### PR TITLE
Quit game only by keyboard

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class MainMenuLogic : ChromeLogic
 	{
-		protected enum MenuType { Main, Singleplayer, Extras, MapEditor, StartupPrompts, None }
+		protected enum MenuType { Main, Singleplayer, Extras, MapEditor, StartupPrompts, None, Quit }
 
 		protected enum MenuPanel { None, Missions, Skirmish, Multiplayer, MapEditor, Replays, GameSaves }
 
@@ -86,7 +86,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			mainMenu.Get<ButtonWidget>("EXTRAS_BUTTON").OnClick = () => SwitchMenu(MenuType.Extras);
 
-			mainMenu.Get<ButtonWidget>("QUIT_BUTTON").OnClick = Game.Exit;
+			mainMenu.Get<ButtonWidget>("QUIT_BUTTON").OnClick = () => SwitchMenu(MenuType.Quit);
+
+			// Quit menu
+			var quitMenu = widget.Get("REALLY_QUIT");
+			quitMenu.IsVisible = () => menuType == MenuType.Quit;
+			quitMenu.Get<ButtonWidget>("CANCEL_QUIT").OnClick = () => SwitchMenu(MenuType.Main);
+			quitMenu.Get<ButtonWidget>("YES_QUIT").OnClick = Game.Exit;
 
 			// Singleplayer menu
 			var singleplayerMenu = widget.Get("SINGLEPLAYER_MENU");

--- a/mods/cnc/chrome/mainmenu.yaml
+++ b/mods/cnc/chrome/mainmenu.yaml
@@ -94,6 +94,33 @@ Container@MENU_BACKGROUND:
 							Width: 140
 							Height: 35
 							Text: Quit
+							Key: escape
+				Container@REALLY_QUIT:
+					Width: PARENT_RIGHT
+					Height: 300
+					Visible: False
+					Children:
+						Label@QUIT_TITLE:
+							X: 50
+							Y: 0
+							Width: 100
+							Height: 20
+							Text: Do you really want to quit OpenRA?
+							Font: Bold
+						Button@CANCEL_QUIT:
+							X: 470
+							Y: 0
+							Width: 150
+							Height: 40
+							Text: Cancel
+							Key: escape
+						Button@YES_QUIT:
+							X: 300
+							Y: 0
+							Width: 150
+							Height: 40
+							Text: Quit
+							Key: q
 				Container@SINGLEPLAYER_MENU:
 					Width: PARENT_RIGHT
 					Visible: False

--- a/mods/common/chrome/mainmenu.yaml
+++ b/mods/common/chrome/mainmenu.yaml
@@ -88,6 +88,34 @@ Container@MAINMENU:
 							Height: 30
 							Text: Quit
 							Font: Bold
+							Key: escape
+				Background@REALLY_QUIT:
+					Width: PARENT_RIGHT
+					Height: 300
+					Visible: False
+					Children:
+						Label@QUIT_TITLE:
+							X: PARENT_RIGHT / 2 - WIDTH / 2
+							Y: 21
+							Width: 140
+							Height: 20
+							Text: Do you want to quit?
+							Align: Center
+							Font: Bold
+						Button@CANCEL_QUIT:
+							X: PARENT_RIGHT / 2 - WIDTH / 2
+							Y: 110
+							Width: 140
+							Height: 50
+							Text: Cancel
+							Key: escape
+						Button@YES_QUIT:
+							X: PARENT_RIGHT / 2 - WIDTH / 2
+							Y: 50
+							Width: 140
+							Height: 50
+							Text: Quit
+							Key: q
 				Background@SINGLEPLAYER_MENU:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM

--- a/mods/d2k/chrome/mainmenu.yaml
+++ b/mods/d2k/chrome/mainmenu.yaml
@@ -75,6 +75,34 @@ Container@MAINMENU:
 							Height: 30
 							Text: Quit
 							Font: Bold
+							Key: escape
+				Background@REALLY_QUIT:
+					Width: PARENT_RIGHT
+					Height: 300
+					Visible: False
+					Children:
+						Label@QUIT_TITLE:
+							X: PARENT_RIGHT / 2 - WIDTH / 2
+							Y: 21
+							Width: 140
+							Height: 20
+							Text: Do you want to quit?
+							Align: Center
+							Font: Bold
+						Button@CANCEL_QUIT:
+							X: PARENT_RIGHT / 2 - WIDTH / 2
+							Y: 110
+							Width: 140
+							Height: 50
+							Text: Cancel
+							Key: escape
+						Button@YES_QUIT:
+							X: PARENT_RIGHT / 2 - WIDTH / 2
+							Y: 50
+							Width: 140
+							Height: 50
+							Text: Quit
+							Key: q
 				Background@SINGLEPLAYER_MENU:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM


### PR DESCRIPTION
Great feature for those who don't like to touch a mouse if not necessary.
Now you can quit game only by pressing ESC, then control question will show up if you really want to quit. Then press 'q'. If you press ESC, you get back to main menu.

note: you already could ESC to go back. I consider it useful if it's complete and you can quit game completely only with keyboard. Also it may be useful to give user hint about 'q' button when quitting.