### PR TITLE
Make ProductionFromMapEdge attack-move units

### DIFF
--- a/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -96,7 +97,7 @@ namespace OpenRA.Mods.Common.Traits
 				var move = newUnit.TraitOrDefault<IMove>();
 				if (move != null)
 					foreach (var cell in destinations)
-						newUnit.QueueActivity(move.MoveTo(cell, 2, evaluateNearestMovableCell: true));
+						newUnit.QueueActivity(new AttackMoveActivity(newUnit, () => move.MoveTo(cell, 2, evaluateNearestMovableCell: true, targetLineColor: Color.OrangeRed)));
 
 				if (!self.IsDead)
 					foreach (var t in self.TraitsImplementing<INotifyProduction>())


### PR DESCRIPTION
It seemed odd for this production trait in particular to not attack-move the produced unit, so I took the liberty of pasting in the same line from the other production traits but kept the nearEnough parameter the same.

Tested in D2K and carryall arrival worked normally