### PR TITLE
Work around unreasonably long Socket.Send delays on the server

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -122,9 +123,14 @@ namespace OpenRA.Server
 					if (error == SocketError.WouldBlock)
 					{
 						Log.Write("server", "Non-blocking send of {0} bytes failed. Falling back to blocking send.", length - start);
+						var startTimestamp = Stopwatch.GetTimestamp();
+
 						s.Blocking = true;
 						sent = s.Send(data, start, length - start, SocketFlags.None);
 						s.Blocking = false;
+
+						var elapsedMs = (Stopwatch.GetTimestamp() - startTimestamp) * 1000f / Stopwatch.Frequency;
+						Log.Write("server", "Blocking send completed in {0}ms.", elapsedMs);
 					}
 					else if (error != SocketError.Success)
 						throw new SocketException((int)error);


### PR DESCRIPTION
Closes #19334.
This should also fix the server "crashes" reported by the multiplayer community when a client drops.

This is really not an elegant fix, but it is the best that we can hope for without a major rewrite of the server code.