### PR TITLE
Reduce excessive logging in debug.log and perf.log

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -606,8 +606,6 @@ namespace OpenRA
 					{
 						++orderManager.LocalFrameNumber;
 
-						Log.Write("debug", "--Tick: {0} ({1})", LocalTick, isNetTick ? "net" : "local");
-
 						if (isNetTick)
 							orderManager.Tick();
 

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -132,6 +132,9 @@ namespace OpenRA
 		[Desc("Enable the chat field during replays to allow use of console commands.")]
 		public bool EnableDebugCommandsInReplays = false;
 
+		[Desc("Enable perf.log output for traits, activities and effects.")]
+		public bool EnableSimulationPerfLogging = false;
+
 		[Desc("Amount of time required for triggering perf.log output.")]
 		public float LongTickThresholdMs = 1;
 

--- a/OpenRA.Game/Support/PerfTickLogger.cs
+++ b/OpenRA.Game/Support/PerfTickLogger.cs
@@ -1,0 +1,48 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Diagnostics;
+
+namespace OpenRA.Support
+{
+	public sealed class PerfTickLogger
+	{
+		readonly DebugSettings settings = Game.Settings.Debug;
+		readonly long threshold = PerfTimer.LongTickThresholdInStopwatchTicks;
+		long start;
+		long current;
+		bool enabled;
+
+		long CurrentTimestamp => enabled ? Stopwatch.GetTimestamp() : 0L;
+
+		public void Start()
+		{
+			enabled = settings.EnableSimulationPerfLogging;
+			start = CurrentTimestamp;
+		}
+
+		public void LogTickAndRestartTimer(string name, object item)
+		{
+			if (!enabled)
+				return;
+
+			current = CurrentTimestamp;
+			if (current - start > threshold)
+			{
+				PerfTimer.LogLongTick(start, current, name, item);
+				start = CurrentTimestamp;
+				return;
+			}
+
+			start = current;
+		}
+	}
+}

--- a/OpenRA.Game/TraitDictionary.cs
+++ b/OpenRA.Game/TraitDictionary.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Support;
@@ -146,6 +145,7 @@ namespace OpenRA
 		{
 			readonly List<Actor> actors = new List<Actor>();
 			readonly List<T> traits = new List<T>();
+			readonly PerfTickLogger perfLogger = new PerfTickLogger();
 
 			public int Queries { get; private set; }
 
@@ -298,21 +298,14 @@ namespace OpenRA
 
 			public void ApplyToAllTimed(Action<Actor, T> action, string text)
 			{
-				var longTickThresholdInStopwatchTicks = PerfTimer.LongTickThresholdInStopwatchTicks;
-				var start = Stopwatch.GetTimestamp();
+				perfLogger.Start();
 				for (var i = 0; i < actors.Count; i++)
 				{
 					var actor = actors[i];
 					var trait = traits[i];
 					action(actor, trait);
-					var current = Stopwatch.GetTimestamp();
-					if (current - start > longTickThresholdInStopwatchTicks)
-					{
-						PerfTimer.LogLongTick(start, current, text, trait);
-						start = Stopwatch.GetTimestamp();
-					}
-					else
-						start = current;
+
+					perfLogger.LogTickAndRestartTimer(text, trait);
 				}
 			}
 		}

--- a/OpenRA.Game/TraitDictionary.cs
+++ b/OpenRA.Game/TraitDictionary.cs
@@ -161,6 +161,7 @@ namespace OpenRA
 				var result = GetOrDefault(actor);
 				if (result == null)
 					throw new InvalidOperationException("Actor {0} does not have trait of type `{1}`".F(actor.Info.Name, typeof(T)));
+
 				return result;
 			}
 
@@ -169,10 +170,12 @@ namespace OpenRA
 				++Queries;
 				var index = actors.BinarySearchMany(actor.ActorID);
 				if (index >= actors.Count || actors[index] != actor)
-					return default(T);
-				else if (index + 1 < actors.Count && actors[index + 1] == actor)
+					return default;
+
+				if (index + 1 < actors.Count && actors[index + 1] == actor)
 					throw new InvalidOperationException("Actor {0} has multiple traits of type `{1}`".F(actor.Info.Name, typeof(T)));
-				else return traits[index];
+
+				return traits[index];
 			}
 
 			public IEnumerable<T> GetMultiple(uint actor)
@@ -229,6 +232,7 @@ namespace OpenRA
 					var current = actors[i];
 					if (current == last)
 						continue;
+
 					yield return current;
 					last = current;
 				}
@@ -244,6 +248,7 @@ namespace OpenRA
 					var current = actors[i];
 					if (current == last || !predicate(traits[i]))
 						continue;
+
 					yield return current;
 					last = current;
 				}
@@ -282,9 +287,11 @@ namespace OpenRA
 				var startIndex = actors.BinarySearchMany(actor);
 				if (startIndex >= actors.Count || actors[startIndex].ActorID != actor)
 					return;
+
 				var endIndex = startIndex + 1;
 				while (endIndex < actors.Count && actors[endIndex].ActorID == actor)
 					endIndex++;
+
 				var count = endIndex - startIndex;
 				actors.RemoveRange(startIndex, count);
 				traits.RemoveRange(startIndex, count);

--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -224,11 +224,6 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (RemoveOnDeath)
 					self.Dispose();
-
-				if (attacker == null)
-					Log.Write("debug", "{0} #{1} was killed.", self.Info.Name, self.ActorID);
-				else
-					Log.Write("debug", "{0} #{1} killed by {2} #{3}", self.Info.Name, self.ActorID, attacker.Info.Name, attacker.ActorID);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithCargoPipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithCargoPipsDecoration.cs
@@ -67,11 +67,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 				var pi = c.Info.TraitInfo<PassengerInfo>();
 				if (n < pi.Weight)
 				{
-					var sequence = Info.FullSequence;
-					if (pi.CustomPipType != null && !Info.CustomPipSequences.TryGetValue(pi.CustomPipType, out sequence))
-						Log.Write("debug", "Actor type {0} defines a custom pip type {1} that is not defined for actor type {2}".F(c.Info.Name, pi.CustomPipType, self.Info.Name));
+					if (pi.CustomPipType != null && Info.CustomPipSequences.TryGetValue(pi.CustomPipType, out var sequence))
+						return sequence;
 
-					return sequence;
+					return Info.FullSequence;
 				}
 
 				n -= pi.Weight;

--- a/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs
+++ b/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (subjectClient == null)
 			{
-				Log.Write("debug", "Order sent to {0}: resolved ClientIndex `{1}` doesn't exist", order.Subject.Owner.PlayerName, subjectClientId);
+				Log.Write("debug", "Tick {0}: Order sent to {1}: resolved ClientIndex `{2}` doesn't exist", world.WorldTick, order.Subject.Owner.PlayerName, subjectClientId);
 				return false;
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/AdvancedSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/AdvancedSettingsLogic.cs
@@ -53,6 +53,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SettingsUtils.BindCheckboxPref(panel, "REPLAY_COMMANDS_CHECKBOX", ds, "EnableDebugCommandsInReplays");
 			SettingsUtils.BindCheckboxPref(panel, "CHECKUNSYNCED_CHECKBOX", ds, "SyncCheckUnsyncedCode");
 			SettingsUtils.BindCheckboxPref(panel, "CHECKBOTSYNC_CHECKBOX", ds, "SyncCheckBotModuleCode");
+			SettingsUtils.BindCheckboxPref(panel, "PERFLOGGING_CHECKBOX", ds, "EnableSimulationPerfLogging");
 
 			panel.Get("DEBUG_OPTIONS").IsVisible = () => ds.DisplayDeveloperSettings;
 			panel.Get("DEBUG_HIDDEN_LABEL").IsVisible = () => !ds.DisplayDeveloperSettings;
@@ -79,6 +80,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ds.SendSystemInformation = dds.SendSystemInformation;
 				ds.CheckVersion = dds.CheckVersion;
 				ds.EnableDebugCommandsInReplays = dds.EnableDebugCommandsInReplays;
+				ds.EnableSimulationPerfLogging = dds.EnableSimulationPerfLogging;
 			};
 		}
 	}

--- a/mods/cnc/chrome/settings-advanced.yaml
+++ b/mods/cnc/chrome/settings-advanced.yaml
@@ -121,3 +121,10 @@ Container@ADVANCED_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Enable Debug Commands in Replays
+				Checkbox@PERFLOGGING_CHECKBOX:
+					X: 310
+					Y: 273
+					Width: 300
+					Height: 20
+					Font: Regular
+					Text: Enable Tick Performance Logging

--- a/mods/common/chrome/settings-advanced.yaml
+++ b/mods/common/chrome/settings-advanced.yaml
@@ -115,3 +115,10 @@ Container@ADVANCED_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Enable Debug Commands in Replays
+				Checkbox@PERFLOGGING_CHECKBOX:
+					X: 310
+					Y: 273
+					Width: 300
+					Height: 20
+					Font: Regular
+					Text: Enable Tick Performance Logging


### PR DESCRIPTION
Following https://github.com/OpenRA/OpenRA/issues/19029#issuecomment-803683420, this PR is meant to complement #19264 and/or other solutions to hopefully solve #19260 for good.

While having as much information as possible available to debug any crashes is generally valuable, the amount of of logging we do seems excessive for the purpose it's mean to serve.

Logging the `--Tick` in `debug.log` seems mostly pointless, as the few kinds of potential crash sources getting logged in debug.log either happen at/before game start, or can include the world tick in their log entry.

Meanwhile, the perf.log of players rarely shows us devs anything we don't already know (except infinite loops when their cost exceeds the threshold, but that's a poor excuse to drag down performance for players).

Additionally, in both cases developers can still set their preferred value in settings.yaml and run a provided replay to get the needed information, if necessary.