### PR TITLE
Fix sync assertions failing when changing OrderGenerators

### DIFF
--- a/OpenRA.Game/Sync.cs
+++ b/OpenRA.Game/Sync.cs
@@ -181,10 +181,10 @@ namespace OpenRA
 		public static T RunUnsynced<T>(bool checkSyncHash, World world, Func<T> fn)
 		{
 			// PERF: Detect sync changes in top level entry point only. Do not recalculate sync hash during reentry.
-			if (!checkSyncHash || inUnsyncedCode || world == null)
+			if (inUnsyncedCode || world == null)
 				return fn();
 
-			var sync = world.SyncHash();
+			var sync = checkSyncHash ? world.SyncHash() : 0;
 			inUnsyncedCode = true;
 
 			try
@@ -197,7 +197,7 @@ namespace OpenRA
 
 				// When the world is disposing all actors and effects have been removed
 				// So do not check the hash for a disposing world since it definitively has changed
-				if (!world.Disposing && sync != world.SyncHash())
+				if (checkSyncHash && !world.Disposing && sync != world.SyncHash())
 					throw new InvalidOperationException("RunUnsynced: sync-changing code may not run here");
 			}
 		}

--- a/OpenRA.Game/Sync.cs
+++ b/OpenRA.Game/Sync.cs
@@ -187,6 +187,7 @@ namespace OpenRA
 			var sync = checkSyncHash ? world.SyncHash() : 0;
 			inUnsyncedCode = true;
 
+			// Running this inside a try with a finally statement means isUnsyncedCode is set to false again as soon as fn completes
 			try
 			{
 				return fn();


### PR DESCRIPTION
Closes #19735. Reproduction case is disabling(!) "Check Sync around Unsynced Code", starting a game and selecting the mcv, which changes OGs and triggers https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Game/World.cs#L153. That in turn causes a crash because of [1dc0a60](https://github.com/OpenRA/OpenRA/commit/1dc0a603c75132776f669789e89596b15245ea26) since which we no longer set `inUnsyncedCode`, so https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Game/Sync.cs#L207-L208 will always throw.