### PR TITLE
Remove "X has joined the game." notification when starting a Skirmish.

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -481,8 +481,8 @@ namespace OpenRA.Server
 
 						Log.Write("server", "{0} ({1}) has joined the game.", client.Name, newConn.EndPoint);
 
-						// Report to all other players
-						SendMessage($"{client.Name} has joined the game.");
+						if (Type != ServerType.Local)
+							SendMessage($"{client.Name} has joined the game.");
 
 						// Send initial ping
 						SendOrderTo(newConn, "Ping", Game.RunTime.ToString(CultureInfo.InvariantCulture));


### PR DESCRIPTION
In #19447 we decided to send "X has joined the game." to the player who joined to further clean up the code. This is reasonable for actual MP games, but makes less sense in skirmish.