### PR TITLE
Move map format loading and saving into mods.

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -13,8 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 using OpenRA.FileFormats;
 using OpenRA.FileSystem;
 using OpenRA.Primitives;
@@ -23,38 +21,6 @@ using OpenRA.Traits;
 
 namespace OpenRA
 {
-	struct BinaryDataHeader
-	{
-		public readonly byte Format;
-		public readonly uint TilesOffset;
-		public readonly uint HeightsOffset;
-		public readonly uint ResourcesOffset;
-
-		public BinaryDataHeader(Stream s, int2 expectedSize)
-		{
-			Format = s.ReadUInt8();
-			var width = s.ReadUInt16();
-			var height = s.ReadUInt16();
-			if (width != expectedSize.X || height != expectedSize.Y)
-				throw new InvalidDataException("Invalid tile data");
-
-			if (Format == 1)
-			{
-				TilesOffset = 5;
-				HeightsOffset = 0;
-				ResourcesOffset = (uint)(3 * width * height + 5);
-			}
-			else if (Format == 2)
-			{
-				TilesOffset = s.ReadUInt32();
-				HeightsOffset = s.ReadUInt32();
-				ResourcesOffset = s.ReadUInt32();
-			}
-			else
-				throw new InvalidDataException("Unknown binary map format '{0}'".F(Format));
-		}
-	}
-
 	[Flags]
 	public enum MapVisibility
 	{
@@ -63,123 +29,16 @@ namespace OpenRA
 		MissionSelector = 4
 	}
 
-	class MapField
+	public interface IMapLoader : IGlobalModData
 	{
-		enum Type { Normal, NodeList, MiniYaml }
-		readonly FieldInfo field;
-		readonly PropertyInfo property;
-		readonly Type type;
-
-		readonly string key;
-		readonly string fieldName;
-		readonly bool required;
-		readonly string ignoreIfValue;
-
-		public MapField(string key, string fieldName = null, bool required = true, string ignoreIfValue = null)
-		{
-			this.key = key;
-			this.fieldName = fieldName ?? key;
-			this.required = required;
-			this.ignoreIfValue = ignoreIfValue;
-
-			field = typeof(Map).GetField(this.fieldName);
-			property = typeof(Map).GetProperty(this.fieldName);
-			if (field == null && property == null)
-				throw new InvalidOperationException("Map does not have a field/property " + fieldName);
-
-			var t = field != null ? field.FieldType : property.PropertyType;
-			type = t == typeof(List<MiniYamlNode>) ? Type.NodeList :
-				t == typeof(MiniYaml) ? Type.MiniYaml : Type.Normal;
-		}
-
-		public void Deserialize(Map map, List<MiniYamlNode> nodes)
-		{
-			var node = nodes.FirstOrDefault(n => n.Key == key);
-			if (node == null)
-			{
-				if (required)
-					throw new YamlException("Required field `{0}` not found in map.yaml".F(key));
-				return;
-			}
-
-			if (field != null)
-			{
-				if (type == Type.NodeList)
-					field.SetValue(map, node.Value.Nodes);
-				else if (type == Type.MiniYaml)
-					field.SetValue(map, node.Value);
-				else
-					FieldLoader.LoadField(map, fieldName, node.Value.Value);
-			}
-
-			if (property != null)
-			{
-				if (type == Type.NodeList)
-					property.SetValue(map, node.Value.Nodes, null);
-				else if (type == Type.MiniYaml)
-					property.SetValue(map, node.Value, null);
-				else
-					FieldLoader.LoadField(map, fieldName, node.Value.Value);
-			}
-		}
-
-		public void Serialize(Map map, List<MiniYamlNode> nodes)
-		{
-			var value = field != null ? field.GetValue(map) : property.GetValue(map, null);
-			if (type == Type.NodeList)
-			{
-				var listValue = (List<MiniYamlNode>)value;
-				if (required || listValue.Any())
-					nodes.Add(new MiniYamlNode(key, null, listValue));
-			}
-			else if (type == Type.MiniYaml)
-			{
-				var yamlValue = (MiniYaml)value;
-				if (required || (yamlValue != null && (yamlValue.Value != null || yamlValue.Nodes.Any())))
-					nodes.Add(new MiniYamlNode(key, yamlValue));
-			}
-			else
-			{
-				var formattedValue = FieldSaver.FormatValue(value);
-				if (required || formattedValue != ignoreIfValue)
-					nodes.Add(new MiniYamlNode(key, formattedValue));
-			}
-		}
+		Map Load(ModData modData, IReadOnlyPackage package);
+		Map Create(ModData modData, TileSet tileSet, int width, int height);
+		string ComputeUID(ModData modData, IReadOnlyPackage package);
+		void UpdatePreview(ModData modData, MapPreview mapPreview, IReadOnlyPackage p, IReadOnlyPackage parent, MapClassification classification, string[] mapCompatibility, MapGridType gridType);
 	}
 
-	public class Map : IReadOnlyFileSystem
+	public abstract class Map : IReadOnlyFileSystem
 	{
-		public const int SupportedMapFormat = 11;
-
-		/// <summary>Defines the order of the fields in map.yaml</summary>
-		static readonly MapField[] YamlFields =
-		{
-			new MapField("MapFormat"),
-			new MapField("RequiresMod"),
-			new MapField("Title"),
-			new MapField("Author"),
-			new MapField("Tileset"),
-			new MapField("MapSize"),
-			new MapField("Bounds"),
-			new MapField("Visibility"),
-			new MapField("Categories"),
-			new MapField("LockPreview", required: false, ignoreIfValue: "False"),
-			new MapField("Players", "PlayerDefinitions"),
-			new MapField("Actors", "ActorDefinitions"),
-			new MapField("Rules", "RuleDefinitions", required: false),
-			new MapField("Sequences", "SequenceDefinitions", required: false),
-			new MapField("ModelSequences", "ModelSequenceDefinitions", required: false),
-			new MapField("Weapons", "WeaponDefinitions", required: false),
-			new MapField("Voices", "VoiceDefinitions", required: false),
-			new MapField("Music", "MusicDefinitions", required: false),
-			new MapField("Notifications", "NotificationDefinitions", required: false),
-			new MapField("Translations", "TranslationDefinitions", required: false)
-		};
-
-		// Format versions
-		public int MapFormat { get; private set; }
-		public readonly byte TileFormat = 2;
-
 		// Standard yaml metadata
 		public string RequiresMod;
 		public string Title;
@@ -190,7 +49,7 @@ namespace OpenRA
 		public MapVisibility Visibility = MapVisibility.Lobby;
 		public string[] Categories = { "Conquest" };
 
-		public int2 MapSize { get; private set; }
+		public int2 MapSize { get; protected set; }
 
 		// Player and actor yaml. Public for access by the map importers and lint checks.
 		public List<MiniYamlNode> PlayerDefinitions = new List<MiniYamlNode>();
@@ -208,8 +67,8 @@ namespace OpenRA
 
 		// Generated data
 		public readonly MapGrid Grid;
-		public IReadOnlyPackage Package { get; private set; }
-		public string Uid { get; private set; }
+		public IReadOnlyPackage Package { get; protected set; }
+		public string Uid { get; protected set; }
 
 		public Ruleset Rules { get; private set; }
 		public bool InvalidCustomRules { get; private set; }
@@ -245,160 +104,32 @@ namespace OpenRA
 		CellLayer<List<MPos>> inverseCellProjection;
 		CellLayer<byte> projectedHeight;
 
-		public static string ComputeUID(IReadOnlyPackage package)
-		{
-			// UID is calculated by taking an SHA1 of the yaml and binary data
-			var requiredFiles = new[] { "map.yaml", "map.bin" };
-			var contents = package.Contents.ToList();
-			foreach (var required in requiredFiles)
-				if (!contents.Contains(required))
-					throw new FileNotFoundException("Required file {0} not present in this map".F(required));
+		public abstract void Save(IReadWritePackage package);
 
-			var streams = new List<Stream>();
-			try
-			{
-				foreach (var filename in contents)
-					if (filename.EndsWith(".yaml") || filename.EndsWith(".bin") || filename.EndsWith(".lua"))
-						streams.Add(package.GetStream(filename));
-
-				// Take the SHA1
-				if (streams.Count == 0)
-					return CryptoUtil.SHA1Hash(new byte[0]);
-
-				var merged = streams[0];
-				for (var i = 1; i < streams.Count; i++)
-					merged = new MergedStream(merged, streams[i]);
-
-				return CryptoUtil.SHA1Hash(merged);
-			}
-			finally
-			{
-				foreach (var stream in streams)
-					stream.Dispose();
-			}
-		}
-
-		/// <summary>
-		/// Initializes a new map created by the editor or importer.
-		/// The map will not receive a valid UID until after it has been saved and reloaded.
-		/// </summary>
-		public Map(ModData modData, TileSet tileset, int width, int height)
+		protected Map(ModData modData)
 		{
 			this.modData = modData;
-			var size = new Size(width, height);
 			Grid = modData.Manifest.Get<MapGrid>();
-			var tileRef = new TerrainTile(tileset.Templates.First().Key, 0);
-
-			Title = "Name your map here";
-			Author = "Your name here";
-
-			MapSize = new int2(size);
-			Tileset = tileset.Id;
 
 			// Empty rules that can be added to by the importers.
 			// Will be dropped on save if nothing is added to it
 			RuleDefinitions = new MiniYaml("");
 
-			Tiles = new CellLayer<TerrainTile>(Grid.Type, size);
-			Resources = new CellLayer<ResourceTile>(Grid.Type, size);
-			Height = new CellLayer<byte>(Grid.Type, size);
-			Ramp = new CellLayer<byte>(Grid.Type, size);
+			MapSize = new int2(1, 1);
+
+			Tiles = new CellLayer<TerrainTile>(this);
+			Resources = new CellLayer<ResourceTile>(this);
+			Height = new CellLayer<byte>(this);
+			Ramp = new CellLayer<byte>(this);
 			if (Grid.MaximumTerrainHeight > 0)
 			{
 				Height.CellEntryChanged += UpdateProjection;
 				Tiles.CellEntryChanged += UpdateProjection;
 				Tiles.CellEntryChanged += UpdateRamp;
 			}
-
-			Tiles.Clear(tileRef);
-
-			PostInit();
 		}
 
-		public Map(ModData modData, IReadOnlyPackage package)
-		{
-			this.modData = modData;
-			Package = package;
-
-			if (!Package.Contains("map.yaml") || !Package.Contains("map.bin"))
-				throw new InvalidDataException("Not a valid map\n File: {0}".F(package.Name));
-
-			var yaml = new MiniYaml(null, MiniYaml.FromStream(Package.GetStream("map.yaml"), package.Name));
-			foreach (var field in YamlFields)
-				field.Deserialize(this, yaml.Nodes);
-
-			if (MapFormat != SupportedMapFormat)
-				throw new InvalidDataException("Map format {0} is not supported.\n File: {1}".F(MapFormat, package.Name));
-
-			PlayerDefinitions = MiniYaml.NodesOrEmpty(yaml, "Players");
-			ActorDefinitions = MiniYaml.NodesOrEmpty(yaml, "Actors");
-
-			Grid = modData.Manifest.Get<MapGrid>();
-
-			var size = new Size(MapSize.X, MapSize.Y);
-			Tiles = new CellLayer<TerrainTile>(Grid.Type, size);
-			Resources = new CellLayer<ResourceTile>(Grid.Type, size);
-			Height = new CellLayer<byte>(Grid.Type, size);
-			Ramp = new CellLayer<byte>(Grid.Type, size);
-
-			using (var s = Package.GetStream("map.bin"))
-			{
-				var header = new BinaryDataHeader(s, MapSize);
-				if (header.TilesOffset > 0)
-				{
-					s.Position = header.TilesOffset;
-					for (var i = 0; i < MapSize.X; i++)
-					{
-						for (var j = 0; j < MapSize.Y; j++)
-						{
-							var tile = s.ReadUInt16();
-							var index = s.ReadUInt8();
-
-							// TODO: Remember to remove this when rewriting tile variants / PickAny
-							if (index == byte.MaxValue)
-								index = (byte)(i % 4 + (j % 4) * 4);
-
-							Tiles[new MPos(i, j)] = new TerrainTile(tile, index);
-						}
-					}
-				}
-
-				if (header.ResourcesOffset > 0)
-				{
-					s.Position = header.ResourcesOffset;
-					for (var i = 0; i < MapSize.X; i++)
-					{
-						for (var j = 0; j < MapSize.Y; j++)
-						{
-							var type = s.ReadUInt8();
-							var density = s.ReadUInt8();
-							Resources[new MPos(i, j)] = new ResourceTile(type, density);
-						}
-					}
-				}
-
-				if (header.HeightsOffset > 0)
-				{
-					s.Position = header.HeightsOffset;
-					for (var i = 0; i < MapSize.X; i++)
-						for (var j = 0; j < MapSize.Y; j++)
-							Height[new MPos(i, j)] = s.ReadUInt8().Clamp((byte)0, Grid.MaximumTerrainHeight);
-				}
-			}
-
-			if (Grid.MaximumTerrainHeight > 0)
-			{
-				Tiles.CellEntryChanged += UpdateRamp;
-				Tiles.CellEntryChanged += UpdateProjection;
-				Height.CellEntryChanged += UpdateProjection;
-			}
-
-			PostInit();
-
-			Uid = ComputeUID(Package);
-		}
-
-		void PostInit()
+		protected void PostInit()
 		{
 			try
 			{
@@ -571,95 +302,6 @@ namespace OpenRA
 				candidates.Add(new PPos(uv.U, uv.V - height));
 
 			return candidates.Where(c => mapHeight.Contains((MPos)c)).ToArray();
-		}
-
-		public void Save(IReadWritePackage toPackage)
-		{
-			MapFormat = SupportedMapFormat;
-
-			var root = new List<MiniYamlNode>();
-			foreach (var field in YamlFields)
-				field.Serialize(this, root);
-
-			// HACK: map.yaml is expected to have empty lines between top-level blocks
-			for (var i = root.Count - 1; i > 0; i--)
-				root.Insert(i, new MiniYamlNode("", ""));
-
-			// Saving to a new package: copy over all the content from the map
-			if (Package != null && toPackage != Package)
-				foreach (var file in Package.Contents)
-					toPackage.Update(file, Package.GetStream(file).ReadAllBytes());
-
-			if (!LockPreview)
-				toPackage.Update("map.png", SavePreview());
-
-			// Update the package with the new map data
-			var s = root.WriteToString();
-			toPackage.Update("map.yaml", Encoding.UTF8.GetBytes(s));
-			toPackage.Update("map.bin", SaveBinaryData());
-			Package = toPackage;
-
-			// Update UID to match the newly saved data
-			Uid = ComputeUID(toPackage);
-		}
-
-		public byte[] SaveBinaryData()
-		{
-			var dataStream = new MemoryStream();
-			using (var writer = new BinaryWriter(dataStream))
-			{
-				// Binary data version
-				writer.Write(TileFormat);
-
-				// Size
-				writer.Write((ushort)MapSize.X);
-				writer.Write((ushort)MapSize.Y);
-
-				// Data offsets
-				var tilesOffset = 17;
-				var heightsOffset = Grid.MaximumTerrainHeight > 0 ? 3 * MapSize.X * MapSize.Y + 17 : 0;
-				var resourcesOffset = (Grid.MaximumTerrainHeight > 0 ? 4 : 3) * MapSize.X * MapSize.Y + 17;
-
-				writer.Write((uint)tilesOffset);
-				writer.Write((uint)heightsOffset);
-				writer.Write((uint)resourcesOffset);
-
-				// Tile data
-				if (tilesOffset != 0)
-				{
-					for (var i = 0; i < MapSize.X; i++)
-					{
-						for (var j = 0; j < MapSize.Y; j++)
-						{
-							var tile = Tiles[new MPos(i, j)];
-							writer.Write(tile.Type);
-							writer.Write(tile.Index);
-						}
-					}
-				}
-
-				// Height data
-				if (heightsOffset != 0)
-					for (var i = 0; i < MapSize.X; i++)
-						for (var j = 0; j < MapSize.Y; j++)
-							writer.Write(Height[new MPos(i, j)]);
-
-				// Resource data
-				if (resourcesOffset != 0)
-				{
-					for (var i = 0; i < MapSize.X; i++)
-					{
-						for (var j = 0; j < MapSize.Y; j++)
-						{
-							var tile = Resources[new MPos(i, j)];
-							writer.Write(tile.Type);
-							writer.Write(tile.Index);
-						}
-					}
-				}
-			}
-
-			return dataStream.ToArray();
 		}
 
 		public Pair<Color, Color> GetTerrainColorPair(MPos uv)

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -105,8 +105,8 @@ namespace OpenRA
 							if (mapPackage == null)
 								continue;
 
-							var uid = Map.ComputeUID(mapPackage);
-							previews[uid].UpdateFromMap(mapPackage, kv.Key, kv.Value, modData.Manifest.MapCompatibility, mapGrid.Type);
+							var uid = modData.MapLoader.ComputeUID(modData, mapPackage);
+							modData.MapLoader.UpdatePreview(modData, previews[uid], mapPackage, kv.Key, kv.Value, modData.Manifest.MapCompatibility, mapGrid.Type);
 						}
 					}
 					catch (Exception e)
@@ -166,7 +166,7 @@ namespace OpenRA
 		public IEnumerable<Map> EnumerateMapsWithoutCaching(MapClassification classification = MapClassification.System)
 		{
 			foreach (var mapPackage in EnumerateMapPackagesWithoutCaching(classification))
-				yield return new Map(modData, mapPackage);
+				yield return modData.MapLoader.Load(modData, mapPackage);
 		}
 
 		public void QueryRemoteMapDetails(string repositoryUrl, IEnumerable<string> uids, Action<MapPreview> mapDetailsReceived = null, Action queryFailed = null)

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -31,6 +31,7 @@ namespace OpenRA
 		public readonly ISpriteLoader[] SpriteLoaders;
 		public readonly ISpriteSequenceLoader SpriteSequenceLoader;
 		public readonly IModelSequenceLoader ModelSequenceLoader;
+		public readonly IMapLoader MapLoader;
 		public readonly HotkeyManager Hotkeys;
 		public ILoadScreen LoadScreen { get; private set; }
 		public CursorProvider CursorProvider { get; private set; }
@@ -89,6 +90,8 @@ namespace OpenRA
 
 			ModelSequenceLoader = (IModelSequenceLoader)modelCtor.Invoke(new[] { this });
 			ModelSequenceLoader.OnMissingModelError = s => Log.Write("debug", s);
+
+			MapLoader = Manifest.Get<IMapLoader>();
 
 			Hotkeys = new HotkeyManager(ModFiles, Game.Settings.Keys, Manifest);
 
@@ -185,7 +188,7 @@ namespace OpenRA
 
 			Map map;
 			using (new Support.PerfTimer("Map"))
-				map = new Map(this, MapCache[uid].Package);
+				map = MapLoader.Load(this, MapCache[uid].Package);
 
 			LoadTranslations(map);
 

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportTSMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportTSMapCommand.cs
@@ -17,6 +17,7 @@ using OpenRA.FileSystem;
 using OpenRA.Mods.Cnc.FileFormats;
 using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.FileFormats;
+using OpenRA.Mods.Common.MapFormats;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -265,7 +266,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			var iniBounds = mapSection.GetValue("LocalSize", "0, 0, 0, 0").Split(',').Select(int.Parse).ToArray();
 			var size = new Size(iniSize[2], 2 * iniSize[3]);
 
-			var map = new Map(Game.ModData, utility.ModData.DefaultTileSets[tileset], size.Width, size.Height)
+			var map = new DefaultMap(Game.ModData, utility.ModData.DefaultTileSets[tileset], size.Width, size.Height)
 			{
 				Title = basic.GetValue("Name", Path.GetFileNameWithoutExtension(filename)),
 				Author = "Westwood Studios",

--- a/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
+++ b/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Linq;
+using OpenRA.Mods.Common.MapFormats;
 
 namespace OpenRA.Mods.Common.Lint
 {
@@ -18,9 +19,11 @@ namespace OpenRA.Mods.Common.Lint
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
 		{
-			if (map.MapFormat != Map.SupportedMapFormat)
+			var defaultMap = map as DefaultMap;
+
+			if (defaultMap != null && defaultMap.MapFormat != DefaultMap.SupportedMapFormat)
 				emitError("Map format {0} does not match the supported version {1}."
-					.F(map.MapFormat, Map.SupportedMapFormat));
+					.F(defaultMap.MapFormat, DefaultMap.SupportedMapFormat));
 
 			if (map.Author == null)
 				emitError("Map does not define a valid author.");

--- a/OpenRA.Mods.Common/MapFormats/DefaultMap.cs
+++ b/OpenRA.Mods.Common/MapFormats/DefaultMap.cs
@@ -1,0 +1,529 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using OpenRA.FileFormats;
+using OpenRA.FileSystem;
+using OpenRA.Primitives;
+
+namespace OpenRA.Mods.Common.MapFormats
+{
+	public class DefaultMapLoader : IMapLoader
+	{
+		public readonly string Type;
+		public readonly IReadOnlyDictionary<string, MiniYaml> Metadata;
+
+		public Map Load(ModData modData, IReadOnlyPackage package)
+		{
+			return new DefaultMap(modData, package);
+		}
+
+		public Map Create(ModData modData, TileSet tileSet, int width, int height)
+		{
+			return new DefaultMap(modData, tileSet, width, height);
+		}
+
+		public string ComputeUID(ModData modData, IReadOnlyPackage package)
+		{
+			return DefaultMap.ComputeUID(package);
+		}
+
+		public void UpdatePreview(ModData modData, MapPreview mp, IReadOnlyPackage p, IReadOnlyPackage parent, MapClassification classification, string[] mapCompatibility, MapGridType gridType)
+		{
+			DefaultMap.UpdatePreview(modData, mp, p, parent, classification, mapCompatibility, gridType);
+		}
+	}
+
+	struct BinaryDataHeader
+	{
+		public readonly byte Format;
+		public readonly uint TilesOffset;
+		public readonly uint HeightsOffset;
+		public readonly uint ResourcesOffset;
+
+		public BinaryDataHeader(Stream s, int2 expectedSize)
+		{
+			Format = s.ReadUInt8();
+			var width = s.ReadUInt16();
+			var height = s.ReadUInt16();
+			if (width != expectedSize.X || height != expectedSize.Y)
+				throw new InvalidDataException("Invalid tile data");
+
+			if (Format == 1)
+			{
+				TilesOffset = 5;
+				HeightsOffset = 0;
+				ResourcesOffset = (uint)(3 * width * height + 5);
+			}
+			else if (Format == 2)
+			{
+				TilesOffset = s.ReadUInt32();
+				HeightsOffset = s.ReadUInt32();
+				ResourcesOffset = s.ReadUInt32();
+			}
+			else
+				throw new InvalidDataException("Unknown binary map format '{0}'".F(Format));
+		}
+	}
+
+	class MapField
+	{
+		enum Type { Normal, NodeList, MiniYaml }
+		readonly FieldInfo field;
+		readonly PropertyInfo property;
+		readonly Type type;
+
+		readonly string key;
+		readonly string fieldName;
+		readonly bool required;
+		readonly string ignoreIfValue;
+
+		public MapField(string key, string fieldName = null, bool required = true, string ignoreIfValue = null)
+		{
+			this.key = key;
+			this.fieldName = fieldName ?? key;
+			this.required = required;
+			this.ignoreIfValue = ignoreIfValue;
+
+			field = typeof(DefaultMap).GetField(this.fieldName);
+			property = typeof(DefaultMap).GetProperty(this.fieldName);
+			if (field == null && property == null)
+				throw new InvalidOperationException("Map does not have a field/property " + fieldName);
+
+			var t = field != null ? field.FieldType : property.PropertyType;
+			type = t == typeof(List<MiniYamlNode>) ? Type.NodeList :
+				t == typeof(MiniYaml) ? Type.MiniYaml : Type.Normal;
+		}
+
+		public void Deserialize(Map map, List<MiniYamlNode> nodes)
+		{
+			var node = nodes.FirstOrDefault(n => n.Key == key);
+			if (node == null)
+			{
+				if (required)
+					throw new YamlException("Required field `{0}` not found in map.yaml".F(key));
+				return;
+			}
+
+			if (field != null)
+			{
+				if (type == Type.NodeList)
+					field.SetValue(map, node.Value.Nodes);
+				else if (type == Type.MiniYaml)
+					field.SetValue(map, node.Value);
+				else
+					FieldLoader.LoadField(map, fieldName, node.Value.Value);
+			}
+
+			if (property != null)
+			{
+				if (type == Type.NodeList)
+					property.SetValue(map, node.Value.Nodes, null);
+				else if (type == Type.MiniYaml)
+					property.SetValue(map, node.Value, null);
+				else
+					FieldLoader.LoadField(map, fieldName, node.Value.Value);
+			}
+		}
+
+		public void Serialize(Map map, List<MiniYamlNode> nodes)
+		{
+			var value = field != null ? field.GetValue(map) : property.GetValue(map, null);
+			if (type == Type.NodeList)
+			{
+				var listValue = (List<MiniYamlNode>)value;
+				if (required || listValue.Any())
+					nodes.Add(new MiniYamlNode(key, null, listValue));
+			}
+			else if (type == Type.MiniYaml)
+			{
+				var yamlValue = (MiniYaml)value;
+				if (required || (yamlValue != null && (yamlValue.Value != null || yamlValue.Nodes.Any())))
+					nodes.Add(new MiniYamlNode(key, yamlValue));
+			}
+			else
+			{
+				var formattedValue = FieldSaver.FormatValue(value);
+				if (required || formattedValue != ignoreIfValue)
+					nodes.Add(new MiniYamlNode(key, formattedValue));
+			}
+		}
+	}
+
+	public class DefaultMap : Map
+	{
+		public const int SupportedMapFormat = 11;
+
+		/// <summary>Defines the order of the fields in map.yaml</summary>
+		static readonly MapField[] YamlFields =
+		{
+			new MapField("MapFormat"),
+			new MapField("RequiresMod"),
+			new MapField("Title"),
+			new MapField("Author"),
+			new MapField("Tileset"),
+			new MapField("MapSize"),
+			new MapField("Bounds"),
+			new MapField("Visibility"),
+			new MapField("Categories"),
+			new MapField("LockPreview", required: false, ignoreIfValue: "False"),
+			new MapField("Players", "PlayerDefinitions"),
+			new MapField("Actors", "ActorDefinitions"),
+			new MapField("Rules", "RuleDefinitions", required: false),
+			new MapField("Sequences", "SequenceDefinitions", required: false),
+			new MapField("ModelSequences", "ModelSequenceDefinitions", required: false),
+			new MapField("Weapons", "WeaponDefinitions", required: false),
+			new MapField("Voices", "VoiceDefinitions", required: false),
+			new MapField("Music", "MusicDefinitions", required: false),
+			new MapField("Notifications", "NotificationDefinitions", required: false),
+			new MapField("Translations", "TranslationDefinitions", required: false)
+		};
+
+		// Format versions
+		public int MapFormat { get; private set; }
+		public readonly byte TileFormat = 2;
+
+		public static string ComputeUID(IReadOnlyPackage package)
+		{
+			// UID is calculated by taking an SHA1 of the yaml and binary data
+			var requiredFiles = new[] { "map.yaml", "map.bin" };
+			var contents = package.Contents.ToList();
+			foreach (var required in requiredFiles)
+				if (!contents.Contains(required))
+					throw new FileNotFoundException("Required file {0} not present in this map".F(required));
+
+			var streams = new List<Stream>();
+			try
+			{
+				foreach (var filename in contents)
+					if (filename.EndsWith(".yaml") || filename.EndsWith(".bin") || filename.EndsWith(".lua"))
+						streams.Add(package.GetStream(filename));
+
+				// Take the SHA1
+				if (streams.Count == 0)
+					return CryptoUtil.SHA1Hash(new byte[0]);
+
+				var merged = streams[0];
+				for (var i = 1; i < streams.Count; i++)
+					merged = new MergedStream(merged, streams[i]);
+
+				return CryptoUtil.SHA1Hash(merged);
+			}
+			finally
+			{
+				foreach (var stream in streams)
+					stream.Dispose();
+			}
+		}
+
+		/// <summary>
+		/// Initializes a new map created by the editor or importer.
+		/// The map will not receive a valid UID until after it has been saved and reloaded.
+		/// </summary>
+		public DefaultMap(ModData modData, TileSet tileset, int width, int height)
+			: base(modData)
+		{
+			var tileRef = new TerrainTile(tileset.Templates.First().Key, 0);
+
+			Title = "Name your map here";
+			Author = "Your name here";
+
+			Tileset = tileset.Id;
+
+			Resize(width, height);
+
+			Tiles.Clear(tileRef);
+
+			PostInit();
+		}
+
+		public DefaultMap(ModData modData, IReadOnlyPackage package)
+			: base(modData)
+		{
+			Package = package;
+
+			if (!Package.Contains("map.yaml") || !Package.Contains("map.bin"))
+				throw new InvalidDataException("Not a valid map\n File: {0}".F(package.Name));
+
+			var yaml = new MiniYaml(null, MiniYaml.FromStream(Package.GetStream("map.yaml"), package.Name));
+			foreach (var field in YamlFields)
+				field.Deserialize(this, yaml.Nodes);
+
+			if (MapFormat != SupportedMapFormat)
+				throw new InvalidDataException("Map format {0} is not supported.\n File: {1}".F(MapFormat, package.Name));
+
+			PlayerDefinitions = MiniYaml.NodesOrEmpty(yaml, "Players");
+			ActorDefinitions = MiniYaml.NodesOrEmpty(yaml, "Actors");
+
+			Resize(MapSize.X, MapSize.Y);
+
+			using (var s = Package.GetStream("map.bin"))
+			{
+				var header = new BinaryDataHeader(s, MapSize);
+				if (header.TilesOffset > 0)
+				{
+					s.Position = header.TilesOffset;
+					for (var i = 0; i < MapSize.X; i++)
+					{
+						for (var j = 0; j < MapSize.Y; j++)
+						{
+							var tile = s.ReadUInt16();
+							var index = s.ReadUInt8();
+
+							// TODO: Remember to remove this when rewriting tile variants / PickAny
+							if (index == byte.MaxValue)
+								index = (byte)(i % 4 + (j % 4) * 4);
+
+							Tiles[new MPos(i, j)] = new TerrainTile(tile, index);
+						}
+					}
+				}
+
+				if (header.ResourcesOffset > 0)
+				{
+					s.Position = header.ResourcesOffset;
+					for (var i = 0; i < MapSize.X; i++)
+					{
+						for (var j = 0; j < MapSize.Y; j++)
+						{
+							var type = s.ReadUInt8();
+							var density = s.ReadUInt8();
+							Resources[new MPos(i, j)] = new ResourceTile(type, density);
+						}
+					}
+				}
+
+				if (header.HeightsOffset > 0)
+				{
+					s.Position = header.HeightsOffset;
+					for (var i = 0; i < MapSize.X; i++)
+						for (var j = 0; j < MapSize.Y; j++)
+							Height[new MPos(i, j)] = s.ReadUInt8().Clamp((byte)0, Grid.MaximumTerrainHeight);
+				}
+			}
+
+			PostInit();
+
+			Uid = ComputeUID(Package);
+		}
+
+		public override void Save(IReadWritePackage toPackage)
+		{
+			MapFormat = SupportedMapFormat;
+
+			var root = new List<MiniYamlNode>();
+			foreach (var field in YamlFields)
+				field.Serialize(this, root);
+
+			// HACK: map.yaml is expected to have empty lines between top-level blocks
+			for (var i = root.Count - 1; i > 0; i--)
+				root.Insert(i, new MiniYamlNode("", ""));
+
+			// Saving to a new package: copy over all the content from the map
+			if (Package != null && toPackage != Package)
+				foreach (var file in Package.Contents)
+					toPackage.Update(file, Package.GetStream(file).ReadAllBytes());
+
+			if (!LockPreview)
+				toPackage.Update("map.png", SavePreview());
+
+			// Update the package with the new map data
+			var s = root.WriteToString();
+			toPackage.Update("map.yaml", Encoding.UTF8.GetBytes(s));
+			toPackage.Update("map.bin", SaveBinaryData());
+			Package = toPackage;
+
+			// Update UID to match the newly saved data
+			Uid = ComputeUID(toPackage);
+		}
+
+		public static void UpdatePreview(ModData modData, MapPreview mp, IReadOnlyPackage p, IReadOnlyPackage parent, MapClassification classification, string[] mapCompatibility, MapGridType gridType)
+		{
+			Dictionary<string, MiniYaml> yaml;
+			using (var yamlStream = p.GetStream("map.yaml"))
+			{
+				if (yamlStream == null)
+					throw new FileNotFoundException("Required file map.yaml not present in this map");
+
+				yaml = new MiniYaml(null, MiniYaml.FromStream(yamlStream, "map.yaml")).ToDictionary();
+			}
+
+			var newData = mp.Init(p, parent);
+			newData.GridType = gridType;
+			newData.Class = classification;
+
+			MiniYaml temp;
+			if (yaml.TryGetValue("MapFormat", out temp))
+			{
+				var format = FieldLoader.GetValue<int>("MapFormat", temp.Value);
+				if (format != SupportedMapFormat)
+					throw new InvalidDataException("Map format {0} is not supported.".F(format));
+			}
+
+			if (yaml.TryGetValue("Title", out temp))
+				newData.Title = temp.Value;
+
+			if (yaml.TryGetValue("Categories", out temp))
+				newData.Categories = FieldLoader.GetValue<string[]>("Categories", temp.Value);
+
+			if (yaml.TryGetValue("Tileset", out temp))
+				newData.TileSet = temp.Value;
+
+			if (yaml.TryGetValue("Author", out temp))
+				newData.Author = temp.Value;
+
+			if (yaml.TryGetValue("Bounds", out temp))
+				newData.Bounds = FieldLoader.GetValue<Rectangle>("Bounds", temp.Value);
+
+			if (yaml.TryGetValue("Visibility", out temp))
+				newData.Visibility = FieldLoader.GetValue<MapVisibility>("Visibility", temp.Value);
+
+			string requiresMod = string.Empty;
+			if (yaml.TryGetValue("RequiresMod", out temp))
+				requiresMod = temp.Value;
+
+			newData.Status = mapCompatibility == null || mapCompatibility.Contains(requiresMod) ?
+				MapStatus.Available : MapStatus.Unavailable;
+
+			try
+			{
+				// Actor definitions may change if the map format changes
+				MiniYaml actorDefinitions;
+				if (yaml.TryGetValue("Actors", out actorDefinitions))
+				{
+					var spawns = new List<CPos>();
+					foreach (var kv in actorDefinitions.Nodes.Where(d => d.Value.Value == "mpspawn"))
+					{
+						var s = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+						spawns.Add(s.Get<LocationInit>().Value);
+					}
+
+					newData.SpawnPoints = spawns.ToArray();
+				}
+				else
+					newData.SpawnPoints = new CPos[0];
+			}
+			catch (Exception)
+			{
+				newData.SpawnPoints = new CPos[0];
+				newData.Status = MapStatus.Unavailable;
+			}
+
+			try
+			{
+				// Player definitions may change if the map format changes
+				MiniYaml playerDefinitions;
+				if (yaml.TryGetValue("Players", out playerDefinitions))
+				{
+					newData.Players = new MapPlayers(playerDefinitions.Nodes);
+					newData.PlayerCount = newData.Players.Players.Count(x => x.Value.Playable);
+				}
+			}
+			catch (Exception)
+			{
+				newData.Status = MapStatus.Unavailable;
+			}
+
+			newData.SetRulesetGenerator(modData, () =>
+			{
+				var ruleDefinitions = LoadRuleSection(yaml, "Rules");
+				var weaponDefinitions = LoadRuleSection(yaml, "Weapons");
+				var voiceDefinitions = LoadRuleSection(yaml, "Voices");
+				var musicDefinitions = LoadRuleSection(yaml, "Music");
+				var notificationDefinitions = LoadRuleSection(yaml, "Notifications");
+				var sequenceDefinitions = LoadRuleSection(yaml, "Sequences");
+				var modelSequenceDefinitions = LoadRuleSection(yaml, "ModelSequences");
+				var rules = Ruleset.Load(modData, mp, mp.TileSet, ruleDefinitions, weaponDefinitions,
+					voiceDefinitions, notificationDefinitions, musicDefinitions, sequenceDefinitions, modelSequenceDefinitions);
+				var flagged = Ruleset.DefinesUnsafeCustomRules(modData, mp, ruleDefinitions,
+					weaponDefinitions, voiceDefinitions, notificationDefinitions, sequenceDefinitions);
+				return Pair.New(rules, flagged);
+			});
+
+			if (p.Contains("map.png"))
+				using (var dataStream = p.GetStream("map.png"))
+					newData.Preview = new Png(dataStream);
+		}
+
+		static MiniYaml LoadRuleSection(Dictionary<string, MiniYaml> yaml, string section)
+		{
+			MiniYaml node;
+			if (!yaml.TryGetValue(section, out node))
+				return null;
+
+			return node;
+		}
+
+		public byte[] SaveBinaryData()
+		{
+			var dataStream = new MemoryStream();
+			using (var writer = new BinaryWriter(dataStream))
+			{
+				// Binary data version
+				writer.Write(TileFormat);
+
+				// Size
+				writer.Write((ushort)MapSize.X);
+				writer.Write((ushort)MapSize.Y);
+
+				// Data offsets
+				var tilesOffset = 17;
+				var heightsOffset = Grid.MaximumTerrainHeight > 0 ? 3 * MapSize.X * MapSize.Y + 17 : 0;
+				var resourcesOffset = (Grid.MaximumTerrainHeight > 0 ? 4 : 3) * MapSize.X * MapSize.Y + 17;
+
+				writer.Write((uint)tilesOffset);
+				writer.Write((uint)heightsOffset);
+				writer.Write((uint)resourcesOffset);
+
+				// Tile data
+				if (tilesOffset != 0)
+				{
+					for (var i = 0; i < MapSize.X; i++)
+					{
+						for (var j = 0; j < MapSize.Y; j++)
+						{
+							var tile = Tiles[new MPos(i, j)];
+							writer.Write(tile.Type);
+							writer.Write(tile.Index);
+						}
+					}
+				}
+
+				// Height data
+				if (heightsOffset != 0)
+					for (var i = 0; i < MapSize.X; i++)
+						for (var j = 0; j < MapSize.Y; j++)
+							writer.Write(Height[new MPos(i, j)]);
+
+				// Resource data
+				if (resourcesOffset != 0)
+				{
+					for (var i = 0; i < MapSize.X; i++)
+					{
+						for (var j = 0; j < MapSize.Y; j++)
+						{
+							var tile = Resources[new MPos(i, j)];
+							writer.Write(tile.Type);
+							writer.Write(tile.Index);
+						}
+					}
+				}
+			}
+
+			return dataStream.ToArray();
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					maps = modData.MapCache.EnumerateMapsWithoutCaching().ToList();
 				}
 				else
-					maps.Add(new Map(modData, new Folder(".").OpenPackage(args[1], modData.ModFiles)));
+					maps.Add(modData.MapLoader.Load(modData, new Folder(".").OpenPackage(args[1], modData.ModFiles)));
 
 				foreach (var testMap in maps)
 				{

--- a/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			SequenceProvider sequences = null;
 			var mapPackage = new Folder(".").OpenPackage(args[2], modData.ModFiles);
 			if (mapPackage != null)
-				sequences = new Map(modData, mapPackage).Rules.Sequences;
+				sequences = modData.MapLoader.Load(modData, mapPackage).Rules.Sequences;
 			else if (!modData.DefaultSequences.TryGetValue(args[2], out sequences))
 				throw new InvalidOperationException("{0} is not a valid tileset or map path".F(args[2]));
 

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractMapRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractMapRules.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		{
 			var modData = Game.ModData = utility.ModData;
 
-			var map = new Map(modData, new Folder(".").OpenPackage(args[1], modData.ModFiles));
+			var map = modData.MapLoader.Load(modData, new Folder(".").OpenPackage(args[1], modData.ModFiles));
 			MergeAndPrint(map, "Rules", map.RuleDefinitions);
 			MergeAndPrint(map, "Sequences", map.SequenceDefinitions);
 			MergeAndPrint(map, "ModelSequences", map.ModelSequenceDefinitions);

--- a/OpenRA.Mods.Common/UtilityCommands/GetMapHashCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/GetMapHashCommand.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		void IUtilityCommand.Run(Utility utility, string[] args)
 		{
 			using (var package = new Folder(".").OpenPackage(args[1], utility.ModData.ModFiles))
-				Console.WriteLine(Map.ComputeUID(package));
+				Console.WriteLine(utility.ModData.MapLoader.ComputeUID(utility.ModData, package));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
@@ -17,6 +17,7 @@ using System.Text;
 using OpenRA.FileSystem;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.FileFormats;
+using OpenRA.Mods.Common.MapFormats;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -69,7 +70,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				if (!ModData.DefaultTileSets.ContainsKey(tileset))
 					throw new InvalidDataException("Unknown tileset {0}".F(tileset));
 
-				Map = new Map(ModData, ModData.DefaultTileSets[tileset], MapSize, MapSize)
+				Map = new DefaultMap(ModData, ModData.DefaultTileSets[tileset], MapSize, MapSize)
 				{
 					Title = basic.GetValue("Name", Path.GetFileNameWithoutExtension(filename)),
 					Author = "Westwood Studios",

--- a/OpenRA.Mods.Common/UtilityCommands/RefreshMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/RefreshMapCommand.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			// HACK: We know that maps can only be oramap or folders, which are ReadWrite
 			var modData = Game.ModData = utility.ModData;
 			using (var package = new Folder(".").OpenPackage(args[1], modData.ModFiles))
-				new Map(modData, package).Save((IReadWritePackage)package);
+				modData.MapLoader.Load(modData, package).Save((IReadWritePackage)package);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/UtilityCommands/ResizeMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ResizeMapCommand.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		void IUtilityCommand.Run(Utility utility, string[] args)
 		{
 			var modData = Game.ModData = utility.ModData;
-			map = new Map(modData, new Folder(".").OpenPackage(args[1], modData.ModFiles));
+			map = modData.MapLoader.Load(modData, new Folder(".").OpenPackage(args[1], modData.ModFiles));
 			Console.WriteLine("Resizing map {0} from {1} to {2},{3}", map.Title, map.MapSize, width, height);
 			map.Resize(width, height);
 

--- a/OpenRA.Mods.Common/UtilityCommands/Utilities.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/Utilities.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			{
 				try
 				{
-					map = new Map(modData, new Folder(".").OpenPackage(mapPath, modData.ModFiles));
+					map = modData.MapLoader.Load(modData, new Folder(".").OpenPackage(mapPath, modData.ModFiles));
 				}
 				catch (InvalidDataException ex)
 				{

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				var maxTerrainHeight = world.Map.Grid.MaximumTerrainHeight;
 				var tileset = modData.DefaultTileSets[tilesetDropDown.Text];
-				var map = new Map(Game.ModData, tileset, width + 2, height + maxTerrainHeight + 2);
+				var map = Game.ModData.MapLoader.Create(Game.ModData, tileset, width + 2, height + maxTerrainHeight + 2);
 
 				var tl = new PPos(1, 1 + maxTerrainHeight);
 				var br = new PPos(width, height + maxTerrainHeight);

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -193,7 +193,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					map.Save(package);
 
 					// Update the map cache so it can be loaded without restarting the game
-					modData.MapCache[map.Uid].UpdateFromMap(map.Package, selectedDirectory.Folder, selectedDirectory.Classification, null, map.Grid.Type);
+					modData.MapLoader.UpdatePreview(modData, modData.MapCache[map.Uid], map.Package, selectedDirectory.Folder, selectedDirectory.Classification, null, map.Grid.Type);
 
 					Console.WriteLine("Saved current map at {0}", combinedPath);
 					Ui.CloseWindow();

--- a/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using OpenRA.Mods.Common.MapFormats;
 using OpenRA.Primitives;
 
 namespace OpenRA.Mods.D2k.UtilityCommands
@@ -309,7 +310,7 @@ namespace OpenRA.Mods.D2k.UtilityCommands
 
 			tileSet = Game.ModData.DefaultTileSets["ARRAKIS"];
 
-			map = new Map(Game.ModData, tileSet, mapSize.Width + 2 * MapCordonWidth, mapSize.Height + 2 * MapCordonWidth)
+			map = new DefaultMap(Game.ModData, tileSet, mapSize.Width + 2 * MapCordonWidth, mapSize.Height + 2 * MapCordonWidth)
 			{
 				Title = Path.GetFileNameWithoutExtension(mapFile),
 				Author = "Westwood Studios"

--- a/mods/all/mod.yaml
+++ b/mods/all/mod.yaml
@@ -29,6 +29,8 @@ SoundFormats:
 
 SpriteFormats:
 
+DefaultMapLoader:
+
 SpriteSequenceFormat: DefaultSpriteSequence
 
 ModelSequenceFormat: PlaceholderModelSequence

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -32,6 +32,8 @@ Packages:
 	cnc|bits/scripts
 	cnc|uibits
 
+DefaultMapLoader:
+
 MapFolders:
 	cnc|maps: System
 	~^maps/cnc/{DEV_VERSION}: User

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -21,6 +21,8 @@ Packages:
 	d2k|bits/tex
 	d2k|uibits
 
+DefaultMapLoader:
+
 MapFolders:
 	d2k|maps: System
 	~^maps/d2k/{DEV_VERSION}: User

--- a/mods/modcontent/mod.yaml
+++ b/mods/modcontent/mod.yaml
@@ -65,6 +65,8 @@ SoundFormats:
 
 SpriteFormats: PngSheet
 
+DefaultMapLoader:
+
 SpriteSequenceFormat: DefaultSpriteSequence
 
 ModelSequenceFormat: PlaceholderModelSequence

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -35,6 +35,8 @@ Packages:
 	ra|bits/scripts
 	ra|uibits
 
+DefaultMapLoader:
+
 MapFolders:
 	ra|maps: System
 	~^maps/ra/{DEV_VERSION}: User

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -49,6 +49,8 @@ Packages:
 	ts|bits
 	ts|uibits
 
+DefaultMapLoader:
+
 MapFolders:
 	ts|maps: System
 	~^maps/ts/{DEV_VERSION}: User


### PR DESCRIPTION
Base step of unhardcoding the map features from the engine: Moving the map formats into the mod dlls.
This allows mods to even load completely different map formats from other games or implement their own map format with custom features. This includes also different approaches on how to spawn entities. Having a map.bin and map.yaml is completely defined by the loader now and can be replaced with whatever loading logic someone wants.

On top of that i plan in the future to completely untangle the map layers, so mods can have as many custom layers with custom traits handling them in the future.