### PR TITLE
 make AI to  handle Plugbuilding like Componentdower [issue 18154] #18155 

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -134,14 +134,34 @@ namespace OpenRA.Mods.Common.Traits
 				// HACK: HACK HACK HACK
 				// TODO: Derive this from BuildingCommonNames instead
 				var type = BuildingType.Building;
+				CPos? location = null;
+				string orderString = "PlaceBuilding";
 
-				// Check if Building is a defense and if we should place it towards the enemy or not.
-				if (world.Map.Rules.Actors[currentBuilding.Item].HasTraitInfo<AttackBaseInfo>() && world.LocalRandom.Next(100) < baseBuilder.Info.PlaceDefenseTowardsEnemyChance)
-					type = BuildingType.Defense;
-				else if (baseBuilder.Info.RefineryTypes.Contains(world.Map.Rules.Actors[currentBuilding.Item].Name))
-					type = BuildingType.Refinery;
+				// Check if Building is a plug for other Building
+				var actorInfo = world.Map.Rules.Actors[currentBuilding.Item];
+				var plugInfo = actorInfo.TraitInfoOrDefault<PlugInfo>();
+				if (plugInfo != null)
+				{
+					var possibleBuilding = world.ActorsWithTrait<Pluggable>().FirstOrDefault(a =>
+						a.Actor.Owner == player && a.Trait.AcceptsPlug(a.Actor, plugInfo.Type));
 
-				var location = ChooseBuildLocation(currentBuilding.Item, true, type);
+					if (possibleBuilding != null)
+					{
+						orderString = "PlacePlug";
+						location = possibleBuilding.Actor.Location + possibleBuilding.Trait.Info.Offset;
+					}
+				}
+				else
+				{
+					// Check if Building is a defense and if we should place it towards the enemy or not.
+					if (actorInfo.HasTraitInfo<AttackBaseInfo>() && world.LocalRandom.Next(100) < baseBuilder.Info.PlaceDefenseTowardsEnemyChance)
+						type = BuildingType.Defense;
+					else if (baseBuilder.Info.RefineryTypes.Contains(actorInfo.Name))
+						type = BuildingType.Refinery;
+
+					location = ChooseBuildLocation(currentBuilding.Item, true, type);
+				}
+
 				if (location == null)
 				{
 					AIUtils.BotDebug("AI: {0} has nowhere to place {1}".F(player, currentBuilding.Item));
@@ -158,7 +178,8 @@ namespace OpenRA.Mods.Common.Traits
 				else
 				{
 					failCount = 0;
-					bot.QueueOrder(new Order("PlaceBuilding", player.PlayerActor, Target.FromCell(world, location.Value), false)
+
+					bot.QueueOrder(new Order(orderString, player.PlayerActor, Target.FromCell(world, location.Value), false)
 					{
 						// Building to place
 						TargetString = currentBuilding.Item,

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -17,7 +17,7 @@ Player:
 		ExcessPowerIncreaseThreshold: 4
 		ConstructionYardTypes: gacnst
 		RefineryTypes: proc
-		PowerTypes: gapowr, napowr, naapwr
+		PowerTypes: gapowr, gapowrup, napowr, naapwr
 		BarracksTypes: gapile, nahand
 		VehiclesFactoryTypes: gaweap, naweap
 		ProductionTypes: gapile, nahand, gaweap, naweap, gahpad, nahpad
@@ -41,6 +41,7 @@ Player:
 			gavulc: 8
 			garock: 2
 			gacsam: 4
+			gactwr: 14
 			naobel: 2
 			nalasr: 8
 			nasam: 4
@@ -61,6 +62,7 @@ Player:
 			gavulc: 10
 			garock: 3
 			gacsam: 6
+			gactwr: 18
 			nasam: 6
 			naobel: 3
 	BuildingRepairBotModule:


### PR DESCRIPTION
This is a short and easy fix, to allow AI, to use pluggable Buildings, like RGB Tower on GDI Componenttower..

(Clone form https://github.com/OpenRA/OpenRA/pull/18155 ) (it was broken..)

Closes #8900.
