### PR TITLE
Split RA expansion mission categories

### DIFF
--- a/mods/ra/missions.yaml
+++ b/mods/ra/missions.yaml
@@ -29,18 +29,20 @@ Soviet Campaign:
 	soviet-09
 	soviet-11a
 	soviet-11b
-Counterstrike:
+Counterstrike Allied Missions:
 	sarin-gas-1-crackdown
 	sarin-gas-2-down-under
 	sarin-gas-3-controlled-burn
 	fall-of-greece-1-personal-war
 	siberian-conflict-1-fresh-tracks
 	siberian-conflict-3-wasteland
+Counterstrike Soviet Missions:
 	soviet-soldier-volkov-n-chitzkoi
 	top-o-the-world
-Aftermath:
+Aftermath Allied Missions:
 	production-disruption
 	monster-tank-madness
+Aftermath Soviet Missions:
 	shock-therapy
 	situation-critical
 OpenRA Originals:


### PR DESCRIPTION
It's not always apparent from the title which faction an expansion mission belongs to, and players may want to know beforehand instead of having to guess.

Also made all title words start uppercase for consistency.