### PR TITLE
Fix WithIdleOverlay PlayerPalette editor rendering.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -51,7 +51,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 				yield break;
 
 			if (Palette != null)
-				p = init.WorldRenderer.Palette(Palette);
+			{
+				var ownerName = init.Get<OwnerInit>().InternalName;
+				p = init.WorldRenderer.Palette(IsPlayerPalette ? Palette + ownerName : Palette);
+			}
 
 			Func<WAngle> facing;
 			var dynamicfacingInit = init.GetOrDefault<DynamicFacingInit>();


### PR DESCRIPTION
Testcase: TS Nod powerplant in the map editor.