### PR TITLE
Fix a crash in the Move activity

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -376,7 +376,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
 		{
-			if (targetLineColor != null)
+			// destination might be initialized with null, but will be set in a subsequent tick
+			if (targetLineColor != null && destination != null)
 				yield return new TargetLineNode(Target.FromCell(self.World, destination.Value), targetLineColor.Value);
 		}
 


### PR DESCRIPTION
Reported by @darkademic on Discord.

We have two constructors that set `destination = null`, so this might crash on a timing before the activity gets around calculating a value for `destination` in `Tick` (especially if the mobile trait is paused).

```
OpenRA engine version prep-CA
Combined Arms mod version 0.70
on map b90739296e2cb58bb231e9c7abb4017f93143db8 (Ups and Downs CA by Lad).
Date: 2020-09-15 20:15:46Z
Runtime Version: .NET CLR 4.0.30319.42000
Exception of type `System.InvalidOperationException`: Nullable object must have a value.
   at System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource)
   at OpenRA.Mods.Common.Activities.Move.<TargetLineNodes>d__27.MoveNext()
   at OpenRA.Mods.Common.Traits.DrawLineToTarget.<OpenRA-Traits-IRenderAboveShroud-RenderAboveShroud>d__6.MoveNext()
   at System.Linq.Enumerable.<SelectManyIterator>d__17`2.MoveNext()
   at System.Linq.Enumerable.<ConcatIterator>d__59`1.MoveNext()
   at System.Linq.Enumerable.<ConcatIterator>d__59`1.MoveNext()
   at System.Linq.Enumerable.<ConcatIterator>d__59`1.MoveNext()
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at System.Collections.Generic.List`1.InsertRange(Int32 index, IEnumerable`1 collection)
   at OpenRA.Graphics.WorldRenderer.PrepareRenderables()
   at OpenRA.Game.RenderTick()
   at OpenRA.Game.Loop()
   at OpenRA.Game.Run()
   at OpenRA.Game.InitializeAndRun(String[] args)
   at OpenRA.WindowsLauncher.RunGame(String[] args)
```