### PR TITLE
Improve yaml configuration and lint checks for move cursors

### DIFF
--- a/OpenRA.Game/Map/TerrainInfo.cs
+++ b/OpenRA.Game/Map/TerrainInfo.cs
@@ -54,7 +54,6 @@ namespace OpenRA
 		public readonly HashSet<string> AcceptsSmudgeType = new HashSet<string>();
 		public readonly Color Color;
 		public readonly bool RestrictPlayerColor = false;
-		public readonly string CustomCursor;
 
 		public TerrainTypeInfo(MiniYaml my) { FieldLoader.Load(this, my); }
 	}

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -162,6 +162,14 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly BooleanExpression RequireForceMoveCondition = null;
 
 		[CursorReference]
+		[Desc("Cursor to display when a move order can be issued at target location.")]
+		public readonly string Cursor = "move";
+
+		[CursorReference]
+		[Desc("Cursor to display when a move order cannot be issued at target location.")]
+		public readonly string BlockedCursor = "move-blocked";
+
+		[CursorReference]
 		[Desc("Cursor to display when able to land at target building.")]
 		public readonly string EnterCursor = "enter";
 
@@ -1285,8 +1293,8 @@ namespace OpenRA.Mods.Common.Traits
 
 				var explored = self.Owner.Shroud.IsExplored(location);
 				cursor = !aircraft.IsTraitPaused && (explored || aircraft.Info.MoveIntoShroud) && self.World.Map.Contains(location) ?
-					(self.World.Map.GetTerrainInfo(location).CustomCursor ?? "move") :
-					"move-blocked";
+					(self.World.Map.GetTerrainInfo(location).CustomCursor ?? aircraft.Info.Cursor) :
+					aircraft.Info.BlockedCursor;
 
 				return true;
 			}

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -1293,8 +1293,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				var explored = self.Owner.Shroud.IsExplored(location);
 				cursor = !aircraft.IsTraitPaused && (explored || aircraft.Info.MoveIntoShroud) && self.World.Map.Contains(location) ?
-					(self.World.Map.GetTerrainInfo(location).CustomCursor ?? aircraft.Info.Cursor) :
-					aircraft.Info.BlockedCursor;
+					aircraft.Info.Cursor : aircraft.Info.BlockedCursor;
 
 				return true;
 			}

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
@@ -207,8 +207,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				var location = self.World.Map.CellContaining(target.CenterPosition);
 				var explored = self.Owner.Shroud.IsExplored(location);
-				cursor = self.World.Map.Contains(location) ?
-					self.World.Map.GetTerrainInfo(location).CustomCursor ?? aircraft.Info.Cursor : aircraft.Info.BlockedCursor;
+				cursor = self.World.Map.Contains(location) ? aircraft.Info.Cursor : aircraft.Info.BlockedCursor;
 
 				IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
 

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
@@ -35,6 +35,14 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool RequiresForceMove = false;
 
 		[CursorReference]
+		[Desc("Cursor to display when a move order can be issued at target location.")]
+		public readonly string Cursor = "move";
+
+		[CursorReference]
+		[Desc("Cursor to display when a move order cannot be issued at target location.")]
+		public readonly string BlockedCursor = "move-blocked";
+
+		[CursorReference]
 		[Desc("Cursor to display when able to land at target building.")]
 		public readonly string EnterCursor = "enter";
 
@@ -200,13 +208,13 @@ namespace OpenRA.Mods.Common.Traits
 				var location = self.World.Map.CellContaining(target.CenterPosition);
 				var explored = self.Owner.Shroud.IsExplored(location);
 				cursor = self.World.Map.Contains(location) ?
-					self.World.Map.GetTerrainInfo(location).CustomCursor ?? "move" : "move-blocked";
+					self.World.Map.GetTerrainInfo(location).CustomCursor ?? aircraft.Info.Cursor : aircraft.Info.BlockedCursor;
 
 				IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
 
 				if (!(self.CurrentActivity is Transform || aircraft.transforms.Any(t => !t.IsTraitDisabled && !t.IsTraitPaused))
 					|| (!explored && !aircraft.Info.MoveIntoShroud))
-					cursor = "move-blocked";
+					cursor = aircraft.Info.BlockedCursor;
 
 				return true;
 			}

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
@@ -29,6 +29,11 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Cursor to display when a move order can be issued at target location.")]
 		public readonly string Cursor = "move";
 
+		[CursorReference(dictionaryReference: LintDictionaryReference.Values)]
+		[Desc("Cursor overrides to display for specific terrain types.",
+			"A dictionary of [terrain type]: [cursor name].")]
+		public readonly Dictionary<string, string> TerrainCursors = new Dictionary<string, string>();
+
 		[CursorReference]
 		[Desc("Cursor to display when a move order cannot be issued at target location.")]
 		public readonly string BlockedCursor = "move-blocked";
@@ -192,13 +197,13 @@ namespace OpenRA.Mods.Common.Traits
 				IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
 
 				var explored = self.Owner.Shroud.IsExplored(location);
-				cursor = self.World.Map.Contains(location) ?
-					(self.World.Map.GetTerrainInfo(location).CustomCursor ?? mobile.Info.Cursor) : mobile.Info.BlockedCursor;
-
-				if (!(self.CurrentActivity is Transform || mobile.transforms.Any(t => !t.IsTraitDisabled && !t.IsTraitPaused))
-					|| (!explored && !mobile.locomotor.Info.MoveIntoShroud)
-					|| (explored && !CanEnterCell(self, location)))
+				if (!self.World.Map.Contains(location) ||
+				    !(self.CurrentActivity is Transform || mobile.transforms.Any(t => !t.IsTraitDisabled && !t.IsTraitPaused))
+				    || (!explored && !mobile.locomotor.Info.MoveIntoShroud)
+				    || (explored && !CanEnterCell(self, location)))
 					cursor = mobile.Info.BlockedCursor;
+				else if (!explored || !mobile.Info.TerrainCursors.TryGetValue(self.World.Map.GetTerrainInfo(location).Type, out cursor))
+					cursor = mobile.Info.Cursor;
 
 				return true;
 			}

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -432,9 +432,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				var location = self.World.Map.CellContaining(target.CenterPosition);
 				var explored = self.Owner.Shroud.IsExplored(location);
-				cursor = self.World.Map.Contains(location) ?
-					(self.World.Map.GetTerrainInfo(location).CustomCursor ?? info.DropOffCursor) :
-					info.DropOffBlockedCursor;
+				cursor = self.World.Map.Contains(location) ? info.DropOffCursor : info.DropOffBlockedCursor;
 
 				IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -45,6 +45,11 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Cursor to display when a move order can be issued at target location.")]
 		public readonly string Cursor = "move";
 
+		[CursorReference(dictionaryReference: LintDictionaryReference.Values)]
+		[Desc("Cursor overrides to display for specific terrain types.",
+			"A dictionary of [terrain type]: [cursor name].")]
+		public readonly Dictionary<string, string> TerrainCursors = new Dictionary<string, string>();
+
 		[CursorReference]
 		[Desc("Cursor to display when a move order cannot be issued at target location.")]
 		public readonly string BlockedCursor = "move-blocked";
@@ -996,13 +1001,14 @@ namespace OpenRA.Mods.Common.Traits
 				IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
 
 				var explored = self.Owner.Shroud.IsExplored(location);
-				cursor = self.World.Map.Contains(location) ?
-					(self.World.Map.GetTerrainInfo(location).CustomCursor ?? mobile.Info.Cursor) : mobile.Info.BlockedCursor;
 
-				if (mobile.IsTraitPaused
+				if (!self.World.Map.Contains(location)
+					|| mobile.IsTraitPaused
 					|| (!explored && !locomotorInfo.MoveIntoShroud)
 					|| (explored && mobile.Locomotor.MovementCostForCell(location) == short.MaxValue))
 					cursor = mobile.Info.BlockedCursor;
+				else if (!explored || !mobile.Info.TerrainCursors.TryGetValue(self.World.Map.GetTerrainInfo(location).Type, out cursor))
+					cursor = mobile.Info.Cursor;
 
 				return true;
 			}

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -319,6 +319,8 @@
 	Mobile:
 		AlwaysTurnInPlace: true
 		Locomotor: foot
+		TerrainCursors:
+			Rough: move-rough
 	Selectable:
 		Bounds: 768, 768, 0, -128
 		DecorationBounds: 384, 640, 0, -128

--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -38,7 +38,6 @@ Terrain:
 		Type: Rough
 		TargetTypes: Ground
 		Color: 587474
-		CustomCursor: move-rough
 	TerrainType@Sand:
 		Type: Sand
 		TargetTypes: Ground


### PR DESCRIPTION
Followup of #17933 and related PRs.

This exposes all but the last hardcoded uses of the move cursor to yaml and linting. The last use of `move-blocked` in `GuardOrderGenerator` will require a non-trivial rework of the guard code that should be done in its own PR.

I don't see a usecase for `TerrainCursors` on `Aircraft`, but I won't object to restoring that if somebody has a convincing reason to do so. Their use in `Carryall` was bogus to begin with.