### PR TITLE
Fix Move jumpy-ness and occasional facing mismatch

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -393,18 +393,18 @@ namespace OpenRA.Mods.Common.Activities
 			protected readonly int ArcToLength;
 			protected readonly WAngle ArcToAngle;
 
-			protected readonly int MoveFractionTotal;
-			protected int moveFraction;
+			protected readonly int Distance;
+			protected int progress;
 
-			public MovePart(Move move, WPos from, WPos to, WAngle fromFacing, WAngle toFacing, int startingFraction)
+			public MovePart(Move move, WPos from, WPos to, WAngle fromFacing, WAngle toFacing, int carryoverProgress)
 			{
 				Move = move;
 				From = from;
 				To = to;
 				FromFacing = fromFacing;
 				ToFacing = toFacing;
-				moveFraction = startingFraction;
-				MoveFractionTotal = (to - from).Length;
+				progress = carryoverProgress;
+				Distance = (to - from).Length;
 				IsInterruptible = false; // See comments in Move.Cancel()
 
 				// Calculate an elliptical arc that joins from and to
@@ -437,11 +437,11 @@ namespace OpenRA.Mods.Common.Activities
 			public override bool Tick(Actor self)
 			{
 				var mobile = Move.mobile;
-				moveFraction += mobile.MovementSpeedForCell(self, mobile.ToCell);
+				progress += mobile.MovementSpeedForCell(self, mobile.ToCell);
 
-				if (moveFraction >= MoveFractionTotal)
+				if (progress >= Distance)
 				{
-					moveFraction = MoveFractionTotal;
+					progress = Distance;
 					mobile.SetCenterPosition(self, To);
 					mobile.Facing = ToFacing;
 
@@ -452,19 +452,19 @@ namespace OpenRA.Mods.Common.Activities
 				WPos pos;
 				if (EnableArc)
 				{
-					var angle = WAngle.Lerp(ArcFromAngle, ArcToAngle, moveFraction, MoveFractionTotal);
-					var length = int2.Lerp(ArcFromLength, ArcToLength, moveFraction, MoveFractionTotal);
-					var height = int2.Lerp(From.Z, To.Z, moveFraction, MoveFractionTotal);
+					var angle = WAngle.Lerp(ArcFromAngle, ArcToAngle, progress, Distance);
+					var length = int2.Lerp(ArcFromLength, ArcToLength, progress, Distance);
+					var height = int2.Lerp(From.Z, To.Z, progress, Distance);
 					pos = ArcCenter + new WVec(0, length, height).Rotate(WRot.FromYaw(angle));
 				}
 				else
-					pos = WPos.Lerp(From, To, moveFraction, MoveFractionTotal);
+					pos = WPos.Lerp(From, To, progress, Distance);
 
 				if (self.Location.Layer == 0)
 					pos -= new WVec(WDist.Zero, WDist.Zero, self.World.Map.DistanceAboveTerrain(pos));
 
 				mobile.SetCenterPosition(self, pos);
-				mobile.Facing = WAngle.Lerp(FromFacing, ToFacing, moveFraction, MoveFractionTotal);
+				mobile.Facing = WAngle.Lerp(FromFacing, ToFacing, progress, Distance);
 				return false;
 			}
 
@@ -478,8 +478,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		class MoveFirstHalf : MovePart
 		{
-			public MoveFirstHalf(Move move, WPos from, WPos to, WAngle fromFacing, WAngle toFacing, int startingFraction)
-				: base(move, from, to, fromFacing, toFacing, startingFraction) { }
+			public MoveFirstHalf(Move move, WPos from, WPos to, WAngle fromFacing, WAngle toFacing, int carryoverProgress)
+				: base(move, from, to, fromFacing, toFacing, carryoverProgress) { }
 
 			static bool IsTurn(Mobile mobile, CPos nextCell, Map map)
 			{
@@ -512,7 +512,7 @@ namespace OpenRA.Mods.Common.Activities
 							Util.BetweenCells(self.World, mobile.ToCell, nextCell.Value.Cell) + (toSubcellOffset + nextSubcellOffset) / 2,
 							mobile.Facing,
 							map.FacingBetween(mobile.ToCell, nextCell.Value.Cell, mobile.Facing),
-							moveFraction - MoveFractionTotal);
+							progress - Distance);
 
 						mobile.FinishedMoving(self);
 						mobile.SetLocation(mobile.ToCell, mobile.ToSubCell, nextCell.Value.Cell, nextCell.Value.SubCell);
@@ -531,7 +531,7 @@ namespace OpenRA.Mods.Common.Activities
 					toPos + toSubcellOffset,
 					mobile.Facing,
 					mobile.Facing,
-					moveFraction - MoveFractionTotal);
+					progress - Distance);
 
 				mobile.EnteringCell(self);
 				mobile.SetLocation(mobile.ToCell, mobile.ToSubCell, mobile.ToCell, mobile.ToSubCell);
@@ -541,8 +541,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		class MoveSecondHalf : MovePart
 		{
-			public MoveSecondHalf(Move move, WPos from, WPos to, WAngle fromFacing, WAngle toFacing, int startingFraction)
-				: base(move, from, to, fromFacing, toFacing, startingFraction) { }
+			public MoveSecondHalf(Move move, WPos from, WPos to, WAngle fromFacing, WAngle toFacing, int carryoverProgress)
+				: base(move, from, to, fromFacing, toFacing, carryoverProgress) { }
 
 			protected override MovePart OnComplete(Actor self, Mobile mobile, Move parent)
 			{

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -38,6 +38,8 @@ namespace OpenRA.Mods.Common.Activities
 			BlockedByActor.None
 		};
 
+		int carryoverProgress;
+
 		List<CPos> path;
 		CPos? destination;
 
@@ -219,7 +221,8 @@ namespace OpenRA.Mods.Common.Activities
 			var to = Util.BetweenCells(self.World, mobile.FromCell, mobile.ToCell) +
 				(map.Grid.OffsetOfSubCell(mobile.FromSubCell) + map.Grid.OffsetOfSubCell(mobile.ToSubCell)) / 2;
 
-			QueueChild(new MoveFirstHalf(this, from, to, mobile.Facing, mobile.Facing, 0));
+			QueueChild(new MoveFirstHalf(this, from, to, mobile.Facing, mobile.Facing, carryoverProgress));
+			carryoverProgress = 0;
 			return false;
 		}
 
@@ -392,9 +395,10 @@ namespace OpenRA.Mods.Common.Activities
 			protected readonly WAngle ArcFromAngle;
 			protected readonly int ArcToLength;
 			protected readonly WAngle ArcToAngle;
-
 			protected readonly int Distance;
 			protected int progress;
+
+			protected bool firstTick = true;
 
 			public MovePart(Move move, WPos from, WPos to, WAngle fromFacing, WAngle toFacing, int carryoverProgress)
 			{
@@ -405,6 +409,7 @@ namespace OpenRA.Mods.Common.Activities
 				ToFacing = toFacing;
 				progress = carryoverProgress;
 				Distance = (to - from).Length;
+
 				IsInterruptible = false; // See comments in Move.Cancel()
 
 				// Calculate an elliptical arc that joins from and to
@@ -437,11 +442,17 @@ namespace OpenRA.Mods.Common.Activities
 			public override bool Tick(Actor self)
 			{
 				var mobile = Move.mobile;
-				progress += mobile.MovementSpeedForCell(self, mobile.ToCell);
+
+				// Having non-zero progress in the first tick means that this MovePart is following on from
+				// a previous MovePart that has just completed during the same tick. In this case, we want to
+				// apply the carried over progress but not evaluate a full new step until the next tick.
+				if (!firstTick || progress == 0)
+					progress += mobile.MovementSpeedForCell(self, mobile.ToCell);
+
+				firstTick = false;
 
 				if (progress >= Distance)
 				{
-					progress = Distance;
 					mobile.SetCenterPosition(self, To);
 					mobile.Facing = ToFacing;
 
@@ -547,6 +558,11 @@ namespace OpenRA.Mods.Common.Activities
 			protected override MovePart OnComplete(Actor self, Mobile mobile, Move parent)
 			{
 				mobile.SetPosition(self, mobile.ToCell);
+
+				// Move might immediately queue a new MoveFirstHalf within the same tick if we haven't
+				// reached the end of the requested path. Make sure that any leftover movement progress is
+				// correctly carried over into this new activity to avoid a glitch in the apparent move speed.
+				Move.carryoverProgress = progress - Distance;
 				return null;
 			}
 		}

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -436,57 +436,36 @@ namespace OpenRA.Mods.Common.Activities
 
 			public override bool Tick(Actor self)
 			{
-				var ret = InnerTick(self, Move.mobile);
-
-				if (moveFraction > MoveFractionTotal)
-					moveFraction = MoveFractionTotal;
-
-				UpdateCenterLocation(self, Move.mobile);
-
-				if (ret == this)
-					return false;
-
-				Queue(ret);
-				return true;
-			}
-
-			Activity InnerTick(Actor self, Mobile mobile)
-			{
+				var mobile = Move.mobile;
 				moveFraction += mobile.MovementSpeedForCell(self, mobile.ToCell);
-				if (moveFraction <= MoveFractionTotal)
-					return this;
-
-				return OnComplete(self, mobile, Move);
-			}
-
-			void UpdateCenterLocation(Actor self, Mobile mobile)
-			{
-				// Avoid division through zero
-				if (MoveFractionTotal != 0)
-				{
-					WPos pos;
-					if (EnableArc)
-					{
-						var angle = WAngle.Lerp(ArcFromAngle, ArcToAngle, moveFraction, MoveFractionTotal);
-						var length = int2.Lerp(ArcFromLength, ArcToLength, moveFraction, MoveFractionTotal);
-						var height = int2.Lerp(From.Z, To.Z, moveFraction, MoveFractionTotal);
-						pos = ArcCenter + new WVec(0, length, height).Rotate(WRot.FromYaw(angle));
-					}
-					else
-						pos = WPos.Lerp(From, To, moveFraction, MoveFractionTotal);
-
-					if (self.Location.Layer == 0)
-						pos -= new WVec(WDist.Zero, WDist.Zero, self.World.Map.DistanceAboveTerrain(pos));
-
-					mobile.SetCenterPosition(self, pos);
-				}
-				else
-					mobile.SetCenterPosition(self, To);
 
 				if (moveFraction >= MoveFractionTotal)
+				{
+					moveFraction = MoveFractionTotal;
+					mobile.SetCenterPosition(self, To);
 					mobile.Facing = ToFacing;
+
+					Queue(OnComplete(self, mobile, Move));
+					return true;
+				}
+
+				WPos pos;
+				if (EnableArc)
+				{
+					var angle = WAngle.Lerp(ArcFromAngle, ArcToAngle, moveFraction, MoveFractionTotal);
+					var length = int2.Lerp(ArcFromLength, ArcToLength, moveFraction, MoveFractionTotal);
+					var height = int2.Lerp(From.Z, To.Z, moveFraction, MoveFractionTotal);
+					pos = ArcCenter + new WVec(0, length, height).Rotate(WRot.FromYaw(angle));
+				}
 				else
-					mobile.Facing = WAngle.Lerp(FromFacing, ToFacing, moveFraction, MoveFractionTotal);
+					pos = WPos.Lerp(From, To, moveFraction, MoveFractionTotal);
+
+				if (self.Location.Layer == 0)
+					pos -= new WVec(WDist.Zero, WDist.Zero, self.World.Map.DistanceAboveTerrain(pos));
+
+				mobile.SetCenterPosition(self, pos);
+				mobile.Facing = WAngle.Lerp(FromFacing, ToFacing, moveFraction, MoveFractionTotal);
+				return false;
 			}
 
 			protected abstract MovePart OnComplete(Actor self, Mobile mobile, Move parent);


### PR DESCRIPTION
1) Fixes facing mismatch bug:
Due to `var ret` passing `mobile.Facing` to the next queued `MovePart` before `UpdateCenterLocation` would set the correct final facing of the current `MovePart`, this was preventing the correct 'final' facing from being set as early as it should, making actors only turn to the correct final facing at the very end of `MoveSecondHalf`.

Best testcase I can offer is the harvester in the RA shellmap: Watch it closely when it makes its final turn towards the first cell it harvests. If you compare bleed and this PR, you should be able to see the difference.

Fixes #16651.
Fixes #18732 (which admittedly was just a duplicate of the above).

2) Fixes ground actors moving too fast and 'jump' during MovePart transitions:
`MovePart` didn't account for usually being on the same tick as the previous `MovePart`s last tick if the latter overshot `MoveFractionTotal` (which is usually the case).

A ground actor with base speed 100 on terrain with 100% modifier will now move exactly as fast as an aircraft with the same speed.

Fixes #13844 (tested)
Fixes #16682.