### PR TITLE
32bpp terrain does not need a palette.

### DIFF
--- a/OpenRA.Mods.Common/Terrain/DefaultTerrain.cs
+++ b/OpenRA.Mods.Common/Terrain/DefaultTerrain.cs
@@ -75,6 +75,7 @@ namespace OpenRA.Mods.Common.Terrain
 		public readonly bool EnableDepth = false;
 		public readonly float MinHeightColorBrightness = 1.0f;
 		public readonly float MaxHeightColorBrightness = 1.0f;
+		public readonly string Palette = TileSet.TerrainPaletteInternalName;
 
 		[FieldLoader.Ignore]
 		public readonly IReadOnlyDictionary<ushort, TerrainTemplateInfo> Templates;

--- a/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void UpdateCell(CPos cell)
 		{
 			var tile = map.Tiles[cell];
-			var palette = TileSet.TerrainPaletteInternalName;
+			var palette = terrainInfo.Palette;
 			if (terrainInfo.Templates.TryGetValue(tile.Type, out var template))
 				palette = ((DefaultTerrainTemplateInfo)template).Palette ?? palette;
 
@@ -178,7 +178,7 @@ namespace OpenRA.Mods.Common.Traits
 					var u = gridType == MapGridType.Rectangular ? x : (x - y) / 2f;
 					var v = gridType == MapGridType.Rectangular ? y : (x + y) / 2f;
 					var offset = (new float2(u * ts.Width, (v - 0.5f * tileInfo.Height) * ts.Height) - 0.5f * sprite.Size.XY).ToInt2();
-					var palette = template.Palette ?? TileSet.TerrainPaletteInternalName;
+					var palette = template.Palette ?? terrainInfo.Palette;
 
 					yield return new UISpriteRenderable(sprite, WPos.Zero, origin + offset, 0, wr.Palette(palette), scale);
 				}
@@ -201,7 +201,7 @@ namespace OpenRA.Mods.Common.Traits
 
 					var sprite = tileCache.TileSprite(tile, 0);
 					var offset = map.Offset(new CVec(x, y), tileInfo.Height);
-					var palette = wr.Palette(template.Palette ?? TileSet.TerrainPaletteInternalName);
+					var palette = wr.Palette(template.Palette ?? terrainInfo.Palette);
 
 					yield return new SpriteRenderable(sprite, origin, offset, 0, palette, 1f, 1f, float3.Ones, TintModifiers.None, false);
 				}


### PR DESCRIPTION
When going full 32bpp on the terrain for a blank new sdk mod, the game still crashes due to the required "terrain" palette.
While this pr does not address all places where the hardcoded palette is used, it avoids the crash on new sdk mods by not requiring an unused terrain palette.