### PR TITLE
Fix three issues with the spectator UI

### DIFF
--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -25,30 +25,26 @@ namespace OpenRA.Mods.Common.Widgets
 		public readonly string Separators = "dropdown-separators";
 		public readonly string SeparatorImage = "separator";
 		public readonly TextAlign PanelAlign = TextAlign.Left;
+		public string PanelRoot;
 
 		Widget panel;
 		MaskWidget fullscreenMask;
 		Widget panelRoot;
-		readonly CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused), Sprite> getMarkerImage;
-		readonly CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused), Sprite> getSeparatorImage;
-
-		public string PanelRoot;
-		public string SelectedItem;
+		CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused), Sprite> getMarkerImage;
+		CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused), Sprite> getSeparatorImage;
 
 		[ObjectCreator.UseCtor]
 		public DropDownButtonWidget(ModData modData)
-			: base(modData)
-		{
-			getMarkerImage = WidgetUtils.GetCachedStatefulImage(Decorations, DecorationMarker);
-			getSeparatorImage = WidgetUtils.GetCachedStatefulImage(Separators, SeparatorImage);
-		}
+			: base(modData) { }
 
 		protected DropDownButtonWidget(DropDownButtonWidget widget)
 			: base(widget)
 		{
 			PanelRoot = widget.PanelRoot;
-			getMarkerImage = WidgetUtils.GetCachedStatefulImage(Decorations, DecorationMarker);
-			getSeparatorImage = WidgetUtils.GetCachedStatefulImage(Separators, SeparatorImage);
+			Decorations = widget.Decorations;
+			DecorationMarker = widget.DecorationMarker;
+			Separators = widget.Separators;
+			SeparatorImage = widget.SeparatorImage;
 		}
 
 		public override void Draw()
@@ -60,8 +56,14 @@ namespace OpenRA.Mods.Common.Widgets
 			var isDisabled = IsDisabled();
 			var isHover = Ui.MouseOverWidget == this || Children.Any(c => c == Ui.MouseOverWidget);
 
+			if (getMarkerImage == null)
+				getMarkerImage = WidgetUtils.GetCachedStatefulImage(Decorations, DecorationMarker);
+
 			var arrowImage = getMarkerImage.Update((isDisabled, Depressed, isHover, false));
 			WidgetUtils.DrawSprite(arrowImage, stateOffset + new float2(rb.Right - (int)((rb.Height + arrowImage.Size.X) / 2), rb.Top + (int)((rb.Height - arrowImage.Size.Y) / 2)));
+
+			if (getSeparatorImage == null)
+				getSeparatorImage = WidgetUtils.GetCachedStatefulImage(Separators, SeparatorImage);
 
 			var separatorImage = getSeparatorImage.Update((isDisabled, Depressed, isHover, false));
 			if (separatorImage != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
@@ -97,13 +97,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				.OrderBy(g => g.Key);
 
 			var noTeams = teams.Count() == 1;
+			var totalPlayers = 0;
 			foreach (var t in teams)
 			{
+				totalPlayers += t.Count();
 				var label = noTeams ? "Players" : t.Key == 0 ? "No Team" : $"Team {t.Key}";
 				groups.Add(label, t);
 			}
 
+			var shroudSelectorDisabled = limitViews && totalPlayers < 2;
 			var shroudSelector = widget.Get<DropDownButtonWidget>("SHROUD_SELECTOR");
+			shroudSelector.IsDisabled = () => shroudSelectorDisabled;
 			shroudSelector.OnMouseDown = _ =>
 			{
 				Func<CameraOption, ScrollItemWidget, ScrollItemWidget> setupItem = (option, template) =>

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			for (var i = 0; i < keyNames.Length; i++)
 				statsHotkeys[i] = logicArgs.TryGetValue("Statistics" + keyNames[i] + "Key", out yaml) ? modData.Hotkeys[yaml.Value] : new HotkeyReference();
 
-			players = world.Players.Where(p => !p.NonCombatant);
+			players = world.Players.Where(p => !p.NonCombatant && p.Playable);
 			teams = players.GroupBy(p => (world.LobbyInfo.ClientWithIndex(p.ClientIndex) ?? new Session.Client()).Team).OrderBy(g => g.Key);
 			hasTeams = !(teams.Count() == 1 && teams.First().Key == 0);
 


### PR DESCRIPTION
This PR fixes some issues that I noticed while testing the netcode work.

<img src="https://user-images.githubusercontent.com/167819/131047265-bd49c4ff-1e54-43da-a0ea-06d88a805ee6.png">

The first commit fixes the red separator in the visibility dropdown. This was a regression from #19443: yaml values are not assigned until the `Initialize` method runs, *after* the ctor.

The second commit fixes the overlapping scrollbar buttons in the dropdown by disabling it if there is only one player.

<img src="https://user-images.githubusercontent.com/167819/131047445-c8913832-769e-4310-82f5-cfc016f33362.png">

The third commit hides non-playable factions (USSR, England) from the info panels. These leak info that allow the player to cheat (which was something we decided we didn't want to allow), and show off all the hacks that the script does with spawning units / manipulating money / etc behind the scenes.