### PR TITLE
Convert IFacing.Facing and TurnSpeed to WAngle.

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -69,8 +69,8 @@ namespace OpenRA
 			get
 			{
 				// TODO: Support non-zero pitch/roll in IFacing (IOrientation?)
-				var facingValue = facing != null ? facing.Facing : 0;
-				return new WRot(WAngle.Zero, WAngle.Zero, WAngle.FromFacing(facingValue));
+				var facingValue = facing != null ? facing.Facing : WAngle.Zero;
+				return new WRot(WAngle.Zero, WAngle.Zero, facingValue);
 			}
 		}
 

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -941,13 +941,13 @@ namespace OpenRA
 			return projectedHeight[(MPos)puv];
 		}
 
-		public int FacingBetween(CPos cell, CPos towards, int fallbackfacing)
+		public WAngle FacingBetween(CPos cell, CPos towards, WAngle fallbackfacing)
 		{
 			var delta = CenterOfCell(towards) - CenterOfCell(cell);
 			if (delta.HorizontalLengthSquared == 0)
 				return fallbackfacing;
 
-			return delta.Yaw.Facing;
+			return delta.Yaw;
 		}
 
 		public void Resize(int width, int height)

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -318,7 +318,7 @@ namespace OpenRA.Traits
 	public interface IFacing
 	{
 		int TurnSpeed { get; }
-		int Facing { get; set; }
+		WAngle Facing { get; set; }
 	}
 
 	public interface IFacingInfo : ITraitInfoInterface { int GetInitialFacing(); }

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -317,7 +317,7 @@ namespace OpenRA.Traits
 
 	public interface IFacing
 	{
-		int TurnSpeed { get; }
+		WAngle TurnSpeed { get; }
 		WAngle Facing { get; set; }
 	}
 

--- a/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
+++ b/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
@@ -132,7 +132,7 @@ namespace OpenRA.Mods.Cnc.Activities
 
 			var destination = self.World.Map.CenterOfSubCell(target.Actor.Location, targetSubcell);
 			var origin = self.World.Map.CenterOfSubCell(self.Location, mobile.FromSubCell);
-			var desiredFacing = (destination - origin).Yaw.Facing;
+			var desiredFacing = (destination - origin).Yaw;
 			if (mobile.Facing != desiredFacing)
 			{
 				QueueChild(new Turn(self, desiredFacing));

--- a/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		readonly Cargo cargo;
 		readonly BodyOrientation body;
 		readonly IFacing facing;
-		int cachedFacing;
+		WAngle cachedFacing;
 
 		Dictionary<Actor, IActorPreview[]> previews = new Dictionary<Actor, IActorPreview[]>();
 
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 				var passengerInits = new TypeDictionary()
 				{
 					new OwnerInit(p.Owner),
-					new DynamicFacingInit(() => body.QuantizeFacing(WAngle.FromFacing(facing.Facing)).Facing),
+					new DynamicFacingInit(() => body.QuantizeFacing(facing.Facing).Facing),
 				};
 
 				foreach (var api in p.TraitsImplementing<IActorPreviewInitModifier>())

--- a/OpenRA.Mods.Cnc/Traits/Render/WithGunboatBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithGunboatBody.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 
 		void ITick.Tick(Actor self)
 		{
-			if (facing.Facing <= 128)
+			if (facing.Facing.Angle <= 512)
 			{
 				var left = NormalizeSequence(self, info.LeftSequence);
 				if (DefaultAnimation.CurrentSequence.Name != left)

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public CPos TopLeft { get { return self.World.Map.CellContaining(CenterPosition); } }
 
 		// Isn't used anyway
-		public int TurnSpeed { get { return 255; } }
+		public WAngle TurnSpeed { get { return WAngle.Zero; } }
 
 		CPos cachedLocation;
 

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -58,12 +58,14 @@ namespace OpenRA.Mods.Cnc.Traits
 	{
 		public readonly TDGunboatInfo Info;
 		readonly Actor self;
+		static readonly WAngle Left = new WAngle(256);
+		static readonly WAngle Right = new WAngle(768);
 
 		IEnumerable<int> speedModifiers;
 		INotifyVisualPositionChanged[] notifyVisualPositionChanged;
 
 		[Sync]
-		public int Facing { get; set; }
+		public WAngle Facing { get; set; }
 
 		[Sync]
 		public WPos CenterPosition { get; private set; }
@@ -88,11 +90,11 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (centerPositionInit != null)
 				SetPosition(self, centerPositionInit.Value);
 
-			Facing = init.GetValue<FacingInit, int>(info, Info.GetInitialFacing());
+			Facing = WAngle.FromFacing(init.GetValue<FacingInit, int>(info, Info.GetInitialFacing()));
 
 			// Prevent mappers from setting bogus facings
-			if (Facing != 64 && Facing != 192)
-				Facing = Facing > 127 ? 192 : 64;
+			if (Facing != Left && Facing != Right)
+				Facing = Facing.Angle > 511 ? Right : Left;
 		}
 
 		void INotifyCreated.Created(Actor self)
@@ -128,10 +130,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		void Turn()
 		{
-			if (Facing == 64)
-				Facing = 192;
-			else
-				Facing = 64;
+			Facing = Facing == Left ? Right : Left;
 		}
 
 		int MovementSpeed
@@ -141,20 +140,20 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public Pair<CPos, SubCell>[] OccupiedCells() { return new[] { Pair.New(TopLeft, SubCell.FullCell) }; }
 
-		WVec MoveStep(int facing)
+		WVec MoveStep(WAngle facing)
 		{
 			return MoveStep(MovementSpeed, facing);
 		}
 
-		WVec MoveStep(int speed, int facing)
+		WVec MoveStep(int speed, WAngle facing)
 		{
-			var dir = new WVec(0, -1024, 0).Rotate(WRot.FromFacing(facing));
+			var dir = new WVec(0, -1024, 0).Rotate(WRot.FromYaw(facing));
 			return speed * dir / 1024;
 		}
 
 		void IDeathActorInitModifier.ModifyDeathActorInit(Actor self, TypeDictionary init)
 		{
-			init.Add(new FacingInit(Facing));
+			init.Add(new FacingInit(Facing.Facing));
 		}
 
 		public bool CanExistInCell(CPos cell) { return true; }
@@ -221,7 +220,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		void IActorPreviewInitModifier.ModifyActorPreviewInit(Actor self, TypeDictionary inits)
 		{
 			if (!inits.Contains<DynamicFacingInit>() && !inits.Contains<FacingInit>())
-				inits.Add(new DynamicFacingInit(() => Facing));
+				inits.Add(new DynamicFacingInit(() => Facing.Facing));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -60,14 +60,14 @@ namespace OpenRA.Mods.Common.Activities
 			this.minRange = minRange;
 		}
 
-		public static void FlyTick(Actor self, Aircraft aircraft, WAngle desiredFacing, WDist desiredAltitude, WVec moveOverride, int turnSpeedOverride = -1)
+		public static void FlyTick(Actor self, Aircraft aircraft, WAngle desiredFacing, WDist desiredAltitude, WVec moveOverride, WAngle? turnSpeedOverride = null)
 		{
 			var dat = self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition);
 			var move = aircraft.Info.CanSlide ? aircraft.FlyStep(desiredFacing) : aircraft.FlyStep(aircraft.Facing);
 			if (moveOverride != WVec.Zero)
 				move = moveOverride;
 
-			var turnSpeed = turnSpeedOverride > -1 ? turnSpeedOverride : aircraft.TurnSpeed;
+			var turnSpeed = turnSpeedOverride ?? aircraft.TurnSpeed;
 			aircraft.Facing = Util.TickFacing(aircraft.Facing, desiredFacing, turnSpeed);
 
 			// Note: we assume that if move.Z is not zero, it's intentional and we want to move in that vertical direction instead of towards desiredAltitude.
@@ -83,18 +83,18 @@ namespace OpenRA.Mods.Common.Activities
 			aircraft.SetPosition(self, aircraft.CenterPosition + move);
 		}
 
-		public static void FlyTick(Actor self, Aircraft aircraft, WAngle desiredFacing, WDist desiredAltitude, int turnSpeedOverride = -1)
+		public static void FlyTick(Actor self, Aircraft aircraft, WAngle desiredFacing, WDist desiredAltitude, WAngle? turnSpeedOverride = null)
 		{
 			FlyTick(self, aircraft, desiredFacing, desiredAltitude, WVec.Zero, turnSpeedOverride);
 		}
 
 		// Should only be used for vertical-only movement, usually VTOL take-off or land. Terrain-induced altitude changes should always be handled by FlyTick.
-		public static bool VerticalTakeOffOrLandTick(Actor self, Aircraft aircraft, WAngle desiredFacing, WDist desiredAltitude, int turnSpeedOverride = -1)
+		public static bool VerticalTakeOffOrLandTick(Actor self, Aircraft aircraft, WAngle desiredFacing, WDist desiredAltitude, WAngle? turnSpeedOverride = null)
 		{
 			var dat = self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition);
 			var move = WVec.Zero;
 
-			var turnSpeed = turnSpeedOverride > -1 ? turnSpeedOverride : aircraft.TurnSpeed;
+			var turnSpeed = turnSpeedOverride ?? aircraft.TurnSpeed;
 			aircraft.Facing = Util.TickFacing(aircraft.Facing, desiredFacing, turnSpeed);
 
 			if (dat != desiredAltitude)
@@ -261,12 +261,12 @@ namespace OpenRA.Mods.Common.Activities
 				yield return new TargetLineNode(useLastVisibleTarget ? lastVisibleTarget : target, targetLineColor.Value);
 		}
 
-		public static int CalculateTurnRadius(int speed, int turnSpeed)
+		public static int CalculateTurnRadius(int speed, WAngle turnSpeed)
 		{
 			// turnSpeed -> divide into 256 to get the number of ticks per complete rotation
 			// speed -> multiply to get distance travelled per rotation (circumference)
 			// 180 -> divide by 2*pi to get the turn radius: 180==1024/(2*pi), with some extra leeway
-			return turnSpeed > 0 ? 180 * speed / turnSpeed : 0;
+			return turnSpeed.Angle > 0 ? 180 * speed / turnSpeed.Angle : 0;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -170,7 +170,7 @@ namespace OpenRA.Mods.Common.Activities
 				QueueChild(new FlyAttackRun(self, target, lastVisibleMaximumRange));
 
 			// Turn to face the target if required.
-			else if (!attackAircraft.TargetInFiringArc(self, target, attackAircraft.Info.FacingTolerance))
+			else if (!attackAircraft.TargetInFiringArc(self, target, 4 * attackAircraft.Info.FacingTolerance))
 				aircraft.Facing = Util.TickFacing(aircraft.Facing, desiredFacing, aircraft.TurnSpeed);
 
 			return false;

--- a/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
@@ -20,13 +20,13 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly Aircraft aircraft;
 		readonly INotifyIdle[] tickIdles;
-		readonly int turnSpeed;
+		readonly WAngle turnSpeed;
 		int remainingTicks;
 
 		public FlyIdle(Actor self, int ticks = -1, bool tickIdle = true)
 		{
 			aircraft = self.Trait<Aircraft>();
-			turnSpeed = aircraft.IdleTurnSpeed > -1 ? aircraft.IdleTurnSpeed : aircraft.TurnSpeed;
+			turnSpeed = aircraft.IdleTurnSpeed ?? aircraft.TurnSpeed;
 			remainingTicks = ticks;
 
 			if (tickIdle)

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -144,7 +144,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				if (desiredFacing.HasValue && desiredFacing.Value != aircraft.Facing)
 				{
-					QueueChild(new Turn(self, desiredFacing.Value.Facing));
+					QueueChild(new Turn(self, desiredFacing.Value));
 					return false;
 				}
 			}

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -198,9 +198,9 @@ namespace OpenRA.Mods.Common.Activities
 				return AttackStatus.NeedsToMove;
 			}
 
-			if (!attack.TargetInFiringArc(self, target, attack.Info.FacingTolerance))
+			if (!attack.TargetInFiringArc(self, target, 4 * attack.Info.FacingTolerance))
 			{
-				var desiredFacing = (attack.GetTargetPosition(pos, target) - pos).Yaw.Facing;
+				var desiredFacing = (attack.GetTargetPosition(pos, target) - pos).Yaw;
 				attackStatus |= AttackStatus.NeedsToTurn;
 				QueueChild(new Turn(self, desiredFacing));
 				return AttackStatus.NeedsToTurn;

--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.Activities
 				var carryableFacing = carryall.Carryable.Trait<IFacing>();
 				var facingDelta = facing.Facing - carryableFacing.Facing;
 				foreach (var t in carryall.Carryable.TraitsImplementing<Turreted>())
-					t.TurretFacing += facingDelta;
+					t.TurretFacing += facingDelta.Facing;
 
 				carryableFacing.Facing = facing.Facing;
 

--- a/OpenRA.Mods.Common/Activities/DeployForGrantedCondition.cs
+++ b/OpenRA.Mods.Common/Activities/DeployForGrantedCondition.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			// Turn to the required facing.
 			if (deploy.DeployState == DeployState.Undeployed && deploy.Info.Facing != -1 && canTurn && !moving)
-				QueueChild(new Turn(self, deploy.Info.Facing));
+				QueueChild(new Turn(self, WAngle.FromFacing(deploy.Info.Facing)));
 		}
 
 		public override bool Tick(Actor self)

--- a/OpenRA.Mods.Common/Activities/HarvestResource.cs
+++ b/OpenRA.Mods.Common/Activities/HarvestResource.cs
@@ -72,11 +72,11 @@ namespace OpenRA.Mods.Common.Activities
 			// Turn to one of the harvestable facings
 			if (harvInfo.HarvestFacings != 0)
 			{
-				var current = WAngle.FromFacing(facing.Facing);
+				var current = facing.Facing;
 				var desired = body.QuantizeFacing(current, harvInfo.HarvestFacings);
 				if (desired != current)
 				{
-					QueueChild(new Turn(self, desired.Facing));
+					QueueChild(new Turn(self, desired));
 					return false;
 				}
 			}

--- a/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				case DockingState.Turn:
 					dockingState = DockingState.Dock;
-					QueueChild(new Turn(self, DockAngle));
+					QueueChild(new Turn(self, WAngle.FromFacing(DockAngle)));
 					if (IsDragRequired)
 						QueueChild(new Drag(self, StartDrag, EndDrag, DragLength));
 					return false;

--- a/OpenRA.Mods.Common/Activities/Move/Drag.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Drag.cs
@@ -24,9 +24,9 @@ namespace OpenRA.Mods.Common.Activities
 		WPos start, end;
 		int length;
 		int ticks = 0;
-		int desiredFacing;
+		WAngle? desiredFacing;
 
-		public Drag(Actor self, WPos start, WPos end, int length, int facing = -1)
+		public Drag(Actor self, WPos start, WPos end, int length, WAngle? facing = null)
 		{
 			positionable = self.Trait<IPositionable>();
 			disableable = self.TraitOrDefault<IMove>() as IDisabledTrait;
@@ -39,8 +39,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected override void OnFirstRun(Actor self)
 		{
-			if (desiredFacing != -1)
-				QueueChild(new Turn(self, desiredFacing));
+			if (desiredFacing.HasValue)
+				QueueChild(new Turn(self, desiredFacing.Value));
 		}
 
 		public override bool Tick(Actor self)

--- a/OpenRA.Mods.Common/Activities/Move/VisualMoveIntoTarget.cs
+++ b/OpenRA.Mods.Common/Activities/Move/VisualMoveIntoTarget.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Turn if required
 			var delta = targetPos - currentPos;
-			var facing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : mobile.Facing;
+			var facing = delta.HorizontalLengthSquared != 0 ? delta.Yaw : mobile.Facing;
 			if (facing != mobile.Facing)
 			{
 				mobile.Facing = Util.TickFacing(mobile.Facing, facing, mobile.TurnSpeed);

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Activities
 					ChildActivity.Cancel(self);
 
 					var localOffset = carryall.OffsetForCarryable(self, cargo).Rotate(carryableBody.QuantizeOrientation(self, cargo.Orientation));
-					QueueChild(new Land(self, Target.FromActor(cargo), -carryableBody.LocalToWorld(localOffset), WAngle.FromFacing(carryableFacing.Facing)));
+					QueueChild(new Land(self, Target.FromActor(cargo), -carryableBody.LocalToWorld(localOffset), carryableFacing.Facing));
 
 					// Pause briefly before attachment for visual effect
 					if (delay > 0)

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		public readonly string ToActor;
 		public CVec Offset = CVec.Zero;
-		public int Facing = 96;
+		public WAngle Facing = WAngle.FromFacing(96);
 		public string[] Sounds = { };
 		public string Notification = null;
 		public int ForceHealthPercentage = 0;
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.Activities
 				{
 					new LocationInit(self.Location + Offset),
 					new OwnerInit(self.Owner),
-					new FacingInit(Facing),
+					new FacingInit(Facing.Facing),
 				};
 
 				if (SkipMakeAnims)

--- a/OpenRA.Mods.Common/Activities/Turn.cs
+++ b/OpenRA.Mods.Common/Activities/Turn.cs
@@ -19,9 +19,9 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly Mobile mobile;
 		readonly IFacing facing;
-		readonly int desiredFacing;
+		readonly WAngle desiredFacing;
 
-		public Turn(Actor self, int desiredFacing)
+		public Turn(Actor self, WAngle desiredFacing)
 		{
 			mobile = self.TraitOrDefault<Mobile>();
 			facing = self.Trait<IFacing>();

--- a/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Scripting
 			}
 
 			if (entryLocation.HasValue && nextLocation.HasValue)
-				initDict.Add(new FacingInit(Context.World.Map.FacingBetween(CPos.Zero, CPos.Zero + (nextLocation.Value - entryLocation.Value), 0)));
+				initDict.Add(new FacingInit(Context.World.Map.FacingBetween(CPos.Zero, CPos.Zero + (nextLocation.Value - entryLocation.Value), WAngle.Zero).Facing));
 
 			var actor = Context.World.CreateActor(addToWorld, actorType, initDict);
 

--- a/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.Common.Scripting
 				if (facing == null)
 					throw new LuaException("Actor '{0}' doesn't define a facing".F(Self));
 
-				return facing.Facing;
+				return facing.Facing.Facing;
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -209,13 +209,7 @@ namespace OpenRA.Mods.Common.Traits
 		IOverrideAircraftLanding overrideAircraftLanding;
 
 		[Sync]
-		public WAngle Facing;
-
-		int IFacing.Facing
-		{
-			get { return Facing.Facing; }
-			set { Facing = WAngle.FromFacing(value); }
-		}
+		public WAngle Facing { get; set; }
 
 		[Sync]
 		public WPos CenterPosition { get; private set; }

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -215,8 +215,8 @@ namespace OpenRA.Mods.Common.Traits
 		public WPos CenterPosition { get; private set; }
 
 		public CPos TopLeft { get { return self.World.Map.CellContaining(CenterPosition); } }
-		public int TurnSpeed { get { return !IsTraitDisabled && !IsTraitPaused ? 4 * Info.TurnSpeed : 0; } }
-		public int IdleTurnSpeed { get { return Info.IdleTurnSpeed != -1 ? 4 * Info.IdleTurnSpeed : -1; } }
+		public WAngle TurnSpeed { get { return !IsTraitDisabled && !IsTraitPaused ? new WAngle(4 * Info.TurnSpeed) : WAngle.Zero; } }
+		public WAngle? IdleTurnSpeed { get { return Info.IdleTurnSpeed != -1 ? new WAngle(4 * Info.IdleTurnSpeed) : (WAngle?)null; } }
 
 		public Actor ReservedActor { get; private set; }
 		public bool MayYieldReservation { get; private set; }

--- a/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!base.CanAttack(self, target))
 				return false;
 
-			return TargetInFiringArc(self, target, base.Info.FacingTolerance);
+			return TargetInFiringArc(self, target, 4 * base.Info.FacingTolerance);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			inAttackRange = false;
 
-			facingTarget = TargetInFiringArc(self, target, info.FacingTolerance);
+			facingTarget = TargetInFiringArc(self, target, 4 * info.FacingTolerance);
 
 			foreach (var a in Armaments)
 			{

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -139,7 +139,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (delta.HorizontalLengthSquared == 0)
 				return true;
 
-			return Util.FacingWithinTolerance(facing.Facing, delta.Yaw.Facing, facingTolerance);
+			return Util.FacingWithinTolerance(facing.Facing, delta.Yaw, facingTolerance);
 		}
 
 		protected virtual bool CanAttack(Actor self, Target target)

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Traits
 			var armaments = ChooseArmamentsForTarget(target, forceAttack);
 			foreach (var a in armaments)
 				if (target.IsInRange(pos, a.MaxRange()) && (a.Weapon.MinRange == WDist.Zero || !target.IsInRange(pos, a.Weapon.MinRange)))
-					if (TargetInFiringArc(self, target, Info.FacingTolerance))
+					if (TargetInFiringArc(self, target, 4 * Info.FacingTolerance))
 						return true;
 
 			return false;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!base.CanAttack(self, target))
 				return false;
 
-			return TargetInFiringArc(self, target, Info.FacingTolerance);
+			return TargetInFiringArc(self, target, 4 * Info.FacingTolerance);
 		}
 
 		public override Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Mods.Common.Traits
 		FirePort SelectFirePort(Actor self, WAngle targetYaw)
 		{
 			// Pick a random port that faces the target
-			var bodyYaw = facing != null ? WAngle.FromFacing(facing.Facing) : WAngle.Zero;
+			var bodyYaw = facing != null ? facing.Facing : WAngle.Zero;
 			var indices = Enumerable.Range(0, Info.Ports.Length).Shuffle(self.World.SharedRandom);
 			foreach (var i in indices)
 			{
@@ -161,8 +161,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (port == null)
 					return;
 
-				var muzzleFacing = targetYaw.Facing;
-				paxFacing[a.Actor].Facing = muzzleFacing;
+				paxFacing[a.Actor].Facing = targetYaw;
 				paxPos[a.Actor].SetVisualPosition(a.Actor, pos + PortOffset(self, port));
 
 				var barrel = a.CheckFire(a.Actor, facing, target);

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -415,7 +415,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!armaments.Any())
 					continue;
 
-				if (!allowTurn && !ab.TargetInFiringArc(self, target, ab.Info.FacingTolerance))
+				if (!allowTurn && !ab.TargetInFiringArc(self, target, 4 * ab.Info.FacingTolerance))
 					continue;
 
 				// Evaluate whether we want to target this actor

--- a/OpenRA.Mods.Common/Traits/Buildings/FreeActorWithDelivery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FreeActorWithDelivery.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var spawn = self.World.Map.CenterOfCell(location);
 
-			var initialFacing = self.World.Map.FacingBetween(location, self.Location, 0);
+			var initialFacing = self.World.Map.FacingBetween(location, self.Location, WAngle.Zero);
 
 			// If aircraft, spawn at cruise altitude
 			var aircraftInfo = self.World.Map.Rules.Actors[deliveringActorName.ToLowerInvariant()].TraitInfoOrDefault<AircraftInfo>();
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Traits
 				new LocationInit(location),
 				new CenterPositionInit(spawn),
 				new OwnerInit(self.Owner),
-				new FacingInit(initialFacing)
+				new FacingInit(initialFacing.Facing)
 			});
 
 			// Create delivered actor

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -370,10 +370,10 @@ namespace OpenRA.Mods.Common.Traits
 
 			var passengerFacing = passenger.TraitOrDefault<IFacing>();
 			if (passengerFacing != null)
-				passengerFacing.Facing = facing.Value.Facing + Info.PassengerFacing;
+				passengerFacing.Facing = facing.Value.Facing + WAngle.FromFacing(Info.PassengerFacing);
 
 			foreach (var t in passenger.TraitsImplementing<Turreted>())
-				t.TurretFacing = facing.Value.Facing + Info.PassengerFacing;
+				t.TurretFacing = facing.Value.Facing.Facing + Info.PassengerFacing;
 		}
 
 		public void Load(Actor self, Actor a)

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Actor Carryable { get; private set; }
 		public CarryallState State { get; private set; }
 
-		int cachedFacing;
+		WAngle cachedFacing;
 		IActorPreview[] carryablePreview;
 		HashSet<string> landableTerrainTypes;
 
@@ -225,7 +225,7 @@ namespace OpenRA.Mods.Common.Traits
 					var carryableInits = new TypeDictionary()
 					{
 						new OwnerInit(Carryable.Owner),
-						new DynamicFacingInit(() => facing.Facing),
+						new DynamicFacingInit(() => facing.Facing.Facing),
 					};
 
 					foreach (var api in Carryable.TraitsImplementing<IActorPreviewInitModifier>())

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -126,19 +126,19 @@ namespace OpenRA.Mods.Common.Traits
 					break;
 				case DeployState.Deploying:
 					if (canTurn)
-						self.Trait<IFacing>().Facing = Info.Facing;
+						self.Trait<IFacing>().Facing = WAngle.FromFacing(Info.Facing);
 
 					Deploy(true);
 					break;
 				case DeployState.Deployed:
 					if (canTurn)
-						self.Trait<IFacing>().Facing = Info.Facing;
+						self.Trait<IFacing>().Facing = WAngle.FromFacing(Info.Facing);
 
 					OnDeployCompleted();
 					break;
 				case DeployState.Undeploying:
 					if (canTurn)
-						self.Trait<IFacing>().Facing = Info.Facing;
+						self.Trait<IFacing>().Facing = WAngle.FromFacing(Info.Facing);
 
 					Undeploy(true);
 					break;

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 		public WPos CenterPosition { get; private set; }
 
 		[Sync]
-		public int Facing { get; set; }
+		public WAngle Facing { get; set; }
 
 		public int TurnSpeed { get { return 0; } }
 
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			TopLeft = init.GetValue<LocationInit, CPos>(info);
 			CenterPosition = init.GetValue<CenterPositionInit, WPos>(info, init.World.Map.CenterOfCell(TopLeft));
-			Facing = init.GetValue<FacingInit, int>(info, 128);
+			Facing = WAngle.FromFacing(init.GetValue<FacingInit, int>(info, 128));
 
 			dragSpeed = init.GetValue<HuskSpeedInit, int>(info, 0);
 			finalPosition = init.World.Map.CenterOfCell(TopLeft);
@@ -163,7 +163,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void IDeathActorInitModifier.ModifyDeathActorInit(Actor self, TypeDictionary init)
 		{
-			init.Add(new FacingInit(Facing));
+			init.Add(new FacingInit(Facing.Facing));
 		}
 
 		// We return self.Owner if there's no effective owner

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Sync]
 		public WAngle Facing { get; set; }
 
-		public int TurnSpeed { get { return 0; } }
+		public WAngle TurnSpeed { get { return WAngle.Zero; } }
 
 		public Husk(ActorInitializer init, HuskInfo info)
 		{

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -222,7 +222,7 @@ namespace OpenRA.Mods.Common.Traits
 			set { facing = value; }
 		}
 
-		public int TurnSpeed { get { return 4 * Info.TurnSpeed; } }
+		public WAngle TurnSpeed { get { return new WAngle(4 * Info.TurnSpeed); } }
 		#endregion
 
 		[Sync]

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -194,7 +194,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 		#endregion
 
-		int oldFacing, facing;
+		WAngle oldFacing, facing;
 		WPos oldPos;
 		CPos fromCell, toCell;
 		public SubCell FromSubCell, ToSubCell;
@@ -216,13 +216,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		#region IFacing
 		[Sync]
-		public int Facing
+		public WAngle Facing
 		{
 			get { return facing; }
 			set { facing = value; }
 		}
 
-		public int TurnSpeed { get { return Info.TurnSpeed; } }
+		public int TurnSpeed { get { return 4 * Info.TurnSpeed; } }
 		#endregion
 
 		[Sync]
@@ -281,7 +281,7 @@ namespace OpenRA.Mods.Common.Traits
 				SetVisualPosition(self, init.World.Map.CenterOfSubCell(FromCell, FromSubCell));
 			}
 
-			Facing = oldFacing = init.GetValue<FacingInit, int>(info, info.InitialFacing);
+			Facing = oldFacing = WAngle.FromFacing(init.GetValue<FacingInit, int>(info, info.InitialFacing));
 
 			// Sets the initial visual position
 			// Unit will move into the cell grid (defined by LocationInit) as its initial activity
@@ -828,7 +828,7 @@ namespace OpenRA.Mods.Common.Traits
 			var length = speed > 0 ? (toPos - fromPos).Length / speed : 0;
 
 			var delta = toPos - fromPos;
-			var facing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : Facing;
+			var facing = delta.HorizontalLengthSquared != 0 ? delta.Yaw : Facing;
 
 			return new Drag(self, fromPos, toPos, length, facing);
 		}
@@ -857,12 +857,12 @@ namespace OpenRA.Mods.Common.Traits
 		void IActorPreviewInitModifier.ModifyActorPreviewInit(Actor self, TypeDictionary inits)
 		{
 			if (!inits.Contains<DynamicFacingInit>() && !inits.Contains<FacingInit>())
-				inits.Add(new DynamicFacingInit(() => facing));
+				inits.Add(new DynamicFacingInit(() => facing.Facing));
 		}
 
 		void IDeathActorInitModifier.ModifyDeathActorInit(Actor self, TypeDictionary init)
 		{
-			init.Add(new FacingInit(facing));
+			init.Add(new FacingInit(facing.Facing));
 
 			// Allows the husk to drag to its final position
 			if (CanEnterCell(self.Location, self, BlockedByActor.Stationary))

--- a/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (aircraftInfo != null)
 				pos += new WVec(0, 0, aircraftInfo.CruiseAltitude.Length);
 
-			var initialFacing = self.World.Map.FacingBetween(location.Value, destinations[0], 0);
+			var initialFacing = self.World.Map.FacingBetween(location.Value, destinations[0], WAngle.Zero);
 
 			self.World.AddFrameEndTask(w =>
 			{
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				td.Add(new LocationInit(location.Value));
 				td.Add(new CenterPositionInit(pos));
-				td.Add(new FacingInit(initialFacing));
+				td.Add(new FacingInit(initialFacing.Facing));
 
 				var newUnit = self.World.CreateActor(producee.Name, td);
 

--- a/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
+++ b/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 	{
 		BodyOrientation body;
 		IFacing facing;
-		int cachedFacing;
+		WAngle cachedFacing;
 		int cachedInterval;
 
 		public LeavesTrails(Actor self, LeavesTrailsInfo info)
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			body = self.Trait<BodyOrientation>();
 			facing = self.TraitOrDefault<IFacing>();
-			cachedFacing = facing != null ? facing.Facing : 0;
+			cachedFacing = facing != null ? facing.Facing : WAngle.Zero;
 			cachedPosition = self.CenterPosition;
 
 			base.Created(self);
@@ -125,14 +125,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 				var pos = Info.Type == TrailType.CenterPosition ? spawnPosition + body.LocalToWorld(offsetRotation) :
 					self.World.Map.CenterOfCell(spawnCell);
 
-				var spawnFacing = Info.SpawnAtLastPosition ? cachedFacing : (facing != null ? facing.Facing : 0);
+				var spawnFacing = Info.SpawnAtLastPosition ? cachedFacing : (facing != null ? facing.Facing : WAngle.Zero);
 
 				if ((Info.TerrainTypes.Count == 0 || Info.TerrainTypes.Contains(type)) && !string.IsNullOrEmpty(Info.Image))
-					self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, self.World, Info.Image,
-						Info.Sequences.Random(Game.CosmeticRandom), Info.Palette, Info.VisibleThroughFog, spawnFacing)));
+					self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, spawnFacing, self.World, Info.Image,
+						Info.Sequences.Random(Game.CosmeticRandom), Info.Palette, Info.VisibleThroughFog)));
 
 				cachedPosition = self.CenterPosition;
-				cachedFacing = facing != null ? facing.Facing : 0;
+				cachedFacing = facing != null ? facing.Facing : WAngle.Zero;
 				ticks = 0;
 
 				cachedInterval = isMoving ? Info.MovingInterval : Info.StationaryInterval;

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -163,7 +163,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (facing == null)
 				return () => WAngle.Zero;
 
-			return () => WAngle.FromFacing(facing.Facing);
+			return () => facing.Facing;
 		}
 
 		public RenderSprites(ActorInitializer init, RenderSpritesInfo info)

--- a/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 					if (turreted != null)
 						getFacing = () => WAngle.FromFacing(turreted.TurretFacing);
 					else if (facing != null)
-						getFacing = () => WAngle.FromFacing(facing.Facing);
+						getFacing = () => facing.Facing;
 					else
 						getFacing = () => WAngle.Zero;
 

--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -91,7 +91,7 @@ namespace OpenRA.Mods.Common.Traits
 			return new Transform(self, Info.IntoActor)
 			{
 				Offset = Info.Offset,
-				Facing = Info.Facing,
+				Facing = WAngle.FromFacing(Info.Facing),
 				Sounds = Info.TransformSounds,
 				Notification = Info.TransformNotification,
 				Faction = faction

--- a/OpenRA.Mods.Common/Traits/TurnOnIdle.cs
+++ b/OpenRA.Mods.Common/Traits/TurnOnIdle.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 	class TurnOnIdle : ConditionalTrait<TurnOnIdleInfo>, INotifyIdle
 	{
 		int currentDelay;
-		int targetFacing;
+		WAngle targetFacing;
 		readonly Mobile mobile;
 
 		public TurnOnIdle(ActorInitializer init, TurnOnIdleInfo info)
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (targetFacing == mobile.Facing)
 			{
-				targetFacing = self.World.SharedRandom.Next(256);
+				targetFacing = new WAngle(self.World.SharedRandom.Next(1024));
 				currentDelay = self.World.SharedRandom.Next(Info.MinDelay, Info.MaxDelay);
 			}
 

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -182,7 +182,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void MoveTurret()
 		{
-			var df = DesiredFacing ?? (facing != null ? facing.Facing : TurretFacing);
+			var df = DesiredFacing ?? (facing != null ? facing.Facing.Facing : TurretFacing);
 			TurretFacing = Util.TickFacing(TurretFacing, df, Info.TurnSpeed);
 		}
 
@@ -247,7 +247,7 @@ namespace OpenRA.Mods.Common.Traits
 				inits.Add(facings);
 			}
 
-			Func<int> bodyFacing = () => facing.Facing;
+			Func<int> bodyFacing = () => facing.Facing.Facing;
 			var dynamicFacing = inits.GetOrDefault<DynamicFacingInit>();
 			var staticFacing = inits.GetOrDefault<FacingInit>();
 			if (dynamicFacing != null)

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -40,14 +40,14 @@ namespace OpenRA.Mods.Common
 		/// If facing is already within step of desiredFacing then desiredFacing is returned.
 		/// Step is given as an integer to allow negative values (step away from the desired facing)
 		/// </summary>
-		public static WAngle TickFacing(WAngle facing, WAngle desiredFacing, int step)
+		public static WAngle TickFacing(WAngle facing, WAngle desiredFacing, WAngle step)
 		{
 			var leftTurn = (facing - desiredFacing).Angle;
 			var rightTurn = (desiredFacing - facing).Angle;
-			if (leftTurn < step || rightTurn < step)
+			if (leftTurn < step.Angle || rightTurn < step.Angle)
 				return desiredFacing;
 
-			return rightTurn < leftTurn ? new WAngle(facing.Angle + step) : new WAngle(facing.Angle - step);
+			return rightTurn < leftTurn ? facing + step : facing - step;
 		}
 
 		/// <summary>

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -35,17 +35,6 @@ namespace OpenRA.Mods.Common
 				return (facing - rot) & 0xFF;
 		}
 
-		public static int GetNearestFacing(int facing, int desiredFacing)
-		{
-			var turn = desiredFacing - facing;
-			if (turn > 128)
-				turn -= 256;
-			if (turn < -128)
-				turn += 256;
-
-			return facing + turn;
-		}
-
 		/// <summary>
 		/// Adds step angle units to facing in the direction that takes it closer to desiredFacing.
 		/// If facing is already within step of desiredFacing then desiredFacing is returned.
@@ -97,13 +86,13 @@ namespace OpenRA.Mods.Common
 			return negative == 0 ? 0 : 256 - negative;
 		}
 
-		public static bool FacingWithinTolerance(int facing, int desiredFacing, int facingTolerance)
+		public static bool FacingWithinTolerance(WAngle facing, WAngle desiredFacing, int facingTolerance)
 		{
 			if (facingTolerance == 0 && facing == desiredFacing)
 				return true;
 
-			var delta = Util.NormalizeFacing(desiredFacing - facing);
-			return delta <= facingTolerance || delta >= 256 - facingTolerance;
+			var delta = (desiredFacing - facing).Angle;
+			return delta <= facingTolerance || delta >= 1024 - facingTolerance;
 		}
 
 		public static WPos BetweenCells(World w, CPos from, CPos to)


### PR DESCRIPTION
This PR takes the next big step towards #15196 and voxel orientations.
Related to #18058, #18067, #18211, #18213.

Fixes #18249.

Note that `TurnSpeed` is in WAngle *units* but remains as an int to avoid unexpected behaviour if somebody decides to define values < 0 or > 1023 (which are wrapped by `WAngle`).