### PR TITLE
fix AreaBeam + GrantExternalConditionWarhead bug

### DIFF
--- a/OpenRA.Mods.Common/Warheads/GrantExternalConditionWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/GrantExternalConditionWarhead.cs
@@ -30,6 +30,10 @@ namespace OpenRA.Mods.Common.Warheads
 		public override void DoImpact(in Target target, WarheadArgs args)
 		{
 			var firedBy = args.SourceActor;
+
+			if (target.Type == TargetType.Invalid)
+				return;
+
 			var actors = target.Type == TargetType.Actor ? new[] { target.Actor } :
 				firedBy.World.FindActorsInCircle(target.CenterPosition, Range);
 


### PR DESCRIPTION
this PR fixes a crash that occurs, when a unit kills another unit with AreaBeam and applies an external condition.