### PR TITLE
Use nameof() in PaletteReference.

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Render/WithDockingOverlay.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithDockingOverlay.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Custom palette name")]
 		public readonly string Palette = null;
 

--- a/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeOverlay.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeOverlay.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		[Desc("Sequence name to use")]
 		public readonly string Sequence = "active";
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Custom palette name")]
 		public readonly string Palette = null;
 

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/GpsPower.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[SequenceReference("DoorImage")]
 		public readonly string DoorSequence = "active";
 
-		[PaletteReference("DoorPaletteIsPlayerPalette")]
+		[PaletteReference(nameof(DoorPaletteIsPlayerPalette))]
 		[Desc("Palette to use for rendering the launch animation")]
 		public readonly string DoorPalette = "player";
 
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[SequenceReference("SatelliteImage")]
 		public readonly string SatelliteSequence = "idle";
 
-		[PaletteReference("SatellitePaletteIsPlayerPalette")]
+		[PaletteReference(nameof(SatellitePaletteIsPlayerPalette))]
 		[Desc("Palette to use for rendering the satellite projectile")]
 		public readonly string SatellitePalette = "player";
 

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Loop a randomly chosen sequence of Image from this list while this projectile is moving.")]
 		public readonly string[] Sequences = { "idle" };
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("The palette used to draw this projectile.")]
 		public readonly string Palette = "effect";
 
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Delay in ticks until trail animation is spawned.")]
 		public readonly int TrailDelay = 1;
 
-		[PaletteReference("TrailUsePlayerPalette")]
+		[PaletteReference(nameof(TrailUsePlayerPalette))]
 		[Desc("Palette used to render the trail sequence.")]
 		public readonly string TrailPalette = "effect";
 

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Loop a randomly chosen sequence of Image from this list while this projectile is moving.")]
 		public readonly string[] Sequences = { "idle" };
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Palette used to render the projectile sequence.")]
 		public readonly string Palette = "effect";
 
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Loop a randomly chosen sequence of TrailImage from this list while this projectile is moving.")]
 		public readonly string[] TrailSequences = { "idle" };
 
-		[PaletteReference("TrailUsePlayerPalette")]
+		[PaletteReference(nameof(TrailUsePlayerPalette))]
 		[Desc("Palette used to render the trail sequence.")]
 		public readonly string TrailPalette = "effect";
 

--- a/OpenRA.Mods.Common/Traits/Buildable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildable.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sequence of the actor that contains the icon.")]
 		public readonly string Icon = "icon";
 
-		[PaletteReference("IconPaletteIsPlayerPalette")]
+		[PaletteReference(nameof(IconPaletteIsPlayerPalette))]
 		[Desc("Palette used for the production icon.")]
 		public readonly string IconPalette = "chrome";
 

--- a/OpenRA.Mods.Common/Traits/Buildings/ActorPreviewPlaceBuildingPreview.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ActorPreviewPlaceBuildingPreview.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Enable the building's idle animation.")]
 		public readonly bool Animated = true;
 
-		[PaletteReference("OverridePaletteIsPlayerPalette")]
+		[PaletteReference(nameof(OverridePaletteIsPlayerPalette))]
 		[Desc("Custom palette name.")]
 		public readonly string OverridePalette = null;
 

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Cursor to display when rally point can be set.")]
 		public readonly string Cursor = "ability";
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Custom indicator palette name")]
 		public readonly string Palette = "player";
 

--- a/OpenRA.Mods.Common/Traits/Buildings/SequencePlaceBuildingPreview.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/SequencePlaceBuildingPreview.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sequence name to use.")]
 		public readonly string Sequence = "idle";
 
-		[PaletteReference("SequencePaletteIsPlayerPalette")]
+		[PaletteReference(nameof(SequencePaletteIsPlayerPalette))]
 		[Desc("Custom palette name.")]
 		public readonly string SequencePalette = null;
 

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string CloakSound = null;
 		public readonly string UncloakSound = null;
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		public readonly string Palette = "cloak";
 		public readonly bool IsPlayerPalette = false;
 

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly bool IsPlayerPalette = true;
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		public readonly string Palette = "player";
 
 		public readonly string BeaconImage = "beacon";

--- a/OpenRA.Mods.Common/Traits/Render/WithAttackOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAttackOverlay.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence name to use")]
 		public readonly string Sequence = null;
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Custom palette name")]
 		public readonly string Palette = null;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Custom palette name")]
 		public readonly string Palette = null;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithChargeOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithChargeOverlay.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence to use for the charge levels.")]
 		public readonly string Sequence = "active";
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Custom palette name")]
 		public readonly string Palette = null;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[SequenceReference("Image")]
 		public readonly string EndSequence = "end";
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Custom palette name.")]
 		public readonly string Palette = null;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence prefix to play when this actor is killed by a warhead.")]
 		public readonly string DeathSequence = "die";
 
-		[PaletteReference("DeathPaletteIsPlayerPalette")]
+		[PaletteReference(nameof(DeathPaletteIsPlayerPalette))]
 		[Desc("The palette used for `DeathSequence`.")]
 		public readonly string DeathSequencePalette = "player";
 
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence to play when this actor is crushed.")]
 		public readonly string CrushedSequence = null;
 
-		[PaletteReference("CrushedPaletteIsPlayerPalette")]
+		[PaletteReference(nameof(CrushedPaletteIsPlayerPalette))]
 		[Desc("The palette used for `CrushedSequence`.")]
 		public readonly string CrushedSequencePalette = "effect";
 

--- a/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence used for this decoration (can be animated).")]
 		public readonly string Sequence = null;
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Palette to render the sprite in. Reference the world actor's PaletteFrom* traits.")]
 		public readonly string Palette = "chrome";
 

--- a/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Custom palette name")]
 		public readonly string Palette = null;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Custom palette name")]
 		public readonly string Palette = null;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[SequenceReference]
 		public readonly string[] StandSequences = { "stand" };
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Custom palette name")]
 		public readonly string Palette = null;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Parachute closing sequence. Defaults to opening sequence played backwards.")]
 		public readonly string ClosingSequence = null;
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Palette used to render the parachute.")]
 		public readonly string Palette = "player";
 

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Custom palette name")]
 		public readonly string Palette = null;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Custom palette name")]
 		public readonly string Palette = null;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithResourceLevelOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResourceLevelOverlay.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence name to use")]
 		public readonly string Sequence = "resources";
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Custom palette name.")]
 		public readonly string Palette = null;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence name to use")]
 		public readonly string Sequence = "turret";
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Custom palette name")]
 		public readonly string Palette = null;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithSupportPowerActivationOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSupportPowerActivationOverlay.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Custom palette name")]
 		public readonly string Palette = null;
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 			"'False' will make the missile continue until it hits the ground and disappears (without triggering another explosion).")]
 		public readonly bool RemoveMissileOnDetonation = true;
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Palette to use for the missile weapon image.")]
 		public readonly string MissilePalette = "effect";
 
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Delay in ticks until trail animation is spawned.")]
 		public readonly int TrailDelay = 1;
 
-		[PaletteReference("TrailUsePlayerPalette")]
+		[PaletteReference(nameof(TrailUsePlayerPalette))]
 		[Desc("Palette used to render the trail sequence.")]
 		public readonly string TrailPalette = "effect";
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly bool BeaconPaletteIsPlayerPalette = true;
 
-		[PaletteReference("BeaconPaletteIsPlayerPalette")]
+		[PaletteReference(nameof(BeaconPaletteIsPlayerPalette))]
 		public readonly string BeaconPalette = "player";
 
 		public readonly string BeaconImage = "beacon";

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("Image containing explosion effect sequence.")]
 		public readonly string Image = "explosion";
 
-		[PaletteReference("UsePlayerPalette")]
+		[PaletteReference(nameof(UsePlayerPalette))]
 		[Desc("Palette to use for explosion effect.")]
 		public readonly string ExplosionPalette = "effect";
 

--- a/OpenRA.Mods.D2k/Traits/Render/WithCrumbleOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithCrumbleOverlay.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.D2k.Traits.Render
 		[Desc("Sequence name to use")]
 		public readonly string Sequence = "crumble-overlay";
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Custom palette name")]
 		public readonly string Palette = null;
 

--- a/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.D2k.Traits.Render
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		[PaletteReference("IsPlayerPalette")]
+		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Custom palette name")]
 		public readonly string Palette = null;
 


### PR DESCRIPTION
Followup to #18485 to add compiler-backed guarantees that these fields actually exist.