### PR TITLE
Add additional .editorconfig naming rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,14 +16,89 @@ indent_size = 4
 dotnet_separate_import_directive_groups = false
 dotnet_sort_system_directives_first = true
 
-csharp_style_var_elsewhere = true
-csharp_style_var_for_built_in_types = true
-csharp_style_var_when_type_is_apparent = true
+csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
 
-csharp_prefer_braces = false
-csharp_using_directive_placement = outside_namespace
+csharp_prefer_braces = false:error
+csharp_using_directive_placement = outside_namespace:suggestion
 csharp_new_line_before_open_brace = all
 csharp_space_around_binary_operators = before_and_after
+
+#### Naming styles ####
+
+dotnet_naming_style.camel_case.capitalization = camel_case
+
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal
+
+dotnet_naming_symbols.const_private_field.applicable_kinds = field
+dotnet_naming_symbols.const_private_field.required_modifiers = const
+dotnet_naming_symbols.const_private_field.applicable_accessibilities = private
+
+dotnet_naming_symbols.internal_field.applicable_kinds = field
+dotnet_naming_symbols.internal_field.applicable_accessibilities = internal
+
+dotnet_naming_symbols.static_private_or_internal_field.required_modifiers = static
+dotnet_naming_symbols.static_private_or_internal_field.applicable_accessibilities = internal, private
+
+dotnet_naming_symbols.private_or_internal_field.applicable_kinds = field
+dotnet_naming_symbols.private_or_internal_field.applicable_accessibilities = internal, private
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal
+
+# Naming rules
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+
+dotnet_naming_rule.static_private_or_internal_field_should_be_pascal_case.severity = none
+dotnet_naming_rule.static_private_or_internal_field_should_be_pascal_case.symbols = static_private_or_internal_field
+dotnet_naming_rule.static_private_or_internal_field_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.const_private_field_should_be_pascal_case.severity = warning
+dotnet_naming_rule.const_private_field_should_be_pascal_case.symbols = const_private_field
+dotnet_naming_rule.const_private_field_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.const_private_or_internal_field_should_be_pascal_case.severity = warning
+dotnet_naming_rule.const_private_or_internal_field_should_be_pascal_case.symbols = internal_field
+dotnet_naming_rule.const_private_or_internal_field_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.private_or_internal_field_should_be_camel_case.severity = warning
+dotnet_naming_rule.private_or_internal_field_should_be_camel_case.symbols = private_or_internal_field
+dotnet_naming_rule.private_or_internal_field_should_be_camel_case.style = camel_case
+
+# Naming rules
+
+#require a space before the colon for bases or interfaces in a type declaration
+csharp_space_after_colon_in_inheritance_clause = true
+#require a space after a keyword in a control flow statement such as a for loop
+csharp_space_after_keywords_in_control_flow_statements = true
+#require a space before the colon for bases or interfaces in a type declaration
+csharp_space_before_colon_in_inheritance_clause = true
+
+#Formatting - wrapping options
+
+#leave code block on single line
+csharp_preserve_single_line_blocks = true
+#leave statements and member declarations on the same line
+csharp_preserve_single_line_statements = true
+
+#prefer the language keyword for member access expressions, instead of the type name, for types that have a keyword to represent them
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+#prefer the language keyword for local variables, method parameters, and class members, instead of the type name, for types that have a keyword to represent them
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 
 ; 4-column tab indentation
 [*.yaml]


### PR DESCRIPTION
I am unsure if you will want to accept this PR, however my Visual Studio has formatting rules that are very different to the coding standards in this repo. I certainly don't want to impose my will on your code, however I would like to contribute. Visual Studio has recently added much more support for dotnet in .editorconfig file and this is helpful to override VS settings to ensure consistency with naming.

I took your existing editorconfig and added some rules that were showing up as warnings on my Visual Studio and tuned them to match the OpenRA codebase as best as I can. While I have not opened every .cs file, it doesn't trigger warnings on the ones I have checked.

Using the [EditorConfig](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.EditorConfig) extension for Visual Studio it highlighed that some of the rules were missing a severity and so I bumped your existing ones to suggestion so the IDE will actually present a suggestion when violating them in the IDE.

Note I bumped the `csharp_prefer_braces` to error here, however it doesn't appear to work on VS 16.6.