### PR TITLE
Disabled UPnP on local games

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -218,7 +218,7 @@ namespace OpenRA.Server
 			if (type != ServerType.Local && settings.EnableGeoIP)
 				GeoIP.Initialize();
 
-			if (UPnP.Status == UPnPStatus.Enabled)
+			if (type != ServerType.Local && UPnP.Status == UPnPStatus.Enabled)
 				UPnP.ForwardPort(Settings.ListenPort, Settings.ListenPort).Wait();
 
 			foreach (var trait in modData.Manifest.ServerTraits)
@@ -310,7 +310,7 @@ namespace OpenRA.Server
 					if (State == ServerState.ShuttingDown)
 					{
 						EndGame();
-						if (UPnP.Status == UPnPStatus.Enabled)
+						if (type != ServerType.Local && UPnP.Status == UPnPStatus.Enabled)
 							UPnP.RemovePortForward().Wait();
 						break;
 					}

--- a/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
@@ -17,7 +17,7 @@ using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.Common.Effects
 {
-	class RallyPointIndicator : IEffect, IEffectAboveShroud, IEffectAnnotation
+	public class RallyPointIndicator : IEffect, IEffectAboveShroud, IEffectAnnotation
 	{
 		readonly Actor building;
 		readonly RallyPoint rp;


### PR DESCRIPTION
Currently, UPnP isn't implemented in an asynchronous way so it has potential to block things. This disables it for skirmishes and missions. Restarting which involves a server disconnect and startup should now be faster.