### PR TITLE
Allow to change default OrderGenerator in World using IDefaultOrderGenerator and DefaultOrderGenerator trait.

### DIFF
--- a/OpenRA.Game/Orders/IDefaultOrderGenerator.cs
+++ b/OpenRA.Game/Orders/IDefaultOrderGenerator.cs
@@ -1,0 +1,21 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Graphics;
+
+namespace OpenRA
+{
+	public interface IDefaultOrderGenerator
+	{
+		IOrderGenerator CreateDefaultOrderGenerator();
+	}
+}

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -167,8 +167,9 @@ namespace OpenRA
 		}
 
 		public readonly ISelection Selection;
+		readonly IDefaultOrderGenerator defaultOrderGenerator;
 
-		public void CancelInputMode() { OrderGenerator = new UnitOrderGenerator(); }
+		public void CancelInputMode() { OrderGenerator = defaultOrderGenerator.CreateDefaultOrderGenerator(); }
 
 		public bool ToggleInputMode<T>() where T : IOrderGenerator, new()
 		{
@@ -192,7 +193,6 @@ namespace OpenRA
 		{
 			Type = type;
 			OrderManager = orderManager;
-			orderGenerator = new UnitOrderGenerator();
 			Map = map;
 			Timestep = orderManager.LobbyInfo.GlobalSettings.Timestep;
 			SharedRandom = new MersenneTwister(orderManager.LobbyInfo.GlobalSettings.RandomSeed);
@@ -205,6 +205,8 @@ namespace OpenRA
 			ActorMap = WorldActor.Trait<IActorMap>();
 			ScreenMap = WorldActor.Trait<ScreenMap>();
 			Selection = WorldActor.Trait<ISelection>();
+			defaultOrderGenerator = WorldActor.Trait<IDefaultOrderGenerator>();
+			orderGenerator = defaultOrderGenerator.CreateDefaultOrderGenerator();
 
 			// Reset mask
 			LongBitSet<PlayerBitMask>.Reset();

--- a/OpenRA.Mods.Common/Traits/World/DefaultOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/DefaultOrderGenerator.cs
@@ -1,0 +1,31 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Orders;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public class DefaultOrderGeneratorInfo : TraitInfo
+	{
+		public override object Create(ActorInitializer init) { return new DefaultOrderGenerator(); }
+	}
+
+	public class DefaultOrderGenerator : IDefaultOrderGenerator
+	{
+		public DefaultOrderGenerator() { }
+
+		IOrderGenerator IDefaultOrderGenerator.CreateDefaultOrderGenerator()
+		{
+			return new UnitOrderGenerator();
+		}
+	}
+}

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -4,6 +4,7 @@
 	ScreenMap:
 	ActorMap:
 	Selection:
+	DefaultOrderGenerator:
 	MusicPlaylist:
 		VictoryMusic: win1
 		DefeatMusic: nod_map1

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -4,6 +4,7 @@
 	ScreenMap:
 	ActorMap:
 	Selection:
+	DefaultOrderGenerator:
 	MusicPlaylist:
 		VictoryMusic: score
 		DefeatMusic: score

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -4,6 +4,7 @@
 	ActorMap:
 	ScreenMap:
 	Selection:
+	DefaultOrderGenerator:
 	MusicPlaylist:
 		VictoryMusic: score
 		DefeatMusic: map

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -4,6 +4,7 @@
 	ScreenMap:
 	ActorMap:
 	Selection:
+	DefaultOrderGenerator:
 	MusicPlaylist:
 		VictoryMusic: score
 		DefeatMusic: maps


### PR DESCRIPTION
Currently only UnitOrderGenerator can be used by default in OpenRA engine.
This PR allow to change this to something else, this need for https://github.com/OpenRA/d2/issues/196

( Initially the problem was in mouse button checks. in d2, need to allow to use any mouse button after command button in the ui was pressed, but UnitOrderGenerator use MouseDefaults and action can be only one mouse button.)