### PR TITLE
Fix a couple of tooltip issues with map previews

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
@@ -209,9 +209,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				titleLabel.IsVisible = () => getMap().Map != MapCache.UnknownMap;
 				var font = Game.Renderer.Fonts[titleLabel.Font];
-				var title = new CachedTransform<MapPreview, string>(m => WidgetUtils.TruncateText(m.Title, titleLabel.Bounds.Width, font));
+				var title = new CachedTransform<MapPreview, string>(m =>
+				{
+					var truncated = WidgetUtils.TruncateText(m.Title, titleLabel.Bounds.Width, font);
+
+					if (m.Title != truncated)
+						titleLabel.GetTooltipText = () => m.Title;
+					else
+						titleLabel.GetTooltipText = null;
+
+					return truncated;
+				});
 				titleLabel.GetText = () => title.Update(getMap().Map);
-				titleLabel.GetTooltipText = () => getMap().Map.Title;
 			}
 
 			var typeLabel = parent.GetOrNull<LabelWidget>("MAP_TYPE");

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -61,9 +61,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (titleLabel != null)
 				{
 					var font = Game.Renderer.Fonts[titleLabel.Font];
-					var title = new CachedTransform<MapPreview, string>(m => WidgetUtils.TruncateText(m.Title, titleLabel.Bounds.Width, font));
+					var title = new CachedTransform<MapPreview, string>(m =>
+					{
+						var truncated = WidgetUtils.TruncateText(m.Title, titleLabel.Bounds.Width, font);
+
+						if (m.Title != truncated)
+							titleLabel.GetTooltipText = () => m.Title;
+						else
+							titleLabel.GetTooltipText = null;
+
+						return truncated;
+					});
 					titleLabel.GetText = () => title.Update(preview);
-					titleLabel.GetTooltipText = () => preview.Title;
 				}
 
 				var typeLabel = panel.GetOrNull<LabelWidget>("MAP_TYPE");

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -231,12 +231,21 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (mapPreview != null)
 				mapPreview.Preview = () => currentMap;
 
-			var mapTitle = widget.GetOrNull<LabelWidget>("SELECTED_MAP");
+			var mapTitle = widget.GetOrNull<LabelWithTooltipWidget>("SELECTED_MAP");
 			if (mapTitle != null)
 			{
 				var font = Game.Renderer.Fonts[mapTitle.Font];
 				var title = new CachedTransform<MapPreview, string>(m =>
-					WidgetUtils.TruncateText(m.Title, mapTitle.Bounds.Width, font));
+				{
+					var truncated = WidgetUtils.TruncateText(m.Title, mapTitle.Bounds.Width, font);
+
+					if (m.Title != truncated)
+						mapTitle.GetTooltipText = () => m.Title;
+					else
+						mapTitle.GetTooltipText = null;
+
+					return truncated;
+				});
 
 				mapTitle.GetText = () =>
 				{

--- a/mods/cnc/chrome/lobby-servers.yaml
+++ b/mods/cnc/chrome/lobby-servers.yaml
@@ -168,12 +168,14 @@ Container@LOBBY_SERVERS_BIN:
 							Width: PARENT_RIGHT - 2
 							Height: PARENT_BOTTOM - 2
 							TooltipContainer: TOOLTIP_CONTAINER
-				Label@SELECTED_MAP:
+				LabelWithTooltip@SELECTED_MAP:
 					Y: 172
 					Width: PARENT_RIGHT
 					Height: 25
 					Font: Bold
 					Align: Center
+					TooltipContainer: TOOLTIP_CONTAINER
+					TooltipTemplate: SIMPLE_TOOLTIP
 				Label@SELECTED_IP:
 					Y: 187
 					Width: PARENT_RIGHT

--- a/mods/cnc/chrome/multiplayer-browser.yaml
+++ b/mods/cnc/chrome/multiplayer-browser.yaml
@@ -168,12 +168,14 @@ Container@MULTIPLAYER_PANEL:
 									Width: PARENT_RIGHT - 2
 									Height: PARENT_BOTTOM - 2
 									TooltipContainer: TOOLTIP_CONTAINER
-						Label@SELECTED_MAP:
+						LabelWithTooltip@SELECTED_MAP:
 							Y: 173
 							Width: PARENT_RIGHT
 							Height: 25
 							Font: Bold
 							Align: Center
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
 						Label@SELECTED_IP:
 							Y: 188
 							Width: PARENT_RIGHT

--- a/mods/common/chrome/lobby-servers.yaml
+++ b/mods/common/chrome/lobby-servers.yaml
@@ -164,12 +164,14 @@ Container@LOBBY_SERVERS_BIN:
 							Width: PARENT_RIGHT - 2
 							Height: PARENT_BOTTOM - 2
 							TooltipContainer: TOOLTIP_CONTAINER
-				Label@SELECTED_MAP:
+				LabelWithTooltip@SELECTED_MAP:
 					Y: 173
 					Width: PARENT_RIGHT
 					Height: 25
 					Font: Bold
 					Align: Center
+					TooltipContainer: TOOLTIP_CONTAINER
+					TooltipTemplate: SIMPLE_TOOLTIP
 				Label@SELECTED_IP:
 					Y: 188
 					Width: PARENT_RIGHT

--- a/mods/common/chrome/multiplayer-browser.yaml
+++ b/mods/common/chrome/multiplayer-browser.yaml
@@ -160,12 +160,14 @@ Background@MULTIPLAYER_PANEL:
 							Width: PARENT_RIGHT - 2
 							Height: PARENT_BOTTOM - 2
 							TooltipContainer: TOOLTIP_CONTAINER
-				Label@SELECTED_MAP:
+				LabelWithTooltip@SELECTED_MAP:
 					Y: 173
 					Width: PARENT_RIGHT
 					Height: 25
 					Font: Bold
 					Align: Center
+					TooltipContainer: TOOLTIP_CONTAINER
+					TooltipTemplate: SIMPLE_TOOLTIP
 				Label@SELECTED_IP:
 					Y: 188
 					Width: PARENT_RIGHT


### PR DESCRIPTION
Tooltips for map titles were not displayed in the server list and they were always displayed in the lobby (even if map title doesn't overflow).
![image](https://user-images.githubusercontent.com/1355810/126151224-21c22515-2869-4f62-9aa0-ead981748815.png)
