### PR TITLE
Rename remaining Stance references to PlayerRelationship.

### DIFF
--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -265,7 +265,7 @@ namespace OpenRA
 			return RelationshipWith(p) == PlayerRelationship.Ally;
 		}
 
-		public Color PlayerStanceColor(Actor a)
+		public Color PlayerRelationshipColor(Actor a)
 		{
 			var player = a.World.RenderPlayer ?? a.World.LocalPlayer;
 			if (player != null && !player.Spectating)

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -76,12 +76,12 @@ namespace OpenRA.Traits
 		Ally = 4,
 	}
 
-	public static class StanceExts
+	public static class PlayerRelationshipExts
 	{
-		public static bool HasStance(this PlayerRelationship s, PlayerRelationship stance)
+		public static bool HasRelationship(this PlayerRelationship r, PlayerRelationship relationship)
 		{
 			// PERF: Enum.HasFlag is slower and requires allocations.
-			return (s & stance) == stance;
+			return (r & relationship) == relationship;
 		}
 	}
 

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -167,7 +167,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (!Disguised || self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				return color;
 
-			return color = Game.Settings.Game.UsePlayerStanceColors ? AsPlayer.PlayerStanceColor(self) : AsPlayer.Color;
+			return color = Game.Settings.Game.UsePlayerStanceColors ? AsPlayer.PlayerRelationshipColor(self) : AsPlayer.Color;
 		}
 
 		public void DisguiseAs(Actor target)
@@ -298,8 +298,8 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public override bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor)
 		{
-			var stance = self.Owner.RelationshipWith(target.Owner);
-			if (!info.ValidRelationships.HasStance(stance))
+			var relationship = self.Owner.RelationshipWith(target.Owner);
+			if (!info.ValidRelationships.HasRelationship(relationship))
 				return false;
 
 			return info.TargetTypes.Overlaps(target.GetAllTargetTypes());
@@ -307,8 +307,8 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public override bool CanTargetFrozenActor(Actor self, FrozenActor target, TargetModifiers modifiers, ref string cursor)
 		{
-			var stance = self.Owner.RelationshipWith(target.Owner);
-			if (!info.ValidRelationships.HasStance(stance))
+			var relationship = self.Owner.RelationshipWith(target.Owner);
+			if (!info.ValidRelationships.HasRelationship(relationship))
 				return false;
 
 			return info.TargetTypes.Overlaps(target.Info.GetAllTargetTypes());

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForDecoration.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForDecoration.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		protected override bool ShouldRender(Actor self)
 		{
-			return infiltrators.Any(i => Info.ValidRelationships.HasStance(i.RelationshipWith(self.World.RenderPlayer)));
+			return infiltrators.Any(i => Info.ValidRelationships.HasRelationship(i.RelationshipWith(self.World.RenderPlayer)));
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
@@ -101,10 +101,10 @@ namespace OpenRA.Mods.Cnc.Traits
 			{
 				case TargetType.Actor:
 					return Info.Types.Overlaps(target.Actor.GetEnabledTargetTypes()) &&
-					       Info.ValidRelationships.HasStance(self.Owner.RelationshipWith(target.Actor.Owner));
+					       Info.ValidRelationships.HasRelationship(self.Owner.RelationshipWith(target.Actor.Owner));
 				case TargetType.FrozenActor:
 					return target.FrozenActor.IsValid && Info.Types.Overlaps(target.FrozenActor.TargetTypes) &&
-					       Info.ValidRelationships.HasStance(self.Owner.RelationshipWith(target.FrozenActor.Owner));
+					       Info.ValidRelationships.HasRelationship(self.Owner.RelationshipWith(target.FrozenActor.Owner));
 				default:
 					return false;
 			}
@@ -136,7 +136,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor)
 		{
 			var stance = self.Owner.RelationshipWith(target.Owner);
-			if (!info.ValidRelationships.HasStance(stance))
+			if (!info.ValidRelationships.HasRelationship(stance))
 				return false;
 
 			return info.Types.Overlaps(target.GetAllTargetTypes());
@@ -145,7 +145,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override bool CanTargetFrozenActor(Actor self, FrozenActor target, TargetModifiers modifiers, ref string cursor)
 		{
 			var stance = self.Owner.RelationshipWith(target.Owner);
-			if (!info.ValidRelationships.HasStance(stance))
+			if (!info.ValidRelationships.HasRelationship(stance))
 				return false;
 
 			return info.Types.Overlaps(target.Info.GetAllTargetTypes());

--- a/OpenRA.Mods.Common/Activities/CaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/CaptureActor.cs
@@ -124,7 +124,7 @@ namespace OpenRA.Mods.Common.Activities
 				foreach (var t in enterActor.TraitsImplementing<INotifyCapture>())
 					t.OnCapture(enterActor, self, oldOwner, self.Owner, captures.Info.CaptureTypes);
 
-				if (self.Owner.RelationshipWith(oldOwner).HasStance(captures.Info.PlayerExperienceRelationships))
+				if (self.Owner.RelationshipWith(oldOwner).HasRelationship(captures.Info.PlayerExperienceRelationships))
 					self.Owner.PlayerActor.TraitOrDefault<PlayerExperience>()?.GiveExperience(captures.Info.PlayerExperience);
 
 				if (captures.Info.ConsumedByCapture)

--- a/OpenRA.Mods.Common/Activities/RepairBuilding.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBuilding.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Activities
 			// Make sure we can still repair the target before entering
 			// (but not before, because this may stop the actor in the middle of nowhere)
 			var stance = self.Owner.RelationshipWith(enterActor.Owner);
-			if (enterHealth == null || enterHealth.DamageState == DamageState.Undamaged || enterEngineerRepariable == null || enterEngineerRepariable.IsTraitDisabled || !info.ValidRelationships.HasStance(stance))
+			if (enterHealth == null || enterHealth.DamageState == DamageState.Undamaged || enterEngineerRepariable == null || enterEngineerRepariable.IsTraitDisabled || !info.ValidRelationships.HasRelationship(stance))
 			{
 				Cancel(self, true);
 				return false;
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Activities
 				return;
 
 			var stance = self.Owner.RelationshipWith(enterActor.Owner);
-			if (!info.ValidRelationships.HasStance(stance))
+			if (!info.ValidRelationships.HasRelationship(stance))
 				return;
 
 			if (enterHealth.DamageState == DamageState.Undamaged)

--- a/OpenRA.Mods.Common/Effects/RevealShroudEffect.cs
+++ b/OpenRA.Mods.Common/Effects/RevealShroudEffect.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Effects
 
 		void AddCellsToPlayerShroud(Player p, PPos[] uv)
 		{
-			if (validStances.HasStance(player.RelationshipWith(p)))
+			if (validStances.HasRelationship(player.RelationshipWith(p)))
 				p.Shroud.AddSource(this, sourceType, uv);
 		}
 

--- a/OpenRA.Mods.Common/Graphics/IsometricSelectionBarsAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/IsometricSelectionBarsAnnotationRenderable.cs
@@ -131,7 +131,7 @@ namespace OpenRA.Mods.Common.Graphics
 		Color GetHealthColor(IHealth health)
 		{
 			if (Game.Settings.Game.UsePlayerStanceColors)
-				return actor.Owner.PlayerStanceColor(actor);
+				return actor.Owner.PlayerRelationshipColor(actor);
 
 			return health.DamageState == DamageState.Critical ? Color.Red :
 				health.DamageState == DamageState.Heavy ? Color.Yellow : Color.LimeGreen;

--- a/OpenRA.Mods.Common/Graphics/SelectionBarsAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBarsAnnotationRenderable.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Graphics
 		Color GetHealthColor(IHealth health)
 		{
 			if (Game.Settings.Game.UsePlayerStanceColors)
-				return actor.Owner.PlayerStanceColor(actor);
+				return actor.Owner.PlayerRelationshipColor(actor);
 
 			return health.DamageState == DamageState.Critical ? Color.Red :
 				health.DamageState == DamageState.Heavy ? Color.Yellow : Color.LimeGreen;

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -319,7 +319,7 @@ namespace OpenRA.Mods.Common.Projectiles
 				if (checkTargetType && !Target.FromActor(victim).IsValidFor(firedBy))
 					continue;
 
-				if (!info.ValidBounceBlockerRelationships.HasStance(firedBy.Owner.RelationshipWith(victim.Owner)))
+				if (!info.ValidBounceBlockerRelationships.HasRelationship(firedBy.Owner.RelationshipWith(victim.Owner)))
 					continue;
 
 				// If the impact position is within any actor's HitShape, we have a direct hit

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -429,7 +429,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			if ((tp.Actor.CenterPosition - pos).HorizontalLengthSquared > tp.Trait.Range.LengthSquared)
 				return false;
 
-			if (!tp.Trait.DeflectionStances.HasStance(tp.Actor.Owner.RelationshipWith(args.SourceActor.Owner)))
+			if (!tp.Trait.DeflectionStances.HasRelationship(tp.Actor.Owner.RelationshipWith(args.SourceActor.Owner)))
 				return false;
 
 			return tp.Actor.World.SharedRandom.Next(100) < tp.Trait.Chance;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -377,7 +377,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			return Armaments.Where(a =>
 				!a.IsTraitDisabled
-				&& (owner == null || (forceAttack ? a.Info.ForceTargetRelationships : a.Info.TargetRelationships).HasStance(self.Owner.RelationshipWith(owner)))
+				&& (owner == null || (forceAttack ? a.Info.ForceTargetRelationships : a.Info.TargetRelationships).HasRelationship(self.Owner.RelationshipWith(owner)))
 				&& a.Weapon.IsValidAgainst(t, self.World, self));
 		}
 

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -325,8 +325,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			return activeTargetPriorities.Any(ati =>
 			{
-				// Incompatible stances
-				if (!ati.ValidRelationships.HasStance(self.Owner.RelationshipWith(owner)))
+				// Incompatible relationship
+				if (!ati.ValidRelationships.HasRelationship(self.Owner.RelationshipWith(owner)))
 					return false;
 
 				// Incompatible target types
@@ -393,8 +393,8 @@ namespace OpenRA.Mods.Common.Traits
 					if (ati.Priority < chosenTargetPriority)
 						return false;
 
-					// Incompatible stances
-					if (!ati.ValidRelationships.HasStance(self.Owner.RelationshipWith(owner)))
+					// Incompatible relationship
+					if (!ati.ValidRelationships.HasRelationship(self.Owner.RelationshipWith(owner)))
 						return false;
 
 					// Incompatible target types

--- a/OpenRA.Mods.Common/Traits/BotModules/CaptureManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/CaptureManagerBotModule.cs
@@ -133,7 +133,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			var randPlayer = world.Players.Where(p => !p.Spectating
-				&& Info.CapturableRelationships.HasStance(player.RelationshipWith(p))).Random(world.LocalRandom);
+				&& Info.CapturableRelationships.HasRelationship(player.RelationshipWith(p))).Random(world.LocalRandom);
 
 			var targetOptions = Info.CheckCaptureTargetsForVisibility
 				? GetVisibleActorsBelongingToPlayer(randPlayer)

--- a/OpenRA.Mods.Common/Traits/CaptureManager.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureManager.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Actors with FrozenUnderFog should therefore not disable the Capturable trait.
 			var stance = captor.Owner.RelationshipWith(frozenActor.Owner);
 			return frozenActor.Info.TraitInfos<CapturableInfo>()
-				.Any(c => c.ValidRelationships.HasStance(stance) && captures.Info.CaptureTypes.Overlaps(c.Types));
+				.Any(c => c.ValidRelationships.HasRelationship(stance) && captures.Info.CaptureTypes.Overlaps(c.Types));
 		}
 	}
 
@@ -108,13 +108,13 @@ namespace OpenRA.Mods.Common.Traits
 			allyCapturableTypes = neutralCapturableTypes = enemyCapturableTypes = default(BitSet<CaptureType>);
 			foreach (var c in enabledCapturable)
 			{
-				if (c.Info.ValidRelationships.HasStance(PlayerRelationship.Ally))
+				if (c.Info.ValidRelationships.HasRelationship(PlayerRelationship.Ally))
 					allyCapturableTypes = allyCapturableTypes.Union(c.Info.Types);
 
-				if (c.Info.ValidRelationships.HasStance(PlayerRelationship.Neutral))
+				if (c.Info.ValidRelationships.HasRelationship(PlayerRelationship.Neutral))
 					neutralCapturableTypes = neutralCapturableTypes.Union(c.Info.Types);
 
-				if (c.Info.ValidRelationships.HasStance(PlayerRelationship.Enemy))
+				if (c.Info.ValidRelationships.HasRelationship(PlayerRelationship.Enemy))
 					enemyCapturableTypes = enemyCapturableTypes.Union(c.Info.Types);
 			}
 		}
@@ -128,14 +128,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool CanBeTargetedBy(Actor self, Actor captor, CaptureManager captorManager)
 		{
-			var stance = captor.Owner.RelationshipWith(self.Owner);
-			if (stance.HasStance(PlayerRelationship.Enemy))
+			var relationship = captor.Owner.RelationshipWith(self.Owner);
+			if (relationship.HasRelationship(PlayerRelationship.Enemy))
 				return captorManager.capturesTypes.Overlaps(enemyCapturableTypes);
 
-			if (stance.HasStance(PlayerRelationship.Neutral))
+			if (relationship.HasRelationship(PlayerRelationship.Neutral))
 				return captorManager.capturesTypes.Overlaps(neutralCapturableTypes);
 
-			if (stance.HasStance(PlayerRelationship.Ally))
+			if (relationship.HasRelationship(PlayerRelationship.Ally))
 				return captorManager.capturesTypes.Overlaps(allyCapturableTypes);
 
 			return false;
@@ -146,14 +146,14 @@ namespace OpenRA.Mods.Common.Traits
 			if (captures.IsTraitDisabled)
 				return false;
 
-			var stance = captor.Owner.RelationshipWith(self.Owner);
-			if (stance.HasStance(PlayerRelationship.Enemy))
+			var relationship = captor.Owner.RelationshipWith(self.Owner);
+			if (relationship.HasRelationship(PlayerRelationship.Enemy))
 				return captures.Info.CaptureTypes.Overlaps(enemyCapturableTypes);
 
-			if (stance.HasStance(PlayerRelationship.Neutral))
+			if (relationship.HasRelationship(PlayerRelationship.Neutral))
 				return captures.Info.CaptureTypes.Overlaps(neutralCapturableTypes);
 
-			if (stance.HasStance(PlayerRelationship.Ally))
+			if (relationship.HasRelationship(PlayerRelationship.Ally))
 				return captures.Info.CaptureTypes.Overlaps(allyCapturableTypes);
 
 			return false;

--- a/OpenRA.Mods.Common/Traits/Conditions/ProximityExternalCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ProximityExternalCondition.cs
@@ -110,8 +110,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (tokens.ContainsKey(a))
 				return;
 
-			var stance = self.Owner.RelationshipWith(a.Owner);
-			if (!Info.ValidRelationships.HasStance(stance))
+			var relationship = self.Owner.RelationshipWith(a.Owner);
+			if (!Info.ValidRelationships.HasRelationship(relationship))
 				return;
 
 			var external = a.TraitsImplementing<ExternalCondition>()
@@ -135,7 +135,7 @@ namespace OpenRA.Mods.Common.Traits
 			if ((produced.CenterPosition - self.CenterPosition).HorizontalLengthSquared <= Info.Range.LengthSquared)
 			{
 				var stance = self.Owner.RelationshipWith(produced.Owner);
-				if (!Info.ValidRelationships.HasStance(stance))
+				if (!Info.ValidRelationships.HasRelationship(stance))
 					return;
 
 				var external = produced.TraitsImplementing<ExternalCondition>()

--- a/OpenRA.Mods.Common/Traits/CreatesShroud.cs
+++ b/OpenRA.Mods.Common/Traits/CreatesShroud.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override void AddCellsToPlayerShroud(Actor self, Player p, PPos[] uv)
 		{
-			if (!info.ValidRelationships.HasStance(self.Owner.RelationshipWith(p)))
+			if (!info.ValidRelationships.HasRelationship(self.Owner.RelationshipWith(p)))
 				return;
 
 			p.Shroud.AddSource(this, Shroud.SourceType.Shroud, uv);

--- a/OpenRA.Mods.Common/Traits/DeliversCash.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversCash.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.Traits
 			public override bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor)
 			{
 				var targetInfo = target.Info.TraitInfoOrDefault<AcceptsDeliveredCashInfo>();
-				if (targetInfo == null || !targetInfo.ValidRelationships.HasStance(target.Owner.RelationshipWith(self.Owner)))
+				if (targetInfo == null || !targetInfo.ValidRelationships.HasRelationship(target.Owner.RelationshipWith(self.Owner)))
 					return false;
 
 				if (targetInfo.ValidTypes.Count == 0)
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Common.Traits
 			public override bool CanTargetFrozenActor(Actor self, FrozenActor target, TargetModifiers modifiers, ref string cursor)
 			{
 				var targetInfo = target.Info.TraitInfoOrDefault<AcceptsDeliveredCashInfo>();
-				if (targetInfo == null || !targetInfo.ValidRelationships.HasStance(target.Owner.RelationshipWith(self.Owner)))
+				if (targetInfo == null || !targetInfo.ValidRelationships.HasRelationship(target.Owner.RelationshipWith(self.Owner)))
 					return false;
 
 				if (targetInfo.ValidTypes.Count == 0)

--- a/OpenRA.Mods.Common/Traits/DeliversExperience.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversExperience.cs
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.Common.Traits
 					return false;
 
 				var targetInfo = target.Info.TraitInfoOrDefault<AcceptsDeliveredExperienceInfo>();
-				if (targetInfo == null || !targetInfo.ValidRelationships.HasStance(target.Owner.RelationshipWith(self.Owner)))
+				if (targetInfo == null || !targetInfo.ValidRelationships.HasRelationship(target.Owner.RelationshipWith(self.Owner)))
 					return false;
 
 				if (targetInfo.ValidTypes.Count == 0)
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.Common.Traits
 					return false;
 
 				var targetInfo = target.Info.TraitInfoOrDefault<AcceptsDeliveredExperienceInfo>();
-				if (targetInfo == null || !targetInfo.ValidRelationships.HasStance(target.Owner.RelationshipWith(self.Owner)))
+				if (targetInfo == null || !targetInfo.ValidRelationships.HasRelationship(target.Owner.RelationshipWith(self.Owner)))
 					return false;
 
 				if (targetInfo.ValidTypes.Count == 0)

--- a/OpenRA.Mods.Common/Traits/Demolition.cs
+++ b/OpenRA.Mods.Common/Traits/Demolition.cs
@@ -117,11 +117,11 @@ namespace OpenRA.Mods.Common.Traits
 				if (modifiers.HasModifier(TargetModifiers.ForceMove))
 					return false;
 
-				var stance = target.Owner.RelationshipWith(self.Owner);
-				if (!info.TargetRelationships.HasStance(stance) && !modifiers.HasModifier(TargetModifiers.ForceAttack))
+				var relationship = target.Owner.RelationshipWith(self.Owner);
+				if (!info.TargetRelationships.HasRelationship(relationship) && !modifiers.HasModifier(TargetModifiers.ForceAttack))
 					return false;
 
-				if (!info.ForceTargetRelationships.HasStance(stance) && modifiers.HasModifier(TargetModifiers.ForceAttack))
+				if (!info.ForceTargetRelationships.HasRelationship(relationship) && modifiers.HasModifier(TargetModifiers.ForceAttack))
 					return false;
 
 				return target.TraitsImplementing<IDemolishable>().Any(i => i.IsValidTarget(target, self));
@@ -129,11 +129,11 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override bool CanTargetFrozenActor(Actor self, FrozenActor target, TargetModifiers modifiers, ref string cursor)
 			{
-				var stance = target.Owner.RelationshipWith(self.Owner);
-				if (!info.TargetRelationships.HasStance(stance) && !modifiers.HasModifier(TargetModifiers.ForceAttack))
+				var relationship = target.Owner.RelationshipWith(self.Owner);
+				if (!info.TargetRelationships.HasRelationship(relationship) && !modifiers.HasModifier(TargetModifiers.ForceAttack))
 					return false;
 
-				if (!info.ForceTargetRelationships.HasStance(stance) && modifiers.HasModifier(TargetModifiers.ForceAttack))
+				if (!info.ForceTargetRelationships.HasRelationship(relationship) && modifiers.HasModifier(TargetModifiers.ForceAttack))
 					return false;
 
 				return target.Info.TraitInfos<IDemolishableInfo>().Any(i => i.IsValidTarget(target.Info, self));

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!engineerRepairable.Info.Types.IsEmpty && !engineerRepairable.Info.Types.Overlaps(info.Types))
 					return false;
 
-				if (!info.ValidRelationships.HasStance(target.Owner.RelationshipWith(self.Owner)))
+				if (!info.ValidRelationships.HasRelationship(target.Owner.RelationshipWith(self.Owner)))
 					return false;
 
 				if (target.GetDamageState() == DamageState.Undamaged)
@@ -139,7 +139,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!engineerRepairable.Types.IsEmpty && !engineerRepairable.Types.Overlaps(info.Types))
 					return false;
 
-				if (!info.ValidRelationships.HasStance(target.Owner.RelationshipWith(self.Owner)))
+				if (!info.ValidRelationships.HasRelationship(target.Owner.RelationshipWith(self.Owner)))
 					return false;
 
 				if (target.DamageState == DamageState.Undamaged)

--- a/OpenRA.Mods.Common/Traits/GivesBounty.cs
+++ b/OpenRA.Mods.Common/Traits/GivesBounty.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (e.Attacker == null || e.Attacker.Disposed || IsTraitDisabled)
 				return;
 
-			if (!Info.ValidRelationships.HasStance(e.Attacker.Owner.RelationshipWith(self.Owner)))
+			if (!Info.ValidRelationships.HasRelationship(e.Attacker.Owner.RelationshipWith(self.Owner)))
 				return;
 
 			if (!Info.DeathTypes.IsEmpty && !e.Damage.DamageTypes.Overlaps(Info.DeathTypes))

--- a/OpenRA.Mods.Common/Traits/GivesExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GivesExperience.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (exp == 0 || e.Attacker == null || e.Attacker.Disposed)
 				return;
 
-			if (!info.ValidRelationships.HasStance(e.Attacker.Owner.RelationshipWith(self.Owner)))
+			if (!info.ValidRelationships.HasRelationship(e.Attacker.Owner.RelationshipWith(self.Owner)))
 				return;
 
 			exp = Util.ApplyPercentageModifiers(exp, experienceModifiers);

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -105,8 +105,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (byPlayer == null)
 				return true;
 
-			var stance = self.Owner.RelationshipWith(byPlayer);
-			return info.AlwaysVisibleRelationships.HasStance(stance) || IsVisibleInner(self, byPlayer);
+			var relationship = self.Owner.RelationshipWith(byPlayer);
+			return info.AlwaysVisibleRelationships.HasRelationship(relationship) || IsVisibleInner(self, byPlayer);
 		}
 
 		void ITick.Tick(Actor self)

--- a/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderShroud.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderShroud.cs
@@ -55,8 +55,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (byPlayer == null)
 				return true;
 
-			var stance = self.Owner.RelationshipWith(byPlayer);
-			return Info.AlwaysVisibleRelationships.HasStance(stance) || IsVisibleInner(self, byPlayer);
+			var relationship = self.Owner.RelationshipWith(byPlayer);
+			return Info.AlwaysVisibleRelationships.HasRelationship(relationship) || IsVisibleInner(self, byPlayer);
 		}
 
 		IEnumerable<IRenderable> IRenderModifier.ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)

--- a/OpenRA.Mods.Common/Traits/Radar/AppearsOnRadar.cs
+++ b/OpenRA.Mods.Common/Traits/Radar/AppearsOnRadar.cs
@@ -42,10 +42,10 @@ namespace OpenRA.Mods.Common.Traits.Radar
 		public void PopulateRadarSignatureCells(Actor self, List<(CPos Cell, Color Color)> destinationBuffer)
 		{
 			var viewer = self.World.RenderPlayer ?? self.World.LocalPlayer;
-			if (IsTraitDisabled || (viewer != null && !Info.ValidRelationships.HasStance(self.Owner.RelationshipWith(viewer))))
+			if (IsTraitDisabled || (viewer != null && !Info.ValidRelationships.HasRelationship(self.Owner.RelationshipWith(viewer))))
 				return;
 
-			var color = Game.Settings.Game.UsePlayerStanceColors ? self.Owner.PlayerStanceColor(self) : self.Owner.Color;
+			var color = Game.Settings.Game.UsePlayerStanceColors ? self.Owner.PlayerRelationshipColor(self) : self.Owner.Color;
 			if (modifier != null)
 				color = modifier.RadarColorOverride(self, color);
 

--- a/OpenRA.Mods.Common/Traits/Render/CashTricklerBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/CashTricklerBar.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		float ISelectionBar.GetValue()
 		{
 			var viewer = self.World.RenderPlayer ?? self.World.LocalPlayer;
-			if (viewer != null && !info.DisplayRelationships.HasStance(self.Owner.RelationshipWith(viewer)))
+			if (viewer != null && !info.DisplayRelationships.HasRelationship(self.Owner.RelationshipWith(viewer)))
 				return 0;
 
 			var complete = cashTricklers.Min(ct => (float)ct.Ticks / ct.Info.Interval);

--- a/OpenRA.Mods.Common/Traits/Render/SupportPowerChargeBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SupportPowerChargeBar.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				return 0;
 
 			var viewer = self.World.RenderPlayer ?? self.World.LocalPlayer;
-			if (viewer != null && !Info.DisplayRelationships.HasStance(self.Owner.RelationshipWith(viewer)))
+			if (viewer != null && !Info.DisplayRelationships.HasRelationship(self.Owner.RelationshipWith(viewer)))
 				return 0;
 
 			return 1 - (float)power.RemainingTicks / power.TotalTicks;

--- a/OpenRA.Mods.Common/Traits/Render/WithDecorationBase.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecorationBase.cs
@@ -81,8 +81,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			if (self.World.RenderPlayer != null)
 			{
-				var stance = self.Owner.RelationshipWith(self.World.RenderPlayer);
-				if (!Info.ValidRelationships.HasStance(stance))
+				var relationship = self.Owner.RelationshipWith(self.World.RenderPlayer);
+				if (!Info.ValidRelationships.HasRelationship(relationship))
 					return false;
 			}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
@@ -91,7 +91,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 					return false;
 
 				var p = self.World.RenderPlayer;
-				return p == null || Info.ValidRelationships.HasStance(self.Owner.RelationshipWith(p)) || (p.Spectating && !p.NonCombatant);
+				return p == null || Info.ValidRelationships.HasRelationship(self.Owner.RelationshipWith(p)) || (p.Spectating && !p.NonCombatant);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/RevealsMap.cs
+++ b/OpenRA.Mods.Common/Traits/RevealsMap.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected void AddCellsToPlayerShroud(Actor self, Player p, PPos[] uv)
 		{
-			if (!Info.ValidRelationships.HasStance(self.Owner.RelationshipWith(p)))
+			if (!Info.ValidRelationships.HasRelationship(self.Owner.RelationshipWith(p)))
 				return;
 
 			p.Shroud.AddSource(this, type, uv);

--- a/OpenRA.Mods.Common/Traits/RevealsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/RevealsShroud.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override void AddCellsToPlayerShroud(Actor self, Player p, PPos[] uv)
 		{
-			if (!info.ValidRelationships.HasStance(self.Owner.RelationshipWith(p)))
+			if (!info.ValidRelationships.HasRelationship(self.Owner.RelationshipWith(p)))
 				return;
 
 			p.Shroud.AddSource(this, type, uv);

--- a/OpenRA.Mods.Common/Traits/Sound/VoiceAnnouncement.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/VoiceAnnouncement.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 			if (player == null)
 				return;
 
-			if (Info.ValidRelationships.HasStance(self.Owner.RelationshipWith(player)))
+			if (Info.ValidRelationships.HasRelationship(self.Owner.RelationshipWith(player)))
 				self.PlayVoice(Info.Voice);
 			else if (Info.PlayToOwner && self.Owner == player)
 				self.PlayVoice(Info.Voice);

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			return units.Distinct().Where(a =>
 			{
-				if (!info.ValidRelationships.HasStance(Self.Owner.RelationshipWith(a.Owner)))
+				if (!info.ValidRelationships.HasRelationship(Self.Owner.RelationshipWith(a.Owner)))
 					return false;
 
 				return a.TraitsImplementing<ExternalCondition>()

--- a/OpenRA.Mods.Common/Traits/Tooltip.cs
+++ b/OpenRA.Mods.Common/Traits/Tooltip.cs
@@ -51,18 +51,18 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override object Create(ActorInitializer init) { return new Tooltip(init.Self, this); }
 
-		public string TooltipForPlayerStance(PlayerRelationship stance)
+		public string TooltipForPlayerStance(PlayerRelationship relationship)
 		{
-			if (stance == PlayerRelationship.None || !GenericVisibility.HasStance(stance))
+			if (relationship == PlayerRelationship.None || !GenericVisibility.HasRelationship(relationship))
 				return Name;
 
-			if (GenericStancePrefix && !string.IsNullOrEmpty(AllyPrefix) && stance == PlayerRelationship.Ally)
+			if (GenericStancePrefix && !string.IsNullOrEmpty(AllyPrefix) && relationship == PlayerRelationship.Ally)
 				return AllyPrefix + " " + GenericName;
 
-			if (GenericStancePrefix && !string.IsNullOrEmpty(NeutralPrefix) && stance == PlayerRelationship.Neutral)
+			if (GenericStancePrefix && !string.IsNullOrEmpty(NeutralPrefix) && relationship == PlayerRelationship.Neutral)
 				return NeutralPrefix + " " + GenericName;
 
-			if (GenericStancePrefix && !string.IsNullOrEmpty(EnemyPrefix) && stance == PlayerRelationship.Enemy)
+			if (GenericStancePrefix && !string.IsNullOrEmpty(EnemyPrefix) && relationship == PlayerRelationship.Enemy)
 				return EnemyPrefix + " " + GenericName;
 
 			return GenericName;

--- a/OpenRA.Mods.Common/Traits/TooltipDescription.cs
+++ b/OpenRA.Mods.Common/Traits/TooltipDescription.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (Owner == null || forPlayer == null)
 				return false;
 
-			return Info.ValidRelationships.HasStance(Owner.RelationshipWith(forPlayer));
+			return Info.ValidRelationships.HasRelationship(Owner.RelationshipWith(forPlayer));
 		}
 
 		public string TooltipText

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -79,8 +79,8 @@ namespace OpenRA.Mods.Common.Warheads
 		// (and to prevent returning ImpactActorType.Invalid on AffectsParent=false)
 		public override bool IsValidAgainst(Actor victim, Actor firedBy)
 		{
-			var stance = firedBy.Owner.RelationshipWith(victim.Owner);
-			if (!ValidRelationships.HasStance(stance))
+			var relationship = firedBy.Owner.RelationshipWith(victim.Owner);
+			if (!ValidRelationships.HasRelationship(relationship))
 				return false;
 
 			// A target type is valid if it is in the valid targets list, and not in the invalid targets list.

--- a/OpenRA.Mods.Common/Warheads/Warhead.cs
+++ b/OpenRA.Mods.Common/Warheads/Warhead.cs
@@ -62,8 +62,8 @@ namespace OpenRA.Mods.Common.Warheads
 			if (!AffectsParent && victim == firedBy)
 				return false;
 
-			var stance = firedBy.Owner.RelationshipWith(victim.Owner);
-			if (!ValidRelationships.HasStance(stance))
+			var relationship = firedBy.Owner.RelationshipWith(victim.Owner);
+			if (!ValidRelationships.HasRelationship(relationship))
 				return false;
 
 			// A target type is valid if it is in the valid targets list, and not in the invalid targets list.
@@ -79,9 +79,9 @@ namespace OpenRA.Mods.Common.Warheads
 			if (!victim.IsValid)
 				return false;
 
-			// AffectsParent checks do not make sense for FrozenActors, so skip to stance checks
-			var stance = firedBy.Owner.RelationshipWith(victim.Owner);
-			if (!ValidRelationships.HasStance(stance))
+			// AffectsParent checks do not make sense for FrozenActors, so skip to relationship checks
+			var relationship = firedBy.Owner.RelationshipWith(victim.Owner);
+			if (!ValidRelationships.HasRelationship(relationship))
 				return false;
 
 			// A target type is valid if it is in the valid targets list, and not in the invalid targets list.

--- a/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				var owner = p.Instances[0].Self.Owner;
 				var viewer = owner.World.RenderPlayer ?? owner.World.LocalPlayer;
-				return viewer == null || p.Info.DisplayTimerRelationships.HasStance(owner.RelationshipWith(viewer));
+				return viewer == null || p.Info.DisplayTimerRelationships.HasRelationship(owner.RelationshipWith(viewer));
 			});
 
 			texts = displayedPowers.Select(p =>
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Widgets
 				var playerColor = self.Owner.Color;
 
 				if (Game.Settings.Game.UsePlayerStanceColors)
-					playerColor = self.Owner.PlayerStanceColor(self);
+					playerColor = self.Owner.PlayerRelationshipColor(self);
 
 				var color = !p.Ready || Game.LocalTick % 50 < 25 ? playerColor : Color.White;
 


### PR DESCRIPTION
This PR fixes some leftover naming inconsistencies from #18677 that were raised on ppmforums.
@abcdefg30 i've lost track of whether you had more followups planned, is this going to conflict (in which case i'll close this)?