### PR TITLE
Reduce subfactions to one trait

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -295,7 +295,7 @@ SPY:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 90
-		Prerequisites: ~!infantry.england, dome, ~tent, ~techlevel.medium
+		Prerequisites: dome, ~tent, ~techlevel.medium
 		Description: Infiltrates enemy structures for intel or\nsabotage. Exact effect depends on the\nbuilding infiltrated.\nLoses disguise when attacking.\nCan detect spies.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft\n  Special Ability: Disguised
 	Valued:
 		Cost: 500
@@ -342,19 +342,6 @@ SPY:
 		Voice: Move
 	Voiced:
 		VoiceSet: SpyVoice
-
-SPY.England:
-	Inherits: SPY
-	Buildable:
-		Prerequisites: ~infantry.england, dome, ~tent, ~techlevel.medium
-	Valued:
-		Cost: 250
-	GivesExperience:
-		Experience: 500
-	DisguiseTooltip:
-		Name: British Spy
-	RenderSprites:
-		Image: spy
 
 E7:
 	Inherits: ^Soldier
@@ -610,7 +597,7 @@ SHOK:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 130
-		Prerequisites: ~barr, stek, tsla, ~infantry.russia, ~techlevel.high
+		Prerequisites: ~barr, stek, tsla, ~techlevel.high
 		Description: Elite infantry with portable Tesla coils.\n  Strong vs Infantry, Vehicles\n  Weak vs Aircraft
 	Valued:
 		Cost: 350

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1525,28 +1525,6 @@ AFLD:
 		UseDirectionalTarget: True
 		DirectionArrowAnimation: paradirection
 		SupportPowerPaletteOrder: 50
-	AirstrikePower@parabombs:
-		OrderName: UkraineParabombs
-		Prerequisites: aircraft.ukraine
-		Icon: parabombs
-		ChargeInterval: 7500
-		Description: Parabombs
-		LongDesc: A squad of Badgers drop parachuted\nbombs on your target.
-		SelectTargetSpeechNotification: SelectTarget
-		CameraActor: camera
-		CameraRemoveDelay: 150
-		UnitType: badr.bomber
-		QuantizedFacings: 8
-		DisplayBeacon: true
-		BeaconPoster: pbmbicon
-		SquadSize: 3
-		SquadOffset: 1792,1792,0
-		ArrowSequence: arrow
-		ClockSequence: clock
-		CircleSequence: circles
-		UseDirectionalTarget: True
-		DirectionArrowAnimation: paradirection
-		SupportPowerPaletteOrder: 40
 	ProductionBar:
 		ProductionType: Aircraft
 	SupportPowerChargeBar:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -555,7 +555,7 @@ MGG:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 330
-		Prerequisites: atek, ~vehicles.england, ~techlevel.high
+		Prerequisites: atek, ~vehicles.allies, ~techlevel.high
 		Description: Regenerates the shroud nearby, \nobscuring the area.\n  Unarmed
 	Valued:
 		Cost: 1000
@@ -756,7 +756,7 @@ CTNK:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 330
-		Prerequisites: atek, ~vehicles.germany, ~techlevel.high
+		Prerequisites: atek, ~vehicles.allies, ~techlevel.high
 		Description: Armed with anti-ground missiles.\nTeleports to areas within range.\n  Strong vs Vehicles, Buildings\n  Weak vs Infantry, Aircraft\n  Special ability: Can teleport
 	Valued:
 		Cost: 1350
@@ -842,7 +842,7 @@ STNK:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 330
-		Prerequisites: atek, ~vehicles.france, ~techlevel.high
+		Prerequisites: atek, ~vehicles.england, ~techlevel.high
 		Description: Lightly armored infantry transport which\ncan cloak. Armed with anti-ground missiles.\n  Strong vs Light armor\n  Weak vs Infantry, Tanks, Aircraft
 	Valued:
 		Cost: 1000

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -104,17 +104,17 @@
 		Name: England
 		InternalName: england
 		Side: Allies
-		Description: England: Counterintelligence\nSpecial Unit: British Spy\nSpecial Unit: Mobile Gap Generator
+		Description: England: Counterintelligence\nSpecial Unit: Phase Transport
 	Faction@2:
 		Name: France
 		InternalName: france
 		Side: Allies
-		Description: France: Deception\nSpecial Ability: Can build fake structures\nSpecial Unit: Phase Transport
+		Description: France: Deception\nSpecial Ability: Can build fake structures
 	Faction@3:
 		Name: Germany
 		InternalName: germany
 		Side: Allies
-		Description: Germany: Technology\nSpecial Ability: Advanced Chronoshift\nSpecial Unit: Chrono Tank
+		Description: Germany: Technology\nSpecial Ability: Advanced Chronoshift
 	Faction@4:
 		Name: Soviet
 		InternalName: soviet
@@ -124,12 +124,12 @@
 		Name: Russia
 		InternalName: russia
 		Side: Soviet
-		Description: Russia: Tesla Weapons\nSpecial Unit: Tesla Tank\nSpecial Unit: Shock Trooper
+		Description: Russia: Tesla Weapons\nSpecial Unit: Tesla Tank
 	Faction@6:
 		Name: Ukraine
 		InternalName: ukraine
 		Side: Soviet
-		Description: Ukraine: Demolitions\nSpecial Ability: Parabombs\nSpecial Unit: Demolition Truck
+		Description: Ukraine: Demolitions\nSpecial Unit: Demolition Truck
 	Faction@random:
 		Name: Any
 		InternalName: Random


### PR DESCRIPTION
Subfactions have been a thorny issue for awhile, particularly Allies. We've gone from 10% stat boosts in the original to two entirely unique traits for each of the 5 subfactions. However, there's not enough interesting traits to go around, so we end up with 1/2 cost spies. There have been plenty of attempts to remedy the situation over the years #18093, #11295 ,#18084 (I'm sure there's more I'm missing), but nothing has really worked. I propose (as suggested by @tovl here: #18093) we reduce the subfactions to one trait each. This solves a lot of issues.

New subfactions:

England: Counterintelligence
Special Unit: Phase Transport

France: Deception
Special Ability: Fake Buildings

Germany: Technology
Special Ability: Advanced Chronoshift

Ukraine: Demolitions
Special Unit: Demo Truck

Russia: Tesla Weapons
Special Unit: Tesla Tank

MGG, Chrono Tank, Shock Troopers made global units (not subfaction restricted)
Half priced spies and Parabombs removed

Advantages:
Every subfaction has one powerful trait
Subfactions have more varied play options due to a wider unit selection
Allies have an analogue to the Mammoth tank late game (Chrono tank)
Potential for Chrono tank to be made a mobile AA unit
Parabombs are no longer an issue (free value ability, only way to make fair is to make Tesla Tech OP)
Half-priced spies are removed, which are both a boring trait and are frequently complained about by teamgame players

Disadvantages:
Less "uniqueness"/flavor for subfactions
Parabombs are removed (feature loss)


Obviously this isn't a perfect solution, but given we've been at it for years with no progress, I think this is the best one.