### PR TITLE
Remove crate crushing from visceroids in TD and TS

### DIFF
--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -104,7 +104,6 @@
 			River: 100
 	Locomotor@CRITTER:
 		Name: critter
-		Crushes: crate
 		TerrainSpeeds:
 			Clear: 90
 			Rough: 80

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -157,7 +157,7 @@
 			Veins: 100
 	Locomotor@VISCEROID:
 		Name: visceroid
-		Crushes: crate, infantry
+		Crushes: infantry
 		TerrainSpeeds:
 			Clear: 90
 			Road: 100


### PR DESCRIPTION
Reported via Facebook. Visceroids can collect crates but apparently only get credits through them. I simply removed their ability to crush crates, as it doesn't really make sense to me anyway.