### PR TITLE
Follow up to making the editor use an EchoConnection

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -72,12 +72,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					// HACK: Work around a synced-code change check.
 					// It's not clear why this is needed here, but not in the other places that load maps.
-					Game.RunAfterTick(() =>
-					{
-						ConnectionLogic.Connect(Game.CreateLocalServer(uid), "",
-							() => Game.LoadEditor(uid),
-							() => { Game.CloseServer(); onExit(); });
-					});
+					Game.RunAfterTick(() => Game.LoadEditor(uid));
 
 					Ui.CloseWindow();
 					onSelect(uid);

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -343,7 +343,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void LoadMapIntoEditor(string uid)
 		{
-			Game.LoadEditor(uid);
+			// HACK: Work around a synced-code change check.
+			// It's not clear why this is needed here, but not in the other places that load maps.
+			Game.RunAfterTick(() => Game.LoadEditor(uid));
 
 			DiscordService.UpdateStatus(DiscordState.InMapEditor);
 


### PR DESCRIPTION
I missed a spot that still uses a local server when a new map is created in #19653. I also added a workaround for a crash that happens when loading into a map with "Check around (un)synced code" is enabled.