### PR TITLE
ActorsWithTrait, call actor where-clause once per actor. 

### DIFF
--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -151,9 +151,9 @@ namespace OpenRA.Graphics
 		// PERF: Avoid LINQ.
 		void GenerateOverlayRenderables()
 		{
-			foreach (var a in World.ActorsWithTrait<IRenderAboveShroud>())
+			foreach (var a in World.ActorsWithTrait<IRenderAboveShroud>(a => a.IsInWorld && !a.Disposed))
 			{
-				if (!a.Actor.IsInWorld || a.Actor.Disposed || (a.Trait.SpatiallyPartitionable && !onScreenActors.Contains(a.Actor)))
+				if (a.Trait.SpatiallyPartitionable && !onScreenActors.Contains(a.Actor))
 					continue;
 
 				foreach (var renderable in a.Trait.RenderAboveShroud(a.Actor, this))
@@ -193,9 +193,9 @@ namespace OpenRA.Graphics
 		// PERF: Avoid LINQ.
 		void GenerateAnnotationRenderables()
 		{
-			foreach (var a in World.ActorsWithTrait<IRenderAnnotations>())
+			foreach (var a in World.ActorsWithTrait<IRenderAnnotations>(a => a.IsInWorld && !a.Disposed))
 			{
-				if (!a.Actor.IsInWorld || a.Actor.Disposed || (a.Trait.SpatiallyPartitionable && !onScreenActors.Contains(a.Actor)))
+				if (a.Trait.SpatiallyPartitionable && !onScreenActors.Contains(a.Actor))
 					continue;
 
 				foreach (var renderAnnotation in a.Trait.RenderAnnotations(a.Actor, this))
@@ -272,9 +272,8 @@ namespace OpenRA.Graphics
 			if (enableDepthBuffer)
 				Game.Renderer.ClearDepthBuffer();
 
-			foreach (var a in World.ActorsWithTrait<IRenderAboveWorld>())
-				if (a.Actor.IsInWorld && !a.Actor.Disposed)
-					a.Trait.RenderAboveWorld(a.Actor, this);
+			foreach (var a in World.ActorsWithTrait<IRenderAboveWorld>(a => a.IsInWorld && !a.Disposed))
+				a.Trait.RenderAboveWorld(a.Actor, this);
 
 			if (enableDepthBuffer)
 				Game.Renderer.ClearDepthBuffer();

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -496,6 +496,16 @@ namespace OpenRA
 			return TraitDict.ActorsWithTrait<T>();
 		}
 
+		public IEnumerable<TraitPair<T>> ActorsWithTrait<T>(Func<Actor, bool> predicate)
+		{
+			return TraitDict.ActorsWithTrait<T>(predicate);
+		}
+
+		public IEnumerable<T> ActorTraits<T>(Func<Actor, bool> predicate)
+		{
+			return TraitDict.ActorTraits<T>(predicate);
+		}
+
 		public void ApplyToActorsWithTraitTimed<T>(Action<Actor, T> action, string text)
 		{
 			TraitDict.ApplyToActorsWithTraitTimed<T>(action, text);

--- a/OpenRA.Mods.Common/AIUtils.cs
+++ b/OpenRA.Mods.Common/AIUtils.cs
@@ -36,9 +36,8 @@ namespace OpenRA.Mods.Common
 
 		public static IEnumerable<ProductionQueue> FindQueues(Player player, string category)
 		{
-			return player.World.ActorsWithTrait<ProductionQueue>()
-				.Where(a => a.Actor.Owner == player && a.Trait.Info.Type == category && a.Trait.Enabled)
-				.Select(a => a.Trait);
+			return player.World.ActorTraits<ProductionQueue>(a => a.Owner == player)
+				.Where(t => t.Info.Type == category && t.Enabled);
 		}
 
 		public static IEnumerable<Actor> GetActorsWithTrait<T>(World world)

--- a/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
@@ -99,10 +99,8 @@ namespace OpenRA.Mods.Common.Traits
 				foreach (var q in queues)
 				{
 					foreach (var b in self.World
-							.ActorsWithTrait<PrimaryBuilding>()
+							.ActorsWithTrait<PrimaryBuilding>(a => a != self && a.Owner == self.Owner)
 							.Where(a =>
-								a.Actor != self &&
-								a.Actor.Owner == self.Owner &&
 								a.Trait.IsPrimary &&
 								a.Actor.TraitsImplementing<Production>().Where(p => !p.IsTraitDisabled).Any(pi => pi.Info.Produces.Contains(q))))
 						b.Trait.SetPrimaryProducer(b.Actor, false);

--- a/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
@@ -52,16 +52,19 @@ namespace OpenRA.Mods.Common.Traits
 			// PERF: Avoid LINQ.
 			Enabled = false;
 			var isActive = false;
-			foreach (var x in self.World.ActorsWithTrait<Production>())
+			foreach (var t in self.World.ActorTraits<Production>(a => a.Owner == self.Owner))
 			{
-				if (x.Trait.IsTraitDisabled)
+				if (t.IsTraitDisabled)
 					continue;
 
-				if (x.Actor.Owner != self.Owner || !x.Trait.Info.Produces.Contains(Info.Type))
+				if (!t.Info.Produces.Contains(Info.Type))
 					continue;
 
 				Enabled |= IsValidFaction;
-				isActive |= !x.Trait.IsTraitPaused;
+				isActive |= !t.IsTraitPaused;
+
+				if (Enabled && isActive)
+					break;
 			}
 
 			if (!Enabled)
@@ -82,9 +85,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override TraitPair<Production> MostLikelyProducer()
 		{
-			var productionActors = self.World.ActorsWithTrait<Production>()
-				.Where(x => x.Actor.Owner == self.Owner
-					&& !x.Trait.IsTraitDisabled && x.Trait.Info.Produces.Contains(Info.Type))
+			var productionActors = self.World.ActorsWithTrait<Production>(a => a.Owner == self.Owner)
+				.Where(x => !x.Trait.IsTraitDisabled && x.Trait.Info.Produces.Contains(Info.Type))
 				.OrderByDescending(x => x.Actor.IsPrimaryBuilding())
 				.ThenByDescending(x => x.Actor.ActorID)
 				.ToList();
@@ -101,9 +103,8 @@ namespace OpenRA.Mods.Common.Traits
 			// Some units may request a specific production type, which is ignored if the AllTech cheat is enabled
 			var type = developerMode.AllTech ? Info.Type : (bi.BuildAtProductionType ?? Info.Type);
 
-			var producers = self.World.ActorsWithTrait<Production>()
-				.Where(x => x.Actor.Owner == self.Owner
-					&& !x.Trait.IsTraitDisabled
+			var producers = self.World.ActorsWithTrait<Production>(a => a.Owner == self.Owner)
+				.Where(x => !x.Trait.IsTraitDisabled
 					&& x.Trait.Info.Produces.Contains(type))
 					.OrderByDescending(x => x.Actor.IsPrimaryBuilding())
 					.ThenByDescending(x => x.Actor.ActorID);
@@ -147,8 +148,8 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				var type = bi.BuildAtProductionType ?? info.Type;
 
-				var selfsameProductionsCount = self.World.ActorsWithTrait<Production>()
-					.Count(p => !p.Trait.IsTraitDisabled && !p.Trait.IsTraitPaused && p.Actor.Owner == self.Owner && p.Trait.Info.Produces.Contains(type));
+				var selfsameProductionsCount = self.World.ActorsWithTrait<Production>(a => a.Owner == self.Owner)
+					.Count(p => !p.Trait.IsTraitDisabled && !p.Trait.IsTraitPaused && p.Trait.Info.Produces.Contains(type));
 
 				var speedModifier = selfsameProductionsCount.Clamp(1, info.BuildTimeSpeedReduction.Length) - 1;
 				time = (time * info.BuildTimeSpeedReduction[speedModifier]) / 100;

--- a/OpenRA.Mods.Common/Traits/Render/RenderJammerCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderJammerCircle.cs
@@ -47,10 +47,9 @@ namespace OpenRA.Mods.Common.Traits
 					BorderWidth);
 			}
 
-			foreach (var a in w.ActorsWithTrait<RenderJammerCircle>())
-				if (a.Actor.Owner.IsAlliedWith(w.RenderPlayer))
-					foreach (var r in a.Trait.RenderAnnotations(a.Actor, wr))
-						yield return r;
+			foreach (var a in w.ActorsWithTrait<RenderJammerCircle>(a => a.Owner.IsAlliedWith(w.RenderPlayer)))
+				foreach (var r in a.Trait.RenderAnnotations(a.Actor, wr))
+					yield return r;
 		}
 
 		public override object Create(ActorInitializer init) { return new RenderJammerCircle(this); }

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -407,7 +407,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			template.Get<LabelWidget>("ASSETS").GetText = () => assetsText.Update(stats.AssetsValue);
 
 			var harvesters = template.Get<LabelWidget>("HARVESTERS");
-			harvesters.GetText = () => world.ActorsWithTrait<Harvester>().Count(a => a.Actor.Owner == player && !a.Actor.IsDead && !a.Trait.IsTraitDisabled).ToString();
+			harvesters.GetText = () => world.ActorTraits<Harvester>(a => a.Owner == player && !a.IsDead).Count(t => !t.IsTraitDisabled).ToString();
 
 			var derricks = template.GetOrNull<LabelWidget>("DERRICKS");
 			if (derricks != null)

--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -99,16 +99,15 @@ namespace OpenRA.Mods.Common.Widgets
 			if (player == null)
 				return;
 
-			var queues = world.ActorsWithTrait<ProductionQueue>()
-				.Where(a => a.Actor.Owner == player)
-				.Select((a, i) => new { a.Trait, i });
+			var queues = world.ActorTraits<ProductionQueue>(a => a.Owner == player)
+				.Select((trait, i) => new { trait, i });
 
 			foreach (var queue in queues)
-				if (!clocks.ContainsKey(queue.Trait))
-					clocks.Add(queue.Trait, new Animation(world, ClockAnimation));
+				if (!clocks.ContainsKey(queue.trait))
+					clocks.Add(queue.trait, new Animation(world, ClockAnimation));
 
 			var currentItemsByItem = queues
-					.Select(a => a.Trait.CurrentItem())
+					.Select(a => a.trait.CurrentItem())
 					.Where(pi => pi != null)
 					.GroupBy(pr => pr.Item)
 					.OrderBy(g => g.First().Queue.Info.DisplayOrder)

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -398,11 +398,8 @@ namespace OpenRA.Mods.Common.Widgets
 					{
 						var colors = (int*)colorBytes;
 
-						foreach (var t in world.ActorsWithTrait<IRadarSignature>())
+						foreach (var t in world.ActorsWithTrait<IRadarSignature>(a => a.IsInWorld && !world.FogObscures(a)))
 						{
-							if (!t.Actor.IsInWorld || world.FogObscures(t.Actor))
-								continue;
-
 							cells.Clear();
 							t.Trait.PopulateRadarSignatureCells(t.Actor, cells);
 							foreach (var cell in cells)


### PR DESCRIPTION


The concept: Pass the `Where` clause as predicate to `WithTraits` already to allow the TraitContainer to skip all traits for actors that do not match and return all traits for actors that did match.

Advantages:
1. The `TraitContainer` can check the predicate once and after skip the check on all traits of that same actor. Avoiding the need to call the same `Where` clause on the same `actor` multiple times. Useful only for those traits of which an actor can have multiple i.e. Production. As a result 90% less calls are done on the actor predicate for Production traits. 

2. Users of `ActorsWithTraits` typically only use the `actor` of a `TraitPair` to check if it is `!Disposed` and/or if the `Owner` is `self.Owner`. By passing this actor predicate as argument (1) to `ActorsWithTrait` the caller afterwards often does no longer need to know about the actor that belongs to the trait (because it typically is `self` or not relevant). This lead to `ActorTraits`. As a result there is no need to allocate temporary `TraitPair`s.

Disadvantages:
- Less LINQy.

Naming of functions can be improved. 

I think it would even be better for an Enumerator to return a list of all traits for a single actor. However the internal TraitContainer storage layout does not easily allow for this - would require an additional array allocation for each call.




