### PR TITLE
 RunUnsynced, do not recalculate sync hash on reentry.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -40,6 +40,7 @@ namespace OpenRA
 		public static Settings Settings;
 		public static CursorManager Cursor;
 		public static bool HideCursor;
+
 		static WorldRenderer worldRenderer;
 		static string modLaunchWrapper;
 
@@ -585,7 +586,7 @@ namespace OpenRA
 			if (Ui.LastTickTime.ShouldAdvance(tick))
 			{
 				Ui.LastTickTime.AdvanceTickTime(tick);
-				Sync.RunUnsynced(Settings.Debug.SyncCheckUnsyncedCode, world, Ui.Tick);
+				Sync.RunUnsynced(world, Ui.Tick);
 				Cursor.Tick();
 			}
 
@@ -597,14 +598,14 @@ namespace OpenRA
 
 					Sound.Tick();
 
-					Sync.RunUnsynced(Settings.Debug.SyncCheckUnsyncedCode, world, orderManager.TickImmediate);
+					Sync.RunUnsynced(world, orderManager.TickImmediate);
 
 					if (world == null)
 						return;
 
 					if (orderManager.TryTick())
 					{
-						Sync.RunUnsynced(Settings.Debug.SyncCheckUnsyncedCode, world, () =>
+						Sync.RunUnsynced(world, () =>
 						{
 							world.OrderGenerator.Tick(world);
 						});
@@ -616,7 +617,7 @@ namespace OpenRA
 
 					// Wait until we have done our first world Tick before TickRendering
 					if (orderManager.LocalFrameNumber > 0)
-						Sync.RunUnsynced(Settings.Debug.SyncCheckUnsyncedCode, world, () => world.TickRender(worldRenderer));
+						Sync.RunUnsynced(world, () => world.TickRender(worldRenderer));
 				}
 
 				benchmark?.Tick(LocalTick);

--- a/OpenRA.Game/Input/InputHandler.cs
+++ b/OpenRA.Game/Input/InputHandler.cs
@@ -37,17 +37,17 @@ namespace OpenRA
 
 		public void OnKeyInput(KeyInput input)
 		{
-			Sync.RunUnsynced(Game.Settings.Debug.SyncCheckUnsyncedCode, world, () => Ui.HandleKeyPress(input));
+			Sync.RunUnsynced(world, () => Ui.HandleKeyPress(input));
 		}
 
 		public void OnTextInput(string text)
 		{
-			Sync.RunUnsynced(Game.Settings.Debug.SyncCheckUnsyncedCode, world, () => Ui.HandleTextInput(text));
+			Sync.RunUnsynced(world, () => Ui.HandleTextInput(text));
 		}
 
 		public void OnMouseInput(MouseInput input)
 		{
-			Sync.RunUnsynced(Game.Settings.Debug.SyncCheckUnsyncedCode, world, () => Ui.HandleInput(input));
+			Sync.RunUnsynced(world, () => Ui.HandleInput(input));
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/World/LoadWidgetAtGameStart.cs
+++ b/OpenRA.Mods.Common/Traits/World/LoadWidgetAtGameStart.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Traits
 				var optionsButton = root.GetOrNull<MenuButtonWidget>("OPTIONS_BUTTON");
 				world.SetPauseState(false);
 				if (optionsButton != null)
-					Sync.RunUnsynced(Game.Settings.Debug.SyncCheckUnsyncedCode, world, optionsButton.OnClick);
+					Sync.RunUnsynced(world, optionsButton.OnClick);
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/World/Selection.cs
+++ b/OpenRA.Mods.Common/Traits/World/Selection.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var sel in a.TraitsImplementing<INotifySelected>())
 				sel.Selected(a);
 
-			Sync.RunUnsynced(Game.Settings.Debug.SyncCheckUnsyncedCode, world, () => world.OrderGenerator.SelectionChanged(world, actors));
+			Sync.RunUnsynced(world, () => world.OrderGenerator.SelectionChanged(world, actors));
 			foreach (var ns in worldNotifySelection)
 				ns.SelectionChanged();
 		}
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (actors.Remove(a))
 			{
 				UpdateHash();
-				Sync.RunUnsynced(Game.Settings.Debug.SyncCheckUnsyncedCode, world, () => world.OrderGenerator.SelectionChanged(world, actors));
+				Sync.RunUnsynced(world, () => world.OrderGenerator.SelectionChanged(world, actors));
 				foreach (var ns in worldNotifySelection)
 					ns.SelectionChanged();
 			}
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.Common.Traits
 				foreach (var sel in a.TraitsImplementing<INotifySelected>())
 					sel.Selected(a);
 
-			Sync.RunUnsynced(Game.Settings.Debug.SyncCheckUnsyncedCode, world, () => world.OrderGenerator.SelectionChanged(world, actors));
+			Sync.RunUnsynced(world, () => world.OrderGenerator.SelectionChanged(world, actors));
 			foreach (var ns in worldNotifySelection)
 				ns.SelectionChanged();
 
@@ -148,7 +148,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			actors.Clear();
 			UpdateHash();
-			Sync.RunUnsynced(Game.Settings.Debug.SyncCheckUnsyncedCode, world, () => world.OrderGenerator.SelectionChanged(world, actors));
+			Sync.RunUnsynced(world, () => world.OrderGenerator.SelectionChanged(world, actors));
 			foreach (var ns in worldNotifySelection)
 				ns.SelectionChanged();
 		}
@@ -170,7 +170,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (removed > 0)
 			{
 				UpdateHash();
-				Sync.RunUnsynced(Game.Settings.Debug.SyncCheckUnsyncedCode, world, () => world.OrderGenerator.SelectionChanged(world, actors));
+				Sync.RunUnsynced(world, () => world.OrderGenerator.SelectionChanged(world, actors));
 				foreach (var ns in worldNotifySelection)
 					ns.SelectionChanged();
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				var optionsButton = playerRoot.GetOrNull<MenuButtonWidget>("OPTIONS_BUTTON");
 				if (optionsButton != null)
-					Sync.RunUnsynced(Game.Settings.Debug.SyncCheckUnsyncedCode, world, optionsButton.OnClick);
+					Sync.RunUnsynced(world, optionsButton.OnClick);
 			};
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -211,7 +211,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override string GetCursor(int2 screenPos)
 		{
-			return Sync.RunUnsynced(Game.Settings.Debug.SyncCheckUnsyncedCode, World, () =>
+			return Sync.RunUnsynced(World, () =>
 			{
 				// Always show an arrow while selecting
 				if (IsValidDragbox)


### PR DESCRIPTION


`RunUnsynched` is called recursively - i.e. during mouse selection. If `calculateSyncHash` is enabled it would cause the sync hash to be calculated 4+ times, 2 times before and 2 times after. Assuming that `Async` code should/can only run in/after one logic frame this seems like overhead - the sync hash should each 4 times be the same. 

Avoid 4 level deep lookup of `Game.Settings.Debug.SyncCheckUnsyncedCode` each time. (The compiler cannot optimize the lookup.)

I considered using the `Unsynced` disposable around `EndFrame` or else in `SqlInput.PumpInput`. But it would cause the sync hash to be calculated - if enabled in debug settings - even when there are not input events. The advantage was that `DefaultInputHandler` does not need to know about `World` and `(Un)Sync`.


Think it could be wise to write a chat log warning message if the player starts a game with the calculation of sync hash in unsynced code enabled in game settings. They might hold up a multi player game without realizing.

