### PR TITLE
Group TerrainSpriteLayer cells by square bins instead of rows.

### DIFF
--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -165,8 +165,13 @@ namespace OpenRA.Graphics
 			nv += 6;
 		}
 
-		public void DrawVertexBuffer(IVertexBuffer<Vertex> buffer, int start, int length, PrimitiveType type, IEnumerable<Sheet> sheets, BlendMode blendMode)
+		internal void SetRenderStateForVertexBuffer(IVertexBuffer<Vertex> buffer, IEnumerable<Sheet> sheets, BlendMode blendMode)
 		{
+			renderer.CurrentBatchRenderer = this;
+			Flush();
+
+			currentBlend = blendMode;
+
 			var i = 0;
 			foreach (var s in sheets)
 			{
@@ -179,8 +184,7 @@ namespace OpenRA.Graphics
 
 			renderer.Context.SetBlendMode(blendMode);
 			shader.PrepareRender();
-			renderer.DrawBatch(buffer, start, length, type);
-			renderer.Context.SetBlendMode(BlendMode.None);
+			buffer.Bind();
 		}
 
 		// PERF: methods that throw won't be inlined by the JIT, so extract a static helper for use on hot paths

--- a/OpenRA.Mods.Cnc/Traits/World/TSVeinsRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSVeinsRenderer.cs
@@ -45,6 +45,9 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Actor types that should be treated as veins for adjacency.")]
 		public readonly HashSet<string> VeinholeActors = new HashSet<string> { };
 
+		[Desc("Size of the terrain layer partitions (cells)")]
+		public readonly int BinSize = 10;
+
 		public override object Create(ActorInitializer init) { return new TSVeinsRenderer(init.Self, this); }
 	}
 
@@ -133,7 +136,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			var first = veinSequence.GetSprite(0);
 			var emptySprite = new Sprite(first.Sheet, Rectangle.Empty, TextureChannel.Alpha);
-			spriteLayer = new TerrainSpriteLayer(w, wr, emptySprite, first.BlendMode, wr.World.Type != WorldType.Editor);
+			spriteLayer = new TerrainSpriteLayer(w, wr, info.BinSize, emptySprite, first.BlendMode, wr.World.Type != WorldType.Editor);
 
 			// Initialize the renderIndices with the initial map state so it is visible
 			// through the fog with the Explored Map option enabled

--- a/OpenRA.Mods.Common/Traits/World/BuildableTerrainOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/BuildableTerrainOverlay.cs
@@ -36,6 +36,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Custom opacity to apply to the overlay sprite.")]
 		public readonly float Alpha = 1f;
 
+		[Desc("Size of the terrain layer partitions (cells)")]
+		public readonly int BinSize = 10;
+
 		public override object Create(ActorInitializer init)
 		{
 			return new BuildableTerrainOverlay(init.Self, this);
@@ -65,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void IWorldLoaded.WorldLoaded(World w, WorldRenderer wr)
 		{
-			render = new TerrainSpriteLayer(w, wr, disabledSprite, BlendMode.Alpha, wr.World.Type != WorldType.Editor);
+			render = new TerrainSpriteLayer(w, wr, info.BinSize, disabledSprite, BlendMode.Alpha, wr.World.Type != WorldType.Editor);
 
 			world.Map.Tiles.CellEntryChanged += UpdateTerrainCell;
 			world.Map.CustomTerrain.CellEntryChanged += UpdateTerrainCell;

--- a/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
@@ -49,6 +49,9 @@ namespace OpenRA.Mods.Common.Traits
 		[FieldLoader.LoadUsing(nameof(LoadResourceTypes))]
 		public readonly Dictionary<string, ResourceTypeInfo> ResourceTypes = null;
 
+		[Desc("Size of the terrain layer partitions (cells)")]
+		public readonly int BinSize = 10;
+
 		// Copied from ResourceLayerInfo
 		protected static object LoadResourceTypes(MiniYaml yaml)
 		{
@@ -107,7 +110,7 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					var first = resourceVariants.First().Value.GetSprite(0);
 					var emptySprite = new Sprite(first.Sheet, Rectangle.Empty, TextureChannel.Alpha);
-					spriteLayer = new TerrainSpriteLayer(w, wr, emptySprite, first.BlendMode, wr.World.Type != WorldType.Editor);
+					spriteLayer = new TerrainSpriteLayer(w, wr, Info.BinSize, emptySprite, first.BlendMode, wr.World.Type != WorldType.Editor);
 				}
 
 				if (shadowLayer == null)
@@ -117,7 +120,7 @@ namespace OpenRA.Mods.Common.Traits
 					{
 						var first = firstWithShadow.GetShadow(0, WAngle.Zero);
 						var emptySprite = new Sprite(first.Sheet, Rectangle.Empty, TextureChannel.Alpha);
-						shadowLayer = new TerrainSpriteLayer(w, wr, emptySprite, first.BlendMode, wr.World.Type != WorldType.Editor);
+						shadowLayer = new TerrainSpriteLayer(w, wr, Info.BinSize, emptySprite, first.BlendMode, wr.World.Type != WorldType.Editor);
 					}
 				}
 

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -54,6 +54,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly int OverrideFogIndex = 15;
 
+		[Desc("Size of the terrain layer partitions (cells)")]
+		public readonly int BinSize = 10;
+
 		public readonly BlendMode ShroudBlend = BlendMode.Alpha;
 		public override object Create(ActorInitializer init) { return new ShroudRenderer(init.World, this); }
 	}
@@ -205,8 +208,8 @@ namespace OpenRA.Mods.Common.Traits
 			var emptySprite = new Sprite(shroudSprites[0].Sprite.Sheet, Rectangle.Empty, TextureChannel.Alpha);
 			shroudPaletteReference = wr.Palette(info.ShroudPalette);
 			fogPaletteReference = wr.Palette(info.FogPalette);
-			shroudLayer = new TerrainSpriteLayer(w, wr, emptySprite, shroudBlend, false);
-			fogLayer = new TerrainSpriteLayer(w, wr, emptySprite, fogBlend, false);
+			shroudLayer = new TerrainSpriteLayer(w, wr, info.BinSize, emptySprite, shroudBlend, false);
+			fogLayer = new TerrainSpriteLayer(w, wr, info.BinSize, emptySprite, fogBlend, false);
 
 			WorldOnRenderPlayerChanged(world.RenderPlayer);
 		}

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -53,6 +53,9 @@ namespace OpenRA.Mods.Common.Traits
 		[FieldLoader.LoadUsing(nameof(LoadInitialSmudges))]
 		public readonly Dictionary<CPos, MapSmudge> InitialSmudges;
 
+		[Desc("Size of the terrain layer partitions (cells)")]
+		public readonly int BinSize = 10;
+
 		public static object LoadInitialSmudges(MiniYaml yaml)
 		{
 			var nd = yaml.ToDictionary();
@@ -123,7 +126,7 @@ namespace OpenRA.Mods.Common.Traits
 					+ "Try using different smudge types for smudges that use different blend modes.");
 
 			paletteReference = wr.Palette(Info.Palette);
-			render = new TerrainSpriteLayer(w, wr, emptySprite, blendMode, w.Type != WorldType.Editor);
+			render = new TerrainSpriteLayer(w, wr, Info.BinSize, emptySprite, blendMode, w.Type != WorldType.Editor);
 
 			// Add map smudges
 			foreach (var kv in Info.InitialSmudges)

--- a/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
@@ -27,6 +27,9 @@ namespace OpenRA.Mods.D2k.Traits
 		[Desc("The hitpoints, which can be reduced by the DamagesConcreteWarhead.")]
 		public readonly int MaxStrength = 9000;
 
+		[Desc("Size of the terrain layer partitions (cells)")]
+		public readonly int BinSize = 10;
+
 		public override object Create(ActorInitializer init) { return new BuildableTerrainLayer(init.Self, this); }
 	}
 
@@ -52,7 +55,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 		void IWorldLoaded.WorldLoaded(World w, WorldRenderer wr)
 		{
-			render = new TerrainSpriteLayer(w, wr, terrainRenderer.MissingTile, BlendMode.Alpha, wr.World.Type != WorldType.Editor);
+			render = new TerrainSpriteLayer(w, wr, info.BinSize, terrainRenderer.MissingTile, BlendMode.Alpha, wr.World.Type != WorldType.Editor);
 			paletteReference = wr.Palette(info.Palette);
 		}
 


### PR DESCRIPTION
We were previously drawing the terrain (and terrain layers like resources) with a single draw call that rendered the full width of the map for the rows visible on screen. This PR changes the tile vertices from being stored in linear order to being grouped in 10x10 cell bins, and then using multiple draw calls to show just the bins that are visible. This saves us from unnecessarily rendering large parts of the map.

We've known for years that we should probably fix this some day, but I was completely astounded at just how big a performance gain I found.

Before:
<img src="https://user-images.githubusercontent.com/167819/126916902-bd05a26d-034b-4888-9a4c-2a13b8d293d7.png">

After:
<img src="https://user-images.githubusercontent.com/167819/126916911-dc382a90-fe16-4675-8c50-b6bba4d22c50.png">

I believe that this was a performance cliff that impacted my GPU specifically more than others - @penev92 only saw a ~20 FPS improvement when testing an earlier version of this branch, and I don't see any meaningful change on my Raspberry Pi 4.

In TS I am seeing a factor of 4-6 improvement, with some of the big maps that were struggling to reach 50 FPS on bleed now rendering at 200-300FPS with vsync disabled. In RA the improvement is "only" about a factor of two. While I expect that others may not see nearly as big of an improvement, it should still hopefully bring some level of improvement for everyone.