### PR TITLE
Replace last uses of 'seconds' with ticks in world simulation

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForPowerOutage.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForPowerOutage.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public readonly BitSet<TargetableType> Types = default(BitSet<TargetableType>);
 
 		[Desc("Measured in ticks.")]
-		public readonly int Duration = 25 * 20;
+		public readonly int Duration = 500;
 
 		[NotificationReference("Speech")]
 		[Desc("Sound the victim will hear when they get sabotaged.")]

--- a/OpenRA.Mods.Common/Scripting/Global/BeaconGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/BeaconGlobal.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Creates a new beacon that stays for the specified time at the specified WPos. " +
 			"Does not remove player set beacons, nor gets removed by placing them. " +
 			"Requires the 'PlaceBeacon' trait on the player actor.")]
-		public void New(Player owner, WPos position, int duration = 30 * 25, bool showRadarPings = true)
+		public void New(Player owner, WPos position, int duration = 750, bool showRadarPings = true)
 		{
 			var beacon = owner.PlayerActor.Info.TraitInfoOrDefault<PlaceBeaconInfo>();
 			if (beacon == null)

--- a/OpenRA.Mods.Common/Scripting/Global/RadarGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/RadarGlobal.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Scripting
 		}
 
 		[Desc("Creates a new radar ping that stays for the specified time at the specified WPos.")]
-		public void Ping(Player player, WPos position, Color color, int duration = 30 * 25)
+		public void Ping(Player player, WPos position, Color color, int duration = 750)
 		{
 			radarPings?.Add(() => player.World.RenderPlayer == player, position, color, duration);
 		}

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -20,9 +20,9 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public class CrateInfo : TraitInfo, IPositionableInfo, Requires<RenderSpritesInfo>
 	{
-		[Desc("Length of time (in seconds) until the crate gets removed automatically. " +
+		[Desc("Length of time (in ticks) until the crate gets removed automatically. " +
 			"A value of zero disables auto-removal.")]
-		public readonly int Lifetime = 0;
+		public readonly int Duration = 0;
 
 		[Desc("Allowed to land on.")]
 		public readonly HashSet<string> TerrainTypes = new HashSet<string>();
@@ -171,7 +171,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ITick.Tick(Actor self)
 		{
-			if (info.Lifetime != 0 && self.IsInWorld && ++ticks >= info.Lifetime * 25)
+			if (info.Duration != 0 && self.IsInWorld && ++ticks >= info.Duration)
 				self.Dispose();
 		}
 
@@ -215,7 +215,7 @@ namespace OpenRA.Mods.Common.Traits
 			self.World.ActorMap.AddInfluence(self, this);
 		}
 
-		public bool IsLeavingCell(CPos location, SubCell subCell = SubCell.Any) { return self.Location == location && ticks + 1 == info.Lifetime * 25; }
+		public bool IsLeavingCell(CPos location, SubCell subCell = SubCell.Any) { return self.Location == location && ticks + 1 == info.Duration; }
 		public SubCell GetValidSubCell(SubCell preferred = SubCell.Any) { return SubCell.FullCell; }
 		public SubCell GetAvailableSubCell(CPos cell, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
 		{

--- a/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int PanicChance = 100;
 
 		[Desc("How long (in ticks) the actor should panic for.")]
-		public readonly int PanicLength = 25 * 10;
+		public readonly int PanicLength = 250;
 
 		[Desc("Panic movement speed as a percentage of the normal speed.")]
 		public readonly int PanicSpeedModifier = 200;

--- a/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int PanicChance = 100;
 
 		[Desc("How long (in ticks) the actor should panic for.")]
-		public readonly int PanicLength = 250;
+		public readonly int PanicDuration = 250;
 
 		[Desc("Panic movement speed as a percentage of the normal speed.")]
 		public readonly int PanicSpeedModifier = 200;
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!Panicking)
 				return;
 
-			if (self.World.WorldTick >= panicStartedTick + info.PanicLength)
+			if (self.World.WorldTick >= panicStartedTick + info.PanicDuration)
 			{
 				self.CancelActivity();
 				panicStartedTick = 0;

--- a/OpenRA.Mods.Common/Traits/Player/BaseAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/BaseAttackNotifier.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly Color RadarPingColor = Color.Red;
 
 		[Desc("Length of time (in ticks) to display a location ping in the minimap.")]
-		public readonly int RadarPingDuration = 10 * 25;
+		public readonly int RadarPingDuration = 250;
 
 		[NotificationReference("Speech")]
 		[Desc("The audio notification type to play.")]

--- a/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly Color RadarPingColor = Color.Red;
 
 		[Desc("Length of time (in ticks) to display a location ping in the minimap.")]
-		public readonly int RadarPingDuration = 10 * 25;
+		public readonly int RadarPingDuration = 250;
 
 		[NotificationReference("Speech")]
 		[Desc("The audio notification type to play.")]

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("A beacon that is constructed from a circle sprite that is animated once and a moving arrow sprite.")]
 	public class PlaceBeaconInfo : TraitInfo
 	{
-		public readonly int Duration = 30 * 25;
+		public readonly int Duration = 750;
 
 		public readonly string NotificationType = "Sounds";
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool DisplayRadarPing = false;
 
 		[Desc("Measured in ticks.")]
-		public readonly int RadarPingDuration = 5 * 25;
+		public readonly int RadarPingDuration = 125;
 
 		public readonly string OrderName;
 

--- a/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int Maximum = 255;
 
 		[Desc("Average time (ticks) between crate spawn.")]
-		public readonly int SpawnInterval = 180 * 25;
+		public readonly int SpawnInterval = 4500;
 
 		[Desc("Delay (in ticks) before the first crate spawns.")]
 		public readonly int InitialSpawnDelay = 0;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20201213/ReplaceCrateSecondsWithTicks.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20201213/ReplaceCrateSecondsWithTicks.cs
@@ -1,0 +1,45 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class ReplaceCrateSecondsWithTicks : UpdateRule
+	{
+		public override string Name => "Changed Crate Lifetime to Duration and use ticks and renamed PanicLength to PanicDuration.";
+
+		public override string Description =>
+			"Crate.Lifetime was the last non-sound-related place to still use 'seconds'\n" +
+			"by multiplying with 25 internally. Converted to use ticks like everything else.\n" +
+			"Also renamed Lifetime to Duration and ScaredyCat.PanicLength to PanicDuration to match other places.";
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var crateNode in actorNode.ChildrenMatching("Crate"))
+			{
+				foreach (var lifetimeNode in crateNode.ChildrenMatching("Lifetime"))
+				{
+					var lifetime = lifetimeNode.NodeValue<int>();
+					lifetimeNode.Value.Value = FieldSaver.FormatValue(lifetime * 25);
+					lifetimeNode.RenameKey("Duration");
+				}
+			}
+
+			foreach (var scNode in actorNode.ChildrenMatching("ScaredyCat"))
+			{
+				scNode.RenameChildrenMatching("PanicLength", "PanicDuration");
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -94,6 +94,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveResourceType(),
 				new ConvertBoundsToWDist(),
 				new RemoveSmokeTrailWhenDamaged(),
+				new ReplaceCrateSecondsWithTicks(),
 			})
 		};
 

--- a/mods/cnc/rules/misc.yaml
+++ b/mods/cnc/rules/misc.yaml
@@ -5,7 +5,7 @@ CRATE.plain:
 CRATE:
 	Inherits: ^Crate
 	Crate:
-		Lifetime: 240
+		Duration: 6000
 	GiveCashCrateAction:
 		Amount: 1000
 		SelectionShares: 20

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -3,7 +3,7 @@ crate:
 	Tooltip:
 		Name: Crate
 	Crate:
-		Lifetime: 120
+		Duration: 3000
 		TerrainTypes: Sand, Rock, Transition, Spice, SpiceSand, Dune, Concrete
 	GiveCashCrateAction@1:
 		Amount: 750

--- a/mods/ra/rules/campaign-rules.yaml
+++ b/mods/ra/rules/campaign-rules.yaml
@@ -56,7 +56,7 @@ HARV:
 
 ^Crate:
 	Crate:
-		Lifetime: 0
+		Duration: 0
 
 MONEYCRATE:
 	Tooltip:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -1129,7 +1129,7 @@
 		GenericName: Crate
 		ShowOwnerRow: false
 	Crate:
-		Lifetime: 180
+		Duration: 4500
 		TerrainTypes: Clear, Rough, Road, Ore, Beach, Water
 	RenderSprites:
 		Palette: effect

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -458,7 +458,7 @@
 	Tooltip:
 		Name: Crate
 	Crate:
-		Lifetime: 180
+		Duration: 4500
 		TerrainTypes: Clear, Rough, Sand, Road, DirtRoad, Tiberium, BlueTiberium, Veins, Green, Pavement
 	RenderSprites:
 		Palette: terraindecoration


### PR DESCRIPTION
This was long overdue.