### PR TITLE
Tooltip remains after leaving/switching the menu - fix #18301

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -159,6 +159,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Ui.CloseWindow();
 			mpe?.Fade(MenuPaletteEffect.EffectType.None);
 			onExit();
+			Ui.ResetTooltips();
 		}
 
 		ButtonWidget AddButton(string id, string text)


### PR DESCRIPTION
Fixes [#18301](https://github.com/OpenRA/OpenRA/issues/18301)

Tooltip displaying data about player now disasppears after closing the in game menu. Fix was achieved by calling Ui.ResetTooltips() function after player closes the in game menu. 

Functionality was tested in all game variants (tiberian dawn/sun, dune and red alert). 
Tests (called by make test and make check) both passed withouth erros.

Edit: Please note this also changes the behaviour of tooltips after leaving the menu and going back to the game. Previously, if we had a cursor on a building/unit, the tooltip with the name would show up. After entering the menu the tooltip would diasappear (as it should). But, once we closed the menu the tooltip would not appear again, unless the player moved the mouse. You can review the changes in the [youtube video](https://www.youtube.com/watch?v=Vg39Fqqteis&feature=youtu.be&ab_channel=PavolMoln%C3%A1r) in case my explanation is not clear enough. This in my opinion should be intended behaviour (as it works the same in the original c&c), but if I am wrong please let me know.
