### PR TITLE
SquaredDistanceTo.

### DIFF
--- a/OpenRA.Game/CPos.cs
+++ b/OpenRA.Game/CPos.cs
@@ -85,6 +85,13 @@ namespace OpenRA
 			return new MPos(u, v);
 		}
 
+		public int SquaredDistanceTo(CPos other)
+		{
+			var x = X - other.X;
+			var y = Y - other.Y;
+			return x * x + y * y;
+		}
+
 		#region Scripting interface
 
 		public LuaValue Add(LuaRuntime runtime, LuaValue left, LuaValue right)

--- a/OpenRA.Game/Primitives/int2.cs
+++ b/OpenRA.Game/Primitives/int2.cs
@@ -84,6 +84,13 @@ namespace OpenRA
 							Math.Min(r.Bottom, Math.Max(Y, r.Top)));
 		}
 
+		public int SquaredDistanceTo(int2 other)
+		{
+			var x = X - other.X;
+			var y = Y - other.Y;
+			return x * x + y * y;
+		}
+
 		public static int Dot(int2 a, int2 b) { return a.X * b.X + a.Y * b.Y; }
 	}
 }

--- a/OpenRA.Game/Traits/World/ScreenShaker.cs
+++ b/OpenRA.Game/Traits/World/ScreenShaker.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Traits
 		{
 			var cp = worldRenderer.Viewport.CenterPosition;
 			var intensity = 100 * 1024 * 1024 * shakeEffects.Sum(
-				e => (float)e.Intensity / (e.Position - cp).LengthSquared);
+				e => (float)e.Intensity / e.Position.SquaredDistanceTo(cp));
 
 			return Math.Min(intensity, 10);
 		}

--- a/OpenRA.Game/WPos.cs
+++ b/OpenRA.Game/WPos.cs
@@ -78,6 +78,14 @@ namespace OpenRA
 
 		public override string ToString() { return X + "," + Y + "," + Z; }
 
+		public int SquaredDistanceTo(WPos other)
+		{
+			var x = X - other.X;
+			var y = Y - other.Y;
+			var z = Z - other.Z;
+			return x * x + y * y + z * z;
+		}
+
 		#region Scripting interface
 
 		public LuaValue Add(LuaRuntime runtime, LuaValue left, LuaValue right)

--- a/OpenRA.Game/WorldUtils.cs
+++ b/OpenRA.Game/WorldUtils.cs
@@ -26,12 +26,12 @@ namespace OpenRA
 
 		public static Actor ClosestTo(this IEnumerable<Actor> actors, WPos pos)
 		{
-			return actors.MinByOrDefault(a => (a.CenterPosition - pos).LengthSquared);
+			return actors.MinByOrDefault(a => a.CenterPosition.SquaredDistanceTo(pos));
 		}
 
 		public static WPos PositionClosestTo(this IEnumerable<WPos> positions, WPos pos)
 		{
-			return positions.MinByOrDefault(p => (p - pos).LengthSquared);
+			return positions.MinByOrDefault(p => p.SquaredDistanceTo(pos));
 		}
 
 		public static IEnumerable<Actor> FindActorsInCircle(this World world, WPos origin, WDist r)

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -203,7 +203,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// HACK: Consider ourselves blocked if we have moved by less than 64 WDist in the last five ticks
 			// Stop if we are blocked and close enough
-			if (positionBuffer.Count >= 5 && (positionBuffer.Last() - positionBuffer[0]).LengthSquared < 4096 &&
+			if (positionBuffer.Count >= 5 && positionBuffer.Last().SquaredDistanceTo(positionBuffer[0]) < 4096 &&
 				delta.HorizontalLengthSquared <= nearEnough.LengthSquared)
 				return true;
 

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -110,7 +110,7 @@ namespace OpenRA.Mods.Common.Activities
 			landingCell = self.World.Map.CellContaining(targetPosition);
 
 			// We are already at the landing location.
-			if ((targetPosition - pos).LengthSquared == 0)
+			if (targetPosition.SquaredDistanceTo(pos) == 0)
 				return true;
 
 			// Look for free landing cell

--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -189,7 +189,7 @@ namespace OpenRA.Mods.Common.Activities
 					domainIndex.IsPassable(self.Location, loc, mobile.Locomotor) && harv.CanHarvestCell(self, loc) && claimLayer.CanClaimCell(self, loc))
 				.WithCustomCost(loc =>
 				{
-					if ((loc - searchFromLoc).LengthSquared > searchRadiusSquared)
+					if (loc.SquaredDistanceTo(searchFromLoc) > searchRadiusSquared)
 						return int.MaxValue;
 
 					// Add a cost modifier to harvestable cells to prefer resources that are closer to the refinery.

--- a/OpenRA.Mods.Common/Activities/Move/LocalMoveIntoTarget.cs
+++ b/OpenRA.Mods.Common/Activities/Move/LocalMoveIntoTarget.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Activities
 			var targetPos = target.Positions.PositionClosestTo(currentPos);
 
 			// Give up if the target has moved too far
-			if (targetMovementThreshold > WDist.Zero && (targetPos - targetStartPos).LengthSquared > targetMovementThreshold.LengthSquared)
+			if (targetMovementThreshold > WDist.Zero && targetPos.SquaredDistanceTo(targetStartPos) > targetMovementThreshold.LengthSquared)
 				return true;
 
 			// Turn if required

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -243,7 +243,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				// Are we close enough?
 				var cellRange = nearEnough.Length / 1024;
-				if (!containsTemporaryBlocker && (mobile.ToCell - destination.Value).LengthSquared <= cellRange * cellRange && mobile.CanStayInCell(mobile.ToCell))
+				if (!containsTemporaryBlocker && mobile.ToCell.SquaredDistanceTo(destination.Value) <= cellRange * cellRange && mobile.CanStayInCell(mobile.ToCell))
 				{
 					// Apply some simple checks to avoid giving up in cases where we can be confident that
 					// nudging/waiting/repathing should produce better results.
@@ -258,10 +258,10 @@ namespace OpenRA.Mods.Common.Activities
 					// We can reasonably assume that the blocker is friendly and has a similar locomotor type.
 					// If there is a free cell next to the blocker that is a similar or closer distance to the
 					// destination then we can probably nudge or path around it.
-					var blockerDistSq = (nextCell - destination.Value).LengthSquared;
+					var blockerDistSq = nextCell.SquaredDistanceTo(destination.Value);
 					var nudgeOrRepath = CVec.Directions
 						.Select(d => nextCell + d)
-						.Any(c => c != self.Location && (c - destination.Value).LengthSquared <= blockerDistSq && mobile.CanEnterCell(c, ignoreActor));
+						.Any(c => c != self.Location && c.SquaredDistanceTo(destination.Value) <= blockerDistSq && mobile.CanEnterCell(c, ignoreActor));
 
 					if (!nudgeOrRepath)
 					{
@@ -316,7 +316,7 @@ namespace OpenRA.Mods.Common.Activities
 					var newCell = mobile.GetAdjacentCell(nextCell);
 					if (newCell != null)
 					{
-						if ((nextCell - newCell).Value.LengthSquared > 2)
+						if (nextCell.SquaredDistanceTo(newCell.Value) > 2)
 							path.Add(mobile.ToCell);
 
 						return (newCell.Value, mobile.GetAvailableSubCell(newCell.Value, mobile.FromSubCell, ignoreActor));

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			// Wait until we are near the target before we try to lock it
-			var distSq = (cargo.CenterPosition - self.CenterPosition).HorizontalLengthSquared;
+			var distSq = cargo.CenterPosition.SquaredDistanceTo(self.CenterPosition);
 			if (state == PickupState.Intercept && distSq <= targetLockRange.LengthSquared)
 				state = PickupState.LockCarryable;
 

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -138,7 +138,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (repairableNear == null)
 					QueueChild(move.MoveTo(targetCell, targetLineColor: moveInfo.GetTargetLineColor()));
 
-				var delta = (self.CenterPosition - host.CenterPosition).LengthSquared;
+				var delta = self.CenterPosition.SquaredDistanceTo(host.CenterPosition);
 				transportCallers.FirstOrDefault(t => t.MinimumDistance.LengthSquared < delta)?.RequestTransport(self, targetCell);
 
 				return false;

--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common
 
 		public static CPos ClosestCell(this Actor self, IEnumerable<CPos> cells)
 		{
-			return cells.MinByOrDefault(c => (self.Location - c).LengthSquared);
+			return cells.MinByOrDefault(c => self.Location.SquaredDistanceTo(c));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/HitShapes/Polygon.cs
+++ b/OpenRA.Mods.Common/HitShapes/Polygon.cs
@@ -52,16 +52,16 @@ namespace OpenRA.Mods.Common.HitShapes
 			combatOverlayVertsTop = Points.Select(p => new WVec(p.X, p.Y, VerticalTopOffset)).ToArray();
 			combatOverlayVertsBottom = Points.Select(p => new WVec(p.X, p.Y, VerticalBottomOffset)).ToArray();
 			squares = new int[Points.Length];
-			squares[0] = (Points[0] - Points[Points.Length - 1]).LengthSquared;
+			squares[0] = Points[0].SquaredDistanceTo(Points[Points.Length - 1]);
 			for (var i = 1; i < Points.Length; i++)
-				squares[i] = (Points[i] - Points[i - 1]).LengthSquared;
+				squares[i] = Points[i].SquaredDistanceTo(Points[i - 1]);
 		}
 
 		static int DistanceSquaredFromLineSegment(int2 c, int2 a, int2 b, int ab2)
 		{
 			var ac = c - a;
 			var ac2 = ac.LengthSquared;
-			var bc2 = (c - b).LengthSquared;
+			var bc2 = c.SquaredDistanceTo(b);
 
 			// c is closest to point a
 			if (ac2 + ab2 <= bc2)
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.HitShapes
 			var ap = new int2((int)((long)ab.X * ap2 / ab2), (int)((long)ab.Y * ap2 / ab2));
 
 			// Length of vector pc squared.
-			return (ac - ap).LengthSquared;
+			return ac.SquaredDistanceTo(ap);
 		}
 
 		public WDist DistanceFromEdge(in WVec v)

--- a/OpenRA.Mods.Common/Traits/AffectsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/AffectsShroud.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.Traits
 			var projectedLocation = self.World.Map.CellContaining(projectedPos);
 			var pos = self.CenterPosition;
 
-			var dirty = Info.MoveRecalculationThreshold.Length > 0 && (pos - cachedPos).LengthSquared > Info.MoveRecalculationThreshold.LengthSquared;
+			var dirty = Info.MoveRecalculationThreshold.Length > 0 && pos.SquaredDistanceTo(cachedPos) > Info.MoveRecalculationThreshold.LengthSquared;
 			if (!dirty && cachedLocation == projectedLocation)
 				return;
 

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -384,7 +384,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				// Sort by distance to target if we have one
 				if (center != target)
-					cells = cells.OrderBy(c => (c - target).LengthSquared);
+					cells = cells.OrderBy(c => c.SquaredDistanceTo(target));
 				else
 					cells = cells.Shuffle(world.LocalRandom);
 

--- a/OpenRA.Mods.Common/Traits/BotModules/CaptureManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/CaptureManagerBotModule.cs
@@ -159,7 +159,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var capturer in capturers)
 			{
-				var targetActor = capturableTargetOptions.MinByOrDefault(target => (target.CenterPosition - capturer.Actor.CenterPosition).LengthSquared);
+				var targetActor = capturableTargetOptions.MinByOrDefault(target => target.CenterPosition.SquaredDistanceTo(capturer.Actor.CenterPosition));
 				if (targetActor == null)
 					continue;
 

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -187,7 +187,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				// Sort by distance to target if we have one
 				if (center != target)
-					cells = cells.OrderBy(c => (c - target).LengthSquared);
+					cells = cells.OrderBy(c => c.SquaredDistanceTo(target));
 				else
 					cells = cells.Shuffle(world.LocalRandom);
 

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/NavyStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/NavyStates.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				// If the naval production is within MaxBaseRadius, it implies that
 				// this squad is close to enemy territory and they should expect a naval combat;
 				// closest enemy makes more sense in that case.
-				if ((nearest.Location - first.Location).LengthSquared > owner.SquadManager.Info.MaxBaseRadius * owner.SquadManager.Info.MaxBaseRadius)
+				if (nearest.Location.SquaredDistanceTo(first.Location) > owner.SquadManager.Info.MaxBaseRadius * owner.SquadManager.Info.MaxBaseRadius)
 					return nearest;
 			}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
@@ -54,8 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 			// called on the same exits in the same order!
 			var all = Exits(actor, productionType)
 				.OrderByDescending(e => e.Info.Priority)
-				.ThenBy(e => (actor.World.Map.CenterOfCell(actor.Location + e.Info.ExitCell) - pos).LengthSquared)
-				.ToList();
+				.ThenBy(e => actor.World.Map.CenterOfCell(actor.Location + e.Info.ExitCell).SquaredDistanceTo(pos)).ToList();
 
 			return p != null ? all.FirstOrDefault(p) : all.FirstOrDefault();
 		}

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -197,7 +197,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			return self.World.ActorsWithTrait<DetectCloaked>().Any(a => a.Actor.Owner.IsAlliedWith(viewer)
 				&& Info.CloakTypes.Overlaps(a.Trait.Info.CloakTypes)
-				&& (self.CenterPosition - a.Actor.CenterPosition).LengthSquared <= a.Trait.Range.LengthSquared);
+				&& self.CenterPosition.SquaredDistanceTo(a.Actor.CenterPosition) <= a.Trait.Range.LengthSquared);
 		}
 
 		Color IRadarColorModifier.RadarColorOverride(Actor self, Color color)

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -122,7 +122,7 @@ namespace OpenRA.Mods.Common.Traits
 					&& a.Actor.Owner.IsAlliedWith(self.Owner) &&
 					Info.RepairActors.Contains(a.Actor.Info.Name))
 				.OrderBy(a => a.Actor.Owner == self.Owner ? 0 : 1)
-				.ThenBy(p => (self.Location - p.Actor.Location).LengthSquared);
+				.ThenBy(p => self.Location.SquaredDistanceTo(p.Actor.Location));
 
 			// Worst case FirstOrDefault() will return a TraitPair<null, null>, which is OK.
 			return repairBuilding.FirstOrDefault().Actor;

--- a/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.Traits
 				? state.AvailableSpawnPoints.Random(playerRandom)
 				: state.AvailableSpawnPoints // pick the most distant spawnpoint from everyone else
 					.Select(s => (Cell: state.SpawnLocations[s - 1], Index: s))
-					.MaxBy(s => state.OccupiedSpawnPoints.Sum(kv => (state.SpawnLocations[kv.Key - 1] - s.Cell).LengthSquared)).Index;
+					.MaxBy(s => state.OccupiedSpawnPoints.Sum(kv => state.SpawnLocations[kv.Key - 1].SquaredDistanceTo(s.Cell))).Index;
 
 			state.AvailableSpawnPoints.Remove(spawnPoint);
 			state.OccupiedSpawnPoints.Add(spawnPoint, client);
@@ -151,7 +151,7 @@ namespace OpenRA.Mods.Common.Traits
 				? availableSpawnPoints.Random(playerRandom)
 				: availableSpawnPoints // pick the most distant spawnpoint from everyone else
 					.Select(s => (Cell: spawnLocations[s - 1], Index: s))
-					.MaxBy(s => occupiedSpawnPoints.Sum(kv => (spawnLocations[kv.Key - 1] - s.Cell).LengthSquared)).Index;
+					.MaxBy(s => occupiedSpawnPoints.Sum(kv => spawnLocations[kv.Key - 1].SquaredDistanceTo(s.Cell))).Index;
 
 			availableSpawnPoints.Remove(spawnPoint);
 			occupiedSpawnPoints.Add(spawnPoint, client);

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -76,12 +76,12 @@ namespace OpenRA.Mods.Common.Traits
 			if (domainIndex != null && !domainIndex.IsPassable(source, target, locomotor))
 				return EmptyPath;
 
-			var distance = source - target;
+			var distanceSquared = source.SquaredDistanceTo(target);
 			var canMoveFreely = locomotor.CanMoveFreelyInto(self, target, check, null);
-			if (distance.LengthSquared < 3 && !canMoveFreely)
+			if (distanceSquared < 3 && !canMoveFreely)
 				return new List<CPos> { };
 
-			if (source.Layer == target.Layer && distance.LengthSquared < 3 && canMoveFreely)
+			if (source.Layer == target.Layer && distanceSquared < 3 && canMoveFreely)
 				return new List<CPos> { target };
 
 			List<CPos> pb;
@@ -112,8 +112,9 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Select only the tiles that are within range from the requested SubCell
 			// This assumes that the SubCell does not change during the path traversal
+			var rangeLengthSquared = range.LengthSquared;
 			var tilesInRange = world.Map.FindTilesInCircle(targetCell, range.Length / 1024 + 1)
-				.Where(t => (world.Map.CenterOfCell(t) - target).LengthSquared <= range.LengthSquared
+				.Where(t => world.Map.CenterOfCell(t).SquaredDistanceTo(target) <= rangeLengthSquared
 							&& mobile.Info.CanEnterCell(self.World, self, t));
 
 			// See if there is any cell within range that does not involve a cross-domain request


### PR DESCRIPTION

In many places the distance between two vectors (`CPos`, `WPos`, `int2`) is calculated using `(a-b).LengthSquared`.

`a.SquaredDistanceTo(b)` is more readable and clearer about the intent.

It offers the trivial performance improvement that no temporary vector `(a-b)` is allocated on which `operator-` is called. Both which do not seem to be inlined.




