### PR TITLE
AI Squad workarounds

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -132,7 +132,7 @@ namespace OpenRA.Mods.Common.Traits
 		// Use for proactive targeting.
 		public bool IsPreferredEnemyUnit(Actor a)
 		{
-			if (a == null || a.IsDead || Player.RelationshipWith(a.Owner) != PlayerRelationship.Enemy || a.Info.HasTraitInfo<HuskInfo>())
+			if (a == null || a.IsDead || Player.RelationshipWith(a.Owner) != PlayerRelationship.Enemy || a.Info.HasTraitInfo<HuskInfo>() || a.Info.HasTraitInfo<AircraftInfo>())
 				return false;
 
 			var targetTypes = a.GetEnabledTargetTypes();

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
@@ -68,6 +68,10 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 
 	class GroundUnitsAttackMoveState : GroundStateBase, IState
 	{
+		int lastUpdatedTick;
+		CPos? lastLeaderLocation;
+		Actor lastTarget;
+
 		public void Activate(Squad owner) { }
 
 		public void Tick(Squad owner)
@@ -90,6 +94,27 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			var leader = owner.Units.ClosestTo(owner.TargetActor.CenterPosition);
 			if (leader == null)
 				return;
+
+			if (leader.Location != lastLeaderLocation)
+			{
+				lastLeaderLocation = leader.Location;
+				lastUpdatedTick = owner.World.WorldTick;
+			}
+
+			if (owner.TargetActor != lastTarget)
+			{
+				lastTarget = owner.TargetActor;
+				lastUpdatedTick = owner.World.WorldTick;
+			}
+
+			// HACK: Drop back to the idle state if we haven't moved in 2.5 seconds
+			// This works around the squad being stuck trying to attack-move to a location
+			// that they cannot path to, generating expensive pathfinding calls each tick.
+			if (owner.World.WorldTick > lastUpdatedTick + 63)
+			{
+				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsIdleState(), true);
+				return;
+			}
 
 			var ownUnits = owner.World.FindActorsInCircle(leader.CenterPosition, WDist.FromCells(owner.Units.Count) / 3)
 				.Where(a => a.Owner == owner.Units.First().Owner && owner.Units.Contains(a)).ToHashSet();
@@ -126,6 +151,10 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 
 	class GroundUnitsAttackState : GroundStateBase, IState
 	{
+		int lastUpdatedTick;
+		CPos? lastLeaderLocation;
+		Actor lastTarget;
+
 		public void Activate(Squad owner) { }
 
 		public void Tick(Squad owner)
@@ -143,6 +172,28 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 					owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsFleeState(), true);
 					return;
 				}
+			}
+
+			var leader = owner.Units.ClosestTo(owner.TargetActor.CenterPosition);
+			if (leader.Location != lastLeaderLocation)
+			{
+				lastLeaderLocation = leader.Location;
+				lastUpdatedTick = owner.World.WorldTick;
+			}
+
+			if (owner.TargetActor != lastTarget)
+			{
+				lastTarget = owner.TargetActor;
+				lastUpdatedTick = owner.World.WorldTick;
+			}
+
+			// HACK: Drop back to the idle state if we haven't moved in 2.5 seconds
+			// This works around the squad being stuck trying to attack-move to a location
+			// that they cannot path to, generating expensive pathfinding calls each tick.
+			if (owner.World.WorldTick > lastUpdatedTick + 63)
+			{
+				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsIdleState(), true);
+				return;
 			}
 
 			foreach (var a in owner.Units)

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -219,7 +219,7 @@ Player:
 		RequiresCondition: enable-omnius-ai
 		SquadSize: 8
 		MaxBaseRadius: 40
-		ExcludeFromSquadsTypes: harvester, mcv
+		ExcludeFromSquadsTypes: harvester, mcv, carryall, carryall.reinforce
 		ConstructionYardTypes: construction_yard
 		IgnoredEnemyTargetTypes: Creep
 	UnitBuilderBotModule@omnius:
@@ -263,7 +263,7 @@ Player:
 		RequiresCondition: enable-vidious-ai
 		SquadSize: 6
 		MaxBaseRadius: 40
-		ExcludeFromSquadsTypes: harvester, mcv
+		ExcludeFromSquadsTypes: harvester, mcv, carryall, carryall.reinforce
 		ConstructionYardTypes: construction_yard
 		IgnoredEnemyTargetTypes: Creep
 	UnitBuilderBotModule@vidious:
@@ -302,7 +302,7 @@ Player:
 		RequiresCondition: enable-gladius-ai
 		SquadSize: 10
 		MaxBaseRadius: 40
-		ExcludeFromSquadsTypes: harvester, mcv
+		ExcludeFromSquadsTypes: harvester, mcv, carryall, carryall.reinforce
 		ConstructionYardTypes: construction_yard
 		IgnoredEnemyTargetTypes: Creep
 	UnitBuilderBotModule@gladius:


### PR DESCRIPTION
We've run out of time to merge any more general AI improvements for the playtest, so this PR focuses on fixing a couple of specific high-impact issues with (hopefully) low risk workarounds.

The first commit essentially solves the AI performance cliff that happens when ground or naval forces squads a naval or ground unit that they cannot reach, and then spend the rest of their lives stuck trying to path to it, bringing performance to a crawl. Forcing the squad into the idle state if the leader hasn't moved for 2.5 seconds breaks this loop and restores normal performance. This has a side-effect of causing units that are stationary *because they are shooting something* to pick new targets, but this is often the same unit they were already shooting so I didn't notice any noticable regression in behaviour when spectating AI games. The RA map "Pool Party" with random bots is a good testcase to demonstrate this issue and workaround.

The second and third commits fix problems with carryalls in d2k: the AI would send carryalls loaded with their harvesters to circle over enemy bases, and combat units would get hung up on enemy carryalls and force games into an idle stalemate. Air units are typically in support roles, so this should hopefully have a similarly small impact in real-game behaviour in the other mods.