### PR TITLE
Throw an exception at load when a map has more than 64 players

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -331,6 +331,9 @@ namespace OpenRA
 				throw new InvalidDataException("Map format {0} is not supported.\n File: {1}".F(MapFormat, package.Name));
 
 			PlayerDefinitions = MiniYaml.NodesOrEmpty(yaml, "Players");
+			if (PlayerDefinitions.Count > 64)
+				throw new InvalidDataException("Maps must not define more than 64 players.\n File: {0}".F(package.Name));
+
 			ActorDefinitions = MiniYaml.NodesOrEmpty(yaml, "Actors");
 
 			Grid = modData.Manifest.Get<MapGrid>();

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -22,8 +22,10 @@ namespace OpenRA.Mods.Common.Lint
 		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
 		{
 			var players = new MapPlayers(map.PlayerDefinitions).Players;
-			var worldOwnerFound = false;
+			if (players.Count > 64)
+				emitError("Defining more than 64 players is not allowed.");
 
+			var worldOwnerFound = false;
 			var playerNames = players.Values.Select(p => p.Name).ToHashSet();
 			foreach (var player in players.Values)
 			{
@@ -55,7 +57,6 @@ namespace OpenRA.Mods.Common.Lint
 				emitError("Found no player owning the world.");
 
 			var worldActor = map.Rules.Actors["world"];
-
 			var factions = worldActor.TraitInfos<FactionInfo>().Select(f => f.InternalName).ToHashSet();
 			foreach (var player in players.Values)
 				if (!string.IsNullOrWhiteSpace(player.Faction) && !factions.Contains(player.Faction))


### PR DESCRIPTION
See #18765. This throws a more useful exception in case there are more than 64 players and adds a lint check. Not crashing here would require us to either abuse the "invalid custom rules" mechanism or create a new mechanism. (Generalise the "invalid custom rules" one?)