### PR TITLE
Add Selectable Class to technicians

### DIFF
--- a/mods/ra/maps/monster-tank-madness/monster-tank-madness.lua
+++ b/mods/ra/maps/monster-tank-madness/monster-tank-madness.lua
@@ -13,7 +13,7 @@ AlliedUnits =
 	{ delay = DateTime.Seconds(7), types = { "e6", "e6", "thf" } }
 }
 ReinforceBaseUnits = { "1tnk", "1tnk", "2tnk", "arty", "arty" }
-CivilianEvacuees = { "c1", "c2", "c5", "c7", "c8" }
+CivilianEvacuees = { "c2", "c3", "c5", "c6", "c8" }
 USSROutpostFlameTurrets = { FlameTurret1, FlameTurret2 }
 ExplosiveBarrels = { ExplosiveBarrel1, ExplosiveBarrel2 }
 SuperTanks = { stnk1, stnk2, stnk3 }

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -104,6 +104,8 @@ TECN:
 	Inherits@2: ^ArmedCivilian
 	Tooltip:
 		Name: Technician
+	Selectable:
+		Class: Technician
 	RenderSprites:
 		Image: C1
 
@@ -112,6 +114,8 @@ TECN2:
 	Inherits@2: ^ArmedCivilian
 	Tooltip:
 		Name: Technician
+	Selectable:
+		Class: Technician
 	RenderSprites:
 		Image: C1
 	WithInfantryBody:


### PR DESCRIPTION
Closes #19184 by giving technicians their own selection class. 

To address the other point of that ticket, I'm swapping out c1 and c7 from Monster Tank Madness as they share skins with technicians. I updated #19179 to do the same there.