### PR TITLE
Changed SupportPower descriptors

### DIFF
--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
@@ -29,8 +29,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Palette used for the icon.")]
 		public readonly string IconPalette = "chrome";
 
+		public readonly string Name = "";
 		public readonly string Description = "";
-		public readonly string LongDesc = "";
 
 		[Desc("Allow multiple instances of the same support power.")]
 		public readonly bool AllowMultiple = false;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20201213/RenameSupportPowerDescription.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20201213/RenameSupportPowerDescription.cs
@@ -1,0 +1,32 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RenameSupportPowerDescription : UpdateRule
+	{
+		public override string Name => "Support powers now use 'Name' and 'Description' fields like units.";
+		public override string Description => "'Description' was renamed to 'Name' and 'LongDesc' was renamed to 'Description'.";
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var traitNode in actorNode.ChildrenContaining("Power"))
+			{
+				traitNode.RenameChildrenMatching("Description", "Name");
+				traitNode.RenameChildrenMatching("LongDesc", "Description");
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/CopyIsometricSelectableHeight.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/CopyIsometricSelectableHeight.cs
@@ -63,8 +63,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			if (complete || actorNode.LastChildMatching("IsometricSelectable") != null)
 				yield break;
 
-			var height = 0;
-			if (!selectionHeight.TryGetValue(actorNode.Key.ToLowerInvariant(), out height))
+			if (!selectionHeight.TryGetValue(actorNode.Key.ToLowerInvariant(), out var height))
 				yield break;
 
 			// Don't redefine the default value

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
@@ -53,10 +53,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (sp == lastPower && hotkey == lastHotkey && lastRemainingSeconds == remainingSeconds)
 					return;
 
-				nameLabel.Text = sp.Info.Description;
+				nameLabel.Text = sp.Info.Name;
 				var nameSize = nameFont.Measure(nameLabel.Text);
 
-				descLabel.Text = sp.Info.LongDesc.Replace("\\n", "\n");
+				descLabel.Text = sp.Info.Description.Replace("\\n", "\n");
 				var descSize = descFont.Measure(descLabel.Text);
 
 				var customLabel = sp.TooltipTimeTextOverride();

--- a/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				var self = p.Instances[0].Self;
 				var time = WidgetUtils.FormatTime(p.RemainingTicks, false, self.World.Timestep);
-				var text = Format.F(p.Info.Description, time);
+				var text = Format.F(p.Info.Name, time);
 				var playerColor = self.Owner.Color;
 
 				if (Game.Settings.Game.UsePlayerStanceColors)

--- a/mods/cnc/rules/campaign-maprules.yaml
+++ b/mods/cnc/rules/campaign-maprules.yaml
@@ -62,8 +62,8 @@ airstrike.proxy:
 		ChargeInterval: 3000
 		SquadSize: 3
 		QuantizedFacings: 8
-		Description: Air Strike
-		LongDesc: Deploy an aerial napalm strike.\nBurns buildings and infantry along a line.
+		Name: Air Strike
+		Description: Deploy an aerial napalm strike.\nBurns buildings and infantry along a line.
 		EndChargeSpeechNotification: AirstrikeReady
 		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSpeechNotification: InsufficientPower

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -637,8 +637,8 @@ HQ:
 		ChargeInterval: 7500
 		SquadSize: 3
 		QuantizedFacings: 8
-		Description: Air Strike
-		LongDesc: Deploy an aerial napalm strike.\nBurns buildings and infantry along a line.
+		Name: Air Strike
+		Description: Deploy an aerial napalm strike.\nBurns buildings and infantry along a line.
 		EndChargeSpeechNotification: AirstrikeReady
 		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSpeechNotification: InsufficientPower
@@ -744,8 +744,8 @@ EYE:
 		Icon: ioncannon
 		Cursor: ioncannon
 		ChargeInterval: 9000
-		Description: Ion Cannon
-		LongDesc: Initiate an Ion Cannon strike.\nApplies instant damage to a small area.
+		Name: Ion Cannon
+		Description: Initiate an Ion Cannon strike.\nApplies instant damage to a small area.
 		BeginChargeSpeechNotification: IonCannonCharging
 		EndChargeSpeechNotification: IonCannonReady
 		SelectTargetSpeechNotification: SelectTarget
@@ -798,8 +798,8 @@ TMPL:
 		Icon: abomb
 		Cursor: nuke
 		ChargeInterval: 11250
-		Description: Nuclear Strike
-		LongDesc: Launch a tactical nuclear warhead.\nApplies heavy damage over a large area.
+		Name: Nuclear Strike
+		Description: Launch a tactical nuclear warhead.\nApplies heavy damage over a large area.
 		EndChargeSpeechNotification: NuclearWeaponAvailable
 		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSpeechNotification: InsufficientPower

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -917,12 +917,12 @@ high_tech_factory:
 	ProvidesPrerequisite@buildingname:
 	AirstrikePower:
 		Icon: ornistrike
-		Description: Air Strike
+		Name: Air Strike
 		Prerequisites: ~techlevel.superweapons, upgrade.hightech
 		ChargeInterval: 7500
 		SquadSize: 3
 		SquadOffset: -1536, 1024, 0
-		LongDesc: Ornithopters hit the target with bombs
+		Description: Ornithopters hit the target with bombs
 		UnitType: ornithopter
 		DisplayBeacon: True
 		CameraActor: camera
@@ -1060,8 +1060,8 @@ palace:
 		RequiresCondition: harkonnen
 		Prerequisites: ~techlevel.superweapons, ~palace.nuke
 		ChargeInterval: 7500
-		Description: Death Hand
-		LongDesc: Launches an atomic missile at a target location
+		Name: Death Hand
+		Description: Launches an atomic missile at a target location
 		BeginChargeSpeechNotification: DeathHandMissilePrepping
 		EndChargeSpeechNotification: DeathHandMissileReady
 		IncomingSpeechNotification: MissileLaunchDetected
@@ -1081,8 +1081,8 @@ palace:
 		TrailSequences: idle
 		SupportPowerPaletteOrder: 40
 	ProduceActorPower@fremen:
-		Description: Recruit Fremen
-		LongDesc: Elite infantry unit armed with assault rifles and rockets\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery\n  Special Ability: Invisibility
+		Name: Recruit Fremen
+		Description: Elite infantry unit armed with assault rifles and rockets\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery\n  Special Ability: Invisibility
 		Icon: fremen
 		PauseOnCondition: disabled
 		RequiresCondition: atreides
@@ -1095,8 +1095,8 @@ palace:
 		OrderName: ProduceActorPower.Fremen
 		SupportPowerPaletteOrder: 20
 	ProduceActorPower@saboteur:
-		Description: Recruit Saboteur
-		LongDesc: Sneaky infantry, armed with explosives\n  Strong vs Buildings\n  Weak vs Everything\n  Special Ability: destroy buildings
+		Name: Recruit Saboteur
+		Description: Sneaky infantry, armed with explosives\n  Strong vs Buildings\n  Weak vs Everything\n  Special Ability: destroy buildings
 		Icon: saboteur
 		PauseOnCondition: disabled
 		RequiresCondition: ordos

--- a/mods/ra/maps/bomber-john/rules.yaml
+++ b/mods/ra/maps/bomber-john/rules.yaml
@@ -83,8 +83,8 @@ Player:
 	ChronoshiftPower:
 		Icon: chrono
 		ChargeInterval: 1500
-		Description: Chronoshift
-		LongDesc: Teleport a group of vehicles across\nthe map.
+		Name: Chronoshift
+		Description: Teleport a group of vehicles across\nthe map.
 		SelectTargetSound: slcttgt1.aud
 		BeginChargeSound: chrochr1.aud
 		EndChargeSound: chrordy1.aud
@@ -94,8 +94,8 @@ Player:
 	GrantExternalConditionPower@IRONCURTAIN:
 		Icon: invuln
 		ChargeInterval: 750
-		Description: Invulnerability
-		LongDesc: Makes a unit invulnerable\nfor 3 seconds.
+		Name: Invulnerability
+		Description: Makes a unit invulnerable\nfor 3 seconds.
 		Duration: 75
 		SelectTargetSound: slcttgt1.aud
 		BeginChargeSound: ironchg1.aud

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -344,7 +344,7 @@ V2RL:
 
 powerproxy.parabombs:
 	AirstrikePower:
-		LongDesc: A MiG bomber drops a load of parachuted bombs on your target.
+		Description: A MiG bomber drops a load of parachuted bombs on your target.
 		CameraRemoveDelay: 50
 
 BADR.Bomber:

--- a/mods/ra/maps/top-o-the-world/rules.yaml
+++ b/mods/ra/maps/top-o-the-world/rules.yaml
@@ -54,8 +54,8 @@ powerproxy.spyplane:
 		OrderName: SovietSpyPlane
 		Icon: spyplane
 		ChargeInterval: 4500
-		Description: Spy Plane (Single Use)
-		LongDesc: Reveals an area of the map and cloaked enemy units.
+		Name: Spy Plane (Single Use)
+		Description: Reveals an area of the map and cloaked enemy units.
 		OneShot: true
 		SelectTargetSpeechNotification: SelectTarget
 		EndChargeSpeechNotification: SpyPlaneReady

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -345,8 +345,8 @@ powerproxy.parabombs:
 	AlwaysVisible:
 	AirstrikePower:
 		Icon: parabombs
-		Description: Parabombs (Single Use)
-		LongDesc: A Badger drops a load of parachuted bombs on your target.
+		Name: Parabombs (Single Use)
+		Description: A Badger drops a load of parachuted bombs on your target.
 		OneShot: true
 		AllowMultiple: true
 		UnitType: badr.bomber
@@ -364,8 +364,8 @@ powerproxy.sonarpulse:
 	AlwaysVisible:
 	SpawnActorPower:
 		Icon: sonar
-		Description: Sonar Pulse
-		LongDesc: Reveals all submarines in the vicinity for a \nshort time.
+		Name: Sonar Pulse
+		Description: Reveals all submarines in the vicinity for a \nshort time.
 		ChargeInterval: 750
 		EndChargeSpeechNotification: SonarPulseReady
 		SelectTargetSpeechNotification: SelectTarget
@@ -383,8 +383,8 @@ powerproxy.paratroopers:
 	AlwaysVisible:
 	ParatroopersPower:
 		Icon: paratroopers
-		Description: Paratroopers
-		LongDesc: A Badger drops a squad of infantry\nanywhere on the map.
+		Name: Paratroopers
+		Description: A Badger drops a squad of infantry\nanywhere on the map.
 		DropItems: E1,E1,E1,E3,E3
 		SelectTargetSpeechNotification: SelectTarget
 		AllowImpassableCells: false

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -37,8 +37,8 @@ MSLO:
 		Cursor: nuke
 		Icon: abomb
 		ChargeInterval: 13500
-		Description: Atom Bomb
-		LongDesc: Launches a devastating atomic bomb\nat a target location.
+		Name: Atom Bomb
+		Description: Launches a devastating atomic bomb\nat a target location.
 		BeginChargeSpeechNotification: AbombPrepping
 		EndChargeSpeechNotification: AbombReady
 		SelectTargetSpeechNotification: SelectTarget
@@ -417,8 +417,8 @@ IRON:
 		PauseOnCondition: disabled
 		Icon: invuln
 		ChargeInterval: 3000
-		Description: Invulnerability
-		LongDesc: Makes a group of units invulnerable\nfor 20 seconds.
+		Name: Invulnerability
+		Description: Makes a group of units invulnerable\nfor 20 seconds.
 		Duration: 400
 		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSpeechNotification: InsufficientPower
@@ -488,8 +488,8 @@ PDOX:
 		Prerequisites: !pdox.germany
 		Icon: chrono
 		ChargeInterval: 3000
-		Description: Chronoshift
-		LongDesc: Teleports a group of units across\nthe map for 20 seconds.
+		Name: Chronoshift
+		Description: Teleports a group of units across\nthe map for 20 seconds.
 		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSpeechNotification: InsufficientPower
 		BeginChargeSpeechNotification: ChronosphereCharging
@@ -506,8 +506,8 @@ PDOX:
 		Prerequisites: pdox.germany
 		Icon: chrono
 		ChargeInterval: 3000
-		Description: Advanced Chronoshift
-		LongDesc: Teleports a large group of units across\nthe map for 20 seconds.
+		Name: Advanced Chronoshift
+		Description: Teleports a large group of units across\nthe map for 20 seconds.
 		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSpeechNotification: InsufficientPower
 		BeginChargeSpeechNotification: ChronosphereCharging
@@ -980,8 +980,8 @@ ATEK:
 		Icon: gps
 		OneShot: true
 		ChargeInterval: 12000
-		Description: GPS Satellite
-		LongDesc: Reveals map terrain and provides tactical\ninformation. Requires power and active radar.
+		Name: GPS Satellite
+		Description: Reveals map terrain and provides tactical\ninformation. Requires power and active radar.
 		RevealDelay: 375
 		LaunchSpeechNotification: SatelliteLaunched
 		DisplayTimerRelationships: Ally, Neutral, Enemy
@@ -1501,8 +1501,8 @@ AFLD:
 		Prerequisites: aircraft.soviet
 		Icon: spyplane
 		ChargeInterval: 3750
-		Description: Spy Plane
-		LongDesc: Reveals an area of the map.
+		Name: Spy Plane
+		Description: Reveals an area of the map.
 		SelectTargetSpeechNotification: SelectTarget
 		EndChargeSpeechNotification: SpyPlaneReady
 		CameraActor: camera.spyplane
@@ -1522,8 +1522,8 @@ AFLD:
 		Prerequisites: aircraft.soviet
 		Icon: paratroopers
 		ChargeInterval: 7500
-		Description: Paratroopers
-		LongDesc: A Badger drops a squad of infantry\nanywhere on the map.
+		Name: Paratroopers
+		Description: A Badger drops a squad of infantry\nanywhere on the map.
 		DropItems: E1R1,E1R1,E1R1,E3R1,E3R1
 		ReinforcementsArrivedSpeechNotification: ReinforcementsArrived
 		SelectTargetSpeechNotification: SelectTarget
@@ -1543,8 +1543,8 @@ AFLD:
 		Prerequisites: aircraft.ukraine
 		Icon: parabombs
 		ChargeInterval: 7500
-		Description: Parabombs
-		LongDesc: A squad of Badgers drop parachuted\nbombs on your target.
+		Name: Parabombs
+		Description: A squad of Badgers drop parachuted\nbombs on your target.
 		SelectTargetSpeechNotification: SelectTarget
 		CameraActor: camera
 		CameraRemoveDelay: 150

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -540,8 +540,8 @@ GAPLUG:
 		EffectSequence: ionring
 		WeaponDelay: 0
 		ChargeInterval: 12750
-		Description: Ion Cannon
-		LongDesc: Initiate an Ion Cannon strike.\nApplies instant damage to a small area.
+		Name: Ion Cannon
+		Description: Initiate an Ion Cannon strike.\nApplies instant damage to a small area.
 		EndChargeSpeechNotification: IonCannonReady
 		SelectTargetSpeechNotification: SelectTarget
 		DisplayRadarPing: True
@@ -551,8 +551,8 @@ GAPLUG:
 		PauseOnCondition: disabled || empdisable
 		RequiresCondition: plug.droppoda || plug.droppodb
 		Icon: droppods
-		Description: Drop Pods
-		LongDesc: Drop Pod reinforcements.\nSmall team of elite soldiers orbital drops\nto target location.
+		Name: Drop Pods
+		Description: Drop Pod reinforcements.\nSmall team of elite soldiers orbital drops\nto target location.
 		SelectTargetSpeechNotification: SelectTarget
 		DisplayRadarPing: true
 		ChargeInterval: 10000
@@ -561,8 +561,8 @@ GAPLUG:
 	ProduceActorPower:
 		PauseOnCondition: disabled || empdisable
 		RequiresCondition: plug.hunterseekera || plug.hunterseekerb
-		Description: Hunter Seeker
-		LongDesc: Releases a drone that will acquire and destroy an enemy target.
+		Name: Hunter Seeker
+		Description: Releases a drone that will acquire and destroy an enemy target.
 		Icon: hunterseeker
 		Actors: hunter
 		Type: HunterSeeker

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -462,8 +462,8 @@ NATMPL:
 		Palette: bright
 	ProduceActorPower:
 		PauseOnCondition: empdisable || disabled
-		Description: Hunter Seeker
-		LongDesc: Releases a drone that will acquire and destroy an enemy target.
+		Name: Hunter Seeker
+		Description: Releases a drone that will acquire and destroy an enemy target.
 		Prerequisites: ~techlevel.superweapons
 		Icon: hunterseeker
 		Actors: hunter
@@ -520,8 +520,8 @@ NAMISL:
 		Cursor: nuke
 		Icon: clustermissile
 		ChargeInterval: 13500
-		Description: Cluster Missile
-		LongDesc: Launches an explosive cluster warhead\nat a target location.
+		Name: Cluster Missile
+		Description: Launches an explosive cluster warhead\nat a target location.
 		EndChargeSpeechNotification: ClusterMissileReady
 		SelectTargetSpeechNotification: SelectTarget
 		IncomingSpeechNotification: MissileLaunchDetected

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -47,7 +47,7 @@ NAPULS:
 		Cursor: emp
 		Icon: emp
 		ChargeInterval: 3375
-		Description: E.M. Pulse
-		LongDesc: Fires a pulse blast which disables\nall mechanical units in the area.
+		Name: E.M. Pulse
+		Description: Fires a pulse blast which disables\nall mechanical units in the area.
 		EndChargeSpeechNotification: EmPulseCannonReady
 		SelectTargetSpeechNotification: SelectTarget


### PR DESCRIPTION
This is a somewhat pedantic field name change to bring in consistency, as
* `Tooltip` and `TooltipDescription` as well as `Buildable` use `Name` and `Description`
* `LongDesc` violates the unwritten field name rules by using a needless abbreviation
* `Description` was not really describing but used as a header in the UI