### PR TITLE
Switch mirror for nsis3 package.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,8 +63,8 @@ notifications:
 
 before_deploy:
  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-     wget https://mirrors.edge.kernel.org/ubuntu/pool/universe/n/nsis/nsis-common_3.04-1_all.deb;
-     wget https://mirrors.edge.kernel.org/ubuntu/pool/universe/n/nsis/nsis_3.04-1_amd64.deb;
+     wget http://ftp.debian.org/debian/pool/main/n/nsis/nsis-common_3.04-1_all.deb;
+     wget http://ftp.debian.org/debian/pool/main/n/nsis/nsis_3.04-1_amd64.deb;
      sudo dpkg -i nsis-common_3.04-1_all.deb;
      sudo dpkg -i nsis_3.04-1_amd64.deb;
      echo ${TRAVIS_REPO_SLUG};


### PR DESCRIPTION
These files has been removed from kernel.org, which will break the packaging.

I tested that these packages work on ubuntu 16.04 via gh actions (which is also configured for 16.04 in this build): https://github.com/pchote/OpenRA/runs/1540214309