### PR TITLE
Replace Thread.CurrentThread.ManagedThreadId with Environment.Current…

### DIFF
--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -124,7 +124,7 @@ namespace OpenRA
 				return (IReadOnlyDictionary<string, SequenceProvider>)(new ReadOnlyDictionary<string, SequenceProvider>(items));
 			});
 
-			initialThreadId = System.Threading.Thread.CurrentThread.ManagedThreadId;
+			initialThreadId = Environment.CurrentManagedThreadId;
 		}
 
 		// HACK: Only update the loading screen if we're in the main thread.
@@ -135,7 +135,7 @@ namespace OpenRA
 				LoadScreen.Display();
 		}
 
-		internal bool IsOnMainThread => System.Threading.Thread.CurrentThread.ManagedThreadId == initialThreadId;
+		internal bool IsOnMainThread => Environment.CurrentManagedThreadId == initialThreadId;
 
 		public void InitializeLoaders(IReadOnlyFileSystem fileSystem)
 		{

--- a/OpenRA.Platforms.Default/ThreadAffine.cs
+++ b/OpenRA.Platforms.Default/ThreadAffine.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Threading;
 
 namespace OpenRA.Platforms.Default
 {
@@ -25,12 +24,12 @@ namespace OpenRA.Platforms.Default
 
 		protected void SetThreadAffinity()
 		{
-			managedThreadId = Thread.CurrentThread.ManagedThreadId;
+			managedThreadId = Environment.CurrentManagedThreadId;
 		}
 
 		protected void VerifyThreadAffinity()
 		{
-			if (managedThreadId != Thread.CurrentThread.ManagedThreadId)
+			if (managedThreadId != Environment.CurrentManagedThreadId)
 				throw new InvalidOperationException("Cross-thread operation not valid: This method must only be called from the thread that owns this object.");
 		}
 	}


### PR DESCRIPTION
According to https://github.com/dotnet/runtime/issues/43257 should Environment.CurrentManagedThreadId be more efficient than System.Threading.Thread.CurrentThread.ManagedThreadId. 