### PR TITLE
Add visual projectile interpolation

### DIFF
--- a/OpenRA.Mods.Cnc/Effects/GpsSatellite.cs
+++ b/OpenRA.Mods.Cnc/Effects/GpsSatellite.cs
@@ -54,7 +54,8 @@ namespace OpenRA.Mods.Cnc.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			return anim.Render(pos, wr.Palette(palette));
+			var visualPos = WPos.Lerp(pos, pos + new WVec(0, 0, 427), Game.RenderInterpolatedTimestepProgress, wr.World.Timestep);
+			return anim.Render(visualPos, wr.Palette(palette));
 		}
 	}
 }


### PR DESCRIPTION
This PR adds some world tick / RunTime tracking to the game loop (that could be used for interpolating visual actor positions as well) and adds interpolaton to (sprite) projectiles.