### PR TITLE
Fix self-contained packaging.

### DIFF
--- a/OpenRA.Launcher/OpenRA.Launcher.csproj
+++ b/OpenRA.Launcher/OpenRA.Launcher.csproj
@@ -65,10 +65,4 @@
       <Analyzer Remove="@(Analyzer)" />
     </ItemGroup>
   </Target>
-  <ItemGroup>
-    <TrimmerRootAssembly Include="mscorlib" />
-    <TrimmerRootAssembly Include="netstandard" />
-    <TrimmerRootAssembly Include="System.IO.Pipes" />
-    <TrimmerRootAssembly Include="System.Threading.Tasks.Parallel" />
-  </ItemGroup>
 </Project>

--- a/OpenRA.WindowsLauncher/OpenRA.WindowsLauncher.csproj
+++ b/OpenRA.WindowsLauncher/OpenRA.WindowsLauncher.csproj
@@ -58,10 +58,4 @@
       <Analyzer Remove="@(Analyzer)" />
     </ItemGroup>
   </Target>
-  <ItemGroup>
-    <TrimmerRootAssembly Include="mscorlib" />
-    <TrimmerRootAssembly Include="netstandard" />
-    <TrimmerRootAssembly Include="System.IO.Pipes" />
-    <TrimmerRootAssembly Include="System.Threading.Tasks.Parallel" />
-  </ItemGroup>
 </Project>

--- a/packaging/functions.sh
+++ b/packaging/functions.sh
@@ -97,7 +97,7 @@ install_assemblies() {
 	ORIG_PWD=$(pwd)
 	cd "${SRC_PATH}" || exit 1
 
-	dotnet publish -c Release -p:TargetPlatform="${TARGETPLATFORM}" -p:PublishTrimmed=true -p:CopyGenericLauncher="${COPY_GENERIC_LAUNCHER}" -p:CopyCncDll="${COPY_CNC_DLL}" -p:CopyD2kDll="${COPY_D2K_DLL}" -r "${TARGETPLATFORM}" -o "${DEST_PATH}"
+	dotnet publish -c Release -p:TargetPlatform="${TARGETPLATFORM}" -p:PublishTrimmed=true -p:CopyGenericLauncher="${COPY_GENERIC_LAUNCHER}" -p:CopyCncDll="${COPY_CNC_DLL}" -p:CopyD2kDll="${COPY_D2K_DLL}" -r "${TARGETPLATFORM}" -o "${DEST_PATH}" --self-contained true
 
 	cd "${ORIG_PWD}" || exit 1
 }
@@ -170,7 +170,7 @@ install_windows_launcher()
 	FAQ_URL="${7}"
 
 	rm -rf "${SRC_PATH}/OpenRA.WindowsLauncher/obj"
-	dotnet publish "${SRC_PATH}/OpenRA.WindowsLauncher/OpenRA.WindowsLauncher.csproj" -c Release -r "${TARGETPLATFORM}" -p:LauncherName="${LAUNCHER_NAME}" -p:TargetPlatform="${TARGETPLATFORM}" -p:ModID="${MOD_ID}" -p:DisplayName="${MOD_NAME}" -p:FaqUrl="${FAQ_URL}" -o "${DEST_PATH}"
+	dotnet publish "${SRC_PATH}/OpenRA.WindowsLauncher/OpenRA.WindowsLauncher.csproj" -c Release -r "${TARGETPLATFORM}" -p:LauncherName="${LAUNCHER_NAME}" -p:TargetPlatform="${TARGETPLATFORM}" -p:ModID="${MOD_ID}" -p:DisplayName="${MOD_NAME}" -p:FaqUrl="${FAQ_URL}" -o "${DEST_PATH}" --self-contained true
 
 	# NET 5 is unable to customize the application host for windows when compiling from Linux,
 	# so we must patch the properties we need in the PE header.


### PR DESCRIPTION
The .NET docs noted that the `--self-contained` parameter would
> Default is true if a runtime identifier is specified and the project is an executable project (not a library project).

I initially interpreted this as meaning it would default to true for *all* the projects in the sln, because it would be crazy if some projects were treated as self contained and others weren't when all are being published together. It turns out that .NET is crazy, and that the csproj changes in #18995 introduced new breaking errors related to this (thanks to @IceReaper for discovering the issue).

Setting `--self-contained` explicitly fixes this, and also appears to solve the trimming problems from the original PR, so i'm dropping those workarounds too.

Test release: https://github.com/pchote/OpenRA/releases/tag/devtest-20210309