### PR TITLE
Fix the aircraft facing slider in the editor

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -196,7 +196,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<EditorActorOption> IEditorActorOptions.ActorOptions(ActorInfo ai, World world)
 		{
-			yield return new EditorActorSlider("Facing", EditorFacingDisplayOrder, 0, 1024, 8,
+			yield return new EditorActorSlider("Facing", EditorFacingDisplayOrder, 0, 1023, 8,
 				actor =>
 				{
 					var init = actor.GetInitOrDefault<FacingInit>(this);


### PR DESCRIPTION
Fixes a regression from #18279.

Reproduction case is placing an aircraft in the editor and moving the facing slider to maximum.