### PR TITLE
Remove PathHash and CellIsEvacuating optimisation

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -341,7 +341,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			foreach (var actor in self.World.ActorMap.GetActorsAt(cell))
 			{
-				var move = actor.TraitOrDefault<Mobile>();
+				var move = actor.OccupiesSpace as Mobile;
 				if (move == null || !move.IsTraitEnabled() || !move.IsLeaving())
 					return false;
 			}

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -150,7 +150,6 @@ namespace OpenRA.Mods.Common.Activities
 		List<CPos> EvalPath(BlockedByActor check)
 		{
 			var path = getPath(check).TakeWhile(a => a != mobile.ToCell).ToList();
-			mobile.PathHash = HashList(path);
 			return path;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -215,9 +215,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Sync]
 		public CPos ToCell => toCell;
 
-		[Sync]
-		public int PathHash;	// written by Move.EvalPath, to temporarily debug this crap.
-
 		public Locomotor Locomotor { get; private set; }
 
 		public IPathFinder Pathfinder { get; private set; }


### PR DESCRIPTION
My stopwatch testing only showed up to 8 stopwatch ticks cost per PathHash on RA's shellmap, but that might not be the best testcase and it's not zero in any case, the perf win might add up on slower machines and/or in larger games on larger maps.

I'll trust https://github.com/OpenRA/OpenRA/issues/19216#issuecomment-792021205 on this.

2nd commit is just another of those "probably completely insignificant, but not zero and a simple change" cases.
Perf gains on RA shellmap during first 1200 ticks from 2nd commit (left = bleed, right = PR):
![mobile-lookup-savings](https://user-images.githubusercontent.com/2857877/111070128-72432880-84d0-11eb-9174-d3085d180644.png)
