### PR TITLE
Implement armament switch to prevent weapon auto reload.

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
+++ b/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				return true;
 
 			// Can't leap yet
-			if (attack.Armaments.All(a => a.IsReloading))
+			if (attack.Armaments.All(a => a.IsWaiting))
 				return false;
 
 			// Use CenterOfSubCell with ToSubCell instead of target.Centerposition

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -65,6 +65,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Condition to grant while reloading.")]
 		public readonly string ReloadingCondition = null;
 
+		[Desc("Whether the weapon is assumed to be reloaded if enough time between shots has passed for a reload.")]
+		public readonly bool ReloadWhileWaiting = true;
+
 		public WeaponInfo WeaponInfo { get; private set; }
 		public WDist ModifiedRange { get; private set; }
 
@@ -185,7 +188,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (string.IsNullOrEmpty(Info.ReloadingCondition))
 				return;
 
-			var enabled = !IsTraitDisabled && IsReloading;
+			var enabled = !IsTraitDisabled && IsWaiting;
 
 			if (enabled && conditionToken == Actor.InvalidConditionToken)
 				conditionToken = self.GrantCondition(Info.ReloadingCondition);
@@ -236,7 +239,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected virtual bool CanFire(Actor self, in Target target)
 		{
-			if (IsReloading || IsTraitPaused)
+			if (IsWaiting || IsTraitPaused)
 				return false;
 
 			if (turret != null && !turret.HasAchievedDesiredFacing)
@@ -259,7 +262,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!CanFire(self, target))
 				return null;
 
-			if (ticksSinceLastShot >= Weapon.ReloadDelay)
+			if (Info.ReloadWhileWaiting && ticksSinceLastShot >= Weapon.ReloadDelay)
 				Burst = Weapon.Burst;
 
 			ticksSinceLastShot = 0;
@@ -368,7 +371,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public virtual bool IsReloading => FireDelay > 0 || IsTraitDisabled;
+		public virtual bool IsWaiting => FireDelay > 0 || IsTraitDisabled;
 
 		public WVec MuzzleOffset(Actor self, Barrel b)
 		{

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -240,7 +240,7 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var armament in Armaments)
 			{
 				var checkIsValid = checkForCenterTargetingWeapons ? armament.Weapon.TargetActorCenter : !armament.IsTraitPaused;
-				var reloadingStateIsValid = !reloadingIsInvalid || !armament.IsReloading;
+				var reloadingStateIsValid = !reloadingIsInvalid || !armament.IsWaiting;
 				if (checkIsValid && reloadingStateIsValid && !armament.IsTraitDisabled && armament.Weapon.IsValidAgainst(t, self.World, self))
 					return true;
 			}

--- a/OpenRA.Mods.Common/Traits/Explodes.cs
+++ b/OpenRA.Mods.Common/Traits/Explodes.cs
@@ -142,7 +142,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			// PERF: Avoid LINQ
 			foreach (var a in armaments)
-				if (!a.IsReloading)
+				if (!a.IsWaiting)
 					return Info.WeaponInfo;
 
 			return Info.EmptyWeaponInfo;


### PR DESCRIPTION
Armament.ReloadWhileWaiting is a new bool property which defaults to true (the original behavior).
When set to false, a weapon will not assume to be magically reloaded if enough time has passed.
This allows mods to manualy trigger the reloading process. By doing so, stuff like WithReloadAnimation can be implemented properly as ReloadWhileWaiting does to specify a particular point for traits to know when the actual reloading happens.
Additionally i renamed IsReloading to IsWaiting as it checks the FireDelay which is set by the ReloadDelay and the BurstDelay to avoid confusion. A BurstDelay is actualy no reloading ;)
