### PR TITLE
Fix actors ending up in invalid powerstate when changing owner and state between ticks

### DIFF
--- a/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
@@ -149,11 +149,9 @@ namespace OpenRA.Mods.Common.Traits
 				UpdatePowerState();
 			}
 
-			if (--nextPowerAdviceTime <= 0)
+			if (isLowPower && --nextPowerAdviceTime <= 0)
 			{
-				if (isLowPower)
-					Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.SpeechNotification, self.Owner.Faction.InternalName);
-
+				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.SpeechNotification, self.Owner.Faction.InternalName);
 				nextPowerAdviceTime = info.AdviceInterval;
 			}
 

--- a/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
@@ -73,16 +73,21 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void UpdateActor(Actor a)
 		{
+			// old is 0 if a is not in powerDrain
 			int old;
-			powerDrain.TryGetValue(a, out old); // old is 0 if a is not in powerDrain
+			powerDrain.TryGetValue(a, out old);
+
 			var amount = a.TraitsImplementing<Power>().Where(t => !t.IsTraitDisabled).Sum(p => p.GetEnabledPower());
 			powerDrain[a] = amount;
+
 			if (amount == old || devMode.UnlimitedPower)
 				return;
+
 			if (old > 0)
 				totalProvided -= old;
 			else if (old < 0)
 				totalDrained += old;
+
 			if (amount > 0)
 				totalProvided += amount;
 			else if (amount < 0)
@@ -113,11 +118,15 @@ namespace OpenRA.Mods.Common.Traits
 				totalDrained = 0;
 
 				if (!devMode.UnlimitedPower)
+				{
 					foreach (var kv in powerDrain)
+					{
 						if (kv.Value > 0)
 							totalProvided += kv.Value;
 						else if (kv.Value < 0)
 							totalDrained -= kv.Value;
+					}
+				}
 
 				wasHackEnabled = devMode.UnlimitedPower;
 			}
@@ -148,8 +157,12 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				if (PowerProvided >= PowerDrained) return PowerState.Normal;
-				if (PowerProvided > PowerDrained / 2) return PowerState.Low;
+				if (PowerProvided >= PowerDrained)
+					return PowerState.Normal;
+
+				if (PowerProvided > PowerDrained / 2)
+					return PowerState.Low;
+
 				return PowerState.Critical;
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
@@ -92,6 +92,8 @@ namespace OpenRA.Mods.Common.Traits
 				totalProvided += amount;
 			else if (amount < 0)
 				totalDrained -= amount;
+
+			UpdatePowerState();
 		}
 
 		public void RemoveActor(Actor a)
@@ -108,6 +110,21 @@ namespace OpenRA.Mods.Common.Traits
 				totalProvided -= amount;
 			else if (amount < 0)
 				totalDrained += amount;
+
+			UpdatePowerState();
+		}
+
+		void UpdatePowerState()
+		{
+			isLowPower = ExcessPower < 0;
+
+			if (isLowPower != wasLowPower)
+				UpdatePowerRequiringActors();
+
+			if (isLowPower && !wasLowPower)
+				nextPowerAdviceTime = 0;
+
+			wasLowPower = isLowPower;
 		}
 
 		void ITick.Tick(Actor self)
@@ -129,17 +146,8 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				wasHackEnabled = devMode.UnlimitedPower;
+				UpdatePowerState();
 			}
-
-			isLowPower = ExcessPower < 0;
-
-			if (isLowPower != wasLowPower)
-				UpdatePowerRequiringActors();
-
-			if (isLowPower && !wasLowPower)
-				nextPowerAdviceTime = 0;
-
-			wasLowPower = isLowPower;
 
 			if (--nextPowerAdviceTime <= 0)
 			{


### PR DESCRIPTION
Testcase is the Evacuation mission. You can see that the Radar Dome doesn't have power and doesn't provide radar at the game start, despite you having enough power. Once you go low power (just wait for the parabombs) and then have enough power again (repair the power plants after the parabombs) the Radar works again.

This happens because the mission transfers ownership of the base actors at the start. All those actors change owner inbetween  ticks, which means here that the Radar changes owner, then goes to low power mode since there is not enough power, and then the Power Plants change owner, but do not change the power state. This would usually be done inside the `Tick` method of the manager. However, since all this happened in-between two ticks, the old and new power state are not different (despite changing in the meantime) and no update is triggered.

This is fixed by simply triggering an update if we change the state when power is added or removed.