### PR TITLE
Video refactor

### DIFF
--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -124,7 +124,6 @@ namespace OpenRA
 
 	public interface ITexture : IDisposable
 	{
-		void SetData(uint[,] colors);
 		void SetData(byte[] colors, int width, int height);
 		void SetFloatData(float[] data, int width, int height);
 		byte[] GetData();

--- a/OpenRA.Game/Graphics/Video.cs
+++ b/OpenRA.Game/Graphics/Video.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Video
 		/// Current frame color data in 32-bit BGRA.
 		/// </summary>
 		byte[] CurrentFrameData { get; }
-		int CurrentFrameNumber { get; }
+		int CurrentFrameIndex { get; }
 		void AdvanceFrame();
 
 		bool HasAudio { get; }

--- a/OpenRA.Game/Graphics/Video.cs
+++ b/OpenRA.Game/Graphics/Video.cs
@@ -13,13 +13,16 @@ namespace OpenRA.Video
 {
 	public interface IVideo
 	{
-		ushort Frames { get; }
+		ushort FrameCount { get; }
 		byte Framerate { get; }
 		ushort Width { get; }
 		ushort Height { get; }
-		uint[,] FrameData { get; }
 
-		int CurrentFrame { get; }
+		/// <summary>
+		/// Current frame color data in 32-bit BGRA.
+		/// </summary>
+		uint[,] CurrentFrameData { get; }
+		int CurrentFrameNumber { get; }
 		void AdvanceFrame();
 
 		bool HasAudio { get; }

--- a/OpenRA.Game/Graphics/Video.cs
+++ b/OpenRA.Game/Graphics/Video.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Video
 		/// <summary>
 		/// Current frame color data in 32-bit BGRA.
 		/// </summary>
-		uint[,] CurrentFrameData { get; }
+		byte[] CurrentFrameData { get; }
 		int CurrentFrameNumber { get; }
 		void AdvanceFrame();
 

--- a/OpenRA.Game/Graphics/VideoLoader.cs
+++ b/OpenRA.Game/Graphics/VideoLoader.cs
@@ -15,15 +15,15 @@ namespace OpenRA.Video
 {
 	public interface IVideoLoader
 	{
-		bool TryParseVideo(Stream s, out IVideo video);
+		bool TryParseVideo(Stream s, bool useFramePadding, out IVideo video);
 	}
 
 	public static class VideoLoader
 	{
-		public static IVideo GetVideo(Stream stream, IVideoLoader[] loaders)
+		public static IVideo GetVideo(Stream stream, bool useFramePadding, IVideoLoader[] loaders)
 		{
 			foreach (var loader in loaders)
-				if (loader.TryParseVideo(stream, out var video))
+				if (loader.TryParseVideo(stream, useFramePadding, out var video))
 					return video;
 
 			return null;

--- a/OpenRA.Mods.Cnc/FileFormats/VqaReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/VqaReader.cs
@@ -18,29 +18,38 @@ namespace OpenRA.Mods.Cnc.FileFormats
 {
 	public class VqaReader : IVideo
 	{
-		public ushort Frames => frames;
-		public byte Framerate => framerate;
-		public ushort Width => width;
-		public ushort Height => height;
+		public ushort FrameCount { get; }
+		public byte Framerate { get; }
+		public ushort Width { get; }
+		public ushort Height { get; }
 
-		readonly ushort frames;
-		readonly byte framerate;
-		readonly ushort width;
-		readonly ushort height;
+		public int CurrentFrameNumber { get; private set; }
+		public uint[,] CurrentFrameData
+		{
+			get
+			{
+				if (cachedFrameNumber != CurrentFrameNumber)
+					DecodeFrameData();
 
-		Stream stream;
-		int currentFrame;
-		ushort numColors;
-		ushort blockWidth;
-		ushort blockHeight;
-		byte chunkBufferParts;
-		int2 blocks;
-		uint[] offsets;
-		uint[] palette;
-		uint videoFlags; // if 0x10 is set the video is a 16 bit hq video (ts and later)
-		int sampleRate;
-		int sampleBits;
-		int audioChannels;
+				return cachedCurrentFrameData;
+			}
+		}
+
+		public bool HasAudio { get; set; }
+		public byte[] AudioData { get; private set; } // audio for this frame: 22050Hz 16bit mono pcm, uncompressed.
+		public int AudioChannels { get; }
+		public int SampleBits { get; }
+		public int SampleRate { get; }
+
+		readonly Stream stream;
+		readonly ushort numColors;
+		readonly ushort blockWidth;
+		readonly ushort blockHeight;
+		readonly byte chunkBufferParts;
+		readonly int2 blocks;
+		readonly uint[] offsets;
+		readonly uint[] palette;
+		readonly uint videoFlags; // if 0x10 is set the video is a 16 bit hq video (ts and later)
 
 		// Stores a list of subpixels, referenced by the VPTZ chunk
 		byte[] cbf;
@@ -60,17 +69,8 @@ namespace OpenRA.Mods.Cnc.FileFormats
 		// Top half contains block info, bottom half contains references to cbf array
 		byte[] origData;
 
-		// Final frame output
-		uint[,] frameData;
-		byte[] audioData;		// audio for this frame: 22050Hz 16bit mono pcm, uncompressed.
-		bool hasAudio;
-
-		public byte[] AudioData => audioData;
-		public int CurrentFrame => currentFrame;
-		public int SampleRate => sampleRate;
-		public int SampleBits => sampleBits;
-		public int AudioChannels => audioChannels;
-		public bool HasAudio => hasAudio;
+		int cachedFrameNumber = -1;
+		uint[,] cachedCurrentFrameData;
 
 		public VqaReader(Stream stream)
 		{
@@ -87,15 +87,15 @@ namespace OpenRA.Mods.Cnc.FileFormats
 
 			/*var version = */stream.ReadUInt16();
 			videoFlags = stream.ReadUInt16();
-			frames = stream.ReadUInt16();
-			width = stream.ReadUInt16();
-			height = stream.ReadUInt16();
+			FrameCount = stream.ReadUInt16();
+			Width = stream.ReadUInt16();
+			Height = stream.ReadUInt16();
 
 			blockWidth = stream.ReadUInt8();
 			blockHeight = stream.ReadUInt8();
-			framerate = stream.ReadUInt8();
+			Framerate = stream.ReadUInt8();
 			chunkBufferParts = stream.ReadUInt8();
-			blocks = new int2(width / blockWidth, height / blockHeight);
+			blocks = new int2(Width / blockWidth, Height / blockHeight);
 
 			numColors = stream.ReadUInt16();
 			/*var maxBlocks = */stream.ReadUInt16();
@@ -103,9 +103,9 @@ namespace OpenRA.Mods.Cnc.FileFormats
 			/*var unknown2 = */stream.ReadUInt32();
 
 			// Audio
-			sampleRate = stream.ReadUInt16();
-			audioChannels = stream.ReadByte();
-			sampleBits = stream.ReadByte();
+			SampleRate = stream.ReadUInt16();
+			AudioChannels = stream.ReadByte();
+			SampleBits = stream.ReadByte();
 
 			/*var unknown3 =*/stream.ReadUInt32();
 			/*var unknown4 =*/stream.ReadUInt16();
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 
 			/*var unknown5 =*/stream.ReadUInt32();
 
-			var frameSize = Exts.NextPowerOf2(Math.Max(width, height));
+			var frameSize = Exts.NextPowerOf2(Math.Max(Width, Height));
 
 			if (IsHqVqa)
 			{
@@ -123,14 +123,14 @@ namespace OpenRA.Mods.Cnc.FileFormats
 			}
 			else
 			{
-				cbfBuffer = new byte[width * height];
-				cbf = new byte[width * height];
-				cbp = new byte[width * height];
+				cbfBuffer = new byte[Width * Height];
+				cbf = new byte[Width * Height];
+				cbp = new byte[Width * Height];
 				origData = new byte[2 * blocks.X * blocks.Y];
 			}
 
 			palette = new uint[numColors];
-			frameData = new uint[frameSize, frameSize];
+			cachedCurrentFrameData = new uint[frameSize, frameSize];
 			var type = stream.ReadASCII(4);
 			while (type != "FINF")
 			{
@@ -149,8 +149,8 @@ namespace OpenRA.Mods.Cnc.FileFormats
 			/*var unknown4 = */stream.ReadUInt16();
 
 			// Frame offsets
-			offsets = new uint[frames];
-			for (var i = 0; i < frames; i++)
+			offsets = new uint[FrameCount];
+			for (var i = 0; i < FrameCount; i++)
 			{
 				offsets[i] = stream.ReadUInt32();
 				if (offsets[i] > 0x40000000)
@@ -165,7 +165,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 
 		public void Reset()
 		{
-			currentFrame = chunkBufferOffset = currentChunkBuffer = 0;
+			CurrentFrameNumber = chunkBufferOffset = currentChunkBuffer = 0;
 			LoadFrame();
 		}
 
@@ -175,10 +175,10 @@ namespace OpenRA.Mods.Cnc.FileFormats
 			var audio2 = new MemoryStream(); // right channel
 			var adpcmIndex = 0;
 			var compressed = false;
-			for (var i = 0; i < frames; i++)
+			for (var i = 0; i < FrameCount; i++)
 			{
 				stream.Seek(offsets[i], SeekOrigin.Begin);
-				var end = (i < frames - 1) ? offsets[i + 1] : stream.Length;
+				var end = (i < FrameCount - 1) ? offsets[i + 1] : stream.Length;
 
 				while (stream.Position < end)
 				{
@@ -196,9 +196,9 @@ namespace OpenRA.Mods.Cnc.FileFormats
 					{
 						case "SND0":
 						case "SND2":
-							if (audioChannels == 0)
+							if (AudioChannels == 0)
 								throw new NotSupportedException();
-							else if (audioChannels == 1)
+							else if (AudioChannels == 1)
 							{
 								var rawAudio = stream.ReadBytes((int)length);
 								audio1.WriteArray(rawAudio);
@@ -227,8 +227,8 @@ namespace OpenRA.Mods.Cnc.FileFormats
 				}
 			}
 
-			if (audioChannels == 1)
-				audioData = compressed ? ImaAdpcmReader.LoadImaAdpcmSound(audio1.ToArray(), ref adpcmIndex) : audio1.ToArray();
+			if (AudioChannels == 1)
+				AudioData = compressed ? ImaAdpcmReader.LoadImaAdpcmSound(audio1.ToArray(), ref adpcmIndex) : audio1.ToArray();
 			else
 			{
 				byte[] leftData, rightData;
@@ -245,40 +245,40 @@ namespace OpenRA.Mods.Cnc.FileFormats
 					rightData = ImaAdpcmReader.LoadImaAdpcmSound(audio2.ToArray(), ref adpcmIndex);
 				}
 
-				audioData = new byte[rightData.Length + leftData.Length];
+				AudioData = new byte[rightData.Length + leftData.Length];
 				var rightIndex = 0;
 				var leftIndex = 0;
-				for (var i = 0; i < audioData.Length;)
+				for (var i = 0; i < AudioData.Length;)
 				{
-					audioData[i++] = leftData[leftIndex++];
-					audioData[i++] = leftData[leftIndex++];
-					audioData[i++] = rightData[rightIndex++];
-					audioData[i++] = rightData[rightIndex++];
+					AudioData[i++] = leftData[leftIndex++];
+					AudioData[i++] = leftData[leftIndex++];
+					AudioData[i++] = rightData[rightIndex++];
+					AudioData[i++] = rightData[rightIndex++];
 				}
 			}
 
-			hasAudio = audioData.Length > 0;
+			HasAudio = AudioData.Length > 0;
 		}
 
 		public void AdvanceFrame()
 		{
-			currentFrame++;
+			CurrentFrameNumber++;
 			LoadFrame();
 		}
 
 		void LoadFrame()
 		{
-			if (currentFrame >= frames)
+			if (CurrentFrameNumber >= FrameCount)
 				return;
 
 			// Seek to the start of the frame
-			stream.Seek(offsets[currentFrame], SeekOrigin.Begin);
-			var end = (currentFrame < frames - 1) ? offsets[currentFrame + 1] : stream.Length;
+			stream.Seek(offsets[CurrentFrameNumber], SeekOrigin.Begin);
+			var end = (CurrentFrameNumber < FrameCount - 1) ? offsets[CurrentFrameNumber + 1] : stream.Length;
 
 			while (stream.Position < end)
 			{
 				var type = stream.ReadASCII(4);
-				var length = 0U;
+				uint length;
 				if (type == "SN2J")
 				{
 					var jmp = int2.Swap(stream.ReadUInt32());
@@ -425,11 +425,9 @@ namespace OpenRA.Mods.Cnc.FileFormats
 			}
 		}
 
-		int cachedFrame = -1;
-
 		void DecodeFrameData()
 		{
-			cachedFrame = currentFrame;
+			cachedFrameNumber = CurrentFrameNumber;
 			if (IsHqVqa)
 			{
 				/* The VP?? chunks of the video file contains an array of instructions for
@@ -494,22 +492,11 @@ namespace OpenRA.Mods.Cnc.FileFormats
 							{
 								var cbfi = (mod * 256 + px) * 8 + j * blockWidth + i;
 								var color = (mod == 0x0f) ? px : cbf[cbfi];
-								frameData[y * blockHeight + j, x * blockWidth + i] = palette[color];
+								cachedCurrentFrameData[y * blockHeight + j, x * blockWidth + i] = palette[color];
 							}
 						}
 					}
 				}
-			}
-		}
-
-		public uint[,] FrameData
-		{
-			get
-			{
-				if (cachedFrame != currentFrame)
-					DecodeFrameData();
-
-				return frameData;
 			}
 		}
 
@@ -527,7 +514,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 					{
 						var p = (bx + by * blockWidth) * 3;
 
-						frameData[frameY + by, frameX + bx] = (uint)(0xFF << 24 | cbf[offset + p] << 16 | cbf[offset + p + 1] << 8 | cbf[offset + p + 2]);
+						cachedCurrentFrameData[frameY + by, frameX + bx] = (uint)(0xFF << 24 | cbf[offset + p] << 16 | cbf[offset + p + 1] << 8 | cbf[offset + p + 2]);
 					}
 
 				x++;

--- a/OpenRA.Mods.Cnc/FileFormats/VqaVideo.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/VqaVideo.cs
@@ -16,7 +16,7 @@ using OpenRA.Video;
 
 namespace OpenRA.Mods.Cnc.FileFormats
 {
-	public class VqaReader : IVideo
+	public class VqaVideo : IVideo
 	{
 		public ushort FrameCount { get; }
 		public byte Framerate { get; }
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 		// Top half contains block info, bottom half contains references to cbf array
 		byte[] origData;
 
-		public VqaReader(Stream stream, bool useFramePadding)
+		public VqaVideo(Stream stream, bool useFramePadding)
 		{
 			this.stream = stream;
 

--- a/OpenRA.Mods.Cnc/FileFormats/VqaVideo.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/VqaVideo.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 		public ushort Height { get; }
 
 		public byte[] CurrentFrameData { get; }
-		public int CurrentFrameNumber { get; private set; }
+		public int CurrentFrameIndex { get; private set; }
 
 		public bool HasAudio { get; set; }
 		public byte[] AudioData { get; private set; } // audio for this frame: 22050Hz 16bit mono pcm, uncompressed.
@@ -163,7 +163,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 
 		public void Reset()
 		{
-			CurrentFrameNumber = chunkBufferOffset = currentChunkBuffer = 0;
+			CurrentFrameIndex = chunkBufferOffset = currentChunkBuffer = 0;
 			LoadFrame();
 		}
 
@@ -260,18 +260,18 @@ namespace OpenRA.Mods.Cnc.FileFormats
 
 		public void AdvanceFrame()
 		{
-			CurrentFrameNumber++;
+			CurrentFrameIndex++;
 			LoadFrame();
 		}
 
 		void LoadFrame()
 		{
-			if (CurrentFrameNumber >= FrameCount)
+			if (CurrentFrameIndex >= FrameCount)
 				return;
 
 			// Seek to the start of the frame
-			stream.Seek(offsets[CurrentFrameNumber], SeekOrigin.Begin);
-			var end = (CurrentFrameNumber < FrameCount - 1) ? offsets[CurrentFrameNumber + 1] : stream.Length;
+			stream.Seek(offsets[CurrentFrameIndex], SeekOrigin.Begin);
+			var end = (CurrentFrameIndex < FrameCount - 1) ? offsets[CurrentFrameIndex + 1] : stream.Length;
 
 			while (stream.Position < end)
 			{

--- a/OpenRA.Mods.Cnc/FileFormats/WsaReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/WsaReader.cs
@@ -22,17 +22,8 @@ namespace OpenRA.Mods.Cnc.FileFormats
 		public ushort Width { get; }
 		public ushort Height { get; }
 
+		public uint[,] CurrentFrameData { get; }
 		public int CurrentFrameNumber { get; private set; }
-		public uint[,] CurrentFrameData
-		{
-			get
-			{
-				if (cachedFrameNumber != CurrentFrameNumber)
-					LoadFrame();
-
-				return cachedCurrentFrameData;
-			}
-		}
 
 		public bool HasAudio => false;
 		public byte[] AudioData => null;
@@ -46,9 +37,6 @@ namespace OpenRA.Mods.Cnc.FileFormats
 
 		byte[] previousFramePaletteIndexData;
 		byte[] currentFramePaletteIndexData;
-
-		int cachedFrameNumber = -1;
-		uint[,] cachedCurrentFrameData;
 
 		public WsaReader(Stream stream)
 		{
@@ -89,6 +77,9 @@ namespace OpenRA.Mods.Cnc.FileFormats
 				for (var i = 0; i < frameOffsets.Length; i++)
 					frameOffsets[i] += 768;
 			}
+
+			var frameSize = Exts.NextPowerOf2(Math.Max(Width, Height));
+			CurrentFrameData = new uint[frameSize, frameSize];
 
 			Reset();
 		}
@@ -132,11 +123,9 @@ namespace OpenRA.Mods.Cnc.FileFormats
 			XORDeltaCompression.DecodeInto(intermediateData, currentFramePaletteIndexData, 0);
 
 			var c = 0;
-			var frameSize = Exts.NextPowerOf2(Math.Max(Width, Height));
-			cachedCurrentFrameData = new uint[frameSize, frameSize];
 			for (var y = 0; y < Height; y++)
 				for (var x = 0; x < Width; x++)
-					cachedCurrentFrameData[y, x] = palette[currentFramePaletteIndexData[c++]];
+					CurrentFrameData[y, x] = palette[currentFramePaletteIndexData[c++]];
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/FileFormats/WsaReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/WsaReader.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 		public ushort Width { get; }
 		public ushort Height { get; }
 
-		public uint[,] CurrentFrameData { get; }
+		public byte[] CurrentFrameData { get; }
 		public int CurrentFrameNumber { get; private set; }
 
 		public bool HasAudio => false;
@@ -78,8 +78,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 					frameOffsets[i] += 768;
 			}
 
-			var frameSize = Exts.NextPowerOf2(Math.Max(Width, Height));
-			CurrentFrameData = new uint[frameSize, frameSize];
+			CurrentFrameData = new byte[Width * Height * 4];
 
 			Reset();
 		}
@@ -123,9 +122,18 @@ namespace OpenRA.Mods.Cnc.FileFormats
 			XORDeltaCompression.DecodeInto(intermediateData, currentFramePaletteIndexData, 0);
 
 			var c = 0;
+			var position = 0;
 			for (var y = 0; y < Height; y++)
+			{
 				for (var x = 0; x < Width; x++)
-					CurrentFrameData[y, x] = palette[currentFramePaletteIndexData[c++]];
+				{
+					var color = palette[currentFramePaletteIndexData[c++]];
+					CurrentFrameData[position++] = (byte)(color & 0xFF);
+					CurrentFrameData[position++] = (byte)(color >> 8 & 0xFF);
+					CurrentFrameData[position++] = (byte)(color >> 16 & 0xFF);
+					CurrentFrameData[position++] = (byte)(color >> 24 & 0xFF);
+				}
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/FileFormats/WsaVideo.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/WsaVideo.cs
@@ -15,7 +15,7 @@ using OpenRA.Video;
 
 namespace OpenRA.Mods.Cnc.FileFormats
 {
-	public class WsaReader : IVideo
+	public class WsaVideo : IVideo
 	{
 		public ushort FrameCount { get; }
 		public byte Framerate => 1;
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 		byte[] previousFramePaletteIndexData;
 		byte[] currentFramePaletteIndexData;
 
-		public WsaReader(Stream stream, bool useFramePadding)
+		public WsaVideo(Stream stream, bool useFramePadding)
 		{
 			this.stream = stream;
 

--- a/OpenRA.Mods.Cnc/FileFormats/WsaVideo.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/WsaVideo.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 		public ushort Height { get; }
 
 		public byte[] CurrentFrameData { get; }
-		public int CurrentFrameNumber { get; private set; }
+		public int CurrentFrameIndex { get; private set; }
 
 		public bool HasAudio => false;
 		public byte[] AudioData => null;
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 
 		public void Reset()
 		{
-			CurrentFrameNumber = 0;
+			CurrentFrameIndex = 0;
 			previousFramePaletteIndexData = null;
 			LoadFrame();
 		}
@@ -107,18 +107,18 @@ namespace OpenRA.Mods.Cnc.FileFormats
 		public void AdvanceFrame()
 		{
 			previousFramePaletteIndexData = currentFramePaletteIndexData;
-			CurrentFrameNumber++;
+			CurrentFrameIndex++;
 			LoadFrame();
 		}
 
 		void LoadFrame()
 		{
-			if (CurrentFrameNumber >= FrameCount)
+			if (CurrentFrameIndex >= FrameCount)
 				return;
 
-			stream.Seek(frameOffsets[CurrentFrameNumber], SeekOrigin.Begin);
+			stream.Seek(frameOffsets[CurrentFrameIndex], SeekOrigin.Begin);
 
-			var dataLength = frameOffsets[CurrentFrameNumber + 1] - frameOffsets[CurrentFrameNumber];
+			var dataLength = frameOffsets[CurrentFrameIndex + 1] - frameOffsets[CurrentFrameIndex];
 
 			var rawData = StreamExts.ReadBytes(stream, (int)dataLength);
 			var intermediateData = new byte[Width * Height];

--- a/OpenRA.Mods.Cnc/VideoLoaders/VqaLoader.cs
+++ b/OpenRA.Mods.Cnc/VideoLoaders/VqaLoader.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Cnc.VideoLoaders
 			if (!IsWestwoodVqa(s))
 				return false;
 
-			video = new VqaReader(s, useFramePadding);
+			video = new VqaVideo(s, useFramePadding);
 			return true;
 		}
 

--- a/OpenRA.Mods.Cnc/VideoLoaders/VqaLoader.cs
+++ b/OpenRA.Mods.Cnc/VideoLoaders/VqaLoader.cs
@@ -17,14 +17,14 @@ namespace OpenRA.Mods.Cnc.VideoLoaders
 {
 	public class VqaLoader : IVideoLoader
 	{
-		public bool TryParseVideo(Stream s, out IVideo video)
+		public bool TryParseVideo(Stream s, bool useFramePadding, out IVideo video)
 		{
 			video = null;
 
 			if (!IsWestwoodVqa(s))
 				return false;
 
-			video = new VqaReader(s);
+			video = new VqaReader(s, useFramePadding);
 			return true;
 		}
 

--- a/OpenRA.Mods.Cnc/VideoLoaders/WsaLoader.cs
+++ b/OpenRA.Mods.Cnc/VideoLoaders/WsaLoader.cs
@@ -18,14 +18,14 @@ namespace OpenRA.Mods.Cnc.VideoLoaders
 {
 	public class WsaLoader : IVideoLoader
 	{
-		public bool TryParseVideo(Stream s, out IVideo video)
+		public bool TryParseVideo(Stream s, bool useFramePadding, out IVideo video)
 		{
 			video = null;
 
 			if (!IsWsa(s))
 				return false;
 
-			video = new WsaReader(s);
+			video = new WsaReader(s, useFramePadding);
 			return true;
 		}
 

--- a/OpenRA.Mods.Cnc/VideoLoaders/WsaLoader.cs
+++ b/OpenRA.Mods.Cnc/VideoLoaders/WsaLoader.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Cnc.VideoLoaders
 			if (!IsWsa(s))
 				return false;
 
-			video = new WsaReader(s, useFramePadding);
+			video = new WsaVideo(s, useFramePadding);
 			return true;
 		}
 

--- a/OpenRA.Mods.Common/Scripting/Media.cs
+++ b/OpenRA.Mods.Common/Scripting/Media.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Scripting
 
 		public static IVideo LoadVideo(Stream s)
 		{
-			return VideoLoader.GetVideo(s, Game.ModData.VideoLoaders);
+			return VideoLoader.GetVideo(s, true, Game.ModData.VideoLoaders);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -506,7 +506,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					// Mute music so it doesn't interfere with the current asset.
 					MuteSounds();
 
-					var video = VideoLoader.GetVideo(Game.ModData.DefaultFileSystem.Open(filename), Game.ModData.VideoLoaders);
+					var video = VideoLoader.GetVideo(Game.ModData.DefaultFileSystem.Open(filename), true, Game.ModData.VideoLoaders);
 					if (video != null)
 					{
 						player = panel.Get<VideoPlayerWidget>("PLAYER");

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -165,7 +165,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var frameContainer = panel.GetOrNull("FRAME_SELECTOR");
 			if (frameContainer != null)
 				frameContainer.IsVisible = () => (currentSprites != null && currentSprites.Length > 1) ||
-					(isVideoLoaded && player != null && player.Video != null && player.Video.Frames > 1) ||
+					(isVideoLoaded && player != null && player.Video != null && player.Video.FrameCount > 1) ||
 					currentSoundFormat != null;
 
 			frameSlider = panel.GetOrNull<SliderWidget>("FRAME_SLIDER");
@@ -180,7 +180,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				frameSlider.GetValue = () =>
 				{
 					if (isVideoLoaded)
-						return player.Video.CurrentFrame;
+						return player.Video.CurrentFrameNumber;
 
 					if (currentSound != null)
 						return currentSound.SeekPosition * currentSoundFormat.SampleRate;
@@ -197,7 +197,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				frameText.GetText = () =>
 				{
 					if (isVideoLoaded)
-						return $"{player.Video.CurrentFrame + 1} / {player.Video.Frames}";
+						return $"{player.Video.CurrentFrameNumber + 1} / {player.Video.FrameCount}";
 
 					if (currentSoundFormat != null)
 						return $"{Math.Round(currentSoundFormat.LengthInSeconds, 3)} sec";
@@ -516,7 +516,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 						if (frameSlider != null)
 						{
-							frameSlider.MaximumValue = (float)player.Video.Frames - 1;
+							frameSlider.MaximumValue = (float)player.Video.FrameCount - 1;
 							frameSlider.Ticks = 0;
 						}
 					}

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -180,7 +180,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				frameSlider.GetValue = () =>
 				{
 					if (isVideoLoaded)
-						return player.Video.CurrentFrameNumber;
+						return player.Video.CurrentFrameIndex;
 
 					if (currentSound != null)
 						return currentSound.SeekPosition * currentSoundFormat.SampleRate;
@@ -197,7 +197,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				frameText.GetText = () =>
 				{
 					if (isVideoLoaded)
-						return $"{player.Video.CurrentFrameNumber + 1} / {player.Video.FrameCount}";
+						return $"{player.Video.CurrentFrameIndex + 1} / {player.Video.FrameCount}";
 
 					if (currentSoundFormat != null)
 						return $"{Math.Round(currentSoundFormat.LengthInSeconds, 3)} sec";

--- a/OpenRA.Mods.Common/Widgets/VideoPlayerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/VideoPlayerWidget.cs
@@ -37,6 +37,7 @@ namespace OpenRA.Mods.Common.Widgets
 		float overlayScale;
 		bool stopped;
 		bool paused;
+		int textureSize;
 
 		Action onComplete;
 
@@ -45,7 +46,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (filename == cachedVideo)
 				return;
 
-			var video = VideoLoader.GetVideo(Game.ModData.DefaultFileSystem.Open(filename), Game.ModData.VideoLoaders);
+			var video = VideoLoader.GetVideo(Game.ModData.DefaultFileSystem.Open(filename), true, Game.ModData.VideoLoaders);
 			Open(video);
 
 			cachedVideo = filename;
@@ -63,11 +64,11 @@ namespace OpenRA.Mods.Common.Widgets
 			invLength = video.Framerate * 1f / video.FrameCount;
 
 			var size = Math.Max(video.Width, video.Height);
-			var textureSize = Exts.NextPowerOf2(size);
+			textureSize = Exts.NextPowerOf2(size);
 			var videoSheet = new Sheet(SheetType.BGRA, new Size(textureSize, textureSize));
 
 			videoSheet.GetTexture().ScaleFilter = TextureScaleFilter.Linear;
-			videoSheet.GetTexture().SetData(video.CurrentFrameData);
+			videoSheet.GetTexture().SetData(video.CurrentFrameData, textureSize, textureSize);
 
 			videoSprite = new Sprite(videoSheet,
 				new Rectangle(
@@ -110,12 +111,12 @@ namespace OpenRA.Mods.Common.Widgets
 				while (nextFrame > video.CurrentFrameNumber)
 				{
 					video.AdvanceFrame();
-					videoSprite.Sheet.GetTexture().SetData(video.CurrentFrameData);
+					videoSprite.Sheet.GetTexture().SetData(video.CurrentFrameData, textureSize, textureSize);
 					skippedFrames++;
 				}
 
 				if (skippedFrames > 1)
-					Log.Write("perf", "VqaPlayer : {0} skipped {1} frames at position {2}", cachedVideo, skippedFrames, video.CurrentFrameNumber);
+					Log.Write("perf", "VideoPlayer: {0} skipped {1} frames at position {2}", cachedVideo, skippedFrames, video.CurrentFrameNumber);
 			}
 
 			WidgetUtils.DrawSprite(videoSprite, videoOrigin, videoSize);
@@ -218,7 +219,7 @@ namespace OpenRA.Mods.Common.Widgets
 			paused = true;
 			Game.Sound.StopVideo();
 			video.Reset();
-			videoSprite.Sheet.GetTexture().SetData(video.CurrentFrameData);
+			videoSprite.Sheet.GetTexture().SetData(video.CurrentFrameData, textureSize, textureSize);
 			Game.RunAfterTick(onComplete);
 		}
 

--- a/OpenRA.Mods.Common/Widgets/VideoPlayerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/VideoPlayerWidget.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Widgets
 		Sprite videoSprite, overlaySprite;
 		Sheet overlaySheet;
 		IVideo video = null;
-		string cachedVideo;
+		string cachedVideoFileName;
 		float invLength;
 		float2 videoOrigin, videoSize;
 		float2 overlayOrigin, overlaySize;
@@ -43,13 +43,13 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public void Load(string filename)
 		{
-			if (filename == cachedVideo)
+			if (filename == cachedVideoFileName)
 				return;
 
 			var video = VideoLoader.GetVideo(Game.ModData.DefaultFileSystem.Open(filename), true, Game.ModData.VideoLoaders);
 			Open(video);
 
-			cachedVideo = filename;
+			cachedVideoFileName = filename;
 		}
 
 		public void Open(IVideo video)
@@ -98,17 +98,17 @@ namespace OpenRA.Mods.Common.Widgets
 				if (video.HasAudio && !Game.Sound.DummyEngine)
 					nextFrame = (int)float2.Lerp(0, video.FrameCount, Game.Sound.VideoSeekPosition * invLength);
 				else
-					nextFrame = video.CurrentFrameNumber + 1;
+					nextFrame = video.CurrentFrameIndex + 1;
 
 				// Without the 2nd check the sound playback sometimes ends before the final frame is displayed which causes the player to be stuck on the first frame
-				if (nextFrame > video.FrameCount || nextFrame < video.CurrentFrameNumber)
+				if (nextFrame > video.FrameCount || nextFrame < video.CurrentFrameIndex)
 				{
 					Stop();
 					return;
 				}
 
 				var skippedFrames = 0;
-				while (nextFrame > video.CurrentFrameNumber)
+				while (nextFrame > video.CurrentFrameIndex)
 				{
 					video.AdvanceFrame();
 					videoSprite.Sheet.GetTexture().SetData(video.CurrentFrameData, textureSize, textureSize);
@@ -116,7 +116,7 @@ namespace OpenRA.Mods.Common.Widgets
 				}
 
 				if (skippedFrames > 1)
-					Log.Write("perf", "VideoPlayer: {0} skipped {1} frames at position {2}", cachedVideo, skippedFrames, video.CurrentFrameNumber);
+					Log.Write("perf", $"{nameof(VideoPlayerWidget)}: {cachedVideoFileName} skipped {skippedFrames} frames at position {video.CurrentFrameIndex}");
 			}
 
 			WidgetUtils.DrawSprite(videoSprite, videoOrigin, videoSize);

--- a/OpenRA.Platforms.Default/Texture.cs
+++ b/OpenRA.Platforms.Default/Texture.cs
@@ -92,24 +92,6 @@ namespace OpenRA.Platforms.Default
 			}
 		}
 
-		// An array of RGBA
-		public void SetData(uint[,] colors)
-		{
-			VerifyThreadAffinity();
-			var width = colors.GetUpperBound(1) + 1;
-			var height = colors.GetUpperBound(0) + 1;
-
-			if (!Exts.IsPowerOf2(width) || !Exts.IsPowerOf2(height))
-				throw new InvalidDataException($"Non-power-of-two array {width}x{height}");
-
-			Size = new Size(width, height);
-			unsafe
-			{
-				fixed (uint* ptr = &colors[0, 0])
-					SetData(new IntPtr(ptr), width, height);
-			}
-		}
-
 		public void SetFloatData(float[] data, int width, int height)
 		{
 			VerifyThreadAffinity();

--- a/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
+++ b/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
@@ -557,10 +557,10 @@ namespace OpenRA.Platforms.Default
 		readonly Func<object> getSize;
 		readonly Action<object> setEmpty;
 		readonly Func<byte[]> getData;
-		readonly Action<object> setData2;
-		readonly Func<object, object> setData3;
-		readonly Action<object> setData4;
-		readonly Func<object, object> setData5;
+		readonly Action<object> setData1;
+		readonly Func<object, object> setData2;
+		readonly Action<object> setData3;
+		readonly Func<object, object> setData4;
 		readonly Action dispose;
 
 		public ThreadedTexture(ThreadedGraphicsContext device, ITextureInternal texture)
@@ -572,10 +572,10 @@ namespace OpenRA.Platforms.Default
 			getSize = () => texture.Size;
 			setEmpty = tuple => { var t = (ValueTuple<int, int>)tuple; texture.SetEmpty(t.Item1, t.Item2); };
 			getData = () => texture.GetData();
-			setData2 = tuple => { var t = (ValueTuple<byte[], int, int>)tuple; texture.SetData(t.Item1, t.Item2, t.Item3); };
-			setData3 = tuple => { setData2(tuple); return null; };
-			setData4 = tuple => { var t = (ValueTuple<float[], int, int>)tuple; texture.SetFloatData(t.Item1, t.Item2, t.Item3); };
-			setData5 = tuple => { setData4(tuple); return null; };
+			setData1 = tuple => { var t = (ValueTuple<byte[], int, int>)tuple; texture.SetData(t.Item1, t.Item2, t.Item3); };
+			setData2 = tuple => { setData1(tuple); return null; };
+			setData3 = tuple => { var t = (ValueTuple<float[], int, int>)tuple; texture.SetFloatData(t.Item1, t.Item2, t.Item3); };
+			setData4 = tuple => { setData3(tuple); return null; };
 			dispose = texture.Dispose;
 		}
 
@@ -609,13 +609,13 @@ namespace OpenRA.Platforms.Default
 				// If we are able to create a small array the GC can collect easily, post a message to avoid blocking.
 				var temp = new byte[colors.Length];
 				Array.Copy(colors, temp, temp.Length);
-				device.Post(setData2, (temp, width, height));
+				device.Post(setData1, (temp, width, height));
 			}
 			else
 			{
 				// If the length is large and would result in an array on the Large Object Heap (LOH),
 				// send a message and block to avoid LOH allocation as this requires a Gen2 collection.
-				device.Send(setData3, (colors, width, height));
+				device.Send(setData2, (colors, width, height));
 			}
 		}
 
@@ -628,13 +628,13 @@ namespace OpenRA.Platforms.Default
 				// If we are able to create a small array the GC can collect easily, post a message to avoid blocking.
 				var temp = new float[data.Length];
 				Array.Copy(data, temp, temp.Length);
-				device.Post(setData4, (temp, width, height));
+				device.Post(setData3, (temp, width, height));
 			}
 			else
 			{
 				// If the length is large and would result in an array on the Large Object Heap (LOH),
 				// send a message and block to avoid LOH allocation as this requires a Gen2 collection.
-				device.Send(setData5, (data, width, height));
+				device.Send(setData4, (data, width, height));
 			}
 		}
 

--- a/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
+++ b/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
@@ -557,7 +557,6 @@ namespace OpenRA.Platforms.Default
 		readonly Func<object> getSize;
 		readonly Action<object> setEmpty;
 		readonly Func<byte[]> getData;
-		readonly Func<object, object> setData1;
 		readonly Action<object> setData2;
 		readonly Func<object, object> setData3;
 		readonly Action<object> setData4;
@@ -573,7 +572,6 @@ namespace OpenRA.Platforms.Default
 			getSize = () => texture.Size;
 			setEmpty = tuple => { var t = (ValueTuple<int, int>)tuple; texture.SetEmpty(t.Item1, t.Item2); };
 			getData = () => texture.GetData();
-			setData1 = colors => { texture.SetData((uint[,])colors); return null; };
 			setData2 = tuple => { var t = (ValueTuple<byte[], int, int>)tuple; texture.SetData(t.Item1, t.Item2, t.Item3); };
 			setData3 = tuple => { setData2(tuple); return null; };
 			setData4 = tuple => { var t = (ValueTuple<float[], int, int>)tuple; texture.SetFloatData(t.Item1, t.Item2, t.Item3); };
@@ -600,12 +598,6 @@ namespace OpenRA.Platforms.Default
 		public byte[] GetData()
 		{
 			return device.Send(getData);
-		}
-
-		public void SetData(uint[,] colors)
-		{
-			// We can't return until we are finished with the data, so we must Send here.
-			device.Send(setData1, colors);
 		}
 
 		public void SetData(byte[] colors, int width, int height)


### PR DESCRIPTION
The goal here was to change the output of video parsers (`IVideo.FrameData`) from `uint[,]` to a more standard `byte[]`.
Along the way I took the liberty to beautify and slightly refactor the interface and implementing classes.
Big and scary PR that should be reasonably separated by commits, so still best review by those.
~~Still has 2 issues to fix before it is done, both related to commit 3 - `Changed IVideo.CurrentFrameData [,] -> byte[]`.~~
The other 3 commits should be reviewable from the start, and all three are intended to not change anything other than code style, meaning there should be no behavioral changes.

P.S.: How would people feel about renaming `VqaReader` -> `VqaVideo` and `WsaReader` -> `WsaVideo`, since the interface they implement is called `IVideo` and they not only read, but also store (and to a limited sense "play") the video?