### PR TITLE
Allow mods to replace UnitOrderGenerator with their own default.

### DIFF
--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -79,6 +79,7 @@ namespace OpenRA
 		public readonly IReadOnlyDictionary<string, string> Packages;
 		public readonly IReadOnlyDictionary<string, string> MapFolders;
 		public readonly MiniYaml LoadScreen;
+		public readonly string DefaultOrderGenerator;
 
 		public readonly string[] SoundFormats = Array.Empty<string>();
 		public readonly string[] SpriteFormats = Array.Empty<string>();
@@ -90,7 +91,7 @@ namespace OpenRA
 			"Include", "Metadata", "Folders", "MapFolders", "Packages", "Rules",
 			"Sequences", "ModelSequences", "Cursors", "Chrome", "Assemblies", "ChromeLayout", "Weapons",
 			"Voices", "Notifications", "Music", "Translations", "TileSets", "ChromeMetrics", "Missions", "Hotkeys",
-			"ServerTraits", "LoadScreen", "SupportsMapsFrom", "SoundFormats", "SpriteFormats", "VideoFormats",
+			"ServerTraits", "LoadScreen", "DefaultOrderGenerator", "SupportsMapsFrom", "SoundFormats", "SpriteFormats", "VideoFormats",
 			"RequiresMods", "PackageFormats"
 		};
 
@@ -160,6 +161,9 @@ namespace OpenRA
 				compat.AddRange(yaml["SupportsMapsFrom"].Value.Split(',').Select(c => c.Trim()));
 
 			MapCompatibility = compat.ToArray();
+
+			if (yaml.ContainsKey("DefaultOrderGenerator"))
+				DefaultOrderGenerator = yaml["DefaultOrderGenerator"].Value;
 
 			if (yaml.ContainsKey("PackageFormats"))
 				PackageFormats = FieldLoader.GetValue<string[]>("PackageFormats", yaml["PackageFormats"].Value);

--- a/OpenRA.Game/Orders/IOrderGenerator.cs
+++ b/OpenRA.Game/Orders/IOrderGenerator.cs
@@ -12,7 +12,7 @@
 using System.Collections.Generic;
 using OpenRA.Graphics;
 
-namespace OpenRA
+namespace OpenRA.Orders
 {
 	public interface IOrderGenerator
 	{

--- a/OpenRA.Mods.Common/Orders/ForceModifiersOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/ForceModifiersOrderGenerator.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.Orders;
 
 namespace OpenRA.Mods.Common.Orders
 {

--- a/OpenRA.Mods.Common/Orders/GuardOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/GuardOrderGenerator.cs
@@ -12,7 +12,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Orders;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Orders

--- a/OpenRA.Mods.Common/Orders/OrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/OrderGenerator.cs
@@ -12,6 +12,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Orders;
 
 namespace OpenRA.Mods.Common.Orders
 {

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Orders;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 using OpenRA.Widgets;

--- a/OpenRA.Mods.Common/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/UnitOrderGenerator.cs
@@ -12,10 +12,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Orders;
 using OpenRA.Traits;
 using OpenRA.Widgets;
 
-namespace OpenRA.Orders
+namespace OpenRA.Mods.Common.Orders
 {
 	public class UnitOrderGenerator : IOrderGenerator
 	{

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -12,7 +12,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
-using OpenRA.Orders;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SelectDirectionalTarget.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SelectDirectionalTarget.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Widgets;
+using OpenRA.Orders;
 using OpenRA.Traits;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
@@ -14,7 +14,6 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Orders;
 using OpenRA.Traits;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/OrderButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/OrderButtonsChromeLogic.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using OpenRA.Mods.Common.Orders;
+using OpenRA.Orders;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -12,8 +12,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Orders;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 using OpenRA.Widgets;

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -223,6 +223,8 @@ MapGrid:
 	TileSize: 24,24
 	Type: Rectangular
 
+DefaultOrderGenerator: UnitOrderGenerator
+
 SupportsMapsFrom: cnc
 
 SoundFormats: Aud, Wav

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -204,6 +204,8 @@ Fonts:
 Missions:
 	d2k|missions.yaml
 
+DefaultOrderGenerator: UnitOrderGenerator
+
 SupportsMapsFrom: d2k
 
 SoundFormats: Aud, Wav

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -226,6 +226,8 @@ MapGrid:
 	TileSize: 24,24
 	Type: Rectangular
 
+DefaultOrderGenerator: UnitOrderGenerator
+
 SupportsMapsFrom: ra
 
 SoundFormats: Aud, Wav

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -256,6 +256,8 @@ Fonts:
 		Size: 32
 		Ascender: 24
 
+DefaultOrderGenerator: UnitOrderGenerator
+
 SupportsMapsFrom: ts
 
 SoundFormats: Aud, Wav


### PR DESCRIPTION
Discord discussion around #19494 raised the question about whether it is appropriate to have things like the default order generator defined as a trait on the world actor. While that was originally my suggestion, i'm now leaning towards probably not.

This PR provides an alternative implementation for discussion and to possibly supersede #19494. It also includes a couple of related cleanups.