### PR TITLE
Restrict Chronoshiftable trait to Mobile and Husk actors.

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
+++ b/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
@@ -36,6 +36,12 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("The color the bar of the 'return-to-origin' logic has.")]
 		public readonly Color TimeBarColor = Color.White;
 
+		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
+		{
+			if (!ai.HasTraitInfo<MobileInfo>() && !ai.HasTraitInfo<HuskInfo>())
+				throw new YamlException("Chronoshiftable requires actors to have the Mobile or Husk traits.");
+		}
+
 		public override object Create(ActorInitializer init) { return new Chronoshiftable(init, this); }
 	}
 


### PR DESCRIPTION
Closes #19224.

This issue came up for discussion on the community discord, and the conclusion was that allowing aircraft to be chronoshifted would require a significant amount of work (probably rewriting the entire implementation) and would introduce new gameplay problems that may not even have a solution*. Rather than leave that issue sit idle for years, we can provide closure and avoid future confusion by making the trait explicitly incompatible with aircraft.

*The fundamental design is based around ground-based units in cells. How do you begin to even approach balancing this feature if players can abuse the buggy aircraft adjacency logic to cram another 10 helicopters on top of the standard vehicle set? And how do you deal with selecting aircraft that circle when idle?