### PR TITLE
Fix TLS error on Win7

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -24,6 +24,7 @@ function All-Command
 	{
 		echo "Downloading IP2Location GeoIP database."
 		$target = Join-Path $pwd.ToString() "IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP"
+		[Net.ServicePointManager]::SecurityProtocol = 'Tls12'
 		(New-Object System.Net.WebClient).DownloadFile("https://github.com/OpenRA/GeoIP-Database/releases/download/monthly/IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP", $target)
 	}
 }


### PR DESCRIPTION
Fixes the below TLS error when make.ps1 attempts to download the IP2Location GeoIP database on Windows 7:

`Exception calling "DownloadFile" with "2" argument(s): "The request was aborted: Could not create SSL/TLS
secure channel."`
`At C:\dev\OpenRA\make.ps1:27 char:3`
`+         (New-Object System.Net.WebClient).DownloadFile("https://githu ...`
`+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`
`    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException`
`    + FullyQualifiedErrorId : WebException`