### PR TITLE
Refactors around order transmission and serialisation

### DIFF
--- a/OpenRA.Game/Network/Connection.cs
+++ b/OpenRA.Game/Network/Connection.cs
@@ -123,11 +123,11 @@ namespace OpenRA.Network
 
 		public virtual void Send(int frame, List<byte[]> orders)
 		{
-			var ms = new MemoryStream();
+			var ms = new MemoryStream(orders.Sum(i => i.Length) + 4);
 			ms.WriteArray(BitConverter.GetBytes(frame));
 			foreach (var o in orders)
 				ms.WriteArray(o);
-			Send(ms.ToArray());
+			Send(ms.GetBuffer());
 		}
 
 		public virtual void SendImmediate(IEnumerable<byte[]> orders)

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -285,13 +285,10 @@ namespace OpenRA
 		{
 			var minLength = 1 + OrderString.Length + 1;
 			if (Type == OrderType.Handshake)
-				minLength += TargetString.Length + 2; // dont know exctaly why +2, but it is 2
+				minLength += TargetString.Length + 2; // +2 are the trayling bytes
 			else if (Type == OrderType.Fields)
 			{
-				minLength += 1; // 6 The smallest order is "Building Placement"
-
-				if (ExtraActors != null)
-					minLength += ExtraActors.Length * 4;
+				minLength += 1;
 
 				if (GroupedActors != null)
 					minLength += GroupedActors.Length * 4;
@@ -366,7 +363,10 @@ namespace OpenRA
 						fields |= OrderFields.Grouped;
 
 					if (ExtraActors != null)
+					{
 						fields |= OrderFields.ExtraActors;
+						minLength += (ExtraActors.Length * 4) + 5;
+					}
 
 					if (ExtraLocation != CPos.Zero)
 						fields |= OrderFields.ExtraLocation;

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -342,7 +342,7 @@ namespace OpenRA
 						switch (Target.SerializableType)
 						{
 							case TargetType.Actor:
-								minLength += 4;
+								minLength += 6;
 								break;
 							case TargetType.FrozenActor:
 								minLength += 8;

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -440,7 +440,22 @@ namespace OpenRA
 					throw new InvalidDataException("Cannot serialize order type {0}".F(Type));
 			}
 
-			return ret.Capacity == ret.Length ? ret.GetBuffer() : ret.ToArray();
+			byte[] result;
+
+			// capacity being equal to the length means that whatever iteration
+			// like a for or foreach is safe and wont yield problems. Safe coding
+			// approaches could make use of the buffer whatever the delta though.
+			// I left the ToArray just in case.
+			if (ret.Capacity == ret.Length)
+			{
+				result = ret.GetBuffer();
+			}
+			else
+			{
+				result = ret.ToArray();
+			}
+
+			return result;
 		}
 
 		public override string ToString()

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -327,7 +327,7 @@ namespace OpenRA
 					if (TargetString != null)
 					{
 						fields |= OrderFields.TargetString;
-						minLength += (TargetString.Length + 2); // one trayling byte on each side
+						minLength += TargetString.Length + (OrderString == "PlaceBuilding" ? 1 : 2);
 					}
 
 					if (ExtraData != 0)
@@ -348,9 +348,10 @@ namespace OpenRA
 								minLength += 8;
 								break;
 							case TargetType.Terrain:
-								minLength += 12;
 								if (fields.HasField(OrderFields.TargetIsCell))
-									minLength++;
+									minLength += 4;
+								else
+									minLength += 7;
 
 								break;
 						}

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -285,12 +285,17 @@ namespace OpenRA
 		{
 			var minLength = 1 + OrderString.Length + 1;
 			if (Type == OrderType.Handshake)
-				minLength += TargetString.Length + 1;
+				minLength += TargetString.Length + 2; // dont know exctaly why +2, but it is 2
 			else if (Type == OrderType.Fields)
+			{
 				minLength += 4 + 2 + 13 + (TargetString != null ? TargetString.Length + 1 : 0) + 4 + 4 + 4;
 
-			if (ExtraActors != null)
-				minLength += ExtraActors.Length * 4;
+				if (ExtraActors != null)
+					minLength += ExtraActors.Length * 4;
+
+				if (GroupedActors != null)
+					minLength += GroupedActors.Length * 4;
+			}
 
 			// ProtocolVersion.Orders and the associated documentation MUST be updated if the serialized format changes
 			var ret = new MemoryStream(minLength);
@@ -399,7 +404,7 @@ namespace OpenRA
 					throw new InvalidDataException("Cannot serialize order type {0}".F(Type));
 			}
 
-			return ret.ToArray();
+			return ret.Capacity == ret.Length ? ret.GetBuffer() : ret.ToArray();
 		}
 
 		public override string ToString()

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -288,7 +288,7 @@ namespace OpenRA
 				minLength += TargetString.Length + 2; // dont know exctaly why +2, but it is 2
 			else if (Type == OrderType.Fields)
 			{
-				minLength += 4 + 2 + 13 + (TargetString != null ? TargetString.Length + 1 : 0) + 4 + 4 + 4;
+				minLength += 1 + 2 + 13 + (TargetString != null ? TargetString.Length + 1 : 0); // The smallest order is "Building Placement"
 
 				if (ExtraActors != null)
 					minLength += ExtraActors.Length * 4;


### PR DESCRIPTION
Basically I refactored code to avoid the costly ".ToArray()"... could not reconcile all the `Order`s but the majors/more-frequent are there... if this gets approved I plan on working on the other `Order`s

This is basically a double/combo/multiplier processing time saver, since the `MemoryStream` backing array no longer needs to be copied (calling `GetBuffer` instead of `ToArray` prevents that) AND less garbage is generated in the process which triggers the GC even less