### PR TITLE
Renamed SmudgeLayer smoke fields and set defaults to zero/null

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.Common.Traits
 				throw new InvalidDataException("Smudges specify different blend modes. "
 					+ "Try using different smudge types for smudges that use different blend modes.");
 
-			render = new TerrainSpriteLayer(w, wr, sheet, blendMode, wr.Palette(Info.Palette), wr.World.Type != WorldType.Editor);
+			render = new TerrainSpriteLayer(w, wr, sheet, blendMode, wr.Palette(Info.Palette), w.Type != WorldType.Editor);
 
 			// Add map smudges
 			foreach (var kv in Info.InitialSmudges)
@@ -184,7 +184,7 @@ namespace OpenRA.Mods.Common.Traits
 			var remove = new List<CPos>();
 			foreach (var kv in dirty)
 			{
-				if (!self.World.FogObscures(kv.Key))
+				if (!world.FogObscures(kv.Key))
 				{
 					// A null Sequence
 					if (kv.Value.Sequence == null)

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -32,13 +32,15 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sprite sequence name")]
 		public readonly string Sequence = "scorch";
 
-		public readonly int SmokePercentage = 25;
+		[Desc("Chance of smoke rising from the ground")]
+		public readonly int SmokeChance = 0;
 
-		[Desc("Sprite sequence name")]
-		public readonly string SmokeType = "smoke_m";
+		[Desc("Smoke sprite image name")]
+		public readonly string SmokeImage = null;
 
-		[SequenceReference(nameof(SmokeType))]
-		public readonly string SmokeSequence = "idle";
+		[SequenceReference(nameof(SmokeImage))]
+		[Desc("Smoke sprite sequences randomly chosen from")]
+		public readonly string[] SmokeSequences = { };
 
 		[PaletteReference]
 		public readonly string SmokePalette = "effect";
@@ -89,6 +91,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Dictionary<CPos, Smudge> dirty = new Dictionary<CPos, Smudge>();
 		readonly Dictionary<string, ISpriteSequence> smudges = new Dictionary<string, ISpriteSequence>();
 		readonly World world;
+		readonly bool hasSmoke;
 
 		TerrainSpriteLayer render;
 		bool disposed;
@@ -97,6 +100,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			Info = info;
 			world = self.World;
+			hasSmoke = !string.IsNullOrEmpty(info.SmokeImage) && info.SmokeSequences.Any();
 
 			var sequenceProvider = world.Map.Rules.Sequences;
 			var types = sequenceProvider.Sequences(Info.Sequence);
@@ -144,8 +148,9 @@ namespace OpenRA.Mods.Common.Traits
 			if (!world.Map.Contains(loc))
 				return;
 
-			if (Game.CosmeticRandom.Next(0, 100) <= Info.SmokePercentage)
-				world.AddFrameEndTask(w => w.Add(new SpriteEffect(world.Map.CenterOfCell(loc), w, Info.SmokeType, Info.SmokeSequence, Info.SmokePalette)));
+			if (hasSmoke && Game.CosmeticRandom.Next(0, 100) <= Info.SmokeChance)
+				world.AddFrameEndTask(w => w.Add(new SpriteEffect(
+					w.Map.CenterOfCell(loc), w, Info.SmokeImage, Info.SmokeSequences.Random(w.SharedRandom), Info.SmokePalette)));
 
 			// A null Sequence indicates a deleted smudge.
 			if ((!dirty.ContainsKey(loc) || dirty[loc].Sequence == null) && !tiles.ContainsKey(loc))

--- a/OpenRA.Mods.Common/UpdateRules/Rules/RenameSmudgeSmokeFields.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/RenameSmudgeSmokeFields.cs
@@ -1,0 +1,54 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RenameSmudgeSmokeFields : UpdateRule
+	{
+		public override string Name { get { return "Renamed smoke-related properties on SmudgeLayer."; } }
+		public override string Description
+		{
+			get
+			{
+				return "Renamed smoke-related properties on SmudgeLayer to be in line with comparable properties.\n" +
+					"Additionally, set the *Chance, *Image and *Sequences defaults to null.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var layer in actorNode.ChildrenMatching("SmudgeLayer"))
+			{
+				var chance = layer.LastChildMatching("SmokePercentage");
+				if (chance != null)
+					chance.RenameKey("SmokeChance");
+				else
+					layer.AddNode("SmokeChance", FieldSaver.FormatValue("25"));
+
+				var image = layer.LastChildMatching("SmokeType");
+				if (image != null)
+					image.RenameKey("SmokeImage");
+				else
+					layer.AddNode("SmokeImage", FieldSaver.FormatValue("smoke_m"));
+
+				var sequences = layer.LastChildMatching("SmokeSequence");
+				if (sequences != null)
+					sequences.RenameKey("SmokeSequences");
+				else
+					layer.AddNode("SmokeSequences", FieldSaver.FormatValue("idle"));
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -74,6 +74,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new ReplaceBurns(),
 				new RemoveMuzzleSplitFacings(),
 				new RemoveTurnToDock(),
+				new RenameSmudgeSmokeFields(),
 			})
 		};
 

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -1038,7 +1038,7 @@ ATWR:
 	-RenderRangeCircle:
 	WithRangeCircle:
 		Range: 7c0
-		Color: FFFF0080	
+		Color: FFFF0080
 	WithBuildingBib:
 		HasMinibib: true
 	Turreted:

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -179,10 +179,15 @@ World:
 	SmudgeLayer@SCORCH:
 		Type: Scorch
 		Sequence: scorches
-		SmokePercentage: 50
+		SmokeChance: 50
+		SmokeImage: smoke_m
+		SmokeSequences: idle
 	SmudgeLayer@CRATER:
 		Type: Crater
 		Sequence: craters
+		SmokeChance: 25
+		SmokeImage: smoke_m
+		SmokeSequences: idle
 	ResourceLayer:
 	ResourceClaimLayer:
 	WarheadDebugOverlay:

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -151,11 +151,9 @@ World:
 	SmudgeLayer@Rock:
 		Type: RockCrater
 		Sequence: rockcraters
-		SmokePercentage: 0
 	SmudgeLayer@Sand:
 		Type: SandCrater
 		Sequence: sandcraters
-		SmokePercentage: 0
 	MapCreeps:
 		CheckboxLabel: Worms
 		CheckboxDescription: Worms roam the map and devour unprepared forces

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -200,10 +200,15 @@ World:
 	SmudgeLayer@SCORCH:
 		Type: Scorch
 		Sequence: scorches
-		SmokePercentage: 50
+		SmokeChance: 50
+		SmokeImage: smoke_m
+		SmokeSequences: idle
 	SmudgeLayer@CRATER:
 		Type: Crater
 		Sequence: craters
+		SmokeChance: 25
+		SmokeImage: smoke_m
+		SmokeSequences: idle
 	ResourceLayer:
 	ResourceClaimLayer:
 	WarheadDebugOverlay:

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -254,29 +254,29 @@ World:
 	SmudgeLayer@SMALLSCORCH:
 		Type: SmallScorch
 		Sequence: smallscorches
-		SmokeType: smallfire
-		SmokePercentage: 50
+		SmokeImage: smallfire
+		SmokeSequences: idle
+		SmokeChance: 50
 	SmudgeLayer@MEDIUMSCORCH:
 		Type: MediumScorch
 		Sequence: mediumscorches
-		SmokeType: mediumfire
-		SmokePercentage: 75
+		SmokeImage: mediumfire
+		SmokeSequences: idle
+		SmokeChance: 75
 	SmudgeLayer@LARGESCORCH:
 		Type: LargeScorch
 		Sequence: largescorches
-		SmokeType: largefire
-		SmokePercentage: 100
+		SmokeImage: largefire
+		SmokeSequences: idle
+		SmokeChance: 100
 	SmudgeLayer@SMALLCRATER:
 		Type: SmallCrater
-		SmokeType: smallsmoke
 		Sequence: smallcraters
 	SmudgeLayer@MEDIUMCRATER:
 		Type: MediumCrater
-		SmokeType: smallsmoke
 		Sequence: mediumcraters
 	SmudgeLayer@LARGECRATER:
 		Type: LargeCrater
-		SmokeType: largesmoke
 		Sequence: largecraters
 	ResourceLayer:
 	BridgeLayer:


### PR DESCRIPTION
Smoke spawn chance, image and sequence defaults not being null has been an annoyance and source of crashes when setting up new projects that aren't based on TD or RA for quite some time, I ran into that more than once myself.
In fact, the 'smoke' defined for our TS mod craters was a placeholder to work around that (hence why this PR removes those entries).

Note: Please no scope-creeping towards a larger `SmudgeLayer` refactor :)

Note2: I have a (very small) follow-up for this, but I didn't want to run into rebase conflicts more than necessary, so I'll file that after this is merged.