### PR TITLE
TD Veterancy Adjustment

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -51,7 +51,7 @@
 		Conditions:
 			250: rank-veteran
 			500: rank-veteran
-			800: rank-veteran
+			750: rank-veteran
 		LevelUpImage: crate-effects
 	GrantCondition@RANK-ELITE:
 		RequiresCondition: rank-veteran >= 3


### PR DESCRIPTION
Current Veterancy %'s: 250 500 800
New Veterancy %: 250 500 750

I originally set it to 800 because I wanted it to be easy to quickly calculate how much experience you needed to go heroic (300% instead of 250%).

However,

A) In a frantic game I don't have time to calculate either way
B) The consistency police are going to come and get me eventually about this
C) I wouldn't mind seeing a few more heroic units in matches

Related balance PRs: #18273, #18427, #18520, #18654, #18687