### PR TITLE
Fix a compilation error in WithInfantryBody.cs

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			anim.PlayRepeating(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), StandSequences.First()));
 
 			if (IsPlayerPalette)
-				p = init.WorldRenderer.Palette(Palette + init.Get<OwnerInit>().PlayerName);
+				p = init.WorldRenderer.Palette(Palette + init.Get<OwnerInit>().InternalName);
 			else if (Palette != null)
 				p = init.WorldRenderer.Palette(Palette);
 


### PR DESCRIPTION
https://github.com/OpenRA/OpenRA/commit/7c6ec577dcfb05044f300dc5a011a75a9765b3c8#diff-b444fdd6cfebc6b359567271de3e143fL63-R90 (#18164) renamed `PlayerName` to `InternalName`. https://github.com/OpenRA/OpenRA/pull/18099/commits/015c02ade17233cad33593f32f702978073a8d63 (#18099) unfortunately still used `PlayerName`.

Closes #18304.