### PR TITLE
Update to .NET 6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,17 +7,17 @@ on:
 
 jobs:
   linux:
-    name: Linux (.NET 5.0)
+    name: Linux (.NET 6.0)
     runs-on: ubuntu-20.04
 
     steps:
       - name: Clone Repository
         uses: actions/checkout@v2
 
-      - name: Install .NET 5
+      - name: Install .NET 6.0
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
 
       - name: Check Code
         run: |
@@ -48,17 +48,17 @@ jobs:
           make RUNTIME=mono test
 
   windows:
-    name: Windows (.NET 5.0)
+    name: Windows (.NET 6.0)
     runs-on: windows-2019
 
     steps:
       - name: Clone Repository
         uses: actions/checkout@v2
 
-      - name: Install .NET 5
+      - name: Install .NET 6.0
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
 
       - name: Check Code
         shell: powershell

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -39,10 +39,10 @@ jobs:
       - name: Clone Repository
         uses: actions/checkout@v2
 
-      - name: Install .NET 5
+      - name: Install .NET 6.0
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
 
       - name: Prepare Environment
         run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> ${GITHUB_ENV}
@@ -68,10 +68,10 @@ jobs:
       - name: Clone Repository
         uses: actions/checkout@v2
 
-      - name: Install .NET 5
+      - name: Install .NET 6.0
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
 
       - name: Prepare Environment
         run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> ${GITHUB_ENV}
@@ -103,10 +103,10 @@ jobs:
       - name: Clone Repository
         uses: actions/checkout@v2
 
-      - name: Install .NET 5
+      - name: Install .NET 6.0
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
 
       - name: Prepare Environment
         run: |

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(Mono)' == ''">net5.0</TargetFramework>
+    <TargetFramework Condition="'$(Mono)' == ''">net6.0</TargetFramework>
     <TargetFramework Condition="'$(Mono)' != ''">netstandard2.1</TargetFramework>
   </PropertyGroup>
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,7 +8,7 @@ Windows
 
 Compiling OpenRA requires the following dependencies:
 * [Windows PowerShell >= 4.0](http://microsoft.com/powershell) (included by default in recent Windows 10 versions)
-* [.NET 5 SDK](https://dotnet.microsoft.com/download/dotnet/5.0) (or via Visual Studio)
+* [.NET 6 SDK](https://dotnet.microsoft.com/download/dotnet/6.0) (or via Visual Studio)
 
 To compile OpenRA, open the `OpenRA.sln` solution in the main folder, build it from the command-line with `dotnet` or use the Makefile analogue command `make all` scripted in PowerShell syntax.
 
@@ -17,9 +17,9 @@ Run the game with `launch-game.cmd`. It can be handed arguments that specify the
 Linux
 =====
 
-.NET 5 or Mono (version 6.4 or later) is required to compile OpenRA. We recommend using .NET 5 when possible, as Mono is poorly packaged by most Linux distributions (e.g. missing the required `msbuild` toolchain), and has been deprecated as a standalone project.
+.NET 6 or Mono (version 6.4 or later) is required to compile OpenRA. We recommend using .NET 6 when possible, as Mono is poorly packaged by most Linux distributions (e.g. missing the required `msbuild` toolchain), and has been deprecated as a standalone project.
 
-The [.NET 5 download page](https://dotnet.microsoft.com/download/dotnet/5.0) provides repositories for various package managers and binary releases for several architectures. If you prefer to use Mono, we suggest adding the [upstream repository](https://www.mono-project.com/download/stable/#download-lin) for your distro to obtain the latest version and the `msbuild` toolchain.
+The [.NET 6 download page](https://dotnet.microsoft.com/download/dotnet/6.0) provides repositories for various package managers and binary releases for several architectures. If you prefer to use Mono, we suggest adding the [upstream repository](https://www.mono-project.com/download/stable/#download-lin) for your distro to obtain the latest version and the `msbuild` toolchain.
 
 To compile OpenRA, run `make` from the command line (or `make RUNTIME=mono` if using Mono). After this one can run the game with `./launch-game.sh`. It is also possible to specify the mod you wish to run from the command line, e.g. with `./launch-game.sh Game.Mod=ts` if you wish to try the experimental Tiberian Sun mod.
 
@@ -78,6 +78,6 @@ Type `sudo make install` for system-wide installation. Run `sudo make install-li
 macOS
 =====
 
-[.NET 5](https://dotnet.microsoft.com/download/dotnet/5.0) or [Mono](https://www.mono-project.com/download/stable/#download-mac) (version 6.4 or later) is required to compile OpenRA. We recommend using .NET 5 unless you are running a very old version of macOS (10.9 through 10.12).
+[.NET 6](https://dotnet.microsoft.com/download/dotnet/6.0) or [Mono](https://www.mono-project.com/download/stable/#download-mac) (version 6.4 or later) is required to compile OpenRA. We recommend using .NET 6 unless you are running a very old version of macOS (10.9 through 10.14).
 
 To compile OpenRA, run `make` from the command line (or `make RUNTIME=mono` if using Mono). Run with `./launch-game.sh`.

--- a/Makefile
+++ b/Makefile
@@ -3,20 +3,20 @@
 # to compile, run:
 #   make
 #
-# to compile using Mono (version 6.4 or greater) instead of .NET 5, run:
+# to compile using Mono (version 6.4 or greater) instead of .NET 6, run:
 #   make RUNTIME=mono
 #
 # to compile using system libraries for native dependencies, run:
-#   make [RUNTIME=net5] TARGETPLATFORM=unix-generic
+#   make [RUNTIME=net6] TARGETPLATFORM=unix-generic
 #
 # to check the official mods for erroneous yaml files, run:
-#   make [RUNTIME=net5] test
+#   make [RUNTIME=net6] test
 #
 # to check the engine and official mod dlls for code style violations, run:
-#   make [RUNTIME=net5] check
+#   make [RUNTIME=net6] check
 #
 # to compile and install Red Alert, Tiberian Dawn, and Dune 2000, run:
-#   make [RUNTIME=net5] [prefix=/foo] [bindir=/bar/bin] install
+#   make [RUNTIME=net6] [prefix=/foo] [bindir=/bar/bin] install
 #
 # to compile and install Red Alert, Tiberian Dawn, and Dune 2000
 # using system libraries for native dependencies, run:
@@ -53,7 +53,7 @@ RM_R = $(RM) -r
 RM_F = $(RM) -f
 RM_RF = $(RM) -rf
 
-RUNTIME ?= net5
+RUNTIME ?= net6
 CONFIGURATION ?= Release
 
 # Only for use in target version:
@@ -159,24 +159,24 @@ help:
 	@echo 'to compile, run:'
 	@echo '  make'
 	@echo
-	@echo 'to compile using Mono (version 6.4 or greater) instead of .NET 5, run:'
+	@echo 'to compile using Mono (version 6.4 or greater) instead of .NET 6, run:'
 	@echo '  make RUNTIME=mono'
 	@echo
 	@echo 'to compile using system libraries for native dependencies, run:'
-	@echo '  make [RUNTIME=net5] TARGETPLATFORM=unix-generic'
+	@echo '  make [RUNTIME=net6] TARGETPLATFORM=unix-generic'
 	@echo
 	@echo 'to check the official mods for erroneous yaml files, run:'
-	@echo '  make [RUNTIME=net5] test'
+	@echo '  make [RUNTIME=net6] test'
 	@echo
 	@echo 'to check the engine and official mod dlls for code style violations, run:'
-	@echo '  make [RUNTIME=net5] check'
+	@echo '  make [RUNTIME=net6] check'
 	@echo
 	@echo 'to compile and install Red Alert, Tiberian Dawn, and Dune 2000 run:'
-	@echo '  make [RUNTIME=net5] [prefix=/foo] [TARGETPLATFORM=unix-generic] install'
+	@echo '  make [RUNTIME=net6] [prefix=/foo] [TARGETPLATFORM=unix-generic] install'
 	@echo
 	@echo 'to compile and install Red Alert, Tiberian Dawn, and Dune 2000'
 	@echo 'using system libraries for native dependencies, run:'
-	@echo '   make [RUNTIME=net5] [prefix=/foo] [bindir=/bar/bin] TARGETPLATFORM=unix-generic install'
+	@echo '   make [RUNTIME=net6] [prefix=/foo] [bindir=/bar/bin] TARGETPLATFORM=unix-generic install'
 	@echo
 	@echo 'to install Linux startup scripts, desktop files, icons, and MIME metadata'
 	@echo '  make install-linux-shortcuts'

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -6,7 +6,7 @@
     <DefineConstants>MONO</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition="'$(Mono)' == ''">
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
@@ -15,6 +15,6 @@
     <PackageReference Include="Mono.NAT" Version="3.0.2" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Threading.Channels" Version="5.0.0" />
+    <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/OpenRA.Game/Support/HttpQueryBuilder.cs
+++ b/OpenRA.Game/Support/HttpQueryBuilder.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Support
 			parameters.Add(new Parameter
 			{
 				Name = name,
-				Value = Uri.EscapeUriString(value.ToString())
+				Value = Uri.EscapeDataString(value.ToString())
 			});
 		}
 

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -3,14 +3,14 @@
     <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj">
       <Private>False</Private>
     </ProjectReference>
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="OpenRA-FuzzyLogicLibrary" Version="1.0.1" />
     <PackageReference Include="DiscordRichPresence" Version="1.0.175" />
     <PackageReference Include="MP3Sharp" Version="1.0.5" />
     <PackageReference Include="NVorbis" Version="0.10.4" />
     <PackageReference Include="TagLibSharp" Version="2.2.0" />
     <PackageReference Include="rix0rrr.BeaconLib" Version="1.0.2" />
-    <PackageReference Include="Pfim" Version="0.10.2" />
+    <PackageReference Include="Pfim" Version="0.10.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using OpenRA.Mods.Common.FileFormats;
 using OpenRA.Widgets;
@@ -470,6 +471,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return null;
 
 				if (Platform.CurrentPlatform != PlatformType.Windows)
+					return null;
+
+				// We need an extra check for the platform here to silence a warning when the registry is accessed
+				// TODO: Remove this once our platform checks use the same method
+				if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 					return null;
 
 				foreach (var prefix in source.RegistryPrefixes)

--- a/OpenRA.Mods.Common/Widgets/Logic/SystemInfoPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SystemInfoPromptLogic.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			return $"&sysinfoversion={SystemInformationVersion}&"
 			       + GetSystemInformation()
-				       .Select(kv => kv.Key + "=" + Uri.EscapeUriString(kv.Value.Value))
+				       .Select(kv => kv.Key + "=" + Uri.EscapeDataString(kv.Value.Value))
 				       .JoinWith("&");
 		}
 

--- a/OpenRA.Test/OpenRA.Test.csproj
+++ b/OpenRA.Test/OpenRA.Test.csproj
@@ -8,9 +8,9 @@
     <ProjectReference Include="..\OpenRA.Mods.Common\OpenRA.Mods.Common.csproj">
       <Private>True</Private>
     </ProjectReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit.Console" Version="3.13.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
   </ItemGroup>
 </Project>

--- a/configure-system-libraries.sh
+++ b/configure-system-libraries.sh
@@ -30,7 +30,7 @@ patch_config()
 			done
 		done
 	else
-		# NET 5 does not support .config files, so we must use symlinks instead
+		# .NET 6 does not support .config files, so we must use symlinks instead
 		# Exit early if the symlink already exists
 		if [ -L "bin/${REPLACE}" ]; then
 			return 0

--- a/packaging/functions.sh
+++ b/packaging/functions.sh
@@ -11,7 +11,7 @@
 #   SRC_PATH: Path to the root OpenRA directory
 #   DEST_PATH: Path to the root of the install destination (will be created if necessary)
 #   TARGETPLATFORM: Platform type (win-x86, win-x64, osx-x64, linux-x64, unix-generic)
-#   RUNTIME: Runtime type (net5, mono)
+#   RUNTIME: Runtime type (net6, mono)
 #   COPY_GENERIC_LAUNCHER: If set to True the OpenRA.exe will also be copied (True, False)
 #   COPY_CNC_DLL: If set to True the OpenRA.Mods.Cnc.dll will also be copied (True, False)
 #   COPY_D2K_DLL: If set to True the OpenRA.Mods.D2k.dll will also be copied (True, False)
@@ -153,7 +153,7 @@ install_windows_launcher()
 	rm -rf "${SRC_PATH}/OpenRA.WindowsLauncher/obj"
 	dotnet publish "${SRC_PATH}/OpenRA.WindowsLauncher/OpenRA.WindowsLauncher.csproj" -c Release -r "${TARGETPLATFORM}" -p:LauncherName="${LAUNCHER_NAME}" -p:TargetPlatform="${TARGETPLATFORM}" -p:ModID="${MOD_ID}" -p:DisplayName="${MOD_NAME}" -p:FaqUrl="${FAQ_URL}" -o "${DEST_PATH}" --self-contained true
 
-	# NET 5 is unable to customize the application host for windows when compiling from Linux,
+	# NET 6 is unable to customize the application host for windows when compiling from Linux,
 	# so we must patch the properties we need in the PE header.
 	# Setting the application icon requires an external tool, so is left to the calling code
 	python3 "${SRC_PATH}/packaging/windows/fixlauncher.py" "${DEST_PATH}/${LAUNCHER_NAME}.exe"

--- a/packaging/functions.sh
+++ b/packaging/functions.sh
@@ -78,7 +78,7 @@ install_assemblies() {
 			done
 		fi
 	else
-		dotnet publish -c Release -p:TargetPlatform="${TARGETPLATFORM}" -p:PublishTrimmed=true -p:CopyGenericLauncher="${COPY_GENERIC_LAUNCHER}" -p:CopyCncDll="${COPY_CNC_DLL}" -p:CopyD2kDll="${COPY_D2K_DLL}" -r "${TARGETPLATFORM}" -o "${DEST_PATH}" --self-contained true
+		dotnet publish -c Release -p:TargetPlatform="${TARGETPLATFORM}" -p:CopyGenericLauncher="${COPY_GENERIC_LAUNCHER}" -p:CopyCncDll="${COPY_CNC_DLL}" -p:CopyD2kDll="${COPY_D2K_DLL}" -r "${TARGETPLATFORM}" -o "${DEST_PATH}" --self-contained true
 	fi
 	cd "${ORIG_PWD}" || exit 1
 }

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -65,7 +65,7 @@ build_appimage() {
 		IS_D2K="True"
 	fi
 
-	install_assemblies "${SRCDIR}" "${APPDIR}/usr/lib/openra" "linux-x64" "net5" "True" "True" "${IS_D2K}"
+	install_assemblies "${SRCDIR}" "${APPDIR}/usr/lib/openra" "linux-x64" "net6" "True" "True" "${IS_D2K}"
 	install_data "${SRCDIR}" "${APPDIR}/usr/lib/openra" "${MOD_ID}"
 	set_engine_version "${TAG}" "${APPDIR}/usr/lib/openra"
 	set_mod_version "${TAG}" "${APPDIR}/usr/lib/openra/mods/${MOD_ID}/mod.yaml" "${APPDIR}/usr/lib/openra/mods/modcontent/mod.yaml"

--- a/packaging/macos/buildpackage.sh
+++ b/packaging/macos/buildpackage.sh
@@ -74,7 +74,7 @@ build_app() {
 	fi
 
 	# Install engine and mod files
-	RUNTIME="net5"
+	RUNTIME="net6"
 	if [ "${PLATFORM}" = "compat" ]; then
 		RUNTIME="mono"
 	fi
@@ -128,8 +128,8 @@ build_platform() {
 		modify_plist "{MINIMUM_SYSTEM_VERSION}" "10.9" "${TEMPLATE_DIR}/Contents/Info.plist"
 		clang -m64 launcher-mono.m -o "${TEMPLATE_DIR}/Contents/MacOS/Launcher" -framework AppKit -mmacosx-version-min=10.9
 	else
-		modify_plist "{MINIMUM_SYSTEM_VERSION}" "10.13" "${TEMPLATE_DIR}/Contents/Info.plist"
-		clang -m64 launcher.m -o "${TEMPLATE_DIR}/Contents/MacOS/Launcher" -framework AppKit -mmacosx-version-min=10.13
+		modify_plist "{MINIMUM_SYSTEM_VERSION}" "10.14" "${TEMPLATE_DIR}/Contents/Info.plist"
+		clang -m64 launcher.m -o "${TEMPLATE_DIR}/Contents/MacOS/Launcher" -framework AppKit -mmacosx-version-min=10.14
 	fi
 
 	build_app "${PLATFORM}" "${TEMPLATE_DIR}" "${BUILTDIR}/OpenRA - Red Alert.app" "ra" "Red Alert" "699222659766026240"

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -63,7 +63,7 @@ function build_platform()
 		USE_PROGRAMFILES32=""
 	fi
 
-	install_assemblies "${SRCDIR}" "${BUILTDIR}" "win-${PLATFORM}" "net5" "False" "True" "True"
+	install_assemblies "${SRCDIR}" "${BUILTDIR}" "win-${PLATFORM}" "net6" "False" "True" "True"
 	install_data "${SRCDIR}" "${BUILTDIR}" "cnc" "d2k" "ra"
 	set_engine_version "${TAG}" "${BUILTDIR}"
 	set_mod_version "${TAG}" "${BUILTDIR}/mods/cnc/mod.yaml" "${BUILTDIR}/mods/d2k/mod.yaml" "${BUILTDIR}/mods/ra/mod.yaml"  "${BUILTDIR}/mods/modcontent/mod.yaml"


### PR DESCRIPTION
New version of #19236 based on the .NET 6. Also increases the minimum version for macOS packaging to `10.14`.

⚠️ Visual Studio 2019 does not work with .NET 6, you'll need to update to Visual Studio 2022. ⚠️ 