### PR TITLE
Fixed aiming not propertly stopped.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -155,6 +155,12 @@ namespace OpenRA.Mods.Common.Activities
 			return true;
 		}
 
+		protected override void OnLastRun(Actor self)
+		{
+			foreach (var attack in attackTraits)
+				attack.IsAiming = false;
+		}
+
 		protected virtual AttackStatus TickAttack(Actor self, AttackFrontal attack)
 		{
 			if (!target.IsValidFor(self))


### PR DESCRIPTION
Title says all. The activity sets the IsAiming bool, but does not reset it when required.
This results in WithAimAnimation to continously aim.
This should also fix #17784
