### PR TITLE
Fix RA infantry death anims playing too fast

### DIFF
--- a/mods/ra/sequences/infantry.yaml
+++ b/mods/ra/sequences/infantry.yaml
@@ -51,21 +51,27 @@ e1:
 	die1:
 		Start: 288
 		Length: 8
+		Tick: 80
 	die2:
 		Start: 296
 		Length: 8
+		Tick: 80
 	die3:
 		Start: 304
 		Length: 8
+		Tick: 80
 	die4:
 		Start: 312
 		Length: 12
+		Tick: 80
 	die5:
 		Start: 324
 		Length: 18
+		Tick: 80
 	die6: electro
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Tick: 80
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -159,21 +165,27 @@ sniper:
 	die1:
 		Start: 416
 		Length: 8
+		Tick: 80
 	die2:
 		Start: 424
 		Length: 8
+		Tick: 80
 	die3:
 		Start: 432
 		Length: 8
+		Tick: 80
 	die4:
 		Start: 440
 		Length: 12
+		Tick: 80
 	die5:
 		Start: 452
 		Length: 18
+		Tick: 80
 	die6: electro
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Tick: 80
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -220,21 +232,27 @@ e3:
 	die1:
 		Start: 304
 		Length: 8
+		Tick: 80
 	die2:
 		Start: 312
 		Length: 8
+		Tick: 80
 	die3:
 		Start: 320
 		Length: 8
+		Tick: 80
 	die4:
 		Start: 328
 		Length: 12
+		Tick: 80
 	die5:
 		Start: 340
 		Length: 18
+		Tick: 80
 	die6: electro
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Tick: 80
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -290,21 +308,27 @@ e6:
 	die1:
 		Start: 146
 		Length: 8
+		Tick: 80
 	die2:
 		Start: 154
 		Length: 8
+		Tick: 80
 	die3:
 		Start: 162
 		Length: 8
+		Tick: 80
 	die4:
 		Start: 170
 		Length: 12
+		Tick: 80
 	die5:
 		Start: 182
 		Length: 18
+		Tick: 80
 	die6: electro
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Tick: 80
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -354,22 +378,28 @@ medi:
 		Tick: 120
 	die1:
 		Start: 193
-		Length: 7
+		Length: 8
+		Tick: 80
 	die2:
 		Start: 201
 		Length: 8
+		Tick: 80
 	die3:
 		Start: 209
 		Length: 8
+		Tick: 80
 	die4:
 		Start: 217
 		Length: 12
+		Tick: 80
 	die5:
 		Start: 229
 		Length: 18
+		Tick: 80
 	die6: electro
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Tick: 80
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -415,22 +445,28 @@ mech:
 		Tick: 120
 	die1:
 		Start: 193
-		Length: 7
+		Length: 8
+		Tick: 80
 	die2:
 		Start: 201
 		Length: 8
+		Tick: 80
 	die3:
 		Start: 209
 		Length: 8
+		Tick: 80
 	die4:
 		Start: 217
 		Length: 12
+		Tick: 80
 	die5:
 		Start: 229
 		Length: 18
+		Tick: 80
 	die6: electro
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Tick: 80
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -482,21 +518,27 @@ e2:
 	die1:
 		Start: 416
 		Length: 8
+		Tick: 80
 	die2:
 		Start: 424
 		Length: 8
+		Tick: 80
 	die3:
 		Start: 432
 		Length: 8
+		Tick: 80
 	die4:
 		Start: 440
 		Length: 12
+		Tick: 80
 	die5:
 		Start: 452
 		Length: 18
+		Tick: 80
 	die6: electro
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Tick: 80
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -557,20 +599,26 @@ dog:
 	die1:
 		Start: 236
 		Length: 6
+		Tick: 80
 	die2:
 		Start: 242
 		Length: 9
+		Tick: 80
 	die3:
 		Start: 236
 		Length: 6
+		Tick: 80
 	die4:
 		Start: 242
 		Length: 9
+		Tick: 80
 	die5:
 		Start: 251
 		Length: 14
+		Tick: 80
 	die6: electdog
 		Length: *
+		Tick: 80
 	die-crushed: corpse1
 		Length: 6
 		Tick: 1600
@@ -610,21 +658,27 @@ spy:
 	die1:
 		Start: 288
 		Length: 8
+		Tick: 80
 	die2:
 		Start: 296
 		Length: 8
+		Tick: 80
 	die3:
 		Start: 304
 		Length: 8
+		Tick: 80
 	die4:
 		Start: 312
 		Length: 12
+		Tick: 80
 	die5:
 		Start: 324
 		Length: 18
+		Tick: 80
 	die6: electro
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Tick: 80
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -671,21 +725,27 @@ thf:
 	die1:
 		Start: 139
 		Length: 8
+		Tick: 80
 	die2:
 		Start: 147
 		Length: 8
+		Tick: 80
 	die3:
 		Start: 155
 		Length: 8
+		Tick: 80
 	die4:
 		Start: 163
 		Length: 12
+		Tick: 80
 	die5:
 		Start: 175
 		Length: 18
+		Tick: 80
 	die6: electro
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Tick: 80
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -772,21 +832,27 @@ e7:
 	die1:
 		Start: 262
 		Length: 8
+		Tick: 80
 	die2:
 		Start: 270
 		Length: 8
+		Tick: 80
 	die3:
 		Start: 278
 		Length: 8
+		Tick: 80
 	die4:
 		Start: 286
 		Length: 12
+		Tick: 80
 	die5:
 		Start: 298
 		Length: 18
+		Tick: 80
 	die6: electro
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Tick: 80
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -846,21 +912,27 @@ e4:
 	die1:
 		Start: 416
 		Length: 8
+		Tick: 80
 	die2:
 		Start: 424
 		Length: 8
+		Tick: 80
 	die3:
 		Start: 432
 		Length: 8
+		Tick: 80
 	die4:
 		Start: 440
 		Length: 12
+		Tick: 80
 	die5:
 		Start: 452
 		Length: 18
+		Tick: 80
 	die6: electro
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Tick: 80
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -928,21 +1000,27 @@ gnrl:
 	die1:
 		Start: 210
 		Length: 8
+		Tick: 80
 	die2:
 		Start: 218
 		Length: 8
+		Tick: 80
 	die3:
 		Start: 226
 		Length: 8
+		Tick: 80
 	die4:
 		Start: 234
 		Length: 12
+		Tick: 80
 	die5:
 		Start: 246
 		Length: 18
+		Tick: 80
 	die6: electro
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Tick: 80
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -1009,21 +1087,27 @@ shok:
 	die1:
 		Start: 416
 		Length: 8
+		Tick: 80
 	die2:
 		Start: 424
 		Length: 8
+		Tick: 80
 	die3:
 		Start: 432
 		Length: 8
+		Tick: 80
 	die4:
 		Start: 440
 		Length: 12
+		Tick: 80
 	die5:
 		Start: 452
 		Length: 18
+		Tick: 80
 	die6: electro
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Tick: 80
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -1054,21 +1138,27 @@ c1:
 	die1:
 		Start: 152
 		Length: 8
+		Tick: 80
 	die2:
 		Start: 160
 		Length: 8
+		Tick: 80
 	die3:
 		Start: 168
 		Length: 12
+		Tick: 80
 	die4:
 		Start: 168
 		Length: 12
+		Tick: 80
 	die5:
 		Start: 180
 		Length: 18
+		Tick: 80
 	die6: electro
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Tick: 80
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -1103,21 +1193,27 @@ c2:
 	die1:
 		Start: 152
 		Length: 8
+		Tick: 80
 	die2:
 		Start: 160
 		Length: 8
+		Tick: 80
 	die3:
 		Start: 168
 		Length: 12
+		Tick: 80
 	die4:
 		Start: 168
 		Length: 12
+		Tick: 80
 	die5:
 		Start: 180
 		Length: 18
+		Tick: 80
 	die6: electro
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Tick: 80
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -1152,21 +1248,27 @@ c11:
 	die1:
 		Start: 152
 		Length: 8
+		Tick: 80
 	die2:
 		Start: 160
 		Length: 8
+		Tick: 80
 	die3:
 		Start: 168
 		Length: 12
+		Tick: 80
 	die4:
 		Start: 168
 		Length: 12
+		Tick: 80
 	die5:
 		Start: 180
 		Length: 18
+		Tick: 80
 	die6: electro
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Tick: 80
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -1202,21 +1304,27 @@ einstein:
 	die1:
 		Start: 120
 		Length: 8
+		Tick: 80
 	die2:
 		Start: 128
 		Length: 8
+		Tick: 80
 	die3:
 		Start: 136
 		Length: 12
+		Tick: 80
 	die4:
 		Start: 136
 		Length: 12
+		Tick: 80
 	die5:
 		Start: 148
 		Length: 17
+		Tick: 80
 	die6: electro
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Tick: 80
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -1247,21 +1355,27 @@ delphi:
 	die1:
 		Start: 329
 		Length: 8
+		Tick: 80
 	die2:
 		Start: 337
 		Length: 8
+		Tick: 80
 	die3:
 		Start: 345
 		Length: 12
+		Tick: 80
 	die4:
 		Start: 345
 		Length: 12
+		Tick: 80
 	die5:
 		Start: 357
 		Length: 17
+		Tick: 80
 	die6: electro
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Tick: 80
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -1292,21 +1406,27 @@ chan:
 	die1:
 		Start: 120
 		Length: 8
+		Tick: 80
 	die2:
 		Start: 128
 		Length: 8
+		Tick: 80
 	die3:
 		Start: 136
 		Length: 12
+		Tick: 80
 	die4:
 		Start: 136
 		Length: 12
+		Tick: 80
 	die5:
 		Start: 148
 		Length: 17
+		Tick: 80
 	die6: electro
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Tick: 80
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -1342,21 +1462,27 @@ zombie:
 	die1:
 		Start: 106
 		Length: 8
+		Tick: 80
 	die2:
 		Start: 106
 		Length: 8
+		Tick: 80
 	die3:
 		Start: 106
 		Length: 8
+		Tick: 80
 	die4:
 		Start: 106
 		Length: 8
+		Tick: 80
 	die5:
 		Start: 114
 		Length: 19
+		Tick: 80
 	die6: electro
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Tick: 80
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT


### PR DESCRIPTION
I noticed this literally years ago, but whenever it stood out to me I was to busy with testing something and forgot about it before I could file a PR.

Matches TD death anim speeds, is more consistent with most other animations and simply looks better this way.
Should be picked to prep, in my opinion.