### PR TITLE
Adjust some naming and order of parameters in CellInfo

### DIFF
--- a/OpenRA.Mods.Common/Pathfinder/CellInfo.cs
+++ b/OpenRA.Mods.Common/Pathfinder/CellInfo.cs
@@ -31,6 +31,11 @@ namespace OpenRA.Mods.Common.Pathfinder
 	public readonly struct CellInfo
 	{
 		/// <summary>
+		/// The status of this node. Accessing other fields is only valid when the status is not <see cref="CellStatus.Unvisited"/>.
+		/// </summary>
+		public readonly CellStatus Status;
+
+		/// <summary>
 		/// The cost to move from the start up to this node.
 		/// </summary>
 		public readonly int CostSoFar;
@@ -38,19 +43,14 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// <summary>
 		/// The estimation of how far this node is from our target.
 		/// </summary>
-		public readonly int EstimatedTotal;
+		public readonly int EstimatedTotalCost;
 
 		/// <summary>
 		/// The previous node of this one that follows the shortest path.
 		/// </summary>
-		public readonly CPos PreviousPos;
+		public readonly CPos PreviousNode;
 
-		/// <summary>
-		/// The status of this node. Accessing other fields is only valid when the status is not <see cref="CellStatus.Unvisited"/>.
-		/// </summary>
-		public readonly CellStatus Status;
-
-		public CellInfo(int costSoFar, int estimatedTotal, CPos previousPos, CellStatus status)
+		public CellInfo(CellStatus status, int costSoFar, int estimatedTotalCost, CPos previousNode)
 		{
 			if (status == CellStatus.Unvisited)
 				throw new ArgumentException(
@@ -59,8 +59,8 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 			Status = status;
 			CostSoFar = costSoFar;
-			EstimatedTotal = estimatedTotal;
-			PreviousPos = previousPos;
+			EstimatedTotalCost = estimatedTotalCost;
+			PreviousNode = previousNode;
 		}
 
 		public override string ToString()
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 			return
 				$"{Status} {nameof(CostSoFar)}={CostSoFar} " +
-				$"{nameof(EstimatedTotal)}={EstimatedTotal} {nameof(PreviousPos)}={PreviousPos}";
+				$"{nameof(EstimatedTotalCost)}={EstimatedTotalCost} {nameof(PreviousNode)}={PreviousNode}";
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
@@ -157,15 +157,15 @@ namespace OpenRA.Mods.Common.Pathfinder
 		{
 			var layer = position.Layer;
 			var info = cellInfoForLayer[layer];
-			var previousPos = info[position].PreviousPos;
+			var previousNode = info[position].PreviousNode;
 
-			var dx = position.X - previousPos.X;
-			var dy = position.Y - previousPos.Y;
+			var dx = position.X - previousNode.X;
+			var dy = position.Y - previousNode.Y;
 			var index = dy * 3 + dx + 4;
 
 			var heightLayer = World.Map.Height;
 			var directions =
-				(checkTerrainHeight && layer == 0 && previousPos.Layer == 0 && heightLayer[position] != heightLayer[previousPos]
+				(checkTerrainHeight && layer == 0 && previousNode.Layer == 0 && heightLayer[position] != heightLayer[previousNode]
 				? DirectedNeighborsConservative
 				: DirectedNeighbors)[index];
 

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			search.isGoal = loc =>
 			{
 				var locInfo = search.Graph[loc];
-				return locInfo.EstimatedTotal - locInfo.CostSoFar == 0;
+				return locInfo.EstimatedTotalCost - locInfo.CostSoFar == 0;
 			};
 
 			foreach (var sl in froms)
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		protected override void AddInitialCell(CPos location)
 		{
 			var cost = heuristic(location);
-			Graph[location] = new CellInfo(0, cost, location, CellStatus.Open);
+			Graph[location] = new CellInfo(CellStatus.Open, 0, cost, location);
 			var connection = new GraphConnection(location, cost);
 			OpenQueue.Add(connection);
 			StartPoints.Add(connection);
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			var currentMinNode = OpenQueue.Pop().Destination;
 
 			var currentCell = Graph[currentMinNode];
-			Graph[currentMinNode] = new CellInfo(currentCell.CostSoFar, currentCell.EstimatedTotal, currentCell.PreviousPos, CellStatus.Closed);
+			Graph[currentMinNode] = new CellInfo(CellStatus.Closed, currentCell.CostSoFar, currentCell.EstimatedTotalCost, currentCell.PreviousNode);
 
 			if (Graph.CustomCost != null && Graph.CustomCost(currentMinNode) == PathGraph.PathCostForInvalidPath)
 				return currentMinNode;
@@ -128,12 +128,12 @@ namespace OpenRA.Mods.Common.Pathfinder
 				// estimated total and the cost so far
 				int hCost;
 				if (neighborCell.Status == CellStatus.Open)
-					hCost = neighborCell.EstimatedTotal - neighborCell.CostSoFar;
+					hCost = neighborCell.EstimatedTotalCost - neighborCell.CostSoFar;
 				else
 					hCost = heuristic(neighborCPos);
 
 				var estimatedCost = gCost + hCost;
-				Graph[neighborCPos] = new CellInfo(gCost, estimatedCost, currentMinNode, CellStatus.Open);
+				Graph[neighborCPos] = new CellInfo(CellStatus.Open, gCost, estimatedCost, currentMinNode);
 
 				if (neighborCell.Status != CellStatus.Open)
 					OpenQueue.Add(new GraphConnection(neighborCPos, estimatedCost));

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -199,10 +199,10 @@ namespace OpenRA.Mods.Common.Traits
 			var ret = new List<CPos>();
 			var currentNode = destination;
 
-			while (cellInfo[currentNode].PreviousPos != currentNode)
+			while (cellInfo[currentNode].PreviousNode != currentNode)
 			{
 				ret.Add(currentNode);
-				currentNode = cellInfo[currentNode].PreviousPos;
+				currentNode = cellInfo[currentNode].PreviousNode;
 			}
 
 			ret.Add(currentNode);
@@ -217,10 +217,10 @@ namespace OpenRA.Mods.Common.Traits
 			var ret = new List<CPos>();
 
 			var q = confluenceNode;
-			while (ca[q].PreviousPos != q)
+			while (ca[q].PreviousNode != q)
 			{
 				ret.Add(q);
-				q = ca[q].PreviousPos;
+				q = ca[q].PreviousNode;
 			}
 
 			ret.Add(q);
@@ -228,9 +228,9 @@ namespace OpenRA.Mods.Common.Traits
 			ret.Reverse();
 
 			q = confluenceNode;
-			while (cb[q].PreviousPos != q)
+			while (cb[q].PreviousNode != q)
 			{
-				q = cb[q].PreviousPos;
+				q = cb[q].PreviousNode;
 				ret.Add(q);
 			}
 


### PR DESCRIPTION
- Make Status the first field.
- Rename EstimatedTotal to EstimatedTotalCost to make it clearer it has the same unit as the CostSoFar field.
- Rename PreviousPos to PreviousNode as node terminology is a better match for usage.