### PR TITLE
Fix savegames not saving sync packets correctly

### DIFF
--- a/OpenRA.Game/Network/GameSave.cs
+++ b/OpenRA.Game/Network/GameSave.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Network
 
 				LastOrdersFrame = rs.ReadInt32();
 				LastSyncFrame = rs.ReadInt32();
-				lastSyncPacket = rs.ReadBytes(5);
+				lastSyncPacket = rs.ReadBytes(Order.SyncHashOrderLength);
 
 				var globalSettings = MiniYaml.FromString(rs.ReadString(Encoding.UTF8, Connection.MaxOrderLength));
 				GlobalSettings = Session.Global.Deserialize(globalSettings[0].Value);
@@ -282,7 +282,7 @@ namespace OpenRA.Network
 			file.Write(BitConverter.GetBytes(MetadataMarker), 0, 4);
 			file.Write(BitConverter.GetBytes(LastOrdersFrame), 0, 4);
 			file.Write(BitConverter.GetBytes(LastSyncFrame), 0, 4);
-			file.Write(lastSyncPacket, 0, 5);
+			file.Write(lastSyncPacket, 0, Order.SyncHashOrderLength);
 
 			var globalSettingsNodes = new List<MiniYamlNode>() { GlobalSettings.Serialize() };
 			file.WriteString(Encoding.UTF8, globalSettingsNodes.WriteToString());

--- a/OpenRA.Game/Network/GameSave.cs
+++ b/OpenRA.Game/Network/GameSave.cs
@@ -188,8 +188,14 @@ namespace OpenRA.Network
 		public void DispatchOrders(Connection conn, int frame, byte[] data)
 		{
 			// Sync packet - we only care about the last value
-			if (data.Length == Order.SyncHashOrderLength && data[0] == (byte)OrderType.SyncHash && frame > LastSyncFrame)
+			if (data.Length > 0 && data[0] == (byte)OrderType.SyncHash && frame > LastSyncFrame)
 			{
+				if (data.Length != Order.SyncHashOrderLength)
+				{
+					Log.Write("debug", "Dropped sync order with length {0}. Expected length {1}.".F(data.Length, Order.SyncHashOrderLength));
+					return;
+				}
+
 				LastSyncFrame = frame;
 				lastSyncPacket = data;
 			}

--- a/OpenRA.Game/Network/GameSave.cs
+++ b/OpenRA.Game/Network/GameSave.cs
@@ -188,7 +188,7 @@ namespace OpenRA.Network
 		public void DispatchOrders(Connection conn, int frame, byte[] data)
 		{
 			// Sync packet - we only care about the last value
-			if (data.Length > 0 && data[0] == (byte)OrderType.SyncHash && frame > LastSyncFrame)
+			if (data.Length == Order.SyncHashOrderLength && data[0] == (byte)OrderType.SyncHash && frame > LastSyncFrame)
 			{
 				LastSyncFrame = frame;
 				lastSyncPacket = data;

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -49,6 +49,9 @@ namespace OpenRA
 
 	public sealed class Order
 	{
+		// Length of orders with type OrderType.SyncHash
+		public const int SyncHashOrderLength = 13;
+
 		public readonly string OrderString;
 		public readonly Actor Subject;
 		public readonly bool Queued;

--- a/OpenRA.Game/Network/OrderIO.cs
+++ b/OpenRA.Game/Network/OrderIO.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Network
 
 		public static byte[] SerializeSync(int sync, ulong defeatState)
 		{
-			var ms = new MemoryStream(1 + 4 + 8);
+			var ms = new MemoryStream(Order.SyncHashOrderLength);
 			using (var writer = new BinaryWriter(ms))
 			{
 				writer.Write((byte)OrderType.SyncHash);

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -47,10 +47,10 @@ namespace OpenRA.Network
 		internal int GameSaveLastFrame = -1;
 		internal int GameSaveLastSyncFrame = -1;
 
-		List<Order> localOrders = new List<Order>();
-		List<Order> localImmediateOrders = new List<Order>();
+		readonly List<Order> localOrders = new List<Order>();
+		readonly List<Order> localImmediateOrders = new List<Order>();
 
-		List<ChatLine> chatCache = new List<ChatLine>();
+		readonly List<ChatLine> chatCache = new List<ChatLine>();
 
 		public readonly ReadOnlyList<ChatLine> ChatCache;
 

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Network
 					var frame = BitConverter.ToInt32(packet, 0);
 					if (packet.Length == 5 && packet[4] == (byte)OrderType.Disconnect)
 						frameData.ClientQuit(clientId, frame);
-					else if (packet.Length == 4 + 1 + 4 + 8 && packet[4] == (byte)OrderType.SyncHash)
+					else if (packet.Length == 4 + Order.SyncHashOrderLength && packet[4] == (byte)OrderType.SyncHash)
 						CheckSync(packet);
 					else if (frame == 0)
 						immediatePackets.Add((clientId, packet));

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -123,8 +123,16 @@ namespace OpenRA.Network
 					var frame = BitConverter.ToInt32(packet, 0);
 					if (packet.Length == 5 && packet[4] == (byte)OrderType.Disconnect)
 						frameData.ClientQuit(clientId, frame);
-					else if (packet.Length == 4 + Order.SyncHashOrderLength && packet[4] == (byte)OrderType.SyncHash)
+					else if (packet.Length > 4 && packet[4] == (byte)OrderType.SyncHash)
+					{
+						if (packet.Length != 4 + Order.SyncHashOrderLength)
+						{
+							Log.Write("debug", "Dropped sync order with length {0}. Expected length {1}.".F(packet.Length, 4 + Order.SyncHashOrderLength));
+							return;
+						}
+
 						CheckSync(packet);
+					}
 					else if (frame == 0)
 						immediatePackets.Add((clientId, packet));
 					else

--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Network
 
 					if (packet.Length == 5 && packet[4] == (byte)OrderType.Disconnect)
 						continue; // disconnect
-					else if (packet.Length >= 5 && packet[4] == (byte)OrderType.SyncHash)
+					else if (packet.Length == 4 + Order.SyncHashOrderLength && packet[4] == (byte)OrderType.SyncHash)
 						continue; // sync
 					else if (frame == 0)
 					{

--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -70,10 +70,7 @@ namespace OpenRA.Network
 					if (frame != int.MaxValue && (!lastClientsFrame.ContainsKey(client) || frame > lastClientsFrame[client]))
 						lastClientsFrame[client] = frame;
 
-					if (packet.Length == 5 && packet[4] == (byte)OrderType.Disconnect)
-						continue;
-
-					if (packet.Length == 4 + Order.SyncHashOrderLength && packet[4] == (byte)OrderType.SyncHash)
+					if (packet.Length > 4 && (packet[4] == (byte)OrderType.Disconnect || packet[4] == (byte)OrderType.SyncHash))
 						continue;
 
 					if (frame == 0)

--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -55,28 +55,28 @@ namespace OpenRA.Network
 			using (var rs = File.OpenRead(replayFilename))
 			{
 				var packets = new List<(int ClientId, byte[] Packet)>();
-
 				var chunk = new Chunk();
-
 				while (rs.Position < rs.Length)
 				{
 					var client = rs.ReadInt32();
 					if (client == ReplayMetadata.MetaStartMarker)
 						break;
+
 					var packetLen = rs.ReadInt32();
 					var packet = rs.ReadBytes(packetLen);
 					var frame = BitConverter.ToInt32(packet, 0);
 					packets.Add((client, packet));
 
-					if (frame != int.MaxValue &&
-						(!lastClientsFrame.ContainsKey(client) || frame > lastClientsFrame[client]))
+					if (frame != int.MaxValue && (!lastClientsFrame.ContainsKey(client) || frame > lastClientsFrame[client]))
 						lastClientsFrame[client] = frame;
 
 					if (packet.Length == 5 && packet[4] == (byte)OrderType.Disconnect)
-						continue; // disconnect
-					else if (packet.Length == 4 + Order.SyncHashOrderLength && packet[4] == (byte)OrderType.SyncHash)
-						continue; // sync
-					else if (frame == 0)
+						continue;
+
+					if (packet.Length == 4 + Order.SyncHashOrderLength && packet[4] == (byte)OrderType.SyncHash)
+						continue;
+
+					if (frame == 0)
 					{
 						// Parse replay metadata from orders stream
 						var orders = packet.ToOrderList(null);

--- a/OpenRA.Game/Network/ReplayRecorder.cs
+++ b/OpenRA.Game/Network/ReplayRecorder.cs
@@ -26,9 +26,7 @@ namespace OpenRA.Network
 
 		static bool IsGameStart(byte[] data)
 		{
-			if (data.Length == 5 && data[4] == (byte)OrderType.Disconnect)
-				return false;
-			if (data.Length == 4 + Order.SyncHashOrderLength && data[4] == (byte)OrderType.SyncHash)
+			if (data.Length > 4 && (data[4] == (byte)OrderType.Disconnect || data[4] == (byte)OrderType.SyncHash))
 				return false;
 
 			var frame = BitConverter.ToInt32(data, 0);

--- a/OpenRA.Game/Network/ReplayRecorder.cs
+++ b/OpenRA.Game/Network/ReplayRecorder.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Network
 		{
 			if (data.Length == 5 && data[4] == (byte)OrderType.Disconnect)
 				return false;
-			if (data.Length >= 5 && data[4] == (byte)OrderType.SyncHash)
+			if (data.Length == 4 + Order.SyncHashOrderLength && data[4] == (byte)OrderType.SyncHash)
 				return false;
 
 			var frame = BitConverter.ToInt32(data, 0);

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -784,7 +784,7 @@ namespace OpenRA.Server
 			{
 				recorder.ReceiveFrame(from, frame, data);
 
-				if (data.Length == 1 + 4 + 8 && data[0] == (byte)OrderType.SyncHash)
+				if (data.Length == Order.SyncHashOrderLength && data[0] == (byte)OrderType.SyncHash)
 					HandleSyncOrder(frame, data);
 			}
 		}

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -784,8 +784,13 @@ namespace OpenRA.Server
 			{
 				recorder.ReceiveFrame(from, frame, data);
 
-				if (data.Length == Order.SyncHashOrderLength && data[0] == (byte)OrderType.SyncHash)
-					HandleSyncOrder(frame, data);
+				if (data.Length > 0 && data[0] == (byte)OrderType.SyncHash)
+				{
+					if (data.Length == Order.SyncHashOrderLength)
+						HandleSyncOrder(frame, data);
+					else
+						Log.Write("server", "Dropped sync order with length {0} from client {1}. Expected length {2}.".F(data.Length, from, Order.SyncHashOrderLength));
+				}
 			}
 		}
 


### PR DESCRIPTION
Regression from #17578 which changed the size of sync packets from 5 to 13. I fixed that (hopefully once for all) by extracting a constant and using that everywhere. I also changed sync order with mismatching length to be dropped right away, since explicitly checking for size and continuing on mismatch causes crashes later on: Testcase is creating a new savegame and then loading it on bleed. A savegame created after #17578 will basically be corrupted and cannot be loaded even with this PR.