### PR TITLE
Fix AutoTarget.ChooseTarget ignoring AttackBase.TargetFrozenActors.

### DIFF
--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -348,8 +348,11 @@ namespace OpenRA.Mods.Common.Traits
 				return chosenTarget;
 
 			var targetsInRange = self.World.FindActorsInCircle(self.CenterPosition, scanRange)
-				.Select(Target.FromActor)
-				.Concat(self.Owner.FrozenActorLayer.FrozenActorsInCircle(self.World, self.CenterPosition, scanRange)
+				.Select(Target.FromActor);
+
+			if (allowMove || ab.Info.TargetFrozenActors)
+				targetsInRange = targetsInRange
+					.Concat(self.Owner.FrozenActorLayer.FrozenActorsInCircle(self.World, self.CenterPosition, scanRange)
 					.Select(Target.FromFrozenActor));
 
 			foreach (var target in targetsInRange)


### PR DESCRIPTION
Fixes #18974.

Testcase:
* Start a two player RA test game.
* Player 1 builds an ore silo
* Player 2 builds a minigunner and moves it in range of the silo so it is revealed
* Player 2 pulls the minigunner back so the silo is frozen under the fog
* Player 2 assault-moves the minigunner to a location behind the silo

On bleed the minigunner will stop and sit doing nothing. On this PR the minigunner will move 1 cell closer to unfreeze the actor, then start attacking.