### PR TITLE
SpriteRenderer, do not copy vertex array data each flush.

### DIFF
--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -84,6 +84,7 @@ namespace OpenRA
 	public interface IGraphicsContext : IDisposable
 	{
 		IVertexBuffer<Vertex> CreateVertexBuffer(int size);
+		Vertex[] CreateVertices(int size);
 		ITexture CreateTexture();
 		IFrameBuffer CreateFrameBuffer(Size s);
 		IFrameBuffer CreateFrameBuffer(Size s, Color clearColor);
@@ -105,6 +106,11 @@ namespace OpenRA
 	{
 		void Bind();
 		void SetData(T[] vertices, int length);
+
+		/// <summary>
+		/// Upon return `vertices` may reference another array object of at least the same size - containing random values.
+		/// </summary>
+		void SetData(ref T[] vertices, int length);
 		void SetData(T[] vertices, int offset, int start, int length);
 	}
 

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Graphics
 		readonly Renderer renderer;
 		readonly IShader shader;
 
-		readonly Vertex[] vertices;
+		Vertex[] vertices;
 		readonly Sheet[] sheets = new Sheet[SheetCount];
 
 		BlendMode currentBlend = BlendMode.Alpha;
@@ -34,7 +34,7 @@ namespace OpenRA.Graphics
 		{
 			this.renderer = renderer;
 			this.shader = shader;
-			vertices = new Vertex[renderer.TempBufferSize];
+			vertices = renderer.Context.CreateVertices(renderer.TempBufferSize);
 		}
 
 		public void Flush()
@@ -49,7 +49,9 @@ namespace OpenRA.Graphics
 
 				renderer.Context.SetBlendMode(currentBlend);
 				shader.PrepareRender();
-				renderer.DrawBatch(vertices, nv, PrimitiveType.TriangleList);
+
+				// PERF: The renderer may choose to replace vertices with a different temporary buffer.
+				renderer.DrawBatch(ref vertices, nv, PrimitiveType.TriangleList);
 				renderer.Context.SetBlendMode(BlendMode.None);
 
 				nv = 0;

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -333,6 +333,12 @@ namespace OpenRA
 			DrawBatch(tempBuffer, 0, numVertices, type);
 		}
 
+		public void DrawBatch(ref Vertex[] vertices, int numVertices, PrimitiveType type)
+		{
+			tempBuffer.SetData(ref vertices, numVertices);
+			DrawBatch(tempBuffer, 0, numVertices, type);
+		}
+
 		public void DrawBatch<T>(IVertexBuffer<T> vertices,
 			int firstVertex, int numVertices, PrimitiveType type)
 			where T : struct

--- a/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
@@ -67,6 +67,12 @@ namespace OpenRA.Platforms.Default
 			return new VertexBuffer<Vertex>(size);
 		}
 
+		public Vertex[] CreateVertices(int size)
+		{
+			VerifyThreadAffinity();
+			return new Vertex[size];
+		}
+
 		public ITexture CreateTexture()
 		{
 			VerifyThreadAffinity();

--- a/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
+++ b/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
@@ -404,6 +404,11 @@ namespace OpenRA.Platforms.Default
 			return Send(getCreateVertexBuffer, length);
 		}
 
+		public Vertex[] CreateVertices(int size)
+		{
+			return GetVertices(size);
+		}
+
 		public void DisableDepthBuffer()
 		{
 			Post(doDisableDepthBuffer);
@@ -524,6 +529,16 @@ namespace OpenRA.Platforms.Default
 			var buffer = device.GetVertices(length);
 			Array.Copy(vertices, buffer, length);
 			device.Post(setData1, (buffer, length));
+		}
+
+		/// <summary>
+		/// PERF: The vertices array is passed without copying to the render thread. Upon return `vertices` may reference another
+		/// array object of at least the same size - containing random values.
+		/// </summary>
+		public void SetData(ref Vertex[] vertices, int length)
+		{
+			device.Post(setData1, (vertices, length));
+			vertices = device.GetVertices(vertices.Length);
 		}
 
 		public void SetData(Vertex[] vertices, int offset, int start, int length)

--- a/OpenRA.Platforms.Default/VertexBuffer.cs
+++ b/OpenRA.Platforms.Default/VertexBuffer.cs
@@ -60,6 +60,11 @@ namespace OpenRA.Platforms.Default
 			SetData(data, 0, 0, length);
 		}
 
+		public void SetData(ref T[] data, int length)
+		{
+			SetData(data, 0, 0, length);
+		}
+
 		public void SetData(T[] data, int offset, int start, int length)
 		{
 			Bind();


### PR DESCRIPTION

`SpriteRenderer` renders 'into' a temporary vertex array. It will clear this temporary vertex array after each `Flush()`.

Because the array is cleared there is no need for `IVertexBuffer.SetData()` to send a copy of the array to the graphics thread. The original array can be passed rather. The caller can continue to use any other Vertex array of the same size.

This avoids the copy - in the main game thread - of all vertex array data from `SpriteRenderer.Flush()` each render.
