### PR TITLE
World, SyncHash, cache per tick.

### DIFF
--- a/OpenRA.Game/Sync.cs
+++ b/OpenRA.Game/Sync.cs
@@ -112,7 +112,7 @@ namespace OpenRA
 
 		public static int HashCPos(CPos i2)
 		{
-			return ((i2.X * 5) ^ (i2.Y * 3)) / 4;
+			return i2.Bits;
 		}
 
 		public static int HashCVec(CVec i2)
@@ -142,10 +142,11 @@ namespace OpenRA
 					return (int)(t.Actor.ActorID << 16) * 0x567;
 
 				case TargetType.FrozenActor:
-					if (t.FrozenActor.Actor == null)
+					var actor = t.FrozenActor.Actor;
+					if (actor == null)
 						return 0;
 
-					return (int)(t.FrozenActor.Actor.ActorID << 16) * 0x567;
+					return (int)(actor.ActorID << 16) * 0x567;
 
 				case TargetType.Terrain:
 					return HashUsingHashCode(t.CenterPosition);


### PR DESCRIPTION

- `HashCPos` return CPos.Bits. So many fields are XOR-ed to calculate the hash I don't see how it could harm to just use the int.
- `HashCVec` avoid second lookup of `FrozenActor` and `Actor`. IL showed that 2 calls were being made.
- SyncHash is called (at least 8) times per WorldTIck. Cache the sync hash. Assuming it can only change during World/Logic ticks. 

Perhaps the cause is that `OrderManager.ProcessOrders` calls `World.SyncHash` too often?

In the case that it can also change during render ticks - i.e. due to effects. Then I'd propose to use a different trait for that and only update that part of the hash each call to SyncHash.

Alternative could be to calculate a sync hash at the end of each game tick - over using a cached value.

I can imagine you do not want his as it might cause out of syncs to be spotted one world tick later - but calculating a world hash 8 times each game tick seems like overkill. Also because a third of CPU time was spent in calculating it.











