### PR TITLE
Add death types support to the Lua Kill() API.

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/HealthProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/HealthProperties.cs
@@ -9,6 +9,8 @@
  */
 #endregion
 
+using Eluant;
+using OpenRA.Primitives;
 using OpenRA.Scripting;
 using OpenRA.Traits;
 
@@ -34,10 +36,18 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Maximum health of the actor.")]
 		public int MaxHealth { get { return health.MaxHP; } }
 
-		[Desc("Kill the actor.")]
-		public void Kill()
+		[Desc("Kill the actor. damageTypes may be omitted, specified as a string, or as table of strings.")]
+		public void Kill(object damageTypes = null)
 		{
-			health.InflictDamage(Self, Self, new Damage(health.MaxHP), true);
+			Damage damage;
+			if (damageTypes is string d)
+				damage = new Damage(health.MaxHP, new BitSet<DamageType>(new[] { d }));
+			else if (damageTypes is LuaTable t && t.TryGetClrValue(out string[] ds))
+				damage = new Damage(health.MaxHP, new BitSet<DamageType>(ds));
+			else
+				damage = new Damage(health.MaxHP);
+
+			health.InflictDamage(Self, Self, damage, true);
 		}
 	}
 }

--- a/mods/ra/maps/sarin-gas-2-down-under/downunder.lua
+++ b/mods/ra/maps/sarin-gas-2-down-under/downunder.lua
@@ -113,7 +113,7 @@ ConsoleTriggers = function()
 			Trigger.AfterDelay(DateTime.Seconds(4), function()
 				Utils.Do(SarinVictims, function(actor)
 					if not actor.IsDead then
-						actor.Kill()
+						actor.Kill("ExplosionDeath")
 					end
 				end)
 			end)

--- a/mods/ra/maps/top-o-the-world/scu36ea.lua
+++ b/mods/ra/maps/top-o-the-world/scu36ea.lua
@@ -285,59 +285,59 @@ WorldLoaded = function()
 --Units Death Setup
 	Trigger.AfterDelay(DateTime.Seconds(660), function()
 		Utils.Do(USSRDie01, function(actor)
-			if not actor.IsDead then actor.Kill() end
+			if not actor.IsDead then actor.Kill("DefaultDeath") end
 		end)
 	end)
 
 	Trigger.AfterDelay(DateTime.Seconds(744), function()
 		Utils.Do(USSRDie02, function(actor)
-			if not actor.IsDead then actor.Kill() end
+			if not actor.IsDead then actor.Kill("DefaultDeath") end
 		end)
 	end)
 
 	Trigger.AfterDelay(DateTime.Seconds(1122), function()
-		if not USSRHTank03.IsDead then USSRHTank03.Kill() end
+		if not USSRHTank03.IsDead then USSRHTank03.Kill("DefaultDeath") end
 	end)
 
 	Trigger.AfterDelay(DateTime.Seconds(1230), function()
 		Utils.Do(USSRDie03, function(actor)
-			if not actor.IsDead then actor.Kill() end
+			if not actor.IsDead then actor.Kill("DefaultDeath") end
 		end)
 	end)
 
 	Trigger.AfterDelay(DateTime.Seconds(1338), function()
 		Utils.Do(USSRDie04, function(actor)
-			if not actor.IsDead then actor.Kill() end
+			if not actor.IsDead then actor.Kill("DefaultDeath") end
 		end)
 	end)
 
 	Trigger.AfterDelay(DateTime.Seconds(1416), function()
 		Utils.Do(USSRDie05, function(actor)
-			if not actor.IsDead then actor.Kill() end
+			if not actor.IsDead then actor.Kill("DefaultDeath") end
 		end)
 	end)
 
 	Trigger.AfterDelay(DateTime.Seconds(1668), function()
-		if not USSRV201.IsDead then USSRV201.Kill() end
+		if not USSRV201.IsDead then USSRV201.Kill("DefaultDeath") end
 	end)
 
 	Trigger.AfterDelay(DateTime.Seconds(1746), function()
 		Utils.Do(USSRDie06, function(actor)
-			if not actor.IsDead then actor.Kill() end
+			if not actor.IsDead then actor.Kill("DefaultDeath") end
 		end)
 	end)
 
 	Trigger.AfterDelay(DateTime.Seconds(2034), function()
-		if not USSRMTank02.IsDead then USSRMTank02.Kill() end
+		if not USSRMTank02.IsDead then USSRMTank02.Kill("DefaultDeath") end
 	end)
 
 	Trigger.AfterDelay(DateTime.Seconds(2142), function()
-		if not USSRMTank01.IsDead then USSRMTank01.Kill() end
+		if not USSRMTank01.IsDead then USSRMTank01.Kill("DefaultDeath") end
 	end)
 
 	Trigger.OnTimerExpired(function()
 		if not ObjectiveTruck01.IsDead then
-			ObjectiveTruck01.Kill()
+			ObjectiveTruck01.Kill("DefaultDeath")
 
 			-- Set the limit to one so that the timer displays 0 and never ends
 			-- (which would display the game time instead of 0)


### PR DESCRIPTION
Fixes #18169.

Adding this to the milestone because @Smittytron has another ant mission ready to PR that depends on this (which i'd like to get into the playtest too), and it sounds like we can also use this to fix a polish bug in Sarin Gas 2 (if someone can tell me the changes i'll add them here).

Testcase: add the following snippet to the bottom of `SendInsertionHelicopter` in `mods/ra/maps/allies-01/allies01.lua` and uncomment each case to test:
```lua
Trigger.AfterDelay(DateTime.Seconds(4), function()
	tanya.Kill()
	--tanya.Kill("FireDeath")
	--tanya.Kill({"FireDeath", "Incendiary"})
end)
```