### PR TITLE
Limit resource center queries to 50 maps at a time.

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -516,7 +516,14 @@ namespace OpenRA.Mods.Common.Server
 				{
 					server.SendOrderTo(conn, "Message", "Searching for map on the Resource Center...");
 					var mapRepository = server.ModData.Manifest.Get<WebServices>().MapRepository;
-					server.ModData.MapCache.QueryRemoteMapDetails(mapRepository, new[] { s }, selectMap, queryFailed);
+					var reported = false;
+					server.ModData.MapCache.QueryRemoteMapDetails(mapRepository, new[] { s }, selectMap, _ =>
+					{
+						if (!reported)
+							queryFailed();
+
+						reported = true;
+					});
 				}
 				else
 					queryFailed();


### PR DESCRIPTION
This PR fixes custom map previews failing to load on the multiplayer server list.

The problem was caused by us now having too many different servers hosting too many different maps: the API query ends up containing well over 100 different map UIDs, which overflows the maximum 4096 character request string length. The server rejects this, and the client doesn't get any of the map info.

Breaking the query into smaller chunks avoids this problem and the map previews once again work as expected.

I split this out of a larger PR I am working on because it is important enough to justify its own PR and changelog entry, and has an easy to reproduce test case.

I suggest enabling "hide whitespace changes" to make the diff a lot simpler to read.