### PR TITLE
Add LeaveMapAtClosestEdge idle behaviour for Aircraft

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -27,6 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		Land,
 		ReturnToBase,
 		LeaveMap,
+		LeaveMapAtClosestEdge
 	}
 
 	public class AircraftInfo : PausableConditionalTraitInfo, IPositionableInfo, IFacingInfo, IMoveInfo, ICruiseAltitudeInfo,
@@ -722,6 +723,12 @@ namespace OpenRA.Mods.Common.Traits
 			if (Info.IdleBehavior == IdleBehaviorType.LeaveMap)
 			{
 				self.QueueActivity(new FlyOffMap(self));
+				self.QueueActivity(new RemoveSelf());
+			}
+			else if (Info.IdleBehavior == IdleBehaviorType.LeaveMapAtClosestEdge)
+			{
+				var edgeCell = self.World.Map.ChooseClosestEdgeCell(self.Location);
+				self.QueueActivity(new FlyOffMap(self, Target.FromCell(self.World, edgeCell)));
 				self.QueueActivity(new RemoveSelf());
 			}
 			else if (Info.IdleBehavior == IdleBehaviorType.ReturnToBase && GetActorBelow() == null)

--- a/mods/ra/maps/intervention/rules.yaml
+++ b/mods/ra/maps/intervention/rules.yaml
@@ -80,7 +80,7 @@ MIG.SCRIPTED:
 	AmmoPool:
 		Ammo: 2
 	Aircraft:
-		IdleBehavior: LeaveMap
+		IdleBehavior: LeaveMapAtClosestEdge
 
 HELI:
 	Buildable:


### PR DESCRIPTION
This is just a small addition to lessen the weird apathic impression aircraft give off once the LeaveMap logic kicks in.