### PR TITLE
Display lobby options in-game on a dedicated tab

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -102,29 +102,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					activePanel = type;
 			}
 
-			// Handle empty space when tabs aren't displayed
 			var titleText = widget.Get<LabelWidget>("TITLE");
-			var titleTextNoTabs = widget.GetOrNull<LabelWidget>("TITLE_NO_TABS");
 
 			var mapTitle = world.Map.Title;
 			var firstCategory = world.Map.Categories.FirstOrDefault();
 			if (firstCategory != null)
 				mapTitle = firstCategory + ": " + mapTitle;
 
-			titleText.IsVisible = () => numTabs > 1 || (numTabs == 1 && titleTextNoTabs == null);
 			titleText.GetText = () => mapTitle;
-			if (titleTextNoTabs != null)
-			{
-				titleTextNoTabs.IsVisible = () => numTabs == 1;
-				titleTextNoTabs.GetText = () => mapTitle;
-			}
-
-			var bg = widget.Get<BackgroundWidget>("BACKGROUND");
-			var bgNoTabs = widget.GetOrNull<BackgroundWidget>("BACKGROUND_NO_TABS");
-
-			bg.IsVisible = () => numTabs > 1 || (numTabs == 1 && bgNoTabs == null);
-			if (bgNoTabs != null)
-				bgNoTabs.IsVisible = () => numTabs == 1;
 		}
 
 		void SetupObjectivesPanel(ButtonWidget objectivesTabButton, Widget objectivesPanelContainer)

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
@@ -168,8 +168,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			panel.ContentHeight = yMargin + optionsContainer.Bounds.Height;
 			optionsContainer.Bounds.Y = yMargin;
-			if (panel.ContentHeight < panel.Bounds.Height)
-				optionsContainer.Bounds.Y += (panel.Bounds.Height - panel.ContentHeight) / 2;
 
 			panel.ScrollToTop();
 		}

--- a/mods/cnc/chrome/ingame-info-lobby-options.yaml
+++ b/mods/cnc/chrome/ingame-info-lobby-options.yaml
@@ -1,0 +1,48 @@
+Container@LOBBY_OPTIONS_PANEL:
+	Height: PARENT_BOTTOM
+	Width: PARENT_RIGHT
+	Children:
+		ScrollPanel:
+			Logic: LobbyOptionsLogic
+			X: 15
+			Y: 15
+			Width: 482
+			Height: 345
+			Children:
+				Container@LOBBY_OPTIONS:
+					X: 18
+					Y: 9
+					Width: PARENT_RIGHT - 24 - 18
+					Children:
+						Container@CHECKBOX_ROW_TEMPLATE:
+							Height: 34
+							Children:
+								Checkbox@A:
+									Width: 220
+									Height: 20
+									Font: Regular
+									Visible: False
+									TooltipContainer: TOOLTIP_CONTAINER
+								Checkbox@B:
+									X: 225
+									Width: 220
+									Height: 20
+									Font: Regular
+									Visible: False
+									TooltipContainer: TOOLTIP_CONTAINER
+						Container@DROPDOWN_ROW_TEMPLATE:
+							Height: 34
+							Width: PARENT_RIGHT
+							Children:
+								Label@A_DESC:
+									Width: 140
+									Height: 25
+									Align: Right
+									Visible: False
+								DropDownButton@A:
+									X: 145
+									Width: 180
+									Height: 25
+									Font: Regular
+									Visible: False
+									TooltipContainer: TOOLTIP_CONTAINER

--- a/mods/cnc/chrome/ingame-info.yaml
+++ b/mods/cnc/chrome/ingame-info.yaml
@@ -116,3 +116,6 @@ Container@GAME_INFO_PANEL:
 				Container@CHAT_PANEL:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM
+				Container@LOBBY_OPTIONS_PANEL:
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM

--- a/mods/cnc/chrome/ingame-info.yaml
+++ b/mods/cnc/chrome/ingame-info.yaml
@@ -13,13 +13,6 @@ Container@GAME_INFO_PANEL:
 			Align: Center
 			Font: BigBold
 			Contrast: true
-		Label@TITLE_NO_TABS:
-			Width: PARENT_RIGHT
-			Y: 18
-			Text: Game Information
-			Align: Center
-			Font: BigBold
-			Contrast: true
 		Container@TAB_CONTAINER_2:
 			Visible: False
 			Children:

--- a/mods/cnc/chrome/ingame-infostats.yaml
+++ b/mods/cnc/chrome/ingame-infostats.yaml
@@ -8,20 +8,20 @@ Container@SKIRMISH_STATS:
 			Children:
 				Label@MISSION:
 					X: 15
-					Y: 12
-					Width: 85
-					Height: 25
+					Y: 17
+					Width: 80
+					Height: 20
 					Font: MediumBold
 					Text: Mission:
 				Label@STATS_STATUS:
-					X: 100
-					Y: 12
-					Width: PARENT_RIGHT - 10
-					Height: 25
+					X: 95
+					Y: 17
+					Width: PARENT_RIGHT - 110
+					Height: 20
 					Font: MediumBold
 				Checkbox@STATS_CHECKBOX:
 					X: 15
-					Y: 45
+					Y: 50
 					Width: 482
 					Height: 20
 					Font: Bold

--- a/mods/cnc/maps/funpark01/rules.yaml
+++ b/mods/cnc/maps/funpark01/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/cnc/maps/gdi05a/rules.yaml
+++ b/mods/cnc/maps/gdi05a/rules.yaml
@@ -29,6 +29,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/cnc/maps/gdi05c/rules.yaml
+++ b/mods/cnc/maps/gdi05c/rules.yaml
@@ -38,6 +38,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/cnc/maps/gdi06/rules.yaml
+++ b/mods/cnc/maps/gdi06/rules.yaml
@@ -33,6 +33,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/cnc/maps/gdi08b/rules.yaml
+++ b/mods/cnc/maps/gdi08b/rules.yaml
@@ -14,6 +14,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/cnc/maps/nod06a/rules.yaml
+++ b/mods/cnc/maps/nod06a/rules.yaml
@@ -12,6 +12,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/cnc/maps/nod06b/rules.yaml
+++ b/mods/cnc/maps/nod06b/rules.yaml
@@ -12,6 +12,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/cnc/maps/nod09/rules.yaml
+++ b/mods/cnc/maps/nod09/rules.yaml
@@ -30,6 +30,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/cnc/maps/nod10a/rules.yaml
+++ b/mods/cnc/maps/nod10a/rules.yaml
@@ -25,6 +25,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/cnc/maps/nod10b/rules.yaml
+++ b/mods/cnc/maps/nod10b/rules.yaml
@@ -10,6 +10,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/cnc/maps/the-hot-box/rules.yaml
+++ b/mods/cnc/maps/the-hot-box/rules.yaml
@@ -17,6 +17,9 @@ World:
 		BuildRadiusCheckboxEnabled: True
 		BuildRadiusCheckboxVisible: False
 	MapOptions:
+		ShortGameCheckboxVisible: False
+		ShortGameCheckboxLocked: True
+		ShortGameCheckboxEnabled: False
 		TechLevelDropdownLocked: True
 		TechLevelDropdownVisible: False
 		TechLevel: unrestricted
@@ -63,4 +66,8 @@ Player:
 		DefaultCashDropdownVisible: False
 		DefaultCash: 5000
 	LobbyPrerequisiteCheckbox@GLOBALFACTUNDEPLOY:
+		Visible: False
+	LobbyPrerequisiteCheckbox@GLOBALC17STEALTH:
+		Enabled: False
+		Locked: True
 		Visible: False

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -123,6 +123,7 @@ ChromeLayout:
 	cnc|chrome/ingame-infoscripterror.yaml
 	cnc|chrome/ingame-infoobjectives.yaml
 	cnc|chrome/ingame-infostats.yaml
+	cnc|chrome/ingame-info-lobby-options.yaml
 	cnc|chrome/ingame-debuginfo.yaml
 	cnc|chrome/music.yaml
 	cnc|chrome/settings.yaml

--- a/mods/cnc/rules/campaign-maprules.yaml
+++ b/mods/cnc/rules/campaign-maprules.yaml
@@ -5,16 +5,24 @@ World:
 	ObjectivesPanel:
 		PanelName: MISSION_OBJECTIVES
 	MapCreeps:
+		CheckboxVisible: False
 		CheckboxLocked: True
 		CheckboxEnabled: False
 	MapBuildRadius:
+		AllyBuildRadiusCheckboxVisible: False
 		AllyBuildRadiusCheckboxLocked: True
 		AllyBuildRadiusCheckboxEnabled: False
+		BuildRadiusCheckboxVisible: False
 		BuildRadiusCheckboxLocked: True
 		BuildRadiusCheckboxEnabled: True
 	MapOptions:
+		ShortGameCheckboxVisible: False
 		ShortGameCheckboxLocked: True
 		ShortGameCheckboxEnabled: False
+		TechLevelDropdownVisible: False
+		TechLevelDropdownLocked: True
+	TimeLimitManager:
+		TimeLimitDropdownVisible: False
 
 Player:
 	-ConquestVictoryConditions:
@@ -22,13 +30,26 @@ Player:
 		EarlyGameOver: true
 		GameOverDelay: 3000
 	Shroud:
+		FogCheckboxVisible: False
 		FogCheckboxLocked: True
 		FogCheckboxEnabled: True
+		ExploredMapCheckboxVisible: False
 		ExploredMapCheckboxLocked: True
 		ExploredMapCheckboxEnabled: False
 	PlayerResources:
+		DefaultCashDropdownVisible: False
 		DefaultCashDropdownLocked: True
 		DefaultCash: 5000
+	LobbyPrerequisiteCheckbox@GLOBALFACTUNDEPLOY:
+		Enabled: False
+		Locked: True
+		Visible: False
+	LobbyPrerequisiteCheckbox@GLOBALC17STEALTH:
+		Enabled: False
+		Locked: True
+		Visible: False
+	DeveloperMode:
+		CheckboxVisible: False
 	ModularBot@CampaignAI:
 		Name: Campaign Player AI
 		Type: campaign

--- a/mods/common/chrome/ingame-info-lobby-options.yaml
+++ b/mods/common/chrome/ingame-info-lobby-options.yaml
@@ -1,0 +1,45 @@
+Container@LOBBY_OPTIONS_PANEL:
+	Height: PARENT_BOTTOM
+	Width: PARENT_RIGHT
+	Children:
+		ScrollPanel:
+			Logic: LobbyOptionsLogic
+			X: 20
+			Y: 20
+			Width: 482
+			Height: 350
+			Children:
+				Container@LOBBY_OPTIONS:
+					X: 10
+					Y: 9
+					Width: PARENT_RIGHT - 10 - 24
+					Children:
+						Container@CHECKBOX_ROW_TEMPLATE:
+							Height: 30
+							Children:
+								Checkbox@A:
+									Width: 220
+									Height: 20
+									Visible: False
+									TooltipContainer: TOOLTIP_CONTAINER
+								Checkbox@B:
+									X: 225
+									Width: 220
+									Height: 20
+									Visible: False
+									TooltipContainer: TOOLTIP_CONTAINER
+						Container@DROPDOWN_ROW_TEMPLATE:
+							Height: 30
+							Width: PARENT_RIGHT
+							Children:
+								Label@A_DESC:
+									Width: 140
+									Height: 25
+									Align: Right
+									Visible: False
+								DropDownButton@A:
+									X: 145
+									Width: 180
+									Height: 25
+									Visible: False
+									TooltipContainer: TOOLTIP_CONTAINER

--- a/mods/common/chrome/ingame-info.yaml
+++ b/mods/common/chrome/ingame-info.yaml
@@ -9,18 +9,8 @@ Container@GAME_INFO_PANEL:
 		Background@BACKGROUND:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
-		Background@BACKGROUND_NO_TABS:
-			Y: 25
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM - 25
 		Label@TITLE:
 			Y: 21
-			Width: PARENT_RIGHT
-			Height: 25
-			Align: Center
-			Font: Bold
-		Label@TITLE_NO_TABS:
-			Y: 46
 			Width: PARENT_RIGHT
 			Height: 25
 			Align: Center

--- a/mods/common/chrome/ingame-info.yaml
+++ b/mods/common/chrome/ingame-info.yaml
@@ -146,3 +146,7 @@ Container@GAME_INFO_PANEL:
 			Y: 65
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
+		Container@LOBBY_OPTIONS_PANEL:
+			Y: 65
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM

--- a/mods/d2k/maps/atreides-01a/rules.yaml
+++ b/mods/d2k/maps/atreides-01a/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/atreides-01b/rules.yaml
+++ b/mods/d2k/maps/atreides-01b/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/atreides-02a/rules.yaml
+++ b/mods/d2k/maps/atreides-02a/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/atreides-02b/rules.yaml
+++ b/mods/d2k/maps/atreides-02b/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/atreides-03a/rules.yaml
+++ b/mods/d2k/maps/atreides-03a/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/atreides-03b/rules.yaml
+++ b/mods/d2k/maps/atreides-03b/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/atreides-04/rules.yaml
+++ b/mods/d2k/maps/atreides-04/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/atreides-05/rules.yaml
+++ b/mods/d2k/maps/atreides-05/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/harkonnen-01a/rules.yaml
+++ b/mods/d2k/maps/harkonnen-01a/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/harkonnen-01b/rules.yaml
+++ b/mods/d2k/maps/harkonnen-01b/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/harkonnen-02a/rules.yaml
+++ b/mods/d2k/maps/harkonnen-02a/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/harkonnen-02b/rules.yaml
+++ b/mods/d2k/maps/harkonnen-02b/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/harkonnen-03a/rules.yaml
+++ b/mods/d2k/maps/harkonnen-03a/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/harkonnen-03b/rules.yaml
+++ b/mods/d2k/maps/harkonnen-03b/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/harkonnen-04/rules.yaml
+++ b/mods/d2k/maps/harkonnen-04/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/harkonnen-05/rules.yaml
+++ b/mods/d2k/maps/harkonnen-05/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/harkonnen-06a/rules.yaml
+++ b/mods/d2k/maps/harkonnen-06a/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/harkonnen-06b/rules.yaml
+++ b/mods/d2k/maps/harkonnen-06b/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/harkonnen-07/rules.yaml
+++ b/mods/d2k/maps/harkonnen-07/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/harkonnen-08/rules.yaml
+++ b/mods/d2k/maps/harkonnen-08/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/harkonnen-09a/rules.yaml
+++ b/mods/d2k/maps/harkonnen-09a/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/harkonnen-09b/rules.yaml
+++ b/mods/d2k/maps/harkonnen-09b/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/ordos-01a/rules.yaml
+++ b/mods/d2k/maps/ordos-01a/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/ordos-01b/rules.yaml
+++ b/mods/d2k/maps/ordos-01b/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/ordos-02a/rules.yaml
+++ b/mods/d2k/maps/ordos-02a/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/ordos-02b/rules.yaml
+++ b/mods/d2k/maps/ordos-02b/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/ordos-03a/rules.yaml
+++ b/mods/d2k/maps/ordos-03a/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/ordos-03b/rules.yaml
+++ b/mods/d2k/maps/ordos-03b/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/ordos-04/rules.yaml
+++ b/mods/d2k/maps/ordos-04/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/ordos-05/rules.yaml
+++ b/mods/d2k/maps/ordos-05/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/maps/ordos-06a/rules.yaml
+++ b/mods/d2k/maps/ordos-06a/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -76,6 +76,7 @@ ChromeLayout:
 	common|chrome/ingame-infobriefing.yaml
 	common|chrome/ingame-infoobjectives.yaml
 	d2k|chrome/ingame-infostats.yaml
+	common|chrome/ingame-info-lobby-options.yaml
 	d2k|chrome/ingame-observer.yaml
 	d2k|chrome/ingame-player.yaml
 	common|chrome/ingame-perf.yaml

--- a/mods/d2k/rules/campaign-rules.yaml
+++ b/mods/d2k/rules/campaign-rules.yaml
@@ -4,12 +4,21 @@ Player:
 		EarlyGameOver: true
 		GameOverDelay: 3000
 	Shroud:
+		FogCheckboxVisible: False
 		FogCheckboxLocked: True
 		FogCheckboxEnabled: True
+		ExploredMapCheckboxVisible: False
 		ExploredMapCheckboxLocked: True
 		ExploredMapCheckboxEnabled: False
 	PlayerResources:
+		DefaultCashDropdownVisible: False
 		DefaultCashDropdownLocked: True
+	LobbyPrerequisiteCheckbox@AUTOCONCRETE:
+		Enabled: False
+		Locked: True
+		Visible: False
+	DeveloperMode:
+		CheckboxVisible: False
 	ModularBot@CampaignAI:
 		Name: Campaign Player AI
 		Type: campaign
@@ -24,15 +33,24 @@ World:
 		Minimum: 1
 		Maximum: 1
 	MapCreeps:
+		CheckboxVisible: False
 		CheckboxLocked: True
 		CheckboxEnabled: True
 	MapBuildRadius:
+		AllyBuildRadiusCheckboxVisible: False
 		AllyBuildRadiusCheckboxLocked: True
 		AllyBuildRadiusCheckboxEnabled: False
+		BuildRadiusCheckboxVisible: False
+		BuildRadiusCheckboxLocked: True
+		BuildRadiusCheckboxEnabled: True
 	MapOptions:
-		TechLevelDropdownLocked: True
+		ShortGameCheckboxVisible: False
 		ShortGameCheckboxLocked: True
 		ShortGameCheckboxEnabled: False
+		TechLevelDropdownVisible: False
+		TechLevelDropdownLocked: True
+	TimeLimitManager:
+		TimeLimitDropdownVisible: False
 
 ^AutoTargetGroundAssaultMove:
 	GrantConditionOnBotOwner@BOTOWNER:

--- a/mods/ra/maps/allies-02/rules.yaml
+++ b/mods/ra/maps/allies-02/rules.yaml
@@ -17,6 +17,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/allies-03a/rules.yaml
+++ b/mods/ra/maps/allies-03a/rules.yaml
@@ -9,6 +9,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/allies-03b/rules.yaml
+++ b/mods/ra/maps/allies-03b/rules.yaml
@@ -9,6 +9,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/allies-04/rules.yaml
+++ b/mods/ra/maps/allies-04/rules.yaml
@@ -16,6 +16,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/allies-05a/rules.yaml
+++ b/mods/ra/maps/allies-05a/rules.yaml
@@ -12,6 +12,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/allies-05b/rules.yaml
+++ b/mods/ra/maps/allies-05b/rules.yaml
@@ -10,6 +10,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/allies-05c/rules.yaml
+++ b/mods/ra/maps/allies-05c/rules.yaml
@@ -10,6 +10,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/allies-06a/rules.yaml
+++ b/mods/ra/maps/allies-06a/rules.yaml
@@ -16,6 +16,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/allies-06b/rules.yaml
+++ b/mods/ra/maps/allies-06b/rules.yaml
@@ -16,6 +16,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/allies-07/rules.yaml
+++ b/mods/ra/maps/allies-07/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/allies-08a/rules.yaml
+++ b/mods/ra/maps/allies-08a/rules.yaml
@@ -14,6 +14,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/allies-08b/rules.yaml
+++ b/mods/ra/maps/allies-08b/rules.yaml
@@ -14,6 +14,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/allies-09a/rules.yaml
+++ b/mods/ra/maps/allies-09a/rules.yaml
@@ -13,6 +13,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/ant-01/rules.yaml
+++ b/mods/ra/maps/ant-01/rules.yaml
@@ -5,6 +5,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/ant-03/rules.yaml
+++ b/mods/ra/maps/ant-03/rules.yaml
@@ -6,6 +6,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/bomber-john/rules.yaml
+++ b/mods/ra/maps/bomber-john/rules.yaml
@@ -12,6 +12,9 @@ World:
 		BuildRadiusCheckboxEnabled: True
 		BuildRadiusCheckboxVisible: False
 	MapOptions:
+		ShortGameCheckboxVisible: False
+		ShortGameCheckboxLocked: True
+		ShortGameCheckboxEnabled: False
 		TechLevelDropdownLocked: True
 		TechLevelDropdownVisible: False
 		TechLevel: unrestricted
@@ -109,6 +112,8 @@ Player:
 		Locked: True
 		Visible: False
 	LobbyPrerequisiteCheckbox@GLOBALFACTUNDEPLOY:
+		Visible: False
+	LobbyPrerequisiteCheckbox@REUSABLEENGINEERS:
 		Visible: False
 
 MNLYR:

--- a/mods/ra/maps/drop-zone-battle-of-tikiaki/rules.yaml
+++ b/mods/ra/maps/drop-zone-battle-of-tikiaki/rules.yaml
@@ -4,12 +4,16 @@ World:
 		SpawnInterval: 125
 		CrateActors: unitcrate
 		InitialSpawnDelay: 0
+		CheckboxVisible: False
 	-SpawnStartingUnits:
 	-MapStartingLocations:
 	MapBuildRadius:
 		AllyBuildRadiusCheckboxVisible: False
 		BuildRadiusCheckboxVisible: False
 	MapOptions:
+		ShortGameCheckboxVisible: False
+		ShortGameCheckboxLocked: True
+		ShortGameCheckboxEnabled: False
 		TechLevelDropdownLocked: True
 		TechLevelDropdownVisible: False
 		TechLevel: unrestricted

--- a/mods/ra/maps/drop-zone-w/rules.yaml
+++ b/mods/ra/maps/drop-zone-w/rules.yaml
@@ -5,12 +5,16 @@ World:
 		WaterChance: 100
 		CrateActors: unitcrate
 		InitialSpawnDelay: 0
+		CheckboxVisible: False
 	-SpawnStartingUnits:
 	-MapStartingLocations:
 	MapBuildRadius:
 		AllyBuildRadiusCheckboxVisible: False
 		BuildRadiusCheckboxVisible: False
 	MapOptions:
+		ShortGameCheckboxVisible: False
+		ShortGameCheckboxLocked: True
+		ShortGameCheckboxEnabled: False
 		TechLevelDropdownLocked: True
 		TechLevelDropdownVisible: False
 		TechLevel: unrestricted
@@ -69,4 +73,6 @@ Player:
 		Locked: True
 		Visible: False
 	LobbyPrerequisiteCheckbox@GLOBALFACTUNDEPLOY:
+		Visible: False
+	LobbyPrerequisiteCheckbox@REUSABLEENGINEERS:
 		Visible: False

--- a/mods/ra/maps/drop-zone/rules.yaml
+++ b/mods/ra/maps/drop-zone/rules.yaml
@@ -4,12 +4,16 @@ World:
 		SpawnInterval: 125
 		CrateActors: unitcrate
 		InitialSpawnDelay: 0
+		CheckboxVisible: False
 	-SpawnStartingUnits:
 	-MapStartingLocations:
 	MapBuildRadius:
 		AllyBuildRadiusCheckboxVisible: False
 		BuildRadiusCheckboxVisible: False
 	MapOptions:
+		ShortGameCheckboxVisible: False
+		ShortGameCheckboxLocked: True
+		ShortGameCheckboxEnabled: False
 		TechLevelDropdownLocked: True
 		TechLevelDropdownVisible: False
 		TechLevel: unrestricted

--- a/mods/ra/maps/evacuation/map.yaml
+++ b/mods/ra/maps/evacuation/map.yaml
@@ -1755,4 +1755,4 @@ Actors:
 		Owner: Soviets
 		ScriptTags: TownAttacker
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, ra|rules/campaign-palettes.yaml, rules.yaml
+Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, ra|rules/campaign-palettes.yaml, ra|rules/coop-missions-rules.yaml, rules.yaml

--- a/mods/ra/maps/evacuation/rules.yaml
+++ b/mods/ra/maps/evacuation/rules.yaml
@@ -12,6 +12,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/exodus/map.yaml
+++ b/mods/ra/maps/exodus/map.yaml
@@ -1382,4 +1382,4 @@ Actors:
 		Owner: Soviets
 		Location: 130,45
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, ra|rules/campaign-palettes.yaml, rules.yaml
+Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, ra|rules/campaign-palettes.yaml, ra|rules/coop-missions-rules.yaml, rules.yaml

--- a/mods/ra/maps/exodus/rules.yaml
+++ b/mods/ra/maps/exodus/rules.yaml
@@ -10,6 +10,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/fall-of-greece-1-personal-war/rules.yaml
+++ b/mods/ra/maps/fall-of-greece-1-personal-war/rules.yaml
@@ -8,6 +8,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			normal: Normal
 			hard: Hard

--- a/mods/ra/maps/fall-of-greece-2-evacuation/rules.yaml
+++ b/mods/ra/maps/fall-of-greece-2-evacuation/rules.yaml
@@ -12,6 +12,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/infiltration/map.yaml
+++ b/mods/ra/maps/infiltration/map.yaml
@@ -1789,4 +1789,4 @@ Actors:
 		Owner: Soviets
 		Location: 43,50
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, ra|rules/campaign-palettes.yaml, rules.yaml
+Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, ra|rules/campaign-palettes.yaml, ra|rules/coop-missions-rules.yaml, rules.yaml

--- a/mods/ra/maps/infiltration/rules.yaml
+++ b/mods/ra/maps/infiltration/rules.yaml
@@ -10,6 +10,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/intervention/rules.yaml
+++ b/mods/ra/maps/intervention/rules.yaml
@@ -10,6 +10,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			normal: Normal
 			hard: Hard

--- a/mods/ra/maps/production-disruption/rules.yaml
+++ b/mods/ra/maps/production-disruption/rules.yaml
@@ -8,6 +8,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/sarin-gas-1-crackdown/rules.yaml
+++ b/mods/ra/maps/sarin-gas-1-crackdown/rules.yaml
@@ -7,6 +7,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/sarin-gas-2-down-under/rules.yaml
+++ b/mods/ra/maps/sarin-gas-2-down-under/rules.yaml
@@ -8,6 +8,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			normal: Normal
 			hard: Hard

--- a/mods/ra/maps/sarin-gas-3-controlled-burn/rules.yaml
+++ b/mods/ra/maps/sarin-gas-3-controlled-burn/rules.yaml
@@ -8,6 +8,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/siberian-conflict-1-fresh-tracks/rules.yaml
+++ b/mods/ra/maps/siberian-conflict-1-fresh-tracks/rules.yaml
@@ -8,6 +8,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/siberian-conflict-3-wasteland/rules.yaml
+++ b/mods/ra/maps/siberian-conflict-3-wasteland/rules.yaml
@@ -8,6 +8,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/soviet-03/rules.yaml
+++ b/mods/ra/maps/soviet-03/rules.yaml
@@ -10,6 +10,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/soviet-04a/rules.yaml
+++ b/mods/ra/maps/soviet-04a/rules.yaml
@@ -16,6 +16,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/soviet-04b/rules.yaml
+++ b/mods/ra/maps/soviet-04b/rules.yaml
@@ -16,6 +16,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/soviet-05/rules.yaml
+++ b/mods/ra/maps/soviet-05/rules.yaml
@@ -74,6 +74,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/soviet-06a/rules.yaml
+++ b/mods/ra/maps/soviet-06a/rules.yaml
@@ -14,6 +14,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/soviet-06b/rules.yaml
+++ b/mods/ra/maps/soviet-06b/rules.yaml
@@ -14,6 +14,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/soviet-07/rules.yaml
+++ b/mods/ra/maps/soviet-07/rules.yaml
@@ -10,6 +10,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/soviet-08a/rules.yaml
+++ b/mods/ra/maps/soviet-08a/rules.yaml
@@ -10,6 +10,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/soviet-08b/rules.yaml
+++ b/mods/ra/maps/soviet-08b/rules.yaml
@@ -10,6 +10,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/soviet-09/rules.yaml
+++ b/mods/ra/maps/soviet-09/rules.yaml
@@ -10,6 +10,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/soviet-10/rules.yaml
+++ b/mods/ra/maps/soviet-10/rules.yaml
@@ -10,6 +10,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/soviet-11a/rules.yaml
+++ b/mods/ra/maps/soviet-11a/rules.yaml
@@ -10,6 +10,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/soviet-11b/rules.yaml
+++ b/mods/ra/maps/soviet-11b/rules.yaml
@@ -10,6 +10,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/soviet-soldier-volkov-n-chitzkoi/rules.yaml
+++ b/mods/ra/maps/soviet-soldier-volkov-n-chitzkoi/rules.yaml
@@ -8,6 +8,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/survival01/rules.yaml
+++ b/mods/ra/maps/survival01/rules.yaml
@@ -10,6 +10,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/maps/top-o-the-world/rules.yaml
+++ b/mods/ra/maps/top-o-the-world/rules.yaml
@@ -8,6 +8,7 @@ World:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty
+		Description: Change the difficulty of the mission
 		Values:
 			easy: Easy
 			normal: Normal

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -92,6 +92,7 @@ ChromeLayout:
 	common|chrome/ingame-infobriefing.yaml
 	common|chrome/ingame-infoobjectives.yaml
 	common|chrome/ingame-infostats.yaml
+	common|chrome/ingame-info-lobby-options.yaml
 	common|chrome/ingame-menu.yaml
 	ra|chrome/ingame-observer.yaml
 	ra|chrome/ingame-player.yaml

--- a/mods/ra/rules/campaign-rules.yaml
+++ b/mods/ra/rules/campaign-rules.yaml
@@ -4,13 +4,30 @@ Player:
 		EarlyGameOver: true
 		GameOverDelay: 3000
 	Shroud:
+		FogCheckboxVisible: False
 		FogCheckboxLocked: True
 		FogCheckboxEnabled: True
+		ExploredMapCheckboxVisible: False
 		ExploredMapCheckboxLocked: True
 		ExploredMapCheckboxEnabled: False
 	PlayerResources:
+		DefaultCashDropdownVisible: False
 		DefaultCashDropdownLocked: True
 		DefaultCash: 0
+	LobbyPrerequisiteCheckbox@GLOBALBOUNTY:
+		Enabled: False
+		Locked: True
+		Visible: False
+	LobbyPrerequisiteCheckbox@GLOBALFACTUNDEPLOY:
+		Enabled: True
+		Locked: True
+		Visible: False
+	LobbyPrerequisiteCheckbox@REUSABLEENGINEERS:
+		Enabled: False
+		Locked: True
+		Visible: False
+	DeveloperMode:
+		CheckboxVisible: False
 	ModularBot@CampaignAI:
 		Name: Campaign Player AI
 		Type: campaign
@@ -19,19 +36,26 @@ World:
 	CrateSpawner:
 		CheckboxEnabled: False
 		CheckboxLocked: True
+		CheckboxVisible: False
 	-SpawnStartingUnits:
 	-MapStartingLocations:
 	ObjectivesPanel:
 		PanelName: MISSION_OBJECTIVES
 	MapBuildRadius:
+		AllyBuildRadiusCheckboxVisible: False
 		AllyBuildRadiusCheckboxLocked: True
 		AllyBuildRadiusCheckboxEnabled: False
+		BuildRadiusCheckboxVisible: False
 		BuildRadiusCheckboxLocked: True
 		BuildRadiusCheckboxEnabled: True
 	MapOptions:
-		TechLevelDropdownLocked: True
+		ShortGameCheckboxVisible: False
 		ShortGameCheckboxLocked: True
 		ShortGameCheckboxEnabled: False
+		TechLevelDropdownVisible: False
+		TechLevelDropdownLocked: True
+	TimeLimitManager:
+		TimeLimitDropdownVisible: False
 
 E7:
 	-Crushable:

--- a/mods/ra/rules/coop-missions-rules.yaml
+++ b/mods/ra/rules/coop-missions-rules.yaml
@@ -1,0 +1,26 @@
+Player:
+	Shroud:
+		FogCheckboxVisible: True
+		ExploredMapCheckboxVisible: True
+	PlayerResources:
+		DefaultCashDropdownVisible: True
+	LobbyPrerequisiteCheckbox@GLOBALBOUNTY:
+		Visible: True
+	LobbyPrerequisiteCheckbox@GLOBALFACTUNDEPLOY:
+		Visible: True
+	LobbyPrerequisiteCheckbox@REUSABLEENGINEERS:
+		Visible: True
+	DeveloperMode:
+		CheckboxVisible: True
+
+World:
+	CrateSpawner:
+		CheckboxVisible: True
+	MapBuildRadius:
+		AllyBuildRadiusCheckboxVisible: True
+		BuildRadiusCheckboxVisible: True
+	MapOptions:
+		ShortGameCheckboxVisible: True
+		TechLevelDropdownVisible: True
+	TimeLimitManager:
+		TimeLimitDropdownVisible: True

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -138,6 +138,7 @@ ChromeLayout:
 	common|chrome/ingame-infobriefing.yaml
 	common|chrome/ingame-infoobjectives.yaml
 	common|chrome/ingame-infostats.yaml
+	common|chrome/ingame-info-lobby-options.yaml
 	ts|chrome/ingame-observer.yaml
 	ts|chrome/ingame-player.yaml
 	common|chrome/ingame-perf.yaml


### PR DESCRIPTION
It's a common frustration that lobby options can't be reviewed once a game has started. Displaying them in-game actually turned out to be not that difficult because the existing chrome logic works just fine in-game. So it became more of an UI problem and most of the changes in this PR deal with the UI. Commit messages give more detail on what's going on and the last couple of commits are mostly polishing. 

At first I thought that the lobby options shouldn't be displayed for missions but then I found that the ones that are not relevant can be easily hidden. That's why I took the time to hide various options from missions and mini-games.

![Screenshot_20210623_140428](https://user-images.githubusercontent.com/1355810/123090662-16722f00-d431-11eb-8f50-0bafa3614434.png)
_All options are displayed for co-op missions, skirmish and multiplayer_
![Screenshot_20210623_140700](https://user-images.githubusercontent.com/1355810/123090675-1b36e300-d431-11eb-81b4-9ec3fad4f1f0.png)
_Only relevant options are displayed for missions and mini-games_

Closes #8396
Related #12349