### PR TITLE
Add the rotate of the vehicle on ramp

### DIFF
--- a/OpenRA.Game/Map/MapGrid.cs
+++ b/OpenRA.Game/Map/MapGrid.cs
@@ -120,6 +120,7 @@ namespace OpenRA
 		};
 
 		public CellRamp[] Ramps { get; private set; }
+		public WRot[] RampsRots { get; private set; }
 
 		internal readonly CVec[][] TilesByDistance;
 
@@ -174,6 +175,15 @@ namespace OpenRA
 				new CellRamp(Type, tr: RampCornerHeight.Half, bl: RampCornerHeight.Half, split: RampSplit.X),
 				new CellRamp(Type, tl: RampCornerHeight.Half, br: RampCornerHeight.Half, split: RampSplit.X),
 			};
+
+			RampsRots = new WRot[Ramps.Length];
+			for (var i = 0; i < Ramps.Length; i++)
+			{
+				RampsRots[i] = new WRot(
+					WAngle.ArcTan(Ramps[i].Corners[3].Z - Ramps[i].Corners[1].Z, Ramps[i].Corners[1].X - Ramps[i].Corners[3].X),
+					WAngle.ArcTan(Ramps[i].Corners[0].Z - Ramps[i].Corners[2].Z, Ramps[i].Corners[2].Y - Ramps[i].Corners[0].Y),
+					WAngle.Zero);
+			}
 
 			TilesByDistance = CreateTilesByDistance();
 		}

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -518,6 +518,10 @@ namespace OpenRA.Mods.Common.Activities
 			protected override MovePart OnComplete(Actor self, Mobile mobile, Move parent)
 			{
 				var map = self.World.Map;
+
+				var rampType = self.World.Map.Rules.TerrainInfo.GetTerrainInfo(self.World.Map.Tiles[mobile.ToCell]).RampType;
+				mobile.RampOrientation = map.Grid.RampsRots[rampType];
+
 				var fromSubcellOffset = map.Grid.OffsetOfSubCell(mobile.FromSubCell);
 				var toSubcellOffset = map.Grid.OffsetOfSubCell(mobile.ToSubCell);
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -177,6 +177,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		WAngle oldFacing;
 		WRot orientation;
+		public WRot RampOrientation { get; set; }
 		WPos oldPos;
 		CPos fromCell, toCell;
 		public SubCell FromSubCell, ToSubCell;
@@ -203,7 +204,7 @@ namespace OpenRA.Mods.Common.Traits
 			set => orientation = orientation.WithYaw(value);
 		}
 
-		public WRot Orientation => orientation;
+		public WRot Orientation => orientation.Rotate(RampOrientation);
 
 		public WAngle TurnSpeed => Info.TurnSpeed;
 


### PR DESCRIPTION
# Add the rotate of the vehicle on ramp

![2021-03-18_20-41-28](https://user-images.githubusercontent.com/42258154/111634966-fa5b6200-8831-11eb-9ef5-05be84159f6f.gif)

The angle of rotation looks a bit too big , because the height of each layer of the terrain grid should be 418, not 724. 
Find more information at #18993 