### PR TITLE
TD Balance Fall 2021

### DIFF
--- a/mods/cnc/maps/nod07c/map.yaml
+++ b/mods/cnc/maps/nod07c/map.yaml
@@ -708,7 +708,7 @@ Actors:
 		Location: 49,52
 		Owner: GDI
 		ScriptTags: GDIBuilding
-	GDIBuilding5: nuke
+	GDIBuilding5: nuk2
 		Location: 56,53
 		Owner: GDI
 		ScriptTags: GDIBuilding

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -111,8 +111,8 @@ HELI:
 	SpawnActorOnDeath:
 		Actor: HELI.Husk
 	ReloadAmmoPool:
-		Delay: 40
-		Count: 1
+		Delay: 70
+		Count: 2
 	Selectable:
 		DecorationBounds: 1280, 1024
 	WithAmmoPipsDecoration:
@@ -140,7 +140,7 @@ ORCA:
 		TurnSpeed: 28
 		Speed: 186
 	Health:
-		HP: 9000
+		HP: 10000
 	Armor:
 		Type: Light
 	RevealsShroud:

--- a/mods/cnc/rules/campaign-maprules.yaml
+++ b/mods/cnc/rules/campaign-maprules.yaml
@@ -92,3 +92,8 @@ MoneyCrate:
 TRUCK:
 	Buildable:
 		Prerequisites: ~disabled
+
+MISS:
+	Inherits: ^CivBuilding
+	RevealsShroud:
+		Range: 3c0

--- a/mods/cnc/rules/campaign-tooltips.yaml
+++ b/mods/cnc/rules/campaign-tooltips.yaml
@@ -66,6 +66,8 @@ MISS:
 	Tooltip:
 		GenericVisibility: None
 		ShowOwnerRow: False
+	-TooltipDescription@ally:
+	-TooltipDescription@other:		
 
 BIO:
 	-TooltipDescription@ally:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -508,7 +508,7 @@
 	Armor:
 		Type: Wood
 	Buildable:
-		Queue: Biolab
+		Queue: Infantry.GDI, Infantry.Nod
 		BuildPaletteOrder: 50
 		Prerequisites: ~disabled
 	Valued:
@@ -556,8 +556,10 @@
 	Inherits@selection: ^SelectableCombatUnit
 	Inherits@handicaps: ^PlayerHandicaps
 	Huntable:
+	OwnerLostAction:
+		Action: Kill
 	Health:
-		HP: 40000
+		HP: 30000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -565,7 +567,7 @@
 	Mobile:
 		Voice: Move
 		Speed: 68
-		Locomotor: critter
+		Locomotor: visc
 	Selectable:
 		Bounds: 1024, 1024
 	Targetable:
@@ -576,7 +578,7 @@
 		Voice: Attack
 	HiddenUnderFog:
 	Valued:
-		Cost: 1000
+		Cost: 700
 	Tooltip:
 		Name: Visceroid
 	Armament:
@@ -592,8 +594,12 @@
 	Guard:
 		Voice: Move
 	Guardable:
+	ChangesHealth:
+		Step: 100
+		Delay: 4
+		StartIfBelow: 100
 	DamagedByTerrain:
-		Damage: -100
+		Damage: -50
 		DamageInterval: 4
 		DamageTypes: TiberiumDeath
 		Terrain: Tiberium, BlueTiberium

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -258,8 +258,9 @@ RMBO:
 PVICE:
 	Inherits: ^Viceroid
 	Buildable:
-		Queue: Biolab
-		BuildPaletteOrder: 40
+		Queue: Infantry.GDI, Infantry.Nod
+		BuildPaletteOrder: 50
+		Prerequisites: ~disabled
 		Description: Mutated abomination that spits liquid Tiberium.\n  Strong vs Infantry, Buildings\n  Weak vs Aircraft
 	Tooltip:
 	UpdatesPlayerStatistics:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -375,8 +375,12 @@ HAND:
 	WithBuildingBib:
 	RallyPoint:
 	Exit@1:
+		Priority: 2
 		SpawnOffset: 512,1024,0
 		ExitCell: 1,2
+	Exit@fallback1:
+		SpawnOffset: -1024,256,0
+		ExitCell: -1,1
 	Production:
 		Produces: Infantry.Nod
 	ProductionQueue:
@@ -1008,7 +1012,7 @@ GTWR:
 	Turreted:
 		TurnSpeed: 512
 	Power:
-		Amount: -10
+		Amount: -20
 
 ATWR:
 	Inherits: ^Defense

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -87,29 +87,11 @@ BIO:
 	Tooltip:
 		Name: Biological Lab
 	TooltipDescription@ally:
-		Description: Provides infantry with Tiberium immunity. Produces Visceroids.
+		Description: Provides infantry with Tiberium immunity.
 		ValidRelationships: Ally
 	TooltipDescription@other:
-		Description: Capture to enable Tiberium immunity for infantry. Produces Visceroids.
+		Description: Capture to enable Tiberium immunity for infantry.
 		ValidRelationships: Neutral, Enemy
-	Exit@1:
-		SpawnOffset: 0,-426,0
-		ExitCell: 0,-1
-	Production:
-		Produces: Biolab
-	ProductionQueue:
-		Type: Biolab
-		Group: Infantry
-		LowPowerModifier: 300
-		ReadyAudio: UnitReady
-		BlockedAudio: NoBuild
-		LimitedAudio: BuildingInProgress
-		QueuedAudio: Training
-		OnHoldAudio: OnHold
-		CancelledAudio: Cancelled
-	ProductionBar:
-		ProductionType: Biolab
-	RallyPoint:
 	SpawnActorOnDeath:
 		Actor: BIO.Husk
 	ProvidesPrerequisite@buildingname:
@@ -125,8 +107,11 @@ BIO.Husk:
 		Name: Biological Lab (Destroyed)
 
 MISS:
-	Inherits: ^CivBuilding
+	Inherits: ^TechBuilding
 	Inherits@shape: ^3x2Shape
+	HitShape:
+		UseTargetableCellsOffsets: false
+		TargetableOffsets: 0,0,0, 840,0,0, 840,-1024,0, 420,768,0, -840,0,0, -840,-1024,0, -840,1024,0
 	Selectable:
 		Bounds: 3072, 2048
 	Building:
@@ -139,7 +124,17 @@ MISS:
 		BuildPaletteOrder: 1000
 		Prerequisites: ~disabled
 	Valued:
-		Cost: 2000
+		Cost: 0
+	Health:
+		HP: 80000
+	RevealsShroud:
+		Range: 13c0
+	TooltipDescription@ally:
+		Description: Provides range of vision.
+		ValidRelationships: Ally
+	TooltipDescription@other:
+		Description: Capture to give visual range.
+		ValidRelationships: Neutral, Enemy
 	WithBuildingBib:
 		HasMinibib: true
 	WithMakeAnimation:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -223,8 +223,7 @@ ARTY:
 		EffectiveOwnerFromOwner: true
 	Explodes:
 		Weapon: ArtilleryShell
-		EmptyWeapon: UnitExplode
-		LoadedChance: 75
+		EmptyWeapon: ArtilleryShell
 
 FTNK:
 	Inherits: ^Tank
@@ -706,8 +705,8 @@ STNK:
 	RevealsShroud:
 		Range: 7c0
 	Cloak:
-		InitialDelay: 90
-		CloakDelay: 90
+		InitialDelay: 85
+		CloakDelay: 85
 		CloakSound: trans1.aud
 		UncloakSound: trans1.aud
 		UncloakOn: Attack, Unload, Dock, Damage, Heal

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -112,6 +112,17 @@
 			Tiberium: 78
 			BlueTiberium: 78
 			Beach: 89
+	Locomotor@VISC:
+		Name: visc
+		Crushes: crate
+		TerrainSpeeds:
+			Clear: 100
+			Rough: 89
+			Road: 111
+			Bridge: 111
+			Tiberium: 100
+			BlueTiberium: 100
+			Beach: 89
 	Faction@Random:
 		Name: Any
 		InternalName: Random

--- a/mods/cnc/weapons/ballistics.yaml
+++ b/mods/cnc/weapons/ballistics.yaml
@@ -78,7 +78,7 @@ ArtilleryShell:
 		Damage: 10000
 		Versus:
 			None: 150
-			Wood: 120
+			Wood: 100
 			Light: 112
 			Heavy: 75
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -102,7 +102,7 @@ OrcaAAMissiles:
 	ValidTargets: Air
 	Projectile: Missile
 		Arm: 0
-		Speed: 298
+		Speed: 341
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: Air
 		Versus:
@@ -222,7 +222,9 @@ BoatMissile:
 
 TowerMissile:
 	Inherits: ^MissileWeapon
-	ReloadDelay: 15
+	ReloadDelay: 30
+	Burst: 2
+	BurstDelays: 8
 	Range: 7c0
 	Report: rocket2.aud
 	ValidTargets: Ground, Water
@@ -240,11 +242,14 @@ TowerMissile:
 			Heavy: 100
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@3Eff: CreateEffect
-		Explosions: med_frag
+		Explosions: big_frag
+		ImpactSounds: xplobig4.aud
 
 TowerAAMissile:
 	Inherits: ^MissileWeapon
-	ReloadDelay: 15
+	ReloadDelay: 30
+	Burst: 2
+	BurstDelays: 8
 	Range: 8c0
 	Report: rocket2.aud
 	ValidTargets: Air

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -83,7 +83,7 @@ HeliAAGun:
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: Air
 		Versus:
-			Light: 50
+			Light: 55
 
 ^LightMG:
 	Inherits: ^HeavyMG


### PR DESCRIPTION
Hey everyone,

This is a small balance patch that was tested over the summer. The focus was on tweaking balance issues from the last patch and looking at units I didn't get to last time. I tested it under QoL (Quality of Life).

Balance Changes:

Orca:
Health: 9k -> 10k
AA Missiles: Speed 298 -> 341, ~~Range Limit 6c0 - > 7c0~~

The Orca is on the weaker side, being completely unviable in GDI mirrors and difficult to use vs Nod. In particular you were extremely punished for micro mistakes due to their low health.  The Apache felt better to use (which has 12.5k health), so I nudged the health up a little. This allows them to resist one more bike rocket (3 -> 4), gives better resistance to APCs, and no longer get 1 shot by Mammoth Tanks.

Another annoying thing with Orcas were their abysmal tracking on their AA missiles. If the target moved it basically always missed. I upped the tracking while still leaving in the possibility to miss at max chase distance (if the target makes a hard turn it'll start taking hits).

Apache:
~~Speed: 180 -> 186~~
AA Light: 50 -> 55
Reload: Count 1 -> 2, Delay 40 -> 70

The Apache is in a mostly good spot, these were to balance out the Orca buffs. ~~I needed it to match the Orca's speed (186), since Orcas have better tracking on the AA missiles.~~ Slight buff to AA damage due to Orca health buff. 

I also took a look at its reload. I think it's very misleading it reloads 1 ammo at a time but shoots 2 at a time. I often see Apache players commit their planes when out of ammo when they shouldn't, since they're actually doing half damage shooting 1 bullet a time. I also took a look at out-of-ammo Apache vs out-of-ammo Orca, and the Orca wins easily. The faster reload should help a bit in that situation (Orca still wins), and allow the Apache to get value a little faster vs things that don't shoot back at it.

Artillery:
Removed Empty Weapon (now always explodes on death)
Wood Damage: 120 -> 100

Artillery spam was becoming an issue in team games again. One problem was they had a small splash on death but it only occurred when the weapon was loaded (and only at a 75% chance). Since artillery are almost always firing and it has no visual indicator I removed it. Artilleries splash for about 33% health now when next to each other. This should make groups of them easier to take out.

The wood damage has always been a strong selling point on Arties but it's at too high a level. People are sniping the strongest structure in the game (construction yard) in a matter of moments with a group of artillery. I've toned it down a bit while still leaving it fairly strong (5 -> 6 shots to kill a power plant now).

Stealth Tank:
CloakDelay: 90 -> 85

Small buff to cloak to make back line harassment more viable.

Guard Tower:
Power: -10 -> -20

Guard towers are a bit too strong when combined with rocket soldiers as a defensive line. This is a small change to make guard tower spam a bit more costly and bring it in line with turrets (-20 power). This broke Nod 07C (Steal the Orca) GDI base, so I changed one of the power plants to an adv power so it has positive power again.

Advanced Guard Tower:
Burst: 1 -> 2
BurstDelays: 8
ReloadDelay: 15 -> 30
AG: Changed Impact Sound and Effect

Finally following up on #18972. The AGT changes were initially denied due to the sound effect not sounding right with our AGT's fast fire rate. Now that I've had time to test the new fire rate, we can now include these changes.

I went into CnC Remastered and tried to emulate the original firing pattern as close as possible. I've changed the sound and impact visual to match the original. It looked funny on the AA weapon so I left it alone (we can just imagine the AA missile is a lighter variant).

Overall the AGT is slightly weaker due to lower DPS, with the burstdelay making the total delay 38 for every 2 missiles. I could go into detail the small changes this makes, but suffice to say I think it's in a good spot and has a more interesting firing pattern.


Misc Changes

Hand of Nod:
Backup Exit Added

GDI benefits from an unblockable Barracks but the Hand of Nod is fairly easy to block. I've added a backup exit on the side door that's only used when the front entrance is blocked.


Tech Structure Changes:

Tech Center:
Inherits Tech Structure
Adjusted HitShape
Cost: 2000 -> 0
Reveal Shroud: 13c0
Tooltip Adjusted
Campaign Overrides: Inherits Civ Building, removed Vision buff, removed tooltip changes

Grants vision like its counterpart in RA (13c0). I've upped the health to match oil health. Not sure why it costed 2k but reduced it to 0 like other tech structures so it doesn't grant veterancy. I copied the hitshape from RA which better matches the outline of the structure.

I think I did the campaign overrides right and checked in game (Nod 03 and Nod 10 I believe), but it'd be great if someone more familiar double checked.

Biolab:
Removed ability to produce Visceroids (and other critters in debug)
Adjusted Tooltips

Visceroid:
No longer buildable (can be built with the Dinos in the Rax/Hand now)
Added OwnerLostAction so it dies when you lose
Health: 40k -> 30k
Cost: 1k -> 700
Locomotive: Critter -> Visc (Visc is a new locomotive that isn't slowed on Tiberium)
Constant Self Heal Added (-100/4)
Tiberium Healing: -100/4 -> -50/4

So, I started this patch trying to make Visceroids viable. I reduced their cost and gave them a constant self-heal since I figured that would be an interesting way to make them unique (had to reduce their health to compensate). I also stopped them from being slowed on Tiberium.

However, this then brought up the issue if they should even be buildable in the first place. I asked a lot of opinions on this and it was contested, but the community seemed to be in favor of removing them. So I removed them from the biolab. However, this created an issue since if you had the biolab it would still cycle through it for production even though it couldn't produce anything, so I had to remove the dinos as well (the debug ones). To compensate I moved all of them to the rax/hand under debug, like RA.

If players want they can always add them back in with custom maps.