### PR TITLE
Add selected actors count to feedback notification text

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/SelectAllUnitsHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/SelectAllUnitsHotkeyLogic.cs
@@ -44,19 +44,28 @@ namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 			var eligiblePlayers = SelectionUtils.GetPlayersToIncludeInSelection(world);
 
 			// Select actors on the screen which belong to the current player(s)
-			var ownUnitsOnScreen = SelectionUtils.SelectActorsOnScreen(world, worldRenderer, null, eligiblePlayers).SubsetWithHighestSelectionPriority(e.Modifiers).ToList();
+			var newSelection = SelectionUtils.SelectActorsOnScreen(world, worldRenderer, null, eligiblePlayers).SubsetWithHighestSelectionPriority(e.Modifiers).ToList();
 
 			// Check if selecting actors on the screen has selected new units
-			if (ownUnitsOnScreen.Count > selection.Actors.Count())
-				TextNotificationsManager.AddFeedbackLine("Selected across screen.");
+			if (newSelection.Count > selection.Actors.Count())
+			{
+				if (newSelection.Count > 1)
+					TextNotificationsManager.AddFeedbackLine($"Selected {newSelection.Count} units across screen.");
+				else
+					TextNotificationsManager.AddFeedbackLine($"Selected one unit across screen.");
+			}
 			else
 			{
 				// Select actors in the world that have highest selection priority
-				ownUnitsOnScreen = SelectionUtils.SelectActorsInWorld(world, null, eligiblePlayers).SubsetWithHighestSelectionPriority(e.Modifiers).ToList();
-				TextNotificationsManager.AddFeedbackLine("Selected across map.");
+				newSelection = SelectionUtils.SelectActorsInWorld(world, null, eligiblePlayers).SubsetWithHighestSelectionPriority(e.Modifiers).ToList();
+
+				if (newSelection.Count > 1)
+					TextNotificationsManager.AddFeedbackLine($"Selected {newSelection.Count} units across map.");
+				else
+					TextNotificationsManager.AddFeedbackLine($"Selected one unit across map.");
 			}
 
-			selection.Combine(world, ownUnitsOnScreen, false, false);
+			selection.Combine(world, newSelection, false, false);
 
 			Game.Sound.PlayNotification(world.Map.Rules, world.LocalPlayer, "Sounds", ClickSound, null);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/SelectUnitsByTypeHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/SelectUnitsByTypeHotkeyLogic.cs
@@ -70,12 +70,21 @@ namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 
 			// Check if selecting actors on the screen has selected new units
 			if (newSelection.Count > selection.Actors.Count())
-				TextNotificationsManager.AddFeedbackLine("Selected across screen.");
+			{
+				if (newSelection.Count > 1)
+					TextNotificationsManager.AddFeedbackLine($"Selected {newSelection.Count} units across screen.");
+				else
+					TextNotificationsManager.AddFeedbackLine($"Selected one unit across screen.");
+			}
 			else
 			{
 				// Select actors in the world that have the same selection class as one of the already selected actors
 				newSelection = SelectionUtils.SelectActorsInWorld(world, selectedClasses, eligiblePlayers).ToList();
-				TextNotificationsManager.AddFeedbackLine("Selected across map.");
+
+				if (newSelection.Count > 1)
+					TextNotificationsManager.AddFeedbackLine($"Selected {newSelection.Count} units across map.");
+				else
+					TextNotificationsManager.AddFeedbackLine($"Selected one unit across map.");
 			}
 
 			selection.Combine(world, newSelection, true, false);


### PR DESCRIPTION
The goal is make the number in the parenthesis less ambiguous. The message means _"Selected {number} units across screen. ({number of duplicate messages})_".

A slight drawback is that the message now contains the word "units" and in rare cases the selection may be mixed or contain only buildings.

A side effect is that this allows the player to easily count units of the same type (e.g. harvesters) which does have some gameplay implications.

![cnc-2022-01-08T174312698Z](https://user-images.githubusercontent.com/1355810/148654182-405de2a7-56a6-4b60-a22b-d7a29132a7b8.png)
