### PR TITLE
Fix the cargo unload regression with scripted transports

### DIFF
--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -699,16 +699,6 @@ namespace OpenRA.Mods.Common.Traits
 				QueueChild(mobile.VisualMove(self, pos, self.World.Map.CenterOfSubCell(cell, subCell)));
 				return true;
 			}
-
-			public override void Cancel(Actor self, bool keepQueue = false)
-			{
-				// If we are forbidden from stopping in this cell, use evaluateNearestMovableCell
-				// to nudge us to the nearest cell that we can stop in.
-				if (!mobile.CanStayInCell(cell))
-					QueueChild(new Move(self, cell, WDist.Zero, null, true));
-
-				base.Cancel(self, keepQueue);
-			}
 		}
 
 		public Activity MoveToTarget(Actor self, Target target,


### PR DESCRIPTION
Closes #18174.

This appears to be a regression from #18083. Actors leaving the transport have a `ReturnToCellActivity` activity that is uninterruptible with `0,0` as target as their creation activity. This is not a problem, as cargo which was added to transports without being added to the world (see here https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Traits/Passenger.cs#L142-L150) first recalculate the destination position once being unloaded (and here https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Traits/Mobile.cs#L674).

The problem arises when `UnloadCargo` tries to cancel all activities of the actor (https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Activities/UnloadCargo.cs#L127) which then triggers `ReturnToCellActivity` to queue a `Move` child (https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Traits/Mobile.cs#L705-L708). This happens before the position is re-assigned in `OnFirstRun` meaning we redirect that `Move` to `0,0`!

Honestly, I'm not sure why we queue a `Move` here considering that this is "to nudge us to the nearest cell that we can stop in." while the activity is not interruptible so will finish regardless? For now I worked around this by checking if we are in the world before queue a `Move`, which seems to work fine, but I'm not sure if that is the best way to go here. Maybe someone else has an idea before me. (As suggested above we might be able to get rid of that move entirely, for example.)