### PR TITLE
Exposed build palette fonts to configuration

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -532,7 +532,7 @@ namespace OpenRA.Mods.Common.Widgets
 							icon.Pos + timeOffset,
 							Color.White, Color.Black, 1);
 
-					if (first.Infinite)
+					if (first.Infinite && symbolFont != null)
 						symbolFont.DrawTextWithContrast(InfiniteSymbol,
 							icon.Pos + infiniteOffset,
 							Color.White, Color.Black, 1);

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -65,6 +65,9 @@ namespace OpenRA.Mods.Common.Widgets
 		public readonly string NotBuildableSequence = "idle";
 		public readonly string NotBuildablePalette = "chrome";
 
+		public readonly string OverlayFont = "TinyBold";
+		public readonly string SymbolsFont = "Symbols";
+
 		public readonly bool DrawTime = true;
 
 		[Translate]
@@ -149,8 +152,8 @@ namespace OpenRA.Mods.Common.Widgets
 			cantBuild.PlayFetchIndex(NotBuildableSequence, () => 0);
 			clock = new Animation(world, ClockAnimation);
 
-			overlayFont = Game.Renderer.Fonts["TinyBold"];
-			Game.Renderer.Fonts.TryGetValue("Symbols", out symbolFont);
+			overlayFont = Game.Renderer.Fonts[OverlayFont];
+			Game.Renderer.Fonts.TryGetValue(SymbolsFont, out symbolFont);
 		}
 
 		public override void Initialize(WidgetArgs args)


### PR DESCRIPTION
I would like to use other fonts compared to the rest of the UI there so this just unhardcodes them.