### PR TITLE
Add more weapon burst controls and simplify RA Vulcan setup

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -115,6 +115,12 @@ namespace OpenRA.GameRules
 			"If multiple entries, their number needs to match Burst - 1.")]
 		public readonly int[] BurstDelays = { 5 };
 
+		[Desc("Update the firing position to follow targets if they move between bursts?")]
+		public readonly bool BurstTracking = true;
+
+		[Desc("Allow the weapon to cancel its target between bursts if requested by the player or the target dies?")]
+		public readonly bool BurstInterruptable = true;
+
 		[Desc("The minimum range the weapon can fire.")]
 		public readonly WDist MinRange = WDist.Zero;
 

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -28,7 +28,6 @@ namespace OpenRA.Mods.Common.Activities
 		readonly IEnumerable<AttackFrontal> attackTraits;
 		readonly RevealsShroud[] revealsShroud;
 		readonly IMove move;
-		readonly IFacing facing;
 		readonly IPositionable positionable;
 		readonly bool forceAttack;
 		readonly Color? targetLineColor;
@@ -53,7 +52,6 @@ namespace OpenRA.Mods.Common.Activities
 
 			attackTraits = self.TraitsImplementing<AttackFrontal>().ToArray().Where(Exts.IsTraitEnabled);
 			revealsShroud = self.TraitsImplementing<RevealsShroud>().ToArray();
-			facing = self.Trait<IFacing>();
 			positionable = self.Trait<IPositionable>();
 
 			move = allowMovement ? self.TraitOrDefault<IMove>() : null;
@@ -222,7 +220,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			if (!attack.IsTraitPaused)
 				foreach (var a in armaments)
-					a.CheckFire(self, facing, target);
+					a.CheckFire(self, target);
 		}
 
 		void IActivityNotifyStanceChanged.StanceChanged(Actor self, AutoTarget autoTarget, UnitStance oldStance, UnitStance newStance)

--- a/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 						continue;
 
 					inAttackRange = true;
-					a.CheckFire(self, facing, target);
+					a.CheckFire(self, target);
 				}
 
 				// Actors without armaments may want to trigger an action when it passes the target

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -327,18 +327,18 @@ namespace OpenRA.Mods.Common.Traits
 					var projectile = args.Weapon.Projectile.Create(args);
 					if (projectile != null)
 						self.World.Add(projectile);
-
-					if (args.Weapon.Report != null && args.Weapon.Report.Any())
-						Game.Sound.Play(SoundType.World, args.Weapon.Report, self.World, self.CenterPosition);
-
-					if (Burst == args.Weapon.Burst && args.Weapon.StartBurstReport != null && args.Weapon.StartBurstReport.Any())
-						Game.Sound.Play(SoundType.World, args.Weapon.StartBurstReport, self.World, self.CenterPosition);
-
-					foreach (var na in notifyAttacks)
-						na.Attacking(self, target, this, barrel);
-
-					Recoil = Info.Recoil;
 				}
+
+				if (args.Weapon.Report != null && args.Weapon.Report.Any())
+					Game.Sound.Play(SoundType.World, args.Weapon.Report, self.World, self.CenterPosition);
+
+				if (Burst == args.Weapon.Burst && args.Weapon.StartBurstReport != null && args.Weapon.StartBurstReport.Any())
+					Game.Sound.Play(SoundType.World, args.Weapon.StartBurstReport, self.World, self.CenterPosition);
+
+				foreach (var na in notifyAttacks)
+					na.Attacking(self, target, this, barrel);
+
+				Recoil = Info.Recoil;
 			});
 		}
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -169,7 +169,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			foreach (var a in Armaments)
-				a.CheckFire(self, facing, target);
+				a.CheckFire(self, target);
 		}
 
 		IEnumerable<IOrderTargeter> IIssueOrder.Orders

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -171,8 +171,7 @@ namespace OpenRA.Mods.Common.Traits
 				paxFacing[a.Actor].Facing = targetYaw;
 				paxPos[a.Actor].SetVisualPosition(a.Actor, pos + PortOffset(self, port));
 
-				var barrel = a.CheckFire(a.Actor, facing, target);
-				if (barrel == null)
+				if (!a.CheckFire(a.Actor, facing, target))
 					continue;
 
 				if (a.Info.MuzzleSequence != null)
@@ -193,8 +192,13 @@ namespace OpenRA.Mods.Common.Traits
 					muzzleAnim.PlayThen(sequence, () => muzzles.Remove(muzzleFlash));
 				}
 
+				// Armament only notifies the Armament's owner, not the garrisoned actor, so we need to do this manually here
+				// to make traits like Cloak work on garrisoned actors.
+				// Thankfully, WithMuzzleOverlay is literally the only trait implementing INotifyAttack
+				// that actually uses the 'barrel' parameter, and AttackGarrisoned does its own muzzle stuff above,
+				// so we can safely pass null instead of doing more code gymnastics to get the correct barrel.
 				foreach (var npa in notifyAttacks)
-					npa.Attacking(self, target, a, barrel);
+					npa.Attacking(self, target, a, null);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -78,6 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class AttackGarrisoned : AttackFollow, INotifyPassengerEntered, INotifyPassengerExited, IRender
 	{
 		public readonly new AttackGarrisonedInfo Info;
+		INotifyAttack[] notifyAttacks;
 		Lazy<BodyOrientation> coords;
 		List<Armament> armaments;
 		List<AnimationWithOffset> muzzles;
@@ -100,6 +101,12 @@ namespace OpenRA.Mods.Common.Traits
 		protected override Func<IEnumerable<Armament>> InitializeGetArmaments(Actor self)
 		{
 			return () => armaments;
+		}
+
+		protected override void Created(Actor self)
+		{
+			notifyAttacks = self.TraitsImplementing<INotifyAttack>().ToArray();
+			base.Created(self);
 		}
 
 		void INotifyPassengerEntered.OnPassengerEntered(Actor self, Actor passenger)
@@ -186,7 +193,7 @@ namespace OpenRA.Mods.Common.Traits
 					muzzleAnim.PlayThen(sequence, () => muzzles.Remove(muzzleFlash));
 				}
 
-				foreach (var npa in self.TraitsImplementing<INotifyAttack>())
+				foreach (var npa in notifyAttacks)
 					npa.Attacking(self, target, a, barrel);
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -171,7 +171,7 @@ namespace OpenRA.Mods.Common.Traits
 				paxFacing[a.Actor].Facing = targetYaw;
 				paxPos[a.Actor].SetVisualPosition(a.Actor, pos + PortOffset(self, port));
 
-				if (!a.CheckFire(a.Actor, facing, target))
+				if (!a.CheckFire(a.Actor, target))
 					continue;
 
 				if (a.Info.MuzzleSequence != null)

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -82,11 +82,7 @@ namespace OpenRA.Mods.D2k.Activities
 			foreach (var player in affectedPlayers)
 				self.World.AddFrameEndTask(w => w.Add(new MapNotificationEffect(player, "Speech", swallow.Info.WormAttackNotification, 25, true, attackPosition, Color.Red)));
 
-			var barrel = armament.CheckFire(self, facing, target);
-			if (barrel == null)
-				return false;
-
-			return true;
+			return armament.CheckFire(self, facing, target);
 		}
 
 		public override bool Tick(Actor self)

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -33,7 +33,6 @@ namespace OpenRA.Mods.D2k.Activities
 		readonly Armament armament;
 		readonly AttackSwallow swallow;
 		readonly IPositionable positionable;
-		readonly IFacing facing;
 
 		int countdown;
 		CPos burrowLocation;
@@ -43,7 +42,6 @@ namespace OpenRA.Mods.D2k.Activities
 		public SwallowActor(Actor self, Target target, Armament a, IFacing facing)
 		{
 			this.target = target;
-			this.facing = facing;
 			armament = a;
 			weapon = a.Weapon;
 			sandworm = self.Trait<Sandworm>();
@@ -82,7 +80,7 @@ namespace OpenRA.Mods.D2k.Activities
 			foreach (var player in affectedPlayers)
 				self.World.AddFrameEndTask(w => w.Add(new MapNotificationEffect(player, "Speech", swallow.Info.WormAttackNotification, 25, true, attackPosition, Color.Red)));
 
-			return armament.CheckFire(self, facing, target);
+			return armament.CheckFire(self, target);
 		}
 
 		public override bool Tick(Actor self)

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -86,10 +86,6 @@ namespace OpenRA.Mods.D2k.Activities
 			if (barrel == null)
 				return false;
 
-			// armament.CheckFire already calls INotifyAttack.PreparingAttack
-			foreach (var notify in self.TraitsImplementing<INotifyAttack>())
-				notify.Attacking(self, target, armament, barrel);
-
 			return true;
 		}
 

--- a/mods/ra/sequences/infantry.yaml
+++ b/mods/ra/sequences/infantry.yaml
@@ -79,8 +79,33 @@ e1:
 			DESERT: TEMPERAT
 			INTERIOR: TEMPERAT
 	garrison-muzzle: minigun
-		Length: 6
+		Length: 12
 		Facings: 8
+		Combine:
+			minigun:
+				Length: 12
+				Frames: 0,1,2,3,4,5,0,1,2,3,4,5
+			minigun:
+				Length: 12
+				Frames: 6,7,8,9,10,11,6,7,8,9,10,11
+			minigun:
+				Length: 12
+				Frames: 12,13,14,15,16,17,12,13,14,15,16,17
+			minigun:
+				Length: 12
+				Frames: 18,19,20,21,22,23,18,19,20,21,22,23
+			minigun:
+				Length: 12
+				Frames: 24,25,26,27,28,29,24,25,26,27,28,29
+			minigun:
+				Length: 12
+				Frames: 30,31,32,33,34,35,30,31,32,33,34,35
+			minigun:
+				Length: 12
+				Frames: 36,37,38,39,40,41,36,37,38,39,40,41
+			minigun:
+				Length: 12
+				Frames: 42,43,44,45,46,47,42,43,44,45,46,47
 	icon: e1icon
 
 sniper:

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -96,6 +96,12 @@ FLAK-23-AG:
 
 Vulcan:
 	Inherits: ^HeavyMG
+	-Report:
+	StartBurstReport: gun13.aud
+	Burst: 6
+	BurstDelays: 2
+	BurstTracking: false
+	BurstInterruptable: false
 	Warhead@1Dam: SpreadDamage
 		Damage: 1000
 		Versus:
@@ -104,111 +110,6 @@ Vulcan:
 			Light: 50
 			Heavy: 20
 			Concrete: 20
-	Warhead@4Dam_2: SpreadDamage
-		Spread: 128
-		Damage: 1000
-		Delay: 2
-		Versus:
-			None: 200
-			Wood: 50
-			Light: 50
-			Heavy: 20
-			Concrete: 20
-		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
-	Warhead@4Eff_2: CreateEffect
-		Explosions: piffs
-		ValidTargets: Ground
-		ImpactActors: false
-		Delay: 2
-	Warhead@4Eff_2Water: CreateEffect
-		Explosions: water_piffs
-		ValidTargets: Water, Underwater
-		InvalidTargets: Bridge
-		Delay: 2
-	Warhead@5Dam_3: SpreadDamage
-		Spread: 128
-		Damage: 1000
-		Delay: 4
-		Versus:
-			None: 200
-			Wood: 50
-			Light: 50
-			Heavy: 20
-			Concrete: 20
-		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
-	Warhead@6Eff_3: CreateEffect
-		Explosions: piffs
-		ValidTargets: Ground
-		ImpactActors: false
-		Delay: 4
-	Warhead@6Eff_3Water: CreateEffect
-		Explosions: water_piffs
-		ValidTargets: Water, Underwater
-		InvalidTargets: Bridge
-		Delay: 4
-	Warhead@7Dam_4: SpreadDamage
-		Spread: 128
-		Damage: 1000
-		Delay: 6
-		Versus:
-			None: 200
-			Wood: 50
-			Light: 50
-			Heavy: 20
-			Concrete: 20
-		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
-	Warhead@8Eff_4: CreateEffect
-		Explosions: piffs
-		ValidTargets: Ground
-		ImpactActors: false
-		Delay: 6
-	Warhead@8Eff_4Water: CreateEffect
-		Explosions: water_piffs
-		ValidTargets: Water, Underwater
-		InvalidTargets: Bridge
-		Delay: 6
-	Warhead@9Dam_5: SpreadDamage
-		Spread: 128
-		Damage: 1000
-		Delay: 8
-		Versus:
-			None: 200
-			Wood: 50
-			Light: 50
-			Heavy: 20
-			Concrete: 20
-		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
-	Warhead@10Eff_5: CreateEffect
-		Explosions: piffs
-		ValidTargets: Ground
-		ImpactActors: false
-		Delay: 8
-	Warhead@10Eff_5Water: CreateEffect
-		Explosions: water_piffs
-		ValidTargets: Water, Underwater
-		InvalidTargets: Bridge
-		Delay: 8
-	Warhead@11Dam_6: SpreadDamage
-		Spread: 128
-		Damage: 1000
-		Delay: 10
-		Versus:
-			None: 200
-			Wood: 50
-			Light: 50
-			Heavy: 20
-			Concrete: 20
-		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
-	Warhead@12Eff_6: CreateEffect
-		Explosions: piffs
-		ValidTargets: Ground
-		ImpactActors: false
-		Delay: 10
-	Warhead@12Eff_6Water: CreateEffect
-		Explosions: water_piffs
-		ValidTargets: Water, Underwater
-		InvalidTargets: Bridge
-		Delay: 10
 
 ChainGun:
 	Inherits: ^HeavyMG


### PR DESCRIPTION
Added more configurability for burst behavior to `WeaponInfo`.

Closes #13220.
Fixes #18312.