### PR TITLE
Let CaptureActor activity properly cancel when the target capturable trait is disabled.

### DIFF
--- a/OpenRA.Mods.Common/Activities/CaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/CaptureActor.cs
@@ -28,6 +28,19 @@ namespace OpenRA.Mods.Common.Activities
 			manager = self.Trait<CaptureManager>();
 		}
 
+		protected override void TickInner(Actor self, Target target, bool targetIsDeadOrHiddenActor)
+		{
+			if (target.Type == TargetType.Actor && enterActor != target.Actor)
+			{
+				enterActor = target.Actor;
+				enterCaptureManager = target.Actor.TraitOrDefault<CaptureManager>();
+			}
+
+			if (!targetIsDeadOrHiddenActor && target.Type != TargetType.FrozenActor &&
+				(enterCaptureManager == null || !enterCaptureManager.CanBeTargetedBy(enterActor, self, manager)))
+				Cancel(self, true);
+		}
+
 		protected override bool TryStartEnter(Actor self, Actor targetActor)
 		{
 			if (enterActor != targetActor)

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -590,6 +590,13 @@
 	Explodes:
 		Weapon: UnitExplode
 		RequiresCondition: !airborne
+	CaptureManager:
+	Capturable:
+		Types: aircraft
+		RequiresCondition: !airborne
+	CaptureNotification:
+		Notification: UnitStolen
+		LoseNotification: UnitLost
 
 ^Plane:
 	Inherits: ^NeutralPlane

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -575,7 +575,7 @@ THF:
 		CustomPipType: blue
 	CaptureManager:
 	Captures:
-		CaptureTypes: vehicle
+		CaptureTypes: vehicle, aircraft
 		PlayerExperience: 50
 	Infiltrates:
 		Types: ThiefInfiltrate


### PR DESCRIPTION
Fixes #18428

Using Punsho's testcase for making aircraft capturable when landed.