### PR TITLE
Change Subs to use the Defend stance by default

### DIFF
--- a/mods/ra/maps/allies-06a/rules.yaml
+++ b/mods/ra/maps/allies-06a/rules.yaml
@@ -91,7 +91,3 @@ CA:
 MSUB:
 	Buildable:
 		Prerequisites: ~disabled
-
-SS:
-	AutoTarget:
-		InitialStanceAI: AttackAnything

--- a/mods/ra/maps/allies-06b/rules.yaml
+++ b/mods/ra/maps/allies-06b/rules.yaml
@@ -87,7 +87,3 @@ CA:
 MSUB:
 	Buildable:
 		Prerequisites: ~disabled
-
-SS:
-	AutoTarget:
-		InitialStanceAI: AttackAnything

--- a/mods/ra/maps/allies-07/rules.yaml
+++ b/mods/ra/maps/allies-07/rules.yaml
@@ -127,7 +127,3 @@ CA:
 MSUB:
 	Buildable:
 		Prerequisites: ~disabled
-
-SS:
-	AutoTarget:
-		InitialStanceAI: AttackAnything

--- a/mods/ra/maps/sarin-gas-1-crackdown/rules.yaml
+++ b/mods/ra/maps/sarin-gas-1-crackdown/rules.yaml
@@ -113,7 +113,3 @@ STNK:
 E7:
 	Buildable:
 		Prerequisites: ~disabled
-
-SS:
-	AutoTarget:
-		InitialStanceAI: AttackAnything

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -49,9 +49,6 @@ SS:
 		LocalOffset: 0,-171,0, 0,171,0
 		FireDelay: 2
 	AttackFrontal:
-	AutoTarget:
-		InitialStance: HoldFire
-		InitialStanceAI: ReturnFire
 	AutoTargetPriority@DEFAULT:
 		ValidTargets: WaterActor, Underwater
 	AutoTargetPriority@ATTACKANYTHING:


### PR DESCRIPTION
This has been asked for several times already. As is you have to change the Subs stance, otherwise you will lose them when not paying constant attention since other naval units will just pick them off when attack moving.