### PR TITLE
Add terrain orientation support for Mobile. 

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -900,6 +900,14 @@ namespace OpenRA
 			return new WDist(offset.Z);
 		}
 
+		public WRot TerrainOrientation(CPos cell)
+		{
+			if (!Ramp.Contains(cell))
+				return WRot.None;
+
+			return Grid.Ramps[Ramp[cell]].Orientation;
+		}
+
 		public WVec Offset(CVec delta, int dz)
 		{
 			if (Grid.Type == MapGridType.Rectangular)

--- a/OpenRA.Game/Map/MapGrid.cs
+++ b/OpenRA.Game/Map/MapGrid.cs
@@ -27,9 +27,11 @@ namespace OpenRA
 		public readonly int CenterHeightOffset;
 		public readonly WVec[] Corners;
 		public readonly WVec[][] Polygons;
+		public readonly WRot Orientation;
 
-		public CellRamp(MapGridType type, RampCornerHeight tl = RampCornerHeight.Low, RampCornerHeight tr = RampCornerHeight.Low, RampCornerHeight br = RampCornerHeight.Low,  RampCornerHeight bl = RampCornerHeight.Low, RampSplit split = RampSplit.Flat)
+		public CellRamp(MapGridType type, WRot orientation, RampCornerHeight tl = RampCornerHeight.Low, RampCornerHeight tr = RampCornerHeight.Low, RampCornerHeight br = RampCornerHeight.Low,  RampCornerHeight bl = RampCornerHeight.Low, RampSplit split = RampSplit.Flat)
 		{
+			Orientation = orientation;
 			if (type == MapGridType.RectangularIsometric)
 			{
 				Corners = new[]
@@ -138,41 +140,52 @@ namespace OpenRA
 					throw new InvalidDataException("Subcell default index must be a valid index into the offset triples and must be greater than 0 for mods with subcells");
 			}
 
+			// Rotation axes and amounts for the different slope types
+			var southEast = new WVec(724, 724, 0);
+			var southWest = new WVec(-724, 724, 0);
+			var south = new WVec(0, 1024, 0);
+			var east = new WVec(1024, 0, 0);
+
+			var forward = new WAngle(64);
+			var backward = -forward;
+			var halfForward = new WAngle(48);
+			var halfBackward = -halfForward;
+
 			// Slope types are hardcoded following the convention from the TS and RA2 map format
 			Ramps = new[]
 			{
 				// Flat
-				new CellRamp(Type),
+				new CellRamp(Type, WRot.None),
 
 				// Two adjacent corners raised by half a cell
-				new CellRamp(Type, tr: RampCornerHeight.Half, br: RampCornerHeight.Half),
-				new CellRamp(Type, br: RampCornerHeight.Half, bl: RampCornerHeight.Half),
-				new CellRamp(Type, tl: RampCornerHeight.Half, bl: RampCornerHeight.Half),
-				new CellRamp(Type, tl: RampCornerHeight.Half, tr: RampCornerHeight.Half),
+				new CellRamp(Type, new WRot(southEast, backward), tr: RampCornerHeight.Half, br: RampCornerHeight.Half),
+				new CellRamp(Type, new WRot(southWest, backward), br: RampCornerHeight.Half, bl: RampCornerHeight.Half),
+				new CellRamp(Type, new WRot(southEast, forward), tl: RampCornerHeight.Half, bl: RampCornerHeight.Half),
+				new CellRamp(Type, new WRot(southWest, forward), tl: RampCornerHeight.Half, tr: RampCornerHeight.Half),
 
 				// One corner raised by half a cell
-				new CellRamp(Type, br: RampCornerHeight.Half, split: RampSplit.X),
-				new CellRamp(Type, bl: RampCornerHeight.Half, split: RampSplit.Y),
-				new CellRamp(Type, tl: RampCornerHeight.Half, split: RampSplit.X),
-				new CellRamp(Type, tr: RampCornerHeight.Half, split: RampSplit.Y),
+				new CellRamp(Type, new WRot(south, halfBackward), br: RampCornerHeight.Half, split: RampSplit.X),
+				new CellRamp(Type, new WRot(east, halfForward), bl: RampCornerHeight.Half, split: RampSplit.Y),
+				new CellRamp(Type, new WRot(south, halfForward), tl: RampCornerHeight.Half, split: RampSplit.X),
+				new CellRamp(Type, new WRot(east, halfBackward), tr: RampCornerHeight.Half, split: RampSplit.Y),
 
 				// Three corners raised by half a cell
-				new CellRamp(Type, tr: RampCornerHeight.Half, br: RampCornerHeight.Half, bl: RampCornerHeight.Half, split: RampSplit.X),
-				new CellRamp(Type, tl: RampCornerHeight.Half, br: RampCornerHeight.Half, bl: RampCornerHeight.Half, split: RampSplit.Y),
-				new CellRamp(Type, tl: RampCornerHeight.Half, tr: RampCornerHeight.Half, bl: RampCornerHeight.Half, split: RampSplit.X),
-				new CellRamp(Type, tl: RampCornerHeight.Half, tr: RampCornerHeight.Half, br: RampCornerHeight.Half, split: RampSplit.Y),
+				new CellRamp(Type, new WRot(south, halfBackward), tr: RampCornerHeight.Half, br: RampCornerHeight.Half, bl: RampCornerHeight.Half, split: RampSplit.X),
+				new CellRamp(Type, new WRot(east, halfForward), tl: RampCornerHeight.Half, br: RampCornerHeight.Half, bl: RampCornerHeight.Half, split: RampSplit.Y),
+				new CellRamp(Type, new WRot(south, halfForward), tl: RampCornerHeight.Half, tr: RampCornerHeight.Half, bl: RampCornerHeight.Half, split: RampSplit.X),
+				new CellRamp(Type, new WRot(east, halfBackward), tl: RampCornerHeight.Half, tr: RampCornerHeight.Half, br: RampCornerHeight.Half, split: RampSplit.Y),
 
 				// Full tile sloped (mid corners raised by half cell, far corner by full cell)
-				new CellRamp(Type, tr: RampCornerHeight.Half, br: RampCornerHeight.Full, bl: RampCornerHeight.Half),
-				new CellRamp(Type, tl: RampCornerHeight.Half, br: RampCornerHeight.Half, bl: RampCornerHeight.Full),
-				new CellRamp(Type, tl: RampCornerHeight.Full, tr: RampCornerHeight.Half, bl: RampCornerHeight.Half),
-				new CellRamp(Type, tl: RampCornerHeight.Half, tr: RampCornerHeight.Full, br: RampCornerHeight.Half),
+				new CellRamp(Type, new WRot(south, backward), tr: RampCornerHeight.Half, br: RampCornerHeight.Full, bl: RampCornerHeight.Half),
+				new CellRamp(Type, new WRot(east, forward), tl: RampCornerHeight.Half, br: RampCornerHeight.Half, bl: RampCornerHeight.Full),
+				new CellRamp(Type, new WRot(south, forward), tl: RampCornerHeight.Full, tr: RampCornerHeight.Half, bl: RampCornerHeight.Half),
+				new CellRamp(Type, new WRot(east, backward), tl: RampCornerHeight.Half, tr: RampCornerHeight.Full, br: RampCornerHeight.Half),
 
 				// Two opposite corners raised by half a cell
-				new CellRamp(Type, tr: RampCornerHeight.Half, bl: RampCornerHeight.Half, split: RampSplit.Y),
-				new CellRamp(Type, tl: RampCornerHeight.Half, br: RampCornerHeight.Half, split: RampSplit.Y),
-				new CellRamp(Type, tr: RampCornerHeight.Half, bl: RampCornerHeight.Half, split: RampSplit.X),
-				new CellRamp(Type, tl: RampCornerHeight.Half, br: RampCornerHeight.Half, split: RampSplit.X),
+				new CellRamp(Type, WRot.None, tr: RampCornerHeight.Half, bl: RampCornerHeight.Half, split: RampSplit.Y),
+				new CellRamp(Type, WRot.None, tl: RampCornerHeight.Half, br: RampCornerHeight.Half, split: RampSplit.Y),
+				new CellRamp(Type, WRot.None, tr: RampCornerHeight.Half, bl: RampCornerHeight.Half, split: RampSplit.X),
+				new CellRamp(Type, WRot.None, tl: RampCornerHeight.Half, br: RampCornerHeight.Half, split: RampSplit.X),
 			};
 
 			TilesByDistance = CreateTilesByDistance();

--- a/OpenRA.Game/WRot.cs
+++ b/OpenRA.Game/WRot.cs
@@ -24,6 +24,9 @@ namespace OpenRA
 		// Internal calculations use the quaternion form
 		readonly int x, y, z, w;
 
+		/// <summary>
+		/// Construct a rotation from euler angles.
+		/// </summary>
 		public WRot(WAngle roll, WAngle pitch, WAngle yaw)
 		{
 			Roll = roll;
@@ -48,6 +51,21 @@ namespace OpenRA
 			w = (int)((cr * cp * cy + sr * sp * sy) / 1048576);
 		}
 
+		/// <summary>
+		/// Construct a rotation from an axis and angle.
+		/// The axis is expected to be normalized to length 1024
+		/// </summary>
+		public WRot(WVec axis, WAngle angle)
+		{
+			// Angles increase clockwise
+			x = axis.X * new WAngle(-angle.Angle / 2).Sin() / 1024;
+			y = axis.Y * new WAngle(-angle.Angle / 2).Sin() / 1024;
+			z = axis.Z * new WAngle(-angle.Angle / 2).Sin() / 1024;
+			w = new WAngle(-angle.Angle / 2).Cos();
+
+			(Roll, Pitch, Yaw) = QuaternionToEuler(x, y, z, w);
+		}
+
 		WRot(int x, int y, int z, int w)
 		{
 			this.x = x;
@@ -55,6 +73,11 @@ namespace OpenRA
 			this.z = z;
 			this.w = w;
 
+			(Roll, Pitch, Yaw) = QuaternionToEuler(x, y, z, w);
+		}
+
+		static (WAngle, WAngle, WAngle) QuaternionToEuler(int x, int y, int z, int w)
+		{
 			// Theoretically 1024 squared, but may differ slightly due to rounding
 			var lsq = x * x + y * y + z * z + w * w;
 
@@ -64,9 +87,11 @@ namespace OpenRA
 			var sycp = 2 * (w * z + x * y);
 			var cycp = lsq - 2 * (y * y + z * z);
 
-			Roll = -WAngle.ArcTan(srcp, crcp);
-			Pitch = -(Math.Abs(sp) >= 1024 ? new WAngle(Math.Sign(sp) * 256) : WAngle.ArcSin(sp));
-			Yaw = -WAngle.ArcTan(sycp, cycp);
+			var roll = -WAngle.ArcTan(srcp, crcp);
+			var pitch = -(Math.Abs(sp) >= 1024 ? new WAngle(Math.Sign(sp) * 256) : WAngle.ArcSin(sp));
+			var yaw = -WAngle.ArcTan(sycp, cycp);
+
+			return (roll, pitch, yaw);
 		}
 
 		WRot(int x, int y, int z, int w, WAngle roll, WAngle pitch, WAngle yaw)
@@ -168,5 +193,32 @@ namespace OpenRA
 		public override bool Equals(object obj) { return obj is WRot && Equals((WRot)obj); }
 
 		public override string ToString() { return Roll + "," + Pitch + "," + Yaw; }
+
+		public static WRot SLerp(in WRot a, in WRot b, int mul, int div)
+		{
+			// This implements the standard spherical linear interpolation
+			// between two quaternions, accounting for OpenRA's integer math
+			// conventions and WRot always using (nearly) normalized quaternions
+			var dot = a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
+			var flip = dot >= 0 ? 1 : -1;
+
+			// a and b describe the same rotation
+			if (flip * dot >= 1024 * 1024)
+				return a;
+
+			var theta = WAngle.ArcCos(dot / 1024);
+			var s1 = new WAngle((div - mul) * theta.Angle / div).Sin();
+			var s2 = new WAngle(mul * theta.Angle / div).Sin();
+			var s3 = theta.Sin();
+
+			var x = ((long)a.x * s1 + flip * b.x * s2) / s3;
+			var y = ((long)a.y * s1 + flip * b.y * s2) / s3;
+			var z = ((long)a.z * s1 + flip * b.z * s2) / s3;
+			var w = ((long)a.w * s1 + flip * b.w * s2) / s3;
+
+			// Normalize to 1024 == 1.0
+			var l = Exts.ISqrt(x * x + y * y + z * z + w * w);
+			return new WRot((int)(1024 * x / l), (int)(1024 * y / l), (int)(1024 * z / l), (int)(1024 * w / l));
+		}
 	}
 }

--- a/OpenRA.Mods.Common/Graphics/ModelRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/ModelRenderable.cs
@@ -189,7 +189,9 @@ namespace OpenRA.Mods.Common.Graphics
 
 				// Draw sprite rect
 				var offset = pxOrigin + renderProxy.Sprite.Offset - 0.5f * renderProxy.Sprite.Size;
-				Game.Renderer.WorldRgbaColorRenderer.DrawRect(offset.XY, (offset + renderProxy.Sprite.Size).XY, 1, Color.Red);
+				var tl = wr.Viewport.WorldToViewPx(offset.XY);
+				var br = wr.Viewport.WorldToViewPx((offset + renderProxy.Sprite.Size).XY);
+				Game.Renderer.RgbaColorRenderer.DrawRect(tl, br, 1, Color.Red);
 
 				// Draw transformed shadow sprite rect
 				var c = Color.Purple;

--- a/OpenRA.Mods.Common/Graphics/ModelRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/ModelRenderable.cs
@@ -133,8 +133,12 @@ namespace OpenRA.Mods.Common.Graphics
 				this.model = model;
 				var draw = model.models.Where(v => v.IsVisible);
 
+				var map = wr.World.Map;
+				var groundOrientation = map.TerrainOrientation(map.CellContaining(model.pos));
+				var groundNormal = OpenRA.Graphics.Util.MatrixVectorMultiply(OpenRA.Graphics.Util.MakeFloatMatrix(groundOrientation.AsMatrix()), GroundNormal);
+
 				renderProxy = Game.Renderer.WorldModelRenderer.RenderAsync(
-					wr, draw, model.camera, model.scale, GroundNormal, model.lightSource,
+					wr, draw, model.camera, model.scale, groundNormal, model.lightSource,
 					model.lightAmbientColor, model.lightDiffuseColor,
 					model.palette, model.normalsPalette, model.shadowPalette);
 			}

--- a/OpenRA.Mods.Common/Graphics/ModelRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/ModelRenderable.cs
@@ -116,8 +116,6 @@ namespace OpenRA.Mods.Common.Graphics
 				palette, normalsPalette, shadowPalette, alpha, newTint, newTintModifiers);
 		}
 
-		// This will need generalizing once we support TS/RA2 terrain
-		static readonly float[] GroundNormal = new float[] { 0, 0, 1, 1 };
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr)
 		{
 			return new FinalizedModelRenderable(wr, this);
@@ -135,10 +133,8 @@ namespace OpenRA.Mods.Common.Graphics
 
 				var map = wr.World.Map;
 				var groundOrientation = map.TerrainOrientation(map.CellContaining(model.pos));
-				var groundNormal = OpenRA.Graphics.Util.MatrixVectorMultiply(OpenRA.Graphics.Util.MakeFloatMatrix(groundOrientation.AsMatrix()), GroundNormal);
-
 				renderProxy = Game.Renderer.WorldModelRenderer.RenderAsync(
-					wr, draw, model.camera, model.scale, groundNormal, model.lightSource,
+					wr, draw, model.camera, model.scale, groundOrientation, model.lightSource,
 					model.lightAmbientColor, model.lightDiffuseColor,
 					model.palette, model.normalsPalette, model.shadowPalette);
 			}

--- a/OpenRA.Mods.Common/Graphics/UIModelRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/UIModelRenderable.cs
@@ -68,7 +68,6 @@ namespace OpenRA.Mods.Common.Graphics
 		public IRenderable OffsetBy(in WVec vec) { return this; }
 		public IRenderable AsDecoration() { return this; }
 
-		static readonly float[] GroundNormal = { 0, 0, 1, 1 };
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr)
 		{
 			return new FinalizedUIModelRenderable(wr, this);
@@ -85,7 +84,7 @@ namespace OpenRA.Mods.Common.Graphics
 				var draw = model.models.Where(v => v.IsVisible);
 
 				renderProxy = Game.Renderer.WorldModelRenderer.RenderAsync(
-					wr, draw, model.camera, model.scale, GroundNormal, model.lightSource,
+					wr, draw, model.camera, model.scale, WRot.None, model.lightSource,
 					model.lightAmbientColor, model.lightDiffuseColor,
 					model.palette, model.normalsPalette, model.shadowPalette);
 			}

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -780,6 +780,7 @@
 		Locomotor: wheeled
 		TurnSpeed: 20
 		Voice: Move
+		TerrainOrientationAdjustmentMargin: 256
 	Selectable:
 		Bounds: 1206, 1448
 	Voiced:

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -67,6 +67,7 @@ HVR:
 	Mobile:
 		Speed: 99
 		Locomotor: hover
+		TerrainOrientationAdjustmentMargin: -1
 	Selectable:
 		Bounds: 1206, 1448, 0, -603
 	Health:
@@ -123,6 +124,7 @@ SMECH:
 		TurnSpeed: 20
 		Speed: 99
 		AlwaysTurnInPlace: true
+		TerrainOrientationAdjustmentMargin: -1
 	Health:
 		HP: 17500
 	Armor:
@@ -176,6 +178,7 @@ MMCH:
 		TurnSpeed: 20
 		Speed: 56
 		AlwaysTurnInPlace: true
+		TerrainOrientationAdjustmentMargin: -1
 	Health:
 		HP: 40000
 	Armor:
@@ -341,6 +344,7 @@ JUGG:
 		AlwaysTurnInPlace: true
 		ImmovableCondition: !undeployed
 		RequireForceMoveCondition: !undeployed
+		TerrainOrientationAdjustmentMargin: -1
 	RevealsShroud:
 		RequiresCondition: !inside-tunnel
 		Range: 9c0


### PR DESCRIPTION
https://user-images.githubusercontent.com/167819/127195973-ce5257bd-18be-4283-8cbf-37109f9c307f.mov

This PR implements my loooooooong delayed plans for mobile units tilting on slopes. This is finally possible thanks to #19220 identifying and fixing the cause of the `Move.progress` glitches.

Fixes #9012.

This feature really highlighted the fundamental incompatibility between my original idea for calculating physically correct shadows and ts's terrain system. The shallow difference between the light source angle and the terrain slopes leads to very long shadows being cast for units on SE/NW slopes, which both looks awful and leads to a lot of clipping issues. The second commit works around this by placing the shadow light source at a fixed orientation relative to the ground plane instead of relative to the world. This works well enough for now, but I plan to eventually fix this and all the other shadow issues properly by replacing the "correct" shadow calculations with a much simpler algorithm that behaves more like the original game.

The third commit works around a visual glitch that kept on causing problems when making videos to show off the feature. I would be okay with dropping this if its considered too much of a hack, but as it is self contained and has no other side effects I think its worth keeping.