### PR TITLE
TraitDictionary use EmptyEnumerable

### DIFF
--- a/OpenRA.Game/Map/CellLayer.cs
+++ b/OpenRA.Game/Map/CellLayer.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using OpenRA.Primitives;
 
 namespace OpenRA
@@ -121,19 +122,25 @@ namespace OpenRA
 			return uv.Clamp(new Rectangle(0, 0, Size.Width - 1, Size.Height - 1));
 		}
 
-		public IEnumerable<T> Region(ProjectedCellRegion projectedCellRegion)
+		public IEnumerable<T> Region(Map map)
 		{
+			var btl = new PPos(map.Bounds.Left, map.Bounds.Top);
+			var bbr = new PPos(map.Bounds.Right - 1, map.Bounds.Bottom - 1);
+
 			// PERF: Direct access to cell entries. Avoiding index calculation and property item lookup.
 			if (GridType == MapGridType.Rectangular)
 			{
 				// PERF: Skip PPos to MPos conversion when possible
 				var mapCoordsRegion = new MapCoordsRegion(
-					(MPos)projectedCellRegion.TopLeft,
-					(MPos)projectedCellRegion.BottomRight);
+					(MPos)btl,
+					(MPos)bbr);
 				return new RectangularRegionCellEnumerable(this, mapCoordsRegion);
 			}
 			else
-				return new RegionCellEnumerable(this, projectedCellRegion);
+			{
+				var projectedCells = new ProjectedCellRegion(map, btl, bbr);
+				return new RegionCellEnumerable(this, projectedCells);
+			}
 		}
 
 		class RectangularRegionCellEnumerable : IEnumerable<T>
@@ -258,7 +265,7 @@ namespace OpenRA
 			}
 
 			public T Current { get { return layer[(MPos)current]; } }
-			object IEnumerator.Current { get { return Current; } }
+			object System.Collections.IEnumerator.Current { get { return Current; } }
 			public void Dispose() { }
 		}
 	}

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -53,7 +53,7 @@ namespace OpenRA
 		public bool DiscoverNatDevices = false;
 
 		[Desc("Time in milliseconds to search for UPnP enabled NAT devices.")]
-		public int NatDiscoveryTimeout = 5000;
+		public int NatDiscoveryTimeout = 1000;
 
 		[Desc("Starts the game with a default map. Input as hash that can be obtained by the utility.")]
 		public string Map = null;
@@ -177,8 +177,7 @@ namespace OpenRA
 
 		[Desc("Preferred OpenGL profile to use.",
 			"Modern: OpenGL Core Profile 3.2 or greater.",
-			"Embedded: OpenGL ES 3.0 or greater.",
-			"Legacy: OpenGL 2.1 with framebuffer_object extension.")]
+			"Embedded: OpenGL ES 3.0 or greater.")]
 		public GLProfile GLProfile = GLProfile.Modern;
 
 		public int BatchSize = 8192;

--- a/OpenRA.Game/Traits/Player/Shroud.cs
+++ b/OpenRA.Game/Traits/Player/Shroud.cs
@@ -16,7 +16,7 @@ using OpenRA.Primitives;
 namespace OpenRA.Traits
 {
 	[Desc("Required for shroud and fog visibility checks. Add this to the player actor.")]
-	public class ShroudInfo : ITraitInfo, ILobbyOptions
+	public class ShroudInfo : TraitInfo, ILobbyOptions
 	{
 		[Translate]
 		[Desc("Descriptive label for the fog checkbox in the lobby.")]
@@ -66,7 +66,7 @@ namespace OpenRA.Traits
 				FogCheckboxVisible, FogCheckboxDisplayOrder, FogCheckboxEnabled, FogCheckboxLocked);
 		}
 
-		public object Create(ActorInitializer init) { return new Shroud(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new Shroud(init.Self, this); }
 	}
 
 	public class Shroud : ISync, INotifyCreated, ITick
@@ -165,7 +165,7 @@ namespace OpenRA.Traits
 			if (OnShroudChanged == null)
 				return;
 
-			foreach (var cell in layer.Region(map.ProjectedCellBounds))
+			foreach (var cell in layer.Region(map))
 			{
 				if (!cell.Touched)
 					continue;
@@ -185,9 +185,7 @@ namespace OpenRA.Traits
 				var oldResolvedType = cell.ResolvedType;
 				cell.ResolvedType = type;
 				if (type != oldResolvedType)
-				{
 					OnShroudChanged((PPos)cell.Position);
-				}
 			}
 
 			Hash = Sync.HashPlayer(self.Owner) + self.World.WorldTick;
@@ -237,6 +235,7 @@ namespace OpenRA.Traits
 
 				var uv = (MPos)puv;
 				var cell = layer[uv];
+				cell.Touched = true;
 				switch (type)
 				{
 					case SourceType.PassiveVisibility:
@@ -269,6 +268,7 @@ namespace OpenRA.Traits
 				{
 					var uv = (MPos)puv;
 					var cell = layer[uv];
+					cell.Touched = true;
 					switch (state.Type)
 					{
 						case SourceType.PassiveVisibility:
@@ -309,7 +309,7 @@ namespace OpenRA.Traits
 			if (map.Bounds != s.map.Bounds)
 				throw new ArgumentException("The map bounds of these shrouds do not match.", "s");
 
-			foreach (var puv in map.ProjectedCellBounds)
+			foreach (var puv in map.ProjectedCells)
 			{
 				var uv = (MPos)puv;
 				var cell = layer[uv];
@@ -323,7 +323,7 @@ namespace OpenRA.Traits
 
 		public void ExploreAll()
 		{
-			foreach (var puv in map.ProjectedCellBounds)
+			foreach (var puv in map.ProjectedCells)
 			{
 				var uv = (MPos)puv;
 				var cell = layer[uv];
@@ -337,7 +337,7 @@ namespace OpenRA.Traits
 
 		public void ResetExploration()
 		{
-			foreach (var puv in map.ProjectedCellBounds)
+			foreach (var puv in map.ProjectedCells)
 			{
 				var uv = (MPos)puv;
 				var cell = layer[uv];

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -108,8 +108,6 @@ namespace OpenRA.Platforms.Default
 			}
 		}
 
-		public bool HasInputFocus { get; internal set; }
-
 		public GLProfile GLProfile
 		{
 			get
@@ -151,9 +149,9 @@ namespace OpenRA.Platforms.Default
 				// We first need to query the available profiles on Windows/Linux.
 				// On macOS, known/consistent OpenGL support is provided by the OS.
 				if (Platform.CurrentPlatform == PlatformType.OSX)
-					supportedProfiles = new[] { GLProfile.Modern, GLProfile.Legacy };
+					supportedProfiles = new[] { GLProfile.Modern };
 				else
-					supportedProfiles = new[] { GLProfile.Modern, GLProfile.Embedded, GLProfile.Legacy }
+					supportedProfiles = new[] { GLProfile.Modern, GLProfile.Embedded }
 						.Where(CanCreateGLWindow)
 						.ToArray();
 
@@ -238,11 +236,11 @@ namespace OpenRA.Platforms.Default
 							switch (e.window.windowEvent)
 							{
 								case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_FOCUS_LOST:
-									HasInputFocus = false;
+									Game.HasInputFocus = false;
 									break;
 
 								case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_FOCUS_GAINED:
-									HasInputFocus = true;
+									Game.HasInputFocus = true;
 									break;
 							}
 						}
@@ -486,10 +484,6 @@ namespace OpenRA.Platforms.Default
 					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_MAJOR_VERSION, 3);
 					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_MINOR_VERSION, 0);
 					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_PROFILE_MASK, (int)SDL.SDL_GLprofile.SDL_GL_CONTEXT_PROFILE_ES);
-					break;
-				case GLProfile.Legacy:
-					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_MAJOR_VERSION, 2);
-					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_MINOR_VERSION, 1);
 					break;
 			}
 		}

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -40,6 +40,7 @@ V2RL:
 		RequiresCondition: reloading
 		Sequence: empty-idle
 		Name: reloading
+	SelectionDecorations:
 	Explodes:
 		Weapon: V2Explode
 	ProducibleWithLevel:
@@ -132,6 +133,7 @@ V2RL:
 	WithSpriteTurret:
 	SpawnActorOnDeath:
 		Actor: 2TNK.Husk
+	SelectionDecorations:
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 	Selectable:
@@ -178,6 +180,7 @@ V2RL:
 	WithSpriteTurret:
 	SpawnActorOnDeath:
 		Actor: 3TNK.Husk
+	SelectionDecorations:
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 	Selectable:
@@ -237,6 +240,7 @@ V2RL:
 		Delay: 3
 		HealIfBelow: 50
 		DamageCooldown: 150
+	SelectionDecorations:
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 	Selectable:
@@ -301,13 +305,13 @@ HARV:
 		GenericName: Harvester
 	Selectable:
 		DecorationBounds: 42,42
+	SelectionDecorations:
 	Harvester:
 		Capacity: 20
 		Resources: Ore,Gems
 		BaleUnloadDelay: 1
 		SearchFromProcRadius: 15
 		SearchFromHarvesterRadius: 8
-		HarvestFacings: 8
 		EmptyCondition: no-ore
 	Health:
 		HP: 60000
@@ -338,14 +342,6 @@ HARV:
 	WithHarvesterSpriteBody:
 		ImageByFullness: harvempty, harvhalf, harv
 	-WithFacingSpriteBody:
-	WithHarvesterPipsDecoration:
-		Position: BottomLeft
-		Margin: 4, 3
-		RequiresSelection: true
-		PipCount: 7
-		ResourceSequences:
-			Ore: pip-yellow
-			Gems: pip-red
 
 MCV:
 	Inherits: ^Vehicle
@@ -362,6 +358,7 @@ MCV:
 		Name: Mobile Construction Vehicle
 	Selectable:
 		DecorationBounds: 42,42
+	SelectionDecorations:
 	Health:
 		HP: 60000
 	Armor:
@@ -389,7 +386,6 @@ JEEP:
 	Inherits: ^Vehicle
 	Inherits@GAINSEXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
-	Inherits@CARGOPIPS: ^CargoPips
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 130
@@ -428,6 +424,7 @@ JEEP:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 1
+		PipCount: 1
 		LoadingCondition: notmobile
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
@@ -436,7 +433,6 @@ APC:
 	Inherits: ^TrackedVehicle
 	Inherits@GAINSEXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
-	Inherits@CARGOPIPS: ^CargoPips
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 120
@@ -470,6 +466,7 @@ APC:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 5
+		PipCount: 5
 		LoadingCondition: notmobile
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
@@ -518,11 +515,7 @@ MNLY:
 	Rearmable:
 		RearmActors: fix
 	Targetable:
-		TargetTypes: GroundActor, Vehicle, Mine
-	WithAmmoPipsDecoration:
-		Position: BottomLeft
-		Margin: 4, 3
-		RequiresSelection: true
+		TargetTypes: Ground, Vehicle, Mine
 
 TRUK:
 	Inherits: ^Vehicle
@@ -656,6 +649,7 @@ TTNK:
 	Turreted:
 	WithIdleOverlay@SPINNER:
 		Sequence: spinner
+	SelectionDecorations:
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 	Selectable:
@@ -705,6 +699,7 @@ FTRK:
 	AttackTurreted:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
+	SelectionDecorations:
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 	Selectable:
@@ -765,6 +760,7 @@ CTNK:
 		GenericName: Tank
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
+	SelectionDecorations:
 	Health:
 		HP: 40000
 	Armor:
@@ -824,13 +820,14 @@ QTNK:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 4c0
+	SelectionDecorations:
 	MadTank:
 		DeployedCondition: deployed
 	WithRangeCircle:
 		Color: FFFF0080
 		Range: 7c0
 	Targetable:
-		TargetTypes: GroundActor, MADTank, Vehicle
+		TargetTypes: Ground, MADTank, Vehicle
 	Selectable:
 		DecorationBounds: 44,38,0,-4
 
@@ -838,7 +835,6 @@ STNK:
 	Inherits: ^Vehicle
 	Inherits@GAINSEXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
-	Inherits@CARGOPIPS: ^CargoPips
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 330
@@ -877,6 +873,7 @@ STNK:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 5
+		PipCount: 4
 		LoadingCondition: notmobile
 	Cloak:
 		InitialDelay: 125

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -2,12 +2,12 @@
 	ReloadDelay: 10
 	Range: 8c0
 	Report: aacanon3.aud
-	ValidTargets: AirborneActor
+	ValidTargets: Air
 	Projectile: InstantHit
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 2000
-		ValidTargets: AirborneActor
+		ValidTargets: Air
 		Versus:
 			None: 40
 			Wood: 10
@@ -37,35 +37,33 @@ ZSU-23:
 FLAK-23-AA:
 	Inherits: ^AACannon
 	Warhead@1Dam: SpreadDamage
-		ValidTargets: AirborneActor, GroundActor, WaterActor
+		ValidTargets: Air, Ground, Water
 
 FLAK-23-AG:
 	Inherits: ^AACannon
 	Range: 6c0
-	ValidTargets: Ground, Water, GroundActor, WaterActor
+	ValidTargets: Ground, Water
 	Projectile: InstantHit
 		Blockable: true
 	Warhead@1Dam: SpreadDamage
-		ValidTargets: AirborneActor, GroundActor, WaterActor
+		ValidTargets: Air, Ground, Water
 	Warhead@2Eff: CreateEffect
 		Explosions: flak_explosion_ground
-		ValidTargets: Ground, GroundActor, Air, AirborneActor, WaterActor, Trees
+		ValidTargets: Ground, Ship, Air, Trees
 	Warhead@3EffWater: CreateEffect
 		Explosions: small_splash
 		ValidTargets: Water, Underwater
-		InvalidTargets: Bridge
+		InvalidTargets: Ship, Structure, Bridge
 
 ^HeavyMG:
 	ReloadDelay: 30
 	Range: 6c0
 	Report: gun13.aud
-	ValidTargets: Ground, Water, GroundActor, WaterActor
 	Projectile: InstantHit
 		Blockable: true
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 2500
-		ValidTargets: GroundActor, WaterActor
 		Versus:
 			None: 120
 			Wood: 60
@@ -75,12 +73,11 @@ FLAK-23-AG:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground, Air
-		ImpactActors: false
+		ValidTargets: Ground, Ship, Air, Trees
 	Warhead@3EffWater: CreateEffect
 		Explosions: water_piffs
 		ValidTargets: Water, Underwater
-		InvalidTargets: Bridge
+		InvalidTargets: Ship, Structure, Bridge
 
 ^LightMG:
 	Inherits: ^HeavyMG
@@ -117,13 +114,12 @@ Vulcan:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@4Eff_2: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground
-		ImpactActors: false
+		ValidTargets: Ground, Ship, Trees
 		Delay: 2
 	Warhead@4Eff_2Water: CreateEffect
 		Explosions: water_piffs
 		ValidTargets: Water, Underwater
-		InvalidTargets: Bridge
+		InvalidTargets: Ship, Structure, Bridge
 		Delay: 2
 	Warhead@5Dam_3: SpreadDamage
 		Spread: 128
@@ -138,13 +134,12 @@ Vulcan:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@6Eff_3: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground
-		ImpactActors: false
+		ValidTargets: Ground, Ship, Trees
 		Delay: 4
 	Warhead@6Eff_3Water: CreateEffect
 		Explosions: water_piffs
 		ValidTargets: Water, Underwater
-		InvalidTargets: Bridge
+		InvalidTargets: Ship, Structure, Bridge
 		Delay: 4
 	Warhead@7Dam_4: SpreadDamage
 		Spread: 128
@@ -159,13 +154,12 @@ Vulcan:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@8Eff_4: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground
-		ImpactActors: false
+		ValidTargets: Ground, Ship, Trees
 		Delay: 6
 	Warhead@8Eff_4Water: CreateEffect
 		Explosions: water_piffs
 		ValidTargets: Water, Underwater
-		InvalidTargets: Bridge
+		InvalidTargets: Ship, Structure, Bridge
 		Delay: 6
 	Warhead@9Dam_5: SpreadDamage
 		Spread: 128
@@ -180,13 +174,12 @@ Vulcan:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@10Eff_5: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground
-		ImpactActors: false
+		ValidTargets: Ground, Ship, Trees
 		Delay: 8
 	Warhead@10Eff_5Water: CreateEffect
 		Explosions: water_piffs
 		ValidTargets: Water, Underwater
-		InvalidTargets: Bridge
+		InvalidTargets: Ship, Structure, Bridge
 		Delay: 8
 	Warhead@11Dam_6: SpreadDamage
 		Spread: 128
@@ -201,13 +194,12 @@ Vulcan:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@12Eff_6: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground
-		ImpactActors: false
+		ValidTargets: Ground, Ship, Trees
 		Delay: 10
 	Warhead@12Eff_6Water: CreateEffect
 		Explosions: water_piffs
 		ValidTargets: Water, Underwater
-		InvalidTargets: Bridge
+		InvalidTargets: Ship, Structure, Bridge
 		Delay: 10
 
 ChainGun:
@@ -274,7 +266,8 @@ M60mg:
 	ReloadDelay: 80
 	Range: 2c512
 	Report: gun5.aud
-	ValidTargets: Ground, Infantry, Barrel
+	ValidTargets: Ground, Infantry
+	InvalidTargets: Vehicle, Water, Structure, Wall, Husk, Mine
 	Projectile: InstantHit
 		Blockable: true
 	Warhead@1Dam: SpreadDamage


### PR DESCRIPTION
A static Enumerable.Empty<T> is 14% faster over AllEnumerable, 25% faster over MultipleEnumerable - as the cost of having to check if the actors list is empty.

5% of all TraitDict queries seems to return an empty result (during a 1 minute game replay).

--
Extended the trait report with more columns. Should have no performance impact - apart increasing an integer if GetMultiple returns no results.

Example trait report output
```
Actors  Traits  QTotal  QActors QAPred  QAll    QGet    QMult   QMulNA  Trait
20      20      22670   0       0       22590   0       50      30      Production
464     464     15224   0       0       0       0       15203   21      HitShape
167     167     5912    0       0       0       0       3173    2739    IDisableEnemyAutoTarget
172     172     5095    0       0       0       5095    0       0       Mobile  
457     457     3446    0       0       0       3446    0       0       IHealth 

```
Actor column could be improved to show unique actors.
