### PR TITLE
Rewrite spawn point assignment logic.

### DIFF
--- a/OpenRA.Game/GameInformation.cs
+++ b/OpenRA.Game/GameInformation.cs
@@ -122,7 +122,7 @@ namespace OpenRA
 				Team = client.Team,
 				SpawnPoint = runtimePlayer.SpawnPoint,
 				IsRandomFaction = runtimePlayer.Faction.InternalName != client.Faction,
-				IsRandomSpawnPoint = runtimePlayer.SpawnPoint != client.SpawnPoint,
+				IsRandomSpawnPoint = runtimePlayer.DisplaySpawnPoint == 0,
 				Fingerprint = client.Fingerprint
 			};
 

--- a/OpenRA.Game/Map/PlayerReference.cs
+++ b/OpenRA.Game/Map/PlayerReference.cs
@@ -32,7 +32,19 @@ namespace OpenRA
 		public bool LockColor = false;
 		public Color Color = Game.ModData.Manifest.Get<DefaultPlayer>().Color;
 
+		/// <summary>
+		/// Sets the "Home" location, which can be used by traits and scripts to e.g. set the initial camera
+		/// location or choose the map edge for reinforcements.
+		/// This will usually be overridden for client (lobby slot) players with a location based on the Spawn index
+		/// </summary>
+		public CPos HomeLocation = CPos.Zero;
+
 		public bool LockSpawn = false;
+
+		/// <summary>
+		/// Sets the initial spawn point index that is used to override the "Home" location for client (lobby slot) players.
+		/// Map players always ignore this and use HomeLocation directly.
+		/// </summary>
 		public int Spawn = 0;
 
 		public bool LockTeam = false;

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -56,6 +56,7 @@ namespace OpenRA
 		public readonly bool NonCombatant = false;
 		public readonly bool Playable = true;
 		public readonly int ClientIndex;
+		public readonly CPos HomeLocation;
 		public readonly PlayerReference PlayerReference;
 		public readonly bool IsBot;
 		public readonly string BotType;
@@ -65,8 +66,13 @@ namespace OpenRA
 		/// <summary>The faction (including Random, etc) that was selected in the lobby.</summary>
 		public readonly FactionInfo DisplayFaction;
 
+		/// <summary>The spawn point index that was assigned for client-based players.</summary>
+		public readonly int SpawnPoint;
+
+		/// <summary>The spawn point index (including 0 for Random) that was selected in the lobby for client-based players.</summary>
+		public readonly int DisplaySpawnPoint;
+
 		public WinState WinState = WinState.Undefined;
-		public int SpawnPoint;
 		public bool HasObjectives = false;
 		public bool Spectating;
 
@@ -153,6 +159,11 @@ namespace OpenRA
 				BotType = client.Bot;
 				Faction = ChooseFaction(world, client.Faction, !pr.LockFaction);
 				DisplayFaction = ChooseDisplayFaction(world, client.Faction);
+
+				var assignSpawnPoints = world.WorldActor.TraitOrDefault<IAssignSpawnPoints>();
+				HomeLocation = assignSpawnPoints?.AssignHomeLocation(world, client) ?? pr.HomeLocation;
+				SpawnPoint = assignSpawnPoints?.SpawnPointForPlayer(this) ?? client.SpawnPoint;
+				DisplaySpawnPoint = client.SpawnPoint;
 			}
 			else
 			{
@@ -166,6 +177,8 @@ namespace OpenRA
 				BotType = pr.Bot;
 				Faction = ChooseFaction(world, pr.Faction, false);
 				DisplayFaction = ChooseDisplayFaction(world, pr.Faction);
+				HomeLocation = pr.HomeLocation;
+				SpawnPoint = DisplaySpawnPoint = 0;
 			}
 
 			if (!Spectating)

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -373,6 +373,13 @@ namespace OpenRA.Traits
 		void CreateServerPlayers(MapPreview map, Session lobbyInfo, List<GameInformation.Player> players);
 	}
 
+	[RequireExplicitImplementation]
+	public interface IAssignSpawnPoints
+	{
+		CPos AssignHomeLocation(World world, Session.Client client);
+		int SpawnPointForPlayer(Player player);
+	}
+
 	public interface IBotInfo : ITraitInfoInterface
 	{
 		string Type { get; }

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -311,6 +311,7 @@ namespace OpenRA
 					using (new PerfTimer(iwl.GetType().Name + ".WorldLoaded"))
 						iwl.WorldLoaded(this, wr);
 
+			var assignSpawnLocations = WorldActor.TraitOrDefault<IAssignSpawnPoints>();
 			gameInfo.StartTimeUtc = DateTime.UtcNow;
 			foreach (var player in Players)
 				gameInfo.AddPlayer(player, OrderManager.LobbyInfo);

--- a/OpenRA.Mods.Common/Scripting/Properties/PlayerProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/PlayerProperties.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Scripting
 			get
 			{
 				var c = Player.World.LobbyInfo.Clients.FirstOrDefault(i => i.Index == Player.ClientIndex);
-				return c != null ? c.Team : 0;
+				return c?.Team ?? 0;
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
@@ -51,19 +51,17 @@ namespace OpenRA.Mods.Common.Traits
 			var owner = self.Owner;
 			var map = owner.World.Map;
 			var aircraftInfo = self.World.Map.Rules.Actors[info.ActorType].TraitInfo<AircraftInfo>();
-			var mpStart = owner.World.WorldActor.TraitOrDefault<MPStartLocations>();
 
 			CPos startPos;
 			CPos endPos;
 			WAngle spawnFacing;
 
-			if (info.BaselineSpawn && mpStart != null)
+			if (info.BaselineSpawn)
 			{
-				var spawn = mpStart.Start[owner];
 				var bounds = map.Bounds;
 				var center = new MPos(bounds.Left + bounds.Width / 2, bounds.Top + bounds.Height / 2).ToCPos(map);
-				var spawnVec = spawn - center;
-				startPos = spawn + spawnVec * (Exts.ISqrt((bounds.Height * bounds.Height + bounds.Width * bounds.Width) / (4 * spawnVec.LengthSquared)));
+				var spawnVec = owner.HomeLocation - center;
+				startPos = owner.HomeLocation + spawnVec * (Exts.ISqrt((bounds.Height * bounds.Height + bounds.Width * bounds.Width) / (4 * spawnVec.LengthSquared)));
 				endPos = startPos;
 				var spawnDirection = new WVec((self.Location - startPos).X, (self.Location - startPos).Y, 0);
 				spawnFacing = spawnDirection.Yaw;


### PR DESCRIPTION
The current spawn point code does a poor job of distinguishing between what are actually three different things:
* The spawn point selected in the lobby:
  * Only relevant for client players (humans + bots)
  * Needs a way to represent "no specific choice / random"
  * Abstract labels that do not care about a physical location
* Resolved spawn points for game init, replays, and server browser:
  * Still only relevant for client players
  * No random choice - every player is matched to a specific label
  * Abstract label, but does care about position (for the "separate team spawns" option - which I was originally going to fix properly in this PR but dropped from here to avoid mixing refactoring with behaviour changes)
 * Player "Home" position:
   * Relevant for *all* players, including scripted ones - support powers and other traits may change their behaviour based on it.
   * No random choice - every player is matched to a specific location
   * Position, not a label - and we need a way to assign this for scripted players without making things awkward for the Lobby UI.

This PR reworks the backend logic to be more sensible, accounting for the new use cases from PRs like #17578, #18425, #18111, #18238.