### PR TITLE
Improve server validation

### DIFF
--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -166,6 +166,7 @@ namespace OpenRA
 		public void QueryRemoteMapDetails(string repositoryUrl, IEnumerable<string> uids, Action<MapPreview> mapDetailsReceived = null, Action queryFailed = null)
 		{
 			var maps = uids.Distinct()
+				.Where(uid => uid != null)
 				.Select(uid => previews[uid])
 				.Where(p => p.Status == MapStatus.Unavailable)
 				.ToDictionary(p => p.Uid, p => p);

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -334,14 +334,24 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				List<GameServer> games = null;
 				if (i.Error == null)
 				{
+					games = new List<GameServer>();
 					try
 					{
 						var data = Encoding.UTF8.GetString(i.Result);
 						var yaml = MiniYaml.FromString(data);
-
-						games = yaml.Select(a => new GameServer(a.Value))
-							.Where(gs => gs.Address != null)
-							.ToList();
+						foreach (var node in yaml)
+						{
+							try
+							{
+								var gs = new GameServer(node.Value);
+								if (gs.Address != null)
+									games.Add(gs);
+							}
+							catch
+							{
+								// Ignore any invalid games advertised.
+							}
+						}
 					}
 					catch
 					{


### PR DESCRIPTION
Fixes #19098.

The first commit should be obvious.
The second commit can be tested by adding
```csharp
yaml.Add(new MiniYamlNode("", new MiniYaml("", new List<MiniYamlNode>()
{
	new MiniYamlNode("Players", "invalid")
})));
```
after
```csharp
var yaml = MiniYaml.FromString(data);
```