### PR TITLE
Cache IOrderValidator and IResolveOrder traits

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -102,6 +102,7 @@ namespace OpenRA
 
 		readonly IFacing facing;
 		readonly IHealth health;
+		readonly IResolveOrder[] resolveOrders;
 		readonly IRenderModifier[] renderModifiers;
 		readonly IRender[] renders;
 		readonly IMouseBounds[] mouseBounds;
@@ -156,6 +157,7 @@ namespace OpenRA
 			EffectiveOwner = TraitOrDefault<IEffectiveOwner>();
 			facing = TraitOrDefault<IFacing>();
 			health = TraitOrDefault<IHealth>();
+			resolveOrders = TraitsImplementing<IResolveOrder>().ToArray();
 			renderModifiers = TraitsImplementing<IRenderModifier>().ToArray();
 			renders = TraitsImplementing<IRender>().ToArray();
 			mouseBounds = TraitsImplementing<IMouseBounds>().ToArray();
@@ -402,6 +404,12 @@ namespace OpenRA
 
 				luaInterface?.Value.OnActorDestroyed();
 			});
+		}
+
+		public void ResolveOrder(Order order)
+		{
+			foreach (var r in resolveOrders)
+				r.ResolveOrder(this, order);
 		}
 
 		// TODO: move elsewhere.

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -346,8 +346,7 @@ namespace OpenRA.Network
 				return;
 
 			if (world.OrderValidators.All(vo => vo.OrderValidation(orderManager, world, clientId, order)))
-				foreach (var t in order.Subject.TraitsImplementing<IResolveOrder>())
-					t.ResolveOrder(order.Subject, order);
+				order.Subject.ResolveOrder(order);
 		}
 
 		static void SetOrderLag(OrderManager o)

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -330,22 +330,22 @@ namespace OpenRA.Network
 							break;
 
 						if (order.GroupedActors == null)
-							ResolveOrder(order, world.OrderValidators, orderManager, clientId);
+							ResolveOrder(order, world, orderManager, clientId);
 						else
 							foreach (var subject in order.GroupedActors)
-								ResolveOrder(Order.FromGroupedOrder(order, subject), world.OrderValidators, orderManager, clientId);
+								ResolveOrder(Order.FromGroupedOrder(order, subject), world, orderManager, clientId);
 
 						break;
 					}
 			}
 		}
 
-		static void ResolveOrder(Order order, IEnumerable<IValidateOrder> validateOrders, OrderManager orderManager, int clientId)
+		static void ResolveOrder(Order order, World world, OrderManager orderManager, int clientId)
 		{
 			if (order.Subject == null || order.Subject.IsDead)
 				return;
 
-			if (validateOrders.All(vo => vo.OrderValidation(orderManager, order.Subject.World, clientId, order)))
+			if (world.OrderValidators.All(vo => vo.OrderValidation(orderManager, world, clientId, order)))
 				foreach (var t in order.Subject.TraitsImplementing<IResolveOrder>())
 					t.ResolveOrder(order.Subject, order);
 		}

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -330,14 +330,10 @@ namespace OpenRA.Network
 							break;
 
 						if (order.GroupedActors == null)
-							ResolveOrder(order, world.WorldActor.TraitsImplementing<IValidateOrder>(), orderManager, clientId);
+							ResolveOrder(order, world.OrderValidators, orderManager, clientId);
 						else
-						{
-							// PERF: Cache the result of TraitsImplementing as we are likely to use it for several order subjects
-							var validateOrders = world.WorldActor.TraitsImplementing<IValidateOrder>().ToArray();
 							foreach (var subject in order.GroupedActors)
-								ResolveOrder(Order.FromGroupedOrder(order, subject), validateOrders, orderManager, clientId);
-						}
+								ResolveOrder(Order.FromGroupedOrder(order, subject), world.OrderValidators, orderManager, clientId);
 
 						break;
 					}

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -142,6 +142,8 @@ namespace OpenRA
 		public readonly ScreenMap ScreenMap;
 		public readonly WorldType Type;
 
+		public readonly IValidateOrder[] OrderValidators;
+
 		readonly GameInformation gameInfo;
 
 		// Hide the OrderManager from mod code
@@ -203,6 +205,7 @@ namespace OpenRA
 			ActorMap = WorldActor.Trait<IActorMap>();
 			ScreenMap = WorldActor.Trait<ScreenMap>();
 			Selection = WorldActor.Trait<ISelection>();
+			OrderValidators = WorldActor.TraitsImplementing<IValidateOrder>().ToArray();
 
 			// Reset mask
 			LongBitSet<PlayerBitMask>.Reset();


### PR DESCRIPTION
This should reduce overhead from looking up order-related traits when giving orders.