### PR TITLE
Fixed hashset being translated into set of arrays

### DIFF
--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -212,7 +212,7 @@ namespace OpenRA.Mods.Common
 		public static string FriendlyTypeName(Type t)
 		{
 			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(HashSet<>))
-				return $"Set of {t.GetGenericArguments().Select(FriendlyTypeName).ToArray()}";
+				return $"Set of {t.GetGenericArguments().Select(FriendlyTypeName).First()}";
 
 			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Dictionary<,>))
 			{


### PR DESCRIPTION
`HashSet<string>` gets converted into `Set of System.String[]` when running `./utility.sh all --docs > traits.md` which is confusing. A hash set can't have more than one content type as far as I know.