### PR TITLE
Fixed the Windows make script always building in Release

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -10,7 +10,9 @@ function All-Command
 		return
 	}
 
-	dotnet build -c Release --nologo -p:TargetPlatform=win-x64
+	Write-Host "Building in" $configuration "configuration..." -ForegroundColor Cyan
+	dotnet build -c $configuration --nologo -p:TargetPlatform=win-x64
+
 	if ($lastexitcode -ne 0)
 	{
 		Write-Host "Build failed. If just the development tools failed to build, try installing Visual Studio. You may also still be able to run the game." -ForegroundColor Red
@@ -233,6 +235,12 @@ else
 
 $env:ENGINE_DIR = ".."
 $utilityPath = "bin\OpenRA.Utility.exe"
+
+$configuration = "Release"
+if ($args.Contains("CONFIGURATION=Debug"))
+{
+	$configuration = "Debug"
+}
 
 $execute = $command
 if ($command.Length -gt 1)


### PR DESCRIPTION
This is a follow-up to #19379, which aimed to "provide an easy debug option for VSCode developers", but only did so for non-Windows users. VSCode has been building in Release mode for ever and continued to do so on Windows after that PR.
Ideally this would be the other way around, with `Release` being the optional profile and `Debug` being the default, but that is more likely to break a preexisting condition somewhere.