### PR TITLE
Overhaul editor ActorInit handling

### DIFF
--- a/OpenRA.Game/Map/ActorInitializer.cs
+++ b/OpenRA.Game/Map/ActorInitializer.cs
@@ -145,6 +145,9 @@ namespace OpenRA
 		protected ValueActorInit(TraitInfo info, T value)
 			: base(info.InstanceName) { this.value = value; }
 
+		protected ValueActorInit(string instanceName, T value)
+			: base(instanceName) { this.value = value; }
+
 		protected ValueActorInit(T value) { this.value = value; }
 
 		public virtual T Value { get { return value; } }

--- a/OpenRA.Game/Map/ActorInitializer.cs
+++ b/OpenRA.Game/Map/ActorInitializer.cs
@@ -26,6 +26,12 @@ namespace OpenRA
 		U GetValue<T, U>(TraitInfo info) where T : ValueActorInit<U>;
 		U GetValue<T, U>(TraitInfo info, U fallback) where T : ValueActorInit<U>;
 		bool Contains<T>(TraitInfo info) where T : ActorInit;
+
+		T GetOrDefault<T>() where T : ActorInit, ISingleInstanceInit;
+		T Get<T>() where T : ActorInit, ISingleInstanceInit;
+		U GetValue<T, U>() where T : ValueActorInit<U>, ISingleInstanceInit;
+		U GetValue<T, U>(U fallback) where T : ValueActorInit<U>, ISingleInstanceInit;
+		bool Contains<T>() where T : ActorInit, ISingleInstanceInit;
 	}
 
 	public class ActorInitializer : IActorInitializer
@@ -77,6 +83,29 @@ namespace OpenRA
 		}
 
 		public bool Contains<T>(TraitInfo info) where T : ActorInit { return GetOrDefault<T>(info) != null; }
+
+		public T GetOrDefault<T>() where T : ActorInit, ISingleInstanceInit
+		{
+			return Dict.GetOrDefault<T>();
+		}
+
+		public T Get<T>() where T : ActorInit, ISingleInstanceInit
+		{
+			return Dict.Get<T>();
+		}
+
+		public U GetValue<T, U>() where T : ValueActorInit<U>, ISingleInstanceInit
+		{
+			return Get<T>().Value;
+		}
+
+		public U GetValue<T, U>(U fallback) where T : ValueActorInit<U>, ISingleInstanceInit
+		{
+			var init = GetOrDefault<T>();
+			return init != null ? init.Value : fallback;
+		}
+
+		public bool Contains<T>() where T : ActorInit, ISingleInstanceInit { return GetOrDefault<T>() != null; }
 	}
 
 	/*
@@ -88,6 +117,9 @@ namespace OpenRA
 	 *   finds with an argument type that matches the given LuaValue.
 	 * - Most ActorInits will want to inherit either ValueActorInit<T> or CompositeActorInit which hide the low-level plumbing.
 	 * - Inits that reference actors should use ActorInitActorReference which allows actors to be referenced by name in map.yaml
+	 * - Inits that should only have a single instance defined on an actor should implement ISingleInstanceInit to allow
+	 *   direct queries and runtime enforcement.
+	 * - Inits that aren't ISingleInstanceInit should expose a ctor that accepts a TraitInfo to allow per-trait targeting.
 	 */
 	public abstract class ActorInit
 	{
@@ -103,6 +135,8 @@ namespace OpenRA
 
 		public abstract MiniYaml Save();
 	}
+
+	public interface ISingleInstanceInit { }
 
 	public abstract class ValueActorInit<T> : ActorInit
 	{
@@ -182,16 +216,13 @@ namespace OpenRA
 		}
 	}
 
-	public class LocationInit : ValueActorInit<CPos>
+	public class LocationInit : ValueActorInit<CPos>, ISingleInstanceInit
 	{
-		public LocationInit(TraitInfo info, CPos value)
-			: base(info, value) { }
-
 		public LocationInit(CPos value)
 			: base(value) { }
 	}
 
-	public class OwnerInit : ActorInit
+	public class OwnerInit : ActorInit, ISingleInstanceInit
 	{
 		public readonly string InternalName;
 		protected readonly Player value;

--- a/OpenRA.Game/Map/ActorReference.cs
+++ b/OpenRA.Game/Map/ActorReference.cs
@@ -40,7 +40,14 @@ namespace OpenRA
 			{
 				var dict = new TypeDictionary();
 				foreach (var i in inits)
-					dict.Add(LoadInit(i.Key, i.Value));
+				{
+					var init = LoadInit(i.Key, i.Value);
+					if (init is ISingleInstanceInit && dict.Contains(init.GetType()))
+						throw new InvalidDataException("Duplicate initializer '{0}'".F(init.GetType().Name));
+
+					dict.Add(init);
+				}
+
 				return dict;
 			});
 		}
@@ -88,7 +95,14 @@ namespace OpenRA
 		}
 
 		// for initialization syntax
-		public void Add(object o) { InitDict.Add(o); }
+		public void Add(ActorInit init)
+		{
+			if (init is ISingleInstanceInit && InitDict.Contains(init.GetType()))
+				throw new InvalidDataException("Duplicate initializer '{0}'".F(init.GetType().Name));
+
+			InitDict.Add(init);
+		}
+
 		public IEnumerator GetEnumerator() { return InitDict.GetEnumerator(); }
 
 		public ActorReference Clone()

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -276,7 +276,7 @@ namespace OpenRA
 					foreach (var kv in actorDefinitions.Nodes.Where(d => d.Value.Value == "mpspawn"))
 					{
 						var s = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
-						spawns.Add(s.InitDict.Get<LocationInit>().Value);
+						spawns.Add(s.Get<LocationInit>().Value);
 					}
 
 					newData.SpawnPoints = spawns.ToArray();

--- a/OpenRA.Game/Primitives/TypeDictionary.cs
+++ b/OpenRA.Game/Primitives/TypeDictionary.cs
@@ -41,6 +41,11 @@ namespace OpenRA.Primitives
 			return data.ContainsKey(typeof(T));
 		}
 
+		public bool Contains(Type t)
+		{
+			return data.ContainsKey(t);
+		}
+
 		public T Get<T>()
 		{
 			return (T)Get(typeof(T), true);

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -334,6 +334,11 @@ namespace OpenRA
 			return CreateActor(true, name, initDict);
 		}
 
+		public Actor CreateActor(bool addToWorld, ActorReference reference)
+		{
+			return CreateActor(addToWorld, reference.Type, reference.InitDict);
+		}
+
 		public Actor CreateActor(bool addToWorld, string name, TypeDictionary initDict)
 		{
 			var a = new Actor(this, name, initDict);

--- a/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
+++ b/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			self = init.Self;
 
-			var returnInit = init.GetOrDefault<ChronoshiftReturnInit>(info);
+			var returnInit = init.GetOrDefault<ChronoshiftReturnInit>();
 			if (returnInit != null)
 			{
 				ReturnTicks = returnInit.Ticks;
@@ -176,7 +176,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		void ITransformActorInitModifier.ModifyTransformActorInit(Actor self, TypeDictionary init) { ModifyActorInit(init); }
 	}
 
-	public class ChronoshiftReturnInit : CompositeActorInit
+	public class ChronoshiftReturnInit : CompositeActorInit, ISingleInstanceInit
 	{
 		public readonly int Ticks;
 		public readonly int Duration;

--- a/OpenRA.Mods.Cnc/Traits/ConyardChronoReturn.cs
+++ b/OpenRA.Mods.Cnc/Traits/ConyardChronoReturn.cs
@@ -95,9 +95,9 @@ namespace OpenRA.Mods.Cnc.Traits
 			health = self.Trait<Health>();
 
 			wsb = self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == info.Body);
-			faction = init.GetValue<FactionInit, string>(info, self.Owner.Faction.InternalName);
+			faction = init.GetValue<FactionInit, string>(self.Owner.Faction.InternalName);
 
-			var returnInit = init.GetOrDefault<ChronoshiftReturnInit>(info);
+			var returnInit = init.GetOrDefault<ChronoshiftReturnInit>();
 			if (returnInit != null)
 			{
 				returnTicks = returnInit.Ticks;

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForTransform.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForTransform.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public InfiltrateForTransform(ActorInitializer init, InfiltrateForTransformInfo info)
 		{
 			this.info = info;
-			faction = init.GetValue<FactionInit, string>(info, init.Self.Owner.Faction.InternalName);
+			faction = init.GetValue<FactionInit, string>(init.Self.Owner.Faction.InternalName);
 		}
 
 		void INotifyInfiltrated.Infiltrated(Actor self, Actor infiltrator, BitSet<TargetableType> types)

--- a/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			var bibOffset = bi.Dimensions.Y - rows;
 			var centerOffset = bi.CenterOffset(init.World);
 			var map = init.World.Map;
-			var location = init.GetValue<LocationInit, CPos>(this, CPos.Zero);
+			var location = init.GetValue<LocationInit, CPos>(CPos.Zero);
 
 			for (var i = 0; i < rows * width; i++)
 			{

--- a/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		IEnumerable<object> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)
+		IEnumerable<ActorInit> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)
 		{
 			yield return new HideBibPreviewInit();
 		}

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public int GetInitialFacing() { return InitialFacing; }
 
-		IEnumerable<object> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)
+		IEnumerable<ActorInit> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)
 		{
 			yield return new FacingInit(PreviewFacing);
 		}

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -82,15 +82,15 @@ namespace OpenRA.Mods.Cnc.Traits
 			Info = info;
 			self = init.Self;
 
-			var locationInit = init.GetOrDefault<LocationInit>(info);
+			var locationInit = init.GetOrDefault<LocationInit>();
 			if (locationInit != null)
 				SetPosition(self, locationInit.Value);
 
-			var centerPositionInit = init.GetOrDefault<CenterPositionInit>(info);
+			var centerPositionInit = init.GetOrDefault<CenterPositionInit>();
 			if (centerPositionInit != null)
 				SetPosition(self, centerPositionInit.Value);
 
-			Facing = WAngle.FromFacing(init.GetValue<FacingInit, int>(info, Info.GetInitialFacing()));
+			Facing = WAngle.FromFacing(init.GetValue<FacingInit, int>(Info.GetInitialFacing()));
 
 			// Prevent mappers from setting bogus facings
 			if (Facing != Left && Facing != Right)

--- a/OpenRA.Mods.Common/ActorInitializer.cs
+++ b/OpenRA.Mods.Common/ActorInitializer.cs
@@ -16,38 +16,38 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common
 {
-	public class FacingInit : ValueActorInit<int>
+	public class FacingInit : ValueActorInit<int>, ISingleInstanceInit
 	{
 		public FacingInit(int value)
 			: base(value) { }
 	}
 
-	public class CreationActivityDelayInit : ValueActorInit<int>
+	public class CreationActivityDelayInit : ValueActorInit<int>, ISingleInstanceInit
 	{
 		public CreationActivityDelayInit(int value)
 			: base(value) { }
 	}
 
-	public class DynamicFacingInit : ValueActorInit<Func<int>>
+	public class DynamicFacingInit : ValueActorInit<Func<int>>, ISingleInstanceInit
 	{
 		public DynamicFacingInit(Func<int> value)
 			: base(value) { }
 	}
 
-	public class SubCellInit : ValueActorInit<SubCell>
+	public class SubCellInit : ValueActorInit<SubCell>, ISingleInstanceInit
 	{
 		public SubCellInit(SubCell value)
 			: base(value) { }
 	}
 
-	public class CenterPositionInit : ValueActorInit<WPos>
+	public class CenterPositionInit : ValueActorInit<WPos>, ISingleInstanceInit
 	{
 		public CenterPositionInit(WPos value)
 			: base(value) { }
 	}
 
 	// Allows maps / transformations to specify the faction variant of an actor.
-	public class FactionInit : ValueActorInit<string>
+	public class FactionInit : ValueActorInit<string>, ISingleInstanceInit
 	{
 		public FactionInit(string value)
 			: base(value) { }

--- a/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Widgets
 				if (!actor.Footprint.All(c => world.Map.Tiles.Contains(c.Key)))
 					return true;
 
-				var action = new AddActorAction(editorLayer, actor.Actor);
+				var action = new AddActorAction(editorLayer, actor.Export());
 				editorActionManager.Add(action);
 			}
 

--- a/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
@@ -134,11 +134,11 @@ namespace OpenRA.Mods.Common.Widgets
 							continue;
 
 						var copy = preview.Export();
-						if (copy.InitDict.Contains<LocationInit>())
+						var locationInit = copy.GetOrDefault<LocationInit>();
+						if (locationInit != null)
 						{
-							var location = copy.InitDict.Get<LocationInit>();
-							copy.InitDict.Remove(location);
-							copy.InitDict.Add(new LocationInit(location.Value + offset));
+							copy.RemoveAll<LocationInit>();
+							copy.Add(new LocationInit(locationInit.Value + offset));
 						}
 
 						previews.Add(preview.ID, copy);

--- a/OpenRA.Mods.Common/Graphics/ActorPreview.cs
+++ b/OpenRA.Mods.Common/Graphics/ActorPreview.cs
@@ -77,6 +77,29 @@ namespace OpenRA.Mods.Common.Graphics
 			return init != null ? init.Value : fallback;
 		}
 
+		public bool Contains<T>() where T : ActorInit, ISingleInstanceInit { return GetOrDefault<T>() != null; }
+
+		public T GetOrDefault<T>() where T : ActorInit, ISingleInstanceInit
+		{
+			return dict.GetOrDefault<T>();
+		}
+
+		public T Get<T>() where T : ActorInit, ISingleInstanceInit
+		{
+			return dict.Get<T>();
+		}
+
+		public U GetValue<T, U>() where T : ValueActorInit<U>, ISingleInstanceInit
+		{
+			return Get<T>().Value;
+		}
+
+		public U GetValue<T, U>(U fallback) where T : ValueActorInit<U>, ISingleInstanceInit
+		{
+			var init = GetOrDefault<T>();
+			return init != null ? init.Value : fallback;
+		}
+
 		public bool Contains<T>(TraitInfo info) where T : ActorInit { return GetOrDefault<T>(info) != null; }
 
 		public Func<WRot> GetOrientation()

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Lint
 				foreach (var kv in map.ActorDefinitions.Where(d => d.Value.Value == "mpspawn"))
 				{
 					var s = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
-					spawns.Add(s.InitDict.Get<LocationInit>().Value);
+					spawns.Add(s.Get<LocationInit>().Value);
 				}
 
 				if (playerCount > spawns.Count)
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Lint
 			foreach (var kv in map.ActorDefinitions)
 			{
 				var actorReference = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
-				var ownerInit = actorReference.InitDict.GetOrDefault<OwnerInit>();
+				var ownerInit = actorReference.GetOrDefault<OwnerInit>();
 				if (ownerInit == null)
 					emitError("Actor {0} is not owned by any player.".F(kv.Key));
 				else

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -249,16 +249,16 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			self = init.Self;
 
-			var locationInit = init.GetOrDefault<LocationInit>(info);
+			var locationInit = init.GetOrDefault<LocationInit>();
 			if (locationInit != null)
 				SetPosition(self, locationInit.Value);
 
-			var centerPositionInit = init.GetOrDefault<CenterPositionInit>(info);
+			var centerPositionInit = init.GetOrDefault<CenterPositionInit>();
 			if (centerPositionInit != null)
 				SetPosition(self, centerPositionInit.Value);
 
-			Facing = WAngle.FromFacing(init.GetValue<FacingInit, int>(info, Info.InitialFacing));
-			creationActivityDelay = init.GetValue<CreationActivityDelayInit, int>(info, 0);
+			Facing = WAngle.FromFacing(init.GetValue<FacingInit, int>(Info.InitialFacing));
+			creationActivityDelay = init.GetValue<CreationActivityDelayInit, int>(0);
 		}
 
 		public WDist LandAltitude

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -184,7 +184,7 @@ namespace OpenRA.Mods.Common.Traits
 			yield return new EditorActorSlider("Facing", EditorFacingDisplayOrder, 0, 255, 8,
 				actor =>
 				{
-					var init = actor.Init<FacingInit>();
+					var init = actor.GetInitOrDefault<FacingInit>(this);
 					return init != null ? init.Value : InitialFacing;
 				},
 				(actor, value) => actor.ReplaceInit(new FacingInit((int)value)));

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -150,7 +150,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override object Create(ActorInitializer init) { return new Aircraft(init, this); }
 
-		IEnumerable<object> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)
+		IEnumerable<ActorInit> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)
 		{
 			yield return new FacingInit(PreviewFacing);
 		}

--- a/OpenRA.Mods.Common/Traits/AppearsOnMapPreview.cs
+++ b/OpenRA.Mods.Common/Traits/AppearsOnMapPreview.cs
@@ -42,14 +42,14 @@ namespace OpenRA.Mods.Common.Traits
 			}
 			else
 			{
-				var owner = map.PlayerDefinitions.Single(p => s.InitDict.Get<OwnerInit>().InternalName == p.Value.Nodes.Last(k => k.Key == "Name").Value.Value);
+				var owner = map.PlayerDefinitions.Single(p => s.Get<OwnerInit>().InternalName == p.Value.Nodes.Last(k => k.Key == "Name").Value.Value);
 				var colorValue = owner.Value.Nodes.Where(n => n.Key == "Color");
 				var ownerColor = colorValue.Any() ? colorValue.First().Value.Value : "FFFFFF";
 				Color.TryParse(ownerColor, out color);
 			}
 
 			var ios = ai.TraitInfo<IOccupySpaceInfo>();
-			var cells = ios.OccupiedCells(ai, s.InitDict.Get<LocationInit>().Value);
+			var cells = ios.OccupiedCells(ai, s.Get<LocationInit>().Value);
 			foreach (var cell in cells)
 				destinationBuffer.Add(new Pair<MPos, Color>(cell.Key.ToMPos(map), color));
 		}

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Traits
 			yield return new EditorActorDropdown("Stance", EditorStanceDisplayOrder, labels,
 				actor =>
 				{
-					var init = actor.Init<StanceInit>();
+					var init = actor.GetInitOrDefault<StanceInit>(this);
 					var stance = init != null ? init.Value : InitialStance;
 					return stances[(int)stance];
 				},

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -183,7 +183,7 @@ namespace OpenRA.Mods.Common.Traits
 			var self = init.Self;
 			ActiveAttackBases = self.TraitsImplementing<AttackBase>().ToArray().Where(Exts.IsTraitEnabled);
 
-			stance = init.GetValue<StanceInit, UnitStance>(info, self.Owner.IsBot || !self.Owner.Playable ? info.InitialStanceAI : info.InitialStance);
+			stance = init.GetValue<StanceInit, UnitStance>(self.Owner.IsBot || !self.Owner.Playable ? info.InitialStanceAI : info.InitialStance);
 
 			PredictedStance = stance;
 
@@ -445,7 +445,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class StanceInit : ValueActorInit<UnitStance>
+	public class StanceInit : ValueActorInit<UnitStance>, ISingleInstanceInit
 	{
 		public StanceInit(TraitInfo info, UnitStance value)
 			: base(info, value) { }

--- a/OpenRA.Mods.Common/Traits/BodyOrientation.cs
+++ b/OpenRA.Mods.Common/Traits/BodyOrientation.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.info = info;
 			var self = init.Self;
-			var faction = init.GetValue<FactionInit, string>(info, self.Owner.Faction.InternalName);
+			var faction = init.GetValue<FactionInit, string>(self.Owner.Faction.InternalName);
 
 			quantizedFacings = Exts.Lazy(() =>
 			{

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -278,7 +278,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Building(ActorInitializer init, BuildingInfo info)
 		{
 			self = init.Self;
-			topLeft = init.GetValue<LocationInit, CPos>(info);
+			topLeft = init.GetValue<LocationInit, CPos>();
 			Info = info;
 			influence = self.World.WorldActor.Trait<BuildingInfluence>();
 

--- a/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Traits
 			: base(info, value) { }
 	}
 
-	public class ParentActorInit : ValueActorInit<ActorInitActorReference>
+	public class ParentActorInit : ValueActorInit<ActorInitActorReference>, ISingleInstanceInit
 	{
 		public ParentActorInit(Actor value)
 			: base(value) { }

--- a/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 			yield return new EditorActorCheckbox("Spawn Child Actor", EditorFreeActorDisplayOrder,
 				actor =>
 				{
-					var init = actor.Init<FreeActorInit>();
+					var init = actor.GetInitOrDefault<FreeActorInit>(this);
 					if (init != null)
 						return init.Value;
 
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 				},
 				(actor, value) =>
 				{
-					actor.ReplaceInit(new FreeActorInit(this, value));
+					actor.ReplaceInit(new FreeActorInit(this, value), this);
 				});
 		}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/LegacyBridgeHut.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/LegacyBridgeHut.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public LegacyBridgeHut(ActorInitializer init, LegacyBridgeHutInfo info)
 		{
-			var bridge = init.Get<ParentActorInit>(info).Value;
+			var bridge = init.Get<ParentActorInit>().Value;
 			init.World.AddFrameEndTask(_ =>
 			{
 				Bridge = bridge.Actor(init.World).Value.Trait<Bridge>();

--- a/OpenRA.Mods.Common/Traits/Buildings/LineBuild.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/LineBuild.cs
@@ -16,13 +16,13 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	public enum LineBuildDirection { Unset, X, Y }
-	public class LineBuildDirectionInit : ValueActorInit<LineBuildDirection>
+	public class LineBuildDirectionInit : ValueActorInit<LineBuildDirection>, ISingleInstanceInit
 	{
 		public LineBuildDirectionInit(LineBuildDirection value)
 			: base(value) { }
 	}
 
-	public class LineBuildParentInit : ValueActorInit<string[]>
+	public class LineBuildParentInit : ValueActorInit<string[]>, ISingleInstanceInit
 	{
 		readonly Actor[] parents = null;
 
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.Traits
 		public LineBuild(ActorInitializer init, LineBuildInfo info)
 		{
 			this.info = info;
-			var lineBuildParentInit = init.GetOrDefault<LineBuildParentInit>(info);
+			var lineBuildParentInit = init.GetOrDefault<LineBuildParentInit>();
 			if (lineBuildParentInit != null)
 				parentNodes = lineBuildParentInit.ActorValue(init.World);
 		}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits
 			yield return new EditorActorCheckbox("Deployed", EditorDeployedDisplayOrder,
 				actor =>
 				{
-					var init = actor.Init<DeployStateInit>();
+					var init = actor.GetInitOrDefault<DeployStateInit>();
 					if (init != null)
 						return init.Value == DeployState.Deployed;
 

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 				},
 				(actor, value) =>
 				{
-					actor.ReplaceInit(new DeployStateInit(this, value ? DeployState.Deployed : DeployState.Undeployed));
+					actor.ReplaceInit(new DeployStateInit(value ? DeployState.Deployed : DeployState.Undeployed));
 				});
 		}
 
@@ -111,7 +111,7 @@ namespace OpenRA.Mods.Common.Traits
 			checkTerrainType = info.AllowedTerrainTypes.Count > 0;
 			canTurn = self.Info.HasTraitInfo<IFacingInfo>();
 			move = self.TraitOrDefault<IMove>();
-			deployState = init.GetValue<DeployStateInit, DeployState>(info, DeployState.Undeployed);
+			deployState = init.GetValue<DeployStateInit, DeployState>(DeployState.Undeployed);
 		}
 
 		protected override void Created(Actor self)
@@ -337,11 +337,8 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class DeployStateInit : ValueActorInit<DeployState>
+	public class DeployStateInit : ValueActorInit<DeployState>, ISingleInstanceInit
 	{
-		public DeployStateInit(TraitInfo info, DeployState value)
-			: base(info, value) { }
-
 		public DeployStateInit(DeployState value)
 			: base(value) { }
 	}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnFaction.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnFaction.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 		public GrantConditionOnFaction(ActorInitializer init, GrantConditionOnFactionInfo info)
 			: base(info)
 		{
-			faction = init.GetValue<FactionInit, string>(info, init.Self.Owner.Faction.InternalName);
+			faction = init.GetValue<FactionInit, string>(init.Self.Owner.Faction.InternalName);
 		}
 
 		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLineBuildDirection.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLineBuildDirection.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 		public GrantConditionOnLineBuildDirection(ActorInitializer init, GrantConditionOnLineBuildDirectionInfo info)
 		{
 			this.info = info;
-			direction = init.GetValue<LineBuildDirectionInit, LineBuildDirection>(info);
+			direction = init.GetValue<LineBuildDirectionInit, LineBuildDirection>();
 		}
 
 		void INotifyCreated.Created(Actor self)

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Traits
 			self = init.Self;
 			this.info = info;
 
-			var locationInit = init.GetOrDefault<LocationInit>(info);
+			var locationInit = init.GetOrDefault<LocationInit>();
 			if (locationInit != null)
 				SetPosition(self, locationInit.Value);
 		}

--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 			yield return new EditorActorSlider("Health", EditorHealthDisplayOrder, 0, 100, 5,
 				actor =>
 				{
-					var init = actor.Init<HealthInit>();
+					var init = actor.GetInitOrDefault<HealthInit>();
 					return init != null ? init.Value : 100;
 				},
 				(actor, value) => actor.ReplaceInit(new HealthInit((int)value)));

--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Traits
 			MaxHP = hp = info.HP > 0 ? info.HP : 1;
 
 			// Cast to long to avoid overflow when multiplying by the health
-			var healthInit = init.GetOrDefault<HealthInit>(info);
+			var healthInit = init.GetOrDefault<HealthInit>();
 			if (healthInit != null)
 				hp = (int)(healthInit.Value * (long)MaxHP / 100);
 
@@ -233,12 +233,9 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class HealthInit : ValueActorInit<int>
+	public class HealthInit : ValueActorInit<int>, ISingleInstanceInit
 	{
 		readonly bool allowZero;
-
-		public HealthInit(TraitInfo info, int value, bool allowZero = false)
-			: base(info, value) { this.allowZero = allowZero; }
 
 		public HealthInit(int value, bool allowZero = false)
 			: base(value) { this.allowZero = allowZero; }

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Facing to use for actor previews (map editor, color picker, etc)")]
 		public readonly int PreviewFacing = 96;
 
-		IEnumerable<object> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)
+		IEnumerable<ActorInit> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)
 		{
 			yield return new FacingInit(PreviewFacing);
 		}

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -78,11 +78,11 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 			self = init.Self;
 
-			TopLeft = init.GetValue<LocationInit, CPos>(info);
-			CenterPosition = init.GetValue<CenterPositionInit, WPos>(info, init.World.Map.CenterOfCell(TopLeft));
-			Facing = WAngle.FromFacing(init.GetValue<FacingInit, int>(info, 128));
+			TopLeft = init.GetValue<LocationInit, CPos>();
+			CenterPosition = init.GetValue<CenterPositionInit, WPos>(init.World.Map.CenterOfCell(TopLeft));
+			Facing = WAngle.FromFacing(init.GetValue<FacingInit, int>(128));
 
-			dragSpeed = init.GetValue<HuskSpeedInit, int>(info, 0);
+			dragSpeed = init.GetValue<HuskSpeedInit, int>(0);
 			finalPosition = init.World.Map.CenterOfCell(TopLeft);
 
 			effectiveOwner = init.GetValue<EffectiveOwnerInit, Player>(info, self.Owner);
@@ -171,7 +171,7 @@ namespace OpenRA.Mods.Common.Traits
 		Player IEffectiveOwner.Owner { get { return effectiveOwner; } }
 	}
 
-	public class HuskSpeedInit : ValueActorInit<int>
+	public class HuskSpeedInit : ValueActorInit<int>, ISingleInstanceInit
 	{
 		public HuskSpeedInit(int value)
 			: base(value) { }

--- a/OpenRA.Mods.Common/Traits/Immobile.cs
+++ b/OpenRA.Mods.Common/Traits/Immobile.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Immobile(ActorInitializer init, ImmobileInfo info)
 		{
-			location = init.GetValue<LocationInit, CPos>(info);
+			location = init.GetValue<LocationInit, CPos>();
 			position = init.World.Map.CenterOfCell(location);
 
 			if (info.OccupiesSpace)

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -130,23 +130,24 @@ namespace OpenRA.Mods.Common.Traits
 			yield return new EditorActorSlider("Facing", EditorFacingDisplayOrder, 0, 255, 8,
 				actor =>
 				{
-					var init = actor.Init<FacingInit>();
+					var init = actor.GetInitOrDefault<FacingInit>(this);
 					return init != null ? init.Value : InitialFacing;
 				},
 				(actor, value) =>
 				{
 					// TODO: This can all go away once turrets are properly defined as a relative facing
-					var turretInit = actor.Init<TurretFacingInit>();
-					var turretsInit = actor.Init<TurretFacingsInit>();
-					var facingInit = actor.Init<FacingInit>();
+					var turretsInit = actor.GetInitOrDefault<TurretFacingsInit>();
+					var facingInit = actor.GetInitOrDefault<FacingInit>();
 
 					var oldFacing = facingInit != null ? facingInit.Value : InitialFacing;
 					var newFacing = (int)value;
 
-					if (turretInit != null)
+					var turretInits = actor.GetInits<TurretFacingInit>().ToList();
+					actor.RemoveInits<TurretFacingInit>();
+					foreach (var turretInit in turretInits)
 					{
 						var newTurretFacing = (turretInit.Value + newFacing - oldFacing + 255) % 255;
-						actor.ReplaceInit(new TurretFacingInit(this, newTurretFacing));
+						actor.AddInit(new TurretFacingInit(turretInit.InstanceName, newTurretFacing));
 					}
 
 					if (turretsInit != null)

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Boolean expression defining the condition under which this actor cannot be nudged by other actors.")]
 		public readonly BooleanExpression ImmovableCondition = null;
 
-		IEnumerable<object> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)
+		IEnumerable<ActorInit> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)
 		{
 			yield return new FacingInit(PreviewFacing);
 		}

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -267,25 +267,25 @@ namespace OpenRA.Mods.Common.Traits
 
 			ToSubCell = FromSubCell = info.LocomotorInfo.SharesCell ? init.World.Map.Grid.DefaultSubCell : SubCell.FullCell;
 
-			var subCellInit = init.GetOrDefault<SubCellInit>(info);
+			var subCellInit = init.GetOrDefault<SubCellInit>();
 			if (subCellInit != null)
 			{
 				FromSubCell = ToSubCell = subCellInit.Value;
 				returnToCellOnCreationRecalculateSubCell = false;
 			}
 
-			var locationInit = init.GetOrDefault<LocationInit>(info);
+			var locationInit = init.GetOrDefault<LocationInit>();
 			if (locationInit != null)
 			{
 				fromCell = toCell = locationInit.Value;
 				SetVisualPosition(self, init.World.Map.CenterOfSubCell(FromCell, FromSubCell));
 			}
 
-			Facing = oldFacing = WAngle.FromFacing(init.GetValue<FacingInit, int>(info, info.InitialFacing));
+			Facing = oldFacing = WAngle.FromFacing(init.GetValue<FacingInit, int>(info.InitialFacing));
 
 			// Sets the initial visual position
 			// Unit will move into the cell grid (defined by LocationInit) as its initial activity
-			var centerPositionInit = init.GetOrDefault<CenterPositionInit>(info);
+			var centerPositionInit = init.GetOrDefault<CenterPositionInit>();
 			if (centerPositionInit != null)
 			{
 				oldPos = centerPositionInit.Value;
@@ -293,7 +293,7 @@ namespace OpenRA.Mods.Common.Traits
 				returnToCellOnCreation = true;
 			}
 
-			creationActivityDelay = init.GetValue<CreationActivityDelayInit, int>(info, 0);
+			creationActivityDelay = init.GetValue<CreationActivityDelayInit, int>(0);
 		}
 
 		protected override void Created(Actor self)

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Explore map-placed actors if the "Explore Map" option is enabled
 			var shroudInfo = init.World.Map.Rules.Actors["player"].TraitInfo<ShroudInfo>();
 			var exploredMap = init.World.LobbyInfo.GlobalSettings.OptionOrDefault("explored", shroudInfo.ExploredMapCheckboxEnabled);
-			startsRevealed = exploredMap && init.Contains<SpawnedByMapInit>(info) && !init.Contains<HiddenUnderFogInit>(info);
+			startsRevealed = exploredMap && init.Contains<SpawnedByMapInit>() && !init.Contains<HiddenUnderFogInit>();
 			var buildingInfo = init.Self.Info.TraitInfoOrDefault<BuildingInfo>();
 			var footprintCells = buildingInfo != null ? buildingInfo.FrozenUnderFogTiles(init.Self.Location).ToList() : new List<CPos>() { init.Self.Location };
 			footprint = footprintCells.SelectMany(c => map.ProjectedCellsCovering(c.ToMPos(map))).ToArray();
@@ -195,5 +195,5 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class HiddenUnderFogInit : RuntimeFlagInit { }
+	public class HiddenUnderFogInit : RuntimeFlagInit, ISingleInstanceInit { }
 }

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -131,7 +131,7 @@ namespace OpenRA.Mods.Common.Traits
 			self = init.Self;
 			Info = info;
 
-			Faction = init.GetValue<FactionInit, string>(info, self.Owner.Faction.InternalName);
+			Faction = init.GetValue<FactionInit, string>(self.Owner.Faction.InternalName);
 			IsValidFaction = !info.Factions.Any() || info.Factions.Contains(Faction);
 			Enabled = IsValidFaction;
 

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (string.IsNullOrEmpty(prerequisite))
 				prerequisite = init.Self.Info.Name;
 
-			faction = init.GetValue<FactionInit, string>(info, init.Self.Owner.Faction.InternalName);
+			faction = init.GetValue<FactionInit, string>(init.Self.Owner.Faction.InternalName);
 		}
 
 		public IEnumerable<string> ProvidesPrerequisites

--- a/OpenRA.Mods.Common/Traits/Pluggable.cs
+++ b/OpenRA.Mods.Common/Traits/Pluggable.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class PluggableInfo : TraitInfo
+	public class PluggableInfo : TraitInfo, IEditorActorOptions
 	{
 		[Desc("Footprint cell offset where a plug can be placed.")]
 		public readonly CVec Offset = CVec.Zero;
@@ -32,6 +32,17 @@ namespace OpenRA.Mods.Common.Traits
 			"Value is the condition expression defining the requirements to place the plug.")]
 		public readonly Dictionary<string, BooleanExpression> Requirements = new Dictionary<string, BooleanExpression>();
 
+		[Desc("Options to display in the map editor.",
+			"Key is the plug type that the requirements applies to.",
+			"Value is the label that is displayed in the actor editor dropdown.")]
+		public readonly Dictionary<string, string> EditorOptions = new Dictionary<string, string>();
+
+		[Desc("Label to use for an empty plug socket.")]
+		public readonly string EmptyOption = "Empty";
+
+		[Desc("Display order for the dropdown in the map editor")]
+		public readonly int EditorDisplayOrder = 5;
+
 		[GrantedConditionReference]
 		public IEnumerable<string> LinterConditions { get { return Conditions.Values; } }
 
@@ -39,6 +50,28 @@ namespace OpenRA.Mods.Common.Traits
 		public IEnumerable<string> ConsumedConditions
 		{
 			get { return Requirements.Values.SelectMany(r => r.Variables).Distinct(); }
+		}
+
+		IEnumerable<EditorActorOption> IEditorActorOptions.ActorOptions(ActorInfo ai, World world)
+		{
+			if (!EditorOptions.Any())
+				yield break;
+
+			// Make sure the no-plug option is always available
+			EditorOptions[""] = EmptyOption;
+			yield return new EditorActorDropdown("Plug", EditorDisplayOrder, EditorOptions,
+				actor =>
+				{
+					var init = actor.GetInitOrDefault<PlugInit>(this);
+					return init != null ? init.Value : "";
+				},
+				(actor, value) =>
+				{
+					if (string.IsNullOrEmpty(value))
+						actor.RemoveInit<PlugInit>(this);
+					else
+						actor.ReplaceInit(new PlugInit(this, value), this);
+				});
 		}
 
 		public override object Create(ActorInitializer init) { return new Pluggable(init, this); }
@@ -58,9 +91,10 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			Info = info;
 
-			var plugInit = init.GetValue<PlugsInit, Dictionary<CVec, string>>(info, new Dictionary<CVec, string>());
-			if (plugInit.ContainsKey(Info.Offset))
-				initialPlug = plugInit[Info.Offset];
+			initialPlug = init.GetValue<PlugInit, string>(info, null);
+			var plugsInit = init.GetValue<PlugsInit, Dictionary<CVec, string>>(new Dictionary<CVec, string>());
+			if (plugsInit.ContainsKey(Info.Offset))
+				initialPlug = plugsInit[Info.Offset];
 
 			if (info.Requirements.Count > 0)
 			{
@@ -124,5 +158,11 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public PlugsInit(Dictionary<CVec, string> value)
 			: base(value) { }
+	}
+
+	public class PlugInit : ValueActorInit<string>
+	{
+		public PlugInit(TraitInfo info, string value)
+			: base(info, value) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Pluggable.cs
+++ b/OpenRA.Mods.Common/Traits/Pluggable.cs
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class PlugsInit : ValueActorInit<Dictionary<CVec, string>>
+	public class PlugsInit : ValueActorInit<Dictionary<CVec, string>>, ISingleInstanceInit
 	{
 		public PlugsInit(Dictionary<CVec, string> value)
 			: base(value) { }

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 			: base(info)
 		{
 			rp = Exts.Lazy(() => init.Self.IsDead ? null : init.Self.TraitOrDefault<RallyPoint>());
-			Faction = init.GetValue<FactionInit, string>(info, init.Self.Owner.Faction.InternalName);
+			Faction = init.GetValue<FactionInit, string>(init.Self.Owner.Faction.InternalName);
 		}
 
 		public virtual void DoProduction(Actor self, ActorInfo producee, ExitInfo exitinfo, string productionType, TypeDictionary inits)

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			var sequenceProvider = init.World.Map.Rules.Sequences;
 			var faction = init.GetValue<FactionInit, string>(this);
-			var ownerName = init.Get<OwnerInit>(this).InternalName;
+			var ownerName = init.Get<OwnerInit>().InternalName;
 			var image = GetImage(init.Actor, sequenceProvider, faction);
 			var palette = init.WorldRenderer.Palette(Palette ?? PlayerPalette + ownerName);
 
@@ -169,7 +169,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public RenderSprites(ActorInitializer init, RenderSpritesInfo info)
 		{
 			Info = info;
-			faction = init.GetValue<FactionInit, string>(info, init.Self.Owner.Faction.InternalName);
+			faction = init.GetValue<FactionInit, string>(init.Self.Owner.Faction.InternalName);
 		}
 
 		public string GetImage(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
 			var faction = init.GetValue<FactionInit, string>(this);
-			var ownerName = init.Get<OwnerInit>(this).InternalName;
+			var ownerName = init.Get<OwnerInit>().InternalName;
 			var sequenceProvider = init.World.Map.Rules.Sequences;
 			var image = Image ?? init.Actor.Name;
 			var facings = body.QuantizedFacings == -1 ?

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				p = init.WorldRenderer.Palette(Palette);
 
 			Func<WAngle> facing;
-			var dynamicfacingInit = init.GetOrDefault<DynamicFacingInit>(this);
+			var dynamicfacingInit = init.GetOrDefault<DynamicFacingInit>();
 			if (dynamicfacingInit != null)
 			{
 				var getFacing = dynamicfacingInit.Value;
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			}
 			else
 			{
-				var f = WAngle.FromFacing(init.GetValue<FacingInit, int>(this, 0));
+				var f = WAngle.FromFacing(init.GetValue<FacingInit, int>(0));
 				facing = () => f;
 			}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
@@ -78,12 +78,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 				p = init.WorldRenderer.Palette(Palette);
 
 			Func<int> facing;
-			var dynamicfacingInit = init.GetOrDefault<DynamicFacingInit>(this);
+			var dynamicfacingInit = init.GetOrDefault<DynamicFacingInit>();
 			if (dynamicfacingInit != null)
 				facing = dynamicfacingInit.Value;
 			else
 			{
-				var f = init.GetValue<FacingInit, int>(this, 0);
+				var f = init.GetValue<FacingInit, int>(0);
 				facing = () => f;
 			}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			};
 
 			if (IsPlayerPalette)
-				p = init.WorldRenderer.Palette(Palette + init.Get<OwnerInit>(this).InternalName);
+				p = init.WorldRenderer.Palette(Palette + init.Get<OwnerInit>().InternalName);
 			else if (Palette != null)
 				p = init.WorldRenderer.Palette(Palette);
 

--- a/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
@@ -37,8 +37,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 				yield break;
 
 			var adjacent = 0;
-			var locationInit = init.GetOrDefault<LocationInit>(this);
-			var neighbourInit = init.GetOrDefault<RuntimeNeighbourInit>(this);
+			var locationInit = init.GetOrDefault<LocationInit>();
+			var neighbourInit = init.GetOrDefault<RuntimeNeighbourInit>();
 
 			if (locationInit != null && neighbourInit != null)
 			{
@@ -168,7 +168,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	public class RuntimeNeighbourInit : ValueActorInit<Dictionary<CPos, string[]>>, ISuppressInitExport
+	public class RuntimeNeighbourInit : ValueActorInit<Dictionary<CPos, string[]>>, ISuppressInitExport, ISingleInstanceInit
 	{
 		public RuntimeNeighbourInit(Dictionary<CPos, string[]> value)
 			: base(value) { }

--- a/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits
 			: base(info)
 		{
 			enabled = !info.RequiresLobbyCreeps || init.Self.World.WorldActor.Trait<MapCreeps>().Enabled;
-			faction = init.GetValue<FactionInit, string>(info, init.Self.Owner.Faction.InternalName);
+			faction = init.GetValue<FactionInit, string>(init.Self.Owner.Faction.InternalName);
 		}
 
 		void INotifyKilled.Killed(Actor self, AttackInfo e)

--- a/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 		public ProduceActorPower(ActorInitializer init, ProduceActorPowerInfo info)
 			: base(init.Self, info)
 		{
-			faction = init.GetValue<FactionInit, string>(info, init.Self.Owner.Faction.InternalName);
+			faction = init.GetValue<FactionInit, string>(init.Self.Owner.Faction.InternalName);
 		}
 
 		public override void SelectTarget(Actor self, string order, SupportPowerManager manager)

--- a/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
@@ -65,8 +65,8 @@ namespace OpenRA.Mods.Common.Traits
 			var body = self.Trait<BodyOrientation>();
 
 			// TODO: Carry orientation over from the parent instead of just facing
-			var dynamicFacingInit = init.GetOrDefault<DynamicFacingInit>(info);
-			var bodyFacing = dynamicFacingInit != null ? dynamicFacingInit.Value() : init.GetValue<FacingInit, int>(info, 0);
+			var dynamicFacingInit = init.GetOrDefault<DynamicFacingInit>();
+			var bodyFacing = dynamicFacingInit != null ? dynamicFacingInit.Value() : init.GetValue<FacingInit, int>(0);
 			facing = WAngle.FromFacing(Turreted.TurretFacingFromInit(init, info, 0)());
 
 			// Calculate final position

--- a/OpenRA.Mods.Common/Traits/TransformCrusherOnCrush.cs
+++ b/OpenRA.Mods.Common/Traits/TransformCrusherOnCrush.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 		public TransformCrusherOnCrush(ActorInitializer init, TransformCrusherOnCrushInfo info)
 		{
 			this.info = info;
-			faction = init.GetValue<FactionInit, string>(info, init.Self.Owner.Faction.InternalName);
+			faction = init.GetValue<FactionInit, string>(init.Self.Owner.Faction.InternalName);
 		}
 
 		void INotifyCrushed.WarnCrush(Actor self, Actor crusher, BitSet<CrushClass> crushClasses) { }

--- a/OpenRA.Mods.Common/Traits/TransformOnCapture.cs
+++ b/OpenRA.Mods.Common/Traits/TransformOnCapture.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 		public TransformOnCapture(ActorInitializer init, TransformOnCaptureInfo info)
 		{
 			this.info = info;
-			faction = init.GetValue<FactionInit, string>(info, init.Self.Owner.Faction.InternalName);
+			faction = init.GetValue<FactionInit, string>(init.Self.Owner.Faction.InternalName);
 		}
 
 		void INotifyCapture.OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner, BitSet<CaptureType> captureTypes)

--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 			self = init.Self;
 			actorInfo = self.World.Map.Rules.Actors[info.IntoActor];
 			buildingInfo = actorInfo.TraitInfoOrDefault<BuildingInfo>();
-			faction = init.GetValue<FactionInit, string>(info, self.Owner.Faction.InternalName);
+			faction = init.GetValue<FactionInit, string>(self.Owner.Faction.InternalName);
 		}
 
 		public string VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Display order for the turret facing slider in the map editor")]
 		public readonly int EditorTurretFacingDisplayOrder = 4;
 
-		IEnumerable<object> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)
+		IEnumerable<ActorInit> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)
 		{
 			// HACK: The ActorInit system does not support multiple instances of the same type
 			// Make sure that we only return one TurretFacingInit, even for actors with multiple turrets

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -106,12 +106,12 @@ namespace OpenRA.Mods.Common.Traits
 			if (turret != null)
 			{
 				Func<int> getFacing;
-				var dynamicTurretFacingsInit = init.GetOrDefault<DynamicTurretFacingsInit>(info);
+				var dynamicTurretFacingsInit = init.GetOrDefault<DynamicTurretFacingsInit>();
 				if (dynamicTurretFacingsInit != null && dynamicTurretFacingsInit.Value.TryGetValue(turret, out getFacing))
 					return getFacing;
 
 				int facing;
-				var turretFacingsInit = init.GetOrDefault<TurretFacingsInit>(info);
+				var turretFacingsInit = init.GetOrDefault<TurretFacingsInit>();
 				if (turretFacingsInit != null && turretFacingsInit.Value.TryGetValue(turret, out facing))
 					return () => facing;
 			}
@@ -123,11 +123,11 @@ namespace OpenRA.Mods.Common.Traits
 				return () => facing;
 			}
 
-			var dynamicFacingInit = init.GetOrDefault<DynamicFacingInit>(info);
+			var dynamicFacingInit = init.GetOrDefault<DynamicFacingInit>();
 			if (dynamicFacingInit != null)
 				return dynamicFacingInit.Value;
 
-			var facingInit = init.GetOrDefault<FacingInit>(info);
+			var facingInit = init.GetOrDefault<FacingInit>();
 			if (facingInit != null)
 			{
 				var facing = facingInit.Value;
@@ -245,7 +245,7 @@ namespace OpenRA.Mods.Common.Traits
 			var facings = inits.GetOrDefault<DynamicTurretFacingsInit>();
 			if (facings == null)
 			{
-				facings = new DynamicTurretFacingsInit(Info, new Dictionary<string, Func<int>>());
+				facings = new DynamicTurretFacingsInit(new Dictionary<string, Func<int>>());
 				inits.Add(facings);
 			}
 
@@ -278,15 +278,15 @@ namespace OpenRA.Mods.Common.Traits
 			: base(value) { }
 	}
 
-	public class TurretFacingsInit : ValueActorInit<Dictionary<string, int>>
+	public class TurretFacingsInit : ValueActorInit<Dictionary<string, int>>, ISingleInstanceInit
 	{
 		public TurretFacingsInit(Dictionary<string, int> value)
 			: base(value) { }
 	}
 
-	public class DynamicTurretFacingsInit : ValueActorInit<Dictionary<string, Func<int>>>
+	public class DynamicTurretFacingsInit : ValueActorInit<Dictionary<string, Func<int>>>, ISingleInstanceInit
 	{
-		public DynamicTurretFacingsInit(TraitInfo info, Dictionary<string, Func<int>> value)
-			: base(info, value) { }
+		public DynamicTurretFacingsInit(Dictionary<string, Func<int>> value)
+			: base(value) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -38,18 +38,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<ActorInit> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)
 		{
-			// HACK: The ActorInit system does not support multiple instances of the same type
-			// Make sure that we only return one TurretFacingInit, even for actors with multiple turrets
-			if (ai.TraitInfos<TurretedInfo>().FirstOrDefault() == this)
-				yield return new TurretFacingInit(this, PreviewFacing);
+			yield return new TurretFacingInit(this, PreviewFacing);
 		}
 
 		IEnumerable<EditorActorOption> IEditorActorOptions.ActorOptions(ActorInfo ai, World world)
 		{
-			// TODO: Handle multiple turrets properly (will probably require a rewrite of the Init system)
-			if (ai.TraitInfos<TurretedInfo>().FirstOrDefault() != this)
-				yield break;
-
 			yield return new EditorActorSlider("Turret", EditorTurretFacingDisplayOrder, 0, 255, 8,
 				actor =>
 				{
@@ -66,10 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 				(actor, value) =>
 				{
 					actor.RemoveInit<TurretFacingsInit>();
-
-					// Force a single global turret facing for multi-turret actors
-					actor.RemoveInits<TurretFacingInit>();
-					actor.AddInit(new TurretFacingInit((int)value));
+					actor.ReplaceInit(new TurretFacingInit(this, (int)value), this);
 				});
 		}
 

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -53,11 +53,11 @@ namespace OpenRA.Mods.Common.Traits
 			yield return new EditorActorSlider("Turret", EditorTurretFacingDisplayOrder, 0, 255, 8,
 				actor =>
 				{
-					var init = actor.Init<TurretFacingInit>();
+					var init = actor.GetInitOrDefault<TurretFacingInit>(this);
 					if (init != null)
 						return init.Value;
 
-					var facingInit = actor.Init<FacingInit>();
+					var facingInit = actor.GetInitOrDefault<FacingInit>(this);
 					if (facingInit != null)
 						return facingInit.Value;
 
@@ -67,8 +67,9 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					actor.RemoveInit<TurretFacingsInit>();
 
-					// Force a single global turret facing for multi-turret actors by not passing this TraitInfo instance
-					actor.ReplaceInit(new TurretFacingInit((int)value));
+					// Force a single global turret facing for multi-turret actors
+					actor.RemoveInits<TurretFacingInit>();
+					actor.AddInit(new TurretFacingInit((int)value));
 				});
 		}
 
@@ -273,6 +274,9 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public TurretFacingInit(TraitInfo info, int value)
 			: base(info, value) { }
+
+		public TurretFacingInit(string instanceName, int value)
+			: base(instanceName, value) { }
 
 		public TurretFacingInit(int value)
 			: base(value) { }

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -118,7 +118,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public EditorActorPreview Add(string id, ActorReference reference, bool initialSetup = false)
 		{
-			var owner = Players.Players[reference.InitDict.Get<OwnerInit>().InternalName];
+			var owner = Players.Players[reference.Get<OwnerInit>().InternalName];
 			var preview = new EditorActorPreview(worldRenderer, id, reference, owner);
 
 			Add(preview, initialSetup);
@@ -144,7 +144,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				UpdateNeighbours(preview.Footprint);
 
-				if (preview.Actor.Type == "mpspawn")
+				if (preview.Type == "mpspawn")
 					SyncMultiplayerCount();
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -28,7 +28,6 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly IReadOnlyDictionary<CPos, SubCell> Footprint;
 		public readonly Rectangle Bounds;
 		public readonly SelectionBoxAnnotationRenderable SelectionBox;
-		public readonly ActorReference Actor;
 
 		public string Tooltip
 		{
@@ -39,6 +38,8 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
+		public string Type { get { return reference.Type; } }
+
 		public string ID { get; set; }
 		public PlayerReference Owner { get; set; }
 		public SubCell SubCell { get; private set; }
@@ -47,30 +48,31 @@ namespace OpenRA.Mods.Common.Traits
 		readonly WorldRenderer worldRenderer;
 		readonly TooltipInfoBase tooltip;
 		IActorPreview[] previews;
+		readonly ActorReference reference;
 
-		public EditorActorPreview(WorldRenderer worldRenderer, string id, ActorReference actor, PlayerReference owner)
+		public EditorActorPreview(WorldRenderer worldRenderer, string id, ActorReference reference, PlayerReference owner)
 		{
 			ID = id;
-			Actor = actor;
+			this.reference = reference;
 			Owner = owner;
 			this.worldRenderer = worldRenderer;
 
-			if (!actor.InitDict.Contains<FactionInit>())
-				actor.InitDict.Add(new FactionInit(owner.Faction));
+			if (!reference.Contains<FactionInit>())
+				reference.Add(new FactionInit(owner.Faction));
 
-			if (!actor.InitDict.Contains<OwnerInit>())
-				actor.InitDict.Add(new OwnerInit(owner.Name));
+			if (!reference.Contains<OwnerInit>())
+				reference.Add(new OwnerInit(owner.Name));
 
 			var world = worldRenderer.World;
-			if (!world.Map.Rules.Actors.TryGetValue(actor.Type.ToLowerInvariant(), out Info))
-				throw new InvalidDataException("Actor {0} of unknown type {1}".F(id, actor.Type.ToLowerInvariant()));
+			if (!world.Map.Rules.Actors.TryGetValue(reference.Type.ToLowerInvariant(), out Info))
+				throw new InvalidDataException("Actor {0} of unknown type {1}".F(id, reference.Type.ToLowerInvariant()));
 
-			CenterPosition = PreviewPosition(world, actor.InitDict);
+			CenterPosition = PreviewPosition(world, reference);
 
-			var location = actor.InitDict.Get<LocationInit>().Value;
+			var location = reference.Get<LocationInit>().Value;
 			var ios = Info.TraitInfoOrDefault<IOccupySpaceInfo>();
 
-			var subCellInit = actor.InitDict.GetOrDefault<SubCellInit>();
+			var subCellInit = reference.GetOrDefault<SubCellInit>();
 			var subCell = subCellInit != null ? subCellInit.Value : SubCell.Any;
 
 			if (ios != null)
@@ -124,27 +126,66 @@ namespace OpenRA.Mods.Common.Traits
 				yield return SelectionBox;
 		}
 
-		public void ReplaceInit<T>(T init)
+		public void AddInit<T>(T init) where T : ActorInit
 		{
-			var original = Actor.InitDict.GetOrDefault<T>();
-			if (original != null)
-				Actor.InitDict.Remove(original);
-
-			Actor.InitDict.Add(init);
+			reference.Add(init);
 			GeneratePreviews();
 		}
 
-		public void RemoveInit<T>()
+		public void ReplaceInit<T>(T init, TraitInfo info) where T : ActorInit
 		{
-			var original = Actor.InitDict.GetOrDefault<T>();
+			var original = GetInitOrDefault<T>(info);
 			if (original != null)
-				Actor.InitDict.Remove(original);
+				reference.Remove(original);
+
+			reference.Add(init);
 			GeneratePreviews();
 		}
 
-		public T Init<T>()
+		public void RemoveInit<T>(TraitInfo info) where T : ActorInit
 		{
-			return Actor.InitDict.GetOrDefault<T>();
+			var original = GetInitOrDefault<T>(info);
+			if (original != null)
+				reference.Remove(original);
+			GeneratePreviews();
+		}
+
+		public int RemoveInits<T>() where T : ActorInit
+		{
+			var removed = reference.RemoveAll<T>();
+			GeneratePreviews();
+			return removed;
+		}
+
+		public T GetInitOrDefault<T>(TraitInfo info) where T : ActorInit
+		{
+			return reference.GetOrDefault<T>(info);
+		}
+
+		public IEnumerable<T> GetInits<T>() where T : ActorInit
+		{
+			return reference.GetAll<T>();
+		}
+
+		public T GetInitOrDefault<T>() where T : ActorInit, ISingleInstanceInit
+		{
+			return reference.GetOrDefault<T>();
+		}
+
+		public void ReplaceInit<T>(T init) where T : ActorInit, ISingleInstanceInit
+		{
+			var original = reference.GetOrDefault<T>();
+			if (original != null)
+				reference.Remove(original);
+
+			reference.Add(init);
+			GeneratePreviews();
+		}
+
+		public void RemoveInit<T>() where T : ActorInit, ISingleInstanceInit
+		{
+			reference.RemoveAll<T>();
+			GeneratePreviews();
 		}
 
 		public MiniYaml Save()
@@ -160,20 +201,23 @@ namespace OpenRA.Mods.Common.Traits
 				return true;
 			};
 
-			return Actor.Save(saveInit);
+			return reference.Save(saveInit);
 		}
 
-		WPos PreviewPosition(World world, TypeDictionary init)
+		WPos PreviewPosition(World world, ActorReference actor)
 		{
-			if (init.Contains<CenterPositionInit>())
-				return init.Get<CenterPositionInit>().Value;
+			var centerPositionInit = actor.GetOrDefault<CenterPositionInit>();
+			if (centerPositionInit != null)
+				return centerPositionInit.Value;
 
-			if (init.Contains<LocationInit>())
+			var locationInit = actor.GetOrDefault<LocationInit>();
+
+			if (locationInit != null)
 			{
-				var cell = init.Get<LocationInit>().Value;
+				var cell = locationInit.Value;
 				var offset = WVec.Zero;
 
-				var subCellInit = Actor.InitDict.GetOrDefault<SubCellInit>();
+				var subCellInit = reference.GetOrDefault<SubCellInit>();
 				var subCell = subCellInit != null ? subCellInit.Value : SubCell.Any;
 
 				var buildingInfo = Info.TraitInfoOrDefault<BuildingInfo>();
@@ -188,7 +232,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void GeneratePreviews()
 		{
-			var init = new ActorPreviewInitializer(Info, worldRenderer, Actor.InitDict);
+			var init = new ActorPreviewInitializer(reference, worldRenderer);
 			previews = Info.TraitInfos<IRenderActorPreviewInfo>()
 				.SelectMany(rpi => rpi.RenderPreview(init))
 				.ToArray();
@@ -196,7 +240,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public ActorReference Export()
 		{
-			return new ActorReference(Actor.Type, Actor.Save().ToDictionary());
+			return reference.Clone();
 		}
 
 		public override string ToString()

--- a/OpenRA.Mods.Common/Traits/World/EditorCursorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorCursorLayer.cs
@@ -113,8 +113,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (actorLocation != cell)
 				{
 					actorLocation = cell;
-					Actor.Actor.InitDict.Remove(Actor.Actor.InitDict.Get<LocationInit>());
-					Actor.Actor.InitDict.Add(new LocationInit(cell));
+					Actor.ReplaceInit(new LocationInit(cell));
 					updated = true;
 				}
 
@@ -122,23 +121,19 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					actorSubCell = subCell;
 
-					var subcellInit = Actor.Actor.InitDict.GetOrDefault<SubCellInit>();
-					if (subcellInit != null)
-					{
-						Actor.Actor.InitDict.Remove(subcellInit);
+					if (Actor.RemoveInits<SubCellInit>() > 0)
 						updated = true;
-					}
 
 					var subcell = world.Map.Tiles.Contains(cell) ? editorLayer.FreeSubCellAt(cell) : SubCell.Invalid;
 					if (subcell != SubCell.Invalid)
 					{
-						Actor.Actor.InitDict.Add(new SubCellInit(subcell));
+						Actor.AddInit(new SubCellInit(subcell));
 						updated = true;
 					}
 				}
 
 				if (updated)
-					Actor = new EditorActorPreview(wr, null, Actor.Actor, Actor.Owner);
+					Actor = new EditorActorPreview(wr, null, Actor.Export(), Actor.Owner);
 			}
 		}
 
@@ -184,25 +179,25 @@ namespace OpenRA.Mods.Common.Traits
 				ownerName = specificOwnerInfo.ValidOwnerNames.First();
 
 			var reference = new ActorReference(actor.Name);
-			reference.InitDict.Add(new OwnerInit(ownerName));
-			reference.InitDict.Add(new FactionInit(owner.Faction));
+			reference.Add(new OwnerInit(ownerName));
+			reference.Add(new FactionInit(owner.Faction));
 
 			var worldPx = wr.Viewport.ViewToWorldPx(Viewport.LastMousePos) - wr.ScreenPxOffset(actorCenterOffset);
 			var cell = wr.Viewport.ViewToWorld(wr.Viewport.WorldToViewPx(worldPx));
 
-			reference.InitDict.Add(new LocationInit(cell));
+			reference.Add(new LocationInit(cell));
 			if (ios != null && ios.SharesCell)
 			{
 				actorSubCell = editorLayer.FreeSubCellAt(cell);
 				if (actorSubCell != SubCell.Invalid)
-					reference.InitDict.Add(new SubCellInit(actorSubCell));
+					reference.Add(new SubCellInit(actorSubCell));
 			}
 
 			if (actor.HasTraitInfo<IFacingInfo>())
-				reference.InitDict.Add(new FacingInit(info.PreviewFacing));
+				reference.Add(new FacingInit(info.PreviewFacing));
 
 			if (actor.HasTraitInfo<TurretedInfo>())
-				reference.InitDict.Add(new TurretFacingInit(info.PreviewFacing));
+				reference.Add(new TurretFacingInit(info.PreviewFacing));
 
 			Type = EditorCursorType.Actor;
 			Actor = new EditorActorPreview(wr, null, reference, owner);

--- a/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public class SkipMakeAnimsInit : RuntimeFlagInit { }
-	public class SpawnedByMapInit : ValueActorInit<string>, ISuppressInitExport
+	public class SpawnedByMapInit : ValueActorInit<string>, ISuppressInitExport, ISingleInstanceInit
 	{
 		public SpawnedByMapInit(string value)
 			: base(value) { }

--- a/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
@@ -35,18 +35,17 @@ namespace OpenRA.Mods.Common.Traits
 				var actorReference = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
 
 				// If there is no real player associated, don't spawn it.
-				var ownerName = actorReference.InitDict.Get<OwnerInit>().InternalName;
+				var ownerName = actorReference.Get<OwnerInit>().InternalName;
 				if (!world.Players.Any(p => p.InternalName == ownerName))
 					continue;
 
-				var initDict = actorReference.InitDict;
-				initDict.Add(new SkipMakeAnimsInit());
-				initDict.Add(new SpawnedByMapInit(kv.Key));
+				actorReference.Add(new SkipMakeAnimsInit());
+				actorReference.Add(new SpawnedByMapInit(kv.Key));
 
 				if (PreventMapSpawn(world, actorReference, preventMapSpawns))
 					continue;
 
-				var actor = world.CreateActor(actorReference.Type, initDict);
+				var actor = world.CreateActor(true, actorReference);
 				Actors[kv.Key] = actor;
 				LastMapActorID = actor.ActorID;
 			}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -400,7 +400,7 @@ namespace OpenRA.Mods.Common.Traits
 	[RequireExplicitImplementation]
 	public interface IActorPreviewInitInfo : ITraitInfoInterface
 	{
-		IEnumerable<object> ActorPreviewInits(ActorInfo ai, ActorPreviewType type);
+		IEnumerable<ActorInit> ActorPreviewInits(ActorInfo ai, ActorPreviewType type);
 	}
 
 	public interface IMove

--- a/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
@@ -410,11 +410,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						new OwnerInit(parts[0]),
 					};
 
-					var initDict = actor.InitDict;
 					if (health != 100)
-						initDict.Add(new HealthInit(health));
+						actor.Add(new HealthInit(health));
 					if (facing != 0)
-						initDict.Add(new FacingInit(255 - facing));
+						actor.Add(new FacingInit(255 - facing));
 
 					if (section == "INFANTRY")
 						actor.Add(new SubCellInit((SubCell)Exts.ParseByte(parts[4])));

--- a/OpenRA.Mods.Common/UtilityCommands/ResizeMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ResizeMapCommand.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.FileSystem;
 
 namespace OpenRA.Mods.Common.UtilityCommands
@@ -57,10 +58,13 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			foreach (var kv in map.ActorDefinitions)
 			{
 				var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
-				var location = actor.InitDict.Get<LocationInit>().Value;
-				if (!map.Contains(location))
+				var locationInit = actor.GetOrDefault<LocationInit>();
+				if (locationInit == null)
+					continue;
+
+				if (!map.Contains(locationInit.Value))
 				{
-					Console.WriteLine("Removing actor {0} located at {1} due being outside of the new map boundaries.".F(actor.Type, location));
+					Console.WriteLine("Removing actor {0} located at {1} due being outside of the new map boundaries.".F(actor.Type, locationInit.Value));
 					forRemoval.Add(kv);
 				}
 			}

--- a/mods/ts/maps/fields-of-green/map.yaml
+++ b/mods/ts/maps/fields-of-green/map.yaml
@@ -208,14 +208,12 @@ Actors:
 		Location: 84,-1
 		TurretFacing: 92
 		Facing: 60
-		Plugs:
-			0,0: tower.vulcan
+		Plug: tower.vulcan
 	Actor56: gactwr
 		Owner: GDI
 		Location: 80,-3
 		Facing: 60
-		Plugs:
-			0,0: tower.vulcan
+		Plug: tower.vulcan
 	Actor57: gawall
 		Owner: GDI
 		Location: 79,-3
@@ -247,8 +245,7 @@ Actors:
 		Owner: GDI
 		Location: 84,-4
 		Facing: 60
-		Plugs:
-			0,0: tower.rocket
+		Plug: tower.rocket
 	Actor67: gawall
 		Owner: GDI
 		Location: 88,-1
@@ -295,21 +292,18 @@ Actors:
 		Owner: GDI
 		Location: 86,-3
 		Facing: 60
-		Plugs:
-			0,1: powrup
-			1,1: powrup
+		Plug@pluga: powrup
+		Plug@plugb: powrup
 	Actor82: gapowr
 		Owner: GDI
 		Location: 86,-5
-		Plugs:
-			0,1: powrup
-			1,1: powrup
+		Plug@pluga: powrup
+		Plug@plugb: powrup
 	Actor91: gactwr
 		Owner: GDI
 		Location: 85,-11
 		Facing: -40
-		Plugs:
-			0,0: tower.vulcan
+		Plug: tower.vulcan
 	Actor90: gasilo
 		Owner: GDI
 		Location: 79,-10
@@ -326,8 +320,7 @@ Actors:
 		Owner: GDI
 		Location: 81,-11
 		Facing: -40
-		Plugs:
-			0,0: tower.vulcan
+		Plug: tower.vulcan
 	Actor89: gagate_a
 		Owner: GDI
 		Location: 82,-11

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -42,6 +42,8 @@ GAPOWR:
 			powrup: powrup.a
 		Requirements:
 			powrup: !build-incomplete && !powrup.a
+		EditorOptions:
+			powrup: Power Turbine
 	Power@pluga:
 		RequiresCondition: !empdisable && powrup.a
 		Amount: 50
@@ -55,6 +57,8 @@ GAPOWR:
 			powrup: powrup.b
 		Requirements:
 			powrup: !build-incomplete && !powrup.b
+		EditorOptions:
+			powrup: Power Turbine
 	WithIdleOverlay@plugb:
 		RequiresCondition: !build-incomplete && powrup.b
 		PauseOnCondition: empdisable
@@ -508,6 +512,9 @@ GAPLUG:
 		Requirements:
 			plug.ioncannon: !build-incomplete && !plug.ioncannonb && !plug.ioncannona && !plug.hunterseekera
 			plug.hunterseeker: !build-incomplete && !plug.hunterseekerb && !plug.ioncannona && !plug.hunterseekera
+		EditorOptions:
+			plug.ioncannon: Ion Cannon
+			plug.hunterseeker: Hunter Seeker
 	WithIdleOverlay@ioncannona:
 		RequiresCondition: !build-incomplete && plug.ioncannona
 		PauseOnCondition: disabled
@@ -524,6 +531,9 @@ GAPLUG:
 		Requirements:
 			plug.ioncannon: !build-incomplete && !plug.ioncannona && !plug.ioncannonb && !plug.hunterseekerb
 			plug.hunterseeker: !build-incomplete && !plug.hunterseekera && !plug.ioncannonb && !plug.hunterseekerb
+		EditorOptions:
+			plug.ioncannon: Ion Cannon
+			plug.hunterseeker: Hunter Seeker
 	WithIdleOverlay@ioncannonb:
 		RequiresCondition: !build-incomplete && plug.ioncannonb
 		PauseOnCondition: disabled

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -138,6 +138,10 @@ GACTWR:
 			tower.vulcan: !build-incomplete && !tower.vulcan && !tower.rocket && !tower.sam
 			tower.rocket: !build-incomplete && !tower.rocket && !tower.vulcan && !tower.sam
 			tower.sam: !build-incomplete && !tower.vulcan && !tower.rocket && !tower.sam
+		EditorOptions:
+			tower.vulcan: Vulcan Tower
+			tower.rocket: RPG Upgrade
+			tower.sam: SAM Upgrade
 	ProvidesPrerequisite@buildingname:
 	ProvidesPrerequisite@pluggable:
 		RequiresCondition: !build-incomplete && !tower.vulcan && !tower.rocket && !tower.sam


### PR DESCRIPTION
This PR extends the ActorInit rework through the map editor, and exposes multiple turrets and plugs in the map editor.

The first commit revisits the changes from #18164 - this PR fell into the "Everything is a... (multi-instance init)" trap, which makes life unnecessarily difficult for the map editor. The `ISingleInstanceInit` acknowledges that most inits *shouldn't* support multiple instances, and enforces this with compile and runtime checks.

The third commit reduces unnecessary duplication by changing `ActorPreview` and `EditorActorPreview` to wrap `ActorReference`, which now implements the shared init queries. This removes the previous single-init limitation, and finishes the multi-init implementation.

Note that #18201 broke loading/saving of the now-obsolete `TurretFacingsInit` and `PlugsInit` - these will be removed and automatically migrated to targeted `TurretFacingInit` and `PlugInit` in the next PR, which will introduce a new update rule method for transforming map actors, and also convert `FacingInit` and `TurretFacingInit` to WAngle.