### PR TITLE
Refactor WithDamageOverlay - part 1

### DIFF
--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -27,6 +27,7 @@ namespace OpenRA.Graphics
 		readonly Func<bool> paused;
 
 		int frame;
+		int playedCount;
 		bool backwards;
 		bool tickAlways;
 		int timeUntilNextFrame;
@@ -145,6 +146,30 @@ namespace OpenRA.Graphics
 			timeUntilNextFrame = Math.Min(CurrentSequenceTickOrDefault(), timeUntilNextFrame);
 			frame %= CurrentSequence.Length;
 			return true;
+		}
+
+		public void PlayNTimesThen(string sequenceName, int times, Action after)
+		{
+			backwards = false;
+			tickAlways = false;
+			PlaySequence(sequenceName);
+
+			frame = 0;
+			tickFunc = () =>
+			{
+				++frame;
+				if (frame >= CurrentSequence.Length)
+				{
+					if (++playedCount < times)
+						frame = 0;
+					else
+					{
+						frame = CurrentSequence.Length - 1;
+						tickFunc = () => { };
+						after?.Invoke();
+					}
+				}
+			};
 		}
 
 		public void PlayThen(string sequenceName, Action after)

--- a/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
@@ -70,10 +70,15 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (!info.DamageTypes.IsEmpty && !e.Damage.DamageTypes.Overlaps(info.DamageTypes))
 				return;
 
-			if (isSmoking) return;
-			if (e.Damage.Value < 0) return;	/* getting healed */
-			if (e.DamageState < info.MinimumDamageState) return;
-			if (e.DamageState > info.MaximumDamageState) return;
+			if (isSmoking)
+				return;
+
+			// Getting healed
+			if (e.Damage.Value < 0)
+				return;
+
+			if (e.DamageState < info.MinimumDamageState || e.DamageState > info.MaximumDamageState)
+				return;
 
 			isSmoking = true;
 			anim.PlayThen(info.IdleSequence,

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20201213/RefactorWithDamageOverlay.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20201213/RefactorWithDamageOverlay.cs
@@ -1,0 +1,54 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RefactorWithDamageOverlay : UpdateRule
+	{
+		public override string Name => "Refactored WithDamageOverlay to be more configurable.";
+
+		public override string Description =>
+			"Internal defaults for Image and all 3 *Sequence properties were removed.\n" +
+			"IdleSequence was renamed to StartSequence and made optional, EndSequence was also made optional.\n" +
+			"LoopSequence can now actually be looped via the new LoopCount property:\n" +
+			"Either a fixed number of times, or (by setting a negative value) until hitting an invalid damage state.";
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var damageOverlay in actorNode.ChildrenMatching("WithDamageOverlay"))
+			{
+				var imageNode = damageOverlay.LastChildMatching("Image");
+
+				var idleSequenceNode = damageOverlay.LastChildMatching("IdleSequence");
+				var loopSequenceNode = damageOverlay.LastChildMatching("LoopSequence");
+				var endSequenceNode = damageOverlay.LastChildMatching("EndSequence");
+
+				if (imageNode == null)
+					damageOverlay.AddNode("Image", FieldSaver.FormatValue("smoke_m"));
+
+				if (idleSequenceNode == null)
+					damageOverlay.AddNode("StartSequence", FieldSaver.FormatValue("idle"));
+				else
+					idleSequenceNode.RenameKey("StartSequence");
+
+				if (loopSequenceNode == null)
+					damageOverlay.AddNode("LoopSequence", FieldSaver.FormatValue("loop"));
+
+				if (endSequenceNode == null)
+					damageOverlay.AddNode("EndSequence", FieldSaver.FormatValue("end"));
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -90,6 +90,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveRenderSpritesScale(),
 				new RemovePlaceBuildingPalette(),
 				new ReplaceShadowPalette(),
+				new RefactorWithDamageOverlay(),
 			})
 		};
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -248,6 +248,10 @@
 	HiddenUnderFog:
 	AttackMove:
 	WithDamageOverlay:
+		Image: smoke_m
+		StartSequence: idle
+		LoopSequence: loop
+		EndSequence: end
 	WithFacingSpriteBody:
 	Explodes:
 		Weapon: UnitExplodeSmall
@@ -646,6 +650,10 @@
 	ActorLostNotification:
 	AttackMove:
 	WithDamageOverlay:
+		Image: smoke_m
+		StartSequence: idle
+		LoopSequence: loop
+		EndSequence: end
 	Explodes:
 		Weapon: UnitExplodeShip
 		EmptyWeapon: UnitExplodeShip
@@ -910,16 +918,25 @@
 		Image: burn-s
 		MinimumDamageState: Light
 		MaximumDamageState: Medium
+		StartSequence: idle
+		LoopSequence: loop
+		EndSequence: end
 	WithDamageOverlay@MediumBurn:
 		DamageTypes: Incendiary
 		Image: burn-m
 		MinimumDamageState: Medium
 		MaximumDamageState: Heavy
+		StartSequence: idle
+		LoopSequence: loop
+		EndSequence: end
 	WithDamageOverlay@LargeBurn:
 		DamageTypes: Incendiary
 		Image: burn-l
 		MinimumDamageState: Heavy
 		MaximumDamageState: Dead
+		StartSequence: idle
+		LoopSequence: loop
+		EndSequence: end
 	HiddenUnderShroud:
 	HitShape:
 	MapEditorData:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -252,6 +252,7 @@
 		StartSequence: idle
 		LoopSequence: loop
 		EndSequence: end
+		LoopCount: 8
 	WithFacingSpriteBody:
 	Explodes:
 		Weapon: UnitExplodeSmall
@@ -654,6 +655,7 @@
 		StartSequence: idle
 		LoopSequence: loop
 		EndSequence: end
+		LoopCount: 8
 	Explodes:
 		Weapon: UnitExplodeShip
 		EmptyWeapon: UnitExplodeShip
@@ -921,6 +923,7 @@
 		StartSequence: idle
 		LoopSequence: loop
 		EndSequence: end
+		LoopCount: 6
 	WithDamageOverlay@MediumBurn:
 		DamageTypes: Incendiary
 		Image: burn-m
@@ -929,6 +932,7 @@
 		StartSequence: idle
 		LoopSequence: loop
 		EndSequence: end
+		LoopCount: 6
 	WithDamageOverlay@LargeBurn:
 		DamageTypes: Incendiary
 		Image: burn-l
@@ -937,6 +941,7 @@
 		StartSequence: idle
 		LoopSequence: loop
 		EndSequence: end
+		LoopCount: 6
 	HiddenUnderShroud:
 	HitShape:
 	MapEditorData:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -917,7 +917,7 @@
 		DamageTypes: Incendiary
 		Image: burn-s
 		MinimumDamageState: Light
-		MaximumDamageState: Medium
+		MaximumDamageState: Light
 		StartSequence: idle
 		LoopSequence: loop
 		EndSequence: end
@@ -925,7 +925,7 @@
 		DamageTypes: Incendiary
 		Image: burn-m
 		MinimumDamageState: Medium
-		MaximumDamageState: Heavy
+		MaximumDamageState: Medium
 		StartSequence: idle
 		LoopSequence: loop
 		EndSequence: end

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -272,6 +272,10 @@
 	GpsDot:
 		String: Vehicle
 	WithDamageOverlay:
+		Image: smoke_m
+		StartSequence: idle
+		LoopSequence: loop
+		EndSequence: end
 	Guard:
 	Guardable:
 	Tooltip:
@@ -519,6 +523,10 @@
 	GpsDot:
 		String: Ship
 	WithDamageOverlay:
+		Image: smoke_m
+		StartSequence: idle
+		LoopSequence: loop
+		EndSequence: end
 	Explodes:
 		Weapon: UnitExplodeShip
 		EmptyWeapon: UnitExplodeShip
@@ -921,18 +929,27 @@
 		Palette: effect
 		MinimumDamageState: Light
 		MaximumDamageState: Medium
+		StartSequence: idle
+		LoopSequence: loop
+		EndSequence: end
 	WithDamageOverlay@MediumBurn:
 		DamageTypes: Incendiary
 		Image: burn-m
 		Palette: effect
 		MinimumDamageState: Medium
 		MaximumDamageState: Heavy
+		StartSequence: idle
+		LoopSequence: loop
+		EndSequence: end
 	WithDamageOverlay@LargeBurn:
 		DamageTypes: Incendiary
 		Image: burn-l
 		Palette: effect
 		MinimumDamageState: Heavy
 		MaximumDamageState: Dead
+		StartSequence: idle
+		LoopSequence: loop
+		EndSequence: end
 	HiddenUnderShroud:
 	MapEditorData:
 		ExcludeTilesets: INTERIOR

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -928,7 +928,7 @@
 		Image: burn-s
 		Palette: effect
 		MinimumDamageState: Light
-		MaximumDamageState: Medium
+		MaximumDamageState: Light
 		StartSequence: idle
 		LoopSequence: loop
 		EndSequence: end
@@ -937,7 +937,7 @@
 		Image: burn-m
 		Palette: effect
 		MinimumDamageState: Medium
-		MaximumDamageState: Heavy
+		MaximumDamageState: Medium
 		StartSequence: idle
 		LoopSequence: loop
 		EndSequence: end

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -276,6 +276,7 @@
 		StartSequence: idle
 		LoopSequence: loop
 		EndSequence: end
+		LoopCount: 8
 	Guard:
 	Guardable:
 	Tooltip:
@@ -527,6 +528,7 @@
 		StartSequence: idle
 		LoopSequence: loop
 		EndSequence: end
+		LoopCount: 8
 	Explodes:
 		Weapon: UnitExplodeShip
 		EmptyWeapon: UnitExplodeShip
@@ -932,6 +934,7 @@
 		StartSequence: idle
 		LoopSequence: loop
 		EndSequence: end
+		LoopCount: 6
 	WithDamageOverlay@MediumBurn:
 		DamageTypes: Incendiary
 		Image: burn-m
@@ -941,6 +944,7 @@
 		StartSequence: idle
 		LoopSequence: loop
 		EndSequence: end
+		LoopCount: 6
 	WithDamageOverlay@LargeBurn:
 		DamageTypes: Incendiary
 		Image: burn-l
@@ -950,6 +954,7 @@
 		StartSequence: idle
 		LoopSequence: loop
 		EndSequence: end
+		LoopCount: 6
 	HiddenUnderShroud:
 	MapEditorData:
 		ExcludeTilesets: INTERIOR


### PR DESCRIPTION
This trait has various limitations. Part 1 fixes some legacy cruft, makes Start- and EndSequence optional and makes `LoopSequence` actually loopable, and uses that to polish damage overlays in RA & TD a bit.

Part 2 will add offset support and fix/polish smoke and fire offsets on vehicles and trees.

A later follow-up will use the added configurability to set up the 'flames erupting on damage state change' functionality the original games had.