### PR TITLE
Fix PickupUnit not always validating cargo on first run.

### DIFF
--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -49,6 +49,10 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected override void OnFirstRun(Actor self)
 		{
+			// The cargo might have become invalid while we were moving towards it.
+			if (cargo.IsDead || carryable.IsTraitDisabled || !cargo.AppearsFriendlyTo(self))
+				return;
+
 			if (carryall.ReserveCarryable(self, cargo))
 			{
 				// Fly to the target and wait for it to be locked for pickup


### PR DESCRIPTION
This fixes a crash in ts when a to-be-picked-up unit dies before the carryall enters the pick-up activity. It does not apply to  `AutoCarryall` because there is already a (now possibly redundant) check in place.
<details>

```
Exception of type `System.InvalidOperationException`: Attempted to get trait from destroyed object (bggy 206 (not in world))
  at OpenRA.TraitDictionary.CheckDestroyed (OpenRA.Actor actor) [0x0001c] in <75796e53a1c14feaafc8ceaf332a1adf>:0 
  at OpenRA.TraitDictionary.Get[T] (OpenRA.Actor actor) [0x00000] in <75796e53a1c14feaafc8ceaf332a1adf>:0 
  at OpenRA.Actor.Trait[T] () [0x00000] in <75796e53a1c14feaafc8ceaf332a1adf>:0 
  at OpenRA.Mods.Common.Traits.Carryall.ReserveCarryable (OpenRA.Actor self, OpenRA.Actor carryable) [0x00018] in <57ebcdbb6701441b9b96b3750fe27cb0>:0 
  at OpenRA.Mods.Common.Activities.PickupUnit.OnFirstRun (OpenRA.Actor self) [0x00000] in <57ebcdbb6701441b9b96b3750fe27cb0>:0 
  at OpenRA.Activities.Activity.TickOuter (OpenRA.Actor self) [0x00034] in <75796e53a1c14feaafc8ceaf332a1adf>:0 
  at OpenRA.Traits.ActivityUtils.RunActivity (OpenRA.Actor self, OpenRA.Activities.Activity act) [0x00015] in <75796e53a1c14feaafc8ceaf332a1adf>:0 
  at OpenRA.Actor.Tick () [0x0000f] in <75796e53a1c14feaafc8ceaf332a1adf>:0 
  at OpenRA.World.Tick () [0x00123] in <75796e53a1c14feaafc8ceaf332a1adf>:0 
  at OpenRA.Game.InnerLogicTick (OpenRA.Network.OrderManager orderManager) [0x001bc] in <75796e53a1c14feaafc8ceaf332a1adf>:0 
  at OpenRA.Game.LogicTick () [0x0003e] in <75796e53a1c14feaafc8ceaf332a1adf>:0 
  at OpenRA.Game.Loop () [0x000f1] in <75796e53a1c14feaafc8ceaf332a1adf>:0 
  at OpenRA.Game.Run () [0x0003c] in <75796e53a1c14feaafc8ceaf332a1adf>:0 
  at OpenRA.Game.InitializeAndRun (System.String[] args) [0x00010] in <75796e53a1c14feaafc8ceaf332a1adf>:0 
  at OpenRA.Program.Main (System.String[] args) [0x00044] in <75796e53a1c14feaafc8ceaf332a1adf>:0 
```
</details>

Reproduction: Queue some move orders followed by a pickup order and destroy the cargo before the carryall finishes the move orders. With these changes, the carryall continues subsequent move orders or if there are none becomes idle without moving to where the cargo was. I tested this in d2k and ts.