### PR TITLE
Replace hardcoded UnitOrderGenerator in World with DefaultOrderGenera…

### DIFF
--- a/OpenRA.Game/Orders/IOrderGeneratorFactory.cs
+++ b/OpenRA.Game/Orders/IOrderGeneratorFactory.cs
@@ -1,0 +1,18 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+namespace OpenRA
+{
+	public interface IOrderGeneratorFactory
+	{
+		IOrderGenerator CreateOrderGenerator();
+	}
+}

--- a/OpenRA.Game/Traits/World/DefaultOrderGenerator.cs
+++ b/OpenRA.Game/Traits/World/DefaultOrderGenerator.cs
@@ -1,0 +1,31 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Orders;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public class DefaultOrderGeneratorInfo : TraitInfo
+	{
+		public override object Create(ActorInitializer init) { return new DefaultOrderGenerator(); }
+	}
+
+	public class DefaultOrderGenerator : IOrderGeneratorFactory
+	{
+		public DefaultOrderGenerator() { }
+
+		IOrderGenerator IOrderGeneratorFactory.CreateOrderGenerator()
+		{
+			return new UnitOrderGenerator();
+		}
+	}
+}

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -158,8 +158,9 @@ namespace OpenRA
 		}
 
 		public readonly ISelection Selection;
+		readonly IOrderGeneratorFactory orderGeneratorFactory;
 
-		public void CancelInputMode() { OrderGenerator = new UnitOrderGenerator(); }
+		public void CancelInputMode() { OrderGenerator = orderGeneratorFactory.CreateOrderGenerator(); }
 
 		public bool ToggleInputMode<T>() where T : IOrderGenerator, new()
 		{
@@ -183,7 +184,6 @@ namespace OpenRA
 		{
 			Type = type;
 			OrderManager = orderManager;
-			orderGenerator = new UnitOrderGenerator();
 			Map = map;
 
 			var gameSpeeds = modData.Manifest.Get<GameSpeeds>();
@@ -208,6 +208,8 @@ namespace OpenRA
 			ScreenMap = WorldActor.Trait<ScreenMap>();
 			Selection = WorldActor.Trait<ISelection>();
 			OrderValidators = WorldActor.TraitsImplementing<IValidateOrder>().ToArray();
+			orderGeneratorFactory = WorldActor.Trait<IOrderGeneratorFactory>();
+			orderGenerator = orderGeneratorFactory.CreateOrderGenerator();
 
 			LongBitSet<PlayerBitMask>.Reset();
 

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -4,6 +4,7 @@
 	ScreenMap:
 	ActorMap:
 	Selection:
+	DefaultOrderGenerator:
 	MusicPlaylist:
 		VictoryMusic: win1
 		DefeatMusic: nod_map1

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -4,6 +4,7 @@
 	ScreenMap:
 	ActorMap:
 	Selection:
+	DefaultOrderGenerator:
 	MusicPlaylist:
 		VictoryMusic: score
 		DefeatMusic: score

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -4,6 +4,7 @@
 	ActorMap:
 	ScreenMap:
 	Selection:
+	DefaultOrderGenerator:
 	MusicPlaylist:
 		VictoryMusic: score
 		DefeatMusic: map

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -4,6 +4,7 @@
 	ScreenMap:
 	ActorMap:
 	Selection:
+	DefaultOrderGenerator:
 	MusicPlaylist:
 		VictoryMusic: score
 		DefeatMusic: maps


### PR DESCRIPTION
…tor trait

This is replacement for https://github.com/OpenRA/OpenRA/pull/18337, unfortunatelly original branch with this changes was deleted.

It is needed for https://github.com/OpenRA/d2/issues/196

Currently only UnitOrderGenerator can be used by default in OpenRA engine.
This PR allow to change this to something else.

( Initially the problem was in mouse button checks. in d2, need to allow to use any mouse button after command button in the ui was pressed, but UnitOrderGenerator use MouseDefaults and action can be only one mouse button.)

