### PR TITLE
Fix target lines appearing not long enough on screen

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -20,8 +20,8 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Renders target lines between order waypoints.")]
 	public class DrawLineToTargetInfo : TraitInfo
 	{
-		[Desc("Delay (in ticks) before the target lines disappear.")]
-		public readonly int Delay = 60;
+		[Desc("Delay (in milliseconds) before the target lines disappear.")]
+		public readonly int Delay = 2400;
 
 		[Desc("Width (in pixels) of the target lines.")]
 		public readonly int LineWidth = 1;
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly DrawLineToTargetInfo info;
 		readonly List<IRenderable> renderableCache = new List<IRenderable>();
-		int lifetime;
+		long lifetime;
 
 		public DrawLineToTarget(Actor self, DrawLineToTargetInfo info)
 		{
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			// Reset the order line timeout.
-			lifetime = info.Delay;
+			lifetime = Game.RunTime + info.Delay;
 		}
 
 		void INotifySelected.Selected(Actor self)
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Players want to see the lines when in waypoint mode.
 			var force = Game.GetModifierKeys().HasModifier(Modifiers.Shift) || self.World.OrderGenerator is ForceModifiersOrderGenerator;
 
-			if (--lifetime <= 0 && !force)
+			if (Game.RunTime > lifetime && !force)
 				yield break;
 
 			var pal = wr.Palette(TileSet.TerrainPaletteInternalName);
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Players want to see the lines when in waypoint mode.
 			var force = Game.GetModifierKeys().HasModifier(Modifiers.Shift) || self.World.OrderGenerator is ForceModifiersOrderGenerator;
 
-			if (--lifetime <= 0 && !force)
+			if (Game.RunTime > lifetime && !force)
 				return Enumerable.Empty<IRenderable>();
 
 			renderableCache.Clear();

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ChangeTargetLineDelayToMilliseconds.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ChangeTargetLineDelayToMilliseconds.cs
@@ -1,0 +1,44 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	class ChangeTargetLineDelayToMilliseconds : UpdateRule
+	{
+		public override string Name { get { return "Changed DrawLineToTarget.Delay interpretation from ticks to milliseconds."; } }
+		public override string Description
+		{
+			get
+			{
+				return "Going forward, the value of the `Delay` attribute of the `DrawLineToTarget` trait will be\n" +
+					"interpreted as milliseconds instead of ticks.\n";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var dltt in actorNode.ChildrenMatching("DrawLineToTarget", includeRemovals: false))
+			{
+				var delayNode = dltt.LastChildMatching("Delay", false);
+				if (delayNode != null)
+				{
+					int delay;
+					if (Exts.TryParseIntegerInvariant(delayNode.Value.Value, out delay))
+						delayNode.ReplaceValue((delay * 1000 / 25).ToString());
+				}
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -68,6 +68,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new UpdateTilesetColors(),
 				new UpdateMapInits(),
 				new CreateFlashPaletteEffectWarhead(),
+				new ChangeTargetLineDelayToMilliseconds(),
 			})
 		};
 


### PR DESCRIPTION
Also changes the `Delay` attribute from ticks to milliseconds, as requested in https://github.com/OpenRA/OpenRA/issues/18158#issuecomment-631529473.

Fixes #18158.