### PR TITLE
Added faction-specific units for colorpicker previews in TS

### DIFF
--- a/mods/ts/chrome/color-picker.yaml
+++ b/mods/ts/chrome/color-picker.yaml
@@ -4,29 +4,29 @@ Background@COLOR_CHOOSER:
 		PalettePresetRows: 2
 		PaletteCustomRows: 1
 	Background: dialog2
-	Width: 326
+	Width: 330
 	Height: 154
 	Children:
 		Button@RANDOM_BUTTON:
 			Key: tab
 			X: 245
 			Y: 95
-			Width: 76
+			Width: 80
 			Height: 25
 			Text: Random
 			Font: Bold
 		Button@STORE_BUTTON:
 			X: 245
 			Y: 124
-			Width: 76
+			Width: 80
 			Height: 25
 			Text: Store
 			Font: Bold
 		ActorPreview@PREVIEW:
-			X: 245
-			Y: 16
-			Width: 76
-			Height: 74
+			X: PARENT_RIGHT - 94
+			Y: 10
+			Width: 90
+			Height: 90
 			Animate: true
 		Button@MIXER_TAB_BUTTON:
 			X: 5
@@ -46,7 +46,7 @@ Background@COLOR_CHOOSER:
 			Background: dialog3
 			X: 5
 			Y: 5
-			Width: PARENT_RIGHT - 90
+			Width: PARENT_RIGHT - 94
 			Height: PARENT_BOTTOM - 34
 			Children:
 				ColorMixer@MIXER:
@@ -58,7 +58,7 @@ Background@COLOR_CHOOSER:
 			Background: dialog3
 			X: 5
 			Y: 5
-			Width: PARENT_RIGHT - 90
+			Width: PARENT_RIGHT - 94
 			Height: PARENT_BOTTOM - 34
 			Visible: false
 			Children:

--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -28,20 +28,32 @@ waypoint:
 	MapEditorData:
 		Categories: System
 
-mmch.colorpicker:
-	Inherits: MMCH
-	Mobile:
-		InitialFacing: 640
-	WithFacingSpriteBody:
-		Sequence: walk
+harv.colorpicker:
+	Inherits: HARV
 	-Buildable:
 	-MapEditorData:
 	RenderVoxels:
-		Image: mmch
+		Image: harv
 		Palette: colorpicker
-	RenderSprites:
-		Image: mmch
+		Scale: 18
+
+hvr.colorpicker:
+	Inherits: HVR
+	-Buildable:
+	-MapEditorData:
+	RenderVoxels:
+		Image: hvr
 		Palette: colorpicker
+		Scale: 18
+
+stnk.colorpicker:
+	Inherits: STNK
+	-Buildable:
+	-MapEditorData:
+	RenderVoxels:
+		Image: stnk
+		Palette: colorpicker
+		Scale: 18
 
 CAMERA:
 	Interactable:

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -381,7 +381,10 @@ World:
 	ScriptTriggers:
 	TimeLimitManager:
 	ColorPickerManager:
-		PreviewActor: mmch.colorpicker
+		PreviewActor: harv.colorpicker
+		FactionPreviewActors:
+			gdi: hvr.colorpicker
+			nod: stnk.colorpicker
 		PresetHues: 0, 0.125, 0.185, 0.4, 0.54, 0.66, 0.79, 0.875, 0, 0.14, 0.23, 0.43, 0.54, 0.625, 0.77, 0.85
 		PresetSaturations: 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.4, 0.5, 0.4, 0.5, 0.4, 0.5, 0.4, 0.5
 	OrderEffects:


### PR DESCRIPTION
Requested by @VonNah  on Discord and also showcases a feature the engine has but we don't use anywhere.