### PR TITLE
Memory Stream Refactor for PNGs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@
 WHITELISTED_OPENRA_ASSEMBLIES = OpenRA.Game.exe OpenRA.Utility.exe OpenRA.Platforms.Default.dll OpenRA.Mods.Common.dll OpenRA.Mods.Cnc.dll OpenRA.Mods.D2k.dll OpenRA.Game.dll
 
 # These are explicitly shipped alongside our core files by the packaging script
-WHITELISTED_THIRDPARTY_ASSEMBLIES = ICSharpCode.SharpZipLib.dll FuzzyLogicLibrary.dll Eluant.dll BeaconLib.dll Open.Nat.dll SDL2-CS.dll OpenAL-CS.Core.dll DiscordRPC.dll Newtonsoft.Json.dll
+WHITELISTED_THIRDPARTY_ASSEMBLIES = ICSharpCode.SharpZipLib.dll FuzzyLogicLibrary.dll Eluant.dll BeaconLib.dll Open.Nat.dll SDL2-CS.dll OpenAL-CS.Core.dll DiscordRPC.dll Newtonsoft.Json.dll Microsoft.IO.RecyclableMemoryStream.dll
 
 # These are shipped in our custom minimal mono runtime and also available in the full system-installed .NET/mono stack
 # This list *must* be kept in sync with the files packaged by the AppImageSupport and OpenRALauncherOSX repositories

--- a/OpenRA.Game/ExternalMods.cs
+++ b/OpenRA.Game/ExternalMods.cs
@@ -101,17 +101,17 @@ namespace OpenRA
 			{
 				var iconNode = yaml.Nodes.FirstOrDefault(n => n.Key == "Icon");
 				if (iconNode != null && !string.IsNullOrEmpty(iconNode.Value.Value))
-					using (var stream = new MemoryStream(Convert.FromBase64String(iconNode.Value.Value)))
+					using (var stream = MemoryStreamManager.GetMemoryStream(Convert.FromBase64String(iconNode.Value.Value)))
 						mod.Icon = sheetBuilder.Add(new Png(stream));
 
 				var icon2xNode = yaml.Nodes.FirstOrDefault(n => n.Key == "Icon2x");
 				if (icon2xNode != null && !string.IsNullOrEmpty(icon2xNode.Value.Value))
-					using (var stream = new MemoryStream(Convert.FromBase64String(icon2xNode.Value.Value)))
+					using (var stream = MemoryStreamManager.GetMemoryStream(Convert.FromBase64String(icon2xNode.Value.Value)))
 						mod.Icon2x = sheetBuilder.Add(new Png(stream), 1f / 2);
 
 				var icon3xNode = yaml.Nodes.FirstOrDefault(n => n.Key == "Icon3x");
 				if (icon3xNode != null && !string.IsNullOrEmpty(icon3xNode.Value.Value))
-					using (var stream = new MemoryStream(Convert.FromBase64String(icon3xNode.Value.Value)))
+					using (var stream = MemoryStreamManager.GetMemoryStream(Convert.FromBase64String(icon3xNode.Value.Value)))
 						mod.Icon3x = sheetBuilder.Add(new Png(stream), 1f / 3);
 			}
 

--- a/OpenRA.Game/FileFormats/Png.cs
+++ b/OpenRA.Game/FileFormats/Png.cs
@@ -44,8 +44,9 @@ namespace OpenRA.FileFormats
 
 			while (true)
 			{
-				var length = IPAddress.NetworkToHostOrder(s.ReadInt32());
-				var type = Encoding.UTF8.GetString(s.ReadBytes(4));
+				var lengthAndTypeBytes = s.ReadBytes(8);
+				var length = IPAddress.NetworkToHostOrder(BitConverter.ToInt32(lengthAndTypeBytes, 0));
+				var type = Encoding.UTF8.GetString(lengthAndTypeBytes, 4, 4);
 				var content = s.ReadBytes(length);
 				/*var crc = */s.ReadInt32();
 

--- a/OpenRA.Game/FileFormats/Png.cs
+++ b/OpenRA.Game/FileFormats/Png.cs
@@ -41,10 +41,11 @@ namespace OpenRA.FileFormats
 			var isPaletted = false;
 			var is24Bit = false;
 			var data = new List<byte>();
+			byte[] lengthAndTypeBytes = new byte[8];
 
 			while (true)
 			{
-				var lengthAndTypeBytes = s.ReadBytes(8);
+				s.Read(lengthAndTypeBytes, 0, 8);
 				var length = IPAddress.NetworkToHostOrder(BitConverter.ToInt32(lengthAndTypeBytes, 0));
 				var type = Encoding.UTF8.GetString(lengthAndTypeBytes, 4, 4);
 

--- a/OpenRA.Game/FileFormats/Png.cs
+++ b/OpenRA.Game/FileFormats/Png.cs
@@ -41,7 +41,7 @@ namespace OpenRA.FileFormats
 			var isPaletted = false;
 			var is24Bit = false;
 			var data = new List<byte>();
-			byte[] lengthAndTypeBytes = new byte[8];
+			var lengthAndTypeBytes = new byte[8];
 
 			while (true)
 			{
@@ -60,13 +60,15 @@ namespace OpenRA.FileFormats
 						case "IHDR":
 						{
 							ms = PrepareMemoryStream(s, length);
+							var width_Height_Depth_Type_Compresseion_SKIP_Interlace = new byte[13];
+							ms.Read(width_Height_Depth_Type_Compresseion_SKIP_Interlace, 0, 13);
 							if (headerParsed)
 								throw new InvalidDataException("Invalid PNG file - duplicate header.");
-							Width = IPAddress.NetworkToHostOrder(ms.ReadInt32());
-							Height = IPAddress.NetworkToHostOrder(ms.ReadInt32());
+							Width = IPAddress.NetworkToHostOrder(BitConverter.ToInt32(width_Height_Depth_Type_Compresseion_SKIP_Interlace, 0));
+							Height = IPAddress.NetworkToHostOrder(BitConverter.ToInt32(width_Height_Depth_Type_Compresseion_SKIP_Interlace, 4));
 
-							var bitDepth = ms.ReadUInt8();
-							var colorType = (PngColorType)ms.ReadByte();
+							var bitDepth = width_Height_Depth_Type_Compresseion_SKIP_Interlace[8];
+							var colorType = (PngColorType)width_Height_Depth_Type_Compresseion_SKIP_Interlace[9];
 							isPaletted = IsPaletted(bitDepth, colorType);
 							is24Bit = colorType == PngColorType.Color;
 
@@ -76,9 +78,9 @@ namespace OpenRA.FileFormats
 
 							Data = new byte[dataLength];
 
-							var compression = ms.ReadByte();
-							/*var filter = */ms.ReadByte();
-							var interlace = ms.ReadByte();
+							var compression = width_Height_Depth_Type_Compresseion_SKIP_Interlace[10];
+							/*var filter = ms.ReadByte();*/
+							var interlace = width_Height_Depth_Type_Compresseion_SKIP_Interlace[12];
 
 							if (compression != 0)
 								throw new InvalidDataException("Compression method not supported");

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -101,15 +101,12 @@ namespace OpenRA
 					IReadOnlyPackage mapPackage = null;
 					try
 					{
-						using (new Support.PerfTimer(map))
-						{
-							mapPackage = kv.Key.OpenPackage(map, modData.ModFiles);
-							if (mapPackage == null)
-								continue;
+						mapPackage = kv.Key.OpenPackage(map, modData.ModFiles);
+						if (mapPackage == null)
+							continue;
 
-							var uid = Map.ComputeUID(mapPackage);
-							previews[uid].UpdateFromMap(mapPackage, kv.Key, kv.Value, modData.Manifest.MapCompatibility, mapGrid.Type);
-						}
+						var uid = Map.ComputeUID(mapPackage);
+						previews[uid].UpdateFromMap(mapPackage, kv.Key, kv.Value, modData.Manifest.MapCompatibility, mapGrid.Type);
 					}
 					catch (Exception e)
 					{

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -321,14 +321,14 @@ namespace OpenRA
 			if (p.Contains("map.png"))
 				using (var dataStream = p.GetStream("map.png"))
 				{
-					var workStream = dataStream;
+					Stream workStream = null;
 					if (dataStream is FileStream)
 					{
 						var buffer = dataStream.ReadAllBytes();
 						workStream = MemoryStreamManager.GetMemoryStream(buffer);
 					}
 
-					newData.Preview = new Png(workStream);
+					newData.Preview = new Png(workStream ?? dataStream);
 				}
 
 			// Assign the new data atomically

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -372,7 +372,7 @@ namespace OpenRA
 					newData.GridType = r.map_grid_type;
 					try
 					{
-						newData.Preview = new Png(new MemoryStream(Convert.FromBase64String(r.minimap)));
+						newData.Preview = new Png(MemoryStreamManager.GetMemoryStream(Convert.FromBase64String(r.minimap)));
 					}
 					catch (Exception e)
 					{

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -320,7 +320,16 @@ namespace OpenRA
 
 			if (p.Contains("map.png"))
 				using (var dataStream = p.GetStream("map.png"))
-					newData.Preview = new Png(dataStream);
+				{
+					var workStream = dataStream;
+					if (dataStream is FileStream)
+					{
+						var buffer = dataStream.ReadAllBytes();
+						workStream = MemoryStreamManager.GetMemoryStream(buffer);
+					}
+
+					newData.Preview = new Png(workStream);
+				}
 
 			// Assign the new data atomically
 			innerData = newData;

--- a/OpenRA.Game/MemoryStreamManager.cs
+++ b/OpenRA.Game/MemoryStreamManager.cs
@@ -1,5 +1,14 @@
-﻿using System;
-using System.Diagnostics;
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
 using System.IO;
 using Microsoft.IO;
 

--- a/OpenRA.Game/MemoryStreamManager.cs
+++ b/OpenRA.Game/MemoryStreamManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using Microsoft.IO;
 
@@ -15,7 +16,7 @@ namespace OpenRA
 		{
 			if (singletonManager == null)
 			{
-				singletonManager = new RecyclableMemoryStreamManager();
+				Initialize();
 			}
 
 			return singletonManager.GetStream();
@@ -25,10 +26,19 @@ namespace OpenRA
 		{
 			if (singletonManager == null)
 			{
-				singletonManager = new RecyclableMemoryStreamManager();
+				Initialize();
 			}
 
 			return singletonManager.GetStream(buffer);
+		}
+
+		static void Initialize()
+		{
+			var blockSize = 4096;
+			var maxBufferSize = blockSize * 1024 * 5;
+			singletonManager = new RecyclableMemoryStreamManager(blockSize, blockSize * 512, maxBufferSize);
+			singletonManager.AggressiveBufferReturn = true;
+			singletonManager.MaximumFreeSmallPoolBytes = blockSize * 1024;
 		}
 	}
 }

--- a/OpenRA.Game/MemoryStreamManager.cs
+++ b/OpenRA.Game/MemoryStreamManager.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.IO;
+using Microsoft.IO;
+
+namespace OpenRA
+{
+	public class MemoryStreamManager
+	{
+		static RecyclableMemoryStreamManager singletonManager;
+		MemoryStreamManager()
+		{
+		}
+
+		public static MemoryStream GetMemoryStream()
+		{
+			if (singletonManager == null)
+			{
+				singletonManager = new RecyclableMemoryStreamManager();
+			}
+
+			return singletonManager.GetStream();
+		}
+
+		public static MemoryStream GetMemoryStream(byte[] buffer)
+		{
+			if (singletonManager == null)
+			{
+				singletonManager = new RecyclableMemoryStreamManager();
+			}
+
+			return singletonManager.GetStream(buffer);
+		}
+	}
+}

--- a/OpenRA.Game/MemoryStreamManager.cs
+++ b/OpenRA.Game/MemoryStreamManager.cs
@@ -41,6 +41,16 @@ namespace OpenRA
 			return singletonManager.GetStream(buffer);
 		}
 
+		public static MemoryStream GetMemoryStream(int minSizeRequired, bool tryContiguosBuffer, string tag = null)
+		{
+			if (singletonManager == null)
+			{
+				Initialize();
+			}
+
+			return singletonManager.GetStream(tag, minSizeRequired, tryContiguosBuffer);
+		}
+
 		static void Initialize()
 		{
 			var blockSize = 4096;

--- a/OpenRA.Game/MemoryStreamManager.cs
+++ b/OpenRA.Game/MemoryStreamManager.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Diagnostics;
 using System.IO;
 using Microsoft.IO;
 
@@ -53,11 +54,24 @@ namespace OpenRA
 
 		static void Initialize()
 		{
-			var blockSize = 4096;
-			var maxBufferSize = blockSize * 1024 * 5;
-			singletonManager = new RecyclableMemoryStreamManager(blockSize, blockSize * 512, maxBufferSize);
+			var blockSize = 8192;
+			var maxBufferSize = blockSize * 128;
+			singletonManager = new RecyclableMemoryStreamManager(blockSize, blockSize * 16, maxBufferSize);
 			singletonManager.AggressiveBufferReturn = true;
 			singletonManager.MaximumFreeSmallPoolBytes = blockSize * 1024;
+
+			// singletonManager.BlockCreated += SingletonManager_BlockCreated;
+			// singletonManager.LargeBufferCreated += SingletonManager_LargeBufferCreated;
+		}
+
+		private static void SingletonManager_LargeBufferCreated()
+		{
+			Debug.Print("Large BUFFER");
+		}
+
+		private static void SingletonManager_BlockCreated()
+		{
+			Debug.Print("BUFFER");
 		}
 	}
 }

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -59,6 +59,7 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <AdditionalFiles Include="../stylecop.json" />
     <AdditionalFiles Include="Properties/launchSettings.json" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.5" />
   </ItemGroup>
   <Target Name="DisableAnalyzers" BeforeTargets="CoreCompile" Condition="'$(Configuration)'=='Release'">
     <!-- Disable code style analysis on Release builds to improve compile-time performance -->

--- a/OpenRA.Game/PlayerDatabase.cs
+++ b/OpenRA.Game/PlayerDatabase.cs
@@ -46,7 +46,7 @@ namespace OpenRA
 
 				try
 				{
-					var icon = new Png(new MemoryStream(i.Result));
+					var icon = new Png(MemoryStreamManager.GetMemoryStream(i.Result));
 					if (icon.Width == spriteSize && icon.Height == spriteSize)
 					{
 						Game.RunAfterTick(() =>


### PR DESCRIPTION
Focusing on avoiding allocation of `MemoryStream` adhoc-ally I implemented the Microsoft recommend `RecyclableMemoryStream` which I described on #18721 but only for the PNG class thus far. The results of change alone are promising (GC collection reduction of about 10%) but the refactor I made right after made the memory footprint drop 2-5% and consequentially the GC collection dropped about 15%.

If this is approved I intend on spread the implementation to the whole code.