### PR TITLE
Restore threaded renderer.

### DIFF
--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -303,9 +303,15 @@ namespace OpenRA.Platforms.Default
 			// Run graphics rendering on a dedicated thread.
 			// The calling thread will then have more time to process other tasks, since rendering happens in parallel.
 			// If the calling thread is the main game thread, this means it can run more logic and render ticks.
-			var ctx = new Sdl2GraphicsContext(this);
-			ctx.InitializeOpenGL();
-			context = ctx;
+			// This is disabled when running in windowed mode on Windows because it breaks the ability to minimize/restore the window.
+			if (Platform.CurrentPlatform == PlatformType.Windows && windowMode == WindowMode.Windowed)
+			{
+				var ctx = new Sdl2GraphicsContext(this);
+				ctx.InitializeOpenGL();
+				context = ctx;
+			}
+			else
+				context = new ThreadedGraphicsContext(new Sdl2GraphicsContext(this), batchSize);
 
 			context.SetVSyncEnabled(Game.Settings.Graphics.VSync);
 


### PR DESCRIPTION
Fixes an embarrasing oversight from #19675 - I originally developed and tested the changes in an offline macOS 10.15 VM, but then deleted the wrong branch from the condition when manually repeating the changes in my main working copy 🤦.

The threaded renderer does work correctly now on macOS 10.15, but this unfortunately didn't fix the windows input issue after all.