### PR TITLE
Checkbox for Stealth C17

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -195,6 +195,14 @@ C17:
 		MaxWeight: 10
 	DamageMultiplier@INVULNERABLE:
 		Modifier: 0
+	GrantConditionOnPrerequisite@GLOBALC17STEALTH:
+		Condition: global-C17-stealth
+		Prerequisites: global-C17-stealth
+	Cloak:
+		InitialDelay: 0
+		CloakDelay: 0
+		CloakTypes: C17
+		RequiresCondition: global-C17-stealth
 	Contrail@1:
 		Offset: -261,-650,0
 		TrailLength: 15

--- a/mods/cnc/rules/player.yaml
+++ b/mods/cnc/rules/player.yaml
@@ -27,7 +27,7 @@ Player:
 		SelectableCash: 2500, 5000, 7500, 10000, 20000
 		DefaultCash: 7500
 	DeveloperMode:
-		CheckboxDisplayOrder: 8
+		CheckboxDisplayOrder: 9
 	BaseAttackNotifier:
 	Shroud:
 		FogCheckboxDisplayOrder: 3
@@ -38,6 +38,13 @@ Player:
 		Enabled: True
 		DisplayOrder: 7
 		Prerequisites: global-factundeploy
+	LobbyPrerequisiteCheckbox@GLOBALC17STEALTH:
+		ID: C17-Stealth
+		Label: Stealth Deliveries
+		Description: Nod's delivery plane is cloaked
+		Enabled: False
+		DisplayOrder: 8
+		Prerequisites: global-C17-stealth
 	PlayerStatistics:
 	FrozenActorLayer:
 	PlaceBeacon:


### PR DESCRIPTION
![001650](https://user-images.githubusercontent.com/42915475/95369442-6e6a0500-08a5-11eb-8c95-40012f192507.png)

Solves competitive issues revolving around left/right spawns on maps. Seeing the frequency of vehicle deliveries gives you free scouting intel on what the Nod player is producing (frequent = bike/buggy, slow = harvesters).

C17 has its own stealth so it can't be detected by anything.

I opted for a checkbox as that seemed like the best way to compromise between purists and competitive players (like explored map). This method also doesn't affect the campaign.

Part of my balance efforts: #18273, #18427, #18520, #18654