### PR TITLE
Reduce Tanya firing rate and polish attack animation

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -29,8 +29,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly string DefaultAttackSequence = null;
 
 		[SequenceReference(dictionaryReference: LintDictionaryReference.Values)]
-		[Desc("Attack sequence to use for each armament.")]
-		public readonly Dictionary<string, string> AttackSequences = new Dictionary<string, string>();
+		[Desc("Attack sequence to use for each armament.",
+			"A dictionary of [armament name]: [sequence name(s)].",
+			"Multiple sequence names can be defined to specify per-burst animations.")]
+		public readonly Dictionary<string, string[]> AttackSequences = new Dictionary<string, string[]>();
 
 		[SequenceReference]
 		public readonly string[] IdleSequences = { };
@@ -133,11 +135,21 @@ namespace OpenRA.Mods.Common.Traits.Render
 			}
 		}
 
-		public void Attacking(Actor self, in Target target, Armament a)
+		void Attacking(Actor self, Armament a, Barrel barrel)
 		{
 			var info = GetDisplayInfo();
-			if (!info.AttackSequences.TryGetValue(a.Info.Name, out var sequence))
-				sequence = info.DefaultAttackSequence;
+			var sequence = info.DefaultAttackSequence;
+
+			if (info.AttackSequences.TryGetValue(a.Info.Name, out var sequences) && sequences.Length > 0)
+			{
+				sequence = sequences[0];
+
+				// Find the sequence corresponding to this barrel/burst.
+				if (barrel != null && sequences.Length > 1)
+					for (var i = 0; i < sequences.Length; i++)
+						if (a.Barrels[i] == barrel)
+							sequence = sequences[i];
+			}
 
 			if (!string.IsNullOrEmpty(sequence) && DefaultAnimation.HasSequence(NormalizeInfantrySequence(self, sequence)))
 			{
@@ -148,12 +160,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel)
 		{
-			// Lambdas can't use 'in' variables, so capture a copy for later
-			var attackTarget = target;
-
 			// HACK: The FrameEndTask makes sure that this runs after Tick(), preventing that from
 			// overriding the animation when an infantry unit stops to attack
-			self.World.AddFrameEndTask(_ => Attacking(self, attackTarget, a));
+			self.World.AddFrameEndTask(_ => Attacking(self, a, barrel));
 		}
 
 		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel) { }

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -389,14 +389,17 @@ E7:
 		Voice: Move
 	Armament@PRIMARY:
 		Weapon: Colt45
+		LocalOffset: 0,0,0, 0,0,0
 	Armament@SECONDARY:
 		Weapon: Colt45
+		LocalOffset: 0,0,0, 0,0,0
 	Armament@GARRISONED:
 		Name: garrisoned
 		Weapon: Colt45
 		MuzzleSequence: garrison-muzzle
 	WithInfantryBody:
-		DefaultAttackSequence: shoot
+		AttackSequences:
+			primary: shoot-left, shoot-right
 		StandSequences: stand
 	ExternalCondition@PRODUCED:
 		Condition: produced

--- a/mods/ra/sequences/infantry.yaml
+++ b/mods/ra/sequences/infantry.yaml
@@ -717,9 +717,49 @@ e7:
 		Length: 6
 		Facings: 8
 		Tick: 80
-	shoot:
-		Start: 56
-		Length: 7
+	shoot-left:
+		Combine:
+			e7:
+				Length: 8
+				Frames: 58, 56, 64, 63, 71, 70, 79, 77
+			e7:
+				Length: 2
+				Frames: 85, 84
+				Offset: 1, 0
+			e7:
+				Length: 2
+				Frames: 92, 91
+			e7:
+				Length: 2
+				Frames: 99, 98
+				Offset: 1, -2
+			e7:
+				Length: 2
+				Frames: 107, 105
+				Offset: 0, -2
+		Length: 2
+		Facings: 8
+	shoot-right:
+		Combine:
+			e7:
+				Length: 8
+				Frames: 57, 56, 65, 63, 72, 70, 78, 77
+			e7:
+				Length: 2
+				Frames: 86, 84
+				Offset: 1, 0
+			e7:
+				Length: 2
+				Frames: 93, 91
+			e7:
+				Length: 2
+				Frames: 100, 98
+				Offset: 1, -2
+			e7:
+				Length: 2
+				Frames: 106, 105
+				Offset: 0, -2
+		Length: 2
 		Facings: 8
 	idle1:
 		Start: 233

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -329,7 +329,7 @@ SilencedPPK:
 
 Colt45:
 	Inherits: ^SnipeWeapon
-	ReloadDelay: 5
+	ReloadDelay: 7
 	Range: 7c0
 	Warhead@1Dam: SpreadDamage
 		Damage: 5000


### PR DESCRIPTION
Fixes #19055.

The first commit implements the nerf suggested by the competitive community. The second and third commits sync the firing animation to the attacks and fixes the jumping animation frames.

I dialed back on my original plans to remove the second Colt armament (which causes the attack sound to be extra loud) and to stagger the burst shots to make tanya feel less robotic. These would have been nice polish, but at this point I just want to get a stable release out without risking blowback or delays over balance implications.