### PR TITLE
Fixed "Attempted to get trait from destroyed object" in *OrderGenerator.SelectionChanged 

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -218,7 +218,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			protected override void SelectionChanged(World world, IEnumerable<Actor> selected)
 			{
 				minelayers.Clear();
-				minelayers.AddRange(selected.Where(s => s.Info.HasTraitInfo<MinelayerInfo>()));
+				minelayers.AddRange(selected.Where(s => !s.IsDead && s.Info.HasTraitInfo<MinelayerInfo>()));
 				if (!minelayers.Any())
 					world.CancelInputMode();
 			}

--- a/OpenRA.Mods.Common/Orders/GuardOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/GuardOrderGenerator.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Orders
 		public override void SelectionChanged(World world, IEnumerable<Actor> selected)
 		{
 			// Guarding doesn't work without AutoTarget, so require at least one unit in the selection to have it
-			subjects = selected.Where(s => s.Info.HasTraitInfo<GuardInfo>());
+			subjects = selected.Where(s => !s.IsDead && s.Info.HasTraitInfo<GuardInfo>());
 			if (!subjects.Any(s => s.Info.HasTraitInfo<AutoTargetInfo>()))
 				world.CancelInputMode();
 		}

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override void SelectionChanged(World world, IEnumerable<Actor> selected)
 		{
-			subjects = selected.SelectMany(a => a.TraitsImplementing<AttackMove>()
+			subjects = selected.Where(s => !s.IsDead).SelectMany(a => a.TraitsImplementing<AttackMove>()
 					.Select(am => new TraitPair<AttackMove>(a, am)))
 				.ToArray();
 


### PR DESCRIPTION
This is a fix for https://github.com/Dzierzan/OpenSA/issues/134.