### PR TITLE
Avoid three time array lookup in TraitContainer.Actors.

### DIFF
--- a/OpenRA.Game/TraitDictionary.cs
+++ b/OpenRA.Game/TraitDictionary.cs
@@ -213,10 +213,11 @@ namespace OpenRA
 				Actor last = null;
 				for (var i = 0; i < actors.Count; i++)
 				{
-					if (actors[i] == last)
+					var current = actors[i];
+					if (current == last)
 						continue;
-					yield return actors[i];
-					last = actors[i];
+					yield return current;
+					last = current;
 				}
 			}
 
@@ -227,10 +228,12 @@ namespace OpenRA
 
 				for (var i = 0; i < actors.Count; i++)
 				{
-					if (actors[i] == last || !predicate(traits[i]))
-						continue;
-					yield return actors[i];
 					last = actors[i];
+					var current = actors[i];
+					if (current == last || !predicate(traits[i]))
+						continue;
+					yield return current;
+					last = current;
 				}
 			}
 


### PR DESCRIPTION

Compiler doesn't seem to optimize.

Illustration of instructions needed for a single array lookup. This would happen three times.

```
                        public void Example()                                      
                        {                                                       
                                var current = actors[0xf];                      
   eb3a8:       48 8b 04 24             mov    (%rsp),%rax                      
   eb3ac:       48 8b 58 10             mov    0x10(%rax),%rbx                  
   eb3b0:       48 8b 3d 29 f3 2b 00    mov    0x2bf329(%rip),%rdi        # 3aa6e0 <mono_aot_OpenRA_Game_llvm_got+0x8f90>
   eb3b7:       80 7f 2d 00             cmpb   $0x0,0x2d(%rdi)                  
   eb3bb:       75 05                   jne    eb3c2 <OpenRA_TraitDictionary_TraitContainer_1_T_REF_Example+0x42>
   eb3bd:       e8 90 de 05 00          callq  149252 <plt__jit_icall_mono_generic_class_init>
   eb3c2:       48 8b 03                mov    (%rbx),%rax                      
   eb3c5:       be 0f 00 00 00          mov    $0xf,%esi                        
   eb3ca:       48 89 df                mov    %rbx,%rdi                        
   eb3cd:       e8 90 14 06 00          callq  14c862 <plt_System_Collections_Generic_List_1_OpenRA_Actor_get_Item_int>
                        } 
```