### PR TITLE
Replace server Select loop with individual client threads.

### DIFF
--- a/OpenRA.Game/Server/Connection.cs
+++ b/OpenRA.Game/Server/Connection.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Sockets;
 
 namespace OpenRA.Server
@@ -130,6 +131,8 @@ namespace OpenRA.Server
 				}
 			}
 		}
+
+		public EndPoint EndPoint => Socket.RemoteEndPoint;
 	}
 
 	public enum ReceiveState { Header, Data }

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -374,19 +374,16 @@ namespace OpenRA.Server
 				return;
 			}
 
-			var newConn = new Connection { Socket = newSocket };
+
+			// Validate player identity by asking them to sign a random blob of data
+			// which we can then verify against the player public key database
+			var token = Convert.ToBase64String(OpenRA.Exts.MakeArray(256, _ => (byte)Random.Next()));
+
+			var newConn = new Connection(newSocket, ChooseFreePlayerIndex(), token);
 			try
 			{
 				newConn.Socket.Blocking = false;
 				newConn.Socket.NoDelay = true;
-
-				// Validate player identity by asking them to sign a random blob of data
-				// which we can then verify against the player public key database
-				var token = Convert.ToBase64String(OpenRA.Exts.MakeArray(256, _ => (byte)Random.Next()));
-
-				// Assign the player number.
-				newConn.PlayerIndex = ChooseFreePlayerIndex();
-				newConn.AuthToken = token;
 
 				// Send handshake and client index.
 				var ms = new MemoryStream(8);

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -645,7 +645,7 @@ namespace OpenRA.Mods.Common.Server
 
 				Exts.TryParseIntegerInvariant(split[0], out var kickClientID);
 
-				var kickConn = server.Conns.SingleOrDefault(c => server.GetClient(c) != null && server.GetClient(c).Index == kickClientID);
+				var kickConn = server.Conns.SingleOrDefault(c => server.GetClient(c)?.Index == kickClientID);
 				if (kickConn == null)
 				{
 					server.SendOrderTo(conn, "Message", "No-one in that slot.");
@@ -690,7 +690,7 @@ namespace OpenRA.Mods.Common.Server
 				}
 
 				Exts.TryParseIntegerInvariant(s, out var newAdminId);
-				var newAdminConn = server.Conns.SingleOrDefault(c => server.GetClient(c) != null && server.GetClient(c).Index == newAdminId);
+				var newAdminConn = server.Conns.SingleOrDefault(c => server.GetClient(c)?.Index == newAdminId);
 
 				if (newAdminConn == null)
 				{
@@ -727,7 +727,7 @@ namespace OpenRA.Mods.Common.Server
 				}
 
 				Exts.TryParseIntegerInvariant(s, out var targetId);
-				var targetConn = server.Conns.SingleOrDefault(c => server.GetClient(c) != null && server.GetClient(c).Index == targetId);
+				var targetConn = server.Conns.SingleOrDefault(c => server.GetClient(c)?.Index == targetId);
 
 				if (targetConn == null)
 				{

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -144,7 +144,7 @@ namespace OpenRA.Mods.Common.Server
 				}
 
 				client.State = state;
-				Log.Write("server", "Player @{0} is {1}", conn.Socket.RemoteEndPoint, client.State);
+				Log.Write("server", "Player @{0} is {1}", conn.EndPoint, client.State);
 
 				server.SyncLobbyClients();
 				CheckAutoStart(server);
@@ -759,7 +759,7 @@ namespace OpenRA.Mods.Common.Server
 				if (sanitizedName == client.Name)
 					return true;
 
-				Log.Write("server", "Player@{0} is now known as {1}.", conn.Socket.RemoteEndPoint, sanitizedName);
+				Log.Write("server", "Player@{0} is now known as {1}.", conn.EndPoint, sanitizedName);
 				server.SendMessage($"{client.Name} is now known as {sanitizedName}.");
 				client.Name = sanitizedName;
 				server.SyncLobbyClients();


### PR DESCRIPTION
Closes #19334 and the other issues where clients dropping uncleanly can freeze the server.

This PR replaces #19338 with a full reimplementation that splits the centralized Socket management out to individual threads for each socket. The first three commits are moving things around to improve the encapsulation of `Connection` state with (hopefully) no real logic changes. The last commit contains the real changes and is best viewed with https://github.com/OpenRA/OpenRA/commit/10ccfc19b314c4671c8c3879a728912ff90379e9?w=1.

@hz-ad has been running a slightly earlier version of this branch rebased onto release-20210321 for the last couple of days, and has reported that the performance issues from #19338 have been resolved and that players have not reported any new issues.