### PR TITLE
Allow the default value of a CellInfo to be an Unvisited location.

### DIFF
--- a/OpenRA.Game/Map/CellLayer.cs
+++ b/OpenRA.Game/Map/CellLayer.cs
@@ -25,22 +25,31 @@ namespace OpenRA
 		public CellLayer(MapGridType gridType, Size size)
 			: base(gridType, size) { }
 
-		public override void Clear()
-		{
-			if (CellEntryChanged != null)
-				throw new InvalidOperationException(
-					"Cannot clear values when there are listeners attached to the CellEntryChanged event.");
-
-			base.Clear();
-		}
-
 		public override void CopyValuesFrom(CellLayerBase<T> anotherLayer)
 		{
 			if (CellEntryChanged != null)
 				throw new InvalidOperationException(
-					"Cannot copy values when there are listeners attached to the CellEntryChanged event.");
+					$"Cannot copy values when there are listeners attached to the {nameof(CellEntryChanged)} event.");
 
 			base.CopyValuesFrom(anotherLayer);
+		}
+
+		public override void Clear()
+		{
+			if (CellEntryChanged != null)
+				throw new InvalidOperationException(
+					$"Cannot clear values when there are listeners attached to the {nameof(CellEntryChanged)} event.");
+
+			base.Clear();
+		}
+
+		public override void Clear(T clearValue)
+		{
+			if (CellEntryChanged != null)
+				throw new InvalidOperationException(
+					$"Cannot clear values when there are listeners attached to the {nameof(CellEntryChanged)} event.");
+
+			base.Clear(clearValue);
 		}
 
 		// Resolve an array index from cell coordinates

--- a/OpenRA.Game/Map/CellLayer.cs
+++ b/OpenRA.Game/Map/CellLayer.cs
@@ -25,6 +25,15 @@ namespace OpenRA
 		public CellLayer(MapGridType gridType, Size size)
 			: base(gridType, size) { }
 
+		public override void Clear()
+		{
+			if (CellEntryChanged != null)
+				throw new InvalidOperationException(
+					"Cannot clear values when there are listeners attached to the CellEntryChanged event.");
+
+			base.Clear();
+		}
+
 		public override void CopyValuesFrom(CellLayerBase<T> anotherLayer)
 		{
 			if (CellEntryChanged != null)
@@ -32,21 +41,6 @@ namespace OpenRA
 					"Cannot copy values when there are listeners attached to the CellEntryChanged event.");
 
 			base.CopyValuesFrom(anotherLayer);
-		}
-
-		public static CellLayer<T> CreateInstance(Func<MPos, T> initialCellValueFactory, Size size, MapGridType mapGridType)
-		{
-			var cellLayer = new CellLayer<T>(mapGridType, size);
-			for (var v = 0; v < size.Height; v++)
-			{
-				for (var u = 0; u < size.Width; u++)
-				{
-					var mpos = new MPos(u, v);
-					cellLayer[mpos] = initialCellValueFactory(mpos);
-				}
-			}
-
-			return cellLayer;
 		}
 
 		// Resolve an array index from cell coordinates

--- a/OpenRA.Game/Map/CellLayerBase.cs
+++ b/OpenRA.Game/Map/CellLayerBase.cs
@@ -35,6 +35,11 @@ namespace OpenRA
 			entries = new T[size.Width * size.Height];
 		}
 
+		public virtual void Clear()
+		{
+			Array.Clear(entries, 0, entries.Length);
+		}
+
 		public virtual void CopyValuesFrom(CellLayerBase<T> anotherLayer)
 		{
 			if (Size != anotherLayer.Size || GridType != anotherLayer.GridType)

--- a/OpenRA.Game/Map/CellLayerBase.cs
+++ b/OpenRA.Game/Map/CellLayerBase.cs
@@ -35,11 +35,6 @@ namespace OpenRA
 			entries = new T[size.Width * size.Height];
 		}
 
-		public virtual void Clear()
-		{
-			Array.Clear(entries, 0, entries.Length);
-		}
-
 		public virtual void CopyValuesFrom(CellLayerBase<T> anotherLayer)
 		{
 			if (Size != anotherLayer.Size || GridType != anotherLayer.GridType)
@@ -48,11 +43,16 @@ namespace OpenRA
 			Array.Copy(anotherLayer.entries, entries, entries.Length);
 		}
 
-		/// <summary>Clears the layer contents with a known value</summary>
-		public void Clear(T clearValue)
+		/// <summary>Clears the layer contents with their default value</summary>
+		public virtual void Clear()
 		{
-			for (var i = 0; i < entries.Length; i++)
-				entries[i] = clearValue;
+			Array.Clear(entries, 0, entries.Length);
+		}
+
+		/// <summary>Clears the layer contents with a known value</summary>
+		public virtual void Clear(T clearValue)
+		{
+			Array.Fill(entries, clearValue);
 		}
 
 		public IEnumerator<T> GetEnumerator()

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -309,14 +309,13 @@ namespace OpenRA
 			Resources = new CellLayer<ResourceTile>(Grid.Type, size);
 			Height = new CellLayer<byte>(Grid.Type, size);
 			Ramp = new CellLayer<byte>(Grid.Type, size);
+			Tiles.Clear(terrainInfo.DefaultTerrainTile);
 			if (Grid.MaximumTerrainHeight > 0)
 			{
 				Height.CellEntryChanged += UpdateProjection;
 				Tiles.CellEntryChanged += UpdateProjection;
 				Tiles.CellEntryChanged += UpdateRamp;
 			}
-
-			Tiles.Clear(terrainInfo.DefaultTerrainTile);
 
 			PostInit();
 		}

--- a/OpenRA.Mods.Common/Pathfinder/CellInfo.cs
+++ b/OpenRA.Mods.Common/Pathfinder/CellInfo.cs
@@ -9,13 +9,15 @@
  */
 #endregion
 
+using System;
+
 namespace OpenRA.Mods.Common.Pathfinder
 {
 	/// <summary>
 	/// Describes the three states that a node in the graph can have.
 	/// Based on A* algorithm specification
 	/// </summary>
-	public enum CellStatus
+	public enum CellStatus : byte
 	{
 		Unvisited,
 		Open,
@@ -23,36 +25,52 @@ namespace OpenRA.Mods.Common.Pathfinder
 	}
 
 	/// <summary>
-	/// Stores information about nodes in the pathfinding graph
+	/// Stores information about nodes in the pathfinding graph.
+	/// The default value of this struct represents an <see cref="CellStatus.Unvisited"/> location.
 	/// </summary>
 	public readonly struct CellInfo
 	{
 		/// <summary>
-		/// The cost to move from the start up to this node
+		/// The cost to move from the start up to this node.
 		/// </summary>
 		public readonly int CostSoFar;
 
 		/// <summary>
-		/// The estimation of how far is the node from our goal
+		/// The estimation of how far this node is from our target.
 		/// </summary>
 		public readonly int EstimatedTotal;
 
 		/// <summary>
-		/// The previous node of this one that follows the shortest path
+		/// The previous node of this one that follows the shortest path.
 		/// </summary>
 		public readonly CPos PreviousPos;
 
 		/// <summary>
-		/// The status of this node
+		/// The status of this node. Accessing other fields is only valid when the status is not <see cref="CellStatus.Unvisited"/>.
 		/// </summary>
 		public readonly CellStatus Status;
 
 		public CellInfo(int costSoFar, int estimatedTotal, CPos previousPos, CellStatus status)
 		{
-			CostSoFar = costSoFar;
-			PreviousPos = previousPos;
+			if (status == CellStatus.Unvisited)
+				throw new ArgumentException(
+					$"The default {nameof(CellInfo)} is the only such {nameof(CellInfo)} allowed for representing an {nameof(CellStatus.Unvisited)} location.",
+					nameof(status));
+
 			Status = status;
+			CostSoFar = costSoFar;
 			EstimatedTotal = estimatedTotal;
+			PreviousPos = previousPos;
+		}
+
+		public override string ToString()
+		{
+			if (Status == CellStatus.Unvisited)
+				return Status.ToString();
+
+			return
+				$"{Status} {nameof(CostSoFar)}={CostSoFar} " +
+				$"{nameof(EstimatedTotal)}={EstimatedTotal} {nameof(PreviousPos)}={PreviousPos}";
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Pathfinder/CellInfoLayerPool.cs
+++ b/OpenRA.Mods.Common/Pathfinder/CellInfoLayerPool.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.Pathfinder
 {
@@ -19,15 +18,11 @@ namespace OpenRA.Mods.Common.Pathfinder
 	{
 		const int MaxPoolSize = 4;
 		readonly Stack<CellLayer<CellInfo>> pool = new Stack<CellLayer<CellInfo>>(MaxPoolSize);
-		readonly CellLayer<CellInfo> defaultLayer;
+		readonly Map map;
 
 		public CellInfoLayerPool(Map map)
 		{
-			defaultLayer =
-				CellLayer<CellInfo>.CreateInstance(
-					mpos => new CellInfo(PathGraph.PathCostForInvalidPath, PathGraph.PathCostForInvalidPath, mpos.ToCPos(map), CellStatus.Unvisited),
-					new Size(map.MapSize.X, map.MapSize.Y),
-					map.Grid.Type);
+			this.map = map;
 		}
 
 		public PooledCellInfoLayer Get()
@@ -42,9 +37,14 @@ namespace OpenRA.Mods.Common.Pathfinder
 				if (pool.Count > 0)
 					layer = pool.Pop();
 
+			// As the default value of CellInfo represents an Unvisited location,
+			// we don't need to initialize the values in the layer,
+			// we can just clear them to the defaults.
 			if (layer == null)
-				layer = new CellLayer<CellInfo>(defaultLayer.GridType, defaultLayer.Size);
-			layer.CopyValuesFrom(defaultLayer);
+				layer = new CellLayer<CellInfo>(map);
+			else
+				layer.Clear();
+
 			return layer;
 		}
 

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -119,7 +119,8 @@ namespace OpenRA.Mods.Common.Pathfinder
 				var neighborCell = Graph[neighborCPos];
 
 				// Cost is even higher; next direction:
-				if (neighborCell.Status == CellStatus.Closed || gCost >= neighborCell.CostSoFar)
+				if (neighborCell.Status == CellStatus.Closed ||
+					(neighborCell.Status == CellStatus.Open && gCost >= neighborCell.CostSoFar))
 					continue;
 
 				// Now we may seriously consider this direction using heuristics. If the cell has


### PR DESCRIPTION
In CellInfoLayerPool, instead of having to store a layer with the default values, we know we can just clear the pooled layer in order to reset it. This saves on memory, and also makes resetting marginally faster.

In PathSearch, we need to amend a check to ensure a cell info is not Unvisited before we check on its cost.