### PR TITLE
Update apt metadata before installing dependencies.

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -77,7 +77,8 @@ jobs:
       - name: Prepare Environment
         run: |
           echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> ${GITHUB_ENV}
-          sudo apt install nsis wine64
+          sudo apt-get update
+          sudo apt-get install nsis wine64
 
       - name: Package Installers
         run: |


### PR DESCRIPTION
While testing mod SDK packaging I found that stale apt metadata can cause the installation to fail. Updating the package cache fixes this, and using `apt-get` instead of `apt` fixes the warning about `apt` not having a stable scripting API.