### PR TITLE
Added support to detect game installations by uninstaller location

### DIFF
--- a/OpenRA.Mods.Common/ModContent.cs
+++ b/OpenRA.Mods.Common/ModContent.cs
@@ -17,7 +17,7 @@ namespace OpenRA
 {
 	public class ModContent : IGlobalModData
 	{
-		public enum SourceType { Disc, Install }
+		public enum SourceType { Disc, RegistryDirectory, RegistryDirectoryFromFile }
 		public class ModPackage
 		{
 			public readonly string Title;

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
@@ -175,7 +175,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (Platform.CurrentPlatform == PlatformType.Windows)
 				{
 					var installations = missingSources
-						.Where(s => s.Type == ModContent.SourceType.Install)
+						.Where(s => s.Type == ModContent.SourceType.RegistryDirectory || s.Type == ModContent.SourceType.RegistryDirectoryFromFile)
 						.Select(s => s.Title)
 						.Distinct();
 
@@ -476,7 +476,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		string FindSourcePath(ModContent.ModSource source, IEnumerable<string> volumes)
 		{
-			if (source.Type == ModContent.SourceType.Install)
+			if (source.Type == ModContent.SourceType.RegistryDirectory || source.Type == ModContent.SourceType.RegistryDirectoryFromFile)
 			{
 				if (source.RegistryKey == null)
 					return null;
@@ -489,6 +489,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var path = Microsoft.Win32.Registry.GetValue(prefix + source.RegistryKey, source.RegistryValue, null) as string;
 					if (path == null)
 						continue;
+
+					if (source.Type == ModContent.SourceType.RegistryDirectoryFromFile)
+						path = Path.GetDirectoryName(path);
 
 					return IsValidSourcePath(path, source) ? path : null;
 				}

--- a/mods/cnc/installer/origin.yaml
+++ b/mods/cnc/installer/origin.yaml
@@ -1,5 +1,5 @@
 origin: C&C The Ultimate Collection (Origin version, English)
-	Type: Install
+	Type: RegistryDirectory
 	RegistryPrefixes: HKEY_LOCAL_MACHINE\Software\, HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\
 	RegistryKey: EA Games\CNC and The Covert Operations
 	RegistryValue: Install Dir

--- a/mods/d2k/installer/gruntmods.yaml
+++ b/mods/d2k/installer/gruntmods.yaml
@@ -1,5 +1,5 @@
 gruntmods: Dune 2000: GruntMods Edition
-	Type: Install
+	Type: RegistryDirectory
 	RegistryPrefixes: HKEY_LOCAL_MACHINE\Software\, HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\
 	RegistryKey: Dune 2000: Gruntmods Edition
 	IDFiles:

--- a/mods/ra/installer/origin.yaml
+++ b/mods/ra/installer/origin.yaml
@@ -1,5 +1,5 @@
 ra-origin: C&C The Ultimate Collection (Origin version, English)
-	Type: Install
+	Type: RegistryDirectory
 	RegistryPrefixes: HKEY_LOCAL_MACHINE\Software\, HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\
 	RegistryKey: EA Games\Command and Conquer Red Alert
 	RegistryValue: Install Dir
@@ -457,7 +457,7 @@ ra-origin: C&C The Ultimate Collection (Origin version, English)
 				Length: 9073
 
 cnc-origin: Command & Conquer (Origin version, English)
-	Type: Install
+	Type: RegistryDirectory
 	RegistryPrefixes: HKEY_LOCAL_MACHINE\Software\, HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\
 	RegistryKey: EA Games\CNC and The Covert Operations
 	RegistryValue: Install Dir

--- a/mods/ts/installer/origin.yaml
+++ b/mods/ts/installer/origin.yaml
@@ -1,5 +1,5 @@
 origin: C&C The Ultimate Collection (Origin version, English)
-	Type: Install
+	Type: RegistryDirectory
 	RegistryPrefixes: HKEY_LOCAL_MACHINE\Software\, HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\
 	RegistryKey: EA Games\Command and Conquer Tiberian Sun
 	RegistryValue: Install Dir


### PR DESCRIPTION
This is for cases where no `InstallFolder` is available, but the uninstaller executable location is written to the registry and it is located in the game directory, which is quite common place in the 90s.