### PR TITLE
Use named pathfinding constants.

### DIFF
--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -191,7 +191,7 @@ namespace OpenRA.Mods.Common.Activities
 				.WithCustomCost(loc =>
 				{
 					if ((loc - searchFromLoc).LengthSquared > searchRadiusSquared)
-						return PathGraph.CostForInvalidCell;
+						return PathGraph.PathCostForInvalidPath;
 
 					// Add a cost modifier to harvestable cells to prefer resources that are closer to the refinery.
 					// This reduces the tendancy for harvesters to move in straight lines

--- a/OpenRA.Mods.Common/Pathfinder/CellInfoLayerPool.cs
+++ b/OpenRA.Mods.Common/Pathfinder/CellInfoLayerPool.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		{
 			defaultLayer =
 				CellLayer<CellInfo>.CreateInstance(
-					mpos => new CellInfo(int.MaxValue, int.MaxValue, mpos.ToCPos(map), CellStatus.Unvisited),
+					mpos => new CellInfo(PathGraph.PathCostForInvalidPath, PathGraph.PathCostForInvalidPath, mpos.ToCPos(map), CellStatus.Unvisited),
 					new Size(map.MapSize.X, map.MapSize.Y),
 					map.Grid.Type);
 		}

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -108,7 +108,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			var currentCell = Graph[currentMinNode];
 			Graph[currentMinNode] = new CellInfo(currentCell.CostSoFar, currentCell.EstimatedTotal, currentCell.PreviousPos, CellStatus.Closed);
 
-			if (Graph.CustomCost != null && Graph.CustomCost(currentMinNode) == PathGraph.CostForInvalidCell)
+			if (Graph.CustomCost != null && Graph.CustomCost(currentMinNode) == PathGraph.PathCostForInvalidPath)
 				return currentMinNode;
 
 			foreach (var connection in Graph.GetConnections(currentMinNode))

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
@@ -12,6 +12,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Pathfinder;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -210,7 +211,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			bool CanEnterCell(Actor self, CPos cell)
 			{
-				if (mobile.locomotor.MovementCostForCell(cell) == short.MaxValue)
+				if (mobile.locomotor.MovementCostForCell(cell) == PathGraph.MovementCostForUnreachableCell)
 					return false;
 
 				return mobile.locomotor.CanMoveFreelyInto(self, cell, BlockedByActor.All, null);

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -206,7 +206,7 @@ namespace OpenRA.Mods.Common.Traits
 
 					// Too many harvesters clogs up the refinery's delivery location:
 					if (occupancy >= Info.MaxUnloadQueue)
-						return PathGraph.CostForInvalidCell;
+						return PathGraph.PathCostForInvalidPath;
 
 					// Prefer refineries with less occupancy (multiplier is to offset distance cost):
 					return occupancy * Info.UnloadQueueCostModifier;

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Traits
 				locomotor = world.WorldActor.TraitsImplementing<Locomotor>()
 				   .SingleOrDefault(l => l.Info.Name == Locomotor);
 
-			if (locomotor.MovementCostForCell(cell) == short.MaxValue)
+			if (locomotor.MovementCostForCell(cell) == PathGraph.MovementCostForUnreachableCell)
 				return false;
 
 			return locomotor.CanMoveFreelyInto(self, cell, subCell, check, ignoreActor);
@@ -520,7 +520,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool CanExistInCell(CPos cell)
 		{
-			return Locomotor.MovementCostForCell(cell) != short.MaxValue;
+			return Locomotor.MovementCostForCell(cell) != PathGraph.MovementCostForUnreachableCell;
 		}
 
 		public bool CanEnterCell(CPos cell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
@@ -1020,7 +1020,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (mobile.IsTraitPaused
 					|| !self.World.Map.Contains(location)
 					|| (!explored && !locomotorInfo.MoveIntoShroud)
-					|| (explored && mobile.Locomotor.MovementCostForCell(location) == short.MaxValue))
+					|| (explored && mobile.Locomotor.MovementCostForCell(location) == PathGraph.MovementCostForUnreachableCell))
 					cursor = mobile.Info.BlockedCursor;
 				else if (!explored || !mobile.Info.TerrainCursors.TryGetValue(self.World.Map.GetTerrainInfo(location).Type, out cursor))
 					cursor = mobile.Info.Cursor;

--- a/OpenRA.Mods.Common/Traits/World/ElevatedBridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ElevatedBridgeLayer.cs
@@ -80,14 +80,14 @@ namespace OpenRA.Mods.Common.Traits
 			return cellCenters[cell];
 		}
 
-		int ICustomMovementLayer.EntryMovementCost(LocomotorInfo li, CPos cell)
+		short ICustomMovementLayer.EntryMovementCost(LocomotorInfo li, CPos cell)
 		{
-			return ends.Contains(cell) ? 0 : PathGraph.CostForInvalidCell;
+			return ends.Contains(cell) ? (short)0 : PathGraph.MovementCostForUnreachableCell;
 		}
 
-		int ICustomMovementLayer.ExitMovementCost(LocomotorInfo li, CPos cell)
+		short ICustomMovementLayer.ExitMovementCost(LocomotorInfo li, CPos cell)
 		{
-			return ends.Contains(cell) ? 0 : PathGraph.CostForInvalidCell;
+			return ends.Contains(cell) ? (short)0 : PathGraph.MovementCostForUnreachableCell;
 		}
 
 		byte ICustomMovementLayer.GetTerrainIndex(CPos cell)

--- a/OpenRA.Mods.Common/Traits/World/JumpjetActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/JumpjetActorLayer.cs
@@ -87,16 +87,16 @@ namespace OpenRA.Mods.Common.Traits
 			return map.Ramp[cell] == 0;
 		}
 
-		int ICustomMovementLayer.EntryMovementCost(LocomotorInfo li, CPos cell)
+		short ICustomMovementLayer.EntryMovementCost(LocomotorInfo li, CPos cell)
 		{
 			var jli = (JumpjetLocomotorInfo)li;
-			return ValidTransitionCell(cell, jli) ? jli.JumpjetTransitionCost : PathGraph.CostForInvalidCell;
+			return ValidTransitionCell(cell, jli) ? jli.JumpjetTransitionCost : PathGraph.MovementCostForUnreachableCell;
 		}
 
-		int ICustomMovementLayer.ExitMovementCost(LocomotorInfo li, CPos cell)
+		short ICustomMovementLayer.ExitMovementCost(LocomotorInfo li, CPos cell)
 		{
 			var jli = (JumpjetLocomotorInfo)li;
-			return ValidTransitionCell(cell, jli) ? jli.JumpjetTransitionCost : PathGraph.CostForInvalidCell;
+			return ValidTransitionCell(cell, jli) ? jli.JumpjetTransitionCost : PathGraph.MovementCostForUnreachableCell;
 		}
 
 		byte ICustomMovementLayer.GetTerrainIndex(CPos cell)

--- a/OpenRA.Mods.Common/Traits/World/JumpjetLocomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/JumpjetLocomotor.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class JumpjetLocomotorInfo : LocomotorInfo
 	{
 		[Desc("Pathfinding cost for taking off or landing.")]
-		public readonly int JumpjetTransitionCost = 0;
+		public readonly short JumpjetTransitionCost = 0;
 
 		[Desc("The terrain types that this actor can transition on. Leave empty to allow any.")]
 		public readonly HashSet<string> JumpjetTransitionTerrainTypes = new HashSet<string>();

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -167,7 +167,7 @@ namespace OpenRA.Mods.Common.Traits
 				// make some progress on the first search
 				var p = fromSrc.Expand();
 				if (fromDest.Graph[p].Status == CellStatus.Closed &&
-					fromDest.Graph[p].CostSoFar < int.MaxValue)
+					fromDest.Graph[p].CostSoFar != PathGraph.PathCostForInvalidPath)
 				{
 					path = MakeBidiPath(fromSrc, fromDest, p);
 					break;
@@ -176,7 +176,7 @@ namespace OpenRA.Mods.Common.Traits
 				// make some progress on the second search
 				var q = fromDest.Expand();
 				if (fromSrc.Graph[q].Status == CellStatus.Closed &&
-					fromSrc.Graph[q].CostSoFar < int.MaxValue)
+					fromSrc.Graph[q].CostSoFar != PathGraph.PathCostForInvalidPath)
 				{
 					path = MakeBidiPath(fromSrc, fromDest, q);
 					break;

--- a/OpenRA.Mods.Common/Traits/World/SubterraneanActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SubterraneanActorLayer.cs
@@ -85,16 +85,16 @@ namespace OpenRA.Mods.Common.Traits
 			return map.Ramp[cell] == 0;
 		}
 
-		int ICustomMovementLayer.EntryMovementCost(LocomotorInfo li, CPos cell)
+		short ICustomMovementLayer.EntryMovementCost(LocomotorInfo li, CPos cell)
 		{
 			var sli = (SubterraneanLocomotorInfo)li;
-			return ValidTransitionCell(cell, sli) ? sli.SubterraneanTransitionCost : PathGraph.CostForInvalidCell;
+			return ValidTransitionCell(cell, sli) ? sli.SubterraneanTransitionCost : PathGraph.MovementCostForUnreachableCell;
 		}
 
-		int ICustomMovementLayer.ExitMovementCost(LocomotorInfo li, CPos cell)
+		short ICustomMovementLayer.ExitMovementCost(LocomotorInfo li, CPos cell)
 		{
 			var sli = (SubterraneanLocomotorInfo)li;
-			return ValidTransitionCell(cell, sli) ? sli.SubterraneanTransitionCost : PathGraph.CostForInvalidCell;
+			return ValidTransitionCell(cell, sli) ? sli.SubterraneanTransitionCost : PathGraph.MovementCostForUnreachableCell;
 		}
 
 		byte ICustomMovementLayer.GetTerrainIndex(CPos cell)

--- a/OpenRA.Mods.Common/Traits/World/SubterraneanLocomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/SubterraneanLocomotor.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class SubterraneanLocomotorInfo : LocomotorInfo
 	{
 		[Desc("Pathfinding cost for submerging or reemerging.")]
-		public readonly int SubterraneanTransitionCost = 0;
+		public readonly short SubterraneanTransitionCost = 0;
 
 		[Desc("The terrain types that this actor can transition on. Leave empty to allow any.")]
 		public readonly HashSet<string> SubterraneanTransitionTerrainTypes = new HashSet<string>();
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Can this actor transition on slopes?")]
 		public readonly bool SubterraneanTransitionOnRamps = false;
 
-		[Desc("Depth at which the subterranian condition is applied.")]
+		[Desc("Depth at which the subterranean condition is applied.")]
 		public readonly WDist SubterraneanTransitionDepth = new WDist(-1024);
 
 		public override bool DisableDomainPassabilityCheck => true;

--- a/OpenRA.Mods.Common/Traits/World/TerrainTunnelLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainTunnelLayer.cs
@@ -79,14 +79,14 @@ namespace OpenRA.Mods.Common.Traits
 			return cellCenters[cell];
 		}
 
-		int ICustomMovementLayer.EntryMovementCost(LocomotorInfo li, CPos cell)
+		short ICustomMovementLayer.EntryMovementCost(LocomotorInfo li, CPos cell)
 		{
-			return portals.Contains(cell) ? 0 : PathGraph.CostForInvalidCell;
+			return portals.Contains(cell) ? (short)0 : PathGraph.MovementCostForUnreachableCell;
 		}
 
-		int ICustomMovementLayer.ExitMovementCost(LocomotorInfo li, CPos cell)
+		short ICustomMovementLayer.ExitMovementCost(LocomotorInfo li, CPos cell)
 		{
-			return portals.Contains(cell) ? 0 : PathGraph.CostForInvalidCell;
+			return portals.Contains(cell) ? (short)0 : PathGraph.MovementCostForUnreachableCell;
 		}
 
 		byte ICustomMovementLayer.GetTerrainIndex(CPos cell)

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -404,8 +404,8 @@ namespace OpenRA.Mods.Common.Traits
 		bool ReturnToGroundLayerOnIdle { get; }
 
 		bool EnabledForLocomotor(LocomotorInfo li);
-		int EntryMovementCost(LocomotorInfo li, CPos cell);
-		int ExitMovementCost(LocomotorInfo li, CPos cell);
+		short EntryMovementCost(LocomotorInfo li, CPos cell);
+		short ExitMovementCost(LocomotorInfo li, CPos cell);
 
 		byte GetTerrainIndex(CPos cell);
 		WPos CenterOfCell(CPos cell);


### PR DESCRIPTION
- Rename CostForInvalidCell to PathCostForInvalidPath
- Add MovementCostForUnreachableCell
- Update usages of int.MaxValue and short.Maxvalue to use named constants where relevant.
- Update costs on ICustomMovementLayer to return short, for consistency with costs from Locomotor.

----

I did attempt to look into isolating the use of `short` to within `Locomotor` per https://github.com/OpenRA/OpenRA/pull/19693#issuecomment-927273675 - but it bleeds out through the terrain tile as well and wasn't proving as easy to isolate as I had hoped. Instead, let's at least use a named constant everywhere to make tripping up on it less likely. I have also changed `ICustomMovementLayer` costs to `short` to match the costs in `Locomotor` just for niceness.