### PR TITLE
32bpp bullets no longer crash without palette.

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -297,7 +297,11 @@ namespace OpenRA.Mods.Common.Projectiles
 							.WithAlpha(shadowAlpha);
 				}
 
-				var palette = wr.Palette(info.Palette + (info.IsPlayerPalette ? args.SourceActor.Owner.InternalName : ""));
+				var paletteName = info.Palette;
+				if (paletteName != null && info.IsPlayerPalette)
+					paletteName += args.SourceActor.Owner.InternalName;
+
+				var palette = wr.Palette(paletteName);
 				foreach (var r in anim.Render(pos, palette))
 					yield return r;
 			}


### PR DESCRIPTION
Title says all. Current behavior will make null palettes an empty string, which causes a crash on bullets.