### PR TITLE
Minimize INotifyKilled cost of Explodes and GivesExperience

### DIFF
--- a/OpenRA.Mods.Common/Traits/Explodes.cs
+++ b/OpenRA.Mods.Common/Traits/Explodes.cs
@@ -84,6 +84,9 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly IHealth health;
 		BuildingInfo buildingInfo;
+		Armament[] armaments;
+
+		bool anyArmaments;
 
 		public Explodes(ExplodesInfo info, Actor self)
 			: base(info)
@@ -94,6 +97,9 @@ namespace OpenRA.Mods.Common.Traits
 		protected override void Created(Actor self)
 		{
 			buildingInfo = self.Info.TraitInfoOrDefault<BuildingInfo>();
+			armaments = self.TraitsImplementing<Armament>().ToArray();
+			anyArmaments = armaments.Length > 0;
+
 			base.Created(self);
 		}
 
@@ -102,13 +108,14 @@ namespace OpenRA.Mods.Common.Traits
 			if (IsTraitDisabled || !self.IsInWorld)
 				return;
 
-			if (self.World.SharedRandom.Next(100) > Info.Chance)
+			var sharedRandom = self.World.SharedRandom.Next(100);
+			if (sharedRandom > Info.Chance)
 				return;
 
 			if (!Info.DeathTypes.IsEmpty && !e.Damage.DamageTypes.Overlaps(Info.DeathTypes))
 				return;
 
-			var weapon = ChooseWeaponForExplosion(self);
+			var weapon = ChooseWeaponForExplosion(self, sharedRandom);
 			if (weapon == null)
 				return;
 
@@ -129,24 +136,24 @@ namespace OpenRA.Mods.Common.Traits
 			weapon.Impact(Target.FromPos(self.CenterPosition), source);
 		}
 
-		WeaponInfo ChooseWeaponForExplosion(Actor self)
+		WeaponInfo ChooseWeaponForExplosion(Actor self, int sharedRandom)
 		{
-			var armaments = self.TraitsImplementing<Armament>();
-			if (!armaments.Any())
+			if (!anyArmaments)
 				return Info.WeaponInfo;
+			else if (sharedRandom > Info.LoadedChance)
+				return Info.EmptyWeaponInfo;
 
-			// TODO: EmptyWeapon should be removed in favour of conditions
-			var shouldExplode = !armaments.All(a => a.IsReloading);
-			var useFullExplosion = self.World.SharedRandom.Next(100) <= Info.LoadedChance;
-			return (shouldExplode && useFullExplosion) ? Info.WeaponInfo : Info.EmptyWeaponInfo;
+			// PERF: Avoid LINQ
+			foreach (var a in armaments)
+				if (!a.IsReloading)
+					return Info.WeaponInfo;
+
+			return Info.EmptyWeaponInfo;
 		}
 
 		void INotifyDamage.Damaged(Actor self, AttackInfo e)
 		{
-			if (IsTraitDisabled || !self.IsInWorld)
-				return;
-
-			if (Info.DamageThreshold == 0)
+			if (Info.DamageThreshold == 0 || IsTraitDisabled || !self.IsInWorld)
 				return;
 
 			if (!Info.DeathTypes.IsEmpty && !e.Damage.DamageTypes.Overlaps(Info.DeathTypes))

--- a/OpenRA.Mods.Common/Traits/Explodes.cs
+++ b/OpenRA.Mods.Common/Traits/Explodes.cs
@@ -86,8 +86,6 @@ namespace OpenRA.Mods.Common.Traits
 		BuildingInfo buildingInfo;
 		Armament[] armaments;
 
-		bool anyArmaments;
-
 		public Explodes(ExplodesInfo info, Actor self)
 			: base(info)
 		{
@@ -98,7 +96,6 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			buildingInfo = self.Info.TraitInfoOrDefault<BuildingInfo>();
 			armaments = self.TraitsImplementing<Armament>().ToArray();
-			anyArmaments = armaments.Length > 0;
 
 			base.Created(self);
 		}
@@ -108,14 +105,13 @@ namespace OpenRA.Mods.Common.Traits
 			if (IsTraitDisabled || !self.IsInWorld)
 				return;
 
-			var sharedRandom = self.World.SharedRandom.Next(100);
-			if (sharedRandom > Info.Chance)
+			if (self.World.SharedRandom.Next(100) > Info.Chance)
 				return;
 
 			if (!Info.DeathTypes.IsEmpty && !e.Damage.DamageTypes.Overlaps(Info.DeathTypes))
 				return;
 
-			var weapon = ChooseWeaponForExplosion(self, sharedRandom);
+			var weapon = ChooseWeaponForExplosion(self);
 			if (weapon == null)
 				return;
 
@@ -136,11 +132,11 @@ namespace OpenRA.Mods.Common.Traits
 			weapon.Impact(Target.FromPos(self.CenterPosition), source);
 		}
 
-		WeaponInfo ChooseWeaponForExplosion(Actor self, int sharedRandom)
+		WeaponInfo ChooseWeaponForExplosion(Actor self)
 		{
-			if (!anyArmaments)
+			if (armaments.Length == 0)
 				return Info.WeaponInfo;
-			else if (sharedRandom > Info.LoadedChance)
+			else if (self.World.SharedRandom.Next(100) > Info.LoadedChance)
 				return Info.EmptyWeaponInfo;
 
 			// PERF: Avoid LINQ

--- a/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
@@ -77,10 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyKilled.Killed(Actor self, AttackInfo e)
 		{
-			if (!enabled || IsTraitDisabled)
-				return;
-
-			if (!self.IsInWorld)
+			if (!enabled || IsTraitDisabled || !self.IsInWorld)
 				return;
 
 			if (self.World.SharedRandom.Next(100) > Info.Probability)


### PR DESCRIPTION
Disclaimer: No, I haven't performance-profiled this, the performance hit of actors dying fluctuates so strongly I'm not sure how to do that reliably.

I also don't expect this to make that much of a difference.

However, we already apply similar optimizations in many places, and out of all traits implementing `INotifyKilled` or `INotifyRemovedFromWorld` I checked, these were the only cases where I saw any optimization potential with at least a chance of making a difference at all (of course this doesn't really apply to the 'if' merge in `SpawnActorOnDeath`, I just threw that in while I was at it).

Tries to reduce #9142 a little.