### PR TITLE
Add option for airstrikes to arrive from behind the player start location

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -1264,9 +1264,9 @@ namespace OpenRA
 		public WDist DistanceToEdge(WPos pos, WVec dir)
 		{
 			var projectedPos = pos - new WVec(0, pos.Z, pos.Z);
-			var x = dir.X == 0 ? int.MaxValue : ((dir.X < 0 ? ProjectedTopLeft.X : ProjectedBottomRight.X) - projectedPos.X) / dir.X;
-			var y = dir.Y == 0 ? int.MaxValue : ((dir.Y < 0 ? ProjectedTopLeft.Y : ProjectedBottomRight.Y) - projectedPos.Y) / dir.Y;
-			return new WDist(Math.Min(x, y) * dir.Length);
+			var x = dir.X == 0 ? int.MaxValue : ((dir.X < 0 ? ProjectedTopLeft.X : ProjectedBottomRight.X) - projectedPos.X) * dir.Length / dir.X;
+			var y = dir.Y == 0 ? int.MaxValue : ((dir.Y < 0 ? ProjectedTopLeft.Y : ProjectedBottomRight.Y) - projectedPos.Y) * dir.Length / dir.Y;
+			return new WDist(Math.Min(x, y));
 		}
 
 		// Both ranges are inclusive because everything that calls it is designed for maxRange being inclusive:

--- a/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
@@ -22,11 +22,19 @@ namespace OpenRA.Mods.Common.Traits
 	public class AirstrikePowerInfo : SupportPowerInfo
 	{
 		[ActorReference(typeof(AircraftInfo))]
+		[Desc("Aircraft used to deliver the airstrike.")]
 		public readonly string UnitType = "badr.bomber";
+
+		[Desc("Number of aircraft to use in an airstrike formation.")]
 		public readonly int SquadSize = 1;
+
+		[Desc("Offset vector between the aircraft in a formation.")]
 		public readonly WVec SquadOffset = new WVec(-1536, 1536, 0);
 
+		[Desc("Number of different possible facings of the aircraft (used only for choosing a random direction to spawn from.)")]
 		public readonly int QuantizedFacings = 32;
+
+		[Desc("Additional distance from the map edge to spawn and despawn the aircraft.")]
 		public readonly WDist Cordon = new WDist(5120);
 
 		[ActorReference]

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1544,7 +1544,8 @@ AFLD:
 		ArrowSequence: arrow
 		ClockSequence: clock
 		CircleSequence: circles
-		UseDirectionalTarget: True
+		BaselineSpawn: true
+		UseDirectionalTarget: false
 		DirectionArrowAnimation: paradirection
 		SupportPowerPaletteOrder: 40
 	ProductionBar:


### PR DESCRIPTION
This adds the mod option for airstrikes to arrive from the edge of the map behind the spawn point of the player that called it instead of the direction being either random or freely choosable by the player. The logic here is similar to #16595.

This was requested in https://github.com/OpenRA/OpenRA/issues/18093#issuecomment-630318416

Known limitation: Since this relies on the existence of `MPSpawn` it will only work in skirmish maps. If `MPSpawn` is not defined, it will default to the regular random direction instead.