### PR TITLE
Fixed odd sprite size "frame hopping".

### DIFF
--- a/OpenRA.Game/Graphics/SpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderable.cs
@@ -76,7 +76,8 @@ namespace OpenRA.Graphics
 
 		float3 ScreenPosition(WorldRenderer wr)
 		{
-			return wr.Screen3DPxPosition(pos) + wr.ScreenPxOffset(offset) - 0.5f * scale * sprite.Size;
+			var s = 0.5f * scale * sprite.Size;
+			return wr.Screen3DPxPosition(pos) + wr.ScreenPxOffset(offset) - new float3((int)s.X, (int)s.Y, s.Z);
 		}
 
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }


### PR DESCRIPTION
In the example here, the overlay animation has a single frame with an odd height (the colors are broken in the gif somehow. but it shows the "jump" problem)
![Animation](https://user-images.githubusercontent.com/1322277/129514437-e1a26cab-dc6d-43f5-b977-680211b7e715.gif)
