### PR TITLE
Fixed "Cannot change state when game started (state NotReady)"

### DIFF
--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -302,10 +302,7 @@ namespace OpenRA.Network
 						{
 							var strings = node.Key.Split('@');
 							if (strings[0] == "GlobalSettings")
-							{
 								orderManager.LobbyInfo.GlobalSettings = Session.Global.Deserialize(node.Value);
-								orderManager.IssueOrder(Order.Command("state {0}".F(Session.ClientState.NotReady)));
-							}
 						}
 
 						SetOrderLag(orderManager);

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -523,6 +523,11 @@ namespace OpenRA.Mods.Common.Server
 			server.SyncLobbyGlobalSettings();
 			server.SendMessage(option.ValueChangedMessage(client.Name, split[1]));
 
+			foreach (var c in server.LobbyInfo.Clients)
+				c.State = Session.ClientState.NotReady;
+
+			server.SyncLobbyClients();
+
 			return true;
 		}
 


### PR DESCRIPTION
This is a proposed fix for https://github.com/OpenHV/OpenHV/issues/181 which was most likely introduced in https://github.com/OpenRA/OpenRA/pull/18494.