### PR TITLE
Add engine support for RGBA remap hue/saturation colour shifts.

### DIFF
--- a/OpenRA.Game/Graphics/PaletteReference.cs
+++ b/OpenRA.Game/Graphics/PaletteReference.cs
@@ -28,5 +28,7 @@ namespace OpenRA.Graphics
 			this.index = index;
 			this.hardwarePalette = hardwarePalette;
 		}
+
+		public bool HasColorShift => hardwarePalette.HasColorShift(Name);
 	}
 }

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -125,6 +125,7 @@ namespace OpenRA
 	{
 		void SetData(uint[,] colors);
 		void SetData(byte[] colors, int width, int height);
+		void SetFloatData(float[] data, int width, int height);
 		byte[] GetData();
 		Size Size { get; }
 		TextureScaleFilter ScaleFilter { get; set; }

--- a/OpenRA.Game/Graphics/SpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderable.cs
@@ -41,6 +41,12 @@ namespace OpenRA.Graphics
 			this.isDecoration = isDecoration;
 			this.tintModifiers = tintModifiers;
 			this.alpha = alpha;
+
+			// PERF: Remove useless palette assignments for RGBA sprites
+			// HACK: This is working around the fact that palettes are defined on traits rather than sequences
+			// and can be removed once this has been fixed
+			if (sprite.Channel == TextureChannel.RGBA && !(palette?.HasColorShift ?? false))
+				this.palette = null;
 		}
 
 		public WPos Pos => pos + offset;

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -116,14 +116,28 @@ namespace OpenRA.Graphics
 			nv += 6;
 		}
 
+		float ResolveTextureIndex(Sprite s, PaletteReference pal)
+		{
+			if (pal == null)
+				return 0;
+
+			// PERF: Remove useless palette assignments for RGBA sprites
+			// HACK: This is working around the limitation that palettes are defined on traits rather than on sequences,
+			// and can be removed once this has been fixed
+			if (s.Channel == TextureChannel.RGBA && !pal.HasColorShift)
+				return 0;
+
+			return pal.TextureIndex;
+		}
+
 		public void DrawSprite(Sprite s, in float3 location, PaletteReference pal)
 		{
-			DrawSprite(s, location, pal.TextureIndex, s.Size);
+			DrawSprite(s, location, ResolveTextureIndex(s, pal), s.Size);
 		}
 
 		public void DrawSprite(Sprite s, in float3 location, PaletteReference pal, float3 size)
 		{
-			DrawSprite(s, location, pal.TextureIndex, size);
+			DrawSprite(s, location, ResolveTextureIndex(s, pal), size);
 		}
 
 		public void DrawSprite(Sprite s, in float3 a, in float3 b, in float3 c, in float3 d)
@@ -142,7 +156,7 @@ namespace OpenRA.Graphics
 
 		public void DrawSprite(Sprite s, in float3 location, PaletteReference pal, in float3 size, in float3 tint, float alpha)
 		{
-			DrawSprite(s, location, pal.TextureIndex, size, tint, alpha);
+			DrawSprite(s, location, ResolveTextureIndex(s, pal), size, tint, alpha);
 		}
 
 		public void DrawSprite(Sprite s, in float3 a, in float3 b, in float3 c, in float3 d, in float3 tint, float alpha)
@@ -189,9 +203,10 @@ namespace OpenRA.Graphics
 			nv += v.Length;
 		}
 
-		public void SetPalette(ITexture palette)
+		public void SetPalette(ITexture palette, ITexture colorShifts)
 		{
 			shader.SetTexture("Palette", palette);
+			shader.SetTexture("ColorShifts", colorShifts);
 		}
 
 		public void SetViewportParams(Size screen, float depthScale, float depthOffset, int2 scroll)

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Graphics
 {
 	public class SpriteRenderer : Renderer.IBatchRenderer
 	{
-		public const int SheetCount = 7;
+		public const int SheetCount = 8;
 		static readonly string[] SheetIndexToTextureName = Exts.MakeArray(SheetCount, i => $"Texture{i}");
 
 		readonly Renderer renderer;

--- a/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
+++ b/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
@@ -164,6 +164,12 @@ namespace OpenRA.Graphics
 					throw new InvalidDataException("Attempted to add sprite with a different blend mode");
 
 				samplers = new int2(GetOrAddSheetIndex(sprite.Sheet), GetOrAddSheetIndex((sprite as SpriteWithSecondaryData)?.SecondarySheet));
+
+				// PERF: Remove useless palette assignments for RGBA sprites
+				// HACK: This is working around the limitation that palettes are defined on traits rather than on sequences,
+				// and can be removed once this has been fixed
+				if (sprite.Channel == TextureChannel.RGBA && !(palette?.HasColorShift ?? false))
+					palette = null;
 			}
 			else
 			{

--- a/OpenRA.Game/Graphics/UISpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/UISpriteRenderable.cs
@@ -32,6 +32,12 @@ namespace OpenRA.Graphics
 			this.palette = palette;
 			this.scale = scale;
 			this.alpha = alpha;
+
+			// PERF: Remove useless palette assignments for RGBA sprites
+			// HACK: This is working around the fact that palettes are defined on traits rather than sequences
+			// and can be removed once this has been fixed
+			if (sprite.Channel == TextureChannel.RGBA && !(palette?.HasColorShift ?? false))
+				this.palette = null;
 		}
 
 		// Does not exist in the world, so a world positions don't make sense

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -109,6 +109,11 @@ namespace OpenRA.Graphics
 				palettes[name].Palette = pal;
 		}
 
+		public void SetPaletteColorShift(string name, float hueOffset, float satOffset, float minHue, float maxHue)
+		{
+			palette.SetColorShift(name, hueOffset, satOffset, minHue, maxHue);
+		}
+
 		// PERF: Avoid LINQ.
 		void GenerateRenderables()
 		{

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -249,14 +249,16 @@ namespace OpenRA
 
 		public void SetPalette(HardwarePalette palette)
 		{
+			// Note: palette.Texture and palette.ColorShifts are updated at the same time
+			// so we only need to check one of the two to know whether we must update the textures
 			if (palette.Texture == currentPaletteTexture)
 				return;
 
 			Flush();
 			currentPaletteTexture = palette.Texture;
 
-			SpriteRenderer.SetPalette(currentPaletteTexture);
-			WorldSpriteRenderer.SetPalette(currentPaletteTexture);
+			SpriteRenderer.SetPalette(currentPaletteTexture, palette.ColorShifts);
+			WorldSpriteRenderer.SetPalette(currentPaletteTexture, palette.ColorShifts);
 			WorldModelRenderer.SetPalette(currentPaletteTexture);
 		}
 

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -144,6 +144,8 @@ namespace OpenRA.Platforms.Default
 		public const int GL_INFO_LOG_LENGTH = 0x8B84;
 		public const int GL_ACTIVE_UNIFORMS = 0x8B86;
 
+		public const int GL_RGBA16F = 0x881A;
+
 		// OpenGL 4.3
 		public const int GL_DEBUG_OUTPUT = 0x92E0;
 		public const int GL_DEBUG_OUTPUT_SYNCHRONOUS = 0x8242;

--- a/OpenRA.Platforms.Default/Texture.cs
+++ b/OpenRA.Platforms.Default/Texture.cs
@@ -110,6 +110,25 @@ namespace OpenRA.Platforms.Default
 			}
 		}
 
+		public void SetFloatData(float[] data, int width, int height)
+		{
+			VerifyThreadAffinity();
+			if (!Exts.IsPowerOf2(width) || !Exts.IsPowerOf2(height))
+				throw new InvalidDataException("Non-power-of-two array {0}x{1}".F(width, height));
+
+			Size = new Size(width, height);
+			unsafe
+			{
+				fixed (float* ptr = &data[0])
+				{
+					PrepareTexture();
+					OpenGL.glTexImage2D(OpenGL.GL_TEXTURE_2D, 0, OpenGL.GL_RGBA16F, width, height,
+						0, OpenGL.GL_RGBA, OpenGL.GL_FLOAT, new IntPtr(ptr));
+					OpenGL.CheckGLError();
+				}
+			}
+		}
+
 		public byte[] GetData()
 		{
 			VerifyThreadAffinity();

--- a/glsl/combined.frag
+++ b/glsl/combined.frag
@@ -10,6 +10,7 @@ uniform sampler2D Texture3;
 uniform sampler2D Texture4;
 uniform sampler2D Texture5;
 uniform sampler2D Texture6;
+uniform sampler2D Texture7;
 uniform sampler2D Palette;
 
 uniform bool EnableDepthPreview;
@@ -35,6 +36,7 @@ uniform vec2 Texture3Size;
 uniform vec2 Texture4Size;
 uniform vec2 Texture5Size;
 uniform vec2 Texture6Size;
+uniform vec2 Texture7Size;
 #else
 in vec4 vColor;
 
@@ -82,8 +84,10 @@ vec2 Size(float samplerIndex)
 		return Texture4Size;
 	else if (samplerIndex < 5.5)
 		return Texture5Size;
+	else if (samplerIndex < 6.5)
+		return Texture6Size;
 
-	return Texture6Size;
+	return Texture7Size;
 }
 
 vec4 Sample(float samplerIndex, vec2 pos)
@@ -100,8 +104,10 @@ vec4 Sample(float samplerIndex, vec2 pos)
 		return texture2D(Texture4, pos);
 	else if (samplerIndex < 5.5)
 		return texture2D(Texture5, pos);
+	else if (samplerIndex < 6.5)
+		return texture2D(Texture6, pos);
 
-	return texture2D(Texture6, pos);
+	return texture2D(Texture7, pos);
 }
 #else
 ivec2 Size(float samplerIndex)
@@ -118,8 +124,10 @@ ivec2 Size(float samplerIndex)
 		return textureSize(Texture4, 0);
 	else if (samplerIndex < 5.5)
 		return textureSize(Texture5, 0);
+	else if (samplerIndex < 6.5)
+		return textureSize(Texture6, 0);
 
-	return textureSize(Texture6, 0);
+	return textureSize(Texture7, 0);
 }
 
 vec4 Sample(float samplerIndex, vec2 pos)
@@ -136,8 +144,10 @@ vec4 Sample(float samplerIndex, vec2 pos)
 		return texture(Texture4, pos);
 	else if (samplerIndex < 5.5)
 		return texture(Texture5, pos);
+	else if (samplerIndex < 6.5)
+		return texture(Texture6, pos);
 
-	return texture(Texture6, pos);
+	return texture(Texture7, pos);
 }
 #endif
 


### PR DESCRIPTION
This PR implements the engine backend for chroma-keyed player colours on 32bit sprites.

Depends on #19335 (only the last 4 commits are new).

#3692 basically forces us to treat these as add-ons to existing indexed palettes. This fits well with our first major usecase (remastered asset support), but isn't great for mods that might want to exclusively use 32 bit sprites. The actual engine plumbing won't change much, but this does impact the way we set up the traits.

For this reason i'm limiting this PR to the engine plumbing, and leaving the actual traits to downstream mods until #3692 has been finished. This strikes a balance where advanced modders can start to use the feature and provide feedback/bugs but not lock us into supporting a set of traits that we know will need to be replaced.

The testcase commit adds @mabulsoud's chronosphere to the asset browser. Open the asset browser, search for pdox.png, and notice that it responds to the color picker.