### PR TITLE
TD Playtest Balance Tweaks

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -67,7 +67,7 @@ HELI:
 		TurnSpeed: 28
 		Speed: 180
 	Health:
-		HP: 12000
+		HP: 12500
 	Armor:
 		Type: Light
 	RevealsShroud:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -548,9 +548,9 @@
 	Inherits@selection: ^SelectableCombatUnit
 	Huntable:
 	Health:
-		HP: 30000
+		HP: 40000
 	Armor:
-		Type: Wood
+		Type: Light
 	RevealsShroud:
 		Range: 6c0
 	Mobile:
@@ -992,9 +992,9 @@
 	Inherits@1: ^ClassicFacingSpriteActor
 	Interactable:
 	Health:
-		HP: 14000
+		HP: 28000
 	Armor:
-		Type: Light
+		Type: Heavy
 	HiddenUnderFog:
 		Type: CenterPosition
 		AlwaysVisibleRelationships: None
@@ -1029,14 +1029,14 @@
 		Sequence: 1
 		IsDecoration: True
 	ChangesHealth:
-		Step: -100
+		Step: -200
 		StartIfBelow: 101
 		Delay: 6
 
 ^LightHusk:
 	Inherits: ^Husk
 	Health:
-		HP: 2000
+		HP: 4000
 
 ^HelicopterHusk:
 	Inherits: ^CommonHuskDefaults

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -110,7 +110,7 @@ APC:
 		Queue: Vehicle.GDI
 		Description: Armed infantry transport.\nCan attack Aircraft.\n  Strong vs Vehicles\n  Weak vs Infantry
 	Mobile:
-		TurnSpeed: 20
+		TurnSpeed: 28
 		Speed: 132
 		PauseOnCondition: notmobile
 	Health:
@@ -629,7 +629,7 @@ STNK:
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetAllAssaultMove
 	Valued:
-		Cost: 1000
+		Cost: 900
 	Tooltip:
 		Name: Stealth Tank
 	UpdatesPlayerStatistics:
@@ -648,7 +648,7 @@ STNK:
 	Health:
 		HP: 15000
 	Repairable:
-		HpPerStep: 682
+		HpPerStep: 758
 	Armor:
 		Type: Light
 	RevealsShroud:

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -65,6 +65,7 @@ Rockets:
 
 BikeRockets:
 	Inherits: ^MissileWeapon
+	ReloadDelay: 60
 	Burst: 2
 	BurstDelays: 10
 	Projectile: Missile

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -1,7 +1,7 @@
 Sniper:
 	Report: ramgun2.aud
 	ValidTargets: Ground, Infantry
-	InvalidTargets: Vehicle, Water, Structure, Wall, Husk
+	InvalidTargets: Vehicle, Water, Structure, Wall, Husk, Creep
 	ReloadDelay: 40
 	Range: 8c0
 	Projectile: Bullet
@@ -72,7 +72,7 @@ HeliAGGun:
 		Damage: 2000
 		Versus:
 			None: 100
-			Wood: 50
+			Wood: 75
 			Light: 75
 			Heavy: 25
 		DamageTypes: Prone80Percent, TriggerProne, RippedApartDeath
@@ -175,6 +175,6 @@ APCGun.AA:
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: Air
 		Versus:
-			Light: 140
+			Light: 125
 	Warhead@2Eff: CreateEffect
 		Explosions: small_poof


### PR DESCRIPTION
Some small tweaks based on changes from the playtest and other minor gameplay improvements.

**Playtest Balance Changes:**

`Bike: Reload Delay 50 -> 60`

Bikes are able to fire on moving targets now, which is a pretty big buff. Since it was mostly a DPS buff I've nerfed the DPS a little here. This also encourages more kiting micro.

`Apache: Health 12000 -> 12500`

This is undoing a change I made. Bikes are also much better at shooting aircraft now, so I reintroduced the change that let Apache resist one more bike/stealth tank rocket.

**Minor Gameplay Improvements:**

`APC: AA Light Damage: 140 -> 125, Turn Speed: 20 -> 28`

Buffing the damage was the wrong direction, so I've removed my change here. Instead, I've upped the turn speed. They used to have medium tank turn speed but now have Light Tank/Flame Tank turn speed. This should make them easier to micro. 

`Apache: Wood Damage: 50 -> 75`

Apaches have no utility if there are no soft targets available. This change allows them to have some use in base harassment. For the value I decided to buff it to match their light damage value (75), since the Orca has matching Light/Wood damage. Orcas still have more burst damage vs structures but Apaches do roughly the same total damage if they empty their whole clip.

`Stealth Tank: Cost 1000 -> 900`

Stealth tanks are still underperforming a little since the "uncloak on damage" change, so I've undone the cost change.

**Misc Changes:**

`Husks: Light -> Heavy Armor, Health: 14000 -> 28000, Health Decay: -100 -> -200`

Now that ref/wf blocking is no longer a thing, I felt free to standardize husks between RA/TD. The issue currently is that if any overkill damage hits a husk it very quickly times out, and as a player it feels pretty random when they timeout as a result (resulting in wasted engineers/attention).

They still timeout at the same rate, but damage has less of an affect on how quickly it times out. RA husks still last 33% longer (having a delay of 8 instead of 6 on step). I may standardize this in the future but that has balance considerations that will need to be vetted first.

`Commando: Weapon ignores creeps (Visceroid), Visceroid: Wood -> Light Armor, Health: 30000 -> 40000`

I noticed a bug in one of my games where commandos were firing on visceroids but doing no damage. This didn't make sense as the unit already ignores vehicles to target infantry, so commandos should no longer fire on visceroids.

While I was at it I also noticed Visceroids have wood armor. This means defenses such as obelisks do very little damage to them, among other weird values. I've changed it to light which means all weapons do some damage to them, which makes more sense to me. Most (all?) weapons do more damage to light than wood though, so I've upped their health to compensate (I took a brief look and it seemed like most weapons did about 33% more damage to light than wood).

I do want to change the cost of the Visceroid (1k), as it provides ridiculous veterancy and is kind of useless out of the biolab, but I didn't want to implement that without testing, so next +1 sort of thing.