### PR TITLE
Display error message instead of stack trace in battlefield news when failing to fetch news

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -312,7 +312,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							{
 								Game.RunAfterTick(() => // run on the main thread
 								{
-									SetNewsStatus($"Failed to retrieve news: {e}");
+									SetNewsStatus($"Failed to retrieve news: {e.Message}");
 								});
 							}
 						});


### PR DESCRIPTION
Closes #19684.

The original issue actually is intended behavior, as described in this [comment](https://github.com/OpenRA/OpenRA/issues/19684#issuecomment-952609677).