### PR TITLE
Fix querying the PlayerActor in Created causing NREs

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -171,7 +171,7 @@ namespace OpenRA
 			SyncHashes = TraitsImplementing<ISync>().Select(sync => new SyncHash(sync)).ToArray();
 		}
 
-		internal void Created()
+		internal void Initialize(bool addToWorld = true)
 		{
 			created = true;
 
@@ -225,6 +225,9 @@ namespace OpenRA
 				activity.Queue(CurrentActivity);
 				CurrentActivity = activity;
 			}
+
+			if (addToWorld)
+				World.Add(this);
 		}
 
 		public void Tick()

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -166,6 +166,9 @@ namespace OpenRA
 			if (!Spectating)
 				PlayerMask = new LongBitSet<PlayerBitMask>(InternalName);
 
+			// Set this property before running any Created callbacks on the player actor
+			IsBot = BotType != null;
+
 			// Special case handling is required for the Player actor:
 			// Since Actor.Created would be called before PlayerActor is assigned here
 			// querying player traits in INotifyCreated.Created would crash.
@@ -179,7 +182,6 @@ namespace OpenRA
 			FrozenActorLayer = PlayerActor.TraitOrDefault<FrozenActorLayer>();
 
 			// Enable the bot logic on the host
-			IsBot = BotType != null;
 			if (IsBot && Game.IsHost)
 			{
 				var logic = PlayerActor.TraitsImplementing<IBot>().FirstOrDefault(b => b.Info.Type == BotType);

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -14,7 +14,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Eluant;
 using Eluant.ObjectBinding;
-using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Primitives;
 using OpenRA.Scripting;

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -36,6 +36,9 @@ namespace OpenRA
 
 	public class Player : IScriptBindable, IScriptNotifyBind, ILuaTableBinding, ILuaEqualityBinding, ILuaToStringBinding
 	{
+		public const string PlayerActorType = "Player";
+		public const string EditorPlayerActorType = "EditorPlayer";
+
 		struct StanceColors
 		{
 			public Color Self;
@@ -163,7 +166,7 @@ namespace OpenRA
 			if (!Spectating)
 				PlayerMask = new LongBitSet<PlayerBitMask>(InternalName);
 
-			var playerActorType = world.Type == WorldType.Editor ? "EditorPlayer" : "Player";
+			var playerActorType = world.Type == WorldType.Editor ? EditorPlayerActorType : PlayerActorType;
 			PlayerActor = world.CreateActor(playerActorType, new TypeDictionary { new OwnerInit(this) });
 			Shroud = PlayerActor.Trait<Shroud>();
 			FrozenActorLayer = PlayerActor.TraitOrDefault<FrozenActorLayer>();

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -166,8 +166,16 @@ namespace OpenRA
 			if (!Spectating)
 				PlayerMask = new LongBitSet<PlayerBitMask>(InternalName);
 
+			// Special case handling is required for the Player actor:
+			// Since Actor.Created would be called before PlayerActor is assigned here
+			// querying player traits in INotifyCreated.Created would crash.
+			// Therefore only call the constructor of Actor and run the Created callbacks ourselves.
+			// Add the PlayerActor to the world afterwards.
 			var playerActorType = world.Type == WorldType.Editor ? EditorPlayerActorType : PlayerActorType;
-			PlayerActor = world.CreateActor(playerActorType, new TypeDictionary { new OwnerInit(this) });
+			PlayerActor = new Actor(world, playerActorType, new TypeDictionary { new OwnerInit(this) });
+			PlayerActor.Created();
+			world.Add(PlayerActor);
+
 			Shroud = PlayerActor.Trait<Shroud>();
 			FrozenActorLayer = PlayerActor.TraitOrDefault<FrozenActorLayer>();
 

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -169,12 +169,11 @@ namespace OpenRA
 			// Special case handling is required for the Player actor:
 			// Since Actor.Created would be called before PlayerActor is assigned here
 			// querying player traits in INotifyCreated.Created would crash.
-			// Therefore only call the constructor of Actor and run the Created callbacks ourselves.
-			// Add the PlayerActor to the world afterwards.
+			// Therefore assign the uninitialized actor and run the Created callbacks
+			// by calling Initialize ourselves.
 			var playerActorType = world.Type == WorldType.Editor ? EditorPlayerActorType : PlayerActorType;
 			PlayerActor = new Actor(world, playerActorType, new TypeDictionary { new OwnerInit(this) });
-			PlayerActor.Created();
-			world.Add(PlayerActor);
+			PlayerActor.Initialize(true);
 
 			Shroud = PlayerActor.Trait<Shroud>();
 			FrozenActorLayer = PlayerActor.TraitOrDefault<FrozenActorLayer>();

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -337,10 +337,7 @@ namespace OpenRA
 		public Actor CreateActor(bool addToWorld, string name, TypeDictionary initDict)
 		{
 			var a = new Actor(this, name, initDict);
-			a.Created();
-			if (addToWorld)
-				Add(a);
-
+			a.Initialize(addToWorld);
 			return a;
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/ResourcePurifier.cs
+++ b/OpenRA.Mods.Cnc/Traits/ResourcePurifier.cs
@@ -52,12 +52,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		protected override void Created(Actor self)
 		{
-			// Special case handling is required for the Player actor.
-			// Created is called before Player.PlayerActor is assigned,
-			// so we must query other player traits from self, knowing that
-			// it refers to the same actor as self.Owner.PlayerActor
-			var playerActor = self.Info.Name == "player" ? self : self.Owner.PlayerActor;
-			playerResources = playerActor.Trait<PlayerResources>();
+			playerResources = self.Owner.PlayerActor.Trait<PlayerResources>();
 
 			base.Created(self);
 		}

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/GrantPrerequisiteChargeDrainPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/GrantPrerequisiteChargeDrainPower.cs
@@ -56,13 +56,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		protected override void Created(Actor self)
 		{
-			// Special case handling is required for the Player actor.
-			// Created is called before Player.PlayerActor is assigned,
-			// so we must query other player traits from self, knowing that
-			// it refers to the same actor as self.Owner.PlayerActor
-			var playerActor = self.Info.Name == "player" ? self : self.Owner.PlayerActor;
-
-			techTree = playerActor.Trait<TechTree>();
+			techTree = self.Owner.PlayerActor.Trait<TechTree>();
 
 			base.Created(self);
 		}

--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -160,13 +160,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override void Created(Actor self)
 		{
-			// Special case handling is required for the Player actor.
-			// Created is called before Player.PlayerActor is assigned,
-			// so we must query player traits from self, which refers
-			// for bot modules always to the Player actor.
-			playerPower = self.TraitOrDefault<PowerManager>();
-			playerResources = self.Trait<PlayerResources>();
-			positionsUpdatedModules = self.TraitsImplementing<IBotPositionsUpdated>().ToArray();
+			playerPower = self.Owner.PlayerActor.TraitOrDefault<PowerManager>();
+			playerResources = self.Owner.PlayerActor.Trait<PlayerResources>();
+			positionsUpdatedModules = self.Owner.PlayerActor.TraitsImplementing<IBotPositionsUpdated>().ToArray();
 		}
 
 		protected override void TraitEnabled(Actor self)

--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -78,11 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override void Created(Actor self)
 		{
-			// Special case handling is required for the Player actor.
-			// Created is called before Player.PlayerActor is assigned,
-			// so we must query player traits from self, which refers
-			// for bot modules always to the Player actor.
-			requestUnitProduction = self.TraitsImplementing<IBotRequestUnitProduction>().ToArray();
+			requestUnitProduction = self.Owner.PlayerActor.TraitsImplementing<IBotRequestUnitProduction>().ToArray();
 		}
 
 		protected override void TraitEnabled(Actor self)

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -82,12 +82,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override void Created(Actor self)
 		{
-			// Special case handling is required for the Player actor.
-			// Created is called before Player.PlayerActor is assigned,
-			// so we must query player traits from self, which refers
-			// for bot modules always to the Player actor.
-			notifyPositionsUpdated = self.TraitsImplementing<IBotPositionsUpdated>().ToArray();
-			requestUnitProduction = self.TraitsImplementing<IBotRequestUnitProduction>().ToArray();
+			notifyPositionsUpdated = self.Owner.PlayerActor.TraitsImplementing<IBotPositionsUpdated>().ToArray();
+			requestUnitProduction = self.Owner.PlayerActor.TraitsImplementing<IBotRequestUnitProduction>().ToArray();
 		}
 
 		protected override void TraitEnabled(Actor self)

--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -150,12 +150,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override void Created(Actor self)
 		{
-			// Special case handling is required for the Player actor.
-			// Created is called before Player.PlayerActor is assigned,
-			// so we must query player traits from self, which refers
-			// for bot modules always to the Player actor.
-			notifyPositionsUpdated = self.TraitsImplementing<IBotPositionsUpdated>().ToArray();
-			notifyIdleBaseUnits = self.TraitsImplementing<IBotNotifyIdleBaseUnits>().ToArray();
+			notifyPositionsUpdated = self.Owner.PlayerActor.TraitsImplementing<IBotPositionsUpdated>().ToArray();
+			notifyIdleBaseUnits = self.Owner.PlayerActor.TraitsImplementing<IBotNotifyIdleBaseUnits>().ToArray();
 		}
 
 		protected override void TraitEnabled(Actor self)

--- a/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
@@ -54,11 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override void Created(Actor self)
 		{
-			// Special case handling is required for the Player actor.
-			// Created is called before Player.PlayerActor is assigned,
-			// so we must query player traits from self, which refers
-			// for bot modules always to the Player actor.
-			supportPowerManager = self.Trait<SupportPowerManager>();
+			supportPowerManager = self.Owner.PlayerActor.Trait<SupportPowerManager>();
 		}
 
 		protected override void TraitEnabled(Actor self)

--- a/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
@@ -62,11 +62,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override void Created(Actor self)
 		{
-			// Special case handling is required for the Player actor.
-			// Created is called before Player.PlayerActor is assigned,
-			// so we must query player traits from self, which refers
-			// for bot modules always to the Player actor.
-			requestPause = self.TraitsImplementing<IBotRequestPauseUnitProduction>().ToArray();
+			requestPause = self.Owner.PlayerActor.TraitsImplementing<IBotRequestPauseUnitProduction>().ToArray();
 		}
 
 		void IBotNotifyIdleBaseUnits.UpdatedIdleBaseUnits(List<Actor> idleUnits)

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs
@@ -42,15 +42,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyCreated.Created(Actor self)
 		{
-			// Special case handling is required for the Player actor.
-			// Created is called before Player.IsBot is set, so we
-			// must use a different method to enable this trait if
-			// it's defined on the PlayerActor.
-			self.World.AddFrameEndTask(w =>
-			{
-				if (self.Owner.IsBot && info.Bots.Contains(self.Owner.BotType))
-					conditionToken = self.GrantCondition(info.Condition);
-			});
+			if (self.Owner.IsBot && info.Bots.Contains(self.Owner.BotType))
+				conditionToken = self.GrantCondition(info.Condition);
 		}
 
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPlayerResources.cs
@@ -42,12 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyCreated.Created(Actor self)
 		{
-			// Special case handling is required for the Player actor.
-			// Created is called before Player.PlayerActor is assigned,
-			// so we must query other player traits from self, knowing that
-			// it refers to the same actor as self.Owner.PlayerActor
-			var playerActor = self.Info.Name == "player" ? self : self.Owner.PlayerActor;
-			playerResources = playerActor.Trait<PlayerResources>();
+			playerResources = self.Owner.PlayerActor.Trait<PlayerResources>();
 		}
 
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPrerequisite.cs
@@ -44,13 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyCreated.Created(Actor self)
 		{
-			// Special case handling is required for the Player actor.
-			// Created is called before Player.PlayerActor is assigned,
-			// so we must query other player traits from self, knowing that
-			// it refers to the same actor as self.Owner.PlayerActor
-			var playerActor = self.Info.Name == "player" ? self : self.Owner.PlayerActor;
-
-			globalManager = playerActor.Trait<GrantConditionOnPrerequisiteManager>();
+			globalManager = self.Owner.PlayerActor.Trait<GrantConditionOnPrerequisiteManager>();
 		}
 
 		void INotifyAddedToWorld.AddedToWorld(Actor self)

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -141,19 +141,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyCreated.Created(Actor self)
 		{
-			// Special case handling is required for the Player actor.
-			// Created is called before Player.PlayerActor is assigned,
-			// so we must query other player traits from self, knowing that
-			// it refers to the same actor as self.Owner.PlayerActor
-			var playerActor = self.Info.Name == "player" ? self : self.Owner.PlayerActor;
-
-			playerPower = playerActor.TraitOrDefault<PowerManager>();
-			playerResources = playerActor.Trait<PlayerResources>();
-			developerMode = playerActor.Trait<DeveloperMode>();
-			techTree = playerActor.Trait<TechTree>();
+			playerPower = self.Owner.PlayerActor.TraitOrDefault<PowerManager>();
+			playerResources = self.Owner.PlayerActor.Trait<PlayerResources>();
+			developerMode = self.Owner.PlayerActor.Trait<DeveloperMode>();
+			techTree = self.Owner.PlayerActor.Trait<TechTree>();
 
 			productionTraits = self.TraitsImplementing<Production>().Where(p => p.Info.Produces.Contains(Info.Type)).ToArray();
-			CacheProducibles(playerActor);
+			CacheProducibles(self.Owner.PlayerActor);
 		}
 
 		protected void ClearQueue()

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
@@ -69,13 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override void Created(Actor self)
 		{
-			// Special case handling is required for the Player actor.
-			// Created is called before Player.PlayerActor is assigned,
-			// so we must query other player traits from self, knowing that
-			// it refers to the same actor as self.Owner.PlayerActor
-			var playerActor = self.Info.Name == "player" ? self : self.Owner.PlayerActor;
-
-			techTree = playerActor.Trait<TechTree>();
+			techTree = self.Owner.PlayerActor.Trait<TechTree>();
 
 			Update();
 


### PR DESCRIPTION
Apparently we have created specific workarounds for single traits (e.g. #14428 and #15272) when we needed it. Imo it is better to fix this generally and for all traits: We first construct the `PlayerActor`, then set the reference (`Player.PlayerActor`) and only then do the `Created` callbacks and add the actor to the world.

Testcase was adding the following to `ai.yaml` of the RA mod:
```
CashTrickler:
	Amount: 50
	RequiresCondition: enable-normal-ai
	Interval: 125
	ShowTicks: false
```
(Also see https://forum.openra.net/viewtopic.php?f=82&t=21167)

Note that I haven't removed all the individual workarounds yet, but wanted some feedback on the approach first.