### PR TITLE
Add option to limit render fps to game tick rate

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -787,8 +787,12 @@ namespace OpenRA
 					logicInterval = logicWorld == OrderManager.World ? OrderManager.SuggestedTimestep : logicWorld.Timestep;
 
 				// Ideal time between screen updates
-				var maxFramerate = Settings.Graphics.CapFramerate ? Settings.Graphics.MaxFramerate.Clamp(1, 1000) : 1000;
-				var renderInterval = 1000 / maxFramerate;
+				var renderInterval = logicInterval;
+				if (!Settings.Graphics.CapFramerateToGameFps)
+				{
+					var maxFramerate = Settings.Graphics.CapFramerate ? Settings.Graphics.MaxFramerate.Clamp(1, 1000) : 1000;
+					renderInterval = 1000 / maxFramerate;
+				}
 
 				// Tick as fast as possible while restoring game saves, capping rendering at 5 FPS
 				if (OrderManager.World != null && OrderManager.World.IsLoadingGameSave)

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -192,6 +192,9 @@ namespace OpenRA
 		[Desc("At which frames per second to cap the framerate.")]
 		public int MaxFramerate = 60;
 
+		[Desc("Set a frame rate limit of 1 render frame per game simulation frame (overrides CapFramerate/MaxFramerate).")]
+		public bool CapFramerateToGameFps = false;
+
 		[Desc("Disable the OpenGL debug message callback feature.")]
 		public bool DisableGLDebugMessageCallback = false;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -139,6 +139,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SettingsUtils.BindCheckboxPref(panel, "CURSORDOUBLE_CHECKBOX", ds, "CursorDouble");
 			SettingsUtils.BindCheckboxPref(panel, "VSYNC_CHECKBOX", ds, "VSync");
 			SettingsUtils.BindCheckboxPref(panel, "FRAME_LIMIT_CHECKBOX", ds, "CapFramerate");
+			SettingsUtils.BindCheckboxPref(panel, "FRAME_LIMIT_GAMESPEED_CHECKBOX", ds, "CapFramerateToGameFps");
 			SettingsUtils.BindIntSliderPref(panel, "FRAME_LIMIT_SLIDER", ds, "MaxFramerate");
 			SettingsUtils.BindCheckboxPref(panel, "PLAYER_STANCE_COLORS_CHECKBOX", gs, "UsePlayerStanceColors");
 			if (panel.GetOrNull<CheckboxWidget>("PAUSE_SHELLMAP_CHECKBOX") != null)
@@ -223,12 +224,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			restartDesc.IsVisible = () => ds.Mode != OriginalGraphicsMode || ds.VideoDisplay != OriginalVideoDisplay || ds.GLProfile != OriginalGLProfile ||
 				(ds.Mode == WindowMode.Windowed && (origWidthText != windowWidth.Text || origHeightText != windowHeight.Text));
 
+			var frameLimitGamespeedCheckbox = panel.Get<CheckboxWidget>("FRAME_LIMIT_GAMESPEED_CHECKBOX");
 			var frameLimitCheckbox = panel.Get<CheckboxWidget>("FRAME_LIMIT_CHECKBOX");
 			var frameLimitOrigLabel = frameLimitCheckbox.Text;
 			var frameLimitLabel = new CachedTransform<int, string>(fps => frameLimitOrigLabel + $" ({fps} FPS)");
 			frameLimitCheckbox.GetText = () => frameLimitLabel.Update(ds.MaxFramerate);
+			frameLimitCheckbox.IsDisabled = () => ds.CapFramerateToGameFps;
 
-			panel.Get<SliderWidget>("FRAME_LIMIT_SLIDER").IsDisabled = () => !frameLimitCheckbox.IsChecked();
+			panel.Get<SliderWidget>("FRAME_LIMIT_SLIDER").IsDisabled = () => !frameLimitCheckbox.IsChecked() || frameLimitGamespeedCheckbox.IsChecked();
 
 			// Player profile
 			var ps = Game.Settings.Player;
@@ -305,6 +308,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				ds.CapFramerate = dds.CapFramerate;
 				ds.MaxFramerate = dds.MaxFramerate;
+				ds.CapFramerateToGameFps = dds.CapFramerateToGameFps;
 				ds.GLProfile = dds.GLProfile;
 				ds.Mode = dds.Mode;
 				ds.VideoDisplay = dds.VideoDisplay;

--- a/mods/cnc/chrome/settings-display.yaml
+++ b/mods/cnc/chrome/settings-display.yaml
@@ -303,6 +303,16 @@ Container@DISPLAY_PANEL:
 									Height: 20
 									Font: Regular
 									Text: Enable VSync
+						Container@FRAME_LIMIT_GAMESPEED_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Y: 25
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@FRAME_LIMIT_GAMESPEED_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Limit framerate to game tick rate
 				Container@ROW:
 					Width: PARENT_RIGHT - 24
 					Height: 50

--- a/mods/common/chrome/settings-display.yaml
+++ b/mods/common/chrome/settings-display.yaml
@@ -312,6 +312,16 @@ Container@DISPLAY_PANEL:
 									Height: 20
 									Font: Regular
 									Text: Enable VSync
+						Container@FRAME_LIMIT_GAMESPEED_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Y: 25
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@FRAME_LIMIT_GAMESPEED_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Limit framerate to game tick rate
 				Container@ROW:
 					Width: PARENT_RIGHT - 24
 					Height: 50


### PR DESCRIPTION
We know there are systems out there that struggle to maintain 50, and since our default simulation speed is only 25 anyway, supporting a lower minimum seems like a fair solution to make things a bit easier for players with slow systems.

Min FPS are still clamped to simulation FPS, so gamespeeds of 'Fast' up to 'Fastest' will still result in higher min (render) FPS for now.

Also widened the sliders to make it a bit easier to set specific values despite the increased range.