### PR TITLE
Add a utility.sh development helper

### DIFF
--- a/utility.sh
+++ b/utility.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+ENGINE_DIR=.. mono --debug bin/OpenRA.Utility.exe $@


### PR DESCRIPTION
Followup to #18846, this PR adds a simple wrapper script to simplify calling the utility from the bin directory.

~The second commit adds a minor cleanup that fixes the Linux packaging on recent distros that have unshipped python2.~ &rarr; moved to #18865.