### PR TITLE
Make ISpriteLoader aware of the source file name.

### DIFF
--- a/OpenRA.Game/Graphics/SpriteLoader.cs
+++ b/OpenRA.Game/Graphics/SpriteLoader.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Graphics
 
 	public interface ISpriteLoader
 	{
-		bool TryParseSprite(Stream s, out ISpriteFrame[] frames, out TypeDictionary metadata);
+		bool TryParseSprite(Stream s, string filename, out ISpriteFrame[] frames, out TypeDictionary metadata);
 	}
 
 	public interface ISpriteFrame
@@ -173,7 +173,7 @@ namespace OpenRA.Graphics
 		{
 			using (var stream = fileSystem.Open(filename))
 			{
-				var spriteFrames = GetFrames(stream, loaders, out metadata);
+				var spriteFrames = GetFrames(stream, loaders, filename, out metadata);
 				if (spriteFrames == null)
 					throw new InvalidDataException(filename + " is not a valid sprite file!");
 
@@ -181,12 +181,12 @@ namespace OpenRA.Graphics
 			}
 		}
 
-		public static ISpriteFrame[] GetFrames(Stream stream, ISpriteLoader[] loaders, out TypeDictionary metadata)
+		public static ISpriteFrame[] GetFrames(Stream stream, ISpriteLoader[] loaders, string filename, out TypeDictionary metadata)
 		{
 			metadata = null;
 
 			foreach (var loader in loaders)
-				if (loader.TryParseSprite(stream, out var frames, out metadata))
+				if (loader.TryParseSprite(stream, filename, out var frames, out metadata))
 					return frames;
 
 			return null;

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpD2Loader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpD2Loader.cs
@@ -155,7 +155,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			return frames;
 		}
 
-		public bool TryParseSprite(Stream s, out ISpriteFrame[] frames, out TypeDictionary metadata)
+		public bool TryParseSprite(Stream s, string filename, out ISpriteFrame[] frames, out TypeDictionary metadata)
 		{
 			metadata = null;
 			if (!IsShpD2(s))

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpRemasteredLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpRemasteredLoader.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			return isZipFile;
 		}
 
-		public bool TryParseSprite(Stream s, out ISpriteFrame[] frames, out TypeDictionary metadata)
+		public bool TryParseSprite(Stream s, string filename, out ISpriteFrame[] frames, out TypeDictionary metadata)
 		{
 			metadata = null;
 			if (!IsShpRemastered(s))

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpTDLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpTDLoader.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			return b == 0x20 || b == 0x40 || b == 0x80;
 		}
 
-		public bool TryParseSprite(Stream s, out ISpriteFrame[] frames, out TypeDictionary metadata)
+		public bool TryParseSprite(Stream s, string filename, out ISpriteFrame[] frames, out TypeDictionary metadata)
 		{
 			metadata = null;
 			if (!IsShpTD(s))

--- a/OpenRA.Mods.Cnc/SpriteLoaders/TmpRALoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/TmpRALoader.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			return tiles;
 		}
 
-		public bool TryParseSprite(Stream s, out ISpriteFrame[] frames, out TypeDictionary metadata)
+		public bool TryParseSprite(Stream s, string filename, out ISpriteFrame[] frames, out TypeDictionary metadata)
 		{
 			metadata = null;
 			if (!IsTmpRA(s))

--- a/OpenRA.Mods.Cnc/SpriteLoaders/TmpTDLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/TmpTDLoader.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			return tiles;
 		}
 
-		public bool TryParseSprite(Stream s, out ISpriteFrame[] frames, out TypeDictionary metadata)
+		public bool TryParseSprite(Stream s, string filename, out ISpriteFrame[] frames, out TypeDictionary metadata)
 		{
 			metadata = null;
 			if (!IsTmpTD(s))

--- a/OpenRA.Mods.Cnc/SpriteLoaders/TmpTSLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/TmpTSLoader.cs
@@ -184,7 +184,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			return tiles;
 		}
 
-		public bool TryParseSprite(Stream s, out ISpriteFrame[] frames, out TypeDictionary metadata)
+		public bool TryParseSprite(Stream s, string filename, out ISpriteFrame[] frames, out TypeDictionary metadata)
 		{
 			metadata = null;
 			if (!IsTmpTS(s))

--- a/OpenRA.Mods.Common/SpriteLoaders/DdsLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/DdsLoader.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 			return isDds;
 		}
 
-		public bool TryParseSprite(Stream s, out ISpriteFrame[] frames, out TypeDictionary metadata)
+		public bool TryParseSprite(Stream s, string filename, out ISpriteFrame[] frames, out TypeDictionary metadata)
 		{
 			metadata = null;
 			if (!IsDds(s))

--- a/OpenRA.Mods.Common/SpriteLoaders/PngSheetLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/PngSheetLoader.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 			public bool DisableExportPadding => false;
 		}
 
-		public bool TryParseSprite(Stream s, out ISpriteFrame[] frames, out TypeDictionary metadata)
+		public bool TryParseSprite(Stream s, string filename, out ISpriteFrame[] frames, out TypeDictionary metadata)
 		{
 			metadata = null;
 			frames = null;

--- a/OpenRA.Mods.Common/SpriteLoaders/ShpTSLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/ShpTSLoader.cs
@@ -146,7 +146,7 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 			return frames;
 		}
 
-		public bool TryParseSprite(Stream s, out ISpriteFrame[] frames, out TypeDictionary metadata)
+		public bool TryParseSprite(Stream s, string filename, out ISpriteFrame[] frames, out TypeDictionary metadata)
 		{
 			metadata = null;
 			if (!IsShpTS(s))

--- a/OpenRA.Mods.Common/SpriteLoaders/TgaLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/TgaLoader.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 			}
 		}
 
-		public bool TryParseSprite(Stream s, out ISpriteFrame[] frames, out TypeDictionary metadata)
+		public bool TryParseSprite(Stream s, string filename, out ISpriteFrame[] frames, out TypeDictionary metadata)
 		{
 			metadata = null;
 			if (!IsTga(s))

--- a/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			for (var i = 0; i < Palette.Size; i++)
 				palColors[i] = palette.GetColor(i);
 
-			var frames = FrameLoader.GetFrames(File.OpenRead(src), modData.SpriteLoaders, out _);
+			var frames = FrameLoader.GetFrames(File.OpenRead(src), modData.SpriteLoaders, src, out _);
 
 			var usePadding = !args.Contains("--nopadding");
 			var count = 0;

--- a/OpenRA.Mods.D2k/SpriteLoaders/R8Loader.cs
+++ b/OpenRA.Mods.D2k/SpriteLoaders/R8Loader.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.D2k.SpriteLoaders
 			return d == 8;
 		}
 
-		public bool TryParseSprite(Stream s, out ISpriteFrame[] frames, out TypeDictionary metadata)
+		public bool TryParseSprite(Stream s, string filename, out ISpriteFrame[] frames, out TypeDictionary metadata)
 		{
 			metadata = null;
 			if (!IsR8(s))


### PR DESCRIPTION
Sometimes games have have multiple different sprite formats, where the only possible filetype detection algorythm would be wether the file could be successfully parsed till fileend is reached... This PR basicaly makes the ISpriteLoader aware of the filename, which allows in these cases to avoid unnecesary complex code based checks and simply rely on the file extension.