### PR TITLE
Make SpriteFont.Measure take zero allocations

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -533,6 +533,50 @@ namespace OpenRA
 
 			return default(T);
 		}
+
+		public static LineSplitEnumerator SplitLines(this string str, char separator)
+		{
+			return new LineSplitEnumerator(str.AsSpan(), separator);
+		}
+	}
+
+	public ref struct LineSplitEnumerator
+	{
+		ReadOnlySpan<char> str;
+		readonly char separator;
+
+		public LineSplitEnumerator(ReadOnlySpan<char> str, char separator)
+		{
+			this.str = str;
+			this.separator = separator;
+			Current = default;
+		}
+
+		public LineSplitEnumerator GetEnumerator() => this;
+
+		public bool MoveNext()
+		{
+			var span = str;
+
+			// Reach the end of the string
+			if (span.Length == 0)
+				return false;
+
+			var index = span.IndexOf(separator);
+			if (index == -1)
+			{
+				// The remaining string is an empty string
+				str = ReadOnlySpan<char>.Empty;
+				Current = span;
+				return true;
+			}
+
+			Current = span.Slice(0, index);
+			str = span.Slice(index + 1);
+			return true;
+		}
+
+		public ReadOnlySpan<char> Current { get; private set; }
 	}
 
 	public static class Enum<T>


### PR DESCRIPTION
By using spans instead of splitting strings we avoids making allocations, which will help performance.