### PR TITLE
Add a per-player handicap option to the lobby.

### DIFF
--- a/OpenRA.Game/GameInformation.cs
+++ b/OpenRA.Game/GameInformation.cs
@@ -123,6 +123,7 @@ namespace OpenRA
 				DisplayFactionId = runtimePlayer.DisplayFaction.InternalName,
 				Color = runtimePlayer.Color,
 				Team = client.Team,
+				Handicap = client.Handicap,
 				SpawnPoint = runtimePlayer.SpawnPoint,
 				IsRandomFaction = runtimePlayer.Faction.InternalName != client.Faction,
 				IsRandomSpawnPoint = runtimePlayer.DisplaySpawnPoint == 0,
@@ -166,6 +167,7 @@ namespace OpenRA
 			/// <summary>The team ID on start-up, or 0 if the player is not part of a team.</summary>
 			public int Team;
 			public int SpawnPoint;
+			public int Handicap;
 
 			/// <summary>True if the faction was chosen at random; otherwise, false.</summary>
 			public bool IsRandomFaction;

--- a/OpenRA.Game/Map/PlayerReference.cs
+++ b/OpenRA.Game/Map/PlayerReference.cs
@@ -50,6 +50,9 @@ namespace OpenRA
 		public bool LockTeam = false;
 		public int Team = 0;
 
+		public bool LockHandicap = false;
+		public int Handicap = 0;
+
 		public string[] Allies = { };
 		public string[] Enemies = { };
 

--- a/OpenRA.Game/Network/GameSave.cs
+++ b/OpenRA.Game/Network/GameSave.cs
@@ -25,6 +25,7 @@ namespace OpenRA.Network
 		public readonly string Faction;
 		public readonly int SpawnPoint;
 		public readonly int Team;
+		public readonly int Handicap;
 		public readonly string Slot;
 		public readonly string Bot;
 		public readonly bool IsAdmin;
@@ -39,6 +40,7 @@ namespace OpenRA.Network
 			Faction = client.Faction;
 			SpawnPoint = client.SpawnPoint;
 			Team = client.Team;
+			Handicap = client.Handicap;
 			Slot = client.Slot;
 			Bot = client.Bot;
 			IsAdmin = client.IsAdmin;
@@ -53,6 +55,7 @@ namespace OpenRA.Network
 			client.Faction = Faction;
 			client.SpawnPoint = SpawnPoint;
 			client.Team = Team;
+			client.Handicap = Handicap;
 			client.Slot = Slot;
 			client.Bot = Bot;
 			client.IsAdmin = IsAdmin;

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -144,6 +144,7 @@ namespace OpenRA.Network
 
 			public ClientState State = ClientState.Invalid;
 			public int Team;
+			public int Handicap;
 			public string Slot; // Slot ID, or null for observer
 			public string Bot; // Bot type, null for real clients
 			public int BotControllerClientIndex; // who added the bot to the slot
@@ -193,6 +194,7 @@ namespace OpenRA.Network
 			public bool LockFaction;
 			public bool LockColor;
 			public bool LockTeam;
+			public bool LockHandicap;
 			public bool LockSpawn;
 			public bool Required;
 

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -58,6 +58,7 @@ namespace OpenRA
 		public readonly bool Playable = true;
 		public readonly int ClientIndex;
 		public readonly CPos HomeLocation;
+		public readonly int Handicap;
 		public readonly PlayerReference PlayerReference;
 		public readonly bool IsBot;
 		public readonly string BotType;
@@ -180,6 +181,8 @@ namespace OpenRA
 				HomeLocation = assignSpawnPoints?.AssignHomeLocation(world, client, playerRandom) ?? pr.HomeLocation;
 				SpawnPoint = assignSpawnPoints?.SpawnPointForPlayer(this) ?? client.SpawnPoint;
 				DisplaySpawnPoint = client.SpawnPoint;
+
+				Handicap = client.Handicap;
 			}
 			else
 			{
@@ -195,6 +198,7 @@ namespace OpenRA
 				DisplayFaction = ResolveDisplayFaction(world, pr.Faction);
 				HomeLocation = pr.HomeLocation;
 				SpawnPoint = DisplaySpawnPoint = 0;
+				Handicap = pr.Handicap;
 			}
 
 			if (!spectating)

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -93,6 +93,8 @@ namespace OpenRA.Server
 				c.SpawnPoint = pr.Spawn;
 			if (pr.LockTeam)
 				c.Team = pr.Team;
+			if (pr.LockHandicap)
+				c.Team = pr.Handicap;
 
 			c.Color = pr.LockColor ? pr.Color : c.PreferredColor;
 		}
@@ -437,6 +439,7 @@ namespace OpenRA.Server
 					Faction = "Random",
 					SpawnPoint = 0,
 					Team = 0,
+					Handicap = 0,
 					State = Session.ClientState.Invalid,
 				};
 

--- a/OpenRA.Mods.Common/Scripting/Properties/PlayerProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/PlayerProperties.cs
@@ -52,6 +52,16 @@ namespace OpenRA.Mods.Common.Scripting
 			}
 		}
 
+		[Desc("The player's handicap level.")]
+		public int Handicap
+		{
+			get
+			{
+				var c = Player.World.LobbyInfo.Clients.FirstOrDefault(i => i.Index == Player.ClientIndex);
+				return c?.Handicap ?? 0;
+			}
+		}
+
 		[Desc("Returns true if the player is a bot.")]
 		public bool IsBot { get { return Player.IsBot; } }
 

--- a/OpenRA.Mods.Common/Traits/Multipliers/HandicapDamageMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/HandicapDamageMultiplier.cs
@@ -1,0 +1,40 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Modifies the damage applied to this actor based on the owner's handicap.")]
+	public class HandicapDamageMultiplierInfo : TraitInfo
+	{
+		public override object Create(ActorInitializer init) { return new HandicapDamageMultiplier(init.Self); }
+	}
+
+	public class HandicapDamageMultiplier : IDamageModifier
+	{
+		readonly Actor self;
+
+		public HandicapDamageMultiplier(Actor self)
+		{
+			this.self = self;
+		}
+
+		int IDamageModifier.GetDamageModifier(Actor attacker, Damage damage)
+		{
+			// Equivalent to the health handicap from C&C3:
+			//  5% handicap = 95% health = 105% damage
+			// 50% handicap = 50% health = 200% damage
+			// 95% handicap = 5% health = 2000% damage
+			return 10000 / (100 - self.Owner.Handicap);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Multipliers/HandicapFirepowerMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/HandicapFirepowerMultiplier.cs
@@ -1,0 +1,40 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Modifies the damage applied by this actor based on the owner's handicap.")]
+	public class HandicapFirepowerMultiplierInfo : TraitInfo
+	{
+		public override object Create(ActorInitializer init) { return new HandicapFirepowerMultiplier(init.Self); }
+	}
+
+	public class HandicapFirepowerMultiplier : IFirepowerModifier
+	{
+		readonly Actor self;
+
+		public HandicapFirepowerMultiplier(Actor self)
+		{
+			this.self = self;
+		}
+
+		int IFirepowerModifier.GetFirepowerModifier()
+		{
+			// Equivalent to the firepower handicap from C&C3:
+			//  5% handicap = 95% firepower
+			// 50% handicap = 50% firepower
+			// 95% handicap = 5% firepower
+			return 100 - self.Owner.Handicap;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Multipliers/HandicapProductionTimeMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/HandicapProductionTimeMultiplier.cs
@@ -1,0 +1,32 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Modifies the production time of this actor based on the producer's handicap.")]
+	public class HandicapProductionTimeMultiplierInfo : TraitInfo<HandicapProductionTimeMultiplier>, IProductionTimeModifierInfo
+	{
+		int IProductionTimeModifierInfo.GetProductionTimeModifier(TechTree techTree, string queue)
+		{
+			// Equivalent to the build speed handicap from C&C3:
+			//  5% handicap = 105% build time
+			// 50% handicap = 150% build time
+			// 95% handicap = 195% build time
+			return 100 + techTree.Owner.Handicap;
+		}
+	}
+
+	public class HandicapProductionTimeMultiplier { }
+}

--- a/OpenRA.Mods.Common/Traits/Player/TechTree.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TechTree.cs
@@ -106,6 +106,8 @@ namespace OpenRA.Mods.Common.Traits
 			return ret;
 		}
 
+		public Player Owner { get { return player; } }
+
 		class Watcher
 		{
 			public readonly string Key;

--- a/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs
+++ b/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs
@@ -64,6 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 					DisplayFactionId = clientFaction.InternalName,
 					Color = client.Color,
 					Team = client.Team,
+					Handicap = client.Handicap,
 					SpawnPoint = resolvedSpawnPoint,
 					IsRandomFaction = clientFaction.RandomFactionMembers.Any(),
 					IsRandomSpawnPoint = client.SpawnPoint == 0,

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -624,6 +624,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					LobbyUtils.SetupEditableColorWidget(template, slot, client, orderManager, shellmapWorld, colorPreview);
 					LobbyUtils.SetupEditableFactionWidget(template, slot, client, orderManager, factions);
 					LobbyUtils.SetupEditableTeamWidget(template, slot, client, orderManager, map);
+					LobbyUtils.SetupEditableHandicapWidget(template, slot, client, orderManager, map);
 					LobbyUtils.SetupEditableSpawnWidget(template, slot, client, orderManager, map);
 					LobbyUtils.SetupEditableReadyWidget(template, slot, client, orderManager, map);
 				}
@@ -640,6 +641,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					if (isHost)
 					{
 						LobbyUtils.SetupEditableTeamWidget(template, slot, client, orderManager, map);
+						LobbyUtils.SetupEditableHandicapWidget(template, slot, client, orderManager, map);
 						LobbyUtils.SetupEditableSpawnWidget(template, slot, client, orderManager, map);
 						LobbyUtils.SetupPlayerActionWidget(template, slot, client, orderManager, worldRenderer,
 							lobby, () => panel = PanelType.Kick, () => panel = PanelType.Players);
@@ -648,6 +650,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						LobbyUtils.SetupNameWidget(template, slot, client, orderManager, worldRenderer);
 						LobbyUtils.SetupTeamWidget(template, slot, client);
+						LobbyUtils.SetupHandicapWidget(template, slot, client);
 						LobbyUtils.SetupSpawnWidget(template, slot, client);
 					}
 

--- a/mods/cnc/chrome/lobby-music.yaml
+++ b/mods/cnc/chrome/lobby-music.yaml
@@ -20,12 +20,13 @@ Container@LOBBY_MUSIC_BIN:
 					Height: 25
 					Text: Track
 					Font: Bold
-				Label@TYPE:
-					X: PARENT_RIGHT - 63
+				Label@LENGTH:
+					X: PARENT_RIGHT - 80
 					Height: 25
 					Width: 50
 					Text: Length
 					Font: Bold
+					Align: Right
 		Background@CONTROLS:
 			Background: panel-transparent
 			Width: 308

--- a/mods/cnc/chrome/lobby-options.yaml
+++ b/mods/cnc/chrome/lobby-options.yaml
@@ -23,21 +23,21 @@ Container@LOBBY_OPTIONS_BIN:
 							Height: 34
 							Children:
 								Checkbox@A:
-									Width: 175
+									Width: 220
 									Height: 20
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								Checkbox@B:
-									X: 195
-									Width: 175
+									X: 225
+									Width: 220
 									Height: 20
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								Checkbox@C:
-									X: 375
-									Width: 175
+									X: 450
+									Width: 220
 									Height: 20
 									Font: Regular
 									Visible: False
@@ -47,26 +47,26 @@ Container@LOBBY_OPTIONS_BIN:
 							Width: PARENT_RIGHT
 							Children:
 								Label@A_DESC:
-									Width: 80
+									Width: 140
 									Height: 25
 									Align: Right
 									Visible: False
 								DropDownButton@A:
-									X: 85
-									Width: 160
+									X: 145
+									Width: 180
 									Height: 25
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								Label@B_DESC:
-									X: PARENT_RIGHT - WIDTH - 183
-									Width: 160
+									X: PARENT_RIGHT - WIDTH - 203
+									Width: 140
 									Height: 25
 									Align: Right
 									Visible: False
 								DropDownButton@B:
 									X: PARENT_RIGHT - WIDTH - 18
-									Width: 160
+									Width: 180
 									Height: 25
 									Font: Regular
 									Visible: False

--- a/mods/cnc/chrome/lobby-players.yaml
+++ b/mods/cnc/chrome/lobby-players.yaml
@@ -16,34 +16,34 @@ Container@LOBBY_PLAYER_BIN:
 					Font: Bold
 				Label@COLOR:
 					X: 210
-					Width: 76
+					Width: 94
 					Height: 25
 					Text: Color
 					Align: Center
 					Font: Bold
 				Label@FACTION:
-					X: 291
+					X: 309
 					Width: 120
 					Height: 25
 					Text: Faction
 					Align: Center
 					Font: Bold
 				Label@TEAM:
-					X: 416
+					X: 460-25
 					Width: 50
 					Height: 25
 					Text: Team
 					Align: Center
 					Font: Bold
 				Label@SPAWN:
-					X: 471
+					X: 571
 					Width: 50
 					Height: 25
 					Text: Spawn
 					Align: Left
 					Font: Bold
 				Label@STATUS:
-					X: 527
+					X: 627
 					Width: 20
 					Height: 25
 					Text: Ready
@@ -108,7 +108,7 @@ Container@LOBBY_PLAYER_BIN:
 							Visible: false
 						DropDownButton@COLOR:
 							X: 210
-							Width: 76
+							Width: 94
 							Height: 25
 							Font: Regular
 							IgnoreChildMouseOver: true
@@ -119,7 +119,7 @@ Container@LOBBY_PLAYER_BIN:
 									Width: PARENT_RIGHT - 35
 									Height: PARENT_BOTTOM - 12
 						DropDownButton@FACTION:
-							X: 291
+							X: 309
 							Width: 120
 							Height: 25
 							Font: Regular
@@ -138,17 +138,17 @@ Container@LOBBY_PLAYER_BIN:
 									Height: 25
 									Text: Faction
 						DropDownButton@TEAM_DROPDOWN:
-							X: 416
+							X: 435
 							Width: 50
 							Height: 25
 							Font: Regular
 						DropDownButton@SPAWN_DROPDOWN:
-							X: 471
+							X: 571
 							Width: 50
 							Height: 25
 							Font: Regular
 						Image@STATUS_IMAGE:
-							X: 529
+							X: 629
 							Y: 4
 							Width: 20
 							Height: 20
@@ -156,7 +156,7 @@ Container@LOBBY_PLAYER_BIN:
 							ImageName: checked
 							Visible: false
 						Checkbox@STATUS_CHECKBOX:
-							X: 527
+							X: 627
 							Y: 2
 							Width: 20
 							Height: 20
@@ -224,10 +224,10 @@ Container@LOBBY_PLAYER_BIN:
 						ColorBlock@COLORBLOCK:
 							X: 215
 							Y: 6
-							Width: 41
+							Width: 59
 							Height: 13
 						Container@FACTION:
-							X: 291
+							X: 309
 							Width: 120
 							Height: 25
 							Children:
@@ -242,29 +242,29 @@ Container@LOBBY_PLAYER_BIN:
 									Height: 25
 									Text: Faction
 						Label@TEAM:
-							X: 416
-							Width: 25
-							Height: 25
-							Align: Center
-						Label@SPAWN:
-							X: 471
+							X: 435
 							Width: 25
 							Height: 25
 							Align: Center
 						DropDownButton@TEAM_DROPDOWN:
-							X: 416
+							X: 435
 							Width: 50
 							Height: 25
 							Font: Regular
 							Visible: false
+						Label@SPAWN:
+							X: 571
+							Width: 25
+							Height: 25
+							Align: Center
 						DropDownButton@SPAWN_DROPDOWN:
-							X: 471
+							X: 571
 							Width: 50
 							Height: 25
 							Font: Regular
 							Visible: false
 						Image@STATUS_IMAGE:
-							X: 529
+							X: 629
 							Y: 4
 							Width: 20
 							Height: 20
@@ -291,7 +291,7 @@ Container@LOBBY_PLAYER_BIN:
 							Visible: false
 						Button@JOIN:
 							X: 210
-							Width: 338
+							Width: 438
 							Height: 25
 							Text: Play in this slot
 							Font: Regular
@@ -340,13 +340,13 @@ Container@LOBBY_PLAYER_BIN:
 									Template: ANONYMOUS_PLAYER_TOOLTIP
 						Label@SPECTATOR:
 							X: 210
-							Width: 341
+							Width: 441
 							Height: 25
 							Text: Spectator
 							Align: Center
 							Font: Bold
 						Image@STATUS_IMAGE:
-							X: 529
+							X: 629
 							Y: 4
 							Width: 20
 							Height: 20
@@ -354,7 +354,7 @@ Container@LOBBY_PLAYER_BIN:
 							ImageName: checked
 							Visible: false
 						Checkbox@STATUS_CHECKBOX:
-							X: 527
+							X: 627
 							Y: 2
 							Width: 20
 							Height: 20
@@ -421,13 +421,13 @@ Container@LOBBY_PLAYER_BIN:
 									Template: ANONYMOUS_PLAYER_TOOLTIP
 						Label@SPECTATOR:
 							X: 210
-							Width: 341
+							Width: 441
 							Height: 25
 							Text: Spectator
 							Align: Center
 							Font: Bold
 						Image@STATUS_IMAGE:
-							X: 527
+							X: 627
 							Y: 4
 							Width: 20
 							Height: 20
@@ -448,7 +448,7 @@ Container@LOBBY_PLAYER_BIN:
 							Text: Allow Spectators?
 						Button@SPECTATE:
 							X: 210
-							Width: 338
+							Width: 438
 							Height: 25
 							Text: Spectate
 							Font: Regular

--- a/mods/cnc/chrome/lobby-players.yaml
+++ b/mods/cnc/chrome/lobby-players.yaml
@@ -35,6 +35,13 @@ Container@LOBBY_PLAYER_BIN:
 					Text: Team
 					Align: Center
 					Font: Bold
+				Label@HANDICAP:
+					X: 491
+					Width: 75
+					Height: 25
+					Text: Handicap
+					Align: Center
+					Font: Bold
 				Label@SPAWN:
 					X: 571
 					Width: 50
@@ -142,6 +149,13 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 50
 							Height: 25
 							Font: Regular
+						DropDownButton@HANDICAP_DROPDOWN:
+							X: 491
+							Width: 75
+							Height: 25
+							Font: Regular
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipText: A handicap decreases the combat effectiveness of the player's forces
 						DropDownButton@SPAWN_DROPDOWN:
 							X: 571
 							Width: 50
@@ -252,6 +266,18 @@ Container@LOBBY_PLAYER_BIN:
 							Height: 25
 							Font: Regular
 							Visible: false
+						Label@HANDICAP:
+							X: 491
+							Width: 50
+							Height: 25
+							Align: Center
+						DropDownButton@HANDICAP_DROPDOWN:
+							X: 491
+							Width: 75
+							Height: 25
+							Font: Regular
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipText: A handicap decreases the combat effectiveness of the player's forces
 						Label@SPAWN:
 							X: 571
 							Width: 25

--- a/mods/cnc/chrome/lobby-servers.yaml
+++ b/mods/cnc/chrome/lobby-servers.yaml
@@ -9,32 +9,32 @@ Container@LOBBY_SERVERS_BIN:
 			Children:
 				Label@NAME:
 					X: 5
-					Width: 255
+					Width: 355
 					Height: 25
 					Text: Server
 					Align: Center
 					Font: Bold
 				Label@PLAYERS:
-					X: 290
+					X: 390
 					Width: 85
 					Height: 25
 					Text: Players
 					Font: Bold
 				Label@LOCATION:
-					X: 380
+					X: 480
 					Width: 110
 					Height: 25
 					Text: Location
 					Font: Bold
 				Label@STATUS:
-					X: 495
+					X: 595
 					Width: 50
 					Height: 25
 					Text: Status
 					Font: Bold
 		LogicTicker@NOTICE_WATCHER:
 		Container@NOTICE_CONTAINER:
-			Width: 582
+			Width: PARENT_RIGHT
 			Height: 19
 			Children:
 				Background@bg:
@@ -87,12 +87,12 @@ Container@LOBBY_SERVERS_BIN:
 					Children:
 						LabelWithTooltip@TITLE:
 							X: 5
-							Width: 245
+							Width: 345
 							Height: 25
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 						Image@PASSWORD_PROTECTED:
-							X: 272
+							X: 372
 							Y: 6
 							Width: 12
 							Height: 13
@@ -101,7 +101,7 @@ Container@LOBBY_SERVERS_BIN:
 							TooltipTemplate: SIMPLE_TOOLTIP
 							TooltipText: Requires Password
 						Image@REQUIRES_AUTHENTICATION:
-							X: 272
+							X: 372
 							Y: 6
 							Width: 12
 							Height: 13
@@ -110,17 +110,17 @@ Container@LOBBY_SERVERS_BIN:
 							TooltipTemplate: SIMPLE_TOOLTIP
 							TooltipText: Requires OpenRA forum account
 						LabelWithTooltip@PLAYERS:
-							X: 290
+							X: 390
 							Width: 85
 							Height: 25
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 						Label@LOCATION:
-							X: 380
+							X: 480
 							Width: 110
 							Height: 25
 						Label@STATUS:
-							X: 495
+							X: 595
 							Width: 50
 							Height: 25
 		Label@PROGRESS_LABEL:
@@ -132,12 +132,12 @@ Container@LOBBY_SERVERS_BIN:
 			Visible: false
 		DropDownButton@FILTERS_DROPDOWNBUTTON:
 			Y: PARENT_BOTTOM + 5
-			Width: 151
+			Width: 180
 			Height: 25
 			Text: Filter Games
 			Font: Bold
 		Button@RELOAD_BUTTON:
-			X: 156
+			X: 185
 			Y: PARENT_BOTTOM + 5
 			Width: 26
 			Height: 25

--- a/mods/cnc/chrome/lobby.yaml
+++ b/mods/cnc/chrome/lobby.yaml
@@ -2,7 +2,7 @@ Container@SERVER_LOBBY:
 	Logic: LobbyLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - 560) / 2
-	Width: 800
+	Width: 900
 	Height: 575
 	Children:
 		ColorPreviewManager@COLOR_MANAGER:
@@ -25,55 +25,57 @@ Container@SERVER_LOBBY:
 				DropDownButton@SLOTS_DROPDOWNBUTTON:
 					X: 15
 					Y: 254
-					Width: 182
+					Width: 211
 					Height: 25
 					Text: Slot Admin
 				Container@SKIRMISH_TABS:
+					X: 697 - WIDTH
+					Width: 465
 					Visible: False
 					Children:
 						Button@PLAYERS_TAB:
-							X: 202
 							Y: 248
-							Width: 129
+							Width: 151
 							Height: 31
 							Text: Players
 						Button@OPTIONS_TAB:
-							X: 336
+							X: 157
 							Y: 248
-							Width: 128
+							Width: 151
 							Height: 31
 							Text: Options
 						Button@MUSIC_TAB:
-							X: 469
+							X: 314
 							Y: 248
-							Width: 128
+							Width: 151
 							Height: 31
 							Text: Music
 				Container@MULTIPLAYER_TABS:
+					X: 697 - WIDTH
+					Width: 465
 					Visible: False
 					Children:
 						Button@PLAYERS_TAB:
-							X: 202
 							Y: 248
-							Width: 95
+							Width: 112
 							Height: 31
 							Text: Players
 						Button@OPTIONS_TAB:
-							X: 302
+							X: 118
 							Y: 248
-							Width: 95
+							Width: 112
 							Height: 31
 							Text: Options
 						Button@MUSIC_TAB:
-							X: 402
+							X: 236
 							Y: 248
-							Width: 95
+							Width: 112
 							Height: 31
 							Text: Music
 						Button@SERVERS_TAB:
-							X: 502
+							X: 354
 							Y: 248
-							Width: 95
+							Width: 111
 							Height: 31
 							Text: Servers
 				Button@CHANGEMAP_BUTTON:
@@ -85,7 +87,7 @@ Container@SERVER_LOBBY:
 				Container@TOP_PANELS_ROOT:
 					X: 15
 					Y: 30
-					Width: 582
+					Width: 682
 					Height: 219
 				Container@LOBBYCHAT:
 					X: 15

--- a/mods/cnc/chrome/multiplayer-browser.yaml
+++ b/mods/cnc/chrome/multiplayer-browser.yaml
@@ -2,7 +2,7 @@ Container@MULTIPLAYER_PANEL:
 	Logic: MultiplayerLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - 560) / 2
-	Width: 800
+	Width: 900
 	Height: 575
 	Children:
 		Label@TITLE:
@@ -25,25 +25,25 @@ Container@MULTIPLAYER_PANEL:
 					Children:
 						Label@NAME:
 							X: 5
-							Width: 255
+							Width: 355
 							Height: 25
 							Text: Server
 							Align: Center
 							Font: Bold
 						Label@PLAYERS:
-							X: 290
+							X: 390
 							Width: 85
 							Height: 25
 							Text: Players
 							Font: Bold
 						Label@LOCATION:
-							X: 380
+							X: 480
 							Width: 110
 							Height: 25
 							Text: Location
 							Font: Bold
 						Label@STATUS:
-							X: 495
+							X: 595
 							Width: 50
 							Height: 25
 							Text: Status
@@ -52,7 +52,7 @@ Container@MULTIPLAYER_PANEL:
 				Container@NOTICE_CONTAINER:
 					X: 15
 					Y: 30
-					Width: 582
+					Width: 682
 					Height: 19
 					Children:
 						Background@bg:
@@ -84,7 +84,7 @@ Container@MULTIPLAYER_PANEL:
 				ScrollPanel@SERVER_LIST:
 					X: 15
 					Y: 30
-					Width: 582
+					Width: 682
 					Height: PARENT_BOTTOM - 75
 					TopBottomSpacing: 2
 					Children:
@@ -107,12 +107,12 @@ Container@MULTIPLAYER_PANEL:
 							Children:
 								LabelWithTooltip@TITLE:
 									X: 5
-									Width: 245
+									Width: 345
 									Height: 25
 									TooltipContainer: TOOLTIP_CONTAINER
 									TooltipTemplate: SIMPLE_TOOLTIP
 								Image@PASSWORD_PROTECTED:
-									X: 272
+									X: 372
 									Y: 6
 									Width: 12
 									Height: 13
@@ -121,7 +121,7 @@ Container@MULTIPLAYER_PANEL:
 									TooltipTemplate: SIMPLE_TOOLTIP
 									TooltipText: Requires Password
 								Image@REQUIRES_AUTHENTICATION:
-									X: 272
+									X: 372
 									Y: 6
 									Width: 12
 									Height: 13
@@ -130,23 +130,23 @@ Container@MULTIPLAYER_PANEL:
 									TooltipTemplate: SIMPLE_TOOLTIP
 									TooltipText: Requires OpenRA forum account
 								LabelWithTooltip@PLAYERS:
-									X: 290
+									X: 390
 									Width: 85
 									Height: 25
 									TooltipContainer: TOOLTIP_CONTAINER
 									TooltipTemplate: SIMPLE_TOOLTIP
 								Label@LOCATION:
-									X: 380
+									X: 480
 									Width: 110
 									Height: 25
 								Label@STATUS:
-									X: 495
+									X: 595
 									Width: 50
 									Height: 25
 				Label@PROGRESS_LABEL:
 					X: 15
 					Y: 31 + (PARENT_BOTTOM - 75 - HEIGHT) / 2
-					Width: 582
+					Width: 682
 					Height: 25
 					Font: Bold
 					Align: Center
@@ -231,20 +231,20 @@ Container@MULTIPLAYER_PANEL:
 							Children:
 								LogicTicker@ANIMATION:
 				Label@PLAYER_COUNT:
-					X: 198
+					X: 248
 					Y: PARENT_BOTTOM - 40
 					Width: 189
 					Height: 25
 					Align: Center
 					Font: Bold
 				Button@DIRECTCONNECT_BUTTON:
-					X: 387
+					X: 487
 					Y: PARENT_BOTTOM - 40
 					Width: 100
 					Height: 25
 					Text: Direct IP
 				Button@CREATE_BUTTON:
-					X: 492
+					X: 592
 					Y: PARENT_BOTTOM - 40
 					Width: 105
 					Height: 25

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -187,6 +187,11 @@
 	AttackMove:
 		AssaultMoveCondition: assault-move
 
+^PlayerHandicaps:
+	HandicapFirepowerMultiplier:
+	HandicapDamageMultiplier:
+	HandicapProductionTimeMultiplier:
+
 ^AcceptsCloakCrate:
 	Cloak:
 		InitialDelay: 15
@@ -224,6 +229,7 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@3: ^ClassicFacingSpriteActor
 	Inherits@selection: ^SelectableCombatUnit
+	Inherits@handicaps: ^PlayerHandicaps
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -269,6 +275,7 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@3: ^ClassicFacingSpriteActor
 	Inherits@selection: ^SelectableCombatUnit
+	Inherits@handicaps: ^PlayerHandicaps
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -323,6 +330,7 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@3: ^SpriteActor
 	Inherits@selection: ^SelectableCombatUnit
+	Inherits@handicaps: ^PlayerHandicaps
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -492,6 +500,7 @@
 	Inherits@2: ^SpriteActor
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Inherits@selection: ^SelectableCombatUnit
+	Inherits@handicaps: ^PlayerHandicaps
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -546,6 +555,7 @@
 	Inherits@2: ^SpriteActor
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Inherits@selection: ^SelectableCombatUnit
+	Inherits@handicaps: ^PlayerHandicaps
 	Huntable:
 	Health:
 		HP: 30000
@@ -601,6 +611,7 @@
 ^Plane:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^ClassicFacingSpriteActor
+	Inherits@handicaps: ^PlayerHandicaps
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -626,6 +637,7 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@3: ^SpriteActor
 	Inherits@selection: ^SelectableCombatUnit
+	Inherits@handicaps: ^PlayerHandicaps
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -653,6 +665,7 @@
 	Inherits@2: ^SpriteActor
 	Inherits@shape: ^1x1Shape
 	Inherits@selection: ^SelectableBuilding
+	Inherits@handicaps: ^PlayerHandicaps
 	Huntable:
 	OwnerLostAction:
 		Action: Kill

--- a/mods/common/chrome/lobby-music.yaml
+++ b/mods/common/chrome/lobby-music.yaml
@@ -20,12 +20,13 @@ Container@LOBBY_MUSIC_BIN:
 					Height: 25
 					Text: Track
 					Font: Bold
-				Label@TYPE:
-					X: PARENT_RIGHT - 63
+				Label@LENGTH:
+					X: PARENT_RIGHT - 80
 					Height: 25
 					Width: 50
 					Text: Length
 					Font: Bold
+					Align: Right
 		Background@CONTROLS:
 			Background: dialog3
 			Width: 268

--- a/mods/common/chrome/lobby-options.yaml
+++ b/mods/common/chrome/lobby-options.yaml
@@ -23,19 +23,19 @@ Container@LOBBY_OPTIONS_BIN:
 							Height: 30
 							Children:
 								Checkbox@A:
-									Width: 175
+									Width: 220
 									Height: 20
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								Checkbox@B:
-									X: 190
-									Width: 175
+									X: 225
+									Width: 220
 									Height: 20
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								Checkbox@C:
-									X: 375
-									Width: 175
+									X: 450
+									Width: 220
 									Height: 20
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
@@ -44,25 +44,25 @@ Container@LOBBY_OPTIONS_BIN:
 							Width: PARENT_RIGHT
 							Children:
 								Label@A_DESC:
-									Width: 90
+									Width: 140
 									Height: 25
 									Align: Right
 									Visible: False
 								DropDownButton@A:
-									X: 95
-									Width: 160
+									X: 145
+									Width: 180
 									Height: 25
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								Label@B_DESC:
-									X: PARENT_RIGHT - WIDTH - 183
-									Width: 160
+									X: PARENT_RIGHT - WIDTH - 203
+									Width: 140
 									Height: 25
 									Align: Right
 									Visible: False
 								DropDownButton@B:
 									X: PARENT_RIGHT - WIDTH - 18
-									Width: 160
+									Width: 180
 									Height: 25
 									Font: Regular
 									Visible: False

--- a/mods/common/chrome/lobby-players.yaml
+++ b/mods/common/chrome/lobby-players.yaml
@@ -23,27 +23,27 @@ Container@LOBBY_PLAYER_BIN:
 					Font: Bold
 				Label@LABEL_LOBBY_FACTION:
 					X: 270
-					Width: 130
+					Width: 140
 					Height: 25
 					Text: Faction
 					Align: Center
 					Font: Bold
 				Label@LABEL_LOBBY_TEAM:
-					X: 410
+					X: 420
 					Width: 48
 					Height: 25
 					Text: Team
 					Align: Center
 					Font: Bold
 				Label@LABEL_LOBBY_SPAWN:
-					X: 468
+					X: 560
 					Width: 48
 					Height: 25
 					Text: Spawn
 					Align: Center
 					Font: Bold
 				Label@LABEL_LOBBY_STATUS:
-					X: 525
+					X: 617
 					Width: 20
 					Height: 25
 					Text: Ready
@@ -118,7 +118,7 @@ Container@LOBBY_PLAYER_BIN:
 									Height: PARENT_BOTTOM - 12
 						DropDownButton@FACTION:
 							X: 270
-							Width: 130
+							Width: 140
 							Height: 25
 							IgnoreChildMouseOver: true
 							TooltipContainer: TOOLTIP_CONTAINER
@@ -135,23 +135,23 @@ Container@LOBBY_PLAYER_BIN:
 									Height: 25
 									Text: Faction
 						DropDownButton@TEAM_DROPDOWN:
-							X: 410
+							X: 420
 							Width: 48
 							Height: 25
 							Text: Team
 						DropDownButton@SPAWN_DROPDOWN:
-							X: 468
+							X: 560
 							Width: 48
 							Height: 25
 							Text: Spawn
 						Checkbox@STATUS_CHECKBOX:
-							X: 525
+							X: 617
 							Y: 2
 							Width: 20
 							Height: 20
 							Visible: false
 						Image@STATUS_IMAGE:
-							X: 527
+							X: 619
 							Y: 4
 							Width: 20
 							Height: 20
@@ -225,7 +225,7 @@ Container@LOBBY_PLAYER_BIN:
 							Height: 13
 						Container@FACTION:
 							X: 270
-							Width: 150
+							Width: 160
 							Height: 25
 							Children:
 								Image@FACTIONFLAG:
@@ -239,28 +239,28 @@ Container@LOBBY_PLAYER_BIN:
 									Height: 25
 									Text: Faction
 						Label@TEAM:
-							X: 410
+							X: 420
 							Width: 23
 							Height: 25
 							Text: Team
 							Align: Center
-						Label@SPAWN:
-							X: 468
-							Width: 23
-							Height: 25
-							Align: Center
 						DropDownButton@TEAM_DROPDOWN:
-							X: 410
+							X: 420
 							Width: 48
 							Height: 25
 							Visible: false
+						Label@SPAWN:
+							X: 560
+							Width: 23
+							Height: 25
+							Align: Center
 						DropDownButton@SPAWN_DROPDOWN:
-							X: 468
+							X: 560
 							Width: 48
 							Height: 25
 							Visible: false
 						Image@STATUS_IMAGE:
-							X: 527
+							X: 619
 							Y: 4
 							Width: 20
 							Height: 20
@@ -287,7 +287,7 @@ Container@LOBBY_PLAYER_BIN:
 						Button@JOIN:
 							X: 190
 							Text: Play in this slot
-							Width: 326
+							Width: 418
 							Height: 25
 				Container@TEMPLATE_EDITABLE_SPECTATOR:
 					X: 5
@@ -333,19 +333,19 @@ Container@LOBBY_PLAYER_BIN:
 									Template: ANONYMOUS_PLAYER_TOOLTIP
 						Label@SPECTATOR:
 							X: 190
-							Width: 326
+							Width: 418
 							Height: 25
 							Text: Spectator
 							Align: Center
 							Font: Bold
 						Checkbox@STATUS_CHECKBOX:
-							X: 525
+							X: 617
 							Y: 2
 							Width: 20
 							Height: 20
 							Visible: false
 						Image@STATUS_IMAGE:
-							X: 527
+							X: 619
 							Y: 4
 							Width: 20
 							Height: 20
@@ -414,13 +414,13 @@ Container@LOBBY_PLAYER_BIN:
 									Template: ANONYMOUS_PLAYER_TOOLTIP
 						Label@SPECTATOR:
 							X: 190
-							Width: 326
+							Width: 418
 							Height: 25
 							Text: Spectator
 							Align: Center
 							Font: Bold
 						Image@STATUS_IMAGE:
-							X: 527
+							X: 619
 							Y: 4
 							Width: 20
 							Height: 20
@@ -441,7 +441,7 @@ Container@LOBBY_PLAYER_BIN:
 							Text: Allow Spectators?
 						Button@SPECTATE:
 							X: 190
-							Width: 326
+							Width: 418
 							Height: 25
 							Text: Spectate
 							Font: Regular

--- a/mods/common/chrome/lobby-players.yaml
+++ b/mods/common/chrome/lobby-players.yaml
@@ -35,6 +35,13 @@ Container@LOBBY_PLAYER_BIN:
 					Text: Team
 					Align: Center
 					Font: Bold
+				Label@LABEL_LOBBY_HANDICAP:
+					X: 478
+					Width: 72
+					Height: 25
+					Text: Handicap
+					Align: Center
+					Font: Bold
 				Label@LABEL_LOBBY_SPAWN:
 					X: 560
 					Width: 48
@@ -139,6 +146,12 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 48
 							Height: 25
 							Text: Team
+						DropDownButton@HANDICAP_DROPDOWN:
+							X: 478
+							Width: 72
+							Height: 25
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipText: A handicap decreases the combat effectiveness of the player's forces
 						DropDownButton@SPAWN_DROPDOWN:
 							X: 560
 							Width: 48
@@ -249,6 +262,17 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 48
 							Height: 25
 							Visible: false
+						Label@HANDICAP:
+							X: 478
+							Width: 47
+							Height: 25
+							Align: Center
+						DropDownButton@HANDICAP_DROPDOWN:
+							X: 478
+							Width: 72
+							Height: 25
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipText: A handicap decreases the combat effectiveness of the player's forces
 						Label@SPAWN:
 							X: 560
 							Width: 23

--- a/mods/common/chrome/lobby-servers.yaml
+++ b/mods/common/chrome/lobby-servers.yaml
@@ -9,32 +9,32 @@ Container@LOBBY_SERVERS_BIN:
 			Children:
 				Label@NAME:
 					X: 5
-					Width: 255
+					Width: 347
 					Height: 25
 					Text: Server
 					Align: Center
 					Font: Bold
 				Label@PLAYERS:
-					X: 290
+					X: 382
 					Width: 85
 					Height: 25
 					Text: Players
 					Font: Bold
 				Label@LOCATION:
-					X: 380
+					X: 472
 					Width: 110
 					Height: 25
 					Text: Location
 					Font: Bold
 				Label@STATUS:
-					X: 495
+					X: 587
 					Width: 50
 					Height: 25
 					Text: Status
 					Font: Bold
 		LogicTicker@NOTICE_WATCHER:
 		Background@NOTICE_CONTAINER:
-			Width: 583
+			Width: PARENT_RIGHT
 			Height: 20
 			Background: dialog2
 			Children:
@@ -83,12 +83,12 @@ Container@LOBBY_SERVERS_BIN:
 					Children:
 						LabelWithTooltip@TITLE:
 							X: 5
-							Width: 245
+							Width: 337
 							Height: 25
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 						Image@PASSWORD_PROTECTED:
-							X: 272
+							X: 364
 							Y: 6
 							Width: 12
 							Height: 13
@@ -97,7 +97,7 @@ Container@LOBBY_SERVERS_BIN:
 							TooltipTemplate: SIMPLE_TOOLTIP
 							TooltipText: Requires Password
 						Image@REQUIRES_AUTHENTICATION:
-							X: 272
+							X: 364
 							Y: 6
 							Width: 12
 							Height: 13
@@ -106,17 +106,17 @@ Container@LOBBY_SERVERS_BIN:
 							TooltipTemplate: SIMPLE_TOOLTIP
 							TooltipText: Requires OpenRA forum account
 						LabelWithTooltip@PLAYERS:
-							X: 290
+							X: 382
 							Width: 85
 							Height: 25
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 						Label@LOCATION:
-							X: 380
+							X: 472
 							Width: 110
 							Height: 25
 						Label@STATUS:
-							X: 495
+							X: 587
 							Width: 50
 							Height: 25
 		Label@PROGRESS_LABEL:
@@ -128,12 +128,12 @@ Container@LOBBY_SERVERS_BIN:
 			Visible: false
 		DropDownButton@FILTERS_DROPDOWNBUTTON:
 			Y: PARENT_BOTTOM + 5
-			Width: 147
+			Width: 154
 			Height: 25
 			Text: Filter Games
 			Font: Bold
 		Button@RELOAD_BUTTON:
-			X: 152
+			X: 159
 			Y: PARENT_BOTTOM + 5
 			Width: 26
 			Height: 25

--- a/mods/common/chrome/lobby.yaml
+++ b/mods/common/chrome/lobby.yaml
@@ -2,7 +2,7 @@ Background@SERVER_LOBBY:
 	Logic: LobbyLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
-	Width: 808
+	Width: 900
 	Height: 600
 	Children:
 		ColorPreviewManager@COLOR_MANAGER:
@@ -20,69 +20,71 @@ Background@SERVER_LOBBY:
 		DropDownButton@SLOTS_DROPDOWNBUTTON:
 			X: 20
 			Y: 291
-			Width: 178
+			Width: 185
 			Height: 25
 			Font: Bold
 			Text: Slot Admin
 		Container@SKIRMISH_TABS:
+			X: 695 - WIDTH
+			Width: 486
 			Visible: False
 			Children:
 				Button@PLAYERS_TAB:
-					X: 203
 					Y: 285
-					Width: 134
+					Width: 162
 					Height: 31
 					Font: Bold
 					Text: Players
 				Button@OPTIONS_TAB:
-					X: 337
+					X: 162
 					Y: 285
-					Width: 133
+					Width: 162
 					Height: 31
 					Font: Bold
 					Text: Options
 				Button@MUSIC_TAB:
-					X: 470
+					X: 2*162
 					Y: 285
-					Width: 133
+					Width: 162
 					Height: 31
 					Font: Bold
 					Text: Music
 		Container@MULTIPLAYER_TABS:
+			X: 695 - WIDTH
+			Width: 486
 			Visible: False
 			Children:
 				Button@PLAYERS_TAB:
-					X: 203
 					Y: 285
-					Width: 100
+					Width: 121
 					Height: 31
 					Font: Bold
 					Text: Players
 				Button@OPTIONS_TAB:
-					X: 303
+					X: 121
 					Y: 285
-					Width: 100
+					Width: 122
 					Height: 31
 					Font: Bold
 					Text: Options
 				Button@MUSIC_TAB:
-					X: 403
+					X: 243
 					Y: 285
-					Width: 100
+					Width: 121
 					Height: 31
 					Font: Bold
 					Text: Music
 				Button@SERVERS_TAB:
-					X: 503
+					X: 364
 					Y: 285
-					Width: 100
+					Width: 122
 					Height: 31
 					Font: Bold
 					Text: Servers
 		Container@TOP_PANELS_ROOT:
 			X: 20
 			Y: 67
-			Width: 583
+			Width: 675
 			Height: 219
 		Button@CHANGEMAP_BUTTON:
 			X: PARENT_RIGHT - WIDTH - 20

--- a/mods/common/chrome/multiplayer-browser.yaml
+++ b/mods/common/chrome/multiplayer-browser.yaml
@@ -2,7 +2,7 @@ Background@MULTIPLAYER_PANEL:
 	Logic: MultiplayerLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
-	Width: 808
+	Width: 900
 	Height: 600
 	Children:
 		Label@TITLE:
@@ -20,25 +20,25 @@ Background@MULTIPLAYER_PANEL:
 			Children:
 				Label@NAME:
 					X: 5
-					Width: 255
+					Width: 347
 					Height: 25
 					Text: Server
 					Align: Center
 					Font: Bold
 				Label@PLAYERS:
-					X: 290
+					X: 382
 					Width: 85
 					Height: 25
 					Text: Players
 					Font: Bold
 				Label@LOCATION:
-					X: 380
+					X: 472
 					Width: 110
 					Height: 25
 					Text: Location
 					Font: Bold
 				Label@STATUS:
-					X: 495
+					X: 587
 					Width: 50
 					Height: 25
 					Text: Status
@@ -47,7 +47,7 @@ Background@MULTIPLAYER_PANEL:
 		Background@NOTICE_CONTAINER:
 			X: 20
 			Y: 67
-			Width: 583
+			Width: 675
 			Height: 20
 			Background: dialog2
 			Children:
@@ -75,7 +75,7 @@ Background@MULTIPLAYER_PANEL:
 		ScrollPanel@SERVER_LIST:
 			X: 20
 			Y: 67
-			Width: 583
+			Width: 675
 			Height: PARENT_BOTTOM - 119
 			TopBottomSpacing: 2
 			Children:
@@ -99,12 +99,12 @@ Background@MULTIPLAYER_PANEL:
 					Children:
 						LabelWithTooltip@TITLE:
 							X: 5
-							Width: 245
+							Width: 337
 							Height: 25
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 						Image@PASSWORD_PROTECTED:
-							X: 272
+							X: 364
 							Y: 6
 							Width: 12
 							Height: 13
@@ -113,7 +113,7 @@ Background@MULTIPLAYER_PANEL:
 							TooltipTemplate: SIMPLE_TOOLTIP
 							TooltipText: Requires Password
 						Image@REQUIRES_AUTHENTICATION:
-							X: 272
+							X: 364
 							Y: 6
 							Width: 12
 							Height: 13
@@ -122,23 +122,23 @@ Background@MULTIPLAYER_PANEL:
 							TooltipTemplate: SIMPLE_TOOLTIP
 							TooltipText: Requires OpenRA forum account
 						LabelWithTooltip@PLAYERS:
-							X: 290
+							X: 382
 							Width: 85
 							Height: 25
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 						Label@LOCATION:
-							X: 380
+							X: 472
 							Width: 110
 							Height: 25
 						Label@STATUS:
-							X: 495
+							X: 587
 							Width: 50
 							Height: 25
 		Label@PROGRESS_LABEL:
 			X: 20
 			Y: 67 + (PARENT_BOTTOM - 119 - HEIGHT) / 2
-			Width: 582
+			Width: 675
 			Height: 25
 			Font: Bold
 			Align: Center
@@ -225,21 +225,21 @@ Background@MULTIPLAYER_PANEL:
 					Children:
 						LogicTicker@ANIMATION:
 		Label@PLAYER_COUNT:
-			X: 208
+			X: 254
 			Y: PARENT_BOTTOM - HEIGHT - 20
 			Width: 190
 			Height: 25
 			Align: Center
 			Font: Bold
 		Button@DIRECTCONNECT_BUTTON:
-			X: 398
+			X: 490
 			Y: PARENT_BOTTOM - HEIGHT - 20
 			Width: 100
 			Height: 25
 			Text: Direct IP
 			Font: Bold
 		Button@CREATE_BUTTON:
-			X: 503
+			X: 595
 			Y: PARENT_BOTTOM - HEIGHT - 20
 			Width: 100
 			Height: 25

--- a/mods/d2k/chrome/lobby-players.yaml
+++ b/mods/d2k/chrome/lobby-players.yaml
@@ -23,27 +23,27 @@ Container@LOBBY_PLAYER_BIN:
 					Font: Bold
 				Label@LABEL_LOBBY_FACTION:
 					X: 270
-					Width: 130
+					Width: 140
 					Height: 25
 					Text: Faction
 					Align: Center
 					Font: Bold
 				Label@LABEL_LOBBY_TEAM:
-					X: 410
+					X: 420
 					Width: 48
 					Height: 25
 					Text: Team
 					Align: Center
 					Font: Bold
 				Label@LABEL_LOBBY_SPAWN:
-					X: 468
+					X: 560
 					Width: 48
 					Height: 25
 					Text: Spawn
 					Align: Center
 					Font: Bold
 				Label@LABEL_LOBBY_STATUS:
-					X: 525
+					X: 617
 					Width: 20
 					Height: 25
 					Text: Ready
@@ -118,7 +118,7 @@ Container@LOBBY_PLAYER_BIN:
 									Height: PARENT_BOTTOM - 12
 						DropDownButton@FACTION:
 							X: 270
-							Width: 130
+							Width: 140
 							Height: 25
 							IgnoreChildMouseOver: true
 							TooltipContainer: TOOLTIP_CONTAINER
@@ -135,23 +135,23 @@ Container@LOBBY_PLAYER_BIN:
 									Height: 25
 									Text: Faction
 						DropDownButton@TEAM_DROPDOWN:
-							X: 410
+							X: 420
 							Width: 48
 							Height: 25
 							Text: Team
 						DropDownButton@SPAWN_DROPDOWN:
-							X: 468
+							X: 560
 							Width: 48
 							Height: 25
 							Text: Spawn
 						Checkbox@STATUS_CHECKBOX:
-							X: 525
+							X: 617
 							Y: 2
 							Width: 20
 							Height: 20
 							Visible: false
 						Image@STATUS_IMAGE:
-							X: 527
+							X: 619
 							Y: 4
 							Width: 20
 							Height: 20
@@ -225,7 +225,7 @@ Container@LOBBY_PLAYER_BIN:
 							Height: 13
 						Container@FACTION:
 							X: 270
-							Width: 160
+							Width: 170
 							Height: 25
 							Children:
 								Image@FACTIONFLAG:
@@ -235,32 +235,32 @@ Container@LOBBY_PLAYER_BIN:
 									Height: 23
 								Label@FACTIONNAME:
 									X: 34
-									Width: 60
+									Width: 70
 									Height: 25
 									Text: Faction
 						Label@TEAM:
-							X: 410
+							X: 420
 							Width: 23
 							Height: 25
 							Align: Center
 							Text: Team
-						Label@SPAWN:
-							X: 468
-							Width: 23
-							Height: 25
-							Align: Center
 						DropDownButton@TEAM_DROPDOWN:
-							X: 410
+							X: 420
 							Width: 48
 							Height: 25
 							Visible: false
+						Label@SPAWN:
+							X: 560
+							Width: 23
+							Height: 25
+							Align: Center
 						DropDownButton@SPAWN_DROPDOWN:
-							X: 468
+							X: 560
 							Width: 48
 							Height: 25
 							Visible: false
 						Image@STATUS_IMAGE:
-							X: 527
+							X: 619
 							Y: 4
 							Width: 20
 							Height: 20
@@ -286,7 +286,7 @@ Container@LOBBY_PLAYER_BIN:
 							Visible: false
 						Button@JOIN:
 							X: 190
-							Width: 326
+							Width: 418
 							Height: 25
 							Text: Play in this slot
 				Container@TEMPLATE_EDITABLE_SPECTATOR:
@@ -333,19 +333,19 @@ Container@LOBBY_PLAYER_BIN:
 									Template: ANONYMOUS_PLAYER_TOOLTIP
 						Label@SPECTATOR:
 							X: 190
-							Width: 326
+							Width: 418
 							Height: 25
 							Text: Spectator
 							Align: Center
 							Font: Bold
 						Checkbox@STATUS_CHECKBOX:
-							X: 525
+							X: 617
 							Y: 2
 							Width: 20
 							Height: 20
 							Visible: false
 						Image@STATUS_IMAGE:
-							X: 527
+							X: 619
 							Y: 4
 							Width: 20
 							Height: 20
@@ -414,13 +414,13 @@ Container@LOBBY_PLAYER_BIN:
 									Template: ANONYMOUS_PLAYER_TOOLTIP
 						Label@SPECTATOR:
 							X: 190
-							Width: 326
+							Width: 418
 							Height: 25
 							Text: Spectator
 							Align: Center
 							Font: Bold
 						Image@STATUS_IMAGE:
-							X: 527
+							X: 619
 							Y: 4
 							Width: 20
 							Height: 20
@@ -441,7 +441,7 @@ Container@LOBBY_PLAYER_BIN:
 							Font: Regular
 						Button@SPECTATE:
 							X: 190
-							Width: 326
+							Width: 418
 							Height: 25
 							Text: Spectate
 							Font: Regular

--- a/mods/d2k/chrome/lobby-players.yaml
+++ b/mods/d2k/chrome/lobby-players.yaml
@@ -35,6 +35,13 @@ Container@LOBBY_PLAYER_BIN:
 					Text: Team
 					Align: Center
 					Font: Bold
+				Label@LABEL_LOBBY_HANDICAP:
+					X: 478
+					Width: 72
+					Height: 25
+					Text: Handicap
+					Align: Center
+					Font: Bold
 				Label@LABEL_LOBBY_SPAWN:
 					X: 560
 					Width: 48
@@ -139,6 +146,12 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 48
 							Height: 25
 							Text: Team
+						DropDownButton@HANDICAP_DROPDOWN:
+							X: 478
+							Width: 72
+							Height: 25
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipText: A handicap decreases the combat effectiveness of the player's forces
 						DropDownButton@SPAWN_DROPDOWN:
 							X: 560
 							Width: 48
@@ -249,6 +262,17 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 48
 							Height: 25
 							Visible: false
+						Label@HANDICAP:
+							X: 478
+							Width: 47
+							Height: 25
+							Align: Center
+						DropDownButton@HANDICAP_DROPDOWN:
+							X: 478
+							Width: 72
+							Height: 25
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipText: A handicap decreases the combat effectiveness of the player's forces
 						Label@SPAWN:
 							X: 560
 							Width: 23

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -184,10 +184,16 @@
 		AttackMoveCondition: attack-move
 		AssaultMoveCondition: assault-move
 
+^PlayerHandicaps:
+	HandicapFirepowerMultiplier:
+	HandicapDamageMultiplier:
+	HandicapProductionTimeMultiplier:
+
 ^Vehicle:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
 	Inherits@selection: ^SelectableCombatUnit
+	Inherits@handicaps: ^PlayerHandicaps
 	Tooltip:
 		GenericName: Unit
 	Huntable:
@@ -298,6 +304,7 @@
 	Inherits@2: ^GainsExperience
 	Inherits@3: ^SpriteActor
 	Inherits@selection: ^SelectableCombatUnit
+	Inherits@handicaps: ^PlayerHandicaps
 	Tooltip:
 		GenericName: Unit
 	Huntable:
@@ -366,6 +373,7 @@
 ^Plane:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
+	Inherits@handicaps: ^PlayerHandicaps
 	Interactable:
 	Tooltip:
 		GenericName: Unit
@@ -391,6 +399,7 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
 	Inherits@selection: ^SelectableBuilding
+	Inherits@handicaps: ^PlayerHandicaps
 	Tooltip:
 		GenericName: Structure
 	Huntable:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -221,6 +221,11 @@
 	AttackMove:
 		AssaultMoveCondition: assault-move
 
+^PlayerHandicaps:
+	HandicapFirepowerMultiplier:
+	HandicapDamageMultiplier:
+	HandicapProductionTimeMultiplier:
+
 ^GlobalBounty:
 	GrantConditionOnPrerequisite@GLOBALBOUNTY:
 		Condition: global-bounty
@@ -234,6 +239,7 @@
 	Inherits@3: ^ClassicFacingSpriteActor
 	Inherits@bounty: ^GlobalBounty
 	Inherits@selection: ^SelectableCombatUnit
+	Inherits@handicaps: ^PlayerHandicaps
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -313,6 +319,7 @@
 	Inherits@4: ^SpriteActor
 	Inherits@bounty: ^GlobalBounty
 	Inherits@selection: ^SelectableCombatUnit
+	Inherits@handicaps: ^PlayerHandicaps
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -483,6 +490,7 @@
 	Inherits@4: ^SpriteActor
 	Inherits@bounty: ^GlobalBounty
 	Inherits@selection: ^SelectableCombatUnit
+	Inherits@handicaps: ^PlayerHandicaps
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -532,6 +540,7 @@
 	Inherits@4: ^SpriteActor
 	Inherits@bounty: ^GlobalBounty
 	Inherits@selection: ^SelectableCombatUnit
+	Inherits@handicaps: ^PlayerHandicaps
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -632,6 +641,7 @@
 	Inherits@shape: ^1x1Shape
 	Inherits@bounty: ^GlobalBounty
 	Inherits@selection: ^SelectableBuilding
+	Inherits@handicaps: ^PlayerHandicaps
 	Targetable:
 		TargetTypes: GroundActor, C4, DetonateAttack, Structure
 	Building:
@@ -737,6 +747,7 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
 	Inherits@shape: ^1x1Shape
+	Inherits@handicaps: ^PlayerHandicaps
 	Interactable:
 		Bounds: 24,24
 	OwnerLostAction:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -183,6 +183,11 @@
 	AttackMove:
 		AssaultMoveCondition: assault-move
 
+^PlayerHandicaps:
+	HandicapFirepowerMultiplier:
+	HandicapDamageMultiplier:
+	HandicapProductionTimeMultiplier:
+
 ^2x1Shape:
 	HitShape:
 		Type: Rectangle
@@ -302,6 +307,7 @@
 	Inherits@2: ^SpriteActor
 	Inherits@3: ^Cloakable
 	Inherits@selection: ^SelectableBuilding
+	Inherits@handicaps: ^PlayerHandicaps
 	Huntable:
 	Targetable:
 		TargetTypes: Ground, Building, C4
@@ -538,6 +544,7 @@
 	Inherits@4: ^Cloakable
 	Inherits@CRATESTATS: ^CrateStatModifiers
 	Inherits@selection: ^SelectableCombatUnit
+	Inherits@handicaps: ^PlayerHandicaps
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -754,6 +761,7 @@
 	Inherits@5: ^DamagedByVeins
 	Inherits@CRATESTATS: ^CrateStatModifiers
 	Inherits@selection: ^SelectableCombatUnit
+	Inherits@handicaps: ^PlayerHandicaps
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -860,6 +868,7 @@
 	Inherits@2: ^ExistsInWorld
 	Inherits@3: ^Cloakable
 	Inherits@selection: ^SelectableCombatUnit
+	Inherits@handicaps: ^PlayerHandicaps
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -958,6 +967,7 @@
 	Inherits@2: ^SpriteActor
 	Inherits@3: ^HealsOnTiberium
 	Inherits@selection: ^SelectableCombatUnit
+	Inherits@handicaps: ^PlayerHandicaps
 	Huntable:
 	Health:
 	Armor:
@@ -1108,6 +1118,7 @@
 	Inherits@2: ^ExistsInWorld
 	Inherits@3: ^Cloakable
 	Inherits@selection: ^SelectableCombatUnit
+	Inherits@handicaps: ^PlayerHandicaps
 	Huntable:
 	RenderVoxels:
 	RenderSprites:


### PR DESCRIPTION
This PR implements the handicap feature from C&C3, which sets health (damage) / firepower / build speed modifiers on specific players. Handicaps can be set on bots if the player finds them too challenging, on themself if they aren't challenged enough, and I imagine this will also be used to help balance out casual multiplayer games. This feature removes the need to implement a cheating Brutal AI type.

<img width="709" alt="Screenshot 2020-12-27 at 10 24 17" src="https://user-images.githubusercontent.com/167819/103168755-d3daeb80-482d-11eb-8526-a6f40b5744e1.png">

C&C3 also adjusted support power charge times (using the same factors as build speed), which we could add in a followup PR that implements the required modifier interface.

Supersedes #17937.

The last few comments in #16126 show that this could be a significant improvement for some players, and might be the difference between having fun or giving up on OpenRA completely. This is a reasonably straightfoward PR, so If there are no objections I propose also picking this to prep for the next playtest.