### PR TITLE
Fix bogus SpriteFrameType channel handling

### DIFF
--- a/OpenRA.Game/Graphics/CursorManager.cs
+++ b/OpenRA.Game/Graphics/CursorManager.cs
@@ -72,10 +72,10 @@ namespace OpenRA.Graphics
 					// Resolve indexed data to real colours
 					var data = f.Data;
 					var type = f.Type;
-					if (type == SpriteFrameType.Indexed)
+					if (type == SpriteFrameType.Indexed8)
 					{
 						data = ConvertIndexedToBgra(kv.Key, f, palette);
-						type = SpriteFrameType.BGRA;
+						type = SpriteFrameType.Bgra32;
 					}
 
 					c.Sprites[c.Length++] = sheetBuilder.Add(data, type, f.Size, 0, hotspot);
@@ -226,7 +226,7 @@ namespace OpenRA.Graphics
 
 		public static byte[] ConvertIndexedToBgra(string name, ISpriteFrame frame, ImmutablePalette palette)
 		{
-			if (frame.Type != SpriteFrameType.Indexed)
+			if (frame.Type != SpriteFrameType.Indexed8)
 				throw new ArgumentException("ConvertIndexedToBgra requires input frames to be indexed.", nameof(frame));
 
 			// All palettes must be explicitly referenced, even if they are embedded in the sprite.

--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -79,21 +79,17 @@ namespace OpenRA.Graphics
 
 		public Png AsPng()
 		{
-			var data = GetData();
+			if (Type == SheetType.Indexed)
+				throw new InvalidOperationException("AsPng() cannot be called on Indexed sheets.");
 
-			// Convert BGRA to RGBA
-			for (var i = 0; i < Size.Width * Size.Height; i++)
-			{
-				var temp = data[i * 4];
-				data[i * 4] = data[i * 4 + 2];
-				data[i * 4 + 2] = temp;
-			}
-
-			return new Png(data, Size.Width, Size.Height);
+			return new Png(GetData(), SpriteFrameType.BGRA, Size.Width, Size.Height);
 		}
 
 		public Png AsPng(TextureChannel channel, IPalette pal)
 		{
+			if (Type != SheetType.Indexed)
+				throw new InvalidOperationException("AsPng(TextureChannel, IPalette) can only be called on Indexed sheets.");
+
 			var d = GetData();
 			var plane = new byte[Size.Width * Size.Height];
 			var dataStride = 4 * Size.Width;
@@ -107,7 +103,7 @@ namespace OpenRA.Graphics
 			for (var i = 0; i < Palette.Size; i++)
 				palColors[i] = pal.GetColor(i);
 
-			return new Png(plane, Size.Width, Size.Height, palColors);
+			return new Png(plane, SpriteFrameType.BGRA, Size.Width, Size.Height, palColors);
 		}
 
 		public void CreateBuffer()

--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Graphics
 			if (Type == SheetType.Indexed)
 				throw new InvalidOperationException("AsPng() cannot be called on Indexed sheets.");
 
-			return new Png(GetData(), SpriteFrameType.BGRA, Size.Width, Size.Height);
+			return new Png(GetData(), SpriteFrameType.Bgra32, Size.Width, Size.Height);
 		}
 
 		public Png AsPng(TextureChannel channel, IPalette pal)
@@ -103,7 +103,7 @@ namespace OpenRA.Graphics
 			for (var i = 0; i < Palette.Size; i++)
 				palColors[i] = pal.GetColor(i);
 
-			return new Png(plane, SpriteFrameType.BGRA, Size.Width, Size.Height, palColors);
+			return new Png(plane, SpriteFrameType.Bgra32, Size.Width, Size.Height, palColors);
 		}
 
 		public void CreateBuffer()

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -52,8 +52,15 @@ namespace OpenRA.Graphics
 		{
 			switch (t)
 			{
-				case SpriteFrameType.Indexed: return SheetType.Indexed;
-				case SpriteFrameType.BGRA: return SheetType.BGRA;
+				case SpriteFrameType.Indexed:
+					return SheetType.Indexed;
+
+				// Util.FastCopyIntoChannel will automatically convert these to BGRA
+				case SpriteFrameType.BGRA:
+				case SpriteFrameType.BGR:
+				case SpriteFrameType.RGBA:
+				case SpriteFrameType.RGB:
+					return SheetType.BGRA;
 				default: throw new NotImplementedException("Unknown SpriteFrameType {0}".F(t));
 			}
 		}
@@ -74,16 +81,16 @@ namespace OpenRA.Graphics
 			this.margin = margin;
 		}
 
-		public Sprite Add(ISpriteFrame frame) { return Add(frame.Data, frame.Size, 0, frame.Offset); }
-		public Sprite Add(byte[] src, Size size) { return Add(src, size, 0, float3.Zero); }
-		public Sprite Add(byte[] src, Size size, float zRamp, in float3 spriteOffset)
+		public Sprite Add(ISpriteFrame frame) { return Add(frame.Data, frame.Type, frame.Size, 0, frame.Offset); }
+		public Sprite Add(byte[] src, SpriteFrameType type, Size size) { return Add(src, type, size, 0, float3.Zero); }
+		public Sprite Add(byte[] src, SpriteFrameType type, Size size, float zRamp, in float3 spriteOffset)
 		{
 			// Don't bother allocating empty sprites
 			if (size.Width == 0 || size.Height == 0)
 				return new Sprite(current, Rectangle.Empty, 0, spriteOffset, channel, BlendMode.Alpha);
 
 			var rect = Allocate(size, zRamp, spriteOffset);
-			Util.FastCopyIntoChannel(rect, src);
+			Util.FastCopyIntoChannel(rect, src, type);
 			current.CommitBufferedData();
 			return rect;
 		}
@@ -94,15 +101,6 @@ namespace OpenRA.Graphics
 			Util.FastCopyIntoSprite(rect, src);
 			current.CommitBufferedData();
 			return rect;
-		}
-
-		public Sprite Add(Size size, byte paletteIndex)
-		{
-			var data = new byte[size.Width * size.Height];
-			for (var i = 0; i < data.Length; i++)
-				data[i] = paletteIndex;
-
-			return Add(data, size);
 		}
 
 		TextureChannel? NextChannel(TextureChannel t)

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -52,14 +52,14 @@ namespace OpenRA.Graphics
 		{
 			switch (t)
 			{
-				case SpriteFrameType.Indexed:
+				case SpriteFrameType.Indexed8:
 					return SheetType.Indexed;
 
 				// Util.FastCopyIntoChannel will automatically convert these to BGRA
-				case SpriteFrameType.BGRA:
-				case SpriteFrameType.BGR:
-				case SpriteFrameType.RGBA:
-				case SpriteFrameType.RGB:
+				case SpriteFrameType.Bgra32:
+				case SpriteFrameType.Bgr24:
+				case SpriteFrameType.Rgba32:
+				case SpriteFrameType.Rgb24:
 					return SheetType.BGRA;
 				default: throw new NotImplementedException("Unknown SpriteFrameType {0}".F(t));
 			}

--- a/OpenRA.Game/Graphics/SpriteLoader.cs
+++ b/OpenRA.Game/Graphics/SpriteLoader.cs
@@ -18,7 +18,29 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Graphics
 {
-	public enum SpriteFrameType { Indexed, BGRA }
+	/// <summary>
+	/// Describes the format of the pixel data in a ISpriteFrame.
+	/// Note that the channel order is defined for little-endian bytes, so BGRA corresponds
+	/// to a 32bit ARGB value, such as that returned by Color.ToArgb()!
+	/// </summary>
+	public enum SpriteFrameType
+	{
+		// 8 bit index into an external palette
+		Indexed,
+
+		// 32 bit color such as returned by Color.ToArgb() or the bmp file format
+		// (remember that little-endian systems place the little bits in the first byte!)
+		BGRA,
+
+		// Like BGRA, but without an alpha channel
+		BGR,
+
+		// 32 bit color in big-endian format, like png
+		RGBA,
+
+		// Like RGBA, but without an alpha channel
+		RGB
+	}
 
 	public interface ISpriteLoader
 	{
@@ -47,7 +69,7 @@ namespace OpenRA.Graphics
 
 	public class SpriteCache
 	{
-		public readonly Cache<SpriteFrameType, SheetBuilder> SheetBuilders;
+		public readonly Cache<SheetType, SheetBuilder> SheetBuilders;
 		readonly ISpriteLoader[] loaders;
 		readonly IReadOnlyFileSystem fileSystem;
 
@@ -57,7 +79,7 @@ namespace OpenRA.Graphics
 
 		public SpriteCache(IReadOnlyFileSystem fileSystem, ISpriteLoader[] loaders)
 		{
-			SheetBuilders = new Cache<SpriteFrameType, SheetBuilder>(t => new SheetBuilder(SheetBuilder.FrameTypeToSheetType(t)));
+			SheetBuilders = new Cache<SheetType, SheetBuilder>(t => new SheetBuilder(t));
 
 			this.fileSystem = fileSystem;
 			this.loaders = loaders;
@@ -103,7 +125,7 @@ namespace OpenRA.Graphics
 					{
 						if (unloaded[i] != null)
 						{
-							sprite[i] = SheetBuilders[unloaded[i].Type].Add(unloaded[i]);
+							sprite[i] = SheetBuilders[SheetBuilder.FrameTypeToSheetType(unloaded[i].Type)].Add(unloaded[i]);
 							unloaded[i] = null;
 						}
 					}

--- a/OpenRA.Game/Graphics/SpriteLoader.cs
+++ b/OpenRA.Game/Graphics/SpriteLoader.cs
@@ -26,20 +26,20 @@ namespace OpenRA.Graphics
 	public enum SpriteFrameType
 	{
 		// 8 bit index into an external palette
-		Indexed,
+		Indexed8,
 
 		// 32 bit color such as returned by Color.ToArgb() or the bmp file format
 		// (remember that little-endian systems place the little bits in the first byte!)
-		BGRA,
+		Bgra32,
 
 		// Like BGRA, but without an alpha channel
-		BGR,
+		Bgr24,
 
 		// 32 bit color in big-endian format, like png
-		RGBA,
+		Rgba32,
 
 		// Like RGBA, but without an alpha channel
-		RGB
+		Rgb24
 	}
 
 	public interface ISpriteLoader

--- a/OpenRA.Game/Graphics/Theater.cs
+++ b/OpenRA.Game/Graphics/Theater.cs
@@ -138,9 +138,9 @@ namespace OpenRA.Graphics
 
 			// 1x1px transparent tile
 			if (sheetBuilder.Type == SheetType.BGRA)
-				missingTile = sheetBuilder.Add(new byte[4], SpriteFrameType.BGRA, new Size(1, 1));
+				missingTile = sheetBuilder.Add(new byte[4], SpriteFrameType.Bgra32, new Size(1, 1));
 			else
-				missingTile = sheetBuilder.Add(new byte[1], SpriteFrameType.Indexed, new Size(1, 1));
+				missingTile = sheetBuilder.Add(new byte[1], SpriteFrameType.Indexed8, new Size(1, 1));
 
 			Sheet.ReleaseBuffer();
 		}

--- a/OpenRA.Game/Graphics/Theater.cs
+++ b/OpenRA.Game/Graphics/Theater.cs
@@ -107,12 +107,13 @@ namespace OpenRA.Graphics
 							throw new YamlException("Sprite type mismatch. Terrain sprites must all be either Indexed or RGBA.");
 
 						var s = sheetBuilder.Allocate(f.Size, zRamp, offset);
-						Util.FastCopyIntoChannel(s, f.Data);
+						Util.FastCopyIntoChannel(s, f.Data, f.Type);
 
 						if (tileset.EnableDepth)
 						{
 							var ss = sheetBuilder.Allocate(f.Size, zRamp, offset);
-							Util.FastCopyIntoChannel(ss, allFrames[j + frameCount].Data);
+							var depthFrame = allFrames[j + frameCount];
+							Util.FastCopyIntoChannel(ss, depthFrame.Data, depthFrame.Type);
 
 							// s and ss are guaranteed to use the same sheet
 							// because of the custom terrain sheet allocation
@@ -136,7 +137,10 @@ namespace OpenRA.Graphics
 			}
 
 			// 1x1px transparent tile
-			missingTile = sheetBuilder.Add(new byte[sheetBuilder.Type == SheetType.BGRA ? 4 : 1], new Size(1, 1));
+			if (sheetBuilder.Type == SheetType.BGRA)
+				missingTile = sheetBuilder.Add(new byte[4], SpriteFrameType.BGRA, new Size(1, 1));
+			else
+				missingTile = sheetBuilder.Add(new byte[1], SpriteFrameType.Indexed, new Size(1, 1));
 
 			Sheet.ReleaseBuffer();
 		}

--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -88,23 +88,23 @@ namespace OpenRA.Graphics
 								byte r, g, b, a;
 								switch (srcType)
 								{
-									case SpriteFrameType.BGRA:
-									case SpriteFrameType.BGR:
+									case SpriteFrameType.Bgra32:
+									case SpriteFrameType.Bgr24:
 									{
 										b = src[k++];
 										g = src[k++];
 										r = src[k++];
-										a = srcType == SpriteFrameType.BGRA ? src[k++] : (byte)255;
+										a = srcType == SpriteFrameType.Bgra32 ? src[k++] : (byte)255;
 										break;
 									}
 
-									case SpriteFrameType.RGBA:
-									case SpriteFrameType.RGB:
+									case SpriteFrameType.Rgba32:
+									case SpriteFrameType.Rgb24:
 									{
 										r = src[k++];
 										g = src[k++];
 										b = src[k++];
-										a = srcType == SpriteFrameType.RGBA ? src[k++] : (byte)255;
+										a = srcType == SpriteFrameType.Rgba32 ? src[k++] : (byte)255;
 										break;
 									}
 
@@ -163,19 +163,19 @@ namespace OpenRA.Graphics
 							Color cc;
 							switch (src.Type)
 							{
-								case SpriteFrameType.Indexed:
+								case SpriteFrameType.Indexed8:
 								{
 									cc = src.Palette[src.Data[k++]];
 									break;
 								}
 
-								case SpriteFrameType.RGBA:
-								case SpriteFrameType.RGB:
+								case SpriteFrameType.Rgba32:
+								case SpriteFrameType.Rgb24:
 								{
 									var r = src.Data[k++];
 									var g = src.Data[k++];
 									var b = src.Data[k++];
-									var a = src.Type == SpriteFrameType.RGBA ? src.Data[k++] : (byte)255;
+									var a = src.Type == SpriteFrameType.Rgba32 ? src.Data[k++] : (byte)255;
 									cc = Color.FromArgb(a, r, g, b);
 									break;
 								}

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -17,6 +17,7 @@ using System.Reflection;
 using System.Text;
 using OpenRA.FileFormats;
 using OpenRA.FileSystem;
+using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Traits;
@@ -780,7 +781,7 @@ namespace OpenRA
 				}
 			}
 
-			var png = new Png(minimapData, bitmapWidth, height);
+			var png = new Png(minimapData, SpriteFrameType.BGRA, bitmapWidth, height);
 			return png.Save();
 		}
 

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -781,7 +781,7 @@ namespace OpenRA
 				}
 			}
 
-			var png = new Png(minimapData, SpriteFrameType.BGRA, bitmapWidth, height);
+			var png = new Png(minimapData, SpriteFrameType.Bgra32, bitmapWidth, height);
 			return png.Save();
 		}
 

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -431,24 +431,15 @@ namespace OpenRA
 			var srcWidth = screenSprite.Sheet.Size.Width;
 			var destWidth = screenSprite.Bounds.Width;
 			var destHeight = -screenSprite.Bounds.Height;
-			var channelOrder = new[] { 2, 1, 0, 3 };
 
 			ThreadPool.QueueUserWorkItem(_ =>
 			{
-				// Convert BGRA to RGBA
+				// Extract the screen rect from the (larger) backing surface
 				var dest = new byte[4 * destWidth * destHeight];
 				for (var y = 0; y < destHeight; y++)
-				{
-					for (var x = 0; x < destWidth; x++)
-					{
-						var destOffset = 4 * (y * destWidth + x);
-						var srcOffset = 4 * (y * srcWidth + x);
-						for (var i = 0; i < 4; i++)
-							dest[destOffset + i] = src[srcOffset + channelOrder[i]];
-					}
-				}
+					Array.Copy(src, 4 * y * srcWidth, dest, 4 * y * destWidth, 4 * destWidth);
 
-				new Png(dest, destWidth, destHeight).Save(path);
+				new Png(dest, SpriteFrameType.BGRA, destWidth, destHeight).Save(path);
 			});
 		}
 

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -439,7 +439,7 @@ namespace OpenRA
 				for (var y = 0; y < destHeight; y++)
 					Array.Copy(src, 4 * y * srcWidth, dest, 4 * y * destWidth, 4 * destWidth);
 
-				new Png(dest, SpriteFrameType.BGRA, destWidth, destHeight).Save(path);
+				new Png(dest, SpriteFrameType.Bgra32, destWidth, destHeight).Save(path);
 			});
 		}
 

--- a/OpenRA.Mods.Cnc/Graphics/VoxelLoader.cs
+++ b/OpenRA.Mods.Cnc/Graphics/VoxelLoader.cs
@@ -77,8 +77,8 @@ namespace OpenRA.Mods.Cnc.Graphics
 			var size = new Size(su, sv);
 			var s = sheetBuilder.Allocate(size);
 			var t = sheetBuilder.Allocate(size);
-			OpenRA.Graphics.Util.FastCopyIntoChannel(s, colors);
-			OpenRA.Graphics.Util.FastCopyIntoChannel(t, normals);
+			OpenRA.Graphics.Util.FastCopyIntoChannel(s, colors, SpriteFrameType.Indexed);
+			OpenRA.Graphics.Util.FastCopyIntoChannel(t, normals, SpriteFrameType.Indexed);
 
 			// s and t are guaranteed to use the same sheet because
 			// of the custom voxel sheet allocation implementation

--- a/OpenRA.Mods.Cnc/Graphics/VoxelLoader.cs
+++ b/OpenRA.Mods.Cnc/Graphics/VoxelLoader.cs
@@ -77,8 +77,8 @@ namespace OpenRA.Mods.Cnc.Graphics
 			var size = new Size(su, sv);
 			var s = sheetBuilder.Allocate(size);
 			var t = sheetBuilder.Allocate(size);
-			OpenRA.Graphics.Util.FastCopyIntoChannel(s, colors, SpriteFrameType.Indexed);
-			OpenRA.Graphics.Util.FastCopyIntoChannel(t, normals, SpriteFrameType.Indexed);
+			OpenRA.Graphics.Util.FastCopyIntoChannel(s, colors, SpriteFrameType.Indexed8);
+			OpenRA.Graphics.Util.FastCopyIntoChannel(t, normals, SpriteFrameType.Indexed8);
 
 			// s and t are guaranteed to use the same sheet because
 			// of the custom voxel sheet allocation implementation

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpD2Loader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpD2Loader.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 
 		class ShpD2Frame : ISpriteFrame
 		{
-			public SpriteFrameType Type { get { return SpriteFrameType.Indexed; } }
+			public SpriteFrameType Type { get { return SpriteFrameType.Indexed8; } }
 			public Size Size { get; private set; }
 			public Size FrameSize { get { return Size; } }
 			public float2 Offset { get { return float2.Zero; } }

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpTDLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpTDLoader.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 
 		class ImageHeader : ISpriteFrame
 		{
-			public SpriteFrameType Type { get { return SpriteFrameType.Indexed; } }
+			public SpriteFrameType Type { get { return SpriteFrameType.Indexed8; } }
 			public Size Size { get { return reader.Size; } }
 			public Size FrameSize { get { return reader.Size; } }
 			public float2 Offset { get { return float2.Zero; } }

--- a/OpenRA.Mods.Cnc/SpriteLoaders/TmpRALoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/TmpRALoader.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 	{
 		class TmpRAFrame : ISpriteFrame
 		{
-			public SpriteFrameType Type { get { return SpriteFrameType.Indexed; } }
+			public SpriteFrameType Type { get { return SpriteFrameType.Indexed8; } }
 			public Size Size { get; private set; }
 			public Size FrameSize { get; private set; }
 			public float2 Offset { get { return float2.Zero; } }

--- a/OpenRA.Mods.Cnc/SpriteLoaders/TmpTDLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/TmpTDLoader.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 	{
 		class TmpTDFrame : ISpriteFrame
 		{
-			public SpriteFrameType Type { get { return SpriteFrameType.Indexed; } }
+			public SpriteFrameType Type { get { return SpriteFrameType.Indexed8; } }
 			public Size Size { get; private set; }
 			public Size FrameSize { get; private set; }
 			public float2 Offset { get { return float2.Zero; } }

--- a/OpenRA.Mods.Cnc/SpriteLoaders/TmpTSLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/TmpTSLoader.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 		{
 			readonly TmpTSFrame parent;
 
-			public SpriteFrameType Type { get { return SpriteFrameType.Indexed; } }
+			public SpriteFrameType Type { get { return SpriteFrameType.Indexed8; } }
 			public Size Size { get { return parent.Size; } }
 			public Size FrameSize { get { return Size; } }
 			public float2 Offset { get { return parent.Offset; } }
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 
 		class TmpTSFrame : ISpriteFrame
 		{
-			public SpriteFrameType Type { get { return SpriteFrameType.Indexed; } }
+			public SpriteFrameType Type { get { return SpriteFrameType.Indexed8; } }
 			public Size Size { get; private set; }
 			public Size FrameSize { get { return Size; } }
 			public float2 Offset { get; private set; }

--- a/OpenRA.Mods.Cnc/UtilityCommands/ConvertPngToShpCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ConvertPngToShpCommand.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using OpenRA.FileFormats;
+using OpenRA.Graphics;
 using OpenRA.Mods.Cnc.SpriteLoaders;
 using OpenRA.Primitives;
 
@@ -35,7 +36,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			var dest = inputFiles[0].Split('-').First() + ".shp";
 
 			var frames = inputFiles.Select(a => new Png(File.OpenRead(a))).ToList();
-			if (frames.Any(f => f.Palette == null))
+			if (frames.Any(f => f.Type != SpriteFrameType.Indexed))
 				throw new InvalidOperationException("All frames must be paletted");
 
 			var size = new Size(frames[0].Width, frames[0].Height);

--- a/OpenRA.Mods.Cnc/UtilityCommands/ConvertPngToShpCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ConvertPngToShpCommand.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			var dest = inputFiles[0].Split('-').First() + ".shp";
 
 			var frames = inputFiles.Select(a => new Png(File.OpenRead(a))).ToList();
-			if (frames.Any(f => f.Type != SpriteFrameType.Indexed))
+			if (frames.Any(f => f.Type != SpriteFrameType.Indexed8))
 				throw new InvalidOperationException("All frames must be paletted");
 
 			var size = new Size(frames[0].Width, frames[0].Height);

--- a/OpenRA.Mods.Common/SpriteLoaders/PngSheetLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/PngSheetLoader.cs
@@ -61,24 +61,22 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 				RegionsFromSlices(png, out frameRegions, out frameOffsets);
 
 			frames = new ISpriteFrame[frameRegions.Count];
-
+			var stride = png.PixelStride;
 			for (var i = 0; i < frames.Length; i++)
 			{
 				var frameStart = frameRegions[i].X + frameRegions[i].Y * png.Width;
 				var frameSize = new Size(frameRegions[i].Width, frameRegions[i].Height);
-				var pixelLength = png.Palette == null ? 4 : 1;
-
 				frames[i] = new PngSheetFrame()
 				{
 					Size = frameSize,
 					FrameSize = frameSize,
 					Offset = frameOffsets[i],
-					Data = new byte[frameRegions[i].Width * frameRegions[i].Height * pixelLength],
-					Type = png.Palette == null ? SpriteFrameType.BGRA : SpriteFrameType.Indexed
+					Data = new byte[frameRegions[i].Width * frameRegions[i].Height * stride],
+					Type = png.Type
 				};
 
 				for (var y = 0; y < frames[i].Size.Height; y++)
-					Array.Copy(png.Data, (frameStart + y * png.Width) * pixelLength, frames[i].Data, y * frames[i].Size.Width * pixelLength, frames[i].Size.Width * pixelLength);
+					Array.Copy(png.Data, (frameStart + y * png.Width) * stride, frames[i].Data, y * frames[i].Size.Width * stride, frames[i].Size.Width * stride);
 			}
 
 			metadata = new TypeDictionary

--- a/OpenRA.Mods.Common/SpriteLoaders/ShpTSLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/ShpTSLoader.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 	{
 		class ShpTSFrame : ISpriteFrame
 		{
-			public SpriteFrameType Type { get { return SpriteFrameType.Indexed; } }
+			public SpriteFrameType Type { get { return SpriteFrameType.Indexed8; } }
 			public Size Size { get; private set; }
 			public Size FrameSize { get; private set; }
 			public float2 Offset { get; private set; }

--- a/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 							frame.Size.Width);
 				}
 
-				var png = new Png(pngData, SpriteFrameType.Indexed, frameSize.Width, frameSize.Height, palColors);
+				var png = new Png(pngData, SpriteFrameType.Indexed8, frameSize.Width, frameSize.Height, palColors);
 				png.Save("{0}-{1:D4}.png".F(prefix, count++));
 			}
 

--- a/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
@@ -78,16 +78,8 @@ namespace OpenRA.Mods.Common.UtilityCommands
 							frame.Size.Width);
 				}
 
-				if (frame.Type == SpriteFrameType.BGRA)
-				{
-					var png = new Png(pngData, frameSize.Width, frameSize.Height);
-					png.Save("{0}-{1:D4}.png".F(prefix, count++));
-				}
-				else
-				{
-					var png = new Png(pngData, frameSize.Width, frameSize.Height, palColors);
-					png.Save("{0}-{1:D4}.png".F(prefix, count++));
-				}
+				var png = new Png(pngData, SpriteFrameType.Indexed, frameSize.Width, frameSize.Height, palColors);
+				png.Save("{0}-{1:D4}.png".F(prefix, count++));
 			}
 
 			Console.WriteLine("Saved {0}-[0..{1}].png", prefix, count - 1);

--- a/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			var count = 0;
 
-			var sb = sequences.SpriteCache.SheetBuilders[SpriteFrameType.Indexed];
+			var sb = sequences.SpriteCache.SheetBuilders[SheetType.Indexed];
 			foreach (var s in sb.AllSheets)
 			{
 				var max = s == sb.Current ? (int)sb.CurrentChannel + 1 : 4;
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					s.AsPng((TextureChannel)ChannelMasks[i], palette).Save("{0}.png".F(count++));
 			}
 
-			sb = sequences.SpriteCache.SheetBuilders[SpriteFrameType.BGRA];
+			sb = sequences.SpriteCache.SheetBuilders[SheetType.BGRA];
 			foreach (var s in sb.AllSheets)
 				s.AsPng().Save("{0}.png".F(count++));
 

--- a/OpenRA.Mods.D2k/SpriteLoaders/R8Loader.cs
+++ b/OpenRA.Mods.D2k/SpriteLoaders/R8Loader.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.D2k.SpriteLoaders
 	{
 		class R8Frame : ISpriteFrame
 		{
-			public SpriteFrameType Type { get { return SpriteFrameType.Indexed; } }
+			public SpriteFrameType Type { get { return SpriteFrameType.Indexed8; } }
 			public Size Size { get; private set; }
 			public Size FrameSize { get; private set; }
 			public float2 Offset { get; private set; }

--- a/OpenRA.Mods.D2k/SpriteLoaders/R8Loader.cs
+++ b/OpenRA.Mods.D2k/SpriteLoaders/R8Loader.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.D2k.SpriteLoaders
 	{
 		class R8Frame : ISpriteFrame
 		{
-			public SpriteFrameType Type { get; set; }
+			public SpriteFrameType Type { get { return SpriteFrameType.Indexed; } }
 			public Size Size { get; private set; }
 			public Size FrameSize { get; private set; }
 			public float2 Offset { get; private set; }


### PR DESCRIPTION
From the commit message:

> Our SpriteFrameType names refer to the byte channel order rather than
> the bit order, meaning that SpriteFrameType.BGRA corresponds to the
> standard Color.ToArgb() etc byte order when the (little-endian) integer
> is read as 4 individual bytes.
> 
> The previous code did not account for the fact that non-indexed Png
> uses big-endian storage for its RGBA colours, and that SheetBuilder
> had the color channels incorrectly swapped to match and cancel this out.
> 
> New SpriteFrameType enums are introduced to distinguish between BGRA
> (little-endian) and RGBA (big-endian) formats, and also for 24bit data
> without alpha. The channel swizzling / alpha creation is now handled
> when copying into the texture atlas, removing the need for non-png
> ISpriteLoader implementations to allocate an additional temporary array
> and reorder the channels during load.

This is an important correctness fix for the engine, but the upstream mods aren't likely to see any memory or performance improvements. The real impact is for downstream mods that use 32bit sprites, and for the remastered assets: saving 1.1GB(!) of unnecessary allocations and several seconds of load time on my test integration branch.