### PR TITLE
Show a tooltip for titles and author in map chooser

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -253,12 +253,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					() => selectedUid = preview.Uid, dblClick);
 				item.IsVisible = () => item.RenderBounds.IntersectsWith(scrollpanels[tab].RenderBounds);
 
-				var titleLabel = item.Get<LabelWidget>("TITLE");
+				var titleLabel = item.Get<LabelWithTooltipWidget>("TITLE");
 				if (titleLabel != null)
 				{
-					var font = Game.Renderer.Fonts[titleLabel.Font];
-					var title = WidgetUtils.TruncateText(preview.Title, titleLabel.Bounds.Width, font);
-					titleLabel.GetText = () => title;
+					WidgetUtils.TruncateLabelToTooltip(titleLabel, preview.Title);
 				}
 
 				var previewWidget = item.Get<MapPreviewWidget>("PREVIEW");
@@ -276,12 +274,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					detailsWidget.GetText = () => details;
 				}
 
-				var authorWidget = item.GetOrNull<LabelWidget>("AUTHOR");
+				var authorWidget = item.GetOrNull<LabelWithTooltipWidget>("AUTHOR");
 				if (authorWidget != null)
 				{
-					var font = Game.Renderer.Fonts[authorWidget.Font];
-					var author = WidgetUtils.TruncateText($"Created by {preview.Author}", authorWidget.Bounds.Width, font);
-					authorWidget.GetText = () => author;
+					WidgetUtils.TruncateLabelToTooltip(authorWidget, $"Created by {preview.Author}");
 				}
 
 				var sizeWidget = item.GetOrNull<LabelWidget>("SIZE");

--- a/mods/cnc/chrome/mapchooser.yaml
+++ b/mods/cnc/chrome/mapchooser.yaml
@@ -80,6 +80,7 @@ Container@MAPCHOOSER_PANEL:
 					Height: 262
 					X: 1
 					Visible: false
+					EnableChildMouseOver: True
 					Children:
 						MapPreview@PREVIEW:
 							X: (PARENT_RIGHT - WIDTH) / 2
@@ -88,27 +89,35 @@ Container@MAPCHOOSER_PANEL:
 							Height: 204
 							IgnoreMouseOver: true
 							IgnoreMouseInput: true
-						Label@TITLE:
+						LabelWithTooltip@TITLE:
 							X: 4
-							Y: PARENT_BOTTOM - 46
+							Y: PARENT_BOTTOM - HEIGHT - 33
 							Width: PARENT_RIGHT - 8
+							Height: 24
 							Align: Center
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
 						Label@DETAILS:
 							Width: PARENT_RIGHT - 8
+							Height: 12
 							X: 4
-							Y: PARENT_BOTTOM - 32
+							Y: PARENT_BOTTOM - HEIGHT - 26
 							Align: Center
 							Font: Tiny
-						Label@AUTHOR:
+						LabelWithTooltip@AUTHOR:
 							Width: PARENT_RIGHT - 8
+							Height: 12
 							X: 4
-							Y: PARENT_BOTTOM - 20
+							Y: PARENT_BOTTOM - HEIGHT - 14
 							Align: Center
 							Font: Tiny
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
 						Label@SIZE:
 							Width: PARENT_RIGHT - 8
+							Height: 12
 							X: 4
-							Y: PARENT_BOTTOM - 8
+							Y: PARENT_BOTTOM - HEIGHT - 2
 							Align: Center
 							Font: Tiny
 				Button@BUTTON_CANCEL:
@@ -143,3 +152,4 @@ Container@MAPCHOOSER_PANEL:
 					Width: 140
 					Height: 35
 					Text: Ok
+				TooltipContainer@TOOLTIP_CONTAINER:

--- a/mods/common/chrome/map-chooser.yaml
+++ b/mods/common/chrome/map-chooser.yaml
@@ -51,6 +51,7 @@ Background@MAPCHOOSER_PANEL:
 			Height: 266
 			X: 2
 			Visible: false
+			EnableChildMouseOver: True
 			Children:
 				MapPreview@PREVIEW:
 					X: (PARENT_RIGHT - WIDTH) / 2
@@ -59,27 +60,35 @@ Background@MAPCHOOSER_PANEL:
 					Height: 202
 					IgnoreMouseOver: true
 					IgnoreMouseInput: true
-				Label@TITLE:
+				LabelWithTooltip@TITLE:
 					X: 4
-					Y: PARENT_BOTTOM - 52
+					Y: PARENT_BOTTOM - HEIGHT - 39
 					Width: PARENT_RIGHT - 8
+					Height: 24
 					Align: Center
+					TooltipContainer: TOOLTIP_CONTAINER
+					TooltipTemplate: SIMPLE_TOOLTIP
 				Label@DETAILS:
 					Width: PARENT_RIGHT - 8
+					Height: 12
 					X: 4
-					Y: PARENT_BOTTOM - 36
+					Y: PARENT_BOTTOM - HEIGHT - 30
 					Align: Center
 					Font: Tiny
-				Label@AUTHOR:
+				LabelWithTooltip@AUTHOR:
 					Width: PARENT_RIGHT - 8
+					Height: 12
 					X: 4
-					Y: PARENT_BOTTOM - 24
+					Y: PARENT_BOTTOM - HEIGHT - 18
 					Align: Center
 					Font: Tiny
+					TooltipContainer: TOOLTIP_CONTAINER
+					TooltipTemplate: SIMPLE_TOOLTIP
 				Label@SIZE:
 					Width: PARENT_RIGHT - 8
+					Height: 12
 					X: 4
-					Y: PARENT_BOTTOM - 12
+					Y: PARENT_BOTTOM - HEIGHT - 6
 					Align: Center
 					Font: Tiny
 		Label@FILTER_DESC:
@@ -145,3 +154,4 @@ Background@MAPCHOOSER_PANEL:
 			Text: Back
 			Font: Bold
 			Key: escape
+		TooltipContainer@TOOLTIP_CONTAINER:


### PR DESCRIPTION
An attempt to fix #19108 

But the tooltip won't show up. Either I'm missing something or there's something wonky going on :thinking: Help appreciated.