### PR TITLE
Allow each armament to define ammo used

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/LayMines.cs
+++ b/OpenRA.Mods.Cnc/Activities/LayMines.cs
@@ -147,7 +147,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				if (pool == null)
 					return;
 
-				pool.TakeAmmo(self, 1);
+				pool.TakeAmmo(self, minelayer.Info.AmmoUsage);
 			}
 
 			self.World.AddFrameEndTask(w => w.CreateActor(minelayer.Info.Mine, new TypeDictionary

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -62,6 +62,9 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Cursor to display when able to lay a mine.")]
 		public readonly string AbilityCursor = "ability";
 
+		[Desc("Ammo the minelayer consumes per mine.")]
+		public readonly int AmmoUsage = 1;
+
 		public override object Create(ActorInitializer init) { return new Minelayer(init.Self, this); }
 	}
 

--- a/OpenRA.Mods.Common/Traits/AmmoPool.cs
+++ b/OpenRA.Mods.Common/Traits/AmmoPool.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.Traits
 		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
 			if (a != null && Info.Armaments.Contains(a.Info.Name))
-				TakeAmmo(self, 1);
+				TakeAmmo(self, a.Info.AmmoUsage);
 		}
 
 		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel) { }

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -83,6 +83,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Cursor to display when hovering over a valid target that is outside of range.")]
 		public readonly string OutsideRangeCursor = "attackoutsiderange";
 
+		[Desc("Ammo the weapon consumes per shot.")]
+		public readonly int AmmoUsage = 1;
+
 		public override object Create(ActorInitializer init) { return new Armament(init.Self, this); }
 
 		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)


### PR DESCRIPTION
This allows modders to make certain weapons use more ammo from the same pool than others. Test case included: RA Longbow should be only able to fire half as many missiles against air as it does against ground, no unexpected changes with behavior of other use cases so far.