### PR TITLE
Add visual inaccuracy to effect warhead and use it on light RA/TD weapons

### DIFF
--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -46,6 +46,9 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("Whether to consider actors in determining whether the explosion should happen. If false, only terrain will be considered.")]
 		public readonly bool ImpactActors = true;
 
+		[Desc("The maximum inaccuracy of the effect spawn position relative to actual impact position.")]
+		public readonly WDist Inaccuracy = WDist.Zero;
+
 		static readonly BitSet<TargetableType> TargetTypeAir = new BitSet<TargetableType>("Air");
 
 		/// <summary>Checks if there are any actors at impact position and if the warhead is valid against any of them.</summary>
@@ -109,6 +112,9 @@ namespace OpenRA.Mods.Common.Warheads
 			var explosion = Explosions.RandomOrDefault(world.LocalRandom);
 			if (Image != null && explosion != null)
 			{
+				if (Inaccuracy.Length > 0)
+					pos += WVec.FromPDF(world.SharedRandom, 2) * Inaccuracy.Length / 1024;
+
 				if (ForceDisplayAtGroundLevel)
 				{
 					var dat = world.Map.DistanceAboveTerrain(pos);

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -99,6 +99,7 @@ HeliAAGun:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piff
+		Inaccuracy: 171
 
 Pistol:
 	Inherits: ^LightMG
@@ -109,9 +110,19 @@ Pistol:
 		Damage: 100
 		Versus:
 			None: 100
+	Warhead@2Eff: CreateEffect
+		Inaccuracy: 128
 
 M16:
 	Inherits: ^LightMG
+	Warhead@2Eff2: CreateEffect
+		Delay: 2
+		Explosions: piff
+		Inaccuracy: 171
+	Warhead@2Eff3: CreateEffect
+		Delay: 4
+		Explosions: piff
+		Inaccuracy: 171
 
 MachineGun:
 	Inherits: ^LightMG
@@ -122,7 +133,7 @@ MachineGun:
 			Wood: 10
 			Light: 70
 	Warhead@2Eff: CreateEffect
-		Explosions: piffs
+		Inaccuracy: 213
 
 MachineGunH:
 	Inherits: MachineGun

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -11,6 +11,10 @@ Sniper:
 		Damage: 10000
 		ValidTargets: Infantry
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
+	Warhead@2Eff: CreateEffect
+		Explosions: piff
+		ImpactActors: false
+		ValidTargets: Ground, Water, Air
 
 ^HeavyMG:
 	ReloadDelay: 25

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -81,16 +81,6 @@ HeliAAGun:
 		Versus:
 			Light: 50
 
-Pistol:
-	Inherits: ^LightMG
-	ReloadDelay: 7
-	Range: 3c0
-	Report: gun18.aud
-	Warhead@1Dam: SpreadDamage
-		Damage: 100
-		Versus:
-			None: 100
-
 ^LightMG:
 	Inherits: ^HeavyMG
 	ReloadDelay: 20
@@ -109,6 +99,16 @@ Pistol:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piff
+
+Pistol:
+	Inherits: ^LightMG
+	ReloadDelay: 7
+	Range: 3c0
+	Report: gun18.aud
+	Warhead@1Dam: SpreadDamage
+		Damage: 100
+		Versus:
+			None: 100
 
 M16:
 	Inherits: ^LightMG

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -93,6 +93,12 @@ FLAK-23-AG:
 			Heavy: 10
 			Concrete: 10
 		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
+	Warhead@2Eff: CreateEffect
+		Explosions: piff
+		Inaccuracy: 171
+	Warhead@3EffWater: CreateEffect
+		Explosions: water_piff
+		Inaccuracy: 171
 
 Vulcan:
 	Inherits: ^HeavyMG
@@ -252,9 +258,9 @@ Pistol:
 		Versus:
 			None: 100
 	Warhead@2Eff: CreateEffect
-		Explosions: piff
+		Inaccuracy: 128
 	Warhead@3EffWater: CreateEffect
-		Explosions: water_piff
+		Inaccuracy: 128
 
 M1Carbine:
 	Inherits: ^LightMG
@@ -264,6 +270,26 @@ M1Carbine:
 	Warhead@1Dam: SpreadDamage
 		Versus:
 			Wood: 30
+	Warhead@2Eff2: CreateEffect
+		Delay: 2
+		Explosions: piff
+		Inaccuracy: 171
+	Warhead@3EffWater2: CreateEffect
+		Delay: 2
+		ValidTargets: Water, Underwater
+		InvalidTargets: Bridge
+		Explosions: water_piff
+		Inaccuracy: 171
+	Warhead@2Eff3: CreateEffect
+		Delay: 4
+		Explosions: piff
+		Inaccuracy: 171
+	Warhead@3EffWater3: CreateEffect
+		Delay: 4
+		ValidTargets: Water, Underwater
+		InvalidTargets: Bridge
+		Explosions: water_piff
+		Inaccuracy: 171
 
 M60mg:
 	Inherits: ^LightMG
@@ -274,6 +300,10 @@ M60mg:
 	Warhead@1Dam: SpreadDamage
 		Versus:
 			Light: 30
+	Warhead@2Eff: CreateEffect
+		Inaccuracy: 213
+	Warhead@3EffWater: CreateEffect
+		Inaccuracy: 213
 
 ^SnipeWeapon:
 	ReloadDelay: 80

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -317,26 +317,6 @@ M60mg:
 		Damage: 15000
 		ValidTargets: Barrel, Infantry
 		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
-
-SilencedPPK:
-	Inherits: ^SnipeWeapon
-	Report: silppk.aud
-	Warhead@1Dam: SpreadDamage
-		Spread: 128
-	Warhead@2Eff: CreateEffect
-		Explosions: piffs
-		ValidTargets: Ground, Ship, Air, Trees
-	Warhead@3EffWater: CreateEffect
-		Explosions: water_piffs
-		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
-
-Colt45:
-	Inherits: ^SnipeWeapon
-	ReloadDelay: 5
-	Range: 7c0
-	Warhead@1Dam: SpreadDamage
-		Damage: 5000
 	Warhead@2Eff: CreateEffect
 		Explosions: piff
 		ValidTargets: Ground, Ship, Air, Trees
@@ -344,6 +324,19 @@ Colt45:
 		Explosions: water_piff
 		ValidTargets: Water, Underwater
 		InvalidTargets: Ship, Structure, Bridge
+
+SilencedPPK:
+	Inherits: ^SnipeWeapon
+	Report: silppk.aud
+	Warhead@1Dam: SpreadDamage
+		Spread: 128
+
+Colt45:
+	Inherits: ^SnipeWeapon
+	ReloadDelay: 5
+	Range: 7c0
+	Warhead@1Dam: SpreadDamage
+		Damage: 5000
 
 Sniper:
 	Inherits: ^SnipeWeapon

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -75,8 +75,7 @@ FLAK-23-AG:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground, Air
-		ImpactActors: false
+		ValidTargets: Ground, GroundActor, Air, AirborneActor, WaterActor, Trees
 	Warhead@3EffWater: CreateEffect
 		Explosions: water_piffs
 		ValidTargets: Water, Underwater
@@ -124,8 +123,7 @@ Vulcan:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@4Eff_2: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground
-		ImpactActors: false
+		ValidTargets: Ground, GroundActor, Air, AirborneActor, WaterActor, Trees
 		Delay: 2
 	Warhead@4Eff_2Water: CreateEffect
 		Explosions: water_piffs
@@ -146,8 +144,7 @@ Vulcan:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@6Eff_3: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground
-		ImpactActors: false
+		ValidTargets: Ground, GroundActor, Air, AirborneActor, WaterActor, Trees
 		Delay: 4
 	Warhead@6Eff_3Water: CreateEffect
 		Explosions: water_piffs
@@ -168,8 +165,7 @@ Vulcan:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@8Eff_4: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground
-		ImpactActors: false
+		ValidTargets: Ground, GroundActor, Air, AirborneActor, WaterActor, Trees
 		Delay: 6
 	Warhead@8Eff_4Water: CreateEffect
 		Explosions: water_piffs
@@ -190,8 +186,7 @@ Vulcan:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@10Eff_5: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground
-		ImpactActors: false
+		ValidTargets: Ground, GroundActor, Air, AirborneActor, WaterActor, Trees
 		Delay: 8
 	Warhead@10Eff_5Water: CreateEffect
 		Explosions: water_piffs
@@ -212,8 +207,7 @@ Vulcan:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@12Eff_6: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground
-		ImpactActors: false
+		ValidTargets: Ground, GroundActor, Air, AirborneActor, WaterActor, Trees
 		Delay: 10
 	Warhead@12Eff_6Water: CreateEffect
 		Explosions: water_piffs
@@ -273,6 +267,7 @@ M1Carbine:
 	Warhead@2Eff2: CreateEffect
 		Delay: 2
 		Explosions: piff
+		ValidTargets: Ground, GroundActor, Air, AirborneActor, WaterActor, Trees
 		Inaccuracy: 171
 	Warhead@3EffWater2: CreateEffect
 		Delay: 2
@@ -283,6 +278,7 @@ M1Carbine:
 	Warhead@2Eff3: CreateEffect
 		Delay: 4
 		Explosions: piff
+		ValidTargets: Ground, GroundActor, Air, AirborneActor, WaterActor, Trees
 		Inaccuracy: 171
 	Warhead@3EffWater3: CreateEffect
 		Delay: 4
@@ -319,7 +315,7 @@ M60mg:
 		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piff
-		ValidTargets: Ground, Ship, Air, Trees
+		ValidTargets: Ground, GroundActor, Air, AirborneActor, WaterActor, Trees
 	Warhead@3EffWater: CreateEffect
 		Explosions: water_piff
 		ValidTargets: Water, Underwater


### PR DESCRIPTION
Purely cosmetic, allows to 'fake' slight inaccuracy without affecting game balance on weapons like light machine guns.

Used on RA Minigunner M1Carbine and the M60 MGs in both RA and TD to drop the somewhat overkill `piffs` animation if favor of just `piff`.