### PR TITLE
Fix build limit icon bug (new approach)

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/GrantConditionOnPrerequisiteManager.cs
+++ b/OpenRA.Mods.Common/Traits/Player/GrantConditionOnPrerequisiteManager.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!upgradables.ContainsKey(key))
 			{
 				upgradables.Add(key, new List<Pair<Actor, GrantConditionOnPrerequisite>>());
-				techTree.Add(key, prerequisites, 0, this);
+				techTree.Add(key, prerequisites, this);
 			}
 
 			upgradables[key].Add(Pair.New(actor, u));

--- a/OpenRA.Mods.Common/Traits/Render/VeteranProductionIconOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/VeteranProductionIconOverlay.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			{
 				var uwc = a.TraitInfoOrDefault<ProducibleWithLevelInfo>();
 				if (uwc != null)
-					ttc.Add(MakeKey(a.Name), uwc.Prerequisites, 0, this);
+					ttc.Add(MakeKey(a.Name), uwc.Prerequisites, this);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 
 					if (t.Info.Prerequisites.Any())
 					{
-						TechTree.Add(key, t.Info.Prerequisites, 0, this);
+						TechTree.Add(key, t.Info.Prerequisites, this);
 						TechTree.Update();
 					}
 				}


### PR DESCRIPTION
1. Fix two build limit performance bug:
    1.1 the icon will turn grey only when build limit is 1,  which means it won't work for build limit > 1.
    1.2 the icon will change to avaliable palette when build limit unit enters the transport.
Fix #5872

2. Add a "Isdead" check for build limit check in ProductionQueue.cs. I guess those fixs can prevent some bugs that not yet found.

3. Remove the build-limit-check in "TechTree" and simplified data struct in it to get better performance and let it focus on normal prequisites only. Now the "ProductionQueue" will check the build limit for icon.