### PR TITLE
Change the display name of England to Britain

### DIFF
--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -101,10 +101,10 @@
 		Side: Allies
 		Selectable: False
 	Faction@1:
-		Name: England
+		Name: Britain
 		InternalName: england
 		Side: Allies
-		Description: England: Counterintelligence\nSpecial Unit: British Spy\nSpecial Unit: Mobile Gap Generator
+		Description: Britain: Counterintelligence\nSpecial Unit: British Spy\nSpecial Unit: Mobile Gap Generator
 	Faction@2:
 		Name: France
 		InternalName: france


### PR DESCRIPTION
The simple name change fixes one of the most glaring issues listed in #18084 while retaining the faction and iconic flag.