### PR TITLE
Update ICustomMovementLayer to not depend on actor for costs.

### DIFF
--- a/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
@@ -103,7 +103,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 			// PERF: Avoid LINQ
 			foreach (var cml in world.GetCustomMovementLayers().Values)
-				if (cml.EnabledForActor(actor.Info, locomotorInfo))
+				if (cml.EnabledForLocomotor(locomotorInfo))
 					customLayerInfo[cml.Index] = (cml, pooledLayer.GetLayer());
 
 			World = world;
@@ -159,7 +159,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 				foreach (var cli in customLayerInfo.Values)
 				{
 					var layerPosition = new CPos(position.X, position.Y, cli.Layer.Index);
-					var entryCost = cli.Layer.EntryMovementCost(Actor.Info, locomotor.Info, layerPosition);
+					var entryCost = cli.Layer.EntryMovementCost(locomotor.Info, layerPosition);
 					if (entryCost != CostForInvalidCell)
 						validNeighbors.Add(new GraphConnection(layerPosition, entryCost));
 				}
@@ -167,7 +167,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			else
 			{
 				var layerPosition = new CPos(position.X, position.Y, 0);
-				var exitCost = customLayerInfo[posLayer].Layer.ExitMovementCost(Actor.Info, locomotor.Info, layerPosition);
+				var exitCost = customLayerInfo[posLayer].Layer.ExitMovementCost(locomotor.Info, layerPosition);
 				if (exitCost != CostForInvalidCell)
 					validNeighbors.Add(new GraphConnection(layerPosition, exitCost));
 			}

--- a/OpenRA.Mods.Common/Traits/World/ElevatedBridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ElevatedBridgeLayer.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Pathfinder;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -69,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		bool ICustomMovementLayer.EnabledForActor(ActorInfo a, LocomotorInfo li) { return enabled; }
+		bool ICustomMovementLayer.EnabledForLocomotor(LocomotorInfo li) { return enabled; }
 		byte ICustomMovementLayer.Index => CustomMovementLayerType.ElevatedBridge;
 		bool ICustomMovementLayer.InteractsWithDefaultLayer => true;
 		bool ICustomMovementLayer.ReturnToGroundLayerOnIdle => false;
@@ -79,14 +80,14 @@ namespace OpenRA.Mods.Common.Traits
 			return cellCenters[cell];
 		}
 
-		int ICustomMovementLayer.EntryMovementCost(ActorInfo a, LocomotorInfo li, CPos cell)
+		int ICustomMovementLayer.EntryMovementCost(LocomotorInfo li, CPos cell)
 		{
-			return ends.Contains(cell) ? 0 : int.MaxValue;
+			return ends.Contains(cell) ? 0 : PathGraph.CostForInvalidCell;
 		}
 
-		int ICustomMovementLayer.ExitMovementCost(ActorInfo a, LocomotorInfo li, CPos cell)
+		int ICustomMovementLayer.ExitMovementCost(LocomotorInfo li, CPos cell)
 		{
-			return ends.Contains(cell) ? 0 : int.MaxValue;
+			return ends.Contains(cell) ? 0 : PathGraph.CostForInvalidCell;
 		}
 
 		byte ICustomMovementLayer.GetTerrainIndex(CPos cell)

--- a/OpenRA.Mods.Common/Traits/World/JumpjetActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/JumpjetActorLayer.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Linq;
+using OpenRA.Mods.Common.Pathfinder;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -62,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		bool ICustomMovementLayer.EnabledForActor(ActorInfo a, LocomotorInfo li) { return li is JumpjetLocomotorInfo; }
+		bool ICustomMovementLayer.EnabledForLocomotor(LocomotorInfo li) { return li is JumpjetLocomotorInfo; }
 		byte ICustomMovementLayer.Index => CustomMovementLayerType.Jumpjet;
 		bool ICustomMovementLayer.InteractsWithDefaultLayer => true;
 		bool ICustomMovementLayer.ReturnToGroundLayerOnIdle => true;
@@ -86,16 +87,16 @@ namespace OpenRA.Mods.Common.Traits
 			return map.Ramp[cell] == 0;
 		}
 
-		int ICustomMovementLayer.EntryMovementCost(ActorInfo a, LocomotorInfo li, CPos cell)
+		int ICustomMovementLayer.EntryMovementCost(LocomotorInfo li, CPos cell)
 		{
 			var jli = (JumpjetLocomotorInfo)li;
-			return ValidTransitionCell(cell, jli) ? jli.JumpjetTransitionCost : int.MaxValue;
+			return ValidTransitionCell(cell, jli) ? jli.JumpjetTransitionCost : PathGraph.CostForInvalidCell;
 		}
 
-		int ICustomMovementLayer.ExitMovementCost(ActorInfo a, LocomotorInfo li, CPos cell)
+		int ICustomMovementLayer.ExitMovementCost(LocomotorInfo li, CPos cell)
 		{
 			var jli = (JumpjetLocomotorInfo)li;
-			return ValidTransitionCell(cell, jli) ? jli.JumpjetTransitionCost : int.MaxValue;
+			return ValidTransitionCell(cell, jli) ? jli.JumpjetTransitionCost : PathGraph.CostForInvalidCell;
 		}
 
 		byte ICustomMovementLayer.GetTerrainIndex(CPos cell)

--- a/OpenRA.Mods.Common/Traits/World/SubterraneanActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SubterraneanActorLayer.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Linq;
+using OpenRA.Mods.Common.Pathfinder;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -61,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		bool ICustomMovementLayer.EnabledForActor(ActorInfo a, LocomotorInfo li) { return li is SubterraneanLocomotorInfo; }
+		bool ICustomMovementLayer.EnabledForLocomotor(LocomotorInfo li) { return li is SubterraneanLocomotorInfo; }
 		byte ICustomMovementLayer.Index => CustomMovementLayerType.Subterranean;
 		bool ICustomMovementLayer.InteractsWithDefaultLayer => false;
 		bool ICustomMovementLayer.ReturnToGroundLayerOnIdle => true;
@@ -84,16 +85,16 @@ namespace OpenRA.Mods.Common.Traits
 			return map.Ramp[cell] == 0;
 		}
 
-		int ICustomMovementLayer.EntryMovementCost(ActorInfo a, LocomotorInfo li, CPos cell)
+		int ICustomMovementLayer.EntryMovementCost(LocomotorInfo li, CPos cell)
 		{
 			var sli = (SubterraneanLocomotorInfo)li;
-			return ValidTransitionCell(cell, sli) ? sli.SubterraneanTransitionCost : int.MaxValue;
+			return ValidTransitionCell(cell, sli) ? sli.SubterraneanTransitionCost : PathGraph.CostForInvalidCell;
 		}
 
-		int ICustomMovementLayer.ExitMovementCost(ActorInfo a, LocomotorInfo li, CPos cell)
+		int ICustomMovementLayer.ExitMovementCost(LocomotorInfo li, CPos cell)
 		{
 			var sli = (SubterraneanLocomotorInfo)li;
-			return ValidTransitionCell(cell, sli) ? sli.SubterraneanTransitionCost : int.MaxValue;
+			return ValidTransitionCell(cell, sli) ? sli.SubterraneanTransitionCost : PathGraph.CostForInvalidCell;
 		}
 
 		byte ICustomMovementLayer.GetTerrainIndex(CPos cell)

--- a/OpenRA.Mods.Common/Traits/World/TerrainTunnelLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainTunnelLayer.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Pathfinder;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -68,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		bool ICustomMovementLayer.EnabledForActor(ActorInfo a, LocomotorInfo li) { return enabled; }
+		bool ICustomMovementLayer.EnabledForLocomotor(LocomotorInfo li) { return enabled; }
 		byte ICustomMovementLayer.Index => CustomMovementLayerType.Tunnel;
 		bool ICustomMovementLayer.InteractsWithDefaultLayer => false;
 		bool ICustomMovementLayer.ReturnToGroundLayerOnIdle => true;
@@ -78,14 +79,14 @@ namespace OpenRA.Mods.Common.Traits
 			return cellCenters[cell];
 		}
 
-		int ICustomMovementLayer.EntryMovementCost(ActorInfo a, LocomotorInfo li, CPos cell)
+		int ICustomMovementLayer.EntryMovementCost(LocomotorInfo li, CPos cell)
 		{
-			return portals.Contains(cell) ? 0 : int.MaxValue;
+			return portals.Contains(cell) ? 0 : PathGraph.CostForInvalidCell;
 		}
 
-		int ICustomMovementLayer.ExitMovementCost(ActorInfo a, LocomotorInfo li, CPos cell)
+		int ICustomMovementLayer.ExitMovementCost(LocomotorInfo li, CPos cell)
 		{
-			return portals.Contains(cell) ? 0 : int.MaxValue;
+			return portals.Contains(cell) ? 0 : PathGraph.CostForInvalidCell;
 		}
 
 		byte ICustomMovementLayer.GetTerrainIndex(CPos cell)

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -403,9 +403,9 @@ namespace OpenRA.Mods.Common.Traits
 		bool InteractsWithDefaultLayer { get; }
 		bool ReturnToGroundLayerOnIdle { get; }
 
-		bool EnabledForActor(ActorInfo a, LocomotorInfo li);
-		int EntryMovementCost(ActorInfo a, LocomotorInfo li, CPos cell);
-		int ExitMovementCost(ActorInfo a, LocomotorInfo li, CPos cell);
+		bool EnabledForLocomotor(LocomotorInfo li);
+		int EntryMovementCost(LocomotorInfo li, CPos cell);
+		int ExitMovementCost(LocomotorInfo li, CPos cell);
 
 		byte GetTerrainIndex(CPos cell);
 		WPos CenterOfCell(CPos cell);


### PR DESCRIPTION
No implementations require the actor. Also change costs to short, as costs for single connections are currently represented as such within the locomotor.