### PR TITLE
Fixed BeingCapturedCondition getting revoked from the wrong actor

### DIFF
--- a/OpenRA.Mods.Common/Traits/CaptureManager.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureManager.cs
@@ -262,7 +262,7 @@ namespace OpenRA.Mods.Common.Traits
 				capturingToken = self.RevokeCondition(capturingToken);
 
 			if (targetManager.beingCapturedToken != Actor.InvalidConditionToken)
-				targetManager.beingCapturedToken = self.RevokeCondition(targetManager.beingCapturedToken);
+				targetManager.beingCapturedToken = target.RevokeCondition(targetManager.beingCapturedToken);
 
 			currentTarget = null;
 			currentTargetManager = null;


### PR DESCRIPTION
as discovered by @GraionDilach on Discord. Fixes the following crash when capturing buildings:
```
Exception of type `System.InvalidOperationException`: Attempting to revoke condition with invalid token 1 for e6 54.
  at OpenRA.Actor.RevokeCondition (System.Int32 token) [0x0002d] in <2c68d1f93b0b4dbca886dccd2a13d343>:0 
  at OpenRA.Mods.Common.Traits.CaptureManager.CancelCapture (OpenRA.Actor self, OpenRA.Actor target, OpenRA.Mods.Common.Traits.CaptureManager targetManager) [0x00084] in <dde4544319fa48308eb9b678ec1dc14e>:0 
  at OpenRA.Mods.Common.Activities.CaptureActor.CancelCapture (OpenRA.Actor self) [0x00000] in <dde4544319fa48308eb9b678ec1dc14e>:0 
  at OpenRA.Mods.Common.Activities.CaptureActor.OnActorDispose (OpenRA.Actor self) [0x00000] in <dde4544319fa48308eb9b678ec1dc14e>:0 
  at OpenRA.Activities.Activity.OnActorDisposeOuter (OpenRA.Actor self) [0x00014] in <2c68d1f93b0b4dbca886dccd2a13d343>:0 
  at OpenRA.Actor.Dispose () [0x0000e] in <2c68d1f93b0b4dbca886dccd2a13d343>:0 
  at OpenRA.Mods.Common.Activities.CaptureActor+<>c__DisplayClass6_0.<DoCapture>b__0 (OpenRA.World w) [0x001f7] in <dde4544319fa48308eb9b678ec1dc14e>:0 
  at OpenRA.World.Tick () [0x001a9] in <2c68d1f93b0b4dbca886dccd2a13d343>:0 
  at OpenRA.Game.InnerLogicTick (OpenRA.Network.OrderManager orderManager) [0x001bc] in <2c68d1f93b0b4dbca886dccd2a13d343>:0 
  at OpenRA.Game.LogicTick () [0x0003e] in <2c68d1f93b0b4dbca886dccd2a13d343>:0 
  at OpenRA.Game.Loop () [0x000f1] in <2c68d1f93b0b4dbca886dccd2a13d343>:0 
  at OpenRA.Game.Run () [0x0003c] in <2c68d1f93b0b4dbca886dccd2a13d343>:0 
  at OpenRA.Game.InitializeAndRun (System.String[] args) [0x00010] in <2c68d1f93b0b4dbca886dccd2a13d343>:0 
  at OpenRA.Program.Main (System.String[] args) [0x00044] in <2c68d1f93b0b4dbca886dccd2a13d343>:0
```

Closes https://github.com/OpenRA/OpenRA/issues/18176.