### PR TITLE
Add support for TS-style tinted target flashes

### DIFF
--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -76,6 +76,9 @@ namespace OpenRA.Traits
 		static readonly Rectangle[] NoBounds = new Rectangle[0];
 
 		int flashTicks;
+		TintModifiers flashModifiers;
+		float3 flashTint;
+		float? flashAlpha;
 
 		public FrozenActor(Actor actor, ICreatesFrozenActors frozenTrait, PPos[] footprint, Player viewer, bool startsRevealed)
 		{
@@ -176,9 +179,20 @@ namespace OpenRA.Traits
 			Owner = null;
 		}
 
-		public void Flash()
+		public void Flash(Color color, float alpha)
 		{
 			flashTicks = 5;
+			flashModifiers = TintModifiers.ReplaceColor;
+			flashTint = new float3(color.R, color.G, color.B) / 255f;
+			flashAlpha = alpha;
+		}
+
+		public void Flash(float3 tint)
+		{
+			flashTicks = 5;
+			flashModifiers = TintModifiers.None;
+			flashTint = tint;
+			flashAlpha = null;
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
@@ -192,7 +206,11 @@ namespace OpenRA.Traits
 					.Select(r =>
 					{
 						var mr = (IModifyableRenderable)r;
-						return mr.WithTint(float3.Ones, mr.TintModifiers | TintModifiers.ReplaceColor).WithAlpha(0.5f);
+						mr = mr.WithTint(flashTint, mr.TintModifiers | flashModifiers);
+						if (flashAlpha.HasValue)
+							mr = mr.WithAlpha(flashAlpha.Value);
+
+						return mr;
 					}));
 			}
 

--- a/OpenRA.Mods.Common/Activities/Demolish.cs
+++ b/OpenRA.Mods.Common/Activities/Demolish.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (!enterDemolishables.Any(i => i.IsValidTarget(enterActor, self)))
 					return;
 
-				w.Add(new FlashTarget(enterActor, count: flashes, delay: flashesDelay, interval: flashInterval));
+				w.Add(new FlashTarget(enterActor, Color.White, count: flashes, interval: flashInterval, delay: flashesDelay));
 
 				foreach (var ind in notifiers)
 					ind.Demolishing(self);

--- a/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
@@ -14,6 +14,7 @@ using Eluant;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 using OpenRA.Scripting;
 using OpenRA.Traits;
 
@@ -76,7 +77,7 @@ namespace OpenRA.Mods.Common.Scripting
 			"defines which player palette to use. Duration is in ticks.")]
 		public void Flash(int duration = 4, Player asPlayer = null)
 		{
-			Self.World.Add(new FlashTarget(Self, asPlayer, duration));
+			Self.World.Add(new FlashTarget(Self, asPlayer?.Color ?? Color.White, duration));
 		}
 
 		[Desc("The effective owner of the actor.")]

--- a/OpenRA.Mods.Common/Traits/CapturableProgressBlink.cs
+++ b/OpenRA.Mods.Common/Traits/CapturableProgressBlink.cs
@@ -64,10 +64,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (tick / 4 < captorOwners.Count && tick % 4 == 0)
 			{
 				var captorOwner = captorOwners[tick / 4];
-				self.World.Add(new FlashTarget(self, captorOwner));
+				self.World.Add(new FlashTarget(self, captorOwner.Color));
 				foreach (var captor in captors)
 					if (captor.Owner == captorOwner)
-						self.World.Add(new FlashTarget(captor, captorOwner));
+						self.World.Add(new FlashTarget(captor, captorOwner.Color));
 			}
 
 			if (++tick >= Info.Interval)

--- a/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
@@ -179,7 +179,7 @@ namespace OpenRA.Mods.Common.Traits
 				self.ChangeOwner(captor.Owner);
 
 				if (self.Owner == self.World.LocalPlayer)
-					w.Add(new FlashTarget(self));
+					w.Add(new FlashTarget(self, Color.White));
 
 				var pc = captor.Info.TraitInfoOrDefault<ProximityCaptorInfo>();
 				foreach (var t in self.TraitsImplementing<INotifyCapture>())

--- a/OpenRA.Mods.Common/Traits/World/OrderEffects.cs
+++ b/OpenRA.Mods.Common/Traits/World/OrderEffects.cs
@@ -14,56 +14,56 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-    [Desc("Renders an effect at the order target locations.")]
-    public class OrderEffectsInfo : TraitInfo
-    {
-        [Desc("The image to use.")]
-        [FieldLoader.Require]
-        public readonly string TerrainFlashImage;
+	[Desc("Renders an effect at the order target locations.")]
+	public class OrderEffectsInfo : TraitInfo
+	{
+		[Desc("The image to use.")]
+		[FieldLoader.Require]
+		public readonly string TerrainFlashImage;
 
-        [Desc("The sequence to use.")]
-        [FieldLoader.Require]
-        public readonly string TerrainFlashSequence;
+		[Desc("The sequence to use.")]
+		[FieldLoader.Require]
+		public readonly string TerrainFlashSequence;
 
-        [Desc("The palette to use.")]
-        public readonly string TerrainFlashPalette;
+		[Desc("The palette to use.")]
+		public readonly string TerrainFlashPalette;
 
-        public override object Create(ActorInitializer init)
-        {
-            return new OrderEffects(this);
-        }
-    }
+		public override object Create(ActorInitializer init)
+		{
+			return new OrderEffects(this);
+		}
+	}
 
-    public class OrderEffects : INotifyOrderIssued
-    {
-        readonly OrderEffectsInfo info;
+	public class OrderEffects : INotifyOrderIssued
+	{
+		readonly OrderEffectsInfo info;
 
-        public OrderEffects(OrderEffectsInfo info)
-        {
-            this.info = info;
-        }
+		public OrderEffects(OrderEffectsInfo info)
+		{
+			this.info = info;
+		}
 
-        bool INotifyOrderIssued.OrderIssued(World world, Target target)
-        {
-            if (target.Type == TargetType.Actor)
-            {
-                world.AddFrameEndTask(w => w.Add(new FlashTarget(target.Actor)));
-                return true;
-            }
+		bool INotifyOrderIssued.OrderIssued(World world, Target target)
+		{
+			if (target.Type == TargetType.Actor)
+			{
+				world.AddFrameEndTask(w => w.Add(new FlashTarget(target.Actor)));
+				return true;
+			}
 
-            if (target.Type == TargetType.FrozenActor)
-            {
-                target.FrozenActor.Flash();
-                return true;
-            }
+			if (target.Type == TargetType.FrozenActor)
+			{
+				target.FrozenActor.Flash();
+				return true;
+			}
 
-            if (target.Type == TargetType.Terrain)
-            {
-                world.AddFrameEndTask(w => w.Add(new SpriteAnnotation(target.CenterPosition, world, info.TerrainFlashImage, info.TerrainFlashSequence, info.TerrainFlashPalette)));
-                return true;
-            }
+			if (target.Type == TargetType.Terrain)
+			{
+				world.AddFrameEndTask(w => w.Add(new SpriteAnnotation(target.CenterPosition, world, info.TerrainFlashImage, info.TerrainFlashSequence, info.TerrainFlashPalette)));
+				return true;
+			}
 
-            return false;
-        }
-    }
+			return false;
+		}
+	}
 }

--- a/OpenRA.Mods.Common/Traits/World/OrderEffects.cs
+++ b/OpenRA.Mods.Common/Traits/World/OrderEffects.cs
@@ -17,6 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public enum ActorFlashType { Overlay, Tint }
 
+	[TraitLocation(SystemActors.World)]
 	[Desc("Renders an effect at the order target locations.")]
 	public class OrderEffectsInfo : TraitInfo
 	{

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -388,6 +388,7 @@ World:
 		TerrainFlashImage: moveflsh
 		TerrainFlashSequence: idle
 		TerrainFlashPalette: moveflash
+		ActorFlashType: Tint
 
 EditorWorld:
 	Inherits: ^BaseWorld


### PR DESCRIPTION
Implementing the last piece from #18310, this PR hooks up an option to flash targets using the multiply effect from the original TS and enables it for the TS mod. The first commit fixes the incorrect intentation (spaces to tabs) that wasn't caught in #19444.