### PR TITLE
CallFunc, avoid null check.

### DIFF
--- a/OpenRA.Game/Activities/CallFunc.cs
+++ b/OpenRA.Game/Activities/CallFunc.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Activities
 
 		public override bool Tick(Actor self)
 		{
-			a?.Invoke();
+			a.Invoke();
 			return true;
 		}
 	}


### PR DESCRIPTION

Avoid check each tick. Assumes action is not null in the common case.
