### PR TITLE
Use FireClusterWarhead with barrels

### DIFF
--- a/mods/ra/maps/allies-03a/allies03a.lua
+++ b/mods/ra/maps/allies-03a/allies03a.lua
@@ -263,6 +263,13 @@ InitTriggers = function()
 			player.MarkCompletedObjective(KillUSSR)
 		end)
 	end)
+
+	Trigger.OnKilled(Jail1Barrel, function()
+		Jail1.Destroy()
+	end)
+	Trigger.OnKilled(Jail2Barrel, function()
+		Jail2.Destroy()
+	end)
 end
 
 WorldLoaded = function()

--- a/mods/ra/maps/allies-03a/map.yaml
+++ b/mods/ra/maps/allies-03a/map.yaml
@@ -512,7 +512,7 @@ Actors:
 	Actor155: v19
 		Location: 57,61
 		Owner: USSR
-	Actor156: brl3
+	Jail1Barrel: brl3
 		Location: 58,61
 		Owner: USSR
 	Actor157: barl
@@ -575,7 +575,7 @@ Actors:
 	Actor189: barl
 		Location: 59,69
 		Owner: USSR
-	Actor191: brl3
+	Jail2Barrel: brl3
 		Location: 56,67
 		Owner: USSR
 	Actor191b: brl3

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -142,15 +142,38 @@ CivPanicExplosion:
 		Delay: 1
 
 BarrelExplode:
-	Inherits: ^Explosion
+	Warhead@Cluster: FireCluster
+		Weapon: BarrelCluster
+		Dimensions: 3,3
+		Footprint: _X_ X_X _X_
 	Warhead@1Dam: SpreadDamage
+		Spread: 325
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 5
 		ValidTargets: GroundActor, Trees
 		Versus:
 			None: 120
-			Wood: 100
 			Light: 50
+			Wood: 20
+			Concrete: 10
+	Warhead@2Eff: CreateEffect
+		Explosions: building
+		ImpactSounds: kaboom25.aud
+	Warhead@Smu: LeaveSmudge
+		SmudgeType: Crater
+
+BarrelCluster:
+	Inherits: ^Explosion
+	Projectile: InstantHit
+	Warhead@1Dam: SpreadDamage
+		Spread: 325
+		Falloff: 1000, 368, 135, 50, 18, 7, 0
+		Delay: 5
+		ValidTargets: GroundActor, Trees
+		Versus:
+			None: 120
+			Light: 50
+			Wood: 20
 			Concrete: 10
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@2Eff: CreateEffect
@@ -160,8 +183,6 @@ BarrelExplode:
 	-Warhead@3EffWater:
 	Warhead@Smu: LeaveSmudge
 		SmudgeType: Scorch
-		Size: 2
-		Delay: 5
 
 ATMine:
 	ValidTargets: Ground, Water, GroundActor, WaterActor


### PR DESCRIPTION
The original had four additional explosions adjacent to barrels; up, down, left, and right. These were [their own explosion](https://github.com/electronicarts/CnC_Remastered_Collection/blob/7d496e8a633a8bbf8a14b65f490b4d21fa32ca03/REDALERT/BUILDING.CPP#L1375-L1399), not just a visual effect.

Closes #19079