### PR TITLE
Add a setting to pause the shellmap.

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -253,6 +253,8 @@ namespace OpenRA
 		public int IntroductionPromptVersion = 0;
 
 		public MPGameFilters MPGameFilters = MPGameFilters.Waiting | MPGameFilters.Empty | MPGameFilters.Protected | MPGameFilters.Started;
+
+		public bool PauseShellmap = false;
 	}
 
 	public class Settings

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -32,6 +32,7 @@ namespace OpenRA
 		readonly List<IEffect> effects = new List<IEffect>();
 		readonly List<IEffect> unpartitionedEffects = new List<IEffect>();
 		readonly List<ISync> syncedEffects = new List<ISync>();
+		readonly GameSettings gameSettings;
 
 		readonly Queue<Action<World>> frameEndActions = new Queue<Action<World>>();
 
@@ -226,6 +227,7 @@ namespace OpenRA
 			};
 
 			RulesContainTemporaryBlocker = map.Rules.Actors.Any(a => a.Value.HasTraitInfo<ITemporaryBlockerInfo>());
+			gameSettings = Game.Settings.Game;
 		}
 
 		public void AddToMaps(Actor self, IOccupySpace ios)
@@ -424,7 +426,9 @@ namespace OpenRA
 				wasLoadingGameSave = false;
 			}
 
-			if (!Paused)
+			// Allow users to pause the shellmap via the settings menu
+			// Some traits initialize important state during the first tick, so we must allow it to tick at least once
+			if (!Paused && (Type != WorldType.Shellmap || !gameSettings.PauseShellmap || WorldTick == 0))
 			{
 				WorldTick++;
 

--- a/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
@@ -21,12 +21,14 @@ namespace OpenRA.Mods.Common.Scripting
 	{
 		readonly SpawnMapActors sma;
 		readonly World world;
+		readonly GameSettings gameSettings;
 
 		public MapGlobal(ScriptContext context)
 			: base(context)
 		{
 			sma = context.World.WorldActor.Trait<SpawnMapActors>();
 			world = context.World;
+			gameSettings = Game.Settings.Game;
 
 			// Register map actors as globals (yuck!)
 			foreach (var kv in sma.Actors)
@@ -108,6 +110,9 @@ namespace OpenRA.Mods.Common.Scripting
 
 		[Desc("Returns true if there is only one human player.")]
 		public bool IsSinglePlayer { get { return Context.World.LobbyInfo.NonBotPlayers.Count() == 1; } }
+
+		[Desc("Returns true if this is a shellmap and the player has paused animations.")]
+		public bool IsPausedShellmap { get { return Context.World.Type == WorldType.Shellmap && gameSettings.PauseShellmap; } }
 
 		[Desc("Returns the value of a `ScriptLobbyDropdown` selected in the game lobby.")]
 		public LuaValue LobbyOption(string id)

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -246,6 +246,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			BindCheckboxPref(panel, "FRAME_LIMIT_CHECKBOX", ds, "CapFramerate");
 			BindIntSliderPref(panel, "FRAME_LIMIT_SLIDER", ds, "MaxFramerate");
 			BindCheckboxPref(panel, "PLAYER_STANCE_COLORS_CHECKBOX", gs, "UsePlayerStanceColors");
+			if (panel.GetOrNull<CheckboxWidget>("PAUSE_SHELLMAP_CHECKBOX") != null)
+				BindCheckboxPref(panel, "PAUSE_SHELLMAP_CHECKBOX", gs, "PauseShellmap");
 
 			var windowModeDropdown = panel.Get<DropDownButtonWidget>("MODE_DROPDOWN");
 			windowModeDropdown.OnMouseDown = _ => ShowWindowModeDropdown(windowModeDropdown, ds);

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -188,12 +188,19 @@ Background@SETTINGS_PANEL:
 					Font: Regular
 					Text: Increase Cursor Size
 				Checkbox@PLAYER_STANCE_COLORS_CHECKBOX:
-					X: 310
+					X: 195
 					Y: 133
 					Width: 200
 					Height: 20
 					Font: Regular
 					Text: Player Stance Colors
+				Checkbox@PAUSE_SHELLMAP_CHECKBOX:
+					X: 375
+					Y: 133
+					Width: 200
+					Height: 20
+					Font: Regular
+					Text: Pause Menu Background
 				Label@VIDEO_TITLE:
 					Y: 190
 					Width: PARENT_RIGHT

--- a/mods/d2k/maps/shellmap/d2k-shellmap.lua
+++ b/mods/d2k/maps/shellmap/d2k-shellmap.lua
@@ -147,8 +147,10 @@ speed = 5
 Tick = function()
 	ticks = ticks + 1
 
-	local t = (ticks + 45) % (360 * speed) * (math.pi / 180) / speed;
-	Camera.Position = viewportOrigin + WVec.New(19200 * math.sin(t), 28800 * math.cos(t), 0)
+	if ticks > 1 or not Map.IsPausedShellmap then
+		local t = (ticks + 45) % (360 * speed) * (math.pi / 180) / speed;
+		Camera.Position = viewportOrigin + WVec.New(19200 * math.sin(t), 28800 * math.cos(t), 0)
+	end
 end
 
 WorldLoaded = function()


### PR DESCRIPTION
We've had a trickle of comments/requests/complaints about having the ability to disable the shellmap animation ever since we removed the option to disable it completely a few years ago. Each time we have a new release, and people comment asking for this, i've meant to do something but then inevitably forget.

This PR implements a solution to disable the motion that makes some people feel ill. Considering the benefit and how simple this is, I would like to scope creep this into the next playtest if there are no objections. I realize i'm jumping the queue and stealing the UI spot that I suggested @dragunoff use in #18905, but we can solve that there by increasing the settings panel height to create a new row with 2x2 checkboxes instead of 1x3. Note that I have intentionally left this out of TD where it is not relevant.