### PR TITLE
Streamline sizes of several UI panels

### DIFF
--- a/mods/cnc/chrome/assetbrowser.yaml
+++ b/mods/cnc/chrome/assetbrowser.yaml
@@ -2,8 +2,8 @@ Container@ASSETBROWSER_PANEL:
 	Logic: AssetBrowserLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
-	Width: 695
-	Height: 435
+	Width: 900
+	Height: 540
 	Children:
 		LogicTicker@ANIMATION_TICKER:
 		Label@ASSETBROWSER_TITLE:
@@ -15,36 +15,35 @@ Container@ASSETBROWSER_PANEL:
 			Text: Asset Browser
 		Background@bg:
 			Width: PARENT_RIGHT
-			Height: 435
+			Height: PARENT_BOTTOM
 			Background: panel-black
 			Children:
 				Label@SOURCE_SELECTOR_DESC:
 					X: 15
 					Y: 6
-					Width: 160
+					Width: 195
 					Height: 25
 					Font: TinyBold
 					Align: Center
 					Text: Select asset source
 				DropDownButton@SOURCE_SELECTOR:
 					X: 15
-					Y: 35
-					Width: 160
+					Y: 30
+					Width: 195
 					Height: 25
 					Font: Bold
 					Text: Folders
 				ScrollPanel@ASSET_LIST:
 					X: 15
 					Y: 65
-					Width: 160
-					Height: 275
+					Width: 195
+					Height: PARENT_BOTTOM - 170
 					CollapseHiddenChildren: True
 					Children:
 						ScrollItem@ASSET_TEMPLATE:
 							Width: PARENT_RIGHT - 27
 							Height: 25
 							X: 2
-							Y: 0
 							Visible: false
 							EnableChildMouseOver: True
 							Children:
@@ -56,16 +55,16 @@ Container@ASSETBROWSER_PANEL:
 									TooltipTemplate: SIMPLE_TOOLTIP
 				Label@FILENAME_DESC:
 					X: 15
-					Y: 341
-					Width: 160
+					Y: PARENT_BOTTOM - HEIGHT - 74
+					Width: 195
 					Height: 25
 					Font: TinyBold
 					Align: Center
 					Text: Filter by name
 				TextField@FILENAME_INPUT:
 					X: 15
-					Y: 365
-					Width: 160
+					Y: PARENT_BOTTOM - HEIGHT - 50
+					Width: 195
 					Height: 25
 					Type: Filename
 				Label@PALETTE_DESC:
@@ -94,10 +93,10 @@ Container@ASSETBROWSER_PANEL:
 							Width: PARENT_RIGHT - 35
 							Height: PARENT_BOTTOM - 12
 				Background@SPRITE_BG:
-					X: 190
+					X: 225
 					Y: 65
-					Width: 490
-					Height: 325
+					Width: PARENT_RIGHT - 195 - 45
+					Height: PARENT_BOTTOM - 115
 					Background: scrollpanel-bg
 					Children:
 						Sprite@SPRITE:
@@ -108,15 +107,15 @@ Container@ASSETBROWSER_PANEL:
 							Height: PARENT_BOTTOM
 							AspectRatio: 1
 						Label@ERROR:
-							X: 5
-							Width: 490 - 10
-							Height: 325
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
 							Align: Center
 							Visible: false
 							Text: Error displaying file. See assetbrowser.log for details.
 				Container@FRAME_SELECTOR:
-					X: 190
-					Y: 395
+					X: 225
+					Y: PARENT_BOTTOM - 40
+					Width: PARENT_RIGHT - 225
 					Children:
 						Button@BUTTON_PREV:
 							Width: 26
@@ -186,19 +185,19 @@ Container@ASSETBROWSER_PANEL:
 						Slider@FRAME_SLIDER:
 							X: 140
 							Y: 3
-							Width: 300
+							Width: PARENT_RIGHT - 140 - 85
 							Height: 20
 							MinimumValue: 0
 						Label@FRAME_COUNT:
-							X: 445
+							X: PARENT_RIGHT - WIDTH + 5
 							Y: 1
-							Width: 40
+							Width: 80
 							Height: 25
 							Font: TinyBold
 							Align: Left
 		Button@CLOSE_BUTTON:
 			Key: escape
-			Y: 434
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Back

--- a/mods/cnc/chrome/credits.yaml
+++ b/mods/cnc/chrome/credits.yaml
@@ -1,7 +1,7 @@
 Container@CREDITS_PANEL:
 	Logic: CreditsLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - 400) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
 	Width: 410
 	Height: 435
 	Children:
@@ -14,7 +14,7 @@ Container@CREDITS_PANEL:
 			Text: Credits
 		Background@bg:
 			Width: PARENT_RIGHT
-			Height: 400
+			Height: PARENT_BOTTOM
 			Background: panel-black
 			Children:
 				Container@TAB_CONTAINER:
@@ -45,7 +45,7 @@ Container@CREDITS_PANEL:
 							Height: 16
 							VAlign: Top
 		Button@BACK_BUTTON:
-			Y: 399
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Back

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -3,7 +3,7 @@ Container@NEW_MAP_BG:
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
 	Width: 300
-	Height: 125
+	Height: 95
 	Children:
 		Label@TITLE:
 			Text: New Map
@@ -14,7 +14,7 @@ Container@NEW_MAP_BG:
 			Align: Center
 		Background@bg:
 			Width: PARENT_RIGHT
-			Height: 90
+			Height: PARENT_BOTTOM
 			Background: panel-black
 			Children:
 				Label@TILESET_LABEL:
@@ -60,7 +60,7 @@ Container@NEW_MAP_BG:
 					Text: 128
 					Type: Integer
 		Button@CANCEL_BUTTON:
-			Y: 89
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Cancel
@@ -68,7 +68,7 @@ Container@NEW_MAP_BG:
 			Key: escape
 		Button@CREATE_BUTTON:
 			X: PARENT_RIGHT - WIDTH
-			Y: 89
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Create
@@ -80,7 +80,7 @@ Container@SAVE_MAP_PANEL:
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
 	Width: 345
-	Height: 229
+	Height: 195
 	Children:
 		Label@LABEL_TITLE:
 			Text: Save Map
@@ -91,7 +91,7 @@ Container@SAVE_MAP_PANEL:
 			Align: Center
 		Background@SAVE_MAP_BACKGROUND:
 			Width: PARENT_RIGHT
-			Height: 195
+			Height: PARENT_BOTTOM
 			Background: panel-black
 			Children:
 				Label@TITLE_LABEL:
@@ -167,7 +167,7 @@ Container@SAVE_MAP_PANEL:
 					Height: 25
 					Font: Regular
 		Button@BACK_BUTTON:
-			Y: PARENT_BOTTOM - 35
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Cancel
@@ -175,7 +175,7 @@ Container@SAVE_MAP_PANEL:
 			Key: escape
 		Button@SAVE_BUTTON:
 			X: PARENT_RIGHT - 140
-			Y: PARENT_BOTTOM - 35
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Save

--- a/mods/cnc/chrome/gamesave-browser.yaml
+++ b/mods/cnc/chrome/gamesave-browser.yaml
@@ -2,8 +2,8 @@ Container@GAMESAVE_BROWSER_PANEL:
 	Logic: GameSaveBrowserLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
-	Width: 600
-	Height: 400
+	Width: 714
+	Height: 435
 	Children:
 		Label@LOAD_TITLE:
 			Width: PARENT_RIGHT
@@ -27,10 +27,10 @@ Container@GAMESAVE_BROWSER_PANEL:
 			Background: panel-black
 			Children:
 				ScrollPanel@GAME_LIST:
-					X: 10
-					Y: 10
-					Width: PARENT_RIGHT - 20
-					Height: PARENT_BOTTOM - 20
+					X: 15
+					Y: 15
+					Width: PARENT_RIGHT - 30
+					Height: PARENT_BOTTOM - 30
 					Children:
 						ScrollItem@NEW_TEMPLATE:
 							Width: PARENT_RIGHT - 27
@@ -62,10 +62,10 @@ Container@GAMESAVE_BROWSER_PANEL:
 									Height: 25
 									Align: Right
 				Container@SAVE_WIDGETS:
-					X: 10
-					Y: PARENT_BOTTOM - 35
-					Width: PARENT_RIGHT - 20
-					Height: 35
+					X: 15
+					Y: PARENT_BOTTOM - 40
+					Width: PARENT_RIGHT - 30
+					Height: 30
 					Visible: False
 					Children:
 						TextField@SAVE_TEXTFIELD:
@@ -76,24 +76,24 @@ Container@GAMESAVE_BROWSER_PANEL:
 					Key: escape
 					X: 0
 					Y: PARENT_BOTTOM - 1
-					Width: 100
+					Width: 140
 					Height: 35
 					Text: Back
 				Button@DELETE_ALL_BUTTON:
-					X: PARENT_RIGHT - 330 - WIDTH
+					X: PARENT_RIGHT - 370 - WIDTH
 					Y: PARENT_BOTTOM - 1
 					Width: 100
 					Height: 35
 					Text: Delete All
 				Button@DELETE_BUTTON:
-					X: PARENT_RIGHT - 220 - WIDTH
+					X: PARENT_RIGHT - 260 - WIDTH
 					Y: PARENT_BOTTOM - 1
 					Width: 100
 					Height: 35
 					Text: Delete
 					Key: Delete
 				Button@RENAME_BUTTON:
-					X: PARENT_RIGHT - 110 - WIDTH
+					X: PARENT_RIGHT - 150 - WIDTH
 					Y: PARENT_BOTTOM - 1
 					Width: 100
 					Height: 35
@@ -103,7 +103,7 @@ Container@GAMESAVE_BROWSER_PANEL:
 					Key: return
 					X: PARENT_RIGHT - WIDTH
 					Y: PARENT_BOTTOM - 1
-					Width: 100
+					Width: 140
 					Height: 35
 					Text: Load
 					Visible: False
@@ -111,7 +111,7 @@ Container@GAMESAVE_BROWSER_PANEL:
 					Key: return
 					X: PARENT_RIGHT - WIDTH
 					Y: PARENT_BOTTOM - 1
-					Width: 100
+					Width: 140
 					Height: 35
 					Text: Save
 					Visible: False

--- a/mods/cnc/chrome/lobby.yaml
+++ b/mods/cnc/chrome/lobby.yaml
@@ -1,9 +1,9 @@
 Container@SERVER_LOBBY:
 	Logic: LobbyLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - 560) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
 	Width: 900
-	Height: 575
+	Height: 540
 	Children:
 		Label@SERVER_NAME:
 			Width: PARENT_RIGHT
@@ -13,7 +13,7 @@ Container@SERVER_LOBBY:
 			Align: Center
 		Background@bg:
 			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM - 35
+			Height: PARENT_BOTTOM
 			Background: panel-black
 			Children:
 				Container@MAP_PREVIEW_ROOT:
@@ -137,13 +137,13 @@ Container@SERVER_LOBBY:
 							Width: PARENT_RIGHT - 55
 							Height: 25
 		Button@DISCONNECT_BUTTON:
-			Y: PARENT_BOTTOM - 36
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Leave Game
 		Button@START_GAME_BUTTON:
 			X: PARENT_RIGHT - WIDTH
-			Y: PARENT_BOTTOM - 36
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Start Game

--- a/mods/cnc/chrome/mapchooser.yaml
+++ b/mods/cnc/chrome/mapchooser.yaml
@@ -1,9 +1,9 @@
 Container@MAPCHOOSER_PANEL:
 	Logic: MapChooserLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - 560) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
 	Width: 900
-	Height: 575
+	Height: 540
 	Children:
 		Label@TITLE:
 			Width: PARENT_RIGHT

--- a/mods/cnc/chrome/missionbrowser.yaml
+++ b/mods/cnc/chrome/missionbrowser.yaml
@@ -3,7 +3,7 @@ Container@MISSIONBROWSER_PANEL:
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
 	Width: 714
-	Height: 420
+	Height: 435
 	Children:
 		Label@MISSIONBROWSER_TITLE:
 			Y: 0 - 22
@@ -13,15 +13,15 @@ Container@MISSIONBROWSER_PANEL:
 			Contrast: true
 			Font: BigBold
 		Background@BG:
-			Width: 714
-			Height: 420
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
 			Background: panel-black
 			Children:
 				ScrollPanel@MISSION_LIST:
 					X: 15
 					Y: 15
 					Width: 311
-					Height: 390
+					Height: PARENT_BOTTOM - 30
 					Children:
 						ScrollItem@HEADER:
 							Width: PARENT_RIGHT - 27
@@ -51,7 +51,7 @@ Container@MISSIONBROWSER_PANEL:
 					X: 337
 					Y: 15
 					Width: 362
-					Height: 392
+					Height: PARENT_BOTTOM - 30
 					Children:
 						Background@MISSION_BG:
 							Width: PARENT_RIGHT
@@ -69,7 +69,7 @@ Container@MISSIONBROWSER_PANEL:
 						ScrollPanel@MISSION_DESCRIPTION_PANEL:
 							Y: 213
 							Width: PARENT_RIGHT
-							Height: 142
+							Height: 157
 							TopBottomSpacing: 5
 							Children:
 								Label@MISSION_DESCRIPTION:
@@ -78,32 +78,32 @@ Container@MISSIONBROWSER_PANEL:
 									VAlign: Top
 									Font: Small
 						Label@DIFFICULTY_DESC:
-							Y: 365
+							Y: PARENT_BOTTOM - HEIGHT
 							Width: 56
 							Height: 25
 							Text: Difficulty:
 							Align: Right
 						DropDownButton@DIFFICULTY_DROPDOWNBUTTON:
 							X: 61
-							Y: 365
+							Y: PARENT_BOTTOM - HEIGHT
 							Width: 120
 							Height: 25
 							Font: Regular
 						Label@GAMESPEED_DESC:
 							X: PARENT_RIGHT - WIDTH - 125
-							Y: 365
+							Y: PARENT_BOTTOM - HEIGHT
 							Width: 120
 							Height: 25
 							Text: Speed:
 							Align: Right
 						DropDownButton@GAMESPEED_DROPDOWNBUTTON:
 							X: PARENT_RIGHT - WIDTH
-							Y: 365
+							Y: PARENT_BOTTOM - HEIGHT
 							Width: 120
 							Height: 25
 							Font: Regular
 		Button@BACK_BUTTON:
-			Y: 419
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Back
@@ -111,46 +111,51 @@ Container@MISSIONBROWSER_PANEL:
 			Key: escape
 		Button@START_BRIEFING_VIDEO_BUTTON:
 			X: PARENT_RIGHT - 290
-			Y: 419
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Watch Briefing
 			Font: Bold
 		Button@STOP_BRIEFING_VIDEO_BUTTON:
 			X: PARENT_RIGHT - 290
-			Y: 419
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Stop Briefing
 			Font: Bold
 		Button@START_INFO_VIDEO_BUTTON:
 			X: PARENT_RIGHT - 440
-			Y: 419
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Watch Info Video
 			Font: Bold
 		Button@STOP_INFO_VIDEO_BUTTON:
 			X: PARENT_RIGHT - 440
-			Y: 419
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Stop Info Video
 			Font: Bold
 		Button@STARTGAME_BUTTON:
 			X: PARENT_RIGHT - 140
-			Y: 419
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Play
 			Font: Bold
-		Container@MISSION_BIN:
+		Background@MISSION_BIN:
+			X: 15
+			Y: 15
+			Width: 686
+			Height: 405
+			Background: panel-black
 			Children:
 				VideoPlayer@MISSION_VIDEO:
 					X: 1
 					Y: 1
-					Width: 712
-					Height: 418
+					Width: 684
+					Height: 402
 		TooltipContainer@TOOLTIP_CONTAINER:
 
 Background@FULLSCREEN_PLAYER:

--- a/mods/cnc/chrome/multiplayer-browser.yaml
+++ b/mods/cnc/chrome/multiplayer-browser.yaml
@@ -1,9 +1,9 @@
 Container@MULTIPLAYER_PANEL:
 	Logic: MultiplayerLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - 560) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
 	Width: 900
-	Height: 575
+	Height: 540
 	Children:
 		Label@TITLE:
 			Text: Multiplayer
@@ -14,7 +14,7 @@ Container@MULTIPLAYER_PANEL:
 			Align: Center
 		Background@bg:
 			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM - 35
+			Height: PARENT_BOTTOM
 			Background: panel-black
 			Children:
 				Container@LABEL_CONTAINER:
@@ -254,7 +254,7 @@ Container@MULTIPLAYER_PANEL:
 		Button@BACK_BUTTON:
 			Key: escape
 			X: 0
-			Y: PARENT_BOTTOM - 36
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Back

--- a/mods/cnc/chrome/multiplayer-createserver.yaml
+++ b/mods/cnc/chrome/multiplayer-createserver.yaml
@@ -14,7 +14,7 @@ Container@MULTIPLAYER_CREATESERVER_PANEL:
 			Text: Create Server
 		Background@bg:
 			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM - 35
+			Height: PARENT_BOTTOM
 			Background: panel-black
 			Children:
 				Label@SERVER_NAME_LABEL:
@@ -242,20 +242,20 @@ Container@MULTIPLAYER_CREATESERVER_PANEL:
 					Align: Center
 		Button@BACK_BUTTON:
 			Key: return
-			Y: PARENT_BOTTOM - 36
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Back
 		Button@MAP_BUTTON:
 			X: PARENT_RIGHT - WIDTH - 150
-			Y: PARENT_BOTTOM - 36
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Change Map
 		Button@CREATE_BUTTON:
 			Key: return
 			X: PARENT_RIGHT - WIDTH
-			Y: PARENT_BOTTOM - 36
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Create

--- a/mods/cnc/chrome/music.yaml
+++ b/mods/cnc/chrome/music.yaml
@@ -1,28 +1,28 @@
 Container@MUSIC_PANEL:
 	Logic: MusicPlayerLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - 400) / 2
-	Width: 360
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 410
 	Height: 435
 	Children:
 		LogicTicker@SONG_WATCHER:
 		Label@TITLE:
-			Width: 360
+			Width: PARENT_RIGHT
 			Y: 0 - 22
 			Font: BigBold
 			Contrast: true
 			Align: Center
 			Text: Music Player
 		Background@bg:
-			Width: 360
-			Height: 400
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
 			Background: panel-black
 			Children:
 				ScrollPanel@MUSIC_LIST:
 					X: 15
 					Y: 30
-					Width: 330
-					Height: 275
+					Width: PARENT_RIGHT - 30
+					Height: PARENT_BOTTOM - 125
 					Children:
 						ScrollItem@MUSIC_TEMPLATE:
 							Width: PARENT_RIGHT - 27
@@ -46,7 +46,7 @@ Container@MUSIC_PANEL:
 				Container@LABEL_CONTAINER:
 					X: 25
 					Y: 4
-					Width: 330
+					Width: PARENT_RIGHT - 30
 					Children:
 						Label@TITLE:
 							Width: 100
@@ -64,7 +64,7 @@ Container@MUSIC_PANEL:
 				Container@BUTTONS:
 					X: 15
 					Y: PARENT_BOTTOM - HEIGHT - 40
-					Width: 170
+					Width: PARENT_RIGHT - 30
 					Children:
 						Button@BUTTON_PREV:
 							Width: 26
@@ -132,36 +132,36 @@ Container@MUSIC_PANEL:
 									ImageCollection: music
 									ImageName: next
 						ExponentialSlider@MUSIC_SLIDER:
-							X: 145
+							X: PARENT_RIGHT - WIDTH
 							Y: 3
-							Width: 185
+							Width: PARENT_RIGHT - 145
 							Height: 20
 							Ticks: 7
 				Label@TIME_LABEL:
 					X: (PARENT_RIGHT - WIDTH) / 2
-					Y: 317
+					Y: PARENT_BOTTOM - HEIGHT - 60 - 3
 					Width: 140
 					Height: 25
 					Align: Center
 				Checkbox@SHUFFLE:
 					X: 15
-					Y: 320
+					Y: PARENT_BOTTOM - HEIGHT - 60
 					Width: 85
 					Height: 20
 					Font: Regular
 					Text: Shuffle
 				Checkbox@REPEAT:
 					X: PARENT_RIGHT - 15 - WIDTH
-					Y: 320
+					Y: PARENT_BOTTOM - HEIGHT - 60
 					Width: 70
 					Height: 20
 					Font: Regular
 					Text: Loop
 				Container@NO_MUSIC_LABEL:
 					X: 15
-					Y: 121
-					Width: 330
-					Height: 60
+					Y: (PARENT_BOTTOM - HEIGHT - 60) / 2
+					Width: PARENT_RIGHT - 30
+					Height: 75
 					Visible: false
 					Children:
 						Label@TITLE:
@@ -185,13 +185,13 @@ Container@MUSIC_PANEL:
 		Button@BACK_BUTTON:
 			Key: escape
 			X: 0
-			Y: 399
+			Y: PARENT_BOTTOM - 1
 			Width: 140
 			Height: 35
 			Text: Back
 		Label@MUTE_LABEL:
 			X: 100
-			Y: 339
+			Y: PARENT_BOTTOM - 60 - 3
 			Width: 300
 			Height: 20
 			Font: Small

--- a/mods/cnc/chrome/replaybrowser.yaml
+++ b/mods/cnc/chrome/replaybrowser.yaml
@@ -2,8 +2,8 @@ Container@REPLAYBROWSER_PANEL:
 	Logic: ReplayBrowserLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
-	Width: 780
-	Height: 500
+	Width: 900
+	Height: 540
 	Children:
 		Label@TITLE:
 			Width: PARENT_RIGHT
@@ -18,17 +18,18 @@ Container@REPLAYBROWSER_PANEL:
 			Background: panel-black
 			Children:
 				Container@FILTER_AND_MANAGE_CONTAINER:
-					X: 20
-					Y: 20
-					Width: 280
-					Height: PARENT_BOTTOM - 40
+					X: 15
+					Y: 15
+					Width: 285
+					Height: PARENT_BOTTOM
 					Children:
 						Container@FILTERS:
-							Width: 280
+							Width: PARENT_RIGHT
 							Height: 320
 							Children:
 								Label@FILTERS_TITLE:
 									X: 85
+									Y: 0 - 9
 									Width: PARENT_RIGHT - 85
 									Height: 25
 									Font: Bold
@@ -36,107 +37,106 @@ Container@REPLAYBROWSER_PANEL:
 									Text: Filter
 								Label@FLT_GAMETYPE_DESC:
 									X: 0
-									Y: 30
+									Y: 15
 									Width: 80
 									Height: 25
 									Text: Type:
 									Align: Right
 								DropDownButton@FLT_GAMETYPE_DROPDOWNBUTTON:
 									X: 85
-									Y: 30
+									Y: 15
 									Width: PARENT_RIGHT - 85
 									Height: 25
 									Text: Any
 								Label@FLT_DATE_DESC:
 									X: 0
-									Y: 60
+									Y: 45
 									Width: 80
 									Height: 25
 									Text: Date:
 									Align: Right
 								DropDownButton@FLT_DATE_DROPDOWNBUTTON:
 									X: 85
-									Y: 60
+									Y: 45
 									Width: PARENT_RIGHT - 85
 									Height: 25
 									Text: Any
 								Label@FLT_DURATION_DESC:
 									X: 0
-									Y: 90
+									Y: 75
 									Width: 80
 									Height: 25
 									Text: Duration:
 									Align: Right
 								DropDownButton@FLT_DURATION_DROPDOWNBUTTON:
 									X: 85
-									Y: 90
+									Y: 75
 									Width: PARENT_RIGHT - 85
 									Height: 25
 									Text: Any
 								Label@FLT_MAPNAME_DESC:
 									X: 0
-									Y: 120
+									Y: 105
 									Width: 80
 									Height: 25
 									Text: Map:
 									Align: Right
 								DropDownButton@FLT_MAPNAME_DROPDOWNBUTTON:
 									X: 85
-									Y: 120
+									Y: 105
 									Width: PARENT_RIGHT - 85
 									Height: 25
 									Text: Any
 								Label@FLT_PLAYER_DESC:
 									X: 0
-									Y: 150
+									Y: 135
 									Width: 80
 									Height: 25
 									Text: Player:
 									Align: Right
 								DropDownButton@FLT_PLAYER_DROPDOWNBUTTON:
 									X: 85
-									Y: 150
+									Y: 135
 									Width: PARENT_RIGHT - 85
 									Height: 25
 									Text: Anyone
 								Label@FLT_OUTCOME_DESC:
 									X: 0
-									Y: 180
+									Y: 165
 									Width: 80
 									Height: 25
 									Text: Outcome:
 									Align: Right
 								DropDownButton@FLT_OUTCOME_DROPDOWNBUTTON:
 									X: 85
-									Y: 180
+									Y: 165
 									Width: PARENT_RIGHT - 85
 									Height: 25
 									Text: Any
 								Label@FLT_FACTION_DESC:
 									X: 0
-									Y: 210
+									Y: 195
 									Width: 80
 									Height: 25
 									Text: Faction:
 									Align: Right
 								DropDownButton@FLT_FACTION_DROPDOWNBUTTON:
 									X: 85
-									Y: 210
+									Y: 195
 									Width: PARENT_RIGHT - 85
 									Height: 25
 									Text: Any
 								Button@FLT_RESET_BUTTON:
 									X: 85
-									Y: 250
+									Y: 235
 									Width: PARENT_RIGHT - 85
 									Height: 25
 									Text: Reset Filters
 									Font: Bold
 						Container@MANAGEMENT:
 							X: 85
-							Y: PARENT_BOTTOM - 115
+							Y: 395
 							Width: PARENT_RIGHT - 85
-							Height: 115
 							Children:
 								Label@MANAGE_TITLE:
 									Y: 1
@@ -166,13 +166,13 @@ Container@REPLAYBROWSER_PANEL:
 									Text: Delete All
 									Font: Bold
 				Container@REPLAY_LIST_CONTAINER:
-					X: 310
-					Y: 20
-					Width: 250
-					Height: PARENT_BOTTOM - 20 - 20
+					X: 314
+					Y: 15
+					Width: 383
+					Height: PARENT_BOTTOM - 45
 					Children:
 						Label@REPLAYBROWSER_LABEL_TITLE:
-							Y: 1
+							Y: 0 - 9
 							Width: PARENT_RIGHT
 							Height: 25
 							Text: Choose Replay
@@ -180,9 +180,9 @@ Container@REPLAYBROWSER_PANEL:
 							Font: Bold
 						ScrollPanel@REPLAY_LIST:
 							X: 0
-							Y: 30
+							Y: 15
 							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM - 30
+							Height: PARENT_BOTTOM
 							CollapseHiddenChildren: True
 							Children:
 								ScrollItem@REPLAY_TEMPLATE:
@@ -199,15 +199,15 @@ Container@REPLAYBROWSER_PANEL:
 											TooltipContainer: TOOLTIP_CONTAINER
 											TooltipTemplate: SIMPLE_TOOLTIP
 				Container@MAP_PREVIEW_ROOT:
-					X: PARENT_RIGHT - WIDTH - 20
-					Y: 50
-					Width: 194
+					X: PARENT_RIGHT - WIDTH - 15
+					Y: 30
+					Width: 174
 					Height: 250
 				Container@REPLAY_INFO:
-					X: PARENT_RIGHT - WIDTH - 20
-					Y: 250
-					Width: 194
-					Height: PARENT_BOTTOM - 260
+					X: PARENT_RIGHT - WIDTH - 15
+					Y: 230
+					Width: 174
+					Height: PARENT_BOTTOM - 240
 					Children:
 						Label@DURATION:
 							Y: 21
@@ -218,7 +218,7 @@ Container@REPLAYBROWSER_PANEL:
 						ScrollPanel@PLAYER_LIST:
 							Y: 40
 							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM - 50
+							Height: PARENT_BOTTOM - 45
 							IgnoreChildMouseOver: true
 							Children:
 								ScrollItem@HEADER:
@@ -254,18 +254,18 @@ Container@REPLAYBROWSER_PANEL:
 											X: 5
 											Width: PARENT_RIGHT
 											Height: 25
-				Button@CANCEL_BUTTON:
-					Key: escape
-					X: 0
-					Y: PARENT_BOTTOM - 1
-					Width: 140
-					Height: 35
-					Text: Back
-				Button@WATCH_BUTTON:
-					Key: return
-					X: PARENT_RIGHT - 140
-					Y: PARENT_BOTTOM - 1
-					Width: 140
-					Height: 35
-					Text: Watch
-				TooltipContainer@TOOLTIP_CONTAINER:
+		Button@CANCEL_BUTTON:
+			Key: escape
+			X: 0
+			Y: PARENT_BOTTOM - 1
+			Width: 140
+			Height: 35
+			Text: Back
+		Button@WATCH_BUTTON:
+			Key: return
+			X: PARENT_RIGHT - 140
+			Y: PARENT_BOTTOM - 1
+			Width: 140
+			Height: 35
+			Text: Watch
+		TooltipContainer@TOOLTIP_CONTAINER:

--- a/mods/common/chrome/assetbrowser.yaml
+++ b/mods/common/chrome/assetbrowser.yaml
@@ -2,12 +2,12 @@ Background@ASSETBROWSER_PANEL:
 	Logic: AssetBrowserLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
-	Width: 700
-	Height: 500
+	Width: 900
+	Height: 600
 	Children:
 		LogicTicker@ANIMATION_TICKER:
 		Label@ASSETBROWSER_TITLE:
-			Y: 21
+			Y: 16
 			Width: PARENT_RIGHT
 			Height: 25
 			Font: Bold
@@ -16,7 +16,7 @@ Background@ASSETBROWSER_PANEL:
 		Label@SOURCE_SELECTOR_DESC:
 			X: 20
 			Y: 36
-			Width: 160
+			Width: 195
 			Height: 25
 			Font: TinyBold
 			Align: Center
@@ -24,22 +24,21 @@ Background@ASSETBROWSER_PANEL:
 		DropDownButton@SOURCE_SELECTOR:
 			X: 20
 			Y: 60
-			Width: 160
+			Width: 195
 			Height: 25
 			Font: Bold
 			Text: Folders
 		ScrollPanel@ASSET_LIST:
 			X: 20
 			Y: 90
-			Width: 160
-			Height: 275
+			Width: 195
+			Height: PARENT_BOTTOM - 225
 			CollapseHiddenChildren: True
 			Children:
 				ScrollItem@ASSET_TEMPLATE:
 					Width: PARENT_RIGHT - 27
 					Height: 25
 					X: 2
-					Y: 0
 					Visible: false
 					EnableChildMouseOver: True
 					Children:
@@ -51,16 +50,16 @@ Background@ASSETBROWSER_PANEL:
 							TooltipTemplate: SIMPLE_TOOLTIP
 		Label@FILENAME_DESC:
 			X: 20
-			Y: 371
-			Width: 160
+			Y: 471
+			Width: 195
 			Height: 25
 			Font: TinyBold
 			Align: Center
 			Text: Filter by name
 		TextField@FILENAME_INPUT:
 			X: 20
-			Y: 395
-			Width: 160
+			Y: PARENT_BOTTOM - 105
+			Width: 195
 			Height: 25
 			Type: Filename
 		Label@PALETTE_DESC:
@@ -89,10 +88,10 @@ Background@ASSETBROWSER_PANEL:
 					Width: PARENT_RIGHT - 35
 					Height: PARENT_BOTTOM - 12
 		Background@SPRITE_BG:
-			X: 190
+			X: 226
 			Y: 90
-			Width: 490
-			Height: 330
+			Width: PARENT_RIGHT - 226 - 20
+			Height: PARENT_BOTTOM - 170
 			Background: dialog3
 			Children:
 				Sprite@SPRITE:
@@ -108,20 +107,17 @@ Background@ASSETBROWSER_PANEL:
 					Palette: colorpicker
 					PlayerPalette: colorpicker
 				Label@ERROR:
-					Y: 1
-					X: 5
-					Width: 490 - 10
-					Height: 330
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
 					Align: Center
 					Visible: false
 					Text: Error displaying file. See assetbrowser.log for details.
 		Container@FRAME_SELECTOR:
-			X: 190
-			Y: 425
+			X: 226
+			Y: PARENT_BOTTOM - 75
+			Width: PARENT_RIGHT - 226
 			Children:
 				Button@BUTTON_PREV:
-					X: 0
-					Y: 0
 					Width: 26
 					Height: 26
 					Key: LEFT
@@ -133,7 +129,6 @@ Background@ASSETBROWSER_PANEL:
 							ImageName: prev
 				Button@BUTTON_PLAY:
 					X: 35
-					Y: 0
 					Width: 26
 					Height: 26
 					Key: SPACE
@@ -146,7 +141,6 @@ Background@ASSETBROWSER_PANEL:
 				Button@BUTTON_PAUSE:
 					Visible: false
 					X: 35
-					Y: 0
 					Width: 26
 					Height: 26
 					Key: SPACE
@@ -158,7 +152,6 @@ Background@ASSETBROWSER_PANEL:
 							ImageName: pause
 				Button@BUTTON_STOP:
 					X: 70
-					Y: 0
 					Width: 26
 					Height: 26
 					Key: RETURN
@@ -170,7 +163,6 @@ Background@ASSETBROWSER_PANEL:
 							ImageName: stop
 				Button@BUTTON_NEXT:
 					X: 105
-					Y: 0
 					Width: 26
 					Height: 26
 					Key: RIGHT
@@ -183,22 +175,21 @@ Background@ASSETBROWSER_PANEL:
 				Slider@FRAME_SLIDER:
 					X: 140
 					Y: 3
-					Width: 300
+					Width: PARENT_RIGHT - 140 - 85
 					Height: 20
 					MinimumValue: 0
 				Label@FRAME_COUNT:
-					X: 445
+					X: PARENT_RIGHT - WIDTH + 5
 					Y: 1
-					Width: 40
+					Width: 85
 					Height: 25
 					Font: TinyBold
 					Align: Left
 		Container@VOXEL_SELECTOR:
-			X: 60
-			Y: 425
+			X: 226
+			Y: PARENT_BOTTOM - 75
 			Children:
 				Label@ROLL:
-					X: 140
 					Y: 1
 					Width: 40
 					Height: 25
@@ -206,14 +197,14 @@ Background@ASSETBROWSER_PANEL:
 					Align: Left
 					Text: Roll
 				Slider@ROLL_SLIDER:
-					X: 165
+					X: 30
 					Y: 3
 					Width: 100
 					Height: 20
 					MinimumValue: 1
 					MaximumValue: 1023
 				Label@PITCH:
-					X: 310
+					X: 150
 					Y: 1
 					Width: 40
 					Height: 25
@@ -221,14 +212,14 @@ Background@ASSETBROWSER_PANEL:
 					Align: Left
 					Text: Pitch
 				Slider@PITCH_SLIDER:
-					X: 335
+					X: 190
 					Y: 3
 					Width: 100
 					Height: 20
 					MinimumValue: 1
 					MaximumValue: 1023
 				Label@YAW:
-					X: 480
+					X: 305
 					Y: 1
 					Width: 40
 					Height: 25
@@ -236,7 +227,7 @@ Background@ASSETBROWSER_PANEL:
 					Align: Left
 					Text: Yaw
 				Slider@YAW_SLIDER:
-					X: 505
+					X: 335
 					Y: 3
 					Width: 100
 					Height: 20

--- a/mods/common/chrome/credits.yaml
+++ b/mods/common/chrome/credits.yaml
@@ -1,9 +1,9 @@
 Background@CREDITS_PANEL:
 	Logic: CreditsLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - 400) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
 	Width: 410
-	Height: 450
+	Height: 500
 	Children:
 		Label@CREDITS_TITLE:
 			Width: PARENT_RIGHT
@@ -14,9 +14,9 @@ Background@CREDITS_PANEL:
 			Text: Credits
 		Container@TAB_CONTAINER:
 			Visible: False
-			X: 15
+			X: 20
 			Y: 50
-			Width: PARENT_RIGHT - 30
+			Width: PARENT_RIGHT - 40
 			Height: 30
 			Children:
 				Button@MOD_TAB:
@@ -30,10 +30,10 @@ Background@CREDITS_PANEL:
 					Text: OpenRA
 					Font: Bold
 		ScrollPanel@CREDITS_DISPLAY:
-			X: 15
+			X: 20
 			Y: 50
-			Width: PARENT_RIGHT - 30
-			Height: 345
+			Width: PARENT_RIGHT - 40
+			Height: 395
 			TopBottomSpacing: 8
 			Children:
 				Label@CREDITS_TEMPLATE:

--- a/mods/common/chrome/gamesave-browser.yaml
+++ b/mods/common/chrome/gamesave-browser.yaml
@@ -2,12 +2,12 @@ Background@GAMESAVE_BROWSER_PANEL:
 	Logic: GameSaveBrowserLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
-	Width: 600
-	Height: 400
+	Width: 700
+	Height: 500
 	Children:
 		Label@LOAD_TITLE:
 			Width: PARENT_RIGHT
-			Y: 21
+			Y: 16
 			Height: 25
 			Font: Bold
 			Align: Center
@@ -15,7 +15,7 @@ Background@GAMESAVE_BROWSER_PANEL:
 			Visible: False
 		Label@SAVE_TITLE:
 			Width: PARENT_RIGHT
-			Y: 21
+			Y: 16
 			Height: 25
 			Font: Bold
 			Align: Center
@@ -23,9 +23,9 @@ Background@GAMESAVE_BROWSER_PANEL:
 			Visible: False
 		ScrollPanel@GAME_LIST:
 			X: 20
-			Y: 50
+			Y: 45
 			Width: PARENT_RIGHT - 40
-			Height: PARENT_BOTTOM - 102
+			Height: PARENT_BOTTOM - 97
 			Children:
 				ScrollItem@NEW_TEMPLATE:
 					Width: PARENT_RIGHT - 27

--- a/mods/common/chrome/missionbrowser.yaml
+++ b/mods/common/chrome/missionbrowser.yaml
@@ -2,8 +2,8 @@ Background@MISSIONBROWSER_PANEL:
 	Logic: MissionBrowserLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
-	Width: 682
-	Height: 487
+	Width: 700
+	Height: 500
 	Children:
 		Label@MISSIONBROWSER_TITLE:
 			Y: 21
@@ -15,8 +15,8 @@ Background@MISSIONBROWSER_PANEL:
 		ScrollPanel@MISSION_LIST:
 			X: 20
 			Y: 50
-			Width: 270
-			Height: 377
+			Width: 288
+			Height: PARENT_BOTTOM - 110
 			Children:
 				ScrollItem@HEADER:
 					BaseName: scrollheader
@@ -43,10 +43,10 @@ Background@MISSIONBROWSER_PANEL:
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 		Container@MISSION_INFO:
-			X: 300
+			X: 318
 			Y: 50
 			Width: 362
-			Height: 363
+			Height: PARENT_BOTTOM - 110
 			Children:
 				Background@MISSION_BG:
 					Width: PARENT_RIGHT
@@ -64,7 +64,7 @@ Background@MISSIONBROWSER_PANEL:
 				ScrollPanel@MISSION_DESCRIPTION_PANEL:
 					Y: 212
 					Width: PARENT_RIGHT
-					Height: 130
+					Height: 143
 					TopBottomSpacing: 5
 					Children:
 						Label@MISSION_DESCRIPTION:
@@ -73,27 +73,27 @@ Background@MISSIONBROWSER_PANEL:
 							VAlign: Top
 							Font: Small
 				Label@DIFFICULTY_DESC:
-					Y: 352
+					Y: PARENT_BOTTOM - HEIGHT
 					Width: 56
 					Height: 25
 					Text: Difficulty:
 					Align: Right
 				DropDownButton@DIFFICULTY_DROPDOWNBUTTON:
 					X: 61
-					Y: 352
+					Y: PARENT_BOTTOM - HEIGHT
 					Width: 135
 					Height: 25
 					Font: Regular
 				Label@GAMESPEED_DESC:
 					X: PARENT_RIGHT - WIDTH - 115
-					Y: 352
+					Y: PARENT_BOTTOM - HEIGHT
 					Width: 120
 					Height: 25
 					Text: Speed:
 					Align: Right
 				DropDownButton@GAMESPEED_DROPDOWNBUTTON:
 					X: PARENT_RIGHT - WIDTH
-					Y: 352
+					Y: PARENT_BOTTOM - HEIGHT
 					Width: 110
 					Height: 25
 					Font: Regular
@@ -143,15 +143,15 @@ Background@MISSIONBROWSER_PANEL:
 		Background@MISSION_BIN:
 			X: 20
 			Y: 50
-			Width: 642
-			Height: 377
+			Width: PARENT_RIGHT - 40
+			Height: PARENT_BOTTOM - 110
 			Background: dialog3
 			Children:
 				VideoPlayer@MISSION_VIDEO:
 					X: 1
 					Y: 1
-					Width: 640
-					Height: 375
+					Width: PARENT_RIGHT - 2
+					Height: PARENT_BOTTOM - 2
 		TooltipContainer@TOOLTIP_CONTAINER:
 
 Background@FULLSCREEN_PLAYER:

--- a/mods/common/chrome/multiplayer-browser.yaml
+++ b/mods/common/chrome/multiplayer-browser.yaml
@@ -76,7 +76,7 @@ Background@MULTIPLAYER_PANEL:
 			X: 20
 			Y: 67
 			Width: 675
-			Height: PARENT_BOTTOM - 119
+			Height: PARENT_BOTTOM - 122
 			TopBottomSpacing: 2
 			Children:
 				ScrollItem@HEADER_TEMPLATE:

--- a/mods/common/chrome/musicplayer.yaml
+++ b/mods/common/chrome/musicplayer.yaml
@@ -1,16 +1,16 @@
 Background@MUSIC_PANEL:
 	Logic: MusicPlayerLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - 400) / 2
-	Width: 360
-	Height: 450
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 410
+	Height: 500
 	Children:
 		LogicTicker@SONG_WATCHER:
 		ScrollPanel@MUSIC_LIST:
-			X: 15
+			X: 20
 			Y: 45
-			Width: 330
-			Height: 275
+			Width: PARENT_RIGHT - 40
+			Height: PARENT_BOTTOM - 175
 			Children:
 				ScrollItem@MUSIC_TEMPLATE:
 					Width: PARENT_RIGHT - 27
@@ -32,9 +32,9 @@ Background@MUSIC_PANEL:
 							Align: Right
 							Height: 25
 		Container@LABEL_CONTAINER:
-			X: 25
+			X: 20
 			Y: 16
-			Width: 330
+			Width: PARENT_RIGHT - 40
 			Children:
 				Label@TITLE:
 					Width: 100
@@ -43,16 +43,16 @@ Background@MUSIC_PANEL:
 					Align: Center
 					Font: Bold
 				Label@TYPE:
-					X: PARENT_RIGHT - 85
+					X: PARENT_RIGHT - WIDTH
 					Height: 25
-					Width: 50
+					Width: 95
 					Text: Length
-					Align: Right
+					Align: Center
 					Font: Bold
 		Container@BUTTONS:
-			X: 15
+			X: 20
 			Y: PARENT_BOTTOM - HEIGHT - 85
-			Width: 170
+			Width: PARENT_RIGHT - 40
 			Children:
 				Button@BUTTON_PREV:
 					Width: 26
@@ -110,35 +110,35 @@ Background@MUSIC_PANEL:
 							ImageCollection: music
 							ImageName: next
 				ExponentialSlider@MUSIC_SLIDER:
-					X: 145
+					X: PARENT_RIGHT - WIDTH
 					Y: 3
-					Width: 175
+					Width: PARENT_RIGHT - 145
 					Height: 20
 					Ticks: 7
 		Label@TIME_LABEL:
 			X: (PARENT_RIGHT - WIDTH) / 2
-			Y: 332
+			Y: PARENT_BOTTOM - HEIGHT - 95 - 3
 			Width: 140
 			Height: 25
 			Align: Center
 			Font: Bold
 		Checkbox@SHUFFLE:
-			X: 15
-			Y: 335
+			X: 20
+			Y: PARENT_BOTTOM - HEIGHT - 95
 			Width: 85
 			Height: 20
 			Text: Shuffle
 		Checkbox@REPEAT:
 			X: PARENT_RIGHT - 15 - WIDTH
-			Y: 335
+			Y: PARENT_BOTTOM - HEIGHT - 95
 			Width: 70
 			Height: 20
 			Text: Loop
 		Container@NO_MUSIC_LABEL:
-			X: 15
-			Y: 136
-			Width: 330
-			Height: 60
+			X: 20
+			Y: (PARENT_BOTTOM - HEIGHT - 95) / 2
+			Width: PARENT_RIGHT - 40
+			Height: 75
 			Visible: false
 			Children:
 				Label@TITLE:
@@ -160,9 +160,9 @@ Background@MUSIC_PANEL:
 					Align: Center
 					Text: from the "Manage Content" menu.
 		Button@BACK_BUTTON:
-			X: PARENT_RIGHT - 140
+			X: PARENT_RIGHT - WIDTH - 20
 			Y: PARENT_BOTTOM - 45
-			Width: 120
+			Width: 160
 			Height: 25
 			Text: Close
 			Font: Bold

--- a/mods/common/chrome/replaybrowser.yaml
+++ b/mods/common/chrome/replaybrowser.yaml
@@ -2,12 +2,19 @@ Background@REPLAYBROWSER_PANEL:
 	Logic: ReplayBrowserLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
-	Width: 780
-	Height: 535
+	Width: 900
+	Height: 600
 	Children:
+		Label@TITLE:
+			Y: 16
+			Width: PARENT_RIGHT
+			Height: 25
+			Text: Replay Viewer
+			Align: Center
+			Font: Bold
 		Container@FILTER_AND_MANAGE_CONTAINER:
 			X: 20
-			Y: 20
+			Y: 37
 			Width: 280
 			Height: PARENT_BOTTOM - 75
 			Children:
@@ -17,6 +24,7 @@ Background@REPLAYBROWSER_PANEL:
 					Children:
 						Label@FILTERS_TITLE:
 							X: 85
+							Y: 6
 							Width: PARENT_RIGHT - 85
 							Height: 25
 							Font: Bold
@@ -122,9 +130,8 @@ Background@REPLAYBROWSER_PANEL:
 							Font: Bold
 				Container@MANAGEMENT:
 					X: 85
-					Y: PARENT_BOTTOM - 115
+					Y: 395
 					Width: PARENT_RIGHT - 85
-					Height: 115
 					Children:
 						Label@MANAGE_TITLE:
 							Y: 1
@@ -154,13 +161,13 @@ Background@REPLAYBROWSER_PANEL:
 							Text: Delete All
 							Font: Bold
 		Container@REPLAY_LIST_CONTAINER:
-			X: 310
-			Y: 20
-			Width: 250
-			Height: PARENT_BOTTOM - 20 - 55
+			X: 311
+			Y: 37
+			Width: 384
+			Height: PARENT_BOTTOM - 37 - 55
 			Children:
 				Label@REPLAYBROWSER_LABEL_TITLE:
-					Y: 1
+					Y: 6
 					Width: PARENT_RIGHT
 					Height: 25
 					Text: Choose Replay
@@ -188,14 +195,14 @@ Background@REPLAYBROWSER_PANEL:
 									TooltipTemplate: SIMPLE_TOOLTIP
 		Container@MAP_PREVIEW_ROOT:
 			X: PARENT_RIGHT - WIDTH - 20
-			Y: 50
-			Width: 194
+			Y: 67
+			Width: 174
 			Height: 250
 		Container@REPLAY_INFO:
 			X: PARENT_RIGHT - WIDTH - 20
-			Y: 250
-			Width: 194
-			Height: PARENT_BOTTOM - 250 - 45
+			Y: 267
+			Width: 174
+			Height: PARENT_BOTTOM - 267 - 45
 			Children:
 				Label@DURATION:
 					Y: 19


### PR DESCRIPTION
I took a pass at resizing and adjusting the white space in many of the UI panels. They fit in two size categories now:
- Large (Multiplayer Browser, Lobby, Asset Browser, Replay Browser)
- Medium (Mission Browser, Settings - after #19677)
- Small (Credits, Music Player) (same height as the medium size)

I have not yet touched several panels (Game Save/Load, In-game Info). I plan to address them in a follow up because the size of the changes here is starting to get intimidating. Some additional polish may be needed but I also want to leave that to follow ups or at least after #19677 and #19461).

Things are still not quite consistent (especially wrt to white-space) as it is quite difficult to layout everything with absolute positioning but nevertheless this PR makes great progress towards #16596

It's best to review by opening two clients and switching between the windows to see the differences and how the panel dimensions line up.

Supersedes #19680