### PR TITLE
Replace `NetFrameNumber >= 1` with `GameStarted` and `0x7FFFFFFF` with `int.MaxValue`

### DIFF
--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -164,14 +164,14 @@ namespace OpenRA.Network
 
 		public bool IsReadyForNextFrame
 		{
-			get { return NetFrameNumber >= 1 && frameData.IsReadyForFrame(NetFrameNumber); }
+			get { return GameStarted && frameData.IsReadyForFrame(NetFrameNumber); }
 		}
 
 		public IEnumerable<Session.Client> GetClientsNotReadyForNextFrame
 		{
 			get
 			{
-				return NetFrameNumber >= 1
+				return GameStarted
 					? frameData.ClientsNotReadyForFrame(NetFrameNumber)
 						.Select(a => LobbyInfo.ClientWithIndex(a))
 					: NoClients;

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -1013,7 +1013,7 @@ namespace OpenRA.Server
 
 			foreach (var c in Conns)
 				foreach (var d in Conns)
-					DispatchOrdersToClient(c, d.PlayerIndex, 0x7FFFFFFF, new[] { (byte)OrderType.Disconnect });
+					DispatchOrdersToClient(c, d.PlayerIndex, int.MaxValue, new[] { (byte)OrderType.Disconnect });
 
 			if (GameSave == null && LobbyInfo.GlobalSettings.GameSavesEnabled)
 				GameSave = new GameSave();


### PR DESCRIPTION
I created [a new struct](https://github.com/ycanardeau/OpenRA/blob/6b21b4d412a4b10a9f815ef19d6ae83fd999f384/OpenRA.Game/Network/FrameID.cs) for storing frame numbers. I tried to refactor client IDs as well, but it was impossible because `clientId` in [NetworkConnection](https://github.com/OpenRA/OpenRA/blob/bacec2689d603800c403adccbbade68ec36b29d2/OpenRA.Game/Network/Connection.cs#L210) is declared as volatile.