### PR TITLE
Added configurable tooltips to the Discord integration

### DIFF
--- a/OpenRA.Mods.Common/DiscordService.cs
+++ b/OpenRA.Mods.Common/DiscordService.cs
@@ -32,6 +32,7 @@ namespace OpenRA.Mods.Common
 	public sealed class DiscordService : IGlobalModData, IDisposable
 	{
 		public readonly string ApplicationId = null;
+		public readonly string Tooltip = "Open Source real-time strategy game engine for early Westwood titles.";
 		DiscordRpcClient client;
 		DiscordState currentState;
 
@@ -167,7 +168,7 @@ namespace OpenRA.Mods.Common
 				Assets = new Assets
 				{
 					LargeImageKey = "large",
-					LargeImageText = Game.ModData.Manifest.Metadata.Title,
+					LargeImageText = Tooltip,
 				},
 				Timestamps = timestamp.HasValue ? new Timestamps(timestamp.Value) : null,
 				Party = party,


### PR DESCRIPTION
Repeating the title **OpenRA** in the tooltip is a bit redundant. Giving some explanations might be nicer.

![image](https://user-images.githubusercontent.com/756669/144122312-68d54d77-d7cf-4700-b677-caaedfa18035.png)
