### PR TITLE
Fix WithInfantryBody wrongly overwriting attack animations

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -160,6 +160,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		protected virtual void Tick(Actor self)
 		{
+			// Attacking takes care of reverting back to PlayStandAnimation
+			if (state == AnimationState.Attacking)
+				return;
+
 			if (rsm != null)
 			{
 				if (wasModifying != rsm.IsModifyingSequence)


### PR DESCRIPTION
Closes #17743.

The `PlayThen` with `PlayStandAnimation` already takes care of changing the animation again, so we can ignore `Tick` while attacking.
https://github.com/OpenRA/OpenRA/blob/1a63cc4a414665b5f6fc41bde8147b31d20f6aac/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs#L144-L145