### PR TITLE
Music separated by Factions 

### DIFF
--- a/OpenRA.Game/GameRules/MusicInfo.cs
+++ b/OpenRA.Game/GameRules/MusicInfo.cs
@@ -28,6 +28,7 @@ namespace OpenRA.GameRules
 		public MusicInfo(string key, MiniYaml value)
 		{
 			Title = value.Value;
+			Faction = string.Empty;
 
 			var nd = value.ToDictionary();
 			if (nd.ContainsKey("Hidden"))

--- a/OpenRA.Game/GameRules/MusicInfo.cs
+++ b/OpenRA.Game/GameRules/MusicInfo.cs
@@ -23,6 +23,7 @@ namespace OpenRA.GameRules
 
 		public int Length { get; private set; } // seconds
 		public bool Exists { get; private set; }
+		public string Faction { get; private set; }
 
 		public MusicInfo(string key, MiniYaml value)
 		{
@@ -34,6 +35,9 @@ namespace OpenRA.GameRules
 
 			if (nd.ContainsKey("VolumeModifier"))
 				VolumeModifier = FieldLoader.GetValue<float>("VolumeModifier", nd["VolumeModifier"].Value);
+
+			if (nd.ContainsKey("Faction"))
+				Faction = FieldLoader.GetValue<string>("Faction", nd["Faction"].Value);
 
 			var ext = nd.ContainsKey("Extension") ? nd["Extension"].Value : "aud";
 			Filename = (nd.ContainsKey("Filename") ? nd["Filename"].Value : key) + "." + ext;

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -206,6 +206,7 @@ namespace OpenRA
 		public bool CashTicks = true;
 		public bool Mute = false;
 		public bool MuteBackgroundMusic = false;
+		public bool FactionMusic = true;
 	}
 
 	public class PlayerSettings

--- a/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
+++ b/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
@@ -75,6 +75,17 @@ namespace OpenRA.Mods.Common.Traits
 				.Select(a => a.Value)
 				.ToArray();
 
+			if (Game.Settings.Sound.FactionMusic && world.LocalPlayer != null && !string.IsNullOrEmpty(world.LocalPlayer.Faction.Side))
+			{
+				var playerFaction = world.LocalPlayer.Faction.Side;
+
+				// TODO: need append non fraction music?
+				var factionMusicTheme = playlist
+					.Where(x => x.Faction.Equals(playerFaction, StringComparison.OrdinalIgnoreCase))
+					.ToArray();
+				playlist = factionMusicTheme;
+			}
+
 			random = playlist.Shuffle(Game.CosmeticRandom).ToArray();
 			IsMusicAvailable = playlist.Any();
 			AllowMuteBackgroundMusic = info.AllowMuteBackgroundMusic;
@@ -131,17 +142,6 @@ namespace OpenRA.Mods.Common.Traits
 		public MusicInfo[] AvailablePlaylist()
 		{
 			// TODO: add filter options for faction-specific music
-			if (Game.Settings.Sound.FactionMusic && world.LocalPlayer != null && !string.IsNullOrEmpty(world.LocalPlayer.Faction.Side))
-			{
-				var playerFaction = world.LocalPlayer.Faction.Side;
-
-				// TODO: need append non fraction music?
-				var factionMusicTheme = playlist
-					.Where(x => x.Faction.Equals(playerFaction, StringComparison.OrdinalIgnoreCase))
-					.ToArray();
-				return factionMusicTheme.Any() ? factionMusicTheme : playlist;
-			}
-
 			return playlist;
 		}
 
@@ -225,7 +225,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!IsMusicAvailable)
 				return null;
 
-			var songs = Game.Settings.Sound.Shuffle ? random : AvailablePlaylist();
+			var songs = Game.Settings.Sound.Shuffle ? random : playlist;
 
 			var next = reverse ? songs.Reverse().SkipWhile(m => m != currentSong)
 				.Skip(1).FirstOrDefault() ?? songs.Reverse().FirstOrDefault() :

--- a/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
+++ b/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
@@ -131,6 +131,17 @@ namespace OpenRA.Mods.Common.Traits
 		public MusicInfo[] AvailablePlaylist()
 		{
 			// TODO: add filter options for faction-specific music
+			if (world.LocalPlayer != null && !string.IsNullOrEmpty(world.LocalPlayer.Faction.Side))
+			{
+				var playerFaction = world.LocalPlayer.Faction.Side;
+
+				// TODO: need append non fraction music?
+				var factionMusicTheme = playlist
+					.Where(x => x.Faction.Equals(playerFaction, StringComparison.OrdinalIgnoreCase))
+					.ToArray();
+				return factionMusicTheme.Any() ? factionMusicTheme : playlist;
+			}
+
 			return playlist;
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
+++ b/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
@@ -131,7 +131,7 @@ namespace OpenRA.Mods.Common.Traits
 		public MusicInfo[] AvailablePlaylist()
 		{
 			// TODO: add filter options for faction-specific music
-			if (world.LocalPlayer != null && !string.IsNullOrEmpty(world.LocalPlayer.Faction.Side))
+			if (Game.Settings.Sound.FactionMusic && world.LocalPlayer != null && !string.IsNullOrEmpty(world.LocalPlayer.Faction.Side))
 			{
 				var playerFaction = world.LocalPlayer.Faction.Side;
 
@@ -225,7 +225,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!IsMusicAvailable)
 				return null;
 
-			var songs = Game.Settings.Sound.Shuffle ? random : playlist;
+			var songs = Game.Settings.Sound.Shuffle ? random : AvailablePlaylist();
 
 			var next = reverse ? songs.Reverse().SkipWhile(m => m != currentSong)
 				.Skip(1).FirstOrDefault() ?? songs.Reverse().FirstOrDefault() :

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/AudioSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/AudioSettingsLogic.cs
@@ -47,6 +47,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SettingsUtils.BindCheckboxPref(panel, "CASH_TICKS", ss, "CashTicks");
 			SettingsUtils.BindCheckboxPref(panel, "MUTE_SOUND", ss, "Mute");
 			SettingsUtils.BindCheckboxPref(panel, "MUTE_BACKGROUND_MUSIC", ss, "MuteBackgroundMusic");
+			SettingsUtils.BindCheckboxPref(panel, "FACTION_MUSIC", ss, "FactionMusic");
 
 			SettingsUtils.BindSliderPref(panel, "SOUND_VOLUME", ss, "SoundVolume");
 			SettingsUtils.BindSliderPref(panel, "MUSIC_VOLUME", ss, "MusicVolume");

--- a/mods/cnc/chrome/settings-audio.yaml
+++ b/mods/cnc/chrome/settings-audio.yaml
@@ -39,6 +39,13 @@ Container@AUDIO_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Mute Background Music
+				Checkbox@FACTION_MUSIC:
+					X: 15
+					Y: 133
+					Width: 200
+					Height: 20
+					Font: Regular
+					Text: Use Faction Music Theme
 				Label@SOUND_LABEL:
 					X: PARENT_RIGHT - WIDTH - 270
 					Y: 40

--- a/mods/common/chrome/settings-audio.yaml
+++ b/mods/common/chrome/settings-audio.yaml
@@ -33,6 +33,13 @@ Container@AUDIO_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Mute Background Music
+				Checkbox@FACTION_MUSIC:
+					X: 15
+					Y: 133
+					Width: 200
+					Height: 20
+					Font: Regular
+					Text: Use Faction Music Theme
 				Label@SOUND_LABEL:
 					X: PARENT_RIGHT - WIDTH - 270
 					Y: 40

--- a/mods/ra/audio/music.yaml
+++ b/mods/ra/audio/music.yaml
@@ -1,19 +1,29 @@
+# Faction music theme taken from the original 
+# https://github.com/electronicarts/CnC_Remastered_Collection/blob/master/REDALERT/THEME.CPP
 await_r: Afterlife (Await)
 	VolumeModifier: 0.7
+	Faction: Allies
 bigf226m: Bigfoot
 	VolumeModifier: 0.7
+	Faction: Allies
 crus226m: Crush
 	VolumeModifier: 0.7
+	Faction: Soviet
 dense_r: Dense
 	VolumeModifier: 0.7
+	Faction: Allies
 fac1226m: Face to the Enemy 1
 	VolumeModifier: 0.85
+	Faction: Allies
 fac2226m: Face to the Enemy 2
 	VolumeModifier: 0.7
+	Faction: Soviet
 fogger1a: Fogger
 	VolumeModifier: 0.8
+	Faction: Allies
 hell226m: Hell March
 	VolumeModifier: 0.7
+	Faction: Allies
 intro: Intro
 	Hidden: true
 	VolumeModifier: 0.9
@@ -22,57 +32,85 @@ map: Map
 	VolumeModifier: 0.6
 mud1a: Mud
 	VolumeModifier: 0.7
+	Faction: Allies
 radio2: Radio 2
 	VolumeModifier: 0.7
+	Faction: Allies
 credits: Reload Fire (Credits)
 	VolumeModifier: 0.9
 rollout: Roll Out
 	VolumeModifier: 0.7
+	Faction: Allies
 run1226m: Run (For Your Life)
 	VolumeModifier: 0.7
+	Faction: Soviet
 score: Militant Force (Scores)
 	Hidden: true
 	VolumeModifier: 0.7
 smsh226m: Smash
 	VolumeModifier: 0.7
+	Faction: Allies
 snake: Snake
 	VolumeModifier: 0.7
+	Faction: Allies
 terminat: Terminate
 	VolumeModifier: 0.7
+	Faction: Allies
 tren226m: Trenches
 	VolumeModifier: 0.7
+	Faction: Soviet
 twin: Twin Cannon
 	VolumeModifier: 0.7
+	Faction: Allies
 vector1a: Vector
 	VolumeModifier: 0.7
+	Faction: Allies
 work226m: Workmen
 	VolumeModifier: 0.7
+	Faction: Allies
 
 # Counterstrike tracks
 araziod: Arazoid
 	VolumeModifier: 0.8
+	Faction: Soviet
 backstab: Backstab
 	VolumeModifier: 0.9
+	Faction: Allies
 chaos2: Chaos
 	VolumeModifier: 0.9
+	Faction: Soviet
 shut_it: Shut It
 	VolumeModifier: 0.9
+	Faction: Allies
 2nd_hand: The Second Hand
+	Faction: Allies
 twinmix1: Twin Cannon (Remix)
 	VolumeModifier: 0.9
+	Faction: Soviet
 under3: Underlying Thoughts
 	VolumeModifier: 0.95
+	Faction: Allies
 vr2: Voice Rhythm 2
 	VolumeModifier: 0.95
+	Faction: Soviet
 
 # Aftermath tracks
 await: Afterlife (Await)
+	Faction: Allies
 bog: Bog
 	VolumeModifier: 0.9
+	Faction: Allies
 float_v2: Floating
+	Faction: Soviet
 gloom: Gloom
+	Faction: Allies
 grndwire: Groundwire
+	Faction: Soviet
 rpt: Running Through Pipes
+	Faction: Allies
 search: The Search
+	Faction: Soviet
 traction: Traction
+	Faction: Allies
 wastelnd: Wasteland
+	Faction: Soviet


### PR DESCRIPTION
Implement #19320 

Currently only for RA
Faction music theme taken from the original https://github.com/electronicarts/CnC_Remastered_Collection/blob/master/REDALERT/THEME.CPP

For other mods need change /audio/music.yaml