### PR TITLE
Prevent AttackPopupTurreted.TickIdle from running while disabled.

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackPopupTurreted.cs
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		void INotifyIdle.TickIdle(Actor self)
 		{
-			if (IsTraitPaused)
+			if (IsTraitDisabled || IsTraitPaused)
 				return;
 
 			if (state == PopupState.Open && idleTicks++ > info.CloseDelay)


### PR DESCRIPTION
Fixes #19094.