### PR TITLE
Add actor experience to the Lua API

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/GainsExperienceProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GainsExperienceProperties.cs
@@ -1,0 +1,53 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Scripting;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Scripting
+{
+	[ScriptPropertyGroup("Experience")]
+	public class GainsExperienceProperties : ScriptActorProperties, Requires<GainsExperienceInfo>
+	{
+		readonly GainsExperience exp;
+
+		public GainsExperienceProperties(ScriptContext context, Actor self)
+			: base(context, self)
+		{
+			exp = self.Trait<GainsExperience>();
+		}
+
+		[Desc("The actor's amount of experience.")]
+		public int Experience { get { return exp.Experience; } }
+
+		[Desc("The actor's level.")]
+		public int Level { get { return exp.Level; } }
+
+		[Desc("The actor's maximum possible level.")]
+		public int MaxLevel { get { return exp.MaxLevel; } }
+
+		[Desc("Returns true if the actor can gain a level.")]
+		public bool CanGainLevel { get { return exp.CanGainLevel; } }
+
+		[Desc("Gives the actor experience. If 'silent' is true, no animation or sound will be played if the actor levels up.")]
+		public void GiveExperience(int amount, bool silent = false)
+		{
+			exp.GiveExperience(amount, silent);
+		}
+
+		[Desc("Gives the actor level(s). If 'silent' is true, no animation or sound will be played.")]
+		public void GiveLevels(int numLevels, bool silent = false)
+		{
+			exp.GiveLevels(numLevels, silent);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		// Stored as a percentage of our value
 		[Sync]
-		int experience = 0;
+		public int Experience { get; private set; }
 
 		[Sync]
 		public int Level { get; private set; }
@@ -73,6 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 			self = init.Self;
 			this.info = info;
 
+			Experience = 0;
 			MaxLevel = info.Conditions.Count;
 			initialExperience = init.GetValue<ExperienceInit, int>(info, 0);
 		}
@@ -96,7 +97,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			var newLevel = Math.Min(Level + numLevels, MaxLevel);
-			GiveExperience(nextLevel[newLevel - 1].First - experience, silent);
+			GiveExperience(nextLevel[newLevel - 1].First - Experience, silent);
 		}
 
 		public void GiveExperience(int amount, bool silent = false)
@@ -107,9 +108,9 @@ namespace OpenRA.Mods.Common.Traits
 			if (MaxLevel == 0)
 				return;
 
-			experience = (experience + amount).Clamp(0, nextLevel[MaxLevel - 1].First);
+			Experience = (Experience + amount).Clamp(0, nextLevel[MaxLevel - 1].First);
 
-			while (Level < MaxLevel && experience >= nextLevel[Level].First)
+			while (Level < MaxLevel && Experience >= nextLevel[Level].First)
 			{
 				self.GrantCondition(nextLevel[Level].Second);
 
@@ -141,7 +142,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ITransformActorInitModifier.ModifyTransformActorInit(Actor self, TypeDictionary init)
 		{
-			init.Add(new ExperienceInit(info, experience));
+			init.Add(new ExperienceInit(info, Experience));
 		}
 	}
 


### PR DESCRIPTION
This exposes several `GainsExperience` properties and functions to the Lua API. I have interest getting an actor's `Experience` so I can provide it in an ActorInit (cloning an existing actor), and I may implement purchasing actor levels in a custom map.

A test case commit is attached that demonstrates the additions.