### PR TITLE
Fixed GitHub syntax highlight complaining about tabs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,6 @@
 
 # Custom for Visual Studio
 *.cs     diff=csharp
+
+# https://github.com/github/linguist/blob/master/docs/overrides.md
+*.yaml linguist-language=SaltStack


### PR DESCRIPTION
Same as https://github.com/OpenRA/OpenRA/pull/18002 but project wide.
Preview: https://github.com/OpenHV/OpenHV/tree/master/mods/hv/rules