### PR TITLE
Better path finder

### DIFF
--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -216,7 +216,7 @@ namespace OpenRA.Mods.Common.Activities
 				})
 				.FromPoint(searchFromLoc)
 				.FromPoint(self.Location))
-				path = mobile.Pathfinder.FindPath(search);
+				path = mobile.Pathfinder.FindPath(search, self.Orientation);
 
 			if (path.Count > 0)
 				return path[0];

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Activities
 				using (var search =
 					PathSearch.FromPoint(self.World, mobile.Locomotor, self, mobile.ToCell, destination, check)
 					.WithoutLaneBias())
-					path = mobile.Pathfinder.FindPath(search);
+					path = mobile.Pathfinder.FindPath(search, self.Orientation);
 				return path;
 			};
 

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -134,7 +134,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			using (var fromSrc = PathSearch.FromPoints(self.World, Mobile.Locomotor, self, searchCells, loc, check))
 			using (var fromDest = PathSearch.FromPoint(self.World, Mobile.Locomotor, self, loc, lastVisibleTargetLocation, check).Reverse())
-				return Mobile.Pathfinder.FindBidiPath(fromSrc, fromDest);
+				return Mobile.Pathfinder.FindBidiPath(fromSrc, fromDest, self.Orientation);
 		}
 
 		public override IEnumerable<Target> GetTargets(Actor self)

--- a/OpenRA.Mods.Common/Pathfinder/BasePathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/BasePathSearch.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		bool IsTarget(CPos location);
 
 		bool CanExpand { get; }
-		CPos Expand();
+		CPos Expand(WRot orientation);
 	}
 
 	public abstract class BasePathSearch : IPathSearch
@@ -177,7 +177,8 @@ namespace OpenRA.Mods.Common.Pathfinder
 		}
 
 		public bool CanExpand => !OpenQueue.Empty;
-		public abstract CPos Expand();
+
+		public abstract CPos Expand(WRot orientation);
 
 		protected virtual void Dispose(bool disposing)
 		{

--- a/OpenRA.Mods.Common/Pathfinder/PathFinderUnitPathCacheDecorator.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathFinderUnitPathCacheDecorator.cs
@@ -76,16 +76,16 @@ namespace OpenRA.Mods.Common.Pathfinder
 			}
 		}
 
-		public List<CPos> FindPath(IPathSearch search)
+		public List<CPos> FindPath(IPathSearch search, WRot orientation)
 		{
 			using (new PerfSample("Pathfinder"))
-				return pathFinder.FindPath(search);
+				return pathFinder.FindPath(search, orientation);
 		}
 
-		public List<CPos> FindBidiPath(IPathSearch fromSrc, IPathSearch fromDest)
+		public List<CPos> FindBidiPath(IPathSearch fromSrc, IPathSearch fromDest, WRot orientation)
 		{
 			using (new PerfSample("Pathfinder"))
-				return pathFinder.FindBidiPath(fromSrc, fromDest);
+				return pathFinder.FindBidiPath(fromSrc, fromDest, orientation);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -156,7 +156,7 @@ namespace OpenRA.Mods.Common.Traits
 					.WithCustomCost(loc => world.FindActorsInCircle(world.Map.CenterOfCell(loc), Info.HarvesterEnemyAvoidanceRadius)
 						.Where(u => !u.IsDead && actor.Owner.RelationshipWith(u.Owner) == PlayerRelationship.Enemy)
 						.Sum(u => Math.Max(WDist.Zero.Length, Info.HarvesterEnemyAvoidanceRadius.Length - (world.Map.CenterOfCell(loc) - u.CenterPosition).Length)))
-					.FromPoint(actor.Location));
+					.FromPoint(actor.Location), actor.Orientation);
 
 			if (path.Count == 0)
 				return Target.Invalid;

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -206,7 +206,7 @@ namespace OpenRA.Mods.Common.Traits
 					// Prefer refineries with less occupancy (multiplier is to offset distance cost):
 					return occupancy * Info.UnloadQueueCostModifier;
 				}))
-				path = mobile.Pathfinder.FindPath(search);
+				path = mobile.Pathfinder.FindPath(search, self.Orientation);
 
 			if (path.Count != 0)
 				return refineries[path.Last()].First().Actor;

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -807,7 +807,7 @@ namespace OpenRA.Mods.Common.Traits
 			using (var search = PathSearch.Search(self.World, Locomotor, self, BlockedByActor.All,
 					loc => loc.Layer == 0 && CanEnterCell(loc))
 				.FromPoint(self.Location))
-				path = Pathfinder.FindPath(search);
+				path = Pathfinder.FindPath(search, self.Orientation);
 
 			if (path.Count > 0)
 				return path[0];


### PR DESCRIPTION
Issue  #19465

Orientation of Actor (vehicle) is stored in Trait.Orientation.Yaw as integer from range [0...1023].
For example: 512 means that Actor is oriented to South.
128 |   0   | 896
256 | ...... | 768
384 | 512 | 640
These numbers should help to understand added lines in Expand() function.
Result of these lines is that cost of movement to most directions is little bit changed: direction which Actor is oriented to has no additional cost, two neighboring directions (there is 8 directions in total) have additional cost 1, directions in 90° have additional cost 2, next ones additional cost 3 and last opposite one has additional cost 4.

If vehicle is oriented to S, then
SW and SE gain additional cost 1
W, E gain additional cost 2
NW, NE gain additional cost 3
N gains  4

These additional costs are pretty low, because we do not want to harm A* algorithm, but they can still help when we consider 2 same-cost paths. We prefer the path with smaller initial rotation needed.

We had to bring Orientation to Expand(), so additional argument in FindPath showed up.