### PR TITLE
Specify interaction bounds relative to the mod tile size.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Interactable.cs
+++ b/OpenRA.Mods.Common/Traits/Interactable.cs
@@ -21,13 +21,13 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[Desc("Defines a custom rectangle for mouse interaction with the actor.",
 			"If null, the engine will guess an appropriate size based on the With*Body trait.",
-			"The first two numbers define the width and height of the rectangle.",
+			"The first two numbers define the width and height of the rectangle as a world distance.",
 			"The (optional) second two numbers define an x and y offset from the actor center.")]
-		public readonly int[] Bounds = null;
+		public readonly WDist[] Bounds = null;
 
 		[Desc("Defines a custom rectangle for Decorations (e.g. the selection box).",
 			"If null, Bounds will be used instead")]
-		public readonly int[] DecorationBounds = null;
+		public readonly WDist[] DecorationBounds = null;
 
 		public override object Create(ActorInitializer init) { return new Interactable(this); }
 	}
@@ -52,16 +52,17 @@ namespace OpenRA.Mods.Common.Traits
 			return autoBounds.Select(s => s.AutoMouseoverBounds(self, wr)).FirstOrDefault(r => !r.IsEmpty);
 		}
 
-		Polygon Bounds(Actor self, WorldRenderer wr, int[] bounds)
+		Polygon Bounds(Actor self, WorldRenderer wr, WDist[] bounds)
 		{
 			if (bounds == null)
 				return new Polygon(AutoBounds(self, wr));
 
-			var size = new int2(bounds[0], bounds[1]);
+			// Convert from WDist to pixels
+			var size = new int2(bounds[0].Length * wr.TileSize.Width / wr.TileScale, bounds[1].Length * wr.TileSize.Height / wr.TileScale);
 
 			var offset = -size / 2;
 			if (bounds.Length > 2)
-				offset += new int2(bounds[2], bounds[3]);
+				offset += new int2(bounds[2].Length * wr.TileSize.Width / wr.TileScale, bounds[3].Length * wr.TileSize.Height / wr.TileScale);
 
 			var xy = wr.ScreenPxPosition(self.CenterPosition) + offset;
 			return new Polygon(new Rectangle(xy.X, xy.Y, size.X, size.Y));

--- a/OpenRA.Mods.Common/Traits/IsometricSelectable.cs
+++ b/OpenRA.Mods.Common/Traits/IsometricSelectable.cs
@@ -87,12 +87,13 @@ namespace OpenRA.Mods.Common.Traits
 			int2 left, right, top, bottom;
 			if (bounds != null)
 			{
-				var offset = bounds.Length >= 4 ? new int2(bounds[2], bounds[3]) : int2.Zero;
+				// Convert from WDist to pixels
+				var offset = bounds.Length >= 4 ? new int2(bounds[2] * wr.TileSize.Width / wr.TileScale, bounds[3] * wr.TileSize.Height / wr.TileScale) : int2.Zero;
 				var center = wr.ScreenPxPosition(self.CenterPosition) + offset;
-				left = center - new int2(bounds[0] / 2, 0);
-				right = left + new int2(bounds[0], 0);
-				top = center - new int2(0, bounds[1] / 2);
-				bottom = top + new int2(0, bounds[1]);
+				left = center - new int2(bounds[0] * wr.TileSize.Width / (2 * wr.TileScale), 0);
+				right = left + new int2(bounds[0] * wr.TileSize.Width / wr.TileScale, 0);
+				top = center - new int2(0, bounds[1] * wr.TileSize.Height / (2 * wr.TileScale));
+				bottom = top + new int2(0, bounds[1] * wr.TileSize.Height / wr.TileScale);
 			}
 			else
 			{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20201213/ConvertBoundsToWDist.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20201213/ConvertBoundsToWDist.cs
@@ -1,0 +1,55 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class ConvertBoundsToWDist : UpdateRule
+	{
+		public override string Name => "Convert Interactable and Selection bounds from pixels to WDist.";
+
+		public override string Description =>
+			"The Bounds and DecorationBounds fields on Interactable and Selectable have been converted from pixels to WDist.\n" +
+			"All bounds must be scaled by 1024 (Rectangular map grid) or 1448 (Isometric map grid) divided by your mod tile size.";
+
+		readonly string[] traits = { "Interactable", "Selectable", "IsometricSelectable" };
+		readonly string[] fields = { "Bounds", "DecorationBounds" };
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var grid = modData.Manifest.Get<MapGrid>();
+			var tileSize = grid.TileSize;
+			var tileScale = grid.Type == MapGridType.RectangularIsometric ? 1448 : 1024;
+
+			foreach (var trait in traits)
+			{
+				foreach (var traitNode in actorNode.ChildrenMatching(trait))
+				{
+					foreach (var field in fields)
+					{
+						foreach (var fieldNode in traitNode.ChildrenMatching(field))
+						{
+							var value = fieldNode.NodeValue<int[]>();
+							for (var i = 0; i < value.Length; i++)
+								value[i] = value[i] * tileScale / (i % 2 == 1 ? tileSize.Height : tileSize.Width);
+
+							fieldNode.ReplaceValue(FieldSaver.FormatValue(value));
+						}
+					}
+				}
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -92,6 +92,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new ReplaceShadowPalette(),
 				new ReplaceResourceValueModifiers(),
 				new RemoveResourceType(),
+				new ConvertBoundsToWDist(),
 			})
 		};
 

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -46,7 +46,7 @@ TRAN:
 	SpawnActorOnDeath:
 		Actor: TRAN.Husk
 	Selectable:
-		DecorationBounds: 41,41
+		DecorationBounds: 1749, 1749
 
 HELI:
 	Inherits: ^Helicopter
@@ -109,7 +109,7 @@ HELI:
 		Delay: 40
 		Count: 1
 	Selectable:
-		DecorationBounds: 30,24
+		DecorationBounds: 1280, 1024
 	WithAmmoPipsDecoration:
 		Position: BottomLeft
 		Margin: 4, 3
@@ -167,7 +167,7 @@ ORCA:
 		Delay: 100
 		Count: 2
 	Selectable:
-		DecorationBounds: 30,24
+		DecorationBounds: 1280, 1024
 	WithAmmoPipsDecoration:
 		Position: BottomLeft
 		Margin: 4, 3

--- a/mods/cnc/rules/civilian.yaml
+++ b/mods/cnc/rules/civilian.yaml
@@ -416,7 +416,7 @@ BRIDGE1:
 		Actor: bridgehut
 		SpawnOffset: 0,2
 	Interactable:
-		Bounds: 96,96
+		Bounds: 4096, 4096
 
 BRIDGE2:
 	Inherits: ^Bridge
@@ -433,7 +433,7 @@ BRIDGE2:
 		Actor: bridgehut
 		SpawnOffset: 2,2
 	Interactable:
-		Bounds: 120,120
+		Bounds: 5120, 5120
 
 BRIDGE3:
 	Inherits: ^Bridge
@@ -450,7 +450,7 @@ BRIDGE3:
 		Actor: bridgehut
 		SpawnOffset: 1,2
 	Interactable:
-		Bounds: 144,120
+		Bounds: 6144, 5120
 
 BRIDGE4:
 	Inherits: ^Bridge
@@ -467,7 +467,7 @@ BRIDGE4:
 		Actor: bridgehut
 		SpawnOffset: 3,2
 	Interactable:
-		Bounds: 144,96
+		Bounds: 6144, 4096
 
 BRIDGEHUT:
 	AlwaysVisible:
@@ -478,7 +478,7 @@ BRIDGEHUT:
 	Targetable:
 		TargetTypes: BridgeHut, C4
 	Interactable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 
 C1:
 	Inherits: ^CivInfantry

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -237,7 +237,7 @@
 		Locomotor: wheeled
 		TurnSpeed: 20
 	Selectable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 	Targetable:
 		TargetTypes: Ground, Vehicle
 	Repairable:
@@ -288,7 +288,7 @@
 		TargetTypes: Air
 		RequiresCondition: airborne
 	Selectable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 	Repairable:
 		RepairActors: hpad
 	Aircraft:
@@ -344,8 +344,8 @@
 		AlwaysTurnInPlace: true
 		Locomotor: foot
 	Selectable:
-		Bounds: 18,18,0,-6
-		DecorationBounds: 12,17,0,-6
+		Bounds: 768, 768, 0, -256
+		DecorationBounds: 512, 725, 0, -256
 	Targetable:
 		TargetTypes: Ground, Infantry
 	QuantizeFacingsFromSequence:
@@ -520,7 +520,7 @@
 		Speed: 113
 		Voice: Move
 	Selectable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 	Targetable:
 		TargetTypes: Ground, Creep
 	HiddenUnderFog:
@@ -565,7 +565,7 @@
 		Speed: 71
 		Locomotor: critter
 	Selectable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 	Targetable:
 		TargetTypes: Ground, Creep
 	AutoTarget:
@@ -835,7 +835,7 @@
 	Inherits@1: ^SpriteActor
 	Inherits@shape: ^1x1Shape
 	Interactable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 	CombatDebugOverlay:
 	AppearsOnRadar:
 	OwnerLostAction:

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -273,8 +273,8 @@ TREX:
 	Armament:
 		Weapon: teeth
 	Selectable:
-		Bounds: 48,36,2,1
-		DecorationBounds: 52,38
+		Bounds: 2048, 1536, 85, 42
+		DecorationBounds: 2218, 1621
 	Buildable:
 		Description: Bipedal carnivore with a massive skull
 
@@ -287,7 +287,7 @@ TRIC:
 	Buildable:
 		Description: Quadruped with large bony frill and three horns
 	Selectable:
-		DecorationBounds: 34,24,0,2
+		DecorationBounds: 1450, 1024, 0, 85
 
 RAPT:
 	Inherits: ^DINO

--- a/mods/cnc/rules/ships.yaml
+++ b/mods/cnc/rules/ships.yaml
@@ -31,8 +31,8 @@ BOAT:
 	WithGunboatBody:
 		Sequence: left # Just a work-around to avoid crash
 	Selectable:
-		Bounds: 42,24
-		DecorationBounds: 42,24
+		Bounds: 1792, 1024
+		DecorationBounds: 1792, 1024
 	AutoTarget:
 		AllowMovement: false
 	RejectsOrders:
@@ -72,7 +72,7 @@ LST:
 	ClassicFacingBodyOrientation:
 	WithFacingSpriteBody:
 	Interactable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	WithCargo:
 		DisplayTypes: Infantry, Vehicle
 		LocalOffset: 390,-256,0, 390,256,0, 0,0,0, -390,-256,0, -390,256,0

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -2,7 +2,7 @@ FACT:
 	Inherits: ^BaseBuilding
 	Inherits@shape: ^3x2Shape
 	Selectable:
-		Bounds: 72,48
+		Bounds: 3072, 2048
 	Valued:
 		Cost: 3000
 	Tooltip:
@@ -140,7 +140,7 @@ NUKE:
 	Inherits: ^BaseBuilding
 	Inherits@shape: ^2x2Shape
 	Selectable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	HitShape:
 		TargetableOffsets: 630,299,0
 	Valued:
@@ -171,7 +171,7 @@ NUK2:
 	Inherits: ^BaseBuilding
 	Inherits@shape: ^2x2Shape
 	Selectable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	HitShape:
 		TargetableOffsets: 630,299,0
 	Valued:
@@ -236,8 +236,8 @@ PROC:
 	StoresResources:
 		Capacity: 1000
 	Selectable:
-		Bounds: 72,56
-		DecorationBounds: 73,72
+		Bounds: 3072, 2389
+		DecorationBounds: 3114, 3072
 	CustomSellValue:
 		Value: 400
 	FreeActor:
@@ -286,8 +286,8 @@ SILO:
 		RequiredForShortGame: false
 	-AcceptsDeliveredCash:
 	Selectable:
-		Bounds: 48,24
-		DecorationBounds: 49,30
+		Bounds: 2048, 1024
+		DecorationBounds: 2090, 1280
 
 PYLE:
 	Inherits: ^BaseBuilding
@@ -345,7 +345,7 @@ PYLE:
 		Amount: -15
 	ProvidesPrerequisite@buildingname:
 	Selectable:
-		Bounds: 48,42,0,-5
+		Bounds: 2048, 1792, 0, -213
 
 HAND:
 	Inherits: ^BaseBuilding
@@ -396,13 +396,13 @@ HAND:
 		Amount: -15
 	ProvidesPrerequisite@buildingname:
 	Selectable:
-		Bounds: 48,48
-		DecorationBounds: 48,68,0,-10
+		Bounds: 2048, 2048
+		DecorationBounds: 2048, 2901, 0, -426
 
 AFLD:
 	Inherits: ^BaseBuilding
 	Selectable:
-		Bounds: 96,48
+		Bounds: 4096, 2048
 	HitShape:
 		TargetableOffsets: 0,0,0, 0,-512,256, 0,-1451,384, 0,512,128, 0,1536,85
 		Type: Rectangle
@@ -480,8 +480,8 @@ WEAP:
 		Dimensions: 3,3
 		LocalCenterOffset: 0,-512,0
 	Selectable:
-		Bounds: 72,48
-		DecorationBounds: 72,64,0,-16
+		Bounds: 3072, 2048
+		DecorationBounds: 3072, 2730, 0, -682
 	Health:
 		HP: 110000
 	RevealsShroud:
@@ -522,7 +522,7 @@ HPAD:
 	Inherits: ^BaseBuilding
 	Inherits@shape: ^2x2Shape
 	Selectable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 768,-512,0, 768,512,0, -281,-512,0, -630,512,0
@@ -611,8 +611,8 @@ HQ:
 		Dimensions: 2,3
 		LocalCenterOffset: 0,-512,0
 	Selectable:
-		Bounds: 48,40,0,9
-		DecorationBounds: 48,53,0,-4
+		Bounds: 2048, 1706, 0, 384
+		DecorationBounds: 2048, 2261, 0, -170
 	WithSpriteBody:
 		PauseOnCondition: lowpower
 	Health:
@@ -674,8 +674,8 @@ FIX:
 		Footprint: _+_ +++ _+_
 		Dimensions: 3,3
 	Selectable:
-		Bounds: 64,34,0,3
-		DecorationBounds: 72,48
+		Bounds: 2730, 1450, 0, 128
+		DecorationBounds: 3072, 2048
 	Health:
 		HP: 80000
 	RevealsShroud:
@@ -719,8 +719,8 @@ EYE:
 		Dimensions: 2,3
 		LocalCenterOffset: 0,-512,0
 	Selectable:
-		Bounds: 48,40,0,9
-		DecorationBounds: 48,53,0,-4
+		Bounds: 2048, 1706, 0, 384
+		DecorationBounds: 2048, 2261, 0, -170
 	WithSpriteBody:
 		PauseOnCondition: lowpower
 	Health:
@@ -778,8 +778,8 @@ TMPL:
 		Dimensions: 3,3
 		LocalCenterOffset: 0,-512,0
 	Selectable:
-		Bounds: 72,48
-		DecorationBounds: 72,68,0,-12
+		Bounds: 3072, 2048
+		DecorationBounds: 3072, 2901, 0, -512
 	Health:
 		HP: 210000
 	RevealsShroud:
@@ -828,7 +828,7 @@ GUN:
 	Inherits: ^Defense
 	Inherits@AUTOTARGET: ^AutoTargetGround
 	Selectable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 	Valued:
 		Cost: 600
 	Tooltip:
@@ -879,7 +879,7 @@ SAM:
 	Inherits@AUTOTARGET: ^AutoTargetAir
 	Inherits@shape: ^2x1Shape
 	Selectable:
-		Bounds: 48,24
+		Bounds: 2048, 1024
 	HitShape:
 		Type: Rectangle
 			TopLeft: -768,-512
@@ -942,8 +942,8 @@ OBLI:
 		BuildDuration: 2080
 		Description: Advanced base defense.\nRequires power to operate.\n  Strong vs all Ground units\n  Cannot target Aircraft
 	Selectable:
-		Bounds: 24,24
-		DecorationBounds: 22,44,0,-10
+		Bounds: 1024, 1024
+		DecorationBounds: 938, 1877, 0, -426
 	Health:
 		HP: 75000
 	Armor:
@@ -978,7 +978,7 @@ GTWR:
 	Inherits: ^Defense
 	Inherits@AUTOTARGET: ^AutoTargetGround
 	Selectable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 	Valued:
 		Cost: 600
 	Tooltip:
@@ -1027,8 +1027,8 @@ ATWR:
 		BuildDuration: 1920
 		Description: All-purpose defensive structure.\n  Strong vs Aircraft, Infantry\n  Weak vs Tanks
 	Selectable:
-		Bounds: 24,24
-		DecorationBounds: 22,48,0,-12
+		Bounds: 1024, 1024
+		DecorationBounds: 938, 2048, 0, -512
 	Health:
 		HP: 55000
 	Armor:

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -1,7 +1,7 @@
 V19:
 	Inherits: ^TechBuilding
 	Selectable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 	CashTrickler:
 		Amount: 10
 		RequiresCondition: enabled
@@ -27,7 +27,7 @@ V19:
 V19.Husk:
 	Inherits: ^CivBuildingHusk
 	Interactable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 	WithSpriteBody:
 	WithIdleOverlay:
 		StartSequence: fire-start
@@ -42,7 +42,7 @@ HOSP:
 	Inherits: ^TechBuilding
 	Inherits@shape: ^2x2Shape
 	Selectable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -65,7 +65,7 @@ HOSP:
 HOSP.Husk:
 	Inherits: ^CivBuildingHusk
 	Interactable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -78,7 +78,7 @@ BIO:
 	Inherits: ^TechBuilding
 	Inherits@shape: ^2x2Shape
 	Selectable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -117,7 +117,7 @@ BIO:
 BIO.Husk:
 	Inherits: ^CivBuildingHusk
 	Interactable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -128,7 +128,7 @@ MISS:
 	Inherits: ^CivBuilding
 	Inherits@shape: ^3x2Shape
 	Selectable:
-		Bounds: 72,48
+		Bounds: 3072, 2048
 	Building:
 		Footprint: xxx xxx
 		Dimensions: 3,2

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -11,7 +11,7 @@ MCV:
 		Queue: Vehicle.GDI, Vehicle.Nod
 		Description: Deploys into another Construction Yard.\n  Unarmed
 	Selectable:
-		DecorationBounds: 36,36
+		DecorationBounds: 1536, 1536
 	Mobile:
 		Speed: 71
 		Locomotor: heavywheeled
@@ -52,7 +52,7 @@ HARV:
 		Queue: Vehicle.GDI, Vehicle.Nod
 		Description: Collects Tiberium for processing.\n  Unarmed
 	Selectable:
-		DecorationBounds: 36,36
+		DecorationBounds: 1536, 1536
 	Harvester:
 		Resources: Tiberium, BlueTiberium
 		Capacity: 20
@@ -468,7 +468,7 @@ MTNK:
 		OwnerType: InternalName
 		EffectiveOwnerFromOwner: true
 	Selectable:
-		DecorationBounds: 28,28
+		DecorationBounds: 1194, 1194
 
 HTNK:
 	Inherits: ^Tank
@@ -529,7 +529,7 @@ HTNK:
 		OwnerType: InternalName
 		EffectiveOwnerFromOwner: true
 	Selectable:
-		DecorationBounds: 34,34,0,-3
+		DecorationBounds: 1450, 1450, 0, -128
 
 MSAM:
 	Inherits: ^Tank

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -204,7 +204,7 @@
 		Locomotor: vehicle
 		PauseOnCondition: notmobile
 	Selectable:
-		Bounds: 32,32
+		Bounds: 1024, 1024
 	Targetable:
 		TargetTypes: Ground, Vehicle, C4
 	Passenger:
@@ -320,8 +320,8 @@
 		AlwaysTurnInPlace: true
 		Locomotor: foot
 	Selectable:
-		Bounds: 24,24,0,-4
-		DecorationBounds: 12,20,0,-4
+		Bounds: 768, 768, 0, -128
+		DecorationBounds: 384, 640, 0, -128
 	Targetable:
 		TargetTypes: Ground, Infantry
 	QuantizeFacingsFromSequence:

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -137,7 +137,7 @@ crate:
 	MapEditorData:
 		Categories: System
 	Interactable:
-		Bounds: 20,20
+		Bounds: 640, 640
 
 mpspawn:
 	Interactable:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -63,7 +63,7 @@ construction_yard:
 		-ConcretePrerequisites:
 	WithBuildingBib:
 	Selectable:
-		Bounds: 96,64
+		Bounds: 3072, 2048
 	Health:
 		HP: 30000
 	HitShape:
@@ -116,7 +116,7 @@ wind_trap:
 		BuildDurationModifier: 100
 		Description: Provides power for other structures.
 	Selectable:
-		Bounds: 64,64
+		Bounds: 2048, 2048
 	Valued:
 		Cost: 225
 	Tooltip:
@@ -165,7 +165,7 @@ barracks:
 		BuildDurationModifier: 100
 		Description: Trains infantry.
 	Selectable:
-		Bounds: 64,64
+		Bounds: 2048, 2048
 	Valued:
 		Cost: 225
 	Tooltip:
@@ -232,7 +232,7 @@ refinery:
 		BuildDurationModifier: 100
 		Description: Harvesters unload Spice here for processing.
 	Selectable:
-		Bounds: 96,64
+		Bounds: 3072, 2048
 	Valued:
 		Cost: 1500
 	Tooltip:
@@ -301,7 +301,7 @@ silo:
 		BuildDurationModifier: 100
 		Description: Stores excess harvested Spice.
 	Selectable:
-		Bounds: 32,32
+		Bounds: 1024, 1024
 	Valued:
 		Cost: 120
 	Tooltip:
@@ -356,7 +356,7 @@ light_factory:
 		BuildDurationModifier: 100
 		Description: Produces light vehicles.
 	Selectable:
-		Bounds: 96,64
+		Bounds: 3072, 2048
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -434,7 +434,7 @@ heavy_factory:
 		BuildDurationModifier: 100
 		Description: Produces heavy vehicles.
 	Selectable:
-		Bounds: 96,96
+		Bounds: 3072, 3072
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -522,7 +522,7 @@ outpost:
 		BuildDurationModifier: 100
 		Description: Provides a radar map of the battlefield.\n  Requires power to operate.
 	Selectable:
-		Bounds: 96,64
+		Bounds: 3072, 2048
 	Valued:
 		Cost: 750
 	Tooltip:
@@ -579,7 +579,7 @@ starport:
 		Footprint: xxx x=x =x=
 		Dimensions: 3,3
 	Selectable:
-		Bounds: 96,96
+		Bounds: 3072, 3072
 	Health:
 		HP: 35000
 	HitShape:
@@ -729,8 +729,8 @@ medium_gun_turret:
 	RequiresBuildableArea:
 		Adjacent: 4
 	Selectable:
-		Bounds: 32,32
-		DecorationBounds: 32,40,0,-8
+		Bounds: 1024, 1024
+		DecorationBounds: 1024, 1280, 0, -256
 	Health:
 		HP: 27000
 	Armor:
@@ -773,8 +773,8 @@ large_gun_turret:
 	RequiresBuildableArea:
 		Adjacent: 4
 	Selectable:
-		Bounds: 32,32
-		DecorationBounds: 32,40,0,-8
+		Bounds: 1024, 1024
+		DecorationBounds: 1024, 1280, 0, -256
 	Health:
 		HP: 30000
 	Armor:
@@ -828,7 +828,7 @@ repair_pad:
 	RevealsShroud:
 		Range: 3c768
 	Selectable:
-		Bounds: 96,96
+		Bounds: 3072, 3072
 	Reservable:
 	RepairsUnits:
 		Interval: 10
@@ -863,7 +863,7 @@ high_tech_factory:
 		BuildDurationModifier: 100
 		Description: Unlocks advanced technology.
 	Selectable:
-		Bounds: 96,96
+		Bounds: 3072, 3072
 	Valued:
 		Cost: 1150
 	Tooltip:
@@ -942,7 +942,7 @@ research_centre:
 		BuildDurationModifier: 100
 		Description: Unlocks advanced tanks.
 	Selectable:
-		Bounds: 96,96
+		Bounds: 3072, 3072
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -994,7 +994,7 @@ palace:
 		BuildDurationModifier: 100
 		Description: Unlocks elite infantry and weapons.
 	Selectable:
-		Bounds: 96,96
+		Bounds: 3072, 3072
 	Valued:
 		Cost: 1600
 	Tooltip:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -14,7 +14,7 @@ mcv:
 		Name: Mobile Construction Vehicle
 	Selectable:
 		Class: mcv
-		DecorationBounds: 42,42
+		DecorationBounds: 1344, 1344
 	Health:
 		HP: 45000
 	Armor:
@@ -63,7 +63,7 @@ harvester:
 		Name: Spice Harvester
 	Selectable:
 		Class: harvester
-		DecorationBounds: 42,42
+		DecorationBounds: 1344, 1344
 	Harvester:
 		Capacity: 28
 		HarvestFacings: 8
@@ -390,7 +390,7 @@ devastator:
 		Delay: 3
 		StartIfBelow: 50
 	Selectable:
-		DecorationBounds: 44,38,0,0
+		DecorationBounds: 1408, 1216, 0, 0
 
 raider:
 	Inherits: ^Vehicle

--- a/mods/ra/maps/allies-09a/rules.yaml
+++ b/mods/ra/maps/allies-09a/rules.yaml
@@ -7,9 +7,9 @@ World:
 		Scripts: campaign-global.lua, allies09a.lua, allies09a-AI.lua
 	MissionData:
 		Briefing: One of Stalin's top atomic strategists, Vladimir Kosygin, wishes to defect. His knowledge of Stalin's atomic strategies is invaluable to us. We will extract him from the Riga compound where he is stationed.\n\nUse a spy to infiltrate the Soviet command center and contact Kosygin. Once he is out of the building, guide him back to your base any way you can.
-		StartVideo: 
-		WinVideo: 
-		LossVideo: 
+		StartVideo:
+		WinVideo:
+		LossVideo:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -144,7 +144,7 @@ MOBILETENT:
 	Tooltip:
 		Name: Mobile Tent
 	Selectable:
-		DecorationBounds: 21,21
+		DecorationBounds: 896, 896
 	SelectionDecorations:
 	Health:
 		HP: 60000

--- a/mods/ra/maps/monster-tank-madness/rules.yaml
+++ b/mods/ra/maps/monster-tank-madness/rules.yaml
@@ -166,7 +166,7 @@ PBOX:
 		StartIfBelow: 100
 		DamageCooldown: 150
 	Selectable:
-		Bounds: 44,38,0,-4
+		Bounds: 1877, 1621, 0, -170
 	RenderSprites:
 		Image: 4TNK
 

--- a/mods/ra/maps/oil-spill/rules.yaml
+++ b/mods/ra/maps/oil-spill/rules.yaml
@@ -46,7 +46,7 @@ OILB.Husk:
 	Inherits@shape: ^2x2Shape
 	Selectable:
 		Priority: 0
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	CapturableProgressBar:
 	CapturableProgressBlink:
 	Building:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -95,8 +95,8 @@ MIG:
 		Ammo: 8
 		AmmoCondition: ammo
 	Selectable:
-		Bounds: 36,28,0,2
-		DecorationBounds: 40,29,0,1
+		Bounds: 1536, 1194, 0, 85
+		DecorationBounds: 1706, 1237, 0, 42
 	Contrail@1:
 		Offset: -598,-683,0
 	Contrail@2:
@@ -179,7 +179,7 @@ YAK:
 	ProducibleWithLevel:
 		Prerequisites: aircraft.upgraded
 	Selectable:
-		DecorationBounds: 30,28,0,2
+		DecorationBounds: 1280, 1194, 0, 85
 	Rearmable:
 		RearmActors: afld, afld.ukraine
 	WithAmmoPipsDecoration:
@@ -240,7 +240,7 @@ TRAN:
 	SpawnActorOnDeath:
 		Actor: TRAN.Husk
 	Selectable:
-		DecorationBounds: 40,36
+		DecorationBounds: 1706, 1536
 
 HELI:
 	Inherits: ^Helicopter
@@ -304,7 +304,7 @@ HELI:
 	ProducibleWithLevel:
 		Prerequisites: aircraft.upgraded
 	Selectable:
-		DecorationBounds: 36,28
+		DecorationBounds: 1536, 1194
 	Rearmable:
 		RearmActors: hpad
 	WithAmmoPipsDecoration:
@@ -377,7 +377,7 @@ HIND:
 	ProducibleWithLevel:
 		Prerequisites: aircraft.upgraded
 	Selectable:
-		DecorationBounds: 38,32
+		DecorationBounds: 1621, 1365
 	Rearmable:
 		RearmActors: hpad
 	WithAmmoPipsDecoration:
@@ -479,7 +479,7 @@ MH60:
 	ProducibleWithLevel:
 		Prerequisites: aircraft.upgraded
 	Selectable:
-		DecorationBounds: 38,32
+		DecorationBounds: 1621, 1365
 	Rearmable:
 		RearmActors: hpad
 	WithAmmoPipsDecoration:

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -124,7 +124,7 @@ FCOM:
 	Inherits: ^TechBuilding
 	Inherits@shape: ^2x2Shape
 	Selectable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	OwnerLostAction:
 		Action: ChangeOwner
 	Building:
@@ -176,7 +176,7 @@ HOSP:
 		Action: ChangeOwner
 	Selectable:
 		Priority: 0
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -400,7 +400,7 @@ BARL:
 	MapEditorData:
 		Categories: Decoration
 	Interactable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 
 BRL3:
 	Inherits: ^TechBuilding
@@ -422,7 +422,7 @@ BRL3:
 	MapEditorData:
 		Categories: Decoration
 	Interactable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 
 AMMOBOX1:
 	Inherits: ^AmmoBox
@@ -441,7 +441,7 @@ MISS:
 		TargetableOffsets: 0,0,0, 840,0,0, 840,-1024,0, 420,768,0, -840,0,0, -840,-1024,0, -840,1024,0
 	Selectable:
 		Priority: 0
-		Bounds: 72,48
+		Bounds: 3072, 2048
 	OwnerLostAction:
 		Action: ChangeOwner
 	Building:
@@ -485,7 +485,7 @@ BIO:
 	Inherits: ^TechBuilding
 	Inherits@shape: ^2x2Shape
 	Selectable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	OwnerLostAction:
 		Action: ChangeOwner
 	Building:
@@ -523,7 +523,7 @@ OILB:
 		TargetableOffsets: 0,0,0, 630,-300,0, 420,512,0, -420,-512,0, -630,300,0
 	Selectable:
 		Priority: 0
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	OwnerLostAction:
 		Action: ChangeOwner
 	Building:
@@ -614,7 +614,7 @@ BRIDGE1:
 		Actor: bridgehut
 		SpawnOffset: 0,1
 	Interactable:
-		Bounds: 120,72
+		Bounds: 5120, 3072
 
 BRIDGE2:
 	Inherits: ^Bridge
@@ -632,7 +632,7 @@ BRIDGE2:
 		Actor: bridgehut
 		SpawnOffset: 2,1
 	Interactable:
-		Bounds: 120,48
+		Bounds: 5120, 2048
 
 BRIDGE3:
 	Inherits: ^Bridge
@@ -650,7 +650,7 @@ BRIDGE3:
 		Actor: bridgehut
 		SpawnOffset: 0,1
 	Interactable:
-		Bounds: 96,48
+		Bounds: 4096, 2048
 
 BRIDGE4:
 	Inherits: ^Bridge
@@ -668,7 +668,7 @@ BRIDGE4:
 		Actor: bridgehut
 		SpawnOffset: 2,1
 	Interactable:
-		Bounds: 96,48
+		Bounds: 4096, 2048
 
 SBRIDGE1:
 	Inherits: ^Bridge
@@ -686,7 +686,7 @@ SBRIDGE1:
 		Actor: bridgehut.small
 		SpawnOffset: 1,1
 	Interactable:
-		Bounds: 72,48
+		Bounds: 3072, 2048
 
 SBRIDGE2:
 	Inherits: ^Bridge
@@ -704,7 +704,7 @@ SBRIDGE2:
 		Actor: bridgehut.small
 		SpawnOffset: 1,1
 	Interactable:
-		Bounds: 48,72
+		Bounds: 2048, 3072
 
 SBRIDGE3:
 	Inherits: ^Bridge
@@ -738,7 +738,7 @@ BRIDGEHUT:
 		Footprint: __ __
 		Dimensions: 2,2
 	Selectable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 		Priority: 2
 	LegacyBridgeHut:
 	Targetable:
@@ -750,7 +750,7 @@ BRIDGEHUT.small:
 		Footprint: _
 		Dimensions: 1,1
 	Selectable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 		Priority: 2
 	LegacyBridgeHut:
 	Targetable:
@@ -923,7 +923,7 @@ LHUS:
 	MapEditorData:
 		RequireTilesets: TEMPERAT
 	Selectable:
-		Bounds: 24,48,0,-16
+		Bounds: 1024, 2048, 0, -682
 	Tooltip:
 		Name: Lighthouse
 	Building:
@@ -935,8 +935,8 @@ WINDMILL:
 	MapEditorData:
 		RequireTilesets: TEMPERAT
 	Selectable:
-		Bounds: 24,24,0,-14
-		DecorationBounds: 36,36,0,-14
+		Bounds: 1024, 1024, 0, -597
+		DecorationBounds: 1536, 1536, 0, -597
 	Tooltip:
 		Name: Windmill
 	Building:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -249,7 +249,7 @@
 		Locomotor: wheeled
 		TurnSpeed: 20
 	Selectable:
-		Bounds: 24, 24
+		Bounds: 1024, 1024
 	Targetable:
 		RequiresCondition: !parachute
 		TargetTypes: GroundActor, Vehicle
@@ -335,8 +335,8 @@
 		AlwaysTurnInPlace: true
 		Locomotor: foot
 	Selectable:
-		Bounds: 18,20,0,-6
-		DecorationBounds: 12,18,0,-8
+		Bounds: 768, 853, 0, -256
+		DecorationBounds: 512, 768, 0, -341
 	Targetable:
 		RequiresCondition: !parachute
 		TargetTypes: GroundActor, Infantry, Disguise
@@ -498,7 +498,7 @@
 	Mobile:
 		Locomotor: naval
 	Selectable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 	Targetable:
 		TargetTypes: WaterActor, Ship
 	Targetable@REPAIR:
@@ -550,7 +550,7 @@
 	AppearsOnRadar:
 		UseLocation: true
 	Selectable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 	Aircraft:
 		AirborneCondition: airborne
 	Targetable@GROUND:
@@ -729,7 +729,7 @@
 	Inherits: ^Building
 	Inherits@selection: ^SelectableCombatBuilding
 	Selectable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 	Targetable:
 		TargetTypes: GroundActor, C4, DetonateAttack, Structure, Defense
 	MustBeDestroyed:
@@ -750,7 +750,7 @@
 	Inherits@shape: ^1x1Shape
 	Inherits@handicaps: ^PlayerHandicaps
 	Interactable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 	OwnerLostAction:
 		Action: ChangeOwner
 	Building:
@@ -861,7 +861,7 @@
 	MapEditorData:
 		Categories: Decoration
 	Interactable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 
 ^CivBuilding:
 	Inherits: ^TechBuilding
@@ -1083,7 +1083,7 @@
 	BodyOrientation:
 		QuantizedFacings: 1
 	Interactable:
-		Bounds: 96,48
+		Bounds: 4096, 2048
 	ShakeOnDeath:
 		Duration: 15
 		Intensity: 6
@@ -1122,7 +1122,7 @@
 ^Crate:
 	Inherits@1: ^SpriteActor
 	Interactable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 	HiddenUnderFog:
 	Tooltip:
 		Name: Crate
@@ -1156,7 +1156,7 @@
 ^Mine:
 	Inherits: ^SpriteActor
 	Interactable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 	WithSpriteBody:
 	HiddenUnderFog:
 	Mine:

--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -3,7 +3,7 @@ FPWR:
 	Inherits@infiltrate: ^InfiltratableFake
 	Inherits@shape: ^2x2Shape
 	Selectable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 640,-384,0, 640,512,0, -710,-512,0, -710,512,0
@@ -37,7 +37,7 @@ TENF:
 	Inherits@infiltrate: ^InfiltratableFake
 	Inherits@shape: ^2x2Shape
 	Selectable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	Buildable:
 		BuildPaletteOrder: 880
 		Queue: Defense
@@ -70,7 +70,7 @@ SYRF:
 	Inherits: ^FakeBuilding
 	Inherits@infiltrate: ^InfiltratableFake
 	Selectable:
-		Bounds: 72,48
+		Bounds: 3072, 2048
 	Buildable:
 		BuildPaletteOrder: 890
 		Queue: Defense
@@ -115,7 +115,7 @@ SPEF:
 	Inherits: ^FakeBuilding
 	Inherits@infiltrate: ^InfiltratableFake
 	Selectable:
-		Bounds: 72,48
+		Bounds: 3072, 2048
 	Targetable:
 		TargetTypes: WaterActor, Structure, SpyInfiltrate
 	Buildable:
@@ -160,7 +160,7 @@ WEAF:
 	Inherits@infiltrate: ^InfiltratableFake
 	Inherits@shape: ^3x2Shape
 	Selectable:
-		Bounds: 72,48
+		Bounds: 3072, 2048
 	Buildable:
 		BuildPaletteOrder: 920
 		Prerequisites: ~structures.france, ~techlevel.medium
@@ -199,7 +199,7 @@ DOMF:
 	Inherits@infiltrate: ^InfiltratableFake
 	Inherits@shape: ^2x2Shape
 	Selectable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 630,-384,0, 630,384,0, -700,-512,0, -700,512,0
@@ -231,8 +231,8 @@ DOMF:
 FIXF:
 	Inherits: ^FakeBuilding
 	Selectable:
-		Bounds: 68,34,0,3
-		DecorationBounds: 72,48
+		Bounds: 2901, 1450, 0, 128
+		DecorationBounds: 3072, 2048
 	Buildable:
 		BuildPaletteOrder: 940
 		Queue: Defense
@@ -291,8 +291,8 @@ FAPW:
 	RenderSprites:
 		Image: APWR
 	Selectable:
-		Bounds: 72,48
-		DecorationBounds: 72,68,0,-10
+		Bounds: 3072, 2048
+		DecorationBounds: 3072, 2901, 0, -426
 	Valued:
 		Cost: 50
 
@@ -301,7 +301,7 @@ ATEF:
 	Inherits@IDISABLE: ^DisableOnLowPower
 	Inherits@shape: ^2x2Shape
 	Selectable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	Tooltip:
 		Name: Fake Allied Tech Center
 		GenericName: Allied Tech Center
@@ -332,7 +332,7 @@ PDOF:
 	Inherits@IDISABLE: ^DisableOnLowPower
 	Inherits@shape: ^2x2Shape
 	Selectable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	Tooltip:
 		Name: Fake Chronosphere
 		GenericName: Chronosphere
@@ -366,7 +366,7 @@ MSLF:
 	Inherits@IDISABLE: ^DisableOnLowPower
 	Inherits@shape: ^2x1Shape
 	Selectable:
-		Bounds: 48,24
+		Bounds: 2048, 1024
 	Tooltip:
 		Name: Fake Missile Silo
 		GenericName: Missile Silo
@@ -396,7 +396,7 @@ MSLF:
 FACF:
 	Inherits: ^FakeBuilding
 	Selectable:
-		Bounds: 72,72
+		Bounds: 3072, 3072
 	Buildable:
 		BuildPaletteOrder: 1000
 		Queue: Defense

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -14,8 +14,8 @@ DOG:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Selectable:
-		Bounds: 12,17,-1,-4
-		DecorationBounds: 12,17,-1,-4
+		Bounds: 512, 725, -42, -170
+		DecorationBounds: 512, 725, -42, -170
 	Health:
 		HP: 1800
 	Mobile:
@@ -749,8 +749,8 @@ Ant:
 		Prerequisites: ~barracks, ~bio
 		Description: Irradiated insect that grew oversize.
 	Selectable:
-		Bounds: 24,24,0,-5
-		DecorationBounds: 30,30,0,-2
+		Bounds: 1024, 1024, 0, -213
+		DecorationBounds: 1280, 1280, 0, -85
 	Health:
 		HP: 75000
 	Mobile:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -63,7 +63,7 @@ SS:
 		EmptyWeapon: UnitExplodeSubmarine
 	-MustBeDestroyed:
 	Selectable:
-		DecorationBounds: 38,38
+		DecorationBounds: 1621, 1621
 
 MSUB:
 	Inherits: ^Ship
@@ -134,7 +134,7 @@ MSUB:
 		EmptyWeapon: UnitExplodeSubmarine
 	-MustBeDestroyed:
 	Selectable:
-		DecorationBounds: 44,44
+		DecorationBounds: 1877, 1877
 
 DD:
 	Inherits: ^Ship
@@ -186,7 +186,7 @@ DD:
 		Range: 4c0
 	RenderDetectionCircle:
 	Selectable:
-		DecorationBounds: 38,38
+		DecorationBounds: 1621, 1621
 
 CA:
 	Inherits: ^Ship
@@ -249,7 +249,7 @@ CA:
 	WithSpriteTurret@SECONDARY:
 		Turret: secondary
 	Selectable:
-		DecorationBounds: 44,44
+		DecorationBounds: 1877, 1877
 
 LST:
 	Inherits: ^Ship
@@ -288,7 +288,7 @@ LST:
 		LoadingCondition: notmobile
 	-Chronoshiftable:
 	Selectable:
-		DecorationBounds: 36,36
+		DecorationBounds: 1536, 1536
 
 PT:
 	Inherits: ^Ship
@@ -337,4 +337,4 @@ PT:
 		Range: 4c0
 	RenderDetectionCircle:
 	Selectable:
-		DecorationBounds: 36,36
+		DecorationBounds: 1536, 1536

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -3,7 +3,7 @@ MSLO:
 	Inherits@IDISABLE: ^DisableOnLowPowerOrPowerDown
 	Inherits@shape: ^2x1Shape
 	Selectable:
-		Bounds: 48,24
+		Bounds: 2048, 1024
 	Valued:
 		Cost: 2500
 	Tooltip:
@@ -81,8 +81,8 @@ GAP:
 		Prerequisites: atek, ~structures.allies, ~techlevel.high
 		Description: Obscures the enemy's view with shroud.\nRequires power to operate.
 	Selectable:
-		Bounds: 24,24
-		DecorationBounds: 24,48,0,-12
+		Bounds: 1024, 1024
+		DecorationBounds: 1024, 2048, 0, -512
 	WithSpriteBody:
 		PauseOnCondition: disabled
 	Health:
@@ -118,7 +118,7 @@ SPEN:
 	Inherits: ^Building
 	Inherits@PRIMARY: ^PrimaryBuilding
 	Selectable:
-		Bounds: 72,48
+		Bounds: 3072, 2048
 	InfiltrateForSupportPower:
 		Proxy: powerproxy.sonarpulse
 		Types: SpyInfiltrate
@@ -257,7 +257,7 @@ SYRD:
 	Inherits: ^Building
 	Inherits@PRIMARY: ^PrimaryBuilding
 	Selectable:
-		Bounds: 72,48
+		Bounds: 3072, 2048
 	InfiltrateForSupportPower:
 		Proxy: powerproxy.sonarpulse
 		Types: SpyInfiltrate
@@ -392,8 +392,8 @@ IRON:
 		Footprint: xx
 		Dimensions: 2,1
 	Selectable:
-		Bounds: 48,28,0,2
-		DecorationBounds: 50,50,0,-12
+		Bounds: 2048, 1194, 0, 85
+		DecorationBounds: 2133, 2133, 0, -512
 	Health:
 		HP: 100000
 	Armor:
@@ -443,7 +443,7 @@ PDOX:
 	Inherits@IDISABLE: ^DisableOnLowPowerOrPowerDown
 	Inherits@shape: ^2x2Shape
 	Selectable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 120
@@ -541,8 +541,8 @@ TSLA:
 	Tooltip:
 		Name: Tesla Coil
 	Selectable:
-		Bounds: 24,24
-		DecorationBounds: 24,40,0,-8
+		Bounds: 1024, 1024
+		DecorationBounds: 1024, 1706, 0, -341
 	Health:
 		HP: 40000
 	Armor:
@@ -586,8 +586,8 @@ AGUN:
 	Tooltip:
 		Name: AA Gun
 	Selectable:
-		Bounds: 24,24
-		DecorationBounds: 24,32,0,-4
+		Bounds: 1024, 1024
+		DecorationBounds: 1024, 1365, 0, -170
 	Health:
 		HP: 40000
 	Armor:
@@ -628,7 +628,7 @@ DOME:
 	Inherits@IDISABLE: ^DisableOnLowPowerOrPowerDown
 	Inherits@shape: ^2x2Shape
 	Selectable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 630,-384,0, 630,384,0, -700,-512,0, -700,512,0
@@ -892,7 +892,7 @@ SAM:
 	Inherits@AUTOTARGET: ^AutoTargetAir
 	Inherits@shape: ^2x1Shape
 	Selectable:
-		Bounds: 48,24
+		Bounds: 2048, 1024
 	HitShape:
 		Type: Rectangle
 			TopLeft: -768,-512
@@ -949,7 +949,7 @@ ATEK:
 	Inherits@IDISABLE: ^DisableOnLowPower
 	Inherits@shape: ^2x2Shape
 	Selectable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 140
@@ -1001,7 +1001,7 @@ WEAP:
 	Inherits@shape: ^3x2Shape
 	Inherits@PRIMARY: ^PrimaryBuilding
 	Selectable:
-		Bounds: 72,48
+		Bounds: 3072, 2048
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 80
@@ -1108,7 +1108,7 @@ WEAP:
 FACT:
 	Inherits: ^Building
 	Selectable:
-		Bounds: 72,72
+		Bounds: 3072, 3072
 	Building:
 		Footprint: xxX xxx XxX ===
 		Dimensions: 3,4
@@ -1234,8 +1234,8 @@ PROC:
 		Dimensions: 3,4
 		LocalCenterOffset: 0,-512,0
 	Selectable:
-		Bounds: 72,50,0,4
-		DecorationBounds: 72,70,0,-2
+		Bounds: 3072, 2133, 0, 170
+		DecorationBounds: 3072, 2986, 0, -85
 	Targetable:
 		TargetTypes: GroundActor, Structure, C4, DetonateAttack, ThiefInfiltrate, SpyInfiltrate
 	Health:
@@ -1301,7 +1301,7 @@ PROC:
 SILO:
 	Inherits: ^Building
 	Selectable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 35
@@ -1350,7 +1350,7 @@ HPAD:
 	Inherits@shape: ^2x2Shape
 	Inherits@PRIMARY: ^PrimaryBuilding
 	Selectable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 768,-512,0, 768,512,0, -281,-512,0, -630,512,0
@@ -1448,7 +1448,7 @@ AFLD:
 		Name: Airfield
 	Selectable:
 		Class: afld
-		Bounds: 72,48
+		Bounds: 3072, 2048
 	Building:
 		Footprint: xxx xxx
 		Dimensions: 3,2
@@ -1586,7 +1586,7 @@ POWR:
 	Inherits@POWER_OUTAGE: ^DisabledByPowerOutage
 	Inherits@shape: ^2x2Shape
 	Selectable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 640,-384,0, 640,512,0, -710,-512,0, -710,512,0
@@ -1643,8 +1643,8 @@ APWR:
 		Dimensions: 3,3
 		LocalCenterOffset: 0,-512,0
 	Selectable:
-		Bounds: 72,48
-		DecorationBounds: 72,68,0,-10
+		Bounds: 3072, 2048
+		DecorationBounds: 3072, 2901, 0, -426
 	Health:
 		HP: 70000
 	Armor:
@@ -1665,7 +1665,7 @@ STEK:
 	Inherits: ^ScienceBuilding
 	Inherits@shape: ^3x2Shape
 	Selectable:
-		Bounds: 72,48
+		Bounds: 3072, 2048
 	HitShape:
 		TargetableOffsets: 420,-768,0, 420,768,0, -770,-768,0, -770,768,0
 	Buildable:
@@ -1703,7 +1703,7 @@ BARR:
 	Inherits@shape: ^2x2Shape
 	Inherits@PRIMARY: ^PrimaryBuilding
 	Selectable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 490,-470,0, 355,512,0, -355,-512,0, -630,512,0
@@ -1787,7 +1787,7 @@ KENN:
 	Inherits: ^Building
 	Inherits@PRIMARY: ^PrimaryBuilding
 	Selectable:
-		Bounds: 24,24
+		Bounds: 1024, 1024
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 175
@@ -1864,7 +1864,7 @@ TENT:
 	Inherits@shape: ^2x2Shape
 	Inherits@PRIMARY: ^PrimaryBuilding
 	Selectable:
-		Bounds: 48,48
+		Bounds: 2048, 2048
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 630,-512,0, 355,512,0, -281,-512,0, -630,512,0
@@ -1965,8 +1965,8 @@ FIX:
 		Footprint: _+_ +++ _+_
 		Dimensions: 3,3
 	Selectable:
-		Bounds: 68,34,0,3
-		DecorationBounds: 72,48
+		Bounds: 2901, 1450, 0, 128
+		DecorationBounds: 3072, 2048
 	Health:
 		HP: 80000
 	Armor:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -45,7 +45,7 @@ V2RL:
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 	Selectable:
-		DecorationBounds: 28,28
+		DecorationBounds: 1194, 1194
 
 1TNK:
 	Inherits: ^TrackedVehicle
@@ -133,7 +133,7 @@ V2RL:
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 	Selectable:
-		DecorationBounds: 28,28
+		DecorationBounds: 1194, 1194
 
 3TNK:
 	Inherits: ^TrackedVehicle
@@ -179,7 +179,7 @@ V2RL:
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 	Selectable:
-		DecorationBounds: 28,28
+		DecorationBounds: 1194, 1194
 
 4TNK:
 	Inherits: ^TrackedVehicle
@@ -238,7 +238,7 @@ V2RL:
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 	Selectable:
-		DecorationBounds: 44,38,0,-4
+		DecorationBounds: 1877, 1621, 0, -170
 
 ARTY:
 	Inherits: ^TrackedVehicle
@@ -298,7 +298,7 @@ HARV:
 		Name: Ore Truck
 		GenericName: Harvester
 	Selectable:
-		DecorationBounds: 42,42
+		DecorationBounds: 1792, 1792
 	Harvester:
 		Capacity: 20
 		Resources: Ore,Gems
@@ -359,7 +359,7 @@ MCV:
 	Tooltip:
 		Name: Mobile Construction Vehicle
 	Selectable:
-		DecorationBounds: 42,42
+		DecorationBounds: 1792, 1792
 	Health:
 		HP: 60000
 	Armor:
@@ -658,7 +658,7 @@ TTNK:
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 	Selectable:
-		DecorationBounds: 30,30
+		DecorationBounds: 1280, 1280
 
 FTRK:
 	Inherits: ^Vehicle
@@ -707,7 +707,7 @@ FTRK:
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 	Selectable:
-		DecorationBounds: 28,28
+		DecorationBounds: 1194, 1194
 
 DTRK:
 	Inherits: ^Vehicle
@@ -791,7 +791,7 @@ CTNK:
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 	Selectable:
-		DecorationBounds: 30,30
+		DecorationBounds: 1280, 1280
 
 QTNK:
 	Inherits: ^TrackedVehicle
@@ -831,7 +831,7 @@ QTNK:
 	Targetable:
 		TargetTypes: GroundActor, MADTank, Vehicle
 	Selectable:
-		DecorationBounds: 44,38,0,-4
+		DecorationBounds: 1877, 1621, 0, -170
 
 STNK:
 	Inherits: ^Vehicle

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -134,7 +134,7 @@ ORCA:
 		Prerequisites: ~gahpad
 		Description: Fast assault gunship with\ndual missile launchers.\n  Strong vs Buildings, Vehicles\n  Weak vs Infantry, Aircraft
 	Selectable:
-		Bounds: 30,24
+		Bounds: 905, 1448
 	Aircraft:
 		TurnSpeed: 20
 		Speed: 186
@@ -195,7 +195,7 @@ ORCAB:
 		Prerequisites: ~gahpad, gatech
 		Description: Heavy bomber.\n  Strong vs Buildings, Vehicles\n  Weak vs Infantry, Aircraft
 	Selectable:
-		Bounds: 30,24
+		Bounds: 905, 1448
 	Aircraft:
 		CruiseAltitude: 5c512
 		TurnSpeed: 12
@@ -323,7 +323,7 @@ TRNSPORT:
 		Type: CenterPosition
 	RenderSprites:
 	Selectable:
-		Bounds: 44,32,0,-8
+		Bounds: 1327, 1930, 0, -482
 	SpawnActorOnDeath:
 		Actor: TRNSPORT.Husk
 		RequiresCondition: !empdisable
@@ -347,7 +347,7 @@ SCRIN:
 		Prerequisites: ~nahpad, natech
 		Description: Advanced fighter-bomber craft\nwith twin plasma cannons.\n  Strong vs Buildings, Vehicles\n  Weak vs Infantry, Aircraft
 	Selectable:
-		Bounds: 30,24
+		Bounds: 905, 1448
 	Voiced:
 		VoiceSet: Scrin
 	Aircraft:
@@ -414,7 +414,7 @@ APACHE:
 		Prerequisites: ~nahpad
 		Description: Anti-personnel support gunship\narmed with dual chain guns.\n  Strong vs Infantry, Light armor, Aircraft\n  Weak vs Vehicles
 	Selectable:
-		Bounds: 30,24
+		Bounds: 905, 1448
 	Aircraft:
 		Pitch: -32
 		PitchSpeed: 8

--- a/mods/ts/rules/bridges.yaml
+++ b/mods/ts/rules/bridges.yaml
@@ -89,7 +89,7 @@ LOBRDG_A_D:
 		AOffset: 1,-1
 		BOffset: 1,1
 	Interactable:
-		Bounds: 96, 48
+		Bounds: 2896, 2896
 
 LOBRDG_B:
 	Inherits: ^LowBridge
@@ -128,7 +128,7 @@ LOBRDG_B_D:
 		AOffset: 1,1
 		BOffset: -1,1
 	Interactable:
-		Bounds: 96, 48
+		Bounds: 2896, 2896
 
 LOBRDG_R_SE:
 	Inherits: ^LowBridgeRamp
@@ -190,7 +190,7 @@ LOBRDG_R_SW:
 	MapEditorData:
 		Categories: Bridge
 	Interactable:
-		Bounds: 96, 144
+		Bounds: 2896, 8688
 
 BRIDGE1:
 	Inherits: ^ElevatedBridgePlaceholder

--- a/mods/ts/rules/critters.yaml
+++ b/mods/ts/rules/critters.yaml
@@ -10,7 +10,7 @@ DOGGIE:
 	Health:
 		HP: 25000
 	Selectable:
-		Bounds: 24,24
+		Bounds: 724, 1448
 	Valued:
 		Cost: 100
 	Armor:
@@ -138,7 +138,7 @@ JFISH:
 		Image: floater
 		Palette: player-nobright
 	Selectable:
-		Bounds: 32,32,0,-5
+		Bounds: 965, 1930, 0, -301
 	AmbientSound:
 		SoundFiles: floatmov.aud, flotmov2.aud, flotmov3.aud, flotmov4.aud
 		Delay: 150, 450

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -466,7 +466,7 @@
 	MapEditorData:
 		Categories: System
 	Interactable:
-		Bounds: 24,24
+		Bounds: 724, 1448
 
 ^Wall:
 	Inherits@1: ^SpriteActor
@@ -570,8 +570,8 @@
 		Locomotor: foot
 	TurnOnIdle:
 	Selectable:
-		DecorationBounds: 15,23,0,-9
-		Bounds: 24,24,0,-9
+		DecorationBounds: 452, 1387, 0, -543
+		Bounds: 724, 1448, 0, -543
 	Voiced:
 		VoiceSet: Infantry
 	Targetable:
@@ -781,7 +781,7 @@
 		TurnSpeed: 20
 		Voice: Move
 	Selectable:
-		Bounds: 40,24
+		Bounds: 1206, 1448
 	Voiced:
 		VoiceSet: Vehicle
 	Targetable:
@@ -987,7 +987,7 @@
 		TurnSpeed: 64
 		Locomotor: visceroid
 	Selectable:
-		Bounds: 26,26,0,-3
+		Bounds: 784, 1568, 0, -181
 	Targetable:
 		TargetTypes: Ground, Creep
 	AttackMove:
@@ -1151,7 +1151,7 @@
 		MaxHeightDelta: 3
 		RequiresCondition: !inside-tunnel
 	Selectable:
-		Bounds: 40,24
+		Bounds: 1206, 1448
 	Voiced:
 		VoiceSet: Vehicle
 	Targetable:
@@ -1213,7 +1213,7 @@
 	MapEditorData:
 		Categories: Tunnel
 	Interactable:
-		Bounds: 144, 144
+		Bounds: 4344, 8688
 
 ^Gate:
 	Inherits: ^Building

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -68,7 +68,7 @@ HVR:
 		Speed: 99
 		Locomotor: hover
 	Selectable:
-		Bounds: 40,24,0,-10
+		Bounds: 1206, 1448, 0, -603
 	Health:
 		HP: 23000
 	Armor:
@@ -153,7 +153,7 @@ SMECH:
 		MoveSequence: walk
 		ValidMovementTypes: Horizontal, Turn
 	Selectable:
-		Bounds: 20, 32, 0, -8
+		Bounds: 603, 1930, 0, -482
 	-DamagedByTerrain@VEINS:
 	-LeavesTrails@VEINS:
 
@@ -214,7 +214,7 @@ MMCH:
 	WithVoxelBarrel:
 		LocalOffset: 0,51,256
 	Selectable:
-		Bounds: 30, 42, 0, -8
+		Bounds: 905, 2534, 0, -482
 	Carryable:
 		LocalOffset: 0,0,577
 
@@ -261,7 +261,7 @@ HMEC:
 	WithVoxelWalkerBody:
 		TickRate: 1
 	Selectable:
-		Bounds: 40, 40, 0, -8
+		Bounds: 1206, 2413, 0, -482
 	Carryable:
 		LocalOffset: 0,0,509
 
@@ -416,4 +416,4 @@ JUGG:
 	RevealOnFire:
 		ArmamentNames: deployed
 	Selectable:
-		DecorationBounds: 48,40,0,-8
+		DecorationBounds: 1448, 2413, 0, -482

--- a/mods/ts/rules/nod-infantry.yaml
+++ b/mods/ts/rules/nod-infantry.yaml
@@ -53,8 +53,8 @@ CYBORG:
 		Prerequisites: ~nahand, ~techlevel.medium
 		Description: Cybernetic infantry unit.\n  Strong vs Infantry, Light armor\n  Weak vs Vehicles, Aircraft
 	Selectable:
-		Bounds: 16,31,0,-10
-		DecorationBounds: 16,31,0,-10
+		Bounds: 482, 1870, 0, -603
+		DecorationBounds: 482, 1870, 0, -603
 	Voiced:
 		VoiceSet: Cyborg
 	Mobile:
@@ -91,8 +91,8 @@ CYC2:
 		BuildLimit: 1
 		Description: Elite cybernetic infantry unit.\n  Strong vs Infantry, Vehicles, Buildings\n  Weak vs Aircraft\nMaximum 1 can be trained.
 	Selectable:
-		Bounds: 16,32,-1,-12
-		DecorationBounds: 16,32,-1,-12
+		Bounds: 482, 1930, -30, -724
+		DecorationBounds: 482, 1930, -30, -724
 	Voiced:
 		VoiceSet: CyborgCommando
 	Mobile:

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -162,7 +162,7 @@ NAFNCE:
 		Pieces: 0, 1
 		Range: 2c0, 5c0
 	Interactable:
-		Bounds: 48, 24
+		Bounds: 1448, 1448
 
 NALASR:
 	Inherits: ^Defense

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -12,7 +12,7 @@ MCV:
 	Tooltip:
 		Name: Mobile Construction Vehicle
 	Selectable:
-		DecorationBounds: 42,42
+		DecorationBounds: 1267, 2534
 	Health:
 		HP: 100000
 	Armor:
@@ -54,8 +54,8 @@ HARV:
 		Prerequisites: ~factory, proc, ~techlevel.low
 		Description: Collects Tiberium for processing.\n  Unarmed
 	Selectable:
-		Bounds: 36,36
-		DecorationBounds: 36,36
+		Bounds: 1086, 2172
+		DecorationBounds: 1086, 2172
 	Harvester:
 		DeliveryBuildings: proc
 		Capacity: 28


### PR DESCRIPTION
This PR changes the selection/interaction box sizes to be specified in WDist instead of pixels, making them independent of the mod artwork's resolution. This removes the need to specifically override selection box sizes when using the remastered assets.