### PR TITLE
ignore rcedit-x86.exe. It gets downloaded when windows package is built.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ obj
 *.lastcodeanalysissucceeded
 _ReSharper.*/
 /.vs
+**/rcedit-*.exe
 
 # binaries
 mods/*/*.dll


### PR DESCRIPTION
rcedit-x86.exe is downloaded when building windows package.

I added it to .gitignore to prevent accidental commits.

Acknowledgement: No entry in AUTHORS is required as it is not code contribution.  