### PR TITLE
Drop FlyAttackRun targets when we don't have valid armaments against them

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -528,7 +528,7 @@ namespace OpenRA
 		{
 			// PERF: Avoid LINQ.
 			foreach (var targetable in Targetables)
-				if (targetable.IsTraitEnabled() && targetable.TargetableBy(this, byActor))
+				if (targetable.TargetableBy(this, byActor))
 					return true;
 
 			return false;

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -166,7 +166,7 @@ namespace OpenRA.Mods.Common.Activities
 			else if (attackAircraft.Info.AttackType == AirAttackType.Strafe)
 				QueueChild(new StrafeAttackRun(self, attackAircraft, aircraft, target, strafeDistance != WDist.Zero ? strafeDistance : lastVisibleMaximumRange));
 			else if (attackAircraft.Info.AttackType == AirAttackType.Default && !aircraft.Info.CanHover)
-				QueueChild(new FlyAttackRun(self, target, lastVisibleMaximumRange));
+				QueueChild(new FlyAttackRun(self, target, lastVisibleMaximumRange, attackAircraft));
 
 			// Turn to face the target if required.
 			else if (!attackAircraft.TargetInFiringArc(self, target, 4 * attackAircraft.Info.FacingTolerance))
@@ -207,17 +207,19 @@ namespace OpenRA.Mods.Common.Activities
 
 	class FlyAttackRun : Activity
 	{
+		readonly AttackAircraft attack;
 		readonly WDist exitRange;
 
 		Target target;
 		bool targetIsVisibleActor;
 
-		public FlyAttackRun(Actor self, in Target t, WDist exitRange)
+		public FlyAttackRun(Actor self, in Target t, WDist exitRange, AttackAircraft attack)
 		{
 			ChildHasPriority = false;
 
 			target = t;
 			this.exitRange = exitRange;
+			this.attack = attack;
 		}
 
 		protected override void OnFirstRun(Actor self)
@@ -245,7 +247,7 @@ namespace OpenRA.Mods.Common.Activities
 			target = target.Recalculate(self.Owner, out var targetIsHiddenActor);
 			targetIsVisibleActor = target.Type == TargetType.Actor && !targetIsHiddenActor;
 
-			if (targetWasVisibleActor && !target.IsValidFor(self))
+			if (targetWasVisibleActor && (!target.IsValidFor(self) || !attack.HasAnyValidWeapons(target)))
 				Cancel(self);
 
 			return false;


### PR DESCRIPTION
Resolves the remark from https://github.com/OpenRA/OpenRA/pull/18470#issuecomment-668277123.
Has a soft dependency on #17935.

I probably need to adjust `StrafeAttackRun` too, but haven't tested that and am throwing this out in case someone has comments. What I was wondering about is if we can move the target (visibility and validity) recalculation code and then the `HasAnyValidWeapons` check to a common helper method every activity can call instead of seemingly duplicating that code into every attack activity.