### PR TITLE
Path finding optimizations. Skip (15%) closed cells early.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
         shell: powershell
         run: |
           # Work around runtime failures on the GH Actions runner
-          dotnet nuget locals all --clear
+          dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org
           .\make.ps1 check
           dotnet build OpenRA.Test\OpenRA.Test.csproj -c Debug --nologo -p:TargetPlatform=win-x64
           dotnet test bin\OpenRA.Test.dll --test-adapter-path:.

--- a/OpenRA.Game/CPos.cs
+++ b/OpenRA.Game/CPos.cs
@@ -85,6 +85,11 @@ namespace OpenRA
 			return new MPos(u, v);
 		}
 
+		public CPos ToLayer(byte layer)
+		{
+			return new CPos((Bits & 0xff) | layer);
+		}
+
 		#region Scripting interface
 
 		public LuaValue Add(LuaRuntime runtime, LuaValue left, LuaValue right)

--- a/OpenRA.Game/CacheStorage.cs
+++ b/OpenRA.Game/CacheStorage.cs
@@ -11,10 +11,10 @@
 
 namespace OpenRA
 {
-	public interface ICacheStorage<T>
+	public interface ICacheStorage<K, V>
 	{
-		void Remove(string key);
-		void Store(string key, T data);
-		T Retrieve(string key);
+		void Remove(in K key);
+		void Store(in K key, V data);
+		V Retrieve(in K key);
 	}
 }

--- a/OpenRA.Game/Map/CellLayer.cs
+++ b/OpenRA.Game/Map/CellLayer.cs
@@ -49,10 +49,17 @@ namespace OpenRA
 			return cellLayer;
 		}
 
-		// Resolve an array index from cell coordinates
-		int Index(CPos cell)
+		int Index(CPos pos)
 		{
-			return Index(cell.ToMPos(GridType));
+			// PERF: Inline CPos.ToMPos to avoid MPos allocation
+			var x = pos.X;
+			var y = pos.Y;
+			if (GridType == MapGridType.Rectangular)
+				return y * Size.Width + x;
+
+			var u = (x - y) / 2;
+			var v = x + y;
+			return v * Size.Width + u;
 		}
 
 		// Resolve an array index from map coordinates

--- a/OpenRA.Game/Primitives/PriorityQueue.cs
+++ b/OpenRA.Game/Primitives/PriorityQueue.cs
@@ -20,6 +20,8 @@ namespace OpenRA.Primitives
 		bool Empty { get; }
 		T Peek();
 		T Pop();
+		bool TryPeek(out T elem);
+		bool TryPop(out T elem);
 	}
 
 	public class PriorityQueue<T> : IPriorityQueue<T>
@@ -41,12 +43,14 @@ namespace OpenRA.Primitives
 		{
 			var addLevel = level;
 			var addIndex = index;
+			var above = Above(addLevel, addIndex);
 
-			while (addLevel >= 1 && comparer.Compare(Above(addLevel, addIndex), item) > 0)
+			while (addLevel >= 1 && comparer.Compare(above), item) > 0)
 			{
-				items[addLevel][addIndex] = Above(addLevel, addIndex);
+				items[addLevel][addIndex] = above;
 				--addLevel;
 				addIndex >>= 1;
+				above = Above(addLevel, addIndex);
 			}
 
 			items[addLevel][addIndex] = item;
@@ -89,6 +93,33 @@ namespace OpenRA.Primitives
 			if (--index < 0)
 				index = (1 << --level) - 1;
 			return ret;
+		}
+
+		public bool TryPeek(out T item)
+		{
+			if (level == 0)
+			{
+				item = default;
+				return false;
+			}
+
+			item = At(0, 0);
+			return true;
+		}
+
+		public bool TryPop(out T item)
+		{
+			if (level == 0)
+			{
+				item = default;
+				return false;
+			}
+
+			item = At(0, 0);
+			BubbleInto(0, 0, Last());
+			if (--index < 0)
+				index = (1 << --level) - 1;
+			return true;
 		}
 
 		void BubbleInto(int intoLevel, int intoIndex, T val)

--- a/OpenRA.Game/Primitives/PriorityQueue.cs
+++ b/OpenRA.Game/Primitives/PriorityQueue.cs
@@ -43,14 +43,18 @@ namespace OpenRA.Primitives
 		{
 			var addLevel = level;
 			var addIndex = index;
-			var above = Above(addLevel, addIndex);
 
-			while (addLevel >= 1 && comparer.Compare(above), item) > 0)
+			while (addLevel >= 1)
 			{
-				items[addLevel][addIndex] = above;
-				--addLevel;
-				addIndex >>= 1;
-				above = Above(addLevel, addIndex);
+				var above = Above(addLevel, addIndex);
+				if (comparer.Compare(above, item) > 0)
+				{
+					items[addLevel][addIndex] = above;
+					--addLevel;
+					addIndex >>= 1;
+				}
+				else
+					break;
 			}
 
 			items[addLevel][addIndex] = item;

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -58,9 +58,17 @@ namespace OpenRA.Mods.Common.Activities
 			getPath = check =>
 			{
 				List<CPos> path;
-				using (var search =
-					PathSearch.FromPoint(self.World, mobile.Locomotor, self, mobile.ToCell, destination, check)
-					.WithoutLaneBias())
+				var query = new PathQuery(
+					queryType: PathQueryType.PositionUnidirectional,
+					world: self.World,
+					locomotor: mobile.Locomotor,
+					actor: self,
+					laneBiasDisabled: true,
+					fromPosition: mobile.ToCell,
+					toPosition: destination,
+					check: check);
+
+				using (var search = new PathSearch(query))
 					path = mobile.Pathfinder.FindPath(search);
 				return path;
 			};

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -132,8 +132,27 @@ namespace OpenRA.Mods.Common.Activities
 			if (!searchCells.Any())
 				return NoPath;
 
-			using (var fromSrc = PathSearch.FromPoints(self.World, Mobile.Locomotor, self, searchCells, loc, check))
-			using (var fromDest = PathSearch.FromPoint(self.World, Mobile.Locomotor, self, loc, lastVisibleTargetLocation, check).Reverse())
+			var fromSrcQuery = new PathQuery(
+				queryType: PathQueryType.PositionBidirectional,
+				world: self.World,
+				locomotor: Mobile.Locomotor,
+				actor: self,
+				fromPositions: searchCells,
+				toPosition: loc,
+				check: check);
+
+			var fromDestQuery = new PathQuery(
+				queryType: PathQueryType.PositionBidirectional,
+				world: self.World,
+				locomotor: Mobile.Locomotor,
+				actor: self,
+				fromPosition: loc,
+				toPosition: lastVisibleTargetLocation,
+				check: check,
+				reverse: true);
+
+			using (var fromSrc = new PathSearch(fromSrcQuery))
+			using (var fromDest = new PathSearch(fromDestQuery))
 				return Mobile.Pathfinder.FindBidiPath(fromSrc, fromDest);
 		}
 

--- a/OpenRA.Mods.Common/Pathfinder/BasePathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/BasePathSearch.cs
@@ -14,90 +14,194 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
+using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Pathfinder
 {
-	public interface IPathSearch : IDisposable
+	public enum PathQueryType
 	{
-		/// <summary>
-		/// The Graph used by the A*
-		/// </summary>
-		IGraph<CellInfo> Graph { get; }
+		// Destination unknown. Search until `IsGoal` returns true.
+		ConditionUnidirectional,
 
-		/// <summary>
-		/// Stores the analyzed nodes by the expand function
-		/// </summary>
-		IEnumerable<(CPos Cell, int Cost)> Considered { get; }
+		// Destination known. Search from 'from' to 'to'.
+		PositionUnidirectional,
 
-		Player Owner { get; }
-
-		int MaxCost { get; }
-
-		IPathSearch Reverse();
-
-		IPathSearch WithCustomBlocker(Func<CPos, bool> customBlock);
-
-		IPathSearch WithIgnoredActor(Actor b);
-
-		IPathSearch WithHeuristic(Func<CPos, int> h);
-
-		IPathSearch WithHeuristicWeight(int percentage);
-
-		IPathSearch WithCustomCost(Func<CPos, int> w);
-
-		IPathSearch WithoutLaneBias();
-
-		IPathSearch FromPoint(CPos from);
-
-		/// <summary>
-		/// Decides whether a location is a target based on its estimate
-		/// (An estimate of 0 means that the location and the unit's goal
-		/// are the same. There could be multiple goals).
-		/// </summary>
-		/// <param name="location">The location to assess</param>
-		/// <returns>Whether the location is a target</returns>
-		bool IsTarget(CPos location);
-
-		bool CanExpand { get; }
-		CPos Expand();
+		// Destination known. Search from both 'from' and 'to', meet in middle.
+		PositionBidirectional
 	}
 
-	public abstract class BasePathSearch : IPathSearch
+	public class PathQuery
 	{
-		public IGraph<CellInfo> Graph { get; set; }
+		public readonly PathQueryType QueryType;
+		public readonly World World;
+		public readonly Locomotor Locomotor;
+		public readonly Actor Actor;
+		public readonly BlockedByActor Check;
+		public readonly IEnumerable<CPos> FromPositions;
+
+		// To be set for Position searches.
+		public readonly CPos? ToPosition;
+
+		public readonly Func<CPos, bool> CustomBlock;
+		public readonly Actor IgnoreActor;
+		public readonly Func<CPos, int> CustomCost;
+		public readonly Func<CPos, bool> IsGoal;
+		public readonly bool LaneBiasDisabled;
+
+		// The other end of a bidirectional search.
+		public readonly bool Reverse;
+
+		public PathQuery(PathQueryType queryType,
+			World world,
+			Locomotor locomotor,
+			Actor actor,
+			BlockedByActor check,
+			IEnumerable<CPos> fromPositions,
+			CPos? toPosition = null,
+			Func<CPos, bool> customBlock = null,
+			Actor ignoreActor = null,
+			Func<CPos, int> customCost = null,
+			Func<CPos, bool> isGoal = null,
+			bool laneBiasDisabled = false,
+			bool reverse = false)
+		{
+			QueryType = queryType;
+			World = world;
+			Locomotor = locomotor;
+			Actor = actor;
+			Check = check;
+			FromPositions = fromPositions;
+			ToPosition = toPosition;
+			CustomBlock = customBlock;
+			IgnoreActor = ignoreActor;
+			CustomCost = customCost;
+			IsGoal = isGoal;
+			LaneBiasDisabled = laneBiasDisabled;
+			Reverse = reverse;
+		}
+
+		public PathQuery(PathQueryType queryType,
+			World world,
+			Locomotor locomotor,
+			Actor actor,
+			BlockedByActor check,
+			CPos fromPosition,
+			CPos? toPosition = null,
+			Func<CPos, bool> customBlock = null,
+			Actor ignoreActor = null,
+			Func<CPos, int> customCost = null,
+			Func<CPos, bool> isGoal = null,
+			bool laneBiasDisabled = false,
+			bool reverse = false)
+		{
+			QueryType = queryType;
+			World = world;
+			Locomotor = locomotor;
+			Actor = actor;
+			Check = check;
+			FromPositions = new[] { fromPosition };
+			ToPosition = toPosition;
+			CustomBlock = customBlock;
+			IgnoreActor = ignoreActor;
+			CustomCost = customCost;
+			IsGoal = isGoal;
+			LaneBiasDisabled = laneBiasDisabled;
+			Reverse = reverse;
+		}
+
+		public PathQuery CreateReverse()
+		{
+			if (QueryType != PathQueryType.PositionBidirectional)
+				throw new ArgumentException("Only bidirectional queries use a reverse");
+
+			if (!ToPosition.HasValue)
+				throw new ArgumentException("ToPosition not set");
+
+			if (FromPositions.Count() > 1)
+				throw new ArgumentException("Reverse requires a single FromPosition");
+
+			return new PathQuery(
+				QueryType,
+				World,
+				Locomotor,
+				Actor,
+				Check,
+				new[] { ToPosition.Value },
+				FromPositions.First(),
+				CustomBlock,
+				IgnoreActor,
+				CustomCost,
+				IsGoal,
+				LaneBiasDisabled,
+				!Reverse);
+		}
+	}
+
+	public abstract class BasePathSearch : IDisposable
+	{
+		public readonly PathGraph Graph;
+		public readonly PathQuery Query;
+		public readonly Func<CPos, bool> IsGoal;
+		public readonly bool Debug;
+
+		// Stores maximum cost in debug mode. Zero otherwise.
+		public int MaxCost { get; protected set; }
+
+		// Stores considered cells in debug mode. Empty otherwise.
+		public abstract IEnumerable<(CPos Cell, int Cost)> Considered { get; }
 
 		protected IPriorityQueue<GraphConnection> OpenQueue { get; private set; }
 
-		public abstract IEnumerable<(CPos Cell, int Cost)> Considered { get; }
+		protected readonly Func<CPos, int> heuristic;
+		protected readonly int heuristicWeightPercentage;
+		readonly int cellCost, diagonalCellCost;
 
-		public Player Owner => Graph.Actor.Owner;
-		public int MaxCost { get; protected set; }
-		public bool Debug { get; set; }
-		protected Func<CPos, int> heuristic;
-		protected Func<CPos, bool> isGoal;
-		protected int heuristicWeightPercentage;
-
-		// This member is used to compute the ID of PathSearch.
-		// Essentially, it represents a collection of the initial
-		// points considered and their Heuristics to reach
-		// the target. It pretty match identifies, in conjunction of the Actor,
-		// a deterministic set of calculations
-		protected readonly IPriorityQueue<GraphConnection> StartPoints;
-
-		private readonly int cellCost, diagonalCellCost;
-
-		protected BasePathSearch(IGraph<CellInfo> graph)
+		protected BasePathSearch(PathGraph graph, PathQuery query, bool debug)
 		{
+			Debug = debug;
 			Graph = graph;
+			Query = query;
 			OpenQueue = new PriorityQueue<GraphConnection>(GraphConnection.ConnectionCostComparer);
-			StartPoints = new PriorityQueue<GraphConnection>(GraphConnection.ConnectionCostComparer);
 			MaxCost = 0;
-			heuristicWeightPercentage = 100;
 
 			// Determine the minimum possible cost for moving horizontally between cells based on terrain speeds.
 			// The minimum possible cost diagonally is then Sqrt(2) times more costly.
-			cellCost = ((Mobile)graph.Actor.OccupiesSpace).Info.LocomotorInfo.TerrainSpeeds.Values.Min(ti => ti.Cost);
+			cellCost = ((Mobile)Query.Actor.OccupiesSpace).Info.LocomotorInfo.TerrainSpeeds.Values.Min(ti => ti.Cost);
 			diagonalCellCost = cellCost * 141421 / 100000;
+
+			if (Query.QueryType == PathQueryType.ConditionUnidirectional)
+			{
+				if (Query.IsGoal == null)
+					throw new ArgumentException("IsGoal not set in path query");
+
+				IsGoal = Query.IsGoal;
+				heuristicWeightPercentage = 100;
+				heuristic = loc => 0;
+			}
+			else
+			{
+				if (Query.FromPositions == null)
+					throw new ArgumentException("FromPositions not set in path query");
+
+				if (!Query.ToPosition.HasValue)
+					throw new ArgumentException("ToPosition set in path query");
+
+				IsGoal = loc =>
+				{
+					var locInfo = graph[loc];
+					return locInfo.EstimatedTotal - locInfo.CostSoFar == 0;
+				};
+
+				// The search will aim for the shortest path by default, a weight of 100%.
+				// We can allow the search to find paths that aren't optimal by changing the weight.
+				// We provide a weight that limits the worst case length of the path,
+				// e.g. a weight of 110% will find a path no more than 10% longer than the shortest possible.
+				// The benefit of allowing the search to return suboptimal paths is faster computation time.
+				// The search can skip some areas of the search space, meaning it has less work to do.
+				// We allow paths up to 25% longer than the shortest, optimal path, to improve pathfinding time.
+				heuristicWeightPercentage = 125;
+				heuristic = DefaultEstimator(query.ToPosition.Value);
+			}
 		}
 
 		/// <summary>
@@ -105,7 +209,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// http://theory.stanford.edu/~amitp/GameProgramming/Heuristics.html
 		/// </summary>
 		/// <returns>A delegate that calculates the estimation for a node</returns>
-		protected Func<CPos, int> DefaultEstimator(CPos destination)
+		Func<CPos, int> DefaultEstimator(CPos destination)
 		{
 			return here =>
 			{
@@ -119,65 +223,8 @@ namespace OpenRA.Mods.Common.Pathfinder
 			};
 		}
 
-		public IPathSearch Reverse()
-		{
-			Graph.InReverse = true;
-			return this;
-		}
-
-		public IPathSearch WithCustomBlocker(Func<CPos, bool> customBlock)
-		{
-			Graph.CustomBlock = customBlock;
-			return this;
-		}
-
-		public IPathSearch WithIgnoredActor(Actor b)
-		{
-			Graph.IgnoreActor = b;
-			return this;
-		}
-
-		public IPathSearch WithHeuristic(Func<CPos, int> h)
-		{
-			heuristic = h;
-			return this;
-		}
-
-		public IPathSearch WithHeuristicWeight(int percentage)
-		{
-			heuristicWeightPercentage = percentage;
-			return this;
-		}
-
-		public IPathSearch WithCustomCost(Func<CPos, int> w)
-		{
-			Graph.CustomCost = w;
-			return this;
-		}
-
-		public IPathSearch WithoutLaneBias()
-		{
-			Graph.LaneBias = 0;
-			return this;
-		}
-
-		public IPathSearch FromPoint(CPos from)
-		{
-			if (Graph.World.Map.Contains(from))
-				AddInitialCell(from);
-
-			return this;
-		}
-
-		protected abstract void AddInitialCell(CPos cell);
-
-		public bool IsTarget(CPos location)
-		{
-			return isGoal(location);
-		}
-
 		public bool CanExpand => !OpenQueue.Empty;
-		public abstract CPos Expand();
+		public abstract bool TryExpand(out CPos mostPromisingNode);
 
 		protected virtual void Dispose(bool disposing)
 		{

--- a/OpenRA.Mods.Common/Pathfinder/CellInfoLayerPool.cs
+++ b/OpenRA.Mods.Common/Pathfinder/CellInfoLayerPool.cs
@@ -15,7 +15,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.Pathfinder
 {
-	sealed class CellInfoLayerPool
+	public sealed class CellInfoLayerPool
 	{
 		const int MaxPoolSize = 4;
 		readonly Stack<CellLayer<CellInfo>> pool = new Stack<CellLayer<CellInfo>>(MaxPoolSize);

--- a/OpenRA.Mods.Common/Pathfinder/PathFinderUnitPathCacheDecorator.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathFinderUnitPathCacheDecorator.cs
@@ -22,9 +22,9 @@ namespace OpenRA.Mods.Common.Pathfinder
 	public class PathFinderUnitPathCacheDecorator : IPathFinder
 	{
 		readonly IPathFinder pathFinder;
-		readonly ICacheStorage<List<CPos>> cacheStorage;
+		readonly ICacheStorage<PathCacheKey, List<CPos>> cacheStorage;
 
-		public PathFinderUnitPathCacheDecorator(IPathFinder pathFinder, ICacheStorage<List<CPos>> cacheStorage)
+		public PathFinderUnitPathCacheDecorator(IPathFinder pathFinder, ICacheStorage<PathCacheKey, List<CPos>> cacheStorage)
 		{
 			this.pathFinder = pathFinder;
 			this.cacheStorage = cacheStorage;
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		{
 			using (new PerfSample("Pathfinder"))
 			{
-				var key = "FindUnitPath" + self.ActorID + source.X + source.Y + target.X + target.Y;
+				var key = new PathCacheKey(PathCacheQueryType.UnitPath, self.ActorID, source, target);
 
 				// Only cache path when transient actors are ignored, otherwise there is no guarantee that the path
 				// is still valid at the next check.
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		{
 			using (new PerfSample("Pathfinder"))
 			{
-				var key = "FindUnitPathToRange" + self.ActorID + source.X + source.Y + target.X + target.Y;
+				var key = new PathCacheKey(PathCacheQueryType.UnitPathToRange, self.ActorID, source, target);
 
 				if (check == BlockedByActor.None)
 				{
@@ -76,13 +76,13 @@ namespace OpenRA.Mods.Common.Pathfinder
 			}
 		}
 
-		public List<CPos> FindPath(IPathSearch search)
+		public List<CPos> FindPath(BasePathSearch search)
 		{
 			using (new PerfSample("Pathfinder"))
 				return pathFinder.FindPath(search);
 		}
 
-		public List<CPos> FindBidiPath(IPathSearch fromSrc, IPathSearch fromDest)
+		public List<CPos> FindBidiPath(BasePathSearch fromSrc, BasePathSearch fromDest)
 		{
 			using (new PerfSample("Pathfinder"))
 				return pathFinder.FindBidiPath(fromSrc, fromDest);

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -36,61 +36,25 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 		#region Constructors
 
-		private PathSearch(IGraph<CellInfo> graph)
-			: base(graph)
+		public PathSearch(PathQuery query, bool debug = false)
+			: base(new PathGraph(LayerPoolForWorld(query.World), query), query, debug)
 		{
 			considered = new LinkedList<(CPos, int)>();
-		}
-
-		public static IPathSearch Search(World world, Locomotor locomotor, Actor self, BlockedByActor check, Func<CPos, bool> goalCondition)
-		{
-			var graph = new PathGraph(LayerPoolForWorld(world), locomotor, self, world, check);
-			var search = new PathSearch(graph);
-			search.isGoal = goalCondition;
-			search.heuristic = loc => 0;
-			return search;
-		}
-
-		public static IPathSearch FromPoint(World world, Locomotor locomotor, Actor self, CPos @from, CPos target, BlockedByActor check)
-		{
-			return FromPoints(world, locomotor, self, new[] { from }, target, check);
-		}
-
-		public static IPathSearch FromPoints(World world, Locomotor locomotor, Actor self, IEnumerable<CPos> froms, CPos target, BlockedByActor check)
-		{
-			var graph = new PathGraph(LayerPoolForWorld(world), locomotor, self, world, check);
-			var search = new PathSearch(graph);
-			search.heuristic = search.DefaultEstimator(target);
-
-			// The search will aim for the shortest path by default, a weight of 100%.
-			// We can allow the search to find paths that aren't optimal by changing the weight.
-			// We provide a weight that limits the worst case length of the path,
-			// e.g. a weight of 110% will find a path no more than 10% longer than the shortest possible.
-			// The benefit of allowing the search to return suboptimal paths is faster computation time.
-			// The search can skip some areas of the search space, meaning it has less work to do.
-			// We allow paths up to 25% longer than the shortest, optimal path, to improve pathfinding time.
-			search.heuristicWeightPercentage = 125;
-
-			search.isGoal = loc =>
+			if (Query.FromPositions != null)
 			{
-				var locInfo = search.Graph[loc];
-				return locInfo.EstimatedTotal - locInfo.CostSoFar == 0;
-			};
-
-			foreach (var sl in froms)
-				if (world.Map.Contains(sl))
-					search.AddInitialCell(sl);
-
-			return search;
+				var map = Query.World.Map;
+				foreach (var sl in Query.FromPositions)
+					if (map.Contains(sl))
+						AddInitialCell(sl);
+			}
 		}
 
-		protected override void AddInitialCell(CPos location)
+		void AddInitialCell(CPos location)
 		{
 			var cost = heuristic(location);
 			Graph[location] = new CellInfo(0, cost, location, CellStatus.Open);
 			var connection = new GraphConnection(location, cost);
 			OpenQueue.Add(connection);
-			StartPoints.Add(connection);
 			considered.AddLast((location, 0));
 		}
 
@@ -100,16 +64,27 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// This function analyzes the neighbors of the most promising node in the Pathfinding graph
 		/// using the A* algorithm (A-star) and returns that node
 		/// </summary>
-		/// <returns>The most promising node of the iteration</returns>
-		public override CPos Expand()
+		/// <returns>The most promising node of the iteration or false if expansion is no longer possible</returns>
+		public override bool TryExpand(out CPos mostPromisingNode)
 		{
-			var currentMinNode = OpenQueue.Pop().Destination;
+			if (!OpenQueue.TryPop(out var currentMinConnection))
+			{
+				mostPromisingNode = default(CPos);
+				return false;
+			}
+
+			var currentMinNode = currentMinConnection.Destination;
 
 			var currentCell = Graph[currentMinNode];
-			Graph[currentMinNode] = new CellInfo(currentCell.CostSoFar, currentCell.EstimatedTotal, currentCell.PreviousPos, CellStatus.Closed);
+			Graph[currentMinNode] = new CellInfo(currentCell.CostSoFar,
+				currentCell.EstimatedTotal, currentCell.PreviousPos, CellStatus.Closed);
 
-			if (Graph.CustomCost != null && Graph.CustomCost(currentMinNode) == PathGraph.CostForInvalidCell)
-				return currentMinNode;
+			var customCost = Query.CustomCost;
+			if (customCost != null && customCost(currentMinNode) == PathGraph.CostForInvalidCell)
+			{
+				mostPromisingNode = currentMinNode;
+				return true;
+			}
 
 			foreach (var connection in Graph.GetConnections(currentMinNode))
 			{
@@ -147,7 +122,8 @@ namespace OpenRA.Mods.Common.Pathfinder
 				}
 			}
 
-			return currentMinNode;
+			mostPromisingNode = currentMinNode;
+			return true;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -178,38 +178,56 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Actor ClosestProc(Actor self, Actor ignore)
 		{
-			// Find all refineries and their occupancy count:
-			var refineries = self.World.ActorsWithTrait<IAcceptResources>()
+			var world = self.World;
+
+			// Find all refineries and their occupancy count
+			var refineries = world.ActorsWithTrait<IAcceptResources>()
 				.Where(r => r.Actor != ignore && r.Actor.Owner == self.Owner && IsAcceptableProcType(r.Actor))
-				.Select(r => new
+				.ToArray();
+
+			if (refineries.Length == 0)
+				return null;
+
+			// PERF: Avoid LINQ, use Dictionary over Lookup, calculate cost already
+			var locationCost = new Dictionary<CPos, (Actor Actor, int Cost)>(refineries.Length);
+			foreach (var r in refineries)
+			{
+				var location = r.Actor.Location + r.Trait.DeliveryOffset;
+				var occupancy = world.ActorsHavingTrait<Harvester>(h => h.LinkedProc == r.Actor)
+					.Count();
+
+				int cost;
+				if (occupancy >= Info.MaxUnloadQueue)
 				{
-					Location = r.Actor.Location + r.Trait.DeliveryOffset,
-					Actor = r.Actor,
-					Occupancy = self.World.ActorsHavingTrait<Harvester>(h => h.LinkedProc == r.Actor).Count()
-				}).ToLookup(r => r.Location);
+					// Too many harvesters clogs up the refinery's delivery location:
+					cost = PathGraph.CostForInvalidCell;
+				}
+				else
+				{
+					// Prefer refineries with less occupancy (multiplier is to offset distance cost):
+					cost = occupancy * Info.UnloadQueueCostModifier;
+				}
+
+				locationCost.TryAdd(location, (r.Actor, cost));
+			}
 
 			// Start a search from each refinery's delivery location:
 			List<CPos> path;
+			var query = new PathQuery(
+				queryType: PathQueryType.PositionUnidirectional,
+				world: world,
+				locomotor: mobile.Locomotor,
+				actor: self,
+				fromPositions: locationCost.Keys,
+				toPosition: self.Location,
+				check: BlockedByActor.None,
+				customCost: location => locationCost.TryGetValue(location, out var lc) ? lc.Cost : 0);
 
-			using (var search = PathSearch.FromPoints(self.World, mobile.Locomotor, self, refineries.Select(r => r.Key), self.Location, BlockedByActor.None)
-				.WithCustomCost(location =>
-				{
-					if (!refineries.Contains(location))
-						return 0;
-
-					var occupancy = refineries[location].First().Occupancy;
-
-					// Too many harvesters clogs up the refinery's delivery location:
-					if (occupancy >= Info.MaxUnloadQueue)
-						return PathGraph.CostForInvalidCell;
-
-					// Prefer refineries with less occupancy (multiplier is to offset distance cost):
-					return occupancy * Info.UnloadQueueCostModifier;
-				}))
+			using (var search = new PathSearch(query))
 				path = mobile.Pathfinder.FindPath(search);
 
 			if (path.Count != 0)
-				return refineries[path.Last()].First().Actor;
+				return locationCost[path.Last()].Actor;
 
 			return null;
 		}

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -804,9 +804,16 @@ namespace OpenRA.Mods.Common.Traits
 				return above;
 
 			List<CPos> path;
-			using (var search = PathSearch.Search(self.World, Locomotor, self, BlockedByActor.All,
-					loc => loc.Layer == 0 && CanEnterCell(loc))
-				.FromPoint(self.Location))
+			var query = new PathQuery(
+				queryType: PathQueryType.ConditionUnidirectional,
+				world: self.World,
+				locomotor: Locomotor,
+				actor: self,
+				check: BlockedByActor.All,
+				fromPosition: self.Location,
+				isGoal: loc => loc.Layer == 0 && CanEnterCell(loc));
+
+			using (var search = new PathSearch(query))
 				path = Pathfinder.FindPath(search);
 
 			if (path.Count > 0)

--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -261,7 +261,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!influence.Contains(uv))
 				return Enumerable.Empty<Actor>();
 
-			var layer = a.Layer == 0 ? influence : customInfluence[a.Layer];
+			var layerIndex = a.Layer;
+			var layer = layerIndex == 0 ? influence : customInfluence[layerIndex];
 			return new ActorsAtEnumerable(layer[uv]);
 		}
 
@@ -271,7 +272,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!influence.Contains(uv))
 				yield break;
 
-			var layer = a.Layer == 0 ? influence : customInfluence[a.Layer];
+			var layerIndex = a.Layer;
+			var layer = layerIndex == 0 ? influence : customInfluence[layerIndex];
 			for (var i = layer[uv]; i != null; i = i.Next)
 				if (!i.Actor.Disposed && (i.SubCell == sub || i.SubCell == SubCell.FullCell || sub == SubCell.FullCell || sub == SubCell.Any))
 					yield return i.Actor;
@@ -318,7 +320,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!influence.Contains(uv))
 				return false;
 
-			var layer = a.Layer == 0 ? influence : customInfluence[a.Layer];
+			var layerIndex = a.Layer;
+			var layer = layerIndex == 0 ? influence : customInfluence[layerIndex];
 			return layer[uv] != null;
 		}
 
@@ -330,7 +333,8 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			var always = sub == SubCell.FullCell || sub == SubCell.Any;
-			var layer = a.Layer == 0 ? influence : customInfluence[a.Layer];
+			var layerIndex = a.Layer;
+			var layer = layerIndex == 0 ? influence : customInfluence[layerIndex];
 			for (var i = layer[uv]; i != null; i = i.Next)
 			{
 				if (always || i.SubCell == sub || i.SubCell == SubCell.FullCell)
@@ -355,7 +359,8 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			var always = sub == SubCell.FullCell || sub == SubCell.Any;
-			var layer = a.Layer == 0 ? influence : customInfluence[a.Layer];
+			var layerIndex = a.Layer;
+			var layer = layerIndex == 0 ? influence : customInfluence[layerIndex];
 			for (var i = layer[uv]; i != null; i = i.Next)
 				if ((always || i.SubCell == sub || i.SubCell == SubCell.FullCell) && !i.Actor.Disposed && withCondition(i.Actor))
 					return true;
@@ -371,7 +376,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (!influence.Contains(uv))
 					continue;
 
-				var layer = c.Cell.Layer == 0 ? influence : customInfluence[c.Cell.Layer];
+				var layerIndex = c.Cell.Layer;
+				var layer = layerIndex == 0 ? influence : customInfluence[layerIndex];
 				layer[uv] = new InfluenceNode { Next = layer[uv], SubCell = c.SubCell, Actor = self };
 
 				if (cellTriggerInfluence.TryGetValue(c.Cell, out var triggers))
@@ -390,7 +396,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (!influence.Contains(uv))
 					continue;
 
-				var layer = c.Cell.Layer == 0 ? influence : customInfluence[c.Cell.Layer];
+				var layerIndex = c.Cell.Layer;
+				var layer = layerIndex == 0 ? influence : customInfluence[layerIndex];
 				var temp = layer[uv];
 				RemoveInfluenceInner(ref temp, self);
 				layer[uv] = temp;

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -175,7 +175,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!world.Map.Contains(cell))
 				return short.MaxValue;
 
-			return cell.Layer == 0 ? cellsCost[cell] : customLayerCellsCost[cell.Layer][cell];
+			var layer = cell.Layer;
+			return layer == 0 ? cellsCost[cell] : customLayerCellsCost[layer][cell];
 		}
 
 		public int MovementSpeedForCell(CPos cell)
@@ -191,7 +192,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!world.Map.Contains(destNode))
 				return short.MaxValue;
 
-			var cellCost = destNode.Layer == 0 ? cellsCost[destNode] : customLayerCellsCost[destNode.Layer][destNode];
+			var destLayer = destNode.Layer;
+			var cellCost = destLayer == 0 ? cellsCost[destNode] : customLayerCellsCost[destLayer][destNode];
 
 			if (cellCost == short.MaxValue ||
 				!CanMoveFreelyInto(actor, destNode, check, ignoreActor))
@@ -399,7 +401,8 @@ namespace OpenRA.Mods.Common.Traits
 				dirtyCells.Remove(cell);
 			}
 
-			var cache = cell.Layer == 0 ? blockingCache : customLayerBlockingCache[cell.Layer];
+			var layer = cell.Layer;
+			var cache = layer == 0 ? blockingCache : customLayerBlockingCache[layer];
 
 			return cache[cell];
 		}

--- a/OpenRA.Mods.Common/Traits/World/SubterraneanActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SubterraneanActorLayer.cs
@@ -72,10 +72,9 @@ namespace OpenRA.Mods.Common.Traits
 			return pos + new WVec(0, 0, height[cell] - pos.Z);
 		}
 
-		bool ValidTransitionCell(CPos cell, LocomotorInfo li)
+		bool ValidTransitionCell(CPos cell, SubterraneanLocomotorInfo sli)
 		{
 			var terrainType = map.GetTerrainInfo(cell).Type;
-			var sli = (SubterraneanLocomotorInfo)li;
 			if (!sli.SubterraneanTransitionTerrainTypes.Contains(terrainType) && sli.SubterraneanTransitionTerrainTypes.Any())
 				return false;
 


### PR DESCRIPTION
In path finding `GetConnections` considers connections to already closed cells and calculates the cost for them. The caller afterwards ignores them. These are 15% of all connections.

Add `CPos.ToOffset` to avoid `MPos` allocation in `CellLayer`.

Additional small changes with minimal performance benefit which I can imagine you won't find 'pretty'. Feel free to reject.

Use `PathGraph` directly over `IGraph` to allow non virtual index operator access. There will likely be no alternative implementations - and switching back is easy once there are.

Copies `CellInfo` to a local variable. The trade off between copying `CellInfo` versus calculating a cell index offset - and accessing an array twice.

Tested by running a replay of 20 mins.

Suggestion: remove most properties in `IGraph` and `IPathSearch` and pass them as constructor variables i.e. `PathQuery` as they are often only set once and not used outside the implementing classes.
