### PR TITLE
Remove obsolete LocomotorInfo caching.

### DIFF
--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -24,7 +24,6 @@ namespace OpenRA.Mods.Common.Activities
 		readonly Harvester harv;
 		readonly HarvesterInfo harvInfo;
 		readonly Mobile mobile;
-		readonly LocomotorInfo locomotorInfo;
 		readonly ResourceClaimLayer claimLayer;
 		readonly IPathFinder pathFinder;
 		readonly DomainIndex domainIndex;
@@ -43,7 +42,6 @@ namespace OpenRA.Mods.Common.Activities
 			harv = self.Trait<Harvester>();
 			harvInfo = self.Info.TraitInfo<HarvesterInfo>();
 			mobile = self.Trait<Mobile>();
-			locomotorInfo = mobile.Info.LocomotorInfo;
 			claimLayer = self.World.WorldActor.Trait<ResourceClaimLayer>();
 			pathFinder = self.World.WorldActor.Trait<IPathFinder>();
 			domainIndex = self.World.WorldActor.Trait<DomainIndex>();
@@ -195,7 +193,7 @@ namespace OpenRA.Mods.Common.Activities
 			// Find any harvestable resources:
 			List<CPos> path;
 			using (var search = PathSearch.Search(self.World, mobile.Locomotor, self, BlockedByActor.Stationary, loc =>
-					domainIndex.IsPassable(self.Location, loc, locomotorInfo) && harv.CanHarvestCell(self, loc) && claimLayer.CanClaimCell(self, loc))
+					domainIndex.IsPassable(self.Location, loc, mobile.Locomotor) && harv.CanHarvestCell(self, loc) && claimLayer.CanClaimCell(self, loc))
 				.WithCustomCost(loc =>
 				{
 					if ((loc - searchFromLoc.Value).LengthSquared > searchRadiusSquared)

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -133,7 +133,7 @@ namespace OpenRA.Mods.Common.Activities
 				searchCells.Clear();
 				searchCellsTick = self.World.WorldTick;
 				foreach (var cell in CandidateMovementCells(self))
-					if (domainIndex.IsPassable(loc, cell, Mobile.Info.LocomotorInfo) && Mobile.CanEnterCell(cell))
+					if (domainIndex.IsPassable(loc, cell, Mobile.Locomotor) && Mobile.CanEnterCell(cell))
 						searchCells.Add(cell);
 			}
 

--- a/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
@@ -87,7 +87,6 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 		readonly BlockedByActor checkConditions;
 		readonly Locomotor locomotor;
-		readonly LocomotorInfo.WorldMovementInfo worldMovementInfo;
 		readonly CellInfoLayerPool.PooledCellInfoLayer pooledLayer;
 		readonly bool checkTerrainHeight;
 		CellLayer<CellInfo> groundInfo;
@@ -108,7 +107,6 @@ namespace OpenRA.Mods.Common.Pathfinder
 				customLayerInfo[cml.Index] = (cml, pooledLayer.GetLayer());
 
 			World = world;
-			worldMovementInfo = locomotorInfo.GetWorldMovementInfo(world);
 			Actor = actor;
 			LaneBias = 1;
 			checkConditions = check;

--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -145,7 +145,7 @@ namespace OpenRA.Mods.Common.Traits
 		Target FindNextResource(Actor actor, HarvesterTraitWrapper harv)
 		{
 			Func<CPos, bool> isValidResource = cell =>
-				domainIndex.IsPassable(actor.Location, cell, harv.Locomotor.Info) &&
+				domainIndex.IsPassable(actor.Location, cell, harv.Locomotor) &&
 				harv.Harvester.CanHarvestCell(actor, cell) &&
 				claimLayer.CanClaimCell(actor, cell);
 

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/NavyStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/NavyStates.cs
@@ -29,11 +29,11 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			// (Way better than finding a nearest target which is likely to be on Ground)
 			// You might be tempted to move these lookups into Activate() but that causes null reference exception.
 			var domainIndex = first.World.WorldActor.Trait<DomainIndex>();
-			var locomotorInfo = first.Info.TraitInfo<MobileInfo>().LocomotorInfo;
+			var locomotor = first.Trait<Mobile>().Locomotor;
 
 			var navalProductions = owner.World.ActorsHavingTrait<Building>().Where(a
 				=> owner.SquadManager.Info.NavalProductionTypes.Contains(a.Info.Name)
-				&& domainIndex.IsPassable(first.Location, a.Location, locomotorInfo)
+				&& domainIndex.IsPassable(first.Location, a.Location, locomotor)
 				&& a.AppearsHostileTo(first));
 
 			if (navalProductions.Any())

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -725,16 +725,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public int MovementSpeedForCell(Actor self, CPos cell)
 		{
-			var index = cell.Layer == 0 ? self.World.Map.GetTerrainIndex(cell) :
-				self.World.GetCustomMovementLayers()[cell.Layer].GetTerrainIndex(cell);
-
-			if (index == byte.MaxValue)
-				return 0;
-
-			var terrainSpeed = Info.LocomotorInfo.TilesetTerrainInfo[self.World.Map.Rules.TileSet][index].Speed;
-			if (terrainSpeed == 0)
-				return 0;
-
+			var terrainSpeed = Locomotor.MovementSpeedForCell(cell);
 			var modifiers = speedModifiers.Value.Append(terrainSpeed);
 
 			return Util.ApplyPercentageModifiers(Info.Speed, modifiers);

--- a/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -62,9 +63,9 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (mobileInfo != null)
 				{
-					var locomotorInfo = mobileInfo.LocomotorInfo;
+					var locomotor = self.World.WorldActor.TraitsImplementing<Locomotor>().First(l => l.Info.Name == mobileInfo.Locomotor);
 					location = self.World.Map.ChooseClosestMatchingEdgeCell(self.Location,
-						c => mobileInfo.CanEnterCell(self.World, null, c) && domainIndex.IsPassable(c, destinations[0], locomotorInfo));
+						c => mobileInfo.CanEnterCell(self.World, null, c) && domainIndex.IsPassable(c, destinations[0], locomotor));
 				}
 			}
 

--- a/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
+++ b/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
@@ -31,24 +31,23 @@ namespace OpenRA.Mods.Common.Traits
 			domainIndexes = new Dictionary<uint, MovementClassDomainIndex>();
 			tileSet = world.Map.Rules.TileSet;
 			var locomotors = world.WorldActor.TraitsImplementing<Locomotor>().Where(l => !string.IsNullOrEmpty(l.Info.Name));
-			var movementClasses = locomotors.Select(t => (uint)t.Info.GetMovementClass(tileSet)).Distinct();
+			var movementClasses = locomotors.Select(t => t.MovementClass).Distinct();
 
 			foreach (var mc in movementClasses)
 				domainIndexes[mc] = new MovementClassDomainIndex(world, mc);
 		}
 
-		public bool IsPassable(CPos p1, CPos p2, LocomotorInfo li)
+		public bool IsPassable(CPos p1, CPos p2, Locomotor locomotor)
 		{
 			// HACK: Work around units in other movement layers from being blocked
 			// when the point in the main layer is not pathable
 			if (p1.Layer != 0 || p2.Layer != 0)
 				return true;
 
-			if (li.DisableDomainPassabilityCheck)
+			if (locomotor.Info.DisableDomainPassabilityCheck)
 				return true;
 
-			var movementClass = li.GetMovementClass(tileSet);
-			return domainIndexes[movementClass].IsPassable(p1, p2);
+			return domainIndexes[locomotor.MovementClass].IsPassable(p1, p2);
 		}
 
 		/// <summary>Regenerate the domain index for a group of cells.</summary>

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// If a water-land transition is required, bail early
-			if (domainIndex != null && !domainIndex.IsPassable(source, target, locomotor.Info))
+			if (domainIndex != null && !domainIndex.IsPassable(source, target, locomotor))
 				return EmptyPath;
 
 			var distance = source - target;
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Really, we only need to check the circle perimeter, but it's not clear that would be a performance win
 			if (domainIndex != null)
 			{
-				tilesInRange = new List<CPos>(tilesInRange.Where(t => domainIndex.IsPassable(source, t, locomotor.Info)));
+				tilesInRange = new List<CPos>(tilesInRange.Where(t => domainIndex.IsPassable(source, t, locomotor)));
 				if (!tilesInRange.Any())
 					return EmptyPath;
 			}


### PR DESCRIPTION
A small cleanup in preparation for the larger TileSet refactoring needed for the remasters, TS, and community mods.

`WorldMovementInfo` was left completely unused by the locomotor caching, and the `MovementClass` caching is much simpler on `Locomotor`.