### PR TITLE
Add the ability for all remaining RA infantry to attack when garrisoned

### DIFF
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -472,6 +472,9 @@
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Armament:
 		Weapon: Pistol
+	Armament@GARRISONED:
+		Name: garrisoned
+		Weapon: Pistol
 	AttackFrontal:
 	WithInfantryBody:
 		DefaultAttackSequence: shoot

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -179,6 +179,9 @@ E3:
 		LocalOffset: 0,0,555
 	Armament@GARRISONED:
 		Name: garrisoned
+		Weapon: RedEye
+	Armament@GARRISONEDSECONDARY:
+		Name: garrisoned
 		Weapon: Dragon
 	TakeCover:
 		ProneOffset: 384,0,-395
@@ -337,6 +340,9 @@ SPY:
 		RequiresCondition: disguise
 	IgnoresDisguise:
 	Armament:
+		Weapon: SilencedPPK
+	Armament@GARRISONED:
+		Name: garrisoned
 		Weapon: SilencedPPK
 	AttackMove:
 		Voice: Move

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -712,6 +712,12 @@ PBOX:
 		Types: Infantry
 		MaxWeight: 1
 		InitialUnits: e1
+		PassengerConditions:
+			e3: RocketSoldier
+	WithRangeCircle@ROCKETSOLDIER:
+		Color: FFFF0080
+		Range: 5c0
+		RequiresCondition: RocketSoldier
 	-SpawnActorsOnSell:
 	AttackGarrisoned:
 		RequiresCondition: !build-incomplete


### PR DESCRIPTION
This is mostly a way overdue consistency change, it shouldn't have a any significant bearing on balance. It adds the ability to fire from a pillbox to Spy, Technician, and for Rocket Soldier to fire at air targets