### PR TITLE
Fix subs targeting naval structures by default

### DIFF
--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -51,6 +51,7 @@ SS:
 	AttackFrontal:
 	AutoTargetPriority@DEFAULT:
 		ValidTargets: WaterActor, Underwater
+		InvalidTargets: NoAutoTarget, Structure
 	AutoTargetPriority@ATTACKANYTHING:
 		ValidTargets: WaterActor, Underwater
 	DetectCloaked:


### PR DESCRIPTION
Fixes a 'regression' from https://github.com/OpenRA/OpenRA/pull/18237#issuecomment-640085263 (it was there for a longer time but now more visible, so we should fix it for the next release).