### PR TITLE
Expose targetline colors to yaml

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -507,7 +507,10 @@ namespace OpenRA.Traits
 		bool AlwaysEnabled { get; }
 	}
 
-	public interface IMoveInfo : ITraitInfoInterface { }
+	public interface IMoveInfo : ITraitInfoInterface
+	{
+		Color GetTargetLineColor();
+	}
 
 	[RequireExplicitImplementation]
 	public interface IGameOver { void GameOver(World world); }

--- a/OpenRA.Mods.Cnc/Activities/Infiltrate.cs
+++ b/OpenRA.Mods.Cnc/Activities/Infiltrate.cs
@@ -24,8 +24,8 @@ namespace OpenRA.Mods.Cnc.Activities
 		readonly INotifyInfiltration[] notifiers;
 		Actor enterActor;
 
-		public Infiltrate(Actor self, in Target target, Infiltrates infiltrates)
-			: base(self, target, Color.Crimson)
+		public Infiltrate(Actor self, in Target target, Infiltrates infiltrates, Color? targetLineColor)
+			: base(self, target, targetLineColor)
 		{
 			this.infiltrates = infiltrates;
 			notifiers = self.TraitsImplementing<INotifyInfiltration>().ToArray();

--- a/OpenRA.Mods.Cnc/Activities/LayMines.cs
+++ b/OpenRA.Mods.Cnc/Activities/LayMines.cs
@@ -26,6 +26,7 @@ namespace OpenRA.Mods.Cnc.Activities
 		readonly Minelayer minelayer;
 		readonly AmmoPool[] ammoPools;
 		readonly IMove movement;
+		readonly IMoveInfo moveInfo;
 		readonly RearmableInfo rearmableInfo;
 
 		List<CPos> minefield;
@@ -37,6 +38,7 @@ namespace OpenRA.Mods.Cnc.Activities
 			minelayer = self.Trait<Minelayer>();
 			ammoPools = self.TraitsImplementing<AmmoPool>().ToArray();
 			movement = self.Trait<IMove>();
+			moveInfo = self.Info.TraitInfo<IMoveInfo>();
 			rearmableInfo = self.Info.TraitInfoOrDefault<RearmableInfo>();
 			this.minefield = minefield;
 		}
@@ -118,17 +120,17 @@ namespace OpenRA.Mods.Cnc.Activities
 		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
 		{
 			if (returnToBase)
-				yield return new TargetLineNode(Target.FromActor(rearmTarget), Color.Green);
+				yield return new TargetLineNode(Target.FromActor(rearmTarget), moveInfo.GetTargetLineColor());
 
 			if (minefield == null || minefield.Count == 0)
 				yield break;
 
 			var nextCell = NextValidCell(self);
 			if (nextCell != null)
-				yield return new TargetLineNode(Target.FromCell(self.World, nextCell.Value), Color.Crimson);
+				yield return new TargetLineNode(Target.FromCell(self.World, nextCell.Value), minelayer.Info.TargetLineColor);
 
 			foreach (var c in minefield)
-				yield return new TargetLineNode(Target.FromCell(self.World, c), Color.Crimson, tile: minelayer.Tile);
+				yield return new TargetLineNode(Target.FromCell(self.World, c), minelayer.Info.TargetLineColor, tile: minelayer.Tile);
 		}
 
 		static bool CanLayMine(Actor self, CPos p)

--- a/OpenRA.Mods.Cnc/Scripting/Properties/InfiltrateProperties.cs
+++ b/OpenRA.Mods.Cnc/Scripting/Properties/InfiltrateProperties.cs
@@ -37,7 +37,8 @@ namespace OpenRA.Mods.Cnc.Scripting
 			if (infiltrates == null)
 				throw new LuaException("{0} tried to infiltrate invalid target {1}!".F(Self, target));
 
-			Self.QueueActivity(new Infiltrate(Self, Target.FromActor(target), infiltrates));
+			// NB: Scripted actions get no visible targetlines.
+			Self.QueueActivity(new Infiltrate(Self, Target.FromActor(target), infiltrates, null));
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
@@ -27,6 +27,9 @@ namespace OpenRA.Mods.Cnc.Traits
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
+		[Desc("Color to use for the target line.")]
+		public readonly Color TargetLineColor = Color.Crimson;
+
 		[Desc("What diplomatic stances can be infiltrated by this actor.")]
 		public readonly PlayerRelationship ValidStances = PlayerRelationship.Neutral | PlayerRelationship.Enemy;
 
@@ -115,7 +118,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (!CanInfiltrateTarget(self, order.Target))
 				return;
 
-			self.QueueActivity(order.Queued, new Infiltrate(self, order.Target, this));
+			self.QueueActivity(order.Queued, new Infiltrate(self, order.Target, this, Info.TargetLineColor));
 			self.ShowTargetLines();
 		}
 	}

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -17,6 +17,7 @@ using OpenRA.Graphics;
 using OpenRA.Mods.Cnc.Activities;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
@@ -33,6 +34,9 @@ namespace OpenRA.Mods.Cnc.Traits
 		[VoiceReference]
 		[Desc("Voice to use when ordered to lay a minefield.")]
 		public readonly string Voice = "Action";
+
+		[Desc("Color to use for the target line when laying mines.")]
+		public readonly Color TargetLineColor = Color.Crimson;
 
 		[Desc("Sprite overlay to use for valid minefield cells.")]
 		public readonly string TileValidName = "build-valid";

--- a/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
@@ -68,6 +68,9 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Range circle border width.")]
 		public readonly float CircleBorderWidth = 3;
 
+		[Desc("Color to use for the target line.")]
+		public readonly Color TargetLineColor = Color.LawnGreen;
+
 		public override object Create(ActorInitializer init) { return new PortableChrono(init.Self, this); }
 	}
 
@@ -128,10 +131,10 @@ namespace OpenRA.Mods.Cnc.Traits
 
 				var cell = self.World.Map.CellContaining(order.Target.CenterPosition);
 				if (maxDistance != null)
-					self.QueueActivity(move.MoveWithinRange(order.Target, WDist.FromCells(maxDistance.Value), targetLineColor: Color.LawnGreen));
+					self.QueueActivity(move.MoveWithinRange(order.Target, WDist.FromCells(maxDistance.Value), targetLineColor: Info.TargetLineColor));
 
 				self.QueueActivity(new Teleport(self, cell, maxDistance, Info.KillCargo, Info.FlashScreen, Info.ChronoshiftSound));
-				self.QueueActivity(move.MoveTo(cell, 5, targetLineColor: Color.LawnGreen));
+				self.QueueActivity(move.MoveTo(cell, 5, targetLineColor: Info.TargetLineColor));
 				self.ShowTargetLines();
 			}
 		}

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -32,6 +32,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new TDGunboat(init, this); }
 
 		public WAngle GetInitialFacing() { return InitialFacing; }
+		public Color GetTargetLineColor() { return Color.Green; }
 
 		IEnumerable<ActorInit> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)
 		{

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -131,7 +131,7 @@ namespace OpenRA.Mods.Common.Activities
 		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
 		{
 			if (ChildActivity == null)
-				yield return new TargetLineNode(Target.FromActor(dest), Color.Green);
+				yield return new TargetLineNode(Target.FromActor(dest), aircraft.Info.TargetLineColor);
 			else
 				foreach (var n in ChildActivity.TargetLineNodes(self))
 					yield return n;

--- a/OpenRA.Mods.Common/Activities/CaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/CaptureActor.cs
@@ -22,8 +22,8 @@ namespace OpenRA.Mods.Common.Activities
 		Actor enterActor;
 		CaptureManager enterCaptureManager;
 
-		public CaptureActor(Actor self, in Target target)
-			: base(self, target, Color.Crimson)
+		public CaptureActor(Actor self, in Target target, Color? targetLineColor)
+			: base(self, target, targetLineColor)
 		{
 			manager = self.Trait<CaptureManager>();
 		}

--- a/OpenRA.Mods.Common/Activities/DeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverResources.cs
@@ -85,9 +85,9 @@ namespace OpenRA.Mods.Common.Activities
 		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
 		{
 			if (proc != null)
-				yield return new TargetLineNode(Target.FromActor(proc), Color.Green);
+				yield return new TargetLineNode(Target.FromActor(proc), harv.Info.DeliverLineColor);
 			else
-				yield return new TargetLineNode(Target.FromActor(harv.LinkedProc), Color.Green);
+				yield return new TargetLineNode(Target.FromActor(harv.LinkedProc), harv.Info.DeliverLineColor);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
 		{
-			yield return new TargetLineNode(destination, Color.Yellow);
+			yield return new TargetLineNode(destination, carryall.Info.TargetLineColor);
 		}
 
 		class ReleaseUnit : Activity

--- a/OpenRA.Mods.Common/Activities/Demolish.cs
+++ b/OpenRA.Mods.Common/Activities/Demolish.cs
@@ -30,9 +30,9 @@ namespace OpenRA.Mods.Common.Activities
 		Actor enterActor;
 		IDemolishable[] enterDemolishables;
 
-		public Demolish(Actor self, in Target target, EnterBehaviour enterBehaviour, int delay,
-			int flashes, int flashesDelay, int flashInterval, BitSet<DamageType> damageTypes)
-			: base(self, target, Color.Crimson)
+		public Demolish(Actor self, in Target target, EnterBehaviour enterBehaviour, int delay, int flashes,
+			int flashesDelay, int flashInterval, BitSet<DamageType> damageTypes, Color? targetLineColor)
+			: base(self, target, targetLineColor)
 		{
 			notifiers = self.TraitsImplementing<INotifyDemolition>().ToArray();
 			this.delay = delay;

--- a/OpenRA.Mods.Common/Activities/DonateCash.cs
+++ b/OpenRA.Mods.Common/Activities/DonateCash.cs
@@ -21,8 +21,8 @@ namespace OpenRA.Mods.Common.Activities
 		readonly int payload;
 		readonly int playerExperience;
 
-		public DonateCash(Actor self, in Target target, int payload, int playerExperience)
-			: base(self, target, Color.Yellow)
+		public DonateCash(Actor self, in Target target, int payload, int playerExperience, Color? targetLineColor)
+			: base(self, target, targetLineColor)
 		{
 			this.payload = payload;
 			this.playerExperience = playerExperience;

--- a/OpenRA.Mods.Common/Activities/DonateExperience.cs
+++ b/OpenRA.Mods.Common/Activities/DonateExperience.cs
@@ -23,8 +23,8 @@ namespace OpenRA.Mods.Common.Activities
 		Actor enterActor;
 		GainsExperience enterGainsExperience;
 
-		public DonateExperience(Actor self, in Target target, int level, int playerExperience)
-			: base(self, target, Color.Yellow)
+		public DonateExperience(Actor self, in Target target, int level, int playerExperience, Color? targetLineColor)
+			: base(self, target, targetLineColor)
 		{
 			this.level = level;
 			this.playerExperience = playerExperience;

--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -243,9 +243,9 @@ namespace OpenRA.Mods.Common.Activities
 					yield return n;
 
 			if (orderLocation != null)
-				yield return new TargetLineNode(Target.FromCell(self.World, orderLocation.Value), Color.Crimson);
+				yield return new TargetLineNode(Target.FromCell(self.World, orderLocation.Value), harvInfo.HarvestLineColor);
 			else if (deliverActor != null)
-				yield return new TargetLineNode(Target.FromActor(deliverActor), Color.Green);
+				yield return new TargetLineNode(Target.FromActor(deliverActor), harvInfo.DeliverLineColor);
 		}
 
 		CPos? GetSearchFromProcLocation(Actor self)

--- a/OpenRA.Mods.Common/Activities/HarvestResource.cs
+++ b/OpenRA.Mods.Common/Activities/HarvestResource.cs
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
 		{
-			yield return new TargetLineNode(Target.FromCell(self.World, targetCell), Color.Crimson);
+			yield return new TargetLineNode(Target.FromCell(self.World, targetCell), harvInfo.HarvestLineColor);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -116,7 +116,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
 		{
-			yield return new TargetLineNode(Target.FromActor(cargo), Color.Yellow);
+			yield return new TargetLineNode(Target.FromActor(cargo), carryall.Info.TargetLineColor);
 		}
 
 		class AttachUnit : Activity

--- a/OpenRA.Mods.Common/Activities/RepairBridge.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBridge.cs
@@ -24,8 +24,8 @@ namespace OpenRA.Mods.Common.Activities
 		BridgeHut enterHut;
 		LegacyBridgeHut enterLegacyHut;
 
-		public RepairBridge(Actor self, in Target target, EnterBehaviour enterBehaviour, string notification)
-			: base(self, target, Color.Yellow)
+		public RepairBridge(Actor self, in Target target, EnterBehaviour enterBehaviour, string notification, Color targetLineColor)
+			: base(self, target, targetLineColor)
 		{
 			this.enterBehaviour = enterBehaviour;
 			this.notification = notification;

--- a/OpenRA.Mods.Common/Activities/RepairBuilding.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBuilding.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Activities
 		EngineerRepairable enterEngineerRepariable;
 
 		public RepairBuilding(Actor self, in Target target, EngineerRepairInfo info)
-			: base(self, target, Color.Yellow)
+			: base(self, target, info.TargetLineColor)
 		{
 			this.info = info;
 		}

--- a/OpenRA.Mods.Common/Activities/RideTransport.cs
+++ b/OpenRA.Mods.Common/Activities/RideTransport.cs
@@ -23,8 +23,8 @@ namespace OpenRA.Mods.Common.Activities
 		Cargo enterCargo;
 		Aircraft enterAircraft;
 
-		public RideTransport(Actor self, in Target target)
-			: base(self, target, Color.Green)
+		public RideTransport(Actor self, in Target target, Color? targetLineColor)
+			: base(self, target, targetLineColor)
 		{
 			passenger = self.Trait<Passenger>();
 		}

--- a/OpenRA.Mods.Common/Scripting/Properties/CaptureProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CaptureProperties.cs
@@ -35,7 +35,8 @@ namespace OpenRA.Mods.Common.Scripting
 			if (targetManager == null || !targetManager.CanBeTargetedBy(target, Self, captureManager))
 				throw new LuaException("Actor '{0}' cannot capture actor '{1}'!".F(Self, target));
 
-			Self.QueueActivity(new CaptureActor(Self, Target.FromActor(target)));
+			// NB: Scripted actions get no visible targetlines.
+			Self.QueueActivity(new CaptureActor(Self, Target.FromActor(target), null));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/Properties/DeliveryProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/DeliveryProperties.cs
@@ -33,7 +33,9 @@ namespace OpenRA.Mods.Common.Scripting
 		public void DeliverCash(Actor target)
 		{
 			var t = Target.FromActor(target);
-			Self.QueueActivity(new DonateCash(Self, t, info.Payload, info.PlayerExperience));
+
+			// NB: Scripted actions get no visible targetlines.
+			Self.QueueActivity(new DonateCash(Self, t, info.Payload, info.PlayerExperience, null));
 		}
 	}
 
@@ -62,9 +64,10 @@ namespace OpenRA.Mods.Common.Scripting
 				return;
 
 			var level = gainsExperience.Level;
-
 			var t = Target.FromActor(target);
-			Self.QueueActivity(new DonateExperience(Self, t, level, deliversExperience.PlayerExperience));
+
+			// NB: Scripted actions get no visible targetlines.
+			Self.QueueActivity(new DonateExperience(Self, t, level, deliversExperience.PlayerExperience, null));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/Properties/DemolitionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/DemolitionProperties.cs
@@ -31,8 +31,9 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Demolish the target actor.")]
 		public void Demolish(Actor target)
 		{
+			// NB: Scripted actions get no visible targetlines.
 			Self.QueueActivity(new Demolish(Self, Target.FromActor(target), info.EnterBehaviour, info.DetonationDelay,
-				info.Flashes, info.FlashesDelay, info.FlashInterval, info.DamageTypes));
+				info.Flashes, info.FlashesDelay, info.FlashInterval, info.DamageTypes, null));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Move to and enter the transport.")]
 		public void EnterTransport(Actor transport)
 		{
-			Self.QueueActivity(new RideTransport(Self, Target.FromActor(transport)));
+			Self.QueueActivity(new RideTransport(Self, Target.FromActor(transport), null));
 		}
 
 		[Desc("Whether the actor can move (false if immobilized).")]

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -94,6 +94,9 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
+		[Desc("Color to use for the target line for regular move orders.")]
+		public readonly Color TargetLineColor = Color.Green;
+
 		[GrantedConditionReference]
 		[Desc("The condition to grant to self while airborne.")]
 		public readonly string AirborneCondition = null;
@@ -165,6 +168,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public WAngle GetInitialFacing() { return InitialFacing; }
 		public WDist GetCruiseAltitude() { return CruiseAltitude; }
+		public Color GetTargetLineColor() { return TargetLineColor; }
 
 		public override object Create(ActorInitializer init) { return new Aircraft(init, this); }
 
@@ -1082,7 +1086,7 @@ namespace OpenRA.Mods.Common.Traits
 				var target = Target.FromCell(self.World, cell);
 
 				// TODO: this should scale with unit selection group size.
-				self.QueueActivity(order.Queued, new Fly(self, target, WDist.FromCells(8), targetLineColor: Color.Green));
+				self.QueueActivity(order.Queued, new Fly(self, target, WDist.FromCells(8), targetLineColor: Info.TargetLineColor));
 				self.ShowTargetLines();
 			}
 			else if (orderString == "Land")
@@ -1096,7 +1100,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				var target = Target.FromCell(self.World, cell);
 
-				self.QueueActivity(order.Queued, new Land(self, target, targetLineColor: Color.Green));
+				self.QueueActivity(order.Queued, new Land(self, target, targetLineColor: Info.TargetLineColor));
 				self.ShowTargetLines();
 			}
 			else if (orderString == "Enter" || orderString == "ForceEnter" || orderString == "Repair")

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -24,6 +24,9 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
+		[Desc("Color to use for the target line.")]
+		public readonly Color TargetLineColor = Color.OrangeRed;
+
 		[GrantedConditionReference]
 		[Desc("The condition to grant to self while an attack-move is active.")]
 		public readonly string AttackMoveCondition = null;
@@ -76,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 				var assaultMoving = order.OrderString == "AssaultMove";
 
 				// TODO: this should scale with unit selection group size.
-				self.QueueActivity(order.Queued, new AttackMoveActivity(self, () => move.MoveTo(targetLocation, 8, targetLineColor: Color.OrangeRed), assaultMoving));
+				self.QueueActivity(order.Queued, new AttackMoveActivity(self, () => move.MoveTo(targetLocation, 8, targetLineColor: Info.TargetLineColor), assaultMoving));
 				self.ShowTargetLines();
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
@@ -34,6 +34,9 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
+		[Desc("Color to use for the target line for regular move orders.")]
+		public readonly Color TargetLineColor = Color.Green;
+
 		[Desc("Require the force-move modifier to display the move cursor.")]
 		public readonly bool RequiresForceMove = false;
 
@@ -113,7 +116,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!order.Queued)
 					activity.NextActivity?.Cancel(self);
 
-				activity.Queue(new IssueOrderAfterTransform("Move", order.Target, Color.Green));
+				activity.Queue(new IssueOrderAfterTransform("Move", order.Target, Info.TargetLineColor));
 
 				if (currentTransform == null)
 					self.QueueActivity(order.Queued, activity);

--- a/OpenRA.Mods.Common/Traits/Captures.cs
+++ b/OpenRA.Mods.Common/Traits/Captures.cs
@@ -58,6 +58,9 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
+		[Desc("Color to use for the target line.")]
+		public readonly Color TargetLineColor = Color.Crimson;
+
 		public override object Create(ActorInitializer init) { return new Captures(init.Self, this); }
 	}
 
@@ -100,7 +103,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (order.OrderString != "CaptureActor" || IsTraitDisabled)
 				return;
 
-			self.QueueActivity(order.Queued, new CaptureActor(self, order.Target));
+			self.QueueActivity(order.Queued, new CaptureActor(self, order.Target, Info.TargetLineColor));
 			self.ShowTargetLines();
 		}
 

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -60,6 +60,9 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
+		[Desc("Color to use for the target line.")]
+		public readonly Color TargetLineColor = Color.Yellow;
+
 		public override object Create(ActorInitializer init) { return new Carryall(init.Self, this); }
 	}
 

--- a/OpenRA.Mods.Common/Traits/DeliversCash.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversCash.cs
@@ -12,6 +12,7 @@
 using System.Collections.Generic;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -36,6 +37,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		[VoiceReference]
 		public readonly string Voice = "Action";
+
+		[Desc("Color to use for the target line.")]
+		public readonly Color TargetLineColor = Color.Yellow;
 
 		public override object Create(ActorInitializer init) { return new DeliversCash(this); }
 	}
@@ -75,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (order.OrderString != "DeliverCash")
 				return;
 
-			self.QueueActivity(order.Queued, new DonateCash(self, order.Target, info.Payload, info.PlayerExperience));
+			self.QueueActivity(order.Queued, new DonateCash(self, order.Target, info.Payload, info.PlayerExperience, info.TargetLineColor));
 			self.ShowTargetLines();
 		}
 

--- a/OpenRA.Mods.Common/Traits/DeliversExperience.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversExperience.cs
@@ -12,6 +12,7 @@
 using System.Collections.Generic;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -30,6 +31,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		[VoiceReference]
 		public readonly string Voice = "Action";
+
+		[Desc("Color to use for the target line.")]
+		public readonly Color TargetLineColor = Color.Yellow;
 
 		public override object Create(ActorInitializer init) { return new DeliversExperience(init, this); }
 	}
@@ -86,7 +90,7 @@ namespace OpenRA.Mods.Common.Traits
 			else if (order.Target.Type != TargetType.FrozenActor)
 				return;
 
-			self.QueueActivity(order.Queued, new DonateExperience(self, order.Target, gainsExperience.Level, info.PlayerExperience));
+			self.QueueActivity(order.Queued, new DonateExperience(self, order.Target, gainsExperience.Level, info.PlayerExperience, info.TargetLineColor));
 			self.ShowTargetLines();
 		}
 

--- a/OpenRA.Mods.Common/Traits/Demolition.cs
+++ b/OpenRA.Mods.Common/Traits/Demolition.cs
@@ -44,6 +44,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Voice string when planting explosive charges.")]
 		public readonly string Voice = "Action";
 
+		[Desc("Color to use for the target line.")]
+		public readonly Color TargetLineColor = Color.Crimson;
+
 		public readonly PlayerRelationship TargetStances = PlayerRelationship.Enemy | PlayerRelationship.Neutral;
 		public readonly PlayerRelationship ForceTargetStances = PlayerRelationship.Enemy | PlayerRelationship.Neutral | PlayerRelationship.Ally;
 
@@ -88,7 +91,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			self.QueueActivity(order.Queued, new Demolish(self, order.Target, info.EnterBehaviour, info.DetonationDelay,
-				info.Flashes, info.FlashesDelay, info.FlashInterval, info.DamageTypes));
+				info.Flashes, info.FlashesDelay, info.FlashInterval, info.DamageTypes, info.TargetLineColor));
 
 			self.ShowTargetLines();
 		}

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -26,6 +26,9 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
+		[Desc("Color to use for the target line.")]
+		public readonly Color TargetLineColor = Color.Yellow;
+
 		[Desc("Behaviour when entering the structure.",
 			"Possible values are Exit, Suicide, Dispose.")]
 		public readonly EnterBehaviour EnterBehaviour = EnterBehaviour.Dispose;

--- a/OpenRA.Mods.Common/Traits/EntersTunnels.cs
+++ b/OpenRA.Mods.Common/Traits/EntersTunnels.cs
@@ -31,6 +31,9 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
+		[Desc("Color to use for the target line while in tunnels.")]
+		public readonly Color TargetLineColor = Color.Green;
+
 		[ConsumedConditionReference]
 		[Desc("Boolean expression defining the condition under which the regular (non-force) enter cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;
@@ -42,12 +45,14 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly EntersTunnelsInfo info;
 		readonly IMove move;
+		readonly IMoveInfo moveInfo;
 		bool requireForceMove;
 
 		public EntersTunnels(Actor self, EntersTunnelsInfo info)
 		{
 			this.info = info;
 			move = self.Trait<IMove>();
+			moveInfo = self.Info.TraitInfo<IMoveInfo>();
 		}
 
 		public IEnumerable<IOrderTargeter> Orders
@@ -85,8 +90,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (tunnel == null || !tunnel.Exit.HasValue)
 				return;
 
-			self.QueueActivity(order.Queued, move.MoveTo(tunnel.Entrance, tunnel.NearEnough, targetLineColor: Color.Green));
-			self.QueueActivity(move.MoveTo(tunnel.Exit.Value, tunnel.NearEnough, targetLineColor: Color.Green));
+			self.QueueActivity(order.Queued, move.MoveTo(tunnel.Entrance, tunnel.NearEnough, targetLineColor: moveInfo.GetTargetLineColor()));
+			self.QueueActivity(move.MoveTo(tunnel.Exit.Value, tunnel.NearEnough, targetLineColor: info.TargetLineColor));
 			self.ShowTargetLines();
 		}
 

--- a/OpenRA.Mods.Common/Traits/Guard.cs
+++ b/OpenRA.Mods.Common/Traits/Guard.cs
@@ -21,6 +21,9 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
+		[Desc("Color to use for the target line.")]
+		public readonly Color TargetLineColor = Color.OrangeRed;
+
 		public override object Create(ActorInitializer init) { return new Guard(this); }
 	}
 
@@ -51,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			var range = target.Actor.Info.TraitInfo<GuardableInfo>().Range;
-			self.QueueActivity(queued, new AttackMoveActivity(self, () => move.MoveFollow(self, target, WDist.Zero, range, targetLineColor: Color.OrangeRed)));
+			self.QueueActivity(queued, new AttackMoveActivity(self, () => move.MoveFollow(self, target, WDist.Zero, range, targetLineColor: info.TargetLineColor)));
 			self.ShowTargetLines();
 		}
 

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -16,6 +16,7 @@ using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.Common.Pathfinder;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -82,6 +83,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		[VoiceReference]
 		public readonly string DeliverVoice = "Action";
+
+		[Desc("Color to use for the target line of harvest orders.")]
+		public readonly Color HarvestLineColor = Color.Crimson;
+
+		[Desc("Color to use for the target line of harvest orders.")]
+		public readonly Color DeliverLineColor = Color.Green;
 
 		[Desc("Cursor to display when able to unload at target actor.")]
 		public readonly string EnterCursor = "enter";

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -49,6 +49,9 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
+		[Desc("Color to use for the target line for regular move orders.")]
+		public readonly Color TargetLineColor = Color.Green;
+
 		[Desc("Facing to use for actor previews (map editor, color picker, etc)")]
 		public readonly WAngle PreviewFacing = new WAngle(384);
 
@@ -67,6 +70,8 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			yield return new FacingInit(PreviewFacing);
 		}
+
+		public Color GetTargetLineColor() { return TargetLineColor; }
 
 		public override object Create(ActorInitializer init) { return new Mobile(init, this); }
 
@@ -923,7 +928,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!Info.LocomotorInfo.MoveIntoShroud && !self.Owner.Shroud.IsExplored(cell))
 					return;
 
-				self.QueueActivity(order.Queued, WrapMove(new Move(self, cell, WDist.FromCells(8), null, true, Color.Green)));
+				self.QueueActivity(order.Queued, WrapMove(new Move(self, cell, WDist.FromCells(8), null, true, Info.TargetLineColor)));
 				self.ShowTargetLines();
 			}
 

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -12,6 +12,7 @@
 using System.Collections.Generic;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
+using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Traits;
 
@@ -41,6 +42,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		[VoiceReference]
 		public readonly string Voice = "Action";
+
+		[Desc("Color to use for the target line.")]
+		public readonly Color TargetLineColor = Color.Green;
 
 		[ConsumedConditionReference]
 		[Desc("Boolean expression defining the condition under which the regular (non-force) enter cursor is disabled.")]
@@ -173,7 +177,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!IsCorrectCargoType(targetActor))
 				return;
 
-			self.QueueActivity(order.Queued, new RideTransport(self, order.Target));
+			self.QueueActivity(order.Queued, new RideTransport(self, order.Target, Info.TargetLineColor));
 			self.ShowTargetLines();
 		}
 

--- a/OpenRA.Mods.Common/Traits/RepairsBridges.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsBridges.cs
@@ -12,6 +12,7 @@
 using System.Collections.Generic;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -21,6 +22,9 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[VoiceReference]
 		public readonly string Voice = "Action";
+
+		[Desc("Color to use for the target line.")]
+		public readonly Color TargetLineColor = Color.Yellow;
 
 		[Desc("Behaviour when entering the structure.",
 			"Possible values are Exit, Suicide, Dispose.")]
@@ -101,7 +105,7 @@ namespace OpenRA.Mods.Common.Traits
 				else
 					return;
 
-				self.QueueActivity(order.Queued, new RepairBridge(self, order.Target, info.EnterBehaviour, info.RepairNotification));
+				self.QueueActivity(order.Queued, new RepairBridge(self, order.Target, info.EnterBehaviour, info.RepairNotification, info.TargetLineColor));
 				self.ShowTargetLines();
 			}
 		}


### PR DESCRIPTION
Fixes #18467

- Exposes all targetline colors to yaml so that they can be changed by mods.
- ~Changes the default targetline colors to be more distinguishable.~
- ~Gives all heal actions in standard mods the same unique color.~
- Removed target lines from scripted activities.