### PR TITLE
Bumped dependency versions

### DIFF
--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fluent.Net" Version="1.0.50" />
+    <PackageReference Include="Fluent.Net" Version="1.0.52" />
     <PackageReference Include="OpenRA-Eluant" Version="1.0.18" />
     <PackageReference Include="Mono.NAT" Version="3.0.1" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Fluent.Net" Version="1.0.52" />
     <PackageReference Include="OpenRA-Eluant" Version="1.0.18" />
-    <PackageReference Include="Mono.NAT" Version="3.0.1" />
+    <PackageReference Include="Mono.NAT" Version="3.0.2" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Threading.Channels" Version="5.0.0" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="NVorbis" Version="0.10.4" />
     <PackageReference Include="TagLibSharp" Version="2.2.0" />
     <PackageReference Include="rix0rrr.BeaconLib" Version="1.0.2" />
-    <PackageReference Include="Pfim" Version="0.9.1" />
+    <PackageReference Include="Pfim" Version="0.10.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="OpenRA-FuzzyLogicLibrary" Version="1.0.1" />
     <PackageReference Include="DiscordRichPresence" Version="1.0.175" />
     <PackageReference Include="MP3Sharp" Version="1.0.5" />
-    <PackageReference Include="NVorbis" Version="0.10.3" />
+    <PackageReference Include="NVorbis" Version="0.10.4" />
     <PackageReference Include="TagLibSharp" Version="2.2.0" />
     <PackageReference Include="rix0rrr.BeaconLib" Version="1.0.2" />
     <PackageReference Include="Pfim" Version="0.9.1" />

--- a/OpenRA.Test/OpenRA.Test.csproj
+++ b/OpenRA.Test/OpenRA.Test.csproj
@@ -9,8 +9,8 @@
       <Private>True</Private>
     </ProjectReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit.Console" Version="3.11.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0-beta.1" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit.Console" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* https://github.com/alanmcgovern/Mono.Nat/releases/tag/release-v3.0.2
* https://github.com/NVorbis/NVorbis/releases/tag/v0.10.4
* https://github.com/nickbabcock/Pfim/releases
* https://github.com/nunit/nunit/releases 3.13 adds support for .NET 5