### PR TITLE
Add a text field next to the map editor actor initializer sliders.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -308,6 +308,20 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							slider.OnChange += value => so.OnChange(actor, value);
 							slider.OnChange += value => editorActionHandle.OnChange(value);
 
+							var valueField = sliderContainer.GetOrNull<TextFieldWidget>("VALUE");
+							if (valueField != null)
+							{
+								Action<float> updateValueField = f => valueField.Text = ((int)f).ToString();
+								updateValueField(so.GetValue(actor));
+								slider.OnChange += updateValueField;
+
+								valueField.OnTextEdited = () =>
+								{
+									if (float.TryParse(valueField.Text, out var result))
+										slider.UpdateValue(result);
+								};
+							}
+
 							initContainer.AddChild(sliderContainer);
 						}
 						else if (o is EditorActorDropdown)

--- a/OpenRA.Mods.Common/Widgets/SliderWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SliderWidget.cs
@@ -48,10 +48,12 @@ namespace OpenRA.Mods.Common.Widgets
 			GetValue = other.GetValue;
 		}
 
-		void UpdateValue(float newValue)
+		public void UpdateValue(float newValue)
 		{
+			var oldValue = Value;
 			Value = newValue.Clamp(MinimumValue, MaximumValue);
-			OnChange(Value);
+			if (oldValue != Value)
+				OnChange(Value);
 		}
 
 		public override bool HandleMouseInput(MouseInput mi)
@@ -114,7 +116,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (!IsVisible())
 				return;
 
-			Value = GetValue();
+			UpdateValue(GetValue());
 
 			var tr = ThumbRect;
 			var rb = RenderBounds;

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -277,8 +277,14 @@ Container@EDITOR_WORLD_ROOT:
 										Slider@OPTION:
 											X: 58
 											Y: 1
-											Width: 207
+											Width: 146
 											Height: 20
+										TextField@VALUE:
+											X: 206
+											Y: 1
+											Width: 50
+											Height: 20
+											Type: Integer
 								Container@DROPDOWN_OPTION_TEMPLATE:
 									Width: PARENT_RIGHT
 									Height: 27

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -271,8 +271,14 @@ Container@EDITOR_WORLD_ROOT:
 										Slider@OPTION:
 											X: 75
 											Y: 1
-											Width: 210
+											Width: 149
 											Height: 20
+										TextField@VALUE:
+											X: 226
+											Y: 1
+											Width: 50
+											Height: 20
+											Type: Integer
 								Container@DROPDOWN_OPTION_TEMPLATE:
 									Width: PARENT_RIGHT
 									Height: 27


### PR DESCRIPTION
This PR is #18361 with fixups applied so we can get that feature merged.
* Fixes @abcdefg30's requests
* Fixes text box positioning (misaligned by 1px along the right edge)
* Fixed commit message running past the shortlog length limit and being wrapped
* Squashed fixups into main commit
* Dropped an unnecessary blank line

Unfortunately @papaneko has disabled maintainer pushes, so I couldn't push this directly to the original PR.

This now LGTM, so filing this with my :+1: already applied.