### PR TITLE
Added .NET 5 runtime dependency for itch packages

### DIFF
--- a/packaging/.itch.toml
+++ b/packaging/.itch.toml
@@ -1,3 +1,6 @@
+[[prereqs]]
+name = "net-runtime-5-x64-windows"
+
 [[actions]]
 os = "windows"
 name = "Red Alert"


### PR DESCRIPTION
See https://github.com/itchio/itch/issues/2459. Followup of https://github.com/OpenRA/OpenRA/pull/17989.