### PR TITLE
Updated TD unit speeds to account for move jumpy-ness fix.

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -465,7 +465,7 @@
 		Name: Civilian
 		GenericVisibility: None
 	Mobile:
-		Speed: 56
+		Speed: 54
 	Health:
 		HP: 2500
 	RevealsShroud:
@@ -562,7 +562,7 @@
 		Range: 6c0
 	Mobile:
 		Voice: Move
-		Speed: 71
+		Speed: 68
 		Locomotor: critter
 	Selectable:
 		Bounds: 1024, 1024

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -15,7 +15,7 @@ E1:
 		Queue: Infantry.GDI, Infantry.Nod
 		Description: General-purpose infantry.\n  Strong vs Infantry\n  Weak vs Vehicles
 	Mobile:
-		Speed: 56
+		Speed: 54
 	Health:
 		HP: 5000
 	AutoTarget:
@@ -43,7 +43,7 @@ E2:
 		Queue: Infantry.GDI
 		Description: Fast infantry armed with grenades. \n  Strong vs Buildings, slow-moving targets
 	Mobile:
-		Speed: 71
+		Speed: 68
 	Health:
 		HP: 5000
 	AutoTarget:
@@ -78,7 +78,7 @@ E3:
 		Queue: Infantry.GDI, Infantry.Nod
 		Description: Anti-tank/Anti-aircraft infantry. \n  Strong vs Tanks, Aircraft\n  Weak vs Infantry
 	Mobile:
-		Speed: 42
+		Speed: 39
 	Health:
 		HP: 4500
 	AutoTarget:
@@ -109,7 +109,7 @@ E4:
 		Queue: Infantry.Nod
 		Description: Advanced Anti-infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Tanks
 	Mobile:
-		Speed: 56
+		Speed: 54
 	Health:
 		HP: 9000
 	AutoTarget:
@@ -142,7 +142,7 @@ E5:
 		Queue: Infantry.Nod
 		Description: Advanced general-purpose infantry.\n  Strong vs all Ground units
 	Mobile:
-		Speed: 56
+		Speed: 54
 		Locomotor: chem
 	Health:
 		HP: 9000
@@ -175,7 +175,7 @@ E6:
 		Queue: Infantry.GDI, Infantry.Nod
 		Description: Damages and captures enemy structures.\n  Repairs destroyed vehicles\n  Unarmed
 	Mobile:
-		Speed: 48
+		Speed: 46
 	Health:
 		HP: 3000
 	Passenger:
@@ -209,7 +209,7 @@ RMBO:
 		Queue: Infantry.GDI
 		Description: Elite sniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles
 	Mobile:
-		Speed: 71
+		Speed: 68
 		Voice: Move
 	Guard:
 		Voice: Move

--- a/mods/cnc/rules/ships.yaml
+++ b/mods/cnc/rules/ships.yaml
@@ -14,7 +14,7 @@ BOAT:
 	Armor:
 		Type: Heavy
 	TDGunboat:
-		Speed: 28
+		Speed: 29
 	RevealsShroud:
 		Range: 7c0
 		Type: CenterPosition
@@ -60,7 +60,7 @@ LST:
 		Locomotor: lcraft
 		InitialFacing: 0
 		TurnSpeed: 16
-		Speed: 142
+		Speed: 170
 		PauseOnCondition: notmobile
 	Health:
 		HP: 40000

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -13,7 +13,7 @@ MCV:
 	Selectable:
 		DecorationBounds: 1536, 1536
 	Mobile:
-		Speed: 71
+		Speed: 60
 		Locomotor: heavywheeled
 	Health:
 		HP: 120000
@@ -63,7 +63,7 @@ HARV:
 		HarvestFacings: 8
 		EmptyCondition: no-tiberium
 	Mobile:
-		Speed: 85
+		Speed: 72
 	Health:
 		HP: 62500
 	Repairable:
@@ -114,7 +114,7 @@ APC:
 		Description: Armed infantry transport.\nCan attack Aircraft.\n  Strong vs Vehicles\n  Weak vs Infantry
 	Mobile:
 		TurnSpeed: 20
-		Speed: 132
+		Speed: 128
 		PauseOnCondition: notmobile
 	Health:
 		HP: 19000
@@ -189,7 +189,7 @@ ARTY:
 		Description: Long-range artillery.\n  Strong vs Infantry, Vehicles and Buildings
 	Mobile:
 		TurnSpeed: 16
-		Speed: 85
+		Speed: 72
 	Health:
 		HP: 7500
 	Repairable:
@@ -235,7 +235,7 @@ FTNK:
 		Description: Heavily armored flame-throwing vehicle.\n  Strong vs Infantry, Buildings and Vehicles\n  Weak vs Tanks
 	Mobile:
 		TurnSpeed: 28
-		Speed: 99
+		Speed: 92
 	Health:
 		HP: 27000
 	Repairable:
@@ -318,7 +318,7 @@ BIKE:
 		Description: Fast scout vehicle, armed with\nrockets.\nCan attack Aircraft.\n  Strong vs Vehicles, Tanks\n  Weak vs Infantry
 	Mobile:
 		TurnSpeed: 40
-		Speed: 184
+		Speed: 192
 		Locomotor: wheeled
 	Health:
 		HP: 11000
@@ -356,7 +356,7 @@ JEEP:
 		Description: Fast scout and anti-infantry vehicle.\n  Strong vs Infantry\n  Weak vs Tanks
 	Mobile:
 		TurnSpeed: 40
-		Speed: 156
+		Speed: 145
 	Health:
 		HP: 16000
 	Repairable:
@@ -398,7 +398,7 @@ LTNK:
 		Description: Fast, light tank.\n  Strong vs Vehicles, Tanks\n  Weak vs Infantry
 	Mobile:
 		TurnSpeed: 28
-		Speed: 110
+		Speed: 102
 	Health:
 		HP: 34000
 	Repairable:
@@ -440,7 +440,7 @@ MTNK:
 		Queue: Vehicle.GDI
 		Description: General-Purpose GDI Tank.\n  Strong vs Tanks, Vehicles\n  Weak vs Infantry
 	Mobile:
-		Speed: 85
+		Speed: 72
 	Health:
 		HP: 45000
 	Repairable:
@@ -488,7 +488,7 @@ HTNK:
 		Description: Heavily armored GDI Tank.\nCan attack Aircraft.\n  Strong vs Everything
 	Mobile:
 		Locomotor: heavytracked
-		Speed: 56
+		Speed: 46
 		TurnSpeed: 12
 	Health:
 		HP: 87000
@@ -548,7 +548,7 @@ MSAM:
 		Queue: Vehicle.GDI
 		Description: Long range rocket artillery.\n  Strong vs all Ground units.
 	Mobile:
-		Speed: 85
+		Speed: 72
 		TurnSpeed: 16
 	Health:
 		HP: 12000
@@ -599,7 +599,7 @@ MLRS:
 		Queue: Vehicle.Nod
 		Description: Powerful anti-air unit.\nCannot attack Ground units.
 	Mobile:
-		Speed: 99
+		Speed: 92
 		TurnSpeed: 28
 	Health:
 		HP: 18000
@@ -657,7 +657,7 @@ STNK:
 	Mobile:
 		Locomotor: heavywheeled
 		TurnSpeed: 40
-		Speed: 142
+		Speed: 127
 	Targetable:
 		TargetTypes: Ground, Vehicle, StealthTank
 	Health:
@@ -708,7 +708,7 @@ MHQ:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 85
+		Speed: 72
 	RevealsShroud:
 		Range: 6c0
 	WithIdleOverlay@SPINNER:
@@ -735,7 +735,7 @@ TRUCK:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 128
+		Speed: 113
 	RevealsShroud:
 		Range: 4c0
 	DeliversCash:

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -20,71 +20,71 @@
 		Crushes: crate
 		SharesCell: true
 		TerrainSpeeds:
-			Clear: 90
-			Rough: 80
-			Road: 100
-			Bridge: 100
-			Tiberium: 70
+			Clear: 100
+			Rough: 89
+			Road: 111
+			Bridge: 111
+			Tiberium: 78
 				PathingCost: 300
-			BlueTiberium: 70
+			BlueTiberium: 78
 				PathingCost: 300
-			Beach: 80
+			Beach: 89
 	Locomotor@CHEM:
 		Name: chem
 		Crushes: crate
 		SharesCell: true
 		TerrainSpeeds:
-			Clear: 90
-			Rough: 80
-			Road: 100
-			Bridge: 100
-			Tiberium: 90
-			BlueTiberium: 90
-			Beach: 80
+			Clear: 100
+			Rough: 89
+			Road: 111
+			Bridge: 111
+			Tiberium: 100
+			BlueTiberium: 100
+			Beach: 89
 	Locomotor@WHEELED:
 		Name: wheeled
 		Crushes: crate
 		TerrainSpeeds:
-			Clear: 80
-			Rough: 50
-			Road: 100
-			Bridge: 100
-			Tiberium: 50
-			BlueTiberium: 50
+			Clear: 100
+			Rough: 63
+			Road: 125
+			Bridge: 125
+			Tiberium: 63
+			BlueTiberium: 63
 			Beach: 50
 	Locomotor@HEAVYWHEELED:
 		Name: heavywheeled
 		Crushes: crate, infantry
 		TerrainSpeeds:
-			Clear: 80
-			Rough: 50
-			Road: 100
-			Bridge: 100
-			Tiberium: 50
-			BlueTiberium: 50
+			Clear: 100
+			Rough: 63
+			Road: 125
+			Bridge: 125
+			Tiberium: 63
+			BlueTiberium: 63
 			Beach: 50
 	Locomotor@TRACKED:
 		Name: tracked
 		Crushes: wall, crate, infantry
 		TerrainSpeeds:
-			Clear: 80
-			Rough: 70
-			Road: 100
-			Bridge: 100
-			Tiberium: 70
-			BlueTiberium: 70
-			Beach: 70
+			Clear: 100
+			Rough: 88
+			Road: 125
+			Bridge: 125
+			Tiberium: 88
+			BlueTiberium: 88
+			Beach: 88
 	Locomotor@HEAVYTRACKED:
 		Name: heavytracked
 		Crushes: wall, heavywall, crate, infantry
 		TerrainSpeeds:
-			Clear: 80
-			Rough: 70
-			Road: 100
-			Bridge: 100
-			Tiberium: 70
-			BlueTiberium: 70
-			Beach: 70
+			Clear: 100
+			Rough: 88
+			Road: 125
+			Bridge: 125
+			Tiberium: 88
+			BlueTiberium: 88
+			Beach: 88
 	Locomotor@NAVAL:
 		Name: naval
 		Crushes: crate
@@ -105,13 +105,13 @@
 	Locomotor@CRITTER:
 		Name: critter
 		TerrainSpeeds:
-			Clear: 90
-			Rough: 80
-			Road: 100
-			Bridge: 100
-			Tiberium: 70
-			BlueTiberium: 70
-			Beach: 80
+			Clear: 100
+			Rough: 89
+			Road: 111
+			Bridge: 111
+			Tiberium: 78
+			BlueTiberium: 78
+			Beach: 89
 	Faction@Random:
 		Name: Any
 		InternalName: Random


### PR DESCRIPTION
Following on from: https://github.com/OpenRA/OpenRA/pull/19348

The recently merged #19220 causes the speeds of all non-aircraft units to change.

This adjusts all of the TD unit speeds so that their in-game movement is the same as it was prior to the fix.

It has been pointed out that there'll also be differences when units are turning while moving which can't be as straightforwardly tested, so this should just serve as the starting point for more fine tuning.

In addition I've adjusted all the locomotors to have 100% movement on clear terrain, as this makes for easier comparison between units using different locomotors - given that most time is spent on clear terrain. There may be some very minor differences due to rounding for the other terrain types, but it should be close enough to not be noticeable/impactful.

Video of before and after side by side: https://www.youtube.com/watch?v=QyTt-eBmO_Y