### PR TITLE
Support multiple Replaceable and Replacement traits

### DIFF
--- a/OpenRA.Mods.Common/Traits/Replaceable.cs
+++ b/OpenRA.Mods.Common/Traits/Replaceable.cs
@@ -16,15 +16,15 @@ namespace OpenRA.Mods.Common.Traits
 	public class ReplaceableInfo : ConditionalTraitInfo
 	{
 		[FieldLoader.Require]
-		[Desc("Replacement types this Relpaceable actor accepts.")]
+		[Desc("Replacement types this Replaceable actor accepts.")]
 		public readonly HashSet<string> Types = new HashSet<string>();
 
-		public override object Create(ActorInitializer init) { return new Replaceable(init, this); }
+		public override object Create(ActorInitializer init) { return new Replaceable(this); }
 	}
 
 	public class Replaceable : ConditionalTrait<ReplaceableInfo>
 	{
-		public Replaceable(ActorInitializer init, ReplaceableInfo info)
+		public Replaceable(ReplaceableInfo info)
 			: base(info) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Replacement.cs
+++ b/OpenRA.Mods.Common/Traits/Replacement.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class ReplacementInfo : TraitInfo<Replacement>
 	{
 		[FieldLoader.Require]
-		[Desc("Replacement type (matched against Conditions in Replaceable).")]
+		[Desc("Replacement type (matched against Types in Replaceable).")]
 		public readonly HashSet<string> ReplaceableTypes = new HashSet<string>();
 	}
 


### PR DESCRIPTION
While working to remove the `BuildingInfluence` trait (which will come straight after this) I noticed that the `Replaceable` and `Replacement` traits added by #14862 did not behave well if multiple traits were used on the same actor.

This PR rewrites the logic to address this while also switching `BuildingInfluence` &rarr; `ActorMap`.

A simple testcase is to split the `GAWALL` `Replaceable` defintions over two traits, and to add a second `Replacement` trait to `NAGATE_A` that allows it (but not `NAGATE_B`) to also be placed on GDI walls:

```diff
diff --git a/mods/ts/rules/gdi-support.yaml b/mods/ts/rules/gdi-support.yaml
index 652e0fa75b..d206d4d093 100644
--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -16,8 +16,10 @@ GAWALL:
                CrushClasses: heavywall
        LineBuild:
                NodeTypes: wall, turret
-       Replaceable:
-               Types: GDIGate, GDITower
+       Replaceable@GDIGATE:
+               Types: GDIGate
+       Replaceable@GDITOWER:
+               Types: GDITower
 
 GAGATE_A:
        Inherits: ^Gate_A
diff --git a/mods/ts/rules/nod-support.yaml b/mods/ts/rules/nod-support.yaml
index 1ee8c69286..986e7dd314 100644
--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -27,8 +27,10 @@ NAGATE_A:
                Prerequisites: nahand, ~structures.nod, ~techlevel.low
        Tooltip:
                Name: Nod Gate
-       Replacement:
+       Replacement@NODGATE:
                ReplaceableTypes: NodGate
+       Replacement@GDITOWER:
+               ReplaceableTypes: GDITower
 
 NAGATE_B:
        Inherits: ^Gate_B
```