### PR TITLE
ST Death Explosion Change

### DIFF
--- a/mods/cnc/rules/husks.yaml
+++ b/mods/cnc/rules/husks.yaml
@@ -133,6 +133,9 @@ STNK.Husk:
 		IntoActor: stnk
 	RenderSprites:
 		Image: stnk.destroyed
+	Explodes:
+		Weapon: UnitExplodeStealthTank
+		EmptyWeapon: UnitExplodeStealthTank
 
 TRUCK.Husk:
 	Inherits: ^LightHusk

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -643,6 +643,8 @@ STNK:
 		Locomotor: heavywheeled
 		TurnSpeed: 40
 		Speed: 142
+	Targetable:
+		TargetTypes: Ground, Vehicle, StealthTank
 	Health:
 		HP: 15000
 	Repairable:
@@ -671,6 +673,9 @@ STNK:
 	AutoTarget:
 		InitialStance: HoldFire
 		InitialStanceAI: ReturnFire
+	Explodes:
+		Weapon: UnitExplodeStealthTank
+		EmptyWeapon: UnitExplodeStealthTank
 	SpawnActorOnDeath:
 		Actor: STNK.Husk
 		OwnerType: InternalName

--- a/mods/cnc/weapons/explosions.yaml
+++ b/mods/cnc/weapons/explosions.yaml
@@ -74,6 +74,11 @@ UnitExplodeSmall:
 		Explosions: big_frag
 		ImpactSounds: xplobig4.aud
 
+UnitExplodeStealthTank:
+	Inherits: UnitExplodeSmall
+	Warhead@1Dam: SpreadDamage
+		InvalidTargets: StealthTank
+
 GrenadierExplode:
 	Inherits: ^DamagingExplosionHE
 	Warhead@1Dam: SpreadDamage


### PR DESCRIPTION
So, now that stealth tanks uncloak on damage (#18654), when one dies it reveals the others in the pack (due to all units possessing a small death explosion).

I wasn't sure on the impact of this, but after testing I'm pretty sure this is undesirable. The main thing is it's just *annoying*, which I've heard repeated by other players. There's a small micro trick you can do to pull away the uncloaked stealth tank from the pack, but I find you often don't have time to do it(it also doesn't help the explosion reaches more than 1 cell away).

It really punishes groups of stealth tanks and overall made them weaker than I was intending.

Now, there's a few different routes to fixing this, and it depends on how targeted the fix is. I ended up electing to be the least disruptive as possible. The only change here is that the stealth tank explosion no longer affects other vehicles on death (husk explosion is still same as normal). This prevents the above, while still preserving the aesthetic (everything explodes in TD) and infantry will still go prone.

Of course this is an exception, which I'm not a huge fan of, but of the available options it seemed the best to me. I am open to alternatives.