### PR TITLE
Shroud, combine IsVisible and IsExplored into a single function.

### DIFF
--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -155,14 +155,15 @@ namespace OpenRA.Traits
 			// PERF: Avoid LINQ.
 			foreach (var puv in Footprint)
 			{
-				if (shroud.IsVisible(puv))
+				var cv = shroud.GetVisibility(puv);
+				if (cv.HasFlag(Shroud.CellVisibility.Visible))
 				{
 					Visible = false;
 					Shrouded = false;
 					break;
 				}
 
-				if (Shrouded && shroud.IsExplored(puv))
+				if (Shrouded && cv.HasFlag(Shroud.CellVisibility.Explored))
 					Shrouded = false;
 			}
 

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -22,6 +22,9 @@ namespace OpenRA.Mods.Common.Widgets
 {
 	public sealed class RadarWidget : Widget, IDisposable
 	{
+		public readonly int ColorFog = Color.FromArgb(128, Color.Black).ToArgb();
+		public readonly int ColorShroud = Color.Black.ToArgb();
+
 		public string WorldInteractionController = null;
 		public int AnimationLength = 5;
 		public string RadarOnlineSound = null;
@@ -240,10 +243,11 @@ namespace OpenRA.Mods.Common.Widgets
 		void UpdateShroudCell(PPos puv)
 		{
 			var color = 0;
-			if (!currentPlayer.Shroud.IsExplored(puv))
-				color = Color.Black.ToArgb();
-			else if (!currentPlayer.Shroud.IsVisible(puv))
-				color = Color.FromArgb(128, Color.Black).ToArgb();
+			var cv = currentPlayer.Shroud.GetVisibility(puv);
+			if (cv == Shroud.CellVisibility.Hidden)
+				color = ColorShroud;
+			else if (cv.HasFlag(Shroud.CellVisibility.Visible))
+				color = ColorFog;
 
 			var stride = radarSheet.Size.Width;
 			unsafe


### PR DESCRIPTION




Combine `Shroud.IsExplored` and `Shroud.IsVisible` into `Shroud.Visbility`.

Calculate neighbors and their visibility only once and reuse to determine both shroud and fog edges.

Avoids multiple cell layer lookups and map bound checks.

Trivial performance improvement. `ShroudRenderer.UpdateShroud` is 21% faster on average. Did not check for `RadarWidget` or `FrozenActorLayer`. The shroud does not get updated often enough to have a visible noticeable impact on performance.

See also #19562 . This pull request does not fix that, but keeps backward compatibility.

Tested on RA on shell map and 5 min replay by comparing previous and new version calculated edges.


Side notes:
- Confusing each time to realize that Shroud relates to IsExplored and Fog to IsVisible. Or was it the other way around ;)
- Also that you have `Shroud.Disabled` and `FogEnabled`. Better to call both `Enabled`.
- Perhaps CellVisibility can be merged with ShroudCellType, but it would be better to rename the last in that case, because Visibility and Explored is the terminology used by callers. Although the last is clearer in terms. The mapping is currently not one on one though.


