### PR TITLE
Use pattern matching in FieldSaver

### DIFF
--- a/OpenRA.Game/FieldSaver.cs
+++ b/OpenRA.Game/FieldSaver.cs
@@ -72,32 +72,14 @@ namespace OpenRA
 				return "";
 
 			var t = v.GetType();
-
-			if (t == typeof(Color))
-			{
-				return ((Color)v).ToString();
-			}
-
-			if (t == typeof(Rectangle))
-			{
-				var r = (Rectangle)v;
-				return "{0},{1},{2},{3}".F(r.X, r.Y, r.Width, r.Height);
-			}
-
 			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(BitSet<>))
-			{
 				return ((IEnumerable<string>)v).Select(FormatValue).JoinWith(", ");
-			}
 
 			if (t.IsArray && t.GetArrayRank() == 1)
-			{
 				return ((Array)v).Cast<object>().Select(FormatValue).JoinWith(", ");
-			}
 
 			if (t.IsGenericType && (t.GetGenericTypeDefinition() == typeof(HashSet<>) || t.GetGenericTypeDefinition() == typeof(List<>)))
-			{
 				return ((System.Collections.IEnumerable)v).Cast<object>().Select(FormatValue).JoinWith(", ");
-			}
 
 			// This is only for documentation generation
 			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Dictionary<,>))
@@ -118,11 +100,8 @@ namespace OpenRA
 				return result;
 			}
 
-			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Primitives.Cache<,>))
-				return ""; // TODO
-
-			if (t == typeof(DateTime))
-				return ((DateTime)v).ToString("yyyy-MM-dd HH-mm-ss", CultureInfo.InvariantCulture);
+			if (v is DateTime d)
+				return d.ToString("yyyy-MM-dd HH-mm-ss", CultureInfo.InvariantCulture);
 
 			// Try the TypeConverter
 			var conv = TypeDescriptor.GetConverter(t);

--- a/OpenRA.Game/Primitives/Rectangle.cs
+++ b/OpenRA.Game/Primitives/Rectangle.cs
@@ -126,7 +126,7 @@ namespace OpenRA.Primitives
 
 		public override string ToString()
 		{
-			return string.Format("{{X={0},Y={1},Width={2},Height={3}}}", X, Y, Width, Height);
+			return "{0},{1},{2},{3}".F(X, Y, Width, Height);
 		}
 	}
 }


### PR DESCRIPTION
Uses new syntax to make the code easier to read. I also applied style changes. I didn't change the matching for the generic types since I don't think we can use pattern matching there.