### PR TITLE
Fixed mod game news overriding each other

### DIFF
--- a/OpenRA.Mods.Common/WebServices.cs
+++ b/OpenRA.Mods.Common/WebServices.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Mods.Common
 		public readonly string ServerAdvertise = "https://master.openra.net/ping";
 		public readonly string MapRepository = "https://resource.openra.net/map/";
 		public readonly string GameNews = "https://master.openra.net/gamenews";
+		public readonly string GameNewsFileName = "news.yaml";
 		public readonly string VersionCheck = "https://master.openra.net/versioncheck";
 
 		public ModVersionStatus ModVersionStatus { get; private set; }

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -232,7 +232,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				Action onSysInfoComplete = () =>
 				{
-					LoadAndDisplayNews(webServices.GameNews, newsBG);
+					LoadAndDisplayNews(webServices, newsBG);
 					SwitchMenu(MenuType.Main);
 				};
 
@@ -260,11 +260,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Game.OnShellmapLoaded += OpenMenuBasedOnLastGame;
 		}
 
-		void LoadAndDisplayNews(string newsURL, Widget newsBG)
+		void LoadAndDisplayNews(WebServices webServices, Widget newsBG)
 		{
 			if (newsBG != null && Game.Settings.Game.FetchNews)
 			{
-				var cacheFile = Platform.ResolvePath(Platform.SupportDirPrefix, "news.yaml");
+				var cacheFile = Platform.ResolvePath(Platform.SupportDirPrefix, webServices.GameNewsFileName);
 				var currentNews = ParseNews(cacheFile);
 				if (currentNews != null)
 					DisplayNews(currentNews);
@@ -275,7 +275,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					if (!fetchedNews)
 					{
 						// Send the mod and engine version to support version-filtered news (update prompts)
-						newsURL += "?version={0}&mod={1}&modversion={2}".F(
+						var newsURL = "{0}?version={1}&mod={2}&modversion={3}".F(
+							webServices.GameNews,
 							Uri.EscapeUriString(Game.EngineVersion),
 							Uri.EscapeUriString(Game.ModData.Manifest.Id),
 							Uri.EscapeUriString(Game.ModData.Manifest.Metadata.Version));


### PR DESCRIPTION
This unhardcodes a filename so that mods can deploy their own news which won't get overridden by other OpenRA mods.