### PR TITLE
Add pitch and roll to TS helicopters

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -69,9 +69,7 @@ namespace OpenRA
 		{
 			get
 			{
-				// TODO: Support non-zero pitch/roll in IFacing (IOrientation?)
-				var facingValue = facing != null ? facing.Facing : WAngle.Zero;
-				return new WRot(WAngle.Zero, WAngle.Zero, facingValue);
+				return facing != null ? facing.Orientation : WRot.Zero;
 			}
 		}
 

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -319,6 +319,7 @@ namespace OpenRA.Traits
 	{
 		WAngle TurnSpeed { get; }
 		WAngle Facing { get; set; }
+		WRot Orientation { get; }
 	}
 
 	public interface IFacingInfo : ITraitInfoInterface { int GetInitialFacing(); }

--- a/OpenRA.Game/WRot.cs
+++ b/OpenRA.Game/WRot.cs
@@ -36,6 +36,16 @@ namespace OpenRA
 
 		public static bool operator !=(WRot me, WRot other) { return !(me == other); }
 
+		public WRot WithRoll(WAngle roll)
+		{
+			return new WRot(roll, Pitch, Yaw);
+		}
+
+		public WRot WithPitch(WAngle pitch)
+		{
+			return new WRot(Roll, pitch, Yaw);
+		}
+
 		public WRot WithYaw(WAngle yaw)
 		{
 			return new WRot(Roll, Pitch, yaw);

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -64,8 +64,16 @@ namespace OpenRA.Mods.Cnc.Traits
 		IEnumerable<int> speedModifiers;
 		INotifyVisualPositionChanged[] notifyVisualPositionChanged;
 
+		WRot orientation;
+
 		[Sync]
-		public WAngle Facing { get; set; }
+		public WAngle Facing
+		{
+			get { return orientation.Yaw; }
+			set { orientation = orientation.WithYaw(value); }
+		}
+
+		public WRot Orientation { get { return orientation; } }
 
 		[Sync]
 		public WPos CenterPosition { get; private set; }

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -60,15 +60,28 @@ namespace OpenRA.Mods.Common.Activities
 			this.minRange = minRange;
 		}
 
-		public static void FlyTick(Actor self, Aircraft aircraft, WAngle desiredFacing, WDist desiredAltitude, WVec moveOverride, WAngle? turnSpeedOverride = null)
+		public static void FlyTick(Actor self, Aircraft aircraft, WAngle desiredFacing, WDist desiredAltitude, WVec moveOverride, bool idleTurn = false)
 		{
 			var dat = self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition);
 			var move = aircraft.Info.CanSlide ? aircraft.FlyStep(desiredFacing) : aircraft.FlyStep(aircraft.Facing);
 			if (moveOverride != WVec.Zero)
 				move = moveOverride;
 
-			var turnSpeed = turnSpeedOverride ?? aircraft.TurnSpeed;
+			var oldFacing = aircraft.Facing;
+			var turnSpeed = idleTurn ? aircraft.IdleTurnSpeed ?? aircraft.TurnSpeed : aircraft.TurnSpeed;
 			aircraft.Facing = Util.TickFacing(aircraft.Facing, desiredFacing, turnSpeed);
+
+			var roll = idleTurn ? aircraft.Info.IdleRoll ?? aircraft.Info.Roll : aircraft.Info.Roll;
+			if (roll != WAngle.Zero)
+			{
+				var desiredRoll = aircraft.Facing == desiredFacing ? WAngle.Zero :
+					new WAngle(roll.Angle * Util.GetTurnDirection(aircraft.Facing, oldFacing));
+
+				aircraft.Roll = Util.TickFacing(aircraft.Roll, desiredRoll, aircraft.Info.RollSpeed);
+			}
+
+			if (aircraft.Info.Pitch != WAngle.Zero)
+				aircraft.Pitch = Util.TickFacing(aircraft.Pitch, aircraft.Info.Pitch, aircraft.Info.PitchSpeed);
 
 			// Note: we assume that if move.Z is not zero, it's intentional and we want to move in that vertical direction instead of towards desiredAltitude.
 			// If that is not desired, the place that calls this should make sure moveOverride.Z is zero.
@@ -83,18 +96,18 @@ namespace OpenRA.Mods.Common.Activities
 			aircraft.SetPosition(self, aircraft.CenterPosition + move);
 		}
 
-		public static void FlyTick(Actor self, Aircraft aircraft, WAngle desiredFacing, WDist desiredAltitude, WAngle? turnSpeedOverride = null)
+		public static void FlyTick(Actor self, Aircraft aircraft, WAngle desiredFacing, WDist desiredAltitude, bool idleTurn = false)
 		{
-			FlyTick(self, aircraft, desiredFacing, desiredAltitude, WVec.Zero, turnSpeedOverride);
+			FlyTick(self, aircraft, desiredFacing, desiredAltitude, WVec.Zero, idleTurn);
 		}
 
 		// Should only be used for vertical-only movement, usually VTOL take-off or land. Terrain-induced altitude changes should always be handled by FlyTick.
-		public static bool VerticalTakeOffOrLandTick(Actor self, Aircraft aircraft, WAngle desiredFacing, WDist desiredAltitude, WAngle? turnSpeedOverride = null)
+		public static bool VerticalTakeOffOrLandTick(Actor self, Aircraft aircraft, WAngle desiredFacing, WDist desiredAltitude, bool idleTurn = false)
 		{
 			var dat = self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition);
 			var move = WVec.Zero;
 
-			var turnSpeed = turnSpeedOverride ?? aircraft.TurnSpeed;
+			var turnSpeed = idleTurn ? aircraft.IdleTurnSpeed ?? aircraft.TurnSpeed : aircraft.TurnSpeed;
 			aircraft.Facing = Util.TickFacing(aircraft.Facing, desiredFacing, turnSpeed);
 
 			if (dat != desiredAltitude)

--- a/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
@@ -20,16 +20,16 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly Aircraft aircraft;
 		readonly INotifyIdle[] tickIdles;
-		readonly WAngle turnSpeed;
+		readonly bool idleTurn;
 		int remainingTicks;
 
-		public FlyIdle(Actor self, int ticks = -1, bool tickIdle = true)
+		public FlyIdle(Actor self, int ticks = -1, bool idleTurn = true)
 		{
 			aircraft = self.Trait<Aircraft>();
-			turnSpeed = aircraft.IdleTurnSpeed ?? aircraft.TurnSpeed;
 			remainingTicks = ticks;
+			this.idleTurn = idleTurn;
 
-			if (tickIdle)
+			if (idleTurn)
 				tickIdles = self.TraitsImplementing<INotifyIdle>().ToArray();
 		}
 
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				// We can't possibly turn this fast
 				var desiredFacing = aircraft.Facing + new WAngle(256);
-				Fly.FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, move, turnSpeed);
+				Fly.FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, move, idleTurn);
 			}
 
 			return false;

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Activities
 				// Fly to the target and wait for it to be locked for pickup
 				// These activities will be cancelled and replaced by Land once the target has been locked
 				QueueChild(new Fly(self, Target.FromActor(cargo)));
-				QueueChild(new FlyIdle(self, tickIdle: false));
+				QueueChild(new FlyIdle(self, idleTurn: false));
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -208,8 +208,16 @@ namespace OpenRA.Mods.Common.Traits
 		INotifyVisualPositionChanged[] notifyVisualPositionChanged;
 		IOverrideAircraftLanding overrideAircraftLanding;
 
+		WRot orientation;
+
 		[Sync]
-		public WAngle Facing { get; set; }
+		public WAngle Facing
+		{
+			get { return orientation.Yaw; }
+			set { orientation = orientation.WithYaw(value); }
+		}
+
+		public WRot Orientation { get { return orientation; } }
 
 		[Sync]
 		public WPos CenterPosition { get; private set; }

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -56,6 +56,21 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly int Speed = 1;
 
+		[Desc("Body pitch when flying forwards. Only relevant for voxel aircraft.")]
+		public readonly WAngle Pitch = WAngle.Zero;
+
+		[Desc("Pitch steps to apply each tick when starting/stopping.")]
+		public readonly WAngle PitchSpeed = WAngle.Zero;
+
+		[Desc("Body roll when turning. Only relevant for voxel aircraft.")]
+		public readonly WAngle Roll = WAngle.Zero;
+
+		[Desc("Body roll to apply when aircraft flies in circles while idle. Defaults to Roll if undefined. Only relevant for voxel aircraft.")]
+		public readonly WAngle? IdleRoll = null;
+
+		[Desc("Roll steps to apply each tick when turning.")]
+		public readonly WAngle RollSpeed = WAngle.Zero;
+
 		[Desc("Minimum altitude where this aircraft is considered airborne.")]
 		public readonly int MinAirborneAltitude = 1;
 
@@ -215,6 +230,18 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get { return orientation.Yaw; }
 			set { orientation = orientation.WithYaw(value); }
+		}
+
+		public WAngle Pitch
+		{
+			get { return orientation.Pitch; }
+			set { orientation = orientation.WithPitch(value); }
+		}
+
+		public WAngle Roll
+		{
+			get { return orientation.Roll; }
+			set { orientation = orientation.WithRoll(value); }
 		}
 
 		public WRot Orientation { get { return orientation; } }
@@ -388,6 +415,15 @@ namespace OpenRA.Mods.Common.Traits
 				newMovementTypes |= MovementType.Vertical;
 
 			CurrentMovementTypes = newMovementTypes;
+
+			if (!CurrentMovementTypes.HasFlag(MovementType.Horizontal))
+			{
+				if (Info.Roll != WAngle.Zero && Roll != WAngle.Zero)
+					Roll = Util.TickFacing(Roll, WAngle.Zero, Info.RollSpeed);
+
+				if (Info.Pitch != WAngle.Zero && Pitch != WAngle.Zero)
+					Pitch = Util.TickFacing(Pitch, WAngle.Zero, Info.PitchSpeed);
+			}
 
 			Repulse();
 		}

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -68,8 +68,16 @@ namespace OpenRA.Mods.Common.Traits
 		[Sync]
 		public WPos CenterPosition { get; private set; }
 
+		WRot orientation;
+
 		[Sync]
-		public WAngle Facing { get; set; }
+		public WAngle Facing
+		{
+			get { return orientation.Yaw; }
+			set { orientation = orientation.WithYaw(value); }
+		}
+
+		public WRot Orientation { get { return orientation; } }
 
 		public WAngle TurnSpeed { get { return WAngle.Zero; } }
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -195,10 +195,12 @@ namespace OpenRA.Mods.Common.Traits
 		}
 		#endregion
 
-		WAngle oldFacing, facing;
+		WAngle oldFacing;
+		WRot orientation;
 		WPos oldPos;
 		CPos fromCell, toCell;
 		public SubCell FromSubCell, ToSubCell;
+
 		INotifyCustomLayerChanged[] notifyCustomLayerChanged;
 		INotifyVisualPositionChanged[] notifyVisualPositionChanged;
 		INotifyMoving[] notifyMoving;
@@ -216,12 +218,15 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		#region IFacing
+
 		[Sync]
 		public WAngle Facing
 		{
-			get { return facing; }
-			set { facing = value; }
+			get { return orientation.Yaw; }
+			set { orientation = orientation.WithYaw(value); }
 		}
+
+		public WRot Orientation { get { return orientation; } }
 
 		public WAngle TurnSpeed { get { return new WAngle(4 * Info.TurnSpeed); } }
 		#endregion
@@ -858,12 +863,12 @@ namespace OpenRA.Mods.Common.Traits
 		void IActorPreviewInitModifier.ModifyActorPreviewInit(Actor self, TypeDictionary inits)
 		{
 			if (!inits.Contains<DynamicFacingInit>() && !inits.Contains<FacingInit>())
-				inits.Add(new DynamicFacingInit(() => facing.Facing));
+				inits.Add(new DynamicFacingInit(() => Facing.Facing));
 		}
 
 		void IDeathActorInitModifier.ModifyDeathActorInit(Actor self, TypeDictionary init)
 		{
-			init.Add(new FacingInit(facing.Facing));
+			init.Add(new FacingInit(Facing.Facing));
 
 			// Allows the husk to drag to its final position
 			if (CanEnterCell(self.Location, self, BlockedByActor.Stationary))

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -8,6 +8,8 @@ DPOD:
 		Name: Drop Pod
 	Aircraft:
 		IdleBehavior: Land
+		Pitch: 0
+		Roll: 0
 		TurnSpeed: 5
 		Speed: 149
 		InitialFacing: 0
@@ -46,6 +48,8 @@ DSHP:
 		AddToArmyValue: true
 	Aircraft:
 		IdleBehavior: Land
+		Pitch: 0
+		Roll: 0
 		TurnSpeed: 5
 		Speed: 168
 		InitialFacing: 0
@@ -257,6 +261,8 @@ TRNSPORT:
 		TurnSpeed: 5
 		Speed: 149
 		InitialFacing: 0
+		Pitch: 0
+		Roll: 0
 		TakeoffSounds: dropup1.aud
 		LandingSounds: dropdwn1.aud
 	Carryall:
@@ -364,6 +370,10 @@ APACHE:
 	Selectable:
 		Bounds: 30,24
 	Aircraft:
+		Pitch: -32
+		PitchSpeed: 8
+		Roll: 16
+		RollSpeed: 8
 		TurnSpeed: 5
 		Speed: 130
 		CanSlide: false
@@ -426,6 +436,8 @@ HUNTER:
 	Aircraft:
 		TurnSpeed: 16
 		Speed: 355
+		Pitch: 0
+		Roll: 0
 		CruiseAltitude: 3c128
 		CruisingCondition: cruising
 		MoveIntoShroud: true

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -888,6 +888,10 @@
 		CanHover: true
 		CanSlide: true
 		VTOL: true
+		Pitch: -64
+		PitchSpeed: 16
+		Roll: 56
+		RollSpeed: 14
 	Voiced:
 		VoiceSet: Heli
 	HiddenUnderFog:


### PR DESCRIPTION
Aircraft in TS would pitch forward by 30 degrees while flying, and roll to an angle of 20 degrees while turning.
This was effectively purely visual effect, and we have converted enough of the facing code to enable this for everything except the carryall.

https://i.imgur.com/Er7j4Bp.mp4

~Depends on #18228~

~I have taken the liberty of adjusting the pitch and roll values to look better with the current speed configuration on the different aircraft. I have also taken the approach from #17796 to define the roll as a factor of the turn amount, which looks more natural for aircraft that have different turn vs idle turn speeds.~
