### PR TITLE
Add WRot multiplication support.

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -69,7 +69,7 @@ namespace OpenRA
 		{
 			get
 			{
-				return facing != null ? facing.Orientation : WRot.Zero;
+				return facing != null ? facing.Orientation : WRot.None;
 			}
 		}
 

--- a/OpenRA.Game/Graphics/ModelAnimation.cs
+++ b/OpenRA.Game/Graphics/ModelAnimation.cs
@@ -19,12 +19,12 @@ namespace OpenRA.Graphics
 	{
 		public readonly IModel Model;
 		public readonly Func<WVec> OffsetFunc;
-		public readonly Func<IEnumerable<WRot>> RotationFunc;
+		public readonly Func<WRot> RotationFunc;
 		public readonly Func<bool> DisableFunc;
 		public readonly Func<uint> FrameFunc;
 		public readonly bool ShowShadow;
 
-		public ModelAnimation(IModel model, Func<WVec> offset, Func<IEnumerable<WRot>> rotation, Func<bool> disable, Func<uint> frame, bool showshadow)
+		public ModelAnimation(IModel model, Func<WVec> offset, Func<WRot> rotation, Func<bool> disable, Func<uint> frame, bool showshadow)
 		{
 			Model = model;
 			OffsetFunc = offset;

--- a/OpenRA.Game/Graphics/ModelRenderer.cs
+++ b/OpenRA.Game/Graphics/ModelRenderer.cs
@@ -114,8 +114,7 @@ namespace OpenRA.Graphics
 				var offsetVec = Util.MatrixVectorMultiply(invCameraTransform, wr.ScreenVector(m.OffsetFunc()));
 				var offsetTransform = Util.TranslationMatrix(offsetVec[0], offsetVec[1], offsetVec[2]);
 
-				var worldTransform = m.RotationFunc().Aggregate(Util.IdentityMatrix(),
-					(x, y) => Util.MatrixMultiply(Util.MakeFloatMatrix(y.AsMatrix()), x));
+				var worldTransform = Util.MakeFloatMatrix(m.RotationFunc().AsMatrix());
 				worldTransform = Util.MatrixMultiply(scaleTransform, worldTransform);
 				worldTransform = Util.MatrixMultiply(offsetTransform, worldTransform);
 
@@ -189,8 +188,7 @@ namespace OpenRA.Graphics
 					var offsetVec = Util.MatrixVectorMultiply(invCameraTransform, wr.ScreenVector(m.OffsetFunc()));
 					var offsetTransform = Util.TranslationMatrix(offsetVec[0], offsetVec[1], offsetVec[2]);
 
-					var rotations = m.RotationFunc().Aggregate(Util.IdentityMatrix(),
-						(x, y) => Util.MatrixMultiply(Util.MakeFloatMatrix(y.AsMatrix()), x));
+					var rotations = Util.MakeFloatMatrix(m.RotationFunc().AsMatrix());
 					var worldTransform = Util.MatrixMultiply(scaleTransform, rotations);
 					worldTransform = Util.MatrixMultiply(offsetTransform, worldTransform);
 

--- a/OpenRA.Game/WAngle.cs
+++ b/OpenRA.Game/WAngle.cs
@@ -82,6 +82,50 @@ namespace OpenRA
 			return new WAngle(aa + (bb - aa) * mul / div);
 		}
 
+		public static WAngle ArcSin(int d)
+		{
+			if (d < -1024 || d > 1024)
+				throw new ArgumentException("ArcSin is only valid for values between -1024 and 1024. Received {0}".F(d));
+
+			var a = ClosestCosineIndex(Math.Abs(d));
+			return new WAngle(d < 0 ? 768 + a : 256 - a);
+		}
+
+		public static WAngle ArcCos(int d)
+		{
+			if (d < -1024 || d > 1024)
+				throw new ArgumentException("ArcCos is only valid for values between -1024 and 1024. Received {0}".F(d));
+
+			var a = ClosestCosineIndex(Math.Abs(d));
+			return new WAngle(d < 0 ? 512 - a : a);
+		}
+
+		/// <summary>
+		/// Find the index of CosineTable that has the value closest to the given value.
+		/// The first or last index will be returned for values above or below the valid range
+		/// </summary>
+		static int ClosestCosineIndex(int value)
+		{
+			var aboveIndex = 0;
+			var belowIndex = 256;
+			while (aboveIndex != belowIndex - 1)
+			{
+				var index = (aboveIndex + belowIndex) / 2;
+				var val = CosineTable[index];
+
+				if (val == value)
+					return index;
+
+				if (val < value)
+					belowIndex = index;
+				else
+					aboveIndex = index;
+			}
+
+			// Take the index with the smallest error
+			return CosineTable[aboveIndex] - value > value - CosineTable[belowIndex] ? belowIndex : aboveIndex;
+		}
+
 		public static WAngle ArcTan(int y, int x) { return ArcTan(y, x, 1); }
 		public static WAngle ArcTan(int y, int x, int stride)
 		{

--- a/OpenRA.Game/WRot.cs
+++ b/OpenRA.Game/WRot.cs
@@ -21,7 +21,7 @@ namespace OpenRA
 		public readonly WAngle Roll, Pitch, Yaw;
 
 		public WRot(WAngle roll, WAngle pitch, WAngle yaw) { Roll = roll; Pitch = pitch; Yaw = yaw; }
-		public static readonly WRot Zero = new WRot(WAngle.Zero, WAngle.Zero, WAngle.Zero);
+		public static readonly WRot None = new WRot(WAngle.Zero, WAngle.Zero, WAngle.Zero);
 
 		public static WRot FromFacing(int facing) { return new WRot(WAngle.Zero, WAngle.Zero, WAngle.FromFacing(facing)); }
 		public static WRot FromYaw(WAngle yaw) { return new WRot(WAngle.Zero, WAngle.Zero, yaw); }

--- a/OpenRA.Mods.Cnc/Traits/Render/WithVoxelUnloadBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithVoxelUnloadBody.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
 			var model = init.World.ModelCache.GetModelSequence(image, IdleSequence);
 			yield return new ModelAnimation(model, () => WVec.Zero,
-				() => new[] { body.QuantizeOrientation(orientation(), facings) },
+				() => body.QuantizeOrientation(orientation(), facings),
 				() => false, () => 0, ShowShadow);
 		}
 	}
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 
 			var idleModel = self.World.ModelCache.GetModelSequence(rv.Image, info.IdleSequence);
 			modelAnimation = new ModelAnimation(idleModel, () => WVec.Zero,
-				() => new[] { body.QuantizeOrientation(self, self.Orientation) },
+				() => body.QuantizeOrientation(self, self.Orientation),
 				() => Docked,
 				() => 0, info.ShowShadow);
 
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 
 			var unloadModel = self.World.ModelCache.GetModelSequence(rv.Image, info.UnloadSequence);
 			rv.Add(new ModelAnimation(unloadModel, () => WVec.Zero,
-				() => new[] { body.QuantizeOrientation(self, self.Orientation) },
+				() => body.QuantizeOrientation(self, self.Orientation),
 				() => !Docked,
 				() => 0, info.ShowShadow));
 		}

--- a/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 			var frame = init.GetValue<BodyAnimationFrameInit, uint>(this, 0);
 
 			yield return new ModelAnimation(model, () => WVec.Zero,
-				() => new[] { body.QuantizeOrientation(orientation(), facings) },
+				() => body.QuantizeOrientation(orientation(), facings),
 				() => false, () => frame, ShowShadow);
 		}
 	}
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 			var model = self.World.ModelCache.GetModelSequence(rv.Image, info.Sequence);
 			frames = model.Frames;
 			modelAnimation = new ModelAnimation(model, () => WVec.Zero,
-				() => new[] { body.QuantizeOrientation(self, self.Orientation) },
+				() => body.QuantizeOrientation(self, self.Orientation),
 				() => false, () => frame, info.ShowShadow);
 
 			rv.Add(modelAnimation);

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -159,7 +159,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				// Approach landing from the opposite direction of the desired facing
 				// TODO: Calculate sensible trajectory without preferred facing.
-				var rotation = WRot.Zero;
+				var rotation = WRot.None;
 				if (desiredFacing.HasValue)
 					rotation = WRot.FromYaw(desiredFacing.Value);
 

--- a/OpenRA.Mods.Common/Graphics/ActorPreview.cs
+++ b/OpenRA.Mods.Common/Graphics/ActorPreview.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Graphics
 		{
 			var facingInfo = Actor.TraitInfoOrDefault<IFacingInfo>();
 			if (facingInfo == null)
-				return () => WRot.Zero;
+				return () => WRot.None;
 
 			// Dynamic facing takes priority
 			var dynamicInit = reference.GetOrDefault<DynamicFacingInit>();

--- a/OpenRA.Mods.Common/Graphics/ModelRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/ModelRenderable.cs
@@ -157,8 +157,8 @@ namespace OpenRA.Mods.Common.Graphics
 				foreach (var v in draw)
 				{
 					var bounds = v.Model.Bounds(v.FrameFunc());
-					var worldTransform = v.RotationFunc().Reverse().Aggregate(scaleTransform,
-						(x, y) => OpenRA.Graphics.Util.MatrixMultiply(x, OpenRA.Graphics.Util.MakeFloatMatrix(y.AsMatrix())));
+					var rotation = OpenRA.Graphics.Util.MakeFloatMatrix(v.RotationFunc().AsMatrix());
+					var worldTransform = OpenRA.Graphics.Util.MatrixMultiply(scaleTransform, rotation);
 
 					var pxPos = pxOrigin + wr.ScreenVectorComponents(v.OffsetFunc());
 					var screenTransform = OpenRA.Graphics.Util.MatrixMultiply(cameraTransform, worldTransform);
@@ -215,8 +215,8 @@ namespace OpenRA.Mods.Common.Graphics
 				foreach (var v in draw)
 				{
 					var bounds = v.Model.Bounds(v.FrameFunc());
-					var worldTransform = v.RotationFunc().Reverse().Aggregate(scaleTransform,
-						(x, y) => OpenRA.Graphics.Util.MatrixMultiply(x, OpenRA.Graphics.Util.MakeFloatMatrix(y.AsMatrix())));
+					var rotation = OpenRA.Graphics.Util.MakeFloatMatrix(v.RotationFunc().AsMatrix());
+					var worldTransform = OpenRA.Graphics.Util.MatrixMultiply(scaleTransform, rotation);
 
 					var pxPos = pxOrigin + wr.ScreenVectorComponents(v.OffsetFunc());
 					var screenTransform = OpenRA.Graphics.Util.MatrixMultiply(cameraTransform, worldTransform);

--- a/OpenRA.Mods.Common/Graphics/UIModelRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/UIModelRenderable.cs
@@ -129,8 +129,8 @@ namespace OpenRA.Mods.Common.Graphics
 				foreach (var v in draw)
 				{
 					var bounds = v.Model.Bounds(v.FrameFunc());
-					var worldTransform = v.RotationFunc().Reverse().Aggregate(scaleTransform,
-						(x, y) => OpenRA.Graphics.Util.MatrixMultiply(x, OpenRA.Graphics.Util.MakeFloatMatrix(y.AsMatrix())));
+					var rotation = OpenRA.Graphics.Util.MakeFloatMatrix(v.RotationFunc().AsMatrix());
+					var worldTransform = OpenRA.Graphics.Util.MatrixMultiply(scaleTransform, rotation);
 
 					var pxPos = pxOrigin + wr.ScreenVectorComponents(v.OffsetFunc());
 					var screenTransform = OpenRA.Graphics.Util.MatrixMultiply(cameraTransform, worldTransform);

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var localOffset = Info.LocalOffset + new WVec(-armament.Recoil, WDist.Zero, WDist.Zero);
 			var turretOffset = turreted != null ? turreted.Position(self) : WVec.Zero;
 			var quantizedBody = body.QuantizeOrientation(self, self.Orientation);
-			var turretOrientation = turreted != null ? turreted.WorldOrientation(self) - quantizedBody : WRot.Zero;
+			var turretOrientation = turreted != null ? turreted.WorldOrientation(self) - quantizedBody : WRot.None;
 
 			var quantizedTurret = body.QuantizeOrientation(self, turretOrientation);
 			return turretOffset + body.LocalToWorld(localOffset.Rotate(quantizedTurret).Rotate(quantizedBody));

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly WVec LocalOffset = WVec.Zero;
 
 		[Desc("Rotate the barrel relative to the body")]
-		public readonly WRot LocalOrientation = WRot.Zero;
+		public readonly WRot LocalOrientation = WRot.None;
 
 		[Desc("Defines if the Voxel should have a shadow.")]
 		public readonly bool ShowShadow = true;
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var qb = body.QuantizeOrientation(self, b);
 			var localOffset = Info.LocalOffset + new WVec(-armament.Recoil, WDist.Zero, WDist.Zero);
 			var turretLocalOffset = turreted != null ? turreted.Offset : WVec.Zero;
-			var turretOrientation = turreted != null ? turreted.WorldOrientation(self) - b + WRot.FromYaw(b.Yaw - qb.Yaw) : WRot.Zero;
+			var turretOrientation = turreted != null ? turreted.WorldOrientation(self) - b + WRot.FromYaw(b.Yaw - qb.Yaw) : WRot.None;
 
 			return body.LocalToWorld((turretLocalOffset + localOffset.Rotate(turretOrientation)).Rotate(qb));
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
@@ -57,9 +57,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 			Func<WRot> quantizedTurret = () => body.QuantizeOrientation(turretOrientation(), facings);
 			Func<WRot> quantizedBody = () => body.QuantizeOrientation(orientation(), facings);
 			Func<WVec> barrelOffset = () => body.LocalToWorld((t.Offset + LocalOffset.Rotate(quantizedTurret())).Rotate(quantizedBody()));
-
-			yield return new ModelAnimation(model, barrelOffset, () => new[] { turretOrientation(), orientation() },
-				() => false, () => 0, ShowShadow);
+			Func<WRot> barrelOrientation = () => turretOrientation().Rotate(orientation());
+			yield return new ModelAnimation(model, barrelOffset, barrelOrientation, () => false, () => 0, ShowShadow);
 		}
 	}
 
@@ -97,13 +96,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return body.LocalToWorld((turretLocalOffset + localOffset.Rotate(turretOrientation)).Rotate(qb));
 		}
 
-		IEnumerable<WRot> BarrelRotation()
+		WRot BarrelRotation()
 		{
 			var b = self.Orientation;
 			var qb = body.QuantizeOrientation(self, b);
-			yield return Info.LocalOrientation;
-			yield return turreted.WorldOrientation(self) - b + WRot.FromYaw(b.Yaw - qb.Yaw);
-			yield return qb;
+			var t = turreted.WorldOrientation(self) - b + WRot.FromYaw(b.Yaw - qb.Yaw);
+			return Info.LocalOrientation.Rotate(t).Rotate(qb);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
 			var model = init.World.ModelCache.GetModelSequence(image, Sequence);
 			yield return new ModelAnimation(model, () => WVec.Zero,
-				() => new[] { body.QuantizeOrientation(orientation(), facings) },
+				() => body.QuantizeOrientation(orientation(), facings),
 				() => false, () => 0, ShowShadow);
 		}
 	}
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			var model = self.World.ModelCache.GetModelSequence(rv.Image, info.Sequence);
 			modelAnimation = new ModelAnimation(model, () => WVec.Zero,
-				() => new[] { body.QuantizeOrientation(self, self.Orientation) },
+				() => body.QuantizeOrientation(self, self.Orientation),
 				() => IsTraitDisabled, () => 0, info.ShowShadow);
 
 			rv.Add(modelAnimation);

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
@@ -45,9 +45,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 			Func<WVec> turretOffset = () => body.LocalToWorld(t.Offset.Rotate(orientation()));
 
 			var turretFacing = Turreted.TurretFacingFromInit(init, t);
-			Func<WRot> turretBodyOrientation = () => WRot.FromYaw(turretFacing() - orientation().Yaw);
-			yield return new ModelAnimation(model, turretOffset,
-				() => new[] { turretBodyOrientation(), body.QuantizeOrientation(orientation(), facings) }, () => false, () => 0, ShowShadow);
+			Func<WRot> turretOrientation = () => WRot.FromYaw(turretFacing() - orientation().Yaw)
+				.Rotate(body.QuantizeOrientation(orientation(), facings));
+
+			yield return new ModelAnimation(model, turretOffset, turretOrientation, () => false, () => 0, ShowShadow);
 		}
 	}
 
@@ -71,12 +72,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 				() => IsTraitDisabled, () => 0, info.ShowShadow));
 		}
 
-		IEnumerable<WRot> TurretRotation()
+		WRot TurretRotation()
 		{
 			var b = self.Orientation;
 			var qb = body.QuantizeOrientation(self, b);
-			yield return turreted.WorldOrientation(self) - b + WRot.FromYaw(b.Yaw - qb.Yaw);
-			yield return qb;
+			return (turreted.WorldOrientation(self) - b + WRot.FromYaw(b.Yaw - qb.Yaw)).Rotate(qb);
 		}
 	}
 }


### PR DESCRIPTION
This PR adds the plumbing to convert from a quaternion back to a `WRot`, and uses the quaternions to implement multiplication over rotations. This plumbing will be used by my turret facing rework to finally fix turret/barrel/muzzle positioning and orientation on slopes.

The first commit implements the low level maths - see https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles for more details. #17796 also had an implementation for this, but it relied on floating point calculations that aren't suitable for simulation code.

The second commit changes the voxel rendering to take a single resolved rotation instead of an enumerable that it applies in order. This is technically a step backwards because converting back to a single `WRot` is slower and less precise, but we win significantly in reduced complexity and consistency by being able to use the same implementation for simulation and rendering. We may regret this, but I think its the right choice at least in the short term.

The key tests here are to make sure that the PR maintains the same behaviour as current bleed for turret and muzzle positions on voxel units. You can add `orientation = new WRot(WAngle.Zero, new WAngle(128), WAngle.Zero);` before the `Facing = oldFacing = ...` line in the `Mobile` ctor to check how (broken) it looks for inclined units.

You can do something like
```csharp
for (var i = 0; i <= 1024; i++)
	System.Console.WriteLine("ArcSin(Sin({0})) = {1}", i, WAngle.ArcSin(new WAngle(i).Sin()));
```


to verify that the new `WAngle.ArcSin` and `WAngle.ArcCos` behave as expected - but note that we do expect some disagreement due to (a) the limited integer precision, and (b) the periodic domain of trig functions causing the round-tripped value to be reflected/offset. This precision limitation makes it difficult to write any proper unit tests for this.

While this isn't strictly needed to fix the facing &rarr; WAngle conversion and world &rarr; body origin in `Turreted`, this allows us to do it properly instead of adjusting incorrect code in the short term only to replace it later.