### PR TITLE
Fix RA/TD turret facings sometimes breaking during make anim

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -857,6 +857,8 @@ GUN:
 	WithSpriteTurret:
 		RequiresCondition: !build-incomplete
 		Recoils: false
+	WithTurretAttackAnimation:
+		Sequence: recoil
 	Armament:
 		Weapon: TurretGun
 		LocalOffset: 512,0,112

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -853,8 +853,10 @@ GUN:
 		TurnSpeed: 48
 		InitialFacing: 192
 		RealignDelay: -1
-	-WithSpriteBody:
-	WithEmbeddedTurretSpriteBody:
+		RequiresCondition: !build-incomplete
+	WithSpriteTurret:
+		RequiresCondition: !build-incomplete
+		Recoils: false
 	Armament:
 		Weapon: TurretGun
 		LocalOffset: 512,0,112

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -851,7 +851,7 @@ GUN:
 		HasMinibib: true
 	Turreted:
 		TurnSpeed: 48
-		InitialFacing: 224
+		InitialFacing: 192
 		RealignDelay: -1
 	-WithSpriteBody:
 	WithEmbeddedTurretSpriteBody:

--- a/mods/cnc/sequences/structures.yaml
+++ b/mods/cnc/sequences/structures.yaml
@@ -435,14 +435,15 @@ wood:
 		Length: 16
 
 gun:
-	idle:
+	idle: gunmake # Empty first frame. We need WithSpriteBody for the make anim, and WSB needs at least a placeholder default sequence to work
+	turret:
 		Facings: 32
 		UseClassicFacings: True
 	recoil:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
-	damaged-idle:
+	damaged-turret:
 		Start: 64
 		Facings: 32
 		UseClassicFacings: True

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -602,7 +602,7 @@ AGUN:
 		HasMinibib: true
 	Turreted:
 		TurnSpeed: 60
-		InitialFacing: 896
+		InitialFacing: 832
 		RealignDelay: -1
 	-WithSpriteBody:
 	WithEmbeddedTurretSpriteBody:
@@ -817,7 +817,7 @@ GUN:
 		HasMinibib: true
 	Turreted:
 		TurnSpeed: 48
-		InitialFacing: 224
+		InitialFacing: 192
 		RealignDelay: -1
 	-WithSpriteBody:
 	WithEmbeddedTurretSpriteBody:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -604,8 +604,10 @@ AGUN:
 		TurnSpeed: 60
 		InitialFacing: 832
 		RealignDelay: -1
-	-WithSpriteBody:
-	WithEmbeddedTurretSpriteBody:
+		RequiresCondition: !build-incomplete
+	WithSpriteTurret:
+		RequiresCondition: !build-incomplete
+		Recoils: false
 	Armament:
 		Weapon: ZSU-23
 		LocalOffset: 520,100,450, 520,-150,450
@@ -819,8 +821,10 @@ GUN:
 		TurnSpeed: 48
 		InitialFacing: 192
 		RealignDelay: -1
-	-WithSpriteBody:
-	WithEmbeddedTurretSpriteBody:
+		RequiresCondition: !build-incomplete
+	WithSpriteTurret:
+		RequiresCondition: !build-incomplete
+		Recoils: false
 	Armament:
 		Weapon: TurretGun
 		LocalOffset: 512,0,112
@@ -919,8 +923,10 @@ SAM:
 		TurnSpeed: 120
 		InitialFacing: 0
 		RealignDelay: -1
-	-WithSpriteBody:
-	WithEmbeddedTurretSpriteBody:
+		RequiresCondition: !build-incomplete
+	WithSpriteTurret:
+		RequiresCondition: !build-incomplete
+		Recoils: false
 	Armament:
 		Weapon: Nike
 		LocalOffset: 0,0,320

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -825,6 +825,8 @@ GUN:
 	WithSpriteTurret:
 		RequiresCondition: !build-incomplete
 		Recoils: false
+	WithTurretAttackAnimation:
+		Sequence: recoil
 	Armament:
 		Weapon: TurretGun
 		LocalOffset: 512,0,112

--- a/mods/ra/sequences/structures.yaml
+++ b/mods/ra/sequences/structures.yaml
@@ -378,16 +378,17 @@ fix:
 	fake-icon: fixficon
 
 gun:
-	idle:
+	idle: gunmake # Empty first frame. We need WithSpriteBody for the make anim, and WSB needs at least a placeholder default sequence to work
+	make: gunmake
+		Length: *
+	turret:
 		Facings: 32
 		UseClassicFacings: True
 	recoil:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
-	make: gunmake
-		Length: *
-	damaged-idle:
+	damaged-turret:
 		Start: 64
 		Facings: 32
 		UseClassicFacings: True
@@ -404,7 +405,11 @@ gun:
 	icon: gunicon
 
 agun:
-	idle:
+	idle: gunmake # Empty first frame (agunmake has no empty frames). We need WithSpriteBody for the make anim, and WSB needs at least a placeholder default sequence to work
+	make: agunmake
+		Length: *
+		Offset: 0,-13
+	turret:
 		Facings: 32
 		UseClassicFacings: True
 		Offset: 0,-13
@@ -413,10 +418,7 @@ agun:
 		Facings: 32
 		UseClassicFacings: True
 		Offset: 0,-13
-	make: agunmake
-		Length: *
-		Offset: 0,-13
-	damaged-idle:
+	damaged-turret:
 		Start: 64
 		Facings: 32
 		UseClassicFacings: True
@@ -435,11 +437,12 @@ agun:
 	icon: agunicon
 
 sam:
-	idle: sam2
+	idle: gunmake # Empty first frame (sammake has no empty frames). We need WithSpriteBody for the make anim, and WSB needs at least a placeholder default sequence to work
+	turret: sam2
 		Facings: 32
 		UseClassicFacings: True
 		Offset: -1,-2
-	damaged-idle: sam2
+	damaged-turret: sam2
 		Start: 34
 		Facings: 32
 		UseClassicFacings: True


### PR DESCRIPTION
Fixes #18618.
Fixes default facing of Gun Turrets (compared to make anim and original, we were 1 sprite facing off).
Fixes default facing of RA Flak cannon (compared to make anim and original, we were 2 sprite facings off).
Enables recoil anim for Gun Turrets (not for AA cannon, since it looks bad with its very high fire rate).