### PR TITLE
More Mobile trait look-up optimizations

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -52,7 +52,8 @@ namespace OpenRA.Mods.Common.Activities
 		// Ignores lane bias and nearby units
 		public Move(Actor self, CPos destination, Color? targetLineColor = null)
 		{
-			mobile = self.Trait<Mobile>();
+			// PERF: Because we can be sure that OccupiesSpace is Mobile here, we can save some performance by avoiding querying for the trait.
+			mobile = (Mobile)self.OccupiesSpace;
 
 			getPath = check =>
 			{
@@ -72,7 +73,8 @@ namespace OpenRA.Mods.Common.Activities
 		public Move(Actor self, CPos destination, WDist nearEnough, Actor ignoreActor = null, bool evaluateNearestMovableCell = false,
 			Color? targetLineColor = null)
 		{
-			mobile = self.Trait<Mobile>();
+			// PERF: Because we can be sure that OccupiesSpace is Mobile here, we can save some performance by avoiding querying for the trait.
+			mobile = (Mobile)self.OccupiesSpace;
 
 			getPath = check =>
 			{
@@ -93,7 +95,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Move(Actor self, CPos destination, SubCell subCell, WDist nearEnough, Color? targetLineColor = null)
 		{
-			mobile = self.Trait<Mobile>();
+			// PERF: Because we can be sure that OccupiesSpace is Mobile here, we can save some performance by avoiding querying for the trait.
+			mobile = (Mobile)self.OccupiesSpace;
 
 			getPath = check => mobile.Pathfinder.FindUnitPathToRange(
 				mobile.FromCell, subCell, self.World.Map.CenterOfSubCell(destination, subCell), nearEnough, self, check);
@@ -105,7 +108,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Move(Actor self, Target target, WDist range, Color? targetLineColor = null)
 		{
-			mobile = self.Trait<Mobile>();
+			// PERF: Because we can be sure that OccupiesSpace is Mobile here, we can save some performance by avoiding querying for the trait.
+			mobile = (Mobile)self.OccupiesSpace;
 
 			getPath = check =>
 			{
@@ -123,7 +127,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Move(Actor self, Func<BlockedByActor, List<CPos>> getPath, Color? targetLineColor = null)
 		{
-			mobile = self.Trait<Mobile>();
+			// PERF: Because we can be sure that OccupiesSpace is Mobile here, we can save some performance by avoiding querying for the trait.
+			mobile = (Mobile)self.OccupiesSpace;
 
 			this.getPath = getPath;
 

--- a/OpenRA.Mods.Common/Pathfinder/BasePathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/BasePathSearch.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 			// Determine the minimum possible cost for moving horizontally between cells based on terrain speeds.
 			// The minimum possible cost diagonally is then Sqrt(2) times more costly.
-			cellCost = graph.Actor.Trait<Mobile>().Locomotor.Info.TerrainSpeeds.Values.Min(ti => ti.Cost);
+			cellCost = ((Mobile)graph.Actor.OccupiesSpace).Info.LocomotorInfo.TerrainSpeeds.Values.Min(ti => ti.Cost);
 			diagonalCellCost = cellCost * 141421 / 100000;
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -348,7 +348,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (check <= BlockedByActor.Immovable && cellFlag.HasCellFlag(CellFlag.HasMovableActor) &&
 				actor.Owner.Stances[otherActor.Owner] == Stance.Ally)
 			{
-				var mobile = otherActor.TraitOrDefault<Mobile>();
+				var mobile = otherActor.OccupiesSpace as Mobile;
 				if (mobile != null && !mobile.IsTraitDisabled && !mobile.IsTraitPaused && !mobile.IsImmovable)
 					return false;
 			}
@@ -369,7 +369,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (cellFlag.HasCellFlag(CellFlag.HasTransitOnlyActor))
 			{
 				// Transit only tiles should not block movement
-				var building = otherActor.TraitOrDefault<Building>();
+				var building = otherActor.OccupiesSpace as Building;
 				if (building != null && building.TransitOnlyCells().Contains(cell))
 					return false;
 			}


### PR DESCRIPTION
Not profiled, but we know from #18205 approximately how much the saving per look-up is.

Commit 1 is mostly to bring down burst look-up cost when giving large armies move orders, the other two should help a little during pathing.