### PR TITLE
Add transient text notifications matching speech notifications

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -37,7 +37,8 @@ namespace OpenRA
 	public enum TextNotificationPoolFilters
 	{
 		None = 0,
-		Feedback = 1
+		Feedback = 1,
+		Transients = 2
 	}
 
 	public enum WorldViewport { Native, Close, Medium, Far }
@@ -273,7 +274,7 @@ namespace OpenRA
 		[Desc("Allow mods to enable the Discord service that can interact with a local Discord client.")]
 		public bool EnableDiscordService = true;
 
-		public TextNotificationPoolFilters TextNotificationPoolFilters = TextNotificationPoolFilters.Feedback;
+		public TextNotificationPoolFilters TextNotificationPoolFilters = TextNotificationPoolFilters.Feedback | TextNotificationPoolFilters.Transients;
 	}
 
 	public class Settings

--- a/OpenRA.Game/TextNotification.cs
+++ b/OpenRA.Game/TextNotification.cs
@@ -14,7 +14,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA
 {
-	public enum TextNotificationPool { System, Chat, Mission, Feedback }
+	public enum TextNotificationPool { System, Chat, Mission, Feedback, Transients }
 
 	public class TextNotification : IEquatable<TextNotification>
 	{
@@ -37,7 +37,7 @@ namespace OpenRA
 
 		public bool CanIncrementOnDuplicate()
 		{
-			return Pool == TextNotificationPool.Feedback || Pool == TextNotificationPool.System;
+			return Pool == TextNotificationPool.Feedback || Pool == TextNotificationPool.System || Pool == TextNotificationPool.Transients;
 		}
 
 		public static bool operator ==(TextNotification me, TextNotification other) { return me.GetHashCode() == other.GetHashCode(); }

--- a/OpenRA.Game/TextNotificationsManager.cs
+++ b/OpenRA.Game/TextNotificationsManager.cs
@@ -26,6 +26,14 @@ namespace OpenRA
 				SystemMessageLabel = "Battlefield Control";
 		}
 
+		public static void AddTransientLine(string text)
+		{
+			if (string.IsNullOrEmpty(text))
+				return;
+
+			AddTextNotification(TextNotificationPool.Transients, SystemMessageLabel, text);
+		}
+
 		public static void AddFeedbackLine(string text)
 		{
 			AddTextNotification(TextNotificationPool.Feedback, SystemMessageLabel, text);
@@ -69,6 +77,7 @@ namespace OpenRA
 			return pool == TextNotificationPool.Chat ||
 				pool == TextNotificationPool.System ||
 				pool == TextNotificationPool.Mission ||
+				(pool == TextNotificationPool.Transients && filters.HasFlag(TextNotificationPoolFilters.Transients)) ||
 				(pool == TextNotificationPool.Feedback && filters.HasFlag(TextNotificationPoolFilters.Feedback));
 		}
 	}

--- a/OpenRA.Game/TextNotificationsManager.cs
+++ b/OpenRA.Game/TextNotificationsManager.cs
@@ -26,12 +26,13 @@ namespace OpenRA
 				SystemMessageLabel = "Battlefield Control";
 		}
 
-		public static void AddTransientLine(string text)
+		public static void AddTransientLine(string text, Player player)
 		{
 			if (string.IsNullOrEmpty(text))
 				return;
 
-			AddTextNotification(TextNotificationPool.Transients, SystemMessageLabel, text);
+			if (player == null || player == player.World.LocalPlayer)
+				AddTextNotification(TextNotificationPool.Transients, SystemMessageLabel, text);
 		}
 
 		public static void AddFeedbackLine(string text)

--- a/OpenRA.Mods.Cnc/Activities/Infiltrate.cs
+++ b/OpenRA.Mods.Cnc/Activities/Infiltrate.cs
@@ -71,6 +71,8 @@ namespace OpenRA.Mods.Cnc.Activities
 				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech",
 					infiltrates.Info.Notification, self.Owner.Faction.InternalName);
 
+			TextNotificationsManager.AddTransientLine(infiltrates.Info.TextNotification, self.Owner);
+
 			if (infiltrates.Info.EnterBehaviour == EnterBehaviour.Dispose)
 				self.Dispose();
 			else if (infiltrates.Info.EnterBehaviour == EnterBehaviour.Suicide)

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForCash.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForCash.cs
@@ -37,9 +37,15 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sound the victim will hear when they get robbed.")]
 		public readonly string InfiltratedNotification = null;
 
+		[Desc("Text notification the victim will see when they get robbed.")]
+		public readonly string InfiltratedTextNotification = null;
+
 		[NotificationReference("Speech")]
 		[Desc("Sound the perpetrator will hear after successful infiltration.")]
 		public readonly string InfiltrationNotification = null;
+
+		[Desc("Text notification the perpetrator will see after successful infiltration.")]
+		public readonly string InfiltrationTextNotification = null;
 
 		[Desc("Whether to show the cash tick indicators rising from the actor.")]
 		public readonly bool ShowTicks = true;
@@ -73,6 +79,9 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			if (info.InfiltrationNotification != null)
 				Game.Sound.PlayNotification(self.World.Map.Rules, infiltrator.Owner, "Speech", info.InfiltrationNotification, infiltrator.Owner.Faction.InternalName);
+
+			TextNotificationsManager.AddTransientLine(info.InfiltratedTextNotification, self.Owner);
+			TextNotificationsManager.AddTransientLine(info.InfiltrationTextNotification, infiltrator.Owner);
 
 			if (info.ShowTicks)
 				self.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, infiltrator.Owner.Color, FloatingText.FormatCashTick(toGive), 30)));

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForExploration.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForExploration.cs
@@ -26,9 +26,15 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sound the victim will hear when they get sabotaged.")]
 		public readonly string InfiltratedNotification = null;
 
+		[Desc("Text notification the victim will see when they get sabotaged.")]
+		public readonly string InfiltratedTextNotification = null;
+
 		[NotificationReference("Speech")]
 		[Desc("Sound the perpetrator will hear after successful infiltration.")]
 		public readonly string InfiltrationNotification = null;
+
+		[Desc("Text notification the perpetrator will see after successful infiltration.")]
+		public readonly string InfiltrationTextNotification = null;
 
 		public override object Create(ActorInitializer init) { return new InfiltrateForExploration(this); }
 	}
@@ -52,6 +58,9 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			if (info.InfiltrationNotification != null)
 				Game.Sound.PlayNotification(self.World.Map.Rules, infiltrator.Owner, "Speech", info.InfiltrationNotification, infiltrator.Owner.Faction.InternalName);
+
+			TextNotificationsManager.AddTransientLine(info.InfiltratedTextNotification, self.Owner);
+			TextNotificationsManager.AddTransientLine(info.InfiltrationTextNotification, infiltrator.Owner);
 
 			infiltrator.Owner.Shroud.Explore(self.Owner.Shroud);
 			var preventReset = self.Owner.PlayerActor.TraitsImplementing<IPreventsShroudReset>()

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForPowerOutage.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForPowerOutage.cs
@@ -27,9 +27,15 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sound the victim will hear when they get sabotaged.")]
 		public readonly string InfiltratedNotification = null;
 
+		[Desc("Text notification the victim will see when they get sabotaged.")]
+		public readonly string InfiltratedTextNotification = null;
+
 		[NotificationReference("Speech")]
 		[Desc("Sound the perpetrator will hear after successful infiltration.")]
 		public readonly string InfiltrationNotification = null;
+
+		[Desc("Text notification the perpetrator will see after successful infiltration.")]
+		public readonly string InfiltrationTextNotification = null;
 
 		public override object Create(ActorInitializer init) { return new InfiltrateForPowerOutage(init.Self, this); }
 	}
@@ -55,6 +61,9 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			if (info.InfiltrationNotification != null)
 				Game.Sound.PlayNotification(self.World.Map.Rules, infiltrator.Owner, "Speech", info.InfiltrationNotification, infiltrator.Owner.Faction.InternalName);
+
+			TextNotificationsManager.AddTransientLine(info.InfiltratedTextNotification, self.Owner);
+			TextNotificationsManager.AddTransientLine(info.InfiltrationTextNotification, infiltrator.Owner);
 
 			playerPower.TriggerPowerOutage(info.Duration);
 		}

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPower.cs
@@ -28,9 +28,15 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sound the victim will hear when technology gets stolen.")]
 		public readonly string InfiltratedNotification = null;
 
+		[Desc("Text notification the victim will see when technology gets stolen.")]
+		public readonly string InfiltratedTextNotification = null;
+
 		[NotificationReference("Speech")]
 		[Desc("Sound the perpetrator will hear after successful infiltration.")]
 		public readonly string InfiltrationNotification = null;
+
+		[Desc("Text notification the perpetrator will see after successful infiltration.")]
+		public readonly string InfiltrationTextNotification = null;
 
 		public override object Create(ActorInitializer init) { return new InfiltrateForSupportPower(this); }
 	}
@@ -54,6 +60,9 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			if (info.InfiltrationNotification != null)
 				Game.Sound.PlayNotification(self.World.Map.Rules, infiltrator.Owner, "Speech", info.InfiltrationNotification, infiltrator.Owner.Faction.InternalName);
+
+			TextNotificationsManager.AddTransientLine(info.InfiltratedTextNotification, self.Owner);
+			TextNotificationsManager.AddTransientLine(info.InfiltrationTextNotification, infiltrator.Owner);
 
 			infiltrator.World.AddFrameEndTask(w => w.CreateActor(info.Proxy, new TypeDictionary
 			{

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPowerReset.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPowerReset.cs
@@ -22,12 +22,18 @@ namespace OpenRA.Mods.Cnc.Traits
 		public readonly BitSet<TargetableType> Types = default(BitSet<TargetableType>);
 
 		[NotificationReference("Speech")]
-		[Desc("Sound the victim will hear when technology gets stolen.")]
+		[Desc("Sound the victim will hear when they get sabotaged.")]
 		public readonly string InfiltratedNotification = null;
+
+		[Desc("Text notification the victim will see when they get sabotaged.")]
+		public readonly string InfiltratedTextNotification = null;
 
 		[NotificationReference("Speech")]
 		[Desc("Sound the perpetrator will hear after successful infiltration.")]
 		public readonly string InfiltrationNotification = null;
+
+		[Desc("Text notification the perpetrator will see after successful infiltration.")]
+		public readonly string InfiltrationTextNotification = null;
 
 		public override object Create(ActorInitializer init) { return new InfiltrateForSupportPowerReset(this); }
 	}
@@ -51,6 +57,9 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			if (info.InfiltrationNotification != null)
 				Game.Sound.PlayNotification(self.World.Map.Rules, infiltrator.Owner, "Speech", info.InfiltrationNotification, infiltrator.Owner.Faction.InternalName);
+
+			TextNotificationsManager.AddTransientLine(info.InfiltratedTextNotification, self.Owner);
+			TextNotificationsManager.AddTransientLine(info.InfiltrationTextNotification, infiltrator.Owner);
 
 			var manager = self.Owner.PlayerActor.Trait<SupportPowerManager>();
 			var powers = manager.GetPowersForActor(self).Where(sp => !sp.Disabled);

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
@@ -41,6 +41,9 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Notification to play when a target is infiltrated.")]
 		public readonly string Notification = null;
 
+		[Desc("Text notification to display when a target is infiltrated.")]
+		public readonly string TextNotification = null;
+
 		[Desc("Experience to grant to the infiltrating player.")]
 		public readonly int PlayerExperience = 0;
 

--- a/OpenRA.Mods.Common/Activities/RepairBridge.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBridge.cs
@@ -18,17 +18,19 @@ namespace OpenRA.Mods.Common.Activities
 	class RepairBridge : Enter
 	{
 		readonly EnterBehaviour enterBehaviour;
-		readonly string notification;
+		readonly string speechNotification;
+		readonly string textNotification;
 
 		Actor enterActor;
 		BridgeHut enterHut;
 		LegacyBridgeHut enterLegacyHut;
 
-		public RepairBridge(Actor self, in Target target, EnterBehaviour enterBehaviour, string notification, Color targetLineColor)
+		public RepairBridge(Actor self, in Target target, EnterBehaviour enterBehaviour, string speechNotification, string textNotification, Color targetLineColor)
 			: base(self, target, targetLineColor)
 		{
 			this.enterBehaviour = enterBehaviour;
-			this.notification = notification;
+			this.speechNotification = speechNotification;
+			this.textNotification = textNotification;
 		}
 
 		bool CanEnterHut()
@@ -75,7 +77,8 @@ namespace OpenRA.Mods.Common.Activities
 			else if (enterHut != null)
 				enterHut.Repair(self);
 
-			Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", notification, self.Owner.Faction.InternalName);
+			Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", speechNotification, self.Owner.Faction.InternalName);
+			TextNotificationsManager.AddTransientLine(textNotification, self.Owner);
 
 			if (enterBehaviour == EnterBehaviour.Dispose)
 				self.Dispose();

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -262,6 +262,7 @@ namespace OpenRA.Mods.Common.Activities
 					host.Actor.Owner.PlayerActor.TraitOrDefault<PlayerExperience>()?.GiveExperience(repairsUnits.Info.PlayerExperience);
 
 				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", repairsUnits.Info.FinishRepairingNotification, self.Owner.Faction.InternalName);
+				TextNotificationsManager.AddTransientLine(repairsUnits.Info.FinishRepairingTextNotification, self.Owner);
 
 				activeResupplyTypes &= ~ResupplyType.Repair;
 				return;
@@ -279,6 +280,7 @@ namespace OpenRA.Mods.Common.Activities
 				{
 					played = true;
 					Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", repairsUnits.Info.StartRepairingNotification, self.Owner.Faction.InternalName);
+					TextNotificationsManager.AddTransientLine(repairsUnits.Info.StartRepairingTextNotification, self.Owner);
 				}
 
 				if (!playerResources.TakeCash(cost, true))

--- a/OpenRA.Mods.Common/Activities/Sell.cs
+++ b/OpenRA.Mods.Common/Activities/Sell.cs
@@ -49,6 +49,7 @@ namespace OpenRA.Mods.Common.Activities
 				self.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, self.Owner.Color, FloatingText.FormatCashTick(refund), 30)));
 
 			Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", sellableInfo.Notification, self.Owner.Faction.InternalName);
+			TextNotificationsManager.AddTransientLine(sellableInfo.TextNotification, self.Owner);
 
 			self.Dispose();
 			return false;

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -26,6 +26,7 @@ namespace OpenRA.Mods.Common.Activities
 		public WAngle Facing = new WAngle(384);
 		public string[] Sounds = Array.Empty<string>();
 		public string Notification = null;
+		public string TextNotification = null;
 		public int ForceHealthPercentage = 0;
 		public bool SkipMakeAnims = false;
 		public string Faction = null;
@@ -95,6 +96,7 @@ namespace OpenRA.Mods.Common.Activities
 					Game.Sound.PlayToPlayer(SoundType.World, self.Owner, s, self.CenterPosition);
 
 				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Notification, self.Owner.Faction.InternalName);
+				TextNotificationsManager.AddTransientLine(TextNotification, self.Owner);
 
 				var init = new TypeDictionary
 				{

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -180,6 +180,8 @@ namespace OpenRA.Mods.Common.Orders
 					if (!AcceptsPlug(topLeft, plugInfo))
 					{
 						Game.Sound.PlayNotification(world.Map.Rules, owner, "Speech", notification, owner.Faction.InternalName);
+						TextNotificationsManager.AddTransientLine(placeBuildingInfo.CannotPlaceTextNotification, owner);
+
 						yield break;
 					}
 				}
@@ -192,6 +194,8 @@ namespace OpenRA.Mods.Common.Orders
 							yield return order;
 
 						Game.Sound.PlayNotification(world.Map.Rules, owner, "Speech", notification, owner.Faction.InternalName);
+						TextNotificationsManager.AddTransientLine(placeBuildingInfo.CannotPlaceTextNotification, owner);
+
 						yield break;
 					}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
@@ -34,8 +34,11 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string PrimaryCondition = null;
 
 		[NotificationReference("Speech")]
-		[Desc("The speech notification to play when selecting a primary building.")]
+		[Desc("Speech notification to play when selecting a primary building.")]
 		public readonly string SelectionNotification = null;
+
+		[Desc("Text notification to display when selecting a primary building.")]
+		public readonly string SelectionTextNotification = null;
 
 		[Desc("List of production queues for which the primary flag should be set.",
 			"If empty, the list given in the `Produces` property of the `" + nameof(Production) + "` trait will be used.")]
@@ -113,6 +116,7 @@ namespace OpenRA.Mods.Common.Traits
 					primaryToken = self.GrantCondition(Info.PrimaryCondition);
 
 				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.SelectionNotification, self.Owner.Faction.InternalName);
+				TextNotificationsManager.AddTransientLine(Info.SelectionTextNotification, self.Owner);
 			}
 			else if (primaryToken != Actor.InvalidConditionToken)
 				primaryToken = self.RevokeCondition(primaryToken);

--- a/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
@@ -21,7 +21,11 @@ namespace OpenRA.Mods.Common.Traits
 	public class ProductionAirdropInfo : ProductionInfo
 	{
 		[NotificationReference("Speech")]
+		[Desc("Speech notification to play when a unit is delivered.")]
 		public readonly string ReadyAudio = "Reinforce";
+
+		[Desc("Text notification to display when a unit is delivered.")]
+		public readonly string ReadyTextNotification = null;
 
 		[FieldLoader.Require]
 		[ActorReference(typeof(AircraftInfo))]
@@ -112,6 +116,7 @@ namespace OpenRA.Mods.Common.Traits
 
 					self.World.AddFrameEndTask(ww => DoProduction(self, producee, exit, productionType, inits));
 					Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.ReadyAudio, self.Owner.Faction.InternalName);
+					TextNotificationsManager.AddTransientLine(info.ReadyTextNotification, self.Owner);
 				}));
 
 				actor.QueueActivity(new FlyOffMap(actor, Target.FromCell(w, endPos)));

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -46,8 +46,11 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly CVec[] Path = Array.Empty<CVec>();
 
 		[NotificationReference("Speech")]
-		[Desc("The speech notification to play when setting a new rallypoint.")]
+		[Desc("Speech notification to play when setting a new rallypoint.")]
 		public readonly string Notification = null;
+
+		[Desc("Text notification to display when setting a new rallypoint.")]
+		public readonly string TextNotification = null;
 
 		[Desc("Used to group equivalent actors to allow force-setting a rallypoint (e.g. for Primary production).")]
 		public readonly string ForceSetType = null;
@@ -101,6 +104,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (order.OrderID == OrderID)
 			{
 				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.Notification, self.Owner.Faction.InternalName);
+				TextNotificationsManager.AddTransientLine(Info.TextNotification, self.Owner);
 
 				return new Order(order.OrderID, self, target, queued)
 				{

--- a/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
@@ -49,6 +49,8 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Speech")]
 		public readonly string RepairingNotification = null;
 
+		public readonly string RepairingTextNotification = null;
+
 		public override object Create(ActorInitializer init) { return new RepairableBuilding(init.Self, this); }
 	}
 
@@ -111,7 +113,10 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			Repairers.Add(player);
+
 			Game.Sound.PlayNotification(self.World.Map.Rules, player, "Speech", Info.RepairingNotification, player.Faction.InternalName);
+			TextNotificationsManager.AddTransientLine(Info.RepairingTextNotification, self.Owner);
+
 			UpdateCondition(self);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Conditions/ToggleConditionOnOrder.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ToggleConditionOnOrder.cs
@@ -31,11 +31,15 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Speech")]
 		public readonly string EnabledSpeech = null;
 
+		public readonly string EnabledTextNotification = null;
+
 		[NotificationReference("Sounds")]
 		public readonly string DisabledSound = null;
 
 		[NotificationReference("Speech")]
 		public readonly string DisabledSpeech = null;
+
+		public readonly string DisabledTextNotification = null;
 
 		public override object Create(ActorInitializer init) { return new ToggleConditionOnOrder(this); }
 	}
@@ -62,6 +66,8 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (Info.EnabledSpeech != null)
 					Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.EnabledSpeech, self.Owner.Faction.InternalName);
+
+				TextNotificationsManager.AddTransientLine(Info.EnabledTextNotification, self.Owner);
 			}
 			else if (!granted && conditionToken != Actor.InvalidConditionToken)
 			{
@@ -72,6 +78,8 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (Info.DisabledSpeech != null)
 					Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.DisabledSpeech, self.Owner.Faction.InternalName);
+
+				TextNotificationsManager.AddTransientLine(Info.DisabledTextNotification, self.Owner);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
@@ -36,8 +36,11 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Sound = null;
 
 		[NotificationReference("Speech")]
-		[Desc("Notification to play when the crate is collected.")]
+		[Desc("Speech notification to play when the crate is collected.")]
 		public readonly string Notification = null;
+
+		[Desc("Text notification to display when the crate is collected.")]
+		public readonly string TextNotification = null;
 
 		[Desc("The earliest time (in ticks) that this crate action can occur on.")]
 		public readonly int TimeDelay = 0;
@@ -91,6 +94,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!string.IsNullOrEmpty(Info.Notification))
 				Game.Sound.PlayNotification(self.World.Map.Rules, collector.Owner, "Speech",
 					Info.Notification, collector.Owner.Faction.InternalName);
+
+			TextNotificationsManager.AddTransientLine(Info.TextNotification, collector.Owner);
 
 			if (Info.Image != null && Info.Sequence != null)
 				collector.World.AddFrameEndTask(w => w.Add(new SpriteEffect(collector, w, Info.Image, Info.Sequence, Info.Palette)));

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -49,6 +49,8 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Sounds")]
 		public readonly string LevelUpNotification = null;
 
+		public readonly string LevelUpTextNotification = null;
+
 		public override object Create(ActorInitializer init) { return new GainsExperience(init, this); }
 	}
 
@@ -119,6 +121,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (!silent)
 				{
 					Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", info.LevelUpNotification, self.Owner.Faction.InternalName);
+					TextNotificationsManager.AddTransientLine(info.LevelUpTextNotification, self.Owner);
+
 					if (info.LevelUpImage != null && info.LevelUpSequence != null)
 						self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(self, w, info.LevelUpImage, info.LevelUpSequence, info.LevelUpPalette)));
 				}

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -103,7 +103,10 @@ namespace OpenRA.Mods.Common.Traits
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)
+				{
 					Game.Sound.PlayNotification(player.World.Map.Rules, player, "Speech", mo.Info.LoseNotification, player.Faction.InternalName);
+					TextNotificationsManager.AddTransientLine(mo.Info.LoseTextNotification, player);
+				}
 			});
 		}
 
@@ -116,7 +119,10 @@ namespace OpenRA.Mods.Common.Traits
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)
+				{
 					Game.Sound.PlayNotification(player.World.Map.Rules, player, "Speech", mo.Info.WinNotification, player.Faction.InternalName);
+					TextNotificationsManager.AddTransientLine(mo.Info.WinTextNotification, player);
+				}
 			});
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
+++ b/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
@@ -89,8 +89,9 @@ namespace OpenRA.Mods.Common.Traits
 				if (lastKnownActorIds.Contains(actor.Actor.ActorID))
 					continue;
 
-				// Should we play a sound notification?
-				var playNotification = !playedNotifications.Contains(actor.Trait.Info.Notification) && ticksBeforeNextNotification <= 0;
+				// Should we play a notification?
+				var notificationId = $"{actor.Trait.Info.Notification} {actor.Trait.Info.TextNotification}";
+				var playNotification = !playedNotifications.Contains(notificationId) && ticksBeforeNextNotification <= 0;
 
 				// Notify the actor that he has been discovered
 				foreach (var trait in actor.Actor.TraitsImplementing<INotifyDiscovered>())
@@ -109,7 +110,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!playNotification)
 					continue;
 
-				playedNotifications.Add(actor.Trait.Info.Notification);
+				playedNotifications.Add(notificationId);
 				announcedAny = true;
 			}
 

--- a/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
@@ -28,8 +28,11 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int RadarPingDuration = 250;
 
 		[NotificationReference("Speech")]
-		[Desc("The audio notification type to play.")]
+		[Desc("Speech notification type to play.")]
 		public readonly string Notification = "HarvesterAttack";
+
+		[Desc("Text notification to display.")]
+		public string TextNotification = null;
 
 		public override object Create(ActorInitializer init) { return new HarvesterAttackNotifier(init.Self, this); }
 	}
@@ -61,6 +64,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (Game.RunTime > lastAttackTime + info.NotifyInterval)
 			{
 				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.Notification, self.Owner.Faction.InternalName);
+				TextNotificationsManager.AddTransientLine(info.TextNotification, self.Owner);
+
 				radarPings?.Add(() => self.Owner.IsAlliedWith(self.World.RenderPlayer), self.CenterPosition, info.RadarPingColor, info.RadarPingDuration);
 
 				lastAttackTime = Game.RunTime;

--- a/OpenRA.Mods.Common/Traits/Player/MissionObjectives.cs
+++ b/OpenRA.Mods.Common/Traits/Player/MissionObjectives.cs
@@ -54,11 +54,17 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Speech")]
 		public readonly string WinNotification = null;
 
+		public readonly string WinTextNotification = null;
+
 		[NotificationReference("Speech")]
 		public readonly string LoseNotification = null;
 
+		public readonly string LoseTextNotification = null;
+
 		[NotificationReference("Speech")]
 		public readonly string LeaveNotification = null;
+
+		public readonly string LeaveTextNotification = null;
 
 		public override object Create(ActorInitializer init) { return new MissionObjectives(init.Self.Owner, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -26,11 +26,18 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int NewOptionsNotificationDelay = 10;
 
 		[NotificationReference("Speech")]
-		[Desc("Notification to play after building placement if new construction options are available.")]
+		[Desc("Speech notification to play after building placement if new construction options are available.")]
 		public readonly string NewOptionsNotification = null;
 
+		[Desc("Text notification to display after building placement if new construction options are available.")]
+		public readonly string NewOptionsTextNotification = null;
+
 		[NotificationReference("Speech")]
+		[Desc("Speech notification to play if building placement is not possible.")]
 		public readonly string CannotPlaceNotification = null;
+
+		[Desc("Text notification to display if building placement is not possible.")]
+		public readonly string CannotPlaceTextNotification = null;
 
 		[Desc("Hotkey to toggle between PlaceBuildingVariants when placing a structure.")]
 		public readonly HotkeyReference ToggleVariantKey = new HotkeyReference();
@@ -223,6 +230,8 @@ namespace OpenRA.Mods.Common.Traits
 		void PlayNotification(Actor self)
 		{
 			Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.NewOptionsNotification, self.Owner.Faction.InternalName);
+			TextNotificationsManager.AddTransientLine(info.NewOptionsTextNotification, self.Owner);
+
 			triggerNotification = false;
 			tick = 0;
 		}

--- a/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
@@ -44,6 +44,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech notification to play when the player does not have any funds.")]
 		public readonly string InsufficientFundsNotification = null;
 
+		[Desc("Text notification to display when the player does not have any funds.")]
+		public readonly string InsufficientFundsTextNotification = null;
+
 		[Desc("Delay (in ticks) during which warnings will be muted.")]
 		public readonly int InsufficientFundsNotificationInterval = 30000;
 
@@ -179,11 +182,11 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (Cash + Resources < num)
 			{
-				if (notifyLowFunds && !string.IsNullOrEmpty(Info.InsufficientFundsNotification) &&
-					Game.RunTime > lastNotificationTime + Info.InsufficientFundsNotificationInterval)
+				if (notifyLowFunds && Game.RunTime > lastNotificationTime + Info.InsufficientFundsNotificationInterval)
 				{
 					lastNotificationTime = Game.RunTime;
 					Game.Sound.PlayNotification(owner.World.Map.Rules, owner, "Speech", Info.InsufficientFundsNotification, owner.Faction.InternalName);
+					TextNotificationsManager.AddTransientLine(Info.InsufficientFundsTextNotification, owner);
 				}
 
 				return false;

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -61,17 +61,28 @@ namespace OpenRA.Mods.Common.Traits
 			"The filename of the audio is defined per faction in notifications.yaml.")]
 		public readonly string ReadyAudio = null;
 
+		[Desc("Notification displayed when production is complete.")]
+		public readonly string ReadyTextNotification = null;
+
 		[NotificationReference("Speech")]
 		[Desc("Notification played when you can't train another actor",
 			"when the build limit exceeded or the exit is jammed.",
 			"The filename of the audio is defined per faction in notifications.yaml.")]
 		public readonly string BlockedAudio = null;
 
+		[Desc("Notification displayed when you can't train another actor",
+			"when the build limit exceeded or the exit is jammed.")]
+		public readonly string BlockedTextNotification = null;
+
 		[NotificationReference("Speech")]
 		[Desc("Notification played when you can't queue another actor",
 			"when the queue length limit is exceeded.",
 			"The filename of the audio is defined per faction in notifications.yaml.")]
 		public readonly string LimitedAudio = null;
+
+		[Desc("Notification displayed when you can't queue another actor",
+			"when the queue length limit is exceeded.")]
+		public readonly string LimitedTextNotification = null;
 
 		[NotificationReference("Speech")]
 		[Desc("Notification played when you can't place a building.",
@@ -84,15 +95,24 @@ namespace OpenRA.Mods.Common.Traits
 			"The filename of the audio is defined per faction in notifications.yaml.")]
 		public readonly string QueuedAudio = null;
 
+		[Desc("Notification displayed when user clicks on the build palette icon.")]
+		public readonly string QueuedTextNotification = null;
+
 		[NotificationReference("Speech")]
 		[Desc("Notification played when player right-clicks on the build palette icon.",
 			"The filename of the audio is defined per faction in notifications.yaml.")]
 		public readonly string OnHoldAudio = null;
 
+		[Desc("Notification displayed when player right-clicks on the build palette icon.")]
+		public readonly string OnHoldTextNotification = null;
+
 		[NotificationReference("Speech")]
 		[Desc("Notification played when player right-clicks on a build palette icon that is already on hold.",
 			"The filename of the audio is defined per faction in notifications.yaml.")]
 		public readonly string CancelledAudio = null;
+
+		[Desc("Notification displayed when player right-clicks on a build palette icon that is already on hold.")]
+		public readonly string CancelledTextNotification = null;
 
 		public override object Create(ActorInitializer init) { return new ProductionQueue(init, this); }
 
@@ -333,9 +353,10 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public bool CanQueue(ActorInfo actor, out string notificationAudio)
+		public bool CanQueue(ActorInfo actor, out string notificationAudio, out string notificationText)
 		{
 			notificationAudio = Info.BlockedAudio;
+			notificationText = Info.BlockedTextNotification;
 
 			var bi = actor.TraitInfoOrDefault<BuildableInfo>();
 			if (bi == null)
@@ -346,6 +367,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (Info.QueueLimit > 0 && Queue.Count >= Info.QueueLimit)
 				{
 					notificationAudio = Info.LimitedAudio;
+					notificationText = Info.LimitedTextNotification;
 					return false;
 				}
 
@@ -353,6 +375,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (Info.ItemLimit > 0 && queueCount >= Info.ItemLimit)
 				{
 					notificationAudio = Info.LimitedAudio;
+					notificationText = Info.LimitedTextNotification;
 					return false;
 				}
 
@@ -366,6 +389,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			notificationAudio = Info.QueuedAudio;
+			notificationText = Info.QueuedTextNotification;
 			return true;
 		}
 
@@ -424,13 +448,22 @@ namespace OpenRA.Mods.Common.Traits
 
 							var isBuilding = unit.HasTraitInfo<BuildingInfo>();
 							if (isBuilding && !hasPlayedSound)
+							{
 								hasPlayedSound = Game.Sound.PlayNotification(rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
+								TextNotificationsManager.AddTransientLine(Info.ReadyTextNotification, self.Owner);
+							}
 							else if (!isBuilding)
 							{
 								if (BuildUnit(unit))
+								{
 									Game.Sound.PlayNotification(rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
+									TextNotificationsManager.AddTransientLine(Info.ReadyTextNotification, self.Owner);
+								}
 								else if (!hasPlayedSound && time > 0)
+								{
 									hasPlayedSound = Game.Sound.PlayNotification(rules, self.Owner, "Speech", Info.BlockedAudio, self.Owner.Faction.InternalName);
+									TextNotificationsManager.AddTransientLine(Info.BlockedTextNotification, self.Owner);
+								}
 							}
 						})), !order.Queued);
 					}

--- a/OpenRA.Mods.Common/Traits/Player/ResourceStorageWarning.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ResourceStorageWarning.cs
@@ -24,8 +24,11 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int Threshold = 80;
 
 		[NotificationReference("Speech")]
-		[Desc("The speech to play for the warning.")]
+		[Desc("Speech to play for the warning.")]
 		public readonly string Notification = "SilosNeeded";
+
+		[Desc("Text to display for the warning.")]
+		public readonly string TextNotification = null;
 
 		public override object Create(ActorInitializer init) { return new ResourceStorageWarning(init.Self, this); }
 	}
@@ -50,7 +53,10 @@ namespace OpenRA.Mods.Common.Traits
 				var owner = self.Owner;
 
 				if (resources.Resources > info.Threshold * resources.ResourceCapacity / 100)
+				{
 					Game.Sound.PlayNotification(self.World.Map.Rules, owner, "Speech", info.Notification, owner.Faction.InternalName);
+					TextNotificationsManager.AddTransientLine(info.TextNotification, owner);
+				}
 
 				lastSiloAdviceTime = Game.RunTime;
 			}

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -140,7 +140,10 @@ namespace OpenRA.Mods.Common.Traits
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)
+				{
 					Game.Sound.PlayNotification(player.World.Map.Rules, player, "Speech", mo.Info.LoseNotification, player.Faction.InternalName);
+					TextNotificationsManager.AddTransientLine(mo.Info.LoseTextNotification, player);
+				}
 			});
 		}
 
@@ -153,7 +156,10 @@ namespace OpenRA.Mods.Common.Traits
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)
+				{
 					Game.Sound.PlayNotification(player.World.Map.Rules, player, "Speech", mo.Info.WinNotification, player.Faction.InternalName);
+					TextNotificationsManager.AddTransientLine(mo.Info.WinTextNotification, player);
+				}
 			});
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
@@ -25,6 +25,8 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Speech")]
 		public readonly string SpeechNotification = null;
 
+		public readonly string TextNotification = null;
+
 		public override object Create(ActorInitializer init) { return new PowerManager(init.Self, this); }
 	}
 
@@ -161,6 +163,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (isLowPower && Game.RunTime > lastPowerAdviceTime + info.AdviceInterval)
 			{
 				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.SpeechNotification, self.Owner.Faction.InternalName);
+				TextNotificationsManager.AddTransientLine(info.TextNotification, self.Owner);
+
 				lastPowerAdviceTime = Game.RunTime;
 			}
 

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -29,8 +29,11 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string ChuteSound = null;
 
 		[NotificationReference("Speech")]
-		[Desc("Notification to play when dropping the unit.")]
+		[Desc("Speech notification to play when dropping the unit.")]
 		public readonly string ReadyAudio = null;
+
+		[Desc("Text notification to display when dropping the unit.")]
+		public readonly string ReadyTextNotification = null;
 
 		public override object Create(ActorInitializer init) { return new ProductionParadrop(init, this); }
 	}
@@ -97,6 +100,7 @@ namespace OpenRA.Mods.Common.Traits
 					self.World.AddFrameEndTask(ww => DoProduction(self, producee, exit?.Info, productionType, inits));
 					Game.Sound.Play(SoundType.World, info.ChuteSound, self.CenterPosition);
 					Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.ReadyAudio, self.Owner.Faction.InternalName);
+					TextNotificationsManager.AddTransientLine(info.ReadyTextNotification, self.Owner);
 				}));
 
 				actor.QueueActivity(new Fly(actor, Target.FromCell(w, endPos)));

--- a/OpenRA.Mods.Common/Traits/RepairsBridges.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsBridges.cs
@@ -42,6 +42,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech notification to play when a bridge is repaired.")]
 		public readonly string RepairNotification = null;
 
+		[Desc("Text notification to display when a bridge is repaired.")]
+		public readonly string RepairTextNotification = null;
+
 		public override object Create(ActorInitializer init) { return new RepairsBridges(this); }
 	}
 
@@ -107,7 +110,7 @@ namespace OpenRA.Mods.Common.Traits
 				else
 					return;
 
-				self.QueueActivity(order.Queued, new RepairBridge(self, order.Target, info.EnterBehaviour, info.RepairNotification, info.TargetLineColor));
+				self.QueueActivity(order.Queued, new RepairBridge(self, order.Target, info.EnterBehaviour, info.RepairNotification, info.RepairTextNotification, info.TargetLineColor));
 				self.ShowTargetLines();
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/RepairsUnits.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsUnits.cs
@@ -28,12 +28,18 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly BitSet<DamageType> RepairDamageTypes = default(BitSet<DamageType>);
 
 		[NotificationReference("Speech")]
-		[Desc("The sound played when starting to repair a unit.")]
+		[Desc("Speech notification played when starting to repair a unit.")]
 		public readonly string StartRepairingNotification = null;
 
+		[Desc("Text notification displayed when starting to repair a unit.")]
+		public readonly string StartRepairingTextNotification = null;
+
 		[NotificationReference("Speech")]
-		[Desc("The sound played when repairing a unit is done.")]
+		[Desc("Speech notification played when repairing a unit is done.")]
 		public readonly string FinishRepairingNotification = null;
+
+		[Desc("Text notification displayed when repairing a unit is done.")]
+		public readonly string FinishRepairingTextNotification = null;
 
 		[Desc("Experience gained by the player owning this actor for repairing an allied unit.")]
 		public readonly int PlayerExperience = 0;

--- a/OpenRA.Mods.Common/Traits/Sellable.cs
+++ b/OpenRA.Mods.Common/Traits/Sellable.cs
@@ -27,8 +27,11 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string[] SellSounds = Array.Empty<string>();
 
 		[NotificationReference("Speech")]
-		[Desc("The audio notification type to play.")]
+		[Desc("Speech notification to play.")]
 		public readonly string Notification = null;
+
+		[Desc("Text notification to display.")]
+		public string TextNotification = null;
 
 		[Desc("Whether to show the cash tick indicators rising from the actor.")]
 		public readonly bool ShowTicks = true;

--- a/OpenRA.Mods.Common/Traits/Sound/ActorLostNotification.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/ActorLostNotification.cs
@@ -16,7 +16,11 @@ namespace OpenRA.Mods.Common.Traits.Sound
 	class ActorLostNotificationInfo : ConditionalTraitInfo
 	{
 		[NotificationReference("Speech")]
+		[Desc("Speech notification to play.")]
 		public readonly string Notification = "UnitLost";
+
+		[Desc("Text notification to display.")]
+		public readonly string TextNotification = null;
 
 		public readonly bool NotifyAll = false;
 
@@ -33,8 +37,15 @@ namespace OpenRA.Mods.Common.Traits.Sound
 			if (IsTraitDisabled)
 				return;
 
-			var player = Info.NotifyAll ? self.World.LocalPlayer : self.Owner;
+			var localPlayer = self.World.LocalPlayer;
+
+			if (localPlayer == null || localPlayer.Spectating)
+				return;
+
+			var player = Info.NotifyAll ? localPlayer : self.Owner;
+
 			Game.Sound.PlayNotification(self.World.Map.Rules, player, "Speech", Info.Notification, self.Owner.Faction.InternalName);
+			TextNotificationsManager.AddTransientLine(Info.TextNotification, player);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Sound/AnnounceOnSeen.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AnnounceOnSeen.cs
@@ -23,7 +23,11 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		public readonly bool PingRadar = false;
 
 		[NotificationReference("Speech")]
+		[Desc("Speech notification to play.")]
 		public readonly string Notification = null;
+
+		[Desc("Text notification to display.")]
+		public readonly string TextNotification = null;
 
 		public readonly bool AnnounceNeutrals = false;
 
@@ -55,6 +59,9 @@ namespace OpenRA.Mods.Common.Traits.Sound
 			// Audio notification
 			if (discoverer != null && !string.IsNullOrEmpty(Info.Notification))
 				Game.Sound.PlayNotification(self.World.Map.Rules, discoverer, "Speech", Info.Notification, discoverer.Faction.InternalName);
+
+			if (discoverer != null)
+				TextNotificationsManager.AddTransientLine(Info.TextNotification, discoverer);
 
 			// Radar notification
 			if (Info.PingRadar)

--- a/OpenRA.Mods.Common/Traits/Sound/CaptureNotification.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/CaptureNotification.cs
@@ -17,15 +17,21 @@ namespace OpenRA.Mods.Common.Traits.Sound
 	public class CaptureNotificationInfo : TraitInfo
 	{
 		[NotificationReference("Speech")]
-		[Desc("The speech notification to play to the new owner.")]
+		[Desc("Speech notification to play to the new owner.")]
 		public readonly string Notification = "BuildingCaptured";
+
+		[Desc("Text notification to display to the new owner.")]
+		public readonly string TextNotification = null;
 
 		[Desc("Specifies if Notification is played with the voice of the new owners faction.")]
 		public readonly bool NewOwnerVoice = true;
 
 		[NotificationReference("Speech")]
-		[Desc("The speech notification to play to the old owner.")]
+		[Desc("Speech notification to play to the old owner.")]
 		public readonly string LoseNotification = null;
+
+		[Desc("Text notification to display to the old owner.")]
+		public readonly string LoseTextNotification = null;
 
 		[Desc("Specifies if LoseNotification is played with the voice of the new owners faction.")]
 		public readonly bool LoseNewOwnerVoice = false;
@@ -45,9 +51,11 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		{
 			var faction = info.NewOwnerVoice ? newOwner.Faction.InternalName : oldOwner.Faction.InternalName;
 			Game.Sound.PlayNotification(self.World.Map.Rules, newOwner, "Speech", info.Notification, faction);
+			TextNotificationsManager.AddTransientLine(info.TextNotification, newOwner);
 
 			var loseFaction = info.LoseNewOwnerVoice ? newOwner.Faction.InternalName : oldOwner.Faction.InternalName;
 			Game.Sound.PlayNotification(self.World.Map.Rules, oldOwner, "Speech", info.LoseNotification, loseFaction);
+			TextNotificationsManager.AddTransientLine(info.LoseTextNotification, oldOwner);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/SupportPowers/ParatroopersPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/ParatroopersPower.cs
@@ -27,8 +27,11 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly WVec SquadOffset = new WVec(-1536, 1536, 0);
 
 		[NotificationReference("Speech")]
-		[Desc("Notification to play when entering the drop zone.")]
+		[Desc("Speech notification to play when entering the drop zone.")]
 		public readonly string ReinforcementsArrivedSpeechNotification = null;
+
+		[Desc("Text notification to display when entering the drop zone.")]
+		public readonly string ReinforcementsArrivedTextNotification = null;
 
 		[Desc("Number of facings that the delivery aircraft may approach from.")]
 		public readonly int QuantizedFacings = 32;
@@ -134,8 +137,12 @@ namespace OpenRA.Mods.Common.Traits
 				RemoveBeacon(beacon);
 
 				if (!aircraftInRange.Any(kv => kv.Value))
+				{
 					Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech",
 						info.ReinforcementsArrivedSpeechNotification, self.Owner.Faction.InternalName);
+
+					TextNotificationsManager.AddTransientLine(info.ReinforcementsArrivedTextNotification, self.Owner);
+				}
 
 				aircraftInRange[a] = true;
 			};

--- a/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
@@ -28,14 +28,20 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Type = null;
 
 		[NotificationReference("Speech")]
-		[Desc("Notification played when production is activated.",
+		[Desc("Speech notification played when production is activated.",
 			"The filename of the audio is defined per faction in notifications.yaml.")]
 		public readonly string ReadyAudio = null;
 
+		[Desc("Text notification displayed when production is activated.")]
+		public readonly string ReadyTextNotification = null;
+
 		[NotificationReference("Speech")]
-		[Desc("Notification played when the exit is jammed.",
+		[Desc("Speech notification played when the exit is jammed.",
 			"The filename of the audio is defined per faction in notifications.yaml.")]
 		public readonly string BlockedAudio = null;
+
+		[Desc("Text notification displayed when the exit is jammed.")]
+		public readonly string BlockedTextNotification = null;
 
 		public override object Create(ActorInitializer init) { return new ProduceActorPower(init, this); }
 	}
@@ -91,9 +97,15 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			if (activated)
+			{
 				Game.Sound.PlayNotification(self.World.Map.Rules, manager.Self.Owner, "Speech", info.ReadyAudio, self.Owner.Faction.InternalName);
+				TextNotificationsManager.AddTransientLine(info.ReadyTextNotification, manager.Self.Owner);
+			}
 			else
+			{
 				Game.Sound.PlayNotification(self.World.Map.Rules, manager.Self.Owner, "Speech", info.BlockedAudio, self.Owner.Faction.InternalName);
+				TextNotificationsManager.AddTransientLine(info.BlockedTextNotification, manager.Self.Owner);
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SpawnActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SpawnActorPower.cs
@@ -95,6 +95,9 @@ namespace OpenRA.Mods.Common.Traits
 			Game.Sound.PlayToPlayer(SoundType.UI, manager.Self.Owner, Info.SelectTargetSound);
 			Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech",
 				Info.SelectTargetSpeechNotification, self.Owner.Faction.InternalName);
+
+			TextNotificationsManager.AddTransientLine(Info.SelectTargetTextNotification, manager.Self.Owner);
+
 			self.World.OrderGenerator = new SelectSpawnActorPowerTarget(order, manager, this, MouseButton.Left);
 		}
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -231,6 +231,8 @@ namespace OpenRA.Mods.Common.Traits
 			Game.Sound.PlayNotification(power.Self.World.Map.Rules, power.Self.Owner, "Speech",
 				Info.SelectTargetSpeechNotification, power.Self.Owner.Faction.InternalName);
 
+			TextNotificationsManager.AddTransientLine(Info.SelectTargetTextNotification, power.Self.Owner);
+
 			power.SelectTarget(power.Self, Key, Manager);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -39,12 +39,18 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string[] NoTransformSounds = Array.Empty<string>();
 
 		[NotificationReference("Speech")]
-		[Desc("Notification to play when transforming.")]
+		[Desc("Speech notification to play when transforming.")]
 		public readonly string TransformNotification = null;
 
+		[Desc("Text notification to display when transforming.")]
+		public readonly string TransformTextNotification = null;
+
 		[NotificationReference("Speech")]
-		[Desc("Notification to play when the transformation is blocked.")]
+		[Desc("Speech notification to play when the transformation is blocked.")]
 		public readonly string NoTransformNotification = null;
+
+		[Desc("Text notification to display when the transformation is blocked.")]
+		public readonly string NoTransformTextNotification = null;
 
 		[CursorReference]
 		[Desc("Cursor to display when able to (un)deploy the actor.")]
@@ -97,6 +103,7 @@ namespace OpenRA.Mods.Common.Traits
 				Facing = Info.Facing,
 				Sounds = Info.TransformSounds,
 				Notification = Info.TransformNotification,
+				TextNotification = Info.TransformTextNotification,
 				Faction = faction
 			};
 		}
@@ -136,6 +143,7 @@ namespace OpenRA.Mods.Common.Traits
 					Game.Sound.PlayToPlayer(SoundType.World, self.Owner, s);
 
 				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.NoTransformNotification, self.Owner.Faction.InternalName);
+				TextNotificationsManager.AddTransientLine(Info.NoTransformTextNotification, self.Owner);
 
 				return;
 			}

--- a/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
+++ b/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
@@ -20,11 +20,17 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Speech")]
 		public readonly string Notification = "StartGame";
 
+		public readonly string TextNotification = null;
+
 		[NotificationReference("Speech")]
 		public readonly string LoadedNotification = "GameLoaded";
 
+		public readonly string LoadedTextNotification = null;
+
 		[NotificationReference("Speech")]
 		public readonly string SavedNotification = "GameSaved";
+
+		public readonly string SavedTextNotification = null;
 
 		public override object Create(ActorInitializer init) { return new StartGameNotification(this); }
 	}
@@ -40,19 +46,28 @@ namespace OpenRA.Mods.Common.Traits
 		void IWorldLoaded.WorldLoaded(World world, WorldRenderer wr)
 		{
 			if (!world.IsLoadingGameSave)
+			{
 				Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", info.Notification, world.RenderPlayer == null ? null : world.RenderPlayer.Faction.InternalName);
+				TextNotificationsManager.AddTransientLine(info.TextNotification, null);
+			}
 		}
 
 		void INotifyGameLoaded.GameLoaded(World world)
 		{
 			if (!world.IsReplay)
+			{
 				Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", info.LoadedNotification, world.RenderPlayer == null ? null : world.RenderPlayer.Faction.InternalName);
+				TextNotificationsManager.AddTransientLine(info.LoadedTextNotification, null);
+			}
 		}
 
 		void INotifyGameSaved.GameSaved(World world)
 		{
 			if (!world.IsReplay)
+			{
 				Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", info.SavedNotification, world.RenderPlayer == null ? null : world.RenderPlayer.Faction.InternalName);
+				TextNotificationsManager.AddTransientLine(info.SavedTextNotification, null);
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -121,6 +121,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					var faction = world.LocalPlayer?.Faction.InternalName;
 					Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", moi.LeaveNotification, faction);
+					TextNotificationsManager.AddTransientLine(moi.LeaveTextNotification, null);
 				}
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameTransientNotificationsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameTransientNotificationsLogic.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		static bool IsNotificationEligible(TextNotification notification)
 		{
-			return notification.Pool == TextNotificationPool.Feedback;
+			return notification.Pool == TextNotificationPool.Transients || notification.Pool == TextNotificationPool.Feedback;
 		}
 
 		bool disposed = false;

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -289,6 +289,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				feedbackCheckbox.IsChecked = () => gs.TextNotificationPoolFilters.HasFlag(TextNotificationPoolFilters.Feedback);
 				feedbackCheckbox.OnClick = () => toggleFilterFlag(TextNotificationPoolFilters.Feedback);
 			}
+
+			var transientsCheckbox = panel.GetOrNull<CheckboxWidget>("TRANSIENTS_CHECKBOX");
+			if (transientsCheckbox != null)
+			{
+				transientsCheckbox.IsChecked = () => gs.TextNotificationPoolFilters.HasFlag(TextNotificationPoolFilters.Transients);
+				transientsCheckbox.OnClick = () => toggleFilterFlag(TextNotificationPoolFilters.Transients);
+			}
 		}
 
 		static void ShowStatusBarsDropdown(DropDownButtonWidget dropdown, GameSettings s)

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -305,6 +305,8 @@ namespace OpenRA.Mods.Common.Widgets
 				// Resume a paused item
 				Game.Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Sounds", ClickSound, null);
 				Game.Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.QueuedAudio, World.LocalPlayer.Faction.InternalName);
+				TextNotificationsManager.AddTransientLine(CurrentQueue.Info.QueuedTextNotification, World.LocalPlayer);
+
 				World.IssueOrder(Order.PauseProduction(CurrentQueue.Actor, icon.Name, false));
 				return true;
 			}
@@ -315,10 +317,13 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				// Queue a new item
 				Game.Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Sounds", ClickSound, null);
-				var canQueue = CurrentQueue.CanQueue(buildable, out var notification);
+				var canQueue = CurrentQueue.CanQueue(buildable, out var notification, out var textNotification);
 
 				if (!CurrentQueue.AllQueued().Any())
+				{
 					Game.Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", notification, World.LocalPlayer.Faction.InternalName);
+					TextNotificationsManager.AddTransientLine(textNotification, World.LocalPlayer);
+				}
 
 				if (canQueue)
 				{
@@ -342,12 +347,16 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				// Instantly cancel items that haven't started, have finished, or if the queue doesn't support pausing
 				Game.Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.CancelledAudio, World.LocalPlayer.Faction.InternalName);
+				TextNotificationsManager.AddTransientLine(CurrentQueue.Info.CancelledTextNotification, World.LocalPlayer);
+
 				World.IssueOrder(Order.CancelProduction(CurrentQueue.Actor, icon.Name, handleCount));
 			}
 			else
 			{
 				// Pause an existing item
 				Game.Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.OnHoldAudio, World.LocalPlayer.Faction.InternalName);
+				TextNotificationsManager.AddTransientLine(CurrentQueue.Info.OnHoldTextNotification, World.LocalPlayer);
+
 				World.IssueOrder(Order.PauseProduction(CurrentQueue.Actor, icon.Name, true));
 			}
 
@@ -362,6 +371,8 @@ namespace OpenRA.Mods.Common.Widgets
 			// Directly cancel, skipping "on-hold"
 			Game.Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Sounds", ClickSound, null);
 			Game.Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.CancelledAudio, World.LocalPlayer.Faction.InternalName);
+			TextNotificationsManager.AddTransientLine(CurrentQueue.Info.CancelledTextNotification, World.LocalPlayer);
+
 			World.IssueOrder(Order.CancelProduction(CurrentQueue.Actor, icon.Name, handleCount));
 
 			return true;

--- a/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
@@ -173,6 +173,8 @@ namespace OpenRA.Mods.Common.Widgets
 				Game.Sound.PlayToPlayer(SoundType.UI, spm.Self.Owner, clicked.Power.Info.InsufficientPowerSound);
 				Game.Sound.PlayNotification(spm.Self.World.Map.Rules, spm.Self.Owner, "Speech",
 					clicked.Power.Info.InsufficientPowerSpeechNotification, spm.Self.Owner.Faction.InternalName);
+
+				TextNotificationsManager.AddTransientLine(clicked.Power.Info.InsufficientPowerTextNotification, spm.Self.Owner);
 			}
 			else
 				clicked.Power.Target();

--- a/OpenRA.Mods.Common/Widgets/TextNotificationsDisplayWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TextNotificationsDisplayWidget.cs
@@ -28,6 +28,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public string SystemTemplate = "SYSTEM_LINE_TEMPLATE";
 		public string MissionTemplate = "CHAT_LINE_TEMPLATE";
 		public string FeedbackTemplate = "TRANSIENT_LINE_TEMPLATE";
+		public string TransientsTemplate = "TRANSIENT_LINE_TEMPLATE";
 		readonly Dictionary<TextNotificationPool, Widget> templates = new Dictionary<TextNotificationPool, Widget>();
 
 		readonly List<int> expirations = new List<int>();
@@ -43,6 +44,7 @@ namespace OpenRA.Mods.Common.Widgets
 			templates.Add(TextNotificationPool.System, Ui.LoadWidget(SystemTemplate, null, new WidgetArgs()));
 			templates.Add(TextNotificationPool.Mission, Ui.LoadWidget(MissionTemplate, null, new WidgetArgs()));
 			templates.Add(TextNotificationPool.Feedback, Ui.LoadWidget(FeedbackTemplate, null, new WidgetArgs()));
+			templates.Add(TextNotificationPool.Transients, Ui.LoadWidget(TransientsTemplate, null, new WidgetArgs()));
 
 			// HACK: Assume that all templates use the same font
 			var lineHeight = Game.Renderer.Fonts[templates[TextNotificationPool.Chat].Get<LabelWidget>("TEXT").Font].Measure("").Y;

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -82,6 +82,9 @@ namespace OpenRA.Mods.D2k.Activities
 			foreach (var player in affectedPlayers)
 				self.World.AddFrameEndTask(w => w.Add(new MapNotificationEffect(player, "Speech", swallow.Info.WormAttackNotification, 25, true, attackPosition, Color.Red)));
 
+			if (affectedPlayers.Contains(self.World.LocalPlayer))
+				TextNotificationsManager.AddTransientLine(swallow.Info.WormAttackTextNotification, self.World.LocalPlayer);
+
 			var barrel = armament.CheckFire(self, facing, target);
 			if (barrel == null)
 				return false;

--- a/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
+++ b/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
@@ -38,6 +38,8 @@ namespace OpenRA.Mods.D2k.Traits
 		[NotificationReference("Speech")]
 		public readonly string WormAttackNotification = "WormAttack";
 
+		public readonly string WormAttackTextNotification = "Worm attack.";
+
 		public override object Create(ActorInitializer init) { return new AttackSwallow(init.Self, this); }
 	}
 

--- a/mods/cnc/chrome/settings-display.yaml
+++ b/mods/cnc/chrome/settings-display.yaml
@@ -163,14 +163,23 @@ Container@DISPLAY_PANEL:
 					Height: 20
 					Children:
 						Container@UI_FEEDBACK_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: 10
+							Width: PARENT_RIGHT / 2 - 10
 							Children:
 								Checkbox@UI_FEEDBACK_CHECKBOX:
 									Width: PARENT_RIGHT
 									Height: 20
 									Font: Regular
-									Text: UI Feedback in Transients Panel
+									Text: Show UI Feedback Notifications
+						Container@TRANSIENTS_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@TRANSIENTS_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Show Game Event Notifications
 				Container@SPACER:
 				Background@SECTION_HEADER:
 					X: 5

--- a/mods/cnc/maps/gdi08b/rules.yaml
+++ b/mods/cnc/maps/gdi08b/rules.yaml
@@ -178,4 +178,5 @@ HQ:
 		MaxMoveDelay: 1000
 	ActorLostNotification:
 		Notification: CivilianKilled
+		TextNotification: Civilian killed.
 		NotifyAll: true

--- a/mods/cnc/rules/campaign-maprules.yaml
+++ b/mods/cnc/rules/campaign-maprules.yaml
@@ -68,6 +68,10 @@ airstrike.proxy:
 		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSpeechNotification: InsufficientPower
 		IncomingSpeechNotification: EnemyPlanesApproaching
+		EndChargeTextNotification: Airstrike ready.
+		SelectTargetTextNotification: Select target.
+		InsufficientPowerTextNotification: Insufficient power.
+		IncomingTextNotification: Enemy planes approaching.
 		UnitType: a10
 		DisplayBeacon: True
 		BeaconPoster: airstrike

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -48,6 +48,7 @@
 ^GainsExperience:
 	GainsExperience:
 		LevelUpNotification: LevelUp
+		LevelUpTextNotification: Unit promoted.
 		Conditions:
 			250: rank-veteran
 			500: rank-veteran
@@ -245,6 +246,7 @@
 	Passenger:
 		CargoType: Vehicle
 	ActorLostNotification:
+		TextNotification: Unit lost.
 	HiddenUnderFog:
 	AttackMove:
 	WithDamageOverlay:
@@ -303,6 +305,7 @@
 	HiddenUnderFog:
 		Type: GroundPosition
 	ActorLostNotification:
+		TextNotification: Unit lost.
 	Explodes:
 		Weapon: HeliExplode
 		EmptyWeapon: HeliExplode
@@ -387,6 +390,7 @@
 		Margin: 5, 6
 		RequiresCondition: hazmatsuits
 	ActorLostNotification:
+		TextNotification: Unit lost.
 	SpawnActorOnDeath:
 		Probability: 5
 		Actor: vice
@@ -629,6 +633,7 @@
 		Type: GroundPosition
 		AlwaysVisibleRelationships: None
 	ActorLostNotification:
+		TextNotification: Unit lost.
 	AttackMove:
 	WithShadow:
 		Offset: 43, 128, 0
@@ -652,6 +657,7 @@
 		TargetTypes: Ground, Water
 	HiddenUnderFog:
 	ActorLostNotification:
+		TextNotification: Unit lost.
 	AttackMove:
 	WithDamageOverlay:
 	Explodes:
@@ -697,9 +703,11 @@
 		EmptyWeapon: BuildingExplode
 	CaptureNotification:
 		Notification: BuildingCaptured
+		TextNotification: Building captured.
 		NewOwnerVoice: false
 	ActorLostNotification:
 		Notification: BuildingLost
+		TextNotification: Structure lost.
 	ShakeOnDeath:
 	Guardable:
 		Range: 3c0
@@ -791,6 +799,7 @@
 		Types: building
 	CaptureNotification:
 		Notification: CivilianBuildingCaptured
+		TextNotification: Civilian building captured.
 	RepairableBuilding:
 		RepairPercent: 40
 		RepairStep: 1400

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -271,6 +271,7 @@ PVICE:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	ActorLostNotification:
+		TextNotification: Unit lost.
 
 STEG:
 	Inherits: ^DINO

--- a/mods/cnc/rules/player.yaml
+++ b/mods/cnc/rules/player.yaml
@@ -14,6 +14,8 @@ Player:
 	PlaceBuilding:
 		NewOptionsNotification: NewOptions
 		CannotPlaceNotification: BuildingCannotPlaceAudio
+		NewOptionsTextNotification: New construction options.
+		CannotPlaceTextNotification: Cannot deploy here.
 	TechTree:
 	SupportPowerManager:
 	ScriptTriggers:
@@ -24,6 +26,7 @@ Player:
 	ConquestVictoryConditions:
 	PowerManager:
 		SpeechNotification: LowPower
+		TextNotification: Low power.
 	AllyRepair:
 	PlayerResources:
 		CashTickUpNotification: CashTickUp
@@ -33,6 +36,8 @@ Player:
 	DeveloperMode:
 		CheckboxDisplayOrder: 9
 	BaseAttackNotifier:
+		TextNotification: Base under attack.
+		AllyTextNotification: Our ally is under attack.
 	Shroud:
 		FogCheckboxDisplayOrder: 3
 	LobbyPrerequisiteCheckbox@GLOBALFACTUNDEPLOY:
@@ -70,6 +75,7 @@ Player:
 		Id: unrestricted
 	GrantConditionOnPrerequisiteManager:
 	ResourceStorageWarning:
+		TextNotification: Silos needed.
 	PlayerExperience:
 	GameSaveViewportManager:
 	PlayerRadarTerrain:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -49,8 +49,11 @@ FACT:
 		Group: Building
 		LowPowerModifier: 150
 		ReadyAudio: ConstructionComplete
+		ReadyTextNotification: Construction complete.
 		BlockedAudio: NoBuild
+		BlockedTextNotification: Unable to build more.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Building
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -61,8 +64,11 @@ FACT:
 		Group: Building
 		LowPowerModifier: 150
 		ReadyAudio: ConstructionComplete
+		ReadyTextNotification: Construction complete.
 		BlockedAudio: NoBuild
+		BlockedTextNotification: Unable to build more.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Building
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -73,8 +79,11 @@ FACT:
 		Group: Defence
 		LowPowerModifier: 150
 		ReadyAudio: ConstructionComplete
+		ReadyTextNotification: Construction complete.
 		BlockedAudio: NoBuild
+		BlockedTextNotification: Unable to build more.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Building
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -85,8 +94,11 @@ FACT:
 		Group: Defence
 		LowPowerModifier: 150
 		ReadyAudio: ConstructionComplete
+		ReadyTextNotification: Construction complete.
 		BlockedAudio: NoBuild
+		BlockedTextNotification: Unable to build more.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Building
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -334,8 +346,11 @@ PYLE:
 		Group: Infantry
 		LowPowerModifier: 150
 		ReadyAudio: UnitReady
+		ReadyTextNotification: Unit ready.
 		BlockedAudio: NoBuild
+		BlockedTextNotification: Unable to build more.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Training
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -389,8 +404,11 @@ HAND:
 		Group: Infantry
 		LowPowerModifier: 150
 		ReadyAudio: UnitReady
+		ReadyTextNotification: Unit ready.
 		BlockedAudio: NoBuild
+		BlockedTextNotification: Unable to build more.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Training
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -438,6 +456,7 @@ AFLD:
 	ProductionAirdrop:
 		Produces: Vehicle.Nod
 		ActorType: c17
+		ReadyTextNotification: Reinforcements have arrived.
 	WithBuildingBib:
 	WithIdleOverlay@DISH:
 		RequiresCondition: !build-incomplete
@@ -450,7 +469,9 @@ AFLD:
 		Group: Vehicle
 		LowPowerModifier: 150
 		BlockedAudio: NoBuild
+		BlockedTextNotification: Unable to build more.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Training
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -507,8 +528,11 @@ WEAP:
 		Group: Vehicle
 		LowPowerModifier: 150
 		ReadyAudio: UnitReady
+		ReadyTextNotification: Unit ready.
 		BlockedAudio: NoBuild
+		BlockedTextNotification: Unable to build more.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Training
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -556,6 +580,7 @@ HPAD:
 		HpPerStep: 1000
 		PlayerExperience: 25
 		StartRepairingNotification: Repairing
+		StartRepairingTextNotification: Repairing.
 	WithResupplyAnimation:
 		RequiresCondition: !build-incomplete
 	RallyPoint:
@@ -566,8 +591,11 @@ HPAD:
 		Group: Aircraft
 		LowPowerModifier: 150
 		ReadyAudio: UnitReady
+		ReadyTextNotification: Unit ready.
 		BlockedAudio: NoBuild
+		BlockedTextNotification: Unable to build more.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Training
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -578,8 +606,11 @@ HPAD:
 		Group: Aircraft
 		LowPowerModifier: 150
 		ReadyAudio: UnitReady
+		ReadyTextNotification: Unit ready.
 		BlockedAudio: NoBuild
+		BlockedTextNotification: Unable to build more.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Training
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -643,6 +674,10 @@ HQ:
 		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSpeechNotification: InsufficientPower
 		IncomingSpeechNotification: EnemyPlanesApproaching
+		EndChargeTextNotification: Airstrike ready.
+		SelectTargetTextNotification: Select target.
+		InsufficientPowerTextNotification: Insufficient power.
+		IncomingTextNotification: Enemy planes approaching.
 		UnitType: a10
 		DisplayBeacon: True
 		BeaconPoster: airstrike
@@ -694,6 +729,7 @@ FIX:
 		Interval: 15
 		PlayerExperience: 25
 		StartRepairingNotification: Repairing
+		StartRepairingTextNotification: Repairing.
 	RallyPoint:
 	Power:
 		Amount: -20
@@ -750,6 +786,10 @@ EYE:
 		EndChargeSpeechNotification: IonCannonReady
 		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSpeechNotification: InsufficientPower
+		BeginChargeTextNotification: Ion cannon charging.
+		EndChargeTextNotification: Ion cannon ready.
+		SelectTargetTextNotification: Select target.
+		InsufficientPowerTextNotification: Insufficient power.
 		OnFireSound: ion1.aud
 		DisplayRadarPing: True
 		CameraActor: camera.small
@@ -805,6 +845,11 @@ TMPL:
 		InsufficientPowerSpeechNotification: InsufficientPower
 		LaunchSpeechNotification: NuclearWeaponLaunched
 		IncomingSpeechNotification: NuclearWarheadApproaching
+		SelectTargetTextNotification: Select target.
+		EndChargeTextNotification: Nuclear weapon available.
+		InsufficientPowerTextNotification: Insufficient power.
+		LaunchTextNotification: Nuclear weapon launched.
+		IncomingTextNotification: Nuclear warhead approaching.
 		MissileWeapon: atomic
 		MissileImage: atomic
 		MissileDelay: 11

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -29,6 +29,7 @@ MCV:
 		Facing: 432
 		TransformSounds: constru2.aud, hvydoor1.aud
 		NoTransformNotification: BuildingCannotPlaceAudio
+		NoTransformTextNotification: Cannot deploy here.
 		Voice: Unload
 	MustBeDestroyed:
 		RequiredForShortGame: true
@@ -75,6 +76,7 @@ HARV:
 		Range: 4c0
 	ActorLostNotification:
 		Notification: HarvesterLost
+		TextNotification: Harvester lost.
 	SpawnActorOnDeath:
 		Actor: HARV.Husk
 		OwnerType: InternalName

--- a/mods/common/chrome/settings-display.yaml
+++ b/mods/common/chrome/settings-display.yaml
@@ -162,6 +162,28 @@ Container@DISPLAY_PANEL:
 					Width: PARENT_RIGHT - 24
 					Height: 20
 					Children:
+						Container@UI_FEEDBACK_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 10
+							Children:
+								Checkbox@UI_FEEDBACK_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Show UI Feedback Notifications
+						Container@TRANSIENTS_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@TRANSIENTS_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Show Game Event Notifications
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 20
+					Children:
 						Container@PAUSE_SHELLMAP_CHECKBOX_CONTAINER:
 							X: 10
 							Width: PARENT_RIGHT / 2 - 10
@@ -171,15 +193,6 @@ Container@DISPLAY_PANEL:
 									Height: 20
 									Font: Regular
 									Text: Pause Menu Background
-						Container@UI_FEEDBACK_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
-							Children:
-								Checkbox@UI_FEEDBACK_CHECKBOX:
-									Width: PARENT_RIGHT
-									Height: 20
-									Font: Regular
-									Text: UI Feedback in Transients Panel
 				Container@SPACER:
 				Background@SECTION_HEADER:
 					X: 5

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -113,6 +113,7 @@ sandworm:
 	IgnoresCloak:
 	AnnounceOnSeen:
 		Notification: WormSign
+		TextNotification: Worm sign.
 		PingRadar: True
 	RevealsShroud:
 		Range: 5c0

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -15,6 +15,7 @@
 ^GainsExperience:
 	GainsExperience:
 		LevelUpNotification: LevelUp
+		LevelUpTextNotification: Unit promoted.
 		Conditions:
 			200: rank-veteran
 			400: rank-veteran
@@ -212,6 +213,7 @@
 	AttackMove:
 	HiddenUnderFog:
 	ActorLostNotification:
+		TextNotification: Unit lost.
 	Repairable:
 		RepairActors: repair_pad
 	Guard:
@@ -352,6 +354,7 @@
 		CargoType: Infantry
 	HiddenUnderFog:
 	ActorLostNotification:
+		TextNotification: Unit lost.
 	Crushable:
 		CrushSound: CRUSH1.WAV
 	Guard:
@@ -393,6 +396,7 @@
 		Type: GroundPosition
 		AlwaysVisibleRelationships: None
 	ActorLostNotification:
+		TextNotification: Unit lost.
 	AttackMove:
 	WithFacingSpriteBody:
 	WithShadow:
@@ -455,8 +459,11 @@
 		RequiredForShortGame: true
 	FrozenUnderFog:
 	CaptureNotification:
+		TextNotification: Enemy building captured.
+		LoseTextNotification: One of our buildings has been captured.
 	ActorLostNotification:
 		Notification: BuildingLost
+		TextNotification: Building lost.
 	ShakeOnDeath:
 	Demolishable:
 		Condition: being-demolished
@@ -600,6 +607,7 @@
 		PrimaryCondition: primary
 		ProductionQueues: Building
 		SelectionNotification: PrimaryBuildingSelected
+		SelectionTextNotification: Primary building selected.
 	WithTextDecoration@primary:
 		RequiresCondition: primary
 		Position: Top

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -16,7 +16,9 @@ Player:
 		DisplayOrder: 0
 		LowPowerModifier: 300
 		ReadyAudio: BuildingReady
+		ReadyTextNotification: Construction complete.
 		BlockedAudio: NoRoom
+		BlockedTextNotification: No room for new unit.
 		QueuedAudio: Building
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -27,7 +29,9 @@ Player:
 		DisplayOrder: 1
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
+		ReadyTextNotification: Unit ready.
 		BlockedAudio: NoRoom
+		BlockedTextNotification: No room for new unit.
 		QueuedAudio: Training
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -38,7 +42,9 @@ Player:
 		DisplayOrder: 2
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
+		ReadyTextNotification: Unit ready.
 		BlockedAudio: NoRoom
+		BlockedTextNotification: No room for new unit.
 		QueuedAudio: Building
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -49,7 +55,9 @@ Player:
 		DisplayOrder: 3
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
+		ReadyTextNotification: Unit ready.
 		BlockedAudio: NoRoom
+		BlockedTextNotification: No room for new unit.
 		QueuedAudio: Building
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -60,6 +68,7 @@ Player:
 		DisplayOrder: 4
 		BuildDurationModifier: 212
 		BlockedAudio: NoRoom
+		BlockedTextNotification: No room for new unit.
 		QueuedAudio: OrderPlaced
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -68,7 +77,9 @@ Player:
 		DisplayOrder: 5
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
+		ReadyTextNotification: Unit ready.
 		BlockedAudio: NoRoom
+		BlockedTextNotification: No room for new unit.
 		QueuedAudio: Building
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -77,13 +88,17 @@ Player:
 	ClassicProductionQueue@Upgrade: # Upgrade is defined after others so it won't be automatically selected by ProductionQueueFromSelection.
 		Type: Upgrade
 		ReadyAudio: NewOptions
+		ReadyTextNotification: New construction options.
 		BlockedAudio: NoRoom
+		BlockedTextNotification: No room for new unit.
 		QueuedAudio: Upgrading
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 	PlaceBuilding:
 		NewOptionsNotification: NewOptions
 		CannotPlaceNotification: BuildingCannotPlaceAudio
+		NewOptionsTextNotification: New construction options.
+		CannotPlaceTextNotification: Cannot build here.
 	SupportPowerManager:
 	ScriptTriggers:
 	MissionObjectives:
@@ -94,15 +109,19 @@ Player:
 	PowerManager:
 		AdviceInterval: 26000
 		SpeechNotification: LowPower
+		TextNotification: Low power.
 	AllyRepair:
 	PlayerResources:
 		SelectableCash: 2500, 5000, 7000, 10000, 20000
 		InsufficientFundsNotification: InsufficientFunds
+		InsufficientFundsTextNotification: Insufficient funds.
 		CashTickUpNotification: CashTickUp
 		CashTickDownNotification: CashTickDown
 	DeveloperMode:
 		CheckboxDisplayOrder: 8
 	BaseAttackNotifier:
+		TextNotification: Base under attack.
+		AllyTextNotification: Our ally is under attack.
 	Shroud:
 		FogCheckboxDisplayOrder: 3
 	LobbyPrerequisiteCheckbox@AUTOCONCRETE:
@@ -114,6 +133,7 @@ Player:
 		Prerequisites: global-auto-concrete
 	FrozenActorLayer:
 	HarvesterAttackNotifier:
+		TextNotification: Harvester under attack.
 	PlayerStatistics:
 	PlaceBeacon:
 	ProvidesPrerequisite@atreides:
@@ -158,6 +178,7 @@ Player:
 	GrantConditionOnPrerequisiteManager:
 	ResourceStorageWarning:
 		AdviceInterval: 26000
+		TextNotification: Silos needed.
 	PlayerExperience:
 	GameSaveViewportManager:
 	PlayerRadarTerrain:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -608,6 +608,7 @@ starport:
 	ProductionAirdrop:
 		Produces: Starport
 		ActorType: frigate
+		ReadyTextNotification: Reinforcements have arrived.
 	RenderSprites:
 		Image: starport.ordos
 		FactionImages:
@@ -836,7 +837,9 @@ repair_pad:
 		Interval: 10
 		HpPerStep: 800
 		StartRepairingNotification: Repairing
+		StartRepairingTextNotification: Repairing.
 		FinishRepairingNotification: UnitRepaired
+		FinishRepairingTextNotification: Unit repaired.
 		PlayerExperience: 15
 	RallyPoint:
 	RenderSprites:
@@ -929,6 +932,8 @@ high_tech_factory:
 		ArrowSequence: arrow
 		CircleSequence: circles
 		SupportPowerPaletteOrder: 10
+		EndChargeTextNotification: Airstrike ready.
+		SelectTargetTextNotification: Select target.
 	Power:
 		Amount: -75
 	GrantConditionOnPrerequisite@UPGRADEABLE:
@@ -1065,6 +1070,10 @@ palace:
 		BeginChargeSpeechNotification: DeathHandMissilePrepping
 		EndChargeSpeechNotification: DeathHandMissileReady
 		IncomingSpeechNotification: MissileLaunchDetected
+		BeginChargeTextNotification: Death Hand missile prepping.
+		EndChargeTextNotification: Death Hand missile ready.
+		IncomingTextNotification: Missile launch detected.
+		SelectTargetTextNotification: Select target.
 		MissileWeapon: deathhand
 		MissileImage: deathhand
 		MissileDelay: 18
@@ -1091,8 +1100,11 @@ palace:
 		Actors: fremen, fremen
 		Type: Fremen
 		ChargeInterval: 2250
+		EndChargeTextNotification: Fremen ready.
 		ReadyAudio: Reinforce
+		ReadyTextNotification: Reinforcements have arrived.
 		BlockedAudio: NoRoom
+		BlockedTextNotification: No room for new unit.
 		OrderName: ProduceActorPower.Fremen
 		SupportPowerPaletteOrder: 20
 	ProduceActorPower@saboteur:
@@ -1105,8 +1117,11 @@ palace:
 		Actors: saboteur
 		Type: Saboteur
 		ChargeInterval: 2250
+		EndChargeTextNotification: Saboteur ready.
 		ReadyAudio: Reinforce
+		ReadyTextNotification: Reinforcements have arrived.
 		BlockedAudio: NoRoom
+		BlockedTextNotification: No room for new unit.
 		OrderName: ProduceActorPower.Saboteur
 		SupportPowerPaletteOrder: 30
 	Exit@1:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -35,6 +35,7 @@ mcv:
 		Offset: -1,-1
 		TransformSounds: BUILD1.WAV
 		NoTransformNotification: CannotDeploy
+		NoTransformTextNotification: Cannot deploy here.
 	SpawnActorOnDeath:
 		Actor: mcv.husk
 		OwnerType: InternalName

--- a/mods/ra/maps/bomber-john/rules.yaml
+++ b/mods/ra/maps/bomber-john/rules.yaml
@@ -97,9 +97,14 @@ Player:
 		Name: Invulnerability
 		Description: Makes a unit invulnerable\nfor 3 seconds.
 		Duration: 75
-		SelectTargetSound: slcttgt1.aud
-		BeginChargeSound: ironchg1.aud
-		EndChargeSound: ironrdy1.aud
+		SelectTargetSpeechNotification: SelectTarget
+		InsufficientPowerSpeechNotification: InsufficientPower
+		BeginChargeSpeechNotification: IronCurtainCharging
+		EndChargeSpeechNotification: IronCurtainReady
+		SelectTargetTextNotification: Select target.
+		InsufficientPowerTextNotification: Insufficient power.
+		BeginChargeTextNotification: Iron curtain charging.
+		EndChargeTextNotification: Iron curtain ready.
 		Condition: invulnerability
 		Sequence: idle
 		OnFireSound: ironcur9.aud

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -164,6 +164,7 @@ MOBILETENT:
 		Facing: 384
 		TransformSounds: placbldg.aud, build5.aud
 		NoTransformNotification: BuildingCannotPlaceAudio
+		NoTransformTextNotification: Cannot deploy here.
 	RenderSprites:
 		Image: TRUK
 

--- a/mods/ra/maps/top-o-the-world/rules.yaml
+++ b/mods/ra/maps/top-o-the-world/rules.yaml
@@ -59,6 +59,8 @@ powerproxy.spyplane:
 		OneShot: true
 		SelectTargetSpeechNotification: SelectTarget
 		EndChargeSpeechNotification: SpyPlaneReady
+		SelectTargetTextNotification: Select target.
+		EndChargeTextNotification: Spy plane ready.
 		CameraActor: camera.spyplane
 		CameraRemoveDelay: 150
 		UnitType: u2

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -47,6 +47,7 @@
 ^GainsExperience:
 	GainsExperience:
 		LevelUpNotification: LevelUp
+		LevelUpTextNotification: Unit promoted.
 		Conditions:
 			200: rank-veteran
 			400: rank-veteran
@@ -267,6 +268,7 @@
 	AttackMove:
 	HiddenUnderFog:
 	ActorLostNotification:
+		TextNotification: Unit lost.
 	ProximityCaptor:
 		Types: Vehicle
 	GpsDot:
@@ -283,7 +285,9 @@
 		CancelActivity: True
 	CaptureNotification:
 		Notification: UnitStolen
+		TextNotification: Unit stolen.
 		LoseNotification: UnitLost
+		LoseTextNotification: Unit lost.
 	MustBeDestroyed:
 	Voiced:
 		VoiceSet: VehicleVoice
@@ -367,6 +371,7 @@
 		RequiresCondition: disable-experience
 	HiddenUnderFog:
 	ActorLostNotification:
+		TextNotification: Unit lost.
 	GpsDot:
 		String: Infantry
 	Crushable:
@@ -513,6 +518,7 @@
 	AttackMove:
 	ActorLostNotification:
 		Notification: NavalUnitLost
+		TextNotification: Naval unit lost.
 	ProximityCaptor:
 		Types: Ship
 	Chronoshiftable:
@@ -573,6 +579,7 @@
 	Guardable:
 	ActorLostNotification:
 		Notification: AirUnitLost
+		TextNotification: Airborne unit lost.
 	ProximityCaptor:
 		Types: Plane
 	EjectOnDeath:
@@ -607,7 +614,9 @@
 		RequiresCondition: !airborne
 	CaptureNotification:
 		Notification: UnitStolen
+		TextNotification: Unit stolen.
 		LoseNotification: UnitLost
+		LoseTextNotification: Unit lost.
 
 ^Plane:
 	Inherits: ^NeutralPlane
@@ -666,6 +675,7 @@
 		Weapon: BuildingExplode
 		EmptyWeapon: BuildingExplode
 	CaptureNotification:
+		TextNotification: Structure captured.
 	ShakeOnDeath:
 	ProximityCaptor:
 		Types: Building
@@ -1306,6 +1316,7 @@
 	PrimaryBuilding:
 		PrimaryCondition: primary
 		SelectionNotification: PrimaryBuildingSelected
+		SelectionTextNotification: Primary building selected.
 	WithDecoration@primary:
 		RequiresCondition: primary
 		Position: Top

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -332,6 +332,7 @@ SPY:
 	Infiltrates:
 		Types: SpyInfiltrate
 		Notification: BuildingInfiltrated
+		TextNotification: Building infiltrated.
 		PlayerExperience: 50
 	AutoTarget:
 		InitialStance: HoldFire
@@ -625,6 +626,7 @@ THF:
 	Infiltrates:
 		Types: ThiefInfiltrate
 		Notification: BuildingInfiltrated
+		TextNotification: Building infiltrated.
 		PlayerExperience: 50
 	Voiced:
 		VoiceSet: ThiefVoice

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -351,6 +351,7 @@ powerproxy.parabombs:
 		AllowMultiple: true
 		UnitType: badr.bomber
 		SelectTargetSpeechNotification: SelectTarget
+		SelectTargetTextNotification: Select target.
 		QuantizedFacings: 8
 		DisplayBeacon: True
 		BeaconPoster: pbmbicon
@@ -369,6 +370,8 @@ powerproxy.sonarpulse:
 		ChargeInterval: 750
 		EndChargeSpeechNotification: SonarPulseReady
 		SelectTargetSpeechNotification: SelectTarget
+		EndChargeTextNotification: Sonar pulse ready.
+		SelectTargetTextNotification: Select target.
 		Actor: sonar
 		Terrain: Water
 		AllowUnderShroud: false
@@ -387,6 +390,7 @@ powerproxy.paratroopers:
 		Description: A Badger drops a squad of infantry\nanywhere on the map.
 		DropItems: E1,E1,E1,E3,E3
 		SelectTargetSpeechNotification: SelectTarget
+		SelectTargetTextNotification: Select target.
 		AllowImpassableCells: false
 		QuantizedFacings: 8
 		CameraActor: camera.paradrop

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -17,8 +17,11 @@ Player:
 		DisplayOrder: 0
 		LowPowerModifier: 300
 		ReadyAudio: ConstructionComplete
+		ReadyTextNotification: Construction complete.
 		BlockedAudio: NoBuild
+		BlockedTextNotification: Unable to build more.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Building
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -28,8 +31,11 @@ Player:
 		DisplayOrder: 1
 		LowPowerModifier: 300
 		ReadyAudio: ConstructionComplete
+		ReadyTextNotification: Construction complete.
 		BlockedAudio: NoBuild
+		BlockedTextNotification: Unable to build more.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Building
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -39,8 +45,11 @@ Player:
 		DisplayOrder: 3
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
+		ReadyTextNotification: Unit ready.
 		BlockedAudio: NoBuild
+		BlockedTextNotification: Unable to build more.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Building
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -51,8 +60,11 @@ Player:
 		DisplayOrder: 2
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
+		ReadyTextNotification: Unit ready.
 		BlockedAudio: NoBuild
+		BlockedTextNotification: Unable to build more.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Training
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -62,8 +74,11 @@ Player:
 		DisplayOrder: 5
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
+		ReadyTextNotification: Unit ready.
 		BlockedAudio: NoBuild
+		BlockedTextNotification: Unable to build more.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Building
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -73,8 +88,11 @@ Player:
 		DisplayOrder: 4
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
+		ReadyTextNotification: Unit ready.
 		BlockedAudio: NoBuild
+		BlockedTextNotification: Unable to build more.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Building
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -82,6 +100,8 @@ Player:
 	PlaceBuilding:
 		NewOptionsNotification: NewOptions
 		CannotPlaceNotification: BuildingCannotPlaceAudio
+		NewOptionsTextNotification: New construction options.
+		CannotPlaceTextNotification: Cannot deploy here.
 	SupportPowerManager:
 	ScriptTriggers:
 	MissionObjectives:
@@ -91,9 +111,11 @@ Player:
 	ConquestVictoryConditions:
 	PowerManager:
 		SpeechNotification: LowPower
+		TextNotification: Low power.
 	AllyRepair:
 	PlayerResources:
 		InsufficientFundsNotification: InsufficientFunds
+		InsufficientFundsTextNotification: Insufficient funds.
 		CashTickUpNotification: CashTickUp
 		CashTickDownNotification: CashTickDown
 	DeveloperMode:
@@ -124,6 +146,8 @@ Player:
 		Prerequisites: global-reusable-engineers
 	FrozenActorLayer:
 	BaseAttackNotifier:
+		TextNotification: Base under attack.
+		AllyTextNotification: Our ally is under attack.
 	PlayerStatistics:
 	PlaceBeacon:
 	ProvidesTechPrerequisite@infonly:
@@ -152,6 +176,7 @@ Player:
 		Image: iconchevrons
 		Sequence: veteran
 	ResourceStorageWarning:
+		TextNotification: Silos needed.
 	PlayerExperience:
 	GameSaveViewportManager:
 	PlayerRadarTerrain:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -44,6 +44,11 @@ MSLO:
 		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSpeechNotification: InsufficientPower
 		IncomingSpeechNotification: AbombLaunchDetected
+		SelectTargetTextNotification: Select target.
+		InsufficientPowerTextNotification: Insufficient power.
+		BeginChargeTextNotification: A-bomb prepping.
+		EndChargeTextNotification: A-bomb ready.
+		IncomingTextNotification: A-bomb launch detected.
 		MissileWeapon: atomic
 		MissileImage: atomic
 		MissileDelay: 5
@@ -206,7 +211,9 @@ SPEN:
 	RepairsUnits:
 		HpPerStep: 1000
 		StartRepairingNotification: Repairing
+		StartRepairingTextNotification: Repairing.
 		FinishRepairingNotification: UnitRepaired
+		FinishRepairingTextNotification: Unit repaired.
 		PlayerExperience: 15
 	RallyPoint:
 		ForceSetType: Ship
@@ -321,7 +328,9 @@ SYRD:
 	RepairsUnits:
 		HpPerStep: 1000
 		StartRepairingNotification: Repairing
+		StartRepairingTextNotification: Repairing.
 		FinishRepairingNotification: UnitRepaired
+		FinishRepairingTextNotification: Unit repaired.
 		PlayerExperience: 15
 	RallyPoint:
 		ForceSetType: Ship
@@ -425,6 +434,10 @@ IRON:
 		InsufficientPowerSpeechNotification: InsufficientPower
 		BeginChargeSpeechNotification: IronCurtainCharging
 		EndChargeSpeechNotification: IronCurtainReady
+		SelectTargetTextNotification: Select target.
+		InsufficientPowerTextNotification: Insufficient power.
+		BeginChargeTextNotification: Iron curtain charging.
+		EndChargeTextNotification: Iron curtain ready.
 		DisplayRadarPing: True
 		Condition: invulnerability
 		OnFireSound: ironcur9.aud
@@ -495,6 +508,10 @@ PDOX:
 		InsufficientPowerSpeechNotification: InsufficientPower
 		BeginChargeSpeechNotification: ChronosphereCharging
 		EndChargeSpeechNotification: ChronosphereReady
+		SelectTargetTextNotification: Select target.
+		InsufficientPowerTextNotification: Insufficient power.
+		BeginChargeTextNotification: Chronosphere charging.
+		EndChargeTextNotification: Chronosphere ready.
 		Duration: 400
 		KillCargo: true
 		DisplayRadarPing: True
@@ -513,6 +530,10 @@ PDOX:
 		InsufficientPowerSpeechNotification: InsufficientPower
 		BeginChargeSpeechNotification: ChronosphereCharging
 		EndChargeSpeechNotification: ChronosphereReady
+		SelectTargetTextNotification: Select target.
+		InsufficientPowerTextNotification: Insufficient power.
+		BeginChargeTextNotification: Chronosphere charging.
+		EndChargeTextNotification: Chronosphere ready.
 		Duration: 400
 		KillCargo: true
 		DisplayRadarPing: True
@@ -985,6 +1006,7 @@ ATEK:
 		Description: Reveals map terrain and provides tactical\ninformation. Requires power and active radar.
 		RevealDelay: 375
 		LaunchSpeechNotification: SatelliteLaunched
+		LaunchTextNotification: Satellite launched.
 		DisplayTimerRelationships: Ally, Neutral, Enemy
 		SupportPowerPaletteOrder: 90
 	SupportPowerChargeBar:
@@ -1264,6 +1286,7 @@ PROC:
 		Percentage: 50
 		Types: SpyInfiltrate, ThiefInfiltrate
 		InfiltratedNotification: CreditsStolen
+		InfiltratedTextNotification: Credits stolen.
 	WithBuildingBib:
 	WithIdleOverlay@TOP:
 		RequiresCondition: !build-incomplete
@@ -1326,6 +1349,7 @@ SILO:
 		Percentage: 50
 		Types: ThiefInfiltrate
 		InfiltratedNotification: CreditsStolen
+		InfiltratedTextNotification: Credits stolen.
 	WithBuildingBib:
 		HasMinibib: true
 	-WithSpriteBody:
@@ -1506,6 +1530,8 @@ AFLD:
 		Description: Reveals an area of the map.
 		SelectTargetSpeechNotification: SelectTarget
 		EndChargeSpeechNotification: SpyPlaneReady
+		SelectTargetTextNotification: Select target.
+		EndChargeTextNotification: Spy plane ready.
 		CameraActor: camera.spyplane
 		CameraRemoveDelay: 150
 		UnitType: u2
@@ -1528,6 +1554,8 @@ AFLD:
 		DropItems: E1R1,E1R1,E1R1,E3R1,E3R1
 		ReinforcementsArrivedSpeechNotification: ReinforcementsArrived
 		SelectTargetSpeechNotification: SelectTarget
+		ReinforcementsArrivedTextNotification: Reinforcements have arrived.
+		SelectTargetTextNotification: Select target.
 		AllowImpassableCells: false
 		QuantizedFacings: 8
 		CameraActor: camera.paradrop
@@ -1547,6 +1575,7 @@ AFLD:
 		Name: Parabombs
 		Description: A squad of Badgers drop parachuted\nbombs on your target.
 		SelectTargetSpeechNotification: SelectTarget
+		SelectTargetTextNotification: Select target.
 		CameraActor: camera
 		CameraRemoveDelay: 150
 		UnitType: badr.bomber
@@ -1989,7 +2018,9 @@ FIX:
 		HpPerStep: 1000
 		Interval: 7
 		StartRepairingNotification: Repairing
+		StartRepairingTextNotification: Repairing.
 		FinishRepairingNotification: UnitRepaired
+		FinishRepairingTextNotification: Unit repaired.
 		PlayerExperience: 15
 	WithBuildingBib:
 		HasMinibib: true

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -377,6 +377,7 @@ MCV:
 		Facing: 384
 		TransformSounds: placbldg.aud, build5.aud
 		NoTransformNotification: BuildingCannotPlaceAudio
+		NoTransformTextNotification: Cannot deploy here.
 	MustBeDestroyed:
 		RequiredForShortGame: true
 	BaseBuilding:

--- a/mods/ts/chrome/ingame-transients.yaml
+++ b/mods/ts/chrome/ingame-transients.yaml
@@ -1,0 +1,13 @@
+Container@TRANSIENTS_PANEL:
+	X: 5
+	Y: WINDOW_BOTTOM - HEIGHT - 65
+	Width: 550
+	Height: 80
+	Logic: IngameTransientNotificationsLogic
+	Children:
+		TextNotificationsDisplay@TRANSIENTS_DISPLAY:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			RemoveTime: 100
+			LogLength: 5
+			HideOverflow: False

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -131,7 +131,7 @@ Assemblies:
 ChromeLayout:
 	common|chrome/ingame.yaml
 	common|chrome/ingame-chat.yaml
-	common|chrome/ingame-transients.yaml
+	ts|chrome/ingame-transients.yaml
 	common|chrome/ingame-fmvplayer.yaml
 	common|chrome/ingame-menu.yaml
 	common|chrome/ingame-info.yaml

--- a/mods/ts/rules/civilian-infantry.yaml
+++ b/mods/ts/rules/civilian-infantry.yaml
@@ -82,6 +82,7 @@ CHAMSPY:
 	Infiltrates:
 		Types: SpyInfiltrate
 		Notification: BuildingInfiltrated
+		TextNotification: Building infiltrated.
 	-WithSplitAttackPaletteInfantryBody:
 	WithDisguisingInfantryBody:
 		IdleSequences: idle1, idle2

--- a/mods/ts/rules/civilian-structures.yaml
+++ b/mods/ts/rules/civilian-structures.yaml
@@ -827,6 +827,7 @@ CAHOSP:
 	Capturable:
 		Types: building
 	CaptureNotification:
+		TextNotification: Building captured.
 	ProvidesPrerequisite@BuildingName:
 	ThrowsShrapnel@SMALL:
 		Pieces: 5, 9

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -17,6 +17,7 @@
 ^GainsExperience:
 	GainsExperience:
 		LevelUpNotification: LevelUp
+		LevelUpTextNotification: Unit promoted.
 		Conditions:
 			500: rank
 			1000: rank
@@ -387,6 +388,7 @@
 	OwnerLostAction:
 		Action: Kill
 	CaptureNotification:
+		TextNotification: Building captured.
 	Demolishable:
 		Condition: being-demolished
 	Sellable:
@@ -594,6 +596,7 @@
 		Voice: Move
 	HiddenUnderFog:
 	ActorLostNotification:
+		TextNotification: Unit lost.
 	DamagedByTerrain:
 		Terrain: Tiberium, BlueTiberium
 		Damage: 200
@@ -805,6 +808,7 @@
 		Voice: Move
 	HiddenUnderFog:
 	ActorLostNotification:
+		TextNotification: Unit lost.
 	CaptureManager:
 		BeingCapturedCondition: being-captured
 	Capturable:
@@ -921,6 +925,7 @@
 		Voice: Move
 		MoveIntoShroud: false
 	ActorLostNotification:
+		TextNotification: Unit lost.
 	BodyOrientation:
 		QuantizedFacings: 0
 		CameraPitch: 85
@@ -1427,6 +1432,7 @@
 	PrimaryBuilding:
 		PrimaryCondition: primary
 		SelectionNotification: PrimaryBuildingSelected
+		SelectionTextNotification: Primary building selected.
 	WithTextDecoration@primary:
 		RequiresCondition: primary
 		Position: Top

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -312,6 +312,9 @@ GAHPAD:
 		PauseOnCondition: empdisable
 		PlayerExperience: 15
 		StartRepairingNotification: Repairing
+		StartRepairingTextNotification: Repairing.
+		FinishRepairingNotification: UnitRepaired
+		FinishRepairingTextNotification: Unit repaired.
 	ProductionBar:
 		ProductionType: Air
 	WithIdleOverlay@PLATFORM:
@@ -359,6 +362,9 @@ GADEPT:
 		PauseOnCondition: empdisable
 		PlayerExperience: 15
 		StartRepairingNotification: Repairing
+		StartRepairingTextNotification: Repairing.
+		FinishRepairingNotification: UnitRepaired
+		FinishRepairingTextNotification: Unit repaired.
 	RallyPoint:
 		Palette: mouse
 		IsPlayerPalette: false
@@ -544,6 +550,8 @@ GAPLUG:
 		Description: Initiate an Ion Cannon strike.\nApplies instant damage to a small area.
 		EndChargeSpeechNotification: IonCannonReady
 		SelectTargetSpeechNotification: SelectTarget
+		EndChargeTextNotification: Ion cannon ready.
+		SelectTargetTextNotification: Select target.
 		DisplayRadarPing: True
 		CameraActor: camera
 	DropPodsPower:
@@ -554,6 +562,7 @@ GAPLUG:
 		Name: Drop Pods
 		Description: Drop Pod reinforcements.\nSmall team of elite soldiers orbital drops\nto target location.
 		SelectTargetSpeechNotification: SelectTarget
+		SelectTargetTextNotification: Select target.
 		DisplayRadarPing: true
 		ChargeInterval: 10000
 		UnitTypes: DPOD2E1, DPOD2E2

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -276,6 +276,9 @@ NAHPAD:
 		PauseOnCondition: empdisable
 		PlayerExperience: 15
 		StartRepairingNotification: Repairing
+		StartRepairingTextNotification: Repairing.
+		FinishRepairingNotification: UnitRepaired
+		FinishRepairingTextNotification: Unit repaired.
 	ProductionBar:
 		ProductionType: Air
 	WithIdleOverlay@PLATFORM:
@@ -525,6 +528,9 @@ NAMISL:
 		EndChargeSpeechNotification: ClusterMissileReady
 		SelectTargetSpeechNotification: SelectTarget
 		IncomingSpeechNotification: MissileLaunchDetected
+		EndChargeTextNotification: Cluster missile ready.
+		SelectTargetTextNotification: Select target.
+		IncomingTextNotification: Missile launch detected.
 		LaunchSound: icbm1.aud
 		MissileWeapon: ClusterMissile
 		MissileImage: ClusterMissile

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -20,7 +20,9 @@ Player:
 		BuildDurationModifier: 120
 		LowPowerModifier: 300
 		ReadyAudio: ConstructionComplete
+		ReadyTextNotification: Construction complete.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Building
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -31,7 +33,9 @@ Player:
 		BuildDurationModifier: 120
 		LowPowerModifier: 300
 		ReadyAudio: ConstructionComplete
+		ReadyTextNotification: Construction complete.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Building
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -42,7 +46,9 @@ Player:
 		BuildDurationModifier: 120
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
+		ReadyTextNotification: Unit ready.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Training
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -53,7 +59,9 @@ Player:
 		BuildDurationModifier: 120
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
+		ReadyTextNotification: Unit ready.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Training
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -64,7 +72,9 @@ Player:
 		BuildDurationModifier: 120
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
+		ReadyTextNotification: Unit ready.
 		LimitedAudio: BuildingInProgress
+		LimitedTextNotification: Unable to comply. Building in progress.
 		QueuedAudio: Training
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
@@ -72,6 +82,8 @@ Player:
 	PlaceBuilding:
 		NewOptionsNotification: NewOptions
 		CannotPlaceNotification: BuildingCannotPlaceAudio
+		NewOptionsTextNotification: New construction options.
+		CannotPlaceTextNotification: Cannot deploy here.
 	SupportPowerManager:
 	ScriptTriggers:
 	MissionObjectives:
@@ -81,9 +93,11 @@ Player:
 	ConquestVictoryConditions:
 	PowerManager:
 		SpeechNotification: LowPower
+		TextNotification: Low power.
 	AllyRepair:
 	PlayerResources:
 		InsufficientFundsNotification: InsufficientFunds
+		InsufficientFundsTextNotification: Insufficient funds.
 		CashTickUpNotification: CashTickUp
 		CashTickDownNotification: CashTickDown
 	DeveloperMode:
@@ -100,8 +114,11 @@ Player:
 		Prerequisites: global-factundeploy
 	FrozenActorLayer:
 	BaseAttackNotifier:
+		TextNotification: Base under attack.
+		AllyTextNotification: Our ally is under attack.
 		AllyNotification: OurAllyIsUnderAttack
 	HarvesterAttackNotifier:
+		TextNotification: Harvester under attack.
 	PlayerStatistics:
 	PlaceBeacon:
 		Palette: effect
@@ -126,6 +143,7 @@ Player:
 		Prerequisites: techlevel.low, techlevel.medium, techlevel.high, techlevel.superweapons
 		Id: unrestricted
 	ResourceStorageWarning:
+		TextNotification: Silos needed.
 	PlayerExperience:
 	GameSaveViewportManager:
 	PlayerRadarTerrain:

--- a/mods/ts/rules/shared-infantry.yaml
+++ b/mods/ts/rules/shared-infantry.yaml
@@ -73,6 +73,7 @@ ENGINEER:
 	EngineerRepair:
 	RepairsBridges:
 		RepairNotification: BridgeRepaired
+		RepairTextNotification: Bridge repaired.
 	CaptureManager:
 	Captures:
 		CaptureTypes: building

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -51,3 +51,5 @@ NAPULS:
 		Description: Fires a pulse blast which disables\nall mechanical units in the area.
 		EndChargeSpeechNotification: EmPulseCannonReady
 		SelectTargetSpeechNotification: SelectTarget
+		EndChargeTextNotification: EMP cannon ready.
+		SelectTargetTextNotification: Select target.

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -34,6 +34,8 @@ MCV:
 		TransformSounds: place2.aud
 		NoTransformSounds:
 		Voice: Move
+		NoTransformNotification: BuildingCannotPlaceAudio
+		NoTransformTextNotification: Cannot deploy here.
 	RenderSprites:
 		Image: mcv.gdi
 		FactionImages:


### PR DESCRIPTION
This PR adds support for text notifications that display along all speech notifications. This is useful for players that don't have audio or whose hearing is impaired. The notifications are displayed in the new transients panel which also hosts the UI feedback notifications. There is an option under "Display" to toggle these notifications and they are enabled by default[^checkbox].

[^checkbox]: I've changed the label of the UI feedback checkbox in settings to read _"Show UI Feedback Notifications"_ (see https://github.com/OpenRA/OpenRA/pull/19677#discussion_r778010108).

The text notifications are added as fields to traits that make use of `[NotificationReference]`[^cash][^beacons]. This is a different approach to my previous attempt where the notifications were transcriptions attached to the speech definitions (see #18929). This new approach results in more code but I think it's better by design because audio and text aren't the same thing - text might not be a direct transcription of the spoken words (e.g. faction announcers) or the audio notification might not even be speech (e.g. sound effects).

[^cash]: Text notifications for cash ticks not implemented because they are too frequent.
[^beacons]: Text notifications for beacons not implemented because I think this needs some more thought and is better left to a follow up.

## Screenshots

![image](https://user-images.githubusercontent.com/1355810/148746863-546d2350-8e7d-418a-834f-11d93366fc54.png)

## List of notifications

I have added all possible notifications to all mods in a TESTCASE commit. We should consider which texts are worthy of keeping. Some of them are backed by other visual cues (e.g. "Building.", "On hold.", "Cancelled", "Select target.", "Rally point established.") while others may be considered noise ("Unit ready.", "Unit lost.").

Here're all traits and my proposal on what notifications to include:

### Common

| Actors | Traits | Notifications | Text |
| --- | --- | --- | --- |
| Classic Production Faciliites | PrimaryBuilding | SelectionTextNotification | Primary building selected. |
| Production Faciliites | RallyPoint | TextNotification | \- |
| Structures | RepairableBuilding | RepairingTextNotification | \- |
| ^DisableOnLowPowerOrPowerDown, ^DisableOnPowerDown | ToggleConditionOnOrder | EnabledTextNotification | \- |
| ^DisableOnLowPowerOrPowerDown, ^DisableOnPowerDown | ToggleConditionOnOrder | DisabledTextNotification | \- |
| Various | CrateAction | TextNotification | \- |
| ^GainsExperience | GainsExperience | LevelUpTextNotification | Unit promoted. |
| Player | BaseAttackNotifier | TextNotification | Base under attack. |
| Player | BaseAttackNotifier | AllyTextNotification | Our ally is under attack. |
| Player | MissionObjectives | WinTextNotification | \- |
| Player | MissionObjectives | LoseTextNotification | \- |
| Player | MissionObjectives | LeaveTextNotification | \- |
| Player | PlaceBeacon | \- | \- |
| Player | PlaceBuilding | NewOptionsTextNotification | New construction options. |
| Player | PlaceBuilding | CannotPlaceTextNotification | Cannot deploy here. |
| Player | PlayerResources | InsufficientFundsTextNotification | Insufficient funds. |
| Player | PlayerResources | CashTickUpNotification | \- |
| Player | PlayerResources | CashTickDownNotification | \- |
| Player or production facilities | ProductionQueue | ReadyTextNotification | Unit ready. / Construction complete. |
| Player or production facilities | ProductionQueue | BlockedTextNotification | Unable to build more. |
| Player or production facilities | ProductionQueue | LimitedTextNotification | Unable to comply. Building in progress. |
| Player or production facilities | ProductionQueue | QueuedTextNotification | \- |
| Player or production facilities | ProductionQueue | OnHoldTextNotification | \- |
| Player or production facilities | ProductionQueue | CancelledTextNotification | \- |
| Player | ResourceStorageWarning | TextNotification | Silos needed. |
| Player | PowerManager | TextNotification | Low power. |
| Buildings | Sellable | TextNotification | \- |
| Units | ActorLostNotification | TextNotification | Unit lost. |
| Support powers | SupportPower | DetectedTextNotification | \- |
| Support powers | SupportPower | BeginChargeTextNotification | \- |
| Support powers | SupportPower | EndChargeTextNotification | \- |
| Support powers | SupportPower | SelectTargetTextNotification | \- |
| Support powers | SupportPower | InsufficientPowerTextNotification | \- |
| Support powers | SupportPower | LaunchTextNotification | \- |
| Support powers | SupportPower | IncomingTextNotification | \- |
| MCV | Transforms | TransformTextNotification | \- |
| MCV | Transforms | NoTransformTextNotification | Cannot deploy here. |
| World | StartGameNotification | TextNotification | \- |
| World | StartGameNotification | LoadedTextNotification | \- |
| World | StartGameNotification | SavedTextNotification | \- |
| (unused) | ProductionParadrop | \- | \- |
| (unused) | GrantPrerequisiteChargeDrainPower | \- | \- |

### TD

| Actors | Traits | Notifications | Text |
| --- | --- | --- | --- |
| AFLD | ProductionAirdrop | ReadyTextNotification | Reinforcements have arrived. |
| E6 | RepairsBridges | RepairTextNotification | \- |
| HPAD, FIX, | RepairsUnits | StartRepairingTextNotification | Repairing. |
| HPAD, FIX | RepairsUnits | FinishRepairingTextNotification | \- |
| ^Building | ActorLostNotification | TextNotification | Structure lost. |
| ^CivInfantry | ActorLostNotification | TextNotification | Civillian killed. |
| HARV | ActorLostNotification | TextNotification | Harvester lost. |
| ^Building | CaptureNotification | TextNotification | Building captured. |
| ^Building | CaptureNotification | LoseTextNotification | \- |
| ^TechBuilding | CaptureNotification | TextNotification | Civilian building captured. |
| ^TechBuilding | CaptureNotification | LoseTextNotification | \- |
| EYE | IonCannonPower | DetectedTextNotification | \- |
| EYE | IonCannonPower | BeginChargeTextNotification | Ion cannon charging. |
| EYE | IonCannonPower | EndChargeTextNotification | Ion cannon ready. |
| EYE | IonCannonPower | SelectTargetTextNotification | Select target. |
| EYE | IonCannonPower | InsufficientPowerTextNotification | Insufficient power. |
| EYE | IonCannonPower | LaunchTextNotification | \- |
| EYE | IonCannonPower | IncomingTextNotification | \- |
| HQ | AirstrikePower | DetectedTextNotification | \- |
| HQ | AirstrikePower | BeginChargeTextNotification | \- |
| HQ | AirstrikePower | EndChargeTextNotification | Airstrike ready. |
| HQ | AirstrikePower | SelectTargetTextNotification | Select target. |
| HQ | AirstrikePower | InsufficientPowerTextNotification | Insufficient power. |
| HQ | AirstrikePower | LaunchTextNotification | \- |
| HQ | AirstrikePower | IncomingTextNotification | Enemy planes approaching. |
| TMPL | NukePower | DetectedTextNotification | \- |
| TMPL | NukePower | BeginChargeTextNotification | \- |
| TMPL | NukePower | EndChargeTextNotification | Nuclear weapon available. |
| TMPL | NukePower | SelectTargetTextNotification | Select target. |
| TMPL | NukePower | InsufficientPowerTextNotification | Insufficient power. |
| TMPL | NukePower | LaunchTextNotification | Nuclear weapon launched. |
| TMPL | NukePower | IncomingTextNotification | Nuclear warhead approaching. |

### RA

| Actors | Traits | Notifications | Text |
| --- | --- | --- | --- |
| PROC, SILO | InfiltrateForCash | InfiltratedTextNotification | Credits stolen. |
| PROC, SILO | InfiltrateForCash | InfiltrationTextNotification | \- |
| DOME | InfiltrateForExploration | InfiltratedTextNotification | \- |
| DOME | InfiltrateForExploration | InfiltrationTextNotification | \- |
| ^DisabledByPowerOutage | InfiltrateForPowerOutage | InfiltratedTextNotification | \- |
| ^DisabledByPowerOutage | InfiltrateForPowerOutage | InfiltrationTextNotification | \- |
| Production Facilities | InfiltrateForSupportPower | InfiltratedTextNotification | \- |
| Production Facilities | InfiltrateForSupportPower | InfiltrationTextNotification | \- |
| Super Weapons | InfiltrateForSupportPowerReset | InfiltratedTextNotification | \- |
| Super Weapons | InfiltrateForSupportPowerReset | InfiltrationTextNotification | \- |
| SPY | Infiltrates | TextNotification | Building infiltrated. |
| E6 | RepairsBridges | RepairTextNotification | \- |
| SYRD, SPEN, FIX | RepairsUnits | StartRepairingTextNotification | Repairing. |
| SYRD, SPEN, FIX | RepairsUnits | FinishRepairingTextNotification | \- |
| Buildings | ActorLostNotification | TextNotification | \- |
| Naval units | ActorLostNotification | TextNotification | Naval unit lost. |
| Air units | ActorLostNotification | TextNotification | Airborne unit lost. |
| ^Vehicle, ^NeutralPlane | CaptureNotification | TextNotification | Unit stolen. |
| ^Vehicle, ^NeutralPlane | CaptureNotification | LoseTextNotification | Unit lost. |
| ^BasicBuilding | CaptureNotification | TextNotification | Structure captured. |
| ^BasicBuilding | CaptureNotification | LoseTextNotification | \- |
| AFLD | ParatroopersPower | ReinforcementsArrivedTextNotification | Reinforcements have arrived. |
| PDOX | ChronoshiftPower | DetectedTextNotification | \- |
| PDOX | ChronoshiftPower | BeginChargeTextNotification | Chronosphere charging. |
| PDOX | ChronoshiftPower | EndChargeTextNotification | Chronosphere ready. |
| PDOX | ChronoshiftPower | SelectTargetTextNotification | Select target. |
| PDOX | ChronoshiftPower | InsufficientPowerTextNotification | Insufficient power. |
| PDOX | ChronoshiftPower | LaunchTextNotification | \- |
| PDOX | ChronoshiftPower | IncomingTextNotification | \- |
| ATEK | GpsPower | DetectedTextNotification | \- |
| ATEK | GpsPower | BeginChargeTextNotification | \- |
| ATEK | GpsPower | EndChargeTextNotification | \- |
| ATEK | GpsPower | SelectTargetTextNotification | \- |
| ATEK | GpsPower | InsufficientPowerTextNotification | \- |
| ATEK | GpsPower | LaunchTextNotification | Satellite launched. |
| ATEK | GpsPower | IncomingTextNotification | \- |
| powerproxy.parabombs | AirstrikePower | DetectedTextNotification | \- |
| powerproxy.parabombs | AirstrikePower | BeginChargeTextNotification | \- |
| powerproxy.parabombs | AirstrikePower | EndChargeTextNotification | \- |
| powerproxy.parabombs | AirstrikePower | SelectTargetTextNotification | Select target. |
| powerproxy.parabombs | AirstrikePower | InsufficientPowerTextNotification | \- |
| powerproxy.parabombs | AirstrikePower | LaunchTextNotification | \- |
| powerproxy.parabombs | AirstrikePower | IncomingTextNotification | \- |
| AirstrikePower@spyplane | AirstrikePower | DetectedTextNotification | \- |
| AirstrikePower@spyplane | AirstrikePower | BeginChargeTextNotification | \- |
| AirstrikePower@spyplane | AirstrikePower | EndChargeTextNotification | Spy plane ready. |
| AirstrikePower@spyplane | AirstrikePower | SelectTargetTextNotification | Select target. |
| AirstrikePower@spyplane | AirstrikePower | InsufficientPowerTextNotification | \- |
| AirstrikePower@spyplane | AirstrikePower | LaunchTextNotification | \- |
| AirstrikePower@spyplane | AirstrikePower | IncomingTextNotification | \- |
| IRON | GrantExternalConditionPower | DetectedTextNotification | \- |
| IRON | GrantExternalConditionPower | BeginChargeTextNotification | Iron curtain charging. |
| IRON | GrantExternalConditionPower | EndChargeTextNotification | Iron curtain ready. |
| IRON | GrantExternalConditionPower | SelectTargetTextNotification | Select target. |
| IRON | GrantExternalConditionPower | InsufficientPowerTextNotification | Insufficient power. |
| IRON | GrantExternalConditionPower | LaunchTextNotification | \- |
| IRON | GrantExternalConditionPower | IncomingTextNotification | \- |
| MSLO | NukePower | DetectedTextNotification | \- |
| MSLO | NukePower | BeginChargeTextNotification | A-bomb prepping. |
| MSLO | NukePower | EndChargeTextNotification | A-bomb ready. |
| MSLO | NukePower | SelectTargetTextNotification | Select target. |
| MSLO | NukePower | InsufficientPowerTextNotification | Insufficient power. |
| MSLO | NukePower | LaunchTextNotification | \- |
| MSLO | NukePower | IncomingTextNotification | A-bomb launch detected. |
| powerproxy.paratroopers | ParatroopersPower | DetectedTextNotification | \- |
| powerproxy.paratroopers | ParatroopersPower | BeginChargeTextNotification | \- |
| powerproxy.paratroopers | ParatroopersPower | EndChargeTextNotification | \- |
| powerproxy.paratroopers | ParatroopersPower | SelectTargetTextNotification | Select target. |
| powerproxy.paratroopers | ParatroopersPower | InsufficientPowerTextNotification | \- |
| powerproxy.paratroopers | ParatroopersPower | LaunchTextNotification | \- |
| powerproxy.paratroopers | ParatroopersPower | IncomingTextNotification | \- |
| powerproxy.sonarpulse | SpawnActorPower | DetectedTextNotification | \- |
| powerproxy.sonarpulse | SpawnActorPower | BeginChargeTextNotification | \- |
| powerproxy.sonarpulse | SpawnActorPower | EndChargeTextNotification | Sonar pulse ready. |
| powerproxy.sonarpulse | SpawnActorPower | SelectTargetTextNotification | Select target. |
| powerproxy.sonarpulse | SpawnActorPower | InsufficientPowerTextNotification | \- |
| powerproxy.sonarpulse | SpawnActorPower | LaunchTextNotification | \- |
| powerproxy.sonarpulse | SpawnActorPower | IncomingTextNotification | \- |

### D2k

| Actors | Traits | Notifications | Text |
| --- | --- | --- | --- |
| starport | ProductionAirdrop | ReadyTextNotification | Reinforcements have arrived. |
| Player | HarvesterAttackNotifier | TextNotification | Harvester under attack. |
| Player | ProductionQueue | BlockedTextNotification | No room for new unit. |
| repair_pad | RepairsUnits | StartRepairingTextNotification | Repairing. |
| repair_pad | RepairsUnits | FinishRepairingTextNotification | Unit repaired. |
| sandworm | AnnounceOnSeen | TextNotification | Worm sign. |
| ^Building | CaptureNotification | TextNotification | Enemy building captured. |
| ^Building | CaptureNotification | LoseTextNotification | One of our buildings has been captured. |
| ^Building | ActorLostNotification | TextNotification | Building lost. |
| palace | NukePower | DetectedTextNotification | \- |
| palace | NukePower | BeginChargeTextNotification | Death Hand missile prepping. |
| palace | NukePower | EndChargeTextNotification | Death Hand missile ready. |
| palace | NukePower | SelectTargetTextNotification | Select target. |
| palace | NukePower | InsufficientPowerTextNotification | \- |
| palace | NukePower | LaunchTextNotification | \- |
| palace | NukePower | IncomingTextNotification | Missile launch detected. |
| sandworm | AttackSwallow | WormAttackTextNotification | Worm attack. |
| high_tech_factory | AirstrikePower | DetectedTextNotification | \- |
| high_tech_factory | AirstrikePower | BeginChargeTextNotification | \- |
| high_tech_factory | AirstrikePower | EndChargeTextNotification | Airstrike ready. |
| high_tech_factory | AirstrikePower | SelectTargetTextNotification | Select target. |
| high_tech_factory | AirstrikePower | InsufficientPowerTextNotification | \- |
| high_tech_factory | AirstrikePower | LaunchTextNotification | \- |
| high_tech_factory | AirstrikePower | IncomingTextNotification | \- |
| ProduceActorPower@fremen | ProduceActorPower | EndChargeTextNotification | Fremen ready. |
| ProduceActorPower@fremen | ProduceActorPower | ReadyTextNotification | Reinforcements have arrived. |
| ProduceActorPower@fremen | ProduceActorPower | BlockedTextNotification | No room for new unit. |
| ProduceActorPower@saboteur | ProduceActorPower | EndChargeTextNotification | Saboteur ready. |
| ProduceActorPower@saboteur | ProduceActorPower | ReadyTextNotification | Reinforcements have arrived. |
| ProduceActorPower@saboteur | ProduceActorPower | BlockedTextNotification | No room for new unit. |

### TS

| Actors | Traits | Notifications | Text |
| --- | --- | --- | --- |
| CHAMSPY | Infiltrates | TextNotification | Building infiltrated. |
| NARADR, GARADR | InfiltrateForExploration | \- |
| Player | HarvesterAttackNotifier | TextNotification | Harvester under attack. |
| ENGINEER | RepairsBridges | RepairTextNotification | Bridge repaired. |
| GAHPAD, GADEPT, NAHPAD | RepairsUnits | StartRepairingTextNotification | Repairing. |
| GAHPAD, GADEPT, NAHPAD | RepairsUnits | FinishRepairingTextNotification | Unit repaired. |
| ^Building, CAHOSP | CaptureNotification | TextNotification | Building captured. |
| ^Building, CAHOSP | CaptureNotification | LoseTextNotification | \- |
| Buildings | ActorLostNotification | TextNotification | \- |
| GAPLUG, NATMPL | ProduceActorPower | ReadyTextNotification | \- |
| GAPLUG, NATMPL | ProduceActorPower | BlockedTextNotification | \- |
| NAPULS | AttackOrderPower | EndChargeTextNotification | EMP cannon ready. |
| NAPULS | AttackOrderPower | SelectTargetTextNotification | Select target. |
| GAPLUG | DropPodsPower | DetectedTextNotification | \- |
| GAPLUG | DropPodsPower | BeginChargeTextNotification | \- |
| GAPLUG | DropPodsPower | EndChargeTextNotification | \- |
| GAPLUG | DropPodsPower | SelectTargetTextNotification | Select target. |
| GAPLUG | DropPodsPower | InsufficientPowerTextNotification | \- |
| GAPLUG | DropPodsPower | LaunchTextNotification | \- |
| GAPLUG | DropPodsPower | IncomingTextNotification | \- |
| GAPLUG | IonCannonPower | DetectedTextNotification | \- |
| GAPLUG | IonCannonPower | BeginChargeTextNotification | \- |
| GAPLUG | IonCannonPower | EndChargeTextNotification | Ion cannon ready. |
| GAPLUG | IonCannonPower | SelectTargetTextNotification | Select target. |
| GAPLUG | IonCannonPower | InsufficientPowerTextNotification | \- |
| GAPLUG | IonCannonPower | LaunchTextNotification | \- |
| GAPLUG | IonCannonPower | IncomingTextNotification | \- |
| NAMISL| NukePower | DetectedTextNotification | \- |
| NAMISL| NukePower | BeginChargeTextNotification | \- |
| NAMISL| NukePower | EndChargeTextNotification | Cluster missile ready. |
| NAMISL| NukePower | SelectTargetTextNotification | Select target. |
| NAMISL| NukePower | InsufficientPowerTextNotification | \- |
| NAMISL| NukePower | LaunchTextNotification | \- |
| NAMISL| NukePower | IncomingTextNotification | Missile launch detected. |

## Linked issues

Closes #3278
Closes #6400
Closes #6354
Closes #12209
Closes #12954
Related #19724