### PR TITLE
Overhaul MapPreview rule loading

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -451,11 +451,11 @@ namespace OpenRA
 			if (!ModData.LoadScreen.BeforeLoad())
 				return;
 
-			using (new PerfTimer("LoadMaps"))
-				ModData.MapCache.LoadMaps();
-
 			ModData.InitializeLoaders(ModData.DefaultFileSystem);
 			Renderer.InitializeFonts(ModData);
+
+			using (new PerfTimer("LoadMaps"))
+				ModData.MapCache.LoadMaps();
 
 			var grid = ModData.Manifest.Contains<MapGrid>() ? ModData.Manifest.Get<MapGrid>() : null;
 			Renderer.InitializeDepthBuffer(grid);

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -86,10 +86,12 @@ namespace OpenRA
 			public MapVisibility Visibility;
 
 			Lazy<Ruleset> rules;
-			public Ruleset Rules => rules?.Value;
 			public bool InvalidCustomRules { get; private set; }
 			public bool DefinesUnsafeCustomRules { get; private set; }
 			public bool RulesLoaded { get; private set; }
+
+			public ActorInfo WorldActorInfo => rules?.Value.Actors[SystemActors.World];
+			public ActorInfo PlayerActorInfo => rules?.Value.Actors[SystemActors.Player];
 
 			public void SetRulesetGenerator(ModData modData, Func<(Ruleset Ruleset, bool DefinesUnsafeCustomRules)> generator)
 			{
@@ -154,16 +156,18 @@ namespace OpenRA
 		public MapClassification Class => innerData.Class;
 		public MapVisibility Visibility => innerData.Visibility;
 
-		public Ruleset Rules => innerData.Rules;
 		public bool InvalidCustomRules => innerData.InvalidCustomRules;
 		public bool RulesLoaded => innerData.RulesLoaded;
+
+		public ActorInfo WorldActorInfo => innerData.WorldActorInfo;
+		public ActorInfo PlayerActorInfo => innerData.PlayerActorInfo;
 
 		public bool DefinesUnsafeCustomRules
 		{
 			get
 			{
 				// Force lazy rules to be evaluated
-				var force = innerData.Rules;
+				var force = innerData.WorldActorInfo;
 				return innerData.DefinesUnsafeCustomRules;
 			}
 		}
@@ -338,7 +342,7 @@ namespace OpenRA
 
 		public void PreloadRules()
 		{
-			var unused = Rules;
+			var unused = WorldActorInfo;
 		}
 
 		public void UpdateRemoteSearch(MapStatus status, MiniYaml yaml, Action<MapPreview> parseMetadata = null)

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using OpenRA.Primitives;
+using OpenRA.Server;
 
 namespace OpenRA.Network
 {
@@ -218,10 +219,21 @@ namespace OpenRA.Network
 			public bool IsEnabled => Value == "True";
 		}
 
+		[Flags]
+		public enum MapStatus
+		{
+			Unknown = 0,
+			Validating = 1,
+			Playable = 2,
+			Incompatible = 4,
+			UnsafeCustomRules = 8,
+		}
+
 		public class Global
 		{
 			public string ServerName;
 			public string Map;
+			public MapStatus MapStatus;
 			public int RandomSeed = 0;
 			public bool AllowSpectators = true;
 			public string GameUid;

--- a/OpenRA.Game/Server/MapStatusCache.cs
+++ b/OpenRA.Game/Server/MapStatusCache.cs
@@ -1,0 +1,100 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using OpenRA.Network;
+
+namespace OpenRA.Server
+{
+	public interface ILintServerMapPass { void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules); }
+
+	public class MapStatusCache
+	{
+		readonly Dictionary<MapPreview, Session.MapStatus> cache = new Dictionary<MapPreview, Session.MapStatus>();
+		readonly Action<string, Session.MapStatus> onStatusChanged;
+		readonly bool enableRemoteLinting;
+		readonly ModData modData;
+
+		public MapStatusCache(ModData modData, Action<string, Session.MapStatus> onStatusChanged, bool enableRemoteLinting)
+		{
+			this.modData = modData;
+			this.enableRemoteLinting = enableRemoteLinting;
+			this.onStatusChanged = onStatusChanged;
+		}
+
+		void RunLintTests(MapPreview map, Ruleset rules)
+		{
+			var status = cache[map];
+			var failed = false;
+
+			Action<string> onLintFailure = message =>
+			{
+				Log.Write("server", "Map {0} failed lint with error: {1}", map.Title, message);
+				failed = true;
+			};
+
+			Action<string> onLintWarning = _ => { };
+
+			foreach (var customMapPassType in modData.ObjectCreator.GetTypesImplementing<ILintServerMapPass>())
+			{
+				try
+				{
+					var customMapPass = (ILintServerMapPass)modData.ObjectCreator.CreateBasic(customMapPassType);
+					customMapPass.Run(onLintFailure, onLintWarning, modData, map, rules);
+				}
+				catch (Exception e)
+				{
+					onLintFailure(e.ToString());
+				}
+			}
+
+			status &= ~Session.MapStatus.Validating;
+			status |= failed ? Session.MapStatus.Incompatible : Session.MapStatus.Playable;
+
+			cache[map] = status;
+			onStatusChanged?.Invoke(map.Uid, status);
+		}
+
+		public Session.MapStatus this[MapPreview map]
+		{
+			get
+			{
+				if (cache.TryGetValue(map, out var status))
+					return status;
+
+				Ruleset rules = null;
+				try
+				{
+					rules = map.LoadRuleset();
+
+					// Locally installed maps are assumed to not require linting
+					status = enableRemoteLinting && map.Status != MapStatus.Available ? Session.MapStatus.Validating : Session.MapStatus.Playable;
+					if (map.DefinesUnsafeCustomRules())
+						status |= Session.MapStatus.UnsafeCustomRules;
+				}
+				catch (Exception e)
+				{
+					Log.Write("server", "Failed to load rules for `{0}` with error :{1}", map.Title, e.Message);
+					status = Session.MapStatus.Incompatible;
+				}
+
+				cache[map] = status;
+
+				if ((status & Session.MapStatus.Validating) != 0)
+					ThreadPool.QueueUserWorkItem(_ => RunLintTests(map, rules));
+
+				return status;
+			}
+		}
+	}
+}

--- a/OpenRA.Game/Server/ProtocolVersion.cs
+++ b/OpenRA.Game/Server/ProtocolVersion.cs
@@ -68,6 +68,6 @@ namespace OpenRA.Server
 		// The protocol for server and world orders
 		// This applies after the handshake has completed, and is provided to support
 		// alternative server implementations that wish to support multiple versions in parallel
-		public const int Orders = 11;
+		public const int Orders = 12;
 	}
 }

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -1209,7 +1209,7 @@ namespace OpenRA.Server
 				// The null padding is needed to keep the player indexes in sync with world.Players on the clients
 				// This will need to change if future code wants to use worldPlayers for other purposes
 				var playerRandom = new MersenneTwister(LobbyInfo.GlobalSettings.RandomSeed);
-				foreach (var cmpi in Map.Rules.Actors[SystemActors.World].TraitInfos<ICreatePlayersInfo>())
+				foreach (var cmpi in Map.WorldActorInfo.TraitInfos<ICreatePlayersInfo>())
 					cmpi.CreateServerPlayers(Map, LobbyInfo, worldPlayers, playerRandom);
 
 				if (recorder != null)

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -91,6 +91,9 @@ namespace OpenRA
 		[Desc("For dedicated servers only, save replays for all games played.")]
 		public bool RecordReplays = false;
 
+		[Desc("For dedicated servers only, treat maps that fail the lint checks as invalid.")]
+		public bool EnableLintChecks = true;
+
 		public ServerSettings Clone()
 		{
 			return (ServerSettings)MemberwiseClone();

--- a/OpenRA.Game/Traits/Player/Shroud.cs
+++ b/OpenRA.Game/Traits/Player/Shroud.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Traits
 		[Desc("Display order for the explore map checkbox in the lobby.")]
 		public readonly int ExploredMapCheckboxDisplayOrder = 0;
 
-		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
 			yield return new LobbyBooleanOption("explored", ExploredMapCheckboxLabel, ExploredMapCheckboxDescription,
 				ExploredMapCheckboxVisible, ExploredMapCheckboxDisplayOrder, ExploredMapCheckboxEnabled, ExploredMapCheckboxLocked);

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -530,7 +530,7 @@ namespace OpenRA.Traits
 	[RequireExplicitImplementation]
 	public interface ILobbyOptions : ITraitInfoInterface
 	{
-		IEnumerable<LobbyOption> LobbyOptions(Ruleset rules);
+		IEnumerable<LobbyOption> LobbyOptions(MapPreview map);
 	}
 
 	public class LobbyOption

--- a/OpenRA.Mods.Common/Lint/CheckAngle.cs
+++ b/OpenRA.Mods.Common/Lint/CheckAngle.cs
@@ -11,12 +11,23 @@
 
 using System;
 using OpenRA.Mods.Common.Projectiles;
+using OpenRA.Server;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckAngle : ILintRulesPass
+	class CheckAngle : ILintRulesPass, ILintServerMapPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		{
+			Run(emitError, rules);
+		}
+
+		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
+		{
+			Run(emitError, mapRules);
+		}
+
+		void Run(Action<string> emitError, Ruleset rules)
 		{
 			foreach (var weaponInfo in rules.Weapons)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckConditions.cs
+++ b/OpenRA.Mods.Common/Lint/CheckConditions.cs
@@ -12,13 +12,24 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Server;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	public class CheckConditions : ILintRulesPass
+	public class CheckConditions : ILintRulesPass, ILintServerMapPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		{
+			Run(emitError, emitWarning, rules);
+		}
+
+		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
+		{
+			Run(emitError, emitWarning, mapRules);
+		}
+
+		void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckConflictingMouseBounds.cs
+++ b/OpenRA.Mods.Common/Lint/CheckConflictingMouseBounds.cs
@@ -12,12 +12,13 @@
 using System;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Network;
 
 namespace OpenRA.Mods.Common.Lint
 {
 	public class CheckConflictingMouseBounds : ILintRulesPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckCursors.cs
+++ b/OpenRA.Mods.Common/Lint/CheckCursors.cs
@@ -12,13 +12,24 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Server;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckCursors : ILintRulesPass
+	class CheckCursors : ILintRulesPass, ILintServerMapPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		{
+			Run(emitError, modData, rules);
+		}
+
+		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
+		{
+			Run(emitError, modData, mapRules);
+		}
+
+		void Run(Action<string> emitError, ModData modData, Ruleset rules)
 		{
 			var fileSystem = modData.DefaultFileSystem;
 			var sequenceYaml = MiniYaml.Merge(modData.Manifest.Cursors.Select(s => MiniYaml.FromStream(fileSystem.Open(s), s)));

--- a/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
+++ b/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
@@ -12,13 +12,24 @@
 using System;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Server;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckDefaultVisibility : ILintRulesPass
+	class CheckDefaultVisibility : ILintRulesPass, ILintServerMapPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		{
+			Run(emitError, rules);
+		}
+
+		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
+		{
+			Run(emitError, mapRules);
+		}
+
+		void Run(Action<string> emitError, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckHitShapes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckHitShapes.cs
@@ -12,13 +12,24 @@
 using System;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Server;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckHitShapes : ILintRulesPass
+	class CheckHitShapes : ILintRulesPass, ILintServerMapPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		{
+			Run(emitError, rules);
+		}
+
+		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
+		{
+			Run(emitError, mapRules);
+		}
+
+		void Run(Action<string> emitError, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckLocomotorReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckLocomotorReferences.cs
@@ -12,13 +12,24 @@
 using System;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Server;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	public class CheckLocomotorReferences : ILintRulesPass
+	public class CheckLocomotorReferences : ILintRulesPass, ILintServerMapPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		{
+			Run(emitError, rules);
+		}
+
+		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
+		{
+			Run(emitError, mapRules);
+		}
+
+		void Run(Action<string> emitError, Ruleset rules)
 		{
 			var worldActor = rules.Actors[SystemActors.World];
 			var locomotorInfos = worldActor.TraitInfos<LocomotorInfo>().ToArray();

--- a/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
+++ b/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
@@ -11,24 +11,34 @@
 
 using System;
 using System.Linq;
+using OpenRA.Server;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	public class CheckMapMetadata : ILintMapPass
+	public class CheckMapMetadata : ILintMapPass, ILintServerMapPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
+		void ILintMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
 		{
-			if (map.MapFormat != Map.SupportedMapFormat)
-				emitError("Map format {0} does not match the supported version {1}."
-					.F(map.MapFormat, Map.SupportedMapFormat));
+			Run(emitError, map.MapFormat, map.Author, map.Title, map.Categories);
+		}
 
-			if (map.Author == null)
+		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
+		{
+			Run(emitError, map.MapFormat, map.Author, map.Title, map.Categories);
+		}
+
+		void Run(Action<string> emitError, int mapFormat, string author, string title, string[] categories)
+		{
+			if (mapFormat != Map.SupportedMapFormat)
+				emitError("Map format {0} does not match the supported version {1}.".F(mapFormat, Map.SupportedMapFormat));
+
+			if (author == null)
 				emitError("Map does not define a valid author.");
 
-			if (map.Title == null)
+			if (title == null)
 				emitError("Map does not define a valid title.");
 
-			if (!map.Categories.Any())
+			if (!categories.Any())
 				emitError("Map does not define any categories.");
 		}
 	}

--- a/OpenRA.Mods.Common/Lint/CheckNotifications.cs
+++ b/OpenRA.Mods.Common/Lint/CheckNotifications.cs
@@ -11,15 +11,25 @@
 
 using System;
 using System.Linq;
-using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Server;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckNotifications : ILintRulesPass
+	class CheckNotifications : ILintRulesPass, ILintServerMapPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		{
+			Run(emitError, rules);
+		}
+
+		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
+		{
+			Run(emitError, mapRules);
+		}
+
+		void Run(Action<string> emitError, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckOwners.cs
+++ b/OpenRA.Mods.Common/Lint/CheckOwners.cs
@@ -1,0 +1,52 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Lint
+{
+	public class CheckOwners : ILintMapPass
+	{
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
+		{
+			var playerNames = new MapPlayers(map.PlayerDefinitions).Players.Values
+				.Select(p => p.Name)
+				.ToHashSet();
+
+			// Check for actors that require specific owners
+			var actorsWithRequiredOwner = map.Rules.Actors
+				.Where(a => a.Value.HasTraitInfo<RequiresSpecificOwnersInfo>())
+				.ToDictionary(a => a.Key, a => a.Value.TraitInfo<RequiresSpecificOwnersInfo>());
+
+			foreach (var kv in map.ActorDefinitions)
+			{
+				var actorReference = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+				var ownerInit = actorReference.GetOrDefault<OwnerInit>();
+				if (ownerInit == null)
+					emitError("Actor {0} is not owned by any player.".F(kv.Key));
+				else
+				{
+					var ownerName = ownerInit.InternalName;
+					if (!playerNames.Contains(ownerName))
+						emitError("Actor {0} is owned by unknown player {1}.".F(kv.Key, ownerName));
+
+					if (actorsWithRequiredOwner.TryGetValue(kv.Value.Value, out var info))
+						if (!info.ValidOwnerNames.Contains(ownerName))
+							emitError("Actor {0} owner {1} is not one of ValidOwnerNames: {2}".F(kv.Key, ownerName, info.ValidOwnerNames.JoinWith(", ")));
+				}
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Lint/CheckPalettes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPalettes.cs
@@ -12,18 +12,28 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Server;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckPalettes : ILintRulesPass
+	class CheckPalettes : ILintRulesPass, ILintServerMapPass
 	{
-		List<string> palettes = new List<string>();
-		List<string> playerPalettes = new List<string>();
-
-		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{
-			GetPalettes(emitError, rules);
+			Run(emitError, rules);
+		}
+
+		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
+		{
+			Run(emitError, mapRules);
+		}
+
+		void Run(Action<string> emitError, Ruleset rules)
+		{
+			var palettes = new List<string>();
+			var playerPalettes = new List<string>();
+			GetPalettes(emitError, rules, palettes, playerPalettes);
 
 			foreach (var actorInfo in rules.Actors)
 			{
@@ -111,7 +121,7 @@ namespace OpenRA.Mods.Common.Lint
 			}
 		}
 
-		void GetPalettes(Action<string> emitError, Ruleset rules)
+		void GetPalettes(Action<string> emitError, Ruleset rules, List<string> palettes, List<string> playerPalettes)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -13,21 +13,39 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Server;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	public class CheckPlayers : ILintMapPass
+	public class CheckPlayers : ILintMapPass, ILintServerMapPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
+		void ILintMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
 		{
-			var players = new MapPlayers(map.PlayerDefinitions).Players;
-			if (players.Count > 64)
+			var players = new MapPlayers(map.PlayerDefinitions);
+			var spawns = new List<CPos>();
+			foreach (var kv in map.ActorDefinitions.Where(d => d.Value.Value == "mpspawn"))
+			{
+				var s = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+				spawns.Add(s.Get<LocationInit>().Value);
+			}
+
+			Run(emitError, emitWarning, players, map.Visibility, map.Rules.Actors[SystemActors.World], spawns.ToArray());
+		}
+
+		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
+		{
+			Run(emitError, emitWarning, map.Players, map.Visibility, map.WorldActorInfo, map.SpawnPoints);
+		}
+
+		void Run(Action<string> emitError, Action<string> emitWarning, MapPlayers players, MapVisibility visibility, ActorInfo worldActorInfo, CPos[] spawnPoints)
+		{
+			if (players.Players.Count > 64)
 				emitError("Defining more than 64 players is not allowed.");
 
 			var worldOwnerFound = false;
-			var playerNames = players.Values.Select(p => p.Name).ToHashSet();
-			foreach (var player in players.Values)
+			var playerNames = players.Players.Values.Select(p => p.Name).ToHashSet();
+			foreach (var player in players.Players.Values)
 			{
 				foreach (var ally in player.Allies)
 					if (!playerNames.Contains(ally))
@@ -46,7 +64,7 @@ namespace OpenRA.Mods.Common.Lint
 					if (player.Playable)
 						emitError("The player {0} owning the world can't be playable.".F(player.Name));
 				}
-				else if (map.Visibility == MapVisibility.MissionSelector && player.Playable && !player.LockFaction)
+				else if (visibility == MapVisibility.MissionSelector && player.Playable && !player.LockFaction)
 				{
 					// Missions must lock the faction of the player to force the server to override the default Random faction
 					emitError("The player {0} must specify LockFaction: True.".F(player.Name));
@@ -56,50 +74,19 @@ namespace OpenRA.Mods.Common.Lint
 			if (!worldOwnerFound)
 				emitError("Found no player owning the world.");
 
-			var worldActor = map.Rules.Actors[SystemActors.World];
-			var factions = worldActor.TraitInfos<FactionInfo>().Select(f => f.InternalName).ToHashSet();
-			foreach (var player in players.Values)
+			var factions = worldActorInfo.TraitInfos<FactionInfo>().Select(f => f.InternalName).ToHashSet();
+			foreach (var player in players.Players.Values)
 				if (!string.IsNullOrWhiteSpace(player.Faction) && !factions.Contains(player.Faction))
 					emitError("Invalid faction {0} chosen for player {1}.".F(player.Faction, player.Name));
 
-			if (worldActor.HasTraitInfo<MapStartingLocationsInfo>())
+			if (worldActorInfo.HasTraitInfo<MapStartingLocationsInfo>())
 			{
-				var playerCount = players.Count(p => p.Value.Playable);
-				var spawns = new List<CPos>();
-				foreach (var kv in map.ActorDefinitions.Where(d => d.Value.Value == "mpspawn"))
-				{
-					var s = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
-					spawns.Add(s.Get<LocationInit>().Value);
-				}
+				var playerCount = players.Players.Count(p => p.Value.Playable);
+				if (playerCount > spawnPoints.Length)
+					emitError("The map allows {0} possible players, but defines only {1} spawn points".F(playerCount, spawnPoints.Length));
 
-				if (playerCount > spawns.Count)
-					emitError("The map allows {0} possible players, but defines only {1} spawn points".F(playerCount, spawns.Count));
-
-				if (spawns.Distinct().Count() != spawns.Count)
+				if (spawnPoints.Distinct().Count() != spawnPoints.Length)
 					emitError("Duplicate spawn point locations detected.");
-			}
-
-			// Check for actors that require specific owners
-			var actorsWithRequiredOwner = map.Rules.Actors
-				.Where(a => a.Value.HasTraitInfo<RequiresSpecificOwnersInfo>())
-				.ToDictionary(a => a.Key, a => a.Value.TraitInfo<RequiresSpecificOwnersInfo>());
-
-			foreach (var kv in map.ActorDefinitions)
-			{
-				var actorReference = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
-				var ownerInit = actorReference.GetOrDefault<OwnerInit>();
-				if (ownerInit == null)
-					emitError("Actor {0} is not owned by any player.".F(kv.Key));
-				else
-				{
-					var ownerName = ownerInit.InternalName;
-					if (!playerNames.Contains(ownerName))
-						emitError("Actor {0} is owned by unknown player {1}.".F(kv.Key, ownerName));
-
-					if (actorsWithRequiredOwner.TryGetValue(kv.Value.Value, out var info))
-						if (!info.ValidOwnerNames.Contains(ownerName))
-							emitError("Actor {0} owner {1} is not one of ValidOwnerNames: {2}".F(kv.Key, ownerName, info.ValidOwnerNames.JoinWith(", ")));
-				}
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Lint/CheckRangeLimit.cs
+++ b/OpenRA.Mods.Common/Lint/CheckRangeLimit.cs
@@ -11,12 +11,23 @@
 
 using System;
 using OpenRA.Mods.Common.Projectiles;
+using OpenRA.Server;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckRangeLimit : ILintRulesPass
+	class CheckRangeLimit : ILintRulesPass, ILintServerMapPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		{
+			Run(emitError, rules);
+		}
+
+		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
+		{
+			Run(emitError, mapRules);
+		}
+
+		void Run(Action<string> emitError, Ruleset rules)
 		{
 			foreach (var weaponInfo in rules.Weapons)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
+++ b/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
@@ -12,13 +12,24 @@
 using System;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Server;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckRevealFootprint : ILintRulesPass
+	class CheckRevealFootprint : ILintRulesPass, ILintServerMapPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		{
+			Run(emitError, rules);
+		}
+
+		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
+		{
+			Run(emitError, mapRules);
+		}
+
+		void Run(Action<string> emitError, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckSpriteBodies.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSpriteBodies.cs
@@ -12,12 +12,23 @@
 using System;
 using System.Linq;
 using OpenRA.Mods.Common.Traits.Render;
+using OpenRA.Server;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckSpriteBodies : ILintRulesPass
+	class CheckSpriteBodies : ILintRulesPass, ILintServerMapPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		{
+			Run(emitError, rules);
+		}
+
+		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
+		{
+			Run(emitError, mapRules);
+		}
+
+		void Run(Action<string> emitError, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckTooltips.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTooltips.cs
@@ -12,12 +12,23 @@
 using System;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Server;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckTooltips : ILintRulesPass
+	class CheckTooltips : ILintRulesPass, ILintServerMapPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		{
+			Run(emitError, rules);
+		}
+
+		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
+		{
+			Run(emitError, mapRules);
+		}
+
+		void Run(Action<string> emitError, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckTraitPrerequisites.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTraitPrerequisites.cs
@@ -11,12 +11,23 @@
 
 using System;
 using System.Linq;
+using OpenRA.Server;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	public class CheckTraitPrerequisites : ILintRulesPass
+	public class CheckTraitPrerequisites : ILintRulesPass, ILintServerMapPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		{
+			Run(emitError, emitWarning, rules);
+		}
+
+		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
+		{
+			Run(emitError, emitWarning, mapRules);
+		}
+
+		void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
@@ -12,13 +12,24 @@
 using System;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Server;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	public class CheckVoiceReferences : ILintRulesPass
+	public class CheckVoiceReferences : ILintRulesPass, ILintServerMapPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		{
+			Run(emitError, rules);
+		}
+
+		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
+		{
+			Run(emitError, mapRules);
+		}
+
+		void Run(Action<string> emitError, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckWorldAndPlayerInherits.cs
+++ b/OpenRA.Mods.Common/Lint/CheckWorldAndPlayerInherits.cs
@@ -1,0 +1,96 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.FileSystem;
+using OpenRA.Mods.Common.UpdateRules;
+using OpenRA.Server;
+
+namespace OpenRA.Mods.Common.Lint
+{
+	public class CheckWorldAndPlayerInherits : ILintPass, ILintMapPass, ILintServerMapPass
+	{
+		void ILintPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData)
+		{
+			var nodes = new List<MiniYamlNode>();
+			foreach (var f in modData.Manifest.Rules)
+				nodes.AddRange(MiniYaml.FromStream(modData.DefaultFileSystem.Open(f), f));
+
+			Run(emitError, nodes);
+		}
+
+		void ILintMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
+		{
+			CheckMapYaml(emitError, modData, map, map.RuleDefinitions);
+		}
+
+		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
+		{
+			CheckMapYaml(emitError, modData, map, map.RuleDefinitions);
+		}
+
+		void CheckMapYaml(Action<string> emitError, ModData modData, IReadOnlyFileSystem fileSystem, MiniYaml ruleDefinitions)
+		{
+			if (ruleDefinitions == null)
+				return;
+
+			var files = modData.Manifest.Rules.AsEnumerable();
+			if (ruleDefinitions.Value != null)
+			{
+				var mapFiles = FieldLoader.GetValue<string[]>("value", ruleDefinitions.Value);
+				files = files.Append(mapFiles);
+			}
+
+			var nodes = new List<MiniYamlNode>();
+			foreach (var f in files)
+				nodes.AddRange(MiniYaml.FromStream(fileSystem.Open(f), f));
+
+			nodes.AddRange(ruleDefinitions.Nodes);
+			Run(emitError, nodes);
+		}
+
+		void Run(Action<string> emitError, List<MiniYamlNode> nodes)
+		{
+			// Build a list of all inheritance relationships
+			var inheritsMap = new Dictionary<string, List<string>>();
+			foreach (var actorNode in nodes)
+			{
+				var inherits = inheritsMap.GetOrAdd(actorNode.Key, _ => new List<string>());
+				foreach (var inheritsNode in actorNode.ChildrenMatching("Inherits"))
+					inherits.Add(inheritsNode.Value.Value);
+			}
+
+			CheckInheritance(emitError, "World", inheritsMap);
+			CheckInheritance(emitError, "Player", inheritsMap);
+		}
+
+		void CheckInheritance(Action<string> emitError, string actor, Dictionary<string, List<string>> inheritsMap)
+		{
+			var toResolve = new Queue<string>(inheritsMap.Keys.Where(k => k.ToLowerInvariant() == actor.ToLowerInvariant()));
+			while (toResolve.TryDequeue(out var key))
+			{
+				// Missing keys are a fatal merge error, so will have already been reported by other lint checks
+				if (!inheritsMap.TryGetValue(key, out var inherits))
+					continue;
+
+				foreach (var inherit in inherits)
+				{
+					if (inherit[0] != '^')
+						emitError("{0} definition inherits from {1}, which is not an abstract template.".F(actor, inherit));
+
+					toResolve.Enqueue(inherit);
+				}
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
+++ b/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
@@ -12,12 +12,23 @@
 using System;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Server;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class LintBuildablePrerequisites : ILintRulesPass
+	class LintBuildablePrerequisites : ILintRulesPass, ILintServerMapPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
+		{
+			Run(emitError, rules);
+		}
+
+		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
+		{
+			Run(emitError, mapRules);
+		}
+
+		void Run(Action<string> emitError, Ruleset rules)
 		{
 			var providedPrereqs = rules.Actors.SelectMany(a => a.Value.TraitInfos<ITechTreePrerequisiteInfo>().SelectMany(p => p.Prerequisites(a.Value)));
 

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -431,6 +431,7 @@ namespace OpenRA.Mods.Common.Server
 
 						var oldSlots = server.LobbyInfo.Slots.Keys.ToArray();
 						server.Map = server.ModData.MapCache[server.LobbyInfo.GlobalSettings.Map];
+						server.LobbyInfo.GlobalSettings.MapStatus = server.MapStatusCache[server.Map];
 
 						server.LobbyInfo.Slots = server.Map.Players.Players
 							.Select(p => MakeSlotFromPlayerReference(p.Value))
@@ -492,7 +493,7 @@ namespace OpenRA.Mods.Common.Server
 
 						server.SendMessage("{0} changed the map to {1}.".F(client.Name, server.Map.Title));
 
-						if (server.Map.DefinesUnsafeCustomRules)
+						if ((server.LobbyInfo.GlobalSettings.MapStatus & Session.MapStatus.UnsafeCustomRules) != 0)
 							server.SendMessage("This map contains custom rules. Game experience may change.");
 
 						if (!server.LobbyInfo.GlobalSettings.EnableSingleplayer)

--- a/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
@@ -23,11 +23,11 @@ namespace OpenRA.Mods.Common.Server
 			lock (server.LobbyInfo)
 			{
 				var defaults = new Session.Global();
-				LobbyCommands.LoadMapSettings(server, defaults, server.Map.Rules);
+				LobbyCommands.LoadMapSettings(server, defaults, server.Map);
 
-				var options = server.Map.Rules.Actors[SystemActors.Player].TraitInfos<ILobbyOptions>()
-					.Concat(server.Map.Rules.Actors[SystemActors.World].TraitInfos<ILobbyOptions>())
-					.SelectMany(t => t.LobbyOptions(server.Map.Rules))
+				var options = server.Map.PlayerActorInfo.TraitInfos<ILobbyOptions>()
+					.Concat(server.Map.WorldActorInfo.TraitInfos<ILobbyOptions>())
+					.SelectMany(t => t.LobbyOptions(server.Map))
 					.ToDictionary(o => o.Id, o => o);
 
 				foreach (var kv in server.LobbyInfo.GlobalSettings.LobbyOptions)

--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Enable the path debug overlay by default.")]
 		public readonly bool PathDebug;
 
-		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
 			yield return new LobbyBooleanOption("cheats", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
 		}

--- a/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Monetery value of each resource type.", "Dictionary of [resource type]: [value per unit].")]
 		public readonly Dictionary<string, int> ResourceValues = new Dictionary<string, int>();
 
-		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
 			var startingCash = SelectableCash.ToDictionary(c => c.ToString(), c => "$" + c.ToString());
 

--- a/OpenRA.Mods.Common/Traits/Player/TimeLimitManager.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TimeLimitManager.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Traits
 				throw new YamlException("TimeLimitDefault must be a value from TimeLimitOptions");
 		}
 
-		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
 			var timelimits = TimeLimitOptions.ToDictionary(c => c.ToString(), c =>
 			{

--- a/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Spawn and remove the plane this far outside the map.")]
 		public readonly WDist Cordon = new WDist(5120);
 
-		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
 			yield return new LobbyBooleanOption("crates", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
 		}

--- a/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs
+++ b/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs
@@ -28,9 +28,8 @@ namespace OpenRA.Mods.Common.Traits
 		/// </summary>
 		void ICreatePlayersInfo.CreateServerPlayers(MapPreview map, Session lobbyInfo, List<GameInformation.Player> players, MersenneTwister playerRandom)
 		{
-			var worldInfo = map.Rules.Actors[SystemActors.World];
-			var factions = worldInfo.TraitInfos<FactionInfo>().ToArray();
-			var assignSpawnLocations = worldInfo.TraitInfoOrDefault<IAssignSpawnPointsInfo>();
+			var factions = map.WorldActorInfo.TraitInfos<FactionInfo>().ToArray();
+			var assignSpawnLocations = map.WorldActorInfo.TraitInfoOrDefault<IAssignSpawnPointsInfo>();
 			var spawnState = assignSpawnLocations?.InitializeState(map, lobbyInfo);
 
 			// Create the unplayable map players -- neutral, shellmap, scripted, etc.
@@ -42,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// Create the regular playable players.
-			var bots = map.Rules.Actors[SystemActors.Player].TraitInfos<IBotInfo>().ToArray();
+			var bots = map.PlayerActorInfo.TraitInfos<IBotInfo>().ToArray();
 
 			foreach (var kv in lobbyInfo.Slots)
 			{

--- a/OpenRA.Mods.Common/Traits/World/LobbyPrerequisiteCheckbox.cs
+++ b/OpenRA.Mods.Common/Traits/World/LobbyPrerequisiteCheckbox.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<string> ITechTreePrerequisiteInfo.Prerequisites(ActorInfo info) { return Prerequisites; }
 
-		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
 			yield return new LobbyBooleanOption(ID, Label, Description,
 				Visible, DisplayOrder, Enabled, Locked);

--- a/OpenRA.Mods.Common/Traits/World/MapBuildRadius.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapBuildRadius.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Display order for the build radius checkbox in the lobby.")]
 		public readonly int BuildRadiusCheckboxDisplayOrder = 0;
 
-		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
 			yield return new LobbyBooleanOption("allybuild", AllyBuildRadiusCheckboxLabel, AllyBuildRadiusCheckboxDescription,
 				AllyBuildRadiusCheckboxVisible, AllyBuildRadiusCheckboxDisplayOrder, AllyBuildRadiusCheckboxEnabled, AllyBuildRadiusCheckboxLocked);

--- a/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Display order for the creeps checkbox in the lobby.")]
 		public readonly int CheckboxDisplayOrder = 0;
 
-		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
 			yield return new LobbyBooleanOption("creeps", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
 		}

--- a/OpenRA.Mods.Common/Traits/World/MapOptions.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapOptions.cs
@@ -73,12 +73,12 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Display order for the game speed option in the lobby.")]
 		public readonly int GameSpeedDropdownDisplayOrder = 0;
 
-		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
 			yield return new LobbyBooleanOption("shortgame", ShortGameCheckboxLabel, ShortGameCheckboxDescription,
 				ShortGameCheckboxVisible, ShortGameCheckboxDisplayOrder, ShortGameCheckboxEnabled, ShortGameCheckboxLocked);
 
-			var techLevels = rules.Actors[SystemActors.Player].TraitInfos<ProvidesTechPrerequisiteInfo>()
+			var techLevels = map.PlayerActorInfo.TraitInfos<ProvidesTechPrerequisiteInfo>()
 				.ToDictionary(t => t.Id, t => t.Name);
 
 			if (techLevels.Any())

--- a/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override object Create(ActorInitializer init) { return new MapStartingLocations(this); }
 
-		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
 			yield return new LobbyBooleanOption(
 				"separateteamspawns",

--- a/OpenRA.Mods.Common/Traits/World/ScriptLobbyDropdown.cs
+++ b/OpenRA.Mods.Common/Traits/World/ScriptLobbyDropdown.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Display order for the option in the lobby.")]
 		public readonly int DisplayOrder = 0;
 
-		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
 			yield return new LobbyOption(ID, Label, Description, Visible, DisplayOrder,
 				Values, Default, Locked);

--- a/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
@@ -39,12 +39,12 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Display order for the starting units option in the lobby.")]
 		public readonly int DropdownDisplayOrder = 0;
 
-		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
 			var startingUnits = new Dictionary<string, string>();
 
 			// Duplicate classes are defined for different race variants
-			foreach (var t in rules.Actors[SystemActors.World].TraitInfos<StartingUnitsInfo>())
+			foreach (var t in map.WorldActorInfo.TraitInfos<StartingUnitsInfo>())
 				startingUnits[t.Class] = t.ClassName;
 
 			if (startingUnits.Any())

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -207,7 +207,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				slotsButton.OnMouseDown = _ =>
 				{
-					var botTypes = map.Rules.Actors[SystemActors.Player].TraitInfos<IBotInfo>().Select(t => t.Type);
+					var botTypes = map.PlayerActorInfo.TraitInfos<IBotInfo>().Select(t => t.Type);
 					var options = new Dictionary<string, IEnumerable<DropDownOption>>();
 
 					var botController = orderManager.LobbyInfo.Clients.FirstOrDefault(c => c.IsAdmin);
@@ -539,7 +539,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						if (addBotOnMapLoad)
 						{
 							var slot = orderManager.LobbyInfo.FirstEmptyBotSlot();
-							var bot = currentMap.Rules.Actors[SystemActors.Player].TraitInfos<IBotInfo>().Select(t => t.Type).FirstOrDefault();
+							var bot = currentMap.PlayerActorInfo.TraitInfos<IBotInfo>().Select(t => t.Type).FirstOrDefault();
 							var botController = orderManager.LobbyInfo.Clients.FirstOrDefault(c => c.IsAdmin);
 							if (slot != null && bot != null)
 								orderManager.IssueOrder(Order.Command("slot_bot {0} {1} {2}".F(slot, botController.Index, bot)));

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
@@ -30,7 +30,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly OrderManager orderManager;
 		readonly Func<bool> configurationDisabled;
 		MapPreview mapPreview;
-		bool validOptions;
 
 		[ObjectCreator.UseCtor]
 		internal LobbyOptionsLogic(Widget widget, OrderManager orderManager, Func<MapPreview> getMap, Func<bool> configurationDisabled)
@@ -42,7 +41,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			panel = (ScrollPanelWidget)widget;
 			optionsContainer = widget.Get("LOBBY_OPTIONS");
 			yMargin = optionsContainer.Bounds.Y;
-			optionsContainer.IsVisible = () => validOptions;
 			checkboxRowTemplate = optionsContainer.Get("CHECKBOX_ROW_TEMPLATE");
 			dropdownRowTemplate = optionsContainer.Get("DROPDOWN_ROW_TEMPLATE");
 
@@ -56,24 +54,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (newMapPreview == mapPreview)
 				return;
 
-			if (newMapPreview.RulesLoaded)
+			// We are currently enumerating the widget tree and so can't modify any layout
+			// Defer it to the end of tick instead
+			Game.RunAfterTick(() =>
 			{
-				// We are currently enumerating the widget tree and so can't modify any layout
-				// Defer it to the end of tick instead
-				Game.RunAfterTick(() =>
-				{
-					mapPreview = newMapPreview;
-					RebuildOptions();
-					validOptions = true;
-				});
-			}
-			else
-				validOptions = false;
+				mapPreview = newMapPreview;
+				RebuildOptions();
+			});
 		}
 
 		void RebuildOptions()
 		{
-			if (mapPreview == null || mapPreview.WorldActorInfo == null || mapPreview.InvalidCustomRules)
+			if (mapPreview == null || mapPreview.WorldActorInfo == null)
 				return;
 
 			optionsContainer.RemoveChildren();

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
@@ -73,14 +73,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void RebuildOptions()
 		{
-			if (mapPreview == null || mapPreview.Rules == null || mapPreview.InvalidCustomRules)
+			if (mapPreview == null || mapPreview.WorldActorInfo == null || mapPreview.InvalidCustomRules)
 				return;
 
 			optionsContainer.RemoveChildren();
 			optionsContainer.Bounds.Height = 0;
-			var allOptions = mapPreview.Rules.Actors[SystemActors.Player].TraitInfos<ILobbyOptions>()
-					.Concat(mapPreview.Rules.Actors[SystemActors.World].TraitInfos<ILobbyOptions>())
-					.SelectMany(t => t.LobbyOptions(mapPreview.Rules))
+			var allOptions = mapPreview.PlayerActorInfo.TraitInfos<ILobbyOptions>()
+					.Concat(mapPreview.WorldActorInfo.TraitInfos<ILobbyOptions>())
+					.SelectMany(t => t.LobbyOptions(mapPreview))
 					.Where(o => o.IsVisible)
 					.OrderBy(o => o.DisplayOrder)
 					.ToArray();

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -630,13 +630,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			HideChildWidget(parent, "SPAWN_DROPDOWN");
 		}
 
-		public static void SetupEditableReadyWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, MapPreview map)
+		public static void SetupEditableReadyWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, MapPreview map, bool isEnabled)
 		{
 			var status = parent.Get<CheckboxWidget>("STATUS_CHECKBOX");
 			status.IsChecked = () => orderManager.LocalClient.IsReady || c.Bot != null;
 			status.IsVisible = () => true;
-			status.IsDisabled = () => c.Bot != null || map.Status != MapStatus.Available ||
-				!map.RulesLoaded || map.InvalidCustomRules;
+			status.IsDisabled = () => c.Bot != null || map.Status != MapStatus.Available || !isEnabled;
 
 			var state = orderManager.LocalClient.IsReady ? Session.ClientState.NotReady : Session.ClientState.Ready;
 			status.OnClick = () => orderManager.IssueOrder(Order.Command("state {0}".F(state)));

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var bots = new List<SlotDropDownOption>();
 			if (slot.AllowBots)
 			{
-				foreach (var b in map.Rules.Actors[SystemActors.Player].TraitInfos<IBotInfo>())
+				foreach (var b in map.PlayerActorInfo.TraitInfos<IBotInfo>())
 				{
 					var botController = orderManager.LobbyInfo.Clients.FirstOrDefault(c => c.IsAdmin);
 					bots.Add(new SlotDropDownOption(b.Name,

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -139,19 +139,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (allPreviews.Any())
 				SelectMap(allPreviews.First());
 
-			// Preload map preview and rules to reduce jank
+			// Preload map preview to reduce jank
 			new Thread(() =>
 			{
 				foreach (var p in allPreviews)
-				{
 					p.GetMinimap();
-					p.PreloadRules();
-				}
 			}).Start();
 
 			var startButton = widget.Get<ButtonWidget>("STARTGAME_BUTTON");
 			startButton.OnClick = StartMissionClicked;
-			startButton.IsDisabled = () => selectedMap == null || selectedMap.InvalidCustomRules;
+			startButton.IsDisabled = () => selectedMap == null;
 
 			widget.Get<ButtonWidget>("BACK_BUTTON").OnClick = () =>
 			{
@@ -372,9 +369,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void StartMissionClicked()
 		{
 			StopVideo(videoPlayer);
-
-			if (selectedMap.InvalidCustomRules)
-				return;
 
 			var orders = new List<Order>();
 			if (difficulty != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -219,7 +219,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			new Thread(() =>
 			{
-				var mapDifficulty = preview.Rules.Actors[SystemActors.World].TraitInfos<ScriptLobbyDropdownInfo>()
+				var mapDifficulty = preview.WorldActorInfo.TraitInfos<ScriptLobbyDropdownInfo>()
 					.FirstOrDefault(sld => sld.ID == "difficulty");
 
 				if (mapDifficulty != null)
@@ -229,7 +229,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					difficultyDisabled = mapDifficulty.Locked;
 				}
 
-				var missionData = preview.Rules.Actors[SystemActors.World].TraitInfoOrDefault<MissionDataInfo>();
+				var missionData = preview.WorldActorInfo.TraitInfoOrDefault<MissionDataInfo>();
 				if (missionData != null)
 				{
 					briefingVideo = missionData.BriefingVideo;
@@ -383,7 +383,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			orders.Add(Order.Command("option gamespeed {0}".F(gameSpeed)));
 			orders.Add(Order.Command("state {0}".F(Session.ClientState.Ready)));
 
-			var missionData = selectedMap.Rules.Actors[SystemActors.World].TraitInfoOrDefault<MissionDataInfo>();
+			var missionData = selectedMap.WorldActorInfo.TraitInfoOrDefault<MissionDataInfo>();
 			if (missionData != null && missionData.StartVideo != null && modData.DefaultFileSystem.Exists(missionData.StartVideo))
 			{
 				var fsPlayer = fullscreenVideoPlayer.Get<VideoPlayerWidget>("PLAYER");

--- a/launch-dedicated.cmd
+++ b/launch-dedicated.cmd
@@ -16,12 +16,13 @@ set ProfileIDWhitelist=""
 set EnableSingleplayer=False
 set EnableSyncReports=False
 set EnableGeoIP=True
+set EnableLintChecks=True
 set ShareAnonymizedIPs=True
 
 set SupportDir=""
 
 :loop
 
-bin\OpenRA.Server.exe Engine.EngineDir=".." Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.RecordReplays=%RecordReplays% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports% Server.EnableGeoIP=%EnableGeoIP% Server.ShareAnonymizedIPs=%ShareAnonymizedIPs% Engine.SupportDir=%SupportDir%
+bin\OpenRA.Server.exe Engine.EngineDir=".." Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.RecordReplays=%RecordReplays% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports% Server.EnableGeoIP=%EnableGeoIP% Server.EnableLintChecks=%EnableLintChecks% Server.ShareAnonymizedIPs=%ShareAnonymizedIPs% Engine.SupportDir=%SupportDir%
 
 goto loop

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -26,6 +26,7 @@ ProfileIDWhitelist="${ProfileIDWhitelist:-""}"
 EnableSingleplayer="${EnableSingleplayer:-"False"}"
 EnableSyncReports="${EnableSyncReports:-"False"}"
 EnableGeoIP="${EnableGeoIP:-"True"}"
+EnableLintChecks="${EnableLintChecks:-"True"}"
 ShareAnonymizedIPs="${ShareAnonymizedIPs:-"True"}"
 
 SupportDir="${SupportDir:-""}"
@@ -43,6 +44,7 @@ while true; do
      Server.ProfileIDWhitelist="$ProfileIDWhitelist" \
      Server.EnableSyncReports="$EnableSyncReports" \
      Server.EnableGeoIP="$EnableGeoIP" \
+     Server.EnableLintChecks="$EnableLintChecks" \
      Server.ShareAnonymizedIPs="$ShareAnonymizedIPs" \
      Engine.SupportDir="$SupportDir"
 done

--- a/mods/cnc/chrome/lobby-mappreview.yaml
+++ b/mods/cnc/chrome/lobby-mappreview.yaml
@@ -77,6 +77,42 @@ Container@MAP_PREVIEW:
 					Font: Tiny
 					Align: Center
 					Text: with this version of OpenRA
+		Container@MAP_VALIDATING:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Children:
+				Background@MAP_BG:
+					Width: PARENT_RIGHT
+					Height: 158
+					Background: panel-gray
+					Children:
+						MapPreview@MAP_PREVIEW:
+							X: 1
+							Y: 1
+							Width: PARENT_RIGHT - 2
+							Height: PARENT_BOTTOM - 2
+							TooltipContainer: TOOLTIP_CONTAINER
+				LabelWithTooltip@MAP_TITLE:
+					Y: 159
+					Width: PARENT_RIGHT
+					Height: 25
+					Font: Bold
+					Align: Center
+					TooltipContainer: TOOLTIP_CONTAINER
+					TooltipTemplate: SIMPLE_TOOLTIP
+				Label@MAP_STATUS_VALIDATING:
+					Y: 174
+					Width: PARENT_RIGHT
+					Height: 25
+					Font: Tiny
+					Align: Center
+					Text: Validating...
+					IgnoreMouseOver: true
+				ProgressBar@MAP_PROGRESSBAR:
+					Y: 194
+					Width: PARENT_RIGHT
+					Height: 25
+					Indeterminate: True
 		Container@MAP_DOWNLOADABLE:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM

--- a/mods/common/chrome/lobby-mappreview.yaml
+++ b/mods/common/chrome/lobby-mappreview.yaml
@@ -77,6 +77,42 @@ Container@MAP_PREVIEW:
 					Font: Tiny
 					Align: Center
 					Text: with this version of OpenRA
+		Container@MAP_VALIDATING:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Children:
+				Background@MAP_BG:
+					Width: PARENT_RIGHT
+					Height: 158
+					Background: dialog3
+					Children:
+						MapPreview@MAP_PREVIEW:
+							X: 1
+							Y: 1
+							Width: PARENT_RIGHT - 2
+							Height: PARENT_BOTTOM - 2
+							TooltipContainer: TOOLTIP_CONTAINER
+				LabelWithTooltip@MAP_TITLE:
+					Y: 159
+					Width: PARENT_RIGHT
+					Height: 25
+					Font: Bold
+					Align: Center
+					TooltipContainer: TOOLTIP_CONTAINER
+					TooltipTemplate: SIMPLE_TOOLTIP
+				Label@MAP_STATUS_VALIDATING:
+					Y: 174
+					Width: PARENT_RIGHT
+					Height: 25
+					Font: Tiny
+					Align: Center
+					Text: Validating...
+					IgnoreMouseOver: true
+				ProgressBar@MAP_PROGRESSBAR:
+					Y: 194
+					Width: PARENT_RIGHT
+					Height: 25
+					Indeterminate: True
 		Container@MAP_DOWNLOADABLE:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM


### PR DESCRIPTION
This PR reworks the way MapPreview handles custom rules, with two major goals in mind:

1. Fix the atrocious performance issues with the mission browser. On my system, and I suspect most others, opening the mission browser will trigger unusable performance on the shellmap for 10+ seconds while the mission rules are cached in the "background" (doesn't feel very background to me).

2. Require maps to pass the lint checks before dedicated servers will allow them to be used. This is responding to the flood of crash reports and complaints from the competitive community caused by copying the previous generation RAGL maps into release-20210321 without verifying that they were actually compatible (they weren't).

The first point is achieved by replacing the general Ruleset parsing with focused parsing for just the world and player definitions, which cuts the parse time for mission/custom maps from ~250ms to ~25ms each. This is small enough to get away with removing the asynchronous code completely, and load the rules up-front at the cost of only 1-2s of additional startup time in RA (less in the other mods).

The previous (very limited) rule syntax checks in the lobby were not compatible with this new approach, so they are moved to the server using a new `LobbyInfo.GlobalSettings.MapStatus` field to relay the result back to the clients. This decoupled approach makes it easy to add additional and longer checks, so I scope creeped a solution to the second point while I was here.

If we can get this merged within a reasonable timeframe I expect to work on a second PR that would bring the "map not available on server" handling ~~under the same system~~ (edit: ended up taking a different approach), which would then naturally extend to supporting server-side map allow/deny lists to make @ubitux's life easier with managing the map pool on the competitive servers.

I strongly recommend reviewing by commit, which makes it a lot easier to understand the different parts of this.