### PR TITLE
BarrelExplode visual improvements

### DIFF
--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -152,7 +152,7 @@ BarrelExplode:
 			Wood: 100
 			Light: 50
 			Concrete: 10
-		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath, Incendiary
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@2Eff: CreateEffect
 		Explosions: napalm
 		ImpactSounds: firebl3.aud

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -154,7 +154,7 @@ BarrelExplode:
 			Concrete: 10
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@2Eff: CreateEffect
-		Explosions: napalm
+		Explosions: large_napalm
 		ImpactSounds: firebl3.aud
 		Delay: 5
 	-Warhead@3EffWater:


### PR DESCRIPTION
Switches barrels to use `FireDeath` and `large_napalm`. This touches on what I want to do with #19079 which, afaik, will require some plumbing in `CreateEffectWarhead` to allow effects offset from the source.