### PR TITLE
APC Balance Tweak

### DIFF
--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -113,7 +113,7 @@ APC:
 		Queue: Vehicle.GDI
 		Description: Armed infantry transport.\nCan attack Aircraft.\n  Strong vs Vehicles\n  Weak vs Infantry
 	Mobile:
-		TurnSpeed: 28
+		TurnSpeed: 20
 		Speed: 132
 		PauseOnCondition: notmobile
 	Health:


### PR DESCRIPTION
Hey all,

So TDGL finals showed that my tweak to APC turn speed may have been a bit much. This PR is simply undoing that change (Turnspeed: 28 -> 20).

The APC + Rockets isn't OP, but it's viable enough to make aircraft never worth it, which I don't think is better than the balance we had before.