### PR TITLE
Fix faction suffix chrome issues

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/AddFactionSuffixLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/AddFactionSuffixLogic.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[ObjectCreator.UseCtor]
 		public AddFactionSuffixLogic(Widget widget, World world)
 		{
-			if (world.LocalPlayer == null)
+			if (world.LocalPlayer == null || world.LocalPlayer.Spectating)
 				return;
 
 			if (!ChromeMetrics.TryGet("FactionSuffix-" + world.LocalPlayer.Faction.InternalName, out string faction))

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngameChatLogic.cs
@@ -1,0 +1,25 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+	public class LoadIngameChatLogic : ChromeLogic
+	{
+		[ObjectCreator.UseCtor]
+		public LoadIngameChatLogic(Widget widget, World world)
+		{
+			var root = widget.Get("CHAT_ROOT");
+			Game.LoadWidget(world, "CHAT_PANEL", root, new WidgetArgs() { { "isMenuChat", false } });
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
@@ -54,7 +54,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			Game.LoadWidget(world, "DEBUG_WIDGETS", worldRoot, new WidgetArgs());
-			Game.LoadWidget(world, "CHAT_PANEL", worldRoot, new WidgetArgs() { { "isMenuChat", false } });
 
 			world.GameOver += () =>
 			{

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -22,7 +22,6 @@ Container@INGAME_ROOT:
 				CycleStatusBarsKey: CycleStatusBars
 				PauseKey: Pause
 		Container@WORLD_ROOT:
-			Logic: LoadIngamePerfLogic
 			Children:
 				LogicTicker@DISCONNECT_WATCHER:
 					Logic: DisconnectWatcherLogic
@@ -37,7 +36,6 @@ Container@INGAME_ROOT:
 				StrategicProgress@STRATEGIC_PROGRESS:
 					X: WINDOW_RIGHT / 2
 					Y: 40
-				Container@PERF_ROOT:
 				WorldInteractionController@INTERACTION_CONTROLLER:
 					Width: WINDOW_RIGHT
 					Height: WINDOW_BOTTOM
@@ -73,8 +71,10 @@ Container@PERF_WIDGETS:
 					Height: 200
 
 Container@OBSERVER_WIDGETS:
-	Logic: MenuButtonsChromeLogic
+	Logic: MenuButtonsChromeLogic, LoadIngamePerfLogic, LoadIngameChatLogic
 	Children:
+		Container@CHAT_ROOT:
+		Container@PERF_ROOT:
 		ViewportController:
 			Width: WINDOW_RIGHT
 			Height: WINDOW_BOTTOM
@@ -1140,7 +1140,10 @@ Container@OBSERVER_WIDGETS:
 							AxisFont: TinyBold
 
 Container@PLAYER_WIDGETS:
+	Logic: LoadIngamePerfLogic, LoadIngameChatLogic
 	Children:
+		Container@CHAT_ROOT:
+		Container@PERF_ROOT:
 		ViewportController:
 			Width: WINDOW_RIGHT
 			Height: WINDOW_BOTTOM

--- a/mods/common/chrome/ingame-observer.yaml
+++ b/mods/common/chrome/ingame-observer.yaml
@@ -1,6 +1,7 @@
 Container@OBSERVER_WIDGETS:
-	Logic: MenuButtonsChromeLogic
+	Logic: MenuButtonsChromeLogic, LoadIngameChatLogic
 	Children:
+		Container@CHAT_ROOT:
 		LogicKeyListener@OBSERVER_KEY_LISTENER:
 		MenuButton@OPTIONS_BUTTON:
 			X: 5

--- a/mods/d2k/chrome/ingame-observer.yaml
+++ b/mods/d2k/chrome/ingame-observer.yaml
@@ -1,6 +1,7 @@
 Container@OBSERVER_WIDGETS:
-	Logic: MenuButtonsChromeLogic
+	Logic: MenuButtonsChromeLogic, LoadIngameChatLogic
 	Children:
+		Container@CHAT_ROOT:
 		LogicKeyListener@OBSERVER_KEY_LISTENER:
 		Container@MUTE_INDICATOR:
 			Logic: MuteIndicatorLogic

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -1,5 +1,7 @@
 Container@PLAYER_WIDGETS:
+	Logic: LoadIngameChatLogic
 	Children:
+		Container@CHAT_ROOT:
 		LogicKeyListener@CONTROLGROUP_KEYHANDLER:
 			Logic: ControlGroupLogic
 		LogicTicker@SIDEBAR_TICKER:

--- a/mods/ra/chrome/ingame-observer.yaml
+++ b/mods/ra/chrome/ingame-observer.yaml
@@ -1,5 +1,7 @@
 Container@OBSERVER_WIDGETS:
+	Logic: LoadIngameChatLogic
 	Children:
+		Container@CHAT_ROOT:
 		Container@MUTE_INDICATOR:
 			Logic: MuteIndicatorLogic
 			X: WINDOW_RIGHT - WIDTH - 260

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -1,5 +1,7 @@
 Container@PLAYER_WIDGETS:
+	Logic: LoadIngameChatLogic
 	Children:
+		Container@CHAT_ROOT:
 		LogicKeyListener@CONTROLGROUP_KEYHANDLER:
 			Logic: ControlGroupLogic
 		LogicTicker@SIDEBAR_TICKER:

--- a/mods/ts/chrome/ingame-observer.yaml
+++ b/mods/ts/chrome/ingame-observer.yaml
@@ -1,6 +1,7 @@
 Container@OBSERVER_WIDGETS:
-	Logic: MenuButtonsChromeLogic
+	Logic: MenuButtonsChromeLogic, LoadIngameChatLogic
 	Children:
+		Container@CHAT_ROOT:
 		LogicKeyListener@OBSERVER_KEY_LISTENER:
 		Container@MUTE_INDICATOR:
 			Logic: MuteIndicatorLogic

--- a/mods/ts/chrome/ingame-player.yaml
+++ b/mods/ts/chrome/ingame-player.yaml
@@ -1,5 +1,7 @@
 Container@PLAYER_WIDGETS:
+	Logic: LoadIngameChatLogic
 	Children:
+		Container@CHAT_ROOT:
 		LogicKeyListener@CONTROLGROUP_KEYHANDLER:
 			Logic: ControlGroupLogic
 		LogicTicker@SIDEBAR_TICKER:


### PR DESCRIPTION
This is a take on fixing the problems introduced by #19488. The approach is to duplicate the widget roots and let them re-initialize when a player transitions to spectators. The only downside I see is that a player typing a message into chat while being defeated will lose that message and the chat will be closed. I think this is not a big issue and can be solved in a follow-up if need be.

Supersedes #19501
Fixes #19500 