### PR TITLE
OrderIO performance improvement

### DIFF
--- a/OpenRA.Game/Network/OrderIO.cs
+++ b/OpenRA.Game/Network/OrderIO.cs
@@ -16,8 +16,14 @@ namespace OpenRA.Network
 {
 	public static class OrderIO
 	{
+		static readonly List<Order> EmptyOrderList = new List<Order>(0);
+
 		public static List<Order> ToOrderList(this byte[] bytes, World world)
 		{
+			// PERF: Skip empty order frames, often per client each frame
+			if (bytes.Length == 4)
+				return EmptyOrderList;
+
 			var ms = new MemoryStream(bytes, 4, bytes.Length - 4);
 			var reader = new BinaryReader(ms);
 			var ret = new List<Order>();


### PR DESCRIPTION
OrderIO.ToOrderList: Skip if frame is empty, which occurs often each client each frame.

Split the part that should be uncontroversial and not conflict with other PRs from #19011.

According to my own measuring, negligible but consistent gains of about 20 stopwatch ticks per tick in singleplayer/shellmap. Not much, but better than nothing.