### PR TITLE
Refactor PathGraph.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -61,10 +61,19 @@ namespace OpenRA.Mods.Common.Activities
 			getPath = check =>
 			{
 				List<CPos> path;
-				using (var search =
-					PathSearch.FromPoint(self.World, mobile.Locomotor, self, mobile.ToCell, destination, check)
-					.WithoutLaneBias())
+				var query = new PathQuery(
+					queryType: PathQueryType.PositionUnidirectional,
+					world: self.World,
+					locomotor: mobile.Locomotor,
+					actor: self,
+					laneBiasDisabled: true,
+					fromPosition: mobile.ToCell,
+					toPosition: destination,
+					check: check);
+
+				using (var search = new PathSearch(query))
 					path = mobile.Pathfinder.FindPath(search);
+
 				return path;
 			};
 

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -132,8 +132,27 @@ namespace OpenRA.Mods.Common.Activities
 			if (!searchCells.Any())
 				return NoPath;
 
-			using (var fromSrc = PathSearch.FromPoints(self.World, Mobile.Locomotor, self, searchCells, loc, check))
-			using (var fromDest = PathSearch.FromPoint(self.World, Mobile.Locomotor, self, loc, lastVisibleTargetLocation, check).Reverse())
+			var fromSrcQuery = new PathQuery(
+				queryType: PathQueryType.PositionBidirectional,
+				world: self.World,
+				locomotor: Mobile.Locomotor,
+				actor: self,
+				fromPositions: searchCells,
+				toPosition: loc,
+				check: check);
+
+			var fromDestQuery = new PathQuery(
+				queryType: PathQueryType.PositionBidirectional,
+				world: self.World,
+				locomotor: Mobile.Locomotor,
+				actor: self,
+				fromPosition: loc,
+				toPosition: lastVisibleTargetLocation,
+				check: check,
+				reverse: true);
+
+			using (var fromSrc = new PathSearch(fromSrcQuery))
+			using (var fromDest = new PathSearch(fromDestQuery))
 				return Mobile.Pathfinder.FindBidiPath(fromSrc, fromDest);
 		}
 

--- a/OpenRA.Mods.Common/Pathfinder/BasePathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/BasePathSearch.cs
@@ -14,90 +14,193 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
+using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Pathfinder
 {
-	public interface IPathSearch : IDisposable
+	public enum PathQueryType
 	{
-		/// <summary>
-		/// The Graph used by the A*
-		/// </summary>
-		IGraph<CellInfo> Graph { get; }
+		// Destination unknown. Search until `IsGoal` returns true.
+		ConditionUnidirectional,
 
-		/// <summary>
-		/// Stores the analyzed nodes by the expand function
-		/// </summary>
-		IEnumerable<(CPos Cell, int Cost)> Considered { get; }
+		// Destination known. Search from 'from' to 'to'.
+		PositionUnidirectional,
 
-		Player Owner { get; }
-
-		int MaxCost { get; }
-
-		IPathSearch Reverse();
-
-		IPathSearch WithCustomBlocker(Func<CPos, bool> customBlock);
-
-		IPathSearch WithIgnoredActor(Actor b);
-
-		IPathSearch WithHeuristic(Func<CPos, int> h);
-
-		IPathSearch WithHeuristicWeight(int percentage);
-
-		IPathSearch WithCustomCost(Func<CPos, int> w);
-
-		IPathSearch WithoutLaneBias();
-
-		IPathSearch FromPoint(CPos from);
-
-		/// <summary>
-		/// Decides whether a location is a target based on its estimate
-		/// (An estimate of 0 means that the location and the unit's goal
-		/// are the same. There could be multiple goals).
-		/// </summary>
-		/// <param name="location">The location to assess</param>
-		/// <returns>Whether the location is a target</returns>
-		bool IsTarget(CPos location);
-
-		bool CanExpand { get; }
-		CPos Expand();
+		// Destination known. Search from both 'from' and 'to', meet in middle.
+		PositionBidirectional
 	}
 
-	public abstract class BasePathSearch : IPathSearch
+	public class PathQuery
 	{
-		public IGraph<CellInfo> Graph { get; set; }
+		public readonly PathQueryType QueryType;
+		public readonly World World;
+		public readonly Locomotor Locomotor;
+		public readonly Actor Actor;
+		public readonly BlockedByActor Check;
+		public readonly IEnumerable<CPos> FromPositions;
 
-		protected IPriorityQueue<GraphConnection> OpenQueue { get; private set; }
+		// To be set for Position searches.
+		public readonly CPos? ToPosition;
+		public readonly Func<CPos, bool> CustomBlock;
+		public readonly Actor IgnoreActor;
+		public readonly Func<CPos, int> CustomCost;
+		public readonly Func<CPos, bool> IsGoal;
+		public readonly bool LaneBiasDisabled;
 
+		// The other end of a bidirectional search.
+		public readonly bool Reverse;
+
+		public PathQuery(PathQueryType queryType,
+			World world,
+			Locomotor locomotor,
+			Actor actor,
+			BlockedByActor check,
+			IEnumerable<CPos> fromPositions,
+			CPos? toPosition = null,
+			Func<CPos, bool> customBlock = null,
+			Actor ignoreActor = null,
+			Func<CPos, int> customCost = null,
+			Func<CPos, bool> isGoal = null,
+			bool laneBiasDisabled = false,
+			bool reverse = false)
+		{
+			QueryType = queryType;
+			World = world;
+			Locomotor = locomotor;
+			Actor = actor;
+			Check = check;
+			FromPositions = fromPositions;
+			ToPosition = toPosition;
+			CustomBlock = customBlock;
+			IgnoreActor = ignoreActor;
+			CustomCost = customCost;
+			IsGoal = isGoal;
+			LaneBiasDisabled = laneBiasDisabled;
+			Reverse = reverse;
+		}
+
+		public PathQuery(PathQueryType queryType,
+			Locomotor locomotor,
+			World world,
+			Actor actor,
+			BlockedByActor check,
+			CPos fromPosition,
+			CPos? toPosition = null,
+			Func<CPos, bool> customBlock = null,
+			Actor ignoreActor = null,
+			Func<CPos, int> customCost = null,
+			Func<CPos, bool> isGoal = null,
+			bool laneBiasDisabled = false,
+			bool reverse = false)
+		{
+			QueryType = queryType;
+			World = world;
+			Locomotor = locomotor;
+			Actor = actor;
+			Check = check;
+			FromPositions = new[] { fromPosition };
+			ToPosition = toPosition;
+			CustomBlock = customBlock;
+			IgnoreActor = ignoreActor;
+			CustomCost = customCost;
+			IsGoal = isGoal;
+			LaneBiasDisabled = laneBiasDisabled;
+			Reverse = reverse;
+		}
+
+		public PathQuery CreateReverse()
+		{
+			if (QueryType != PathQueryType.PositionBidirectional)
+				throw new ArgumentException("Only bidirectional queries use a reverse");
+
+			if (!ToPosition.HasValue)
+				throw new ArgumentException("ToPosition not set");
+
+			if (FromPositions.Count() > 1)
+				throw new ArgumentException("Reverse requires a single FromPosition");
+
+			return new PathQuery(
+				QueryType,
+				World,
+				Locomotor,
+				Actor,
+				Check,
+				new[] { ToPosition.Value },
+				FromPositions.First(),
+				CustomBlock,
+				IgnoreActor,
+				CustomCost,
+				IsGoal,
+				LaneBiasDisabled,
+				!Reverse);
+		}
+	}
+
+	public abstract class BasePathSearch : IDisposable
+	{
+		public readonly PathGraph Graph;
+		public readonly PathQuery Query;
+		public readonly Func<CPos, bool> IsGoal;
+		public readonly bool Debug;
+
+		// Stores maximum cost if Debug is enabled. Zero otherwise.
+		public int MaxCost { get; protected set; }
+
+		// Stores considered cells if Debug is enabled. Empty otherwise.
 		public abstract IEnumerable<(CPos Cell, int Cost)> Considered { get; }
 
-		public Player Owner => Graph.Actor.Owner;
-		public int MaxCost { get; protected set; }
-		public bool Debug { get; set; }
+		protected IPriorityQueue<GraphConnection> OpenQueue { get; private set; }
 		protected Func<CPos, int> heuristic;
-		protected Func<CPos, bool> isGoal;
-		protected int heuristicWeightPercentage;
 
-		// This member is used to compute the ID of PathSearch.
-		// Essentially, it represents a collection of the initial
-		// points considered and their Heuristics to reach
-		// the target. It pretty match identifies, in conjunction of the Actor,
-		// a deterministic set of calculations
-		protected readonly IPriorityQueue<GraphConnection> StartPoints;
+		readonly int cellCost, diagonalCellCost;
+		protected readonly int heuristicWeightPercentage;
 
-		private readonly int cellCost, diagonalCellCost;
-
-		protected BasePathSearch(IGraph<CellInfo> graph)
+		protected BasePathSearch(PathGraph graph, PathQuery query, bool debug)
 		{
 			Graph = graph;
+			Query = query;
+			Debug = debug;
 			OpenQueue = new PriorityQueue<GraphConnection>(GraphConnection.ConnectionCostComparer);
-			StartPoints = new PriorityQueue<GraphConnection>(GraphConnection.ConnectionCostComparer);
 			MaxCost = 0;
-			heuristicWeightPercentage = 100;
 
 			// Determine the minimum possible cost for moving horizontally between cells based on terrain speeds.
 			// The minimum possible cost diagonally is then Sqrt(2) times more costly.
-			cellCost = ((Mobile)graph.Actor.OccupiesSpace).Info.LocomotorInfo.TerrainSpeeds.Values.Min(ti => ti.Cost);
+			cellCost = ((Mobile)Query.Actor.OccupiesSpace).Info.LocomotorInfo.TerrainSpeeds.Values.Min(ti => ti.Cost);
 			diagonalCellCost = cellCost * 141421 / 100000;
+
+			if (Query.QueryType == PathQueryType.ConditionUnidirectional)
+			{
+				if (Query.IsGoal == null)
+					throw new ArgumentException("IsGoal not set in path query");
+
+				IsGoal = Query.IsGoal;
+				heuristicWeightPercentage = 100;
+				heuristic = loc => 0;
+			}
+			else
+			{
+				if (Query.FromPositions == null)
+					throw new ArgumentException("FromPositions not set in path query");
+
+				if (!Query.ToPosition.HasValue)
+					throw new ArgumentException("ToPosition not set in path query");
+
+				IsGoal = loc =>
+   				{
+					var locInfo = graph[loc];
+					return locInfo.EstimatedTotal - locInfo.CostSoFar == 0;
+				};
+
+				// The search will aim for the shortest path by default, a weight of 100%.
+				// We can allow the search to find paths that aren't optimal by changing the weight.
+				// We provide a weight that limits the worst case length of the path,
+				// e.g. a weight of 110% will find a path no more than 10% longer than the shortest possible.
+				// The benefit of allowing the search to return suboptimal paths is faster computation time.
+				// The search can skip some areas of the search space, meaning it has less work to do.
+				// We allow paths up to 25% longer than the shortest, optimal path, to improve pathfinding time.
+				heuristicWeightPercentage = 125;
+				heuristic = DefaultEstimator(query.ToPosition.Value);
+			}
 		}
 
 		/// <summary>
@@ -105,7 +208,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// http://theory.stanford.edu/~amitp/GameProgramming/Heuristics.html
 		/// </summary>
 		/// <returns>A delegate that calculates the estimation for a node</returns>
-		protected Func<CPos, int> DefaultEstimator(CPos destination)
+		Func<CPos, int> DefaultEstimator(CPos destination)
 		{
 			return here =>
 			{
@@ -117,63 +220,6 @@ namespace OpenRA.Mods.Common.Pathfinder
 				// Possible simplification: var h = Constants.CellCost * (straight + (Constants.Sqrt2 - 2) * diag);
 				return (cellCost * straight + (diagonalCellCost - 2 * cellCost) * diag) * heuristicWeightPercentage / 100;
 			};
-		}
-
-		public IPathSearch Reverse()
-		{
-			Graph.InReverse = true;
-			return this;
-		}
-
-		public IPathSearch WithCustomBlocker(Func<CPos, bool> customBlock)
-		{
-			Graph.CustomBlock = customBlock;
-			return this;
-		}
-
-		public IPathSearch WithIgnoredActor(Actor b)
-		{
-			Graph.IgnoreActor = b;
-			return this;
-		}
-
-		public IPathSearch WithHeuristic(Func<CPos, int> h)
-		{
-			heuristic = h;
-			return this;
-		}
-
-		public IPathSearch WithHeuristicWeight(int percentage)
-		{
-			heuristicWeightPercentage = percentage;
-			return this;
-		}
-
-		public IPathSearch WithCustomCost(Func<CPos, int> w)
-		{
-			Graph.CustomCost = w;
-			return this;
-		}
-
-		public IPathSearch WithoutLaneBias()
-		{
-			Graph.LaneBias = 0;
-			return this;
-		}
-
-		public IPathSearch FromPoint(CPos from)
-		{
-			if (Graph.World.Map.Contains(from))
-				AddInitialCell(from);
-
-			return this;
-		}
-
-		protected abstract void AddInitialCell(CPos cell);
-
-		public bool IsTarget(CPos location)
-		{
-			return isGoal(location);
 		}
 
 		public bool CanExpand => !OpenQueue.Empty;

--- a/OpenRA.Mods.Common/Pathfinder/CellInfoLayerPool.cs
+++ b/OpenRA.Mods.Common/Pathfinder/CellInfoLayerPool.cs
@@ -15,7 +15,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.Pathfinder
 {
-	sealed class CellInfoLayerPool
+	public class CellInfoLayerPool
 	{
 		const int MaxPoolSize = 4;
 		readonly Stack<CellLayer<CellInfo>> pool = new Stack<CellLayer<CellInfo>>(MaxPoolSize);

--- a/OpenRA.Mods.Common/Pathfinder/PathFinderUnitPathCacheDecorator.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathFinderUnitPathCacheDecorator.cs
@@ -76,13 +76,13 @@ namespace OpenRA.Mods.Common.Pathfinder
 			}
 		}
 
-		public List<CPos> FindPath(IPathSearch search)
+		public List<CPos> FindPath(BasePathSearch search)
 		{
 			using (new PerfSample("Pathfinder"))
 				return pathFinder.FindPath(search);
 		}
 
-		public List<CPos> FindBidiPath(IPathSearch fromSrc, IPathSearch fromDest)
+		public List<CPos> FindBidiPath(BasePathSearch fromSrc, BasePathSearch fromDest)
 		{
 			using (new PerfSample("Pathfinder"))
 				return pathFinder.FindBidiPath(fromSrc, fromDest);

--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -149,17 +149,38 @@ namespace OpenRA.Mods.Common.Traits
 				harv.Harvester.CanHarvestCell(actor, cell) &&
 				claimLayer.CanClaimCell(actor, cell);
 
-			var path = pathfinder.FindPath(
-				PathSearch.Search(world, harv.Locomotor, actor, BlockedByActor.Stationary, isValidResource)
-					.WithCustomCost(loc => world.FindActorsInCircle(world.Map.CenterOfCell(loc), Info.HarvesterEnemyAvoidanceRadius)
-						.Where(u => !u.IsDead && actor.Owner.RelationshipWith(u.Owner) == PlayerRelationship.Enemy)
-						.Sum(u => Math.Max(WDist.Zero.Length, Info.HarvesterEnemyAvoidanceRadius.Length - (world.Map.CenterOfCell(loc) - u.CenterPosition).Length)))
-					.FromPoint(actor.Location));
+			var map = world.Map;
+			var avoidRadius = Info.HarvesterEnemyAvoidanceRadius;
+			var avoidRadiusLength = avoidRadius.Length;
+			var owner = actor.Owner;
+			Func<CPos, int> customCost = loc =>
+			{
+				var enemies = world.FindActorsInCircle(map.CenterOfCell(loc), avoidRadius)
+					.Where(u => !u.IsDead
+						&& owner.RelationshipWith(u.Owner) == PlayerRelationship.Enemy);
 
-			if (path.Count == 0)
-				return Target.Invalid;
+				return enemies.Sum(u => Math.Max(WDist.Zero.Length,
+					avoidRadiusLength - (map.CenterOfCell(loc) - u.CenterPosition).Length));
+			};
 
-			return Target.FromCell(world, path[0]);
+			var query = new PathQuery(
+				queryType: PathQueryType.ConditionUnidirectional,
+				world: world,
+				locomotor: harv.Locomotor,
+				actor: actor,
+				check: BlockedByActor.Stationary,
+				customCost: customCost,
+				fromPosition: actor.Location,
+				isGoal: isValidResource);
+
+			using (var search = new PathSearch(query))
+  			{
+				var path = pathfinder.FindPath(search);
+				if (path.Count == 0)
+					return Target.Invalid;
+
+				return Target.FromCell(world, path[0]);
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -824,9 +824,16 @@ namespace OpenRA.Mods.Common.Traits
 				return above;
 
 			List<CPos> path;
-			using (var search = PathSearch.Search(self.World, Locomotor, self, BlockedByActor.All,
-					loc => loc.Layer == 0 && CanEnterCell(loc))
-				.FromPoint(self.Location))
+			var query = new PathQuery(
+				queryType: PathQueryType.ConditionUnidirectional,
+				world: self.World,
+				locomotor: Locomotor,
+				actor: self,
+				check: BlockedByActor.All,
+				fromPosition: self.Location,
+				isGoal: loc => loc.Layer == 0 && CanEnterCell(loc));
+
+			using (var search = new PathSearch(query))
 				path = Pathfinder.FindPath(search);
 
 			if (path.Count > 0)


### PR DESCRIPTION

Introducing `PathQuery` to split parameters from actual implementation and to be able to share parameters between `PathSearch` and `PathGraph`.

Removed `IPathSearch`. Removed semi builder pattern from `PathSearch`. Reduced the spread of state variables across 4 classes.

Future improvements likely possible. Too many `Path*` types for my taste.

No functional change intended. In rare situation a path search can result in a slightly different path - this is intended. This may break sync on older replays. See original comment.


Originally part of a separate pull request that I will close in future https://github.com/OpenRA/OpenRA/pull/19245#issuecomment-814249184.
