### PR TITLE
Remove unreachable code in TransformsIntoTransforms

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoTransforms.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoTransforms.cs
@@ -39,9 +39,6 @@ namespace OpenRA.Mods.Common.Traits
 			if (!order.Queued || !(self.CurrentActivity is Transform currentTransform))
 				return;
 
-			if (!order.Queued)
-				currentTransform.NextActivity?.Cancel(self);
-
 			currentTransform.Queue(new IssueOrderAfterTransform("DeployTransform", order.Target));
 
 			self.ShowTargetLines();


### PR DESCRIPTION
Closes #18518.

The last remaining issue of that ticket was the unreachable code in TransformsIntoTransforms. The if check above already makes the method return if `!order.Queued` so this code would never be reached.