### PR TITLE
Evaluate exit distance from the exit cell instead of the spawn position.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 			// called on the same exits in the same order!
 			var all = Exits(actor, productionType)
 				.OrderBy(e => e.Info.Priority)
-				.ThenBy(e => (actor.CenterPosition + e.Info.SpawnOffset - pos).Length)
+				.ThenBy(e => (actor.World.Map.CenterOfCell(actor.Location + e.Info.ExitCell) - pos).LengthSquared)
 				.ToList();
 
 			return p != null ? all.FirstOrDefault(p) : all.FirstOrDefault();


### PR DESCRIPTION
As discussed on discord. The exit cell is more logical, and makes for better gameplay if structures have spawn-exit paths that cross a cell boundary.