### PR TITLE
Remove first-client check from LobbySettingsNotification.

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
@@ -22,9 +22,6 @@ namespace OpenRA.Mods.Common.Server
 		{
 			lock (server.LobbyInfo)
 			{
-				if (server.LobbyInfo.ClientWithIndex(conn.PlayerIndex).IsAdmin)
-					return;
-
 				var defaults = new Session.Global();
 				LobbyCommands.LoadMapSettings(server, defaults, server.Map.Rules);
 


### PR DESCRIPTION
Fixes #18978.

Testcase:
* Start a dedicated server and launch two game clients
* Join server with client A and change some settings (e.g. explored map, crates).
* Disconnect with client A
* Join with client B
* Join with client A

The existing logic means that (assuming the server doesn't crash) client B is not notified about the modified settings, which doesn't seem right. Removing this check avoids the crash and means that all players are notified.