### PR TITLE
Convert projectile facings to WAngle

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -24,8 +24,8 @@ namespace OpenRA.GameRules
 		public int[] DamageModifiers;
 		public int[] InaccuracyModifiers;
 		public int[] RangeModifiers;
-		public int Facing;
-		public Func<int> CurrentMuzzleFacing;
+		public WAngle Facing;
+		public Func<WAngle> CurrentMuzzleFacing;
 		public WPos Source;
 		public Func<WPos> CurrentSource;
 		public Actor SourceActor;

--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		WPos target;
 
 		int length;
-		int towardsTargetFacing;
+		WAngle towardsTargetFacing;
 		int headTicks;
 		int tailTicks;
 		bool isHeadTravelling = true;
@@ -133,11 +133,11 @@ namespace OpenRA.Mods.Common.Projectiles
 				target += WVec.FromPDF(world.SharedRandom, 2) * maxOffset / 1024;
 			}
 
-			towardsTargetFacing = (target - headPos).Yaw.Facing;
+			towardsTargetFacing = (target - headPos).Yaw;
 
 			// Update the target position with the range we shoot beyond the target by
 			// I.e. we can deliberately overshoot, so aim for that position
-			var dir = new WVec(0, -1024, 0).Rotate(WRot.FromFacing(towardsTargetFacing));
+			var dir = new WVec(0, -1024, 0).Rotate(WRot.FromYaw(towardsTargetFacing));
 			target += dir * info.BeyondTargetRange.Length / 1024;
 
 			length = Math.Max((target - headPos).Length / speed.Length, 1);
@@ -160,11 +160,11 @@ namespace OpenRA.Mods.Common.Projectiles
 				else
 				{
 					target = guidedTargetPos;
-					towardsTargetFacing = (target - args.Source).Yaw.Facing;
+					towardsTargetFacing = (target - args.Source).Yaw;
 
 					// Update the target position with the range we shoot beyond the target by
 					// I.e. we can deliberately overshoot, so aim for that position
-					var dir = new WVec(0, -1024, 0).Rotate(WRot.FromFacing(towardsTargetFacing));
+					var dir = new WVec(0, -1024, 0).Rotate(WRot.FromYaw(towardsTargetFacing));
 					target += dir * info.BeyondTargetRange.Length / 1024;
 				}
 			}

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -111,7 +111,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		readonly BulletInfo info;
 		readonly ProjectileArgs args;
 		readonly Animation anim;
-		readonly int facing;
+		readonly WAngle facing;
 		readonly WAngle angle;
 		readonly WDist speed;
 		readonly string trailPalette;
@@ -156,7 +156,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			if (info.AirburstAltitude > WDist.Zero)
 				target += new WVec(WDist.Zero, WDist.Zero, info.AirburstAltitude);
 
-			facing = (target - pos).Yaw.Facing;
+			facing = (target - pos).Yaw;
 			length = Math.Max((target - pos).Length / speed.Length, 1);
 
 			if (!string.IsNullOrEmpty(info.Image))
@@ -184,14 +184,14 @@ namespace OpenRA.Mods.Common.Projectiles
 			var at = (float)ticks / (length - 1);
 			var attitude = angle.Tan() * (1 - 2 * at) / (4 * 1024);
 
-			var u = (facing % 128) / 128f;
-			var scale = 512 * u * (1 - u);
+			var u = (facing.Angle % 512) / 512f;
+			var scale = 2048 * u * (1 - u);
 
-			var effective = (int)(facing < 128
-				? facing - scale * attitude
-				: facing + scale * attitude);
+			var effective = (int)(facing.Angle < 512
+				? facing.Angle - scale * attitude
+				: facing.Angle + scale * attitude);
 
-			return WAngle.FromFacing(effective);
+			return new WAngle(effective);
 		}
 
 		public void Tick(World world)

--- a/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
@@ -65,14 +65,13 @@ namespace OpenRA.Mods.Common.Projectiles
 			this.info = info;
 			this.args = args;
 			pos = args.Source;
-			var facing = WAngle.FromFacing(args.Facing);
 			var convertedVelocity = new WVec(info.Velocity.Y, -info.Velocity.X, info.Velocity.Z);
-			velocity = convertedVelocity.Rotate(WRot.FromYaw(facing));
+			velocity = convertedVelocity.Rotate(WRot.FromYaw(args.Facing));
 			acceleration = new WVec(info.Acceleration.Y, -info.Acceleration.X, info.Acceleration.Z);
 
 			if (!string.IsNullOrEmpty(info.Image))
 			{
-				anim = new Animation(args.SourceActor.World, info.Image, () => facing);
+				anim = new Animation(args.SourceActor.World, info.Image, () => args.Facing);
 
 				if (!string.IsNullOrEmpty(info.OpenSequence))
 					anim.PlayThen(info.OpenSequence, () => anim.PlayRepeating(info.Sequences.Random(args.SourceActor.World.SharedRandom)));

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -149,11 +149,8 @@ namespace OpenRA.Mods.Common.Projectiles
 			source = args.CurrentSource();
 
 			if (hasLaunchEffect && ticks == 0)
-			{
-				Func<WAngle> getMuzzleFacing = () => WAngle.FromFacing(args.CurrentMuzzleFacing());
-				world.AddFrameEndTask(w => w.Add(new SpriteEffect(args.CurrentSource, getMuzzleFacing, world,
+				world.AddFrameEndTask(w => w.Add(new SpriteEffect(args.CurrentSource, args.CurrentMuzzleFacing, world,
 					info.LaunchEffectImage, info.LaunchEffectSequence, info.LaunchEffectPalette)));
-			}
 
 			// Beam tracks target
 			if (info.TrackTarget && args.GuidedTarget.IsValidFor(args.SourceActor))

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -218,7 +218,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			this.args = args;
 
 			pos = args.Source;
-			hFacing = args.Facing;
+			hFacing = args.Facing.Facing;
 			gravity = new WVec(0, 0, -info.Gravity);
 			targetPosition = args.PassiveTarget;
 			rangeLimit = info.RangeLimit != WDist.Zero ? info.RangeLimit : args.Weapon.Range;

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -279,8 +279,8 @@ namespace OpenRA.Mods.Common.Traits
 				na.PreparingAttack(self, target, this, barrel);
 
 			Func<WPos> muzzlePosition = () => self.CenterPosition + MuzzleOffset(self, barrel);
-			var legacyFacing = MuzzleOrientation(self, barrel).Yaw.Angle / 4;
-			Func<int> legacyMuzzleFacing = () => MuzzleOrientation(self, barrel).Yaw.Angle / 4;
+			Func<WAngle> muzzleFacing = () => MuzzleOrientation(self, barrel).Yaw;
+			var muzzleOrientation = WRot.FromYaw(muzzleFacing());
 
 			var passiveTarget = Weapon.TargetActorCenter ? target.CenterPosition : target.Positions.PositionClosestTo(muzzlePosition());
 			var initialOffset = Weapon.FirstBurstTargetOffset;
@@ -288,7 +288,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				// We want this to match Armament.LocalOffset, so we need to convert it to forward, right, up
 				initialOffset = new WVec(initialOffset.Y, -initialOffset.X, initialOffset.Z);
-				passiveTarget += initialOffset.Rotate(WRot.FromFacing(legacyFacing));
+				passiveTarget += initialOffset.Rotate(muzzleOrientation);
 			}
 
 			var followingOffset = Weapon.FollowingBurstTargetOffset;
@@ -296,14 +296,14 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				// We want this to match Armament.LocalOffset, so we need to convert it to forward, right, up
 				followingOffset = new WVec(followingOffset.Y, -followingOffset.X, followingOffset.Z);
-				passiveTarget += ((Weapon.Burst - Burst) * followingOffset).Rotate(WRot.FromFacing(legacyFacing));
+				passiveTarget += ((Weapon.Burst - Burst) * followingOffset).Rotate(muzzleOrientation);
 			}
 
 			var args = new ProjectileArgs
 			{
 				Weapon = Weapon,
-				Facing = legacyFacing,
-				CurrentMuzzleFacing = legacyMuzzleFacing,
+				Facing = muzzleFacing(),
+				CurrentMuzzleFacing = muzzleFacing,
 
 				DamageModifiers = damageModifiers.ToArray(),
 

--- a/OpenRA.Mods.Common/Traits/ThrowsShrapnel.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsShrapnel.cs
@@ -68,8 +68,8 @@ namespace OpenRA.Mods.Common.Traits
 					var args = new ProjectileArgs
 					{
 						Weapon = wep,
-						Facing = self.World.SharedRandom.Next(-1, 255),
-						CurrentMuzzleFacing = () => 0,
+						Facing = new WAngle(self.World.SharedRandom.Next(1024)),
+						CurrentMuzzleFacing = () => WAngle.Zero,
 
 						DamageModifiers = self.TraitsImplementing<IFirepowerModifier>()
 							.Select(a => a.GetFirepowerModifier()).ToArray(),

--- a/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.Warheads
 			var projectileArgs = new ProjectileArgs
 			{
 				Weapon = weapon,
-				Facing = (map.CenterOfCell(targetCell) - target.CenterPosition).Yaw.Facing,
+				Facing = (map.CenterOfCell(targetCell) - target.CenterPosition).Yaw,
 
 				DamageModifiers = args.DamageModifiers,
 				InaccuracyModifiers = new int[0],

--- a/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
+++ b/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
@@ -133,8 +133,8 @@ namespace OpenRA.Mods.D2k.Traits
 				var args = new ProjectileArgs
 				{
 					Weapon = self.World.Map.Rules.Weapons[info.Weapon.ToLowerInvariant()],
-					Facing = 0,
-					CurrentMuzzleFacing = () => 0,
+					Facing = WAngle.Zero,
+					CurrentMuzzleFacing = () => WAngle.Zero,
 
 					DamageModifiers = self.TraitsImplementing<IFirepowerModifier>()
 						.Select(a => a.GetFirepowerModifier()).ToArray(),


### PR DESCRIPTION
Followup to #18058 and #18067. This one pushes `WAngle` through the `ProjectileArgs` and facing calculations in `Bullet` and `AreaBeam`.

`Missile` is going to have to stay with facing for the time being, as the various workarounds inside its implementation make me fairly confident that trying to touch this in any way short of a proper rewrite will cause more bugs and trouble than it is worth.