### PR TITLE
Aircraft kinematics part 2: Separate aircraft flight direction and body orientation.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -60,13 +60,18 @@ namespace OpenRA.Mods.Common.Activities
 			this.minRange = minRange;
 		}
 
-		public static void FlyTick(Actor self, Aircraft aircraft, WAngle desiredFacing, WDist desiredAltitude, WVec moveOverride,
+		public static void FlyTick(Actor self, Aircraft aircraft, WAngle desiredFacing, WDist desiredAltitude, WVec? moveOverride = null,
 			bool idleTurn = false, WAngle? desiredBodyFacing = null)
 		{
 			var dat = self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition);
-			var move = aircraft.FlyStep(aircraft.FlightFacing);
-			if (moveOverride != WVec.Zero)
-				move = moveOverride;
+
+			var speed = aircraft.MovementSpeed;
+			if (idleTurn && aircraft.Info.IdleSpeed >= 0)
+				speed = aircraft.Info.IdleSpeed;
+
+			var move = aircraft.FlyStep(speed, aircraft.FlightFacing);
+			if (moveOverride.HasValue)
+				move = moveOverride.Value;
 
 			var flightTurnSpeed = idleTurn ? aircraft.Info.IdleTurnSpeed ?? aircraft.TurnSpeed : aircraft.TurnSpeed;
 			var flightFacing = Util.TickFacing(aircraft.FlightFacing, desiredFacing, flightTurnSpeed);
@@ -103,11 +108,6 @@ namespace OpenRA.Mods.Common.Activities
 			aircraft.FlightFacing = flightFacing;
 			aircraft.Facing = bodyFacing;
 			aircraft.SetPosition(self, aircraft.CenterPosition + move);
-		}
-
-		public static void FlyTick(Actor self, Aircraft aircraft, WAngle desiredFacing, WDist desiredAltitude, bool idleTurn = false)
-		{
-			FlyTick(self, aircraft, desiredFacing, desiredAltitude, WVec.Zero, idleTurn);
 		}
 
 		// Should only be used for vertical-only movement, usually VTOL take-off or land. Terrain-induced altitude changes should always be handled by FlyTick.
@@ -197,16 +197,11 @@ namespace OpenRA.Mods.Common.Activities
 			var isSlider = aircraft.Info.CanSlide;
 			var desiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw : aircraft.FlightFacing;
 			var desiredBodyFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw : aircraft.Facing;
-			var move = isSlider ? aircraft.FlyStep(desiredFacing) : aircraft.FlyStep(aircraft.FlightFacing);
 
 			// Inside the minimum range, so reverse if we CanSlide, otherwise face away from the target.
 			if (insideMinRange)
 			{
-				if (isSlider)
-					FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, -move, desiredBodyFacing: desiredBodyFacing);
-				else
-					FlyTick(self, aircraft, desiredFacing + new WAngle(512), aircraft.Info.CruiseAltitude, move, desiredBodyFacing: desiredBodyFacing);
-
+				FlyTick(self, aircraft, desiredFacing + new WAngle(512), aircraft.Info.CruiseAltitude, desiredBodyFacing: desiredBodyFacing);
 				return false;
 			}
 
@@ -217,7 +212,7 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 
 			// The next move would overshoot, so consider it close enough or set final position if we CanSlide
-			if (delta.HorizontalLengthSquared < move.HorizontalLengthSquared)
+			if (delta.HorizontalLength < aircraft.MovementSpeed)
 			{
 				// For VTOL landing to succeed, it must reach the exact target position,
 				// so for the final move it needs to behave as if it had CanSlide.

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -60,22 +60,29 @@ namespace OpenRA.Mods.Common.Activities
 			this.minRange = minRange;
 		}
 
-		public static void FlyTick(Actor self, Aircraft aircraft, WAngle desiredFacing, WDist desiredAltitude, WVec moveOverride, bool idleTurn = false)
+		public static void FlyTick(Actor self, Aircraft aircraft, WAngle desiredFacing, WDist desiredAltitude, WVec moveOverride,
+			bool idleTurn = false, WAngle? desiredBodyFacing = null)
 		{
 			var dat = self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition);
-			var move = aircraft.Info.CanSlide ? aircraft.FlyStep(desiredFacing) : aircraft.FlyStep(aircraft.Facing);
+			var move = aircraft.FlyStep(aircraft.FlightFacing);
 			if (moveOverride != WVec.Zero)
 				move = moveOverride;
 
-			var oldFacing = aircraft.Facing;
-			var turnSpeed = idleTurn ? aircraft.IdleTurnSpeed ?? aircraft.TurnSpeed : aircraft.TurnSpeed;
-			aircraft.Facing = Util.TickFacing(aircraft.Facing, desiredFacing, turnSpeed);
+			var flightTurnSpeed = idleTurn ? aircraft.Info.IdleTurnSpeed ?? aircraft.TurnSpeed : aircraft.TurnSpeed;
+			var flightFacing = Util.TickFacing(aircraft.FlightFacing, desiredFacing, flightTurnSpeed);
+
+			var bodyFacing = flightFacing;
+			if (aircraft.Info.CanSlide)
+			{
+				var bodyTurnSpeed = aircraft.Info.BodyTurnSpeed ?? flightTurnSpeed;
+				bodyFacing = Util.TickFacing(aircraft.Facing, desiredBodyFacing ?? desiredFacing, bodyTurnSpeed);
+			}
 
 			var roll = idleTurn ? aircraft.Info.IdleRoll ?? aircraft.Info.Roll : aircraft.Info.Roll;
 			if (roll != WAngle.Zero)
 			{
-				var desiredRoll = aircraft.Facing == desiredFacing ? WAngle.Zero :
-					new WAngle(roll.Angle * Util.GetTurnDirection(aircraft.Facing, oldFacing));
+				var desiredRoll = flightFacing == desiredFacing ? WAngle.Zero :
+					new WAngle(roll.Angle * Util.GetTurnDirection(flightFacing, aircraft.FlightFacing));
 
 				aircraft.Roll = Util.TickFacing(aircraft.Roll, desiredRoll, aircraft.Info.RollSpeed);
 			}
@@ -93,6 +100,8 @@ namespace OpenRA.Mods.Common.Activities
 				move = new WVec(move.X, move.Y, deltaZ);
 			}
 
+			aircraft.FlightFacing = flightFacing;
+			aircraft.Facing = bodyFacing;
 			aircraft.SetPosition(self, aircraft.CenterPosition + move);
 		}
 
@@ -107,8 +116,9 @@ namespace OpenRA.Mods.Common.Activities
 			var dat = self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition);
 			var move = WVec.Zero;
 
-			var turnSpeed = idleTurn ? aircraft.IdleTurnSpeed ?? aircraft.TurnSpeed : aircraft.TurnSpeed;
-			aircraft.Facing = Util.TickFacing(aircraft.Facing, desiredFacing, turnSpeed);
+			var flightTurnSpeed = idleTurn ? aircraft.Info.IdleTurnSpeed ?? aircraft.TurnSpeed : aircraft.TurnSpeed;
+			var bodyTurnSpeed = aircraft.Info.BodyTurnSpeed ?? flightTurnSpeed;
+			aircraft.Facing = Util.TickFacing(aircraft.Facing, desiredFacing, bodyTurnSpeed);
 
 			if (dat != desiredAltitude)
 			{
@@ -185,18 +195,17 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 
 			var isSlider = aircraft.Info.CanSlide;
-			var desiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw : aircraft.Facing;
-			var move = isSlider ? aircraft.FlyStep(desiredFacing) : aircraft.FlyStep(aircraft.Facing);
+			var desiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw : aircraft.FlightFacing;
+			var desiredBodyFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw : aircraft.Facing;
+			var move = isSlider ? aircraft.FlyStep(desiredFacing) : aircraft.FlyStep(aircraft.FlightFacing);
 
 			// Inside the minimum range, so reverse if we CanSlide, otherwise face away from the target.
 			if (insideMinRange)
 			{
 				if (isSlider)
-					FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, -move);
+					FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, -move, desiredBodyFacing: desiredBodyFacing);
 				else
-				{
-					FlyTick(self, aircraft, desiredFacing + new WAngle(512), aircraft.Info.CruiseAltitude, move);
-				}
+					FlyTick(self, aircraft, desiredFacing + new WAngle(512), aircraft.Info.CruiseAltitude, move, desiredBodyFacing: desiredBodyFacing);
 
 				return false;
 			}
@@ -233,15 +242,16 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 			}
 
-			if (!isSlider)
+			var flightTurnSpeed = aircraft.TurnSpeed;
+			if (flightTurnSpeed.Angle < 512)
 			{
 				// Using the turn rate, compute a hypothetical circle traced by a continuous turn.
 				// If it contains the destination point, it's unreachable without more complex manuvering.
-				var turnRadius = CalculateTurnRadius(aircraft.MovementSpeed, aircraft.TurnSpeed);
+				var turnRadius = CalculateTurnRadius(aircraft.MovementSpeed, flightTurnSpeed);
 
 				// The current facing is a tangent of the minimal turn circle.
 				// Make a perpendicular vector, and use it to locate the turn's center.
-				var turnCenterFacing = aircraft.Facing + new WAngle(Util.GetTurnDirection(aircraft.Facing, desiredFacing) * 256);
+				var turnCenterFacing = aircraft.FlightFacing + new WAngle(Util.GetTurnDirection(aircraft.FlightFacing, desiredFacing) * 256);
 
 				var turnCenterDir = new WVec(0, -1024, 0).Rotate(WRot.FromYaw(turnCenterFacing));
 				turnCenterDir *= turnRadius;
@@ -250,7 +260,7 @@ namespace OpenRA.Mods.Common.Activities
 				// Compare with the target point, and keep flying away if it's inside the circle.
 				var turnCenter = aircraft.CenterPosition + turnCenterDir;
 				if ((checkTarget.CenterPosition - turnCenter).HorizontalLengthSquared < turnRadius * turnRadius)
-					desiredFacing = aircraft.Facing;
+					desiredFacing = aircraft.FlightFacing;
 			}
 
 			positionBuffer.Add(self.CenterPosition);

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -151,9 +151,6 @@ namespace OpenRA.Mods.Common.Activities
 				return false;
 			}
 
-			var delta = attackAircraft.GetTargetPosition(pos, target) - pos;
-			var desiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw : aircraft.Facing;
-
 			QueueChild(new TakeOff(self));
 
 			var minimumRange = attackAircraft.Info.AttackType == AirAttackType.Strafe ? WDist.Zero : attackAircraft.GetMinimumRangeVersusTarget(target);
@@ -170,7 +167,11 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Turn to face the target if required.
 			else if (!attackAircraft.TargetInFiringArc(self, target, 4 * attackAircraft.Info.FacingTolerance))
+			{
+				var delta = attackAircraft.GetTargetPosition(pos, target) - pos;
+				var desiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw : aircraft.Facing;
 				aircraft.Facing = Util.TickFacing(aircraft.Facing, desiredFacing, aircraft.TurnSpeed);
+			}
 
 			return false;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (checkTarget.IsInRange(pos, maxRange) && !checkTarget.IsInRange(pos, minRange))
 			{
 				if (!aircraft.Info.CanHover)
-					Fly.FlyTick(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);
+					Fly.FlyTick(self, aircraft, aircraft.FlightFacing, aircraft.Info.CruiseAltitude);
 
 				return useLastVisibleTarget;
 			}

--- a/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
@@ -50,14 +50,10 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (aircraft.Info.IdleSpeed > 0 || (!aircraft.Info.CanHover && aircraft.Info.IdleSpeed < 0))
 			{
-				var speed = aircraft.Info.IdleSpeed < 0 ? aircraft.Info.Speed : aircraft.Info.IdleSpeed;
-
-				// This override is necessary, otherwise aircraft with CanSlide would circle sideways
-				var move = aircraft.FlyStep(speed, aircraft.Facing);
-
 				// We can't possibly turn this fast
 				var desiredFacing = aircraft.FlightFacing + new WAngle(256);
-				Fly.FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, move, idleTurn);
+				Fly.FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, idleTurn: idleTurn,
+					desiredBodyFacing: aircraft.FlightFacing);
 			}
 
 			return false;

--- a/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Activities
 				var move = aircraft.FlyStep(speed, aircraft.Facing);
 
 				// We can't possibly turn this fast
-				var desiredFacing = aircraft.Facing + new WAngle(256);
+				var desiredFacing = aircraft.FlightFacing + new WAngle(256);
 				Fly.FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, move, idleTurn);
 			}
 

--- a/OpenRA.Mods.Common/Activities/Air/FlyTimed.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyTimed.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (IsCanceling || remainingTicks-- == 0)
 				return true;
 
-			Fly.FlyTick(self, aircraft, aircraft.Facing, cruiseAltitude);
+			Fly.FlyTick(self, aircraft, aircraft.FlightFacing, cruiseAltitude);
 
 			return false;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
+++ b/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Activities
 					return false;
 				}
 
-				Fly.FlyTick(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);
+				Fly.FlyTick(self, aircraft, aircraft.FlightFacing, aircraft.Info.CruiseAltitude);
 				return false;
 			}
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RefactorAircraftTurnSpeed.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RefactorAircraftTurnSpeed.cs
@@ -1,0 +1,41 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	class RefactorAircraftTurnSpeed : UpdateRule
+	{
+		public override string Name { get { return "Split up aircraft TurnSpeed into flight and body turn speeds."; } }
+		public override string Description
+		{
+			get
+			{
+				return "Aircraft TurnSpeed has been split into TurnSpeed and BodyTurnSpeed to allow aircraft with CanSlide: true to have" +
+					"independent flight direction and body orientation. If BodyTurnSpeed is defined, TurnSpeed only controls rate of turn" +
+					" for flight direction. Aircraft with CanSlide: true should use BodyTurnSpeed and leave TurnSpeed undefined to maintain" +
+					"the old sliding behaviour.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var rp in actorNode.ChildrenMatching("Aircraft"))
+			{
+				if (rp.LastChildMatching("CanSlide").Key == "true")
+					rp.RenameChildrenMatching("TurnSpeed", "BodyTurnSpeed");
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -76,6 +76,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveTurnToDock(),
 				new RenameSmudgeSmokeFields(),
 				new RenameCircleContrast(),
+				new RefactorAircraftTurnSpeed(),
 			})
 		};
 

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -13,7 +13,7 @@ TRAN:
 		Queue: Aircraft.GDI, Aircraft.Nod
 		Description: Fast Infantry Transport Helicopter.\n  Unarmed
 	Aircraft:
-		TurnSpeed: 20
+		BodyTurnSpeed: 20
 		Speed: 150
 		AltitudeVelocity: 0c100
 	Health:
@@ -64,7 +64,7 @@ HELI:
 		Queue: Aircraft.Nod
 		Description: Helicopter Gunship with Chainguns.\n  Strong vs Infantry, Light Vehicles and\n  Aircraft\n  Weak vs Tanks
 	Aircraft:
-		TurnSpeed: 28
+		BodyTurnSpeed: 28
 		Speed: 180
 	Health:
 		HP: 12000
@@ -132,7 +132,7 @@ ORCA:
 		Queue: Aircraft.GDI
 		Description: Helicopter Gunship with AG Missiles.\n  Strong vs Buildings, Tanks\n  Weak vs Infantry
 	Aircraft:
-		TurnSpeed: 28
+		BodyTurnSpeed: 28
 		Speed: 186
 	Health:
 		HP: 9000
@@ -254,7 +254,7 @@ TRAN.Husk:
 	Tooltip:
 		Name: Chinook Transport
 	Aircraft:
-		TurnSpeed: 20
+		BodyTurnSpeed: 20
 		Speed: 140
 	RevealsShroud:
 		Range: 10c0
@@ -273,7 +273,7 @@ HELI.Husk:
 	Tooltip:
 		Name: Apache Longbow
 	Aircraft:
-		TurnSpeed: 16
+		BodyTurnSpeed: 16
 		Speed: 186
 	RevealsShroud:
 		Range: 10c0
@@ -289,7 +289,7 @@ ORCA.Husk:
 	Tooltip:
 		Name: Orca
 	Aircraft:
-		TurnSpeed: 16
+		BodyTurnSpeed: 16
 		Speed: 186
 	RevealsShroud:
 		Range: 10c0

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -14,7 +14,7 @@ carryall.reinforce:
 		CruiseAltitude: 2160
 		CruisingCondition: cruising
 		Speed: 144
-		TurnSpeed: 16
+		BodyTurnSpeed: 16
 		LandableTerrainTypes: Sand, Rock, Transition, Spice, SpiceSand, Dune, Concrete
 		Repulsable: False
 		AirborneCondition: airborne
@@ -81,7 +81,7 @@ frigate:
 	Aircraft:
 		IdleBehavior: LeaveMap
 		Speed: 189
-		TurnSpeed: 4
+		BodyTurnSpeed: 4
 		Repulsable: False
 		MaximumPitch: 20
 		CruiseAltitude: 2048
@@ -132,7 +132,7 @@ carryall.husk:
 	Tooltip:
 		Name: Carryall
 	Aircraft:
-		TurnSpeed: 16
+		BodyTurnSpeed: 16
 		Speed: 144
 		CanSlide: True
 		VTOL: true
@@ -147,7 +147,7 @@ carryall.huskVTOL:
 		Moves: False
 		Velocity: 0c128
 	Aircraft:
-		TurnSpeed: 16
+		BodyTurnSpeed: 16
 		CanSlide: True
 		VTOL: true
 	RenderSprites:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -214,7 +214,7 @@ TRAN:
 		Range: 6c0
 		Type: GroundPosition
 	Aircraft:
-		TurnSpeed: 20
+		BodyTurnSpeed: 20
 		Speed: 128
 		AltitudeVelocity: 0c58
 	WithIdleOverlay@ROTOR1AIR:
@@ -281,7 +281,7 @@ HELI:
 		AttackType: Hover
 		OpportunityFire: False
 	Aircraft:
-		TurnSpeed: 16
+		BodyTurnSpeed: 16
 		Speed: 149
 	AutoTarget:
 		InitialStance: HoldFire
@@ -354,7 +354,7 @@ HIND:
 		AttackType: Hover
 		OpportunityFire: False
 	Aircraft:
-		TurnSpeed: 16
+		BodyTurnSpeed: 16
 		Speed: 112
 	AutoTarget:
 		InitialStance: HoldFire
@@ -456,7 +456,7 @@ MH60:
 		PersistentTargeting: false
 		AttackType: Hover
 	Aircraft:
-		TurnSpeed: 16
+		BodyTurnSpeed: 16
 		Speed: 112
 	AutoTarget:
 		InitialStance: HoldFire

--- a/mods/ra/rules/husks.yaml
+++ b/mods/ra/rules/husks.yaml
@@ -89,7 +89,7 @@ TRAN.Husk:
 	Tooltip:
 		Name: Chinook
 	Aircraft:
-		TurnSpeed: 16
+		BodyTurnSpeed: 16
 		Speed: 149
 	WithIdleOverlay@PRIMARY:
 		Offset: -597,0,341
@@ -202,7 +202,7 @@ HELI.Husk:
 	Tooltip:
 		Name: Longbow
 	Aircraft:
-		TurnSpeed: 16
+		BodyTurnSpeed: 16
 		Speed: 149
 	WithIdleOverlay:
 		Offset: 0,0,85
@@ -226,7 +226,7 @@ HIND.Husk:
 	Tooltip:
 		Name: Hind
 	Aircraft:
-		TurnSpeed: 16
+		BodyTurnSpeed: 16
 		Speed: 112
 	WithIdleOverlay:
 		Sequence: rotor
@@ -438,7 +438,7 @@ MH60.Husk:
 	Tooltip:
 		Name: Black Hawk
 	Aircraft:
-		TurnSpeed: 16
+		BodyTurnSpeed: 16
 		Speed: 112
 	WithIdleOverlay:
 		Sequence: rotor

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -136,13 +136,12 @@ ORCA:
 	Selectable:
 		Bounds: 30,24
 	Aircraft:
-		BodyTurnSpeed: 12
-		TurnSpeed: 20
+		TurnSpeed: 40
+		BodyTurnSpeed: 20
 		Speed: 186
 		TakeoffSounds: orcaup1.aud
 		LandingSounds: orcadwn1.aud
 		AltitudeVelocity: 128
-		CanSlide: false
 		TakeOffOnResupply: true
 	Health:
 		HP: 20000
@@ -199,7 +198,8 @@ ORCAB:
 		Bounds: 30,24
 	Aircraft:
 		CruiseAltitude: 5c512
-		TurnSpeed: 12
+		TurnSpeed: 20
+		BodyTurnSpeed: 12
 		IdleTurnSpeed: 4
 		Speed: 96
 		IdleSpeed: 72
@@ -207,7 +207,6 @@ ORCAB:
 		TakeoffSounds: orcaup1.aud
 		LandingSounds: orcadwn1.aud
 		CanHover: false
-		CanSlide: false
 	Health:
 		HP: 26000
 	Armor:
@@ -263,6 +262,7 @@ ORCATRAN:
 		Prerequisites: ~disabled
 	RenderSprites:
 	Aircraft:
+		TurnSpeed: 40
 		BodyTurnSpeed: 20
 		Speed: 84
 		LandableTerrainTypes: Clear, Road, Rail, DirtRoad, Rough, Tiberium, BlueTiberium, Veins
@@ -304,6 +304,7 @@ TRNSPORT:
 		Prerequisites: ~gahpad, gadept
 		Description: VTOL aircraft capable of lifting\nand transporting vehicles.\n  Unarmed
 	Aircraft:
+		TurnSpeed: 40
 		BodyTurnSpeed: 20
 		Speed: 149
 		Pitch: 0
@@ -360,7 +361,6 @@ SCRIN:
 		TakeoffSounds: dropup1.aud
 		LandingSounds: dropdwn1.aud
 		CanHover: false
-		CanSlide: false
 	Health:
 		HP: 28000
 	Armor:
@@ -421,9 +421,9 @@ APACHE:
 		PitchSpeed: 8
 		Roll: 16
 		RollSpeed: 8
+		TurnSpeed: 40
 		BodyTurnSpeed: 20
 		Speed: 130
-		CanSlide: false
 		TakeOffOnResupply: true
 	Health:
 		HP: 22500

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -10,7 +10,7 @@ DPOD:
 		IdleBehavior: Land
 		Pitch: 0
 		Roll: 0
-		TurnSpeed: 20
+		BodyTurnSpeed: 20
 		Speed: 149
 	Health:
 		HP: 6000
@@ -47,7 +47,7 @@ DPOD2:
 	Armor:
 		Type: Light
 	Aircraft:
-		TurnSpeed: 20
+		BodyTurnSpeed: 20
 		Speed: 300
 		CruiseAltitude: 16c0
 		MaximumPitch: 110
@@ -95,7 +95,7 @@ DSHP:
 		IdleBehavior: Land
 		Pitch: 0
 		Roll: 0
-		TurnSpeed: 20
+		BodyTurnSpeed: 20
 		Speed: 168
 		TakeoffSounds: dropup1.aud
 		LandingSounds: dropdwn1.aud
@@ -136,6 +136,7 @@ ORCA:
 	Selectable:
 		Bounds: 30,24
 	Aircraft:
+		BodyTurnSpeed: 12
 		TurnSpeed: 20
 		Speed: 186
 		TakeoffSounds: orcaup1.aud
@@ -262,7 +263,7 @@ ORCATRAN:
 		Prerequisites: ~disabled
 	RenderSprites:
 	Aircraft:
-		TurnSpeed: 20
+		BodyTurnSpeed: 20
 		Speed: 84
 		LandableTerrainTypes: Clear, Road, Rail, DirtRoad, Rough, Tiberium, BlueTiberium, Veins
 		Crushes: crate, infantry
@@ -303,7 +304,7 @@ TRNSPORT:
 		Prerequisites: ~gahpad, gadept
 		Description: VTOL aircraft capable of lifting\nand transporting vehicles.\n  Unarmed
 	Aircraft:
-		TurnSpeed: 20
+		BodyTurnSpeed: 20
 		Speed: 149
 		Pitch: 0
 		Roll: 0
@@ -420,7 +421,7 @@ APACHE:
 		PitchSpeed: 8
 		Roll: 16
 		RollSpeed: 8
-		TurnSpeed: 20
+		BodyTurnSpeed: 20
 		Speed: 130
 		CanSlide: false
 		TakeOffOnResupply: true
@@ -483,7 +484,7 @@ HUNTER:
 	Armor:
 		Type: Light
 	Aircraft:
-		TurnSpeed: 64
+		BodyTurnSpeed: 64
 		Speed: 355
 		Pitch: 0
 		Roll: 0

--- a/mods/ts/rules/husks.yaml
+++ b/mods/ts/rules/husks.yaml
@@ -3,7 +3,7 @@ DSHP.Husk:
 	Tooltip:
 		Name: Dropship
 	Aircraft:
-		TurnSpeed: 20
+		BodyTurnSpeed: 20
 		Speed: 168
 	-RenderSprites:
 	RenderVoxels:
@@ -14,7 +14,7 @@ ORCA.Husk:
 	Tooltip:
 		Name: Orca Fighter
 	Aircraft:
-		TurnSpeed: 20
+		BodyTurnSpeed: 20
 		Speed: 186
 	RenderSprites:
 		Image: orca
@@ -30,7 +30,7 @@ ORCAB.Husk:
 	Tooltip:
 		Name: Orca Bomber
 	Aircraft:
-		TurnSpeed: 12
+		BodyTurnSpeed: 12
 		Speed: 96
 	FallsToEarth:
 		MaximumSpinSpeed: 24
@@ -48,7 +48,7 @@ ORCATRAN.Husk:
 	Tooltip:
 		Name: Orca Transport
 	Aircraft:
-		TurnSpeed: 20
+		BodyTurnSpeed: 20
 		Speed: 84
 	RenderSprites:
 		Image: orcatran
@@ -64,7 +64,7 @@ TRNSPORT.Husk:
 	Tooltip:
 		Name: Carryall
 	Aircraft:
-		TurnSpeed: 20
+		BodyTurnSpeed: 20
 		Speed: 149
 	RenderSprites:
 		Image: trnsport
@@ -80,7 +80,7 @@ SCRIN.Husk:
 	Tooltip:
 		Name: Banshee Fighter
 	Aircraft:
-		TurnSpeed: 12
+		BodyTurnSpeed: 12
 		Speed: 168
 	FallsToEarth:
 		MaximumSpinSpeed: 24
@@ -98,7 +98,7 @@ APACHE.Husk:
 	Tooltip:
 		Name: Harpy
 	Aircraft:
-		TurnSpeed: 20
+		BodyTurnSpeed: 20
 		Speed: 130
 	WithIdleOverlay:
 		Offset: 85,0,598


### PR DESCRIPTION
This is the follow-up to #18320.

This gives aircraft an additional facing that determines the flight direction which is independent (in the case of sliding aircraft) from the regular body facing. This more closely matches how sliding aircraft behaved in the original games.

The turn speed for the flight direction can be defined in yaml and can be both higher and lower than the normal turn speed for different effect. this allows more fine-grained control over the sliding behaviour, although we still need to convert the turn speeds exposed to yaml to WAngle to precisely tune in the desired behaviour.

When `FlightTurnSpeed` is set to maximum (the default), the behaviour should be more or less the same as before.

There are four testcases in TS to illustrate the behaviours:
- Orca bomber is still `CanSlide = false`
- Apache is a slider with maximum `FlightTurnSpeed`
- Orca fighter has a `FlightTurnSpeed > TurnSpeed`.
- Banshee has `FlightTurnSpeed < TurnSpeed`