### PR TITLE
Activity. Minor optimization.

### DIFF
--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -53,14 +53,16 @@ namespace OpenRA.Activities
 		Activity childActivity;
 		protected Activity ChildActivity
 		{
-			get => SkipDoneActivities(childActivity);
+			// No side effect.
+			get => (childActivity = SkipDoneActivities(childActivity));
 			private set => childActivity = value;
 		}
 
 		Activity nextActivity;
 		public Activity NextActivity
 		{
-			get => SkipDoneActivities(nextActivity);
+			// No side effect.
+			get => (nextActivity = SkipDoneActivities(nextActivity));
 			private set => nextActivity = value;
 		}
 
@@ -141,8 +143,8 @@ namespace OpenRA.Activities
 
 		protected bool TickChild(Actor self)
 		{
-			ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-			return ChildActivity == null;
+			childActivity = ActivityUtils.RunActivity(self, ChildActivity);
+			return childActivity == null;
 		}
 
 		/// <summary>
@@ -194,7 +196,7 @@ namespace OpenRA.Activities
 		public virtual void Cancel(Actor self, bool keepQueue = false)
 		{
 			if (!keepQueue)
-				NextActivity = null;
+				nextActivity = null;
 
 			if (!IsInterruptible)
 				return;


### PR DESCRIPTION

Only maintain the last `next` and `child` activity.
Do not use the property setter.
While there are no users of the setter(s) left - remove it.
Tested by running a 20m replay.

Missed in an earlier pull request of branch 20201030_activity_next.