### PR TITLE
Fix WithRangeCircle when Visibility is set to Always

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithRangeCircle(init.Self, this); }
 	}
 
-	class WithRangeCircle : ConditionalTrait<WithRangeCircleInfo>, IRenderAnnotationsWhenSelected, IRenderAboveShroud
+	class WithRangeCircle : ConditionalTrait<WithRangeCircleInfo>, IRenderAnnotationsWhenSelected, IRenderAnnotations
 	{
 		readonly Actor self;
 
@@ -102,11 +102,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		bool IRenderAnnotationsWhenSelected.SpatiallyPartitionable { get { return false; } }
 
-		IEnumerable<IRenderable> IRenderAboveShroud.RenderAboveShroud(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAnnotations.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			return RenderRangeCircle(self, wr, RangeCircleVisibility.Always);
 		}
 
-		bool IRenderAboveShroud.SpatiallyPartitionable { get { return false; } }
+		bool IRenderAnnotations.SpatiallyPartitionable { get { return false; } }
 	}
 }


### PR DESCRIPTION
If you use the WithRangeCircle trait and set Visibility to Always (so that the circle appears whether the actor is selected or not) currently the circle is weirdly positioned and moves around and changes shape when you zoom in/out.

This fix makes it so it will appear as expected.

![withrangecircle-fix](https://user-images.githubusercontent.com/41052878/95771408-e758ca80-0cb2-11eb-8c91-deaa07cf3d00.jpg)


