### PR TITLE
Remove GC.SuppressFinalize calls from classes without destructors

### DIFF
--- a/OpenRA.Game/Network/Connection.cs
+++ b/OpenRA.Game/Network/Connection.cs
@@ -375,7 +375,6 @@ namespace OpenRA.Network
 		void IDisposable.Dispose()
 		{
 			Dispose(true);
-			GC.SuppressFinalize(this);
 		}
 	}
 }

--- a/OpenRA.Game/Network/Connection.cs
+++ b/OpenRA.Game/Network/Connection.cs
@@ -357,7 +357,7 @@ namespace OpenRA.Network
 
 		public string ErrorMessage => errorMessage;
 
-		void Dispose(bool disposing)
+		void IDisposable.Dispose()
 		{
 			if (disposed)
 				return;
@@ -368,13 +368,7 @@ namespace OpenRA.Network
 			// This will mark the connection as no longer connected and the thread will terminate cleanly.
 			tcp?.Close();
 
-			if (disposing)
-				Recorder?.Dispose();
-		}
-
-		void IDisposable.Dispose()
-		{
-			Dispose(true);
+			Recorder?.Dispose();
 		}
 	}
 }

--- a/OpenRA.Platforms.Default/FrameBuffer.cs
+++ b/OpenRA.Platforms.Default/FrameBuffer.cs
@@ -144,7 +144,6 @@ namespace OpenRA.Platforms.Default
 		public void Dispose()
 		{
 			Dispose(true);
-			GC.SuppressFinalize(this);
 		}
 
 		void Dispose(bool disposing)

--- a/OpenRA.Platforms.Default/FrameBuffer.cs
+++ b/OpenRA.Platforms.Default/FrameBuffer.cs
@@ -143,16 +143,10 @@ namespace OpenRA.Platforms.Default
 
 		public void Dispose()
 		{
-			Dispose(true);
-		}
-
-		void Dispose(bool disposing)
-		{
 			if (disposed)
 				return;
 			disposed = true;
-			if (disposing)
-				texture.Dispose();
+			texture.Dispose();
 
 			OpenGL.glDeleteFramebuffers(1, ref framebuffer);
 			OpenGL.CheckGLError();

--- a/OpenRA.Platforms.Default/Sdl2HardwareCursor.cs
+++ b/OpenRA.Platforms.Default/Sdl2HardwareCursor.cs
@@ -47,7 +47,6 @@ namespace OpenRA.Platforms.Default
 		public void Dispose()
 		{
 			Dispose(true);
-			GC.SuppressFinalize(this);
 		}
 
 		void Dispose(bool disposing)

--- a/OpenRA.Platforms.Default/Sdl2HardwareCursor.cs
+++ b/OpenRA.Platforms.Default/Sdl2HardwareCursor.cs
@@ -46,11 +46,6 @@ namespace OpenRA.Platforms.Default
 
 		public void Dispose()
 		{
-			Dispose(true);
-		}
-
-		void Dispose(bool disposing)
-		{
 			if (Cursor != IntPtr.Zero)
 			{
 				SDL.SDL_FreeCursor(Cursor);

--- a/OpenRA.Platforms.Default/Texture.cs
+++ b/OpenRA.Platforms.Default/Texture.cs
@@ -207,11 +207,6 @@ namespace OpenRA.Platforms.Default
 
 		public void Dispose()
 		{
-			Dispose(true);
-		}
-
-		void Dispose(bool disposing)
-		{
 			if (disposed)
 				return;
 			disposed = true;

--- a/OpenRA.Platforms.Default/Texture.cs
+++ b/OpenRA.Platforms.Default/Texture.cs
@@ -208,7 +208,6 @@ namespace OpenRA.Platforms.Default
 		public void Dispose()
 		{
 			Dispose(true);
-			GC.SuppressFinalize(this);
 		}
 
 		void Dispose(bool disposing)

--- a/OpenRA.Platforms.Default/VertexBuffer.cs
+++ b/OpenRA.Platforms.Default/VertexBuffer.cs
@@ -98,7 +98,6 @@ namespace OpenRA.Platforms.Default
 		public void Dispose()
 		{
 			Dispose(true);
-			GC.SuppressFinalize(this);
 		}
 
 		void Dispose(bool disposing)

--- a/OpenRA.Platforms.Default/VertexBuffer.cs
+++ b/OpenRA.Platforms.Default/VertexBuffer.cs
@@ -97,11 +97,6 @@ namespace OpenRA.Platforms.Default
 
 		public void Dispose()
 		{
-			Dispose(true);
-		}
-
-		void Dispose(bool disposing)
-		{
 			if (disposed)
 				return;
 			disposed = true;


### PR DESCRIPTION
**Summary**:

There are several classes in codebase which has **GC.SuppressFinalize** call in **Dispose** implementation but they doesn't have destructors so such calls has no effect.
My changes are based on JetBrains analysis (https://www.jetbrains.com/help/rider/GCSuppressFinalizeForTypeWithoutDestructor.html).

Also, I see we can remove 'Dispose with disposing flag' implementations from these classes (because 'disposing' flag is always true; it usually used in destructors with different value), but such changes are more wide and harder to review.

I can imagine only one case when that PR is not suitable for codebase - if someone added destructor to these classes after GC.SuppressFinalize removal behaviour will be different. But I consider such changes as very rare in common.

**Contribution checks**:
- [x] only required changes
- [x] no code style violations (only deletions)
- [x] `make test` and `make check` passes