### PR TITLE
Reduce MiniYaml allocations

### DIFF
--- a/OpenRA.Game/LocalPlayerProfile.cs
+++ b/OpenRA.Game/LocalPlayerProfile.cs
@@ -83,9 +83,9 @@ namespace OpenRA
 					var client = HttpClientFactory.Create();
 
 					var httpResponseMessage = await client.GetAsync(playerDatabase.Profile + Fingerprint);
-					var result = await httpResponseMessage.Content.ReadAsStringAsync();
+					var result = await httpResponseMessage.Content.ReadAsStreamAsync();
 
-					var yaml = MiniYaml.FromString(result).First();
+					var yaml = MiniYaml.FromStream(result).First();
 					if (yaml.Key == "Player")
 					{
 						innerData = FieldLoader.Load<PlayerProfile>(yaml.Value);

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -183,9 +183,9 @@ namespace OpenRA
 					try
 					{
 						var httpResponseMessage = await client.GetAsync(url);
-						var result = await httpResponseMessage.Content.ReadAsStringAsync();
+						var result = await httpResponseMessage.Content.ReadAsStreamAsync();
 
-						var yaml = MiniYaml.FromString(result);
+						var yaml = MiniYaml.FromStream(result);
 						foreach (var kv in yaml)
 							previews[kv.Key].UpdateRemoteSearch(MapStatus.DownloadAvailable, kv.Value, mapDetailsReceived);
 

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -384,19 +384,6 @@ namespace OpenRA
 		/// Merges any duplicate keys that are defined within the same set of nodes.
 		/// Does not resolve inheritance or node removals.
 		/// </summary>
-		static MiniYaml MergeSelfPartial(MiniYaml existingNodes)
-		{
-			// Nothing to do
-			if (existingNodes.Nodes == null || existingNodes.Nodes.Count == 0)
-				return existingNodes;
-
-			return new MiniYaml(existingNodes.Value, MergeSelfPartial(existingNodes.Nodes));
-		}
-
-		/// <summary>
-		/// Merges any duplicate keys that are defined within the same set of nodes.
-		/// Does not resolve inheritance or node removals.
-		/// </summary>
 		static List<MiniYamlNode> MergeSelfPartial(List<MiniYamlNode> existingNodes)
 		{
 			var keys = new HashSet<string>(existingNodes.Count);

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -17,22 +17,20 @@ using OpenRA.FileSystem;
 
 namespace OpenRA
 {
-	using MiniYamlNodes = List<MiniYamlNode>;
-
 	public static class MiniYamlExts
 	{
-		public static void WriteToFile(this MiniYamlNodes y, string filename)
+		public static void WriteToFile(this List<MiniYamlNode> y, string filename)
 		{
 			File.WriteAllLines(filename, y.ToLines().Select(x => x.TrimEnd()).ToArray());
 		}
 
-		public static string WriteToString(this MiniYamlNodes y)
+		public static string WriteToString(this List<MiniYamlNode> y)
 		{
 			// Remove all trailing newlines and restore the final EOF newline
 			return y.ToLines().JoinWith("\n").TrimEnd('\n') + "\n";
 		}
 
-		public static IEnumerable<string> ToLines(this MiniYamlNodes y)
+		public static IEnumerable<string> ToLines(this List<MiniYamlNode> y)
 		{
 			foreach (var kv in y)
 				foreach (var line in kv.Value.ToLines(kv.Key, kv.Comment))
@@ -99,7 +97,7 @@ namespace OpenRA
 
 		public MiniYaml Clone()
 		{
-			var clonedNodes = new MiniYamlNodes(Nodes.Count);
+			var clonedNodes = new List<MiniYamlNode>(Nodes.Count);
 			foreach (var node in Nodes)
 				clonedNodes.Add(node.Clone());
 			return new MiniYaml(Value, clonedNodes);

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -118,7 +118,7 @@ namespace OpenRA
 		public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(
 			Func<string, TKey> keySelector, Func<MiniYaml, TElement> elementSelector)
 		{
-			var ret = new Dictionary<TKey, TElement>();
+			var ret = new Dictionary<TKey, TElement>(Nodes.Count);
 			foreach (var y in Nodes)
 			{
 				var key = keySelector(y.Key);
@@ -208,7 +208,10 @@ namespace OpenRA
 						throw new YamlException($"Bad indent in miniyaml at {location}");
 
 					while (levels.Count > level + 1)
+					{
+						levels[levels.Count - 1].TrimExcess();
 						levels.RemoveAt(levels.Count - 1);
+					}
 
 					// Extract key, value, comment from line as `<key>: <value>#<comment>`
 					// The # character is allowed in the value if escaped (\#).
@@ -315,7 +318,7 @@ namespace OpenRA
 				.Where(n => n.Key != null)
 				.ToDictionary(n => n.Key, n => n.Value);
 
-			var resolved = new Dictionary<string, MiniYaml>();
+			var resolved = new Dictionary<string, MiniYaml>(tree.Count);
 			foreach (var kv in tree)
 			{
 				var inherited = new Dictionary<string, MiniYamlNode.SourceLocation>();
@@ -398,8 +401,8 @@ namespace OpenRA
 		/// </summary>
 		static List<MiniYamlNode> MergeSelfPartial(List<MiniYamlNode> existingNodes)
 		{
-			var keys = new HashSet<string>();
-			var ret = new List<MiniYamlNode>();
+			var keys = new HashSet<string>(existingNodes.Count);
+			var ret = new List<MiniYamlNode>(existingNodes.Count);
 			foreach (var n in existingNodes)
 			{
 				if (keys.Add(n.Key))
@@ -435,7 +438,7 @@ namespace OpenRA
 			if (overrideNodes.Count == 0)
 				return existingNodes;
 
-			var ret = new List<MiniYamlNode>();
+			var ret = new List<MiniYamlNode>(existingNodes.Count + overrideNodes.Count);
 
 			var existingDict = existingNodes.ToDictionaryWithConflictLog(x => x.Key, "MiniYaml.Merge", null, x => $"{x.Key} (at {x.Location})");
 			var overrideDict = overrideNodes.ToDictionaryWithConflictLog(x => x.Key, "MiniYaml.Merge", null, x => $"{x.Key} (at {x.Location})");

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -528,12 +528,12 @@ namespace OpenRA.Server
 					{
 						var httpClient = HttpClientFactory.Create();
 						var httpResponseMessage = await httpClient.GetAsync(playerDatabase.Profile + handshake.Fingerprint);
-						var result = await httpResponseMessage.Content.ReadAsStringAsync();
+						var result = await httpResponseMessage.Content.ReadAsStreamAsync();
 						PlayerProfile profile = null;
 
 						try
 						{
-							var yaml = MiniYaml.FromString(result).First();
+							var yaml = MiniYaml.FromStream(result).First();
 							if (yaml.Key == "Player")
 							{
 								profile = FieldLoader.Load<PlayerProfile>(yaml.Value);

--- a/OpenRA.Mods.Common/FileFormats/IniFile.cs
+++ b/OpenRA.Mods.Common/FileFormats/IniFile.cs
@@ -35,13 +35,9 @@ namespace OpenRA.Mods.Common.FileFormats
 
 		public void Load(Stream s)
 		{
-			var reader = new StreamReader(s);
 			IniSection currentSection = null;
-
-			while (!reader.EndOfStream)
+			foreach (var line in s.ReadAllLines())
 			{
-				var line = reader.ReadLine();
-
 				if (line.Length == 0) continue;
 
 				switch (line[0])

--- a/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
@@ -164,9 +164,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var httpClient = HttpClientFactory.Create();
 
 					var httpResponseMessage = await httpClient.GetAsync(playerDatabase.Profile + client.Fingerprint);
-					var result = await httpResponseMessage.Content.ReadAsStringAsync();
+					var result = await httpResponseMessage.Content.ReadAsStreamAsync();
 
-					var yaml = MiniYaml.FromString(result).First();
+					var yaml = MiniYaml.FromStream(result).First();
 					if (yaml.Key == "Player")
 					{
 						profile = FieldLoader.Load<PlayerProfile>(yaml.Value);

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -346,13 +346,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var games = new List<GameServer>();
 				var client = HttpClientFactory.Create();
 				var httpResponseMessage = await client.GetAsync(queryURL);
-				var result = await httpResponseMessage.Content.ReadAsStringAsync();
+				var result = await httpResponseMessage.Content.ReadAsStreamAsync();
 
 				activeQuery = true;
 
 				try
 				{
-					var yaml = MiniYaml.FromString(result);
+					var yaml = MiniYaml.FromStream(result);
 					foreach (var node in yaml)
 					{
 						try

--- a/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
+++ b/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
@@ -198,17 +198,30 @@ Test:
 		[TestCase(TestName = "Comments are correctly separated from values")]
 		public void TestEscapedHashInValues()
 		{
-			var trailingWhitespace = @"key: value # comment";
-			Assert.AreEqual("value", MiniYaml.FromString(trailingWhitespace, "trailingWhitespace")[0].Value.Value);
+			var trailingWhitespace = MiniYaml.FromString(@"key: value # comment", "trailingWhitespace", discardCommentsAndWhitespace: false)[0];
+			Assert.AreEqual("value", trailingWhitespace.Value.Value);
+			Assert.AreEqual(" comment", trailingWhitespace.Comment);
 
-			var noWhitespace = @"key:value# comment";
-			Assert.AreEqual("value", MiniYaml.FromString(noWhitespace, "noWhitespace")[0].Value.Value);
+			var noWhitespace = MiniYaml.FromString(@"key:value# comment", "noWhitespace", discardCommentsAndWhitespace: false)[0];
+			Assert.AreEqual("value", noWhitespace.Value.Value);
+			Assert.AreEqual(" comment", noWhitespace.Comment);
 
-			var escapedHashInValue = @"key: before \# after # comment";
-			Assert.AreEqual("before # after", MiniYaml.FromString(escapedHashInValue, "escapedHashInValue")[0].Value.Value);
+			var escapedHashInValue = MiniYaml.FromString(@"key: before \# after # comment", "escapedHashInValue", discardCommentsAndWhitespace: false)[0];
+			Assert.AreEqual("before # after", escapedHashInValue.Value.Value);
+			Assert.AreEqual(" comment", escapedHashInValue.Comment);
 
-			var emptyValue = @"key:# comment";
-			Assert.AreEqual(null, MiniYaml.FromString(emptyValue, "emptyValue")[0].Value.Value);
+			var emptyValueAndComment = MiniYaml.FromString(@"key:#", "emptyValueAndComment", discardCommentsAndWhitespace: false)[0];
+			Assert.AreEqual(null, emptyValueAndComment.Value.Value);
+			Assert.AreEqual("", emptyValueAndComment.Comment);
+
+			var noValue = MiniYaml.FromString(@"key:", "noValue", discardCommentsAndWhitespace: false)[0];
+			Assert.AreEqual(null, noValue.Value.Value);
+			Assert.AreEqual(null, noValue.Comment);
+
+			var emptyKey = MiniYaml.FromString(@" : value", "emptyKey", discardCommentsAndWhitespace: false)[0];
+			Assert.AreEqual(null, emptyKey.Key);
+			Assert.AreEqual("value", emptyKey.Value.Value);
+			Assert.AreEqual(null, emptyKey.Comment);
 		}
 
 		[TestCase(TestName = "Leading and trailing whitespace can be guarded using a backslash")]

--- a/OpenRA.Test/OpenRA.Game/StreamExtsTests.cs
+++ b/OpenRA.Test/OpenRA.Game/StreamExtsTests.cs
@@ -1,0 +1,73 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.IO;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+
+namespace OpenRA.Test
+{
+	[TestFixture]
+	class StreamExtsTests
+	{
+		[TestCase(TestName = "ReadAllLines is equivalent to ReadAllLinesAsMemory")]
+		public void ReadAllLines()
+		{
+			foreach (var source in new[]
+			{
+				"abc",
+				"abc\n",
+				"abc\r\n",
+				"abc\ndef",
+				"abc\r\ndef",
+				"abc\n\n\n",
+				"abc\r\n\r\n\r\n",
+				"abc\n\n\ndef",
+				"abc\r\n\r\n\r\ndef",
+				"abc\ndef\nghi\n",
+				"abc\r\ndef\r\nghi\r\n",
+				"abc\ndef\nghi\njkl",
+				"abc\r\ndef\r\nghi\r\njkl",
+				new string('a', 126),
+				new string('a', 126) + '\n',
+				new string('a', 126) + "\r\n",
+				new string('a', 126) + "b",
+				new string('a', 126) + "\nb",
+				new string('a', 126) + "\r\nb",
+				new string('a', 127),
+				new string('a', 127) + '\n',
+				new string('a', 127) + "\r\n",
+				new string('a', 127) + "b",
+				new string('a', 127) + "\nb",
+				new string('a', 127) + "\r\nb",
+				new string('a', 128),
+				new string('a', 128) + '\n',
+				new string('a', 128) + "\r\n",
+				new string('a', 128) + "b",
+				new string('a', 128) + "\nb",
+				new string('a', 128) + "\r\nb",
+				new string('a', 129),
+				new string('a', 129) + '\n',
+				new string('a', 129) + "\r\n",
+				new string('a', 129) + "b",
+				new string('a', 129) + "\nb",
+				new string('a', 129) + "\r\nb",
+			})
+			{
+				var bytes = Encoding.UTF8.GetBytes(source);
+				var lines = new MemoryStream(bytes).ReadAllLines().ToArray();
+				var linesAsMemory = new MemoryStream(bytes).ReadAllLinesAsMemory().Select(l => l.ToString()).ToArray();
+				Assert.That(linesAsMemory, Is.EquivalentTo(lines));
+			}
+		}
+	}
+}


### PR DESCRIPTION
Reduces MiniYaml allocations during:
- `MiniYaml.Merge`: Various collections are pre-sized to a sensible capacity in advance, to avoid reallocating a larger capacity during various operations.
- `MiniYaml.FromLines`: A new extension method allows iterating over the lines from a stream as `ReadOnlyMemory`, avoiding the need to allocate a string for every line in the stream. The parser can then use span operations to avoid realising intermediate strings. Only the final strings required to populate the output data structure are required to be allocated.

This results in some decent reductions in allocations without having to touch the core logic.
`MiniYaml.Merge` now allocates 88% compared to original. `MiniYaml.FromLines` now allocates 72% compared to original.
