### PR TITLE
Remove shadow palette from projectiles and WithShadow

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -50,9 +50,8 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Does this projectile have a shadow?")]
 		public readonly bool Shadow = false;
 
-		[PaletteReference]
-		[Desc("Palette to use for this projectile's shadow if Shadow is true.")]
-		public readonly string ShadowPalette = "shadow";
+		[Desc("Color to draw shadow if Shadow is true.")]
+		public readonly Color ShadowColor = Color.FromArgb(140, 0, 0, 0);
 
 		[Desc("Trail animation.")]
 		public readonly string TrailImage = null;
@@ -122,6 +121,9 @@ namespace OpenRA.Mods.Common.Projectiles
 		readonly WDist speed;
 		readonly string trailPalette;
 
+		readonly float3 shadowColor;
+		readonly float shadowAlpha;
+
 		ContrailRenderable contrail;
 
 		[Sync]
@@ -181,6 +183,9 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			smokeTicks = info.TrailDelay;
 			remainingBounces = info.BounceCount;
+
+			shadowColor = new float3(info.ShadowColor.R, info.ShadowColor.G, info.ShadowColor.B) / 255f;
+			shadowAlpha = info.ShadowColor.A;
 		}
 
 		WAngle GetEffectiveFacing()
@@ -286,8 +291,10 @@ namespace OpenRA.Mods.Common.Projectiles
 				{
 					var dat = world.Map.DistanceAboveTerrain(pos);
 					var shadowPos = pos - new WVec(0, 0, dat.Length);
-					foreach (var r in anim.Render(shadowPos, wr.Palette(info.ShadowPalette)))
-						yield return r;
+					foreach (var r in anim.Render(shadowPos, wr.Palette(info.Palette)))
+						yield return ((IModifyableRenderable)r)
+							.WithTint(shadowColor, ((IModifyableRenderable)r).TintModifiers | TintModifiers.ReplaceColor)
+							.WithAlpha(shadowAlpha);
 				}
 
 				var palette = wr.Palette(info.Palette + (info.IsPlayerPalette ? args.SourceActor.Owner.InternalName : ""));

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -37,8 +37,11 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;
 
-		[Desc("Should the projectile's shadow be rendered?")]
+		[Desc("Does this projectile have a shadow?")]
 		public readonly bool Shadow = false;
+
+		[Desc("Color to draw shadow if Shadow is true.")]
+		public readonly Color ShadowColor = Color.FromArgb(140, 0, 0, 0);
 
 		[Desc("Minimum vertical launch angle (pitch).")]
 		public readonly WAngle MinimumLaunchAngle = new WAngle(-64);
@@ -180,6 +183,9 @@ namespace OpenRA.Mods.Common.Projectiles
 		readonly WAngle minLaunchAngle;
 		readonly WAngle maxLaunchAngle;
 
+		readonly float3 shadowColor;
+		readonly float shadowAlpha;
+
 		int ticks;
 
 		int ticksToNextSmoke;
@@ -264,6 +270,9 @@ namespace OpenRA.Mods.Common.Projectiles
 			trailPalette = info.TrailPalette;
 			if (info.TrailUsePlayerPalette)
 				trailPalette += args.SourceActor.Owner.InternalName;
+
+			shadowColor = new float3(info.ShadowColor.R, info.ShadowColor.G, info.ShadowColor.B) / 255f;
+			shadowAlpha = info.ShadowColor.A;
 		}
 
 		static int LoopRadius(int speed, int rot)
@@ -916,8 +925,10 @@ namespace OpenRA.Mods.Common.Projectiles
 				{
 					var dat = world.Map.DistanceAboveTerrain(pos);
 					var shadowPos = pos - new WVec(0, 0, dat.Length);
-					foreach (var r in anim.Render(shadowPos, wr.Palette("shadow")))
-						yield return r;
+					foreach (var r in anim.Render(shadowPos, wr.Palette(info.Palette)))
+						yield return ((IModifyableRenderable)r)
+							.WithTint(shadowColor, ((IModifyableRenderable)r).TintModifiers | TintModifiers.ReplaceColor)
+							.WithAlpha(shadowAlpha);
 				}
 
 				var palette = wr.Palette(info.Palette + (info.IsPlayerPalette ? args.SourceActor.Owner.InternalName : ""));

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20201213/ReplaceShadowPalette.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20201213/ReplaceShadowPalette.cs
@@ -1,0 +1,64 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class ReplaceShadowPalette : UpdateRule
+	{
+		public override string Name { get { return "Removed ShadowPalette from WithShadow and projectiles."; } }
+
+		public override string Description
+		{
+			get
+			{
+				return "The ShadowPalette field has been replaced by ShadowColor on projectiles.\n" +
+					"The Palette field on WithShadow and ShadowPalette on WithParachute have similarly been replaced with ShadowColor.";
+			}
+		}
+
+		readonly List<string> locations = new List<string>();
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (locations.Any())
+				yield return "The shadow palette overrides have been removed from the following locations:\n" +
+					UpdateUtils.FormatMessageList(locations) + "\n\n" +
+					"You may wish to inspect and change these.";
+
+			locations.Clear();
+		}
+
+		public override IEnumerable<string> UpdateWeaponNode(ModData modData, MiniYamlNode weaponNode)
+		{
+			foreach (var projectileNode in weaponNode.ChildrenMatching("Projectile"))
+				if (projectileNode.RemoveNodes("ShadowPalette") > 0)
+					locations.Add("{0}: {1} ({2})".F(weaponNode.Key, weaponNode.Key, weaponNode.Location.Filename));
+
+			yield break;
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var node in actorNode.ChildrenMatching("WithShadow"))
+				if (node.RemoveNodes("Palette") > 0)
+					locations.Add("{0}: {1} ({2})".F(actorNode.Key, node.Key, actorNode.Location.Filename));
+
+			foreach (var node in actorNode.ChildrenMatching("WithParachute"))
+				if (node.RemoveNodes("ShadowPalette") > 0)
+					locations.Add("{0}: {1} ({2})".F(actorNode.Key, node.Key, actorNode.Location.Filename));
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -89,6 +89,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new ReplaceWithColoredOverlayPalette(),
 				new RemoveRenderSpritesScale(),
 				new RemovePlaceBuildingPalette(),
+				new ReplaceShadowPalette(),
 			})
 		};
 

--- a/mods/cnc/rules/palettes.yaml
+++ b/mods/cnc/rules/palettes.yaml
@@ -72,12 +72,6 @@
 		Filename: temperat.pal
 		ShadowIndex: 4
 		AllowModifiers: false
-	PaletteFromRGBA@shadow:
-		Name: shadow
-		R: 0
-		G: 0
-		B: 0
-		A: 140
 	PaletteFromRGBA@cloak:
 		Name: cloak
 		R: 0

--- a/mods/d2k/rules/palettes.yaml
+++ b/mods/d2k/rules/palettes.yaml
@@ -22,12 +22,6 @@
 		Filename: PALETTE.BIN
 		ShadowIndex: 4
 		AllowModifiers: false
-	PaletteFromRGBA@shadow:
-		Name: shadow
-		R: 0
-		G: 0
-		B: 0
-		A: 140
 	PaletteFromEmbeddedSpritePalette@moveflash-base:
 		Name: moveflash-base
 		Image: moveflsh


### PR DESCRIPTION
This PR implements another incremental step towards supporting RGBA world sprites. The special-case shadow palette for projectiles and aircraft is replaced with a direct color replacement using the new plumbing from #18550. The shadow palette is still used for voxels in TS and torpedos in RA, but can be removed from D2k and TD.

I find it a bit odd that we default to not drawing shadows on projectiles. This must have made sense many years ago, but I don't think it does now. The current PR keeps them off by default, but I think we should flip this. Thoughts?