### PR TITLE
Overhaul settings panel layout 

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/IntroductionPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/IntroductionPromptLogic.cs
@@ -139,6 +139,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Ui.CloseWindow();
 				onComplete();
 			};
+
+			SettingsUtils.AdjustSettingsScrollPanelLayout(widget.Get<ScrollPanelWidget>("SETTINGS_SCROLLPANEL"));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
@@ -161,7 +161,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var label = row.GetOrNull<LabelWidget>(dropdown.Id + "_DESC");
 				if (label != null)
 				{
-					label.GetText = () => option.Name;
+					label.GetText = () => option.Name + ":";
 					label.IsVisible = () => true;
 				}
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/AdvancedSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/AdvancedSettingsLogic.cs
@@ -35,6 +35,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var ds = Game.Settings.Debug;
 			var ss = Game.Settings.Server;
 			var gs = Game.Settings.Game;
+			var scrollPanel = panel.Get<ScrollPanelWidget>("SETTINGS_SCROLLPANEL");
 
 			// Advanced
 			SettingsUtils.BindCheckboxPref(panel, "NAT_DISCOVERY", ss, "DiscoverNatDevices");
@@ -55,8 +56,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SettingsUtils.BindCheckboxPref(panel, "CHECKBOTSYNC_CHECKBOX", ds, "SyncCheckBotModuleCode");
 			SettingsUtils.BindCheckboxPref(panel, "PERFLOGGING_CHECKBOX", ds, "EnableSimulationPerfLogging");
 
-			panel.Get("DEBUG_OPTIONS").IsVisible = () => ds.DisplayDeveloperSettings;
-			panel.Get("DEBUG_HIDDEN_LABEL").IsVisible = () => !ds.DisplayDeveloperSettings;
+			panel.Get("BOTDEBUG_CHECKBOX_CONTAINER").IsVisible = () => ds.DisplayDeveloperSettings;
+			panel.Get("CHECKUNSYNCED_CHECKBOX_CONTAINER").IsVisible = () => ds.DisplayDeveloperSettings;
+			panel.Get("CHECKBOTSYNC_CHECKBOX_CONTAINER").IsVisible = () => ds.DisplayDeveloperSettings;
+			panel.Get("LUADEBUG_CHECKBOX_CONTAINER").IsVisible = () => ds.DisplayDeveloperSettings;
+			panel.Get("REPLAY_COMMANDS_CHECKBOX_CONTAINER").IsVisible = () => ds.DisplayDeveloperSettings;
+			panel.Get("PERFLOGGING_CHECKBOX_CONTAINER").IsVisible = () => ds.DisplayDeveloperSettings;
+			panel.Get("DEBUG_HIDDEN_CONTAINER").IsVisible = () => !ds.DisplayDeveloperSettings;
+
+			SettingsUtils.AdjustSettingsScrollPanelLayout(scrollPanel);
 
 			return () => ss.DiscoverNatDevices != OriginalServerDiscoverNatDevices;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
@@ -155,10 +155,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var duplicateNoticeText = new CachedTransform<HotkeyDefinition, string>(hd => hd != null ? duplicateNotice.Text.F(hd.Description) : duplicateNotice.Text);
 			duplicateNotice.GetText = () => duplicateNoticeText.Update(duplicateHotkeyDefinition);
 
-			var defaultNotice = panel.Get<LabelWidget>("DEFAULT_NOTICE");
-			defaultNotice.TextColor = ChromeMetrics.Get<Color>("NoticeInfoColor");
-			defaultNotice.IsVisible = () => isHotkeyValid && isHotkeyDefault;
-
 			var originalNotice = panel.Get<LabelWidget>("ORIGINAL_NOTICE");
 			originalNotice.TextColor = ChromeMetrics.Get<Color>("NoticeInfoColor");
 			originalNotice.IsVisible = () => isHotkeyValid && !isHotkeyDefault;

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
@@ -86,12 +86,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			hotkeyList = panel.Get<ScrollPanelWidget>("HOTKEY_LIST");
 			hotkeyList.Layout = new GridLayout(hotkeyList);
-			var hotkeyHeader = hotkeyList.Get<ScrollItemWidget>("HEADER");
-			var templates = hotkeyList.Get("TEMPLATES");
+			var headerTemplate = hotkeyList.Get("HEADER");
+			var template = hotkeyList.Get("TEMPLATE");
 			hotkeyList.RemoveChildren();
-
-			Func<bool> returnTrue = () => true;
-			Action doNothing = () => { };
 
 			if (logicArgs.TryGetValue("HotkeyGroups", out var hotkeyGroups))
 			{
@@ -99,18 +96,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				foreach (var hg in hotkeyGroups.Nodes)
 				{
-					var templateNode = hg.Value.Nodes.FirstOrDefault(n => n.Key == "Template");
 					var typesNode = hg.Value.Nodes.FirstOrDefault(n => n.Key == "Types");
-					if (templateNode == null || typesNode == null)
+					if (typesNode == null)
 						continue;
 
-					var header = ScrollItemWidget.Setup(hotkeyHeader, returnTrue, doNothing);
+					var header = headerTemplate.Clone();
 					header.Get<LabelWidget>("LABEL").GetText = () => hg.Key;
 					hotkeyList.AddChild(header);
 
 					var types = FieldLoader.GetValue<string[]>("Types", typesNode.Value.Value);
 					var added = new HashSet<HotkeyDefinition>();
-					var template = templates.Get(templateNode.Value.Value);
 
 					foreach (var t in types)
 					{

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/InputSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/InputSettingsLogic.cs
@@ -28,6 +28,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		Func<bool> InitPanel(Widget panel)
 		{
 			var gs = Game.Settings.Game;
+			var scrollPanel = panel.Get<ScrollPanelWidget>("SETTINGS_SCROLLPANEL");
 
 			SettingsUtils.BindCheckboxPref(panel, "ALTERNATE_SCROLL_CHECKBOX", gs, "UseAlternateScrollButton");
 			SettingsUtils.BindCheckboxPref(panel, "EDGESCROLL_CHECKBOX", gs, "ViewportEdgeScroll");
@@ -88,6 +89,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var zoomModifierDropdown = panel.Get<DropDownButtonWidget>("ZOOM_MODIFIER");
 			zoomModifierDropdown.OnMouseDown = _ => ShowZoomModifierDropdown(zoomModifierDropdown, gs);
 			zoomModifierDropdown.GetText = () => gs.ZoomModifier.ToString();
+
+			SettingsUtils.AdjustSettingsScrollPanelLayout(scrollPanel);
 
 			return () => false;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var panelTemplate = panelContainer.Get<ContainerWidget>("PANEL_TEMPLATE");
 			panelContainer.RemoveChild(panelTemplate);
 
-			tabContainer = widget.Get("TAB_CONTAINER");
+			tabContainer = widget.Get("SETTINGS_TAB_CONTAINER");
 			tabTemplate = tabContainer.Get<ButtonWidget>("BUTTON_TEMPLATE");
 			tabContainer.RemoveChild(tabTemplate);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsUtils.cs
@@ -48,5 +48,30 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			ss.Value = (float)(int)field.GetValue(group);
 			ss.OnChange += x => field.SetValue(group, (int)x);
 		}
+
+		public static void AdjustSettingsScrollPanelLayout(ScrollPanelWidget scrollPanel)
+		{
+			foreach (var row in scrollPanel.Children)
+			{
+				if (row.Children.Count == 0)
+					continue;
+
+				var hasVisibleChildren = false;
+
+				foreach (var container in row.Children)
+				{
+					if (container.IsVisible())
+					{
+						hasVisibleChildren = true;
+						break;
+					}
+				}
+
+				if (!hasVisibleChildren)
+					row.Visible = false;
+			}
+
+			scrollPanel.Layout.AdjustChildren();
+		}
 	}
 }

--- a/mods/cnc/chrome.yaml
+++ b/mods/cnc/chrome.yaml
@@ -448,6 +448,9 @@ dropdown-separators:
 		separator-pressed: 129, 34, 1, 19
 		separator-disabled: 161, 34, 1, 19
 
+separator:
+	Inherits: button
+
 #
 # Common chrome
 # ===

--- a/mods/cnc/chrome/ingame-info-lobby-options.yaml
+++ b/mods/cnc/chrome/ingame-info-lobby-options.yaml
@@ -7,41 +7,56 @@ Container@LOBBY_OPTIONS_PANEL:
 			X: 15
 			Y: 15
 			Width: 482
-			Height: 345
+			Height: 375
 			Children:
 				Container@LOBBY_OPTIONS:
-					X: 18
-					Y: 9
-					Width: PARENT_RIGHT - 24 - 18
+					Y: 10
+					Width: PARENT_RIGHT - 24
 					Children:
 						Container@CHECKBOX_ROW_TEMPLATE:
-							Height: 34
+							Width: PARENT_RIGHT
+							Height: 30
 							Children:
 								Checkbox@A:
-									Width: 220
+									X: 10
+									Width: PARENT_RIGHT / 2 - 20
 									Height: 20
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								Checkbox@B:
-									X: 225
-									Width: 220
+									X: PARENT_RIGHT / 2 + 10
+									Width: PARENT_RIGHT / 2 - 20
 									Height: 20
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 						Container@DROPDOWN_ROW_TEMPLATE:
-							Height: 34
+							Height: 60
 							Width: PARENT_RIGHT
 							Children:
 								Label@A_DESC:
-									Width: 140
-									Height: 25
-									Align: Right
+									X: 10
+									Width: PARENT_RIGHT / 2 - 20
+									Height: 20
 									Visible: False
 								DropDownButton@A:
-									X: 145
-									Width: 180
+									X: 10
+									Y: 25
+									Width: PARENT_RIGHT / 2 - 20
+									Height: 25
+									Font: Regular
+									Visible: False
+									TooltipContainer: TOOLTIP_CONTAINER
+								Label@B_DESC:
+									X: PARENT_RIGHT / 2 + 10
+									Width: PARENT_RIGHT / 2 - 20
+									Height: 20
+									Visible: False
+								DropDownButton@B:
+									X: PARENT_RIGHT / 2 + 10
+									Y: 25
+									Width: PARENT_RIGHT / 2 - 20
 									Height: 25
 									Font: Regular
 									Visible: False

--- a/mods/cnc/chrome/ingame-info.yaml
+++ b/mods/cnc/chrome/ingame-info.yaml
@@ -2,97 +2,86 @@ Container@GAME_INFO_PANEL:
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
 	Width: 512
-	Height: 405
+	Height: 435
 	Logic: GameInfoLogic
 	Visible: False
 	Children:
 		Label@TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 17
+			Y: 0 - 22
 			Text: Game Information
 			Align: Center
 			Font: BigBold
 			Contrast: true
 		Container@TAB_CONTAINER_2:
+			X: 0 - 140 + 1
 			Visible: False
 			Children:
 				Button@BUTTON1:
-					Y: 5
 					Width: 140
 					Height: 35
 				Button@BUTTON2:
-					X: 150
-					Y: 5
+					Y: 45
 					Width: 140
 					Height: 35
 		Container@TAB_CONTAINER_3:
+			X: 0 - 140 + 1
 			Visible: False
 			Children:
 				Button@BUTTON1:
-					Y: 5
 					Width: 140
 					Height: 35
 				Button@BUTTON2:
-					X: 150
-					Y: 5
+					Y: 45
 					Width: 140
 					Height: 35
 				Button@BUTTON3:
-					X: 300
-					Y: 5
+					Y: 90
 					Width: 140
 					Height: 35
 		Container@TAB_CONTAINER_4:
+			X: 0 - 140 + 1
 			Visible: False
 			Children:
 				Button@BUTTON1:
-					Y: 5
-					Width: 121
+					Width: 140
 					Height: 35
 				Button@BUTTON2:
-					X: 131
-					Y: 5
-					Width: 120
+					Y: 45
+					Width: 140
 					Height: 35
 				Button@BUTTON3:
-					X: 261
-					Y: 5
-					Width: 120
+					Y: 90
+					Width: 140
 					Height: 35
 				Button@BUTTON4:
-					X: 391
-					Y: 5
-					Width: 121
+					Y: 135
+					Width: 140
 					Height: 35
 		Container@TAB_CONTAINER_5:
+			X: 0 - 140 + 1
 			Visible: False
 			Children:
 				Button@BUTTON1:
-					Y: 5
-					Width: 99
+					Width: 140
 					Height: 35
 				Button@BUTTON2:
-					X: 104
-					Y: 5
-					Width: 98
+					Y: 45
+					Width: 140
 					Height: 35
 				Button@BUTTON3:
-					X: 207
-					Y: 5
-					Width: 98
+					Y: 90
+					Width: 140
 					Height: 35
 				Button@BUTTON4:
-					X: 310
-					Y: 5
-					Width: 98
+					Y: 135
+					Width: 140
 					Height: 35
 				Button@BUTTON5:
-					X: 413
-					Y: 5
-					Width: 99
+					Y: 180
+					Width: 140
 					Height: 35
 		Background@BACKGROUND:
-			Y: 39
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
 			Background: panel-black

--- a/mods/cnc/chrome/ingame-infobriefing.yaml
+++ b/mods/cnc/chrome/ingame-infobriefing.yaml
@@ -22,7 +22,7 @@ Container@MAP_PANEL:
 			X: 15
 			Y: 228
 			Width: 482
-			Height: 132
+			Height: 162
 			Children:
 				Label@MAP_DESCRIPTION:
 					X: 4

--- a/mods/cnc/chrome/ingame-infochat.yaml
+++ b/mods/cnc/chrome/ingame-infochat.yaml
@@ -1,7 +1,8 @@
 Container@CHAT_CONTAINER:
-	Y: 10
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM - 20
+	X: 15
+	Y: 15
+	Width: PARENT_RIGHT - 30
+	Height: PARENT_BOTTOM - 30
 	Logic: IngameChatLogic
 		Templates:
 			Chat: CHAT_LINE_TEMPLATE
@@ -9,8 +10,7 @@ Container@CHAT_CONTAINER:
 			Mission: CHAT_LINE_TEMPLATE
 	Children:
 		Container@CHAT_CHROME:
-			X: 15
-			Width: PARENT_RIGHT - 30
+			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
 			Children:
 				Button@CHAT_MODE:

--- a/mods/cnc/chrome/ingame-infoobjectives.yaml
+++ b/mods/cnc/chrome/ingame-infoobjectives.yaml
@@ -20,7 +20,7 @@ Container@MISSION_OBJECTIVES:
 			X: 15
 			Y: 50
 			Width: 482
-			Height: 310
+			Height: 340
 			TopBottomSpacing: 15
 			ItemSpacing: 15
 			Children:

--- a/mods/cnc/chrome/ingame-infostats.yaml
+++ b/mods/cnc/chrome/ingame-infostats.yaml
@@ -59,7 +59,7 @@ Container@SKIRMISH_STATS:
 			X: 15
 			Y: 105
 			Width: 482
-			Height: 255
+			Height: 285
 			ItemSpacing: 5
 			Children:
 				ScrollItem@TEAM_TEMPLATE:

--- a/mods/cnc/chrome/lobby-options.yaml
+++ b/mods/cnc/chrome/lobby-options.yaml
@@ -15,58 +15,73 @@ Container@LOBBY_OPTIONS_BIN:
 			Height: PARENT_BOTTOM
 			Children:
 				Container@LOBBY_OPTIONS:
-					X: 18
-					Y: 9
-					Width: PARENT_RIGHT - 24 - 18
+					Y: 10
+					Width: PARENT_RIGHT - 24
 					Children:
 						Container@CHECKBOX_ROW_TEMPLATE:
-							Height: 34
+							Width: PARENT_RIGHT
+							Height: 30
 							Children:
 								Checkbox@A:
-									Width: 220
+									X: 10
+									Width: PARENT_RIGHT / 3 - 20
 									Height: 20
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								Checkbox@B:
-									X: 225
-									Width: 220
+									X: PARENT_RIGHT / 3 + 10
+									Width: PARENT_RIGHT / 3 - 20
 									Height: 20
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								Checkbox@C:
-									X: 450
-									Width: 190
+									X: (PARENT_RIGHT / 3) * 2 + 10
+									Width: PARENT_RIGHT / 3 - 20
 									Height: 20
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 						Container@DROPDOWN_ROW_TEMPLATE:
-							Height: 34
+							Height: 60
 							Width: PARENT_RIGHT
 							Children:
 								Label@A_DESC:
-									Width: 140
-									Height: 25
-									Align: Right
+									X: 10
+									Width: PARENT_RIGHT / 3 - 20
+									Height: 20
 									Visible: False
 								DropDownButton@A:
-									X: 145
-									Width: 180
+									X: 10
+									Width: PARENT_RIGHT / 3 - 20
+									Y: 25
 									Height: 25
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								Label@B_DESC:
-									X: PARENT_RIGHT - WIDTH - 203
-									Width: 140
-									Height: 25
-									Align: Right
+									X: PARENT_RIGHT / 3 + 10
+									Width: PARENT_RIGHT / 3 - 20
+									Height: 20
 									Visible: False
 								DropDownButton@B:
-									X: PARENT_RIGHT - WIDTH - 18
-									Width: 180
+									X: PARENT_RIGHT / 3 + 10
+									Width: PARENT_RIGHT / 3 - 20
+									Y: 25
+									Height: 25
+									Font: Regular
+									Visible: False
+									TooltipContainer: TOOLTIP_CONTAINER
+								Label@C_DESC:
+									X: (PARENT_RIGHT / 3) * 2 + 10
+									Width: PARENT_RIGHT / 3 - 20
+									Height: 20
+									Visible: False
+								DropDownButton@C:
+									X: (PARENT_RIGHT / 3) * 2 + 10
+									Width: PARENT_RIGHT / 3 - 20
+									Y: 25
 									Height: 25
 									Font: Regular
 									Visible: False

--- a/mods/cnc/chrome/mainmenu-prompts.yaml
+++ b/mods/cnc/chrome/mainmenu-prompts.yaml
@@ -2,10 +2,10 @@ Container@MAINMENU_INTRODUCTION_PROMPT:
 	Logic: IntroductionPromptLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
-	Width: 600
-	Height: 350
+	Width: 700
+	Height: 445
 	Children:
-		Label@TITLE:
+		Label@PROMPT_TITLE:
 			Width: PARENT_RIGHT
 			Y: 0 - 25
 			Font: BigBold
@@ -31,222 +31,265 @@ Container@MAINMENU_INTRODUCTION_PROMPT:
 					Font: Regular
 					Align: Center
 					Text: Additional options can be configured later from the Settings menu.
-				Label@PROFILE_TITLE:
-					Width: PARENT_RIGHT
+				ScrollPanel@SETTINGS_SCROLLPANEL:
+					X: 15
 					Y: 60
-					Height: 25
-					Font: Bold
-					Align: Center
-					Text: Profile
-				Label@PLAYER:
-					Text: Player Name:
-					X: 15
-					Y: 90
-					Width: 120
-					Height: 25
-					Align: Right
-				TextField@PLAYERNAME:
-					X: 140
-					Y: 90
-					Width: 160
-					Height: 25
-					MaxLength: 16
-				Label@COLOR:
-					X: 265 + 60
-					Y: 90
-					Width: 145
-					Height: 25
-					Text: Preferred Color:
-					Align: Right
-				DropDownButton@PLAYERCOLOR:
-					X: 415 + 60
-					Y: 90
-					Width: 75
-					Height: 25
-					IgnoreChildMouseOver: true
-					PanelAlign: Right
+					Width: PARENT_RIGHT - 30
+					Height: PARENT_BOTTOM - 75
+					CollapseHiddenChildren: True
+					TopBottomSpacing: 5
+					ItemSpacing: 10
+					ScrollBar: Hidden
 					Children:
-						ColorBlock@COLORBLOCK:
+						Background@SECTION_HEADER:
 							X: 5
-							Y: 6
-							Width: PARENT_RIGHT - 35
-							Height: PARENT_BOTTOM - 12
-				Label@INPUT_TITLE:
-					Width: PARENT_RIGHT
-					Y: 120
-					Height: 25
-					Font: Bold
-					Align: Center
-					Text: Input
-				Label@MOUSE_CONTROL_LABEL:
-					X: 15
-					Y: 150
-					Width: 120
-					Height: 25
-					Font: Regular
-					Text: Control Scheme:
-					Align: Right
-				DropDownButton@MOUSE_CONTROL_DROPDOWN:
-					X: 140
-					Y: 150
-					Width: 160
-					Height: 25
-					Font: Regular
-				Checkbox@EDGESCROLL_CHECKBOX:
-					X: 365
-					Y: 153
-					Width: 180
-					Height: 20
-					Font: Regular
-					Text: Screen Edge Panning
-				Container@MOUSE_CONTROL_DESC_CLASSIC:
-					X: 25
-					Y: 180
-					Width: PARENT_RIGHT - 50
-					Children:
-						LabelWithHighlight@DESC_SELECTION:
-							Height: 16
-							Font: Small
-							Text: - Select units using the {Left} mouse button
-						LabelWithHighlight@DESC_COMMANDS:
-							Y: 17
-							Height: 16
-							Font: Small
-							Text: - Command units using the {Left} mouse button
-						LabelWithHighlight@DESC_BUILDIGS:
-							Y: 34
-							Height: 16
-							Font: Small
-							Text: - Place structures using the {Left} mouse button
-						LabelWithHighlight@DESC_SUPPORT:
-							X: 265
-							Height: 16
-							Font: Small
-							Text: - Target support powers using the {Left} mouse button
-						LabelWithHighlight@DESC_ZOOM:
-							X: 265
-							Y: 17
-							Height: 16
-							Font: Small
-							Text: - Zoom the battlefield using the {Scroll Wheel}
-						LabelWithHighlight@DESC_ZOOM_MODIFIER:
-							X: 265
-							Y: 17
-							Height: 16
-							Font: Small
-							Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
-						LabelWithHighlight@DESC_SCROLL_RIGHT:
-							X: 265
-							Y: 34
-							Height: 16
-							Font: Small
-							Text: - Pan the battlefield using the {Right} mouse button
-						LabelWithHighlight@DESC_SCROLL_MIDDLE:
-							X: 265
-							Y: 34
-							Height: 16
-							Font: Small
-							Text: - Pan the battlefield using the {Middle} mouse button
-						Label@DESC_EDGESCROLL:
-							X: 274
-							Y: 51
-							Height: 16
-							Font: Small
-							Text: or by moving the cursor to the edge of the screen
-				Container@MOUSE_CONTROL_DESC_MODERN:
-					X: 25
-					Y: 180
-					Width: PARENT_RIGHT - 50
-					Children:
-						LabelWithHighlight@DESC_SELECTION:
-							Height: 16
-							Font: Small
-							Text: - Select units using the {Left} mouse button
-						LabelWithHighlight@DESC_COMMANDS:
-							Y: 17
-							Height: 16
-							Font: Small
-							Text: - Command units using the {Right} mouse button
-						LabelWithHighlight@DESC_BUILDIGS:
-							Y: 34
-							Height: 16
-							Font: Small
-							Text: - Place structures using the {Left} mouse button
-						LabelWithHighlight@DESC_SUPPORT:
-							X: 265
-							Height: 16
-							Font: Small
-							Text: - Target support powers using the {Left} mouse button
-						LabelWithHighlight@DESC_ZOOM:
-							X: 265
-							Y: 17
-							Height: 16
-							Font: Small
-							Text: - Zoom the battlefield using the {Scroll Wheel}
-						LabelWithHighlight@DESC_ZOOM_MODIFIER:
-							X: 265
-							Y: 17
-							Height: 16
-							Font: Small
-							Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
-						LabelWithHighlight@DESC_SCROLL_RIGHT:
-							X: 265
-							Y: 34
-							Height: 16
-							Font: Small
-							Text: - Pan the battlefield using the {Right} mouse button
-						LabelWithHighlight@DESC_SCROLL_MIDDLE:
-							X: 265
-							Y: 34
-							Height: 16
-							Font: Small
-							Text: - Pan the battlefield using the {Middle} mouse button
-						Label@DESC_EDGESCROLL:
-							X: 274
-							Y: 51
-							Height: 16
-							Font: Small
-							Text: or by moving the cursor to the edge of the screen
-				Label@INPUT_TITLE:
-					Width: PARENT_RIGHT
-					Y: 250
-					Height: 25
-					Font: Bold
-					Align: Center
-					Text: Display
-				Label@BATTLEFIELD_CAMERA:
-					X: 15
-					Y: 280
-					Width: 120
-					Height: 25
-					Text: Battlefield Camera:
-					Align: Right
-				DropDownButton@BATTLEFIELD_CAMERA_DROPDOWN:
-					X: 140
-					Y: 280
-					Width: 160
-					Height: 25
-					Font: Regular
-				Label@UI_SCALE:
-					X: 275
-					Y: 280
-					Width: 145
-					Height: 25
-					Text: UI Scale:
-					Align: Right
-				DropDownButton@UI_SCALE_DROPDOWN:
-					X: 425
-					Y: 280
-					Width: 160
-					Height: 25
-					Font: Regular
-				Checkbox@CURSORDOUBLE_CHECKBOX:
-					X: 390
-					Y: 313
-					Width: 200
-					Height: 20
-					Font: Regular
-					Text: Increase Cursor Size
+							Width: PARENT_RIGHT - 10
+							Height: 13
+							Background: separator
+							Children:
+								Label@LABEL:
+									Width: PARENT_RIGHT
+									Height: PARENT_BOTTOM
+									Font: TinyBold
+									Align: Center
+									Text: Profile
+						Container@ROW:
+							Width: PARENT_RIGHT
+							Height: 50
+							Children:
+								Container@PLAYER_CONTAINER:
+									X: 10
+									Width: PARENT_RIGHT / 2 - 20
+									Children:
+										Label@PLAYER:
+											Width: PARENT_RIGHT
+											Height: 20
+											Text: Player Name:
+										TextField@PLAYERNAME:
+											Y: 25
+											Width: PARENT_RIGHT
+											Height: 25
+											MaxLength: 16
+											Text: Name
+								Container@PLAYERCOLOR_CONTAINER:
+									X: PARENT_RIGHT / 2 + 10
+									Width: PARENT_RIGHT / 2 - 20
+									Children:
+										Label@COLOR:
+											Width: PARENT_RIGHT
+											Height: 20
+											Text: Preferred Color:
+										DropDownButton@PLAYERCOLOR:
+											Y: 25
+											Width: 75
+											Height: 25
+											IgnoreChildMouseOver: true
+											PanelAlign: Right
+											Children:
+												ColorBlock@COLORBLOCK:
+													X: 5
+													Y: 6
+													Width: PARENT_RIGHT - 35
+													Height: PARENT_BOTTOM - 12
+						Container@SPACER:
+						Background@SECTION_HEADER:
+							X: 5
+							Width: PARENT_RIGHT - 10
+							Height: 13
+							Background: separator
+							Children:
+								Label@LABEL:
+									Width: PARENT_RIGHT
+									Height: PARENT_BOTTOM
+									Font: TinyBold
+									Align: Center
+									Text: Input
+						Container@ROW:
+							Width: PARENT_RIGHT
+							Height: 50
+							Children:
+								Container@MOUSE_CONTROL_CONTAINER:
+									X: 10
+									Width: PARENT_RIGHT / 2 - 20
+									Children:
+										Label@MOUSE_CONTROL_LABEL:
+											Width: PARENT_RIGHT
+											Height: 20
+											Font: Regular
+											Text: Control Scheme:
+										DropDownButton@MOUSE_CONTROL_DROPDOWN:
+											Y: 25
+											Width: PARENT_RIGHT
+											Height: 25
+											Font: Regular
+								Container@MOUSE_CONTROL_DESC_CLASSIC:
+									X: PARENT_RIGHT / 2 + 10
+									Width: PARENT_RIGHT / 2 - 20
+									Children:
+										LabelWithHighlight@DESC_SELECTION:
+											Height: 16
+											Font: Small
+											Text: - Select units using the {Left} mouse button
+										LabelWithHighlight@DESC_COMMANDS:
+											Y: 17
+											Height: 16
+											Font: Small
+											Text: - Command units using the {Left} mouse button
+										LabelWithHighlight@DESC_BUILDIGS:
+											Y: 34
+											Height: 16
+											Font: Small
+											Text: - Place structures using the {Left} mouse button
+										LabelWithHighlight@DESC_SUPPORT:
+											Y: 51
+											Height: 16
+											Font: Small
+											Text: - Target support powers using the {Left} mouse button
+										LabelWithHighlight@DESC_ZOOM:
+											Y: 68
+											Height: 16
+											Font: Small
+											Text: - Zoom the battlefield using the {Scroll Wheel}
+										LabelWithHighlight@DESC_ZOOM_MODIFIER:
+											Y: 68
+											Height: 16
+											Font: Small
+											Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
+										LabelWithHighlight@DESC_SCROLL_RIGHT:
+											Y: 85
+											Height: 16
+											Font: Small
+											Text: - Pan the battlefield using the {Right} mouse button
+										LabelWithHighlight@DESC_SCROLL_MIDDLE:
+											Y: 85
+											Height: 16
+											Font: Small
+											Text: - Pan the battlefield using the {Middle} mouse button
+										Label@DESC_EDGESCROLL:
+											X: 9
+											Y: 102
+											Height: 16
+											Font: Small
+											Text: or by moving the cursor to the edge of the screen
+								Container@MOUSE_CONTROL_DESC_MODERN:
+									X: PARENT_RIGHT / 2 + 10
+									Width: PARENT_RIGHT / 2 - 20
+									Children:
+										LabelWithHighlight@DESC_SELECTION:
+											Height: 16
+											Font: Small
+											Text: - Select units using the {Left} mouse button
+										LabelWithHighlight@DESC_COMMANDS:
+											Y: 17
+											Height: 16
+											Font: Small
+											Text: - Command units using the {Right} mouse button
+										LabelWithHighlight@DESC_BUILDIGS:
+											Y: 34
+											Height: 16
+											Font: Small
+											Text: - Place structures using the {Left} mouse button
+										LabelWithHighlight@DESC_SUPPORT:
+											Y: 51
+											Height: 16
+											Font: Small
+											Text: - Target support powers using the {Left} mouse button
+										LabelWithHighlight@DESC_ZOOM:
+											Y: 68
+											Height: 16
+											Font: Small
+											Text: - Zoom the battlefield using the {Scroll Wheel}
+										LabelWithHighlight@DESC_ZOOM_MODIFIER:
+											Y: 68
+											Height: 16
+											Font: Small
+											Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
+										LabelWithHighlight@DESC_SCROLL_RIGHT:
+											Y: 85
+											Height: 16
+											Font: Small
+											Text: - Pan the battlefield using the {Right} mouse button
+										LabelWithHighlight@DESC_SCROLL_MIDDLE:
+											Y: 85
+											Height: 16
+											Font: Small
+											Text: - Pan the battlefield using the {Middle} mouse button
+										Label@DESC_EDGESCROLL:
+											X: 9
+											Y: 102
+											Height: 16
+											Font: Small
+											Text: or by moving the cursor to the edge of the screen
+						Container@ROW:
+							Width: PARENT_RIGHT
+							Height: 20
+							Children:
+								Container@EDGESCROLL_CHECKBOX_CONTAINER:
+									X: 10
+									Width: PARENT_RIGHT / 2 - 20
+									Children:
+										Checkbox@EDGESCROLL_CHECKBOX:
+											Width: PARENT_RIGHT
+											Height: 20
+											Font: Regular
+											Text: Screen Edge Panning
+						Container@SPACER:
+							Height: 30
+						Background@SECTION_HEADER:
+							X: 5
+							Width: PARENT_RIGHT - 10
+							Height: 13
+							Background: separator
+							Children:
+								Label@LABEL:
+									Width: PARENT_RIGHT
+									Height: PARENT_BOTTOM
+									Font: TinyBold
+									Align: Center
+									Text: Display
+						Container@ROW:
+							Width: PARENT_RIGHT
+							Height: 50
+							Children:
+								Container@BATTLEFIELD_CAMERA_DROPDOWN_CONTAINER:
+									X: 10
+									Width: PARENT_RIGHT / 2 - 20
+									Children:
+										Label@BATTLEFIELD_CAMERA:
+											Width: PARENT_RIGHT
+											Height: 20
+											Text: Battlefield Camera:
+										DropDownButton@BATTLEFIELD_CAMERA_DROPDOWN:
+											Y: 25
+											Width: PARENT_RIGHT
+											Height: 25
+											Font: Regular
+								Container@UI_SCALE_DROPDOWN_CONTAINER:
+									X: PARENT_RIGHT / 2 + 10
+									Width: PARENT_RIGHT / 2 - 20
+									Children:
+										Label@UI_SCALE:
+											Width: PARENT_RIGHT
+											Height: 20
+											Text: UI Scale:
+										DropDownButton@UI_SCALE_DROPDOWN:
+											Y: 25
+											Width: PARENT_RIGHT
+											Height: 25
+											Font: Regular
+						Container@ROW:
+							Width: PARENT_RIGHT
+							Height: 20
+							Children:
+								Container@CURSORDOUBLE_CHECKBOX_CONTAINER:
+									X: PARENT_RIGHT / 2 + 10
+									Width: PARENT_RIGHT / 2 - 20
+									Children:
+										Checkbox@CURSORDOUBLE_CHECKBOX:
+											Width: PARENT_RIGHT
+											Height: 20
+											Font: Regular
+											Text: Increase Cursor Size
 		Button@CONTINUE_BUTTON:
 			X: PARENT_RIGHT - WIDTH
 			Y: PARENT_BOTTOM - 1

--- a/mods/cnc/chrome/settings-advanced.yaml
+++ b/mods/cnc/chrome/settings-advanced.yaml
@@ -3,128 +3,193 @@ Container@ADVANCED_PANEL:
 	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM
 	Children:
-		Label@ADVANCED_TITLE:
-			Y: 21
-			Width: PARENT_RIGHT
-			Font: Bold
-			Text: Advanced
-			Align: Center
-		Checkbox@NAT_DISCOVERY:
-			X: 15
-			Y: 43
-			Width: 200
-			Height: 20
-			Font: Regular
-			Text: Enable UPnP/NAT-PMP Discovery
-		Checkbox@PERFTEXT_CHECKBOX:
-			X: 15
-			Y: 73
-			Width: 300
-			Height: 20
-			Font: Regular
-			Text: Show Performance Text
-		Checkbox@PERFGRAPH_CHECKBOX:
-			X: 15
-			Y: 103
-			Width: 300
-			Height: 20
-			Font: Regular
-			Text: Show Performance Graph
-		Checkbox@FETCH_NEWS_CHECKBOX:
-			X: 310
-			Y: 43
-			Width: 300
-			Height: 20
-			Font: Regular
-			Text: Fetch Community News
-		Checkbox@CHECK_VERSION_CHECKBOX:
-			X: 310
-			Y: 73
-			Width: 300
-			Height: 20
-			Font: Regular
-			Text: Check for Updates
-		Checkbox@SENDSYSINFO_CHECKBOX:
-			X: 310
-			Y: 103
-			Width: 300
-			Height: 20
-			Font: Regular
-			Text: Send System Information
-		Label@SENDSYSINFO_DESC:
-			X: 310
-			Y: 118
-			Width: 255
-			Height: 30
-			Font: Tiny
-			WordWrap: True
-			Text: Your Operating System, OpenGL and .NET runtime versions, and language settings will be sent along with an anonymous ID to help prioritize future development.
-		Label@DEBUG_TITLE:
-			Y: 190
-			Width: PARENT_RIGHT
-			Font: Bold
-			Text: Developer
-			Align: Center
-		Container@DEBUG_HIDDEN_LABEL:
-			Y: 245
-			Width: PARENT_RIGHT
-			Children:
-				Label@A:
-					Width: PARENT_RIGHT
-					Height: 20
-					Font: Regular
-					Text: Additional developer-specific options can be enabled via the
-					Align: Center
-				Label@B:
-					Y: 20
-					Width: PARENT_RIGHT
-					Height: 20
-					Font: Regular
-					Text: Debug.DisplayDeveloperSettings setting or launch flag
-					Align: Center
-		Container@DEBUG_OPTIONS:
+		ScrollPanel@SETTINGS_SCROLLPANEL:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
+			CollapseHiddenChildren: True
+			TopBottomSpacing: 5
+			ItemSpacing: 10
 			Children:
-				Checkbox@BOTDEBUG_CHECKBOX:
-					X: 15
-					Y: 213
-					Width: 300
+				Background@SECTION_HEADER:
+					X: 5
+					Width: PARENT_RIGHT - 24 - 10
+					Height: 13
+					Background: separator
+					Children:
+						Label@LABEL:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Font: TinyBold
+							Align: Center
+							Text: Advanced
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
 					Height: 20
-					Font: Regular
-					Text: Show Bot Debug Messages
-				Checkbox@CHECKUNSYNCED_CHECKBOX:
-					X: 15
-					Y: 243
-					Width: 300
+					Children:
+						Container@NAT_DISCOVERY_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@NAT_DISCOVERY:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Enable UPnP/NAT-PMP Discovery
+						Container@FETCH_NEWS_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@FETCH_NEWS_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Fetch Community News
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
 					Height: 20
-					Font: Regular
-					Text: Check Sync around Unsynced Code
-				Checkbox@CHECKBOTSYNC_CHECKBOX:
-					X: 15
-					Y: 273
-					Width: 300
+					Children:
+						Container@PERFGRAPH_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@PERFGRAPH_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Show Performance Graph
+						Container@CHECK_VERSION_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@CHECK_VERSION_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Check for Updates
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@PERFTEXT_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@PERFTEXT_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Show Performance Text
+						Container@SENDSYSINFO_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@SENDSYSINFO_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Send System Information
+								Label@SENDSYSINFO_DESC:
+									Y: 15
+									Width: PARENT_RIGHT
+									Height: 30
+									Font: Tiny
+									WordWrap: True
+									Text: Your Operating System, OpenGL and .NET runtime versions, and language settings will be sent along with an anonymous ID to help prioritize future development.
+				Container@SPACER:
+				Background@SECTION_HEADER:
+					X: 5
+					Width: PARENT_RIGHT - 24 - 10
+					Height: 13
+					Background: separator
+					Children:
+						Label@LABEL:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Font: TinyBold
+							Align: Center
+							Text: Developer
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 40
+					Children:
+						Container@DEBUG_HIDDEN_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT - 10
+							Children:
+								Label@A:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Additional developer-specific options can be enabled via the
+									Align: Center
+								Label@B:
+									Y: 20
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Debug.DisplayDeveloperSettings setting or launch flag
+									Align: Center
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
 					Height: 20
-					Font: Regular
-					Text: Check Sync around BotModule Code
-				Checkbox@LUADEBUG_CHECKBOX:
-					X: 310
-					Y: 213
-					Width: 300
+					Children:
+						Container@BOTDEBUG_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@BOTDEBUG_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Show Bot Debug Messages
+						Container@CHECKBOTSYNC_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@CHECKBOTSYNC_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Check Sync around BotModule Code
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
 					Height: 20
-					Font: Regular
-					Text: Show Map Debug Messages
-				Checkbox@REPLAY_COMMANDS_CHECKBOX:
-					X: 310
-					Y: 243
-					Width: 300
+					Children:
+						Container@LUADEBUG_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@LUADEBUG_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Show Map Debug Messages
+						Container@CHECKUNSYNCED_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@CHECKUNSYNCED_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Check Sync around Unsynced Code
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
 					Height: 20
-					Font: Regular
-					Text: Enable Debug Commands in Replays
-				Checkbox@PERFLOGGING_CHECKBOX:
-					X: 310
-					Y: 273
-					Width: 300
-					Height: 20
-					Font: Regular
-					Text: Enable Tick Performance Logging
+					Children:
+						Container@REPLAY_COMMANDS_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@REPLAY_COMMANDS_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Enable Debug Commands in Replays
+						Container@PERFLOGGING_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@PERFLOGGING_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Enable Tick Performance Logging

--- a/mods/cnc/chrome/settings-audio.yaml
+++ b/mods/cnc/chrome/settings-audio.yaml
@@ -3,97 +3,140 @@ Container@AUDIO_PANEL:
 	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM
 	Children:
-		Label@AUDIO_TITLE:
-			Y: 21
-			Width: PARENT_RIGHT
-			Font: Bold
-			Text: Audio
-			Align: Center
-		Label@NO_AUDIO_DEVICE:
-			Y: 50
-			Width: PARENT_RIGHT
-			Align: Center
-			Text: Audio controls require an active sound device
-		Container@AUDIO_CONTROLS:
+		ScrollPanel@SETTINGS_SCROLLPANEL:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
+			CollapseHiddenChildren: True
+			TopBottomSpacing: 5
+			ItemSpacing: 10
 			Children:
-				Checkbox@CASH_TICKS:
-					X: 15
-					Y: 43
-					Width: 200
+				Background@SECTION_HEADER:
+					X: 5
+					Width: PARENT_RIGHT - 24 - 10
+					Height: 13
+					Background: separator
+					Children:
+						Label@LABEL:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Font: TinyBold
+							Align: Center
+							Text: Audio
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
 					Height: 20
-					Font: Regular
-					Text: Cash Ticks
-				Checkbox@MUTE_SOUND:
-					X: 15
-					Y: 73
-					Width: 200
+					Children:
+						Container@NO_AUDIO_DEVICE_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT - 10
+							Children:
+								Label@NO_AUDIO_DEVICE:
+									Width: PARENT_RIGHT
+									Height: 20
+									Align: Center
+									Text: Audio controls require an active sound device
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@CASH_TICKS_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@CASH_TICKS:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Cash Ticks
+						Container@MUTE_SOUND_CONTAINER:
+							X: 10
+							Y: 30
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@MUTE_SOUND:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Mute Sound
+						Container@SOUND_VOLUME_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@SOUND_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Sound Volume:
+								ExponentialSlider@SOUND_VOLUME:
+									Y: 30
+									Width: PARENT_RIGHT
+									Height: 20
+									Ticks: 7
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@MUTE_BACKGROUND_MUSIC_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@MUTE_BACKGROUND_MUSIC:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Mute Background Music
+						Container@MUSIC_VOLUME_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@MUSIC_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Music Volume:
+								ExponentialSlider@MUSIC_VOLUME:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 20
+									Ticks: 7
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@AUDIO_DEVICE_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@AUDIO_DEVICE_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Audio Device:
+								DropDownButton@AUDIO_DEVICE:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+						Container@VIDEO_VOLUME_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@VIDEO_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Video Volume:
+								ExponentialSlider@VIDEO_VOLUME:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 20
+									Ticks: 7
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
 					Height: 20
-					Font: Regular
-					Text: Mute Sound
-				Checkbox@MUTE_BACKGROUND_MUSIC:
-					X: 15
-					Y: 103
-					Width: 200
-					Height: 20
-					Font: Regular
-					Text: Mute Background Music
-				Label@SOUND_LABEL:
-					X: PARENT_RIGHT - WIDTH - 270
-					Y: 40
-					Width: 95
-					Height: 25
-					Align: Right
-					Text: Sound Volume:
-				ExponentialSlider@SOUND_VOLUME:
-					X: PARENT_RIGHT - WIDTH - 15
-					Y: 45
-					Width: 250
-					Height: 20
-					Ticks: 7
-				Label@MUSIC_LABEL:
-					X: PARENT_RIGHT - WIDTH - 270
-					Y: 70
-					Width: 95
-					Height: 25
-					Align: Right
-					Text: Music Volume:
-				ExponentialSlider@MUSIC_VOLUME:
-					X: PARENT_RIGHT - WIDTH - 15
-					Y: 75
-					Width: 250
-					Height: 20
-					Ticks: 7
-				Label@VIDEO_LABEL:
-					X: PARENT_RIGHT - WIDTH - 270
-					Y: 100
-					Width: 95
-					Height: 25
-					Align: Right
-					Text: Video Volume:
-				ExponentialSlider@VIDEO_VOLUME:
-					X: PARENT_RIGHT - WIDTH - 15
-					Y: 105
-					Width: 250
-					Height: 20
-					Ticks: 7
-		Label@AUDIO_DEVICE_LABEL:
-			X: 190 - WIDTH - 5
-			Y: 240
-			Width: 75
-			Height: 25
-			Align: Right
-			Text: Audio Device:
-		DropDownButton@AUDIO_DEVICE:
-			X: 190
-			Y: 240
-			Width: 300
-			Height: 25
-		Label@AUDIO_DEVICE_DESC:
-			Y: 261
-			Width: PARENT_RIGHT
-			Height: 25
-			Font: Tiny
-			Align: Center
-			Text: Device changes will be applied after the game is restarted
+					Children:
+						Container@RESTART_REQUIRED_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT - 10
+							Children:
+								Label@RESTART_REQUIRED_DESC:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Tiny
+									Align: Center
+									Text: Device changes will be applied after the game is restarted

--- a/mods/cnc/chrome/settings-display.yaml
+++ b/mods/cnc/chrome/settings-display.yaml
@@ -3,221 +3,306 @@ Container@DISPLAY_PANEL:
 	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM
 	Children:
-		Label@VIDEO_TITLE:
-			Y: 21
+		ScrollPanel@SETTINGS_SCROLLPANEL:
 			Width: PARENT_RIGHT
-			Font: Bold
-			Text: Display
-			Align: Center
-		Label@PLAYER:
-			Text: Player Name:
-			X: 15
-			Y: 40
-			Width: 120
-			Height: 25
-			Align: Right
-		TextField@PLAYERNAME:
-			Text: Name
-			X: 140
-			Y: 40
-			Width: 160
-			Height: 25
-			MaxLength: 16
-		Label@COLOR:
-			X: 265
-			Y: 40
-			Width: 145
-			Height: 25
-			Text: Preferred Color:
-			Align: Right
-		DropDownButton@PLAYERCOLOR:
-			X: 415
-			Y: 40
-			Width: 75
-			Height: 25
-			IgnoreChildMouseOver: true
-			PanelAlign: Right
+			Height: PARENT_BOTTOM
+			CollapseHiddenChildren: True
+			TopBottomSpacing: 5
+			ItemSpacing: 10
 			Children:
-				ColorBlock@COLORBLOCK:
+				Background@SECTION_HEADER:
 					X: 5
-					Y: 6
-					Width: PARENT_RIGHT - 35
-					Height: PARENT_BOTTOM - 12
-		Label@BATTLEFIELD_CAMERA:
-			X: 15
-			Y: 70
-			Width: 120
-			Height: 25
-			Text: Battlefield Camera:
-			Align: Right
-		DropDownButton@BATTLEFIELD_CAMERA_DROPDOWN:
-			X: 140
-			Y: 70
-			Width: 160
-			Height: 25
-			Font: Regular
-		Label@TARGET_LINES:
-			X: 265
-			Y: 70
-			Width: 145
-			Height: 25
-			Text: Target Lines:
-			Align: Right
-		DropDownButton@TARGET_LINES_DROPDOWN:
-			X: 415
-			Y: 70
-			Width: 160
-			Height: 25
-			Font: Regular
-		Label@UI_SCALE:
-			X: 15
-			Y: 100
-			Width: 120
-			Height: 25
-			Text: UI Scale:
-			Align: Right
-		DropDownButton@UI_SCALE_DROPDOWN:
-			X: 140
-			Y: 100
-			Width: 160
-			Height: 25
-			Font: Regular
-		Label@STATUS_BARS:
-			X: 265
-			Y: 100
-			Width: 145
-			Height: 25
-			Text: Status Bars:
-			Align: Right
-		DropDownButton@STATUS_BAR_DROPDOWN:
-			X: 415
-			Y: 100
-			Width: 160
-			Height: 25
-			Font: Regular
-		Checkbox@CURSORDOUBLE_CHECKBOX:
-			X: 15
-			Y: 133
-			Width: 200
-			Height: 20
-			Font: Regular
-			Text: Increase Cursor Size
-		Checkbox@PLAYER_STANCE_COLORS_CHECKBOX:
-			X: 310
-			Y: 133
-			Width: 200
-			Height: 20
-			Font: Regular
-			Text: Player Stance Colors
-		Checkbox@UI_FEEDBACK_CHECKBOX:
-			X: 15
-			Y: 163
-			Width: 200
-			Height: 20
-			Font: Regular
-			Text: UI Feedback in Transients Panel
-		Label@VIDEO_TITLE:
-			Y: 190
-			Width: PARENT_RIGHT
-			Font: Bold
-			Text: Video
-			Align: Center
-		Label@VIDEO_MODE:
-			X: 15
-			Y: 210
-			Width: 120
-			Height: 25
-			Align: Right
-			Text: Video Mode:
-		DropDownButton@MODE_DROPDOWN:
-			X: 140
-			Y: 210
-			Width: 160
-			Height: 25
-			Font: Regular
-			Text: Windowed
-		Container@WINDOW_RESOLUTION:
-			Y: 240
-			Children:
-				Label@WINDOW_SIZE:
-					X: 15
-					Height: 25
-					Width: 120
-					Align: Right
-					Text: Window Size:
-				TextField@WINDOW_WIDTH:
-					X: 140
-					Width: 55
-					Height: 25
-					MaxLength: 5
-					Type: Integer
-				Label@X:
-					Text: x
-					Font: Bold
-					X: 195
-					Height: 25
-					Width: 15
-					Align: Center
-				TextField@WINDOW_HEIGHT:
-					X: 210
-					Width: 55
-					Height: 25
-					MaxLength: 5
-					Type: Integer
-		Container@DISPLAY_SELECTION:
-			Y: 240
-			Children:
-				Label@DISPLAY_SELECTION_LABEL:
-					X: 15
-					Height: 25
-					Width: 120
-					Align: Right
-					Text: Select Display:
-				DropDownButton@DISPLAY_SELECTION_DROPDOWN:
-					X: 140
-					Width: 160
-					Height: 25
-					Font: Regular
-		Checkbox@VSYNC_CHECKBOX:
-			X: 310
-			Y: 210
-			Width: 200
-			Height: 20
-			Font: Regular
-			Text: Enable VSync
-		Checkbox@FRAME_LIMIT_CHECKBOX:
-			X: 310
-			Y: 243
-			Width: 200
-			Height: 20
-			Font: Regular
-			Text: Enable Frame Limiter
-		Slider@FRAME_LIMIT_SLIDER:
-			X: 340
-			Y: 265
-			Width: 200
-			Height: 20
-			Ticks: 20
-			MinimumValue: 50
-			MaximumValue: 240
-		Label@GL_PROFILE:
-			X: 15
-			Y: 270
-			Width: 120
-			Height: 25
-			Align: Right
-			Text: OpenGL Profile:
-		DropDownButton@GL_PROFILE_DROPDOWN:
-			X: 140
-			Y: 270
-			Width: 160
-			Height: 25
-			Font: Regular
-		Label@RESTART_REQUIRED_DESC:
-			X: 300
-			Y: PARENT_BOTTOM + 10
-			Width: PARENT_RIGHT - 300
-			Height: 15
-			Font: TinyBold
-			Text: Display and OpenGL changes require restart
-			Align: Center
+					Width: PARENT_RIGHT - 24 - 10
+					Height: 13
+					Background: separator
+					Children:
+						Label@LABEL:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Font: TinyBold
+							Align: Center
+							Text: Profile
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@PLAYER_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@PLAYER:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Player Name:
+								TextField@PLAYERNAME:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									MaxLength: 16
+									Text: Name
+						Container@PLAYERCOLOR_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@COLOR:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Preferred Color:
+								DropDownButton@PLAYERCOLOR:
+									Y: 25
+									Width: 75
+									Height: 25
+									IgnoreChildMouseOver: true
+									PanelAlign: Right
+									Children:
+										ColorBlock@COLORBLOCK:
+											X: 5
+											Y: 6
+											Width: PARENT_RIGHT - 35
+											Height: PARENT_BOTTOM - 12
+				Container@SPACER:
+				Background@SECTION_HEADER:
+					X: 5
+					Width: PARENT_RIGHT - 24 - 10
+					Height: 13
+					Background: separator
+					Children:
+						Label@LABEL:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Font: TinyBold
+							Align: Center
+							Text: Display
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@BATTLEFIELD_CAMERA_DROPDOWN_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@BATTLEFIELD_CAMERA:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Battlefield Camera:
+								DropDownButton@BATTLEFIELD_CAMERA_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+						Container@TARGET_LINES_DROPDOWN_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@TARGET_LINES:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Target Lines:
+								DropDownButton@TARGET_LINES_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@UI_SCALE_DROPDOWN_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@UI_SCALE:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: UI Scale:
+								DropDownButton@UI_SCALE_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+						Container@STATUS_BAR_DROPDOWN_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@STATUS_BARS:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Status Bars:
+								DropDownButton@STATUS_BAR_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 20
+					Children:
+						Container@CURSORDOUBLE_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@CURSORDOUBLE_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Increase Cursor Size
+						Container@PLAYER_STANCE_COLORS_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@PLAYER_STANCE_COLORS_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Player Stance Colors
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 20
+					Children:
+						Container@UI_FEEDBACK_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@UI_FEEDBACK_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: UI Feedback in Transients Panel
+				Container@SPACER:
+				Background@SECTION_HEADER:
+					X: 5
+					Width: PARENT_RIGHT - 24 - 10
+					Height: 13
+					Background: separator
+					Children:
+						Label@LABEL:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Font: TinyBold
+							Align: Center
+							Text: Video
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@VIDEO_MODE_DROPDOWN_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@VIDEO_MODE:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Video Mode:
+								DropDownButton@MODE_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+									Text: Windowed
+						Container@WINDOW_RESOLUTION_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@WINDOW_SIZE:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Window Size:
+								TextField@WINDOW_WIDTH:
+									Y: 25
+									Width: 55
+									Height: 25
+									MaxLength: 5
+									Type: Integer
+								Label@X:
+									X: 55
+									Y: 25
+									Text: x
+									Font: Bold
+									Height: 25
+									Width: 15
+									Align: Center
+								TextField@WINDOW_HEIGHT:
+									X: 70
+									Y: 25
+									Width: 55
+									Height: 25
+									MaxLength: 5
+									Type: Integer
+						Container@DISPLAY_SELECTION_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@DISPLAY_SELECTION_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Select Display:
+								DropDownButton@DISPLAY_SELECTION_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+									Text: Standard
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@FRAME_LIMIT_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@FRAME_LIMIT_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Enable Frame Limiter
+						Container@FRAME_LIMIT_SLIDER_CONTAINER:
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Slider@FRAME_LIMIT_SLIDER:
+									X: 20
+									Y: 25
+									Width: PARENT_RIGHT - 20
+									Height: 20
+									Ticks: 20
+									MinimumValue: 50
+									MaximumValue: 240
+						Container@VSYNC_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@VSYNC_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Enable VSync
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@GL_PROFILE_DROPDOWN_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@GL_PROFILE:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: OpenGL Profile:
+								DropDownButton@GL_PROFILE_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 30
+					Children:
+						Container@RESTART_REQUIRED_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT - 20
+							Children:
+								Label@RESTART_REQUIRED_DESC:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Tiny
+									Text: Display and OpenGL changes require restart
+									Align: Center

--- a/mods/cnc/chrome/settings-hotkeys.yaml
+++ b/mods/cnc/chrome/settings-hotkeys.yaml
@@ -2,171 +2,123 @@ Container@HOTKEYS_PANEL:
 	Logic: HotkeysSettingsLogic
 		HotkeyGroups:
 			Game Commands:
-				Template: TWO_COLUMN
 				Types: OrderGenerator, World, Menu
 			Viewport Commands:
-				Template: TWO_COLUMN
 				Types: Viewport
 			Observer / Replay Commands:
-				Template: TWO_COLUMN
 				Types: Observer, Replay
 			Unit Commands:
-				Template: THREE_COLUMN
 				Types: Unit
 			Unit Stance Commands:
-				Template: TWO_COLUMN
 				Types: Stance
 			Production Commands:
-				Template: THREE_COLUMN
 				Types: Production, ProductionSlot
 			Support Power Commands:
-				Template: THREE_COLUMN
 				Types: SupportPower
 			Music Commands:
-				Template: TWO_COLUMN
 				Types: Music
 			Chat Commands:
-				Template: TWO_COLUMN
 				Types: Chat
 	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM
 	Children:
-		Label@HOTKEY_TITLE:
-			Y: 21
-			Width: PARENT_RIGHT
-			Font: Bold
-			Text: Hotkeys
-			Align: Center
 		ScrollPanel@HOTKEY_LIST:
-			X: 15
-			Y: 40
-			Width: PARENT_RIGHT - 30
-			TopBottomSpacing: 4
-			ItemSpacing: 4
-			Height: 191
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM - 65
+			TopBottomSpacing: 5
+			ItemSpacing: 5
 			Children:
-				ScrollItem@HEADER:
-					Width: 528
-					Height: 13
-					Visible: false
+				Container@HEADER:
+					Width: PARENT_RIGHT - 24 - 10
+					Height: 18
 					Children:
-						Label@LABEL:
-							Font: TinyBold
+						Background@BACKGROUND:
 							Width: PARENT_RIGHT
 							Height: 13
+							Background: separator
+						Label@LABEL:
+							Width: PARENT_RIGHT
+							Height: 13
+							Font: TinyBold
 							Align: Center
-				Container@TEMPLATES:
+				Container@TEMPLATE:
+					Width: (PARENT_RIGHT - 24) / 2 - 10
+					Height: 30
+					Visible: false
 					Children:
-						Container@TWO_COLUMN:
-							Width: 262
+						Label@FUNCTION:
+							Y: 0 - 1
+							Width: PARENT_RIGHT - 90 - 5
 							Height: 25
-							Visible: false
-							Children:
-								Label@FUNCTION:
-									Y: 0
-									Width: PARENT_RIGHT - 85
-									Height: 25
-									Align: Right
-								Button@HOTKEY:
-									X: PARENT_RIGHT - WIDTH
-									Width: 80
-									Height: 25
-									Align: Left
-									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
-						Container@THREE_COLUMN:
-							Width: 173
+							Align: Right
+						Button@HOTKEY:
+							X: PARENT_RIGHT - WIDTH
+							Width: 90
 							Height: 25
-							Visible: false
-							Children:
-								Label@FUNCTION:
-									Y: 0 - 1
-									Width: PARENT_RIGHT - 84
-									Height: 25
-									Align: Right
-								Button@HOTKEY:
-									X: PARENT_RIGHT - WIDTH + 1
-									Width: 80
-									Height: 25
-									Align: Left
-									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
+							TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 		Background@HOTKEY_DIALOG_ROOT:
-			X: 15
-			Y: 230
-			Width: PARENT_RIGHT - 30
-			Height: 65
+			Y: PARENT_BOTTOM - HEIGHT - 1
+			Width: PARENT_RIGHT
+			Height: 65 + 1
 			Background: panel-gray
 			Children:
 				Label@HOTKEY_LABEL:
 					X: 15
 					Y: 19
-					Width: 220 - 15 - 10
+					Width: 200
 					Height: 25
 					Font: Bold
 					Align: Right
 				HotkeyEntry@HOTKEY_ENTRY:
-					X: 220
+					X: 15 + 200 + 5
 					Y: 20
-					Width: 254
+					Width: 220
 					Height: 25
 				Container@NOTICES:
-					X: 220
+					X: 15 + 200 + 5
 					Y: 42
-					Width: 254
+					Width: 220
 					Height: 25
 					Children:
 						Label@DEFAULT_NOTICE:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							Font: Tiny
-							Align: Left
 							Text: This is the default
 						Label@ORIGINAL_NOTICE:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							Font: Tiny
-							Align: Left
 							Text: The default is "{0}"
 						Label@DUPLICATE_NOTICE:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							Font: Tiny
-							Align: Left
 							Text: This is already used for "{0}"
 				Button@OVERRIDE_HOTKEY_BUTTON:
-					X: PARENT_RIGHT - 50 - 15 - WIDTH - 20
+					X: PARENT_RIGHT - 3 * WIDTH - 30
 					Y: 20
 					Width: 70
 					Height: 25
 					Text: Override
+					Font: Bold
 				Button@CLEAR_HOTKEY_BUTTON:
-					X: PARENT_RIGHT - 25 - 15 - WIDTH - 10
+					X: PARENT_RIGHT - 2 * WIDTH - 30
 					Y: 20
-					Width: 25
+					Width: 65
 					Height: 25
+					Text: Clear
+					Font: Bold
 					TooltipText: Unbind the hotkey
 					TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 					TooltipTemplate: SIMPLE_TOOLTIP
-					Children:
-						Image:
-							ImageCollection: lobby-bits
-							ImageName: kick
-							X: 7
-							Y: 8
-							IgnoreMouseOver: True
 				Button@RESET_HOTKEY_BUTTON:
-					X: PARENT_RIGHT - WIDTH - 15
+					X: PARENT_RIGHT - WIDTH - 20
 					Y: 20
-					Width: 25
+					Width: 65
 					Height: 25
+					Text: Reset
+					Font: Bold
 					TooltipText: Reset to default
 					TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 					TooltipTemplate: SIMPLE_TOOLTIP
-					Children:
-						Image@IMAGE_RELOAD:
-							X: 5
-							Y: 5
-							Width: 16
-							Height: 16
-							ImageCollection: reload-icon
-							ImageName: enabled
-							IgnoreMouseOver: True

--- a/mods/cnc/chrome/settings-hotkeys.yaml
+++ b/mods/cnc/chrome/settings-hotkeys.yaml
@@ -80,11 +80,6 @@ Container@HOTKEYS_PANEL:
 					Width: 220
 					Height: 25
 					Children:
-						Label@DEFAULT_NOTICE:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
-							Font: Tiny
-							Text: This is the default
 						Label@ORIGINAL_NOTICE:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM

--- a/mods/cnc/chrome/settings-input.yaml
+++ b/mods/cnc/chrome/settings-input.yaml
@@ -3,217 +3,266 @@ Container@INPUT_PANEL:
 	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM
 	Children:
-		Label@INPUT_TITLE:
-			Y: 21
+		ScrollPanel@SETTINGS_SCROLLPANEL:
 			Width: PARENT_RIGHT
-			Font: Bold
-			Text: Input
-			Align: Center
-		Label@MOUSE_CONTROL_LABEL:
-			X: 15
-			Y: 40
-			Width: 110
-			Height: 25
-			Font: Regular
-			Text: Control Scheme:
-			Align: Right
-		DropDownButton@MOUSE_CONTROL_DROPDOWN:
-			X: 130
-			Y: 40
-			Width: 150
-			Height: 25
-			Font: Regular
-		Container@MOUSE_CONTROL_DESC_CLASSIC:
-			X: 25
-			Y: 70
-			Width: 300
+			Height: PARENT_BOTTOM
+			CollapseHiddenChildren: True
+			TopBottomSpacing: 5
+			ItemSpacing: 10
 			Children:
-				LabelWithHighlight@DESC_SELECTION:
-					Height: 16
-					Font: Small
-					Text: - Select units using the {Left} mouse button
-				LabelWithHighlight@DESC_COMMANDS:
-					Y: 17
-					Height: 16
-					Font: Small
-					Text: - Command units using the {Left} mouse button
-				LabelWithHighlight@DESC_BUILDIGS:
-					Y: 34
-					Height: 16
-					Font: Small
-					Text: - Place structures using the {Left} mouse button
-				LabelWithHighlight@DESC_SUPPORT:
-					Y: 51
-					Height: 16
-					Font: Small
-					Text: - Target support powers using the {Left} mouse button
-				LabelWithHighlight@DESC_ZOOM:
-					Y: 68
-					Height: 16
-					Font: Small
-					Text: - Zoom the battlefield using the {Scroll Wheel}
-				LabelWithHighlight@DESC_ZOOM_MODIFIER:
-					Y: 68
-					Height: 16
-					Font: Small
-					Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
-				LabelWithHighlight@DESC_SCROLL_RIGHT:
-					Y: 85
-					Height: 16
-					Font: Small
-					Text: - Pan the battlefield using the {Right} mouse button
-				LabelWithHighlight@DESC_SCROLL_MIDDLE:
-					Y: 85
-					Height: 16
-					Font: Small
-					Text: - Pan the battlefield using the {Middle} mouse button
-				Label@DESC_EDGESCROLL:
-					X: 9
-					Y: 102
-					Height: 16
-					Font: Small
-					Text: or by moving the cursor to the edge of the screen
-		Container@MOUSE_CONTROL_DESC_MODERN:
-			X: 25
-			Y: 70
-			Width: 300
-			Children:
-				LabelWithHighlight@DESC_SELECTION:
-					Height: 16
-					Font: Small
-					Text: - Select units using the {Left} mouse button
-				LabelWithHighlight@DESC_COMMANDS:
-					Y: 17
-					Height: 16
-					Font: Small
-					Text: - Command units using the {Right} mouse button
-				LabelWithHighlight@DESC_BUILDIGS:
-					Y: 34
-					Height: 16
-					Font: Small
-					Text: - Place structures using the {Left} mouse button
-				LabelWithHighlight@DESC_SUPPORT:
-					Y: 51
-					Height: 16
-					Font: Small
-					Text: - Target support powers using the {Left} mouse button
-				LabelWithHighlight@DESC_ZOOM:
-					Y: 68
-					Height: 16
-					Font: Small
-					Text: - Zoom the battlefield using the {Scroll Wheel}
-				LabelWithHighlight@DESC_ZOOM_MODIFIER:
-					Y: 68
-					Height: 16
-					Font: Small
-					Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
-				LabelWithHighlight@DESC_SCROLL_RIGHT:
-					Y: 85
-					Height: 16
-					Font: Small
-					Text: - Pan the battlefield using the {Right} mouse button
-				LabelWithHighlight@DESC_SCROLL_MIDDLE:
-					Y: 85
-					Height: 16
-					Font: Small
-					Text: - Pan the battlefield using the {Middle} mouse button
-				Label@DESC_EDGESCROLL:
-					X: 9
-					Y: 102
-					Height: 16
-					Font: Small
-					Text: or by moving the cursor to the edge of the screen
-		Label@MOUSE_SCROLL_TYPE_LABEL:
-			X: 15
-			Y: 210
-			Width: 110
-			Height: 25
-			Font: Regular
-			Text: Pan Behaviour:
-			Align: Right
-		DropDownButton@MOUSE_SCROLL_TYPE_DROPDOWN:
-			X: 130
-			Y: 210
-			Width: 150
-			Height: 25
-			Font: Regular
-		Checkbox@LOCKMOUSE_CHECKBOX:
-			X: 15
-			Y: 243
-			Width: 190
-			Height: 20
-			Font: Regular
-			Text: Lock Mouse to Window
-		Label@ZOOM_MODIFIER_LABEL:
-			X: 350
-			Y: 70
-			Width: 70
-			Height: 25
-			Font: Regular
-			Text: Zoom Modifier:
-			Align: Right
-		DropDownButton@ZOOM_MODIFIER:
-			X: 425
-			Y: 70
-			Width: 150
-			Height: 25
-			Font: Regular
-		Checkbox@EDGESCROLL_CHECKBOX:
-			X: 360
-			Y: 103
-			Width: 180
-			Height: 20
-			Font: Regular
-			Text: Screen Edge Panning
-		Checkbox@ALTERNATE_SCROLL_CHECKBOX:
-			X: 360
-			Y: 133
-			Width: 180
-			Height: 20
-			Font: Regular
-			Text: Alternate Mouse Panning
-		Label@SCROLL_SPEED_LABEL:
-			X: 310
-			Y: 210
-			Width: 100
-			Height: 25
-			Text: Pan Speed:
-			Align: Right
-		Slider@SCROLLSPEED_SLIDER:
-			X: 415
-			Y: 215
-			Width: 160
-			Height: 20
-			Ticks: 5
-			MinimumValue: 10
-			MaximumValue: 50
-		Label@ZOOM_SPEED_LABEL:
-			X: 310
-			Y: 240
-			Width: 100
-			Height: 25
-			Text: Zoom Speed:
-			Align: Right
-		ExponentialSlider@ZOOMSPEED_SLIDER:
-			X: 415
-			Y: 245
-			Width: 160
-			Height: 20
-			Ticks: 5
-			MinimumValue: 0.01
-			MaximumValue: 0.4
-		Label@UI_SCROLL_SPEED_LABEL:
-			X: 310
-			Y: 270
-			Width: 100
-			Height: 25
-			Text: UI Scroll Speed:
-			Align: Right
-		Slider@UI_SCROLLSPEED_SLIDER:
-			X: 415
-			Y: 275
-			Width: 160
-			Height: 20
-			Ticks: 5
-			MinimumValue: 1
-			MaximumValue: 100
+				Background@SECTION_HEADER:
+					X: 5
+					Width: PARENT_RIGHT - 24 - 10
+					Height: 13
+					Background: separator
+					Children:
+						Label@LABEL:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Font: TinyBold
+							Align: Center
+							Text: Input
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@MOUSE_CONTROL_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@MOUSE_CONTROL_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Control Scheme:
+								DropDownButton@MOUSE_CONTROL_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+						Container@ZOOM_MODIFIER_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@ZOOM_MODIFIER_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Zoom Modifier:
+								DropDownButton@ZOOM_MODIFIER:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+						Container@MOUSE_CONTROL_DESC_CLASSIC:
+							X: 10
+							Y: 55
+							Width: PARENT_RIGHT
+							Children:
+								LabelWithHighlight@DESC_SELECTION:
+									Height: 16
+									Font: Small
+									Text: - Select units using the {Left} mouse button
+								LabelWithHighlight@DESC_COMMANDS:
+									Y: 17
+									Height: 16
+									Font: Small
+									Text: - Command units using the {Left} mouse button
+								LabelWithHighlight@DESC_BUILDIGS:
+									Y: 34
+									Height: 16
+									Font: Small
+									Text: - Place structures using the {Left} mouse button
+								LabelWithHighlight@DESC_SUPPORT:
+									Y: 51
+									Height: 16
+									Font: Small
+									Text: - Target support powers using the {Left} mouse button
+								LabelWithHighlight@DESC_ZOOM:
+									Y: 68
+									Height: 16
+									Font: Small
+									Text: - Zoom the battlefield using the {Scroll Wheel}
+								LabelWithHighlight@DESC_ZOOM_MODIFIER:
+									Y: 68
+									Height: 16
+									Font: Small
+									Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
+								LabelWithHighlight@DESC_SCROLL_RIGHT:
+									Y: 85
+									Height: 16
+									Font: Small
+									Text: - Pan the battlefield using the {Right} mouse button
+								LabelWithHighlight@DESC_SCROLL_MIDDLE:
+									Y: 85
+									Height: 16
+									Font: Small
+									Text: - Pan the battlefield using the {Middle} mouse button
+								Label@DESC_EDGESCROLL:
+									X: 9
+									Y: 102
+									Height: 16
+									Font: Small
+									Text: or by moving the cursor to the edge of the screen
+						Container@MOUSE_CONTROL_DESC_MODERN:
+							X: 10
+							Y: 55
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								LabelWithHighlight@DESC_SELECTION:
+									Height: 16
+									Font: Small
+									Text: - Select units using the {Left} mouse button
+								LabelWithHighlight@DESC_COMMANDS:
+									Y: 17
+									Height: 16
+									Font: Small
+									Text: - Command units using the {Right} mouse button
+								LabelWithHighlight@DESC_BUILDIGS:
+									Y: 34
+									Height: 16
+									Font: Small
+									Text: - Place structures using the {Left} mouse button
+								LabelWithHighlight@DESC_SUPPORT:
+									Y: 51
+									Height: 16
+									Font: Small
+									Text: - Target support powers using the {Left} mouse button
+								LabelWithHighlight@DESC_ZOOM:
+									Y: 68
+									Height: 16
+									Font: Small
+									Text: - Zoom the battlefield using the {Scroll Wheel}
+								LabelWithHighlight@DESC_ZOOM_MODIFIER:
+									Y: 68
+									Height: 16
+									Font: Small
+									Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
+								LabelWithHighlight@DESC_SCROLL_RIGHT:
+									Y: 85
+									Height: 16
+									Font: Small
+									Text: - Pan the battlefield using the {Right} mouse button
+								LabelWithHighlight@DESC_SCROLL_MIDDLE:
+									Y: 85
+									Height: 16
+									Font: Small
+									Text: - Pan the battlefield using the {Middle} mouse button
+								Label@DESC_EDGESCROLL:
+									X: 9
+									Y: 102
+									Height: 16
+									Font: Small
+									Text: or by moving the cursor to the edge of the screen
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 20
+					Children:
+						Container@EDGESCROLL_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@EDGESCROLL_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Screen Edge Panning
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 20
+					Children:
+						Container@ALTERNATE_SCROLL_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@ALTERNATE_SCROLL_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Alternate Mouse Panning
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 20
+					Children:
+						Container@LOCKMOUSE_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@LOCKMOUSE_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Lock Mouse to Window
+				Container@SPACER:
+					Height: 30
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@MOUSE_SCROLL_TYPE_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@MOUSE_SCROLL_TYPE_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Pan Behaviour:
+								DropDownButton@MOUSE_SCROLL_TYPE_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+						Container@SCROLLSPEED_SLIDER_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@SCROLL_SPEED_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Pan Speed:
+								Slider@SCROLLSPEED_SLIDER:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 20
+									Ticks: 7
+									MinimumValue: 10
+									MaximumValue: 50
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@ZOOMSPEED_SLIDER_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@ZOOM_SPEED_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Zoom Speed:
+								ExponentialSlider@ZOOMSPEED_SLIDER:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 20
+									Ticks: 7
+									MinimumValue: 0.01
+									MaximumValue: 0.4
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@UI_SCROLLSPEED_SLIDER_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@UI_SCROLL_SPEED_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: UI Scroll Speed:
+								Slider@UI_SCROLLSPEED_SLIDER:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 20
+									Ticks: 7
+									MinimumValue: 1
+									MaximumValue: 100

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -1,6 +1,6 @@
 Container@SETTINGS_PANEL:
 	Logic: SettingsLogic
-		ButtonStride: 120, 0
+		ButtonStride: 0, 45
 		Panels:
 			DISPLAY_PANEL: Display
 			AUDIO_PANEL: Audio
@@ -9,40 +9,42 @@ Container@SETTINGS_PANEL:
 			ADVANCED_PANEL: Advanced
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
-	Width: 590
-	Height: 328
+	Width: 640
+	Height: 435
 	Children:
 		Label@TITLE:
-			Width: 590
+			Width: PARENT_RIGHT
 			Y: 0 - 22
 			Font: BigBold
 			Contrast: true
 			Align: Center
 			Text: Settings
-		Container@TAB_CONTAINER:
-			Children:
-				Button@BUTTON_TEMPLATE:
-					Width: 110
-					Height: 35
-		Background@PANEL_CONTAINER:
-			Y: 34
-			Width: 590
-			Height: 310
-			Background: panel-black
-			Children:
-				Container@PANEL_TEMPLATE:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
 		Button@BACK_BUTTON:
 			Key: escape
-			Y: 343
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Back
 		Button@RESET_BUTTON:
 			X: 150
-			Y: 343
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Reset
+		Container@SETTINGS_TAB_CONTAINER:
+			X: 0 - 140 + 1
+			Children:
+				Button@BUTTON_TEMPLATE:
+					Width: 140
+					Height: 35
+		Background@PANEL_CONTAINER:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Background: panel-black
+			Children:
+				Container@PANEL_TEMPLATE:
+					X: 15
+					Y: 15
+					Width: PARENT_RIGHT - 30
+					Height: PARENT_BOTTOM - 30
 		TooltipContainer@SETTINGS_TOOLTIP_CONTAINER:

--- a/mods/common/chrome/ingame-info-lobby-options.yaml
+++ b/mods/common/chrome/ingame-info-lobby-options.yaml
@@ -7,39 +7,55 @@ Container@LOBBY_OPTIONS_PANEL:
 			X: 20
 			Y: 20
 			Width: 482
-			Height: 350
+			Height: 365
 			Children:
 				Container@LOBBY_OPTIONS:
-					X: 10
-					Y: 9
-					Width: PARENT_RIGHT - 10 - 24
+					Y: 10
+					Width: PARENT_RIGHT - 24
 					Children:
 						Container@CHECKBOX_ROW_TEMPLATE:
+							Width: PARENT_RIGHT
 							Height: 30
 							Children:
 								Checkbox@A:
-									Width: 220
+									X: 10
+									Width: PARENT_RIGHT / 2 - 20
 									Height: 20
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								Checkbox@B:
-									X: 225
-									Width: 220
+									X: PARENT_RIGHT / 2 + 10
+									Width: PARENT_RIGHT / 2 - 20
 									Height: 20
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 						Container@DROPDOWN_ROW_TEMPLATE:
-							Height: 30
+							Height: 60
 							Width: PARENT_RIGHT
 							Children:
 								Label@A_DESC:
-									Width: 140
-									Height: 25
-									Align: Right
+									X: 10
+									Width: PARENT_RIGHT / 2 - 20
+									Height: 20
 									Visible: False
 								DropDownButton@A:
-									X: 145
-									Width: 180
+									X: 10
+									Y: 25
+									Width: PARENT_RIGHT / 2 - 20
 									Height: 25
+									Font: Regular
+									Visible: False
+									TooltipContainer: TOOLTIP_CONTAINER
+								Label@B_DESC:
+									X: PARENT_RIGHT / 2 + 10
+									Width: PARENT_RIGHT / 2 - 20
+									Height: 20
+									Visible: False
+								DropDownButton@B:
+									X: PARENT_RIGHT / 2 + 10
+									Y: 25
+									Width: PARENT_RIGHT / 2 - 20
+									Height: 25
+									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER

--- a/mods/common/chrome/ingame-info.yaml
+++ b/mods/common/chrome/ingame-info.yaml
@@ -2,7 +2,7 @@ Container@GAME_INFO_PANEL:
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
 	Width: 522
-	Height: 485
+	Height: 500
 	Logic: GameInfoLogic
 	Visible: False
 	Children:

--- a/mods/common/chrome/ingame-infobriefing.yaml
+++ b/mods/common/chrome/ingame-infobriefing.yaml
@@ -22,7 +22,7 @@ Container@MAP_PANEL:
 			X: 20
 			Y: 232
 			Width: PARENT_RIGHT - 40
-			Height: 138
+			Height: 153
 			Children:
 				Label@MAP_DESCRIPTION:
 					X: 4

--- a/mods/common/chrome/ingame-infochat.yaml
+++ b/mods/common/chrome/ingame-infochat.yaml
@@ -1,7 +1,7 @@
 Container@CHAT_CONTAINER:
 	Y: 20
 	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM - 100
+	Height: PARENT_BOTTOM - 105
 	Logic: IngameChatLogic
 		Templates:
 			Chat: CHAT_LINE_TEMPLATE

--- a/mods/common/chrome/ingame-infoobjectives.yaml
+++ b/mods/common/chrome/ingame-infoobjectives.yaml
@@ -20,7 +20,7 @@ Container@MISSION_OBJECTIVES:
 			X: 20
 			Y: 60
 			Width: 482
-			Height: 310
+			Height: 325
 			TopBottomSpacing: 15
 			ItemSpacing: 15
 			Children:

--- a/mods/common/chrome/ingame-infostats.yaml
+++ b/mods/common/chrome/ingame-infostats.yaml
@@ -56,7 +56,7 @@ Container@SKIRMISH_STATS:
 			X: 20
 			Y: 105
 			Width: 482
-			Height: 265
+			Height: 280
 			ItemSpacing: 5
 			Children:
 				ScrollItem@TEAM_TEMPLATE:

--- a/mods/common/chrome/lobby-options.yaml
+++ b/mods/common/chrome/lobby-options.yaml
@@ -15,55 +15,68 @@ Container@LOBBY_OPTIONS_BIN:
 			Height: PARENT_BOTTOM
 			Children:
 				Container@LOBBY_OPTIONS:
-					X: 10
-					Y: 9
-					Width: PARENT_RIGHT - 10 - 24
+					Y: 10
+					Width: PARENT_RIGHT - 24
 					Children:
 						Container@CHECKBOX_ROW_TEMPLATE:
+							Width: PARENT_RIGHT
 							Height: 30
 							Children:
 								Checkbox@A:
-									Width: 220
+									X: 10
+									Width: PARENT_RIGHT / 3 - 20
 									Height: 20
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								Checkbox@B:
-									X: 225
-									Width: 220
+									X: PARENT_RIGHT / 3 + 10
+									Width: PARENT_RIGHT / 3 - 20
 									Height: 20
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								Checkbox@C:
-									X: 450
-									Width: 190
+									X: (PARENT_RIGHT / 3) * 2 + 10
+									Width: PARENT_RIGHT / 3 - 20
 									Height: 20
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 						Container@DROPDOWN_ROW_TEMPLATE:
-							Height: 30
+							Height: 60
 							Width: PARENT_RIGHT
 							Children:
 								Label@A_DESC:
-									Width: 140
-									Height: 25
-									Align: Right
+									X: 10
+									Width: PARENT_RIGHT / 3 - 20
+									Height: 20
 									Visible: False
 								DropDownButton@A:
-									X: 145
-									Width: 180
+									X: 10
+									Width: PARENT_RIGHT / 3 - 20
+									Y: 25
 									Height: 25
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								Label@B_DESC:
-									X: PARENT_RIGHT - WIDTH - 203
-									Width: 140
-									Height: 25
-									Align: Right
+									X: PARENT_RIGHT / 3 + 10
+									Width: PARENT_RIGHT / 3 - 20
+									Height: 20
 									Visible: False
 								DropDownButton@B:
-									X: PARENT_RIGHT - WIDTH - 18
-									Width: 180
+									X: PARENT_RIGHT / 3 + 10
+									Width: PARENT_RIGHT / 3 - 20
+									Y: 25
 									Height: 25
-									Font: Regular
+									Visible: False
+									TooltipContainer: TOOLTIP_CONTAINER
+								Label@C_DESC:
+									X: (PARENT_RIGHT / 3) * 2 + 10
+									Width: PARENT_RIGHT / 3 - 20
+									Height: 20
+									Visible: False
+								DropDownButton@C:
+									X: (PARENT_RIGHT / 3) * 2 + 10
+									Width: PARENT_RIGHT / 3 - 20
+									Y: 25
+									Height: 25
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER

--- a/mods/common/chrome/mainmenu-prompts.yaml
+++ b/mods/common/chrome/mainmenu-prompts.yaml
@@ -2,8 +2,8 @@ Background@MAINMENU_INTRODUCTION_PROMPT:
 	Logic: IntroductionPromptLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
-	Width: 600
-	Height: 430
+	Width: 700
+	Height: 525
 	Children:
 		Label@PROMPT_TITLE:
 			Width: PARENT_RIGHT
@@ -26,222 +26,265 @@ Background@MAINMENU_INTRODUCTION_PROMPT:
 			Font: Regular
 			Align: Center
 			Text: Additional options can be configured later from the Settings menu.
-		Label@PROFILE_TITLE:
-			Width: PARENT_RIGHT
+		ScrollPanel@SETTINGS_SCROLLPANEL:
+			X: 20
 			Y: 100
-			Height: 25
-			Font: Bold
-			Align: Center
-			Text: Profile
-		Label@PLAYER:
-			Text: Player Name:
-			X: 20
-			Y: 130
-			Width: 120
-			Height: 25
-			Align: Right
-		TextField@PLAYERNAME:
-			X: 145
-			Y: 130
-			Width: 160
-			Height: 25
-			MaxLength: 16
-		Label@COLOR:
-			X: 265 + 60
-			Y: 130
-			Width: 145
-			Height: 25
-			Text: Preferred Color:
-			Align: Right
-		DropDownButton@PLAYERCOLOR:
-			X: 415 + 60
-			Y: 130
-			Width: 75
-			Height: 25
-			IgnoreChildMouseOver: true
-			PanelAlign: Right
+			Width: PARENT_RIGHT - 40
+			Height: PARENT_BOTTOM - 155
+			CollapseHiddenChildren: True
+			TopBottomSpacing: 5
+			ItemSpacing: 10
+			ScrollBar: Hidden
 			Children:
-				ColorBlock@COLORBLOCK:
+				Background@SECTION_HEADER:
 					X: 5
-					Y: 6
-					Width: PARENT_RIGHT - 35
-					Height: PARENT_BOTTOM - 12
-		Label@INPUT_TITLE:
-			Width: PARENT_RIGHT
-			Y: 160
-			Height: 25
-			Font: Bold
-			Align: Center
-			Text: Input
-		Label@MOUSE_CONTROL_LABEL:
-			X: 20
-			Y: 190
-			Width: 120
-			Height: 25
-			Font: Regular
-			Text: Control Scheme:
-			Align: Right
-		DropDownButton@MOUSE_CONTROL_DROPDOWN:
-			X: 145
-			Y: 190
-			Width: 160
-			Height: 25
-			Font: Regular
-		Checkbox@EDGESCROLL_CHECKBOX:
-			X: 365
-			Y: 193
-			Width: 180
-			Height: 20
-			Font: Regular
-			Text: Screen Edge Panning
-		Container@MOUSE_CONTROL_DESC_CLASSIC:
-			X: 25
-			Y: 220
-			Width: PARENT_RIGHT - 50
-			Children:
-				LabelWithHighlight@DESC_SELECTION:
-					Height: 16
-					Font: Small
-					Text: - Select units using the {Left} mouse button
-				LabelWithHighlight@DESC_COMMANDS:
-					Y: 17
-					Height: 16
-					Font: Small
-					Text: - Command units using the {Left} mouse button
-				LabelWithHighlight@DESC_BUILDIGS:
-					Y: 34
-					Height: 16
-					Font: Small
-					Text: - Place structures using the {Left} mouse button
-				LabelWithHighlight@DESC_SUPPORT:
-					X: 265
-					Height: 16
-					Font: Small
-					Text: - Target support powers using the {Left} mouse button
-				LabelWithHighlight@DESC_ZOOM:
-					X: 265
-					Y: 17
-					Height: 16
-					Font: Small
-					Text: - Zoom the battlefield using the {Scroll Wheel}
-				LabelWithHighlight@DESC_ZOOM_MODIFIER:
-					X: 265
-					Y: 17
-					Height: 16
-					Font: Small
-					Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
-				LabelWithHighlight@DESC_SCROLL_RIGHT:
-					X: 265
-					Y: 34
-					Height: 16
-					Font: Small
-					Text: - Pan the battlefield using the {Right} mouse button
-				LabelWithHighlight@DESC_SCROLL_MIDDLE:
-					X: 265
-					Y: 34
-					Height: 16
-					Font: Small
-					Text: - Pan the battlefield using the {Middle} mouse button
-				Label@DESC_EDGESCROLL:
-					X: 274
-					Y: 51
-					Height: 16
-					Font: Small
-					Text: or by moving the cursor to the edge of the screen
-		Container@MOUSE_CONTROL_DESC_MODERN:
-			X: 25
-			Y: 220
-			Width: PARENT_RIGHT - 50
-			Children:
-				LabelWithHighlight@DESC_SELECTION:
-					Height: 16
-					Font: Small
-					Text: - Select units using the {Left} mouse button
-				LabelWithHighlight@DESC_COMMANDS:
-					Y: 17
-					Height: 16
-					Font: Small
-					Text: - Command units using the {Right} mouse button
-				LabelWithHighlight@DESC_BUILDIGS:
-					Y: 34
-					Height: 16
-					Font: Small
-					Text: - Place structures using the {Left} mouse button
-				LabelWithHighlight@DESC_SUPPORT:
-					X: 265
-					Height: 16
-					Font: Small
-					Text: - Target support powers using the {Left} mouse button
-				LabelWithHighlight@DESC_ZOOM:
-					X: 265
-					Y: 17
-					Height: 16
-					Font: Small
-					Text: - Zoom the battlefield using the {Scroll Wheel}
-				LabelWithHighlight@DESC_ZOOM_MODIFIER:
-					X: 265
-					Y: 17
-					Height: 16
-					Font: Small
-					Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
-				LabelWithHighlight@DESC_SCROLL_RIGHT:
-					X: 265
-					Y: 34
-					Height: 16
-					Font: Small
-					Text: - Pan the battlefield using the {Right} mouse button
-				LabelWithHighlight@DESC_SCROLL_MIDDLE:
-					X: 265
-					Y: 34
-					Height: 16
-					Font: Small
-					Text: - Pan the battlefield using the {Middle} mouse button
-				Label@DESC_EDGESCROLL:
-					X: 274
-					Y: 51
-					Height: 16
-					Font: Small
-					Text: or by moving the cursor to the edge of the screen
-		Label@INPUT_TITLE:
-			Width: PARENT_RIGHT
-			Y: 290
-			Height: 25
-			Font: Bold
-			Align: Center
-			Text: Display
-		Label@BATTLEFIELD_CAMERA:
-			X: 20
-			Y: 320
-			Width: 120
-			Height: 25
-			Text: Battlefield Camera:
-			Align: Right
-		DropDownButton@BATTLEFIELD_CAMERA_DROPDOWN:
-			X: 145
-			Y: 320
-			Width: 160
-			Height: 25
-			Font: Regular
-		Label@UI_SCALE:
-			X: 270
-			Y: 320
-			Width: 145
-			Height: 25
-			Text: UI Scale:
-			Align: Right
-		DropDownButton@UI_SCALE_DROPDOWN:
-			X: 420
-			Y: 320
-			Width: 160
-			Height: 25
-			Font: Regular
-		Checkbox@CURSORDOUBLE_CHECKBOX:
-			X: 390
-			Y: 353
-			Width: 200
-			Height: 20
-			Font: Regular
-			Text: Increase Cursor Size
+					Width: PARENT_RIGHT - 10
+					Height: 13
+					Background: separator
+					Children:
+						Label@LABEL:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Font: TinyBold
+							Align: Center
+							Text: Profile
+				Container@ROW:
+					Width: PARENT_RIGHT
+					Height: 50
+					Children:
+						Container@PLAYER_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@PLAYER:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Player Name:
+								TextField@PLAYERNAME:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									MaxLength: 16
+									Text: Name
+						Container@PLAYERCOLOR_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@COLOR:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Preferred Color:
+								DropDownButton@PLAYERCOLOR:
+									Y: 25
+									Width: 75
+									Height: 25
+									IgnoreChildMouseOver: true
+									PanelAlign: Right
+									Children:
+										ColorBlock@COLORBLOCK:
+											X: 5
+											Y: 6
+											Width: PARENT_RIGHT - 35
+											Height: PARENT_BOTTOM - 12
+				Container@SPACER:
+				Background@SECTION_HEADER:
+					X: 5
+					Width: PARENT_RIGHT - 10
+					Height: 13
+					Background: separator
+					Children:
+						Label@LABEL:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Font: TinyBold
+							Align: Center
+							Text: Input
+				Container@ROW:
+					Width: PARENT_RIGHT
+					Height: 50
+					Children:
+						Container@MOUSE_CONTROL_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@MOUSE_CONTROL_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Control Scheme:
+								DropDownButton@MOUSE_CONTROL_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+						Container@MOUSE_CONTROL_DESC_CLASSIC:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								LabelWithHighlight@DESC_SELECTION:
+									Height: 16
+									Font: Small
+									Text: - Select units using the {Left} mouse button
+								LabelWithHighlight@DESC_COMMANDS:
+									Y: 17
+									Height: 16
+									Font: Small
+									Text: - Command units using the {Left} mouse button
+								LabelWithHighlight@DESC_BUILDIGS:
+									Y: 34
+									Height: 16
+									Font: Small
+									Text: - Place structures using the {Left} mouse button
+								LabelWithHighlight@DESC_SUPPORT:
+									Y: 51
+									Height: 16
+									Font: Small
+									Text: - Target support powers using the {Left} mouse button
+								LabelWithHighlight@DESC_ZOOM:
+									Y: 68
+									Height: 16
+									Font: Small
+									Text: - Zoom the battlefield using the {Scroll Wheel}
+								LabelWithHighlight@DESC_ZOOM_MODIFIER:
+									Y: 68
+									Height: 16
+									Font: Small
+									Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
+								LabelWithHighlight@DESC_SCROLL_RIGHT:
+									Y: 85
+									Height: 16
+									Font: Small
+									Text: - Pan the battlefield using the {Right} mouse button
+								LabelWithHighlight@DESC_SCROLL_MIDDLE:
+									Y: 85
+									Height: 16
+									Font: Small
+									Text: - Pan the battlefield using the {Middle} mouse button
+								Label@DESC_EDGESCROLL:
+									X: 9
+									Y: 102
+									Height: 16
+									Font: Small
+									Text: or by moving the cursor to the edge of the screen
+						Container@MOUSE_CONTROL_DESC_MODERN:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								LabelWithHighlight@DESC_SELECTION:
+									Height: 16
+									Font: Small
+									Text: - Select units using the {Left} mouse button
+								LabelWithHighlight@DESC_COMMANDS:
+									Y: 17
+									Height: 16
+									Font: Small
+									Text: - Command units using the {Right} mouse button
+								LabelWithHighlight@DESC_BUILDIGS:
+									Y: 34
+									Height: 16
+									Font: Small
+									Text: - Place structures using the {Left} mouse button
+								LabelWithHighlight@DESC_SUPPORT:
+									Y: 51
+									Height: 16
+									Font: Small
+									Text: - Target support powers using the {Left} mouse button
+								LabelWithHighlight@DESC_ZOOM:
+									Y: 68
+									Height: 16
+									Font: Small
+									Text: - Zoom the battlefield using the {Scroll Wheel}
+								LabelWithHighlight@DESC_ZOOM_MODIFIER:
+									Y: 68
+									Height: 16
+									Font: Small
+									Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
+								LabelWithHighlight@DESC_SCROLL_RIGHT:
+									Y: 85
+									Height: 16
+									Font: Small
+									Text: - Pan the battlefield using the {Right} mouse button
+								LabelWithHighlight@DESC_SCROLL_MIDDLE:
+									Y: 85
+									Height: 16
+									Font: Small
+									Text: - Pan the battlefield using the {Middle} mouse button
+								Label@DESC_EDGESCROLL:
+									X: 9
+									Y: 102
+									Height: 16
+									Font: Small
+									Text: or by moving the cursor to the edge of the screen
+				Container@ROW:
+					Width: PARENT_RIGHT
+					Height: 20
+					Children:
+						Container@EDGESCROLL_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@EDGESCROLL_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Screen Edge Panning
+				Container@SPACER:
+					Height: 30
+				Background@SECTION_HEADER:
+					X: 5
+					Width: PARENT_RIGHT - 10
+					Height: 13
+					Background: separator
+					Children:
+						Label@LABEL:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Font: TinyBold
+							Align: Center
+							Text: Display
+				Container@ROW:
+					Width: PARENT_RIGHT
+					Height: 50
+					Children:
+						Container@BATTLEFIELD_CAMERA_DROPDOWN_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@BATTLEFIELD_CAMERA:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Battlefield Camera:
+								DropDownButton@BATTLEFIELD_CAMERA_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+						Container@UI_SCALE_DROPDOWN_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@UI_SCALE:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: UI Scale:
+								DropDownButton@UI_SCALE_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+				Container@ROW:
+					Width: PARENT_RIGHT
+					Height: 20
+					Children:
+						Container@CURSORDOUBLE_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@CURSORDOUBLE_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Increase Cursor Size
 		Button@CONTINUE_BUTTON:
 			X: PARENT_RIGHT - 180
 			Y: PARENT_BOTTOM - 45

--- a/mods/common/chrome/settings-advanced.yaml
+++ b/mods/common/chrome/settings-advanced.yaml
@@ -1,124 +1,195 @@
 Container@ADVANCED_PANEL:
 	Logic: AdvancedSettingsLogic
-	Width: PARENT_RIGHT - 10
+	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM
 	Children:
-		Checkbox@NAT_DISCOVERY:
-			X: 15
-			Y: 43
-			Width: 200
-			Height: 20
-			Font: Regular
-			Text: Enable UPnP/NAT-PMP Discovery
-		Checkbox@PERFTEXT_CHECKBOX:
-			X: 15
-			Y: 73
-			Width: 300
-			Height: 20
-			Font: Regular
-			Text: Show Performance Text
-		Checkbox@PERFGRAPH_CHECKBOX:
-			X: 15
-			Y: 103
-			Width: 300
-			Height: 20
-			Font: Regular
-			Text: Show Performance Graph
-		Checkbox@FETCH_NEWS_CHECKBOX:
-			X: 310
-			Y: 43
-			Width: 300
-			Height: 20
-			Font: Regular
-			Text: Fetch Community News
-		Checkbox@CHECK_VERSION_CHECKBOX:
-			X: 310
-			Y: 73
-			Width: 300
-			Height: 20
-			Font: Regular
-			Text: Check for Updates
-		Checkbox@SENDSYSINFO_CHECKBOX:
-			X: 310
-			Y: 103
-			Width: 300
-			Height: 20
-			Font: Regular
-			Text: Send System Information
-		Label@SENDSYSINFO_DESC:
-			X: 310
-			Y: 118
-			Width: 255
-			Height: 30
-			Font: Tiny
-			WordWrap: True
-			Text: Your Operating System, OpenGL and .NET runtime versions, and language settings will be sent along with an anonymous ID to help prioritize future development.
-		Label@DEBUG_TITLE:
-			Y: 190
-			Width: PARENT_RIGHT
-			Font: Bold
-			Text: Developer
-			Align: Center
-		Container@DEBUG_HIDDEN_LABEL:
-			Y: 245
-			Width: PARENT_RIGHT
-			Children:
-				Label@A:
-					Width: PARENT_RIGHT
-					Height: 20
-					Font: Regular
-					Text: Additional developer-specific options can be enabled via the
-					Align: Center
-				Label@B:
-					Y: 20
-					Width: PARENT_RIGHT
-					Height: 20
-					Font: Regular
-					Text: Debug.DisplayDeveloperSettings setting or launch flag
-					Align: Center
-		Container@DEBUG_OPTIONS:
+		ScrollPanel@SETTINGS_SCROLLPANEL:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
+			CollapseHiddenChildren: True
+			TopBottomSpacing: 5
+			ItemSpacing: 10
 			Children:
-				Checkbox@BOTDEBUG_CHECKBOX:
-					X: 15
-					Y: 213
-					Width: 300
+				Background@SECTION_HEADER:
+					X: 5
+					Width: PARENT_RIGHT - 24 - 10
+					Height: 13
+					Background: separator
+					Children:
+						Label@LABEL:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Font: TinyBold
+							Align: Center
+							Text: Advanced
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
 					Height: 20
-					Font: Regular
-					Text: Show Bot Debug Messages
-				Checkbox@CHECKUNSYNCED_CHECKBOX:
-					X: 15
-					Y: 243
-					Width: 300
+					Children:
+						Container@NAT_DISCOVERY_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@NAT_DISCOVERY:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Enable UPnP/NAT-PMP Discovery
+						Container@FETCH_NEWS_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@FETCH_NEWS_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Fetch Community News
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
 					Height: 20
-					Font: Regular
-					Text: Check Sync around Unsynced Code
-				Checkbox@CHECKBOTSYNC_CHECKBOX:
-					X: 15
-					Y: 273
-					Width: 300
+					Children:
+						Container@PERFGRAPH_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@PERFGRAPH_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Show Performance Graph
+						Container@CHECK_VERSION_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@CHECK_VERSION_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Check for Updates
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@PERFTEXT_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@PERFTEXT_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Show Performance Text
+						Container@SENDSYSINFO_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@SENDSYSINFO_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Send System Information
+								Label@SENDSYSINFO_DESC:
+									Y: 15
+									Width: PARENT_RIGHT
+									Height: 30
+									Font: Tiny
+									WordWrap: True
+									Text: Your Operating System, OpenGL and .NET runtime versions, and language settings will be sent along with an anonymous ID to help prioritize future development.
+				Container@SPACER:
+				Background@SECTION_HEADER:
+					X: 5
+					Width: PARENT_RIGHT - 24 - 10
+					Height: 13
+					Background: separator
+					Children:
+						Label@LABEL:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Font: TinyBold
+							Align: Center
+							Text: Developer
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 40
+					Children:
+						Container@DEBUG_HIDDEN_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT - 10
+							Children:
+								Label@A:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Additional developer-specific options can be enabled via the
+									Align: Center
+								Label@B:
+									Y: 20
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Debug.DisplayDeveloperSettings setting or launch flag
+									Align: Center
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
 					Height: 20
-					Font: Regular
-					Text: Check Sync around BotModule Code
-				Checkbox@LUADEBUG_CHECKBOX:
-					X: 310
-					Y: 213
-					Width: 300
+					Children:
+						Container@BOTDEBUG_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@BOTDEBUG_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Show Bot Debug Messages
+						Container@CHECKBOTSYNC_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@CHECKBOTSYNC_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Check Sync around BotModule Code
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
 					Height: 20
-					Font: Regular
-					Text: Show Map Debug Messages
-				Checkbox@REPLAY_COMMANDS_CHECKBOX:
-					X: 310
-					Y: 243
-					Width: 300
+					Children:
+						Container@LUADEBUG_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@LUADEBUG_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Show Map Debug Messages
+						Container@CHECKUNSYNCED_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@CHECKUNSYNCED_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Check Sync around Unsynced Code
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
 					Height: 20
-					Font: Regular
-					Text: Enable Debug Commands in Replays
-				Checkbox@PERFLOGGING_CHECKBOX:
-					X: 310
-					Y: 273
-					Width: 300
-					Height: 20
-					Font: Regular
-					Text: Enable Tick Performance Logging
+					Children:
+						Container@REPLAY_COMMANDS_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@REPLAY_COMMANDS_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Enable Debug Commands in Replays
+						Container@PERFLOGGING_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@PERFLOGGING_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Enable Tick Performance Logging

--- a/mods/common/chrome/settings-audio.yaml
+++ b/mods/common/chrome/settings-audio.yaml
@@ -1,93 +1,142 @@
 Container@AUDIO_PANEL:
 	Logic: AudioSettingsLogic
-	Width: PARENT_RIGHT - 10
+	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM
 	Children:
-		Label@NO_AUDIO_DEVICE:
-			Y: 50
-			Width: PARENT_RIGHT
-			Align: Center
-			Text: Audio controls require an active sound device
-		Container@AUDIO_CONTROLS:
+		ScrollPanel@SETTINGS_SCROLLPANEL:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
+			CollapseHiddenChildren: True
+			TopBottomSpacing: 5
+			ItemSpacing: 10
 			Children:
-				Checkbox@CASH_TICKS:
-					X: 15
-					Y: 43
-					Width: 200
+				Background@SECTION_HEADER:
+					X: 5
+					Width: PARENT_RIGHT - 24 - 10
+					Height: 13
+					Background: separator
+					Children:
+						Label@LABEL:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Font: TinyBold
+							Align: Center
+							Text: Audio
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
 					Height: 20
-					Font: Regular
-					Text: Cash Ticks
-				Checkbox@MUTE_SOUND:
-					X: 15
-					Y: 73
-					Width: 200
+					Children:
+						Container@NO_AUDIO_DEVICE_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT - 10
+							Children:
+								Label@NO_AUDIO_DEVICE:
+									Width: PARENT_RIGHT
+									Height: 20
+									Align: Center
+									Text: Audio controls require an active sound device
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@CASH_TICKS_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@CASH_TICKS:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Cash Ticks
+						Container@MUTE_SOUND_CONTAINER:
+							X: 10
+							Y: 30
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@MUTE_SOUND:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Mute Sound
+						Container@SOUND_VOLUME_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@SOUND_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Sound Volume:
+								ExponentialSlider@SOUND_VOLUME:
+									Y: 30
+									Width: PARENT_RIGHT
+									Height: 20
+									Ticks: 7
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@MUTE_BACKGROUND_MUSIC_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@MUTE_BACKGROUND_MUSIC:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Mute Background Music
+						Container@MUSIC_VOLUME_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@MUSIC_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Music Volume:
+								ExponentialSlider@MUSIC_VOLUME:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 20
+									Ticks: 7
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@AUDIO_DEVICE_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@AUDIO_DEVICE_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Audio Device:
+								DropDownButton@AUDIO_DEVICE:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+						Container@VIDEO_VOLUME_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@VIDEO_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Video Volume:
+								ExponentialSlider@VIDEO_VOLUME:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 20
+									Ticks: 7
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
 					Height: 20
-					Font: Regular
-					Text: Mute Sound
-				Checkbox@MUTE_BACKGROUND_MUSIC:
-					X: 15
-					Y: 103
-					Width: 200
-					Height: 20
-					Font: Regular
-					Text: Mute Background Music
-				Label@SOUND_LABEL:
-					X: PARENT_RIGHT - WIDTH - 270
-					Y: 40
-					Width: 95
-					Height: 25
-					Align: Right
-					Text: Sound Volume:
-				ExponentialSlider@SOUND_VOLUME:
-					X: PARENT_RIGHT - WIDTH - 15
-					Y: 45
-					Width: 250
-					Height: 20
-					Ticks: 7
-				Label@MUSIC_LABEL:
-					X: PARENT_RIGHT - WIDTH - 270
-					Y: 70
-					Width: 95
-					Height: 25
-					Align: Right
-					Text: Music Volume:
-				ExponentialSlider@MUSIC_VOLUME:
-					X: PARENT_RIGHT - WIDTH - 15
-					Y: 75
-					Width: 250
-					Height: 20
-					Ticks: 7
-				Label@VIDEO_LABEL:
-					X: PARENT_RIGHT - WIDTH - 270
-					Y: 100
-					Width: 95
-					Height: 25
-					Align: Right
-					Text: Video Volume:
-				ExponentialSlider@VIDEO_VOLUME:
-					X: PARENT_RIGHT - WIDTH - 15
-					Y: 105
-					Width: 250
-					Height: 20
-					Ticks: 7
-		Label@AUDIO_DEVICE_LABEL:
-			X: 190 - WIDTH - 5
-			Y: 240
-			Width: 75
-			Height: 25
-			Align: Right
-			Text: Audio Device:
-		DropDownButton@AUDIO_DEVICE:
-			X: 190
-			Y: 240
-			Width: 300
-			Height: 25
-		Label@AUDIO_DEVICE_DESC:
-			Y: 261
-			Width: PARENT_RIGHT
-			Height: 25
-			Font: Tiny
-			Align: Center
-			Text: Device changes will be applied after the game is restarted
+					Children:
+						Container@RESTART_REQUIRED_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT - 10
+							Children:
+								Label@RESTART_REQUIRED_DESC:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Tiny
+									Align: Center
+									Text: Device changes will be applied after the game is restarted

--- a/mods/common/chrome/settings-display.yaml
+++ b/mods/common/chrome/settings-display.yaml
@@ -1,224 +1,317 @@
 Container@DISPLAY_PANEL:
 	Logic: DisplaySettingsLogic
-	Width: PARENT_RIGHT - 10
-	Height: PARENT_BOTTOM - 50
+	Width: PARENT_RIGHT
+	Height: PARENT_BOTTOM
 	Children:
-		Label@PLAYER:
-			Text: Player Name:
-			X: 15
-			Y: 40
-			Width: 120
-			Height: 25
-			Align: Right
-		TextField@PLAYERNAME:
-			Text: Name
-			X: 140
-			Y: 40
-			Width: 160
-			Height: 25
-			MaxLength: 16
-		Label@COLOR:
-			X: 265
-			Y: 40
-			Width: 145
-			Height: 25
-			Text: Preferred Color:
-			Align: Right
-		DropDownButton@PLAYERCOLOR:
-			X: 415
-			Y: 40
-			Width: 75
-			Height: 25
-			IgnoreChildMouseOver: true
-			PanelAlign: Right
+		ScrollPanel@SETTINGS_SCROLLPANEL:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			CollapseHiddenChildren: True
+			TopBottomSpacing: 5
+			ItemSpacing: 10
 			Children:
-				ColorBlock@COLORBLOCK:
+				Background@SECTION_HEADER:
 					X: 5
-					Y: 6
-					Width: PARENT_RIGHT - 35
-					Height: PARENT_BOTTOM - 12
-		Label@BATTLEFIELD_CAMERA:
-			X: 15
-			Y: 70
-			Width: 120
-			Height: 25
-			Text: Battlefield Camera:
-			Align: Right
-		DropDownButton@BATTLEFIELD_CAMERA_DROPDOWN:
-			X: 140
-			Y: 70
-			Width: 160
-			Height: 25
-			Font: Regular
-		Label@TARGET_LINES:
-			X: 265
-			Y: 70
-			Width: 145
-			Height: 25
-			Text: Target Lines:
-			Align: Right
-		DropDownButton@TARGET_LINES_DROPDOWN:
-			X: 415
-			Y: 70
-			Width: 160
-			Height: 25
-			Font: Regular
-		Label@UI_SCALE:
-			X: 15
-			Y: 100
-			Width: 120
-			Height: 25
-			Text: UI Scale:
-			Align: Right
-		DropDownButton@UI_SCALE_DROPDOWN:
-			X: 140
-			Y: 100
-			Width: 160
-			Height: 25
-			Font: Regular
-		Label@STATUS_BARS:
-			X: 265
-			Y: 100
-			Width: 145
-			Height: 25
-			Text: Status Bars:
-			Align: Right
-		DropDownButton@STATUS_BAR_DROPDOWN:
-			X: 415
-			Y: 100
-			Width: 160
-			Height: 25
-			Font: Regular
-		Checkbox@CURSORDOUBLE_CHECKBOX:
-			X: 15
-			Y: 133
-			Width: 200
-			Height: 20
-			Font: Regular
-			Text: Increase Cursor Size
-		Checkbox@PLAYER_STANCE_COLORS_CHECKBOX:
-			X: 195
-			Y: 133
-			Width: 200
-			Height: 20
-			Font: Regular
-			Text: Player Stance Colors
-		Checkbox@PAUSE_SHELLMAP_CHECKBOX:
-			X: 375
-			Y: 133
-			Width: 200
-			Height: 20
-			Font: Regular
-			Text: Pause Menu Background
-		Checkbox@UI_FEEDBACK_CHECKBOX:
-			X: 15
-			Y: 163
-			Width: 200
-			Height: 20
-			Font: Regular
-			Text: UI Feedback in Transients Panel
-		Label@VIDEO_TITLE:
-			Y: 190
-			Width: PARENT_RIGHT
-			Font: Bold
-			Text: Video
-			Align: Center
-		Label@VIDEO_MODE:
-			X: 15
-			Y: 210
-			Width: 120
-			Height: 25
-			Align: Right
-			Text: Video Mode:
-		DropDownButton@MODE_DROPDOWN:
-			X: 140
-			Y: 210
-			Width: 160
-			Height: 25
-			Font: Regular
-			Text: Windowed
-		Checkbox@VSYNC_CHECKBOX:
-			X: 310
-			Y: 213
-			Width: 200
-			Height: 20
-			Font: Regular
-			Text: Enable VSync
-		Container@WINDOW_RESOLUTION:
-			Y: 240
-			Children:
-				Label@WINDOW_SIZE:
-					X: 15
-					Height: 25
-					Width: 120
-					Align: Right
-					Text: Window Size:
-				TextField@WINDOW_WIDTH:
-					X: 140
-					Width: 55
-					Height: 25
-					MaxLength: 5
-					Type: Integer
-				Label@X:
-					Text: x
-					Font: Bold
-					X: 195
-					Height: 25
-					Width: 15
-					Align: Center
-				TextField@WINDOW_HEIGHT:
-					X: 210
-					Width: 55
-					Height: 25
-					MaxLength: 5
-					Type: Integer
-		Container@DISPLAY_SELECTION:
-			Y: 240
-			Children:
-				Label@DISPLAY_SELECTION_LABEL:
-					X: 15
-					Height: 25
-					Width: 120
-					Align: Right
-					Text: Select Display:
-				DropDownButton@DISPLAY_SELECTION_DROPDOWN:
-					X: 140
-					Width: 160
-					Height: 25
-					Font: Regular
-					Text: Standard
-		Checkbox@FRAME_LIMIT_CHECKBOX:
-			X: 310
-			Y: 243
-			Width: 200
-			Height: 20
-			Font: Regular
-			Text: Enable Frame Limiter
-		Slider@FRAME_LIMIT_SLIDER:
-			X: 340
-			Y: 265
-			Width: 200
-			Height: 20
-			Ticks: 20
-			MinimumValue: 50
-			MaximumValue: 240
-		Label@GL_PROFILE:
-			X: 15
-			Y: 270
-			Width: 120
-			Height: 25
-			Align: Right
-			Text: OpenGL Profile:
-		DropDownButton@GL_PROFILE_DROPDOWN:
-			X: 140
-			Y: 270
-			Width: 160
-			Height: 25
-			Font: Regular
-		Label@RESTART_REQUIRED_DESC:
-			Y: PARENT_BOTTOM - 40
-			Width: PARENT_RIGHT
-			Height: 15
-			Font: Tiny
-			Text: Display and OpenGL changes require restart
-			Align: Center
+					Width: PARENT_RIGHT - 24 - 10
+					Height: 13
+					Background: separator
+					Children:
+						Label@LABEL:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Font: TinyBold
+							Align: Center
+							Text: Profile
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@PLAYER_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@PLAYER:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Player Name:
+								TextField@PLAYERNAME:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									MaxLength: 16
+									Text: Name
+						Container@PLAYERCOLOR_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@COLOR:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Preferred Color:
+								DropDownButton@PLAYERCOLOR:
+									Y: 25
+									Width: 75
+									Height: 25
+									IgnoreChildMouseOver: true
+									PanelAlign: Right
+									Children:
+										ColorBlock@COLORBLOCK:
+											X: 5
+											Y: 6
+											Width: PARENT_RIGHT - 35
+											Height: PARENT_BOTTOM - 12
+				Container@SPACER:
+				Background@SECTION_HEADER:
+					X: 5
+					Width: PARENT_RIGHT - 24 - 10
+					Height: 13
+					Background: separator
+					Children:
+						Label@LABEL:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Font: TinyBold
+							Align: Center
+							Text: Display
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@BATTLEFIELD_CAMERA_DROPDOWN_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@BATTLEFIELD_CAMERA:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Battlefield Camera:
+								DropDownButton@BATTLEFIELD_CAMERA_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+						Container@TARGET_LINES_DROPDOWN_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@TARGET_LINES:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Target Lines:
+								DropDownButton@TARGET_LINES_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@UI_SCALE_DROPDOWN_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@UI_SCALE:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: UI Scale:
+								DropDownButton@UI_SCALE_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+						Container@STATUS_BAR_DROPDOWN_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@STATUS_BARS:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Status Bars:
+								DropDownButton@STATUS_BAR_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 20
+					Children:
+						Container@CURSORDOUBLE_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@CURSORDOUBLE_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Increase Cursor Size
+						Container@PLAYER_STANCE_COLORS_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@PLAYER_STANCE_COLORS_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Player Stance Colors
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 20
+					Children:
+						Container@PAUSE_SHELLMAP_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 10
+							Children:
+								Checkbox@PAUSE_SHELLMAP_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Pause Menu Background
+						Container@UI_FEEDBACK_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@UI_FEEDBACK_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: UI Feedback in Transients Panel
+				Container@SPACER:
+				Background@SECTION_HEADER:
+					X: 5
+					Width: PARENT_RIGHT - 24 - 10
+					Height: 13
+					Background: separator
+					Children:
+						Label@LABEL:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Font: TinyBold
+							Align: Center
+							Text: Video
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@VIDEO_MODE_DROPDOWN_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@VIDEO_MODE:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Video Mode:
+								DropDownButton@MODE_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+									Text: Windowed
+						Container@WINDOW_RESOLUTION_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@WINDOW_SIZE:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Window Size:
+								TextField@WINDOW_WIDTH:
+									Y: 25
+									Width: 55
+									Height: 25
+									MaxLength: 5
+									Type: Integer
+								Label@X:
+									X: 55
+									Y: 25
+									Text: x
+									Font: Bold
+									Height: 25
+									Width: 15
+									Align: Center
+								TextField@WINDOW_HEIGHT:
+									X: 70
+									Y: 25
+									Width: 55
+									Height: 25
+									MaxLength: 5
+									Type: Integer
+						Container@DISPLAY_SELECTION_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@DISPLAY_SELECTION_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Select Display:
+								DropDownButton@DISPLAY_SELECTION_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+									Text: Standard
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@FRAME_LIMIT_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@FRAME_LIMIT_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Enable Frame Limiter
+						Container@FRAME_LIMIT_SLIDER_CONTAINER:
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Slider@FRAME_LIMIT_SLIDER:
+									X: 20
+									Y: 25
+									Width: PARENT_RIGHT - 20
+									Height: 20
+									Ticks: 20
+									MinimumValue: 50
+									MaximumValue: 240
+						Container@VSYNC_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@VSYNC_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Enable VSync
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@GL_PROFILE_DROPDOWN_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@GL_PROFILE:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: OpenGL Profile:
+								DropDownButton@GL_PROFILE_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 30
+					Children:
+						Container@RESTART_REQUIRED_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT - 20
+							Children:
+								Label@RESTART_REQUIRED_DESC:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Tiny
+									Text: Display and OpenGL changes require restart
+									Align: Center

--- a/mods/common/chrome/settings-hotkeys.yaml
+++ b/mods/common/chrome/settings-hotkeys.yaml
@@ -2,140 +2,98 @@ Container@HOTKEYS_PANEL:
 	Logic: HotkeysSettingsLogic
 		HotkeyGroups:
 			Game Commands:
-				Template: TWO_COLUMN
 				Types: OrderGenerator, World, Menu
 			Viewport Commands:
-				Template: TWO_COLUMN
 				Types: Viewport
 			Observer / Replay Commands:
-				Template: TWO_COLUMN
 				Types: Observer, Replay
 			Unit Commands:
-				Template: THREE_COLUMN
 				Types: Unit
 			Unit Stance Commands:
-				Template: TWO_COLUMN
 				Types: Stance
 			Production Commands:
-				Template: THREE_COLUMN
 				Types: Production, ProductionSlot
 			Support Power Commands:
-				Template: THREE_COLUMN
 				Types: SupportPower
 			Music Commands:
-				Template: TWO_COLUMN
 				Types: Music
 			Chat Commands:
-				Template: TWO_COLUMN
 				Types: Chat
-	Width: PARENT_RIGHT - 10
+	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM
 	Children:
 		ScrollPanel@HOTKEY_LIST:
-			X: 15
-			Y: 40
-			Width: PARENT_RIGHT - 30
-			TopBottomSpacing: 4
-			ItemSpacing: 4
-			Height: 190
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM - 65
+			TopBottomSpacing: 5
+			ItemSpacing: 5
 			Children:
-				ScrollItem@HEADER:
-					BaseName: scrollheader
-					Width: 528
-					Height: 13
+				Container@HEADER:
+					Width: PARENT_RIGHT - 24 - 10
+					Height: 18
+					Children:
+						Background@BACKGROUND:
+							Width: PARENT_RIGHT
+							Height: 13
+							Background: separator
+						Label@LABEL:
+							Width: PARENT_RIGHT
+							Height: 13
+							Font: TinyBold
+							Align: Center
+				Container@TEMPLATE:
+					Width: (PARENT_RIGHT - 24) / 2 - 10
+					Height: 30
 					Visible: false
 					Children:
-						Label@LABEL:
-							Font: TinyBold
-							Width: PARENT_RIGHT
-							Height: 10
-							Align: Center
-						ScrollItem@HEADER:
-							Width: 528
-							Height: 13
-							Visible: false
-							Children:
-								Label@LABEL:
-									Font: TinyBold
-									Width: PARENT_RIGHT
-									Height: 10
-									Align: Center
-						Container@TEMPLATES:
-							Children:
-								Container@TWO_COLUMN:
-									Width: 262
-									Height: 25
-									Visible: false
-									Children:
-										Label@FUNCTION:
-											Y: 0 - 1
-											Width: PARENT_RIGHT - 85
-											Height: 25
-											Align: Right
-										Button@HOTKEY:
-											X: PARENT_RIGHT - WIDTH
-											Width: 80
-											Height: 25
-											Align: Left
-											TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
-								Container@THREE_COLUMN:
-									Width: 173
-									Height: 25
-									Visible: false
-									Children:
-										Label@FUNCTION:
-											Y: 0 - 1
-											Width: PARENT_RIGHT - 84
-											Height: 25
-											Align: Right
-										Button@HOTKEY:
-											X: PARENT_RIGHT - WIDTH + 1
-											Width: 80
-											Height: 25
-											Align: Left
-											TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
+						Label@FUNCTION:
+							Y: 0 - 1
+							Width: PARENT_RIGHT - 120 - 5
+							Height: 25
+							Align: Right
+						Button@HOTKEY:
+							X: PARENT_RIGHT - WIDTH
+							Width: 120
+							Height: 25
+							TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 		Background@HOTKEY_DIALOG_ROOT:
-			X: 15
-			Y: 230
-			Width: PARENT_RIGHT - 30
+			Y: PARENT_BOTTOM - HEIGHT
+			Width: PARENT_RIGHT
 			Height: 65
 			Background: dialog3
 			Children:
 				Label@HOTKEY_LABEL:
 					X: 15
 					Y: 19
-					Width: 219 - 15 - 10
+					Width: 200
 					Height: 25
 					Font: Bold
 					Align: Right
 				HotkeyEntry@HOTKEY_ENTRY:
-					X: 219
+					X: 15 + 200 + 5
 					Y: 20
-					Width: 170
+					Width: 300
 					Height: 25
 				Container@NOTICES:
-					X: 219
+					X: 15 + 200 + 5
 					Y: 42
-					Width: 170
+					Width: 300
 					Height: 25
 					Children:
 						Label@DEFAULT_NOTICE:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							Font: Tiny
-							Align: Left
 							Text: This is the default
 						Label@ORIGINAL_NOTICE:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							Font: Tiny
-							Align: Left
 							Text: The default is "{0}"
 						Label@DUPLICATE_NOTICE:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							Font: Tiny
-							Align: Left
 							Text: This is already used for "{0}"
 				Button@OVERRIDE_HOTKEY_BUTTON:
 					X: PARENT_RIGHT - 3 * WIDTH - 30

--- a/mods/common/chrome/settings-hotkeys.yaml
+++ b/mods/common/chrome/settings-hotkeys.yaml
@@ -80,11 +80,6 @@ Container@HOTKEYS_PANEL:
 					Width: 300
 					Height: 25
 					Children:
-						Label@DEFAULT_NOTICE:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
-							Font: Tiny
-							Text: This is the default
 						Label@ORIGINAL_NOTICE:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM

--- a/mods/common/chrome/settings-input.yaml
+++ b/mods/common/chrome/settings-input.yaml
@@ -1,213 +1,268 @@
 Container@INPUT_PANEL:
 	Logic: InputSettingsLogic
-	Width: PARENT_RIGHT - 10
+	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM
 	Children:
-		Label@MOUSE_CONTROL_LABEL:
-			X: 15
-			Y: 40
-			Width: 110
-			Height: 25
-			Font: Regular
-			Text: Control Scheme:
-			Align: Right
-		DropDownButton@MOUSE_CONTROL_DROPDOWN:
-			X: 130
-			Y: 40
-			Width: 150
-			Height: 25
-			Font: Regular
-		Container@MOUSE_CONTROL_DESC_CLASSIC:
-			X: 25
-			Y: 70
-			Width: 300
+		ScrollPanel@SETTINGS_SCROLLPANEL:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			CollapseHiddenChildren: True
+			TopBottomSpacing: 5
+			ItemSpacing: 10
 			Children:
-				LabelWithHighlight@DESC_SELECTION:
-					Height: 16
-					Font: Small
-					Text: - Select units using the {Left} mouse button
-				LabelWithHighlight@DESC_COMMANDS:
-					Y: 17
-					Height: 16
-					Font: Small
-					Text: - Command units using the {Left} mouse button
-				LabelWithHighlight@DESC_BUILDIGS:
-					Y: 34
-					Height: 16
-					Font: Small
-					Text: - Place structures using the {Left} mouse button
-				LabelWithHighlight@DESC_SUPPORT:
-					Y: 51
-					Height: 16
-					Font: Small
-					Text: - Target support powers using the {Left} mouse button
-				LabelWithHighlight@DESC_ZOOM:
-					Y: 68
-					Height: 16
-					Font: Small
-					Text: - Zoom the battlefield using the {Scroll Wheel}
-				LabelWithHighlight@DESC_ZOOM_MODIFIER:
-					Y: 68
-					Height: 16
-					Font: Small
-					Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
-				LabelWithHighlight@DESC_SCROLL_RIGHT:
-					Y: 85
-					Height: 16
-					Font: Small
-					Text: - Pan the battlefield using the {Right} mouse button
-				LabelWithHighlight@DESC_SCROLL_MIDDLE:
-					Y: 85
-					Height: 16
-					Font: Small
-					Text: - Pan the battlefield using the {Middle} mouse button
-				Label@DESC_EDGESCROLL:
-					X: 9
-					Y: 102
-					Height: 16
-					Font: Small
-					Text: or by moving the cursor to the edge of the screen
-		Container@MOUSE_CONTROL_DESC_MODERN:
-			X: 25
-			Y: 70
-			Width: 300
-			Children:
-				LabelWithHighlight@DESC_SELECTION:
-					Height: 16
-					Font: Small
-					Text: - Select units using the {Left} mouse button
-				LabelWithHighlight@DESC_COMMANDS:
-					Y: 17
-					Height: 16
-					Font: Small
-					Text: - Command units using the {Right} mouse button
-				LabelWithHighlight@DESC_BUILDIGS:
-					Y: 34
-					Height: 16
-					Font: Small
-					Text: - Place structures using the {Left} mouse button
-				LabelWithHighlight@DESC_SUPPORT:
-					Y: 51
-					Height: 16
-					Font: Small
-					Text: - Target support powers using the {Left} mouse button
-				LabelWithHighlight@DESC_ZOOM:
-					Y: 68
-					Height: 16
-					Font: Small
-					Text: - Zoom the battlefield using the {Scroll Wheel}
-				LabelWithHighlight@DESC_ZOOM_MODIFIER:
-					Y: 68
-					Height: 16
-					Font: Small
-					Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
-				LabelWithHighlight@DESC_SCROLL_RIGHT:
-					Y: 85
-					Height: 16
-					Font: Small
-					Text: - Pan the battlefield using the {Right} mouse button
-				LabelWithHighlight@DESC_SCROLL_MIDDLE:
-					Y: 85
-					Height: 16
-					Font: Small
-					Text: - Pan the battlefield using the {Middle} mouse button
-				Label@DESC_EDGESCROLL:
-					X: 9
-					Y: 102
-					Height: 16
-					Font: Small
-					Text: or by moving the cursor to the edge of the screen
-		Label@MOUSE_SCROLL_TYPE_LABEL:
-			X: 15
-			Y: 210
-			Width: 110
-			Height: 25
-			Font: Regular
-			Text: Pan Behaviour:
-			Align: Right
-		DropDownButton@MOUSE_SCROLL_TYPE_DROPDOWN:
-			X: 130
-			Y: 210
-			Width: 150
-			Height: 25
-			Font: Regular
-		Checkbox@LOCKMOUSE_CHECKBOX:
-			X: 15
-			Y: 243
-			Width: 190
-			Height: 20
-			Font: Regular
-			Text: Lock Mouse to Window
-		Label@ZOOM_MODIFIER_LABEL:
-			X: 350
-			Y: 70
-			Width: 70
-			Height: 25
-			Font: Regular
-			Text: Zoom Modifier:
-			Align: Right
-		DropDownButton@ZOOM_MODIFIER:
-			X: 425
-			Y: 70
-			Width: 150
-			Height: 25
-			Font: Regular
-		Checkbox@EDGESCROLL_CHECKBOX:
-			X: 360
-			Y: 103
-			Width: 180
-			Height: 20
-			Font: Regular
-			Text: Screen Edge Panning
-		Checkbox@ALTERNATE_SCROLL_CHECKBOX:
-			X: 360
-			Y: 133
-			Width: 180
-			Height: 20
-			Font: Regular
-			Text: Alternate Mouse Panning
-		Label@SCROLL_SPEED_LABEL:
-			X: 305
-			Y: 210
-			Width: 100
-			Height: 25
-			Text: Pan Speed:
-			Align: Right
-		Slider@SCROLLSPEED_SLIDER:
-			X: 410
-			Y: 215
-			Width: 165
-			Height: 20
-			Ticks: 5
-			MinimumValue: 10
-			MaximumValue: 50
-		Label@ZOOM_SPEED_LABEL:
-			X: 305
-			Y: 240
-			Width: 100
-			Height: 25
-			Text: Zoom Speed:
-			Align: Right
-		ExponentialSlider@ZOOMSPEED_SLIDER:
-			X: 410
-			Y: 245
-			Width: 165
-			Height: 20
-			Ticks: 5
-			MinimumValue: 0.01
-			MaximumValue: 0.4
-		Label@UI_SCROLL_SPEED_LABEL:
-			X: 305
-			Y: 270
-			Width: 100
-			Height: 25
-			Text: UI Scroll Speed:
-			Align: Right
-		Slider@UI_SCROLLSPEED_SLIDER:
-			X: 410
-			Y: 275
-			Width: 165
-			Height: 20
-			Ticks: 5
-			MinimumValue: 1
-			MaximumValue: 100
+				Background@SECTION_HEADER:
+					X: 5
+					Width: PARENT_RIGHT - 24 - 10
+					Height: 13
+					Background: separator
+					Children:
+						Label@LABEL:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Font: TinyBold
+							Align: Center
+							Text: Input
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@MOUSE_CONTROL_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@MOUSE_CONTROL_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Control Scheme:
+								DropDownButton@MOUSE_CONTROL_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+						Container@ZOOM_MODIFIER_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@ZOOM_MODIFIER_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Zoom Modifier:
+								DropDownButton@ZOOM_MODIFIER:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+						Container@MOUSE_CONTROL_DESC_CLASSIC:
+							X: 10
+							Y: 55
+							Width: PARENT_RIGHT
+							Children:
+								LabelWithHighlight@DESC_SELECTION:
+									Height: 16
+									Font: Small
+									Text: - Select units using the {Left} mouse button
+								LabelWithHighlight@DESC_COMMANDS:
+									Y: 17
+									Height: 16
+									Font: Small
+									Text: - Command units using the {Left} mouse button
+								LabelWithHighlight@DESC_BUILDIGS:
+									Y: 34
+									Height: 16
+									Font: Small
+									Text: - Place structures using the {Left} mouse button
+								LabelWithHighlight@DESC_SUPPORT:
+									Y: 51
+									Height: 16
+									Font: Small
+									Text: - Target support powers using the {Left} mouse button
+								LabelWithHighlight@DESC_ZOOM:
+									Y: 68
+									Height: 16
+									Font: Small
+									Text: - Zoom the battlefield using the {Scroll Wheel}
+								LabelWithHighlight@DESC_ZOOM_MODIFIER:
+									Y: 68
+									Height: 16
+									Font: Small
+									Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
+								LabelWithHighlight@DESC_SCROLL_RIGHT:
+									Y: 85
+									Height: 16
+									Font: Small
+									Text: - Pan the battlefield using the {Right} mouse button
+								LabelWithHighlight@DESC_SCROLL_MIDDLE:
+									Y: 85
+									Height: 16
+									Font: Small
+									Text: - Pan the battlefield using the {Middle} mouse button
+								Label@DESC_EDGESCROLL:
+									X: 9
+									Y: 102
+									Height: 16
+									Font: Small
+									Text: or by moving the cursor to the edge of the screen
+						Container@MOUSE_CONTROL_DESC_MODERN:
+							X: 10
+							Y: 55
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								LabelWithHighlight@DESC_SELECTION:
+									Height: 16
+									Font: Small
+									Text: - Select units using the {Left} mouse button
+								LabelWithHighlight@DESC_COMMANDS:
+									Y: 17
+									Height: 16
+									Font: Small
+									Text: - Command units using the {Right} mouse button
+								LabelWithHighlight@DESC_BUILDIGS:
+									Y: 34
+									Height: 16
+									Font: Small
+									Text: - Place structures using the {Left} mouse button
+								LabelWithHighlight@DESC_SUPPORT:
+									Y: 51
+									Height: 16
+									Font: Small
+									Text: - Target support powers using the {Left} mouse button
+								LabelWithHighlight@DESC_ZOOM:
+									Y: 68
+									Height: 16
+									Font: Small
+									Text: - Zoom the battlefield using the {Scroll Wheel}
+								LabelWithHighlight@DESC_ZOOM_MODIFIER:
+									Y: 68
+									Height: 16
+									Font: Small
+									Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
+								LabelWithHighlight@DESC_SCROLL_RIGHT:
+									Y: 85
+									Height: 16
+									Font: Small
+									Text: - Pan the battlefield using the {Right} mouse button
+								LabelWithHighlight@DESC_SCROLL_MIDDLE:
+									Y: 85
+									Height: 16
+									Font: Small
+									Text: - Pan the battlefield using the {Middle} mouse button
+								Label@DESC_EDGESCROLL:
+									X: 9
+									Y: 102
+									Height: 16
+									Font: Small
+									Text: or by moving the cursor to the edge of the screen
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 20
+					Children:
+						Container@EDGESCROLL_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@EDGESCROLL_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Screen Edge Panning
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 20
+					Children:
+						Container@ALTERNATE_SCROLL_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@ALTERNATE_SCROLL_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Alternate Mouse Panning
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 20
+					Children:
+						Container@LOCKMOUSE_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@LOCKMOUSE_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Lock Mouse to Window
+				Container@SPACER:
+					Height: 30
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@MOUSE_SCROLL_TYPE_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@MOUSE_SCROLL_TYPE_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Pan Behaviour:
+								DropDownButton@MOUSE_SCROLL_TYPE_DROPDOWN:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Regular
+						Container@SCROLLSPEED_SLIDER_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@SCROLL_SPEED_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Pan Speed:
+								Slider@SCROLLSPEED_SLIDER:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 20
+									Ticks: 7
+									MinimumValue: 10
+									MaximumValue: 50
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@ZOOMSPEED_SLIDER_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@ZOOM_SPEED_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: Zoom Speed:
+								ExponentialSlider@ZOOMSPEED_SLIDER:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 20
+									Ticks: 7
+									MinimumValue: 0.01
+									MaximumValue: 0.4
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 50
+					Children:
+						Container@UI_SCROLLSPEED_SLIDER_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Label@UI_SCROLL_SPEED_LABEL:
+									Width: PARENT_RIGHT
+									Height: 20
+									Text: UI Scroll Speed:
+								Slider@UI_SCROLLSPEED_SLIDER:
+									Y: 25
+									Width: PARENT_RIGHT
+									Height: 20
+									Ticks: 7
+									MinimumValue: 1
+									MaximumValue: 100

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -1,6 +1,6 @@
 Background@SETTINGS_PANEL:
 	Logic: SettingsLogic
-		ButtonStride: 90, 0
+		ButtonStride: 0, 35
 		Panels:
 			DISPLAY_PANEL: Display
 			AUDIO_PANEL: Audio
@@ -9,8 +9,8 @@ Background@SETTINGS_PANEL:
 			ADVANCED_PANEL: Advanced
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM -  HEIGHT) / 2
-	Width: 600
-	Height: 400
+	Width: 900
+	Height: 600
 	Children:
 		Label@SETTINGS_LABEL_TITLE:
 			Y: 20
@@ -20,7 +20,7 @@ Background@SETTINGS_PANEL:
 			Align: Center
 			Font: Bold
 		Button@RESET_BUTTON:
-			X: 20
+			X: 20 + 10 + WIDTH
 			Y: PARENT_BOTTOM - 45
 			Width: 160
 			Height: 25
@@ -34,14 +34,14 @@ Background@SETTINGS_PANEL:
 			Height: 25
 			Text: Back
 			Font: Bold
-		Container@TAB_CONTAINER:
-			X: 70
+		Container@SETTINGS_TAB_CONTAINER:
+			X: 20
 			Y: 50
 			Width: PARENT_RIGHT
 			Height: 25
 			Children:
 				Button@BUTTON_TEMPLATE:
-					Width: 90
+					Width: 160
 					Height: 25
 					Font: Bold
 		Container@PANEL_CONTAINER:
@@ -49,8 +49,8 @@ Background@SETTINGS_PANEL:
 			Height: PARENT_BOTTOM
 			Children:
 				Container@PANEL_TEMPLATE:
-					X: 5
+					X: 190
 					Y: 50
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_RIGHT - 190 - 20
+					Height: PARENT_BOTTOM - 105
 		TooltipContainer@SETTINGS_TOOLTIP_CONTAINER:

--- a/mods/d2k/chrome.yaml
+++ b/mods/d2k/chrome.yaml
@@ -368,7 +368,7 @@ slider-thumb-pressed:
 	Inherits: button-pressed
 
 slider-thumb-disabled:
-	Inherits: button
+	Inherits: button-disabled
 
 checkbox:
 	Inherits: button-pressed

--- a/mods/d2k/chrome.yaml
+++ b/mods/d2k/chrome.yaml
@@ -430,6 +430,9 @@ dropdown-separators:
 		separator-pressed: 641, 2, 1, 19
 		separator-disabled: 513, 258, 1, 19
 
+separator:
+	Inherits: button
+
 logos:
 	Inherits: ^LoadScreen
 	Regions:

--- a/mods/ra/chrome.yaml
+++ b/mods/ra/chrome.yaml
@@ -497,7 +497,7 @@ slider-thumb-pressed:
 	Inherits: button-pressed
 
 slider-thumb-disabled:
-	Inherits: button
+	Inherits: button-disabled
 
 checkbox:
 	Inherits: button-pressed

--- a/mods/ra/chrome.yaml
+++ b/mods/ra/chrome.yaml
@@ -580,3 +580,6 @@ dropdown-separators:
 		separator-pressed: 766, 2, 1, 19
 		separator-disabled: 513, 258, 1, 19
 		observer-separator: 769, 258, 1, 19
+
+separator:
+	Inherits: button

--- a/mods/ts/chrome.yaml
+++ b/mods/ts/chrome.yaml
@@ -702,6 +702,9 @@ dropdown-separators:
 		separator-pressed: 766, 2, 1, 19
 		separator-disabled: 513, 258, 1, 19
 
+separator:
+	Inherits: button
+
 logos:
 	Inherits: ^LoadScreen
 	Regions:

--- a/mods/ts/chrome.yaml
+++ b/mods/ts/chrome.yaml
@@ -630,7 +630,7 @@ slider-thumb-pressed:
 	Inherits: button-pressed
 
 slider-thumb-disabled:
-	Inherits: button
+	Inherits: button-disabled
 
 checkbox:
 	Inherits: button-pressed

--- a/mods/ts/chrome/settings-hotkeys.yaml
+++ b/mods/ts/chrome/settings-hotkeys.yaml
@@ -2,143 +2,100 @@ Container@HOTKEYS_PANEL:
 	Logic: HotkeysSettingsLogic
 		HotkeyGroups:
 			Game Commands:
-				Template: TWO_COLUMN
 				Types: OrderGenerator, World, Menu
 			Viewport Commands:
-				Template: TWO_COLUMN
 				Types: Viewport
 			Observer / Replay Commands:
-				Template: TWO_COLUMN
 				Types: Observer, Replay
 			Unit Commands:
-				Template: THREE_COLUMN
 				Types: Unit
 			Unit Stance Commands:
-				Template: TWO_COLUMN
 				Types: Stance
 			Production Commands:
-				Template: THREE_COLUMN
 				Types: Production, ProductionSlot
 			Support Power Commands:
-				Template: THREE_COLUMN
 				Types: SupportPower
 			Music Commands:
-				Template: TWO_COLUMN
 				Types: Music
 			Chat Commands:
-				Template: TWO_COLUMN
 				Types: Chat
 			Depth Preview Debug:
-				Template: TWO_COLUMN
 				Types: DepthDebug
-	Width: PARENT_RIGHT - 10
+	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM
 	Children:
 		ScrollPanel@HOTKEY_LIST:
-			X: 15
-			Y: 40
-			Width: PARENT_RIGHT - 30
-			TopBottomSpacing: 4
-			ItemSpacing: 4
-			Height: 190
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM - 65
+			TopBottomSpacing: 5
+			ItemSpacing: 5
 			Children:
-				ScrollItem@HEADER:
-					BaseName: scrollheader
-					Width: 528
-					Height: 13
+				Container@HEADER:
+					Width: PARENT_RIGHT - 24 - 10
+					Height: 18
+					Children:
+						Background@BACKGROUND:
+							Width: PARENT_RIGHT
+							Height: 13
+							Background: separator
+						Label@LABEL:
+							Width: PARENT_RIGHT
+							Height: 13
+							Font: TinyBold
+							Align: Center
+				Container@TEMPLATE:
+					Width: (PARENT_RIGHT - 24) / 2 - 10
+					Height: 30
 					Visible: false
 					Children:
-						Label@LABEL:
-							Font: TinyBold
-							Width: PARENT_RIGHT
-							Height: 10
-							Align: Center
-						ScrollItem@HEADER:
-							Width: 528
-							Height: 13
-							Visible: false
-							Children:
-								Label@LABEL:
-									Font: TinyBold
-									Width: PARENT_RIGHT
-									Height: 10
-									Align: Center
-						Container@TEMPLATES:
-							Children:
-								Container@TWO_COLUMN:
-									Width: 262
-									Height: 25
-									Visible: false
-									Children:
-										Label@FUNCTION:
-											Y: 0 - 1
-											Width: PARENT_RIGHT - 85
-											Height: 25
-											Align: Right
-										Button@HOTKEY:
-											X: PARENT_RIGHT - WIDTH
-											Width: 80
-											Height: 25
-											Align: Left
-											TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
-								Container@THREE_COLUMN:
-									Width: 173
-									Height: 25
-									Visible: false
-									Children:
-										Label@FUNCTION:
-											Y: 0 - 1
-											Width: PARENT_RIGHT - 84
-											Height: 25
-											Align: Right
-										Button@HOTKEY:
-											X: PARENT_RIGHT - WIDTH + 1
-											Width: 80
-											Height: 25
-											Align: Left
-											TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
+						Label@FUNCTION:
+							Y: 0 - 1
+							Width: PARENT_RIGHT - 120 - 5
+							Height: 25
+							Align: Right
+						Button@HOTKEY:
+							X: PARENT_RIGHT - WIDTH
+							Width: 120
+							Height: 25
+							TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 		Background@HOTKEY_DIALOG_ROOT:
-			X: 15
-			Y: 230
-			Width: PARENT_RIGHT - 30
+			Y: PARENT_BOTTOM - HEIGHT
+			Width: PARENT_RIGHT
 			Height: 65
 			Background: dialog3
 			Children:
 				Label@HOTKEY_LABEL:
 					X: 15
 					Y: 19
-					Width: 219 - 15 - 10
+					Width: 200
 					Height: 25
 					Font: Bold
 					Align: Right
 				HotkeyEntry@HOTKEY_ENTRY:
-					X: 219
+					X: 15 + 200 + 5
 					Y: 20
-					Width: 170
+					Width: 300
 					Height: 25
 				Container@NOTICES:
-					X: 219
+					X: 15 + 200 + 5
 					Y: 42
-					Width: 170
+					Width: 300
 					Height: 25
 					Children:
 						Label@DEFAULT_NOTICE:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							Font: Tiny
-							Align: Left
 							Text: This is the default
 						Label@ORIGINAL_NOTICE:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							Font: Tiny
-							Align: Left
 							Text: The default is "{0}"
 						Label@DUPLICATE_NOTICE:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							Font: Tiny
-							Align: Left
 							Text: This is already used for "{0}"
 				Button@OVERRIDE_HOTKEY_BUTTON:
 					X: PARENT_RIGHT - 3 * WIDTH - 30

--- a/mods/ts/chrome/settings-hotkeys.yaml
+++ b/mods/ts/chrome/settings-hotkeys.yaml
@@ -82,11 +82,6 @@ Container@HOTKEYS_PANEL:
 					Width: 300
 					Height: 25
 					Children:
-						Label@DEFAULT_NOTICE:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
-							Font: Tiny
-							Text: This is the default
 						Label@ORIGINAL_NOTICE:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM


### PR DESCRIPTION
This PR lays out the settings panel in a consistent and simple way whilst accommodating any number of any type of settings widgets. 

Closes #18952
Closes #18426
Related #16596

### RA, D2k, TS
The vertical tabs are a precedent but I think they fit and this layout allows for more tabs to be added. In the "common" UI I decided not to touch it as there isn't enough horizontal space because of the main menu. The settings panels is made larger and is the size of the asset browser.
![Screenshot_20210922_195713](https://user-images.githubusercontent.com/1355810/134388570-249ef9b9-c845-4dd4-a13c-2acf45ac8133.png)

### TD
In TD the vertical vs horizontal tabs dissonance was more apparent so I switched the game info to also use the new vertically stacked layout. And both panels are now the same size.
![Screenshot_20210922_172916](https://user-images.githubusercontent.com/1355810/134387618-6162874a-5330-4b98-b396-9584a0916f81.png)
Settings panel with vertical tabs

![Screenshot_20210922_172900](https://user-images.githubusercontent.com/1355810/134387617-7ecf98d0-5d7b-4453-81da-b074cac4ebd3.png)
Game info panel with vertical tabs