### PR TITLE
Added variable reference types & under plumbing

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -537,7 +537,7 @@ namespace OpenRA
 		/// Otherwise, just returns InvalidConditionToken.
 		/// </summary>
 		/// <returns>The token that is used to revoke this condition.</returns>
-		public int GrantCondition(GrantedVariableReference<bool> condition)
+		public int Grant(GrantedVariableReference<bool> condition)
 		{
 			if (!condition.Valid)
 				return InvalidConditionToken;

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -537,14 +537,14 @@ namespace OpenRA
 		/// Otherwise, just returns InvalidConditionToken.
 		/// </summary>
 		/// <returns>The token that is used to revoke this condition.</returns>
-		public int GrantCondition(string condition)
+		public int GrantCondition(GrantedVariableReference<bool> condition)
 		{
-			if (string.IsNullOrEmpty(condition))
+			if (!condition.Valid)
 				return InvalidConditionToken;
 
 			var token = nextConditionToken++;
-			conditionTokens.Add(token, condition);
-			UpdateConditionState(condition, token, false);
+			conditionTokens.Add(token, condition.Name);
+			UpdateConditionState(condition.Name, token, false);
 			return token;
 		}
 

--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -403,6 +403,38 @@ namespace OpenRA
 
 				return InvalidValueAction(value, fieldType, fieldName);
 			}
+			else if (fieldType == typeof(GrantedVariableReference<bool>))
+			{
+				if (value != null)
+				{
+					try
+					{
+						return new GrantedVariableReference<bool>(value);
+					}
+					catch (InvalidDataException e)
+					{
+						throw new YamlException(e.Message);
+					}
+				}
+
+				return InvalidValueAction(value, fieldType, fieldName);
+			}
+			else if (fieldType == typeof(GrantedVariableReference<int>))
+			{
+				if (value != null)
+				{
+					try
+					{
+						return new GrantedVariableReference<int>(value);
+					}
+					catch (InvalidDataException e)
+					{
+						throw new YamlException(e.Message);
+					}
+				}
+
+				return InvalidValueAction(value, fieldType, fieldName);
+			}
 			else if (fieldType.IsEnum)
 			{
 				try

--- a/OpenRA.Game/GrantedVariableReference.cs
+++ b/OpenRA.Game/GrantedVariableReference.cs
@@ -9,11 +9,12 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 
 namespace OpenRA
 {
-	public interface IWithGrantedVariables { IEnumerable<string> GetGrantedVariables(); }
+	public interface IWithGrantedVariables { IEnumerable<KeyValuePair<string, Type>> GetGrantedVariables(); }
 
 	public interface IWithGrantedVariables<TokenType> : IWithGrantedVariables { }
 
@@ -50,20 +51,20 @@ namespace OpenRA
 			return Name.GetHashCode();
 		}
 
-		IEnumerable<string> IWithGrantedVariables.GetGrantedVariables()
+		IEnumerable<KeyValuePair<string, Type>> IWithGrantedVariables.GetGrantedVariables()
 		{
 			if (!string.IsNullOrEmpty(Name))
-				yield return Name;
+				yield return new KeyValuePair<string, Type>(Name, typeof(TokenType));
 		}
 	}
 
 	public static class WithGrantedVariablesExts
 	{
-		public static IEnumerable<string> GetGrantedVariables(this IEnumerable<IWithGrantedVariables> variableCollections)
+		public static IEnumerable<KeyValuePair<string, Type>> GetGrantedVariables(this IEnumerable<IWithGrantedVariables> variableCollections)
 		{
 			foreach (var variables in variableCollections)
 				foreach (var variable in variables.GetGrantedVariables())
-					if (!string.IsNullOrEmpty(variable))
+					if (!string.IsNullOrEmpty(variable.Key))
 						yield return variable;
 		}
 	}

--- a/OpenRA.Game/GrantedVariableReference.cs
+++ b/OpenRA.Game/GrantedVariableReference.cs
@@ -1,0 +1,70 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA
+{
+	public interface IWithGrantedVariables { IEnumerable<string> GetGrantedVariables(); }
+
+	public interface IWithGrantedVariables<TokenType> : IWithGrantedVariables { }
+
+	public struct GrantedVariableReference<TokenType> : IWithGrantedVariables<TokenType>
+	{
+		public readonly string Name;
+
+		public GrantedVariableReference(string name = null)
+		{
+			Name = name;
+		}
+
+		public GrantedVariableReference(GrantedVariableReference<TokenType> reference)
+		{
+			Name = reference.Name;
+		}
+
+		public bool Valid { get { return !string.IsNullOrEmpty(Name); } }
+
+		public override string ToString() { return Name; }
+
+		public static bool operator ==(GrantedVariableReference<TokenType> me, GrantedVariableReference<TokenType> other) { return me.Name == other.Name; }
+		public static bool operator !=(GrantedVariableReference<TokenType> me, GrantedVariableReference<TokenType> other) { return !(me == other); }
+		public static bool operator ==(GrantedVariableReference<TokenType> me, string other) { return me.Name == other; }
+		public static bool operator !=(GrantedVariableReference<TokenType> me, string other) { return me.Name != other; }
+
+		public override bool Equals(object obj)
+		{
+			return Name.Equals(obj.ToString());
+		}
+
+		public override int GetHashCode()
+		{
+			return Name.GetHashCode();
+		}
+
+		IEnumerable<string> IWithGrantedVariables.GetGrantedVariables()
+		{
+			if (!string.IsNullOrEmpty(Name))
+				yield return Name;
+		}
+	}
+
+	public static class WithGrantedVariablesExts
+	{
+		public static IEnumerable<string> GetGrantedVariables(this IEnumerable<IWithGrantedVariables> variableCollections)
+		{
+			foreach (var variables in variableCollections)
+				foreach (var variable in variables.GetGrantedVariables())
+					if (!string.IsNullOrEmpty(variable))
+						yield return variable;
+		}
+	}
+}

--- a/OpenRA.Game/Support/VariableExpression.cs
+++ b/OpenRA.Game/Support/VariableExpression.cs
@@ -18,13 +18,18 @@ using Expressions = System.Linq.Expressions;
 
 namespace OpenRA.Support
 {
-	public abstract class VariableExpression
+	public abstract class VariableExpression : IWithUsedVariables
 	{
 		public static readonly IReadOnlyDictionary<string, int> NoVariables = new ReadOnlyDictionary<string, int>(new Dictionary<string, int>());
 
 		public readonly string Expression;
 		readonly HashSet<string> variables = new HashSet<string>();
 		public IEnumerable<string> Variables { get { return variables; } }
+
+		public IEnumerable<string> GetUsedVariables()
+		{
+			return variables;
+		}
 
 		enum CharClass { Whitespace, Operator, Mixed, Id, Digit }
 
@@ -580,7 +585,7 @@ namespace OpenRA.Support
 			}
 		}
 
-		public VariableExpression(string expression)
+		protected VariableExpression(string expression)
 		{
 			Expression = expression;
 		}

--- a/OpenRA.Game/Traits/LintAttributes.cs
+++ b/OpenRA.Game/Traits/LintAttributes.cs
@@ -62,12 +62,6 @@ namespace OpenRA.Traits
 		}
 	}
 
-	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-	public sealed class GrantedConditionReferenceAttribute : Attribute { }
-
-	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-	public sealed class ConsumedConditionReferenceAttribute : Attribute { }
-
 	[AttributeUsage(AttributeTargets.Field)]
 	public sealed class PaletteDefinitionAttribute : Attribute
 	{

--- a/OpenRA.Game/UsedVariableReference.cs
+++ b/OpenRA.Game/UsedVariableReference.cs
@@ -1,0 +1,68 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA
+{
+	public interface IWithUsedVariables { IEnumerable<string> GetUsedVariables(); }
+
+	public struct UsedVariableReference : IWithUsedVariables
+	{
+		public readonly string Name;
+
+		public UsedVariableReference(string name)
+		{
+			Name = name;
+		}
+
+		public UsedVariableReference(UsedVariableReference reference)
+		{
+			Name = reference.Name;
+		}
+
+		public bool Valid { get { return string.IsNullOrEmpty(Name); } }
+
+		IEnumerable<string> IWithUsedVariables.GetUsedVariables()
+		{
+			if (!string.IsNullOrEmpty(Name))
+				yield return Name;
+		}
+
+		public override string ToString() { return Name; }
+
+		public static bool operator ==(UsedVariableReference me, UsedVariableReference other) { return me.Name == other.Name; }
+		public static bool operator !=(UsedVariableReference me, UsedVariableReference other) { return !(me == other); }
+		public static bool operator ==(UsedVariableReference me, string other) { return me.Name == other; }
+		public static bool operator !=(UsedVariableReference me, string other) { return me.Name != other; }
+
+		public override bool Equals(object obj)
+		{
+			return Name.Equals(obj.ToString());
+		}
+
+		public override int GetHashCode()
+		{
+			return Name.GetHashCode();
+		}
+	}
+
+	public static class WithUsedVariablesExts
+	{
+		public static IEnumerable<string> GetUsedVariables(this IEnumerable<IWithUsedVariables> variableCollections)
+		{
+			foreach (var variables in variableCollections)
+				foreach (var variable in variables.GetUsedVariables())
+					if (!string.IsNullOrEmpty(variable))
+						yield return variable;
+		}
+	}
+}

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackLeap.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackLeap.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public void GrantLeapCondition(Actor self)
 		{
-			leapToken = self.GrantCondition(info.LeapCondition);
+			leapToken = self.Grant(info.LeapCondition);
 		}
 
 		public void RevokeLeapCondition(Actor self)

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackLeap.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackLeap.cs
@@ -24,8 +24,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public readonly WDist Speed = new WDist(426);
 
 		[Desc("Conditions that last from start of the leap until the attack.")]
-		[GrantedConditionReference]
-		public readonly string LeapCondition = "attacking";
+		public readonly GrantedVariableReference<bool> LeapCondition = new GrantedVariableReference<bool>("attacking");
 
 		public override object Create(ActorInitializer init) { return new AttackLeap(init.Self, this); }
 	}

--- a/OpenRA.Mods.Cnc/Traits/ConyardChronoReturn.cs
+++ b/OpenRA.Mods.Cnc/Traits/ConyardChronoReturn.cs
@@ -33,9 +33,8 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sprite body to play the vortex animation on.")]
 		public readonly string Body = "body";
 
-		[GrantedConditionReference]
 		[Desc("Condition to grant while the vortex animation plays.")]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 
 		[Desc("Amount of damage to apply each tick while the vortex animation plays.")]
 		public readonly int Damage = 1000;
@@ -43,7 +42,6 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Apply the damage using these damagetypes.")]
 		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
 
-		[ConsumedConditionReference]
 		[Desc("Boolean expression defining the condition under which to teleport a replacement actor instead of triggering the vortex.")]
 		public readonly BooleanExpression ReturnOriginalActorOnCondition = null;
 

--- a/OpenRA.Mods.Cnc/Traits/ConyardChronoReturn.cs
+++ b/OpenRA.Mods.Cnc/Traits/ConyardChronoReturn.cs
@@ -118,7 +118,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		void TriggerVortex()
 		{
 			if (conditionToken == Actor.InvalidConditionToken)
-				conditionToken = self.GrantCondition(info.Condition);
+				conditionToken = self.Grant(info.Condition);
 
 			triggered = true;
 

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -69,15 +69,16 @@ namespace OpenRA.Mods.Cnc.Traits
 		Move = 32
 	}
 
+
+	#pragma warning disable CS0649
 	[Desc("Provides access to the disguise command, which makes the actor appear to be another player's actor.")]
 	class DisguiseInfo : TraitInfo
 	{
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while disguised.")]
-		public readonly string DisguisedCondition = null;
+		public readonly GrantedVariableReference<bool> DisguisedCondition;
 
 		[Desc("What diplomatic stances can this actor disguise as.")]
 		public readonly Stance ValidStances = Stance.Ally | Stance.Neutral | Stance.Enemy;
@@ -91,16 +92,14 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		[Desc("Conditions to grant when disguised as specified actor.",
 			"A dictionary of [actor id]: [condition].")]
-		public readonly Dictionary<string, string> DisguisedAsConditions = new Dictionary<string, string>();
+		public readonly Dictionary<string, GrantedVariableReference<bool>> DisguisedAsConditions = new Dictionary<string, GrantedVariableReference<bool>>();
 
 		[Desc("Cursor to display when hovering over a valid actor to disguise as.")]
 		public readonly string Cursor = "ability";
 
-		[GrantedConditionReference]
-		public IEnumerable<string> LinterConditions { get { return DisguisedAsConditions.Values; } }
-
 		public override object Create(ActorInitializer init) { return new Disguise(init.Self, this); }
 	}
+	#pragma warning restore CS0649
 
 	class Disguise : IEffectiveOwner, IIssueOrder, IResolveOrder, IOrderVoice, IRadarColorModifier, INotifyAttack,
 		INotifyDamage, INotifyUnload, INotifyDemolition, INotifyInfiltration, ITick
@@ -235,7 +234,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				if (disguisedAsToken != Actor.InvalidConditionToken)
 					disguisedAsToken = self.RevokeCondition(disguisedAsToken);
 
-				string disguisedAsCondition;
+				GrantedVariableReference<bool> disguisedAsCondition;
 				if (info.DisguisedAsConditions.TryGetValue(AsActor.Name, out disguisedAsCondition))
 					disguisedAsToken = self.GrantCondition(disguisedAsCondition);
 			}

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -224,7 +224,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (Disguised != oldDisguiseSetting)
 			{
 				if (Disguised && disguisedToken == Actor.InvalidConditionToken)
-					disguisedToken = self.GrantCondition(info.DisguisedCondition);
+					disguisedToken = self.Grant(info.DisguisedCondition);
 				else if (!Disguised && disguisedToken != Actor.InvalidConditionToken)
 					disguisedToken = self.RevokeCondition(disguisedToken);
 			}
@@ -236,7 +236,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 				GrantedVariableReference<bool> disguisedAsCondition;
 				if (info.DisguisedAsConditions.TryGetValue(AsActor.Name, out disguisedAsCondition))
-					disguisedAsToken = self.GrantCondition(disguisedAsCondition);
+					disguisedAsToken = self.Grant(disguisedAsCondition);
 			}
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/EnergyWall.cs
+++ b/OpenRA.Mods.Cnc/Traits/EnergyWall.cs
@@ -26,7 +26,6 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("The weapon to attack units on top of the wall with when activated.")]
 		public readonly string Weapon = null;
 
-		[ConsumedConditionReference]
 		[Desc("Boolean expression defining the condition to activate this trait.")]
 		public readonly BooleanExpression ActiveCondition = null;
 

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -189,7 +189,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					if (target.Type == TargetType.Invalid)
 						return true;
 
-					self.GrantCondition(mad.info.DeployedCondition);
+					self.Grant(mad.info.DeployedCondition);
 
 					self.World.AddFrameEndTask(w => EjectDriver());
 					if (mad.info.ThumpSequence != null)

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -23,6 +23,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
+	#pragma warning disable CS0649
 	class MadTankInfo : TraitInfo, IRulesetLoaded, Requires<ExplodesInfo>, Requires<WithFacingSpriteBodyInfo>
 	{
 		[SequenceReference]
@@ -52,9 +53,8 @@ namespace OpenRA.Mods.Cnc.Traits
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while deployed.")]
-		public readonly string DeployedCondition = null;
+		public readonly GrantedVariableReference<bool> DeployedCondition;
 
 		public WeaponInfo ThumpDamageWeaponInfo { get; private set; }
 
@@ -82,6 +82,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			DetonationWeaponInfo = detonationWeapon;
 		}
 	}
+	#pragma warning restore CS0649
 
 	class MadTank : IIssueOrder, IResolveOrder, IOrderVoice, IIssueDeployOrder
 	{

--- a/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
+++ b/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
@@ -43,9 +43,9 @@ namespace OpenRA.Mods.Common.Activities
 				return;
 
 			if (isAssaultMove)
-				token = self.GrantCondition(attackMove.Info.AssaultMoveCondition);
+				token = self.Grant(attackMove.Info.AssaultMoveCondition);
 			else
-				token = self.GrantCondition(attackMove.Info.AttackMoveCondition);
+				token = self.Grant(attackMove.Info.AttackMoveCondition);
 		}
 
 		public override bool Tick(Actor self)

--- a/OpenRA.Mods.Common/Lint/LintExts.cs
+++ b/OpenRA.Mods.Common/Lint/LintExts.cs
@@ -57,5 +57,37 @@ namespace OpenRA.Mods.Common.Lint
 			throw new InvalidOperationException("Bad type for reference on {0}.{1}. Supported types: string, IEnumerable<string>, BooleanExpression, IntegerExpression"
 				.F(ruleInfo.GetType().Name, propertyInfo.Name));
 		}
+
+		public static IEnumerable<T> GetFieldValues<T>(object ruleInfo, FieldInfo fieldInfo) where T : class
+		{
+			var type = fieldInfo.FieldType;
+			if (fieldInfo.GetValue(ruleInfo) == null)
+				return Enumerable.Empty<T>();
+
+			if (typeof(T).IsAssignableFrom(type))
+				return new[] { (T)fieldInfo.GetValue(ruleInfo) };
+
+			var enumerable = fieldInfo.GetValue(ruleInfo) as IEnumerable;
+			if (enumerable != null)
+				return enumerable.AsRecursiveEnumerable<T>();
+
+			return Enumerable.Empty<T>();
+		}
+
+		public static IEnumerable<T> GetPropertyValues<T>(object ruleInfo, PropertyInfo propertyInfo) where T : class
+		{
+			var type = propertyInfo.PropertyType;
+			if (propertyInfo.GetValue(ruleInfo) == null)
+				return Enumerable.Empty<T>();
+
+			if (typeof(T).IsAssignableFrom(type))
+				return new[] { (T)propertyInfo.GetValue(ruleInfo) };
+
+			var enumerable = propertyInfo.GetValue(ruleInfo) as IEnumerable;
+			if (enumerable != null)
+				return enumerable.AsRecursiveEnumerable<T>();
+
+			return Enumerable.Empty<T>();
+		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -1134,7 +1134,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			airborne = true;
 			if (airborneToken == Actor.InvalidConditionToken)
-				airborneToken = self.GrantCondition(Info.AirborneCondition);
+				airborneToken = self.Grant(Info.AirborneCondition);
 		}
 
 		void OnAirborneAltitudeLeft()
@@ -1158,7 +1158,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			cruising = true;
 			if (cruisingToken == Actor.InvalidConditionToken)
-				cruisingToken = self.GrantCondition(Info.CruisingCondition);
+				cruisingToken = self.Grant(Info.CruisingCondition);
 		}
 
 		void OnCruisingAltitudeLeft()

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -73,13 +73,11 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while airborne.")]
-		public readonly string AirborneCondition = null;
+		public readonly GrantedVariableReference<bool> AirborneCondition;
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while at cruise altitude.")]
-		public readonly string CruisingCondition = null;
+		public readonly GrantedVariableReference<bool> CruisingCondition;
 
 		[Desc("Can the actor hover in place mid-air? If not, then the actor will have to remain in motion (circle around).")]
 		public readonly bool CanHover = false;
@@ -135,7 +133,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Display order for the facing slider in the map editor")]
 		public readonly int EditorFacingDisplayOrder = 3;
 
-		[ConsumedConditionReference]
 		[Desc("Boolean expression defining the condition under which the regular (non-force) move cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;
 

--- a/OpenRA.Mods.Common/Traits/AmmoPool.cs
+++ b/OpenRA.Mods.Common/Traits/AmmoPool.cs
@@ -40,9 +40,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Time to reload per ReloadCount on airfield etc.")]
 		public readonly int ReloadDelay = 50;
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self for each ammo point in this pool.")]
-		public readonly string AmmoCondition = null;
+		public readonly GrantedVariableReference<bool> AmmoCondition;
 
 		public override object Create(ActorInitializer init) { return new AmmoPool(init.Self, this); }
 	}
@@ -106,7 +105,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void UpdateCondition(Actor self)
 		{
-			if (string.IsNullOrEmpty(Info.AmmoCondition))
+			if (!Info.AmmoCondition.Valid)
 				return;
 
 			while (CurrentAmmoCount > tokens.Count && tokens.Count < Info.Ammo)

--- a/OpenRA.Mods.Common/Traits/AmmoPool.cs
+++ b/OpenRA.Mods.Common/Traits/AmmoPool.cs
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			while (CurrentAmmoCount > tokens.Count && tokens.Count < Info.Ammo)
-				tokens.Push(self.GrantCondition(Info.AmmoCondition));
+				tokens.Push(self.Grant(Info.AmmoCondition));
 
 			while (CurrentAmmoCount < tokens.Count && tokens.Count > 0)
 				self.RevokeCondition(tokens.Pop());

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -186,7 +186,7 @@ namespace OpenRA.Mods.Common.Traits
 			var enabled = !IsTraitDisabled && IsReloading;
 
 			if (enabled && conditionToken == Actor.InvalidConditionToken)
-				conditionToken = self.GrantCondition(Info.ReloadingCondition);
+				conditionToken = self.Grant(Info.ReloadingCondition);
 			else if (!enabled && conditionToken != Actor.InvalidConditionToken)
 				conditionToken = self.RevokeCondition(conditionToken);
 		}

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -63,9 +63,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Use multiple muzzle images if non-zero")]
 		public readonly int MuzzleSplitFacings = 0;
 
-		[GrantedConditionReference]
 		[Desc("Condition to grant while reloading.")]
-		public readonly string ReloadingCondition = null;
+		public readonly GrantedVariableReference<bool> ReloadingCondition;
 
 		public WeaponInfo WeaponInfo { get; private set; }
 		public WDist ModifiedRange { get; private set; }
@@ -181,7 +180,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void UpdateCondition(Actor self)
 		{
-			if (string.IsNullOrEmpty(Info.ReloadingCondition))
+			if (!Info.ReloadingCondition.Valid)
 				return;
 
 			var enabled = !IsTraitDisabled && IsReloading;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackCharges.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackCharges.cs
@@ -25,9 +25,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Amount to decrease the charge level each tick without a valid target.")]
 		public readonly int DischargeRate = 1;
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while the charge level is greater than zero.")]
-		public readonly string ChargingCondition = null;
+		public readonly GrantedVariableReference<bool> ChargingCondition;
 
 		public override object Create(ActorInitializer init) { return new AttackCharges(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackCharges.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackCharges.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 			ChargeLevel = (ChargeLevel + delta).Clamp(0, info.ChargeLevel);
 
 			if (ChargeLevel > 0 && chargingToken == Actor.InvalidConditionToken)
-				chargingToken = self.GrantCondition(info.ChargingCondition);
+				chargingToken = self.Grant(info.ChargingCondition);
 
 			if (ChargeLevel == 0 && chargingToken != Actor.InvalidConditionToken)
 				chargingToken = self.RevokeCondition(chargingToken);

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -19,25 +19,25 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	#pragma warning disable CS0649
 	[Desc("Provides access to the attack-move command, which will make the actor automatically engage viable targets while moving to the destination.")]
 	class AttackMoveInfo : TraitInfo, Requires<IMoveInfo>
 	{
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while an attack-move is active.")]
-		public readonly string AttackMoveCondition = null;
+		public readonly GrantedVariableReference<bool> AttackMoveCondition;
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while an assault-move is active.")]
-		public readonly string AssaultMoveCondition = null;
+		public readonly GrantedVariableReference<bool> AssaultMoveCondition;
 
 		[Desc("Can the actor be ordered to move in to shroud?")]
 		public readonly bool MoveIntoShroud = true;
 
 		public override object Create(ActorInitializer init) { return new AttackMove(init.Self, this); }
 	}
+	#pragma warning restore CS0649
 
 	class AttackMove : IResolveOrder, IOrderVoice
 	{

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -170,7 +170,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			GrantedVariableReference<bool> condition;
 			if (Info.ConditionByStance.TryGetValue(stance, out condition))
-				conditionToken = self.GrantCondition(condition);
+				conditionToken = self.Grant(condition);
 		}
 
 		public AutoTarget(ActorInitializer init, AutoTargetInfo info)

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -53,24 +53,20 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Possible values are HoldFire, ReturnFire, Defend and AttackAnything. Used for human players.")]
 		public readonly UnitStance InitialStance = UnitStance.Defend;
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while in the HoldFire stance.")]
-		public readonly string HoldFireCondition = null;
+		public readonly GrantedVariableReference<bool> HoldFireCondition;
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while in the ReturnFire stance.")]
-		public readonly string ReturnFireCondition = null;
+		public readonly GrantedVariableReference<bool> ReturnFireCondition;
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while in the Defend stance.")]
-		public readonly string DefendCondition = null;
+		public readonly GrantedVariableReference<bool> DefendCondition;
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while in the AttackAnything stance.")]
-		public readonly string AttackAnythingCondition = null;
+		public readonly GrantedVariableReference<bool> AttackAnythingCondition;
 
 		[FieldLoader.Ignore]
-		public readonly Dictionary<UnitStance, string> ConditionByStance = new Dictionary<UnitStance, string>();
+		public readonly Dictionary<UnitStance, GrantedVariableReference<bool>> ConditionByStance = new Dictionary<UnitStance, GrantedVariableReference<bool>>();
 
 		[Desc("Allow the player to change the unit stance.")]
 		public readonly bool EnableStances = true;
@@ -90,16 +86,16 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			base.RulesetLoaded(rules, info);
 
-			if (HoldFireCondition != null)
+			if (HoldFireCondition.Name != null)
 				ConditionByStance[UnitStance.HoldFire] = HoldFireCondition;
 
-			if (ReturnFireCondition != null)
+			if (ReturnFireCondition.Name != null)
 				ConditionByStance[UnitStance.ReturnFire] = ReturnFireCondition;
 
-			if (DefendCondition != null)
+			if (DefendCondition.Name != null)
 				ConditionByStance[UnitStance.Defend] = DefendCondition;
 
-			if (AttackAnythingCondition != null)
+			if (AttackAnythingCondition.Name != null)
 				ConditionByStance[UnitStance.AttackAnything] = AttackAnythingCondition;
 		}
 
@@ -172,7 +168,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (conditionToken != Actor.InvalidConditionToken)
 				conditionToken = self.RevokeCondition(conditionToken);
 
-			string condition;
+			GrantedVariableReference<bool> condition;
 			if (Info.ConditionByStance.TryGetValue(stance, out condition))
 				conditionToken = self.GrantCondition(condition);
 		}

--- a/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
@@ -28,9 +28,8 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Used together with ClassicProductionQueue.")]
 	public class PrimaryBuildingInfo : ConditionalTraitInfo
 	{
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while this is the primary building.")]
-		public readonly string PrimaryCondition = null;
+		public readonly GrantedVariableReference<bool> PrimaryCondition;
 
 		[NotificationReference("Speech")]
 		[Desc("The speech notification to play when selecting a primary building.")]

--- a/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				if (primaryToken == Actor.InvalidConditionToken)
-					primaryToken = self.GrantCondition(Info.PrimaryCondition);
+					primaryToken = self.Grant(Info.PrimaryCondition);
 
 				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.SelectionNotification, self.Owner.Faction.InternalName);
 			}

--- a/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
@@ -42,9 +42,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Experience gained by a player for repairing structures of allied players.")]
 		public readonly int PlayerExperience = 0;
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while being repaired.")]
-		public readonly string RepairCondition = null;
+		public readonly GrantedVariableReference<bool> RepairCondition;
 
 		[NotificationReference("Speech")]
 		public readonly string RepairingNotification = null;
@@ -83,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void UpdateCondition(Actor self)
 		{
-			if (string.IsNullOrEmpty(Info.RepairCondition))
+			if (!Info.RepairCondition.Valid)
 				return;
 
 			var currentRepairers = Repairers.Count;

--- a/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var currentRepairers = Repairers.Count;
 			while (Repairers.Count > repairTokens.Count)
-				repairTokens.Push(self.GrantCondition(Info.RepairCondition));
+				repairTokens.Push(self.Grant(Info.RepairCondition));
 
 			while (Repairers.Count < repairTokens.Count && repairTokens.Count > 0)
 				self.RevokeCondition(repairTokens.Pop());

--- a/OpenRA.Mods.Common/Traits/CaptureManager.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureManager.cs
@@ -27,13 +27,11 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Manages Captures and Capturable traits on an actor.")]
 	public class CaptureManagerInfo : TraitInfo
 	{
-		[GrantedConditionReference]
 		[Desc("Condition granted when capturing an actor.")]
-		public readonly string CapturingCondition = null;
+		public readonly GrantedVariableReference<bool> CapturingCondition;
 
-		[GrantedConditionReference]
 		[Desc("Condition granted when being captured by another actor.")]
-		public readonly string BeingCapturedCondition = null;
+		public readonly GrantedVariableReference<bool> BeingCapturedCondition;
 
 		[Desc("Should units friendly to the capturing actor auto-target this actor while it is being captured?")]
 		public readonly bool PreventsAutoTarget = true;

--- a/OpenRA.Mods.Common/Traits/CaptureManager.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureManager.cs
@@ -203,10 +203,10 @@ namespace OpenRA.Mods.Common.Traits
 				currentTargetDelay += 1;
 
 			if (capturingToken == Actor.InvalidConditionToken)
-				capturingToken = self.GrantCondition(info.CapturingCondition);
+				capturingToken = self.Grant(info.CapturingCondition);
 
 			if (targetManager.beingCapturedToken == Actor.InvalidConditionToken)
-				targetManager.beingCapturedToken = target.GrantCondition(targetManager.info.BeingCapturedCondition);
+				targetManager.beingCapturedToken = target.Grant(targetManager.info.BeingCapturedCondition);
 
 			captures = enabledCaptures
 				.OrderBy(c => c.Info.CaptureDelay)

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -169,11 +169,11 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					GrantedVariableReference<bool> passengerCondition;
 					if (Info.PassengerConditions.TryGetValue(c.Info.Name, out passengerCondition))
-						passengerTokens.GetOrAdd(c.Info.Name).Push(self.GrantCondition(passengerCondition));
+						passengerTokens.GetOrAdd(c.Info.Name).Push(self.Grant(passengerCondition));
 				}
 
 				if (Info.LoadedCondition.Valid)
-					loadedTokens.Push(self.GrantCondition(Info.LoadedCondition));
+					loadedTokens.Push(self.Grant(Info.LoadedCondition));
 			}
 
 			// Defer notifications until we are certain all traits on the transport are initialised
@@ -260,7 +260,7 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			if (loadingToken == Actor.InvalidConditionToken)
-				loadingToken = self.GrantCondition(Info.LoadingCondition);
+				loadingToken = self.Grant(Info.LoadingCondition);
 
 			reserves.Add(a);
 			reservedWeight += w;
@@ -400,10 +400,10 @@ namespace OpenRA.Mods.Common.Traits
 
 			GrantedVariableReference<bool> passengerCondition;
 			if (Info.PassengerConditions.TryGetValue(a.Info.Name, out passengerCondition))
-				passengerTokens.GetOrAdd(a.Info.Name).Push(self.GrantCondition(passengerCondition));
+				passengerTokens.GetOrAdd(a.Info.Name).Push(self.Grant(passengerCondition));
 
 			if (Info.LoadedCondition.Valid)
-				loadedTokens.Push(self.GrantCondition(Info.LoadedCondition));
+				loadedTokens.Push(self.Grant(Info.LoadedCondition));
 		}
 
 		void INotifyKilled.Killed(Actor self, AttackInfo e)

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -66,21 +66,16 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Cursor to display when unable to unload the passengers.")]
 		public readonly string UnloadBlockedCursor = "deploy-blocked";
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while waiting for cargo to load.")]
-		public readonly string LoadingCondition = null;
+		public readonly GrantedVariableReference<bool> LoadingCondition;
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while passengers are loaded.",
 			"Condition can stack with multiple passengers.")]
-		public readonly string LoadedCondition = null;
+		public readonly GrantedVariableReference<bool> LoadedCondition;
 
 		[Desc("Conditions to grant when specified actors are loaded inside the transport.",
 			"A dictionary of [actor id]: [condition].")]
-		public readonly Dictionary<string, string> PassengerConditions = new Dictionary<string, string>();
-
-		[GrantedConditionReference]
-		public IEnumerable<string> LinterPassengerConditions { get { return PassengerConditions.Values; } }
+		public readonly Dictionary<string, GrantedVariableReference<bool>> PassengerConditions = new Dictionary<string, GrantedVariableReference<bool>>();
 
 		public override object Create(ActorInitializer init) { return new Cargo(init, this); }
 	}
@@ -172,12 +167,12 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				foreach (var c in cargo)
 				{
-					string passengerCondition;
+					GrantedVariableReference<bool> passengerCondition;
 					if (Info.PassengerConditions.TryGetValue(c.Info.Name, out passengerCondition))
 						passengerTokens.GetOrAdd(c.Info.Name).Push(self.GrantCondition(passengerCondition));
 				}
 
-				if (!string.IsNullOrEmpty(Info.LoadedCondition))
+				if (Info.LoadedCondition.Valid)
 					loadedTokens.Push(self.GrantCondition(Info.LoadedCondition));
 			}
 
@@ -403,11 +398,11 @@ namespace OpenRA.Mods.Common.Traits
 					npe.OnPassengerEntered(self, a);
 			}
 
-			string passengerCondition;
+			GrantedVariableReference<bool> passengerCondition;
 			if (Info.PassengerConditions.TryGetValue(a.Info.Name, out passengerCondition))
 				passengerTokens.GetOrAdd(a.Info.Name).Push(self.GrantCondition(passengerCondition));
 
-			if (!string.IsNullOrEmpty(Info.LoadedCondition))
+			if (Info.LoadedCondition.Valid)
 				loadedTokens.Push(self.GrantCondition(Info.LoadedCondition));
 		}
 

--- a/OpenRA.Mods.Common/Traits/Carryable.cs
+++ b/OpenRA.Mods.Common/Traits/Carryable.cs
@@ -17,17 +17,14 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Can be carried by actors with the `Carryall` trait.")]
 	public class CarryableInfo : ConditionalTraitInfo
 	{
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while a carryall has been reserved.")]
-		public readonly string ReservedCondition = null;
+		public readonly GrantedVariableReference<bool> ReservedCondition;
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while being carried.")]
-		public readonly string CarriedCondition = null;
+		public readonly GrantedVariableReference<bool> CarriedCondition;
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while being locked for carry.")]
-		public readonly string LockedCondition = null;
+		public readonly GrantedVariableReference<bool> LockedCondition;
 
 		[Desc("Carryall attachment point relative to body.")]
 		public readonly WVec LocalOffset = WVec.Zero;

--- a/OpenRA.Mods.Common/Traits/Carryable.cs
+++ b/OpenRA.Mods.Common/Traits/Carryable.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.Traits
 			attached = true;
 
 			if (carriedToken == Actor.InvalidConditionToken)
-				carriedToken = self.GrantCondition(Info.CarriedCondition);
+				carriedToken = self.Grant(Info.CarriedCondition);
 		}
 
 		// This gets called by carrier after we touched down
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Traits
 			Carrier = carrier;
 
 			if (reservedToken == Actor.InvalidConditionToken)
-				reservedToken = self.GrantCondition(Info.ReservedCondition);
+				reservedToken = self.Grant(Info.ReservedCondition);
 
 			return true;
 		}
@@ -132,7 +132,7 @@ namespace OpenRA.Mods.Common.Traits
 				Carrier = carrier;
 
 				if (lockedToken == Actor.InvalidConditionToken)
-					lockedToken = self.GrantCondition(Info.LockedCondition);
+					lockedToken = self.Grant(Info.LockedCondition);
 			}
 
 			// Make sure we are not moving and at our normal position with respect to the cell grid

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -59,9 +59,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly BitSet<CloakType> CloakTypes = new BitSet<CloakType>("Cloak");
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while cloaked.")]
-		public readonly string CloakedCondition = null;
+		public readonly GrantedVariableReference<bool> CloakedCondition;
 
 		public override object Create(ActorInitializer init) { return new Cloak(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				wasCloaked = true;
 				if (cloakedToken == Actor.InvalidConditionToken)
-					cloakedToken = self.GrantCondition(Info.CloakedCondition);
+					cloakedToken = self.Grant(Info.CloakedCondition);
 			}
 
 			base.Created(self);
@@ -163,7 +163,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (isCloaked && !wasCloaked)
 			{
 				if (cloakedToken == Actor.InvalidConditionToken)
-					cloakedToken = self.GrantCondition(Info.CloakedCondition);
+					cloakedToken = self.Grant(Info.CloakedCondition);
 
 				// Sounds shouldn't play if the actor starts cloaked
 				if (!(firstTick && Info.InitialDelay == 0) && !otherCloaks.Any(a => a.Cloaked))

--- a/OpenRA.Mods.Common/Traits/Conditions/ConditionalTrait.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ConditionalTrait.cs
@@ -18,7 +18,6 @@ namespace OpenRA.Mods.Common.Traits
 	/// <summary>Use as base class for *Info to subclass of ConditionalTrait. (See ConditionalTrait.)</summary>
 	public abstract class ConditionalTraitInfo : TraitInfo, IObservesVariablesInfo, IRulesetLoaded
 	{
-		[ConsumedConditionReference]
 		[Desc("Boolean expression defining the condition to enable this trait.")]
 		public readonly BooleanExpression RequiresCondition = null;
 

--- a/OpenRA.Mods.Common/Traits/Conditions/ExternalCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ExternalCondition.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!CanGrantCondition(self, source))
 				return Actor.InvalidConditionToken;
 
-			var token = self.GrantCondition(Info.Condition);
+			var token = self.Grant(Info.Condition);
 			HashSet<int> permanent;
 			permanentTokens.TryGetValue(source, out permanent);
 

--- a/OpenRA.Mods.Common/Traits/Conditions/ExternalCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ExternalCondition.cs
@@ -25,9 +25,8 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Allows a condition to be granted from an external source (Lua, warheads, etc).")]
 	public class ExternalConditionInfo : TraitInfo
 	{
-		[GrantedConditionReference]
 		[FieldLoader.Require]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 
 		[Desc("If > 0, restrict the number of times that this condition can be granted by a single source.")]
 		public readonly int SourceCap = 0;
@@ -229,7 +228,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		bool Notifies(IConditionTimerWatcher watcher) { return watcher.Condition == Info.Condition; }
+		bool Notifies(IConditionTimerWatcher watcher) { return watcher.Condition == Info.Condition.Name; }
 
 		void INotifyCreated.Created(Actor self)
 		{

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantCondition.cs
@@ -9,23 +9,22 @@
  */
 #endregion
 
-using OpenRA.Traits;
-
 namespace OpenRA.Mods.Common.Traits
 {
+	#pragma warning disable CS0649
 	[Desc("Grants a condition while the trait is active.")]
 	class GrantConditionInfo : ConditionalTraitInfo
 	{
 		[FieldLoader.Require]
-		[GrantedConditionReference]
 		[Desc("Condition to grant.")]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 
 		[Desc("Is the condition irrevocable once it has been activated?")]
 		public readonly bool GrantPermanently = false;
 
 		public override object Create(ActorInitializer init) { return new GrantCondition(this); }
 	}
+	#pragma warning restore CS0649
 
 	class GrantCondition : ConditionalTrait<GrantConditionInfo>
 	{

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantCondition.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		protected override void TraitEnabled(Actor self)
 		{
 			if (conditionToken == Actor.InvalidConditionToken)
-				conditionToken = self.GrantCondition(Info.Condition);
+				conditionToken = self.Grant(Info.Condition);
 		}
 
 		protected override void TraitDisabled(Actor self)

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnAttack.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnAttack.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 		void GrantInstance(Actor self, GrantedVariableReference<bool> condition)
 		{
 			if (condition.Valid)
-				tokens.Push(self.GrantCondition(condition));
+				tokens.Push(self.Grant(condition));
 		}
 
 		void RevokeInstance(Actor self, bool revokeAll)

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnAttack.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnAttack.cs
@@ -17,9 +17,8 @@ namespace OpenRA.Mods.Common.Traits
 	public class GrantConditionOnAttackInfo : PausableConditionalTraitInfo
 	{
 		[FieldLoader.Require]
-		[GrantedConditionReference]
 		[Desc("The condition type to grant.")]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 
 		[Desc("Name of the armaments that grant this condition.")]
 		public readonly HashSet<string> ArmamentNames = new HashSet<string>() { "primary" };
@@ -59,12 +58,10 @@ namespace OpenRA.Mods.Common.Traits
 		public GrantConditionOnAttack(ActorInitializer init, GrantConditionOnAttackInfo info)
 			: base(info) { }
 
-		void GrantInstance(Actor self, string cond)
+		void GrantInstance(Actor self, GrantedVariableReference<bool> condition)
 		{
-			if (string.IsNullOrEmpty(cond))
-				return;
-
-			tokens.Push(self.GrantCondition(cond));
+			if (condition.Valid)
+				tokens.Push(self.GrantCondition(condition));
 		}
 
 		void RevokeInstance(Actor self, bool revokeAll)

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		void INotifyCreated.Created(Actor self)
 		{
 			if (self.Owner.IsBot && info.Bots.Contains(self.Owner.BotType))
-				conditionToken = self.GrantCondition(info.Condition);
+				conditionToken = self.Grant(info.Condition);
 		}
 
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 				conditionToken = self.RevokeCondition(conditionToken);
 
 			if (info.Bots.Contains(newOwner.BotType))
-				conditionToken = self.GrantCondition(info.Condition);
+				conditionToken = self.Grant(info.Condition);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs
@@ -18,9 +18,8 @@ namespace OpenRA.Mods.Common.Traits
 	public class GrantConditionOnBotOwnerInfo : TraitInfo
 	{
 		[FieldLoader.Require]
-		[GrantedConditionReference]
 		[Desc("Condition to grant.")]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 
 		[FieldLoader.Require]
 		[Desc("Bot types that trigger the condition.")]

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDamageState.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDamageState.cs
@@ -17,9 +17,8 @@ namespace OpenRA.Mods.Common.Traits
 	public class GrantConditionOnDamageStateInfo : TraitInfo, Requires<IHealthInfo>
 	{
 		[FieldLoader.Require]
-		[GrantedConditionReference]
 		[Desc("Condition to grant.")]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 
 		[Desc("Play a random sound from this list when enabled.")]
 		public readonly string[] EnabledSounds = { };

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDamageState.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDamageState.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!info.ValidDamageStates.HasFlag(state) || conditionToken != Actor.InvalidConditionToken)
 				return;
 
-			conditionToken = self.GrantCondition(info.Condition);
+			conditionToken = self.Grant(info.Condition);
 
 			var sound = info.EnabledSounds.RandomOrDefault(Game.CosmeticRandom);
 			Game.Sound.Play(SoundType.World, sound, self.CenterPosition);

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -313,7 +313,7 @@ namespace OpenRA.Mods.Common.Traits
 		void OnDeployCompleted()
 		{
 			if (deployedToken == Actor.InvalidConditionToken)
-				deployedToken = self.GrantCondition(Info.DeployedCondition);
+				deployedToken = self.Grant(Info.DeployedCondition);
 
 			deployState = DeployState.Deployed;
 		}
@@ -329,7 +329,7 @@ namespace OpenRA.Mods.Common.Traits
 		void OnUndeployCompleted()
 		{
 			if (undeployedToken == Actor.InvalidConditionToken)
-				undeployedToken = self.GrantCondition(Info.UndeployedCondition);
+				undeployedToken = self.Grant(Info.UndeployedCondition);
 
 			deployState = DeployState.Undeployed;
 		}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -22,14 +22,12 @@ namespace OpenRA.Mods.Common.Traits
 		"Can be paused with the granted condition to disable undeploying.")]
 	public class GrantConditionOnDeployInfo : PausableConditionalTraitInfo, IEditorActorOptions
 	{
-		[GrantedConditionReference]
 		[Desc("The condition to grant while the actor is undeployed.")]
-		public readonly string UndeployedCondition = null;
+		public readonly GrantedVariableReference<bool> UndeployedCondition;
 
 		[FieldLoader.Require]
-		[GrantedConditionReference]
 		[Desc("The condition to grant after deploying and revoke before undeploying.")]
-		public readonly string DeployedCondition = null;
+		public readonly GrantedVariableReference<bool> DeployedCondition;
 
 		[Desc("The terrain types that this actor can deploy on. Leave empty to allow any.")]
 		public readonly HashSet<string> AllowedTerrainTypes = new HashSet<string>();

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnFaction.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnFaction.cs
@@ -14,13 +14,13 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	#pragma warning disable CS0649
 	[Desc("Grants a condition while the trait is active.")]
 	class GrantConditionOnFactionInfo : ConditionalTraitInfo
 	{
 		[FieldLoader.Require]
-		[GrantedConditionReference]
 		[Desc("Condition to grant.")]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 
 		[Desc("Only grant this condition for certain factions.")]
 		public readonly HashSet<string> Factions = new HashSet<string>();
@@ -30,6 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override object Create(ActorInitializer init) { return new GrantConditionOnFaction(init, this); }
 	}
+	#pragma warning restore CS0649
 
 	class GrantConditionOnFaction : ConditionalTrait<GrantConditionOnFactionInfo>, INotifyOwnerChanged
 	{

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnFaction.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnFaction.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 		protected override void TraitEnabled(Actor self)
 		{
 			if (conditionToken == Actor.InvalidConditionToken && Info.Factions.Contains(faction))
-				conditionToken = self.GrantCondition(Info.Condition);
+				conditionToken = self.Grant(Info.Condition);
 		}
 
 		protected override void TraitDisabled(Actor self)

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnHealth.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnHealth.cs
@@ -17,9 +17,8 @@ namespace OpenRA.Mods.Common.Traits
 	public class GrantConditionOnHealthInfo : TraitInfo, IRulesetLoaded, Requires<IHealthInfo>
 	{
 		[FieldLoader.Require]
-		[GrantedConditionReference]
 		[Desc("Condition to grant.")]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 
 		[Desc("Play a random sound from this list when enabled.")]
 		public readonly string[] EnabledSounds = { };

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnHealth.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnHealth.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.MinHP > hp || maxHP < hp || conditionToken != Actor.InvalidConditionToken)
 				return;
 
-			conditionToken = self.GrantCondition(info.Condition);
+			conditionToken = self.Grant(info.Condition);
 
 			var sound = info.EnabledSounds.RandomOrDefault(Game.CosmeticRandom);
 			Game.Sound.Play(SoundType.World, sound, self.CenterPosition);

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnJumpjetLayer.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnJumpjetLayer.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (!jumpjetInAir && newLayer == ValidLayerType && oldLayer != ValidLayerType && conditionToken == Actor.InvalidConditionToken)
 			{
-				conditionToken = self.GrantCondition(Info.Condition);
+				conditionToken = self.Grant(Info.Condition);
 				jumpjetInAir = true;
 			}
 

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLayer.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLayer.cs
@@ -9,16 +9,13 @@
  */
 #endregion
 
-using OpenRA.Traits;
-
 namespace OpenRA.Mods.Common.Traits
 {
 	public abstract class GrantConditionOnLayerInfo : ConditionalTraitInfo
 	{
 		[FieldLoader.Require]
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self when changing to specific custom layer.")]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 	}
 
 	public abstract class GrantConditionOnLayer<InfoType> : ConditionalTrait<InfoType>, INotifyCustomLayerChanged where InfoType : GrantConditionOnLayerInfo

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLayer.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLayer.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 		protected virtual void UpdateConditions(Actor self, byte oldLayer, byte newLayer)
 		{
 			if (newLayer == ValidLayerType && oldLayer != ValidLayerType && conditionToken == Actor.InvalidConditionToken)
-				conditionToken = self.GrantCondition(Info.Condition);
+				conditionToken = self.Grant(Info.Condition);
 			else if (newLayer != ValidLayerType && oldLayer == ValidLayerType && conditionToken != Actor.InvalidConditionToken)
 				conditionToken = self.RevokeCondition(conditionToken);
 		}
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 		protected override void TraitEnabled(Actor self)
 		{
 			if (self.Location.Layer == ValidLayerType && conditionToken == Actor.InvalidConditionToken)
-				conditionToken = self.GrantCondition(Info.Condition);
+				conditionToken = self.Grant(Info.Condition);
 		}
 
 		protected override void TraitDisabled(Actor self)

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLineBuildDirection.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLineBuildDirection.cs
@@ -16,9 +16,8 @@ namespace OpenRA.Mods.Common.Traits
 	public class GrantConditionOnLineBuildDirectionInfo : TraitInfo, Requires<LineBuildInfo>
 	{
 		[FieldLoader.Require]
-		[GrantedConditionReference]
 		[Desc("Condition to grant.")]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 
 		[FieldLoader.Require]
 		[Desc("Line build direction to trigger the condition.")]

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLineBuildDirection.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLineBuildDirection.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 		void INotifyCreated.Created(Actor self)
 		{
 			if (direction == info.Direction)
-				self.GrantCondition(info.Condition);
+				self.Grant(info.Condition);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnMovement.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnMovement.cs
@@ -16,9 +16,8 @@ namespace OpenRA.Mods.Common.Traits
 	public class GrantConditionOnMovementInfo : ConditionalTraitInfo, Requires<IMoveInfo>
 	{
 		[FieldLoader.Require]
-		[GrantedConditionReference]
 		[Desc("Condition to grant.")]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 
 		[Desc("Apply condition on listed movement types. Available options are: None, Horizontal, Vertical, Turn.")]
 		public readonly MovementType ValidMovementTypes = MovementType.Horizontal;

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnMovement.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnMovement.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!validMovement && conditionToken != Actor.InvalidConditionToken)
 				conditionToken = self.RevokeCondition(conditionToken);
 			else if (validMovement && conditionToken == Actor.InvalidConditionToken)
-				conditionToken = self.GrantCondition(Info.Condition);
+				conditionToken = self.Grant(Info.Condition);
 		}
 
 		void INotifyMoving.MovementTypeChanged(Actor self, MovementType types)

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPlayerResources.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var enabled = playerResources.Resources > info.Threshold;
 			if (enabled && conditionToken == Actor.InvalidConditionToken)
-				conditionToken = self.GrantCondition(info.Condition);
+				conditionToken = self.Grant(info.Condition);
 			else if (!enabled && conditionToken != Actor.InvalidConditionToken)
 				conditionToken = self.RevokeCondition(conditionToken);
 		}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPlayerResources.cs
@@ -18,9 +18,8 @@ namespace OpenRA.Mods.Common.Traits
 	public class GrantConditionOnPlayerResourcesInfo : TraitInfo
 	{
 		[FieldLoader.Require]
-		[GrantedConditionReference]
 		[Desc("Condition to grant.")]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 
 		[Desc("Enable condition when the amount of stored resources is greater than this.")]
 		public readonly int Threshold = 0;
@@ -52,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ITick.Tick(Actor self)
 		{
-			if (string.IsNullOrEmpty(info.Condition))
+			if (!info.Condition.Valid)
 				return;
 
 			var enabled = playerResources.Resources > info.Threshold;

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPowerState.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPowerState.cs
@@ -17,9 +17,8 @@ namespace OpenRA.Mods.Common.Traits
 	public class GrantConditionOnPowerStateInfo : ConditionalTraitInfo
 	{
 		[FieldLoader.Require]
-		[GrantedConditionReference]
 		[Desc("Condition to grant.")]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 
 		[FieldLoader.Require]
 		[Desc("PowerStates at which the condition is granted. Options are Normal, Low and Critical.")]

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPowerState.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPowerState.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits
 			validPowerState = !IsTraitDisabled && Info.ValidPowerStates.HasFlag(playerPower.PowerState);
 
 			if (validPowerState && conditionToken == Actor.InvalidConditionToken)
-				conditionToken = self.GrantCondition(Info.Condition);
+				conditionToken = self.Grant(Info.Condition);
 			else if (!validPowerState && conditionToken != Actor.InvalidConditionToken)
 				conditionToken = self.RevokeCondition(conditionToken);
 		}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPrerequisite.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			if (available && conditionToken == Actor.InvalidConditionToken)
-				conditionToken = self.GrantCondition(info.Condition);
+				conditionToken = self.Grant(info.Condition);
 			else if (!available && conditionToken != Actor.InvalidConditionToken)
 				conditionToken = self.RevokeCondition(conditionToken);
 

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPrerequisite.cs
@@ -18,9 +18,8 @@ namespace OpenRA.Mods.Common.Traits
 	public class GrantConditionOnPrerequisiteInfo : TraitInfo
 	{
 		[FieldLoader.Require]
-		[GrantedConditionReference]
 		[Desc("The condition to grant.")]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 
 		[FieldLoader.Require]
 		[Desc("List of required prerequisites.")]

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnProduction.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnProduction.cs
@@ -20,9 +20,8 @@ namespace OpenRA.Mods.Common.Traits
 	public class GrantConditionOnProductionInfo : TraitInfo
 	{
 		[FieldLoader.Require]
-		[GrantedConditionReference]
 		[Desc("The condition to grant")]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 
 		[ActorReference]
 		[Desc("The actors to grant condition for. If empty condition will be granted for all actors.")]

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnProduction.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnProduction.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			if (token == Actor.InvalidConditionToken)
-				token = self.GrantCondition(info.Condition);
+				token = self.Grant(info.Condition);
 
 			ticks = info.Duration;
 		}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnSubterraneanLayer.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnSubterraneanLayer.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Grant condition when new layer is Subterranean and depth is lower than transition depth,
 			// revoke condition when new layer is not Subterranean and depth is at or higher than transition depth.
 			if (newLayer == ValidLayerType && depth < transitionDepth && conditionToken == Actor.InvalidConditionToken)
-				conditionToken = self.GrantCondition(Info.Condition);
+				conditionToken = self.Grant(Info.Condition);
 			else if (newLayer != ValidLayerType && depth > transitionDepth && conditionToken != Actor.InvalidConditionToken)
 			{
 				conditionToken = self.RevokeCondition(conditionToken);

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnTerrain.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (currentTerrain != cachedTerrain)
 			{
 				if (wantsGranted && conditionToken == Actor.InvalidConditionToken)
-					conditionToken = self.GrantCondition(info.Condition);
+					conditionToken = self.Grant(info.Condition);
 				else if (!wantsGranted && conditionToken != Actor.InvalidConditionToken)
 					conditionToken = self.RevokeCondition(conditionToken);
 			}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnTerrain.cs
@@ -17,9 +17,8 @@ namespace OpenRA.Mods.Common.Traits
 	public class GrantConditionOnTerrainInfo : TraitInfo
 	{
 		[FieldLoader.Require]
-		[GrantedConditionReference]
 		[Desc("Condition to grant.")]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 
 		[FieldLoader.Require]
 		[Desc("Terrain names to trigger the condition.")]

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionWhileAiming.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionWhileAiming.cs
@@ -16,9 +16,8 @@ namespace OpenRA.Mods.Common.Traits
 	public class GrantConditionWhileAimingInfo : TraitInfo
 	{
 		[FieldLoader.Require]
-		[GrantedConditionReference]
 		[Desc("The condition to grant while aiming.")]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 
 		public override object Create(ActorInitializer init) { return new GrantConditionWhileAiming(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionWhileAiming.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionWhileAiming.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		void INotifyAiming.StartedAiming(Actor self, AttackBase attack)
 		{
 			if (conditionToken == Actor.InvalidConditionToken)
-				conditionToken = self.GrantCondition(info.Condition);
+				conditionToken = self.Grant(info.Condition);
 		}
 
 		void INotifyAiming.StoppedAiming(Actor self, AttackBase attack)

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantRandomCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantRandomCondition.cs
@@ -18,9 +18,8 @@ namespace OpenRA.Mods.Common.Traits.Conditions
 	public class GrantRandomConditionInfo : TraitInfo
 	{
 		[FieldLoader.Require]
-		[GrantedConditionReference]
 		[Desc("List of conditions to grant from.")]
-		public readonly string[] Conditions = null;
+		public readonly GrantedVariableReference<bool>[] Conditions = null;
 
 		public override object Create(ActorInitializer init) { return new GrantRandomCondition(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantRandomCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantRandomCondition.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits.Conditions
 				return;
 
 			var condition = info.Conditions.Random(self.World.SharedRandom);
-			self.GrantCondition(condition);
+			self.Grant(condition);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Conditions/PausableConditionalTrait.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/PausableConditionalTrait.cs
@@ -18,7 +18,6 @@ namespace OpenRA.Mods.Common.Traits
 	/// <summary>Use as base class for *Info to subclass of PausableConditionalTrait. (See PausableConditionalTrait.)</summary>
 	public abstract class PausableConditionalTraitInfo : ConditionalTraitInfo
 	{
-		[ConsumedConditionReference]
 		[Desc("Boolean expression defining the condition to pause this trait.")]
 		public readonly BooleanExpression PauseOnCondition = null;
 

--- a/OpenRA.Mods.Common/Traits/Conditions/ToggleConditionOnOrder.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ToggleConditionOnOrder.cs
@@ -17,9 +17,8 @@ namespace OpenRA.Mods.Common.Traits
 	public class ToggleConditionOnOrderInfo : PausableConditionalTraitInfo
 	{
 		[FieldLoader.Require]
-		[GrantedConditionReference]
 		[Desc("Condition to grant.")]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 
 		[FieldLoader.Require]
 		[Desc("Order name that toggles the condition.")]

--- a/OpenRA.Mods.Common/Traits/Conditions/ToggleConditionOnOrder.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ToggleConditionOnOrder.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (granted && conditionToken == Actor.InvalidConditionToken)
 			{
-				conditionToken = self.GrantCondition(Info.Condition);
+				conditionToken = self.Grant(Info.Condition);
 
 				if (Info.EnabledSound != null)
 					Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", Info.EnabledSound, self.Owner.Faction.InternalName);

--- a/OpenRA.Mods.Common/Traits/Demolishable.cs
+++ b/OpenRA.Mods.Common/Traits/Demolishable.cs
@@ -20,9 +20,8 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public bool IsValidTarget(ActorInfo actorInfo, Actor saboteur) { return true; }
 
-		[GrantedConditionReference]
 		[Desc("Condition to grant during demolition countdown.")]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 
 		public override object Create(ActorInitializer init) { return new Demolishable(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Demolishable.cs
+++ b/OpenRA.Mods.Common/Traits/Demolishable.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (IsTraitDisabled)
 				return;
 
-			var token = self.GrantCondition(Info.Condition);
+			var token = self.Grant(Info.Condition);
 			actions.Add(new DemolishAction(saboteur, delay, token));
 		}
 

--- a/OpenRA.Mods.Common/Traits/EntersTunnels.cs
+++ b/OpenRA.Mods.Common/Traits/EntersTunnels.cs
@@ -31,7 +31,6 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
-		[ConsumedConditionReference]
 		[Desc("Boolean expression defining the condition under which the regular (non-force) enter cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;
 

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -24,10 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Condition to grant at each level.",
 			"Key is the XP requirements for each level as a percentage of our own value.",
 			"Value is the condition to grant.")]
-		public readonly Dictionary<int, string> Conditions = null;
-
-		[GrantedConditionReference]
-		public IEnumerable<string> LinterConditions { get { return Conditions.Values; } }
+		public readonly Dictionary<int, GrantedVariableReference<bool>> Conditions;
 
 		[Desc("Image for the level up sprite.")]
 		public readonly string LevelUpImage = null;
@@ -58,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly GainsExperienceInfo info;
 		readonly int initialExperience;
 
-		readonly List<Pair<int, string>> nextLevel = new List<Pair<int, string>>();
+		readonly List<Pair<int, GrantedVariableReference<bool>>> nextLevel = new List<Pair<int, GrantedVariableReference<bool>>>();
 
 		// Stored as a percentage of our value
 		[Sync]

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -108,7 +108,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			while (Level < MaxLevel && experience >= nextLevel[Level].First)
 			{
-				self.GrantCondition(nextLevel[Level].Second);
+				self.Grant(nextLevel[Level].Second);
 
 				Level++;
 

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -74,9 +74,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Does the unit queue harvesting runs instead of individual harvest actions?")]
 		public readonly bool QueueFullLoad = false;
 
-		[GrantedConditionReference]
 		[Desc("Condition to grant while empty.")]
-		public readonly string EmptyCondition = null;
+		public readonly GrantedVariableReference<bool> EmptyCondition;
 
 		[VoiceReference]
 		public readonly string HarvestVoice = "Action";
@@ -216,7 +215,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void UpdateCondition(Actor self)
 		{
-			if (string.IsNullOrEmpty(Info.EmptyCondition))
+			if (!Info.EmptyCondition.Valid)
 				return;
 
 			var enabled = IsEmpty;

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -221,7 +221,7 @@ namespace OpenRA.Mods.Common.Traits
 			var enabled = IsEmpty;
 
 			if (enabled && conditionToken == Actor.InvalidConditionToken)
-				conditionToken = self.GrantCondition(Info.EmptyCondition);
+				conditionToken = self.Grant(Info.EmptyCondition);
 			else if (!enabled && conditionToken != Actor.InvalidConditionToken)
 				conditionToken = self.RevokeCondition(conditionToken);
 		}

--- a/OpenRA.Mods.Common/Traits/KillsSelf.cs
+++ b/OpenRA.Mods.Common/Traits/KillsSelf.cs
@@ -14,6 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	#pragma warning disable CS0649
 	class KillsSelfInfo : ConditionalTraitInfo
 	{
 		[Desc("Remove the actor from the world (and destroy it) instead of killing it.")]
@@ -25,12 +26,12 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Types of damage that this trait causes. Leave empty for no damage types.")]
 		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant moments before suiciding.")]
-		public readonly string GrantsCondition = null;
+		public readonly GrantedVariableReference<bool> GrantsCondition;
 
 		public override object Create(ActorInitializer init) { return new KillsSelf(init.Self, this); }
 	}
+	#pragma warning restore CS0649
 
 	class KillsSelf : ConditionalTrait<KillsSelfInfo>, INotifyAddedToWorld, ITick
 	{

--- a/OpenRA.Mods.Common/Traits/KillsSelf.cs
+++ b/OpenRA.Mods.Common/Traits/KillsSelf.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (self.IsDead)
 				return;
 
-			self.GrantCondition(Info.GrantsCondition);
+			self.Grant(Info.GrantsCondition);
 
 			if (Info.RemoveInstead || !self.Info.HasTraitInfo<IHealthInfo>())
 				self.Dispose();

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -52,11 +52,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Display order for the facing slider in the map editor")]
 		public readonly int EditorFacingDisplayOrder = 3;
 
-		[ConsumedConditionReference]
 		[Desc("Boolean expression defining the condition under which the regular (non-force) move cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;
 
-		[ConsumedConditionReference]
 		[Desc("Boolean expression defining the condition under which this actor cannot be nudged by other actors.")]
 		public readonly BooleanExpression ImmovableCondition = null;
 

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 			IsInAir = true;
 
 			if (parachutingToken == Actor.InvalidConditionToken)
-				parachutingToken = self.GrantCondition(info.ParachutingCondition);
+				parachutingToken = self.Grant(info.ParachutingCondition);
 
 			self.NotifyBlocker(self.Location);
 		}

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -50,9 +50,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly int FallRate = 13;
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while parachuting.")]
-		public readonly string ParachutingCondition = null;
+		public readonly GrantedVariableReference<bool> ParachutingCondition;
 
 		public override object Create(ActorInitializer init) { return new Parachutable(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -29,21 +29,16 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly int Weight = 1;
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to when this actor is loaded inside any transport.")]
-		public readonly string CargoCondition = null;
+		public readonly GrantedVariableReference<bool> CargoCondition;
 
 		[Desc("Conditions to grant when this actor is loaded inside specified transport.",
 			"A dictionary of [actor id]: [condition].")]
-		public readonly Dictionary<string, string> CargoConditions = new Dictionary<string, string>();
-
-		[GrantedConditionReference]
-		public IEnumerable<string> LinterCargoConditions { get { return CargoConditions.Values; } }
+		public readonly Dictionary<string, GrantedVariableReference<bool>> CargoConditions = new Dictionary<string, GrantedVariableReference<bool>>();
 
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
-		[ConsumedConditionReference]
 		[Desc("Boolean expression defining the condition under which the regular (non-force) enter cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;
 
@@ -131,7 +126,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyEnteredCargo.OnEnteredCargo(Actor self, Actor cargo)
 		{
-			string specificCargoCondition;
+			GrantedVariableReference<bool> specificCargoCondition;
 
 			if (anyCargoToken == Actor.InvalidConditionToken)
 				anyCargoToken = self.GrantCondition(Info.CargoCondition);

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -129,10 +129,10 @@ namespace OpenRA.Mods.Common.Traits
 			GrantedVariableReference<bool> specificCargoCondition;
 
 			if (anyCargoToken == Actor.InvalidConditionToken)
-				anyCargoToken = self.GrantCondition(Info.CargoCondition);
+				anyCargoToken = self.Grant(Info.CargoCondition);
 
 			if (specificCargoToken == Actor.InvalidConditionToken && Info.CargoConditions.TryGetValue(cargo.Info.Name, out specificCargoCondition))
-				specificCargoToken = self.GrantCondition(specificCargoCondition);
+				specificCargoToken = self.Grant(specificCargoCondition);
 
 			// Allow scripted / initial actors to move from the unload point back into the cell grid on unload
 			// This is handled by the RideTransport activity for player-loaded cargo

--- a/OpenRA.Mods.Common/Traits/Pluggable.cs
+++ b/OpenRA.Mods.Common/Traits/Pluggable.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (conditionToken != Actor.InvalidConditionToken)
 				self.RevokeCondition(conditionToken);
 
-			conditionToken = self.GrantCondition(condition);
+			conditionToken = self.Grant(condition);
 			active = type;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Pluggable.cs
+++ b/OpenRA.Mods.Common/Traits/Pluggable.cs
@@ -10,7 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
+using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Traits;
 
@@ -25,21 +25,12 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Conditions to grant for each accepted plug type.",
 			"Key is the plug type.",
 			"Value is the condition that is granted when the plug is enabled.")]
-		public readonly Dictionary<string, string> Conditions = null;
+		public readonly Dictionary<string, GrantedVariableReference<bool>> Conditions = new Dictionary<string, GrantedVariableReference<bool>>();
 
 		[Desc("Requirements for accepting a plug type.",
 			"Key is the plug type that the requirements applies to.",
 			"Value is the condition expression defining the requirements to place the plug.")]
 		public readonly Dictionary<string, BooleanExpression> Requirements = new Dictionary<string, BooleanExpression>();
-
-		[GrantedConditionReference]
-		public IEnumerable<string> LinterConditions { get { return Conditions.Values; } }
-
-		[ConsumedConditionReference]
-		public IEnumerable<string> ConsumedConditions
-		{
-			get { return Requirements.Values.SelectMany(r => r.Variables).Distinct(); }
-		}
 
 		public override object Create(ActorInitializer init) { return new Pluggable(init, this); }
 	}
@@ -89,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void EnablePlug(Actor self, string type)
 		{
-			string condition;
+			GrantedVariableReference<bool> condition;
 			if (!Info.Conditions.TryGetValue(type, out condition))
 				return;
 

--- a/OpenRA.Mods.Common/Traits/Power/AffectedByPowerOutage.cs
+++ b/OpenRA.Mods.Common/Traits/Power/AffectedByPowerOutage.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 		void Grant(Actor self)
 		{
 			if (token == Actor.InvalidConditionToken)
-				token = self.GrantCondition(Info.Condition);
+				token = self.Grant(Info.Condition);
 		}
 
 		void Revoke(Actor self)

--- a/OpenRA.Mods.Common/Traits/Power/AffectedByPowerOutage.cs
+++ b/OpenRA.Mods.Common/Traits/Power/AffectedByPowerOutage.cs
@@ -17,9 +17,8 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Disables the actor when a power outage is triggered (see `InfiltrateForPowerOutage` for more information).")]
 	public class AffectedByPowerOutageInfo : ConditionalTraitInfo
 	{
-		[GrantedConditionReference]
 		[Desc("The condition to grant while there is a power outage.")]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 
 		public override object Create(ActorInitializer init) { return new AffectedByPowerOutage(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Render/WithDecorationBase.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecorationBase.cs
@@ -12,6 +12,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Traits;
 
@@ -46,12 +47,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Override blink conditions to use when defined conditions are enabled.",
 			"A dictionary of [condition string]: [pattern].")]
 		public readonly Dictionary<BooleanExpression, BlinkState[]> BlinkPatterns = new Dictionary<BooleanExpression, BlinkState[]>();
-
-		[ConsumedConditionReference]
-		public IEnumerable<string> ConsumedConditions
-		{
-			get { return Offsets.Keys.Concat(BlinkPatterns.Keys).SelectMany(r => r.Variables).Distinct(); }
-		}
 	}
 
 	public abstract class WithDecorationBase<InfoType> : ConditionalTrait<InfoType>, IDecoration where InfoType : WithDecorationBaseInfo

--- a/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
@@ -23,9 +23,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence name to use.")]
 		public readonly string Sequence = "make";
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while the make animation is playing.")]
-		public readonly string Condition = null;
+		public readonly GrantedVariableReference<bool> Condition;
 
 		[Desc("Apply to sprite bodies with these names.")]
 		public readonly string[] BodyNames = { "body" };

--- a/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public void Forward(Actor self, Action onComplete)
 		{
 			if (token == Actor.InvalidConditionToken)
-				token = self.GrantCondition(info.Condition);
+				token = self.Grant(info.Condition);
 
 			var wsb = wsbs.FirstEnabledTraitOrDefault();
 
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public void Reverse(Actor self, Action onComplete)
 		{
 			if (token == Actor.InvalidConditionToken)
-				token = self.GrantCondition(info.Condition);
+				token = self.Grant(info.Condition);
 
 			var wsb = wsbs.FirstEnabledTraitOrDefault();
 
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				if (wsb != null)
 					wsb.DefaultAnimation.PlayFetchIndex(info.Sequence, () => 0);
 
-				token = self.GrantCondition(info.Condition);
+				token = self.Grant(info.Condition);
 
 				self.QueueActivity(queued, activity);
 			});

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -33,7 +33,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The amount the unit will be repaired at each step. Use -1 for fallback behavior where HpPerStep from RepairsUnits trait will be used.")]
 		public readonly int HpPerStep = -1;
 
-		[ConsumedConditionReference]
 		[Desc("Boolean expression defining the condition under which the regular (non-force) enter cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;
 

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -30,7 +30,6 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
-		[ConsumedConditionReference]
 		[Desc("Boolean expression defining the condition under which the regular (non-force) enter cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;
 

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -260,6 +260,12 @@ namespace OpenRA.Mods.Common
 			if (t == typeof(IWarhead))
 				return "Warhead";
 
+			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(GrantedVariableReference<>))
+				return "Granted Variable Name";
+
+			if (t == typeof(UsedVariableReference))
+				return "Used Variable Name";
+
 			return t.Name;
 		}
 	}

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.D2k.Activities
 					countdown = swallow.Info.AttackDelay;
 					burrowLocation = self.Location;
 					if (attackingToken == Actor.InvalidConditionToken)
-						attackingToken = self.GrantCondition(swallow.Info.AttackingCondition);
+						attackingToken = self.Grant(swallow.Info.AttackingCondition);
 
 					break;
 				case AttackState.Burrowed:

--- a/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
+++ b/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
@@ -20,6 +20,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits
 {
+	#pragma warning disable CS0649
 	[Desc("Sandworms use this attack model.")]
 	class AttackSwallowInfo : AttackFrontalInfo
 	{
@@ -29,9 +30,8 @@ namespace OpenRA.Mods.D2k.Traits
 		[Desc("The number of ticks it takes to get in place under the target to attack.")]
 		public readonly int AttackDelay = 30;
 
-		[GrantedConditionReference]
 		[Desc("The condition to grant to self while attacking.")]
-		public readonly string AttackingCondition = null;
+		public readonly GrantedVariableReference<bool> AttackingCondition;
 
 		public readonly string WormAttackSound = "WORM.WAV";
 
@@ -40,6 +40,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 		public override object Create(ActorInitializer init) { return new AttackSwallow(init.Self, this); }
 	}
+	#pragma warning restore CS0649
 
 	class AttackSwallow : AttackFrontal
 	{

--- a/OpenRA.Test/OpenRA.Game/RecursiveEnumerableTest.cs
+++ b/OpenRA.Test/OpenRA.Game/RecursiveEnumerableTest.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Test
 			var result = value.AsRecursiveEnumerable<IWithGrantedVariables>().ToArray();
 			Assert.AreEqual(1, result.Length, "Wrong source count");
 			Assert.AreEqual(1, result.SelectMany(r => r.GetGrantedVariables()).Count(), "Wrong source count");
-			Assert.True(result.SelectMany(r => r.GetGrantedVariables()).FirstOrDefault() == "hello", "Wrong string");
+			Assert.True(result.SelectMany(r => r.GetGrantedVariables()).Any() && result.SelectMany(r => r.GetGrantedVariables()).First().Key == "hello", "Wrong string");
 		}
 
 		[TestCase(TestName = "GrantedVariableReference<bool> array")]
@@ -111,8 +111,8 @@ namespace OpenRA.Test
 			var result = value.AsRecursiveEnumerable<IWithGrantedVariables>().ToArray();
 			Assert.AreEqual(2, result.Length, "Wrong source count");
 			Assert.AreEqual(2, result.SelectMany(r => r.GetGrantedVariables()).Count(), "Wrong source count");
-			Assert.True(result.SelectMany(r => r.GetGrantedVariables()).FirstOrDefault() == "hello", "Missing 'hello'");
-			Assert.True(result.SelectMany(r => r.GetGrantedVariables()).LastOrDefault() == "world", "Missing 'World'");
+			Assert.True(result.SelectMany(r => r.GetGrantedVariables()).Any() && result.SelectMany(r => r.GetGrantedVariables()).First().Key == "hello", "Missing 'hello'");
+			Assert.True(result.SelectMany(r => r.GetGrantedVariables()).Any() && result.SelectMany(r => r.GetGrantedVariables()).Last().Key == "world", "Missing 'World'");
 		}
 
 		[TestCase(TestName = "GrantedVariableReference<bool> array array")]
@@ -129,8 +129,8 @@ namespace OpenRA.Test
 			var result = value.AsRecursiveEnumerable<IWithGrantedVariables>().ToArray();
 			Assert.AreEqual(2, result.Length, "Wrong source count");
 			Assert.AreEqual(2, result.SelectMany(r => r.GetGrantedVariables()).Count(), "Wrong variable count");
-			Assert.True(result.SelectMany(r => r.GetGrantedVariables()).FirstOrDefault() == "hello", "Missing 'hello'");
-			Assert.True(result.SelectMany(r => r.GetGrantedVariables()).LastOrDefault() == "world", "Missing 'World'");
+			Assert.True(result.SelectMany(r => r.GetGrantedVariables()).Any() && result.SelectMany(r => r.GetGrantedVariables()).First().Key == "hello", "Missing 'hello'");
+			Assert.True(result.SelectMany(r => r.GetGrantedVariables()).Any() && result.SelectMany(r => r.GetGrantedVariables()).Last().Key == "world", "Missing 'World'");
 		}
 
 		[TestCase(TestName = "Dictionary<GrantedVariableReference<bool>, BooleanExpression>")]
@@ -146,7 +146,7 @@ namespace OpenRA.Test
 			Assert.AreEqual(1, used.Length, "Wrong granted source count");
 			Assert.AreEqual(2, used.GetUsedVariables().Count(), "Wrong used variables count");
 			Assert.AreEqual(1, granted.GetGrantedVariables().Count(), "Wrong granted variables count");
-			Assert.True(granted.Length > 0 && granted[0].GetGrantedVariables().FirstOrDefault() == "message", "Missing 'message'");
+			Assert.True(granted.Length > 0 && granted[0].GetGrantedVariables().Any() && granted[0].GetGrantedVariables().First().Key == "message", "Missing 'message'");
 			Assert.True(used.Length > 0 && used[0].GetUsedVariables().FirstOrDefault() == "hello", "Missing 'hello'");
 			Assert.True(used.Length > 0 && used[0].GetUsedVariables().LastOrDefault() == "world", "Missing 'World'");
 		}

--- a/OpenRA.Test/OpenRA.Game/RecursiveEnumerableTest.cs
+++ b/OpenRA.Test/OpenRA.Game/RecursiveEnumerableTest.cs
@@ -1,0 +1,154 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using OpenRA.Support;
+
+namespace OpenRA.Test
+{
+	[TestFixture]
+	public class RecursiveEnumerableTest
+	{
+		[TestCase(TestName = "single string")]
+		public void GetStringsFromSingle()
+		{
+			object value = "hello";
+			var result = value.AsRecursiveEnumerable<string>().ToArray();
+			Assert.AreEqual(1, result.Length, "Wrong length");
+			Assert.True(result.Length == 1 && result[0] == "hello", "Wrong string");
+		}
+
+		[TestCase(TestName = "string array")]
+		public void GetStringsFromStringArray()
+		{
+			object value = new string[] { "hello", "world" };
+			var result = value.AsRecursiveEnumerable<string>().ToArray();
+			Assert.AreEqual(2, result.Length, "Wrong length");
+			Assert.True(result.Length >= 1 && result[0] == "hello", "Missing 'hello'");
+			Assert.True(result.Length > 1 && result[1] == "world", "Missing 'World'");
+		}
+
+		[TestCase(TestName = "string array array")]
+		public void GetStringsFromStringArrayArray()
+		{
+			object value = new string[][] { new string[] { "hello", "world" } };
+			var result = value.AsRecursiveEnumerable<string>().ToArray();
+			Assert.AreEqual(2, result.Length, "Wrong length");
+			Assert.True(result.Length >= 1 && result[0] == "hello", "Missing 'hello'");
+			Assert.True(result.Length > 1 && result[1] == "world", "Missing 'World'");
+		}
+
+		[TestCase(TestName = "Dictionary<string, string[]>")]
+		public void GetStringsFromStringStringArrayDictionary()
+		{
+			object value = new Dictionary<string, string[]> { { "message", new string[] { "hello", "world" } } };
+			var result = value.AsRecursiveEnumerable<string>().ToArray();
+			Assert.AreEqual(3, result.Length, "Wrong length");
+			Assert.True(result.Length >= 1 && result[0] == "message", "Missing 'message'");
+			Assert.True(result.Length > 1 && result[1] == "hello", "Missing 'hello'");
+			Assert.True(result.Length > 2 && result[2] == "world", "Missing 'World'");
+		}
+
+		[TestCase(TestName = "Dictionary<string, string[][]>")]
+		public void GetStringsFromStringStringArrayArrayDictionary()
+		{
+			object value = new Dictionary<string, string[][]> { { "message", new string[][] { new string[] { "hello" }, new string[] { "world" } } } };
+			var result = value.AsRecursiveEnumerable<string>().ToArray();
+			Assert.AreEqual(3, result.Length, "Wrong length");
+			Assert.True(result.Length >= 1 && result[0] == "message", "Missing 'message'");
+			Assert.True(result.Length > 1 && result[1] == "hello", "Missing 'hello'");
+			Assert.True(result.Length > 2 && result[2] == "world", "Missing 'World'");
+		}
+
+		[TestCase(TestName = "Dictionary<string, List<string[]>>")]
+		public void GetStringsFromStringStringArrayListDictionary()
+		{
+			object value = new Dictionary<string, List<string[]>> { { "message", new List<string[]> { new string[] { "hello" }, new string[] { "world" } } } };
+			var result = value.AsRecursiveEnumerable<string>().ToArray();
+			Assert.AreEqual(3, result.Length, "Wrong length");
+			Assert.True(result.Length >= 1 && result[0] == "message", "Missing 'message'");
+			Assert.True(result.Length > 1 && result[1] == "hello", "Missing 'hello'");
+			Assert.True(result.Length > 2 && result[2] == "world", "Missing 'World'");
+		}
+
+		// Note: object type neither is a string type nor acts a collection of strings.
+		[TestCase(TestName = "object array string array")]
+		public void GetStringsFromObjectArrayStringArray()
+		{
+			object value = new object[] { new string[] { "hello", "world" } };
+			var result = value.AsRecursiveEnumerable<string>().ToArray();
+			Assert.AreEqual(0, result.Length, "Wrong length");
+		}
+
+		[TestCase(TestName = "single GrantedVariableReference<bool>")]
+		public void GetGrantedConditionReferenceFromSingle()
+		{
+			object value = new GrantedVariableReference<bool>("hello");
+			var result = value.AsRecursiveEnumerable<IWithGrantedVariables>().ToArray();
+			Assert.AreEqual(1, result.Length, "Wrong source count");
+			Assert.AreEqual(1, result.SelectMany(r => r.GetGrantedVariables()).Count(), "Wrong source count");
+			Assert.True(result.SelectMany(r => r.GetGrantedVariables()).FirstOrDefault() == "hello", "Wrong string");
+		}
+
+		[TestCase(TestName = "GrantedVariableReference<bool> array")]
+		public void GetGrantedConditionReferencesFromGrantedConditionReferenceArray()
+		{
+			object value = new GrantedVariableReference<bool>[]
+			{
+				new GrantedVariableReference<bool>("hello"),
+				new GrantedVariableReference<bool>("world")
+			};
+			var result = value.AsRecursiveEnumerable<IWithGrantedVariables>().ToArray();
+			Assert.AreEqual(2, result.Length, "Wrong source count");
+			Assert.AreEqual(2, result.SelectMany(r => r.GetGrantedVariables()).Count(), "Wrong source count");
+			Assert.True(result.SelectMany(r => r.GetGrantedVariables()).FirstOrDefault() == "hello", "Missing 'hello'");
+			Assert.True(result.SelectMany(r => r.GetGrantedVariables()).LastOrDefault() == "world", "Missing 'World'");
+		}
+
+		[TestCase(TestName = "GrantedVariableReference<bool> array array")]
+		public void GetIVariablesReferencesFromGrantedConditionReferenceArrayArray()
+		{
+			object value = new GrantedVariableReference<bool>[][]
+			{
+				new GrantedVariableReference<bool>[]
+				{
+					new GrantedVariableReference<bool>("hello"),
+					new GrantedVariableReference<bool>("world")
+				}
+			};
+			var result = value.AsRecursiveEnumerable<IWithGrantedVariables>().ToArray();
+			Assert.AreEqual(2, result.Length, "Wrong source count");
+			Assert.AreEqual(2, result.SelectMany(r => r.GetGrantedVariables()).Count(), "Wrong variable count");
+			Assert.True(result.SelectMany(r => r.GetGrantedVariables()).FirstOrDefault() == "hello", "Missing 'hello'");
+			Assert.True(result.SelectMany(r => r.GetGrantedVariables()).LastOrDefault() == "world", "Missing 'World'");
+		}
+
+		[TestCase(TestName = "Dictionary<GrantedVariableReference<bool>, BooleanExpression>")]
+		public void GetStringsFromGrantedConditionReferenceBooleanExpressionyDictionary()
+		{
+			object value = new Dictionary<GrantedVariableReference<bool>, BooleanExpression>
+			{
+				{ new GrantedVariableReference<bool>("message"), new BooleanExpression("hello && world") }
+			};
+			var granted = value.AsRecursiveEnumerable<IWithGrantedVariables>().ToArray();
+			var used = value.AsRecursiveEnumerable<IWithUsedVariables>().ToArray();
+			Assert.AreEqual(1, used.Length, "Wrong used source count");
+			Assert.AreEqual(1, used.Length, "Wrong granted source count");
+			Assert.AreEqual(2, used.GetUsedVariables().Count(), "Wrong used variables count");
+			Assert.AreEqual(1, granted.GetGrantedVariables().Count(), "Wrong granted variables count");
+			Assert.True(granted.Length > 0 && granted[0].GetGrantedVariables().FirstOrDefault() == "message", "Missing 'message'");
+			Assert.True(used.Length > 0 && used[0].GetUsedVariables().FirstOrDefault() == "hello", "Missing 'hello'");
+			Assert.True(used.Length > 0 && used[0].GetUsedVariables().LastOrDefault() == "world", "Missing 'World'");
+		}
+	}
+}


### PR DESCRIPTION
This adds `GrantedVariableReference<ConditionType>`/"Granted Condition Name" and `UsedVariableReference`/"Used Variable Name" types and underlying plumbing extracting/linting such types from traits (or anything else). This supersedes #13352. The plumbing will also be used when `ActorReference` is added, which will link to `ActorInfo`s. The use is "variable" is because I plan on adding other types of variables to the system including integer and `enum` (`DamageState`, `UnitStance`, etc.) types. `enum`s will be bound by attaching an attribute like the binding for Lua. This will allow attaching variable type info to the references and collecting those to compile static typed expressions as well as assigning the variables indexed slots in arrays for more cohesive memory allocation and replacement of string based lookup. I plan to account for the variable indices in the expression compile cache as well. I also plan to move variable/condition initialization to a split `ActorInfo` and init processing phases so that trait infos can use a prebuilt state in the map editor.