### PR TITLE
Require an explicit launch path for mod registrations.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -408,19 +408,11 @@ namespace OpenRA
 				if (launchPath != null && launchPath.First() == '"' && launchPath.Last() == '"')
 					launchPath = launchPath.Substring(1, launchPath.Length - 2);
 
-				if (launchPath == null)
-				{
-					// When launching the assembly directly we must propagate the Engine.EngineDir argument if defined
-					// Platform-specific launchers are expected to manage this internally.
-					launchPath = Assembly.GetEntryAssembly().Location;
-					if (!string.IsNullOrEmpty(engineDirArg))
-						launchArgs.Add("Engine.EngineDir=\"" + engineDirArg + "\"");
-				}
+				// Metadata registration requires an explicit launch path
+				if (launchPath != null)
+					ExternalMods.Register(Mods[modID], launchPath, launchArgs, ModRegistration.User);
 
-				ExternalMods.Register(Mods[modID], launchPath, launchArgs, ModRegistration.User);
-
-				if (ExternalMods.TryGetValue(ExternalMod.MakeKey(Mods[modID]), out var activeMod))
-					ExternalMods.ClearInvalidRegistrations(activeMod, ModRegistration.User);
+				ExternalMods.ClearInvalidRegistrations(ModRegistration.User);
 			}
 
 			Console.WriteLine("External mods:");

--- a/OpenRA.Game/UtilityCommands/ClearInvalidModRegistrationsCommand.cs
+++ b/OpenRA.Game/UtilityCommands/ClearInvalidModRegistrationsCommand.cs
@@ -32,11 +32,7 @@ namespace OpenRA.UtilityCommands
 			if (args[1] == "user" || args[1] == "both")
 				type |= ModRegistration.User;
 
-			var mods = new ExternalMods();
-
-			ExternalMod activeMod = null;
-			mods.TryGetValue(ExternalMod.MakeKey(utility.ModData.Manifest), out activeMod);
-			mods.ClearInvalidRegistrations(activeMod, type);
+			new ExternalMods().ClearInvalidRegistrations(type);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
@@ -75,16 +75,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Action closeAndExit = () => { Ui.CloseWindow(); onExit(); };
 				if (needsRestart)
 				{
-					Action restart = () =>
+					Action noRestart = () => ConfirmationDialogs.ButtonPrompt(
+						title: "Restart Required",
+						text: "Some changes will not be applied until\nthe game is restarted.",
+						onCancel: closeAndExit,
+						cancelText: "Continue");
+
+					if (!Game.ExternalMods.TryGetValue(ExternalMod.MakeKey(Game.ModData.Manifest), out var external))
 					{
-						var external = Game.ExternalMods[ExternalMod.MakeKey(Game.ModData.Manifest)];
-						Game.SwitchToExternalMod(external, null, closeAndExit);
-					};
+						noRestart();
+						return;
+					}
 
 					ConfirmationDialogs.ButtonPrompt(
 						title: "Restart Now?",
 						text: "Some changes will not be applied until\nthe game is restarted. Restart now?",
-						onConfirm: restart,
+						onConfirm: () => Game.SwitchToExternalMod(external, null, noRestart),
 						onCancel: closeAndExit,
 						confirmText: "Restart Now",
 						cancelText: "Restart Later");

--- a/launch-game.cmd
+++ b/launch-game.cmd
@@ -1,6 +1,6 @@
 @echo off
 title OpenRA
-for %%x in (%*) do (
+for /F "delims==\ " %%x in ("%*") do (
   if "%%~x" EQU "Game.Mod" (goto launch)
 )
 
@@ -17,10 +17,12 @@ echo.
 goto choosemod
 
 :launchmod
-bin\OpenRA.exe Engine.EngineDir=".." Game.Mod=%mod% %*
+cd %~dp0%
+bin\OpenRA.exe Engine.EngineDir=".." Engine.LaunchPath="%~dpf0" Game.Mod=%mod% %*
 goto end
 :launch
-bin\OpenRA.exe Engine.EngineDir=".." %*
+cd %~dp0%
+bin\OpenRA.exe Engine.EngineDir=".." Engine.LaunchPath="%~dpf0" %*
 
 :end
 if %errorlevel% neq 0 goto crashdialog


### PR DESCRIPTION
Fixes #19518.
Supersedes #19589.

Switching to .NET 5 broke (and is, in general, fundamentally incompatible with) the method we used to guess the launch path for external mod switching. This PR solves the problem by removing the assumption that it is always valid to switch to the currently active mod, and only registers mods that explicitly define a launch path. A new alert dialog is shown instead of the restart prompt if the settings are changed and we don't have a valid path for restarting the game.

We would ideally also update `launch-game.cmd` to pass `Engine.LaunchPath` similarly to `launch-game.sh`, but this goes beyond my level of ability and patience (having now spent well over an hour failing at what should have been a trivial change). We need to `cd %~dp0%` before the `bin\OpenRA.exe` lines, and pass `Engine.LaunchPath="%~dpf0"` to create the correct metadata file. The final issue is that the `Game.Mod` detection at the top of the script blocks the restart even though a valid argument is already specified.