### PR TITLE
Change DrawSprite calls to provide scales instead of sizes.

### DIFF
--- a/OpenRA.Game/Graphics/CursorManager.cs
+++ b/OpenRA.Game/Graphics/CursorManager.cs
@@ -196,17 +196,17 @@ namespace OpenRA.Graphics
 			// Render cursor in software
 			var doubleCursor = graphicSettings.CursorDouble;
 			var cursorSprite = cursor.Sprites[frame % cursor.Length];
-			var cursorSize = doubleCursor ? 2.0f * cursorSprite.Size : cursorSprite.Size;
+			var cursorScale = doubleCursor ? 2 : 1;
 
 			// Cursor is rendered in native window coordinates
 			// Apply same scaling rules as hardware cursors
 			if (Game.Renderer.NativeWindowScale > 1.5f)
-				cursorSize = 2 * cursorSize;
+				cursorScale *= 2;
 
 			var mousePos = isLocked ? lockedPosition : Viewport.LastMousePos;
 			renderer.RgbaSpriteRenderer.DrawSprite(cursorSprite,
 				mousePos,
-				cursorSize / Game.Renderer.WindowScale);
+				cursorScale / Game.Renderer.WindowScale);
 		}
 
 		public void Lock()

--- a/OpenRA.Game/Graphics/RgbaSpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/RgbaSpriteRenderer.cs
@@ -22,36 +22,28 @@ namespace OpenRA.Graphics
 			this.parent = parent;
 		}
 
-		public void DrawSprite(Sprite s, in float3 location, in float3 size)
+		public void DrawSprite(Sprite s, in float3 location, in float3 scale)
 		{
 			if (s.Channel != TextureChannel.RGBA)
 				throw new InvalidOperationException("DrawRGBASprite requires a RGBA sprite.");
 
-			parent.DrawSprite(s, location, 0, size);
+			parent.DrawSprite(s, 0, location, scale);
 		}
 
-		public void DrawSprite(Sprite s, in float3 location)
+		public void DrawSprite(Sprite s, in float3 location, float scale = 1f)
 		{
 			if (s.Channel != TextureChannel.RGBA)
 				throw new InvalidOperationException("DrawRGBASprite requires a RGBA sprite.");
 
-			parent.DrawSprite(s, location, 0, s.Size);
+			parent.DrawSprite(s, 0, location, scale);
 		}
 
-		public void DrawSprite(Sprite s, in float3 a, in float3 b, in float3 c, in float3 d)
+		public void DrawSprite(Sprite s, in float3 location, float scale, in float3 tint, float alpha)
 		{
 			if (s.Channel != TextureChannel.RGBA)
 				throw new InvalidOperationException("DrawRGBASprite requires a RGBA sprite.");
 
-			parent.DrawSprite(s, a, b, c, d);
-		}
-
-		public void DrawSprite(Sprite s, in float3 location, in float3 size, in float3 tint, float alpha)
-		{
-			if (s.Channel != TextureChannel.RGBA)
-				throw new InvalidOperationException("DrawRGBASprite requires a RGBA sprite.");
-
-			parent.DrawSprite(s, location, 0, size, tint, alpha);
+			parent.DrawSprite(s, 0, location, scale, tint, alpha);
 		}
 
 		public void DrawSprite(Sprite s, in float3 a, in float3 b, in float3 c, in float3 d, in float3 tint, float alpha)
@@ -59,7 +51,7 @@ namespace OpenRA.Graphics
 			if (s.Channel != TextureChannel.RGBA)
 				throw new InvalidOperationException("DrawRGBASprite requires a RGBA sprite.");
 
-			parent.DrawSprite(s, a, b, c, d, tint, alpha);
+			parent.DrawSprite(s, 0, a, b, c, d, tint, alpha);
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/Sprite.cs
+++ b/OpenRA.Game/Graphics/Sprite.cs
@@ -23,7 +23,6 @@ namespace OpenRA.Graphics
 		public readonly float ZRamp;
 		public readonly float3 Size;
 		public readonly float3 Offset;
-		public readonly float3 FractionalOffset;
 		public readonly float Top, Left, Bottom, Right;
 
 		public Sprite(Sheet sheet, Rectangle bounds, TextureChannel channel, float scale = 1)
@@ -38,8 +37,6 @@ namespace OpenRA.Graphics
 			Channel = channel;
 			Size = scale * new float3(bounds.Size.Width, bounds.Size.Height, bounds.Size.Height * zRamp);
 			BlendMode = blendMode;
-			FractionalOffset = Size.Z != 0 ? offset / Size :
-				new float3(offset.X / Size.X, offset.Y / Size.Y, 0);
 
 			// Some GPUs suffer from precision issues when rendering into non 1:1 framebuffers that result
 			// in rendering a line of texels that sample outside the sprite rectangle.

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Graphics
 					var contrastSprite = contrastGlyphs[(s, screenContrast)];
 					Game.Renderer.RgbaSpriteRenderer.DrawSprite(contrastSprite,
 						(screen + g.Offset - contrastVector) / deviceScale,
-						contrastSprite.Size / deviceScale,
+						1f / deviceScale,
 						tint, 1f);
 				}
 
@@ -116,7 +116,7 @@ namespace OpenRA.Graphics
 				if (g.Sprite != null)
 					Game.Renderer.RgbaSpriteRenderer.DrawSprite(g.Sprite,
 					(screen + g.Offset).ToFloat2() / deviceScale,
-					g.Sprite.Size / deviceScale,
+					1f / deviceScale,
 					tint, 1f);
 
 				screen += new int2((int)(g.Advance + 0.5f), 0);

--- a/OpenRA.Game/Graphics/SpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderable.cs
@@ -76,10 +76,7 @@ namespace OpenRA.Graphics
 
 		float3 ScreenPosition(WorldRenderer wr)
 		{
-			var xy = wr.ScreenPxPosition(pos) + wr.ScreenPxOffset(offset) - (0.5f * scale * sprite.Size.XY).ToInt2();
-
-			// HACK: The z offset needs to be applied somewhere, but this probably is the wrong place.
-			return new float3(xy, sprite.Offset.Z + wr.ScreenZPosition(pos, 0) - 0.5f * scale * sprite.Size.Z);
+			return wr.Screen3DPxPosition(pos) + wr.ScreenPxOffset(offset) - 0.5f * scale * sprite.Size;
 		}
 
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
@@ -95,7 +92,7 @@ namespace OpenRA.Graphics
 			if ((tintModifiers & TintModifiers.ReplaceColor) != 0)
 				a *= -1;
 
-			wsr.DrawSprite(sprite, ScreenPosition(wr), palette, scale * sprite.Size, t, a);
+			wsr.DrawSprite(sprite, palette, ScreenPosition(wr), scale, t, a);
 		}
 
 		public void RenderDebugGeometry(WorldRenderer wr)

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -109,13 +109,6 @@ namespace OpenRA.Graphics
 			return new int2(sheetIndex, secondarySheetIndex);
 		}
 
-		internal void DrawSprite(Sprite s, in float3 location, float paletteTextureIndex, in float3 size)
-		{
-			var samplers = SetRenderStateForSprite(s);
-			Util.FastCreateQuad(vertices, location + s.FractionalOffset * size, s, samplers, paletteTextureIndex, nv, size, float3.Ones, 1f);
-			nv += 6;
-		}
-
 		float ResolveTextureIndex(Sprite s, PaletteReference pal)
 		{
 			if (pal == null)
@@ -130,39 +123,41 @@ namespace OpenRA.Graphics
 			return pal.TextureIndex;
 		}
 
-		public void DrawSprite(Sprite s, in float3 location, PaletteReference pal)
-		{
-			DrawSprite(s, location, ResolveTextureIndex(s, pal), s.Size);
-		}
-
-		public void DrawSprite(Sprite s, in float3 location, PaletteReference pal, float3 size)
-		{
-			DrawSprite(s, location, ResolveTextureIndex(s, pal), size);
-		}
-
-		public void DrawSprite(Sprite s, in float3 a, in float3 b, in float3 c, in float3 d)
+		internal void DrawSprite(Sprite s, float paletteTextureIndex, in float3 location, in float3 scale)
 		{
 			var samplers = SetRenderStateForSprite(s);
-			Util.FastCreateQuad(vertices, a, b, c, d, s, samplers, 0, float3.Ones, 1f, nv);
+			Util.FastCreateQuad(vertices, location + scale * s.Offset, s, samplers, paletteTextureIndex, nv, scale * s.Size, float3.Ones, 1f);
 			nv += 6;
 		}
 
-		internal void DrawSprite(Sprite s, in float3 location, float paletteTextureIndex, in float3 size, in float3 tint, float alpha)
+		internal void DrawSprite(Sprite s, float paletteTextureIndex, in float3 location, float scale)
 		{
 			var samplers = SetRenderStateForSprite(s);
-			Util.FastCreateQuad(vertices, location + s.FractionalOffset * size, s, samplers, paletteTextureIndex, nv, size, tint, alpha);
+			Util.FastCreateQuad(vertices, location + scale * s.Offset, s, samplers, paletteTextureIndex, nv, scale * s.Size, float3.Ones, 1f);
 			nv += 6;
 		}
 
-		public void DrawSprite(Sprite s, in float3 location, PaletteReference pal, in float3 size, in float3 tint, float alpha)
+		public void DrawSprite(Sprite s, PaletteReference pal, in float3 location, float scale = 1f)
 		{
-			DrawSprite(s, location, ResolveTextureIndex(s, pal), size, tint, alpha);
+			DrawSprite(s, ResolveTextureIndex(s, pal), location, scale);
 		}
 
-		public void DrawSprite(Sprite s, in float3 a, in float3 b, in float3 c, in float3 d, in float3 tint, float alpha)
+		internal void DrawSprite(Sprite s, float paletteTextureIndex, in float3 location, float scale, in float3 tint, float alpha)
 		{
 			var samplers = SetRenderStateForSprite(s);
-			Util.FastCreateQuad(vertices, a, b, c, d, s, samplers, 0, tint, alpha, nv);
+			Util.FastCreateQuad(vertices, location + scale * s.Offset, s, samplers, paletteTextureIndex, nv, scale * s.Size, tint, alpha);
+			nv += 6;
+		}
+
+		public void DrawSprite(Sprite s, PaletteReference pal, in float3 location, float scale, in float3 tint, float alpha)
+		{
+			DrawSprite(s, ResolveTextureIndex(s, pal), location, scale, tint, alpha);
+		}
+
+		internal void DrawSprite(Sprite s, float paletteTextureIndex, in float3 a, in float3 b, in float3 c, in float3 d, in float3 tint, float alpha)
+		{
+			var samplers = SetRenderStateForSprite(s);
+			Util.FastCreateQuad(vertices, a, b, c, d, s, samplers, paletteTextureIndex, tint, alpha, nv);
 			nv += 6;
 		}
 

--- a/OpenRA.Game/Graphics/UISpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/UISpriteRenderable.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Graphics
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
 		public void Render(WorldRenderer wr)
 		{
-			Game.Renderer.SpriteRenderer.DrawSprite(sprite, screenPos, palette, scale * sprite.Size, float3.Ones, alpha);
+			Game.Renderer.SpriteRenderer.DrawSprite(sprite, palette, screenPos, scale, float3.Ones, alpha);
 		}
 
 		public void RenderDebugGeometry(WorldRenderer wr)

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -274,10 +274,10 @@ namespace OpenRA
 				screenBuffer.Bind();
 
 				var scale = Window.EffectiveWindowScale;
-				var bufferSize = new float2((int)(screenSprite.Bounds.Width / scale), (int)(-screenSprite.Bounds.Height / scale));
+				var bufferScale = new float3((int)(screenSprite.Bounds.Width / scale) / worldSprite.Size.X, (int)(-screenSprite.Bounds.Height / scale) / worldSprite.Size.Y, 1f);
 
 				SpriteRenderer.SetAntialiasingPixelsPerTexel(Window.SurfaceSize.Height * 1f / worldSprite.Bounds.Height);
-				RgbaSpriteRenderer.DrawSprite(worldSprite, float3.Zero, bufferSize);
+				RgbaSpriteRenderer.DrawSprite(worldSprite, float3.Zero, bufferScale);
 				Flush();
 				SpriteRenderer.SetAntialiasingPixelsPerTexel(0);
 			}
@@ -318,7 +318,7 @@ namespace OpenRA
 			// Render the compositor buffers to the screen
 			// HACK / PERF: Fudge the coordinates to cover the actual window while keeping the buffer viewport parameters
 			// This saves us two redundant (and expensive) SetViewportParams each frame
-			RgbaSpriteRenderer.DrawSprite(screenSprite, new float3(0, lastBufferSize.Height, 0), new float3(lastBufferSize.Width, -lastBufferSize.Height, 0));
+			RgbaSpriteRenderer.DrawSprite(screenSprite, new float3(0, lastBufferSize.Height, 0), new float3(lastBufferSize.Width / screenSprite.Size.X, -lastBufferSize.Height / screenSprite.Size.Y, 1f));
 			Flush();
 
 			Window.PumpInput(inputHandler);

--- a/OpenRA.Mods.Common/Graphics/ModelRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/ModelRenderable.cs
@@ -170,7 +170,7 @@ namespace OpenRA.Mods.Common.Graphics
 					a *= -1;
 
 				wrsr.DrawSprite(renderProxy.ShadowSprite, sa, sb, sc, sd, t, a);
-				wrsr.DrawSprite(renderProxy.Sprite, pxOrigin - 0.5f * renderProxy.Sprite.Size, renderProxy.Sprite.Size, t, a);
+				wrsr.DrawSprite(renderProxy.Sprite, pxOrigin - 0.5f * renderProxy.Sprite.Size, 1f, t, a);
 			}
 
 			public void RenderDebugGeometry(WorldRenderer wr)

--- a/OpenRA.Mods.Common/Graphics/UIModelRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/UIModelRenderable.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Graphics
 				var sb = pxOrigin + psb[2];
 				var sc = pxOrigin + psb[1];
 				var sd = pxOrigin + psb[3];
-				Game.Renderer.RgbaSpriteRenderer.DrawSprite(renderProxy.ShadowSprite, sa, sb, sc, sd);
+				Game.Renderer.RgbaSpriteRenderer.DrawSprite(renderProxy.ShadowSprite, sa, sb, sc, sd, float3.Ones, 1f);
 				Game.Renderer.RgbaSpriteRenderer.DrawSprite(renderProxy.Sprite, pxOrigin - 0.5f * renderProxy.Sprite.Size);
 			}
 

--- a/OpenRA.Mods.Common/Widgets/BadgeWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/BadgeWidget.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var icon = playerDatabase.GetIcon(Badge);
 			if (icon != null)
-				Game.Renderer.RgbaSpriteRenderer.DrawSprite(icon, RenderOrigin);
+				WidgetUtils.DrawSprite(icon, RenderOrigin);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/CheckboxWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/CheckboxWidget.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Widgets
 					checkType += "-disabled";
 
 				var offset = new float2(rect.Left + CheckOffset, rect.Top + CheckOffset);
-				WidgetUtils.DrawRGBA(ChromeProvider.GetImage("checkbox-bits", checkType), offset);
+				WidgetUtils.DrawSprite(ChromeProvider.GetImage("checkbox-bits", checkType), offset);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
@@ -89,12 +89,12 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override void Draw()
 		{
-			Game.Renderer.RgbaSpriteRenderer.DrawSprite(mixerSprite, RenderOrigin, new float2(RenderBounds.Size));
+			WidgetUtils.DrawSprite(mixerSprite, RenderOrigin, RenderBounds.Size);
 
 			var sprite = ChromeProvider.GetImage("lobby-bits", "colorpicker");
 			var pos = RenderOrigin + PxFromValue() - new int2((int)sprite.Size.X, (int)sprite.Size.Y) / 2;
 			WidgetUtils.FillEllipseWithColor(new Rectangle(pos.X + 1, pos.Y + 1, (int)sprite.Size.X - 2, (int)sprite.Size.Y - 2), Color);
-			Game.Renderer.RgbaSpriteRenderer.DrawSprite(sprite, pos);
+			WidgetUtils.DrawSprite(sprite, pos);
 		}
 
 		void SetValueFromPx(int2 xy)

--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -61,11 +61,11 @@ namespace OpenRA.Mods.Common.Widgets
 			var isHover = Ui.MouseOverWidget == this || Children.Any(c => c == Ui.MouseOverWidget);
 
 			var arrowImage = getMarkerImage.Update((isDisabled, Depressed, isHover, false));
-			WidgetUtils.DrawRGBA(arrowImage, stateOffset + new float2(rb.Right - (int)((rb.Height + arrowImage.Size.X) / 2), rb.Top + (int)((rb.Height - arrowImage.Size.Y) / 2)));
+			WidgetUtils.DrawSprite(arrowImage, stateOffset + new float2(rb.Right - (int)((rb.Height + arrowImage.Size.X) / 2), rb.Top + (int)((rb.Height - arrowImage.Size.Y) / 2)));
 
 			var separatorImage = getSeparatorImage.Update((isDisabled, Depressed, isHover, false));
 			if (separatorImage != null)
-				WidgetUtils.DrawRGBA(separatorImage, stateOffset + new float2(-3, 0) + new float2(rb.Right - rb.Height + 4, rb.Top + (int)((rb.Height - separatorImage.Size.Y) / 2)));
+				WidgetUtils.DrawSprite(separatorImage, stateOffset + new float2(-3, 0) + new float2(rb.Right - rb.Height + 4, rb.Top + (int)((rb.Height - separatorImage.Size.Y) / 2)));
 		}
 
 		public override Widget Clone() { return new DropDownButtonWidget(this); }

--- a/OpenRA.Mods.Common/Widgets/ImageWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ImageWidget.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (sprite == null)
 				throw new ArgumentException($"Sprite {collection}/{name} was not found.");
 
-			WidgetUtils.DrawRGBA(sprite, RenderOrigin);
+			WidgetUtils.DrawSprite(sprite, RenderOrigin);
 		}
 
 		public override bool HandleMouseInput(MouseInput mi)

--- a/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
@@ -181,7 +181,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var y = RenderBounds.Y + (RenderBounds.Height - h) / 2;
 			mapRect = new Rectangle(x, y, w, h);
 
-			Game.Renderer.RgbaSpriteRenderer.DrawSprite(minimap, new float2(mapRect.Location), new float2(mapRect.Size));
+			WidgetUtils.DrawSprite(minimap, mapRect.Location, mapRect.Size);
 
 			TooltipSpawnIndex = -1;
 			if (ShowSpawnPoints)
@@ -207,14 +207,14 @@ namespace OpenRA.Mods.Common.Widgets
 
 					if (disabled)
 					{
-						Game.Renderer.RgbaSpriteRenderer.DrawSprite(spawnDisabled, pos - offset);
+						WidgetUtils.DrawSprite(spawnDisabled, pos - offset);
 						continue;
 					}
 
 					if (occupied)
 						WidgetUtils.FillEllipseWithColor(new Rectangle(pos.X - offset.X + 1, pos.Y - offset.Y + 1, (int)sprite.Size.X - 2, (int)sprite.Size.Y - 2), occupant.Color);
 
-					Game.Renderer.RgbaSpriteRenderer.DrawSprite(sprite, pos - offset);
+					WidgetUtils.DrawSprite(sprite, pos - offset);
 
 					var number = Convert.ToChar('A' + spawnPoints.IndexOf(p)).ToString();
 					var textOffset = spawnFont.Measure(number) / 2 + spawnLabelOffset;

--- a/OpenRA.Mods.Common/Widgets/MouseAttachmentWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MouseAttachmentWidget.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Widgets
 				// Cursor is rendered in native window coordinates
 				// Apply same scaling rules as hardware cursors
 				var scale = (graphicSettings.CursorDouble ? 2 : 1) * (Game.Renderer.NativeWindowScale > 1.5f ? 2 : 1);
-				WidgetUtils.DrawSHPCentered(sprite, ChildOrigin, directionPalette, scale / Game.Renderer.WindowScale);
+				WidgetUtils.DrawSpriteCentered(sprite, directionPalette, ChildOrigin, scale / Game.Renderer.WindowScale);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Widgets/ObserverArmyIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverArmyIconsWidget.cs
@@ -108,7 +108,7 @@ namespace OpenRA.Mods.Common.Widgets
 				var centerPosition = iconTopLeft;
 
 				var palette = unit.IconPaletteIsPlayerPalette ? unit.IconPalette + player.InternalName : unit.IconPalette;
-				WidgetUtils.DrawSHPCentered(icon.Image, centerPosition + 0.5f * iconSize, worldRenderer.Palette(palette), 0.5f);
+				WidgetUtils.DrawSpriteCentered(icon.Image, worldRenderer.Palette(palette), centerPosition + 0.5f * iconSize, 0.5f);
 
 				armyIcons.Add(new ArmyIcon
 				{

--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -144,7 +144,7 @@ namespace OpenRA.Mods.Common.Widgets
 				var centerPosition = iconTopLeft + 0.5f * iconSize;
 
 				var palette = bi.IconPaletteIsPlayerPalette ? bi.IconPalette + player.InternalName : bi.IconPalette;
-				WidgetUtils.DrawSHPCentered(icon.Image, centerPosition, worldRenderer.Palette(palette), 0.5f);
+				WidgetUtils.DrawSpriteCentered(icon.Image, worldRenderer.Palette(palette), centerPosition, 0.5f);
 
 				var rect = new Rectangle((int)iconTopLeft.X, (int)iconTopLeft.Y, (int)iconSize.X, (int)iconSize.Y);
 				productionIcons.Add(new ProductionIcon
@@ -161,15 +161,15 @@ namespace OpenRA.Mods.Common.Widgets
 					.FirstOrDefault(p => p.IsOverlayActive(actor));
 
 				if (pio != null)
-					WidgetUtils.DrawSHPCentered(pio.Sprite, centerPosition + pio.Offset(iconSize),
-						worldRenderer.Palette(pio.Palette), 0.5f);
+					WidgetUtils.DrawSpriteCentered(pio.Sprite, worldRenderer.Palette(pio.Palette),
+						centerPosition + pio.Offset(iconSize), 0.5f);
 
 				var clock = clocks[queue];
 				clock.PlayFetchIndex(ClockSequence, () => current.TotalTime == 0 ? 0 :
 					(current.TotalTime - current.RemainingTime) * (clock.CurrentSequence.Length - 1) / current.TotalTime);
 
 				clock.Tick();
-				WidgetUtils.DrawSHPCentered(clock.Image, centerPosition, worldRenderer.Palette(ClockPalette), 0.5f);
+				WidgetUtils.DrawSpriteCentered(clock.Image, worldRenderer.Palette(ClockPalette), centerPosition, 0.5f);
 
 				queueCol++;
 			}

--- a/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
@@ -124,14 +124,14 @@ namespace OpenRA.Mods.Common.Widgets
 				supportPowerIconsIcons.Add(new SupportPowersWidget.SupportPowerIcon { Power = item, Pos = location });
 				supportPowerIconsBounds.Add(new Rectangle((int)location.X, (int)location.Y, (int)iconSize.X, (int)iconSize.Y));
 
-				WidgetUtils.DrawSHPCentered(icon.Image, location + 0.5f * iconSize, worldRenderer.Palette(item.Info.IconPalette), 0.5f);
+				WidgetUtils.DrawSpriteCentered(icon.Image, worldRenderer.Palette(item.Info.IconPalette), location + 0.5f * iconSize, 0.5f);
 
 				var clock = clocks[power.a.Key];
 				clock.PlayFetchIndex(ClockSequence,
 					() => item.TotalTicks == 0 ? 0 : ((item.TotalTicks - item.RemainingTicks)
 						* (clock.CurrentSequence.Length - 1) / item.TotalTicks));
 				clock.Tick();
-				WidgetUtils.DrawSHPCentered(clock.Image, location + 0.5f * iconSize, worldRenderer.Palette(ClockPalette), 0.5f);
+				WidgetUtils.DrawSpriteCentered(clock.Image, worldRenderer.Palette(ClockPalette), location + 0.5f * iconSize, 0.5f);
 			}
 
 			Game.Renderer.DisableAntialiasingFilter();

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -499,12 +499,12 @@ namespace OpenRA.Mods.Common.Widgets
 			Game.Renderer.EnableAntialiasingFilter();
 			foreach (var icon in icons.Values)
 			{
-				WidgetUtils.DrawSHPCentered(icon.Sprite, icon.Pos + iconOffset, icon.Palette);
+				WidgetUtils.DrawSpriteCentered(icon.Sprite, icon.Palette, icon.Pos + iconOffset);
 
 				// Draw the ProductionIconOverlay's sprite
 				var pio = pios.FirstOrDefault(p => p.IsOverlayActive(icon.Actor));
 				if (pio != null)
-					WidgetUtils.DrawSHPCentered(pio.Sprite, icon.Pos + iconOffset + pio.Offset(IconSize), worldRenderer.Palette(pio.Palette), 1f);
+					WidgetUtils.DrawSpriteCentered(pio.Sprite, worldRenderer.Palette(pio.Palette), icon.Pos + iconOffset + pio.Offset(IconSize));
 
 				// Build progress
 				if (icon.Queued.Count > 0)
@@ -515,10 +515,10 @@ namespace OpenRA.Mods.Common.Widgets
 							* (clock.CurrentSequence.Length - 1) / first.TotalTime);
 					clock.Tick();
 
-					WidgetUtils.DrawSHPCentered(clock.Image, icon.Pos + iconOffset, icon.IconClockPalette);
+					WidgetUtils.DrawSpriteCentered(clock.Image, icon.IconClockPalette, icon.Pos + iconOffset);
 				}
 				else if (!buildableItems.Any(a => a.Name == icon.Name))
-					WidgetUtils.DrawSHPCentered(cantBuild.Image, icon.Pos + iconOffset, icon.IconDarkenPalette);
+					WidgetUtils.DrawSpriteCentered(cantBuild.Image, icon.IconDarkenPalette, icon.Pos + iconOffset);
 			}
 
 			Game.Renderer.DisableAntialiasingFilter();

--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -194,11 +194,11 @@ namespace OpenRA.Mods.Common.Widgets
 			ButtonWidget.DrawBackground(Button, rightButtonRect, rightDisabled, rightPressed, rightHover, false);
 
 			var leftArrowImage = getLeftArrowImage.Update((leftDisabled, leftPressed, leftHover, false));
-			WidgetUtils.DrawRGBA(leftArrowImage,
+			WidgetUtils.DrawSprite(leftArrowImage,
 				new float2(leftButtonRect.Left + 2, leftButtonRect.Top + 2));
 
 			var rightArrowImage = getRightArrowImage.Update((rightDisabled, rightPressed, rightHover, false));
-			WidgetUtils.DrawRGBA(rightArrowImage,
+			WidgetUtils.DrawSprite(rightArrowImage,
 				new float2(rightButtonRect.Left + 2, rightButtonRect.Top + 2));
 
 			// Draw tab buttons

--- a/OpenRA.Mods.Common/Widgets/RGBASpriteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RGBASpriteWidget.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			var sprite = GetSprite();
 			if (sprite != null)
-				Game.Renderer.RgbaSpriteRenderer.DrawSprite(sprite, RenderOrigin);
+				WidgetUtils.DrawSprite(sprite, RenderOrigin);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -339,12 +339,11 @@ namespace OpenRA.Mods.Common.Widgets
 			var o = new float2(mapRect.Location.X, mapRect.Location.Y + world.Map.Bounds.Height * previewScale * (1 - radarMinimapHeight) / 2);
 			var s = new float2(mapRect.Size.Width, mapRect.Size.Height * radarMinimapHeight);
 
-			var rsr = Game.Renderer.RgbaSpriteRenderer;
-			rsr.DrawSprite(terrainSprite, o, s);
-			rsr.DrawSprite(actorSprite, o, s);
+			WidgetUtils.DrawSprite(terrainSprite, o, s);
+			WidgetUtils.DrawSprite(actorSprite, o, s);
 
 			if (shroud != null)
-				rsr.DrawSprite(shroudSprite, o, s);
+				WidgetUtils.DrawSprite(shroudSprite, o, s);
 
 			// Draw viewport rect
 			if (hasRadar)

--- a/OpenRA.Mods.Common/Widgets/ResourceBarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ResourceBarWidget.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 				var x = (b.Left + b.Right - indicator.Size.X) / 2;
 				var y = float2.Lerp(b.Bottom, b.Top, usedFrac) - indicator.Size.Y / 2;
-				Game.Renderer.RgbaSpriteRenderer.DrawSprite(indicator, new float2(x, y));
+				WidgetUtils.DrawSprite(indicator, new float2(x, y));
 			}
 			else
 			{
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 				var x = float2.Lerp(b.Left, b.Right, usedFrac) - indicator.Size.X / 2;
 				var y = (b.Bottom + b.Top - indicator.Size.Y) / 2;
-				Game.Renderer.RgbaSpriteRenderer.DrawSprite(indicator, new float2(x, y));
+				WidgetUtils.DrawSprite(indicator, new float2(x, y));
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
@@ -210,11 +210,11 @@ namespace OpenRA.Mods.Common.Widgets
 				var downOffset = !downPressed || downDisabled ? 4 : 4 + ButtonDepth;
 
 				var upArrowImage = getUpArrowImage.Update((upDisabled, upPressed, upHover, false));
-				WidgetUtils.DrawRGBA(upArrowImage,
+				WidgetUtils.DrawSprite(upArrowImage,
 					new float2(upButtonRect.Left + upOffset, upButtonRect.Top + upOffset));
 
 				var downArrowImage = getDownArrowImage.Update((downDisabled, downPressed, downHover, false));
-				WidgetUtils.DrawRGBA(downArrowImage,
+				WidgetUtils.DrawSprite(downArrowImage,
 					new float2(downButtonRect.Left + downOffset, downButtonRect.Top + downOffset));
 			}
 

--- a/OpenRA.Mods.Common/Widgets/SliderWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SliderWidget.cs
@@ -132,7 +132,7 @@ namespace OpenRA.Mods.Common.Widgets
 					trackOrigin + (i * (trackRect.Width - (int)tick.Size.X) / (Ticks - 1)) - tick.Size.X / 2,
 					trackRect.Bottom);
 
-				WidgetUtils.DrawRGBA(tick, tickPos);
+				WidgetUtils.DrawSprite(tick, tickPos);
 			}
 
 			// Track

--- a/OpenRA.Mods.Common/Widgets/SpriteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SpriteWidget.cs
@@ -77,9 +77,8 @@ namespace OpenRA.Mods.Common.Widgets
 				cachedScale = scale;
 			}
 
-			var size = new float2(sprite.Size.X * scale, sprite.Size.Y * scale);
 			Game.Renderer.EnableAntialiasingFilter();
-			Game.Renderer.SpriteRenderer.DrawSprite(sprite, RenderOrigin + offset, pr, size);
+			Game.Renderer.SpriteRenderer.DrawSprite(sprite, pr, RenderOrigin + offset, scale);
 			Game.Renderer.DisableAntialiasingFilter();
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/StrategicProgressWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/StrategicProgressWidget.cs
@@ -47,12 +47,12 @@ namespace OpenRA.Mods.Common.Widgets
 
 			foreach (var a in svc.AllPoints)
 			{
-				WidgetUtils.DrawRGBA(ChromeProvider.GetImage("strategic", "critical_unowned"), offset + new float2(rb.Left + curX, rb.Top));
+				WidgetUtils.DrawSprite(ChromeProvider.GetImage("strategic", "critical_unowned"), offset + new float2(rb.Left + curX, rb.Top));
 
 				if (world.LocalPlayer != null && a.Owner.RelationshipWith(world.LocalPlayer) == PlayerRelationship.Ally)
-					WidgetUtils.DrawRGBA(ChromeProvider.GetImage("strategic", "player_owned"), offset + new float2(rb.Left + curX, rb.Top));
+					WidgetUtils.DrawSprite(ChromeProvider.GetImage("strategic", "player_owned"), offset + new float2(rb.Left + curX, rb.Top));
 				else if (!a.Owner.NonCombatant)
-					WidgetUtils.DrawRGBA(ChromeProvider.GetImage("strategic", "enemy_owned"), offset + new float2(rb.Left + curX, rb.Top));
+					WidgetUtils.DrawSprite(ChromeProvider.GetImage("strategic", "enemy_owned"), offset + new float2(rb.Left + curX, rb.Top));
 
 				curX += 32;
 			}

--- a/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
@@ -202,7 +202,7 @@ namespace OpenRA.Mods.Common.Widgets
 			Game.Renderer.EnableAntialiasingFilter();
 			foreach (var p in icons.Values)
 			{
-				WidgetUtils.DrawSHPCentered(p.Sprite, p.Pos + iconOffset, p.Palette);
+				WidgetUtils.DrawSpriteCentered(p.Sprite, p.Palette, p.Pos + iconOffset);
 
 				// Charge progress
 				var sp = p.Power;
@@ -211,7 +211,7 @@ namespace OpenRA.Mods.Common.Widgets
 					* (clock.CurrentSequence.Length - 1) / sp.TotalTicks);
 
 				clock.Tick();
-				WidgetUtils.DrawSHPCentered(clock.Image, p.Pos + iconOffset, p.IconClockPalette);
+				WidgetUtils.DrawSpriteCentered(clock.Image, p.IconClockPalette, p.Pos + iconOffset);
 			}
 
 			Game.Renderer.DisableAntialiasingFilter();

--- a/OpenRA.Mods.Common/Widgets/VideoPlayerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/VideoPlayerWidget.cs
@@ -118,10 +118,7 @@ namespace OpenRA.Mods.Common.Widgets
 					Log.Write("perf", "VqaPlayer : {0} skipped {1} frames at position {2}", cachedVideo, skippedFrames, video.CurrentFrame);
 			}
 
-			Game.Renderer.RgbaSpriteRenderer.DrawSprite(
-				videoSprite,
-				videoOrigin,
-				videoSize);
+			WidgetUtils.DrawSprite(videoSprite, videoOrigin, videoSize);
 
 			if (DrawOverlay)
 			{
@@ -161,7 +158,7 @@ namespace OpenRA.Mods.Common.Widgets
 					overlayScale = scale;
 				}
 
-				Game.Renderer.RgbaSpriteRenderer.DrawSprite(overlaySprite, overlayOrigin, overlaySize);
+				WidgetUtils.DrawSprite(overlaySprite, overlayOrigin, overlaySize);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
@@ -41,17 +41,22 @@ namespace OpenRA.Mods.Common.Widgets
 					});
 		}
 
-		public static void DrawRGBA(Sprite s, float2 pos)
+		public static void DrawSprite(Sprite s, float2 pos)
 		{
 			Game.Renderer.RgbaSpriteRenderer.DrawSprite(s, pos);
 		}
 
-		public static void DrawSHPCentered(Sprite s, float2 pos, PaletteReference p)
+		public static void DrawSprite(Sprite s, float2 pos, Size size)
 		{
-			Game.Renderer.SpriteRenderer.DrawSprite(s, pos - 0.5f * s.Size, p);
+			Game.Renderer.RgbaSpriteRenderer.DrawSprite(s, pos, new float2(size));
 		}
 
-		public static void DrawSHPCentered(Sprite s, float2 pos, PaletteReference p, float scale)
+		public static void DrawSprite(Sprite s, float2 pos, float2 size)
+		{
+			Game.Renderer.RgbaSpriteRenderer.DrawSprite(s, pos, size);
+		}
+
+		public static void DrawSpriteCentered(Sprite s, PaletteReference p, float2 pos, float scale = 1f)
 		{
 			Game.Renderer.SpriteRenderer.DrawSprite(s, pos - 0.5f * scale * s.Size, p, scale * s.Size);
 		}
@@ -83,7 +88,7 @@ namespace OpenRA.Mods.Common.Widgets
 						ss = new Sprite(s.Sheet, rr, s.Channel, scale);
 					}
 
-					DrawRGBA(ss, new float2(x, y));
+					DrawSprite(ss, new float2(x, y));
 				}
 			}
 		}
@@ -165,19 +170,19 @@ namespace OpenRA.Mods.Common.Widgets
 
 			// Top-left corner
 			if (sprites[0] != null)
-				DrawRGBA(sprites[0], new float2(bounds.Left, bounds.Top));
+				DrawSprite(sprites[0], new float2(bounds.Left, bounds.Top));
 
 			// Top-right corner
 			if (sprites[2] != null)
-				DrawRGBA(sprites[2], new float2(bounds.Right - sprites[2].Size.X, bounds.Top));
+				DrawSprite(sprites[2], new float2(bounds.Right - sprites[2].Size.X, bounds.Top));
 
 			// Bottom-left corner
 			if (sprites[6] != null)
-				DrawRGBA(sprites[6], new float2(bounds.Left, bounds.Bottom - sprites[6].Size.Y));
+				DrawSprite(sprites[6], new float2(bounds.Left, bounds.Bottom - sprites[6].Size.Y));
 
 			// Bottom-right corner
 			if (sprites[8] != null)
-				DrawRGBA(sprites[8], new float2(bounds.Right - sprites[8].Size.X, bounds.Bottom - sprites[8].Size.Y));
+				DrawSprite(sprites[8], new float2(bounds.Right - sprites[8].Size.X, bounds.Bottom - sprites[8].Size.Y));
 		}
 
 		public static string FormatTime(int ticks, int timestep)

--- a/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
@@ -48,17 +48,19 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public static void DrawSprite(Sprite s, float2 pos, Size size)
 		{
-			Game.Renderer.RgbaSpriteRenderer.DrawSprite(s, pos, new float2(size));
+			var scale = new float3(size.Width / s.Size.X, size.Height / s.Size.Y, 1f);
+			Game.Renderer.RgbaSpriteRenderer.DrawSprite(s, pos, scale);
 		}
 
 		public static void DrawSprite(Sprite s, float2 pos, float2 size)
 		{
-			Game.Renderer.RgbaSpriteRenderer.DrawSprite(s, pos, size);
+			var scale = new float3(size.X / s.Size.X, size.Y / s.Size.Y, 1f);
+			Game.Renderer.RgbaSpriteRenderer.DrawSprite(s, pos, scale);
 		}
 
 		public static void DrawSpriteCentered(Sprite s, PaletteReference p, float2 pos, float scale = 1f)
 		{
-			Game.Renderer.SpriteRenderer.DrawSprite(s, pos - 0.5f * scale * s.Size, p, scale * s.Size);
+			Game.Renderer.SpriteRenderer.DrawSprite(s, p, pos - 0.5f * scale * s.Size, scale);
 		}
 
 		public static void DrawPanel(string collection, Rectangle bounds)


### PR DESCRIPTION
The fundamental motivation behind this PR is that the sprite rendering code has always done its drawing taking arguments for the top-left position and the rendered width/height. This was simple and efficient for our original sprite implementation, and continues to work if you introduce the idea of a virtual frame rectangle *or* pixel depth information. Unfortunately for us, we implement *both* of those things, meaning that things break.

The reason is that sprites that embed a block of pixels inside a larger virtual frame need to define an offset: the margin of empty pixels between the top left corner and the actual start of the pixel data. When the renderer is asked to draw a sprite with a location and size it has to work out how to adjust these offsets to keep the pixels correctly offset within the frame.

The scale is trivial to calculate for x and y because the width and height are never 0: you can divide the requested size by the virtual size and always get a valid scale. However, when we introduce depth, 0 is a valid and common size (meaning that the sprite sits flat in the x-y plane), giving us a z scale factor of 0 / 0. We can't assume that the z scale is the same as the x or y scale, because the code doesn't guarantee that even x and y are the same (and some parts of the UI explicitly depend on them being different).

The current code works around the divide by zero with

https://github.com/OpenRA/OpenRA/blob/dcaa658678c398b600a7b591a4d4cf796ea50493/OpenRA.Game/Graphics/Sprite.cs#L41-L42

simply setting the internal (size-dependent) z offset to 0 if the z size is 0.

This breaks the offset calculation, so we bodge a workaround with

https://github.com/OpenRA/OpenRA/blob/dcaa658678c398b600a7b591a4d4cf796ea50493/OpenRA.Game/Graphics/SpriteRenderable.cs#L81-L82

manually adding the offset to the location that we give to the renderer instead of allowing the renderer to add it internally based on the size. This works fine for sprites that have `ZRamp: 0`, but things start getting messy for bibs, railway tracks, etc that have `ZRamp: 1`. We need to fix this properly before we can correcty solve #12229.

This would have been difficult to fix a few years ago back when the depth code was first implemented, but all the other renderer refactoring since then now makes it simple: we already deal with scale in the high level rendering code, we just need to not multiply it by the sprite size when calling the low level rendering code. This PR does just that, and makes some other tweaks to the DrawSprite overloads to make them more consistent.

There are a few places in the UI (e.g. video rendering) that do need split x and y scale, but these don’t care about depth, so the conversion from size to scale is done at the WidgetUtil level where we can use the type system to guarantee that there are no depth components to blow up.

The changes should hopefully be quite obvious with the explanation above in mind, and I don't expect any changes in the ingame behaviour (except maybe around #12229, but the next PR will fix that properly).