### PR TITLE
Add custom map pool support for dedicated servers

### DIFF
--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -38,6 +38,9 @@ namespace OpenRA.Network
 		public bool AuthenticationFailed = false;
 		public ExternalMod ServerExternalMod = null;
 
+		// The default null means "no map restriction" while an empty set means "all maps restricted"
+		public HashSet<string> ServerMapPool = null;
+
 		public int NetFrameNumber { get; private set; }
 		public int LocalFrameNumber;
 		public int FramesAhead = 0;

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -322,6 +322,12 @@ namespace OpenRA.Network
 						break;
 					}
 
+				case "SyncMapPool":
+					{
+						orderManager.ServerMapPool = FieldLoader.GetValue<HashSet<string>>("SyncMapPool", order.TargetString);
+						break;
+					}
+
 				case "Ping":
 					{
 						orderManager.IssueOrder(Order.FromTargetString("Pong", order.TargetString, true));

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -94,6 +94,9 @@ namespace OpenRA
 		[Desc("For dedicated servers only, treat maps that fail the lint checks as invalid.")]
 		public bool EnableLintChecks = true;
 
+		[Desc("For dedicated servers only, a comma separated list of map uids that are allowed to be used.")]
+		public string[] MapPool = { };
+
 		public ServerSettings Clone()
 		{
 			return (ServerSettings)MemberwiseClone();

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -1180,6 +1180,9 @@ namespace OpenRA.Mods.Common.Server
 		{
 			lock (server.LobbyInfo)
 			{
+				if (server.MapPool != null)
+					server.SendOrderTo(conn, "SyncMapPool", FieldSaver.FormatValue(server.MapPool));
+
 				var client = server.GetClient(conn);
 
 				// Validate whether color is allowed and get an alternative if it isn't

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -192,6 +192,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					Ui.OpenWindow("MAPCHOOSER_PANEL", new WidgetArgs()
 					{
 						{ "initialMap", map.Uid },
+						{ "remoteMapPool", orderManager.ServerMapPool },
 						{ "initialTab", MapClassification.System },
 						{ "onExit", DoNothing },
 						{ "onSelect", Game.IsHost ? onSelect : null },

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -179,6 +179,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Game.OpenWindow("MAPCHOOSER_PANEL", new WidgetArgs()
 				{
 					{ "initialMap", null },
+					{ "remoteMapPool", null },
 					{ "initialTab", MapClassification.User },
 					{ "onExit", () => SwitchMenu(MenuType.MapEditor) },
 					{ "onSelect", onSelect },

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -47,6 +47,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					Ui.OpenWindow("MAPCHOOSER_PANEL", new WidgetArgs()
 					{
 						{ "initialMap", preview.Uid },
+						{ "remoteMapPool", null },
 						{ "initialTab", MapClassification.System },
 						{ "onExit", () => { } },
 						{ "onSelect", (Action<string>)(uid => preview = modData.MapCache[uid]) },

--- a/OpenRA.Server/Program.cs
+++ b/OpenRA.Server/Program.cs
@@ -85,8 +85,6 @@ namespace OpenRA.Server
 				var modData = Game.ModData = new ModData(mods[modID], mods);
 				modData.MapCache.LoadMaps();
 
-				settings.Map = modData.MapCache.ChooseInitialMap(settings.Map, new MersenneTwister());
-
 				var endpoints = new List<IPEndPoint> { new IPEndPoint(IPAddress.IPv6Any, settings.ListenPort), new IPEndPoint(IPAddress.Any, settings.ListenPort) };
 				var server = new Server(endpoints, settings, modData, ServerType.Dedicated);
 

--- a/mods/cnc/chrome/mapchooser.yaml
+++ b/mods/cnc/chrome/mapchooser.yaml
@@ -49,6 +49,12 @@ Container@MAPCHOOSER_PANEL:
 					Height: 31
 					Width: 135
 					Text: Official Maps
+				Button@REMOTE_MAPS_TAB_BUTTON:
+					X: 15
+					Y: 15
+					Height: 31
+					Width: 135
+					Text: Server Maps
 				Button@USER_MAPS_TAB_BUTTON:
 					X: 155
 					Y: 15
@@ -56,6 +62,16 @@ Container@MAPCHOOSER_PANEL:
 					Width: 135
 					Text: Custom Maps
 				Container@SYSTEM_MAPS_TAB:
+					X: 15
+					Y: 45
+					Width: PARENT_RIGHT - 30
+					Height: PARENT_BOTTOM - 60
+					Children:
+						ScrollPanel@MAP_LIST:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							ItemSpacing: 1
+				Container@REMOTE_MAPS_TAB:
 					X: 15
 					Y: 45
 					Width: PARENT_RIGHT - 30
@@ -111,6 +127,13 @@ Container@MAPCHOOSER_PANEL:
 							Y: PARENT_BOTTOM - 8
 							Align: Center
 							Font: Tiny
+				Label@REMOTE_MAP_LABEL:
+					X: 140
+					Y: 539
+					Width: PARENT_RIGHT - 430
+					Height: 35
+					Align: Center
+					Font: Bold
 				Button@BUTTON_CANCEL:
 					Key: escape
 					Y: 539

--- a/mods/common/chrome/map-chooser.yaml
+++ b/mods/common/chrome/map-chooser.yaml
@@ -19,6 +19,13 @@ Background@MAPCHOOSER_PANEL:
 			Width: 140
 			Text: Official Maps
 			Font: Bold
+		Button@REMOTE_MAPS_TAB_BUTTON:
+			X: 20
+			Y: 48
+			Height: 31
+			Width: 140
+			Text: Server Maps
+			Font: Bold
 		Button@USER_MAPS_TAB_BUTTON:
 			X: 160
 			Y: 48
@@ -35,7 +42,15 @@ Background@MAPCHOOSER_PANEL:
 				ScrollPanel@MAP_LIST:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM
-					Children:
+		Container@REMOTE_MAPS_TAB:
+			X: 20
+			Y: 77
+			Width: PARENT_RIGHT - 40
+			Height: 471
+			Children:
+				ScrollPanel@MAP_LIST:
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
 		Container@USER_MAPS_TAB:
 			X: 20
 			Y: 77
@@ -45,7 +60,6 @@ Background@MAPCHOOSER_PANEL:
 				ScrollPanel@MAP_LIST:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM
-					Children:
 		ScrollItem@MAP_TEMPLATE:
 			Width: 208
 			Height: 266
@@ -128,6 +142,13 @@ Background@MAPCHOOSER_PANEL:
 			Width: 120
 			Height: 25
 			Text: Delete All Maps
+			Font: Bold
+		Label@REMOTE_MAP_LABEL:
+			X: 140
+			Y: PARENT_BOTTOM - HEIGHT - 20
+			Width: PARENT_RIGHT - 410
+			Height: 25
+			Align: Center
 			Font: Bold
 		Button@BUTTON_OK:
 			X: PARENT_RIGHT - 270


### PR DESCRIPTION
This PR implements two big usability improvements for the ladder and similarly focused servers.

The first (for server hosts) is a new `Server.MapPool` setting to limit the maps that are allowed to be used on the server without resorting to modifying the local files and disabling RC queries. This setting takes a comma separated list of map UIDs, which may either be local maps or queried from the RC.

The second (for players) is that the map browser on these servers will now show the map pool, including maps that aren't installed (again, queried from the RC). This removes any confusion about "Map was not found on server" errors, and allows players to install maps directly ingame instead of having to deal with manually installing map packs.

~Depends on #19317.~
~Depends on #19322.~

I think that with this PR we now also implement enough to close #3357. There are too many UI issues around searching and filtering the RC content to realistically support a full ingame browser, so relying on server hosts to curate map packs that players are able to download ingame strikes a good compromise.