### PR TITLE
Fix MissionObjectives not properly ending the game

### DIFF
--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -80,7 +80,8 @@ namespace OpenRA
 		{
 			get
 			{
-				return spectating || WinState != WinState.Undefined;
+				// Players in mission maps must not leave the player view
+				return !inMissionMap && (spectating || WinState != WinState.Undefined);
 			}
 		}
 


### PR DESCRIPTION
Fixes the issue noted in https://github.com/OpenRA/OpenRA/pull/18695#issuecomment-734865007.

The problem here was using `var enemies = players.Where(p => !p.IsAlliedWith(player));`. By the time we evaluated that enumeration, the player had already been marked as victorious/defeated (= spectating) and thus had no enemies any more.

There are still some visual glitches unrelated to this patch, see https://github.com/OpenRA/OpenRA/pull/18772#issuecomment-739153405.