### PR TITLE
Corrected duplicate ActorID detection in map editor

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -328,7 +328,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public EditorActorPreview this[string id]
 		{
-			get { return previews.FirstOrDefault(p => p.ID.ToLowerInvariant() == id); }
+			get { return previews.FirstOrDefault(p => p.ID.Equals(id, StringComparison.OrdinalIgnoreCase)); }
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly BackgroundWidget actorEditPanel;
 		readonly LabelWidget typeLabel;
 		readonly TextFieldWidget actorIDField;
-		/*readonly*/ LabelWidget actorIDErrorLabel;
+		LabelWidget actorIDErrorLabel;
 
 		readonly Widget initContainer;
 		readonly Widget buttonContainer;
@@ -125,6 +125,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return;
 				}
 
+				// Check for duplicate ActorID
 				foreach (var kv in world.Map.ActorDefinitions)
 				{
 					if (kv.Key.ToString().ToLowerInvariant() == actorId.ToLowerInvariant() &&

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -126,7 +126,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				}
 
 				// Check for duplicate ActorID
-				if (CurrentActor.ID.Equals(actorId, StringComparison.OrdinalIgnoreCase))
+				if (!CurrentActor.ID.Equals(actorId, StringComparison.OrdinalIgnoreCase))
 				{
 					if (editorActorLayer[actorId] != null)
 					{

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly BackgroundWidget actorEditPanel;
 		readonly LabelWidget typeLabel;
 		readonly TextFieldWidget actorIDField;
-		LabelWidget actorIDErrorLabel;
+		readonly LabelWidget actorIDErrorLabel;
 
 		readonly Widget initContainer;
 		readonly Widget buttonContainer;
@@ -128,8 +128,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				// Check for duplicate ActorID
 				foreach (var kv in world.Map.ActorDefinitions)
 				{
-					if (kv.Key.ToString().ToLowerInvariant() == actorId.ToLowerInvariant() &&
-						CurrentActor.ID.ToString().ToLowerInvariant() != actorId.ToString().ToLowerInvariant())
+					if (kv.Key.ToLowerInvariant() == actorId.ToLowerInvariant() &&
+						CurrentActor.ID.ToLowerInvariant() != actorId.ToLowerInvariant())
 					{
 						nextActorIDStatus = ActorIDStatus.Duplicate;
 						actorIDErrorLabel.Text = "Duplicate ActorID";

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly BackgroundWidget actorEditPanel;
 		readonly LabelWidget typeLabel;
 		readonly TextFieldWidget actorIDField;
-		readonly LabelWidget actorIDErrorLabel;
+		/*readonly*/ LabelWidget actorIDErrorLabel;
 
 		readonly Widget initContainer;
 		readonly Widget buttonContainer;
@@ -125,12 +125,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return;
 				}
 
-				// Check for duplicate actor ID
-				if (CurrentActor.ID.Equals(actorId, StringComparison.OrdinalIgnoreCase))
+				foreach (var kv in world.Map.ActorDefinitions)
 				{
-					if (editorActorLayer[actorId] != null)
+					if (kv.Key.ToString().ToLowerInvariant() == actorId.ToLowerInvariant() &&
+						CurrentActor.ID.ToString().ToLowerInvariant() != actorId.ToString().ToLowerInvariant())
 					{
 						nextActorIDStatus = ActorIDStatus.Duplicate;
+						actorIDErrorLabel.Text = "Duplicate ActorID";
+						actorIDErrorLabel.Visible = true;
 						return;
 					}
 				}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -125,12 +125,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return;
 				}
 
-				// Check for duplicate actor ID
+				// Check for duplicate ActorID
 				if (CurrentActor.ID.Equals(actorId, StringComparison.OrdinalIgnoreCase))
 				{
 					if (editorActorLayer[actorId] != null)
 					{
 						nextActorIDStatus = ActorIDStatus.Duplicate;
+						actorIDErrorLabel.Text = "Duplicate ActorID";
+						actorIDErrorLabel.Visible = true;
 						return;
 					}
 				}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -126,10 +126,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				}
 
 				// Check for duplicate ActorID
-				foreach (var kv in world.Map.ActorDefinitions)
+				if (CurrentActor.ID.Equals(actorId, StringComparison.OrdinalIgnoreCase))
 				{
-					if (kv.Key.ToLowerInvariant() == actorId.ToLowerInvariant() &&
-						CurrentActor.ID.ToLowerInvariant() != actorId.ToLowerInvariant())
+					if (editorActorLayer[actorId] != null)
 					{
 						nextActorIDStatus = ActorIDStatus.Duplicate;
 						actorIDErrorLabel.Text = "Duplicate ActorID";


### PR DESCRIPTION
Fixes #19286 and Closes #17895.  Reworked the code that was in place to detect duplicate ActorIDs.