### PR TITLE
Add itch app compatible portable builds

### DIFF
--- a/packaging/.itch.toml
+++ b/packaging/.itch.toml
@@ -1,0 +1,17 @@
+[[prereqs]]
+name = "net-4.7.2"
+
+[[actions]]
+os = "windows"
+name = "Red Alert"
+path = "RedAlert.exe"
+
+[[actions]]
+os = "windows"
+name = "Dune 2000"
+path = "Dune2000.exe"
+
+[[actions]]
+os = "windows"
+name = "Tiberian Dawn"
+path = "TiberianDawn.exe"

--- a/packaging/upload-itch.sh
+++ b/packaging/upload-itch.sh
@@ -29,10 +29,12 @@ chmod +x butler
 
 ./butler -V
 ./butler login
-./butler push "${BUILD_OUTPUT_DIR}/OpenRA-${GIT_TAG}-x64.exe" "openra/openra:win" --userversion-file ../VERSION
+cp ${BUILD_OUTPUT_DIR}/OpenRA-${GIT_TAG}-x64-winportable.zip OpenRA-${GIT_TAG}-x64-win-itch-portable.zip
+zip -u OpenRA-${GIT_TAG}-x64-win-itch-portable.zip .itch.toml
+./butler push "OpenRA-${GIT_TAG}-x64-win-itch-portable.zip" "openra/openra:win" --userversion-file ../VERSION
 ./butler push --fix-permissions "${BUILD_OUTPUT_DIR}/OpenRA-${GIT_TAG}.dmg" "openra/openra:osx" --userversion-file ../VERSION
 ./butler push --fix-permissions "${BUILD_OUTPUT_DIR}/OpenRA-Dune-2000-x86_64.AppImage" "openra/openra:linux-d2k" --userversion-file ../VERSION
 ./butler push --fix-permissions "${BUILD_OUTPUT_DIR}/OpenRA-Red-Alert-x86_64.AppImage" "openra/openra:linux-ra" --userversion-file ../VERSION
 ./butler push --fix-permissions "${BUILD_OUTPUT_DIR}/OpenRA-Tiberian-Dawn-x86_64.AppImage" "openra/openra:linux-td" --userversion-file ../VERSION
 
-rm butler butler-linux-amd64.zip
+rm butler butler-linux-amd64.zip 7z.so libc7zip.so


### PR DESCRIPTION
Closes https://github.com/OpenRA/OpenRA/issues/14214.

A backported version of the "Windows portable with experimental Itch App support" to release-20200503 can be found on https://openra.itch.io/openra for testing.