### PR TITLE
Lower Z-Offsets of decorations that overlap FIX

### DIFF
--- a/mods/cnc/sequences/decorations.yaml
+++ b/mods/cnc/sequences/decorations.yaml
@@ -661,15 +661,15 @@ v12:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-		ZOffset: -512
+		ZOffset: -2c512
 	damaged-idle:
 		Start: 1
-		ZOffset: -512
+		ZOffset: -2c512
 
 v12.husk:
 	idle: v12
 		Start: 2
-		ZOffset: -512
+		ZOffset: -2c512
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -680,15 +680,15 @@ v13:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-		ZOffset: -512
+		ZOffset: -2c512
 	damaged-idle:
 		Start: 1
-		ZOffset: -512
+		ZOffset: -2c512
 
 v13.husk:
 	idle: v13
 		Start: 2
-		ZOffset: -512
+		ZOffset: -2c512
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -699,15 +699,15 @@ v14:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-		ZOffset: -512
+		ZOffset: -2c512
 	damaged-idle:
 		Start: 1
-		ZOffset: -512
+		ZOffset: -2c512
 
 v14.husk:
 	idle: v14
 		Start: 2
-		ZOffset: -512
+		ZOffset: -2c512
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -718,15 +718,15 @@ v15:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-		ZOffset: -512
+		ZOffset: -2c512
 	damaged-idle:
 		Start: 1
-		ZOffset: -512
+		ZOffset: -2c512
 
 v15.husk:
 	idle: v15
 		Start: 2
-		ZOffset: -512
+		ZOffset: -2c512
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -737,15 +737,15 @@ v16:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-		ZOffset: -512
+		ZOffset: -2c512
 	damaged-idle:
 		Start: 1
-		ZOffset: -512
+		ZOffset: -2c512
 
 v16.husk:
 	idle: v16
 		Start: 2
-		ZOffset: -512
+		ZOffset: -2c512
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -756,15 +756,15 @@ v17:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-		ZOffset: -512
+		ZOffset: -2c512
 	damaged-idle:
 		Start: 1
-		ZOffset: -512
+		ZOffset: -2c512
 
 v17.husk:
 	idle: v17
 		Start: 2
-		ZOffset: -512
+		ZOffset: -2c512
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT
@@ -775,15 +775,15 @@ v18:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-		ZOffset: -512
+		ZOffset: -2c512
 	damaged-idle:
 		Start: 1
-		ZOffset: -512
+		ZOffset: -2c512
 
 v18.husk:
 	idle: v18
 		Start: 2
-		ZOffset: -512
+		ZOffset: -2c512
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT

--- a/mods/ra/sequences/decorations.yaml
+++ b/mods/ra/sequences/decorations.yaml
@@ -560,8 +560,10 @@ v12:
 			DESERT: TEMPERAT
 			INTERIOR: TEMPERAT
 	idle:
+		ZOffset: -2c512
 	damaged-idle:
 		Start: 1
+		ZOffset: -2c512
 
 v13:
 	Defaults:
@@ -580,10 +582,10 @@ v14:
 			DESERT: TEMPERAT
 			INTERIOR: TEMPERAT
 	idle:
-		ZOffset: -512
+		ZOffset: -2c512
 	damaged-idle:
 		Start: 1
-		ZOffset: -512
+		ZOffset: -2c512
 
 v15:
 	Defaults:
@@ -592,10 +594,10 @@ v15:
 			DESERT: TEMPERAT
 			INTERIOR: TEMPERAT
 	idle:
-		ZOffset: -512
+		ZOffset: -2c512
 	damaged-idle:
 		Start: 1
-		ZOffset: -512
+		ZOffset: -2c512
 
 v16:
 	Defaults:
@@ -604,10 +606,10 @@ v16:
 			DESERT: TEMPERAT
 			INTERIOR: TEMPERAT
 	idle:
-		ZOffset: -512
+		ZOffset: -2c512
 	damaged-idle:
 		Start: 1
-		ZOffset: -512
+		ZOffset: -2c512
 
 v17:
 	Defaults:
@@ -616,10 +618,10 @@ v17:
 			DESERT: TEMPERAT
 			INTERIOR: TEMPERAT
 	idle:
-		ZOffset: -512
+		ZOffset: -2c512
 	damaged-idle:
 		Start: 1
-		ZOffset: -512
+		ZOffset: -2c512
 
 v18:
 	Defaults:
@@ -628,19 +630,19 @@ v18:
 			DESERT: TEMPERAT
 			INTERIOR: TEMPERAT
 	idle:
-		ZOffset: -512
+		ZOffset: -2c512
 	damaged-idle:
 		Start: 1
-		ZOffset: -512
+		ZOffset: -2c512
 
 rice:
 	Defaults:
 		AddExtension: false
 	idle: rice.tem
-		ZOffset: -512
+		ZOffset: -2c512
 	damaged-idle: rice.tem
 		Start: 1
-		ZOffset: -512
+		ZOffset: -2c512
 
 v19:
 	idle:

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -599,11 +599,11 @@ craters:
 mine:
 	idle:
 		UseTilesetExtension: true
-		ZOffset: -1024
+		ZOffset: -2c512
 
 gmine:
 	idle:
-		ZOffset: -1024
+		ZOffset: -2c512
 		UseTilesetExtension: true
 		TilesetOverrides:
 			INTERIOR: TEMPERAT


### PR DESCRIPTION
Closes #13939
Closes #17832

[Bridges have overlap too](https://github.com/OpenRA/OpenRA/issues/13939#issuecomment-334237740) but they can't hold sequences.