### PR TITLE
Fix Move.PathSearchOrder

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -33,8 +33,8 @@ namespace OpenRA.Mods.Common.Activities
 		static readonly BlockedByActor[] PathSearchOrder =
 		{
 			BlockedByActor.All,
-			BlockedByActor.Immovable,
 			BlockedByActor.Stationary,
+			BlockedByActor.Immovable,
 			BlockedByActor.None
 		};
 


### PR DESCRIPTION
Each successive value of BlockedByActor is a superset of the previous value. Having a mixed up order of values in PathSearchOrder is not useful.

In the previous ordering, if a search for Immovable failed to find a path, it would then attempt Stationary. However Stationary is *more* restrictive then Immovable. If Immovable failed, there is no way Stationary could succeed. This means the search for Stationary is wasted effort.

In the fixed ordering, we try Stationary first. In the fixed ordering there are no pointless searches. Every search might succeed where the previous one failed and is therefore useful to try.