### PR TITLE
Fix ToAhsv using the wrong type for alpha

### DIFF
--- a/OpenRA.Game/Primitives/Color.cs
+++ b/OpenRA.Game/Primitives/Color.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Primitives
 			return FromAhsv(255, h, s, v);
 		}
 
-		public (float A, float H, float S, float V) ToAhsv()
+		public (int A, float H, float S, float V) ToAhsv()
 		{
 			var (h, s, v) = RgbToHsv(R, G, B);
 			return (A, h, s, v);


### PR DESCRIPTION
Fixes an oversight(?) from #19335. Everything else is using `int` for `Alpha` so I suspect this is a simple oversight (with no big implications though).