### PR TITLE
Lua API - Added an optional Actor parameter to UnloadPassenger

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/TransportProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/TransportProperties.cs
@@ -44,8 +44,8 @@ namespace OpenRA.Mods.Common.Scripting
 			cargo.Load(Self, a);
 		}
 
-		[Desc("Remove the first actor from the transport.  This actor is not added to the world.")]
-		public Actor UnloadPassenger() { return cargo.Unload(Self); }
+		[Desc("Remove an existing actor (or first actor if none specified) from the transport.  This actor is not added to the world.")]
+		public Actor UnloadPassenger(Actor a = null) { return cargo.Unload(Self, a); }
 
 		[ScriptActorPropertyActivity]
 		[Desc("Command transport to unload passengers.")]


### PR DESCRIPTION
This adds an optional Actor parameter to `UnloadPassenger()` in the Lua API. Current use of `UnloadPassenger()` still works, and this matches cargo's `Unload` in C#.

Test case commit added.