### PR TITLE
Added missing actor references to MPSpawn

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/MPStartUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/MPStartUnits.cs
@@ -27,12 +27,14 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly HashSet<string> Factions = new HashSet<string>();
 
 		[Desc("The actor at the center, usually the mobile construction vehicle.")]
+		[ActorReference]
 		public readonly string BaseActor = null;
 
 		[Desc("Offset from the spawn point, BaseActor will spawn at.")]
 		public readonly CVec BaseActorOffset = CVec.Zero;
 
 		[Desc("A group of units ready to defend or scout.")]
+		[ActorReference]
 		public readonly string[] SupportActors = { };
 
 		[Desc("Inner radius for spawning support actors")]


### PR DESCRIPTION
as invalid values will crash the game.