### PR TITLE
Mod defined flash image.

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/OrderEffects.cs
+++ b/OpenRA.Mods.Common/Traits/World/OrderEffects.cs
@@ -1,0 +1,69 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Mods.Common.Effects;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+    [Desc("Renders an effect at the order target locations.")]
+    public class OrderEffectsInfo : TraitInfo
+    {
+        [Desc("The image to use.")]
+        [FieldLoader.Require]
+        public readonly string TerrainFlashImage;
+
+        [Desc("The sequence to use.")]
+        [FieldLoader.Require]
+        public readonly string TerrainFlashSequence;
+
+        [Desc("The palette to use.")]
+        public readonly string TerrainFlashPalette;
+
+        public override object Create(ActorInitializer init)
+        {
+            return new OrderEffects(this);
+        }
+    }
+
+    public class OrderEffects : INotifyOrderIssued
+    {
+        readonly OrderEffectsInfo info;
+
+        public OrderEffects(OrderEffectsInfo info)
+        {
+            this.info = info;
+        }
+
+        bool INotifyOrderIssued.OrderIssued(World world, Target target)
+        {
+            if (target.Type == TargetType.Actor)
+            {
+                world.AddFrameEndTask(w => w.Add(new FlashTarget(target.Actor)));
+                return true;
+            }
+
+            if (target.Type == TargetType.FrozenActor)
+            {
+                target.FrozenActor.Flash();
+                return true;
+            }
+
+            if (target.Type == TargetType.Terrain)
+            {
+                world.AddFrameEndTask(w => w.Add(new SpriteAnnotation(target.CenterPosition, world, info.TerrainFlashImage, info.TerrainFlashSequence, info.TerrainFlashPalette)));
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -55,6 +55,12 @@ namespace OpenRA.Mods.Common.Traits
 	public interface IBlocksProjectilesInfo : ITraitInfoInterface { }
 
 	[RequireExplicitImplementation]
+	public interface INotifyOrderIssued
+	{
+		bool OrderIssued(World world, Target target);
+	}
+
+	[RequireExplicitImplementation]
 	public interface INotifySold
 	{
 		void Selling(Actor self);

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -12,7 +12,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Orders;
 using OpenRA.Primitives;
@@ -201,21 +200,9 @@ namespace OpenRA.Mods.Common.Widgets
 				if (!flashed && !o.SuppressVisualFeedback)
 				{
 					var visualTarget = o.VisualFeedbackTarget.Type != TargetType.Invalid ? o.VisualFeedbackTarget : o.Target;
-					if (visualTarget.Type == TargetType.Actor)
-					{
-						world.AddFrameEndTask(w => w.Add(new FlashTarget(visualTarget.Actor)));
-						flashed = true;
-					}
-					else if (visualTarget.Type == TargetType.FrozenActor)
-					{
-						visualTarget.FrozenActor.Flash();
-						flashed = true;
-					}
-					else if (visualTarget.Type == TargetType.Terrain)
-					{
-						world.AddFrameEndTask(w => w.Add(new SpriteAnnotation(visualTarget.CenterPosition, world, "moveflsh", "idle", "moveflash")));
-						flashed = true;
-					}
+
+					foreach (var notifyOrderIssued in world.WorldActor.TraitsImplementing<INotifyOrderIssued>())
+						flashed = notifyOrderIssued.OrderIssued(world, visualTarget);
 				}
 
 				world.IssueOrder(o);

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -257,6 +257,10 @@ World:
 		PreviewActor: fact.colorpicker
 		PresetHues: 0, 0.125, 0.185, 0.4, 0.54, 0.66, 0.79, 0.875, 0, 0.14, 0.23, 0.43, 0.54, 0.625, 0.77, 0.85
 		PresetSaturations: 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.4, 0.5, 0.4, 0.5, 0.4, 0.5, 0.4, 0.5
+	OrderEffects:
+		TerrainFlashImage: moveflsh
+		TerrainFlashSequence: idle
+		TerrainFlashPalette: moveflash
 
 EditorWorld:
 	Inherits: ^BaseWorld

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -239,6 +239,10 @@ World:
 		PreviewActor: carryall.colorpicker
 		PresetHues: 0, 0.13, 0.18, 0.3, 0.475, 0.625, 0.82, 0.89, 0.97, 0.05, 0.23, 0.375, 0.525, 0.6, 0.75, 0.85
 		PresetSaturations: 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.5, 0.35, 0.4, 0.4, 0.5, 0.5, 0.4, 0.35
+	OrderEffects:
+		TerrainFlashImage: moveflsh
+		TerrainFlashSequence: idle
+		TerrainFlashPalette: moveflash
 
 EditorWorld:
 	Inherits: ^BaseWorld

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -284,6 +284,10 @@ World:
 		PreviewActor: fact.colorpicker
 		PresetHues: 0, 0.125, 0.22, 0.375, 0.5, 0.56, 0.8, 0.88, 0, 0.15, 0.235, 0.4, 0.47, 0.55, 0.75, 0.85
 		PresetSaturations: 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.4, 0.5, 0.4, 0.5, 0.4, 0.5, 0.4, 0.5
+	OrderEffects:
+		TerrainFlashImage: moveflsh
+		TerrainFlashSequence: idle
+		TerrainFlashPalette: moveflash
 
 EditorWorld:
 	Inherits: ^BaseWorld

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -384,6 +384,10 @@ World:
 		PreviewActor: mmch.colorpicker
 		PresetHues: 0, 0.125, 0.185, 0.4, 0.54, 0.66, 0.79, 0.875, 0, 0.14, 0.23, 0.43, 0.54, 0.625, 0.77, 0.85
 		PresetSaturations: 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.4, 0.5, 0.4, 0.5, 0.4, 0.5, 0.4, 0.5
+	OrderEffects:
+		TerrainFlashImage: moveflsh
+		TerrainFlashSequence: idle
+		TerrainFlashPalette: moveflash
 
 EditorWorld:
 	Inherits: ^BaseWorld


### PR DESCRIPTION
Allow mods to define their own moveflash image / sequence / palette.
This unhardcodes the names and makes them setable in the metrics.yaml (as its used by widgets only)
