### PR TITLE
Fix starting positions for contrails.

### DIFF
--- a/OpenRA.Mods.Common/Graphics/ContrailRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/ContrailRenderable.cs
@@ -30,8 +30,14 @@ namespace OpenRA.Mods.Common.Graphics
 		int length;
 		int skip;
 
-		public ContrailRenderable(World world, Color color, WDist width, int length, int skip, int zOffset)
-			: this(world, new WPos[length], width, 0, 0, skip, color, zOffset) { }
+		public ContrailRenderable(World world, Color color, WDist width, int length, int skip, int zOffset, WPos source)
+			: this(world, new WPos[length], width, 0, 0, skip, color, zOffset)
+		{
+			// Make sure we have enough segments to draw on the first frame.
+			// Otherwise fast actors will have their trail not starting at their origin.
+			for (var i = 0; i < 3; i++)
+				Update(source);
+		}
 
 		ContrailRenderable(World world, WPos[] trail, WDist width, int next, int length, int skip, Color color, int zOffset)
 		{

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -174,7 +174,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			if (info.ContrailLength > 0)
 			{
 				var color = info.ContrailUsePlayerColor ? ContrailRenderable.ChooseColor(args.SourceActor) : info.ContrailColor;
-				contrail = new ContrailRenderable(world, color, info.ContrailWidth, info.ContrailLength, info.ContrailDelay, info.ContrailZOffset);
+				contrail = new ContrailRenderable(world, color, info.ContrailWidth, info.ContrailLength, info.ContrailDelay, info.ContrailZOffset, pos);
 			}
 
 			trailPalette = info.TrailPalette;

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -264,7 +264,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			if (info.ContrailLength > 0)
 			{
 				var color = info.ContrailUsePlayerColor ? ContrailRenderable.ChooseColor(args.SourceActor) : info.ContrailColor;
-				contrail = new ContrailRenderable(world, color, info.ContrailWidth, info.ContrailLength, info.ContrailDelay, info.ContrailZOffset);
+				contrail = new ContrailRenderable(world, color, info.ContrailWidth, info.ContrailLength, info.ContrailDelay, info.ContrailZOffset, pos);
 			}
 
 			trailPalette = info.TrailPalette;

--- a/OpenRA.Mods.Common/Traits/Render/Contrail.cs
+++ b/OpenRA.Mods.Common/Traits/Render/Contrail.cs
@@ -56,18 +56,22 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.info = info;
 
-			color = info.UsePlayerColor ? ContrailRenderable.ChooseColor(self) : info.Color;
-			trail = new ContrailRenderable(self.World, color, info.TrailWidth, info.TrailLength, 0, info.ZOffset);
-
 			body = self.Trait<BodyOrientation>();
+			color = info.UsePlayerColor ? ContrailRenderable.ChooseColor(self) : info.Color;
+			trail = new ContrailRenderable(self.World, color, info.TrailWidth, info.TrailLength, 0, info.ZOffset, GetPosition(self));
 		}
 
 		void ITick.Tick(Actor self)
 		{
 			// We want to update the trails' position even while the trait is disabled,
 			// otherwise we might get visual 'jumps' when the trait is re-enabled.
+			trail.Update(GetPosition(self));
+		}
+
+		WPos GetPosition(Actor self)
+		{
 			var local = info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation));
-			trail.Update(self.CenterPosition + body.LocalToWorld(local));
+			return self.CenterPosition + body.LocalToWorld(local);
 		}
 
 		IEnumerable<IRenderable> IRender.Render(Actor self, WorldRenderer wr)
@@ -86,7 +90,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
-			trail = new ContrailRenderable(self.World, color, info.TrailWidth, info.TrailLength, 0, info.ZOffset);
+			trail = new ContrailRenderable(self.World, color, info.TrailWidth, info.TrailLength, 0, info.ZOffset, GetPosition(self));
 		}
 	}
 }


### PR DESCRIPTION
Especialy noticable on fast moving actors or projectiles. Contrails will start to appear on the position the source has 4 frames after it was created. Having a bullet with a speed of 2048 and a range of 10 makes the contrail start several tiles away from the source instead. This pr fixes that by pre-setting enough contrail trail elements, so the contrail starts at the position where it should start.