### PR TITLE
WIP: Teamed Faction

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -49,6 +49,7 @@ Also thanks to:
     * clem
     * Cody Brittain (Generalcamo)
     * Constantin Helmig (CH4Code)
+    * copyrights (copyrights)
     * D2k Sardaukar
     * D'Arcy Rush (r34ch)
     * Daniel Derejvanik (Harisson)

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -149,6 +149,7 @@ namespace OpenRA.Network
 			public string Bot; // Bot type, null for real clients
 			public int BotControllerClientIndex; // who added the bot to the slot
 			public bool IsAdmin;
+			public bool IsTeamLead;
 			public bool IsReady { get { return State == ClientState.Ready; } }
 			public bool IsInvalid { get { return State == ClientState.Invalid; } }
 			public bool IsObserver { get { return Slot == null; } }

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -486,6 +486,7 @@ namespace OpenRA.Server
 					{
 						client.Slot = LobbyInfo.FirstEmptySlot();
 						client.IsAdmin = !LobbyInfo.Clients.Any(c1 => c1.IsAdmin);
+						client.IsTeamLead = false;
 
 						if (client.IsObserver && !LobbyInfo.GlobalSettings.AllowSpectators)
 						{
@@ -1126,6 +1127,12 @@ namespace OpenRA.Server
 		{
 			if (State != ServerState.WaitingPlayers)
 				return;
+
+			foreach (var client in LobbyInfo.Clients)
+			{
+				// Check if your team has a team leader else become team leader
+				client.IsTeamLead = LobbyInfo.Clients.Where(c => c.Index != client.Index && c.IsTeamLead && c.Team == client.Team).Count() == 0;
+			}
 
 			lock (LobbyInfo)
 			{

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -486,7 +486,6 @@ namespace OpenRA.Server
 					{
 						client.Slot = LobbyInfo.FirstEmptySlot();
 						client.IsAdmin = !LobbyInfo.Clients.Any(c1 => c1.IsAdmin);
-						client.IsTeamLead = false;
 
 						if (client.IsObserver && !LobbyInfo.GlobalSettings.AllowSpectators)
 						{
@@ -1128,22 +1127,25 @@ namespace OpenRA.Server
 			if (State != ServerState.WaitingPlayers)
 				return;
 
-			foreach (var client in LobbyInfo.Clients)
+			if (LobbyInfo.GlobalSettings.OptionOrDefault("teamedfaction", false))
 			{
-				// Check if your team has a team leader else become team leader
-				client.IsTeamLead = LobbyInfo.Clients.Where(c => c.Index != client.Index && c.IsTeamLead && c.Team == client.Team).Count() == 0 || client.Team == 0;
-			}
-
-			foreach (var client in LobbyInfo.Clients)
-			{
-				// Set team leader's settings to members
-				if (!client.IsTeamLead)
+				foreach (var client in LobbyInfo.Clients)
 				{
-					var tl = LobbyInfo.Clients.First(c => c.IsTeamLead && c.Team == client.Team);
-					client.Color = tl.Color;
-					client.Faction = tl.Faction;
-					client.Handicap = tl.Handicap;
-					client.SpawnPoint = 0;  // only one client per spawn point possible.
+					// Check if your team has a team leader else become team leader
+					client.IsTeamLead = LobbyInfo.Clients.Where(c => c.Index != client.Index && c.IsTeamLead && c.Team == client.Team).Count() == 0 || client.Team == 0;
+				}
+
+				foreach (var client in LobbyInfo.Clients)
+				{
+					// Set team leader's settings to members
+					if (!client.IsTeamLead)
+					{
+						var tl = LobbyInfo.Clients.First(c => c.IsTeamLead && c.Team == client.Team);
+						client.Color = tl.Color;
+						client.Faction = tl.Faction;
+						client.Handicap = tl.Handicap;
+						client.SpawnPoint = 0;  // only one client per spawn point possible.
+					}
 				}
 			}
 

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -1134,6 +1134,20 @@ namespace OpenRA.Server
 				client.IsTeamLead = LobbyInfo.Clients.Where(c => c.Index != client.Index && c.IsTeamLead && c.Team == client.Team).Count() == 0 || client.Team == 0;
 			}
 
+			foreach (var client in LobbyInfo.Clients)
+			{
+				// Set team leader's settings to members
+				if (!client.IsTeamLead)
+				{
+					var tl = LobbyInfo.Clients.First(c => c.IsTeamLead && c.Team == client.Team);
+					client.Color = tl.Color;
+					client.Faction = tl.Faction;
+					client.Handicap = tl.Handicap;
+					// only one client per spawn point possible.
+					client.SpawnPoint = 0;
+				}
+			}
+
 			lock (LobbyInfo)
 			{
 				// TODO: Only need to sync the specific client that has changed to avoid conflicts!

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -1143,8 +1143,7 @@ namespace OpenRA.Server
 					client.Color = tl.Color;
 					client.Faction = tl.Faction;
 					client.Handicap = tl.Handicap;
-					// only one client per spawn point possible.
-					client.SpawnPoint = 0;
+					client.SpawnPoint = 0;  // only one client per spawn point possible.
 				}
 			}
 

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -1131,7 +1131,7 @@ namespace OpenRA.Server
 			foreach (var client in LobbyInfo.Clients)
 			{
 				// Check if your team has a team leader else become team leader
-				client.IsTeamLead = LobbyInfo.Clients.Where(c => c.Index != client.Index && c.IsTeamLead && c.Team == client.Team).Count() == 0;
+				client.IsTeamLead = LobbyInfo.Clients.Where(c => c.Index != client.Index && c.IsTeamLead && c.Team == client.Team).Count() == 0 || client.Team == 0;
 			}
 
 			lock (LobbyInfo)

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -792,11 +792,10 @@ namespace OpenRA.Mods.Common.Server
 					return true;
 				}
 
-				if (!client.IsTeamLead)
+				if (server.LobbyInfo.GlobalSettings.OptionOrDefault("teamedfaction", false) && !client.IsTeamLead)
 					parts[1] = server.LobbyInfo.Clients.First(c => c.IsTeamLead && c.Team == client.Team).Faction;
 
 				targetClient.Faction = parts[1];
-
 				server.SyncLobbyClients();
 
 				return true;
@@ -861,7 +860,7 @@ namespace OpenRA.Mods.Common.Server
 					return false;
 				}
 
-				if (!client.IsTeamLead)
+				if (server.LobbyInfo.GlobalSettings.OptionOrDefault("teamedfaction", false) && !client.IsTeamLead)
 					handicap = server.LobbyInfo.Clients.First(c => c.IsTeamLead && c.Team == client.Team).Handicap;
 
 				targetClient.Handicap = handicap;
@@ -958,7 +957,7 @@ namespace OpenRA.Mods.Common.Server
 					}
 				}
 
-				if (!client.IsTeamLead)
+				if (server.LobbyInfo.GlobalSettings.OptionOrDefault("teamedfaction", false) && !client.IsTeamLead)
 					spawnPoint = 0;  // only one client per spawn point possible.
 
 				targetClient.SpawnPoint = spawnPoint;
@@ -991,7 +990,7 @@ namespace OpenRA.Mods.Common.Server
 				if (newColor == targetClient.Color)
 					targetClient.PreferredColor = targetClient.Color;
 
-				if (!client.IsTeamLead)
+				if (server.LobbyInfo.GlobalSettings.OptionOrDefault("teamedfaction", false) && !client.IsTeamLead)
 					targetClient.Color = server.LobbyInfo.Clients.First(c => c.IsTeamLead && c.Team == client.Team).Color;
 
 				server.SyncLobbyClients();

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -821,6 +821,7 @@ namespace OpenRA.Mods.Common.Server
 				}
 
 				targetClient.Team = team;
+				targetClient.IsTeamLead = false;
 				server.SyncLobbyClients();
 
 				return true;

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -792,7 +792,11 @@ namespace OpenRA.Mods.Common.Server
 					return true;
 				}
 
+				if (!client.IsTeamLead)
+					parts[1] = server.LobbyInfo.Clients.First(c => c.IsTeamLead && c.Team == client.Team).Faction;
+
 				targetClient.Faction = parts[1];
+
 				server.SyncLobbyClients();
 
 				return true;
@@ -856,6 +860,9 @@ namespace OpenRA.Mods.Common.Server
 					Log.Write("server", "Invalid handicap: {0}", s);
 					return false;
 				}
+
+				if (!client.IsTeamLead)
+					handicap = server.LobbyInfo.Clients.First(c => c.IsTeamLead && c.Team == client.Team).Handicap;
 
 				targetClient.Handicap = handicap;
 				server.SyncLobbyClients();
@@ -951,6 +958,9 @@ namespace OpenRA.Mods.Common.Server
 					}
 				}
 
+				if (!client.IsTeamLead)
+					spawnPoint = 0;  // only one client per spawn point possible.
+
 				targetClient.SpawnPoint = spawnPoint;
 				server.SyncLobbyClients();
 
@@ -980,6 +990,9 @@ namespace OpenRA.Mods.Common.Server
 				// Only update player's preferred color if new color is valid
 				if (newColor == targetClient.Color)
 					targetClient.PreferredColor = targetClient.Color;
+
+				if (!client.IsTeamLead)
+					targetClient.Color = server.LobbyInfo.Clients.First(c => c.IsTeamLead && c.Team == client.Team).Color;
 
 				server.SyncLobbyClients();
 

--- a/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs
+++ b/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.Common.Traits
 				var player = new Player(w, client, players[kv.Value.PlayerReference], playerRandom);
 				worldPlayers.Add(player);
 
-				if (client.Index == Game.LocalClientId)
+				if (localPlayer == null)
 					localPlayer = player;
 			}
 

--- a/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs
+++ b/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs
@@ -106,6 +106,17 @@ namespace OpenRA.Mods.Common.Traits
 				throw new InvalidOperationException("Map {0} does not define a player actor owning the world.".F(w.Map.Title));
 
 			Player localPlayer = null;
+			var team = 0;
+
+			// Get team of local player
+			foreach (var kv in w.LobbyInfo.Slots)
+			{
+				var client = w.LobbyInfo.ClientInSlot(kv.Key);
+				if (client == null)
+					continue;
+				if (client.Index == Game.LocalClientId)
+					team = client.Team;
+			}
 
 			// Create the regular playable players.
 			foreach (var kv in w.LobbyInfo.Slots)
@@ -114,11 +125,14 @@ namespace OpenRA.Mods.Common.Traits
 				if (client == null)
 					continue;
 
-				var player = new Player(w, client, players[kv.Value.PlayerReference], playerRandom);
-				worldPlayers.Add(player);
+				if (client.IsTeamLead || client.Team == 0)
+				{
+					var player = new Player(w, client, players[kv.Value.PlayerReference], playerRandom);
+					worldPlayers.Add(player);
 
-				if (localPlayer == null)
-					localPlayer = player;
+					if ((client.Index == Game.LocalClientId) || (team != 0 && client.Team == team))
+						localPlayer = player;
+				}
 			}
 
 			// Create a player that is allied with everyone for shared observer shroud.

--- a/OpenRA.Mods.Common/Traits/World/TeamTogether.cs
+++ b/OpenRA.Mods.Common/Traits/World/TeamTogether.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
 		{
-			yield return new LobbyBooleanOption("TeamedFaction", TeamedFactionCheckboxLabel, TeamedFactionCheckboxDescription,
+			yield return new LobbyBooleanOption("teamedfaction", TeamedFactionCheckboxLabel, TeamedFactionCheckboxDescription,
 				TeamedFactionCheckboxVisible, TeamedFactionCheckboxDisplayOrder, TeamedFactionCheckboxEnabled, TeamedFactionCheckboxLocked);
 		}
 
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 		void INotifyCreated.Created(Actor self)
 		{
 			TeamedFactionEnabled = self.World.LobbyInfo.GlobalSettings
-				.OptionOrDefault("TeamedFaction", info.TeamedFactionCheckboxEnabled);
+				.OptionOrDefault("teamedfaction", info.TeamedFactionCheckboxEnabled);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/TeamTogether.cs
+++ b/OpenRA.Mods.Common/Traits/World/TeamTogether.cs
@@ -1,0 +1,63 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Controls the team together checkbox in the lobby options.")]
+	public class TeamTogetherInfo : TraitInfo, ILobbyOptions
+	{
+		[Desc("Descriptive label for the teamed faction checkbox in the lobby.")]
+		public readonly string TeamedFactionCheckboxLabel = "Teamed Faction";
+
+		[Desc("Tooltip description for the teamed faction checkbox in the lobby.")]
+		public readonly string TeamedFactionCheckboxDescription = "All players in a team control one faction.";
+
+		[Desc("Default value of the command allied units checkbox in the lobby.")]
+		public readonly bool TeamedFactionCheckboxEnabled = false;
+
+		[Desc("Prevent the command allied units state from being changed in the lobby.")]
+		public readonly bool TeamedFactionCheckboxLocked = false;
+
+		[Desc("Whether to display the command allied units checkbox in the lobby.")]
+		public readonly bool TeamedFactionCheckboxVisible = true;
+
+		[Desc("Display order for the command allied units checkbox in the lobby.")]
+		public readonly int TeamedFactionCheckboxDisplayOrder = 0;
+
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		{
+			yield return new LobbyBooleanOption("TeamedFaction", TeamedFactionCheckboxLabel, TeamedFactionCheckboxDescription,
+				TeamedFactionCheckboxVisible, TeamedFactionCheckboxDisplayOrder, TeamedFactionCheckboxEnabled, TeamedFactionCheckboxLocked);
+		}
+
+		public override object Create(ActorInitializer init) { return new TeamTogether(this); }
+	}
+
+	public class TeamTogether : INotifyCreated
+	{
+		readonly TeamTogetherInfo info;
+		public bool TeamedFactionEnabled { get; private set; }
+
+		public TeamTogether(TeamTogetherInfo info)
+		{
+			this.info = info;
+		}
+
+		void INotifyCreated.Created(Actor self)
+		{
+			TeamedFactionEnabled = self.World.LobbyInfo.GlobalSettings
+				.OptionOrDefault("TeamedFaction", info.TeamedFactionCheckboxEnabled);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs
+++ b/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs
@@ -38,8 +38,8 @@ namespace OpenRA.Mods.Common.Traits
 			// Drop orders from players who shouldn't be able to control this actor
 			// This may be because the owner changed within the last net tick,
 			// or, less likely, the client may be trying to do something malicious.
-			// if (subjectClientId != clientId && !isBotOrder)
-			// 	return false;
+			if (subjectClientId != clientId && !isBotOrder)
+				return false;
 
 			return order.Subject.AcceptsOrder(order.OrderString);
 		}

--- a/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs
+++ b/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs
@@ -26,6 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var subjectClientId = order.Subject.Owner.ClientIndex;
 			var subjectClient = orderManager.LobbyInfo.ClientWithIndex(subjectClientId);
+			var playerClient = orderManager.LobbyInfo.ClientWithIndex(clientId);
 
 			if (subjectClient == null)
 			{
@@ -38,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Drop orders from players who shouldn't be able to control this actor
 			// This may be because the owner changed within the last net tick,
 			// or, less likely, the client may be trying to do something malicious.
-			if (subjectClientId != clientId && !isBotOrder)
+			if (subjectClientId != clientId && playerClient.Team != subjectClient.Team && !isBotOrder)
 				return false;
 
 			return order.Subject.AcceptsOrder(order.OrderString);

--- a/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs
+++ b/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs
@@ -38,8 +38,8 @@ namespace OpenRA.Mods.Common.Traits
 			// Drop orders from players who shouldn't be able to control this actor
 			// This may be because the owner changed within the last net tick,
 			// or, less likely, the client may be trying to do something malicious.
-			if (subjectClientId != clientId && !isBotOrder)
-				return false;
+			// if (subjectClientId != clientId && !isBotOrder)
+			// 	return false;
 
 			return order.Subject.AcceptsOrder(order.OrderString);
 		}

--- a/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs
+++ b/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs
@@ -27,6 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 			var subjectClientId = order.Subject.Owner.ClientIndex;
 			var subjectClient = orderManager.LobbyInfo.ClientWithIndex(subjectClientId);
 			var playerClient = orderManager.LobbyInfo.ClientWithIndex(clientId);
+			var teamedFaction = world.WorldActor.Trait<TeamTogether>().TeamedFactionEnabled;
 
 			if (subjectClient == null)
 			{
@@ -39,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Drop orders from players who shouldn't be able to control this actor
 			// This may be because the owner changed within the last net tick,
 			// or, less likely, the client may be trying to do something malicious.
-			if (subjectClientId != clientId && playerClient.Team != subjectClient.Team && !isBotOrder)
+			if (subjectClientId != clientId && (!teamedFaction || playerClient.Team != subjectClient.Team) && !isBotOrder)
 				return false;
 
 			return order.Subject.AcceptsOrder(order.OrderString);

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -526,7 +526,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		public static void SetupEditableColorWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, World world, ColorPreviewManagerWidget colorPreview)
 		{
 			var color = parent.Get<DropDownButtonWidget>("COLOR");
-			color.IsDisabled = () => (s != null && s.LockColor) || orderManager.LocalClient.IsReady || (c.Team != 0 && !c.IsTeamLead);
+			var teamedFaction = orderManager.LobbyInfo.GlobalSettings.OptionOrDefault("teamedfaction", false);
+			color.IsDisabled = () => (s != null && s.LockColor) || orderManager.LocalClient.IsReady || (teamedFaction && c.Team != 0 && !c.IsTeamLead);
 			color.OnMouseDown = _ => ShowColorDropDown(color, c, orderManager, world, colorPreview);
 
 			SetupColorWidget(color, s, c);
@@ -542,7 +543,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Dictionary<string, LobbyFaction> factions)
 		{
 			var dropdown = parent.Get<DropDownButtonWidget>("FACTION");
-			dropdown.IsDisabled = () => s.LockFaction || orderManager.LocalClient.IsReady || (c.Team != 0 && !c.IsTeamLead);
+			var teamedFaction = orderManager.LobbyInfo.GlobalSettings.OptionOrDefault("teamedfaction", false);
+			dropdown.IsDisabled = () => s.LockFaction || orderManager.LocalClient.IsReady || (teamedFaction && c.Team != 0 && !c.IsTeamLead);
 			dropdown.OnMouseDown = _ => ShowFactionDropDown(dropdown, c, orderManager, factions);
 
 			var tooltip = SplitOnFirstToken(factions[c.Faction].Description);
@@ -584,8 +586,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		public static void SetupEditableHandicapWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, MapPreview map)
 		{
 			var dropdown = parent.Get<DropDownButtonWidget>("HANDICAP_DROPDOWN");
+			var teamedFaction = orderManager.LobbyInfo.GlobalSettings.OptionOrDefault("teamedfaction", false);
 			dropdown.IsVisible = () => true;
-			dropdown.IsDisabled = () => s.LockTeam || orderManager.LocalClient.IsReady || (c.Team != 0 && !c.IsTeamLead);
+			dropdown.IsDisabled = () => s.LockTeam || orderManager.LocalClient.IsReady || (teamedFaction && c.Team != 0 && !c.IsTeamLead);
 			dropdown.OnMouseDown = _ => ShowHandicapDropDown(dropdown, c, orderManager);
 
 			var handicapLabel = new CachedTransform<int, string>(h => "{0}%".F(h));
@@ -607,8 +610,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		public static void SetupEditableSpawnWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, MapPreview map)
 		{
 			var dropdown = parent.Get<DropDownButtonWidget>("SPAWN_DROPDOWN");
+			var teamedFaction = orderManager.LobbyInfo.GlobalSettings.OptionOrDefault("teamedfaction", false);
 			dropdown.IsVisible = () => true;
-			dropdown.IsDisabled = () => s.LockSpawn || orderManager.LocalClient.IsReady || (c.Team != 0 && !c.IsTeamLead);
+			dropdown.IsDisabled = () => s.LockSpawn || orderManager.LocalClient.IsReady || (teamedFaction && c.Team != 0 && !c.IsTeamLead);
 			dropdown.OnMouseDown = _ =>
 			{
 				var spawnPoints = Enumerable.Range(0, map.SpawnPoints.Length + 1).Except(

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -526,7 +526,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		public static void SetupEditableColorWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, World world, ColorPreviewManagerWidget colorPreview)
 		{
 			var color = parent.Get<DropDownButtonWidget>("COLOR");
-			color.IsDisabled = () => (s != null && s.LockColor) || orderManager.LocalClient.IsReady;
+			color.IsDisabled = () => (s != null && s.LockColor) || orderManager.LocalClient.IsReady || (c.Team != 0 && !c.IsTeamLead);
 			color.OnMouseDown = _ => ShowColorDropDown(color, c, orderManager, world, colorPreview);
 
 			SetupColorWidget(color, s, c);
@@ -542,7 +542,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Dictionary<string, LobbyFaction> factions)
 		{
 			var dropdown = parent.Get<DropDownButtonWidget>("FACTION");
-			dropdown.IsDisabled = () => s.LockFaction || orderManager.LocalClient.IsReady;
+			dropdown.IsDisabled = () => s.LockFaction || orderManager.LocalClient.IsReady || (c.Team != 0 && !c.IsTeamLead);
 			dropdown.OnMouseDown = _ => ShowFactionDropDown(dropdown, c, orderManager, factions);
 
 			var tooltip = SplitOnFirstToken(factions[c.Faction].Description);
@@ -585,7 +585,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var dropdown = parent.Get<DropDownButtonWidget>("HANDICAP_DROPDOWN");
 			dropdown.IsVisible = () => true;
-			dropdown.IsDisabled = () => s.LockTeam || orderManager.LocalClient.IsReady;
+			dropdown.IsDisabled = () => s.LockTeam || orderManager.LocalClient.IsReady || (c.Team != 0 && !c.IsTeamLead);
 			dropdown.OnMouseDown = _ => ShowHandicapDropDown(dropdown, c, orderManager);
 
 			var handicapLabel = new CachedTransform<int, string>(h => "{0}%".F(h));
@@ -608,7 +608,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var dropdown = parent.Get<DropDownButtonWidget>("SPAWN_DROPDOWN");
 			dropdown.IsVisible = () => true;
-			dropdown.IsDisabled = () => s.LockSpawn || orderManager.LocalClient.IsReady;
+			dropdown.IsDisabled = () => s.LockSpawn || orderManager.LocalClient.IsReady || (c.Team != 0 && !c.IsTeamLead);
 			dropdown.OnMouseDown = _ =>
 			{
 				var spawnPoints = Enumerable.Range(0, map.SpawnPoints.Length + 1).Except(

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -195,6 +195,8 @@ World:
 		GameSpeedDropdownDisplayOrder: 3
 	MapStartingLocations:
 		SeparateTeamSpawnsCheckboxDisplayOrder: 6
+	TeamTogether:
+		TeamedFactionCheckboxDisplayOrder: 7
 	CreateMapPlayers:
 	StartingUnits@mcvonly:
 		Class: none

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -169,6 +169,8 @@ World:
 	CreateMapPlayers:
 	MapStartingLocations:
 		SeparateTeamSpawnsCheckboxDisplayOrder: 6
+	TeamTogether:
+		TeamedFactionCheckboxDisplayOrder: 7
 	StartingUnits@mcv:
 		Class: none
 		ClassName: MCV Only

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -260,6 +260,8 @@ World:
 		OuterSupportRadius: 5
 	MapStartingLocations:
 		SeparateTeamSpawnsCheckboxDisplayOrder: 6
+	TeamTogether:
+		TeamedFactionCheckboxDisplayOrder: 7
 	SpawnStartingUnits:
 		DropdownDisplayOrder: 1
 	PathFinder:

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -349,6 +349,8 @@ World:
 		OuterSupportRadius: 5
 	MapStartingLocations:
 		SeparateTeamSpawnsCheckboxDisplayOrder: 6
+	TeamTogether:
+		TeamedFactionCheckboxDisplayOrder: 7
 	SpawnStartingUnits:
 		DropdownDisplayOrder: 1
 	CrateSpawner:


### PR DESCRIPTION
This addresses #19140. 

The implementation idea is to assign a `OpenRA.Player` to multiple `OpenRA.Network.Session.Client`.

- [x] PoC: assign player to multiple clients
- [x] PoC: control a player with multiple clients (just disable server side check)
- [x] allow multiple clients per player
- [x] assign one player per team
- [x] create only one player per team
- [x] assign team lead in lobby (the one how choose fraction etc.)
- [x] create lobby option
- [x] sync team lead selection to other team members
- [x] disable lobby options for team members (other than choose team)
- [ ] team lead icon in lobby (like game admin's crown)
- [ ] disable bots (or at least multiple bots per team)

Closes #19140 