### PR TITLE
Fix Sardarkaur not attacking while attack-moving.

### DIFF
--- a/mods/d2k/weapons/smallguns.yaml
+++ b/mods/d2k/weapons/smallguns.yaml
@@ -39,6 +39,7 @@ Fremen_S:
 M_LMG:
 	Inherits: ^MG
 	ReloadDelay: 40
+	ValidTargets: Infantry
 
 M_LMG_H:
 	Inherits: M_LMG
@@ -49,6 +50,7 @@ M_HMG:
 	ReloadDelay: 40
 	Range: 3c512
 	Report: 20MMGUN1.WAV
+	InvalidTargets: Infantry
 	Warhead@1Dam: SpreadDamage
 		Damage: 2500
 		Spread: 512


### PR DESCRIPTION
Fixes #18935.

The underlying problem here is caused by inconsistent target validation logic in `AutoTarget` versus `AttackFrontal`'s `Attack` activity: `AutoTarget` considers a target valid if *any* weapon is in range, but `Attack` only considers it valid if *all* valid weapons are in range. Attempting to fix that might open a can of worms, and isn't needed for #18935, so I defer that to #19062.

For the upcoming release, it is sufficient to apply TargetType restrictions to the two weapons. This makes the Sarkarkaur attacks a lot more consistent with the original game (but not exact: they will not fire on infantry using the HMG at 2.5-3.5 cell range) and avoids the underlying bug by ensuring that only one weapon is ever valid against a target.