### PR TITLE
Reduce severity of editorconfig and prefer multiline braces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,7 +20,7 @@ csharp_style_var_elsewhere = true:suggestion
 csharp_style_var_for_built_in_types = true:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
 
-csharp_prefer_braces = false:error
+csharp_prefer_braces = when_multiline:suggestion
 csharp_using_directive_placement = outside_namespace:suggestion
 csharp_new_line_before_open_brace = all
 csharp_space_around_binary_operators = before_and_after


### PR DESCRIPTION
Reduce severity of the `csharp_prefer_braces` setting to `suggestion` and set to `when_multiline` which better matches the code style of this codebase.

Fixes #18445