### PR TITLE
Allow selective muting of 'Unit Ready'

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -202,6 +202,7 @@ namespace OpenRA
 		public bool CashTicks = true;
 		public bool Mute = false;
 		public bool MuteBackgroundMusic = false;
+		public bool MuteUnitReady = false;
 	}
 
 	public class PlayerSettings

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -423,7 +423,10 @@ namespace OpenRA.Mods.Common.Traits
 							else if (!isBuilding)
 							{
 								if (BuildUnit(unit))
-									Game.Sound.PlayNotification(rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
+								{
+									if (!Game.Settings.Sound.MuteUnitReady)
+										Game.Sound.PlayNotification(rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
+								}
 								else if (!hasPlayedSound && time > 0)
 									hasPlayedSound = Game.Sound.PlayNotification(rules, self.Owner, "Speech", Info.BlockedAudio, self.Owner.Faction.InternalName);
 							}

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -415,6 +415,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			BindCheckboxPref(panel, "CASH_TICKS", ss, "CashTicks");
 			BindCheckboxPref(panel, "MUTE_SOUND", ss, "Mute");
 			BindCheckboxPref(panel, "MUTE_BACKGROUND_MUSIC", ss, "MuteBackgroundMusic");
+			BindCheckboxPref(panel, "MUTE_UNIT_READY", ss, "MuteUnitReady");
 
 			BindSliderPref(panel, "SOUND_VOLUME", ss, "SoundVolume");
 			BindSliderPref(panel, "MUSIC_VOLUME", ss, "MusicVolume");
@@ -446,6 +447,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				if (musicPlaylist.CurrentSongIsBackground)
 					musicPlaylist.Stop();
+			};
+
+			var muteUnitReadyCheckBox = panel.Get<CheckboxWidget>("MUTE_UNIT_READY");
+			var muteUnitReadyCheckBoxOnClick = muteUnitReadyCheckBox.OnClick;
+			muteUnitReadyCheckBox.OnClick = () =>
+			{
+				muteUnitReadyCheckBoxOnClick();
 			};
 
 			// Replace controls with a warning label if sound is disabled

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -325,6 +325,13 @@ Container@SETTINGS_PANEL:
 									Height: 20
 									Font: Regular
 									Text: Mute Background Music
+								Checkbox@MUTE_UNIT_READY:
+									X: 15
+									Y: 133
+									Width: 200
+									Height: 20
+									Font: Regular
+									Text: Mute 'Unit Ready'                                    
 								Label@SOUND_LABEL:
 									X: PARENT_RIGHT - WIDTH - 270
 									Y: 40


### PR DESCRIPTION
Relating to the discussion of suggestion #18862, this allows selective muting of 'Unit Ready' notifications.
 
Changes:

- Separate muting of 'Unit Ready' notifications
