### PR TITLE
Add DamageTypes to Demolition

### DIFF
--- a/OpenRA.Mods.Common/Activities/Demolish.cs
+++ b/OpenRA.Mods.Common/Activities/Demolish.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly int flashes;
 		readonly int flashesDelay;
 		readonly int flashInterval;
+		readonly BitSet<DamageType> damageTypes;
 		readonly INotifyDemolition[] notifiers;
 		readonly EnterBehaviour enterBehaviour;
 
@@ -30,7 +31,7 @@ namespace OpenRA.Mods.Common.Activities
 		IDemolishable[] enterDemolishables;
 
 		public Demolish(Actor self, Target target, EnterBehaviour enterBehaviour, int delay,
-			int flashes, int flashesDelay, int flashInterval)
+			int flashes, int flashesDelay, int flashInterval, BitSet<DamageType> damageTypes)
 			: base(self, target, Color.Crimson)
 		{
 			notifiers = self.TraitsImplementing<INotifyDemolition>().ToArray();
@@ -38,6 +39,7 @@ namespace OpenRA.Mods.Common.Activities
 			this.flashes = flashes;
 			this.flashesDelay = flashesDelay;
 			this.flashInterval = flashInterval;
+			this.damageTypes = damageTypes;
 			this.enterBehaviour = enterBehaviour;
 		}
 
@@ -75,7 +77,7 @@ namespace OpenRA.Mods.Common.Activities
 					ind.Demolishing(self);
 
 				foreach (var d in enterDemolishables)
-					d.Demolish(enterActor, self, delay);
+					d.Demolish(enterActor, self, delay, damageTypes);
 
 				if (enterBehaviour == EnterBehaviour.Dispose)
 					self.Dispose();

--- a/OpenRA.Mods.Common/Scripting/Properties/DemolitionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/DemolitionProperties.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Scripting
 		public void Demolish(Actor target)
 		{
 			Self.QueueActivity(new Demolish(Self, Target.FromActor(target), info.EnterBehaviour, info.DetonationDelay,
-				info.Flashes, info.FlashesDelay, info.FlashInterval));
+				info.Flashes, info.FlashesDelay, info.FlashInterval, info.DamageTypes));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -368,7 +368,7 @@ namespace OpenRA.Mods.Common.Traits
 			return damage;
 		}
 
-		public void Demolish(Actor saboteur, int direction)
+		public void Demolish(Actor saboteur, int direction, BitSet<DamageType> damageTypes)
 		{
 			var initialDamage = health.DamageState;
 			self.World.AddFrameEndTask(w =>
@@ -376,7 +376,7 @@ namespace OpenRA.Mods.Common.Traits
 				// Use .FromPos since this actor is killed. Cannot use Target.FromActor
 				info.DemolishWeaponInfo.Impact(Target.FromPos(self.CenterPosition), saboteur);
 
-				self.Kill(saboteur);
+				self.Kill(saboteur, damageTypes);
 			});
 
 			// Destroy adjacent spans between (including) huts
@@ -386,7 +386,7 @@ namespace OpenRA.Mods.Common.Traits
 					0 : info.RepairPropagationDelay;
 
 				self.World.AddFrameEndTask(w => w.Add(new DelayedAction(delay, () =>
-					neighbours[direction].Demolish(saboteur, direction))));
+					neighbours[direction].Demolish(saboteur, direction, damageTypes))));
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Buildings/BridgeHut.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BridgeHut.cs
@@ -12,6 +12,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Effects;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -60,6 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 		int demolishStep;
 		int demolishDelay;
 		Actor demolishSaboteur;
+		BitSet<DamageType> demolishDamageTypes;
 
 		public BridgeHut(World world, BridgeHutInfo info)
 		{
@@ -170,7 +172,7 @@ namespace OpenRA.Mods.Common.Traits
 			return true;
 		}
 
-		void IDemolishable.Demolish(Actor self, Actor saboteur, int delay)
+		void IDemolishable.Demolish(Actor self, Actor saboteur, int delay, BitSet<DamageType> damageTypes)
 		{
 			// TODO: Handle using ITick
 			self.World.Add(new DelayedAction(delay, () =>
@@ -188,11 +190,12 @@ namespace OpenRA.Mods.Common.Traits
 					{
 						demolishStep = 0;
 						demolishSaboteur = saboteur;
+						demolishDamageTypes = damageTypes;
 						DemolishStep();
 					}
 					else
 						foreach (var s in segments.Values)
-							s.Demolish(saboteur);
+							s.Demolish(saboteur, damageTypes);
 				}
 			}));
 		}
@@ -214,7 +217,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (demolishStep < segmentLocations.Count)
 				foreach (var c in segmentLocations[demolishStep])
-					segments[c].Demolish(demolishSaboteur);
+					segments[c].Demolish(demolishSaboteur, demolishDamageTypes);
 
 			demolishDelay = Info.DemolishPropagationDelay;
 

--- a/OpenRA.Mods.Common/Traits/Buildings/BridgePlaceholder.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BridgePlaceholder.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 			});
 		}
 
-		void IBridgeSegment.Demolish(Actor saboteur)
+		void IBridgeSegment.Demolish(Actor saboteur, BitSet<DamageType> damageTypes)
 		{
 			// Do nothing
 		}

--- a/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
@@ -104,7 +104,7 @@ namespace OpenRA.Mods.Common.Traits
 			health.InflictDamage(self, repairer, new Damage(-health.MaxHP), true);
 		}
 
-		void IBridgeSegment.Demolish(Actor saboteur)
+		void IBridgeSegment.Demolish(Actor saboteur, BitSet<DamageType> damageTypes)
 		{
 			self.World.AddFrameEndTask(w =>
 			{
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.Traits
 				// Use .FromPos since this actor is dead. Cannot use Target.FromActor
 				Info.DemolishWeaponInfo.Impact(Target.FromPos(self.CenterPosition), saboteur);
 
-				self.Kill(saboteur);
+				self.Kill(saboteur, damageTypes);
 			});
 		}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/LegacyBridgeHut.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/LegacyBridgeHut.cs
@@ -11,6 +11,7 @@
 
 using System.Linq;
 using OpenRA.Effects;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -53,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 			return BridgeDamageState != DamageState.Dead;
 		}
 
-		void IDemolishable.Demolish(Actor self, Actor saboteur, int delay)
+		void IDemolishable.Demolish(Actor self, Actor saboteur, int delay, BitSet<DamageType> damageTypes)
 		{
 			// TODO: Handle using ITick
 			self.World.Add(new DelayedAction(delay, () =>
@@ -66,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 					.Select(t => t.GetDamageModifier(self, null));
 
 				if (Util.ApplyPercentageModifiers(100, modifiers) > 0)
-					Bridge.Do((b, d) => b.Demolish(saboteur, d));
+					Bridge.Do((b, d) => b.Demolish(saboteur, d, damageTypes));
 			}));
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Demolishable.cs
+++ b/OpenRA.Mods.Common/Traits/Demolishable.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -34,12 +35,14 @@ namespace OpenRA.Mods.Common.Traits
 			public readonly Actor Saboteur;
 			public readonly int Token;
 			public int Delay;
+			public readonly BitSet<DamageType> DamageTypes;
 
-			public DemolishAction(Actor saboteur, int delay, int token)
+			public DemolishAction(Actor saboteur, int delay, int token, BitSet<DamageType> damageTypes)
 			{
 				Saboteur = saboteur;
 				Delay = delay;
 				Token = token;
+				DamageTypes = damageTypes;
 			}
 		}
 
@@ -54,13 +57,13 @@ namespace OpenRA.Mods.Common.Traits
 			return !IsTraitDisabled;
 		}
 
-		void IDemolishable.Demolish(Actor self, Actor saboteur, int delay)
+		void IDemolishable.Demolish(Actor self, Actor saboteur, int delay, BitSet<DamageType> damageTypes)
 		{
 			if (IsTraitDisabled)
 				return;
 
 			var token = self.GrantCondition(Info.Condition);
-			actions.Add(new DemolishAction(saboteur, delay, token));
+			actions.Add(new DemolishAction(saboteur, delay, token, damageTypes));
 		}
 
 		void ITick.Tick(Actor self)
@@ -77,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 						.Select(t => t.GetDamageModifier(self, null));
 
 					if (Util.ApplyPercentageModifiers(100, modifiers) > 0)
-						self.Kill(a.Saboteur);
+						self.Kill(a.Saboteur, a.DamageTypes);
 					else if (a.Token != Actor.InvalidConditionToken)
 					{
 						self.RevokeCondition(a.Token);

--- a/OpenRA.Mods.Common/Traits/Demolition.cs
+++ b/OpenRA.Mods.Common/Traits/Demolition.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -35,6 +36,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Behaviour when entering the structure.",
 			"Possible values are Exit, Suicide, Dispose.")]
 		public readonly EnterBehaviour EnterBehaviour = EnterBehaviour.Exit;
+
+		[Desc("Types of damage that this trait causes. Leave empty for no damage types.")]
+		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
 
 		[VoiceReference]
 		[Desc("Voice string when planting explosive charges.")]
@@ -84,7 +88,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			self.QueueActivity(order.Queued, new Demolish(self, order.Target, info.EnterBehaviour, info.DetonationDelay,
-				info.Flashes, info.FlashesDelay, info.FlashInterval));
+				info.Flashes, info.FlashesDelay, info.FlashInterval, info.DamageTypes));
 
 			self.ShowTargetLines();
 		}

--- a/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -16,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 	interface IBridgeSegment
 	{
 		void Repair(Actor repairer);
-		void Demolish(Actor saboteur);
+		void Demolish(Actor saboteur, BitSet<DamageType> damageTypes);
 
 		string Type { get; }
 		DamageState DamageState { get; }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 	public interface IDemolishable
 	{
 		bool IsValidTarget(Actor self, Actor saboteur);
-		void Demolish(Actor self, Actor saboteur, int delay);
+		void Demolish(Actor self, Actor saboteur, int delay, BitSet<DamageType> damageTypes);
 	}
 
 	// Type tag for crush class bits


### PR DESCRIPTION
RV has a default damage type that all the normal weapons has due to Chrono Legionnaire having a special one. Demolition was lacking ability to deal DamageTypes so Tanya blowing something up played no explosion anims. This PR adds support for that.