### PR TITLE
Keep Visual Studio Code workspace settings locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ obj
 _ReSharper.*/
 /.vs
 
+# Visual Studio Code
+/.vscode/settings.json
+
 # binaries
 mods/*/*.dll
 mods/*/*.mdb

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-	"omnisharp.enableRoslynAnalyzers": true
-}

--- a/omnisharp.json
+++ b/omnisharp.json
@@ -1,0 +1,5 @@
+{
+    "RoslynExtensionsOptions": {
+        "enableAnalyzersSupport": true
+    }
+}


### PR DESCRIPTION
This is a followup to https://github.com/OpenRA/OpenRA/pull/19785 to avoid git tracking the now ever changing workspace file. If you enjoyed the @OmniSharp Roslyn analyzer then I suggest to enable it in the user settings instead.