### PR TITLE
Add a lobby option in D2k to disable Concretes.

### DIFF
--- a/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
-			if (!Info.StartOnThreshold)
+			if (!Info.StartOnThreshold || IsTraitDisabled)
 				return;
 
 			var safeTiles = 0;

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -410,6 +410,7 @@
 		TerrainTypes: Rock, Concrete
 		BuildSounds: BUILD1.WAV
 	D2kActorPreviewPlaceBuildingPreview:
+		RequiresPrerequisites: !global-auto-concrete
 		OverridePalette: placebuilding
 	RequiresBuildableArea:
 		AreaTypes: building
@@ -447,12 +448,20 @@
 		SellSounds: BUILD1.WAV
 	Guardable:
 		Range: 3c0
+	GrantConditionOnPrerequisite@AUTOCONCRETE:
+		Condition: auto-concrete
+		Prerequisites: global-auto-concrete
 	DamagedByTerrain:
+		RequiresCondition: !auto-concrete
 		Damage: 500
 		DamageInterval: 100
 		Terrain: Rock
 		DamageThreshold: 50
 		StartOnThreshold: true
+	LaysTerrain:
+		RequiresCondition: auto-concrete
+		TerrainTypes: Rock
+		Template: 88
 	ThrowsShrapnel:
 		Weapons: Debris, Debris2, Debris3, Debris4
 		Pieces: 2, 5

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -98,10 +98,17 @@ Player:
 		CashTickUpNotification: CashTickUp
 		CashTickDownNotification: CashTickDown
 	DeveloperMode:
-		CheckboxDisplayOrder: 7
+		CheckboxDisplayOrder: 8
 	BaseAttackNotifier:
 	Shroud:
 		FogCheckboxDisplayOrder: 3
+	LobbyPrerequisiteCheckbox@AUTOCONCRETE:
+		ID: autoconcrete
+		Label: Automatic Concrete
+		Description: Concrete foundations are automatically created beneath buildings
+		Enabled: False
+		DisplayOrder: 7
+		Prerequisites: global-auto-concrete
 	FrozenActorLayer:
 	HarvesterAttackNotifier:
 	PlayerStatistics:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -34,6 +34,7 @@ concretea:
 		Cost: 20
 	Buildable:
 		BuildPaletteOrder: 110
+		Prerequisites: ~!global-auto-concrete
 		BuildDuration: 62
 		BuildDurationModifier: 100
 
@@ -48,7 +49,7 @@ concreteb:
 		Cost: 50
 	Buildable:
 		BuildPaletteOrder: 210
-		Prerequisites: upgrade.conyard
+		Prerequisites: upgrade.conyard, ~!global-auto-concrete
 		BuildDuration: 94
 		BuildDurationModifier: 100
 
@@ -64,8 +65,7 @@ construction_yard:
 		Dimensions: 3,3
 		LocalCenterOffset: 0,-512,0
 	LaysTerrain:
-		TerrainTypes: Rock
-		Template: 88
+		-RequiresCondition:
 	WithBuildingBib:
 	Selectable:
 		Bounds: 96,64


### PR DESCRIPTION
PChote gave support on Discord when i said
> The issue is not using them doesn't give you much of a penalty, so you are better off not wasting time on them. Ideally you would only want concrete under the Wind Traps, since those give half power without concrete.
I would like to see concrete being a lobby option tbh. I think it was planned to be in the original, since there are unused UI icons for it. I think the button is in too in the UI code, but it is out of the screen and if you move it, the button doesn't do anything.

so i ended up implementing it. The name of the checkbox can be changed, i couldn't think of something better.