### PR TITLE
Defer rollover checks while generating selection decorations

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/Selection.cs
+++ b/OpenRA.Mods.Common/Traits/World/Selection.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public class SelectionInfo : TraitInfo
 	{
-		public override object Create(ActorInitializer init) { return new Selection(this); }
+		public override object Create(ActorInitializer init) { return new Selection(); }
 	}
 
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
@@ -29,12 +29,10 @@ namespace OpenRA.Mods.Common.Traits
 		public IEnumerable<Actor> Actors => actors;
 
 		readonly HashSet<Actor> actors = new HashSet<Actor>();
+		readonly List<Actor> rolloverActors = new List<Actor>();
 		World world;
-		IEnumerable<Actor> rolloverActors;
 
 		INotifySelection[] worldNotifySelection;
-
-		public Selection(SelectionInfo info) { }
 
 		void INotifyCreated.Created(Actor self)
 		{
@@ -157,12 +155,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void SetRollover(IEnumerable<Actor> rollover)
 		{
-			rolloverActors = rollover;
+			rolloverActors.Clear();
+			rolloverActors.AddRange(rollover);
 		}
 
 		public bool RolloverContains(Actor a)
 		{
-			return rolloverActors != null && rolloverActors.Contains(a);
+			return rolloverActors.Contains(a);
 		}
 
 		void ITick.Tick(Actor self)


### PR DESCRIPTION
In a profiling run a few days ago the rollover check took around 3% of the total CPU time. I wasn't able to reproduce that number in subsequent runs however. (It evened out at ~0.5%.) The changes in this PR still more than halved the time spent in the method (~0.2%), but I wouldn't be opposed to just closing this if the code changes seem to "ugly" for that speedup.
Fwiw, it does make sense to me to not perform those checks for people who use `AlwaysShow` for selection bars. (And with the changes in the PR we'll also not perform them for some cases with `DamageShow`.)