### PR TITLE
Fix a crash in LevelUpCrateAction

### DIFF
--- a/OpenRA.Mods.Common/Traits/Crates/LevelUpCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/LevelUpCrateAction.cs
@@ -67,12 +67,12 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.MaxExtraCollectors > -1)
 				inRange = inRange.Take(info.MaxExtraCollectors);
 
-			foreach (var actor in inRange.Append(collector))
+			foreach (var recipient in inRange.Append(collector))
 			{
-				var recipient = actor;	// loop variable in closure hazard
 				recipient.World.AddFrameEndTask(w =>
 				{
-					recipient.TraitOrDefault<GainsExperience>()?.GiveLevels(info.Levels);
+					if (!recipient.IsDead)
+						recipient.TraitOrDefault<GainsExperience>()?.GiveLevels(info.Levels);
 				});
 			}
 


### PR DESCRIPTION
Reported by Blackened on Discord:
```
OpenRA engine version release-20210321
Red Alert mod version release-20210321
on map 650744c28277f221cad1df5aff64b37ce5e0aa34 (Cliff Hoppers by Blackened).
Date: 2021-03-30 02:38:28Z
Operating System: Windows (Microsoft Windows NT 6.2.9200.0)
Runtime Version: .NET CLR 4.0.30319.42000
Exception of type `System.InvalidOperationException`: Attempted to get trait from destroyed object (jeep 1767 (not in world))
   at OpenRA.TraitDictionary.CheckDestroyed(Actor actor)
   at OpenRA.TraitDictionary.GetOrDefault[T](Actor actor)
   at OpenRA.Mods.Common.Traits.LevelUpCrateAction.<>c__DisplayClass4_1.<Activate>b__1(World w)
   at OpenRA.World.Tick()
   at OpenRA.Game.InnerLogicTick(OrderManager orderManager)
   at OpenRA.Game.LogicTick()
   at OpenRA.Game.Loop()
   at OpenRA.Game.Run()
   at OpenRA.Game.InitializeAndRun(String[] args)
   at OpenRA.WindowsLauncher.WindowsLauncher.RunGame(String[] args)
```