### PR TITLE
Remove docs, wiki, itch deployment from release packaging.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,19 +67,12 @@ before_deploy:
      wget http://ftp.debian.org/debian/pool/main/n/nsis/nsis_3.04-1_amd64.deb;
      sudo dpkg -i nsis-common_3.04-1_all.deb;
      sudo dpkg -i nsis_3.04-1_amd64.deb;
-     echo ${TRAVIS_REPO_SLUG};
-     if [[ "${TRAVIS_REPO_SLUG}" == "OpenRA/OpenRA" ]]; then
-       cd packaging && ./update-wiki.sh ${TRAVIS_TAG} && ./update-docs.sh ${TRAVIS_TAG} && cd ..;
-     fi;
    fi
  - export PATH=${PATH}:${HOME}/usr/bin
  - DOTVERSION=`echo ${TRAVIS_TAG} | sed "s/-/\\./g"`
  - cd packaging
  - mkdir build
  - ./package-all.sh ${TRAVIS_TAG} ${PWD}/build/
- - if [[ "${TRAVIS_REPO_SLUG}" == "OpenRA/OpenRA" ]]; then
-     ./upload-itch.sh ${TRAVIS_TAG} ${PWD}/build/;
-   fi
 
 deploy:
   provider: releases


### PR DESCRIPTION
Our first attempt to tag a playtest failed due to `update-docs.sh` having the wrong file permissions. We could fix this, but we don't know if there are other errors hiding in that script or the itch deployment. Each release package attempt burns about 10% of our total free travis-ci allowance, so we would be risking being left in a situation where we are unable to package the final release build, and therefore forced to switch to github actions sooner than we want to and without sufficient testing.

The safer option is to disable these untested steps from travis, and use #18899 to deploy them via github actions (see my latest comment there).

Edit: It looks like the wiki deployment also failed, deleting the page content instead of updating it: https://github.com/OpenRA/OpenRA/wiki/Settings-(playtest)/_compare/677e2508adf376eed5443dc2b246271b07658aba