### PR TITLE
Move selection hotkeys out of world interaction widget

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/SelectAllUnitsHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/SelectAllUnitsHotkeyLogic.cs
@@ -1,0 +1,66 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Lint;
+using OpenRA.Traits;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
+{
+	[ChromeLogicArgsHotkeys("SelectAllUnitsKey")]
+	public class SelectAllUnitsHotkeyLogic : SingleHotkeyBaseLogic
+	{
+		readonly World world;
+		readonly WorldRenderer worldRenderer;
+		readonly ISelection selection;
+
+		public readonly string ClickSound = ChromeMetrics.Get<string>("ClickSound");
+
+		[ObjectCreator.UseCtor]
+		public SelectAllUnitsHotkeyLogic(Widget widget, ModData modData, WorldRenderer worldRenderer, World world, Dictionary<string, MiniYaml> logicArgs)
+			: base(widget, modData, "SelectAllUnitsKey", "WORLD_KEYHANDLER", logicArgs)
+		{
+			this.world = world;
+			this.worldRenderer = worldRenderer;
+			selection = world.Selection;
+		}
+
+		protected override bool OnHotkeyActivated(KeyInput e)
+		{
+			if (world.IsGameOver)
+				return false;
+
+			var eligiblePlayers = SelectionUtils.GetPlayersToIncludeInSelection(world);
+
+			// Select actors on the screen which belong to the current player(s)
+			var ownUnitsOnScreen = SelectionUtils.SelectActorsOnScreen(world, worldRenderer, null, eligiblePlayers).SubsetWithHighestSelectionPriority(e.Modifiers).ToList();
+
+			// Check if selecting actors on the screen has selected new units
+			if (ownUnitsOnScreen.Count > selection.Actors.Count())
+				TextNotificationsManager.AddFeedbackLine("Selected across screen.");
+			else
+			{
+				// Select actors in the world that have highest selection priority
+				ownUnitsOnScreen = SelectionUtils.SelectActorsInWorld(world, null, eligiblePlayers).SubsetWithHighestSelectionPriority(e.Modifiers).ToList();
+				TextNotificationsManager.AddFeedbackLine("Selected across map.");
+			}
+
+			selection.Combine(world, ownUnitsOnScreen, false, false);
+
+			Game.Sound.PlayNotification(world.Map.Rules, world.LocalPlayer, "Sounds", ClickSound, null);
+
+			return true;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/SelectUnitsByTypeHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/SelectUnitsByTypeHotkeyLogic.cs
@@ -1,0 +1,88 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Lint;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
+{
+	[ChromeLogicArgsHotkeys("SelectUnitsByTypeKey")]
+	public class SelectUnitsByTypeHotkeyLogic : SingleHotkeyBaseLogic
+	{
+		readonly World world;
+		readonly WorldRenderer worldRenderer;
+		readonly ISelection selection;
+
+		public readonly string ClickSound = ChromeMetrics.Get<string>("ClickSound");
+		public readonly string ClickDisabledSound = ChromeMetrics.Get<string>("ClickDisabledSound");
+
+		[ObjectCreator.UseCtor]
+		public SelectUnitsByTypeHotkeyLogic(Widget widget, ModData modData, WorldRenderer worldRenderer, World world, Dictionary<string, MiniYaml> logicArgs)
+			: base(widget, modData, "SelectUnitsByTypeKey", "WORLD_KEYHANDLER", logicArgs)
+		{
+			this.world = world;
+			this.worldRenderer = worldRenderer;
+			selection = world.Selection;
+		}
+
+		protected override bool OnHotkeyActivated(KeyInput e)
+		{
+			if (world.IsGameOver)
+				return false;
+
+			if (!selection.Actors.Any())
+			{
+				TextNotificationsManager.AddFeedbackLine("Nothing selected.");
+				Game.Sound.PlayNotification(world.Map.Rules, world.LocalPlayer, "Sounds", ClickDisabledSound, null);
+
+				return false;
+			}
+
+			var eligiblePlayers = SelectionUtils.GetPlayersToIncludeInSelection(world);
+
+			var ownedActors = selection.Actors
+				.Where(x => !x.IsDead && eligiblePlayers.Contains(x.Owner))
+				.ToList();
+
+			if (!ownedActors.Any())
+				return false;
+
+			// Get all the selected actors' selection classes
+			var selectedClasses = ownedActors
+				.Select(a => a.Trait<ISelectable>().Class)
+				.ToHashSet();
+
+			// Select actors on the screen that have the same selection class as one of the already selected actors
+			var newSelection = SelectionUtils.SelectActorsOnScreen(world, worldRenderer, selectedClasses, eligiblePlayers).ToList();
+
+			// Check if selecting actors on the screen has selected new units
+			if (newSelection.Count > selection.Actors.Count())
+				TextNotificationsManager.AddFeedbackLine("Selected across screen.");
+			else
+			{
+				// Select actors in the world that have the same selection class as one of the already selected actors
+				newSelection = SelectionUtils.SelectActorsInWorld(world, selectedClasses, eligiblePlayers).ToList();
+				TextNotificationsManager.AddFeedbackLine("Selected across map.");
+			}
+
+			selection.Combine(world, newSelection, true, false);
+
+			Game.Sound.PlayNotification(world.Map.Rules, world.LocalPlayer, "Sounds", ClickSound, null);
+
+			return true;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/SelectionUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/SelectionUtils.cs
@@ -1,0 +1,83 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Widgets
+{
+	public static class SelectionUtils
+	{
+		public static IEnumerable<Actor> SelectActorsOnScreen(World world, WorldRenderer wr, IEnumerable<string> selectionClasses, IEnumerable<Player> players)
+		{
+			var actors = world.ScreenMap.ActorsInMouseBox(wr.Viewport.TopLeft, wr.Viewport.BottomRight).Select(a => a.Actor);
+			return SelectActorsByOwnerAndSelectionClass(actors, players, selectionClasses);
+		}
+
+		public static IEnumerable<Actor> SelectActorsInWorld(World world, IEnumerable<string> selectionClasses, IEnumerable<Player> players)
+		{
+			return SelectActorsByOwnerAndSelectionClass(world.Actors.Where(a => a.IsInWorld), players, selectionClasses);
+		}
+
+		public static IEnumerable<Actor> SelectActorsByOwnerAndSelectionClass(IEnumerable<Actor> actors, IEnumerable<Player> owners, IEnumerable<string> selectionClasses)
+		{
+			return actors.Where(a =>
+			{
+				if (!owners.Contains(a.Owner))
+					return false;
+
+				var s = a.TraitOrDefault<ISelectable>();
+
+				// selectionClasses == null means that units, that meet all other criteria, get selected
+				return s != null && (selectionClasses == null || selectionClasses.Contains(s.Class));
+			});
+		}
+
+		public static IEnumerable<Actor> SelectHighestPriorityActorAtPoint(World world, int2 a, Modifiers modifiers)
+		{
+			var selected = world.ScreenMap.ActorsAtMouse(a)
+				.Where(x => x.Actor.Info.HasTraitInfo<ISelectableInfo>() && (x.Actor.Owner.IsAlliedWith(world.RenderPlayer) || !world.FogObscures(x.Actor)))
+				.WithHighestSelectionPriority(a, modifiers);
+
+			if (selected != null)
+				yield return selected;
+		}
+
+		public static IEnumerable<Actor> SelectActorsInBoxWithDeadzone(World world, int2 a, int2 b, Modifiers modifiers)
+		{
+			// For dragboxes that are too small, shrink the dragbox to a single point (point b)
+			if ((a - b).Length <= Game.Settings.Game.SelectionDeadzone)
+				a = b;
+
+			if (a == b)
+				return SelectHighestPriorityActorAtPoint(world, a, modifiers);
+
+			return world.ScreenMap.ActorsInMouseBox(a, b)
+				.Select(x => x.Actor)
+				.Where(x => x.Info.HasTraitInfo<ISelectableInfo>() && (x.Owner.IsAlliedWith(world.RenderPlayer) || !world.FogObscures(x)))
+				.SubsetWithHighestSelectionPriority(modifiers);
+		}
+
+		public static Player[] GetPlayersToIncludeInSelection(World world)
+		{
+			// Players to be included in the selection (the viewer or all players in "Disable shroud" / "All players" mode)
+			var viewer = world.RenderPlayer ?? world.LocalPlayer;
+			var isShroudDisabled = viewer == null || (world.RenderPlayer == null && world.LocalPlayer.Spectating);
+			var isEveryone = viewer != null && viewer.NonCombatant && viewer.Spectating;
+
+			return isShroudDisabled || isEveryone ? world.Players : new[] { viewer };
+		}
+	}
+}

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -10,7 +10,7 @@ Container@INGAME_ROOT:
 				TakeScreenshotKey: TakeScreenshot
 				MuteAudioKey: ToggleMute
 		LogicKeyListener@WORLD_KEYHANDLER:
-			Logic: CycleBasesHotkeyLogic, CycleProductionActorsHotkeyLogic, CycleHarvestersHotkeyLogic, JumpToLastEventHotkeyLogic, JumpToSelectedActorsHotkeyLogic, ResetZoomHotkeyLogic, TogglePlayerStanceColorHotkeyLogic, CycleStatusBarsHotkeyLogic, PauseHotkeyLogic, RemoveFromControlGroupHotkeyLogic
+			Logic: CycleBasesHotkeyLogic, CycleProductionActorsHotkeyLogic, CycleHarvestersHotkeyLogic, JumpToLastEventHotkeyLogic, JumpToSelectedActorsHotkeyLogic, ResetZoomHotkeyLogic, TogglePlayerStanceColorHotkeyLogic, CycleStatusBarsHotkeyLogic, PauseHotkeyLogic, RemoveFromControlGroupHotkeyLogic, SelectUnitsByTypeHotkeyLogic, SelectAllUnitsHotkeyLogic
 				RemoveFromControlGroupKey: RemoveFromControlGroup
 				CycleBasesKey: CycleBase
 				CycleProductionActorsKey: CycleProductionBuildings
@@ -21,6 +21,8 @@ Container@INGAME_ROOT:
 				TogglePlayerStanceColorKey: TogglePlayerStanceColor
 				CycleStatusBarsKey: CycleStatusBars
 				PauseKey: Pause
+				SelectAllUnitsKey: SelectAllUnits
+				SelectUnitsByTypeKey: SelectUnitsByType
 		Container@WORLD_ROOT:
 			Children:
 				LogicTicker@DISCONNECT_WATCHER:
@@ -39,8 +41,6 @@ Container@INGAME_ROOT:
 				WorldInteractionController@INTERACTION_CONTROLLER:
 					Width: WINDOW_RIGHT
 					Height: WINDOW_BOTTOM
-					SelectAllKey: SelectAllUnits
-					SelectSameTypeKey: SelectUnitsByType
 				Container@PLAYER_ROOT:
 		Container@MENU_ROOT:
 		TooltipContainer@TOOLTIP_CONTAINER:

--- a/mods/common/chrome/ingame.yaml
+++ b/mods/common/chrome/ingame.yaml
@@ -10,7 +10,7 @@ Container@INGAME_ROOT:
 				TakeScreenshotKey: TakeScreenshot
 				MuteAudioKey: ToggleMute
 		LogicKeyListener@WORLD_KEYHANDLER:
-			Logic: CycleBasesHotkeyLogic, CycleProductionActorsHotkeyLogic, CycleHarvestersHotkeyLogic, JumpToLastEventHotkeyLogic, JumpToSelectedActorsHotkeyLogic, ResetZoomHotkeyLogic, TogglePlayerStanceColorHotkeyLogic, CycleStatusBarsHotkeyLogic, PauseHotkeyLogic, RemoveFromControlGroupHotkeyLogic
+			Logic: CycleBasesHotkeyLogic, CycleProductionActorsHotkeyLogic, CycleHarvestersHotkeyLogic, JumpToLastEventHotkeyLogic, JumpToSelectedActorsHotkeyLogic, ResetZoomHotkeyLogic, TogglePlayerStanceColorHotkeyLogic, CycleStatusBarsHotkeyLogic, PauseHotkeyLogic, RemoveFromControlGroupHotkeyLogic, SelectUnitsByTypeHotkeyLogic, SelectAllUnitsHotkeyLogic
 				RemoveFromControlGroupKey: RemoveFromControlGroup
 				CycleBasesKey: CycleBase
 				CycleProductionActorsKey: CycleProductionBuildings
@@ -21,6 +21,8 @@ Container@INGAME_ROOT:
 				TogglePlayerStanceColorKey: TogglePlayerStanceColor
 				CycleStatusBarsKey: CycleStatusBars
 				PauseKey: Pause
+				SelectAllUnitsKey: SelectAllUnits
+				SelectUnitsByTypeKey: SelectUnitsByType
 		Container@WORLD_ROOT:
 			Logic: LoadIngamePerfLogic
 			Children:
@@ -37,8 +39,6 @@ Container@INGAME_ROOT:
 				WorldInteractionController@INTERACTION_CONTROLLER:
 					Width: WINDOW_RIGHT
 					Height: WINDOW_BOTTOM
-					SelectAllKey: SelectAllUnits
-					SelectSameTypeKey: SelectUnitsByType
 				ViewportController:
 					Width: WINDOW_RIGHT
 					Height: WINDOW_BOTTOM


### PR DESCRIPTION
In this PR:
- Split SelectionUtils for selecting actors in the world
- Split selection hotkeys into their own logic classes

This will allow mods to more easily replace the world interaction widget to alter the control scheme for the game (see #16669). And also allow for easier addition of new types of selection hotkeys (e.g. a key to select all harvesters on screen/map).