### PR TITLE
Slower damaged units for Dune 2k mod

### DIFF
--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -241,6 +241,11 @@
 			Radius: 16
 	MapEditorData:
 		Categories: Vehicle
+	GrantConditionOnDamageState@HEAVY:
+		Condition: heavy-damage
+	SpeedMultiplier@HEAVYDAMAGE:
+		RequiresCondition: heavy-damage
+		Modifier: 75
 
 ^Tank:
 	Inherits: ^Vehicle


### PR DESCRIPTION
A simple PR that will partly resolve #19454 however the smoke particles not implanted in this PR just units slowing when damaged.

I redid this PR because I couldn't squash my commits for some unknown reason.