### PR TITLE
Fix grouped orders not being validated correctly

### DIFF
--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -27,13 +27,6 @@ namespace OpenRA.Network
 
 		internal static void ProcessOrder(OrderManager orderManager, World world, int clientId, Order order)
 		{
-			if (world != null)
-			{
-				if (!world.WorldActor.TraitsImplementing<IValidateOrder>().All(vo =>
-					vo.OrderValidation(orderManager, world, clientId, order)))
-					return;
-			}
-
 			switch (order.OrderString)
 			{
 				// Server message
@@ -335,20 +328,30 @@ namespace OpenRA.Network
 
 				default:
 					{
+						if (world == null)
+							break;
+
 						if (order.GroupedActors == null)
-							ResolveOrder(order);
+							ResolveOrder(order, world.WorldActor.TraitsImplementing<IValidateOrder>(), orderManager, clientId);
 						else
+						{
+							// PERF: Cache the result of TraitsImplementing as we are likely to use it for several order subjects
+							var validateOrders = world.WorldActor.TraitsImplementing<IValidateOrder>().ToArray();
 							foreach (var subject in order.GroupedActors)
-								ResolveOrder(Order.FromGroupedOrder(order, subject));
+								ResolveOrder(Order.FromGroupedOrder(order, subject), validateOrders, orderManager, clientId);
+						}
 
 						break;
 					}
 			}
 		}
 
-		static void ResolveOrder(Order order)
+		static void ResolveOrder(Order order, IEnumerable<IValidateOrder> validateOrders, OrderManager orderManager, int clientId)
 		{
-			if (order.Subject != null && !order.Subject.IsDead)
+			if (order.Subject == null || order.Subject.IsDead)
+				return;
+
+			if (validateOrders.All(vo => vo.OrderValidation(orderManager, order.Subject.World, clientId, order)))
 				foreach (var t in order.Subject.TraitsImplementing<IResolveOrder>())
 					t.ResolveOrder(order.Subject, order);
 		}


### PR DESCRIPTION
Fixes a serious regression from #17472 which caused `AttackMove` and `Guard` orders to always be validated since `order.Subject` is `null` in grouped orders! (See https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs#L24-L25 for why that is a problem.)
We can move `OrderValidation` into `ResolveOrder` since none of the other cases in the `switch` set `order.Subject`, so the validation would always succeed regardless (which means we win a bit of perf here by not doing a trait lookup for things like `Ping`).