### PR TITLE
Remove superfluous Buildable traits from dummy helper actors

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -1141,29 +1141,21 @@ BARRACKS:
 	Interactable:
 	Tooltip:
 		Name: Infantry Production
-	Buildable:
-		Description: Infantry Production
 
 VEHICLEPRODUCTION:
 	AlwaysVisible:
 	Interactable:
 	Tooltip:
 		Name: Vehicle Production
-	Buildable:
-		Description: Vehicle Production
 
 ANYPOWER:
 	AlwaysVisible:
 	Interactable:
 	Tooltip:
 		Name: Power Plant
-	Buildable:
-		Description: Power Plant
 
 ANYHQ:
 	AlwaysVisible:
 	Interactable:
 	Tooltip:
 		Name: a communications center
-	Buildable:
-		Description: a communications center

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -2119,21 +2119,15 @@ BARRACKS:
 	Interactable:
 	Tooltip:
 		Name: Infantry Production
-	Buildable:
-		Description: Infantry Production
 
 TECHCENTER:
 	AlwaysVisible:
 	Interactable:
 	Tooltip:
 		Name: Tech Center
-	Buildable:
-		Description: Tech Center
 
 ANYPOWER:
 	AlwaysVisible:
 	Interactable:
 	Tooltip:
 		Name: Power Plant
-	Buildable:
-		Description: Power Plant

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -233,37 +233,27 @@ ANYPOWER:
 	Interactable:
 	Tooltip:
 		Name: Power Plant
-	Buildable:
-		Description: Power Plant
 
 BARRACKS:
 	AlwaysVisible:
 	Interactable:
 	Tooltip:
 		Name: Infantry Production
-	Buildable:
-		Description: Infantry Production
 
 FACTORY:
 	AlwaysVisible:
 	Interactable:
 	Tooltip:
 		Name: Vehicle Production
-	Buildable:
-		Description: Vehicle Production
 
 RADAR:
 	AlwaysVisible:
 	Interactable:
 	Tooltip:
 		Name: Radar
-	Buildable:
-		Description: Radar
 
 TECH:
 	AlwaysVisible:
 	Interactable:
 	Tooltip:
 		Name: Tech Center
-	Buildable:
-		Description: Tech Center


### PR DESCRIPTION
These were probably generated back when we move the description from the `Tooltip` to the `Buildable` trait, but are not necessary.
Testcase is simply checking the sidebar tooltip of any building that requires a power plant to be built in RA, or any building that requires a communication center in TD (those are easy to distinguish from the internal names).