### PR TITLE
Initialize the Discord rich presence with an empty presence

### DIFF
--- a/OpenRA.Mods.Common/DiscordService.cs
+++ b/OpenRA.Mods.Common/DiscordService.cs
@@ -79,6 +79,9 @@ namespace OpenRA.Mods.Common
 
 			client.SetSubscription(EventType.Join | EventType.JoinRequest);
 			client.Initialize();
+
+			// Set an initial value for the rich presence to avoid a NRE in the library
+			client.SetPresence(new RichPresence());
 		}
 
 		void OnJoinRequested(object sender, JoinRequestMessage args)

--- a/OpenRA.Mods.Common/Lint/CheckTraitLocation.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTraitLocation.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Linq;
-using DiscordRPC.Helper;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint


### PR DESCRIPTION
This fixes the "issue" from #19718: When debugging in VS with "Just my code" disabled VS will break on an exception thrown inside the DiscordRPC library. We can avoid this by initializing the rich presence with the empty/default presence. (We're then also following their examples in providing a presence directly after calling `client.initialize`.)
The first commit also removes a bogus import (no need for DiscordRPC in update rules).