### PR TITLE
Fix Carryall InitialActor creation.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -128,7 +128,7 @@ namespace OpenRA.Mods.Common.Traits
 					new OwnerInit(self.Owner)
 				});
 
-				unit.Trait<Carryable>().Attached(self);
+				unit.Trait<Carryable>().Attached(unit);
 				AttachCarryable(self, unit);
 			}
 		}


### PR DESCRIPTION
Fixes #19619, which is caused by a bug in #19068.

Carryable.Attached was being called with the wrong actor, which meant that `carriedToken` was being assigned a bogus token value that just happened to match a condition owned by `GrantConditionOnDamageState`. Carryable.Detached revoked the token out from under `GrantConditionOnDamageState`, putting the actor into an inconsistent state that causes a crash when that trait legitimately tried to revoke that condition some time later.