### PR TITLE
WithLandingCraftAnimation now can correctly indentify when the movement stop

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Render/WithLandingCraftAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithLandingCraftAnimation.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 
 		public bool ShouldBeOpen()
 		{
-			if (move.CurrentMovementTypes.HasFlag(MovementType.Horizontal) || self.World.Map.DistanceAboveTerrain(self.CenterPosition).Length > 0)
+			if (move.CurrentMovementTypes != MovementType.None || self.World.Map.DistanceAboveTerrain(self.CenterPosition).Length > 0)
 				return false;
 
 			return cargo.CurrentAdjacentCells.Any(c => self.World.Map.Contains(c)


### PR DESCRIPTION
Which make open/close door for all kinds of SHP transport possible, they won't open/close the door when they are still in movement:
![1](https://user-images.githubusercontent.com/13763394/88680235-db815180-d122-11ea-8d70-339d171244b3.gif)
This is a subterranean drill apc/pod by using this fix.