### PR TITLE
Fix: Making gravity bombs explode on hitting floor

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -234,6 +234,7 @@ namespace OpenRA.Traits
 		void RemovePosition(Actor a, IOccupySpace ios);
 		void UpdatePosition(Actor a, IOccupySpace ios);
 		IEnumerable<Actor> ActorsInBox(WPos a, WPos b);
+		IEnumerable<Actor> ActorsInCube(WPos a, WPos b);
 
 		WDist LargestActorRadius { get; }
 		WDist LargestBlockingActorRadius { get; }

--- a/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
@@ -94,9 +94,11 @@ namespace OpenRA.Mods.Common.Projectiles
 			lastPos = pos;
 			pos += velocity;
 			velocity += acceleration;
+			var distanceAboveTerrain = world.Map.DistanceAboveTerrain(pos);
 
-			if (world.Map.DistanceAboveTerrain(pos) <= WDist.Zero)
+			if (distanceAboveTerrain <= WDist.Zero)
 			{
+				pos += new WVec(0, 0, -distanceAboveTerrain.Length);
 				world.AddFrameEndTask(w => w.Remove(this));
 
 				var warheadArgs = new WarheadArgs(args)

--- a/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
@@ -95,9 +95,8 @@ namespace OpenRA.Mods.Common.Projectiles
 			pos += velocity;
 			velocity += acceleration;
 
-			if (pos.Z <= args.PassiveTarget.Z)
+			if (world.Map.DistanceAboveTerrain(pos) <= WDist.Zero)
 			{
-				pos += new WVec(0, 0, args.PassiveTarget.Z - pos.Z);
 				world.AddFrameEndTask(w => w.Remove(this));
 
 				var warheadArgs = new WarheadArgs(args)

--- a/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.Common.Projectiles
 				shouldExplode = true;
 			}
 
-			if (BlocksProjectiles.AnyBlockingActorsBetween(world, lastPos, pos, info.Width, out var blockedPos))
+			if (BlocksProjectiles.AnyBlockingActorsBetween3D(world, lastPos, pos, info.Width, out var blockedPos))
 			{
 				pos = blockedPos;
 				shouldExplode = true;

--- a/OpenRA.Mods.Common/Traits/BlocksProjectiles.cs
+++ b/OpenRA.Mods.Common/Traits/BlocksProjectiles.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using System.Linq;
 
 namespace OpenRA.Mods.Common.Traits
@@ -41,6 +42,17 @@ namespace OpenRA.Mods.Common.Traits
 		public static bool AnyBlockingActorsBetween(World world, WPos start, WPos end, WDist width, out WPos hit)
 		{
 			var actors = world.FindBlockingActorsOnLine(start, end, width);
+			return CheckForBlockingActors(actors, world, start, end, out hit);
+		}
+
+		public static bool AnyBlockingActorsBetween3D(World world, WPos start, WPos end, WDist width, out WPos hit)
+		{
+			var actors = world.FindActorsOn3DLine(start, end, width, true);
+			return CheckForBlockingActors(actors, world, start, end, out hit);
+		}
+
+		static bool CheckForBlockingActors(IEnumerable<Actor> actors, World world, WPos start, WPos end, out WPos hit)
+		{
 			var length = (end - start).Length;
 
 			foreach (var a in actors)

--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -614,6 +614,33 @@ namespace OpenRA.Mods.Common.Traits
 				}
 			}
 		}
+
+		public IEnumerable<Actor> ActorsInCube(WPos a, WPos b)
+		{
+			// PERF: Inline BinsInBox here to avoid allocations as this method is called often.
+			var left = Math.Min(a.X, b.X);
+			var top = Math.Min(a.Y, b.Y);
+			var down = Math.Min(a.Z, b.Z);
+			var right = Math.Max(a.X, b.X);
+			var bottom = Math.Max(a.Y, b.Y);
+			var up = Math.Max(a.Z, b.Z);
+			var region = BinRectangleCoveringWorldArea(left, top, right, bottom);
+			for (var row = region.Top; row <= region.Bottom; row++)
+			{
+				for (var col = region.Left; col <= region.Right; col++)
+				{
+					foreach (var actor in BinAt(row, col).Actors)
+					{
+						if (actor.IsInWorld)
+						{
+							var c = actor.CenterPosition;
+							if (left <= c.X && c.X <= right && top <= c.Y && c.Y <= bottom && c.Z <= up && down <= c.Z)
+								yield return actor;
+						}
+					}
+				}
+			}
+		}
 	}
 
 	public static class ActorMapWorldExts


### PR DESCRIPTION
Issue #19307 looked like a good first issue for me to investigate in the codebase. 

### Testing

I've tested before (to reproduce the bug) and after, and this looks like it's a relatively small change in the end. I also had a look at other objects that explode/interact with the ground, and this seems like a clean way to approach it from the code side.