### PR TITLE
Remove defenderStats look-up from UpdatePlayerStatistics

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -235,23 +235,22 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			var attackerStats = e.Attacker.Owner.PlayerActor.Trait<PlayerStatistics>();
-			var defenderStats = self.Owner.PlayerActor.Trait<PlayerStatistics>();
 			if (self.Info.HasTraitInfo<BuildingInfo>())
 			{
 				attackerStats.BuildingsKilled++;
-				defenderStats.BuildingsDead++;
+				playerStats.BuildingsDead++;
 			}
 			else if (self.Info.HasTraitInfo<IPositionableInfo>())
 			{
 				attackerStats.UnitsKilled++;
-				defenderStats.UnitsDead++;
+				playerStats.UnitsDead++;
 			}
 
 			attackerStats.KillsCost += cost;
-			defenderStats.DeathsCost += cost;
+			playerStats.DeathsCost += cost;
 			if (includedInArmyValue)
 			{
-				defenderStats.ArmyValue -= cost;
+				playerStats.ArmyValue -= cost;
 				includedInArmyValue = false;
 				playerStats.Units[actorName].Count--;
 			}


### PR DESCRIPTION
`playerStats` is updated on owner change, so it should always be identical to the removed `var defenderStats`.

Should halve the `PlayerStatistics` look-ups per kill (at least from this place).