### PR TITLE
Added observer vision stats

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -341,6 +341,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var armyText = new CachedTransform<int, string>(i => "$" + i);
 			template.Get<LabelWidget>("ARMY_VALUE").GetText = () => armyText.Update(stats.ArmyValue);
 
+			var visionText = new CachedTransform<int, string>(i => Vision(i));
+			template.Get<LabelWidget>("VISION").GetText = () => player.Shroud.Disabled ? "100%" : visionText.Update(player.Shroud.RevealedCells);
+
 			return template;
 		}
 
@@ -567,6 +570,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		string AverageOrdersPerMinute(double orders)
 		{
 			return (world.WorldTick == 0 ? 0 : orders / (world.WorldTick / 1500.0)).ToString("F1");
+		}
+
+		string Vision(int revealedCells)
+		{
+			return Math.Ceiling(revealedCells / (float)world.Map.ProjectedCells.Length * 100).ToString("F0") + "%";
 		}
 
 		static Color GetPowerColor(PowerState state)

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -602,7 +602,7 @@ Container@OBSERVER_WIDGETS:
 						Container@COMBAT_STATS_HEADERS:
 							X: 0
 							Y: 0
-							Width: 730
+							Width: 760
 							Height: PARENT_BOTTOM
 							Children:
 								ColorBlock@HEADER_COLOR:
@@ -648,46 +648,55 @@ Container@OBSERVER_WIDGETS:
 								Label@UNITS_KILLED_HEADER:
 									X: 310
 									Y: 0
-									Width: 90
+									Width: 75
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: Units Killed
+									Text: U. Killed
 									Align: Right
 									Shadow: True
 								Label@UNITS_DEAD_HEADER:
-									X: 400
+									X: 385
 									Y: 0
-									Width: 80
+									Width: 75
 									Height: PARENT_BOTTOM
 									Font: Bold
 									Text: Units Lost
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_KILLED_HEADER:
-									X: 480
-									Y: 0
-									Width: 85
-									Height: PARENT_BOTTOM
-									Font: Bold
-									Text: Bldg Killed
-									Align: Right
-									Shadow: True
-								Label@BUILDINGS_DEAD_HEADER:
-									X: 565
+									X: 460
 									Y: 0
 									Width: 75
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: Bldg Lost
+									Text: B. Killed
+									Align: Right
+									Shadow: True
+								Label@BUILDINGS_DEAD_HEADER:
+									X: 535
+									Y: 0
+									Width: 75
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: B. Lost
 									Align: Right
 									Shadow: True
 								Label@ARMY_VALUE_HEADER:
-									X: 640
+									X: 610
 									Y: 0
-									Width: 85
+									Width: 90
 									Height: PARENT_BOTTOM
 									Font: Bold
 									Text: Army Value
+									Align: Right
+									Shadow: True
+								Label@VISION_HEADER:
+									X: 700
+									Y: 0
+									Width: 60
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Vision
 									Align: Right
 									Shadow: True
 				ScrollPanel@PLAYER_STATS_PANEL:
@@ -1008,7 +1017,7 @@ Container@OBSERVER_WIDGETS:
 						ScrollItem@COMBAT_PLAYER_TEMPLATE:
 							X: 0
 							Y: 0
-							Width: 730
+							Width: 760
 							Height: 24
 							Background: scrollitem-nohover
 							Children:
@@ -1053,35 +1062,42 @@ Container@OBSERVER_WIDGETS:
 								Label@UNITS_KILLED:
 									X: 310
 									Y: 0
-									Width: 90
+									Width: 75
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@UNITS_DEAD:
-									X: 400
+									X: 385
 									Y: 0
-									Width: 80
+									Width: 75
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_KILLED:
-									X: 480
+									X: 460
 									Y: 0
-									Width: 85
+									Width: 75
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_DEAD:
-									X: 565
+									X: 535
 									Y: 0
 									Width: 75
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ARMY_VALUE:
-									X: 640
+									X: 605
 									Y: 0
 									Width: 85
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@VISION:
+									X: 690
+									Y: 0
+									Width: 60
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True

--- a/mods/common/chrome/ingame-observer.yaml
+++ b/mods/common/chrome/ingame-observer.yaml
@@ -475,7 +475,7 @@ Container@OBSERVER_WIDGETS:
 						Container@COMBAT_STATS_HEADERS:
 							X: 0
 							Y: 0
-							Width: 735
+							Width: 760
 							Height: PARENT_BOTTOM
 							Children:
 								ColorBlock@HEADER_COLOR:
@@ -519,48 +519,57 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@UNITS_KILLED_HEADER:
-									X: 305
+									X: 310
 									Y: 0
-									Width: 90
+									Width: 75
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: Units Killed
+									Text: U. Killed
 									Align: Right
 									Shadow: True
 								Label@UNITS_DEAD_HEADER:
-									X: 395
+									X: 385
 									Y: 0
-									Width: 80
+									Width: 75
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: Units Lost
+									Text: U. Lost
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_KILLED_HEADER:
-									X: 475
+									X: 460
 									Y: 0
-									Width: 85
+									Width: 75
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: Bldg Killed
+									Text: B. Killed
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_DEAD_HEADER:
-									X: 560
+									X: 535
 									Y: 0
-									Width: 80
+									Width: 75
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: Bldg Lost
+									Text: B. Lost
 									Align: Right
 									Shadow: True
 								Label@ARMY_VALUE_HEADER:
-									X: 640
+									X: 610
 									Y: 0
 									Width: 90
 									Height: PARENT_BOTTOM
 									Font: Bold
 									Text: Army Value
+									Align: Right
+									Shadow: True
+								Label@VISION_HEADER:
+									X: 700
+									Y: 0
+									Width: 60
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Vision
 									Align: Right
 									Shadow: True
 				ScrollPanel@PLAYER_STATS_PANEL:
@@ -866,7 +875,7 @@ Container@OBSERVER_WIDGETS:
 						ScrollItem@COMBAT_PLAYER_TEMPLATE:
 							X: 0
 							Y: 0
-							Width: 735
+							Width: 760
 							Height: 25
 							Background: scrollitem-nohover
 							Children:
@@ -907,37 +916,44 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@UNITS_KILLED:
-									X: 305
+									X: 310
 									Y: 0
-									Width: 90
+									Width: 75
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@UNITS_DEAD:
-									X: 395
+									X: 385
 									Y: 0
-									Width: 80
+									Width: 75
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_KILLED:
-									X: 475
+									X: 460
 									Y: 0
-									Width: 85
+									Width: 75
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_DEAD:
-									X: 560
+									X: 535
 									Y: 0
-									Width: 80
+									Width: 75
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ARMY_VALUE:
-									X: 640
+									X: 610
 									Y: 0
 									Width: 90
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@VISION:
+									X: 700
+									Y: 0
+									Width: 60
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True

--- a/mods/d2k/chrome/ingame-observer.yaml
+++ b/mods/d2k/chrome/ingame-observer.yaml
@@ -495,7 +495,7 @@ Container@OBSERVER_WIDGETS:
 						Container@COMBAT_STATS_HEADERS:
 							X: 0
 							Y: 0
-							Width: 735
+							Width: 755
 							Height: PARENT_BOTTOM
 							Children:
 								ColorBlock@HEADER_COLOR:
@@ -541,46 +541,55 @@ Container@OBSERVER_WIDGETS:
 								Label@UNITS_KILLED_HEADER:
 									X: 305
 									Y: 0
-									Width: 90
+									Width: 75
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: Units Killed
+									Text: U. Killed
 									Align: Right
 									Shadow: True
 								Label@UNITS_DEAD_HEADER:
-									X: 395
+									X: 380
 									Y: 0
-									Width: 80
+									Width: 75
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: Units Lost
+									Text: U. Lost
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_KILLED_HEADER:
-									X: 475
+									X: 455
 									Y: 0
-									Width: 85
+									Width: 75
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: Bldg Killed
+									Text: B. Killed
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_DEAD_HEADER:
-									X: 560
+									X: 530
 									Y: 0
-									Width: 80
+									Width: 75
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: Bldg Lost
+									Text: B. Lost
 									Align: Right
 									Shadow: True
 								Label@ARMY_VALUE_HEADER:
-									X: 640
+									X: 605
 									Y: 0
 									Width: 90
 									Height: PARENT_BOTTOM
 									Font: Bold
 									Text: Army Value
+									Align: Right
+									Shadow: True
+								Label@VISION_HEADER:
+									X: 695
+									Y: 0
+									Width: 60
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Vision
 									Align: Right
 									Shadow: True
 				ScrollPanel@PLAYER_STATS_PANEL:
@@ -889,7 +898,7 @@ Container@OBSERVER_WIDGETS:
 						ScrollItem@COMBAT_PLAYER_TEMPLATE:
 							X: 0
 							Y: 0
-							Width: 735
+							Width: 755
 							Height: 25
 							Background: scrollitem-nohover
 							Children:
@@ -932,35 +941,42 @@ Container@OBSERVER_WIDGETS:
 								Label@UNITS_KILLED:
 									X: 305
 									Y: 0
-									Width: 90
+									Width: 75
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@UNITS_DEAD:
-									X: 395
+									X: 380
 									Y: 0
-									Width: 80
+									Width: 75
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_KILLED:
-									X: 475
+									X: 455
 									Y: 0
-									Width: 85
+									Width: 75
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_DEAD:
-									X: 560
+									X: 530
 									Y: 0
-									Width: 80
+									Width: 75
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ARMY_VALUE:
-									X: 640
+									X: 605
 									Y: 0
 									Width: 90
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@VISION:
+									X: 695
+									Y: 0
+									Width: 60
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True

--- a/mods/ra/chrome/ingame-observer.yaml
+++ b/mods/ra/chrome/ingame-observer.yaml
@@ -543,7 +543,7 @@ Container@OBSERVER_WIDGETS:
 						Container@COMBAT_STATS_HEADERS:
 							X: 0
 							Y: 0
-							Width: 740
+							Width: 760
 							Height: PARENT_BOTTOM
 							Children:
 								ColorBlock@HEADER_COLOR:
@@ -589,46 +589,55 @@ Container@OBSERVER_WIDGETS:
 								Label@UNITS_KILLED_HEADER:
 									X: 310
 									Y: 0
-									Width: 90
+									Width: 75
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: Units Killed
+									Text: U. Killed
 									Align: Right
 									Shadow: True
 								Label@UNITS_DEAD_HEADER:
-									X: 400
+									X: 385
 									Y: 0
-									Width: 80
+									Width: 75
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: Units Lost
+									Text: U. Lost
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_KILLED_HEADER:
-									X: 480
+									X: 460
 									Y: 0
-									Width: 85
+									Width: 75
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: Bldg Killed
+									Text: B. Killed
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_DEAD_HEADER:
-									X: 565
+									X: 535
 									Y: 0
-									Width: 80
+									Width: 75
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: Bldg Lost
+									Text: B. Lost
 									Align: Right
 									Shadow: True
 								Label@ARMY_VALUE_HEADER:
-									X: 645
+									X: 610
 									Y: 0
 									Width: 90
 									Height: PARENT_BOTTOM
 									Font: Bold
 									Text: Army Value
+									Align: Right
+									Shadow: True
+								Label@VISION_HEADER:
+									X: 700
+									Y: 0
+									Width: 60
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Vision
 									Align: Right
 									Shadow: True
 				ScrollPanel@PLAYER_STATS_PANEL:
@@ -951,7 +960,7 @@ Container@OBSERVER_WIDGETS:
 						ScrollItem@COMBAT_PLAYER_TEMPLATE:
 							X: 0
 							Y: 0
-							Width: 740
+							Width: 760
 							Height: 24
 							Background: scrollitem-nohover
 							Children:
@@ -996,35 +1005,42 @@ Container@OBSERVER_WIDGETS:
 								Label@UNITS_KILLED:
 									X: 310
 									Y: 0
-									Width: 90
+									Width: 75
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@UNITS_DEAD:
-									X: 400
+									X: 385
 									Y: 0
-									Width: 80
+									Width: 75
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_KILLED:
-									X: 480
+									X: 460
 									Y: 0
-									Width: 85
+									Width: 75
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_DEAD:
-									X: 565
+									X: 535
 									Y: 0
-									Width: 80
+									Width: 75
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ARMY_VALUE:
-									X: 645
+									X: 610
 									Y: 0
 									Width: 90
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@VISION:
+									X: 700
+									Y: 0
+									Width: 60
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True

--- a/mods/ts/chrome/ingame-observer.yaml
+++ b/mods/ts/chrome/ingame-observer.yaml
@@ -495,7 +495,7 @@ Container@OBSERVER_WIDGETS:
 						Container@COMBAT_STATS_HEADERS:
 							X: 0
 							Y: 0
-							Width: 740
+							Width: 760
 							Height: PARENT_BOTTOM
 							Children:
 								ColorBlock@HEADER_COLOR:
@@ -541,46 +541,55 @@ Container@OBSERVER_WIDGETS:
 								Label@UNITS_KILLED_HEADER:
 									X: 310
 									Y: 0
-									Width: 90
+									Width: 75
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: Units Killed
+									Text: U. Killed
 									Align: Right
 									Shadow: True
 								Label@UNITS_DEAD_HEADER:
-									X: 400
+									X: 385
 									Y: 0
-									Width: 80
+									Width: 75
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: Units Lost
+									Text: U. Lost
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_KILLED_HEADER:
-									X: 480
+									X: 460
 									Y: 0
-									Width: 85
+									Width: 75
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: Bldg Killed
+									Text: B. Killed
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_DEAD_HEADER:
-									X: 565
+									X: 535
 									Y: 0
-									Width: 80
+									Width: 75
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: Bldg Lost
+									Text: B. Lost
 									Align: Right
 									Shadow: True
 								Label@ARMY_VALUE_HEADER:
-									X: 645
+									X: 610
 									Y: 0
 									Width: 90
 									Height: PARENT_BOTTOM
 									Font: Bold
 									Text: Army Value
+									Align: Right
+									Shadow: True
+								Label@VISION_HEADER:
+									X: 700
+									Y: 0
+									Width: 60
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Vision
 									Align: Right
 									Shadow: True
 				ScrollPanel@PLAYER_STATS_PANEL:
@@ -896,7 +905,7 @@ Container@OBSERVER_WIDGETS:
 						ScrollItem@COMBAT_PLAYER_TEMPLATE:
 							X: 0
 							Y: 0
-							Width: 740
+							Width: 760
 							Height: 24
 							Background: scrollitem-nohover
 							Children:
@@ -941,35 +950,42 @@ Container@OBSERVER_WIDGETS:
 								Label@UNITS_KILLED:
 									X: 310
 									Y: 0
-									Width: 90
+									Width: 75
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@UNITS_DEAD:
-									X: 400
+									X: 385
 									Y: 0
-									Width: 80
+									Width: 75
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_KILLED:
-									X: 480
+									X: 460
 									Y: 0
-									Width: 85
+									Width: 75
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_DEAD:
-									X: 565
+									X: 535
 									Y: 0
-									Width: 80
+									Width: 75
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ARMY_VALUE:
-									X: 645
+									X: 610
 									Y: 0
 									Width: 90
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@VISION:
+									X: 700
+									Y: 0
+									Width: 60
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True


### PR DESCRIPTION
This brings back the map control statistics from https://github.com/OpenRA/OpenRA/pull/7845 but in a more performance friendly way. Closes https://github.com/OpenRA/OpenRA/issues/18744.