### PR TITLE
Cache some values in production widgets

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.Widgets
 		readonly WorldRenderer worldRenderer;
 
 		SpriteFont overlayFont, symbolFont;
-		float2 holdOffset, readyOffset, timeOffset, queuedOffset, infiniteOffset;
+		float2 iconOffset, holdOffset, readyOffset, timeOffset, queuedOffset, infiniteOffset;
 
 		[CustomLintableHotkeyNames]
 		public static IEnumerable<string> LinterHotkeyNames(MiniYamlNode widgetNode, Action<string> emitError, Action<string> emitWarning)
@@ -162,6 +162,16 @@ namespace OpenRA.Mods.Common.Widgets
 
 			overlayFont = Game.Renderer.Fonts[OverlayFont];
 			Game.Renderer.Fonts.TryGetValue(SymbolsFont, out symbolFont);
+
+			iconOffset = 0.5f * IconSize.ToFloat2() + IconSpriteOffset;
+			queuedOffset = new float2(4, 2);
+			holdOffset = iconOffset - overlayFont.Measure(HoldText) / 2;
+			readyOffset = iconOffset - overlayFont.Measure(ReadyText) / 2;
+
+			if (ChromeMetrics.TryGet("InfiniteOffset", out infiniteOffset))
+				infiniteOffset += queuedOffset;
+			else
+				infiniteOffset = queuedOffset;
 		}
 
 		public void ScrollDown()
@@ -464,17 +474,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override void Draw()
 		{
-			var iconOffset = 0.5f * IconSize.ToFloat2() + IconSpriteOffset;
-
 			timeOffset = iconOffset - overlayFont.Measure(WidgetUtils.FormatTime(0, World.Timestep)) / 2;
-			queuedOffset = new float2(4, 2);
-			holdOffset = iconOffset - overlayFont.Measure(HoldText) / 2;
-			readyOffset = iconOffset - overlayFont.Measure(ReadyText) / 2;
-
-			if (ChromeMetrics.TryGet("InfiniteOffset", out infiniteOffset))
-				infiniteOffset += queuedOffset;
-			else
-				infiniteOffset = queuedOffset;
 
 			if (CurrentQueue == null)
 				return;

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -101,8 +101,18 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public ProductionQueue CurrentQueue
 		{
-			get { return currentQueue; }
-			set { currentQueue = value; RefreshIcons(); }
+			get
+			{
+				return currentQueue;
+			}
+			set
+			{
+				currentQueue = value;
+				if (currentQueue != null)
+					UpdateCachedProductionIconOverlays();
+
+				RefreshIcons();
+			}
 		}
 
 		public override Rectangle EventBounds { get { return eventBounds; } }
@@ -114,6 +124,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 		SpriteFont overlayFont, symbolFont;
 		float2 iconOffset, holdOffset, readyOffset, timeOffset, queuedOffset, infiniteOffset;
+
+		Player cachedQueueOwner;
+		IProductionIconOverlay[] pios;
 
 		[CustomLintableHotkeyNames]
 		public static IEnumerable<string> LinterHotkeyNames(MiniYamlNode widgetNode, Action<string> emitError, Action<string> emitWarning)
@@ -225,7 +238,12 @@ namespace OpenRA.Mods.Common.Widgets
 				CurrentQueue = null;
 
 			if (CurrentQueue != null)
+			{
+				if (CurrentQueue.Actor.Owner != cachedQueueOwner)
+					UpdateCachedProductionIconOverlays();
+
 				RefreshIcons();
+			}
 		}
 
 		public override void MouseEntered()
@@ -414,6 +432,12 @@ namespace OpenRA.Mods.Common.Widgets
 			return true;
 		}
 
+		void UpdateCachedProductionIconOverlays()
+		{
+			cachedQueueOwner = CurrentQueue.Actor.Owner;
+			pios = cachedQueueOwner.PlayerActor.TraitsImplementing<IProductionIconOverlay>().ToArray();
+		}
+
 		public void RefreshIcons()
 		{
 			icons = new Dictionary<Rectangle, ProductionIcon>();
@@ -480,8 +504,6 @@ namespace OpenRA.Mods.Common.Widgets
 				return;
 
 			var buildableItems = CurrentQueue.BuildableItems();
-
-			var pios = currentQueue.Actor.Owner.PlayerActor.TraitsImplementing<IProductionIconOverlay>();
 
 			// Icons
 			Game.Renderer.EnableAntialiasingFilter();

--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -91,6 +91,7 @@ namespace OpenRA.Mods.Common.Widgets
 		float listOffset = 0;
 		bool leftPressed = false;
 		bool rightPressed = false;
+		SpriteFont font;
 		Rectangle leftButtonRect;
 		Rectangle rightButtonRect;
 		Lazy<ProductionPaletteWidget> paletteWidget;
@@ -108,6 +109,16 @@ namespace OpenRA.Mods.Common.Widgets
 			IsVisible = () => queueGroup != null && Groups[queueGroup].Tabs.Count > 0;
 
 			paletteWidget = Exts.Lazy(() => Ui.Root.Get<ProductionPaletteWidget>(PaletteWidget));
+		}
+
+		public override void Initialize(WidgetArgs args)
+		{
+			base.Initialize(args);
+
+			var rb = RenderBounds;
+			leftButtonRect = new Rectangle(rb.X, rb.Y, ArrowWidth, rb.Height);
+			rightButtonRect = new Rectangle(rb.Right - ArrowWidth, rb.Y, ArrowWidth, rb.Height);
+			font = Game.Renderer.Fonts["TinyBold"];
 		}
 
 		public bool SelectNextTab(bool reverse)
@@ -173,8 +184,6 @@ namespace OpenRA.Mods.Common.Widgets
 				return;
 
 			var rb = RenderBounds;
-			leftButtonRect = new Rectangle(rb.X, rb.Y, ArrowWidth, rb.Height);
-			rightButtonRect = new Rectangle(rb.Right - ArrowWidth, rb.Y, ArrowWidth, rb.Height);
 
 			var leftDisabled = listOffset >= 0;
 			var leftHover = Ui.MouseOverWidget == this && leftButtonRect.Contains(Viewport.LastMousePos);
@@ -198,7 +207,6 @@ namespace OpenRA.Mods.Common.Widgets
 			// Draw tab buttons
 			Game.Renderer.EnableScissor(new Rectangle(leftButtonRect.Right, rb.Y + 1, rightButtonRect.Left - leftButtonRect.Right - 1, rb.Height));
 			var origin = new int2(leftButtonRect.Right - 1 + (int)listOffset, leftButtonRect.Y);
-			var font = Game.Renderer.Fonts["TinyBold"];
 			contentWidth = 0;
 
 			foreach (var tab in tabs)


### PR DESCRIPTION
This was originally mostly about not looking up the icon overlay trait(s) every Draw() call, but while I was at it, I also cached some other stuff that never changes at widget initialization.