### PR TITLE
Add RA balance changes

### DIFF
--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -206,7 +206,7 @@ TRAN:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 20000
+		HP: 14000
 	RevealsShroud:
 		MinRange: 6c0
 		Range: 8c0

--- a/mods/ra/rules/husks.yaml
+++ b/mods/ra/rules/husks.yaml
@@ -1,16 +1,3 @@
-1TNK.Husk:
-	Inherits: ^Husk
-	Tooltip:
-		Name: Husk (Light Tank)
-	ThrowsParticle@turret:
-		Anim: turret
-	TransformOnCapture:
-		IntoActor: 1tnk
-	InfiltrateForTransform:
-		IntoActor: 1tnk
-	RenderSprites:
-		Image: 1tnk.destroyed
-
 2TNK.Husk:
 	Inherits: ^Husk
 	Tooltip:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -549,7 +549,7 @@ TSLA:
 		Type: Heavy
 	RevealsShroud:
 		MinRange: 6c0
-		Range: 8c0
+		Range: 7c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 6c0
@@ -808,7 +808,7 @@ GUN:
 		Type: Heavy
 	RevealsShroud:
 		MinRange: 5c0
-		Range: 7c0
+		Range: 6c512
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 5c0

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -64,7 +64,7 @@ V2RL:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 22000
+		HP: 26000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -108,7 +108,7 @@ V2RL:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 45000
+		HP: 46000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -602,7 +602,7 @@ MRJ:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 85
+		Speed: 78
 	RevealsShroud:
 		Range: 7c0
 	WithIdleOverlay@SPINNER:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -86,8 +86,6 @@ V2RL:
 	AttackTurreted:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
-	SpawnActorOnDeath:
-		Actor: 1TNK.Husk
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -80,7 +80,7 @@
 TurretGun:
 	Inherits: ^Cannon
 	ReloadDelay: 30
-	Range: 7c0
+	Range: 6c512
 	Report: turret1.aud
 	Warhead@1Dam: SpreadDamage
 		Damage: 6000

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -75,7 +75,7 @@ Napalm:
 
 ^TeslaWeapon:
 	ReloadDelay: 3
-	Range: 8c0
+	Range: 7c0
 	Report: tesla1.aud
 	Projectile: TeslaZap
 	ValidTargets: Ground, Water, GroundActor, WaterActor


### PR DESCRIPTION
CC @Punsho.
Changes:
- Chinook HP 20000 -> 14000
- Light Tank HP 22000 -> 26000
- Medium Tank HP 45000 -> ~47000~ 46000
- Radar Jammer speed 85 -> 78
- Removed Light Tank husk
- Tesla vision and weapon range 8c0 -> 7c0
- Turret vision and weapon range 7c0 -> 6c512

Fwiw, personally I'm not too much of a fan of removing the Light Tank husk, since all other tanks leave husks, but I can see the reasoning. (And on the other hand, Light Tanks are light vehicles like APCs.)