### PR TITLE
fix AreaBeam + GrantExternalConditionWarhead bug

### DIFF
--- a/OpenRA.Mods.Common/Warheads/GrantExternalConditionWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/GrantExternalConditionWarhead.cs
@@ -30,6 +30,10 @@ namespace OpenRA.Mods.Common.Warheads
 		public override void DoImpact(in Target target, WarheadArgs args)
 		{
 			var firedBy = args.SourceActor;
+
+			if (target.Type == TargetType.Invalid)
+				return;
+
 			var actors = target.Type == TargetType.Actor ? new[] { target.Actor } :
 				firedBy.World.FindActorsInCircle(target.CenterPosition, Range);
 

--- a/OpenRA.Mods.Common/Warheads/GrantExternalConditionWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/GrantExternalConditionWarhead.cs
@@ -30,6 +30,11 @@ namespace OpenRA.Mods.Common.Warheads
 		public override void DoImpact(in Target target, WarheadArgs args)
 		{
 			var firedBy = args.SourceActor;
+
+			if (target.Type == TargetType.Invalid) {
+				return;
+			}
+
 			var actors = target.Type == TargetType.Actor ? new[] { target.Actor } :
 				firedBy.World.FindActorsInCircle(target.CenterPosition, Range);
 

--- a/OpenRA.Mods.Common/Warheads/GrantExternalConditionWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/GrantExternalConditionWarhead.cs
@@ -31,9 +31,8 @@ namespace OpenRA.Mods.Common.Warheads
 		{
 			var firedBy = args.SourceActor;
 
-			if (target.Type == TargetType.Invalid) {
+			if (target.Type == TargetType.Invalid)
 				return;
-			}
 
 			var actors = target.Type == TargetType.Actor ? new[] { target.Actor } :
 				firedBy.World.FindActorsInCircle(target.CenterPosition, Range);

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -1048,14 +1048,17 @@ palace:
 		Prerequisite: palace.sardaukar
 		Factions: corrino
 	PrimaryBuilding:
-		RequiresCondition: atreides || ordos
+		PrimaryCondition: primary
 	WithTextDecoration@primary:
-		RequiresCondition: primary && (atreides || ordos)
+		RequiresSelection: true
+		Text: PRIMARY
+		ReferencePoint: Top
+		ZOffset: 256
+		RequiresCondition: primary
 	NukePower:
 		Cursor: nuke
 		Icon: deathhand
 		PauseOnCondition: disabled
-		RequiresCondition: harkonnen
 		Prerequisites: ~techlevel.superweapons, ~palace.nuke
 		ChargeInterval: 7500
 		Description: Death Hand
@@ -1073,20 +1076,18 @@ palace:
 		CameraRange: 10c0
 		ArrowSequence: arrow
 		CircleSequence: circles
-		FlightVelocity: 384
-		TrailInterval: 0
-		TrailImage: large_trail
-		TrailSequences: idle
-		SupportPowerPaletteOrder: 40
+	WithNukeLaunchOverlay:
+		RequiresCondition: !launchpad-damaged
+	GrantConditionOnDamageState@LAUNCHPADDAMAGED:
+		Condition: launchpad-damaged
 	ProduceActorPower@fremen:
 		Description: Recruit Fremen
 		LongDesc: Elite infantry unit armed with assault rifles and rockets\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery\n  Special Ability: Invisibility
 		Icon: fremen
 		PauseOnCondition: disabled
-		RequiresCondition: atreides
 		Prerequisites: ~techlevel.superweapons, ~palace.fremen
 		Actors: fremen, fremen
-		Type: Fremen
+		Type: Palace
 		ChargeInterval: 2250
 		ReadyAudio: Reinforce
 		BlockedAudio: NoRoom
@@ -1097,10 +1098,9 @@ palace:
 		LongDesc: Sneaky infantry, armed with explosives\n  Strong vs Buildings\n  Weak vs Everything\n  Special Ability: destroy buildings
 		Icon: saboteur
 		PauseOnCondition: disabled
-		RequiresCondition: ordos
 		Prerequisites: ~techlevel.superweapons, ~palace.saboteur
 		Actors: saboteur
-		Type: Saboteur
+		Type: Palace
 		ChargeInterval: 2250
 		ReadyAudio: Reinforce
 		BlockedAudio: NoRoom
@@ -1115,23 +1115,9 @@ palace:
 	Exit@3:
 		SpawnOffset: -704,768,0
 		ExitCell: 0,3
-	Production@Atreides:
-		Produces: Fremen
-		RequiresCondition: atreides
-	Production@Ordos:
-		Produces: Saboteur
-		RequiresCondition: ordos
-	GrantConditionOnFaction@Atreides:
-		Condition: atreides
-		Factions: atreides, fremen
-	GrantConditionOnFaction@Harkonnen:
-		Condition: harkonnen
-		Factions: harkonnen
-	GrantConditionOnFaction@Ordos:
-		Condition: ordos
-		Factions: ordos, mercenary, smuggler
+	Production:
+		Produces: Palace
 	SupportPowerChargeBar:
-		RequiresCondition: atreides || harkonnen || ordos
 	ProvidesPrerequisite@buildingname:
 
 conyard.atreides:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -1048,17 +1048,14 @@ palace:
 		Prerequisite: palace.sardaukar
 		Factions: corrino
 	PrimaryBuilding:
-		PrimaryCondition: primary
+		RequiresCondition: atreides || ordos
 	WithTextDecoration@primary:
-		RequiresSelection: true
-		Text: PRIMARY
-		ReferencePoint: Top
-		ZOffset: 256
-		RequiresCondition: primary
+		RequiresCondition: primary && (atreides || ordos)
 	NukePower:
 		Cursor: nuke
 		Icon: deathhand
 		PauseOnCondition: disabled
+		RequiresCondition: harkonnen
 		Prerequisites: ~techlevel.superweapons, ~palace.nuke
 		ChargeInterval: 7500
 		Description: Death Hand
@@ -1076,18 +1073,20 @@ palace:
 		CameraRange: 10c0
 		ArrowSequence: arrow
 		CircleSequence: circles
-	WithNukeLaunchOverlay:
-		RequiresCondition: !launchpad-damaged
-	GrantConditionOnDamageState@LAUNCHPADDAMAGED:
-		Condition: launchpad-damaged
+		FlightVelocity: 384
+		TrailInterval: 0
+		TrailImage: large_trail
+		TrailSequences: idle
+		SupportPowerPaletteOrder: 40
 	ProduceActorPower@fremen:
 		Description: Recruit Fremen
 		LongDesc: Elite infantry unit armed with assault rifles and rockets\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery\n  Special Ability: Invisibility
 		Icon: fremen
 		PauseOnCondition: disabled
+		RequiresCondition: atreides
 		Prerequisites: ~techlevel.superweapons, ~palace.fremen
 		Actors: fremen, fremen
-		Type: Palace
+		Type: Fremen
 		ChargeInterval: 2250
 		ReadyAudio: Reinforce
 		BlockedAudio: NoRoom
@@ -1098,9 +1097,10 @@ palace:
 		LongDesc: Sneaky infantry, armed with explosives\n  Strong vs Buildings\n  Weak vs Everything\n  Special Ability: destroy buildings
 		Icon: saboteur
 		PauseOnCondition: disabled
+		RequiresCondition: ordos
 		Prerequisites: ~techlevel.superweapons, ~palace.saboteur
 		Actors: saboteur
-		Type: Palace
+		Type: Saboteur
 		ChargeInterval: 2250
 		ReadyAudio: Reinforce
 		BlockedAudio: NoRoom
@@ -1115,9 +1115,23 @@ palace:
 	Exit@3:
 		SpawnOffset: -704,768,0
 		ExitCell: 0,3
-	Production:
-		Produces: Palace
+	Production@Atreides:
+		Produces: Fremen
+		RequiresCondition: atreides
+	Production@Ordos:
+		Produces: Saboteur
+		RequiresCondition: ordos
+	GrantConditionOnFaction@Atreides:
+		Condition: atreides
+		Factions: atreides, fremen
+	GrantConditionOnFaction@Harkonnen:
+		Condition: harkonnen
+		Factions: harkonnen
+	GrantConditionOnFaction@Ordos:
+		Condition: ordos
+		Factions: ordos, mercenary, smuggler
 	SupportPowerChargeBar:
+		RequiresCondition: atreides || harkonnen || ordos
 	ProvidesPrerequisite@buildingname:
 
 conyard.atreides:


### PR DESCRIPTION
this PR fixes a crash that occurs, when a unit kills another unit with AreaBeam and applies an external condition. 

Thx @Smittytron for the guide, it helped a lot, the reordering of git history did not happen anymore, however I have some very old revert in here, that I have reverted again :D 
The problem is that Github does not let me fork OpenRA/OpenRA because I have already forked Inq8/OpenRA. I hope this is ok now.