### PR TITLE
Rename methods/activities with Visual in them

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -305,7 +305,7 @@ namespace OpenRA.Traits
 		SubCell GetAvailableSubCell(CPos location, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All);
 		void SetPosition(Actor self, CPos cell, SubCell subCell = SubCell.Any);
 		void SetPosition(Actor self, WPos pos);
-		void SetVisualPosition(Actor self, WPos pos);
+		void SetCenterPosition(Actor self, WPos pos);
 	}
 
 	public interface ITemporaryBlockerInfo : ITraitInfoInterface { }

--- a/OpenRA.Mods.Cnc/Activities/Leap.cs
+++ b/OpenRA.Mods.Cnc/Activities/Leap.cs
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				targetPosition = target.CenterPosition;
 
 			var position = length > 1 ? WPos.Lerp(origin, targetPosition, ticks, length - 1) : targetPosition;
-			mobile.SetVisualPosition(self, position);
+			mobile.SetCenterPosition(self, position);
 
 			// We are at the destination
 			if (++ticks >= length)
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				attack.DoAttack(self, target);
 
 				jumpComplete = true;
-				QueueChild(mobile.VisualMove(self, position, self.World.Map.CenterOfSubCell(destinationCell, destinationSubCell)));
+				QueueChild(mobile.LocalMove(self, position, self.World.Map.CenterOfSubCell(destinationCell, destinationSubCell)));
 			}
 
 			return false;

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		static readonly WAngle Right = new WAngle(768);
 
 		IEnumerable<int> speedModifiers;
-		INotifyVisualPositionChanged[] notifyVisualPositionChanged;
+		INotifyCenterPositionChanged[] notifyCenterPositionChanged;
 
 		WRot orientation;
 
@@ -110,7 +110,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			speedModifiers = self.TraitsImplementing<ISpeedModifier>().ToArray().Select(sm => sm.GetSpeedModifier());
 			cachedLocation = self.Location;
-			notifyVisualPositionChanged = self.TraitsImplementing<INotifyVisualPositionChanged>().ToArray();
+			notifyCenterPositionChanged = self.TraitsImplementing<INotifyCenterPositionChanged>().ToArray();
 		}
 
 		void INotifyAddedToWorld.AddedToWorld(Actor self)
@@ -134,7 +134,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			cachedLocation = self.Location;
 
-			SetVisualPosition(self, self.CenterPosition + MoveStep(Facing));
+			SetCenterPosition(self, self.CenterPosition + MoveStep(Facing));
 		}
 
 		void Turn()
@@ -175,7 +175,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			return SubCell.Invalid;
 		}
 
-		public void SetVisualPosition(Actor self, WPos pos) { SetPosition(self, pos); }
+		public void SetCenterPosition(Actor self, WPos pos) { SetPosition(self, pos); }
 
 		public void SetPosition(Actor self, CPos cell, SubCell subCell = SubCell.Any)
 		{
@@ -195,10 +195,10 @@ namespace OpenRA.Mods.Cnc.Traits
 			self.World.UpdateMaps(self, this);
 			self.World.ActorMap.AddInfluence(self, this);
 
-			// This can be called from the constructor before notifyVisualPositionChanged is assigned.
-			if (notifyVisualPositionChanged != null)
-				foreach (var n in notifyVisualPositionChanged)
-					n.VisualPositionChanged(self, 0, 0);
+			// This can be called from the constructor before notifyCenterPositionChanged is assigned.
+			if (notifyCenterPositionChanged != null)
+				foreach (var n in notifyCenterPositionChanged)
+					n.CenterPositionChanged(self, 0, 0);
 		}
 
 		public Activity MoveTo(CPos cell, int nearEnough = 0, Actor ignoreActor = null,
@@ -213,7 +213,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public Activity MoveToTarget(Actor self, in Target target,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null) { return null; }
 		public Activity MoveIntoTarget(Actor self, in Target target) { return null; }
-		public Activity VisualMove(Actor self, WPos fromPos, WPos toPos) { return null; }
+		public Activity LocalMove(Actor self, WPos fromPos, WPos toPos) { return null; }
 
 		public int EstimatedMoveDuration(Actor self, WPos fromPos, WPos toPos)
 		{

--- a/OpenRA.Mods.Common/Activities/Move/Drag.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Drag.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Activities
 				? WPos.Lerp(start, end, ticks, length - 1)
 				: end;
 
-			positionable.SetVisualPosition(self, pos);
+			positionable.SetCenterPosition(self, pos);
 			if (++ticks >= length)
 				return true;
 

--- a/OpenRA.Mods.Common/Activities/Move/LocalMoveIntoTarget.cs
+++ b/OpenRA.Mods.Common/Activities/Move/LocalMoveIntoTarget.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
-	public class VisualMoveIntoTarget : Activity
+	public class LocalMoveIntoTarget : Activity
 	{
 		readonly Mobile mobile;
 		readonly Target target;
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly WDist targetMovementThreshold;
 		WPos targetStartPos;
 
-		public VisualMoveIntoTarget(Actor self, in Target target, WDist targetMovementThreshold, Color? targetLineColor = null)
+		public LocalMoveIntoTarget(Actor self, in Target target, WDist targetMovementThreshold, Color? targetLineColor = null)
 		{
 			mobile = self.Trait<Mobile>();
 			this.target = target;
@@ -66,12 +66,12 @@ namespace OpenRA.Mods.Common.Activities
 			var speed = mobile.MovementSpeedForCell(self, self.Location);
 			if (delta.LengthSquared <= speed * speed)
 			{
-				mobile.SetVisualPosition(self, targetPos);
+				mobile.SetCenterPosition(self, targetPos);
 				return true;
 			}
 
 			// Move towards the target
-			mobile.SetVisualPosition(self, currentPos + delta * speed / delta.Length);
+			mobile.SetCenterPosition(self, currentPos + delta * speed / delta.Length);
 			return false;
 		}
 

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -478,10 +478,10 @@ namespace OpenRA.Mods.Common.Activities
 					if (self.Location.Layer == 0)
 						pos -= new WVec(WDist.Zero, WDist.Zero, self.World.Map.DistanceAboveTerrain(pos));
 
-					mobile.SetVisualPosition(self, pos);
+					mobile.SetCenterPosition(self, pos);
 				}
 				else
-					mobile.SetVisualPosition(self, To);
+					mobile.SetCenterPosition(self, To);
 
 				if (moveFraction >= MoveFractionTotal)
 					mobile.Facing = ToFacing;

--- a/OpenRA.Mods.Common/Activities/Parachute.cs
+++ b/OpenRA.Mods.Common/Activities/Parachute.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (nextPosition.Z < groundLevel)
 				return true;
 
-			pos.SetVisualPosition(self, nextPosition);
+			pos.SetCenterPosition(self, nextPosition);
 
 			return false;
 		}

--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -122,7 +122,7 @@ namespace OpenRA.Mods.Common.Activities
 					var pos = actor.Trait<IPositionable>();
 
 					pos.SetPosition(actor, exitSubCell.Value.Cell, exitSubCell.Value.SubCell);
-					pos.SetVisualPosition(actor, spawn);
+					pos.SetCenterPosition(actor, spawn);
 
 					actor.CancelActivity();
 					w.Add(actor);

--- a/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Scripting
 		{
 			var pos = Self.CenterPosition;
 			mobile.SetPosition(Self, cell);
-			mobile.SetVisualPosition(Self, pos);
+			mobile.SetCenterPosition(Self, pos);
 			Self.QueueActivity(mobile.ReturnToCell(Self));
 		}
 

--- a/OpenRA.Mods.Common/Traits/AffectsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/AffectsShroud.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public abstract class AffectsShroud : ConditionalTrait<AffectsShroudInfo>, ISync, INotifyAddedToWorld,
-		INotifyRemovedFromWorld, INotifyMoving, INotifyVisualPositionChanged, ITick
+		INotifyRemovedFromWorld, INotifyMoving, INotifyCenterPositionChanged, ITick
 	{
 		static readonly PPos[] NoCells = { };
 
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Traits
 				.ToArray();
 		}
 
-		void INotifyVisualPositionChanged.VisualPositionChanged(Actor self, byte oldLayer, byte newLayer)
+		void INotifyCenterPositionChanged.CenterPositionChanged(Actor self, byte oldLayer, byte newLayer)
 		{
 			if (!self.IsInWorld)
 				return;

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -224,7 +224,7 @@ namespace OpenRA.Mods.Common.Traits
 		IDisposable reservation;
 		IEnumerable<int> speedModifiers;
 		INotifyMoving[] notifyMoving;
-		INotifyVisualPositionChanged[] notifyVisualPositionChanged;
+		INotifyCenterPositionChanged[] notifyCenterPositionChanged;
 		IOverrideAircraftLanding overrideAircraftLanding;
 
 		WRot orientation;
@@ -344,7 +344,7 @@ namespace OpenRA.Mods.Common.Traits
 			notifyMoving = self.TraitsImplementing<INotifyMoving>().ToArray();
 			positionOffsets = self.TraitsImplementing<IAircraftCenterPositionOffset>().ToArray();
 			overrideAircraftLanding = self.TraitOrDefault<IOverrideAircraftLanding>();
-			notifyVisualPositionChanged = self.TraitsImplementing<INotifyVisualPositionChanged>().ToArray();
+			notifyCenterPositionChanged = self.TraitsImplementing<INotifyCenterPositionChanged>().ToArray();
 			base.Created(self);
 		}
 
@@ -769,7 +769,7 @@ namespace OpenRA.Mods.Common.Traits
 			return SubCell.Invalid;
 		}
 
-		public void SetVisualPosition(Actor self, WPos pos) { SetPosition(self, pos); }
+		public void SetCenterPosition(Actor self, WPos pos) { SetPosition(self, pos); }
 
 		// Changes position, but not altitude
 		public void SetPosition(Actor self, CPos cell, SubCell subCell = SubCell.Any)
@@ -800,10 +800,10 @@ namespace OpenRA.Mods.Common.Traits
 			else if (!isCruising && cruising)
 				OnCruisingAltitudeLeft();
 
-			// NB: This can be called from the constructor before notifyVisualPositionChanged is assigned.
-			if (notify && notifyVisualPositionChanged != null)
-				foreach (var n in notifyVisualPositionChanged)
-					n.VisualPositionChanged(self, 0, 0);
+			// NB: This can be called from the constructor before notifyCenterPositionChanged is assigned.
+			if (notify && notifyCenterPositionChanged != null)
+				foreach (var n in notifyCenterPositionChanged)
+					n.CenterPositionChanged(self, 0, 0);
 
 			FinishedMoving(self);
 		}
@@ -949,10 +949,10 @@ namespace OpenRA.Mods.Common.Traits
 			return new Land(self, target);
 		}
 
-		public Activity VisualMove(Actor self, WPos fromPos, WPos toPos)
+		public Activity LocalMove(Actor self, WPos fromPos, WPos toPos)
 		{
 			// TODO: Ignore repulsion when moving
-			var activities = new CallFunc(() => SetVisualPosition(self, fromPos));
+			var activities = new CallFunc(() => SetCenterPosition(self, fromPos));
 			activities.Queue(new Fly(self, Target.FromPos(toPos)));
 			return activities;
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -162,7 +162,7 @@ namespace OpenRA.Mods.Common.Traits
 					return;
 
 				paxFacing[a.Actor].Facing = targetYaw;
-				paxPos[a.Actor].SetVisualPosition(a.Actor, pos + PortOffset(self, port));
+				paxPos[a.Actor].SetCenterPosition(a.Actor, pos + PortOffset(self, port));
 
 				var barrel = a.CheckFire(a.Actor, facing, target);
 				if (barrel == null)

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnSubterraneanLayer.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnSubterraneanLayer.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class GrantConditionOnSubterraneanLayer : GrantConditionOnLayer<GrantConditionOnSubterraneanLayerInfo>, INotifyVisualPositionChanged
+	public class GrantConditionOnSubterraneanLayer : GrantConditionOnLayer<GrantConditionOnSubterraneanLayerInfo>, INotifyCenterPositionChanged
 	{
 		WDist transitionDepth;
 
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 				Game.Sound.Play(SoundType.World, Info.SubterraneanTransitionSound);
 		}
 
-		void INotifyVisualPositionChanged.VisualPositionChanged(Actor self, byte oldLayer, byte newLayer)
+		void INotifyCenterPositionChanged.CenterPositionChanged(Actor self, byte oldLayer, byte newLayer)
 		{
 			var depth = self.World.Map.DistanceAboveTerrain(self.CenterPosition);
 

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Actor self;
 		readonly CrateInfo info;
 		bool collected;
-		INotifyVisualPositionChanged[] notifyVisualPositionChanged;
+		INotifyCenterPositionChanged[] notifyCenterPositionChanged;
 
 		[Sync]
 		int ticks;
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyCreated.Created(Actor self)
 		{
-			notifyVisualPositionChanged = self.TraitsImplementing<INotifyVisualPositionChanged>().ToArray();
+			notifyCenterPositionChanged = self.TraitsImplementing<INotifyCenterPositionChanged>().ToArray();
 		}
 
 		void INotifyCrushed.WarnCrush(Actor self, Actor crusher, BitSet<CrushClass> crushClasses) { }
@@ -181,31 +181,31 @@ namespace OpenRA.Mods.Common.Traits
 
 		public WPos CenterPosition { get; private set; }
 
-		// Sets the location (Location) and visual position (CenterPosition)
+		// Sets the location (Location) and position (CenterPosition)
 		public void SetPosition(Actor self, WPos pos)
 		{
 			var cell = self.World.Map.CellContaining(pos);
 			SetLocation(self, cell);
-			SetVisualPosition(self, self.World.Map.CenterOfCell(cell) + new WVec(WDist.Zero, WDist.Zero, self.World.Map.DistanceAboveTerrain(pos)));
+			SetCenterPosition(self, self.World.Map.CenterOfCell(cell) + new WVec(WDist.Zero, WDist.Zero, self.World.Map.DistanceAboveTerrain(pos)));
 		}
 
-		// Sets the location (Location) and visual position (CenterPosition)
+		// Sets the location (Location) and position (CenterPosition)
 		public void SetPosition(Actor self, CPos cell, SubCell subCell = SubCell.Any)
 		{
 			SetLocation(self, cell, subCell);
-			SetVisualPosition(self, self.World.Map.CenterOfCell(cell));
+			SetCenterPosition(self, self.World.Map.CenterOfCell(cell));
 		}
 
-		// Sets only the visual position (CenterPosition)
-		public void SetVisualPosition(Actor self, WPos pos)
+		// Sets only the CenterPosition
+		public void SetCenterPosition(Actor self, WPos pos)
 		{
 			CenterPosition = pos;
 			self.World.UpdateMaps(self, this);
 
-			// This can be called from the constructor before notifyVisualPositionChanged is assigned.
-			if (notifyVisualPositionChanged != null)
-				foreach (var n in notifyVisualPositionChanged)
-					n.VisualPositionChanged(self, 0, 0);
+			// This can be called from the constructor before notifyCenterPositionChanged is assigned.
+			if (notifyCenterPositionChanged != null)
+				foreach (var n in notifyCenterPositionChanged)
+					n.CenterPositionChanged(self, 0, 0);
 		}
 
 		// Sets only the location (Location)

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly int dragSpeed;
 		readonly WPos finalPosition;
 
-		INotifyVisualPositionChanged[] notifyVisualPositionChanged;
+		INotifyCenterPositionChanged[] notifyCenterPositionChanged;
 
 		[Sync]
 		public CPos TopLeft { get; private set; }
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (dragSpeed > 0 && distance > 0)
 				self.QueueActivity(new Drag(self, CenterPosition, finalPosition, distance / dragSpeed));
 
-			notifyVisualPositionChanged = self.TraitsImplementing<INotifyVisualPositionChanged>().ToArray();
+			notifyCenterPositionChanged = self.TraitsImplementing<INotifyCenterPositionChanged>().ToArray();
 		}
 
 		public bool CanExistInCell(CPos cell)
@@ -138,15 +138,15 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void SetPosition(Actor self, CPos cell, SubCell subCell = SubCell.Any) { SetPosition(self, self.World.Map.CenterOfCell(cell)); }
 
-		public void SetVisualPosition(Actor self, WPos pos)
+		public void SetCenterPosition(Actor self, WPos pos)
 		{
 			CenterPosition = pos;
 			self.World.ScreenMap.AddOrUpdate(self);
 
-			// This can be called from the constructor before notifyVisualPositionChanged is assigned.
-			if (notifyVisualPositionChanged != null)
-				foreach (var n in notifyVisualPositionChanged)
-					n.VisualPositionChanged(self, 0, 0);
+			// This can be called from the constructor before notifyCenterPositionChanged is assigned.
+			if (notifyCenterPositionChanged != null)
+				foreach (var n in notifyCenterPositionChanged)
+					n.CenterPositionChanged(self, 0, 0);
 		}
 
 		public void SetPosition(Actor self, WPos pos)

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -185,7 +185,7 @@ namespace OpenRA.Mods.Common.Traits
 		public SubCell FromSubCell, ToSubCell;
 
 		INotifyCustomLayerChanged[] notifyCustomLayerChanged;
-		INotifyVisualPositionChanged[] notifyVisualPositionChanged;
+		INotifyCenterPositionChanged[] notifyCenterPositionChanged;
 		INotifyMoving[] notifyMoving;
 		INotifyFinishedMoving[] notifyFinishedMoving;
 		IWrapMove[] moveWrappers;
@@ -267,18 +267,18 @@ namespace OpenRA.Mods.Common.Traits
 			if (locationInit != null)
 			{
 				fromCell = toCell = locationInit.Value;
-				SetVisualPosition(self, init.World.Map.CenterOfSubCell(FromCell, FromSubCell));
+				SetCenterPosition(self, init.World.Map.CenterOfSubCell(FromCell, FromSubCell));
 			}
 
 			Facing = oldFacing = init.GetValue<FacingInit, WAngle>(info.InitialFacing);
 
-			// Sets the initial visual position
+			// Sets the initial center position
 			// Unit will move into the cell grid (defined by LocationInit) as its initial activity
 			var centerPositionInit = init.GetOrDefault<CenterPositionInit>();
 			if (centerPositionInit != null)
 			{
 				oldPos = centerPositionInit.Value;
-				SetVisualPosition(self, oldPos);
+				SetCenterPosition(self, oldPos);
 				returnToCellOnCreation = true;
 			}
 
@@ -288,7 +288,7 @@ namespace OpenRA.Mods.Common.Traits
 		protected override void Created(Actor self)
 		{
 			notifyCustomLayerChanged = self.TraitsImplementing<INotifyCustomLayerChanged>().ToArray();
-			notifyVisualPositionChanged = self.TraitsImplementing<INotifyVisualPositionChanged>().ToArray();
+			notifyCenterPositionChanged = self.TraitsImplementing<INotifyCenterPositionChanged>().ToArray();
 			notifyMoving = self.TraitsImplementing<INotifyMoving>().ToArray();
 			notifyFinishedMoving = self.TraitsImplementing<INotifyFinishedMoving>().ToArray();
 			moveWrappers = self.TraitsImplementing<IWrapMove>().ToArray();
@@ -456,7 +456,7 @@ namespace OpenRA.Mods.Common.Traits
 			return preferred;
 		}
 
-		// Sets the location (fromCell, toCell, FromSubCell, ToSubCell) and visual position (CenterPosition)
+		// Sets the location (fromCell, toCell, FromSubCell, ToSubCell) and CenterPosition
 		public void SetPosition(Actor self, CPos cell, SubCell subCell = SubCell.Any)
 		{
 			subCell = GetValidSubCell(subCell);
@@ -466,31 +466,31 @@ namespace OpenRA.Mods.Common.Traits
 				self.World.GetCustomMovementLayers()[cell.Layer].CenterOfCell(cell);
 
 			var subcellOffset = self.World.Map.Grid.OffsetOfSubCell(subCell);
-			SetVisualPosition(self, position + subcellOffset);
+			SetCenterPosition(self, position + subcellOffset);
 			FinishedMoving(self);
 		}
 
-		// Sets the location (fromCell, toCell, FromSubCell, ToSubCell) and visual position (CenterPosition)
+		// Sets the location (fromCell, toCell, FromSubCell, ToSubCell) and CenterPosition
 		public void SetPosition(Actor self, WPos pos)
 		{
 			var cell = self.World.Map.CellContaining(pos);
 			SetLocation(cell, FromSubCell, cell, FromSubCell);
-			SetVisualPosition(self, self.World.Map.CenterOfSubCell(cell, FromSubCell) + new WVec(0, 0, self.World.Map.DistanceAboveTerrain(pos).Length));
+			SetCenterPosition(self, self.World.Map.CenterOfSubCell(cell, FromSubCell) + new WVec(0, 0, self.World.Map.DistanceAboveTerrain(pos).Length));
 			FinishedMoving(self);
 		}
 
-		// Sets only the visual position (CenterPosition)
-		public void SetVisualPosition(Actor self, WPos pos)
+		// Sets only the CenterPosition
+		public void SetCenterPosition(Actor self, WPos pos)
 		{
 			CenterPosition = pos;
 			self.World.UpdateMaps(self, this);
 
-			// The first time SetVisualPosition is called is in the constructor before creation, so we need a null check here as well
-			if (notifyVisualPositionChanged == null)
+			// The first time SetCenterPosition is called is in the constructor before creation, so we need a null check here as well
+			if (notifyCenterPositionChanged == null)
 				return;
 
-			foreach (var n in notifyVisualPositionChanged)
-				n.VisualPositionChanged(self, fromCell.Layer, toCell.Layer);
+			foreach (var n in notifyCenterPositionChanged)
+				n.CenterPositionChanged(self, fromCell.Layer, toCell.Layer);
 		}
 
 		public bool IsLeavingCell(CPos location, SubCell subCell = SubCell.Any)
@@ -670,12 +670,12 @@ namespace OpenRA.Mods.Common.Traits
 
 				// Reserve the exit cell
 				mobile.SetPosition(self, cell, subCell);
-				mobile.SetVisualPosition(self, pos);
+				mobile.SetCenterPosition(self, pos);
 
 				if (delay > 0)
 					QueueChild(new Wait(delay));
 
-				QueueChild(mobile.VisualMove(self, pos, self.World.Map.CenterOfSubCell(cell, subCell)));
+				QueueChild(mobile.LocalMove(self, pos, self.World.Map.CenterOfSubCell(cell, subCell)));
 				return true;
 			}
 		}
@@ -696,12 +696,12 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Activity cancels if the target moves by more than half a cell
 			// to avoid problems with the cell grid
-			return WrapMove(new VisualMoveIntoTarget(self, target, new WDist(512)));
+			return WrapMove(new LocalMoveIntoTarget(self, target, new WDist(512)));
 		}
 
-		public Activity VisualMove(Actor self, WPos fromPos, WPos toPos)
+		public Activity LocalMove(Actor self, WPos fromPos, WPos toPos)
 		{
-			return WrapMove(VisualMove(self, fromPos, toPos, self.Location));
+			return WrapMove(LocalMove(self, fromPos, toPos, self.Location));
 		}
 
 		public int EstimatedMoveDuration(Actor self, WPos fromPos, WPos toPos)
@@ -791,7 +791,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Activity ScriptedMove(CPos cell) { return new Move(self, cell); }
 		public Activity MoveTo(Func<BlockedByActor, List<CPos>> pathFunc) { return new Move(self, pathFunc); }
 
-		Activity VisualMove(Actor self, WPos fromPos, WPos toPos, CPos cell)
+		Activity LocalMove(Actor self, WPos fromPos, WPos toPos, CPos cell)
 		{
 			var speed = MovementSpeedForCell(self, cell);
 			var length = speed > 0 ? (toPos - fromPos).Length / speed : 0;

--- a/OpenRA.Mods.Common/Traits/ParaDrop.cs
+++ b/OpenRA.Mods.Common/Traits/ParaDrop.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Traits
 				dropPositionable.SetPosition(dropActor, dropCell, dropSubCell);
 
 				var dropPosition = dropActor.CenterPosition + new WVec(0, 0, self.CenterPosition.Z - dropActor.CenterPosition.Z);
-				dropPositionable.SetVisualPosition(dropActor, dropPosition);
+				dropPositionable.SetCenterPosition(dropActor, dropPosition);
 				w.Add(dropActor);
 			});
 

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -66,9 +66,9 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[RequireExplicitImplementation]
-	public interface INotifyVisualPositionChanged
+	public interface INotifyCenterPositionChanged
 	{
-		void VisualPositionChanged(Actor self, byte oldLayer, byte newLayer);
+		void CenterPositionChanged(Actor self, byte oldLayer, byte newLayer);
 	}
 
 	[RequireExplicitImplementation]
@@ -425,7 +425,7 @@ namespace OpenRA.Mods.Common.Traits
 			WPos? initialTargetPosition = null, Color? targetLineColor = null);
 		Activity ReturnToCell(Actor self);
 		Activity MoveIntoTarget(Actor self, in Target target);
-		Activity VisualMove(Actor self, WPos fromPos, WPos toPos);
+		Activity LocalMove(Actor self, WPos fromPos, WPos toPos);
 		int EstimatedMoveDuration(Actor self, WPos fromPos, WPos toPos);
 		CPos NearestMoveableCell(CPos target);
 		MovementType CurrentMovementTypes { get; set; }


### PR DESCRIPTION
While they may be only 'visual' in terms of influence/cell grid, they all _do_ update `CenterPosition`, which is essentially the
actual world position of the actor.
'Visual' would imply that it only affects the position where the actor is drawn, which is inaccurate.
Furthermore, continuing to use the term 'Visual' here would make naming future methods/properties related to visual interpolation unnecessarily complicated, because that's where we might potentially need a real `Visual(Only)Position` and `SetVisualPosition`.