### PR TITLE
32bpp assets dont need a palette to be defined.

### DIFF
--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -85,7 +85,13 @@ namespace OpenRA.Graphics
 			return new PaletteReference(name, palette.GetPaletteIndex(name), pal, palette);
 		}
 
-		public PaletteReference Palette(string name) { return palettes.GetOrAdd(name, createPaletteReference); }
+		public PaletteReference Palette(string name)
+		{
+			// HACK: This is working around the fact that palettes are defined on traits rather than sequences
+			// and can be removed once this has been fixed.
+			return name == null ? null : palettes.GetOrAdd(name, createPaletteReference);
+		}
+
 		public void AddPalette(string name, ImmutablePalette pal, bool allowModifiers = false, bool allowOverwrite = false)
 		{
 			if (allowOverwrite && palette.Contains(name))


### PR DESCRIPTION
Currently when you use 32bpp sprites you encounter dozens of crashes quite easily. Most of them are tied to the palettes being null. The dirty workaround was to define a palette in yaml which exists but wont be used on 32bpp assets to get around the crash.
This changes allows palettes to be null, resulting in palettes being not resolved in that case.
There is a note at the end of the SpriteRenderable constructor which sets the palette also to null if an rgba asset is used, so this pr comes along with that behavior and just makes sure the traits do not crash before.
