### PR TITLE
Fix style errors

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
@@ -151,7 +151,7 @@ namespace OpenRA.Mods.Common.Scripting
 				var squad = new List<Actor>();
 				var func = actionFunc.CopyReference() as LuaFunction;
 
-				Action<Actor, Actor> productionHandler = (_, __) => { };
+				Action<Actor, Actor> productionHandler = (a, b) => { };
 				productionHandler = (factory, unit) =>
 				{
 					if (player != factory.Owner)

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.D2k.Activities
 					{
 						var insurance = targetClose.Owner.PlayerActor.TraitOrDefault<HarvesterInsurance>();
 						if (insurance != null)
-							self.World.AddFrameEndTask(__ => insurance.TryActivate());
+							self.World.AddFrameEndTask(w => insurance.TryActivate());
 					}
 				});
 			}

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -19,6 +19,7 @@ using SDL2;
 
 namespace OpenRA.Platforms.Default
 {
+#pragma warning disable IDE1006 // Naming Styles
 	[SuppressMessage("Microsoft.StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter",
 		Justification = "C-style naming is kept for consistency with the underlying native API.")]
 	[SuppressMessage("Microsoft.StyleCop.CSharp.NamingRules", "SA1310:FieldNamesMustNotContainUnderscore",

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -19,7 +19,7 @@ using SDL2;
 
 namespace OpenRA.Platforms.Default
 {
-#pragma warning disable IDE1006 // Naming Styles
+	#pragma warning disable IDE1006 // Naming Styles
 	[SuppressMessage("Microsoft.StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter",
 		Justification = "C-style naming is kept for consistency with the underlying native API.")]
 	[SuppressMessage("Microsoft.StyleCop.CSharp.NamingRules", "SA1310:FieldNamesMustNotContainUnderscore",


### PR DESCRIPTION
Fixes some naming to avoid style errors. `IDE1006` shuts up a VS naming diagnostics as with the other StyleCop based suppressions next to it.