### PR TITLE
Fix a crash when previewing an actor using WithCrateBody in the editor

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{
-			var anim = new Animation(init.World, rs.Image);
+			var anim = new Animation(init.World, image);
 			anim.PlayRepeating(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), IdleSequence));
 			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, p, rs.Scale);
 		}


### PR DESCRIPTION
`rs.Image` is `null` at this point, which will cause a crash in `Animation` which we ignore but log to `debug` instead. `WithCrateBody` is now doing what the other previews are doing as well. My testcase were crates in the TS map editor, since they are not present in the Actor tab on bleed.