### PR TITLE
Fixed an invalid target crash in the InstantHit projectile

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -66,19 +66,14 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		public void Tick(World world)
 		{
-			// Check for blocking actors
-			if (info.Blockable)
-			{
-				// If GuidedTarget has become invalid due to getting killed the same tick,
-				// we need to set target to args.PassiveTarget to prevent target.CenterPosition below from crashing.
-				// The warheads have target validity checks themselves so they don't need this, but AnyBlockingActorsBetween does.
-				if (target.Type == TargetType.Invalid)
-					target = Target.FromPos(args.PassiveTarget);
+			// If GuidedTarget has become invalid due to getting killed the same tick,
+			// we need to set target to args.PassiveTarget to prevent target.CenterPosition below from crashing.
+			if (target.Type == TargetType.Invalid)
+				target = Target.FromPos(args.PassiveTarget);
 
-				if (BlocksProjectiles.AnyBlockingActorsBetween(world, args.Source, target.CenterPosition,
-					info.Width, out var blockedPos))
-					target = Target.FromPos(blockedPos);
-			}
+			// Check for blocking actors
+			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, args.Source, target.CenterPosition, info.Width, out var blockedPos))
+				target = Target.FromPos(blockedPos);
 
 			var warheadArgs = new WarheadArgs(args)
 			{


### PR DESCRIPTION
This backports https://github.com/AttacqueSuperior/Engine/commit/e5c39d07ea969ed41f37989279a344aa923c3f5a. It is a followup of https://github.com/OpenRA/OpenRA/pull/16756.