### PR TITLE
WorldRenderer, replace ActorsWithTraits with ApplyToActorsWithTrait.

### DIFF
--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -153,14 +153,14 @@ namespace OpenRA.Graphics
 		// PERF: Avoid LINQ.
 		void GenerateOverlayRenderables()
 		{
-			foreach (var a in World.ActorsWithTrait<IRenderAboveShroud>())
+			World.ApplyToActorsWithTrait<IRenderAboveShroud>((actor, trait) =>
 			{
-				if (!a.Actor.IsInWorld || a.Actor.Disposed || (a.Trait.SpatiallyPartitionable && !onScreenActors.Contains(a.Actor)))
-					continue;
+				if (!actor.IsInWorld || actor.Disposed || (trait.SpatiallyPartitionable && !onScreenActors.Contains(actor)))
+					return;
 
-				foreach (var renderable in a.Trait.RenderAboveShroud(a.Actor, this))
+				foreach (var renderable in trait.RenderAboveShroud(actor, this))
 					preparedOverlayRenderables.Add(renderable.PrepareRender(this));
-			}
+			});
 
 			foreach (var a in World.Selection.Actors)
 			{
@@ -195,14 +195,14 @@ namespace OpenRA.Graphics
 		// PERF: Avoid LINQ.
 		void GenerateAnnotationRenderables()
 		{
-			foreach (var a in World.ActorsWithTrait<IRenderAnnotations>())
+			World.ApplyToActorsWithTrait<IRenderAnnotations>((actor, trait) =>
 			{
-				if (!a.Actor.IsInWorld || a.Actor.Disposed || (a.Trait.SpatiallyPartitionable && !onScreenActors.Contains(a.Actor)))
-					continue;
+				if (!actor.IsInWorld || actor.Disposed || (trait.SpatiallyPartitionable && !onScreenActors.Contains(actor)))
+					return;
 
-				foreach (var renderAnnotation in a.Trait.RenderAnnotations(a.Actor, this))
+				foreach (var renderAnnotation in trait.RenderAnnotations(actor, this))
 					preparedAnnotationRenderables.Add(renderAnnotation.PrepareRender(this));
-			}
+			});
 
 			foreach (var a in World.Selection.Actors)
 			{
@@ -278,15 +278,16 @@ namespace OpenRA.Graphics
 			if (enableDepthBuffer)
 				Game.Renderer.ClearDepthBuffer();
 
-			foreach (var a in World.ActorsWithTrait<IRenderAboveWorld>())
-				if (a.Actor.IsInWorld && !a.Actor.Disposed)
-					a.Trait.RenderAboveWorld(a.Actor, this);
+			World.ApplyToActorsWithTrait<IRenderAboveWorld>((actor, trait) =>
+			{
+				if (actor.IsInWorld && !actor.Disposed)
+					trait.RenderAboveWorld(actor, this);
+			});
 
 			if (enableDepthBuffer)
 				Game.Renderer.ClearDepthBuffer();
 
-			foreach (var a in World.ActorsWithTrait<IRenderShroud>())
-				a.Trait.RenderShroud(this);
+			World.ApplyToActorsWithTrait<IRenderShroud>((actor, trait) => trait.RenderShroud(this));
 
 			if (enableDepthBuffer)
 				Game.Renderer.Context.DisableDepthBuffer();

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -432,7 +432,7 @@ namespace OpenRA
 					foreach (var a in actors.Values)
 						a.Tick();
 
-				ApplyToActorsWithTraitTimed<ITick>((Actor actor, ITick trait) => trait.Tick(actor), "Trait");
+				ApplyToActorsWithTraitTimed<ITick>((actor, trait) => trait.Tick(actor), "Trait");
 
 				effects.DoTimed(e => e.Tick(this), "Effect");
 			}
@@ -444,7 +444,7 @@ namespace OpenRA
 		// For things that want to update their render state once per tick, ignoring pause state
 		public void TickRender(WorldRenderer wr)
 		{
-			ApplyToActorsWithTraitTimed<ITickRender>((Actor actor, ITickRender trait) => trait.TickRender(wr, actor), "Render");
+			ApplyToActorsWithTraitTimed<ITickRender>((actor, trait) => trait.TickRender(wr, actor), "Render");
 			ScreenMap.TickRender();
 		}
 
@@ -506,6 +506,11 @@ namespace OpenRA
 		public void ApplyToActorsWithTraitTimed<T>(Action<Actor, T> action, string text)
 		{
 			TraitDict.ApplyToActorsWithTraitTimed<T>(action, text);
+		}
+
+		public void ApplyToActorsWithTrait<T>(Action<Actor, T> action)
+		{
+			TraitDict.ApplyToActorsWithTrait<T>(action);
 		}
 
 		public IEnumerable<Actor> ActorsHavingTrait<T>()


### PR DESCRIPTION
Closes #18798.

At least 2 to 4.2 times less ticks are used - by avoiding the allocation of Trait Actor pairs that use generics.

I.e. 2442 ticks before, 571 ticks after.




