### PR TITLE
Fix bots not working after adminship was transferred

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -645,6 +645,13 @@ namespace OpenRA.Mods.Common.Server
 			var newAdminClient = server.GetClient(newAdminConn);
 			client.IsAdmin = false;
 			newAdminClient.IsAdmin = true;
+
+			var bots = server.LobbyInfo.Slots
+				.Select(slot => server.LobbyInfo.ClientInSlot(slot.Key))
+				.Where(c => c != null && c.Bot != null);
+			foreach (var b in bots)
+				b.BotControllerClientIndex = newAdminId;
+
 			server.SendMessage("{0} is now the admin.".F(newAdminClient.Name));
 			Log.Write("server", "{0} is now the admin.".F(newAdminClient.Name));
 			server.SyncLobbyClients();


### PR DESCRIPTION
Closes #18183.

Testcase: Go into a dedicated server and add some bots, then transfer adminship to another player. The bots will be associated with your client id, while they should be with the new admin's, so [ValidateOrder.cs#L36](https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs#L36) drops the order.

This fixes the issue by giving all existing bots the controller id of the new admin.