### PR TITLE
Add multi-sheet/palette rendering to TerrainSpriteLayer

### DIFF
--- a/OpenRA.Mods.Common/Terrain/DefaultTerrain.cs
+++ b/OpenRA.Mods.Common/Terrain/DefaultTerrain.cs
@@ -37,6 +37,7 @@ namespace OpenRA.Mods.Common.Terrain
 	public class DefaultTerrainTemplateInfo : TerrainTemplateInfo
 	{
 		public readonly string[] Images;
+		public readonly string[] DepthImages;
 		public readonly int[] Frames;
 		public readonly string Palette;
 

--- a/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -63,14 +64,12 @@ namespace OpenRA.Mods.Common.Traits
 				if (spriteLayer == null)
 				{
 					var first = r.Value.Variants.First().Value.GetSprite(0);
-					spriteLayer = new TerrainSpriteLayer(w, wr, first.Sheet, first.BlendMode, wr.World.Type != WorldType.Editor);
+					var emptySprite = new Sprite(first.Sheet, Rectangle.Empty, TextureChannel.Alpha);
+					spriteLayer = new TerrainSpriteLayer(w, wr, emptySprite, first.BlendMode, wr.World.Type != WorldType.Editor);
 				}
 
 				// All resources must share a sheet and blend mode
 				var sprites = r.Value.Variants.Values.SelectMany(v => Exts.MakeArray(v.Length, x => v.GetSprite(x)));
-				if (sprites.Any(s => s.Sheet != spriteLayer.Sheet))
-					throw new InvalidDataException("Resource sprites span multiple sheets. Try loading their sequences earlier.");
-
 				if (sprites.Any(s => s.BlendMode != spriteLayer.BlendMode))
 					throw new InvalidDataException("Resource sprites specify different blend modes. "
 						+ "Try using different ResourceRenderer traits for resource types that use different blend modes.");

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -190,26 +191,19 @@ namespace OpenRA.Mods.Common.Traits
 
 			visibleUnderFog = puv => map.Contains(puv);
 
-			var shroudSheet = shroudSprites[0].Sheet;
-			if (shroudSprites.Any(s => s.Sheet != shroudSheet))
-				throw new InvalidDataException("Shroud sprites span multiple sheets. Try loading their sequences earlier.");
-
 			var shroudBlend = shroudSprites[0].BlendMode;
 			if (shroudSprites.Any(s => s.BlendMode != shroudBlend))
 				throw new InvalidDataException("Shroud sprites must all use the same blend mode.");
-
-			var fogSheet = fogSprites[0].Sheet;
-			if (fogSprites.Any(s => s.Sheet != fogSheet))
-				throw new InvalidDataException("Fog sprites span multiple sheets. Try loading their sequences earlier.");
 
 			var fogBlend = fogSprites[0].BlendMode;
 			if (fogSprites.Any(s => s.BlendMode != fogBlend))
 				throw new InvalidDataException("Fog sprites must all use the same blend mode.");
 
+			var emptySprite = new Sprite(shroudSprites[0].Sheet, Rectangle.Empty, TextureChannel.Alpha);
 			shroudPaletteReference = wr.Palette(info.ShroudPalette);
 			fogPaletteReference = wr.Palette(info.FogPalette);
-			shroudLayer = new TerrainSpriteLayer(w, wr, shroudSheet, shroudBlend, false);
-			fogLayer = new TerrainSpriteLayer(w, wr, fogSheet, fogBlend, false);
+			shroudLayer = new TerrainSpriteLayer(w, wr, emptySprite, shroudBlend, false);
+			fogLayer = new TerrainSpriteLayer(w, wr, emptySprite, fogBlend, false);
 
 			WorldOnRenderPlayerChanged(world.RenderPlayer);
 		}

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -106,6 +106,7 @@ namespace OpenRA.Mods.Common.Traits
 		Shroud shroud;
 		Func<PPos, bool> visibleUnderShroud, visibleUnderFog;
 		TerrainSpriteLayer shroudLayer, fogLayer;
+		PaletteReference shroudPaletteReference, fogPaletteReference;
 		bool disposed;
 
 		public ShroudRenderer(World world, ShroudRendererInfo info)
@@ -205,8 +206,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (fogSprites.Any(s => s.BlendMode != fogBlend))
 				throw new InvalidDataException("Fog sprites must all use the same blend mode.");
 
-			shroudLayer = new TerrainSpriteLayer(w, wr, shroudSheet, shroudBlend, wr.Palette(info.ShroudPalette), false);
-			fogLayer = new TerrainSpriteLayer(w, wr, fogSheet, fogBlend, wr.Palette(info.FogPalette), false);
+			shroudPaletteReference = wr.Palette(info.ShroudPalette);
+			fogPaletteReference = wr.Palette(info.FogPalette);
+			shroudLayer = new TerrainSpriteLayer(w, wr, shroudSheet, shroudBlend, false);
+			fogLayer = new TerrainSpriteLayer(w, wr, fogSheet, fogBlend, false);
 
 			WorldOnRenderPlayerChanged(world.RenderPlayer);
 		}
@@ -297,8 +300,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (fogSprite != null)
 					fogPos += fogSprite.Offset - 0.5f * fogSprite.Size;
 
-				shroudLayer.Update(uv, shroudSprite, shroudPos, true);
-				fogLayer.Update(uv, fogSprite, fogPos, true);
+				shroudLayer.Update(uv, shroudSprite, shroudPaletteReference, shroudPos, true);
+				fogLayer.Update(uv, fogSprite, fogPaletteReference, fogPos, true);
 			}
 
 			anyCellDirty = false;

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Effects;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -114,16 +115,14 @@ namespace OpenRA.Mods.Common.Traits
 			var sprites = smudges.Values.SelectMany(v => Exts.MakeArray(v.Length, x => v.GetSprite(x))).ToList();
 			var sheet = sprites[0].Sheet;
 			var blendMode = sprites[0].BlendMode;
-
-			if (sprites.Any(s => s.Sheet != sheet))
-				throw new InvalidDataException("Resource sprites span multiple sheets. Try loading their sequences earlier.");
+			var emptySprite = new Sprite(sheet, Rectangle.Empty, TextureChannel.Alpha);
 
 			if (sprites.Any(s => s.BlendMode != blendMode))
 				throw new InvalidDataException("Smudges specify different blend modes. "
 					+ "Try using different smudge types for smudges that use different blend modes.");
 
 			paletteReference = wr.Palette(Info.Palette);
-			render = new TerrainSpriteLayer(w, wr, sheet, blendMode, w.Type != WorldType.Editor);
+			render = new TerrainSpriteLayer(w, wr, emptySprite, blendMode, w.Type != WorldType.Editor);
 
 			// Add map smudges
 			foreach (var kv in Info.InitialSmudges)

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -94,6 +94,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly bool hasSmoke;
 
 		TerrainSpriteLayer render;
+		PaletteReference paletteReference;
 		bool disposed;
 
 		public SmudgeLayer(Actor self, SmudgeLayerInfo info)
@@ -121,7 +122,8 @@ namespace OpenRA.Mods.Common.Traits
 				throw new InvalidDataException("Smudges specify different blend modes. "
 					+ "Try using different smudge types for smudges that use different blend modes.");
 
-			render = new TerrainSpriteLayer(w, wr, sheet, blendMode, wr.Palette(Info.Palette), w.Type != WorldType.Editor);
+			paletteReference = wr.Palette(Info.Palette);
+			render = new TerrainSpriteLayer(w, wr, sheet, blendMode, w.Type != WorldType.Editor);
 
 			// Add map smudges
 			foreach (var kv in Info.InitialSmudges)
@@ -139,7 +141,7 @@ namespace OpenRA.Mods.Common.Traits
 				};
 
 				tiles.Add(kv.Key, smudge);
-				render.Update(kv.Key, seq, s.Depth);
+				render.Update(kv.Key, seq, paletteReference, s.Depth);
 			}
 		}
 
@@ -201,7 +203,7 @@ namespace OpenRA.Mods.Common.Traits
 					{
 						var smudge = kv.Value;
 						tiles[kv.Key] = smudge;
-						render.Update(kv.Key, smudge.Sequence, smudge.Depth);
+						render.Update(kv.Key, smudge.Sequence, paletteReference, smudge.Depth);
 					}
 
 					remove.Add(kv.Key);

--- a/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
@@ -80,7 +80,9 @@ namespace OpenRA.Mods.Common.Traits
 		void IWorldLoaded.WorldLoaded(World world, WorldRenderer wr)
 		{
 			worldRenderer = wr;
-			spriteLayer = new TerrainSpriteLayer(world, wr, tileCache.Sheet, BlendMode.Alpha, world.Type != WorldType.Editor);
+			var emptySprite = new Sprite(tileCache.Sheet, Rectangle.Empty, TextureChannel.Alpha);
+			spriteLayer = new TerrainSpriteLayer(world, wr, emptySprite, BlendMode.Alpha, world.Type != WorldType.Editor);
+
 			foreach (var cell in map.AllCells)
 				UpdateCell(cell);
 

--- a/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
@@ -80,9 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 		void IWorldLoaded.WorldLoaded(World world, WorldRenderer wr)
 		{
 			worldRenderer = wr;
-			var emptySprite = new Sprite(tileCache.Sheet, Rectangle.Empty, TextureChannel.Alpha);
-			spriteLayer = new TerrainSpriteLayer(world, wr, emptySprite, BlendMode.Alpha, world.Type != WorldType.Editor);
-
+			spriteLayer = new TerrainSpriteLayer(world, wr, tileCache.MissingTile, BlendMode.Alpha, world.Type != WorldType.Editor);
 			foreach (var cell in map.AllCells)
 				UpdateCell(cell);
 
@@ -124,7 +122,7 @@ namespace OpenRA.Mods.Common.Traits
 			disposed = true;
 		}
 
-		Sheet ITiledTerrainRenderer.Sheet { get { return tileCache.Sheet; } }
+		Sprite ITiledTerrainRenderer.MissingTile { get { return tileCache.MissingTile; } }
 
 		Sprite ITiledTerrainRenderer.TileSprite(TerrainTile r, int? variant)
 		{

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -654,7 +654,7 @@ namespace OpenRA.Mods.Common.Traits
 	[RequireExplicitImplementation]
 	public interface ITiledTerrainRenderer
 	{
-		Sheet Sheet { get; }
+		Sprite MissingTile { get; }
 		Sprite TileSprite(TerrainTile r, int? variant = null);
 		Rectangle TemplateBounds(TerrainTemplateInfo template);
 		IEnumerable<IRenderable> RenderUIPreview(WorldRenderer wr, TerrainTemplateInfo template, int2 origin, float scale);

--- a/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits
@@ -51,7 +52,8 @@ namespace OpenRA.Mods.D2k.Traits
 
 		void IWorldLoaded.WorldLoaded(World w, WorldRenderer wr)
 		{
-			render = new TerrainSpriteLayer(w, wr, terrainRenderer.Sheet, BlendMode.Alpha, wr.World.Type != WorldType.Editor);
+			var emptySprite = new Sprite(terrainRenderer.Sheet, Rectangle.Empty, TextureChannel.Alpha);
+			render = new TerrainSpriteLayer(w, wr, emptySprite, BlendMode.Alpha, wr.World.Type != WorldType.Editor);
 			paletteReference = wr.Palette(info.Palette);
 		}
 

--- a/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
@@ -13,7 +13,6 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits
@@ -52,8 +51,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 		void IWorldLoaded.WorldLoaded(World w, WorldRenderer wr)
 		{
-			var emptySprite = new Sprite(terrainRenderer.Sheet, Rectangle.Empty, TextureChannel.Alpha);
-			render = new TerrainSpriteLayer(w, wr, emptySprite, BlendMode.Alpha, wr.World.Type != WorldType.Editor);
+			render = new TerrainSpriteLayer(w, wr, terrainRenderer.MissingTile, BlendMode.Alpha, wr.World.Type != WorldType.Editor);
 			paletteReference = wr.Palette(info.Palette);
 		}
 

--- a/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
@@ -38,6 +38,7 @@ namespace OpenRA.Mods.D2k.Traits
 		readonly CellLayer<int> strength;
 
 		TerrainSpriteLayer render;
+		PaletteReference paletteReference;
 		bool disposed;
 
 		public BuildableTerrainLayer(Actor self, BuildableTerrainLayerInfo info)
@@ -48,9 +49,10 @@ namespace OpenRA.Mods.D2k.Traits
 			terrainRenderer = self.Trait<ITiledTerrainRenderer>();
 		}
 
-		public void WorldLoaded(World w, WorldRenderer wr)
+		void IWorldLoaded.WorldLoaded(World w, WorldRenderer wr)
 		{
-			render = new TerrainSpriteLayer(w, wr, terrainRenderer.Sheet, BlendMode.Alpha, wr.Palette(info.Palette), wr.World.Type != WorldType.Editor);
+			render = new TerrainSpriteLayer(w, wr, terrainRenderer.Sheet, BlendMode.Alpha, wr.World.Type != WorldType.Editor);
+			paletteReference = wr.Palette(info.Palette);
 		}
 
 		public void AddTile(CPos cell, TerrainTile tile)
@@ -100,7 +102,7 @@ namespace OpenRA.Mods.D2k.Traits
 						// Terrain tiles define their origin at the topleft
 						var s = terrainRenderer.TileSprite(tile.Value);
 						var ss = new Sprite(s.Sheet, s.Bounds, s.ZRamp, float2.Zero, s.Channel, s.BlendMode);
-						render.Update(kv.Key, ss, false);
+						render.Update(kv.Key, ss, paletteReference, false);
 					}
 					else
 						render.Clear(kv.Key);


### PR DESCRIPTION
This PR extends #15194 to cover TerrainSpriteLayer, which removes several annoying restrictions.

* Fixes the unclear "sprites span multiple sheets" exceptions that force modders to reorganize their sequence definitions
* Removes the batch overhead from mixing palettes in tilesets
* Allows mods to mix indexed and 32bit artwork in the same tileset
* Fixes #18333

~Depends on #18728.~

Also needed for further optimizations when using the remaster assets.

Testcases:
* TD: replaces temperate clear tiles with desert (shows that palettes can be mixed without increasing the batch count)
* RA: splits the resource definitions onto different sheets (shows that this no longer crashes)
* TS: replaces temperate clear tiles with RGBA + 8bit depth snow tiles (shows that #18333 is solved)