### PR TITLE
Make infantry always turn in place instead of moving in a curve

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -496,6 +496,10 @@ namespace OpenRA.Mods.Common.Activities
 
 			static bool IsTurn(Mobile mobile, CPos nextCell, Map map)
 			{
+				// Some actors with a limited number of sprite facings should never move along curved trajectories.
+				if (mobile.Info.AlwaysTurnInPlace)
+					return false;
+
 				// Tight U-turns should be done in place instead of making silly looking loops.
 				var nextFacing = map.FacingBetween(nextCell, mobile.ToCell, mobile.Facing);
 				var currentFacing = map.FacingBetween(mobile.ToCell, mobile.FromCell, mobile.Facing);

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -37,6 +37,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly int Speed = 1;
 
+		[Desc("If set to true, this unit will always turn in place instead of following a curved trajectory (like infantry).")]
+		public readonly bool AlwaysTurnInPlace = false;
+
 		[Desc("Cursor to display when a move order can be issued at target location.")]
 		public readonly string Cursor = "move";
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -379,6 +379,7 @@
 	RevealsShroud:
 		Range: 5c0
 	Mobile:
+		AlwaysTurnInPlace: true
 		Locomotor: foot
 	Selectable:
 		Bounds: 18,18,0,-6

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -305,6 +305,7 @@
 	RevealsShroud:
 		Range: 3c768
 	Mobile:
+		AlwaysTurnInPlace: true
 		Locomotor: foot
 	Selectable:
 		Bounds: 24,24,0,-4

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -325,6 +325,7 @@
 		Range: 4c0
 	Mobile:
 		Speed: 56
+		AlwaysTurnInPlace: true
 		Locomotor: foot
 	Selectable:
 		Bounds: 18,20,0,-6

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -555,6 +555,7 @@
 	Mobile:
 		Voice: Move
 		Speed: 71
+		AlwaysTurnInPlace: true
 		Locomotor: foot
 	TurnOnIdle:
 	Selectable:

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -122,6 +122,7 @@ SMECH:
 	Mobile:
 		TurnSpeed: 5
 		Speed: 99
+		AlwaysTurnInPlace: true
 	Health:
 		HP: 17500
 	Armor:
@@ -169,6 +170,7 @@ MMCH:
 	Mobile:
 		TurnSpeed: 5
 		Speed: 56
+		AlwaysTurnInPlace: true
 	Health:
 		HP: 40000
 	Armor:
@@ -332,6 +334,7 @@ JUGG:
 	Mobile:
 		Speed: 71
 		TurnSpeed: 5
+		AlwaysTurnInPlace: true
 		ImmovableCondition: !undeployed
 		RequireForceMoveCondition: !undeployed
 	RevealsShroud:


### PR DESCRIPTION
Fixes #18292 

This was actually even simpler than I remembered it being :smile: 

This makes infantry movement identical to the original games and is more fitting to their sprites which only have 8 facings. The last commit also applies the change to walker vehicles in Tiberian Sun. This is completely accurate to the original game, but I'm not completely convinced yet whether this is an improvement or not. I'd like to hear some more opinions on this.