### PR TITLE
Minor optimization. Save a call to `IsAlliedWith` if not disguised. #…

### DIFF
--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -267,15 +267,14 @@ namespace OpenRA
 
 		public Color PlayerRelationshipColor(Actor a)
 		{
-			var player = a.World.RenderPlayer ?? a.World.LocalPlayer;
+			var renderPlayer = a.World.RenderPlayer;
+			var player = renderPlayer ?? a.World.LocalPlayer;
 			if (player != null && !player.Spectating)
 			{
-				var apparentOwner = a.EffectiveOwner != null && a.EffectiveOwner.Disguised
-					? a.EffectiveOwner.Owner
-					: a.Owner;
-
-				if (a.Owner.IsAlliedWith(a.World.RenderPlayer))
-					apparentOwner = a.Owner;
+				var effectiveOwner = a.EffectiveOwner;
+				var apparentOwner = a.Owner;
+				if (effectiveOwner != null && effectiveOwner.Disguised && !a.Owner.IsAlliedWith(renderPlayer))
+					apparentOwner = effectiveOwner.Owner;
 
 				if (apparentOwner == player)
 					return stanceColors.Self;


### PR DESCRIPTION


Fixes #18791.

To be able to close the issue. To improve code readability. To avoid a call two methods deep in the most likely case.
Untested.