### PR TITLE
Support random factions and spawn points in server replays.

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -1198,8 +1198,9 @@ namespace OpenRA.Server
 				// HACK: NonCombatant and non-Playable players are set to null to simplify replay tracking
 				// The null padding is needed to keep the player indexes in sync with world.Players on the clients
 				// This will need to change if future code wants to use worldPlayers for other purposes
+				var playerRandom = new MersenneTwister(LobbyInfo.GlobalSettings.RandomSeed);
 				foreach (var cmpi in Map.Rules.Actors["world"].TraitInfos<ICreatePlayersInfo>())
-					cmpi.CreateServerPlayers(Map, LobbyInfo, worldPlayers);
+					cmpi.CreateServerPlayers(Map, LobbyInfo, worldPlayers, playerRandom);
 
 				if (recorder != null)
 				{

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -18,6 +18,7 @@ using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Primitives;
+using OpenRA.Support;
 
 namespace OpenRA.Traits
 {
@@ -365,19 +366,26 @@ namespace OpenRA.Traits
 	}
 
 	[RequireExplicitImplementation]
-	public interface ICreatePlayers { void CreatePlayers(World w); }
+	public interface ICreatePlayers { void CreatePlayers(World w, MersenneTwister playerRandom); }
 
 	[RequireExplicitImplementation]
 	public interface ICreatePlayersInfo : ITraitInfoInterface
 	{
-		void CreateServerPlayers(MapPreview map, Session lobbyInfo, List<GameInformation.Player> players);
+		void CreateServerPlayers(MapPreview map, Session lobbyInfo, List<GameInformation.Player> players, MersenneTwister playerRandom);
 	}
 
 	[RequireExplicitImplementation]
 	public interface IAssignSpawnPoints
 	{
-		CPos AssignHomeLocation(World world, Session.Client client);
+		CPos AssignHomeLocation(World world, Session.Client client, MersenneTwister playerRandom);
 		int SpawnPointForPlayer(Player player);
+	}
+
+	[RequireExplicitImplementation]
+	public interface IAssignSpawnPointsInfo : ITraitInfoInterface
+	{
+		object InitializeState(MapPreview map, Session lobbyInfo);
+		int AssignSpawnPoint(object state, Session lobbyInfo, Session.Client client, MersenneTwister playerRandom);
 	}
 
 	public interface IBotInfo : ITraitInfoInterface

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -211,8 +211,10 @@ namespace OpenRA
 			LongBitSet<PlayerBitMask>.Reset();
 
 			// Add players
+			// Create an isolated RNG to simplify synchronization between client and server player faction/spawn assignments
+			var playerRandom = new MersenneTwister(orderManager.LobbyInfo.GlobalSettings.RandomSeed);
 			foreach (var cmp in WorldActor.TraitsImplementing<ICreatePlayers>())
-				cmp.CreatePlayers(this);
+				cmp.CreatePlayers(this, playerRandom);
 
 			// Set defaults for any unset stances
 			foreach (var p in Players)

--- a/OpenRA.Mods.Common/Traits/World/CreateMPPlayers.cs
+++ b/OpenRA.Mods.Common/Traits/World/CreateMPPlayers.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Network;
+using OpenRA.Support;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -24,14 +25,22 @@ namespace OpenRA.Mods.Common.Traits
 		/// Returns a list of GameInformation.Players that matches the indexing of ICreatePlayers.CreatePlayers.
 		/// Non-playable players appear as null in the list.
 		/// </summary>
-		void ICreatePlayersInfo.CreateServerPlayers(MapPreview map, Session lobbyInfo, List<GameInformation.Player> players)
+		void ICreatePlayersInfo.CreateServerPlayers(MapPreview map, Session lobbyInfo, List<GameInformation.Player> players, MersenneTwister playerRandom)
 		{
+			var worldInfo = map.Rules.Actors["world"];
+			var factions = worldInfo.TraitInfos<FactionInfo>().ToArray();
+			var assignSpawnLocations = worldInfo.TraitInfoOrDefault<IAssignSpawnPointsInfo>();
+			var spawnState = assignSpawnLocations?.InitializeState(map, lobbyInfo);
+
 			// Create the unplayable map players -- neutral, shellmap, scripted, etc.
 			foreach (var p in map.Players.Players.Where(p => !p.Value.Playable))
+			{
+				// We need to resolve the faction, even though we don't use it, to match the RNG state with clients
+				Player.ResolveFaction(p.Value.Faction, factions, playerRandom, false);
 				players.Add(null);
+			}
 
 			// Create the regular playable players.
-			var factions = map.Rules.Actors["world"].TraitInfos<FactionInfo>().ToArray();
 			var bots = map.Rules.Actors["player"].TraitInfos<IBotInfo>().ToArray();
 
 			foreach (var kv in lobbyInfo.Slots)
@@ -41,19 +50,19 @@ namespace OpenRA.Mods.Common.Traits
 					continue;
 
 				var clientFaction = factions.First(f => client.Faction == f.InternalName);
-
-				// TODO: Resolve random SpawnPoint and Faction to real values
+				var resolvedFaction = Player.ResolveFaction(client.Faction, factions, playerRandom, !kv.Value.LockFaction);
+				var resolvedSpawnPoint = assignSpawnLocations?.AssignSpawnPoint(spawnState, lobbyInfo, client, playerRandom) ?? 0;
 				var player = new GameInformation.Player
 				{
 					ClientIndex = client.Index,
 					Name = Player.ResolvePlayerName(client, lobbyInfo.Clients, bots),
 					IsHuman = client.Bot == null,
 					IsBot = client.Bot != null,
-					FactionName = clientFaction.Name,
-					FactionId = clientFaction.InternalName,
+					FactionName = resolvedFaction.Name,
+					FactionId = resolvedFaction.InternalName,
 					Color = client.Color,
 					Team = client.Team,
-					SpawnPoint = client.SpawnPoint,
+					SpawnPoint = resolvedSpawnPoint,
 					IsRandomFaction = clientFaction.RandomFactionMembers.Any(),
 					IsRandomSpawnPoint = client.SpawnPoint == 0,
 					Fingerprint = client.Fingerprint,
@@ -63,13 +72,15 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// Create a player that is allied with everyone for shared observer shroud.
+			// We need to resolve the faction, even though we don't use it, to match the RNG state with clients
+			Player.ResolveFaction("Random", factions, playerRandom, false);
 			players.Add(null);
 		}
 	}
 
 	public class CreateMPPlayers : ICreatePlayers
 	{
-		void ICreatePlayers.CreatePlayers(World w)
+		void ICreatePlayers.CreatePlayers(World w, MersenneTwister playerRandom)
 		{
 			var players = new MapPlayers(w.Map.PlayerDefinitions).Players;
 			var worldPlayers = new List<Player>();
@@ -78,7 +89,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Create the unplayable map players -- neutral, shellmap, scripted, etc.
 			foreach (var kv in players.Where(p => !p.Value.Playable))
 			{
-				var player = new Player(w, null, kv.Value);
+				var player = new Player(w, null, kv.Value, playerRandom);
 				worldPlayers.Add(player);
 
 				if (kv.Value.OwnsWorld)
@@ -100,7 +111,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (client == null)
 					continue;
 
-				var player = new Player(w, client, players[kv.Value.PlayerReference]);
+				var player = new Player(w, client, players[kv.Value.PlayerReference], playerRandom);
 				worldPlayers.Add(player);
 
 				if (client.Index == Game.LocalClientId)
@@ -115,7 +126,7 @@ namespace OpenRA.Mods.Common.Traits
 				Spectating = true,
 				Faction = "Random",
 				Allies = worldPlayers.Where(p => !p.NonCombatant && p.Playable).Select(p => p.InternalName).ToArray()
-			}));
+			}, playerRandom));
 
 			w.SetPlayers(worldPlayers, localPlayer);
 

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -16,6 +16,7 @@ using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Network;
 using OpenRA.Primitives;
+using OpenRA.Support;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -26,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Size of partition bins (world pixels)")]
 		public readonly int BinSize = 250;
 
-		void ICreatePlayersInfo.CreateServerPlayers(MapPreview map, Session lobbyInfo, List<GameInformation.Player> players)
+		void ICreatePlayersInfo.CreateServerPlayers(MapPreview map, Session lobbyInfo, List<GameInformation.Player> players, MersenneTwister playerRandom)
 		{
 			throw new NotImplementedException("EditorActorLayer must not be defined on the world actor");
 		}
@@ -50,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 		}
 
-		void ICreatePlayers.CreatePlayers(World w)
+		void ICreatePlayers.CreatePlayers(World w, MersenneTwister playerRandom)
 		{
 			if (w.Type != WorldType.Editor)
 				return;
@@ -58,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 			Players = new MapPlayers(w.Map.PlayerDefinitions);
 
 			var worldOwner = Players.Players.Select(kvp => kvp.Value).First(p => !p.Playable && p.OwnsWorld);
-			w.SetWorldOwner(new Player(w, null, worldOwner));
+			w.SetWorldOwner(new Player(w, null, worldOwner, playerRandom));
 		}
 
 		public void WorldLoaded(World world, WorldRenderer wr)

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -77,7 +77,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			panel.Get("REPLAY_INFO").IsVisible = () => selectedReplay != null;
 
 			var spawnOccupants = new CachedTransform<ReplayMetadata, Dictionary<int, SpawnOccupant>>(r =>
-				r.GameInfo.Players.ToDictionary(c => c.SpawnPoint, c => new SpawnOccupant(c)));
+			{
+				// Avoid using .ToDictionary to improve robustness against replays defining duplicate spawn assignments
+				var occupants = new Dictionary<int, SpawnOccupant>();
+				foreach (var p in r.GameInfo.Players)
+					if (p.SpawnPoint != 0)
+						occupants[p.SpawnPoint] = new SpawnOccupant(p);
+
+				return occupants;
+			});
 
 			Ui.LoadWidget("MAP_PREVIEW", mapPreviewRoot, new WidgetArgs
 			{


### PR DESCRIPTION
This PR extends #17578 with the ability for server replays to resolve random faction and spawn point assignments.

Depends on #18672.