### PR TITLE
Fix DamagedByTerrain and LaysTerrain not working when enabling the trait after the actor entered the world

### DIFF
--- a/OpenRA.Mods.D2k/Traits/Buildings/LaysTerrain.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/LaysTerrain.cs
@@ -50,11 +50,19 @@ namespace OpenRA.Mods.D2k.Traits
 
 		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
-			if (IsTraitDisabled)
-				return;
+			if (!IsTraitDisabled)
+				LayTerrain(self);
+		}
 
+		protected override void TraitEnabled(Actor self)
+		{
+			if (self.IsInWorld)
+				LayTerrain(self);
+		}
+
+		void LayTerrain(Actor self)
+		{
 			var map = self.World.Map;
-
 			if (template.PickAny)
 			{
 				// Fill the footprint with random variants

--- a/mods/d2k/maps/atreides-01a/atreides01a.lua
+++ b/mods/d2k/maps/atreides-01a/atreides01a.lua
@@ -141,7 +141,29 @@ WorldLoaded = function()
 	end)
 
 	WavesLeft = HarkonnenAttackWaves[Difficulty]
-	SendReinforcements()
+	--SendReinforcements()
+
+	Actor.Create("wind_trap", true, { Owner = player, Location = AtreidesEntryPath[1] + CVec.New(1, 0) })
+	Actor.Create("wind_trap", true, { Owner = player, Location = AtreidesEntryPath[1] + CVec.New(3, 0) })
+	Actor.Create("wind_trap", true, { Owner = player, Location = AtreidesEntryPath[1] + CVec.New(3, -3) })
+
+	Trigger.AfterDelay(DateTime.Seconds(1), function()
+		-- Start with the trait enabled, but only get added to the world later
+		local testA = Actor.Create("outpost", false, { Owner = player, Location = AtreidesEntryPath[1] + CVec.New(5, -3) })
+		Trigger.AfterDelay(DateTime.Seconds(2), function()
+			testA.IsInWorld = true
+		end)
+		-- Activate LaysTerrain delayed, concrete should appear now
+		-- Note: Visually bugged. You can only see the full concrete after selling
+		Trigger.AfterDelay(DateTime.Seconds(6), function()
+			testA.GrantCondition("auto-concrete2")
+		end)
+
+		-- Start with the trait disabled when added to the world, enable it later
+		local testB = Actor.Create("outpost", false, { Owner = player, Location = AtreidesEntryPath[1] + CVec.New(5, 0) })
+		testB.GrantCondition("auto-concrete", DateTime.Seconds(4))
+		testB.IsInWorld = true
+	end)
 end
 
 SendReinforcements = function()

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -459,9 +459,13 @@
 		DamageThreshold: 50
 		StartOnThreshold: true
 	LaysTerrain:
-		RequiresCondition: auto-concrete
+		RequiresCondition: auto-concrete2
 		TerrainTypes: Rock
 		Template: 88
+	ExternalCondition@Lua:
+		Condition: auto-concrete
+	ExternalCondition@Lua2:
+		Condition: auto-concrete2
 	ThrowsShrapnel:
 		Weapons: Debris, Debris2, Debris3, Debris4
 		Pieces: 2, 5


### PR DESCRIPTION
Follow-up to #18562.

Testcase (don't merge) is coded into Atreides-01a: The first outpost has `DamagedByTerrain` disabled when added to the world, and gets it enabled after 4 seconds (and takes the initial damage then). The second outpost starts with the trait enabled, but gets added to the world with a 2 second delay, and will take the initial damage right when being added. After 4 more seconds the second outpost will get its `LaysTerrain` trait enabled, spawning concrete below. (Note that this is visually bugged the same as when laying concrete in the editor, you only see it fully after removing/selling the building on top.)