### PR TITLE
Set primary structure according to shortest location to rally

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -151,12 +151,14 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					cursor = this.cursor;
 
-					// Notify force-set 'RallyPoint' order watchers with Ctrl and only if this is the only building of its type selected
+					// Notify force-set 'RallyPoint' order watchers with Ctrl
 					if (modifiers.HasModifier(TargetModifiers.ForceAttack))
 					{
 						var selfName = self.Info.Name;
-						if (!self.World.Selection.Actors.Any(a => a.Info.Name == selfName && a.ActorID != self.ActorID))
-							ForceSet = true;
+						ForceSet = self.World.Selection.Actors
+							.Where(a => a.Info.Name == selfName)
+							.OrderBy(a => (location - a.Location).LengthSquared)
+							.First().ActorID == self.ActorID;
 					}
 
 					return true;


### PR DESCRIPTION
When using the Ctrl modifier (force attack) while setting the rally
point of a production facility, it is set as primary. This commit makes
this behaviour work with a selection of structures (that can be of
different types) and using the one(s) closest to the rally point to be
flagged as primary.

This is useful gameplay wise typically when all production facilities
are in a control group, in order to redirect all the production at a
single point quickly.


https://user-images.githubusercontent.com/34467/116595360-88dbfc80-a923-11eb-93a0-0a75c71d2a5c.mp4

