### PR TITLE
Fix Nullable type handling in Lua docs.

### DIFF
--- a/OpenRA.Game/Scripting/ScriptMemberExts.cs
+++ b/OpenRA.Game/Scripting/ScriptMemberExts.cs
@@ -30,6 +30,10 @@ namespace OpenRA.Scripting
 		{
 			if (!LuaTypeNameReplacements.TryGetValue(t.Name, out var ret))
 				ret = t.Name;
+
+			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Nullable<>))
+				ret = "{0}?".F(t.GetGenericArguments().Select(p => p.Name).First());
+
 			return ret;
 		}
 


### PR DESCRIPTION
Fixes #19178.

Before:
```
<tr><td align="right" width="50%"><strong>void DisplayMessage(string text, string prefix = Mission, Nullable`1 color = nil)</strong></td><td>Display a text message to the player.</td></tr>
```

After:
```
<tr><td align="right" width="50%"><strong>void DisplayMessage(string text, string prefix = Mission, Color? color = nil)</strong></td><td>Display a text message to the player.</td></tr>
```