### PR TITLE
Added a CI check for global scripts for Lua errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ check-scripts:
 	@echo "Checking for Lua syntax errors..."
 	@luac -p $(shell find mods/*/maps/* -iname '*.lua')
 	@luac -p $(shell find lua/* -iname '*.lua')
+	@luac -p $(shell find mods/*/bits/scripts/* -iname '*.lua')
 
 check:
 	@echo

--- a/make.ps1
+++ b/make.ps1
@@ -149,6 +149,10 @@ function Check-Scripts-Command
 		{
 			luac -p $script
 		}
+		foreach ($script in ls "mods/*/bits/scripts/*.lua")
+		{
+			luac -p $script
+		}
 		Write-Host "Check completed!" -ForegroundColor Green
 	}
 	else


### PR DESCRIPTION
It seems that was forgotten in https://github.com/OpenRA/OpenRA/pull/13592 https://github.com/OpenRA/OpenRA/pull/16568 and https://github.com/OpenRA/OpenRA/pull/18308. They are quite hidden in a directory that is actually for binary assets.