### PR TITLE
Update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 A Libre/Free Real Time Strategy game engine supporting early Westwood classics.
 
-* Website: [http://www.openra.net](http://www.openra.net)
-* IRC: \#openra on irc.freenode.net
+* Website: [https://www.openra.net](https://www.openra.net)
+* IRC: [#openra on Libera.Chat](ircs://irc.libera.chat:6697/openra)
 * Repository: [https://github.com/OpenRA/OpenRA](https://github.com/OpenRA/OpenRA) ![Continuous Integration](https://github.com/OpenRA/OpenRA/workflows/Continuous%20Integration/badge.svg)
 
-Please read the [FAQ](http://wiki.openra.net/FAQ) in our [Wiki](http://wiki.openra.net) and report problems at [http://bugs.openra.net](http://bugs.openra.net).
+Please read the [FAQ](https://github.com/OpenRA/OpenRA/wiki/FAQ) in our [Wiki](https://github.com/OpenRA/OpenRA/wiki) and report problems at [https://github.com/OpenRA/OpenRA/issues](https://github.com/OpenRA/OpenRA/issues).
 
-Join the [Forums](https://forum.openra.net/) for discussion.
+Join the [Forum](https://forum.openra.net/) for discussion.
 
 ## Play
 
@@ -24,29 +24,29 @@ Check our [Playing the Game](https://github.com/OpenRA/OpenRA/wiki/Playing-the-g
 
 ## Contribute
 
-* Please read [INSTALL.md](https://github.com/OpenRA/OpenRA/blob/bleed/INSTALL.md) and [Compiling](http://wiki.openra.net/Compiling) on how to set up an OpenRA development environment.
-* See [Hacking](http://wiki.openra.net/Hacking) for a (now very outdated) overview of the engine.
+* Please read [INSTALL.md](https://github.com/OpenRA/OpenRA/blob/bleed/INSTALL.md) and [Compiling](https://github.com/OpenRA/OpenRA/wiki/Compiling) on how to set up an OpenRA development environment.
+* See [Hacking](https://github.com/OpenRA/OpenRA/wiki/Hacking) for a (now very outdated) overview of the engine.
 * Read and follow our [Code of Conduct](https://github.com/OpenRA/OpenRA/blob/bleed/CODE_OF_CONDUCT.md).
 * To get your patches merged, please adhere to the [Contributing](https://github.com/OpenRA/OpenRA/blob/bleed/CONTRIBUTING.md) guidelines.
 
 ## Mapping
 
-* We offer a [Mapping](http://wiki.openra.net/Mapping) Tutorial as you can change gameplay drastically with custom rules.
-* For scripted mission have a look at the [Lua API](http://wiki.openra.net/Lua-API).
-* If you want to share your maps with the community, upload them at the [OpenRA Resource Center](http://resource.openra.net).
+* We offer a [Mapping](https://github.com/OpenRA/OpenRA/wiki/Mapping) Tutorial as you can change gameplay drastically with custom rules.
+* For scripted mission have a look at the [Lua API](https://docs.openra.net/en/latest/release/lua/).
+* If you want to share your maps with the community, upload them at the [OpenRA Resource Center](https://resource.openra.net).
 
 ## Modding
 
-* Download a copy of the [OpenRA Mod SDK](https://github.com/OpenRA/OpenRAModSDK/) to start your own mod.
-* Check the [Modding Guide](http://wiki.openra.net/Modding-Guide) to create your own classic RTS.
+* Download a copy of the [OpenRA Mod SDK](https://github.com/OpenRA/OpenRAModSDK) to start your own mod.
+* Check the [Modding Guide](https://github.com/OpenRA/OpenRA/wiki/Modding-Guide) to create your own classic RTS.
 * There exists an auto-generated [Trait documentation](https://docs.openra.net/en/latest/release/traits/) to get started with yaml files.
-* Some hints on how to create new OpenRA compatible [Pixelart](http://wiki.openra.net/Pixelart).
-* Upload total conversions at [our ModDB profile](http://www.moddb.com/games/openra/mods).
+* Some hints on how to create new OpenRA compatible [Pixelart](https://github.com/OpenRA/OpenRA/wiki/Pixelart).
+* Upload total conversions at [our Mod DB profile](https://www.moddb.com/games/openra/mods).
 
 ## Support
 
 * Sponsor a [mirror server](https://github.com/OpenRA/OpenRAWeb/tree/master/content/packages) if you have some bandwidth to spare.
-* You can immediately set up a [Dedicated](http://wiki.openra.net/Dedicated) Game Server.
+* You can immediately set up a [Dedicated](https://github.com/OpenRA/OpenRA/wiki/Dedicated) Game Server.
 
 ## License
 Copyright 2007-2021 The OpenRA Developers (see [AUTHORS](https://github.com/OpenRA/OpenRA/blob/bleed/AUTHORS))


### PR DESCRIPTION
- _http_ `->` _https_ where appropriate
- _wiki.openra.net_ `->` _https://github.com/OpenRA/OpenRA/wiki_
- _bugs.openra.net_ `->` _https://github.com/OpenRA/OpenRA/issues_
- the IRC channel is now on Libera.Chat + make it into a URI

This is in order to be consistent (one link to GitHub wiki already
exists), reflect reality, as well as avoid unnecessary redirects.