### PR TITLE
Add EngineRootPath csproj property to simplify SDK inheritance.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,11 +8,12 @@
     <LangVersion>7.3</LangVersion>
     <DebugSymbols>true</DebugSymbols>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <OutputPath>../bin</OutputPath>
+    <EngineRootPath Condition="'$(EngineRootPath)' == ''">..</EngineRootPath>
+    <OutputPath>$(EngineRootPath)/bin</OutputPath>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ExternalConsole>false</ExternalConsole>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <CodeAnalysisRuleSet>..\OpenRA.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>$(EngineRootPath)/OpenRA.ruleset</CodeAnalysisRuleSet>
     <Nullable>disable</Nullable>
   </PropertyGroup>
 
@@ -48,6 +49,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
-    <AdditionalFiles Include="../stylecop.json" />
+    <AdditionalFiles Include="$(EngineRootPath)/stylecop.json" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR fixes `Directory.Build.props` compatibility for https://github.com/OpenRA/OpenRAModSDK/pull/171. SDK projects could already override `<OutputPath>`  and `<CodeAnalysisRuleSet>`, but they are not able override or remove the `stylecop.json` include which breaks the stylecop integration / `make check`.

Defining a new `<EngineRootPath>` that SDK projects can set before including the shared definitions avoids this problem and even further streamlines their csproj definitions.