### PR TITLE
Prevent radar crash when dealing with map height.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -176,24 +176,35 @@ namespace OpenRA.Mods.Common.Widgets
 
 			// The minimap is drawn in cell space, so we need to
 			// unproject the bounds to find the extent of the map.
+			// TODO: This attempt to find the map bounds accounting for projected cell heights is bogus.
+			// When a map with height is involved, the bounds may not be optimal, this needs fixing.
 			var projectedLeft = map.Bounds.Left;
 			var projectedRight = map.Bounds.Right;
 			var projectedTop = map.Bounds.Top;
 			var projectedBottom = map.Bounds.Bottom;
 			var top = int.MaxValue;
 			var bottom = int.MinValue;
-			var left = map.Bounds.Left * cellWidth;
-			var right = map.Bounds.Right * cellWidth;
+			var left = projectedLeft * cellWidth;
+			var right = projectedRight * cellWidth;
 
 			for (var x = projectedLeft; x < projectedRight; x++)
 			{
+				// Unprojects check can fail and return an empty list.
+				// This happens when the map tile is outside the map projected space,
+				// e.g. if a tile on the bottom edge has a height > 0.
+				// Guard against this by using the map bounds as a fallback.
 				var allTop = map.Unproject(new PPos(x, projectedTop));
 				var allBottom = map.Unproject(new PPos(x, projectedBottom));
+
 				if (allTop.Count > 0)
 					top = Math.Min(top, allTop.MinBy(uv => uv.V).V);
+				else
+					top = map.Bounds.Top;
 
 				if (allBottom.Count > 0)
 					bottom = Math.Max(bottom, allBottom.MaxBy(uv => uv.V).V);
+				else
+					bottom = map.Bounds.Bottom;
 			}
 
 			var b = Rectangle.FromLTRB(left, top, right, bottom);


### PR DESCRIPTION
### Issue

When the bottom edge of a map with height is all non-zero, the radar widget crashes.

### Repro steps

- Make this diff in [`Map.cs`](https://github.com/OpenRA/OpenRA/blob/2ed4cb8aff6349ceefa66b098f94ece90fe55f8f/OpenRA.Game/Map/Map.cs#L390) to force a map to load with all cells at max height:
```diff
- Height[new MPos(i, j)] = s.ReadUInt8().Clamp((byte)0, Grid.MaximumTerrainHeight);
+ Height[new MPos(i, j)] = Grid.MaximumTerrainHeight;
```
- Open TS and start any map
- Build a radar
- Observe crash

This crashes occurs as the radar has calculated incorrect bounds and access an index out of range.

I'm hoping this hack for the map height is a valid way to create the scenario, but it might be flawed.

### Cause

When calculating the bounds, the radar currently unprojects to find the map bounds to draw. However it unprojects starting with co-ordinates in map space which seems like nonsense. I can't wrap my head around what the intended logic here is.

See the logic here: https://github.com/OpenRA/OpenRA/blob/2ed4cb8aff6349ceefa66b098f94ece90fe55f8f/OpenRA.Mods.Common/Widgets/RadarWidget.cs#L177-L197

When dealing with the bottom edge, this causes a problem as the bottom edge of the map may not live in projected space *at all*. This can occur if every tile along the bottom edge has a height > 0. If so, there are no tiles that exist along the bottom edge in projected space because they've all been raised up. So calling `Unproject` returns an empty list because there are no such cells. When the method executes this leaves `bottom` set to `int.MinValue` which screws up the bounds calculations.

### Fix

Instead of trying to do the unprojection, we just use the map bottom edge in the bounds calculation. This means if the bottom edge is raised up we might include more area than we need, but that's better than a crash at least.

A better fix would address whatever these calculations are trying to achieve and set sensible values for all 4 sides - but I can't grok what that is.