### PR TITLE
Use lobby option display values when clients join a server

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -548,8 +548,8 @@ namespace OpenRA.Traits
 	{
 		static readonly Dictionary<string, string> BoolValues = new Dictionary<string, string>()
 		{
-			{ true.ToString(), "enabled" },
-			{ false.ToString(), "disabled" }
+			{ true.ToString(), "Enabled" },
+			{ false.ToString(), "Disabled" }
 		};
 
 		public LobbyBooleanOption(string id, string name, string description, bool visible, int displayorder, bool defaultValue, bool locked)
@@ -557,7 +557,7 @@ namespace OpenRA.Traits
 
 		public override string ValueChangedMessage(string playerName, string newValue)
 		{
-			return playerName + " " + BoolValues[newValue] + " " + Name + ".";
+			return playerName + " " + BoolValues[newValue].ToLowerInvariant() + " " + Name + ".";
 		}
 	}
 

--- a/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Network;
 using OpenRA.Server;
@@ -31,17 +30,14 @@ namespace OpenRA.Mods.Common.Server
 
 				var options = server.Map.Rules.Actors["player"].TraitInfos<ILobbyOptions>()
 					.Concat(server.Map.Rules.Actors["world"].TraitInfos<ILobbyOptions>())
-					.SelectMany(t => t.LobbyOptions(server.Map.Rules));
-
-				var optionNames = new Dictionary<string, string>();
-				foreach (var o in options)
-					optionNames[o.Id] = o.Name;
+					.SelectMany(t => t.LobbyOptions(server.Map.Rules))
+					.ToDictionary(o => o.Id, o => o);
 
 				foreach (var kv in server.LobbyInfo.GlobalSettings.LobbyOptions)
 				{
 					if (!defaults.LobbyOptions.TryGetValue(kv.Key, out var def) || kv.Value.Value != def.Value)
-						if (optionNames.TryGetValue(kv.Key, out var optionName))
-							server.SendOrderTo(conn, "Message", optionName + ": " + kv.Value.Value);
+						if (options.TryGetValue(kv.Key, out var option))
+							server.SendOrderTo(conn, "Message", option.Name + ": " + option.Values[kv.Value.Value]);
 				}
 			}
 		}


### PR DESCRIPTION
This pretties what players see when joining a server with custom rules. It's also more consistent with how changed options are displayed.

Before (joining a server):
![image](https://user-images.githubusercontent.com/566742/95669220-56131800-0b3b-11eb-864a-e31efca4ebfc.png)

After:
![image](https://user-images.githubusercontent.com/566742/95669222-59a69f00-0b3b-11eb-8af4-14d9236ccacf.png)
