### PR TITLE
Add the remasters as install source for the old(!) assets

### DIFF
--- a/OpenRA.Mods.Common/ModContent.cs
+++ b/OpenRA.Mods.Common/ModContent.cs
@@ -17,7 +17,11 @@ namespace OpenRA
 {
 	public class ModContent : IGlobalModData
 	{
-		public enum SourceType { Disc, Install }
+		public enum SourceType { Disc, Install, Steam }
+
+		public const string SteamRegistryPath = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App ";
+		public const string SteamRegistryValue = "InstallLocation";
+
 		public class ModPackage
 		{
 			public readonly string Title;
@@ -46,6 +50,8 @@ namespace OpenRA
 			public readonly string[] RegistryPrefixes = { string.Empty };
 			public readonly string RegistryKey;
 			public readonly string RegistryValue;
+
+			public readonly string SteamAppId;
 
 			public readonly string Title;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
@@ -314,6 +314,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				var read = (int)Math.Min(buffer.Length, length - copied);
 				var write = input.Read(buffer, 0, read);
+				if (write == 0)
+					throw new InvalidOperationException("Reached end of file before finished copying the file!");
+
 				output.Write(buffer, 0, write);
 				copied += write;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
@@ -560,7 +560,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							if (CryptoUtil.SHA1Hash(data) != kv.Value.Value)
 								return false;
 						}
-						else if (CryptoUtil.SHA1Hash(fileStream) != kv.Value.Value)
+						else if (!CryptoUtil.SHA1Hash(fileStream).Equals(kv.Value.Value, StringComparison.OrdinalIgnoreCase))
 								return false;
 					}
 				}

--- a/mods/cnc/installer/remaster.yaml
+++ b/mods/cnc/installer/remaster.yaml
@@ -1,0 +1,333 @@
+remaster: C&C Remastered (Steam version, English)
+	Type: Steam
+	SteamAppId: 1213210
+	IDFiles:
+		Data/CNCDATA/TIBERIAN_DAWN/CD1/CONQUER.MIX: 3f891c8dc0864f654e1710430ea4ff34c3715e97
+	Install:
+		copy: .
+			^Content/cnc/conquer.mix: Data/CNCDATA/TIBERIAN_DAWN/CD1/CONQUER.MIX
+			^Content/cnc/desert.mix: Data/CNCDATA/TIBERIAN_DAWN/CD1/DESERT.MIX
+			^Content/cnc/general.mix: Data/CNCDATA/TIBERIAN_DAWN/CD1/GENERAL.MIX
+			^Content/cnc/scores.mix: Data/CNCDATA/TIBERIAN_DAWN/CD1/SCORES.MIX
+			^Content/cnc/sounds.mix: Data/CNCDATA/TIBERIAN_DAWN/CD1/SOUNDS.MIX
+			^Content/cnc/temperat.mix: Data/CNCDATA/TIBERIAN_DAWN/CD1/TEMPERAT.MIX
+			^Content/cnc/winter.mix: Data/CNCDATA/TIBERIAN_DAWN/CD1/WINTER.MIX
+			^Content/cnc/speech.mix: Data/CNCDATA/TIBERIAN_DAWN/CD1/SPEECH.MIX
+			^Content/cnc/tempicnh.mix: Data/CNCDATA/TIBERIAN_DAWN/CD1/TEMPICNH.MIX
+			^Content/cnc/transit.mix: Data/CNCDATA/TIBERIAN_DAWN/CD1/TRANSIT.MIX
+			^Content/cnc/scores-covertops.mix: Data/CNCDATA/TIBERIAN_DAWN/CONSOLE_1/SCORES.MIX
+		extract-raw: Data/CNCDATA/TIBERIAN_DAWN/CD1/MOVIES.MIX
+			^Content/cnc/movies/visor.vqa:
+				Offset: 774
+				Length: 4407162
+			^Content/cnc/movies/turtkill.vqa:
+				Offset: 4407936
+				Length: 3323444
+			^Content/cnc/movies/tbrinfo3.vqa:
+				Offset: 7731380
+				Length: 14972046
+			^Content/cnc/movies/tbrinfo2.vqa:
+				Offset: 22703426
+				Length: 16195290
+			^Content/cnc/movies/tbrinfo1.vqa:
+				Offset: 38898716
+				Length: 23479052
+			^Content/cnc/movies/seige.vqa:
+				Offset: 62377768
+				Length: 2705978
+			^Content/cnc/movies/samsite.vqa:
+				Offset: 65083746
+				Length: 1410418
+			^Content/cnc/movies/samdie.vqa:
+				Offset: 66494164
+				Length: 3741942
+			^Content/cnc/movies/sabotage.vqa:
+				Offset: 70236106
+				Length: 1386202
+			^Content/cnc/movies/retro.vqa:
+				Offset: 71622308
+				Length: 6434382
+			^Content/cnc/movies/podium.vqa:
+				Offset: 78056690
+				Length: 2790664
+			^Content/cnc/movies/planecra.vqa:
+				Offset: 80847354
+				Length: 5085426
+			^Content/cnc/movies/pintle.vqa:
+				Offset: 85932780
+				Length: 2757536
+			^Content/cnc/movies/paratrop.vqa:
+				Offset: 88690316
+				Length: 3180272
+			^Content/cnc/movies/nodsweep.vqa:
+				Offset: 91870588
+				Length: 3642174
+			^Content/cnc/movies/nodlose.vqa:
+				Offset: 95512762
+				Length: 5148924
+			^Content/cnc/movies/nodflees.vqa:
+				Offset: 100661686
+				Length: 3056426
+			^Content/cnc/movies/nod1.vqa:
+				Offset: 103718112
+				Length: 4663258
+			^Content/cnc/movies/nitejump.vqa:
+				Offset: 108381370
+				Length: 3702838
+			^Content/cnc/movies/napalm.vqa:
+				Offset: 112084208
+				Length: 4004146
+			^Content/cnc/movies/logo.vqa:
+				Offset: 116088354
+				Length: 3562630
+			^Content/cnc/movies/landing.vqa:
+				Offset: 119650984
+				Length: 1617094
+			^Content/cnc/movies/intro2.vqa:
+				Offset: 121268078
+				Length: 21058732
+			^Content/cnc/movies/hellvaly.vqa:
+				Offset: 142326810
+				Length: 6658950
+			^Content/cnc/movies/gunboat.vqa:
+				Offset: 148985760
+				Length: 3203706
+			^Content/cnc/movies/gdilose.vqa:
+				Offset: 152189466
+				Length: 2097912
+			^Content/cnc/movies/gdifinb.vqa:
+				Offset: 154287378
+				Length: 17769978
+			^Content/cnc/movies/gdifina.vqa:
+				Offset: 172057356
+				Length: 12888650
+			^Content/cnc/movies/gdiend2.vqa:
+				Offset: 184946006
+				Length: 25242946
+			^Content/cnc/movies/gdiend1.vqa:
+				Offset: 210188952
+				Length: 25311636
+			^Content/cnc/movies/gdi9.vqa:
+				Offset: 235500588
+				Length: 11806994
+			^Content/cnc/movies/gdi8b.vqa:
+				Offset: 247307582
+				Length: 5324410
+			^Content/cnc/movies/gdi8a.vqa:
+				Offset: 252631992
+				Length: 4672548
+			^Content/cnc/movies/gdi7.vqa:
+				Offset: 257304540
+				Length: 4241952
+			^Content/cnc/movies/gdi6.vqa:
+				Offset: 261546492
+				Length: 3959650
+			^Content/cnc/movies/gdi5.vqa:
+				Offset: 265506142
+				Length: 3818244
+			^Content/cnc/movies/gdi4b.vqa:
+				Offset: 269324386
+				Length: 6603530
+			^Content/cnc/movies/gdi4a.vqa:
+				Offset: 275927916
+				Length: 4450582
+			^Content/cnc/movies/gdi3lose.vqa:
+				Offset: 280378498
+				Length: 2265770
+			^Content/cnc/movies/gdi3.vqa:
+				Offset: 282644268
+				Length: 5443848
+			^Content/cnc/movies/gdi2.vqa:
+				Offset: 288088116
+				Length: 7883500
+			^Content/cnc/movies/gdi15.vqa:
+				Offset: 295971616
+				Length: 11684610
+			^Content/cnc/movies/gdi14.vqa:
+				Offset: 307656226
+				Length: 5282770
+			^Content/cnc/movies/gdi13.vqa:
+				Offset: 312938996
+				Length: 6900914
+			^Content/cnc/movies/gdi12.vqa:
+				Offset: 319839910
+				Length: 3669404
+			^Content/cnc/movies/gdi11.vqa:
+				Offset: 323509314
+				Length: 5895754
+			^Content/cnc/movies/gdi10.vqa:
+				Offset: 329405068
+				Length: 5758492
+			^Content/cnc/movies/gdi1.vqa:
+				Offset: 335163560
+				Length: 6341298
+			^Content/cnc/movies/generic.vqa:
+				Offset: 341504858
+				Length: 1452820
+			^Content/cnc/movies/gameover.vqa:
+				Offset: 342957678
+				Length: 2087322
+			^Content/cnc/movies/forestkl.vqa:
+				Offset: 345045000
+				Length: 1500986
+			^Content/cnc/movies/flyy.vqa:
+				Offset: 346545986
+				Length: 1373532
+			^Content/cnc/movies/flag.vqa:
+				Offset: 347919518
+				Length: 4308680
+			^Content/cnc/movies/dino.vqa:
+				Offset: 352228198
+				Length: 1347896
+			^Content/cnc/movies/desolat.vqa:
+				Offset: 353576094
+				Length: 8385122
+			^Content/cnc/movies/consyard.vqa:
+				Offset: 361961216
+				Length: 7864652
+			^Content/cnc/movies/cc2tease.vqa:
+				Offset: 369825868
+				Length: 11857200
+			^Content/cnc/movies/burdet2.vqa:
+				Offset: 381683068
+				Length: 2062190
+			^Content/cnc/movies/burdet1.vqa:
+				Offset: 383745258
+				Length: 10410614
+			^Content/cnc/movies/bombflee.vqa:
+				Offset: 394155872
+				Length: 2859726
+			^Content/cnc/movies/bombaway.vqa:
+				Offset: 397015598
+				Length: 5579588
+			^Content/cnc/movies/bkground.vqa:
+				Offset: 402595186
+				Length: 15267052
+			^Content/cnc/movies/bcanyon.vqa:
+				Offset: 417862238
+				Length: 5172288
+			^Content/cnc/movies/banner.vqa:
+				Offset: 423034526
+				Length: 2229408
+		extract-raw: Data/CNCDATA/TIBERIAN_DAWN/CD2/MOVIES.MIX
+			^Content/cnc/movies/trtkil_d.vqa:
+				Offset: 4407888
+				Length: 3511836
+			^Content/cnc/movies/tiberfx.vqa:
+				Offset: 7919724
+				Length: 8735102
+			^Content/cnc/movies/tankkill.vqa:
+				Offset: 16654826
+				Length: 3298978
+			^Content/cnc/movies/tankgo.vqa:
+				Offset: 19953804
+				Length: 1403876
+			^Content/cnc/movies/sundial.vqa:
+				Offset: 21357680
+				Length: 3653636
+			^Content/cnc/movies/stealth.vqa:
+				Offset: 25011316
+				Length: 4521860
+			^Content/cnc/movies/spycrash.vqa:
+				Offset: 29533176
+				Length: 1886288
+			^Content/cnc/movies/sethpre.vqa:
+				Offset: 31419464
+				Length: 10914610
+			^Content/cnc/movies/refint.vqa:
+				Offset: 52884852
+				Length: 5090040
+			^Content/cnc/movies/obel.vqa:
+				Offset: 57974892
+				Length: 3851370
+			^Content/cnc/movies/nuke.vqa:
+				Offset: 61826262
+				Length: 3126662
+			^Content/cnc/movies/nodfinal.vqa:
+				Offset: 70101848
+				Length: 23326586
+			^Content/cnc/movies/nodend4.vqa:
+				Offset: 93428434
+				Length: 25535232
+			^Content/cnc/movies/nodend3.vqa:
+				Offset: 118963666
+				Length: 25725824
+			^Content/cnc/movies/nodend2.vqa:
+				Offset: 144689490
+				Length: 27214048
+			^Content/cnc/movies/nodend1.vqa:
+				Offset: 171903538
+				Length: 27172272
+			^Content/cnc/movies/nod9.vqa:
+				Offset: 199075810
+				Length: 9357980
+			^Content/cnc/movies/nod8.vqa:
+				Offset: 208433790
+				Length: 11597940
+			^Content/cnc/movies/nod7b.vqa:
+				Offset: 220031730
+				Length: 4671402
+			^Content/cnc/movies/nod7a.vqa:
+				Offset: 224703132
+				Length: 4740470
+			^Content/cnc/movies/nod6.vqa:
+				Offset: 229443602
+				Length: 5007744
+			^Content/cnc/movies/nod5.vqa:
+				Offset: 234451346
+				Length: 6641700
+			^Content/cnc/movies/nod4b.vqa:
+				Offset: 241093046
+				Length: 3867618
+			^Content/cnc/movies/nod4a.vqa:
+				Offset: 244960664
+				Length: 3838924
+			^Content/cnc/movies/nod3.vqa:
+				Offset: 248799588
+				Length: 3603314
+			^Content/cnc/movies/nod2.vqa:
+				Offset: 252402902
+				Length: 7200720
+			^Content/cnc/movies/nod1pre.vqa:
+				Offset: 259603622
+				Length: 395720
+			^Content/cnc/movies/nod13.vqa:
+				Offset: 259999342
+				Length: 2746626
+			^Content/cnc/movies/nod12.vqa:
+				Offset: 262745968
+				Length: 6576562
+			^Content/cnc/movies/nod11.vqa:
+				Offset: 269322530
+				Length: 4629270
+			^Content/cnc/movies/nod10b.vqa:
+				Offset: 273951800
+				Length: 6386444
+			^Content/cnc/movies/nod10a.vqa:
+				Offset: 280338244
+				Length: 7205632
+			^Content/cnc/movies/kanepre.vqa:
+				Offset: 297386858
+				Length: 17220712
+			^Content/cnc/movies/insites.vqa:
+				Offset: 335666302
+				Length: 460482
+			^Content/cnc/movies/dessweep.vqa:
+				Offset: 353165786
+				Length: 3563646
+			^Content/cnc/movies/deskill.vqa:
+				Offset: 356729432
+				Length: 1483634
+			^Content/cnc/movies/desflees.vqa:
+				Offset: 358213066
+				Length: 2698426
+			^Content/cnc/movies/akira.vqa:
+				Offset: 396474354
+				Length: 7803444
+			^Content/cnc/movies/airstrk.vqa:
+				Offset: 404277798
+				Length: 4444442
+		extract-raw: Data/CNCDATA/TIBERIAN_DAWN/CD3/MOVIES.MIX
+			^Content/cnc/movies/trailer.vqa:
+				Offset: 534
+				Length: 23163930

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -264,22 +264,22 @@ ModContent:
 	Packages:
 		base: Base Game Files
 			TestFiles: ^Content/cnc/conquer.mix, ^Content/cnc/desert.mix, ^Content/cnc/sounds.mix, ^Content/cnc/speech.mix, ^Content/cnc/temperat.mix, ^Content/cnc/tempicnh.mix, ^Content/cnc/winter.mix
-			Sources: gdi95, gdi95-linux, nod95, nod95-linux, tfd, origin
+			Sources: gdi95, gdi95-linux, nod95, nod95-linux, tfd, origin, remaster
 			Required: true
 			Download: basefiles
 		music: Base Game Music
 			TestFiles: ^Content/cnc/scores.mix
-			Sources: gdi95, gdi95-linux, nod95, nod95-linux, tfd, origin
+			Sources: gdi95, gdi95-linux, nod95, nod95-linux, tfd, origin, remaster
 			Download: music
 		movies-gdi: GDI Campaign Briefings
 			TestFiles: ^Content/cnc/movies/visor.vqa, ^Content/cnc/movies/turtkill.vqa, ^Content/cnc/movies/trailer.vqa, ^Content/cnc/movies/tbrinfo3.vqa, ^Content/cnc/movies/tbrinfo2.vqa, ^Content/cnc/movies/tbrinfo1.vqa, ^Content/cnc/movies/seige.vqa, ^Content/cnc/movies/samsite.vqa, ^Content/cnc/movies/samdie.vqa, ^Content/cnc/movies/sabotage.vqa, ^Content/cnc/movies/retro.vqa, ^Content/cnc/movies/podium.vqa, ^Content/cnc/movies/planecra.vqa, ^Content/cnc/movies/pintle.vqa, ^Content/cnc/movies/paratrop.vqa, ^Content/cnc/movies/nodsweep.vqa, ^Content/cnc/movies/nodlose.vqa, ^Content/cnc/movies/nodflees.vqa, ^Content/cnc/movies/nod1.vqa, ^Content/cnc/movies/nitejump.vqa, ^Content/cnc/movies/napalm.vqa, ^Content/cnc/movies/logo.vqa, ^Content/cnc/movies/landing.vqa, ^Content/cnc/movies/intro2.vqa, ^Content/cnc/movies/hellvaly.vqa, ^Content/cnc/movies/gunboat.vqa, ^Content/cnc/movies/generic.vqa, ^Content/cnc/movies/gdilose.vqa, ^Content/cnc/movies/gdifinb.vqa, ^Content/cnc/movies/gdifina.vqa, ^Content/cnc/movies/gdiend2.vqa, ^Content/cnc/movies/gdiend1.vqa, ^Content/cnc/movies/gdi9.vqa, ^Content/cnc/movies/gdi8b.vqa, ^Content/cnc/movies/gdi8a.vqa, ^Content/cnc/movies/gdi7.vqa, ^Content/cnc/movies/gdi6.vqa, ^Content/cnc/movies/gdi5.vqa, ^Content/cnc/movies/gdi4b.vqa, ^Content/cnc/movies/gdi4a.vqa, ^Content/cnc/movies/gdi3lose.vqa, ^Content/cnc/movies/gdi3.vqa, ^Content/cnc/movies/gdi2.vqa, ^Content/cnc/movies/gdi15.vqa, ^Content/cnc/movies/gdi14.vqa, ^Content/cnc/movies/gdi13.vqa, ^Content/cnc/movies/gdi12.vqa, ^Content/cnc/movies/gdi11.vqa, ^Content/cnc/movies/gdi10.vqa, ^Content/cnc/movies/gdi1.vqa, ^Content/cnc/movies/gameover.vqa, ^Content/cnc/movies/forestkl.vqa, ^Content/cnc/movies/flyy.vqa, ^Content/cnc/movies/flag.vqa, ^Content/cnc/movies/dino.vqa, ^Content/cnc/movies/desolat.vqa, ^Content/cnc/movies/consyard.vqa, ^Content/cnc/movies/cc2tease.vqa, ^Content/cnc/movies/burdet2.vqa, ^Content/cnc/movies/burdet1.vqa, ^Content/cnc/movies/bombflee.vqa, ^Content/cnc/movies/bombaway.vqa, ^Content/cnc/movies/bkground.vqa, ^Content/cnc/movies/bcanyon.vqa, ^Content/cnc/movies/banner.vqa
-			Sources: gdi95, gdi95-linux, tfd, origin
+			Sources: gdi95, gdi95-linux, tfd, origin, remaster
 		movies-nod: Nod Campaign Briefings
 			TestFiles: ^Content/cnc/movies/visor.vqa, ^Content/cnc/movies/trtkil_d.vqa, ^Content/cnc/movies/trailer.vqa, ^Content/cnc/movies/tiberfx.vqa, ^Content/cnc/movies/tankkill.vqa, ^Content/cnc/movies/tankgo.vqa, ^Content/cnc/movies/sundial.vqa, ^Content/cnc/movies/stealth.vqa, ^Content/cnc/movies/spycrash.vqa, ^Content/cnc/movies/sethpre.vqa, ^Content/cnc/movies/seige.vqa, ^Content/cnc/movies/samsite.vqa, ^Content/cnc/movies/retro.vqa, ^Content/cnc/movies/refint.vqa, ^Content/cnc/movies/obel.vqa, ^Content/cnc/movies/nuke.vqa, ^Content/cnc/movies/nodlose.vqa, ^Content/cnc/movies/nodfinal.vqa, ^Content/cnc/movies/nodend4.vqa, ^Content/cnc/movies/nodend3.vqa, ^Content/cnc/movies/nodend2.vqa, ^Content/cnc/movies/nodend1.vqa, ^Content/cnc/movies/nod9.vqa, ^Content/cnc/movies/nod8.vqa, ^Content/cnc/movies/nod7b.vqa, ^Content/cnc/movies/nod7a.vqa, ^Content/cnc/movies/nod6.vqa, ^Content/cnc/movies/nod5.vqa, ^Content/cnc/movies/nod4b.vqa, ^Content/cnc/movies/nod4a.vqa, ^Content/cnc/movies/nod3.vqa, ^Content/cnc/movies/nod2.vqa, ^Content/cnc/movies/nod1pre.vqa, ^Content/cnc/movies/nod13.vqa, ^Content/cnc/movies/nod12.vqa, ^Content/cnc/movies/nod11.vqa, ^Content/cnc/movies/nod10b.vqa, ^Content/cnc/movies/nod10a.vqa, ^Content/cnc/movies/nod1.vqa, ^Content/cnc/movies/logo.vqa, ^Content/cnc/movies/landing.vqa, ^Content/cnc/movies/kanepre.vqa, ^Content/cnc/movies/intro2.vqa, ^Content/cnc/movies/insites.vqa, ^Content/cnc/movies/generic.vqa, ^Content/cnc/movies/gdi1.vqa, ^Content/cnc/movies/gameover.vqa, ^Content/cnc/movies/forestkl.vqa, ^Content/cnc/movies/flag.vqa, ^Content/cnc/movies/dino.vqa, ^Content/cnc/movies/dessweep.vqa, ^Content/cnc/movies/deskill.vqa, ^Content/cnc/movies/desflees.vqa, ^Content/cnc/movies/consyard.vqa, ^Content/cnc/movies/cc2tease.vqa, ^Content/cnc/movies/bombflee.vqa, ^Content/cnc/movies/bombaway.vqa, ^Content/cnc/movies/bcanyon.vqa, ^Content/cnc/movies/banner.vqa, ^Content/cnc/movies/akira.vqa, ^Content/cnc/movies/airstrk.vqa
-			Sources: nod95, nod95-linux, tfd, origin
+			Sources: nod95, nod95-linux, tfd, origin, remaster
 		music-covertops: Covert Operations Music
 			TestFiles: ^Content/cnc/scores-covertops.mix
-			Sources: covertops, covertops-linux, tfd, origin
+			Sources: covertops, covertops-linux, tfd, origin, remaster
 	Downloads:
 		cnc|installer/downloads.yaml
 	Sources:
@@ -288,3 +288,4 @@ ModContent:
 		cnc|installer/gdi95.yaml
 		cnc|installer/nod95.yaml
 		cnc|installer/origin.yaml
+		cnc|installer/remaster.yaml

--- a/mods/ra/installer/remaster.yaml
+++ b/mods/ra/installer/remaster.yaml
@@ -1,0 +1,327 @@
+ra-remaster-steam: C&C Remastered (Steam version, English)
+	Type: Steam
+	SteamAppId: 1213210
+	IDFiles:
+		Data/CNCDATA/RED_ALERT/CD1/REDALERT.MIX: 0e58f4b54f44f6cd29fecf8cf379d33cf2d4caef
+	Install:
+		copy: .
+			^Content/ra/v2/expand/expand2.mix: Data/CNCDATA/RED_ALERT/AFTERMATH/EXPAND2.MIX
+			^Content/ra/v2/expand/hires1.mix: Data/CNCDATA/RED_ALERT/AFTERMATH/HIRES1.MIX
+			^Content/ra/v2/expand/lores1.mix: Data/CNCDATA/RED_ALERT/AFTERMATH/LORES1.MIX
+			^Content/ra/v2/cnc/desert.mix: Data/CNCDATA/TIBERIAN_DAWN/CD1/DESERT.MIX
+		extract-raw: Data/CNCDATA/RED_ALERT/CD1/REDALERT.MIX
+			^Content/ra/v2/hires.mix:
+				Offset: 650612
+				Length: 5817417
+			^Content/ra/v2/local.mix:
+				Offset: 6468029
+				Length: 3829837
+			^Content/ra/v2/lores.mix:
+				Offset: 10297866
+				Length: 754800
+			^Content/ra/v2/speech.mix:
+				Offset: 23042864
+				Length: 2003464
+		extract-raw: Data/CNCDATA/RED_ALERT/COUNTERSTRIKE/MAIN.MIX
+			^Content/ra/v2/expand/araziod.aud:
+				Offset: 196490499
+				Length: 2941132
+			^Content/ra/v2/expand/backstab.aud:
+				Offset: 199431631
+				Length: 3178252
+			^Content/ra/v2/expand/chaos2.aud:
+				Offset: 202609883
+				Length: 2860068
+			^Content/ra/v2/expand/shut_it.aud:
+				Offset: 205469951
+				Length: 2991979
+			^Content/ra/v2/expand/2nd_hand.aud:
+				Offset: 193420407
+				Length: 3070092
+			^Content/ra/v2/expand/twinmix1.aud:
+				Offset: 208461930
+				Length: 2536972
+			^Content/ra/v2/expand/under3.aud:
+				Offset: 210998902
+				Length: 2812788
+			^Content/ra/v2/expand/vr2.aud:
+				Offset: 213811690
+				Length: 2920396
+			^Content/ra/v2/expand/await.aud:
+				Offset: 131079062
+				Length: 2972788
+		extract-raw: Data/CNCDATA/RED_ALERT/AFTERMATH/MAIN.MIX
+			^Content/ra/v2/expand/bog.aud:
+				Offset: 225446649
+				Length: 2386955
+			^Content/ra/v2/expand/float_v2.aud:
+				Offset: 227833604
+				Length: 3090115
+			^Content/ra/v2/expand/gloom.aud:
+				Offset: 230923719
+				Length: 2662851
+			^Content/ra/v2/expand/grndwire.aud:
+				Offset: 233586570
+				Length: 2573611
+			^Content/ra/v2/expand/rpt.aud:
+				Offset: 236160181
+				Length: 3092259
+			^Content/ra/v2/expand/search.aud:
+				Offset: 239252440
+				Length: 3104091
+			^Content/ra/v2/expand/traction.aud:
+				Offset: 242356531
+				Length: 2668003
+			^Content/ra/v2/expand/wastelnd.aud:
+				Offset: 245024534
+				Length: 2721563
+			^Content/ra/v2/expand/chrotnk1.aud:
+				Offset: 248925330
+				Length: 22900
+			^Content/ra/v2/expand/fixit1.aud:
+				Offset: 249170308
+				Length: 10707
+			^Content/ra/v2/expand/jburn1.aud:
+				Offset: 249316346
+				Length: 23091
+			^Content/ra/v2/expand/jchrge1.aud:
+				Offset: 249339437
+				Length: 14219
+			^Content/ra/v2/expand/jcrisp1.aud:
+				Offset: 249353656
+				Length: 18211
+			^Content/ra/v2/expand/jdance1.aud:
+				Offset: 249371867
+				Length: 14315
+			^Content/ra/v2/expand/jjuice1.aud:
+				Offset: 249386182
+				Length: 9699
+			^Content/ra/v2/expand/jjump1.aud:
+				Offset: 249395881
+				Length: 8219
+			^Content/ra/v2/expand/jlight1.aud:
+				Offset: 249404100
+				Length: 9875
+			^Content/ra/v2/expand/jpower1.aud:
+				Offset: 249413975
+				Length: 13571
+			^Content/ra/v2/expand/jshock1.aud:
+				Offset: 249427546
+				Length: 14771
+			^Content/ra/v2/expand/jyes1.aud:
+				Offset: 249442317
+				Length: 13795
+			^Content/ra/v2/expand/madchrg2.aud:
+				Offset: 249572228
+				Length: 19782
+			^Content/ra/v2/expand/madexplo.aud:
+				Offset: 249592010
+				Length: 26572
+			^Content/ra/v2/expand/mboss1.aud:
+				Offset: 249624058
+				Length: 20147
+			^Content/ra/v2/expand/mhear1.aud:
+				Offset: 249644205
+				Length: 6714
+			^Content/ra/v2/expand/mhotdig1.aud:
+				Offset: 249650919
+				Length: 10674
+			^Content/ra/v2/expand/mhowdy1.aud:
+				Offset: 249661593
+				Length: 6714
+			^Content/ra/v2/expand/mhuh1.aud:
+				Offset: 249668307
+				Length: 4117
+			^Content/ra/v2/expand/mlaff1.aud:
+				Offset: 249738299
+				Length: 24133
+			^Content/ra/v2/expand/mrise1.aud:
+				Offset: 249775832
+				Length: 13523
+			^Content/ra/v2/expand/mwrench1.aud:
+				Offset: 249789355
+				Length: 10780
+			^Content/ra/v2/expand/myeehaw1.aud:
+				Offset: 249800135
+				Length: 18912
+			^Content/ra/v2/expand/myes1.aud:
+				Offset: 249819047
+				Length: 9073
+		extract-raw: Data/CNCDATA/RED_ALERT/CD1/MAIN.MIX
+			^Content/ra/v2/movies/aagun.vqa:
+				Offset: 37694331
+				Length: 3295512
+			^Content/ra/v2/movies/aftrmath.vqa:
+				Offset: 40989843
+				Length: 2455774
+			^Content/ra/v2/movies/ally1.vqa:
+				Offset: 43445617
+				Length: 13536324
+			^Content/ra/v2/movies/ally10.vqa:
+				Offset: 56981941
+				Length: 21506358
+			^Content/ra/v2/movies/ally10b.vqa:
+				Offset: 78488299
+				Length: 2565152
+			^Content/ra/v2/movies/ally11.vqa:
+				Offset: 81053451
+				Length: 13600398
+			^Content/ra/v2/movies/ally12.vqa:
+				Offset: 94653849
+				Length: 7719544
+			^Content/ra/v2/movies/ally14.vqa:
+				Offset: 102373393
+				Length: 11659080
+			^Content/ra/v2/movies/ally2.vqa:
+				Offset: 114032473
+				Length: 8014018
+			^Content/ra/v2/movies/ally4.vqa:
+				Offset: 122046491
+				Length: 9441906
+			^Content/ra/v2/movies/ally5.vqa:
+				Offset: 131488397
+				Length: 21900328
+			^Content/ra/v2/movies/ally6.vqa:
+				Offset: 153388725
+				Length: 26454212
+			^Content/ra/v2/movies/ally8.vqa:
+				Offset: 179842937
+				Length: 15401062
+			^Content/ra/v2/movies/ally9.vqa:
+				Offset: 195243999
+				Length: 14901460
+			^Content/ra/v2/movies/allyend.vqa:
+				Offset: 210145459
+				Length: 27285692
+			^Content/ra/v2/movies/allymorf.vqa:
+				Offset: 237431151
+				Length: 916964
+			^Content/ra/v2/movies/apcescpe.vqa:
+				Offset: 238348115
+				Length: 1627564
+			^Content/ra/v2/movies/assess.vqa:
+				Offset: 239975679
+				Length: 2929218
+			^Content/ra/v2/movies/battle.vqa:
+				Offset: 242904897
+				Length: 2881110
+			^Content/ra/v2/movies/binoc.vqa:
+				Offset: 245786007
+				Length: 4045856
+			^Content/ra/v2/movies/bmap.vqa:
+				Offset: 249831863
+				Length: 2414312
+			^Content/ra/v2/movies/brdgtilt.vqa:
+				Offset: 252246175
+				Length: 1581318
+			^Content/ra/v2/movies/crontest.vqa:
+				Offset: 253827493
+				Length: 2036620
+			^Content/ra/v2/movies/cronfail.vqa:
+				Offset: 255864113
+				Length: 1717214
+			^Content/ra/v2/movies/destroyr.vqa:
+				Offset: 257581327
+				Length: 2178828
+			^Content/ra/v2/movies/dud.vqa:
+				Offset: 259760155
+				Length: 3110418
+			^Content/ra/v2/movies/elevator.vqa:
+				Offset: 262870573
+				Length: 1741894
+			^Content/ra/v2/movies/flare.vqa:
+				Offset: 264612467
+				Length: 1731744
+			^Content/ra/v2/movies/frozen.vqa:
+				Offset: 266344211
+				Length: 1836994
+			^Content/ra/v2/movies/grvestne.vqa:
+				Offset: 268181205
+				Length: 3155668
+			^Content/ra/v2/movies/landing.vqa:
+				Offset: 271336873
+				Length: 2374106
+			^Content/ra/v2/movies/masasslt.vqa:
+				Offset: 273710979
+				Length: 5354700
+			^Content/ra/v2/movies/mcv.vqa:
+				Offset: 279065679
+				Length: 1296036
+			^Content/ra/v2/movies/mcv_land.vqa:
+				Offset: 280361715
+				Length: 1424358
+			^Content/ra/v2/movies/montpass.vqa:
+				Offset: 281786073
+				Length: 1701852
+			^Content/ra/v2/movies/oildrum.vqa:
+				Offset: 283487925
+				Length: 2430792
+			^Content/ra/v2/movies/overrun.vqa:
+				Offset: 285918717
+				Length: 2174548
+			^Content/ra/v2/movies/prolog.vqa:
+				Offset: 288093265
+				Length: 28658198
+			^Content/ra/v2/movies/redintro.vqa:
+				Offset: 316751463
+				Length: 2269452
+			^Content/ra/v2/movies/shipsink.vqa:
+				Offset: 319020915
+				Length: 3150030
+			^Content/ra/v2/movies/shorbom1.vqa:
+				Offset: 322170945
+				Length: 4046650
+			^Content/ra/v2/movies/shorbom2.vqa:
+				Offset: 326217595
+				Length: 2150364
+			^Content/ra/v2/movies/shorbomb.vqa:
+				Offset: 328367959
+				Length: 6111616
+			^Content/ra/v2/movies/snowbomb.vqa:
+				Offset: 334479575
+				Length: 2465762
+			^Content/ra/v2/movies/soviet1.vqa:
+				Offset: 336945337
+				Length: 24112060
+			^Content/ra/v2/movies/sovtstar.vqa:
+				Offset: 361057397
+				Length: 670794
+			^Content/ra/v2/movies/spy.vqa:
+				Offset: 361728191
+				Length: 1646808
+			^Content/ra/v2/movies/tanya1.vqa:
+				Offset: 363374999
+				Length: 13389684
+			^Content/ra/v2/movies/tanya2.vqa:
+				Offset: 376764683
+				Length: 4103388
+			^Content/ra/v2/movies/toofar.vqa:
+				Offset: 380868071
+				Length: 4244572
+			^Content/ra/v2/movies/trinity.vqa:
+				Offset: 385112643
+				Length: 1669310
+			^Content/ra/v2/interior.mix:
+				Offset: 17172192
+				Length: 247425
+			^Content/ra/v2/conquer.mix:
+				Offset: 236
+				Length: 2177047
+			^Content/ra/v2/allies.mix:
+				Offset: 453257029
+				Length: 309406
+			^Content/ra/v2/temperat.mix:
+				Offset: 453566435
+				Length: 1038859
+			^Content/ra/v2/sounds.mix:
+				Offset: 451984174
+				Length: 1006778
+			^Content/ra/v2/snow.mix:
+				Offset: 450953313
+				Length: 1030861
+			^Content/ra/v2/scores.mix:
+				Offset: 386781953
+				Length: 64171360
+			^Content/ra/v2/russian.mix:
+				Offset: 452990952
+				Length: 266077

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -265,35 +265,35 @@ ModContent:
 	Packages:
 		base: Base Game Files
 			TestFiles: ^Content/ra/v2/allies.mix, ^Content/ra/v2/conquer.mix, ^Content/ra/v2/interior.mix, ^Content/ra/v2/hires.mix, ^Content/ra/v2/lores.mix, ^Content/ra/v2/local.mix, ^Content/ra/v2/speech.mix, ^Content/ra/v2/russian.mix, ^Content/ra/v2/snow.mix, ^Content/ra/v2/sounds.mix, ^Content/ra/v2/temperat.mix
-			Sources: allied, allied-linux, soviet, soviet-linux, tfd, ra-origin
+			Sources: allied, allied-linux, soviet, soviet-linux, tfd, ra-origin, ra-remaster-steam
 			Required: true
 			Download: basefiles
 		aftermathbase: Aftermath Expansion Files
 			TestFiles: ^Content/ra/v2/expand/expand2.mix, ^Content/ra/v2/expand/hires1.mix, ^Content/ra/v2/expand/lores1.mix, ^Content/ra/v2/expand/chrotnk1.aud, ^Content/ra/v2/expand/fixit1.aud, ^Content/ra/v2/expand/jburn1.aud, ^Content/ra/v2/expand/jchrge1.aud, ^Content/ra/v2/expand/jcrisp1.aud, ^Content/ra/v2/expand/jdance1.aud, ^Content/ra/v2/expand/jjuice1.aud, ^Content/ra/v2/expand/jjump1.aud, ^Content/ra/v2/expand/jlight1.aud, ^Content/ra/v2/expand/jpower1.aud, ^Content/ra/v2/expand/jshock1.aud, ^Content/ra/v2/expand/jyes1.aud, ^Content/ra/v2/expand/madchrg2.aud, ^Content/ra/v2/expand/madexplo.aud, ^Content/ra/v2/expand/mboss1.aud, ^Content/ra/v2/expand/mhear1.aud, ^Content/ra/v2/expand/mhotdig1.aud, ^Content/ra/v2/expand/mhowdy1.aud, ^Content/ra/v2/expand/mhuh1.aud, ^Content/ra/v2/expand/mlaff1.aud, ^Content/ra/v2/expand/mrise1.aud, ^Content/ra/v2/expand/mwrench1.aud, ^Content/ra/v2/expand/myeehaw1.aud, ^Content/ra/v2/expand/myes1.aud
-			Sources: aftermath, aftermath-linux, tfd, ra-origin
+			Sources: aftermath, aftermath-linux, tfd, ra-origin, ra-remaster-steam
 			Required: true
 			Download: aftermath
 		cncdesert: C&C Desert Tileset
 			TestFiles: ^Content/ra/v2/cnc/desert.mix
-			Sources: tfd, cnc-origin, cnc95, cnc95-linux
+			Sources: tfd, cnc-origin, cnc95, cnc95-linux, ra-remaster-steam
 			Required: true
 			Download: cncdesert
 		music: Base Game Music
 			TestFiles: ^Content/ra/v2/scores.mix
-			Sources: allied, allied-linux, soviet, soviet-linux, tfd, ra-origin
+			Sources: allied, allied-linux, soviet, soviet-linux, tfd, ra-origin, ra-remaster-steam
 			Download: music
 		movies-allied: Allied Campaign Briefings
 			TestFiles: ^Content/ra/v2/movies/aagun.vqa, ^Content/ra/v2/movies/aftrmath.vqa, ^Content/ra/v2/movies/ally1.vqa, ^Content/ra/v2/movies/ally10.vqa, ^Content/ra/v2/movies/ally10b.vqa, ^Content/ra/v2/movies/ally11.vqa, ^Content/ra/v2/movies/ally12.vqa, ^Content/ra/v2/movies/ally14.vqa, ^Content/ra/v2/movies/ally2.vqa, ^Content/ra/v2/movies/ally4.vqa, ^Content/ra/v2/movies/ally5.vqa, ^Content/ra/v2/movies/ally6.vqa, ^Content/ra/v2/movies/ally8.vqa, ^Content/ra/v2/movies/ally9.vqa, ^Content/ra/v2/movies/allyend.vqa, ^Content/ra/v2/movies/allymorf.vqa, ^Content/ra/v2/movies/apcescpe.vqa, ^Content/ra/v2/movies/assess.vqa, ^Content/ra/v2/movies/battle.vqa, ^Content/ra/v2/movies/binoc.vqa, ^Content/ra/v2/movies/bmap.vqa, ^Content/ra/v2/movies/brdgtilt.vqa, ^Content/ra/v2/movies/crontest.vqa, ^Content/ra/v2/movies/cronfail.vqa, ^Content/ra/v2/movies/destroyr.vqa, ^Content/ra/v2/movies/dud.vqa, ^Content/ra/v2/movies/elevator.vqa, ^Content/ra/v2/movies/flare.vqa, ^Content/ra/v2/movies/frozen.vqa, ^Content/ra/v2/movies/grvestne.vqa, ^Content/ra/v2/movies/landing.vqa, ^Content/ra/v2/movies/masasslt.vqa, ^Content/ra/v2/movies/mcv.vqa, ^Content/ra/v2/movies/mcv_land.vqa, ^Content/ra/v2/movies/montpass.vqa, ^Content/ra/v2/movies/oildrum.vqa, ^Content/ra/v2/movies/overrun.vqa, ^Content/ra/v2/movies/prolog.vqa, ^Content/ra/v2/movies/redintro.vqa, ^Content/ra/v2/movies/shipsink.vqa, ^Content/ra/v2/movies/shorbom1.vqa, ^Content/ra/v2/movies/shorbom2.vqa, ^Content/ra/v2/movies/shorbomb.vqa, ^Content/ra/v2/movies/snowbomb.vqa, ^Content/ra/v2/movies/soviet1.vqa, ^Content/ra/v2/movies/sovtstar.vqa, ^Content/ra/v2/movies/spy.vqa, ^Content/ra/v2/movies/tanya1.vqa, ^Content/ra/v2/movies/tanya2.vqa, ^Content/ra/v2/movies/toofar.vqa, ^Content/ra/v2/movies/trinity.vqa
-			Sources: allied, allied-linux, tfd, ra-origin
+			Sources: allied, allied-linux, tfd, ra-origin, ra-remaster-steam
 		movies-soviet: Soviet Campaign Briefings
 			TestFiles: ^Content/ra/v2/movies/aagun.vqa, ^Content/ra/v2/movies/cronfail.vqa, ^Content/ra/v2/movies/airfield.vqa, ^Content/ra/v2/movies/ally1.vqa, ^Content/ra/v2/movies/allymorf.vqa, ^Content/ra/v2/movies/averted.vqa, ^Content/ra/v2/movies/beachead.vqa, ^Content/ra/v2/movies/bmap.vqa, ^Content/ra/v2/movies/bombrun.vqa, ^Content/ra/v2/movies/countdwn.vqa, ^Content/ra/v2/movies/double.vqa, ^Content/ra/v2/movies/dpthchrg.vqa, ^Content/ra/v2/movies/execute.vqa, ^Content/ra/v2/movies/flare.vqa, ^Content/ra/v2/movies/landing.vqa, ^Content/ra/v2/movies/mcvbrdge.vqa, ^Content/ra/v2/movies/mig.vqa, ^Content/ra/v2/movies/movingin.vqa, ^Content/ra/v2/movies/mtnkfact.vqa, ^Content/ra/v2/movies/nukestok.vqa, ^Content/ra/v2/movies/onthprwl.vqa, ^Content/ra/v2/movies/periscop.vqa, ^Content/ra/v2/movies/prolog.vqa, ^Content/ra/v2/movies/radrraid.vqa, ^Content/ra/v2/movies/redintro.vqa, ^Content/ra/v2/movies/search.vqa, ^Content/ra/v2/movies/sfrozen.vqa, ^Content/ra/v2/movies/sitduck.vqa, ^Content/ra/v2/movies/slntsrvc.vqa, ^Content/ra/v2/movies/snowbomb.vqa, ^Content/ra/v2/movies/snstrafe.vqa, ^Content/ra/v2/movies/sovbatl.vqa, ^Content/ra/v2/movies/sovcemet.vqa, ^Content/ra/v2/movies/sovfinal.vqa, ^Content/ra/v2/movies/soviet1.vqa, ^Content/ra/v2/movies/soviet10.vqa, ^Content/ra/v2/movies/soviet11.vqa, ^Content/ra/v2/movies/soviet12.vqa, ^Content/ra/v2/movies/soviet13.vqa, ^Content/ra/v2/movies/soviet14.vqa, ^Content/ra/v2/movies/soviet2.vqa, ^Content/ra/v2/movies/soviet3.vqa, ^Content/ra/v2/movies/soviet4.vqa, ^Content/ra/v2/movies/soviet5.vqa, ^Content/ra/v2/movies/soviet6.vqa, ^Content/ra/v2/movies/soviet7.vqa, ^Content/ra/v2/movies/soviet8.vqa, ^Content/ra/v2/movies/soviet9.vqa, ^Content/ra/v2/movies/sovmcv.vqa, ^Content/ra/v2/movies/sovtstar.vqa, ^Content/ra/v2/movies/spotter.vqa, ^Content/ra/v2/movies/strafe.vqa, ^Content/ra/v2/movies/take_off.vqa, ^Content/ra/v2/movies/tesla.vqa, ^Content/ra/v2/movies/v2rocket.vqa
 			Sources: soviet, soviet-linux, tfd, ra-origin
 		music-counterstrike: Counterstrike Music
 			TestFiles: ^Content/ra/v2/expand/araziod.aud, ^Content/ra/v2/expand/backstab.aud, ^Content/ra/v2/expand/chaos2.aud, ^Content/ra/v2/expand/shut_it.aud, ^Content/ra/v2/expand/2nd_hand.aud, ^Content/ra/v2/expand/twinmix1.aud, ^Content/ra/v2/expand/under3.aud, ^Content/ra/v2/expand/vr2.aud,
-			Sources: counterstrike, counterstrike-linux, ra-origin
+			Sources: counterstrike, counterstrike-linux, ra-origin, ra-remaster-steam
 		music-aftermath: Aftermath Music
 			TestFiles: ^Content/ra/v2/expand/await.aud, ^Content/ra/v2/expand/bog.aud, ^Content/ra/v2/expand/float_v2.aud, ^Content/ra/v2/expand/gloom.aud, ^Content/ra/v2/expand/grndwire.aud, ^Content/ra/v2/expand/rpt.aud, ^Content/ra/v2/expand/search.aud, ^Content/ra/v2/expand/traction.aud, ^Content/ra/v2/expand/wastelnd.aud
-			Sources: aftermath, aftermath-linux, ra-origin
+			Sources: aftermath, aftermath-linux, ra-origin, ra-remaster-steam
 	Downloads:
 		ra|installer/downloads.yaml
 	Sources:
@@ -304,3 +304,4 @@ ModContent:
 		ra|installer/firstdecade.yaml
 		ra|installer/origin.yaml
 		ra|installer/soviet95.yaml
+		ra|installer/remaster.yaml


### PR DESCRIPTION
I finished RA first. The remasters don't ship the soviet videos so we can't install those.