### PR TITLE
Acknowledge multiple sent order packets for a single nettick

### DIFF
--- a/OpenRA.Game/Server/ProtocolVersion.cs
+++ b/OpenRA.Game/Server/ProtocolVersion.cs
@@ -38,6 +38,7 @@ namespace OpenRA.Server
 		//   - Order-specific data - see OpenRA.Game/Server/Order.cs for details
 		// - 0x10: Order acknowledgement (sent from the server to a client in response to a packet with world orders)
 		//   - Int32 containing the frame number that the client should apply the orders it sent
+		//   - [optional] Int32 containing the number of sent order packets to apply
 		//
 		// A connection handshake begins when a client opens a connection to the server:
 		// - Server sends:
@@ -71,6 +72,6 @@ namespace OpenRA.Server
 		// The protocol for server and world orders
 		// This applies after the handshake has completed, and is provided to support
 		// alternative server implementations that wish to support multiple versions in parallel
-		public const int Orders = 15;
+		public const int Orders = 16;
 	}
 }


### PR DESCRIPTION
Since protocol version 14 it is possible for the server to combine multiple order packets into one before sending it out to the clients. This is required to catch up after the server inserted a dummy order for a specific client (for example to avoid stalling the game if the orders are late). Unfortunately the current acknowledge packet format offers no way to do that so servers are forced to send full orders back to the original client, which is exactly what the acknowledge system is trying to avoid.