### PR TITLE
Fix airstrike and paratroopers power not removing cameras at the map edge

### DIFF
--- a/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
@@ -131,9 +131,9 @@ namespace OpenRA.Mods.Common.Traits
 				aircraftInRange[a] = false;
 
 				// Checking for attack range is not relevant here because
-				// aircraft may be shot down before entering. Thus we remove
-				// the camera and beacon only if the whole squad is dead.
-				if (aircraftInRange.All(kv => kv.Key.IsDead))
+				// aircraft may be shot down before entering the range.
+				// If at the map's edge, they may be removed from world before leaving.
+				if (aircraftInRange.All(kv => !kv.Key.IsInWorld))
 				{
 					RemoveCamera(camera);
 					RemoveBeacon(beacon);

--- a/OpenRA.Mods.Common/Traits/SupportPowers/ParatroopersPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/ParatroopersPower.cs
@@ -161,9 +161,9 @@ namespace OpenRA.Mods.Common.Traits
 				aircraftInRange[a] = false;
 
 				// Checking for attack range is not relevant here because
-				// aircraft may be shot down before entering. Thus we remove
-				// the camera and beacon only if the whole squad is dead.
-				if (aircraftInRange.All(kv => kv.Key.IsDead))
+				// aircraft may be shot down before entering the range.
+				// If at the map's edge, they may be removed from world before leaving.
+				if (aircraftInRange.All(kv => !kv.Key.IsInWorld))
 				{
 					RemoveCamera(camera);
 					RemoveBeacon(beacon);


### PR DESCRIPTION
Reported by @dragunoff on Discord. Testcase is calling in an airstrike at the map edge such that the planes are removed from the map before they leave the range.