### PR TITLE
Fix Lua's DisplaySystemMessage writing messages twice

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -206,8 +206,8 @@ namespace OpenRA.Mods.Common.Scripting
 
 			if (string.IsNullOrEmpty(prefix))
 				Game.AddSystemLine(text);
-
-			Game.AddSystemLine(prefix, text);
+			else
+				Game.AddSystemLine(prefix, text);
 		}
 
 		[Desc("Displays a debug message to the player, if \"Show Map Debug Messages\" is checked in the settings.")]


### PR DESCRIPTION
A small bug fix, currently `Media.DisplaySystemMessage` writes two messages if we don't provide the prefix. 

Test case commit included that will be removed after.