### PR TITLE
Remove AttackFrontal's FacingTolerance and define it explicitly in rules

### DIFF
--- a/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
@@ -18,9 +18,6 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Unit got to face the target")]
 	public class AttackFrontalInfo : AttackBaseInfo, Requires<IFacingInfo>
 	{
-		[Desc("Tolerance for attack angle. Range [0, 512], 512 covers 360 degrees.")]
-		public new readonly WAngle FacingTolerance = WAngle.Zero;
-
 		public override object Create(ActorInitializer init) { return new AttackFrontal(init.Self, this); }
 	}
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20201213/AttackFrontalFacingTolerance.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20201213/AttackFrontalFacingTolerance.cs
@@ -1,0 +1,37 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class AttackFrontalFacingTolerance : UpdateRule
+	{
+		public override string Name => "Adds the old default value for AttackFrontal's FacingTolerance.";
+
+		public override string Description => "The tolerance for the attack angle was defined twice on AttackFrontal. This override has to be defined in the rules now.";
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var attackFrontal in actorNode.ChildrenMatching("AttackFrontal", includeRemovals: false))
+			{
+				var facingTolerance = attackFrontal.LastChildMatching("FacingTolerance");
+				if (facingTolerance != null)
+					continue;
+
+				var facingToleranceNode = new MiniYamlNode("FacingTolerance", FieldSaver.FormatValue(WAngle.Zero));
+				attackFrontal.AddNode(facingToleranceNode);
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -90,6 +90,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new UnhardcodeSquadManager(),
 				new RenameSupportPowerDescription(),
 				new AttackBomberFacingTolerance(),
+				new AttackFrontalFacingTolerance(),
 				new RenameCloakTypes(),
 			})
 		};

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -456,6 +456,7 @@
 		IdleSequences: idle1, idle2
 		StandSequences: stand, stand2
 	AttackFrontal:
+		FacingTolerance: 0
 
 ^CivInfantry:
 	Inherits: ^Infantry
@@ -491,6 +492,7 @@
 	Armament:
 		Weapon: Pistol
 	AttackFrontal:
+		FacingTolerance: 0
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
 
@@ -540,6 +542,7 @@
 		Voice: Attack
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	DeathSounds:
 	Voiced:
 		VoiceSet: DinoVoice
@@ -587,6 +590,7 @@
 		MuzzleSequence: muzzle
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	BodyOrientation:
 		QuantizedFacings: 8
 	WithSpriteBody:

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -24,6 +24,7 @@ E1:
 		Weapon: M16
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	AttackMove:
 		Voice: Attack
 	WithInfantryBody:
@@ -58,6 +59,7 @@ E2:
 		FireDelay: 15
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	AttackMove:
 		Voice: Attack
 	TakeCover:
@@ -97,6 +99,7 @@ E3:
 		FireDelay: 5
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	AttackMove:
 		Voice: Attack
 	TakeCover:
@@ -133,6 +136,7 @@ E4:
 		MuzzleSequence: muzzle
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	AttackMove:
 		Voice: Attack
 	TakeCover:
@@ -171,6 +175,7 @@ E5:
 		MuzzleSequence: muzzle
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	AttackMove:
 		Voice: Attack
 	TakeCover:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -211,6 +211,7 @@ ARTY:
 		TargetFrozenActors: True
 		ForceFireIgnoresActors: True
 		Voice: Attack
+		FacingTolerance: 0
 	AttackMove:
 		Voice: Attack
 	WithMuzzleOverlay:
@@ -257,6 +258,7 @@ FTNK:
 		MuzzleSequence: muzzle
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	AttackMove:
 		Voice: Attack
 	WithMuzzleOverlay:
@@ -347,6 +349,7 @@ BIKE:
 		LocalYaw: 100, -100
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	AttackMove:
 		Voice: Attack
 	SpawnActorOnDeath:
@@ -600,6 +603,7 @@ MSAM:
 		TargetFrozenActors: True
 		ForceFireIgnoresActors: True
 		Voice: Attack
+		FacingTolerance: 0
 	AttackMove:
 		Voice: Attack
 	WithSpriteTurret:
@@ -717,6 +721,7 @@ STNK:
 		LocalOffset: 213,43,128, 213,-43,128
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	AttackMove:
 		Voice: Attack
 	AutoTarget:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -376,6 +376,7 @@
 	MapEditorData:
 		Categories: Infantry
 	AttackFrontal:
+		FacingTolerance: 0
 
 ^Plane:
 	Inherits@1: ^ExistsInWorld

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -142,6 +142,7 @@ trike:
 		LocalOffset: -544,0,0
 		MuzzleSequence: muzzle
 	AttackFrontal:
+		FacingTolerance: 0
 	Explodes:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
@@ -178,6 +179,7 @@ quad:
 		Weapon: Rocket
 		LocalOffset: 128,64,64, 128,-64,64
 	AttackFrontal:
+		FacingTolerance: 0
 	Explodes:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
@@ -222,6 +224,7 @@ siege_tank:
 		LocalOffset: 512,0,320
 		MuzzleSequence: muzzle
 	AttackFrontal:
+		FacingTolerance: 0
 	WithMuzzleOverlay:
 	WithSpriteTurret:
 	Explodes:
@@ -268,6 +271,7 @@ missile_tank:
 		Weapon: mtank_pri
 		LocalOffset: -128,128,171, -128,-128,171
 	AttackFrontal:
+		FacingTolerance: 0
 	AutoTarget:
 		InitialStanceAI: Defend
 	Explodes:
@@ -312,6 +316,7 @@ sonic_tank:
 		Weapon: Sound
 		LocalOffset: 600,0,427
 	AttackFrontal:
+		FacingTolerance: 0
 	Explodes:
 		Weapon: UnitExplodeLarge
 		EmptyWeapon: UnitExplodeLarge
@@ -358,6 +363,7 @@ devastator:
 		LocalOffset: 640,0,32
 		MuzzleSequence: muzzle
 	AttackFrontal:
+		FacingTolerance: 0
 	WithMuzzleOverlay:
 		IgnoreOffset: true
 	Explodes:
@@ -429,6 +435,7 @@ raider:
 		LocalOffset: 170,0,0
 		MuzzleSequence: muzzle
 	AttackFrontal:
+		FacingTolerance: 0
 	Explodes:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
@@ -493,6 +500,7 @@ deviator:
 		Weapon: DeviatorMissile
 		LocalOffset: -299,0,85
 	AttackFrontal:
+		FacingTolerance: 0
 	AutoTarget:
 		InitialStanceAI: Defend
 	Explodes:

--- a/mods/ra/maps/drop-zone-w/rules.yaml
+++ b/mods/ra/maps/drop-zone-w/rules.yaml
@@ -52,6 +52,7 @@ LST:
 		Name: secondary
 		Weapon: M60mg
 	AttackFrontal:
+		FacingTolerance: 0
 	WithMuzzleOverlay:
 	MustBeDestroyed:
 		RequiredForShortGame: true

--- a/mods/ra/maps/situation-critical/rules.yaml
+++ b/mods/ra/maps/situation-critical/rules.yaml
@@ -28,6 +28,7 @@ VOLK:
 		Voice: Action
 	AttackFrontal:
 		Voice: Action
+		FacingTolerance: 0
 	AttackMove:
 		Voice: Action
 	Passenger:

--- a/mods/ra/maps/soviet-soldier-volkov-n-chitzkoi/rules.yaml
+++ b/mods/ra/maps/soviet-soldier-volkov-n-chitzkoi/rules.yaml
@@ -142,6 +142,7 @@ VOLK:
 		Voice: Action
 	AttackFrontal:
 		Voice: Action
+		FacingTolerance: 0
 	AttackMove:
 		Voice: Action
 	Passenger:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -450,6 +450,7 @@
 		IdleSequences: idle1,idle2
 		StandSequences: stand,stand2
 	AttackFrontal:
+		FacingTolerance: 0
 
 ^CivInfantry:
 	Inherits: ^Infantry
@@ -480,6 +481,7 @@
 	Armament:
 		Weapon: Pistol
 	AttackFrontal:
+		FacingTolerance: 0
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
 

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -511,6 +511,7 @@ MECH:
 		ForceTargetRelationships: None
 	AttackFrontal:
 		Voice: Action
+		FacingTolerance: 0
 	CaptureManager:
 	Captures:
 		CaptureTypes: husk
@@ -574,6 +575,7 @@ GNRL:
 		Voice: Move
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	AttackMove:
 		Voice: Move
 	Passenger:
@@ -682,6 +684,7 @@ SHOK:
 		ProneOffset: 227,0,-245
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	AttackMove:
 		Voice: Move
 	Passenger:
@@ -818,6 +821,7 @@ Ant:
 	AutoTarget:
 		ScanRadius: 5
 	AttackFrontal:
+		FacingTolerance: 0
 	WithInfantryBody:
 		DefaultAttackSequence: bite
 	Armament:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -49,6 +49,7 @@ SS:
 		LocalOffset: 0,-171,0, 0,171,0
 		FireDelay: 2
 	AttackFrontal:
+		FacingTolerance: 0
 	AutoTargetPriority@DEFAULT:
 		ValidTargets: WaterActor, Underwater
 		InvalidTargets: NoAutoTarget, Structure
@@ -122,6 +123,7 @@ MSUB:
 	AttackFrontal:
 		TargetFrozenActors: True
 		ForceFireIgnoresActors: True
+		FacingTolerance: 0
 	AutoTarget:
 		InitialStance: HoldFire
 		InitialStanceAI: ReturnFire

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -33,6 +33,7 @@ V2RL:
 	AttackFrontal:
 		TargetFrozenActors: True
 		ForceFireIgnoresActors: True
+		FacingTolerance: 0
 	WithFacingSpriteBody:
 		RequiresCondition: !reloading
 		Name: loaded
@@ -276,6 +277,7 @@ ARTY:
 	AttackFrontal:
 		TargetFrozenActors: True
 		ForceFireIgnoresActors: True
+		FacingTolerance: 0
 	WithMuzzleOverlay:
 	Explodes:
 		Weapon: ArtilleryExplode
@@ -464,6 +466,7 @@ APC:
 		LocalOffset: 85,0,171
 		MuzzleSequence: muzzle
 	AttackFrontal:
+		FacingTolerance: 0
 	WithMuzzleOverlay:
 	Cargo:
 		Types: Infantry
@@ -786,6 +789,7 @@ CTNK:
 		LocalOffset: -160,276,232
 		LocalYaw: -60
 	AttackFrontal:
+		FacingTolerance: 0
 	PortableChrono:
 		ChargeDelay: 250
 	ProducibleWithLevel:

--- a/mods/ts/maps/sunstroke/rules.yaml
+++ b/mods/ts/maps/sunstroke/rules.yaml
@@ -50,6 +50,7 @@ SLAV:
 		Description: Religious loyalist\narmed with sniper rifle.
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	Armament:
 		Weapon: Sniper
 

--- a/mods/ts/rules/civilian-infantry.yaml
+++ b/mods/ts/rules/civilian-infantry.yaml
@@ -19,6 +19,7 @@ WEEDGUY:
 		ProneOffset: 128,0,-320
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	-SpawnActorOnDeath@FLAMEGUY:
 	WithDeathAnimation@fire:
 		DeathSequence: die-
@@ -48,6 +49,7 @@ UMAGON:
 		Weapon: Sniper
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	WithSplitAttackPaletteInfantryBody:
 		DefaultAttackSequence: attack
 	ProducibleWithLevel:
@@ -106,6 +108,7 @@ MUTANT:
 		Weapon: Vulcan
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	WithSplitAttackPaletteInfantryBody:
 		DefaultAttackSequence: attack
 	ProducibleWithLevel:
@@ -133,6 +136,7 @@ MWMN:
 		Weapon: Vulcan
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	WithSplitAttackPaletteInfantryBody:
 		DefaultAttackSequence: attack
 	ProducibleWithLevel:
@@ -160,6 +164,7 @@ MUTANT3:
 		Weapon: Vulcan
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	WithSplitAttackPaletteInfantryBody:
 		DefaultAttackSequence: attack
 		Palette: player-nobright
@@ -230,6 +235,7 @@ CIV1:
 		Weapon: Pistola
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	Voiced:
 		VoiceSet: Civilian1
 
@@ -257,5 +263,6 @@ CTECH:
 		Weapon: Pistola
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	Voiced:
 		VoiceSet: CivilianTechnician

--- a/mods/ts/rules/critters.yaml
+++ b/mods/ts/rules/critters.yaml
@@ -27,6 +27,7 @@ DOGGIE:
 		Weapon: FiendShard
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	AttackWander:
 		WanderMoveRadius: 2
 		MinMoveDelay: 200
@@ -97,6 +98,7 @@ VISC_LRG:
 		ScanRadius: 5
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	AttackWander:
 		WanderMoveRadius: 2
 		MinMoveDelay: 25
@@ -125,6 +127,7 @@ JFISH:
 	AutoTarget:
 		ScanRadius: 5
 	AttackFrontal:
+		FacingTolerance: 0
 	AttackWander:
 		WanderMoveRadius: 6
 		MinMoveDelay: 250

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -26,6 +26,7 @@ E2:
 		ProneOffset: 160,128,-555
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	WithSplitAttackPaletteInfantryBody:
 		DefaultAttackSequence: attack
 	RevealsShroud:
@@ -77,6 +78,7 @@ MEDIC:
 	AutoTargetPriority@DEFAULT:
 		ValidTargets: Infantry
 	AttackFrontal:
+		FacingTolerance: 0
 	WithSplitAttackPaletteInfantryBody:
 		DefaultAttackSequence: heal
 	ChangesHealth:
@@ -119,6 +121,7 @@ JUMPJET:
 	-Crushable:
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	WithSplitAttackPaletteInfantryBody:
 		RequiresCondition: !airborne
 		DefaultAttackSequence: attack
@@ -248,6 +251,7 @@ GHOST:
 		CrushSound: squishy2.aud
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	Demolition:
 		DetonationDelay: 45
 		Voice: Attack

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -136,6 +136,7 @@ SMECH:
 	AttackFrontal:
 		Voice: Attack
 		PauseOnCondition: empdisable
+		FacingTolerance: 0
 	Armament:
 		Weapon: AssaultCannon
 	Voiced:
@@ -254,6 +255,7 @@ HMEC:
 	AttackFrontal:
 		Voice: Attack
 		PauseOnCondition: empdisable
+		FacingTolerance: 0
 	Armament@MISSILES:
 		Weapon: MammothTusk
 		LocalOffset: -243,-368,1208, -243,368,1208

--- a/mods/ts/rules/nod-infantry.yaml
+++ b/mods/ts/rules/nod-infantry.yaml
@@ -27,6 +27,7 @@ E3:
 		ProneOffset: 52,64,-652
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	WithSplitAttackPaletteInfantryBody:
 		DefaultAttackSequence: attack
 	RevealsShroud:
@@ -68,6 +69,7 @@ CYBORG:
 		Weapon: Vulcan3
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded
 
@@ -107,6 +109,7 @@ CYC2:
 		LocalOffset: 240,120,966
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded
 

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -32,6 +32,7 @@ BGGY:
 	AttackFrontal:
 		Voice: Attack
 		PauseOnCondition: empdisable
+		FacingTolerance: 0
 	WithMuzzleOverlay:
 	-DamagedByTerrain@VEINS:
 	-LeavesTrails@VEINS:
@@ -74,6 +75,7 @@ BIKE:
 	AttackFrontal:
 		Voice: Attack
 		PauseOnCondition: empdisable
+		FacingTolerance: 0
 	DamagedByTerrain@VEINS:
 		RequiresCondition: !inside-tunnel && !rank-elite
 	LeavesTrails@VEINS:
@@ -154,6 +156,7 @@ TTNK:
 		Voice: Attack
 		RequiresCondition: undeployed
 		PauseOnCondition: empdisable
+		FacingTolerance: 0
 	Turreted:
 		TurnSpeed: 24
 		Turret: deployed
@@ -327,6 +330,7 @@ REPAIR:
 	AttackFrontal:
 		Voice: Attack
 		PauseOnCondition: empdisable
+		FacingTolerance: 0
 	AutoTarget:
 		ScanRadius: 8
 		InitialStance: AttackAnything
@@ -468,6 +472,7 @@ SUBTANK:
 	AttackFrontal:
 		Voice: Attack
 		PauseOnCondition: empdisable
+		FacingTolerance: 0
 	WithVoxelBody:
 		RequiresCondition: !submerged
 	Targetable:
@@ -530,6 +535,7 @@ STNK:
 	AttackFrontal:
 		Voice: Attack
 		PauseOnCondition: empdisable
+		FacingTolerance: 0
 	AutoTarget:
 		InitialStance: HoldFire
 		InitialStanceAI: ReturnFire

--- a/mods/ts/rules/shared-infantry.yaml
+++ b/mods/ts/rules/shared-infantry.yaml
@@ -26,6 +26,7 @@ E1:
 		RequiresCondition: rank-elite
 	AttackFrontal:
 		Voice: Attack
+		FacingTolerance: 0
 	WithSplitAttackPaletteInfantryBody:
 		DefaultAttackSequence: attack
 	ProducibleWithLevel:


### PR DESCRIPTION
Basically a follow-up to https://github.com/OpenRA/OpenRA/pull/16369#discussion_r277138562 and #19661.

While removing that variable I noticed `AttackBase` has a WAngle of 512 defined as default, so all `AttackFrontal` traits now need to define `FacingTolerance: 0`. That wasn't completely unexpected but I hadn't quite thought of the implications. I'm no longer sure if we want to remove the duplicated `FacingTolerance` info field, as having a polish issue in the documentation might be preferable to having `AttackFrontal` not work as intended out of the box any more. In theory we could completely remove `AttackFrontal` now and use `AttackBase` directly instead, if it wasn't `abstract`. Maybe one of the other `Attack*` traits is suitable?

For now this PR cleans up our update rules and paths, and offers a rule for adding `FacingTolerance: 0` to all `AttackFrontal` traits.