### PR TITLE
Fix AttackMove moving units while targets are in range

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
+++ b/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
@@ -56,8 +56,9 @@ namespace OpenRA.Mods.Common.Activities
 			// We are currently not attacking, so scan for new targets.
 			if (autoTarget != null && (ChildActivity == null || runningInnerActivity))
 			{
-				// ScanForTarget already limits the scanning rate for performance so we don't need to do that here.
-				target = autoTarget.ScanForTarget(self, false, true);
+				// Use the standard ScanForTarget rate limit while we are running the inner move activity to save performance.
+				// Override the rate limit if our attack activity has completed so we can immediately acquire a new target instead of moving.
+				target = autoTarget.ScanForTarget(self, false, true, !runningInnerActivity);
 
 				// Cancel the current inner activity and queue attack activities if we find a new target.
 				if (target.Type != TargetType.Invalid)

--- a/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
+++ b/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
@@ -21,8 +21,9 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly Func<Activity> getInner;
 		readonly bool isAssaultMove;
-		AutoTarget autoTarget;
-		AttackMove attackMove;
+		readonly AutoTarget autoTarget;
+		readonly AttackMove attackMove;
+
 		int token = Actor.InvalidConditionToken;
 
 		public AttackMoveActivity(Actor self, Func<Activity> getInner, bool assaultMoving = false)

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -279,15 +279,16 @@ namespace OpenRA.Mods.Common.Traits
 				--nextScanTime;
 		}
 
-		public Target ScanForTarget(Actor self, bool allowMove, bool allowTurn)
+		public Target ScanForTarget(Actor self, bool allowMove, bool allowTurn, bool ignoreScanInterval = false)
 		{
-			if (nextScanTime <= 0 && ActiveAttackBases.Any())
+			if ((ignoreScanInterval || nextScanTime <= 0) && ActiveAttackBases.Any())
 			{
 				foreach (var dat in disableAutoTarget)
 					if (dat.DisableAutoTarget(self))
 						return Target.Invalid;
 
-				nextScanTime = self.World.SharedRandom.Next(Info.MinimumScanTimeInterval, Info.MaximumScanTimeInterval);
+				if (!ignoreScanInterval)
+					nextScanTime = self.World.SharedRandom.Next(Info.MinimumScanTimeInterval, Info.MaximumScanTimeInterval);
 
 				foreach (var ab in ActiveAttackBases)
 				{


### PR DESCRIPTION
The first two commits refactor the activity to be more conservative with resources. Previously it would always queue the inner (move) activity, then scan for targets and immediately cancel the inner activity again (without ever running it) if we found a target and repeat that after each attack activity finished. That means attack moving into many targets would create and discard several unused move activities (and call wrap move).

The third commit lets us bypass the rate-limiting of `AutoTarget`. We only need the limiting while performing the inner activity (move). In case we just finished an attack activity we immediately need to rescan for a new target before starting to move again.

Bleed (dead if rifles instead of medics):
![attackTarget1](https://user-images.githubusercontent.com/7704140/90907427-3f6e0180-e3d3-11ea-8a4c-9f3e815bb564.gif)
This PR (not dead):
![attackTarget2](https://user-images.githubusercontent.com/7704140/90907442-4563e280-e3d3-11ea-96b8-c4d3f1fe58c4.gif)

Closes #18542.