### PR TITLE
Add RAGL balance changes

### DIFF
--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -4,7 +4,7 @@ BADR:
 		DropRange: 4c0
 		ChuteSound: chute1.aud
 	Health:
-		HP: 30000
+		HP: 40000
 	Aircraft:
 		CruiseAltitude: 2560
 		TurnSpeed: 20
@@ -54,7 +54,7 @@ BADR.Bomber:
 		Image: badr
 	AttackBomber:
 	AmmoPool:
-		Ammo: 5
+		Ammo: 10
 	Armament:
 		Weapon: ParaBomb
 

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -1025,10 +1025,10 @@
 		Types: husk
 		ValidRelationships: Enemy, Neutral
 	TransformOnCapture:
-		ForceHealthPercentage: 25
+		ForceHealthPercentage: 15
 	InfiltrateForTransform:
 		Types: Husk
-		ForceHealthPercentage: 25
+		ForceHealthPercentage: 15
 	WithColoredOverlay@IDISABLE:
 		Color: 000000B4
 	Targetable:
@@ -1182,7 +1182,7 @@
 		AvoidFriendly: false
 		BlockFriendly: false
 	Health:
-		HP: 10000
+		HP: 5000
 		NotifyAppliedDamage: false
 	Armor:
 		Type: Light

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -39,7 +39,7 @@ DOG:
 		Voice: Move
 	GrantConditionOnAttack:
 		Condition: eating
-		RevokeDelay: 45
+		RevokeDelay: 20
 	GrantConditionWhileAiming:
 		Condition: run
 	AutoTarget:
@@ -386,7 +386,7 @@ E7:
 		BuildLimit: 1
 		Description: Elite commando infantry. Armed with\ndual pistols and C4.\nMaximum 1 can be trained.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles, Aircraft\n  Special Ability: Destroy Building with C4
 	Valued:
-		Cost: 1200
+		Cost: 1500
 	Tooltip:
 		Name: Tanya
 	UpdatesPlayerStatistics:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -419,7 +419,7 @@ IRON:
 		ChargeInterval: 3000
 		Description: Invulnerability
 		LongDesc: Makes a group of units invulnerable\nfor 20 seconds.
-		Duration: 500
+		Duration: 400
 		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSpeechNotification: InsufficientPower
 		BeginChargeSpeechNotification: IronCurtainCharging
@@ -638,7 +638,7 @@ DOME:
 		Prerequisites: proc, ~techlevel.medium
 		Description: Provides an overview\nof the battlefield.\nRequires power to operate.
 	Valued:
-		Cost: 1800
+		Cost: 1500
 	Tooltip:
 		Name: Radar Dome
 	Building:
@@ -1552,7 +1552,7 @@ AFLD:
 		QuantizedFacings: 8
 		DisplayBeacon: true
 		BeaconPoster: pbmbicon
-		SquadSize: 3
+		SquadSize: 1
 		SquadOffset: 1792,1792,0
 		ArrowSequence: arrow
 		ClockSequence: clock

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -405,11 +405,11 @@ JEEP:
 		Type: Light
 	Mobile:
 		TurnSpeed: 40
-		Speed: 170
+		Speed: 160
 		PauseOnCondition: notmobile || being-captured
 	RevealsShroud:
 		MinRange: 4c0
-		Range: 8c0
+		Range: 7c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 4c0
@@ -723,11 +723,11 @@ DTRK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 5000
+		HP: 2800
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 72
+		Speed: 67
 	RevealsShroud:
 		Range: 4c0
 	Explodes:

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -74,10 +74,10 @@ Dragon:
 
 HellfireAG:
 	Inherits: ^AntiGroundMissile
-	ReloadDelay: 30
+	ReloadDelay: 34
 	MinRange: 1c256
 	Burst: 2
-	BurstDelays: 7
+	BurstDelays: 10
 	Projectile: Missile
 		Speed: 256
 		HorizontalRateOfTurn: 40
@@ -149,7 +149,7 @@ Nike:
 		Inaccuracy: 0
 		Image: MISSILE
 		HorizontalRateOfTurn: 100
-		RangeLimit: 9c0
+		RangeLimit: 11c0
 		Speed: 341
 	Warhead@1Dam: SpreadDamage
 		Damage: 5000

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -111,7 +111,7 @@ TTankZap:
 DogJaw:
 	ValidTargets: Infantry
 	ReloadDelay: 10
-	Range: 2c0
+	Range: 3c0
 	Report: dogg5p.aud
 	TargetActorCenter: true
 	Projectile: InstantHit

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -1,21 +1,21 @@
 ParaBomb:
 	ReloadDelay: 8
-	Range: 3c0
+	Range: 6c0
 	Report: chute1.aud
 	ValidTargets: Ground, Water, GroundActor, WaterActor
 	Projectile: GravityBomb
 		Image: PARABOMB
 		OpenSequence: open
-		Velocity: 0, 0, -40
+		Velocity: 0, 0, -50
 		Acceleration: 0, 0, 0
 		Shadow: False
 	Warhead@1Dam: SpreadDamage
-		Spread: 768
+		Spread: 1000
 		Damage: 30000
 		ValidTargets: GroundActor, WaterActor
 		Versus:
-			None: 30
-			Wood: 30
+			None: 40
+			Wood: 60
 			Light: 75
 			Concrete: 25
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath


### PR DESCRIPTION
Some of the changes have been played in RAGL 10 and have been tested for about a year now

- Longbow anti-ground reload delay 34 (up from 30), burst delay 10 (up from 7)
- Longbow anti-ground reload delay 34 (up from 30), burst delay 10 (up from 7)
- Radar Dome cost 1500 (down from 1800)
- Ranger speed 160 (down from 170), vision 7c0 (down from 8c0)

Other changes have been tested in BI balance maps and are in current RAGL 11 season

- Tanya cost 1500 (up from 1200)
- Dog chew time 20 (down from 45)
- Dog jump 3c0 (up from 2c0)
- Iron Curtain duration is 400 ticks (down from 500)
- SAM missile max range 11c0 (up from 9c0)
- Husks are restored with 15% health (down from 25%)
- Demo truck health 2800 (down from 5000), speed 75 (down from 85)
- Mine health 5000 (down from 10000)
- Parabombs come from a single badger (down from 3), with health 40000 (up from 30000) and 10 bombs (up from 5)\n  * Each bomb has range 6c0 (up from 3c0), fall speed 50 (up from 40), spread 1000 (up from 768), damage vs none 40 (up from 30) and vs wood 60 (up from 30)

I had to adjust the demo truck speed as it was changed in #19348
I didn't include a few things from RAGL as I think they should have separate PR's. Those changes are:
- Increasing Iron Curtain footprint
- Making MGG disableable
- Skull icon for Tanya
- Adding multiple exits to barracks and airfield
- ERCC