### PR TITLE
Unified debug slash command names

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	class CustomTerrainDebugOverlay : IWorldLoaded, IChatCommand, IRenderAnnotations
 	{
-		const string CommandName = "debugcustomterrain";
+		const string CommandName = "custom-terrain";
 		const string CommandDesc = "toggles the custom terrain debug overlay.";
 
 		public bool Enabled;

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class TerrainGeometryOverlay : IRenderAnnotations, IWorldLoaded, IChatCommand
 	{
-		const string CommandName = "terrainoverlay";
+		const string CommandName = "terrain-geometry";
 		const string CommandDesc = "toggles the terrain geometry overlay.";
 
 		public bool Enabled;


### PR DESCRIPTION
I use the debug chat commands a lot and what annoys me when using tab completion is that they all start with the same redundant word like `/show` or `/debug` so there is a high chance it picks the wrong one. This renames all of them to the clear and concise style of https://github.com/OpenRA/OpenRA/pull/11544 as `/exits-overlay` makes it clear what it is about and the dash between the nouns helps with readability. It doesn't change them too much so hopefully, so muscle memory stays mostly intact.