### PR TITLE
Make size and white-space of "Music" and "Credits" panels consistent

### DIFF
--- a/mods/cnc/chrome/credits.yaml
+++ b/mods/cnc/chrome/credits.yaml
@@ -1,7 +1,7 @@
 Container@CREDITS_PANEL:
 	Logic: CreditsLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - 400) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
 	Width: 410
 	Height: 435
 	Children:
@@ -14,7 +14,7 @@ Container@CREDITS_PANEL:
 			Text: Credits
 		Background@bg:
 			Width: PARENT_RIGHT
-			Height: 400
+			Height: PARENT_BOTTOM
 			Background: panel-black
 			Children:
 				Container@TAB_CONTAINER:
@@ -45,7 +45,7 @@ Container@CREDITS_PANEL:
 							Height: 16
 							VAlign: Top
 		Button@BACK_BUTTON:
-			Y: 399
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Back

--- a/mods/cnc/chrome/music.yaml
+++ b/mods/cnc/chrome/music.yaml
@@ -1,28 +1,28 @@
 Container@MUSIC_PANEL:
 	Logic: MusicPlayerLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - 400) / 2
-	Width: 360
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 410
 	Height: 435
 	Children:
 		LogicTicker@SONG_WATCHER:
 		Label@TITLE:
-			Width: 360
+			Width: PARENT_RIGHT
 			Y: 0 - 22
 			Font: BigBold
 			Contrast: true
 			Align: Center
 			Text: Music Player
 		Background@bg:
-			Width: 360
-			Height: 400
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
 			Background: panel-black
 			Children:
 				ScrollPanel@MUSIC_LIST:
 					X: 15
 					Y: 30
-					Width: 330
-					Height: 275
+					Width: PARENT_RIGHT - 30
+					Height: PARENT_BOTTOM - 125
 					Children:
 						ScrollItem@MUSIC_TEMPLATE:
 							Width: PARENT_RIGHT - 27
@@ -46,7 +46,7 @@ Container@MUSIC_PANEL:
 				Container@LABEL_CONTAINER:
 					X: 25
 					Y: 4
-					Width: 330
+					Width: PARENT_RIGHT - 30
 					Children:
 						Label@TITLE:
 							Width: 100
@@ -64,7 +64,7 @@ Container@MUSIC_PANEL:
 				Container@BUTTONS:
 					X: 15
 					Y: PARENT_BOTTOM - HEIGHT - 40
-					Width: 170
+					Width: PARENT_RIGHT - 30
 					Children:
 						Button@BUTTON_PREV:
 							Width: 26
@@ -132,36 +132,36 @@ Container@MUSIC_PANEL:
 									ImageCollection: music
 									ImageName: next
 						ExponentialSlider@MUSIC_SLIDER:
-							X: 145
+							X: PARENT_RIGHT - WIDTH
 							Y: 3
-							Width: 185
+							Width: PARENT_RIGHT - 145
 							Height: 20
 							Ticks: 7
 				Label@TIME_LABEL:
 					X: (PARENT_RIGHT - WIDTH) / 2
-					Y: 317
+					Y: PARENT_BOTTOM - HEIGHT - 60 - 3
 					Width: 140
 					Height: 25
 					Align: Center
 				Checkbox@SHUFFLE:
 					X: 15
-					Y: 320
+					Y: PARENT_BOTTOM - HEIGHT - 60
 					Width: 85
 					Height: 20
 					Font: Regular
 					Text: Shuffle
 				Checkbox@REPEAT:
 					X: PARENT_RIGHT - 15 - WIDTH
-					Y: 320
+					Y: PARENT_BOTTOM - HEIGHT - 60
 					Width: 70
 					Height: 20
 					Font: Regular
 					Text: Loop
 				Container@NO_MUSIC_LABEL:
 					X: 15
-					Y: 121
-					Width: 330
-					Height: 60
+					Y: (PARENT_BOTTOM - HEIGHT - 60) / 2
+					Width: PARENT_RIGHT - 30
+					Height: 75
 					Visible: false
 					Children:
 						Label@TITLE:
@@ -185,13 +185,13 @@ Container@MUSIC_PANEL:
 		Button@BACK_BUTTON:
 			Key: escape
 			X: 0
-			Y: 399
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Back
 		Label@MUTE_LABEL:
 			X: 100
-			Y: 339
+			Y: PARENT_BOTTOM - 60 - 3
 			Width: 300
 			Height: 20
 			Font: Small

--- a/mods/common/chrome/credits.yaml
+++ b/mods/common/chrome/credits.yaml
@@ -1,9 +1,9 @@
 Background@CREDITS_PANEL:
 	Logic: CreditsLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - 400) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
 	Width: 410
-	Height: 450
+	Height: 500
 	Children:
 		Label@CREDITS_TITLE:
 			Width: PARENT_RIGHT
@@ -14,9 +14,9 @@ Background@CREDITS_PANEL:
 			Text: Credits
 		Container@TAB_CONTAINER:
 			Visible: False
-			X: 15
+			X: 20
 			Y: 50
-			Width: PARENT_RIGHT - 30
+			Width: PARENT_RIGHT - 40
 			Height: 30
 			Children:
 				Button@MOD_TAB:
@@ -30,10 +30,10 @@ Background@CREDITS_PANEL:
 					Text: OpenRA
 					Font: Bold
 		ScrollPanel@CREDITS_DISPLAY:
-			X: 15
+			X: 20
 			Y: 50
-			Width: PARENT_RIGHT - 30
-			Height: 345
+			Width: PARENT_RIGHT - 40
+			Height: 395
 			TopBottomSpacing: 8
 			Children:
 				Label@CREDITS_TEMPLATE:

--- a/mods/common/chrome/musicplayer.yaml
+++ b/mods/common/chrome/musicplayer.yaml
@@ -1,16 +1,16 @@
 Background@MUSIC_PANEL:
 	Logic: MusicPlayerLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - 400) / 2
-	Width: 360
-	Height: 450
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 410
+	Height: 500
 	Children:
 		LogicTicker@SONG_WATCHER:
 		ScrollPanel@MUSIC_LIST:
-			X: 15
+			X: 20
 			Y: 45
-			Width: 330
-			Height: 275
+			Width: PARENT_RIGHT - 40
+			Height: PARENT_BOTTOM - 175
 			Children:
 				ScrollItem@MUSIC_TEMPLATE:
 					Width: PARENT_RIGHT - 27
@@ -32,9 +32,9 @@ Background@MUSIC_PANEL:
 							Align: Right
 							Height: 25
 		Container@LABEL_CONTAINER:
-			X: 25
+			X: 20
 			Y: 16
-			Width: 330
+			Width: PARENT_RIGHT - 40
 			Children:
 				Label@TITLE:
 					Width: 100
@@ -43,16 +43,16 @@ Background@MUSIC_PANEL:
 					Align: Center
 					Font: Bold
 				Label@TYPE:
-					X: PARENT_RIGHT - 85
+					X: PARENT_RIGHT - WIDTH
 					Height: 25
-					Width: 50
+					Width: 95
 					Text: Length
-					Align: Right
+					Align: Center
 					Font: Bold
 		Container@BUTTONS:
-			X: 15
+			X: 20
 			Y: PARENT_BOTTOM - HEIGHT - 85
-			Width: 170
+			Width: PARENT_RIGHT - 40
 			Children:
 				Button@BUTTON_PREV:
 					Width: 26
@@ -110,35 +110,35 @@ Background@MUSIC_PANEL:
 							ImageCollection: music
 							ImageName: next
 				ExponentialSlider@MUSIC_SLIDER:
-					X: 145
+					X: PARENT_RIGHT - WIDTH
 					Y: 3
-					Width: 175
+					Width: PARENT_RIGHT - 145
 					Height: 20
 					Ticks: 7
 		Label@TIME_LABEL:
 			X: (PARENT_RIGHT - WIDTH) / 2
-			Y: 332
+			Y: PARENT_BOTTOM - HEIGHT - 95 - 3
 			Width: 140
 			Height: 25
 			Align: Center
 			Font: Bold
 		Checkbox@SHUFFLE:
-			X: 15
-			Y: 335
+			X: 20
+			Y: PARENT_BOTTOM - HEIGHT - 95
 			Width: 85
 			Height: 20
 			Text: Shuffle
 		Checkbox@REPEAT:
 			X: PARENT_RIGHT - 15 - WIDTH
-			Y: 335
+			Y: PARENT_BOTTOM - HEIGHT - 95
 			Width: 70
 			Height: 20
 			Text: Loop
 		Container@NO_MUSIC_LABEL:
-			X: 15
-			Y: 136
-			Width: 330
-			Height: 60
+			X: 20
+			Y: (PARENT_BOTTOM - HEIGHT - 95) / 2
+			Width: PARENT_RIGHT - 40
+			Height: 75
 			Visible: false
 			Children:
 				Label@TITLE:
@@ -160,9 +160,9 @@ Background@MUSIC_PANEL:
 					Align: Center
 					Text: from the "Manage Content" menu.
 		Button@BACK_BUTTON:
-			X: PARENT_RIGHT - 140
+			X: PARENT_RIGHT - WIDTH - 20
 			Y: PARENT_BOTTOM - 45
-			Width: 120
+			Width: 160
 			Height: 25
 			Text: Close
 			Font: Bold


### PR DESCRIPTION
Made the "Music" and "Credits" panels the same size in width and the same height as the "Asset Browser". Also made the padding and button size in "Music" consistent with other panels.

A small step towards #16596

![image](https://user-images.githubusercontent.com/1355810/134552754-ea497ea9-c719-4c3f-8f29-9a7342288646.png)

![image](https://user-images.githubusercontent.com/1355810/134553340-1fb6c96e-240d-4bed-9da2-75ab7e367f49.png)

