### PR TITLE
Make text fields yield keyboard focus on "Esc" in a consistent way

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -133,7 +133,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			filenameInput = panel.Get<TextFieldWidget>("FILENAME_INPUT");
 			filenameInput.OnTextEdited = () => ApplyFilter();
-			filenameInput.OnEscKey = _ => filenameInput.YieldKeyboardFocus();
+			filenameInput.OnEscKey = _ =>
+			{
+				if (string.IsNullOrEmpty(filenameInput.Text))
+					filenameInput.YieldKeyboardFocus();
+				else
+				{
+					filenameInput.Text = "";
+					filenameInput.OnTextEdited();
+				}
+
+				return true;
+			};
 
 			var frameContainer = panel.GetOrNull("FRAME_SELECTOR");
 			if (frameContainer != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -114,11 +114,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				&& editor.CurrentBrush == editor.DefaultBrush
 				&& Game.RunTime > lastScrollTime + scrollVisibleTimeout;
 
-			actorIDField.OnEscKey = _ =>
-			{
-				actorIDField.YieldKeyboardFocus();
-				return true;
-			};
+			actorIDField.OnEscKey = _ => actorIDField.YieldKeyboardFocus();
 
 			actorIDField.OnTextEdited = () =>
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/CommonSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/CommonSelectorLogic.cs
@@ -46,8 +46,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SearchTextField = widget.Get<TextFieldWidget>("SEARCH_TEXTFIELD");
 			SearchTextField.OnEscKey = _ =>
 			{
-				SearchTextField.Text = "";
-				SearchTextField.YieldKeyboardFocus();
+				if (string.IsNullOrEmpty(SearchTextField.Text))
+					SearchTextField.YieldKeyboardFocus();
+				else
+				{
+					SearchTextField.Text = "";
+					SearchTextField.OnTextEdited();
+				}
+
 				return true;
 			};
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -436,7 +436,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return true;
 			};
 
-			chatTextField.OnEscKey = _ => { chatTextField.Text = ""; return true; };
+			chatTextField.OnEscKey = _ => chatTextField.YieldKeyboardFocus();
 
 			lobbyChatPanel = lobby.Get<ScrollPanelWidget>("CHAT_DISPLAY");
 			chatTemplate = lobbyChatPanel.Get("CHAT_TEMPLATE");


### PR DESCRIPTION
Some text fields were clearing the input on <kbd>Esc</kbd> before yielding focus and others were only clearing input (lobby chat field) and others were doing both at the same time (map editor search filter). This PR standardizes this behavior to just yielding focus without clearing the input. There are some special case text fields that I have not touched (player name, map chooser, in-game chat). In the future we may set this behavior as the default for text inputs so that chrome logic doesn't need to implement it.

Closes #15426