### PR TITLE
Fixed out of map bounds aircraft crashing on isometric mods

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -853,6 +853,9 @@ namespace OpenRA
 			var cell = CellContaining(pos);
 			var offset = pos - CenterOfCell(cell);
 
+			if (!Ramp.Contains(cell))
+				return new WDist(offset.Z);
+
 			var ramp = Ramp[cell];
 			if (ramp != 0)
 			{


### PR DESCRIPTION
Fixes a crash reported by @GraionDilach on Discord. Followup of https://github.com/OpenRA/OpenRA/pull/17990