### PR TITLE
Refactor FindAndDeliverResources (again)

### DIFF
--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -89,8 +89,7 @@ namespace OpenRA.Mods.Common.Activities
 					return true;
 			}
 
-			// Are we full or have nothing more to gather? Deliver resources.
-			if (harv.IsFull || (!harv.IsEmpty && LastSearchFailed))
+			if (harv.IsFull)
 			{
 				QueueChild(new DeliverResources(self));
 				hasDeliveredLoad = true;
@@ -111,10 +110,19 @@ namespace OpenRA.Mods.Common.Activities
 			var closestHarvestableCell = ClosestHarvestablePos(self);
 			LastSearchFailed = !closestHarvestableCell.HasValue;
 
-			// If no harvestable position could be found and we are at the refinery, get out of the way
-			// of the refinery entrance.
 			if (LastSearchFailed)
 			{
+				// Deliver resources first if we can. A new harvestable pos might be available once we are finished.
+				if (!harv.IsEmpty)
+				{
+					QueueChild(new DeliverResources(self));
+					hasDeliveredLoad = true;
+					hasWaited = true;
+					return false;
+				}
+
+				// If no harvestable position could be found and we are at the refinery,
+				// get out of the way of the refinery entrance.
 				var lastproc = harv.LastLinkedProc ?? harv.LinkedProc;
 				if (lastproc != null && !lastproc.Disposed)
 				{

--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -58,9 +58,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected override void OnFirstRun(Actor self)
 		{
-			// If two "harvest" orders are issued consecutively, we deliver the load first if needed.
-			// We have to make sure the actual "harvest" order is not skipped if a third order is queued,
-			// so we keep hasDeliveredLoad false.
+			// The NextActivity handling will drop this activity once the harvester is full,
+			// so deliver the load first if needed while keeping 'hasDeliveredLoad' false.
 			if (orderLocation != null && harv.IsFull)
 				QueueChild(new DeliverResources(self));
 


### PR DESCRIPTION
Closes #18188.
Closes #17046.

Harvesters will now prefer the resources closest to the refinery over closest to the last position harvested at, unless an explicit order is given. If a harvester drives off now it is because the search radii are too large, but at least it will not stay at the remote location but prefer the closer resources. The code is hopefully a lot more readable and structured now and I tried to document the not so obvious parts.