### PR TITLE
Fix a crash in LegacyBridgeLayer

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/LegacyBridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/LegacyBridgeLayer.cs
@@ -89,9 +89,12 @@ namespace OpenRA.Mods.Common.Traits
 				// Where do we expect to find the subtile
 				var subtile = new CPos(ni + ind % template.Size.X, nj + ind / template.Size.X);
 
+				if (!mapTiles.Contains(subtile))
+					continue;
+
 				// This isn't the bridge you're looking for
 				var subti = mapTiles[subtile];
-				if (!mapTiles.Contains(subtile) || subti.Type != tile || subti.Index != ind)
+				if (subti.Type != tile || subti.Index != ind)
 					continue;
 
 				subTiles.Add(subtile, ind);


### PR DESCRIPTION
Fixes #18218. (Which was a regression from https://github.com/OpenRA/OpenRA/pull/17990#discussion_r433763856.)
Testcase: Start the map "Sidestep" of the RA mod.