### PR TITLE
Introduce a new IRejectsOrders interface and make AttackBomber implement it

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Primitives;
@@ -17,12 +18,13 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[Desc("Trait used for scripted actors or actors spawned by a support power. Units with this trait will reject all orders given.")]
 	public class AttackBomberInfo : AttackBaseInfo
 	{
 		public override object Create(ActorInitializer init) { return new AttackBomber(init.Self, this); }
 	}
 
-	public class AttackBomber : AttackBase, ITick, ISync, INotifyRemovedFromWorld
+	public class AttackBomber : AttackBase, ITick, ISync, INotifyRemovedFromWorld, IRejectsOrders
 	{
 		readonly AttackBomberInfo info;
 
@@ -85,6 +87,11 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			OnRemovedFromWorld(self);
 		}
+
+		// Return an empty set for both reject and except to reject all orders
+		readonly HashSet<string> emptyHashset = new HashSet<string>();
+		HashSet<string> IRejectsOrders.Reject => emptyHashset;
+		HashSet<string> IRejectsOrders.Except => emptyHashset;
 
 		public override Activity GetAttackActivity(Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
 		{

--- a/OpenRA.Mods.Common/Traits/RejectsOrders.cs
+++ b/OpenRA.Mods.Common/Traits/RejectsOrders.cs
@@ -27,10 +27,10 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new RejectsOrders(this); }
 	}
 
-	public class RejectsOrders : ConditionalTrait<RejectsOrdersInfo>
+	public class RejectsOrders : ConditionalTrait<RejectsOrdersInfo>, IRejectsOrders
 	{
-		public HashSet<string> Reject => Info.Reject;
-		public HashSet<string> Except => Info.Except;
+		HashSet<string> IRejectsOrders.Reject => Info.Reject;
+		HashSet<string> IRejectsOrders.Except => Info.Except;
 
 		public RejectsOrders(RejectsOrdersInfo info)
 			: base(info) { }
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public static bool AcceptsOrder(this Actor self, string orderString)
 		{
-			var rejectsOrdersTraits = self.TraitsImplementing<RejectsOrders>().Where(Exts.IsTraitEnabled).ToArray();
+			var rejectsOrdersTraits = self.TraitsImplementing<IRejectsOrders>().Where(Exts.IsTraitEnabled).ToArray();
 			if (rejectsOrdersTraits.Length == 0)
 				return true;
 

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -816,4 +816,11 @@ namespace OpenRA.Mods.Common.Traits
 			Actor ignoreActor = null,
 			bool laneBias = true);
 	}
+
+	[RequireExplicitImplementation]
+	public interface IRejectsOrders
+	{
+		HashSet<string> Reject { get; }
+		HashSet<string> Except { get; }
+	}
 }

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -114,7 +114,6 @@ ornithopter:
 		Name: Ornithopter
 	SpawnActorOnDeath:
 		Actor: ornithopter.husk
-	RejectsOrders:
 	RevealOnFire:
 	-MapEditorData:
 

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -457,7 +457,6 @@ U2:
 		SpawnAtLastPosition: False
 		Type: CenterPosition
 		RequiresCondition: enable-smoke
-	RejectsOrders:
 	Interactable:
 	-MapEditorData:
 	GrantConditionOnDamageState@SmokeTrail:


### PR DESCRIPTION
This is basically my suggestion from https://github.com/OpenRA/OpenRA/pull/19678#issuecomment-925823477, which Imho is a bit cleaner as people won't need to worry about setting `RejectsOrders` up themselves. (Although it isn't difficult, the dependency is not obvious.) Opening as draft so people can give their opinion on which approach they prefer.

Testcase (to be removed before merge) are the bombers in RA. They are now selectable, but don't follow any orders.