### PR TITLE
Fixed a crash when defining multiple WithMakeAnimations

### DIFF
--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -56,15 +56,19 @@ namespace OpenRA.Mods.Common.Activities
 			foreach (var nt in self.TraitsImplementing<INotifyTransform>())
 				nt.BeforeTransform(self);
 
-			var makeAnimation = self.TraitOrDefault<WithMakeAnimation>();
-			if (!SkipMakeAnims && makeAnimation != null)
+			var makeAnimations = self.TraitsImplementing<WithMakeAnimation>();
+			if (!SkipMakeAnims)
 			{
-				// Once the make animation starts the activity must not be stopped anymore.
-				IsInterruptible = false;
+				foreach (var makeAnimation in makeAnimations)
+				{
+					// Once the make animation starts the activity must not be stopped anymore.
+					IsInterruptible = false;
 
-				// Wait forever
-				QueueChild(new WaitFor(() => false));
-				makeAnimation.Reverse(self, () => DoTransform(self));
+					// Wait forever
+					QueueChild(new WaitFor(() => false));
+					makeAnimation.Reverse(self, () => DoTransform(self));
+				}
+
 				return false;
 			}
 

--- a/OpenRA.Mods.Common/Traits/Sellable.cs
+++ b/OpenRA.Mods.Common/Traits/Sellable.cs
@@ -76,12 +76,11 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (!info.SkipMakeAnimation)
 			{
-				var makeAnimation = self.TraitOrDefault<WithMakeAnimation>();
-				if (makeAnimation != null)
-				{
+				var makeAnimations = self.TraitsImplementing<WithMakeAnimation>();
+				foreach (var makeAnimation in makeAnimations)
 					makeAnimation.Reverse(self, new Sell(self, info.ShowTicks), false);
-					return;
-				}
+
+				return;
 			}
 
 			self.QueueActivity(false, new Sell(self, info.ShowTicks));


### PR DESCRIPTION
Fixes https://github.com/OpenHV/OpenHV/issues/171. This bug occurs when you define multiple `WithMakeAnimation` on separate sprite bodies and then reverse the animation e.g. by selling the building.