### PR TITLE
Added a lint check for trait placement on hardcoded actor names

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -24,6 +24,15 @@ using OpenRA.Traits;
 
 namespace OpenRA
 {
+	[Flags]
+	public enum SystemActors
+	{
+		Player = 0,
+		EditorPlayer = 1,
+		World = 2,
+		EditorWorld = 4
+	}
+
 	public sealed class Actor : IScriptBindable, IScriptNotifyBind, ILuaTableBinding, ILuaEqualityBinding, ILuaToStringBinding, IEquatable<Actor>, IDisposable
 	{
 		internal readonly struct SyncHash

--- a/OpenRA.Game/GameRules/Ruleset.cs
+++ b/OpenRA.Game/GameRules/Ruleset.cs
@@ -22,7 +22,7 @@ namespace OpenRA
 {
 	public class Ruleset
 	{
-		public readonly IReadOnlyDictionary<string, ActorInfo> Actors;
+		public readonly ActorInfoDictionary Actors;
 		public readonly IReadOnlyDictionary<string, WeaponInfo> Weapons;
 		public readonly IReadOnlyDictionary<string, SoundInfo> Voices;
 		public readonly IReadOnlyDictionary<string, SoundInfo> Notifications;
@@ -41,7 +41,7 @@ namespace OpenRA
 			SequenceProvider sequences,
 			IReadOnlyDictionary<string, MiniYamlNode> modelSequences)
 		{
-			Actors = actors;
+			Actors = new ActorInfoDictionary(actors);
 			Weapons = weapons;
 			Voices = voices;
 			Notifications = notifications;

--- a/OpenRA.Game/Graphics/CursorProvider.cs
+++ b/OpenRA.Game/Graphics/CursorProvider.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Graphics
 
 			// Overwrite previous definitions if there are duplicates
 			var pals = new Dictionary<string, IProvidesCursorPaletteInfo>();
-			foreach (var p in modData.DefaultRules.Actors["world"].TraitInfos<IProvidesCursorPaletteInfo>())
+			foreach (var p in modData.DefaultRules.Actors[SystemActors.World].TraitInfos<IProvidesCursorPaletteInfo>())
 				if (p.Palette != null)
 					pals[p.Palette] = p;
 

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -708,7 +708,7 @@ namespace OpenRA
 			}
 
 			// ResourceLayer is on world actor, which isn't caught above, so an extra check for it.
-			var worldActorInfo = Rules.Actors["world"];
+			var worldActorInfo = Rules.Actors[SystemActors.World];
 			var worldimpsis = worldActorInfo.TraitInfos<IMapPreviewSignatureInfo>();
 			foreach (var worldimpsi in worldimpsis)
 				worldimpsi.PopulateMapPreviewSignatureCells(this, worldActorInfo, null, positions);

--- a/OpenRA.Game/Map/MapPlayers.cs
+++ b/OpenRA.Game/Map/MapPlayers.cs
@@ -30,7 +30,7 @@ namespace OpenRA
 
 		public MapPlayers(Ruleset rules, int playerCount)
 		{
-			var firstFaction = rules.Actors["world"].TraitInfos<FactionInfo>()
+			var firstFaction = rules.Actors[SystemActors.World].TraitInfos<FactionInfo>()
 				.First(f => f.Selectable).InternalName;
 
 			Players = new Dictionary<string, PlayerReference>

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -37,9 +37,6 @@ namespace OpenRA
 
 	public class Player : IScriptBindable, IScriptNotifyBind, ILuaTableBinding, ILuaEqualityBinding, ILuaToStringBinding
 	{
-		public const string PlayerActorType = "Player";
-		public const string EditorPlayerActorType = "EditorPlayer";
-
 		struct StanceColors
 		{
 			public Color Self;
@@ -129,13 +126,13 @@ namespace OpenRA
 
 		static FactionInfo ResolveFaction(World world, string factionName, MersenneTwister playerRandom, bool requireSelectable)
 		{
-			var factionInfos = world.Map.Rules.Actors["world"].TraitInfos<FactionInfo>();
+			var factionInfos = world.Map.Rules.Actors[SystemActors.World].TraitInfos<FactionInfo>();
 			return ResolveFaction(factionName, factionInfos, playerRandom, requireSelectable);
 		}
 
 		static FactionInfo ResolveDisplayFaction(World world, string factionName)
 		{
-			var factions = world.Map.Rules.Actors["world"].TraitInfos<FactionInfo>().ToArray();
+			var factions = world.Map.Rules.Actors[SystemActors.World].TraitInfos<FactionInfo>().ToArray();
 
 			return factions.FirstOrDefault(f => f.InternalName == factionName) ?? factions.First();
 		}
@@ -165,7 +162,7 @@ namespace OpenRA
 			{
 				ClientIndex = client.Index;
 				Color = client.Color;
-				PlayerName = ResolvePlayerName(client, world.LobbyInfo.Clients, world.Map.Rules.Actors["player"].TraitInfos<IBotInfo>());
+				PlayerName = ResolvePlayerName(client, world.LobbyInfo.Clients, world.Map.Rules.Actors[SystemActors.Player].TraitInfos<IBotInfo>());
 
 				BotType = client.Bot;
 				Faction = ResolveFaction(world, client.Faction, playerRandom, !pr.LockFaction);
@@ -206,8 +203,8 @@ namespace OpenRA
 			// querying player traits in INotifyCreated.Created would crash.
 			// Therefore assign the uninitialized actor and run the Created callbacks
 			// by calling Initialize ourselves.
-			var playerActorType = world.Type == WorldType.Editor ? EditorPlayerActorType : PlayerActorType;
-			PlayerActor = new Actor(world, playerActorType, new TypeDictionary { new OwnerInit(this) });
+			var playerActorType = world.Type == WorldType.Editor ? SystemActors.EditorPlayer : SystemActors.Player;
+			PlayerActor = new Actor(world, playerActorType.ToString(), new TypeDictionary { new OwnerInit(this) });
 			PlayerActor.Initialize(true);
 
 			Shroud = PlayerActor.Trait<Shroud>();

--- a/OpenRA.Game/Primitives/ActorInfoDictionary.cs
+++ b/OpenRA.Game/Primitives/ActorInfoDictionary.cs
@@ -1,0 +1,48 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace OpenRA
+{
+	public class ActorInfoDictionary : IReadOnlyDictionary<string, ActorInfo>
+	{
+		readonly Dictionary<string, ActorInfo> dict;
+
+		public ActorInfoDictionary(IReadOnlyDictionary<string, ActorInfo> dict)
+		{
+			if (dict == null)
+				throw new ArgumentNullException(nameof(dict));
+
+			this.dict = new Dictionary<string, ActorInfo>(dict);
+		}
+
+		public bool ContainsKey(string key) => dict.ContainsKey(key);
+
+		public bool TryGetValue(string key, out ActorInfo value) => dict.TryGetValue(key, out value);
+
+		public int Count => dict.Count;
+
+		public ActorInfo this[string key] => dict[key];
+		public ActorInfo this[SystemActors key] => dict[key.ToString().ToLowerInvariant()];
+
+		IEnumerable<string> IReadOnlyDictionary<string, ActorInfo>.Keys => dict.Keys;
+		IEnumerable<ActorInfo> IReadOnlyDictionary<string, ActorInfo>.Values => dict.Values;
+
+		public ICollection<string> Keys => dict.Keys;
+		public ICollection<ActorInfo> Values => dict.Values;
+
+		public IEnumerator<KeyValuePair<string, ActorInfo>> GetEnumerator() => dict.GetEnumerator();
+		IEnumerator IEnumerable.GetEnumerator() => dict.GetEnumerator();
+	}
+}

--- a/OpenRA.Game/Scripting/ScriptContext.cs
+++ b/OpenRA.Game/Scripting/ScriptContext.cs
@@ -159,7 +159,7 @@ namespace OpenRA.Scripting
 			var knownPlayerCommands = Game.ModData.ObjectCreator
 				.GetTypesImplementing<ScriptPlayerProperties>()
 				.ToArray();
-			PlayerCommands = FilterCommands(world.Map.Rules.Actors["player"], knownPlayerCommands);
+			PlayerCommands = FilterCommands(world.Map.Rules.Actors[SystemActors.Player], knownPlayerCommands);
 
 			runtime.Globals["EngineDir"] = Platform.EngineDir;
 			runtime.DoBuffer(File.Open(Path.Combine(Platform.EngineDir, "lua", "scriptwrapper.lua"), FileMode.Open, FileAccess.Read).ReadAllText(), "scriptwrapper.lua").Dispose();

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -1213,7 +1213,7 @@ namespace OpenRA.Server
 				// The null padding is needed to keep the player indexes in sync with world.Players on the clients
 				// This will need to change if future code wants to use worldPlayers for other purposes
 				var playerRandom = new MersenneTwister(LobbyInfo.GlobalSettings.RandomSeed);
-				foreach (var cmpi in Map.Rules.Actors["world"].TraitInfos<ICreatePlayersInfo>())
+				foreach (var cmpi in Map.Rules.Actors[SystemActors.World].TraitInfos<ICreatePlayersInfo>())
 					cmpi.CreateServerPlayers(Map, LobbyInfo, worldPlayers, playerRandom);
 
 				if (recorder != null)

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -400,7 +400,7 @@ namespace OpenRA
 		public static string SanitizedPlayerName(string dirty)
 		{
 			var forbiddenNames = new string[] { "Open", "Closed" };
-			var botNames = OpenRA.Game.ModData.DefaultRules.Actors["player"].TraitInfos<IBotInfo>().Select(t => t.Name);
+			var botNames = OpenRA.Game.ModData.DefaultRules.Actors[SystemActors.Player].TraitInfos<IBotInfo>().Select(t => t.Name);
 
 			var clean = SanitizedName(dirty);
 

--- a/OpenRA.Game/Traits/DebugPauseState.cs
+++ b/OpenRA.Game/Traits/DebugPauseState.cs
@@ -11,6 +11,7 @@
 
 namespace OpenRA.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("Checks for pause related desyncs. Attach this to the world actor.")]
 	public class DebugPauseStateInfo : TraitInfo
 	{

--- a/OpenRA.Game/Traits/LintAttributes.cs
+++ b/OpenRA.Game/Traits/LintAttributes.cs
@@ -105,4 +105,14 @@ namespace OpenRA.Traits
 			PlayerPaletteReferenceSwitch = playerPaletteReferenceSwitch;
 		}
 	}
+
+	[AttributeUsage(AttributeTargets.Class)]
+	public sealed class TraitLocationAttribute : Attribute
+	{
+		public readonly SystemActors SystemActors;
+		public TraitLocationAttribute(SystemActors systemActors)
+		{
+			SystemActors = systemActors;
+		}
+	}
 }

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -22,6 +22,7 @@ namespace OpenRA.Traits
 		void OnVisibilityChanged(FrozenActor frozen);
 	}
 
+	[TraitLocation(SystemActors.Player)]
 	[Desc("Required for FrozenUnderFog to work. Attach this to the player actor.")]
 	public class FrozenActorLayerInfo : TraitInfo, Requires<ShroudInfo>
 	{

--- a/OpenRA.Game/Traits/Player/PlayerColorPalette.cs
+++ b/OpenRA.Game/Traits/Player/PlayerColorPalette.cs
@@ -14,7 +14,8 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Traits
 {
-	[Desc("Add this to the Player actor definition.")]
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
+	[Desc("Add this to the World actor definition.")]
 	public class PlayerColorPaletteInfo : TraitInfo
 	{
 		[PaletteReference]

--- a/OpenRA.Game/Traits/Player/Shroud.cs
+++ b/OpenRA.Game/Traits/Player/Shroud.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 
 namespace OpenRA.Traits
 {
+	[TraitLocation(SystemActors.Player | SystemActors.EditorPlayer)]
 	[Desc("Required for shroud and fog visibility checks. Add this to the player actor.")]
 	public class ShroudInfo : TraitInfo, ILobbyOptions
 	{

--- a/OpenRA.Game/Traits/World/DebugVisualizations.cs
+++ b/OpenRA.Game/Traits/World/DebugVisualizations.cs
@@ -11,6 +11,7 @@
 
 namespace OpenRA.Traits
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Enables visualization commands. Attach this to the world actor.")]
 	public class DebugVisualizationsInfo : TraitInfo<DebugVisualizations> { }
 

--- a/OpenRA.Game/Traits/World/Faction.cs
+++ b/OpenRA.Game/Traits/World/Faction.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 namespace OpenRA.Traits
 {
 	[Desc("Attach this to the `World` actor.")]
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	public class FactionInfo : TraitInfo<Faction>
 	{
 		[Desc("This is the name exposed to the players.")]

--- a/OpenRA.Game/Traits/World/ScreenMap.cs
+++ b/OpenRA.Game/Traits/World/ScreenMap.cs
@@ -30,6 +30,7 @@ namespace OpenRA.Traits
 		public override string ToString() { return "{0}->{1}".F(Actor.Info.Name, Bounds.GetType().Name); }
 	}
 
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	public class ScreenMapInfo : TraitInfo
 	{
 		[Desc("Size of partition bins (world pixels)")]

--- a/OpenRA.Game/Traits/World/ScreenShaker.cs
+++ b/OpenRA.Game/Traits/World/ScreenShaker.cs
@@ -16,6 +16,7 @@ using OpenRA.Graphics;
 
 namespace OpenRA.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	public class ScreenShakerInfo : TraitInfo
 	{
 		public readonly float2 MinMultiplier = new float2(-3, -3);

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -186,8 +186,8 @@ namespace OpenRA
 
 			ModelCache = modData.ModelSequenceLoader.CacheModels(map, modData, map.Rules.ModelSequences);
 
-			var worldActorType = type == WorldType.Editor ? "EditorWorld" : "World";
-			WorldActor = CreateActor(worldActorType, new TypeDictionary());
+			var worldActorType = type == WorldType.Editor ? SystemActors.EditorWorld : SystemActors.World;
+			WorldActor = CreateActor(worldActorType.ToString(), new TypeDictionary());
 			ActorMap = WorldActor.Trait<IActorMap>();
 			ScreenMap = WorldActor.Trait<ScreenMap>();
 			Selection = WorldActor.Trait<ISelection>();

--- a/OpenRA.Mods.Cnc/Traits/GpsWatcher.cs
+++ b/OpenRA.Mods.Cnc/Traits/GpsWatcher.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
+	[TraitLocation(SystemActors.Player)]
 	[Desc("Required for `GpsPower`. Attach this to the player actor.")]
 	class GpsWatcherInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Cnc/Traits/PaletteEffects/ChronoshiftPaletteEffect.cs
+++ b/OpenRA.Mods.Cnc/Traits/PaletteEffects/ChronoshiftPaletteEffect.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Apply palette full screen rotations during chronoshifts. Add this to the world actor.")]
 	public class ChronoshiftPaletteEffectInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Cnc/Traits/PaletteEffects/LightPaletteRotator.cs
+++ b/OpenRA.Mods.Cnc/Traits/PaletteEffects/LightPaletteRotator.cs
@@ -15,6 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Palette effect used for blinking \"animations\" on actors.")]
 	class LightPaletteRotatorInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Cnc/Traits/World/ShroudPalette.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/ShroudPalette.cs
@@ -18,6 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Adds the hard-coded shroud palette to the game")]
 	class ShroudPaletteInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Cnc/Traits/World/TSShroudPalette.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSShroudPalette.cs
@@ -18,6 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Adds the hard-coded shroud palette to the game")]
 	class TSShroudPaletteInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Cnc/UtilityCommands/RemapShpCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/RemapShpCommand.cs
@@ -42,13 +42,13 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			var srcModData = new ModData(utility.Mods[srcMod], utility.Mods);
 			Game.ModData = srcModData;
 
-			var srcPaletteInfo = srcModData.DefaultRules.Actors["player"].TraitInfo<PlayerColorPaletteInfo>();
+			var srcPaletteInfo = srcModData.DefaultRules.Actors[SystemActors.Player].TraitInfo<PlayerColorPaletteInfo>();
 			var srcRemapIndex = srcPaletteInfo.RemapIndex;
 
 			var destMod = args[2].Split(':')[0];
 			var destModData = new ModData(utility.Mods[destMod], utility.Mods);
 			Game.ModData = destModData;
-			var destPaletteInfo = destModData.DefaultRules.Actors["player"].TraitInfo<PlayerColorPaletteInfo>();
+			var destPaletteInfo = destModData.DefaultRules.Actors[SystemActors.Player].TraitInfo<PlayerColorPaletteInfo>();
 			var destRemapIndex = destPaletteInfo.RemapIndex;
 			var shadowIndex = new int[] { };
 

--- a/OpenRA.Mods.Common/Commands/ChatCommands.cs
+++ b/OpenRA.Mods.Common/Commands/ChatCommands.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Commands
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("Enables commands triggered by typing them into the chatbox. Attach this to the world actor.")]
 	public class ChatCommandsInfo : TraitInfo<ChatCommands> { }
 

--- a/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Commands
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("Enables visualization commands via the chatbox. Attach this to the world actor.")]
 	public class DebugVisualizationCommandsInfo : TraitInfo<DebugVisualizationCommands> { }
 

--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -17,6 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Commands
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("Enables developer cheats via the chatbox. Attach this to the world actor.")]
 	public class DevCommandsInfo : TraitInfo<DevCommands> { }
 

--- a/OpenRA.Mods.Common/Commands/HelpCommand.cs
+++ b/OpenRA.Mods.Common/Commands/HelpCommand.cs
@@ -15,6 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Commands
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("Shows a list of available commands in the chatbox. Attach this to the world actor.")]
 	public class HelpCommandInfo : TraitInfo<HelpCommand> { }
 

--- a/OpenRA.Mods.Common/Commands/PlayerCommands.cs
+++ b/OpenRA.Mods.Common/Commands/PlayerCommands.cs
@@ -14,6 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Commands
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("Allows the player to pause or surrender the game via the chatbox. Attach this to the world actor.")]
 	public class PlayerCommandsInfo : TraitInfo<PlayerCommands> { }
 

--- a/OpenRA.Mods.Common/Lint/CheckLocomotorReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckLocomotorReferences.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Lint
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
-			var worldActor = rules.Actors["world"];
+			var worldActor = rules.Actors[SystemActors.World];
 			var locomotorInfos = worldActor.TraitInfos<LocomotorInfo>().ToArray();
 			foreach (var li in locomotorInfos)
 				foreach (var otherLocomotor in locomotorInfos)

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Lint
 			if (!worldOwnerFound)
 				emitError("Found no player owning the world.");
 
-			var worldActor = map.Rules.Actors["world"];
+			var worldActor = map.Rules.Actors[SystemActors.World];
 			var factions = worldActor.TraitInfos<FactionInfo>().Select(f => f.InternalName).ToHashSet();
 			foreach (var player in players.Values)
 				if (!string.IsNullOrWhiteSpace(player.Faction) && !factions.Contains(player.Faction))

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Lint
 
 		void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules, SequenceProvider sequences)
 		{
-			var factions = rules.Actors["world"].TraitInfos<FactionInfo>().Select(f => f.InternalName).ToArray();
+			var factions = rules.Actors[SystemActors.World].TraitInfos<FactionInfo>().Select(f => f.InternalName).ToArray();
 			foreach (var actorInfo in rules.Actors)
 			{
 				// Actors may have 0 or 1 RenderSprites traits

--- a/OpenRA.Mods.Common/Lint/CheckTraitLocation.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTraitLocation.cs
@@ -1,0 +1,43 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using DiscordRPC.Helper;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Lint
+{
+	public class CheckTraitLocation : ILintRulesPass
+	{
+		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		{
+			foreach (var actorInfo in rules.Actors)
+			{
+				foreach (var traitInfo in actorInfo.Value.TraitInfos<TraitInfo>())
+				{
+					var traitLocation = traitInfo.GetType().GetCustomAttributes<TraitLocationAttribute>(true).FirstOrDefault();
+					if (traitLocation == null)
+						continue;
+
+					if (!Enum.TryParse(actorInfo.Key, true, out SystemActors systemActor) || !traitLocation.SystemActors.HasFlag(systemActor))
+					{
+						// Remove the "Info" suffix
+						var traitName = traitInfo.GetType().Name;
+						traitName = traitName.Remove(traitName.Length - 4);
+						var locations = traitLocation.SystemActors.ToString().Replace(", ", " or ");
+						emitError("{0} does not belong on {1}. It is a system trait meant for {2}.".F(traitName, actorInfo.Key, locations));
+					}
+				}
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -357,7 +357,7 @@ namespace OpenRA.Mods.Common.Server
 				}
 
 				var botType = parts[2];
-				var botInfo = server.Map.Rules.Actors["player"].TraitInfos<IBotInfo>()
+				var botInfo = server.Map.Rules.Actors[SystemActors.Player].TraitInfos<IBotInfo>()
 					.FirstOrDefault(b => b.Type == botType);
 
 				if (botInfo == null)
@@ -440,7 +440,7 @@ namespace OpenRA.Mods.Common.Server
 						LoadMapSettings(server, server.LobbyInfo.GlobalSettings, server.Map.Rules);
 
 						// Reset client states
-						var selectableFactions = server.Map.Rules.Actors["world"].TraitInfos<FactionInfo>()
+						var selectableFactions = server.Map.Rules.Actors[SystemActors.World].TraitInfos<FactionInfo>()
 							.Where(f => f.Selectable)
 							.Select(f => f.InternalName)
 							.ToList();
@@ -457,7 +457,7 @@ namespace OpenRA.Mods.Common.Server
 						//  - Players who now lack a slot are made observers
 						//  - Bots who now lack a slot are dropped
 						//  - Bots who are not defined in the map rules are dropped
-						var botTypes = server.Map.Rules.Actors["player"].TraitInfos<IBotInfo>().Select(t => t.Type);
+						var botTypes = server.Map.Rules.Actors[SystemActors.Player].TraitInfos<IBotInfo>().Select(t => t.Type);
 						var slots = server.LobbyInfo.Slots.Keys.ToArray();
 						var i = 0;
 						foreach (var os in oldSlots)
@@ -534,8 +534,8 @@ namespace OpenRA.Mods.Common.Server
 					return true;
 				}
 
-				var allOptions = server.Map.Rules.Actors["player"].TraitInfos<ILobbyOptions>()
-					.Concat(server.Map.Rules.Actors["world"].TraitInfos<ILobbyOptions>())
+				var allOptions = server.Map.Rules.Actors[SystemActors.Player].TraitInfos<ILobbyOptions>()
+					.Concat(server.Map.Rules.Actors[SystemActors.World].TraitInfos<ILobbyOptions>())
 					.SelectMany(t => t.LobbyOptions(server.Map.Rules));
 
 				// Overwrite keys with duplicate ids
@@ -782,7 +782,7 @@ namespace OpenRA.Mods.Common.Server
 				if (server.LobbyInfo.Slots[targetClient.Slot].LockFaction)
 					return true;
 
-				var factions = server.Map.Rules.Actors["world"].TraitInfos<FactionInfo>()
+				var factions = server.Map.Rules.Actors[SystemActors.World].TraitInfos<FactionInfo>()
 					.Where(f => f.Selectable).Select(f => f.InternalName);
 
 				if (!factions.Contains(parts[1]))
@@ -1052,8 +1052,8 @@ namespace OpenRA.Mods.Common.Server
 		{
 			lock (server.LobbyInfo)
 			{
-				var options = rules.Actors["player"].TraitInfos<ILobbyOptions>()
-					.Concat(rules.Actors["world"].TraitInfos<ILobbyOptions>())
+				var options = rules.Actors[SystemActors.Player].TraitInfos<ILobbyOptions>()
+					.Concat(rules.Actors[SystemActors.World].TraitInfos<ILobbyOptions>())
 					.SelectMany(t => t.LobbyOptions(rules));
 
 				foreach (var o in options)
@@ -1114,7 +1114,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static string MissionBriefingOrDefault(S server)
 		{
-			var missionData = server.Map.Rules.Actors["world"].TraitInfoOrDefault<MissionDataInfo>();
+			var missionData = server.Map.Rules.Actors[SystemActors.World].TraitInfoOrDefault<MissionDataInfo>();
 			if (missionData != null && !string.IsNullOrEmpty(missionData.Briefing))
 				return missionData.Briefing.Replace("\\n", "\n");
 

--- a/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
@@ -25,8 +25,8 @@ namespace OpenRA.Mods.Common.Server
 				var defaults = new Session.Global();
 				LobbyCommands.LoadMapSettings(server, defaults, server.Map.Rules);
 
-				var options = server.Map.Rules.Actors["player"].TraitInfos<ILobbyOptions>()
-					.Concat(server.Map.Rules.Actors["world"].TraitInfos<ILobbyOptions>())
+				var options = server.Map.Rules.Actors[SystemActors.Player].TraitInfos<ILobbyOptions>()
+					.Concat(server.Map.Rules.Actors[SystemActors.World].TraitInfos<ILobbyOptions>())
 					.SelectMany(t => t.LobbyOptions(server.Map.Rules))
 					.ToDictionary(o => o.Id, o => o);
 

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
-			if (!rules.Actors["world"].HasTraitInfo<ITiledTerrainRendererInfo>())
+			if (!rules.Actors[SystemActors.World].HasTraitInfo<ITiledTerrainRendererInfo>())
 				throw new YamlException("Bridge requires a tile-based terrain renderer.");
 
 			if (string.IsNullOrEmpty(DemolishWeapon))

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
@@ -14,6 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("A dictionary of buildings placed on the map. Attach this to the world actor.")]
 	public class BuildingInfluenceInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
-			var locomotorInfos = rules.Actors["world"].TraitInfos<LocomotorInfo>();
+			var locomotorInfos = rules.Actors[SystemActors.World].TraitInfos<LocomotorInfo>();
 			LocomotorInfo = locomotorInfos.FirstOrDefault(li => li.Name == Locomotor);
 			if (LocomotorInfo == null)
 				throw new YamlException("A locomotor named '{0}' doesn't exist.".F(Locomotor));

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
-			var locomotorInfos = rules.Actors["world"].TraitInfos<LocomotorInfo>();
+			var locomotorInfos = rules.Actors[SystemActors.World].TraitInfos<LocomotorInfo>();
 			LocomotorInfo = locomotorInfos.FirstOrDefault(li => li.Name == Locomotor);
 			if (LocomotorInfo == null)
 				throw new YamlException("A locomotor named '{0}' doesn't exist.".F(Locomotor));

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 			var map = init.World.Map;
 
 			// Explore map-placed actors if the "Explore Map" option is enabled
-			var shroudInfo = init.World.Map.Rules.Actors["player"].TraitInfo<ShroudInfo>();
+			var shroudInfo = init.World.Map.Rules.Actors[SystemActors.Player].TraitInfo<ShroudInfo>();
 			var exploredMap = init.World.LobbyInfo.GlobalSettings.OptionOrDefault("explored", shroudInfo.ExploredMapCheckboxEnabled);
 			startsRevealed = exploredMap && init.Contains<SpawnedByMapInit>() && !init.Contains<HiddenUnderFogInit>();
 			var buildingInfo = init.Self.Info.TraitInfoOrDefault<BuildingInfo>();

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/FlashPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/FlashPaletteEffect.cs
@@ -18,6 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	using GUtil = OpenRA.Graphics.Util;
 
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Used for bursted one-colored whole screen effects. Add this to the world actor.")]
 	public class FlashPaletteEffectInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/MenuPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/MenuPaletteEffect.cs
@@ -17,6 +17,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Fades the world from/to black at the start/end of the game, and can (optionally) desaturate the world")]
 	public class MenuPaletteEffectInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/RotationPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/RotationPaletteEffect.cs
@@ -15,6 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Palette effect used for sprinkle \"animations\".")]
 	class RotationPaletteEffectInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/Player/AllyRepair.cs
+++ b/OpenRA.Mods.Common/Traits/Player/AllyRepair.cs
@@ -13,6 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.Player)]
 	[Desc("Attach this to the player actor to allow building repair by team mates.")]
 	class AllyRepairInfo : TraitInfo<AllyRepair> { }
 

--- a/OpenRA.Mods.Common/Traits/Player/BaseAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/BaseAttackNotifier.cs
@@ -14,6 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.Player)]
 	[Desc("Plays an audio notification and shows a radar ping when a building is attacked.",
 		"Attach this to the player actor.")]
 	public class BaseAttackNotifierInfo : TraitInfo

--- a/OpenRA.Mods.Common/Traits/Player/ClassicParallelProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicParallelProductionQueue.cs
@@ -21,6 +21,7 @@ namespace OpenRA.Mods.Common.Traits
 		"Will only work together with the Production: trait on the actor that actually does the production.",
 		"You will also want to add PrimaryBuildings: to let the user choose where new units should exit.",
 		"The production speed depends on the number of production buildings and units queued at the same time.")]
+	[TraitLocation(SystemActors.Player)]
 	public class ClassicParallelProductionQueueInfo : ProductionQueueInfo, Requires<TechTreeInfo>, Requires<PlayerResourcesInfo>
 	{
 		[Desc("If you build more actors of the same type,", "the same queue will get its build time lowered for every actor produced there.")]

--- a/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.Player)]
 	[Desc("Attach this to the player actor (not a building!) to define a new shared build queue.",
 		"Will only work together with the Production: trait on the actor that actually does the production.",
 		"You will also want to add PrimaryBuildings: to let the user choose where new units should exit.")]

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -11,11 +11,11 @@
 
 using System.Linq;
 using OpenRA.Network;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.Player)]
 	public class ConquestVictoryConditionsInfo : TraitInfo, Requires<MissionObjectivesInfo>
 	{
 		[Desc("Delay for the end game notification in milliseconds.")]

--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.Player)]
 	[Desc("Attach this to the player actor.")]
 	public class DeveloperModeInfo : TraitInfo, ILobbyOptions
 	{

--- a/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
+++ b/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
@@ -15,6 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.Player)]
 	[Desc("Tracks neutral and enemy actors' visibility and notifies the player.",
 		"Attach this to the player actor. The actors to track need the 'AnnounceOnSeen' trait.")]
 	class EnemyWatcherInfo : TraitInfo

--- a/OpenRA.Mods.Common/Traits/Player/GrantConditionOnPrerequisiteManager.cs
+++ b/OpenRA.Mods.Common/Traits/Player/GrantConditionOnPrerequisiteManager.cs
@@ -11,11 +11,11 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.Player)]
 	[Desc("Attach this to the player actor.")]
 	public class GrantConditionOnPrerequisiteManagerInfo : TraitInfo, Requires<TechTreeInfo>
 	{

--- a/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
@@ -16,6 +16,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Plays an audio notification and shows a radar ping when a harvester is attacked.",
 		"Attach this to the player actor.")]
+	[TraitLocation(SystemActors.Player)]
 	public class HarvesterAttackNotifierInfo : TraitInfo
 	{
 		[Desc("Minimum duration (in seconds) between notification events.")]

--- a/OpenRA.Mods.Common/Traits/Player/MissionObjectives.cs
+++ b/OpenRA.Mods.Common/Traits/Player/MissionObjectives.cs
@@ -35,6 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
+	[TraitLocation(SystemActors.Player)]
 	public class MissionObjectivesInfo : TraitInfo
 	{
 		[Desc("Set this to true if multiple cooperative players have a distinct set of " +
@@ -258,6 +259,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
+	[TraitLocation(SystemActors.World)]
 	[Desc("Provides game mode progress information for players.",
 		"Goes on WorldActor - observers don't have a player it can live on.",
 		"Current options for PanelName are 'SKIRMISH_STATS' and 'MISSION_OBJECTIVES'.")]
@@ -271,6 +273,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new ObjectivesPanel(this); }
 	}
 
+	[TraitLocation(SystemActors.World)]
 	public class ObjectivesPanel : IObjectivesPanel
 	{
 		readonly ObjectivesPanelInfo info;

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
@@ -14,6 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.Player)]
 	[Desc("A beacon that is constructed from a circle sprite that is animated once and a moving arrow sprite.")]
 	public class PlaceBeaconInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -18,6 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 	// Allows third party mods to detect whether an actor was created by PlaceBuilding.
 	public class PlaceBuildingInit : RuntimeFlagInit { }
 
+	[TraitLocation(SystemActors.Player)]
 	[Desc("Allows the player to execute build orders.", " Attach this to the player actor.")]
 	public class PlaceBuildingInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/Player/PlayerExperience.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerExperience.cs
@@ -13,6 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.Player)]
 	[Desc("This trait can be used to track player experience based on units killed with the `GivesExperience` trait.",
 		"It can also be used as a point score system in scripted maps, for example.",
 		"Attach this to the player actor.")]

--- a/OpenRA.Mods.Common/Traits/Player/PlayerRadarTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerRadarTerrain.cs
@@ -11,11 +11,11 @@
 
 using System;
 using OpenRA.Graphics;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.Player)]
 	public class PlayerRadarTerrainInfo : TraitInfo, Requires<ShroudInfo>
 	{
 		public override object Create(ActorInitializer init)

--- a/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.Player | SystemActors.EditorPlayer)]
 	public class PlayerResourcesInfo : TraitInfo, ILobbyOptions
 	{
 		[Desc("Descriptive label for the starting cash option in the lobby.")]

--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -18,6 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.Player)]
 	[Desc("Attach this to the player actor to collect observer stats.")]
 	public class PlayerStatisticsInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
@@ -14,6 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.Player)]
 	public class ProvidesTechPrerequisiteInfo : TraitInfo, ITechTreePrerequisiteInfo
 	{
 		[Desc("Internal id for this tech level.")]

--- a/OpenRA.Mods.Common/Traits/Player/ResourceStorageWarning.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ResourceStorageWarning.cs
@@ -13,6 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.Player)]
 	[Desc("Provides the player with an audible warning when their storage is nearing full.")]
 	public class ResourceStorageWarningInfo : TraitInfo, Requires<PlayerResourcesInfo>
 	{

--- a/OpenRA.Mods.Common/Traits/Player/TechTree.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TechTree.cs
@@ -17,6 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.Player)]
 	[Desc("Manages build limits and pre-requisites.", " Attach this to the player actor.")]
 	public class TechTreeInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/Player/TimeLimitManager.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TimeLimitManager.cs
@@ -17,6 +17,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("This trait allows setting a time limit on matches. Attach this to the World actor.")]
 	public class TimeLimitManagerInfo : TraitInfo, ILobbyOptions, IRulesetLoaded
 	{

--- a/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
@@ -15,6 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.Player)]
 	[Desc("Attach this to the player actor.")]
 	public class PowerManagerInfo : TraitInfo, Requires<DeveloperModeInfo>
 	{

--- a/OpenRA.Mods.Common/Traits/ProductionQueueFromSelection.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionQueueFromSelection.cs
@@ -17,6 +17,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	class ProductionQueueFromSelectionInfo : TraitInfo
 	{
 		public string ProductionTabsWidget = null;

--- a/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void RulesetLoaded(Ruleset rules, ActorInfo info)
 		{
-			var pci = rules.Actors["player"].TraitInfoOrDefault<ProximityCaptorInfo>();
+			var pci = rules.Actors[SystemActors.Player].TraitInfoOrDefault<ProximityCaptorInfo>();
 			if (pci == null)
 				throw new YamlException("ProximityCapturable requires the `Player` actor to have the ProximityCaptor trait.");
 		}

--- a/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
@@ -17,6 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("Displays custom terrain types.")]
 	class CustomTerrainDebugOverlayInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/Render/ProductionBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/ProductionBar.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			// No queues available - check for classic production queues
 			if (queue == null)
-				queue = rules.Actors["player"].TraitInfos<ProductionQueueInfo>().FirstOrDefault(q => ProductionType == q.Type);
+				queue = rules.Actors[SystemActors.Player].TraitInfos<ProductionQueueInfo>().FirstOrDefault(q => ProductionType == q.Type);
 
 			if (queue == null)
 				throw new YamlException("Can't find a queue with ProductionType '{0}'".F(ProductionType));

--- a/OpenRA.Mods.Common/Traits/Render/VeteranProductionIconOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/VeteranProductionIconOverlay.cs
@@ -15,6 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
 {
+	[TraitLocation(SystemActors.Player)]
 	[Desc("Attach this to the player actor. When attached, enables all actors possessing the ProducibleWithLevel ",
 		"trait to have their production queue icons render with an overlay defined in this trait. ",
 		"The icon change occurs when ProducibleWithLevel.Prerequisites are met.")]

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -18,6 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.Player)]
 	[Desc("Attach this to the player actor.")]
 	public class SupportPowerManagerInfo : TraitInfo, Requires<DeveloperModeInfo>, Requires<TechTreeInfo>
 	{

--- a/OpenRA.Mods.Common/Traits/TerrainLightSource.cs
+++ b/OpenRA.Mods.Common/Traits/TerrainLightSource.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
-			if (!rules.Actors["world"].HasTraitInfo<TerrainLightingInfo>())
+			if (!rules.Actors[SystemActors.World].HasTraitInfo<TerrainLightingInfo>())
 				throw new YamlException("TerrainLightSource can only be used with the world TerrainLighting trait.");
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -18,6 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	public class ActorMapInfo : TraitInfo
 	{
 		[Desc("Size of partition bins (cells)")]

--- a/OpenRA.Mods.Common/Traits/World/ActorSpawnManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorSpawnManager.cs
@@ -18,6 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Controls the spawning of specified actor types. Attach this to the world actor.")]
+	[TraitLocation(SystemActors.World)]
 	public class ActorSpawnManagerInfo : ConditionalTraitInfo, Requires<MapCreepsInfo>
 	{
 		[Desc("Minimum number of actors.")]

--- a/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
@@ -18,6 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	public class CrateSpawnerInfo : TraitInfo, ILobbyOptions
 	{
 		[Desc("Descriptive label for the crates checkbox in the lobby.")]

--- a/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs
+++ b/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs
@@ -18,6 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("Attach this to the world actor.")]
 	public class CreateMapPlayersInfo : TraitInfo<CreateMapPlayers>, ICreatePlayersInfo
 	{
@@ -27,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		/// </summary>
 		void ICreatePlayersInfo.CreateServerPlayers(MapPreview map, Session lobbyInfo, List<GameInformation.Player> players, MersenneTwister playerRandom)
 		{
-			var worldInfo = map.Rules.Actors["world"];
+			var worldInfo = map.Rules.Actors[SystemActors.World];
 			var factions = worldInfo.TraitInfos<FactionInfo>().ToArray();
 			var assignSpawnLocations = worldInfo.TraitInfoOrDefault<IAssignSpawnPointsInfo>();
 			var spawnState = assignSpawnLocations?.InitializeState(map, lobbyInfo);
@@ -41,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// Create the regular playable players.
-			var bots = map.Rules.Actors["player"].TraitInfos<IBotInfo>().ToArray();
+			var bots = map.Rules.Actors[SystemActors.Player].TraitInfos<IBotInfo>().ToArray();
 
 			foreach (var kv in lobbyInfo.Slots)
 			{

--- a/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
+++ b/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
@@ -17,6 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("Identify untraversable regions of the map for faster pathfinding, especially with AI.",
 		"This trait is required. Every mod needs it attached to the world actor.")]
 	class DomainIndexInfo : TraitInfo<DomainIndex> { }

--- a/OpenRA.Mods.Common/Traits/World/EditorActionManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActionManager.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.EditorWorld)]
 	public class EditorActionManagerInfo : TraitInfo<EditorActionManager> { }
 
 	public class EditorActionManager : IWorldLoaded

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -21,6 +21,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.EditorWorld)]
 	[Desc("Required for the map editor to work. Attach this to the world actor.")]
 	public class EditorActorLayerInfo : TraitInfo, ICreatePlayersInfo
 	{

--- a/OpenRA.Mods.Common/Traits/World/EditorCursorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorCursorLayer.cs
@@ -19,6 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public enum EditorCursorType { None, Actor, TerrainTemplate, Resource }
 
+	[TraitLocation(SystemActors.EditorWorld)]
 	[Desc("Required for the map editor to work. Attach this to the world actor.")]
 	public class EditorCursorLayerInfo : TraitInfo, Requires<EditorActorLayerInfo>, Requires<ITiledTerrainRendererInfo>
 	{

--- a/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
@@ -18,6 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.EditorWorld)]
 	[Desc("Required for the map editor to work. Attach this to the world actor.")]
 	public class EditorResourceLayerInfo : TraitInfo, IResourceLayerInfo, IMapPreviewSignatureInfo
 	{
@@ -94,7 +95,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (w.Type != WorldType.Editor)
 				return;
 
-			var playerResourcesInfo = w.Map.Rules.Actors["player"].TraitInfoOrDefault<PlayerResourcesInfo>();
+			var playerResourcesInfo = w.Map.Rules.Actors[SystemActors.Player].TraitInfoOrDefault<PlayerResourcesInfo>();
 			resourceValues = playerResourcesInfo?.ResourceValues ?? new Dictionary<string, int>();
 
 			foreach (var cell in Map.AllCells)

--- a/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
@@ -15,6 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.EditorWorld)]
 	[Desc("Required for the map editor to work. Attach this to the world actor.")]
 	public class EditorSelectionLayerInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/World/GameSaveViewportManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/GameSaveViewportManager.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.Player)]
 	public class GameSaveViewportManagerInfo : TraitInfo
 	{
 		public override object Create(ActorInitializer init) { return new GameSaveViewportManager(); }

--- a/OpenRA.Mods.Common/Traits/World/IndexedPalette.cs
+++ b/OpenRA.Mods.Common/Traits/World/IndexedPalette.cs
@@ -17,6 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Define a palette by swapping palette indices.")]
 	public class IndexedPaletteInfo : TraitInfo, IRulesetLoaded
 	{

--- a/OpenRA.Mods.Common/Traits/World/LegacyBridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/LegacyBridgeLayer.cs
@@ -19,6 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	class LegacyBridgeLayerInfo : TraitInfo
 	{
 		[ActorReference]

--- a/OpenRA.Mods.Common/Traits/World/LoadWidgetAtGameStart.cs
+++ b/OpenRA.Mods.Common/Traits/World/LoadWidgetAtGameStart.cs
@@ -16,6 +16,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	public class LoadWidgetAtGameStartInfo : TraitInfo
 	{
 		[Desc("The widget tree to open when a shellmap is loaded (i.e. the main menu).")]

--- a/OpenRA.Mods.Common/Traits/World/LobbyPrerequisiteCheckbox.cs
+++ b/OpenRA.Mods.Common/Traits/World/LobbyPrerequisiteCheckbox.cs
@@ -14,6 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.Player)]
 	[Desc("Enables defined prerequisites at game start for all players if the checkbox is enabled.")]
 	public class LobbyPrerequisiteCheckboxInfo : TraitInfo, ILobbyOptions, ITechTreePrerequisiteInfo
 	{

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -54,6 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 		public const byte ElevatedBridge = 4;
 	}
 
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Used by Mobile. Attach these to the world actor. You can have multiple variants by adding @suffixes.")]
 	public class LocomotorInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/World/MapBuildRadius.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapBuildRadius.cs
@@ -14,6 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("Controls the build radius checkboxes in the lobby options.")]
 	public class MapBuildRadiusInfo : TraitInfo, ILobbyOptions
 	{

--- a/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
@@ -15,6 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Controls the 'Creeps' checkbox in the lobby options.")]
+	[TraitLocation(SystemActors.World)]
 	public class MapCreepsInfo : TraitInfo, ILobbyOptions
 	{
 		[Desc("Descriptive label for the creeps checkbox in the lobby.")]

--- a/OpenRA.Mods.Common/Traits/World/MapOptions.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapOptions.cs
@@ -15,6 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("Controls the game speed, tech level, and short game lobby options.")]
 	public class MapOptionsInfo : TraitInfo, ILobbyOptions, IRulesetLoaded
 	{
@@ -77,7 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 			yield return new LobbyBooleanOption("shortgame", ShortGameCheckboxLabel, ShortGameCheckboxDescription,
 				ShortGameCheckboxVisible, ShortGameCheckboxDisplayOrder, ShortGameCheckboxEnabled, ShortGameCheckboxLocked);
 
-			var techLevels = rules.Actors["player"].TraitInfos<ProvidesTechPrerequisiteInfo>()
+			var techLevels = rules.Actors[SystemActors.Player].TraitInfos<ProvidesTechPrerequisiteInfo>()
 				.ToDictionary(t => t.Id, t => t.Name);
 
 			if (techLevels.Any())

--- a/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
@@ -19,6 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("Allows the map to have working spawnpoints. Also controls the 'Separate Team Spawns' checkbox in the lobby options.")]
 	public class MapStartingLocationsInfo : TraitInfo, ILobbyOptions, IAssignSpawnPointsInfo
 	{

--- a/OpenRA.Mods.Common/Traits/World/MapStartingUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapStartingUnits.cs
@@ -14,6 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("Used by SpawnStartingUnits. Attach these to the world actor. You can have multiple variants by adding @suffixes.")]
 	public class StartingUnitsInfo : TraitInfo<StartingUnits>
 	{

--- a/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
+++ b/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
@@ -17,6 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Trait for music handling. Attach this to the world actor.")]
 	public class MusicPlaylistInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromFile.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromFile.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Load VGA palette (.pal) registers.")]
 	class PaletteFromFileInfo : TraitInfo, IProvidesCursorPaletteInfo
 	{

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromGimpOrJascFile.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromGimpOrJascFile.cs
@@ -19,6 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Load a GIMP .gpl or JASC .pal palette file. Supports per-color alpha.")]
 	class PaletteFromGimpOrJascFileInfo : TraitInfo, IProvidesCursorPaletteInfo
 	{

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromPaletteWithAlpha.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromPaletteWithAlpha.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Create a palette by applying alpha transparency to another palette.")]
 	class PaletteFromPaletteWithAlphaInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromPlayerPaletteWithAlpha.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromPlayerPaletteWithAlpha.cs
@@ -15,6 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Create player palettes by applying alpha transparency to another player palette.")]
 	class PaletteFromPlayerPaletteWithAlphaInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromPng.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromPng.cs
@@ -18,6 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Load a PNG and use its embedded palette.")]
 	class PaletteFromPngInfo : TraitInfo, IProvidesCursorPaletteInfo
 	{

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromRGBA.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromRGBA.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Creates a single color palette without any base palette file.")]
 	class PaletteFromRGBAInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("Calculates routes for mobile units based on the A* search algorithm.", " Attach this to the world actor.")]
 	public class PathFinderInfo : TraitInfo, Requires<LocomotorInfo>
 	{

--- a/OpenRA.Mods.Common/Traits/World/RadarPings.cs
+++ b/OpenRA.Mods.Common/Traits/World/RadarPings.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	public class RadarPingsInfo : TraitInfo
 	{
 		public readonly int FromRadius = 200;

--- a/OpenRA.Mods.Common/Traits/World/ResourceClaimLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceClaimLayer.cs
@@ -15,6 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("Allows harvesters to coordinate their operations. Attach this to the world actor.")]
 	public sealed class ResourceClaimLayerInfo : TraitInfo<ResourceClaimLayer> { }
 

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -31,6 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
+	[TraitLocation(SystemActors.World)]
 	[Desc("Attach this to the world actor.")]
 	public class ResourceLayerInfo : TraitInfo, IResourceLayerInfo, Requires<BuildingInfluenceInfo>, IMapPreviewSignatureInfo
 	{

--- a/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
@@ -18,6 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Visualizes the state of the `ResourceLayer`.", " Attach this to the world actor.")]
 	public class ResourceRendererInfo : TraitInfo, Requires<IResourceLayerInfo>
 	{

--- a/OpenRA.Mods.Common/Traits/World/Selection.cs
+++ b/OpenRA.Mods.Common/Traits/World/Selection.cs
@@ -22,6 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Selection(this); }
 	}
 
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	public class Selection : ISelection, INotifyCreated, INotifyOwnerChanged, ITick, IGameSaveTraitData
 	{
 		public int Hash { get; private set; }

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -19,6 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	public class ShroudRendererInfo : TraitInfo
 	{
 		public readonly string Sequence = "shroud";

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -25,6 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public int Depth;
 	}
 
+	[TraitLocation(SystemActors.World)]
 	[Desc("Attach this to the world actor.", "Order of the layers defines the Z sorting.")]
 	public class SmudgeLayerInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("Spawns the initial units for each player upon game start.")]
 	public class SpawnMapActorsInfo : TraitInfo<SpawnMapActors> { }
 

--- a/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
@@ -18,6 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("Spawn base actor at the spawnpoint and support units in an annulus around the base actor. Both are defined at MPStartUnits. Attach this to the world actor.")]
 	public class SpawnStartingUnitsInfo : TraitInfo, Requires<StartingUnitsInfo>, ILobbyOptions
 	{
@@ -43,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 			var startingUnits = new Dictionary<string, string>();
 
 			// Duplicate classes are defined for different race variants
-			foreach (var t in rules.Actors["world"].TraitInfos<StartingUnitsInfo>())
+			foreach (var t in rules.Actors[SystemActors.World].TraitInfos<StartingUnitsInfo>())
 				startingUnits[t.Class] = t.ClassName;
 
 			if (startingUnits.Any())
@@ -75,7 +76,7 @@ namespace OpenRA.Mods.Common.Traits
 			var spawnClass = p.PlayerReference.StartingUnitsClass ?? w.LobbyInfo.GlobalSettings
 				.OptionOrDefault("startingunits", info.StartingUnitsClass);
 
-			var unitGroup = w.Map.Rules.Actors["world"].TraitInfos<StartingUnitsInfo>()
+			var unitGroup = w.Map.Rules.Actors[SystemActors.World].TraitInfos<StartingUnitsInfo>()
 				.Where(g => g.Class == spawnClass && g.Factions != null && g.Factions.Contains(p.Faction.InternalName))
 				.RandomOrDefault(w.SharedRandom);
 

--- a/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
+++ b/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
@@ -14,6 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	class StartGameNotificationInfo : TraitInfo
 	{
 		[NotificationReference("Speech")]

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -18,6 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Renders a debug overlay showing the terrain cells. Attach this to the world actor.")]
 	public class TerrainGeometryOverlayInfo : TraitInfo<TerrainGeometryOverlay> { }
 

--- a/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
@@ -19,6 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	public class TerrainRendererInfo : TraitInfo, ITiledTerrainRendererInfo
 	{
 		bool ITiledTerrainRendererInfo.ValidateTileSprites(ITemplatedTerrainInfo terrainInfo, Action<string> onError)

--- a/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs
+++ b/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs
@@ -14,6 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("Used to detect exploits. Attach this to the world actor.")]
 	public class ValidateOrderInfo : TraitInfo<ValidateOrder> { }
 

--- a/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
@@ -17,6 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[TraitLocation(SystemActors.World)]
 	[Desc("Part of the combat overlay from DeveloperMode. Attach this to the world actor.")]
 	public class WarheadDebugOverlayInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Common/UtilityCommands/CheckMissingSprites.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckMissingSprites.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						var terrainInfo = modData.DefaultTerrainInfo[kv.Key];
 
 						if (terrainInfo is ITemplatedTerrainInfo templatedTerrainInfo)
-							foreach (var r in modData.DefaultRules.Actors["world"].TraitInfos<ITiledTerrainRendererInfo>())
+							foreach (var r in modData.DefaultRules.Actors[SystemActors.World].TraitInfos<ITiledTerrainRendererInfo>())
 								failed |= r.ValidateTileSprites(templatedTerrainInfo, Console.WriteLine);
 
 						foreach (var image in kv.Value.Images)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoBriefingLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoBriefingLogic.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var mapDescription = widget.Get<LabelWidget>("MAP_DESCRIPTION");
 			var mapFont = Game.Renderer.Fonts[mapDescription.Font];
 
-			var missionData = world.Map.Rules.Actors["world"].TraitInfoOrDefault<MissionDataInfo>();
+			var missionData = world.Map.Rules.Actors[SystemActors.World].TraitInfoOrDefault<MissionDataInfo>();
 			if (missionData != null)
 			{
 				var text = WidgetUtils.WrapText(missionData.Briefing.Replace("\\n", "\n"), mapDescription.Bounds.Width, mapFont);

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			// Can't use DeveloperMode.Enabled because there is a hardcoded hack to *always*
 			// enable developer mode for singleplayer games, but we only want to show the button
 			// if it has been explicitly enabled
-			var def = world.Map.Rules.Actors["player"].TraitInfo<DeveloperModeInfo>().CheckboxEnabled;
+			var def = world.Map.Rules.Actors[SystemActors.Player].TraitInfo<DeveloperModeInfo>().CheckboxEnabled;
 			var developerEnabled = world.LobbyInfo.GlobalSettings.OptionOrDefault("cheats", def);
 			if (lp != null && developerEnabled)
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -116,7 +116,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			// TODO: Create a mechanism to do things like this cleaner. Also needed for scripted missions
 			if (world.Type == WorldType.Regular)
 			{
-				var moi = world.Map.Rules.Actors["player"].TraitInfoOrDefault<MissionObjectivesInfo>();
+				var moi = world.Map.Rules.Actors[SystemActors.Player].TraitInfoOrDefault<MissionObjectivesInfo>();
 				if (moi != null)
 				{
 					var faction = world.LocalPlayer?.Faction.InternalName;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				// Can't use DeveloperMode.Enabled because there is a hardcoded hack to *always*
 				// enable developer mode for singleplayer games, but we only want to show the button
 				// if it has been explicitly enabled
-				var def = world.Map.Rules.Actors["player"].TraitInfo<DeveloperModeInfo>().CheckboxEnabled;
+				var def = world.Map.Rules.Actors[SystemActors.Player].TraitInfo<DeveloperModeInfo>().CheckboxEnabled;
 				var enabled = world.LobbyInfo.GlobalSettings.OptionOrDefault("cheats", def);
 				debug.IsVisible = () => enabled;
 				debug.IsDisabled = () => disableSystemButtons;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			colorPreview = lobby.Get<ColorPreviewManagerWidget>("COLOR_MANAGER");
 			colorPreview.Color = Game.Settings.Player.Color;
 
-			foreach (var f in modRules.Actors["world"].TraitInfos<FactionInfo>())
+			foreach (var f in modRules.Actors[SystemActors.World].TraitInfos<FactionInfo>())
 				factions.Add(f.InternalName, new LobbyFaction { Selectable = f.Selectable, Name = f.Name, Side = f.Side, Description = f.Description });
 
 			var gameStarting = false;
@@ -207,7 +207,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				slotsButton.OnMouseDown = _ =>
 				{
-					var botTypes = map.Rules.Actors["player"].TraitInfos<IBotInfo>().Select(t => t.Type);
+					var botTypes = map.Rules.Actors[SystemActors.Player].TraitInfos<IBotInfo>().Select(t => t.Type);
 					var options = new Dictionary<string, IEnumerable<DropDownOption>>();
 
 					var botController = orderManager.LobbyInfo.Clients.FirstOrDefault(c => c.IsAdmin);
@@ -539,7 +539,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						if (addBotOnMapLoad)
 						{
 							var slot = orderManager.LobbyInfo.FirstEmptyBotSlot();
-							var bot = currentMap.Rules.Actors["player"].TraitInfos<IBotInfo>().Select(t => t.Type).FirstOrDefault();
+							var bot = currentMap.Rules.Actors[SystemActors.Player].TraitInfos<IBotInfo>().Select(t => t.Type).FirstOrDefault();
 							var botController = orderManager.LobbyInfo.Clients.FirstOrDefault(c => c.IsAdmin);
 							if (slot != null && bot != null)
 								orderManager.IssueOrder(Order.Command("slot_bot {0} {1} {2}".F(slot, botController.Index, bot)));

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
@@ -78,8 +78,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			optionsContainer.RemoveChildren();
 			optionsContainer.Bounds.Height = 0;
-			var allOptions = mapPreview.Rules.Actors["player"].TraitInfos<ILobbyOptions>()
-					.Concat(mapPreview.Rules.Actors["world"].TraitInfos<ILobbyOptions>())
+			var allOptions = mapPreview.Rules.Actors[SystemActors.Player].TraitInfos<ILobbyOptions>()
+					.Concat(mapPreview.Rules.Actors[SystemActors.World].TraitInfos<ILobbyOptions>())
 					.SelectMany(t => t.LobbyOptions(mapPreview.Rules))
 					.Where(o => o.IsVisible)
 					.OrderBy(o => o.DisplayOrder)

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var bots = new List<SlotDropDownOption>();
 			if (slot.AllowBots)
 			{
-				foreach (var b in map.Rules.Actors["player"].TraitInfos<IBotInfo>())
+				foreach (var b in map.Rules.Actors[SystemActors.Player].TraitInfos<IBotInfo>())
 				{
 					var botController = orderManager.LobbyInfo.Clients.FirstOrDefault(c => c.IsAdmin);
 					bots.Add(new SlotDropDownOption(b.Name,

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -219,7 +219,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			new Thread(() =>
 			{
-				var mapDifficulty = preview.Rules.Actors["world"].TraitInfos<ScriptLobbyDropdownInfo>()
+				var mapDifficulty = preview.Rules.Actors[SystemActors.World].TraitInfos<ScriptLobbyDropdownInfo>()
 					.FirstOrDefault(sld => sld.ID == "difficulty");
 
 				if (mapDifficulty != null)
@@ -229,7 +229,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					difficultyDisabled = mapDifficulty.Locked;
 				}
 
-				var missionData = preview.Rules.Actors["world"].TraitInfoOrDefault<MissionDataInfo>();
+				var missionData = preview.Rules.Actors[SystemActors.World].TraitInfoOrDefault<MissionDataInfo>();
 				if (missionData != null)
 				{
 					briefingVideo = missionData.BriefingVideo;
@@ -383,7 +383,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			orders.Add(Order.Command("option gamespeed {0}".F(gameSpeed)));
 			orders.Add(Order.Command("state {0}".F(Session.ClientState.Ready)));
 
-			var missionData = selectedMap.Rules.Actors["world"].TraitInfoOrDefault<MissionDataInfo>();
+			var missionData = selectedMap.Rules.Actors[SystemActors.World].TraitInfoOrDefault<MissionDataInfo>();
 			if (missionData != null && missionData.StartVideo != null && modData.DefaultFileSystem.Exists(missionData.StartVideo))
 			{
 				var fsPlayer = fullscreenVideoPlayer.Get<VideoPlayerWidget>("PLAYER");

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -671,7 +671,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 						var flag = item.Get<ImageWidget>("FLAG");
 						flag.GetImageCollection = () => "flags";
-						var factionInfo = modData.DefaultRules.Actors["world"].TraitInfos<FactionInfo>();
+						var factionInfo = modData.DefaultRules.Actors[SystemActors.World].TraitInfos<FactionInfo>();
 						flag.GetImageName = () => (factionInfo != null && factionInfo.Any(f => f.InternalName == o.FactionId)) ? o.FactionId : "Random";
 
 						playerList.AddChild(item);

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -473,7 +473,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (server.Clients.Any(c => c.IsSpectator))
 				teams.Add("Spectators", server.Clients.Where(c => c.IsSpectator));
 
-			var factionInfo = modData.DefaultRules.Actors["world"].TraitInfos<FactionInfo>();
+			var factionInfo = modData.DefaultRules.Actors[SystemActors.World].TraitInfos<FactionInfo>();
 			foreach (var kv in teams)
 			{
 				var group = kv.Key;

--- a/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
@@ -18,6 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.D2k.Traits
 {
 	[Desc("Attach this to the world actor. Required for LaysTerrain to work.")]
+	[TraitLocation(SystemActors.World)]
 	public class BuildableTerrainLayerInfo : TraitInfo, Requires<ITiledTerrainRendererInfo>
 	{
 		[Desc("Palette to render the layer sprites in.")]

--- a/OpenRA.Mods.D2k/Traits/World/D2kResourceRenderer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/D2kResourceRenderer.cs
@@ -14,10 +14,12 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits
 {
 	[Desc("Used to render spice with round borders.", "Attach this to the world actor")]
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	public class D2kResourceRendererInfo : ResourceRendererInfo
 	{
 		public override object Create(ActorInitializer init) { return new D2kResourceRenderer(init.Self, this); }


### PR DESCRIPTION
Traits that belong on `Player`, `EditorPlayer`, `World` and `EditorWorld` can be placed freely which causes crashes or subtle errors that are hard to debug, but easy to check statically with the utility.