### PR TITLE
Fix travis builds not failing when errors occur during static checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,12 @@ env:
 # Run the NUnit tests
 script:
  - make all
- - test "$TRAVIS_OS_NAME" == "linux" && make check || echo "Skipping check"
- - test "$TRAVIS_OS_NAME" == "linux" && make check-scripts || echo "Skipping scripts check"
- - test "$TRAVIS_OS_NAME" == "linux" && make test || echo "Skipping tests"
- - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-     mono ~/.nuget/packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe --noresult OpenRA.Test.dll;
+ - |
+   if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      make check || travis_terminate 1;
+      make check-scripts || travis_terminate 1;
+      make test || travis_terminate 1;
+      mono ~/.nuget/packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe --noresult OpenRA.Test.dll || travis_terminate 1;
    fi
 
 # Only watch the development branch and tagged release.


### PR DESCRIPTION
See https://travis-ci.org/github/OpenRA/OpenRA/builds/699401557#L1396 as example. Right now it would simply output "Skipping tests" instead of failing.

If we wanted to keep the `echo`s and make it shorter I could likely also write this as
```
 - test "$TRAVIS_OS_NAME" == "linux" && make check || test "$TRAVIS_OS_NAME" != "linux" && echo "Skipping check"
 - test "$TRAVIS_OS_NAME" == "linux" && make check-scripts || test "$TRAVIS_OS_NAME" != "linux" && echo "Skipping scripts check"
 - test "$TRAVIS_OS_NAME" == "linux" && make test || test "$TRAVIS_OS_NAME" != "linux" && echo "Skipping tests"
```
or introduce else branches.