### PR TITLE
Replace chan with c10 in actors spawned from selling RA tech buildings

### DIFF
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -712,7 +712,7 @@
 ^ScienceBuilding:
 	Inherits: ^Building
 	SpawnActorsOnSell:
-		ActorTypes: e1,e1,e1,e1,tecn,tecn2,tecn,tecn2,tecn,tecn2,tecn,tecn2,tecn,tecn2,e6,e6,e6,e6,e6,chan,chan,chan,chan
+		ActorTypes: e1,e1,e1,e1,tecn,tecn2,tecn,tecn2,tecn,tecn2,tecn,tecn2,tecn,tecn2,e6,e6,e6,e6,e6,c10,c10,c10,c10
 
 ^Defense:
 	Inherits: ^Building


### PR DESCRIPTION
`chan` is worth 500, which essentially means they take the spot of an engineer, and give 50 kill bounty. `c10` has the value of a normal civilian (10), is still visually distinct (looking similar to `chan`) and also called `Scientist`.