### PR TITLE
Add a ProjectedCellLayer that is indexed by PPos

### DIFF
--- a/OpenRA.Game/Map/CellLayer.cs
+++ b/OpenRA.Game/Map/CellLayer.cs
@@ -10,42 +10,28 @@
 #endregion
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using OpenRA.Primitives;
 
 namespace OpenRA
 {
 	// Represents a layer of "something" that covers the map
-	public class CellLayer<T> : IEnumerable<T>
+	public sealed class CellLayer<T> : CellLayerBase<T>
 	{
-		public readonly Size Size;
-		readonly Rectangle bounds;
-		public readonly MapGridType GridType;
 		public event Action<CPos> CellEntryChanged = null;
 
-		readonly T[] entries;
-
 		public CellLayer(Map map)
-			: this(map.Grid.Type, new Size(map.MapSize.X, map.MapSize.Y)) { }
+			: base(map) { }
 
 		public CellLayer(MapGridType gridType, Size size)
-		{
-			Size = size;
-			bounds = new Rectangle(0, 0, Size.Width, Size.Height);
-			GridType = gridType;
-			entries = new T[size.Width * size.Height];
-		}
+			: base(gridType, size) { }
 
-		public void CopyValuesFrom(CellLayer<T> anotherLayer)
+		public override void CopyValuesFrom(CellLayerBase<T> anotherLayer)
 		{
-			if (Size != anotherLayer.Size || GridType != anotherLayer.GridType)
-				throw new ArgumentException(
-					"layers must have a matching size and shape (grid type).", "anotherLayer");
 			if (CellEntryChanged != null)
 				throw new InvalidOperationException(
 					"Cannot copy values when there are listeners attached to the CellEntryChanged event.");
-			Array.Copy(anotherLayer.entries, entries, entries.Length);
+
+			base.CopyValuesFrom(anotherLayer);
 		}
 
 		public static CellLayer<T> CreateInstance(Func<MPos, T> initialCellValueFactory, Size size, MapGridType mapGridType)
@@ -107,23 +93,6 @@ namespace OpenRA
 				if (CellEntryChanged != null)
 					CellEntryChanged(uv.ToCPos(GridType));
 			}
-		}
-
-		/// <summary>Clears the layer contents with a known value</summary>
-		public void Clear(T clearValue)
-		{
-			for (var i = 0; i < entries.Length; i++)
-				entries[i] = clearValue;
-		}
-
-		public IEnumerator<T> GetEnumerator()
-		{
-			return ((IEnumerable<T>)entries).GetEnumerator();
-		}
-
-		IEnumerator IEnumerable.GetEnumerator()
-		{
-			return GetEnumerator();
 		}
 
 		public bool Contains(CPos cell)

--- a/OpenRA.Game/Map/CellLayerBase.cs
+++ b/OpenRA.Game/Map/CellLayerBase.cs
@@ -1,0 +1,63 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using OpenRA.Primitives;
+
+namespace OpenRA
+{
+	public abstract class CellLayerBase<T> : IEnumerable<T>
+	{
+		public readonly Size Size;
+		public readonly MapGridType GridType;
+
+		protected readonly T[] entries;
+		protected readonly Rectangle bounds;
+
+		public CellLayerBase(Map map)
+			: this(map.Grid.Type, new Size(map.MapSize.X, map.MapSize.Y)) { }
+
+		public CellLayerBase(MapGridType gridType, Size size)
+		{
+			Size = size;
+			bounds = new Rectangle(0, 0, Size.Width, Size.Height);
+			GridType = gridType;
+			entries = new T[size.Width * size.Height];
+		}
+
+		public virtual void CopyValuesFrom(CellLayerBase<T> anotherLayer)
+		{
+			if (Size != anotherLayer.Size || GridType != anotherLayer.GridType)
+				throw new ArgumentException("Layers must have a matching size and shape (grid type).", "anotherLayer");
+
+			Array.Copy(anotherLayer.entries, entries, entries.Length);
+		}
+
+		/// <summary>Clears the layer contents with a known value</summary>
+		public void Clear(T clearValue)
+		{
+			for (var i = 0; i < entries.Length; i++)
+				entries[i] = clearValue;
+		}
+
+		public IEnumerator<T> GetEnumerator()
+		{
+			return ((IEnumerable<T>)entries).GetEnumerator();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return GetEnumerator();
+		}
+	}
+}

--- a/OpenRA.Game/Map/ProjectedCellLayer.cs
+++ b/OpenRA.Game/Map/ProjectedCellLayer.cs
@@ -1,0 +1,50 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using OpenRA.Primitives;
+
+namespace OpenRA
+{
+	public sealed class ProjectedCellLayer<T> : CellLayerBase<T>
+	{
+		public ProjectedCellLayer(Map map)
+			: base(map) { }
+
+		public ProjectedCellLayer(MapGridType gridType, Size size)
+			: base(gridType, size) { }
+
+		// Resolve an array index from map coordinates.
+		int Index(PPos uv)
+		{
+			return uv.V * Size.Width + uv.U;
+		}
+
+		/// <summary>Gets or sets the layer contents using projected map coordinates.</summary>
+		public T this[PPos uv]
+		{
+			get
+			{
+				return entries[Index(uv)];
+			}
+
+			set
+			{
+				entries[Index(uv)] = value;
+			}
+		}
+
+		public bool Contains(PPos uv)
+		{
+			return bounds.Contains(uv.U, uv.V);
+		}
+	}
+}


### PR DESCRIPTION
Profiling revealed that there is a good gain to be made here (~4% of CPU time on my constructed testcase; the real impact will be less, but not insignificant). The constant casts (for every projected cell of the map, every tick!) were the biggest bottleneck here.