### PR TITLE
Add alpha support to sequences.

### DIFF
--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -55,12 +55,13 @@ namespace OpenRA.Graphics
 		public IRenderable[] Render(WPos pos, WVec offset, int zOffset, PaletteReference palette)
 		{
 			var tintModifiers = CurrentSequence.IgnoreWorldTint ? TintModifiers.IgnoreWorldTint : TintModifiers.None;
-			var imageRenderable = new SpriteRenderable(Image, pos, offset, CurrentSequence.ZOffset + zOffset, palette, CurrentSequence.Scale, IsDecoration, tintModifiers);
+			var alpha = CurrentSequence.GetAlpha(CurrentFrame);
+			var imageRenderable = new SpriteRenderable(Image, pos, offset, CurrentSequence.ZOffset + zOffset, palette, CurrentSequence.Scale, alpha, float3.Ones, tintModifiers, IsDecoration);
 
 			if (CurrentSequence.ShadowStart >= 0)
 			{
 				var shadow = CurrentSequence.GetShadow(CurrentFrame, facingFunc());
-				var shadowRenderable = new SpriteRenderable(shadow, pos, offset, CurrentSequence.ShadowZOffset + zOffset, palette, CurrentSequence.Scale, true, tintModifiers);
+				var shadowRenderable = new SpriteRenderable(shadow, pos, offset, CurrentSequence.ShadowZOffset + zOffset, palette, CurrentSequence.Scale, 1f, float3.Ones, tintModifiers, true);
 				return new IRenderable[] { shadowRenderable, imageRenderable };
 			}
 
@@ -72,7 +73,8 @@ namespace OpenRA.Graphics
 			scale *= CurrentSequence.Scale;
 			var screenOffset = (scale * wr.ScreenVectorComponents(offset)).XY.ToInt2();
 			var imagePos = pos + screenOffset - new int2((int)(scale * Image.Size.X / 2), (int)(scale * Image.Size.Y / 2));
-			var imageRenderable = new UISpriteRenderable(Image, WPos.Zero + offset, imagePos, CurrentSequence.ZOffset + zOffset, palette, scale);
+			var alpha = CurrentSequence.GetAlpha(CurrentFrame);
+			var imageRenderable = new UISpriteRenderable(Image, WPos.Zero + offset, imagePos, CurrentSequence.ZOffset + zOffset, palette, scale, alpha);
 
 			if (CurrentSequence.ShadowStart >= 0)
 			{

--- a/OpenRA.Game/Graphics/SequenceProvider.cs
+++ b/OpenRA.Game/Graphics/SequenceProvider.cs
@@ -38,6 +38,7 @@ namespace OpenRA.Graphics
 		Sprite GetSprite(int frame);
 		Sprite GetSprite(int frame, WAngle facing);
 		Sprite GetShadow(int frame, WAngle facing);
+		float GetAlpha(int frame);
 	}
 
 	public interface ISpriteSequenceLoader

--- a/OpenRA.Game/Graphics/SpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderable.cs
@@ -29,12 +29,6 @@ namespace OpenRA.Graphics
 		readonly float alpha;
 		readonly bool isDecoration;
 
-		public SpriteRenderable(Sprite sprite, WPos pos, WVec offset, int zOffset, PaletteReference palette, float scale, bool isDecoration)
-			: this(sprite, pos, offset, zOffset, palette, scale, 1f, float3.Ones, TintModifiers.None, isDecoration) { }
-
-		public SpriteRenderable(Sprite sprite, WPos pos, WVec offset, int zOffset, PaletteReference palette, float scale, bool isDecoration, TintModifiers tintModifiers)
-			: this(sprite, pos, offset, zOffset, palette, scale, 1f, float3.Ones, tintModifiers, isDecoration) { }
-
 		public SpriteRenderable(Sprite sprite, WPos pos, WVec offset, int zOffset, PaletteReference palette, float scale, float alpha, float3 tint, TintModifiers tintModifiers, bool isDecoration)
 		{
 			this.sprite = sprite;

--- a/OpenRA.Game/Graphics/UISpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/UISpriteRenderable.cs
@@ -21,8 +21,9 @@ namespace OpenRA.Graphics
 		readonly int zOffset;
 		readonly PaletteReference palette;
 		readonly float scale;
+		readonly float alpha;
 
-		public UISpriteRenderable(Sprite sprite, WPos effectiveWorldPos, int2 screenPos, int zOffset, PaletteReference palette, float scale)
+		public UISpriteRenderable(Sprite sprite, WPos effectiveWorldPos, int2 screenPos, int zOffset, PaletteReference palette, float scale = 1f, float alpha = 1f)
 		{
 			this.sprite = sprite;
 			this.effectiveWorldPos = effectiveWorldPos;
@@ -30,6 +31,7 @@ namespace OpenRA.Graphics
 			this.zOffset = zOffset;
 			this.palette = palette;
 			this.scale = scale;
+			this.alpha = alpha;
 		}
 
 		// Does not exist in the world, so a world positions don't make sense
@@ -40,7 +42,7 @@ namespace OpenRA.Graphics
 		public PaletteReference Palette { get { return palette; } }
 		public int ZOffset { get { return zOffset; } }
 
-		public IPalettedRenderable WithPalette(PaletteReference newPalette) { return new UISpriteRenderable(sprite, effectiveWorldPos, screenPos, zOffset, newPalette, scale); }
+		public IPalettedRenderable WithPalette(PaletteReference newPalette) { return new UISpriteRenderable(sprite, effectiveWorldPos, screenPos, zOffset, newPalette, scale, alpha); }
 		public IRenderable WithZOffset(int newOffset) { return this; }
 		public IRenderable OffsetBy(WVec vec) { return this; }
 		public IRenderable AsDecoration() { return this; }
@@ -48,7 +50,7 @@ namespace OpenRA.Graphics
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
 		public void Render(WorldRenderer wr)
 		{
-			Game.Renderer.SpriteRenderer.DrawSprite(sprite, screenPos, palette, scale * sprite.Size);
+			Game.Renderer.SpriteRenderer.DrawSprite(sprite, screenPos, palette, scale * sprite.Size, float3.Ones, alpha);
 		}
 
 		public void RenderDebugGeometry(WorldRenderer wr)

--- a/OpenRA.Mods.Cnc/Graphics/TeslaZapRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/TeslaZapRenderable.cs
@@ -149,7 +149,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 
 				var pos = wr.ProjectedPosition((z + new float2(step[2], step[3])).ToInt2());
 				var tintModifiers = s.IgnoreWorldTint ? TintModifiers.IgnoreWorldTint : TintModifiers.None;
-				rs.Add(new SpriteRenderable(s.GetSprite(step[4]), pos, WVec.Zero, 0, pal, 1f, true, tintModifiers).PrepareRender(wr));
+				rs.Add(new SpriteRenderable(s.GetSprite(step[4]), pos, WVec.Zero, 0, pal, 1f, s.GetAlpha(step[4]), float3.Ones, tintModifiers, true).PrepareRender(wr));
 
 				z += new float2(step[0], step[1]);
 				if (rs.Count >= 1000)

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -210,7 +210,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			return footprint.Select(c => (IRenderable)(new SpriteRenderable(
 				terrainRenderer.TileSprite(new TerrainTile(template, c.Value)),
-				wr.World.Map.CenterOfCell(c.Key), WVec.Zero, -offset, palette, 1f, true))).ToArray();
+				wr.World.Map.CenterOfCell(c.Key), WVec.Zero, -offset, palette, 1f, 1f,
+				float3.Ones, TintModifiers.None, true))).ToArray();
 		}
 
 		bool initialized;

--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!a.IsCanceling)
 					foreach (var n in a.TargetLineNodes(self))
 						if (n.Tile != null && n.Target.Type != TargetType.Invalid)
-							yield return new SpriteRenderable(n.Tile, n.Target.CenterPosition, WVec.Zero, -511, pal, 1f, true, TintModifiers.IgnoreWorldTint);
+							yield return new SpriteRenderable(n.Tile, n.Target.CenterPosition, WVec.Zero, -511, pal, 1f, 1f, float3.Ones, TintModifiers.IgnoreWorldTint, true);
 		}
 
 		bool IRenderAboveShroud.SpatiallyPartitionable { get { return false; } }

--- a/OpenRA.Mods.Common/Traits/Render/WithAmmoPipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAmmoPipsDecoration.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			for (var i = 0; i < pipCount; i++)
 			{
 				pips.PlayRepeating(currentAmmo * pipCount > i * totalAmmo ? Info.FullSequence : Info.EmptySequence);
-				yield return new UISpriteRenderable(pips.Image, self.CenterPosition, screenPos, 0, palette, 1f);
+				yield return new UISpriteRenderable(pips.Image, self.CenterPosition, screenPos, 0, palette);
 
 				screenPos += pipStride;
 			}

--- a/OpenRA.Mods.Common/Traits/Render/WithCargoPipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithCargoPipsDecoration.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			for (var i = 0; i < pipCount; i++)
 			{
 				pips.PlayRepeating(GetPipSequence(i));
-				yield return new UISpriteRenderable(pips.Image, self.CenterPosition, screenPos, 0, palette, 1f);
+				yield return new UISpriteRenderable(pips.Image, self.CenterPosition, screenPos, 0, palette);
 
 				screenPos += pipStride;
 			}

--- a/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			return new IRenderable[]
 			{
-				new UISpriteRenderable(anim.Image, self.CenterPosition, screenPos - (0.5f * anim.Image.Size.XY).ToInt2(), 0, GetPalette(self, wr), 1f)
+				new UISpriteRenderable(anim.Image, self.CenterPosition, screenPos - (0.5f * anim.Image.Size.XY).ToInt2(), 0, GetPalette(self, wr))
 			};
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvesterPipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvesterPipsDecoration.cs
@@ -89,7 +89,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			for (var i = 0; i < Info.PipCount; i++)
 			{
 				pips.PlayRepeating(GetPipSequence(i));
-				yield return new UISpriteRenderable(pips.Image, self.CenterPosition, screenPos, 0, palette, 1f);
+				yield return new UISpriteRenderable(pips.Image, self.CenterPosition, screenPos, 0, palette);
 
 				screenPos += pipStride;
 			}

--- a/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
@@ -180,8 +180,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var dat = self.World.Map.DistanceAboveTerrain(self.CenterPosition);
 			var pos = self.CenterPosition - new WVec(0, 0, dat.Length);
 			var palette = wr.Palette(info.Palette);
+			var alpha = shadow.CurrentSequence.GetAlpha(shadow.CurrentFrame);
 			var tintModifiers = shadow.CurrentSequence.IgnoreWorldTint ? TintModifiers.ReplaceColor | TintModifiers.IgnoreWorldTint : TintModifiers.ReplaceColor;
-			return new IRenderable[] { new SpriteRenderable(shadow.Image, pos, info.ShadowOffset, info.ShadowZOffset, palette, 1, shadowAlpha, shadowColor, tintModifiers, true) };
+			return new IRenderable[] { new SpriteRenderable(shadow.Image, pos, info.ShadowOffset, info.ShadowZOffset, palette, 1, shadowAlpha * alpha, shadowColor, tintModifiers, true) };
 		}
 
 		IEnumerable<Rectangle> IRender.ScreenBounds(Actor self, WorldRenderer wr)

--- a/OpenRA.Mods.Common/Traits/Render/WithResourceStoragePipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResourceStoragePipsDecoration.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			for (var i = 0; i < Info.PipCount; i++)
 			{
 				pips.PlayRepeating(player.Resources * Info.PipCount > i * player.ResourceCapacity ? Info.FullSequence : Info.EmptySequence);
-				yield return new UISpriteRenderable(pips.Image, self.CenterPosition, screenPos, 0, palette, 1f);
+				yield return new UISpriteRenderable(pips.Image, self.CenterPosition, screenPos, 0, palette);
 
 				screenPos += pipStride;
 			}

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var palette = wr.Palette(Info.Palette);
 			return new IRenderable[]
 			{
-				new UISpriteRenderable(anim.Image, self.CenterPosition, screenPos, 0, palette, 1f)
+				new UISpriteRenderable(anim.Image, self.CenterPosition, screenPos, 0, palette)
 			};
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
@@ -110,6 +110,7 @@ namespace OpenRA.Mods.Common.Traits
 			readonly char[] footprint;
 			readonly CVec dimensions;
 			readonly Sprite tile;
+			readonly float alpha;
 			readonly SupportPowerManager manager;
 			readonly string order;
 
@@ -124,7 +125,10 @@ namespace OpenRA.Mods.Common.Traits
 				this.power = power;
 				footprint = power.info.Footprint.Where(c => !char.IsWhiteSpace(c)).ToArray();
 				dimensions = power.info.Dimensions;
-				tile = world.Map.Rules.Sequences.GetSequence("overlay", "target-select").GetSprite(0);
+
+				var sequence = world.Map.Rules.Sequences.GetSequence("overlay", "target-select");
+				tile = sequence.GetSprite(0);
+				alpha = sequence.GetAlpha(0);
 			}
 
 			protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
@@ -161,7 +165,7 @@ namespace OpenRA.Mods.Common.Traits
 				var pal = wr.Palette(TileSet.TerrainPaletteInternalName);
 
 				foreach (var t in power.CellsMatching(xy, footprint, dimensions))
-					yield return new SpriteRenderable(tile, wr.World.Map.CenterOfCell(t), WVec.Zero, -511, pal, 1f, true, TintModifiers.IgnoreWorldTint);
+					yield return new SpriteRenderable(tile, wr.World.Map.CenterOfCell(t), WVec.Zero, -511, pal, 1f, alpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
 			}
 
 			protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)

--- a/OpenRA.Mods.Common/Traits/World/EditorCursorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorCursorLayer.cs
@@ -81,9 +81,10 @@ namespace OpenRA.Mods.Common.Traits
 						var sequence = wr.World.Map.Rules.Sequences.GetSequence("resources", variant);
 						var sprite = sequence.GetSprite(Resource.MaxDensity - 1);
 						var palette = wr.Palette(Resource.Palette);
+						var alpha = sequence.GetAlpha(Resource.MaxDensity - 1);
 
 						var tintModifiers = sequence.IgnoreWorldTint ? TintModifiers.IgnoreWorldTint : TintModifiers.None;
-						terrainOrResourcePreview.Add(new SpriteRenderable(sprite, pos, WVec.Zero, 0, palette, 1, false, tintModifiers));
+						terrainOrResourcePreview.Add(new SpriteRenderable(sprite, pos, WVec.Zero, 0, palette, 1f, alpha, float3.Ones, tintModifiers, false));
 					}
 				}
 			}

--- a/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
@@ -43,8 +43,8 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly EditorSelectionLayerInfo info;
 		readonly Map map;
-		readonly Sprite copySprite;
-		readonly Sprite pasteSprite;
+		readonly Sprite copyTile, pasteTile;
+		readonly float copyAlpha, pasteAlpha;
 		PaletteReference palette;
 
 		public CellRegion CopyRegion { get; private set; }
@@ -57,8 +57,14 @@ namespace OpenRA.Mods.Common.Traits
 
 			this.info = info;
 			map = self.World.Map;
-			copySprite = map.Rules.Sequences.GetSequence(info.Image, info.CopySequence).GetSprite(0);
-			pasteSprite = map.Rules.Sequences.GetSequence(info.Image, info.PasteSequence).GetSprite(0);
+
+			var copySequence = map.Rules.Sequences.GetSequence(info.Image, info.CopySequence);
+			copyTile = copySequence.GetSprite(0);
+			copyAlpha = copySequence.GetAlpha(0);
+
+			var pasteSequence = map.Rules.Sequences.GetSequence(info.Image, info.PasteSequence);
+			pasteTile = pasteSequence.GetSprite(0);
+			pasteAlpha = pasteSequence.GetAlpha(0);
 		}
 
 		void IWorldLoaded.WorldLoaded(World w, WorldRenderer wr)
@@ -91,13 +97,13 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (CopyRegion != null)
 				foreach (var c in CopyRegion)
-					yield return new SpriteRenderable(copySprite, wr.World.Map.CenterOfCell(c),
-						WVec.Zero, -511, palette, 1f, info.FootprintAlpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
+					yield return new SpriteRenderable(copyTile, wr.World.Map.CenterOfCell(c),
+							WVec.Zero, -511, palette, 1f, copyAlpha * info.FootprintAlpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
 
 			if (PasteRegion != null)
 				foreach (var c in PasteRegion)
-					yield return new SpriteRenderable(pasteSprite, wr.World.Map.CenterOfCell(c),
-						WVec.Zero, -511, palette, 1f, info.FootprintAlpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
+					yield return new SpriteRenderable(pasteTile, wr.World.Map.CenterOfCell(c),
+						WVec.Zero, -511, palette, 1f, pasteAlpha * info.FootprintAlpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
 		}
 
 		bool IRenderAboveShroud.SpatiallyPartitionable { get { return false; } }

--- a/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
@@ -203,7 +203,7 @@ namespace OpenRA.Mods.Common.Traits
 					var offset = map.Offset(new CVec(x, y), tileInfo.Height);
 					var palette = wr.Palette(template.Palette ?? TileSet.TerrainPaletteInternalName);
 
-					yield return new SpriteRenderable(sprite, origin, offset, 0, palette, 1, false);
+					yield return new SpriteRenderable(sprite, origin, offset, 0, palette, 1f, 1f, float3.Ones, TintModifiers.None, false);
 				}
 			}
 		}

--- a/mods/ts/maps/ThePit/map.yaml
+++ b/mods/ts/maps/ThePit/map.yaml
@@ -1256,9 +1256,9 @@ Actors:
 		Location: 94,-51
 
 Rules:
-	World:
-		GlobalLightingPaletteEffect:
-			Red: 1.2
-			Green: 1.2
-			Blue: 0.8
-			Ambient: 0.7
+	^BaseWorld:
+		TerrainLighting:
+			RedTint: 1.2
+			GreenTint: 1.2
+			BlueTint: 0.8
+			Intensity: 0.7

--- a/mods/ts/rules/civilian-vehicles.yaml
+++ b/mods/ts/rules/civilian-vehicles.yaml
@@ -24,7 +24,6 @@
 		Weapon: 120mmx
 		LocalOffset: 707,85,509, 707,-120,509
 		MuzzleSequence: muzzle
-		MuzzlePalette: effect-ignore-lighting
 	Armament@SECONDARY:
 		Weapon: MammothTusk
 		LocalOffset: 0,283,580, 0,-283,580

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -473,7 +473,6 @@ GAPLUG:
 		Icon: ioncannon
 		Effect: explosion
 		EffectSequence: ionring
-		EffectPalette: effectalpha75
 		WeaponDelay: 0
 		ChargeInterval: 12750
 		Description: Ion Cannon

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -96,14 +96,12 @@ GACTWR:
 		Weapon: VulcanTower
 		LocalOffset: 588,120,1358
 		MuzzleSequence: muzzle
-		MuzzlePalette: effect-ignore-lighting
 	Armament@VULCSECONDARY:
 		RequiresCondition: tower.vulcan
 		Name: secondary
 		Weapon: VulcanTower
 		LocalOffset: 588,-120,1358
 		MuzzleSequence: muzzle
-		MuzzlePalette: effect-ignore-lighting
 	Armament@ROCKET:
 		RequiresCondition: tower.rocket
 		Weapon: RPGTower

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -197,7 +197,6 @@ MMCH:
 	Armament:
 		Weapon: 120mm
 		MuzzleSequence: muzzle
-		MuzzlePalette: effect-ignore-lighting
 		Recoil: 128
 		RecoilRecovery: 32
 		LocalOffset: 1024,272,1216
@@ -408,7 +407,6 @@ JUGG:
 		LocalOffset: 820,203,1386, 820,0,1386, 820,-203,1386
 		RequiresCondition: deployed
 		MuzzleSequence: muzzle
-		MuzzlePalette: effect-ignore-lighting
 	WithMuzzleOverlay:
 	RevealOnFire:
 		ArmamentNames: deployed

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -493,7 +493,6 @@ NAMISL:
 		CameraRange: 10c0
 		FlightVelocity: 1c0
 		TrailImage: small_smoke_trail
-		TrailPalette: effectalpha75
 		TrailInterval: 0
 		TrailSequences: idle
 	WithSupportPowerActivationOverlay:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -29,7 +29,6 @@ BGGY:
 		Weapon: RaiderCannon
 		LocalOffset: 0,-61,543, 0,61,543
 		MuzzleSequence: muzzle
-		MuzzlePalette: effect-ignore-lighting
 	AttackFrontal:
 		Voice: Attack
 		PauseOnCondition: empdisable
@@ -115,13 +114,11 @@ TTNK:
 		LocalOffset: 407,0,362
 		RequiresCondition: !rank-elite
 		MuzzleSequence: muzzle
-		MuzzlePalette: effect-ignore-lighting
 	Armament@ELITE:
 		Weapon: 120mmx
 		LocalOffset: 407,0,362
 		RequiresCondition: rank-elite
 		MuzzleSequence: muzzle
-		MuzzlePalette: effect-ignore-lighting
 	WithMuzzleOverlay:
 	RevealsShroud:
 		RequiresCondition: !inside-tunnel
@@ -184,7 +181,6 @@ TTNK:
 		LocalOffset: 543,0,362
 		RequiresCondition: !rank-elite
 		MuzzleSequence: muzzle
-		MuzzlePalette: effect-ignore-lighting
 	Armament@deployedElite:
 		Name: deployed
 		Turret: deployed
@@ -192,7 +188,6 @@ TTNK:
 		LocalOffset: 543,0,362
 		RequiresCondition: rank-elite
 		MuzzleSequence: muzzle
-		MuzzlePalette: effect-ignore-lighting
 	Armor@deployed:
 		Type: Concrete
 		RequiresCondition: deployed
@@ -296,7 +291,6 @@ ART2:
 		LocalOffset: 820,0,1386
 		RequiresCondition: deployed
 		MuzzleSequence: muzzle
-		MuzzlePalette: effect-ignore-lighting
 	WithMuzzleOverlay:
 	RevealOnFire:
 		ArmamentNames: deployed

--- a/mods/ts/rules/palettes.yaml
+++ b/mods/ts/rules/palettes.yaml
@@ -111,5 +111,3 @@
 		Name: terrainalpha
 		Alpha: 0.55
 	MenuPaletteEffect:
-	GlobalLightingPaletteEffect:
-		ExcludePalettes: cursor, chrome, colorpicker, fog, shroud, alpha, greentiberium, bluetiberium

--- a/mods/ts/rules/palettes.yaml
+++ b/mods/ts/rules/palettes.yaml
@@ -55,33 +55,6 @@
 	PaletteFromFile@effect:
 		Name: effect
 		Filename: anim.pal
-	PaletteFromFile@effect-nolite:
-		Name: effect-ignore-lighting
-		Filename: anim.pal
-	PaletteFromPaletteWithAlpha@effectalpha25:
-		Name: effectalpha25
-		Alpha: 0.25
-		BasePalette: effect
-	PaletteFromPaletteWithAlpha@effectalpha50:
-		Name: effectalpha50
-		Alpha: 0.5
-		BasePalette: effect
-	PaletteFromPaletteWithAlpha@effectalpha75:
-		Name: effectalpha75
-		Alpha: 0.75
-		BasePalette: effect
-	PaletteFromPaletteWithAlpha@effect-nolite-alpha25:
-		Name: effect-ignore-lighting-alpha25
-		Alpha: 0.25
-		BasePalette: effect-ignore-lighting
-	PaletteFromPaletteWithAlpha@effect-nolite-alpha50:
-		Name: effect-ignore-lighting-alpha50
-		Alpha: 0.5
-		BasePalette: effect-ignore-lighting
-	PaletteFromPaletteWithAlpha@effect-nolite-alpha75:
-		Name: effect-ignore-lighting-alpha75
-		Alpha: 0.75
-		BasePalette: effect-ignore-lighting
 	PaletteFromFile@sidebar:
 		Name: sidebar
 		Filename: sidebar-nod|sidebar.pal
@@ -139,4 +112,4 @@
 		Alpha: 0.55
 	MenuPaletteEffect:
 	GlobalLightingPaletteEffect:
-		ExcludePalettes: cursor, chrome, colorpicker, fog, shroud, alpha, effect-ignore-lighting, effect-ignore-lighting-alpha25, effect-ignore-lighting-alpha50, effect-ignore-lighting-alpha75, greentiberium, bluetiberium
+		ExcludePalettes: cursor, chrome, colorpicker, fog, shroud, alpha, greentiberium, bluetiberium

--- a/mods/ts/sequences/civilian.yaml
+++ b/mods/ts/sequences/civilian.yaml
@@ -635,6 +635,7 @@ gaspot:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 	icon: spoticon
 		Offset: 0, 0
 		UseTilesetCode: false
@@ -665,6 +666,7 @@ galite:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 	icon: liteicon
 		Offset: 0, 0
 		-DepthSprite:

--- a/mods/ts/sequences/critters.yaml
+++ b/mods/ts/sequences/critters.yaml
@@ -46,6 +46,7 @@ doggie:
 		Start: 109
 		Length: 10
 		ShadowStart: 228
+		IgnoreWorldTint: True
 	die-melting:
 		Start: 109
 		Length: 10

--- a/mods/ts/sequences/infantry.yaml
+++ b/mods/ts/sequences/infantry.yaml
@@ -221,6 +221,7 @@ cyborg:
 		Length: *
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 	icon: cybiicon
 
 cyc2:
@@ -267,6 +268,7 @@ cyc2:
 		Length: *
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 	icon: cybcicon
 
 medic:
@@ -482,6 +484,7 @@ flameguy:
 		Tick: 80
 		ShadowStart: 148
 		Offset: 0, 0, 16
+		IgnoreWorldTint: True
 	idle:
 	stand:
 	run:
@@ -491,3 +494,4 @@ flameguy:
 		Facings: 1
 		Length: 104
 		ShadowStart: 192
+		AlphaFade: True

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -134,46 +134,65 @@ explosion:
 		Length: *
 		ZOffset: 511
 		Offset: 0, 0, 24
+		AlphaFade: True
+		IgnoreWorldTint: True
 	building: twlt070
 		Offset: 0, 0, 36
 	ionring: ring1
 		ZRamp: 1
 		Tick: 100
+		IgnoreWorldTint: False
 	ionbeam: ionbeam
 		Offset: 0, -60, 60
 		ZRamp: 1
 		Tick: 100
+		IgnoreWorldTint: False
 	ionbeam2: ionbeam
 		Offset: 0, -180, 60
 		ZRamp: 1
 		Tick: 100
+		IgnoreWorldTint: False
 	ionbeam3: ionbeam
 		Offset: 0, -300, 60
 		ZRamp: 1
 		Tick: 100
+		IgnoreWorldTint: False
 	ionbeam4: ionbeam
 		Offset: 0, -420, 60
 		ZRamp: 1
 		Tick: 100
+		IgnoreWorldTint: False
 	ionbeam5: ionbeam
 		Offset: 0, -540, 60
 		ZRamp: 1
 		Tick: 100
+		IgnoreWorldTint: False
 	ionbeam6: ionbeam
 		Offset: 0, -660, 60
 		ZRamp: 1
 		Tick: 100
+		IgnoreWorldTint: False
 	pulse_explosion: pulsefx2
 		BlendMode: Additive
 		ZRamp: 1
 		Tick: 80
 	small_watersplash: h2o_exp2
+		IgnoreWorldTint: False
+		AlphaFade: False
+		Alpha: 0.5
 	large_watersplash: h2o_exp1
 		Offset: 0, 0, 39
+		IgnoreWorldTint: False
+		AlphaFade: False
+		Alpha: 0.5
 	water_piff: w_piff
+		IgnoreWorldTint: False
 	water_piffs: w_piffs
+		IgnoreWorldTint: False
 	piff: piff
+		IgnoreWorldTint: False
 	piffs: piffpiff
+		IgnoreWorldTint: False
 	small_explosion: explosml
 	medium_explosion: explomed
 		Offset: 0, 0, 27
@@ -208,21 +227,29 @@ explosion:
 	verylarge_twlt: twlt100
 		Offset: 0, 0, 51
 	tiny_grey_explosion: xgrysml1
+		IgnoreWorldTint: False
 	small_grey_explosion: xgrysml2
+		IgnoreWorldTint: False
 	medium_grey_explosion: xgrymed1
+		IgnoreWorldTint: False
 	large_grey_explosion: xgrymed2
+		IgnoreWorldTint: False
 	droppod_explosion: droppod
 		Length: 8
 		Tick: 360
+		IgnoreWorldTint: False
 	droppod2_explosion: droppod2
 		Length: 8
 		Tick: 360
+		IgnoreWorldTint: False
 	droppody_explosion: droppody
 		Length: 8
 		Tick: 360
+		IgnoreWorldTint: False
 	droppody2_explosion: droppody2
 		Length: 8
 		Tick: 360
+		IgnoreWorldTint: False
 
 discus:
 	idle:
@@ -267,6 +294,7 @@ torpedo:
 		Length: *
 		ZOffset: 1023
 		Offset: 0, 0, 8
+		IgnoreWorldTint: True
 
 flameall:
 	idle:
@@ -275,50 +303,64 @@ flameall:
 		Tick: 160
 		ZOffset: 1023
 		Offset: 0, 0, 24
+		IgnoreWorldTint: True
+		Alpha: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1
 
 largesmoke:
 	idle: lgrysmk1
 		Length: *
 		ZOffset: 1023
 		Offset: 0, 0, 24
+		AlphaFade: True
 
 smallsmoke:
 	idle: sgrysmk1
 		Length: *
 		ZOffset: 1023
 		Offset: 0, 0, 24
+		AlphaFade: True
 
 large_smoke_trail:
 	idle: smokey
 		Length: *
 		ZOffset: 1023
 		Offset: 0, 0, 24
+		AlphaFade: True
 
 small_smoke_trail:
 	idle: smokey2
 		Length: *
 		ZOffset: 1023
 		Offset: 0, 0, 24
+		AlphaFade: True
 
 largefire:
 	idle: fire1
 		Length: *
 		Offset: 0, 0, 36
+		Alpha: 0.5
+		IgnoreWorldTint: True
 
 mediumfire:
 	idle: fire2
 		Length: *
 		Offset: 0, 0, 24
+		Alpha: 0.5
+		IgnoreWorldTint: True
 
 smallfire:
 	idle: fire3
 		Length: *
 		Offset: 0, 0, 24
+		Alpha: 0.5
+		IgnoreWorldTint: True
 
 tinyfire:
 	idle: fire4
 		Length: *
 		Offset: 0, 0, 24
+		Alpha: 0.75
+		IgnoreWorldTint: True
 
 moveflsh:
 	idle: ring
@@ -327,6 +369,7 @@ moveflsh:
 		ZOffset: 2047
 		Offset: 0, 0, 48
 		ZRamp: 1
+		AlphaFade: True
 
 wake:
 	idle: wake2
@@ -335,7 +378,7 @@ wake:
 		ZOffset: -512
 		ZRamp: 1
 		Offset: 0, 0, 1
-		BlendMode: Translucent
+		AlphaFade: True
 
 resources:
 	Defaults:
@@ -675,3 +718,4 @@ podring:
 	idle:
 		Frames: 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
 		Length: *
+		AlphaFade: True

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -47,6 +47,7 @@ gacnst:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: facticon
 		Offset: 0,0
@@ -105,6 +106,7 @@ gapowr:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: powricon
 		Offset: 0, 0
@@ -165,6 +167,7 @@ gapile:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: brrkicon
 		Offset: 0, 0
@@ -253,6 +256,7 @@ gaweap:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: weapicon
 		Offset: 0, 0
@@ -289,6 +293,7 @@ napowr:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: npwricon
 		Offset: 0, 0, 25
@@ -326,6 +331,7 @@ naapwr:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: apwricon
 		Offset: 0, 0
@@ -372,6 +378,7 @@ nahand:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: handicon
 		Offset: 0, 0
@@ -455,6 +462,7 @@ naweap:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: nwepicon
 		Offset: 0, 0
@@ -491,6 +499,7 @@ naradr:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: nradicon
 		Offset: 0, 0
@@ -526,6 +535,7 @@ natech:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: ntchicon
 		Offset: 0, 0
@@ -563,6 +573,7 @@ natmpl:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: tmplicon
 		Offset: 0, 0
@@ -601,6 +612,7 @@ garadr:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: radricon
 		Offset: 0, 0
@@ -638,6 +650,7 @@ gatech:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: techicon
 		Offset: 0, 0
@@ -717,6 +730,7 @@ gagate_a:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: gateicon
 		Offset: 0, 0
@@ -758,6 +772,7 @@ gagate_b:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: gat2icon
 		Offset: 0, 0
@@ -804,6 +819,7 @@ nagate_a:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: ngaticon
 		Offset: 0, 0
@@ -846,6 +862,7 @@ nagate_b:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: nga2icon
 		Offset: 0, 0
@@ -897,6 +914,7 @@ napost:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: lasricon
 		Offset: 0, 0
@@ -934,6 +952,7 @@ nafnce:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 
 nawall:
@@ -974,6 +993,7 @@ gaicbm:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	make: gaicbmmk
 		Length: 30
@@ -1009,6 +1029,7 @@ naobel:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: obliicon
 		Offset: 0, 0
@@ -1038,6 +1059,7 @@ nalasr:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: plticon
 		Offset: 0, 0
@@ -1075,6 +1097,7 @@ nasam:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 	icon: samicon
 		Offset: 0, 0
 		UseTilesetCode: false
@@ -1135,6 +1158,8 @@ napuls.nod:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: sidebar-nod|empicon
 		Offset: 0, 0
@@ -1172,6 +1197,7 @@ nastlh:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: clckicon
 		Offset: 0, 0
@@ -1232,12 +1258,14 @@ gactwr:
 		Length: 6
 		Offset: 0, 0, 12
 		UseTilesetCode: false
+		IgnoreWorldTint: True
 	emp-overlay: emp_fx01
 		Length: *
 		Offset: 0, 0, 13
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: towricon
 		Offset: 0, 0
@@ -1329,6 +1357,7 @@ gahpad:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 	icon: heliicon
 		Offset: 0, 0
 		UseTilesetCode: false
@@ -1394,6 +1423,7 @@ nahpad:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 	icon: nhpdicon
 		Offset: 0, 0
 		UseTilesetCode: false
@@ -1453,6 +1483,7 @@ proc.gdi:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: sidebar-gdi|reficon
 		Offset: 0, 0
@@ -1514,6 +1545,7 @@ proc.nod:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: sidebar-nod|reficon
 		Offset: 0, 0
@@ -1579,6 +1611,7 @@ nawast:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: wasticon
 		Offset: 0, 0
@@ -1626,6 +1659,7 @@ gasilo.gdi:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: sidebar-gdi|siloicon
 		Offset: 0, 0
@@ -1673,6 +1707,7 @@ gasilo.nod:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: sidebar-nod|siloicon
 		Offset: 0, 0
@@ -1772,6 +1807,7 @@ gadept.gdi:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 	icon: sidebar-gdi|fixicon
 		Offset: 0, 0
 		UseTilesetCode: false
@@ -1869,6 +1905,7 @@ gadept.nod:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 	icon: sidebar-nod|fixicon
 		Offset: 76, 66
 		UseTilesetCode: false
@@ -1907,6 +1944,7 @@ namisl:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: msslicon
 		Offset: 0, 0
@@ -1983,6 +2021,7 @@ gaplug:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
+		IgnoreWorldTint: True
 		-DepthSprite:
 	icon: plugicon
 		Offset: 0, 0

--- a/mods/ts/sequences/vehicles.yaml
+++ b/mods/ts/sequences/vehicles.yaml
@@ -3,6 +3,7 @@
 		Offset: 0, 0, 24
 		Length: *
 		BlendMode: Additive
+		IgnoreWorldTint: True
 
 mcv.gdi:
 	Inherits: ^VehicleOverlays
@@ -40,6 +41,7 @@ hvr:
 	Inherits: ^VehicleOverlays
 	muzzle: gunfire
 		Length: *
+		IgnoreWorldTint: True
 
 lpst.gdi:
 	Inherits: ^VehicleOverlays
@@ -89,6 +91,7 @@ art2:
 	muzzle: gunfire
 		Length: *
 		Offset: 0, 0, 24
+		IgnoreWorldTint: True
 
 weed:
 	Inherits: ^VehicleOverlays
@@ -126,6 +129,7 @@ bggy:
 				Length: 6
 		Facings: 8
 		Length: 6
+		IgnoreWorldTint: True
 	icon: bggyicon
 		Offset: 0, 0
 
@@ -157,6 +161,7 @@ ttnk:
 	muzzle: gunfire
 		Length: *
 		Offset: 0, 0, 24
+		IgnoreWorldTint: True
 	icon: tickicon
 
 stnk:
@@ -183,6 +188,7 @@ mmch:
 	muzzle: gunfire
 		Length: *
 		Offset: 0, 0, 12
+		IgnoreWorldTint: True
 	icon: mmchicon
 
 jugg:
@@ -216,6 +222,7 @@ jugg:
 	muzzle: gunfire
 		Length: *
 		Offset: 0, 0, 24
+		IgnoreWorldTint: True
 
 gghunt:
 	Inherits: ^VehicleOverlays

--- a/mods/ts/weapons/ballisticweapons.yaml
+++ b/mods/ts/weapons/ballisticweapons.yaml
@@ -21,7 +21,6 @@
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: medium_clsn
-		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew14.aud
 		ValidTargets: Ground, Air
 	Warhead@3EffWater: CreateEffect

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -99,7 +99,6 @@ SonicZap:
 		ValidTargets: Ground
 	Warhead@2Eff: CreateEffect
 		Explosions: large_explosion
-		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew12.aud
 		ValidTargets: Ground, Air
 	Warhead@3EffWater: CreateEffect

--- a/mods/ts/weapons/explosions.yaml
+++ b/mods/ts/weapons/explosions.yaml
@@ -11,7 +11,6 @@
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: large_brnl, large_bang, medium_twlt
-		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew09.aud, expnew10.aud, expnew12.aud
 	Warhead@4Smu: LeaveSmudge
 		SmudgeType: MediumCrater
@@ -35,7 +34,6 @@ UnitExplodeSmall:
 BuildingExplosions:
 	Warhead@1Eff: CreateEffect
 		Explosions: building, large_bang, large_brnl, verylarge_clsn, large_tumu
-		ExplosionPalette: effect-ignore-lighting-alpha75
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: MediumCrater
 
@@ -43,7 +41,6 @@ CyborgExplode:
 	Warhead@1Eff: CreateEffect
 		Explosions: medium_bang
 		ImpactSounds: expnew10.aud
-		ExplosionPalette: effect-ignore-lighting-alpha75
 
 TiberiumExplosion:
 	Inherits: ^DamagingExplosion
@@ -56,7 +53,6 @@ TiberiumExplosion:
 		Size: 1,1
 	Warhead@2Eff: CreateEffect
 		Explosions: large_explosion
-		ExplosionPalette: effect-ignore-lighting-alpha75
 	-Warhead@4Smu:
 
 Demolish:
@@ -64,10 +60,8 @@ Demolish:
 		DamageTypes: DefaultDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: large_twlt
-		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew09.aud
 
 DropPodExplode:
 	Warhead@1Eff: CreateEffect
 		Explosions: droppod_explosion, droppod2_explosion, droppody_explosion, droppody2_explosion
-		ExplosionPalette: effect-ignore-lighting-alpha75

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -10,7 +10,6 @@
 		Inaccuracy: 128
 		Image: DRAGON
 		TrailImage: small_smoke_trail
-		TrailPalette: effectalpha75
 		HorizontalRateOfTurn: 100
 		RangeLimit: 15c0
 		Palette: ra
@@ -37,7 +36,6 @@
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: small_clsn
-		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew12.aud
 		ValidTargets: Ground, Air
 	Warhead@3EffWater: CreateEffect

--- a/mods/ts/weapons/otherweapons.yaml
+++ b/mods/ts/weapons/otherweapons.yaml
@@ -48,7 +48,6 @@ Bomb:
 		DamageTypes: Prone100Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: large_explosion
-		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew09.aud
 		ValidTargets: Ground, Air
 	Warhead@3EffWater: CreateEffect
@@ -152,7 +151,6 @@ Veins:
 		DamageTypes: Prone100Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: tiny_twlt
-		ExplosionPalette: effect-ignore-lighting-alpha75
 		ValidTargets: Ground, Air
 	Warhead@3EffWater: CreateEffect
 		Explosions: small_watersplash

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -44,7 +44,6 @@ ClusterMissile:
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@SoundEffect: CreateEffect
 		Explosions: large_twlt
-		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew19.aud
 		ImpactActors: false
 		ValidTargets: Ground, Water, Air
@@ -91,28 +90,22 @@ IonCannon:
 		Delay: 3
 	Warhead@4Effect: CreateEffect
 		Explosions: ionbeam
-		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: ion1.aud
 		ImpactActors: false
 	Warhead@5Effect: CreateEffect
 		Explosions: ionbeam2
-		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactActors: false
 	Warhead@6Effect: CreateEffect
 		Explosions: ionbeam3
-		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactActors: false
 	Warhead@7Effect: CreateEffect
 		Explosions: ionbeam4
-		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactActors: false
 	Warhead@8Effect: CreateEffect
 		Explosions: ionbeam5
-		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactActors: false
 	Warhead@9Effect: CreateEffect
 		Explosions: ionbeam6
-		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactActors: false
 
 EMPulseCannon:
@@ -127,7 +120,6 @@ EMPulseCannon:
 		Image: pulsball
 	Warhead@1Eff: CreateEffect
 		Explosions: pulse_explosion
-		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactActors: false
 	Warhead@emp: GrantExternalCondition
 		Range: 6c0


### PR DESCRIPTION
The first commit introduces `Alpha` and `AlphaFade` properties to the default sequence parsers, implementing the behaviour needed for TS. The second commit fixes all of TS's animations that I could find wrong to match the original game (art.ini `Translucent` &rarr; `AlphaFade`, `Translucency` &rarr; `Alpha`, `UseNormalLight` &rarr; `IgnoreWorldTint`).

Fixes #10727.

I decided against adding the proposed dictionary style overrides in this PR in . This would have added a lot of complexity that i'm not convinced is justified, and was the main thing stopping me from wanting to implement this earlier. We can perhaps revisit that in the future if the behaviours implemented here turn out to be insufficient.

A second PR (which depends on #19090) will extend this to work with `TerrainSpriteLayer`s, which is needed for rendering the fog with the remastered assets.