### PR TITLE
Prevent fallback to other production structures if a primary is set.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
@@ -16,15 +16,6 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	static class PrimaryExts
-	{
-		public static bool IsPrimaryBuilding(this Actor a)
-		{
-			var pb = a.TraitOrDefault<PrimaryBuilding>();
-			return pb != null && pb.IsPrimary;
-		}
-	}
-
 	[Desc("Used together with ClassicProductionQueue.")]
 	public class PrimaryBuildingInfo : ConditionalTraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
@@ -84,13 +84,23 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var productionActors = self.World.ActorsWithTrait<Production>()
 				.Where(x => x.Actor.Owner == self.Owner
-					&& !x.Trait.IsTraitDisabled && x.Trait.Info.Produces.Contains(Info.Type))
-				.OrderByDescending(x => x.Actor.IsPrimaryBuilding())
-				.ThenByDescending(x => x.Actor.ActorID)
+		            && !x.Trait.IsTraitDisabled
+		            && x.Trait.Info.Produces.Contains(Info.Type))
+				.Select<TraitPair<Production>, (TraitPair<Production> TraitPair, PrimaryBuilding PrimaryBuilding)>(
+					x => (x, x.Actor.TraitOrDefault<PrimaryBuilding>()))
+				.OrderByDescending(x => x.PrimaryBuilding != null && x.PrimaryBuilding.IsPrimary)
+				.ThenBy(x => x.TraitPair.Trait.IsTraitPaused)
+				.ThenByDescending(x => x.TraitPair.Actor.ActorID)
 				.ToList();
 
-			var unpaused = productionActors.FirstOrDefault(a => !a.Trait.IsTraitPaused);
-			return unpaused.Trait != null ? unpaused : productionActors.FirstOrDefault();
+			// Primary buildings always take precedence
+			// TraitPair is a struct, so FirstOrDefault always returns a valid object
+			var first = productionActors.FirstOrDefault();
+			if (first.PrimaryBuilding != null && first.PrimaryBuilding.IsPrimary)
+				return first.TraitPair;
+
+			var unpaused = productionActors.FirstOrDefault(a => !a.TraitPair.Trait.IsTraitPaused).TraitPair;
+			return unpaused.Trait != null ? unpaused : first.TraitPair;
 		}
 
 		protected override bool BuildUnit(ActorInfo unit)
@@ -105,8 +115,10 @@ namespace OpenRA.Mods.Common.Traits
 				.Where(x => x.Actor.Owner == self.Owner
 					&& !x.Trait.IsTraitDisabled
 					&& x.Trait.Info.Produces.Contains(type))
-					.OrderByDescending(x => x.Actor.IsPrimaryBuilding())
-					.ThenByDescending(x => x.Actor.ActorID);
+				.Select<TraitPair<Production>, (Actor Actor, Production Production, PrimaryBuilding PrimaryBuilding)>(
+					x => (x.Actor, x.Trait, x.Actor.TraitOrDefault<PrimaryBuilding>()))
+				.OrderByDescending(x => x.PrimaryBuilding != null && x.PrimaryBuilding.IsPrimary)
+				.ThenByDescending(x => x.Actor.ActorID);
 
 			if (!producers.Any())
 			{
@@ -116,21 +128,25 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var p in producers)
 			{
-				if (p.Trait.IsTraitPaused)
+				if (p.Production.IsTraitPaused)
 					continue;
 
 				var inits = new TypeDictionary
 				{
 					new OwnerInit(self.Owner),
-					new FactionInit(BuildableInfo.GetInitialFaction(unit, p.Trait.Faction))
+					new FactionInit(BuildableInfo.GetInitialFaction(unit, p.Production.Faction))
 				};
 
 				var item = Queue.First(i => i.Done && i.Item == unit.Name);
-				if (p.Trait.Produce(p.Actor, unit, type, inits, item.TotalCost))
+				if (p.Production.Produce(p.Actor, unit, type, inits, item.TotalCost))
 				{
 					EndProduction(item);
 					return true;
 				}
+
+				// Wait for the primary building to become available instead of falling back to a non-primary producer
+				if (p.PrimaryBuilding.IsPrimary)
+					return false;
 			}
 
 			return false;

--- a/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
@@ -65,8 +65,10 @@ namespace OpenRA.Mods.Common.Traits
 				.Where(x => x.Actor.Owner == self.Owner
 					&& !x.Trait.IsTraitDisabled
 					&& x.Trait.Info.Produces.Contains(info.Type))
-					.OrderByDescending(x => x.Actor.IsPrimaryBuilding())
-					.ThenByDescending(x => x.Actor.ActorID);
+				.Select<TraitPair<Production>, (Actor Actor, Production Production, PrimaryBuilding PrimaryBuilding)>(
+					x => (x.Actor, x.Trait, x.Actor.TraitOrDefault<PrimaryBuilding>()))
+				.OrderByDescending(x => x.PrimaryBuilding != null && x.PrimaryBuilding.IsPrimary)
+				.ThenByDescending(x => x.Actor.ActorID);
 
 			// TODO: The power should not reset if the production fails.
 			// Fixing this will require a larger rework of the support power code
@@ -83,7 +85,7 @@ namespace OpenRA.Mods.Common.Traits
 						new FactionInit(BuildableInfo.GetInitialFaction(ai, faction))
 					};
 
-					activated |= p.Trait.Produce(p.Actor, ai, info.Type, inits, 0);
+					activated |= p.Production.Produce(p.Actor, ai, info.Type, inits, 0);
 				}
 
 				if (activated)


### PR DESCRIPTION
If a player explicitly sets a primary production structure this PR ensures that production will wait on that building becoming available instead of producing the unit somewhere else against the player's command.

Closes #17404.