### PR TITLE
Disable contrail smoothing on projectiles

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -102,11 +102,18 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Altitude above terrain below which to explode. Zero effectively deactivates airburst.")]
 		public readonly WDist AirburstAltitude = WDist.Zero;
 
+		[Desc("Length of contrail render effect (in ticks, so actual length will depend on speed as well).")]
 		public readonly int ContrailLength = 0;
-		public readonly int ContrailZOffset = 2047;
-		public readonly Color ContrailColor = Color.White;
-		public readonly bool ContrailUsePlayerColor = false;
+
+		[Desc("Contrail point spawn delay in ticks.")]
 		public readonly int ContrailDelay = 1;
+
+		public readonly int ContrailZOffset = 2047;
+
+		public readonly Color ContrailColor = Color.White;
+
+		public readonly bool ContrailUsePlayerColor = false;
+
 		public readonly WDist ContrailWidth = new WDist(64);
 
 		public IProjectile Create(ProjectileArgs args) { return new Bullet(this, args); }
@@ -172,7 +179,9 @@ namespace OpenRA.Mods.Common.Projectiles
 			if (info.ContrailLength > 0)
 			{
 				var color = info.ContrailUsePlayerColor ? ContrailRenderable.ChooseColor(args.SourceActor) : info.ContrailColor;
-				contrail = new ContrailRenderable(world, color, info.ContrailWidth, info.ContrailLength, info.ContrailDelay, info.ContrailZOffset);
+
+				// Bullets don't benefit from contrail smoothing, so disable it to support ContrailLength shorter than 4 + ContrailDelay.
+				contrail = new ContrailRenderable(world, color, info.ContrailWidth, info.ContrailLength, info.ContrailDelay, info.ContrailZOffset, false);
 			}
 
 			trailPalette = info.TrailPalette;

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -126,17 +126,19 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Should trail animation be spawned when the propulsion is not activated.")]
 		public readonly bool TrailWhenDeactivated = false;
 
+		[Desc("Length of contrail render effect (in ticks, so actual length will depend on speed as well).")]
 		public readonly int ContrailLength = 0;
 
-		public readonly int ContrailZOffset = 2047;
+		[Desc("Contrail point spawn delay in ticks.")]
+		public readonly int ContrailDelay = 1;
 
-		public readonly WDist ContrailWidth = new WDist(64);
+		public readonly int ContrailZOffset = 2047;
 
 		public readonly Color ContrailColor = Color.White;
 
 		public readonly bool ContrailUsePlayerColor = false;
 
-		public readonly int ContrailDelay = 1;
+		public readonly WDist ContrailWidth = new WDist(64);
 
 		[Desc("Should missile targeting be thrown off by nearby actors with JamsMissiles.")]
 		public readonly bool Jammable = true;
@@ -258,7 +260,10 @@ namespace OpenRA.Mods.Common.Projectiles
 			if (info.ContrailLength > 0)
 			{
 				var color = info.ContrailUsePlayerColor ? ContrailRenderable.ChooseColor(args.SourceActor) : info.ContrailColor;
-				contrail = new ContrailRenderable(world, color, info.ContrailWidth, info.ContrailLength, info.ContrailDelay, info.ContrailZOffset);
+
+				// Missiles don't benefit from contrail smoothing as long as we don't add a ContrailOffset,
+				// so disable smoothing for now to support contrail lengths shorter than 4 + ContrailDelay.
+				contrail = new ContrailRenderable(world, color, info.ContrailWidth, info.ContrailLength, info.ContrailDelay, info.ContrailZOffset, false);
 			}
 
 			trailPalette = info.TrailPalette;

--- a/OpenRA.Mods.Common/Traits/Contrail.cs
+++ b/OpenRA.Mods.Common/Traits/Contrail.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Offset for Z sorting.")]
 		public readonly int ZOffset = 0;
 
-		[Desc("Length of the trail (in ticks).")]
+		[Desc("Length of the trail (in ticks). Note: Trails are only smoothed for TrailLength 4 or higher.")]
 		public readonly int TrailLength = 25;
 
 		[Desc("Width of the trail.")]
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 
 			color = info.UsePlayerColor ? ContrailRenderable.ChooseColor(self) : info.Color;
-			trail = new ContrailRenderable(self.World, color, info.TrailWidth, info.TrailLength, 0, info.ZOffset);
+			trail = new ContrailRenderable(self.World, color, info.TrailWidth, info.TrailLength, 0, info.ZOffset, info.TrailLength > 3);
 
 			body = self.Trait<BodyOrientation>();
 		}
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
-			trail = new ContrailRenderable(self.World, color, info.TrailWidth, info.TrailLength, 0, info.ZOffset);
+			trail = new ContrailRenderable(self.World, color, info.TrailWidth, info.TrailLength, 0, info.ZOffset, info.TrailLength > 3);
 		}
 	}
 }


### PR DESCRIPTION
Contrail smoothing being mandatory and having a silent 4 + `delay` length requirement silently broke support for trail lengths below 4 (or 4 + `ContrailDelay` on projectiles), without any real benefit for projectiles.

Bullets by definition don't benefit at all (due to static horizontal direction and fixed vertical arcing); missiles only would if they were homing (horizontal turning), supported a `ContrailOffset` _and_ used a non-zero Y offset for the contrail. The latter isn't possible yet and and would be an extreme edge case even if it were.
Automatically enabling contrail smoothing for that edge case should be a good-enough solution if we add support for a `ContrailOffset` at some point.

Additionally, the PR disables smoothing on the `Contrail` trait for lengths < 4, instead of silently rendering nothing, and adds a note about that in the `TrailLength` property description.

Closes #19084.