### PR TITLE
Add ability for host to disable spawns in game lobby

### DIFF
--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -183,6 +183,7 @@ namespace OpenRA.Network
 		{
 			public string PlayerReference; // PlayerReference to bind against.
 			public bool Closed; // Host has explicitly closed this slot.
+			public int ClosedSpawnPoint; // Optionally closed spawn location selected by this slot
 
 			public bool AllowBots;
 			public bool LockFaction;

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net472</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
     <DebugSymbols>true</DebugSymbols>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <OutputPath>../mods/common</OutputPath>

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -258,6 +258,7 @@ namespace OpenRA.Mods.Common.Server
 			}
 
 			server.LobbyInfo.Slots[s].Closed = true;
+			server.LobbyInfo.Slots[s].ClosedSpawnPoint = 0;
 			server.SyncLobbySlots();
 
 			return true;

--- a/OpenRA.Mods.Common/Traits/World/MPStartLocations.cs
+++ b/OpenRA.Mods.Common/Traits/World/MPStartLocations.cs
@@ -85,6 +85,11 @@ namespace OpenRA.Mods.Common.Traits
 
 			var taken = world.LobbyInfo.Clients.Where(c => c.SpawnPoint != 0 && c.Slot != null)
 					.Select(c => spawns[c.SpawnPoint - 1]).ToList();
+
+			// add closed spawn locations to the taken list
+			taken.AddRange(world.LobbyInfo.Slots.Values.Where(s => s.ClosedSpawnPoint != 0 && s.Closed)
+								.Select(c => spawns[c.ClosedSpawnPoint - 1]));
+
 			var available = spawns.Except(taken).ToList();
 
 			// Set spawn

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -237,9 +237,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				.ToDictionary(c => spawns[c.SpawnPoint - 1], c => new SpawnOccupant(c));
 
 			foreach (var closedSlot in lobbyInfo.Slots.Values.Where(s => s.Closed && s.ClosedSpawnPoint - 1 >= 0 && s.ClosedSpawnPoint - 1 < spawns.Length))
-			{
 				occupants[spawns[closedSlot.ClosedSpawnPoint - 1]] = new SpawnOccupant(closedSlot);
-			}
 
 			return occupants;
 		}
@@ -431,13 +429,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			slot.OnMouseDown = _ => ShowSlotDropDown(slot, s, c, orderManager, map);
 
 			if (s.Closed)
-			{
 				SetupEditableSpawnWidget(parent, s, null, orderManager, map);
-			}
 			else
-			{
 				HideChildWidget(parent, "SPAWN_DROPDOWN");
-			}
 
 			// Ensure Name selector (if present) is hidden
 			HideChildWidget(parent, "NAME");

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -267,13 +267,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var locals = orderManager.LobbyInfo.Clients.Where(c => c.Index == orderManager.LocalClient.Index || (Game.IsHost && c.Bot != null));
 			var playerToMove = locals.FirstOrDefault(c => ((selectedSpawn == 0) ^ (c.SpawnPoint == 0) && !c.IsObserver));
+			var slotToMove = orderManager.LobbyInfo.Slots.Values.FirstOrDefault(s => s.Closed && (selectedSpawn == 0 ^ s.ClosedSpawnPoint == 0));
 
-			if (playerToMove != null && mi.Button == MouseButton.Left)
+			if ((playerToMove != null || slotToMove == null) && mi.Button == MouseButton.Left)
 				SetSpawnPoint(orderManager, null, playerToMove, selectedSpawn);
-			else if (Game.IsHost)
+			else if (Game.IsHost && slotToMove != null)
 			{
 				// we don't have a slot or they used RMB and they are a game host
-				var slotToMove = orderManager.LobbyInfo.Slots.Values.FirstOrDefault(s => s.Closed && (selectedSpawn == 0 ^ s.ClosedSpawnPoint == 0));
 				SetSpawnPoint(orderManager, slotToMove, null, selectedSpawn);
 			}
 		}
@@ -288,7 +288,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			if (selectedSpawn == 0 || !owned)
 			{
-				if (playerToMove != null)
+				// Map selection may pass in a null playerToMove so we use the LocalClient index
+				if (playerToMove != null || closedSlot == null)
 					orderManager.IssueOrder(Order.Command("spawn {0} {1}".F((playerToMove ?? orderManager.LocalClient).Index, selectedSpawn)));
 				else if (closedSlot != null)
 					orderManager.IssueOrder(Order.Command("spawn {0} {1}".F(closedSlot.PlayerReference, selectedSpawn)));

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -273,7 +273,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			else if (Game.IsHost)
 			{
 				// we don't have a slot or they used RMB and they are a game host
-				var slotToMove = orderManager.LobbyInfo.Slots.Values.FirstOrDefault(s => selectedSpawn == 0 ^ s.Closed && s.ClosedSpawnPoint == 0);
+				var slotToMove = orderManager.LobbyInfo.Slots.Values.FirstOrDefault(s => s.Closed && (selectedSpawn == 0 ^ s.ClosedSpawnPoint == 0));
 				SetSpawnPoint(orderManager, slotToMove, null, selectedSpawn);
 			}
 		}
@@ -282,8 +282,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			// we could be setting this for a closed slot or a player
 			// positive number is the client index
-			// negative number is the slot
-			var owned = orderManager.LobbyInfo.Clients.Any(c => c.SpawnPoint == selectedSpawn);
+			// Slot PlayerReference is the slot
+			var owned = orderManager.LobbyInfo.Clients.Any(c => c.SpawnPoint == selectedSpawn)
+				|| orderManager.LobbyInfo.Slots.Values.Any(s => s.Closed && s.ClosedSpawnPoint == selectedSpawn);
 
 			if (selectedSpawn == 0 || !owned)
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -252,7 +252,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		public static void SelectSpawnPoint(OrderManager orderManager, MapPreviewWidget mapPreview, MapPreview preview, MouseInput mi)
 		{
-			if (mi.Button != MouseButton.Left)
+			if (mi.Button != MouseButton.Left && mi.Button != MouseButton.Right)
 				return;
 
 			if (!orderManager.LocalClient.IsObserver && orderManager.LocalClient.State == Session.ClientState.Ready)
@@ -267,7 +267,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var locals = orderManager.LobbyInfo.Clients.Where(c => c.Index == orderManager.LocalClient.Index || (Game.IsHost && c.Bot != null));
 			var playerToMove = locals.FirstOrDefault(c => ((selectedSpawn == 0) ^ (c.SpawnPoint == 0) && !c.IsObserver));
-			SetSpawnPoint(orderManager, null, playerToMove, selectedSpawn);
+
+			if (playerToMove != null && mi.Button == MouseButton.Left)
+				SetSpawnPoint(orderManager, null, playerToMove, selectedSpawn);
+			else if (Game.IsHost)
+			{
+				// we don't have a slot or they used RMB and they are a game host
+				var slotToMove = orderManager.LobbyInfo.Slots.Values.FirstOrDefault(s => selectedSpawn == 0 ^ s.Closed && s.ClosedSpawnPoint == 0);
+				SetSpawnPoint(orderManager, slotToMove, null, selectedSpawn);
+			}
 		}
 
 		private static void SetSpawnPoint(OrderManager orderManager, Session.Slot closedSlot, Session.Client playerToMove, int selectedSpawn)

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -573,7 +573,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		public static void SetupEditableSpawnWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, MapPreview map)
 		{
-			var dropdown = parent.Get<DropDownButtonWidget>("SPAWN_DROPDOWN");
+			var dropdown = parent.GetOrNull<DropDownButtonWidget>("SPAWN_DROPDOWN");
+			if (dropdown == null) return;
+
 			dropdown.IsVisible = () => true;
 			dropdown.IsDisabled = () => s.LockSpawn || orderManager.LocalClient.IsReady;
 			dropdown.OnMouseDown = _ =>

--- a/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
@@ -45,6 +45,13 @@ namespace OpenRA.Mods.Common.Widgets
 			SpawnPoint = player.SpawnPoint;
 		}
 
+		public SpawnOccupant(Session.Slot closedSlot)
+		{
+			SpawnPoint = closedSlot.ClosedSpawnPoint;
+			Color = Color.White;
+			PlayerName = closedSlot.PlayerReference.Substring(closedSlot.PlayerReference.Length - 1);
+		}
+
 		public SpawnOccupant(GameClient player, bool suppressFaction)
 		{
 			Color = player.Color;

--- a/mods/cnc/chrome/lobby-players.yaml
+++ b/mods/cnc/chrome/lobby-players.yaml
@@ -295,6 +295,11 @@ Container@LOBBY_PLAYER_BIN:
 							Height: 25
 							Text: Play in this slot
 							Font: Regular
+						DropDownButton@SPAWN_DROPDOWN:
+							X: 471
+							Width: 50
+							Height: 25
+							Font: Regular
 				Container@TEMPLATE_EDITABLE_SPECTATOR:
 					X: 5
 					Width: 530

--- a/mods/common/chrome/lobby-players.yaml
+++ b/mods/common/chrome/lobby-players.yaml
@@ -289,6 +289,11 @@ Container@LOBBY_PLAYER_BIN:
 							Text: Play in this slot
 							Width: 326
 							Height: 25
+						DropDownButton@SPAWN_DROPDOWN:
+							X: 468
+							Width: 48
+							Height: 25
+							Visible: false
 				Container@TEMPLATE_EDITABLE_SPECTATOR:
 					X: 5
 					Width: 475

--- a/mods/d2k/chrome/lobby-players.yaml
+++ b/mods/d2k/chrome/lobby-players.yaml
@@ -289,6 +289,11 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 326
 							Height: 25
 							Text: Play in this slot
+						DropDownButton@SPAWN_DROPDOWN:
+							X: 468
+							Width: 48
+							Height: 25
+							Visible: false
 				Container@TEMPLATE_EDITABLE_SPECTATOR:
 					X: 5
 					Width: 475


### PR DESCRIPTION
This PR introduces the ability for a host to mark closed slots as occupying certain spawn locations.

This shows a multiplayer game which is syncing the closed slot state.

![image](https://user-images.githubusercontent.com/2775804/87784751-3b9e0b00-c87a-11ea-95c2-b4441bb9cbd0.png)

I bumped the LangVersion to 6 to enable the null propagation operator for one line of code and can be altered to remove the C#6 feature, but having said that is there a reason this project is targeting version 5 still?

Closes #18298.