### PR TITLE
Remove unused method in WidgetUtils

### DIFF
--- a/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
@@ -20,11 +20,6 @@ namespace OpenRA.Mods.Common.Widgets
 {
 	public static class WidgetUtils
 	{
-		public static Sprite GetChromeImage(World world, string name)
-		{
-			return ChromeProvider.GetImage("chrome-" + world.LocalPlayer.Faction.InternalName, name);
-		}
-
 		public static string GetStatefulImageName(string baseName, bool disabled = false, bool pressed = false, bool hover = false, bool focused = false)
 		{
 			var suffix = disabled ? "-disabled" :


### PR DESCRIPTION
The method `WidgetUtils.GetChromeImage` has 0 references and its purpose is fulfilled by `AddFactionSuffixLogic`.