### PR TITLE
Add trim_trailing_whitespace to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@ charset=utf-8
 [*]
 end_of_line = LF
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 ; 4-column tab indentation
 [*.cs]


### PR DESCRIPTION
Set `trim_trailing_whitespace` to `true` for all file types as this seems to be the convention in OpenRA.

From the editorconfig docs:
> trim_trailing_whitespace: set to "true" to remove any whitespace characters preceding newline characters and "false" to ensure it doesn't.