### PR TITLE
Do not start DiscordService client if disabled.

### DIFF
--- a/OpenRA.Mods.Common/DiscordService.cs
+++ b/OpenRA.Mods.Common/DiscordService.cs
@@ -58,6 +58,9 @@ namespace OpenRA.Mods.Common
 		{
 			FieldLoader.Load(this, yaml);
 
+			if (!Game.Settings.Game.EnableDiscordService)
+				return;
+
 			// HACK: Prevent service from starting when launching the utility or server.
 			if (Game.Renderer == null)
 				return;


### PR DESCRIPTION

Fix. The client was started still by loading the manifest. This time really don't start the client.

See https://github.com/OpenRA/OpenRA/pull/19343.