### PR TITLE
Fix a crash in Evacuation

### DIFF
--- a/mods/ra/maps/evacuation/evacuation.lua
+++ b/mods/ra/maps/evacuation/evacuation.lua
@@ -126,7 +126,7 @@ SendParatroopers = function()
 		local target = Map.CenterOfCell(para.drop)
 		local dir = target - Map.CenterOfCell(para.entry)
 
-		local aircraft = proxy.ActivateParatroopers(target, dir.facing)
+		local aircraft = proxy.ActivateParatroopers(target, dir.Facing)
 		Utils.Do(aircraft, function(a)
 			Trigger.OnPassengerExited(a, function(t, p)
 				IdleHunt(p)


### PR DESCRIPTION
Fixes a crash reported on Discord. "Facing" needs to be spelled with a capital F: https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Game/WVec.cs#L153