### PR TITLE
Fix three build limit icon bug

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -357,7 +357,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (bi.BuildLimit > 0)
 				{
 					var owned = self.Owner.World.ActorsHavingTrait<Buildable>()
-						.Count(a => a.Info.Name == actor.Name && a.Owner == self.Owner);
+						.Count(a => a.Info.Name == actor.Name && a.Owner == self.Owner && !a.IsDead);
 					if (queueCount + owned >= bi.BuildLimit)
 						return false;
 				}
@@ -400,7 +400,7 @@ namespace OpenRA.Mods.Common.Traits
 						if (bi.BuildLimit > 0)
 						{
 							var inQueue = Queue.Count(pi => pi.Item == order.TargetString);
-							var owned = self.Owner.World.ActorsHavingTrait<Buildable>().Count(a => a.Info.Name == order.TargetString && a.Owner == self.Owner);
+							var owned = self.Owner.World.ActorsHavingTrait<Buildable>().Count(a => a.Info.Name == order.TargetString && a.Owner == self.Owner && !a.IsDead);
 							fromLimit = Math.Min(fromLimit, bi.BuildLimit - (inQueue + owned));
 						}
 


### PR DESCRIPTION
Fix three build limit icon bug:
1. the icon will turn grey only when build limit is 1,  which means it won't work for build limit > 1.
2. the icon will change to avaliable palette when build limit unit enters the transport. Fixes #5872
3. At certain condition (like mod), if actor provides normal prerequisite has the same name as one of the BuildLimit "prerequisite" will make the other actor unbuildable.

*4. use `<string, int>` instead of  `<string, List<Actor>>` for prerequisites count.

Use a hardcode and probably ugly way to solve former sell build limit building tech tree refresh bug.
