### PR TITLE
Add a backward moving option for mobile

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -43,6 +43,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		List<CPos> path;
 		CPos? destination;
+		int startTicks;
 
 		// For dealing with blockers
 		bool hasWaited;
@@ -116,6 +117,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected override void OnFirstRun(Actor self)
 		{
+			startTicks = self.World.WorldTick;
+
 			if (evaluateNearestMovableCell && destination.HasValue)
 			{
 				var movableDestination = mobile.NearestMoveableCell(destination.Value);
@@ -161,6 +164,10 @@ namespace OpenRA.Mods.Common.Activities
 				return false;
 
 			var firstFacing = self.World.Map.FacingBetween(mobile.FromCell, nextCell.Value.Cell, mobile.Facing);
+
+			if (mobile.Info.CanMoveBackward && self.World.WorldTick - startTicks < mobile.Info.BackwardDuration && Math.Abs(firstFacing.Angle - mobile.Facing.Angle) > 256)
+				firstFacing = new WAngle(firstFacing.Angle + 512);
+
 			if (firstFacing != mobile.Facing)
 			{
 				path.Add(nextCell.Value.Cell);

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -65,6 +65,12 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Display order for the facing slider in the map editor")]
 		public readonly int EditorFacingDisplayOrder = 3;
 
+		[Desc("Can move backward if possible")]
+		public readonly bool CanMoveBackward = false;
+
+		[Desc("After how many ticks the actor will turn forward during backoff")]
+		public readonly int BackwardDuration = 40;
+
 		[ConsumedConditionReference]
 		[Desc("Boolean expression defining the condition under which the regular (non-force) move cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;


### PR DESCRIPTION
An option allow actor to move backward if possible, which makes unit can be more flexible with ~~cnc3 and~~ General style

Suitable for TS style hover vehicle:
![back2](https://user-images.githubusercontent.com/13763394/117089772-1175f500-ad89-11eb-9f3d-fa05ff0c4a02.gif)

just ok for 4 leg turreted crawler:
![back4](https://user-images.githubusercontent.com/13763394/117093312-25265900-ad93-11eb-8929-1af610a370ad.gif)

just ok for normal vehicle
![1](https://user-images.githubusercontent.com/13763394/117137543-70188e80-addc-11eb-81bc-94d26bd4afcc.gif)
(BackwardDuration: 20)

History:
>Just OK for normal vehicle (we need better idea later because it move all its way backward):
>![back3](https://user-images.githubusercontent.com/13763394/117089782-19359980-ad89-11eb-9da9-1a61b77e306d.gif)
>![back](https://user-images.githubusercontent.com/13763394/117089787-1a66c680-ad89-11eb-85a4-3200b7bd8883.gif)

And if you enjoy dance step for 2 legs mech
![back5](https://user-images.githubusercontent.com/13763394/117094153-9b2bbf80-ad95-11eb-9d2e-86e039fb65cc.gif)
