### PR TITLE
zenity dropdown replaced with radiobuttons

### DIFF
--- a/launch-game.sh
+++ b/launch-game.sh
@@ -17,12 +17,12 @@ if [ z"${*#*Game.Mod}" = z"$*" ]
 then
 	if command -v zenity > /dev/null
 	then
-		TITLE=$(zenity --forms --add-combo="" --combo-values="Red Alert|Tiberian Dawn|Dune 2000|Tiberian Sun" --text "Select mod" --title="" || echo "cancel")
-		if [ "$TITLE" = "cancel" ]; then exit 0
-		elif [ "$TITLE" = "Tiberian Dawn" ]; then MODARG='Game.Mod=cnc'
+		TITLE=$(zenity --title="" --list --radiolist --text 'Select game mod:' --column 'Select' --column 'Game mod' TRUE 'Red Alert' FALSE 'Tiberian Dawn' FALSE 'Dune 2000' FALSE 'Tiberian Sun' --height=240 || echo "cancel")
+		if [ "$TITLE" = "Tiberian Dawn" ]; then MODARG='Game.Mod=cnc'
 		elif [ "$TITLE" = "Dune 2000" ]; then MODARG='Game.Mod=d2k'
 		elif [ "$TITLE" = "Tiberian Sun" ]; then MODARG='Game.Mod=ts'
-		else MODARG='Game.Mod=ra'
+		elif [ "$TITLE" = "Red Alert" ]; then MODARG='Game.Mod=ra'
+		else exit 0
 		fi
 	else
 		echo "Please provide the Game.Mod=\$MOD argument (possible \$MOD values: ra, cnc, d2k, ts)"


### PR DESCRIPTION
When launching the game from shell without specifying GameMod, zenity dialog will pop up.

BEFORE : In zenity it wasn't possible to set initial value so there was no GameMod selected when dialog popped out. But when you clicked OK with no value of dropdown list, Red Alert was selected.

NOW: there is radiobutton list and it is possible to set initial value. In other words, user can see that Red Alert is selected defaultly. 

This is pretty minor change, not necessarily needed, but I think it makes things prettier :)