### PR TITLE
Make AI minimum refinery count configurable and account for games/maps that have none.

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -266,8 +266,7 @@ namespace OpenRA.Mods.Common.Traits
 			get
 			{
 				// Require at least one refinery, unless we can't build it.
-				return !Info.RefineryTypes.Any() ||
-					AIUtils.CountBuildingByCommonName(Info.RefineryTypes, player) >= MinimumRefineryCount ||
+				return AIUtils.CountBuildingByCommonName(Info.RefineryTypes, player) >= MinimumRefineryCount ||
 					AIUtils.CountBuildingByCommonName(Info.PowerTypes, player) == 0 ||
 					AIUtils.CountBuildingByCommonName(Info.ConstructionYardTypes, player) == 0;
 			}
@@ -277,6 +276,9 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
+				if (!Info.RefineryTypes.Any())
+					return 0;
+
 				return AIUtils.CountBuildingByCommonName(Info.BarracksTypes, player) > 0 ? Info.InititalMinimumRefineryCount + Info.AdditionalMinimumRefineryCount : Info.InititalMinimumRefineryCount;
 			}
 		}

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -75,6 +75,7 @@ Player:
 		ConstructionYardTypes: construction_yard
 		RefineryTypes: refinery
 		PowerTypes: wind_trap
+		BarracksTypes: barracks
 		VehiclesFactoryTypes: light_factory, heavy_factory, starport
 		ProductionTypes: light_factory, heavy_factory, barracks, starport
 		SiloTypes: silo
@@ -125,6 +126,7 @@ Player:
 		ConstructionYardTypes: construction_yard
 		RefineryTypes: refinery
 		PowerTypes: wind_trap
+		BarracksTypes: barracks
 		VehiclesFactoryTypes: light_factory, heavy_factory, starport
 		ProductionTypes: light_factory, heavy_factory, barracks, starport
 		SiloTypes: silo
@@ -175,6 +177,7 @@ Player:
 		ConstructionYardTypes: construction_yard
 		RefineryTypes: refinery
 		PowerTypes: wind_trap
+		BarracksTypes: barracks
 		VehiclesFactoryTypes: light_factory, heavy_factory, starport
 		ProductionTypes: light_factory, heavy_factory, barracks, starport
 		SiloTypes: silo


### PR DESCRIPTION
This will fix the AI not building any units for mods that don't have traditional refineries, which is actually the main motivation here. While I was at it, I unhardcoded everything related. This allows the first building before a second refinery to be something else than just the barracks, which I assume might be helpful for a tank rush AI. Somehow the whole ~~infantry production~~ priority over economy configuration was missing for Dune 2000 which I assume is an oversight.