### PR TITLE
Correct Harkonnen Devastator warhead impact sound

### DIFF
--- a/mods/d2k/weapons/largeguns.yaml
+++ b/mods/d2k/weapons/largeguns.yaml
@@ -77,7 +77,7 @@ DevBullet:
 		Damage: 3250
 	Warhead@3Eff: CreateEffect
 		Explosions: shockwave
-		ImpactSounds: EXPLMD1.WAV
+		ImpactSounds: EXPLMD4.WAV
 
 155mm:
 	Inherits: ^Cannon


### PR DESCRIPTION
This PR makes the Devastator use the original impact sound effect for its projectile.