### PR TITLE
Restore trailing whitespaces to windows batch scripts

### DIFF
--- a/launch-game.cmd
+++ b/launch-game.cmd
@@ -5,7 +5,7 @@ for %%x in (%*) do (
 )
 
 :choosemod
-set /P mod=Select mod (ra, cnc, d2k, ts) or --exit:
+set /P mod="Select mod (ra, cnc, d2k, ts) or --exit: "
 if /I "%mod%" EQU "--exit" (exit /b)
 if "%mod%" EQU "ra" (goto launchmod)
 if "%mod%" EQU "cnc" (goto launchmod)

--- a/utility.cmd
+++ b/utility.cmd
@@ -5,7 +5,7 @@ echo ----------------------------------------
 echo.
 call OpenRA.Utility.exe
 echo Enter --exit to exit
-set /P mod=Please enter a modname: OpenRA.Utility.exe
+set /P mod="Please enter a modname: OpenRA.Utility.exe "
 if /I "%mod%" EQU "--exit" (exit /b)
 if /I "%mod%" EQU "ra" (goto help)
 if /I "%mod%" EQU "cnc" (goto help)
@@ -30,7 +30,7 @@ echo   --exit to exit
 echo   --help to view the help
 echo   --mod to choose a new mod
 echo.
-set /P command=Please enter a command: OpenRA.Utility.exe %mod%
+set /P command="Please enter a command: OpenRA.Utility.exe %mod% "
 if /I "%command%" EQU "--exit" (exit /b)
 if /I "%command%" EQU "--help" (goto help)
 if /I "%command%" EQU "--mod" (goto choosemod)


### PR DESCRIPTION
I forgot those were intentional so they were accidentally removed by #18171.