### PR TITLE
Add 3D orientation support to Turreted

### DIFF
--- a/OpenRA.Game/WRot.cs
+++ b/OpenRA.Game/WRot.cs
@@ -69,13 +69,24 @@ namespace OpenRA
 			Yaw = -WAngle.ArcTan(sycp, cycp);
 		}
 
+		WRot(int x, int y, int z, int w, WAngle roll, WAngle pitch, WAngle yaw)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+			this.w = w;
+			Roll = roll;
+			Pitch = pitch;
+			Yaw = yaw;
+		}
+
 		public static readonly WRot None = new WRot(WAngle.Zero, WAngle.Zero, WAngle.Zero);
 
 		public static WRot FromFacing(int facing) { return new WRot(WAngle.Zero, WAngle.Zero, WAngle.FromFacing(facing)); }
 		public static WRot FromYaw(WAngle yaw) { return new WRot(WAngle.Zero, WAngle.Zero, yaw); }
 		public static WRot operator +(WRot a, WRot b) { return new WRot(a.Roll + b.Roll, a.Pitch + b.Pitch, a.Yaw + b.Yaw); }
 		public static WRot operator -(WRot a, WRot b) { return new WRot(a.Roll - b.Roll, a.Pitch - b.Pitch, a.Yaw - b.Yaw); }
-		public static WRot operator -(WRot a) { return new WRot(-a.Roll, -a.Pitch, -a.Yaw); }
+		public static WRot operator -(WRot a) { return new WRot(-a.x, -a.y, -a.z, a.w, -a.Roll, -a.Pitch, -a.Yaw); }
 
 		public WRot Rotate(WRot rot)
 		{

--- a/OpenRA.Mods.Cnc/Traits/Render/WithEmbeddedTurretSpriteBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithEmbeddedTurretSpriteBody.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 			var wsb = init.Actor.TraitInfos<WithSpriteBodyInfo>().FirstOrDefault();
 
 			// Show the correct turret facing
-			var anim = new Animation(init.World, image, Turreted.TurretFacingFromInit(init, t));
+			var anim = new Animation(init.World, image, t.WorldFacingFromInit(init));
 			anim.PlayRepeating(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), wsb.Sequence));
 
 			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, p, rs.Scale);
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		{
 			// Turret artwork is baked into the sprite, so only the first turret makes sense.
 			var turreted = self.TraitsImplementing<Turreted>().FirstOrDefault();
-			return () => WAngle.FromFacing(turreted.TurretFacing);
+			return () => turreted.WorldOrientation.Yaw;
 		}
 
 		public WithEmbeddedTurretSpriteBody(ActorInitializer init, WithSpriteBodyInfo info)

--- a/OpenRA.Mods.Cnc/Traits/Render/WithGunboatBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithGunboatBody.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		{
 			// Turret artwork is baked into the sprite, so only the first turret makes sense.
 			var turreted = self.TraitsImplementing<Turreted>().FirstOrDefault();
-			return () => WAngle.FromFacing(turreted.TurretFacing);
+			return () => turreted.WorldOrientation.Yaw;
 		}
 
 		public WithGunboatBody(ActorInitializer init, WithGunboatBodyInfo info)

--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -84,15 +84,7 @@ namespace OpenRA.Mods.Common.Activities
 				var targetPosition = self.CenterPosition + body.LocalToWorld(localOffset);
 				var targetLocation = self.World.Map.CellContaining(targetPosition);
 				carryall.Carryable.Trait<IPositionable>().SetPosition(carryall.Carryable, targetLocation, SubCell.FullCell);
-
-				// HACK: directly manipulate the turret facings to match the new orientation
-				// This can eventually go away, when we make turret facings relative to the body
-				var carryableFacing = carryall.Carryable.Trait<IFacing>();
-				var facingDelta = facing.Facing - carryableFacing.Facing;
-				foreach (var t in carryall.Carryable.TraitsImplementing<Turreted>())
-					t.TurretFacing += facingDelta.Facing;
-
-				carryableFacing.Facing = facing.Facing;
+				carryall.Carryable.Trait<IFacing>().Facing = facing.Facing;
 
 				// Put back into world
 				self.World.AddFrameEndTask(w =>

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -371,9 +371,6 @@ namespace OpenRA.Mods.Common.Traits
 			var passengerFacing = passenger.TraitOrDefault<IFacing>();
 			if (passengerFacing != null)
 				passengerFacing.Facing = facing.Value.Facing + Info.PassengerFacing;
-
-			foreach (var t in passenger.TraitsImplementing<Turreted>())
-				t.TurretFacing = (facing.Value.Facing + Info.PassengerFacing).Facing;
 		}
 
 		public void Load(Actor self, Actor a)

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -110,9 +110,15 @@ namespace OpenRA.Mods.Common.Traits
 
 				foreach (var b in a.Barrels)
 				{
+					var barrelEnd = new Barrel
+					{
+						Offset = b.Offset + new WVec(224, 0, 0),
+						Yaw = b.Yaw
+					};
+
 					var muzzle = self.CenterPosition + a.MuzzleOffset(self, b);
-					var dirOffset = new WVec(0, -224, 0).Rotate(a.MuzzleOrientation(self, b));
-					yield return new LineAnnotationRenderable(muzzle, muzzle + dirOffset, 1, Color.White);
+					var endMuzzle = self.CenterPosition + a.MuzzleOffset(self, barrelEnd);
+					yield return new LineAnnotationRenderable(muzzle, endMuzzle, 1, Color.White);
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/HitShape.cs
+++ b/OpenRA.Mods.Common/Traits/HitShape.cs
@@ -109,11 +109,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (turret != null)
 			{
-				// WorldOrientation is quantized to satisfy the *Fudges.
-				// Need to then convert back to a pseudo-local coordinate space, apply offsets,
-				// then rotate back at the end
-				var turretOrientation = turret.WorldOrientation(self) - quantizedBodyOrientation;
-				localOffset = localOffset.Rotate(turretOrientation);
+				localOffset = localOffset.Rotate(turret.LocalOrientation);
 				localOffset += turret.Offset;
 			}
 
@@ -122,27 +118,15 @@ namespace OpenRA.Mods.Common.Traits
 
 		public WDist DistanceFromEdge(Actor self, WPos pos)
 		{
-			var origin = self.CenterPosition;
-			var orientation = self.Orientation;
-			if (turret != null)
-			{
-				origin += turret.Position(self);
-				orientation = turret.WorldOrientation(self);
-			}
-
+			var origin = turret != null ? self.CenterPosition + turret.Position(self) : self.CenterPosition;
+			var orientation = turret != null ? turret.WorldOrientation : self.Orientation;
 			return Info.Type.DistanceFromEdge(pos, origin, orientation);
 		}
 
 		public IEnumerable<IRenderable> RenderDebugOverlay(Actor self, WorldRenderer wr)
 		{
-			var origin = self.CenterPosition;
-			var orientation = self.Orientation;
-			if (turret != null)
-			{
-				origin += turret.Position(self);
-				orientation = turret.WorldOrientation(self);
-			}
-
+			var origin = turret != null ? self.CenterPosition + turret.Position(self) : self.CenterPosition;
+			var orientation = turret != null ? turret.WorldOrientation : self.Orientation;
 			return Info.Type.RenderDebugOverlay(wr, origin, orientation);
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
@@ -52,10 +52,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 					var turreted = self.TraitsImplementing<Turreted>()
 						.FirstOrDefault(t => t.Name == arm.Info.Turret);
 
-					// Workaround for broken ternary operators in certain versions of mono (3.10 and
-					// certain versions of the 3.8 series): https://bugzilla.xamarin.com/show_bug.cgi?id=23319
 					if (turreted != null)
-						getFacing = () => WAngle.FromFacing(turreted.TurretFacing);
+						getFacing = () => turreted.WorldOrientation.Yaw;
 					else if (facing != null)
 						getFacing = () => facing.Facing;
 					else

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var t = init.Actor.TraitInfos<TurretedInfo>()
 				.First(tt => tt.Turret == Turret);
 
-			var turretFacing = Turreted.TurretFacingFromInit(init, t);
+			var turretFacing = t.WorldFacingFromInit(init);
 			var anim = new Animation(init.World, image, turretFacing);
 			anim.Play(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence));
 
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			arms = self.TraitsImplementing<Armament>()
 				.Where(w => w.Info.Turret == info.Turret).ToArray();
 
-			DefaultAnimation = new Animation(self.World, rs.GetImage(self), () => WAngle.FromFacing(t.TurretFacing));
+			DefaultAnimation = new Animation(self.World, rs.GetImage(self), () => t.WorldOrientation.Yaw);
 			DefaultAnimation.PlayRepeating(NormalizeSequence(self, info.Sequence));
 			rs.Add(new AnimationWithOffset(DefaultAnimation,
 				() => TurretOffset(self),
@@ -106,10 +106,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (!Info.Recoils)
 				return t.Position(self);
 
-			var recoil = arms.Aggregate(WDist.Zero, (a, b) => a + b.Recoil);
-			var localOffset = new WVec(-recoil, WDist.Zero, WDist.Zero);
-			var quantizedWorldTurret = t.WorldOrientation(self);
-			return t.Position(self) + body.LocalToWorld(localOffset.Rotate(quantizedWorldTurret));
+			var recoilDist = arms.Aggregate(WDist.Zero, (a, b) => a + b.Recoil);
+			var recoil = new WVec(-recoilDist, WDist.Zero, WDist.Zero);
+			return t.Position(self) + body.LocalToWorld(recoil.Rotate(t.WorldOrientation));
 		}
 
 		public string NormalizeSequence(Actor self, string sequence)

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
@@ -51,13 +51,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			var model = init.World.ModelCache.GetModelSequence(image, Sequence);
 
-			var turretFacing = Turreted.TurretFacingFromInit(init, t);
-			Func<WRot> turretOrientation = () => body.QuantizeOrientation(WRot.FromYaw(turretFacing() - orientation().Yaw), facings);
-
-			Func<WRot> quantizedTurret = () => body.QuantizeOrientation(turretOrientation(), facings);
+			var turretOrientation = t.PreviewOrientation(init, orientation, facings);
 			Func<WRot> quantizedBody = () => body.QuantizeOrientation(orientation(), facings);
-			Func<WVec> barrelOffset = () => body.LocalToWorld((t.Offset + LocalOffset.Rotate(quantizedTurret())).Rotate(quantizedBody()));
-			Func<WRot> barrelOrientation = () => turretOrientation().Rotate(orientation());
+			Func<WVec> barrelOffset = () => body.LocalToWorld((t.Offset + LocalOffset.Rotate(turretOrientation())).Rotate(quantizedBody()));
+			Func<WRot> barrelOrientation = () => LocalOrientation.Rotate(turretOrientation()).Rotate(quantizedBody());
+
 			yield return new ModelAnimation(model, barrelOffset, barrelOrientation, () => false, () => 0, ShowShadow);
 		}
 	}
@@ -87,21 +85,15 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		WVec BarrelOffset()
 		{
-			var b = self.Orientation;
-			var qb = body.QuantizeOrientation(self, b);
+			var orientation = turreted != null ? turreted.WorldOrientation : self.Orientation;
 			var localOffset = Info.LocalOffset + new WVec(-armament.Recoil, WDist.Zero, WDist.Zero);
 			var turretLocalOffset = turreted != null ? turreted.Offset : WVec.Zero;
-			var turretOrientation = turreted != null ? turreted.WorldOrientation(self) - b + WRot.FromYaw(b.Yaw - qb.Yaw) : WRot.None;
-
-			return body.LocalToWorld((turretLocalOffset + localOffset.Rotate(turretOrientation)).Rotate(qb));
+			return body.LocalToWorld(turretLocalOffset + localOffset.Rotate(orientation));
 		}
 
 		WRot BarrelRotation()
 		{
-			var b = self.Orientation;
-			var qb = body.QuantizeOrientation(self, b);
-			var t = turreted.WorldOrientation(self) - b + WRot.FromYaw(b.Yaw - qb.Yaw);
-			return Info.LocalOrientation.Rotate(t).Rotate(qb);
+			return Info.LocalOrientation.Rotate(turreted != null ? turreted.WorldOrientation : self.Orientation);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 			// TODO: Carry orientation over from the parent instead of just facing
 			var dynamicFacingInit = init.GetOrDefault<DynamicFacingInit>();
 			var bodyFacing = dynamicFacingInit != null ? dynamicFacingInit.Value() : init.GetValue<FacingInit, WAngle>(WAngle.Zero);
-			facing = Turreted.TurretFacingFromInit(init, info, WAngle.Zero)();
+			facing = TurretedInfo.WorldFacingFromInit(init, info, WAngle.Zero)();
 
 			// Calculate final position
 			var throwRotation = WRot.FromYaw(new WAngle(Game.CosmeticRandom.Next(1024)));


### PR DESCRIPTION
Turret facings are now specified relative to the body, not the world, and the position and orientation calculations have been fixed to work properly when the actor has non-zero pitch or roll.

The testcase commit demonstrates this by bodging actor orientations on slopes in TS.

Fixes #15843.
Depends on #18382.

This makes a start towards https://github.com/OpenRA/OpenRA/pull/18396#discussion_r453309476 by removing WRot +/- from turret and muzzle calculations. There are several more uses in the hitshape code, which I would prefer to complete in a separate PR rather than delay this one (which IMO is important for the next playtest) further.