### PR TITLE
Fix an edge case where the wrong sheet may be mapped to a depth sprite.

### DIFF
--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -82,28 +82,32 @@ namespace OpenRA.Graphics
 				for (; secondarySheetIndex < ns; secondarySheetIndex++)
 					if (sheets[secondarySheetIndex] == secondarySheet)
 						break;
+
+				// If neither sheet has been mapped both index values will be set to ns.
+				// This is fine if they both reference the same texture, but if they don't
+				// we must increment the secondary sheet index to the next free sampler.
+				if (secondarySheetIndex == sheetIndex && secondarySheet != sheet)
+					secondarySheetIndex++;
 			}
 
 			// Make sure that we have enough free samplers to map both if needed, otherwise flush
-			var needSamplers = (sheetIndex == ns ? 1 : 0) + (secondarySheetIndex == ns ? 1 : 0);
-			if (ns + needSamplers >= sheets.Length)
+			if (Math.Max(sheetIndex, secondarySheetIndex) >= sheets.Length)
 			{
 				Flush();
 				sheetIndex = 0;
-				if (ss != null)
-					secondarySheetIndex = 1;
+				secondarySheetIndex = ss != null && ss.SecondarySheet != sheet ? 1 : 0;
 			}
 
 			if (sheetIndex >= ns)
 			{
 				sheets[sheetIndex] = sheet;
-				ns += 1;
+				ns++;
 			}
 
 			if (secondarySheetIndex >= ns && ss != null)
 			{
 				sheets[secondarySheetIndex] = ss.SecondarySheet;
-				ns += 1;
+				ns++;
 			}
 
 			return new int2(sheetIndex, secondarySheetIndex);


### PR DESCRIPTION
This PR is an alternative implementation of @anvilvapre's fix for incorrect depth sheet assignment first filed as #19540.

This approach IMO keeps the behaviour of `SetRenderStateForSprite` a lot clearer to the reader, and the edge case and the problem and fix should hopefully be clear with the help of the new comment.

I suggest cherry picking this on top of #19561 when testing to take advantage of the improved depth preview mode.

I have also put together a testcase demonstrating the fix for RA2: https://github.com/OpenRA/ra2/issues/710#issuecomment-886187740