### PR TITLE
Add EVA transcriptions to the chat

### DIFF
--- a/OpenRA.Game/GameRules/SoundInfo.cs
+++ b/OpenRA.Game/GameRules/SoundInfo.cs
@@ -33,7 +33,7 @@ namespace OpenRA.GameRules
 		{
 			FieldLoader.Load(this, y);
 
-			VoicePools = Exts.Lazy(() => Voices.ToDictionary(a => a.Key, a => new SoundPool(1f, a.Value)));
+			VoicePools = Exts.Lazy(() => Voices.ToDictionary(a => a.Key, a => new SoundPool(1f, "", a.Value)));
 			NotificationsPools = Exts.Lazy(() => ParseSoundPool(y, "Notifications"));
 		}
 
@@ -48,8 +48,13 @@ namespace OpenRA.GameRules
 				if (volumeModifierNode != null)
 					volumeModifier = FieldLoader.GetValue<float>(volumeModifierNode.Key, volumeModifierNode.Value.Value);
 
+				var transcription = "";
+				var transcriptionNode = t.Value.Nodes.FirstOrDefault(x => x.Key == "Transcription");
+				if (transcriptionNode != null)
+					transcription = FieldLoader.GetValue<string>(transcriptionNode.Key, transcriptionNode.Value.Value);
+
 				var names = FieldLoader.GetValue<string[]>(t.Key, t.Value.Value);
-				var sp = new SoundPool(volumeModifier, names);
+				var sp = new SoundPool(volumeModifier, transcription, names);
 				ret.Add(t.Key, sp);
 			}
 
@@ -60,12 +65,14 @@ namespace OpenRA.GameRules
 	public class SoundPool
 	{
 		public readonly float VolumeModifier;
+		public readonly string Transcription;
 		readonly string[] clips;
 		readonly List<string> liveclips = new List<string>();
 
-		public SoundPool(float volumeModifier, params string[] clips)
+		public SoundPool(float volumeModifier, string transcription, params string[] clips)
 		{
 			VolumeModifier = volumeModifier;
+			Transcription = transcription;
 			this.clips = clips;
 		}
 

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -50,9 +50,9 @@ namespace OpenRA.Network
 		readonly List<Order> localOrders = new List<Order>();
 		readonly List<Order> localImmediateOrders = new List<Order>();
 
-		readonly List<ChatLine> chatCache = new List<ChatLine>();
+		readonly List<TextNotification> notificationsCache = new List<TextNotification>();
 
-		public IReadOnlyList<ChatLine> ChatCache => chatCache;
+		public IReadOnlyList<TextNotification> NotificationsCache => notificationsCache;
 
 		bool disposed;
 		bool generateSyncReport = false;
@@ -100,7 +100,7 @@ namespace OpenRA.Network
 			Password = password;
 			Connection = conn;
 			syncReport = new SyncReport(this);
-			AddChatLine += CacheChatLine;
+			AddTextNotification += CacheTextNotification;
 		}
 
 		public void IssueOrders(Order[] orders)
@@ -117,10 +117,10 @@ namespace OpenRA.Network
 				localOrders.Add(order);
 		}
 
-		public Action<string, Color, string, Color> AddChatLine = (n, nc, s, tc) => { };
-		void CacheChatLine(string name, Color nameColor, string text, Color textColor)
+		public Action<TextNotification> AddTextNotification = (notification) => { };
+		void CacheTextNotification(TextNotification notification)
 		{
-			chatCache.Add(new ChatLine(name, nameColor, text, textColor));
+			notificationsCache.Add(notification);
 		}
 
 		public void TickImmediate()
@@ -244,22 +244,6 @@ namespace OpenRA.Network
 		{
 			disposed = true;
 			Connection?.Dispose();
-		}
-	}
-
-	public class ChatLine
-	{
-		public readonly Color Color;
-		public readonly string Name;
-		public readonly string Text;
-		public readonly Color TextColor;
-
-		public ChatLine(string name, Color nameColor, string text, Color textColor)
-		{
-			Color = nameColor;
-			Name = name;
-			Text = text;
-			TextColor = textColor;
 		}
 	}
 }

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Network
 							if (orderManager.LocalClient != null && client != orderManager.LocalClient && client.Team > 0 && client.Team == orderManager.LocalClient.Team)
 								suffix += " (Ally)";
 
-							TextNotificationsManager.AddChatLine(client.Name + suffix, client.Color, message);
+							TextNotificationsManager.AddChatLine(client.Name + suffix, message, client.Color);
 							break;
 						}
 
@@ -79,7 +79,7 @@ namespace OpenRA.Network
 						{
 							var prefix = order.ExtraData == uint.MaxValue ? "[Spectators] " : "[Team] ";
 							if (orderManager.LocalClient != null && client.Team == orderManager.LocalClient.Team)
-								TextNotificationsManager.AddChatLine(prefix + client.Name, client.Color, message);
+								TextNotificationsManager.AddChatLine(prefix + client.Name, message, client.Color);
 
 							break;
 						}
@@ -93,7 +93,7 @@ namespace OpenRA.Network
 						{
 							// Validate before adding the line
 							if (client.IsObserver || (player != null && player.WinState != WinState.Undefined))
-								TextNotificationsManager.AddChatLine("[Spectators] " + client.Name, client.Color, message);
+								TextNotificationsManager.AddChatLine("[Spectators] " + client.Name, message, client.Color);
 
 							break;
 						}
@@ -103,7 +103,7 @@ namespace OpenRA.Network
 							&& world.LocalPlayer != null && world.LocalPlayer.WinState == WinState.Undefined;
 
 						if (valid && (isSameTeam || world.IsReplay))
-							TextNotificationsManager.AddChatLine("[Team" + (world.IsReplay ? " " + order.ExtraData : "") + "] " + client.Name, client.Color, message);
+							TextNotificationsManager.AddChatLine("[Team" + (world.IsReplay ? " " + order.ExtraData : "") + "] " + client.Name, message, client.Color);
 
 						break;
 					}

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -33,6 +33,12 @@ namespace OpenRA
 		Incompatible = 16
 	}
 
+	[Flags]
+	public enum TextNotificationPoolFilters
+	{
+		None = 0
+	}
+
 	public enum WorldViewport { Native, Close, Medium, Far }
 
 	public class ServerSettings
@@ -265,6 +271,8 @@ namespace OpenRA
 
 		[Desc("Allow mods to enable the Discord service that can interact with a local Discord client.")]
 		public bool EnableDiscordService = true;
+
+		public TextNotificationPoolFilters TextNotificationPoolFilters = TextNotificationPoolFilters.None;
 	}
 
 	public class Settings

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -36,7 +36,8 @@ namespace OpenRA
 	[Flags]
 	public enum TextNotificationPoolFilters
 	{
-		None = 0
+		None = 0,
+		Feedback = 1
 	}
 
 	public enum WorldViewport { Native, Close, Medium, Far }
@@ -272,7 +273,7 @@ namespace OpenRA
 		[Desc("Allow mods to enable the Discord service that can interact with a local Discord client.")]
 		public bool EnableDiscordService = true;
 
-		public TextNotificationPoolFilters TextNotificationPoolFilters = TextNotificationPoolFilters.None;
+		public TextNotificationPoolFilters TextNotificationPoolFilters = TextNotificationPoolFilters.Feedback;
 	}
 
 	public class Settings

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -37,7 +37,8 @@ namespace OpenRA
 	public enum TextNotificationPoolFilters
 	{
 		None = 0,
-		Feedback = 1
+		Feedback = 1,
+		Transcriptions = 2
 	}
 
 	public enum WorldViewport { Native, Close, Medium, Far }

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -391,6 +391,9 @@ namespace OpenRA
 
 					currentSounds[id] = sound;
 				}
+
+				if (!string.IsNullOrEmpty(pool.Transcription))
+					TextNotificationsManager.AddTranscribedLine(pool.Transcription);
 			}
 
 			return true;

--- a/OpenRA.Game/TextNotification.cs
+++ b/OpenRA.Game/TextNotification.cs
@@ -14,7 +14,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA
 {
-	public enum TextNotificationPool { System, Chat, Mission, Feedback }
+	public enum TextNotificationPool { System, Chat, Mission, Feedback, Transcriptions }
 
 	public class TextNotification : IEquatable<TextNotification>
 	{
@@ -35,7 +35,7 @@ namespace OpenRA
 
 		public bool CanIncrementOnDuplicate()
 		{
-			return Pool == TextNotificationPool.Feedback || Pool == TextNotificationPool.System;
+			return Pool == TextNotificationPool.Transcriptions || Pool == TextNotificationPool.Feedback || Pool == TextNotificationPool.System;
 		}
 
 		public bool Equals(TextNotification other)

--- a/OpenRA.Game/TextNotification.cs
+++ b/OpenRA.Game/TextNotification.cs
@@ -1,0 +1,56 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using OpenRA.Primitives;
+
+namespace OpenRA
+{
+	public enum TextNotificationPool { System, Chat, Mission, Feedback }
+
+	public class TextNotification : IEquatable<TextNotification>
+	{
+		public readonly Color PrefixColor;
+		public readonly string Prefix;
+		public readonly string Text;
+		public readonly Color TextColor;
+		public readonly TextNotificationPool Pool;
+
+		public TextNotification(TextNotificationPool pool, string prefix, string text, Color prefixColor, Color textColor)
+		{
+			Pool = pool;
+			Prefix = prefix;
+			Text = text;
+			PrefixColor = prefixColor;
+			TextColor = textColor;
+		}
+
+		public bool CanIncrementOnDuplicate()
+		{
+			return Pool == TextNotificationPool.Feedback || Pool == TextNotificationPool.System;
+		}
+
+		public bool Equals(TextNotification other)
+		{
+			return other != null && other.GetHashCode() == GetHashCode();
+		}
+
+		public override bool Equals(object obj)
+		{
+			return obj is TextNotification && Equals((TextNotification)obj);
+		}
+
+		public override int GetHashCode()
+		{
+			return string.Format("{0}{1}{2}", Prefix, Text, Pool).GetHashCode();
+		}
+	}
+}

--- a/OpenRA.Game/TextNotificationsManager.cs
+++ b/OpenRA.Game/TextNotificationsManager.cs
@@ -28,24 +28,46 @@ namespace OpenRA
 				systemMessageLabel = "Battlefield Control";
 		}
 
+		public static void AddFeedbackLine(string text)
+		{
+			AddTextNotification(TextNotificationPool.Feedback, systemMessageLabel, text, systemMessageColor, systemMessageColor);
+		}
+
 		public static void AddSystemLine(string text)
 		{
 			AddSystemLine(systemMessageLabel, text);
 		}
 
-		public static void AddSystemLine(string name, string text)
+		public static void AddSystemLine(string prefix, string text)
 		{
-			Game.OrderManager.AddChatLine(name, systemMessageColor, text, systemMessageColor);
+			AddTextNotification(TextNotificationPool.System, prefix, text, systemMessageColor, systemMessageColor);
 		}
 
-		public static void AddChatLine(string name, Color nameColor, string text)
+		public static void AddChatLine(string prefix, string text, Color? prefixColor = null, Color? textColor = null)
 		{
-			Game.OrderManager.AddChatLine(name, nameColor, text, chatMessageColor);
+			AddTextNotification(TextNotificationPool.Chat, prefix, text, prefixColor, textColor);
 		}
 
 		public static void Debug(string s, params object[] args)
 		{
 			AddSystemLine("Debug", string.Format(s, args));
+		}
+
+		static void AddTextNotification(TextNotificationPool pool, string prefix, string text, Color? prefixColor = null, Color? textColor = null)
+		{
+			var thePrefixColor = prefixColor ?? chatMessageColor;
+			var theColor = textColor ?? chatMessageColor;
+
+			if (IsPoolEnabled(pool))
+				Game.OrderManager.AddTextNotification(new TextNotification(pool, prefix, text, thePrefixColor, theColor));
+		}
+
+		static bool IsPoolEnabled(TextNotificationPool pool)
+		{
+			return pool == TextNotificationPool.Chat ||
+				pool == TextNotificationPool.System ||
+				pool == TextNotificationPool.Mission ||
+				pool == TextNotificationPool.Feedback;
 		}
 	}
 }

--- a/OpenRA.Game/TextNotificationsManager.cs
+++ b/OpenRA.Game/TextNotificationsManager.cs
@@ -64,10 +64,12 @@ namespace OpenRA
 
 		static bool IsPoolEnabled(TextNotificationPool pool)
 		{
+			var filters = Game.Settings.Game.TextNotificationPoolFilters;
+
 			return pool == TextNotificationPool.Chat ||
 				pool == TextNotificationPool.System ||
 				pool == TextNotificationPool.Mission ||
-				pool == TextNotificationPool.Feedback;
+				(pool == TextNotificationPool.Feedback && filters.HasFlag(TextNotificationPoolFilters.Feedback));
 		}
 	}
 }

--- a/OpenRA.Game/TextNotificationsManager.cs
+++ b/OpenRA.Game/TextNotificationsManager.cs
@@ -28,6 +28,11 @@ namespace OpenRA
 				systemMessageLabel = "Battlefield Control";
 		}
 
+		public static void AddTranscribedLine(string text)
+		{
+			AddTextNotification(TextNotificationPool.Transcriptions, systemMessageLabel, text, systemMessageColor, systemMessageColor);
+		}
+
 		public static void AddFeedbackLine(string text)
 		{
 			AddTextNotification(TextNotificationPool.Feedback, systemMessageLabel, text, systemMessageColor, systemMessageColor);
@@ -69,7 +74,8 @@ namespace OpenRA
 			return pool == TextNotificationPool.Chat ||
 				pool == TextNotificationPool.System ||
 				pool == TextNotificationPool.Mission ||
-				(pool == TextNotificationPool.Feedback && filters.HasFlag(TextNotificationPoolFilters.Feedback));
+				(pool == TextNotificationPool.Feedback && filters.HasFlag(TextNotificationPoolFilters.Feedback)) ||
+				(pool == TextNotificationPool.Transcriptions && filters.HasFlag(TextNotificationPoolFilters.Transcriptions));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -194,7 +194,7 @@ namespace OpenRA.Mods.Common.Scripting
 				return;
 
 			var c = color.HasValue ? color.Value : Color.White;
-			TextNotificationsManager.AddChatLine(prefix, c, text);
+			TextNotificationsManager.AddChatLine(prefix, text, c);
 		}
 
 		[Desc("Display a system message to the player. If 'prefix' is nil the default system prefix is used.")]

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -39,6 +39,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		readonly string chatLineSound = ChromeMetrics.Get<string>("ChatLineSound");
 
+		TextNotification lastLine;
+		int repetitions;
+
 		[ObjectCreator.UseCtor]
 		public IngameChatLogic(Widget widget, OrderManager orderManager, World world, ModData modData, bool isMenuChat, Dictionary<string, MiniYaml> logicArgs)
 		{
@@ -182,10 +185,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			chatScrollPanel.RemoveChildren();
 			chatScrollPanel.ScrollToBottom();
 
-			foreach (var chatLine in orderManager.ChatCache)
-				AddChatLine(chatLine.Name, chatLine.Color, chatLine.Text, chatLine.TextColor, true);
+			foreach (var chatLine in orderManager.NotificationsCache)
+				AddChatLine(chatLine, true);
 
-			orderManager.AddChatLine += AddChatLineWrapper;
+			orderManager.AddTextNotification += AddChatLineWrapper;
 
 			chatText.IsDisabled = () => world.IsReplay && !Game.Settings.Debug.EnableDebugCommandsInReplays;
 
@@ -231,38 +234,58 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			chatOverlay.Visible = true;
 		}
 
-		public void AddChatLineWrapper(string name, Color nameColor, string text, Color textColor)
+		public void AddChatLineWrapper(TextNotification chatLine)
 		{
-			chatOverlayDisplay?.AddLine(name, nameColor, text, textColor);
+			var chatLineToDisplay = chatLine;
+
+			if (chatLine.CanIncrementOnDuplicate() && chatLine.Equals(lastLine))
+			{
+				repetitions++;
+				chatLineToDisplay = new TextNotification(
+					chatLine.Pool,
+					chatLine.Prefix,
+					string.Format("{0} ({1})", chatLine.Text, repetitions + 1),
+					chatLine.PrefixColor,
+					chatLine.TextColor);
+
+				chatScrollPanel.RemoveChild(chatScrollPanel.Children[chatScrollPanel.Children.Count - 1]);
+				chatOverlayDisplay?.RemoveMostRecentLine();
+			}
+			else
+				repetitions = 0;
+
+			lastLine = chatLine;
+
+			chatOverlayDisplay?.AddLine(chatLineToDisplay);
 
 			// HACK: Force disable the chat notification sound for the in-menu chat dialog
 			// This works around our inability to disable the sounds for the in-game dialog when it is hidden
-			AddChatLine(name, nameColor, text, textColor, chatOverlay == null);
+			AddChatLine(chatLineToDisplay, chatOverlay == null);
 		}
 
-		void AddChatLine(string @from, Color nameColor, string text, Color textColor, bool suppressSound)
+		void AddChatLine(TextNotification chatLine, bool suppressSound)
 		{
 			var template = chatTemplate.Clone();
 			var nameLabel = template.Get<LabelWidget>("NAME");
 			var textLabel = template.Get<LabelWidget>("TEXT");
 
 			var name = "";
-			if (!string.IsNullOrEmpty(from))
-				name = from + ":";
+			if (!string.IsNullOrEmpty(chatLine.Prefix))
+				name = chatLine.Prefix + ":";
 
 			var font = Game.Renderer.Fonts[nameLabel.Font];
-			var nameSize = font.Measure(from);
+			var nameSize = font.Measure(chatLine.Prefix);
 
-			nameLabel.GetColor = () => nameColor;
+			nameLabel.GetColor = () => chatLine.PrefixColor;
 			nameLabel.GetText = () => name;
 			nameLabel.Bounds.Width = nameSize.X;
 
-			textLabel.GetColor = () => textColor;
+			textLabel.GetColor = () => chatLine.TextColor;
 			textLabel.Bounds.X += nameSize.X;
 			textLabel.Bounds.Width -= nameSize.X;
 
 			// Hack around our hacky wordwrap behavior: need to resize the widget to fit the text
-			text = WidgetUtils.WrapText(text, textLabel.Bounds.Width, font);
+			var text = WidgetUtils.WrapText(chatLine.Text, textLabel.Bounds.Width, font);
 			textLabel.GetText = () => text;
 			var dh = font.Measure(text).Y - textLabel.Bounds.Height;
 			if (dh > 0)
@@ -285,7 +308,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			if (!disposed)
 			{
-				orderManager.AddChatLine -= AddChatLineWrapper;
+				orderManager.AddTextNotification -= AddChatLineWrapper;
 				disposed = true;
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			services = modData.Manifest.Get<WebServices>();
 
-			orderManager.AddChatLine += AddChatLine;
+			orderManager.AddTextNotification += AddChatLine;
 			Game.LobbyInfoChanged += UpdateCurrentMap;
 			Game.LobbyInfoChanged += UpdatePlayerList;
 			Game.LobbyInfoChanged += UpdateDiscordStatus;
@@ -463,7 +463,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (disposing && !disposed)
 			{
 				disposed = true;
-				orderManager.AddChatLine -= AddChatLine;
+				orderManager.AddTextNotification -= AddChatLine;
 				Game.LobbyInfoChanged -= UpdateCurrentMap;
 				Game.LobbyInfoChanged -= UpdatePlayerList;
 				Game.LobbyInfoChanged -= UpdateDiscordStatus;
@@ -486,10 +486,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				panel = PanelType.Players;
 		}
 
-		void AddChatLine(string name, Color nameColor, string text, Color textColor)
+		void AddChatLine(TextNotification chatLine)
 		{
 			var template = (ContainerWidget)chatTemplate.Clone();
-			LobbyUtils.SetupChatLine(template, DateTime.Now, name, nameColor, text, textColor);
+			LobbyUtils.SetupChatLine(template, DateTime.Now, chatLine);
 
 			var scrolledToBottom = lobbyChatPanel.ScrolledToBottom;
 			lobbyChatPanel.AddChild(template);

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -651,28 +651,28 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			HideChildWidget(parent, "STATUS_IMAGE");
 		}
 
-		public static void SetupChatLine(ContainerWidget template, DateTime time, string name, Color nameColor, string text, Color textColor)
+		public static void SetupChatLine(ContainerWidget template, DateTime time, TextNotification chatLine)
 		{
 			var nameLabel = template.Get<LabelWidget>("NAME");
 			var timeLabel = template.Get<LabelWidget>("TIME");
 			var textLabel = template.Get<LabelWidget>("TEXT");
 
-			var nameText = name + ":";
+			var nameText = chatLine.Prefix + ":";
 			var font = Game.Renderer.Fonts[nameLabel.Font];
 			var nameSize = font.Measure(nameText);
 
 			timeLabel.GetText = () => $"{time.Hour:D2}:{time.Minute:D2}";
 
-			nameLabel.GetColor = () => nameColor;
+			nameLabel.GetColor = () => chatLine.PrefixColor;
 			nameLabel.GetText = () => nameText;
 			nameLabel.Bounds.Width = nameSize.X;
 
-			textLabel.GetColor = () => textColor;
+			textLabel.GetColor = () => chatLine.TextColor;
 			textLabel.Bounds.X += nameSize.X;
 			textLabel.Bounds.Width -= nameSize.X;
 
 			// Hack around our hacky wordwrap behavior: need to resize the widget to fit the text
-			text = WidgetUtils.WrapText(text, textLabel.Bounds.Width, font);
+			var text = WidgetUtils.WrapText(chatLine.Text, textLabel.Bounds.Width, font);
 			textLabel.GetText = () => text;
 			var dh = font.Measure(text).Y - textLabel.Bounds.Height;
 			if (dh > 0)

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -106,6 +106,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			battlefieldCameraDropDown.OnMouseDown = _ => ShowBattlefieldCameraDropdown(battlefieldCameraDropDown, viewportSizes, ds);
 			battlefieldCameraDropDown.GetText = () => battlefieldCameraLabel.Update(ds.ViewportDistance);
 
+			BindTextNotificationPoolFilterSettings(panel, gs);
+
 			// Update vsync immediately
 			var vsyncCheckbox = panel.Get<CheckboxWidget>("VSYNC_CHECKBOX");
 			var vsyncOnClick = vsyncCheckbox.OnClick;
@@ -211,8 +213,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var ds = Game.Settings.Graphics;
 			var ps = Game.Settings.Player;
+			var gs = Game.Settings.Game;
 			var dds = new GraphicSettings();
 			var dps = new PlayerSettings();
+			var dgs = new GameSettings();
 			return () =>
 			{
 				ds.CapFramerate = dds.CapFramerate;
@@ -235,6 +239,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				ps.Color = dps.Color;
 				ps.Name = dps.Name;
+
+				gs.TextNotificationPoolFilters = dgs.TextNotificationPoolFilters;
 			};
 		}
 
@@ -258,6 +264,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, setupItem);
+		}
+
+		public static void BindTextNotificationPoolFilterSettings(Widget panel, GameSettings gs)
+		{
+			Action<TextNotificationPoolFilters> toggleFilterFlag = f =>
+			{
+				gs.TextNotificationPoolFilters ^= f;
+				Game.Settings.Save();
+			};
+
+			var feedbackCheckbox = panel.GetOrNull<CheckboxWidget>("UI_FEEDBACK_CHECKBOX");
+			if (feedbackCheckbox != null)
+			{
+				feedbackCheckbox.IsChecked = () => gs.TextNotificationPoolFilters.HasFlag(TextNotificationPoolFilters.Feedback);
+				feedbackCheckbox.OnClick = () => toggleFilterFlag(TextNotificationPoolFilters.Feedback);
+			}
 		}
 
 		static void ShowStatusBarsDropdown(DropDownButtonWidget dropdown, GameSettings s)

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -274,6 +274,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Game.Settings.Save();
 			};
 
+			var transcriptionsCheckbox = panel.GetOrNull<CheckboxWidget>("TRANSCRIPTIONS_CHECKBOX");
+			if (transcriptionsCheckbox != null)
+			{
+				transcriptionsCheckbox.IsChecked = () => gs.TextNotificationPoolFilters.HasFlag(TextNotificationPoolFilters.Transcriptions);
+				transcriptionsCheckbox.OnClick = () => toggleFilterFlag(TextNotificationPoolFilters.Transcriptions);
+			}
+
 			var feedbackCheckbox = panel.GetOrNull<CheckboxWidget>("UI_FEEDBACK_CHECKBOX");
 			if (feedbackCheckbox != null)
 			{

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -261,12 +261,12 @@ namespace OpenRA.Mods.Common.Widgets
 
 					// Check if selecting actors on the screen has selected new units
 					if (ownUnitsOnScreen.Count > World.Selection.Actors.Count())
-						TextNotificationsManager.AddSystemLine("Selected across screen");
+						TextNotificationsManager.AddFeedbackLine("Selected across screen");
 					else
 					{
 						// Select actors in the world that have highest selection priority
 						ownUnitsOnScreen = SelectActorsInWorld(World, null, eligiblePlayers).SubsetWithHighestSelectionPriority(e.Modifiers).ToList();
-						TextNotificationsManager.AddSystemLine("Selected across map");
+						TextNotificationsManager.AddFeedbackLine("Selected across map");
 					}
 
 					World.Selection.Combine(World, ownUnitsOnScreen, false, false);
@@ -293,12 +293,12 @@ namespace OpenRA.Mods.Common.Widgets
 
 					// Check if selecting actors on the screen has selected new units
 					if (newSelection.Count > World.Selection.Actors.Count())
-						TextNotificationsManager.AddSystemLine("Selected across screen");
+						TextNotificationsManager.AddFeedbackLine("Selected across screen");
 					else
 					{
 						// Select actors in the world that have the same selection class as one of the already selected actors
 						newSelection = SelectActorsInWorld(World, selectedClasses, eligiblePlayers).ToList();
-						TextNotificationsManager.AddSystemLine("Selected across map");
+						TextNotificationsManager.AddFeedbackLine("Selected across map");
 					}
 
 					World.Selection.Combine(World, newSelection, true, false);

--- a/mods/cnc/audio/notifications.yaml
+++ b/mods/cnc/audio/notifications.yaml
@@ -4,50 +4,78 @@ Speech:
 		nod: nod
 	Notifications:
 		AirstrikeReady: airredy1
+			Transcription: Airstrike ready.
 		BaseAttack: baseatk1
+			Transcription: Our base is under attack.
 		Building: bldging1
 		BuildingCannotPlaceAudio: deploy1
+			Transcription: Cannot deploy here.
 		BuildingCaptured: capt1
+			Transcription: Building captured.
 		BuildingInProgress: bldg1
+			Transcription: Unable to comply. Building in progress.
 		BuildingLost: strclost
+			Transcription: Structure lost.
 		Cancelled: cancel1
 		CivilianBuildingCaptured: civcapt1
+			Transcription: Civilian building captured.
 		CivilianKilled: civdead1
+			Transcription: Civilian killed.
 		ConstructionComplete: constru1
+			Transcription: Construction complete.
 		EnemyUnitsApproaching: enmyunit
+			Transcription: Enemy approaching.
 		EnemyStructureDestroyed: estrucx
+			Transcription: Enemy structure destroyed.
 		EnemyPlanesApproaching: enemya
+			Transcription: Enemy planes approaching.
 		HarvesterAttack:
 		HarvesterLost: harvlost
+			Transcription: Harvester lost.
 		InsufficientPower: nopower1
+			Transcription: Insufficient power.
 		IonCannonCharging: ionchrg1
+			Transcription: Ion cannon charging.
 		IonCannonReady: ionredy1
+			Transcription: Ion cannon ready.
 		Leave: batlcon1
+			Transcription: Battle control terminated.
 		Lose: fail1
+			Transcription: Your mission is a failure.
 		LowPower: lopower1
+			Transcription: Low power.
 		MissionAccomplished: accom1
 		MissionFailed: fail1
 		NewOptions: newopt1
+			Transcription: New construction options.
 		NoBuild: nobuild1
+			Transcription: Unable to build more.
 		NodStructureDestroyed: nstruc1
 		NotReady: noredy1
 		NuclearWarheadApproaching: nuke1
+			Transcription: Nuclear warhead approaching.
 		NuclearWeaponAvailable: nukavail
+			Transcription: Nuclear weapon available.
 		NuclearWeaponLaunched: nuklnch1
 		OnHold: onhold1
 		PrimaryBuildingSelected: pribldg1
 		Reinforce: reinfor1
+			Transcription: Reinforcements have arrived.
 		Repairing: repair1
 		SelectTarget: select1
 		SilosNeeded: silos1
+			Transcription: Silos needed.
 		StartGame:
 		GameLoaded:
 		GameSaved:
 		Training: bldging1
 		UnitDestroyed: dead1
 		UnitLost: unitlost
+			Transcription: Unit lost.
 		UnitReady: unitredy
+			Transcription: Unit ready.
 		Win: accom1
+			Transcription: Mission accomplished.
 	DisablePrefixes: AirstrikeReady, BaseAttack, Building, BuildingCannotPlaceAudio, BuildingInProgress, BuildingLost, Cancelled, CivilianBuildingCaptured, CivilianKilled, ConstructionComplete, EnemyUnitsApproaching, EnemyStructureDestroyed, EnemyPlanesApproaching, HarvesterAttack, HarvesterLost, InsufficientPower, IonCannonCharging, IonCannonReady, Leave, Lose, LowPower, MissionAccomplished, MissionFailed, NewOptions, NoBuild, NodStructureDestroyed, NotReady, NuclearWarheadApproaching, NuclearWeaponAvailable, NuclearWeaponLaunched, OnHold, PrimaryBuildingSelected, Reinforce, Repairing, SelectTarget, SilosNeeded, Training, UnitLost, UnitReady, Win
 
 Sounds:

--- a/mods/cnc/chrome/settings-display.yaml
+++ b/mods/cnc/chrome/settings-display.yaml
@@ -109,6 +109,13 @@ Container@DISPLAY_PANEL:
 			Height: 20
 			Font: Regular
 			Text: Player Stance Colors
+		Checkbox@UI_FEEDBACK_CHECKBOX:
+			X: 15
+			Y: 163
+			Width: 200
+			Height: 20
+			Font: Regular
+			Text: UI Feedback in Chat
 		Label@VIDEO_TITLE:
 			Y: 190
 			Width: PARENT_RIGHT

--- a/mods/cnc/chrome/settings-display.yaml
+++ b/mods/cnc/chrome/settings-display.yaml
@@ -116,6 +116,13 @@ Container@DISPLAY_PANEL:
 			Height: 20
 			Font: Regular
 			Text: UI Feedback in Chat
+		Checkbox@TRANSCRIPTIONS_CHECKBOX:
+			X: 310
+			Y: 163
+			Width: 200
+			Height: 20
+			Font: Regular
+			Text: Transcriptions in Chat
 		Label@VIDEO_TITLE:
 			Y: 190
 			Width: PARENT_RIGHT

--- a/mods/common/chrome/settings-display.yaml
+++ b/mods/common/chrome/settings-display.yaml
@@ -110,6 +110,13 @@ Container@DISPLAY_PANEL:
 			Height: 20
 			Font: Regular
 			Text: Pause Menu Background
+		Checkbox@UI_FEEDBACK_CHECKBOX:
+			X: 15
+			Y: 163
+			Width: 200
+			Height: 20
+			Font: Regular
+			Text: UI Feedback in Chat
 		Label@VIDEO_TITLE:
 			Y: 190
 			Width: PARENT_RIGHT


### PR DESCRIPTION
This expands the chat pool idea to include transcriptions of EVA quotes. I implemented it only for TD because it has fewer quotes and I'm quite familiar with them. Not all quotes have been transcribed as I think some of the would be just noise (e.g. _"Building"_, _"Training"_, _"On hold"_). What to include is up for discussion of course.

![image](https://user-images.githubusercontent.com/1355810/102137523-a2dcdd00-3e63-11eb-83b1-026a0add6e0f.png)
_In-game view_

![image](https://user-images.githubusercontent.com/1355810/102137537-a83a2780-3e63-11eb-9d63-7f037ab6303f.png)
_Settings panel_

The commits are split though perhaps it make sense to squash them as the feature won't be complete without them all :man_shrugging: 

Depends on #18905
Closes #6400
Closes #6354
Closes #3278
Closes #12954