### PR TITLE
[TS] fix units walk over tunnels and under bridges

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -469,7 +469,9 @@ namespace OpenRA.Mods.Common.Activities
 					else
 						pos = WPos.Lerp(From, To, moveFraction, MoveFractionTotal);
 
-					pos -= new WVec(WDist.Zero, WDist.Zero, self.World.Map.DistanceAboveTerrain(pos));
+					if (self.Location.Layer == 0)
+						pos -= new WVec(WDist.Zero, WDist.Zero, self.World.Map.DistanceAboveTerrain(pos));
+
 					mobile.SetVisualPosition(self, pos);
 				}
 				else


### PR DESCRIPTION
This fixes units in TS being in the wrong place when they walk through tunnels and over bridges. Credit to pchote

Before Fix:
![image](https://user-images.githubusercontent.com/30208401/85238209-7a1ae400-b3fa-11ea-8eb9-2924a2b8327f.png)
![image](https://user-images.githubusercontent.com/30208401/85238221-928afe80-b3fa-11ea-9160-6c5cb1366aa0.png)


After Fix:
![image](https://user-images.githubusercontent.com/30208401/85238037-2bb91580-b3f9-11ea-834d-68a461b9da69.png)
![image](https://user-images.githubusercontent.com/30208401/85238319-3379b980-b3fb-11ea-97d7-0b4bcedb367e.png)
