### PR TITLE
 Split chat lines into pools and allow the player to filter them

### DIFF
--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -50,9 +50,9 @@ namespace OpenRA.Network
 		readonly List<Order> localOrders = new List<Order>();
 		readonly List<Order> localImmediateOrders = new List<Order>();
 
-		readonly List<ChatLine> chatCache = new List<ChatLine>();
+		readonly List<TextNotification> notificationsCache = new List<TextNotification>();
 
-		public IReadOnlyList<ChatLine> ChatCache => chatCache;
+		public IReadOnlyList<TextNotification> NotificationsCache => notificationsCache;
 
 		bool disposed;
 		bool generateSyncReport = false;
@@ -100,7 +100,7 @@ namespace OpenRA.Network
 			Password = password;
 			Connection = conn;
 			syncReport = new SyncReport(this);
-			AddChatLine += CacheChatLine;
+			AddTextNotification += CacheTextNotification;
 		}
 
 		public void IssueOrders(Order[] orders)
@@ -117,10 +117,10 @@ namespace OpenRA.Network
 				localOrders.Add(order);
 		}
 
-		public Action<string, Color, string, Color> AddChatLine = (n, nc, s, tc) => { };
-		void CacheChatLine(string name, Color nameColor, string text, Color textColor)
+		public Action<TextNotification> AddTextNotification = (notification) => { };
+		void CacheTextNotification(TextNotification notification)
 		{
-			chatCache.Add(new ChatLine(name, nameColor, text, textColor));
+			notificationsCache.Add(notification);
 		}
 
 		public void TickImmediate()
@@ -244,22 +244,6 @@ namespace OpenRA.Network
 		{
 			disposed = true;
 			Connection?.Dispose();
-		}
-	}
-
-	public class ChatLine
-	{
-		public readonly Color Color;
-		public readonly string Name;
-		public readonly string Text;
-		public readonly Color TextColor;
-
-		public ChatLine(string name, Color nameColor, string text, Color textColor)
-		{
-			Color = nameColor;
-			Name = name;
-			Text = text;
-			TextColor = textColor;
 		}
 	}
 }

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Network
 							if (orderManager.LocalClient != null && client != orderManager.LocalClient && client.Team > 0 && client.Team == orderManager.LocalClient.Team)
 								suffix += " (Ally)";
 
-							TextNotificationsManager.AddChatLine(client.Name + suffix, client.Color, message);
+							TextNotificationsManager.AddChatLine(client.Name + suffix, message, client.Color);
 							break;
 						}
 
@@ -79,7 +79,7 @@ namespace OpenRA.Network
 						{
 							var prefix = order.ExtraData == uint.MaxValue ? "[Spectators] " : "[Team] ";
 							if (orderManager.LocalClient != null && client.Team == orderManager.LocalClient.Team)
-								TextNotificationsManager.AddChatLine(prefix + client.Name, client.Color, message);
+								TextNotificationsManager.AddChatLine(prefix + client.Name, message, client.Color);
 
 							break;
 						}
@@ -93,7 +93,7 @@ namespace OpenRA.Network
 						{
 							// Validate before adding the line
 							if (client.IsObserver || (player != null && player.WinState != WinState.Undefined))
-								TextNotificationsManager.AddChatLine("[Spectators] " + client.Name, client.Color, message);
+								TextNotificationsManager.AddChatLine("[Spectators] " + client.Name, message, client.Color);
 
 							break;
 						}
@@ -103,7 +103,7 @@ namespace OpenRA.Network
 							&& world.LocalPlayer != null && world.LocalPlayer.WinState == WinState.Undefined;
 
 						if (valid && (isSameTeam || world.IsReplay))
-							TextNotificationsManager.AddChatLine("[Team" + (world.IsReplay ? " " + order.ExtraData : "") + "] " + client.Name, client.Color, message);
+							TextNotificationsManager.AddChatLine("[Team" + (world.IsReplay ? " " + order.ExtraData : "") + "] " + client.Name, message, client.Color);
 
 						break;
 					}

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -33,6 +33,12 @@ namespace OpenRA
 		Incompatible = 16
 	}
 
+	[Flags]
+	public enum TextNotificationPoolFilters
+	{
+		None = 0
+	}
+
 	public enum WorldViewport { Native, Close, Medium, Far }
 
 	public class ServerSettings
@@ -265,6 +271,8 @@ namespace OpenRA
 
 		[Desc("Allow mods to enable the Discord service that can interact with a local Discord client.")]
 		public bool EnableDiscordService = true;
+
+		public TextNotificationPoolFilters TextNotificationPoolFilters = TextNotificationPoolFilters.None;
 	}
 
 	public class Settings

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -36,7 +36,8 @@ namespace OpenRA
 	[Flags]
 	public enum TextNotificationPoolFilters
 	{
-		None = 0
+		None = 0,
+		Feedback = 1
 	}
 
 	public enum WorldViewport { Native, Close, Medium, Far }
@@ -272,7 +273,7 @@ namespace OpenRA
 		[Desc("Allow mods to enable the Discord service that can interact with a local Discord client.")]
 		public bool EnableDiscordService = true;
 
-		public TextNotificationPoolFilters TextNotificationPoolFilters = TextNotificationPoolFilters.None;
+		public TextNotificationPoolFilters TextNotificationPoolFilters = TextNotificationPoolFilters.Feedback;
 	}
 
 	public class Settings

--- a/OpenRA.Game/TextNotification.cs
+++ b/OpenRA.Game/TextNotification.cs
@@ -1,0 +1,56 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using OpenRA.Primitives;
+
+namespace OpenRA
+{
+	public enum TextNotificationPool { System, Chat, Mission, Feedback }
+
+	public class TextNotification : IEquatable<TextNotification>
+	{
+		public readonly TextNotificationPool Pool;
+		public readonly string Prefix;
+		public readonly string Text;
+		public readonly Color PrefixColor;
+		public readonly Color TextColor;
+
+		public TextNotification(TextNotificationPool pool, string prefix, string text, Color prefixColor, Color textColor)
+		{
+			Pool = pool;
+			Prefix = prefix;
+			Text = text;
+			PrefixColor = prefixColor;
+			TextColor = textColor;
+		}
+
+		public bool CanIncrementOnDuplicate()
+		{
+			return Pool == TextNotificationPool.Feedback || Pool == TextNotificationPool.System;
+		}
+
+		public bool Equals(TextNotification other)
+		{
+			return other != null && other.GetHashCode() == GetHashCode();
+		}
+
+		public override bool Equals(object obj)
+		{
+			return obj is TextNotification && Equals((TextNotification)obj);
+		}
+
+		public override int GetHashCode()
+		{
+			return string.Format("{0}{1}{2}", Prefix, Text, Pool).GetHashCode();
+		}
+	}
+}

--- a/OpenRA.Game/TextNotificationsManager.cs
+++ b/OpenRA.Game/TextNotificationsManager.cs
@@ -61,10 +61,12 @@ namespace OpenRA
 
 		static bool IsPoolEnabled(TextNotificationPool pool)
 		{
+			var filters = Game.Settings.Game.TextNotificationPoolFilters;
+
 			return pool == TextNotificationPool.Chat ||
 				pool == TextNotificationPool.System ||
 				pool == TextNotificationPool.Mission ||
-				pool == TextNotificationPool.Feedback;
+				(pool == TextNotificationPool.Feedback && filters.HasFlag(TextNotificationPoolFilters.Feedback));
 		}
 	}
 }

--- a/OpenRA.Game/TextNotificationsManager.cs
+++ b/OpenRA.Game/TextNotificationsManager.cs
@@ -28,24 +28,43 @@ namespace OpenRA
 				systemMessageLabel = "Battlefield Control";
 		}
 
+		public static void AddFeedbackLine(string text)
+		{
+			AddTextNotification(TextNotificationPool.Feedback, systemMessageLabel, text, systemMessageColor, systemMessageColor);
+		}
+
 		public static void AddSystemLine(string text)
 		{
 			AddSystemLine(systemMessageLabel, text);
 		}
 
-		public static void AddSystemLine(string name, string text)
+		public static void AddSystemLine(string prefix, string text)
 		{
-			Game.OrderManager.AddChatLine(name, systemMessageColor, text, systemMessageColor);
+			AddTextNotification(TextNotificationPool.System, prefix, text, systemMessageColor, systemMessageColor);
 		}
 
-		public static void AddChatLine(string name, Color nameColor, string text)
+		public static void AddChatLine(string prefix, string text, Color? prefixColor = null, Color? textColor = null)
 		{
-			Game.OrderManager.AddChatLine(name, nameColor, text, chatMessageColor);
+			AddTextNotification(TextNotificationPool.Chat, prefix, text, prefixColor, textColor);
 		}
 
 		public static void Debug(string s, params object[] args)
 		{
 			AddSystemLine("Debug", string.Format(s, args));
+		}
+
+		static void AddTextNotification(TextNotificationPool pool, string prefix, string text, Color? prefixColor = null, Color? textColor = null)
+		{
+			if (IsPoolEnabled(pool))
+				Game.OrderManager.AddTextNotification(new TextNotification(pool, prefix, text, prefixColor ?? chatMessageColor, textColor ?? chatMessageColor));
+		}
+
+		static bool IsPoolEnabled(TextNotificationPool pool)
+		{
+			return pool == TextNotificationPool.Chat ||
+				pool == TextNotificationPool.System ||
+				pool == TextNotificationPool.Mission ||
+				pool == TextNotificationPool.Feedback;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -194,7 +194,7 @@ namespace OpenRA.Mods.Common.Scripting
 				return;
 
 			var c = color.HasValue ? color.Value : Color.White;
-			TextNotificationsManager.AddChatLine(prefix, c, text);
+			TextNotificationsManager.AddChatLine(prefix, text, c);
 		}
 
 		[Desc("Display a system message to the player. If 'prefix' is nil the default system prefix is used.")]

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			services = modData.Manifest.Get<WebServices>();
 
-			orderManager.AddChatLine += AddChatLine;
+			orderManager.AddTextNotification += AddChatLine;
 			Game.LobbyInfoChanged += UpdateCurrentMap;
 			Game.LobbyInfoChanged += UpdatePlayerList;
 			Game.LobbyInfoChanged += UpdateDiscordStatus;
@@ -463,7 +463,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (disposing && !disposed)
 			{
 				disposed = true;
-				orderManager.AddChatLine -= AddChatLine;
+				orderManager.AddTextNotification -= AddChatLine;
 				Game.LobbyInfoChanged -= UpdateCurrentMap;
 				Game.LobbyInfoChanged -= UpdatePlayerList;
 				Game.LobbyInfoChanged -= UpdateDiscordStatus;
@@ -486,10 +486,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				panel = PanelType.Players;
 		}
 
-		void AddChatLine(string name, Color nameColor, string text, Color textColor)
+		void AddChatLine(TextNotification chatLine)
 		{
 			var template = (ContainerWidget)chatTemplate.Clone();
-			LobbyUtils.SetupChatLine(template, DateTime.Now, name, nameColor, text, textColor);
+			LobbyUtils.SetupChatLine(template, DateTime.Now, chatLine);
 
 			var scrolledToBottom = lobbyChatPanel.ScrolledToBottom;
 			lobbyChatPanel.AddChild(template);

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -651,28 +651,28 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			HideChildWidget(parent, "STATUS_IMAGE");
 		}
 
-		public static void SetupChatLine(ContainerWidget template, DateTime time, string name, Color nameColor, string text, Color textColor)
+		public static void SetupChatLine(ContainerWidget template, DateTime time, TextNotification chatLine)
 		{
 			var nameLabel = template.Get<LabelWidget>("NAME");
 			var timeLabel = template.Get<LabelWidget>("TIME");
 			var textLabel = template.Get<LabelWidget>("TEXT");
 
-			var nameText = name + ":";
+			var nameText = chatLine.Prefix + ":";
 			var font = Game.Renderer.Fonts[nameLabel.Font];
 			var nameSize = font.Measure(nameText);
 
 			timeLabel.GetText = () => $"{time.Hour:D2}:{time.Minute:D2}";
 
-			nameLabel.GetColor = () => nameColor;
+			nameLabel.GetColor = () => chatLine.PrefixColor;
 			nameLabel.GetText = () => nameText;
 			nameLabel.Bounds.Width = nameSize.X;
 
-			textLabel.GetColor = () => textColor;
+			textLabel.GetColor = () => chatLine.TextColor;
 			textLabel.Bounds.X += nameSize.X;
 			textLabel.Bounds.Width -= nameSize.X;
 
 			// Hack around our hacky wordwrap behavior: need to resize the widget to fit the text
-			text = WidgetUtils.WrapText(text, textLabel.Bounds.Width, font);
+			var text = WidgetUtils.WrapText(chatLine.Text, textLabel.Bounds.Width, font);
 			textLabel.GetText = () => text;
 			var dh = font.Measure(text).Y - textLabel.Bounds.Height;
 			if (dh > 0)

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -106,6 +106,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			battlefieldCameraDropDown.OnMouseDown = _ => ShowBattlefieldCameraDropdown(battlefieldCameraDropDown, viewportSizes, ds);
 			battlefieldCameraDropDown.GetText = () => battlefieldCameraLabel.Update(ds.ViewportDistance);
 
+			BindTextNotificationPoolFilterSettings(panel, gs);
+
 			// Update vsync immediately
 			var vsyncCheckbox = panel.Get<CheckboxWidget>("VSYNC_CHECKBOX");
 			var vsyncOnClick = vsyncCheckbox.OnClick;
@@ -211,8 +213,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var ds = Game.Settings.Graphics;
 			var ps = Game.Settings.Player;
+			var gs = Game.Settings.Game;
 			var dds = new GraphicSettings();
 			var dps = new PlayerSettings();
+			var dgs = new GameSettings();
 			return () =>
 			{
 				ds.CapFramerate = dds.CapFramerate;
@@ -235,6 +239,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				ps.Color = dps.Color;
 				ps.Name = dps.Name;
+
+				gs.TextNotificationPoolFilters = dgs.TextNotificationPoolFilters;
 			};
 		}
 
@@ -258,6 +264,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, setupItem);
+		}
+
+		public static void BindTextNotificationPoolFilterSettings(Widget panel, GameSettings gs)
+		{
+			Action<TextNotificationPoolFilters> toggleFilterFlag = f =>
+			{
+				gs.TextNotificationPoolFilters ^= f;
+				Game.Settings.Save();
+			};
+
+			var feedbackCheckbox = panel.GetOrNull<CheckboxWidget>("UI_FEEDBACK_CHECKBOX");
+			if (feedbackCheckbox != null)
+			{
+				feedbackCheckbox.IsChecked = () => gs.TextNotificationPoolFilters.HasFlag(TextNotificationPoolFilters.Feedback);
+				feedbackCheckbox.OnClick = () => toggleFilterFlag(TextNotificationPoolFilters.Feedback);
+			}
 		}
 
 		static void ShowStatusBarsDropdown(DropDownButtonWidget dropdown, GameSettings s)

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -261,12 +261,12 @@ namespace OpenRA.Mods.Common.Widgets
 
 					// Check if selecting actors on the screen has selected new units
 					if (ownUnitsOnScreen.Count > World.Selection.Actors.Count())
-						TextNotificationsManager.AddSystemLine("Selected across screen");
+						TextNotificationsManager.AddFeedbackLine("Selected across screen");
 					else
 					{
 						// Select actors in the world that have highest selection priority
 						ownUnitsOnScreen = SelectActorsInWorld(World, null, eligiblePlayers).SubsetWithHighestSelectionPriority(e.Modifiers).ToList();
-						TextNotificationsManager.AddSystemLine("Selected across map");
+						TextNotificationsManager.AddFeedbackLine("Selected across map");
 					}
 
 					World.Selection.Combine(World, ownUnitsOnScreen, false, false);
@@ -293,12 +293,12 @@ namespace OpenRA.Mods.Common.Widgets
 
 					// Check if selecting actors on the screen has selected new units
 					if (newSelection.Count > World.Selection.Actors.Count())
-						TextNotificationsManager.AddSystemLine("Selected across screen");
+						TextNotificationsManager.AddFeedbackLine("Selected across screen");
 					else
 					{
 						// Select actors in the world that have the same selection class as one of the already selected actors
 						newSelection = SelectActorsInWorld(World, selectedClasses, eligiblePlayers).ToList();
-						TextNotificationsManager.AddSystemLine("Selected across map");
+						TextNotificationsManager.AddFeedbackLine("Selected across map");
 					}
 
 					World.Selection.Combine(World, newSelection, true, false);

--- a/mods/cnc/chrome/settings-display.yaml
+++ b/mods/cnc/chrome/settings-display.yaml
@@ -109,6 +109,13 @@ Container@DISPLAY_PANEL:
 			Height: 20
 			Font: Regular
 			Text: Player Stance Colors
+		Checkbox@UI_FEEDBACK_CHECKBOX:
+			X: 15
+			Y: 163
+			Width: 200
+			Height: 20
+			Font: Regular
+			Text: UI Feedback in Chat
 		Label@VIDEO_TITLE:
 			Y: 190
 			Width: PARENT_RIGHT

--- a/mods/common/chrome/settings-display.yaml
+++ b/mods/common/chrome/settings-display.yaml
@@ -110,6 +110,13 @@ Container@DISPLAY_PANEL:
 			Height: 20
 			Font: Regular
 			Text: Pause Menu Background
+		Checkbox@UI_FEEDBACK_CHECKBOX:
+			X: 15
+			Y: 163
+			Width: 200
+			Height: 20
+			Font: Regular
+			Text: UI Feedback in Chat
 		Label@VIDEO_TITLE:
 			Y: 190
 			Width: PARENT_RIGHT


### PR DESCRIPTION
This is #17737 stripped down to the core idea:
- Split chat lines into pools (e.g. System, Mission, Chat, Notifications, UI Feedback)
- Allow the player to toggle the display of UI Feedback chat pool

This is the only UI exposed to the player - a checkbox in "Display settings":
![Screenshot_20210208_195234](https://user-images.githubusercontent.com/1355810/111044029-c73e5a80-844e-11eb-9c90-cfed0631e822.png)
![Screenshot_20210208_195512](https://user-images.githubusercontent.com/1355810/111044030-c86f8780-844e-11eb-9ad0-ca7e34a1c8a1.png)

_Display settings_

Repeated messages are merged into one and a counter is displayed:
![image](https://user-images.githubusercontent.com/1355810/101391120-8e7d6b00-38cc-11eb-963a-9b3c5a3170fa.png)
_In game chat_

Closes #16148
Provides the basis for solving #5775, #6400, #6354, #3278 and #12421. These will come in follow-ups.