### PR TITLE
Set _KDE_NET_WM_DESKTOP_FILE x11 window property.

### DIFF
--- a/packaging/linux/openra.appimage.in
+++ b/packaging/linux/openra.appimage.in
@@ -8,19 +8,27 @@ cd "${HERE}/../lib/openra" || exit 1
 if [ -n "${APPIMAGE}" ]; then
 	LAUNCHER=${APPIMAGE}
 
-	# appimaged doesn't update the mime or icon caches when registering AppImages.
-	# Run update-desktop-database and gtk-update-icon-cache ourselves if we detect
-	# that the desktop file has been installed but the handler is not cached
-	if command -v update-desktop-database > /dev/null; then
-		APPIMAGEID=$(printf "file://%s" "${APPIMAGE}" | md5sum | cut -d' ' -f1)
-		LAUNCHER_NAME="appimagekit_${APPIMAGEID}-openra-{MODID}.desktop"
-		LAUNCHER_PATH="${HOME}/.local/share/applications/${LAUNCHER_NAME}"
-		MIMECACHE_PATH="${HOME}/.local/share/applications/mimeinfo.cache"
-		SCHEME="x-scheme-handler/openra-{MODID}-{TAG}"
-		if [ -f "${LAUNCHER_PATH}" ] && ! grep -qs "${SCHEME}=" "${MIMECACHE_PATH}"; then
-			update-desktop-database "${HOME}/.local/share/applications"
-			if command -v gtk-update-icon-cache > /dev/null; then
-				gtk-update-icon-cache ~/.local/share/icons/hicolor/ -t
+	APPIMAGEID=$(printf "file://%s" "${APPIMAGE}" | md5sum | cut -d' ' -f1)
+	LAUNCHER_NAME="appimagekit_${APPIMAGEID}-openra-{MODID}.desktop"
+	LAUNCHER_PATH="${HOME}/.local/share/applications/${LAUNCHER_NAME}"
+	export SDL_VIDEO_X11_WMCLASS="openra-{MODID}-{TAG}"
+
+	if [ -f "${LAUNCHER_PATH}" ]; then
+		# The KDE task switcher limits itself to the 128px icon unless we
+		# set an X11 _KDE_NET_WM_DESKTOP_FILE property on the window
+		export OPENRA_DESKTOP_FILENAME="${LAUNCHER_NAME}"
+
+		# appimaged doesn't update the mime or icon caches when registering AppImages.
+		# Run update-desktop-database and gtk-update-icon-cache ourselves if we detect
+		# that the desktop file has been installed but the handler is not cached
+		if command -v update-desktop-database > /dev/null; then
+			MIMECACHE_PATH="${HOME}/.local/share/applications/mimeinfo.cache"
+			SCHEME="x-scheme-handler/openra-{MODID}-{TAG}"
+			if ! grep -qs "${SCHEME}=" "${MIMECACHE_PATH}"; then
+				update-desktop-database "${HOME}/.local/share/applications"
+				if command -v gtk-update-icon-cache > /dev/null; then
+					gtk-update-icon-cache ~/.local/share/icons/hicolor/ -t
+				fi
 			fi
 		fi
 	fi


### PR DESCRIPTION
This PR fixes a small polish annoyance when running the appimages with https://github.com/TheAssassin/AppImageLauncher integrations. Different components in the KDE desktop seem to have different heuristics for matching windows to their icons, and this was the only way I could find to properly solve all of them.

I suggest reviewing [with ?w=1](https://github.com/OpenRA/OpenRA/pull/19553/files?w=1) to get a clearer picture of what has actually changed.

Before:
<img width="392" alt="Screenshot 2021-07-21 at 19 20 02" src="https://user-images.githubusercontent.com/167819/126539660-d86ed74d-f612-46cd-9e48-dec7495949af.png">

After:
<img width="395" alt="Screenshot 2021-07-21 at 19 17 34" src="https://user-images.githubusercontent.com/167819/126539680-65732687-4bb9-4ed8-a2d5-62d10dca98d7.png">
