### PR TITLE
Don't throw an exception when creating a hardware cursor fails

### DIFF
--- a/OpenRA.Game/Graphics/CursorManager.cs
+++ b/OpenRA.Game/Graphics/CursorManager.cs
@@ -118,18 +118,13 @@ namespace OpenRA.Graphics
 					var paddingTL = -(template.Bounds.Location - template.Sprites[i].Offset.XY.ToInt2());
 					var paddingBR = template.PaddedSize - new int2(template.Sprites[i].Bounds.Size) - paddingTL;
 
-					try
+					var hardwareCursor = CreateHardwareCursor(kv.Key, template.Sprites[i], paddingTL, paddingBR, -template.Bounds.Location);
+					if (hardwareCursor != null)
+						template.Cursors[i] = hardwareCursor;
+					else
 					{
-						template.Cursors[i] = CreateHardwareCursor(kv.Key, template.Sprites[i], paddingTL, paddingBR, -template.Bounds.Location);
-					}
-					catch (Exception e)
-					{
-						Log.Write("debug", "Failed to initialize hardware cursor for {0}.", template.Name);
-						Log.Write("debug", "Error was: " + e.Message);
-
-						Console.WriteLine("Failed to initialize hardware cursor for {0}.", template.Name);
-						Console.WriteLine("Error was: " + e.Message);
-						template.Cursors[i] = null;
+						Log.Write("debug", $"Failed to initialize hardware cursor for {template.Name}.");
+						Console.WriteLine($"Failed to initialize hardware cursor for {template.Name}.");
 					}
 				}
 			}

--- a/OpenRA.Platforms.Default/Sdl2HardwareCursor.cs
+++ b/OpenRA.Platforms.Default/Sdl2HardwareCursor.cs
@@ -45,9 +45,6 @@ namespace OpenRA.Platforms.Default
 				// This call very occasionally fails on Windows, but often works when retried.
 				for (var retries = 0; retries < 3 && Cursor == IntPtr.Zero; retries++)
 					Cursor = SDL.SDL_CreateColorCursor(surface, hotspot.X, hotspot.Y);
-
-				if (Cursor == IntPtr.Zero)
-					throw new Sdl2HardwareCursorException($"Failed to create cursor: {SDL.SDL_GetError()}");
 			}
 			catch
 			{

--- a/OpenRA.Platforms.Default/Sdl2HardwareCursor.cs
+++ b/OpenRA.Platforms.Default/Sdl2HardwareCursor.cs
@@ -17,15 +17,6 @@ using SDL2;
 
 namespace OpenRA.Platforms.Default
 {
-	class Sdl2HardwareCursorException : Exception
-	{
-		public Sdl2HardwareCursorException(string message)
-			: base(message) { }
-
-		public Sdl2HardwareCursorException(string message, Exception innerException)
-			: base(message, innerException) { }
-	}
-
 	sealed class Sdl2HardwareCursor : IHardwareCursor
 	{
 		public IntPtr Cursor { get; private set; }

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -344,11 +344,14 @@ namespace OpenRA.Platforms.Default
 					hotspot *= 2;
 				}
 
-				return new Sdl2HardwareCursor(size, data, hotspot);
+				var cursor = new Sdl2HardwareCursor(size, data, hotspot);
+				return cursor.Cursor == IntPtr.Zero ? null : cursor;
 			}
 			catch (Exception ex)
 			{
-				throw new Sdl2HardwareCursorException($"Failed to create hardware cursor `{name}` - {ex.Message}", ex);
+				Log.Write("debug", $"Failed to create hardware cursor `{name}` - {ex.Message}");
+				Console.WriteLine($"Failed to create hardware cursor `{name}` - {ex.Message}");
+				return null;
 			}
 		}
 


### PR DESCRIPTION
With this "fix" I no longer get a single failed hardware cursor creation, which means this shifts the timings to be lucky enough and hide the bug on my machine at least.