### PR TITLE
Fix Firestorm asset installation.

### DIFF
--- a/mods/ts/installer/firestorm.yaml
+++ b/mods/ts/installer/firestorm.yaml
@@ -4,6 +4,7 @@ fstorm: Firestorm Expansion Disc (English)
 		Install/Language.dll: 4df87c1a2289da57dd14d0a7299546f37357fcca
 	Install:
 		copy: .
+			^SupportDir|Content/ts/firestorm/scores01.mix: scores01.mix
 		extract-raw: Install/expand01.mix
 			^SupportDir|Content/ts/firestorm/m_emp.vxl:
 				Offset: 2187652
@@ -539,28 +540,3 @@ fstorm: Firestorm Expansion Disc (English)
 			^SupportDir|Content/ts/firestorm/sounds01.mix:
 				Offset: 28229956
 				Length: 990096
-		extract-raw: scores01.mix
-			^SupportDir|Content/ts/firestorm/elusive.aud:
-				Offset: 188
-				Length: 2991051
-			^SupportDir|Content/ts/firestorm/hacker.aud:
-				Offset: 2991244
-				Length: 2719611
-			^SupportDir|Content/ts/firestorm/infiltra.aud:
-				Offset: 5710860
-				Length: 2915781
-			^SupportDir|Content/ts/firestorm/linkup.aud:
-				Offset: 8626652
-				Length: 2210011
-			^SupportDir|Content/ts/firestorm/kmachine.aud:
-				Offset: 10836668
-				Length: 2323371
-			^SupportDir|Content/ts/firestorm/rainnite.aud:
-				Offset: 13160044
-				Length: 2679051
-			^SupportDir|Content/ts/firestorm/slavesys.aud:
-				Offset: 15839100
-				Length: 1747576
-			^SupportDir|Content/ts/firestorm/dmachine.aud:
-				Offset: 17586684
-				Length: 2492891

--- a/mods/ts/installer/firstdecade.yaml
+++ b/mods/ts/installer/firstdecade.yaml
@@ -11,7 +11,7 @@ tfd: C&C The First Decade (English)
 				^SupportDir|Content/ts/scores.mix: Tiberian Sun\SUN\SCORES.MIX
 				^SupportDir|Content/ts/tibsun.mix: Tiberian Sun\SUN\TIBSUN.MIX
 				^SupportDir|Content/ts/expand01.mix: Tiberian Sun\SUN\expand01.mix
-				^SupportDir|Content/ts/scores01.mix: Tiberian Sun\SUN\scores01.mix
+				^SupportDir|Content/ts/firestorm/scores01.mix: Tiberian Sun\SUN\scores01.mix
 		extract-raw: ^SupportDir|Content/ts/tibsun.mix
 			^SupportDir|Content/ts/cache.mix:
 				Offset: 300
@@ -592,29 +592,3 @@ tfd: C&C The First Decade (English)
 				Offset: 28229956
 				Length: 990096
 		delete: ^SupportDir|Content/ts/expand01.mix
-		extract-raw: ^SupportDir|Content/ts/scores01.mix
-			^SupportDir|Content/ts/firestorm/elusive.aud:
-				Offset: 188
-				Length: 2991051
-			^SupportDir|Content/ts/firestorm/hacker.aud:
-				Offset: 2991244
-				Length: 2719611
-			^SupportDir|Content/ts/firestorm/infiltra.aud:
-				Offset: 5710860
-				Length: 2915781
-			^SupportDir|Content/ts/firestorm/linkup.aud:
-				Offset: 8626652
-				Length: 2210011
-			^SupportDir|Content/ts/firestorm/kmachine.aud:
-				Offset: 10836668
-				Length: 2323371
-			^SupportDir|Content/ts/firestorm/rainnite.aud:
-				Offset: 13160044
-				Length: 2679051
-			^SupportDir|Content/ts/firestorm/slavesys.aud:
-				Offset: 15839100
-				Length: 1747576
-			^SupportDir|Content/ts/firestorm/dmachine.aud:
-				Offset: 17586684
-				Length: 2492891
-		delete: ^SupportDir|Content/ts/scores01.mix

--- a/mods/ts/installer/origin.yaml
+++ b/mods/ts/installer/origin.yaml
@@ -8,6 +8,7 @@ origin: C&C The Ultimate Collection (Origin version, English)
 	Install:
 		copy: .
 			^SupportDir|Content/ts/scores.mix: SCORES.MIX
+			^SupportDir|Content/ts/firestorm/scores01.mix: scores01.mix
 		extract-raw: TIBSUN.MIX
 			^SupportDir|Content/ts/cache.mix:
 				Offset: 300
@@ -51,3 +52,538 @@ origin: C&C The Ultimate Collection (Origin version, English)
 			^SupportDir|Content/ts/temperat.mix:
 				Offset: 73056940
 				Length: 2037606
+		extract-raw: expand01.mix
+			^SupportDir|Content/ts/firestorm/m_emp.vxl:
+				Offset: 2187652
+				Length: 24652
+			^SupportDir|Content/ts/firestorm/mwar_nod.vxl:
+				Offset: 2212308
+				Length: 31118
+			^SupportDir|Content/ts/firestorm/djuggbar.vxl:
+				Offset: 2243428
+				Length: 18283
+			^SupportDir|Content/ts/firestorm/sgen.vxl:
+				Offset: 2261716
+				Length: 24136
+			^SupportDir|Content/ts/firestorm/m_emp.hva:
+				Offset: 2285860
+				Length: 88
+			^SupportDir|Content/ts/firestorm/mwar_nod.hva:
+				Offset: 2285956
+				Length: 88
+			^SupportDir|Content/ts/firestorm/djuggbar.hva:
+				Offset: 2286052
+				Length: 88
+			^SupportDir|Content/ts/firestorm/sgen.hva:
+				Offset: 2286148
+				Length: 88
+			^SupportDir|Content/ts/firestorm/c_kodiak.shp:
+				Offset: 2286244
+				Length: 24080
+			^SupportDir|Content/ts/firestorm/k_light1.shp:
+				Offset: 2310324
+				Length: 12328
+			^SupportDir|Content/ts/firestorm/k_light2.shp:
+				Offset: 2322660
+				Length: 5928
+			^SupportDir|Content/ts/firestorm/mwarmk.shp:
+				Offset: 2328596
+				Length: 129824
+			^SupportDir|Content/ts/firestorm/mstlmk.shp:
+				Offset: 2458420
+				Length: 26712
+			^SupportDir|Content/ts/firestorm/defdmk.shp:
+				Offset: 2485140
+				Length: 80728
+			^SupportDir|Content/ts/firestorm/coremk.shp:
+				Offset: 2565876
+				Length: 155384
+			^SupportDir|Content/ts/firestorm/blat01.tem:
+				Offset: 12709962
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat01a.tem:
+				Offset: 12711194
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat02.tem:
+				Offset: 12712426
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat02a.tem:
+				Offset: 12713658
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat03.tem:
+				Offset: 12714890
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat03a.tem:
+				Offset: 12716122
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat04.tem:
+				Offset: 12717354
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat04a.tem:
+				Offset: 12718586
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat05.tem:
+				Offset: 12719818
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat05a.tem:
+				Offset: 12721050
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat06.tem:
+				Offset: 12722282
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat06a.tem:
+				Offset: 12723514
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat07.tem:
+				Offset: 12724746
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat07a.tem:
+				Offset: 12725978
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat08.tem:
+				Offset: 12727210
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat08a.tem:
+				Offset: 12728442
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat09.tem:
+				Offset: 12729674
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat09a.tem:
+				Offset: 12730906
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat10.tem:
+				Offset: 12732138
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat10a.tem:
+				Offset: 12733370
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat11.tem:
+				Offset: 12734602
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat11a.tem:
+				Offset: 12735834
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat12.tem:
+				Offset: 12737066
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat12a.tem:
+				Offset: 12738298
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat13.tem:
+				Offset: 12739530
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat13a.tem:
+				Offset: 12740762
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat14.tem:
+				Offset: 12741994
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat14a.tem:
+				Offset: 12743226
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat15.tem:
+				Offset: 12744458
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat15a.tem:
+				Offset: 12745690
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat16.tem:
+				Offset: 12746922
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blat16a.tem:
+				Offset: 12748154
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blue01.tem:
+				Offset: 12749386
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blue01a.tem:
+				Offset: 12750618
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blue01b.tem:
+				Offset: 12751850
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blue01c.tem:
+				Offset: 12753082
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blue01d.tem:
+				Offset: 12754314
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blue01e.tem:
+				Offset: 12755546
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blue01f.tem:
+				Offset: 12756778
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/blue01g.tem:
+				Offset: 12758010
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/ccliff01.tem:
+				Offset: 12759242
+				Length: 10514
+			^SupportDir|Content/ts/firestorm/ccliff02.tem:
+				Offset: 12769770
+				Length: 10514
+			^SupportDir|Content/ts/firestorm/ccliff03.tem:
+				Offset: 12780298
+				Length: 14972
+			^SupportDir|Content/ts/firestorm/ccliff04.tem:
+				Offset: 12795274
+				Length: 6888
+			^SupportDir|Content/ts/firestorm/ccliff05.tem:
+				Offset: 12802170
+				Length: 10512
+			^SupportDir|Content/ts/firestorm/ccliff06.tem:
+				Offset: 12812682
+				Length: 10512
+			^SupportDir|Content/ts/firestorm/crash01.tem:
+				Offset: 12823194
+				Length: 52004
+			^SupportDir|Content/ts/firestorm/crash02.tem:
+				Offset: 12875210
+				Length: 14068
+			^SupportDir|Content/ts/firestorm/crash03.tem:
+				Offset: 12889290
+				Length: 95662
+			^SupportDir|Content/ts/firestorm/crash04.tem:
+				Offset: 12984954
+				Length: 21784
+			^SupportDir|Content/ts/firestorm/crash05.tem:
+				Offset: 13006746
+				Length: 38512
+			^SupportDir|Content/ts/firestorm/crash06.tem:
+				Offset: 13045258
+				Length: 36768
+			^SupportDir|Content/ts/firestorm/crash07.tem:
+				Offset: 13082026
+				Length: 37090
+			^SupportDir|Content/ts/firestorm/crys01.tem:
+				Offset: 13119130
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/crys01a.tem:
+				Offset: 13120362
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/crys01b.tem:
+				Offset: 13121594
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/crys01c.tem:
+				Offset: 13122826
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/crys01d.tem:
+				Offset: 13124058
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/crys01e.tem:
+				Offset: 13125290
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/crys01f.tem:
+				Offset: 13126522
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/crys01g.tem:
+				Offset: 13127754
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat01.tem:
+				Offset: 13128986
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat01a.tem:
+				Offset: 13130218
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat02.tem:
+				Offset: 13131450
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat02a.tem:
+				Offset: 13132682
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat03.tem:
+				Offset: 13133914
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat03a.tem:
+				Offset: 13135146
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat04.tem:
+				Offset: 13136378
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat04a.tem:
+				Offset: 13137610
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat05.tem:
+				Offset: 13138842
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat05a.tem:
+				Offset: 13140074
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat06.tem:
+				Offset: 13141306
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat06a.tem:
+				Offset: 13142538
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat07.tem:
+				Offset: 13143770
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat07a.tem:
+				Offset: 13145002
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat08.tem:
+				Offset: 13146234
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat08a.tem:
+				Offset: 13147466
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat09.tem:
+				Offset: 13148698
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat09a.tem:
+				Offset: 13149930
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat10.tem:
+				Offset: 13151162
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat10a.tem:
+				Offset: 13152394
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat11.tem:
+				Offset: 13153626
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat11a.tem:
+				Offset: 13154858
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat12.tem:
+				Offset: 13156090
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat12a.tem:
+				Offset: 13157322
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat13.tem:
+				Offset: 13158554
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat13a.tem:
+				Offset: 13159786
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat14.tem:
+				Offset: 13161018
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat14a.tem:
+				Offset: 13162250
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat15.tem:
+				Offset: 13163482
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat15a.tem:
+				Offset: 13164714
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat16.tem:
+				Offset: 13165946
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/cylat16a.tem:
+				Offset: 13167178
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat01.tem:
+				Offset: 13168410
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat01a.tem:
+				Offset: 13169642
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat02.tem:
+				Offset: 13170874
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat02a.tem:
+				Offset: 13172106
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat03.tem:
+				Offset: 13173338
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat03a.tem:
+				Offset: 13174570
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat04.tem:
+				Offset: 13175802
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat04a.tem:
+				Offset: 13177034
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat05.tem:
+				Offset: 13178266
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat05a.tem:
+				Offset: 13179498
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat06.tem:
+				Offset: 13180730
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat06a.tem:
+				Offset: 13181962
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat07.tem:
+				Offset: 13183194
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat07a.tem:
+				Offset: 13184426
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat08.tem:
+				Offset: 13185658
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat08a.tem:
+				Offset: 13186890
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat09.tem:
+				Offset: 13188122
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat09a.tem:
+				Offset: 13189354
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat10.tem:
+				Offset: 13190586
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat10a.tem:
+				Offset: 13191818
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat11.tem:
+				Offset: 13193050
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat11a.tem:
+				Offset: 13194282
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat12.tem:
+				Offset: 13195514
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat12a.tem:
+				Offset: 13196746
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat13.tem:
+				Offset: 13197978
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat13a.tem:
+				Offset: 13199210
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat14.tem:
+				Offset: 13200442
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat14a.tem:
+				Offset: 13201674
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat15.tem:
+				Offset: 13202906
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat15a.tem:
+				Offset: 13204138
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat16.tem:
+				Offset: 13205370
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/slat16a.tem:
+				Offset: 13206602
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/swamp01.tem:
+				Offset: 13207834
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/swamp01a.tem:
+				Offset: 13209066
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/swamp01b.tem:
+				Offset: 13210298
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/swamp01c.tem:
+				Offset: 13211530
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/swamp01d.tem:
+				Offset: 13212762
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/swamp01e.tem:
+				Offset: 13213994
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/swamp01f.tem:
+				Offset: 13215226
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/swamp01g.tem:
+				Offset: 13216458
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/swamp02.tem:
+				Offset: 13217690
+				Length: 4848
+			^SupportDir|Content/ts/firestorm/swamp03.tem:
+				Offset: 13222538
+				Length: 4848
+			^SupportDir|Content/ts/firestorm/swamp04.tem:
+				Offset: 13227386
+				Length: 4848
+			^SupportDir|Content/ts/firestorm/swamp05.tem:
+				Offset: 13232234
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/swamp06.tem:
+				Offset: 13233466
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/swamp07.tem:
+				Offset: 13234698
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/swamp08.tem:
+				Offset: 13235930
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/swamp09.tem:
+				Offset: 13237162
+				Length: 1224
+			^SupportDir|Content/ts/firestorm/fona01.tem:
+				Offset: 15276198
+				Length: 2048
+			^SupportDir|Content/ts/firestorm/fona02.tem:
+				Offset: 15278246
+				Length: 1304
+			^SupportDir|Content/ts/firestorm/fona03.tem:
+				Offset: 15279558
+				Length: 1864
+			^SupportDir|Content/ts/firestorm/fona04.tem:
+				Offset: 15281430
+				Length: 1952
+			^SupportDir|Content/ts/firestorm/fona05.tem:
+				Offset: 15283382
+				Length: 1328
+			^SupportDir|Content/ts/firestorm/fona06.tem:
+				Offset: 15284710
+				Length: 1160
+			^SupportDir|Content/ts/firestorm/fona07.tem:
+				Offset: 15285878
+				Length: 1216
+			^SupportDir|Content/ts/firestorm/fona08.tem:
+				Offset: 15287094
+				Length: 872
+			^SupportDir|Content/ts/firestorm/fona09.tem:
+				Offset: 15287974
+				Length: 608
+			^SupportDir|Content/ts/firestorm/fona10.tem:
+				Offset: 15288582
+				Length: 616
+			^SupportDir|Content/ts/firestorm/fona11.tem:
+				Offset: 15289206
+				Length: 2448
+			^SupportDir|Content/ts/firestorm/fona12.tem:
+				Offset: 15291654
+				Length: 2360
+			^SupportDir|Content/ts/firestorm/fona13.tem:
+				Offset: 15294022
+				Length: 1608
+			^SupportDir|Content/ts/firestorm/fona14.tem:
+				Offset: 15295638
+				Length: 1544
+			^SupportDir|Content/ts/firestorm/fona15.tem:
+				Offset: 15297190
+				Length: 2496
+			^SupportDir|Content/ts/firestorm/bigblue3.tem:
+				Offset: 15299686
+				Length: 12808
+			^SupportDir|Content/ts/firestorm/ecache01.mix:
+				Offset: 17400340
+				Length: 2229224
+			^SupportDir|Content/ts/firestorm/e01sc01.mix:
+				Offset: 19629572
+				Length: 6324
+			^SupportDir|Content/ts/firestorm/e01sc02.mix:
+				Offset: 19635908
+				Length: 6324
+			^SupportDir|Content/ts/firestorm/e01vox01.mix:
+				Offset: 19642244
+				Length: 6313740
+			^SupportDir|Content/ts/firestorm/e01vox02.mix:
+				Offset: 25955988
+				Length: 2273956
+			^SupportDir|Content/ts/firestorm/sounds01.mix:
+				Offset: 28229956
+				Length: 990096

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -311,14 +311,14 @@ ModContent:
 		tibsun-music: Base Game Music
 			TestFiles: ^SupportDir|Content/ts/scores.mix
 			Sources: tibsun, tibsun-linux, tfd, origin
-		fstorm: Expansion Freeware Content
+		fstorm: Firestorm Expansion Files
 			TestFiles: ^SupportDir|Content/ts/firestorm/e01sc01.mix, ^SupportDir|Content/ts/firestorm/e01sc02.mix, ^SupportDir|Content/ts/firestorm/e01vox01.mix, ^SupportDir|Content/ts/firestorm/e01vox02.mix
 			Sources: tfd, origin, fstorm
 			Required: true
 			Download: fstorm
-		fstorm-music: Expansion Freeware Music
+		fstorm-music: Firestorm Expansion Music
 			Sources: tfd, origin, fstorm
-			TestFiles: ^SupportDir|Content/ts/firestorm/linkup.aud, ^SupportDir|Content/ts/firestorm/hacker.aud
+			TestFiles: ^SupportDir|Content/ts/firestorm/scores01.mix
 	Downloads:
 		ts|installer/downloads.yaml
 	Sources:


### PR DESCRIPTION
@penev92 raised in the discord that we aren't copying any firestorm files from the Origin install, and further investigation revealed further inconsistencies with how we handle FS content from the other sources. This PR adds the missing files from Origin and standardizes what we copy from all sources.