### PR TITLE
Allow BuildingInfluence to track overlapping buildings in the same cell. 

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/World/TSResourceLayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSResourceLayer.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			var blockedByNeighbours = Map.Ramp[cell] == 0 && !Common.Util.ExpandFootprint(cell, false)
 				.All(c => check(cell, c));
 
-			return !blockedByNeighbours && (resourceType == info.VeinType || BuildingInfluence.GetBuildingAt(cell) == null);
+			return !blockedByNeighbours && (resourceType == info.VeinType || !BuildingInfluence.AnyBuildingAt(cell));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -180,10 +180,24 @@ namespace OpenRA.Mods.Common.Traits
 			return null;
 		}
 
-		bool ActorGrantsValidArea(Actor a, RequiresBuildableAreaInfo rba)
+		static bool AnyGivesBuildableArea(IEnumerable<Actor> actors, Player p, bool allyBuildEnabled, RequiresBuildableAreaInfo rba)
 		{
-			return rba.AreaTypes.Overlaps(a.TraitsImplementing<GivesBuildableArea>()
-				.SelectMany(gba => gba.AreaTypes));
+			foreach (var a in actors)
+			{
+				if (!a.IsInWorld)
+					continue;
+
+				if (a.Owner != p && (!allyBuildEnabled || a.Owner.RelationshipWith(p) != PlayerRelationship.Ally))
+					continue;
+
+				var overlaps = rba.AreaTypes.Overlaps(a.TraitsImplementing<GivesBuildableArea>()
+					.SelectMany(gba => gba.AreaTypes));
+
+				if (overlaps)
+					return true;
+			}
+
+			return false;
 		}
 
 		public virtual bool IsCloseEnoughToBase(World world, Player p, ActorInfo ai, CPos topLeft)
@@ -211,21 +225,17 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				for (var x = scanStart.X; x < scanEnd.X; x++)
 				{
-					var pos = new CPos(x, y);
-					var buildingAtPos = bi.GetBuildingAt(pos);
-
-					if (buildingAtPos == null)
+					var c = new CPos(x, y);
+					if (AnyGivesBuildableArea(world.ActorMap.GetActorsAt(c), p, allyBuildEnabled, requiresBuildableArea))
 					{
-						var unitsAtPos = world.ActorMap.GetActorsAt(pos).Where(a => a.IsInWorld
-							&& (a.Owner == p || (allyBuildEnabled && a.Owner.RelationshipWith(p) == PlayerRelationship.Ally))
-							&& ActorGrantsValidArea(a, requiresBuildableArea));
-
-						if (unitsAtPos.Any())
-							nearnessCandidates.Add(pos);
+						nearnessCandidates.Add(c);
+						continue;
 					}
-					else if (buildingAtPos.IsInWorld && ActorGrantsValidArea(buildingAtPos, requiresBuildableArea)
-						&& (buildingAtPos.Owner == p || (allyBuildEnabled && buildingAtPos.Owner.RelationshipWith(p) == PlayerRelationship.Ally)))
-						nearnessCandidates.Add(pos);
+
+					// Building bibs and pathable footprint cells are not included in the ActorMap
+					// TODO: Allow ActorMap to track these and finally remove the BuildingInfluence layer completely
+					if (AnyGivesBuildableArea(new[] { bi.GetBuildingAt(c) }, p, allyBuildEnabled, requiresBuildableArea))
+						nearnessCandidates.Add(c);
 				}
 			}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -234,7 +234,7 @@ namespace OpenRA.Mods.Common.Traits
 
 					// Building bibs and pathable footprint cells are not included in the ActorMap
 					// TODO: Allow ActorMap to track these and finally remove the BuildingInfluence layer completely
-					if (AnyGivesBuildableArea(new[] { bi.GetBuildingAt(c) }, p, allyBuildEnabled, requiresBuildableArea))
+					if (AnyGivesBuildableArea(bi.GetBuildingsAt(c), p, allyBuildEnabled, requiresBuildableArea))
 						nearnessCandidates.Add(c);
 				}
 			}

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
@@ -50,5 +50,10 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			return influence.Contains(cell) ? influence[cell] : null;
 		}
+
+		public bool AnyBuildingAt(CPos cell)
+		{
+			return influence.Contains(cell) && influence[cell] != null;
+		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
@@ -54,8 +54,8 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				// Replacements are enabled and the cell contained at least one (not ignored) actor or building bib
-				var building = world.WorldActor.Trait<BuildingInfluence>().GetBuildingAt(cell);
-				if (foundActors || building != null)
+				var foundBuilding = world.WorldActor.Trait<BuildingInfluence>().AnyBuildingAt(cell);
+				if (foundActors || foundBuilding)
 				{
 					// The cell contains at least one actor, and none were replaceable
 					if (acceptedReplacements == null)
@@ -73,8 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				// HACK: To preserve legacy behaviour, AllowInvalidPlacement should display red placement indicators
 				// if (and only if) there is a building or bib in the cell
-				var building = world.WorldActor.Trait<BuildingInfluence>().GetBuildingAt(cell);
-				if (building != null)
+				if (world.WorldActor.Trait<BuildingInfluence>().AnyBuildingAt(cell))
 					return false;
 			}
 

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -178,7 +178,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!resourceInfo.AllowedTerrainTypes.Contains(Map.GetTerrainInfo(cell).Type))
 				return false;
 
-			return BuildingInfluence.GetBuildingAt(cell) == null;
+			return !BuildingInfluence.AnyBuildingAt(cell);
 		}
 
 		ResourceLayerContents CreateResourceCell(string resourceType, CPos cell, int density)

--- a/OpenRA.Mods.D2k/Traits/Buildings/D2kBuilding.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/D2kBuilding.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.D2k.Traits.Buildings
 							continue;
 
 						// Don't place under other buildings (or their bib)
-						if (bi.GetBuildingAt(c) != self)
+						if (bi.GetBuildingsAt(c).Any(a => a != self))
 							continue;
 
 						var index = Game.CosmeticRandom.Next(template.TilesCount);
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.D2k.Traits.Buildings
 							continue;
 
 						// Don't place under other buildings (or their bib)
-						if (bi.GetBuildingAt(c) != self)
+						if (bi.GetBuildingsAt(c).Any(a => a != self))
 							continue;
 
 						layer.AddTile(c, new TerrainTile(template.Id, (byte)i));


### PR DESCRIPTION
This PR implements my take on #19254.

There are two main differences:
* Replaces most uses of `GetBuildingAt` with a new `AnyBuildingAt` and cleaned up the main remaining use of `GetBuildingAt` to make it clearer.
* Implements the influence layer the same way as `ActorMap`, using a linked list.

~~The way `RemoveInfluence` is set up looks like it is expecting `InfluenceNode` to be a struct, but it is (and always has been?) a class. I expect we'll need some additional changes to clean this up.~~