### PR TITLE
Fix exit priority ordering.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 			// This is important because p may have side-effects that trigger a desync if not
 			// called on the same exits in the same order!
 			var all = Exits(actor, productionType)
-				.OrderBy(e => e.Info.Priority)
+				.OrderByDescending(e => e.Info.Priority)
 				.ThenBy(e => (actor.World.Map.CenterOfCell(actor.Location + e.Info.ExitCell) - pos).LengthSquared)
 				.ToList();
 


### PR DESCRIPTION
Fixes #18919. Larger numbers = higher priority!

Testcase: Build a kennel in RA or a GDI barracks in TS, and place a rallypoint behind the structure. Notice that units now correctly only use the fallback exits if the primary exit is blocked.