### PR TITLE
Fix Neutral crushing checks.

### DIFF
--- a/OpenRA.Game/Primitives/LongBitSet.cs
+++ b/OpenRA.Game/Primitives/LongBitSet.cs
@@ -18,6 +18,7 @@ namespace OpenRA.Primitives
 	static class LongBitSetAllocator<T> where T : class
 	{
 		static readonly Cache<string, long> Bits = new Cache<string, long>(Allocate);
+		static long allBits = 1;
 		static long nextBits = 1;
 
 		static long Allocate(string value)
@@ -25,6 +26,7 @@ namespace OpenRA.Primitives
 			lock (Bits)
 			{
 				var bits = nextBits;
+				allBits |= bits;
 				nextBits <<= 1;
 
 				if (nextBits == 0)
@@ -85,6 +87,8 @@ namespace OpenRA.Primitives
 				nextBits = 1;
 			}
 		}
+
+		public static long Mask { get { return allBits; } }
 	}
 
 	// Opitmized BitSet to be used only when guaranteed to be no more than 64 values.
@@ -114,6 +118,7 @@ namespace OpenRA.Primitives
 
 		public static bool operator ==(LongBitSet<T> me, LongBitSet<T> other) { return me.bits == other.bits; }
 		public static bool operator !=(LongBitSet<T> me, LongBitSet<T> other) { return !(me == other); }
+		public static LongBitSet<T> operator ~(LongBitSet<T> me) { return new LongBitSet<T>(me.bits ^ LongBitSetAllocator<T>.Mask); }
 
 		public bool Equals(LongBitSet<T> other) { return other == this; }
 		public override bool Equals(object obj) { return obj is LongBitSet<T> && Equals((LongBitSet<T>)obj); }

--- a/OpenRA.Mods.Cnc/Traits/Mine.cs
+++ b/OpenRA.Mods.Cnc/Traits/Mine.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				return self.World.NoPlayersMask;
 
 			// Friendly units should move around!
-			return info.BlockFriendly ? self.Owner.EnemyPlayersMask : self.World.AllPlayersMask;
+			return info.BlockFriendly ? ~self.Owner.AlliedPlayersMask : self.World.AllPlayersMask;
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Crushable.cs
+++ b/OpenRA.Mods.Common/Traits/Crushable.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (IsTraitDisabled || !self.IsAtGroundLevel() || !Info.CrushClasses.Overlaps(crushClasses))
 				return self.World.NoPlayersMask;
 
-			return Info.CrushedByFriendlies ? self.World.AllPlayersMask : self.Owner.EnemyPlayersMask;
+			return Info.CrushedByFriendlies ? self.World.AllPlayersMask : ~self.Owner.AlliedPlayersMask;
 		}
 
 		bool CrushableInner(BitSet<CrushClass> crushClasses, Player crushOwner)


### PR DESCRIPTION
Fixes #18897.

As I mention in that issue, the previous bitmask code (which was only used by `Crushable` and `Mine`) counted neutral players in the `EnemyPlayersMask`, which wasn't really correct to start with and isn't possible now that all stance checks use the mask. This PR replaces the checks that depended on this old behaviour with a "not allied" bitmask created by doing a length-aware bit negation to the `AlliedPlayerMask`.