### PR TITLE
Remove rcedit after building windows packages.

### DIFF
--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -86,3 +86,4 @@ function build_platform()
 
 build_platform "x86"
 build_platform "x64"
+rm rcedit-x64.exe


### PR DESCRIPTION
Supersedes #19192.