### PR TITLE
Rename several MP traits

### DIFF
--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Lint
 				if (!string.IsNullOrWhiteSpace(player.Faction) && !factions.Contains(player.Faction))
 					emitError("Invalid faction {0} chosen for player {1}.".F(player.Faction, player.Name));
 
-			if (worldActor.HasTraitInfo<MPStartLocationsInfo>())
+			if (worldActor.HasTraitInfo<MapStartingLocationsInfo>())
 			{
 				var playerCount = players.Count(p => p.Value.Playable);
 				var spawns = new List<CPos>();

--- a/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs
+++ b/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Attach this to the world actor.")]
-	public class CreateMPPlayersInfo : TraitInfo<CreateMPPlayers>, ICreatePlayersInfo
+	public class CreateMapPlayersInfo : TraitInfo<CreateMapPlayers>, ICreatePlayersInfo
 	{
 		/// <summary>
 		/// Returns a list of GameInformation.Players that matches the indexing of ICreatePlayers.CreatePlayers.
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class CreateMPPlayers : ICreatePlayers
+	public class CreateMapPlayers : ICreatePlayers
 	{
 		void ICreatePlayers.CreatePlayers(World w, MersenneTwister playerRandom)
 		{

--- a/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Allows the map to have working spawnpoints. Also controls the 'Separate Team Spawns' checkbox in the lobby options.")]
-	public class MPStartLocationsInfo : TraitInfo, ILobbyOptions, IAssignSpawnPointsInfo
+	public class MapStartingLocationsInfo : TraitInfo, ILobbyOptions, IAssignSpawnPointsInfo
 	{
 		public readonly WDist InitialExploreRange = WDist.FromCells(5);
 
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Display order for the spawn positions checkbox in the lobby.")]
 		public readonly int SeparateTeamSpawnsCheckboxDisplayOrder = 0;
 
-		public override object Create(ActorInitializer init) { return new MPStartLocations(this); }
+		public override object Create(ActorInitializer init) { return new MapStartingLocations(this); }
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
 		{
@@ -103,15 +103,15 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class MPStartLocations : IWorldLoaded, INotifyCreated, IAssignSpawnPoints
+	public class MapStartingLocations : IWorldLoaded, INotifyCreated, IAssignSpawnPoints
 	{
-		readonly MPStartLocationsInfo info;
+		readonly MapStartingLocationsInfo info;
 		readonly Dictionary<int, Session.Client> occupiedSpawnPoints = new Dictionary<int, Session.Client>();
 		bool separateTeamSpawns;
 		CPos[] spawnLocations;
 		List<int> availableSpawnPoints;
 
-		public MPStartLocations(MPStartLocationsInfo info)
+		public MapStartingLocations(MapStartingLocationsInfo info)
 		{
 			this.info = info;
 		}

--- a/OpenRA.Mods.Common/Traits/World/MapStartingUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapStartingUnits.cs
@@ -14,8 +14,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	[Desc("Used by SpawnMPUnits. Attach these to the world actor. You can have multiple variants by adding @suffixes.")]
-	public class MPStartUnitsInfo : TraitInfo<MPStartUnits>
+	[Desc("Used by SpawnStartingUnits. Attach these to the world actor. You can have multiple variants by adding @suffixes.")]
+	public class StartingUnitsInfo : TraitInfo<StartingUnits>
 	{
 		[Desc("Internal class ID.")]
 		public readonly string Class = "none";
@@ -50,5 +50,5 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly WAngle? SupportActorsFacing = null;
 	}
 
-	public class MPStartUnits { }
+	public class StartingUnits { }
 }

--- a/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Spawn base actor at the spawnpoint and support units in an annulus around the base actor. Both are defined at MPStartUnits. Attach this to the world actor.")]
-	public class SpawnMPUnitsInfo : TraitInfo, Requires<MPStartUnitsInfo>, ILobbyOptions
+	public class SpawnStartingUnitsInfo : TraitInfo, Requires<StartingUnitsInfo>, ILobbyOptions
 	{
 		public readonly string StartingUnitsClass = "none";
 
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 			var startingUnits = new Dictionary<string, string>();
 
 			// Duplicate classes are defined for different race variants
-			foreach (var t in rules.Actors["world"].TraitInfos<MPStartUnitsInfo>())
+			foreach (var t in rules.Actors["world"].TraitInfos<StartingUnitsInfo>())
 				startingUnits[t.Class] = t.ClassName;
 
 			if (startingUnits.Any())
@@ -51,14 +51,14 @@ namespace OpenRA.Mods.Common.Traits
 					new ReadOnlyDictionary<string, string>(startingUnits), StartingUnitsClass, DropdownLocked);
 		}
 
-		public override object Create(ActorInitializer init) { return new SpawnMPUnits(this); }
+		public override object Create(ActorInitializer init) { return new SpawnStartingUnits(this); }
 	}
 
-	public class SpawnMPUnits : IWorldLoaded
+	public class SpawnStartingUnits : IWorldLoaded
 	{
-		readonly SpawnMPUnitsInfo info;
+		readonly SpawnStartingUnitsInfo info;
 
-		public SpawnMPUnits(SpawnMPUnitsInfo info)
+		public SpawnStartingUnits(SpawnStartingUnitsInfo info)
 		{
 			this.info = info;
 		}
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 			var spawnClass = p.PlayerReference.StartingUnitsClass ?? w.LobbyInfo.GlobalSettings
 				.OptionOrDefault("startingunits", info.StartingUnitsClass);
 
-			var unitGroup = w.Map.Rules.Actors["world"].TraitInfos<MPStartUnitsInfo>()
+			var unitGroup = w.Map.Rules.Actors["world"].TraitInfos<StartingUnitsInfo>()
 				.Where(g => g.Class == spawnClass && g.Factions != null && g.Factions.Contains(p.Faction.InternalName))
 				.RandomOrDefault(w.SharedRandom);
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20201213/RenameMPTraits.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20201213/RenameMPTraits.cs
@@ -1,0 +1,38 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RenameMPTraits : UpdateRule
+	{
+		public override string Name { get { return "Several traits spawning map actors and players have been renamed."; } }
+
+		public override string Description
+		{
+			get
+			{
+				return "'SpawnMPUnits' was renamed to 'SpawnStartingUnits', 'MPStartUnits' to 'StartingUnits', 'MPStartLocations' to " +
+					"'MapStartingLocations', and 'CreateMPPlayers' to 'CreateMapPlayers'.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			actorNode.RenameChildrenMatching("SpawnMPUnits", "SpawnStartingUnits");
+			actorNode.RenameChildrenMatching("MPStartUnits", "StartingUnits");
+			actorNode.RenameChildrenMatching("MPStartLocations", "MapStartingLocations");
+			actorNode.RenameChildrenMatching("CreateMPPlayers", "CreateMapPlayers");
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -53,9 +53,9 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RenameRallyPointPath(),
 			}),
 
-			new UpdatePath("release-20200503", new UpdateRule[]
+			new UpdatePath("release-20200503", "playtest-20201213", new UpdateRule[]
 			{
-				// Bleed only changes here
+				// Prep only changes here
 				new AddPipDecorationTraits(),
 				new ModernizeDecorationTraits(),
 				new RenameHealCrateAction(),
@@ -79,6 +79,12 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RenameCircleContrast(),
 				new SplitDamagedByTerrain(),
 				new RemoveLaysTerrain(),
+			}),
+
+			new UpdatePath("playtest-20201213", new UpdateRule[]
+			{
+				// Bleed only changes here
+				new RenameMPTraits(),
 			})
 		};
 

--- a/mods/cnc/maps/blank-shellmap/map.yaml
+++ b/mods/cnc/maps/blank-shellmap/map.yaml
@@ -27,8 +27,8 @@ Actors:
 
 Rules:
 	World:
-		-SpawnMPUnits:
-		-MPStartLocations:
+		-SpawnStartingUnits:
+		-MapStartingLocations:
 		-CrateSpawner:
 		MusicPlaylist:
 			BackgroundMusic: map1

--- a/mods/cnc/maps/the-hot-box/rules.yaml
+++ b/mods/cnc/maps/the-hot-box/rules.yaml
@@ -7,8 +7,8 @@ World:
 		SpawnInterval: 125
 		CrateActors: unitcrate
 		InitialSpawnDelay: 0
-	-SpawnMPUnits:
-	-MPStartLocations:
+	-SpawnStartingUnits:
+	-MapStartingLocations:
 	MapBuildRadius:
 		AllyBuildRadiusCheckboxLocked: True
 		AllyBuildRadiusCheckboxEnabled: False

--- a/mods/cnc/rules/campaign-maprules.yaml
+++ b/mods/cnc/rules/campaign-maprules.yaml
@@ -1,6 +1,6 @@
 World:
-	-SpawnMPUnits:
-	-MPStartLocations:
+	-SpawnStartingUnits:
+	-MapStartingLocations:
 	-CrateSpawner:
 	ObjectivesPanel:
 		PanelName: MISSION_OBJECTIVES

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -193,51 +193,51 @@ World:
 		ShortGameCheckboxDisplayOrder: 2
 		TechLevelDropdownDisplayOrder: 2
 		GameSpeedDropdownDisplayOrder: 3
-	MPStartLocations:
+	MapStartingLocations:
 		SeparateTeamSpawnsCheckboxDisplayOrder: 6
-	CreateMPPlayers:
-	MPStartUnits@mcvonly:
+	CreateMapPlayers:
+	StartingUnits@mcvonly:
 		Class: none
 		ClassName: MCV Only
 		Factions: gdi, nod
 		BaseActor: mcv
-	MPStartUnits@defaultgdia:
+	StartingUnits@defaultgdia:
 		Class: light
 		ClassName: Light Support
 		Factions: gdi
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e1,e1,e3,e3,jeep
-	MPStartUnits@defaultnoda:
+	StartingUnits@defaultnoda:
 		Class: light
 		ClassName: Light Support
 		Factions: nod
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e1,e1,e1,e3,e3,bggy
-	MPStartUnits@heavynoda:
+	StartingUnits@heavynoda:
 		Class: heavy
 		ClassName: Heavy Support
 		Factions: nod
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e1,e3,e3,ltnk,ltnk,ftnk
-	MPStartUnits@heavynodb:
+	StartingUnits@heavynodb:
 		Class: heavy
 		ClassName: Heavy Support
 		Factions: nod
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e1,e1,e3,e3,e3,ftnk,ftnk
-	MPStartUnits@heavygdia:
+	StartingUnits@heavygdia:
 		Class: heavy
 		ClassName: Heavy Support
 		Factions: gdi
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e1,e3,e3,jeep,mtnk,mtnk
-	MPStartUnits@heavygdib:
+	StartingUnits@heavygdib:
 		Class: heavy
 		ClassName: Heavy Support
 		Factions: gdi
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e1,e1,e2,e2,e2,e3,e3,apc,mtnk
-	SpawnMPUnits:
+	SpawnStartingUnits:
 		DropdownDisplayOrder: 0
 	CrateSpawner:
 		Minimum: 1

--- a/mods/d2k/maps/shellmap/rules.yaml
+++ b/mods/d2k/maps/shellmap/rules.yaml
@@ -4,8 +4,8 @@ Player:
 
 World:
 	-CrateSpawner:
-	-SpawnMPUnits:
-	-MPStartLocations:
+	-SpawnStartingUnits:
+	-MapStartingLocations:
 	ResourceType@Spice:
 		ValuePerUnit: 0
 	ActorSpawnManager:

--- a/mods/d2k/rules/campaign-rules.yaml
+++ b/mods/d2k/rules/campaign-rules.yaml
@@ -16,8 +16,8 @@ Player:
 
 World:
 	-CrateSpawner:
-	-SpawnMPUnits:
-	-MPStartLocations:
+	-SpawnStartingUnits:
+	-MapStartingLocations:
 	ObjectivesPanel:
 		PanelName: MISSION_OBJECTIVES
 	ActorSpawnManager:

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -166,15 +166,15 @@ World:
 		ShortGameCheckboxDisplayOrder: 2
 		TechLevelDropdownDisplayOrder: 2
 		GameSpeedDropdownDisplayOrder: 3
-	CreateMPPlayers:
-	MPStartLocations:
+	CreateMapPlayers:
+	MapStartingLocations:
 		SeparateTeamSpawnsCheckboxDisplayOrder: 6
-	MPStartUnits@mcv:
+	StartingUnits@mcv:
 		Class: none
 		ClassName: MCV Only
 		BaseActor: mcv
 		Factions: atreides, ordos, harkonnen
-	MPStartUnits@lightatreides:
+	StartingUnits@lightatreides:
 		Class: light
 		ClassName: Light Support
 		Factions: atreides
@@ -182,7 +182,7 @@ World:
 		SupportActors: light_inf, light_inf, light_inf, trooper, grenadier, trike, quad
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
-	MPStartUnits@lightharkonnen:
+	StartingUnits@lightharkonnen:
 		Class: light
 		ClassName: Light Support
 		Factions: harkonnen
@@ -190,7 +190,7 @@ World:
 		SupportActors: light_inf, light_inf, light_inf, trooper, trooper, trike, quad
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
-	MPStartUnits@lightordos:
+	StartingUnits@lightordos:
 		Class: light
 		ClassName: Light Support
 		Factions: ordos
@@ -198,7 +198,7 @@ World:
 		SupportActors: light_inf, light_inf, light_inf, trooper, engineer, raider, quad
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
-	MPStartUnits@heavyatreides:
+	StartingUnits@heavyatreides:
 		Class: heavy
 		ClassName: Heavy Support
 		Factions: atreides
@@ -206,7 +206,7 @@ World:
 		SupportActors: light_inf, light_inf, light_inf, trooper, grenadier, trike, combat_tank_a, missile_tank
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
-	MPStartUnits@heavyharkonnen:
+	StartingUnits@heavyharkonnen:
 		Class: heavy
 		ClassName: Heavy Support
 		Factions: harkonnen
@@ -214,7 +214,7 @@ World:
 		SupportActors: light_inf, light_inf, light_inf, trooper, engineer, quad, combat_tank_h, siege_tank
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
-	MPStartUnits@heavyordos:
+	StartingUnits@heavyordos:
 		Class: heavy
 		ClassName: Heavy Support
 		Factions: ordos
@@ -222,7 +222,7 @@ World:
 		SupportActors: light_inf, light_inf, light_inf, trooper, engineer, raider, combat_tank_o, missile_tank
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
-	SpawnMPUnits:
+	SpawnStartingUnits:
 		DropdownDisplayOrder: 1
 	PathFinder:
 	ValidateOrder:

--- a/mods/ra/maps/bomber-john/rules.yaml
+++ b/mods/ra/maps/bomber-john/rules.yaml
@@ -3,7 +3,7 @@ World:
 		CheckboxEnabled: False
 		CheckboxLocked: True
 		CheckboxVisible: False
-	-SpawnMPUnits:
+	-SpawnStartingUnits:
 	MapBuildRadius:
 		AllyBuildRadiusCheckboxLocked: True
 		AllyBuildRadiusCheckboxEnabled: False
@@ -15,7 +15,7 @@ World:
 		TechLevelDropdownLocked: True
 		TechLevelDropdownVisible: False
 		TechLevel: unrestricted
-	MPStartLocations:
+	MapStartingLocations:
 		SeparateTeamSpawnsCheckboxVisible: false
 	Locomotor@LIGHTTRACKED:
 		WaitAverage: 1

--- a/mods/ra/maps/desert-shellmap/rules.yaml
+++ b/mods/ra/maps/desert-shellmap/rules.yaml
@@ -6,8 +6,8 @@ Player:
 
 World:
 	-CrateSpawner:
-	-SpawnMPUnits:
-	-MPStartLocations:
+	-SpawnStartingUnits:
+	-MapStartingLocations:
 	MusicPlaylist:
 		BackgroundMusic: intro
 		AllowMuteBackgroundMusic: true

--- a/mods/ra/maps/drop-zone-battle-of-tikiaki/rules.yaml
+++ b/mods/ra/maps/drop-zone-battle-of-tikiaki/rules.yaml
@@ -4,8 +4,8 @@ World:
 		SpawnInterval: 125
 		CrateActors: unitcrate
 		InitialSpawnDelay: 0
-	-SpawnMPUnits:
-	-MPStartLocations:
+	-SpawnStartingUnits:
+	-MapStartingLocations:
 	MapBuildRadius:
 		AllyBuildRadiusCheckboxVisible: False
 		BuildRadiusCheckboxVisible: False

--- a/mods/ra/maps/drop-zone-w/rules.yaml
+++ b/mods/ra/maps/drop-zone-w/rules.yaml
@@ -5,8 +5,8 @@ World:
 		WaterChance: 100
 		CrateActors: unitcrate
 		InitialSpawnDelay: 0
-	-SpawnMPUnits:
-	-MPStartLocations:
+	-SpawnStartingUnits:
+	-MapStartingLocations:
 	MapBuildRadius:
 		AllyBuildRadiusCheckboxVisible: False
 		BuildRadiusCheckboxVisible: False

--- a/mods/ra/maps/drop-zone/rules.yaml
+++ b/mods/ra/maps/drop-zone/rules.yaml
@@ -4,8 +4,8 @@ World:
 		SpawnInterval: 125
 		CrateActors: unitcrate
 		InitialSpawnDelay: 0
-	-SpawnMPUnits:
-	-MPStartLocations:
+	-SpawnStartingUnits:
+	-MapStartingLocations:
 	MapBuildRadius:
 		AllyBuildRadiusCheckboxVisible: False
 		BuildRadiusCheckboxVisible: False

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -4,7 +4,7 @@ World:
 		Maximum: 4
 		SpawnInterval: 1000
 		CrateActors: fortcrate
-	MPStartUnits@mcvonly:
+	StartingUnits@mcvonly:
 		BaseActor: tent
 	WeatherOverlay:
 		WindTick: 150, 550
@@ -31,7 +31,7 @@ World:
 	MapBuildRadius:
 		AllyBuildRadiusCheckboxVisible: False
 		BuildRadiusCheckboxVisible: False
-	SpawnMPUnits:
+	SpawnStartingUnits:
 		DropdownVisible: False
 	MapOptions:
 		TechLevelDropdownLocked: True
@@ -53,7 +53,7 @@ World:
 			endless: Endless mode
 		Default: hard
 		DisplayOrder: 5
-	MPStartLocations:
+	MapStartingLocations:
 		SeparateTeamSpawnsCheckboxEnabled: False
 		SeparateTeamSpawnsCheckboxLocked: True
 		SeparateTeamSpawnsCheckboxVisible: False

--- a/mods/ra/maps/oil-spill/rules.yaml
+++ b/mods/ra/maps/oil-spill/rules.yaml
@@ -1,9 +1,9 @@
 World:
 	LuaScript:
 		Scripts: oil-spill.lua
-	SpawnMPUnits:
+	SpawnStartingUnits:
 		DropdownVisible: False
-	MPStartUnits@mcvonly:
+	StartingUnits@mcvonly:
 		BaseActor: fcom
 
 FCOM:

--- a/mods/ra/rules/campaign-rules.yaml
+++ b/mods/ra/rules/campaign-rules.yaml
@@ -19,8 +19,8 @@ World:
 	CrateSpawner:
 		CheckboxEnabled: False
 		CheckboxLocked: True
-	-SpawnMPUnits:
-	-MPStartLocations:
+	-SpawnStartingUnits:
+	-MapStartingLocations:
 	ObjectivesPanel:
 		PanelName: MISSION_OBJECTIVES
 	MapBuildRadius:

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -220,13 +220,13 @@ World:
 		ShortGameCheckboxDisplayOrder: 2
 		TechLevelDropdownDisplayOrder: 2
 		GameSpeedDropdownDisplayOrder: 3
-	CreateMPPlayers:
-	MPStartUnits@mcvonly:
+	CreateMapPlayers:
+	StartingUnits@mcvonly:
 		Class: none
 		ClassName: MCV Only
 		Factions: allies, england, france, germany, soviet, russia, ukraine
 		BaseActor: mcv
-	MPStartUnits@lightallies:
+	StartingUnits@lightallies:
 		Class: light
 		ClassName: Light Support
 		Factions: allies, england, france, germany
@@ -234,7 +234,7 @@ World:
 		SupportActors: e1,e1,e1,e3,e3,jeep,1tnk
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
-	MPStartUnits@lightsoviet:
+	StartingUnits@lightsoviet:
 		Class: light
 		ClassName: Light Support
 		Factions: soviet, russia, ukraine
@@ -242,7 +242,7 @@ World:
 		SupportActors: e1,e1,e1,e3,e3,apc,ftrk
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
-	MPStartUnits@heavyallies:
+	StartingUnits@heavyallies:
 		Class: heavy
 		ClassName: Heavy Support
 		Factions: allies, england, france, germany
@@ -250,7 +250,7 @@ World:
 		SupportActors: e1,e1,e1,e3,e3,jeep,1tnk,2tnk,2tnk,2tnk
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
-	MPStartUnits@heavysoviet:
+	StartingUnits@heavysoviet:
 		Class: heavy
 		ClassName: Heavy Support
 		Factions: soviet, russia, ukraine
@@ -258,9 +258,9 @@ World:
 		SupportActors: e1,e1,e1,e3,e3,apc,ftrk,3tnk,3tnk
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
-	MPStartLocations:
+	MapStartingLocations:
 		SeparateTeamSpawnsCheckboxDisplayOrder: 6
-	SpawnMPUnits:
+	SpawnStartingUnits:
 		DropdownDisplayOrder: 1
 	PathFinder:
 	ValidateOrder:

--- a/mods/ts/maps/fields-of-green/rules.yaml
+++ b/mods/ts/maps/fields-of-green/rules.yaml
@@ -4,8 +4,8 @@ Player:
 World:
 	-CrateSpawner:
 	-StartGameNotification:
-	-SpawnMPUnits:
-	-MPStartLocations:
+	-SpawnStartingUnits:
+	-MapStartingLocations:
 	LuaScript:
 		Scripts: fields-of-green.lua
 	ResourceType@Tiberium:

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -293,13 +293,13 @@ World:
 		ShortGameCheckboxDisplayOrder: 2
 		TechLevelDropdownDisplayOrder: 2
 		GameSpeedDropdownDisplayOrder: 3
-	CreateMPPlayers:
-	MPStartUnits@MCV:
+	CreateMapPlayers:
+	StartingUnits@MCV:
 		Class: none
 		ClassName: MCV Only
 		Factions: gdi, nod
 		BaseActor: mcv
-	MPStartUnits@light.gdi:
+	StartingUnits@light.gdi:
 		Class: light
 		ClassName: Light
 		Factions: gdi
@@ -307,7 +307,7 @@ World:
 		SupportActors: e1,e1,e1,smech
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
-	MPStartUnits@light.nod:
+	StartingUnits@light.nod:
 		Class: light
 		ClassName: Light
 		Factions: nod
@@ -315,7 +315,7 @@ World:
 		SupportActors: e1,e1,e1,bggy
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
-	MPStartUnits@med.gdi:
+	StartingUnits@med.gdi:
 		Class: medium
 		ClassName: Medium
 		Factions: gdi
@@ -323,7 +323,7 @@ World:
 		SupportActors: e1,e1,e2,e2,jumpjet,smech
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
-	MPStartUnits@med.nod:
+	StartingUnits@med.nod:
 		Class: medium
 		ClassName: Medium
 		Factions: nod
@@ -331,7 +331,7 @@ World:
 		SupportActors: e1,e1,e3,e3,cyborg,bggy
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
-	MPStartUnits@heavy.gdi:
+	StartingUnits@heavy.gdi:
 		Class: heavy
 		ClassName: Heavy
 		Factions: gdi
@@ -339,7 +339,7 @@ World:
 		SupportActors: e1,e1,e2,e2,jumpjet,smech,smech,mmch
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
-	MPStartUnits@heavy.nod:
+	StartingUnits@heavy.nod:
 		Class: heavy
 		ClassName: Heavy
 		Factions: nod
@@ -347,9 +347,9 @@ World:
 		SupportActors: e1,e1,e3,e3,cyborg,bggy,bike,ttnk
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
-	MPStartLocations:
+	MapStartingLocations:
 		SeparateTeamSpawnsCheckboxDisplayOrder: 6
-	SpawnMPUnits:
+	SpawnStartingUnits:
 		DropdownDisplayOrder: 1
 	CrateSpawner:
 		Minimum: 1


### PR DESCRIPTION
As suggested at https://github.com/OpenRA/OpenRA/pull/18677#discussion_r523006613.
Renames:
- `SpawnMPUnits` to `SpawnStartingUnits`
- `MPStartUnits` to `MapStartingUnits`
- `MPStartLocations` to `MapStartingLocations`
- `CreateMPPlayers` to `CreateMapPlayers`