### PR TITLE
Apply range modifiers to Missile RangeLimit.

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -223,7 +223,8 @@ namespace OpenRA.Mods.Common.Projectiles
 			hFacing = args.Facing.Facing;
 			gravity = new WVec(0, 0, -info.Gravity);
 			targetPosition = args.PassiveTarget;
-			rangeLimit = info.RangeLimit != WDist.Zero ? info.RangeLimit : args.Weapon.Range;
+			var limit = info.RangeLimit != WDist.Zero ? info.RangeLimit : args.Weapon.Range;
+			rangeLimit = new WDist(Util.ApplyPercentageModifiers(limit.Length, args.RangeModifiers));
 			minLaunchSpeed = info.MinimumLaunchSpeed.Length > -1 ? info.MinimumLaunchSpeed.Length : info.Speed.Length;
 			maxLaunchSpeed = info.MaximumLaunchSpeed.Length > -1 ? info.MaximumLaunchSpeed.Length : info.Speed.Length;
 			maxSpeed = info.Speed.Length;


### PR DESCRIPTION
Fixes #18747.

Testcase: Add the following to your favorite missile-shooting unit and see that it can now reach the full modified range:
```
RangeMultiplier:
	Modifier: 1000
```