### PR TITLE
Remove an used TerrainTemplateInfo constructor

### DIFF
--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -54,13 +54,6 @@ namespace OpenRA
 
 		readonly TerrainTileInfo[] tileInfo;
 
-		public TerrainTemplateInfo(ushort id, string[] images, int2 size, byte[] tiles)
-		{
-			Id = id;
-			Images = images;
-			Size = size;
-		}
-
 		public TerrainTemplateInfo(TileSet tileSet, MiniYaml my)
 		{
 			FieldLoader.Load(this, my);


### PR DESCRIPTION
It didn't work properly any more since the `byte[] tiles` parameter was unused. Since the constructor was unused itself after the Tileset Builder was removed, I deleted the constructor.