### PR TITLE
Improve startup performance

### DIFF
--- a/OpenRA.Game/Graphics/CursorManager.cs
+++ b/OpenRA.Game/Graphics/CursorManager.cs
@@ -236,15 +236,14 @@ namespace OpenRA.Graphics
 			{
 				for (var i = 0; i < width; i++)
 				{
-					var bytes = BitConverter.GetBytes(palette[frame.Data[j * width + i]]);
-					var c = palette[frame.Data[j * width + i]];
+					var rgba = palette[frame.Data[j * width + i]];
 					var k = 4 * (j * width + i);
 
 					// Convert RGBA to BGRA
-					data[k] = bytes[2];
-					data[k + 1] = bytes[1];
-					data[k + 2] = bytes[0];
-					data[k + 3] = bytes[3];
+					data[k] = (byte)(rgba >> 16);
+					data[k + 1] = (byte)(rgba >> 8);
+					data[k + 2] = (byte)(rgba >> 0);
+					data[k + 3] = (byte)(rgba >> 24);
 				}
 			}
 

--- a/OpenRA.Game/Primitives/MergedStream.cs
+++ b/OpenRA.Game/Primitives/MergedStream.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.IO;
 
 namespace OpenRA.Primitives
@@ -18,7 +19,7 @@ namespace OpenRA.Primitives
 		public Stream Stream1 { get; set; }
 		public Stream Stream2 { get; set; }
 
-		long VirtualLength { get; set; }
+		long VirtualLength { get; }
 		long position;
 
 		public MergedStream(Stream stream1, Stream stream2)
@@ -61,7 +62,21 @@ namespace OpenRA.Primitives
 
 		public override void SetLength(long value)
 		{
-			VirtualLength = value;
+			throw new NotSupportedException();
+		}
+
+		public override int ReadByte()
+		{
+			int value;
+
+			if (position >= Stream1.Length)
+				value = Stream2.ReadByte();
+			else
+				value = Stream1.ReadByte();
+
+			position++;
+
+			return value;
 		}
 
 		public override int Read(byte[] buffer, int offset, int count)
@@ -83,12 +98,14 @@ namespace OpenRA.Primitives
 			return bytesRead;
 		}
 
+		public override void WriteByte(byte value)
+		{
+			throw new NotSupportedException();
+		}
+
 		public override void Write(byte[] buffer, int offset, int count)
 		{
-			if (position >= Stream1.Length)
-				Stream2.Write(buffer, offset - (int)Stream1.Length, count);
-			else
-				Stream1.Write(buffer, offset, count);
+			throw new NotSupportedException();
 		}
 
 		public override bool CanRead
@@ -103,7 +120,7 @@ namespace OpenRA.Primitives
 
 		public override bool CanWrite
 		{
-			get { return Stream1.CanWrite && Stream2.CanWrite; }
+			get { return false; }
 		}
 
 		public override long Length

--- a/OpenRA.Game/Primitives/ReadOnlyAdapterStream.cs
+++ b/OpenRA.Game/Primitives/ReadOnlyAdapterStream.cs
@@ -48,8 +48,24 @@ namespace OpenRA.Primitives
 
 		public sealed override long Seek(long offset, SeekOrigin origin) { throw new NotSupportedException(); }
 		public sealed override void SetLength(long value) { throw new NotSupportedException(); }
+		public sealed override void WriteByte(byte value) { throw new NotSupportedException(); }
 		public sealed override void Write(byte[] buffer, int offset, int count) { throw new NotSupportedException(); }
 		public sealed override void Flush() { throw new NotSupportedException(); }
+
+		public sealed override int ReadByte()
+		{
+			if (data.Count > 0)
+				return data.Dequeue();
+
+			while (!baseStreamEmpty)
+			{
+				baseStreamEmpty = BufferData(baseStream, data);
+				if (data.Count > 0)
+					return data.Dequeue();
+			}
+
+			return -1;
+		}
 
 		public sealed override int Read(byte[] buffer, int offset, int count)
 		{
@@ -66,7 +82,8 @@ namespace OpenRA.Primitives
 		}
 
 		/// <summary>
-		/// Reads data into a buffer, which will be used to satisfy <see cref="Read(byte[], int, int)"/> calls.
+		/// Reads data into a buffer, which will be used to satisfy <see cref="ReadByte()"/> and
+		/// <see cref="Read(byte[], int, int)"/> calls.
 		/// </summary>
 		/// <param name="baseStream">The source stream from which bytes should be read.</param>
 		/// <param name="data">The queue where bytes should be enqueued. Do not dequeue from this buffer.</param>

--- a/OpenRA.Game/Primitives/SegmentStream.cs
+++ b/OpenRA.Game/Primitives/SegmentStream.cs
@@ -59,8 +59,35 @@ namespace OpenRA.Primitives
 			set { BaseStream.Position = BaseOffset + value; }
 		}
 
-		public override int Read(byte[] buffer, int offset, int count) { return BaseStream.Read(buffer, offset, count); }
-		public override void Write(byte[] buffer, int offset, int count) { BaseStream.Write(buffer, offset, count); }
+		public override int ReadByte()
+		{
+			if (Position < Length)
+				return BaseStream.ReadByte();
+			return -1;
+		}
+
+		public override int Read(byte[] buffer, int offset, int count)
+		{
+			var remaining = Length - Position;
+			if (remaining <= 0)
+				return 0;
+			return BaseStream.Read(buffer, offset, (int)Math.Min(remaining, count));
+		}
+
+		public override void WriteByte(byte value)
+		{
+			if (Position < Length)
+				BaseStream.WriteByte(value);
+			throw new IOException("Attempted to write past the end of the stream.");
+		}
+
+		public override void Write(byte[] buffer, int offset, int count)
+		{
+			if (Position + count >= Length)
+				throw new IOException("Attempted to write past the end of the stream.");
+			BaseStream.Write(buffer, offset, count);
+		}
+
 		public override void Flush() { BaseStream.Flush(); }
 		public override long Seek(long offset, SeekOrigin origin)
 		{

--- a/OpenRA.Game/StreamExts.cs
+++ b/OpenRA.Game/StreamExts.cs
@@ -61,22 +61,22 @@ namespace OpenRA
 
 		public static ushort ReadUInt16(this Stream s)
 		{
-			return BitConverter.ToUInt16(s.ReadBytes(2), 0);
+			return (ushort)(s.ReadUInt8() | s.ReadUInt8() << 8);
 		}
 
 		public static short ReadInt16(this Stream s)
 		{
-			return BitConverter.ToInt16(s.ReadBytes(2), 0);
+			return (short)(s.ReadUInt8() | s.ReadUInt8() << 8);
 		}
 
 		public static uint ReadUInt32(this Stream s)
 		{
-			return BitConverter.ToUInt32(s.ReadBytes(4), 0);
+			return (uint)(s.ReadUInt8() | s.ReadUInt8() << 8 | s.ReadUInt8() << 16 | s.ReadUInt8() << 24);
 		}
 
 		public static int ReadInt32(this Stream s)
 		{
-			return BitConverter.ToInt32(s.ReadBytes(4), 0);
+			return s.ReadUInt8() | s.ReadUInt8() << 8 | s.ReadUInt8() << 16 | s.ReadUInt8() << 24;
 		}
 
 		public static void Write(this Stream s, int value)

--- a/OpenRA.Mods.Cnc/FileSystem/PackageEntry.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/PackageEntry.cs
@@ -65,16 +65,16 @@ namespace OpenRA.Mods.Cnc.FileSystem
 						if (name.Length % 4 != 0)
 							name = name.PadRight(name.Length + (4 - name.Length % 4), '\0');
 
-						using (var ms = new MemoryStream(Encoding.ASCII.GetBytes(name)))
+						var result = 0u;
+						var data = Encoding.ASCII.GetBytes(name);
+						var i = 0;
+						while (i < data.Length)
 						{
-							var len = name.Length >> 2;
-							uint result = 0;
-
-							while (len-- != 0)
-								result = ((result << 1) | (result >> 31)) + ms.ReadUInt32();
-
-							return result;
+							var next = (uint)(data[i++] | data[i++] << 8 | data[i++] << 16 | data[i++] << 24);
+							result = ((result << 1) | (result >> 31)) + next;
 						}
+
+						return result;
 					}
 
 				case PackageHashType.CRC32:


### PR DESCRIPTION
Several changes targeted specifically at avoiding allocations during startup. By allocating less we make less work for the GC to clean up after us, which accumulates in saved time during loading from fewer GC collections. See commit messages for motivation for each change.

Startup time improvements for the default mods on my machine:

| Mod | Bleed  | PR |
| - | - | - |
| d2k | 5.22s | 3.77s |
| ts    | 6.50s | 6.11s |
| ra    | 5.79s | 5.56s |
| cnc  | 3.91s | 3.82s |

Each mod run several times until it produced consistent timing results (the first couple of runs tend to be slower until files are in the OS cache) then took the average of 6 runs. Timing given by making the following change in [Game.cs](https://github.com/OpenRA/OpenRA/blob/14fc0254c69ab376dd424ed6efb5f11705b017f2/OpenRA.Game/Game.cs#L268-L275):

```diff
public static RunStatus InitializeAndRun(string[] args)
{
	Initialize(new Arguments(args));
 
	// Proactively collect memory during loading to reduce peak memory.
	GC.Collect();
-	return Run();
+	Console.WriteLine(stopwatch.Elapsed.TotalSeconds.ToString("0.00s"));
+	return RunStatus.Success;
}
```