### PR TITLE
Apply reload delay modifiers to BurstDelays as well

### DIFF
--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -342,16 +342,16 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected virtual void UpdateBurst(Actor self, Target target)
 		{
+			var modifiers = reloadModifiers.ToArray();
 			if (--Burst > 0)
 			{
 				if (Weapon.BurstDelays.Length == 1)
-					FireDelay = Weapon.BurstDelays[0];
+					FireDelay = Util.ApplyPercentageModifiers(Weapon.BurstDelays[0], modifiers);
 				else
-					FireDelay = Weapon.BurstDelays[Weapon.Burst - (Burst + 1)];
+					FireDelay = Util.ApplyPercentageModifiers(Weapon.BurstDelays[Weapon.Burst - (Burst + 1)], modifiers);
 			}
 			else
 			{
-				var modifiers = reloadModifiers.ToArray();
 				FireDelay = Util.ApplyPercentageModifiers(Weapon.ReloadDelay, modifiers);
 				Burst = Weapon.Burst;
 


### PR DESCRIPTION
I believe this has been requested before, and it makes sense: If we don't scale `BurstDelays` along with `ReloadDelay`, it could lead to the undesired result of the effective `ReloadDelay` dropping below `BurstDelays`, effectively breaking the multi-burst nature of a weapon.

Note that this may potentially have a minor impact on balance due to veterancy.