### PR TITLE
Server side order receive and dispatch optimization.

### DIFF
--- a/OpenRA.Game/Network/Frame.cs
+++ b/OpenRA.Game/Network/Frame.cs
@@ -9,16 +9,28 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.Linq;
+using System;
 
-namespace OpenRA.Server
+namespace OpenRA.Network
 {
-	static class Exts
+	public struct Frame
 	{
-		public static IEnumerable<T> Except<T>(this IEnumerable<T> ts, T t)
+		public readonly int Index;
+
+		// A frame contains one or multiple serialized orders
+		// TODO: replace with Span<byte> once available
+		public readonly ArraySegment<byte> Data;
+
+		public Frame(int index, byte[] data)
 		{
-			return ts.Except(new[] { t });
+			Index = index;
+			Data = new ArraySegment<byte>(data);
+		}
+
+		public Frame(int index, ArraySegment<byte> data)
+		{
+			Index = index;
+			Data = data;
 		}
 	}
 }

--- a/OpenRA.Game/Network/ReplayRecorder.cs
+++ b/OpenRA.Game/Network/ReplayRecorder.cs
@@ -84,11 +84,12 @@ namespace OpenRA.Network
 			writer.Write(data);
 		}
 
-		public void ReceiveFrame(int clientID, int frame, byte[] data)
+		public void ReceiveFrame(int clientID, Frame frame)
 		{
-			var ms = new MemoryStream(4 + data.Length);
-			ms.WriteArray(BitConverter.GetBytes(frame));
-			ms.WriteArray(data);
+			var ms = new MemoryStream(4 + frame.Data.Count);
+			ms.WriteArray(BitConverter.GetBytes(frame.Index));
+			var data = frame.Data;
+			ms.Write(data.Array, data.Offset, data.Count);
 			Receive(clientID, ms.GetBuffer());
 		}
 


### PR DESCRIPTION
Frame, helper class, currently only used by server. To avoid reconstruction/copy of frame data
multiple times in connection, recorder, save game and server. Allows easier replacement of ArraySegment with Span in future.

Connection, rename MaxOrderLength, to MaxOrderFrameLength, a frame can have multiple orders.
Connection, OrderHeaderLength.
Connection, avoid use of List<byte>.
Connection, use single receive buffer, MaxOrderFrameLength (128k) per client connection, server side.
Connection, avoid copy of frame data over three times.
Connection, make use of larger than 1024 byte Linux OS receive buffer size (/proc/sys/net/ipv4/tcp_rmem). #18807 
Connection, use ArraySegment while we can't use Span<byte> yet.
Connection, make class fields not used outside class private.
Connection, process all frames received in full at once. Typically sync order frames cached by the client
that are sent along with client local orders.

ReplayRecorder, use Frame.
SaveGame, use Frame.

Server, DispatchOrdersToClients, avoid using Except LINQ statement.
Server, DispatchOrdersToClient(s), use Order over byte array argument.

No network protocol changes.

Performance impact of changes not measured.

Further testing needed.


