### PR TITLE
Update AppStream metadata for linux packaging

### DIFF
--- a/packaging/linux/openra.metainfo.xml.in
+++ b/packaging/linux/openra.metainfo.xml.in
@@ -49,6 +49,7 @@
   <content_rating type="oars-1.1">
     <content_attribute id="violence-realistic">moderate</content_attribute>
     <content_attribute id="violence-bloodshed">moderate</content_attribute>
+    <content_attribute id="violence-worship">moderate</content_attribute>
     <content_attribute id="drugs-tobacco">moderate</content_attribute>
     <content_attribute id="language-profanity">mild</content_attribute>
     <content_attribute id="language-humor">mild</content_attribute>

--- a/packaging/linux/openra.metainfo.xml.in
+++ b/packaging/linux/openra.metainfo.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="desktop">
+<component type="desktop-application">
   <id>openra-{MODID}.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0</project_license>
@@ -24,6 +24,7 @@
       OpenRA is 100% free, and comes bundled with three distinct mods. When you run a mod for the first time the game can automatically download the original game assets, or you can use the original game disks.
     </p>
   </description>
+  <launchable type="desktop-id">openra-{MODID}.desktop</launchable>
   <screenshots>
     <screenshot{SCREENSHOT_RA}>
       <image>http://www.openra.net/images/appdata/ingame-ra.png</image>
@@ -42,28 +43,15 @@
       <caption>Multiplayer lobby in the Tiberian Dawn mod</caption>
     </screenshot>
   </screenshots>
-  <url type="homepage">http://www.openra.net</url>
+  <url type="homepage">https://www.openra.net</url>
+  <url type="bugtracker">https://github.com/OpenRA/OpenRA/issues</url>
   <update_contact>paul_at_chote.net</update_contact>
-  <content_rating type="oars-1.0">
-    <content_attribute id="violence-cartoon">none</content_attribute>
-    <content_attribute id="violence-fantasy">none</content_attribute>
+  <content_rating type="oars-1.1">
     <content_attribute id="violence-realistic">moderate</content_attribute>
     <content_attribute id="violence-bloodshed">moderate</content_attribute>
-    <content_attribute id="violence-sexual">none</content_attribute>
-    <content_attribute id="drugs-alcohol">none</content_attribute>
-    <content_attribute id="drugs-narcotics">none</content_attribute>
     <content_attribute id="drugs-tobacco">moderate</content_attribute>
-    <content_attribute id="sex-nudity">none</content_attribute>
-    <content_attribute id="sex-themes">none</content_attribute>
     <content_attribute id="language-profanity">mild</content_attribute>
     <content_attribute id="language-humor">mild</content_attribute>
-    <content_attribute id="language-discrimination">none</content_attribute>
     <content_attribute id="social-chat">intense</content_attribute>
-    <content_attribute id="social-info">none</content_attribute>
-    <content_attribute id="social-audio">none</content_attribute>
-    <content_attribute id="social-location">none</content_attribute>
-    <content_attribute id="social-contacts">none</content_attribute>
-    <content_attribute id="money-purchasing">none</content_attribute>
-    <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
 </component>


### PR DESCRIPTION
A few small improvements:
* The type `desktop` was renamed to `desktop-appliaction` (a long time ago)
* Add `launchable` to tell how the application can be launched
* Use `https` for homepage link
* Add link to the bugtracker
* Update `oars-1.0` to `oars-1.1`
* Remove all unnecessary `content_attribute` entries with value `none`