### PR TITLE
Fix a crash when using legacy GL.

### DIFF
--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -631,6 +631,7 @@ namespace OpenRA.Platforms.Default
 					glGenVertexArrays = null;
 					glBindVertexArray = null;
 					glBindFragDataLocation = null;
+					glGetTexImage = Bind<GetTexImage>("glGetTexImage");
 					glGenFramebuffers = Bind<GenFramebuffers>("glGenFramebuffersEXT");
 					glBindFramebuffer = Bind<BindFramebuffer>("glBindFramebufferEXT");
 					glFramebufferTexture2D = Bind<FramebufferTexture2D>("glFramebufferTexture2DEXT");


### PR DESCRIPTION
This fixes a regression introduced by #18666.

It may be deprecated and disabled by default, but we might as well keep this functional until we're ready to remove it.