### PR TITLE
Update VS Code launch configuration to match .NET 5 migration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
 				"type": "mono"
 			},
 			"request": "launch",
-			"program": "${workspaceRoot}/bin/OpenRA.exe",
+			"program": "${workspaceRoot}/bin/OpenRA.dll",
 			"args": ["Game.Mod=cnc", "Engine.EngineDir=.."],
 			"preLaunchTask": "build",
 		},
@@ -25,7 +25,7 @@
 				"type": "mono"
 			},
 			"request": "launch",
-			"program": "${workspaceRoot}/bin/OpenRA.exe",
+			"program": "${workspaceRoot}/bin/OpenRA.dll",
 			"args": ["Game.Mod=ra", "Engine.EngineDir=.."],
 			"preLaunchTask": "build",
 		},
@@ -39,7 +39,7 @@
 				"type": "mono"
 			},
 			"request": "launch",
-			"program": "${workspaceRoot}/bin/OpenRA.exe",
+			"program": "${workspaceRoot}/bin/OpenRA.dll",
 			"args": ["Game.Mod=d2k", "Engine.EngineDir=.."],
 			"preLaunchTask": "build",
 		},
@@ -53,7 +53,7 @@
 				"type": "mono"
 			},
 			"request": "launch",
-			"program": "${workspaceRoot}/bin/OpenRA.exe",
+			"program": "${workspaceRoot}/bin/OpenRA.dll",
 			"args": ["Game.Mod=ts", "Engine.EngineDir=.."],
 			"preLaunchTask": "build",
 		},


### PR DESCRIPTION
5e74e58b2204b223ab100cba09a151eeac888910 has us producing and running `OpenRA.dll` instead of `OpenRA.exe`, so update the VSCode launch config (without these changes, launching will fail with a file-not-found error).