### PR TITLE
Fix bumps in the production scaling

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ClassicParallelProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicParallelProductionQueue.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Every time another production building of the same queue is",
 			"constructed, the build times of all actors in the queue",
 			"modified by a percentage of the original time.")]
-		public readonly int[] BuildingCountBuildTimeMultipliers = { 100, 85, 75, 65, 60, 55, 50 };
+		public readonly int[] BuildingCountBuildTimeMultipliers = { 100, 86, 75, 67, 60, 55, 50 };
 
 		[Desc("Build time modifier multiplied by the number of parallel production for producing different actors at the same time.")]
 		public readonly int[] ParallelPenaltyBuildTimeMultipliers = { 100, 116, 133, 150, 166, 183, 200, 216, 233, 250 };

--- a/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Every time another production building of the same queue is",
 			"constructed, the build times of all actors in the queue",
 			"decreased by a percentage of the original time.")]
-		public readonly int[] BuildTimeSpeedReduction = { 100, 85, 75, 65, 60, 55, 50 };
+		public readonly int[] BuildTimeSpeedReduction = { 100, 86, 75, 67, 60, 55, 50 };
 
 		public override object Create(ActorInitializer init) { return new ClassicProductionQueue(init, this); }
 	}


### PR DESCRIPTION
![graph](https://user-images.githubusercontent.com/37534529/140033403-7710c8c8-6002-4c84-8863-a176fbd52ae0.png)

The current production scaling adds the same amount of additional assets for every new production structure, but it has a few bumps. This pr irons them out. 

This scaling has been used and tested in BI balance maps and the current season of RAGL