### PR TITLE
Fix multiple harvester dock sequence bugs

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/VoxelHarvesterDockSequence.cs
+++ b/OpenRA.Mods.Cnc/Activities/VoxelHarvesterDockSequence.cs
@@ -11,6 +11,7 @@
 
 using OpenRA.Mods.Cnc.Traits.Render;
 using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.Cnc.Activities
 {
@@ -29,6 +30,10 @@ namespace OpenRA.Mods.Cnc.Activities
 		public override void OnStateDock(Actor self)
 		{
 			body.Docked = true;
+			foreach (var trait in self.TraitsImplementing<INotifyHarvesterAction>())
+				trait.Docked();
+			foreach (var nd in Refinery.TraitsImplementing<INotifyDocking>())
+				nd.Docked(Refinery, self);
 
 			if (spriteOverlay != null && !spriteOverlay.Visible)
 			{
@@ -57,12 +62,26 @@ namespace OpenRA.Mods.Cnc.Activities
 					dockingState = DockingState.Complete;
 					body.Docked = false;
 					spriteOverlay.Visible = false;
+
+					foreach (var trait in self.TraitsImplementing<INotifyHarvesterAction>())
+						trait.Undocked();
+
+					if (Refinery.IsInWorld && !Refinery.IsDead)
+						foreach (var nd in Refinery.TraitsImplementing<INotifyDocking>())
+							nd.Undocked(Refinery, self);
 				});
 			}
 			else
 			{
 				dockingState = DockingState.Complete;
 				body.Docked = false;
+
+				foreach (var trait in self.TraitsImplementing<INotifyHarvesterAction>())
+					trait.Undocked();
+
+				if (Refinery.IsInWorld && !Refinery.IsDead)
+					foreach (var nd in Refinery.TraitsImplementing<INotifyDocking>())
+						nd.Undocked(Refinery, self);
 			}
 		}
 	}

--- a/OpenRA.Mods.Cnc/Activities/VoxelHarvesterDockSequence.cs
+++ b/OpenRA.Mods.Cnc/Activities/VoxelHarvesterDockSequence.cs
@@ -45,10 +45,12 @@ namespace OpenRA.Mods.Cnc.Activities
 
 		public override void OnStateUndock(Actor self)
 		{
-			dockingState = DockingState.Wait;
-
-			if (spriteOverlay != null && !spriteOverlay.Visible)
+			// If body.Docked wasn't set, we didn't actually dock and have to skip the undock overlay
+			if (!body.Docked)
+				dockingState = DockingState.Complete;
+			else if (spriteOverlay != null && !spriteOverlay.Visible)
 			{
+				dockingState = DockingState.Wait;
 				spriteOverlay.Visible = true;
 				spriteOverlay.WithOffset.Animation.PlayBackwardsThen(spriteOverlay.Info.Sequence, () =>
 				{

--- a/OpenRA.Mods.Cnc/Activities/VoxelHarvesterDockSequence.cs
+++ b/OpenRA.Mods.Cnc/Activities/VoxelHarvesterDockSequence.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Cnc.Activities
 			// If body.Docked wasn't set, we didn't actually dock and have to skip the undock overlay
 			if (!body.Docked)
 				dockingState = DockingState.Complete;
-			else if (spriteOverlay != null && !spriteOverlay.Visible)
+			else if (Refinery.IsInWorld && !Refinery.IsDead && spriteOverlay != null && !spriteOverlay.Visible)
 			{
 				dockingState = DockingState.Wait;
 				spriteOverlay.Visible = true;

--- a/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
@@ -62,10 +62,15 @@ namespace OpenRA.Mods.Common.Activities
 
 				case DockingState.Dock:
 					if (Refinery.IsInWorld && !Refinery.IsDead)
+					{
 						foreach (var nd in Refinery.TraitsImplementing<INotifyDocking>())
 							nd.Docked(Refinery, self);
 
-					OnStateDock(self);
+						OnStateDock(self);
+					}
+					else
+						dockingState = DockingState.Undock;
+
 					return false;
 
 				case DockingState.Loop:

--- a/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
@@ -70,12 +70,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				case DockingState.Dock:
 					if (!IsCanceling && Refinery.IsInWorld && !Refinery.IsDead)
-					{
-						foreach (var nd in Refinery.TraitsImplementing<INotifyDocking>())
-							nd.Docked(Refinery, self);
-
 						OnStateDock(self);
-					}
 					else
 						dockingState = DockingState.Undock;
 
@@ -92,10 +87,6 @@ namespace OpenRA.Mods.Common.Activities
 					return false;
 
 				case DockingState.Complete:
-					if (Refinery.IsInWorld && !Refinery.IsDead)
-						foreach (var nd in Refinery.TraitsImplementing<INotifyDocking>())
-							nd.Undocked(Refinery, self);
-
 					Harv.LastLinkedProc = Harv.LinkedProc;
 					Harv.LinkProc(self, null);
 					if (IsDragRequired)

--- a/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Activities
 					return false;
 
 				case DockingState.Drag:
-					if (!Refinery.IsInWorld || Refinery.IsDead)
+					if (IsCanceling || !Refinery.IsInWorld || Refinery.IsDead)
 						return true;
 
 					dockingState = DockingState.Dock;
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Activities
 					return false;
 
 				case DockingState.Dock:
-					if (Refinery.IsInWorld && !Refinery.IsDead)
+					if (!IsCanceling && Refinery.IsInWorld && !Refinery.IsDead)
 					{
 						foreach (var nd in Refinery.TraitsImplementing<INotifyDocking>())
 							nd.Docked(Refinery, self);
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Activities
 					return false;
 
 				case DockingState.Loop:
-					if (!Refinery.IsInWorld || Refinery.IsDead || Harv.TickUnload(self, Refinery))
+					if (IsCanceling || !Refinery.IsInWorld || Refinery.IsDead || Harv.TickUnload(self, Refinery))
 						dockingState = DockingState.Undock;
 
 					return false;
@@ -105,12 +105,6 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			throw new InvalidOperationException("Invalid harvester dock state");
-		}
-
-		public override void Cancel(Actor self, bool keepQueue = false)
-		{
-			dockingState = DockingState.Undock;
-			base.Cancel(self);
 		}
 
 		public override IEnumerable<Target> GetTargets(Actor self)

--- a/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public abstract class HarvesterDockSequence : Activity
 	{
-		protected enum DockingState { Wait, Turn, Dock, Loop, Undock, Complete }
+		protected enum DockingState { Wait, Turn, Drag, Dock, Loop, Undock, Complete }
 
 		protected readonly Actor Refinery;
 		protected readonly Harvester Harv;
@@ -54,10 +54,18 @@ namespace OpenRA.Mods.Common.Activities
 					return false;
 
 				case DockingState.Turn:
-					dockingState = DockingState.Dock;
+					dockingState = DockingState.Drag;
 					QueueChild(new Turn(self, DockAngle));
+					return false;
+
+				case DockingState.Drag:
+					if (!Refinery.IsInWorld || Refinery.IsDead)
+						return true;
+
+					dockingState = DockingState.Dock;
 					if (IsDragRequired)
 						QueueChild(new Drag(self, StartDrag, EndDrag, DragLength));
+
 					return false;
 
 				case DockingState.Dock:

--- a/OpenRA.Mods.Common/Activities/SpriteHarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/SpriteHarvesterDockSequence.cs
@@ -31,6 +31,8 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			foreach (var trait in self.TraitsImplementing<INotifyHarvesterAction>())
 				trait.Docked();
+			foreach (var nd in Refinery.TraitsImplementing<INotifyDocking>())
+				nd.Docked(Refinery, self);
 
 			wsb.PlayCustomAnimation(self, wda.DockSequence, () => wsb.PlayCustomAnimationRepeating(self, wda.DockLoopSequence));
 			dockAnimPlayed = true;
@@ -53,6 +55,10 @@ namespace OpenRA.Mods.Common.Activities
 					dockingState = DockingState.Complete;
 					foreach (var trait in self.TraitsImplementing<INotifyHarvesterAction>())
 						trait.Undocked();
+
+					if (Refinery.IsInWorld && !Refinery.IsDead)
+						foreach (var nd in Refinery.TraitsImplementing<INotifyDocking>())
+							nd.Undocked(Refinery, self);
 				});
 		}
 	}


### PR DESCRIPTION
Fixes
- drag activity running even if refinery died while turning to dock angle
- dock anim running even if refinery died while dragging towards it
- undock anim playing even if dock anim didn't run for the above or some other reason
- and some more (see commit messages)

Fixes #18422.
Fixes #18733.