### PR TITLE
Emulate GLES using ANGLE on windows and disable legacy GL by default

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -188,6 +188,8 @@ distributed under MIT License.
 Using Json.NET developed by James Newton-King
 distributed under MIT License.
 
+Using ANGLE distributed under the BS3 3-Clause license.
+
 This site or product includes IP2Location LITE data
 available from http://www.ip2location.com.
 

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,9 @@ ifeq ($(TARGETPLATFORM), $(filter $(TARGETPLATFORM),win-x86 win-x64))
 	@$(INSTALL_PROGRAM) SDL2.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) freetype6.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) lua51.dll "$(DATA_INSTALL_DIR)"
+	@$(INSTALL_PROGRAM) libEGL.dll "$(DATA_INSTALL_DIR)"
+	@$(INSTALL_PROGRAM) libGLESv2.dll "$(DATA_INSTALL_DIR)"
+
 endif
 ifeq ($(TARGETPLATFORM), linux-x64)
 	@-echo "Installing OpenRA dependencies to $(DATA_INSTALL_DIR)"

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -26,7 +26,7 @@ namespace OpenRA
 
 	public interface IPlatform
 	{
-		IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int batchSize, int videoDisplay, GLProfile profile);
+		IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int batchSize, int videoDisplay, GLProfile profile, bool enableLegacyGL);
 		ISoundEngine CreateSound(string device);
 		IFont CreateFont(byte[] data);
 	}

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -18,6 +18,7 @@ namespace OpenRA
 	public enum GLProfile
 	{
 		Automatic,
+		ANGLE,
 		Modern,
 		Embedded,
 		Legacy

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -17,6 +17,7 @@ namespace OpenRA
 {
 	public enum GLProfile
 	{
+		Automatic,
 		Modern,
 		Embedded,
 		Legacy

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -77,7 +77,7 @@ namespace OpenRA
 
 			Window = platform.CreateWindow(new Size(resolution.Width, resolution.Height),
 				graphicSettings.Mode, graphicSettings.UIScale, graphicSettings.BatchSize,
-				graphicSettings.VideoDisplay, graphicSettings.GLProfile);
+				graphicSettings.VideoDisplay, graphicSettings.GLProfile, !graphicSettings.DisableLegacyGL);
 
 			Context = Window.Context;
 

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -172,13 +172,16 @@ namespace OpenRA
 		[Desc("Disable operating-system provided cursor rendering.")]
 		public bool DisableHardwareCursors = false;
 
+		[Desc("Disable legacy OpenGL 2.1 support.")]
+		public bool DisableLegacyGL = true;
+
 		[Desc("Display index to use in a multi-monitor fullscreen setup.")]
 		public int VideoDisplay = 0;
 
 		[Desc("Preferred OpenGL profile to use.",
 			"Modern: OpenGL Core Profile 3.2 or greater.",
 			"Embedded: OpenGL ES 3.0 or greater.",
-			"Legacy: OpenGL 2.1 with framebuffer_object extension.",
+			"Legacy: OpenGL 2.1 with framebuffer_object extension (requires DisableLegacyGL: False)",
 			"Automatic: Use the first supported profile.")]
 		public GLProfile GLProfile = GLProfile.Automatic;
 

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -178,8 +178,9 @@ namespace OpenRA
 		[Desc("Preferred OpenGL profile to use.",
 			"Modern: OpenGL Core Profile 3.2 or greater.",
 			"Embedded: OpenGL ES 3.0 or greater.",
-			"Legacy: OpenGL 2.1 with framebuffer_object extension.")]
-		public GLProfile GLProfile = GLProfile.Modern;
+			"Legacy: OpenGL 2.1 with framebuffer_object extension.",
+			"Automatic: Use the first supported profile.")]
+		public GLProfile GLProfile = GLProfile.Automatic;
 
 		public int BatchSize = 8192;
 		public int SheetSize = 2048;

--- a/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
@@ -105,18 +105,21 @@ namespace OpenRA.Mods.Common.LoadScreens
 
 		public virtual bool BeforeLoad()
 		{
+			var graphicSettings = Game.Settings.Graphics;
+
 			// Reset the UI scaling if the user has configured a UI scale that pushes us below the minimum allowed effective resolution
 			var minResolution = ModData.Manifest.Get<WorldViewportSizes>().MinEffectiveResolution;
 			var resolution = Game.Renderer.Resolution;
 			if ((resolution.Width < minResolution.Width || resolution.Height < minResolution.Height) && Game.Settings.Graphics.UIScale > 1.0f)
 			{
-				Game.Settings.Graphics.UIScale = 1.0f;
+				graphicSettings.UIScale = 1.0f;
 				Game.Renderer.SetUIScale(1.0f);
 			}
 
 			// Saved settings may have been invalidated by a hardware change
-			Game.Settings.Graphics.GLProfile = Game.Renderer.GLProfile;
-			Game.Settings.Graphics.VideoDisplay = Game.Renderer.CurrentDisplay;
+			graphicSettings.VideoDisplay = Game.Renderer.CurrentDisplay;
+			if (graphicSettings.GLProfile != GLProfile.Automatic && graphicSettings.GLProfile != Game.Renderer.GLProfile)
+				graphicSettings.GLProfile = GLProfile.Automatic;
 
 			// If a ModContent section is defined then we need to make sure that the
 			// required content is installed or switch to the defined content installer.

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -267,9 +267,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var glProfileLabel = new CachedTransform<GLProfile, string>(p => p.ToString());
 			var glProfileDropdown = panel.Get<DropDownButtonWidget>("GL_PROFILE_DROPDOWN");
+			var disableProfile = Game.Renderer.SupportedGLProfiles.Length < 2 && ds.GLProfile == GLProfile.Automatic;
 			glProfileDropdown.OnMouseDown = _ => ShowGLProfileDropdown(glProfileDropdown, ds);
 			glProfileDropdown.GetText = () => glProfileLabel.Update(ds.GLProfile);
-			glProfileDropdown.IsDisabled = () => Game.Renderer.SupportedGLProfiles.Length < 2;
+			glProfileDropdown.IsDisabled = () => disableProfile;
 
 			var statusBarsDropDown = panel.Get<DropDownButtonWidget>("STATUS_BAR_DROPDOWN");
 			statusBarsDropDown.OnMouseDown = _ => ShowStatusBarsDropdown(statusBarsDropDown, gs);
@@ -893,7 +894,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return item;
 			};
 
-			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, Game.Renderer.SupportedGLProfiles, setupItem);
+			var profiles = new[] { GLProfile.Automatic }.Concat(Game.Renderer.SupportedGLProfiles);
+			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, profiles, setupItem);
 		}
 
 		static void ShowTargetLinesDropdown(DropDownButtonWidget dropdown, GameSettings s)

--- a/OpenRA.Platforms.Default/DefaultPlatform.cs
+++ b/OpenRA.Platforms.Default/DefaultPlatform.cs
@@ -16,9 +16,9 @@ namespace OpenRA.Platforms.Default
 {
 	public class DefaultPlatform : IPlatform
 	{
-		public IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int batchSize, int videoDisplay, GLProfile profile)
+		public IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int batchSize, int videoDisplay, GLProfile profile, bool enableLegacyGL)
 		{
-			return new Sdl2PlatformWindow(size, windowMode, scaleModifier, batchSize, videoDisplay, profile);
+			return new Sdl2PlatformWindow(size, windowMode, scaleModifier, batchSize, videoDisplay, profile, enableLegacyGL);
 		}
 
 		public ISoundEngine CreateSound(string device)

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -543,6 +543,7 @@ namespace OpenRA.Platforms.Default
 				}
 			}
 
+			Console.WriteLine("OpenGL renderer: " + glGetString(GL_RENDERER));
 			Console.WriteLine("OpenGL version: " + glGetString(GL_VERSION));
 
 			try

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -596,15 +596,24 @@ namespace OpenRA.Platforms.Default
 				glBindTexture = Bind<BindTexture>("glBindTexture");
 				glActiveTexture = Bind<ActiveTexture>("glActiveTexture");
 				glTexImage2D = Bind<TexImage2D>("glTexImage2D");
-				glGetTexImage = Bind<GetTexImage>("glGetTexImage");
 				glTexParameteri = Bind<TexParameteri>("glTexParameteri");
 				glTexParameterf = Bind<TexParameterf>("glTexParameterf");
 
 				if (Profile != GLProfile.Legacy)
 				{
+					if (Profile != GLProfile.Embedded)
+					{
+						glGetTexImage = Bind<GetTexImage>("glGetTexImage");
+						glBindFragDataLocation = Bind<BindFragDataLocation>("glBindFragDataLocation");
+					}
+					else
+					{
+						glGetTexImage = null;
+						glBindFragDataLocation = null;
+					}
+
 					glGenVertexArrays = Bind<GenVertexArrays>("glGenVertexArrays");
 					glBindVertexArray = Bind<BindVertexArray>("glBindVertexArray");
-					glBindFragDataLocation = Bind<BindFragDataLocation>("glBindFragDataLocation");
 					glGenFramebuffers = Bind<GenFramebuffers>("glGenFramebuffers");
 					glBindFramebuffer = Bind<BindFramebuffer>("glBindFramebuffer");
 					glFramebufferTexture2D = Bind<FramebufferTexture2D>("glFramebufferTexture2D");

--- a/OpenRA.Platforms.Default/OpenRA.Platforms.Default.csproj
+++ b/OpenRA.Platforms.Default/OpenRA.Platforms.Default.csproj
@@ -29,7 +29,7 @@
     <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj" />
     <PackageReference Include="OpenRA-Freetype6" Version="1.0.4" />
     <PackageReference Include="OpenRA-OpenAL-CS" Version="1.0.16" />
-    <PackageReference Include="OpenRA-SDL2-CS" Version="1.0.27" />
+    <PackageReference Include="OpenRA-SDL2-CS" Version="1.0.28" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <AdditionalFiles Include="../stylecop.json" />

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -135,7 +135,7 @@ namespace OpenRA.Platforms.Default
 		static extern bool SetProcessDPIAware();
 
 		public Sdl2PlatformWindow(Size requestEffectiveWindowSize, WindowMode windowMode,
-			float scaleModifier, int batchSize, int videoDisplay, GLProfile requestProfile)
+			float scaleModifier, int batchSize, int videoDisplay, GLProfile requestProfile, bool enableLegacyGL)
 		{
 			// Lock the Window/Surface properties until initialization is complete
 			lock (syncObject)
@@ -148,7 +148,10 @@ namespace OpenRA.Platforms.Default
 
 				// Decide which OpenGL profile to use.
 				// Prefer standard GL over GLES provided by the native driver
-				var testProfiles = new List<GLProfile> { GLProfile.ANGLE, GLProfile.Modern, GLProfile.Embedded, GLProfile.Legacy };
+				var testProfiles = new List<GLProfile> { GLProfile.ANGLE, GLProfile.Modern, GLProfile.Embedded };
+				if (enableLegacyGL)
+					testProfiles.Add(GLProfile.Legacy);
+
 				supportedProfiles = testProfiles
 					.Where(CanCreateGLWindow)
 					.ToArray();

--- a/OpenRA.Platforms.Default/Shader.cs
+++ b/OpenRA.Platforms.Default/Shader.cs
@@ -84,7 +84,7 @@ namespace OpenRA.Platforms.Default
 			OpenGL.glBindAttribLocation(program, TintAttributeIndex, "aVertexTint");
 			OpenGL.CheckGLError();
 
-			if (OpenGL.Profile != GLProfile.Legacy)
+			if (OpenGL.Profile == GLProfile.Modern)
 			{
 				OpenGL.glBindFragDataLocation(program, 0, "fragColor");
 				OpenGL.CheckGLError();

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -153,6 +153,8 @@ Section "Game" GAME
 	File "${SRCDIR}\DiscordRPC.dll"
 	File "${SRCDIR}\Newtonsoft.Json.dll"
 	File "${SRCDIR}\SDL2.dll"
+	File "${SRCDIR}\libEGL.dll"
+	File "${SRCDIR}\libGLESv2.dll"
 	File "${SRCDIR}\freetype6.dll"
 	File "${SRCDIR}\lua51.dll"
 
@@ -263,6 +265,8 @@ Function ${UN}Clean
 	Delete $INSTDIR\IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP
 	Delete $INSTDIR\soft_oal.dll
 	Delete $INSTDIR\SDL2.dll
+	Delete $INSTDIR\libEGL.dll
+	Delete $INSTDIR\libGLESv2.dll
 	Delete $INSTDIR\lua51.dll
 	Delete $INSTDIR\eluant.dll
 	Delete $INSTDIR\freetype6.dll


### PR DESCRIPTION
Our first attempt to drop GL2 support ran into problems thanks to the surprising number of people that experienced problems when running under GL3+. This PR attempts to solve those by using [ANGLE](https://chromium.googlesource.com/angle/angle) to instead run on Direct 3D 11 via GLES 3.0.

This then hides GL2 support behind a feature flag, disabled by default, but which we can easy restore in a later playtest if needed.

Test builds: https://github.com/pchote/OpenRA/releases/tag/devtest-20201001