### PR TITLE
Fix non-relative path handling in install logic.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
@@ -268,11 +268,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 							case "delete":
 							{
-								var sourcePath = Path.Combine(path, i.Value.Value);
-
-								// Try as an absolute path
-								if (!File.Exists(sourcePath))
-									sourcePath = Platform.ResolvePath(i.Value.Value);
+								// Yaml path may be specified relative to a named directory (e.g. ^SupportDir) or the detected disc path
+								var sourcePath = i.Value.Value.StartsWith("^") ? Platform.ResolvePath(i.Value.Value) : Path.Combine(path, i.Value.Value);
 
 								Log.Write("debug", "Deleting {0}", sourcePath);
 								File.Delete(sourcePath);
@@ -325,11 +322,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		static void ExtractFromPackage(ExtractionType type, string path, MiniYaml actionYaml, List<string> extractedFiles, Action<string> updateMessage)
 		{
-			var sourcePath = Path.Combine(path, actionYaml.Value);
-
-			// Try as an absolute path
-			if (!File.Exists(sourcePath))
-				sourcePath = Platform.ResolvePath(actionYaml.Value);
+			// Yaml path may be specified relative to a named directory (e.g. ^SupportDir) or the detected disc path
+			var sourcePath = actionYaml.Value.StartsWith("^") ? Platform.ResolvePath(actionYaml.Value) : Path.Combine(path, actionYaml.Value);
 
 			using (var source = File.OpenRead(sourcePath))
 			{
@@ -384,11 +378,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		static void ExtractFromMSCab(string path, MiniYaml actionYaml, List<string> extractedFiles, Action<string> updateMessage)
 		{
-			var sourcePath = Path.Combine(path, actionYaml.Value);
-
-			// Try as an absolute path
-			if (!File.Exists(sourcePath))
-				sourcePath = Platform.ResolvePath(actionYaml.Value);
+			// Yaml path may be specified relative to a named directory (e.g. ^SupportDir) or the detected disc path
+			var sourcePath = actionYaml.Value.StartsWith("^") ? Platform.ResolvePath(actionYaml.Value) : Path.Combine(path, actionYaml.Value);
 
 			using (var source = File.OpenRead(sourcePath))
 			{
@@ -418,11 +409,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		static void ExtractFromISCab(string path, MiniYaml actionYaml, List<string> extractedFiles, Action<string> updateMessage)
 		{
-			var sourcePath = Path.Combine(path, actionYaml.Value);
-
-			// Try as an absolute path
-			if (!File.Exists(sourcePath))
-				sourcePath = Platform.ResolvePath(actionYaml.Value);
+			// Yaml path may be specified relative to a named directory (e.g. ^SupportDir) or the detected disc path
+			var sourcePath = actionYaml.Value.StartsWith("^") ? Platform.ResolvePath(actionYaml.Value) : Path.Combine(path, actionYaml.Value);
 
 			var volumeNode = actionYaml.Nodes.FirstOrDefault(n => n.Key == "Volumes");
 			if (volumeNode == null)


### PR DESCRIPTION
Fixes #19229.

All our installer definitions except for TFD have `extract-raw` etc specify a path relative to the CD root. TFD is different because all the files are compressed in a cab file - we must extract the whole of main.mix to the support dir, then extract the files we want from them, then delete main.mix once we are done. The install logic handled this case by first assuming that the path is relative to the disc, and then only if that isn't found checking to see if it specifies a relative path.

This used to work because `/path/to/CD/^Content/ra/v2/main.mix` was a valid file path even though it is never going to exist. #18846 broke this (but only on windows!) because `/path/to/CD/^SupportDir|Content/ra/v2/main.mix` is *not* a valid file path (windows bans `|` in filenames) and throws the "Illegal characters in path" exception that we see in #19229.

This PR fixes the issue by checking whether the yaml is specifying a relative or absolute path *before* calling `Path.Combine`. I've tested that the installer still works for the TFD and Allies95 disks on macOS, and the TFD disc and Origin installs on Windows.