### PR TITLE
Remove global fallback to software cursors on error.

### DIFF
--- a/OpenRA.Game/Graphics/CursorManager.cs
+++ b/OpenRA.Game/Graphics/CursorManager.cs
@@ -106,33 +106,32 @@ namespace OpenRA.Graphics
 			// Dispose any existing cursors to avoid leaking native resources
 			ClearHardwareCursors();
 
-			try
+			foreach (var kv in cursors)
 			{
-				foreach (var kv in cursors)
+				var template = kv.Value;
+				for (var i = 0; i < template.Sprites.Length; i++)
 				{
-					var template = kv.Value;
-					for (var i = 0; i < template.Sprites.Length; i++)
+					if (template.Cursors[i] != null)
+						template.Cursors[i].Dispose();
+
+					// Calculate the padding to position the frame within sequenceBounds
+					var paddingTL = -(template.Bounds.Location - template.Sprites[i].Offset.XY.ToInt2());
+					var paddingBR = template.PaddedSize - new int2(template.Sprites[i].Bounds.Size) - paddingTL;
+
+					try
 					{
-						if (template.Cursors[i] != null)
-							template.Cursors[i].Dispose();
-
-						// Calculate the padding to position the frame within sequenceBounds
-						var paddingTL = -(template.Bounds.Location - template.Sprites[i].Offset.XY.ToInt2());
-						var paddingBR = template.PaddedSize - new int2(template.Sprites[i].Bounds.Size) - paddingTL;
-
 						template.Cursors[i] = CreateHardwareCursor(kv.Key, template.Sprites[i], paddingTL, paddingBR, -template.Bounds.Location);
 					}
+					catch (Exception e)
+					{
+						Log.Write("debug", "Failed to initialize hardware cursor for {0}.", template.Name);
+						Log.Write("debug", "Error was: " + e.Message);
+
+						Console.WriteLine("Failed to initialize hardware cursor for {0}.", template.Name);
+						Console.WriteLine("Error was: " + e.Message);
+						template.Cursors[i] = null;
+					}
 				}
-			}
-			catch (Exception e)
-			{
-				Log.Write("debug", "Failed to initialize hardware cursors. Falling back to software cursors.");
-				Log.Write("debug", "Error was: " + e.Message);
-
-				Console.WriteLine("Failed to initialize hardware cursors. Falling back to software cursors.");
-				Console.WriteLine("Error was: " + e.Message);
-
-				ClearHardwareCursors();
 			}
 
 			hardwareCursorsDoubled = graphicSettings.CursorDouble;
@@ -177,10 +176,11 @@ namespace OpenRA.Graphics
 			if (cursor != null && frame >= cursor.Cursors.Length)
 				frame %= cursor.Cursors.Length;
 
-			if (cursor == null || isLocked)
+			var hardwareCursor = cursor?.Cursors[frame];
+			if (hardwareCursor == null || isLocked)
 				Game.Renderer.Window.SetHardwareCursor(null);
 			else
-				Game.Renderer.Window.SetHardwareCursor(cursor.Cursors[frame]);
+				Game.Renderer.Window.SetHardwareCursor(hardwareCursor);
 		}
 
 		public void Render(Renderer renderer)


### PR DESCRIPTION
#10172 is still an problem for some players, and we still have no idea on how to solve it. The latest release (probably the SDL update) seems to have changed the specific audience who experience it, which triggered some discussion in Discord that brought this back to my attention.

We know that only one or two cursors seem to fail during any single game load, but the original all-or-nothing hardware cursor implementation meant that we had to throw away everything and use software rendering for all cursors. This limitation was removed as part of the support power drag targeting and RGBA cursor support PRs, so we can now do much better.

This PR removes the global fallback for all cursor types, and instead only renders software cursors for the specific ones that failed to load. This should hopefully bring a noticeable improvement for players who suffer from the bug.

Suggested testcase:

Comment out
https://github.com/OpenRA/OpenRA/blob/771932354b2ced702986bb70432576adcc832e30/OpenRA.Game/Graphics/CursorManager.cs#L192-L194

so that both hardware and software cursors are rendered, then add

```csharp
if (template.Name == "default")
	throw new NotImplementedException();
```

inside the `try` inside `CreateOrUpdateHardwareCursors`.

Run the game and notice that all cursor types except default show duplicated cursors.