### PR TITLE
Avoid WaterCheck game crash in base builder

### DIFF
--- a/OpenRA.Mods.Common/AIUtils.cs
+++ b/OpenRA.Mods.Common/AIUtils.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common
 {
 	public enum BuildingType { Building, Defense, Refinery }
 
-	public enum WaterCheck { NotChecked, EnoughWater, NotEnoughWater }
+	public enum WaterCheck { NotChecked, EnoughWater, NotEnoughWater, DontCheck }
 
 	public static class AIUtils
 	{

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -51,6 +51,8 @@ namespace OpenRA.Mods.Common.Traits
 			failRetryTicks = baseBuilder.Info.StructureProductionResumeDelay;
 			minimumExcessPower = baseBuilder.Info.MinimumExcessPower;
 			this.resourceTypeIndices = resourceTypeIndices;
+			if (!baseBuilder.Info.NavalProductionTypes.Any())
+				waterState = WaterCheck.DontCheck;
 		}
 
 		public void Tick(IBot bot)


### PR DESCRIPTION
## About the bug to avoid
There is a chance for water check in `BaseBuilderQueueManager` will crash the game. It is some bug related to `AIUtils` but it will affect many place use it if I try to touch it.
Exception log:
```
OpenRA engine version 9277e06
Shattered Paradise mod version SP-Playtest-20200919
on map 5c210cf232c0a85aa035b53c40e5f61a70148cb9 (Well of Wealth by Stolen Tech).
Date: 2020-10-08 11:05:03Z
Operating System: Windows (Microsoft Windows NT 6.2.9200.0)
Runtime Version: .NET CLR 4.0.30319.42000
Exception of type `System.IndexOutOfRangeException`: Index was outside the bounds of the array
   at OpenRA.Map.GetTerrainIndex(CPos cell) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Map\Map.cs: 1057
   at OpenRA.Map.GetTerrainInfo(CPos cell) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Map\Map.cs: 1084
   at OpenRA.Mods.Common.AIUtils.<>c__DisplayClass0_0`1.<IsAreaAvailable>b__4(CPos ac) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\AIUtils.cs: 33
   at System.Linq.Enumerable.All[TSource](IEnumerable`1 source, Func`2 predicate)
   at OpenRA.Mods.Common.AIUtils.<>c__DisplayClass0_0`1.<IsAreaAvailable>b__3(CPos c) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\AIUtils.cs: 31
   at System.Linq.Enumerable.Count[TSource](IEnumerable`1 source, Func`2 predicate)
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at OpenRA.Mods.Common.Traits.BaseBuilderQueueManager.Tick(IBot bot) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\Traits\BotModules\BotModuleLogic\BaseBuilderQueueManager.cs: 75
   at OpenRA.Mods.Common.Traits.BaseBuilderBotModule.OpenRA.Mods.Common.Traits.IBotTick.BotTick(IBot bot) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\Traits\BotModules\BaseBuilderBotModule.cs: 206
   at OpenRA.Mods.Common.Traits.ModularBot.<OpenRA.Traits.ITick.Tick>b__14_0() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\Traits\Player\ModularBot.cs: 94
   at OpenRA.Sync.<>c__DisplayClass13_0.<RunUnsynced>b__0() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Sync.cs: 166
   at OpenRA.Sync.RunUnsynced[T](Boolean checkSyncHash, World world, Func`1 fn) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Sync.cs: 182
   at OpenRA.Mods.Common.Traits.ModularBot.OpenRA.Traits.ITick.Tick(Actor self) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\Traits\Player\ModularBot.cs: 90
   at OpenRA.WorldUtils.DoTimed[T](IEnumerable`1 e, Action`1 a, String text) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\WorldUtils.cs: 79
   at OpenRA.World.Tick() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\World.cs: 466
   at OpenRA.Game.InnerLogicTick(OrderManager orderManager) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Game.cs: 595
   at OpenRA.Game.LogicTick() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Game.cs: 620
   at OpenRA.Game.Loop() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Game.cs: 787
   at OpenRA.Game.Run() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Game.cs: 825
   at OpenRA.Game.InitializeAndRun(String[] args) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Game.cs: 259
   at OpenRA.Program.Main(String[] args) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Support\Program.cs: 33
```
See [here](https://github.com/ABrandau/Shattered-Paradise-SDK/issues/94) for replay file and related mod.

## About the fix
It is only to avoid this bug for non-navy mod like TS, and may also increase performance for those mods for we don't need this water check when we don't even build water building.

