### PR TITLE
Fix some incorrect logic in PathGraph.GetConnections

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -375,6 +375,11 @@ namespace OpenRA
 			return ts.Concat(moreTs);
 		}
 
+		public static IEnumerable<T> Exclude<T>(this IEnumerable<T> ts, params T[] exclusions)
+		{
+			return ts.Except(exclusions);
+		}
+
 		public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source)
 		{
 			return new HashSet<T>(source);


### PR DESCRIPTION
Firstly, when dealing with maps with height discontinuities, the neighbouring cells we need to search are more that the set we need to search on flat maps. We ensure that as we traverse a map with varying height, we now consider cells "behind" us that may have become accessible due to a height change.

Secondly, when considering connections available via Custom Movement Layers, make sure the target cell on the new layer is actually enterable. Previously this cell would be reported as a valid connection, even if it wasn't actually possible to enter the cell as it was blocked. We also apply the same optimization of ignoring already closed cells.

----

To understand the first scenario better, here comes another terrible diagram.

On the left, we have a flat map with no height changes. Imagine the pathfinder is exploring towards the north. In step 1 it explores the 3 tiles to the north of it. We can see the blue tile which I am interested in is reachable in step 1, as shown by the orange line. In steps 2 and 3 we only explore the 3 tiles "ahead". Even though our blue tile is reachable from steps 2 and 3 as well.

On flat maps, we can optimize the checking because we know when moving in a given direction, we would have explored the tile on a previous step. Therefore we don't need to check all 7 adjacent tiles.

That is to say, for flat maps on step 2 we don't need to check tiles to the side, because we would've reached them from the previous tile in step 1. On step 3 we don't need to check the tile to the side and behind, because we would've reached it on step 2 anyway.

On the right, imagine a map with height differences. Imagine the green and blue tiles are 2 height apart, forming an impassable cliff - the black line. The light green tiles are 1 above the green, and 1 below the blue. You can go from green<->light green<->blue, but not from green to blue directly.

On steps 1 and 2 when we try and reach the target cell, we find it inaccessible due to the cliff. On step 3 we find it *is* accessible, because we've changed height and can now it is a step up a hill rather than an impassable cliff.

You can see on the right diagram, we therefore need to check all 7 adjacent cells as shown in step 3, because we don't have the guarantee that the previous steps 1 or 2 would've been able to access the cell.

Therefore when cells are at different heights we must check more adjacent cells in order to ensure we explore any connections that have become available due to the height change.

![image](https://user-images.githubusercontent.com/3399086/134772721-5a302595-ccf3-4421-ad50-18ebe3c6b327.png)


