### PR TITLE
Ignore modifiers when applying initial placement damage.

### DIFF
--- a/OpenRA.Mods.D2k/Traits/Buildings/D2kBuilding.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/D2kBuilding.cs
@@ -142,10 +142,10 @@ namespace OpenRA.Mods.D2k.Traits.Buildings
 			if (!info.StartOnThreshold)
 				return;
 
-			// Start with maximum damage applied
+			// Start with maximum damage applied, ignoring modifiers like player handicap
 			var delta = health.HP - damageThreshold;
 			if (delta > 0)
-				self.InflictDamage(self.World.WorldActor, new Damage(delta, info.DamageTypes));
+				health.InflictDamage(self, self.World.WorldActor, new Damage(delta, info.DamageTypes), true);
 		}
 
 		void ITick.Tick(Actor self)
@@ -153,7 +153,8 @@ namespace OpenRA.Mods.D2k.Traits.Buildings
 			if (totalTiles == safeTiles || health.HP <= damageThreshold || --damageTicks > 0)
 				return;
 
-			self.InflictDamage(self.World.WorldActor, new Damage(info.Damage, info.DamageTypes));
+			// Terrain damage should not change with modifiers like player handicap
+			health.InflictDamage(self, self.World.WorldActor, new Damage(info.Damage, info.DamageTypes), true);
 			damageTicks = info.DamageInterval;
 		}
 	}


### PR DESCRIPTION
Fixes #19633.