### PR TITLE
Fix unknown/hidden locations being displayed as "false" in server tab

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -678,7 +678,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						if (location != null)
 						{
 							var font = Game.Renderer.Fonts[location.Font];
-							var label = WidgetUtils.TruncateText(game.Location, location.Bounds.Width, font);
+							var label = WidgetUtils.TruncateText(game.Location == "false" ? "Unknown" : game.Location, location.Bounds.Width, font);
 							location.GetText = () => label;
 							location.GetColor = () => canJoin ? location.TextColor : incompatibleGameColor;
 						}


### PR DESCRIPTION
Replaces the Location "false" with "Unknown". This makes it feel much less like a bug:
![grafik](https://user-images.githubusercontent.com/21260178/138315127-012f5343-2885-4747-a383-d9063c4693f8.png)
