### PR TITLE
Clean up Platform.(Un)ResolvePath usage.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -262,7 +262,7 @@ namespace OpenRA
 
 		public static void InitializeSettings(Arguments args)
 		{
-			Settings = new Settings(Platform.ResolvePath(Path.Combine(Platform.SupportDirPrefix, "settings.yaml")), args);
+			Settings = new Settings(Path.Combine(Platform.SupportDir, "settings.yaml"), args);
 		}
 
 		public static RunStatus InitializeAndRun(string[] args)
@@ -285,7 +285,7 @@ namespace OpenRA
 			// Load the engine version as early as possible so it can be written to exception logs
 			try
 			{
-				EngineVersion = File.ReadAllText(Platform.ResolvePath(Path.Combine(".", "VERSION"))).Trim();
+				EngineVersion = File.ReadAllText(Path.Combine(Platform.GameDir, "VERSION")).Trim();
 			}
 			catch { }
 
@@ -324,7 +324,7 @@ namespace OpenRA
 				Settings.Game.Platform = p;
 				try
 				{
-					var rendererPath = Platform.ResolvePath(Path.Combine(".", "OpenRA.Platforms." + p + ".dll"));
+					var rendererPath = Path.Combine(Platform.GameDir, "OpenRA.Platforms." + p + ".dll");
 					var assembly = Assembly.LoadFile(rendererPath);
 
 					var platformType = assembly.GetTypes().SingleOrDefault(t => typeof(IPlatform).IsAssignableFrom(t));
@@ -423,7 +423,7 @@ namespace OpenRA
 
 			ModData = new ModData(Mods[mod], Mods, true);
 
-			LocalPlayerProfile = new LocalPlayerProfile(Platform.ResolvePath(Path.Combine("^", Settings.Game.AuthProfile)), ModData.Manifest.Get<PlayerDatabase>());
+			LocalPlayerProfile = new LocalPlayerProfile(Path.Combine(Platform.SupportDir, Settings.Game.AuthProfile), ModData.Manifest.Get<PlayerDatabase>());
 
 			if (!ModData.LoadScreen.BeforeLoad())
 				return;
@@ -539,7 +539,7 @@ namespace OpenRA
 			using (new PerfTimer("Renderer.SaveScreenshot"))
 			{
 				var mod = ModData.Manifest.Metadata;
-				var directory = Platform.ResolvePath(Platform.SupportDirPrefix, "Screenshots", ModData.Manifest.Id, mod.Version);
+				var directory = Path.Combine(Platform.SupportDir, "Screenshots", ModData.Manifest.Id, mod.Version);
 				Directory.CreateDirectory(directory);
 
 				var filename = TimestampedFilename(true);

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -354,7 +354,7 @@ namespace OpenRA
 			var modSearchArg = args.GetValue("Engine.ModSearchPaths", null);
 			var modSearchPaths = modSearchArg != null ?
 				FieldLoader.GetValue<string[]>("Engine.ModsPath", modSearchArg) :
-				new[] { Path.Combine(".", "mods") };
+				new[] { Path.Combine(Platform.GameDir, "mods") };
 
 			Mods = new InstalledMods(modSearchPaths, explicitModPaths);
 			Console.WriteLine("Internal mods:");

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -72,13 +72,10 @@ namespace OpenRA
 				try
 				{
 					// HACK: If the path is inside the the support directory then we may need to create it
-					if (Platform.IsPathRelativeToSupportDirectory(name))
-					{
-						// Assume that the path is a directory if there is not an existing file with the same name
-						var resolved = Platform.ResolvePath(name);
-						if (!File.Exists(resolved))
-							Directory.CreateDirectory(resolved);
-					}
+					// Assume that the path is a directory if there is not an existing file with the same name
+					var resolved = Platform.ResolvePath(name);
+					if (resolved.StartsWith(Platform.SupportDir) && !File.Exists(resolved))
+						Directory.CreateDirectory(resolved);
 
 					package = modData.ModFiles.OpenPackage(name);
 				}
@@ -144,12 +141,9 @@ namespace OpenRA
 					name = name.Substring(1);
 
 				// Don't try to open the map directory in the support directory if it doesn't exist
-				if (Platform.IsPathRelativeToSupportDirectory(name))
-				{
-					var resolved = Platform.ResolvePath(name);
-					if (!Directory.Exists(resolved) || !File.Exists(resolved))
-						continue;
-				}
+				var resolved = Platform.ResolvePath(name);
+				if (resolved.StartsWith(Platform.SupportDir) && (!Directory.Exists(resolved) || !File.Exists(resolved)))
+					continue;
 
 				using (var package = (IReadWritePackage)modData.ModFiles.OpenPackage(name))
 				{

--- a/OpenRA.Game/Network/ReplayRecorder.cs
+++ b/OpenRA.Game/Network/ReplayRecorder.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Network
 		{
 			var filename = chooseFilename();
 			var mod = Game.ModData.Manifest;
-			var dir = Platform.ResolvePath(Platform.SupportDirPrefix, "Replays", mod.Id, mod.Metadata.Version);
+			var dir = Path.Combine(Platform.SupportDir, "Replays", mod.Id, mod.Metadata.Version);
 
 			if (!Directory.Exists(dir))
 				Directory.CreateDirectory(dir);

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -22,7 +22,6 @@ namespace OpenRA
 
 	public static class Platform
 	{
-		public const string SupportDirPrefix = "^";
 		public static PlatformType CurrentPlatform { get { return currentPlatform.Value; } }
 		public static readonly Guid SessionGUID = Guid.NewGuid();
 
@@ -190,7 +189,7 @@ namespace OpenRA
 			path = path.TrimEnd(' ', '\t');
 
 			// Paths starting with ^ are relative to the support dir
-			if (IsPathRelativeToSupportDirectory(path))
+			if (path.StartsWith("^", StringComparison.Ordinal))
 				path = SupportDir + path.Substring(1);
 
 			// Paths starting with . are relative to the game dir
@@ -213,7 +212,7 @@ namespace OpenRA
 			// with inconsistent drive letter case
 			var compare = CurrentPlatform == PlatformType.Windows ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 			if (path.StartsWith(SupportDir, compare))
-				path = SupportDirPrefix + path.Substring(SupportDir.Length);
+				path = "^" + path.Substring(SupportDir.Length);
 
 			if (path.StartsWith(GameDir, compare))
 				path = "./" + path.Substring(GameDir.Length);
@@ -222,11 +221,6 @@ namespace OpenRA
 				path = path.Replace('\\', '/');
 
 			return path;
-		}
-
-		public static bool IsPathRelativeToSupportDirectory(string path)
-		{
-			return path.StartsWith(SupportDirPrefix, StringComparison.Ordinal);
 		}
 	}
 }

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -203,12 +203,6 @@ namespace OpenRA
 			return path;
 		}
 
-		/// <summary>Replace special character prefixes with full paths.</summary>
-		public static string ResolvePath(params string[] path)
-		{
-			return ResolvePath(Path.Combine(path));
-		}
-
 		/// <summary>
 		/// Replace the full path prefix with the special notation characters ^ or .
 		/// and transforms \ path separators to / on Windows

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -201,26 +201,5 @@ namespace OpenRA
 
 			return path;
 		}
-
-		/// <summary>
-		/// Replace the full path prefix with the special notation characters ^ or .
-		/// and transforms \ path separators to / on Windows
-		/// </summary>
-		public static string UnresolvePath(string path)
-		{
-			// Use a case insensitive comparison on windows to avoid problems
-			// with inconsistent drive letter case
-			var compare = CurrentPlatform == PlatformType.Windows ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-			if (path.StartsWith(SupportDir, compare))
-				path = "^" + path.Substring(SupportDir.Length);
-
-			if (path.StartsWith(GameDir, compare))
-				path = "./" + path.Substring(GameDir.Length);
-
-			if (CurrentPlatform == PlatformType.Windows)
-				path = path.Replace('\\', '/');
-
-			return path;
-		}
 	}
 }

--- a/OpenRA.Game/Scripting/ScriptContext.cs
+++ b/OpenRA.Game/Scripting/ScriptContext.cs
@@ -162,7 +162,7 @@ namespace OpenRA.Scripting
 			PlayerCommands = FilterCommands(world.Map.Rules.Actors["player"], knownPlayerCommands);
 
 			runtime.Globals["GameDir"] = Platform.GameDir;
-			runtime.DoBuffer(File.Open(Platform.ResolvePath(".", "lua", "scriptwrapper.lua"), FileMode.Open, FileAccess.Read).ReadAllText(), "scriptwrapper.lua").Dispose();
+			runtime.DoBuffer(File.Open(Path.Combine(Platform.GameDir, "lua", "scriptwrapper.lua"), FileMode.Open, FileAccess.Read).ReadAllText(), "scriptwrapper.lua").Dispose();
 			tick = (LuaFunction)runtime.Globals["Tick"];
 
 			// Register globals

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -531,7 +531,7 @@ namespace OpenRA.Server
 
 						if (Type == ServerType.Dedicated)
 						{
-							var motdFile = Platform.ResolvePath(Platform.SupportDirPrefix, "motd.txt");
+							var motdFile = Path.Combine(Platform.SupportDir, "motd.txt");
 							if (!File.Exists(motdFile))
 								File.WriteAllText(motdFile, "Welcome, have fun and good luck!");
 
@@ -930,8 +930,8 @@ namespace OpenRA.Server
 								while ((invalidIndex = filename.IndexOfAny(invalidChars)) != -1)
 									filename = filename.Remove(invalidIndex, 1);
 
-								var baseSavePath = Platform.ResolvePath(
-									Platform.SupportDirPrefix,
+								var baseSavePath = Path.Combine(
+									Platform.SupportDir,
 									"Saves",
 									ModData.Manifest.Id,
 									ModData.Manifest.Metadata.Version);
@@ -958,8 +958,8 @@ namespace OpenRA.Server
 							while ((invalidIndex = filename.IndexOfAny(invalidChars)) != -1)
 								filename = filename.Remove(invalidIndex, 1);
 
-							var savePath = Platform.ResolvePath(
-								Platform.SupportDirPrefix,
+							var savePath = Path.Combine(
+								Platform.SupportDir,
 								"Saves",
 								ModData.Manifest.Id,
 								ModData.Manifest.Metadata.Version,

--- a/OpenRA.Mods.Common/UtilityCommands/CheckRuntimeAssembliesCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckRuntimeAssembliesCommand.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				.ToArray();
 
 			// Load the renderer assembly so we can check its dependencies
-			Assembly.LoadFile(Platform.ResolvePath(Path.Combine(".", "OpenRA.Platforms.Default.dll")));
+			Assembly.LoadFile(Path.Combine(Platform.GameDir, "OpenRA.Platforms.Default.dll"));
 
 			var missing = new List<string>();
 			foreach (var a in AppDomain.CurrentDomain.GetAssemblies())

--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					maps = modData.MapCache.EnumerateMapsWithoutCaching().ToList();
 				}
 				else
-					maps.Add(new Map(modData, new Folder(".").OpenPackage(args[1], modData.ModFiles)));
+					maps.Add(new Map(modData, new Folder(Platform.GameDir).OpenPackage(args[1], modData.ModFiles)));
 
 				foreach (var testMap in maps)
 				{

--- a/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			var palette = new ImmutablePalette(args[1], new int[0]);
 
 			SequenceProvider sequences = null;
-			var mapPackage = new Folder(".").OpenPackage(args[2], modData.ModFiles);
+			var mapPackage = new Folder(Platform.GameDir).OpenPackage(args[2], modData.ModFiles);
 			if (mapPackage != null)
 				sequences = new Map(modData, mapPackage).Rules.Sequences;
 			else if (!modData.DefaultSequences.TryGetValue(args[2], out sequences))

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractLanguageStringsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractLanguageStringsCommand.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			{
 				modData.ModFiles.TryGetPackageContaining(filename, out var package, out var name);
 				name = package.Name + "/" + name;
-				Console.WriteLine("# {0}:", Platform.UnresolvePath(name));
+				Console.WriteLine("# {0}:", filename);
 
 				var yaml = MiniYaml.FromFile(name, false);
 				FromChromeLayout(ref yaml, null,

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractMapRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractMapRules.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		{
 			var modData = Game.ModData = utility.ModData;
 
-			var map = new Map(modData, new Folder(".").OpenPackage(args[1], modData.ModFiles));
+			var map = new Map(modData, new Folder(Platform.GameDir).OpenPackage(args[1], modData.ModFiles));
 			MergeAndPrint(map, "Rules", map.RuleDefinitions);
 			MergeAndPrint(map, "Sequences", map.SequenceDefinitions);
 			MergeAndPrint(map, "ModelSequences", map.ModelSequenceDefinitions);

--- a/OpenRA.Mods.Common/UtilityCommands/GetMapHashCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/GetMapHashCommand.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		[Desc("MAPFILE", "Generate hash of specified oramap file.")]
 		void IUtilityCommand.Run(Utility utility, string[] args)
 		{
-			using (var package = new Folder(".").OpenPackage(args[1], utility.ModData.ModFiles))
+			using (var package = new Folder(Platform.GameDir).OpenPackage(args[1], utility.ModData.ModFiles))
 				Console.WriteLine(Map.ComputeUID(package));
 		}
 	}

--- a/OpenRA.Mods.Common/UtilityCommands/RefreshMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/RefreshMapCommand.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			// HACK: The engine code assumes that Game.modData is set.
 			// HACK: We know that maps can only be oramap or folders, which are ReadWrite
 			var modData = Game.ModData = utility.ModData;
-			using (var package = new Folder(".").OpenPackage(args[1], modData.ModFiles))
+			using (var package = new Folder(Platform.GameDir).OpenPackage(args[1], modData.ModFiles))
 				new Map(modData, package).Save((IReadWritePackage)package);
 		}
 	}

--- a/OpenRA.Mods.Common/UtilityCommands/ResizeMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ResizeMapCommand.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		void IUtilityCommand.Run(Utility utility, string[] args)
 		{
 			var modData = Game.ModData = utility.ModData;
-			map = new Map(modData, new Folder(".").OpenPackage(args[1], modData.ModFiles));
+			map = new Map(modData, new Folder(Platform.GameDir).OpenPackage(args[1], modData.ModFiles));
 			Console.WriteLine("Resizing map {0} from {1} to {2},{3}", map.Title, map.MapSize, width, height);
 			map.Resize(width, height);
 

--- a/OpenRA.Mods.Common/UtilityCommands/UpdateMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpdateMapCommand.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			var modData = Game.ModData = utility.ModData;
 
 			// HACK: We know that maps can only be oramap or folders, which are ReadWrite
-			var package = new Folder(".").OpenPackage(args[1], modData.ModFiles) as IReadWritePackage;
+			var package = new Folder(Platform.GameDir).OpenPackage(args[1], modData.ModFiles) as IReadWritePackage;
 			if (package == null)
 				throw new FileNotFoundException(args[1]);
 

--- a/OpenRA.Mods.Common/UtilityCommands/Utilities.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/Utilities.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			{
 				try
 				{
-					map = new Map(modData, new Folder(".").OpenPackage(mapPath, modData.ModFiles));
+					map = new Map(modData, new Folder(Platform.GameDir).OpenPackage(mapPath, modData.ModFiles));
 				}
 				catch (InvalidDataException ex)
 				{

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -34,10 +34,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			public readonly string DisplayName;
 			public readonly MapClassification Classification;
 
-			public SaveDirectory(Folder folder, MapClassification classification)
+			public SaveDirectory(Folder folder, string displayName, MapClassification classification)
 			{
 				Folder = folder;
-				DisplayName = Platform.UnresolvePath(Folder.Name);
+				DisplayName = displayName;
 				Classification = classification;
 			}
 		}
@@ -103,7 +103,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							// Do nothing: we just want to test whether we can create the file
 						}
 
-						writableDirectories.Add(new SaveDirectory(folder, kv.Value));
+						writableDirectories.Add(new SaveDirectory(folder, kv.Value.ToString(), kv.Value));
 					}
 					catch
 					{

--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var newTemplate = panel.Get<ScrollItemWidget>("NEW_TEMPLATE");
 
 			var mod = modData.Manifest;
-			baseSavePath = Platform.ResolvePath(Platform.SupportDirPrefix, "Saves", mod.Id, mod.Metadata.Version);
+			baseSavePath = Path.Combine(Platform.SupportDir, "Saves", mod.Id, mod.Metadata.Version);
 
 			// Avoid filename conflicts when creating new saves
 			if (isSavePanel)
@@ -304,8 +304,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void Save(World world)
 		{
 			var filename = saveTextField.Text + ".orasav";
-			var testPath = Platform.ResolvePath(
-				Platform.SupportDirPrefix,
+			var testPath = Path.Combine(
+				Platform.SupportDir,
 				"Saves",
 				modData.Manifest.Id,
 				modData.Manifest.Metadata.Version,
@@ -351,7 +351,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		public static bool IsLoadPanelEnabled(Manifest mod)
 		{
-			var baseSavePath = Platform.ResolvePath(Platform.SupportDirPrefix, "Saves", mod.Id, mod.Metadata.Version);
+			var baseSavePath = Path.Combine(Platform.SupportDir, "Saves", mod.Id, mod.Metadata.Version);
 			if (!Directory.Exists(baseSavePath))
 				return false;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -264,7 +264,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			if (newsBG != null && Game.Settings.Game.FetchNews)
 			{
-				var cacheFile = Platform.ResolvePath(Platform.SupportDirPrefix, webServices.GameNewsFileName);
+				var cacheFile = Path.Combine(Platform.SupportDir, webServices.GameNewsFileName);
 				var currentNews = ParseNews(cacheFile);
 				if (currentNews != null)
 					DisplayNews(currentNews);

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var template = panel.Get<ScrollItemWidget>("REPLAY_TEMPLATE");
 
 			var mod = modData.Manifest;
-			var dir = Platform.ResolvePath(Platform.SupportDirPrefix, "Replays", mod.Id, mod.Metadata.Version);
+			var dir = Path.Combine(Platform.SupportDir, "Replays", mod.Id, mod.Metadata.Version);
 
 			if (Directory.Exists(dir))
 				ThreadPool.QueueUserWorkItem(_ => LoadReplays(dir, template));

--- a/OpenRA.Server/Program.cs
+++ b/OpenRA.Server/Program.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Server
 			var envModSearchPaths = Environment.GetEnvironmentVariable("MOD_SEARCH_PATHS");
 			var modSearchPaths = !string.IsNullOrWhiteSpace(envModSearchPaths) ?
 				FieldLoader.GetValue<string[]>("MOD_SEARCH_PATHS", envModSearchPaths) :
-				new[] { Path.Combine(".", "mods") };
+				new[] { Path.Combine(Platform.GameDir, "mods") };
 
 			var mods = new InstalledMods(modSearchPaths, explicitModPaths);
 

--- a/OpenRA.Test/OpenRA.Game/PlatformTest.cs
+++ b/OpenRA.Test/OpenRA.Game/PlatformTest.cs
@@ -45,18 +45,5 @@ namespace OpenRA.Test
 			Assert.That(Platform.ResolvePath("testpath"),
 				Is.EqualTo("testpath"));
 		}
-
-		[TestCase(TestName = "Returns encoded paths")]
-		public void UnresolvePath()
-		{
-			Assert.That(Platform.UnresolvePath(Path.Combine(supportDir, "testpath")),
-				Is.EqualTo("^testpath"));
-
-			Assert.That(Platform.UnresolvePath(Path.Combine(gameDir, "testpath")),
-				Is.EqualTo("./testpath"));
-
-			Assert.That(Platform.UnresolvePath("testpath"),
-				Is.EqualTo("testpath"));
-		}
 	}
 }

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -48,7 +48,7 @@ namespace OpenRA
 			var envModSearchPaths = Environment.GetEnvironmentVariable("MOD_SEARCH_PATHS");
 			var modSearchPaths = !string.IsNullOrWhiteSpace(envModSearchPaths) ?
 				FieldLoader.GetValue<string[]>("MOD_SEARCH_PATHS", envModSearchPaths) :
-				new[] { Path.Combine(".", "mods") };
+				new[] { Path.Combine(Platform.GameDir, "mods") };
 
 			if (args.Length == 0)
 			{

--- a/packaging/windows/WindowsLauncher.cs.in
+++ b/packaging/windows/WindowsLauncher.cs.in
@@ -178,7 +178,7 @@ namespace OpenRA
 		{
 			try
 			{
-				Process.Start(Platform.ResolvePath("^", "Logs"));
+				Process.Start(Path.Combine(Platform.SupportDir, "Logs"));
 			}
 			catch { }
 		}


### PR DESCRIPTION
This PR implements a scaled-back version of my original plan to clean up path resolving. `Platform.ResolvePath` is kept for now, but most unnecessary uses are removed. `Platform.UnresolvePath` and `Platform.IsPathRelativeToSupportDirectory` are completely removed, and a more robust solution for the editor/asset browser display name issue (see #18505/#18526) is implemented.

This should be simple enough to review if you go commit by commit. The plan is to follow this up with a second PR to rework the magic path prefixes so that we can merge @teinarss's project bin dir changes before we tag the playtest.