### PR TITLE
Apply Firestorm alike logic for support power

### DIFF
--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantSelfConditionPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantSelfConditionPower.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits.SupportPowers
+{
+	class GrantSelfConditionPowerInfo : SupportPowerInfo
+	{
+		[FieldLoader.Require]
+		[GrantedConditionReference]
+		[Desc("The condition type to grant when actived.")]
+		public readonly string Condition = null;
+
+		public override object Create(ActorInitializer init) { return new GrantSelfConditionPower(init.Self, this); }
+	}
+
+	class GrantSelfConditionPower : SupportPower
+	{
+		readonly GrantSelfConditionPowerInfo info;
+		int conditionToken = Actor.InvalidConditionToken;
+
+		public GrantSelfConditionPower(Actor self, GrantSelfConditionPowerInfo info)
+			: base(self, info)
+		{
+			this.info = info;
+		}
+
+		public override void SelectTarget(Actor self, string order, SupportPowerManager manager)
+		{
+			self.World.IssueOrder(new Order(order, manager.Self, false));
+		}
+
+		public override void Activate(Actor self, Order order, SupportPowerManager manager)
+		{
+			base.Activate(self, order, manager);
+			PlayLaunchSounds();
+			if (conditionToken == Actor.InvalidConditionToken)
+				conditionToken = self.GrantCondition(info.Condition);
+		}
+
+		public override void Deactivate(Actor self, Order order, SupportPowerManager manager)
+		{
+			if (conditionToken != Actor.InvalidConditionToken)
+				conditionToken = self.RevokeCondition(conditionToken);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
@@ -120,6 +120,18 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sort order for the support power palette. Smaller numbers are presented earlier.")]
 		public readonly int SupportPowerPaletteOrder = 9999;
 
+		/* Those is for support power like Firestorm in TS,
+		 * Which superweapon can be charge and shortly relase and recharge */
+		[Desc("If it is going to be actived, it must be fully charged")]
+		public readonly bool IsSteamValveLogic = false;
+
+		[Desc("Discharging time before it is all over. Measured in ticks. Requires true in `IsSteamValveLogic` above.")]
+		public readonly int DisChargeInterval = 0;
+
+		[Desc("If it is going to be actived, it must be charged to this percentage. Requires true in `IsSteamValveLogic` above.")]
+		public readonly int ChargingPercentageBeforeActivation = 100;
+		/* I mean those surrounded by these comment block */
+
 		public SupportPowerInfo() { OrderName = GetType().Name + "Order"; }
 	}
 
@@ -180,6 +192,9 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var notify in self.TraitsImplementing<INotifySupportPower>())
 				notify.Activated(self);
 		}
+
+		// Designed for `IsSteamValveLogic = ture`.
+		public virtual void Deactivate(Actor self, Order order, SupportPowerManager manager) { }
 
 		public virtual void PlayLaunchSounds()
 		{

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -640,3 +640,53 @@ GAPLUG4:
 		Type: plug.droppod
 	Power:
 		Amount: -20
+
+GAFIRE:
+	Inherits: ^Building
+	Inherits@2: ^3x2Shape
+	Inherits@IDISABLE: ^DisableOnLowPowerOrPowerDown
+	Buildable:
+		Queue: Building
+		BuildPaletteOrder: 190
+		Description: Firestorm Generator
+		Prerequisites: gatech, ~structures.gdi
+	Valued:
+		Cost: 1500
+	Tooltip:
+		Name: Firestorm Generator
+	Building:
+		Footprint: xxx xxx
+		Dimensions: 3,2
+	RevealsShroud:
+		Range: 6c0
+		MaxHeightDelta: 3
+	WithRangeCircle:
+		Range: 12c0
+		Type: cloakgenerator
+	Health:
+		HP: 150000
+	WithIdleOverlay@1:
+		Sequence: idle1
+		RequiresCondition: !Building-Buildup
+	WithIdleOverlay@2:
+		Sequence: idle2
+		RequiresCondition: !Building-Buildup
+	Power:
+		Amount: -100
+	ProvidesPrerequisite@buildingname:
+	RequiresBuildableArea:
+		AreaTypes: building
+	GrantSelfConditionPower:
+		PauseOnCondition: disabled || empdisable
+		Condition: actived
+		Description: Firestorm
+		LongDesc: Firestorm Defence System
+		Icon: firestorm
+		ChargeInterval: 500
+		IsSteamValveLogic: true
+		DisChargeInterval: 250
+		ChargingPercentageBeforeActivation: 100
+	##### used for test paused conditon ##
+	Power@Actived:
+		RequiresCondition: actived
+		Amount: -100

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -455,6 +455,7 @@ icon:
 	hunterseeker: detnicon
 	emp: pulsicon
 	droppods: podsicon
+	firestorm: fstdicon
 
 clustermissile:
 	up: mltimisl-placeholder # TODO: use voxel

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -2025,3 +2025,40 @@ gaplug4:
 		Length: 14
 		Tick: 120
 	icon: rad1icon
+
+gafire:
+	Defaults:
+		Offset: -12, -30, 30
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+	damaged-idle:
+		Start: 1
+		ShadowStart: 4
+	dead:
+		Start: 2
+		ShadowStart: 5
+		Tick: 400
+	idle1: gtfire_b
+		Length: 16
+	damaged-idle1: gtfire_b
+		Length: 16
+	idle2: gtfire_c
+		Length: 6
+		Tick: 200
+	damaged-idle2: gtfire_c
+		Length: 6
+		Tick: 240
+	make: gtfiremk
+		Length: 15
+		ShadowStart: 17
+	emp-overlay: emp_fx01
+		Length: *
+		Offset: 0, 0
+		UseTilesetCode: false
+		ZOffset: 512
+		BlendMode: Additive
+	icon: fsdicon
+		Offset: 0, 0
+		UseTilesetCode: false
+


### PR DESCRIPTION
In this branch I don't completely remake the GDI Firestorm, but apply the logic in engine it needs.

I make "GFIRE" which is original Firestorm Generator asset as a test actor for this logic, beware it is just a test actor: if you turn the Firestorm on, it just simply consume more power before charging run out.

Suggested test case:
<img width="267" alt="testcase" src="https://user-images.githubusercontent.com/13763394/90314340-9c863500-df45-11ea-8987-3b69726d3492.PNG">

The changing in the `SupportPowerManager`, `SupportPower` as well as the newly added `GrantSelfConditionPower` may still have bug, the name of var may be weird.
