### PR TITLE
Add Damage Type checks to ShakeOnDeath and SoundOnDamageTransition.

### DIFF
--- a/OpenRA.Mods.Common/Traits/ShakeOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/ShakeOnDeath.cs
@@ -9,12 +9,16 @@
  */
 #endregion
 
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
 	public class ShakeOnDeathInfo : TraitInfo
 	{
+		[Desc("DeathType(s) that trigger the shake. Leave empty to always trigger a shake.")]
+		public readonly BitSet<DamageType> DeathTypes = default(BitSet<DamageType>);
+
 		public readonly int Duration = 10;
 		public readonly int Intensity = 1;
 		public override object Create(ActorInitializer init) { return new ShakeOnDeath(this); }
@@ -31,6 +35,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyKilled.Killed(Actor self, AttackInfo e)
 		{
+			if (!info.DeathTypes.IsEmpty && !e.Damage.DamageTypes.Overlaps(info.DeathTypes))
+				return;
+
 			self.World.WorldActor.Trait<ScreenShaker>().AddEffect(info.Duration, self.CenterPosition, info.Intensity);
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Sound/SoundOnDamageTransition.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/SoundOnDamageTransition.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Sound
@@ -20,6 +21,9 @@ namespace OpenRA.Mods.Common.Traits.Sound
 
 		[Desc("Play a random sound from this list when destroyed.")]
 		public readonly string[] DestroyedSounds = { };
+
+		[Desc("DamageType(s) that trigger the sounds. Leave empty to always trigger a sound.")]
+		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
 
 		public override object Create(ActorInitializer init) { return new SoundOnDamageTransition(this); }
 	}
@@ -35,6 +39,9 @@ namespace OpenRA.Mods.Common.Traits.Sound
 
 		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
 		{
+			if (!info.DamageTypes.IsEmpty && !e.Damage.DamageTypes.Overlaps(info.DamageTypes))
+				return;
+
 			var rand = Game.CosmeticRandom;
 
 			if (e.DamageState == DamageState.Dead)


### PR DESCRIPTION
I finally decided to get around to make Chrono Legionnaries actually kill the units instead of disposing them, which prevented then from getting experience. But this 2 traits seems to be missing damage type checks so i couldn't prevent CLeg from triggering them, so added them.