### PR TITLE
Netcode: Server-side order sync and optimizations to reduce latency

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -609,9 +609,7 @@ namespace OpenRA
 
 			var worldTickDelta = tick - orderManager.LastTickTime;
 			if (worldTimestep == 0 || worldTickDelta < worldTimestep)
-			{
 				return;
-			}
 
 			using (new PerfSample("tick_time"))
 			{
@@ -840,7 +838,6 @@ namespace OpenRA
 						LogicTick();
 
 						// Force at least one render per tick during regular gameplay
-						// TODO: Have OrderManager tell us when we should force render
 						if (!OrderManager.IsStalling && !(OrderManager.CatchUpFrames > 2) && OrderManager.World != null && !OrderManager.World.IsLoadingGameSave && !OrderManager.World.IsReplay)
 							renderBeforeNextTick = true;
 					}

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -35,7 +35,7 @@ namespace OpenRA
 		public const int NewNetcodeNetTickScale = 1; // Net tick every world frame
 		public const int Timestep = 40;
 		public const int TimestepJankThreshold = 250; // Don't catch up for delays larger than 250ms
-
+		public const double NetCatchupFactor = 0.25;
 		public static InstalledMods Mods { get; private set; }
 		public static ExternalMods ExternalMods { get; private set; }
 
@@ -600,10 +600,11 @@ namespace OpenRA
 				worldTimestep = Timestep;
 			else if (world.IsLoadingGameSave)
 				worldTimestep = 1;
-			else if (orderManager.IsCatchingUp)
-				worldTimestep = Timestep / 4;
+			else if (orderManager.CatchUpFrames > 0)
+				worldTimestep = (int)Math.Floor(world.Timestep / (1.0 + NetCatchupFactor * orderManager.CatchUpFrames)); // Smooth catchup
 			else
 				worldTimestep = world.Timestep;
+
 			var worldTickDelta = tick - orderManager.LastTickTime;
 			if (worldTimestep == 0 || worldTickDelta < worldTimestep)
 			{
@@ -804,12 +805,9 @@ namespace OpenRA
 				var maxFramerate = Settings.Graphics.CapFramerate ? Settings.Graphics.MaxFramerate.Clamp(1, 1000) : 1000;
 				var renderInterval = 1000 / maxFramerate;
 
-				// Halve framerate and double logic when catching up
-				if (OrderManager.IsCatchingUp)
-				{
-					logicInterval /= 4;
-					renderInterval *= 2;
-				}
+				// TODO: limit rendering if we are taking too long to catch up
+				if (OrderManager.CatchUpFrames > 0)
+					logicInterval = (int)Math.Floor(logicInterval / (1.0 + NetCatchupFactor * OrderManager.CatchUpFrames));
 
 				// Tick as fast as possible while restoring game saves, capping rendering at 5 FPS
 				if (OrderManager.World != null && OrderManager.World.IsLoadingGameSave)
@@ -837,7 +835,7 @@ namespace OpenRA
 						LogicTick();
 
 						// Force at least one render per tick during regular gameplay
-						if (!OrderManager.IsCatchingUp && OrderManager.World != null && !OrderManager.World.IsLoadingGameSave && !OrderManager.World.IsReplay)
+						if (!(OrderManager.CatchUpFrames > 0) && OrderManager.World != null && !OrderManager.World.IsLoadingGameSave && !OrderManager.World.IsReplay)
 							renderBeforeNextTick = true;
 					}
 

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -33,9 +33,11 @@ namespace OpenRA
 	{
 		public const int DefaultNetTickScale = 3; // 120ms net tick for 40ms timestep
 		public const int NewNetcodeNetTickScale = 1; // Net tick every world frame
+		public const int MaxNetworkSimLag = 50;
+		public const int MaxSimLagBeforeFrameDrops = 50;
 		public const int Timestep = 40;
 		public const int TimestepJankThreshold = 250; // Don't catch up for delays larger than 250ms
-		public const double NetCatchupFactor = 0.1;
+		public const double NetCatchupFactor = 0.2;
 		public static InstalledMods Mods { get; private set; }
 		public static ExternalMods ExternalMods { get; private set; }
 
@@ -595,17 +597,7 @@ namespace OpenRA
 				Cursor.Tick();
 			}
 
-			int worldTimestep;
-			if (world == null)
-				worldTimestep = Timestep;
-			else if (world.IsLoadingGameSave)
-				worldTimestep = 1;
-			else if (orderManager.IsStalling)
-				worldTimestep = 1;
-			else if (orderManager.CatchUpFrames > 0)
-				worldTimestep = (int)Math.Floor(world.Timestep / (1.0 + NetCatchupFactor * orderManager.CatchUpFrames)); // Smooth catchup
-			else
-				worldTimestep = world.Timestep;
+			var worldTimestep = orderManager.SuggestedTimestep;
 
 			var worldTickDelta = tick - orderManager.LastTickTime;
 			if (worldTimestep == 0 || worldTickDelta < worldTimestep)
@@ -613,12 +605,17 @@ namespace OpenRA
 
 			using (new PerfSample("tick_time"))
 			{
-				// Tick the world to advance the world time to match real time:
-				//    If dt < TickJankThreshold then we should try and catch up by repeatedly ticking
-				//    If dt >= TickJankThreshold then we should accept the jank and progress at the normal rate
-				// dt is rounded down to an integer tick count in order to preserve fractional tick components.
-				var integralTickTimestep = (worldTickDelta / worldTimestep) * worldTimestep;
-				orderManager.LastTickTime += integralTickTimestep >= TimestepJankThreshold ? integralTickTimestep : worldTimestep;
+				if (world == null || !orderManager.ShouldUseCatchUp || !orderManager.LobbyInfo.GlobalSettings.UseNewNetcode)
+				{
+					// Tick the world to advance the world time to match real time:
+					//    If dt < TickJankThreshold then we should try and catch up by repeatedly ticking
+					//    If dt >= TickJankThreshold then we should accept the jank and progress at the normal rate
+					// dt is rounded down to an integer tick count in order to preserve fractional tick components.
+					var integralTickTimestep = (worldTickDelta / worldTimestep) * worldTimestep;
+					orderManager.LastTickTime += integralTickTimestep >= TimestepJankThreshold ? integralTickTimestep : worldTimestep;
+				}
+
+				orderManager.RealTickTime = tick;
 
 				Sound.Tick();
 
@@ -799,23 +796,16 @@ namespace OpenRA
 			{
 				// Ideal time between logic updates. Timestep = 0 means the game is paused
 				// but we still call LogicTick() because it handles pausing internally.
-				var logicInterval = worldRenderer != null && worldRenderer.World.Timestep != 0 ? worldRenderer.World.Timestep : Timestep;
+				// var logicInterval = worldRenderer != null && worldRenderer.World.Timestep != 0 ? worldRenderer.World.Timestep : OrderManager.SuggestedTimestep;
+				var logicInterval = 1;
 
 				// Ideal time between screen updates
 				var maxFramerate = Settings.Graphics.CapFramerate ? Settings.Graphics.MaxFramerate.Clamp(1, 1000) : 1000;
 				var renderInterval = 1000 / maxFramerate;
 
-				if (OrderManager.IsStalling)
-					logicInterval = 1;
-
-				// TODO: limit rendering if we are taking too long to catch up
-				else if (OrderManager.CatchUpFrames > 0)
-					logicInterval = (int)Math.Floor(logicInterval / (1.0 + NetCatchupFactor * OrderManager.CatchUpFrames));
-
-				// Tick as fast as possible while restoring game saves, capping rendering at 5 FPS
+				// Whilst restoring game saves, cap rendering at 5 FPS
 				if (OrderManager.World != null && OrderManager.World.IsLoadingGameSave)
 				{
-					logicInterval = 1;
 					renderInterval = 200;
 				}
 
@@ -827,18 +817,20 @@ namespace OpenRA
 
 				// When's the next update (logic or render)
 				var nextUpdate = Math.Min(nextLogic, nextRender);
+
 				if (now >= nextUpdate)
 				{
 					var forceRender = renderBeforeNextTick || now >= forcedNextRender;
 
 					if (now >= nextLogic && !renderBeforeNextTick)
 					{
-						nextLogic += logicInterval;
+						// nextLogic += logicInterval;
+						nextLogic = now + logicInterval;
 
 						LogicTick();
 
 						// Force at least one render per tick during regular gameplay
-						if (!OrderManager.IsStalling && !(OrderManager.CatchUpFrames > 2) && OrderManager.World != null && !OrderManager.World.IsLoadingGameSave && !OrderManager.World.IsReplay)
+						if (!OrderManager.IsStalling && OrderManager.SimLag < MaxSimLagBeforeFrameDrops && OrderManager.World != null && !OrderManager.World.IsLoadingGameSave && !OrderManager.World.IsReplay)
 							renderBeforeNextTick = true;
 					}
 

--- a/OpenRA.Game/Network/Connection.cs
+++ b/OpenRA.Game/Network/Connection.cs
@@ -353,7 +353,7 @@ namespace OpenRA.Network
 				byte[] queuedPacket = default;
 				if (awaitingAckPackets.Count > 0 && !awaitingAckPackets.TryDequeue(out queuedPacket))
 				{
-					// The dequeing failed because of concurrency, so we retry
+					// The dequeuing failed because of concurrency, so we retry
 					for (var c = 0; c < 5; c++)
 					{
 						if (awaitingAckPackets.TryDequeue(out queuedPacket))
@@ -384,7 +384,7 @@ namespace OpenRA.Network
 				ms.WriteArray(BitConverter.GetBytes(frame));
 				ms.WriteArray(syncData);
 
-				queuedSyncPackets.Add(ms.GetBuffer()); // TODO: re-add sync packets
+				queuedSyncPackets.Add(ms.GetBuffer());
 			}
 		}
 
@@ -402,16 +402,14 @@ namespace OpenRA.Network
 				using (var ackMs = new MemoryStream(ordersLength))
 				{
 					foreach (var o in orders)
-					{
 						ackMs.WriteArray(o);
-					}
 
 					ackArray = ackMs.GetBuffer();
 				}
 
 				if (UseNewNetcode)
 				{
-					awaitingAckPackets.Enqueue(ackArray); // TODO fix having to write byte buffer twice
+					awaitingAckPackets.Enqueue(ackArray);
 				}
 				else
 				{

--- a/OpenRA.Game/Network/Connection.cs
+++ b/OpenRA.Game/Network/Connection.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Network
 			public int Timestep;
 		}
 
-		readonly ConcurrentBag<ReceivedPacket> receivedPackets = new ConcurrentBag<ReceivedPacket>();
+		readonly ConcurrentQueue<ReceivedPacket> receivedPackets = new ConcurrentQueue<ReceivedPacket>();
 		public ReplayRecorder Recorder { get; private set; }
 
 		public virtual int LocalClientId
@@ -160,14 +160,14 @@ namespace OpenRA.Network
 
 		protected void AddPacket(ReceivedPacket packet)
 		{
-			receivedPackets.Add(packet);
+			receivedPackets.Enqueue(packet);
 		}
 
 		public virtual void Receive(Action<int, byte[], int> packetFn)
 		{
 			var packets = new List<ReceivedPacket>(receivedPackets.Count);
 
-			while (receivedPackets.TryTake(out var received))
+			while (receivedPackets.TryDequeue(out var received))
 			{
 				packets.Add(received);
 			}

--- a/OpenRA.Game/Network/FrameData.cs
+++ b/OpenRA.Game/Network/FrameData.cs
@@ -87,12 +87,22 @@ namespace OpenRA.Network
 
 		public bool TryPeekTimestep(out int timestep)
 		{
-			return timestepData.TryPeek(out timestep);
+			if (timestepData.Any())
+			{
+				timestep = timestepData.Dequeue();
+				return true;
+			}
+			else
+			{
+				timestep = 0;
+				return false;
+			}
 		}
 
 		public void AdvanceFrame()
 		{
-			timestepData.TryDequeue(out _);
+			if (timestepData.Any())
+				timestepData.Dequeue();
 		}
 
 		public int BufferTimeRemaining()

--- a/OpenRA.Game/Network/FrameData.cs
+++ b/OpenRA.Game/Network/FrameData.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -27,55 +28,59 @@ namespace OpenRA.Network
 			}
 		}
 
-		readonly Dictionary<int, int> clientQuitTimes = new Dictionary<int, int>();
-		readonly Dictionary<int, Dictionary<int, byte[]>> framePackets = new Dictionary<int, Dictionary<int, byte[]>>();
+		readonly HashSet<int> quitClients = new HashSet<int>();
+		readonly Dictionary<int, Queue<byte[]>> framePackets = new Dictionary<int, Queue<byte[]>>();
 
-		public IEnumerable<int> ClientsPlayingInFrame(int frame)
+		public IEnumerable<int> ClientsPlayingInFrame()
 		{
-			return clientQuitTimes
-				.Where(x => frame <= x.Value)
-				.Select(x => x.Key)
-				.OrderBy(x => x);
+			return framePackets.Keys.Where(x => !quitClients.Contains(x)).OrderBy(x => x);
 		}
 
-		public void ClientQuit(int clientId, int lastClientFrame)
+		public void AddClient(int clientId)
 		{
-			if (lastClientFrame == -1)
-				lastClientFrame = framePackets
-					.Where(x => x.Value.ContainsKey(clientId))
-					.Select(x => x.Key).MaxByOrDefault(x => x);
-
-			clientQuitTimes[clientId] = lastClientFrame;
+			if (!framePackets.ContainsKey(clientId))
+				framePackets.Add(clientId, new Queue<byte[]>());
 		}
 
-		public void AddFrameOrders(int clientId, int frame, byte[] orders)
+		public void ClientQuit(int clientId)
 		{
-			var frameData = framePackets.GetOrAdd(frame);
-			frameData.Add(clientId, orders);
+			// TODO review whether we need to specify quit frame
+			quitClients.Add(clientId);
 		}
 
-		public bool IsReadyForFrame(int frame)
+		public void AddFrameOrders(int clientId, byte[] orders)
 		{
-			return !ClientsNotReadyForFrame(frame).Any();
+			// HACK: Due to design we can actually receive client orders before the game start order
+			// has been acted on, since immediate orders are buffered, so not all clients will have
+			// been added yet. However, all clients are guaranteed to be added before the first
+			// frame is stepped since they are added in OrderManager.StartGame()
+			AddClient(clientId);
+
+			var frameData = framePackets[clientId];
+			frameData.Enqueue(orders);
 		}
 
-		public IEnumerable<int> ClientsNotReadyForFrame(int frame)
+		public bool IsReadyForFrame()
 		{
-			var frameData = framePackets.GetOrAdd(frame);
-			return ClientsPlayingInFrame(frame)
-				.Where(client => !frameData.ContainsKey(client));
+			return !ClientsNotReadyForFrame().Any();
 		}
 
-		public IEnumerable<ClientOrder> OrdersForFrame(World world, int frame)
+		public IEnumerable<int> ClientsNotReadyForFrame()
 		{
-			var frameData = framePackets[frame];
-			var clientData = ClientsPlayingInFrame(frame)
-				.ToDictionary(k => k, v => frameData[v]);
+			return ClientsPlayingInFrame()
+				.Where(client => framePackets[client].Count == 0);
+		}
 
-			return clientData
-				.SelectMany(x => x.Value
-					.ToOrderList(world)
-					.Select(o => new ClientOrder { Client = x.Key, Order = o }));
+		public IEnumerable<ClientOrder> OrdersForFrame(World world)
+		{
+			return ClientsPlayingInFrame()
+				.SelectMany(x => framePackets[x].Dequeue().ToOrderList(world)
+					.Select(y => new ClientOrder { Client = x, Order = y }));
+		}
+
+		public int BufferSizeForClient(int client)
+		{
+			return framePackets[client].Count;
 		}
 	}
 }

--- a/OpenRA.Game/Network/FrameData.cs
+++ b/OpenRA.Game/Network/FrameData.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -44,7 +43,6 @@ namespace OpenRA.Network
 
 		public void ClientQuit(int clientId)
 		{
-			// TODO review whether we need to specify quit frame
 			quitClients.Add(clientId);
 		}
 

--- a/OpenRA.Game/Network/FrameData.cs
+++ b/OpenRA.Game/Network/FrameData.cs
@@ -87,22 +87,12 @@ namespace OpenRA.Network
 
 		public bool TryPeekTimestep(out int timestep)
 		{
-			if (timestepData.Any())
-			{
-				timestep = timestepData.Dequeue();
-				return true;
-			}
-			else
-			{
-				timestep = 0;
-				return false;
-			}
+			return timestepData.TryDequeue(out timestep);
 		}
 
 		public void AdvanceFrame()
 		{
-			if (timestepData.Any())
-				timestepData.Dequeue();
+			timestepData.TryDequeue(out _);
 		}
 
 		public int BufferTimeRemaining()

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -21,7 +21,8 @@ namespace OpenRA
 		SyncHash = 0x65,
 		Disconnect = 0xBF,
 		Handshake = 0xFE,
-		Fields = 0xFF
+		Fields = 0xFF,
+		Ack = 0x10
 	}
 
 	[Flags]

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -93,9 +93,6 @@ namespace OpenRA.Network
 			NetFrameNumber = 1;
 			NextOrderFrame = 1;
 
-			// HACK: FramesAhead is only ever 0 in singleplayer, so we increase the rate of apparent net ticks to decrease latency
-			// if (OrderLatency == 0)
-			// 	NetTickScale = 1;
 			if (LobbyInfo.GlobalSettings.UseNewNetcode)
 				localImmediateOrders.Add(Order.FromTargetString("Loaded", "", true));
 			else

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -79,9 +79,7 @@ namespace OpenRA.Network
 				return;
 
 			if (LobbyInfo.Clients.Count == 0)
-			{
 				frameData.AddClient(Connection.LocalClientId);
-			}
 
 			foreach (var client in LobbyInfo.Clients)
 			{
@@ -100,14 +98,10 @@ namespace OpenRA.Network
 			// if (OrderLatency == 0)
 			// 	NetTickScale = 1;
 			if (LobbyInfo.GlobalSettings.UseNewNetcode)
-			{
 				localImmediateOrders.Add(Order.FromTargetString("Loaded", "", true));
-			}
 			else
-			{
 				for (var i = 0; i <= OrderLatency; ++i)
 					SendOrders();
-			}
 		}
 
 		public OrderManager(ConnectionTarget endpoint, string password, IConnection conn)
@@ -344,9 +338,7 @@ namespace OpenRA.Network
 			}
 
 			if (Connection is NetworkConnection c)
-			{
 				c.UseNewNetcode = LobbyInfo.GlobalSettings.UseNewNetcode;
-			}
 		}
 	}
 

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -59,6 +59,9 @@ namespace OpenRA.Network
 				if (World == null)
 					return Game.Timestep;
 
+				if (!ShouldUseCatchUp)
+					return World.Timestep;
+
 				if (IsStalling || World.IsLoadingGameSave)
 					return 1;
 

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -47,6 +47,7 @@ namespace OpenRA.Network
 		public int OrderLatency; // Set during lobby by a "SyncInfo" packet, see UnitOrders
 		public int NextOrderFrame;
 		public int CatchUpFrames { get; private set; }
+		public bool IsStalling { get; private set; }
 
 		public long LastTickTime = Game.RunTime;
 
@@ -197,6 +198,7 @@ namespace OpenRA.Network
 
 		void CompensateForLatency()
 		{
+			// NOTE: subtract 1 because we are only interested in *excess* frames
 			var catchUpNetFrames = frameData.BufferSizeForClient(Connection.LocalClientId) - 1;
 			if (catchUpNetFrames < 0)
 				catchUpNetFrames = 0;
@@ -309,6 +311,8 @@ namespace OpenRA.Network
 				willTick = frameData.IsReadyForFrame();
 				if (willTick)
 					ProcessOrders();
+
+				IsStalling = !willTick;
 			}
 
 			if (willTick)

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Network
 		public bool ShouldUseCatchUp;
 		public int OrderLatency; // Set during lobby by a "SyncInfo" packet, see UnitOrders
 		public int NextOrderFrame;
-		public bool IsCatchingUp { get; private set; }
+		public int CatchUpFrames { get; private set; }
 
 		public long LastTickTime = Game.RunTime;
 
@@ -201,7 +201,7 @@ namespace OpenRA.Network
 			if (catchUpNetFrames < 0)
 				catchUpNetFrames = 0;
 
-			IsCatchingUp = ShouldUseCatchUp && catchUpNetFrames > 0;
+			CatchUpFrames = ShouldUseCatchUp ? catchUpNetFrames : 0;
 
 			if (LastSlowDownRequestTick + 5 < NetFrameNumber && (catchUpNetFrames > 5))
 			{

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -82,10 +82,8 @@ namespace OpenRA.Network
 				frameData.AddClient(Connection.LocalClientId);
 
 			foreach (var client in LobbyInfo.Clients)
-			{
 				if (!client.IsBot)
 					frameData.AddClient(client.Index);
-			}
 
 			// Generating sync reports is expensive, so only do it if we have
 			// other players to compare against if a desync did occur
@@ -245,9 +243,7 @@ namespace OpenRA.Network
 		{
 			var orders = frameData.OrdersForFrame(World).ToList();
 			foreach (var order in orders)
-			{
 				UnitOrders.ProcessOrder(this, World, order.Client, order.Order);
-			}
 
 			if (NetFrameNumber % SyncFrameScale == 0)
 			{
@@ -296,11 +292,9 @@ namespace OpenRA.Network
 					SendOrders();
 			}
 
+			// Sets catchup frames and asks server to slow down if they are too high
 			if (LobbyInfo.GlobalSettings.UseNewNetcode)
-			{
-				// Sets catchup frames and asks server to slow down if they are too high
 				CompensateForLatency();
-			}
 
 			SendImmediateOrders();
 

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -101,9 +101,7 @@ namespace OpenRA.Network
 			// 	NetTickScale = 1;
 			if (LobbyInfo.GlobalSettings.UseNewNetcode)
 			{
-				// Technically redundant since we will attempt to send orders before the next frame
-				// but gets our framesahead orders out sooner
-				SendOrders();
+				localImmediateOrders.Add(Order.FromTargetString("Loaded", "", true));
 			}
 			else
 			{

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -261,6 +261,11 @@ namespace OpenRA.Network
 			LastTickTime = RealTickTime - SimLag;
 
 			OldRealTickTime = RealTickTime;
+
+			PerfHistory.Increment("net_buffer", bufferRemaining);
+			PerfHistory.Increment("net_slowdown", slowDownRequired < 0 ? slowDownRequired : 0);
+			PerfHistory.Increment("net_simlag", 100.0 * (double)SimLag / (double)SimLagLimit);
+			PerfHistory.Increment("net_speed", 100.0 * (double)World.Timestep / (double)ActualTimestep);
 		}
 
 		IEnumerable<Session.Client> GetClientsNotReadyForNextFrame

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -275,7 +275,7 @@ namespace OpenRA.Network
 		{
 			get
 			{
-				return GameStarted // TODO review, compare to bleed
+				return GameStarted
 					? frameData.ClientsNotReadyForFrame()
 						.Select(a => LobbyInfo.ClientWithIndex(a))
 					: NoClients;

--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -124,7 +124,7 @@ namespace OpenRA.Network
 				}
 			}
 
-			ordersFrame = LobbyInfo.GlobalSettings.OrderLatency; // TODO Fix when adaptive order latency is on
+			ordersFrame = LobbyInfo.GlobalSettings.UseNewNetcode ? 1 : LobbyInfo.GlobalSettings.OrderLatency;
 		}
 
 		// Do nothing: ignore locally generated orders

--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -147,9 +147,7 @@ namespace OpenRA.Network
 		public void Receive(Action<int, byte[]> packetFn)
 		{
 			while (sync.Count != 0)
-			{
 				packetFn(LocalClientId, sync.Dequeue());
-			}
 
 			while (chunks.Count != 0 && chunks.Peek().Frame <= ordersFrame)
 				foreach (var o in chunks.Dequeue().Packets)

--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -162,11 +162,6 @@ namespace OpenRA.Network
 			}
 		}
 
-		public int LastAckedFrame
-		{
-			get { return ordersFrame;  }
-		}
-
 		public void Dispose() { }
 	}
 }

--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -144,21 +144,21 @@ namespace OpenRA.Network
 			ordersFrame = frame + 1;
 		}
 
-		public void Receive(Action<int, byte[]> packetFn)
+		public void Receive(Action<int, byte[], int> packetFn)
 		{
 			while (sync.Count != 0)
-				packetFn(LocalClientId, sync.Dequeue());
+				packetFn(LocalClientId, sync.Dequeue(), 0);
 
 			while (chunks.Count != 0 && chunks.Peek().Frame <= ordersFrame)
 				foreach (var o in chunks.Dequeue().Packets)
-					packetFn(o.ClientId, o.Packet);
+					packetFn(o.ClientId, o.Packet, 0);
 
 			// Stream ended, disconnect everyone
 			if (chunks.Count == 0)
 			{
 				var disconnectPacket = new byte[] { 0, 0, 0, 0, (byte)OrderType.Disconnect };
 				foreach (var client in LobbyInfo.Clients)
-					packetFn(client.Index, disconnectPacket);
+					packetFn(client.Index, disconnectPacket, 0);
 			}
 		}
 

--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Network
 
 		Queue<Chunk> chunks = new Queue<Chunk>();
 		Queue<byte[]> sync = new Queue<byte[]>();
-		int ordersFrame;
+		int ordersFrame = 1;
 		Dictionary<int, int> lastClientsFrame = new Dictionary<int, int>();
 
 		public int LocalClientId { get { return -1; } }
@@ -123,8 +123,6 @@ namespace OpenRA.Network
 					}
 				}
 			}
-
-			ordersFrame = LobbyInfo.GlobalSettings.UseNewNetcode ? 1 : LobbyInfo.GlobalSettings.OrderLatency;
 		}
 
 		// Do nothing: ignore locally generated orders

--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -108,11 +108,6 @@ namespace OpenRA.Network
 					{
 						var client = tmpPacketPair.ClientId;
 
-						// Don't replace the final disconnection packet - we still want this to end the replay.
-						// TODO Ensure that this is not necessary
-						/*if (client == lastClientToDisconnect)
-							continue;*/
-
 						var packet = tmpPacketPair.Packet;
 						if (packet.Length == 5 && packet[4] == (byte)OrderType.Disconnect)
 						{

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -148,6 +148,7 @@ namespace OpenRA.Network
 			public string Slot; // Slot ID, or null for observer
 			public string Bot; // Bot type, null for real clients
 			public int BotControllerClientIndex; // who added the bot to the slot
+			public bool IsBot { get { return Bot != null; } }
 			public bool IsAdmin;
 			public bool IsReady { get { return State == ClientState.Ready; } }
 			public bool IsInvalid { get { return State == ClientState.Invalid; } }
@@ -229,6 +230,7 @@ namespace OpenRA.Network
 			public string GameUid;
 			public bool EnableSingleplayer;
 			public bool EnableSyncReports;
+			public bool UseNewNetcode;
 			public bool Dedicated;
 			public bool GameSavesEnabled;
 

--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -51,19 +51,20 @@ namespace OpenRA.Network
 				syncReports[i] = new Report();
 		}
 
-		internal void UpdateSyncReport()
+		internal void UpdateSyncReport(List<FrameData.ClientOrder> orders)
 		{
-			GenerateSyncReport(syncReports[curIndex]);
+			GenerateSyncReport(syncReports[curIndex], orders);
 			curIndex = ++curIndex % NumSyncReports;
 		}
 
-		void GenerateSyncReport(Report report)
+		void GenerateSyncReport(Report report, List<FrameData.ClientOrder> orders)
 		{
 			report.Frame = orderManager.NetFrameNumber;
 			report.SyncedRandom = orderManager.World.SharedRandom.Last;
 			report.TotalCount = orderManager.World.SharedRandom.TotalCount;
 			report.Traits.Clear();
 			report.Effects.Clear();
+			report.Orders = orders;
 
 			foreach (var actor in orderManager.World.ActorsHavingTrait<ISync>())
 			{
@@ -100,7 +101,7 @@ namespace OpenRA.Network
 			}
 		}
 
-		internal void DumpSyncReport(int frame, IEnumerable<FrameData.ClientOrder> orders)
+		internal void DumpSyncReport(int frame)
 		{
 			var reportName = "syncreport-" + DateTime.UtcNow.ToString("yyyy-MM-ddTHHmmssZ", CultureInfo.InvariantCulture) + ".log";
 			Log.AddChannel("sync", reportName);
@@ -137,7 +138,7 @@ namespace OpenRA.Network
 					}
 
 					Log.Write("sync", "Orders Issued:");
-					foreach (var o in orders)
+					foreach (var o in r.Orders)
 						Log.Write("sync", "\t {0}", o.ToString());
 
 					return;
@@ -154,6 +155,7 @@ namespace OpenRA.Network
 			public int TotalCount;
 			public List<TraitReport> Traits = new List<TraitReport>();
 			public List<EffectReport> Effects = new List<EffectReport>();
+			public List<FrameData.ClientOrder> Orders = new List<FrameData.ClientOrder>();
 		}
 
 		struct TraitReport

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -254,7 +254,7 @@ namespace OpenRA.Network
 				case "SyncInfo":
 					{
 						orderManager.LobbyInfo = Session.Deserialize(order.TargetString);
-						SetOrderLag(orderManager);
+						orderManager.SyncLobbyInfo();
 						Game.SyncLobbyInfo();
 						break;
 					}
@@ -304,7 +304,7 @@ namespace OpenRA.Network
 								orderManager.LobbyInfo.GlobalSettings = Session.Global.Deserialize(node.Value);
 						}
 
-						SetOrderLag(orderManager);
+						orderManager.SyncLobbyInfo();
 						Game.SyncLobbyInfo();
 						break;
 					}
@@ -353,15 +353,6 @@ namespace OpenRA.Network
 
 			if (world.OrderValidators.All(vo => vo.OrderValidation(orderManager, world, clientId, order)))
 				order.Subject.ResolveOrder(order);
-		}
-
-		static void SetOrderLag(OrderManager o)
-		{
-			if (o.FramesAhead != o.LobbyInfo.GlobalSettings.OrderLatency && !o.GameStarted)
-			{
-				o.FramesAhead = o.LobbyInfo.GlobalSettings.OrderLatency;
-				Log.Write("server", "Order lag is now {0} frames.", o.LobbyInfo.GlobalSettings.OrderLatency);
-			}
 		}
 	}
 }

--- a/OpenRA.Game/Server/Connection.cs
+++ b/OpenRA.Game/Server/Connection.cs
@@ -27,6 +27,7 @@ namespace OpenRA.Server
 		public int Frame = 0;
 		public int MostRecentFrame = 0;
 		public bool Validated;
+		public bool Loaded;
 
 		public long TimeSinceLastResponse { get { return Game.RunTime - lastReceivedTime; } }
 		public bool TimeoutMessageShown = false;

--- a/OpenRA.Game/Server/Connection.cs
+++ b/OpenRA.Game/Server/Connection.cs
@@ -153,7 +153,7 @@ namespace OpenRA.Server
 			}
 		}
 
-		private void InnerSend(byte[] data)
+		void InnerSend(byte[] data)
 		{
 			var start = 0;
 			var length = data.Length;

--- a/OpenRA.Game/Server/OrderBuffer.cs
+++ b/OpenRA.Game/Server/OrderBuffer.cs
@@ -10,9 +10,7 @@
 #endregion
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace OpenRA.Server
 {

--- a/OpenRA.Game/Server/OrderBuffer.cs
+++ b/OpenRA.Game/Server/OrderBuffer.cs
@@ -1,0 +1,85 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Server
+{
+	/*
+	 * OpenRA orders do not need to be frame-specific, as long as each client resolves the same orders in the same order
+	 * they should be able to maintain a deterministic simulation with a mostly expected result.
+	 *
+	 * This allows the server to act as a dumb "master order synchronizer", simply acting as the authority and central
+	 * point of synchronization on which orders to resolve each frame.
+	 *
+	 * The buffer is fairly simple, it maintains a list of all incoming order packets, minus their associated frames,
+	 * so that all orders can be batched for a single frame to all clients at a time of the server's choosing.
+	 *
+	 * A mechanism for clients to inform/request slowdown should be provided so that clients which are overloaded do
+	 * not fall behind indefinitely.
+	 */
+	public class OrderBuffer
+	{
+		// Maintaining a queue of the serialized order lists prevents us from having to deserialize the orders
+		// or copy them on receive. They should be able to be written the TCP stream without being copied.
+		// The count of the byte[] queue is used as the number of frames to ack.
+		// Since the connection is reliable, clients will understand what the ack count means.
+		readonly Dictionary<int, List<byte[]>> clientOrdersBuffer = new Dictionary<int, List<byte[]>>();
+
+		public void BufferOrders(int client, byte[] serializedOrderList)
+		{
+			if (!clientOrdersBuffer.TryGetValue(client, out var orderQueue))
+				throw new InvalidOperationException("Tried to buffer orders for client that wasn't added");
+
+			orderQueue.Add(serializedOrderList);
+		}
+
+		public void AddClient(int client)
+		{
+			clientOrdersBuffer.Add(client, new List<byte[]>());
+		}
+
+		public void DropClient(int client)
+		{
+			clientOrdersBuffer.Remove(client);
+		}
+
+		// Calls the given action with all necessary communications in the form:
+		// From, To, EnumerableData
+		// Then clears the buffer
+		// TODO allow server to optionally store buffered frames and enable client joins and re-connects
+		public void DispatchOrders(IFrameOrderDispatcher dispatcher)
+		{
+			foreach (var fromPair in clientOrdersBuffer)
+			{
+				var fromClient = fromPair.Key;
+				var orders = fromPair.Value;
+
+				// Ack the frames sent to be applied on this frame
+				dispatcher.DispatchBufferedOrderAcks(fromClient, orders.Count);
+
+				// Send each client's order buffer (because they were queued, order is preserved)
+				dispatcher.DispatchBufferedOrdersToOtherClients(fromClient, orders);
+
+				orders.Clear();
+			}
+		}
+	}
+
+	public interface IFrameOrderDispatcher
+	{
+		void DispatchBufferedOrdersToOtherClients(int fromClient, List<byte[]> allData);
+		void DispatchBufferedOrderAcks(int forClient, int ackCount);
+	}
+}

--- a/OpenRA.Game/Server/OrderBuffer.cs
+++ b/OpenRA.Game/Server/OrderBuffer.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Server
 		// From, To, EnumerableData
 		// Then clears the buffer
 		// TODO allow server to optionally store buffered frames and enable client joins and re-connects
-		public void DispatchOrders(IFrameOrderDispatcher dispatcher)
+		public void DispatchOrders(IFrameOrderDispatcher dispatcher, int timestep)
 		{
 			foreach (var fromPair in clientOrdersBuffer)
 			{
@@ -64,7 +64,7 @@ namespace OpenRA.Server
 				var orders = fromPair.Value;
 
 				// Ack the frames sent to be applied on this frame
-				dispatcher.DispatchBufferedOrderAcks(fromClient, orders.Count);
+				dispatcher.DispatchBufferedOrderAcks(fromClient, orders.Count, timestep);
 
 				// Send each client's order buffer (because they were queued, order is preserved)
 				dispatcher.DispatchBufferedOrdersToOtherClients(fromClient, orders);
@@ -77,6 +77,6 @@ namespace OpenRA.Server
 	public interface IFrameOrderDispatcher
 	{
 		void DispatchBufferedOrdersToOtherClients(int fromClient, List<byte[]> allData);
-		void DispatchBufferedOrderAcks(int forClient, int ackCount);
+		void DispatchBufferedOrderAcks(int forClient, int ackCount, int timestep);
 	}
 }

--- a/OpenRA.Game/Server/OrderBuffer.cs
+++ b/OpenRA.Game/Server/OrderBuffer.cs
@@ -36,7 +36,6 @@ namespace OpenRA.Server
 		// The count of the byte[] queue is used as the number of frames to ack.
 		// Since the connection is reliable, clients will understand what the ack count means.
 		readonly Dictionary<int, List<byte[]>> clientOrdersBuffer = new Dictionary<int, List<byte[]>>();
-
 		public void BufferOrders(int client, byte[] serializedOrderList)
 		{
 			if (!clientOrdersBuffer.TryGetValue(client, out var orderQueue))

--- a/OpenRA.Game/Server/ProtocolVersion.cs
+++ b/OpenRA.Game/Server/ProtocolVersion.cs
@@ -36,6 +36,11 @@ namespace OpenRA.Server
 		//   - OrderFields enum encoded as a byte: specifies the data included in the rest of the order
 		//   - Order-specific data - see OpenRA.Game/Server/Order.cs for details
 		//
+		// When the frame of a packet is 0, it is an immediate order, and may or may not be relayed to clients e.g. chat
+		//
+		// When the frame is not 0, it will always be relayed to all clients
+		// and in UseNewNetcode mode, a packet with a number of orders messages to ack is returned to the sender
+		//
 		// A connection handshake begins when a client opens a connection to the server:
 		// - Server sends:
 		//   - Int32 specifying the handshake protocol version

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -830,7 +830,6 @@ namespace OpenRA.Server
 				}
 			}
 
-			// TODO: Make this nicer
 			if (GameSave != null && conn != null)
 				GameSave.DispatchOrders(conn, frame, data);
 		}
@@ -843,7 +842,6 @@ namespace OpenRA.Server
 			foreach (var c in Conns.ToList())
 				DispatchFrameToClient(c, frameData);
 
-			// TODO: Make this nicer
 			if (GameSave != null && fakeFrom != null)
 				GameSave.DispatchOrders(fakeFrom, frame, data);
 		}
@@ -856,13 +854,13 @@ namespace OpenRA.Server
 				GameSave?.DispatchOrders(conn, frame, data);
 			}
 
-			// TODO: Find a less hacky way to deal with synchash relaying
+			// HACK: This is not a good way to detect and relay sync hashes but it is currently the only way
 			else if (conn != null && data.Length != 0 && (OrderType)data[0] == OrderType.SyncHash)
 				DispatchOrdersToOtherClients(conn, frame, data, true);
-			else if (conn != null && LobbyInfo.GlobalSettings.UseNewNetcode && State >= ServerState.GameStarted)
+			else if (conn != null && LobbyInfo.GlobalSettings.UseNewNetcode && State == ServerState.GameStarted && GameState == GameState.Playing)
 				serverGame.OrderBuffer.BufferOrders(conn.PlayerIndex, data);
 
-			// TODO: Remove frame-based order relaying unless game is running
+			// Relay all orders as normal, for old netcode and pre-game
 			else
 				DispatchOrdersToOtherClients(conn, frame, data);
 		}

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -269,7 +269,11 @@ namespace OpenRA.Server
 						// Block for at most 1 second in order to guarantee a minimum tick rate for ServerTraits
 						// Decrease this to 100ms to improve responsiveness if we are waiting for an authentication query
 						if (LobbyInfo.GlobalSettings.UseNewNetcode && State == ServerState.GameStarted && GameState == GameState.Playing)
+						{
 							selectTimeout = serverGame.MillisToNextNetFrame * 1000;
+							if (selectTimeout < 0)
+								selectTimeout = 0;
+						}
 						else
 							selectTimeout = waitingForAuthenticationCallback > 0 ? 100000 : 1000000;
 

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -1111,9 +1111,7 @@ namespace OpenRA.Server
 								serverGame.SlowDown(amount);
 							}
 							else
-							{
 								Log.Write("server", "Received request to slow down from client {0} but not using new netcode!", conn.PlayerIndex);
-							}
 
 							break;
 						}
@@ -1121,13 +1119,9 @@ namespace OpenRA.Server
 					case "Loaded":
 						{
 							if (LobbyInfo.GlobalSettings.UseNewNetcode)
-							{
 								conn.Loaded = true;
-							}
 							else
-							{
 								Log.Write("server", "Received Loaded message from client {0} but not using new netcode!", conn.PlayerIndex);
-							}
 
 							break;
 						}
@@ -1352,9 +1346,7 @@ namespace OpenRA.Server
 					State = ServerState.GameLoading;
 				}
 				else
-				{
 					State = ServerState.GameStarted;
-				}
 
 				// TODO remove: this "pre-disconnecting" method adds unnecessary complexity just for the sake of the replay stream
 				/*var disconnectData = new[] { (byte)OrderType.Disconnect };

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -877,15 +877,16 @@ namespace OpenRA.Server
 			DispatchOrdersToOtherClients(conn, serverGame.CurrentNetFrame, ms.ToArray(), true);
 		}
 
-		public void DispatchBufferedOrderAcks(int forClient, int acks)
+		public void DispatchBufferedOrderAcks(int forClient, int acks, int timestep)
 		{
 			if (acks > 0xFFFF)
 				throw new InvalidOperationException("Acks too great");
 
-			var ms = new MemoryStream(3);
+			var ms = new MemoryStream(5);
 			var writer = new BinaryWriter(ms);
 			writer.Write((byte)OrderType.Ack);
 			writer.Write((short)acks);
+			writer.Write((short)timestep);
 
 			var conn = Conns.FirstOrDefault(c => c.PlayerIndex == forClient);
 

--- a/OpenRA.Game/Server/ServerGame.cs
+++ b/OpenRA.Game/Server/ServerGame.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace OpenRA.Server

--- a/OpenRA.Game/Server/ServerGame.cs
+++ b/OpenRA.Game/Server/ServerGame.cs
@@ -1,0 +1,84 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace OpenRA.Server
+{
+	public class ServerGame
+	{
+		const int JankThreshold = 250;
+
+		Stopwatch gameTimer;
+		public long RunTime
+		{
+			get { return gameTimer.ElapsedMilliseconds; }
+		}
+
+		public readonly OrderBuffer OrderBuffer;
+		public int CurrentNetFrame { get; protected set; }
+		public long NextFrameTick { get; protected set; }
+		public int NetTimestep { get; protected set; }
+
+		int slowdownHold;
+		int slowdownAmount;
+		public int AdjustedTimestep { get { return NetTimestep + slowdownAmount; } }
+
+		public int MillisToNextNetFrame
+		{
+			get { return (int)(NextFrameTick - RunTime); }
+			set { NextFrameTick = RunTime + value; }
+		}
+
+		public ServerGame(int worldTimeStep)
+		{
+			CurrentNetFrame = 1;
+			NetTimestep = worldTimeStep * Game.NewNetcodeNetTickScale; // TODO: Set net tick scale via lobby settings
+			NextFrameTick = NetTimestep;
+			gameTimer = Stopwatch.StartNew();
+			OrderBuffer = new OrderBuffer();
+		}
+
+		public bool TryTick(IFrameOrderDispatcher dispatcher)
+		{
+			var now = RunTime;
+			if (now < NextFrameTick)
+				return false;
+
+			OrderBuffer.DispatchOrders(dispatcher);
+
+			CurrentNetFrame++;
+			if (now - NextFrameTick > JankThreshold)
+				NextFrameTick = now + AdjustedTimestep;
+			else
+				NextFrameTick += AdjustedTimestep;
+
+			if (slowdownHold > 0)
+				slowdownHold--;
+
+			if (slowdownHold == 0 && slowdownAmount > 0)
+				slowdownAmount = slowdownAmount - (slowdownAmount / 4) - 1;
+
+			return true;
+		}
+
+		public void SlowDown(int amount)
+		{
+			if (slowdownAmount < amount)
+			{
+				slowdownAmount = amount;
+				slowdownHold = amount;
+			}
+		}
+	}
+}

--- a/OpenRA.Game/Server/ServerGame.cs
+++ b/OpenRA.Game/Server/ServerGame.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Server
 		public ServerGame(int worldTimeStep)
 		{
 			CurrentNetFrame = 1;
-			NetTimestep = worldTimeStep * Game.NewNetcodeNetTickScale; // TODO: Set net tick scale via lobby settings
+			NetTimestep = worldTimeStep * Game.NewNetcodeNetTickScale;
 			NextFrameTick = NetTimestep;
 			gameTimer = Stopwatch.StartNew();
 			OrderBuffer = new OrderBuffer();

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -79,6 +79,9 @@ namespace OpenRA
 		[Desc("Enable client-side report generation to help debug desync errors.")]
 		public bool EnableSyncReports = false;
 
+		[Desc("Use the new server-sync netcode (experimental).")]
+		public bool UseNewNetcode = false;
+
 		[Desc("Sets the timestamp format. Defaults to the ISO 8601 standard.")]
 		public string TimestampFormat = "yyyy-MM-ddTHH:mm:ss";
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/AdvancedSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/AdvancedSettingsLogic.cs
@@ -38,6 +38,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			// Advanced
 			SettingsUtils.BindCheckboxPref(panel, "NAT_DISCOVERY", ss, "DiscoverNatDevices");
+			SettingsUtils.BindCheckboxPref(panel, "USE_NEW_NETCODE_CHECKBOX", ss, "UseNewNetcode");
 			SettingsUtils.BindCheckboxPref(panel, "PERFTEXT_CHECKBOX", ds, "PerfText");
 			SettingsUtils.BindCheckboxPref(panel, "PERFGRAPH_CHECKBOX", ds, "PerfGraph");
 			SettingsUtils.BindCheckboxPref(panel, "FETCH_NEWS_CHECKBOX", gs, "FetchNews");
@@ -70,6 +71,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			return () =>
 			{
 				ss.DiscoverNatDevices = dss.DiscoverNatDevices;
+				ss.UseNewNetcode = dss.UseNewNetcode;
 				ds.PerfText = dds.PerfText;
 				ds.PerfGraph = dds.PerfGraph;
 				ds.SyncCheckUnsyncedCode = dds.SyncCheckUnsyncedCode;

--- a/launch-dedicated.cmd
+++ b/launch-dedicated.cmd
@@ -15,6 +15,7 @@ set ProfileIDWhitelist=""
 
 set EnableSingleplayer=False
 set EnableSyncReports=False
+set UseNewNetcode=False
 set EnableGeoIP=True
 set ShareAnonymizedIPs=True
 
@@ -22,6 +23,6 @@ set SupportDir=""
 
 :loop
 
-bin\OpenRA.Server.exe Engine.EngineDir=".." Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.RecordReplays=%RecordReplays% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports% Server.EnableGeoIP=%EnableGeoIP% Server.ShareAnonymizedIPs=%ShareAnonymizedIPs% Engine.SupportDir=%SupportDir%
+bin\OpenRA.Server.exe Engine.EngineDir=".." Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.RecordReplays=%RecordReplays% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports% Server.UseNewNetcode=%UseNewNetcode% Server.EnableGeoIP=%EnableGeoIP% Server.ShareAnonymizedIPs=%ShareAnonymizedIPs% Engine.SupportDir=%SupportDir%
 
 goto loop

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -25,6 +25,7 @@ ProfileIDWhitelist="${ProfileIDWhitelist:-""}"
 
 EnableSingleplayer="${EnableSingleplayer:-"False"}"
 EnableSyncReports="${EnableSyncReports:-"False"}"
+UseNewNetcode="${UseNewNetcode:-"False"}"
 EnableGeoIP="${EnableGeoIP:-"True"}"
 ShareAnonymizedIPs="${ShareAnonymizedIPs:-"True"}"
 
@@ -42,6 +43,7 @@ while true; do
      Server.ProfileIDBlacklist="$ProfileIDBlacklist" \
      Server.ProfileIDWhitelist="$ProfileIDWhitelist" \
      Server.EnableSyncReports="$EnableSyncReports" \
+     Server.UseNewNetcode="$UseNewNetcode" \
      Server.EnableGeoIP="$EnableGeoIP" \
      Server.ShareAnonymizedIPs="$ShareAnonymizedIPs" \
      Engine.SupportDir="$SupportDir"

--- a/mods/cnc/chrome/settings-advanced.yaml
+++ b/mods/cnc/chrome/settings-advanced.yaml
@@ -16,16 +16,23 @@ Container@ADVANCED_PANEL:
 			Height: 20
 			Font: Regular
 			Text: Enable Network Discovery (UPnP)
+		Checkbox@USE_NEW_NETCODE_CHECKBOX:
+			X: 15
+			Y: 72
+			Width: 300
+			Height: 20
+			Font: Regular
+			Text: Use New Netcode (Experimental)
 		Checkbox@PERFTEXT_CHECKBOX:
 			X: 15
-			Y: 73
+			Y: 103
 			Width: 300
 			Height: 20
 			Font: Regular
 			Text: Show Performance Text
 		Checkbox@PERFGRAPH_CHECKBOX:
 			X: 15
-			Y: 103
+			Y: 133
 			Width: 300
 			Height: 20
 			Font: Regular

--- a/mods/common/chrome/settings-advanced.yaml
+++ b/mods/common/chrome/settings-advanced.yaml
@@ -10,16 +10,23 @@ Container@ADVANCED_PANEL:
 			Height: 20
 			Font: Regular
 			Text: Enable Network Discovery (UPnP)
-		Checkbox@PERFTEXT_CHECKBOX:
+		Checkbox@USE_NEW_NETCODE_CHECKBOX:
 			X: 15
 			Y: 73
+			Width: 300
+			Height: 20
+			Font: Regular
+			Text: Use New Netcode (Experimental)
+		Checkbox@PERFTEXT_CHECKBOX:
+			X: 15
+			Y: 103
 			Width: 300
 			Height: 20
 			Font: Regular
 			Text: Show Performance Text
 		Checkbox@PERFGRAPH_CHECKBOX:
 			X: 15
-			Y: 103
+			Y: 133
 			Width: 300
 			Height: 20
 			Font: Regular


### PR DESCRIPTION
An updated version of #17900. See that PR for a more in-depth discussion of the changes.

This code change improves input responsiveness in multiplayer games to be as small as possible (from well over 300ms). Please give it a spin and try a comparison for yourself.

It's expected that there will be a few instabilities: replays and singleplayer may be broken.

## Install and Use

Dedicated servers must launch with the additional env option: `UseNewNetcode="True"`. Game clients can host games with the new netcode using the checkbox provided in the Settings->Advanced tab.

You need to ensure that you have a valid version tag in the game to play online with the server browser, which can be done reliably with the following commands:

On Windows with PowerShell use:
```
.\make.cmd version
.\make.cmd all
.\launch-game.cmd Game.Mod=ra
```

On Linux:
```
make version
make all
./launch-game.cmd Game.Mod=ra
```

[Script for a dedicated server on Ubuntu 20.04 (needs specific version for Mono)](https://gist.github.com/adammitchelldev/4986da1e6d65d79ed23db64e07afbfdd)

You can try executing it directly with:
```
curl -sSf https://gist.githubusercontent.com/adammitchelldev/4986da1e6d65d79ed23db64e07afbfdd/raw/634e6899842cd41c34dba8c34c89c453ce4cfb9b/netcode.sh | bash
```