### PR TITLE
Reduce ongoing allocations

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -110,7 +110,7 @@ namespace OpenRA
 		readonly IDefaultVisibility defaultVisibility;
 		readonly INotifyBecomingIdle[] becomingIdles;
 		readonly INotifyIdle[] tickIdles;
-		readonly ITargetablePositions[] targetablePositions;
+		readonly IEnumerable<ITargetablePositions> enabledTargetablePositions;
 		WPos[] staticTargetablePositions;
 		bool created;
 
@@ -166,7 +166,8 @@ namespace OpenRA
 			becomingIdles = TraitsImplementing<INotifyBecomingIdle>().ToArray();
 			tickIdles = TraitsImplementing<INotifyIdle>().ToArray();
 			Targetables = TraitsImplementing<ITargetable>().ToArray();
-			targetablePositions = TraitsImplementing<ITargetablePositions>().ToArray();
+			var targetablePositions = TraitsImplementing<ITargetablePositions>().ToArray();
+			enabledTargetablePositions = targetablePositions.Where(Exts.IsTraitEnabled);
 			world.AddFrameEndTask(w =>
 			{
 				// Caching this in a AddFrameEndTask, because trait construction order might cause problems if done directly at creation time.
@@ -515,9 +516,8 @@ namespace OpenRA
 			if (staticTargetablePositions != null)
 				return staticTargetablePositions;
 
-			var enabledTargetablePositionTraits = targetablePositions.Where(Exts.IsTraitEnabled);
-			if (enabledTargetablePositionTraits.Any())
-				return enabledTargetablePositionTraits.SelectMany(tp => tp.TargetablePositions(this));
+			if (enabledTargetablePositions.Any())
+				return enabledTargetablePositions.SelectMany(tp => tp.TargetablePositions(this));
 
 			return new[] { CenterPosition };
 		}

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -239,7 +239,15 @@ namespace OpenRA.Graphics
 				return new int2(0, size);
 
 			var lines = text.Split('\n');
-			return new int2((int)Math.Ceiling(lines.Max(lineWidth)), lines.Length * size);
+			return new int2((int)Math.Ceiling(MaxLineWidth(lines, lineWidth)), lines.Length * size);
+		}
+
+		static float MaxLineWidth(string[] lines, Func<string, float> lineWidth)
+		{
+			var maxWidth = 0f;
+			foreach (var line in lines)
+				maxWidth = Math.Max(maxWidth, lineWidth(line));
+			return maxWidth;
 		}
 
 		GlyphInfo CreateGlyph(char c)

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -10,17 +10,21 @@
 #endregion
 
 using System;
+using System.Linq;
 using OpenRA.Primitives;
 
 namespace OpenRA.Graphics
 {
 	public class SpriteRenderer : Renderer.IBatchRenderer
 	{
+		const int SheetCount = 7;
+		static readonly string[] SheetIndexToTextureName = Exts.MakeArray(SheetCount, i => "Texture{0}".F(i));
+
 		readonly Renderer renderer;
 		readonly IShader shader;
 
 		readonly Vertex[] vertices;
-		readonly Sheet[] sheets = new Sheet[7];
+		readonly Sheet[] sheets = new Sheet[SheetCount];
 
 		BlendMode currentBlend = BlendMode.Alpha;
 		int nv = 0;
@@ -39,7 +43,7 @@ namespace OpenRA.Graphics
 			{
 				for (var i = 0; i < ns; i++)
 				{
-					shader.SetTexture("Texture{0}".F(i), sheets[i].GetTexture());
+					shader.SetTexture(SheetIndexToTextureName[i], sheets[i].GetTexture());
 					sheets[i] = null;
 				}
 

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -282,7 +282,7 @@ namespace OpenRA.Graphics
 			// Try and find the closest cell
 			if (candidates.Count > 0)
 			{
-				return candidates.OrderBy(uv =>
+				return candidates.MinBy(uv =>
 				{
 					var p = map.CenterOfCell(uv.ToCPos(map.Grid.Type));
 					var s = worldRenderer.ScreenPxPosition(p);
@@ -290,7 +290,7 @@ namespace OpenRA.Graphics
 					var dy = Math.Abs(s.Y - world.Y);
 
 					return dx * dx + dy * dy;
-				}).First().ToCPos(map);
+				}).ToCPos(map);
 			}
 
 			// Something is very wrong, but lets return something that isn't completely bogus and hope the caller can recover

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Graphics
 {
 	public sealed class WorldRenderer : IDisposable
 	{
-		public static readonly Func<IRenderable, int> RenderableScreenZPositionComparisonKey =
+		public static readonly Func<IRenderable, int> RenderableZPositionComparisonKey =
 			r => ZPosition(r.Pos, r.ZOffset);
 
 		public readonly Size TileSize;
@@ -133,7 +133,9 @@ namespace OpenRA.Graphics
 			foreach (var e in World.ScreenMap.RenderableEffectsInBox(Viewport.TopLeft, Viewport.BottomRight))
 				renderablesBuffer.AddRange(e.Render(this));
 
-			foreach (var renderable in renderablesBuffer.OrderBy(RenderableScreenZPositionComparisonKey))
+			renderablesBuffer.Sort((x, y) => RenderableZPositionComparisonKey(x).CompareTo(RenderableZPositionComparisonKey(y)));
+
+			foreach (var renderable in renderablesBuffer)
 				preparedRenderables.Add(renderable.PrepareRender(this));
 
 			// PERF: Reuse collection to avoid allocations.

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -1282,16 +1282,12 @@ namespace OpenRA
 				throw new ArgumentOutOfRangeException("maxRange",
 					"The requested range ({0}) cannot exceed the value of MaximumTileSearchRange ({1})".F(maxRange, Grid.MaximumTileSearchRange));
 
-			Func<CPos, bool> valid = Contains;
-			if (allowOutsideBounds)
-				valid = Tiles.Contains;
-
 			for (var i = minRange; i <= maxRange; i++)
 			{
 				foreach (var offset in Grid.TilesByDistance[i])
 				{
 					var t = offset + center;
-					if (valid(t))
+					if (allowOutsideBounds ? Tiles.Contains(t) : Contains(t))
 						yield return t;
 				}
 			}

--- a/OpenRA.Game/Network/FrameData.cs
+++ b/OpenRA.Game/Network/FrameData.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Network
 			if (lastClientFrame == -1)
 				lastClientFrame = framePackets
 					.Where(x => x.Value.ContainsKey(clientId))
-					.Select(x => x.Key).OrderBy(x => x).LastOrDefault();
+					.Select(x => x.Key).MaxByOrDefault(x => x);
 
 			clientQuitTimes[clientId] = lastClientFrame;
 		}

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -39,10 +39,11 @@ namespace OpenRA.Traits
 		readonly ICreatesFrozenActors frozenTrait;
 		readonly Player viewer;
 		readonly Shroud shroud;
+		readonly List<WPos> targetablePositions = new List<WPos>();
 
 		public Player Owner { get; private set; }
 		public BitSet<TargetableType> TargetTypes { get; private set; }
-		public WPos[] TargetablePositions { get; private set; }
+		public IEnumerable<WPos> TargetablePositions { get { return targetablePositions; } }
 
 		public ITooltipInfo TooltipInfo { get; private set; }
 		public Player TooltipOwner { get; private set; }
@@ -117,7 +118,8 @@ namespace OpenRA.Traits
 		{
 			Owner = actor.Owner;
 			TargetTypes = actor.GetEnabledTargetTypes();
-			TargetablePositions = actor.GetTargetablePositions().ToArray();
+			targetablePositions.Clear();
+			targetablePositions.AddRange(actor.GetTargetablePositions());
 			Hidden = !actor.CanBeViewedByPlayer(viewer);
 
 			if (health != null)

--- a/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
@@ -72,8 +72,8 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 
 		void ITick.Tick(Actor self)
 		{
-			if (movement.CurrentMovementTypes.HasFlag(MovementType.Horizontal)
-				|| movement.CurrentMovementTypes.HasFlag(MovementType.Turn))
+			if (movement.CurrentMovementTypes.HasMovementType(MovementType.Horizontal)
+				|| movement.CurrentMovementTypes.HasMovementType(MovementType.Turn))
 				tick++;
 
 			if (tick < info.TickRate)

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -419,7 +419,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			CurrentMovementTypes = newMovementTypes;
 
-			if (!CurrentMovementTypes.HasFlag(MovementType.Horizontal))
+			if (!CurrentMovementTypes.HasMovementType(MovementType.Horizontal))
 			{
 				if (Info.Roll != WAngle.Zero && Roll != WAngle.Zero)
 					Roll = Util.TickFacing(Roll, WAngle.Zero, Info.RollSpeed);

--- a/OpenRA.Mods.Common/Traits/Buildings/ActorPreviewPlaceBuildingPreview.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ActorPreviewPlaceBuildingPreview.cs
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Common.Traits
 				foreach (var r in RenderFootprint(wr, topLeft, footprint, info.FootprintUnderPreview))
 					yield return r;
 
-			foreach (var r in previewRenderables.OrderBy(WorldRenderer.RenderableScreenZPositionComparisonKey))
+			foreach (var r in previewRenderables.OrderBy(WorldRenderer.RenderableZPositionComparisonKey))
 				yield return r;
 
 			if (info.FootprintOverPreview != PlaceBuildingCellType.None)

--- a/OpenRA.Mods.Common/Traits/CapturableProgressBlink.cs
+++ b/OpenRA.Mods.Common/Traits/CapturableProgressBlink.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (IsTraitDisabled)
 				return;
 
-			if (!captorOwners.Any())
+			if (captorOwners.Count == 0)
 			{
 				tick = 0;
 				return;

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -249,7 +249,7 @@ namespace OpenRA.Mods.Common.Traits
 				var offset = body.LocalToWorld(CarryableOffset.Rotate(body.QuantizeOrientation(self, self.Orientation)));
 				var previewRenderables = carryablePreview
 					.SelectMany(p => p.Render(wr, self.CenterPosition + offset))
-					.OrderBy(WorldRenderer.RenderableScreenZPositionComparisonKey);
+					.OrderBy(WorldRenderer.RenderableZPositionComparisonKey);
 
 				foreach (var r in previewRenderables)
 					yield return r;

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -55,13 +55,18 @@ namespace OpenRA.Mods.Common.Traits
 		IEnumerable<IRenderable> IRenderAnnotations.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			if (debugVis == null || !debugVis.CombatGeometry || self.World.FogObscures(self))
-				yield break;
+				return Enumerable.Empty<IRenderable>();
 
+			return RenderAnnotations(self, wr);
+		}
+
+		IEnumerable<IRenderable> RenderAnnotations(Actor self, WorldRenderer wr)
+		{
 			var blockers = allBlockers.Where(Exts.IsTraitEnabled).ToList();
 			if (blockers.Count > 0)
 			{
 				var height = new WVec(0, 0, blockers.Max(b => b.BlockingHeight.Length));
-				yield return new LineAnnotationRenderable(self.CenterPosition, self.CenterPosition + height, 1,  Color.Orange);
+				yield return new LineAnnotationRenderable(self.CenterPosition, self.CenterPosition + height, 1, Color.Orange);
 			}
 
 			var activeShapes = shapes.Where(Exts.IsTraitEnabled);

--- a/OpenRA.Mods.Common/Traits/CreatesShroud.cs
+++ b/OpenRA.Mods.Common/Traits/CreatesShroud.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -25,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class CreatesShroud : AffectsShroud
 	{
 		readonly CreatesShroudInfo info;
-		ICreatesShroudModifier[] rangeModifiers;
+		IEnumerable<int> rangeModifiers;
 
 		public CreatesShroud(Actor self, CreatesShroudInfo info)
 			: base(self, info)
@@ -37,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			base.Created(self);
 
-			rangeModifiers = self.TraitsImplementing<ICreatesShroudModifier>().ToArray();
+			rangeModifiers = self.TraitsImplementing<ICreatesShroudModifier>().ToArray().Select(x => x.GetCreatesShroudModifier());
 		}
 
 		protected override void AddCellsToPlayerShroud(Actor self, Player p, PPos[] uv)
@@ -57,8 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (CachedTraitDisabled)
 					return WDist.Zero;
 
-				var revealsShroudModifier = rangeModifiers.Select(x => x.GetCreatesShroudModifier());
-				var range = Util.ApplyPercentageModifiers(Info.Range.Length, revealsShroudModifier);
+				var range = Util.ApplyPercentageModifiers(Info.Range.Length, rangeModifiers);
 				return new WDist(range);
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/HitShape.cs
+++ b/OpenRA.Mods.Common/Traits/HitShape.cs
@@ -90,8 +90,13 @@ namespace OpenRA.Mods.Common.Traits
 		IEnumerable<WPos> ITargetablePositions.TargetablePositions(Actor self)
 		{
 			if (IsTraitDisabled)
-				yield break;
+				return Enumerable.Empty<WPos>();
 
+			return TargetablePositions(self);
+		}
+
+		IEnumerable<WPos> TargetablePositions(Actor self)
+		{
 			if (Info.UseTargetableCellsOffsets && targetableCells != null)
 				foreach (var c in targetableCells.TargetableCells())
 					yield return self.World.Map.CenterOfCell(c.Cell);

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -402,10 +402,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool IsLeaving()
 		{
-			if (CurrentMovementTypes.HasFlag(MovementType.Horizontal))
+			if (CurrentMovementTypes.HasMovementType(MovementType.Horizontal))
 				return true;
 
-			if (CurrentMovementTypes.HasFlag(MovementType.Turn))
+			if (CurrentMovementTypes.HasMovementType(MovementType.Turn))
 				return TurnToMove;
 
 			return false;

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -309,7 +309,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected void CancelUnbuildableItems()
 		{
-			var buildableNames = BuildableItems().Select(b => b.Name).ToList();
+			if (Queue.Count == 0)
+				return;
+
+			var buildableNames = BuildableItems().Select(b => b.Name).ToHashSet();
 
 			// EndProduction removes the item from the queue, so we enumerate
 			// by index in reverse to avoid issues with index reassignment

--- a/OpenRA.Mods.Common/Traits/Render/ProductionBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/ProductionBar.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (IsTraitDisabled)
 				return;
 
-			var current = queue.AllQueued().Where(i => i.Started).OrderBy(i => i.RemainingTime).FirstOrDefault();
+			var current = queue.AllQueued().Where(i => i.Started).MinByOrDefault(i => i.RemainingTime);
 			value = current != null ? 1 - (float)current.RemainingCost / current.TotalCost : 0;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingRepairDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingRepairDecoration.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		protected override bool ShouldRender(Actor self)
 		{
-			if (!rb.Repairers.Any())
+			if (rb.Repairers.Count == 0)
 				return false;
 
 			return base.ShouldRender(self);

--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -168,12 +168,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 				wasModifying = rsm.IsModifyingSequence;
 			}
 
-			if ((state != AnimationState.Moving || dirty) && move.CurrentMovementTypes.HasFlag(MovementType.Horizontal))
+			if ((state != AnimationState.Moving || dirty) && move.CurrentMovementTypes.HasMovementType(MovementType.Horizontal))
 			{
 				state = AnimationState.Moving;
 				DefaultAnimation.PlayRepeating(NormalizeInfantrySequence(self, GetDisplayInfo().MoveSequence));
 			}
-			else if (((state == AnimationState.Moving || dirty) && !move.CurrentMovementTypes.HasFlag(MovementType.Horizontal))
+			else if (((state == AnimationState.Moving || dirty) && !move.CurrentMovementTypes.HasMovementType(MovementType.Horizontal))
 				|| ((state == AnimationState.Idle || state == AnimationState.IdleAnimating) && !self.IsIdle))
 				PlayStandAnimation(self);
 

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -106,8 +106,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (!Info.Recoils)
 				return t.Position(self);
 
-			var recoilDist = arms.Aggregate(WDist.Zero, (a, b) => a + b.Recoil);
-			var recoil = new WVec(-recoilDist, WDist.Zero, WDist.Zero);
+			var recoilDist = 0;
+			foreach (var arm in arms)
+				recoilDist += arm.Recoil.Length;
+			var recoil = new WVec(new WDist(-recoilDist), WDist.Zero, WDist.Zero);
 			return t.Position(self) + body.LocalToWorld(recoil.Rotate(t.WorldOrientation));
 		}
 

--- a/OpenRA.Mods.Common/Traits/RevealsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/RevealsShroud.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -29,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly RevealsShroudInfo info;
 		readonly Shroud.SourceType type;
-		IRevealsShroudModifier[] rangeModifiers;
+		IEnumerable<int> rangeModifiers;
 
 		public RevealsShroud(Actor self, RevealsShroudInfo info)
 			: base(self, info)
@@ -43,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			base.Created(self);
 
-			rangeModifiers = self.TraitsImplementing<IRevealsShroudModifier>().ToArray();
+			rangeModifiers = self.TraitsImplementing<IRevealsShroudModifier>().ToArray().Select(x => x.GetRevealsShroudModifier());
 		}
 
 		protected override void AddCellsToPlayerShroud(Actor self, Player p, PPos[] uv)
@@ -63,8 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (CachedTraitDisabled)
 					return WDist.Zero;
 
-				var revealsShroudModifier = rangeModifiers.Select(x => x.GetRevealsShroudModifier());
-				var range = Util.ApplyPercentageModifiers(Info.Range.Length, revealsShroudModifier);
+				var range = Util.ApplyPercentageModifiers(Info.Range.Length, rangeModifiers);
 				return new WDist(range);
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/World/EditorCursorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorCursorLayer.cs
@@ -147,7 +147,7 @@ namespace OpenRA.Mods.Common.Traits
 				return terrainOrResourcePreview;
 
 			if (Type == EditorCursorType.Actor)
-				return Actor.Render().OrderBy(WorldRenderer.RenderableScreenZPositionComparisonKey);
+				return Actor.Render().OrderBy(WorldRenderer.RenderableZPositionComparisonKey);
 
 			return NoRenderables;
 		}

--- a/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			renderables = preview
 				.SelectMany(p => p.RenderUI(worldRenderer, origin, scale))
-				.OrderBy(WorldRenderer.RenderableScreenZPositionComparisonKey)
+				.OrderBy(WorldRenderer.RenderableZPositionComparisonKey)
 				.Select(r => r.PrepareRender(worldRenderer))
 				.ToArray();
 		}

--- a/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
@@ -249,7 +249,8 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var position = GetTextPosition(text, font, rb);
 
-			var hover = Ui.MouseOverWidget == this || Children.Any(c => c == Ui.MouseOverWidget);
+			// PERF: Avoid LINQ by using Children.Find(...) != null instead of Children.Any(...)
+			var hover = Ui.MouseOverWidget == this || Children.Find(c => c == Ui.MouseOverWidget) != null;
 			DrawBackground(rb, disabled, Depressed, hover, highlighted);
 			if (Contrast)
 				font.DrawTextWithContrast(text, position + stateOffset,

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -740,7 +740,7 @@ namespace OpenRA.Platforms.Default
 		public static void CheckGLError()
 		{
 			// Let the debug message handler log the errors instead.
-			if (Features.HasFlag(GLFeatures.DebugMessagesCallback))
+			if ((Features & GLFeatures.DebugMessagesCallback) == GLFeatures.DebugMessagesCallback)
 				return;
 
 			var type = glGetError();


### PR DESCRIPTION
Batch of collected small tweaks to reduce ongoing allocations in the main game loop. These were all driven by profiling and are each largely insignificant changes on their own, but make a small impact when combined together.

I have separated the changes out of several commits for easier review. Additionally if any change impacts readability too much, we can happily remove that commit.