### PR TITLE
Show out of range cursor when targeting cells inside a unit's minimum range

### DIFF
--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -496,7 +496,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (a == null)
 					a = armaments.First();
 
-				cursor = !target.IsInRange(self.CenterPosition, a.MaxRange())
+				cursor = !target.IsInRange(self.CenterPosition, a.MaxRange()) || target.IsInRange(self.CenterPosition, a.Weapon.MinRange)
 					? ab.Info.OutsideRangeCursor ?? a.Info.OutsideRangeCursor
 					: ab.Info.Cursor ?? a.Info.Cursor;
 


### PR DESCRIPTION
Reduces likelihood of accidentally undeploying Nod artillery in TS.