### PR TITLE
Fix actor previews for actors with types written in capital letters

### DIFF
--- a/OpenRA.Mods.Common/Graphics/ActorPreview.cs
+++ b/OpenRA.Mods.Common/Graphics/ActorPreview.cs
@@ -39,12 +39,12 @@ namespace OpenRA.Mods.Common.Graphics
 		{
 			Actor = actor;
 			WorldRenderer = worldRenderer;
-			reference = new ActorReference(actor.Name, dict);
+			reference = new ActorReference(actor.Name.ToLowerInvariant(), dict);
 		}
 
 		public ActorPreviewInitializer(ActorReference actor, WorldRenderer worldRenderer)
 		{
-			Actor = worldRenderer.World.Map.Rules.Actors[actor.Type];
+			Actor = worldRenderer.World.Map.Rules.Actors[actor.Type.ToLowerInvariant()];
 			reference = actor;
 			WorldRenderer = worldRenderer;
 		}


### PR DESCRIPTION
A current example can be found in #16827. It works in the PR's current state, but after rebasing to bleed opening maps in the editor will throw an exception.

This regressed in https://github.com/OpenRA/OpenRA/pull/18264/commits/972ed5a8ce862326d17ffe8250dbdee51c4f906b