### PR TITLE
Add sprite loaders for C&C Remastered Collection

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -191,6 +191,9 @@ distributed under MIT License.
 
 Using ANGLE distributed under the BS3 3-Clause license.
 
+Using Pfim developed by Nick Babcock
+distributed under the MIT license.
+
 This site or product includes IP2Location LITE data
 available from http://www.ip2location.com.
 

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpRemasteredLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpRemasteredLoader.cs
@@ -1,0 +1,117 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using ICSharpCode.SharpZipLib.Zip;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.SpriteLoaders;
+using OpenRA.Primitives;
+
+namespace OpenRA.Mods.Cnc.SpriteLoaders
+{
+	public class ShpRemasteredLoader : ISpriteLoader
+	{
+		public static bool IsShpRemastered(Stream s)
+		{
+			var start = s.Position;
+			var isZipFile = s.ReadUInt32() == 0x04034B50;
+			s.Position = start;
+
+			return isZipFile;
+		}
+
+		public bool TryParseSprite(Stream s, out ISpriteFrame[] frames, out TypeDictionary metadata)
+		{
+			metadata = null;
+			if (!IsShpRemastered(s))
+			{
+				frames = null;
+				return false;
+			}
+
+			frames = new ShpRemasteredSprite(s).Frames.ToArray();
+			return true;
+		}
+	}
+
+	public class ShpRemasteredSprite
+	{
+		static readonly Regex FilenameRegex = new Regex(@"^(?<prefix>.+?[\-_])(?<frame>\d{4})\.tga$");
+		static readonly Regex MetaRegex = new Regex(@"^\{""size"":\[(?<width>\d+),(?<height>\d+)\],""crop"":\[(?<left>\d+),(?<top>\d+),(?<right>\d+),(?<bottom>\d+)\]\}$");
+
+		int ParseGroup(Match match, string group)
+		{
+			return int.Parse(match.Groups[group].Value);
+		}
+
+		public IReadOnlyList<ISpriteFrame> Frames { get; private set; }
+
+		public ShpRemasteredSprite(Stream stream)
+		{
+			var container = new ZipFile(stream);
+
+			string framePrefix = null;
+			var frameCount = 0;
+			foreach (ZipEntry entry in container)
+			{
+				var match = FilenameRegex.Match(entry.Name);
+				if (!match.Success)
+					continue;
+
+				var prefix = match.Groups["prefix"].Value;
+				if (framePrefix == null)
+					framePrefix = prefix;
+
+				if (prefix != framePrefix)
+					throw new InvalidDataException("Frame prefix mismatch: `{0}` != `{1}`".F(prefix, framePrefix));
+
+				frameCount = Math.Max(frameCount, int.Parse(match.Groups["frame"].Value) + 1);
+			}
+
+			var frames = new ISpriteFrame[frameCount];
+			for (var i = 0; i < frames.Length; i++)
+			{
+				var tgaEntry = container.GetEntry("{0}{1:D4}.tga".F(framePrefix, i));
+
+				// Blank frame
+				if (tgaEntry == null)
+				{
+					frames[i] = new TgaSprite.TgaFrame();
+					continue;
+				}
+
+				var metaEntry = container.GetEntry("{0}{1:D4}.meta".F(framePrefix, i));
+				using (var tgaStream = container.GetInputStream(tgaEntry))
+				{
+					var metaStream = metaEntry != null ? container.GetInputStream(metaEntry) : null;
+					if (metaStream != null)
+					{
+						var meta = MetaRegex.Match(metaStream.ReadAllText());
+						var crop = Rectangle.FromLTRB(
+							ParseGroup(meta, "left"), ParseGroup(meta, "top"),
+							ParseGroup(meta, "right"), ParseGroup(meta, "bottom"));
+
+						var frameSize = new Size(ParseGroup(meta, "width"), ParseGroup(meta, "height"));
+						frames[i] = new TgaSprite.TgaFrame(tgaStream, frameSize, crop);
+						metaStream.Dispose();
+					}
+					else
+						frames[i] = new TgaSprite.TgaFrame(tgaStream);
+				}
+			}
+
+			Frames = frames.AsReadOnly();
+		}
+	}
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="OpenRA-FuzzyLogicLibrary" Version="1.0.1" />
     <PackageReference Include="DiscordRichPresence" Version="1.0.150" />
     <PackageReference Include="rix0rrr.BeaconLib" Version="1.0.2" />
+    <PackageReference Include="Pfim" Version="0.9.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <AdditionalFiles Include="../stylecop.json" />

--- a/OpenRA.Mods.Common/SpriteLoaders/DdsLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/DdsLoader.cs
@@ -1,0 +1,80 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.IO;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Primitives;
+using Pfim;
+
+namespace OpenRA.Mods.Common.SpriteLoaders
+{
+	public class DdsLoader : ISpriteLoader
+	{
+		public static bool IsDds(Stream s)
+		{
+			var start = s.Position;
+			var isDds = s.ReadUInt32() == 0x20534444;
+			s.Position = start;
+
+			return isDds;
+		}
+
+		public bool TryParseSprite(Stream s, out ISpriteFrame[] frames, out TypeDictionary metadata)
+		{
+			metadata = null;
+			if (!IsDds(s))
+			{
+				frames = null;
+				return false;
+			}
+
+			frames = new DdsSprite(s).Frames.ToArray();
+			return true;
+		}
+	}
+
+	public class DdsSprite
+	{
+		class DdsFrame : ISpriteFrame
+		{
+			public SpriteFrameType Type { get; private set; }
+			public Size Size { get; private set; }
+			public Size FrameSize { get { return Size; } }
+			public float2 Offset { get { return float2.Zero; } }
+			public byte[] Data { get; private set; }
+			public bool DisableExportPadding { get { return false; } }
+
+			public DdsFrame(Stream stream)
+			{
+				using (var dds = Dds.Create(stream, new PfimConfig()))
+				{
+					Size = new Size(dds.Width, dds.Height);
+					Data = dds.Data;
+					switch (dds.Format)
+					{
+						// SpriteFrameType refers to the channel byte order, which is reversed from the little-endian bit order
+						case ImageFormat.Rgba32: Type = SpriteFrameType.Bgra32; break;
+						case ImageFormat.Rgb24: Type = SpriteFrameType.Bgr24; break;
+						default: throw new InvalidDataException("Unhandled ImageFormat {0}".F(dds.Format));
+					}
+				}
+			}
+		}
+
+		public IReadOnlyList<ISpriteFrame> Frames { get; private set; }
+
+		public DdsSprite(Stream stream)
+		{
+			Frames = new ISpriteFrame[] { new DdsFrame(stream) }.AsReadOnly();
+		}
+	}
+}

--- a/OpenRA.Mods.Common/SpriteLoaders/TgaLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/TgaLoader.cs
@@ -75,6 +75,11 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 			public byte[] Data { get; private set; }
 			public bool DisableExportPadding { get { return false; } }
 
+			public TgaFrame()
+			{
+				Data = new byte[0];
+			}
+
 			public TgaFrame(Stream stream)
 			{
 				using (var tga = Targa.Create(stream, new PfimConfig()))
@@ -89,6 +94,13 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 						default: throw new InvalidDataException("Unhandled ImageFormat {0}".F(tga.Format));
 					}
 				}
+			}
+
+			public TgaFrame(Stream stream, Size frameSize, Rectangle frameWindow)
+				: this(stream)
+			{
+				FrameSize = frameSize;
+				Offset = 0.5f * new float2(frameWindow.Left + frameWindow.Right - FrameSize.Width, frameWindow.Top + frameWindow.Bottom - FrameSize.Height);
 			}
 		}
 


### PR DESCRIPTION
This PR adds sprite loaders for object (unit/structure/vfx/etc) and terrain artwork.

Object artwork is packaged as a zip file containing tga images and json metadata.
Terrain artwork is loose dds files that will need additional tileset support before a mod can use them. As noted in the code, this is intended as a first implementation of DDS that I expect we will eventually rewrite to keep the texture data compressed all the way through to the GPU.

This is best tested by combining with #18443 and then modifying TD's mod.yaml to add `/path/to/TEXTURES_TD_SRGB.MEG` in the `Packages` list; `ShpRemastered, Dds` to the `SpriteFormats` list and `.ZIP, .DDS` to the AssetBrowser `SupportedExtensions` list. The sprites can then be viewed in the asset browser.