### PR TITLE
Remove hacks around checking sync while disposing the shellmap

### DIFF
--- a/OpenRA.Game/Sync.cs
+++ b/OpenRA.Game/Sync.cs
@@ -181,10 +181,10 @@ namespace OpenRA
 		public static T RunUnsynced<T>(bool checkSyncHash, World world, Func<T> fn)
 		{
 			// PERF: Detect sync changes in top level entry point only. Do not recalculate sync hash during reentry.
-			if (inUnsyncedCode || world == null)
+			if (!checkSyncHash || inUnsyncedCode || world == null)
 				return fn();
 
-			var sync = checkSyncHash ? world.SyncHash() : 0;
+			var sync = world.SyncHash();
 			inUnsyncedCode = true;
 
 			try
@@ -194,7 +194,7 @@ namespace OpenRA
 			finally
 			{
 				inUnsyncedCode = false;
-				if (checkSyncHash && sync != world.SyncHash())
+				if (sync != world.SyncHash())
 					throw new InvalidOperationException("RunUnsynced: sync-changing code may not run here");
 			}
 		}

--- a/OpenRA.Game/Sync.cs
+++ b/OpenRA.Game/Sync.cs
@@ -194,7 +194,10 @@ namespace OpenRA
 			finally
 			{
 				inUnsyncedCode = false;
-				if (sync != world.SyncHash())
+
+				// When the world is disposing all actors and effects have been removed
+				// So do not check the hash for a disposing world since it definitively has changed
+				if (!world.Disposing && sync != world.SyncHash())
 					throw new InvalidOperationException("RunUnsynced: sync-changing code may not run here");
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -70,9 +70,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				Action<string> afterSave = uid =>
 				{
-					// HACK: Work around a synced-code change check.
-					// It's not clear why this is needed here, but not in the other places that load maps.
-					Game.RunAfterTick(() => Game.LoadEditor(uid));
+					Game.LoadEditor(uid);
 
 					Ui.CloseWindow();
 					onSelect(uid);

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -343,9 +343,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void LoadMapIntoEditor(string uid)
 		{
-			// HACK: Work around a synced-code change check.
-			// It's not clear why this is needed here, but not in the other places that load maps.
-			Game.RunAfterTick(() => Game.LoadEditor(uid));
+			Game.LoadEditor(uid);
 
 			DiscordService.UpdateStatus(DiscordState.InMapEditor);
 


### PR DESCRIPTION
#19657 made me investigate why those hacks/workarounds are needed. It turns out the sync of the world changes because all actors and effects are dropped from the (shellmap) world when it is being disposed this tick.
This PR comes with three commits:
- We bail early when checking around unsynced code is not enabled, saving us from running the function inside try catch and making the code easier to read imo.
- We no longer trigger an exception when the world is disposing (and thus the sync hash changed). I don't think it makes sense to have a check for sync changes when the world is about to get thrown out anyway.
- We can now remove the `HACK`s and directly load into the editor.