### PR TITLE
FindAndDeliverResources, do not add self location twice to path search.

### DIFF
--- a/OpenRA.Game/CPos.cs
+++ b/OpenRA.Game/CPos.cs
@@ -51,7 +51,7 @@ namespace OpenRA
 		public static CVec operator -(CPos a, CPos b) { return new CVec(a.X - b.X, a.Y - b.Y); }
 
 		public static bool operator ==(CPos me, CPos other) { return me.Bits == other.Bits; }
-		public static bool operator !=(CPos me, CPos other) { return !(me == other); }
+		public static bool operator !=(CPos me, CPos other) { return me.Bits != other.Bits; }
 
 		public override int GetHashCode() { return Bits.GetHashCode(); }
 

--- a/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
+++ b/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
@@ -154,10 +154,10 @@ namespace OpenRA.Mods.Common.Traits
 			while (toProcess.Any())
 			{
 				var current = toProcess.Pop();
-				if (!transientConnections.ContainsKey(current))
+				if (!transientConnections.TryGetValue(current, out var conns))
 					continue;
 
-				foreach (var neighbor in transientConnections[current])
+				foreach (var neighbor in conns)
 				{
 					if (neighbor == d2)
 						return true;


### PR DESCRIPTION

Fix. In `ClosestHarvestablePos` do not add `self.Location` twice as `StartPoint` for path finding. 

Resulting in  `PathSearch.Expand` to not consider the location twice - avoiding the need to calculation neighbor connections and cost once more.

Additional minor optimizations by reordering logic.

No functional changes intended. Tested with a very brief replay.


