### PR TITLE
Remove SpawnActorOnDeath from civilian structures

### DIFF
--- a/mods/ra/maps/monster-tank-madness/rules.yaml
+++ b/mods/ra/maps/monster-tank-madness/rules.yaml
@@ -26,9 +26,6 @@ World:
 	Explodes:
 		Weapon: BarrelExplode
 		EmptyWeapon: BarrelExplode
-	-SpawnActorOnDeath@1:
-	-SpawnActorOnDeath@2:
-	-SpawnActorOnDeath@3:
 
 V01.exploding:
 	Inherits: ^ExplodingCivBuilding

--- a/mods/ra/maps/soviet-08a/rules.yaml
+++ b/mods/ra/maps/soviet-08a/rules.yaml
@@ -33,11 +33,6 @@ LST.Reinforcement:
 		Image: lst
 	Interactable:
 
-V01:
-	-SpawnActorOnDeath@1:
-	-SpawnActorOnDeath@2:
-	-SpawnActorOnDeath@3:
-
 SCRIPTEDDROP:
 	ParatroopersPower:
 		DisplayBeacon: False

--- a/mods/ra/maps/soviet-08b/rules.yaml
+++ b/mods/ra/maps/soviet-08b/rules.yaml
@@ -33,11 +33,6 @@ LST.Reinforcement:
 		Image: lst
 	Interactable:
 
-V01:
-	-SpawnActorOnDeath@1:
-	-SpawnActorOnDeath@2:
-	-SpawnActorOnDeath@3:
-
 SCRIPTEDDROP:
 	ParatroopersPower:
 		DisplayBeacon: False

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -356,9 +356,6 @@ V19:
 		Palette: player
 	Tooltip:
 		Name: Oil Pump
-	-SpawnActorOnDeath@1:
-	-SpawnActorOnDeath@2:
-	-SpawnActorOnDeath@3:
 	SpawnActorOnDeath:
 		Actor: V19.Husk
 	Targetable:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -869,15 +869,6 @@
 	MapEditorData:
 		ExcludeTilesets: INTERIOR
 		Categories: Civilian building
-	SpawnActorOnDeath@1:
-		Actor: c1
-		Probability: 40
-	SpawnActorOnDeath@2:
-		Actor: c4
-		Probability: 20
-	SpawnActorOnDeath@3:
-		Actor: c3
-		Probability: 15
 	Explodes:
 		Weapon: SmallBuildingExplode
 	Explodes@CIVPANIC:


### PR DESCRIPTION
Third attempt at fixing our crates spawning under buildings issue. See discussion here: (https://github.com/OpenRA/OpenRA/pull/18318#issuecomment-748624929) Decided it would be cleaner to remove civilian spawn entirely instead of trying to override it in campaign-rules.

Closes #16790
Closes #17802