### PR TITLE
CPos.ToMPos, get and calculate x and y once.

### DIFF
--- a/OpenRA.Game/CPos.cs
+++ b/OpenRA.Game/CPos.cs
@@ -51,7 +51,7 @@ namespace OpenRA
 		public static CVec operator -(CPos a, CPos b) { return new CVec(a.X - b.X, a.Y - b.Y); }
 
 		public static bool operator ==(CPos me, CPos other) { return me.Bits == other.Bits; }
-		public static bool operator !=(CPos me, CPos other) { return !(me == other); }
+		public static bool operator !=(CPos me, CPos other) { return me.Bits != other.Bits; }
 
 		public override int GetHashCode() { return Bits.GetHashCode(); }
 
@@ -80,8 +80,10 @@ namespace OpenRA
 			// (b) Therefore:
 			//  - ax + by adds (a - b)/2 to u (only even increments count)
 			//  - ax + by adds a + b to v
-			var u = (X - Y) / 2;
-			var v = X + Y;
+			var x = X;
+			var y = Y;
+			var u = (x - y) / 2;
+			var v = x + y;
 			return new MPos(u, v);
 		}
 


### PR DESCRIPTION



Old IL:
```
  .method public hidebysig instance default OpenRA.MPos ToMPos(OpenRA.MapGridType gridType) cil managed
  {                                                                             
    // Method begins at Relative Virtual Address (RVA) 0x35D8                   
    // Code size 59 (0x3B)                                                      
    .maxstack 2                                                                 
    .locals init(int32 V_0, int32 V_1)                                          
    IL_0000: ldarg.1                                                            
    IL_0001: brtrue.s     IL_0015                                               
    IL_0003: ldarg.0                                                            
    IL_0004: call instance int32 class OpenRA.CPos::get_X()                     
    IL_0009: ldarg.0                                                            
    IL_000a: call instance int32 class OpenRA.CPos::get_Y()                     
    IL_000f: newobj instance void class OpenRA.MPos::.ctor(int32, int32)        
    IL_0014: ret                                                                
    IL_0015: ldarg.0                                                            
    IL_0016: call instance int32 class OpenRA.CPos::get_X()                     
    IL_001b: ldarg.0                                                            
    IL_001c: call instance int32 class OpenRA.CPos::get_Y()                     
    IL_0021: sub                                                                
    IL_0022: ldc.i4.2                                                           
    IL_0023: div                                                                
    IL_0024: stloc.0                                                            
    IL_0025: ldarg.0                                                            
    IL_0026: call instance int32 class OpenRA.CPos::get_X()                     
    IL_002b: ldarg.0                                                            
    IL_002c: call instance int32 class OpenRA.CPos::get_Y()                     
    IL_0031: add                                                                
    IL_0032: stloc.1                                                            
    IL_0033: ldloc.0                                                            
    IL_0034: ldloc.1                                                            
    IL_0035: newobj instance void class OpenRA.MPos::.ctor(int32, int32)        
    IL_003a: ret                                                                
  } // End of method OpenRA.MPos OpenRA.CPos::ToMPos(OpenRA.MapGridType) 
```