### PR TITLE
Misc PPos/MPos changes

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -233,7 +233,7 @@ namespace OpenRA
 		public CellLayer<byte> Ramp { get; private set; }
 		public CellLayer<byte> CustomTerrain { get; private set; }
 
-		public ProjectedCellRegion ProjectedCellBounds { get; private set; }
+		public PPos[] ProjectedCells { get; private set; }
 		public CellRegion AllCells { get; private set; }
 		public List<CPos> AllEdgeCells { get; private set; }
 
@@ -797,6 +797,7 @@ namespace OpenRA
 			foreach (var puv in projectedCells)
 				if (!Contains(puv))
 					return false;
+
 			return true;
 		}
 
@@ -992,7 +993,8 @@ namespace OpenRA
 				ProjectedBottomRight = new WPos(br.U * 1024 - 1, (br.V + 1) * 1024 - 1, 0);
 			}
 
-			ProjectedCellBounds = new ProjectedCellRegion(this, tl, br);
+			// PERF: This enumeration isn't going to change during the game
+			ProjectedCells = new ProjectedCellRegion(this, tl, br).ToArray();
 		}
 
 		public void FixOpenAreas()

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -785,8 +785,9 @@ namespace OpenRA
 
 		bool ContainsAllProjectedCellsCovering(MPos uv)
 		{
+			// PERF: Checking the bounds directly here is the same as calling Contains((PPos)uv) but saves an allocation
 			if (Grid.MaximumTerrainHeight == 0)
-				return Contains((PPos)uv);
+				return Bounds.Contains(uv.U, uv.V);
 
 			// If the cell has no valid projection, then we're off the map.
 			var projectedCells = ProjectedCellsCovering(uv);

--- a/OpenRA.Game/Traits/Player/Shroud.cs
+++ b/OpenRA.Game/Traits/Player/Shroud.cs
@@ -162,7 +162,7 @@ namespace OpenRA.Traits
 			if (OnShroudChanged == null)
 				return;
 
-			foreach (var puv in map.ProjectedCellBounds)
+			foreach (var puv in map.ProjectedCells)
 			{
 				if (!touched[puv])
 					continue;
@@ -298,7 +298,7 @@ namespace OpenRA.Traits
 			if (map.Bounds != s.map.Bounds)
 				throw new ArgumentException("The map bounds of these shrouds do not match.", "s");
 
-			foreach (var puv in map.ProjectedCellBounds)
+			foreach (var puv in map.ProjectedCells)
 			{
 				if (!explored[puv] && s.explored[puv])
 				{
@@ -310,7 +310,7 @@ namespace OpenRA.Traits
 
 		public void ExploreAll()
 		{
-			foreach (var puv in map.ProjectedCellBounds)
+			foreach (var puv in map.ProjectedCells)
 			{
 				if (!explored[puv])
 				{
@@ -322,7 +322,7 @@ namespace OpenRA.Traits
 
 		public void ResetExploration()
 		{
-			foreach (var puv in map.ProjectedCellBounds)
+			foreach (var puv in map.ProjectedCells)
 			{
 				touched[puv] = true;
 				explored[puv] = (visibleCount[puv] + passiveVisibleCount[puv]) > 0;

--- a/OpenRA.Mods.Common/Traits/RevealsMap.cs
+++ b/OpenRA.Mods.Common/Traits/RevealsMap.cs
@@ -49,8 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected PPos[] ProjectedCells(Actor self)
 		{
-			var map = self.World.Map;
-			return map.ProjectedCellBounds.ToArray();
+			return self.World.Map.ProjectedCells;
 		}
 
 		void INotifyActorDisposing.Disposing(Actor self)

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -271,7 +271,7 @@ namespace OpenRA.Mods.Common.Traits
 			UpdateShroud(new ProjectedCellRegion(map, tl, br));
 		}
 
-		void UpdateShroud(ProjectedCellRegion region)
+		void UpdateShroud(IEnumerable<PPos> region)
 		{
 			foreach (var puv in region)
 			{
@@ -299,7 +299,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void IRenderShroud.RenderShroud(WorldRenderer wr)
 		{
-			UpdateShroud(map.ProjectedCellBounds);
+			UpdateShroud(map.ProjectedCells);
 			fogLayer.Draw(wr.Viewport);
 			shroudLayer.Draw(wr.Viewport);
 		}

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -134,7 +134,7 @@ namespace OpenRA.Mods.Common.Widgets
 				if (newShroud != null)
 				{
 					newShroud.OnShroudChanged += UpdateShroudCell;
-					foreach (var puv in world.Map.ProjectedCellBounds)
+					foreach (var puv in world.Map.ProjectedCells)
 						UpdateShroudCell(puv);
 				}
 


### PR DESCRIPTION
Reduces the amount of MPos -> PPos (-> MPos) conversions in the first ~~three~~ ~~two~~ commit~~s~~.
The last commit is a bit different but likely the most important one: It caches the result of the `ProjectedCellRegion` enumerator, so that we don't have to evaluate what appears to remain static every tick (see https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Game/Traits/Player/Shroud.cs#L165). I flew a few yaks around on bleed which resulted in that evaluation taking ~3% (!) of total CPU time.
Filing as draft since I need to do more/proper testing, and likely a bit more profiling.