### PR TITLE
Fixed use of unintialized field in CursorSequence.

### DIFF
--- a/OpenRA.Game/Graphics/CursorSequence.cs
+++ b/OpenRA.Game/Graphics/CursorSequence.cs
@@ -31,8 +31,10 @@ namespace OpenRA.Graphics
 			Palette = palette;
 			Name = name;
 
+			Frames = cache[cursorSrc].Skip(Start).ToArray();
+
 			if ((d.ContainsKey("Length") && d["Length"].Value == "*") || (d.ContainsKey("End") && d["End"].Value == "*"))
-				Length = Frames.Length - Start;
+				Length = Frames.Length;
 			else if (d.ContainsKey("Length"))
 				Length = Exts.ParseIntegerInvariant(d["Length"].Value);
 			else if (d.ContainsKey("End"))
@@ -40,10 +42,7 @@ namespace OpenRA.Graphics
 			else
 				Length = 1;
 
-			Frames = cache[cursorSrc]
-				.Skip(Start)
-				.Take(Length)
-				.ToArray();
+			Frames = Frames.Take(Length).ToArray();
 
 			if (d.ContainsKey("X"))
 			{


### PR DESCRIPTION
See https://github.com/OpenRA/OpenRA/issues/18518. As `End: *` or `Length: *` are not used in cursor sequence definitions, no one noticed this was broken in a weird way.