### PR TITLE
Display player status in shroud selector

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -93,20 +93,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					LobbyUtils.SetupProfileWidget(item, client, orderManager, worldRenderer);
 
 					var nameLabel = item.Get<LabelWidget>("NAME");
-					var nameFont = Game.Renderer.Fonts[nameLabel.Font];
-
-					var suffixLength = new CachedTransform<string, int>(s => nameFont.Measure(s).X);
-					var name = new CachedTransform<Pair<string, string>, string>(c =>
-						WidgetUtils.TruncateText(c.First, nameLabel.Bounds.Width - suffixLength.Update(c.Second), nameFont) + c.Second);
-
-					nameLabel.GetText = () =>
-					{
-						var suffix = pp.WinState == WinState.Undefined ? "" : " (" + pp.WinState + ")";
-						if (client != null && client.State == Session.ClientState.Disconnected)
-							suffix = " (Gone)";
-
-						return name.Update(Pair.New(pp.PlayerName, suffix));
-					};
+					WidgetUtils.AddSuffixToPlayerNameLabel(nameLabel, pp);
 					nameLabel.GetColor = () => pp.Color;
 
 					var flag = item.Get<ImageWidget>("FACTIONFLAG");

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					LobbyUtils.SetupProfileWidget(item, client, orderManager, worldRenderer);
 
 					var nameLabel = item.Get<LabelWidget>("NAME");
-					WidgetUtils.AddSuffixToPlayerNameLabel(nameLabel, pp);
+					WidgetUtils.BindPlayerNameAndStatus(nameLabel, pp);
 					nameLabel.GetColor = () => pp.Color;
 
 					var flag = item.Get<ImageWidget>("FACTIONFLAG");

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
@@ -33,6 +33,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly World world;
 
 		CameraOption selected;
+		LabelWidget shroudLabel;
 
 		class CameraOption
 		{
@@ -50,7 +51,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Color = p.Color;
 				Faction = p.Faction.InternalName;
 				IsSelected = () => p.World.RenderPlayer == p;
-				OnClick = () => { p.World.RenderPlayer = p; logic.selected = this; p.World.Selection.Clear(); };
+				OnClick = () =>
+				{
+					p.World.RenderPlayer = p;
+					logic.selected = this;
+					p.World.Selection.Clear();
+					WidgetUtils.BindPlayerNameAndStatus(logic.shroudLabel, p);
+				};
 			}
 
 			public CameraOption(ObserverShroudSelectorLogic logic, World w, string label, Player p)
@@ -107,8 +114,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					var label = item.Get<LabelWidget>("LABEL");
 					label.IsVisible = () => showFlag;
-					label.GetText = () => option.Label;
 					label.GetColor = () => option.Color;
+
+					if (showFlag)
+						WidgetUtils.BindPlayerNameAndStatus(label, option.Player);
+					else
+						label.GetText = () => option.Label;
 
 					var flag = item.Get<ImageWidget>("FLAG");
 					flag.IsVisible = () => showFlag;
@@ -126,7 +137,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				shroudSelector.ShowDropDown("SPECTATOR_DROPDOWN_TEMPLATE", 400, groups, setupItem);
 			};
 
-			var shroudLabel = shroudSelector.Get<LabelWidget>("LABEL");
+			shroudLabel = shroudSelector.Get<LabelWidget>("LABEL");
 			shroudLabel.IsVisible = () => selected.Faction != null;
 			shroudLabel.GetText = () => selected.Label;
 			shroudLabel.GetColor = () => selected.Color;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -526,7 +526,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			flag.GetImageName = () => player.Faction.InternalName;
 
 			var playerName = template.Get<LabelWidget>("PLAYER");
-			WidgetUtils.AddSuffixToPlayerNameLabel(playerName, player);
+			WidgetUtils.BindPlayerNameAndStatus(playerName, player);
 
 			playerName.GetColor = () => player.Color;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -525,22 +525,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			flag.GetImageCollection = () => "flags";
 			flag.GetImageName = () => player.Faction.InternalName;
 
-			var client = player.World.LobbyInfo.ClientWithIndex(player.ClientIndex);
 			var playerName = template.Get<LabelWidget>("PLAYER");
-			var playerNameFont = Game.Renderer.Fonts[playerName.Font];
-			var suffixLength = new CachedTransform<string, int>(s => playerNameFont.Measure(s).X);
-			var name = new CachedTransform<Pair<string, int>, string>(c =>
-				WidgetUtils.TruncateText(c.First, playerName.Bounds.Width - c.Second, playerNameFont));
-
-			playerName.GetText = () =>
-			{
-				var suffix = player.WinState == WinState.Undefined ? "" : " (" + player.WinState + ")";
-				if (client != null && client.State == Session.ClientState.Disconnected)
-					suffix = " (Gone)";
-
-				var sl = suffixLength.Update(suffix);
-				return name.Update(Pair.New(player.PlayerName, sl)) + suffix;
-			};
+			WidgetUtils.AddSuffixToPlayerNameLabel(playerName, player);
 
 			playerName.GetColor = () => player.Color;
 		}

--- a/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Network;
 using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.Widgets
@@ -269,6 +270,24 @@ namespace OpenRA.Mods.Common.Widgets
 				button.GetTooltipText = () => text;
 			else
 				button.GetTooltipText = null;
+		}
+
+		public static void AddSuffixToPlayerNameLabel(LabelWidget label, Player p)
+		{
+			var client = p.World.LobbyInfo.ClientWithIndex(p.ClientIndex);
+			var playerNameFont = Game.Renderer.Fonts[label.Font];
+			var suffixLength = new CachedTransform<string, int>(s => playerNameFont.Measure(s).X);
+			var name = new CachedTransform<Pair<string, string>, string>(c =>
+				WidgetUtils.TruncateText(c.First, label.Bounds.Width - suffixLength.Update(c.Second), playerNameFont));
+
+			label.GetText = () =>
+			{
+				var suffix = p.WinState == WinState.Undefined ? "" : " (" + p.WinState + ")";
+				if (client != null && client.State == Session.ClientState.Disconnected)
+					suffix = " (Gone)";
+
+				return name.Update(Pair.New(p.PlayerName, suffix)) + suffix;
+			};
 		}
 	}
 

--- a/mods/cnc/chrome/dialogs.yaml
+++ b/mods/cnc/chrome/dialogs.yaml
@@ -142,7 +142,7 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 					Height: 16
 				Label@LABEL:
 					X: 40
-					Width: 60
+					Width: PARENT_RIGHT
 					Height: 25
 					Shadow: True
 				Label@NOFLAG_LABEL:

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -271,7 +271,7 @@ Container@OBSERVER_WIDGETS:
 					Height: 16
 				Label@LABEL:
 					X: 40
-					Width: 60
+					Width: PARENT_RIGHT
 					Height: 25
 					Shadow: True
 				Label@NOFLAG_LABEL:

--- a/mods/common/chrome/dropdowns.yaml
+++ b/mods/common/chrome/dropdowns.yaml
@@ -108,7 +108,7 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 					Height: 16
 				Label@LABEL:
 					X: 40
-					Width: 60
+					Width: PARENT_RIGHT
 					Height: 25
 					Shadow: True
 				Label@NOFLAG_LABEL:

--- a/mods/common/chrome/ingame-observer.yaml
+++ b/mods/common/chrome/ingame-observer.yaml
@@ -74,7 +74,7 @@ Container@OBSERVER_WIDGETS:
 							Y: 2
 						Label@LABEL:
 							X: 34
-							Width: 60
+							Width: PARENT_RIGHT
 							Height: 25
 							Shadow: True
 						Label@NOFLAG_LABEL:

--- a/mods/d2k/chrome/dropdowns.yaml
+++ b/mods/d2k/chrome/dropdowns.yaml
@@ -104,7 +104,7 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 					Y: 2
 				Label@LABEL:
 					X: 34
-					Width: 60
+					Width: PARENT_RIGHT
 					Height: 25
 					Shadow: True
 				Label@NOFLAG_LABEL:

--- a/mods/d2k/chrome/ingame-observer.yaml
+++ b/mods/d2k/chrome/ingame-observer.yaml
@@ -94,7 +94,7 @@ Container@OBSERVER_WIDGETS:
 							Y: 2
 						Label@LABEL:
 							X: 34
-							Width: 60
+							Width: PARENT_RIGHT
 							Height: 25
 							Shadow: True
 						Label@NOFLAG_LABEL:

--- a/mods/ra/chrome/ingame-observer.yaml
+++ b/mods/ra/chrome/ingame-observer.yaml
@@ -108,7 +108,7 @@ Container@OBSERVER_WIDGETS:
 							Height: 16
 						Label@LABEL:
 							X: 40
-							Width: 60
+							Width: PARENT_RIGHT
 							Height: 25
 							Shadow: True
 						Label@NOFLAG_LABEL:

--- a/mods/ts/chrome/dropdowns.yaml
+++ b/mods/ts/chrome/dropdowns.yaml
@@ -104,7 +104,7 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 					Height: 16
 				Label@LABEL:
 					X: 40
-					Width: 60
+					Width: PARENT_RIGHT
 					Height: 25
 					Shadow: True
 				Label@NOFLAG_LABEL:

--- a/mods/ts/chrome/ingame-observer.yaml
+++ b/mods/ts/chrome/ingame-observer.yaml
@@ -94,7 +94,7 @@ Container@OBSERVER_WIDGETS:
 							Y: 5
 						Label@LABEL:
 							X: 34
-							Width: 60
+							Width: PARENT_RIGHT
 							Height: 25
 							Shadow: True
 						Label@NOFLAG_LABEL:


### PR DESCRIPTION
Closes #18074

The first commit adds a helper method to reduce duplication across the places that need to add suffix to the player name.

Note that this doesn't invalidate #14491 - removing dead players is a different thing and suffixes are still good to have for disconnected players.

![OpenRA-2020-05-18T144552129Z](https://user-images.githubusercontent.com/1355810/82228349-afcb3980-9931-11ea-8ddd-f4c9a7c3cd04.png)