### PR TITLE
Refactor parts of the GameSpeed system

### DIFF
--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -27,7 +27,10 @@ namespace OpenRA.Network
 
 		Queue<Chunk> chunks = new Queue<Chunk>();
 		List<byte[]> sync = new List<byte[]>();
+
+		readonly int orderLatency;
 		int ordersFrame;
+
 		Dictionary<int, int> lastClientsFrame = new Dictionary<int, int>();
 
 		public int LocalClientId => -1;
@@ -122,7 +125,10 @@ namespace OpenRA.Network
 				}
 			}
 
-			ordersFrame = LobbyInfo.GlobalSettings.OrderLatency;
+			var gameSpeeds = Game.ModData.Manifest.Get<GameSpeeds>();
+			var gameSpeedName = LobbyInfo.GlobalSettings.OptionOrDefault("gamespeed", gameSpeeds.DefaultSpeed);
+			orderLatency = gameSpeeds.Speeds[gameSpeedName].OrderLatency;
+			ordersFrame = orderLatency;
 		}
 
 		// Do nothing: ignore locally generated orders
@@ -137,7 +143,7 @@ namespace OpenRA.Network
 			sync.Add(ms.GetBuffer());
 
 			// Store the current frame so Receive() can return the next chunk of orders.
-			ordersFrame = frame + LobbyInfo.GlobalSettings.OrderLatency;
+			ordersFrame = frame + orderLatency;
 		}
 
 		public void Receive(Action<int, byte[]> packetFn)

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -222,8 +222,6 @@ namespace OpenRA.Network
 		{
 			public string ServerName;
 			public string Map;
-			public int Timestep = 40;
-			public int OrderLatency = 3; // net tick frames (x 120 = ms)
 			public int RandomSeed = 0;
 			public bool AllowSpectators = true;
 			public string GameUid;

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -254,7 +254,6 @@ namespace OpenRA.Network
 				case "SyncInfo":
 					{
 						orderManager.LobbyInfo = Session.Deserialize(order.TargetString);
-						SetOrderLag(orderManager);
 						Game.SyncLobbyInfo();
 						break;
 					}
@@ -304,7 +303,6 @@ namespace OpenRA.Network
 								orderManager.LobbyInfo.GlobalSettings = Session.Global.Deserialize(node.Value);
 						}
 
-						SetOrderLag(orderManager);
 						Game.SyncLobbyInfo();
 						break;
 					}
@@ -353,15 +351,6 @@ namespace OpenRA.Network
 
 			if (world.OrderValidators.All(vo => vo.OrderValidation(orderManager, world, clientId, order)))
 				order.Subject.ResolveOrder(order);
-		}
-
-		static void SetOrderLag(OrderManager o)
-		{
-			if (o.FramesAhead != o.LobbyInfo.GlobalSettings.OrderLatency && !o.GameStarted)
-			{
-				o.FramesAhead = o.LobbyInfo.GlobalSettings.OrderLatency;
-				Log.Write("server", "Order lag is now {0} frames.", o.LobbyInfo.GlobalSettings.OrderLatency);
-			}
 		}
 	}
 }

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -1200,10 +1200,6 @@ namespace OpenRA.Server
 					DropClient(c);
 				}
 
-				// HACK: Turn down the latency if there is only one real player
-				if (LobbyInfo.NonBotClients.Count() == 1)
-					LobbyInfo.GlobalSettings.OrderLatency = 1;
-
 				// Enable game saves for singleplayer missions only
 				// TODO: Enable for multiplayer (non-dedicated servers only) once the lobby UI has been created
 				LobbyInfo.GlobalSettings.GameSavesEnabled = Type != ServerType.Dedicated && LobbyInfo.NonBotClients.Count() == 1;

--- a/OpenRA.Mods.Common/Scripting/Global/DateTimeGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/DateTimeGlobal.cs
@@ -20,11 +20,15 @@ namespace OpenRA.Mods.Common.Scripting
 	public class DateGlobal : ScriptGlobal
 	{
 		readonly TimeLimitManager tlm;
+		readonly int ticksPerSecond;
 
 		public DateGlobal(ScriptContext context)
 			: base(context)
 		{
 			tlm = context.World.WorldActor.TraitOrDefault<TimeLimitManager>();
+			var gameSpeeds = Game.ModData.Manifest.Get<GameSpeeds>();
+			var defaultGameSpeed = gameSpeeds.Speeds[gameSpeeds.DefaultSpeed];
+			ticksPerSecond = 1000 / defaultGameSpeed.Timestep;
 		}
 
 		[Desc("True on the 31st of October.")]
@@ -36,7 +40,7 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Converts the number of seconds into game time (ticks).")]
 		public int Seconds(int seconds)
 		{
-			return seconds * 25;
+			return seconds * ticksPerSecond;
 		}
 
 		[Desc("Converts the number of minutes into game time (ticks).")]

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -563,13 +563,6 @@ namespace OpenRA.Mods.Common.Server
 
 				oo.Value = oo.PreferredValue = split[1];
 
-				if (option.Id == "gamespeed")
-				{
-					var speed = server.ModData.Manifest.Get<GameSpeeds>().Speeds[oo.Value];
-					server.LobbyInfo.GlobalSettings.Timestep = speed.Timestep;
-					server.LobbyInfo.GlobalSettings.OrderLatency = speed.OrderLatency;
-				}
-
 				server.SyncLobbyGlobalSettings();
 				server.SendMessage(option.ValueChangedMessage(client.Name, split[1]));
 
@@ -1080,13 +1073,6 @@ namespace OpenRA.Mods.Common.Server
 					state.Value = value;
 					state.PreferredValue = preferredValue;
 					gs.LobbyOptions[o.Id] = state;
-
-					if (o.Id == "gamespeed")
-					{
-						var speed = server.ModData.Manifest.Get<GameSpeeds>().Speeds[value];
-						gs.Timestep = speed.Timestep;
-						gs.OrderLatency = speed.OrderLatency;
-					}
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Common.Traits
 			var randomFactor = world.LocalRandom.Next(0, baseBuilder.Info.StructureProductionRandomBonusDelay);
 
 			// Needs to be at least 4 * OrderLatency because otherwise the AI frequently duplicates build orders (i.e. makes the same build decision twice)
-			waitTicks = active ? 4 * world.LobbyInfo.GlobalSettings.OrderLatency + baseBuilder.Info.StructureProductionActiveDelay + randomFactor
+			waitTicks = active ? 4 * world.OrderLatency + baseBuilder.Info.StructureProductionActiveDelay + randomFactor
 				: baseBuilder.Info.StructureProductionInactiveDelay + randomFactor;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -58,7 +58,6 @@ namespace OpenRA.Mods.Common.Traits
 		int lastIncome;
 		int lastIncomeTick;
 		int ticks;
-		int replayTimestep;
 
 		bool armyGraphDisabled;
 		bool incomeGraphDisabled;
@@ -81,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			ticks++;
 
-			var timestep = self.World.IsReplay ? replayTimestep : self.World.Timestep;
+			var timestep = self.World.Timestep;
 			if (ticks * timestep >= 30000)
 			{
 				ticks = 0;
@@ -124,9 +123,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void WorldLoaded(World w, WorldRenderer wr)
 		{
-			if (w.IsReplay)
-				replayTimestep = w.WorldActor.Trait<MapOptions>().GameSpeed.Timestep;
-
 			if (!armyGraphDisabled)
 				ArmySamples.Add(ArmyValue);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameTimerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameTimerLogic.cs
@@ -26,27 +26,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var tlm = world.WorldActor.TraitOrDefault<TimeLimitManager>();
 			var startTick = Ui.LastTickTime;
 
-			Func<bool> shouldShowStatus = () => (world.Paused || world.Timestep != world.LobbyInfo.GlobalSettings.Timestep)
+			Func<bool> shouldShowStatus = () => (world.Paused || world.ReplayTimestep != world.Timestep)
 				&& (Ui.LastTickTime - startTick) / 1000 % 2 == 0;
 
 			Func<string> statusText = () =>
 			{
-				if (world.Paused || world.Timestep == 0)
+				if (world.Paused || world.ReplayTimestep == 0)
 					return "Paused";
 
-				if (world.Timestep == 1)
+				if (world.ReplayTimestep == 1)
 					return "Max Speed";
 
-				return "{0}% Speed".F(world.LobbyInfo.GlobalSettings.Timestep * 100 / world.Timestep);
+				return "{0}% Speed".F(world.Timestep * 100 / world.ReplayTimestep);
 			};
 
 			if (timer != null)
 			{
-				// Timers in replays should be synced to the effective game time, not the playback time.
-				var timestep = world.Timestep;
-				if (world.IsReplay)
-					timestep = world.WorldActor.Trait<MapOptions>().GameSpeed.Timestep;
-
 				timer.GetText = () =>
 				{
 					if (status == null && shouldShowStatus())
@@ -54,7 +49,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					var timeLimit = tlm?.TimeLimit ?? 0;
 					var displayTick = timeLimit > 0 ? timeLimit - world.WorldTick : world.WorldTick;
-					return WidgetUtils.FormatTime(Math.Max(0, displayTick), timestep);
+					return WidgetUtils.FormatTime(Math.Max(0, displayTick), world.Timestep);
 				};
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ReplayControlBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ReplayControlBarLogic.cs
@@ -46,12 +46,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var originalTimestep = world.Timestep;
 
 				var pauseButton = widget.Get<ButtonWidget>("BUTTON_PAUSE");
-				pauseButton.IsVisible = () => world.Timestep != 0 && orderManager.NetFrameNumber < replayNetTicks;
-				pauseButton.OnClick = () => world.Timestep = 0;
+				pauseButton.IsVisible = () => world.ReplayTimestep != 0 && orderManager.NetFrameNumber < replayNetTicks;
+				pauseButton.OnClick = () => world.ReplayTimestep = 0;
 
 				var playButton = widget.Get<ButtonWidget>("BUTTON_PLAY");
-				playButton.IsVisible = () => world.Timestep == 0 || orderManager.NetFrameNumber >= replayNetTicks;
-				playButton.OnClick = () => world.Timestep = (int)Math.Ceiling(originalTimestep * multipliers[speed]);
+				playButton.IsVisible = () => world.ReplayTimestep == 0 || orderManager.NetFrameNumber >= replayNetTicks;
+				playButton.OnClick = () => world.ReplayTimestep = (int)Math.Ceiling(originalTimestep * multipliers[speed]);
 				playButton.IsDisabled = () => orderManager.NetFrameNumber >= replayNetTicks;
 
 				var slowButton = widget.Get<ButtonWidget>("BUTTON_SLOW");
@@ -60,8 +60,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				slowButton.OnClick = () =>
 				{
 					speed = PlaybackSpeed.Slow;
-					if (world.Timestep != 0)
-						world.Timestep = (int)Math.Ceiling(originalTimestep * multipliers[speed]);
+					if (world.ReplayTimestep != 0)
+						world.ReplayTimestep = (int)Math.Ceiling(originalTimestep * multipliers[speed]);
 				};
 
 				var normalSpeedButton = widget.Get<ButtonWidget>("BUTTON_REGULAR");
@@ -70,8 +70,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				normalSpeedButton.OnClick = () =>
 				{
 					speed = PlaybackSpeed.Regular;
-					if (world.Timestep != 0)
-						world.Timestep = (int)Math.Ceiling(originalTimestep * multipliers[speed]);
+					if (world.ReplayTimestep != 0)
+						world.ReplayTimestep = (int)Math.Ceiling(originalTimestep * multipliers[speed]);
 				};
 
 				var fastButton = widget.Get<ButtonWidget>("BUTTON_FAST");
@@ -80,8 +80,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				fastButton.OnClick = () =>
 				{
 					speed = PlaybackSpeed.Fast;
-					if (world.Timestep != 0)
-						world.Timestep = (int)Math.Ceiling(originalTimestep * multipliers[speed]);
+					if (world.ReplayTimestep != 0)
+						world.ReplayTimestep = (int)Math.Ceiling(originalTimestep * multipliers[speed]);
 				};
 
 				var maximumButton = widget.Get<ButtonWidget>("BUTTON_MAXIMUM");
@@ -90,8 +90,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				maximumButton.OnClick = () =>
 				{
 					speed = PlaybackSpeed.Maximum;
-					if (world.Timestep != 0)
-						world.Timestep = (int)Math.Ceiling(originalTimestep * multipliers[speed]);
+					if (world.ReplayTimestep != 0)
+						world.ReplayTimestep = (int)Math.Ceiling(originalTimestep * multipliers[speed]);
 				};
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -27,7 +27,6 @@ namespace OpenRA.Mods.Common.Widgets
 		public Func<Player> GetPlayer;
 		readonly World world;
 		readonly WorldRenderer worldRenderer;
-		readonly int timestep;
 
 		public int IconWidth = 32;
 		public int IconHeight = 24;
@@ -56,7 +55,6 @@ namespace OpenRA.Mods.Common.Widgets
 			this.world = world;
 			this.worldRenderer = worldRenderer;
 			clocks = new Dictionary<ProductionQueue, Animation>();
-			timestep = world.IsReplay ? world.WorldActor.Trait<MapOptions>().GameSpeed.Timestep : world.Timestep;
 			GetTooltipIcon = () => TooltipIcon;
 			tooltipContainer = Exts.Lazy(() =>
 				Ui.Root.Get<TooltipContainerWidget>(TooltipContainer));
@@ -69,7 +67,6 @@ namespace OpenRA.Mods.Common.Widgets
 			GetPlayer = other.GetPlayer;
 			world = other.world;
 			worldRenderer = other.worldRenderer;
-			timestep = other.timestep;
 			clocks = other.clocks;
 
 			IconWidth = other.IconWidth;
@@ -198,7 +195,7 @@ namespace OpenRA.Mods.Common.Widgets
 			foreach (var icon in productionIcons)
 			{
 				var current = icon.Queued.First();
-				var text = GetOverlayForItem(current, timestep);
+				var text = GetOverlayForItem(current, world.Timestep);
 				tiny.DrawTextWithContrast(text,
 					icon.Pos + new float2(16, 12) - new float2(tiny.Measure(text).X / 2, 0),
 					Color.White, Color.Black, 1);

--- a/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
@@ -26,7 +26,6 @@ namespace OpenRA.Mods.Common.Widgets
 		readonly World world;
 		readonly WorldRenderer worldRenderer;
 		readonly Dictionary<string, Animation> clocks;
-		readonly int timestep;
 
 		readonly Lazy<TooltipContainerWidget> tooltipContainer;
 
@@ -55,11 +54,6 @@ namespace OpenRA.Mods.Common.Widgets
 			this.worldRenderer = worldRenderer;
 			clocks = new Dictionary<string, Animation>();
 
-			// Timers in replays should be synced to the effective game time, not the playback time.
-			timestep = world.Timestep;
-			if (world.IsReplay)
-				timestep = world.WorldActor.Trait<MapOptions>().GameSpeed.Timestep;
-
 			tooltipContainer = Exts.Lazy(() =>
 				Ui.Root.Get<TooltipContainerWidget>(TooltipContainer));
 		}
@@ -72,7 +66,6 @@ namespace OpenRA.Mods.Common.Widgets
 			world = other.world;
 			worldRenderer = other.worldRenderer;
 			clocks = other.clocks;
-			timestep = other.timestep;
 
 			IconWidth = other.IconWidth;
 			IconHeight = other.IconHeight;
@@ -146,7 +139,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var tiny = Game.Renderer.Fonts["Tiny"];
 			foreach (var icon in supportPowerIconsIcons)
 			{
-				var text = GetOverlayForItem(icon.Power, timestep);
+				var text = GetOverlayForItem(icon.Power, world.Timestep);
 				tiny.DrawTextWithContrast(text,
 					icon.Pos + new float2(16, 12) - new float2(tiny.Measure(text).X / 2, 0),
 					Color.White, Color.Black, 1);

--- a/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
@@ -25,7 +25,6 @@ namespace OpenRA.Mods.Common.Widgets
 		public readonly TextAlign Align = TextAlign.Left;
 		public readonly TimerOrder Order = TimerOrder.Descending;
 
-		readonly int timestep;
 		readonly IEnumerable<SupportPowerInstance> powers;
 		readonly Color bgDark, bgLight;
 		(string Text, Color Color)[] texts;
@@ -37,11 +36,6 @@ namespace OpenRA.Mods.Common.Widgets
 				.Where(p => !p.Actor.IsDead && !p.Actor.Owner.NonCombatant)
 				.SelectMany(s => s.Trait.Powers.Values)
 				.Where(p => p.Instances.Any() && p.Info.DisplayTimerRelationships != PlayerRelationship.None && !p.Disabled);
-
-			// Timers in replays should be synced to the effective game time, not the playback time.
-			timestep = world.Timestep;
-			if (world.IsReplay)
-				timestep = world.WorldActor.Trait<MapOptions>().GameSpeed.Timestep;
 
 			bgDark = ChromeMetrics.Get<Color>("TextContrastColorDark");
 			bgLight = ChromeMetrics.Get<Color>("TextContrastColorLight");
@@ -58,9 +52,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 			texts = displayedPowers.Select(p =>
 			{
-				var time = WidgetUtils.FormatTime(p.RemainingTicks, false, timestep);
-				var text = Format.F(p.Info.Description, time);
 				var self = p.Instances[0].Self;
+				var time = WidgetUtils.FormatTime(p.RemainingTicks, false, self.World.Timestep);
+				var text = Format.F(p.Info.Description, time);
 				var playerColor = self.Owner.Color;
 
 				if (Game.Settings.Game.UsePlayerStanceColors)

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -236,30 +236,32 @@ AssetBrowser:
 	SupportedExtensions: .shp, .tem, .des, .sno, .jun, .vqa, .wsa
 
 GameSpeeds:
-	slowest:
-		Name: Slowest
-		Timestep: 80
-		OrderLatency: 2
-	slower:
-		Name: Slower
-		Timestep: 50
-		OrderLatency: 3
-	default:
-		Name: Normal
-		Timestep: 40
-		OrderLatency: 3
-	fast:
-		Name: Fast
-		Timestep: 35
-		OrderLatency: 4
-	faster:
-		Name: Faster
-		Timestep: 30
-		OrderLatency: 4
-	fastest:
-		Name: Fastest
-		Timestep: 20
-		OrderLatency: 6
+	DefaultSpeed: default
+	Speeds:
+		slowest:
+			Name: Slowest
+			Timestep: 80
+			OrderLatency: 2
+		slower:
+			Name: Slower
+			Timestep: 50
+			OrderLatency: 3
+		default:
+			Name: Normal
+			Timestep: 40
+			OrderLatency: 3
+		fast:
+			Name: Fast
+			Timestep: 35
+			OrderLatency: 4
+		faster:
+			Name: Faster
+			Timestep: 30
+			OrderLatency: 4
+		fastest:
+			Name: Fastest
+			Timestep: 20
+			OrderLatency: 6
 
 ColorValidator:
 	TeamColorPresets: f70606, ff7a22, f8d3b3, f8e947, 94b319, f335a0, a64d6c, ce08f9, f5b2db, 12b572, 502048, 1d06f7, 328dff, 78dbf8, cef6b1, 391d1d

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -211,30 +211,32 @@ AssetBrowser:
 	SupportedExtensions: .shp, .r8, .vqa
 
 GameSpeeds:
-	slowest:
-		Name: Slowest
-		Timestep: 80
-		OrderLatency: 2
-	slower:
-		Name: Slower
-		Timestep: 50
-		OrderLatency: 3
-	default:
-		Name: Normal
-		Timestep: 40
-		OrderLatency: 3
-	fast:
-		Name: Fast
-		Timestep: 35
-		OrderLatency: 4
-	faster:
-		Name: Faster
-		Timestep: 30
-		OrderLatency: 4
-	fastest:
-		Name: Fastest
-		Timestep: 20
-		OrderLatency: 6
+	DefaultSpeed: default
+	Speeds:
+		slowest:
+			Name: Slowest
+			Timestep: 80
+			OrderLatency: 2
+		slower:
+			Name: Slower
+			Timestep: 50
+			OrderLatency: 3
+		default:
+			Name: Normal
+			Timestep: 40
+			OrderLatency: 3
+		fast:
+			Name: Fast
+			Timestep: 35
+			OrderLatency: 4
+		faster:
+			Name: Faster
+			Timestep: 30
+			OrderLatency: 4
+		fastest:
+			Name: Fastest
+			Timestep: 20
+			OrderLatency: 6
 
 ColorValidator:
 	TeamColorPresets: 9023cd, f53333, ffae00, fff830, 87f506, f872ad, da06f3, ddb8ff, def7b2, 39c46f, 200738, 280df6, 2f86f2, 76d2f8, 498221, 392929

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -241,30 +241,32 @@ AssetBrowser:
 	SupportedExtensions: .shp, .tmp, .tem, .des, .sno, .int, .vqa, .wsa
 
 GameSpeeds:
-	slowest:
-		Name: Slowest
-		Timestep: 80
-		OrderLatency: 2
-	slower:
-		Name: Slower
-		Timestep: 50
-		OrderLatency: 3
-	default:
-		Name: Normal
-		Timestep: 40
-		OrderLatency: 3
-	fast:
-		Name: Fast
-		Timestep: 35
-		OrderLatency: 4
-	faster:
-		Name: Faster
-		Timestep: 30
-		OrderLatency: 4
-	fastest:
-		Name: Fastest
-		Timestep: 20
-		OrderLatency: 6
+	DefaultSpeed: default
+	Speeds:
+		slowest:
+			Name: Slowest
+			Timestep: 80
+			OrderLatency: 2
+		slower:
+			Name: Slower
+			Timestep: 50
+			OrderLatency: 3
+		default:
+			Name: Normal
+			Timestep: 40
+			OrderLatency: 3
+		fast:
+			Name: Fast
+			Timestep: 35
+			OrderLatency: 4
+		faster:
+			Name: Faster
+			Timestep: 30
+			OrderLatency: 4
+		fastest:
+			Name: Fastest
+			Timestep: 20
+			OrderLatency: 6
 
 ColorValidator:
 	TeamColorPresets: f7b3b3, f50606, 98331f, f57606, f7bb06, f861a4, da06f3, ddb8ff, 06f739, cef7b2, 200738, 280df6, 2f86f2, 76d2f8, 34ba93, 391d1d

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -270,30 +270,32 @@ AssetBrowser:
 	SupportedExtensions: .shp, .tem, .sno, .vqa, .vxl
 
 GameSpeeds:
-	slowest:
-		Name: Slowest
-		Timestep: 80
-		OrderLatency: 2
-	slower:
-		Name: Slower
-		Timestep: 50
-		OrderLatency: 3
-	default:
-		Name: Normal
-		Timestep: 40
-		OrderLatency: 3
-	fast:
-		Name: Fast
-		Timestep: 35
-		OrderLatency: 4
-	faster:
-		Name: Faster
-		Timestep: 30
-		OrderLatency: 4
-	fastest:
-		Name: Fastest
-		Timestep: 20
-		OrderLatency: 6
+	DefaultSpeed: default
+	Speeds:
+		slowest:
+			Name: Slowest
+			Timestep: 80
+			OrderLatency: 2
+		slower:
+			Name: Slower
+			Timestep: 50
+			OrderLatency: 3
+		default:
+			Name: Normal
+			Timestep: 40
+			OrderLatency: 3
+		fast:
+			Name: Fast
+			Timestep: 35
+			OrderLatency: 4
+		faster:
+			Name: Faster
+			Timestep: 30
+			OrderLatency: 4
+		fastest:
+			Name: Fastest
+			Timestep: 20
+			OrderLatency: 6
 
 ColorValidator:
 	TeamColorPresets: f70606, ff7a22, f8d3b3, f8e947, 94b319, f335a0, a64d6c, ce08f9, f5b2db, 12b572, 4A1948, 1d06f7, 328dff, 78dbf8, cef6b1, 391d1d


### PR DESCRIPTION
Refactors how we read and apply game speeds to get rid of various hardcodings, work-arounds and limitations.

Fixes #19138.
Fixes hardcoded Timestep 40 (25 ticks/sec) assumption in `DateTimeGlobal`.
Removes various hardcodings and work-arounds.