### PR TITLE
ActorMap, ProximitySensor, avoid HashSet copy.

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -234,6 +234,7 @@ namespace OpenRA.Traits
 		void RemovePosition(Actor a, IOccupySpace ios);
 		void UpdatePosition(Actor a, IOccupySpace ios);
 		IEnumerable<Actor> ActorsInBox(WPos a, WPos b);
+		IEnumerable<Actor> ActorsInCircle(WPos origin, WDist r);
 
 		WDist LargestActorRadius { get; }
 		WDist LargestBlockingActorRadius { get; }

--- a/OpenRA.Game/WorldUtils.cs
+++ b/OpenRA.Game/WorldUtils.cs
@@ -36,10 +36,7 @@ namespace OpenRA
 
 		public static IEnumerable<Actor> FindActorsInCircle(this World world, WPos origin, WDist r)
 		{
-			// Target ranges are calculated in 2D, so ignore height differences
-			var vec = new WVec(r, r, WDist.Zero);
-			return world.ActorMap.ActorsInBox(origin - vec, origin + vec).Where(
-				a => (a.CenterPosition - origin).HorizontalLengthSquared <= r.LengthSquared);
+			return world.ActorMap.ActorsInCircle(origin, r);
 		}
 
 		public static bool ContainsTemporaryBlocker(this World world, CPos cell, Actor ignoreActor = null)

--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -144,13 +144,12 @@ namespace OpenRA.Mods.Common.Traits
 
 				var ra = Math.Abs(range.Length);
 				var rs = range.LengthSquared;
-				var vrs = ra == 0 ? 0 : vRange.LengthSquared;
+				var vrs = vRange.LengthSquared;
 
 				// PERF: Avoid LINQ.
-				foreach (var a in am.ActorsInBox(position.X - ra, position.Y - ra, position.X + ra, position.Y + ra))
+				foreach (var a in am.ActorsInCircle(position, new WDist(ra)))
 				{
-					var c = a.CenterPosition;
-					if ((c - position).HorizontalLengthSquared < rs && (vrs == 0 || a.World.Map.DistanceAboveTerrain(c).LengthSquared <= vrs))
+					if (vrs == 0 || a.World.Map.DistanceAboveTerrain(a.CenterPosition).LengthSquared <= vrs)
 						currentActors.Add(a);
 				}
 


### PR DESCRIPTION

avoid copying a HashSet each time. wouldn't this be more sensible? at the cost that the field can't be readonly. 

`HashSet.UnionWith` is also not cheap - since it will check for each element that it inserts if it does not already exist. 
