### PR TITLE
Move order latency control to the server

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -84,7 +84,14 @@ namespace OpenRA
 
 		static void JoinInner(OrderManager om)
 		{
-			OrderManager?.Dispose();
+			// HACK: The shellmap World and OrderManager are owned by the main menu's WorldRenderer instead of Game.
+			// This allows us to switch Game.OrderManager from the shellmap to the new network connection when joining
+			// a lobby, while keeping the OrderManager that runs the shellmap intact.
+			// A matching check in World.Dispose (which is called by WorldRenderer.Dispose) makes sure that we dispose
+			// the shellmap's OM when a lobby game actually starts.
+			if (OrderManager?.World == null || OrderManager.World.Type != WorldType.Shellmap)
+				OrderManager?.Dispose();
+
 			OrderManager = om;
 		}
 

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -167,10 +167,7 @@ namespace OpenRA
 				map = ModData.PrepareMap(mapUID);
 
 			using (new PerfTimer("NewWorld"))
-			{
 				OrderManager.World = new World(ModData, map, OrderManager, type);
-				OrderManager.FramesAhead = OrderManager.World.OrderLatency;
-			}
 
 			OrderManager.World.GameOver += FinishBenchmark;
 

--- a/OpenRA.Game/Network/Connection.cs
+++ b/OpenRA.Game/Network/Connection.cs
@@ -52,22 +52,12 @@ namespace OpenRA.Network
 
 		public virtual void Send(int frame, IEnumerable<Order> orders)
 		{
-			var ms = new MemoryStream();
-			ms.WriteArray(BitConverter.GetBytes(frame));
-			foreach (var o in orders)
-				ms.WriteArray(o.Serialize());
-			Send(ms.ToArray());
+			Send(OrderIO.SerializeOrders(frame, orders));
 		}
 
 		public virtual void SendImmediate(IEnumerable<Order> orders)
 		{
-			foreach (var o in orders)
-			{
-				var ms = new MemoryStream();
-				ms.WriteArray(BitConverter.GetBytes(0));
-				ms.WriteArray(o.Serialize());
-				Send(ms.ToArray());
-			}
+			Send(OrderIO.SerializeOrders(0, orders));
 		}
 
 		public virtual void SendSync(int frame, int syncHash, ulong defeatState)

--- a/OpenRA.Game/Network/Connection.cs
+++ b/OpenRA.Game/Network/Connection.cs
@@ -32,6 +32,7 @@ namespace OpenRA.Network
 	public interface IConnection : IDisposable
 	{
 		int LocalClientId { get; }
+		void StartGame();
 		void Send(int frame, IEnumerable<Order> orders);
 		void SendImmediate(IEnumerable<Order> orders);
 		void SendSync(int frame, int syncHash, ulong defeatState);
@@ -46,6 +47,12 @@ namespace OpenRA.Network
 		readonly Queue<OrderPacket> immediateOrders = new Queue<OrderPacket>();
 
 		int IConnection.LocalClientId => LocalClientId;
+
+		void IConnection.StartGame()
+		{
+			// Inject an empty frame to fill the gap we are making by projecting forward orders
+			orders.Enqueue((0, new OrderPacket(Array.Empty<Order>())));
+		}
 
 		void IConnection.Send(int frame, IEnumerable<Order> o)
 		{
@@ -67,8 +74,9 @@ namespace OpenRA.Network
 			while (immediateOrders.TryDequeue(out var i))
 				orderManager.ReceiveImmediateOrders(LocalClientId, i);
 
+			// Project orders forward to the next frame
 			while (orders.TryDequeue(out var o))
-				orderManager.ReceiveOrders(LocalClientId, o);
+				orderManager.ReceiveOrders(LocalClientId, (o.Frame + 1, o.Orders));
 
 			while (sync.TryDequeue(out var s))
 				orderManager.ReceiveSync(s);
@@ -207,6 +215,8 @@ namespace OpenRA.Network
 
 		int IConnection.LocalClientId => clientId;
 
+		void IConnection.StartGame() { }
+
 		void IConnection.Send(int frame, IEnumerable<Order> orders)
 		{
 			var o = new OrderPacket(orders.ToArray());
@@ -270,19 +280,26 @@ namespace OpenRA.Network
 				Recorder?.Receive(clientId, OrderIO.SerializeSync(s));
 			}
 
-			while (sentOrders.TryDequeue(out var o))
-			{
-				orderManager.ReceiveOrders(clientId, o);
-				Recorder?.Receive(clientId, o.Orders.Serialize(o.Frame));
-			}
-
 			// Orders from other players
 			while (receivedPackets.TryDequeue(out var p))
 			{
+				var record = true;
 				if (OrderIO.TryParseDisconnect(p.Data, out var disconnectClient))
 					orderManager.ReceiveDisconnect(disconnectClient);
 				else if (OrderIO.TryParseSync(p.Data, out var sync))
 					orderManager.ReceiveSync(sync);
+				else if (OrderIO.TryParseAck(p, out var ackFrame))
+				{
+					if (!sentOrders.TryDequeue(out var q))
+						throw new InvalidOperationException("Received Ack with empty send queue");
+
+					// The Acknowledgement packet is a placeholder that tells us to process the first packet in our
+					// local sent buffer and the frame at which it should be applied. This is an optimization to avoid having
+					// to send the (much larger than 5 byte) packet back to us over the network.
+					orderManager.ReceiveOrders(clientId, (ackFrame, q.Orders));
+					Recorder?.Receive(clientId, q.Orders.Serialize(ackFrame));
+					record = false;
+				}
 				else if (OrderIO.TryParseOrderPacket(p.Data, out var orders))
 				{
 					if (orders.Frame == 0)
@@ -293,7 +310,8 @@ namespace OpenRA.Network
 				else
 					throw new InvalidDataException($"Received unknown packet from client {p.FromClient} with length {p.Data.Length}");
 
-				Recorder?.Receive(p.FromClient, p.Data);
+				if (record)
+					Recorder?.Receive(p.FromClient, p.Data);
 			}
 		}
 

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -18,6 +18,7 @@ namespace OpenRA
 {
 	public enum OrderType : byte
 	{
+		Ack = 0x10,
 		SyncHash = 0x65,
 		Disconnect = 0xBF,
 		Handshake = 0xFE,

--- a/OpenRA.Game/Network/OrderIO.cs
+++ b/OpenRA.Game/Network/OrderIO.cs
@@ -79,6 +79,15 @@ namespace OpenRA.Network
 			return ms.GetBuffer();
 		}
 
+		public static byte[] SerializeOrders(int frame, IEnumerable<Order> orders)
+		{
+			var ms = new MemoryStream();
+			ms.WriteArray(BitConverter.GetBytes(frame));
+			foreach (var o in orders)
+				ms.WriteArray(o.Serialize());
+			return ms.ToArray();
+		}
+
 		public static bool TryParseDisconnect(byte[] packet, out int clientId)
 		{
 			if (packet.Length == Order.DisconnectOrderLength + 4 && packet[4] == (byte)OrderType.Disconnect)

--- a/OpenRA.Game/Network/OrderIO.cs
+++ b/OpenRA.Game/Network/OrderIO.cs
@@ -106,6 +106,19 @@ namespace OpenRA.Network
 			return true;
 		}
 
+		public static bool TryParseAck((int FromClient, byte[] Data) packet, out int frame)
+		{
+			// Ack packets are only accepted from the server
+			if (packet.FromClient != 0 || packet.Data.Length != 5 || packet.Data[4] != (byte)OrderType.Ack)
+			{
+				frame = 0;
+				return false;
+			}
+
+			frame = BitConverter.ToInt32(packet.Data, 0);
+			return true;
+		}
+
 		public static bool TryParseOrderPacket(byte[] packet, out (int Frame, OrderPacket Orders) data)
 		{
 			// Not a valid packet

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -128,19 +128,11 @@ namespace OpenRA.Network
 
 		public void ReceiveDisconnect(int clientIndex)
 		{
-			// HACK: The shellmap relies on ticking a disposed OM
-			if (disposed && World.Type != WorldType.Shellmap)
-				return;
-
 			pendingOrders.Remove(clientIndex);
 		}
 
 		public void ReceiveSync((int Frame, int SyncHash, ulong DefeatState) sync)
 		{
-			// HACK: The shellmap relies on ticking a disposed OM
-			if (disposed && World.Type != WorldType.Shellmap)
-				return;
-
 			if (syncForFrame.TryGetValue(sync.Frame, out var s))
 			{
 				if (s.SyncHash != sync.SyncHash || s.DefeatState != sync.DefeatState)
@@ -152,10 +144,6 @@ namespace OpenRA.Network
 
 		public void ReceiveImmediateOrders(int clientId, OrderPacket orders)
 		{
-			// HACK: The shellmap relies on ticking a disposed OM
-			if (disposed && World.Type != WorldType.Shellmap)
-				return;
-
 			foreach (var o in orders.GetOrders(World))
 			{
 				UnitOrders.ProcessOrder(this, World, clientId, o);
@@ -168,10 +156,6 @@ namespace OpenRA.Network
 
 		public void ReceiveOrders(int clientId, (int Frame, OrderPacket Orders) orders)
 		{
-			// HACK: The shellmap relies on ticking a disposed OM
-			if (disposed && World.Type != WorldType.Shellmap)
-				return;
-
 			if (pendingOrders.TryGetValue(clientId, out var queue))
 				queue.Enqueue((orders.Frame, orders.Orders));
 			else

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -137,19 +137,19 @@ namespace OpenRA.Network
 			pendingOrders.Remove(clientIndex);
 		}
 
-		public void ReceiveSync(int frame, int syncHash, ulong defeatState)
+		public void ReceiveSync((int Frame, int SyncHash, ulong DefeatState) sync)
 		{
 			// HACK: The shellmap relies on ticking a disposed OM
 			if (disposed && World.Type != WorldType.Shellmap)
 				return;
 
-			if (syncForFrame.TryGetValue(frame, out var s))
+			if (syncForFrame.TryGetValue(sync.Frame, out var s))
 			{
-				if (s.SyncHash != syncHash || s.DefeatState != defeatState)
-					OutOfSync(frame);
+				if (s.SyncHash != sync.SyncHash || s.DefeatState != sync.DefeatState)
+					OutOfSync(sync.Frame);
 			}
 			else
-				syncForFrame.Add(frame, (syncHash, defeatState));
+				syncForFrame.Add(sync.Frame, (sync.SyncHash, sync.DefeatState));
 		}
 
 		public void ReceiveImmediateOrders(int clientId, OrderPacket orders)
@@ -168,16 +168,16 @@ namespace OpenRA.Network
 			}
 		}
 
-		public void ReceiveOrders(int clientId, int frame, OrderPacket orders)
+		public void ReceiveOrders(int clientId, (int Frame, OrderPacket Orders) orders)
 		{
 			// HACK: The shellmap relies on ticking a disposed OM
 			if (disposed && World.Type != WorldType.Shellmap)
 				return;
 
 			if (pendingOrders.TryGetValue(clientId, out var queue))
-				queue.Enqueue((frame, orders));
+				queue.Enqueue((orders.Frame, orders.Orders));
 			else
-				Log.Write("debug", $"Received packet from disconnected client '{clientId}'");
+				throw new InvalidDataException($"Received packet from disconnected client '{clientId}'");
 		}
 
 		void ReceiveAllOrdersAndCheckSync()

--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -124,6 +124,8 @@ namespace OpenRA.Network
 			ordersFrame = orderLatency;
 		}
 
+		void IConnection.StartGame() { }
+
 		// Do nothing: ignore locally generated orders
 		void IConnection.Send(int frame, IEnumerable<Order> orders) { }
 		void IConnection.SendImmediate(IEnumerable<Order> orders) { }

--- a/OpenRA.Game/Network/ReplayRecorder.cs
+++ b/OpenRA.Game/Network/ReplayRecorder.cs
@@ -29,10 +29,10 @@ namespace OpenRA.Network
 
 		static bool IsGameStart(byte[] data)
 		{
-			if (!OrderIO.TryParseOrderPacket(data, out var frame, out var orders))
+			if (!OrderIO.TryParseOrderPacket(data, out var orders))
 				return false;
 
-			return frame == 0 && orders.GetOrders(null).Any(o => o.OrderString == "StartGame");
+			return orders.Frame == 0 && orders.Orders.GetOrders(null).Any(o => o.OrderString == "StartGame");
 		}
 
 		public ReplayRecorder(Func<string> chooseFilename)

--- a/OpenRA.Game/Server/ProtocolVersion.cs
+++ b/OpenRA.Game/Server/ProtocolVersion.cs
@@ -35,6 +35,8 @@ namespace OpenRA.Server
 		//   - Length-prefixed string specifying the order name
 		//   - OrderFields enum encoded as a byte: specifies the data included in the rest of the order
 		//   - Order-specific data - see OpenRA.Game/Server/Order.cs for details
+		// - 0x10: Order acknowledgement (sent from the server to a client in response to a packet with world orders)
+		//   - Int32 containing the frame number that the client should apply the orders it sent
 		//
 		// A connection handshake begins when a client opens a connection to the server:
 		// - Server sends:
@@ -68,6 +70,6 @@ namespace OpenRA.Server
 		// The protocol for server and world orders
 		// This applies after the handshake has completed, and is provided to support
 		// alternative server implementations that wish to support multiple versions in parallel
-		public const int Orders = 13;
+		public const int Orders = 14;
 	}
 }

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -61,6 +61,9 @@ namespace OpenRA.Server
 		public readonly MapStatusCache MapStatusCache;
 		public GameSave GameSave = null;
 
+		// Default to the next frame for ServerType.Local - MP servers take the value from the selected GameSpeed.
+		public int OrderLatency = 1;
+
 		readonly int randomSeed;
 		readonly List<TcpListener> listeners = new List<TcpListener>();
 		readonly TypeDictionary serverTraits = new TypeDictionary();
@@ -611,14 +614,22 @@ namespace OpenRA.Server
 
 		byte[] CreateFrame(int client, int frame, byte[] data)
 		{
-			using (var ms = new MemoryStream(data.Length + 12))
-			{
-				ms.WriteArray(BitConverter.GetBytes(data.Length + 4));
-				ms.WriteArray(BitConverter.GetBytes(client));
-				ms.WriteArray(BitConverter.GetBytes(frame));
-				ms.WriteArray(data);
-				return ms.GetBuffer();
-			}
+			var ms = new MemoryStream(data.Length + 12);
+			ms.WriteArray(BitConverter.GetBytes(data.Length + 4));
+			ms.WriteArray(BitConverter.GetBytes(client));
+			ms.WriteArray(BitConverter.GetBytes(frame));
+			ms.WriteArray(data);
+			return ms.GetBuffer();
+		}
+
+		byte[] CreateAckFrame(int frame)
+		{
+			var ms = new MemoryStream(13);
+			ms.WriteArray(BitConverter.GetBytes(5));
+			ms.WriteArray(BitConverter.GetBytes(0));
+			ms.WriteArray(BitConverter.GetBytes(frame));
+			ms.WriteByte((byte)OrderType.Ack);
+			return ms.GetBuffer();
 		}
 
 		void DispatchOrdersToClient(Connection c, int client, int frame, byte[] data)
@@ -784,10 +795,23 @@ namespace OpenRA.Server
 			if (frame == 0)
 				InterpretServerOrders(conn, data);
 			else
-				DispatchOrdersToClients(conn, frame, data);
+			{
+				// Non-immediate orders must be projected into the future so that all players can
+				// apply them on the same world tick. We can do this directly when forwarding the
+				// packet on to other clients, but sending the same data back to the client that
+				// sent it just to update the frame number would be wasteful. We instead send them
+				// a separate Ack packet that tells them to apply the order from a locally stored queue.
+				// TODO: Replace static latency with a dynamic order buffering system
+				if (data.Length == 0 || data[0] != (byte)OrderType.SyncHash)
+				{
+					frame += OrderLatency;
+					DispatchFrameToClient(conn, conn.PlayerIndex, CreateAckFrame(frame));
+				}
 
-			if (GameSave != null)
-				GameSave.DispatchOrders(conn, frame, data);
+				DispatchOrdersToClients(conn, frame, data);
+			}
+
+			GameSave?.DispatchOrders(conn, frame, data);
 		}
 
 		void InterpretServerOrders(Connection conn, byte[] data)
@@ -1202,6 +1226,13 @@ namespace OpenRA.Server
 				SyncLobbyInfo();
 				State = ServerState.GameStarted;
 
+				if (Type != ServerType.Local)
+				{
+					var gameSpeeds = Game.ModData.Manifest.Get<GameSpeeds>();
+					var gameSpeedName = LobbyInfo.GlobalSettings.OptionOrDefault("gamespeed", gameSpeeds.DefaultSpeed);
+					OrderLatency = gameSpeeds.Speeds[gameSpeedName].OrderLatency;
+				}
+
 				if (GameSave == null && LobbyInfo.GlobalSettings.GameSavesEnabled)
 					GameSave = new GameSave();
 
@@ -1224,6 +1255,7 @@ namespace OpenRA.Server
 				foreach (var t in serverTraits.WithInterface<IStartGame>())
 					t.GameStarted(this);
 
+				var firstFrame = 1;
 				if (GameSave != null && GameSave.LastOrdersFrame >= 0)
 				{
 					GameSave.ParseOrders(LobbyInfo, (frame, client, data) =>
@@ -1232,6 +1264,28 @@ namespace OpenRA.Server
 							if (c.Validated)
 								DispatchOrdersToClient(c, client, frame, data);
 					});
+
+					firstFrame += GameSave.LastOrdersFrame;
+				}
+
+				// ReceiveOrders projects player orders into the future so that all players can
+				// apply them on the same world tick.
+				// Clients require every frame to have an orders packet associated with it, so we must
+				// inject an empty packet for each frame that we are skipping forwards.
+				// TODO: Replace static latency with a dynamic order buffering system
+				var conns = Conns.Where(c => c.Validated).ToList();
+				foreach (var from in conns)
+				{
+					for (var i = 0; i < OrderLatency; i++)
+					{
+						var frame = firstFrame + i;
+						var frameData = CreateFrame(from.PlayerIndex, frame, Array.Empty<byte>());
+						foreach (var to in conns)
+							DispatchFrameToClient(to, from.PlayerIndex, frameData);
+
+						RecordOrder(frame, Array.Empty<byte>(), from.PlayerIndex);
+						GameSave?.DispatchOrders(from, frame, Array.Empty<byte>());
+					}
 				}
 			}
 		}

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -289,10 +289,8 @@ namespace OpenRA
 
 			gameInfo.DisabledSpawnPoints = OrderManager.LobbyInfo.DisabledSpawnPoints;
 
-			var rc = (OrderManager.Connection as EchoConnection)?.Recorder;
-
-			if (rc != null)
-				rc.Metadata = new ReplayMetadata(gameInfo);
+			if (OrderManager.Connection is NetworkConnection nc && nc.Recorder != null)
+				nc.Recorder.Metadata = new ReplayMetadata(gameInfo);
 		}
 
 		public void SetWorldOwner(Player p)

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -39,7 +39,6 @@ namespace OpenRA
 		public readonly GameSpeed GameSpeed;
 
 		public readonly int Timestep;
-		public readonly int OrderLatency;
 
 		public int ReplayTimestep;
 
@@ -189,13 +188,7 @@ namespace OpenRA
 			var gameSpeeds = modData.Manifest.Get<GameSpeeds>();
 			var gameSpeedName = orderManager.LobbyInfo.GlobalSettings.OptionOrDefault("gamespeed", gameSpeeds.DefaultSpeed);
 			GameSpeed = gameSpeeds.Speeds[gameSpeedName];
-
 			Timestep = ReplayTimestep = GameSpeed.Timestep;
-			OrderLatency = GameSpeed.OrderLatency;
-
-			// HACK: Turn down the latency if there is only one real player/spectator
-			if (orderManager.LobbyInfo.NonBotClients.Count() == 1)
-				OrderLatency = 1;
 
 			SharedRandom = new MersenneTwister(orderManager.LobbyInfo.GlobalSettings.RandomSeed);
 			LocalRandom = new MersenneTwister();

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -574,6 +574,12 @@ namespace OpenRA
 			while (frameEndActions.Count != 0)
 				frameEndActions.Dequeue()(this);
 
+			// HACK: The shellmap OrderManager is owned by its world in order to avoid
+			// problems with having multiple OMs active when joining a game lobby from the main menu.
+			// A matching check in Game.JoinInner handles OM disposal for all other cases.
+			if (Type == WorldType.Shellmap)
+				OrderManager.Dispose();
+
 			Game.FinishBenchmark();
 		}
 	}


### PR DESCRIPTION
This PR takes the order acks concept from #19588 and reworks it in a way that should be compatible with both current and new netcode systems, reducing the amount of parallel code and hopefully reducing the surface area for bugs.

The fundamental concept behind OpenRA's netcode is that clients generate packets that contain orders (attack X, move to Y) that are distributed to all clients, and then applied to the game state on some mutually agreed frame/tick. Getting these orders from each client to every other client takes a finite amount of time, so orders that are generated on net frame X (note that net frames are distinct from world ticks) need to be applied on net frame X + dX, where dX is what we call the order latency (typically 2-6 frames, or 6-18 ticks).

Our current plumbing uses a fixed latency for each game speed, which all clients manually add when serializing orders. This approach has worked well enough for many years, but can be done better. One of the big ideas from the netcode rework is to allow the server to dynamically vary the latency during gameplay, meaning that the common case can be much more responsive without making the game unplayable if network conditions degrade.

This PR takes the first few steps towards this by moving the calculation that applies the latency from the individual clients (before they send the orders) to the server (when the orders are routed to everyone else). This currently uses the same constant values as before - #19588 will replace this with its `OrderBuffer` system. It is not *quite* this simple, because the original client no longer knows when their orders should be applied. It would waste bandwidth if the server forwarded the players orders back to them, so it responds with just the frame number which the client combines with the original orders (which are stored in a new buffer) to give the same result to `OrderManager`. The server now also has to handle injecting empty frames at the start of the game, which is messy but (for now at least) an important part of the system.

I have taken this opportunity to clean up a bunch of other code and structural issues surrounding `OrderManager` and `Connection`. I strongly recommend reviewing by commit, with some extra context to help:

* ~~The first commit removes the one piece of gameplay code that depends on the order latency. Removing this now means we can remove all references to GameSpeed.OrderLatency from the client side. This is essentially replacing #9486 with a simpler (and hopefully temporary) workaround - the original issue was that `StructureProductionActiveDelay: 10` was not large enough for the fastest game speed, which has `OrderLatency: 6` ~ 18 ticks. I decided to use 25 because that is a nice round number (1 second) at the default game speed, and basically matches the current value at the fastest gamespeed. A future PR can hopefully fix this properly by explicitly accounting for just-placed structures and things in other production queues.~~
* ~~The second commit tries to implement a clear separation between `OrderManager` and `Connection`. `OrderManager` now only deals with engine-level concepts, and `Connection` (plus the new `OrdersPacket`) deals with converting those to and from raw byte streams. This should in theory be pure refactoring, with no changes to how/when things are processed.~~
* The third commit reduces some duplication in order serialization, split to its own commit because this does change how/when things are processed. Immediate orders are no longer forced to have their own individual packets, which has been redundant for many years now (afaik).
* The fourth commit splits the implementation of `EchoConnection` (used by the shellmap) and `NetworkConnection` (used by everything else). `EchoConnection` can now avoid serializating orders entirely. This may impact the order in which orders/immediate orders/sync packets are processed (but not the orders within each).
* The fifth commit finally implements the latency changes described at the start.