### PR TITLE
Remove ScriptTriggers from indestructible map deco actors

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -832,7 +832,6 @@
 		Palette: terrain
 	WithSpriteBody:
 	FrozenUnderFog:
-	ScriptTriggers:
 	MapEditorData:
 		Categories: Husk
 
@@ -923,7 +922,6 @@
 		MinimumDamageState: Heavy
 		MaximumDamageState: Dead
 	HiddenUnderShroud:
-	ScriptTriggers:
 	HitShape:
 	MapEditorData:
 		Categories: Tree
@@ -946,7 +944,6 @@
 		Name: Tree (Burnt)
 		ShowOwnerRow: false
 	HiddenUnderShroud:
-	ScriptTriggers:
 	MapEditorData:
 		Categories: Tree
 	RequiresSpecificOwners:
@@ -994,7 +991,6 @@
 	AppearsOnMapPreview:
 		Terrain: Tree
 	HiddenUnderShroud:
-	ScriptTriggers:
 	MapEditorData:
 		RequireTilesets: DESERT
 		Categories: Decoration

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -890,6 +890,7 @@
 	-Explodes:
 	-Explodes@CIVPANIC:
 	-Selectable:
+	-ScriptTriggers:
 	Tooltip:
 		Name: Field
 	-Targetable:
@@ -941,7 +942,6 @@
 		MinimumDamageState: Heavy
 		MaximumDamageState: Dead
 	HiddenUnderShroud:
-	ScriptTriggers:
 	MapEditorData:
 		ExcludeTilesets: INTERIOR
 		Categories: Tree
@@ -966,7 +966,6 @@
 		Name: Tree (Burnt)
 		ShowOwnerRow: false
 	HiddenUnderShroud:
-	ScriptTriggers:
 	MapEditorData:
 		Categories: Tree
 	RequiresSpecificOwners:
@@ -1115,7 +1114,6 @@
 	AppearsOnMapPreview:
 		Terrain: Tree
 	HiddenUnderShroud:
-	ScriptTriggers:
 	MapEditorData:
 		RequireTilesets: DESERT
 		Categories: Decoration


### PR DESCRIPTION
Removes `ScriptTriggers` trait from trees, rocks and destroyed fields (in other words, indestructible map decoration actors) in RA and C&C.

This trait isn't free in terms of performance due to all the INotify* calls, and the mentioned actors should rarely - more likely never - need it. Besides, if a mission ever really needs this on those actors, the trait can be added back via map rules.

Split from #18588 to get the uncontroversial(?) and easy stuff out of the way, as some maps have lots of trees so there might already be a small win from this alone.