### PR TITLE
Explicitly return on failure in make.ps1

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -99,13 +99,13 @@ function Test-Command
 
 	Write-Host "Testing mods..." -ForegroundColor Cyan
 	Write-Host "Testing Tiberian Sun mod MiniYAML..." -ForegroundColor Cyan
-	Invoke-Expression "$utilityPath ts --check-yaml"
+	InvokeCommand "$utilityPath ts --check-yaml"
 	Write-Host "Testing Dune 2000 mod MiniYAML..." -ForegroundColor Cyan
-	Invoke-Expression "$utilityPath d2k --check-yaml"
+	InvokeCommand "$utilityPath d2k --check-yaml"
 	Write-Host "Testing Tiberian Dawn mod MiniYAML..." -ForegroundColor Cyan
-	Invoke-Expression "$utilityPath cnc --check-yaml"
+	InvokeCommand "$utilityPath cnc --check-yaml"
 	Write-Host "Testing Red Alert mod MiniYAML..." -ForegroundColor Cyan
-	Invoke-Expression "$utilityPath ra --check-yaml"
+	InvokeCommand "$utilityPath ra --check-yaml"
 }
 
 function Check-Command
@@ -120,10 +120,10 @@ function Check-Command
 	if ((CheckForUtility) -eq 0)
 	{
 		Write-Host "Checking for explicit interface violations..." -ForegroundColor Cyan
-		Invoke-Expression "$utilityPath all --check-explicit-interfaces"
+		InvokeCommand "$utilityPath all --check-explicit-interfaces"
 
 		Write-Host "Checking for incorrect conditional trait interface overrides..." -ForegroundColor Cyan
-		Invoke-Expression "$utilityPath all --check-conditional-trait-interface-overrides"
+		InvokeCommand "$utilityPath all --check-conditional-trait-interface-overrides"
 	}
 }
 
@@ -198,6 +198,20 @@ function WaitForInput
 			exit
 		}
 		Start-Sleep -Milliseconds 50
+	}
+}
+
+function InvokeCommand
+{
+	param($expression)
+	# $? is the return value of the called expression
+	# Invoke-Expression itself will always succeed, even if the invoked expression fails
+	# So temporarily store the return value in $success
+	$expression += '; $success = $?'
+	Invoke-Expression $expression
+	if ($success -eq $False)
+	{
+		exit 1
 	}
 }
 


### PR DESCRIPTION
Closes #18949:

Using `Invoke-Expression` has a side-effect: The return value won't be the one from the invoked expression, but from the `Invoke-Expression` command itself (which always succeeds). We can easily avoid that so I wrote a wrapper function.