### PR TITLE
Let harvesters only search for refineries when needing to unload.

### DIFF
--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -179,13 +179,8 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Determine where to search from and how far to search:
 			var procLoc = GetSearchFromProcLocation(self);
-			var searchFromLoc = lastHarvestedCell ?? procLoc;
+			var searchFromLoc = lastHarvestedCell ?? procLoc ?? self.Location;
 			var searchRadius = lastHarvestedCell.HasValue ? harvInfo.SearchFromHarvesterRadius : harvInfo.SearchFromProcRadius;
-			if (!searchFromLoc.HasValue)
-			{
-				searchFromLoc = self.Location;
-				searchRadius = harvInfo.SearchFromHarvesterRadius;
-			}
 
 			var searchRadiusSquared = searchRadius * searchRadius;
 
@@ -198,7 +193,7 @@ namespace OpenRA.Mods.Common.Activities
 					domainIndex.IsPassable(self.Location, loc, locomotorInfo) && harv.CanHarvestCell(self, loc) && claimLayer.CanClaimCell(self, loc))
 				.WithCustomCost(loc =>
 				{
-					if ((loc - searchFromLoc.Value).LengthSquared > searchRadiusSquared)
+					if ((loc - searchFromLoc).LengthSquared > searchRadiusSquared)
 						return int.MaxValue;
 
 					// Add a cost modifier to harvestable cells to prefer resources that are closer to the refinery.
@@ -223,7 +218,7 @@ namespace OpenRA.Mods.Common.Activities
 
 					return 0;
 				})
-				.FromPoint(searchFromLoc.Value)
+				.FromPoint(searchFromLoc)
 				.FromPoint(self.Location))
 				path = pathFinder.FindPath(search);
 

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -141,8 +141,6 @@ namespace OpenRA.Mods.Common.Traits
 			resourceMultipliers = self.TraitsImplementing<HarvesterResourceMultiplier>().ToArray();
 			UpdateCondition(self);
 
-			self.QueueActivity(new CallFunc(() => ChooseNewProc(self, null)));
-
 			// Note: This is queued in a FrameEndTask because otherwise the activity is dropped/overridden while moving out of a factory.
 			if (Info.SearchOnCreation)
 				self.World.AddFrameEndTask(w => self.QueueActivity(new FindAndDeliverResources(self)));


### PR DESCRIPTION
Fixes #18563 

Queueing a callfunc on creation was unneeded, since `DeliverResources` will take care of linking with a new refinery when needed anyway.