### PR TITLE
Implement mod defined model shaders.

### DIFF
--- a/OpenRA.Game/Graphics/Model.cs
+++ b/OpenRA.Game/Graphics/Model.cs
@@ -34,13 +34,17 @@ namespace OpenRA.Graphics
 	{
 		public readonly int Start;
 		public readonly int Count;
-		public readonly Sheet Sheet;
+		public readonly IShader Shader;
+		public readonly IVertexBuffer VertexBuffer;
+		public readonly Dictionary<string, ITexture> Textures;
 
-		public ModelRenderData(int start, int count, Sheet sheet)
+		public ModelRenderData(int start, int count, IShader shader, IVertexBuffer vertexBuffer, Dictionary<string, ITexture> textures)
 		{
 			Start = start;
 			Count = count;
-			Sheet = sheet;
+			Shader = shader;
+			VertexBuffer = vertexBuffer;
+			Textures = textures;
 		}
 	}
 

--- a/OpenRA.Game/Graphics/ShaderBindings.cs
+++ b/OpenRA.Game/Graphics/ShaderBindings.cs
@@ -1,0 +1,54 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Graphics
+{
+	public abstract class ShaderBindings : IShaderBindings
+	{
+		public string VertexShaderName { get; }
+		public string FragmentShaderName { get; }
+		public int Stride => 52;
+
+		public IEnumerable<ShaderVertexAttribute> Attributes { get; } = new[]
+		{
+			new ShaderVertexAttribute("aVertexPosition", 0, 3, 0),
+			new ShaderVertexAttribute("aVertexTexCoord", 1, 4, 12),
+			new ShaderVertexAttribute("aVertexTexMetadata", 2, 2, 28),
+			new ShaderVertexAttribute("aVertexTint", 3, 4, 36)
+		};
+
+		protected ShaderBindings(string name)
+		{
+			VertexShaderName = name;
+			FragmentShaderName = name;
+		}
+
+		public void SetRenderData(IShader shader, ModelRenderData renderData)
+		{
+			foreach (var (name, texture) in renderData.Textures)
+				shader.SetTexture(name, texture);
+		}
+	}
+
+	public class CombinedShaderBindings : ShaderBindings
+	{
+		public CombinedShaderBindings()
+			: base("combined") { }
+	}
+
+	public class ModelShaderBindings : ShaderBindings
+	{
+		public ModelShaderBindings()
+			: base("model") { }
+	}
+}

--- a/OpenRA.Game/Graphics/ShaderVertexAttribute.cs
+++ b/OpenRA.Game/Graphics/ShaderVertexAttribute.cs
@@ -1,0 +1,29 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+namespace OpenRA.Graphics
+{
+	public class ShaderVertexAttribute
+	{
+		public readonly string Name;
+		public readonly int Index;
+		public readonly int Components;
+		public readonly int Offset;
+
+		public ShaderVertexAttribute(string name, int index, int components, int offset)
+		{
+			Name = name;
+			Index = index;
+			Components = components;
+			Offset = offset;
+		}
+	}
+}

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Graphics
 
 				renderer.Context.SetBlendMode(currentBlend);
 				shader.PrepareRender();
-				renderer.DrawBatch(vertices, nv, PrimitiveType.TriangleList);
+				renderer.DrawBatch(shader, vertices, nv, PrimitiveType.TriangleList);
 				renderer.Context.SetBlendMode(BlendMode.None);
 
 				nv = 0;
@@ -165,7 +165,7 @@ namespace OpenRA.Graphics
 			nv += 6;
 		}
 
-		public void DrawVertexBuffer(IVertexBuffer<Vertex> buffer, int start, int length, PrimitiveType type, IEnumerable<Sheet> sheets, BlendMode blendMode)
+		public void DrawVertexBuffer(IVertexBuffer buffer, int start, int length, PrimitiveType type, IEnumerable<Sheet> sheets, BlendMode blendMode)
 		{
 			var i = 0;
 			foreach (var s in sheets)
@@ -179,7 +179,7 @@ namespace OpenRA.Graphics
 
 			renderer.Context.SetBlendMode(blendMode);
 			shader.PrepareRender();
-			renderer.DrawBatch(buffer, start, length, type);
+			renderer.DrawBatch(shader, buffer, start, length, type);
 			renderer.Context.SetBlendMode(BlendMode.None);
 		}
 

--- a/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
+++ b/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Graphics
 
 			vertices = new Vertex[rowStride * map.MapSize.Y];
 			palettes = new PaletteReference[map.MapSize.X * map.MapSize.Y];
-			vertexBuffer = Game.Renderer.Context.CreateVertexBuffer(vertices.Length);
+			vertexBuffer = Game.Renderer.Context.CreateVertexBuffer<Vertex>(vertices.Length);
 
 			wr.PaletteInvalidated += UpdatePaletteIndices;
 

--- a/OpenRA.Mods.Cnc/Graphics/VoxelLoader.cs
+++ b/OpenRA.Mods.Cnc/Graphics/VoxelLoader.cs
@@ -189,13 +189,13 @@ namespace OpenRA.Mods.Cnc.Graphics
 			var start = totalVertexCount;
 			var count = v.Length;
 			totalVertexCount += count;
-			return new ModelRenderData(start, count, sheetBuilder.Current);
+			return new ModelRenderData(start, count, Game.Renderer.GetShader<ModelShaderBindings>(), VertexBuffer, new Dictionary<string, ITexture>() { { "DiffuseTexture", sheetBuilder.Current.GetTexture() } });
 		}
 
 		public void RefreshBuffer()
 		{
 			vertexBuffer?.Dispose();
-			vertexBuffer = Game.Renderer.CreateVertexBuffer(totalVertexCount);
+			vertexBuffer = Game.Renderer.CreateVertexBuffer<Vertex>(totalVertexCount);
 			vertexBuffer.SetData(vertices.SelectMany(v => v).ToArray(), totalVertexCount);
 			cachedVertexCount = totalVertexCount;
 		}

--- a/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
@@ -10,7 +10,7 @@
 #endregion
 
 using System;
-using OpenRA.Graphics;
+using System.Collections.Generic;
 using OpenRA.Primitives;
 using SDL2;
 
@@ -21,6 +21,7 @@ namespace OpenRA.Platforms.Default
 		readonly Sdl2PlatformWindow window;
 		bool disposed;
 		IntPtr context;
+		readonly Dictionary<Type, IShader> shaders = new Dictionary<Type, IShader>();
 
 		public Sdl2GraphicsContext(Sdl2PlatformWindow window)
 		{
@@ -45,21 +46,13 @@ namespace OpenRA.Platforms.Default
 				OpenGL.glBindVertexArray(vao);
 				OpenGL.CheckGLError();
 			}
-
-			OpenGL.glEnableVertexAttribArray(Shader.VertexPosAttributeIndex);
-			OpenGL.CheckGLError();
-			OpenGL.glEnableVertexAttribArray(Shader.TexCoordAttributeIndex);
-			OpenGL.CheckGLError();
-			OpenGL.glEnableVertexAttribArray(Shader.TexMetadataAttributeIndex);
-			OpenGL.CheckGLError();
-			OpenGL.glEnableVertexAttribArray(Shader.TintAttributeIndex);
-			OpenGL.CheckGLError();
 		}
 
-		public IVertexBuffer<Vertex> CreateVertexBuffer(int size)
+		public IVertexBuffer<T> CreateVertexBuffer<T>(int size)
+				where T : struct
 		{
 			VerifyThreadAffinity();
-			return new VertexBuffer<Vertex>(size);
+			return new VertexBuffer<T>(size);
 		}
 
 		public ITexture CreateTexture()
@@ -86,10 +79,30 @@ namespace OpenRA.Platforms.Default
 			return new FrameBuffer(s, texture, clearColor);
 		}
 
-		public IShader CreateShader(string name)
+		public IShader CreateUnsharedShader(Type type)
+		{
+			return new Shader((IShaderBindings)Activator.CreateInstance(type));
+		}
+
+		public IShader CreateUnsharedShader<T>() where T : IShaderBindings
+		{
+			return CreateUnsharedShader(typeof(T));
+		}
+
+		public IShader CreateShader(Type type)
 		{
 			VerifyThreadAffinity();
-			return new Shader(name);
+
+			if (!shaders.ContainsKey(type))
+				shaders.Add(type, new Shader((IShaderBindings)Activator.CreateInstance(type)));
+
+			return shaders[type];
+		}
+
+		public IShader CreateShader<T>()
+			where T : IShaderBindings
+		{
+			return CreateShader(typeof(T));
 		}
 
 		public void EnableScissor(int x, int y, int width, int height)

--- a/OpenRA.Platforms.Default/VertexBuffer.cs
+++ b/OpenRA.Platforms.Default/VertexBuffer.cs
@@ -85,14 +85,6 @@ namespace OpenRA.Platforms.Default
 			VerifyThreadAffinity();
 			OpenGL.glBindBuffer(OpenGL.GL_ARRAY_BUFFER, buffer);
 			OpenGL.CheckGLError();
-			OpenGL.glVertexAttribPointer(Shader.VertexPosAttributeIndex, 3, OpenGL.GL_FLOAT, false, VertexSize, IntPtr.Zero);
-			OpenGL.CheckGLError();
-			OpenGL.glVertexAttribPointer(Shader.TexCoordAttributeIndex, 4, OpenGL.GL_FLOAT, false, VertexSize, new IntPtr(12));
-			OpenGL.CheckGLError();
-			OpenGL.glVertexAttribPointer(Shader.TexMetadataAttributeIndex, 2, OpenGL.GL_FLOAT, false, VertexSize, new IntPtr(28));
-			OpenGL.CheckGLError();
-			OpenGL.glVertexAttribPointer(Shader.TintAttributeIndex, 4, OpenGL.GL_FLOAT, false, VertexSize, new IntPtr(36));
-			OpenGL.CheckGLError();
 		}
 
 		public void Dispose()


### PR DESCRIPTION
This splits out the mod defined VertexBuffer and Shader support from #19459 
This implements the following:

- Implemented the ShaderBindings class, which defines the glsl files, Vertex format and shader attributes setup. Additionally it supports to set uniforms and bind textures. This allows the mods to setup the shader bindings without the need to access any platform implementation code.
- Along with that, creating a vertex buffer now supports and requires to pass the Vertex struct as generic parameter.
- Instead of passing a Sheet to draw, the ModelRenderData class now requires the full stack: the shader to use, the VertexBuffer to draw, and additionally the textures to bind. This allows any texture usage besides using Sheets.
- To avoid each and every shader to be compiled multiple times, the shaders themself are cached once created.
- Additionally CreateUnsharedShader allows to explicitly create a non-shared shader instance if required for special purposes.
