### PR TITLE
Add a death animation to visceroids

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -632,6 +632,8 @@
 			Radius: 427
 	MapEditorData:
 		Categories: Critter
+	WithDeathAnimation:
+		UseDeathTypeSuffix: false
 
 ^Plane:
 	Inherits@1: ^ExistsInWorld

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -189,6 +189,8 @@ World:
 	CustomTerrainDebugOverlay:
 	MapCreeps:
 		CheckboxVisible: False
+		CheckboxEnabled: True
+		CheckboxLocked: True
 	SpawnMapActors:
 	MapBuildRadius:
 		AllyBuildRadiusCheckboxDisplayOrder: 4

--- a/mods/cnc/sequences/infantry.yaml
+++ b/mods/cnc/sequences/infantry.yaml
@@ -29,6 +29,9 @@ vice:
 				Offset: -3,2
 		Facings: 8
 		Length: 13
+	die: chemball
+		Length: *
+		ZOffset: 2047
 	icon: viceicnh
 
 pvice:


### PR DESCRIPTION
Closes #18416.

The first commit also force enables Visceroids, since they might have ended up disabled if you changed map from a map that did disable them.

I couldn't get any Visceroids to spawn in the remasters, so not sure what they do. There doesn't appear to be a death animation, but imo the chem explosion looks good enough (and is better than just disappearing).