### PR TITLE
Ensure TargetLineRenderable width and marker size don't get lost.

### DIFF
--- a/OpenRA.Game/Graphics/TargetLineRenderable.cs
+++ b/OpenRA.Game/Graphics/TargetLineRenderable.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Graphics
 		readonly int width;
 		readonly int markerSize;
 
-		public TargetLineRenderable(IEnumerable<WPos> waypoints, Color color, int width = 1, int markerSize = 1)
+		public TargetLineRenderable(IEnumerable<WPos> waypoints, Color color, int width, int markerSize)
 		{
 			this.waypoints = waypoints;
 			this.color = color;
@@ -34,13 +34,13 @@ namespace OpenRA.Graphics
 		public int ZOffset => 0;
 		public bool IsDecoration => true;
 
-		public IRenderable WithZOffset(int newOffset) { return new TargetLineRenderable(waypoints, color); }
+		public IRenderable WithZOffset(int newOffset) { return this; }
 
 		public IRenderable OffsetBy(in WVec vec)
 		{
 			// Lambdas can't use 'in' variables, so capture a copy for later
 			var offset = vec;
-			return new TargetLineRenderable(waypoints.Select(w => w + offset), color);
+			return new TargetLineRenderable(waypoints.Select(w => w + offset), color, width, markerSize);
 		}
 
 		public IRenderable AsDecoration() { return this; }

--- a/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Mods.Common.Effects
 			{
 				var targetLine = new[] { prev, pos };
 				prev = pos;
-				yield return new TargetLineRenderable(targetLine, building.Owner.Color, rp.Info.LineWidth);
+				yield return new TargetLineRenderable(targetLine, building.Owner.Color, rp.Info.LineWidth, 1);
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Render/SelectionDecorationsBase.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SelectionDecorationsBase.cs
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 					yield return r;
 
 			if (selected && self.World.LocalPlayer != null && self.World.LocalPlayer.PlayerActor.Trait<DeveloperMode>().PathDebug)
-				yield return new TargetLineRenderable(ActivityTargetPath(self), Color.Green);
+				yield return new TargetLineRenderable(ActivityTargetPath(self), Color.Green, 1, 2);
 
 			// Hide decorations for spectators that zoom out further than the normal minimum level
 			// This avoids graphical glitches with pip rows and icons overlapping the selection box


### PR DESCRIPTION
By making the constructor take non-optional parameters, this highlights some calls sites which were forgetting to set these values. These are now fixed.

Set the path debug to have a marker size of 2 for better visibility.