### PR TITLE
Disable chat for the first 5s (configurable) after joining a server.

### DIFF
--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -34,6 +34,21 @@ namespace OpenRA.Network
 					TextNotificationsManager.AddSystemLine(order.TargetString);
 					break;
 
+				case "DisableChatEntry":
+					{
+						// Order must originate from the server
+						if (clientId != 0)
+							break;
+
+						// Server may send MaxValue to indicate that it is disabled until further notice
+						if (order.ExtraData == uint.MaxValue)
+							TextNotificationsManager.ChatDisabledUntil = uint.MaxValue;
+						else
+							TextNotificationsManager.ChatDisabledUntil = Game.RunTime + order.ExtraData;
+
+						break;
+					}
+
 				case "Chat":
 					{
 						var client = orderManager.LobbyInfo.ClientWithIndex(clientId);

--- a/OpenRA.Game/Server/Connection.cs
+++ b/OpenRA.Game/Server/Connection.cs
@@ -31,6 +31,7 @@ namespace OpenRA.Server
 		public readonly int PlayerIndex;
 		public readonly string AuthToken;
 		public readonly EndPoint EndPoint;
+		public readonly Stopwatch ConnectionTimer = Stopwatch.StartNew();
 
 		public long TimeSinceLastResponse => Game.RunTime - lastReceivedTime;
 

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -101,6 +101,9 @@ namespace OpenRA
 		[Desc("For dedicated servers only, treat maps that fail the lint checks as invalid.")]
 		public bool EnableLintChecks = true;
 
+		[Desc("Delay in milliseconds before newly joined players can send chat messages.")]
+		public int JoinChatDelay = 5000;
+
 		public ServerSettings Clone()
 		{
 			return (ServerSettings)MemberwiseClone();

--- a/OpenRA.Game/TextNotificationsManager.cs
+++ b/OpenRA.Game/TextNotificationsManager.cs
@@ -20,6 +20,8 @@ namespace OpenRA
 		static Color chatMessageColor = Color.White;
 		static string systemMessageLabel;
 
+		public static long ChatDisabledUntil { get; internal set; }
+
 		static TextNotificationsManager()
 		{
 			ChromeMetrics.TryGet("ChatMessageColor", out chatMessageColor);

--- a/launch-dedicated.cmd
+++ b/launch-dedicated.cmd
@@ -19,10 +19,12 @@ set EnableGeoIP=True
 set EnableLintChecks=True
 set ShareAnonymizedIPs=True
 
+set JoinChatDelay=5000
+
 set SupportDir=""
 
 :loop
 
-bin\OpenRA.Server.exe Engine.EngineDir=".." Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.RecordReplays=%RecordReplays% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports% Server.EnableGeoIP=%EnableGeoIP% Server.EnableLintChecks=%EnableLintChecks% Server.ShareAnonymizedIPs=%ShareAnonymizedIPs% Engine.SupportDir=%SupportDir%
+bin\OpenRA.Server.exe Engine.EngineDir=".." Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.RecordReplays=%RecordReplays% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports% Server.EnableGeoIP=%EnableGeoIP% Server.EnableLintChecks=%EnableLintChecks% Server.ShareAnonymizedIPs=%ShareAnonymizedIPs% Server.JoinChatDelay=%JoinChatDelay% Engine.SupportDir=%SupportDir%
 
 goto loop

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -29,6 +29,8 @@ EnableGeoIP="${EnableGeoIP:-"True"}"
 EnableLintChecks="${EnableLintChecks:-"True"}"
 ShareAnonymizedIPs="${ShareAnonymizedIPs:-"True"}"
 
+JoinChatDelay="${JoinChatDelay:-"5000"}"
+
 SupportDir="${SupportDir:-""}"
 
 while true; do
@@ -46,5 +48,6 @@ while true; do
      Server.EnableGeoIP="$EnableGeoIP" \
      Server.EnableLintChecks="$EnableLintChecks" \
      Server.ShareAnonymizedIPs="$ShareAnonymizedIPs" \
+     Server.JoinChatDelay="$JoinChatDelay" \
      Engine.SupportDir="$SupportDir"
 done


### PR DESCRIPTION
Implements the same feature as the serverside hotfix, but now with client-side integration to disable the chat box until the timeout has expired. The delay has been reduced to 5s and is now configurable by the server host.