### PR TITLE
Server DispatchOrdersToClients create frame once for all clients.

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -662,12 +662,14 @@ namespace OpenRA.Server
 
 		byte[] CreateFrame(int client, int frame, byte[] data)
 		{
-			var ms = new MemoryStream(data.Length + 12);
-			ms.WriteArray(BitConverter.GetBytes(data.Length + 4));
-			ms.WriteArray(BitConverter.GetBytes(client));
-			ms.WriteArray(BitConverter.GetBytes(frame));
-			ms.WriteArray(data);
-			return ms.ToArray();
+			using (var ms = new MemoryStream(data.Length + 12))
+			{
+				ms.WriteArray(BitConverter.GetBytes(data.Length + 4));
+				ms.WriteArray(BitConverter.GetBytes(client));
+				ms.WriteArray(BitConverter.GetBytes(frame));
+				ms.WriteArray(data);
+				return ms.GetBuffer();
+			}
 		}
 
 		void DispatchOrdersToClient(Connection c, int client, int frame, byte[] data)


### PR DESCRIPTION
Avoid creating frame data per client connection. Avoid
the allocation of a memory stream and setting frame header
and copying frame data.
