### PR TITLE
Add Lua Scripting for Carryall.

### DIFF
--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -12,6 +12,7 @@
 using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
@@ -22,19 +23,21 @@ namespace OpenRA.Mods.Common.Activities
 		readonly BodyOrientation body;
 		readonly bool assignTargetOnFirstRun;
 		readonly WDist deliverRange;
+		readonly Color? targetLineColor;
 
 		Target destination;
 
-		public DeliverUnit(Actor self, WDist deliverRange)
-			: this(self, Target.Invalid, deliverRange)
+		public DeliverUnit(Actor self, WDist deliverRange, Color? targetLineColor)
+			: this(self, Target.Invalid, deliverRange, targetLineColor)
 		{
 			assignTargetOnFirstRun = true;
 		}
 
-		public DeliverUnit(Actor self, in Target destination, WDist deliverRange)
+		public DeliverUnit(Actor self, in Target destination, WDist deliverRange, Color? targetLineColor)
 		{
 			this.destination = destination;
 			this.deliverRange = deliverRange;
+			this.targetLineColor = targetLineColor;
 
 			carryall = self.Trait<Carryall>();
 			body = self.Trait<BodyOrientation>();
@@ -59,7 +62,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
 		{
-			yield return new TargetLineNode(destination, carryall.Info.TargetLineColor);
+			if (targetLineColor != null)
+				yield return new TargetLineNode(destination, targetLineColor.Value);
 		}
 
 		class ReleaseUnit : Activity

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -12,6 +12,7 @@
 using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
@@ -25,6 +26,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly BodyOrientation carryableBody;
 
 		readonly int delay;
+		readonly Color? targetLineColor;
 
 		// TODO: Expose this to yaml
 		readonly WDist targetLockRange = WDist.FromCells(4);
@@ -32,10 +34,11 @@ namespace OpenRA.Mods.Common.Activities
 		enum PickupState { Intercept, LockCarryable, Pickup }
 		PickupState state = PickupState.Intercept;
 
-		public PickupUnit(Actor self, Actor cargo, int delay)
+		public PickupUnit(Actor self, Actor cargo, int delay, Color? targetLineColor)
 		{
 			this.cargo = cargo;
 			this.delay = delay;
+			this.targetLineColor = targetLineColor;
 			carryable = cargo.Trait<Carryable>();
 			carryableFacing = cargo.Trait<IFacing>();
 			carryableBody = cargo.Trait<BodyOrientation>();
@@ -115,7 +118,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
 		{
-			yield return new TargetLineNode(Target.FromActor(cargo), carryall.Info.TargetLineColor);
+			if (targetLineColor != null)
+				yield return new TargetLineNode(Target.FromActor(cargo), targetLineColor.Value);
 		}
 
 		class AttachUnit : Activity

--- a/OpenRA.Mods.Common/Scripting/Properties/CarryallProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CarryallProperties.cs
@@ -1,0 +1,49 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using Eluant;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Scripting;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Scripting
+{
+	[ScriptPropertyGroup("Ability")]
+	public class CarryallProperties : ScriptActorProperties, Requires<CarryallInfo>
+	{
+		readonly Carryall carryall;
+
+		public CarryallProperties(ScriptContext context, Actor self)
+			: base(context, self)
+		{
+			carryall = Self.Trait<Carryall>();
+		}
+
+		[ScriptActorPropertyActivity]
+		[Desc("Pick up the target actor.")]
+		public void PickupCarryable(Actor target)
+		{
+			var carryable = target.TraitOrDefault<Carryable>();
+			if (carryable == null)
+				throw new LuaException("Actor '{0}' cannot carry actor '{1}'!".F(Self, target));
+
+			Self.QueueActivity(new PickupUnit(Self, target, carryall.Info.BeforeLoadDelay, null));
+		}
+
+		[ScriptActorPropertyActivity]
+		[Desc("Drop the actor being carried at the target location.")]
+		public void DeliverCarryable(CPos target)
+		{
+			Self.QueueActivity(new DeliverUnit(Self, Target.FromCell(Self.World, target), carryall.Info.DropRange, null));
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/AutoCarryall.cs
+++ b/OpenRA.Mods.Common/Traits/AutoCarryall.cs
@@ -105,16 +105,20 @@ namespace OpenRA.Mods.Common.Traits
 		class FerryUnit : Activity
 		{
 			readonly Actor cargo;
+			readonly Carryable carryable;
+			readonly CarryallInfo carryallInfo;
 
 			public FerryUnit(Actor self, Actor cargo)
 			{
 				this.cargo = cargo;
+				carryable = cargo.Trait<Carryable>();
+				carryallInfo = self.Trait<Carryall>().Info;
 			}
 
 			protected override void OnFirstRun(Actor self)
 			{
 				if (!cargo.IsDead)
-					QueueChild(new PickupUnit(self, cargo, 0));
+					QueueChild(new PickupUnit(self, cargo, 0, carryallInfo.TargetLineColor));
 			}
 
 			public override bool Tick(Actor self)
@@ -122,10 +126,10 @@ namespace OpenRA.Mods.Common.Traits
 				if (cargo.IsDead)
 					return true;
 
-				var dropRange = self.Trait<Carryall>().Info.DropRange;
-				var destination = cargo.Trait<Carryable>().Destination;
+				var dropRange = carryallInfo.DropRange;
+				var destination = carryable.Destination;
 				if (destination != null)
-					self.QueueActivity(true, new DeliverUnit(self, Target.FromCell(self.World, destination.Value), dropRange));
+					self.QueueActivity(true, new DeliverUnit(self, Target.FromCell(self.World, destination.Value), dropRange, carryallInfo.TargetLineColor));
 
 				return true;
 			}

--- a/OpenRA.Mods.Common/Traits/Buildings/FreeActorWithDelivery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FreeActorWithDelivery.cs
@@ -65,8 +65,9 @@ namespace OpenRA.Mods.Common.Traits
 			var carryable = cargo.Trait<Carryable>();
 			carryable.Reserve(cargo, carrier);
 
-			carrier.Trait<Carryall>().AttachCarryable(carrier, cargo);
-			carrier.QueueActivity(new DeliverUnit(carrier, Target.FromCell(self.World, location), info.DeliveryRange));
+			var carryall = carrier.Trait<Carryall>();
+			carryall.AttachCarryable(carrier, cargo);
+			carrier.QueueActivity(new DeliverUnit(carrier, Target.FromCell(self.World, location), info.DeliveryRange, carryall.Info.TargetLineColor));
 			carrier.QueueActivity(new Fly(carrier, Target.FromCell(self.World, self.World.Map.ChooseRandomEdgeCell(self.World.SharedRandom))));
 			carrier.QueueActivity(new RemoveSelf());
 

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -333,7 +333,7 @@ namespace OpenRA.Mods.Common.Traits
 					return;
 
 				var targetLocation = move.NearestMoveableCell(cell);
-				self.QueueActivity(order.Queued, new DeliverUnit(self, order.Target, Info.DropRange));
+				self.QueueActivity(order.Queued, new DeliverUnit(self, order.Target, Info.DropRange, Info.TargetLineColor));
 				self.ShowTargetLines();
 			}
 			else if (order.OrderString == "Unload")
@@ -341,14 +341,14 @@ namespace OpenRA.Mods.Common.Traits
 				if (!order.Queued && !CanUnload())
 					return;
 
-				self.QueueActivity(order.Queued, new DeliverUnit(self, Info.DropRange));
+				self.QueueActivity(order.Queued, new DeliverUnit(self, Info.DropRange, Info.TargetLineColor));
 			}
 			else if (order.OrderString == "PickupUnit")
 			{
 				if (order.Target.Type != TargetType.Actor)
 					return;
 
-				self.QueueActivity(order.Queued, new PickupUnit(self, order.Target.Actor, Info.BeforeLoadDelay));
+				self.QueueActivity(order.Queued, new PickupUnit(self, order.Target.Actor, Info.BeforeLoadDelay, Info.TargetLineColor));
 				self.ShowTargetLines();
 			}
 		}


### PR DESCRIPTION
I changed the Carryalls in SP to actually use Carryall logic. The shellmap had some carryall stuff, which we didn't support yet for the actual Carryall logic. This PR adds functions for Picking Up and Dropping the carried unit for Carryalls. Altho i'm not sure if what i did for ignoring the Pickup/Deliver if the Carryall is already Full/Empty is the best way of doing it.