### PR TITLE
Use cached selected in SelectionDecorationsBase

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/SelectionDecorationsBase.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SelectionDecorationsBase.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (wr.Viewport.Zoom < wr.Viewport.MinZoom)
 				yield break;
 
-			var renderDecorations = self.World.Selection.Contains(self) ? selectedDecorations : decorations;
+			var renderDecorations = selected ? selectedDecorations : decorations;
 			foreach (var kv in renderDecorations)
 			{
 				var pos = GetDecorationPosition(self, wr, kv.Key);


### PR DESCRIPTION
I see no reason to not use this, so I think this was just an oversight.