### PR TITLE
PlayerStatistics ResolveOrder fixes

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -121,27 +121,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void ResolveOrder(Actor self, Order order)
 		{
-			switch (order.OrderString)
-			{
-				case "Chat":
-				case "HandshakeResponse":
-				case "PauseGame":
-				case "StartGame":
-				case "Disconnected":
-				case "ServerError":
-				case "AuthenticationError":
-				case "SyncLobbyInfo":
-				case "SyncClientInfo":
-				case "SyncLobbySlots":
-				case "SyncLobbyGlobalSettings":
-				case "SyncClientPing":
-				case "Ping":
-				case "Pong":
-					return;
-			}
-
 			if (order.OrderString.StartsWith("Dev"))
 				return;
+
 			OrderCount++;
 		}
 


### PR DESCRIPTION
~Some system order strings were changed or missing.~

> ResolveOrder (which is used by PlayerStatistics) is only called in the default case of UnitOrders.ProcessOrder:
https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Game/Network/UnitOrders.cs#L339-L343

Therefore removing the switch instead.