### PR TITLE
Let docking angle be determined by the host building.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -111,9 +111,12 @@ namespace OpenRA.Mods.Common.Activities
 			if (ShouldLandAtBuilding(self, dest))
 			{
 				var exit = dest.FirstExitOrDefault();
-				var offset = exit != null ? exit.Info.SpawnOffset : WVec.Zero;
-				if (aircraft.Info.TurnToDock || !aircraft.Info.VTOL)
-					facing = aircraft.Info.InitialFacing;
+				var offset = WVec.Zero;
+				if (exit != null)
+				{
+					offset = exit.Info.SpawnOffset;
+					facing = exit.Info.Facing;
+				}
 
 				aircraft.MakeReservation(dest);
 				QueueChild(new Land(self, Target.FromActor(dest), offset, facing, Color.Green));

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -114,9 +114,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Does this VTOL actor need to turn before landing (on terrain)?")]
 		public readonly bool TurnToLand = false;
 
-		[Desc("Does this VTOL actor need to turn before landing on a resupplier?")]
-		public readonly bool TurnToDock = true;
-
 		[Desc("Does this actor automatically take off after resupplying?")]
 		public readonly bool TakeOffOnResupply = false;
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/RemoveTurnToDock.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/RemoveTurnToDock.cs
@@ -1,0 +1,61 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RemoveTurnToDock : UpdateRule
+	{
+		public override string Name { get { return "TurnToDock is removed from the Aircraft trait."; } }
+		public override string Description
+		{
+			get
+			{
+				return "TurnToDock is removed from the Aircraft trait in favor of letting the Exit trait on the host" +
+					"building determine whether or not turning is required and to what facing the aircraft must turn.";
+			}
+		}
+
+		readonly List<Tuple<string, string>> turningAircraft = new List<Tuple<string, string>>();
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			var message = "TurnToDock is now deprecated. The following actors had TurnToDock enabled:\n"
+				+ UpdateUtils.FormatMessageList(turningAircraft.Select(n => n.Item1 + " (" + n.Item2 + ")"))
+				+ "\n If you wish these units to keep their turning behaviour when docking with a host building" +
+					"you will need to define a 'Facing' parameter on the 'Exit' trait of the host building. This change" +
+					"does not affect the behaviour for landing on terrain which is governed by TurnToLand.";
+
+			if (turningAircraft.Any())
+				yield return message;
+
+			turningAircraft.Clear();
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var aircraft = actorNode.LastChildMatching("Aircraft");
+			if (aircraft != null)
+			{
+				var turnToDock = aircraft.LastChildMatching("TurnToDock");
+				if (turnToDock != null || turnToDock.NodeValue<bool>())
+					yield break;
+
+				turningAircraft.Add(Tuple.Create(actorNode.Key, actorNode.Location.Filename));
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -73,6 +73,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RenameSelfHealing(),
 				new ReplaceBurns(),
 				new RemoveMuzzleSplitFacings(),
+				new RemoveTurnToDock(),
 			})
 		};
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -329,7 +329,6 @@
 		VTOL: true
 		LandableTerrainTypes: Clear, Rough, Road, Beach, Tiberium, BlueTiberium
 		Crushes: crate, infantry
-		InitialFacing: 896
 		CanSlide: True
 	HiddenUnderFog:
 		Type: GroundPosition

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -545,6 +545,7 @@ HPAD:
 		Range: 5c0
 	Exit@1:
 		SpawnOffset: 0,-256,0
+		Facing: 896
 	Production:
 		Produces: Aircraft.GDI, Aircraft.Nod
 	Reservable:

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -13,7 +13,6 @@ carryall.reinforce:
 	Aircraft:
 		CruiseAltitude: 2160
 		CruisingCondition: cruising
-		InitialFacing: 0
 		Speed: 144
 		TurnSpeed: 16
 		LandableTerrainTypes: Sand, Rock, Transition, Spice, SpiceSand, Dune, Concrete

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -84,7 +84,6 @@ MIG:
 		OpportunityFire: False
 	Aircraft:
 		CruiseAltitude: 2560
-		InitialFacing: 768
 		TurnSpeed: 16
 		Speed: 223
 		RepulsionSpeed: 40
@@ -158,7 +157,6 @@ YAK:
 		OpportunityFire: False
 	Aircraft:
 		CruiseAltitude: 2560
-		InitialFacing: 768
 		TurnSpeed: 16
 		Speed: 178
 		RepulsionSpeed: 40

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -617,7 +617,6 @@
 		VTOL: true
 		LandableTerrainTypes: Clear, Rough, Road, Ore, Beach, Gems
 		Crushes: crate, mine, infantry
-		InitialFacing: 896
 		CanSlide: True
 	GpsDot:
 		String: Helicopter

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -12,7 +12,6 @@ DPOD:
 		Roll: 0
 		TurnSpeed: 20
 		Speed: 149
-		InitialFacing: 0
 	Health:
 		HP: 6000
 	Armor:
@@ -98,7 +97,6 @@ DSHP:
 		Roll: 0
 		TurnSpeed: 20
 		Speed: 168
-		InitialFacing: 0
 		TakeoffSounds: dropup1.aud
 		LandingSounds: dropdwn1.aud
 		IdealSeparation: 1275
@@ -266,7 +264,6 @@ ORCATRAN:
 	Aircraft:
 		TurnSpeed: 20
 		Speed: 84
-		InitialFacing: 0
 		LandableTerrainTypes: Clear, Road, Rail, DirtRoad, Rough, Tiberium, BlueTiberium, Veins
 		Crushes: crate, infantry
 		TakeoffSounds: orcaup1.aud
@@ -308,7 +305,6 @@ TRNSPORT:
 	Aircraft:
 		TurnSpeed: 20
 		Speed: 149
-		InitialFacing: 0
 		Pitch: 0
 		Roll: 0
 		TakeoffSounds: dropup1.aud

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -875,7 +875,6 @@
 		RepairActors: gadept
 		Voice: Move
 	Aircraft:
-		InitialFacing: 896
 		AirborneCondition: airborne
 		CruisingCondition: cruising
 		CruiseAltitude: 4c704

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -266,6 +266,7 @@ GAHPAD:
 		MaxHeightDelta: 3
 	Exit@1:
 		SpawnOffset: 0,-256,0
+		Facing: 896
 	ExitsDebugOverlay:
 	RallyPoint:
 		Palette: mouse

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -241,6 +241,7 @@ NAHPAD:
 		MaxHeightDelta: 3
 	Exit@1:
 		SpawnOffset: 0,-256,0
+		Facing: 896
 	ExitsDebugOverlay:
 	RallyPoint:
 		Palette: mouse


### PR DESCRIPTION
Allows airfields/helipads to set the facing angle used for docking. This means that it is possible for example to have different airfields with landing strips in different directions. This is also more consistent with the way general production and airlifts work and more intuitive for modders.

When no facing is defined by the host building, the aircraft can land in any direction, or must use `InitialFacing` when `TurnToLand` is set to true. `TurnToDock` is removed because it is now redundant.