### PR TITLE
Fix reservable crashing when unreserving and attack moving

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
@@ -84,9 +84,11 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				if (reservedForAircraft.GetActorBelow() == self)
 				{
+					// HACK: Cache this in a local var, such that the inner activity of AttackMoveActivity can access the trait easily after reservedForAircraft was nulled
+					var aircraft = reservedForAircraft;
 					if (rallyPoint != null && rallyPoint.Path.Count > 0)
 						foreach (var cell in rallyPoint.Path)
-							reservedFor.QueueActivity(new AttackMoveActivity(reservedFor, () => reservedForAircraft.MoveTo(cell, 1, targetLineColor: Color.OrangeRed)));
+							reservedFor.QueueActivity(new AttackMoveActivity(reservedFor, () => aircraft.MoveTo(cell, 1, targetLineColor: Color.OrangeRed)));
 					else
 						reservedFor.QueueActivity(new TakeOff(reservedFor));
 				}


### PR DESCRIPTION
~~Closes #18803.~~ Closes https://github.com/OpenRA/OpenRA/issues/18801.

I actually don't have a reproduction case, since this is probably happening on some weird timing with us removing reservations in an disposable task. I reproduced this on #18039 and found out via a breakpoint that indeed `reservedForAircraft` is `null`. For testing the following can be used in a big AI game (on #18039).
```csharp
reservedFor.QueueActivity(new AttackMoveActivity(reservedFor, () =>
{
	// If we hit this debug we would have crashed on bleed
	if (reservedForAircraft == null)
		Game.Debug("oh no");

	return aircraft.MoveTo(cell, 1, targetLineColor: Color.OrangeRed);
}));
```