### PR TITLE
Fix MiG missiles damaging airborne actors

### DIFF
--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -58,6 +58,7 @@ Maverick:
 		CruiseAltitude: 2c0
 		RangeLimit: 14c410
 	Warhead@1Dam: SpreadDamage
+		InvalidTargets: AirborneActor
 		Damage: 7000
 		Versus:
 			None: 30


### PR DESCRIPTION
Reported by @Orb370 on Discord: https://clips.twitch.tv/InquisitiveAlluringPeachKevinTurtle

Only disables the damage of the impact.