### PR TITLE
Fix rendering artifacts with RA's dialog5 background.

### DIFF
--- a/mods/ra/chrome.yaml
+++ b/mods/ra/chrome.yaml
@@ -320,7 +320,7 @@ dialog4:
 # completely black tile
 dialog5:
 	Inherits: ^Dialog
-	PanelRegion: 579, 387, 0, 0, 64, 64, 0, 0
+	PanelRegion: 580, 388, 0, 0, 62, 62, 0, 0
 	PanelSides: Center
 
 lobby-bits:


### PR DESCRIPTION
RA's dialog5 was breaking the golden rule of not having repeating textures end at a hard artwork border, which caused trasnparent horizontal lines in the FMV letterboxes on HiDPI displays (zoom in and look at the left/right edges).

Before:
<img src="https://user-images.githubusercontent.com/167819/108634788-2eca4100-7473-11eb-94e6-85f20fd05ab0.png">

After:
<img src="https://user-images.githubusercontent.com/167819/108634790-325dc800-7473-11eb-905a-3fe06acbdac1.png">

This is a simple fix that goes nicely with the other FMV fixes, so adding to the milestone.