### PR TITLE
Minor dev experience improvement for Linux/Mac devs

### DIFF
--- a/launch-game.sh
+++ b/launch-game.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
-MODLAUNCHER=$(python -c "import os; print(os.path.realpath('$0'))")
+if command -v python3 >/dev/null 2>&1; then
+	 MODLAUNCHER=$(python3 -c "import os; print(os.path.realpath('$0'))")
+else
+	 MODLAUNCHER=$(python -c "import os; print(os.path.realpath('$0'))")
+fi
 
 # Prompt for a mod to launch if one is not already specified
 MODARG=''


### PR DESCRIPTION
Some Linux distros (namely ubuntu) now only ship with python 3 using the command 'python3' this will cause your launch-game.sh script to fail at detecting the game engine path.

The following changes add a retry for python3 and some logging around when the path is empty.

Revision of: https://github.com/OpenRA/OpenRA/pull/18262