### PR TITLE
Hide "Furthest" battlefield camera option if the mod disables it.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -941,7 +941,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (farRange.X < windowHeight)
 				validSizes.Add(WorldViewport.Far);
 
-			if (farRange.Y < windowHeight)
+			if (viewportSizes.AllowNativeZoom && farRange.Y < windowHeight)
 				validSizes.Add(WorldViewport.Native);
 
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, validSizes, setupItem);


### PR DESCRIPTION
Fixes #18435.

This hides the UI, but doesn't reset the player preference. The settings are shared between mods, and it would be a bad experience if players who prefer Furthest in e.g. RA were forced to manually reset their preferred camera option each time they return after playing e.g. RV.