### PR TITLE
Remove an outdated reference to ConditionManager

### DIFF
--- a/OpenRA.Mods.Common/Traits/Conditions/ConditionalTrait.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ConditionalTrait.cs
@@ -56,8 +56,8 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			Info = info;
 
-			// Conditional traits will be enabled (if appropriate) by the ConditionManager
-			// calling ConditionConsumers at the end of INotifyCreated.
+			// Conditional traits will be enabled (if appropriate) by the Actor
+			// calling ConditionConsumers after INotifyCreated runs.
 			IsTraitDisabled = Info.RequiresCondition != null;
 		}
 


### PR DESCRIPTION
`ConditionManager` was merged into `Actor`, so I just adjusted the wording.