### PR TITLE
Fixed D2k VQA videos crashing the game

### DIFF
--- a/OpenRA.Mods.Cnc/FileFormats/VqaReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/VqaReader.cs
@@ -326,7 +326,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 			// Annoyingly, the complete table is not applied until the frame
 			// *after* the one that contains the 8th chunk.
 			// Do we have a set of partial lookup tables ready to apply?
-			if (currentChunkBuffer == chunkBufferParts)
+			if (currentChunkBuffer == chunkBufferParts && chunkBufferParts != 0)
 			{
 				if (!cbpIsCompressed)
 					cbf = (byte[])cbp.Clone();


### PR DESCRIPTION
What #18661 missed when pulling the check outside of the safety of the CBP0/CBPZ-specific case is that apparently Dune 2000 videos don't have any CBP? and thus `chunkBufferParts` is always 0.
I have verified that that is true for all D2k videos, so this piece of code is specific to TD and RA VQAs.

Fixes #19124.

P.S.: Apparently this also had the side-effect of fixing playback for TS VQAs, which also don't use any CBP.