### PR TITLE
Shroud, access ProjectedCellLayer by array index over PPos index.

### DIFF
--- a/OpenRA.Game/Map/ProjectedCellLayer.cs
+++ b/OpenRA.Game/Map/ProjectedCellLayer.cs
@@ -22,9 +22,22 @@ namespace OpenRA
 			: base(gridType, size) { }
 
 		// Resolve an array index from map coordinates.
-		int Index(PPos uv)
+		public int Index(PPos uv)
 		{
 			return uv.V * Size.Width + uv.U;
+		}
+
+		public T this[int index]
+		{
+			get
+			{
+				return entries[index];
+			}
+
+			set
+			{
+				entries[index] = value;
+			}
 		}
 
 		/// <summary>Gets or sets the layer contents using projected map coordinates.</summary>


### PR DESCRIPTION
Performance improvement. Avoid the multiple PPos to array index
conversions in the same method call by calculating the cell
layer index once.

Background:

`Shroud.Tick` and `ProjectedCellLayer.Index(PPos puv)` shows up
in profile reports as one of the most expensive methods
(9% of CPU time).

`Shroud.Tick` calls `ProjectedCellLayer.Index(PPos puv)` multiple
times for the same or different cell layers of the same dimension.

Improvement:

Benchmark results show an 0.5ms mean (10%) improvement in tick
time and 0.3 improvement in render time -
on a replay map of 1.12 min of play at max speed.

Render time:
       render222052(bleed)  render221934(this commit)
count   8144.000000   8144.000000
mean      11.410075     11.470100
std        5.004876      4.731463
min        3.450700      3.638400
25%        7.409100      7.015900
50%       12.410600     12.435900
75%       13.998100     14.242900
max      149.036200    149.656500
![render0](https://user-images.githubusercontent.com/12512948/96787413-f990e200-13f1-11eb-949e-491e87033c79.png)

Tick time:
       tick_time222043(bleed)  tick_time221923(this commit)
count      2366.000000      2366.000000
mean          4.762923         4.275833
std           3.240976         3.206362
min           0.263900         1.653600
25%           4.145375         3.668600
50%           4.779350         4.240050
75%           5.232575         4.611775
max          85.751800        87.387100

![tick0](https://user-images.githubusercontent.com/12512948/96787416-fac20f00-13f1-11eb-9d2e-f506c16607d3.png)


Please validate improvements. Render time improvements seem less obvious/stable.

Possible future improvement could be to let map.ProjectedCellsAsCellLayerIndexes return an enumeration of cell layer indexes.
