### PR TITLE
Fix harvest animation facing glitch.

### DIFF
--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -64,6 +64,7 @@ HARV:
 		BaleUnloadDelay: 6
 		SearchFromProcRadius: 15
 		SearchFromHarvesterRadius: 8
+		HarvestFacings: 8
 		EmptyCondition: no-tiberium
 	Mobile:
 		Speed: 85

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -307,6 +307,7 @@ HARV:
 		BaleUnloadDelay: 1
 		SearchFromProcRadius: 15
 		SearchFromHarvesterRadius: 8
+		HarvestFacings: 8
 		EmptyCondition: no-ore
 	Health:
 		HP: 60000


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/pull/18067#issuecomment-635553768.

Testcase:
* Build a harvester in RA or TD.
* Force move harvester onto a cell with ore/tiberium (or wait for it to start harvesting then stop).
* Issue a move order to a cell in a different direction, then immediately use the stop hotkey so the harvester not facing on one of the 8 primary facings.
* Issue a harvest order on the cell below the harvester.

Old behaviour: harvester starts harvesting immediately, with the facing glitching between the harvest animation (which has only 8) and the idle animation (which has 32).
New behaviour: harvester turns to one of the 8 primary facings and then starts harvesting
