### PR TITLE
Fix TD Building SoundOnDamageTransition DamagedSound and add variety to Building DestroyedSounds

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -668,8 +668,8 @@
 	ActorPreviewPlaceBuildingPreview:
 		OverridePalette: placebuilding
 	SoundOnDamageTransition:
-		DamagedSounds: xplos.aud
-		DestroyedSounds: crumble.aud
+		DamagedSounds: xplobig4.aud
+		DestroyedSounds: crumble.aud, xplobig4.aud
 	WithSpriteBody:
 	Explodes:
 		Type: Footprint


### PR DESCRIPTION
This PR fixes `^Building` `SoundOnDamageTransition` `DamagedSounds` with the correct one and adds a second audio file to `DestroyedSounds` for more variation (extra oomph) like in the original Tiberian Dawn.