### PR TITLE
Remove unnecessary allocations from spawn point rendering

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -227,22 +227,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			color.AttachPanel(colorChooser, onExit);
 		}
 
-		public static Dictionary<CPos, SpawnOccupant> GetSpawnOccupants(Session lobbyInfo, MapPreview preview)
-		{
-			var spawns = preview.SpawnPoints;
-			return lobbyInfo.Clients
-				.Where(c => (c.SpawnPoint - 1 >= 0) && (c.SpawnPoint - 1 < spawns.Length))
-				.ToDictionary(c => spawns[c.SpawnPoint - 1], c => new SpawnOccupant(c));
-		}
-
-		public static Dictionary<CPos, SpawnOccupant> GetSpawnOccupants(IEnumerable<GameInformation.Player> players, MapPreview preview)
-		{
-			var spawns = preview.SpawnPoints;
-			return players
-					.Where(c => (c.SpawnPoint - 1 >= 0) && (c.SpawnPoint - 1 < spawns.Length))
-					.ToDictionary(c => spawns[c.SpawnPoint - 1], c => new SpawnOccupant(c));
-		}
-
 		public static void SelectSpawnPoint(OrderManager orderManager, MapPreviewWidget mapPreview, MapPreview preview, MouseInput mi)
 		{
 			if (mi.Button != MouseButton.Left)

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		[ObjectCreator.UseCtor]
 		internal MapPreviewLogic(Widget widget, ModData modData, OrderManager orderManager, Func<MapPreview> getMap,
-			Action<MapPreviewWidget, MapPreview, MouseInput> onMouseDown, Func<MapPreview, Dictionary<CPos, SpawnOccupant>> getSpawnOccupants, bool showUnoccupiedSpawnpoints)
+			Action<MapPreviewWidget, MapPreview, MouseInput> onMouseDown, Func<Dictionary<int, SpawnOccupant>> getSpawnOccupants, bool showUnoccupiedSpawnpoints)
 		{
 			var mapRepository = modData.Manifest.Get<WebServices>().MapRepository;
 
@@ -172,12 +172,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 
 		void SetupWidgets(Widget parent, Func<MapPreview> getMap,
-			Action<MapPreviewWidget, MapPreview, MouseInput> onMouseDown, Func<MapPreview, Dictionary<CPos, SpawnOccupant>> getSpawnOccupants, bool showUnoccupiedSpawnpoints)
+			Action<MapPreviewWidget, MapPreview, MouseInput> onMouseDown, Func<Dictionary<int, SpawnOccupant>> getSpawnOccupants, bool showUnoccupiedSpawnpoints)
 		{
 			var preview = parent.Get<MapPreviewWidget>("MAP_PREVIEW");
 			preview.Preview = () => getMap();
 			preview.OnMouseDown = mi => onMouseDown(preview, getMap(), mi);
-			preview.SpawnOccupants = () => getSpawnOccupants(getMap());
+			preview.SpawnOccupants = getSpawnOccupants;
 			preview.ShowUnoccupiedSpawnpoints = showUnoccupiedSpawnpoints;
 
 			var titleLabel = parent.GetOrNull<LabelWithTooltipWidget>("MAP_TITLE");

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/SpawnSelectorTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/SpawnSelectorTooltipLogic.cs
@@ -41,10 +41,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			tooltipContainer.BeforeRender = () =>
 			{
 				showTooltip = true;
-				var occupant = preview.SpawnOccupants().Values.FirstOrDefault(c => c.SpawnPoint == preview.TooltipSpawnIndex);
 
 				var teamWidth = 0;
-				if (occupant == null)
+				if (preview.SpawnOccupants().TryGetValue(preview.TooltipSpawnIndex, out var occupant))
+				{
+					labelText = occupant.PlayerName;
+					playerFaction = occupant.Faction;
+					playerTeam = occupant.Team;
+					widget.Bounds.Height = playerTeam > 0 ? doubleHeight : singleHeight;
+					teamWidth = teamFont.Measure(team.GetText()).X;
+				}
+				else
 				{
 					if (!showUnoccupiedSpawnpoints)
 					{
@@ -56,14 +63,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					playerFaction = null;
 					playerTeam = 0;
 					widget.Bounds.Height = singleHeight;
-				}
-				else
-				{
-					labelText = occupant.PlayerName;
-					playerFaction = occupant.Faction;
-					playerTeam = occupant.Team;
-					widget.Bounds.Height = playerTeam > 0 ? doubleHeight : singleHeight;
-					teamWidth = teamFont.Measure(team.GetText()).X;
 				}
 
 				label.Bounds.X = playerFaction != null ? flag.Bounds.Right + labelMargin : labelMargin;

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -76,15 +76,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			mapPreviewRoot.IsVisible = () => selectedReplay != null;
 			panel.Get("REPLAY_INFO").IsVisible = () => selectedReplay != null;
 
+			var spawnOccupants = new CachedTransform<ReplayMetadata, Dictionary<int, SpawnOccupant>>(r =>
+				r.GameInfo.Players.ToDictionary(c => c.SpawnPoint, c => new SpawnOccupant(c)));
+
 			Ui.LoadWidget("MAP_PREVIEW", mapPreviewRoot, new WidgetArgs
 			{
 				{ "orderManager", null },
 				{ "getMap", (Func<MapPreview>)(() => map) },
 				{ "onMouseDown",  (Action<MapPreviewWidget, MapPreview, MouseInput>)((preview, mapPreview, mi) => { }) },
-				{
-					"getSpawnOccupants", (Func<MapPreview, Dictionary<CPos, SpawnOccupant>>)(mapPreview =>
-						LobbyUtils.GetSpawnOccupants(selectedReplay.GameInfo.Players, mapPreview))
-				},
+				{ "getSpawnOccupants", (Func<Dictionary<int, SpawnOccupant>>)(() => spawnOccupants.Update(selectedReplay)) },
 				{ "showUnoccupiedSpawnpoints", false },
 			});
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -424,7 +424,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var spawns = currentMap.SpawnPoints;
 				var occupants = server.Clients
 					.Where(c => (c.SpawnPoint - 1 >= 0) && (c.SpawnPoint - 1 < spawns.Length))
-					.ToDictionary(c => spawns[c.SpawnPoint - 1], c => new SpawnOccupant(c, server.Mod != modData.Manifest.Id));
+					.ToDictionary(c => c.SpawnPoint, c => new SpawnOccupant(c, server.Mod != modData.Manifest.Id));
 
 				mapPreview.SpawnOccupants = () => occupants;
 			}

--- a/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Widgets
 		readonly int2 spawnLabelOffset;
 
 		public Func<MapPreview> Preview = () => null;
-		public Func<Dictionary<CPos, SpawnOccupant>> SpawnOccupants = () => new Dictionary<CPos, SpawnOccupant>();
+		public Func<Dictionary<int, SpawnOccupant>> SpawnOccupants = () => new Dictionary<int, SpawnOccupant>();
 		public Action<MouseInput> OnMouseDown = _ => { };
 		public int TooltipSpawnIndex = -1;
 		public bool ShowUnoccupiedSpawnpoints = true;
@@ -182,19 +182,21 @@ namespace OpenRA.Mods.Common.Widgets
 			TooltipSpawnIndex = -1;
 			if (ShowSpawnPoints)
 			{
-				var colors = SpawnOccupants().ToDictionary(c => c.Key, c => c.Value.Color);
-
 				var spawnPoints = preview.SpawnPoints;
+				var occupants = SpawnOccupants();
 				var gridType = preview.GridType;
-				foreach (var p in spawnPoints)
+				for (var i = 0; i < spawnPoints.Length; i++)
 				{
-					var owned = colors.ContainsKey(p);
+					var p = spawnPoints[i];
+
+					// Spawn numbers are 1 indexed with 0 meaning "random spawn".
+					var occupied = occupants.TryGetValue(i + 1, out var occupant);
 					var pos = ConvertToPreview(p, gridType);
-					var sprite = owned ? spawnClaimed : spawnUnclaimed;
+					var sprite = occupied ? spawnClaimed : spawnUnclaimed;
 					var offset = sprite.Size.XY.ToInt2() / 2;
 
-					if (owned)
-						WidgetUtils.FillEllipseWithColor(new Rectangle(pos.X - offset.X + 1, pos.Y - offset.Y + 1, (int)sprite.Size.X - 2, (int)sprite.Size.Y - 2), colors[p]);
+					if (occupied)
+						WidgetUtils.FillEllipseWithColor(new Rectangle(pos.X - offset.X + 1, pos.Y - offset.Y + 1, (int)sprite.Size.X - 2, (int)sprite.Size.Y - 2), occupant.Color);
 
 					Game.Renderer.RgbaSpriteRenderer.DrawSprite(sprite, pos - offset);
 					var number = Convert.ToChar('A' + spawnPoints.IndexOf(p)).ToString();


### PR DESCRIPTION
While reviewing #18425 I noticed that we were calling `LobbyUtils.GetSpawnOccupants` multiple times per render for no good reason. This PR sets up caching to remove the unnecessary dictionary allocations and changes `getSpawnOccupants` to provide a dictionary keyed on spawn index instead of spawn position, which makes more sense and will simplify the implementation of #18425.