### PR TITLE
Fix WithDeliveryAnimation overriding sell animation.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithDeliveryAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeliveryAnimation.cs
@@ -44,7 +44,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public void Delivered(Actor self)
 		{
-			wsb.CancelCustomAnimation(self);
+			// Animation has already been cancelled by TraitDisabled below
+			if (!IsTraitDisabled)
+				wsb.CancelCustomAnimation(self);
 		}
 
 		protected override void TraitDisabled(Actor self)


### PR DESCRIPTION
Fixes #18888.

Testcase: Build a vehicle and sell the airfield just before the plane arrives.