### PR TITLE
Revert "Determine stance for spectators based on shroud selection"

### DIFF
--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -225,11 +225,7 @@ namespace OpenRA
 		public Dictionary<Player, Stance> Stances = new Dictionary<Player, Stance>();
 		public bool IsAlliedWith(Player p)
 		{
-			// Current shroud selection is used to determine stance for spectators
-			if (p != null && p.Spectating && !NonCombatant && p.World.RenderPlayer != null)
-				return Stances[p.World.RenderPlayer] == Stance.Ally;
-
-			// Observers are considered allies if RenderPlayer property is null
+			// Observers are considered allies to active combatants
 			return p == null || Stances[p] == Stance.Ally || (p.Spectating && !NonCombatant);
 		}
 


### PR DESCRIPTION
This PR reverts #18077 - RenderPlayer is not synced between clients, so cannot be used from synced code like `IsAlliedWith`!

This should fix the recent bleed desync, and we will have to find a different solution to the original issues.