### PR TITLE
Fix resupply not displaying target lines correctly

### DIFF
--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -133,7 +133,7 @@ namespace OpenRA.Mods.Common.Activities
 				// HACK: Repairable needs the actor to move to host center.
 				// TODO: Get rid of this or at least replace it with something less hacky.
 				if (repairableNear == null)
-					QueueChild(move.MoveTo(targetCell));
+					QueueChild(move.MoveTo(targetCell, targetLineColor: Color.Green));
 
 				var delta = (self.CenterPosition - host.CenterPosition).LengthSquared;
 				var transport = transportCallers.FirstOrDefault(t => t.MinimumDistance.LengthSquared < delta);
@@ -222,7 +222,7 @@ namespace OpenRA.Mods.Common.Activities
 				{
 					if (rp != null && rp.Path.Count > 0)
 						foreach (var cell in rp.Path)
-							QueueChild(move.MoveTo(cell, 1, repairableNear != null ? null : host.Actor, true));
+							QueueChild(move.MoveTo(cell, 1, repairableNear != null ? null : host.Actor, true, Color.Green));
 					else if (repairableNear == null)
 						QueueChild(move.MoveToTarget(self, host));
 				}


### PR DESCRIPTION
The first bug is easy to spot: Queue a move order and then a repair order to a service depot (using a damaged unit). The target line to the depot will disappear on bleed once the unit completed the first move and moves towards the depot.
The second bug is not displaying the target lines for the queued rally points.

I noticed that both the working case here (aircraft) and `Reservable` do not show the target lines for all rally points, but just the line for each move sequentially. This is due to the moves being child activities. I'd like to fix that in a different PR, so that this remains relatively simple.