### PR TITLE
Added automated uploads on new release to itch.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ before_deploy:
  - cd packaging
  - mkdir build
  - ./package-all.sh ${TRAVIS_TAG} ${PWD}/build/
+ - cd itch && ./upload.sh ${TRAVIS_TAG} ${PWD}/build/
 deploy:
   provider: releases
   api_key:

--- a/packaging/itch/upload.sh
+++ b/packaging/itch/upload.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+export GIT_TAG="$1"
+export BUILD_OUTPUT_DIR="$2"
+
+case "${GIT_TAG}" in
+	bleed)
+		exit
+		;;
+	next | playtest-*)
+		exit
+		;;
+	master | release-*)
+		;;
+	*)
+		echo "Unknown branch: $1"
+		exit
+		;;
+esac
+
+if command -v curl >/dev/null 2>&1; then
+	curl -L -o butler-linux-amd64.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
+else
+	wget -cq -O butler-linux-amd64.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
+fi
+
+unzip butler-linux-amd64.zip
+chmod +x butler
+./butler -V
+./butler login
+
+./butler push "${BUILD_OUTPUT_DIR}/OpenRA-${GIT_TAG}-x64.exe" "openra/openra:win" --userversion-file ../../VERSION
+./butler push --fix-permissions "${BUILD_OUTPUT_DIR}/OpenRA-${GIT_TAG}.dmg" "openra/openra:osx" --userversion-file ../../VERSION
+./butler push --fix-permissions "${BUILD_OUTPUT_DIR}/OpenRA-Dune-2000-x86_64.AppImage" "openra/openra:linux-d2k" --userversion-file ../../VERSION
+./butler push --fix-permissions "${BUILD_OUTPUT_DIR}/OpenRA-Red-Alert-x86_64.AppImage" "openra/openra:linux-ra" --userversion-file ../../VERSION
+./butler push --fix-permissions "${BUILD_OUTPUT_DIR}/OpenRA-Tiberian-Dawn-x86_64.AppImage" "openra/openra:linux-td" --userversion-file ../../VERSION


### PR DESCRIPTION
This automatically uploads new releases to https://openra.itch.io/openra and as you can see I used the latest release as test case. This addresses https://github.com/OpenRA/OpenRA/issues/14214 on Linux as the AppImages run out of the box already. We may need a portable installation for Mac/Windows for proper diff updating and https://itch.io/app compatibility.

Closes https://github.com/OpenRA/OpenRA/issues/11352.