### PR TITLE
Threaded Renderer improvements

### DIFF
--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -101,8 +101,7 @@ namespace OpenRA
 	{
 		void Bind();
 		void SetData(T[] vertices, int length);
-		void SetData(T[] vertices, int start, int length);
-		void SetData(IntPtr data, int start, int length);
+		void SetData(T[] vertices, int offset, int start, int length);
 	}
 
 	public interface IShader

--- a/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
+++ b/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
@@ -183,15 +183,7 @@ namespace OpenRA.Graphics
 					continue;
 
 				var rowOffset = rowStride * row;
-
-				unsafe
-				{
-					// The compiler / language spec won't let us calculate a pointer to
-					// an offset inside a generic array T[], and so we are forced to
-					// calculate the start-of-row pointer here to pass in to SetData.
-					fixed (Vertex* vPtr = &vertices[0])
-						vertexBuffer.SetData((IntPtr)(vPtr + rowOffset), rowOffset, rowStride);
-				}
+				vertexBuffer.SetData(vertices, rowOffset, rowOffset, rowStride);
 			}
 
 			Game.Renderer.WorldSpriteRenderer.DrawVertexBuffer(

--- a/OpenRA.Platforms.Default/VertexBuffer.cs
+++ b/OpenRA.Platforms.Default/VertexBuffer.cs
@@ -57,10 +57,10 @@ namespace OpenRA.Platforms.Default
 
 		public void SetData(T[] data, int length)
 		{
-			SetData(data, 0, length);
+			SetData(data, 0, 0, length);
 		}
 
-		public void SetData(T[] data, int start, int length)
+		public void SetData(T[] data, int offset, int start, int length)
 		{
 			Bind();
 
@@ -70,23 +70,13 @@ namespace OpenRA.Platforms.Default
 				OpenGL.glBufferSubData(OpenGL.GL_ARRAY_BUFFER,
 					new IntPtr(VertexSize * start),
 					new IntPtr(VertexSize * length),
-					ptr.AddrOfPinnedObject());
+					ptr.AddrOfPinnedObject() + VertexSize * offset);
 			}
 			finally
 			{
 				ptr.Free();
 			}
 
-			OpenGL.CheckGLError();
-		}
-
-		public void SetData(IntPtr data, int start, int length)
-		{
-			Bind();
-			OpenGL.glBufferSubData(OpenGL.GL_ARRAY_BUFFER,
-				new IntPtr(VertexSize * start),
-				new IntPtr(VertexSize * length),
-				data);
 			OpenGL.CheckGLError();
 		}
 


### PR DESCRIPTION
- VertexBuffer interface redefined to remove an IntPtr overload for SetData. This removes some unsafe code in TerrainSpriteLayer. This also allows the ThreadedVertexBuffer to use a buffer and post these calls, meaning the SetData call can now be non-blocking.
- ThreadedTexture SetData now checks the incoming array size. As the arrays sent here are usually large (megabytes) this allows us to avoid creating temp arrays in the LOH and skip Array.Copy calls on large arrays. This means the call is now blocking more often, but significantly reduces memory churn and GC Gen2 collections.

----

The vertex buffer change is a nice win all around - removes some unsafe code in `TerrainSpriteLayer` and makes the SetData non-blocking in practise.

The `ThreadedTexture` change means we introduce a blocking call there instead. Combined with the vertex buffer change this hopefully means the change in perf-neutral in terms of the amount of blocking calls to the threaded-renderer.

However this significantly benefits us by allowing us to avoid allocating large temp arrays that go straight into the LOH. This can only be collected by a Gen2 collection which is significant work for the GC. Needing to `Array.Copy` data into these large arrays is also a time-sink.

We add a path that allows small arrays to continue to be copied to temp arrays and use a non-blocking call. In practise this allows the `HardwarePalette` which updates the palette once per frame to remain non-blocking. Since the array is small, it does not go into the LOH and can be collected by a cheap Gen0/1 GC.

This means using the threaded renderer no longer creates significant memory churn nor forces the GC to run a Gen2 GC every few seconds to collect all the large temp arrays.

In practise, the only blocking call during a frame in a game now comes from the radar needing to update it's texture each frame. This array is too big for the non-blocking path.

Overall this means we shifted from one blocking call per frame for `TerrainSpriteLayer` updates to one for the radar and therefore fairly neutral in that respect - but the memory churn is much improved.