### PR TITLE
Polish issues with mission difficulty dropdowns

### DIFF
--- a/mods/cnc/bits/scripts/campaign-global.lua
+++ b/mods/cnc/bits/scripts/campaign-global.lua
@@ -6,9 +6,6 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
-
-Difficulty = Map.LobbyOption("difficulty")
-
 IdleHunt = function(actor)
 	if actor.HasProperty("Hunt") and not actor.IsDead then
 		Trigger.OnIdle(actor, actor.Hunt)

--- a/mods/cnc/maps/funpark01/rules.yaml
+++ b/mods/cnc/maps/funpark01/rules.yaml
@@ -16,8 +16,7 @@ World:
 		Values:
 			easy: Easy
 			normal: Normal
-		Default: easy
-		Locked: false
+		Default: normal
 
 Player:
 	EnemyWatcher:

--- a/mods/cnc/maps/gdi05a/gdi05a.lua
+++ b/mods/cnc/maps/gdi05a/gdi05a.lua
@@ -6,6 +6,7 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
+Difficulty = Map.LobbyOption("difficulty")
 
 RepairThreshold = { easy = 0.3, normal = 0.6, hard = 0.9 }
 

--- a/mods/cnc/maps/gdi05a/rules.yaml
+++ b/mods/cnc/maps/gdi05a/rules.yaml
@@ -33,8 +33,7 @@ World:
 			easy: Easy
 			normal: Normal
 			hard: Hard
-		Default: easy
-		Locked: false
+		Default: normal
 
 Player:
 	EnemyWatcher:

--- a/mods/cnc/maps/gdi06/gdi06.lua
+++ b/mods/cnc/maps/gdi06/gdi06.lua
@@ -6,6 +6,7 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
+Difficulty = Map.LobbyOption("difficulty")
 
 IslandSamSites = { SAM01, SAM02 }
 NodBase = { PowerPlant1, PowerPlant2, PowerPlant3, PowerPlant4, PowerPlant5, Refinery, HandOfNod, Silo1, Silo2, Silo3, Silo4, ConYard, CommCenter }

--- a/mods/cnc/maps/gdi06/rules.yaml
+++ b/mods/cnc/maps/gdi06/rules.yaml
@@ -39,8 +39,7 @@ World:
 			easy: Easy
 			normal: Normal
 			hard: Hard
-		Default: easy
-		Locked: false
+		Default: normal
 
 Player:
 	PlayerResources:

--- a/mods/cnc/maps/nod06a/nod06a.lua
+++ b/mods/cnc/maps/nod06a/nod06a.lua
@@ -6,6 +6,7 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
+Difficulty = Map.LobbyOption("difficulty")
 
 NodStartUnitsRight =
 {

--- a/mods/cnc/maps/nod06a/rules.yaml
+++ b/mods/cnc/maps/nod06a/rules.yaml
@@ -18,7 +18,6 @@ World:
 			hard: Hard
 			tough: Real tough guy
 		Default: normal
-		Locked: false
 
 Player:
 	EnemyWatcher:

--- a/mods/cnc/maps/nod06b/nod06b.lua
+++ b/mods/cnc/maps/nod06b/nod06b.lua
@@ -6,6 +6,7 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
+Difficulty = Map.LobbyOption("difficulty")
 
 NodUnitsVehicle1 =
 {

--- a/mods/cnc/maps/nod06b/rules.yaml
+++ b/mods/cnc/maps/nod06b/rules.yaml
@@ -18,7 +18,6 @@ World:
 			hard: Hard
 			tough: Real tough guy
 		Default: normal
-		Locked: false
 
 Player:
 	PlayerResources:

--- a/mods/cnc/maps/nod09/nod09.lua
+++ b/mods/cnc/maps/nod09/nod09.lua
@@ -6,6 +6,7 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
+Difficulty = Map.LobbyOption("difficulty")
 
 if Difficulty == "easy" then
 	Rambo = "rmbo.easy"

--- a/mods/cnc/maps/nod09/rules.yaml
+++ b/mods/cnc/maps/nod09/rules.yaml
@@ -34,8 +34,7 @@ World:
 			easy: Easy
 			normal: Normal
 			hard: Hard
-		Default: easy
-		Locked: false
+		Default: normal
 
 Player:
 	PlayerResources:

--- a/mods/cnc/maps/nod10a/nod10a.lua
+++ b/mods/cnc/maps/nod10a/nod10a.lua
@@ -6,6 +6,7 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
+Difficulty = Map.LobbyOption("difficulty")
 
 if Difficulty == "easy" then
 	Rambo = "rmbo.easy"

--- a/mods/cnc/maps/nod10a/rules.yaml
+++ b/mods/cnc/maps/nod10a/rules.yaml
@@ -29,8 +29,7 @@ World:
 			easy: Easy
 			normal: Normal
 			hard: Hard
-		Default: easy
-		Locked: false
+		Default: normal
 	-LegacyBridgeLayer:
 
 ^CivBuilding:

--- a/mods/cnc/maps/nod10b/nod10b.lua
+++ b/mods/cnc/maps/nod10b/nod10b.lua
@@ -6,6 +6,7 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
+Difficulty = Map.LobbyOption("difficulty")
 
 if Difficulty == "easy" then
 	Rambo = "rmbo.easy"

--- a/mods/cnc/maps/nod10b/rules.yaml
+++ b/mods/cnc/maps/nod10b/rules.yaml
@@ -14,8 +14,7 @@ World:
 			easy: Easy
 			normal: Normal
 			hard: Hard
-		Default: easy
-		Locked: false
+		Default: normal
 	-LegacyBridgeLayer:
 
 Player:

--- a/mods/cnc/rules/campaign-maprules.yaml
+++ b/mods/cnc/rules/campaign-maprules.yaml
@@ -15,13 +15,6 @@ World:
 	MapOptions:
 		ShortGameCheckboxLocked: True
 		ShortGameCheckboxEnabled: False
-	ScriptLobbyDropdown@difficulty:
-		ID: difficulty
-		Label: Difficulty
-		Values:
-			normal: Normal
-		Default: normal
-		Locked: true
 
 Player:
 	-ConquestVictoryConditions:

--- a/mods/ra/maps/ant-01/rules.yaml
+++ b/mods/ra/maps/ant-01/rules.yaml
@@ -9,7 +9,7 @@ World:
 			easy: Easy
 			normal: Normal
 			hard: Hard
-		Default: easy
+		Default: normal
 	LuaScript:
 		Scripts: ant-01.lua, ant-attack.lua, campaign-global.lua
 	MissionData:

--- a/mods/ra/maps/fall-of-greece-2-evacuation/rules.yaml
+++ b/mods/ra/maps/fall-of-greece-2-evacuation/rules.yaml
@@ -16,7 +16,7 @@ World:
 			easy: Easy
 			normal: Normal
 			hard: Hard
-		Default: easy
+		Default: normal
 
 PARADROP:
 	ParatroopersPower:

--- a/mods/ra/maps/sarin-gas-2-down-under/rules.yaml
+++ b/mods/ra/maps/sarin-gas-2-down-under/rules.yaml
@@ -11,7 +11,7 @@ World:
 		Values:
 			normal: Normal
 			hard: Hard
-		Default: Normal
+		Default: normal
 
 Player:
 	PlayerResources:

--- a/mods/ra/maps/soviet-10/rules.yaml
+++ b/mods/ra/maps/soviet-10/rules.yaml
@@ -14,7 +14,7 @@ World:
 			easy: Easy
 			normal: Normal
 			hard: Hard
-		Default: easy
+		Default: normal
 
 Player:
 	PlayerResources:


### PR DESCRIPTION
- First commit fixes the TD dropdowns so that Normal isn't listed above Easy.
- ~~Second~~ First commit also standardizes TD default mission difficulties to Normal like we did with RA in #19392.
- Last commit fixes the dropdown on the RA mission Down Under so that Normal appears selected.