### PR TITLE
Lint test AttackBomber to have RejectsOrders to avoid crashes

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Trait used for scripted actors or actors spawned by a support power.")]
-	public class AttackBomberInfo : AttackBaseInfo
+	public class AttackBomberInfo : AttackBaseInfo, Requires<RejectsOrdersInfo>
 	{
 		public override object Create(ActorInitializer init) { return new AttackBomber(init.Self, this); }
 	}


### PR DESCRIPTION
Not having `RejectsOrders` on scripted bombers is a recipe for disaster as the AI will try to order them around, which is a guaranteed crash that may not be obvious to people who do not know the code base.