### PR TITLE
Fix copying public key to clipboard if already linked to a forum account

### DIFF
--- a/OpenRA.Game/LocalPlayerProfile.cs
+++ b/OpenRA.Game/LocalPlayerProfile.cs
@@ -80,8 +80,6 @@ namespace OpenRA
 			{
 				try
 				{
-					innerState = LinkState.Unlinked;
-
 					if (i.Error != null)
 					{
 						innerState = LinkState.ConnectionFailed;
@@ -100,6 +98,8 @@ namespace OpenRA
 						else
 							innerState = LinkState.Linked;
 					}
+					else
+						innerState = LinkState.Unlinked;
 				}
 				catch (Exception e)
 				{


### PR DESCRIPTION
Fixes #18217.

When launching OpenRA, our `LocalPlayerProfile.LinkState` begins as `Unlinked`. When checking our key pair, state is set to `CheckingLink`, then shortly moved back to `Unlinked`. Depending on timing, the check [here](https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs#L49) can evaluate to true even if we have a valid key pair, copying our public key to clipboard when we don't need it.

This change appropriately keeps us at `CheckingLink` when validating our key pair, and will set back to `Unlinked` if appropriate.

To help ensure nothing was broken by this change I re-tested authentication with these tests:

- No `player.oraid` file. Generated a new key and logged in.
- Logged out. Generated a new key and logged in.
- Revoked my public keys. Restarted OpenRA. Generated a new key and logged in.
- Logged out. Left OpenRA on the "A key has been copied..." prompt. Cleraed clipboard. Restarted OpenRA. Generated a new key and logged in.

I did not test a connection failed state, but that should be unaffected.