### PR TITLE
Exempt D2k Harvesters from slowness modifiers applied when damaged

### DIFF
--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -102,6 +102,8 @@ harvester:
 		Margin: 1, 4
 		RequiresSelection: true
 		PipCount: 7
+	-GrantConditionOnDamageState@HEAVY:
+	-SpeedMultiplier@HEAVYDAMAGE:
 
 trike:
 	Inherits: ^Vehicle


### PR DESCRIPTION
Basically reverts a part of #19468 because of https://github.com/OpenRA/OpenRA/issues/19454#issuecomment-935885134.