### PR TITLE
Add Patrol activity

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Patrol.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Patrol.cs
@@ -1,0 +1,100 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Eluant;
+using OpenRA.Activities;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
+using OpenRA.Scripting;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Activities
+{
+	public class Patrol : Activity
+	{
+		readonly IMove move;
+		readonly CPos[] waypoints;
+		readonly Func<bool> loopUntil;
+		readonly LuaFunction luaFunc;
+		readonly int wait;
+		readonly bool assaultMove;
+
+		int waypoint;
+
+		public Patrol(Actor self, CPos[] waypoints, LuaFunction func, ScriptContext context, int wait = 0, bool assaultMove = false)
+			: this(self, waypoints, null, wait, assaultMove)
+		{
+			luaFunc = func.CopyReference() as LuaFunction;
+			loopUntil = new Func<bool>(() => luaFunc.Call(self.ToLuaValue(context)).First().ToBoolean());
+		}
+
+		public Patrol(Actor self, CPos[] waypoints, bool loop = true, int wait = 0, bool assaultMove = false)
+			: this(self, waypoints, () => !loop, wait, assaultMove)
+		{ }
+
+		public Patrol(Actor self, CPos[] waypoints, Func<bool> loopUntil, int wait = 0, bool assaultMove = false)
+		{
+			move = self.Trait<IMove>();
+			this.waypoints = waypoints;
+
+			this.loopUntil = loopUntil;
+			this.wait = wait;
+			this.assaultMove = assaultMove;
+		}
+
+		public override bool Tick(Actor self)
+		{
+			if (IsCanceling)
+				return true;
+
+			if (waypoint >= waypoints.Length)
+			{
+				if (!loopUntil() && waypoints.Length > 0)
+					waypoint = 0;
+				else
+					return true;
+			}
+
+			var wpt = waypoints[waypoint++];
+			QueueChild(new AttackMoveActivity(self, () => move.MoveTo(wpt, 2), assaultMove));
+			if (wait > 0)
+				QueueChild(new Wait(wait));
+
+			return false;
+		}
+
+		protected override void OnLastRun(Actor self)
+		{
+			if (luaFunc != null)
+				luaFunc.Dispose();
+		}
+
+		protected override void OnActorDispose(Actor self)
+		{
+			if (luaFunc != null)
+				luaFunc.Dispose();
+		}
+
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			for (var wpt = 0; wpt < waypoints.Length; wpt++)
+				yield return new TargetLineNode(Target.FromCell(self.World, waypoints[wpt]), Color.Red);
+
+			if (waypoints.Length > 0 && !loopUntil())
+				yield return new TargetLineNode(Target.FromCell(self.World, waypoints[0]), Color.Red);
+
+			yield break;
+		}
+	}
+}

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -1214,7 +1214,7 @@ Container@PLAYER_WIDGETS:
 					Key: AttackMove
 					DisableKeySound: true
 					TooltipText: Attack Move
-					TooltipDesc: Selected units will move to the desired location\nand attack any enemies they encounter en route.\n\nHold {(Ctrl)} while targeting to order an Assault Move\nthat attacks any units or structures encountered en route.\n\nLeft-click icon then right-click on target location.
+					TooltipDesc: Selected units will move to the desired location\nand attack any enemies they encounter en route.\n\nHold {(Ctrl)} while targeting to order an Assault Move\nthat attacks any units or structures encountered en route.\n\nLeft-click icon then right-click on target location.\n\nAlternatively, hold {(Alt)} while right-clicking on\na target location to start a patrol route. Place\nadditional waypoints by right-clicking.\n\nMistakes can be corrected by right-clicking on the\nmisplaced waypoint again to remove it.\n\nThe patrol will start when you close the route by\nright-clicking on the first waypoint again. Holding\n {(Ctrl)} while doing so will order an Assault Patrol.
 					TooltipContainer: TOOLTIP_CONTAINER
 					TooltipTemplate: BUTTON_WITH_DESC_HIGHLIGHT_TOOLTIP_FACTIONSUFFIX
 					Children:

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -41,7 +41,7 @@ Container@PLAYER_WIDGETS:
 					Key: AttackMove
 					DisableKeySound: true
 					TooltipText: Attack Move
-					TooltipDesc: Selected units will move to the desired location\nand attack any enemies they encounter en route.\n\nHold {(Ctrl)} while targeting to order an Assault Move\nthat attacks any units or structures encountered en route.\n\nLeft-click icon then right-click on target location.
+					TooltipDesc: Selected units will move to the desired location\nand attack any enemies they encounter en route.\n\nHold {(Ctrl)} while targeting to order an Assault Move\nthat attacks any units or structures encountered en route.\n\nLeft-click icon then right-click on target location.\n\nAlternatively, hold {(Alt)} while right-clicking on\na target location to start a patrol route. Place\nadditional waypoints by right-clicking.\n\nMistakes can be corrected by right-clicking on the\nmisplaced waypoint again to remove it.\n\nThe patrol will start when you close the route by\nright-clicking on the first waypoint again. Holding\n {(Ctrl)} while doing so will order an Assault Patrol.
 					TooltipContainer: TOOLTIP_CONTAINER
 					TooltipTemplate: BUTTON_WITH_DESC_HIGHLIGHT_TOOLTIP
 					Children:

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -57,7 +57,7 @@ Container@PLAYER_WIDGETS:
 					Key: AttackMove
 					DisableKeySound: true
 					TooltipText: Attack Move
-					TooltipDesc: Selected units will move to the desired location\nand attack any enemies they encounter en route.\n\nHold {(Ctrl)} while targeting to order an Assault Move\nthat attacks any units or structures encountered en route.\n\nLeft-click icon then right-click on target location.
+					TooltipDesc: Selected units will move to the desired location\nand attack any enemies they encounter en route.\n\nHold {(Ctrl)} while targeting to order an Assault Move\nthat attacks any units or structures encountered en route.\n\nLeft-click icon then right-click on target location.\n\nAlternatively, hold {(Alt)} while right-clicking on\na target location to start a patrol route. Place\nadditional waypoints by right-clicking.\n\nMistakes can be corrected by right-clicking on the\nmisplaced waypoint again to remove it.\n\nThe patrol will start when you close the route by\nright-clicking on the first waypoint again. Holding\n {(Ctrl)} while doing so will order an Assault Patrol.
 					TooltipContainer: TOOLTIP_CONTAINER
 					TooltipTemplate: BUTTON_WITH_DESC_HIGHLIGHT_TOOLTIP
 					Children:

--- a/mods/ts/chrome/ingame-player.yaml
+++ b/mods/ts/chrome/ingame-player.yaml
@@ -45,7 +45,7 @@ Container@PLAYER_WIDGETS:
 					Key: AttackMove
 					DisableKeySound: true
 					TooltipText: Attack Move
-					TooltipDesc: Selected units will move to the desired location\nand attack any enemies they encounter en route.\n\nHold {(Ctrl)} while targeting to order an Assault Move\nthat attacks any units or structures encountered en route.\n\nLeft-click icon then right-click on target location.
+					TooltipDesc: Selected units will move to the desired location\nand attack any enemies they encounter en route.\n\nHold {(Ctrl)} while targeting to order an Assault Move\nthat attacks any units or structures encountered en route.\n\nLeft-click icon then right-click on target location.\n\nAlternatively, hold {(Alt)} while right-clicking on\na target location to start a patrol route. Place\nadditional waypoints by right-clicking.\n\nMistakes can be corrected by right-clicking on the\nmisplaced waypoint again to remove it.\n\nThe patrol will start when you close the route by\nright-clicking on the first waypoint again. Holding\n {(Ctrl)} while doing so will order an Assault Patrol.
 					TooltipContainer: TOOLTIP_CONTAINER
 					TooltipTemplate: BUTTON_WITH_DESC_HIGHLIGHT_TOOLTIP
 					Children:


### PR DESCRIPTION
This finally adds a proper Patrol feature to OpenRA which replaces the clunky workaround used for Lua scripting.  Also available to actual players via the AttackMove command, activated by holding ALT while placing the first waypoint.

Note that the AttackMove order generator has also been changed so that the AttackMove input mode isn't canceled when shift-clicking. I find this to be more user-friendly, but won't object to undoing it.

Closes #10470, as discussed.