### PR TITLE
Allow mod.yaml to be splitted into multiple files.

### DIFF
--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -73,7 +73,7 @@ namespace OpenRA
 
 		readonly string[] reservedModuleNames =
 		{
-			"Metadata", "Folders", "MapFolders", "Packages", "Rules",
+			"Includes", "Metadata", "Folders", "MapFolders", "Packages", "Rules",
 			"Sequences", "ModelSequences", "Cursors", "Chrome", "Assemblies", "ChromeLayout", "Weapons",
 			"Voices", "Notifications", "Music", "Translations", "TileSets", "ChromeMetrics", "Missions", "Hotkeys",
 			"ServerTraits", "LoadScreen", "SupportsMapsFrom", "SoundFormats", "SpriteFormats",
@@ -89,7 +89,14 @@ namespace OpenRA
 		{
 			Id = modId;
 			Package = package;
-			yaml = new MiniYaml(null, MiniYaml.FromStream(package.GetStream("mod.yaml"), "mod.yaml")).ToDictionary();
+
+			var nodes = MiniYaml.FromStream(package.GetStream("mod.yaml"), "mod.yaml");
+			var includes = nodes.FirstOrDefault(node => node.Key == "Includes");
+
+			if (includes != null)
+				nodes = MiniYaml.Merge(new[] { nodes }.Concat(includes.Value.ToDictionary().Keys.Select(i => MiniYaml.FromStream(package.GetStream(i), i))));
+
+			yaml = new MiniYaml(null, nodes).ToDictionary();
 
 			Metadata = FieldLoader.Load<ModMetadata>(yaml["Metadata"]);
 


### PR DESCRIPTION
This PR adds an optional "Includes:" list to the mod.yaml allowing mods to split up the mod.yaml into multiple smaller yaml files to avoid the mod.yaml getting a huge mess.
An usage example is provided here: https://github.com/IceReaper/KKnD/commit/f3ece12db0aaa8eb620883f276fbdc09d3e26f1d