### PR TITLE
Use version from VERSION file for install-linux-shortcuts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ endif
 	@sh -c '. ./packaging/functions.sh; install_data $(CWD) $(DESTDIR)$(gameinstalldir) cnc d2k ra'
 
 install-linux-shortcuts:
-	@sh -c '. ./packaging/functions.sh; install_linux_shortcuts $(CWD) "$(DESTDIR)" "$(gameinstalldir)" "$(bindir)" "$(datadir)" $(VERSION) cnc d2k ra'
+	@sh -c '. ./packaging/functions.sh; install_linux_shortcuts $(CWD) "$(DESTDIR)" "$(gameinstalldir)" "$(bindir)" "$(datadir)" "$(shell head -n1 VERSION)" cnc d2k ra'
 
 install-linux-appdata:
 	@sh -c '. ./packaging/functions.sh; install_linux_appdata $(CWD) "$(DESTDIR)" "$(datadir)" cnc d2k ra'


### PR DESCRIPTION
The `VERSION` variable doesn't work with a release tarball, because it requires git to be set correctly.
Instead this reads the version from the `VERSION` file.