### PR TITLE
Fixed LeavesTrails overlapping when vehicle change direction

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
+++ b/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
 
@@ -93,6 +94,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 		bool wasStationary;
 		bool isMoving;
 
+		bool previouslySpawned;
+		CPos previousSpawnCell;
+		WAngle previousSpawnFacing;
+
 		void ITick.Tick(Actor self)
 		{
 			if (IsTraitDisabled)
@@ -120,17 +125,25 @@ namespace OpenRA.Mods.Common.Traits.Render
 				if (++offset >= Info.Offsets.Length)
 					offset = 0;
 
-				var offsetRotation = Info.Offsets[offset].Rotate(body.QuantizeOrientation(self, self.Orientation));
-				var spawnPosition = Info.SpawnAtLastPosition ? cachedPosition : self.CenterPosition;
+				if (!Info.TerrainTypes.Any() || Info.TerrainTypes.Contains(type))
+				{
+					var spawnFacing = Info.SpawnAtLastPosition ? cachedFacing : facing?.Facing ?? WAngle.Zero;
 
-				var pos = Info.Type == TrailType.CenterPosition ? spawnPosition + body.LocalToWorld(offsetRotation) :
-					self.World.Map.CenterOfCell(spawnCell);
+					if (previouslySpawned && previousSpawnCell == spawnCell)
+						spawnFacing = previousSpawnFacing;
 
-				var spawnFacing = Info.SpawnAtLastPosition ? cachedFacing : facing?.Facing ?? WAngle.Zero;
+					var offsetRotation = Info.Offsets[offset].Rotate(body.QuantizeOrientation(self, self.Orientation));
+					var spawnPosition = Info.SpawnAtLastPosition ? cachedPosition : self.CenterPosition;
+					var pos = Info.Type == TrailType.CenterPosition ? spawnPosition + body.LocalToWorld(offsetRotation) :
+						self.World.Map.CenterOfCell(spawnCell);
 
-				if (Info.TerrainTypes.Count == 0 || Info.TerrainTypes.Contains(type))
 					self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, spawnFacing, self.World, Info.Image,
 						Info.Sequences.Random(Game.CosmeticRandom), Info.Palette, Info.VisibleThroughFog)));
+
+					previouslySpawned = true;
+					previousSpawnCell = spawnCell;
+					previousSpawnFacing = spawnFacing;
+				}
 
 				cachedPosition = self.CenterPosition;
 				cachedFacing = facing?.Facing ?? WAngle.Zero;

--- a/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
+++ b/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
@@ -128,7 +128,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 				var spawnFacing = Info.SpawnAtLastPosition ? cachedFacing : facing?.Facing ?? WAngle.Zero;
 
-				if ((Info.TerrainTypes.Count == 0 || Info.TerrainTypes.Contains(type)) && !string.IsNullOrEmpty(Info.Image))
+				if (Info.TerrainTypes.Count == 0 || Info.TerrainTypes.Contains(type))
 					self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, spawnFacing, self.World, Info.Image,
 						Info.Sequences.Random(Game.CosmeticRandom), Info.Palette, Info.VisibleThroughFog)));
 


### PR DESCRIPTION
This backports the changes from https://github.com/OpenRA/d2/pull/187 by @evgeniysergeev, but also includes some further optimizations and saner default values when setting this up for multiple vehicles with per actor track sprites.

I set up a crude test case at https://github.com/OpenHV/OpenHV/tree/tracks/.