### PR TITLE
Added more code style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -115,14 +115,14 @@ dotnet_style_predefined_type_for_locals_parameters_members = true
 # Show an IDE warning when default access modifiers are explicitly specified.
 dotnet_style_require_accessibility_modifiers = omit_if_default:warning
 
-# Raise a warning on build when default access modifiers are explicitly specified.
-dotnet_diagnostic.IDE0040.severity = warning
-
 # Don't prefer braces (for one liners).
 dotnet_diagnostic.IDE0011.severity = silent
 
 # Modifiers are not ordered.
 dotnet_diagnostic.IDE0036.severity = warning
+
+# Raise a warning on build when default access modifiers are explicitly specified.
+dotnet_diagnostic.IDE0040.severity = warning
 
 # Avoid unnecessary zero-length array allocations.
 dotnet_diagnostic.CA1825.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -116,6 +116,9 @@ dotnet_diagnostic.IDE0040.severity = warning
 # Don't prefer braces (for one liners).
 dotnet_diagnostic.IDE0011.severity = none
 
+# Modifiers are not ordered.
+dotnet_diagnostic.IDE0036.severity = warning
+
 # Avoid unnecessary zero-length array allocations.
 dotnet_diagnostic.CA1825.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -25,12 +25,12 @@ csharp_using_directive_placement = outside_namespace:suggestion
 csharp_new_line_before_open_brace = all
 csharp_space_around_binary_operators = before_and_after
 
-# Naming styles:
+## Naming styles:
 
 dotnet_naming_style.camel_case.capitalization = camel_case
 dotnet_naming_style.pascal_case.capitalization = pascal_case
 
-# Symbol specifications:
+## Symbol specifications:
 
 dotnet_naming_symbols.interface.applicable_kinds = interface
 dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal
@@ -56,16 +56,19 @@ dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, int
 
 dotnet_naming_symbols.parameters.applicable_kinds = parameter
 
-# Naming rules:
+## Naming rules:
 
+# IDE1006, IDE-only counterpart of StyleCopAnalyzers - SA1300: ElementMustBeginWithUpperCaseLetter.
 dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = warning
 dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
 dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
+# IDE1006, IDE-only counterpart of StyleCopAnalyzers - SA1311: StaticReadonlyFieldsMustBeginWithUpperCaseLetter.
 dotnet_naming_rule.static_private_or_internal_field_should_be_pascal_case.severity = none
 dotnet_naming_rule.static_private_or_internal_field_should_be_pascal_case.symbols = static_private_or_internal_field
 dotnet_naming_rule.static_private_or_internal_field_should_be_pascal_case.style = pascal_case
 
+# IDE1006, IDE-only counterpart of StyleCopAnalyzers - SA1303: ConstFieldNamesMustBeginWithUpperCaseLetter.
 dotnet_naming_rule.const_private_field_should_be_pascal_case.severity = warning
 dotnet_naming_rule.const_private_field_should_be_pascal_case.symbols = const_private_field
 dotnet_naming_rule.const_private_field_should_be_pascal_case.style = pascal_case
@@ -74,15 +77,17 @@ dotnet_naming_rule.const_private_or_internal_field_should_be_pascal_case.severit
 dotnet_naming_rule.const_private_or_internal_field_should_be_pascal_case.symbols = internal_field
 dotnet_naming_rule.const_private_or_internal_field_should_be_pascal_case.style = pascal_case
 
+# IDE1006, IDE-only counterpart of StyleCopAnalyzers - SA1306: FieldNamesMustBeginWithLowerCaseLetter.
 dotnet_naming_rule.private_or_internal_field_should_be_camel_case.severity = warning
 dotnet_naming_rule.private_or_internal_field_should_be_camel_case.symbols = private_or_internal_field
 dotnet_naming_rule.private_or_internal_field_should_be_camel_case.style = camel_case
 
+# IDE1006, IDE-only counterpart of StyleCopAnalyzers - SA1313: ParameterNamesMustBeginWithLowerCaseLetter.
 dotnet_naming_rule.parameters.severity = warning
 dotnet_naming_rule.parameters.symbols = parameters
 dotnet_naming_rule.parameters.style = camel_case
 
-# Formatting:
+## Formatting:
 
 # Also handled by StyleCopAnalyzers - SA1024: ColonsMustBeSpacedCorrectly.
 csharp_space_after_colon_in_inheritance_clause = true
@@ -99,13 +104,13 @@ csharp_preserve_single_line_blocks = true
 # Leave statements and member declarations on the same line.
 csharp_preserve_single_line_statements = true
 
-# Also handled by StyleCopAnalyzers - SA1121: UseBuiltInTypeAlias. Also by IDE0049, it seems.
+# IDE0049, IDE-only counterpart of StyleCopAnalyzers - SA1121: UseBuiltInTypeAlias.
 dotnet_style_predefined_type_for_member_access = true
 
-# Also handled by StyleCopAnalyzers - SA1121: UseBuiltInTypeAlias. Also by IDE0049, it seems.
+# IDE0049, IDE-only counterpart of StyleCopAnalyzers - SA1121: UseBuiltInTypeAlias.
 dotnet_style_predefined_type_for_locals_parameters_members = true
 
-# Others:
+## Others:
 
 # Show an IDE warning when default access modifiers are explicitly specified.
 dotnet_style_require_accessibility_modifiers = omit_if_default:warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -114,7 +114,7 @@ dotnet_style_require_accessibility_modifiers = omit_if_default:warning
 dotnet_diagnostic.IDE0040.severity = warning
 
 # Don't prefer braces (for one liners).
-dotnet_diagnostic.IDE0011.severity = none
+dotnet_diagnostic.IDE0011.severity = silent
 
 # Modifiers are not ordered.
 dotnet_diagnostic.IDE0036.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -116,6 +116,9 @@ dotnet_diagnostic.IDE0040.severity = warning
 # Don't prefer braces (for one liners).
 dotnet_diagnostic.IDE0011.severity = none
 
+# Avoid unnecessary zero-length array allocations.
+dotnet_diagnostic.CA1825.severity = warning
+
 ; 4-column tab indentation
 [*.yaml]
 indent_style = tab

--- a/OpenRA.Game/Graphics/HardwarePalette.cs
+++ b/OpenRA.Game/Graphics/HardwarePalette.cs
@@ -24,8 +24,8 @@ namespace OpenRA.Graphics
 		readonly Dictionary<string, ImmutablePalette> palettes = new Dictionary<string, ImmutablePalette>();
 		readonly Dictionary<string, MutablePalette> mutablePalettes = new Dictionary<string, MutablePalette>();
 		readonly Dictionary<string, int> indices = new Dictionary<string, int>();
-		byte[] buffer = new byte[0];
-		float[] colorShiftBuffer = new float[0];
+		byte[] buffer = Array.Empty<byte>();
+		float[] colorShiftBuffer = Array.Empty<float>();
 
 		public HardwarePalette()
 		{

--- a/OpenRA.Game/Graphics/SpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderable.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using OpenRA.Primitives;
 
@@ -16,7 +17,7 @@ namespace OpenRA.Graphics
 {
 	public class SpriteRenderable : IPalettedRenderable, IModifyableRenderable, IFinalizedRenderable
 	{
-		public static readonly IEnumerable<IRenderable> None = new IRenderable[0];
+		public static readonly IEnumerable<IRenderable> None = Array.Empty<IRenderable>();
 
 		readonly Sprite sprite;
 		readonly WPos pos;

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -370,11 +370,11 @@ namespace OpenRA
 					newData.SpawnPoints = spawns.ToArray();
 				}
 				else
-					newData.SpawnPoints = new CPos[0];
+					newData.SpawnPoints = Array.Empty<CPos>();
 			}
 			catch (Exception)
 			{
-				newData.SpawnPoints = new CPos[0];
+				newData.SpawnPoints = Array.Empty<CPos>();
 				newData.Status = MapStatus.Unavailable;
 			}
 

--- a/OpenRA.Game/Primitives/TypeDictionary.cs
+++ b/OpenRA.Game/Primitives/TypeDictionary.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Primitives
 		{
 			if (data.TryGetValue(typeof(T), out var objs))
 				return objs.Cast<T>();
-			return new T[0];
+			return Array.Empty<T>();
 		}
 
 		public void Remove<T>(T val)

--- a/OpenRA.Game/Scripting/ScriptContext.cs
+++ b/OpenRA.Game/Scripting/ScriptContext.cs
@@ -279,7 +279,7 @@ namespace OpenRA.Scripting
 			return outer.SelectMany(i => i.GetGenericArguments());
 		}
 
-		static readonly object[] NoArguments = new object[0];
+		static readonly object[] NoArguments = Array.Empty<object>();
 		Type[] FilterActorCommands(ActorInfo ai)
 		{
 			return FilterCommands(ai, knownActorCommands);

--- a/OpenRA.Game/StreamExts.cs
+++ b/OpenRA.Game/StreamExts.cs
@@ -229,7 +229,7 @@ namespace OpenRA
 			if (!string.IsNullOrEmpty(text))
 				bytes = encoding.GetBytes(text);
 			else
-				bytes = new byte[0];
+				bytes = Array.Empty<byte>();
 
 			s.Write(bytes.Length);
 			s.WriteArray(bytes);

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -72,8 +72,8 @@ namespace OpenRA.Traits
 
 		public Polygon MouseBounds = Polygon.Empty;
 
-		static readonly IRenderable[] NoRenderables = new IRenderable[0];
-		static readonly Rectangle[] NoBounds = new Rectangle[0];
+		static readonly IRenderable[] NoRenderables = Array.Empty<IRenderable>();
+		static readonly Rectangle[] NoBounds = Array.Empty<Rectangle>();
 
 		int flashTicks;
 		TintModifiers flashModifiers;

--- a/OpenRA.Game/Traits/World/ScreenMap.cs
+++ b/OpenRA.Game/Traits/World/ScreenMap.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Traits
 
 	public class ScreenMap : IWorldLoaded
 	{
-		static readonly IEnumerable<FrozenActor> NoFrozenActors = new FrozenActor[0];
+		static readonly IEnumerable<FrozenActor> NoFrozenActors = Array.Empty<FrozenActor>();
 		readonly Func<FrozenActor, bool> frozenActorIsValid = fa => fa.IsValid;
 		readonly Func<Actor, bool> actorIsInWorld = a => a.IsInWorld;
 		readonly Func<Actor, ActorBoundsPair> selectActorAndBounds;

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -51,7 +51,7 @@ namespace OpenRA
 		public LongBitSet<PlayerBitMask> AllPlayersMask = default(LongBitSet<PlayerBitMask>);
 		public readonly LongBitSet<PlayerBitMask> NoPlayersMask = default(LongBitSet<PlayerBitMask>);
 
-		public Player[] Players = new Player[0];
+		public Player[] Players = Array.Empty<Player>();
 
 		public event Action<Player> RenderPlayerChanged;
 

--- a/OpenRA.Mods.Cnc/Graphics/TeslaZapRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/TeslaZapRenderable.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 
 			cachedPos = WPos.Zero;
 			cachedLength = WVec.Zero;
-			cache = new IFinalizedRenderable[] { };
+			cache = Array.Empty<IFinalizedRenderable>();
 		}
 
 		public WPos Pos => pos;

--- a/OpenRA.Mods.Cnc/SpriteLoaders/TmpRALoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/TmpRALoader.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.IO;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
@@ -32,7 +33,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 				Data = data;
 
 				if (data == null)
-					Data = new byte[0];
+					Data = Array.Empty<byte>();
 				else
 					Size = size;
 			}

--- a/OpenRA.Mods.Cnc/SpriteLoaders/TmpTDLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/TmpTDLoader.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.IO;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
@@ -32,7 +33,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 				Data = data;
 
 				if (data == null)
-					Data = new byte[0];
+					Data = Array.Empty<byte>();
 				else
 					Size = size;
 			}

--- a/OpenRA.Mods.Cnc/SpriteLoaders/TmpTSLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/TmpTSLoader.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.IO;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
@@ -109,7 +110,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 					}
 				}
 				else
-					Data = new byte[0];
+					Data = Array.Empty<byte>();
 			}
 		}
 

--- a/OpenRA.Mods.Cnc/UtilityCommands/RemapShpCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/RemapShpCommand.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			Game.ModData = destModData;
 			var destPaletteInfo = destModData.DefaultRules.Actors[SystemActors.Player].TraitInfo<PlayerColorPaletteInfo>();
 			var destRemapIndex = destPaletteInfo.RemapIndex;
-			var shadowIndex = new int[] { };
+			var shadowIndex = Array.Empty<int>();
 
 			// the remap range is always 16 entries, but their location and order changes
 			for (var i = 0; i < 16; i++)

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Activities
 			aircraft = self.Trait<Aircraft>();
 			this.target = target;
 			this.offset = offset;
-			this.clearCells = clearCells ?? new CPos[0];
+			this.clearCells = clearCells ?? Array.Empty<CPos>();
 			this.landRange = landRange.Length >= 0 ? landRange : aircraft.Info.LandRange;
 			this.targetLineColor = targetLineColor;
 

--- a/OpenRA.Mods.Common/Effects/SpawnActorEffect.cs
+++ b/OpenRA.Mods.Common/Effects/SpawnActorEffect.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Effects;
@@ -26,10 +27,10 @@ namespace OpenRA.Mods.Common.Effects
 		int remainingDelay;
 
 		public SpawnActorEffect(Actor actor)
-			: this(actor, 0, new CPos[0], null) { }
+			: this(actor, 0, Array.Empty<CPos>(), null) { }
 
 		public SpawnActorEffect(Actor actor, int delay)
-			: this(actor, delay, new CPos[0], null) { }
+			: this(actor, delay, Array.Empty<CPos>(), null) { }
 
 		public SpawnActorEffect(Actor actor, int delay, CPos[] pathAfterSpawn, Activity activityAtDestination)
 		{

--- a/OpenRA.Mods.Common/SpriteLoaders/TgaLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/TgaLoader.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -78,7 +79,7 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 
 			public TgaFrame()
 			{
-				Data = new byte[0];
+				Data = Array.Empty<byte>();
 			}
 
 			public TgaFrame(Stream stream)

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 				throw new YamlException("Facing tolerance must be in range of [0, 512], 512 covers 360 degrees.");
 		}
 
-		public override abstract object Create(ActorInitializer init);
+		public abstract override object Create(ActorInitializer init);
 	}
 
 	public abstract class AttackBase : PausableConditionalTrait<AttackBaseInfo>, ITick, IIssueOrder, IResolveOrder, IOrderVoice, ISync

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class AttackFrontalInfo : AttackBaseInfo, Requires<IFacingInfo>
 	{
 		[Desc("Tolerance for attack angle. Range [0, 512], 512 covers 360 degrees.")]
-		public readonly new WAngle FacingTolerance = WAngle.Zero;
+		public new readonly WAngle FacingTolerance = WAngle.Zero;
 
 		public override object Create(ActorInitializer init) { return new AttackFrontal(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class AttackGarrisoned : AttackFollow, INotifyPassengerEntered, INotifyPassengerExited, IRender
 	{
-		public readonly new AttackGarrisonedInfo Info;
+		public new readonly AttackGarrisonedInfo Info;
 		Lazy<BodyOrientation> coords;
 		List<Armament> armaments;
 		List<AnimationWithOffset> muzzles;

--- a/OpenRA.Mods.Common/Traits/Buildings/LineBuild.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/LineBuild.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
@@ -27,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Actor[] parents = null;
 
 		public LineBuildParentInit(Actor[] value)
-			: base(new string[0])
+			: base(Array.Empty<string>())
 		{
 			parents = value;
 		}
@@ -70,7 +71,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class LineBuild : INotifyKilled, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyLineBuildSegmentsChanged
 	{
 		readonly LineBuildInfo info;
-		readonly Actor[] parentNodes = new Actor[0];
+		readonly Actor[] parentNodes = Array.Empty<Actor>();
 		HashSet<Actor> segments;
 
 		public LineBuild(ActorInitializer init, LineBuildInfo info)

--- a/OpenRA.Mods.Common/Traits/Immobile.cs
+++ b/OpenRA.Mods.Common/Traits/Immobile.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using OpenRA.Traits;
 
@@ -46,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.OccupiesSpace)
 				occupied = new[] { (TopLeft, SubCell.FullCell) };
 			else
-				occupied = new (CPos, SubCell)[0];
+				occupied = Array.Empty<(CPos, SubCell)>();
 		}
 
 		public CPos TopLeft => location;

--- a/OpenRA.Mods.Common/Traits/Targetable.cs
+++ b/OpenRA.Mods.Common/Traits/Targetable.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -29,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class Targetable : ConditionalTrait<TargetableInfo>, ITargetable
 	{
-		protected static readonly string[] None = new string[] { };
+		protected static readonly string[] None = Array.Empty<string>();
 		protected Cloak[] cloaks;
 
 		public Targetable(Actor self, TargetableInfo info)

--- a/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			var modData = Game.ModData = utility.ModData;
 
 			var src = args[1];
-			var shadowIndex = new int[] { };
+			var shadowIndex = Array.Empty<int>();
 			if (args.Contains("--noshadow"))
 			{
 				Array.Resize(ref shadowIndex, shadowIndex.Length + 3);

--- a/OpenRA.Mods.Common/UtilityCommands/CreateManPage.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CreateManPage.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			Console.WriteLine(".SH OPTIONS");
 
 			var sections = Game.Settings.Sections;
-			sections.Add("Launch", new LaunchArguments(new Arguments(new string[0])));
+			sections.Add("Launch", new LaunchArguments(new Arguments(Array.Empty<string>())));
 			foreach (var section in sections.OrderBy(s => s.Key))
 			{
 				var fields = section.Value.GetType().GetFields();

--- a/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			// HACK: The engine code assumes that Game.modData is set.
 			var modData = Game.ModData = utility.ModData;
 
-			var palette = new ImmutablePalette(args[1], new[] { 0 }, new int[0]);
+			var palette = new ImmutablePalette(args[1], new[] { 0 }, Array.Empty<int>());
 
 			SequenceProvider sequences = null;
 			var mapPackage = new Folder(Platform.EngineDir).OpenPackage(args[2], modData.ModFiles);

--- a/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.GameRules;
@@ -80,8 +81,8 @@ namespace OpenRA.Mods.Common.Warheads
 				CurrentMuzzleFacing = () => (map.CenterOfCell(targetCell) - target.CenterPosition).Yaw,
 
 				DamageModifiers = args.DamageModifiers,
-				InaccuracyModifiers = new int[0],
-				RangeModifiers = new int[0],
+				InaccuracyModifiers = Array.Empty<int>(),
+				RangeModifiers = Array.Empty<int>(),
 
 				Source = target.CenterPosition,
 				CurrentSource = () => target.CenterPosition,

--- a/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		readonly WorldRenderer worldRenderer;
 
-		IActorPreview[] preview = new IActorPreview[0];
+		IActorPreview[] preview = Array.Empty<IActorPreview>();
 		public int2 PreviewOffset { get; private set; }
 		public int2 IdealPreviewSize { get; private set; }
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Widgets
 		int scatterHighlighted;
 		int stopHighlighted;
 
-		TraitPair<IIssueDeployOrder>[] selectedDeploys = { };
+		TraitPair<IIssueDeployOrder>[] selectedDeploys = Array.Empty<TraitPair<IIssueDeployOrder>>();
 
 		[ObjectCreator.UseCtor]
 		public CommandBarLogic(Widget widget, World world, Dictionary<string, MiniYaml> logicArgs)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/StanceSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/StanceSelectorLogic.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Widgets;
@@ -20,7 +21,7 @@ namespace OpenRA.Mods.Common.Widgets
 		readonly World world;
 
 		int selectionHash;
-		TraitPair<AutoTarget>[] actorStances = { };
+		TraitPair<AutoTarget>[] actorStances = Array.Empty<TraitPair<AutoTarget>>();
 
 		[ObjectCreator.UseCtor]
 		public StanceSelectorLogic(Widget widget, World world)

--- a/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
+++ b/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 	class AttackSwallow : AttackFrontal
 	{
-		public readonly new AttackSwallowInfo Info;
+		public new readonly AttackSwallowInfo Info;
 
 		public AttackSwallow(Actor self, AttackSwallowInfo info)
 			: base(self, info)

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -68,7 +68,7 @@ namespace OpenRA
 
 			if (args.Length == 0)
 			{
-				PrintUsage(new InstalledMods(modSearchPaths, new string[0]), null);
+				PrintUsage(new InstalledMods(modSearchPaths, Array.Empty<string>()), null);
 				return;
 			}
 


### PR DESCRIPTION
This is a continuation of my recent efforts to finally have our toolchain enforce our long-standing code style rules.
Follow-up of  #19747 and #19801, this adds ~~two~~ three more rules to `.editorconfig` to treat ~~two~~ three more suggestions as warnings, which the CI then treats as errors.
Calling @RoosterDragon.