### PR TITLE
PathFinder minor optimizations.

### DIFF
--- a/OpenRA.Game/Primitives/PriorityQueue.cs
+++ b/OpenRA.Game/Primitives/PriorityQueue.cs
@@ -20,6 +20,8 @@ namespace OpenRA.Primitives
 		bool Empty { get; }
 		T Peek();
 		T Pop();
+		bool TryPeek(out T elem);
+		bool TryPop(out T elem);
 	}
 
 	public class PriorityQueue<T> : IPriorityQueue<T>
@@ -42,11 +44,17 @@ namespace OpenRA.Primitives
 			var addLevel = level;
 			var addIndex = index;
 
-			while (addLevel >= 1 && comparer.Compare(Above(addLevel, addIndex), item) > 0)
+			while (addLevel >= 1)
 			{
-				items[addLevel][addIndex] = Above(addLevel, addIndex);
-				--addLevel;
-				addIndex >>= 1;
+				var above = Above(addLevel, addIndex);
+				if (comparer.Compare(above, item) > 0)
+				{
+					items[addLevel][addIndex] = above;
+					--addLevel;
+					addIndex >>= 1;
+				}
+				else
+					break;
 			}
 
 			items[addLevel][addIndex] = item;
@@ -89,6 +97,33 @@ namespace OpenRA.Primitives
 			if (--index < 0)
 				index = (1 << --level) - 1;
 			return ret;
+		}
+
+		public bool TryPeek(out T item)
+		{
+			if (level == 0)
+			{
+				item = default;
+				return false;
+			}
+
+			item = At(0, 0);
+			return true;
+		}
+
+		public bool TryPop(out T item)
+		{
+			if (level == 0)
+			{
+				item = default;
+				return false;
+			}
+
+			item = At(0, 0);
+			BubbleInto(0, 0, Last());
+			if (--index < 0)
+				index = (1 << --level) - 1;
+			return true;
 		}
 
 		void BubbleInto(int intoLevel, int intoIndex, T val)

--- a/OpenRA.Mods.Common/Pathfinder/BasePathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/BasePathSearch.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		bool IsTarget(CPos location);
 
 		bool CanExpand { get; }
-		CPos Expand();
+		bool TryExpand(out CPos cell);
 	}
 
 	public abstract class BasePathSearch : IPathSearch
@@ -177,7 +177,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		}
 
 		public bool CanExpand => !OpenQueue.Empty;
-		public abstract CPos Expand();
+		public abstract bool TryExpand(out CPos cell);
 
 		protected virtual void Dispose(bool disposing)
 		{


### PR DESCRIPTION

Combine two calls `CanExpand` and `Expand` into a single call to `TryExpand`.

Reduce the number of cell layer index cell look-ups.

No functional change intended.

Originally part of a separate pull request that I will close in future https://github.com/OpenRA/OpenRA/pull/19245.

