### PR TITLE
Only give actors ScriptTriggers on scripted maps in official mods

### DIFF
--- a/mods/cnc/rules/campaign-maprules.yaml
+++ b/mods/cnc/rules/campaign-maprules.yaml
@@ -1,4 +1,5 @@
 World:
+	ScriptTriggers:
 	-SpawnMPUnits:
 	-MPStartLocations:
 	-CrateSpawner:
@@ -24,6 +25,7 @@ World:
 		Locked: true
 
 Player:
+	ScriptTriggers:
 	-ConquestVictoryConditions:
 	MissionObjectives:
 		EarlyGameOver: true
@@ -39,6 +41,21 @@ Player:
 	ModularBot@CampaignAI:
 		Name: Campaign Player AI
 		Type: campaign
+
+^ExistsInWorld:
+	ScriptTriggers:
+
+^CivBuildingHusk:
+	ScriptTriggers:
+
+^Wall:
+	ScriptTriggers:
+
+^Husk:
+	ScriptTriggers:
+
+^Bridge:
+	ScriptTriggers:
 
 airstrike.proxy:
 	AlwaysVisible:
@@ -63,6 +80,10 @@ airstrike.proxy:
 		ClockSequence: clock
 		CircleSequence: circles
 		SupportPowerPaletteOrder: 10
+
+CRATE.plain:
+	Inherits: ^Crate
+	ScriptTriggers:
 
 MoneyCrate:
 	Inherits: ^Crate

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -855,7 +855,6 @@
 		Palette: terrain
 	WithSpriteBody:
 	FrozenUnderFog:
-	ScriptTriggers:
 	MapEditorData:
 		Categories: Husk
 
@@ -945,7 +944,6 @@
 		MinimumDamageState: Heavy
 		MaximumDamageState: Dead
 	HiddenUnderShroud:
-	ScriptTriggers:
 	HitShape:
 	MapEditorData:
 		Categories: Tree
@@ -968,7 +966,6 @@
 		Name: Tree (Burnt)
 		ShowOwnerRow: false
 	HiddenUnderShroud:
-	ScriptTriggers:
 	MapEditorData:
 		Categories: Tree
 	RequiresSpecificOwners:
@@ -1016,7 +1013,6 @@
 	AppearsOnMapPreview:
 		Terrain: Tree
 	HiddenUnderShroud:
-	ScriptTriggers:
 	MapEditorData:
 		RequireTilesets: DESERT
 		Categories: Decoration

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -4,7 +4,6 @@
 	CombatDebugOverlay:
 	GivesExperience:
 		PlayerExperienceModifier: 1
-	ScriptTriggers:
 	RenderDebugState:
 
 ^SpriteActor:
@@ -794,7 +793,6 @@
 		GenericStancePrefix: false
 		ShowOwnerRow: false
 	FrozenUnderFog:
-	ScriptTriggers:
 	MapEditorData:
 		Categories: Husk
 
@@ -895,7 +893,6 @@
 		SellSounds: cashturn.aud
 	Guardable:
 	FrozenUnderFog:
-	ScriptTriggers:
 	Health:
 		HP: 10000
 	AppearsOnMapPreview:
@@ -1051,7 +1048,6 @@
 		GenericName: Destroyed Vehicle
 	WithColoredOverlay@IDISABLE:
 		Palette: disabled
-	ScriptTriggers:
 	Explodes:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
@@ -1101,7 +1097,6 @@
 	SoundOnDamageTransition:
 		DamagedSounds: xplos.aud
 		DestroyedSounds: xplobig4.aud
-	ScriptTriggers:
 	BodyOrientation:
 		QuantizedFacings: 1
 	ShakeOnDeath:

--- a/mods/cnc/rules/misc.yaml
+++ b/mods/cnc/rules/misc.yaml
@@ -1,7 +1,3 @@
-CRATE.plain:
-	Inherits: ^Crate
-	ScriptTriggers:
-
 CRATE:
 	Inherits: ^Crate
 	Crate:

--- a/mods/cnc/rules/player.yaml
+++ b/mods/cnc/rules/player.yaml
@@ -12,7 +12,6 @@ Player:
 		CannotPlaceNotification: BuildingCannotPlaceAudio
 	TechTree:
 	SupportPowerManager:
-	ScriptTriggers:
 	MissionObjectives:
 		WinNotification: Win
 		LoseNotification: Lose

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -260,7 +260,6 @@ World:
 	RadarPings:
 	LoadWidgetAtGameStart:
 		ShellmapRoot: MENU_BACKGROUND
-	ScriptTriggers:
 	TimeLimitManager:
 
 EditorWorld:

--- a/mods/d2k/rules/campaign-rules.yaml
+++ b/mods/d2k/rules/campaign-rules.yaml
@@ -1,4 +1,5 @@
 Player:
+	ScriptTriggers:
 	-ConquestVictoryConditions:
 	MissionObjectives:
 		EarlyGameOver: true
@@ -15,6 +16,7 @@ Player:
 		Type: campaign
 
 World:
+	ScriptTriggers:
 	-CrateSpawner:
 	-SpawnMPUnits:
 	-MPStartLocations:
@@ -41,3 +43,6 @@ World:
 ^AutoTargetAllAssaultMove:
 	GrantConditionOnBotOwner@BOTOWNER:
 		Bots: campaign
+
+^ExistsInWorld:
+	ScriptTriggers:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -4,7 +4,6 @@
 	CombatDebugOverlay:
 	GivesExperience:
 		PlayerExperienceModifier: 1
-	ScriptTriggers:
 	RenderDebugState:
 
 ^SpriteActor:

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -82,7 +82,6 @@ Player:
 		NewOptionsNotification: NewOptions
 		CannotPlaceNotification: BuildingCannotPlaceAudio
 	SupportPowerManager:
-	ScriptTriggers:
 	MissionObjectives:
 		WinNotification: Win
 		LoseNotification: Lose

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -234,7 +234,6 @@ World:
 		ExitDelay: 0
 		PanelName: SKIRMISH_STATS
 	LoadWidgetAtGameStart:
-	ScriptTriggers:
 	StartGameNotification:
 	TimeLimitManager:
 

--- a/mods/ra/maps/bomber-john/map.yaml
+++ b/mods/ra/maps/bomber-john/map.yaml
@@ -754,4 +754,4 @@ Actors:
 
 Rules: rules.yaml
 
-Sequences: sequences.yaml
+Sequences: sequences.yaml, ra|rules/enable-mp-coop-scripttriggers.yaml

--- a/mods/ra/maps/desert-shellmap/map.yaml
+++ b/mods/ra/maps/desert-shellmap/map.yaml
@@ -1264,6 +1264,6 @@ Actors:
 		Location: 1,28
 		Owner: Neutral
 
-Rules: ra|rules/campaign-palettes.yaml, rules.yaml
+Rules: ra|rules/campaign-palettes.yaml, ra|rules/enable-mp-coop-scripttriggers.yaml, rules.yaml
 
 Weapons: weapons.yaml

--- a/mods/ra/maps/fort-lonestar/map.yaml
+++ b/mods/ra/maps/fort-lonestar/map.yaml
@@ -461,7 +461,7 @@ Actors:
 		Location: 46,32
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules: rules.yaml, ra|rules/enable-mp-coop-scripttriggers.yaml
 
 Weapons: weapons.yaml
 

--- a/mods/ra/rules/campaign-rules.yaml
+++ b/mods/ra/rules/campaign-rules.yaml
@@ -1,4 +1,5 @@
 Player:
+	ScriptTriggers:
 	-ConquestVictoryConditions:
 	MissionObjectives:
 		EarlyGameOver: true
@@ -16,6 +17,7 @@ Player:
 		Type: campaign
 
 World:
+	ScriptTriggers:
 	CrateSpawner:
 		CheckboxEnabled: False
 		CheckboxLocked: True
@@ -32,6 +34,15 @@ World:
 		TechLevelDropdownLocked: True
 		ShortGameCheckboxLocked: True
 		ShortGameCheckboxEnabled: False
+
+^ExistsInWorld:
+	ScriptTriggers:
+
+^BasicHusk:
+	ScriptTriggers:
+
+^Bridge:
+	ScriptTriggers:
 
 E7:
 	-Crushable:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -871,6 +871,7 @@
 	-Explodes:
 	-Explodes@CIVPANIC:
 	-Selectable:
+	-ScriptTriggers:
 	Tooltip:
 		Name: Field
 	-Targetable:
@@ -922,7 +923,6 @@
 		MinimumDamageState: Heavy
 		MaximumDamageState: Dead
 	HiddenUnderShroud:
-	ScriptTriggers:
 	MapEditorData:
 		ExcludeTilesets: INTERIOR
 		Categories: Tree
@@ -947,7 +947,6 @@
 		Name: Tree (Burnt)
 		ShowOwnerRow: false
 	HiddenUnderShroud:
-	ScriptTriggers:
 	MapEditorData:
 		Categories: Tree
 	RequiresSpecificOwners:
@@ -1096,7 +1095,6 @@
 	AppearsOnMapPreview:
 		Terrain: Tree
 	HiddenUnderShroud:
-	ScriptTriggers:
 	MapEditorData:
 		RequireTilesets: DESERT
 		Categories: Decoration

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -3,7 +3,6 @@
 	CombatDebugOverlay:
 	GivesExperience:
 		PlayerExperienceModifier: 1
-	ScriptTriggers:
 	RenderDebugState:
 
 ^SpriteActor:
@@ -871,7 +870,6 @@
 	-Explodes:
 	-Explodes@CIVPANIC:
 	-Selectable:
-	-ScriptTriggers:
 	Tooltip:
 		Name: Field
 	-Targetable:
@@ -971,7 +969,6 @@
 	HiddenUnderFog:
 		Type: CenterPosition
 		AlwaysVisibleStances: None
-	ScriptTriggers:
 	WithFacingSpriteBody:
 	HitShape:
 	MapEditorData:
@@ -1068,7 +1065,6 @@
 		HP: 100000
 	Armor:
 		Type: Concrete
-	ScriptTriggers:
 	BodyOrientation:
 		QuantizedFacings: 1
 	Interactable:

--- a/mods/ra/rules/enable-mp-coop-scripttriggers.yaml
+++ b/mods/ra/rules/enable-mp-coop-scripttriggers.yaml
@@ -1,0 +1,14 @@
+^ExistsInWorld:
+	ScriptTriggers:
+
+^BasicHusk:
+	ScriptTriggers:
+
+^Bridge:
+	ScriptTriggers:
+
+World:
+	ScriptTriggers:
+
+Player:
+	ScriptTriggers:

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -79,7 +79,6 @@ Player:
 		NewOptionsNotification: NewOptions
 		CannotPlaceNotification: BuildingCannotPlaceAudio
 	SupportPowerManager:
-	ScriptTriggers:
 	MissionObjectives:
 		WinNotification: Win
 		LoseNotification: Lose

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -265,7 +265,6 @@ World:
 	ObjectivesPanel:
 		PanelName: SKIRMISH_STATS
 	LoadWidgetAtGameStart:
-	ScriptTriggers:
 	TimeLimitManager:
 		TimeLimitWarnings:
 			40: FourtyMinutesRemaining

--- a/mods/ts/maps/fields-of-green/map.yaml
+++ b/mods/ts/maps/fields-of-green/map.yaml
@@ -1414,4 +1414,4 @@ Actors:
 		Owner: Neutral
 		Location: 58,16
 
-Rules: rules.yaml
+Rules: rules.yaml, ts|rules/enable-scripttriggers.yaml

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -4,7 +4,6 @@
 	CombatDebugOverlay:
 	GivesExperience:
 		PlayerExperienceModifier: 1
-	ScriptTriggers:
 	RenderDebugState:
 
 ^SpriteActor:
@@ -500,7 +499,6 @@
 	Sellable:
 		RequiresCondition: !being-demolished
 		SellSounds: cashturn.aud
-	ScriptTriggers:
 	Health:
 	HitShape:
 		Type: Rectangle
@@ -944,7 +942,6 @@
 	HiddenUnderFog:
 		Type: GroundPosition
 		AlwaysVisibleStances: None
-	ScriptTriggers:
 	Interactable:
 	Tooltip:
 		GenericName: Destroyed Aircraft

--- a/mods/ts/rules/enable-scripttriggers.yaml
+++ b/mods/ts/rules/enable-scripttriggers.yaml
@@ -1,0 +1,11 @@
+World:
+	ScriptTriggers:
+
+Player:
+	ScriptTriggers:
+
+^ExistsInWorld:
+	ScriptTriggers:
+
+^Wall:
+	ScriptTriggers:

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -68,7 +68,6 @@ Player:
 		NewOptionsNotification: NewOptions
 		CannotPlaceNotification: BuildingCannotPlaceAudio
 	SupportPowerManager:
-	ScriptTriggers:
 	MissionObjectives:
 		WinNotification: Win
 		LoseNotification: Lose

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -369,7 +369,6 @@ World:
 		PanelName: SKIRMISH_STATS
 	LoadWidgetAtGameStart:
 		ShellmapRoot: MAINMENU_PRERELEASE_NOTIFICATION
-	ScriptTriggers:
 	TimeLimitManager:
 
 EditorWorld:


### PR DESCRIPTION
This should reduce the amount of some `INotify*` calls (especially `INotifyKilled`) substantially during normal MP/skirmish games, reducing worst-case peaks.