### PR TITLE
Improve Health.InflictDamage performance

### DIFF
--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -88,6 +88,9 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
+				if (hp == MaxHP)
+					return DamageState.Undamaged;
+
 				if (hp <= 0)
 					return DamageState.Dead;
 
@@ -99,9 +102,6 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (hp * 100L < MaxHP * 75L)
 					return DamageState.Medium;
-
-				if (hp == MaxHP)
-					return DamageState.Undamaged;
 
 				return DamageState.Light;
 			}


### PR DESCRIPTION
While this is not responsible for the occasionally huge cost of `InflictDamage` (that's usually caused by `INotify*` calls to `ScriptTriggers`), profiling has shown that filtering out `100` damage modifiers (no damage change) early is cheaper than applying those anyway.
Additionally, profiling also showed foreach loops to be cheaper than LINQ here as well.

On `tran.husk2` on the RA shellmap, which loses health every 8 ticks, the cost for applying damage modifiers went down from ~180 to just ~9 stopwatch ticks (and from several thousand to just 50 on world tick 1). Other reproducable cases I compared showed improvements as well.

Also moved up the `Undamaged` check in `DamageState` since it should be cheaper than those Critical/Heavy/Medium checks, so in my opinion it makes sense to perform that first. More of an extra, though.