### PR TITLE
Fix the position of the red cross in RA

### DIFF
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -387,6 +387,7 @@
 		Image: pips
 		Sequence: medic
 		Position: BottomRight
+		Margin: 17, 4
 		RequiresCondition: hospitalheal
 		BlinkInterval: 32
 		BlinkPattern: Off, On


### PR DESCRIPTION
Closes #18442.

This should look relatively similar to the screenshot @Smittytron provided now:
![grafik](https://user-images.githubusercontent.com/7704140/88487908-91b13380-cf89-11ea-94d1-38b381f278cc.png)
