### PR TITLE
New TD Money Setting (7500)

### DIFF
--- a/mods/cnc/rules/player.yaml
+++ b/mods/cnc/rules/player.yaml
@@ -24,6 +24,8 @@ Player:
 	PlayerResources:
 		CashTickUpNotification: CashTickUp
 		CashTickDownNotification: CashTickDown
+		SelectableCash: 2500, 5000, 7500, 10000, 20000
+		DefaultCash: 7500
 	DeveloperMode:
 		CheckboxDisplayOrder: 8
 	BaseAttackNotifier:

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -244,7 +244,6 @@ World:
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e1,e1,e2,e2,e2,e3,e3,apc,mtnk
 	SpawnMPUnits:
-		StartingUnitsClass: light
 		DropdownDisplayOrder: 0
 	CrateSpawner:
 		Minimum: 1


### PR DESCRIPTION
I've been looking into adjusting the early economy of TD, as there is a hard stall a few minutes in where you can't build anything but vehicles. This makes the game incredibly cut throat early on, as any expenditure will delay starting structure production again. Building a defense (rax + the defense itself) sets you majorly behind, so often that's skipped entirely, meaning you're at the mercy of your opponent if they get ahead in army supply.

The most straightforward solution is actually just to increase the starting cash. At 7500 this allows you to comfortably afford a rax + defense, and a few scouting rifles. Additionally you don't need to pause structure production unless you do a really aggressive opener. 

10k proved to be too much in testing, which is why I've added 7.5k. I've left the 5k setting in for people who want to play with the old setting.

As part of the PR I also made 7.5k the default cash setting, and MCV only the default setting (light support has fallen out of favor).

Part of my balance efforts: #18273, #18427