### PR TITLE
Update the Desc of AttackBase.FacingTolerance

### DIFF
--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
-		[Desc("Tolerance for attack angle. Range [0, 128], 128 covers 360 degrees.")]
+		[Desc("Tolerance for attack angle. Range [0, 512], 512 covers 360 degrees.")]
 		public readonly WAngle FacingTolerance = new WAngle(512);
 
 		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)


### PR DESCRIPTION
Apparently the `Desc` wasn't updated during the `WAngle` change, but the default value was.