### PR TITLE
Make PortableChrono teleport immediately on force move

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			{
 				// HACK: Switch the global order generator instead of actually issuing an order
 				if (CanTeleport)
-					self.World.OrderGenerator = new PortableChronoOrderGenerator(self, Info);
+					self.World.OrderGenerator = new PortableChronoOrderGenerator(self, this);
 
 				// HACK: We need to issue a fake order to stop the game complaining about the bodge above
 				return new Order(order.OrderID, self, Target.Invalid, queued);
@@ -166,17 +166,14 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			if (modifiers.HasModifier(TargetModifiers.ForceMove))
 			{
-				var xy = self.World.Map.CellContaining(target.CenterPosition);
-
 				IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
 
+				var xy = self.World.Map.CellContaining(target.CenterPosition);
 				if (self.IsInWorld && self.Owner.Shroud.IsExplored(xy))
 				{
 					cursor = targetCursor;
 					return true;
 				}
-
-				return false;
 			}
 
 			return false;
@@ -186,12 +183,12 @@ namespace OpenRA.Mods.Cnc.Traits
 	class PortableChronoOrderGenerator : OrderGenerator
 	{
 		readonly Actor self;
-		readonly PortableChronoInfo info;
+		readonly PortableChrono portableChrono;
 
-		public PortableChronoOrderGenerator(Actor self, PortableChronoInfo info)
+		public PortableChronoOrderGenerator(Actor self, PortableChrono portableChrono)
 		{
 			this.self = self;
-			this.info = info;
+			this.portableChrono = portableChrono;
 		}
 
 		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
@@ -202,8 +199,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				yield break;
 			}
 
-			if (self.IsInWorld && self.Location != cell
-				&& self.Trait<PortableChrono>().CanTeleport && self.Owner.Shroud.IsExplored(cell))
+			if (self.IsInWorld && self.Location != cell && portableChrono.CanTeleport && self.Owner.Shroud.IsExplored(cell))
 			{
 				world.CancelInputMode();
 				yield return new Order("PortableChronoTeleport", self, Target.FromCell(world, cell), mi.Modifiers.HasModifier(Modifiers.Shift));
@@ -225,12 +221,12 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (!self.IsInWorld || self.Owner != self.World.LocalPlayer)
 				yield break;
 
-			if (!self.Trait<PortableChrono>().Info.HasDistanceLimit)
+			if (!portableChrono.Info.HasDistanceLimit)
 				yield break;
 
 			yield return new RangeCircleAnnotationRenderable(
 				self.CenterPosition,
-				WDist.FromCells(self.Trait<PortableChrono>().Info.MaxDistance),
+				WDist.FromCells(portableChrono.Info.MaxDistance),
 				0,
 				Color.FromArgb(128, Color.LawnGreen),
 				Color.FromArgb(96, Color.Black));
@@ -238,11 +234,10 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
-			if (self.IsInWorld && self.Location != cell
-				&& self.Trait<PortableChrono>().CanTeleport && self.Owner.Shroud.IsExplored(cell))
-				return info.TargetCursor;
+			if (self.IsInWorld && self.Location != cell && portableChrono.CanTeleport && self.Owner.Shroud.IsExplored(cell))
+				return portableChrono.Info.TargetCursor;
 			else
-				return info.TargetBlockedCursor;
+				return portableChrono.Info.TargetBlockedCursor;
 		}
 	}
 }


### PR DESCRIPTION
Closes #17058.

The first commit allows us to save  several trait lookups while `PortableChronoOrderGenerator` is active.
The second allows us to detect force teleport orders and moves magic strings to variables. (Inspired by what we do in `AttackBase`.)