### PR TITLE
Replace .F in OrderManager

### DIFF
--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Network
 
 			public override string ToString()
 			{
-				return "ClientId: {0} {1}".F(Client, Order);
+				return $"ClientId: {Client} {Order}";
 			}
 		}
 


### PR DESCRIPTION
The conflict I talked about in https://github.com/OpenRA/OpenRA/pull/19402#issuecomment-835805445 seems to have been handled better by github auto-rebase than my local one, but I noticed a case that still used the old .F pattern.