### PR TITLE
Add SelectableSupportUnit to Thief

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -558,6 +558,7 @@ GNRL:
 
 THF:
 	Inherits: ^Soldier
+	Inherits@selection: ^SelectableSupportUnit
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier


### PR DESCRIPTION
Closes #14769

I brought this issue up in the Discord balance-and-playtesting channel. Between the comments there and the 👍 on the ticket, lowering the selection priority of the Thief has broad popular support. It was in my balance test maps three years ago but I didn't push it back then.