### PR TITLE
Aircraft kinematics part 4: Add angular acceleration to aircraft.

### DIFF
--- a/OpenRA.Game/WAngle.cs
+++ b/OpenRA.Game/WAngle.cs
@@ -71,6 +71,23 @@ namespace OpenRA
 			return new WAngle(Angle - 512).Tan();
 		}
 
+		public WAngle Clamp(WAngle min, WAngle max)
+		{
+			// Wrap around.
+			var a = min.Angle;
+			var b = max.Angle;
+			var angle = Angle;
+			if (a > b)
+			{
+				b += 1024;
+
+				if (angle < 512)
+					angle += 1024;
+			}
+
+			return new WAngle(angle.Clamp(a, b));
+		}
+
 		public static WAngle Lerp(WAngle a, WAngle b, int mul, int div)
 		{
 			// Map 1024 <-> 0 wrapping into linear space

--- a/OpenRA.Game/WAngle.cs
+++ b/OpenRA.Game/WAngle.cs
@@ -48,6 +48,9 @@ namespace OpenRA
 
 		public int Facing { get { return Angle / 4; } }
 
+		// Angle in the domain (-512, +512]
+		public int Angle2 { get { return Angle > 512 ? Angle - 1024 : Angle; } }
+
 		public int Sin() { return new WAngle(Angle - 256).Cos(); }
 
 		public int Cos()

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -73,13 +73,13 @@ namespace OpenRA.Mods.Common.Activities
 			if (moveOverride.HasValue)
 				move = moveOverride.Value;
 
-			var flightTurnSpeed = idleTurn ? aircraft.TurnSpeed : aircraft.IdleTurnSpeed ?? aircraft.TurnSpeed;
+			var flightTurnSpeed = idleTurn ? aircraft.Info.IdleTurnSpeed ?? aircraft.TurnSpeed : aircraft.TurnSpeed;
 			var flightFacing = Util.TickFacing(aircraft.FlightFacing, desiredFacing, flightTurnSpeed);
 
 			var bodyFacing = flightFacing;
 			if (aircraft.Info.CanSlide)
 			{
-				var bodyTurnSpeed = aircraft.BodyTurnSpeed ?? flightTurnSpeed;
+				var bodyTurnSpeed = aircraft.Info.BodyTurnSpeed ?? flightTurnSpeed;
 				bodyFacing = Util.TickFacing(aircraft.Facing, desiredBodyFacing ?? desiredFacing, bodyTurnSpeed);
 			}
 
@@ -116,8 +116,8 @@ namespace OpenRA.Mods.Common.Activities
 			var dat = self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition);
 			var move = WVec.Zero;
 
-			var flightTurnSpeed = idleTurn ? aircraft.IdleTurnSpeed ?? aircraft.TurnSpeed : aircraft.TurnSpeed;
-			var bodyTurnSpeed = aircraft.BodyTurnSpeed ?? flightTurnSpeed;
+			var flightTurnSpeed = idleTurn ? aircraft.Info.IdleTurnSpeed ?? aircraft.TurnSpeed : aircraft.TurnSpeed;
+			var bodyTurnSpeed = aircraft.Info.BodyTurnSpeed ?? flightTurnSpeed;
 			aircraft.Facing = Util.TickFacing(aircraft.Facing, desiredFacing, bodyTurnSpeed);
 
 			if (dat != desiredAltitude)

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -152,9 +152,6 @@ namespace OpenRA.Mods.Common.Activities
 				return false;
 			}
 
-			var delta = attackAircraft.GetTargetPosition(pos, target) - pos;
-			var desiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw : aircraft.Facing;
-
 			QueueChild(new TakeOff(self));
 
 			var minimumRange = attackAircraft.Info.AttackType == AirAttackType.Strafe ? WDist.Zero : attackAircraft.GetMinimumRangeVersusTarget(target);
@@ -171,7 +168,11 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Turn to face the target if required.
 			else if (!attackAircraft.TargetInFiringArc(self, target, 4 * attackAircraft.Info.FacingTolerance))
+			{
+				var delta = attackAircraft.GetTargetPosition(pos, target) - pos;
+				var desiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw : aircraft.Facing;
 				aircraft.Facing = Util.TickFacing(aircraft.Facing, desiredFacing, aircraft.TurnSpeed);
+			}
 
 			return false;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (checkTarget.IsInRange(pos, maxRange) && !checkTarget.IsInRange(pos, minRange))
 			{
 				if (!aircraft.Info.CanHover)
-					Fly.FlyTick(self, aircraft, aircraft.FlightFacing, aircraft.Info.CruiseAltitude);
+					Fly.FlyTick(self, aircraft, aircraft.Info.CruiseAltitude);
 
 				return useLastVisibleTarget;
 			}

--- a/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (checkTarget.IsInRange(pos, maxRange) && !checkTarget.IsInRange(pos, minRange))
 			{
 				if (!aircraft.Info.CanHover)
-					Fly.FlyTick(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);
+					Fly.FlyTick(self, aircraft, aircraft.FlightFacing, aircraft.Info.CruiseAltitude);
 
 				return useLastVisibleTarget;
 			}

--- a/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
@@ -48,10 +48,12 @@ namespace OpenRA.Mods.Common.Activities
 				foreach (var tickIdle in tickIdles)
 					tickIdle.TickIdle(self);
 
-			if (!aircraft.Info.CanHover)
+			if (aircraft.Info.IdleSpeed > 0 || (!aircraft.Info.CanHover && aircraft.Info.IdleSpeed < 0))
 			{
+				var speed = aircraft.Info.IdleSpeed < 0 ? aircraft.Info.Speed : aircraft.Info.IdleSpeed;
+
 				// This override is necessary, otherwise aircraft with CanSlide would circle sideways
-				var move = aircraft.FlyStep(aircraft.Facing);
+				var move = aircraft.FlyStep(speed, aircraft.Facing);
 
 				// We can't possibly turn this fast
 				var desiredFacing = aircraft.Facing + new WAngle(256);

--- a/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
@@ -48,13 +48,10 @@ namespace OpenRA.Mods.Common.Activities
 				foreach (var tickIdle in tickIdles)
 					tickIdle.TickIdle(self);
 
-			if (aircraft.Info.IdleSpeed > 0 || (!aircraft.Info.CanHover && aircraft.Info.IdleSpeed < 0))
-			{
-				// We can't possibly turn this fast
-				var desiredFacing = aircraft.FlightFacing + new WAngle(256);
-				Fly.FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, idleTurn: idleTurn,
-					desiredBodyFacing: aircraft.FlightFacing);
-			}
+			// We can't possibly turn this fast
+			var desiredFacing = aircraft.IdleSpeed > 0 ? aircraft.FlightFacing + new WAngle(256) : aircraft.FlightFacing;
+			Fly.FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, idleTurn: idleTurn,
+				desiredBodyFacing: aircraft.FlightFacing, desiredSpeed: aircraft.IdleSpeed);
 
 			return false;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
@@ -50,14 +50,10 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (aircraft.Info.IdleSpeed > 0 || (!aircraft.Info.CanHover && aircraft.Info.IdleSpeed < 0))
 			{
-				var speed = aircraft.Info.IdleSpeed < 0 ? aircraft.Info.Speed : aircraft.Info.IdleSpeed;
-
-				// This override is necessary, otherwise aircraft with CanSlide would circle sideways
-				var move = aircraft.FlyStep(speed, aircraft.Facing);
-
 				// We can't possibly turn this fast
 				var desiredFacing = aircraft.FlightFacing + new WAngle(256);
-				Fly.FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, move, idleTurn);
+				Fly.FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, idleTurn: idleTurn,
+					desiredBodyFacing: aircraft.FlightFacing);
 			}
 
 			return false;

--- a/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
@@ -49,9 +49,8 @@ namespace OpenRA.Mods.Common.Activities
 					tickIdle.TickIdle(self);
 
 			// We can't possibly turn this fast
-			var desiredFacing = aircraft.IdleSpeed > 0 ? aircraft.FlightFacing + new WAngle(256) : aircraft.FlightFacing;
-			Fly.FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, idleTurn: idleTurn,
-				desiredBodyFacing: aircraft.FlightFacing, desiredSpeed: aircraft.IdleSpeed);
+			Fly.FlyTick(self, aircraft, aircraft.Info.CruiseAltitude, desiredBodyFacing: aircraft.FlightFacing,
+				desiredSpeed: aircraft.IdleSpeed, desiredTurnSpeed: aircraft.IdleTurnSpeed);
 
 			return false;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Activities
 				var move = aircraft.FlyStep(speed, aircraft.Facing);
 
 				// We can't possibly turn this fast
-				var desiredFacing = aircraft.Facing + new WAngle(256);
+				var desiredFacing = aircraft.FlightFacing + new WAngle(256);
 				Fly.FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, move, idleTurn);
 			}
 

--- a/OpenRA.Mods.Common/Activities/Air/FlyTimed.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyTimed.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (IsCanceling || remainingTicks-- == 0)
 				return true;
 
-			Fly.FlyTick(self, aircraft, aircraft.Facing, cruiseAltitude);
+			Fly.FlyTick(self, aircraft, aircraft.FlightFacing, cruiseAltitude);
 
 			return false;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/FlyTimed.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyTimed.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (IsCanceling || remainingTicks-- == 0)
 				return true;
 
-			Fly.FlyTick(self, aircraft, aircraft.FlightFacing, cruiseAltitude);
+			Fly.FlyTick(self, aircraft, cruiseAltitude);
 
 			return false;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -138,7 +138,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				if ((pos - targetPosition).HorizontalLengthSquared != 0)
 				{
-					QueueChild(new Fly(self, Target.FromPos(targetPosition)));
+					QueueChild(new Fly(self, Target.FromPos(targetPosition), speed: 0));
 					return false;
 				}
 

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -138,7 +138,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				if ((pos - targetPosition).HorizontalLengthSquared != 0)
 				{
-					QueueChild(new Fly(self, Target.FromPos(targetPosition), speed: 0));
+					QueueChild(new Fly(self, Target.FromPos(targetPosition), speed: 0, facing: desiredFacing));
 					return false;
 				}
 

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -253,7 +253,7 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			var landingAlt = self.World.Map.DistanceAboveTerrain(targetPosition) + aircraft.LandAltitude;
-			Fly.FlyTick(self, aircraft, d.Yaw, landingAlt);
+			Fly.FlyTick(self, aircraft, landingAlt, d.Yaw);
 
 			return false;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
+++ b/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Activities
 					return false;
 				}
 
-				Fly.FlyTick(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);
+				Fly.FlyTick(self, aircraft, aircraft.FlightFacing, aircraft.Info.CruiseAltitude);
 				return false;
 			}
 

--- a/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
+++ b/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Activities
 					return false;
 				}
 
-				Fly.FlyTick(self, aircraft, aircraft.FlightFacing, aircraft.Info.CruiseAltitude);
+				Fly.FlyTick(self, aircraft, aircraft.Info.CruiseAltitude);
 				return false;
 			}
 

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -292,6 +292,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
+		public WAngle IdleTurnSpeed { get { return IdleSpeed > 0 ? (Info.IdleTurnSpeed ?? TurnSpeed) : WAngle.Zero; } }
 		public int Acceleration { get { return Info.Acceleration >= 0 ? Info.Acceleration : MovementSpeed; } }
 		public WAngle TurnAcceleration { get { return Info.TurnAcceleration ?? Info.TurnSpeed; } }
 		public WAngle BodyTurnAcceleration { get { return Info.BodyTurnAcceleration ?? TurnAcceleration; } }

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -50,13 +50,13 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int InitialFacing = 0;
 
 		[Desc("How fast can this actor change its flight direction?")]
-		public readonly int TurnSpeed = 255;
+		public readonly WAngle TurnSpeed = new WAngle(512);
 
-		[Desc("How fast can this actor change its body facing? defaults to TurnSpeed when -1. This parameter only applies to aircraft with CanSlide.")]
-		public readonly int BodyTurnSpeed = 255;
+		[Desc("How fast can this actor change its body facing? defaults to TurnSpeed if undefined. This parameter only applies to aircraft with CanSlide.")]
+		public readonly WAngle? BodyTurnSpeed = null;
 
-		[Desc("Turn speed to apply when aircraft flies in circles while idle. Defaults to TurnSpeed if negative.")]
-		public readonly int IdleTurnSpeed = -1;
+		[Desc("Turn speed to apply when aircraft flies in circles while idle. Defaults to TurnSpeed if undefined.")]
+		public readonly WAngle? IdleTurnSpeed = null;
 
 		[Desc("Maximum flight speed")]
 		public readonly int Speed = 1;
@@ -260,9 +260,7 @@ namespace OpenRA.Mods.Common.Traits
 		public WPos CenterPosition { get; private set; }
 
 		public CPos TopLeft { get { return self.World.Map.CellContaining(CenterPosition); } }
-		public WAngle TurnSpeed { get { return !IsTraitDisabled && !IsTraitPaused ? new WAngle(4 * Info.TurnSpeed) : WAngle.Zero; } }
-		public WAngle? IdleTurnSpeed { get { return Info.IdleTurnSpeed != -1 ? new WAngle(4 * Info.IdleTurnSpeed) : (WAngle?)null; } }
-		public WAngle? BodyTurnSpeed { get { return Info.BodyTurnSpeed != -1 ? new WAngle(4 * Info.BodyTurnSpeed) : (WAngle?)null; } }
+		public WAngle TurnSpeed { get { return !IsTraitDisabled && !IsTraitPaused ? Info.TurnSpeed : WAngle.Zero; } }
 
 		public Actor ReservedActor { get; private set; }
 		public bool MayYieldReservation { get; private set; }

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -68,10 +68,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Maximum acceleration/deceleration for forward movement. defaults to Speed if -1.")]
 		public readonly int Acceleration = -1;
 
-		[Desc("Body pitch when flying forwards. Only relevant for voxel aircraft.")]
+		[Desc("Maximum pitch offset when flying forwards at maximum speed. Only relevant for voxel aircraft.")]
 		public readonly WAngle Pitch = WAngle.Zero;
 
-		[Desc("Pitch steps to apply each tick when starting/stopping.")]
+		[Desc("Pitch steps to apply each tick when not moving forward.")]
 		public readonly WAngle PitchSpeed = WAngle.Zero;
 
 		[Desc("Body roll when turning. Only relevant for voxel aircraft.")]
@@ -258,7 +258,7 @@ namespace OpenRA.Mods.Common.Traits
 			set { orientation = orientation.WithRoll(value); }
 		}
 
-		public WRot Orientation { get { return orientation; } }
+		public WRot Orientation { get { return orientation; } set { orientation = value; } }
 
 		public WAngle FlightFacing { get; set; }
 		public int CurrentSpeed { get; set; }
@@ -452,9 +452,6 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				if (Info.Roll != WAngle.Zero && Roll != WAngle.Zero)
 					Roll = Util.TickFacing(Roll, WAngle.Zero, Info.RollSpeed);
-
-				if (Info.Pitch != WAngle.Zero && Pitch != WAngle.Zero)
-					Pitch = Util.TickFacing(Pitch, WAngle.Zero, Info.PitchSpeed);
 
 				FlightFacing = Facing;
 			}

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -54,7 +54,11 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Turn speed to apply when aircraft flies in circles while idle. Defaults to TurnSpeed if negative.")]
 		public readonly int IdleTurnSpeed = -1;
 
+		[Desc("Maximum flight speed")]
 		public readonly int Speed = 1;
+
+		[Desc("If non-negative, force the aircraft to move in circles at this speed when idle, ignoring CanHover.")]
+		public readonly int IdleSpeed = -1;
 
 		[Desc("Body pitch when flying forwards. Only relevant for voxel aircraft.")]
 		public readonly WAngle Pitch = WAngle.Zero;

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Traits
 			" Only relevant for voxel aircraft.")]
 		public readonly WAngle? IdleRoll = null;
 
-		[Desc("Roll steps to apply each tick when turning.")]
+		[Desc("Roll steps to apply each tick when not turning.")]
 		public readonly WAngle RollSpeed = WAngle.Zero;
 
 		[Desc("Minimum altitude where this aircraft is considered airborne.")]
@@ -461,12 +461,7 @@ namespace OpenRA.Mods.Common.Traits
 			CurrentMovementTypes = newMovementTypes;
 
 			if (!CurrentMovementTypes.HasFlag(MovementType.Horizontal))
-			{
-				if (Info.Roll != WAngle.Zero && Roll != WAngle.Zero)
-					Roll = Util.TickFacing(Roll, WAngle.Zero, Info.RollSpeed);
-
 				FlightFacing = Facing;
-			}
 
 			Repulse();
 		}

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -59,6 +59,12 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Turn speed to apply when aircraft flies in circles while idle. Defaults to TurnSpeed if undefined.")]
 		public readonly WAngle? IdleTurnSpeed = null;
 
+		[Desc("Maximum acceleration/deceleration for rotational movement. defaults to TurnSpeed if undefined.")]
+		public readonly WAngle? TurnAcceleration = null;
+
+		[Desc("Maximum acceleration/deceleration for body facing rotation. defaults to TurnAcceleration if undefined.")]
+		public readonly WAngle? BodyTurnAcceleration = null;
+
 		[Desc("Maximum flight speed")]
 		public readonly int Speed = 1;
 
@@ -262,12 +268,15 @@ namespace OpenRA.Mods.Common.Traits
 
 		public WAngle FlightFacing { get; set; }
 		public int CurrentSpeed { get; set; }
+		public WAngle CurrentFlightTurnSpeed { get; set; }
+		public WAngle CurrentBodyTurnSpeed { get; set; }
 
 		[Sync]
 		public WPos CenterPosition { get; private set; }
 
 		public CPos TopLeft { get { return self.World.Map.CellContaining(CenterPosition); } }
 		public WAngle TurnSpeed { get { return !IsTraitDisabled && !IsTraitPaused ? Info.TurnSpeed : WAngle.Zero; } }
+		public WAngle BodyTurnSpeed { get { return Info.BodyTurnSpeed ?? Info.TurnSpeed; } }
 
 		public int IdleSpeed
 		{
@@ -284,6 +293,8 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		public int Acceleration { get { return Info.Acceleration >= 0 ? Info.Acceleration : MovementSpeed; } }
+		public WAngle TurnAcceleration { get { return Info.TurnAcceleration ?? Info.TurnSpeed; } }
+		public WAngle BodyTurnAcceleration { get { return Info.BodyTurnAcceleration ?? TurnAcceleration; } }
 
 		public Actor ReservedActor { get; private set; }
 		public bool MayYieldReservation { get; private set; }
@@ -325,6 +336,7 @@ namespace OpenRA.Mods.Common.Traits
 				SetPosition(self, centerPositionInit.Value);
 
 			FlightFacing = Facing = init.GetValue<FacingInit, WAngle>(WAngle.FromFacing(Info.InitialFacing));
+			CurrentFlightTurnSpeed = CurrentBodyTurnSpeed = WAngle.Zero;
 			creationActivityDelay = init.GetValue<CreationActivityDelayInit, int>(0);
 		}
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RefactorAircraftTurnSpeed.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RefactorAircraftTurnSpeed.cs
@@ -1,0 +1,41 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	class RefactorAircraftTurnSpeed : UpdateRule
+	{
+		public override string Name { get { return "Split up aircraft TurnSpeed into flight and body turn speeds."; } }
+		public override string Description
+		{
+			get
+			{
+				return "Aircraft TurnSpeed has been split into TurnSpeed and BodyTurnSpeed to allow aircraft with CanSlide: true to have" +
+					"independent flight direction and body orientation. If BodyTurnSpeed is defined, TurnSpeed only controls rate of turn" +
+					" for flight direction. Aircraft with CanSlide: true should use BodyTurnSpeed and leave TurnSpeed undefined to maintain" +
+					"the old sliding behaviour.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var rp in actorNode.ChildrenMatching("Aircraft"))
+			{
+				if (rp.LastChildMatching("CanSlide").Key == "true")
+					rp.RenameChildrenMatching("TurnSpeed", "BodyTurnSpeed");
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -67,6 +67,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new ConvertSupportPowerRangesToFootprint(),
 				new UpdateTilesetColors(),
 				new UpdateMapInits(),
+				new RefactorAircraftTurnSpeed(),
 			})
 		};
 

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -52,6 +52,14 @@ namespace OpenRA.Mods.Common
 			return rightTurn < leftTurn ? facing + step : facing - step;
 		}
 
+		public static int TickSpeed(int speed, int desiredSpeed, int acceleration)
+		{
+			if (desiredSpeed >= speed)
+				return Math.Min(speed + acceleration, desiredSpeed);
+
+			return Math.Max(speed - acceleration, desiredSpeed);
+		}
+
 		/// <summary>
 		/// Determines whether desiredFacing is clockwise (-1) or anticlockwise (+1) of facing.
 		/// If desiredFacing is equal to facing or directly behind facing we treat it as being anticlockwise

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -13,7 +13,7 @@ TRAN:
 		Queue: Aircraft.GDI, Aircraft.Nod
 		Description: Fast Infantry Transport Helicopter.\n  Unarmed
 	Aircraft:
-		BodyTurnSpeed: 5
+		BodyTurnSpeed: 20
 		Speed: 150
 		AltitudeVelocity: 0c100
 	Health:
@@ -64,7 +64,7 @@ HELI:
 		Queue: Aircraft.Nod
 		Description: Helicopter Gunship with Chainguns.\n  Strong vs Infantry, Light Vehicles and\n  Aircraft\n  Weak vs Tanks
 	Aircraft:
-		BodyTurnSpeed: 7
+		BodyTurnSpeed: 28
 		Speed: 180
 	Health:
 		HP: 12500
@@ -132,7 +132,7 @@ ORCA:
 		Queue: Aircraft.GDI
 		Description: Helicopter Gunship with AG Missiles.\n  Strong vs Buildings, Tanks\n  Weak vs Infantry
 	Aircraft:
-		BodyTurnSpeed: 7
+		BodyTurnSpeed: 28
 		Speed: 186
 	Health:
 		HP: 9000
@@ -182,7 +182,7 @@ C17:
 	Valued:
 		Cost: 2000
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 326
 		Repulsable: False
 		MaximumPitch: 36
@@ -215,7 +215,7 @@ A10:
 	Valued:
 		Cost: 2000
 	Aircraft:
-		TurnSpeed: 4
+		TurnSpeed: 16
 		Speed: 373
 		Repulsable: False
 	AttackBomber:
@@ -242,7 +242,7 @@ TRAN.Husk:
 	Tooltip:
 		Name: Chinook Transport
 	Aircraft:
-		BodyTurnSpeed: 5
+		BodyTurnSpeed: 20
 		Speed: 140
 	RevealsShroud:
 		Range: 10c0
@@ -261,7 +261,7 @@ HELI.Husk:
 	Tooltip:
 		Name: Apache Longbow
 	Aircraft:
-		BodyTurnSpeed: 4
+		BodyTurnSpeed: 16
 		Speed: 186
 	RevealsShroud:
 		Range: 10c0
@@ -277,7 +277,7 @@ ORCA.Husk:
 	Tooltip:
 		Name: Orca
 	Aircraft:
-		BodyTurnSpeed: 4
+		BodyTurnSpeed: 16
 		Speed: 186
 	RevealsShroud:
 		Range: 10c0

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -13,7 +13,7 @@ TRAN:
 		Queue: Aircraft.GDI, Aircraft.Nod
 		Description: Fast Infantry Transport Helicopter.\n  Unarmed
 	Aircraft:
-		TurnSpeed: 5
+		BodyTurnSpeed: 5
 		Speed: 150
 		AltitudeVelocity: 0c100
 	Health:
@@ -64,7 +64,7 @@ HELI:
 		Queue: Aircraft.Nod
 		Description: Helicopter Gunship with Chainguns.\n  Strong vs Infantry, Light Vehicles and\n  Aircraft\n  Weak vs Tanks
 	Aircraft:
-		TurnSpeed: 7
+		BodyTurnSpeed: 7
 		Speed: 180
 	Health:
 		HP: 12500
@@ -132,7 +132,7 @@ ORCA:
 		Queue: Aircraft.GDI
 		Description: Helicopter Gunship with AG Missiles.\n  Strong vs Buildings, Tanks\n  Weak vs Infantry
 	Aircraft:
-		TurnSpeed: 7
+		BodyTurnSpeed: 7
 		Speed: 186
 	Health:
 		HP: 9000
@@ -242,7 +242,7 @@ TRAN.Husk:
 	Tooltip:
 		Name: Chinook Transport
 	Aircraft:
-		TurnSpeed: 5
+		BodyTurnSpeed: 5
 		Speed: 140
 	RevealsShroud:
 		Range: 10c0
@@ -261,7 +261,7 @@ HELI.Husk:
 	Tooltip:
 		Name: Apache Longbow
 	Aircraft:
-		TurnSpeed: 4
+		BodyTurnSpeed: 4
 		Speed: 186
 	RevealsShroud:
 		Range: 10c0
@@ -277,7 +277,7 @@ ORCA.Husk:
 	Tooltip:
 		Name: Orca
 	Aircraft:
-		TurnSpeed: 4
+		BodyTurnSpeed: 4
 		Speed: 186
 	RevealsShroud:
 		Range: 10c0

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -13,13 +13,13 @@ carryall.reinforce:
 		CruisingCondition: cruising
 		InitialFacing: 0
 		Speed: 144
-		BodyTurnSpeed: 4
+		BodyTurnSpeed: 16
 		LandableTerrainTypes: Sand, Rock, Transition, Spice, SpiceSand, Dune, Concrete
 		Repulsable: False
 		AirborneCondition: airborne
 		CanSlide: True
 		VTOL: true
-		IdleTurnSpeed: 1
+		IdleTurnSpeed: 4
 	Targetable@GROUND:
 		TargetTypes: Ground, Vehicle
 		RequiresCondition: !airborne
@@ -78,7 +78,7 @@ frigate:
 	Aircraft:
 		IdleBehavior: LeaveMap
 		Speed: 189
-		BodyTurnSpeed: 1
+		BodyTurnSpeed: 4
 		Repulsable: False
 		MaximumPitch: 20
 		CruiseAltitude: 2048
@@ -101,7 +101,7 @@ ornithopter:
 		Type: light
 	Aircraft:
 		Speed: 224
-		TurnSpeed: 2
+		TurnSpeed: 8
 		Repulsable: False
 		CruiseAltitude: 1920
 	AmmoPool:
@@ -119,7 +119,7 @@ ornithopter.husk:
 	Tooltip:
 		Name: Ornithopter
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 224
 	RenderSprites:
 		Image: ornithopter
@@ -129,7 +129,7 @@ carryall.husk:
 	Tooltip:
 		Name: Carryall
 	Aircraft:
-		BodyTurnSpeed: 4
+		BodyTurnSpeed: 16
 		Speed: 144
 		CanSlide: True
 		VTOL: true
@@ -144,7 +144,7 @@ carryall.huskVTOL:
 		Moves: False
 		Velocity: 0c128
 	Aircraft:
-		BodyTurnSpeed: 4
+		BodyTurnSpeed: 16
 		CanSlide: True
 		VTOL: true
 	RenderSprites:

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -13,7 +13,7 @@ carryall.reinforce:
 		CruisingCondition: cruising
 		InitialFacing: 0
 		Speed: 144
-		TurnSpeed: 4
+		BodyTurnSpeed: 4
 		LandableTerrainTypes: Sand, Rock, Transition, Spice, SpiceSand, Dune, Concrete
 		Repulsable: False
 		AirborneCondition: airborne
@@ -78,7 +78,7 @@ frigate:
 	Aircraft:
 		IdleBehavior: LeaveMap
 		Speed: 189
-		TurnSpeed: 1
+		BodyTurnSpeed: 1
 		Repulsable: False
 		MaximumPitch: 20
 		CruiseAltitude: 2048
@@ -129,7 +129,7 @@ carryall.husk:
 	Tooltip:
 		Name: Carryall
 	Aircraft:
-		TurnSpeed: 4
+		BodyTurnSpeed: 4
 		Speed: 144
 		CanSlide: True
 		VTOL: true
@@ -144,7 +144,7 @@ carryall.huskVTOL:
 		Moves: False
 		Velocity: 0c128
 	Aircraft:
-		TurnSpeed: 4
+		BodyTurnSpeed: 4
 		CanSlide: True
 		VTOL: true
 	RenderSprites:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -216,7 +216,7 @@ TRAN:
 		Range: 6c0
 		Type: GroundPosition
 	Aircraft:
-		TurnSpeed: 5
+		BodyTurnSpeed: 5
 		Speed: 128
 		AltitudeVelocity: 0c58
 	WithIdleOverlay@ROTOR1AIR:
@@ -283,7 +283,7 @@ HELI:
 		AttackType: Hover
 		OpportunityFire: False
 	Aircraft:
-		TurnSpeed: 4
+		BodyTurnSpeed: 4
 		Speed: 149
 	AutoTarget:
 		InitialStance: HoldFire
@@ -356,7 +356,7 @@ HIND:
 		AttackType: Hover
 		OpportunityFire: False
 	Aircraft:
-		TurnSpeed: 4
+		BodyTurnSpeed: 4
 		Speed: 112
 	AutoTarget:
 		InitialStance: HoldFire
@@ -458,7 +458,7 @@ MH60:
 		PersistentTargeting: false
 		AttackType: Hover
 	Aircraft:
-		TurnSpeed: 4
+		BodyTurnSpeed: 4
 		Speed: 112
 	AutoTarget:
 		InitialStance: HoldFire

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -7,7 +7,7 @@ BADR:
 		HP: 30000
 	Aircraft:
 		CruiseAltitude: 2560
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 180
 		Repulsable: False
 		MaximumPitch: 56
@@ -85,7 +85,7 @@ MIG:
 	Aircraft:
 		CruiseAltitude: 2560
 		InitialFacing: 192
-		TurnSpeed: 4
+		TurnSpeed: 16
 		Speed: 223
 		RepulsionSpeed: 40
 		MaximumPitch: 56
@@ -159,7 +159,7 @@ YAK:
 	Aircraft:
 		CruiseAltitude: 2560
 		InitialFacing: 192
-		TurnSpeed: 4
+		TurnSpeed: 16
 		Speed: 178
 		RepulsionSpeed: 40
 		MaximumPitch: 56
@@ -216,7 +216,7 @@ TRAN:
 		Range: 6c0
 		Type: GroundPosition
 	Aircraft:
-		BodyTurnSpeed: 5
+		BodyTurnSpeed: 20
 		Speed: 128
 		AltitudeVelocity: 0c58
 	WithIdleOverlay@ROTOR1AIR:
@@ -283,7 +283,7 @@ HELI:
 		AttackType: Hover
 		OpportunityFire: False
 	Aircraft:
-		BodyTurnSpeed: 4
+		BodyTurnSpeed: 16
 		Speed: 149
 	AutoTarget:
 		InitialStance: HoldFire
@@ -356,7 +356,7 @@ HIND:
 		AttackType: Hover
 		OpportunityFire: False
 	Aircraft:
-		BodyTurnSpeed: 4
+		BodyTurnSpeed: 16
 		Speed: 112
 	AutoTarget:
 		InitialStance: HoldFire
@@ -396,7 +396,7 @@ U2:
 		Name: Spy Plane
 	Aircraft:
 		CruiseAltitude: 2560
-		TurnSpeed: 7
+		TurnSpeed: 28
 		Speed: 373
 		Repulsable: False
 		MaximumPitch: 56
@@ -458,7 +458,7 @@ MH60:
 		PersistentTargeting: false
 		AttackType: Hover
 	Aircraft:
-		BodyTurnSpeed: 4
+		BodyTurnSpeed: 16
 		Speed: 112
 	AutoTarget:
 		InitialStance: HoldFire

--- a/mods/ra/rules/husks.yaml
+++ b/mods/ra/rules/husks.yaml
@@ -102,7 +102,7 @@ TRAN.Husk:
 	Tooltip:
 		Name: Chinook
 	Aircraft:
-		BodyTurnSpeed: 4
+		BodyTurnSpeed: 16
 		Speed: 149
 	WithIdleOverlay@PRIMARY:
 		Offset: -597,0,341
@@ -146,7 +146,7 @@ BADR.Husk:
 	Tooltip:
 		Name: Badger
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 149
 	SmokeTrailWhenDamaged@0:
 		Offset: -432,560,0
@@ -169,7 +169,7 @@ MIG.Husk:
 	Contrail@2:
 		Offset: -598,683,0
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 186
 	SmokeTrailWhenDamaged:
 		Offset: -853,0,171
@@ -193,7 +193,7 @@ YAK.Husk:
 	Contrail:
 		Offset: -853,0,0
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 20
 		Speed: 149
 	SmokeTrailWhenDamaged:
 		Offset: -853,0,0
@@ -215,7 +215,7 @@ HELI.Husk:
 	Tooltip:
 		Name: Longbow
 	Aircraft:
-		BodyTurnSpeed: 4
+		BodyTurnSpeed: 16
 		Speed: 149
 	WithIdleOverlay:
 		Offset: 0,0,85
@@ -239,7 +239,7 @@ HIND.Husk:
 	Tooltip:
 		Name: Hind
 	Aircraft:
-		BodyTurnSpeed: 4
+		BodyTurnSpeed: 16
 		Speed: 112
 	WithIdleOverlay:
 		Sequence: rotor
@@ -262,7 +262,7 @@ U2.Husk:
 	Tooltip:
 		Name: Husk (Spy Plane)
 	Aircraft:
-		TurnSpeed: 7
+		TurnSpeed: 28
 		Speed: 373
 	Contrail@1:
 		Offset: -725,683,0

--- a/mods/ra/rules/husks.yaml
+++ b/mods/ra/rules/husks.yaml
@@ -102,7 +102,7 @@ TRAN.Husk:
 	Tooltip:
 		Name: Chinook
 	Aircraft:
-		TurnSpeed: 4
+		BodyTurnSpeed: 4
 		Speed: 149
 	WithIdleOverlay@PRIMARY:
 		Offset: -597,0,341
@@ -215,7 +215,7 @@ HELI.Husk:
 	Tooltip:
 		Name: Longbow
 	Aircraft:
-		TurnSpeed: 4
+		BodyTurnSpeed: 4
 		Speed: 149
 	WithIdleOverlay:
 		Offset: 0,0,85
@@ -239,7 +239,7 @@ HIND.Husk:
 	Tooltip:
 		Name: Hind
 	Aircraft:
-		TurnSpeed: 4
+		BodyTurnSpeed: 4
 		Speed: 112
 	WithIdleOverlay:
 		Sequence: rotor
@@ -451,7 +451,7 @@ MH60.Husk:
 	Tooltip:
 		Name: Black Hawk
 	Aircraft:
-		TurnSpeed: 4
+		BodyTurnSpeed: 4
 		Speed: 112
 	WithIdleOverlay:
 		Sequence: rotor

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -140,6 +140,8 @@ ORCA:
 	Aircraft:
 		TurnSpeed: 40
 		BodyTurnSpeed: 20
+		TurnAcceleration: 5
+		BodyTurnAcceleration: 3
 		Speed: 186
 		TakeoffSounds: orcaup1.aud
 		LandingSounds: orcadwn1.aud
@@ -363,6 +365,8 @@ SCRIN:
 		IdleTurnSpeed: 6
 		Speed: 168
 		IdleSpeed: 100
+		Pitch: 0
+		Roll: 128
 		TakeoffSounds: dropup1.aud
 		LandingSounds: dropdwn1.aud
 		CanHover: false
@@ -427,6 +431,8 @@ APACHE:
 		RollSpeed: 8
 		TurnSpeed: 40
 		BodyTurnSpeed: 20
+		TurnAcceleration: 5
+		BodyTurnAcceleration: 3
 		Speed: 130
 		TakeOffOnResupply: true
 	Health:

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -138,13 +138,12 @@ ORCA:
 	Selectable:
 		Bounds: 30,24
 	Aircraft:
-		BodyTurnSpeed: 12
-		TurnSpeed: 20
+		TurnSpeed: 40
+		BodyTurnSpeed: 20
 		Speed: 186
 		TakeoffSounds: orcaup1.aud
 		LandingSounds: orcadwn1.aud
 		AltitudeVelocity: 128
-		CanSlide: false
 		TakeOffOnResupply: true
 	Health:
 		HP: 20000
@@ -201,7 +200,8 @@ ORCAB:
 		Bounds: 30,24
 	Aircraft:
 		CruiseAltitude: 5c512
-		TurnSpeed: 12
+		TurnSpeed: 20
+		BodyTurnSpeed: 12
 		IdleTurnSpeed: 4
 		Speed: 96
 		IdleSpeed: 60
@@ -209,7 +209,6 @@ ORCAB:
 		TakeoffSounds: orcaup1.aud
 		LandingSounds: orcadwn1.aud
 		CanHover: false
-		CanSlide: false
 	Health:
 		HP: 26000
 	Armor:
@@ -265,6 +264,7 @@ ORCATRAN:
 		Prerequisites: ~disabled
 	RenderSprites:
 	Aircraft:
+		TurnSpeed: 40
 		BodyTurnSpeed: 20
 		Speed: 84
 		InitialFacing: 0
@@ -307,6 +307,7 @@ TRNSPORT:
 		Prerequisites: ~gahpad, gadept
 		Description: VTOL aircraft capable of lifting\nand transporting vehicles.\n  Unarmed
 	Aircraft:
+		TurnSpeed: 40
 		BodyTurnSpeed: 20
 		Speed: 149
 		InitialFacing: 0
@@ -357,14 +358,14 @@ SCRIN:
 		VoiceSet: Scrin
 	Aircraft:
 		CruiseAltitude: 5c0
-		BodyTurnSpeed: 12
+		TurnSpeed: 12
+		BodyTurnSpeed: 20
+		IdleTurnSpeed: 6
 		Speed: 168
-		IdleTurnSpeed: 8
 		IdleSpeed: 100
 		TakeoffSounds: dropup1.aud
 		LandingSounds: dropdwn1.aud
 		CanHover: false
-		CanSlide: false
 	Health:
 		HP: 28000
 	Armor:
@@ -425,9 +426,9 @@ APACHE:
 		PitchSpeed: 8
 		Roll: 16
 		RollSpeed: 8
+		TurnSpeed: 40
 		BodyTurnSpeed: 20
 		Speed: 130
-		CanSlide: false
 		TakeOffOnResupply: true
 	Health:
 		HP: 22500

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -423,7 +423,6 @@ APACHE:
 		Bounds: 30,24
 	Aircraft:
 		Pitch: -32
-		PitchSpeed: 8
 		Roll: 16
 		RollSpeed: 8
 		TurnSpeed: 40

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -10,7 +10,7 @@ DPOD:
 		IdleBehavior: Land
 		Pitch: 0
 		Roll: 0
-		TurnSpeed: 5
+		BodyTurnSpeed: 5
 		Speed: 149
 		InitialFacing: 0
 	Health:
@@ -48,7 +48,7 @@ DPOD2:
 	Armor:
 		Type: Light
 	Aircraft:
-		TurnSpeed: 5
+		BodyTurnSpeed: 5
 		Speed: 300
 		CruiseAltitude: 16c0
 		MaximumPitch: 110
@@ -96,7 +96,7 @@ DSHP:
 		IdleBehavior: Land
 		Pitch: 0
 		Roll: 0
-		TurnSpeed: 5
+		BodyTurnSpeed: 5
 		Speed: 168
 		InitialFacing: 0
 		TakeoffSounds: dropup1.aud
@@ -138,7 +138,7 @@ ORCA:
 	Selectable:
 		Bounds: 30,24
 	Aircraft:
-		TurnSpeed: 5
+		BodyTurnSpeed: 5
 		Speed: 186
 		TakeoffSounds: orcaup1.aud
 		LandingSounds: orcadwn1.aud
@@ -264,7 +264,7 @@ ORCATRAN:
 		Prerequisites: ~disabled
 	RenderSprites:
 	Aircraft:
-		TurnSpeed: 5
+		BodyTurnSpeed: 5
 		Speed: 84
 		InitialFacing: 0
 		LandableTerrainTypes: Clear, Road, Rail, DirtRoad, Rough, Tiberium, BlueTiberium, Veins
@@ -306,7 +306,7 @@ TRNSPORT:
 		Prerequisites: ~gahpad, gadept
 		Description: VTOL aircraft capable of lifting\nand transporting vehicles.\n  Unarmed
 	Aircraft:
-		TurnSpeed: 5
+		BodyTurnSpeed: 5
 		Speed: 149
 		InitialFacing: 0
 		Pitch: 0
@@ -424,7 +424,7 @@ APACHE:
 		PitchSpeed: 8
 		Roll: 16
 		RollSpeed: 8
-		TurnSpeed: 5
+		BodyTurnSpeed: 5
 		Speed: 130
 		CanSlide: false
 		TakeOffOnResupply: true
@@ -484,7 +484,7 @@ HUNTER:
 	Armor:
 		Type: Light
 	Aircraft:
-		TurnSpeed: 16
+		BodyTurnSpeed: 16
 		Speed: 355
 		Pitch: 0
 		Roll: 0

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -201,7 +201,9 @@ ORCAB:
 	Aircraft:
 		CruiseAltitude: 5c512
 		TurnSpeed: 3
+		IdleTurnSpeed: 1
 		Speed: 96
+		IdleSpeed: 60
 		CruisingCondition: cruising
 		TakeoffSounds: orcaup1.aud
 		LandingSounds: orcadwn1.aud
@@ -356,6 +358,8 @@ SCRIN:
 		CruiseAltitude: 5c0
 		TurnSpeed: 3
 		Speed: 168
+		IdleTurnSpeed: 2
+		IdleSpeed: 100
 		TakeoffSounds: dropup1.aud
 		LandingSounds: dropdwn1.aud
 		CanHover: false

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -10,7 +10,7 @@ DPOD:
 		IdleBehavior: Land
 		Pitch: 0
 		Roll: 0
-		BodyTurnSpeed: 5
+		BodyTurnSpeed: 20
 		Speed: 149
 		InitialFacing: 0
 	Health:
@@ -48,7 +48,7 @@ DPOD2:
 	Armor:
 		Type: Light
 	Aircraft:
-		BodyTurnSpeed: 5
+		BodyTurnSpeed: 20
 		Speed: 300
 		CruiseAltitude: 16c0
 		MaximumPitch: 110
@@ -96,7 +96,7 @@ DSHP:
 		IdleBehavior: Land
 		Pitch: 0
 		Roll: 0
-		BodyTurnSpeed: 5
+		BodyTurnSpeed: 20
 		Speed: 168
 		InitialFacing: 0
 		TakeoffSounds: dropup1.aud
@@ -138,7 +138,8 @@ ORCA:
 	Selectable:
 		Bounds: 30,24
 	Aircraft:
-		BodyTurnSpeed: 5
+		BodyTurnSpeed: 12
+		TurnSpeed: 20
 		Speed: 186
 		TakeoffSounds: orcaup1.aud
 		LandingSounds: orcadwn1.aud
@@ -200,8 +201,8 @@ ORCAB:
 		Bounds: 30,24
 	Aircraft:
 		CruiseAltitude: 5c512
-		TurnSpeed: 3
-		IdleTurnSpeed: 1
+		TurnSpeed: 12
+		IdleTurnSpeed: 4
 		Speed: 96
 		IdleSpeed: 60
 		CruisingCondition: cruising
@@ -264,7 +265,7 @@ ORCATRAN:
 		Prerequisites: ~disabled
 	RenderSprites:
 	Aircraft:
-		BodyTurnSpeed: 5
+		BodyTurnSpeed: 20
 		Speed: 84
 		InitialFacing: 0
 		LandableTerrainTypes: Clear, Road, Rail, DirtRoad, Rough, Tiberium, BlueTiberium, Veins
@@ -306,7 +307,7 @@ TRNSPORT:
 		Prerequisites: ~gahpad, gadept
 		Description: VTOL aircraft capable of lifting\nand transporting vehicles.\n  Unarmed
 	Aircraft:
-		BodyTurnSpeed: 5
+		BodyTurnSpeed: 20
 		Speed: 149
 		InitialFacing: 0
 		Pitch: 0
@@ -356,9 +357,9 @@ SCRIN:
 		VoiceSet: Scrin
 	Aircraft:
 		CruiseAltitude: 5c0
-		TurnSpeed: 3
+		BodyTurnSpeed: 12
 		Speed: 168
-		IdleTurnSpeed: 2
+		IdleTurnSpeed: 8
 		IdleSpeed: 100
 		TakeoffSounds: dropup1.aud
 		LandingSounds: dropdwn1.aud
@@ -424,7 +425,7 @@ APACHE:
 		PitchSpeed: 8
 		Roll: 16
 		RollSpeed: 8
-		BodyTurnSpeed: 5
+		BodyTurnSpeed: 20
 		Speed: 130
 		CanSlide: false
 		TakeOffOnResupply: true
@@ -484,7 +485,7 @@ HUNTER:
 	Armor:
 		Type: Light
 	Aircraft:
-		BodyTurnSpeed: 16
+		BodyTurnSpeed: 64
 		Speed: 355
 		Pitch: 0
 		Roll: 0

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -892,8 +892,9 @@
 		Pitch: -64
 		PitchSpeed: 5
 		Roll: 56
-		RollSpeed: 14
+		RollSpeed: 5
 		Acceleration: 5
+		TurnAcceleration: 1
 	Voiced:
 		VoiceSet: Heli
 	HiddenUnderFog:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -890,9 +890,10 @@
 		CanSlide: true
 		VTOL: true
 		Pitch: -64
-		PitchSpeed: 16
+		PitchSpeed: 5
 		Roll: 56
 		RollSpeed: 14
+		Acceleration: 5
 	Voiced:
 		VoiceSet: Heli
 	HiddenUnderFog:

--- a/mods/ts/rules/husks.yaml
+++ b/mods/ts/rules/husks.yaml
@@ -3,7 +3,7 @@ DSHP.Husk:
 	Tooltip:
 		Name: Dropship
 	Aircraft:
-		TurnSpeed: 5
+		BodyTurnSpeed: 5
 		Speed: 168
 	-RenderSprites:
 	RenderVoxels:
@@ -14,7 +14,7 @@ ORCA.Husk:
 	Tooltip:
 		Name: Orca Fighter
 	Aircraft:
-		TurnSpeed: 5
+		BodyTurnSpeed: 5
 		Speed: 186
 	RenderSprites:
 		Image: orca
@@ -30,7 +30,7 @@ ORCAB.Husk:
 	Tooltip:
 		Name: Orca Bomber
 	Aircraft:
-		TurnSpeed: 3
+		BodyTurnSpeed: 3
 		Speed: 96
 	FallsToEarth:
 		MaximumSpinSpeed: 6
@@ -48,7 +48,7 @@ ORCATRAN.Husk:
 	Tooltip:
 		Name: Orca Transport
 	Aircraft:
-		TurnSpeed: 5
+		BodyTurnSpeed: 5
 		Speed: 84
 	RenderSprites:
 		Image: orcatran
@@ -64,7 +64,7 @@ TRNSPORT.Husk:
 	Tooltip:
 		Name: Carryall
 	Aircraft:
-		TurnSpeed: 5
+		BodyTurnSpeed: 5
 		Speed: 149
 	RenderSprites:
 		Image: trnsport
@@ -80,7 +80,7 @@ SCRIN.Husk:
 	Tooltip:
 		Name: Banshee Fighter
 	Aircraft:
-		TurnSpeed: 3
+		BodyTurnSpeed: 3
 		Speed: 168
 	FallsToEarth:
 		MaximumSpinSpeed: 6
@@ -98,7 +98,7 @@ APACHE.Husk:
 	Tooltip:
 		Name: Harpy
 	Aircraft:
-		TurnSpeed: 5
+		BodyTurnSpeed: 5
 		Speed: 130
 	WithIdleOverlay:
 		Offset: 85,0,598


### PR DESCRIPTION
This is a follow up to #18320,  #18322 and #18360

This allows aircraft to perform smoother turns by implementing angular acceleration.
It adds `TurnAcceleration` and `BodyTurnAcceleration` parameters to `Aircraft` which define the maximum turn speed increase/decrease per tick. The visual roll of the aircraft now also varies linearly with the actual turn speed of the aircraft similar to what #18360 did for the forward pitch and speed.

Furthermore aircraft with `Canslide: true` will now turn towards the required landing facing (when landing at an airpad) while flying towards it instead of having to turn in place. They will time their turn so that they will achieve the required facing just in time for the landing to start.

I once again took the liberty of setting some preliminary values for angular acceleration for all TS aircraft.