### PR TITLE
Add support for custom smudge smoke offset and add flame spawns to RA/TD

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -36,6 +36,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Chance of smoke rising from the ground")]
 		public readonly int SmokeChance = 0;
 
+		[Desc("By how much (in each direction) can the smoke appearance offset stray from the center of the cell?",
+			"Note: Limit this to half a cell for square and 1/3 a cell for isometric cells to avoid straying into neighbour cells.")]
+		public readonly WDist MaxSmokeOffsetDistance = WDist.Zero;
+
 		[Desc("Smoke sprite image name")]
 		public readonly string SmokeImage = null;
 
@@ -150,8 +154,14 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			if (hasSmoke && Game.CosmeticRandom.Next(0, 100) <= Info.SmokeChance)
+			{
+				var maxOffsetDistance = Info.MaxSmokeOffsetDistance.Length;
+				var x = world.SharedRandom.Next(-maxOffsetDistance, maxOffsetDistance);
+				var y = world.SharedRandom.Next(-maxOffsetDistance, maxOffsetDistance);
+				var offset = new WVec(x, y, 0);
 				world.AddFrameEndTask(w => w.Add(new SpriteEffect(
-					w.Map.CenterOfCell(loc), w, Info.SmokeImage, Info.SmokeSequences.Random(w.SharedRandom), Info.SmokePalette)));
+					w.Map.CenterOfCell(loc) + offset, w, Info.SmokeImage, Info.SmokeSequences.Random(w.SharedRandom), Info.SmokePalette)));
+			}
 
 			// A null Sequence indicates a deleted smudge.
 			if ((!dirty.ContainsKey(loc) || dirty[loc].Sequence == null) && !tiles.ContainsKey(loc))

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -169,8 +169,8 @@ World:
 		Type: Scorch
 		Sequence: scorches
 		SmokeChance: 50
-		SmokeImage: smoke_m
-		SmokeSequences: idle
+		SmokeImage: scorch_flames
+		SmokeSequences: large_flame, medium_flame, small_flame
 		MaxSmokeOffsetDistance: 341
 	SmudgeLayer@CRATER:
 		Type: Crater

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -171,12 +171,14 @@ World:
 		SmokeChance: 50
 		SmokeImage: smoke_m
 		SmokeSequences: idle
+		MaxSmokeOffsetDistance: 341
 	SmudgeLayer@CRATER:
 		Type: Crater
 		Sequence: craters
 		SmokeChance: 25
 		SmokeImage: smoke_m
 		SmokeSequences: idle
+		MaxSmokeOffsetDistance: 213
 	ResourceLayer:
 	ResourceClaimLayer:
 	WarheadDebugOverlay:

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -72,6 +72,177 @@ smoke_m:
 		Offset: 2, -5
 		ZOffset: 512
 
+scorch_flames:
+	large_flame:
+		Length: *
+		Combine:
+			fire1:
+				Length: *
+				Offset: 0,-3
+			fire1:
+				Length: *
+				Offset: 0,-3
+			fire1:
+				Length: *
+				Offset: 0,-3
+			fire1:
+				Length: *
+				Offset: 0,-3
+			fire2:
+				Length: *
+				Offset: 0,-3
+			fire2:
+				Length: *
+				Offset: 0,-3
+			fire2:
+				Length: *
+				Offset: 0,-3
+			smoke_m:
+				Length: *
+				Offset: 2, -5
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.75
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.5
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.25
+	medium_flame:
+		Length: *
+		Combine:
+			fire2:
+				Length: *
+				Offset: 0,-3
+			fire2:
+				Length: *
+				Offset: 0,-3
+			fire2:
+				Length: *
+				Offset: 0,-3
+			fire2:
+				Length: *
+				Offset: 0,-3
+			fire2:
+				Length: *
+				Offset: 0,-3
+			smoke_m:
+				Length: *
+				Offset: 2, -5
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.75
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.5
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.25
+	small_flame:
+		Combine:
+			fire3:
+				Length: *
+				Offset: 0,-3
+			fire3:
+				Length: *
+				Offset: 0,-3
+			fire3:
+				Length: *
+				Offset: 0,-3
+			fire3:
+				Length: *
+				Offset: 0,-3
+			fire3:
+				Length: *
+				Offset: 0,-3
+			smoke_m:
+				Length: *
+				Offset: 2, -5
+				Scale: 0.75
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.5
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.25
+		Length: *
+		Offset: 0,-3
+	tiny_flame:
+		Combine:
+			fire4:
+				Length: *
+				Offset: 0,-3
+			fire4:
+				Length: *
+				Offset: 0,-3
+			fire4:
+				Length: *
+				Offset: 0,-3
+			fire4:
+				Length: *
+				Offset: 0,-3
+			smoke_m:
+				Length: *
+				Offset: 2, -5
+				Scale: 0.3
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.2
+		Length: *
+		Offset: 0,-3
+	smoke:
+		Combine:
+			smoke_m:
+				Length: *
+				Offset: 2, -5
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.8
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.6
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.4
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.2
+
 laserfire:
 	idle: veh-hit3
 		Length: *

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -203,12 +203,14 @@ World:
 		SmokeChance: 50
 		SmokeImage: smoke_m
 		SmokeSequences: idle
+		MaxSmokeOffsetDistance: 341
 	SmudgeLayer@CRATER:
 		Type: Crater
 		Sequence: craters
 		SmokeChance: 25
 		SmokeImage: smoke_m
 		SmokeSequences: idle
+		MaxSmokeOffsetDistance: 213
 	ResourceLayer:
 	ResourceClaimLayer:
 	WarheadDebugOverlay:

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -201,8 +201,8 @@ World:
 		Type: Scorch
 		Sequence: scorches
 		SmokeChance: 50
-		SmokeImage: smoke_m
-		SmokeSequences: idle
+		SmokeImage: scorch_flames
+		SmokeSequences: large_flame, medium_flame, small_flame
 		MaxSmokeOffsetDistance: 341
 	SmudgeLayer@CRATER:
 		Type: Crater

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -184,6 +184,177 @@ smoke_m:
 		Offset: 2, -5
 		ZOffset: 512
 
+scorch_flames:
+	large_flame:
+		Length: *
+		Combine:
+			fire1:
+				Length: *
+				Offset: 0,-3
+			fire1:
+				Length: *
+				Offset: 0,-3
+			fire1:
+				Length: *
+				Offset: 0,-3
+			fire1:
+				Length: *
+				Offset: 0,-3
+			fire2:
+				Length: *
+				Offset: 0,-3
+			fire2:
+				Length: *
+				Offset: 0,-3
+			fire2:
+				Length: *
+				Offset: 0,-3
+			smoke_m:
+				Length: *
+				Offset: 2, -5
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.75
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.5
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.25
+	medium_flame:
+		Length: *
+		Combine:
+			fire2:
+				Length: *
+				Offset: 0,-3
+			fire2:
+				Length: *
+				Offset: 0,-3
+			fire2:
+				Length: *
+				Offset: 0,-3
+			fire2:
+				Length: *
+				Offset: 0,-3
+			fire2:
+				Length: *
+				Offset: 0,-3
+			smoke_m:
+				Length: *
+				Offset: 2, -5
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.75
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.5
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.25
+	small_flame:
+		Combine:
+			fire3:
+				Length: *
+				Offset: 0,-3
+			fire3:
+				Length: *
+				Offset: 0,-3
+			fire3:
+				Length: *
+				Offset: 0,-3
+			fire3:
+				Length: *
+				Offset: 0,-3
+			fire3:
+				Length: *
+				Offset: 0,-3
+			smoke_m:
+				Length: *
+				Offset: 2, -5
+				Scale: 0.75
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.5
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.25
+		Length: *
+		Offset: 0,-3
+	tiny_flame:
+		Combine:
+			fire4:
+				Length: *
+				Offset: 0,-3
+			fire4:
+				Length: *
+				Offset: 0,-3
+			fire4:
+				Length: *
+				Offset: 0,-3
+			fire4:
+				Length: *
+				Offset: 0,-3
+			smoke_m:
+				Length: *
+				Offset: 2, -5
+				Scale: 0.3
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.2
+		Length: *
+		Offset: 0,-3
+	smoke:
+		Combine:
+			smoke_m:
+				Length: *
+				Offset: 2, -5
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.8
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.6
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.4
+			smoke_m:
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.2
+
 dragon:
 	idle:
 		Facings: 32

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -257,18 +257,21 @@ World:
 		SmokeImage: smallfire
 		SmokeSequences: idle
 		SmokeChance: 50
+		MaxSmokeOffsetDistance: 256
 	SmudgeLayer@MEDIUMSCORCH:
 		Type: MediumScorch
 		Sequence: mediumscorches
 		SmokeImage: mediumfire
 		SmokeSequences: idle
 		SmokeChance: 75
+		MaxSmokeOffsetDistance: 192
 	SmudgeLayer@LARGESCORCH:
 		Type: LargeScorch
 		Sequence: largescorches
 		SmokeImage: largefire
 		SmokeSequences: idle
 		SmokeChance: 100
+		MaxSmokeOffsetDistance: 128
 	SmudgeLayer@SMALLCRATER:
 		Type: SmallCrater
 		Sequence: smallcraters


### PR DESCRIPTION
This was mostly inspired by the smoke left by the exploding oil derrick on RA shellmap looking too orderly and disappearing too fast, as well as flamethrowers spawning no flames on projectile impact.