### PR TITLE
Remove the 'docs' target from the windows make file

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -151,20 +151,6 @@ function Check-Scripts-Command
 	}
 }
 
-function Docs-Command
-{
-	if ((CheckForUtility) -eq 1)
-	{
-		return
-	}
-
-	./make.ps1 version
-	Invoke-Expression "$utilityPath all --docs" | Out-File -Encoding "UTF8" DOCUMENTATION.md
-	Invoke-Expression "$utilityPath all --weapon-docs" | Out-File -Encoding "UTF8" WEAPONS.md
-	Invoke-Expression "$utilityPath all --lua-docs" | Out-File -Encoding "UTF8" Lua-API.md
-	Invoke-Expression "$utilityPath all --settings-docs" | Out-File -Encoding "UTF8" Settings.md
-}
-
 function CheckForUtility
 {
 	if (Test-Path $utilityPath)
@@ -236,7 +222,6 @@ if ($args.Length -eq 0)
 	Write-Host "  test, t             Tests the default mods for errors."
 	Write-Host "  check, ck           Checks .cs files for StyleCop violations."
 	Write-Host "  check-scripts, cs   Checks .lua files for syntax errors."
-	Write-Host "  docs                Generates the trait and Lua API documentation."
 	Write-Host ""
 	$command = (Read-Host "Enter command").Split(' ', 2)
 }
@@ -262,7 +247,6 @@ switch ($execute)
 	{"test",          "t"  -contains $_} { Test-Command }
 	{"check",         "ck" -contains $_} { Check-Command }
 	{"check-scripts", "cs" -contains $_} { Check-Scripts-Command }
-	 "docs"                              { Docs-Command }
 	Default { Write-Host ("Invalid command '{0}'" -f $command) }
 }
 


### PR DESCRIPTION
See the discussion at https://github.com/OpenRA/OpenRAModSDK/pull/170#discussion_r567245435. Apparently nobody used the command in a long while and it only was "accidentally" fixed during our .NET 5 migration (but still fails on prep, although not for the same reason as in the SDK).