### PR TITLE
Possibility to set exact integer values when editing unit traits in Map Editor

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -309,27 +309,21 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							slider.OnChange += value => so.OnChange(actor, value);
 							slider.OnChange += value => editorActionHandle.OnChange(value);
 
-							var valueField = sliderContainer.Get<TextFieldWidget>("VALUE");
+							var valueField = sliderContainer.GetOrNull<TextFieldWidget>("VALUE");
 
-							Action<float> updateValueField = (float f) =>
+							if (valueField != null)
 							{
-								var stringValue = ((int)f).ToString();
-								if (valueField.Text != stringValue)
-									valueField.Text = stringValue;
-							};
+								Action<float> updateValueField = f => valueField.Text = ((int)f).ToString();
+								updateValueField(so.GetValue(actor));
+								slider.OnChange += updateValueField;
 
-							updateValueField(so.GetValue(actor));
-
-							slider.OnChange += updateValueField;
-
-							Action updateSliderFromValueField = () =>
-							{
-								float result;
-								if (float.TryParse(valueField.Text, out result) && ((int)slider.Value) != ((int)result))
-									slider.UpdateValue(result);
-							};
-
-							valueField.OnTextEdited = updateSliderFromValueField;
+								valueField.OnTextEdited = () =>
+								{
+									float result;
+									if (float.TryParse(valueField.Text, out result))
+										slider.UpdateValue(result);
+								};
+							}
 
 							initContainer.AddChild(sliderContainer);
 						}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -309,6 +309,28 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							slider.OnChange += value => so.OnChange(actor, value);
 							slider.OnChange += value => editorActionHandle.OnChange(value);
 
+							var valueField = sliderContainer.Get<TextFieldWidget>("VALUE");
+
+							Action<float> updateValueField = (float f) =>
+							{
+								var stringValue = ((int)f).ToString();
+								if (valueField.Text != stringValue)
+									valueField.Text = stringValue;
+							};
+
+							updateValueField(so.GetValue(actor));
+
+							slider.OnChange += updateValueField;
+
+							Action updateSliderFromValueField = () =>
+							{
+								float result;
+								if (float.TryParse(valueField.Text, out result) && ((int)slider.Value) != ((int)result))
+									slider.UpdateValue(result);
+							};
+
+							valueField.OnTextEdited = updateSliderFromValueField;
+
 							initContainer.AddChild(sliderContainer);
 						}
 						else if (o is EditorActorDropdown)

--- a/OpenRA.Mods.Common/Widgets/SliderWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SliderWidget.cs
@@ -48,10 +48,12 @@ namespace OpenRA.Mods.Common.Widgets
 			GetValue = other.GetValue;
 		}
 
-		void UpdateValue(float newValue)
+		public void UpdateValue(float newValue)
 		{
+			var oldValue = Value;
 			Value = newValue.Clamp(MinimumValue, MaximumValue);
-			OnChange(Value);
+			if (oldValue != newValue)
+				OnChange(Value);
 		}
 
 		public override bool HandleMouseInput(MouseInput mi)
@@ -114,7 +116,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (!IsVisible())
 				return;
 
-			Value = GetValue();
+			UpdateValue(GetValue());
 
 			var tr = ThumbRect;
 			var rb = RenderBounds;

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -277,8 +277,14 @@ Container@EDITOR_WORLD_ROOT:
 										Slider@OPTION:
 											X: 58
 											Y: 1
-											Width: 207
+											Width: 145
 											Height: 20
+										TextField@VALUE:
+											X: 205
+											Y: 1
+											Width: 50
+											Height: 20
+                                            Type: Integer
 								Container@DROPDOWN_OPTION_TEMPLATE:
 									Width: PARENT_RIGHT
 									Height: 27

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -284,7 +284,7 @@ Container@EDITOR_WORLD_ROOT:
 											Y: 1
 											Width: 50
 											Height: 20
-                                            Type: Integer
+											Type: Integer
 								Container@DROPDOWN_OPTION_TEMPLATE:
 									Width: PARENT_RIGHT
 									Height: 27

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -278,7 +278,7 @@ Container@EDITOR_WORLD_ROOT:
 											Y: 1
 											Width: 50
 											Height: 20
-                                            Type: Integer
+											Type: Integer
 								Container@DROPDOWN_OPTION_TEMPLATE:
 									Width: PARENT_RIGHT
 									Height: 27

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -271,8 +271,14 @@ Container@EDITOR_WORLD_ROOT:
 										Slider@OPTION:
 											X: 75
 											Y: 1
-											Width: 210
+											Width: 150
 											Height: 20
+										TextField@VALUE:
+											X: 227
+											Y: 1
+											Width: 50
+											Height: 20
+                                            Type: Integer
 								Container@DROPDOWN_OPTION_TEMPLATE:
 									Width: PARENT_RIGHT
 									Height: 27


### PR DESCRIPTION
#18358 
A new Text Field Widget to show and edit traits values more exactly (integer resolution)

