### PR TITLE
Enable the restart button for missions with script errors

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -323,7 +323,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var button = AddButton("RESTART", RestartButton);
-			button.IsDisabled = () => hasError || leaving;
+			button.IsDisabled = () => leaving;
 			button.OnClick = () =>
 			{
 				hideMenu = true;


### PR DESCRIPTION
Closes #17540.
~~Edit: #14104 is still open.~~

~~I didn't encounter a desync when restarting a multiplayer replay, but I also don't know the reproduction case of https://github.com/OpenRA/OpenRA/issues/15423#issuecomment-412343652.~~