### PR TITLE
Adjust spawn label offset to center it

### DIFF
--- a/mods/cnc/metrics.yaml
+++ b/mods/cnc/metrics.yaml
@@ -15,3 +15,4 @@ Metrics:
 	NormalSelectionColor: FFFFFF
 	AltSelectionColor: 00FFFF
 	CtrlSelectionColor: FFFF00
+	SpawnLabelOffset: -1,1


### PR DESCRIPTION
This PR is in response to feedback received in #18425. The spawn letters appear to be visually off-center, biasing to the left. The main cause is the circle sprites being used for the circle is actually 19px wide in the original artwork for cnc. The other mods have a different circle that is 18px wide.

A better fix would be perhaps be increasing the circle in the artwork to 20px or reducing its size to 18px. Without changing that, applying a small label offset also appears to improve it.

While it isn't pixel perfect in all cases, overall I think they are more centered. This is a screenshot showing various map positions with this change

![image](https://user-images.githubusercontent.com/2775804/91626339-a9009800-e9f1-11ea-81e1-d21c455e4bc4.png)

vs unmodified

![image](https://user-images.githubusercontent.com/2775804/91626372-e82ee900-e9f1-11ea-9b75-3f2f3bf7d983.png)

The New Mandarins the A looks slightly too far to the right. Understanding Power the A looks fractionally too the right but the B looks better. I think the A character is the most problematic.

These maps look better (IMO)
Two Ponds
Hattrix
Break of Day
Burning Hammer
Carter's Ridge

I don't want to mix it in #18425 but since I am already modifying the artwork I might adjust the circles for cnc and see if that solves it better also.