### PR TITLE
SpriteFont.Measure optimization.

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -533,50 +533,6 @@ namespace OpenRA
 
 			return default(T);
 		}
-
-		public static LineSplitEnumerator SplitLines(this string str, char separator)
-		{
-			return new LineSplitEnumerator(str.AsSpan(), separator);
-		}
-	}
-
-	public ref struct LineSplitEnumerator
-	{
-		ReadOnlySpan<char> str;
-		readonly char separator;
-
-		public LineSplitEnumerator(ReadOnlySpan<char> str, char separator)
-		{
-			this.str = str;
-			this.separator = separator;
-			Current = default;
-		}
-
-		public LineSplitEnumerator GetEnumerator() => this;
-
-		public bool MoveNext()
-		{
-			var span = str;
-
-			// Reach the end of the string
-			if (span.Length == 0)
-				return false;
-
-			var index = span.IndexOf(separator);
-			if (index == -1)
-			{
-				// The remaining string is an empty string
-				str = ReadOnlySpan<char>.Empty;
-				Current = span;
-				return true;
-			}
-
-			Current = span.Slice(0, index);
-			str = span.Slice(index + 1);
-			return true;
-		}
-
-		public ReadOnlySpan<char> Current { get; private set; }
 	}
 
 	public static class Enum<T>

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -227,20 +227,29 @@ namespace OpenRA.Graphics
 			DrawTextWithShadow(text, location, fg, GetContrastColor(fg, bgDark, bgLight), offset, angle);
 		}
 
-		public int2 Measure(string text)
+		public int2 Measure(ReadOnlySpan<char> text)
 		{
-			if (string.IsNullOrEmpty(text))
+			if (text == null || text.IsEmpty)
 				return new int2(0, size);
 
-			var lines = text.SplitLines('\n');
-
 			var maxWidth = 0f;
-			var rows = 0;
-			foreach (var line in lines)
+			var rows = 1;
+
+			var lineStart = 0;
+			var i = 0;
+			for (; i < text.Length; ++i)
 			{
-				rows++;
-				maxWidth = Math.Max(maxWidth, LineWidth(line));
+				if (text[i] == '\n')
+				{
+					var line = text.Slice(lineStart, i - lineStart);
+					maxWidth = Math.Max(maxWidth, LineWidth(line));
+					lineStart = i + 1;
+					rows++;
+				}
 			}
+
+			var lastLine = text.Slice(lineStart, i - lineStart);
+			maxWidth = Math.Max(maxWidth, LineWidth(lastLine));
 
 			return new int2((int)Math.Ceiling(maxWidth), rows * size);
 		}


### PR DESCRIPTION
1. `SpriteFont.Measure` twice as fast. 
- Use ReadOnlySpan
- Do not call `String.Split`, do not convert array to List. Do not join list after to a new string.
- Function is called often.
- Tested to be compatible with old.

2. `WidgetUtils.WrapText` faster.
- Functionality changed. The old function would only split a single line once. Now a line is split more often.
- Not called that often. Mostly with long chat lines and/or large UI messages.
- Not all branched tested.

`Exts.SplitLines` and `SplitLineEnumerator` are now no longer used.
