### PR TITLE
Fix a crash with support powers and units without selection decorations

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -192,8 +192,9 @@ namespace OpenRA.Mods.Cnc.Traits
 					if (unit.CanBeViewedByPlayer(manager.Self.Owner))
 					{
 						var decorations = unit.TraitsImplementing<ISelectionDecorations>().FirstEnabledTraitOrDefault();
-						foreach (var d in decorations.RenderSelectionAnnotations(unit, wr, Color.Red))
-							yield return d;
+						if (decorations != null)
+							foreach (var d in decorations.RenderSelectionAnnotations(unit, wr, Color.Red))
+								yield return d;
 					}
 				}
 			}
@@ -318,8 +319,9 @@ namespace OpenRA.Mods.Cnc.Traits
 					if (unit.CanBeViewedByPlayer(manager.Self.Owner))
 					{
 						var decorations = unit.TraitsImplementing<ISelectionDecorations>().FirstEnabledTraitOrDefault();
-						foreach (var d in decorations.RenderSelectionAnnotations(unit, wr, Color.Red))
-							yield return d;
+						if (decorations != null)
+							foreach (var d in decorations.RenderSelectionAnnotations(unit, wr, Color.Red))
+								yield return d;
 					}
 				}
 			}

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
@@ -155,8 +155,9 @@ namespace OpenRA.Mods.Common.Traits
 				foreach (var unit in power.UnitsInRange(xy))
 				{
 					var decorations = unit.TraitsImplementing<ISelectionDecorations>().FirstEnabledTraitOrDefault();
-					foreach (var d in decorations.RenderSelectionAnnotations(unit, wr, Color.Red))
-						yield return d;
+					if (decorations != null)
+						foreach (var d in decorations.RenderSelectionAnnotations(unit, wr, Color.Red))
+							yield return d;
 				}
 			}
 


### PR DESCRIPTION
Testcase: Try to use Chronoshift on a husk.