### PR TITLE
Fix a crash when calling an airstrike at the map edge

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
@@ -50,27 +50,30 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ITick.Tick(Actor self)
 		{
-			var dat = self.World.Map.DistanceAboveTerrain(target.CenterPosition);
-			target = Target.FromPos(target.CenterPosition - new WVec(WDist.Zero, WDist.Zero, dat));
 			var wasInAttackRange = inAttackRange;
-			var wasFacingTarget = facingTarget;
-
 			inAttackRange = false;
 
-			facingTarget = TargetInFiringArc(self, target, 4 * info.FacingTolerance);
-
-			foreach (var a in Armaments)
+			if (self.IsInWorld)
 			{
-				if (!target.IsInRange(self.CenterPosition, a.MaxRange()))
-					continue;
+				var dat = self.World.Map.DistanceAboveTerrain(target.CenterPosition);
+				target = Target.FromPos(target.CenterPosition - new WVec(WDist.Zero, WDist.Zero, dat));
 
-				inAttackRange = true;
-				a.CheckFire(self, facing, target);
+				var wasFacingTarget = facingTarget;
+				facingTarget = TargetInFiringArc(self, target, 4 * info.FacingTolerance);
+
+				foreach (var a in Armaments)
+				{
+					if (!target.IsInRange(self.CenterPosition, a.MaxRange()))
+						continue;
+
+					inAttackRange = true;
+					a.CheckFire(self, facing, target);
+				}
+
+				// Actors without armaments may want to trigger an action when it passes the target
+				if (!Armaments.Any())
+					inAttackRange = !wasInAttackRange && !facingTarget && wasFacingTarget;
 			}
-
-			// Actors without armaments may want to trigger an action when it passes the target
-			if (!Armaments.Any())
-				inAttackRange = !wasInAttackRange && !facingTarget && wasFacingTarget;
 
 			if (inAttackRange && !wasInAttackRange)
 				OnEnteredAttackRange(self);

--- a/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
@@ -162,6 +162,7 @@ namespace OpenRA.Mods.Common.Traits
 				});
 
 				aircraft.Add(a);
+				aircraftInRange.Add(a, false);
 
 				var attack = a.Trait<AttackBomber>();
 				attack.SetTarget(self.World, target + targetOffset);
@@ -192,7 +193,6 @@ namespace OpenRA.Mods.Common.Traits
 					a.QueueActivity(new Fly(a, Target.FromPos(target + spawnOffset)));
 					a.QueueActivity(new Fly(a, Target.FromPos(finishEdge + spawnOffset)));
 					a.QueueActivity(new RemoveSelf());
-					aircraftInRange.Add(a, false);
 					distanceTestActor = a;
 				}
 


### PR DESCRIPTION
Closes #18365.

The problem was that `AttackBomber` marks actors as "in range" before they are even in the world (they are added to the world and the dictionary in a FrameEndTask). The first commit fixes the crash right away by creating the dictionary entries together with the actors. The second commit makes AttackBomber only consider actors in range that are actually in the world.