### PR TITLE
Improve shroud performance

### DIFF
--- a/OpenRA.Game/Map/ProjectedCellLayer.cs
+++ b/OpenRA.Game/Map/ProjectedCellLayer.cs
@@ -15,6 +15,8 @@ namespace OpenRA
 {
 	public sealed class ProjectedCellLayer<T> : CellLayerBase<T>
 	{
+		public int MaxIndex { get { return Size.Width * Size.Height; } }
+
 		public ProjectedCellLayer(Map map)
 			: base(map) { }
 
@@ -25,6 +27,11 @@ namespace OpenRA
 		public int Index(PPos uv)
 		{
 			return uv.V * Size.Width + uv.U;
+		}
+
+		public PPos PPosFromIndex(int index)
+		{
+			return new PPos(index % Size.Width, index / Size.Width);
 		}
 
 		public T this[int index]


### PR DESCRIPTION
Some profiling revealed that `Shroud.Tick` was a large source of tick time on my system for bigger maps with lots of players. There has been a fairly extensive discussion around optimizing this point in #17383. In short, the `Shroud.Tick` for each player loops through every cell to check whether or not it has been "touched" this frame.

By replacing the `foreach` and immediate conversion from `PPos` to index (which involves dereference and multiplication) with a direct loop on the index, we can make the hottest path of this loop much lighter. In my performance testing with `PerfSample`, this completely removed `Shroud.Tick` from the chart, compared to constituting about 10ms prior (in an AI game with 12 players on Europe).