### PR TITLE
Fixed AttackBomber FacingTolerance being defined twice

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
@@ -19,9 +19,6 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public class AttackBomberInfo : AttackBaseInfo
 	{
-		[Desc("Tolerance for attack angle. Range [0, 512], 512 covers 360 degrees.")]
-		public readonly new WAngle FacingTolerance = new WAngle(8);
-
 		public override object Create(ActorInitializer init) { return new AttackBomber(init.Self, this); }
 	}
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/AttackBomberFacingTolerance.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/AttackBomberFacingTolerance.cs
@@ -1,0 +1,37 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class AttackBomberFacingTolerance : UpdateRule
+	{
+		public override string Name => "Adds the old default value for AttackBomber FacingTolerance.";
+
+		public override string Description => "The tolerance for attack angle was defined twice on AttackBomber. This override has to be defined in the rules now.";
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var attackBomber in actorNode.ChildrenMatching("AttackBomber"))
+			{
+				var facingTolerance = attackBomber.LastChildMatching("FacingTolerance");
+				if (facingTolerance != null)
+					continue;
+
+				var facingToleranceNode = new MiniYamlNode("FacingTolerance", FieldSaver.FormatValue(new WAngle(8)));
+				attackBomber.AddNode(facingToleranceNode);
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -96,6 +96,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveSmokeTrailWhenDamaged(),
 				new ReplaceCrateSecondsWithTicks(),
 				new UseMillisecondsForSounds(),
+				new AttackBomberFacingTolerance(),
 			})
 		};
 

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -232,6 +232,7 @@ A10:
 		Repulsable: False
 	AttackBomber:
 		Armaments: gun, bombs
+		FacingTolerance: 8
 	Armament@GUNS:
 		Name: gun
 		Weapon: Vulcan

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -96,6 +96,7 @@ frigate:
 ornithopter:
 	Inherits: ^Plane
 	AttackBomber:
+		FacingTolerance: 8
 	Armament:
 		Weapon: OrniBomb
 	Health:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -53,6 +53,7 @@ BADR.Bomber:
 	RenderSprites:
 		Image: badr
 	AttackBomber:
+		FacingTolerance: 8
 	AmmoPool:
 		Ammo: 5
 	Armament:
@@ -439,6 +440,7 @@ U2:
 		Repulsable: False
 		MaximumPitch: 56
 	AttackBomber:
+		FacingTolerance: 8
 	-Selectable:
 	-Voiced:
 	-Targetable@AIRBORNE:


### PR DESCRIPTION
https://docs.openra.net/en/latest/release/traits/#attackbomber reveals that `FacingTolerance` is defined twice. I believe the override should happen in .yaml level and not in code by duplicating fields.