### PR TITLE
Fix d2k conyards granting an unconsumed "auto-concrete" condition

### DIFF
--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -66,6 +66,7 @@ construction_yard:
 		LocalCenterOffset: 0,-512,0
 	LaysTerrain:
 		-RequiresCondition:
+	-GrantConditionOnPrerequisite@AUTOCONCRETE:
 	WithBuildingBib:
 	Selectable:
 		Bounds: 96,64


### PR DESCRIPTION
Regression from #18562 which generates `Actor type 'construction_yard' grants conditions that are not consumed: auto-concrete` lint *warnings* (which do not fail the buid...): https://travis-ci.org/github/OpenRA/OpenRA/builds/733293906#L1432