### PR TITLE
Allow notification volume settings

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -193,6 +193,7 @@ namespace OpenRA
 		public float SoundVolume = 0.5f;
 		public float MusicVolume = 0.5f;
 		public float VideoVolume = 0.5f;
+		public float NotificationVolume = 0.5f;
 
 		public bool Shuffle = false;
 		public bool Repeat = false;

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -336,6 +336,21 @@ namespace OpenRA
 			}
 		}
 
+		public float NotificationVolume
+		{
+			get
+			{
+				return Game.Settings.Sound.NotificationVolume;
+			}
+
+			set
+			{
+				Game.Settings.Sound.NotificationVolume = value;
+				if (video != null)
+					video.Volume = value;
+			}
+		}
+
 		public float MusicSeekPosition
 		{
 			get { return music != null ? music.SeekPosition : 0; }
@@ -422,8 +437,9 @@ namespace OpenRA
 
 			if (type == null || notification == null)
 				return false;
+			var volume = Game.Settings.Sound.NotificationVolume;
 
-			return PlayPredefined(SoundType.UI, rules, player, null, type.ToLowerInvariant(), notification, variant, true, WPos.Zero, 1f, false);
+			return PlayPredefined(SoundType.UI, rules, player, null, type.ToLowerInvariant(), notification, variant, true, WPos.Zero, volume, false);
 		}
 
 		public void Dispose()

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -419,6 +419,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			BindSliderPref(panel, "SOUND_VOLUME", ss, "SoundVolume");
 			BindSliderPref(panel, "MUSIC_VOLUME", ss, "MusicVolume");
 			BindSliderPref(panel, "VIDEO_VOLUME", ss, "VideoVolume");
+			BindSliderPref(panel, "NOTIFICATION_VOLUME", ss, "NotificationVolume");
 
 			var muteCheckbox = panel.Get<CheckboxWidget>("MUTE_SOUND");
 			var muteCheckboxOnClick = muteCheckbox.OnClick;
@@ -466,6 +467,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var videoVolumeSlider = panel.Get<SliderWidget>("VIDEO_VOLUME");
 			videoVolumeSlider.OnChange += x => Game.Sound.VideoVolume = x;
 
+			var notificationVolumeSlider = panel.Get<SliderWidget>("NOTIFICATION_VOLUME");
+			videoVolumeSlider.OnChange += x => Game.Sound.VideoVolume = x;
+
 			var devices = Game.Sound.AvailableDevices();
 			soundDevice = devices.FirstOrDefault(d => d.Device == ss.Device) ?? devices.First();
 
@@ -492,6 +496,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ss.SoundVolume = dss.SoundVolume;
 				ss.MusicVolume = dss.MusicVolume;
 				ss.VideoVolume = dss.VideoVolume;
+				ss.NotificationVolume = dss.NotificationVolume;
+
 				ss.CashTicks = dss.CashTicks;
 				ss.Mute = dss.Mute;
 				ss.MuteBackgroundMusic = dss.MuteBackgroundMusic;
@@ -503,6 +509,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Game.Sound.MusicVolume = ss.MusicVolume;
 				panel.Get<SliderWidget>("VIDEO_VOLUME").Value = ss.VideoVolume;
 				Game.Sound.VideoVolume = ss.VideoVolume;
+				panel.Get<SliderWidget>("NOTIFICATION_VOLUME").Value = ss.NotificationVolume;
+				Game.Sound.NotificationVolume = ss.NotificationVolume;
 				Game.Sound.UnmuteAudio();
 				soundDevice = Game.Sound.AvailableDevices().First();
 			};

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -363,6 +363,18 @@ Container@SETTINGS_PANEL:
 									Y: 105
 									Width: 250
 									Height: 20
+								Label@NOTIFICATION_LABEL:
+									X: PARENT_RIGHT - WIDTH - 270
+									Y: 130
+									Width: 95
+									Height: 25
+									Align: Right
+									Text: Notification Volume:
+								ExponentialSlider@NOTIFICATION_VOLUME:
+									X: PARENT_RIGHT - WIDTH - 15
+									Y: 135
+									Width: 250
+									Height: 20
 									Ticks: 7
 						Label@AUDIO_DEVICE_LABEL:
 							X: 190 - WIDTH - 5


### PR DESCRIPTION
Relating to suggestion #18862, this implements a separate volume bar for the announcer.


Changes:
- Separate volume control for notifications