### PR TITLE
Fix kill statistics regarding walls and neutral/creep actors

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -233,16 +233,21 @@ namespace OpenRA.Mods.Common.Traits
 			var attackerStats = e.Attacker.Owner.PlayerActor.Trait<PlayerStatistics>();
 			if (self.Info.HasTraitInfo<BuildingInfo>())
 			{
-				attackerStats.BuildingsKilled++;
+				if (!self.Owner.NonCombatant)
+					attackerStats.BuildingsKilled++;
+
 				playerStats.BuildingsDead++;
 			}
 			else if (self.Info.HasTraitInfo<IPositionableInfo>())
 			{
-				attackerStats.UnitsKilled++;
+				if (!self.Owner.NonCombatant)
+					attackerStats.UnitsKilled++;
+
 				playerStats.UnitsDead++;
 			}
 
-			attackerStats.KillsCost += cost;
+			if (!self.Owner.NonCombatant)
+				attackerStats.KillsCost += cost;
 		}
 
 		void INotifyCreated.Created(Actor self)

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -916,8 +916,6 @@
 		Terrain: Wall
 	MapEditorData:
 		Categories: Wall
-	UpdatesPlayerStatistics:
-		AddToAssetsValue: false
 
 ^Tree:
 	Inherits@1: ^SpriteActor

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -664,8 +664,6 @@ wall:
 		Cost: 20
 	CustomSellValue:
 		Value: 0
-	UpdatesPlayerStatistics:
-		AddToAssetsValue: false
 	Tooltip:
 		Name: Concrete Wall
 		GenericName: Structure

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -793,8 +793,6 @@
 		Terrain: Wall
 	MapEditorData:
 		Categories: Wall
-	UpdatesPlayerStatistics:
-		AddToAssetsValue: false
 
 ^TechBuilding:
 	Inherits: ^BasicBuilding


### PR DESCRIPTION
Closes #19753.

First commit removes all `UpdatesPlayerStatistics` occurences concerning walls. With the second commit, destroyed actors owned by noncombatant players (neutral, creeps) are not counted to the kills statistic.