### PR TITLE
Replace zenity select dropdown with a list

### DIFF
--- a/launch-game.sh
+++ b/launch-game.sh
@@ -17,12 +17,12 @@ if [ z"${*#*Game.Mod}" = z"$*" ]
 then
 	if command -v zenity > /dev/null
 	then
-		TITLE=$(zenity --forms --add-combo="" --combo-values="Red Alert|Tiberian Dawn|Dune 2000|Tiberian Sun" --text "Select mod" --title="" || echo "cancel")
-		if [ "$TITLE" = "cancel" ]; then exit 0
-		elif [ "$TITLE" = "Tiberian Dawn" ]; then MODARG='Game.Mod=cnc'
+		TITLE=$(zenity --title='Launch OpenRA' --list --hide-header --text 'Select game mod:' --column 'Game mod' 'Red Alert' 'Tiberian Dawn' 'Dune 2000' 'Tiberian Sun' || echo "cancel")
+		if [ "$TITLE" = "Tiberian Dawn" ]; then MODARG='Game.Mod=cnc'
 		elif [ "$TITLE" = "Dune 2000" ]; then MODARG='Game.Mod=d2k'
 		elif [ "$TITLE" = "Tiberian Sun" ]; then MODARG='Game.Mod=ts'
-		else MODARG='Game.Mod=ra'
+		elif [ "$TITLE" = "Red Alert" ]; then MODARG='Game.Mod=ra'
+		else exit 0
 		fi
 	else
 		echo "Please provide the Game.Mod=\$MOD argument (possible \$MOD values: ra, cnc, d2k, ts)"

--- a/launch-game.sh
+++ b/launch-game.sh
@@ -13,7 +13,7 @@ fi
 
 # Prompt for a mod to launch if one is not already specified
 MODARG=''
-if [ z"${*#*Game.Mod}" = z"$*" ]
+if [ z"${*#*Game.Mod=}" = z"$*" ]
 then
 	if command -v zenity > /dev/null
 	then


### PR DESCRIPTION
Change the zenity select dropdown to a list. The list has better keyboard usability because it is navigable with up/down arrows and pressing Enter submits the selected item. It is also searchable so you can press "D" to get straight to d2k. Unfortunately I couldn't find a way to make the first item selected by default. A list is better than a radio list because the radio list doesn't respond to any keyboard input (except Tab). I also added a title to the window "Launch OpenRA".

![Screenshot_20210927_185027](https://user-images.githubusercontent.com/1355810/134942631-0748a223-4154-4dd3-b16d-0af0c7af309a.png)
(items overflow because my display is scaled at 125%, it should be fine on 100%)

Supersedes #19463