### PR TITLE
Tiberian Dawn Summer 2020 Balance Changes

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -183,7 +183,7 @@ C17:
 		Cost: 2000
 	Aircraft:
 		TurnSpeed: 5
-		Speed: 326
+		Speed: 700
 		Repulsable: False
 		MaximumPitch: 36
 	HiddenUnderFog:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -105,20 +105,9 @@
 	ReloadDelayMultiplier@RANK-ELITE:
 		RequiresCondition: rank-elite
 		Modifier: 75
-	InaccuracyMultiplier@RANK-1:
-		RequiresCondition: rank-veteran == 1
-		Modifier: 90
-	InaccuracyMultiplier@RANK-2:
-		RequiresCondition: rank-veteran == 2
-		Modifier: 80
-	InaccuracyMultiplier@RANK-3:
-		RequiresCondition: rank-veteran == 3
-		Modifier: 70
-	InaccuracyMultiplier@RANK-ELITE:
-		RequiresCondition: rank-elite
-		Modifier: 50
 	SelfHealing@ELITE:
-		Step: 200
+		Step: 0
+		PercentageStep: 5
 		Delay: 100
 		HealIfBelow: 100
 		DamageCooldown: 125
@@ -129,6 +118,7 @@
 		Palette: effect
 		Position: BottomRight
 		Margin: 5, 6
+		ValidStances: Ally, Enemy, Neutral
 		RequiresCondition: rank-veteran == 1
 	WithDecoration@RANK-2:
 		Image: rank
@@ -136,6 +126,7 @@
 		Palette: effect
 		Position: BottomRight
 		Margin: 5, 6
+		ValidStances: Ally, Enemy, Neutral
 		RequiresCondition: rank-veteran == 2
 	WithDecoration@RANK-3:
 		Image: rank
@@ -143,6 +134,7 @@
 		Palette: effect
 		Position: BottomRight
 		Margin: 5, 6
+		ValidStances: Ally, Enemy, Neutral
 		RequiresCondition: rank-veteran == 3
 	WithDecoration@RANK-ELITE:
 		Image: rank
@@ -150,6 +142,7 @@
 		Palette: effect
 		Position: BottomRight
 		Margin: 5, 6
+		ValidStances: Ally, Enemy, Neutral
 		RequiresCondition: rank-elite
 
 ^InfantryExperienceHospitalHazmatOverrides:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -97,10 +97,11 @@ FACT:
 		ProductionType: Building.Nod
 	ProductionBar@DefenceGDI:
 		ProductionType: Defence.GDI
+		Color: 8A8A8A
 	ProductionBar@DefenceNod:
 		ProductionType: Defence.Nod
+		Color: 8A8A8A
 	BaseProvider:
-		Cooldown: 75
 		Range: 14c0
 	WithBuildingBib:
 	WithBuildingPlacedAnimation:
@@ -219,7 +220,7 @@ PROC:
 		Queue: Building.GDI, Building.Nod
 		Description: Processes raw Tiberium\ninto useable resources
 	Building:
-		Footprint: _x_ xxx === ===
+		Footprint: _x_ xxx +++ ===
 		Dimensions: 3,4
 		LocalCenterOffset: 0,-512,0
 	Health:
@@ -342,7 +343,7 @@ PYLE:
 	ProductionBar:
 		ProductionType: Infantry.GDI
 	Power:
-		Amount: -20
+		Amount: -15
 	ProvidesPrerequisite@buildingname:
 	Selectable:
 		Bounds: 48,42,0,-5
@@ -393,7 +394,7 @@ HAND:
 	ProductionBar:
 		ProductionType: Infantry.Nod
 	Power:
-		Amount: -20
+		Amount: -15
 	ProvidesPrerequisite@buildingname:
 	Selectable:
 		Bounds: 48,48
@@ -476,7 +477,7 @@ WEAP:
 		Queue: Building.GDI
 		Description: Produces vehicles
 	Building:
-		Footprint: xxx === ===
+		Footprint: xxx +++ ===
 		Dimensions: 3,3
 		LocalCenterOffset: 0,-512,0
 	Selectable:
@@ -1033,6 +1034,10 @@ ATWR:
 		Type: Heavy
 	RevealsShroud:
 		Range: 8c0
+	-RenderRangeCircle:
+	WithRangeCircle:
+		Range: 7c0
+		Color: FFFF0080	
 	WithBuildingBib:
 		HasMinibib: true
 	Turreted:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -381,7 +381,7 @@ LTNK:
 	Inherits@CLOAK: ^AcceptsCloakCrate
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 650
+		Cost: 750
 	Tooltip:
 		Name: Light Tank
 	UpdatesPlayerStatistics:
@@ -390,8 +390,6 @@ LTNK:
 		BuildPaletteOrder: 40
 		Prerequisites: anyhq, ~techlevel.medium
 		Queue: Vehicle.Nod
-		BuildDuration: 1020
-		BuildDurationModifier: 40
 		Description: Fast, light tank.\n  Strong vs Vehicles, Tanks\n  Weak vs Infantry
 	Mobile:
 		TurnSpeed: 7
@@ -426,7 +424,7 @@ MTNK:
 	Inherits@CLOAK: ^AcceptsCloakCrate
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 800
+		Cost: 900
 	Tooltip:
 		Name: Medium Tank
 	UpdatesPlayerStatistics:
@@ -470,7 +468,7 @@ HTNK:
 	Inherits@CLOAK: ^AcceptsCloakCrate
 	Inherits@AUTOTARGET: ^AutoTargetAllAssaultMove
 	Valued:
-		Cost: 1500
+		Cost: 1800
 	Tooltip:
 		Name: Mammoth Tank
 	UpdatesPlayerStatistics:

--- a/mods/cnc/weapons/other.yaml
+++ b/mods/cnc/weapons/other.yaml
@@ -22,20 +22,21 @@
 		InvalidTargets: Vehicle, Structure, Wall
 	Warhead@3Eff: CreateEffect
 		Explosions: small_napalm
-		ImpactSounds: flamer2.aud
 		ImpactActors: false
 
 Flamethrower:
 	Inherits: ^FlameWeapon
+	Warhead@1Dam: SpreadDamage
+		Spread: 256
 
 BigFlamer:
 	Inherits: ^FlameWeapon
-	ReloadDelay: 50
+	ReloadDelay: 65
 	Range: 3c512
 	Projectile: Bullet
 		Speed: 341
 	Burst: 2
-	BurstDelays: 25
+	BurstDelays: 10
 	Warhead@1Dam: SpreadDamage
 		Spread: 400
 		Damage: 10000

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -49,7 +49,7 @@ Vulcan:
 		Damage: 10000
 		Versus:
 			Wood: 15
-			Light: 100
+			Light: 30
 			Heavy: 35
 
 HeliAGGun:


### PR DESCRIPTION
Hello everyone. Since AoA has seemingly lost interest in working on balance (I don't blame him), I decided a few months ago to take a crack at balance. This PR will be the first step in a process to get TD up to speed to RA standards (Balance, meta, gameplay, etc).

The goal of this first PR is to address the significant imbalance between Nod and GDI. I've also looked at some gameplay and polish issues. These changes were tested under the name "Essentials" (ES1 through ES5).

**GDI/Nod Imbalance:**

`C17 Mobile 326 -> 700 (Cargo Plane)`

The most straightforward disadvantage Nod experiences is the long delay between finishing a vehicle and its arrival. It can be up to 12s before a vehicle arrives. A larger map results  in longer delays. 

Increasing the speed of the cargo plane helps mitigate these issues.

The other issue with the C17 is that it flies across the map. If flying over an enemy base, this can give an enemy player free intel based on the frequency of the C17's passovers. Frequent C17's mean cheap light vehicles produced. Slower means harvesters.

In our testing we stealthed the C17 to get around this. It worked, and most people didn't mind, but it felt a little sloppy. Ideally something like #17834 would be implemented to solve this.

`Airstrike: Vulcan Light 100 -> 30`

With directional support powers airstrikes received a significant upgrade in potency.  While I would like to look more into adjusting them, for now the vulcans have been tuned to not 1 shot light vehicles. The bombs will still kill any light vehicles lingering around. This allows Nod to harass harvesters (which are usually at the edge of the map) with bikes, without having to fear losing them instantly.

`Obelisk:
Range 7c512 -> 7c0
Tech Requirement: Temple of Nod -> Comm Center`

The Obelisk has always been a little weak. In looking to buff it, I was told it was originally on T2 in vanilla TD. It seemed like an easy change to me, and the results show. I've seen a lot of interesting plays with the earlier Obelisk.

It is still a very expensive structure (1500, -90 power), so Nod players have to think carefully when and where they place it.

I've reduced the range to counteract the buff somewhat.

`Mammoth Tank: Mobile: 56 -> 50
Tusk Missiles: Light 90 -> 50, None 44 -> 28, Spread 298 -> 128`


The GDI mammoth tank is an extremely cost effective generalist unit. In the current balance it has no cost effective counter, except being a little slow.

I've tuned it to be more vulnerable to infantry. The tusk missiles do significantly less damage to infantry, and it has been slowed a little to allow infantry to engage easier. However, the mammoth will still be able to defeat small groups of infantry. I've also reduced the light damage so it doesn't torpedo aircraft in one volley.

The main role of the mammoth tank is now an armor killer.

`AGT: Heavy 100 -> 70`

AGT is a generalist defensive tower that's a bit too good at it's role. I often see AGT spam in games.

This change is to give it a small weakness to tanks. I've changed its description with this in mind.

Polish wise I changed the range circle to match the ground weapon. It was originally showing the air weapon which had a longer range.

**Gameplay Improvements**

These changes aren't necessarily targeted at GDI/Nod imbalance, but instead aim to improve gameplay.

`Rocket Soldier Mobile: 42 -> 56`

Infantry have always been kind of weak in TD. This naturally results in tank spam and difficulty in comebacks (you can't counter your opponent's superior tank count). Increasing the rocket soldier's speed allows him to keep up with armies, retreat easier, and generally is a better unit to use. It also makes crushing harder.

This also solves the snowballing issue of retreating and your rocket soldiers falling behind (Not only did you lose the fight, you also lose all your rockets).

Gameplay effects have been positive, with more unit mixing and more stable gameplay. Infantry spam still has a variety of counters. All-in's don't seem broken.

`Light/Medium Tank: Cost 650->750, 800-> 900. Custom build time of light tank removed`

Similar in idea to above, tanks are just too cost effective.  Increasing cost is the easiest way to reduce tank spam.

LT had a custom build duration of about 700 cost. I didn't see this as necessary anymore so it was removed.

`Barracks/Hand of Nod: Power -20 -> -15`

In testing it became clear there was a bit of an oddity with power. If you went barracks (-20), refinery (-40), then war factory (-40), you'd be exactly at 0 power. This mean if anything tickled your powerplant (minigunner, light vehicle explosion, etc), you'd get "low power" and have to immediately repair it. This created weird gameplay where I would constantly repair my powerplant between volleys of a single minigunner in order to maximize production. Needless to say this was kind of silly so I reduced the power requirement of the barracks.

Early aggression is still possible, but you'll need about 4 minigunner to overtake the repair rate of the power plant.

`Construction Yard: Cooldown removed, defense bar different color`

One of the more annoying aspects of TD is being unable to place two structures without having to wait. I don't think anyone likes this mechanic. I imagine it was introduced to counteract multiple MCV builds, but that build is no longer viable with the extreme cost of the unit (4k).

It is also annoying in team games.

I also changed the color of the defense production bar so it is distinguishable from the structure one (they were the same color). It is the color that RA uses.

**Polish/Misc.**

`RA Veterancy Rework: No more accuracy bonuses, elite regeneration is % based, enemies can see veterancy`

I've transferred the veterancy changes that were implemented in RA to TD. The accuracy bonus was meaningless in TD as everything was accurate anyway. Elite regeneration was too slow for the pace of the game, so it made sense to transfer over the % one implemented by RA. Finally, being able to see enemy veterancy makes sense, and allows players to make better decisions (maybe you target down the vetted unit first). It's also a standard feature in later CnC's.

`Flamethrower: Spread 468 -> 256`

Flamethrowers do friendly fire. This significantly reduces it.

`Flame Tank: BurstDelay 25 -> 10, ReloadDelay 50 -> 65`

This makes the flame tank burstier (more like vanilla TD), without changing the overall DPS.

`Flame weapon impact sound removed`

Flame weapons have the same sound for when they're fired and when the weapon hits. This creates overlapping sound files, so I've removed the sound when the weapon impacts.

**Closing Notes**

#18193 APC firerate change shouldn't impact balance.

#18168  I'd like to see this implemented. I don't think there's much disagreement in the TD community, though the _how_ has to still be decided. Personally I think transit-only is best.

#14987 Is still an issue. I think it would also be a good idea to implement a slight distortion that players can see instead of being completely invisible, a la SC2 (I believe it is also a feature in the remasters).


