### PR TITLE
Add support for non-overlapping sound notifications 

### DIFF
--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -45,6 +45,7 @@ namespace OpenRA
 		ISound video;
 		MusicInfo currentMusic;
 		Dictionary<uint, ISound> currentSounds = new Dictionary<uint, ISound>();
+		Dictionary<string, ISound> currentNotifications = new Dictionary<string, ISound>();
 		public bool DummyEngine { get; private set; }
 
 		public Sound(IPlatform platform, SoundSettings soundSettings)
@@ -390,16 +391,29 @@ namespace OpenRA
 
 			if (!string.IsNullOrEmpty(name) && (p == null || p == p.World.LocalPlayer))
 			{
+				if (currentNotifications.ContainsKey(name) && !currentNotifications[name].Complete)
+				{
+					if (pool.AllowInterrupt)
+						soundEngine.StopSound(currentNotifications[name]);
+					else
+						return false;
+				}
+				else if (currentSounds.ContainsKey(id) && !currentSounds[id].Complete)
+				{
+					if (pool.AllowInterrupt)
+						soundEngine.StopSound(currentSounds[id]);
+					else
+						return false;
+				}
+
 				var sound = soundEngine.Play2D(sounds[name],
 					false, relative, pos,
 					InternalSoundVolume * volumeModifier * pool.VolumeModifier, attenuateVolume);
-				if (id != 0)
-				{
-					if (currentSounds.ContainsKey(id))
-						soundEngine.StopSound(currentSounds[id]);
 
+				if (id != 0)
 					currentSounds[id] = sound;
-				}
+				else
+					currentNotifications[name] = sound;
 			}
 
 			return true;

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -388,6 +388,7 @@ namespace OpenRA
 			}
 
 			var name = prefix + clip + suffix;
+			var actorId = voicedActor != null && voicedActor.World.Selection.Contains(voicedActor) ? 0 : id;
 
 			if (!string.IsNullOrEmpty(name) && (p == null || p == p.World.LocalPlayer))
 			{
@@ -398,10 +399,10 @@ namespace OpenRA
 					else
 						return false;
 				}
-				else if (currentSounds.ContainsKey(id) && !currentSounds[id].Complete)
+				else if (currentSounds.ContainsKey(actorId) && !currentSounds[actorId].Complete)
 				{
 					if (pool.AllowInterrupt)
-						soundEngine.StopSound(currentSounds[id]);
+						soundEngine.StopSound(currentSounds[actorId]);
 					else
 						return false;
 				}
@@ -410,8 +411,8 @@ namespace OpenRA
 					false, relative, pos,
 					InternalSoundVolume * volumeModifier * pool.VolumeModifier, attenuateVolume);
 
-				if (id != 0)
-					currentSounds[id] = sound;
+				if (voicedActor != null)
+					currentSounds[actorId] = sound;
 				else
 					currentNotifications[name] = sound;
 			}

--- a/mods/cnc/audio/notifications.yaml
+++ b/mods/cnc/audio/notifications.yaml
@@ -54,6 +54,7 @@ Sounds:
 	Notifications:
 		Appear: appear1
 		Beacon: bleep2
+			AllowInterrupt: true
 		Beepy2: beepy2
 		Beepy3: beepy3
 		Beepy6: beepy6
@@ -61,8 +62,11 @@ Sounds:
 		CashTickUp: tone15
 			VolumeModifier: 0.33
 		ChatLine: scold1
+			AllowInterrupt: true
 		ClickDisabledSound: scold2
+			AllowInterrupt: true
 		ClickSound: button
+			AllowInterrupt: true
 		Cloak: trans1
 		Clock: clock1
 		Construction: constru2

--- a/mods/d2k/audio/notifications.yaml
+++ b/mods/d2k/audio/notifications.yaml
@@ -70,9 +70,14 @@ Sounds:
 		CashTickDown: CASHTIK1
 		LevelUp: SCORTIK1
 		ChatLine: CHAT1
+			AllowInterrupt: true
 		BuildPaletteOpen: BUTTON1
 		BuildPaletteClose: BUTTON1
 		TabClick: SIDEBAR1
+			AllowInterrupt: true
 		ClickSound: BUTTON1
+			AllowInterrupt: true
 		ClickDisabledSound: ENDLIST1
+			AllowInterrupt: true
 		Beacon: CHAT1
+			AllowInterrupt: true

--- a/mods/ra/audio/notifications.yaml
+++ b/mods/ra/audio/notifications.yaml
@@ -126,9 +126,12 @@ Sounds:
 		DisablePower: bleep11
 		EnablePower: bleep12
 		ChatLine: rabeep1
+			AllowInterrupt: true
 		ClickSound: ramenu1
+			AllowInterrupt: true
 		ClickDisabledSound:
 		Beacon: beepslct
+			AllowInterrupt: true
 		AlertBuzzer: buzzy1
 		AlertBleep: bleep6
 		BaseSetup: bleep9

--- a/mods/ts/audio/sounds-generic.yaml
+++ b/mods/ts/audio/sounds-generic.yaml
@@ -2,6 +2,7 @@ Sounds:
 	Notifications:
 		Bargraph: bargraph
 		Beacon: message1
+			AllowInterrupt: true
 		Bestbox: bestbox
 		Blip: blip
 		BuildPaletteClose: emblem
@@ -13,8 +14,11 @@ Sounds:
 		CashTickUp: credup1
 			VolumeModifier: 0.33
 		ChatLine: message1
+			AllowInterrupt: true
 		ClickDisabledSound: wrong1
+			AllowInterrupt: true
 		ClickSound: clicky1
+			AllowInterrupt: true
 		GameForming: gamefrm1
 		Gdiclose: gdiclose
 		Gdiopen: gdiopen


### PR DESCRIPTION
## Notifications
Currently there are no checks so all notifications play generating loud noise, for example:
```
Unit lost.
Unit lost.
 Unit lost.
  Unit lost.
    Unit lost.
          Unit lost.
```

This PR allows notifications to play in one of two ways:
1. Stop the audio that's playing and then start it again (by setting `AllowInterrupt` to `true`):
```
U
 U
  Un
    Unit l
          Unit lost.
```
This is useful for user initiated actions that should always give audible feedback (button clicks, beacons). **Note:** This produces a noticeable difference for longer sound samples (for example compare the sound when spamming beacons in d2k).

2. Play a new notification only if there's none of the same type playing at the moment:
```
Unit lost.
          Unit lost.
```
This removes superfluous notifications (e.g. multiple units dying in quick succession).

## Voices
Unit voices currently are handled differently by restarting the sound which results in a stutter:
```
A
 A
  Af
    Affir
         Affirmitive. 
```
This is not how most games handle voices so I've also changed it so that each quote plays in full:
```
Affirmitive.
            Affirmitive. 
```

Closes #4690
Related #3449

Depends on #19660