### PR TITLE
Fixed a crash when putting AmbientSound on the World actor

### DIFF
--- a/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
@@ -52,13 +52,16 @@ namespace OpenRA.Mods.Common.Traits.Sound
 
 			currentSounds.RemoveWhere(s => s == null || s.Complete);
 
-			var pos = self.CenterPosition;
-			if (pos != cachedPosition)
+			if (self.OccupiesSpace != null)
 			{
-				foreach (var s in currentSounds)
-					s.SetPosition(pos);
+				var pos = self.CenterPosition;
+				if (pos != cachedPosition)
+				{
+					foreach (var s in currentSounds)
+						s.SetPosition(pos);
 
-				cachedPosition = pos;
+					cachedPosition = pos;
+				}
 			}
 
 			if (delay < 0)


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/OpenRA/OpenRA/pull/12672. Closes https://github.com/OpenRA/OpenRA/issues/15292.