### PR TITLE
20201011 perf drawline

### DIFF
--- a/OpenRA.Game/Graphics/RgbaColorRenderer.cs
+++ b/OpenRA.Game/Graphics/RgbaColorRenderer.cs
@@ -30,7 +30,8 @@ namespace OpenRA.Graphics
 
 		public void DrawLine(float3 start, float3 end, float width, Color startColor, Color endColor)
 		{
-			var delta = (end - start) / (end - start).XY.Length;
+			var diff = end - start;
+			var delta = diff / diff.XY.Length;
 			var corner = width / 2 * new float3(-delta.Y, delta.X, delta.Z);
 
 			startColor = Util.PremultiplyAlpha(startColor);
@@ -57,7 +58,8 @@ namespace OpenRA.Graphics
 
 		public void DrawLine(float3 start, float3 end, float width, Color color)
 		{
-			var delta = (end - start) / (end - start).XY.Length;
+			var diff = end - start;
+			var delta = diff / diff.XY.Length;
 			var corner = width / 2 * new float2(-delta.Y, delta.X);
 
 			color = Util.PremultiplyAlpha(color);

--- a/OpenRA.Game/Graphics/RgbaColorRenderer.cs
+++ b/OpenRA.Game/Graphics/RgbaColorRenderer.cs
@@ -46,13 +46,14 @@ namespace OpenRA.Graphics
 			var eb = endColor.B / 255.0f;
 			var ea = endColor.A / 255.0f;
 
-			vertices[0] = new Vertex(start - corner + Offset, sr, sg, sb, sa, 0, 0);
+			var vs = new Vertex(start - corner + Offset, sr, sg, sb, sa, 0, 0);
+			vertices[0] = vs;
 			vertices[1] = new Vertex(start + corner + Offset, sr, sg, sb, sa, 0, 0);
-			vertices[2] = new Vertex(end + corner + Offset, er, eg, eb, ea, 0, 0);
-			vertices[3] = new Vertex(end + corner + Offset, er, eg, eb, ea, 0, 0);
+			var ve = new Vertex(end + corner + Offset, er, eg, eb, ea, 0, 0);
+			vertices[2] = ve;
+			vertices[3] = ve;
 			vertices[4] = new Vertex(end - corner + Offset, er, eg, eb, ea, 0, 0);
-			vertices[5] = new Vertex(start - corner + Offset, sr, sg, sb, sa, 0, 0);
-
+			vertices[5] = vs;
 			parent.DrawRGBAVertices(vertices);
 		}
 
@@ -68,12 +69,14 @@ namespace OpenRA.Graphics
 			var b = color.B / 255.0f;
 			var a = color.A / 255.0f;
 
-			vertices[0] = new Vertex(start - corner + Offset, r, g, b, a, 0, 0);
+			var vs = new Vertex(start - corner + Offset, r, g, b, a, 0, 0);
+			vertices[0] = vs;
 			vertices[1] = new Vertex(start + corner + Offset, r, g, b, a, 0, 0);
-			vertices[2] = new Vertex(end + corner + Offset, r, g, b, a, 0, 0);
-			vertices[3] = new Vertex(end + corner + Offset, r, g, b, a, 0, 0);
+			var ve = new Vertex(end + corner + Offset, r, g, b, a, 0, 0);
+			vertices[2] = ve;
+			vertices[3] = ve;
 			vertices[4] = new Vertex(end - corner + Offset, r, g, b, a, 0, 0);
-			vertices[5] = new Vertex(start - corner + Offset, r, g, b, a, 0, 0);
+			vertices[5] = vs;
 			parent.DrawRGBAVertices(vertices);
 		}
 

--- a/OpenRA.Mods.Common/Graphics/ContrailRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/ContrailRenderable.cs
@@ -75,7 +75,10 @@ namespace OpenRA.Mods.Common.Graphics
 				var nextColor = Exts.ColorLerp(i * 1f / (length - 4), color, Color.Transparent);
 
 				if (!world.FogObscures(curPos) && !world.FogObscures(nextPos))
-					wcr.DrawLine(wr.Screen3DPosition(curPos), wr.Screen3DPosition(nextPos), screenWidth, curColor, nextColor);
+					if (curColor != nextColor)
+						wcr.DrawLine(wr.Screen3DPosition(curPos), wr.Screen3DPosition(nextPos), screenWidth, curColor, nextColor);
+					else
+						wcr.DrawLine(wr.Screen3DPosition(curPos), wr.Screen3DPosition(nextPos), screenWidth, curColor);
 
 				curPos = nextPos;
 				curColor = nextColor;


### PR DESCRIPTION
DrawLine, performance improvement.


DrawLine shows up in profiling report.

ContrailRenderable calls DrawLine with same start and end color often.

Question: should 'width / 2' use integer division or could it be 2.0f?