### PR TITLE
Fixed Player Properties / Commands not rendering a ToC

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				Console.WriteLine("</table>");
 			}
 
-			Console.WriteLine("### Actor Properties / Commands");
+			Console.WriteLine("## Actor Properties / Commands");
 
 			var actorCategories = utility.ModData.ObjectCreator.GetTypesImplementing<ScriptActorProperties>().SelectMany(cg =>
 			{
@@ -140,7 +140,8 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			foreach (var kv in playerCategories)
 			{
-				Console.WriteLine("<table align=\"center\" width=\"1024\"><tr><th colspan=\"2\" width=\"1024\">{0}</th></tr>", kv.Key);
+				Console.WriteLine("### " + kv.Key);
+				Console.WriteLine("<table>");
 
 				foreach (var property in kv.OrderBy(p => p.Item2.Name))
 				{


### PR DESCRIPTION
This is a followup of https://github.com/OpenRA/OpenRA/pull/18681 to fix https://docs.openra.net/en/latest/release/lua/#player-properties-commands which doesn't render in the table of contents and uses a hard-coded width for the table.