### PR TITLE
Downscale framebuffer resolution for large world viewports.

### DIFF
--- a/OpenRA.Game/Graphics/Sprite.cs
+++ b/OpenRA.Game/Graphics/Sprite.cs
@@ -41,10 +41,15 @@ namespace OpenRA.Graphics
 			FractionalOffset = Size.Z != 0 ? offset / Size :
 				new float3(offset.X / Size.X, offset.Y / Size.Y, 0);
 
-			Left = (float)Math.Min(bounds.Left, bounds.Right) / sheet.Size.Width;
-			Top = (float)Math.Min(bounds.Top, bounds.Bottom) / sheet.Size.Height;
-			Right = (float)Math.Max(bounds.Left, bounds.Right) / sheet.Size.Width;
-			Bottom = (float)Math.Max(bounds.Top, bounds.Bottom) / sheet.Size.Height;
+			// Some GPUs suffer from precision issues when rendering into non 1:1 framebuffers that result
+			// in rendering a line of texels that sample outside the sprite rectangle.
+			// Insetting the texture coordinates by a small fraction of a pixel avoids this
+			// with negligible impact on the 1:1 rendering case.
+			var inset = 1 / 128f;
+			Left = (Math.Min(bounds.Left, bounds.Right) + inset) / sheet.Size.Width;
+			Top = (Math.Min(bounds.Top, bounds.Bottom) + inset) / sheet.Size.Height;
+			Right = (Math.Max(bounds.Left, bounds.Right) - inset) / sheet.Size.Width;
+			Bottom = (Math.Max(bounds.Top, bounds.Bottom) - inset) / sheet.Size.Height;
 		}
 	}
 

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -194,17 +194,22 @@ namespace OpenRA.Graphics
 			shader.SetTexture("Palette", palette);
 		}
 
-		public void SetViewportParams(Size screen, float depthScale, float depthOffset, int2 scroll)
+		public void SetViewportParams(Size sheetSize, int downscale, float depthMargin, int2 scroll)
 		{
+			// Calculate the effective size of the render surface in viewport pixels
+			var width = downscale * sheetSize.Width;
+			var height = downscale * sheetSize.Height;
+			var depthScale = height / (height + depthMargin);
+			var depthOffset = depthScale / 2;
 			shader.SetVec("Scroll", scroll.X, scroll.Y, scroll.Y);
 			shader.SetVec("r1",
-				2f / screen.Width,
-				2f / screen.Height,
-				-depthScale / screen.Height);
+				2f / width,
+				2f / height,
+				-depthScale / height);
 			shader.SetVec("r2", -1, -1, 1 - depthOffset);
 
 			// Texture index is sampled as a float, so convert to pixels then scale
-			shader.SetVec("DepthTextureScale", 128 * depthScale / screen.Height);
+			shader.SetVec("DepthTextureScale", 128 * depthScale / height);
 		}
 
 		public void SetDepthPreviewEnabled(bool enabled)

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -250,6 +250,9 @@ namespace OpenRA.Graphics
 			else
 				Zoom = Zoom.Clamp(minZoom, maxZoom);
 
+			var maxSize = (1f / (unlockMinZoom ? unlockedMinZoom : minZoom) * new float2(Game.Renderer.NativeResolution));
+			Game.Renderer.SetMaximumViewportSize(new Size((int)maxSize.X, (int)maxSize.Y));
+
 			foreach (var t in worldRenderer.World.WorldActor.TraitsImplementing<INotifyViewportZoomExtentsChanged>())
 				t.ViewportZoomExtentsChanged(minZoom, maxZoom);
 		}

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -52,8 +52,12 @@ namespace OpenRA
 		IFrameBuffer worldBuffer;
 		Sheet worldSheet;
 		Sprite worldSprite;
+		int worldDownscaleFactor = 1;
+		Size lastMaximumViewportSize;
+		Size lastWorldViewportSize;
 
 		public Size WorldFrameBufferSize => worldSheet.Size;
+		public int WorldDownscaleFactor => worldDownscaleFactor;
 
 		SheetBuilder fontSheetBuilder;
 		readonly IPlatform platform;
@@ -123,6 +127,9 @@ namespace OpenRA
 			{
 				Game.RunAfterTick(() =>
 				{
+					// Recalculate downscaling factor for the new window scale
+					SetMaximumViewportSize(lastMaximumViewportSize);
+
 					ChromeProvider.SetDPIScale(newEffective);
 
 					foreach (var f in Fonts)
@@ -175,19 +182,33 @@ namespace OpenRA
 			var bufferSize = new Size((int)(surfaceBufferSize.Width / scale), (int)(surfaceBufferSize.Height / scale));
 			if (lastBufferSize != bufferSize)
 			{
-				SpriteRenderer.SetViewportParams(bufferSize, 0f, 0f, int2.Zero);
+				SpriteRenderer.SetViewportParams(bufferSize, 1, 0f, int2.Zero);
 				lastBufferSize = bufferSize;
 			}
 		}
 
 		public void SetMaximumViewportSize(Size size)
 		{
-			var worldBufferSize = size.NextPowerOf2();
-			if (worldSprite == null || worldSprite.Sheet.Size != worldBufferSize)
+			// Aim to render the world into a framebuffer at 1:1 scaling which is then up/downscaled using a custom
+			// filter to provide crisp scaling and avoid rendering glitches when the depth buffer is used and samples don't match.
+			// This approach does not scale well to large sizes, first saturating GPU fill rate and then crashing when
+			// reaching the framebuffer size limits (typically 16k). We therefore clamp the maximum framebuffer size to
+			// twice the window surface size, which strikes a reasonable balance between rendering quality and performance.
+			// Mods that use the depth buffer must instead limit their artwork resolution or maximum zoom-out levels.
+			Size worldBufferSize;
+			if (depthMargin == 0)
+			{
+				var surfaceSize = Window.SurfaceSize;
+				worldBufferSize = new Size(Math.Min(size.Width, 2 * surfaceSize.Width), Math.Min(size.Height, 2 * surfaceSize.Height)).NextPowerOf2();
+			}
+			else
+				worldBufferSize = size.NextPowerOf2();
+
+			if (worldSprite == null || worldSheet.Size != worldBufferSize)
 			{
 				worldBuffer?.Dispose();
 
-				// Render the world into a framebuffer at 1:1 scaling to allow the depth buffer to match the artwork at all zoom levels
+				// If enableWorldFrameBufferDownscale and the world is more than twice the size of the final output size do we allow it to be downsampled!
 				worldBuffer = Context.CreateFrameBuffer(worldBufferSize);
 
 				// Pixel art scaling mode is a customized bilinear sampling
@@ -198,6 +219,8 @@ namespace OpenRA
 				lastWorldViewport = Rectangle.Empty;
 				worldSprite = null;
 			}
+
+			lastMaximumViewportSize = size;
 		}
 
 		public void BeginWorld(Rectangle worldViewport)
@@ -210,15 +233,27 @@ namespace OpenRA
 			if (worldSheet == null)
 				throw new InvalidOperationException($"BeginWorld called before SetMaximumViewportSize has been set.");
 
-			if (worldSprite == null || worldViewport.Size != worldSprite.Bounds.Size)
-				worldSprite = new Sprite(worldSheet, new Rectangle(int2.Zero, worldViewport.Size), TextureChannel.RGBA);
+			if (worldSprite == null || worldViewport.Size != lastWorldViewportSize)
+			{
+				// Downscale world rendering if needed to fit within the framebuffer
+				var vw = worldViewport.Size.Width;
+				var vh = worldViewport.Size.Height;
+				var bw = worldSheet.Size.Width;
+				var bh = worldSheet.Size.Height;
+				worldDownscaleFactor = 1;
+				while (vw / worldDownscaleFactor > bw || vh / worldDownscaleFactor > bh)
+					worldDownscaleFactor++;
+
+				var s = new Size(vw / worldDownscaleFactor, vh / worldDownscaleFactor);
+				worldSprite = new Sprite(worldSheet, new Rectangle(int2.Zero, s), TextureChannel.RGBA);
+				lastWorldViewportSize = worldViewport.Size;
+			}
 
 			worldBuffer.Bind();
 
 			if (lastWorldViewport != worldViewport)
 			{
-				var depthScale = worldSheet.Size.Height / (worldSheet.Size.Height + depthMargin);
-				WorldSpriteRenderer.SetViewportParams(worldSheet.Size, depthScale, depthScale / 2, worldViewport.Location);
+				WorldSpriteRenderer.SetViewportParams(worldSheet.Size, worldDownscaleFactor, depthMargin, worldViewport.Location);
 				WorldModelRenderer.SetViewportParams(worldSheet.Size, worldViewport.Location);
 
 				lastWorldViewport = worldViewport;
@@ -239,10 +274,10 @@ namespace OpenRA
 				screenBuffer.Bind();
 
 				var scale = Window.EffectiveWindowScale;
-				var bufferSize = new Size((int)(screenSprite.Bounds.Width / scale), (int)(-screenSprite.Bounds.Height / scale));
+				var bufferSize = new float2((int)(screenSprite.Bounds.Width / scale), (int)(-screenSprite.Bounds.Height / scale));
 
 				SpriteRenderer.SetAntialiasingPixelsPerTexel(Window.SurfaceSize.Height * 1f / worldSprite.Bounds.Height);
-				RgbaSpriteRenderer.DrawSprite(worldSprite, float3.Zero, new float2(bufferSize));
+				RgbaSpriteRenderer.DrawSprite(worldSprite, float3.Zero, bufferSize);
 				Flush();
 				SpriteRenderer.SetAntialiasingPixelsPerTexel(0);
 			}
@@ -346,7 +381,14 @@ namespace OpenRA
 			Flush();
 
 			if (renderType == RenderType.World)
-				worldBuffer.EnableScissor(rect);
+			{
+				var r = Rectangle.FromLTRB(
+					rect.Left / worldDownscaleFactor,
+					rect.Top / worldDownscaleFactor,
+					(rect.Right + worldDownscaleFactor - 1) / worldDownscaleFactor,
+					(rect.Bottom + worldDownscaleFactor - 1) / worldDownscaleFactor);
+				worldBuffer.EnableScissor(r);
+			}
 			else
 				Context.EnableScissor(rect.X, rect.Y, rect.Width, rect.Height);
 
@@ -362,7 +404,15 @@ namespace OpenRA
 			{
 				// Restore previous scissor rect
 				if (scissorState.Any())
-					worldBuffer.EnableScissor(scissorState.Peek());
+				{
+					var rect = scissorState.Peek();
+					var r = Rectangle.FromLTRB(
+						rect.Left / worldDownscaleFactor,
+						rect.Top / worldDownscaleFactor,
+						(rect.Right + worldDownscaleFactor - 1) / worldDownscaleFactor,
+						(rect.Bottom + worldDownscaleFactor - 1) / worldDownscaleFactor);
+					worldBuffer.EnableScissor(r);
+				}
 				else
 					worldBuffer.DisableScissor();
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/PerfDebugLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PerfDebugLogic.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Diagnostics;
+using OpenRA.Graphics;
 using OpenRA.Support;
 using OpenRA.Widgets;
 
@@ -18,7 +19,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class PerfDebugLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
-		public PerfDebugLogic(Widget widget)
+		public PerfDebugLogic(Widget widget, WorldRenderer worldRenderer)
 		{
 			var perfGraph = widget.Get("GRAPH_BG");
 			perfGraph.IsVisible = () => Game.Settings.Debug.PerfGraph;
@@ -40,7 +41,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					fpsReferenceFrame = Game.RenderFrame;
 				}
 
-				return $"FPS: {fps}\nTick {Game.LocalTick} @ {PerfHistory.Items["tick_time"].Average(Game.Settings.Debug.Samples):F1} ms\nRender {Game.RenderFrame} @ {PerfHistory.Items["render"].Average(Game.Settings.Debug.Samples):F1} ms\nBatches: {PerfHistory.Items["batches"].LastValue}";
+				var wfbSize = Game.Renderer.WorldFrameBufferSize;
+				var viewportSize = worldRenderer.Viewport.Rectangle.Size;
+				return $"FPS: {fps}\nTick {Game.LocalTick} @ {PerfHistory.Items["tick_time"].Average(Game.Settings.Debug.Samples):F1} ms\n" +
+					$"Render {Game.RenderFrame} @ {PerfHistory.Items["render"].Average(Game.Settings.Debug.Samples):F1} ms\n" +
+					$"Batches: {PerfHistory.Items["batches"].LastValue}\n" +
+					$"Viewport Size: {viewportSize.Width} x {viewportSize.Height}\n" +
+					$"WFB Size: {wfbSize.Width} x {wfbSize.Height}";
 			};
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/Logic/PerfDebugLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PerfDebugLogic.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return $"FPS: {fps}\nTick {Game.LocalTick} @ {PerfHistory.Items["tick_time"].Average(Game.Settings.Debug.Samples):F1} ms\n" +
 					$"Render {Game.RenderFrame} @ {PerfHistory.Items["render"].Average(Game.Settings.Debug.Samples):F1} ms\n" +
 					$"Batches: {PerfHistory.Items["batches"].LastValue}\n" +
-					$"Viewport Size: {viewportSize.Width} x {viewportSize.Height}\n" +
+					$"Viewport Size: {viewportSize.Width} x {viewportSize.Height} / {Game.Renderer.WorldDownscaleFactor}\n" +
 					$"WFB Size: {wfbSize.Width} x {wfbSize.Height}";
 			};
 		}

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -53,7 +53,7 @@ Container@PERF_WIDGETS:
 	Children:
 		Label@PERF_TEXT:
 			X: WINDOW_RIGHT - 200
-			Y: WINDOW_BOTTOM - 70
+			Y: WINDOW_BOTTOM - 90
 			Width: 170
 			Height: 40
 			Contrast: true


### PR DESCRIPTION
This is the first of several PRs to add engine support for mods that wish to use HiDPI world graphics (i.e. artwork which must be downscaled when rendering at the default zoom level on non-HiDPI displays). The immediate usecase is the Remastered Collection assets, but i'm sure that community projects will also want to take advantage of this.

World renderering happens in two phases. The first currently renders the visible viewport at 1:1 artwork pixel scale into a frame buffer, which the second pass then scales to the actual screen resolution. This system was designed with upscaling in mind, but for HiDPI worlds we must also support downscaling.

There are two immediate problems here:

1. Requiring DX11-level hardware means that we can safely assume that we can create 16k textures, but this isn't enough - at 128px tile size, this is only 128 tiles. This manifests as the game crashing if I try to zoom out too far in spectator mode or in the map editor.

2. We unnecessarily waste a lot of performance by rendering a full 16k image if we know that we will be downscaling it to 2k (i.e. 1080p).

This PR implements a simple solution that essentially says "if the intermediate framebuffer oversamples the final image by more than 2x, reduce its resolution by an integer factor until we are oversampling by no more than 2x". This solves the first point, provided the player has less than 8k horizontal resolution, and solves the second point with only a small reduction in rendering quality.

~A new WFB (world frame buffer) perf debug line is added to expose some internal parameters to help with debugging:
<viewport width / surface width>, <viewport height / surface height> / <log2(buffer width)>, <log2(buffer height)> / <buffer downscale factor>. Showing the logarithm of the buffer size (i.e. 14 = 2^14 = 16384) was a cheat to reduce the width of the debug line, taking advantage of the fact that this will always be a power of 2. I'm not sure these are the best parameters to show, so may change things in a future push.~


~I'm opening this as a draft now to help with managing my remaster focused branches (its otherwise too easy to accidentally drop commits). The default mods are too low resolution to robustly test this, as they can at most trigger a 2x downscale by zooming right out in a large map in the editor. I expect that this PR will stay open until we have merged enough of my other PRs to enable testing with the remaster assets.~

~#11332 returns when the downscaling kicks in, so we may want to identify and fix the real cause of that issue before we merge this.~