### PR TITLE
Fix a crash when updating the DiscordPresence party size

### DIFF
--- a/OpenRA.Mods.Common/DiscordService.cs
+++ b/OpenRA.Mods.Common/DiscordService.cs
@@ -169,6 +169,22 @@ namespace OpenRA.Mods.Common
 			currentState = state;
 		}
 
+		void UpdateParty(int players, int slots)
+		{
+			if (client.CurrentPresence.Party != null)
+			{
+				client.UpdatePartySize(players, slots);
+				return;
+			}
+
+			client.UpdateParty(new Party
+			{
+				ID = Secrets.CreateFriendlySecret(new Random()),
+				Size = players,
+				Max = slots
+			});
+		}
+
 		public void Dispose()
 		{
 			if (client != null)
@@ -186,7 +202,7 @@ namespace OpenRA.Mods.Common
 
 		public static void UpdatePlayers(int players, int slots)
 		{
-			Service?.client.UpdatePartySize(players, slots);
+			Service?.UpdateParty(players, slots);
 		}
 
 		public static void UpdateDetails(string details)

--- a/OpenRA.Mods.Common/DiscordService.cs
+++ b/OpenRA.Mods.Common/DiscordService.cs
@@ -36,16 +36,19 @@ namespace OpenRA.Mods.Common
 		DiscordState currentState;
 
 		static DiscordService instance;
-		static DiscordService GetService()
+		static DiscordService Service
 		{
-			if (instance != null)
+			get
+			{
+				if (instance != null)
+					return instance;
+
+				if (!Game.ModData.Manifest.Contains<DiscordService>())
+					return null;
+
+				instance = Game.ModData.Manifest.Get<DiscordService>();
 				return instance;
-
-			if (!Game.ModData.Manifest.Contains<DiscordService>())
-				return null;
-
-			instance = Game.ModData.Manifest.Get<DiscordService>();
-			return instance;
+			}
 		}
 
 		public DiscordService(MiniYaml yaml)
@@ -178,12 +181,12 @@ namespace OpenRA.Mods.Common
 
 		public static void UpdateStatus(DiscordState state, string details = null, string secret = null, int? players = null, int? slots = null)
 		{
-			GetService()?.SetStatus(state, details, secret, players, slots);
+			Service?.SetStatus(state, details, secret, players, slots);
 		}
 
 		public static void SetPlayers(int players, int slots)
 		{
-			GetService()?.client.UpdateParty(new Party
+			Service?.client.UpdateParty(new Party
 			{
 				ID = Secrets.CreateFriendlySecret(new Random()),
 				Size = players,
@@ -193,12 +196,12 @@ namespace OpenRA.Mods.Common
 
 		public static void UpdatePlayers(int players, int slots)
 		{
-			GetService()?.client.UpdatePartySize(players, slots);
+			Service?.client.UpdatePartySize(players, slots);
 		}
 
 		public static void UpdateDetails(string details)
 		{
-			GetService()?.client.UpdateDetails(details);
+			Service?.client.UpdateDetails(details);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/DiscordService.cs
+++ b/OpenRA.Mods.Common/DiscordService.cs
@@ -184,16 +184,6 @@ namespace OpenRA.Mods.Common
 			Service?.SetStatus(state, details, secret, players, slots);
 		}
 
-		public static void SetPlayers(int players, int slots)
-		{
-			Service?.client.UpdateParty(new Party
-			{
-				ID = Secrets.CreateFriendlySecret(new Random()),
-				Size = players,
-				Max = slots
-			});
-		}
-
 		public static void UpdatePlayers(int players, int slots)
 		{
 			Service?.client.UpdatePartySize(players, slots);

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -784,6 +784,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				if (!skirmishMode)
 					DiscordService.UpdatePlayers(numberOfPlayers, slots);
+
 				DiscordService.UpdateDetails(mapTitle);
 			}
 		}


### PR DESCRIPTION
Closes #18508.

I'm not quite sure what causes this but it must be some sort of race condition within the Discord Service, since the party was certainly not set to null moments before the crash and after putting a band aid over the crash the next call (directly following the player size update at https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs#L787) revealed the party was set again.