### PR TITLE
Fixed linter for player palettes on weapon defintitions

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Loop a randomly chosen sequence of Image from this list while this projectile is moving.")]
 		public readonly string[] Sequences = { "idle" };
 
-		[PaletteReference]
+		[PaletteReference("IsPlayerPalette")]
 		[Desc("The palette used to draw this projectile.")]
 		public readonly string Palette = "effect";
 

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Loop a randomly chosen sequence of Image from this list while this projectile is moving.")]
 		public readonly string[] Sequences = { "idle" };
 
-		[PaletteReference]
+		[PaletteReference("IsPlayerPalette")]
 		[Desc("Palette used to render the projectile sequence.")]
 		public readonly string Palette = "effect";
 


### PR DESCRIPTION
Stumbled upon by accident. It does error on valid palette setups. Probably an oversight.