### PR TITLE
Enabled debug mode by default on Linux launch scripts

### DIFF
--- a/launch-game.sh
+++ b/launch-game.sh
@@ -25,7 +25,7 @@ then
 fi
 
 # Launch the engine with the appropriate arguments
-mono bin/OpenRA.exe Engine.EngineDir=".." Engine.LaunchPath="$MODLAUNCHER" $MODARG "$@"
+mono --debug bin/OpenRA.exe Engine.EngineDir=".." Engine.LaunchPath="$MODLAUNCHER" $MODARG "$@"
 
 # Show a crash dialog if something went wrong
 if [ $? != 0 ] && [ $? != 1 ]; then


### PR DESCRIPTION
The performance overhead is minor and getting line numbers in stack traces is really valuable for development.