### PR TITLE
TD Balance 2020 #3

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -67,7 +67,7 @@ HELI:
 		TurnSpeed: 28
 		Speed: 180
 	Health:
-		HP: 12500
+		HP: 12000
 	Armor:
 		Type: Light
 	RevealsShroud:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -49,65 +49,41 @@
 	GainsExperience:
 		LevelUpNotification: LevelUp
 		Conditions:
-			200: rank-veteran
-			400: rank-veteran
+			250: rank-veteran
+			500: rank-veteran
 			800: rank-veteran
-			1600: rank-veteran
 		LevelUpImage: crate-effects
 	GrantCondition@RANK-ELITE:
-		RequiresCondition: rank-veteran >= 4
+		RequiresCondition: rank-veteran >= 3
 		Condition: rank-elite
-	DamageMultiplier@RANK-1:
-		RequiresCondition: rank-veteran == 1
-		Modifier: 95
-	DamageMultiplier@RANK-2:
-		RequiresCondition: rank-veteran == 2
-		Modifier: 90
-	DamageMultiplier@RANK-3:
-		RequiresCondition: rank-veteran == 3
-		Modifier: 85
-	DamageMultiplier@RANK-ELITE:
-		RequiresCondition: rank-elite
-		Modifier: 75
 	FirepowerMultiplier@RANK-1:
 		RequiresCondition: rank-veteran == 1
-		Modifier: 105
+		Modifier: 125
 	FirepowerMultiplier@RANK-2:
 		RequiresCondition: rank-veteran == 2
-		Modifier: 110
-	FirepowerMultiplier@RANK-3:
-		RequiresCondition: rank-veteran == 3
-		Modifier: 120
+		Modifier: 125
 	FirepowerMultiplier@RANK-ELITE:
 		RequiresCondition: rank-elite
-		Modifier: 130
-	SpeedMultiplier@RANK-1:
-		RequiresCondition: rank-veteran == 1
-		Modifier: 105
-	SpeedMultiplier@RANK-2:
+		Modifier: 125
+	DamageMultiplier@RANK-2:
 		RequiresCondition: rank-veteran == 2
-		Modifier: 110
-	SpeedMultiplier@RANK-3:
-		RequiresCondition: rank-veteran == 3
-		Modifier: 120
+		Modifier: 80
+	DamageMultiplier@RANK-ELITE:
+		RequiresCondition: rank-elite
+		Modifier: 80
 	SpeedMultiplier@RANK-ELITE:
 		RequiresCondition: rank-elite
-		Modifier: 140
-	ReloadDelayMultiplier@RANK-1:
-		RequiresCondition: rank-veteran == 1
-		Modifier: 95
-	ReloadDelayMultiplier@RANK-2:
-		RequiresCondition: rank-veteran == 2
-		Modifier: 90
-	ReloadDelayMultiplier@RANK-3:
-		RequiresCondition: rank-veteran == 3
-		Modifier: 85
-	ReloadDelayMultiplier@RANK-ELITE:
+		Modifier: 125
+	RangeMultiplier@RANK-ELITE:
 		RequiresCondition: rank-elite
-		Modifier: 75
+		Modifier: 125
+	RevealsShroudMultiplier@RANK-ELITE:
+		RequiresCondition: rank-elite
+		Modifier: 125
 	ChangesHealth@ELITE:
-		Step: 200
-		Delay: 100
+		Step: 0
+		PercentageStep: 5
+		Delay: 75
 		StartIfBelow: 100
 		DamageCooldown: 125
 		RequiresCondition: rank-elite
@@ -127,14 +103,6 @@
 		Margin: 5, 6
 		ValidStances: Ally, Enemy, Neutral
 		RequiresCondition: rank-veteran == 2
-	WithDecoration@RANK-3:
-		Image: rank
-		Sequence: rank-veteran-3
-		Palette: effect
-		Position: BottomRight
-		Margin: 5, 6
-		ValidStances: Ally, Enemy, Neutral
-		RequiresCondition: rank-veteran == 3
 	WithDecoration@RANK-ELITE:
 		Image: rank
 		Sequence: rank-elite
@@ -151,11 +119,6 @@
 			hospitalheal && hazmatsuits: On, Off, Off
 			hospitalheal || hazmatsuits: On, Off
 	WithDecoration@RANK-2:
-		BlinkInterval: 32
-		BlinkPatterns:
-			hospitalheal && hazmatsuits: On, Off, Off
-			hospitalheal || hazmatsuits: On, Off
-	WithDecoration@RANK-3:
 		BlinkInterval: 32
 		BlinkPatterns:
 			hospitalheal && hazmatsuits: On, Off, Off
@@ -890,7 +853,6 @@
 	RenderSprites:
 		Palette: staticterrain
 	WithWallSpriteBody:
-	GivesExperience:
 	Sellable:
 		SellSounds: cashturn.aud
 	Guardable:

--- a/mods/cnc/rules/husks.yaml
+++ b/mods/cnc/rules/husks.yaml
@@ -17,7 +17,7 @@ HARV.Husk:
 		Image: harv.destroyed
 
 APC.Husk:
-	Inherits: ^LightHusk
+	Inherits: ^Husk
 	Tooltip:
 		Name: APC (Destroyed)
 	TransformOnCapture:
@@ -35,7 +35,7 @@ FTNK.Husk:
 		Image: ftnk.destroyed
 
 ARTY.Husk:
-	Inherits: ^Husk
+	Inherits: ^LightHusk
 	Tooltip:
 		Name: Artillery (Destroyed)
 	TransformOnCapture:
@@ -104,7 +104,7 @@ HTNK.Husk:
 		Image: htnk.destroyed
 
 MSAM.Husk:
-	Inherits: ^Husk
+	Inherits: ^LightHusk
 	Tooltip:
 		Name: Rocket Launcher (Destroyed)
 	ThrowsParticle@turret:
@@ -115,7 +115,7 @@ MSAM.Husk:
 		Image: msam.destroyed
 
 MLRS.Husk:
-	Inherits: ^Husk
+	Inherits: ^LightHusk
 	Tooltip:
 		Name: Mobile S.A.M. (Destroyed)
 	ThrowsParticle@turret:
@@ -135,7 +135,7 @@ STNK.Husk:
 		Image: stnk.destroyed
 
 TRUCK.Husk:
-	Inherits: ^Husk
+	Inherits: ^LightHusk
 	Tooltip:
 		Name: Supply Truck (Destroyed)
 	TransformOnCapture:

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -198,7 +198,7 @@ RMBO:
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Inherits@DECORATIONS: ^InfantryExperienceHospitalHazmatOverrides
 	Valued:
-		Cost: 2000
+		Cost: 1800
 	Tooltip:
 		Name: Commando
 	UpdatesPlayerStatistics:
@@ -207,8 +207,6 @@ RMBO:
 		BuildPaletteOrder: 50
 		Prerequisites: eye, ~techlevel.high
 		Queue: Infantry.GDI
-		BuildDuration: 2000
-		BuildDurationModifier: 40
 		Description: Elite sniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles
 	Mobile:
 		Speed: 71

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -4,7 +4,7 @@ FACT:
 	Selectable:
 		Bounds: 72,48
 	Valued:
-		Cost: 3500
+		Cost: 3000
 	Tooltip:
 		Name: Construction Yard
 	Building:
@@ -47,7 +47,7 @@ FACT:
 		DisplayOrder: 0
 		Factions: gdi
 		Group: Building
-		LowPowerModifier: 200
+		LowPowerModifier: 150
 		ReadyAudio: ConstructionComplete
 		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
@@ -59,7 +59,7 @@ FACT:
 		DisplayOrder: 0
 		Factions: nod
 		Group: Building
-		LowPowerModifier: 200
+		LowPowerModifier: 150
 		ReadyAudio: ConstructionComplete
 		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
@@ -71,7 +71,7 @@ FACT:
 		DisplayOrder: 1
 		Factions: gdi
 		Group: Defence
-		LowPowerModifier: 300
+		LowPowerModifier: 150
 		ReadyAudio: ConstructionComplete
 		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
@@ -83,7 +83,7 @@ FACT:
 		DisplayOrder: 1
 		Factions: nod
 		Group: Defence
-		LowPowerModifier: 300
+		LowPowerModifier: 150
 		ReadyAudio: ConstructionComplete
 		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
@@ -153,7 +153,6 @@ NUKE:
 		BuildPaletteOrder: 10
 		Prerequisites: fact
 		Queue: Building.GDI, Building.Nod
-		BuildDuration: 330
 		Description: Generates power
 	Building:
 		Footprint: xX xx ==
@@ -240,7 +239,7 @@ PROC:
 		Bounds: 72,56
 		DecorationBounds: 73,72
 	CustomSellValue:
-		Value: 500
+		Value: 400
 	FreeActor:
 		Actor: HARV
 		SpawnOffset: 1,2
@@ -333,7 +332,7 @@ PYLE:
 		Type: Infantry.GDI
 		DisplayOrder: 2
 		Group: Infantry
-		LowPowerModifier: 300
+		LowPowerModifier: 150
 		ReadyAudio: UnitReady
 		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
@@ -384,7 +383,7 @@ HAND:
 		Type: Infantry.Nod
 		DisplayOrder: 2
 		Group: Infantry
-		LowPowerModifier: 300
+		LowPowerModifier: 150
 		ReadyAudio: UnitReady
 		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
@@ -445,7 +444,7 @@ AFLD:
 		Type: Vehicle.Nod
 		DisplayOrder: 3
 		Group: Vehicle
-		LowPowerModifier: 300
+		LowPowerModifier: 150
 		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
 		QueuedAudio: Training
@@ -502,7 +501,7 @@ WEAP:
 		Type: Vehicle.GDI
 		DisplayOrder: 3
 		Group: Vehicle
-		LowPowerModifier: 300
+		LowPowerModifier: 150
 		ReadyAudio: UnitReady
 		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
@@ -561,7 +560,7 @@ HPAD:
 		DisplayOrder: 4
 		Factions: gdi
 		Group: Aircraft
-		LowPowerModifier: 300
+		LowPowerModifier: 150
 		ReadyAudio: UnitReady
 		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
@@ -573,7 +572,7 @@ HPAD:
 		DisplayOrder: 4
 		Factions: nod
 		Group: Aircraft
-		LowPowerModifier: 300
+		LowPowerModifier: 150
 		ReadyAudio: UnitReady
 		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
@@ -585,7 +584,7 @@ HPAD:
 	ProductionBar@Nod:
 		ProductionType: Aircraft.Nod
 	Power:
-		Amount: -10
+		Amount: -20
 	ProvidesPrerequisite@buildingname:
 
 HQ:
@@ -631,7 +630,7 @@ HQ:
 		PauseOnCondition: lowpower
 		Prerequisites: ~techlevel.superweapons
 		Icon: airstrike
-		ChargeInterval: 6000
+		ChargeInterval: 7500
 		SquadSize: 3
 		QuantizedFacings: 8
 		Description: Air Strike
@@ -740,7 +739,7 @@ EYE:
 		Prerequisites: ~techlevel.superweapons
 		Icon: ioncannon
 		Cursor: ioncannon
-		ChargeInterval: 6750
+		ChargeInterval: 9000
 		Description: Ion Cannon
 		LongDesc: Initiate an Ion Cannon strike.\nApplies instant damage to a small area.
 		BeginChargeSpeechNotification: IonCannonCharging
@@ -794,7 +793,7 @@ TMPL:
 		Prerequisites: ~techlevel.superweapons
 		Icon: abomb
 		Cursor: nuke
-		ChargeInterval: 9000
+		ChargeInterval: 11250
 		Description: Nuclear Strike
 		LongDesc: Launch a tactical nuclear warhead.\nApplies heavy damage over a large area.
 		EndChargeSpeechNotification: NuclearWeaponAvailable
@@ -901,7 +900,7 @@ SAM:
 	Armor:
 		Type: Heavy
 	RevealsShroud:
-		Range: 6c0
+		Range: 8c0
 	Turreted:
 		TurnSpeed: 40
 		InitialFacing: 0
@@ -1131,8 +1130,6 @@ BRIK:
 	Crushable:
 		CrushClasses: heavywall
 		-CrushSound:
-	SoundOnDamageTransition:
-		DestroyedSounds: crumble.aud
 	LineBuild:
 		NodeTypes: concrete
 	LineBuildNode:

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -3,6 +3,7 @@ V19:
 	Selectable:
 		Bounds: 24,24
 	CashTrickler:
+		Amount: 10
 	Building:
 		Footprint: x
 		Dimensions: 1,1
@@ -83,10 +84,10 @@ BIO:
 	Tooltip:
 		Name: Biological Lab
 	TooltipDescription@ally:
-		Description: Produces Bio-Lab units.
+		Description: Provides infantry with Tiberium immunity. Produces Visceroids.
 		ValidStances: Ally
 	TooltipDescription@other:
-		Description: Capture to produce Bio-Lab units.
+		Description: Capture to enable Tiberium immunity for infantry. Produces Visceroids.
 		ValidStances: Neutral, Enemy
 	Exit@1:
 		SpawnOffset: 0,-426,0

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -2,15 +2,13 @@ MCV:
 	Inherits: ^Vehicle
 	Inherits@selection: ^SelectableSupportUnit
 	Valued:
-		Cost: 3500
+		Cost: 3000
 	Tooltip:
 		Name: Mobile Construction Vehicle
 	Buildable:
 		BuildPaletteOrder: 100
 		Prerequisites: anyhq, ~techlevel.medium, fix
 		Queue: Vehicle.GDI, Vehicle.Nod
-		BuildDuration: 3750
-		BuildDurationModifier: 40
 		Description: Deploys into another Construction Yard.\n  Unarmed
 	Selectable:
 		DecorationBounds: 36,36
@@ -44,7 +42,7 @@ HARV:
 	Inherits@CLOAK: ^AcceptsCloakCrate
 	Inherits@selection: ^SelectableEconomicUnit
 	Valued:
-		Cost: 1000
+		Cost: 1100
 	Tooltip:
 		Name: Harvester
 		GenericName: Harvester
@@ -52,8 +50,6 @@ HARV:
 		BuildPaletteOrder: 10
 		Prerequisites: proc
 		Queue: Vehicle.GDI, Vehicle.Nod
-		BuildDuration: 1680
-		BuildDurationModifier: 40
 		Description: Collects Tiberium for processing.\n  Unarmed
 	Selectable:
 		DecorationBounds: 36,36
@@ -316,8 +312,8 @@ BIKE:
 		Description: Fast scout vehicle, armed with\nrockets.\nCan attack Aircraft.\n  Strong vs Vehicles, Tanks\n  Weak vs Infantry
 	Mobile:
 		TurnSpeed: 40
-		Speed: 213
-		Locomotor: bike
+		Speed: 184
+		Locomotor: wheeled
 	Health:
 		HP: 11000
 	Repairable:
@@ -633,7 +629,7 @@ STNK:
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetAllAssaultMove
 	Valued:
-		Cost: 900
+		Cost: 1000
 	Tooltip:
 		Name: Stealth Tank
 	UpdatesPlayerStatistics:
@@ -660,6 +656,7 @@ STNK:
 		CloakDelay: 90
 		CloakSound: trans1.aud
 		UncloakSound: trans1.aud
+		UncloakOn: Attack, Unload, Dock, Damage, Heal
 		PauseOnCondition: cloak-force-disabled
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
@@ -707,9 +704,10 @@ TRUCK:
 		Queue: Vehicle.GDI, Vehicle.Nod
 		BuildPaletteOrder: 35
 		Prerequisites: vehicleproduction
-		Description: Transports cash to other players.\n  Unarmed
+		BuildDuration: 500
+		Description: Transports cash to other players.\n  Builds fast\n  Unarmed
 	Valued:
-		Cost: 500
+		Cost: 1000
 	Tooltip:
 		Name: Supply Truck
 	Health:
@@ -721,8 +719,8 @@ TRUCK:
 	RevealsShroud:
 		Range: 4c0
 	DeliversCash:
-		Payload: 500
-		PlayerExperience: 50
+		Payload: 1000
+		PlayerExperience: 100
 	SpawnActorOnDeath:
 		Actor: TRUCK.Husk
 		OwnerType: InternalName

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -52,17 +52,6 @@
 			Tiberium: 50
 			BlueTiberium: 50
 			Beach: 50
-	Locomotor@BIKE:
-		Name: bike
-		Crushes: crate
-		TerrainSpeeds:
-			Clear: 70
-			Rough: 35
-			Road: 100
-			Bridge: 100
-			Tiberium: 35
-			BlueTiberium: 35
-			Beach: 35
 	Locomotor@HEAVYWHEELED:
 		Name: heavywheeled
 		Crushes: crate, infantry

--- a/mods/cnc/weapons/ballistics.yaml
+++ b/mods/cnc/weapons/ballistics.yaml
@@ -34,7 +34,7 @@
 		Damage: 2500
 		Versus:
 			None: 24
-			Wood: 72
+			Wood: 88
 			Light: 100
 			Heavy: 88
 

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -160,7 +160,7 @@ MammothMissiles:
 		Versus:
 			None: 24
 			Wood: 60
-			Light: 90
+			Light: 100
 			Heavy: 48
 	Warhead@3Eff: CreateEffect
 		Explosions: med_frag

--- a/mods/cnc/weapons/other.yaml
+++ b/mods/cnc/weapons/other.yaml
@@ -1,13 +1,13 @@
 ^FlameWeapon:
 	ValidTargets: Ground, Water, Trees
 	ReloadDelay: 55
-	Range: 2c512
+	Range: 3c0
 	InvalidTargets: Wall
 	Report: flamer2.aud
 	Projectile: Bullet
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
-		Spread: 468
+		Spread: 256
 		Damage: 4000
 		ValidTargets: Ground, Water, Trees
 		InvalidTargets: Wall
@@ -26,8 +26,6 @@
 
 Flamethrower:
 	Inherits: ^FlameWeapon
-	Warhead@1Dam: SpreadDamage
-		Spread: 256
 
 BigFlamer:
 	Inherits: ^FlameWeapon
@@ -51,10 +49,8 @@ BigFlamer:
 Chemspray:
 	Inherits: ^FlameWeapon
 	ReloadDelay: 65
-	Range: 3c0
 	-InvalidTargets:
 	Warhead@1Dam: SpreadDamage
-		Spread: 256
 		Damage: 8000
 		-InvalidTargets:
 		Versus:

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -48,8 +48,9 @@ Vulcan:
 		Spread: 426
 		Damage: 10000
 		Versus:
+			None: 90
 			Wood: 15
-			Light: 30
+			Light: 35
 			Heavy: 35
 
 HeliAGGun:
@@ -63,7 +64,7 @@ HeliAGGun:
 	Projectile: Bullet
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
-		Spread: 256
+		Spread: 128
 		Damage: 2000
 		Versus:
 			None: 100
@@ -76,7 +77,6 @@ HeliAAGun:
 	Inherits: HeliAGGun
 	ValidTargets: Air
 	Warhead@1Dam: SpreadDamage
-		Spread: 128
 		ValidTargets: Air
 		Versus:
 			Light: 50
@@ -162,7 +162,7 @@ APCGun.AA:
 		Versus:
 			None: 60
 			Wood: 60
-			Light: 125
+			Light: 140
 			Heavy: 60
 	Warhead@2Eff: CreateEffect
 		Explosions: small_poof


### PR DESCRIPTION
This is the third major patch addressing TD balance. This one addresses support powers, and went under the name "Rain and Thunder". With this patch I believe I have the majority of the outstanding issues smoothed out. From here it will be tweaks/polish, rather than major changes (hopefully). As per usual I also addressed other issues that came up in addition to the support power changes.

**Support Powers**
`Airstrike: 4:00 -> 5:00`
`Ion Cannon: 4:30 -> 6:00` 
`Nuke: 6:00 -> 7:30`

Support powers (Or "one clicks" as they're called in CnC3) define the game too much. They hit too early and too often. It's frustrating having a good flanking attack cleaned up by an airstrike, or a rag tag defense instantly annihilated by an ion cannon. Pushing them further out significantly reduces their impact, as you have more assets and can more easily lose a small army.

`Airstrike Vulcan: None 100 -> 90`

Airstrike was a little *too* good at shredding infantry. This is a small change to let infantry at the edges of the airstrike able to dodge easier.

**Removing Custom Build Times**
I've been slowly removing custom build times over time. I don't think they're a good way to balance. I took the plunge and removed the last of them (except defenses, which I don't plan to change) this patch.

`Harvester: Cost 1000 -> 1100, custom build time was 1100`

Building economy was a little too good at the moment, so this should help with that.

`MCV/Conyard: Cost 3500 -> 3000, custom build time was 2500`

This should make going two MCV early on more punishing (even less combat vehicles produced), but more reasonable late game (where cash is more of a restriction than production).

`Commando: Cost 2000 -> 1800, custom build time was 1400`

The much asked for commando cost reduction is in. Infantry production is fairly easy to obtain, so I don't think the production time increase will have much impact.

`Power Plant: Cost 500, custom build time was 300`

This was added by AoA to address low power snowballing issues. I actually like the change, but I think there's a better way to do it. The side effect of this change makes teching faster, which was causing issues. It also made basic power plants better than adv in most cases.

**Low Power Adjustments**
Low power snowballing is a unique issue for TD. Power is expensive and is easy to eliminate with bikes and other fast attack vehicles.

`Low Power Structure Modifier: 200% -> 150%`
`All Other Low Power Modifiers: 300% -> 150%`

Combined with the buildspeed change of the power plant, this readjusts the weaknesses of low power. Getting power back online actually takes longer (300x2 = 600 old, 500x1.5 = 750 new), which will result in longer delays in structure production, defenses being offline, and support powers delayed. However unit production takes significantly less of a hit, so you can actually produce the units you need to defend your power plants (preventing snowballing).

**Balance Adjustments**
`Sam Site: Vision 6 -> 8`

Sam sites have 10 range! They rarely get to use it though since their vision is so low. This combined with their pop-up animation makes them extremely easy to abuse with air. Their vision now matches the AGT.

`Flamethrower: Range 2.5 -> 3`

Flamethrowers are kind of weak and have a lot of difficulty attacking in army fights. They tend to bug out and reach melee range with enemy units. I found chem warriors a lot more reliable (which have 3 range), so I changed the flamethrower range to match it. Buggies/humvees have opportunity fire so they can still easily kite flamethrowers if someone puts in the time to micro it.

`Oil: Income 15 -> 10`

Oils were defining games too much. You lose oil control you lose the game. With the reduced income they are still useful to capture (particularly mid-game), but an early oil scuffle won't end the game anymore.

`Light Tank: Wood 72 -> 88`

With this change their wood damage now matches their heavy damage (88). Light tanks had an abnormally low structure damage and had a hard time doing any kind of structure harassment. I imagine this was because light tanks used to be OP, but this is no longer the case.

`Apache: Health 12500 -> 12000, AG Spread 256 -> 128`

Apaches were over performing quite a bit in patch. Their ability to obtain value was much faster and easier than orcas. There were also some meta issues: Apaches kill everything that kill infantry (buggies, infantry, artillery, other apaches) which meant you could just spam infantry + apache.

The 500 health allowed Apaches to resist one more stealth tank (2 -> 3) and bike (4 -> 5) shot, which didn't really seem necessary. Apaches already demolish bikes and stealth tanks received an AA nerf.

The AOE adjustment means they don't clean up rocket soldiers as easily anymore. You'd quickly go from 2 shot on rocket soldiers to 1 shot due to the AOE. This allowed them to obtain a lot of value quickly, and made it difficult to defend your infantry detachments.

`Stealth Tank: Cost 900 -> 1100`

Now that games last longer due to the support power nerfs (and the airstrike damage nerf, which used to be the main counter to STs), it was quickly becoming apparent stealth tanks were overperforming. Just looking at the stats, they were good to build even without stealth! You'd often see players sacking a bunch of stealth tanks to kill a tech structure since they were so cheap. This change puts them less in a "spam and throw everywhere" position and more of something you have to micro and use well to get ahead.

`Helipad: Power -10 -> -20`

There was a particularly good build that let you get 2 refineries, 1 wf, 1 rax, comm center, and a helipad off of two powerplants.  You could have 3 production queues running and quickly expand. This change forces you to build a third powerplant if you want both infantry and aircraft production. It also doesn't really make sense the helipad needs less power than a barracks.

**Misc/Polish**
`Husk Changes:`
`APC: LightHusk -> Husk`
`MSAM/MRLS/Arty/Supply: Husk -> LightHusk`

 This is to address the issue raised by this comment: https://github.com/OpenRA/OpenRA/pull/15150#pullrequestreview-123690017

The APC change in particular is possible now that blocking has been removed.

`Concrete Death Sound Removed`

Concrete destruction uses the structure destruction sound, which is very confusing and panic inducing. I checked TD remastered and there is no sound for wall destruction, so I removed it.

`Walls no longer grant experience`

Didn't make sense, also RA walls don't grant experience so this makes it more consistent.

`Bike Mobile: Road/Bridge 100 -> 90`

This one is a bit lazy by me, but basically bikes get _more_ of a speed advantage for roads than other vehicles. This makes sense I guess, but can cause some maps to favor bikes vs others simply due to the road layout, which I think is restrictive for map makers.

A better solution might be to remove bikes having a unique locomotion entirely (they are also slower on tiberium compared to other vehicles). I'd like some feedback on this one.

![001597](https://user-images.githubusercontent.com/42915475/94465530-0b35ef80-018e-11eb-82bd-ca15ecb3cfa7.png)

`Biolab Description Change`
From: Produces Bio-Lab units
To: Provides infantry with Tiberium immunity. Produces Visceroids.

`Refinery Custom Sell Value: 500 -> 400`

Since harvesters cost 1100 now.

`Code cleanup`

Apache AG AOE now matches their air weapon, so that can be inherited.

Flamethrowers and Chems have the same AOE and range, so that can be inherited.

**Future**

Before merging, I still have a few issues to look at. I was a little sloppy in my first patch and the vulcans on the airstrike actually do more damage to heavy vehicles than light, which doesn't make sense. I also need to look into Nod late game. Even with the stealth tank nerf they are still overperforming some. I plan to do some small adjustments to the nuke AOE and probably another small ST nerf.

Part of my balance efforts: #18273, #18427, #18520
