### PR TITLE
PathGraph, skip closed cells early. Fix #19579.

### DIFF
--- a/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
@@ -147,13 +147,10 @@ namespace OpenRA.Mods.Common.Pathfinder
 			{
 				var dir = directions[i];
 				var neighbor = position + dir;
+				var movementCost = GetCostToNode(neighbor, dir);
 
 				// PERF: Skip closed cells already, 15% of all cells
-				if (info[neighbor].Status == CellStatus.Closed)
-					continue;
-
-				var movementCost = GetCostToNode(neighbor, dir);
-				if (movementCost != CostForInvalidCell)
+				if (movementCost != CostForInvalidCell && info[neighbor].Status != CellStatus.Closed)
 					validNeighbors.Add(new GraphConnection(neighbor, movementCost));
 			}
 


### PR DESCRIPTION


Avoid index out of bounds exception. Check if neighbour position is 'valid' before checking status.

Closes #19579.