### PR TITLE
In Move.EvalPath, mutate existing path rather than copying to a new list

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -110,7 +110,10 @@ namespace OpenRA.Mods.Common.Activities
 
 		List<CPos> EvalPath(BlockedByActor check)
 		{
-			var path = getPath(check).TakeWhile(a => a != mobile.ToCell).ToList();
+			var path = getPath(check);
+			var toCellIndex = path.IndexOf(mobile.ToCell);
+			if (toCellIndex != -1)
+				path.RemoveRange(toCellIndex, path.Count - toCellIndex);
 			return path;
 		}
 


### PR DESCRIPTION
Since `getPath` generates a new list for us with the path in, we can modify it directly to remove the `ToCell` and everything afterwards, rather than copying to a new list pointlessly.