### PR TITLE
Support mod defined vertex buffers and shaders.

### DIFF
--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using OpenRA.Graphics;
 using OpenRA.Primitives;
 
 namespace OpenRA
@@ -79,7 +78,7 @@ namespace OpenRA
 
 	public interface IGraphicsContext : IDisposable
 	{
-		IVertexBuffer<Vertex> CreateVertexBuffer(int size);
+		IVertexBuffer<T> CreateVertexBuffer<T>(int size) where T : struct;
 		ITexture CreateTexture();
 		IFrameBuffer CreateFrameBuffer(Size s);
 		IFrameBuffer CreateFrameBuffer(Size s, Color clearColor);
@@ -99,6 +98,7 @@ namespace OpenRA
 
 	public interface IVertexBuffer<T> : IDisposable
 	{
+		int Length { get; }
 		void Bind();
 		void SetData(T[] vertices, int length);
 		void SetData(T[] vertices, int start, int length);

--- a/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
+++ b/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Graphics
 			rowStride = 6 * map.MapSize.X;
 
 			vertices = new Vertex[rowStride * map.MapSize.Y];
-			vertexBuffer = Game.Renderer.Context.CreateVertexBuffer(vertices.Length);
+			vertexBuffer = Game.Renderer.Context.CreateVertexBuffer<Vertex>(vertices.Length);
 			emptySprite = new Sprite(sheet, Rectangle.Empty, TextureChannel.Alpha);
 
 			wr.PaletteInvalidated += UpdatePaletteIndices;

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -92,7 +92,7 @@ namespace OpenRA
 			RgbaSpriteRenderer = new RgbaSpriteRenderer(SpriteRenderer);
 			RgbaColorRenderer = new RgbaColorRenderer(SpriteRenderer);
 
-			tempBuffer = Context.CreateVertexBuffer(TempBufferSize);
+			tempBuffer = Context.CreateVertexBuffer<Vertex>(TempBufferSize);
 		}
 
 		static Size GetResolution(GraphicSettings graphicsSettings)
@@ -335,9 +335,14 @@ namespace OpenRA
 			}
 		}
 
-		public IVertexBuffer<Vertex> CreateVertexBuffer(int length)
+		public IVertexBuffer<T> CreateVertexBuffer<T>(int length) where T : struct
 		{
-			return Context.CreateVertexBuffer(length);
+			return Context.CreateVertexBuffer<T>(length);
+		}
+
+		public IShader CreateShader(string name)
+		{
+			return Context.CreateShader(name);
 		}
 
 		public void EnableScissor(Rectangle rect)

--- a/OpenRA.Mods.Cnc/Graphics/VoxelLoader.cs
+++ b/OpenRA.Mods.Cnc/Graphics/VoxelLoader.cs
@@ -196,7 +196,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 		{
 			if (vertexBuffer != null)
 				vertexBuffer.Dispose();
-			vertexBuffer = Game.Renderer.CreateVertexBuffer(totalVertexCount);
+			vertexBuffer = Game.Renderer.CreateVertexBuffer<Vertex>(totalVertexCount);
 			vertexBuffer.SetData(vertices.SelectMany(v => v).ToArray(), totalVertexCount);
 			cachedVertexCount = totalVertexCount;
 		}

--- a/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using OpenRA.Graphics;
 using OpenRA.Primitives;
 using SDL2;
 
@@ -57,10 +56,10 @@ namespace OpenRA.Platforms.Default
 			OpenGL.CheckGLError();
 		}
 
-		public IVertexBuffer<Vertex> CreateVertexBuffer(int size)
+		public IVertexBuffer<T> CreateVertexBuffer<T>(int size) where T : struct
 		{
 			VerifyThreadAffinity();
-			return new VertexBuffer<Vertex>(size);
+			return new VertexBuffer<T>(size);
 		}
 
 		public ITexture CreateTexture()

--- a/OpenRA.Platforms.Default/Shader.cs
+++ b/OpenRA.Platforms.Default/Shader.cs
@@ -31,9 +31,11 @@ namespace OpenRA.Platforms.Default
 
 		protected uint CompileShaderObject(int type, string name)
 		{
+			Stream stream;
+
 			var ext = type == OpenGL.GL_VERTEX_SHADER ? "vert" : "frag";
-			var filename = Path.Combine(Platform.GameDir, "glsl", name + "." + ext);
-			var code = File.ReadAllText(filename);
+			var filename = name + "." + ext;
+			var code = Game.ModData != null && Game.ModData.DefaultFileSystem.TryOpen(filename, out stream) ? stream.ReadAllText() : File.ReadAllText(Path.Combine(Platform.GameDir, "glsl", filename));
 
 			var version = OpenGL.Profile == GLProfile.Embedded ? "300 es" :
 				OpenGL.Profile == GLProfile.Legacy ? "120" : "140";

--- a/OpenRA.Platforms.Default/VertexBuffer.cs
+++ b/OpenRA.Platforms.Default/VertexBuffer.cs
@@ -21,8 +21,11 @@ namespace OpenRA.Platforms.Default
 		uint buffer;
 		bool disposed;
 
+		public int Length { get; private set; }
+
 		public VertexBuffer(int size)
 		{
+			Length = size;
 			OpenGL.glGenBuffers(1, out buffer);
 			OpenGL.CheckGLError();
 			Bind();
@@ -62,6 +65,7 @@ namespace OpenRA.Platforms.Default
 
 		public void SetData(T[] data, int start, int length)
 		{
+			Length = length;
 			Bind();
 
 			var ptr = GCHandle.Alloc(data, GCHandleType.Pinned);
@@ -82,6 +86,7 @@ namespace OpenRA.Platforms.Default
 
 		public void SetData(IntPtr data, int start, int length)
 		{
+			Length = length;
 			Bind();
 			OpenGL.glBufferSubData(OpenGL.GL_ARRAY_BUFFER,
 				new IntPtr(VertexSize * start),


### PR DESCRIPTION
Title says all. This allows mods to load up their own glsl shaders and assign a proper vertex buffer to it. This allows mods for example to load up 3d assets from any custom mod, animate it, and render it as it should.