### PR TITLE
Remove unneeded chrome yaml declarations

### DIFF
--- a/mods/cnc/chrome.yaml
+++ b/mods/cnc/chrome.yaml
@@ -365,23 +365,18 @@ scrollpanel-decorations:
 	Inherits: ^Chrome
 	Regions:
 		down: 836, 17, 16, 16
-		down-pressed: 836, 17, 16, 16
 		down-disabled: 853, 17, 16, 16
 		up: 870, 17, 16, 16
-		up-pressed: 870, 17, 16, 16
 		up-disabled: 887, 17, 16, 16
 		right: 904, 17, 16, 16
-		right-pressed: 904, 17, 16, 16
 		right-disabled: 921, 17, 16, 16
 		left: 938, 17, 16, 16
-		left-pressed: 938, 17, 16, 16
 		left-disabled: 955, 17, 16, 16
 
 dropdown-decorations:
 	Inherits: ^Chrome
 	Regions:
 		marker: 836, 17, 16, 16
-		marker-pressed: 836, 17, 16, 16
 		marker-disabled: 853, 17, 16, 16
 
 dropdown-separators:

--- a/mods/ra/chrome.yaml
+++ b/mods/ra/chrome.yaml
@@ -557,23 +557,18 @@ scrollpanel-decorations:
 	Inherits: ^Glyphs
 	Regions:
 		down: 68, 17, 16, 16
-		down-pressed: 68, 17, 16, 16
 		down-disabled: 85, 17, 16, 16
 		up: 102, 17, 16, 16
-		up-pressed: 102, 17, 16, 16
 		up-disabled: 119, 17, 16, 16
 		right: 136, 17, 16, 16
-		right-pressed: 136, 17, 16, 16
 		right-disabled: 153, 17, 16, 16
 		left: 170, 17, 16, 16
-		left-pressed: 170, 17, 16, 16
 		left-disabled: 187, 17, 16, 16
 
 dropdown-decorations:
 	Inherits: ^Glyphs
 	Regions:
 		marker: 68, 17, 16, 16
-		marker-pressed: 68, 17, 16, 16
 		marker-disabled: 85, 17, 16, 16
 
 dropdown-separators:

--- a/mods/ts/chrome.yaml
+++ b/mods/ts/chrome.yaml
@@ -679,23 +679,18 @@ scrollpanel-decorations:
 	Inherits: ^Glyphs
 	Regions:
 		down: 68, 17, 16, 16
-		down-pressed: 68, 17, 16, 16
 		down-disabled: 85, 17, 16, 16
 		up: 102, 17, 16, 16
-		up-pressed: 102, 17, 16, 16
 		up-disabled: 119, 17, 16, 16
 		right: 136, 17, 16, 16
-		right-pressed: 136, 17, 16, 16
 		right-disabled: 153, 17, 16, 16
 		left: 170, 17, 16, 16
-		left-pressed: 170, 17, 16, 16
 		left-disabled: 187, 17, 16, 16
 
 dropdown-decorations:
 	Inherits: ^Glyphs
 	Regions:
 		marker: 68, 17, 16, 16
-		marker-pressed: 68, 17, 16, 16
 		marker-disabled: 85, 17, 16, 16
 
 dropdown-separators:


### PR DESCRIPTION
An oversight from #17663

These declarations are not needed because dropdowns and scrollbars fall back to the base name if there is no image defined for a given state and the state sprites in these cases are the same as the base.