### PR TITLE
Excluded C17, A10, carryall.reinforce and walls from the assets value

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -56,6 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 		public int BuildingsDead;
 
 		public int ArmyValue;
+		public int AssetsValue;
 
 		// High resolution (every second) record of earnings, limited to the last minute
 		readonly Queue<int> earnedSeconds = new Queue<int>(60);
@@ -186,6 +187,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Add to army value in statistics")]
 		public bool AddToArmyValue = false;
 
+		[Desc("Add to assets value in statistics")]
+		public bool AddToAssetsValue = true;
+
 		[ActorReference]
 		[Desc("Count this actor as a different type in the spectator army display.")]
 		public string OverrideActor = null;
@@ -201,6 +205,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		PlayerStatistics playerStats;
 		bool includedInArmyValue = false;
+		bool includedInAssetsValue = false;
 
 		public UpdatesPlayerStatistics(UpdatesPlayerStatisticsInfo info, Actor self)
 		{
@@ -236,17 +241,26 @@ namespace OpenRA.Mods.Common.Traits
 				includedInArmyValue = false;
 				playerStats.Units[actorName].Count--;
 			}
+
+			if (includedInAssetsValue)
+			{
+				playerStats.AssetsValue -= cost;
+				includedInAssetsValue = false;
+			}
 		}
 
 		void INotifyCreated.Created(Actor self)
 		{
 			includedInArmyValue = info.AddToArmyValue;
-
 			if (includedInArmyValue)
 			{
 				playerStats.ArmyValue += cost;
 				playerStats.Units[actorName].Count++;
 			}
+
+			includedInAssetsValue = info.AddToAssetsValue;
+			if (includedInAssetsValue)
+				playerStats.AssetsValue += cost;
 		}
 
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
@@ -260,6 +274,12 @@ namespace OpenRA.Mods.Common.Traits
 				newOwnerStats.Units[actorName].Count++;
 			}
 
+			if (includedInAssetsValue)
+			{
+				playerStats.AssetsValue -= cost;
+				newOwnerStats.AssetsValue += cost;
+			}
+
 			playerStats = newOwnerStats;
 		}
 
@@ -270,6 +290,12 @@ namespace OpenRA.Mods.Common.Traits
 				playerStats.ArmyValue -= cost;
 				includedInArmyValue = false;
 				playerStats.Units[actorName].Count--;
+			}
+
+			if (includedInAssetsValue)
+			{
+				playerStats.AssetsValue -= cost;
+				includedInAssetsValue = false;
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -386,11 +386,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			SetupPlayerColor(player, template, playerColor, playerGradient);
 
-			var res = player.PlayerActor.Trait<PlayerResources>();
 			var stats = player.PlayerActor.TraitOrDefault<PlayerStatistics>();
 			if (stats == null)
 				return template;
 
+			var res = player.PlayerActor.Trait<PlayerResources>();
 			var cashText = new CachedTransform<int, string>(i => "$" + i);
 			template.Get<LabelWidget>("CASH").GetText = () => cashText.Update(res.Cash + res.Resources);
 
@@ -404,10 +404,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			template.Get<LabelWidget>("SPENT").GetText = () => spentText.Update(res.Spent);
 
 			var assetsText = new CachedTransform<int, string>(i => "$" + i);
-			var assets = template.Get<LabelWidget>("ASSETS");
-			assets.GetText = () => assetsText.Update(world.ActorsHavingTrait<Valued>()
-				.Where(a => a.Owner == player && !a.IsDead)
-				.Sum(a => a.Info.TraitInfos<ValuedInfo>().First().Cost));
+			template.Get<LabelWidget>("ASSETS").GetText = () => assetsText.Update(stats.AssetsValue);
 
 			var harvesters = template.Get<LabelWidget>("HARVESTERS");
 			harvesters.GetText = () => world.ActorsHavingTrait<Harvester>().Count(a => a.Owner == player && !a.IsDead).ToString();

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -181,6 +181,8 @@ C17:
 		Name: Supply Aircraft
 	Valued:
 		Cost: 2000
+	UpdatesPlayerStatistics:
+		AddToAssetsValue: false
 	Aircraft:
 		TurnSpeed: 20
 		Speed: 700
@@ -214,6 +216,8 @@ A10:
 		Name: A10 Bomber
 	Valued:
 		Cost: 2000
+	UpdatesPlayerStatistics:
+		AddToAssetsValue: false
 	Aircraft:
 		TurnSpeed: 16
 		Speed: 373

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -905,6 +905,8 @@
 		Terrain: Wall
 	MapEditorData:
 		Categories: Wall
+	UpdatesPlayerStatistics:
+		AddToAssetsValue: false
 
 ^Tree:
 	Inherits@1: ^SpriteActor

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -2,6 +2,8 @@ carryall.reinforce:
 	Inherits: ^Plane
 	Valued:
 		Cost: 1100
+	UpdatesPlayerStatistics:
+		AddToAssetsValue: false
 	Tooltip:
 		Name: Carryall
 	Health:
@@ -49,6 +51,8 @@ carryall.reinforce:
 
 carryall:
 	Inherits: carryall.reinforce
+	UpdatesPlayerStatistics:
+		AddToAssetsValue: true
 	-Carryall:
 	AutoCarryall:
 		BeforeLoadDelay: 10

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -665,6 +665,8 @@ wall:
 		Cost: 20
 	CustomSellValue:
 		Value: 0
+	UpdatesPlayerStatistics:
+		AddToAssetsValue: false
 	Tooltip:
 		Name: Concrete Wall
 		GenericName: Structure

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -775,6 +775,8 @@
 		Terrain: Wall
 	MapEditorData:
 		Categories: Wall
+	UpdatesPlayerStatistics:
+		AddToAssetsValue: false
 
 ^TechBuilding:
 	Inherits: ^BasicBuilding


### PR DESCRIPTION
Reported on Discord by @Orb370. The `Assets` in the economy spectator tab is directly calculated from unit costs, so ordering a unit via the airstrip would temporarily increase the displayed value by 2000 for the transport plane.