### PR TITLE
Fix units not attack moving to waypoints after resupply/takeoff

### DIFF
--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -201,7 +201,7 @@ namespace OpenRA.Mods.Common.Activities
 				{
 					if (self.CurrentActivity.NextActivity == null && rp != null && rp.Path.Count > 0)
 						foreach (var cell in rp.Path)
-							QueueChild(move.MoveTo(cell, 1, ignoreActor: repairableNear != null ? null : host.Actor, targetLineColor: Color.Green));
+							QueueChild(new AttackMoveActivity(self, () => move.MoveTo(cell, 1, ignoreActor: repairableNear != null ? null : host.Actor, targetLineColor: Color.OrangeRed)));
 					else
 						QueueChild(new TakeOff(self));
 
@@ -222,7 +222,7 @@ namespace OpenRA.Mods.Common.Activities
 				{
 					if (rp != null && rp.Path.Count > 0)
 						foreach (var cell in rp.Path)
-							QueueChild(move.MoveTo(cell, 1, repairableNear != null ? null : host.Actor, true, Color.Green));
+							QueueChild(new AttackMoveActivity(self, () => move.MoveTo(cell, 1, repairableNear != null ? null : host.Actor, true, Color.OrangeRed)));
 					else if (repairableNear == null)
 						QueueChild(move.MoveToTarget(self, host));
 				}

--- a/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					if (rallyPoint != null && rallyPoint.Path.Count > 0)
 						foreach (var cell in rallyPoint.Path)
-							reservedFor.QueueActivity(reservedForAircraft.MoveTo(cell, 1, targetLineColor: Color.Green));
+							reservedFor.QueueActivity(new AttackMoveActivity(reservedFor, () => reservedForAircraft.MoveTo(cell, 1, targetLineColor: Color.OrangeRed)));
 					else
 						reservedFor.QueueActivity(new TakeOff(reservedFor));
 				}


### PR DESCRIPTION
Units attack move in all other cases when they move to rally points.