### PR TITLE
SupportPowerManager, only refresh icons when changed.

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/GrantPrerequisiteChargeDrainPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/GrantPrerequisiteChargeDrainPower.cs
@@ -122,10 +122,10 @@ namespace OpenRA.Mods.Cnc.Traits
 					((GrantPrerequisiteChargeDrainPower)p).Deactivate(p.Self, this);
 			}
 
-			public override void Tick()
+			public override bool Tick()
 			{
 				var orig = remainingSubTicks;
-				base.Tick();
+				var disableStateChanged = base.Tick();
 
 				if (Ready)
 					available = true;
@@ -144,6 +144,8 @@ namespace OpenRA.Mods.Cnc.Traits
 						Deactivate();
 					}
 				}
+
+				return disableStateChanged;
 			}
 
 			public void Discharge(int subTicks)


### PR DESCRIPTION
Mentioned as a todo.

Maintain a hash to determine if `SupportPowerManager.Powers` changed.

Maintain a hash in the widget to determine of the same powers were disabled. 

This mainly has advantage later during a game when a player has support powers. 