### PR TITLE
Fix Atreides silo damaged sequence

### DIFF
--- a/mods/d2k/sequences/structures.yaml
+++ b/mods/d2k/sequences/structures.yaml
@@ -413,14 +413,14 @@ silo.atreides:
 		Start: 2814
 		Offset: -16,16
 	damaged-idle: DATA.R8
-		Start: 2817
+		Start: 2818
 		Offset: -16,16
 	stages: DATA.R8
 		Start: 2814
 		Length: 4
 		Offset: -16,16
 	damaged-stages: DATA.R8
-		Start: 2817
+		Start: 2818
 		Offset: -16,16
 	make: DATA.R8
 		Start: 4577


### PR DESCRIPTION
Fix the Atreides silo rendering as full silo instead of damaged silo when that silo is damaged.

This is how it looks now.
https://user-images.githubusercontent.com/31252576/118027601-2814e100-b373-11eb-8126-b50d41a57f24.mp4

This pull request tries to fix it 😃 
