### PR TITLE
Give an option on owner-changing on Cargo

### DIFF
--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -80,6 +80,9 @@ namespace OpenRA.Mods.Common.Traits
 			"A dictionary of [actor id]: [condition].")]
 		public readonly Dictionary<string, string> PassengerConditions = new Dictionary<string, string>();
 
+		[Desc("Change the passengers' owner if the transport's owner changed.")]
+		public readonly bool InheritOwnerChange = true;
+
 		[GrantedConditionReference]
 		public IEnumerable<string> LinterPassengerConditions { get { return PassengerConditions.Values; } }
 
@@ -463,7 +466,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
-			if (cargo == null)
+			if (!Info.InheritOwnerChange || cargo == null)
 				return;
 
 			foreach (var p in Passengers)


### PR DESCRIPTION
I know there is no use case in default mods on change transport owner, and I know cargo needs a refactor due to its flaw so it is better not to touch it. However, I think third-party mods really need this function to remove the cargo bug on hijacker and mind control.