### PR TITLE
Removed HTML tags from Markdown trait export

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of
@@ -70,16 +70,19 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				var name = t.GetCustomAttributes<ScriptGlobalAttribute>(true).First().Name;
 				var members = ScriptMemberWrapper.WrappableMembers(t);
 
+				Console.WriteLine();
 				Console.WriteLine("### " + name);
-				Console.WriteLine("<table>");
+				Console.WriteLine();
+				Console.WriteLine("| Function | Description |");
+				Console.WriteLine("|---------:|-------------|");
 				foreach (var m in members.OrderBy(m => m.Name))
 				{
-					var desc = m.HasAttribute<DescAttribute>() ? m.GetCustomAttributes<DescAttribute>(true).First().Lines.JoinWith("\n") : "";
-					Console.WriteLine($"<tr><td align=\"right\" width=\"50%\"><strong>{m.LuaDocString()}</strong></td><td>{desc}</td></tr>");
+					var desc = m.HasAttribute<DescAttribute>() ? m.GetCustomAttributes<DescAttribute>(true).First().Lines.JoinWith("<br />") : "";
+					Console.WriteLine($"| **{m.LuaDocString()}** | {desc} |");
 				}
-
-				Console.WriteLine("</table>");
 			}
+
+			Console.WriteLine();
 
 			Console.WriteLine("## Actor Properties / Commands");
 
@@ -94,8 +97,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			foreach (var kv in actorCategories)
 			{
+				Console.WriteLine();
 				Console.WriteLine("### " + kv.Key);
-				Console.WriteLine("<table>");
+				Console.WriteLine();
+				Console.WriteLine("| Function | Description |");
+				Console.WriteLine("|---------:|-------------|");
 
 				foreach (var property in kv.OrderBy(p => p.Item2.Name))
 				{
@@ -105,27 +111,27 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					var hasRequires = required.Any();
 					var isActivity = mi.HasAttribute<ScriptActorPropertyActivityAttribute>();
 
-					Console.WriteLine("<tr><td width=\"50%\" align=\"right\"><strong>{0}</strong>", mi.LuaDocString());
+					Console.Write($"| **{mi.LuaDocString()}**");
 
 					if (isActivity)
-						Console.WriteLine("<br /><em>Queued Activity</em>");
+						Console.Write("<br />*Queued Activity*");
 
-					Console.WriteLine("</td><td>");
+					Console.Write(" | ");
 
 					if (hasDesc)
-						Console.WriteLine(mi.GetCustomAttributes<DescAttribute>(false).First().Lines.JoinWith("\n"));
+						Console.Write(mi.GetCustomAttributes<DescAttribute>(false).First().Lines.JoinWith("<br />"));
 
 					if (hasDesc && hasRequires)
-						Console.WriteLine("<br />");
+						Console.Write("<br />");
 
 					if (hasRequires)
-						Console.WriteLine($"<b>Requires {(required.Length == 1 ? "Trait" : "Traits")}:</b> {required.JoinWith(", ")}");
+						Console.Write($"**Requires {(required.Length == 1 ? "Trait" : "Traits")}:** {required.JoinWith(", ")}");
 
-					Console.WriteLine("</td></tr>");
+					Console.WriteLine(" |");
 				}
-
-				Console.WriteLine("</table>");
 			}
+
+			Console.WriteLine();
 
 			Console.WriteLine("## Player Properties / Commands");
 
@@ -140,8 +146,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			foreach (var kv in playerCategories)
 			{
+				Console.WriteLine();
 				Console.WriteLine("### " + kv.Key);
-				Console.WriteLine("<table>");
+				Console.WriteLine();
+				Console.WriteLine("| Function | Description |");
+				Console.WriteLine("|---------:|-------------|");
 
 				foreach (var property in kv.OrderBy(p => p.Item2.Name))
 				{
@@ -151,26 +160,26 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					var hasRequires = required.Any();
 					var isActivity = mi.HasAttribute<ScriptActorPropertyActivityAttribute>();
 
-					Console.WriteLine("<tr><td width=\"50%\" align=\"right\"><strong>{0}</strong>", mi.LuaDocString());
+					Console.Write($"| **{mi.LuaDocString()}**");
 
 					if (isActivity)
-						Console.WriteLine("<br /><em>Queued Activity</em>");
+						Console.Write("<br />*Queued Activity*");
 
-					Console.WriteLine("</td><td>");
+					Console.Write(" | ");
 
 					if (hasDesc)
-						Console.WriteLine(mi.GetCustomAttributes<DescAttribute>(false).First().Lines.JoinWith("\n"));
+						Console.Write(mi.GetCustomAttributes<DescAttribute>(false).First().Lines.JoinWith("<br />"));
 
 					if (hasDesc && hasRequires)
-						Console.WriteLine("<br />");
+						Console.Write("<br />");
 
 					if (hasRequires)
-						Console.WriteLine($"<b>Requires {(required.Length == 1 ? "Trait" : "Traits")}:</b> {required.JoinWith(", ")}");
+						Console.Write($"**Requires {(required.Length == 1 ? "Trait" : "Traits")}:** {required.JoinWith(", ")}");
 
-					Console.WriteLine("</td></tr>");
+					Console.WriteLine(" |");
 				}
 
-				Console.WriteLine("</table>");
+				Console.WriteLine();
 			}
 		}
 

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of
@@ -85,23 +85,21 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				var infos = FieldLoader.GetTypeLoadInfo(t);
 				if (!infos.Any())
 					continue;
-				doc.AppendLine("<table>");
-				doc.AppendLine("<tr><th>Property</th><th>Default Value</th><th>Type</th><th>Description</th></tr>");
+				doc.AppendLine();
+				doc.AppendLine("| Property | Default Value | Type | Description |");
+				doc.AppendLine("| -------- | --------------| ---- | ----------- |");
 				var liveTraitInfo = Game.ModData.ObjectCreator.CreateBasic(t);
 				foreach (var info in infos)
 				{
 					var fieldDescLines = info.Field.GetCustomAttributes<DescAttribute>(true).SelectMany(d => d.Lines);
 					var fieldType = Util.FriendlyTypeName(info.Field.FieldType);
 					var loadInfo = info.Field.GetCustomAttributes<FieldLoader.SerializeAttribute>(true).FirstOrDefault();
-					var defaultValue = loadInfo != null && loadInfo.Required ? "<em>(required)</em>" : FieldSaver.SaveField(liveTraitInfo, info.Field.Name).Value.Value;
-					doc.Append($"<tr><td>{info.YamlName}</td><td>{defaultValue}</td><td>{fieldType}</td>");
-					doc.Append("<td>");
+					var defaultValue = loadInfo != null && loadInfo.Required ? "*(required)*" : FieldSaver.SaveField(liveTraitInfo, info.Field.Name).Value.Value;
+					doc.Append($"| {info.YamlName} | {defaultValue} | {fieldType} | ");
 					foreach (var line in fieldDescLines)
 						doc.Append(line + " ");
-					doc.AppendLine("</td></tr>");
+					doc.AppendLine("|");
 				}
-
-				doc.AppendLine("</table>");
 			}
 
 			Console.Write(doc.ToString());

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractWeaponDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractWeaponDocsCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of
@@ -78,8 +78,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				if (!infos.Any())
 					continue;
 
-				doc.AppendLine("<table>");
-				doc.AppendLine("<tr><th>Property</th><th>Default Value</th><th>Type</th><th>Description</th></tr>");
+				doc.AppendLine();
+				doc.AppendLine("| Property | Default Value | Type | Description |");
+				doc.AppendLine("| -------- | --------------| ---- | ----------- |");
 
 				var liveTraitInfo = t == typeof(WeaponInfo) ? null : objectCreator.CreateBasic(t);
 				foreach (var info in infos)
@@ -87,16 +88,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					var fieldDescLines = info.Field.GetCustomAttributes<DescAttribute>(true).SelectMany(d => d.Lines);
 					var fieldType = Util.FriendlyTypeName(info.Field.FieldType);
 					var defaultValue = liveTraitInfo == null ? "" : FieldSaver.SaveField(liveTraitInfo, info.Field.Name).Value.Value;
-					doc.Append($"<tr><td>{info.YamlName}</td><td>{defaultValue}</td><td>{fieldType}</td>");
-					doc.Append("<td>");
-
+					doc.Append($"| {info.YamlName} | {defaultValue} | {fieldType} | ");
 					foreach (var line in fieldDescLines)
 						doc.Append(line + " ");
-
-					doc.AppendLine("</td></tr>");
+					doc.AppendLine("|");
 				}
-
-				doc.AppendLine("</table>");
 			}
 
 			Console.Write(doc.ToString());


### PR DESCRIPTION
This is a workaround for https://github.com/mkdocs/mkdocs/issues/2400, but I thought it might actually be nicer as Markdown is easier for humans to read compared to hard-coded HTML tags.