### PR TITLE
Make the editor use an EchoConnection instead of a local server

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -103,6 +103,20 @@ namespace OpenRA
 		static void JoinLocal()
 		{
 			JoinInner(new OrderManager(new EchoConnection()));
+
+			// Add a spectator client for the local player
+			// On the shellmap this player is controlling the map via scripted orders
+			OrderManager.LobbyInfo.Clients.Add(new Session.Client
+			{
+				Index = OrderManager.Connection.LocalClientId,
+				Name = Settings.Player.Name,
+				PreferredColor = Settings.Player.Color,
+				Color = Settings.Player.Color,
+				Faction = "Random",
+				SpawnPoint = 0,
+				Team = 0,
+				State = Session.ClientState.Ready
+			});
 		}
 
 		// More accurate replacement for Environment.TickCount
@@ -484,27 +498,13 @@ namespace OpenRA
 
 		public static void LoadEditor(string mapUid)
 		{
+			JoinLocal();
 			StartGame(mapUid, WorldType.Editor);
 		}
 
 		public static void LoadShellMap()
 		{
 			var shellmap = ChooseShellmap();
-
-			// Add a spectator client for the local player,
-			// who is controlling the map via scripted orders
-			OrderManager.LobbyInfo.Clients.Add(new Session.Client
-			{
-				Index = OrderManager.Connection.LocalClientId,
-				Name = Settings.Player.Name,
-				PreferredColor = Settings.Player.Color,
-				Color = Settings.Player.Color,
-				Faction = "Random",
-				SpawnPoint = 0,
-				Team = 0,
-				State = Session.ClientState.Ready
-			});
-
 			using (new PerfTimer("StartGame"))
 			{
 				StartGame(shellmap, WorldType.Shellmap);

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -343,10 +343,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void LoadMapIntoEditor(string uid)
 		{
-			ConnectionLogic.Connect(Game.CreateLocalServer(uid),
-				"",
-				() => { Game.LoadEditor(uid); },
-				() => { Game.CloseServer(); SwitchMenu(MenuType.MapEditor); });
+			Game.LoadEditor(uid);
 
 			DiscordService.UpdateStatus(DiscordState.InMapEditor);
 


### PR DESCRIPTION
Fixes #19652. We no longer join a local server, and move the shellmap-specific special case for adding a dummy client to `JoinLocal` so it is re-used for the editor.