### PR TITLE
Lua API - Added a damage parameter to Trigger.OnDamage callback

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Global/TriggerGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/TriggerGlobal.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Scripting
 		}
 
 		[Desc("Call a function when the actor is damaged. The callback " +
-			"function will be called as func(Actor self, Actor attacker).")]
+			"function will be called as func(Actor self, Actor attacker, int damage).")]
 		public void OnDamaged(Actor a, LuaFunction func)
 		{
 			GetScriptTriggers(a).RegisterCallback(Trigger.OnDamaged, func, Context);

--- a/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
+++ b/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
@@ -118,7 +118,8 @@ namespace OpenRA.Mods.Common.Scripting
 				try
 				{
 					using (var b = e.Attacker.ToLuaValue(f.Context))
-						f.Function.Call(f.Self, b).Dispose();
+					using (var c = e.Damage.Value.ToLuaValue(f.Context))
+						f.Function.Call(f.Self, b, c).Dispose();
 				}
 				catch (Exception ex)
 				{


### PR DESCRIPTION
Old callback: `func(Actor self, Actor attacker)`
New callback: `func(Actor self, Actor attacker, int damage)`

Doesn't break any existing usage of `Trigger.OnDamage`.

The use case for this is my Renegade 2D maps. I currently use damage dealt to calculate score / credit rewards, but currently have to use a global table and track health state each time an actor is damaged.

Test case attached, send Tanya in allies01 to the left of the tech center to take damage.
