### PR TITLE
Overhaul packaging scripts and helpers

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,8 +21,7 @@ after_test:
   - move  /Y %APPVEYOR_BUILD_FOLDER%\bin\* %APPVEYOR_BUILD_FOLDER%
   - if defined APPVEYOR_REPO_TAG_NAME set VERSION=%APPVEYOR_REPO_TAG_NAME%
   - if not defined APPVEYOR_REPO_TAG_NAME set VERSION=%APPVEYOR_REPO_COMMIT:~0,7%
-  - '"C:\Program Files (x86)\NSIS\makensis.exe" /DSRCDIR="%APPVEYOR_BUILD_FOLDER%" /DTAG="git-%VERSION%" /DSUFFIX=" (dev)" /V3 packaging/windows/OpenRA.nsi'
-  - move /Y %APPVEYOR_BUILD_FOLDER%\packaging\windows\OpenRA.Setup.exe %APPVEYOR_BUILD_FOLDER%\OpenRA-%VERSION%.exe
+  - '"C:\Program Files (x86)\NSIS\makensis.exe" /DSRCDIR="%APPVEYOR_BUILD_FOLDER%" /DTAG="git-%VERSION%" /DSUFFIX=" (dev)" /V3 /DOUTFILE="OpenRA-$(VERSION).exe" packaging/windows/OpenRA.nsi'
 
 artifacts:
   - path: OpenRA-$(VERSION).exe

--- a/packaging/functions.sh
+++ b/packaging/functions.sh
@@ -1,0 +1,332 @@
+#!/bin/sh
+# Helper functions for packaging and installing OpenRA
+
+####
+# This file must stay /bin/sh and POSIX compliant for macOS and BSD portability.
+# Copy-paste the entire script into http://shellcheck.net to check.
+####
+
+# Compile and publish (using Mono) the core engine and specified mod assemblies to the target directory
+# Arguments:
+#   SRC_PATH: Path to the root OpenRA directory
+#   DEST_PATH: Path to the root of the install destination (will be created if necessary)
+#   TARGETPLATFORM: Platform type (win-x86, win-x64, osx-x64, linux-x64, unix-generic)
+#   COPY_GENERIC_LAUNCHER: If set to True the OpenRA.exe will also be copied (True, False)
+#   COPY_CNC_DLL: If set to True the OpenRA.Mods.Cnc.dll will also be copied (True, False)
+#   COPY_D2K_DLL: If set to True the OpenRA.Mods.D2k.dll and OpenRA.Mods.Cnc.dll will also be copied (True, False)
+# Used by:
+#   Makefile (install target for local installs and downstream packaging)
+#   Linux AppImage packaging
+#   macOS packaging
+#   Windows packaging
+#   Mod SDK Linux AppImage packaging
+#   Mod SDK macOS packaging
+#   Mod SDK Windows packaging
+install_assemblies_mono() {
+	SRC_PATH="${1}"
+	DEST_PATH="${2}"
+	TARGETPLATFORM="${3}"
+	COPY_GENERIC_LAUNCHER="${4}"
+	COPY_CNC_DLL="${5}"
+	COPY_D2K_DLL="${6}"
+
+	echo "Building assemblies"
+	ORIG_PWD=$(pwd)
+	cd "${SRC_PATH}" || exit 1
+	msbuild -verbosity:m -nologo -t:Clean
+	rm -rf "${SRC_PATH:?}/bin"
+	msbuild -verbosity:m -nologo -t:Build -restore -p:Configuration=Release -p:TargetPlatform="${TARGETPLATFORM}"
+	if [ "${TARGETPLATFORM}" = "unix-generic" ]; then
+		./configure-system-libraries.sh
+	fi
+
+	./fetch-geoip.sh
+	cd "${ORIG_PWD}" || exit 1
+
+	echo "Installing engine to ${DEST_PATH}"
+	install -d "${DEST_PATH}"
+
+	# Core engine
+	install -m755 "${SRC_PATH}/bin/OpenRA.Server.exe" "${DEST_PATH}"
+	install -m755 "${SRC_PATH}/bin/OpenRA.Utility.exe" "${DEST_PATH}"
+	install -m644 "${SRC_PATH}/bin/OpenRA.Game.dll" "${DEST_PATH}"
+	install -m644 "${SRC_PATH}/bin/OpenRA.Platforms.Default.dll" "${DEST_PATH}"
+	if [ "${COPY_GENERIC_LAUNCHER}" = "True" ]; then
+		install -m755 "${SRC_PATH}/bin/OpenRA.exe" "${DEST_PATH}"
+	fi
+
+	# Mod dlls
+	install -m644 "${SRC_PATH}/bin/OpenRA.Mods.Common.dll" "${DEST_PATH}"
+	if [ "${COPY_CNC_DLL}" = "True" ]; then
+		install -m644 "${SRC_PATH}/bin/OpenRA.Mods.Cnc.dll" "${DEST_PATH}"
+	fi
+
+	if [ "${COPY_D2K_DLL}" = "True" ]; then
+		install -m644 "${SRC_PATH}/bin/OpenRA.Mods.D2k.dll" "${DEST_PATH}"
+	fi
+
+	# Managed Dependencies
+	for LIB in ICSharpCode.SharpZipLib.dll FuzzyLogicLibrary.dll Open.Nat.dll BeaconLib.dll DiscordRPC.dll Newtonsoft.Json.dll SDL2-CS.dll OpenAL-CS.Core.dll Eluant.dll; do
+		install -m644 "${SRC_PATH}/bin/${LIB}" "${DEST_PATH}"
+	done
+
+	# Native dependencies
+	if [ "${TARGETPLATFORM}" = "win-x86" ] || [ "${TARGETPLATFORM}" = "win-x64" ]; then
+		echo "Installing dependencies for ${TARGETPLATFORM} to ${DEST_PATH}"
+		for LIB in soft_oal.dll SDL2.dll freetype6.dll lua51.dll libEGL.dll libGLESv2.dll; do
+			install -m644 "${SRC_PATH}/bin/${LIB}" "${DEST_PATH}"
+		done
+	else
+		for LIB in OpenRA.Platforms.Default.dll.config SDL2-CS.dll.config OpenAL-CS.Core.dll.config Eluant.dll.config; do
+			install -m644 "${SRC_PATH}/bin/${LIB}" "${DEST_PATH}"
+		done
+	fi
+
+	if [ "${TARGETPLATFORM}" = "linux-x64" ]; then
+		echo "Installing dependencies for ${TARGETPLATFORM} to ${DEST_PATH}"
+		for LIB in soft_oal.so SDL2.so freetype6.so lua51.so; do
+			install -m755 "${SRC_PATH}/bin/${LIB}" "${DEST_PATH}"
+		done
+	fi
+
+	if [ "${TARGETPLATFORM}" = "osx-x64" ]; then
+		echo "Installing dependencies for ${TARGETPLATFORM} to ${DEST_PATH}"
+		for LIB in soft_oal.dylib SDL2.dylib freetype6.dylib lua51.dylib; do
+			install -m755 "${SRC_PATH}/bin/${LIB}" "${DEST_PATH}"
+		done
+	fi
+}
+
+# Copy the core engine and specified mod data to the target directory
+# Arguments:
+#   SRC_PATH: Path to the root OpenRA directory
+#   DEST_PATH: Path to the root of the install destination (will be created if necessary)
+#   MOD [MOD...]: One or more mod ids to copy (cnc, d2k, ra)
+# Used by:
+#   Makefile (install target for local installs and downstream packaging)
+#   Linux AppImage packaging
+#   macOS packaging
+#   Windows packaging
+#   Mod SDK Linux AppImage packaging
+#   Mod SDK macOS packaging
+#   Mod SDK Windows packaging
+install_data() {
+	SRC_PATH="${1}"
+	DEST_PATH="${2}"
+	shift 2
+
+	echo "Installing engine files to ${DEST_PATH}"
+	for FILE in VERSION AUTHORS COPYING IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP "global mix database.dat"; do
+		install -m644 "${SRC_PATH}/${FILE}" "${DEST_PATH}"
+	done
+
+	cp -r "${SRC_PATH}/glsl" "${DEST_PATH}"
+	cp -r "${SRC_PATH}/lua" "${DEST_PATH}"
+
+	echo "Installing common mod files to ${DEST_PATH}"
+	install -d "${DEST_PATH}/mods"
+	cp -r "${SRC_PATH}/mods/common" "${DEST_PATH}/mods/"
+
+	while [ -n "${1}" ]; do
+		MOD_ID="${1}"
+		if [ "${MOD_ID}" = "ra" ] || [ "${MOD_ID}" = "cnc" ] || [ "${MOD_ID}" = "d2k" ]; then
+			echo "Installing mod ${MOD_ID} to ${DEST_PATH}"
+			cp -r "${SRC_PATH}/mods/${MOD_ID}" "${DEST_PATH}/mods/"
+			cp -r "${SRC_PATH}/mods/modcontent" "${DEST_PATH}/mods/"
+		fi
+
+		shift
+	done
+}
+
+# Compile and publish (using Mono) a windows launcher with the specified mod details to the target directory
+# Arguments:
+#   SRC_PATH: Path to the root OpenRA directory
+#   DEST_PATH: Path to the root of the install destination (will be created if necessary)
+#   TARGETPLATFORM: Platform type (win-x86, win-x64)
+#   MOD_ID: Mod id to launch (e.g. "ra")
+#   LAUNCHER_NAME: Filename (without the .exe extension) for the launcher
+#   MOD_NAME: Human-readable mod name to show in the crash dialog (e.g. "Red Alert")
+#   ICON_PATH: Path to a windows .ico file
+#   FAQ_URL: URL to load when the "View FAQ" button is pressed in the crash dialog (e.g. https://wiki.openra.net/FAQ)
+# Used by:
+#   Windows packaging
+#   Mod SDK Windows packaging
+install_windows_launcher()
+{
+	SRC_PATH="${1}"
+	DEST_PATH="${2}"
+	TARGETPLATFORM="${3}"
+	MOD_ID="${4}"
+	LAUNCHER_NAME="${5}"
+	MOD_NAME="${6}"
+	ICON_PATH="${7}"
+	FAQ_URL="${8}"
+
+	msbuild -verbosity:m -nologo -t:Clean "${SRC_PATH}/OpenRA.WindowsLauncher/OpenRA.WindowsLauncher.csproj"
+	rm -rf "${SRC_PATH:?}/bin"
+	msbuild -t:Build "${SRC_PATH}/OpenRA.WindowsLauncher/OpenRA.WindowsLauncher.csproj" -restore -p:Configuration=Release -p:TargetPlatform="${TARGETPLATFORM}" -p:LauncherName="${LAUNCHER_NAME}" -p:LauncherIcon="${ICON_PATH}" -p:ModID="${MOD_ID}" -p:DisplayName="${MOD_NAME}" -p:FaqUrl="${FAQ_URL}"
+	install -m755 "${SRC_PATH}/bin/${LAUNCHER_NAME}.exe" "${DEST_PATH}"
+	install -m644 "${SRC_PATH}/bin/${LAUNCHER_NAME}.exe.config" "${DEST_PATH}"
+
+	# Enable the full 4GB address space for the 32 bit game executable
+	# The server and utility do not use enough memory to need this
+	if [ "${TARGETPLATFORM}" = "win-x86" ]; then
+		python3 "${SRC_PATH}/packaging/windows/MakeLAA.py" "${DEST_PATH}/${LAUNCHER_NAME}.exe"
+	fi
+}
+
+# Write a version string to the engine VERSION file
+# Arguments:
+#   VERSION: OpenRA version string
+#   DEST_PATH: Path to the root of the install destination
+# Used by:
+#   Makefile (install target for local installs and downstream packaging)
+#   Linux AppImage packaging
+#   macOS packaging
+#   Windows packaging
+#   Mod SDK Linux AppImage packaging
+#   Mod SDK macOS packaging
+#   Mod SDK Windows packaging
+set_engine_version() {
+	VERSION="${1}"
+	DEST_PATH="${2}"
+	echo "${VERSION}" > "${DEST_PATH}/VERSION"
+}
+
+# Write a version string to a list of specified mod.yamls
+# Arguments:
+#   VERSION: OpenRA version string
+#   MOD_YAML_PATH [MOD_YAML_PATH...]: One or more mod.yaml files to update
+# Used by:
+#   Makefile (install target for local installs and downstream packaging)
+#   Linux AppImage packaging
+#   macOS packaging
+#   Windows packaging
+#   Mod SDK Linux AppImage packaging
+#   Mod SDK macOS packaging
+#   Mod SDK Windows packaging
+set_mod_version() {
+	VERSION="${1}"
+	shift
+	while [ -n "${1}" ]; do
+		MOD_YAML_PATH="${1}"
+		awk -v v="${VERSION}" '{sub("Version:.*$", "Version: " v); print $0}' "${MOD_YAML_PATH}" > "${MOD_YAML_PATH}.tmp"
+		awk -v v="${VERSION}" '{sub("/[^/]*: User$", "/"v ": User"); print $0}' "${MOD_YAML_PATH}.tmp" > "${MOD_YAML_PATH}"
+		rm "${MOD_YAML_PATH}.tmp"
+		shift
+	done
+}
+
+# Copy launch wrappers, application icons, desktop, and MIME files to the target directory
+# Arguments:
+#   SRC_PATH: Path to the root OpenRA directory
+#   OPENRA_PATH: Path to the OpenRA installation (e.g. /usr/local/lib/openra)
+#   BIN_PATH: Path to install wrapper scripts (e.g. /usr/local/bin)
+#   SHARE_PATH: Parent path to the icons and applications directory (e.g. /usr/local/share)
+#   VERSION: OpenRA version string
+#   MOD [MOD...]: One or more mod ids to copy (cnc, d2k, ra)
+# Used by:
+#   Makefile (install-linux-shortcuts target for local installs and downstream packaging)
+install_linux_shortcuts() {
+	SRC_PATH="${1}"
+	OPENRA_PATH="${2}"
+	BIN_PATH="${3}"
+	SHARE_PATH="${4}"
+	VERSION="${5}"
+	shift 5
+
+	while [ -n "${1}" ]; do
+		MOD_ID="${1}"
+		if [ "${MOD_ID}" = "ra" ] || [ "${MOD_ID}" = "cnc" ] || [ "${MOD_ID}" = "d2k" ]; then
+			if [ "${MOD_ID}" = "cnc" ]; then
+				MOD_NAME="Tiberian Dawn"
+			fi
+
+			if [ "${MOD_ID}" = "d2k" ]; then
+				MOD_NAME="Dune 2000"
+			fi
+
+			if [ "${MOD_ID}" = "ra" ]; then
+				MOD_NAME="Red Alert"
+			fi
+
+			# bin wrappers
+			install -d "${DEST_PATH}/bin"
+
+			sed 's/{DEBUG}/--debug/' "${SRC_PATH}/packaging/linux/openra.in" | sed "s|{GAME_INSTALL_DIR}|${OPENRA_PATH}|" | sed "s|{BIN_DIR}|${DEST_PATH}/bin)|" | sed "s/{MODID}/${MOD_ID}/g" | sed "s/{TAG}/${VERSION}/g" | sed "s/{MODNAME}/${MOD_NAME}/g" > "${SRC_PATH}/packaging/linux/openra-${MOD_ID}"
+			sed 's/{DEBUG}/--debug/' "${SRC_PATH}/packaging/linux/openra-server.in" | sed "s|{GAME_INSTALL_DIR}|${OPENRA_PATH}|" | sed "s/{MODID}/${MOD_ID}/g" > "${SRC_PATH}/packaging/linux/openra-${MOD_ID}-server"
+			install -m755 "${SRC_PATH}/packaging/linux/openra-${MOD_ID}" "${BIN_PATH}"
+			install -m755 "${SRC_PATH}/packaging/linux/openra-${MOD_ID}-server" "${BIN_PATH}"
+			rm "${SRC_PATH}/packaging/linux/openra-${MOD_ID}" "${SRC_PATH}/packaging/linux/openra-${MOD_ID}-server"
+
+			# desktop files
+			install -d "${SHARE_PATH}/applications"
+			sed "s/{MODID}/${MOD_ID}/g" "${SRC_PATH}/packaging/linux/openra.desktop.in" | sed "s/{MODNAME}/${MOD_NAME}/g" | sed "s/{TAG}/${VERSION}/g" > "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.desktop"
+			install -m644 "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.desktop" "${SHARE_PATH}/applications"
+			rm "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.desktop"
+
+			# icons
+			for SIZE in 16x16 32x32 48x48 64x64 128x128; do
+				install -d "${SHARE_PATH}/icons/hicolor/${SIZE}/apps"
+				install -m644 "${SRC_PATH}/packaging/artwork/${MOD_ID}_${SIZE}.png" "${SHARE_PATH}/icons/hicolor/${SIZE}/apps/openra-${MOD_ID}.png"
+			done
+
+			if [ "${MOD_ID}" = "ra" ] || [ "${MOD_ID}" = "cnc" ]; then
+				install -d "${SHARE_PATH}/icons/hicolor/scalable/apps"
+				install -m644 "${SRC_PATH}/packaging/artwork/${MOD_ID}_scalable.svg" "${SHARE_PATH}/icons/hicolor/scalable/apps/openra-${MOD_ID}.svg"
+			fi
+
+			# MIME info
+			install -d "${SHARE_PATH}/mime/packages"
+			sed "s/{MODID}/${MOD_ID}/g" "${SRC_PATH}/packaging/linux/openra-mimeinfo.xml.in" | sed "s/{TAG}/${VERSION}/g" > "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.xml"
+			install -m644 "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.xml" "${SHARE_PATH}/mime/packages/openra-${MOD_ID}.xml"
+			rm "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.xml"
+		fi
+
+		shift
+	done
+}
+
+# Copy AppStream metadata to the target directory
+# Arguments:
+#   SRC_PATH: Path to the root OpenRA directory
+#   SHARE_PATH: Parent path to the appdata directory (e.g. /usr/local/share)
+#   MOD [MOD...]: One or more mod ids to copy (cnc, d2k, ra)
+# Used by:
+#   Makefile (install-linux-appdata target for local installs and downstream packaging)
+install_linux_appdata() {
+	SRC_PATH="${1}"
+	SHARE_PATH="${2}"
+	shift 2
+	while [ -n "${1}" ]; do
+		MOD_ID="${1}"
+		SCREENSHOT_CNC=
+		SCREENSHOT_D2K=
+		SCREENSHOT_RA=
+		if [ "${MOD_ID}" = "ra" ] || [ "${MOD_ID}" = "cnc" ] || [ "${MOD_ID}" = "d2k" ]; then
+			if [ "${MOD_ID}" = "cnc" ]; then
+				MOD_NAME="Tiberian Dawn"
+				SCREENSHOT_CNC=" type=\"default\""
+			fi
+
+			if [ "${MOD_ID}" = "d2k" ]; then
+				MOD_NAME="Dune 2000"
+				SCREENSHOT_D2K=" type=\"default\""
+			fi
+
+			if [ "${MOD_ID}" = "ra" ]; then
+				MOD_NAME="Red Alert"
+				SCREENSHOT_RA=" type=\"default\""
+			fi
+		fi
+
+		install -d "${SHARE_PATH}/appdata"
+
+		sed "s/{MODID}/${MOD_ID}/g" "${SRC_PATH}/packaging/linux/openra.appdata.xml.in" | sed "s/{MOD_NAME}/${MOD_NAME}/g" | sed "s/{SCREENSHOT_RA}/${SCREENSHOT_RA}/g" | sed "s/{SCREENSHOT_CNC}/${SCREENSHOT_CNC}/g" | sed "s/{SCREENSHOT_D2K}/${SCREENSHOT_D2K}/g"> "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.appdata.xml"
+		install -m644 "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.appdata.xml" "${SHARE_PATH}/appdata"
+		rm "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.appdata.xml"
+
+		shift
+	done
+}

--- a/packaging/linux/openra-mimeinfo.xml.discord.in
+++ b/packaging/linux/openra-mimeinfo.xml.discord.in
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+  <mime-type type="x-scheme-handler/openra-{MODID}-{TAG}">
+    <icon name="openra-{MODID}" />
+    <generic-icon name="applications-games"/>
+    <comment>Join OpenRA server</comment>
+    <glob weight="60" pattern="openra-{MODID}-{TAG}://*"/>
+  </mime-type>
+  <mime-type type="x-scheme-handler/discord-{DISCORDAPPID}">
+    <generic-icon name="applications-games"/>
+    <comment>Launch OpenRA from Discord</comment>
+    <glob weight="60" pattern="discord-{DISCORDAPPID}://*"/>
+  </mime-type>
+</mime-info>

--- a/packaging/linux/openra-server.appimage.in
+++ b/packaging/linux/openra-server.appimage.in
@@ -2,4 +2,4 @@
 HERE="$(dirname "$(readlink -f "${0}")")"
 cd "${HERE}/../lib/openra" || exit 1
 
-mono --debug OpenRA.Server.exe Game.Mod={MODID} "$@"
+mono --debug OpenRA.Server.exe Game.Mod="{MODID}" "$@"

--- a/packaging/linux/openra.desktop.discord.in
+++ b/packaging/linux/openra.desktop.discord.in
@@ -9,4 +9,4 @@ Exec=openra-{MODID} %U
 Terminal=false
 Categories=Game;StrategyGame;
 StartupWMClass=openra-{MODID}-{TAG}
-MimeType=x-scheme-handler/openra-{MODID}-{TAG};
+MimeType=x-scheme-handler/openra-{MODID}-{TAG};x-scheme-handler/discord-{DISCORDAPPID};

--- a/packaging/macos/Eluant.dll.config
+++ b/packaging/macos/Eluant.dll.config
@@ -1,3 +1,0 @@
-<configuration>
-  <dllmap os="osx" dll="lua51.dll" target="liblua.5.1.dylib" />
-</configuration>

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -19,7 +19,7 @@
 !include "WordFunc.nsh"
 
 Name "OpenRA"
-OutFile "OpenRA.Setup.exe"
+OutFile "${OUTFILE}"
 
 ManifestDPIAware true
 

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# OpenRA packaging script for Windows
+
+set -e
 
 command -v curl >/dev/null 2>&1 || { echo >&2 "Windows packaging requires curl."; exit 1; }
 command -v makensis >/dev/null 2>&1 || { echo >&2 "Windows packaging requires makensis."; exit 1; }
@@ -12,6 +15,7 @@ fi
 
 # Set the working dir to the location of this script
 cd "$(dirname "$0")" || exit 1
+. ../functions.sh
 
 TAG="$1"
 OUTPUTDIR="$2"
@@ -19,7 +23,7 @@ SRCDIR="$(pwd)/../.."
 BUILTDIR="$(pwd)/build"
 ARTWORK_DIR="$(pwd)/../artwork/"
 
-FAQ_URL="http://wiki.openra.net/FAQ"
+FAQ_URL="https://wiki.openra.net/FAQ"
 
 SUFFIX=" (dev)"
 if [[ ${TAG} == release* ]]; then
@@ -35,19 +39,8 @@ function makelauncher()
 	MOD_ID="${3}"
 	PLATFORM="${4}"
 
-	# Create multi-resolution icon
 	convert "${ARTWORK_DIR}/${MOD_ID}_16x16.png" "${ARTWORK_DIR}/${MOD_ID}_24x24.png" "${ARTWORK_DIR}/${MOD_ID}_32x32.png" "${ARTWORK_DIR}/${MOD_ID}_48x48.png" "${ARTWORK_DIR}/${MOD_ID}_256x256.png" "${BUILTDIR}/${MOD_ID}.ico"
-
-	# Create mod-specific launcher
-	msbuild -t:Build "${SRCDIR}/OpenRA.WindowsLauncher/OpenRA.WindowsLauncher.csproj" -restore -p:Configuration=Release -p:TargetPlatform="win-${PLATFORM}" -p:LauncherName="${LAUNCHER_NAME}" -p:LauncherIcon="${BUILTDIR}/${MOD_ID}.ico" -p:ModID="${MOD_ID}" -p:DisplayName="${DISPLAY_NAME}" -p:FaqUrl="${FAQ_URL}"
-	cp "${SRCDIR}/bin/${LAUNCHER_NAME}.exe" "${BUILTDIR}"
-	cp "${SRCDIR}/bin/${LAUNCHER_NAME}.exe.config" "${BUILTDIR}"
-
-	# Enable the full 4GB address space for the 32 bit game executable
-	# The server and utility do not use enough memory to need this
-	if [ "${PLATFORM}" = "x86" ]; then
-		python3 MakeLAA.py "${BUILTDIR}/${LAUNCHER_NAME}.exe"
-	fi
+	install_windows_launcher "${SRCDIR}" "${BUILTDIR}" "win-${PLATFORM}" "${MOD_ID}" "${LAUNCHER_NAME}"  "${DISPLAY_NAME}" "${BUILTDIR}/${MOD_ID}.ico" "${FAQ_URL}"
 }
 
 function build_platform()
@@ -55,37 +48,24 @@ function build_platform()
 	PLATFORM="${1}"
 
 	echo "Building core files (${PLATFORM})"
-	if [ "${PLATFORM}" = "win-x86" ]; then
+	if [ "${PLATFORM}" = "x86" ]; then
 		USE_PROGRAMFILES32="-DUSE_PROGRAMFILES32=true"
 	else
 		USE_PROGRAMFILES32=""
 	fi
 
-	pushd "${SRCDIR}" > /dev/null || exit 1
-	make clean
-	make core TARGETPLATFORM="win-${PLATFORM}"
-	make version VERSION="${TAG}"
-	make install-engine TARGETPLATFORM="win-${PLATFORM}" gameinstalldir="" DESTDIR="${BUILTDIR}"
-	make install-common-mod-files gameinstalldir="" DESTDIR="${BUILTDIR}"
-	make install-default-mods gameinstalldir="" DESTDIR="${BUILTDIR}"
-	make install-dependencies TARGETPLATFORM="win-${PLATFORM}" gameinstalldir="" DESTDIR="${BUILTDIR}"
-	popd > /dev/null || exit 1
+	install_assemblies_mono "${SRCDIR}" "${BUILTDIR}" "win-${PLATFORM}" "False" "True" "True"
+	install_data "${SRCDIR}" "${BUILTDIR}" "cnc" "d2k" "ra"
+	set_engine_version "${TAG}" "${BUILTDIR}"
+	set_mod_version "${TAG}" "${BUILTDIR}/mods/cnc/mod.yaml" "${BUILTDIR}/mods/d2k/mod.yaml" "${BUILTDIR}/mods/ra/mod.yaml"  "${BUILTDIR}/mods/modcontent/mod.yaml"
 
 	echo "Compiling Windows launchers (${PLATFORM})"
-	makelauncher "RedAlert" "Red Alert" "ra" ${PLATFORM}
-	makelauncher "TiberianDawn" "Tiberian Dawn" "cnc" ${PLATFORM}
-	makelauncher "Dune2000" "Dune 2000" "d2k" ${PLATFORM}
-
-	# Remove redundant generic launcher
-	rm "${BUILTDIR}/OpenRA.exe"
+	makelauncher "RedAlert" "Red Alert" "ra" "${PLATFORM}"
+	makelauncher "TiberianDawn" "Tiberian Dawn" "cnc" "${PLATFORM}"
+	makelauncher "Dune2000" "Dune 2000" "d2k" "${PLATFORM}"
 
 	echo "Building Windows setup.exe ($1)"
-	makensis -V2 -DSRCDIR="${BUILTDIR}" -DTAG="${TAG}" -DSUFFIX="${SUFFIX}" ${USE_PROGRAMFILES32} OpenRA.nsi
-	if [ $? -eq 0 ]; then
-		mv OpenRA.Setup.exe "${OUTPUTDIR}/OpenRA-${TAG}-${PLATFORM}.exe"
-	else
-		exit 1
-	fi
+	makensis -V2 -DSRCDIR="${BUILTDIR}" -DTAG="${TAG}" -DSUFFIX="${SUFFIX}" -DOUTFILE="${OUTPUTDIR}/OpenRA-${TAG}-${PLATFORM}.exe" ${USE_PROGRAMFILES32} OpenRA.nsi || exit 1
 
 	echo "Packaging zip archive ($1)"
 	pushd "${BUILTDIR}" > /dev/null


### PR DESCRIPTION
This PR takes @teinarss's idea from #17989 and ~scope creeps~ generalizes it into a more comprehensive cleanup of our packaging code. The diff may look a little intimidating, but i'd like to think that if you read the new scripts directly you will find them now much clearer to read and understand.

I have kept the `install` and `install-linux-shortcuts` and `install-linux-appdata` Makefile targets for our downstream Linux/BSD packagers, and I believe that they should work without regressions (as far as my testing the targets individually can show). The finer grained targets (`install-engine`, `install-common-mod-files`, etc) that were introduced for the Mod SDK have been removed as they are made obsolete by the SDK counterpart to this PR (https://github.com/OpenRA/OpenRAModSDK/pull/170).

Some of the changes (like `install_assemblies_mono` manually cleaning and rebuilding and managing mod dlls as well as the engine) are a bit odd/crap by our previous standards, but this design is needed for NET Core where preparing binaries for packaging uses a different toolchain action that behaves quite differently (e.g. creating native binaries and stripping unused code) to the standard development compilation actions.

I have tested the macOS/Windows/Linux builds manually for both the upstream releases and for the Mod SDK, but somebody else will need to tag a devtest build on their own fork as I have already used my free Travis-CI allowance for the month (and don't want to go the hassle of asking for more since I plan on working on GH actions next).