### PR TITLE
Use TileSet ID in sequences instead of the TileSet object.

### DIFF
--- a/OpenRA.Game/GameRules/Ruleset.cs
+++ b/OpenRA.Game/GameRules/Ruleset.cs
@@ -208,7 +208,7 @@ namespace OpenRA
 
 				// TODO: Top-level dictionary should be moved into the Ruleset instead of in its own object
 				var sequences = mapSequences == null ? modData.DefaultSequences[tileSet] :
-					new SequenceProvider(fileSystem, modData, ts, mapSequences);
+					new SequenceProvider(fileSystem, modData, tileSet, mapSequences);
 
 				var modelSequences = dr.ModelSequences;
 				if (mapModelSequences != null)

--- a/OpenRA.Game/Graphics/SequenceProvider.cs
+++ b/OpenRA.Game/Graphics/SequenceProvider.cs
@@ -41,20 +41,20 @@ namespace OpenRA.Graphics
 
 	public interface ISpriteSequenceLoader
 	{
-		IReadOnlyDictionary<string, ISpriteSequence> ParseSequences(ModData modData, TileSet tileSet, SpriteCache cache, MiniYamlNode node);
+		IReadOnlyDictionary<string, ISpriteSequence> ParseSequences(ModData modData, string tileSet, SpriteCache cache, MiniYamlNode node);
 	}
 
 	public class SequenceProvider : IDisposable
 	{
 		readonly ModData modData;
-		readonly TileSet tileSet;
+		readonly string tileSet;
 		readonly Lazy<Sequences> sequences;
 		readonly Lazy<SpriteCache> spriteCache;
 		public SpriteCache SpriteCache { get { return spriteCache.Value; } }
 
 		readonly Dictionary<string, UnitSequences> sequenceCache = new Dictionary<string, UnitSequences>();
 
-		public SequenceProvider(IReadOnlyFileSystem fileSystem, ModData modData, TileSet tileSet, MiniYaml additionalSequences)
+		public SequenceProvider(IReadOnlyFileSystem fileSystem, ModData modData, string tileSet, MiniYaml additionalSequences)
 		{
 			this.modData = modData;
 			this.tileSet = tileSet;

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -107,7 +107,7 @@ namespace OpenRA
 
 			defaultSequences = Exts.Lazy(() =>
 			{
-				var items = DefaultTileSets.ToDictionary(t => t.Key, t => new SequenceProvider(DefaultFileSystem, this, t.Value, null));
+				var items = DefaultTileSets.ToDictionary(t => t.Key, t => new SequenceProvider(DefaultFileSystem, this, t.Key, null));
 				return (IReadOnlyDictionary<string, SequenceProvider>)(new ReadOnlyDictionary<string, SequenceProvider>(items));
 			});
 

--- a/OpenRA.Mods.Cnc/Graphics/ClassicSpriteSequence.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ClassicSpriteSequence.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 		public ClassicSpriteSequenceLoader(ModData modData)
 			: base(modData) { }
 
-		public override ISpriteSequence CreateSequence(ModData modData, TileSet tileSet, SpriteCache cache, string sequence, string animation, MiniYaml info)
+		public override ISpriteSequence CreateSequence(ModData modData, string tileSet, SpriteCache cache, string sequence, string animation, MiniYaml info)
 		{
 			return new ClassicSpriteSequence(modData, tileSet, cache, this, sequence, animation, info);
 		}
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 	{
 		readonly bool useClassicFacings;
 
-		public ClassicSpriteSequence(ModData modData, TileSet tileSet, SpriteCache cache, ISpriteSequenceLoader loader, string sequence, string animation, MiniYaml info)
+		public ClassicSpriteSequence(ModData modData, string tileSet, SpriteCache cache, ISpriteSequenceLoader loader, string sequence, string animation, MiniYaml info)
 			: base(modData, tileSet, cache, loader, sequence, animation, info)
 		{
 			var d = info.ToDictionary();

--- a/OpenRA.Mods.Cnc/Graphics/ClassicTilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ClassicTilesetSpecificSpriteSequence.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 				TilesetCodes = yaml.ToDictionary(kv => kv.Value);
 		}
 
-		public override ISpriteSequence CreateSequence(ModData modData, TileSet tileSet, SpriteCache cache, string sequence, string animation, MiniYaml info)
+		public override ISpriteSequence CreateSequence(ModData modData, string tileSet, SpriteCache cache, string sequence, string animation, MiniYaml info)
 		{
 			return new ClassicTilesetSpecificSpriteSequence(modData, tileSet, cache, this, sequence, animation, info);
 		}
@@ -43,24 +43,22 @@ namespace OpenRA.Mods.Cnc.Graphics
 
 	public class ClassicTilesetSpecificSpriteSequence : ClassicSpriteSequence
 	{
-		public ClassicTilesetSpecificSpriteSequence(ModData modData, TileSet tileSet, SpriteCache cache, ISpriteSequenceLoader loader, string sequence, string animation, MiniYaml info)
+		public ClassicTilesetSpecificSpriteSequence(ModData modData, string tileSet, SpriteCache cache, ISpriteSequenceLoader loader, string sequence, string animation, MiniYaml info)
 			: base(modData, tileSet, cache, loader, sequence, animation, info) { }
 
-		string ResolveTilesetId(TileSet tileSet, Dictionary<string, MiniYaml> d)
+		string ResolveTilesetId(string tileSet, Dictionary<string, MiniYaml> d)
 		{
-			var tsId = tileSet.Id;
-
 			if (d.TryGetValue("TilesetOverrides", out var yaml))
 			{
-				var tsNode = yaml.Nodes.FirstOrDefault(n => n.Key == tsId);
+				var tsNode = yaml.Nodes.FirstOrDefault(n => n.Key == tileSet);
 				if (tsNode != null)
-					tsId = tsNode.Value.Value;
+					tileSet = tsNode.Value.Value;
 			}
 
-			return tsId;
+			return tileSet;
 		}
 
-		protected override string GetSpriteSrc(ModData modData, TileSet tileSet, string sequence, string animation, string sprite, Dictionary<string, MiniYaml> d)
+		protected override string GetSpriteSrc(ModData modData, string tileSet, string sequence, string animation, string sprite, Dictionary<string, MiniYaml> d)
 		{
 			var loader = (ClassicTilesetSpecificSpriteSequenceLoader)Loader;
 

--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -42,12 +42,12 @@ namespace OpenRA.Mods.Common.Graphics
 	{
 		public DefaultSpriteSequenceLoader(ModData modData) { }
 
-		public virtual ISpriteSequence CreateSequence(ModData modData, TileSet tileSet, SpriteCache cache, string sequence, string animation, MiniYaml info)
+		public virtual ISpriteSequence CreateSequence(ModData modData, string tileSet, SpriteCache cache, string sequence, string animation, MiniYaml info)
 		{
 			return new DefaultSpriteSequence(modData, tileSet, cache, this, sequence, animation, info);
 		}
 
-		public IReadOnlyDictionary<string, ISpriteSequence> ParseSequences(ModData modData, TileSet tileSet, SpriteCache cache, MiniYamlNode node)
+		public IReadOnlyDictionary<string, ISpriteSequence> ParseSequences(ModData modData, string tileSet, SpriteCache cache, MiniYamlNode node)
 		{
 			var sequences = new Dictionary<string, ISpriteSequence>();
 			var nodes = node.Value.ToDictionary();
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Common.Graphics
 
 		public readonly uint[] EmbeddedPalette;
 
-		protected virtual string GetSpriteSrc(ModData modData, TileSet tileSet, string sequence, string animation, string sprite, Dictionary<string, MiniYaml> d)
+		protected virtual string GetSpriteSrc(ModData modData, string tileSet, string sequence, string animation, string sprite, Dictionary<string, MiniYaml> d)
 		{
 			return sprite ?? sequence;
 		}
@@ -166,7 +166,7 @@ namespace OpenRA.Mods.Common.Graphics
 			return Rectangle.FromLTRB(left, top, right, bottom);
 		}
 
-		public DefaultSpriteSequence(ModData modData, TileSet tileSet, SpriteCache cache, ISpriteSequenceLoader loader, string sequence, string animation, MiniYaml info)
+		public DefaultSpriteSequence(ModData modData, string tileSet, SpriteCache cache, ISpriteSequenceLoader loader, string sequence, string animation, MiniYaml info)
 		{
 			this.sequence = sequence;
 			Name = animation;

--- a/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Graphics
 				TilesetCodes = yaml.ToDictionary(kv => kv.Value);
 		}
 
-		public override ISpriteSequence CreateSequence(ModData modData, TileSet tileSet, SpriteCache cache, string sequence, string animation, MiniYaml info)
+		public override ISpriteSequence CreateSequence(ModData modData, string tileSet, SpriteCache cache, string sequence, string animation, MiniYaml info)
 		{
 			return new TilesetSpecificSpriteSequence(modData, tileSet, cache, this, sequence, animation, info);
 		}
@@ -43,24 +43,22 @@ namespace OpenRA.Mods.Common.Graphics
 
 	public class TilesetSpecificSpriteSequence : DefaultSpriteSequence
 	{
-		public TilesetSpecificSpriteSequence(ModData modData, TileSet tileSet, SpriteCache cache, ISpriteSequenceLoader loader, string sequence, string animation, MiniYaml info)
+		public TilesetSpecificSpriteSequence(ModData modData, string tileSet, SpriteCache cache, ISpriteSequenceLoader loader, string sequence, string animation, MiniYaml info)
 			: base(modData, tileSet, cache, loader, sequence, animation, info) { }
 
-		string ResolveTilesetId(TileSet tileSet, Dictionary<string, MiniYaml> d)
+		string ResolveTilesetId(string tileSet, Dictionary<string, MiniYaml> d)
 		{
-			var tsId = tileSet.Id;
-
 			if (d.TryGetValue("TilesetOverrides", out var yaml))
 			{
-				var tsNode = yaml.Nodes.FirstOrDefault(n => n.Key == tsId);
+				var tsNode = yaml.Nodes.FirstOrDefault(n => n.Key == tileSet);
 				if (tsNode != null)
-					tsId = tsNode.Value.Value;
+					tileSet = tsNode.Value.Value;
 			}
 
-			return tsId;
+			return tileSet;
 		}
 
-		protected override string GetSpriteSrc(ModData modData, TileSet tileSet, string sequence, string animation, string sprite, Dictionary<string, MiniYaml> d)
+		protected override string GetSpriteSrc(ModData modData, string tileSet, string sequence, string animation, string sprite, Dictionary<string, MiniYaml> d)
 		{
 			var loader = (TilesetSpecificSpriteSequenceLoader)Loader;
 


### PR DESCRIPTION
A small cleanup in preparation for the larger TileSet refactoring needed for the remasters, TS, and community mods.

Sequence implementations only need the ID, so passing just that decouples the sequence and tileset implementations.