### PR TITLE
Fix AttackMove getting unarmed units stuck

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
+++ b/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
@@ -39,8 +39,11 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected override void OnFirstRun(Actor self)
 		{
-			if (attackMove == null)
+			if (attackMove == null || autoTarget == null)
+			{
+				QueueChild(getMove());
 				return;
+			}
 
 			if (isAssaultMove)
 				token = self.GrantCondition(attackMove.Info.AssaultMoveCondition);
@@ -50,11 +53,11 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override bool Tick(Actor self)
 		{
-			if (IsCanceling)
+			if (IsCanceling || attackMove == null || autoTarget == null)
 				return TickChild(self);
 
 			// We are currently not attacking, so scan for new targets.
-			if (autoTarget != null && (ChildActivity == null || runningMoveActivity))
+			if (ChildActivity == null || runningMoveActivity)
 			{
 				// Use the standard ScanForTarget rate limit while we are running the move activity to save performance.
 				// Override the rate limit if our attack activity has completed so we can immediately acquire a new target instead of moving.


### PR DESCRIPTION
Reported by Graion on Discord.

Apparently we all forgot to test unarmed units which attack move out of factories (which just get stuck on bleed right now because they never queue a move and complete the activity).

I changed the activity to just queue a move child and only run that and nothing else when the unit doesn't have `AttackMove` or `AutoTarget` (for which doing anything else wouldn't make much sense anyway).

Closes #18611.