### PR TITLE
Add flash to mission nukes

### DIFF
--- a/mods/ra/maps/fall-of-greece-1-personal-war/weapons.yaml
+++ b/mods/ra/maps/fall-of-greece-1-personal-war/weapons.yaml
@@ -57,3 +57,6 @@ ParaBomb:
 		ValidTargets: Ground, Infantry
 		Size: 3
 		Delay: 10
+	Warhead@13FlashEffect: FlashPaletteEffect
+		Duration: 20
+		FlashType: Nuke

--- a/mods/ra/maps/situation-critical/weapons.yaml
+++ b/mods/ra/maps/situation-critical/weapons.yaml
@@ -75,3 +75,6 @@ ParaBomb:
 		ValidTargets: Ground, Infantry
 		Size: 3
 		Delay: 10
+	Warhead@13FlashEffect: FlashPaletteEffect
+		Duration: 20
+		FlashType: Nuke


### PR DESCRIPTION
This adds flashes via #17284 to the para-nukes in Personal War and Situation Critical.