### PR TITLE
Make yaml check utility load each map separately to reduce memory usage.

### DIFF
--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -117,7 +117,7 @@ namespace OpenRA
 			}
 		}
 
-		public IEnumerable<IReadWritePackage> EnumerateMapPackagesWithoutCaching(MapClassification classification = MapClassification.System)
+		public IEnumerable<IReadWritePackage> EnumerateMapDirPackages(MapClassification classification = MapClassification.System)
 		{
 			// Utility mod that does not support maps
 			if (!modData.Manifest.Contains<MapGrid>())
@@ -143,14 +143,27 @@ namespace OpenRA
 					continue;
 
 				using (var package = (IReadWritePackage)modData.ModFiles.OpenPackage(name))
-				{
-					foreach (var map in package.Contents)
-					{
-						if (package.OpenPackage(map, modData.ModFiles) is IReadWritePackage mapPackage)
-							yield return mapPackage;
-					}
-				}
+					yield return package;
 			}
+		}
+
+		public IEnumerable<(IReadWritePackage package, string map)> EnumerateMapDirPackagesAndNames(MapClassification classification = MapClassification.System)
+		{
+			var mapDirPackages = EnumerateMapDirPackages(classification);
+
+			foreach (var mapDirPackage in mapDirPackages)
+				foreach (var map in mapDirPackage.Contents)
+					yield return (mapDirPackage, map);
+		}
+
+		public IEnumerable<IReadWritePackage> EnumerateMapPackagesWithoutCaching(MapClassification classification = MapClassification.System)
+		{
+			var mapDirPackages = EnumerateMapDirPackages(classification);
+
+			foreach (var mapDirPackage in mapDirPackages)
+				foreach (var map in mapDirPackage.Contents)
+					if (mapDirPackage.OpenPackage(map, modData.ModFiles) is IReadWritePackage mapPackage)
+						yield return mapPackage;
 		}
 
 		public IEnumerable<Map> EnumerateMapsWithoutCaching(MapClassification classification = MapClassification.System)


### PR DESCRIPTION
I ran into an out of memory exception when building CA, and identified the problem being with the YAML check in the utility tool. It loads every map with a significant overhead before checking them, and CA with its 300+ maps ends up using about 8.5GB of RAM.

Running --check-yaml on the bleed RA mod uses approx 1.2GB of RAM. These changes reduce it to around 400MB.