### PR TITLE
Remove custom palettes from building placement previews. 

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
@@ -22,6 +22,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Palette to use for rendering the placement sprite.")]
 		public readonly string Palette = TileSet.TerrainPaletteInternalName;
 
+		[Desc("Custom opacity to apply to the placement sprite.")]
+		public readonly float FootprintAlpha = 1f;
+
 		[Desc("Sequence image where the selection overlay types are defined.")]
 		public readonly string Image = "editor-overlay";
 
@@ -89,12 +92,12 @@ namespace OpenRA.Mods.Common.Traits
 			if (CopyRegion != null)
 				foreach (var c in CopyRegion)
 					yield return new SpriteRenderable(copySprite, wr.World.Map.CenterOfCell(c),
-						WVec.Zero, -511, palette, 1f, true, TintModifiers.IgnoreWorldTint);
+						WVec.Zero, -511, palette, 1f, info.FootprintAlpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
 
 			if (PasteRegion != null)
 				foreach (var c in PasteRegion)
 					yield return new SpriteRenderable(pasteSprite, wr.World.Map.CenterOfCell(c),
-						WVec.Zero, -511, palette, 1f, true, TintModifiers.IgnoreWorldTint);
+						WVec.Zero, -511, palette, 1f, info.FootprintAlpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
 		}
 
 		bool IRenderAboveShroud.SpatiallyPartitionable { get { return false; } }

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20201213/RemovePlaceBuildingPalette.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20201213/RemovePlaceBuildingPalette.cs
@@ -1,0 +1,77 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RemovePlaceBuildingPalette : UpdateRule
+	{
+		public override string Name { get { return "*PlaceBuildingPreview palette overrides have been removed."; } }
+
+		public override string Description
+		{
+			get
+			{
+				return "The palette overrides on the ActorPreviewPlaceBuildingPreview, FootprintPlaceBuildingPreview\n" +
+					"SequencePlaceBuildingPreview, and D2kActorPreviewPlaceBuildingPreview traits have been removed.\n" +
+					"New Alpha and LineBuildSegmentAlpha properties have been added in their place.";
+			}
+		}
+
+		readonly List<string> locations = new List<string>();
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (locations.Any())
+				yield return "The *Palette fields have been removed from the *PlaceBuildingPreview traits.\n" +
+				             "You may wish to inspect the following definitions and define new Alpha or\n" +
+				             "LineBuildSegmentAlpha properties as appropriate to recreate transparency effects:\n" +
+				             UpdateUtils.FormatMessageList(locations);
+
+			locations.Clear();
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var removed = 0;
+			foreach (var node in actorNode.ChildrenMatching("ActorPreviewPlaceBuildingPreview"))
+			{
+				removed += node.RemoveNodes("OverridePalette");
+				removed += node.RemoveNodes("OverridePaletteIsPlayerPalette");
+				removed += node.RemoveNodes("LineBuildSegmentPalette");
+			}
+
+			foreach (var node in actorNode.ChildrenMatching("D2kActorPreviewPlaceBuildingPreview"))
+			{
+				removed += node.RemoveNodes("OverridePalette");
+				removed += node.RemoveNodes("OverridePaletteIsPlayerPalette");
+				removed += node.RemoveNodes("LineBuildSegmentPalette");
+			}
+
+			foreach (var node in actorNode.ChildrenMatching("FootprintPlaceBuildingPreview"))
+				removed += node.RemoveNodes("LineBuildSegmentPalette");
+
+			foreach (var node in actorNode.ChildrenMatching("SequencePlaceBuildingPreview"))
+			{
+				removed += node.RemoveNodes("SequencePalette");
+				removed += node.RemoveNodes("SequencePaletteIsPlayerPalette");
+				removed += node.RemoveNodes("LineBuildSegmentPalette");
+			}
+
+			if (removed > 0)
+				locations.Add("{0} ({1})".F(actorNode.Key, actorNode.Location.Filename));
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -88,6 +88,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemovePlayerHighlightPalette(),
 				new ReplaceWithColoredOverlayPalette(),
 				new RemoveRenderSpritesScale(),
+				new RemovePlaceBuildingPalette(),
 			})
 		};
 

--- a/OpenRA.Mods.D2k/Traits/Buildings/D2kActorPreviewPlaceBuildingPreview.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/D2kActorPreviewPlaceBuildingPreview.cs
@@ -72,8 +72,7 @@ namespace OpenRA.Mods.D2k.Traits
 		protected override IEnumerable<IRenderable> RenderFootprint(WorldRenderer wr, CPos topLeft, Dictionary<CPos, PlaceBuildingCellType> footprint,
 			PlaceBuildingCellType filter = PlaceBuildingCellType.Invalid | PlaceBuildingCellType.Valid | PlaceBuildingCellType.LineBuild)
 		{
-			var cellPalette = wr.Palette(info.Palette);
-			var linePalette = wr.Palette(info.LineBuildSegmentPalette);
+			var palette = wr.Palette(info.Palette);
 			var topLeftPos = wr.World.Map.CenterOfCell(topLeft);
 
 			var candidateSafeTiles = unpathableCells.Update(topLeft);
@@ -82,14 +81,14 @@ namespace OpenRA.Mods.D2k.Traits
 				if ((c.Value & filter) == 0)
 					continue;
 
-				var tile = HasFlag(c.Value, PlaceBuildingCellType.Invalid) ? buildBlocked :
+				var tile = (c.Value & PlaceBuildingCellType.Invalid) != 0 ? buildBlocked :
 					(checkUnsafeTiles && candidateSafeTiles.Contains(c.Key) && info.UnsafeTerrainTypes.Contains(wr.World.Map.GetTerrainInfo(c.Key).Type))
 					? buildUnsafe : buildOk;
 
-				var pal = HasFlag(c.Value, PlaceBuildingCellType.LineBuild) ? linePalette : cellPalette;
 				var pos = wr.World.Map.CenterOfCell(c.Key);
 				var offset = new WVec(0, 0, topLeftPos.Z - pos.Z);
-				yield return new SpriteRenderable(tile, pos, offset, -511, pal, 1f, true, TintModifiers.IgnoreWorldTint);
+				var alpha = (c.Value & PlaceBuildingCellType.LineBuild) != 0 ? info.LineBuildFootprintAlpha : info.FootprintAlpha;
+				yield return new SpriteRenderable(tile, pos, offset, -511, palette, 1f, alpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
 			}
 		}
 	}

--- a/mods/cnc/rules/campaign-palettes.yaml
+++ b/mods/cnc/rules/campaign-palettes.yaml
@@ -1,6 +1,5 @@
 ^Palettes:
 	-PlayerColorPalette:
-	-PaletteFromPlayerPaletteWithAlpha@placebuilding:
 	IndexedPlayerPalette:
 		BasePalette: terrain
 		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
@@ -16,10 +15,6 @@
 			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
 			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
 			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	PaletteFromPlayerPaletteWithAlpha@Placebuilding:
-		BaseName: placebuilding
-		Alpha: 0.65
-		BasePalette: player
 
 ^Vehicle:
 	RenderSprites:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -679,7 +679,7 @@
 		Dimensions: 1,1
 		Footprint: x
 	ActorPreviewPlaceBuildingPreview:
-		OverridePalette: placebuilding
+		PreviewAlpha: 0.65
 	SoundOnDamageTransition:
 		DamagedSounds: xplobig4.aud
 		DestroyedSounds: crumble.aud, xplobig4.aud
@@ -850,7 +850,7 @@
 		BuildSounds: hvydoor1.aud
 		TerrainTypes: Clear,Road
 	FootprintPlaceBuildingPreview:
-		LineBuildSegmentPalette: placelinesegment
+		LineBuildFootprintAlpha: 0.65
 	RequiresBuildableArea:
 		AreaTypes: building
 		Adjacent: 4

--- a/mods/cnc/rules/palettes.yaml
+++ b/mods/cnc/rules/palettes.yaml
@@ -110,11 +110,3 @@
 	RotationPaletteEffect@water:
 		ExcludePalettes: effect, chrome
 		RotationBase: 32
-	PaletteFromPaletteWithAlpha@placelinesegment:
-		Name: placelinesegment
-		BasePalette: terrain
-		Alpha: 0.65
-	PaletteFromPlayerPaletteWithAlpha@placebuilding:
-		BaseName: placebuilding
-		Alpha: 0.65
-		BasePalette: player

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -516,7 +516,7 @@ WEAP:
 	-ActorPreviewPlaceBuildingPreview:
 	SequencePlaceBuildingPreview:
 		Sequence: place
-		SequencePalette: placebuilding
+		SequenceAlpha: 0.65
 
 HPAD:
 	Inherits: ^BaseBuilding
@@ -925,7 +925,7 @@ SAM:
 	-ActorPreviewPlaceBuildingPreview:
 	SequencePlaceBuildingPreview:
 		Sequence: place
-		SequencePalette: placebuilding
+		SequenceAlpha: 0.65
 
 OBLI:
 	Inherits: ^Defense

--- a/mods/d2k/rules/campaign-palettes.yaml
+++ b/mods/d2k/rules/campaign-palettes.yaml
@@ -2,7 +2,6 @@
 	-PlayerColorPalette:
 	-PaletteFromPlayerPaletteWithAlpha@deviatorgas:
 	-PaletteFromPlayerPaletteWithAlpha@cloak:
-	-PaletteFromPlayerPaletteWithAlpha@placebuilding:
 	IndexedPlayerPalette:
 		BasePalette: d2k
 		BaseName: player
@@ -26,7 +25,3 @@
 		BaseName: cloak
 		BasePalette: player
 		Alpha: 0.55
-	PaletteFromPlayerPaletteWithAlpha@Placebuilding:
-		BaseName: placebuilding
-		BasePalette: player
-		Alpha: 0.65

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -421,7 +421,7 @@
 		ConcretePrerequisites: global-auto-concrete
 	D2kActorPreviewPlaceBuildingPreview:
 		RequiresPrerequisites: !global-auto-concrete
-		OverridePalette: placebuilding
+		PreviewAlpha: 0.65
 	RequiresBuildableArea:
 		AreaTypes: building
 		Adjacent: 3

--- a/mods/d2k/rules/palettes.yaml
+++ b/mods/d2k/rules/palettes.yaml
@@ -71,11 +71,3 @@
 		BaseName: cloak
 		BasePalette: player
 		Alpha: 0.55
-	PaletteFromPaletteWithAlpha@placelinesegment:
-		Name: placelinesegment
-		BasePalette: terrain
-		Alpha: 0.65
-	PaletteFromPlayerPaletteWithAlpha@placebuilding:
-		BaseName: placebuilding
-		BasePalette: player
-		Alpha: 0.65

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -670,7 +670,7 @@ wall:
 		BuildSounds: CHUNG.WAV
 		TerrainTypes: Rock, Concrete
 	FootprintPlaceBuildingPreview:
-		LineBuildSegmentPalette: placelinesegment
+		LineBuildFootprintAlpha: 0.65
 	RequiresBuildableArea:
 		AreaTypes: building
 		Adjacent: 7

--- a/mods/ra/rules/campaign-palettes.yaml
+++ b/mods/ra/rules/campaign-palettes.yaml
@@ -1,7 +1,6 @@
 ^Palettes:
 	-PlayerColorPalette:
 	-PaletteFromPlayerPaletteWithAlpha@cloak:
-	-PaletteFromPlayerPaletteWithAlpha@placebuilding:
 	IndexedPlayerPalette:
 		BasePalette: player
 		BaseName: player
@@ -24,7 +23,3 @@
 		BaseName: cloak
 		BasePalette: player
 		Alpha: 0.55
-	PaletteFromPlayerPaletteWithAlpha@Placebuilding:
-		BaseName: placebuilding
-		BasePalette: player
-		Alpha: 0.65

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -652,7 +652,7 @@
 		BuildSounds: placbldg.aud, build5.aud
 		UndeploySounds: cashturn.aud
 	ActorPreviewPlaceBuildingPreview:
-		OverridePalette: placebuilding
+		PreviewAlpha: 0.65
 	RequiresBuildableArea:
 		AreaTypes: building
 	SoundOnDamageTransition:
@@ -760,7 +760,7 @@
 		TerrainTypes: Clear,Road
 		UndeploySounds: cashturn.aud
 	FootprintPlaceBuildingPreview:
-		LineBuildSegmentPalette: placelinesegment
+		LineBuildFootprintAlpha: 0.65
 	RequiresBuildableArea:
 		AreaTypes: building
 		Adjacent: 7

--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -191,7 +191,7 @@ WEAF:
 	-ActorPreviewPlaceBuildingPreview:
 	SequencePlaceBuildingPreview:
 		Sequence: place
-		SequencePalette: placebuilding
+		SequenceAlpha: 0.65
 
 DOMF:
 	Inherits: ^FakeBuilding

--- a/mods/ra/rules/palettes.yaml
+++ b/mods/ra/rules/palettes.yaml
@@ -94,14 +94,6 @@
 	ChronoshiftPaletteEffect:
 	FlashPaletteEffect@NUKE:
 		Type: Nuke
-	PaletteFromPaletteWithAlpha@placelinesegment:
-		Name: placelinesegment
-		BasePalette: terrain
-		Alpha: 0.65
-	PaletteFromPlayerPaletteWithAlpha@placebuilding:
-		BaseName: placebuilding
-		BasePalette: player
-		Alpha: 0.65
 	IndexedPalette@CIV2:
 		Name: civilian2
 		BasePalette: player

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1103,7 +1103,7 @@ WEAP:
 	-ActorPreviewPlaceBuildingPreview:
 	SequencePlaceBuildingPreview:
 		Sequence: place
-		SequencePalette: placebuilding
+		SequenceAlpha: 0.65
 
 FACT:
 	Inherits: ^Building
@@ -1290,7 +1290,7 @@ PROC:
 	-ActorPreviewPlaceBuildingPreview:
 	SequencePlaceBuildingPreview:
 		Sequence: idle
-		SequencePalette: placebuilding
+		SequenceAlpha: 0.65
 	WithResourceStoragePipsDecoration:
 		Position: BottomLeft
 		Margin: 4, 3

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -324,9 +324,10 @@
 		TerrainTypes: Clear, Rough, Road, DirtRoad, Green, Sand, Pavement
 		UndeploySounds: cashturn.aud
 	ActorPreviewPlaceBuildingPreview:
-		Palette: placefootprint
-		LineBuildSegmentPalette: placelinesegment
-		OverridePalette: placebuilding
+		Palette: ra
+		FootprintAlpha: 0.7
+		LineBuildFootprintAlpha: 0.5
+		PreviewAlpha: 0.55
 		FootprintUnderPreview: Valid, LineBuild, Invalid
 		FootprintOverPreview: None
 	RequiresBuildableArea:
@@ -483,8 +484,9 @@
 		TerrainTypes: Clear, Rough, Road, DirtRoad, Green, Sand, Pavement
 		UndeploySounds: cashturn.aud
 	FootprintPlaceBuildingPreview:
-		Palette: placefootprint
-		LineBuildSegmentPalette: placelinesegment
+		Palette: ra
+		FootprintAlpha: 0.7
+		LineBuildFootprintAlpha: 0.5
 	RequiresBuildableArea:
 		AreaTypes: building
 		Adjacent: 7
@@ -533,8 +535,9 @@
 		UndeploySounds: cashturn.aud
 	SequencePlaceBuildingPreview:
 		Sequence: place
-		SequencePalette: placebuilding
-		Palette: placefootprint
+		Palette: ra
+		FootprintAlpha: 0.7
+		SequenceAlpha: 0.55
 	KillsSelf:
 		RemoveInstead: true
 	RenderSprites:

--- a/mods/ts/rules/palettes.yaml
+++ b/mods/ts/rules/palettes.yaml
@@ -129,18 +129,6 @@
 	PlayerColorPalette:
 		BasePalette: player
 		RemapIndex: 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
-	PaletteFromPaletteWithAlpha@placebuilding:
-		Name: placefootprint
-		BasePalette: ra
-		Alpha: 0.7
-	PaletteFromPaletteWithAlpha@placelinesegment:
-		Name: placelinesegment
-		BasePalette: ra
-		Alpha: 0.5
-	PaletteFromPlayerPaletteWithAlpha@placebuilding:
-		BaseName: placebuilding
-		BasePalette: player
-		Alpha: 0.55
 	PaletteFromPlayerPaletteWithAlpha@cloak:
 		BaseName: cloak
 		BasePalette: player

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -378,6 +378,7 @@ EditorWorld:
 	EditorCursorLayer:
 	EditorResourceLayer:
 	EditorSelectionLayer:
-		Palette: placefootprint
+		Palette: ra
+		FootprintAlpha: 0.7
 	LoadWidgetAtGameStart:
 	EditorActionManager:


### PR DESCRIPTION
Building on #18550, this PR replaces the custom palettes in PBOG previews with an explicit alpha value to make them compatible with with 32bit sprites.

The testcase commit demonstrates that target flashes and WithColoredOverlay (from #18550) and building placement previews work as expected for the D2k R16 sprites (loaded as 32bit). You will need to provide your own R16 files from an original game install.