### PR TITLE
Fix RA infantry shadow being visible when parachuting

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -52,10 +52,14 @@ DOG:
 		MoveSequence: walk
 		StandSequences: stand
 		DefaultAttackSequence: eat
-		RequiresCondition: !run
+		RequiresCondition: !run && !parachute
 	WithInfantryBody@RUN:
 		MoveSequence: run
-		RequiresCondition: run
+		RequiresCondition: run && !parachute
+	WithInfantryBody@PARACHUTE:
+		RequiresCondition: parachute
+		Palette: player-noshadow
+		IsPlayerPalette: true
 	SpeedMultiplier:
 		Modifier: 150
 		RequiresCondition: run
@@ -95,6 +99,8 @@ E1:
 	WithInfantryBody@PARACHUTE:
 		StandSequences: parachute
 		RequiresCondition: parachute
+		Palette: player-noshadow
+		IsPlayerPalette: true
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded
 
@@ -144,6 +150,8 @@ E2:
 	WithInfantryBody@PARACHUTE:
 		StandSequences: parachute
 		RequiresCondition: parachute
+		Palette: player-noshadow
+		IsPlayerPalette: true
 	Explodes:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
@@ -188,6 +196,8 @@ E3:
 	WithInfantryBody@PARACHUTE:
 		StandSequences: parachute
 		RequiresCondition: parachute
+		Palette: player-noshadow
+		IsPlayerPalette: true
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded
 	AutoTarget:
@@ -240,6 +250,8 @@ E4:
 	WithInfantryBody@PARACHUTE:
 		StandSequences: parachute
 		RequiresCondition: parachute
+		Palette: player-noshadow
+		IsPlayerPalette: true
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded
 
@@ -263,6 +275,8 @@ E6:
 	WithInfantryBody@PARACHUTE:
 		StandSequences: parachute
 		RequiresCondition: parachute
+		Palette: player-noshadow
+		IsPlayerPalette: true
 	Passenger:
 		CustomPipType: yellow
 	EngineerRepair:
@@ -328,6 +342,11 @@ SPY:
 		DefaultAttackSequence: shoot
 		IdleSequences: idle1,idle2
 		StandSequences: stand,stand2
+		RequiresCondition: !parachute
+	WithDisguisingInfantryBody@PARACHUTE:
+		RequiresCondition: parachute
+		Palette: player-noshadow
+		IsPlayerPalette: true
 	WithDecoration@disguise:
 		Position: Top
 		Margin: 0, -6
@@ -401,6 +420,11 @@ E7:
 		AttackSequences:
 			primary: shoot-left, shoot-right
 		StandSequences: stand
+		RequiresCondition: !parachute
+	WithInfantryBody@PARACHUTE:
+		RequiresCondition: parachute
+		Palette: player-noshadow
+		IsPlayerPalette: true
 	ExternalCondition@PRODUCED:
 		Condition: produced
 	VoiceAnnouncement:
@@ -444,6 +468,11 @@ MEDI:
 		IdleSequences: idle
 		StandSequences: stand
 		DefaultAttackSequence: heal
+		RequiresCondition: !parachute
+	WithInfantryBody@PARACHUTE:
+		RequiresCondition: parachute
+		Palette: player-noshadow
+		IsPlayerPalette: true
 	Voiced:
 		VoiceSet: MedicVoice
 	AutoTarget:
@@ -495,6 +524,11 @@ MECH:
 		IdleSequences: idle
 		DefaultAttackSequence: repair
 		StandSequences: stand
+		RequiresCondition: !parachute
+	WithInfantryBody@PARACHUTE:
+		RequiresCondition: parachute
+		Palette: player-noshadow
+		IsPlayerPalette: true
 	Voiced:
 		VoiceSet: MechanicVoice
 	AutoTarget:
@@ -555,6 +589,11 @@ GNRL:
 		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1
+		RequiresCondition: !parachute
+	WithInfantryBody@PARACHUTE:
+		RequiresCondition: parachute
+		Palette: player-noshadow
+		IsPlayerPalette: true
 
 THF:
 	Inherits: ^Soldier
@@ -591,6 +630,11 @@ THF:
 	WithInfantryBody:
 		IdleSequences: idle
 		StandSequences: stand
+		RequiresCondition: !parachute
+	WithInfantryBody@PARACHUTE:
+		RequiresCondition: parachute
+		Palette: player-noshadow
+		IsPlayerPalette: true
 	Crushable:
 		WarnProbability: 95
 	Cloak:
@@ -650,6 +694,8 @@ SHOK:
 	WithInfantryBody@PARACHUTE:
 		StandSequences: parachute
 		RequiresCondition: parachute
+		Palette: player-noshadow
+		IsPlayerPalette: true
 	Voiced:
 		VoiceSet: ShokVoice
 	ProducibleWithLevel:
@@ -688,6 +734,11 @@ SNIPER:
 		MuzzleSequence: garrison-muzzle
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
+		RequiresCondition: !parachute
+	WithInfantryBody@PARACHUTE:
+		RequiresCondition: parachute
+		Palette: player-noshadow
+		IsPlayerPalette: true
 	Cloak:
 		InitialDelay: 250
 		CloakDelay: 120
@@ -727,6 +778,11 @@ Zombie:
 	WithInfantryBody:
 		DefaultAttackSequence: bite
 		IdleSequences: idle1
+		RequiresCondition: !parachute
+	WithInfantryBody@PARACHUTE:
+		RequiresCondition: parachute
+		Palette: player-noshadow
+		IsPlayerPalette: true
 	Armament:
 		Weapon: claw
 	Voiced:

--- a/mods/ra/rules/palettes.yaml
+++ b/mods/ra/rules/palettes.yaml
@@ -23,6 +23,10 @@
 		Name: player
 		Filename: temperat.pal
 		ShadowIndex: 4
+	PaletteFromFile@player-noshadow:
+		Name: player-noshadow
+		Filename: temperat.pal
+		TransparentIndex: 0, 4
 	PaletteFromFile@chrome:
 		Name: chrome
 		Filename: temperat.pal
@@ -71,6 +75,10 @@
 		Fog: true
 	PlayerColorPalette:
 		BasePalette: player
+		RemapIndex: 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95
+	PlayerColorPalette@NOSHADOW:
+		BaseName: player-noshadow
+		BasePalette: player-noshadow
 		RemapIndex: 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95
 	PaletteFromPlayerPaletteWithAlpha@cloak:
 		BaseName: cloak


### PR DESCRIPTION
Thanks to `TransparentIndex`, this doesn't require custom sprites or similar gymnastics anymore.

Closes #7603