### PR TITLE
Rewrite ActorInit queries.

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -122,8 +122,9 @@ namespace OpenRA
 
 			World = world;
 			ActorID = world.NextAID();
-			if (initDict.Contains<OwnerInit>())
-				Owner = init.Get<OwnerInit, Player>();
+			var ownerInit = init.GetOrDefault<OwnerInit>(null);
+			if (ownerInit != null)
+				Owner = ownerInit.Value(world);
 
 			if (name != null)
 			{

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -276,7 +276,7 @@ namespace OpenRA
 					foreach (var kv in actorDefinitions.Nodes.Where(d => d.Value.Value == "mpspawn"))
 					{
 						var s = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
-						spawns.Add(s.InitDict.Get<LocationInit>().Value(null));
+						spawns.Add(s.InitDict.Get<LocationInit>().Value);
 					}
 
 					newData.SpawnPoints = spawns.ToArray();

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackPopupTurreted.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			this.info = info;
 			turret = turrets.FirstOrDefault();
 			wsb = init.Self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == info.Body);
-			skippedMakeAnimation = init.Contains<SkipMakeAnimsInit>();
+			skippedMakeAnimation = init.Contains<SkipMakeAnimsInit>(info);
 		}
 
 		protected override void Created(Actor self)

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForTransform.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForTransform.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public InfiltrateForTransform(ActorInitializer init, InfiltrateForTransformInfo info)
 		{
 			this.info = info;
-			faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
+			faction = init.GetValue<FactionInit, string>(info, init.Self.Owner.Faction.InternalName);
 		}
 
 		void INotifyInfiltrated.Infiltrated(Actor self, Actor infiltrator, BitSet<TargetableType> types)

--- a/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{
-			if (init.Contains<HideBibPreviewInit>() && init.Get<HideBibPreviewInit, bool>())
+			if (init.Contains<HideBibPreviewInit>(this))
 				yield break;
 
 			if (Palette != null)
@@ -45,10 +45,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			var bibOffset = bi.Dimensions.Y - rows;
 			var centerOffset = bi.CenterOffset(init.World);
 			var map = init.World.Map;
-			var location = CPos.Zero;
-
-			if (init.Contains<LocationInit>())
-				location = init.Get<LocationInit, CPos>();
+			var location = init.GetValue<LocationInit, CPos>(this, CPos.Zero);
 
 			for (var i = 0; i < rows * width; i++)
 			{
@@ -136,13 +133,8 @@ namespace OpenRA.Mods.Cnc.Traits
 		}
 	}
 
-	class HideBibPreviewInit : IActorInit<bool>, ISuppressInitExport
+	class HideBibPreviewInit : IActorInit, ISuppressInitExport
 	{
-		[FieldFromYamlKey]
-		readonly bool value = true;
-
 		public HideBibPreviewInit() { }
-		public HideBibPreviewInit(bool init) { value = init; }
-		public bool Value(World world) { return value; }
 	}
 }

--- a/OpenRA.Mods.Cnc/Traits/Render/WithEmbeddedTurretSpriteBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithEmbeddedTurretSpriteBody.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 			var wsb = init.Actor.TraitInfos<WithSpriteBodyInfo>().FirstOrDefault();
 
 			// Show the correct turret facing
-			var facing = WAngle.FromFacing(init.Contains<TurretFacingInit>() ? init.Get<TurretFacingInit>().Value(init.World) : t.InitialFacing);
+			var facing = WAngle.FromFacing(init.GetValue<TurretFacingInit, int>(this, t.InitialFacing));
 
 			var anim = new Animation(init.World, image, () => facing);
 			anim.PlayRepeating(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), wsb.Sequence));

--- a/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		{
 			var model = init.World.ModelCache.GetModelSequence(image, Sequence);
 			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
-			var frame = init.Contains<BodyAnimationFrameInit>() ? init.Get<BodyAnimationFrameInit, uint>() : 0;
+			var frame = init.GetValue<BodyAnimationFrameInit, uint>(this, 0);
 
 			yield return new ModelAnimation(model, () => WVec.Zero,
 				() => new[] { body.QuantizeOrientation(orientation(), facings) },
@@ -102,6 +102,6 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 
 		public BodyAnimationFrameInit() { }
 		public BodyAnimationFrameInit(uint init) { value = init; }
-		public uint Value(World world) { return value; }
+		public uint Value { get { return value; } }
 	}
 }

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -80,13 +80,15 @@ namespace OpenRA.Mods.Cnc.Traits
 			Info = info;
 			self = init.Self;
 
-			if (init.Contains<LocationInit>())
-				SetPosition(self, init.Get<LocationInit, CPos>());
+			var locationInit = init.GetOrDefault<LocationInit>(info);
+			if (locationInit != null)
+				SetPosition(self, locationInit.Value);
 
-			if (init.Contains<CenterPositionInit>())
-				SetPosition(self, init.Get<CenterPositionInit, WPos>());
+			var centerPositionInit = init.GetOrDefault<CenterPositionInit>(info);
+			if (centerPositionInit != null)
+				SetPosition(self, centerPositionInit.Value);
 
-			Facing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : Info.GetInitialFacing();
+			Facing = init.GetValue<FacingInit, int>(info, Info.GetInitialFacing());
 
 			// Prevent mappers from setting bogus facings
 			if (Facing != 64 && Facing != 192)

--- a/OpenRA.Mods.Common/ActorInitializer.cs
+++ b/OpenRA.Mods.Common/ActorInitializer.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common
 
 		public FacingInit() { }
 		public FacingInit(int init) { value = init; }
-		public int Value(World world) { return value; }
+		public int Value { get { return value; } }
 	}
 
 	public class CreationActivityDelayInit : IActorInit<int>
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common
 
 		public CreationActivityDelayInit() { }
 		public CreationActivityDelayInit(int init) { value = init; }
-		public int Value(World world) { return value; }
+		public int Value { get { return value; } }
 	}
 
 	public class DynamicFacingInit : IActorInit<Func<int>>
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common
 		readonly Func<int> func;
 
 		public DynamicFacingInit(Func<int> func) { this.func = func; }
-		public Func<int> Value(World world) { return func; }
+		public Func<int> Value { get { return func; } }
 	}
 
 	public class SubCellInit : IActorInit<SubCell>
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common
 		public SubCellInit() { }
 		public SubCellInit(byte init) { value = init; }
 		public SubCellInit(SubCell init) { value = (byte)init; }
-		public SubCell Value(World world) { return (SubCell)value; }
+		public SubCell Value { get { return (SubCell)value; } }
 	}
 
 	public class CenterPositionInit : IActorInit<WPos>
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common
 
 		public CenterPositionInit() { }
 		public CenterPositionInit(WPos init) { value = init; }
-		public WPos Value(World world) { return value; }
+		public WPos Value { get { return value; } }
 	}
 
 	// Allows maps / transformations to specify the faction variant of an actor.
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common
 
 		public FactionInit() { }
 		public FactionInit(string faction) { Faction = faction; }
-		public string Value(World world) { return Faction; }
+		public string Value { get { return Faction; } }
 	}
 
 	public class EffectiveOwnerInit : IActorInit<Player>
@@ -81,6 +81,6 @@ namespace OpenRA.Mods.Common
 
 		public EffectiveOwnerInit() { }
 		public EffectiveOwnerInit(Player owner) { value = owner; }
-		Player IActorInit<Player>.Value(World world) { return value; }
+		public Player Value { get { return value; } }
 	}
 }

--- a/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
@@ -138,7 +138,7 @@ namespace OpenRA.Mods.Common.Widgets
 						{
 							var location = copy.InitDict.Get<LocationInit>();
 							copy.InitDict.Remove(location);
-							copy.InitDict.Add(new LocationInit(location.Value(worldRenderer.World) + offset));
+							copy.InitDict.Add(new LocationInit(location.Value + offset));
 						}
 
 						previews.Add(preview.ID, copy);

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Lint
 				foreach (var kv in map.ActorDefinitions.Where(d => d.Value.Value == "mpspawn"))
 				{
 					var s = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
-					spawns.Add(s.InitDict.Get<LocationInit>().Value(null));
+					spawns.Add(s.InitDict.Get<LocationInit>().Value);
 				}
 
 				if (playerCount > spawns.Count)
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Lint
 					emitError("Actor {0} is not owned by any player.".F(kv.Key));
 				else
 				{
-					var ownerName = ownerInit.PlayerName;
+					var ownerName = ownerInit.InternalName;
 					if (!playerNames.Contains(ownerName))
 						emitError("Actor {0} is owned by unknown player {1}.".F(kv.Key, ownerName));
 

--- a/OpenRA.Mods.Common/Scripting/Global/ActorGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ActorGlobal.cs
@@ -41,11 +41,18 @@ namespace OpenRA.Mods.Common.Scripting
 					if (initType == null)
 						throw new LuaException("Unknown initializer type '{0}'".F(typeName));
 
-					// Cast it up to an IActorInit<T>
-					var genericType = initType.GetInterfaces()
-						.First(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IActorInit<>));
-					var innerType = genericType.GetGenericArguments().First();
-					var valueType = innerType.IsEnum ? Enum.GetUnderlyingType(innerType) : innerType;
+					// HACK: Handle OwnerInit as a special case until ActorInit creation can be rewritten
+					Type innerType, valueType;
+					if (initType != typeof(OwnerInit))
+					{
+						// Cast it up to an IActorInit<T>
+						var genericType = initType.GetInterfaces()
+							.First(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IActorInit<>));
+						innerType = genericType.GetGenericArguments().First();
+						valueType = innerType.IsEnum ? Enum.GetUnderlyingType(innerType) : innerType;
+					}
+					else
+						innerType = valueType = typeof(Player);
 
 					// Try and coerce the table value to the required type
 					object value;

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -179,7 +179,7 @@ namespace OpenRA.Mods.Common.Traits
 				actor =>
 				{
 					var init = actor.Init<FacingInit>();
-					return init != null ? init.Value(world) : InitialFacing;
+					return init != null ? init.Value : InitialFacing;
 				},
 				(actor, value) => actor.ReplaceInit(new FacingInit((int)value)));
 		}
@@ -241,16 +241,16 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			self = init.Self;
 
-			if (init.Contains<LocationInit>())
-				SetPosition(self, init.Get<LocationInit, CPos>());
+			var locationInit = init.GetOrDefault<LocationInit>(info);
+			if (locationInit != null)
+				SetPosition(self, locationInit.Value);
 
-			if (init.Contains<CenterPositionInit>())
-				SetPosition(self, init.Get<CenterPositionInit, WPos>());
+			var centerPositionInit = init.GetOrDefault<CenterPositionInit>(info);
+			if (centerPositionInit != null)
+				SetPosition(self, centerPositionInit.Value);
 
-			Facing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : Info.InitialFacing;
-
-			if (init.Contains<CreationActivityDelayInit>())
-				creationActivityDelay = init.Get<CreationActivityDelayInit, int>();
+			Facing = init.GetValue<FacingInit, int>(info, Info.InitialFacing);
+			creationActivityDelay = init.GetValue<CreationActivityDelayInit, int>(info, 0);
 		}
 
 		public WDist LandAltitude

--- a/OpenRA.Mods.Common/Traits/Air/FallsToEarth.cs
+++ b/OpenRA.Mods.Common/Traits/Air/FallsToEarth.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 		public FallsToEarth(ActorInitializer init, FallsToEarthInfo info)
 		{
 			this.info = info;
-			effectiveOwner = init.Contains<EffectiveOwnerInit>() ? init.Get<EffectiveOwnerInit, Player>() : init.Self.Owner;
+			effectiveOwner = init.GetValue<EffectiveOwnerInit, Player>(info, init.Self.Owner);
 		}
 
 		// We return init.Self.Owner if there's no effective owner

--- a/OpenRA.Mods.Common/Traits/AppearsOnMapPreview.cs
+++ b/OpenRA.Mods.Common/Traits/AppearsOnMapPreview.cs
@@ -42,14 +42,14 @@ namespace OpenRA.Mods.Common.Traits
 			}
 			else
 			{
-				var owner = map.PlayerDefinitions.Where(p => s.InitDict.Get<OwnerInit>().PlayerName == p.Value.Nodes.First(k => k.Key == "Name").Value.Value).First();
+				var owner = map.PlayerDefinitions.Single(p => s.InitDict.Get<OwnerInit>().InternalName == p.Value.Nodes.Last(k => k.Key == "Name").Value.Value);
 				var colorValue = owner.Value.Nodes.Where(n => n.Key == "Color");
 				var ownerColor = colorValue.Any() ? colorValue.First().Value.Value : "FFFFFF";
 				Color.TryParse(ownerColor, out color);
 			}
 
 			var ios = ai.TraitInfo<IOccupySpaceInfo>();
-			var cells = ios.OccupiedCells(ai, s.InitDict.Get<LocationInit>().Value(null));
+			var cells = ios.OccupiedCells(ai, s.InitDict.Get<LocationInit>().Value);
 			foreach (var cell in cells)
 				destinationBuffer.Add(new Pair<MPos, Color>(cell.Key.ToMPos(map), color));
 		}

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Common.Traits
 				actor =>
 				{
 					var init = actor.Init<StanceInit>();
-					var stance = init != null ? init.Value(world) : InitialStance;
+					var stance = init != null ? init.Value : InitialStance;
 					return stances[(int)stance];
 				},
 				(actor, value) => actor.ReplaceInit(new StanceInit((UnitStance)stances.IndexOf(value))));
@@ -183,10 +183,7 @@ namespace OpenRA.Mods.Common.Traits
 			var self = init.Self;
 			ActiveAttackBases = self.TraitsImplementing<AttackBase>().ToArray().Where(Exts.IsTraitEnabled);
 
-			if (init.Contains<StanceInit>())
-				stance = init.Get<StanceInit, UnitStance>();
-			else
-				stance = self.Owner.IsBot || !self.Owner.Playable ? info.InitialStanceAI : info.InitialStance;
+			stance = init.GetValue<StanceInit, UnitStance>(info, self.Owner.IsBot || !self.Owner.Playable ? info.InitialStanceAI : info.InitialStance);
 
 			PredictedStance = stance;
 
@@ -455,6 +452,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		public StanceInit() { }
 		public StanceInit(UnitStance init) { value = init; }
-		public UnitStance Value(World world) { return value; }
+		public UnitStance Value { get { return value; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/BodyOrientation.cs
+++ b/OpenRA.Mods.Common/Traits/BodyOrientation.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.info = info;
 			var self = init.Self;
-			var faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : self.Owner.Faction.InternalName;
+			var faction = init.GetValue<FactionInit, string>(info, self.Owner.Faction.InternalName);
 
 			quantizedFacings = Exts.Lazy(() =>
 			{

--- a/OpenRA.Mods.Common/Traits/Buildings/ActorPreviewPlaceBuildingPreview.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ActorPreviewPlaceBuildingPreview.cs
@@ -68,8 +68,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (!string.IsNullOrEmpty(info.OverridePalette))
 			{
-				var owner = init.Get<OwnerInit>().Value(wr.World);
-				palette = wr.Palette(info.OverridePaletteIsPlayerPalette ? info.OverridePalette + owner.InternalName : info.OverridePalette);
+				var ownerName = init.Get<OwnerInit>().InternalName;
+				palette = wr.Palette(info.OverridePaletteIsPlayerPalette ? info.OverridePalette + ownerName : info.OverridePalette);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -278,7 +278,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Building(ActorInitializer init, BuildingInfo info)
 		{
 			self = init.Self;
-			topLeft = init.Get<LocationInit, CPos>();
+			topLeft = init.GetValue<LocationInit, CPos>(info);
 			Info = info;
 			influence = self.World.WorldActor.Trait<BuildingInfluence>();
 

--- a/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -43,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					var init = actor.Init<FreeActorInit>();
 					if (init != null)
-						return init.Value(world);
+						return init.Value;
 
 					return true;
 				},
@@ -63,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 		public FreeActor(ActorInitializer init, FreeActorInfo info)
 			: base(info)
 		{
-			allowSpawn = !init.Contains<FreeActorInit>() || init.Get<FreeActorInit>().ActorValue;
+			allowSpawn = init.GetValue<FreeActorInit, bool>(info, true);
 		}
 
 		protected override void TraitEnabled(Actor self)
@@ -92,13 +93,14 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool ActorValue = true;
 		public FreeActorInit() { }
 		public FreeActorInit(bool init) { ActorValue = init; }
-		public bool Value(World world) { return ActorValue; }
+		public bool Value { get { return ActorValue; } }
 	}
 
-	public class ParentActorInit : IActorInit<Actor>
+	public class ParentActorInit : IActorInit
 	{
-		public readonly Actor ActorValue;
-		public ParentActorInit(Actor parent) { ActorValue = parent; }
-		public Actor Value(World world) { return ActorValue; }
+		readonly Actor value;
+		public ParentActorInit(Actor init) { value = init; }
+
+		public Lazy<Actor> Value(World world) { return new Lazy<Actor>(() => value); }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Buildings/LegacyBridgeHut.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/LegacyBridgeHut.cs
@@ -20,22 +20,26 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public bool IsValidTarget(ActorInfo actorInfo, Actor saboteur) { return false; } // TODO: bridges don't support frozen under fog
 
-		public override object Create(ActorInitializer init) { return new LegacyBridgeHut(init); }
+		public override object Create(ActorInitializer init) { return new LegacyBridgeHut(init, this); }
 	}
 
 	class LegacyBridgeHut : IDemolishable
 	{
-		public readonly Bridge FirstBridge;
-		public readonly Bridge Bridge;
+		public Bridge FirstBridge { get; private set; }
+		public Bridge Bridge { get; private set; }
 		public DamageState BridgeDamageState { get { return Bridge.AggregateDamageState(); } }
 		public bool Repairing { get { return repairDirections > 0; } }
 		int repairDirections = 0;
 
-		public LegacyBridgeHut(ActorInitializer init)
+		public LegacyBridgeHut(ActorInitializer init, LegacyBridgeHutInfo info)
 		{
-			Bridge = init.Get<ParentActorInit>().ActorValue.Trait<Bridge>();
-			Bridge.AddHut(this);
-			FirstBridge = Bridge.Enumerate(0, true).Last();
+			var bridge = init.GetOrDefault<ParentActorInit>(info);
+			init.World.AddFrameEndTask(_ =>
+			{
+				Bridge = bridge.Value(init.World).Value.Trait<Bridge>();
+				Bridge.AddHut(this);
+				FirstBridge = Bridge.Enumerate(0, true).Last();
+			});
 		}
 
 		public void Repair(Actor repairer)

--- a/OpenRA.Mods.Common/Traits/Buildings/LineBuild.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/LineBuild.cs
@@ -23,10 +23,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public LineBuildDirectionInit() { }
 		public LineBuildDirectionInit(LineBuildDirection init) { value = init; }
-		public LineBuildDirection Value(World world) { return value; }
+		public LineBuildDirection Value { get { return value; } }
 	}
 
-	public class LineBuildParentInit : IActorInit<Actor[]>
+	public class LineBuildParentInit : IActorInit<string[]>
 	{
 		[FieldFromYamlKey]
 		public readonly string[] ParentNames = new string[0];
@@ -35,7 +35,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public LineBuildParentInit() { }
 		public LineBuildParentInit(Actor[] init) { parents = init; }
-		public Actor[] Value(World world)
+		public string[] Value { get { return ParentNames; } }
+		public Actor[] ActorValue(World world)
 		{
 			if (parents != null)
 				return parents;
@@ -79,8 +80,9 @@ namespace OpenRA.Mods.Common.Traits
 		public LineBuild(ActorInitializer init, LineBuildInfo info)
 		{
 			this.info = info;
-			if (init.Contains<LineBuildParentInit>())
-				parentNodes = init.Get<LineBuildParentInit>().Value(init.World);
+			var lineBuildParentInit = init.GetOrDefault<LineBuildParentInit>(info);
+			if (lineBuildParentInit != null)
+				parentNodes = lineBuildParentInit.ActorValue(init.World);
 		}
 
 		void INotifyLineBuildSegmentsChanged.SegmentAdded(Actor self, Actor segment)

--- a/OpenRA.Mods.Common/Traits/Buildings/SequencePlaceBuildingPreview.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/SequencePlaceBuildingPreview.cs
@@ -61,15 +61,15 @@ namespace OpenRA.Mods.Common.Traits
 			: base(wr, ai, info, init)
 		{
 			this.info = info;
-			var owner = init.Get<OwnerInit>().Value(wr.World);
-			var faction = init.Get<FactionInit>().Value(wr.World);
+			var ownerName = init.Get<OwnerInit>().InternalName;
+			var faction = init.Get<FactionInit>().Value;
 
 			var rsi = ai.TraitInfo<RenderSpritesInfo>();
 
 			if (!string.IsNullOrEmpty(info.SequencePalette))
-				palette = wr.Palette(info.SequencePaletteIsPlayerPalette ? info.SequencePalette + owner.InternalName : info.SequencePalette);
+				palette = wr.Palette(info.SequencePaletteIsPlayerPalette ? info.SequencePalette + ownerName : info.SequencePalette);
 			else
-				palette = wr.Palette(rsi.Palette ?? rsi.PlayerPalette + owner.InternalName);
+				palette = wr.Palette(rsi.Palette ?? rsi.PlayerPalette + ownerName);
 
 			preview = new Animation(wr.World, rsi.GetImage(ai, wr.World.Map.Rules.Sequences, faction));
 			preview.PlayRepeating(info.Sequence);

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -129,14 +129,16 @@ namespace OpenRA.Mods.Common.Traits
 				return Util.AdjacentCells(self.World, Target.FromActor(self)).Where(c => loc != c);
 			});
 
-			if (init.Contains<RuntimeCargoInit>())
+			var runtimeCargoInit = init.GetOrDefault<RuntimeCargoInit>(info);
+			var cargoInit = init.GetOrDefault<CargoInit>(info);
+			if (runtimeCargoInit != null)
 			{
-				cargo = new List<Actor>(init.Get<RuntimeCargoInit, Actor[]>());
+				cargo = runtimeCargoInit.Value.ToList();
 				totalWeight = cargo.Sum(c => GetWeight(c));
 			}
-			else if (init.Contains<CargoInit>())
+			else if (cargoInit != null)
 			{
-				foreach (var u in init.Get<CargoInit, string[]>())
+				foreach (var u in cargoInit.Value)
 				{
 					var unit = self.World.CreateActor(false, u.ToLowerInvariant(),
 						new TypeDictionary { new OwnerInit(self.Owner) });
@@ -487,7 +489,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Actor[] value = { };
 		public RuntimeCargoInit() { }
 		public RuntimeCargoInit(Actor[] init) { value = init; }
-		public Actor[] Value(World world) { return value; }
+		public Actor[] Value { get { return value; } }
 	}
 
 	public class CargoInit : IActorInit<string[]>
@@ -496,6 +498,6 @@ namespace OpenRA.Mods.Common.Traits
 		readonly string[] value = { };
 		public CargoInit() { }
 		public CargoInit(string[] init) { value = init; }
-		public string[] Value(World world) { return value; }
+		public string[] Value { get { return value; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					var init = actor.Init<DeployStateInit>();
 					if (init != null)
-						return init.Value(world) == DeployState.Deployed;
+						return init.Value == DeployState.Deployed;
 
 					return false;
 				},
@@ -111,8 +111,7 @@ namespace OpenRA.Mods.Common.Traits
 			checkTerrainType = info.AllowedTerrainTypes.Count > 0;
 			canTurn = self.Info.HasTraitInfo<IFacingInfo>();
 			move = self.TraitOrDefault<IMove>();
-			if (init.Contains<DeployStateInit>())
-				deployState = init.Get<DeployStateInit, DeployState>();
+			deployState = init.GetValue<DeployStateInit, DeployState>(info, DeployState.Undeployed);
 		}
 
 		protected override void Created(Actor self)
@@ -352,6 +351,6 @@ namespace OpenRA.Mods.Common.Traits
 		readonly DeployState value = DeployState.Deployed;
 		public DeployStateInit() { }
 		public DeployStateInit(DeployState init) { value = init; }
-		public DeployState Value(World world) { return value; }
+		public DeployState Value { get { return value; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnFaction.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnFaction.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 		public GrantConditionOnFaction(ActorInitializer init, GrantConditionOnFactionInfo info)
 			: base(info)
 		{
-			faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
+			faction = init.GetValue<FactionInit, string>(info, init.Self.Owner.Faction.InternalName);
 		}
 
 		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLineBuildDirection.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLineBuildDirection.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 		public GrantConditionOnLineBuildDirection(ActorInitializer init, GrantConditionOnLineBuildDirectionInfo info)
 		{
 			this.info = info;
-			direction = init.Get<LineBuildDirectionInit>().Value(init.World);
+			direction = init.GetValue<LineBuildDirectionInit, LineBuildDirection>(info);
 		}
 
 		void INotifyCreated.Created(Actor self)

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -93,8 +93,9 @@ namespace OpenRA.Mods.Common.Traits
 			self = init.Self;
 			this.info = info;
 
-			if (init.Contains<LocationInit>())
-				SetPosition(self, init.Get<LocationInit, CPos>());
+			var locationInit = init.GetOrDefault<LocationInit>(info);
+			if (locationInit != null)
+				SetPosition(self, locationInit.Value);
 		}
 
 		void INotifyCreated.Created(Actor self)

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -74,9 +74,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 
 			MaxLevel = info.Conditions.Count;
-
-			if (init.Contains<ExperienceInit>())
-				initialExperience = init.Get<ExperienceInit, int>();
+			initialExperience = init.GetValue<ExperienceInit, int>(info, 0);
 		}
 
 		void INotifyCreated.Created(Actor self)
@@ -154,6 +152,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		public ExperienceInit() { }
 		public ExperienceInit(int init) { value = init; }
-		public int Value(World world) { return value; }
+		public int Value { get { return value; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 				actor =>
 				{
 					var init = actor.Init<HealthInit>();
-					return init != null ? init.Value(world) : 100;
+					return init != null ? init.Value : 100;
 				},
 				(actor, value) => actor.ReplaceInit(new HealthInit((int)value)));
 		}
@@ -68,10 +68,12 @@ namespace OpenRA.Mods.Common.Traits
 		public Health(ActorInitializer init, HealthInfo info)
 		{
 			Info = info;
-			MaxHP = info.HP > 0 ? info.HP : 1;
+			MaxHP = hp = info.HP > 0 ? info.HP : 1;
 
 			// Cast to long to avoid overflow when multiplying by the health
-			hp = init.Contains<HealthInit>() ? (int)(init.Get<HealthInit, int>() * (long)MaxHP / 100) : MaxHP;
+			var healthInit = init.GetOrDefault<HealthInit>(info);
+			if (healthInit != null)
+				hp = (int)(healthInit.Value * (long)MaxHP / 100);
 
 			DisplayHP = hp;
 		}
@@ -247,12 +249,15 @@ namespace OpenRA.Mods.Common.Traits
 			value = init;
 		}
 
-		public int Value(World world)
+		public int Value
 		{
-			if (value < 0 || (value == 0 && !allowZero))
-				return 1;
+			get
+			{
+				if (value < 0 || (value == 0 && !allowZero))
+					return 1;
 
-			return value;
+				return value;
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -78,14 +78,14 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 			self = init.Self;
 
-			TopLeft = init.Get<LocationInit, CPos>();
-			CenterPosition = init.Contains<CenterPositionInit>() ? init.Get<CenterPositionInit, WPos>() : init.World.Map.CenterOfCell(TopLeft);
-			Facing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : 128;
+			TopLeft = init.GetValue<LocationInit, CPos>(info);
+			CenterPosition = init.GetValue<CenterPositionInit, WPos>(info, init.World.Map.CenterOfCell(TopLeft));
+			Facing = init.GetValue<FacingInit, int>(info, 128);
 
-			dragSpeed = init.Contains<HuskSpeedInit>() ? init.Get<HuskSpeedInit, int>() : 0;
+			dragSpeed = init.GetValue<HuskSpeedInit, int>(info, 0);
 			finalPosition = init.World.Map.CenterOfCell(TopLeft);
 
-			effectiveOwner = init.Contains<EffectiveOwnerInit>() ? init.Get<EffectiveOwnerInit, Player>() : self.Owner;
+			effectiveOwner = init.GetValue<EffectiveOwnerInit, Player>(info, self.Owner);
 		}
 
 		void INotifyCreated.Created(Actor self)
@@ -178,6 +178,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		public HuskSpeedInit() { }
 		public HuskSpeedInit(int init) { value = init; }
-		public int Value(World world) { return value; }
+		public int Value { get { return value; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Immobile.cs
+++ b/OpenRA.Mods.Common/Traits/Immobile.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Immobile(ActorInitializer init, ImmobileInfo info)
 		{
-			location = init.Get<LocationInit, CPos>();
+			location = init.GetValue<LocationInit, CPos>(info);
 			position = init.World.Map.CenterOfCell(location);
 
 			if (info.OccupiesSpace)

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Explore map-placed actors if the "Explore Map" option is enabled
 			var shroudInfo = init.World.Map.Rules.Actors["player"].TraitInfo<ShroudInfo>();
 			var exploredMap = init.World.LobbyInfo.GlobalSettings.OptionOrDefault("explored", shroudInfo.ExploredMapCheckboxEnabled);
-			startsRevealed = exploredMap && init.Contains<SpawnedByMapInit>() && !init.Contains<HiddenUnderFogInit>();
+			startsRevealed = exploredMap && init.Contains<SpawnedByMapInit>(info) && !init.Contains<HiddenUnderFogInit>(info);
 			var buildingInfo = init.Self.Info.TraitInfoOrDefault<BuildingInfo>();
 			var footprintCells = buildingInfo != null ? buildingInfo.FrozenUnderFogTiles(init.Self.Location).ToList() : new List<CPos>() { init.Self.Location };
 			footprint = footprintCells.SelectMany(c => map.ProjectedCellsCovering(c.ToMPos(map))).ToArray();

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -131,7 +131,7 @@ namespace OpenRA.Mods.Common.Traits
 			self = init.Self;
 			Info = info;
 
-			Faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : self.Owner.Faction.InternalName;
+			Faction = init.GetValue<FactionInit, string>(info, self.Owner.Faction.InternalName);
 			IsValidFaction = !info.Factions.Any() || info.Factions.Contains(Faction);
 			Enabled = IsValidFaction;
 

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (string.IsNullOrEmpty(prerequisite))
 				prerequisite = init.Self.Info.Name;
 
-			faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
+			faction = init.GetValue<FactionInit, string>(info, init.Self.Owner.Faction.InternalName);
 		}
 
 		public IEnumerable<string> ProvidesPrerequisites

--- a/OpenRA.Mods.Common/Traits/Pluggable.cs
+++ b/OpenRA.Mods.Common/Traits/Pluggable.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			Info = info;
 
-			var plugInit = init.Contains<PlugsInit>() ? init.Get<PlugsInit, Dictionary<CVec, string>>() : new Dictionary<CVec, string>();
+			var plugInit = init.GetValue<PlugsInit, Dictionary<CVec, string>>(info, new Dictionary<CVec, string>());
 			if (plugInit.ContainsKey(Info.Offset))
 				initialPlug = plugInit[Info.Offset];
 
@@ -126,6 +126,6 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Dictionary<CVec, string> value = new Dictionary<CVec, string>();
 		public PlugsInit() { }
 		public PlugsInit(Dictionary<CVec, string> init) { value = init; }
-		public Dictionary<CVec, string> Value(World world) { return value; }
+		public Dictionary<CVec, string> Value { get { return value; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 			: base(info)
 		{
 			rp = Exts.Lazy(() => init.Self.IsDead ? null : init.Self.TraitOrDefault<RallyPoint>());
-			Faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
+			Faction = init.GetValue<FactionInit, string>(info, init.Self.Owner.Faction.InternalName);
 		}
 
 		public virtual void DoProduction(Actor self, ActorInfo producee, ExitInfo exitinfo, string productionType, TypeDictionary inits)

--- a/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using OpenRA.Primitives;
+using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
@@ -30,8 +31,10 @@ namespace OpenRA.Mods.Common.Traits
 			: base(init, info)
 		{
 			domainIndex = init.Self.World.WorldActor.Trait<DomainIndex>();
-			if (init.Contains<ProductionSpawnLocationInit>())
-				spawnLocation = init.Get<ProductionSpawnLocationInit, CPos>();
+
+			var spawnLocationInit = init.GetOrDefault<ProductionSpawnLocationInit>(info);
+			if (spawnLocationInit != null)
+				spawnLocation = spawnLocationInit.Value;
 		}
 
 		protected override void Created(Actor self)
@@ -114,6 +117,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		public ProductionSpawnLocationInit() { }
 		public ProductionSpawnLocationInit(CPos init) { value = init; }
-		public CPos Value(World world) { return value; }
+		public CPos Value { get { return value; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -49,8 +49,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init)
 		{
 			var sequenceProvider = init.World.Map.Rules.Sequences;
-			var faction = init.Get<FactionInit, string>();
-			var ownerName = init.Get<OwnerInit>().PlayerName;
+			var faction = init.GetValue<FactionInit, string>(this);
+			var ownerName = init.Get<OwnerInit>(this).InternalName;
 			var image = GetImage(init.Actor, sequenceProvider, faction);
 			var palette = init.WorldRenderer.Palette(Palette ?? PlayerPalette + ownerName);
 
@@ -169,7 +169,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public RenderSprites(ActorInitializer init, RenderSpritesInfo info)
 		{
 			Info = info;
-			faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
+			faction = init.GetValue<FactionInit, string>(info, init.Self.Owner.Faction.InternalName);
 		}
 
 		public string GetImage(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
@@ -57,8 +57,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public virtual IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init)
 		{
 			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
-			var faction = init.Get<FactionInit, string>();
-			var ownerName = init.Get<OwnerInit>().PlayerName;
+			var faction = init.GetValue<FactionInit, string>(this);
+			var ownerName = init.Get<OwnerInit>(this).InternalName;
 			var sequenceProvider = init.World.Map.Rules.Sequences;
 			var image = Image ?? init.Actor.Name;
 			var facings = body.QuantizedFacings == -1 ?

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -49,14 +49,15 @@ namespace OpenRA.Mods.Common.Traits.Render
 				p = init.WorldRenderer.Palette(Palette);
 
 			Func<WAngle> facing;
-			if (init.Contains<DynamicFacingInit>())
+			var dynamicfacingInit = init.GetOrDefault<DynamicFacingInit>(this);
+			if (dynamicfacingInit != null)
 			{
-				var getFacing = init.Get<DynamicFacingInit, Func<int>>();
+				var getFacing = dynamicfacingInit.Value;
 				facing = () => WAngle.FromFacing(getFacing());
 			}
 			else
 			{
-				var f = WAngle.FromFacing(init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : 0);
+				var f = WAngle.FromFacing(init.GetValue<FacingInit, int>(this, 0));
 				facing = () => f;
 			}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			this.info = info;
 			var self = init.Self;
 			wsbs = self.TraitsImplementing<WithSpriteBody>().Where(w => info.BodyNames.Contains(w.Info.Name)).ToArray();
-			skipMakeAnimation = init.Contains<SkipMakeAnimsInit>();
+			skipMakeAnimation = init.Contains<SkipMakeAnimsInit>(info);
 		}
 
 		void INotifyCreated.Created(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
@@ -78,11 +78,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 				p = init.WorldRenderer.Palette(Palette);
 
 			Func<int> facing;
-			if (init.Contains<DynamicFacingInit>())
-				facing = init.Get<DynamicFacingInit, Func<int>>();
+			var dynamicfacingInit = init.GetOrDefault<DynamicFacingInit>(this);
+			if (dynamicfacingInit != null)
+				facing = dynamicfacingInit.Value;
 			else
 			{
-				var f = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : 0;
+				var f = init.GetValue<FacingInit, int>(this, 0);
 				facing = () => f;
 			}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var t = init.Actor.TraitInfos<TurretedInfo>()
 				.First(tt => tt.Turret == armament.Turret);
 
-			var turretFacing = Turreted.TurretFacingFromInit(init, t.InitialFacing, armament.Turret);
+			var turretFacing = Turreted.TurretFacingFromInit(init, t);
 			var anim = new Animation(init.World, image, () => WAngle.FromFacing(turretFacing()));
 			anim.Play(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence));
 

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var t = init.Actor.TraitInfos<TurretedInfo>()
 				.First(tt => tt.Turret == Turret);
 
-			var turretFacing = Turreted.TurretFacingFromInit(init, t.InitialFacing, Turret);
+			var turretFacing = Turreted.TurretFacingFromInit(init, t);
 			var anim = new Animation(init.World, image, () => WAngle.FromFacing(turretFacing()));
 			anim.Play(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence));
 
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			};
 
 			if (IsPlayerPalette)
-				p = init.WorldRenderer.Palette(Palette + init.Get<OwnerInit>().PlayerName);
+				p = init.WorldRenderer.Palette(Palette + init.Get<OwnerInit>(this).InternalName);
 			else if (Palette != null)
 				p = init.WorldRenderer.Palette(Palette);
 

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			var model = init.World.ModelCache.GetModelSequence(image, Sequence);
 
-			var turretFacing = Turreted.TurretFacingFromInit(init, t.InitialFacing, t.Turret);
+			var turretFacing = Turreted.TurretFacingFromInit(init, t);
 			Func<WRot> turretOrientation = () => body.QuantizeOrientation(WRot.FromYaw(WAngle.FromFacing(turretFacing()) - orientation().Yaw), facings);
 
 			Func<WRot> quantizedTurret = () => body.QuantizeOrientation(turretOrientation(), facings);

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var model = init.World.ModelCache.GetModelSequence(image, Sequence);
 			Func<WVec> turretOffset = () => body.LocalToWorld(t.Offset.Rotate(orientation()));
 
-			var turretFacing = Turreted.TurretFacingFromInit(init, t.InitialFacing, Turret);
+			var turretFacing = Turreted.TurretFacingFromInit(init, t);
 			Func<WRot> turretBodyOrientation = () => WRot.FromYaw(WAngle.FromFacing(turretFacing()) - orientation().Yaw);
 			yield return new ModelAnimation(model, turretOffset,
 				() => new[] { turretBodyOrientation(), body.QuantizeOrientation(orientation(), facings) }, () => false, () => 0, ShowShadow);

--- a/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
@@ -37,15 +37,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 				yield break;
 
 			var adjacent = 0;
+			var locationInit = init.GetOrDefault<LocationInit>(this);
+			var neighbourInit = init.GetOrDefault<RuntimeNeighbourInit>(this);
 
-			if (init.Contains<RuntimeNeighbourInit>())
+			if (locationInit != null && neighbourInit != null)
 			{
-				var location = CPos.Zero;
-				if (init.Contains<LocationInit>())
-					location = init.Get<LocationInit, CPos>();
-
-				var neighbours = init.Get<RuntimeNeighbourInit, Dictionary<CPos, string[]>>();
-				foreach (var kv in neighbours)
+				var location = locationInit.Value;
+				foreach (var kv in neighbourInit.Value)
 				{
 					var haveNeighbour = false;
 					foreach (var n in kv.Value)
@@ -177,6 +175,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public RuntimeNeighbourInit() { }
 		public RuntimeNeighbourInit(Dictionary<CPos, string[]> init) { value = init; }
-		public Dictionary<CPos, string[]> Value(World world) { return value; }
+		public Dictionary<CPos, string[]> Value { get { return value; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/ScriptTags.cs
+++ b/OpenRA.Mods.Common/Traits/ScriptTags.cs
@@ -26,8 +26,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public ScriptTags(ActorInitializer init, ScriptTagsInfo info)
 		{
-			if (init.Contains<ScriptTagsInit>())
-				foreach (var tag in init.Get<ScriptTagsInit, string[]>())
+			var scriptTagsInit = init.GetOrDefault<ScriptTagsInit>(info);
+			if (scriptTagsInit != null)
+				foreach (var tag in scriptTagsInit.Value)
 					tags.Add(tag);
 		}
 
@@ -55,6 +56,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		public ScriptTagsInit() { }
 		public ScriptTagsInit(string[] init) { value = init; }
-		public string[] Value(World world) { return value; }
+		public string[] Value { get { return value; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits
 			: base(info)
 		{
 			enabled = !info.RequiresLobbyCreeps || init.Self.World.WorldActor.Trait<MapCreeps>().Enabled;
-			faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
+			faction = init.GetValue<FactionInit, string>(info, init.Self.Owner.Faction.InternalName);
 		}
 
 		void INotifyKilled.Killed(Actor self, AttackInfo e)

--- a/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 		public ProduceActorPower(ActorInitializer init, ProduceActorPowerInfo info)
 			: base(init.Self, info)
 		{
-			faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
+			faction = init.GetValue<FactionInit, string>(info, init.Self.Owner.Faction.InternalName);
 		}
 
 		public override void SelectTarget(Actor self, string order, SupportPowerManager manager)

--- a/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
@@ -65,9 +65,9 @@ namespace OpenRA.Mods.Common.Traits
 			var body = self.Trait<BodyOrientation>();
 
 			// TODO: Carry orientation over from the parent instead of just facing
-			var bodyFacing = init.Contains<DynamicFacingInit>() ? init.Get<DynamicFacingInit, Func<int>>()()
-				: init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : 0;
-			facing = WAngle.FromFacing(Turreted.TurretFacingFromInit(init, 0)());
+			var dynamicFacingInit = init.GetOrDefault<DynamicFacingInit>(info);
+			var bodyFacing = dynamicFacingInit != null ? dynamicFacingInit.Value() : init.GetValue<FacingInit, int>(info, 0);
+			facing = WAngle.FromFacing(Turreted.TurretFacingFromInit(init, info, 0)());
 
 			// Calculate final position
 			var throwRotation = WRot.FromFacing(Game.CosmeticRandom.Next(1024));

--- a/OpenRA.Mods.Common/Traits/TransformCrusherOnCrush.cs
+++ b/OpenRA.Mods.Common/Traits/TransformCrusherOnCrush.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 		public TransformCrusherOnCrush(ActorInitializer init, TransformCrusherOnCrushInfo info)
 		{
 			this.info = info;
-			faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
+			faction = init.GetValue<FactionInit, string>(info, init.Self.Owner.Faction.InternalName);
 		}
 
 		void INotifyCrushed.WarnCrush(Actor self, Actor crusher, BitSet<CrushClass> crushClasses) { }

--- a/OpenRA.Mods.Common/Traits/TransformOnCapture.cs
+++ b/OpenRA.Mods.Common/Traits/TransformOnCapture.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 		public TransformOnCapture(ActorInitializer init, TransformOnCaptureInfo info)
 		{
 			this.info = info;
-			faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
+			faction = init.GetValue<FactionInit, string>(info, init.Self.Owner.Faction.InternalName);
 		}
 
 		void INotifyCapture.OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner, BitSet<CaptureType> captureTypes)

--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 			self = init.Self;
 			actorInfo = self.World.Map.Rules.Actors[info.IntoActor];
 			buildingInfo = actorInfo.TraitInfoOrDefault<BuildingInfo>();
-			faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : self.Owner.Faction.InternalName;
+			faction = init.GetValue<FactionInit, string>(info, self.Owner.Faction.InternalName);
 		}
 
 		public string VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -118,8 +118,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public EditorActorPreview Add(string id, ActorReference reference, bool initialSetup = false)
 		{
-			var owner = Players.Players[reference.InitDict.Get<OwnerInit>().PlayerName];
-
+			var owner = Players.Players[reference.InitDict.Get<OwnerInit>().InternalName];
 			var preview = new EditorActorPreview(worldRenderer, id, reference, owner);
 
 			Add(preview, initialSetup);

--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -67,11 +67,11 @@ namespace OpenRA.Mods.Common.Traits
 
 			CenterPosition = PreviewPosition(world, actor.InitDict);
 
-			var location = actor.InitDict.Get<LocationInit>().Value(worldRenderer.World);
+			var location = actor.InitDict.Get<LocationInit>().Value;
 			var ios = Info.TraitInfoOrDefault<IOccupySpaceInfo>();
 
 			var subCellInit = actor.InitDict.GetOrDefault<SubCellInit>();
-			var subCell = subCellInit != null ? subCellInit.Value(worldRenderer.World) : SubCell.Any;
+			var subCell = subCellInit != null ? subCellInit.Value : SubCell.Any;
 
 			if (ios != null)
 				Footprint = ios.OccupiedCells(Info, location, subCell);
@@ -152,7 +152,7 @@ namespace OpenRA.Mods.Common.Traits
 			Func<object, bool> saveInit = init =>
 			{
 				var factionInit = init as FactionInit;
-				if (factionInit != null && factionInit.Faction == Owner.Faction)
+				if (factionInit != null && factionInit.Value == Owner.Faction)
 					return false;
 
 				// TODO: Other default values will need to be filtered
@@ -166,15 +166,15 @@ namespace OpenRA.Mods.Common.Traits
 		WPos PreviewPosition(World world, TypeDictionary init)
 		{
 			if (init.Contains<CenterPositionInit>())
-				return init.Get<CenterPositionInit>().Value(world);
+				return init.Get<CenterPositionInit>().Value;
 
 			if (init.Contains<LocationInit>())
 			{
-				var cell = init.Get<LocationInit>().Value(world);
+				var cell = init.Get<LocationInit>().Value;
 				var offset = WVec.Zero;
 
 				var subCellInit = Actor.InitDict.GetOrDefault<SubCellInit>();
-				var subCell = subCellInit != null ? subCellInit.Value(worldRenderer.World) : SubCell.Any;
+				var subCell = subCellInit != null ? subCellInit.Value : SubCell.Any;
 
 				var buildingInfo = Info.TraitInfoOrDefault<BuildingInfo>();
 				if (buildingInfo != null)

--- a/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 				var actorReference = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
 
 				// If there is no real player associated, don't spawn it.
-				var ownerName = actorReference.InitDict.Get<OwnerInit>().PlayerName;
+				var ownerName = actorReference.InitDict.Get<OwnerInit>().InternalName;
 				if (!world.Players.Any(p => p.InternalName == ownerName))
 					continue;
 
@@ -68,9 +68,6 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Name;
 		public SpawnedByMapInit(string name) { Name = name; }
 
-		public string Value(World world)
-		{
-			return Name;
-		}
+		public string Value { get { return Name; } }
 	}
 }

--- a/OpenRA.Mods.Common/UtilityCommands/ResizeMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ResizeMapCommand.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			foreach (var kv in map.ActorDefinitions)
 			{
 				var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
-				var location = actor.InitDict.Get<LocationInit>().Value(null);
+				var location = actor.InitDict.Get<LocationInit>().Value;
 				if (!map.Contains(location))
 				{
 					Console.WriteLine("Removing actor {0} located at {1} due being outside of the new map boundaries.".F(actor.Type, location));

--- a/OpenRA.Mods.D2k/Traits/Render/WithCrumbleOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithCrumbleOverlay.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.D2k.Traits.Render
 		{
 			this.info = info;
 
-			if (init.Contains<SkipMakeAnimsInit>())
+			if (init.Contains<SkipMakeAnimsInit>(info))
 				return;
 
 			renderSprites = init.Self.Trait<RenderSprites>();


### PR DESCRIPTION
This PR implements the first half of my ActorInit rework. The main goals here are:

* Replace the inefficient and verbose `Contains<> ? Get<> : default` pattern with a `GetValue<>` method that can that can be given a fallback.
* Remove unnecessary `World` argument when resolving most init values
* Prepare for #18118 by passing the traitinfo to the init lookup and changing a few other details. If something in this PR looks odd/unjustified it is worth checking [the full implementation](https://github.com/OpenRA/OpenRA/compare/bleed...pchote:init-rework) for context. 