### PR TITLE
Update Target to readonly and apply the in modifier.

### DIFF
--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Activities
 		public readonly Color Color;
 		public readonly Sprite Tile;
 
-		public TargetLineNode(Target target, Color color, Sprite tile = null)
+		public TargetLineNode(in Target target, Color color, Sprite tile = null)
 		{
 			// Note: Not all activities are drawable. In that case, pass Target.Invalid as target,
 			// if "yield break" in TargetLineNode(Actor self) is not feasible.

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -55,7 +55,7 @@ namespace OpenRA
 		public readonly string OrderString;
 		public readonly Actor Subject;
 		public readonly bool Queued;
-		public readonly Target Target;
+		public ref readonly Target Target => ref target;
 		public readonly Actor[] GroupedActors;
 
 		public string TargetString;
@@ -66,15 +66,18 @@ namespace OpenRA
 		public OrderType Type = OrderType.Fields;
 
 		public bool SuppressVisualFeedback;
-		public Target VisualFeedbackTarget;
+		public ref readonly Target VisualFeedbackTarget => ref visualFeedbackTarget;
 
 		public Player Player { get { return Subject != null ? Subject.Owner : null; } }
 
-		Order(string orderString, Actor subject, Target target, string targetString, bool queued, Actor[] extraActors, CPos extraLocation, uint extraData, Actor[] groupedActors = null)
+		readonly Target target;
+		readonly Target visualFeedbackTarget;
+
+		Order(string orderString, Actor subject, in Target target, string targetString, bool queued, Actor[] extraActors, CPos extraLocation, uint extraData, Actor[] groupedActors = null)
 		{
 			OrderString = orderString ?? "";
 			Subject = subject;
-			Target = target;
+			this.target = target;
 			TargetString = targetString;
 			Queued = queued;
 			ExtraActors = extraActors;
@@ -278,8 +281,14 @@ namespace OpenRA
 		public Order(string orderString, Actor subject, bool queued, Actor[] extraActors = null, Actor[] groupedActors = null)
 			: this(orderString, subject, Target.Invalid, null, queued, extraActors, CPos.Zero, 0, groupedActors) { }
 
-		public Order(string orderString, Actor subject, Target target, bool queued, Actor[] extraActors = null, Actor[] groupedActors = null)
+		public Order(string orderString, Actor subject, in Target target, bool queued, Actor[] extraActors = null, Actor[] groupedActors = null)
 			: this(orderString, subject, target, null, queued, extraActors, CPos.Zero, 0, groupedActors) { }
+
+		public Order(string orderString, Actor subject, Target target, Target visualFeedbackTarget, bool queued)
+			: this(orderString, subject, target, null, queued, null, CPos.Zero, 0, null)
+		{
+			this.visualFeedbackTarget = visualFeedbackTarget;
+		}
 
 		public byte[] Serialize()
 		{

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -196,15 +196,17 @@ namespace OpenRA.Orders
 			public readonly IOrderTargeter Order;
 			public readonly IIssueOrder Trait;
 			public readonly string Cursor;
-			public readonly Target Target;
+			public ref readonly Target Target => ref target;
 
-			public UnitOrderResult(Actor actor, IOrderTargeter order, IIssueOrder trait, string cursor, Target target)
+			readonly Target target;
+
+			public UnitOrderResult(Actor actor, IOrderTargeter order, IIssueOrder trait, string cursor, in Target target)
 			{
 				Actor = actor;
 				Order = order;
 				Trait = trait;
 				Cursor = cursor;
-				Target = target;
+				this.target = target;
 			}
 		}
 

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Traits
 		}
 
 		public static Target FromPos(WPos p) { return new Target(p); }
-		public static Target FromTargetPositions(Target t) { return new Target(t.CenterPosition, t.Positions.ToArray()); }
+		public static Target FromTargetPositions(in Target t) { return new Target(t.CenterPosition, t.Positions.ToArray()); }
 		public static Target FromCell(World w, CPos c, SubCell subCell = SubCell.FullCell) { return new Target(w, c, subCell); }
 		public static Target FromActor(Actor a) { return a != null ? new Target(a) : Invalid; }
 		public static Target FromFrozenActor(FrozenActor fa) { return new Target(fa); }

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -16,7 +16,7 @@ using System.Linq;
 namespace OpenRA.Traits
 {
 	public enum TargetType : byte { Invalid, Actor, Terrain, FrozenActor }
-	public struct Target
+	public readonly struct Target
 	{
 		public static readonly Target[] None = { };
 		public static readonly Target Invalid = default(Target);

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -128,7 +128,7 @@ namespace OpenRA.Traits
 	public interface IIssueOrder
 	{
 		IEnumerable<IOrderTargeter> Orders { get; }
-		Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued);
+		Order IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued);
 	}
 
 	[Flags]
@@ -147,9 +147,9 @@ namespace OpenRA.Traits
 	{
 		string OrderID { get; }
 		int OrderPriority { get; }
-		bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor);
+		bool CanTarget(Actor self, in Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor);
 		bool IsQueued { get; }
-		bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers);
+		bool TargetOverridesSelection(Actor self, in Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers);
 	}
 
 	public interface IResolveOrder { void ResolveOrder(Actor self, Order order); }
@@ -517,7 +517,7 @@ namespace OpenRA.Traits
 		int Delay { get; }
 		bool IsValidAgainst(Actor victim, Actor firedBy);
 		bool IsValidAgainst(FrozenActor victim, Actor firedBy);
-		void DoImpact(Target target, WarheadArgs args);
+		void DoImpact(in Target target, WarheadArgs args);
 	}
 
 	public interface IRulesetLoaded<TInfo> { void RulesetLoaded(Ruleset rules, TInfo info); }

--- a/OpenRA.Mods.Cnc/Activities/Infiltrate.cs
+++ b/OpenRA.Mods.Cnc/Activities/Infiltrate.cs
@@ -24,14 +24,14 @@ namespace OpenRA.Mods.Cnc.Activities
 		readonly INotifyInfiltration[] notifiers;
 		Actor enterActor;
 
-		public Infiltrate(Actor self, Target target, Infiltrates infiltrates)
+		public Infiltrate(Actor self, in Target target, Infiltrates infiltrates)
 			: base(self, target, Color.Crimson)
 		{
 			this.infiltrates = infiltrates;
 			notifiers = self.TraitsImplementing<INotifyInfiltration>().ToArray();
 		}
 
-		protected override void TickInner(Actor self, Target target, bool targetIsDeadOrHiddenActor)
+		protected override void TickInner(Actor self, in Target target, bool targetIsDeadOrHiddenActor)
 		{
 			if (infiltrates.IsTraitDisabled)
 				Cancel(self, true);

--- a/OpenRA.Mods.Cnc/Activities/Leap.cs
+++ b/OpenRA.Mods.Cnc/Activities/Leap.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Cnc.Activities
 		int ticks = 0;
 		WPos targetPosition;
 
-		public Leap(Actor self, Target target, Mobile mobile, Mobile targetMobile, int speed, AttackLeap attack, EdibleByLeap edible)
+		public Leap(Actor self, in Target target, Mobile mobile, Mobile targetMobile, int speed, AttackLeap attack, EdibleByLeap edible)
 		{
 			this.mobile = mobile;
 			this.targetMobile = targetMobile;

--- a/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
+++ b/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Cnc.Activities
 		BitSet<TargetableType> lastVisibleTargetTypes;
 		Player lastVisibleOwner;
 
-		public LeapAttack(Actor self, Target target, bool allowMovement, bool forceAttack, AttackLeap attack, AttackLeapInfo info, Color? targetLineColor = null)
+		public LeapAttack(Actor self, in Target target, bool allowMovement, bool forceAttack, AttackLeap attack, AttackLeapInfo info, Color? targetLineColor = null)
 		{
 			this.target = target;
 			this.targetLineColor = targetLineColor;

--- a/OpenRA.Mods.Cnc/Projectiles/DropPodImpact.cs
+++ b/OpenRA.Mods.Cnc/Projectiles/DropPodImpact.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Cnc.Effects
 		int weaponDelay;
 		bool impacted = false;
 
-		public DropPodImpact(Player firedBy, WeaponInfo weapon, World world, WPos launchPos, Target target,
+		public DropPodImpact(Player firedBy, WeaponInfo weapon, World world, WPos launchPos, in Target target,
 			int delay, string entryEffect, string entrySequence, string entryPalette)
 		{
 			this.target = target;

--- a/OpenRA.Mods.Cnc/Projectiles/IonCannon.cs
+++ b/OpenRA.Mods.Cnc/Projectiles/IonCannon.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Cnc.Effects
 		int weaponDelay;
 		bool impacted = false;
 
-		public IonCannon(Player firedBy, WeaponInfo weapon, World world, WPos launchPos, Target target, string effect, string sequence, string palette, int delay)
+		public IonCannon(Player firedBy, WeaponInfo weapon, World world, WPos launchPos, in Target target, string effect, string sequence, string palette, int delay)
 		{
 			this.target = target;
 			this.firedBy = firedBy;

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackLeap.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackLeap.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			this.info = info;
 		}
 
-		protected override bool CanAttack(Actor self, Target target)
+		protected override bool CanAttack(Actor self, in Target target)
 		{
 			if (target.Type != TargetType.Actor)
 				return false;
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				leapToken = self.RevokeCondition(leapToken);
 		}
 
-		public override Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
+		public override Activity GetAttackActivity(Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
 		{
 			return new LeapAttack(self, newTarget, allowMove, forceAttack, this, info, targetLineColor);
 		}

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackPopupTurreted.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		protected override bool CanAttack(Actor self, Target target)
+		protected override bool CanAttack(Actor self, in Target target)
 		{
 			if (state == PopupState.Closed)
 			{

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTDGunboatTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTDGunboatTurreted.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public AttackTDGunboatTurreted(Actor self, AttackTDGunboatTurretedInfo info)
 			: base(self, info) { }
 
-		public override Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
+		public override Activity GetAttackActivity(Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
 		{
 			return new AttackTDGunboatTurretedActivity(self, newTarget, allowMove, forceAttack, targetLineColor);
 		}
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			readonly Color? targetLineColor;
 			bool hasTicked;
 
-			public AttackTDGunboatTurretedActivity(Actor self, Target target, bool allowMove, bool forceAttack, Color? targetLineColor = null)
+			public AttackTDGunboatTurretedActivity(Actor self, in Target target, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 			{
 				attack = self.Trait<AttackTDGunboatTurreted>();
 				this.target = target;

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				charges = info.MaxCharges;
 		}
 
-		protected override bool CanAttack(Actor self, Target target)
+		protected override bool CanAttack(Actor self, in Target target)
 		{
 			if (!IsReachableTarget(target, true))
 				return false;
@@ -70,15 +70,15 @@ namespace OpenRA.Mods.Cnc.Traits
 			return base.CanAttack(self, target);
 		}
 
-		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel)
+		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
 			--charges;
 			timeToRecharge = info.ReloadDelay;
 		}
 
-		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel) { }
+		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel) { }
 
-		public override Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
+		public override Activity GetAttackActivity(Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 		{
 			return new ChargeAttack(this, newTarget, forceAttack, targetLineColor);
 		}
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			readonly bool forceAttack;
 			readonly Color? targetLineColor;
 
-			public ChargeAttack(AttackTesla attack, Target target, bool forceAttack, Color? targetLineColor = null)
+			public ChargeAttack(AttackTesla attack, in Target target, bool forceAttack, Color? targetLineColor = null)
 			{
 				this.attack = attack;
 				this.target = target;
@@ -149,7 +149,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			readonly AttackTesla attack;
 			readonly Target target;
 
-			public ChargeFire(AttackTesla attack, Target target)
+			public ChargeFire(AttackTesla attack, in Target target)
 			{
 				this.attack = attack;
 				this.target = target;

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -136,7 +136,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID == "Disguise")
 				return new Order(order.OrderID, self, target, queued);
@@ -244,9 +244,9 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel) { }
+		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel) { }
 
-		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel)
+		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
 			if (info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Attack))
 				DisguiseAs(null);

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID != "Infiltrate")
 				return null;
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				? Info.Voice : null;
 		}
 
-		public bool CanInfiltrateTarget(Actor self, Target target)
+		public bool CanInfiltrateTarget(Actor self, in Target target)
 		{
 			switch (target.Type)
 			{

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID != "DetonateAttack" && order.OrderID != "Detonate")
 				return null;
@@ -150,7 +150,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				assignTargetOnFirstRun = true;
 			}
 
-			public DetonationSequence(Actor self, MadTank mad, Target target)
+			public DetonationSequence(Actor self, MadTank mad, in Target target)
 			{
 				this.self = self;
 				this.mad = mad;

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			switch (order.OrderID)
 			{
@@ -299,9 +299,9 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			public string OrderID { get { return "BeginMinefield"; } }
 			public int OrderPriority { get { return 5; } }
-			public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
+			public bool TargetOverridesSelection(Actor self, in Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
 
-			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
+			public bool CanTarget(Actor self, in Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 			{
 				if (target.Type != TargetType.Terrain)
 					return false;

--- a/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID == "PortableChronoDeploy")
 			{
@@ -172,9 +172,9 @@ namespace OpenRA.Mods.Cnc.Traits
 		public string OrderID { get { return "PortableChronoTeleport"; } }
 		public int OrderPriority { get { return 5; } }
 		public bool IsQueued { get; protected set; }
-		public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
+		public bool TargetOverridesSelection(Actor self, in Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
 
-		public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
+		public bool CanTarget(Actor self, in Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 		{
 			if (modifiers.HasModifier(TargetModifiers.ForceMove))
 			{

--- a/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeAnimation.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 			wsb = init.Self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == info.Body);
 		}
 
-		void INotifyTeslaCharging.Charging(Actor self, Target target)
+		void INotifyTeslaCharging.Charging(Actor self, in Target target)
 		{
 			wsb.PlayCustomAnimation(self, info.ChargeSequence, () => wsb.CancelCustomAnimation(self));
 		}

--- a/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeOverlay.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeOverlay.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 				info.Palette, info.IsPlayerPalette);
 		}
 
-		void INotifyTeslaCharging.Charging(Actor self, Target target)
+		void INotifyTeslaCharging.Charging(Actor self, in Target target)
 		{
 			charging = true;
 			overlay.PlayThen(RenderSprites.NormalizeSequence(overlay, self.GetDamageState(), info.Sequence), () => charging = false);

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			base.Created(self);
 		}
 
-		void INotifyBurstComplete.FiredBurst(Actor self, Target target, Armament a)
+		void INotifyBurstComplete.FiredBurst(Actor self, in Target target, Armament a)
 		{
 			self.World.IssueOrder(new Order("Stop", self, false));
 		}

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -202,16 +202,16 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public Activity MoveTo(CPos cell, int nearEnough = 0, Actor ignoreActor = null,
 			bool evaluateNearestMovableCell = false, Color? targetLineColor = null) { return null; }
-		public Activity MoveWithinRange(Target target, WDist range,
+		public Activity MoveWithinRange(in Target target, WDist range,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null) { return null; }
-		public Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange,
+		public Activity MoveWithinRange(in Target target, WDist minRange, WDist maxRange,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null) { return null; }
-		public Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange,
+		public Activity MoveFollow(Actor self, in Target target, WDist minRange, WDist maxRange,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null) { return null; }
 		public Activity ReturnToCell(Actor self) { return null; }
-		public Activity MoveToTarget(Actor self, Target target,
+		public Activity MoveToTarget(Actor self, in Target target,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null) { return null; }
-		public Activity MoveIntoTarget(Actor self, Target target) { return null; }
+		public Activity MoveIntoTarget(Actor self, in Target target) { return null; }
 		public Activity VisualMove(Actor self, WPos fromPos, WPos toPos) { return null; }
 
 		public int EstimatedMoveDuration(Actor self, WPos fromPos, WPos toPos)
@@ -224,7 +224,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		// Actors with TDGunboat always move
 		public MovementType CurrentMovementTypes { get { return MovementType.Horizontal; } set { } }
 
-		public bool CanEnterTargetNow(Actor self, Target target)
+		public bool CanEnterTargetNow(Actor self, in Target target)
 		{
 			return false;
 		}

--- a/OpenRA.Mods.Cnc/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Cnc/TraitsInterfaces.cs
@@ -14,5 +14,5 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[RequireExplicitImplementation]
-	public interface INotifyTeslaCharging { void Charging(Actor self, Target target); }
+	public interface INotifyTeslaCharging { void Charging(Actor self, in Target target); }
 }

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -31,13 +31,13 @@ namespace OpenRA.Mods.Common.Activities
 		bool useLastVisibleTarget;
 		readonly List<WPos> positionBuffer = new List<WPos>();
 
-		public Fly(Actor self, Target t, WDist nearEnough, WPos? initialTargetPosition = null, Color? targetLineColor = null)
+		public Fly(Actor self, in Target t, WDist nearEnough, WPos? initialTargetPosition = null, Color? targetLineColor = null)
 			: this(self, t, initialTargetPosition, targetLineColor)
 		{
 			this.nearEnough = nearEnough;
 		}
 
-		public Fly(Actor self, Target t, WPos? initialTargetPosition = null, Color? targetLineColor = null)
+		public Fly(Actor self, in Target t, WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
 			aircraft = self.Trait<Aircraft>();
 			target = t;
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Activities
 				lastVisibleTarget = Target.FromPos(initialTargetPosition.Value);
 		}
 
-		public Fly(Actor self, Target t, WDist minRange, WDist maxRange,
+		public Fly(Actor self, in Target t, WDist minRange, WDist maxRange,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 			: this(self, t, initialTargetPosition, targetLineColor)
 		{

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Activities
 		bool hasTicked;
 		bool returnToBase;
 
-		public FlyAttack(Actor self, AttackSource source, Target target, bool forceAttack, Color? targetLineColor)
+		public FlyAttack(Actor self, AttackSource source, in Target target, bool forceAttack, Color? targetLineColor)
 		{
 			this.source = source;
 			this.target = target;
@@ -211,7 +211,7 @@ namespace OpenRA.Mods.Common.Activities
 		WDist exitRange;
 		bool targetIsVisibleActor;
 
-		public FlyAttackRun(Actor self, Target t, WDist exitRange)
+		public FlyAttackRun(Actor self, in Target t, WDist exitRange)
 		{
 			ChildHasPriority = false;
 
@@ -254,7 +254,7 @@ namespace OpenRA.Mods.Common.Activities
 		WDist exitRange;
 		readonly AttackAircraft attackAircraft;
 
-		public StrafeAttackRun(Actor self, AttackAircraft attackAircraft, Target t, WDist exitRange)
+		public StrafeAttackRun(Actor self, AttackAircraft attackAircraft, in Target t, WDist exitRange)
 		{
 			ChildHasPriority = false;
 

--- a/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Activities
 		bool useLastVisibleTarget;
 		bool wasMovingWithinRange;
 
-		public FlyFollow(Actor self, Target target, WDist minRange, WDist maxRange,
+		public FlyFollow(Actor self, in Target target, WDist minRange, WDist maxRange,
 			WPos? initialTargetPosition, Color? targetLineColor = null)
 		{
 			this.target = target;

--- a/OpenRA.Mods.Common/Activities/Air/FlyOffMap.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyOffMap.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Activities
 			this.endingDelay = endingDelay;
 		}
 
-		public FlyOffMap(Actor self, Target target, int endingDelay = 25)
+		public FlyOffMap(Actor self, in Target target, int endingDelay = 25)
 			: this(self, endingDelay)
 		{
 			this.target = target;

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -40,16 +40,16 @@ namespace OpenRA.Mods.Common.Activities
 			assignTargetOnFirstRun = true;
 		}
 
-		public Land(Actor self, Target target, WAngle? facing = null, Color? targetLineColor = null)
+		public Land(Actor self, in Target target, WAngle? facing = null, Color? targetLineColor = null)
 			: this(self, target, new WDist(-1), WVec.Zero, facing, targetLineColor: targetLineColor) { }
 
-		public Land(Actor self, Target target, WDist landRange, WAngle? facing = null, Color? targetLineColor = null)
+		public Land(Actor self, in Target target, WDist landRange, WAngle? facing = null, Color? targetLineColor = null)
 			: this(self, target, landRange, WVec.Zero, facing, targetLineColor: targetLineColor) { }
 
-		public Land(Actor self, Target target, WVec offset, WAngle? facing = null, Color? targetLineColor = null)
+		public Land(Actor self, in Target target, WVec offset, WAngle? facing = null, Color? targetLineColor = null)
 			: this(self, target, WDist.Zero, offset, facing, targetLineColor: targetLineColor) { }
 
-		public Land(Actor self, Target target, WDist landRange, WVec offset, WAngle? facing = null, CPos[] clearCells = null, Color? targetLineColor = null)
+		public Land(Actor self, in Target target, WDist landRange, WVec offset, WAngle? facing = null, CPos[] clearCells = null, Color? targetLineColor = null)
 		{
 			aircraft = self.Trait<Aircraft>();
 			this.target = target;

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Activities
 		WDist maxRange;
 		AttackStatus attackStatus = AttackStatus.UnableToAttack;
 
-		public Attack(Actor self, Target target, bool allowMovement, bool forceAttack, Color? targetLineColor = null)
+		public Attack(Actor self, in Target target, bool allowMovement, bool forceAttack, Color? targetLineColor = null)
 		{
 			this.target = target;
 			this.targetLineColor = targetLineColor;
@@ -64,8 +64,11 @@ namespace OpenRA.Mods.Common.Activities
 			    || target.Type == TargetType.FrozenActor || target.Type == TargetType.Terrain)
 			{
 				lastVisibleTarget = Target.FromPos(target.CenterPosition);
+
+				// Lambdas can't use 'in' variables, so capture a copy for later
+				var rangeTarget = target;
 				lastVisibleMaximumRange = attackTraits.Where(x => !x.IsTraitDisabled)
-					.Min(x => x.GetMaximumRangeVersusTarget(target));
+					.Min(x => x.GetMaximumRangeVersusTarget(rangeTarget));
 
 				if (target.Type == TargetType.Actor)
 				{

--- a/OpenRA.Mods.Common/Activities/CaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/CaptureActor.cs
@@ -22,13 +22,13 @@ namespace OpenRA.Mods.Common.Activities
 		Actor enterActor;
 		CaptureManager enterCaptureManager;
 
-		public CaptureActor(Actor self, Target target)
+		public CaptureActor(Actor self, in Target target)
 			: base(self, target, Color.Crimson)
 		{
 			manager = self.Trait<CaptureManager>();
 		}
 
-		protected override void TickInner(Actor self, Target target, bool targetIsDeadOrHiddenActor)
+		protected override void TickInner(Actor self, in Target target, bool targetIsDeadOrHiddenActor)
 		{
 			if (target.Type == TargetType.Actor && enterActor != target.Actor)
 			{

--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Activities
 			assignTargetOnFirstRun = true;
 		}
 
-		public DeliverUnit(Actor self, Target destination, WDist deliverRange)
+		public DeliverUnit(Actor self, in Target destination, WDist deliverRange)
 		{
 			this.destination = destination;
 			this.deliverRange = deliverRange;

--- a/OpenRA.Mods.Common/Activities/Demolish.cs
+++ b/OpenRA.Mods.Common/Activities/Demolish.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Activities
 		Actor enterActor;
 		IDemolishable[] enterDemolishables;
 
-		public Demolish(Actor self, Target target, EnterBehaviour enterBehaviour, int delay,
+		public Demolish(Actor self, in Target target, EnterBehaviour enterBehaviour, int delay,
 			int flashes, int flashesDelay, int flashInterval, BitSet<DamageType> damageTypes)
 			: base(self, target, Color.Crimson)
 		{

--- a/OpenRA.Mods.Common/Activities/DonateCash.cs
+++ b/OpenRA.Mods.Common/Activities/DonateCash.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly int payload;
 		readonly int playerExperience;
 
-		public DonateCash(Actor self, Target target, int payload, int playerExperience)
+		public DonateCash(Actor self, in Target target, int payload, int playerExperience)
 			: base(self, target, Color.Yellow)
 		{
 			this.payload = payload;

--- a/OpenRA.Mods.Common/Activities/DonateExperience.cs
+++ b/OpenRA.Mods.Common/Activities/DonateExperience.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 		Actor enterActor;
 		GainsExperience enterGainsExperience;
 
-		public DonateExperience(Actor self, Target target, int level, int playerExperience)
+		public DonateExperience(Actor self, in Target target, int level, int playerExperience)
 			: base(self, target, Color.Yellow)
 		{
 			this.level = level;

--- a/OpenRA.Mods.Common/Activities/Enter.cs
+++ b/OpenRA.Mods.Common/Activities/Enter.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Activities
 		bool useLastVisibleTarget;
 		EnterState lastState = EnterState.Approaching;
 
-		protected Enter(Actor self, Target target, Color? targetLineColor = null)
+		protected Enter(Actor self, in Target target, Color? targetLineColor = null)
 		{
 			move = self.Trait<IMove>();
 			this.target = target;
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Activities
 		/// Called early in the activity tick to allow subclasses to update state.
 		/// Call Cancel(self, true) if it is no longer valid to enter
 		/// </summary>
-		protected virtual void TickInner(Actor self, Target target, bool targetIsDeadOrHiddenActor) { }
+		protected virtual void TickInner(Actor self, in Target target, bool targetIsDeadOrHiddenActor) { }
 
 		/// <summary>
 		/// Called when the actor is ready to transition from approaching to entering the target actor.

--- a/OpenRA.Mods.Common/Activities/Move/Follow.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Follow.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Activities
 		bool useLastVisibleTarget;
 		bool wasMovingWithinRange;
 
-		public Follow(Actor self, Target target, WDist minRange, WDist maxRange,
+		public Follow(Actor self, in Target target, WDist minRange, WDist maxRange,
 			WPos? initialTargetPosition, Color? targetLineColor = null)
 		{
 			this.target = target;

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Activities
 		protected CPos lastVisibleTargetLocation;
 		bool useLastVisibleTarget;
 
-		public MoveAdjacentTo(Actor self, Target target, WPos? initialTargetPosition = null, Color? targetLineColor = null)
+		public MoveAdjacentTo(Actor self, in Target target, WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
 			this.target = target;
 			this.targetLineColor = targetLineColor;

--- a/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly WDist maxRange;
 		readonly WDist minRange;
 
-		public MoveWithinRange(Actor self, Target target, WDist minRange, WDist maxRange,
+		public MoveWithinRange(Actor self, in Target target, WDist minRange, WDist maxRange,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 			: base(self, target, initialTargetPosition, targetLineColor)
 		{

--- a/OpenRA.Mods.Common/Activities/Move/VisualMoveIntoTarget.cs
+++ b/OpenRA.Mods.Common/Activities/Move/VisualMoveIntoTarget.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly WDist targetMovementThreshold;
 		WPos targetStartPos;
 
-		public VisualMoveIntoTarget(Actor self, Target target, WDist targetMovementThreshold, Color? targetLineColor = null)
+		public VisualMoveIntoTarget(Actor self, in Target target, WDist targetMovementThreshold, Color? targetLineColor = null)
 		{
 			mobile = self.Trait<Mobile>();
 			this.target = target;

--- a/OpenRA.Mods.Common/Activities/RepairBridge.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBridge.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Activities
 		BridgeHut enterHut;
 		LegacyBridgeHut enterLegacyHut;
 
-		public RepairBridge(Actor self, Target target, EnterBehaviour enterBehaviour, string notification)
+		public RepairBridge(Actor self, in Target target, EnterBehaviour enterBehaviour, string notification)
 			: base(self, target, Color.Yellow)
 		{
 			this.enterBehaviour = enterBehaviour;

--- a/OpenRA.Mods.Common/Activities/RepairBuilding.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBuilding.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 		IHealth enterHealth;
 		EngineerRepairable enterEngineerRepariable;
 
-		public RepairBuilding(Actor self, Target target, EngineerRepairInfo info)
+		public RepairBuilding(Actor self, in Target target, EngineerRepairInfo info)
 			: base(self, target, Color.Yellow)
 		{
 			this.info = info;

--- a/OpenRA.Mods.Common/Activities/RideTransport.cs
+++ b/OpenRA.Mods.Common/Activities/RideTransport.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 		Cargo enterCargo;
 		Aircraft enterAircraft;
 
-		public RideTransport(Actor self, Target target)
+		public RideTransport(Actor self, in Target target)
 			: base(self, target, Color.Green)
 		{
 			passenger = self.Trait<Passenger>();

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -151,7 +151,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly Target target;
 		readonly Color? targetLineColor;
 
-		public IssueOrderAfterTransform(string orderString, Target target, Color? targetLineColor = null)
+		public IssueOrderAfterTransform(string orderString, in Target target, Color? targetLineColor = null)
 		{
 			this.orderString = orderString;
 			this.target = target;

--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Activities
 			assignTargetOnFirstRun = true;
 		}
 
-		public UnloadCargo(Actor self, Target destination, WDist unloadRange, bool unloadAll = true)
+		public UnloadCargo(Actor self, in Target destination, WDist unloadRange, bool unloadAll = true)
 		{
 			this.self = self;
 			cargo = self.Trait<Cargo>();

--- a/OpenRA.Mods.Common/Orders/DeployOrderTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/DeployOrderTargeter.cs
@@ -33,9 +33,9 @@ namespace OpenRA.Mods.Common.Orders
 
 		public string OrderID { get; private set; }
 		public int OrderPriority { get; private set; }
-		public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
+		public bool TargetOverridesSelection(Actor self, in Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
 
-		public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
+		public bool CanTarget(Actor self, in Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 		{
 			if (target.Type != TargetType.Actor)
 				return false;

--- a/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
@@ -70,10 +70,7 @@ namespace OpenRA.Mods.Common.Orders
 			if (repairBuilding == null)
 				yield break;
 
-			yield return new Order(orderId, underCursor, Target.FromActor(repairBuilding), mi.Modifiers.HasModifier(Modifiers.Shift))
-			{
-				VisualFeedbackTarget = Target.FromActor(underCursor)
-			};
+			yield return new Order(orderId, underCursor, Target.FromActor(repairBuilding), Target.FromActor(underCursor), mi.Modifiers.HasModifier(Modifiers.Shift));
 		}
 
 		protected override void Tick(World world)

--- a/OpenRA.Mods.Common/Orders/UnitOrderTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/UnitOrderTargeter.cs
@@ -32,12 +32,12 @@ namespace OpenRA.Mods.Common.Orders
 		public string OrderID { get; private set; }
 		public int OrderPriority { get; private set; }
 		public bool? ForceAttack = null;
-		public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
+		public bool TargetOverridesSelection(Actor self, in Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
 
 		public abstract bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor);
 		public abstract bool CanTargetFrozenActor(Actor self, FrozenActor target, TargetModifiers modifiers, ref string cursor);
 
-		public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
+		public bool CanTarget(Actor self, in Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 		{
 			var type = target.Type;
 			if (type != TargetType.Actor && type != TargetType.FrozenActor)

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -875,20 +875,20 @@ namespace OpenRA.Mods.Common.Traits
 			return new Fly(self, Target.FromCell(self.World, cell), WDist.FromCells(nearEnough), targetLineColor: targetLineColor);
 		}
 
-		public Activity MoveWithinRange(Target target, WDist range,
+		public Activity MoveWithinRange(in Target target, WDist range,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
 			return new Fly(self, target, WDist.Zero, range, initialTargetPosition, targetLineColor);
 		}
 
-		public Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange,
+		public Activity MoveWithinRange(in Target target, WDist minRange, WDist maxRange,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
 			return new Fly(self, target, minRange, maxRange,
 				initialTargetPosition, targetLineColor);
 		}
 
-		public Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange,
+		public Activity MoveFollow(Actor self, in Target target, WDist minRange, WDist maxRange,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
 			return new FlyFollow(self, target, minRange, maxRange,
@@ -934,13 +934,13 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public Activity MoveToTarget(Actor self, Target target,
+		public Activity MoveToTarget(Actor self, in Target target,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
 			return new Fly(self, target, initialTargetPosition, targetLineColor);
 		}
 
-		public Activity MoveIntoTarget(Actor self, Target target)
+		public Activity MoveIntoTarget(Actor self, in Target target)
 		{
 			return new Land(self, target);
 		}
@@ -978,9 +978,11 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public bool CanEnterTargetNow(Actor self, Target target)
+		public bool CanEnterTargetNow(Actor self, in Target target)
 		{
-			if (target.Positions.Any(p => self.World.ActorMap.GetActorsAt(self.World.Map.CellContaining(p)).Any(a => a != self && a != target.Actor)))
+			// Lambdas can't use 'in' variables, so capture a copy for later
+			var targetActor = target;
+			if (target.Positions.Any(p => self.World.ActorMap.GetActorsAt(self.World.Map.CellContaining(p)).Any(a => a != self && a != targetActor.Actor)))
 				return false;
 
 			MakeReservation(target.Actor);
@@ -1015,7 +1017,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (!IsTraitDisabled &&
 				(order.OrderID == "Enter" || order.OrderID == "Move" || order.OrderID == "Land" || order.OrderID == "ForceEnter"))
@@ -1250,7 +1252,7 @@ namespace OpenRA.Mods.Common.Traits
 				OrderID = "Move";
 			}
 
-			public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers)
+			public bool TargetOverridesSelection(Actor self, in Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers)
 			{
 				// Always prioritise orders over selecting other peoples actors or own actors that are already selected
 				if (target.Type == TargetType.Actor && (target.Actor.Owner != self.Owner || self.World.Selection.Contains(target.Actor)))
@@ -1259,7 +1261,7 @@ namespace OpenRA.Mods.Common.Traits
 				return modifiers.HasModifier(TargetModifiers.ForceMove);
 			}
 
-			public virtual bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
+			public virtual bool CanTarget(Actor self, in Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 			{
 				if (target.Type != TargetType.Terrain || (aircraft.requireForceMove && !modifiers.HasModifier(TargetModifiers.ForceMove)))
 					return false;

--- a/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
@@ -48,12 +48,12 @@ namespace OpenRA.Mods.Common.Traits
 			aircraftInfo = self.Info.TraitInfo<AircraftInfo>();
 		}
 
-		public override Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
+		public override Activity GetAttackActivity(Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 		{
 			return new FlyAttack(self, source, newTarget, forceAttack, targetLineColor);
 		}
 
-		protected override bool CanAttack(Actor self, Target target)
+		protected override bool CanAttack(Actor self, in Target target)
 		{
 			// Don't fire while landed or when outside the map.
 			if (self.World.Map.DistanceAboveTerrain(self.CenterPosition).Length < aircraftInfo.MinAirborneAltitude

--- a/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
@@ -89,7 +89,7 @@ namespace OpenRA.Mods.Common.Traits
 			OnRemovedFromWorld(self);
 		}
 
-		public override Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
+		public override Activity GetAttackActivity(Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
 		{
 			throw new NotImplementedException("AttackBomber requires a scripted target");
 		}

--- a/OpenRA.Mods.Common/Traits/AmmoPool.cs
+++ b/OpenRA.Mods.Common/Traits/AmmoPool.cs
@@ -96,13 +96,13 @@ namespace OpenRA.Mods.Common.Traits
 			RemainingTicks = Info.ReloadDelay;
 		}
 
-		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel)
+		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
 			if (a != null && Info.Armaments.Contains(a.Info.Name))
 				TakeAmmo(self, 1);
 		}
 
-		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel) { }
+		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel) { }
 
 		void UpdateCondition(Actor self)
 		{

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -229,7 +229,7 @@ namespace OpenRA.Mods.Common.Traits
 				a();
 		}
 
-		protected virtual bool CanFire(Actor self, Target target)
+		protected virtual bool CanFire(Actor self, in Target target)
 		{
 			if (IsReloading || IsTraitPaused)
 				return false;
@@ -249,7 +249,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		// Note: facing is only used by the legacy positioning code
 		// The world coordinate model uses Actor.Orientation
-		public virtual Barrel CheckFire(Actor self, IFacing facing, Target target)
+		public virtual Barrel CheckFire(Actor self, IFacing facing, in Target target)
 		{
 			if (!CanFire(self, target))
 				return null;
@@ -271,7 +271,7 @@ namespace OpenRA.Mods.Common.Traits
 			return barrel;
 		}
 
-		protected virtual void FireBarrel(Actor self, IFacing facing, Target target, Barrel barrel)
+		protected virtual void FireBarrel(Actor self, IFacing facing, in Target target, Barrel barrel)
 		{
 			foreach (var na in notifyAttacks)
 				na.PreparingAttack(self, target, this, barrel);
@@ -316,6 +316,8 @@ namespace OpenRA.Mods.Common.Traits
 				GuidedTarget = target
 			};
 
+			// Lambdas can't use 'in' variables, so capture a copy for later
+			var delayedTarget = target;
 			ScheduleDelayedAction(Info.FireDelay, () =>
 			{
 				if (args.Weapon.Projectile != null)
@@ -331,14 +333,14 @@ namespace OpenRA.Mods.Common.Traits
 						Game.Sound.Play(SoundType.World, args.Weapon.StartBurstReport, self.World, self.CenterPosition);
 
 					foreach (var na in notifyAttacks)
-						na.Attacking(self, target, this, barrel);
+						na.Attacking(self, delayedTarget, this, barrel);
 
 					Recoil = Info.Recoil;
 				}
 			});
 		}
 
-		protected virtual void UpdateBurst(Actor self, Target target)
+		protected virtual void UpdateBurst(Actor self, in Target target)
 		{
 			if (--Burst > 0)
 			{

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -126,7 +126,7 @@ namespace OpenRA.Mods.Common.Traits
 			return () => armaments;
 		}
 
-		public bool TargetInFiringArc(Actor self, Target target, int facingTolerance)
+		public bool TargetInFiringArc(Actor self, in Target target, int facingTolerance)
 		{
 			if (facing == null)
 				return true;
@@ -141,7 +141,7 @@ namespace OpenRA.Mods.Common.Traits
 			return Util.FacingWithinTolerance(facing.Facing, delta.Yaw, facingTolerance);
 		}
 
-		protected virtual bool CanAttack(Actor self, Target target)
+		protected virtual bool CanAttack(Actor self, in Target target)
 		{
 			if (!self.IsInWorld || IsTraitDisabled || IsTraitPaused)
 				return false;
@@ -162,7 +162,7 @@ namespace OpenRA.Mods.Common.Traits
 			return true;
 		}
 
-		public virtual void DoAttack(Actor self, Target target)
+		public virtual void DoAttack(Actor self, in Target target)
 		{
 			if (!CanAttack(self, target))
 				return;
@@ -186,7 +186,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order is AttackOrderTargeter)
 				return new Order(order.OrderID, self, target, queued);
@@ -226,9 +226,9 @@ namespace OpenRA.Mods.Common.Traits
 			return order.OrderString == attackOrderName || order.OrderString == forceAttackOrderName ? Info.Voice : null;
 		}
 
-		public abstract Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null);
+		public abstract Activity GetAttackActivity(Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null);
 
-		public bool HasAnyValidWeapons(Target t, bool checkForCenterTargetingWeapons = false)
+		public bool HasAnyValidWeapons(in Target t, bool checkForCenterTargetingWeapons = false)
 		{
 			if (IsTraitDisabled)
 				return false;
@@ -247,7 +247,7 @@ namespace OpenRA.Mods.Common.Traits
 			return false;
 		}
 
-		public virtual WPos GetTargetPosition(WPos pos, Target target)
+		public virtual WPos GetTargetPosition(WPos pos, in Target target)
 		{
 			return HasAnyValidWeapons(target, true) ? target.CenterPosition : target.Positions.PositionClosestTo(pos);
 		}
@@ -298,7 +298,7 @@ namespace OpenRA.Mods.Common.Traits
 			return max;
 		}
 
-		public WDist GetMinimumRangeVersusTarget(Target target)
+		public WDist GetMinimumRangeVersusTarget(in Target target)
 		{
 			if (IsTraitDisabled)
 				return WDist.Zero;
@@ -324,7 +324,7 @@ namespace OpenRA.Mods.Common.Traits
 			return min != WDist.MaxValue ? min : WDist.Zero;
 		}
 
-		public WDist GetMaximumRangeVersusTarget(Target target)
+		public WDist GetMaximumRangeVersusTarget(in Target target)
 		{
 			if (IsTraitDisabled)
 				return WDist.Zero;
@@ -382,7 +382,7 @@ namespace OpenRA.Mods.Common.Traits
 				&& a.Weapon.IsValidAgainst(t, self.World, self));
 		}
 
-		public void AttackTarget(Target target, AttackSource source, bool queued, bool allowMove, bool forceAttack = false, Color? targetLineColor = null)
+		public void AttackTarget(in Target target, AttackSource source, bool queued, bool allowMove, bool forceAttack = false, Color? targetLineColor = null)
 		{
 			if (IsTraitDisabled)
 				return;
@@ -395,9 +395,9 @@ namespace OpenRA.Mods.Common.Traits
 			OnResolveAttackOrder(self, activity, target, queued, forceAttack);
 		}
 
-		public virtual void OnResolveAttackOrder(Actor self, Activity activity, Target target, bool queued, bool forceAttack) { }
+		public virtual void OnResolveAttackOrder(Actor self, Activity activity, in Target target, bool queued, bool forceAttack) { }
 
-		public bool IsReachableTarget(Target target, bool allowMove)
+		public bool IsReachableTarget(in Target target, bool allowMove)
 		{
 			return HasAnyValidWeapons(target)
 				&& (target.IsInRange(self.CenterPosition, GetMaximumRangeVersusTarget(target)) || (allowMove && self.Info.HasTraitInfo<IMoveInfo>()));
@@ -427,9 +427,9 @@ namespace OpenRA.Mods.Common.Traits
 
 			public string OrderID { get; private set; }
 			public int OrderPriority { get; private set; }
-			public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
+			public bool TargetOverridesSelection(Actor self, in Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
 
-			bool CanTargetActor(Actor self, Target target, ref TargetModifiers modifiers, ref string cursor)
+			bool CanTargetActor(Actor self, in Target target, ref TargetModifiers modifiers, ref string cursor)
 			{
 				IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
 
@@ -505,7 +505,7 @@ namespace OpenRA.Mods.Common.Traits
 				return true;
 			}
 
-			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
+			public bool CanTarget(Actor self, in Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 			{
 				switch (target.Type)
 				{

--- a/OpenRA.Mods.Common/Traits/Attack/AttackCharges.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackCharges.cs
@@ -63,14 +63,14 @@ namespace OpenRA.Mods.Common.Traits
 			base.Tick(self);
 		}
 
-		protected override bool CanAttack(Actor self, Target target)
+		protected override bool CanAttack(Actor self, in Target target)
 		{
 			charging = base.CanAttack(self, target) && IsReachableTarget(target, true);
 			return ChargeLevel >= info.ChargeLevel && charging;
 		}
 
-		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel) { ChargeLevel = 0; }
-		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel) { }
+		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel) { ChargeLevel = 0; }
+		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel) { }
 		void INotifySold.Selling(Actor self) { ChargeLevel = 0; }
 		void INotifySold.Sold(Actor self) { }
 	}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits
 		bool opportunityForceAttack;
 		bool opportunityTargetIsPersistentTarget;
 
-		public void SetRequestedTarget(Actor self, Target target, bool isForceAttack = false)
+		public void SetRequestedTarget(Actor self, in Target target, bool isForceAttack = false)
 		{
 			RequestedTarget = target;
 			requestedForceAttack = isForceAttack;
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 			base.Created(self);
 		}
 
-		protected bool CanAimAtTarget(Actor self, Target target, bool forceAttack)
+		protected bool CanAimAtTarget(Actor self, in Target target, bool forceAttack)
 		{
 			if (target.Type == TargetType.Actor && !target.Actor.CanBeViewedByPlayer(self.Owner))
 				return false;
@@ -154,12 +154,12 @@ namespace OpenRA.Mods.Common.Traits
 			base.Tick(self);
 		}
 
-		public override Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
+		public override Activity GetAttackActivity(Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 		{
 			return new AttackActivity(self, newTarget, allowMove, forceAttack, targetLineColor);
 		}
 
-		public override void OnResolveAttackOrder(Actor self, Activity activity, Target target, bool queued, bool forceAttack)
+		public override void OnResolveAttackOrder(Actor self, Activity activity, in Target target, bool queued, bool forceAttack)
 		{
 			// We can improve responsiveness for turreted actors by preempting
 			// the last order (usually a move) and setting the target immediately
@@ -228,7 +228,7 @@ namespace OpenRA.Mods.Common.Traits
 			bool wasMovingWithinRange;
 			bool hasTicked;
 
-			public AttackActivity(Actor self, Target target, bool allowMove, bool forceAttack, Color? targetLineColor = null)
+			public AttackActivity(Actor self, in Target target, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 			{
 				attack = self.Trait<AttackFollow>();
 				move = allowMove ? self.TraitOrDefault<IMove>() : null;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 			Info = info;
 		}
 
-		protected override bool CanAttack(Actor self, Target target)
+		protected override bool CanAttack(Actor self, in Target target)
 		{
 			if (!base.CanAttack(self, target))
 				return false;
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 			return TargetInFiringArc(self, target, 4 * Info.FacingTolerance);
 		}
 
-		public override Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
+		public override Activity GetAttackActivity(Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 		{
 			return new Activities.Attack(self, newTarget, allowMove, forceAttack, targetLineColor);
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Common.Traits
 			return coords.Value.LocalToWorld(p.Offset.Rotate(bodyOrientation));
 		}
 
-		public override void DoAttack(Actor self, Target target)
+		public override void DoAttack(Actor self, in Target target)
 		{
 			if (!CanAttack(self, target))
 				return;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		public AttackOmni(Actor self, AttackOmniInfo info)
 			: base(self, info) { }
 
-		public override Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
+		public override Activity GetAttackActivity(Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 		{
 			return new SetTarget(this, newTarget, allowMove, forceAttack, targetLineColor);
 		}
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 			readonly Color? targetLineColor;
 			Target target;
 
-			public SetTarget(AttackOmni attack, Target target, bool allowMove, bool forceAttack, Color? targetLineColor = null)
+			public SetTarget(AttackOmni attack, in Target target, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 			{
 				this.target = target;
 				this.targetLineColor = targetLineColor;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 			turrets = self.TraitsImplementing<Turreted>().Where(t => info.Turrets.Contains(t.Info.Turret)).ToArray();
 		}
 
-		protected override bool CanAttack(Actor self, Target target)
+		protected override bool CanAttack(Actor self, in Target target)
 		{
 			if (target.Type == TargetType.Invalid)
 				return false;

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -312,7 +312,7 @@ namespace OpenRA.Mods.Common.Traits
 				Attack(self, target, allowMove);
 		}
 
-		void Attack(Actor self, Target target, bool allowMove)
+		void Attack(Actor self, in Target target, bool allowMove)
 		{
 			foreach (var ab in ActiveAttackBases)
 				ab.AttackTarget(target, AttackSource.AutoTarget, false, allowMove);

--- a/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID == OrderID)
 				return new Order(order.OrderID, self, false);

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.Traits
 			get { yield return new RallyPointOrderTargeter(Info.Cursor); }
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID == OrderID)
 			{
@@ -140,11 +140,11 @@ namespace OpenRA.Mods.Common.Traits
 
 			public string OrderID { get { return "SetRallyPoint"; } }
 			public int OrderPriority { get { return 0; } }
-			public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
+			public bool TargetOverridesSelection(Actor self, in Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
 			public bool ForceSet { get; private set; }
 			public bool IsQueued { get; protected set; }
 
-			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
+			public bool CanTarget(Actor self, in Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 			{
 				if (target.Type != TargetType.Terrain)
 					return false;

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		// Note: Returns a valid order even if the unit can't move to the target
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID == "Enter" || order.OrderID == "Move")
 				return new Order(order.OrderID, self, target, queued);
@@ -168,7 +168,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			readonly TransformsIntoAircraft aircraft;
 
-			public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers)
+			public bool TargetOverridesSelection(Actor self, in Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers)
 			{
 				// Always prioritise orders over selecting other peoples actors or own actors that are already selected
 				if (target.Type == TargetType.Actor && (target.Actor.Owner != self.Owner || self.World.Selection.Contains(target.Actor)))
@@ -186,7 +186,7 @@ namespace OpenRA.Mods.Common.Traits
 			public int OrderPriority { get { return 4; } }
 			public bool IsQueued { get; protected set; }
 
-			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
+			public bool CanTarget(Actor self, in Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 			{
 				if (target.Type != TargetType.Terrain || (aircraft.Info.RequiresForceMove && !modifiers.HasModifier(TargetModifiers.ForceMove)))
 					return false;

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoEntersTunnels.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoEntersTunnels.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Traits
 			return self.CurrentActivity is Transform || transforms.Any(t => !t.IsTraitDisabled && !t.IsTraitPaused);
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID == "EnterTunnel")
 				return new Order(order.OrderID, self, target, queued) { SuppressVisualFeedback = true };

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		// Note: Returns a valid order even if the unit can't move to the target
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order is MoveOrderTargeter)
 				return new Order("Move", self, target, queued);
@@ -159,7 +159,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			readonly TransformsIntoMobile mobile;
 			readonly bool rejectMove;
-			public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers)
+			public bool TargetOverridesSelection(Actor self, in Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers)
 			{
 				// Always prioritise orders over selecting other peoples actors or own actors that are already selected
 				if (target.Type == TargetType.Actor && (target.Actor.Owner != self.Owner || self.World.Selection.Contains(target.Actor)))
@@ -178,7 +178,7 @@ namespace OpenRA.Mods.Common.Traits
 			public int OrderPriority { get { return 4; } }
 			public bool IsQueued { get; protected set; }
 
-			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
+			public bool CanTarget(Actor self, in Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 			{
 				if (rejectMove || target.Type != TargetType.Terrain || (mobile.Info.RequiresForceMove && !modifiers.HasModifier(TargetModifiers.ForceMove)))
 					return false;

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoPassenger.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoPassenger.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID == "EnterTransport")
 				return new Order(order.OrderID, self, target, queued);

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoRepairable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoRepairable.cs
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Common.Traits
 			return Info.RepairActors.Contains(target.Info.Name);
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID == "Repair")
 				return new Order(order.OrderID, self, target, queued);

--- a/OpenRA.Mods.Common/Traits/Captures.cs
+++ b/OpenRA.Mods.Common/Traits/Captures.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID != "CaptureActor")
 				return null;

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -208,7 +208,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID == "Unload")
 				return new Order(order.OrderID, self, queued);

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -285,7 +285,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID == "PickupUnit" || order.OrderID == "DeliverUnit" || order.OrderID == "Unload")
 				return new Order(order.OrderID, self, target, queued);
@@ -383,7 +383,7 @@ namespace OpenRA.Mods.Common.Traits
 			public string OrderID { get { return "DeliverUnit"; } }
 			public int OrderPriority { get { return 6; } }
 			public bool IsQueued { get; protected set; }
-			public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
+			public bool TargetOverridesSelection(Actor self, in Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
 
 			public CarryallDeliverUnitTargeter(AircraftInfo aircraftInfo, CarryallInfo info)
 			{
@@ -391,7 +391,7 @@ namespace OpenRA.Mods.Common.Traits
 				this.info = info;
 			}
 
-			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
+			public bool CanTarget(Actor self, in Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 			{
 				if (!info.AllowDropOff || !modifiers.HasModifier(TargetModifiers.ForceMove))
 					return false;

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -108,9 +108,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void Uncloak(int time) { remainingTime = Math.Max(remainingTime, time); }
 
-		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel) { if (Info.UncloakOn.HasFlag(UncloakType.Attack)) Uncloak(); }
+		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel) { if (Info.UncloakOn.HasFlag(UncloakType.Attack)) Uncloak(); }
 
-		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel) { }
+		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel) { }
 
 		void INotifyDamage.Damaged(Actor self, AttackInfo e)
 		{

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnAttack.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnAttack.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		bool TargetChanged(Target lastTarget, Target target)
+		bool TargetChanged(in Target lastTarget, in Target target)
 		{
 			// Invalidate reveal changing the target.
 			if (lastTarget.Type == TargetType.FrozenActor && target.Type == TargetType.Actor)
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Common.Traits
 			return false;
 		}
 
-		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel)
+		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
 			if (IsTraitDisabled || IsTraitPaused)
 				return;
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel) { }
+		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel) { }
 
 		protected override void TraitDisabled(Actor self)
 		{

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -172,7 +172,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID == "GrantConditionOnDeploy")
 				return new Order(order.OrderID, self, target, queued);

--- a/OpenRA.Mods.Common/Traits/DeliversCash.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversCash.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 			get { yield return new DeliversCashOrderTargeter(info); }
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID != "DeliverCash")
 				return null;

--- a/OpenRA.Mods.Common/Traits/DeliversExperience.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversExperience.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID != "DeliverExperience")
 				return null;

--- a/OpenRA.Mods.Common/Traits/Demolition.cs
+++ b/OpenRA.Mods.Common/Traits/Demolition.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 			get { yield return new DemolitionOrderTargeter(info); }
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID != "C4")
 				return null;

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID != "EngineerRepair")
 				return null;

--- a/OpenRA.Mods.Common/Traits/EntersTunnels.cs
+++ b/OpenRA.Mods.Common/Traits/EntersTunnels.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 			return !requireForceMove || modifiers.HasModifier(TargetModifiers.ForceMove);
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID != "EnterTunnel")
 				return null;

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -294,7 +294,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID == "Deliver" || order.OrderID == "Harvest")
 				return new Order(order.OrderID, self, target, queued);
@@ -364,9 +364,9 @@ namespace OpenRA.Mods.Common.Traits
 			public string OrderID { get { return "Harvest"; } }
 			public int OrderPriority { get { return 10; } }
 			public bool IsQueued { get; protected set; }
-			public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
+			public bool TargetOverridesSelection(Actor self, in Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
 
-			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
+			public bool CanTarget(Actor self, in Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 			{
 				if (target.Type != TargetType.Terrain)
 					return false;

--- a/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
@@ -88,13 +88,13 @@ namespace OpenRA.Mods.Common.Traits
 				Panic();
 		}
 
-		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel)
+		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
 			if (self.World.SharedRandom.Next(100) < info.AttackPanicChance)
 				Panic();
 		}
 
-		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel) { }
+		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel) { }
 
 		int ISpeedModifier.GetSpeedModifier()
 		{

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -602,19 +602,19 @@ namespace OpenRA.Mods.Common.Traits
 			return WrapMove(new Move(self, cell, WDist.FromCells(nearEnough), ignoreActor, evaluateNearestMovableCell, targetLineColor));
 		}
 
-		public Activity MoveWithinRange(Target target, WDist range,
+		public Activity MoveWithinRange(in Target target, WDist range,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
 			return WrapMove(new MoveWithinRange(self, target, WDist.Zero, range, initialTargetPosition, targetLineColor));
 		}
 
-		public Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange,
+		public Activity MoveWithinRange(in Target target, WDist minRange, WDist maxRange,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
 			return WrapMove(new MoveWithinRange(self, target, minRange, maxRange, initialTargetPosition, targetLineColor));
 		}
 
-		public Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange,
+		public Activity MoveFollow(Actor self, in Target target, WDist minRange, WDist maxRange,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
 			return WrapMove(new Follow(self, target, minRange, maxRange, initialTargetPosition, targetLineColor));
@@ -675,7 +675,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public Activity MoveToTarget(Actor self, Target target,
+		public Activity MoveToTarget(Actor self, in Target target,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
 			if (target.Type == TargetType.Invalid)
@@ -684,7 +684,7 @@ namespace OpenRA.Mods.Common.Traits
 			return WrapMove(new MoveAdjacentTo(self, target, initialTargetPosition, targetLineColor));
 		}
 
-		public Activity MoveIntoTarget(Actor self, Target target)
+		public Activity MoveIntoTarget(Actor self, in Target target)
 		{
 			if (target.Type == TargetType.Invalid)
 				return null;
@@ -711,7 +711,7 @@ namespace OpenRA.Mods.Common.Traits
 			return NearestMoveableCell(target, 1, 10);
 		}
 
-		public bool CanEnterTargetNow(Actor self, Target target)
+		public bool CanEnterTargetNow(Actor self, in Target target)
 		{
 			if (target.Type == TargetType.FrozenActor && !target.FrozenActor.IsValid)
 				return false;
@@ -904,7 +904,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		// Note: Returns a valid order even if the unit can't move to the target
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order is MoveOrderTargeter)
 				return new Order("Move", self, target, queued);
@@ -968,7 +968,7 @@ namespace OpenRA.Mods.Common.Traits
 			readonly Mobile mobile;
 			readonly LocomotorInfo locomotorInfo;
 			readonly bool rejectMove;
-			public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers)
+			public bool TargetOverridesSelection(Actor self, in Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers)
 			{
 				// Always prioritise orders over selecting other peoples actors or own actors that are already selected
 				if (target.Type == TargetType.Actor && (target.Actor.Owner != self.Owner || self.World.Selection.Contains(target.Actor)))
@@ -988,7 +988,7 @@ namespace OpenRA.Mods.Common.Traits
 			public int OrderPriority { get { return 4; } }
 			public bool IsQueued { get; protected set; }
 
-			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
+			public bool CanTarget(Actor self, in Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 			{
 				if (rejectMove || target.Type != TargetType.Terrain || (mobile.requireForceMove && !modifiers.HasModifier(TargetModifiers.ForceMove)))
 					return false;

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID == "EnterTransport")
 				return new Order(order.OrderID, self, target, queued);

--- a/OpenRA.Mods.Common/Traits/ReloadAmmoPool.cs
+++ b/OpenRA.Mods.Common/Traits/ReloadAmmoPool.cs
@@ -66,13 +66,13 @@ namespace OpenRA.Mods.Common.Traits
 			});
 		}
 
-		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel)
+		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
 			if (Info.ResetOnFire)
 				remainingTicks = Util.ApplyPercentageModifiers(Info.Delay, modifiers.Select(m => m.GetReloadAmmoModifier()));
 		}
 
-		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel) { }
+		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel) { }
 
 		void ITick.Tick(Actor self)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/WithAttackAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAttackAnimation.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				wsb.PlayCustomAnimation(self, Info.Sequence);
 		}
 
-		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel)
+		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
 			if (a == armament && Info.DelayRelativeTo == AttackDelayType.Attack)
 			{
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			}
 		}
 
-		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel)
+		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel)
 		{
 			if (a == armament && Info.DelayRelativeTo == AttackDelayType.Preparation)
 			{

--- a/OpenRA.Mods.Common/Traits/Render/WithAttackOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAttackOverlay.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			overlay.PlayThen(info.Sequence, () => attacking = false);
 		}
 
-		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel)
+		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
 			if (info.DelayRelativeTo == AttackDelayType.Attack)
 			{
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			}
 		}
 
-		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel)
+		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel)
 		{
 			if (info.DelayRelativeTo == AttackDelayType.Preparation)
 			{

--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -133,7 +133,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			}
 		}
 
-		public void Attacking(Actor self, Target target, Armament a)
+		public void Attacking(Actor self, in Target target, Armament a)
 		{
 			var info = GetDisplayInfo();
 			if (!info.AttackSequences.TryGetValue(a.Info.Name, out var sequence))
@@ -146,12 +146,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 			}
 		}
 
-		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel)
+		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel)
 		{
 			Attacking(self, target, a);
 		}
 
-		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel) { }
+		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel) { }
 
 		void ITick.Tick(Actor self)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			}
 		}
 
-		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel)
+		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
 			if (a == null || barrel == null || !armaments.Contains(a))
 				return;
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			anims[barrel].Animation.PlayThen(sequence, () => visible[barrel] = false);
 		}
 
-		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel) { }
+		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel) { }
 
 		IEnumerable<IRenderable> IRender.Render(Actor self, WorldRenderer wr)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/WithTurretAttackAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurretAttackAnimation.cs
@@ -64,13 +64,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 				PlayAttackAnimation(self);
 		}
 
-		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel)
+		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
 			if (!IsTraitDisabled && a == armament && Info.DelayRelativeTo == AttackDelayType.Attack)
 				NotifyAttack(self);
 		}
 
-		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel)
+		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel)
 		{
 			if (!IsTraitDisabled && a == armament && Info.DelayRelativeTo == AttackDelayType.Preparation)
 				NotifyAttack(self);

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID == "Repair")
 				return new Order(order.OrderID, self, target, queued);

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID == "RepairNear")
 				return new Order(order.OrderID, self, target, queued);

--- a/OpenRA.Mods.Common/Traits/RepairsBridges.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsBridges.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 			get { yield return new RepairBridgeOrderTargeter(info); }
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID == "RepairBridge")
 				return new Order(order.OrderID, self, target, queued);

--- a/OpenRA.Mods.Common/Traits/RevealOnFire.cs
+++ b/OpenRA.Mods.Common/Traits/RevealOnFire.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 		}
 
-		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel)
+		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
 			if (IsTraitDisabled)
 				return;
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		Player GetTargetPlayer(Target target)
+		Player GetTargetPlayer(in Target target)
 		{
 			if (target.Type == TargetType.Actor)
 				return target.Actor.Owner;
@@ -74,6 +74,6 @@ namespace OpenRA.Mods.Common.Traits
 			return null;
 		}
 
-		void INotifyAttack.PreparingAttack(Actor self, OpenRA.Traits.Target target, Armament a, Barrel barrel) { }
+		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Sound/AttackSounds.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AttackSounds.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 				Game.Sound.Play(SoundType.World, info.Sounds, self.World, self.CenterPosition);
 		}
 
-		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel)
+		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
 			if (info.DelayRelativeTo == AttackDelayType.Attack)
 			{
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 			}
 		}
 
-		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel)
+		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel)
 		{
 			if (info.DelayRelativeTo == AttackDelayType.Preparation)
 			{

--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -108,7 +108,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
 			if (order.OrderID == "DeployTransform")
 				return new Order(order.OrderID, self, queued);

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -250,7 +250,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public bool FaceTarget(Actor self, Target target)
+		public bool FaceTarget(Actor self, in Target target)
 		{
 			if (IsTraitDisabled || IsTraitPaused || attack == null || attack.IsTraitDisabled || attack.IsTraitPaused)
 				return false;

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -110,8 +110,8 @@ namespace OpenRA.Mods.Common.Traits
 	[RequireExplicitImplementation]
 	public interface INotifyAttack
 	{
-		void Attacking(Actor self, Target target, Armament a, Barrel barrel);
-		void PreparingAttack(Actor self, Target target, Armament a, Barrel barrel);
+		void Attacking(Actor self, in Target target, Armament a, Barrel barrel);
+		void PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel);
 	}
 
 	[RequireExplicitImplementation]
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Common.Traits
 	public interface INotifySupportPower { void Charged(Actor self); void Activated(Actor self); }
 
 	public interface INotifyBuildingPlaced { void BuildingPlaced(Actor self); }
-	public interface INotifyBurstComplete { void FiredBurst(Actor self, Target target, Armament a); }
+	public interface INotifyBurstComplete { void FiredBurst(Actor self, in Target target, Armament a); }
 	public interface INotifyChat { bool OnChat(string from, string message); }
 	public interface INotifyProduction { void UnitProduced(Actor self, Actor other, CPos exit); }
 	public interface INotifyOtherProduction { void UnitProducedByOther(Actor self, Actor producer, Actor produced, string productionType, TypeDictionary init); }
@@ -414,21 +414,21 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		Activity MoveTo(CPos cell, int nearEnough = 0, Actor ignoreActor = null,
 		 	bool evaluateNearestMovableCell = false, Color? targetLineColor = null);
-		Activity MoveWithinRange(Target target, WDist range,
+		Activity MoveWithinRange(in Target target, WDist range,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null);
-		Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange,
+		Activity MoveWithinRange(in Target target, WDist minRange, WDist maxRange,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null);
-		Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange,
+		Activity MoveFollow(Actor self, in Target target, WDist minRange, WDist maxRange,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null);
-		Activity MoveToTarget(Actor self, Target target,
+		Activity MoveToTarget(Actor self, in Target target,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null);
 		Activity ReturnToCell(Actor self);
-		Activity MoveIntoTarget(Actor self, Target target);
+		Activity MoveIntoTarget(Actor self, in Target target);
 		Activity VisualMove(Actor self, WPos fromPos, WPos toPos);
 		int EstimatedMoveDuration(Actor self, WPos fromPos, WPos toPos);
 		CPos NearestMoveableCell(CPos target);
 		MovementType CurrentMovementTypes { get; set; }
-		bool CanEnterTargetNow(Actor self, Target target);
+		bool CanEnterTargetNow(Actor self, in Target target);
 	}
 
 	public interface IWrapMove

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -162,7 +162,7 @@ namespace OpenRA.Mods.Common
 			return cells.SelectMany(c => Neighbours(c, allowDiagonal)).Distinct();
 		}
 
-		public static IEnumerable<CPos> AdjacentCells(World w, Target target)
+		public static IEnumerable<CPos> AdjacentCells(World w, in Target target)
 		{
 			var cells = target.Positions.Select(p => w.Map.CellContaining(p)).Distinct();
 			return ExpandFootprint(cells, true);

--- a/OpenRA.Mods.Common/Warheads/ChangeOwnerWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/ChangeOwnerWarhead.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Warheads
 
 		public readonly WDist Range = WDist.FromCells(1);
 
-		public override void DoImpact(Target target, WarheadArgs args)
+		public override void DoImpact(in Target target, WarheadArgs args)
 		{
 			var firedBy = args.SourceActor;
 			var actors = target.Type == TargetType.Actor ? new[] { target.Actor } :

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Warheads
 			return true;
 		}
 
-		public override void DoImpact(Target target, WarheadArgs args)
+		public override void DoImpact(in Target target, WarheadArgs args)
 		{
 			if (target.Type == TargetType.Invalid)
 				return;

--- a/OpenRA.Mods.Common/Warheads/CreateResourceWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateResourceWarhead.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Warheads
 		}
 
 		// TODO: Allow maximum resource splatter to be defined. (Per tile, and in total).
-		public override void DoImpact(Target target, WarheadArgs args)
+		public override void DoImpact(in Target target, WarheadArgs args)
 		{
 			if (target.Type == TargetType.Invalid)
 				return;

--- a/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Warheads
 			return base.IsValidAgainst(victim, firedBy);
 		}
 
-		public override void DoImpact(Target target, WarheadArgs args)
+		public override void DoImpact(in Target target, WarheadArgs args)
 		{
 			var firedBy = args.SourceActor;
 

--- a/OpenRA.Mods.Common/Warheads/DestroyResourceWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DestroyResourceWarhead.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Warheads
 		public readonly int[] Size = { 0, 0 };
 
 		// TODO: Allow maximum resource removal to be defined. (Per tile, and in total).
-		public override void DoImpact(Target target, WarheadArgs args)
+		public override void DoImpact(in Target target, WarheadArgs args)
 		{
 			if (target.Type == TargetType.Invalid)
 				return;

--- a/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Warheads
 				throw new YamlException("Weapons Ruleset does not contain an entry '{0}'".F(Weapon.ToLowerInvariant()));
 		}
 
-		public override void DoImpact(Target target, WarheadArgs args)
+		public override void DoImpact(in Target target, WarheadArgs args)
 		{
 			if (target.Type == TargetType.Invalid)
 				return;

--- a/OpenRA.Mods.Common/Warheads/FlashPaletteEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/FlashPaletteEffectWarhead.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("Duration of the flashing, measured in ticks. Set to -1 to default to the `Length` of the `FlashPaletteEffect`.")]
 		public readonly int Duration = 0;
 
-		public override void DoImpact(Target target, WarheadArgs args)
+		public override void DoImpact(in Target target, WarheadArgs args)
 		{
 			foreach (var flash in args.SourceActor.World.WorldActor.TraitsImplementing<FlashPaletteEffect>())
 				if (flash.Info.Type == FlashType)

--- a/OpenRA.Mods.Common/Warheads/GrantExternalConditionWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/GrantExternalConditionWarhead.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Warheads
 
 		public readonly WDist Range = WDist.FromCells(1);
 
-		public override void DoImpact(Target target, WarheadArgs args)
+		public override void DoImpact(in Target target, WarheadArgs args)
 		{
 			var firedBy = args.SourceActor;
 			var actors = target.Type == TargetType.Actor ? new[] { target.Actor } :

--- a/OpenRA.Mods.Common/Warheads/LeaveSmudgeWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/LeaveSmudgeWarhead.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("Percentual chance the smudge is created.")]
 		public readonly int Chance = 100;
 
-		public override void DoImpact(Target target, WarheadArgs args)
+		public override void DoImpact(in Target target, WarheadArgs args)
 		{
 			if (target.Type == TargetType.Invalid)
 				return;

--- a/OpenRA.Mods.Common/Warheads/ShakeScreenWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/ShakeScreenWarhead.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("Shake multipliers by the X and Y axis, comma-separated.")]
 		public readonly float2 Multiplier = new float2(0, 0);
 
-		public override void DoImpact(Target target, WarheadArgs args)
+		public override void DoImpact(in Target target, WarheadArgs args)
 		{
 			args.SourceActor.World.WorldActor.Trait<ScreenShaker>().AddEffect(Duration, target.CenterPosition, Intensity, Multiplier);
 		}

--- a/OpenRA.Mods.Common/Warheads/Warhead.cs
+++ b/OpenRA.Mods.Common/Warheads/Warhead.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Warheads
 		}
 
 		/// <summary>Applies the warhead's effect against the target.</summary>
-		public abstract void DoImpact(Target target, WarheadArgs args);
+		public abstract void DoImpact(in Target target, WarheadArgs args);
 
 		/// <summary>Checks if the warhead is valid against (can do something to) the actor.</summary>
 		public virtual bool IsValidAgainst(Actor victim, Actor firedBy)

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.D2k.Activities
 		AttackState stance;
 		int attackingToken = Actor.InvalidConditionToken;
 
-		public SwallowActor(Actor self, Target target, Armament a, IFacing facing)
+		public SwallowActor(Actor self, in Target target, Armament a, IFacing facing)
 		{
 			this.target = target;
 			this.facing = facing;

--- a/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
+++ b/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.D2k.Traits
 			Info = info;
 		}
 
-		public override void DoAttack(Actor self, Target target)
+		public override void DoAttack(Actor self, in Target target)
 		{
 			// This is so that the worm does not launch an attack against a target that has reached solid rock
 			if (target.Type != TargetType.Actor || !CanAttack(self, target))
@@ -70,14 +70,14 @@ namespace OpenRA.Mods.D2k.Traits
 			self.QueueActivity(false, new SwallowActor(self, target, a, facing));
 		}
 
-		public override Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
+		public override Activity GetAttackActivity(Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
 		{
 			return new SwallowTarget(self, newTarget, allowMove, forceAttack);
 		}
 
 		public class SwallowTarget : Attack
 		{
-			public SwallowTarget(Actor self, Target target, bool allowMovement, bool forceAttack)
+			public SwallowTarget(Actor self, in Target target, bool allowMovement, bool forceAttack)
 				: base(self, target, allowMovement, forceAttack) { }
 
 			protected override Target RecalculateTarget(Actor self, out bool targetIsHiddenActor)

--- a/OpenRA.Mods.D2k/Warheads/DamagesConcreteWarhead.cs
+++ b/OpenRA.Mods.D2k/Warheads/DamagesConcreteWarhead.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.D2k.Warheads
 		[FieldLoader.Require]
 		public readonly int Damage = 0;
 
-		public override void DoImpact(Target target, WarheadArgs args)
+		public override void DoImpact(in Target target, WarheadArgs args)
 		{
 			if (target.Type == TargetType.Invalid)
 				return;


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/dotnet/csharp/write-safe-efficient-code#apply-the-in-modifier-to-readonly-struct-parameters-larger-than-systemintptrsize we should use the `in` modifier to readonly structs that are larger than IntPtr.Size (which is 8 byte), Our `Target` struct is 72 bytes in size.

Also did a benchmark, did not show any big (or at all?) performance improvement, we should see a bigger improvement in a game with many orders running. 
![image](https://user-images.githubusercontent.com/19173272/90677608-e2047400-e25d-11ea-9982-f43829dd6952.png)
