### PR TITLE
WIP: Teamed Faction

### DIFF
--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -149,6 +149,7 @@ namespace OpenRA.Network
 			public string Bot; // Bot type, null for real clients
 			public int BotControllerClientIndex; // who added the bot to the slot
 			public bool IsAdmin;
+			public bool IsTeamLead;
 			public bool IsReady { get { return State == ClientState.Ready; } }
 			public bool IsInvalid { get { return State == ClientState.Invalid; } }
 			public bool IsObserver { get { return Slot == null; } }

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -486,6 +486,7 @@ namespace OpenRA.Server
 					{
 						client.Slot = LobbyInfo.FirstEmptySlot();
 						client.IsAdmin = !LobbyInfo.Clients.Any(c1 => c1.IsAdmin);
+						client.IsTeamLead = false;
 
 						if (client.IsObserver && !LobbyInfo.GlobalSettings.AllowSpectators)
 						{
@@ -1126,6 +1127,12 @@ namespace OpenRA.Server
 		{
 			if (State != ServerState.WaitingPlayers)
 				return;
+
+			foreach (var client in LobbyInfo.Clients)
+			{
+				// Check if your team has a team leader else become team leader
+				client.IsTeamLead = LobbyInfo.Clients.Where(c => c.Index != client.Index && c.IsTeamLead && c.Team == client.Team).Count() == 0;
+			}
 
 			lock (LobbyInfo)
 			{

--- a/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs
+++ b/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.Common.Traits
 				var player = new Player(w, client, players[kv.Value.PlayerReference], playerRandom);
 				worldPlayers.Add(player);
 
-				if (client.Index == Game.LocalClientId)
+				if (localPlayer == null)
 					localPlayer = player;
 			}
 

--- a/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs
+++ b/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs
@@ -106,6 +106,17 @@ namespace OpenRA.Mods.Common.Traits
 				throw new InvalidOperationException("Map {0} does not define a player actor owning the world.".F(w.Map.Title));
 
 			Player localPlayer = null;
+			var team = 0;
+
+			// Get team of local player
+			foreach (var kv in w.LobbyInfo.Slots)
+			{
+				var client = w.LobbyInfo.ClientInSlot(kv.Key);
+				if (client == null)
+					continue;
+				if (client.Index == Game.LocalClientId)
+					team = client.Team;
+			}
 
 			// Create the regular playable players.
 			foreach (var kv in w.LobbyInfo.Slots)
@@ -114,11 +125,14 @@ namespace OpenRA.Mods.Common.Traits
 				if (client == null)
 					continue;
 
-				var player = new Player(w, client, players[kv.Value.PlayerReference], playerRandom);
-				worldPlayers.Add(player);
+				if (client.IsTeamLead || client.Team == 0)
+				{
+					var player = new Player(w, client, players[kv.Value.PlayerReference], playerRandom);
+					worldPlayers.Add(player);
 
-				if (localPlayer == null)
-					localPlayer = player;
+					if ((client.Index == Game.LocalClientId) || (team != 0 && client.Team == team))
+						localPlayer = player;
+				}
 			}
 
 			// Create a player that is allied with everyone for shared observer shroud.

--- a/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs
+++ b/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs
@@ -38,8 +38,8 @@ namespace OpenRA.Mods.Common.Traits
 			// Drop orders from players who shouldn't be able to control this actor
 			// This may be because the owner changed within the last net tick,
 			// or, less likely, the client may be trying to do something malicious.
-			// if (subjectClientId != clientId && !isBotOrder)
-			// 	return false;
+			if (subjectClientId != clientId && !isBotOrder)
+				return false;
 
 			return order.Subject.AcceptsOrder(order.OrderString);
 		}

--- a/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs
+++ b/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs
@@ -26,6 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var subjectClientId = order.Subject.Owner.ClientIndex;
 			var subjectClient = orderManager.LobbyInfo.ClientWithIndex(subjectClientId);
+			var playerClient = orderManager.LobbyInfo.ClientWithIndex(clientId);
 
 			if (subjectClient == null)
 			{
@@ -38,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Drop orders from players who shouldn't be able to control this actor
 			// This may be because the owner changed within the last net tick,
 			// or, less likely, the client may be trying to do something malicious.
-			if (subjectClientId != clientId && !isBotOrder)
+			if (subjectClientId != clientId && playerClient.Team != subjectClient.Team && !isBotOrder)
 				return false;
 
 			return order.Subject.AcceptsOrder(order.OrderString);

--- a/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs
+++ b/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs
@@ -38,8 +38,8 @@ namespace OpenRA.Mods.Common.Traits
 			// Drop orders from players who shouldn't be able to control this actor
 			// This may be because the owner changed within the last net tick,
 			// or, less likely, the client may be trying to do something malicious.
-			if (subjectClientId != clientId && !isBotOrder)
-				return false;
+			// if (subjectClientId != clientId && !isBotOrder)
+			// 	return false;
 
 			return order.Subject.AcceptsOrder(order.OrderString);
 		}


### PR DESCRIPTION
This addresses #19140. 

The implementation idea is to assign a `OpenRA.Player` to multiple `OpenRA.Network.Session.Client`.

- [x] PoC: assign player to multiple clients
- [x] PoC: control a player with multiple clients (just disable server side check)
- [x] allow multiple clients per player
- [x] assign one player per team
- [x] create only one player per team
- [ ] create lobby option
- [x] assign team lead in lobby (the one how choose fraction etc.)
- [ ] sync team lead selection to other team members
- [ ] disable lobby options for team members (other than choose team)
- [ ] team lead icon in lobby (like game admin's crown)
- [ ] disable bots (or at least multiple bots per team)

Closes #19140 