### PR TITLE
Do not enforce mods to use stylecop.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -48,7 +48,7 @@
   <!-- StyleCop -->
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
     <AdditionalFiles Include="$(EngineRootPath)/stylecop.json" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Currently any mod based on bleed will be based on the PR open on the mod sdk.
That includes to explicitly load the Directory.Build.props file for mods. See:
https://github.com/OpenRA/OpenRAModSDK/pull/171/files#diff-644695c3936d4ed7228994cff4ca3de3f895c0a65cfb3ac5e6893d3c7ec5d325L14-L15

When deciding to custom-configure the mod to not include that particular file, the project imports for Game and Common will still enforce the project to use StyleCop, which cannot be disabled. This PR changes that. This will have no effect on any project in OpenRA git, nor on any project based upon the mod SDK (due to the linked code above), except when the include to the props file is explicitely removed as i did in OpenKrush, for full customization.
