### PR TITLE
Fixed Map UID mismatch between Linux/Windows filesystems and .zip files

### DIFF
--- a/OpenRA.Game/FileSystem/Folder.cs
+++ b/OpenRA.Game/FileSystem/Folder.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace OpenRA.FileSystem
 {
@@ -32,10 +33,11 @@ namespace OpenRA.FileSystem
 		{
 			get
 			{
-				foreach (var filename in Directory.GetFiles(path, "*", SearchOption.TopDirectoryOnly))
-					yield return Path.GetFileName(filename);
-				foreach (var filename in Directory.GetDirectories(path))
-					yield return Path.GetFileName(filename);
+				// Order may vary on different file systems and it matters for hashing.
+				return Directory.GetFiles(path, "*", SearchOption.TopDirectoryOnly)
+					.Concat(Directory.GetDirectories(path))
+					.Select(Path.GetFileName)
+					.OrderBy(f => f);
 			}
 		}
 


### PR DESCRIPTION
This is a proposed fix for https://github.com/OpenRA/OpenRAModSDK/issues/162. The bug is also reproducible without the SDK. Might also close https://github.com/OpenRA/OpenRA/issues/16053.