### PR TITLE
Work around a sound issue when loading saves

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
+++ b/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
@@ -69,9 +69,6 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 			this.world = world;
 
-			if (info.DisableWorldSounds)
-				Game.Sound.DisableWorldSounds = true;
-
 			IsMusicInstalled = world.Map.Rules.InstalledMusic.Any();
 			if (!IsMusicInstalled)
 				return;
@@ -105,6 +102,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		void IWorldLoaded.WorldLoaded(World world, WorldRenderer wr)
 		{
+			// Reset any bogus pre-existing state
+			Game.Sound.DisableWorldSounds = info.DisableWorldSounds;
+
 			if (!world.IsLoadingGameSave)
 				Play();
 		}


### PR DESCRIPTION
Closes #17359.

Testcase is described in https://github.com/OpenRA/OpenRA/issues/17359#issuecomment-687791308.

This is only a workaround since the original issue (the menu being closed without `onExit` running, leaving bogus state), but I don't know how to solve that directly. (Probably needs a larger widget rework?)