### PR TITLE
Hide TraitInfo.InstanceName from FieldLoader.

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -329,6 +329,7 @@ namespace OpenRA.Traits
 	public abstract class TraitInfo : ITraitInfoInterface
 	{
 		// Value is set using reflection during TraitInfo creation
+		[FieldLoader.Ignore]
 		public readonly string InstanceName = null;
 
 		public abstract object Create(ActorInitializer init);


### PR DESCRIPTION
This prevents InstanceName from being listed on every trait in the utility `--docs` output.