### PR TITLE
Preparation changes for Burst refactor

### DIFF
--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -28,7 +28,6 @@ namespace OpenRA.Mods.Common.Activities
 		readonly IEnumerable<AttackFrontal> attackTraits;
 		readonly RevealsShroud[] revealsShroud;
 		readonly IMove move;
-		readonly IFacing facing;
 		readonly IPositionable positionable;
 		readonly bool forceAttack;
 		readonly Color? targetLineColor;
@@ -53,7 +52,6 @@ namespace OpenRA.Mods.Common.Activities
 
 			attackTraits = self.TraitsImplementing<AttackFrontal>().ToArray().Where(Exts.IsTraitEnabled);
 			revealsShroud = self.TraitsImplementing<RevealsShroud>().ToArray();
-			facing = self.Trait<IFacing>();
 			positionable = self.Trait<IPositionable>();
 
 			move = allowMovement ? self.TraitOrDefault<IMove>() : null;
@@ -221,7 +219,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			if (!attack.IsTraitPaused)
 				foreach (var a in armaments)
-					a.CheckFire(self, facing, target);
+					a.TryFiring(self, target);
 		}
 
 		void IActivityNotifyStanceChanged.StanceChanged(Actor self, AutoTarget autoTarget, UnitStance oldStance, UnitStance newStance)

--- a/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 						continue;
 
 					inAttackRange = true;
-					a.CheckFire(self, facing, target);
+					a.TryFiring(self, target);
 				}
 
 				// Actors without armaments may want to trigger an action when it passes the target

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -323,18 +323,18 @@ namespace OpenRA.Mods.Common.Traits
 					var projectile = args.Weapon.Projectile.Create(args);
 					if (projectile != null)
 						self.World.Add(projectile);
-
-					if (args.Weapon.Report != null && args.Weapon.Report.Any())
-						Game.Sound.Play(SoundType.World, args.Weapon.Report, self.World, self.CenterPosition);
-
-					if (Burst == args.Weapon.Burst && args.Weapon.StartBurstReport != null && args.Weapon.StartBurstReport.Any())
-						Game.Sound.Play(SoundType.World, args.Weapon.StartBurstReport, self.World, self.CenterPosition);
-
-					foreach (var na in notifyAttacks)
-						na.Attacking(self, target, this, barrel);
-
-					Recoil = Info.Recoil;
 				}
+
+				if (args.Weapon.Report != null && args.Weapon.Report.Any())
+					Game.Sound.Play(SoundType.World, args.Weapon.Report, self.World, self.CenterPosition);
+
+				if (Burst == args.Weapon.Burst && args.Weapon.StartBurstReport != null && args.Weapon.StartBurstReport.Any())
+					Game.Sound.Play(SoundType.World, args.Weapon.StartBurstReport, self.World, self.CenterPosition);
+
+				foreach (var na in notifyAttacks)
+					na.Attacking(self, target, this, barrel);
+
+				Recoil = Info.Recoil;
 			});
 		}
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -168,7 +168,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			foreach (var a in Armaments)
-				a.CheckFire(self, facing, target);
+				a.TryFiring(self, target);
 		}
 
 		IEnumerable<IOrderTargeter> IIssueOrder.Orders

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -171,8 +171,7 @@ namespace OpenRA.Mods.Common.Traits
 				paxFacing[a.Actor].Facing = targetYaw;
 				paxPos[a.Actor].SetVisualPosition(a.Actor, pos + PortOffset(self, port));
 
-				var barrel = a.CheckFire(a.Actor, facing, target);
-				if (barrel == null)
+				if (!a.TryFiring(a.Actor, target, out var barrel))
 					continue;
 
 				if (a.Info.MuzzleSequence != null)

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -78,6 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class AttackGarrisoned : AttackFollow, INotifyPassengerEntered, INotifyPassengerExited, IRender
 	{
 		public readonly new AttackGarrisonedInfo Info;
+		INotifyAttack[] notifyAttacks;
 		Lazy<BodyOrientation> coords;
 		List<Armament> armaments;
 		List<AnimationWithOffset> muzzles;
@@ -100,6 +101,12 @@ namespace OpenRA.Mods.Common.Traits
 		protected override Func<IEnumerable<Armament>> InitializeGetArmaments(Actor self)
 		{
 			return () => armaments;
+		}
+
+		protected override void Created(Actor self)
+		{
+			notifyAttacks = self.TraitsImplementing<INotifyAttack>().ToArray();
+			base.Created(self);
 		}
 
 		void INotifyPassengerEntered.OnPassengerEntered(Actor self, Actor passenger)
@@ -182,7 +189,7 @@ namespace OpenRA.Mods.Common.Traits
 					muzzleAnim.PlayThen(sequence, () => muzzles.Remove(muzzleFlash));
 				}
 
-				foreach (var npa in self.TraitsImplementing<INotifyAttack>())
+				foreach (var npa in notifyAttacks)
 					npa.Attacking(self, target, a, barrel);
 			}
 		}

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -86,10 +86,6 @@ namespace OpenRA.Mods.D2k.Activities
 			if (barrel == null)
 				return false;
 
-			// armament.CheckFire already calls INotifyAttack.PreparingAttack
-			foreach (var notify in self.TraitsImplementing<INotifyAttack>())
-				notify.Attacking(self, target, armament, barrel);
-
 			return true;
 		}
 

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -33,7 +33,6 @@ namespace OpenRA.Mods.D2k.Activities
 		readonly Armament armament;
 		readonly AttackSwallow swallow;
 		readonly IPositionable positionable;
-		readonly IFacing facing;
 
 		int countdown;
 		CPos burrowLocation;
@@ -43,7 +42,6 @@ namespace OpenRA.Mods.D2k.Activities
 		public SwallowActor(Actor self, Target target, Armament a, IFacing facing)
 		{
 			this.target = target;
-			this.facing = facing;
 			armament = a;
 			weapon = a.Weapon;
 			sandworm = self.Trait<Sandworm>();
@@ -82,11 +80,7 @@ namespace OpenRA.Mods.D2k.Activities
 			foreach (var player in affectedPlayers)
 				self.World.AddFrameEndTask(w => w.Add(new MapNotificationEffect(player, "Speech", swallow.Info.WormAttackNotification, 25, true, attackPosition, Color.Red)));
 
-			var barrel = armament.CheckFire(self, facing, target);
-			if (barrel == null)
-				return false;
-
-			return true;
+			return armament.TryFiring(self, target);
 		}
 
 		public override bool Tick(Actor self)


### PR DESCRIPTION
Split from #18170. 

This is the bulk of (presumably) uncontroversial changes from #18170 to reduce its number of commits and diff for easier reviewing.

Apart from making `FireDelay` work on special cases like D2k worms and using up-to-date information when actually creating and launching the projectile, this PR doesn't introduce any real changes, so testing for in-game regressions on edge cases like Grenadiers (FireDelay), pillboxes, D2k worms and some representative two-shooter should be enough to catch any potential regressions.

It would be good if this PR was reviewed (and hopefully merged) fairly quickly, so I can rebase and update #18170 soon.