### PR TITLE
Overhaul and improve sequence linting

### DIFF
--- a/OpenRA.Game/Graphics/SequenceProvider.cs
+++ b/OpenRA.Game/Graphics/SequenceProvider.cs
@@ -41,7 +41,6 @@ namespace OpenRA.Graphics
 
 	public interface ISpriteSequenceLoader
 	{
-		Action<string> OnMissingSpriteError { get; set; }
 		IReadOnlyDictionary<string, ISpriteSequence> ParseSequences(ModData modData, TileSet tileSet, SpriteCache cache, MiniYamlNode node);
 	}
 
@@ -79,6 +78,8 @@ namespace OpenRA.Graphics
 			return seq;
 		}
 
+		public IEnumerable<string> Images { get { return sequences.Value.Keys; } }
+
 		public bool HasSequence(string unitName)
 		{
 			return sequences.Value.ContainsKey(unitName);
@@ -104,10 +105,11 @@ namespace OpenRA.Graphics
 		{
 			var nodes = MiniYaml.Load(fileSystem, modData.Manifest.Sequences, additionalSequences);
 			var items = new Dictionary<string, UnitSequences>();
-			foreach (var n in nodes)
+			foreach (var node in nodes)
 			{
-				// Work around the loop closure issue in older versions of C#
-				var node = n;
+				// Nodes starting with ^ are inheritable but never loaded directly
+				if (node.Key.StartsWith(ActorInfo.AbstractActorPrefix, StringComparison.Ordinal))
+					continue;
 
 				var key = node.Value.ToLines(node.Key).JoinWith("|");
 

--- a/OpenRA.Game/Graphics/Theater.cs
+++ b/OpenRA.Game/Graphics/Theater.cs
@@ -80,7 +80,14 @@ namespace OpenRA.Graphics
 						allFrames = frameCache[i];
 
 					var frameCount = tileset.EnableDepth ? allFrames.Length / 2 : allFrames.Length;
-					var indices = t.Value.Frames != null ? t.Value.Frames : Enumerable.Range(0, frameCount);
+					var indices = t.Value.Frames != null ? t.Value.Frames : Exts.MakeArray(t.Value.TilesCount, j => j);
+
+					var start = indices.Min();
+					var end = indices.Max();
+					if (start < 0 || end >= frameCount)
+						throw new YamlException("Template `{0}` uses frames [{1}..{2}] of {3}, but only [0..{4}] actually exist"
+							.F(t.Key, start, end, i, frameCount - 1));
+
 					variants.Add(indices.Select(j =>
 					{
 						var f = allFrames[j];
@@ -97,7 +104,7 @@ namespace OpenRA.Graphics
 						if (sheetBuilder == null)
 							sheetBuilder = new SheetBuilder(SheetBuilder.FrameTypeToSheetType(f.Type), allocate);
 						else if (type != sheetBuilder.Type)
-							throw new InvalidDataException("Sprite type mismatch. Terrain sprites must all be either Indexed or RGBA.");
+							throw new YamlException("Sprite type mismatch. Terrain sprites must all be either Indexed or RGBA.");
 
 						var s = sheetBuilder.Allocate(f.Size, zRamp, offset);
 						Util.FastCopyIntoChannel(s, f.Data);

--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -73,10 +73,10 @@ namespace OpenRA
 				foreach (var node in nodes)
 				{
 					if (!int.TryParse(node.Key, out var key))
-						throw new InvalidDataException("Tileset `{0}` template `{1}` frame `{2}` is not a valid integer.".F(tileSet.Id, Id, node.Key));
+						throw new YamlException("Tileset `{0}` template `{1}` defines a frame `{2}` that is not a valid integer.".F(tileSet.Id, Id, node.Key));
 
 					if (key < 0 || key >= tileInfo.Length)
-						throw new InvalidDataException("Tileset `{0}` template `{1}` frame `{2}` must be between 0 and {3} for a {4}x{5} Size template.".F(tileSet.Id, Id, node.Key, tileInfo.Length, Size.X, Size.Y));
+						throw new YamlException("Tileset `{0}` template `{1}` references frame {2}, but only [0..{3}] are valid for a {4}x{5} Size template.".F(tileSet.Id, Id, key, tileInfo.Length - 1, Size.X, Size.Y));
 
 					tileInfo[key] = LoadTileInfo(tileSet, node.Value);
 				}
@@ -88,8 +88,11 @@ namespace OpenRA
 				var i = 0;
 				foreach (var node in nodes)
 				{
-					if (!int.TryParse(node.Key, out var key) || key != i++)
-						throw new InvalidDataException("Invalid tile key '{0}' on template '{1}' of tileset '{2}'.".F(node.Key, Id, tileSet.Id));
+					if (!int.TryParse(node.Key, out var key))
+						throw new YamlException("Tileset `{0}` template `{1}` defines a frame `{2}` that is not a valid integer.".F(tileSet.Id, Id, node.Key));
+
+					if (key != i++)
+						throw new YamlException("Tileset `{0}` template `{1}` is missing a definition for frame {2}.".F(tileSet.Id, Id, i - 1));
 
 					tileInfo[key] = LoadTileInfo(tileSet, node.Value);
 				}
@@ -165,14 +168,14 @@ namespace OpenRA
 				.ToArray();
 
 			if (TerrainInfo.Length >= byte.MaxValue)
-				throw new InvalidDataException("Too many terrain types.");
+				throw new YamlException("Too many terrain types.");
 
 			for (byte i = 0; i < TerrainInfo.Length; i++)
 			{
 				var tt = TerrainInfo[i].Type;
 
 				if (terrainIndexByType.ContainsKey(tt))
-					throw new InvalidDataException("Duplicate terrain type '{0}' in '{1}'.".F(tt, filepath));
+					throw new YamlException("Duplicate terrain type '{0}' in '{1}'.".F(tt, filepath));
 
 				terrainIndexByType.Add(tt, i);
 			}

--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -72,8 +72,11 @@ namespace OpenRA
 				tileInfo = new TerrainTileInfo[Size.X * Size.Y];
 				foreach (var node in nodes)
 				{
-					if (!int.TryParse(node.Key, out var key) || key < 0 || key >= tileInfo.Length)
-						throw new InvalidDataException("Invalid tile key '{0}' on template '{1}' of tileset '{2}'.".F(node.Key, Id, tileSet.Id));
+					if (!int.TryParse(node.Key, out var key))
+						throw new InvalidDataException("Tileset `{0}` template `{1}` frame `{2}` is not a valid integer.".F(tileSet.Id, Id, node.Key));
+
+					if (key < 0 || key >= tileInfo.Length)
+						throw new InvalidDataException("Tileset `{0}` template `{1}` frame `{2}` must be between 0 and {3} for a {4}x{5} Size template.".F(tileSet.Id, Id, node.Key, tileInfo.Length, Size.X, Size.Y));
 
 					tileInfo[key] = LoadTileInfo(tileSet, node.Value);
 				}

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -79,7 +79,6 @@ namespace OpenRA
 				throw new InvalidOperationException("Unable to find a sequence loader for type '{0}'.".F(sequenceFormat.Type));
 
 			SpriteSequenceLoader = (ISpriteSequenceLoader)sequenceCtor.Invoke(new[] { this });
-			SpriteSequenceLoader.OnMissingSpriteError = s => Log.Write("debug", s);
 
 			var modelFormat = Manifest.Get<ModelSequenceFormat>();
 			var modelLoader = ObjectCreator.FindType(modelFormat.Type + "Loader");

--- a/OpenRA.Game/Traits/LintAttributes.cs
+++ b/OpenRA.Game/Traits/LintAttributes.cs
@@ -13,8 +13,6 @@ using System;
 
 namespace OpenRA.Traits
 {
-	/* attributes used by OpenRA.Lint to understand the rules */
-
 	[AttributeUsage(AttributeTargets.Field)]
 	public sealed class ActorReferenceAttribute : Attribute
 	{
@@ -27,28 +25,6 @@ namespace OpenRA.Traits
 
 	[AttributeUsage(AttributeTargets.Field)]
 	public sealed class WeaponReferenceAttribute : Attribute { }
-
-	[AttributeUsage(AttributeTargets.Field)]
-	public sealed class VoiceSetReferenceAttribute : Attribute { }
-
-	[AttributeUsage(AttributeTargets.Field)]
-	public sealed class VoiceReferenceAttribute : Attribute { }
-
-	[AttributeUsage(AttributeTargets.Field)]
-	public sealed class LocomotorReferenceAttribute : Attribute { }
-
-	[AttributeUsage(AttributeTargets.Field)]
-	public sealed class NotificationReferenceAttribute : Attribute
-	{
-		public readonly string NotificationTypeFieldName = null;
-		public readonly string NotificationType = null;
-
-		public NotificationReferenceAttribute(string type = null, string typeFromField = null)
-		{
-			NotificationType = type;
-			NotificationTypeFieldName = typeFromField;
-		}
-	}
 
 	[AttributeUsage(AttributeTargets.Field)]
 	public sealed class SequenceReferenceAttribute : Attribute

--- a/OpenRA.Game/Traits/LintAttributes.cs
+++ b/OpenRA.Game/Traits/LintAttributes.cs
@@ -31,12 +31,13 @@ namespace OpenRA.Traits
 	{
 		public readonly string ImageReference; // The field name in the same trait info that contains the image name.
 		public readonly bool Prefix;
-		public readonly bool ActorNameFallback;
-		public SequenceReferenceAttribute(string imageReference = null, bool prefix = false, bool actorNameFallback = false)
+		public readonly bool AllowNullImage;
+
+		public SequenceReferenceAttribute(string imageReference = null, bool prefix = false, bool allowNullImage = false)
 		{
 			ImageReference = imageReference;
 			Prefix = prefix;
-			ActorNameFallback = actorNameFallback;
+			AllowNullImage = allowNullImage;
 		}
 	}
 

--- a/OpenRA.Game/Traits/LintAttributes.cs
+++ b/OpenRA.Game/Traits/LintAttributes.cs
@@ -13,6 +13,13 @@ using System;
 
 namespace OpenRA.Traits
 {
+	public enum LintDictionaryReference
+	{
+		None = 0,
+		Keys = 1,
+		Values = 2
+	}
+
 	[AttributeUsage(AttributeTargets.Field)]
 	public sealed class ActorReferenceAttribute : Attribute
 	{
@@ -29,15 +36,19 @@ namespace OpenRA.Traits
 	[AttributeUsage(AttributeTargets.Field)]
 	public sealed class SequenceReferenceAttribute : Attribute
 	{
-		public readonly string ImageReference; // The field name in the same trait info that contains the image name.
+		// The field name in the same trait info that contains the image name.
+		public readonly string ImageReference;
 		public readonly bool Prefix;
 		public readonly bool AllowNullImage;
+		public readonly LintDictionaryReference DictionaryReference;
 
-		public SequenceReferenceAttribute(string imageReference = null, bool prefix = false, bool allowNullImage = false)
+		public SequenceReferenceAttribute(string imageReference = null, bool prefix = false, bool allowNullImage = false,
+			LintDictionaryReference dictionaryReference = LintDictionaryReference.None)
 		{
 			ImageReference = imageReference;
 			Prefix = prefix;
 			AllowNullImage = allowNullImage;
+			DictionaryReference = dictionaryReference;
 		}
 	}
 

--- a/OpenRA.Mods.Cnc/Projectiles/TeslaZap.cs
+++ b/OpenRA.Mods.Cnc/Projectiles/TeslaZap.cs
@@ -21,10 +21,10 @@ namespace OpenRA.Mods.Cnc.Projectiles
 	{
 		public readonly string Image = "litning";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		public readonly string BrightSequence = "bright";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		public readonly string DimSequence = "dim";
 
 		[PaletteReference]

--- a/OpenRA.Mods.Cnc/Traits/GpsDot.cs
+++ b/OpenRA.Mods.Cnc/Traits/GpsDot.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sprite collection for symbols.")]
 		public readonly string Image = "gpsdot";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		[Desc("Sprite used for this actor.")]
 		public readonly string String = "Infantry";
 

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -37,13 +37,13 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public readonly string FootprintImage = "overlay";
 
-		[SequenceReference("FootprintImage", prefix: true)]
+		[SequenceReference(nameof(FootprintImage), prefix: true)]
 		public readonly string ValidFootprintSequence = "target-valid";
 
-		[SequenceReference("FootprintImage")]
+		[SequenceReference(nameof(FootprintImage))]
 		public readonly string InvalidFootprintSequence = "target-invalid";
 
-		[SequenceReference("FootprintImage")]
+		[SequenceReference(nameof(FootprintImage))]
 		public readonly string SourceFootprintSequence = "target-select";
 
 		public readonly bool KillCargo = true;

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public readonly string FootprintImage = "overlay";
 
-		[SequenceReference("FootprintImage", true)]
+		[SequenceReference("FootprintImage", prefix: true)]
 		public readonly string ValidFootprintSequence = "target-valid";
 
 		[SequenceReference("FootprintImage")]

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/DropPodsPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/DropPodsPower.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public readonly string EntryEffect = "podring";
 
 		[Desc("Effect sequence to display in the air.")]
-		[SequenceReference("Effect")]
+		[SequenceReference("EntryEffect")]
 		public readonly string EntryEffectSequence = "idle";
 
 		[PaletteReference]

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/DropPodsPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/DropPodsPower.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public readonly string EntryEffect = "podring";
 
 		[Desc("Effect sequence to display in the air.")]
-		[SequenceReference("EntryEffect")]
+		[SequenceReference(nameof(EntryEffect))]
 		public readonly string EntryEffectSequence = "idle";
 
 		[PaletteReference]

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/GpsPower.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public readonly string DoorImage = "atek";
 
-		[SequenceReference("DoorImage")]
+		[SequenceReference(nameof(DoorImage))]
 		public readonly string DoorSequence = "active";
 
 		[PaletteReference(nameof(DoorPaletteIsPlayerPalette))]
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public readonly string SatelliteImage = "sputnik";
 
-		[SequenceReference("SatelliteImage")]
+		[SequenceReference(nameof(SatelliteImage))]
 		public readonly string SatelliteSequence = "idle";
 
 		[PaletteReference(nameof(SatellitePaletteIsPlayerPalette))]

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/IonCannonPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/IonCannonPower.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Effect sequence sprite image")]
 		public readonly string Effect = "ionsfx";
 
-		[SequenceReference("Effect")]
+		[SequenceReference(nameof(Effect))]
 		[Desc("Effect sequence to display")]
 		public readonly string EffectSequence = "idle";
 

--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -40,7 +40,6 @@ namespace OpenRA.Mods.Common.Graphics
 
 	public class DefaultSpriteSequenceLoader : ISpriteSequenceLoader
 	{
-		public Action<string> OnMissingSpriteError { get; set; }
 		public DefaultSpriteSequenceLoader(ModData modData) { }
 
 		public virtual ISpriteSequence CreateSequence(ModData modData, TileSet tileSet, SpriteCache cache, string sequence, string animation, MiniYaml info)
@@ -80,14 +79,43 @@ namespace OpenRA.Mods.Common.Graphics
 					}
 					catch (FileNotFoundException ex)
 					{
-						// Eat the FileNotFound exceptions from missing sprites
-						OnMissingSpriteError(ex.Message);
+						// Defer exception until something tries to access the sequence
+						// This allows the asset installer and OpenRA.Utility to load the game without having the actor assets
+						sequences.Add(kvp.Key, new FileNotFoundSequence(ex));
 					}
 				}
 			}
 
 			return new ReadOnlyDictionary<string, ISpriteSequence>(sequences);
 		}
+	}
+
+	public class FileNotFoundSequence : ISpriteSequence
+	{
+		readonly FileNotFoundException exception;
+
+		public FileNotFoundSequence(FileNotFoundException exception)
+		{
+			this.exception = exception;
+		}
+
+		public string Filename { get { return exception.FileName; } }
+
+		string ISpriteSequence.Name { get { throw exception; } }
+		int ISpriteSequence.Start { get { throw exception; } }
+		int ISpriteSequence.Length { get { throw exception; } }
+		int ISpriteSequence.Stride { get { throw exception; } }
+		int ISpriteSequence.Facings { get { throw exception; } }
+		int ISpriteSequence.Tick { get { throw exception; } }
+		int ISpriteSequence.ZOffset { get { throw exception; } }
+		int ISpriteSequence.ShadowStart { get { throw exception; } }
+		int ISpriteSequence.ShadowZOffset { get { throw exception; } }
+		int[] ISpriteSequence.Frames { get { throw exception; } }
+		Rectangle ISpriteSequence.Bounds { get { throw exception; } }
+		bool ISpriteSequence.IgnoreWorldTint { get { throw exception; } }
+		Sprite ISpriteSequence.GetSprite(int frame) { throw exception; }
+		Sprite ISpriteSequence.GetSprite(int frame, WAngle facing) { throw exception; }
+		Sprite ISpriteSequence.GetShadow(int frame, WAngle facing) { throw exception; }
 	}
 
 	public class DefaultSpriteSequence : ISpriteSequence

--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -217,39 +217,32 @@ namespace OpenRA.Mods.Common.Graphics
 					Stride = LoadField(d, "Stride", Length);
 
 					if (Length > Stride)
-						throw new InvalidOperationException(
-							"{0}: Sequence {1}.{2}: Length must be <= stride"
-							.F(info.Nodes[0].Location, sequence, animation));
+						throw new YamlException("Sequence {0}.{1}: Length must be <= stride"
+							.F(sequence, animation));
 
 					if (Frames != null && Length > Frames.Length)
-						throw new InvalidOperationException(
-							"{0}: Sequence {1}.{2}: Length must be <= Frames.Length"
-							.F(info.Nodes[0].Location, sequence, animation));
+						throw new YamlException("Sequence {0}.{1}: Length must be <= Frames.Length"
+							.F(sequence, animation));
 
 					var end = Start + (Facings - 1) * Stride + Length - 1;
 					if (Frames != null)
 					{
 						foreach (var f in Frames)
 							if (f < 0 || f >= frameCount)
-								throw new InvalidOperationException(
-									"{5}: Sequence {0}.{1} defines a Frames override that references frame {4}, but only [{2}..{3}] actually exist"
-										.F(sequence, animation, Start, end, f, info.Nodes[0].Location));
+								throw new YamlException("Sequence {0}.{1} defines a Frames override that references frame {2}, but only [{3}..{4}] actually exist"
+									.F(sequence, animation, f, Start, end));
 
 						if (Start < 0 || end >= Frames.Length)
-							throw new InvalidOperationException(
-								"{5}: Sequence {0}.{1} uses indices [{2}..{3}] of the Frames list, but only {4} frames are defined"
-									.F(sequence, animation, Start, end, Frames.Length, info.Nodes[0].Location));
+							throw new YamlException("Sequence {0}.{1} uses indices [{2}..{3}] of the Frames list, but only {4} frames are defined"
+									.F(sequence, animation, Start, end, Frames.Length));
 					}
 					else if (Start < 0 || end >= frameCount)
-						throw new InvalidOperationException(
-							"{5}: Sequence {0}.{1} uses frames [{2}..{3}], but only 0..{4} actually exist"
-								.F(sequence, animation, Start, end, frameCount - 1, info.Nodes[0].Location));
+						throw new YamlException("Sequence {0}.{1} uses frames [{2}..{3}], but only [0..{4}] actually exist"
+								.F(sequence, animation, Start, end, frameCount - 1));
 
 					if (ShadowStart >= 0 && ShadowStart + (Facings - 1) * Stride + Length > frameCount)
-						throw new InvalidOperationException(
-							"{5}: Sequence {0}.{1}'s shadow frames use frames [{2}..{3}], but only [0..{4}] actually exist"
-							.F(sequence, animation, ShadowStart, ShadowStart + (Facings - 1) * Stride + Length - 1, frameCount - 1,
-								info.Nodes[0].Location));
+						throw new YamlException("Sequence {0}.{1}'s shadow frames use frames [{2}..{3}], but only [0..{4}] actually exist"
+							.F(sequence, animation, ShadowStart, ShadowStart + (Facings - 1) * Stride + Length - 1, frameCount - 1));
 
 					var usedFrames = new List<int>();
 					for (var facing = 0; facing < Facings; facing++)

--- a/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Lint
 	{
 		Action<string> emitError;
 
-		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
 			this.emitError = emitError;
 

--- a/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
@@ -13,6 +13,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using OpenRA.GameRules;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint

--- a/OpenRA.Mods.Common/Lint/CheckAngle.cs
+++ b/OpenRA.Mods.Common/Lint/CheckAngle.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.Lint
 {
 	class CheckAngle : ILintRulesPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
 			foreach (var weaponInfo in rules.Weapons)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckConditions.cs
+++ b/OpenRA.Mods.Common/Lint/CheckConditions.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Lint
 {
 	public class CheckConditions : ILintRulesPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckConflictingMouseBounds.cs
+++ b/OpenRA.Mods.Common/Lint/CheckConflictingMouseBounds.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Lint
 {
 	public class CheckConflictingMouseBounds : ILintRulesPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
+++ b/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Lint
 {
 	class CheckDefaultVisibility : ILintRulesPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckHitShapes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckHitShapes.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Lint
 {
 	class CheckHitShapes : ILintRulesPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckLocomotorReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckLocomotorReferences.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Lint
 {
 	public class CheckLocomotorReferences : ILintRulesPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
 			var worldActor = rules.Actors["world"];
 			var locomotorInfos = worldActor.TraitInfos<LocomotorInfo>().ToArray();

--- a/OpenRA.Mods.Common/Lint/CheckNotifications.cs
+++ b/OpenRA.Mods.Common/Lint/CheckNotifications.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Linq;
 using OpenRA.GameRules;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint

--- a/OpenRA.Mods.Common/Lint/CheckNotifications.cs
+++ b/OpenRA.Mods.Common/Lint/CheckNotifications.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Lint
 {
 	class CheckNotifications : ILintRulesPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckPalettes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPalettes.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Lint
 		List<string> palettes = new List<string>();
 		List<string> playerPalettes = new List<string>();
 
-		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
 			GetPalettes(emitError, rules);
 

--- a/OpenRA.Mods.Common/Lint/CheckRangeLimit.cs
+++ b/OpenRA.Mods.Common/Lint/CheckRangeLimit.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.Lint
 {
 	class CheckRangeLimit : ILintRulesPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
 			foreach (var weaponInfo in rules.Weapons)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
+++ b/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Lint
 {
 	class CheckRevealFootprint : ILintRulesPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
@@ -83,7 +84,7 @@ namespace OpenRA.Mods.Common.Lint
 							sequenceImages = new[] { imageOverride.ToLowerInvariant() };
 						}
 
-						foreach (var sequence in LintExts.GetFieldValues(traitInfo, field, emitError))
+						foreach (var sequence in LintExts.GetFieldValues(traitInfo, field, emitError, sequenceReference.DictionaryReference))
 						{
 							if (string.IsNullOrEmpty(sequence))
 								continue;
@@ -128,7 +129,7 @@ namespace OpenRA.Mods.Common.Lint
 					}
 
 					image = image.ToLowerInvariant();
-					foreach (var sequence in LintExts.GetFieldValues(projectileInfo, field, emitError))
+					foreach (var sequence in LintExts.GetFieldValues(projectileInfo, field, emitError, sequenceReference.DictionaryReference))
 					{
 						if (string.IsNullOrEmpty(sequence))
 							continue;

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -12,172 +12,136 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
+using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckSequences : ILintMapPass
+	class CheckSequences : ILintRulesPass
 	{
-		Action<string> emitError;
-
-		List<MiniYamlNode> sequenceDefinitions;
-
-		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
+		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
-			if (map.SequenceDefinitions == null)
-				return;
+			// Custom maps define rules.Sequences, default mod rules leave it null.
+			if (rules.Sequences == null)
+			{
+				foreach (var kv in modData.DefaultSequences)
+				{
+					Console.WriteLine("Testing default sequences for {0}", kv.Key);
+					Run(emitError, emitWarning, rules, kv.Value);
+				}
+			}
+			else if (!modData.DefaultSequences.Values.Contains(rules.Sequences))
+				Run(emitError, emitWarning, rules, rules.Sequences);
+		}
 
-			this.emitError = emitError;
-
-			sequenceDefinitions = MiniYaml.Load(map, modData.Manifest.Sequences, map.SequenceDefinitions);
-
-			var rules = map.Rules;
+		void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules, SequenceProvider sequences)
+		{
 			var factions = rules.Actors["world"].TraitInfos<FactionInfo>().Select(f => f.InternalName).ToArray();
-			var sequenceProviders = new[] { rules.Sequences };
-
 			foreach (var actorInfo in rules.Actors)
 			{
-				foreach (var renderInfo in actorInfo.Value.TraitInfos<RenderSpritesInfo>())
+				// Actors may have 0 or 1 RenderSprites traits
+				var renderInfo = actorInfo.Value.TraitInfoOrDefault<RenderSpritesInfo>();
+				if (renderInfo == null)
+					continue;
+
+				var images = new HashSet<string>()
 				{
-					foreach (var faction in factions)
-					{
-						foreach (var sequenceProvider in sequenceProviders)
-						{
-							var image = renderInfo.GetImage(actorInfo.Value, sequenceProvider, faction);
-							if (sequenceDefinitions.All(s => s.Key != image.ToLowerInvariant()))
-								emitError("Sprite image {0} from actor {1} using faction {2} has no sequence definition."
-									.F(image, actorInfo.Value.Name, faction));
-						}
-					}
-				}
+					renderInfo.GetImage(actorInfo.Value, sequences, null).ToLowerInvariant()
+				};
+
+				// Some actors define faction-specific artwork
+				foreach (var faction in factions)
+					images.Add(renderInfo.GetImage(actorInfo.Value, sequences, faction).ToLowerInvariant());
 
 				foreach (var traitInfo in actorInfo.Value.TraitInfos<TraitInfo>())
 				{
+					// Remove the "Info" suffix
+					var traitName = traitInfo.GetType().Name;
+					traitName = traitName.Remove(traitName.Length - 4);
+
 					var fields = traitInfo.GetType().GetFields();
 					foreach (var field in fields)
 					{
-						if (field.HasAttribute<SequenceReferenceAttribute>())
+						var sequenceReference = field.GetCustomAttributes<SequenceReferenceAttribute>(true).FirstOrDefault();
+						if (sequenceReference == null)
+							continue;
+
+						// Some sequences may specify their own Image override
+						IEnumerable<string> sequenceImages = images;
+						if (!string.IsNullOrEmpty(sequenceReference.ImageReference))
 						{
-							var sequences = LintExts.GetFieldValues(traitInfo, field, emitError);
-							foreach (var sequence in sequences)
+							var imageField = fields.First(f => f.Name == sequenceReference.ImageReference);
+							var imageOverride = (string)imageField.GetValue(traitInfo);
+							if (string.IsNullOrEmpty(imageOverride))
 							{
-								if (string.IsNullOrEmpty(sequence))
-									continue;
-
-								var renderInfo = actorInfo.Value.TraitInfos<RenderSpritesInfo>().FirstOrDefault();
-								if (renderInfo == null)
-									continue;
-
-								foreach (var faction in factions)
-								{
-									var sequenceReference = field.GetCustomAttributes<SequenceReferenceAttribute>(true).FirstOrDefault();
-									if (sequenceReference != null && !string.IsNullOrEmpty(sequenceReference.ImageReference))
-									{
-										var imageField = fields.FirstOrDefault(f => f.Name == sequenceReference.ImageReference);
-										if (imageField != null)
-										{
-											foreach (var imageOverride in LintExts.GetFieldValues(traitInfo, imageField, emitError))
-											{
-												if (string.IsNullOrEmpty(imageOverride))
-												{
-													if (!sequenceReference.ActorNameFallback)
-													{
-														emitWarning("Custom sprite image of actor {0} is null and there is no fallback.".F(actorInfo.Value.Name));
-														continue;
-													}
-
-													foreach (var sequenceProvider in sequenceProviders)
-													{
-														var image = renderInfo.GetImage(actorInfo.Value, sequenceProvider, faction);
-														CheckDefinitions(image, sequenceReference, actorInfo, sequence, faction, field, traitInfo);
-													}
-
-													continue;
-												}
-
-												if (sequenceDefinitions.All(s => s.Key != imageOverride.ToLowerInvariant()))
-													emitError("Custom sprite image {0} from actor {1} has no sequence definition.".F(imageOverride, actorInfo.Value.Name));
-												else
-													CheckDefinitions(imageOverride, sequenceReference, actorInfo, sequence, faction, field, traitInfo);
-											}
-										}
-									}
-									else
-									{
-										foreach (var sequenceProvider in sequenceProviders)
-										{
-											var image = renderInfo.GetImage(actorInfo.Value, sequenceProvider, faction);
-											CheckDefinitions(image, sequenceReference, actorInfo, sequence, faction, field, traitInfo);
-										}
-									}
-								}
+								if (!sequenceReference.AllowNullImage)
+									emitError("Actor type `{0}` trait `{1}` must define a value for `{2}`".F(actorInfo.Value.Name, traitName, sequenceReference.ImageReference));
+								continue;
 							}
+
+							sequenceImages = new[] { imageOverride.ToLowerInvariant() };
 						}
-					}
-				}
 
-				foreach (var weaponInfo in rules.Weapons)
-				{
-					var projectileInfo = weaponInfo.Value.Projectile;
-					if (projectileInfo == null)
-						continue;
-
-					var fields = projectileInfo.GetType().GetFields();
-					foreach (var field in fields)
-					{
-						if (field.HasAttribute<SequenceReferenceAttribute>())
+						foreach (var sequence in LintExts.GetFieldValues(traitInfo, field, emitError))
 						{
-							var sequences = LintExts.GetFieldValues(projectileInfo, field, emitError);
-							foreach (var sequence in sequences)
-							{
-								if (string.IsNullOrEmpty(sequence))
-									continue;
+							if (string.IsNullOrEmpty(sequence))
+								continue;
 
-								var sequenceReference = field.GetCustomAttributes<SequenceReferenceAttribute>(true).FirstOrDefault();
-								if (sequenceReference != null && !string.IsNullOrEmpty(sequenceReference.ImageReference))
+							foreach (var i in sequenceImages)
+							{
+								if (sequenceReference.Prefix)
 								{
-									var imageField = fields.FirstOrDefault(f => f.Name == sequenceReference.ImageReference);
-									if (imageField != null)
-									{
-										foreach (var imageOverride in LintExts.GetFieldValues(projectileInfo, imageField, emitError))
-										{
-											if (!string.IsNullOrEmpty(imageOverride))
-											{
-												var definitions = sequenceDefinitions.FirstOrDefault(n => n.Key == imageOverride.ToLowerInvariant());
-												if (definitions == null)
-													emitError("Can't find sequence definition for projectile image {0} at weapon {1}.".F(imageOverride, weaponInfo.Key));
-												else if (!definitions.Value.Nodes.Any(n => n.Key == sequence))
-													emitError("Projectile sprite image {0} from weapon {1} does not define sequence {2} from field {3} of {4}"
-														.F(imageOverride, weaponInfo.Key, sequence, field.Name, projectileInfo));
-											}
-										}
-									}
+									// TODO: Remove prefixed sequence references and instead use explicit lists of lintable references
+									if (!sequences.Sequences(i).Any(s => s.StartsWith(sequence)))
+										emitWarning("Actor type `{0}` trait `{1}` field `{2}` defines a prefix `{3}` that does not match any sequences on image `{4}`.".F(actorInfo.Value.Name, traitName, field.Name, sequence, i));
 								}
+								else if (!sequences.HasSequence(i, sequence))
+									emitError("Actor type `{0}` trait `{1}` field `{2}` references an undefined sequence `{3}` on image `{4}`.".F(actorInfo.Value.Name, traitName, field.Name, sequence, i));
 							}
 						}
 					}
 				}
 			}
-		}
 
-		void CheckDefinitions(string image, SequenceReferenceAttribute sequenceReference,
-			KeyValuePair<string, ActorInfo> actorInfo, string sequence, string faction, FieldInfo field, TraitInfo traitInfo)
-		{
-			var definitions = sequenceDefinitions.FirstOrDefault(n => n.Key == image.ToLowerInvariant());
-			if (definitions != null)
+			foreach (var weaponInfo in rules.Weapons)
 			{
-				if (sequenceReference != null && sequenceReference.Prefix)
+				var projectileInfo = weaponInfo.Value.Projectile;
+				if (projectileInfo == null)
+					continue;
+
+				var fields = projectileInfo.GetType().GetFields();
+				foreach (var field in fields)
 				{
-					if (!definitions.Value.Nodes.Any(n => n.Key.StartsWith(sequence)))
-						emitError("Sprite image {0} from actor {1} of faction {2} does not define sequence prefix {3} from field {4} of {5}"
-							.F(image, actorInfo.Value.Name, faction, sequence, field.Name, traitInfo));
-				}
-				else if (definitions.Value.Nodes.All(n => n.Key != sequence))
-				{
-					emitError("Sprite image {0} from actor {1} of faction {2} does not define sequence {3} from field {4} of {5}"
-						.F(image, actorInfo.Value.Name, faction, sequence, field.Name, traitInfo));
+					var sequenceReference = field.GetCustomAttributes<SequenceReferenceAttribute>(true).FirstOrDefault();
+					if (sequenceReference == null)
+						continue;
+
+					// All weapon sequences must specify their corresponding image
+					var image = ((string)fields.First(f => f.Name == sequenceReference.ImageReference).GetValue(projectileInfo));
+					if (string.IsNullOrEmpty(image))
+					{
+						if (!sequenceReference.AllowNullImage)
+							emitError("Weapon type `{0}` projectile field `{1}` must define a value".F(weaponInfo.Key, sequenceReference.ImageReference));
+
+						continue;
+					}
+
+					image = image.ToLowerInvariant();
+					foreach (var sequence in LintExts.GetFieldValues(projectileInfo, field, emitError))
+					{
+						if (string.IsNullOrEmpty(sequence))
+							continue;
+
+						if (sequenceReference.Prefix)
+						{
+							// TODO: Remove prefixed sequence references and instead use explicit lists of lintable references
+							if (!sequences.Sequences(image).Any(s => s.StartsWith(sequence)))
+								emitWarning("Weapon type `{0}` projectile field `{1}` defines a prefix `{2}` that does not match any sequences on image `{3}`.".F(weaponInfo.Key, field.Name, sequence, image));
+						}
+						else if (!sequences.HasSequence(image, sequence))
+							emitError("Weapon type `{0}` projectile field `{1}` references an undefined sequence `{2}` on image `{3}`.".F(weaponInfo.Key, field.Name, sequence, image));
+					}
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/Lint/CheckSpriteBodies.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSpriteBodies.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Lint
 {
 	class CheckSpriteBodies : ILintRulesPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckTooltips.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTooltips.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Lint
 {
 	class CheckTooltips : ILintRulesPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckTraitPrerequisites.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTraitPrerequisites.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.Lint
 {
 	public class CheckTraitPrerequisites : ILintRulesPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Linq;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint

--- a/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Lint
 {
 	public class CheckVoiceReferences : ILintRulesPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
+++ b/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Lint
 {
 	class LintBuildablePrerequisites : ILintRulesPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
 			var providedPrereqs = rules.Actors.SelectMany(a => a.Value.TraitInfos<ITechTreePrerequisiteInfo>().SelectMany(p => p.Prerequisites(a.Value)));
 

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Image to display.")]
 		public readonly string Image = null;
 
-		[SequenceReference("Image", allowNullImage: true)]
+		[SequenceReference(nameof(Image), allowNullImage: true)]
 		[Desc("Loop a randomly chosen sequence of Image from this list while this projectile is moving.")]
 		public readonly string[] Sequences = { "idle" };
 
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Trail animation.")]
 		public readonly string TrailImage = null;
 
-		[SequenceReference("TrailImage", allowNullImage: true)]
+		[SequenceReference(nameof(TrailImage), allowNullImage: true)]
 		[Desc("Loop a randomly chosen sequence of TrailImage from this list while this projectile is moving.")]
 		public readonly string[] TrailSequences = { "idle" };
 

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Image to display.")]
 		public readonly string Image = null;
 
-		[SequenceReference("Image")]
+		[SequenceReference("Image", allowNullImage: true)]
 		[Desc("Loop a randomly chosen sequence of Image from this list while this projectile is moving.")]
 		public readonly string[] Sequences = { "idle" };
 
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Trail animation.")]
 		public readonly string TrailImage = null;
 
-		[SequenceReference("TrailImage")]
+		[SequenceReference("TrailImage", allowNullImage: true)]
 		[Desc("Loop a randomly chosen sequence of TrailImage from this list while this projectile is moving.")]
 		public readonly string[] TrailSequences = { "idle" };
 

--- a/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
@@ -20,11 +20,11 @@ namespace OpenRA.Mods.Common.Projectiles
 	{
 		public readonly string Image = null;
 
-		[SequenceReference("Image", allowNullImage: true)]
+		[SequenceReference(nameof(Image), allowNullImage: true)]
 		[Desc("Loop a randomly chosen sequence of Image from this list while falling.")]
 		public readonly string[] Sequences = { "idle" };
 
-		[SequenceReference("Image", allowNullImage: true)]
+		[SequenceReference(nameof(Image), allowNullImage: true)]
 		[Desc("Sequence to play when launched. Skipped if null or empty.")]
 		public readonly string OpenSequence = null;
 

--- a/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
@@ -20,11 +20,11 @@ namespace OpenRA.Mods.Common.Projectiles
 	{
 		public readonly string Image = null;
 
-		[SequenceReference("Image")]
+		[SequenceReference("Image", allowNullImage: true)]
 		[Desc("Loop a randomly chosen sequence of Image from this list while falling.")]
 		public readonly string[] Sequences = { "idle" };
 
-		[SequenceReference("Image")]
+		[SequenceReference("Image", allowNullImage: true)]
 		[Desc("Sequence to play when launched. Skipped if null or empty.")]
 		public readonly string OpenSequence = null;
 

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Impact animation.")]
 		public readonly string HitAnim = null;
 
-		[SequenceReference("HitAnim", allowNullImage: true)]
+		[SequenceReference(nameof(HitAnim), allowNullImage: true)]
 		[Desc("Sequence of impact animation to use.")]
 		public readonly string HitAnimSequence = "idle";
 
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Image containing launch effect sequence.")]
 		public readonly string LaunchEffectImage = null;
 
-		[SequenceReference("LaunchEffectImage", allowNullImage: true)]
+		[SequenceReference(nameof(LaunchEffectImage), allowNullImage: true)]
 		[Desc("Launch effect sequence to play.")]
 		public readonly string LaunchEffectSequence = null;
 

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Impact animation.")]
 		public readonly string HitAnim = null;
 
-		[SequenceReference("HitAnim")]
+		[SequenceReference("HitAnim", allowNullImage: true)]
 		[Desc("Sequence of impact animation to use.")]
 		public readonly string HitAnimSequence = "idle";
 
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Image containing launch effect sequence.")]
 		public readonly string LaunchEffectImage = null;
 
-		[SequenceReference("LaunchEffectImage")]
+		[SequenceReference("LaunchEffectImage", allowNullImage: true)]
 		[Desc("Launch effect sequence to play.")]
 		public readonly string LaunchEffectSequence = null;
 

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Name of the image containing the projectile sequence.")]
 		public readonly string Image = null;
 
-		[SequenceReference("Image", allowNullImage: true)]
+		[SequenceReference(nameof(Image), allowNullImage: true)]
 		[Desc("Loop a randomly chosen sequence of Image from this list while this projectile is moving.")]
 		public readonly string[] Sequences = { "idle" };
 
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Image that contains the trail animation.")]
 		public readonly string TrailImage = null;
 
-		[SequenceReference("TrailImage", allowNullImage: true)]
+		[SequenceReference(nameof(TrailImage), allowNullImage: true)]
 		[Desc("Loop a randomly chosen sequence of TrailImage from this list while this projectile is moving.")]
 		public readonly string[] TrailSequences = { "idle" };
 

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Name of the image containing the projectile sequence.")]
 		public readonly string Image = null;
 
-		[SequenceReference("Image")]
+		[SequenceReference("Image", allowNullImage: true)]
 		[Desc("Loop a randomly chosen sequence of Image from this list while this projectile is moving.")]
 		public readonly string[] Sequences = { "idle" };
 
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Image that contains the trail animation.")]
 		public readonly string TrailImage = null;
 
-		[SequenceReference("TrailImage")]
+		[SequenceReference("TrailImage", allowNullImage: true)]
 		[Desc("Loop a randomly chosen sequence of TrailImage from this list while this projectile is moving.")]
 		public readonly string[] TrailSequences = { "idle" };
 

--- a/OpenRA.Mods.Common/Projectiles/Railgun.cs
+++ b/OpenRA.Mods.Common/Projectiles/Railgun.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		public readonly string HitAnim = null;
 
 		[Desc("Sequence of impact animation to use.")]
-		[SequenceReference("HitAnim")]
+		[SequenceReference("HitAnim", allowNullImage: true)]
 		public readonly string HitAnimSequence = "idle";
 
 		[PaletteReference]

--- a/OpenRA.Mods.Common/Projectiles/Railgun.cs
+++ b/OpenRA.Mods.Common/Projectiles/Railgun.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		public readonly string HitAnim = null;
 
 		[Desc("Sequence of impact animation to use.")]
-		[SequenceReference("HitAnim", allowNullImage: true)]
+		[SequenceReference(nameof(HitAnim), allowNullImage: true)]
 		public readonly string HitAnimSequence = "idle";
 
 		[PaletteReference]

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -24,10 +24,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Width (in pixels) of the rallypoint line.")]
 		public readonly int LineWidth = 1;
 
-		[SequenceReference("Image", allowNullImage: true)]
+		[SequenceReference(nameof(Image), allowNullImage: true)]
 		public readonly string FlagSequence = "flag";
 
-		[SequenceReference("Image", allowNullImage: true)]
+		[SequenceReference(nameof(Image), allowNullImage: true)]
 		public readonly string CirclesSequence = "circles";
 
 		[Desc("Cursor to display when rally point can be set.")]

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -24,10 +24,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Width (in pixels) of the rallypoint line.")]
 		public readonly int LineWidth = 1;
 
-		[SequenceReference("Image")]
+		[SequenceReference("Image", allowNullImage: true)]
 		public readonly string FlagSequence = "flag";
 
-		[SequenceReference("Image")]
+		[SequenceReference("Image", allowNullImage: true)]
 		public readonly string CirclesSequence = "circles";
 
 		[Desc("Cursor to display when rally point can be set.")]

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnSubterraneanLayer.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnSubterraneanLayer.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Dig animation image to play when transitioning.")]
 		public readonly string SubterraneanTransitionImage = null;
 
-		[SequenceReference("SubterraneanTransitionImage")]
+		[SequenceReference(nameof(SubterraneanTransitionImage))]
 		[Desc("Dig animation sequence to play when transitioning.")]
 		public readonly string SubterraneanTransitionSequence = null;
 

--- a/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Image containing the crate effect animation sequence.")]
 		public readonly string Image = "crate-effects";
 
-		[SequenceReference("Image", allowNullImage: true)]
+		[SequenceReference(nameof(Image), allowNullImage: true)]
 		[Desc("Animation sequence played when collected. Leave empty for no effect.")]
 		public readonly string Sequence = null;
 

--- a/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Image containing the crate effect animation sequence.")]
 		public readonly string Image = "crate-effects";
 
-		[SequenceReference("Image")]
+		[SequenceReference("Image", allowNullImage: true)]
 		[Desc("Animation sequence played when collected. Leave empty for no effect.")]
 		public readonly string Sequence = null;
 

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Image for the level up sprite.")]
 		public readonly string LevelUpImage = null;
 
-		[SequenceReference("LevelUpImage")]
+		[SequenceReference("LevelUpImage", allowNullImage: true)]
 		[Desc("Sequence for the level up sprite. Needs to be present on LevelUpImage.")]
 		public readonly string LevelUpSequence = "levelup";
 

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Image for the level up sprite.")]
 		public readonly string LevelUpImage = null;
 
-		[SequenceReference("LevelUpImage", allowNullImage: true)]
+		[SequenceReference(nameof(LevelUpImage), allowNullImage: true)]
 		[Desc("Sequence for the level up sprite. Needs to be present on LevelUpImage.")]
 		public readonly string LevelUpSequence = "levelup";
 

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -32,8 +32,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Image for the level up sprite.")]
 		public readonly string LevelUpImage = null;
 
-		[SequenceReference("Image")]
-		[Desc("Sequence for the level up sprite. Needs to be present on Image.")]
+		[SequenceReference("LevelUpImage")]
+		[Desc("Sequence for the level up sprite. Needs to be present on LevelUpImage.")]
 		public readonly string LevelUpSequence = "levelup";
 
 		[PaletteReference]

--- a/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Chance (out of 100) the unit has to enter panic mode when attacking.")]
 		public readonly int AttackPanicChance = 20;
 
-		[SequenceReference(null, true)]
+		[SequenceReference(prefix: true)]
 		public readonly string PanicSequencePrefix = "panic-";
 
 		public override object Create(ActorInitializer init) { return new ScaredyCat(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Muzzle offset modifier to apply while prone.")]
 		public readonly WVec ProneOffset = new WVec(500, 0, 0);
 
-		[SequenceReference(null, true)]
+		[SequenceReference(prefix: true)]
 		[Desc("Sequence prefix to apply while prone.")]
 		public readonly string ProneSequencePrefix = "prone-";
 

--- a/OpenRA.Mods.Common/Traits/LintAttributes.cs
+++ b/OpenRA.Mods.Common/Traits/LintAttributes.cs
@@ -1,0 +1,37 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[AttributeUsage(AttributeTargets.Field)]
+	public sealed class VoiceSetReferenceAttribute : Attribute { }
+
+	[AttributeUsage(AttributeTargets.Field)]
+	public sealed class VoiceReferenceAttribute : Attribute { }
+
+	[AttributeUsage(AttributeTargets.Field)]
+	public sealed class LocomotorReferenceAttribute : Attribute { }
+
+	[AttributeUsage(AttributeTargets.Field)]
+	public sealed class NotificationReferenceAttribute : Attribute
+	{
+		public readonly string NotificationTypeFieldName = null;
+		public readonly string NotificationType = null;
+
+		public NotificationReferenceAttribute(string type = null, string typeFromField = null)
+		{
+			NotificationType = type;
+			NotificationTypeFieldName = typeFromField;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Image where Ground/WaterCorpseSequence is looked up.")]
 		public readonly string Image = "explosion";
 
-		[SequenceReference("Image", allowNullImage: true)]
+		[SequenceReference(nameof(Image), allowNullImage: true)]
 		public readonly string GroundCorpseSequence = null;
 
 		[PaletteReference]
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly string GroundImpactSound = null;
 
-		[SequenceReference("Image", allowNullImage: true)]
+		[SequenceReference(nameof(Image), allowNullImage: true)]
 		public readonly string WaterCorpseSequence = null;
 
 		[PaletteReference]

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Image where Ground/WaterCorpseSequence is looked up.")]
 		public readonly string Image = "explosion";
 
-		[SequenceReference("Image")]
+		[SequenceReference("Image", allowNullImage: true)]
 		public readonly string GroundCorpseSequence = null;
 
 		[PaletteReference]
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly string GroundImpactSound = null;
 
-		[SequenceReference("Image")]
+		[SequenceReference("Image", allowNullImage: true)]
 		public readonly string WaterCorpseSequence = null;
 
 		[PaletteReference]

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
@@ -31,13 +31,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly string BeaconImage = "beacon";
 
-		[SequenceReference("BeaconImage")]
+		[SequenceReference(nameof(BeaconImage))]
 		public readonly string BeaconSequence = null;
 
-		[SequenceReference("BeaconImage")]
+		[SequenceReference(nameof(BeaconImage))]
 		public readonly string ArrowSequence = "arrow";
 
-		[SequenceReference("BeaconImage")]
+		[SequenceReference(nameof(BeaconImage))]
 		public readonly string CircleSequence = "circles";
 
 		public override object Create(ActorInitializer init) { return new PlaceBeacon(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
+++ b/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[FieldLoader.Require]
 		public readonly string Image = null;
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		public readonly string[] Sequences = { "idle" };
 
 		[PaletteReference]

--- a/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
+++ b/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
@@ -20,6 +20,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Renders a sprite effect when leaving a cell.")]
 	public class LeavesTrailsInfo : ConditionalTraitInfo
 	{
+		[FieldLoader.Require]
 		public readonly string Image = null;
 
 		[SequenceReference("Image")]

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -74,12 +74,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public string GetImage(ActorInfo actor, SequenceProvider sequenceProvider, string faction)
 		{
-			if (FactionImages != null && !string.IsNullOrEmpty(faction))
-			{
-				string factionImage = null;
-				if (FactionImages.TryGetValue(faction, out factionImage) && sequenceProvider.HasSequence(factionImage))
-					return factionImage;
-			}
+			if (FactionImages != null && !string.IsNullOrEmpty(faction) && FactionImages.TryGetValue(faction, out var factionImage))
+				return factionImage.ToLowerInvariant();
 
 			return (Image ?? actor.Name).ToLowerInvariant();
 		}

--- a/OpenRA.Mods.Common/Traits/Render/VeteranProductionIconOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/VeteranProductionIconOverlay.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Image used for the overlay.")]
 		public readonly string Image = null;
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		[Desc("Sequence used for the overlay (cannot be animated).")]
 		public readonly string Sequence = null;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithAmmoPipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAmmoPipsDecoration.cs
@@ -27,11 +27,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Image that defines the pip sequences.")]
 		public readonly string Image = "pips";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		[Desc("Sequence used for empty pips.")]
 		public readonly string EmptySequence = "pip-empty";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		[Desc("Sequence used for full pips.")]
 		public readonly string FullSequence = "pip-green";
 

--- a/OpenRA.Mods.Common/Traits/Render/WithCargoPipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithCargoPipsDecoration.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence used for full pips that aren't defined in CustomPipSequences.")]
 		public readonly string FullSequence = "pip-green";
 
-		// TODO: [SequenceReference] isn't smart enough to use Dictionaries.
+		[SequenceReference("Image", dictionaryReference: LintDictionaryReference.Values)]
 		[Desc("Pip sequence to use for specific passenger actors.")]
 		public readonly Dictionary<string, string> CustomPipSequences = new Dictionary<string, string>();
 

--- a/OpenRA.Mods.Common/Traits/Render/WithCargoPipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithCargoPipsDecoration.cs
@@ -26,15 +26,15 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Image that defines the pip sequences.")]
 		public readonly string Image = "pips";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		[Desc("Sequence used for empty pips.")]
 		public readonly string EmptySequence = "pip-empty";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		[Desc("Sequence used for full pips that aren't defined in CustomPipSequences.")]
 		public readonly string FullSequence = "pip-green";
 
-		[SequenceReference("Image", dictionaryReference: LintDictionaryReference.Values)]
+		[SequenceReference(nameof(Image), dictionaryReference: LintDictionaryReference.Values)]
 		[Desc("Pip sequence to use for specific passenger actors.")]
 		public readonly Dictionary<string, string> CustomPipSequences = new Dictionary<string, string>();
 

--- a/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
@@ -20,13 +20,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 	{
 		public readonly string Image = "smoke_m";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		public readonly string IdleSequence = "idle";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		public readonly string LoopSequence = "loop";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		public readonly string EndSequence = "end";
 
 		[PaletteReference(nameof(IsPlayerPalette))]

--- a/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("This actor has a death animation.")]
 	public class WithDeathAnimationInfo : ConditionalTraitInfo, Requires<RenderSpritesInfo>
 	{
-		[SequenceReference(null, true)]
+		[SequenceReference(prefix: true)]
 		[Desc("Sequence prefix to play when this actor is killed by a warhead.")]
 		public readonly string DeathSequence = "die";
 

--- a/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly string Image = null;
 
 		[FieldLoader.Require]
-		[SequenceReference("Image", allowNullImage: true)]
+		[SequenceReference(nameof(Image), allowNullImage: true)]
 		[Desc("Sequence used for this decoration (can be animated).")]
 		public readonly string Sequence = null;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly string Image = null;
 
 		[FieldLoader.Require]
-		[SequenceReference("Image", false, true)]
+		[SequenceReference("Image", allowNullImage: true)]
 		[Desc("Sequence used for this decoration (can be animated).")]
 		public readonly string Sequence = null;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvesterPipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvesterPipsDecoration.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence used for full pips that aren't defined in ResourceSequences.")]
 		public readonly string FullSequence = "pip-green";
 
-		// TODO: [SequenceReference] isn't smart enough to use Dictionaries.
+		[SequenceReference("Image", dictionaryReference: LintDictionaryReference.Values)]
 		[Desc("Pip sequence to use for specific resource types.")]
 		public readonly Dictionary<string, string> ResourceSequences = new Dictionary<string, string>();
 

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvesterPipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvesterPipsDecoration.cs
@@ -27,15 +27,15 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Image that defines the pip sequences.")]
 		public readonly string Image = "pips";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		[Desc("Sequence used for empty pips.")]
 		public readonly string EmptySequence = "pip-empty";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		[Desc("Sequence used for full pips that aren't defined in ResourceSequences.")]
 		public readonly string FullSequence = "pip-green";
 
-		[SequenceReference("Image", dictionaryReference: LintDictionaryReference.Values)]
+		[SequenceReference(nameof(Image), dictionaryReference: LintDictionaryReference.Values)]
 		[Desc("Pip sequence to use for specific resource types.")]
 		public readonly Dictionary<string, string> ResourceSequences = new Dictionary<string, string>();
 

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -23,11 +23,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Image used for this decoration. Defaults to the actor's type.")]
 		public readonly string Image = null;
 
-		[SequenceReference("Image", false, true)]
+		[SequenceReference("Image", allowNullImage: true)]
 		[Desc("Animation to play when the actor is created.")]
 		public readonly string StartSequence = null;
 
-		[SequenceReference("Image", false, true)]
+		[SequenceReference("Image", allowNullImage: true)]
 		[Desc("Sequence name to use")]
 		public readonly string Sequence = "idle-overlay";
 

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				facing = () => f;
 			}
 
-			var anim = new Animation(init.World, image, facing);
+			var anim = new Animation(init.World, Image ?? image, facing);
 			anim.IsDecoration = IsDecoration;
 			anim.PlayRepeating(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence));
 

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -23,11 +23,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Image used for this decoration. Defaults to the actor's type.")]
 		public readonly string Image = null;
 
-		[SequenceReference("Image", allowNullImage: true)]
+		[SequenceReference(nameof(Image), allowNullImage: true)]
 		[Desc("Animation to play when the actor is created.")]
 		public readonly string StartSequence = null;
 
-		[SequenceReference("Image", allowNullImage: true)]
+		[SequenceReference(nameof(Image), allowNullImage: true)]
 		[Desc("Sequence name to use")]
 		public readonly string Sequence = "idle-overlay";
 

--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[SequenceReference]
 		public readonly string DefaultAttackSequence = null;
 
-		// TODO: [SequenceReference] isn't smart enough to use Dictionaries.
+		[SequenceReference(dictionaryReference: LintDictionaryReference.Values)]
 		[Desc("Attack sequence to use for each armament.")]
 		public readonly Dictionary<string, string> AttackSequences = new Dictionary<string, string>();
 

--- a/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
@@ -25,15 +25,15 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("The image that contains the parachute sequences.")]
 		public readonly string Image = null;
 
-		[SequenceReference("Image", allowNullImage: true)]
+		[SequenceReference(nameof(Image), allowNullImage: true)]
 		[Desc("Parachute opening sequence.")]
 		public readonly string OpeningSequence = null;
 
-		[SequenceReference("Image", allowNullImage: true)]
+		[SequenceReference(nameof(Image), allowNullImage: true)]
 		[Desc("Parachute idle sequence.")]
 		public readonly string Sequence = null;
 
-		[SequenceReference("Image", allowNullImage: true)]
+		[SequenceReference(nameof(Image), allowNullImage: true)]
 		[Desc("Parachute closing sequence. Defaults to opening sequence played backwards.")]
 		public readonly string ClosingSequence = null;
 
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("The image that contains the shadow sequence for the paradropped unit.")]
 		public readonly string ShadowImage = null;
 
-		[SequenceReference("ShadowImage", allowNullImage: true)]
+		[SequenceReference(nameof(ShadowImage), allowNullImage: true)]
 		[Desc("Paradropped unit's shadow sequence.")]
 		public readonly string ShadowSequence = null;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
@@ -25,15 +25,15 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("The image that contains the parachute sequences.")]
 		public readonly string Image = null;
 
-		[SequenceReference("Image")]
+		[SequenceReference("Image", allowNullImage: true)]
 		[Desc("Parachute opening sequence.")]
 		public readonly string OpeningSequence = null;
 
-		[SequenceReference("Image")]
+		[SequenceReference("Image", allowNullImage: true)]
 		[Desc("Parachute idle sequence.")]
 		public readonly string Sequence = null;
 
-		[SequenceReference("Image")]
+		[SequenceReference("Image", allowNullImage: true)]
 		[Desc("Parachute closing sequence. Defaults to opening sequence played backwards.")]
 		public readonly string ClosingSequence = null;
 
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("The image that contains the shadow sequence for the paradropped unit.")]
 		public readonly string ShadowImage = null;
 
-		[SequenceReference("ShadowImage")]
+		[SequenceReference("ShadowImage", allowNullImage: true)]
 		[Desc("Paradropped unit's shadow sequence.")]
 		public readonly string ShadowSequence = null;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Displays an overlay when the building is being repaired by the player.")]
 	public class WithRepairOverlayInfo : PausableConditionalTraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
-		[SequenceReference("Image")]
+		[SequenceReference]
 		[Desc("Sequence to use upon repair beginning.")]
 		public readonly string StartSequence = null;
 
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence name to play once during repair intervals or repeatedly if a start sequence is set.")]
 		public readonly string Sequence = "active";
 
-		[SequenceReference("Image")]
+		[SequenceReference]
 		[Desc("Sequence to use after repairing has finished.")]
 		public readonly string EndSequence = null;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithResourceStoragePipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResourceStoragePipsDecoration.cs
@@ -27,11 +27,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Image that defines the pip sequences.")]
 		public readonly string Image = "pips";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		[Desc("Sequence used for empty pips.")]
 		public readonly string EmptySequence = "pip-empty";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		[Desc("Sequence used for full pips.")]
 		public readonly string FullSequence = "pip-green";
 

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public readonly string Image = "pips";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		[Desc("Sprite sequence used to render the control group 0-9 numbers.")]
 		public readonly string GroupSequence = "groups";
 

--- a/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
+++ b/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly string Sprite = "smokey";
 
-		[SequenceReference("Sprite")]
+		[SequenceReference(nameof(Sprite))]
 		public readonly string Sequence = "idle";
 
 		public readonly string Palette = "effect";

--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -27,11 +27,11 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Delay (in ticks) after launch until the missile is spawned.")]
 		public readonly int MissileDelay = 0;
 
-		[SequenceReference("MissileWeapon")]
+		[SequenceReference(nameof(MissileWeapon))]
 		[Desc("Sprite sequence for the ascending missile.")]
 		public readonly string MissileUp = "up";
 
-		[SequenceReference("MissileWeapon")]
+		[SequenceReference(nameof(MissileWeapon))]
 		[Desc("Sprite sequence for the descending missile.")]
 		public readonly string MissileDown = "down";
 
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Trail animation.")]
 		public readonly string TrailImage = null;
 
-		[SequenceReference("TrailImage", allowNullImage: true)]
+		[SequenceReference(nameof(TrailImage), allowNullImage: true)]
 		[Desc("Loop a randomly chosen sequence of TrailImage from this list while this projectile is moving.")]
 		public readonly string[] TrailSequences = { };
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Trail animation.")]
 		public readonly string TrailImage = null;
 
-		[SequenceReference("TrailImage")]
+		[SequenceReference("TrailImage", allowNullImage: true)]
 		[Desc("Loop a randomly chosen sequence of TrailImage from this list while this projectile is moving.")]
 		public readonly string[] TrailSequences = { };
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SpawnActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SpawnActorPower.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly string EffectImage = null;
 
-		[SequenceReference("EffectImage")]
+		[SequenceReference(nameof(EffectImage))]
 		public readonly string EffectSequence = null;
 
 		[PaletteReference]

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly string IconImage = "icon";
 
-		[SequenceReference("IconImage")]
+		[SequenceReference(nameof(IconImage))]
 		[Desc("Icon sprite displayed in the support power palette.")]
 		public readonly string Icon = null;
 
@@ -89,22 +89,22 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly string BeaconImage = "beacon";
 
-		[SequenceReference("BeaconImage")]
+		[SequenceReference(nameof(BeaconImage))]
 		public readonly string BeaconPoster = null;
 
 		[PaletteReference]
 		public readonly string BeaconPosterPalette = "chrome";
 
-		[SequenceReference("BeaconImage")]
+		[SequenceReference(nameof(BeaconImage))]
 		public readonly string ClockSequence = null;
 
-		[SequenceReference("BeaconImage")]
+		[SequenceReference(nameof(BeaconImage))]
 		public readonly string BeaconSequence = null;
 
-		[SequenceReference("BeaconImage")]
+		[SequenceReference(nameof(BeaconImage))]
 		public readonly string ArrowSequence = null;
 
-		[SequenceReference("BeaconImage")]
+		[SequenceReference(nameof(BeaconImage))]
 		public readonly string CircleSequence = null;
 
 		[Desc("Delay after launch, measured in ticks.")]

--- a/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
@@ -25,11 +25,11 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sequence image where the selection overlay types are defined.")]
 		public readonly string Image = "editor-overlay";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		[Desc("Sequence to use for the copy overlay.")]
 		public readonly string CopySequence = "copy";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		[Desc("Sequence to use for the paste overlay.")]
 		public readonly string PasteSequence = "paste";
 

--- a/OpenRA.Mods.Common/Traits/World/ResourceType.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceType.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Image = "resources";
 
 		[FieldLoader.Require]
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		[Desc("Randomly chosen image sequences.")]
 		public readonly string[] Sequences = { };
 

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -21,10 +21,10 @@ namespace OpenRA.Mods.Common.Traits
 	public class ShroudRendererInfo : TraitInfo
 	{
 		public readonly string Sequence = "shroud";
-		[SequenceReference("Sequence")]
+		[SequenceReference(nameof(Sequence))]
 		public readonly string[] ShroudVariants = { "shroud" };
 
-		[SequenceReference("Sequence")]
+		[SequenceReference(nameof(Sequence))]
 		public readonly string[] FogVariants = { "fog" };
 
 		[PaletteReference]
@@ -40,13 +40,13 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Use the upper four bits when calculating frame")]
 		public readonly bool UseExtendedIndex = false;
 
-		[SequenceReference("Sequence")]
+		[SequenceReference(nameof(Sequence))]
 		[Desc("Override for source art that doesn't define a fully shrouded tile")]
 		public readonly string OverrideFullShroud = null;
 
 		public readonly int OverrideShroudIndex = 15;
 
-		[SequenceReference("Sequence")]
+		[SequenceReference(nameof(Sequence))]
 		[Desc("Override for source art that doesn't define a fully fogged tile")]
 		public readonly string OverrideFullFog = null;
 

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sprite sequence name")]
 		public readonly string SmokeType = "smoke_m";
 
-		[SequenceReference("SmokeType")]
+		[SequenceReference(nameof(SmokeType))]
 		public readonly string SmokeSequence = "idle";
 
 		[PaletteReference]

--- a/OpenRA.Mods.Common/UtilityCommands/CheckMissingSprites.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckMissingSprites.cs
@@ -10,28 +10,49 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
+using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class CheckSequenceSprites : IUtilityCommand
+	class CheckMissingSprites : IUtilityCommand
 	{
-		string IUtilityCommand.Name { get { return "--check-sequence-sprites"; } }
+		string IUtilityCommand.Name { get { return "--check-missing-sprites"; } }
 
 		bool IUtilityCommand.ValidateArguments(string[] args)
 		{
 			return true;
 		}
 
-		[Desc("Check the sequence definitions for missing sprite files.")]
+		[Desc("Check tileset and sequence definitions for missing sprite files.")]
 		void IUtilityCommand.Run(Utility utility, string[] args)
 		{
 			// HACK: The engine code assumes that Game.modData is set.
 			var modData = Game.ModData = utility.ModData;
 			var failed = false;
+
+			// DefaultSequences is a dictionary of tileset: SequenceProvider
+			// so we can also use this to key our tileset checks
 			foreach (var kv in modData.DefaultSequences)
 			{
 				Console.WriteLine("Tileset: " + kv.Key);
+				var tileset = modData.DefaultTileSets[kv.Key];
+				var missingImages = new HashSet<string>();
+				Action<uint, string> onMissingImage = (id, f) =>
+				{
+					Console.WriteLine("\tTemplate `{0}` references sprite `{1}` that does not exist.", id, f);
+					missingImages.Add(f);
+				};
+
+				var theater = new Theater(tileset, onMissingImage);
+				foreach (var t in tileset.Templates)
+					for (var v = 0; v < t.Value.Images.Length; v++)
+						if (!missingImages.Contains(t.Value.Images[v]))
+							for (var i = 0; i < t.Value.TilesCount; i++)
+								if (t.Value[i] != null && !theater.HasTileSprite(new TerrainTile(t.Key, (byte)i), v))
+									Console.WriteLine("\tTemplate `{0}` references frame {1} that does not exist in sprite `{2}`.", t.Key, i, t.Value.Images[v]);
+
 				foreach (var image in kv.Value.Images)
 				{
 					foreach (var sequence in kv.Value.Sequences(image))

--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -134,7 +134,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				try
 				{
 					var customRulesPass = (ILintRulesPass)modData.ObjectCreator.CreateBasic(customRulesPassType);
-					customRulesPass.Run(EmitError, EmitWarning, rules);
+					customRulesPass.Run(EmitError, EmitWarning, modData, rules);
 				}
 				catch (Exception e)
 				{

--- a/OpenRA.Mods.Common/UtilityCommands/LintInterfaces.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/LintInterfaces.cs
@@ -15,5 +15,5 @@ namespace OpenRA.Mods.Common.Lint
 {
 	public interface ILintPass { void Run(Action<string> emitError, Action<string> emitWarning, ModData modData); }
 	public interface ILintMapPass { void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map); }
-	public interface ILintRulesPass { void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules); }
+	public interface ILintRulesPass { void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules); }
 }

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Warheads
 {
 	public class CreateEffectWarhead : Warhead
 	{
-		[SequenceReference("Image")]
+		[SequenceReference("Image", allowNullImage: true)]
 		[Desc("List of explosion sequences that can be used.")]
 		public readonly string[] Explosions = new string[0];
 

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Warheads
 {
 	public class CreateEffectWarhead : Warhead
 	{
-		[SequenceReference("Image", allowNullImage: true)]
+		[SequenceReference(nameof(Image), allowNullImage: true)]
 		[Desc("List of explosion sequences that can be used.")]
 		public readonly string[] Explosions = new string[0];
 

--- a/OpenRA.Mods.D2k/Lint/CheckImportActors.cs
+++ b/OpenRA.Mods.D2k/Lint/CheckImportActors.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.D2k.Lint
 {
 	public class CheckImportActors : ILintRulesPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
 			foreach (var actorData in D2kMapImporter.ActorDataByActorCode.Values)
 			{


### PR DESCRIPTION
This PR started with the goal of adding linter support for reference attributes on dictionaries before scope-creeping into a general rework of the `[SequenceReference]` code. This should make the sequence linter more accurate, and a lot easier to understand.

Fixes #6975.
Fixes #12753.
Fixes #16095.
Fixes #17596.
Fixes #18516.
Supersedes #7817.
Supersedes #17597.