### PR TITLE
Fix missing System.Threading.Tasks.Parallel in packaged net5 builds.

### DIFF
--- a/OpenRA.Launcher/OpenRA.Launcher.csproj
+++ b/OpenRA.Launcher/OpenRA.Launcher.csproj
@@ -69,5 +69,6 @@
     <TrimmerRootAssembly Include="mscorlib" />
     <TrimmerRootAssembly Include="netstandard" />
     <TrimmerRootAssembly Include="System.IO.Pipes" />
+    <TrimmerRootAssembly Include="System.Threading.Tasks.Parallel" />
   </ItemGroup>
 </Project>

--- a/OpenRA.WindowsLauncher/OpenRA.WindowsLauncher.csproj
+++ b/OpenRA.WindowsLauncher/OpenRA.WindowsLauncher.csproj
@@ -62,5 +62,6 @@
     <TrimmerRootAssembly Include="mscorlib" />
     <TrimmerRootAssembly Include="netstandard" />
     <TrimmerRootAssembly Include="System.IO.Pipes" />
+    <TrimmerRootAssembly Include="System.Threading.Tasks.Parallel" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR fixes a crash when trying to access the replay browser with at least one replay present in a net5 packaged build.