### PR TITLE
Game no longer crashes when TextFieldWidget sends Enter key press and onSelect action is null.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -43,7 +43,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.modData = modData;
 			this.onSelect = onSelect;
 
-			var approving = new Action(() => { Ui.CloseWindow(); onSelect(selectedUid); });
+			var approving = new Action(() =>
+			{
+				Ui.CloseWindow();
+				onSelect?.Invoke(selectedUid);
+			});
+
 			var canceling = new Action(() => { Ui.CloseWindow(); onExit(); });
 
 			var okButton = widget.Get<ButtonWidget>("BUTTON_OK");


### PR DESCRIPTION
Closes #18936.

I wasn't entirely sure if this was the proper fix due to maybe onSelect should not be null in this scenario for whatever reason, mostly due to my ignorance of the code base, but I did see below that there was a null check on it to check if the OK button should be disabled or not, so it was at least a safe bet that onSelect being null is a valid scenario. After adding the null check and testing, the game no longer crashes for the given scenario.