### PR TITLE
Slower damaged units for Dune 2k mod

### DIFF
--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -241,6 +241,12 @@
 			Radius: 16
 	MapEditorData:
 		Categories: Vehicle
+	GrantConditionOnDamageState@HEAVY:
+		Condition: heavy-damage
+		ValidDamageStates: Heavy
+	SpeedMultiplier@HEAVYDAMAGE:
+		RequiresCondition: heavy-damage
+		Modifier: 75
 
 ^Tank:
 	Inherits: ^Vehicle

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -243,7 +243,6 @@
 		Categories: Vehicle
 	GrantConditionOnDamageState@HEAVY:
 		Condition: heavy-damage
-		ValidDamageStates: Heavy
 	SpeedMultiplier@HEAVYDAMAGE:
 		RequiresCondition: heavy-damage
 		Modifier: 75


### PR DESCRIPTION
A simple PR that will partly resolve #19454 however the smoke particles not implanted in this PR just units slowing when damaged.