### PR TITLE
Fixed Mono slowing down the build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@
 # see travis-ci.org for details
 
 language: csharp
-mono: 6.4.0
+mono: none
+dotnet: 2.2.207
 
 jobs:
   include:
@@ -23,6 +24,8 @@ addons:
     - dpkg
     - zsync
     - markdown
+    - mono-runtime
+    - libmono-*-cil
 
 # Environment variables
 env:

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ INSTALL_DATA = $(INSTALL) -m644
 
 # Toolchain
 MSBUILD = msbuild -verbosity:m -nologo
+DOTNET = dotnet
 
 # Enable 32 bit builds while generating the windows installer
 WIN32 = false
@@ -107,7 +108,7 @@ check-scripts:
 check:
 	@echo
 	@echo "Compiling in debug mode..."
-	@$(MSBUILD) -t:build -p:Configuration=Debug
+	@$(DOTNET) build -c Debug -p:TargetPlatform=$(TARGETPLATFORM)
 	@echo
 	@echo "Checking runtime assemblies..."
 	@mono --debug OpenRA.Utility.exe all --check-runtime-assemblies $(WHITELISTED_OPENRA_ASSEMBLIES) $(WHITELISTED_THIRDPARTY_ASSEMBLIES) $(WHITELISTED_CORE_ASSEMBLIES)
@@ -137,8 +138,8 @@ test: core
 all: core
 
 core:
-	@command -v $(firstword $(MSBUILD)) >/dev/null || (echo "OpenRA requires the '$(MSBUILD)' tool provided by Mono >= 5.18."; exit 1)
-	@$(MSBUILD) -t:Build -restore -p:Configuration=Release -p:TargetPlatform=$(TARGETPLATFORM)
+	@$(DOTNET) build -c Release -p:TargetPlatform=$(TARGETPLATFORM)
+
 ifeq ($(TARGETPLATFORM), unix-generic)
 	@./configure-system-libraries.sh
 endif
@@ -148,7 +149,7 @@ clean:
 	@-$(RM_F) *.config IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP
 	@-$(RM_F) *.exe *.dll *.dll.config *.so *.dylib ./OpenRA*/*.dll *.pdb mods/**/*.dll mods/**/*.pdb *.resources
 	@-$(RM_RF) ./*/bin ./*/obj
-	@ $(MSBUILD) -t:clean
+	@$(DOTNET) clean
 
 version: VERSION mods/ra/mod.yaml mods/cnc/mod.yaml mods/d2k/mod.yaml mods/ts/mod.yaml mods/modcontent/mod.yaml mods/all/mod.yaml
 	@echo "$(VERSION)" > VERSION


### PR DESCRIPTION
This is just an experiment. We are already using the .NET reference assemblies so this might just work?