### PR TITLE
Fix possible endless loop in replay recorder while opening save file.

### DIFF
--- a/OpenRA.Game/Network/ReplayRecorder.cs
+++ b/OpenRA.Game/Network/ReplayRecorder.cs
@@ -19,6 +19,9 @@ namespace OpenRA.Network
 {
 	sealed class ReplayRecorder
 	{
+		// Arbitrary value.
+		const int CreateReplayFileMaxRetryCount = 128;
+
 		public ReplayMetadata Metadata;
 		BinaryWriter writer;
 		Func<string> chooseFilename;
@@ -59,7 +62,12 @@ namespace OpenRA.Network
 				{
 					file = File.Create(fullFilename);
 				}
-				catch (IOException) { }
+				catch (IOException ex)
+				{
+					if (id > CreateReplayFileMaxRetryCount)
+						throw new ArgumentException(
+							"Error creating replay file \"{0}.orarep\"".F(filename), ex);
+				}
 			}
 
 			file.WriteArray(initialContent);


### PR DESCRIPTION
Fixes #18789.

Minimal fix. To be able to close the issue. Should not occur in practice.

Throws an `ArgumentException` because the normal situation the filename contains a timestamp. If a file can not be created after 128+ attempt is likely indicates the filename refers to an invalid - non writable - path.
