### PR TITLE
Disable Stylecop on debug config

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,6 @@
     <Optimize>true</Optimize>
     <LangVersion>7.3</LangVersion>
     <DebugSymbols>true</DebugSymbols>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EngineRootPath Condition="'$(EngineRootPath)' == ''">..</EngineRootPath>
     <OutputPath>$(EngineRootPath)/bin</OutputPath>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Makefile
+++ b/Makefile
@@ -97,11 +97,11 @@ clean:
 
 check:
 	@echo
-	@echo "Compiling in debug mode..."
+	@echo "Compiling in Debug mode..."
 ifeq ($(RUNTIME), mono)
-	@$(MSBUILD) -t:build -restore -p:Configuration=Debug -p:TargetPlatform=$(TARGETPLATFORM) -p:Mono=true
+	@$(MSBUILD) -t:build -restore -p:Configuration=Debug -warnaserror -p:TargetPlatform=$(TARGETPLATFORM) -p:Mono=true
 else
-	@$(DOTNET) build -c Debug -nologo -p:TargetPlatform=$(TARGETPLATFORM)
+	@$(DOTNET) build -c Debug -nologo -warnaserror -p:TargetPlatform=$(TARGETPLATFORM)
 endif
 ifeq ($(TARGETPLATFORM), unix-generic)
 	@./configure-system-libraries.sh

--- a/make.ps1
+++ b/make.ps1
@@ -110,8 +110,8 @@ function Test-Command
 
 function Check-Command
 {
-	Write-Host "Compiling in debug configuration..." -ForegroundColor Cyan
-	dotnet build -c Debug --nologo -p:TargetPlatform=win-x64
+	Write-Host "Compiling in Debug configuration..." -ForegroundColor Cyan
+	dotnet build -c Debug --nologo -warnaserror -p:TargetPlatform=win-x64
 	if ($lastexitcode -ne 0)
 	{
 		Write-Host "Build failed." -ForegroundColor Red


### PR DESCRIPTION
Disables Stylecop in the default build configuration to make it not as cumbersome when developing and testing new code,
added a new configuration for stylecop checks.