### PR TITLE
Fix a crash in the TSResourceLayer neighbour validation

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/World/TSEditorResourceLayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSEditorResourceLayer.cs
@@ -42,6 +42,9 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		bool IsValidVeinNeighbour(CPos cell, CPos neighbour)
 		{
+			if (!Map.Contains(neighbour))
+				return false;
+
 			// Cell is automatically valid if it contains a veinhole actor
 			if (actorLayer.PreviewsAt(neighbour).Any(a => info.VeinholeActors.Contains(a.Info.Name)))
 				return true;

--- a/OpenRA.Mods.Cnc/Traits/World/TSResourceLayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSResourceLayer.cs
@@ -74,6 +74,9 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		bool IsValidResourceNeighbour(CPos cell, CPos neighbour)
 		{
+			if (!Map.Contains(neighbour))
+				return false;
+
 			// Non-vein resources are not allowed in the cardinal neighbours to
 			// an already existing vein cell
 			return Content[neighbour].Type != info.VeinType;
@@ -81,6 +84,9 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		bool IsValidVeinNeighbour(CPos cell, CPos neighbour)
 		{
+			if (!Map.Contains(neighbour))
+				return false;
+
 			// Cell is automatically valid if it contains a veinhole actor
 			if (veinholeCells.Contains(neighbour))
 				return true;
@@ -112,8 +118,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			// Ensure there is space for the vein border tiles (not needed on ramps)
 			var check = resourceType == info.VeinType ? (Func<CPos, CPos, bool>)IsValidVeinNeighbour : IsValidResourceNeighbour;
-			var blockedByNeighbours = Map.Ramp[cell] == 0 && !Common.Util.ExpandFootprint(cell, false)
-				.All(c => check(cell, c));
+			var blockedByNeighbours = Map.Ramp[cell] == 0 && !Common.Util.ExpandFootprint(cell, false).All(c => check(cell, c));
 
 			return !blockedByNeighbours && (resourceType == info.VeinType || !BuildingInfluence.AnyBuildingAt(cell));
 		}


### PR DESCRIPTION
Not yet tested, but should fix #19788.