### PR TITLE
Update DestroyResourceWarhead to support ResourceType and amount parameters

### DIFF
--- a/OpenRA.Mods.Common/Warheads/DestroyResourceWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DestroyResourceWarhead.cs
@@ -9,6 +9,9 @@
  */
 #endregion
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
@@ -17,10 +20,15 @@ namespace OpenRA.Mods.Common.Warheads
 {
 	public class DestroyResourceWarhead : Warhead
 	{
-		[Desc("Size of the area. The resources are seeded within this area.", "Provide 2 values for a ring effect (outer/inner).")]
+		[Desc("Size of the area. The resources are removed within this area.", "Provide 2 values for a ring effect (outer/inner).")]
 		public readonly int[] Size = { 0, 0 };
 
-		// TODO: Allow maximum resource removal to be defined. (Per tile, and in total).
+		[Desc("Amount of resources to be removed. If negative or zero, all resources within the area will be removed.")]
+		public readonly int ResourceAmount = 0;
+
+		[Desc("Resource types to remove with this warhead.", "If empty, all resource types will be removed.")]
+		public readonly HashSet<string> ResourceTypes = new HashSet<string>();
+
 		public override void DoImpact(in Target target, WarheadArgs args)
 		{
 			if (target.Type == TargetType.Invalid)
@@ -39,9 +47,20 @@ namespace OpenRA.Mods.Common.Warheads
 			var minRange = (Size.Length > 1 && Size[1] > 0) ? Size[1] : 0;
 			var allCells = world.Map.FindTilesInAnnulus(targetTile, minRange, Size[0]);
 
-			// Destroy all resources in the selected tiles
+			var removeAllTypes = ResourceTypes.Count == 0;
+
 			foreach (var cell in allCells)
-				resourceLayer.ClearResources(cell);
+			{
+				var cellContents = resourceLayer.GetResource(cell);
+
+				if (removeAllTypes || ResourceTypes.Contains(cellContents.Type))
+				{
+					if (ResourceAmount <= 0)
+						resourceLayer.ClearResources(cell);
+					else
+						resourceLayer.RemoveResource(cellContents.Type, cell, ResourceAmount);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Closes #17244 and removes the `TODO` in `DestroyResourceWarhead`.
This PR adds the possibility to
~- specify resources that are targeted by the Warhead (Testcase: Throw nuke on gems, no effect)~
- specify resource amount to remove per cell or in total (Testcase for `PerTile`: Nuke Truck, Testcase for `Total`: Nuke)

~The testcase also shows how much resource was removed in total when using the `Total` parameter to ensure that about the correct amount gets removed (Testcase: Nuke).~