### PR TITLE
Fixes footprints when affected by multiple buildings.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -212,9 +212,9 @@ namespace OpenRA.Mods.Common.Traits
 				for (var x = scanStart.X; x < scanEnd.X; x++)
 				{
 					var pos = new CPos(x, y);
-					var buildingAtPos = bi.GetBuildingAt(pos);
+					var buildingsAtPos = bi.GetBuildingsAt(pos);
 
-					if (buildingAtPos == null)
+					if (!buildingsAtPos.Any())
 					{
 						var unitsAtPos = world.ActorMap.GetActorsAt(pos).Where(a => a.IsInWorld
 							&& (a.Owner == p || (allyBuildEnabled && a.Owner.RelationshipWith(p) == PlayerRelationship.Ally))
@@ -223,9 +223,13 @@ namespace OpenRA.Mods.Common.Traits
 						if (unitsAtPos.Any())
 							nearnessCandidates.Add(pos);
 					}
-					else if (buildingAtPos.IsInWorld && ActorGrantsValidArea(buildingAtPos, requiresBuildableArea)
-						&& (buildingAtPos.Owner == p || (allyBuildEnabled && buildingAtPos.Owner.RelationshipWith(p) == PlayerRelationship.Ally)))
-						nearnessCandidates.Add(pos);
+					else
+					{
+						nearnessCandidates.AddRange(buildingsAtPos.Where(buildingAtPos =>
+								buildingAtPos.IsInWorld && ActorGrantsValidArea(buildingAtPos, requiresBuildableArea) &&
+								(buildingAtPos.Owner == p || (allyBuildEnabled && buildingAtPos.Owner.RelationshipWith(p) == PlayerRelationship.Ally)))
+							.Select(buildingAtPos => pos));
+					}
 				}
 			}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
@@ -23,32 +23,44 @@ namespace OpenRA.Mods.Common.Traits
 	public class BuildingInfluence
 	{
 		readonly Map map;
-		readonly CellLayer<Actor> influence;
+		readonly CellLayer<List<Actor>> influence;
 
 		public BuildingInfluence(World world)
 		{
 			map = world.Map;
 
-			influence = new CellLayer<Actor>(map);
+			influence = new CellLayer<List<Actor>>(map);
 		}
 
 		internal void AddInfluence(Actor a, IEnumerable<CPos> tiles)
 		{
 			foreach (var u in tiles)
-				if (influence.Contains(u) && influence[u] == null)
-					influence[u] = a;
+			{
+				if (!influence.Contains(u))
+					continue;
+
+				if (influence[u] == null)
+					influence[u] = new List<Actor>();
+
+				influence[u].Add(a);
+			}
 		}
 
 		internal void RemoveInfluence(Actor a, IEnumerable<CPos> tiles)
 		{
 			foreach (var u in tiles)
-				if (influence.Contains(u) && influence[u] == a)
-					influence[u] = null;
+			{
+				if (!influence.Contains(u) || influence[u] == null)
+					continue;
+
+				if (influence[u].Contains(a))
+					influence[u].Remove(a);
+			}
 		}
 
-		public Actor GetBuildingAt(CPos cell)
+		public IEnumerable<Actor> GetBuildingsAt(CPos cell)
 		{
-			return influence.Contains(cell) ? influence[cell] : null;
+			return influence.Contains(cell) && influence[cell] != null ? influence[cell] : new List<Actor>();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
@@ -54,8 +54,8 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				// Replacements are enabled and the cell contained at least one (not ignored) actor or building bib
-				var building = world.WorldActor.Trait<BuildingInfluence>().GetBuildingAt(cell);
-				if (foundActors || building != null)
+				var buildings = world.WorldActor.Trait<BuildingInfluence>().GetBuildingsAt(cell);
+				if (foundActors || buildings.Any())
 				{
 					// The cell contains at least one actor, and none were replaceable
 					if (acceptedReplacements == null)
@@ -73,8 +73,8 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				// HACK: To preserve legacy behaviour, AllowInvalidPlacement should display red placement indicators
 				// if (and only if) there is a building or bib in the cell
-				var building = world.WorldActor.Trait<BuildingInfluence>().GetBuildingAt(cell);
-				if (building != null)
+				var buildings = world.WorldActor.Trait<BuildingInfluence>().GetBuildingsAt(cell);
+				if (buildings.Any())
 					return false;
 			}
 

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!rt.Info.AllowUnderActors && world.ActorMap.AnyActorsAt(cell))
 				return false;
 
-			if (!rt.Info.AllowUnderBuildings && buildingInfluence.GetBuildingAt(cell) != null)
+			if (!rt.Info.AllowUnderBuildings && buildingInfluence.GetBuildingsAt(cell).Any())
 				return false;
 
 			return rt.Info.AllowOnRamps || world.Map.Ramp[cell] == 0;

--- a/OpenRA.Mods.D2k/Traits/Buildings/D2kBuilding.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/D2kBuilding.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.D2k.Traits.Buildings
 							continue;
 
 						// Don't place under other buildings (or their bib)
-						if (bi.GetBuildingAt(c) != self)
+						if (!bi.GetBuildingsAt(c).Contains(self))
 							continue;
 
 						var index = Game.CosmeticRandom.Next(template.TilesCount);
@@ -116,7 +116,7 @@ namespace OpenRA.Mods.D2k.Traits.Buildings
 							continue;
 
 						// Don't place under other buildings (or their bib)
-						if (bi.GetBuildingAt(c) != self)
+						if (!bi.GetBuildingsAt(c).Contains(self))
 							continue;
 
 						layer.AddTile(c, new TerrainTile(template.Id, (byte)i));


### PR DESCRIPTION
Imagine the following case:
A building occupies 3x3 cells.
Now another building will be created, which footprint overlaps with this building -> no problem so far.
Now one of the two buildings gets removed -> the overlapped cells will be freed and the footprint of the other building is now broken. This PR fixes this by saving all actors which occupy particular cells, making the cells free if no single actor is occupying it anymore.

This is currently a problem with OpenKrush: An actor deploys into a building on top of another building actor only, consuming the old actor. So the order is -> place new building, remove old building. This results always in a broken footprint.