### PR TITLE
Add dictionary support to [ActorReference]

### DIFF
--- a/OpenRA.Game/Traits/LintAttributes.cs
+++ b/OpenRA.Game/Traits/LintAttributes.cs
@@ -23,10 +23,21 @@ namespace OpenRA.Traits
 	[AttributeUsage(AttributeTargets.Field)]
 	public sealed class ActorReferenceAttribute : Attribute
 	{
-		public Type[] RequiredTraits;
-		public ActorReferenceAttribute(params Type[] requiredTraits)
+		public readonly Type[] RequiredTraits;
+		public readonly LintDictionaryReference DictionaryReference;
+
+		public ActorReferenceAttribute(Type[] requiredTraits,
+			LintDictionaryReference dictionaryReference = LintDictionaryReference.None)
 		{
 			RequiredTraits = requiredTraits;
+			DictionaryReference = dictionaryReference;
+		}
+
+		public ActorReferenceAttribute(Type requiredTrait = null,
+			LintDictionaryReference dictionaryReference = LintDictionaryReference.None)
+		{
+			RequiredTraits = requiredTrait != null ? new[] { requiredTrait } : new Type[0];
+			DictionaryReference = dictionaryReference;
 		}
 	}
 

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -89,6 +89,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			"Unload, Infiltrate, Demolish, Move.")]
 		public readonly RevealDisguiseType RevealDisguiseOn = RevealDisguiseType.Attack;
 
+		[ActorReference(dictionaryReference: LintDictionaryReference.Keys)]
 		[Desc("Conditions to grant when disguised as specified actor.",
 			"A dictionary of [actor id]: [condition].")]
 		public readonly Dictionary<string, string> DisguisedAsConditions = new Dictionary<string, string>();

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/DropPodsPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/DropPodsPower.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	{
 		[FieldLoader.Require]
 		[Desc("Drop pod unit")]
-		[ActorReference(typeof(AircraftInfo), typeof(FallsToEarthInfo))]
+		[ActorReference(new[] { typeof(AircraftInfo), typeof(FallsToEarthInfo) })]
 		public readonly string[] UnitTypes = null;
 
 		[Desc("Number of drop pods spawned.")]

--- a/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Lint
 			IReadOnlyDictionary<string, ActorInfo> dict,
 			ActorReferenceAttribute attribute)
 		{
-			var values = LintExts.GetFieldValues(traitInfo, fieldInfo, emitError);
+			var values = LintExts.GetFieldValues(traitInfo, fieldInfo, emitError, attribute.DictionaryReference);
 			foreach (var value in values)
 			{
 				if (value == null)

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -75,6 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 			"Condition can stack with multiple passengers.")]
 		public readonly string LoadedCondition = null;
 
+		[ActorReference(dictionaryReference: LintDictionaryReference.Keys)]
 		[Desc("Conditions to grant when specified actors are loaded inside the transport.",
 			"A dictionary of [actor id]: [condition].")]
 		public readonly Dictionary<string, string> PassengerConditions = new Dictionary<string, string>();

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -31,6 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The condition to grant to when this actor is loaded inside any transport.")]
 		public readonly string CargoCondition = null;
 
+		[ActorReference(dictionaryReference: LintDictionaryReference.Keys)]
 		[Desc("Conditions to grant when this actor is loaded inside specified transport.",
 			"A dictionary of [actor id]: [condition].")]
 		public readonly Dictionary<string, string> CargoConditions = new Dictionary<string, string>();


### PR DESCRIPTION
This adds a lint test to catch the footgun @Punsho discovered today on Discord, and for the other related traits.

Depends on #18514 - only the last two commits are new.