### PR TITLE
Convert trait/missile facings and rotation speeds to WAngle

### DIFF
--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -567,6 +567,9 @@ namespace OpenRA
 			}
 			else if (fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() == typeof(Nullable<>))
 			{
+				if (string.IsNullOrEmpty(value))
+					return null;
+
 				var innerType = fieldType.GetGenericArguments().First();
 				var innerValue = GetValue("Nullable<T>", innerType, value, field);
 				return fieldType.GetConstructor(new[] { innerType }).Invoke(new[] { innerValue });

--- a/OpenRA.Mods.Cnc/Activities/VoxelHarvesterDockSequence.cs
+++ b/OpenRA.Mods.Cnc/Activities/VoxelHarvesterDockSequence.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Cnc.Activities
 		readonly WithVoxelUnloadBody body;
 		readonly WithDockingOverlay spriteOverlay;
 
-		public VoxelHarvesterDockSequence(Actor self, Actor refinery, int dockAngle, bool isDragRequired, WVec dragOffset, int dragLength)
+		public VoxelHarvesterDockSequence(Actor self, Actor refinery, WAngle dockAngle, bool isDragRequired, WVec dragOffset, int dragLength)
 			: base(self, refinery, dockAngle, isDragRequired, dragOffset, dragLength)
 		{
 			body = self.Trait<WithVoxelUnloadBody>();

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackPopupTurreted.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("How many game ticks should pass before closing the actor's turret.")]
 		public readonly int CloseDelay = 125;
 
-		public readonly int DefaultFacing = 0;
+		public readonly WAngle DefaultFacing = WAngle.Zero;
 
 		[Desc("The percentage of damage that is received while this actor is closed.")]
 		public readonly int ClosedDamageMultiplier = 50;
@@ -107,10 +107,10 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			if (state == PopupState.Open && idleTicks++ > info.CloseDelay)
 			{
-				turret.DesiredFacing = info.DefaultFacing;
+				turret.DesiredFacing = info.DefaultFacing.Facing;
 				state = PopupState.Rotating;
 			}
-			else if (state == PopupState.Rotating && turret.TurretFacing == info.DefaultFacing)
+			else if (state == PopupState.Rotating && turret.TurretFacing == info.DefaultFacing.Facing)
 			{
 				state = PopupState.Transitioning;
 				wsb.PlayCustomAnimation(self, info.ClosingSequence, () =>

--- a/OpenRA.Mods.Cnc/Traits/ConyardChronoReturn.cs
+++ b/OpenRA.Mods.Cnc/Traits/ConyardChronoReturn.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public readonly string OriginalActor = "mcv";
 
 		[Desc("Facing of the returned actor.")]
-		public readonly int Facing = 96;
+		public readonly WAngle Facing = new WAngle(384);
 
 		public readonly string ChronoshiftSound = "chrono2.aud";
 
@@ -175,7 +175,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			{
 				new LocationInit(destination.Value),
 				new OwnerInit(self.Owner),
-				new FacingInit(WAngle.FromFacing(info.Facing)),
+				new FacingInit(info.Facing),
 				new FactionInit(faction),
 				new HealthInit((int)(health.HP * 100L / health.MaxHP))
 			};

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/DropPodsPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/DropPodsPower.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public readonly int2 Drops = new int2(5, 8);
 
 		[Desc("Sets the approach direction.")]
-		public readonly int PodFacing = 32;
+		public readonly WAngle PodFacing = new WAngle(128);
 
 		[Desc("Maximum offset from targetLocation")]
 		public readonly int PodScatter = 3;
@@ -91,7 +91,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			base.Activate(self, order, manager);
 
-			SendDropPods(self, order, WAngle.FromFacing(info.PodFacing));
+			SendDropPods(self, order, info.PodFacing);
 		}
 
 		public void SendDropPods(Actor self, Order order, WAngle facing)

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -24,18 +24,18 @@ namespace OpenRA.Mods.Cnc.Traits
 		public readonly int Speed = 28;
 
 		[Desc("Facing to use when actor spawns. Only 64 and 192 supported.")]
-		public readonly int InitialFacing = 64;
+		public readonly WAngle InitialFacing = new WAngle(256);
 
 		[Desc("Facing to use for actor previews (map editor, color picker, etc). Only 64 and 192 supported.")]
-		public readonly int PreviewFacing = 64;
+		public readonly WAngle PreviewFacing = new WAngle(256);
 
 		public override object Create(ActorInitializer init) { return new TDGunboat(init, this); }
 
-		public WAngle GetInitialFacing() { return WAngle.FromFacing(InitialFacing); }
+		public WAngle GetInitialFacing() { return InitialFacing; }
 
 		IEnumerable<ActorInit> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)
 		{
-			yield return new FacingInit(WAngle.FromFacing(PreviewFacing));
+			yield return new FacingInit(PreviewFacing);
 		}
 
 		public IReadOnlyDictionary<CPos, SubCell> OccupiedCells(ActorInfo info, CPos location, SubCell subCell = SubCell.Any)

--- a/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Activities
 			this.info = info;
 			IsInterruptible = false;
 			aircraft = self.Trait<Aircraft>();
-			if (info.MaximumSpinSpeed != 0)
+			if (!info.MaximumSpinSpeed.HasValue || info.MaximumSpinSpeed.Value != WAngle.Zero)
 				acceleration = self.World.SharedRandom.Next(2) * 2 - 1;
 		}
 
@@ -49,14 +49,13 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 			}
 
-			if (info.MaximumSpinSpeed != 0)
+			if (acceleration != 0)
 			{
-				if (info.MaximumSpinSpeed < 0 || Math.Abs(spin) < info.MaximumSpinSpeed)
-					spin += acceleration; // TODO: Possibly unhardcode this
+				if (!info.MaximumSpinSpeed.HasValue || Math.Abs(spin) < info.MaximumSpinSpeed.Value.Angle)
+					spin += 4 * acceleration; // TODO: Possibly unhardcode this
 
 				// Allow for negative spin values and convert from facing to angle units
-				// TODO: Remember to convert this when removing WAngle.FromFacing
-				aircraft.Facing = new WAngle(aircraft.Facing.Angle + 4 * spin);
+				aircraft.Facing = new WAngle(aircraft.Facing.Angle + spin);
 			}
 
 			var move = info.Moves ? aircraft.FlyStep(aircraft.Facing) : WVec.Zero;

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Activities
 			// NOTE: desiredFacing = -1 means we should not prefer any particular facing and instead just
 			// use whatever facing gives us the most direct path to the landing site.
 			if (!facing.HasValue && aircraft.Info.TurnToLand)
-				desiredFacing = WAngle.FromFacing(aircraft.Info.InitialFacing);
+				desiredFacing = aircraft.Info.InitialFacing;
 			else
 				desiredFacing = facing;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.Activities
 				var exit = dest.FirstExitOrDefault();
 				var offset = exit != null ? exit.Info.SpawnOffset : WVec.Zero;
 				if (aircraft.Info.TurnToDock || !aircraft.Info.VTOL)
-					facing = WAngle.FromFacing(aircraft.Info.InitialFacing);
+					facing = aircraft.Info.InitialFacing;
 
 				aircraft.MakeReservation(dest);
 				QueueChild(new Land(self, Target.FromActor(dest), offset, facing, Color.Green));

--- a/OpenRA.Mods.Common/Activities/DeployForGrantedCondition.cs
+++ b/OpenRA.Mods.Common/Activities/DeployForGrantedCondition.cs
@@ -31,8 +31,8 @@ namespace OpenRA.Mods.Common.Activities
 		protected override void OnFirstRun(Actor self)
 		{
 			// Turn to the required facing.
-			if (deploy.DeployState == DeployState.Undeployed && deploy.Info.Facing != -1 && canTurn && !moving)
-				QueueChild(new Turn(self, WAngle.FromFacing(deploy.Info.Facing)));
+			if (deploy.DeployState == DeployState.Undeployed && deploy.Info.Facing.HasValue && canTurn && !moving)
+				QueueChild(new Turn(self, deploy.Info.Facing.Value));
 		}
 
 		public override bool Tick(Actor self)

--- a/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected readonly Actor Refinery;
 		protected readonly Harvester Harv;
-		protected readonly int DockAngle;
+		protected readonly WAngle DockAngle;
 		protected readonly bool IsDragRequired;
 		protected readonly WVec DragOffset;
 		protected readonly int DragLength;
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected DockingState dockingState;
 
-		public HarvesterDockSequence(Actor self, Actor refinery, int dockAngle, bool isDragRequired, WVec dragOffset, int dragLength)
+		public HarvesterDockSequence(Actor self, Actor refinery, WAngle dockAngle, bool isDragRequired, WVec dragOffset, int dragLength)
 		{
 			dockingState = DockingState.Turn;
 			Refinery = refinery;
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				case DockingState.Turn:
 					dockingState = DockingState.Dock;
-					QueueChild(new Turn(self, WAngle.FromFacing(DockAngle)));
+					QueueChild(new Turn(self, DockAngle));
 					if (IsDragRequired)
 						QueueChild(new Drag(self, StartDrag, EndDrag, DragLength));
 					return false;

--- a/OpenRA.Mods.Common/Activities/SpriteHarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/SpriteHarvesterDockSequence.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly WithSpriteBody wsb;
 		readonly WithDockingAnimationInfo wda;
 
-		public SpriteHarvesterDockSequence(Actor self, Actor refinery, int dockAngle, bool isDragRequired, WVec dragOffset, int dragLength)
+		public SpriteHarvesterDockSequence(Actor self, Actor refinery, WAngle dockAngle, bool isDragRequired, WVec dragOffset, int dragLength)
 			: base(self, refinery, dockAngle, isDragRequired, dragOffset, dragLength)
 		{
 			wsb = self.Trait<WithSpriteBody>();

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		public readonly string ToActor;
 		public CVec Offset = CVec.Zero;
-		public WAngle Facing = WAngle.FromFacing(96);
+		public WAngle Facing = new WAngle(384);
 		public string[] Sounds = { };
 		public string Notification = null;
 		public int ForceHealthPercentage = 0;

--- a/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.Common.Scripting
 				// Scripted cargo aircraft must turn to default position before unloading.
 				// TODO: pass facing through UnloadCargo instead.
 				if (aircraft != null)
-					transport.QueueActivity(new Land(transport, Target.FromCell(transport.World, entryPath.Last()), WDist.FromCells(dropRange), WAngle.FromFacing(aircraft.Info.InitialFacing)));
+					transport.QueueActivity(new Land(transport, Target.FromCell(transport.World, entryPath.Last()), WDist.FromCells(dropRange), aircraft.Info.InitialFacing));
 
 				if (cargo != null)
 					transport.QueueActivity(new UnloadCargo(transport, WDist.FromCells(dropRange)));

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -47,12 +47,13 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The speed at which the aircraft is repulsed from other aircraft. Specify -1 for normal movement speed.")]
 		public readonly int RepulsionSpeed = -1;
 
-		public readonly int InitialFacing = 0;
+		public readonly WAngle InitialFacing = WAngle.Zero;
 
-		public readonly int TurnSpeed = 255;
+		[Desc("Speed at which the actor turns.")]
+		public readonly WAngle TurnSpeed = new WAngle(512);
 
-		[Desc("Turn speed to apply when aircraft flies in circles while idle. Defaults to TurnSpeed if negative.")]
-		public readonly int IdleTurnSpeed = -1;
+		[Desc("Turn speed to apply when aircraft flies in circles while idle. Defaults to TurnSpeed if undefined.")]
+		public readonly WAngle? IdleTurnSpeed = null;
 
 		public readonly int Speed = 1;
 
@@ -145,7 +146,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int NumberOfTicksToVerifyAvailableAirport = 150;
 
 		[Desc("Facing to use for actor previews (map editor, color picker, etc)")]
-		public readonly int PreviewFacing = 96;
+		public readonly WAngle PreviewFacing = new WAngle(384);
 
 		[Desc("Display order for the facing slider in the map editor")]
 		public readonly int EditorFacingDisplayOrder = 3;
@@ -160,14 +161,14 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Cursor to display when unable to land at target building.")]
 		public readonly string EnterBlockedCursor = "enter-blocked";
 
-		public WAngle GetInitialFacing() { return WAngle.FromFacing(InitialFacing); }
+		public WAngle GetInitialFacing() { return InitialFacing; }
 		public WDist GetCruiseAltitude() { return CruiseAltitude; }
 
 		public override object Create(ActorInitializer init) { return new Aircraft(init, this); }
 
 		IEnumerable<ActorInit> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)
 		{
-			yield return new FacingInit(WAngle.FromFacing(PreviewFacing));
+			yield return new FacingInit(PreviewFacing);
 		}
 
 		public IReadOnlyDictionary<CPos, SubCell> OccupiedCells(ActorInfo info, CPos location, SubCell subCell = SubCell.Any) { return new ReadOnlyDictionary<CPos, SubCell>(); }
@@ -200,7 +201,7 @@ namespace OpenRA.Mods.Common.Traits
 				actor =>
 				{
 					var init = actor.GetInitOrDefault<FacingInit>(this);
-					return (init != null ? init.Value : WAngle.FromFacing(InitialFacing)).Angle;
+					return (init != null ? init.Value : InitialFacing).Angle;
 				},
 				(actor, value) => actor.ReplaceInit(new FacingInit(new WAngle((int)value))));
 		}
@@ -250,8 +251,8 @@ namespace OpenRA.Mods.Common.Traits
 		public WPos CenterPosition { get; private set; }
 
 		public CPos TopLeft { get { return self.World.Map.CellContaining(CenterPosition); } }
-		public WAngle TurnSpeed { get { return !IsTraitDisabled && !IsTraitPaused ? new WAngle(4 * Info.TurnSpeed) : WAngle.Zero; } }
-		public WAngle? IdleTurnSpeed { get { return Info.IdleTurnSpeed != -1 ? new WAngle(4 * Info.IdleTurnSpeed) : (WAngle?)null; } }
+		public WAngle TurnSpeed { get { return !IsTraitDisabled && !IsTraitPaused ? Info.TurnSpeed : WAngle.Zero; } }
+		public WAngle? IdleTurnSpeed { get { return Info.IdleTurnSpeed; } }
 
 		public Actor ReservedActor { get; private set; }
 		public bool MayYieldReservation { get; private set; }
@@ -292,7 +293,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (centerPositionInit != null)
 				SetPosition(self, centerPositionInit.Value);
 
-			Facing = init.GetValue<FacingInit, WAngle>(WAngle.FromFacing(Info.InitialFacing));
+			Facing = init.GetValue<FacingInit, WAngle>(Info.InitialFacing);
 			creationActivityDelay = init.GetValue<CreationActivityDelayInit, int>(0);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Air/FallsToEarth.cs
+++ b/OpenRA.Mods.Common/Traits/Air/FallsToEarth.cs
@@ -22,9 +22,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Explosion weapon that triggers when hitting ground.")]
 		public readonly string Explosion = "UnitExplode";
 
-		[Desc("Limit the maximum spin (in facing units per tick) that can be achieved while crashing.",
-			"0 disables spinning. Negative values imply no limit.")]
-		public readonly int MaximumSpinSpeed = -1;
+		[Desc("Limit the maximum spin (in angle units per tick) that can be achieved while crashing.",
+			"0 disables spinning. Leave undefined for no limit.")]
+		public readonly WAngle? MaximumSpinSpeed = null;
 
 		[Desc("Does the aircraft (husk) move forward at aircraft speed?")]
 		public readonly bool Moves = false;

--- a/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Cell offset where the exiting actor enters the ActorMap relative to the topleft cell of the producing actor.")]
 		public readonly CVec ExitCell = CVec.Zero;
-		public readonly int Facing = -1;
+		public readonly WAngle? Facing = null;
 
 		[Desc("Type tags on this exit.")]
 		public readonly HashSet<string> ProductionTypes = new HashSet<string>();

--- a/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly CVec SpawnOffset = CVec.Zero;
 
 		[Desc("Which direction the unit should face.")]
-		public readonly int Facing = 0;
+		public readonly WAngle Facing = WAngle.Zero;
 
 		[Desc("Whether another actor should spawn upon re-enabling the trait.")]
 		public readonly bool AllowRespawn = false;
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Traits
 					new ParentActorInit(self),
 					new LocationInit(self.Location + Info.SpawnOffset),
 					new OwnerInit(self.Owner),
-					new FacingInit(WAngle.FromFacing(Info.Facing)),
+					new FacingInit(Info.Facing),
 				});
 			});
 		}

--- a/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool BaselineSpawn = false;
 
 		[Desc("Direction the aircraft should face to land.")]
-		public readonly int Facing = 64;
+		public readonly WAngle Facing = new WAngle(256);
 
 		public override object Create(ActorInitializer init) { return new ProductionAirdrop(init, this); }
 	}
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 				var loc = self.Location.ToMPos(map);
 				startPos = new MPos(loc.U + map.Bounds.Width, loc.V).ToCPos(map);
 				endPos = new MPos(map.Bounds.Left, loc.V).ToCPos(map);
-				spawnFacing = WAngle.FromFacing(info.Facing);
+				spawnFacing = info.Facing;
 			}
 
 			// Assume a single exit point for simplicity
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.Traits
 				});
 
 				var exitCell = self.Location + exit.ExitCell;
-				actor.QueueActivity(new Land(actor, Target.FromActor(self), WDist.Zero, WVec.Zero, WAngle.FromFacing(info.Facing), clearCells: new CPos[1] { exitCell }));
+				actor.QueueActivity(new Land(actor, Target.FromActor(self), WDist.Zero, WVec.Zero, info.Facing, clearCells: new CPos[1] { exitCell }));
 				actor.QueueActivity(new CallFunc(() =>
 				{
 					if (!self.IsInWorld || self.IsDead)

--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -23,8 +23,8 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public class RefineryInfo : TraitInfo, Requires<WithSpriteBodyInfo>, IAcceptResourcesInfo
 	{
-		[Desc("Actual harvester facing when docking, 0-255 counter-clock-wise.")]
-		public readonly int DockAngle = 0;
+		[Desc("Actual harvester facing when docking.")]
+		public readonly WAngle DockAngle = WAngle.Zero;
 
 		[Desc("Docking cell relative to top-left cell.")]
 		public readonly CVec DockOffset = CVec.Zero;
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool AllowDocking { get { return !preventDock; } }
 		public CVec DeliveryOffset { get { return info.DockOffset; } }
-		public int DeliveryAngle { get { return info.DockAngle; } }
+		public WAngle DeliveryAngle { get { return info.DockAngle; } }
 		public bool IsDragRequired { get { return info.IsDragRequired; } }
 		public WVec DragOffset { get { return info.DragOffset; } }
 		public int DragLength { get { return info.DragLength; } }

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly WDist LoadRange = WDist.FromCells(5);
 
 		[Desc("Which direction the passenger will face (relative to the transport) when unloading.")]
-		public readonly int PassengerFacing = 128;
+		public readonly WAngle PassengerFacing = new WAngle(512);
 
 		[Desc("Delay (in ticks) before continuing after loading a passenger.")]
 		public readonly int AfterLoadDelay = 8;
@@ -370,10 +370,10 @@ namespace OpenRA.Mods.Common.Traits
 
 			var passengerFacing = passenger.TraitOrDefault<IFacing>();
 			if (passengerFacing != null)
-				passengerFacing.Facing = facing.Value.Facing + WAngle.FromFacing(Info.PassengerFacing);
+				passengerFacing.Facing = facing.Value.Facing + Info.PassengerFacing;
 
 			foreach (var t in passenger.TraitsImplementing<Turreted>())
-				t.TurretFacing = facing.Value.Facing.Facing + Info.PassengerFacing;
+				t.TurretFacing = (facing.Value.Facing + Info.PassengerFacing).Facing;
 		}
 
 		public void Load(Actor self, Actor a)

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -43,8 +43,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Cursor to display when unable to (un)deploy the actor.")]
 		public readonly string DeployBlockedCursor = "deploy-blocked";
 
-		[Desc("Facing that the actor must face before deploying. Set to -1 to deploy regardless of facing.")]
-		public readonly int Facing = -1;
+		[Desc("Facing that the actor must face before deploying. Leave undefined to deploy regardless of facing.")]
+		public readonly WAngle? Facing = null;
 
 		[Desc("Play a randomly selected sound from this list when deploying.")]
 		public readonly string[] DeploySounds = null;
@@ -94,8 +94,6 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly Actor self;
 		readonly bool checkTerrainType;
-		readonly bool canTurn;
-		readonly IMove move;
 
 		DeployState deployState;
 		INotifyDeployTriggered[] notify;
@@ -109,8 +107,6 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			self = init.Self;
 			checkTerrainType = info.AllowedTerrainTypes.Count > 0;
-			canTurn = self.Info.HasTraitInfo<IFacingInfo>();
-			move = self.TraitOrDefault<IMove>();
 			deployState = init.GetValue<DeployStateInit, DeployState>(DeployState.Undeployed);
 		}
 
@@ -119,27 +115,25 @@ namespace OpenRA.Mods.Common.Traits
 			notify = self.TraitsImplementing<INotifyDeployTriggered>().ToArray();
 			base.Created(self);
 
+			if (Info.Facing.HasValue && deployState != DeployState.Undeployed)
+			{
+				var facing = self.TraitOrDefault<IFacing>();
+				if (facing != null)
+					facing.Facing = Info.Facing.Value;
+			}
+
 			switch (deployState)
 			{
 				case DeployState.Undeployed:
 					OnUndeployCompleted();
 					break;
 				case DeployState.Deploying:
-					if (canTurn)
-						self.Trait<IFacing>().Facing = WAngle.FromFacing(Info.Facing);
-
 					Deploy(true);
 					break;
 				case DeployState.Deployed:
-					if (canTurn)
-						self.Trait<IFacing>().Facing = WAngle.FromFacing(Info.Facing);
-
 					OnDeployCompleted();
 					break;
 				case DeployState.Undeploying:
-					if (canTurn)
-						self.Trait<IFacing>().Facing = WAngle.FromFacing(Info.Facing);
-
 					Undeploy(true);
 					break;
 			}

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -23,16 +23,16 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly HashSet<string> AllowedTerrain = new HashSet<string>();
 
 		[Desc("Facing to use for actor previews (map editor, color picker, etc)")]
-		public readonly int PreviewFacing = 96;
+		public readonly WAngle PreviewFacing = new WAngle(384);
 
 		IEnumerable<ActorInit> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)
 		{
-			yield return new FacingInit(WAngle.FromFacing(PreviewFacing));
+			yield return new FacingInit(PreviewFacing);
 		}
 
 		public override object Create(ActorInitializer init) { return new Husk(init, this); }
 
-		public WAngle GetInitialFacing() { return WAngle.FromFacing(128); }
+		public WAngle GetInitialFacing() { return new WAngle(512); }
 
 		public IReadOnlyDictionary<CPos, SubCell> OccupiedCells(ActorInfo info, CPos location, SubCell subCell = SubCell.Any)
 		{

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -30,10 +30,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Which Locomotor does this trait use. Must be defined on the World actor.")]
 		public readonly string Locomotor = null;
 
-		public readonly int InitialFacing = 0;
+		public readonly WAngle InitialFacing = WAngle.Zero;
 
 		[Desc("Speed at which the actor turns.")]
-		public readonly int TurnSpeed = 255;
+		public readonly WAngle TurnSpeed = new WAngle(512);
 
 		public readonly int Speed = 1;
 
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Voice = "Action";
 
 		[Desc("Facing to use for actor previews (map editor, color picker, etc)")]
-		public readonly int PreviewFacing = 96;
+		public readonly WAngle PreviewFacing = new WAngle(384);
 
 		[Desc("Display order for the facing slider in the map editor")]
 		public readonly int EditorFacingDisplayOrder = 3;
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<ActorInit> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)
 		{
-			yield return new FacingInit(WAngle.FromFacing(PreviewFacing));
+			yield return new FacingInit(PreviewFacing);
 		}
 
 		public override object Create(ActorInitializer init) { return new Mobile(init, this); }
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Traits
 			base.RulesetLoaded(rules, ai);
 		}
 
-		public WAngle GetInitialFacing() { return WAngle.FromFacing(InitialFacing); }
+		public WAngle GetInitialFacing() { return InitialFacing; }
 
 		// initialized and used by CanEnterCell
 		Locomotor locomotor;
@@ -134,7 +134,7 @@ namespace OpenRA.Mods.Common.Traits
 				actor =>
 				{
 					var init = actor.GetInitOrDefault<FacingInit>(this);
-					return (init != null ? init.Value : WAngle.FromFacing(InitialFacing)).Angle;
+					return (init != null ? init.Value : InitialFacing).Angle;
 				},
 				(actor, value) => actor.ReplaceInit(new FacingInit(new WAngle((int)value))));
 		}
@@ -206,7 +206,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public WRot Orientation { get { return orientation; } }
 
-		public WAngle TurnSpeed { get { return new WAngle(4 * Info.TurnSpeed); } }
+		public WAngle TurnSpeed { get { return Info.TurnSpeed; } }
 		#endregion
 
 		[Sync]
@@ -265,7 +265,7 @@ namespace OpenRA.Mods.Common.Traits
 				SetVisualPosition(self, init.World.Map.CenterOfSubCell(FromCell, FromSubCell));
 			}
 
-			Facing = oldFacing = init.GetValue<FacingInit, WAngle>(WAngle.FromFacing(info.InitialFacing));
+			Facing = oldFacing = init.GetValue<FacingInit, WAngle>(info.InitialFacing);
 
 			// Sets the initial visual position
 			// Unit will move into the cell grid (defined by LocationInit) as its initial activity

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -56,8 +56,8 @@ namespace OpenRA.Mods.Common.Traits
 				var spawn = self.CenterPosition + exitinfo.SpawnOffset;
 				var to = self.World.Map.CenterOfCell(exit);
 
-				var initialFacing = WAngle.FromFacing(exitinfo.Facing);
-				if (exitinfo.Facing < 0)
+				WAngle initialFacing;
+				if (!exitinfo.Facing.HasValue)
 				{
 					var delta = to - spawn;
 					if (delta.HorizontalLengthSquared == 0)
@@ -68,6 +68,8 @@ namespace OpenRA.Mods.Common.Traits
 					else
 						initialFacing = delta.Yaw;
 				}
+				else
+					initialFacing = exitinfo.Facing.Value;
 
 				exitLocations = rp.Value != null && rp.Value.Path.Count > 0 ? rp.Value.Path : new List<CPos> { exit };
 

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -124,7 +124,7 @@ namespace OpenRA.Mods.Common.Traits
 				var spawn = self.World.Map.CenterOfCell(exit) + new WVec(WDist.Zero, WDist.Zero, altitude);
 				var to = self.World.Map.CenterOfCell(exit);
 
-				var initialFacing = exitinfo == null || exitinfo.Facing < 0 ? (to - spawn).Yaw : WAngle.FromFacing(exitinfo.Facing);
+				var initialFacing = (exitinfo != null && exitinfo.Facing.HasValue) ? exitinfo.Facing.Value : (to - spawn).Yaw;
 
 				exitLocations = rp.Value != null && rp.Value.Path.Count > 0 ? rp.Value.Path : new List<CPos> { exit };
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var aircraft = new List<Actor>();
 			if (!facing.HasValue)
-				facing = WAngle.FromFacing(256 * self.World.SharedRandom.Next(info.QuantizedFacings) / info.QuantizedFacings);
+				facing = new WAngle(1024 * self.World.SharedRandom.Next(info.QuantizedFacings) / info.QuantizedFacings);
 
 			var altitude = self.World.Map.Rules.Actors[info.UnitType].TraitInfo<AircraftInfo>().CruiseAltitude.Length;
 			var attackRotation = WRot.FromYaw(facing.Value);

--- a/OpenRA.Mods.Common/Traits/SupportPowers/ParatroopersPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/ParatroopersPower.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Traits
 			var info = Info as ParatroopersPowerInfo;
 
 			if (!facing.HasValue)
-				facing = WAngle.FromFacing(256 * self.World.SharedRandom.Next(info.QuantizedFacings) / info.QuantizedFacings);
+				facing = new WAngle(1024 * self.World.SharedRandom.Next(info.QuantizedFacings) / info.QuantizedFacings);
 
 			var utLower = info.UnitType.ToLowerInvariant();
 			ActorInfo unitType;

--- a/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int Velocity = 75;
 
 		[Desc("Speed at which the particle turns.")]
-		public readonly int TurnSpeed = 15;
+		public readonly WAngle TurnSpeed = new WAngle(60);
 
 		public override object Create(ActorInitializer init) { return new ThrowsParticle(init, this); }
 	}
@@ -80,9 +80,9 @@ namespace OpenRA.Mods.Common.Traits
 			length = (finalPos - initialPos).Length / info.Velocity;
 
 			// WAngle requires positive inputs, so track the speed and direction separately
-			var rotationSpeed = WDist.FromPDF(Game.CosmeticRandom, 2).Length * info.TurnSpeed / 1024;
+			var rotationSpeed = WDist.FromPDF(Game.CosmeticRandom, 2).Length * info.TurnSpeed.Angle / 1024;
 			direction = rotationSpeed < 0 ? -1 : 1;
-			rotation = WAngle.FromFacing(Math.Abs(rotationSpeed));
+			rotation = new WAngle(Math.Abs(rotationSpeed));
 
 			var anim = new Animation(init.World, rs.GetImage(self), () => facing);
 			anim.PlayRepeating(info.Anim);

--- a/OpenRA.Mods.Common/Traits/ThrowsShrapnel.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsShrapnel.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				for (var i = 0; pieces > i; i++)
 				{
-					var rotation = WRot.FromFacing(self.World.SharedRandom.Next(1024));
+					var rotation = WRot.FromYaw(new WAngle(self.World.SharedRandom.Next(1024)));
 					var args = new ProjectileArgs
 					{
 						Weapon = wep,

--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly CVec Offset = CVec.Zero;
 
 		[Desc("Facing that the actor must face before transforming.")]
-		public readonly int Facing = 96;
+		public readonly WAngle Facing = new WAngle(384);
 
 		[Desc("Sounds to play when transforming.")]
 		public readonly string[] TransformSounds = { };
@@ -91,7 +91,7 @@ namespace OpenRA.Mods.Common.Traits
 			return new Transform(self, Info.IntoActor)
 			{
 				Offset = Info.Offset,
-				Facing = WAngle.FromFacing(Info.Facing),
+				Facing = Info.Facing,
 				Sounds = Info.TransformSounds,
 				Notification = Info.TransformNotification,
 				Faction = faction

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -20,9 +20,11 @@ namespace OpenRA.Mods.Common.Traits
 	public class TurretedInfo : PausableConditionalTraitInfo, Requires<BodyOrientationInfo>, IActorPreviewInitInfo, IEditorActorOptions
 	{
 		public readonly string Turret = "primary";
+
 		[Desc("Speed at which the turret turns.")]
-		public readonly int TurnSpeed = 255;
-		public readonly int InitialFacing = 0;
+		public readonly WAngle TurnSpeed = new WAngle(512);
+
+		public readonly WAngle InitialFacing = WAngle.Zero;
 
 		[Desc("Number of ticks before turret is realigned. (-1 turns off realignment)")]
 		public readonly int RealignDelay = 40;
@@ -35,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<ActorInit> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)
 		{
-			yield return new TurretFacingInit(this, WAngle.FromFacing(InitialFacing));
+			yield return new TurretFacingInit(this, InitialFacing);
 		}
 
 		IEnumerable<EditorActorOption> IEditorActorOptions.ActorOptions(ActorInfo ai, World world)
@@ -47,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 					if (init != null)
 						return init.Value.Angle;
 
-					return WAngle.FromFacing(InitialFacing).Angle;
+					return InitialFacing.Angle;
 				},
 				(actor, value) => actor.ReplaceInit(new TurretFacingInit(this, new WAngle((int)value)), this));
 		}
@@ -78,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public static Func<WAngle> TurretFacingFromInit(IActorInitializer init, TurretedInfo info)
 		{
-			return TurretFacingFromInit(init, info, WAngle.FromFacing(info.InitialFacing));
+			return TurretFacingFromInit(init, info, info.InitialFacing);
 		}
 
 		public static Func<WAngle> TurretFacingFromInit(IActorInitializer init, TraitInfo info, WAngle defaultFacing)
@@ -155,7 +157,7 @@ namespace OpenRA.Mods.Common.Traits
 		void MoveTurret()
 		{
 			var df = DesiredFacing ?? (facing != null ? facing.Facing.Facing : TurretFacing);
-			TurretFacing = Util.TickFacing(TurretFacing, df, Info.TurnSpeed);
+			TurretFacing = Util.TickFacing(TurretFacing, df, Info.TurnSpeed.Facing);
 		}
 
 		public bool FaceTarget(Actor self, Target target)

--- a/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
@@ -141,7 +141,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (info.DeliveryAircraft != null)
 				{
 					var crate = w.CreateActor(false, crateActor, new TypeDictionary { new OwnerInit(w.WorldActor.Owner) });
-					var dropFacing = WAngle.FromFacing(256 * self.World.SharedRandom.Next(info.QuantizedFacings) / info.QuantizedFacings);
+					var dropFacing = new WAngle(1024 * self.World.SharedRandom.Next(info.QuantizedFacings) / info.QuantizedFacings);
 					var delta = new WVec(0, -1024, 0).Rotate(WRot.FromYaw(dropFacing));
 
 					var altitude = self.World.Map.Rules.Actors[info.DeliveryAircraft].TraitInfo<AircraftInfo>().CruiseAltitude.Length;

--- a/OpenRA.Mods.Common/Traits/World/EditorCursorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorCursorLayer.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Required for the map editor to work. Attach this to the world actor.")]
 	public class EditorCursorLayerInfo : TraitInfo, Requires<EditorActorLayerInfo>
 	{
-		public readonly int PreviewFacing = 96;
+		public readonly WAngle PreviewFacing = new WAngle(384);
 
 		public override object Create(ActorInitializer init) { return new EditorCursorLayer(init.Self, this); }
 	}
@@ -194,7 +194,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			if (actor.HasTraitInfo<IFacingInfo>())
-				reference.Add(new FacingInit(WAngle.FromFacing(info.PreviewFacing)));
+				reference.Add(new FacingInit(info.PreviewFacing));
 
 			Type = EditorCursorType.Actor;
 			Actor = new EditorActorPreview(wr, null, reference, owner);

--- a/OpenRA.Mods.Common/Traits/World/MPStartUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/MPStartUnits.cs
@@ -43,11 +43,11 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Outer radius for spawning support actors")]
 		public readonly int OuterSupportRadius = 4;
 
-		[Desc("Initial facing of BaseActor. -1 means random.")]
-		public readonly int BaseActorFacing = 128;
+		[Desc("Initial facing of BaseActor. Leave undefined for random facings.")]
+		public readonly WAngle? BaseActorFacing = new WAngle(512);
 
-		[Desc("Initial facing of SupportActors. -1 means random.")]
-		public readonly int SupportActorsFacing = -1;
+		[Desc("Initial facing of SupportActors. Leave undefined for random facings.")]
+		public readonly WAngle? SupportActorsFacing = null;
 	}
 
 	public class MPStartUnits { }

--- a/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (unitGroup.BaseActor != null)
 			{
-				var facing = unitGroup.BaseActorFacing < 0 ? new WAngle(w.SharedRandom.Next(1024)) : WAngle.FromFacing(unitGroup.BaseActorFacing);
+				var facing = unitGroup.BaseActorFacing.HasValue ? unitGroup.BaseActorFacing.Value : new WAngle(w.SharedRandom.Next(1024));
 				w.CreateActor(unitGroup.BaseActor.ToLowerInvariant(), new TypeDictionary
 				{
 					new LocationInit(sp + unitGroup.BaseActorOffset),
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				var subCell = ip.SharesCell ? w.ActorMap.FreeSubCell(validCell) : 0;
-				var facing = unitGroup.SupportActorsFacing < 0 ? new WAngle(w.SharedRandom.Next(1024)) : WAngle.FromFacing(unitGroup.SupportActorsFacing);
+				var facing = unitGroup.SupportActorsFacing.HasValue ? unitGroup.SupportActorsFacing.Value : new WAngle(w.SharedRandom.Next(1024));
 
 				w.CreateActor(s.ToLowerInvariant(), new TypeDictionary
 				{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ReplaceFacingAngles.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ReplaceFacingAngles.cs
@@ -1,0 +1,105 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	class ReplaceFacingAngles : UpdateRule
+	{
+		static readonly Dictionary<string, string[]> TraitFields = new Dictionary<string, string[]>()
+		{
+			{ "Aircraft", new[] { "InitialFacing", "PreviewFacing", "TurnSpeed", "IdleTurnSpeed" } },
+			{ "Mobile", new[] { "InitialFacing", "PreviewFacing", "TurnSpeed" } },
+			{ "Husk", new[] { "PreviewFacing" } },
+			{ "Turreted", new[] { "InitialFacing", "TurnSpeed" } },
+			{ "GrantConditionOnDeploy", new[] { "Facing" } },
+			{ "FreeActor", new[] { "Facing" } },
+			{ "ProductionAirdrop", new[] { "Facing" } },
+			{ "EditorCursorLayer", new[] { "PreviewFacing" } },
+			{ "MPStartUnits", new[] { "BaseActorFacing", "SupportActorsFacing" } },
+			{ "Refinery", new[] { "DockAngle" } },
+			{ "Cargo", new[] { "PassengerFacing" } },
+			{ "Exit", new[] { "Facing" } },
+			{ "ThrowsParticle", new[] { "TurnSpeed" } },
+			{ "Transforms", new[] { "Facing" } },
+			{ "FallsToEarth", new[] { "MaximumSpinSpeed" } },
+			{ "ConyardChronoReturn", new[] { "Facing" } },
+			{ "TDGunboat", new[] { "InitialFacing", "PreviewFacing" } },
+			{ "AttackPopupTurreted", new[] { "DefaultFacing" } },
+			{ "DropPodsPower", new[] { "PodFacing" } },
+			{ "TiberianSunRefinery", new[] { "DockAngle" } },
+		};
+
+		static readonly Dictionary<string, string[]> ProjectileFields = new Dictionary<string, string[]>()
+		{
+			{ "Missile", new[] { "HorizontalRateOfTurn", "VerticalRateOfTurn" } }
+		};
+
+		public override string Name { get { return "Increase facing angle resolution"; } }
+		public override string Description
+		{
+			get
+			{
+				return "Trait fields that defined facings (0-255) have been replaced with higher resolution angles (0-1023).\n" +
+					"Values for the following trait fields should be multiplied by 4, or if undefined (-1) replaced by an empty definition:\n" +
+					UpdateUtils.FormatMessageList(TraitFields.Select(t => t.Key + "\n" + UpdateUtils.FormatMessageList(t.Value))) + "\n" +
+					"Values for the following projectile files should be multiplied by 4:\n" +
+					UpdateUtils.FormatMessageList(ProjectileFields.Select(t => t.Key + "\n" + UpdateUtils.FormatMessageList(t.Value)));
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var kv in TraitFields)
+			{
+				foreach (var traitNode in actorNode.ChildrenMatching(kv.Key))
+				{
+					foreach (var fieldName in kv.Value)
+					{
+						foreach (var fieldNode in traitNode.ChildrenMatching(fieldName))
+						{
+							var value = fieldNode.NodeValue<int>();
+							fieldNode.Value.Value = value != -1 ? FieldSaver.FormatValue(value != 255 ? 4 * value : 1023) : "";
+						}
+					}
+				}
+			}
+
+			yield break;
+		}
+
+		public override IEnumerable<string> UpdateWeaponNode(ModData modData, MiniYamlNode weaponNode)
+		{
+			foreach (var projectileNode in weaponNode.ChildrenMatching("Projectile"))
+			{
+				if (projectileNode.Value.Value == null)
+					continue;
+
+				string[] fieldNames;
+				if (ProjectileFields.TryGetValue(projectileNode.Value.Value, out fieldNames))
+				{
+					foreach (var fieldName in fieldNames)
+					{
+						foreach (var fieldNode in projectileNode.ChildrenMatching(fieldName))
+						{
+							var value = fieldNode.NodeValue<int>();
+							fieldNode.Value.Value = FieldSaver.FormatValue(value != 255 ? 4 * value : 1023);
+						}
+					}
+				}
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -69,6 +69,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new UpdateMapInits(),
 				new CreateFlashPaletteEffectWarhead(),
 				new ChangeTargetLineDelayToMilliseconds(),
+				new ReplaceFacingAngles(),
 			})
 		};
 

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -13,7 +13,7 @@ TRAN:
 		Queue: Aircraft.GDI, Aircraft.Nod
 		Description: Fast Infantry Transport Helicopter.\n  Unarmed
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 150
 		AltitudeVelocity: 0c100
 	Health:
@@ -64,7 +64,7 @@ HELI:
 		Queue: Aircraft.Nod
 		Description: Helicopter Gunship with Chainguns.\n  Strong vs Infantry, Light Vehicles and\n  Aircraft\n  Weak vs Tanks
 	Aircraft:
-		TurnSpeed: 7
+		TurnSpeed: 28
 		Speed: 180
 	Health:
 		HP: 12500
@@ -132,7 +132,7 @@ ORCA:
 		Queue: Aircraft.GDI
 		Description: Helicopter Gunship with AG Missiles.\n  Strong vs Buildings, Tanks\n  Weak vs Infantry
 	Aircraft:
-		TurnSpeed: 7
+		TurnSpeed: 28
 		Speed: 186
 	Health:
 		HP: 9000
@@ -182,7 +182,7 @@ C17:
 	Valued:
 		Cost: 2000
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 700
 		Repulsable: False
 		MaximumPitch: 36
@@ -215,7 +215,7 @@ A10:
 	Valued:
 		Cost: 2000
 	Aircraft:
-		TurnSpeed: 4
+		TurnSpeed: 16
 		Speed: 373
 		Repulsable: False
 	AttackBomber:
@@ -242,7 +242,7 @@ TRAN.Husk:
 	Tooltip:
 		Name: Chinook Transport
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 140
 	RevealsShroud:
 		Range: 10c0
@@ -261,7 +261,7 @@ HELI.Husk:
 	Tooltip:
 		Name: Apache Longbow
 	Aircraft:
-		TurnSpeed: 4
+		TurnSpeed: 16
 		Speed: 186
 	RevealsShroud:
 		Range: 10c0
@@ -277,7 +277,7 @@ ORCA.Husk:
 	Tooltip:
 		Name: Orca
 	Aircraft:
-		TurnSpeed: 4
+		TurnSpeed: 16
 		Speed: 186
 	RevealsShroud:
 		Range: 10c0

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -267,7 +267,7 @@
 		Action: Kill
 	Mobile:
 		Locomotor: wheeled
-		TurnSpeed: 5
+		TurnSpeed: 20
 	Selectable:
 		Bounds: 24,24
 	Targetable:
@@ -299,7 +299,7 @@
 	Inherits: ^Vehicle
 	Mobile:
 		Locomotor: tracked
-		TurnSpeed: 5
+		TurnSpeed: 20
 	Tooltip:
 		GenericName: Tank
 
@@ -330,7 +330,7 @@
 		VTOL: true
 		LandableTerrainTypes: Clear, Rough, Road, Beach, Tiberium, BlueTiberium
 		Crushes: crate, infantry
-		InitialFacing: 224
+		InitialFacing: 896
 		CanSlide: True
 	HiddenUnderFog:
 		Type: GroundPosition

--- a/mods/cnc/rules/ships.yaml
+++ b/mods/cnc/rules/ships.yaml
@@ -18,7 +18,7 @@ BOAT:
 		Range: 7c0
 		Type: CenterPosition
 	Turreted:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Offset: 0,896,171
 	Armament:
 		Weapon: BoatMissile
@@ -62,7 +62,7 @@ LST:
 	Mobile:
 		Locomotor: lcraft
 		InitialFacing: 0
-		TurnSpeed: 4
+		TurnSpeed: 16
 		Speed: 142
 		PauseOnCondition: notmobile
 	Health:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -24,7 +24,7 @@ FACT:
 		PauseOnCondition: being-demolished || build-incomplete
 		IntoActor: mcv
 		Offset: 1,1
-		Facing: 108
+		Facing: 432
 	TransformsIntoMobile:
 		RequiresCondition: factundeploy
 		Locomotor: heavywheeled
@@ -228,7 +228,7 @@ PROC:
 	RevealsShroud:
 		Range: 6c0
 	Refinery:
-		DockAngle: 112
+		DockAngle: 448
 		DockOffset: 0,2
 		IsDragRequired: True
 		DragOffset: -554,512,0
@@ -244,7 +244,7 @@ PROC:
 	FreeActor:
 		Actor: HARV
 		SpawnOffset: 1,2
-		Facing: 64
+		Facing: 256
 	WithBuildingBib:
 	WithResourceLevelOverlay:
 		RequiresCondition: !build-incomplete
@@ -850,8 +850,8 @@ GUN:
 	WithBuildingBib:
 		HasMinibib: true
 	Turreted:
-		TurnSpeed: 12
-		InitialFacing: 56
+		TurnSpeed: 48
+		InitialFacing: 224
 	-WithSpriteBody:
 	WithEmbeddedTurretSpriteBody:
 	Armament:
@@ -901,7 +901,7 @@ SAM:
 	RevealsShroud:
 		Range: 6c0
 	Turreted:
-		TurnSpeed: 10
+		TurnSpeed: 40
 		InitialFacing: 0
 		RealignDelay: -1
 	-WithSpriteBody:
@@ -1006,7 +1006,7 @@ GTWR:
 		Range: 3c0
 	WithMuzzleOverlay:
 	Turreted:
-		TurnSpeed: 255
+		TurnSpeed: 512
 	Power:
 		Amount: -10
 
@@ -1041,7 +1041,7 @@ ATWR:
 	WithBuildingBib:
 		HasMinibib: true
 	Turreted:
-		TurnSpeed: 255
+		TurnSpeed: 512
 		Offset: 128,128,384
 	Armament@PRIMARY:
 		Weapon: TowerMissile

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -28,7 +28,7 @@ MCV:
 	Transforms:
 		IntoActor: fact
 		Offset: -1,-1
-		Facing: 108
+		Facing: 432
 		TransformSounds: constru2.aud, hvydoor1.aud
 		NoTransformNotification: BuildingCannotPlaceAudio
 	MustBeDestroyed:
@@ -114,7 +114,7 @@ APC:
 		BuildDurationModifier: 40
 		Description: Armed infantry transport.\nCan attack Aircraft.\n  Strong vs Vehicles\n  Weak vs Infantry
 	Mobile:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 132
 		PauseOnCondition: notmobile
 	Health:
@@ -126,7 +126,7 @@ APC:
 	RevealsShroud:
 		Range: 6c0
 	Turreted:
-		TurnSpeed: 10
+		TurnSpeed: 40
 	Armament@PRIMARY:
 		Weapon: APCGun
 		Recoil: 48
@@ -183,7 +183,7 @@ ARTY:
 		Queue: Vehicle.Nod
 		Description: Long-range artillery.\n  Strong vs Infantry, Vehicles and Buildings
 	Mobile:
-		TurnSpeed: 4
+		TurnSpeed: 16
 		Speed: 85
 	Health:
 		HP: 7500
@@ -229,7 +229,7 @@ FTNK:
 		Queue: Vehicle.Nod
 		Description: Heavily armored flame-throwing vehicle.\n  Strong vs Infantry, Buildings and Vehicles\n  Weak vs Tanks
 	Mobile:
-		TurnSpeed: 7
+		TurnSpeed: 28
 		Speed: 99
 	Health:
 		HP: 27000
@@ -270,7 +270,7 @@ BGGY:
 		Queue: Vehicle.Nod
 		Description: Fast scout and anti-infantry vehicle.\n  Strong vs Infantry\n  Weak vs Tanks
 	Mobile:
-		TurnSpeed: 10
+		TurnSpeed: 40
 		Speed: 170
 	Health:
 		HP: 12000
@@ -281,7 +281,7 @@ BGGY:
 	RevealsShroud:
 		Range: 8c0
 	Turreted:
-		TurnSpeed: 10
+		TurnSpeed: 40
 		Offset: -43,0,128
 	Armament:
 		Weapon: MachineGun
@@ -312,7 +312,7 @@ BIKE:
 		Queue: Vehicle.Nod
 		Description: Fast scout vehicle, armed with\nrockets.\nCan attack Aircraft.\n  Strong vs Vehicles, Tanks\n  Weak vs Infantry
 	Mobile:
-		TurnSpeed: 10
+		TurnSpeed: 40
 		Speed: 213
 		Locomotor: bike
 	Health:
@@ -350,7 +350,7 @@ JEEP:
 		Queue: Vehicle.GDI
 		Description: Fast scout and anti-infantry vehicle.\n  Strong vs Infantry\n  Weak vs Tanks
 	Mobile:
-		TurnSpeed: 10
+		TurnSpeed: 40
 		Speed: 156
 	Health:
 		HP: 16000
@@ -361,7 +361,7 @@ JEEP:
 	RevealsShroud:
 		Range: 8c0
 	Turreted:
-		TurnSpeed: 10
+		TurnSpeed: 40
 		Offset: -85,0,128
 	Armament:
 		Weapon: MachineGunH
@@ -392,7 +392,7 @@ LTNK:
 		Queue: Vehicle.Nod
 		Description: Fast, light tank.\n  Strong vs Vehicles, Tanks\n  Weak vs Infantry
 	Mobile:
-		TurnSpeed: 7
+		TurnSpeed: 28
 		Speed: 110
 	Health:
 		HP: 34000
@@ -403,7 +403,7 @@ LTNK:
 	RevealsShroud:
 		Range: 6c0
 	Turreted:
-		TurnSpeed: 7
+		TurnSpeed: 28
 	Armament:
 		Weapon: 70mm
 		Recoil: 85
@@ -445,7 +445,7 @@ MTNK:
 	RevealsShroud:
 		Range: 6c0
 	Turreted:
-		TurnSpeed: 5
+		TurnSpeed: 20
 	Armament:
 		Weapon: 120mm
 		Recoil: 128
@@ -481,7 +481,7 @@ HTNK:
 	Mobile:
 		Locomotor: heavytracked
 		Speed: 56
-		TurnSpeed: 3
+		TurnSpeed: 12
 	Health:
 		HP: 87000
 	Repairable:
@@ -492,7 +492,7 @@ HTNK:
 		Range: 6c0
 	WithSpriteTurret:
 	Turreted:
-		TurnSpeed: 3
+		TurnSpeed: 12
 	Armament@PRIMARY:
 		Weapon: 120mmDual
 		LocalOffset: 900,180,340, 900,-180,340
@@ -538,7 +538,7 @@ MSAM:
 		Description: Long range rocket artillery.\n  Strong vs all Ground units.
 	Mobile:
 		Speed: 85
-		TurnSpeed: 4
+		TurnSpeed: 16
 	Health:
 		HP: 12000
 	Repairable:
@@ -548,7 +548,7 @@ MSAM:
 	RevealsShroud:
 		Range: 5c0
 	Turreted:
-		TurnSpeed: 255
+		TurnSpeed: 512
 		Offset: -256,0,128
 	Armament@PRIMARY:
 		Weapon: 227mm
@@ -586,7 +586,7 @@ MLRS:
 		Description: Powerful anti-air unit.\nCannot attack Ground units.
 	Mobile:
 		Speed: 99
-		TurnSpeed: 7
+		TurnSpeed: 28
 	Health:
 		HP: 18000
 	Repairable:
@@ -596,7 +596,7 @@ MLRS:
 	RevealsShroud:
 		Range: 8c0
 	Turreted:
-		TurnSpeed: 8
+		TurnSpeed: 32
 		Offset: -128,0,128
 		RealignDelay: 0
 	Armament:
@@ -642,7 +642,7 @@ STNK:
 		Description: Long-range missile tank that can cloak.\nCan attack Aircraft.\nHas weak armor. Can be spotted by infantry and defense structures.\n  Strong vs Vehicles, Tanks\n  Weak vs Infantry.
 	Mobile:
 		Locomotor: heavywheeled
-		TurnSpeed: 10
+		TurnSpeed: 40
 		Speed: 142
 	Health:
 		HP: 15000

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -10,7 +10,7 @@
 		Inaccuracy: 128
 		Image: DRAGON
 		Shadow: true
-		HorizontalRateOfTurn: 15
+		HorizontalRateOfTurn: 60
 		TrailImage: smokey
 		ContrailLength: 8
 		Speed: 298
@@ -49,7 +49,7 @@ Dragon:
 	BurstDelays: 5
 	Projectile: Missile
 		Speed: 426
-		HorizontalRateOfTurn: 20
+		HorizontalRateOfTurn: 80
 		RangeLimit: 12c0
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: Air
@@ -68,7 +68,7 @@ BikeRockets:
 	Burst: 2
 	BurstDelays: 10
 	Projectile: Missile
-		HorizontalRateOfTurn: 10
+		HorizontalRateOfTurn: 40
 		Speed: 213
 	Warhead@1Dam: SpreadDamage
 		Versus:
@@ -85,7 +85,7 @@ OrcaAGMissiles:
 	ValidTargets: Ground, Water
 	Projectile: Missile
 		Arm: 1
-		HorizontalRateOfTurn: 20
+		HorizontalRateOfTurn: 80
 		Speed: 256
 		RangeLimit: 6c0
 	Warhead@1Dam: SpreadDamage
@@ -117,7 +117,7 @@ MammothMissiles:
 	Burst: 2
 	BurstDelays: 15
 	Projectile: Missile
-		HorizontalRateOfTurn: 20
+		HorizontalRateOfTurn: 80
 		Speed: 341
 		RangeLimit: 6c0
 	Warhead@1Dam: SpreadDamage
@@ -174,7 +174,7 @@ MammothMissiles:
 	BurstDelays: 10
 	Projectile: Missile
 		Inaccuracy: 213
-		HorizontalRateOfTurn: 10
+		HorizontalRateOfTurn: 40
 		Speed: 213
 		RangeLimit: 8c409
 	Warhead@1Dam: SpreadDamage
@@ -194,7 +194,7 @@ BoatMissile:
 	Report: rocket2.aud
 	Projectile: Missile
 		Inaccuracy: 426
-		HorizontalRateOfTurn: 5
+		HorizontalRateOfTurn: 20
 		Speed: 170
 		RangeLimit: 9c614
 	Warhead@1Dam: SpreadDamage
@@ -218,7 +218,7 @@ TowerMissile:
 	Report: rocket2.aud
 	ValidTargets: Ground, Water
 	Projectile: Missile
-		HorizontalRateOfTurn: 20
+		HorizontalRateOfTurn: 80
 		Speed: 298
 		RangeLimit: 8c409
 	Warhead@1Dam: SpreadDamage
@@ -241,7 +241,7 @@ TowerAAMissile:
 	ValidTargets: Air
 	Projectile: Missile
 		Image: MISSILE
-		HorizontalRateOfTurn: 20
+		HorizontalRateOfTurn: 80
 		Speed: 426
 		RangeLimit: 9c614
 		Inaccuracy: 0
@@ -266,7 +266,7 @@ Patriot:
 	ValidTargets: Air
 	Projectile: Missile
 		Image: MISSILE
-		HorizontalRateOfTurn: 20
+		HorizontalRateOfTurn: 80
 		Speed: 300
 		RangeLimit: 10c819
 		Inaccuracy: 0

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -13,13 +13,13 @@ carryall.reinforce:
 		CruisingCondition: cruising
 		InitialFacing: 0
 		Speed: 144
-		TurnSpeed: 4
+		TurnSpeed: 16
 		LandableTerrainTypes: Sand, Rock, Transition, Spice, SpiceSand, Dune, Concrete
 		Repulsable: False
 		AirborneCondition: airborne
 		CanSlide: True
 		VTOL: true
-		IdleTurnSpeed: 1
+		IdleTurnSpeed: 4
 	Targetable@GROUND:
 		TargetTypes: Ground, Vehicle
 		RequiresCondition: !airborne
@@ -78,7 +78,7 @@ frigate:
 	Aircraft:
 		IdleBehavior: LeaveMap
 		Speed: 189
-		TurnSpeed: 1
+		TurnSpeed: 4
 		Repulsable: False
 		MaximumPitch: 20
 		CruiseAltitude: 2048
@@ -101,7 +101,7 @@ ornithopter:
 		Type: light
 	Aircraft:
 		Speed: 224
-		TurnSpeed: 2
+		TurnSpeed: 8
 		Repulsable: False
 		CruiseAltitude: 1920
 	AmmoPool:
@@ -119,7 +119,7 @@ ornithopter.husk:
 	Tooltip:
 		Name: Ornithopter
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 224
 	RenderSprites:
 		Image: ornithopter
@@ -129,7 +129,7 @@ carryall.husk:
 	Tooltip:
 		Name: Carryall
 	Aircraft:
-		TurnSpeed: 4
+		TurnSpeed: 16
 		Speed: 144
 		CanSlide: True
 		VTOL: true
@@ -144,7 +144,7 @@ carryall.huskVTOL:
 		Moves: False
 		Velocity: 0c128
 	Aircraft:
-		TurnSpeed: 4
+		TurnSpeed: 16
 		CanSlide: True
 		VTOL: true
 	RenderSprites:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -194,7 +194,7 @@
 	OwnerLostAction:
 		Action: Kill
 	Mobile:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Locomotor: vehicle
 		PauseOnCondition: notmobile
 	Selectable:

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -110,7 +110,7 @@ thumper:
 	GrantConditionOnDeploy:
 		DeployedCondition: deployed
 		UndeployedCondition: undeployed
-		Facing: 128
+		Facing: 512
 		AllowedTerrainTypes: Sand, Spice, Dune, SpiceSand
 	WithInfantryBody:
 		RequiresCondition: undeployed

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -172,7 +172,7 @@ waypoint:
 carryall.colorpicker:
 	Inherits: carryall
 	Aircraft:
-		InitialFacing: 104
+		InitialFacing: 416
 	-Buildable:
 	-MapEditorData:
 	RenderSprites:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -261,7 +261,7 @@ refinery:
 	RevealsShroud:
 		Range: 3c768
 	Refinery:
-		DockAngle: 160
+		DockAngle: 640
 		DockOffset: 2,1
 		TickRate: 20
 	StoresResources:
@@ -744,8 +744,8 @@ medium_gun_turret:
 		QuantizedFacings: 32
 	WithMuzzleOverlay:
 	Turreted:
-		TurnSpeed: 6
-		InitialFacing: 128
+		TurnSpeed: 24
+		InitialFacing: 512
 	Armament:
 		Weapon: 110mm_Gun
 		LocalOffset: 512,0,432
@@ -789,8 +789,8 @@ large_gun_turret:
 		Weapon: TowerMissile
 		LocalOffset: 256,384,768, 256,-384,768
 	Turreted:
-		TurnSpeed: 8
-		InitialFacing: 128
+		TurnSpeed: 32
+		InitialFacing: 512
 	Power:
 		Amount: -60
 	RevealOnDeath:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -30,7 +30,7 @@ mcv:
 		Weapon: UnitExplodeLarge
 		EmptyWeapon: UnitExplodeLarge
 	Transforms:
-		Facing: 16
+		Facing: 64
 		IntoActor: construction_yard
 		Offset: -1,-1
 		TransformSounds: BUILD1.WAV
@@ -127,7 +127,7 @@ trike:
 	Armor:
 		Type: wood
 	Mobile:
-		TurnSpeed: 10
+		TurnSpeed: 40
 		Speed: 128
 	RevealsShroud:
 		Range: 4c768
@@ -168,7 +168,7 @@ quad:
 	Armor:
 		Type: light
 	Mobile:
-		TurnSpeed: 8
+		TurnSpeed: 32
 		Speed: 96
 	RevealsShroud:
 		Range: 4c768
@@ -207,11 +207,11 @@ siege_tank:
 		Type: light
 	Mobile:
 		Speed: 43
-		TurnSpeed: 3
+		TurnSpeed: 12
 	RevealsShroud:
 		Range: 6c768
 	Turreted:
-		TurnSpeed: 3
+		TurnSpeed: 12
 		Offset: 0,0,-32
 	Armament:
 		Weapon: 155mm
@@ -255,7 +255,7 @@ missile_tank:
 		Cost: 900
 	Mobile:
 		Speed: 64
-		TurnSpeed: 5
+		TurnSpeed: 20
 	Health:
 		HP: 13000
 	Armor:
@@ -302,7 +302,7 @@ sonic_tank:
 	Armor:
 		Type: light
 	Mobile:
-		TurnSpeed: 3
+		TurnSpeed: 12
 		Speed: 31
 	RevealsShroud:
 		Range: 5c768
@@ -342,7 +342,7 @@ devastator:
 	Armor:
 		Type: heavy
 	Mobile:
-		TurnSpeed: 3
+		TurnSpeed: 12
 		Speed: 31
 		Locomotor: devastator
 		RequiresCondition: !overload
@@ -414,7 +414,7 @@ raider:
 	Armor:
 		Type: wood
 	Mobile:
-		TurnSpeed: 10
+		TurnSpeed: 40
 		Speed: 149
 	RevealsShroud:
 		Range: 4c768
@@ -479,7 +479,7 @@ deviator:
 		BuildDurationModifier: 100
 		Description: Fires a warhead which changes\nthe allegiance of enemy vehicles
 	Mobile:
-		TurnSpeed: 3
+		TurnSpeed: 12
 		Speed: 53
 	Health:
 		HP: 11000
@@ -525,11 +525,11 @@ deviator:
 		Type: heavy
 	Mobile:
 		Speed: 75
-		TurnSpeed: 5
+		TurnSpeed: 20
 	RevealsShroud:
 		Range: 5c768
 	Turreted:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		RealignDelay: 0
 	Armament:
 		Weapon: 80mm_A
@@ -578,7 +578,7 @@ combat_tank_o:
 	Buildable:
 		Prerequisites: ~heavy.ordos_combat
 	Turreted:
-		TurnSpeed: 5
+		TurnSpeed: 20
 	Armament:
 		Weapon: 80mm_O
 	Mobile:

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -44,11 +44,11 @@
 	MinRange: 0c512
 	Projectile: Missile
 		Shadow: true
-		HorizontalRateOfTurn: 3
+		HorizontalRateOfTurn: 12
 		RangeLimit: 6c614
 		CruiseAltitude: 1c0
 		MinimumLaunchAngle: 64
-		VerticalRateOfTurn: 10
+		VerticalRateOfTurn: 40
 		Image: MISSILE2
 		TrailImage: large_trail
 		Speed: 288
@@ -104,7 +104,7 @@ TowerMissile:
 	BurstDelays: 60
 	ValidTargets: Ground, Air
 	Projectile: Missile
-		HorizontalRateOfTurn: 1
+		HorizontalRateOfTurn: 4
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: Ground, Air
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath

--- a/mods/ra/maps/bomber-john/rules.yaml
+++ b/mods/ra/maps/bomber-john/rules.yaml
@@ -123,7 +123,7 @@ MNLYR:
 		Type: Heavy
 	Mobile:
 		Speed: 128
-		TurnSpeed: 900
+		TurnSpeed: 512
 	RevealsShroud:
 		Range: 40c0
 	MustBeDestroyed:
@@ -131,7 +131,7 @@ MNLYR:
 	Transforms:
 		IntoActor: ftur
 		Offset: 0,0
-		Facing: 96
+		Facing: 384
 	CashTrickler:
 		Interval: 150
 		Amount: 20
@@ -147,7 +147,7 @@ FTUR:
 	Transforms:
 		IntoActor: mnlyr
 		Offset: 0,0
-		Facing: 96
+		Facing: 384
 	MustBeDestroyed:
 		RequiredForShortGame: true
 	CashTrickler:

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -161,7 +161,7 @@ MOBILETENT:
 	Transforms:
 		IntoActor: tent
 		Offset: 0,0
-		Facing: 96
+		Facing: 384
 		TransformSounds: placbldg.aud, build5.aud
 		NoTransformNotification: BuildingCannotPlaceAudio
 	RenderSprites:
@@ -328,7 +328,7 @@ V2RL:
 	RevealsShroud:
 		Range: 14c0
 	Turreted:
-		TurnSpeed: 1
+		TurnSpeed: 4
 	Armament@PRIMARY:
 		Recoil: 8
 		RecoilRecovery: 0c7

--- a/mods/ra/maps/fort-lonestar/weapons.yaml
+++ b/mods/ra/maps/fort-lonestar/weapons.yaml
@@ -30,7 +30,7 @@ MammothTusk:
 		TrailImage: smokey
 		ContrailLength: 150
 		Inaccuracy: 0c853
-		HorizontalRateOfTurn: 10
+		HorizontalRateOfTurn: 40
 		RangeLimit: 12c0
 	Warhead@1Dam: SpreadDamage
 		Spread: 640

--- a/mods/ra/maps/monster-tank-madness/rules.yaml
+++ b/mods/ra/maps/monster-tank-madness/rules.yaml
@@ -141,7 +141,7 @@ PBOX:
 	ExternalCondition@friendly:
 		Condition: friendly
 	Turreted:
-		TurnSpeed: 1
+		TurnSpeed: 4
 	Armament@PRIMARY:
 		Weapon: SuperTankPrimary
 		LocalOffset: 900,180,340, 900,-180,340

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -7,7 +7,7 @@ BADR:
 		HP: 30000
 	Aircraft:
 		CruiseAltitude: 2560
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 180
 		Repulsable: False
 		MaximumPitch: 56
@@ -84,8 +84,8 @@ MIG:
 		OpportunityFire: False
 	Aircraft:
 		CruiseAltitude: 2560
-		InitialFacing: 192
-		TurnSpeed: 4
+		InitialFacing: 768
+		TurnSpeed: 16
 		Speed: 223
 		RepulsionSpeed: 40
 		MaximumPitch: 56
@@ -158,8 +158,8 @@ YAK:
 		OpportunityFire: False
 	Aircraft:
 		CruiseAltitude: 2560
-		InitialFacing: 192
-		TurnSpeed: 4
+		InitialFacing: 768
+		TurnSpeed: 16
 		Speed: 178
 		RepulsionSpeed: 40
 		MaximumPitch: 56
@@ -216,7 +216,7 @@ TRAN:
 		Range: 6c0
 		Type: GroundPosition
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 128
 		AltitudeVelocity: 0c58
 	WithIdleOverlay@ROTOR1AIR:
@@ -283,7 +283,7 @@ HELI:
 		AttackType: Hover
 		OpportunityFire: False
 	Aircraft:
-		TurnSpeed: 4
+		TurnSpeed: 16
 		Speed: 149
 	AutoTarget:
 		InitialStance: HoldFire
@@ -356,7 +356,7 @@ HIND:
 		AttackType: Hover
 		OpportunityFire: False
 	Aircraft:
-		TurnSpeed: 4
+		TurnSpeed: 16
 		Speed: 112
 	AutoTarget:
 		InitialStance: HoldFire
@@ -396,7 +396,7 @@ U2:
 		Name: Spy Plane
 	Aircraft:
 		CruiseAltitude: 2560
-		TurnSpeed: 7
+		TurnSpeed: 28
 		Speed: 373
 		Repulsable: False
 		MaximumPitch: 56
@@ -458,7 +458,7 @@ MH60:
 		PersistentTargeting: false
 		AttackType: Hover
 	Aircraft:
-		TurnSpeed: 4
+		TurnSpeed: 16
 		Speed: 112
 	AutoTarget:
 		InitialStance: HoldFire

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -241,7 +241,7 @@
 	Mobile:
 		PauseOnCondition: being-captured
 		Locomotor: wheeled
-		TurnSpeed: 5
+		TurnSpeed: 20
 	Selectable:
 		Bounds: 24, 24
 	Targetable:
@@ -609,7 +609,7 @@
 		VTOL: true
 		LandableTerrainTypes: Clear, Rough, Road, Ore, Beach, Gems
 		Crushes: crate, mine, infantry
-		InitialFacing: 224
+		InitialFacing: 896
 		CanSlide: True
 	GpsDot:
 		String: Helicopter

--- a/mods/ra/rules/husks.yaml
+++ b/mods/ra/rules/husks.yaml
@@ -102,7 +102,7 @@ TRAN.Husk:
 	Tooltip:
 		Name: Chinook
 	Aircraft:
-		TurnSpeed: 4
+		TurnSpeed: 16
 		Speed: 149
 	WithIdleOverlay@PRIMARY:
 		Offset: -597,0,341
@@ -146,7 +146,7 @@ BADR.Husk:
 	Tooltip:
 		Name: Badger
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 149
 	SmokeTrailWhenDamaged@0:
 		Offset: -432,560,0
@@ -169,7 +169,7 @@ MIG.Husk:
 	Contrail@2:
 		Offset: -598,683,0
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 186
 	SmokeTrailWhenDamaged:
 		Offset: -853,0,171
@@ -193,7 +193,7 @@ YAK.Husk:
 	Contrail:
 		Offset: -853,0,0
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 149
 	SmokeTrailWhenDamaged:
 		Offset: -853,0,0
@@ -215,7 +215,7 @@ HELI.Husk:
 	Tooltip:
 		Name: Longbow
 	Aircraft:
-		TurnSpeed: 4
+		TurnSpeed: 16
 		Speed: 149
 	WithIdleOverlay:
 		Offset: 0,0,85
@@ -239,7 +239,7 @@ HIND.Husk:
 	Tooltip:
 		Name: Hind
 	Aircraft:
-		TurnSpeed: 4
+		TurnSpeed: 16
 		Speed: 112
 	WithIdleOverlay:
 		Sequence: rotor
@@ -262,7 +262,7 @@ U2.Husk:
 	Tooltip:
 		Name: Husk (Spy Plane)
 	Aircraft:
-		TurnSpeed: 7
+		TurnSpeed: 28
 		Speed: 373
 	Contrail@1:
 		Offset: -725,683,0
@@ -451,7 +451,7 @@ MH60.Husk:
 	Tooltip:
 		Name: Black Hawk
 	Aircraft:
-		TurnSpeed: 4
+		TurnSpeed: 16
 		Speed: 112
 	WithIdleOverlay:
 		Sequence: rotor

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -752,7 +752,7 @@ Ant:
 		HP: 75000
 	Mobile:
 		Speed: 99
-		TurnSpeed: 12
+		TurnSpeed: 48
 		Locomotor: lighttracked
 	-Crushable:
 	AutoTarget:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -18,7 +18,7 @@ SS:
 	Armor:
 		Type: Light
 	Mobile:
-		TurnSpeed: 4
+		TurnSpeed: 16
 		Speed: 71
 	RevealsShroud:
 		MinRange: 5c0
@@ -84,7 +84,7 @@ MSUB:
 	Armor:
 		Type: Light
 	Mobile:
-		TurnSpeed: 3
+		TurnSpeed: 12
 		Speed: 42
 	RevealsShroud:
 		MinRange: 5c0
@@ -155,7 +155,7 @@ DD:
 	Armor:
 		Type: Heavy
 	Mobile:
-		TurnSpeed: 7
+		TurnSpeed: 28
 		Speed: 85
 	RevealsShroud:
 		MinRange: 5c0
@@ -164,7 +164,7 @@ DD:
 	RevealsShroud@GAPGEN:
 		Range: 5c0
 	Turreted:
-		TurnSpeed: 7
+		TurnSpeed: 28
 		Offset: 469,0,128
 	Armament@PRIMARY:
 		Weapon: Stinger
@@ -207,7 +207,7 @@ CA:
 	Armor:
 		Type: Heavy
 	Mobile:
-		TurnSpeed: 3
+		TurnSpeed: 12
 		Speed: 42
 	RevealsShroud:
 		MinRange: 5c0
@@ -218,11 +218,11 @@ CA:
 	Turreted@PRIMARY:
 		Turret: primary
 		Offset: -896,0,128
-		TurnSpeed: 3
+		TurnSpeed: 12
 	Turreted@SECONDARY:
 		Turret: secondary
 		Offset: 768,0,128
-		TurnSpeed: 3
+		TurnSpeed: 12
 	Armament@PRIMARY:
 		Turret: primary
 		Weapon: 8Inch
@@ -309,7 +309,7 @@ PT:
 	Armor:
 		Type: Heavy
 	Mobile:
-		TurnSpeed: 7
+		TurnSpeed: 28
 		Speed: 128
 	RevealsShroud:
 		MinRange: 5c0
@@ -318,7 +318,7 @@ PT:
 	RevealsShroud@GAPGEN:
 		Range: 5c0
 	Turreted:
-		TurnSpeed: 7
+		TurnSpeed: 28
 		Offset: 512,0,0
 	Armament@PRIMARY:
 		Weapon: 2Inch

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -154,49 +154,49 @@ SPEN:
 	Exit@1:
 		RequiresCondition: !being-captured
 		SpawnOffset: 0,-213,0
-		Facing: 96
+		Facing: 384
 		ExitCell: -1,2
 		ProductionTypes: Submarine
 	Exit@2:
 		RequiresCondition: !being-captured
 		SpawnOffset: 0,-213,0
-		Facing: 160
+		Facing: 640
 		ExitCell: 3,2
 		ProductionTypes: Submarine
 	Exit@3:
 		RequiresCondition: !being-captured
 		SpawnOffset: 0,0,0
-		Facing: 32
+		Facing: 128
 		ExitCell: 0,0
 		ProductionTypes: Submarine
 	Exit@4:
 		RequiresCondition: !being-captured
 		SpawnOffset: 0,0,0
-		Facing: 224
+		Facing: 896
 		ExitCell: 2,0
 		ProductionTypes: Submarine
 	Exit@b1:
 		RequiresCondition: !being-captured
 		SpawnOffset: -1024,1024,0
-		Facing: 160
+		Facing: 640
 		ExitCell: 0,2
 		ProductionTypes: Ship
 	Exit@b2:
 		RequiresCondition: !being-captured
 		SpawnOffset: 1024,1024,0
-		Facing: 224
+		Facing: 896
 		ExitCell: 2,2
 		ProductionTypes: Ship
 	Exit@b3:
 		RequiresCondition: !being-captured
 		SpawnOffset: -1024,-1024,0
-		Facing: 96
+		Facing: 384
 		ExitCell: 0,0
 		ProductionTypes: Ship
 	Exit@b4:
 		RequiresCondition: !being-captured
 		SpawnOffset: 1024,-1024,0
-		Facing: 32
+		Facing: 128
 		ExitCell: 2,0
 		ProductionTypes: Ship
 	Production:
@@ -292,25 +292,25 @@ SYRD:
 	Exit@1:
 		RequiresCondition: !being-captured
 		SpawnOffset: -1024,1024,0
-		Facing: 160
+		Facing: 640
 		ExitCell: 0,2
 		ProductionTypes: Ship, Boat
 	Exit@2:
 		RequiresCondition: !being-captured
 		SpawnOffset: 1024,1024,0
-		Facing: 224
+		Facing: 896
 		ExitCell: 2,2
 		ProductionTypes: Ship, Boat
 	Exit@3:
 		RequiresCondition: !being-captured
 		SpawnOffset: -1024,-1024,0
-		Facing: 96
+		Facing: 384
 		ExitCell: 0,0
 		ProductionTypes: Ship, Boat
 	Exit@4:
 		RequiresCondition: !being-captured
 		SpawnOffset: 1024,-1024,0
-		Facing: 32
+		Facing: 128
 		ExitCell: 2,0
 		ProductionTypes: Ship, Boat
 	Production:
@@ -601,8 +601,8 @@ AGUN:
 	WithBuildingBib:
 		HasMinibib: true
 	Turreted:
-		TurnSpeed: 15
-		InitialFacing: 224
+		TurnSpeed: 60
+		InitialFacing: 896
 	-WithSpriteBody:
 	WithEmbeddedTurretSpriteBody:
 	Armament:
@@ -699,7 +699,7 @@ PBOX:
 	WithBuildingBib:
 		HasMinibib: true
 	Turreted:
-		TurnSpeed: 255
+		TurnSpeed: 512
 	-QuantizeFacingsFromSequence:
 	BodyOrientation:
 		QuantizedFacings: 8
@@ -761,7 +761,7 @@ HBOX:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical
 	Turreted:
-		TurnSpeed: 255
+		TurnSpeed: 512
 	-QuantizeFacingsFromSequence:
 	BodyOrientation:
 		QuantizedFacings: 8
@@ -815,8 +815,8 @@ GUN:
 	WithBuildingBib:
 		HasMinibib: true
 	Turreted:
-		TurnSpeed: 12
-		InitialFacing: 56
+		TurnSpeed: 48
+		InitialFacing: 224
 	-WithSpriteBody:
 	WithEmbeddedTurretSpriteBody:
 	Armament:
@@ -859,7 +859,7 @@ FTUR:
 	WithBuildingBib:
 		HasMinibib: true
 	Turreted:
-		TurnSpeed: 255
+		TurnSpeed: 512
 		Offset: 0,0,112
 	Armament:
 		Weapon: FireballLauncher
@@ -914,7 +914,7 @@ SAM:
 	WithBuildingBib:
 		HasMinibib: true
 	Turreted:
-		TurnSpeed: 30
+		TurnSpeed: 120
 		InitialFacing: 0
 	-WithSpriteBody:
 	WithEmbeddedTurretSpriteBody:
@@ -1158,7 +1158,7 @@ FACT:
 		PauseOnCondition: chrono-vortex || being-captured || being-demolished || build-incomplete
 		IntoActor: mcv
 		Offset: 1,1
-		Facing: 96
+		Facing: 384
 	TransformsIntoMobile:
 		RequiresCondition: factundeploy
 		Locomotor: heavywheeled
@@ -1238,7 +1238,7 @@ PROC:
 	RevealsShroud@GAPGEN:
 		Range: 4c0
 	Refinery:
-		DockAngle: 64
+		DockAngle: 256
 		DockOffset: 1,2
 	StoresResources:
 		Capacity: 2000
@@ -1247,7 +1247,7 @@ PROC:
 	FreeActor:
 		Actor: HARV
 		SpawnOffset: 1,2
-		Facing: 64
+		Facing: 256
 	InfiltrateForCash:
 		Percentage: 50
 		Types: SpyInfiltrate, ThiefInfiltrate
@@ -1373,7 +1373,7 @@ HPAD:
 		RequiresCondition: !being-captured
 		SpawnOffset: 0,-256,0
 		ExitCell: 0,0
-		Facing: 224
+		Facing: 896
 	RallyPoint:
 	Production:
 		Produces: Aircraft, Helicopter
@@ -1454,7 +1454,7 @@ AFLD:
 	Exit@1:
 		RequiresCondition: !being-captured
 		ExitCell: 1,1
-		Facing: 192
+		Facing: 768
 	RallyPoint:
 	Production:
 		Produces: Aircraft, Plane

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -76,7 +76,7 @@ V2RL:
 	RevealsShroud@GAPGEN:
 		Range: 4c0
 	Turreted:
-		TurnSpeed: 7
+		TurnSpeed: 28
 	Armament:
 		Weapon: 25mm
 		Recoil: 85
@@ -120,7 +120,7 @@ V2RL:
 	RevealsShroud@GAPGEN:
 		Range: 4c0
 	Turreted:
-		TurnSpeed: 5
+		TurnSpeed: 20
 	Armament:
 		Weapon: 90mm
 		Recoil: 128
@@ -166,7 +166,7 @@ V2RL:
 	RevealsShroud@GAPGEN:
 		Range: 4c0
 	Turreted:
-		TurnSpeed: 5
+		TurnSpeed: 20
 	Armament:
 		Weapon: 105mm
 		Recoil: 128
@@ -213,7 +213,7 @@ V2RL:
 	RevealsShroud@GAPGEN:
 		Range: 4c0
 	Turreted:
-		TurnSpeed: 2
+		TurnSpeed: 8
 	Armament@PRIMARY:
 		Weapon: 120mm
 		LocalOffset: 900,180,340, 900,-180,340
@@ -262,7 +262,7 @@ ARTY:
 	Armor:
 		Type: Light
 	Mobile:
-		TurnSpeed: 2
+		TurnSpeed: 8
 		Speed: 85
 		Locomotor: lighttracked
 	RevealsShroud:
@@ -374,7 +374,7 @@ MCV:
 	Transforms:
 		IntoActor: fact
 		Offset: -1,-1
-		Facing: 96
+		Facing: 384
 		TransformSounds: placbldg.aud, build5.aud
 		NoTransformNotification: BuildingCannotPlaceAudio
 	MustBeDestroyed:
@@ -406,7 +406,7 @@ JEEP:
 	Armor:
 		Type: Light
 	Mobile:
-		TurnSpeed: 10
+		TurnSpeed: 40
 		Speed: 170
 		PauseOnCondition: notmobile || being-captured
 	RevealsShroud:
@@ -416,7 +416,7 @@ JEEP:
 	RevealsShroud@GAPGEN:
 		Range: 4c0
 	Turreted:
-		TurnSpeed: 10
+		TurnSpeed: 40
 		Offset: 0,0,128
 	Armament:
 		Weapon: M60mg
@@ -681,7 +681,7 @@ FTRK:
 	Armor:
 		Type: Light
 	Mobile:
-		TurnSpeed: 10
+		TurnSpeed: 40
 		Speed: 118
 	RevealsShroud:
 		MinRange: 4c0
@@ -690,7 +690,7 @@ FTRK:
 	RevealsShroud@GAPGEN:
 		Range: 4c0
 	Turreted:
-		TurnSpeed: 10
+		TurnSpeed: 40
 		Offset: -298,0,298
 	Armament@AA:
 		Weapon: FLAK-23-AA
@@ -871,7 +871,7 @@ STNK:
 		Weapon: APTusk.stnk
 		LocalOffset: 192,0,176
 	Turreted:
-		TurnSpeed: 5
+		TurnSpeed: 20
 	AttackTurreted:
 	WithSpriteTurret:
 	Cargo:

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -12,7 +12,7 @@
 		Inaccuracy: 128
 		Image: DRAGON
 		Shadow: True
-		HorizontalRateOfTurn: 5
+		HorizontalRateOfTurn: 20
 		RangeLimit: 6c0
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
@@ -79,7 +79,7 @@ HellfireAG:
 	BurstDelays: 7
 	Projectile: Missile
 		Speed: 256
-		HorizontalRateOfTurn: 10
+		HorizontalRateOfTurn: 40
 		RangeLimit: 8c512
 	Warhead@1Dam: SpreadDamage
 		Damage: 6000
@@ -99,7 +99,7 @@ HellfireAA:
 	Projectile: Missile
 		Speed: 492
 		Inaccuracy: 128
-		HorizontalRateOfTurn: 25
+		HorizontalRateOfTurn: 100
 		RangeLimit: 7c0
 		CloseEnough: 0c600
 	Warhead@1Dam: SpreadDamage
@@ -119,7 +119,7 @@ MammothTusk:
 	ValidTargets: AirborneActor, Infantry
 	Projectile: Missile
 		Speed: 341
-		HorizontalRateOfTurn: 15
+		HorizontalRateOfTurn: 60
 		RangeLimit: 9c614
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
@@ -147,7 +147,7 @@ Nike:
 		Arm: 3
 		Inaccuracy: 0
 		Image: MISSILE
-		HorizontalRateOfTurn: 25
+		HorizontalRateOfTurn: 100
 		RangeLimit: 9c0
 		Speed: 341
 	Warhead@1Dam: SpreadDamage
@@ -164,7 +164,7 @@ RedEye:
 	ReloadDelay: 50
 	Projectile: Missile
 		Inaccuracy: 0
-		HorizontalRateOfTurn: 20
+		HorizontalRateOfTurn: 80
 		Speed: 298
 	Warhead@1Dam: SpreadDamage
 		Damage: 4000
@@ -182,7 +182,7 @@ Stinger:
 	Projectile: Missile
 		Arm: 3
 		Inaccuracy: 0
-		HorizontalRateOfTurn: 20
+		HorizontalRateOfTurn: 80
 		RangeLimit: 9c512
 		Speed: 170
 		CloseEnough: 149
@@ -212,7 +212,7 @@ APTusk:
 	Projectile: Missile
 		Speed: 298
 		TrailImage: smokey
-		HorizontalRateOfTurn: 10
+		HorizontalRateOfTurn: 40
 		RangeLimit: 7c204
 
 APTusk.stnk:
@@ -231,7 +231,7 @@ TorpTube:
 		Arm: 3
 		Speed: 85
 		TrailImage: bubbles
-		HorizontalRateOfTurn: 1
+		HorizontalRateOfTurn: 4
 		RangeLimit: 10c819
 		BoundToTerrainType: Water
 		Palette: shadow
@@ -265,7 +265,7 @@ TorpTube:
 	Projectile: Missile
 		Speed: 234
 		Inaccuracy: 0c614
-		HorizontalRateOfTurn: 15
+		HorizontalRateOfTurn: 60
 		RangeLimit: 9c0
 		Image: MISSILE
 		TrailImage: smokey

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -10,7 +10,7 @@ DPOD:
 		IdleBehavior: Land
 		Pitch: 0
 		Roll: 0
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 149
 		InitialFacing: 0
 	Health:
@@ -48,7 +48,7 @@ DPOD2:
 	Armor:
 		Type: Light
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 300
 		CruiseAltitude: 16c0
 		MaximumPitch: 110
@@ -96,7 +96,7 @@ DSHP:
 		IdleBehavior: Land
 		Pitch: 0
 		Roll: 0
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 168
 		InitialFacing: 0
 		TakeoffSounds: dropup1.aud
@@ -138,7 +138,7 @@ ORCA:
 	Selectable:
 		Bounds: 30,24
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 186
 		TakeoffSounds: orcaup1.aud
 		LandingSounds: orcadwn1.aud
@@ -200,7 +200,7 @@ ORCAB:
 		Bounds: 30,24
 	Aircraft:
 		CruiseAltitude: 5c512
-		TurnSpeed: 3
+		TurnSpeed: 12
 		Speed: 96
 		CruisingCondition: cruising
 		TakeoffSounds: orcaup1.aud
@@ -262,7 +262,7 @@ ORCATRAN:
 		Prerequisites: ~disabled
 	RenderSprites:
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 84
 		InitialFacing: 0
 		LandableTerrainTypes: Clear, Road, Rail, DirtRoad, Rough, Tiberium, BlueTiberium, Veins
@@ -304,7 +304,7 @@ TRNSPORT:
 		Prerequisites: ~gahpad, gadept
 		Description: VTOL aircraft capable of lifting\nand transporting vehicles.\n  Unarmed
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 149
 		InitialFacing: 0
 		Pitch: 0
@@ -354,7 +354,7 @@ SCRIN:
 		VoiceSet: Scrin
 	Aircraft:
 		CruiseAltitude: 5c0
-		TurnSpeed: 3
+		TurnSpeed: 12
 		Speed: 168
 		TakeoffSounds: dropup1.aud
 		LandingSounds: dropdwn1.aud
@@ -420,7 +420,7 @@ APACHE:
 		PitchSpeed: 8
 		Roll: 16
 		RollSpeed: 8
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 130
 		CanSlide: false
 		TakeOffOnResupply: true
@@ -480,7 +480,7 @@ HUNTER:
 	Armor:
 		Type: Light
 	Aircraft:
-		TurnSpeed: 16
+		TurnSpeed: 64
 		Speed: 355
 		Pitch: 0
 		Roll: 0

--- a/mods/ts/rules/civilian-structures.yaml
+++ b/mods/ts/rules/civilian-structures.yaml
@@ -1690,7 +1690,7 @@ GAICBM:
 	Transforms:
 		IntoActor: icbm
 		Offset: 1,1
-		Facing: 96
+		Facing: 384
 		TransformSounds: place2.aud
 		NoTransformSounds:
 	-WithDeathAnimation:

--- a/mods/ts/rules/civilian-vehicles.yaml
+++ b/mods/ts/rules/civilian-vehicles.yaml
@@ -9,7 +9,7 @@
 		Name: Mammoth Tank
 	Mobile:
 		Speed: 56
-		TurnSpeed: 5
+		TurnSpeed: 20
 	Health:
 		HP: 60000
 	Armor:
@@ -19,7 +19,7 @@
 		MaxHeightDelta: 3
 		RequiresCondition: !inside-tunnel
 	Turreted:
-		TurnSpeed: 3
+		TurnSpeed: 12
 	Armament@PRIMARY:
 		Weapon: 120mmx
 		LocalOffset: 707,85,509, 707,-120,509
@@ -77,7 +77,7 @@ ICBM:
 		Type: Light
 	Mobile:
 		Speed: 85
-		TurnSpeed: 5
+		TurnSpeed: 20
 	RevealsShroud:
 		RequiresCondition: !inside-tunnel
 		Range: 7c0
@@ -85,7 +85,7 @@ ICBM:
 	Transforms:
 		IntoActor: gaicbm
 		Offset: -1,-1
-		Facing: 96
+		Facing: 384
 		TransformSounds:
 		NoTransformSounds:
 		Voice: Move
@@ -98,7 +98,7 @@ BUS:
 	Tooltip:
 		Name: School Bus
 	Mobile:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 113
 		PauseOnCondition: empdisable || loading || being-captured || carried
 	Health:
@@ -124,7 +124,7 @@ PICK:
 	Tooltip:
 		Name: Pickup
 	Mobile:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 113
 		PauseOnCondition: empdisable || loading || being-captured || carried
 	Health:
@@ -150,7 +150,7 @@ CAR:
 	Tooltip:
 		Name: Automobile
 	Mobile:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 113
 		PauseOnCondition: empdisable || loading || being-captured || carried
 	Health:
@@ -176,7 +176,7 @@ WINI:
 	Tooltip:
 		Name: Recreational Vehicle
 	Mobile:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 113
 		PauseOnCondition: empdisable || loading || being-captured || carried
 	Health:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -760,7 +760,7 @@
 	Mobile:
 		PauseOnCondition: empdisable || being-captured || carried
 		Locomotor: wheeled
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Voice: Move
 	Selectable:
 		Bounds: 40,24
@@ -875,7 +875,7 @@
 		RepairActors: gadept
 		Voice: Move
 	Aircraft:
-		InitialFacing: 224
+		InitialFacing: 896
 		AirborneCondition: airborne
 		CruisingCondition: cruising
 		CruiseAltitude: 4c704
@@ -951,7 +951,7 @@
 	FallsToEarth:
 		Moves: true
 		Velocity: 112
-		MaximumSpinSpeed: 10
+		MaximumSpinSpeed: 40
 	HitShape:
 
 ^Visceroid:
@@ -965,7 +965,7 @@
 		Type: Light
 	Mobile:
 		Speed: 113
-		TurnSpeed: 16
+		TurnSpeed: 64
 		Locomotor: visceroid
 	Selectable:
 		Bounds: 26,26,0,-3
@@ -1114,7 +1114,7 @@
 	RenderSprites:
 	WithVoxelBody:
 	Mobile:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Voice: Move
 		Speed: 113
 		PauseOnCondition: empdisable

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -73,8 +73,8 @@ GACTWR:
 	DetectCloaked:
 		RequiresCondition: !empdisable && !disabled && (tower.vulcan || tower.rocket || tower.sam)
 	Turreted:
-		TurnSpeed: 10
-		InitialFacing: 224
+		TurnSpeed: 40
+		InitialFacing: 896
 	AttackTurreted:
 		RequiresCondition: !build-incomplete && (tower.vulcan || tower.rocket || tower.sam)
 		PauseOnCondition: empdisable || disabled

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -14,7 +14,7 @@ APC:
 		Prerequisites: ~gaweap, gapile, ~techlevel.medium
 		Description: Armored infantry transport.\nCan move on water.\n  Unarmed
 	Mobile:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 113
 		PauseOnCondition: empdisable || loading || being-captured || carried
 		Locomotor: amphibious
@@ -81,7 +81,7 @@ HVR:
 		Weapon: HoverMissile
 		LocalOffset: 0,242,543, 0,-242,543
 	Turreted:
-		TurnSpeed: 7
+		TurnSpeed: 28
 		Offset: -128,0,85
 	AttackTurreted:
 		Voice: Attack
@@ -120,7 +120,7 @@ SMECH:
 		Prerequisites: ~gaweap, ~techlevel.low
 		Description: Anti-personnel walker.\n  Strong vs Infantry, Light armor\n  Weak vs Vehicles, Aircraft
 	Mobile:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 99
 		AlwaysTurnInPlace: true
 	Health:
@@ -168,7 +168,7 @@ MMCH:
 		Prerequisites: ~gaweap, ~techlevel.medium
 		Description: General purpose mechanized walker.\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
 	Mobile:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 56
 		AlwaysTurnInPlace: true
 	Health:
@@ -188,7 +188,7 @@ MMCH:
 		MoveSequence: walk
 		ValidMovementTypes: Horizontal, Turn
 	Turreted:
-		TurnSpeed: 5
+		TurnSpeed: 20
 	AttackTurreted:
 		Voice: Attack
 		PauseOnCondition: empdisable
@@ -232,7 +232,7 @@ HMEC:
 		BuildLimit: 1
 		Description: Slow heavy walker.\nArmed with dual railguns and rocket launchers.\n  Strong vs Infantry, Vehicles, Aircraft and Buildings\n  Weak vs Nothing\nMaximum 1 can be built.
 	Mobile:
-		TurnSpeed: 3
+		TurnSpeed: 12
 		Speed: 42
 	Health:
 		HP: 80000
@@ -280,7 +280,7 @@ SONIC:
 	Targetable:
 		TargetTypes: Ground, Vehicle, Disruptor
 	Mobile:
-		TurnSpeed: 4
+		TurnSpeed: 16
 		Speed: 56
 	Health:
 		HP: 50000
@@ -298,7 +298,7 @@ SONIC:
 		PauseOnCondition: empdisable
 		OpportunityFire: False
 	Turreted:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Offset: -170,0,0
 	WithVoxelTurret:
 	Explodes:
@@ -333,7 +333,7 @@ JUGG:
 		Type: Light
 	Mobile:
 		Speed: 71
-		TurnSpeed: 5
+		TurnSpeed: 20
 		AlwaysTurnInPlace: true
 		ImmovableCondition: !undeployed
 		RequireForceMoveCondition: !undeployed
@@ -359,7 +359,7 @@ JUGG:
 		UndeployedCondition: undeployed
 		UndeployOnMove: true
 		UndeployOnPickup: true
-		Facing: 96
+		Facing: 384
 		AllowedTerrainTypes: Clear, Road, DirtRoad, Rough
 		DeploySounds: place2.aud
 		UndeploySounds: clicky1.aud
@@ -379,8 +379,8 @@ JUGG:
 		Name: deployedbody
 	Turreted:
 		Turret: deployed
-		TurnSpeed: 5
-		InitialFacing: 96
+		TurnSpeed: 20
+		InitialFacing: 384
 		Offset: -153,-17,633
 		RealignDelay: -1
 	WithVoxelBarrel:

--- a/mods/ts/rules/husks.yaml
+++ b/mods/ts/rules/husks.yaml
@@ -3,7 +3,7 @@ DSHP.Husk:
 	Tooltip:
 		Name: Dropship
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 168
 	-RenderSprites:
 	RenderVoxels:
@@ -14,7 +14,7 @@ ORCA.Husk:
 	Tooltip:
 		Name: Orca Fighter
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 186
 	RenderSprites:
 		Image: orca
@@ -30,10 +30,10 @@ ORCAB.Husk:
 	Tooltip:
 		Name: Orca Bomber
 	Aircraft:
-		TurnSpeed: 3
+		TurnSpeed: 12
 		Speed: 96
 	FallsToEarth:
-		MaximumSpinSpeed: 6
+		MaximumSpinSpeed: 24
 	RenderSprites:
 		Image: orcab
 	RenderVoxels:
@@ -48,7 +48,7 @@ ORCATRAN.Husk:
 	Tooltip:
 		Name: Orca Transport
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 84
 	RenderSprites:
 		Image: orcatran
@@ -64,7 +64,7 @@ TRNSPORT.Husk:
 	Tooltip:
 		Name: Carryall
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 149
 	RenderSprites:
 		Image: trnsport
@@ -80,10 +80,10 @@ SCRIN.Husk:
 	Tooltip:
 		Name: Banshee Fighter
 	Aircraft:
-		TurnSpeed: 3
+		TurnSpeed: 12
 		Speed: 168
 	FallsToEarth:
-		MaximumSpinSpeed: 6
+		MaximumSpinSpeed: 24
 	RenderSprites:
 		Image: scrin
 	RenderVoxels:
@@ -98,7 +98,7 @@ APACHE.Husk:
 	Tooltip:
 		Name: Harpy
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 130
 	WithIdleOverlay:
 		Offset: 85,0,598

--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -31,9 +31,9 @@ waypoint:
 mmch.colorpicker:
 	Inherits: MMCH
 	Mobile:
-		InitialFacing: 160
+		InitialFacing: 640
 	Turreted:
-		InitialFacing: 160
+		InitialFacing: 640
 	WithFacingSpriteBody:
 		Sequence: walk
 	-Buildable:

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -522,7 +522,7 @@ NAWAST:
 		Range: 6c0
 		MaxHeightDelta: 3
 	TiberianSunRefinery:
-		DockAngle: 160
+		DockAngle: 640
 		DockOffset: 2,1
 	StoresResources:
 		Capacity: 56
@@ -531,7 +531,7 @@ NAWAST:
 	FreeActor:
 		Actor: WEED
 		SpawnOffset: 3,1
-		Facing: 160
+		Facing: 640
 	WithIdleOverlay@GLOW:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-glow

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -163,8 +163,8 @@ NALASR:
 	DetectCloaked:
 		Range: 3c0
 	Turreted:
-		TurnSpeed: 10
-		InitialFacing: 224
+		TurnSpeed: 40
+		InitialFacing: 896
 		Offset: 298,-171,288
 	AttackTurreted:
 		RequiresCondition: !build-incomplete
@@ -247,8 +247,8 @@ NASAM:
 	RenderRangeCircle:
 		RangeCircleType: aa
 	Turreted:
-		TurnSpeed: 10
-		InitialFacing: 224
+		TurnSpeed: 40
+		InitialFacing: 896
 	AttackTurreted:
 		RequiresCondition: !build-incomplete
 		PauseOnCondition: empdisable || disabled

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -15,7 +15,7 @@ BGGY:
 		Prerequisites: ~naweap, ~techlevel.low
 		Description: Fast scout and anti-infantry vehicle.\n  Strong vs Infantry, Light armor\n  Weak vs Vehicles, Aircraft
 	Mobile:
-		TurnSpeed: 8
+		TurnSpeed: 32
 		Speed: 142
 	Health:
 		HP: 22000
@@ -55,7 +55,7 @@ BIKE:
 		Prerequisites: ~naweap, ~techlevel.low
 		Description: Fast scout vehicle, armed with\nrockets.\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
 	Mobile:
-		TurnSpeed: 8
+		TurnSpeed: 32
 		Speed: 170
 	Health:
 		HP: 15000
@@ -102,7 +102,7 @@ TTNK:
 		Prerequisites: ~naweap, ~techlevel.medium
 		Description: Nod's main battle tank.\nCan deploy to gain extra protection.\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
 	Mobile:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 85
 		ImmovableCondition: !undeployed
 		RequireForceMoveCondition: !undeployed
@@ -137,7 +137,7 @@ TTNK:
 		UndeployedCondition: undeployed
 		UndeployOnMove: true
 		UndeployOnPickup: true
-		Facing: 160
+		Facing: 640
 		AllowedTerrainTypes: Clear, Road, DirtRoad, Rough
 		DeploySounds: place2.aud
 		UndeploySounds: clicky1.aud
@@ -159,9 +159,9 @@ TTNK:
 		RequiresCondition: undeployed
 		PauseOnCondition: empdisable
 	Turreted:
-		TurnSpeed: 6
+		TurnSpeed: 24
 		Turret: deployed
-		InitialFacing: 160
+		InitialFacing: 640
 		Offset: -20, -130, 128
 		RealignDelay: -1
 	WithVoxelBarrel:
@@ -232,7 +232,7 @@ ART2:
 		Type: Light
 	Mobile:
 		Speed: 71
-		TurnSpeed: 2
+		TurnSpeed: 8
 		ImmovableCondition: !undeployed
 		RequireForceMoveCondition: !undeployed
 	RevealsShroud:
@@ -250,7 +250,7 @@ ART2:
 		UndeployedCondition: undeployed
 		UndeployOnMove: true
 		UndeployOnPickup: true
-		Facing: 96
+		Facing: 384
 		AllowedTerrainTypes: Clear, Road, DirtRoad, Rough
 		DeploySounds: place2.aud
 		UndeploySounds: clicky1.aud
@@ -269,8 +269,8 @@ ART2:
 		RequiresCondition: !undeployed && real-actor
 	Turreted:
 		Turret: deployed
-		TurnSpeed: 5
-		InitialFacing: 96
+		TurnSpeed: 20
+		InitialFacing: 384
 		Offset: 0,0,256
 		RealignDelay: -1
 	WithVoxelBarrel:
@@ -320,7 +320,7 @@ REPAIR:
 		HP: 20000
 	Mobile:
 		Speed: 85
-		TurnSpeed: 5
+		TurnSpeed: 20
 	RevealsShroud:
 		RequiresCondition: !inside-tunnel
 		Range: 5c0
@@ -365,7 +365,7 @@ WEED:
 		DeliverVoice: Move
 	Mobile:
 		Speed: 71
-		TurnSpeed: 5
+		TurnSpeed: 20
 	Health:
 		HP: 60000
 	SelfHealing:
@@ -407,7 +407,7 @@ SAPC:
 		Prerequisites: ~naweap, natech, ~techlevel.medium
 		Description: Troop transport that can move\nunderground to avoid detection.\n  Unarmed
 	Mobile:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 71
 		PauseOnCondition: empdisable || loading || being-captured || carried
 		Locomotor: subterranean
@@ -459,7 +459,7 @@ SUBTANK:
 		Prerequisites: ~naweap, natech, ~techlevel.high
 		Description: Subterranean Flame Tank.\nIs able to move underground.\n  Strong vs Infantry, Buildings\n  Weak vs Tanks, Aircraft
 	Mobile:
-		TurnSpeed: 6
+		TurnSpeed: 24
 		Speed: 71
 		Locomotor: subterranean
 	Health:
@@ -509,7 +509,7 @@ STNK:
 		Queue: Vehicle
 		Description: Lightly armoured tank equipped with a personal\nstealth generator. Armed with missiles.\nCan be spotted by infantry at close range.\n  Strong vs Vehicles, Aircraft\n  Weak vs Infantry
 	Mobile:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 85
 	Health:
 		HP: 18000

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -32,7 +32,7 @@ GACNST:
 		PauseOnCondition: empdisable || being-demolished || build-incomplete
 		IntoActor: mcv
 		Offset: 1,1
-		Facing: 96
+		Facing: 384
 		DeployCursor: undeploy
 	TransformsIntoMobile:
 		RequiresCondition: factundeploy
@@ -105,7 +105,7 @@ PROC:
 		Range: 6c0
 		MaxHeightDelta: 3
 	TiberianSunRefinery:
-		DockAngle: 160
+		DockAngle: 640
 		DockOffset: 2,1
 		DiscardExcessResources: true
 	StoresResources:
@@ -115,7 +115,7 @@ PROC:
 	FreeActor:
 		Actor: HARV
 		SpawnOffset: 2,1
-		Facing: 160
+		Facing: 640
 	WithIdleOverlay@REDLIGHTS:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-redlights

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -21,8 +21,8 @@ NAPULS:
 	RevealsShroud:
 		Range: 8c0
 	Turreted:
-		TurnSpeed: 10
-		InitialFacing: 224
+		TurnSpeed: 40
+		InitialFacing: 896
 	AttackTurreted:
 		RequiresCondition: !build-incomplete && !empdisable && !disabled
 	Armament:

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -30,7 +30,7 @@ MCV:
 		PauseOnCondition: empdisable || being-captured
 		IntoActor: gacnst
 		Offset: -1,-1
-		Facing: 96
+		Facing: 384
 		TransformSounds: place2.aud
 		NoTransformSounds:
 		Voice: Move
@@ -134,7 +134,7 @@ LPST:
 		Type: Wood
 	Mobile:
 		Speed: 85
-		TurnSpeed: 5
+		TurnSpeed: 20
 		ImmovableCondition: !undeployed
 		RequireForceMoveCondition: !undeployed
 	RevealsShroud:
@@ -159,7 +159,7 @@ LPST:
 		UndeployedCondition: undeployed
 		UndeployOnMove: true
 		UndeployOnPickup: true
-		Facing: 160
+		Facing: 640
 		AllowedTerrainTypes: Clear, Road, DirtRoad, Rough
 		DeploySounds: place2.aud
 		UndeploySounds: clicky1.aud

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -117,7 +117,7 @@ CyCannon:
 	Projectile: Missile
 		MaximumLaunchSpeed: 192
 		Blockable: false
-		HorizontalRateOfTurn: 2
+		HorizontalRateOfTurn: 8
 		Shadow: true
 		Image: TORPEDO
 		MinimumLaunchSpeed: 75

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -11,7 +11,7 @@
 		Image: DRAGON
 		TrailImage: small_smoke_trail
 		TrailPalette: effectalpha75
-		HorizontalRateOfTurn: 25
+		HorizontalRateOfTurn: 100
 		RangeLimit: 15c0
 		Palette: ra
 		MinimumLaunchSpeed: 75
@@ -19,7 +19,7 @@
 		Acceleration: 96
 		MinimumLaunchAngle: 128
 		MaximumLaunchAngle: 192
-		VerticalRateOfTurn: 25
+		VerticalRateOfTurn: 100
 		CruiseAltitude: 5c512
 		AllowSnapping: true
 		TerrainHeightAware: true
@@ -128,7 +128,7 @@ RedEye2:
 	ValidTargets: Air
 	Projectile: Missile
 		Arm: 1
-		VerticalRateOfTurn: 35
+		VerticalRateOfTurn: 140
 		RangeLimit: 25c0
 		Speed: 288
 	Warhead@1Dam: SpreadDamage

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -10,7 +10,7 @@ MultiCluster:
 		MaximumLaunchAngle: 255
 		RangeLimit: 10c0
 		AllowSnapping: false
-		VerticalRateOfTurn: 16
+		VerticalRateOfTurn: 64
 	Warhead@1Dam: SpreadDamage
 		Spread: 216
 		Damage: 13000


### PR DESCRIPTION
This PR takes one of the final steps to completing the facing &rarr; WAngle conversion. Now only turrets, missiles, and a couple of other small pieces are left using the old system.

Closes #15196.

I have converted everything that ran through `WAngle.FromFacing` - it is possible that I have missed one or two things that kept everything as integers, but all the previous PRs have hopefully already removed those cases.