### PR TITLE
Ability to save/load skirmish settings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -147,6 +147,7 @@ Also thanks to:
     * Tristan Mühlbacher (MicroBit)
     * UnknownProgrammer
     * Vladimir Komarov (VrKomarov)
+    * William Carter (CarterWilliam)
     * Wojciech Walaszek (Voidwalker)
     * Wuschel
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using OpenRA.Graphics;
@@ -355,6 +356,31 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					panel = PanelType.Servers;
 				};
 			}
+
+			var saveGameButton = lobby.Get<ButtonWidget>("SAVE_SETTINGS");
+			saveGameButton.OnClick = () =>
+			{
+				Ui.OpenWindow(
+					"SAVED_SETTINGS_BROWSER_PANEL", new WidgetArgs
+					{
+						{ "isSavePanel", true },
+						{ "orderManager", orderManager },
+						{ "map", map }
+					});
+			};
+
+			var loadOptionsButton = lobby.Get<ButtonWidget>("LOAD_SETTINGS");
+			loadOptionsButton.OnClick = () =>
+			{
+				Ui.OpenWindow(
+					"SAVED_SETTINGS_BROWSER_PANEL", new WidgetArgs
+					{
+						{ "isSavePanel", false },
+						{ "orderManager", orderManager },
+						{ "map", map }
+					});
+			};
+			loadOptionsButton.IsDisabled = () => configurationDisabled() || !LobbySavedSettingsBrowserLogic.IsLoadPanelEnabled(modData.Manifest);
 
 			// Force start panel
 			Action startGame = () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbySavedSettingsBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbySavedSettingsBrowserLogic.cs
@@ -183,7 +183,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			if (Directory.Exists(baseSavePath))
 			{
-				var saveFiles = Directory.GetFiles(baseSavePath, "*.yaml", SearchOption.AllDirectories)
+				var saveFiles = Directory.GetFiles(baseSavePath, "*.yaml", SearchOption.TopDirectoryOnly)
 					.OrderByDescending(p => File.GetLastWriteTime(p))
 					.ToList();
 
@@ -224,7 +224,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var globalSettings = orderManager.LobbyInfo.GlobalSettings.Serialize();
 			var options = globalSettings.Value.ToDictionary()["Options"];
-			var unlockedOptions = options.Nodes.FindAll(optionYaml => optionYaml.Value.ToDictionary()["IsLocked"].Value == "False");
+			var unlockedOptions = options.Nodes.FindAll(optionYaml => optionYaml.Value.ToDictionary()["IsLocked"].Value.ToLower() == "false");
 			var optionsYaml = new List<MiniYamlNode>()
 			{
 				new MiniYamlNode(SettingsKeyMapId, map.Uid),

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbySavedSettingsBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbySavedSettingsBrowserLogic.cs
@@ -135,7 +135,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			deleteButton.OnClick = () =>
 			{
 				ConfirmationDialogs.ButtonPrompt(
-					title: "Delete selected game save?",
+					title: "Delete selected lobby settings save?",
 					text: "Delete '{0}'?".F(Path.GetFileNameWithoutExtension(selectedSave)),
 					onConfirm: () =>
 					{
@@ -298,7 +298,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 			catch (Exception ex)
 			{
-				Console.WriteLine(ex);
+				Game.Debug("Failed to rename '{0}' to '{1}'. See the logs for details.", oldName, newName);
 				Log.Write("debug", ex.ToString());
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbySavedSettingsBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbySavedSettingsBrowserLogic.cs
@@ -1,0 +1,351 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using OpenRA.Network;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+	public class LobbySavedSettingsBrowserLogic : ChromeLogic
+	{
+		const string SettingsKeyMapId = "Map";
+		const string SettingsKeyOptions = "Options";
+
+		readonly Widget panel;
+		readonly ScrollPanelWidget saveList;
+		readonly TextFieldWidget saveTextField;
+		readonly List<string> saves = new List<string>();
+		readonly ModData modData;
+		readonly bool isSavePanel;
+		readonly OrderManager orderManager;
+		readonly MapPreview map;
+
+		readonly string baseSavePath;
+		readonly string defaultSaveFilename;
+		string selectedSave;
+
+		[ObjectCreator.UseCtor]
+		public LobbySavedSettingsBrowserLogic(Widget widget, ModData modData, bool isSavePanel, OrderManager orderManager, MapPreview map)
+		{
+			panel = widget;
+
+			this.modData = modData;
+			this.isSavePanel = isSavePanel;
+			this.orderManager = orderManager;
+			this.map = map;
+
+			panel.Get<ButtonWidget>("CANCEL_BUTTON").OnClick = () =>
+			{
+				Ui.CloseWindow();
+			};
+
+			saveList = panel.Get<ScrollPanelWidget>("SETTINGS_LIST");
+			var newTemplate = panel.Get<ScrollItemWidget>("NEW_TEMPLATE");
+			var savedTemplate = panel.Get<ScrollItemWidget>("GAME_TEMPLATE");
+
+			baseSavePath = BaseSavePath(modData.Manifest);
+
+			if (isSavePanel)
+			{
+				panel.Get("SAVE_TITLE").IsVisible = () => true;
+
+				defaultSaveFilename = map.Title;
+				var filenameAttempt = 0;
+				while (true)
+				{
+					if (!File.Exists(SettingsFilePath(defaultSaveFilename)))
+						break;
+
+					defaultSaveFilename = map.Title + " ({0})".F(++filenameAttempt);
+				}
+
+				var saveWidgets = panel.Get("SAVE_WIDGETS");
+				saveTextField = saveWidgets.Get<TextFieldWidget>("SAVE_TEXTFIELD");
+				saveTextField.OnEnterKey = () =>
+				{
+					if (CanSave())
+						Save();
+					return true;
+				};
+				saveList.Bounds.Height -= saveWidgets.Bounds.Height;
+				saveWidgets.IsVisible = () => true;
+
+				var saveButton = panel.Get<ButtonWidget>("SAVE_BUTTON");
+				saveButton.OnClick = Save;
+				saveButton.IsVisible = () => true;
+				saveButton.IsDisabled = () => !CanSave();
+			}
+			else
+			{
+				panel.Get("LOAD_TITLE").IsVisible = () => true;
+
+				var loadButton = panel.Get<ButtonWidget>("LOAD_BUTTON");
+				loadButton.OnClick = Load;
+				loadButton.IsVisible = () => true;
+				loadButton.IsDisabled = () => selectedSave == null;
+			}
+
+			var renameButton = panel.Get<ButtonWidget>("RENAME_BUTTON");
+			renameButton.IsDisabled = () => selectedSave == null;
+			renameButton.OnClick = () =>
+			{
+				var initialName = Path.GetFileNameWithoutExtension(selectedSave);
+				var invalidChars = Path.GetInvalidFileNameChars();
+
+				ConfirmationDialogs.TextInputPrompt(
+					"Rename Save",
+					"Enter a new file name:",
+					initialName,
+					onAccept: newName => Rename(initialName, newName),
+					onCancel: null,
+					acceptText: "Rename",
+					cancelText: null,
+					inputValidator: newName =>
+					{
+						if (newName == initialName)
+							return false;
+
+						if (string.IsNullOrWhiteSpace(newName))
+							return false;
+
+						if (newName.IndexOfAny(invalidChars) >= 0)
+							return false;
+
+						if (File.Exists(SettingsFilePath(newName)))
+							return false;
+
+						return true;
+					});
+			};
+
+			var deleteButton = panel.Get<ButtonWidget>("DELETE_BUTTON");
+			deleteButton.IsDisabled = () => selectedSave == null;
+			deleteButton.OnClick = () =>
+			{
+				ConfirmationDialogs.ButtonPrompt(
+					title: "Delete selected game save?",
+					text: "Delete '{0}'?".F(Path.GetFileNameWithoutExtension(selectedSave)),
+					onConfirm: () =>
+					{
+						Delete(selectedSave);
+
+						if (!saves.Any() && !isSavePanel)
+						{
+							Ui.CloseWindow();
+						}
+						else
+							SelectFirstVisible();
+					},
+					confirmText: "Delete",
+					onCancel: () => { });
+			};
+
+			LoadExistingSaves(newTemplate, savedTemplate);
+			SelectFirstVisible();
+		}
+
+		void SelectFirstVisible()
+		{
+			Select(isSavePanel ? null : saves.FirstOrDefault());
+		}
+
+		void Select(string savePath)
+		{
+			selectedSave = savePath;
+			if (isSavePanel)
+				saveTextField.Text = savePath == null ? defaultSaveFilename :
+					Path.GetFileNameWithoutExtension(savePath);
+		}
+
+		void LoadExistingSaves(ScrollItemWidget newTemplate, ScrollItemWidget savedTemplate)
+		{
+			saveList.RemoveChildren();
+
+			if (isSavePanel)
+			{
+				var item = ScrollItemWidget.Setup(newTemplate,
+					() => selectedSave == null || !saves.Contains(SettingsFilePath(saveTextField.Text)),
+					() => { });
+				saveList.AddChild(item);
+			}
+
+			if (Directory.Exists(baseSavePath))
+			{
+				var saveFiles = Directory.GetFiles(baseSavePath, "*.yaml", SearchOption.AllDirectories)
+					.OrderByDescending(p => File.GetLastWriteTime(p))
+					.ToList();
+
+				foreach (var savePath in saveFiles)
+				{
+					saves.Add(savePath);
+
+					// Create the item manually so the click handlers can refer to itself
+					// This simplifies the rename handling (only needs to update ItemKey)
+					var item = savedTemplate.Clone() as ScrollItemWidget;
+					item.ItemKey = savePath;
+					item.IsVisible = () => true;
+					item.OnClick = () => Select(item.ItemKey);
+					if (isSavePanel)
+					{
+						item.IsSelected = () => saveTextField.Text == Path.GetFileNameWithoutExtension(item.ItemKey);
+						item.OnDoubleClick = Save;
+					}
+					else
+					{
+						item.IsSelected = () => selectedSave == item.ItemKey;
+						item.OnDoubleClick = Load;
+					}
+
+					var title = Path.GetFileNameWithoutExtension(savePath);
+					var label = item.Get<LabelWithTooltipWidget>("TITLE");
+					WidgetUtils.TruncateLabelToTooltip(label, title);
+
+					var date = File.GetLastWriteTime(savePath).ToString("yyyy-MM-dd HH:mm:ss");
+					item.Get<LabelWidget>("DATE").GetText = () => date;
+
+					saveList.AddChild(item);
+				}
+			}
+		}
+
+		void Save()
+		{
+			var globalSettings = orderManager.LobbyInfo.GlobalSettings.Serialize();
+			var options = globalSettings.Value.ToDictionary()["Options"];
+			var unlockedOptions = options.Nodes.FindAll(optionYaml => optionYaml.Value.ToDictionary()["IsLocked"].Value == "False");
+			var optionsYaml = new List<MiniYamlNode>()
+			{
+				new MiniYamlNode(SettingsKeyMapId, map.Uid),
+				new MiniYamlNode(SettingsKeyOptions, new MiniYaml(options.Value, unlockedOptions))
+			};
+
+			if (!Directory.Exists(baseSavePath))
+				Directory.CreateDirectory(baseSavePath);
+
+			var filename = SettingsFilePath(saveTextField.Text);
+
+			Action inner = () =>
+			{
+				optionsYaml.WriteToFile(filename);
+				Ui.CloseWindow();
+			};
+
+			if (File.Exists(filename))
+			{
+				ConfirmationDialogs.ButtonPrompt(
+					title: "Overwrite saved settings?",
+					text: "Overwrite {0}?".F(saveTextField.Text),
+					onConfirm: inner,
+					confirmText: "Overwrite",
+					onCancel: () => { });
+			}
+			else
+				inner();
+		}
+
+		void Load()
+		{
+			var optionsYaml = MiniYaml.FromFile(selectedSave);
+
+			Ui.CloseWindow();
+
+			var savedMap = optionsYaml.Find(node => node.Key == SettingsKeyMapId).Value.Value;
+			if (savedMap != map.Uid)
+				orderManager.IssueOrder(Order.Command("map {0}".F(savedMap)));
+
+			var savedOptions = optionsYaml.Find(node => node.Key == SettingsKeyOptions);
+			foreach (var option in savedOptions.Value.Nodes)
+			{
+				string optionName = option.Key;
+				string optionValue = option.Value.ToDictionary()["Value"].Value;
+				orderManager.IssueOrder(Order.Command("option {0} {1}".F(optionName, optionValue)));
+			}
+		}
+
+		void Rename(string oldName, string newName)
+		{
+			try
+			{
+				var oldPath = SettingsFilePath(oldName);
+				var newPath = SettingsFilePath(newName);
+				File.Move(oldPath, newPath);
+
+				saves[saves.IndexOf(oldPath)] = newPath;
+				foreach (var c in saveList.Children)
+				{
+					var item = c as ScrollItemWidget;
+					if (item == null || item.ItemKey != oldPath)
+						continue;
+
+					item.ItemKey = newPath;
+					item.Get<LabelWidget>("TITLE").GetText = () => newName;
+				}
+
+				if (selectedSave == oldPath)
+					selectedSave = newPath;
+			}
+			catch (Exception ex)
+			{
+				Console.WriteLine(ex);
+				Log.Write("debug", ex.ToString());
+			}
+		}
+
+		void Delete(string savePath)
+		{
+			try
+			{
+				File.Delete(savePath);
+			}
+			catch (Exception ex)
+			{
+				Game.Debug("Failed to delete save file '{0}'. See the logs for details.", savePath);
+				Log.Write("debug", ex.ToString());
+				return;
+			}
+
+			if (savePath == selectedSave)
+				Select(null);
+
+			var item = saveList.Children
+				.Select(c => c as ScrollItemWidget)
+				.FirstOrDefault(c => c.ItemKey == savePath);
+
+			saveList.RemoveChild(item);
+			saves.Remove(savePath);
+		}
+
+		bool CanSave()
+		{
+			return saveTextField.Text != "";
+		}
+
+		string SettingsFilePath(string id)
+		{
+			return Path.Combine(baseSavePath, id + ".yaml");
+		}
+
+		static string BaseSavePath(Manifest mod)
+		{
+			return Platform.ResolvePath(Platform.SupportDirPrefix, "SkirmishSettings", mod.Id, mod.Metadata.Version);
+		}
+
+		public static bool IsLoadPanelEnabled(Manifest mod)
+		{
+			var baseSavePath = BaseSavePath(mod);
+			return Directory.Exists(baseSavePath) && Directory.GetFiles(baseSavePath, "*.yaml", SearchOption.AllDirectories).Any();
+		}
+	}
+}

--- a/mods/cnc/chrome/lobby-savedsettingsbrowser.yaml
+++ b/mods/cnc/chrome/lobby-savedsettingsbrowser.yaml
@@ -1,0 +1,112 @@
+Container@SAVED_SETTINGS_BROWSER_PANEL:
+	Logic: LobbySavedSettingsBrowserLogic
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 600
+	Height: 400
+	Children:
+		Label@LOAD_TITLE:
+			Width: PARENT_RIGHT
+			Y: 0 - 22
+			Font: BigBold
+			Contrast: true
+			Align: Center
+			Text: Load game
+			Visible: False
+		Label@SAVE_TITLE:
+			Width: PARENT_RIGHT
+			Y: 0 - 22
+			Font: BigBold
+			Contrast: true
+			Align: Center
+			Text: Save game
+			Visible: False
+		Background@bg:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Background: panel-black
+			Children:
+				ScrollPanel@SETTINGS_LIST:
+					X: 10
+					Y: 10
+					Width: PARENT_RIGHT - 20
+					Height: PARENT_BOTTOM - 20
+					Children:
+						ScrollItem@NEW_TEMPLATE:
+							Width: PARENT_RIGHT - 27
+							Height: 25
+							X: 2
+							Visible: false
+							Children:
+								Label@TITLE:
+									Width: PARENT_RIGHT
+									Height: PARENT_BOTTOM
+									Align: Center
+									Text: [CREATE NEW FILE]
+						ScrollItem@GAME_TEMPLATE:
+							Width: PARENT_RIGHT - 27
+							Height: 25
+							X: 2
+							Visible: false
+							EnableChildMouseOver: True
+							Children:
+								LabelWithTooltip@TITLE:
+									X: 10
+									Width: PARENT_RIGHT - 200 - 10
+									Height: 25
+									TooltipContainer: SAVED_SETTINGS_TOOLTIP_CONTAINER
+									TooltipTemplate: SIMPLE_TOOLTIP
+								Label@DATE:
+									X: PARENT_RIGHT - WIDTH - 10
+									Width: 200
+									Height: 25
+									Align: Right
+				Container@SAVE_WIDGETS:
+					X: 10
+					Y: PARENT_BOTTOM - 35
+					Width: PARENT_RIGHT - 20
+					Height: 35
+					Visible: False
+					Children:
+						TextField@SAVE_TEXTFIELD:
+							Width: PARENT_RIGHT
+							Height: 25
+							Type: Filename
+				Button@CANCEL_BUTTON:
+					Key: escape
+					X: 0
+					Y: PARENT_BOTTOM - 1
+					Width: 100
+					Height: 35
+					Text: Back
+				Button@DELETE_BUTTON:
+					X: PARENT_RIGHT - 220 - WIDTH
+					Y: PARENT_BOTTOM - 1
+					Width: 100
+					Height: 35
+					Text: Delete
+					Key: Delete
+				Button@RENAME_BUTTON:
+					X: PARENT_RIGHT - 110 - WIDTH
+					Y: PARENT_BOTTOM - 1
+					Width: 100
+					Height: 35
+					Text: Rename
+					Key: F2
+				Button@LOAD_BUTTON:
+					Key: return
+					X: PARENT_RIGHT - WIDTH
+					Y: PARENT_BOTTOM - 1
+					Width: 100
+					Height: 35
+					Text: Load
+					Visible: False
+				Button@SAVE_BUTTON:
+					Key: return
+					X: PARENT_RIGHT - WIDTH
+					Y: PARENT_BOTTOM - 1
+					Width: 100
+					Height: 35
+					Text: Save
+					Visible: False
+		TooltipContainer@SAVED_SETTINGS_TOOLTIP_CONTAINER:

--- a/mods/cnc/chrome/lobby-savedsettingsbrowser.yaml
+++ b/mods/cnc/chrome/lobby-savedsettingsbrowser.yaml
@@ -11,7 +11,7 @@ Container@SAVED_SETTINGS_BROWSER_PANEL:
 			Font: BigBold
 			Contrast: true
 			Align: Center
-			Text: Load game
+			Text: Load lobby settings
 			Visible: False
 		Label@SAVE_TITLE:
 			Width: PARENT_RIGHT
@@ -19,7 +19,7 @@ Container@SAVED_SETTINGS_BROWSER_PANEL:
 			Font: BigBold
 			Contrast: true
 			Align: Center
-			Text: Save game
+			Text: Save lobby settings
 			Visible: False
 		Background@bg:
 			Width: PARENT_RIGHT

--- a/mods/cnc/chrome/lobby.yaml
+++ b/mods/cnc/chrome/lobby.yaml
@@ -137,6 +137,18 @@ Container@SERVER_LOBBY:
 			Width: 140
 			Height: 35
 			Text: Leave Game
+		Button@SAVE_SETTINGS:
+			X: 160
+			Y: PARENT_BOTTOM - 36
+			Width: 140
+			Height: 35
+			Text: Save Settings
+		Button@LOAD_SETTINGS:
+			X: 320
+			Y: PARENT_BOTTOM - 36
+			Width: 140
+			Height: 35
+			Text: Load Settings
 		Button@START_GAME_BUTTON:
 			X: PARENT_RIGHT - WIDTH
 			Y: PARENT_BOTTOM - 36

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -105,6 +105,7 @@ ChromeLayout:
 	cnc|chrome/lobby-music.yaml
 	cnc|chrome/lobby-servers.yaml
 	cnc|chrome/lobby-kickdialogs.yaml
+	cnc|chrome/lobby-savedsettingsbrowser.yaml
 	cnc|chrome/connection.yaml
 	cnc|chrome/color-picker.yaml
 	cnc|chrome/mapchooser.yaml

--- a/mods/common/chrome/lobby-savedsettingsbrowser.yaml
+++ b/mods/common/chrome/lobby-savedsettingsbrowser.yaml
@@ -1,0 +1,112 @@
+Background@SAVED_SETTINGS_BROWSER_PANEL:
+	Logic: LobbySavedSettingsBrowserLogic
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 600
+	Height: 400
+	Children:
+		Label@LOAD_TITLE:
+			Width: PARENT_RIGHT
+			Y: 21
+			Height: 25
+			Font: Bold
+			Align: Center
+			Text: Load settings
+			Visible: False
+		Label@SAVE_TITLE:
+			Width: PARENT_RIGHT
+			Y: 21
+			Height: 25
+			Font: Bold
+			Align: Center
+			Text: Save settings
+			Visible: False
+		ScrollPanel@SETTINGS_LIST:
+			X: 20
+			Y: 50
+			Width: PARENT_RIGHT - 40
+			Height: PARENT_BOTTOM - 102
+			Children:
+				ScrollItem@NEW_TEMPLATE:
+					Width: PARENT_RIGHT - 27
+					Height: 25
+					X: 2
+					Visible: false
+					Children:
+						Label@TITLE:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Align: Center
+							Text: [CREATE NEW FILE]
+				ScrollItem@GAME_TEMPLATE:
+					Width: PARENT_RIGHT - 27
+					Height: 25
+					X: 2
+					Visible: false
+					EnableChildMouseOver: True
+					Children:
+						LabelWithTooltip@TITLE:
+							X: 10
+							Width: PARENT_RIGHT - 200 - 10
+							Height: 25
+							TooltipContainer: SAVED_SETTINGS_TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
+						Label@DATE:
+							X: PARENT_RIGHT - WIDTH - 10
+							Width: 200
+							Height: 25
+							Align: Right
+		Container@SAVE_WIDGETS:
+			X: 20
+			Y: PARENT_BOTTOM - 77
+			Width: PARENT_RIGHT - 40
+			Height: 32
+			Visible: False
+			Children:
+				TextField@SAVE_TEXTFIELD:
+					Width: PARENT_RIGHT
+					Height: 25
+					Type: Filename
+		Button@CANCEL_BUTTON:
+			Key: escape
+			X: 20
+			Y: PARENT_BOTTOM - 45
+			Width: 100
+			Height: 25
+			Text: Back
+			Font: Bold
+		Button@DELETE_BUTTON:
+			X: PARENT_RIGHT - 240 - WIDTH
+			Y: PARENT_BOTTOM - 45
+			Width: 100
+			Height: 25
+			Text: Delete
+			Font: Bold
+			Key: Delete
+		Button@RENAME_BUTTON:
+			X: PARENT_RIGHT - 130 - WIDTH
+			Y: PARENT_BOTTOM - 45
+			Width: 100
+			Height: 25
+			Text: Rename
+			Font: Bold
+			Key: F2
+		Button@LOAD_BUTTON:
+			Key: return
+			X: PARENT_RIGHT - WIDTH - 20
+			Y: PARENT_BOTTOM - 45
+			Width: 100
+			Height: 25
+			Text: Load
+			Font: Bold
+			Visible: False
+		Button@SAVE_BUTTON:
+			Key: return
+			X: PARENT_RIGHT - WIDTH - 20
+			Y: PARENT_BOTTOM - 45
+			Width: 100
+			Height: 25
+			Text: Save
+			Font: Bold
+			Visible: False
+		TooltipContainer@SAVED_SETTINGS_TOOLTIP_CONTAINER:

--- a/mods/common/chrome/lobby.yaml
+++ b/mods/common/chrome/lobby.yaml
@@ -3,7 +3,7 @@ Background@SERVER_LOBBY:
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
 	Width: 808
-	Height: 600
+	Height: 630
 	Children:
 		ColorPreviewManager@COLOR_MANAGER:
 		Label@SERVER_NAME:
@@ -93,7 +93,7 @@ Background@SERVER_LOBBY:
 			Font: Bold
 		Container@LOBBYCHAT:
 			X: 20
-			Y: PARENT_BOTTOM - HEIGHT - 20
+			Y: 320
 			Width: PARENT_RIGHT - 40
 			Height: 259
 			Children:
@@ -133,8 +133,22 @@ Background@SERVER_LOBBY:
 				TextField@CHAT_TEXTFIELD:
 					X: 55
 					Y: PARENT_BOTTOM - HEIGHT
-					Width: PARENT_RIGHT - 260 - 55
+					Width: PARENT_RIGHT - 55
 					Height: 25
+		Button@SAVE_SETTINGS:
+			X: 20
+			Y: PARENT_BOTTOM - HEIGHT - 20
+			Width: 120
+			Height: 25
+			Text: Save Settings
+			Font: Bold
+		Button@LOAD_SETTINGS:
+			X: 150
+			Y: PARENT_BOTTOM - HEIGHT - 20
+			Width: 120
+			Height: 25
+			Text: Load Settings
+			Font: Bold
 		Button@START_GAME_BUTTON:
 			X: PARENT_RIGHT - WIDTH - 150
 			Y: PARENT_BOTTOM - HEIGHT - 20

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -93,6 +93,7 @@ ChromeLayout:
 	common|chrome/lobby-music.yaml
 	common|chrome/lobby-servers.yaml
 	common|chrome/lobby-kickdialogs.yaml
+	common|chrome/lobby-savedsettingsbrowser.yaml
 	common|chrome/color-picker.yaml
 	common|chrome/map-chooser.yaml
 	common|chrome/multiplayer-browser.yaml

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -108,6 +108,7 @@ ChromeLayout:
 	common|chrome/lobby-music.yaml
 	common|chrome/lobby-servers.yaml
 	common|chrome/lobby-kickdialogs.yaml
+	common|chrome/lobby-savedsettingsbrowser.yaml
 	common|chrome/color-picker.yaml
 	common|chrome/map-chooser.yaml
 	common|chrome/multiplayer-browser.yaml

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -155,6 +155,7 @@ ChromeLayout:
 	common|chrome/lobby-music.yaml
 	common|chrome/lobby-servers.yaml
 	common|chrome/lobby-kickdialogs.yaml
+	common|chrome/lobby-savedsettingsbrowser.yaml
 	common|chrome/playerprofile.yaml
 	ts|chrome/color-picker.yaml
 	common|chrome/map-chooser.yaml


### PR DESCRIPTION
Thanks for an amazing game. My friends and I have been playing it _a lot_ since lockdown began.

We have found it a little annoying that you can't save settings between games. We have a particular rule set which we like to use and so each time we play a game we spend more time than we want configuring it (especially when we get something wrong and have to start from the beginning). I noticed this is quite an old issue (https://github.com/OpenRA/OpenRA/issues/14938) so this PR attempts to fix it.

Closes #4122

**Change Summary**
- Add a save/load buttons to the lobby UI which open a new file browser to save/load your settings
  - File Browser can delete/rename files just like the save/load game browser
  - Disable load button if user is not the host or no load files exist
- Upon saving, create a yaml file containing the map ID and all non-locked options and write it to local application support directory. This is specific to the mod and the version.
- Upon loading, map is updated and options are set using the `orderManager`.

![save-skirmish-options-browser](https://user-images.githubusercontent.com/7325691/89101254-225a9a00-d3f6-11ea-98f4-40768c8e698e.gif)

**Existing Bugs With Save/Load Game Browser**
I noticed while implementing this there are some low impact bugs in the existing save/load game browser. I didn't fix these in this MR because I didn't want to change anything unrelated to the MR but I can add these fixes if desired or open a separate PR? They are both quick fixes. The bugs are:
- When saving a game, if the user selects an existing save, then changes the name, then clicks save, they get the overwrite dialog despite not overwriting anything. This is because any non-null selection also triggers the dialog ([source](https://github.com/OpenRA/OpenRA/blob/8c10dc406aaf76742cf47a038a80485cb0086189/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs#L321).
- The rename dialog has an invalid state when the name matches some existing save ([source](https://github.com/OpenRA/OpenRA/blob/8c10dc406aaf76742cf47a038a80485cb0086189/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs#L122). However, this never actually fires because the file extension is not taken into account.

I know the community is very busy with more exciting things at the moment but if anyone has time to review this I will be very grateful.