### PR TITLE
Remove CivilianKilled notification default from TD

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -472,9 +472,6 @@
 		Range: 2c0
 	Passenger:
 		CustomPipType: gray
-	ActorLostNotification:
-		Notification: CivilianKilled
-		NotifyAll: true
 	ScaredyCat:
 		AvoidTerrainTypes: Tiberium, BlueTiberium
 	Crushable:


### PR DESCRIPTION
This removes the global `CivilianKilled `notification from every civilian death. This notification doesn't make sense as a global default as several Nod missions require the player to kill civilians. It's also annoying in multiplayer. If there is a specific GDI mission with a protect civilians objective it should be added there.

Closes #8530