### PR TITLE
Fix d2k map editor crash if spice is placed at the edge of map.

### DIFF
--- a/OpenRA.Mods.D2k/Traits/World/D2kResourceRenderer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/D2kResourceRenderer.cs
@@ -140,7 +140,8 @@ namespace OpenRA.Mods.D2k.Traits
 			for (var i = 0; i < directions.Length; i++)
 			{
 				var neighbour = cell + directions[i];
-				UpdateRenderedSpriteInner(neighbour, RenderContents[neighbour]);
+				if (RenderContents.Contains(neighbour))
+					UpdateRenderedSpriteInner(neighbour, RenderContents[neighbour]);
 			}
 		}
 


### PR DESCRIPTION
Fixes #19654.