### PR TITLE
Allow mod code to access BuildableTerrainOverlay

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/BuildableTerrainOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/BuildableTerrainOverlay.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.EditorWorld)]
-	class BuildableTerrainOverlayInfo : TraitInfo
+	public class BuildableTerrainOverlayInfo : TraitInfo
 	{
 		[FieldLoader.Require]
 		public readonly HashSet<string> AllowedTerrainTypes = null;
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	class BuildableTerrainOverlay : IRenderAboveWorld, IWorldLoaded, INotifyActorDisposing
+	public class BuildableTerrainOverlay : IRenderAboveWorld, IWorldLoaded, INotifyActorDisposing
 	{
 		readonly BuildableTerrainOverlayInfo info;
 		readonly World world;


### PR DESCRIPTION
This is a followup of https://github.com/OpenRA/OpenRA/pull/18434 as @OpenHV has a custom map editor and can't access it.