### PR TITLE
Add GrantConditionOnCombatantOwner.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnCombatantOwner.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnCombatantOwner.cs
@@ -1,0 +1,53 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Grants a condition if the owner is a combatant.")]
+	public class GrantConditionOnCombatantOwnerInfo : TraitInfo
+	{
+		[FieldLoader.Require]
+		[GrantedConditionReference]
+		[Desc("The condition to grant.")]
+		public readonly string Condition = null;
+
+		public override object Create(ActorInitializer init) { return new GrantConditionOnCombatantOwner(init.Self, this); }
+	}
+
+	public class GrantConditionOnCombatantOwner : INotifyCreated, INotifyOwnerChanged
+	{
+		readonly GrantConditionOnCombatantOwnerInfo info;
+
+		int conditionToken = Actor.InvalidConditionToken;
+
+		public GrantConditionOnCombatantOwner(Actor self, GrantConditionOnCombatantOwnerInfo info)
+		{
+			this.info = info;
+		}
+
+		void INotifyCreated.Created(Actor self)
+		{
+			if (!self.Owner.NonCombatant)
+				conditionToken = self.GrantCondition(info.Condition);
+		}
+
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		{
+			if (conditionToken != Actor.InvalidConditionToken)
+				conditionToken = self.RevokeCondition(conditionToken);
+
+			if (!newOwner.NonCombatant)
+				conditionToken = self.GrantCondition(info.Condition);
+		}
+	}
+}

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -4,6 +4,7 @@ V19:
 		Bounds: 24,24
 	CashTrickler:
 		Amount: 10
+		RequiresCondition: enabled
 	Building:
 		Footprint: x
 		Dimensions: 1,1
@@ -20,6 +21,8 @@ V19:
 	SpawnActorOnDeath:
 		Actor: V19.Husk
 	UpdatesDerrickCount:
+	GrantConditionOnCombatantOwner:
+		Condition: enabled
 
 V19.Husk:
 	Inherits: ^CivBuildingHusk

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -545,6 +545,7 @@ OILB:
 	CashTrickler:
 		Interval: 375
 		Amount: 100
+		RequiresCondition: enabled
 	Tooltip:
 		Name: Oil Derrick
 	TooltipDescription@ally:
@@ -561,6 +562,8 @@ OILB:
 	GivesCashOnCapture:
 		Amount: 100
 	UpdatesDerrickCount:
+	GrantConditionOnCombatantOwner:
+		Condition: enabled
 
 BR1:
 	Inherits: ^Bridge


### PR DESCRIPTION
I have been using this in RV to prevent tech structures from working before being captured. I asked PChote in Discord if it would be ok to have this in upstream and he approved that so here is it.

TESTCASE makes it so RA Oil Derricks don't work until being captured.