### PR TITLE
Enable dark mode support on macOS.

### DIFF
--- a/packaging/macos/Info.plist.in
+++ b/packaging/macos/Info.plist.in
@@ -46,5 +46,7 @@
 	<string>{FAQ_URL}</string>
 	<key>JoinServerUrlScheme</key>
 	<string>{JOIN_SERVER_URL_SCHEME}</string>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
Third time lucky?

The light window bar now looks even more out of place in the dark theme after the macOS 11 theme changes. I'm hoping that the switch to modern GL last release means that the odd rendering issues that this caused the last two times will no longer occur. If not, it is at least now a lot easier to revert the change.

Test build: https://github.com/pchote/OpenRA/releases/tag/devtest-20201116-3