### PR TITLE
Add alpha support to TerrainSpriteLayer

### DIFF
--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Graphics
 			float sr = 0;
 			float sb = 0;
 
-			// See shp.vert for documentation on the channel attribute format
+			// See combined.vert for documentation on the channel attribute format
 			var attribC = r.Channel == TextureChannel.RGBA ? 0x02 : ((byte)r.Channel) << 1 | 0x01;
 			attribC |= samplers.X << 6;
 			var ss = r as SpriteWithSecondaryData;

--- a/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 					}
 				}
 
-				// All resources must share a sheet and blend mode
+				// All resources must share a blend mode
 				var sprites = r.Value.Variants.Values.SelectMany(v => Exts.MakeArray(v.Length, x => v.GetSprite(x)));
 				if (sprites.Any(s => s.BlendMode != spriteLayer.BlendMode))
 					throw new InvalidDataException("Resource sprites specify different blend modes. "

--- a/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
@@ -107,7 +107,7 @@ namespace OpenRA.Mods.Common.Traits
 			// resource.Type is meaningless (and may be null) if resource.Sequence is null
 			if (sequence != null)
 			{
-				shadowLayer?.Update(cell, sequence.GetShadow(frame, WAngle.Zero), palette, 1f, sequence.IgnoreWorldTint);
+				shadowLayer?.Update(cell, sequence.GetShadow(frame, WAngle.Zero), palette, 1f, 1f, sequence.IgnoreWorldTint);
 				spriteLayer.Update(cell, sequence, palette, frame);
 			}
 			else

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -294,8 +294,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (fogSprite != null)
 					fogPos += fogSprite.Offset - 0.5f * fogSprite.Size;
 
-				shroudLayer.Update(uv, shroudSprite, shroudPaletteReference, shroudPos, 1f, true);
-				fogLayer.Update(uv, fogSprite, fogPaletteReference, fogPos, 1f, true);
+				shroudLayer.Update(uv, shroudSprite, shroudPaletteReference, shroudPos, 1f, 1f, true);
+				fogLayer.Update(uv, fogSprite, fogPaletteReference, fogPos, 1f, 1f, true);
 			}
 
 			anyCellDirty = false;


### PR DESCRIPTION
Followup to #19122 that extends sequence Alpha support to `TerrainSpriteLayer` (resources, craters, shroud, etc). This is needed for rendering the fog with the remastered assets.

~~Depends on #19122.~~

Testcase: Add `Alpha: 0.5` to the shroud or resources sequence definitions.