### PR TITLE
Allow dedicated servers to show information in the player tooltip

### DIFF
--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -156,6 +156,11 @@ namespace OpenRA.Network
 			// Linked to the online player database
 			public string Fingerprint;
 
+			// Servers can add up to three lines of custom text to the player tooltip
+			public string ServerTooltipLine1;
+			public string ServerTooltipLine2;
+			public string ServerTooltipLine3;
+
 			public MiniYamlNode Serialize()
 			{
 				return new MiniYamlNode("Client@{0}".F(Index), FieldSaver.Save(this));

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -582,6 +582,9 @@ namespace OpenRA.Server
 									client.Fingerprint = handshake.Fingerprint;
 									Log.Write("server", "{0} authenticated as {1} (UID {2})", newConn.Socket.RemoteEndPoint,
 										profile.ProfileName, profile.ProfileID);
+
+									foreach (var t in serverTraits.WithInterface<IClientAuthenticated>())
+										t.ClientAuthenticated(this, client, profile);
 								}
 								else if (profile.KeyRevoked)
 								{

--- a/OpenRA.Game/Server/TraitInterfaces.cs
+++ b/OpenRA.Game/Server/TraitInterfaces.cs
@@ -22,6 +22,7 @@ namespace OpenRA.Server
 	public interface INotifyServerShutdown { void ServerShutdown(Server server); }
 	public interface IStartGame { void GameStarted(Server server); }
 	public interface IClientJoined { void ClientJoined(Server server, Connection conn); }
+	public interface IClientAuthenticated { void ClientAuthenticated(Server server, Session.Client client, PlayerProfile profile); }
 	public interface IEndGame { void GameEnded(Server server); }
 	public interface ITick { void Tick(Server server); }
 

--- a/OpenRA.Mods.Common/ServerTraits/AddRegisteredClientTooltip.cs
+++ b/OpenRA.Mods.Common/ServerTraits/AddRegisteredClientTooltip.cs
@@ -1,0 +1,86 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenRA.Network;
+using OpenRA.Server;
+using OpenRA.Support;
+using S = OpenRA.Server.Server;
+
+namespace OpenRA.Mods.Common.Server
+{
+	public class QueryRegisteredClientTooltip : IGlobalModData
+	{
+		[FieldLoader.Require]
+		public readonly string Endpoint = null;
+	}
+
+	public class AddRegisteredClientTooltip : ServerTrait, IClientAuthenticated
+	{
+		class PlayerInfo
+		{
+			public readonly string Line1 = null;
+			public readonly string Line2 = null;
+			public readonly string Line3 = null;
+		}
+
+		void IClientAuthenticated.ClientAuthenticated(S server, Session.Client client, PlayerProfile profile)
+		{
+			Task.Run(async () =>
+			{
+				var httpClient = HttpClientFactory.Create();
+
+				var queryUrl = server.ModData.Manifest.Get<QueryRegisteredClientTooltip>().Endpoint + profile.ProfileID;
+				var httpResponseMessage = await httpClient.GetAsync(queryUrl);
+
+				if (httpResponseMessage.StatusCode != HttpStatusCode.OK)
+				{
+					Log.Write("server", "Failed to query tooltip info for profile {0}; HTTP status: {1}",
+						profile.ProfileID, httpResponseMessage.StatusCode);
+					return;
+				}
+
+				var data = await httpResponseMessage.Content.ReadAsStringAsync();
+				try
+				{
+					var yaml = MiniYaml.FromString(data).First();
+					if (yaml.Key != "ServerInfo")
+					{
+						Log.Write("server", "Failed to query tooltip info for profile {0}; unexpected data:\n{1}",
+							profile.ProfileID, data);
+						return;
+					}
+
+					var info = FieldLoader.Load<PlayerInfo>(yaml.Value);
+
+					// The client info is stored inside the LobbyInfo, so we must take the lock to avoid race conditions
+					lock (server.LobbyInfo)
+					{
+						client.ServerTooltipLine1 = info.Line1;
+						client.ServerTooltipLine2 = info.Line2;
+						client.ServerTooltipLine3 = info.Line3;
+						server.SyncLobbyClients();
+					}
+				}
+				catch (Exception e)
+				{
+					Log.Write("server", "Failed to query tooltip info for profile {0}; exception: {1}", profile.ProfileID, e);
+				}
+			});
+		}
+	}
+}

--- a/mods/cnc/chrome/tooltips.yaml
+++ b/mods/cnc/chrome/tooltips.yaml
@@ -511,6 +511,23 @@ Container@REGISTERED_PLAYER_TOOLTIP:
 							Width: PARENT_RIGHT - 20
 							Height: 23
 							Font: Bold
+		Background@SERVER_CONTAINER:
+			Width: PARENT_RIGHT
+			Y: 0-1
+			Visible: false
+			Background: panel-black
+			Children:
+				Label@TITLE:
+					X: 5
+					Y: 5
+					Height: 12
+					Text: Server Information
+					Font: Bold
+				LabelWithHighlight@LINE:
+					X: 5
+					Y: 20
+					Height: 12
+					Font: TinyBold
 		Background@BADGES_CONTAINER:
 			Width: PARENT_RIGHT
 			Y: 0-1

--- a/mods/common/chrome/tooltips.yaml
+++ b/mods/common/chrome/tooltips.yaml
@@ -223,6 +223,26 @@ Background@REGISTERED_PLAYER_TOOLTIP:
 							Width: PARENT_RIGHT - 14
 							Height: 23
 							Font: Bold
+		Container@SERVER_CONTAINER:
+			Width: PARENT_RIGHT
+			Visible: false
+			Children:
+				Background@SEPARATOR:
+					X: 10
+					Height: 1
+					Background: tooltip-separator
+				Label@TITLE:
+					X: 7
+					Y: 5
+					Height: 12
+					Text: Server Information
+					Font: Bold
+				LabelWithHighlight@LINE:
+					X: 7
+					Y: 20
+					Width: PARENT_RIGHT - 14
+					Height: 14
+					Font: TinyBold
 		Container@BADGES_CONTAINER:
 			Width: PARENT_RIGHT
 			Visible: false

--- a/mods/d2k/chrome.yaml
+++ b/mods/d2k/chrome.yaml
@@ -430,6 +430,11 @@ dropdown-separators:
 		separator-pressed: 641, 2, 1, 19
 		separator-disabled: 513, 258, 1, 19
 
+tooltip-separator:
+	Inherits: ^Dialog
+	Regions:
+		border-t: 642, 1, 124, 1
+
 logos:
 	Inherits: ^LoadScreen
 	Regions:

--- a/mods/ra/chrome.yaml
+++ b/mods/ra/chrome.yaml
@@ -580,3 +580,8 @@ dropdown-separators:
 		separator-pressed: 766, 2, 1, 19
 		separator-disabled: 513, 258, 1, 19
 		observer-separator: 769, 258, 1, 19
+
+tooltip-separator:
+	Inherits: ^Dialog
+	Regions:
+		border-t: 518, 387, 52, 1

--- a/mods/ts/chrome.yaml
+++ b/mods/ts/chrome.yaml
@@ -702,6 +702,11 @@ dropdown-separators:
 		separator-pressed: 766, 2, 1, 19
 		separator-disabled: 513, 258, 1, 19
 
+tooltip-separator:
+	Inherits: ^Dialog
+	Regions:
+		border-t: 518, 387, 52, 1
+
 logos:
 	Inherits: ^LoadScreen
 	Regions:


### PR DESCRIPTION
This PR allows dedicated servers to add up to three lines of custom text to a client, which will be displayed with formatting in the player tooltips. The main usecase is to show ladder stats in the competitive ladder servers, but server hosts can use this to display whatever text they want.

Server hosts will need to configure this feature by defining an appropriate server trait in mod.yaml. Many of our server hosts aren't experienced with C#, so I have included a default `AddRegisteredClientTooltip` trait that fetches content from a web endpoint. We may need to tweak the exact properties we expose to mod.yaml, but this gives a basic start.

This can be tested against @ubitux's ladder API by adding
```
QueryRegisteredClientTooltip:
    Endpoint: http://oraladder.net/player-miniyaml/
```
to mod.yaml and `AddRegisteredClientTooltip` to the ServerTraits list, then starting a local MP server.
You'll need to have at least one game played on the ladder server (or spoof as somebody who has) for the content to be displayed.

<img width="313" src="https://user-images.githubusercontent.com/167819/113772754-05acf980-971d-11eb-930f-7b22d42fbe8d.png">
<img width="282" src="https://user-images.githubusercontent.com/167819/113772757-0776bd00-971d-11eb-9c4d-c93674657b09.png">
