### PR TITLE
Fix several issues with the macOS compatibility build

### DIFF
--- a/packaging/macos/launcher-mono.m
+++ b/packaging/macos/launcher-mono.m
@@ -69,20 +69,6 @@ static int check_mono_version(const char *version, const char *req_version)
 		return FALSE;
 	}
 
-	mono_main _mono_main = (mono_main)dlsym(libmono, "mono_main");
-	if (!_mono_main)
-	{
-		fprintf(stderr, "Could not load mono_main(): %s\n", dlerror());
-		return FALSE;
-	}
-
-	mono_free _mono_free = (mono_free)dlsym(libmono, "mono_free");
-	if (!_mono_free)
-	{
-		fprintf(stderr, "Could not load mono_free(): %s\n", dlerror());
-		return FALSE;
-	}
-
 	mono_get_runtime_build_info _mono_get_runtime_build_info = (mono_get_runtime_build_info)dlsym(libmono, "mono_get_runtime_build_info");
 	if (!_mono_get_runtime_build_info)
 	{

--- a/packaging/macos/launcher-mono.m
+++ b/packaging/macos/launcher-mono.m
@@ -257,7 +257,7 @@ static int check_mono_version(const char *version, const char *req_version)
 	NSString *gamePath = [[[NSBundle mainBundle] bundlePath] stringByAppendingPathComponent: @"Contents/Resources/"];
 
 	NSString *launchPath = [SYSTEM_MONO_PATH stringByAppendingPathComponent: @"Commands/mono"];
-	NSString *appPath = [exePath stringByAppendingPathComponent: @"OpenRA"];
+	NSString *appPath = [exePath stringByAppendingPathComponent: @"Launcher"];
 	NSString *engineLaunchPath = [self resolveTranslocatedPath: appPath];
 
 	NSMutableArray *launchArgs = [NSMutableArray arrayWithCapacity: [gameArgs count] + 2];


### PR DESCRIPTION
This PR fixes an issue that prevented ingame mod switching from working with macOS compatibility builds, and changes the way it launches mono so that the OS can match the game window to the app bundle's info.plist and assign the correct dock icon / application title / dark mode support.

The `_mono_main` launch method is copied from https://github.com/OpenRA/OpenRALauncherOSX/tree/6be2bd5b6632540f4537a9b3d76e6d5631242e59, and is how the macOS launchers used to work for everyone between 2015-2017. This means it should hopefully be a low risk change. I just folded the separate `launchgame` executable into the main `Launcher`, copying the approach that we use for our Windows launchers.