### PR TITLE
Bump SharpZipLib from 1.3.1 to 1.3.3

### DIFF
--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Fluent.Net" Version="1.0.50" />
     <PackageReference Include="OpenRA-Eluant" Version="1.0.18" />
     <PackageReference Include="Mono.NAT" Version="3.0.1" />
-    <PackageReference Include="SharpZipLib" Version="1.3.1" />
+    <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Threading.Channels" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
https://github.com/icsharpcode/SharpZipLib/releases/tag/v1.3.2 promises 
> speed improvements when used in newer versions of .NET (Core)