### PR TITLE
Adding map name support to parameter Launch.Map=<map-name-or-uid>

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -956,12 +956,9 @@ namespace OpenRA
 				Order.Command($"state {Session.ClientState.Ready}")
 			};
 
-			var path = Platform.ResolvePath(launchMap);
-			var map = ModData.MapCache.SingleOrDefault(m => m.Uid == launchMap) ??
-				ModData.MapCache.SingleOrDefault(m => m.Package.Name == path);
-
+			var map = ModData.MapCache.SingleOrDefault(m => m.Uid == launchMap || Path.GetFileName(m.Package.Name) == launchMap);
 			if (map == null)
-				throw new InvalidOperationException($"Could not find map '{launchMap}'.");
+				throw new ArgumentException($"Could not find map '{launchMap}'.");
 
 			CreateAndStartLocalServer(map.Uid, orders);
 		}


### PR DESCRIPTION
This change adds support for using relative paths with forward slashes in the Launch.Map=<map-path-or-uid> parameter, when launching the game via command line, by re-using the code from utility.cmd, which currently allows such paths. Previously if not using a UID, only an absolute path was allowed, such as shown in the below commands:

launch-game.cmd Game.Mod=ra **Launch.Map="C:\OpenRA\mods\ra\maps\a-nuclear-winter"**
launch-game.cmd Game.Mod=ra **Launch.Map=C:\OpenRA\mods\ra\maps\warwind.oramap**

Now these maps may also be loaded using the below commands:

launch-game.cmd Game.Mod=ra **Launch.Map=mods/ra/maps/a-nuclear-winter**
launch-game.cmd Game.Mod=ra **Launch.Map="mods/ra/maps/warwind.oramap"**

Note that quotes are not needed but allowed, as can be seen here. Both unpacked maps (map folders) and packed maps (.oramap files) work with this change. Also note that absolute paths such as those from the first example still work with this change. Have also tested running the game without the Launch.Map parameter to check for any regression errors in single player, and no issues have arose.