### PR TITLE
Add customization to the support power widget font

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -151,9 +151,6 @@ namespace OpenRA.Mods.Common.Widgets
 			cantBuild = new Animation(world, NotBuildableAnimation);
 			cantBuild.PlayFetchIndex(NotBuildableSequence, () => 0);
 			clock = new Animation(world, ClockAnimation);
-
-			overlayFont = Game.Renderer.Fonts[OverlayFont];
-			Game.Renderer.Fonts.TryGetValue(SymbolsFont, out symbolFont);
 		}
 
 		public override void Initialize(WidgetArgs args)
@@ -162,6 +159,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 			hotkeys = Exts.MakeArray(HotkeyCount,
 				i => modData.Hotkeys[HotkeyPrefix + (i + 1).ToString("D2")]);
+
+			overlayFont = Game.Renderer.Fonts[OverlayFont];
+			Game.Renderer.Fonts.TryGetValue(SymbolsFont, out symbolFont);
 		}
 
 		public void ScrollDown()

--- a/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
@@ -28,6 +28,8 @@ namespace OpenRA.Mods.Common.Widgets
 		[Translate]
 		public readonly string HoldText = "";
 
+		public readonly string OverlayFont = "TinyBold";
+
 		public readonly int2 IconSize = new int2(64, 48);
 		public readonly int IconMargin = 10;
 		public readonly int2 IconSpriteOffset = int2.Zero;
@@ -107,6 +109,8 @@ namespace OpenRA.Mods.Common.Widgets
 
 			hotkeys = Exts.MakeArray(HotkeyCount,
 				i => modData.Hotkeys[HotkeyPrefix + (i + 1).ToString("D2")]);
+
+			overlayFont = Game.Renderer.Fonts[OverlayFont];
 		}
 
 		public class SupportPowerIcon
@@ -191,7 +195,6 @@ namespace OpenRA.Mods.Common.Widgets
 		public override void Draw()
 		{
 			var iconOffset = 0.5f * IconSize.ToFloat2() + IconSpriteOffset;
-			overlayFont = Game.Renderer.Fonts["TinyBold"];
 
 			holdOffset = iconOffset - overlayFont.Measure(HoldText) / 2;
 			readyOffset = iconOffset - overlayFont.Measure(ReadyText) / 2;


### PR DESCRIPTION
This is a followup of https://github.com/OpenRA/OpenRA/pull/18472. Also saves a font lookup every render frame.