### PR TITLE
Updated RA unit speeds to account for move jumpy-ness fix.

### DIFF
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -331,7 +331,7 @@
 	RevealsShroud:
 		Range: 4c0
 	Mobile:
-		Speed: 56
+		Speed: 54
 		AlwaysTurnInPlace: true
 		Locomotor: foot
 	Selectable:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -19,7 +19,7 @@ DOG:
 	Health:
 		HP: 1800
 	Mobile:
-		Speed: 99
+		Speed: 100
 		Voice: Move
 		PauseOnCondition: attack-cooldown || eating
 	Guard:
@@ -133,7 +133,7 @@ E2:
 	Health:
 		HP: 5000
 	Mobile:
-		Speed: 71
+		Speed: 68
 	Armament@PRIMARY:
 		Weapon: Grenade
 		LocalOffset: 0,0,555
@@ -394,7 +394,7 @@ E7:
 	Health:
 		HP: 10000
 	Mobile:
-		Speed: 71
+		Speed: 68
 		Voice: Move
 	Guard:
 		Voice: Move
@@ -453,7 +453,7 @@ MEDI:
 	Health:
 		HP: 6000
 	Mobile:
-		Speed: 50
+		Speed: 49
 	RevealsShroud:
 		Range: 3c0
 	Passenger:
@@ -496,7 +496,7 @@ MECH:
 	Health:
 		HP: 8000
 	Mobile:
-		Speed: 50
+		Speed: 49
 		Voice: Move
 	RevealsShroud:
 		Range: 3c0
@@ -541,7 +541,7 @@ EINSTEIN:
 	Tooltip:
 		Name: Prof. Einstein
 	Mobile:
-		Speed: 71
+		Speed: 68
 	Voiced:
 		VoiceSet: EinsteinVoice
 
@@ -551,7 +551,7 @@ DELPHI:
 	Tooltip:
 		Name: Agent Delphi
 	Mobile:
-		Speed: 71
+		Speed: 68
 
 CHAN:
 	Inherits: ^CivInfantry
@@ -648,7 +648,7 @@ THF:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical
 	Mobile:
-		Speed: 71
+		Speed: 68
 	-AttackFrontal:
 
 SHOK:
@@ -772,7 +772,7 @@ Zombie:
 	Health:
 		HP: 25000
 	Mobile:
-		Speed: 42
+		Speed: 39
 	AutoTarget:
 		ScanRadius: 5
 	WithInfantryBody:
@@ -811,7 +811,7 @@ Ant:
 	Health:
 		HP: 75000
 	Mobile:
-		Speed: 99
+		Speed: 92
 		TurnSpeed: 48
 		Locomotor: lighttracked
 	-Crushable:
@@ -838,7 +838,7 @@ FireAnt:
 		Name: Fire Ant
 		GenericVisibility: none
 	Mobile:
-		Speed: 80
+		Speed: 68
 	Armament:
 		Weapon: AntFireball
 	Health:
@@ -868,7 +868,7 @@ WarriorAnt:
 		Name: Warrior Ant
 		GenericVisibility: none
 	Mobile:
-		Speed: 65
+		Speed: 56
 	Health:
 		HP: 12500
 	Armor:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -19,7 +19,7 @@ SS:
 		Type: Light
 	Mobile:
 		TurnSpeed: 16
-		Speed: 71
+		Speed: 78
 	RevealsShroud:
 		MinRange: 5c0
 		Range: 8c0
@@ -86,7 +86,7 @@ MSUB:
 		Type: Light
 	Mobile:
 		TurnSpeed: 12
-		Speed: 42
+		Speed: 44
 	RevealsShroud:
 		MinRange: 5c0
 		Range: 8c0
@@ -157,7 +157,7 @@ DD:
 		Type: Heavy
 	Mobile:
 		TurnSpeed: 28
-		Speed: 85
+		Speed: 92
 	RevealsShroud:
 		MinRange: 5c0
 		Range: 6c0
@@ -209,7 +209,7 @@ CA:
 		Type: Heavy
 	Mobile:
 		TurnSpeed: 12
-		Speed: 42
+		Speed: 44
 	RevealsShroud:
 		MinRange: 5c0
 		Range: 7c0
@@ -271,7 +271,7 @@ LST:
 		Type: Heavy
 	Mobile:
 		Locomotor: lcraft
-		Speed: 113
+		Speed: 128
 		PauseOnCondition: notmobile
 	RevealsShroud:
 		MinRange: 5c0
@@ -311,7 +311,7 @@ PT:
 		Type: Heavy
 	Mobile:
 		TurnSpeed: 28
-		Speed: 128
+		Speed: 142
 	RevealsShroud:
 		MinRange: 5c0
 		Range: 7c0

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -18,7 +18,7 @@ V2RL:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 85
+		Speed: 72
 	RevealsShroud:
 		MinRange: 4c0
 		Range: 5c0
@@ -68,7 +68,7 @@ V2RL:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 118
+		Speed: 113
 	RevealsShroud:
 		MinRange: 4c0
 		Range: 5c0
@@ -110,7 +110,7 @@ V2RL:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 85
+		Speed: 72
 	RevealsShroud:
 		MinRange: 4c0
 		Range: 6c0
@@ -156,7 +156,7 @@ V2RL:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 71
+		Speed: 60
 	RevealsShroud:
 		MinRange: 4c0
 		Range: 6c0
@@ -202,7 +202,7 @@ V2RL:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 50
+		Speed: 43
 		Locomotor: heavytracked
 	RevealsShroud:
 		MinRange: 4c0
@@ -261,7 +261,7 @@ ARTY:
 		Type: Light
 	Mobile:
 		TurnSpeed: 8
-		Speed: 85
+		Speed: 72
 		Locomotor: lighttracked
 	RevealsShroud:
 		MinRange: 4c0
@@ -312,7 +312,7 @@ HARV:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 85
+		Speed: 72
 		Locomotor: heavywheeled
 	RevealsShroud:
 		Range: 4c0
@@ -365,7 +365,7 @@ MCV:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 71
+		Speed: 60
 		Locomotor: heavywheeled
 	RevealsShroud:
 		Range: 4c0
@@ -451,7 +451,7 @@ APC:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 142
+		Speed: 128
 		PauseOnCondition: notmobile || being-captured
 	RevealsShroud:
 		MinRange: 4c0
@@ -491,7 +491,7 @@ MNLY:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 128
+		Speed: 113
 	RevealsShroud:
 		MinRange: 4c0
 		Range: 5c0
@@ -540,7 +540,7 @@ TRUK:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 128
+		Speed: 113
 	RevealsShroud:
 		Range: 4c0
 	DeliversCash:
@@ -567,7 +567,7 @@ MGG:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 85
+		Speed: 72
 	WithIdleOverlay@SPINNER:
 		Offset: -299,0,171
 		Sequence: spinner
@@ -601,7 +601,7 @@ MRJ:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 78
+		Speed: 68
 	RevealsShroud:
 		Range: 7c0
 	WithIdleOverlay@SPINNER:
@@ -641,7 +641,7 @@ TTNK:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 99
+		Speed: 92
 	RevealsShroud:
 		MinRange: 6c0
 		Range: 7c0
@@ -681,7 +681,7 @@ FTRK:
 		Type: Light
 	Mobile:
 		TurnSpeed: 40
-		Speed: 118
+		Speed: 113
 	RevealsShroud:
 		MinRange: 4c0
 		Range: 6c0
@@ -727,7 +727,7 @@ DTRK:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 85
+		Speed: 72
 	RevealsShroud:
 		Range: 4c0
 	Explodes:
@@ -769,7 +769,7 @@ CTNK:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 96
+		Speed: 86
 		Locomotor: heavywheeled
 	RevealsShroud:
 		MinRange: 4c0
@@ -814,7 +814,7 @@ QTNK:
 	Mobile:
 		RequiresCondition: !deployed
 		PauseOnCondition: being-captured
-		Speed: 56
+		Speed: 46
 	Chronoshiftable:
 		RequiresCondition: !deployed && !being-captured
 	RevealsShroud:
@@ -854,7 +854,7 @@ STNK:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 142
+		Speed: 128
 		Locomotor: heavywheeled
 		PauseOnCondition: notmobile || being-captured
 	RevealsShroud:

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -14,68 +14,68 @@
 		Crushes: mine, crate
 		SharesCell: true
 		TerrainSpeeds:
-			Clear: 90
-			Rough: 80
-			Road: 100
-			Bridge: 100
-			Ore: 80
-			Gems: 80
-			Beach: 80
+			Clear: 100
+			Rough: 89
+			Road: 111
+			Bridge: 111
+			Ore: 89
+			Gems: 89
+			Beach: 89
 	Locomotor@WHEELED:
 		Name: wheeled
 		Crushes: mine, crate
 		TerrainSpeeds:
-			Clear: 80
-			Rough: 40
-			Road: 100
-			Bridge: 100
-			Ore: 70
-			Gems: 70
-			Beach: 40
+			Clear: 100
+			Rough: 50
+			Road: 125
+			Bridge: 125
+			Ore: 88
+			Gems: 88
+			Beach: 50
 	Locomotor@HEAVYWHEELED:
 		Name: heavywheeled
 		Crushes: wall, mine, crate, infantry
 		TerrainSpeeds:
-			Clear: 80
-			Rough: 40
-			Road: 100
-			Bridge: 100
-			Ore: 70
-			Gems: 70
-			Beach: 40
+			Clear: 100
+			Rough: 50
+			Road: 125
+			Bridge: 125
+			Ore: 88
+			Gems: 88
+			Beach: 50
 	Locomotor@LIGHTTRACKED:
 		Name: lighttracked
 		Crushes: wall, mine, crate
 		TerrainSpeeds:
-			Clear: 80
-			Rough: 70
-			Road: 100
-			Bridge: 100
-			Ore: 70
-			Gems: 70
-			Beach: 70
+			Clear: 100
+			Rough: 88
+			Road: 125
+			Bridge: 125
+			Ore: 88
+			Gems: 88
+			Beach: 88
 	Locomotor@TRACKED:
 		Name: tracked
 		Crushes: wall, infantry, mine, crate
 		TerrainSpeeds:
-			Clear: 80
-			Rough: 70
-			Road: 100
-			Bridge: 100
-			Ore: 70
-			Gems: 70
-			Beach: 70
+			Clear: 100
+			Rough: 88
+			Road: 125
+			Bridge: 125
+			Ore: 88
+			Gems: 88
+			Beach: 88
 	Locomotor@HEAVYTRACKED:
 		Name: heavytracked
 		Crushes: wall, infantry, mine, crate, heavywall
 		TerrainSpeeds:
-			Clear: 80
-			Rough: 70
-			Road: 100
-			Bridge: 100
-			Ore: 70
-			Gems: 70
-			Beach: 70
+			Clear: 100
+			Rough: 88
+			Road: 125
+			Bridge: 125
+			Ore: 88
+			Gems: 88
+			Beach: 88
 	Locomotor@NAVAL:
 		Name: naval
 		Crushes: crate


### PR DESCRIPTION
The recently merged https://github.com/OpenRA/OpenRA/pull/19220 causes the speeds of all non-aircraft units to change.

This adjusts all of the RA unit speeds so that their in-game movement is the same as it was prior to the fix.

In addition I've adjusted all the locomotors to have 100% movement on clear terrain, as this makes for easier comparison between units using different locomotors - given that most time is spent on clear terrain. There may be some very minor differences due to rounding for the other terrain types, but it should be close enough to not be noticeable/impactful.

As the APC/Phase Tank now have 128 speed, a fix for https://github.com/OpenRA/OpenRA/issues/19347 would also be needed. Edit: Have changed these to 127 for the time being, as it seems equally close to the original speed.

Video of before and after side by side (APC and Transport speeds are incorrect, as noted above): https://www.youtube.com/watch?v=GtFThkpMmfE

Addendum: 1TNK and FTRK previously had speed 118, and MNLY/TRUK previously had speed 128, but their actual speeds in-game were the same. Have given all of these the same speed to reflect the previous behaviour, will leave it to balancers to decide whether to adjust them for any intended difference.

--

To figure out the speeds I just created a map with 50 cells of water in a line, to use as a measuring stick. Then I used the stopwatch on my phone, clicking each unit to move from one end of the line to the other, starting the timer on clicking, and ending when the unit stops moving. Maybe not the most accurate way to do it, but it seemed to work well enough (I'd reliably get times within maybe .2 seconds for the same speed). Then it was just a case of trial and error trying out speeds with the movement fix in place to find the closest match for each unique speed.

Speeds used in RA vs time taken (s) to traverse 50 cells (starting on cell 1, ending on 50):

Vehicles/Ants

50 - 47.15
56 - 43.45
65 - 35.68
71 - 33.5
78 - 29.8
80 - 29.8
85 - 27.86
96 - 23.9
99 - 21.9
118 - 18.15
128 - 17.92
142 - 15.96
170 - 12.13

Ships

42 - 45.47
71 - 25.94
85 - 21.93
113 - 15.9
128 - 14.06

Infantry

42 - 51.1
50 - 41.43
56 - 37.64
71 - 29.8
99 - 20

I did go through them quite quickly so I'll probably go back and double check. Could also measure in ticks using the in-game performance info combined with pausing, but would be subject to a similar margin of error.