### PR TITLE
Support OPENRA_DISPLAY_SCALE environment variable on Windows.

### DIFF
--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -176,15 +176,19 @@ namespace OpenRA.Platforms.Default
 				// This is not necessary on macOS, which defines window sizes in effective units ("points").
 				if (Platform.CurrentPlatform == PlatformType.Windows)
 				{
-					if (SDL.SDL_GetDisplayDPI(videoDisplay, out var ddpi, out _, out _) == 0)
-						windowScale = ddpi / 96;
+					// Launch the game with OPENRA_DISPLAY_SCALE to force a specific scaling factor
+					// Otherwise fall back to Windows's DPI configuration
+					var scaleVariable = Environment.GetEnvironmentVariable("OPENRA_DISPLAY_SCALE");
+					if (scaleVariable == null || !float.TryParse(scaleVariable, NumberStyles.Float, NumberFormatInfo.InvariantInfo, out windowScale) || windowScale <= 0)
+						if (SDL.SDL_GetDisplayDPI(videoDisplay, out var ddpi, out _, out _) == 0)
+							windowScale = ddpi / 96;
 				}
-				else if (Platform.CurrentPlatform != PlatformType.OSX)
+				else if (Platform.CurrentPlatform == PlatformType.Linux)
 				{
 					// Launch the game with OPENRA_DISPLAY_SCALE to force a specific scaling factor
 					// Otherwise fall back to GDK_SCALE or parsing the x11 DPI configuration
 					var scaleVariable = Environment.GetEnvironmentVariable("OPENRA_DISPLAY_SCALE") ?? Environment.GetEnvironmentVariable("GDK_SCALE");
-					if (scaleVariable == null || !float.TryParse(scaleVariable, NumberStyles.Float, NumberFormatInfo.InvariantInfo, out windowScale))
+					if (scaleVariable == null || !float.TryParse(scaleVariable, NumberStyles.Float, NumberFormatInfo.InvariantInfo, out windowScale) || windowScale <= 0)
 					{
 						// Attempt to automatically detect DPI
 						try


### PR DESCRIPTION
Closes #18206.
Fixes #18226.
