### PR TITLE
Fail Situation Critical if Volkov is killed before entering the world.

### DIFF
--- a/mods/ra/maps/situation-critical/situation-critical.lua
+++ b/mods/ra/maps/situation-critical/situation-critical.lua
@@ -124,11 +124,11 @@ SendInVolkov = function()
 		Media.PlaySpeechNotification(USSR, "ReinforcementsArrived")
 		local teamVolkov = Reinforcements.ReinforceWithTransport(USSR, InsertionTransport, VolkovandFriend, VolkovEntryPath, { VolkovEntryPath[1] })[2]
 		VolkovArrived = true
+		Trigger.OnKilled(teamVolkov[1], function()
+			USSR.MarkFailedObjective(VolkovSurvive)
+		end)
 		Trigger.OnAddedToWorld(teamVolkov[1], function(a)
 			Media.DisplayMessage("IFF software update failed. Require manual target input.", "Volkov")
-			Trigger.OnKilled(a, function()
-				USSR.MarkFailedObjective(VolkovSurvive)
-			end)
 		end)
 
 		Trigger.OnAddedToWorld(teamVolkov[2], function(b)


### PR DESCRIPTION
Fixes #19230.

Quick repro case: control group the missile subs into two groups of two. Have the first two fire a single volley at the tesla coil next to the starting point, then wait for them to reload. Have the second group fire a volley at the northern power plant, then immediately switch to the first group and have them fire again on the telsa coil. This will trigger the transport arrival but then immediately bring the power back online so it can be killed by the tesla before it enters the bay.