### PR TITLE
Removed effective owner check in ChooseArmamentsForTarget

### DIFF
--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -371,20 +371,9 @@ namespace OpenRA.Mods.Common.Traits
 			// (short-circuiting in the logical expression below)
 			Player owner = null;
 			if (t.Type == TargetType.FrozenActor)
-			{
 				owner = t.FrozenActor.Owner;
-			}
 			else if (t.Type == TargetType.Actor)
-			{
-				owner = t.Actor.EffectiveOwner != null && t.Actor.EffectiveOwner.Owner != null
-					? t.Actor.EffectiveOwner.Owner
-					: t.Actor.Owner;
-
-				// Special cases for spies so we don't kill friendly disguised spies
-				// and enable dogs to kill enemy disguised spies.
-				if (self.Owner.Stances[t.Actor.Owner] == Stance.Ally || self.Info.HasTraitInfo<IgnoresDisguiseInfo>())
-					owner = t.Actor.Owner;
-			}
+				owner = t.Actor.Owner;
 
 			return Armaments.Where(a =>
 				!a.IsTraitDisabled


### PR DESCRIPTION
Fixes #18631. 

This caused units to stalk or idle after a target spy took on a disguise, since they couldn't pick a proper armament.

IMO the code being removed has rotted. It mentions stance checks for dogs/spies which is actually bogus, and I can't see why we would want to use effective owner here. It was also added prior to letting units target disguised spies without force-attack.

Testable with two clients:
- Client 1: Target a spy with no disguise
- Client 2: Disguise the spy
- Before this PR -- `AttackFollow` units would stalk the spy without dropping the target (planes would idle, helicopters would stalk).
- After this PR -- unit will continue to attack the spy.
