### PR TITLE
Allow launcher scripts to run from other working directories.

### DIFF
--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -6,7 +6,8 @@
 #  $ Mod="d2k" ./launch-dedicated.sh # Launch a dedicated server with default settings but override the Mod
 #  Read the file to see which settings you can override
 
-if command -v mono >/dev/null 2>&1 && [ "$(grep -c .NETCoreApp,Version= bin/OpenRA.Server.dll)" = "0" ]; then
+ENGINEDIR=$(dirname "$0")
+if command -v mono >/dev/null 2>&1 && [ "$(grep -c .NETCoreApp,Version= ${ENGINEDIR}/bin/OpenRA.Server.dll)" = "0" ]; then
 	RUNTIME_LAUNCHER="mono --debug"
 else
 	RUNTIME_LAUNCHER="dotnet"
@@ -34,7 +35,7 @@ JoinChatDelay="${JoinChatDelay:-"5000"}"
 SupportDir="${SupportDir:-""}"
 
 while true; do
-     ${RUNTIME_LAUNCHER} bin/OpenRA.Server.dll Engine.EngineDir=".." Game.Mod="$Mod" \
+     ${RUNTIME_LAUNCHER} ${ENGINEDIR}/bin/OpenRA.Server.dll Engine.EngineDir=".." Game.Mod="$Mod" \
      Server.Name="$Name" \
      Server.ListenPort="$ListenPort" \
      Server.AdvertiseOnline="$AdvertiseOnline" \

--- a/launch-game.sh
+++ b/launch-game.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-if command -v mono >/dev/null 2>&1 && [ "$(grep -c .NETCoreApp,Version= bin/OpenRA.dll)" = "0" ]; then
+ENGINEDIR=$(dirname "$0")
+if command -v mono >/dev/null 2>&1 && [ "$(grep -c .NETCoreApp,Version= ${ENGINEDIR}/bin/OpenRA.dll)" = "0" ]; then
 	RUNTIME_LAUNCHER="mono --debug"
 else
 	RUNTIME_LAUNCHER="dotnet"
@@ -31,7 +32,7 @@ then
 fi
 
 # Launch the engine with the appropriate arguments
-${RUNTIME_LAUNCHER} bin/OpenRA.dll Engine.EngineDir=".." Engine.LaunchPath="${LAUNCHPATH}" ${MODARG} "$@"
+${RUNTIME_LAUNCHER} ${ENGINEDIR}/bin/OpenRA.dll Engine.EngineDir=".." Engine.LaunchPath="${LAUNCHPATH}" ${MODARG} "$@"
 
 # Show a crash dialog if something went wrong
 if [ $? != 0 ] && [ $? != 1 ]; then

--- a/utility.sh
+++ b/utility.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
-if command -v mono >/dev/null 2>&1 && [ "$(grep -c .NETCoreApp,Version= bin/OpenRA.Utility.dll)" = "0" ]; then
+ENGINEDIR=$(dirname "$0")
+if command -v mono >/dev/null 2>&1 && [ "$(grep -c .NETCoreApp,Version= ${ENGINEDIR}/bin/OpenRA.Utility.dll)" = "0" ]; then
 	RUNTIME_LAUNCHER="mono --debug"
 else
 	RUNTIME_LAUNCHER="dotnet"
 fi
 
-ENGINE_DIR=.. ${RUNTIME_LAUNCHER} bin/OpenRA.Utility.dll "$@"
+ENGINE_DIR=.. ${RUNTIME_LAUNCHER} ${ENGINEDIR}/bin/OpenRA.Utility.dll "$@"


### PR DESCRIPTION
testcase: launch `launch-game.sh` or the other scripts using an absolute path from a different working directory.