### PR TITLE
Move shared sound and color definitions to common metrics

### DIFF
--- a/mods/cnc/metrics.yaml
+++ b/mods/cnc/metrics.yaml
@@ -7,9 +7,6 @@ Metrics:
 	ColorPickerActorType: fact.colorpicker
 	ColorPickerRemapIndices: 176, 178, 180, 182, 184, 186, 189, 191, 177, 179, 181, 183, 185, 187, 188, 190
 	TextfieldColorHighlight: 800000
-	ChatLineSound: ChatLine
-	ClickDisabledSound: ClickDisabledSound
-	ClickSound: ClickSound
 	ChatMessageColor: FFFFFF
 	SystemMessageColor: FFFF00
 	NormalSelectionColor: FFFFFF

--- a/mods/cnc/metrics.yaml
+++ b/mods/cnc/metrics.yaml
@@ -7,8 +7,3 @@ Metrics:
 	ColorPickerActorType: fact.colorpicker
 	ColorPickerRemapIndices: 176, 178, 180, 182, 184, 186, 189, 191, 177, 179, 181, 183, 185, 187, 188, 190
 	TextfieldColorHighlight: 800000
-	ChatMessageColor: FFFFFF
-	SystemMessageColor: FFFF00
-	NormalSelectionColor: FFFFFF
-	AltSelectionColor: 00FFFF
-	CtrlSelectionColor: FFFF00

--- a/mods/common/metrics.yaml
+++ b/mods/common/metrics.yaml
@@ -46,3 +46,6 @@ Metrics:
 	NoticeWarningColor: FFA500
 	NoticeSuccessColor: 00FF00
 	NoticeErrorColor: FF0000
+	ChatLineSound: ChatLine
+	ClickDisabledSound: ClickDisabledSound
+	ClickSound: ClickSound

--- a/mods/common/metrics.yaml
+++ b/mods/common/metrics.yaml
@@ -49,3 +49,8 @@ Metrics:
 	ChatLineSound: ChatLine
 	ClickDisabledSound: ClickDisabledSound
 	ClickSound: ClickSound
+	ChatMessageColor: FFFFFF
+	SystemMessageColor: FFFF00
+	NormalSelectionColor: FFFFFF
+	AltSelectionColor: 00FFFF
+	CtrlSelectionColor: FFFF00

--- a/mods/d2k/metrics.yaml
+++ b/mods/d2k/metrics.yaml
@@ -7,9 +7,6 @@ Metrics:
 	FactionSuffix-smuggler: ordos
 	FactionSuffix-mercenary: ordos
 	TextfieldColorHighlight: 7f4d29
-	ChatLineSound: ChatLine
-	ClickDisabledSound: ClickDisabledSound
-	ClickSound: ClickSound
 	ChatMessageColor: FFFFFF
 	SystemMessageColor: FFFF00
 	NormalSelectionColor: FFFFFF

--- a/mods/d2k/metrics.yaml
+++ b/mods/d2k/metrics.yaml
@@ -7,8 +7,3 @@ Metrics:
 	FactionSuffix-smuggler: ordos
 	FactionSuffix-mercenary: ordos
 	TextfieldColorHighlight: 7f4d29
-	ChatMessageColor: FFFFFF
-	SystemMessageColor: FFFF00
-	NormalSelectionColor: FFFFFF
-	AltSelectionColor: 00FFFF
-	CtrlSelectionColor: FFFF00

--- a/mods/ra/metrics.yaml
+++ b/mods/ra/metrics.yaml
@@ -16,8 +16,3 @@ Metrics:
 	IncompatibleProtectedGameColor: B22222
 	IncompatibleVersionColor: D3D3D3
 	TextfieldColorHighlight: 562020
-	ChatMessageColor: FFFFFF
-	SystemMessageColor: FFFF00
-	NormalSelectionColor: FFFFFF
-	AltSelectionColor: 00FFFF
-	CtrlSelectionColor: FFFF00

--- a/mods/ra/metrics.yaml
+++ b/mods/ra/metrics.yaml
@@ -16,9 +16,6 @@ Metrics:
 	IncompatibleProtectedGameColor: B22222
 	IncompatibleVersionColor: D3D3D3
 	TextfieldColorHighlight: 562020
-	ChatLineSound: ChatLine
-	ClickDisabledSound: ClickDisabledSound
-	ClickSound: ClickSound
 	ChatMessageColor: FFFFFF
 	SystemMessageColor: FFFF00
 	NormalSelectionColor: FFFFFF

--- a/mods/ts/metrics.yaml
+++ b/mods/ts/metrics.yaml
@@ -3,8 +3,3 @@ Metrics:
 	ColorPickerActorType: mmch.colorpicker
 	ColorPickerRemapIndices: 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
 	TextfieldColorHighlight: 1a1a1a
-	ChatMessageColor: FFFFFF
-	SystemMessageColor: FFFF00
-	NormalSelectionColor: FFFFFF
-	AltSelectionColor: 00FFFF
-	CtrlSelectionColor: FFFF00

--- a/mods/ts/metrics.yaml
+++ b/mods/ts/metrics.yaml
@@ -3,9 +3,6 @@ Metrics:
 	ColorPickerActorType: mmch.colorpicker
 	ColorPickerRemapIndices: 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
 	TextfieldColorHighlight: 1a1a1a
-	ChatLineSound: ChatLine
-	ClickDisabledSound: ClickDisabledSound
-	ClickSound: ClickSound
 	ChatMessageColor: FFFFFF
 	SystemMessageColor: FFFF00
 	NormalSelectionColor: FFFFFF


### PR DESCRIPTION
When updating a mod from an older version all your text will suddenly be black even when you reference the common metrics file. Plus this reduces some duplication.