### PR TITLE
GameSettings, EnableDiscordService.

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -258,6 +258,9 @@ namespace OpenRA
 		public MPGameFilters MPGameFilters = MPGameFilters.Waiting | MPGameFilters.Empty | MPGameFilters.Protected | MPGameFilters.Started;
 
 		public bool PauseShellmap = false;
+
+		[Desc("Allow mods to enable the Discord service that can interact with a local Discord client.")]
+		public bool EnableDiscordService = true;
 	}
 
 	public class Settings

--- a/OpenRA.Mods.Common/DiscordService.cs
+++ b/OpenRA.Mods.Common/DiscordService.cs
@@ -43,6 +43,9 @@ namespace OpenRA.Mods.Common
 				if (instance != null)
 					return instance;
 
+				if (!Game.Settings.Game.EnableDiscordService)
+					return null;
+
 				if (!Game.ModData.Manifest.Contains<DiscordService>())
 					return null;
 


### PR DESCRIPTION

`GameSettings.EnableDiscordService` to allow users to manually edit the setting.yaml to disable the start of the Discord thread by mods that have the DiscordService trait.

Useful for players that do not use a local Discord client. And useful to be able to exclude the Discord thread from profiling reports. The thread shows up using 33% of CPU time.



