### PR TITLE
Use RenderPlayer to determine viewer.

### DIFF
--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -213,20 +213,20 @@ namespace OpenRA
 
 		public Color PlayerStanceColor(Actor a)
 		{
-			var player = a.World.RenderPlayer ?? a.World.LocalPlayer;
-			if (player != null && !player.Spectating)
+			var viewer = a.World.RenderPlayer;
+			if (viewer != null)
 			{
 				var apparentOwner = a.EffectiveOwner != null && a.EffectiveOwner.Disguised
 					? a.EffectiveOwner.Owner
 					: a.Owner;
 
-				if (a.Owner.IsAlliedWith(a.World.RenderPlayer))
+				if (a.Owner.IsAlliedWith(viewer))
 					apparentOwner = a.Owner;
 
-				if (apparentOwner == player)
+				if (apparentOwner == viewer)
 					return stanceColors.Self;
 
-				if (apparentOwner.IsAlliedWith(player))
+				if (apparentOwner.IsAlliedWith(viewer))
 					return stanceColors.Allies;
 
 				if (!apparentOwner.NonCombatant)

--- a/OpenRA.Game/SelectableExts.cs
+++ b/OpenRA.Game/SelectableExts.cs
@@ -31,9 +31,9 @@ namespace OpenRA.Traits
 			var info = a.Info.TraitInfo<ISelectableInfo>();
 			var basePriority = BaseSelectionPriority(info, modifiers);
 
-			var viewer = (a.World.LocalPlayer == null || a.World.LocalPlayer.Spectating) ? a.World.RenderPlayer : a.World.LocalPlayer;
+			var viewer = a.World.RenderPlayer;
 
-			if (a.Owner == viewer || viewer == null)
+			if (viewer == null || a.Owner == viewer)
 				return basePriority;
 
 			switch (viewer.Stances[a.Owner])

--- a/OpenRA.Mods.Common/Traits/Radar/AppearsOnRadar.cs
+++ b/OpenRA.Mods.Common/Traits/Radar/AppearsOnRadar.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits.Radar
 
 		public void PopulateRadarSignatureCells(Actor self, List<Pair<CPos, Color>> destinationBuffer)
 		{
-			var viewer = self.World.RenderPlayer ?? self.World.LocalPlayer;
+			var viewer = self.World.RenderPlayer;
 			if (IsTraitDisabled || (viewer != null && !Info.ValidStances.HasStance(self.Owner.Stances[viewer])))
 				return;
 

--- a/OpenRA.Mods.Common/Traits/Render/CashTricklerBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/CashTricklerBar.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		float ISelectionBar.GetValue()
 		{
-			var viewer = self.World.RenderPlayer ?? self.World.LocalPlayer;
+			var viewer = self.World.RenderPlayer;
 			if (viewer != null && !info.DisplayStances.HasStance(self.Owner.Stances[viewer]))
 				return 0;
 

--- a/OpenRA.Mods.Common/Traits/Render/SupportPowerChargeBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SupportPowerChargeBar.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (power == null)
 				return 0;
 
-			var viewer = self.World.RenderPlayer ?? self.World.LocalPlayer;
+			var viewer = self.World.RenderPlayer;
 			if (viewer != null && !Info.DisplayStances.HasStance(self.Owner.Stances[viewer]))
 				return 0;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoObjectivesLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoObjectivesLogic.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[ObjectCreator.UseCtor]
 		public GameInfoObjectivesLogic(Widget widget, World world)
 		{
-			var player = world.RenderPlayer ?? world.LocalPlayer;
+			var player = world.RenderPlayer;
 
 			var objectivesPanel = widget.Get<ScrollPanelWidget>("OBJECTIVES_PANEL");
 			template = objectivesPanel.Get<ContainerWidget>("OBJECTIVE_TEMPLATE");

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/CycleBasesHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/CycleBasesHotkeyLogic.cs
@@ -37,17 +37,19 @@ namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 
 		protected override bool OnHotkeyActivated(KeyInput e)
 		{
-			var player = world.RenderPlayer ?? world.LocalPlayer;
+			var viewer = world.RenderPlayer;
+			if (viewer == null)
+				return true;
 
 			var bases = world.ActorsHavingTrait<BaseBuilding>()
-				.Where(a => a.Owner == player)
+				.Where(a => a.Owner == viewer)
 				.ToList();
 
 			// If no BaseBuilding exist pick the first selectable Building.
 			if (!bases.Any())
 			{
 				var building = world.ActorsHavingTrait<Building>()
-					.FirstOrDefault(a => a.Owner == player && a.Info.HasTraitInfo<SelectableInfo>());
+					.FirstOrDefault(a => a.Owner == viewer && a.Info.HasTraitInfo<SelectableInfo>());
 
 				// No buildings left
 				if (building == null)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/CycleHarvestersHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/CycleHarvestersHotkeyLogic.cs
@@ -37,10 +37,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 
 		protected override bool OnHotkeyActivated(KeyInput e)
 		{
-			var player = world.RenderPlayer ?? world.LocalPlayer;
+			var viewer = world.RenderPlayer;
+			if (viewer == null)
+				return true;
 
 			var harvesters = world.ActorsHavingTrait<Harvester>()
-				.Where(a => a.IsInWorld && a.Owner == player)
+				.Where(a => a.IsInWorld && a.Owner == viewer)
 				.ToList();
 
 			if (!harvesters.Any())

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/CycleProductionActorsHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/CycleProductionActorsHotkeyLogic.cs
@@ -43,10 +43,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 
 		protected override bool OnHotkeyActivated(KeyInput e)
 		{
-			var player = world.RenderPlayer ?? world.LocalPlayer;
+			var viewer = world.RenderPlayer;
+			if (viewer == null)
+				return true;
 
 			var facilities = world.ActorsHavingTrait<Production>()
-				.Where(a => a.Owner == player && a.OccupiesSpace != null && !a.Info.HasTraitInfo<BaseBuildingInfo>()
+				.Where(a => a.Owner == viewer && a.OccupiesSpace != null && !a.Info.HasTraitInfo<BaseBuildingInfo>()
 					&& a.TraitsImplementing<Production>().Any(t => !t.IsTraitDisabled))
 				.OrderBy(f => f.TraitsImplementing<Production>().First(t => !t.IsTraitDisabled).Info.Produces.First())
 				.ToList();

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -98,10 +98,10 @@ namespace OpenRA.Mods.Common.Widgets
 
 			MapBoundsChanged();
 
-			var player = world.Type == WorldType.Regular ? world.LocalPlayer ?? world.RenderPlayer : null;
-			SetPlayer(player, true);
+			var viewer = world.Type == WorldType.Regular ? world.RenderPlayer : null;
+			SetPlayer(viewer, true);
 
-			if (player == null)
+			if (viewer == null)
 			{
 				// Set initial terrain data
 				foreach (var uv in world.Map.AllCells.MapCoords)

--- a/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var displayedPowers = powers.Where(p =>
 			{
 				var owner = p.Instances[0].Self.Owner;
-				var viewer = owner.World.RenderPlayer ?? owner.World.LocalPlayer;
+				var viewer = owner.World.RenderPlayer;
 				return viewer == null || p.Info.DisplayTimerStances.HasStance(owner.Stances[viewer]);
 			});
 

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -133,8 +133,8 @@ namespace OpenRA.Mods.Common.Widgets
 						.WithHighestSelectionPriority(mousePos, mi.Modifiers);
 
 					// Players to be included in the selection (the viewer or all players in "Disable shroud" / "All players" mode)
-					var viewer = World.RenderPlayer ?? World.LocalPlayer;
-					var isShroudDisabled = viewer == null || (World.RenderPlayer == null && World.LocalPlayer.Spectating);
+					var viewer = World.RenderPlayer;
+					var isShroudDisabled = viewer == null;
 					var isEveryone = viewer != null && viewer.NonCombatant && viewer.Spectating;
 					var eligiblePlayers = isShroudDisabled || isEveryone ? World.Players : new[] { viewer };
 
@@ -256,8 +256,8 @@ namespace OpenRA.Mods.Common.Widgets
 			if (e.Event == KeyInputEvent.Down)
 			{
 				// Players to be included in the selection (the viewer or all players in "Disable shroud" / "All players" mode)
-				var viewer = World.RenderPlayer ?? World.LocalPlayer;
-				var isShroudDisabled = viewer == null || (World.RenderPlayer == null && World.LocalPlayer.Spectating);
+				var viewer = World.RenderPlayer;
+				var isShroudDisabled = viewer == null;
 				var isEveryone = viewer != null && viewer.NonCombatant && viewer.Spectating;
 				var eligiblePlayers = isShroudDisabled || isEveryone ? World.Players : new[] { viewer };
 


### PR DESCRIPTION
This removes the convention of `viewer = self.World.RenderPlayer ?? self.World.LocalPlayer` and replaces it with `viewer = self.World.RenderPlayer`. 

We already account for `RenderPlayer` being null in all places that I found (and I added the null check where we didn't). `RenderPlayer` being null is an explicit feature (e.g. "Disable Shroud view") so this should not need any fallback.

This change should not alter any behavior or functionality. I've tested the usecases that were touched here but will do more testing after intitial feedback, since I might have missed something that made the fallback to `LocalPlayer` necessary.