### PR TITLE
Add condition support to ActorLostNotification.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Sound/ActorLostNotification.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/ActorLostNotification.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Sound
 {
-	class ActorLostNotificationInfo : TraitInfo
+	class ActorLostNotificationInfo : ConditionalTraitInfo
 	{
 		[NotificationReference("Speech")]
 		public readonly string Notification = "UnitLost";
@@ -23,18 +23,18 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		public override object Create(ActorInitializer init) { return new ActorLostNotification(this); }
 	}
 
-	class ActorLostNotification : INotifyKilled
+	class ActorLostNotification : ConditionalTrait<ActorLostNotificationInfo>, INotifyKilled
 	{
-		ActorLostNotificationInfo info;
 		public ActorLostNotification(ActorLostNotificationInfo info)
-		{
-			this.info = info;
-		}
+			: base(info) { }
 
 		void INotifyKilled.Killed(Actor self, AttackInfo e)
 		{
-			var player = info.NotifyAll ? self.World.LocalPlayer : self.Owner;
-			Game.Sound.PlayNotification(self.World.Map.Rules, player, "Speech", info.Notification, self.Owner.Faction.InternalName);
+			if (IsTraitDisabled)
+				return;
+
+			var player = Info.NotifyAll ? self.World.LocalPlayer : self.Owner;
+			Game.Sound.PlayNotification(self.World.Map.Rules, player, "Speech", Info.Notification, self.Owner.Faction.InternalName);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #19244.

Testcase: Change the `ActorLostNotification` on `^NeutralPlane` to
```
	ActorLostNotification@airborne:
		RequiresCondition: airborne
		Notification: AirUnitLost
	ActorLostNotification:
		RequiresCondition: !airborne
		Notification: UnitLost
```

and notice that airborne planes give "Airborne unit lost" while planes on the airfield give "Unit lost".