### PR TITLE
Fix `make check` ignoring TARGETPLATFORM override.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,10 @@ clean:
 check:
 	@echo
 	@echo "Compiling in debug mode..."
-	@$(MSBUILD) -t:build -restore -p:Configuration=Debug
+	@$(MSBUILD) -t:build -restore -p:Configuration=Debug -p:TargetPlatform=$(TARGETPLATFORM)
+ifeq ($(TARGETPLATFORM), unix-generic)
+	@./configure-system-libraries.sh
+endif
 	@echo
 	@echo "Checking runtime assemblies..."
 	@$(OPENRA_UTILITY) all --check-runtime-assemblies $(WHITELISTED_OPENRA_ASSEMBLIES) $(WHITELISTED_THIRDPARTY_ASSEMBLIES) $(WHITELISTED_CORE_ASSEMBLIES)


### PR DESCRIPTION
Fixes #19040 (prep version).

#17989 already fixed the msbuild arg on bleed, and I will add the missing `configure-system-libraries.sh` call in #19026.