### PR TITLE
Command Allied Units

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -49,6 +49,7 @@ Also thanks to:
     * clem
     * Cody Brittain (Generalcamo)
     * Constantin Helmig (CH4Code)
+    * copyrights
     * D2k Sardaukar
     * D'Arcy Rush (r34ch)
     * Daniel Derejvanik (Harisson)

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -140,7 +140,13 @@ namespace OpenRA.Orders
 			if (mi.Button != Game.Settings.Game.MouseButtonPreference.Action)
 				return null;
 
-			if (self.Owner != self.World.LocalPlayer)
+			if (self.World.LocalPlayer == null)
+				return null;
+
+			if (self.World.LocalPlayer.Spectating)
+				return null;
+
+			if (!self.World.LocalPlayer.CanControlUnitsOf(self.Owner))
 				return null;
 
 			if (self.World.IsGameOver)

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -103,6 +103,8 @@ namespace OpenRA
 
 		readonly StanceColors stanceColors;
 
+		readonly bool commandAlliedUnits;
+
 		public static FactionInfo ResolveFaction(string factionName, IEnumerable<FactionInfo> factionInfos, MersenneTwister playerRandom, bool requireSelectable = true)
 		{
 			var selectableFactions = factionInfos
@@ -228,6 +230,8 @@ namespace OpenRA
 
 			unlockRenderPlayer = PlayerActor.TraitsImplementing<IUnlocksRenderPlayer>().ToArray();
 			notifyDisconnected = PlayerActor.TraitsImplementing<INotifyPlayerDisconnected>().ToArray();
+
+			commandAlliedUnits = world.OrderManager.LobbyInfo.GlobalSettings.OptionOrDefault("commandalliedunits", false);
 		}
 
 		public override string ToString()
@@ -257,6 +261,11 @@ namespace OpenRA
 		public bool IsAlliedWith(Player p)
 		{
 			return RelationshipWith(p) == PlayerRelationship.Ally;
+		}
+
+		public bool CanControlUnitsOf(Player p)
+		{
+			return this == p || (commandAlliedUnits && IsAlliedWith(p));
 		}
 
 		public Color PlayerRelationshipColor(Actor a)

--- a/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
@@ -238,7 +238,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		protected override IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world)
 		{
-			if (!self.IsInWorld || self.Owner != self.World.LocalPlayer)
+			if (!self.IsInWorld || !world.LocalPlayer.CanControlUnitsOf(self.Owner))
 				yield break;
 
 			if (!self.Trait<PortableChrono>().Info.HasDistanceLimit)

--- a/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Orders
 			{
 				var underCursor = world.ScreenMap.ActorsAtMouse(mi)
 					.Select(a => a.Actor)
-					.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.TraitsImplementing<T>()
+					.FirstOrDefault(a => world.LocalPlayer.CanControlUnitsOf(a.Owner) && a.TraitsImplementing<T>()
 						.Any(IsValidTrait));
 
 				if (underCursor == null)

--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -139,7 +139,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// Target lines are only automatically shown for the owning player
 			// Spectators and allies must use the force-display modifier
-			if (self.Owner != self.World.LocalPlayer)
+			if (self.World.LocalPlayer == null || !self.World.LocalPlayer.CanControlUnitsOf(self.Owner))
 				return;
 
 			// Draw after frame end so that all the queueing of activities are done before drawing.

--- a/OpenRA.Mods.Common/Traits/World/ControlGroups.cs
+++ b/OpenRA.Mods.Common/Traits/World/ControlGroups.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			RemoveActorsFromAllControlGroups(world.Selection.Actors);
 
-			controlGroups[group].AddRange(world.Selection.Actors.Where(a => a.Owner == world.LocalPlayer));
+			controlGroups[group].AddRange(world.Selection.Actors.Where(a => world.LocalPlayer.CanControlUnitsOf(a.Owner)));
 		}
 
 		public void AddSelectionToControlGroup(int group)
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			RemoveActorsFromAllControlGroups(world.Selection.Actors);
 
-			controlGroups[group].AddRange(world.Selection.Actors.Where(a => a.Owner == world.LocalPlayer));
+			controlGroups[group].AddRange(world.Selection.Actors.Where(a => world.LocalPlayer.CanControlUnitsOf(a.Owner)));
 		}
 
 		public void CombineSelectionWithControlGroup(int group)
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var cg in controlGroups)
 			{
 				// note: NOT `!a.IsInWorld`, since that would remove things that are in transports.
-				cg.RemoveAll(a => a.Disposed || a.Owner != world.LocalPlayer);
+				cg.RemoveAll(a => a.Disposed || !world.LocalPlayer.CanControlUnitsOf(a.Owner));
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/Selection.cs
+++ b/OpenRA.Mods.Common/Traits/World/Selection.cs
@@ -130,7 +130,10 @@ namespace OpenRA.Mods.Common.Traits
 			// TODO: This probably should only be considering the newly selected actors
 			foreach (var actor in actors)
 			{
-				if (actor.Owner != world.LocalPlayer || !actor.IsInWorld)
+				if (world.LocalPlayer == null)
+					continue;
+
+				if (!world.LocalPlayer.CanControlUnitsOf(actor.Owner) || !actor.IsInWorld)
 					continue;
 
 				var selectable = actor.Info.TraitInfoOrDefault<ISelectableInfo>();

--- a/OpenRA.Mods.Common/Traits/World/TeamTogether.cs
+++ b/OpenRA.Mods.Common/Traits/World/TeamTogether.cs
@@ -1,0 +1,52 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Controls the team together checkbox in the lobby options.")]
+	public class TeamTogetherInfo : TraitInfo, ILobbyOptions
+	{
+		[Desc("Descriptive label for the command allied units checkbox in the lobby.")]
+		public readonly string CommandAlliedUnitsCheckboxLabel = "Command Allied Units";
+
+		[Desc("Tooltip description for the command allied units checkbox in the lobby.")]
+		public readonly string CommandAlliedUnitsCheckboxDescription = "Allow team members to command your units and like wise command team members units.";
+
+		[Desc("Default value of the command allied units checkbox in the lobby.")]
+		public readonly bool CommandAlliedUnitsCheckboxEnabled = false;
+
+		[Desc("Prevent the command allied units state from being changed in the lobby.")]
+		public readonly bool CommandAlliedUnitsCheckboxLocked = false;
+
+		[Desc("Whether to display the command allied units checkbox in the lobby.")]
+		public readonly bool CommandAlliedUnitsCheckboxVisible = true;
+
+		[Desc("Display order for the command allied units checkbox in the lobby.")]
+		public readonly int CommandAlliedUnitsCheckboxDisplayOrder = 0;
+
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
+		{
+			yield return new LobbyBooleanOption("commandalliedunits", CommandAlliedUnitsCheckboxLabel, CommandAlliedUnitsCheckboxDescription,
+				CommandAlliedUnitsCheckboxVisible, CommandAlliedUnitsCheckboxDisplayOrder, CommandAlliedUnitsCheckboxEnabled, CommandAlliedUnitsCheckboxLocked);
+		}
+
+		public override object Create(ActorInitializer init) { return TeamTogether.Instance; }
+	}
+
+	public class TeamTogether
+	{
+		public static readonly TeamTogether Instance = new TeamTogether();
+		TeamTogether() { }
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
@@ -285,7 +285,7 @@ namespace OpenRA.Mods.Common.Widgets
 				return;
 
 			selectedActors = world.Selection.Actors
-				.Where(a => a.Owner == world.LocalPlayer && a.IsInWorld && !a.IsDead)
+				.Where(a => world.LocalPlayer.CanControlUnitsOf(a.Owner) && a.IsInWorld && !a.IsDead)
 				.ToArray();
 
 			attackMoveDisabled = !selectedActors.Any(a => a.Info.HasTraitInfo<AttackMoveInfo>() && a.Info.HasTraitInfo<AutoTargetInfo>());

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/RemoveFromControlGroupHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/RemoveFromControlGroupHotkeyLogic.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 		protected override bool OnHotkeyActivated(KeyInput e)
 		{
 			var selectedActors = selection.Actors
-				.Where(a => a.Owner == world.LocalPlayer && a.IsInWorld && !a.IsDead)
+				.Where(a => world.LocalPlayer.CanControlUnitsOf(a.Owner) && a.IsInWorld && !a.IsDead)
 				.ToArray();
 
 			foreach (var a in selectedActors)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/StanceSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/StanceSelectorLogic.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Widgets
 				return;
 
 			actorStances = world.Selection.Actors
-				.Where(a => a.Owner == world.LocalPlayer && a.IsInWorld)
+				.Where(a => world.LocalPlayer.CanControlUnitsOf(a.Owner) && a.IsInWorld)
 				.SelectMany(a => a.TraitsImplementing<AutoTarget>()
 					.Where(at => at.Info.EnableStances)
 					.Select(at => new TraitPair<AutoTarget>(a, at)))

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -204,6 +204,8 @@ World:
 		GameSpeedDropdownDisplayOrder: 3
 	MapStartingLocations:
 		SeparateTeamSpawnsCheckboxDisplayOrder: 6
+	TeamTogether:
+		CommandAlliedUnitsCheckboxDisplayOrder: 7
 	CreateMapPlayers:
 	StartingUnits@mcvonly:
 		Class: none

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -170,6 +170,8 @@ World:
 	CreateMapPlayers:
 	MapStartingLocations:
 		SeparateTeamSpawnsCheckboxDisplayOrder: 6
+	TeamTogether:
+		CommandAlliedUnitsCheckboxDisplayOrder: 7
 	StartingUnits@mcv:
 		Class: none
 		ClassName: MCV Only

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -264,6 +264,8 @@ World:
 		OuterSupportRadius: 5
 	MapStartingLocations:
 		SeparateTeamSpawnsCheckboxDisplayOrder: 6
+	TeamTogether:
+		CommandAlliedUnitsCheckboxDisplayOrder: 7
 	SpawnStartingUnits:
 		DropdownDisplayOrder: 1
 	PathFinder:

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -359,6 +359,8 @@ World:
 		OuterSupportRadius: 5
 	MapStartingLocations:
 		SeparateTeamSpawnsCheckboxDisplayOrder: 6
+	TeamTogether:
+		CommandAlliedUnitsCheckboxDisplayOrder: 7
 	SpawnStartingUnits:
 		DropdownDisplayOrder: 1
 	CrateSpawner:


### PR DESCRIPTION
This is the first part to implement #19140, but it is a standalone feature.

This feature allows you to command allied units and allow allies to control your units. 

In the lobby you have a new option "Command Allied Units". When checked feature is activated. 
![team](https://user-images.githubusercontent.com/219009/107863099-b56a9700-6e51-11eb-9501-c29dd6727919.png)


ToDos:

- [x] command other units
- [x] restrict to allied units
- [x] allow command bar actions
- [x] allow binding allied units hotkeys
- [x] decide if prioritize selection of allied units is needed :arrow_right: **decision: no**
- [x] make it an option in game lobby
- [x] don't allow dead players to control all units :rofl:
- [x] add other half of command bar
- [x] add chrono annotations for allied units
- [x] new order/response when selecting allied units
- [x] add target lines for allied units
- [x] remove from control group hotkey for allied units