### PR TITLE
Fix turreted defenses always realigning

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -853,6 +853,7 @@ GUN:
 	Turreted:
 		TurnSpeed: 48
 		InitialFacing: 224
+		RealignDelay: -1
 	-WithSpriteBody:
 	WithEmbeddedTurretSpriteBody:
 	Armament:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -748,6 +748,7 @@ medium_gun_turret:
 	Turreted:
 		TurnSpeed: 24
 		InitialFacing: 512
+		RealignDelay: -1
 	Armament:
 		Weapon: 110mm_Gun
 		LocalOffset: 512,0,432
@@ -793,6 +794,7 @@ large_gun_turret:
 	Turreted:
 		TurnSpeed: 32
 		InitialFacing: 512
+		RealignDelay: -1
 	Power:
 		Amount: -60
 	RevealOnDeath:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -603,6 +603,7 @@ AGUN:
 	Turreted:
 		TurnSpeed: 60
 		InitialFacing: 896
+		RealignDelay: -1
 	-WithSpriteBody:
 	WithEmbeddedTurretSpriteBody:
 	Armament:
@@ -817,6 +818,7 @@ GUN:
 	Turreted:
 		TurnSpeed: 48
 		InitialFacing: 224
+		RealignDelay: -1
 	-WithSpriteBody:
 	WithEmbeddedTurretSpriteBody:
 	Armament:
@@ -916,6 +918,7 @@ SAM:
 	Turreted:
 		TurnSpeed: 120
 		InitialFacing: 0
+		RealignDelay: -1
 	-WithSpriteBody:
 	WithEmbeddedTurretSpriteBody:
 	Armament:

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -75,6 +75,7 @@ GACTWR:
 	Turreted:
 		TurnSpeed: 40
 		InitialFacing: 896
+		RealignDelay: -1
 	AttackTurreted:
 		RequiresCondition: !build-incomplete && (tower.vulcan || tower.rocket || tower.sam)
 		PauseOnCondition: empdisable || disabled

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -166,6 +166,7 @@ NALASR:
 		TurnSpeed: 40
 		InitialFacing: 896
 		Offset: 298,-171,288
+		RealignDelay: -1
 	AttackTurreted:
 		RequiresCondition: !build-incomplete
 		PauseOnCondition: empdisable || disabled
@@ -249,6 +250,7 @@ NASAM:
 	Turreted:
 		TurnSpeed: 40
 		InitialFacing: 896
+		RealignDelay: -1
 	AttackTurreted:
 		RequiresCondition: !build-incomplete
 		PauseOnCondition: empdisable || disabled

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -23,6 +23,7 @@ NAPULS:
 	Turreted:
 		TurnSpeed: 40
 		InitialFacing: 896
+		RealignDelay: -1
 	AttackTurreted:
 		RequiresCondition: !build-incomplete && !empdisable && !disabled
 	Armament:


### PR DESCRIPTION
Since the recent turret facings refactor, turrets now by default realign to their default `InitialFacing` after `RealignDelay` passes. This is fine for turreted vehicles, but on defenses with (visible) turret it looks strange, and makes it impossible to set a real custom start facing via maps.

This PR disables automatic realignment for turreted defenses in the official mods.