### PR TITLE
Fix TransformsIntoAircraft transforming on all orders

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
@@ -123,6 +123,8 @@ namespace OpenRA.Mods.Common.Traits
 
 				var targetActor = order.Target.Actor;
 			}
+			else
+				return;
 
 			var currentTransform = self.CurrentActivity as Transform;
 			var transform = transforms.FirstOrDefault(t => !t.IsTraitDisabled && !t.IsTraitPaused);

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
@@ -111,8 +111,6 @@ namespace OpenRA.Mods.Common.Traits
 				var cell = self.World.Map.Clamp(self.World.Map.CellContaining(order.Target.CenterPosition));
 				if (!Info.MoveIntoShroud && !self.Owner.Shroud.IsExplored(cell))
 					return;
-
-				var target = Target.FromCell(self.World, cell);
 			}
 			else if (order.OrderString == "Enter")
 			{
@@ -121,7 +119,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (order.Target.Type != TargetType.Actor)
 					return;
 
-				var targetActor = order.Target.Actor;
+				if (!AircraftCanEnter(order.Target.Actor))
+					return;
 			}
 			else
 				return;


### PR DESCRIPTION
If you apply the testcase to bleed, you will notice that the Turret transforms and moves to the target location not only when you give a move order, but also when you give an attack order. Closes #18813.
Testing steps on this PR:
- The Turret transforms and moves when giving a move order
- The Turret transforms and reloads when giving an enter order to a Helipad
- No transforming on orders other than move, enter or deploy