### PR TITLE
Fix building bibs not blocking placement.

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -239,6 +239,10 @@ namespace OpenRA.Traits
 
 		void UpdateOccupiedCells(IOccupySpace ios);
 		event Action<CPos> CellUpdated;
+
+		bool IsBuildingBlocked(CPos cell);
+		void AddBuildingBlocker(object blocker, IEnumerable<CPos> footprint);
+		void RemoveBuildingBlocker(object blocker);
 	}
 
 	[RequireExplicitImplementation]

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -305,11 +305,13 @@ namespace OpenRA.Mods.Common.Traits
 				RemoveSmudges();
 
 			self.World.AddToMaps(self, this);
+			self.World.ActorMap.AddBuildingBlocker(this, Info.Tiles(self.Location));
 		}
 
 		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
 		{
 			self.World.RemoveFromMaps(self, this);
+			self.World.ActorMap.RemoveBuildingBlocker(this);
 		}
 
 		void INotifySold.Selling(Actor self)

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
@@ -70,7 +70,8 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// Buildings can never be placed on ramps
-			return world.Map.Ramp[cell] == 0 && bi.TerrainTypes.Contains(world.Map.GetTerrainInfo(cell).Type);
+			return world.Map.Ramp[cell] == 0 && bi.TerrainTypes.Contains(world.Map.GetTerrainInfo(cell).Type) &&
+				!world.ActorMap.IsBuildingBlocked(cell);
 		}
 
 		public static bool CanPlaceBuilding(this World world, CPos cell, ActorInfo ai, BuildingInfo bi, Actor toIgnore)


### PR DESCRIPTION
Fixes #18816, which was regressed by #18688 removing the `BuildingInfluence` check from `BuildingUtils.IsCellBuildable`. 
Fixes #18840.

Bib cells are not added to the `ActorMap`, so were no longer being considered for blocking building placement. This PR solves the regression by adding a new set of methods to explicitly track cells that are blocked for building.