### PR TITLE
Make Attack turn during its own tick

### DIFF
--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -209,9 +209,16 @@ namespace OpenRA.Mods.Common.Activities
 			if (!attack.TargetInFiringArc(self, target, attack.Info.FacingTolerance))
 			{
 				var desiredFacing = (attack.GetTargetPosition(pos, target) - pos).Yaw;
-				attackStatus |= AttackStatus.NeedsToTurn;
-				QueueChild(new Turn(self, desiredFacing));
-				return AttackStatus.NeedsToTurn;
+
+				// Don't queue a turn activity: Executing a child takes an additional tick during which the target may have moved again
+				facing.Facing = Util.TickFacing(facing.Facing, desiredFacing, facing.TurnSpeed);
+
+				// Check again if we turned enough and directly continue attacking if we did
+				if (!attack.TargetInFiringArc(self, target, attack.Info.FacingTolerance))
+				{
+					attackStatus |= AttackStatus.NeedsToTurn;
+					return AttackStatus.NeedsToTurn;
+				}
 			}
 
 			attackStatus |= AttackStatus.Attacking;


### PR DESCRIPTION
Queueing a `Turn` child meant we were wasting an additional tick until that child ran. During that time moving targets would already be at a different position, changing `desiredFacing` once again and causing `Attack` to queue another `Turn`. That essentially means `Attack` was stuck in a loop queueing `Turn` activities. Now it directly turns and checks right afterwards if it can attack. If it cannot, the `Attack` activity continues as usual the next tick (and continues turning there, making a `Turn` activity obsolete). This also fixes units not moving into range when they are stuck in the `Turn` child.

Closes #16486.
Closes #18867.
Closes #18871.

Testcase is just starting Allies02.