### PR TITLE
Fix OpenAlSound.Complete being incorrect when OpenAl source is reused.

### DIFF
--- a/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
+++ b/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
@@ -171,6 +171,15 @@ namespace OpenRA.Platforms.Default
 					freeSources.Add(freeSource);
 					AL10.alSourceRewind(freeSource);
 					AL10.alSourcei(freeSource, AL10.AL_BUFFER, 0);
+
+					// Make sure we can accurately determine the end of the original sound,
+					// even if the source is immediately reused.
+					sound.Done = true;
+
+					var slot = kv.Value;
+					slot.SoundSource = null;
+					slot.Sound = null;
+					slot.IsActive = false;
 				}
 			}
 
@@ -178,14 +187,6 @@ namespace OpenRA.Platforms.Default
 			{
 				source = 0;
 				return false;
-			}
-
-			foreach (var freeSource in freeSources)
-			{
-				var slot = sourcePool[freeSource];
-				slot.SoundSource = null;
-				slot.Sound = null;
-				slot.IsActive = false;
 			}
 
 			source = freeSources[0];
@@ -416,6 +417,8 @@ namespace OpenRA.Platforms.Default
 		public readonly uint Source;
 		protected readonly float SampleRate;
 
+		public bool Done;
+
 		public OpenAlSound(uint source, bool looping, bool relative, WPos pos, float volume, int sampleRate, uint buffer)
 			: this(source, looping, relative, pos, volume, sampleRate)
 		{
@@ -458,6 +461,9 @@ namespace OpenRA.Platforms.Default
 		{
 			get
 			{
+				if (Done)
+					return true;
+
 				AL10.alGetSourcei(Source, AL10.AL_SOURCE_STATE, out var state);
 				return state == AL10.AL_STOPPED;
 			}


### PR DESCRIPTION
I ran into this issue when trying to synchronize sequences to audio clips downstream. For that I needed to know when an audio clip has completed. When there are a lot of other sounds playing at the same time this would often go wrong.

The problem here is that OpenAlSound.Complete just looks at the status of the underlying OpenAl source. If another sound is started after the original sound has completed, the new sound might reuse the same underlying source. If the Complete method on the original sound is then evaluated again afterwards, it will return the status of the new sound instead of the original sound.

I added a simple boolean flag that gets set whenever the underlying source of the sound is reused, so that the Complete method will keep evaluating as true.