### PR TITLE
Fix the gun sounds not playing in Allies05a

### DIFF
--- a/mods/ra/maps/allies-05a/weapons.yaml
+++ b/mods/ra/maps/allies-05a/weapons.yaml
@@ -5,3 +5,4 @@ PrisonColt:
 	Projectile: InstantHit
 	Warhead@1Dam: SpreadDamage
 		AffectsParent: true
+		ValidTargets: Ground, GroundActor

--- a/mods/ra/maps/allies-05a/weapons.yaml
+++ b/mods/ra/maps/allies-05a/weapons.yaml
@@ -1,6 +1,6 @@
 PrisonColt:
 	ValidTargets: Ground, GroundActor
-	ReloadDelay: 5
+	ReloadDelay: 7
 	Report: gun5.aud
 	Projectile: InstantHit
 	Warhead@1Dam: SpreadDamage


### PR DESCRIPTION
Closes #19111.

The default targets were missing the `GroundActor` type.