### PR TITLE
Let Railgun implement ISync

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/Railgun.cs
+++ b/OpenRA.Mods.Common/Projectiles/Railgun.cs
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		}
 	}
 
-	public class Railgun : IProjectile
+	public class Railgun : IProjectile, ISync
 	{
 		readonly ProjectileArgs args;
 		readonly RailgunInfo info;


### PR DESCRIPTION
Resolves the `OpenRA.Utility(1,1): Warning: OpenRA.Mods.Common.Projectiles.Railgun has members with the Sync attribute but does not implement ISync` errors we currently have on bleed. (Which is a regression from #18009.)