### PR TITLE
Improve HitShape debug overlays

### DIFF
--- a/OpenRA.Mods.Common/HitShapes/Capsule.cs
+++ b/OpenRA.Mods.Common/HitShapes/Capsule.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.HitShapes
@@ -92,7 +93,7 @@ namespace OpenRA.Mods.Common.HitShapes
 			return DistanceFromEdge((pos - new WPos(origin.X, origin.Y, pos.Z)).Rotate(-orientation));
 		}
 
-		IEnumerable<IRenderable> IHitShape.RenderDebugOverlay(WorldRenderer wr, WPos origin, WRot orientation)
+		IEnumerable<IRenderable> IHitShape.RenderDebugOverlay(HitShape hs, WorldRenderer wr, WPos origin, WRot orientation)
 		{
 			var a = origin + new WVec(PointA.X, PointA.Y, VerticalTopOffset).Rotate(orientation);
 			var b = origin + new WVec(PointB.X, PointB.Y, VerticalTopOffset).Rotate(orientation);
@@ -104,15 +105,17 @@ namespace OpenRA.Mods.Common.HitShapes
 			var offset2 = new WVec(aa.Y - bb.Y, bb.X - aa.X, 0);
 			offset2 = offset2 * Radius.Length / offset2.Length;
 
-			yield return new CircleAnnotationRenderable(a, Radius, 1, Color.Yellow);
-			yield return new CircleAnnotationRenderable(b, Radius, 1, Color.Yellow);
-			yield return new CircleAnnotationRenderable(aa, Radius, 1, Color.Yellow);
-			yield return new CircleAnnotationRenderable(bb, Radius, 1, Color.Yellow);
-			yield return new CircleAnnotationRenderable(origin, OuterRadius, 1,  Color.LimeGreen);
-			yield return new LineAnnotationRenderable(a - offset1, b - offset1, 1, Color.Yellow);
-			yield return new LineAnnotationRenderable(a + offset1, b + offset1, 1, Color.Yellow);
-			yield return new LineAnnotationRenderable(aa - offset2, bb - offset2, 1, Color.Yellow);
-			yield return new LineAnnotationRenderable(aa + offset2, bb + offset2, 1, Color.Yellow);
+			var shapeColor = hs.IsTraitDisabled ? Color.LightGray : Color.Yellow;
+
+			yield return new CircleAnnotationRenderable(a, Radius, 1, shapeColor);
+			yield return new CircleAnnotationRenderable(b, Radius, 1, shapeColor);
+			yield return new CircleAnnotationRenderable(aa, Radius, 1, shapeColor);
+			yield return new CircleAnnotationRenderable(bb, Radius, 1, shapeColor);
+			yield return new CircleAnnotationRenderable(origin, OuterRadius, 1, hs.IsTraitDisabled ? Color.Gray : Color.LimeGreen);
+			yield return new LineAnnotationRenderable(a - offset1, b - offset1, 1, shapeColor);
+			yield return new LineAnnotationRenderable(a + offset1, b + offset1, 1, shapeColor);
+			yield return new LineAnnotationRenderable(aa - offset2, bb - offset2, 1, shapeColor);
+			yield return new LineAnnotationRenderable(aa + offset2, bb + offset2, 1, shapeColor);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/HitShapes/Circle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Circle.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.HitShapes
@@ -56,10 +57,11 @@ namespace OpenRA.Mods.Common.HitShapes
 			return DistanceFromEdge(pos - new WPos(origin.X, origin.Y, pos.Z));
 		}
 
-		IEnumerable<IRenderable> IHitShape.RenderDebugOverlay(WorldRenderer wr, WPos origin, WRot orientation)
+		IEnumerable<IRenderable> IHitShape.RenderDebugOverlay(HitShape hs, WorldRenderer wr, WPos origin, WRot orientation)
 		{
-			yield return new CircleAnnotationRenderable(origin + new WVec(0, 0, VerticalTopOffset), Radius, 1, Color.Yellow);
-			yield return new CircleAnnotationRenderable(origin + new WVec(0, 0, VerticalBottomOffset), Radius, 1, Color.Yellow);
+			var shapeColor = hs.IsTraitDisabled ? Color.LightGray : Color.Yellow;
+			yield return new CircleAnnotationRenderable(origin + new WVec(0, 0, VerticalTopOffset), Radius, 1, shapeColor);
+			yield return new CircleAnnotationRenderable(origin + new WVec(0, 0, VerticalBottomOffset), Radius, 1, shapeColor);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/HitShapes/IHitShape.cs
+++ b/OpenRA.Mods.Common/HitShapes/IHitShape.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.Common.HitShapes
 {
@@ -22,6 +23,6 @@ namespace OpenRA.Mods.Common.HitShapes
 		WDist DistanceFromEdge(WPos pos, WPos origin, WRot orientation);
 
 		void Initialize();
-		IEnumerable<IRenderable> RenderDebugOverlay(WorldRenderer wr, WPos origin, WRot orientation);
+		IEnumerable<IRenderable> RenderDebugOverlay(HitShape hs, WorldRenderer wr, WPos origin, WRot orientation);
 	}
 }

--- a/OpenRA.Mods.Common/HitShapes/Polygon.cs
+++ b/OpenRA.Mods.Common/HitShapes/Polygon.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.HitShapes
@@ -112,15 +113,17 @@ namespace OpenRA.Mods.Common.HitShapes
 			return DistanceFromEdge((pos - new WPos(origin.X, origin.Y, pos.Z)).Rotate(-orientation));
 		}
 
-		IEnumerable<IRenderable> IHitShape.RenderDebugOverlay(WorldRenderer wr, WPos actorPos, WRot orientation)
+		IEnumerable<IRenderable> IHitShape.RenderDebugOverlay(HitShape hs, WorldRenderer wr, WPos actorPos, WRot orientation)
 		{
 			orientation += WRot.FromYaw(LocalYaw);
 			var vertsTop = combatOverlayVertsTop.Select(v => actorPos + v.Rotate(orientation)).ToArray();
 			var vertsBottom = combatOverlayVertsBottom.Select(v => actorPos + v.Rotate(orientation)).ToArray();
 
-			yield return new PolygonAnnotationRenderable(vertsTop, actorPos, 1, Color.Yellow);
-			yield return new PolygonAnnotationRenderable(vertsBottom, actorPos, 1, Color.Yellow);
-			yield return new CircleAnnotationRenderable(actorPos, OuterRadius, 1, Color.LimeGreen);
+			var shapeColor = hs.IsTraitDisabled ? Color.LightGray : Color.Yellow;
+
+			yield return new PolygonAnnotationRenderable(vertsTop, actorPos, 1, shapeColor);
+			yield return new PolygonAnnotationRenderable(vertsBottom, actorPos, 1, shapeColor);
+			yield return new CircleAnnotationRenderable(actorPos, OuterRadius, 1, hs.IsTraitDisabled ? Color.Gray : Color.LimeGreen);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/HitShapes/Rectangle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Rectangle.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.HitShapes
@@ -125,7 +126,7 @@ namespace OpenRA.Mods.Common.HitShapes
 			return DistanceFromEdge((pos - new WPos(origin.X, origin.Y, pos.Z)).Rotate(-orientation));
 		}
 
-		IEnumerable<IRenderable> IHitShape.RenderDebugOverlay(WorldRenderer wr, WPos origin, WRot orientation)
+		IEnumerable<IRenderable> IHitShape.RenderDebugOverlay(HitShape hs, WorldRenderer wr, WPos origin, WRot orientation)
 		{
 			orientation += WRot.FromYaw(LocalYaw);
 
@@ -134,11 +135,13 @@ namespace OpenRA.Mods.Common.HitShapes
 			var side1 = combatOverlayVertsSide1.Select(v => origin + v.Rotate(orientation)).ToArray();
 			var side2 = combatOverlayVertsSide2.Select(v => origin + v.Rotate(orientation)).ToArray();
 
-			yield return new PolygonAnnotationRenderable(vertsTop, origin, 1, Color.Yellow);
-			yield return new PolygonAnnotationRenderable(vertsBottom, origin, 1, Color.Yellow);
-			yield return new PolygonAnnotationRenderable(side1, origin, 1, Color.Yellow);
-			yield return new PolygonAnnotationRenderable(side2, origin, 1, Color.Yellow);
-			yield return new CircleAnnotationRenderable(origin, OuterRadius, 1, Color.LimeGreen);
+			var shapeColor = hs.IsTraitDisabled ? Color.LightGray : Color.Yellow;
+
+			yield return new PolygonAnnotationRenderable(vertsTop, origin, 1, shapeColor);
+			yield return new PolygonAnnotationRenderable(vertsBottom, origin, 1, shapeColor);
+			yield return new PolygonAnnotationRenderable(side1, origin, 1, shapeColor);
+			yield return new PolygonAnnotationRenderable(side2, origin, 1, shapeColor);
+			yield return new CircleAnnotationRenderable(origin, OuterRadius, 1, hs.IsTraitDisabled ? Color.Gray : Color.LimeGreen);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -28,9 +28,6 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class CombatDebugOverlay : IRenderAnnotations, INotifyDamage, INotifyCreated
 	{
-		static readonly WVec TargetPosHLine = new WVec(0, 128, 0);
-		static readonly WVec TargetPosVLine = new WVec(128, 0, 0);
-
 		readonly DebugVisualizations debugVis;
 		readonly IHealthInfo healthInfo;
 		readonly Lazy<BodyOrientation> coords;
@@ -70,14 +67,12 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			foreach (var s in shapes)
+			{
+				foreach (var a in s.RenderDebugAnnotations(self, wr))
+					yield return a;
+
 				foreach (var r in s.RenderDebugOverlay(self, wr))
 					yield return r;
-
-			var positions = Target.FromActor(self).Positions;
-			foreach (var p in positions)
-			{
-				yield return new LineAnnotationRenderable(p - TargetPosHLine, p + TargetPosHLine, 1, Color.Lime);
-				yield return new LineAnnotationRenderable(p - TargetPosVLine, p + TargetPosVLine, 1, Color.Lime);
 			}
 
 			foreach (var attack in self.TraitsImplementing<AttackBase>().Where(x => !x.IsTraitDisabled))

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -69,8 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 				yield return new LineAnnotationRenderable(self.CenterPosition, self.CenterPosition + height, 1, Color.Orange);
 			}
 
-			var activeShapes = shapes.Where(Exts.IsTraitEnabled);
-			foreach (var s in activeShapes)
+			foreach (var s in shapes)
 				foreach (var r in s.RenderDebugOverlay(self, wr))
 					yield return r;
 

--- a/OpenRA.Mods.Common/Traits/HitShape.cs
+++ b/OpenRA.Mods.Common/Traits/HitShape.cs
@@ -133,7 +133,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var origin = turret != null ? self.CenterPosition + turret.Position(self) : self.CenterPosition;
 			var orientation = turret != null ? turret.WorldOrientation : self.Orientation;
-			return Info.Type.RenderDebugOverlay(wr, origin, orientation);
+			return Info.Type.RenderDebugOverlay(this, wr, origin, orientation);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/HitShape.cs
+++ b/OpenRA.Mods.Common/Traits/HitShape.cs
@@ -69,16 +69,18 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class HitShape : ConditionalTrait<HitShapeInfo>, ITargetablePositions
 	{
-		BodyOrientation orientation;
+		readonly BodyOrientation orientation;
 		ITargetableCells targetableCells;
 		Turreted turret;
 
 		public HitShape(Actor self, HitShapeInfo info)
-			: base(info) { }
+			: base(info)
+		{
+			orientation = self.Trait<BodyOrientation>();
+		}
 
 		protected override void Created(Actor self)
 		{
-			orientation = self.Trait<BodyOrientation>();
 			targetableCells = self.TraitOrDefault<ITargetableCells>();
 			turret = self.TraitsImplementing<Turreted>().FirstOrDefault(t => t.Name == Info.Turret);
 

--- a/OpenRA.Mods.Common/Traits/HitShape.cs
+++ b/OpenRA.Mods.Common/Traits/HitShape.cs
@@ -12,6 +12,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Common.HitShapes;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -129,6 +130,18 @@ namespace OpenRA.Mods.Common.Traits
 			var origin = turret != null ? self.CenterPosition + turret.Position(self) : self.CenterPosition;
 			var orientation = turret != null ? turret.WorldOrientation : self.Orientation;
 			return Info.Type.DistanceFromEdge(pos, origin, orientation);
+		}
+
+		public IEnumerable<IRenderable> RenderDebugAnnotations(Actor self, WorldRenderer wr)
+		{
+			var targetPosHLine = new WVec(0, 128, 0);
+			var targetPosVLine = new WVec(128, 0, 0);
+			var targetPosColor = IsTraitDisabled ? Color.Gainsboro : Color.Lime;
+			foreach (var p in TargetablePositions(self))
+			{
+				yield return new LineAnnotationRenderable(p - targetPosHLine, p + targetPosHLine, 1, targetPosColor);
+				yield return new LineAnnotationRenderable(p - targetPosVLine, p + targetPosVLine, 1, targetPosColor);
+			}
 		}
 
 		public IEnumerable<IRenderable> RenderDebugOverlay(Actor self, WorldRenderer wr)


### PR DESCRIPTION
Instead of just not rendering disabled shapes and targetable positions, they're now rendered in light gray shades when their housing `HitShape` trait is disabled.

Makes it easier to debug conditional HitShapes.

Also made `orientation` readonly since `HitShape` `Requires<BodyOrientation>` anyway.

I use this in one of my projects, so it would be nice if this were merged soonish so I can cut down the number of custom commits a bit for easier rebases/maintenance.

For those who don't feel like or don't know how to set up a testcase, this is what it looks like in-game:
![ingame](https://user-images.githubusercontent.com/2857877/123545130-d5428d80-d756-11eb-903e-2af5d8ab477d.png)