### PR TITLE
Revert Difficulty swap from campaign-global

### DIFF
--- a/mods/cnc/bits/scripts/campaign-global.lua
+++ b/mods/cnc/bits/scripts/campaign-global.lua
@@ -6,6 +6,8 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
+Difficulty = Map.LobbyOption("difficulty")
+
 IdleHunt = function(actor)
 	if actor.HasProperty("Hunt") and not actor.IsDead then
 		Trigger.OnIdle(actor, actor.Hunt)

--- a/mods/cnc/maps/gdi05a/gdi05a.lua
+++ b/mods/cnc/maps/gdi05a/gdi05a.lua
@@ -6,8 +6,6 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
-Difficulty = Map.LobbyOption("difficulty")
-
 RepairThreshold = { easy = 0.3, normal = 0.6, hard = 0.9 }
 
 ActorRemovals =

--- a/mods/cnc/maps/gdi06/gdi06.lua
+++ b/mods/cnc/maps/gdi06/gdi06.lua
@@ -6,8 +6,6 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
-Difficulty = Map.LobbyOption("difficulty")
-
 IslandSamSites = { SAM01, SAM02 }
 NodBase = { PowerPlant1, PowerPlant2, PowerPlant3, PowerPlant4, PowerPlant5, Refinery, HandOfNod, Silo1, Silo2, Silo3, Silo4, ConYard, CommCenter }
 

--- a/mods/cnc/maps/nod06a/nod06a.lua
+++ b/mods/cnc/maps/nod06a/nod06a.lua
@@ -6,8 +6,6 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
-Difficulty = Map.LobbyOption("difficulty")
-
 NodStartUnitsRight =
 {
 	tough = { 'ltnk', 'bike', 'e1', 'e1', 'e3', 'e3' },

--- a/mods/cnc/maps/nod06b/nod06b.lua
+++ b/mods/cnc/maps/nod06b/nod06b.lua
@@ -6,8 +6,6 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
-Difficulty = Map.LobbyOption("difficulty")
-
 NodUnitsVehicle1 =
 {
 	tough = { 'bggy', 'bike', 'bike' },

--- a/mods/cnc/maps/nod09/nod09.lua
+++ b/mods/cnc/maps/nod09/nod09.lua
@@ -6,8 +6,6 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
-Difficulty = Map.LobbyOption("difficulty")
-
 if Difficulty == "easy" then
 	Rambo = "rmbo.easy"
 elseif Difficulty == "hard" then

--- a/mods/cnc/maps/nod10a/nod10a.lua
+++ b/mods/cnc/maps/nod10a/nod10a.lua
@@ -6,8 +6,6 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
-Difficulty = Map.LobbyOption("difficulty")
-
 if Difficulty == "easy" then
 	Rambo = "rmbo.easy"
 elseif Difficulty == "hard" then

--- a/mods/cnc/maps/nod10b/nod10b.lua
+++ b/mods/cnc/maps/nod10b/nod10b.lua
@@ -6,8 +6,6 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
-Difficulty = Map.LobbyOption("difficulty")
-
 if Difficulty == "easy" then
 	Rambo = "rmbo.easy"
 elseif Difficulty == "hard" then


### PR DESCRIPTION
This reverts a change that mistakenly made it through #19426. I was testing what was causing the dropdown mix-up and left in a change that wasn't the culprit. Noticed while testing #19355.