### PR TITLE
Add map refresh

### DIFF
--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of
@@ -39,6 +39,14 @@ namespace OpenRA
 
 		public Dictionary<string, string> StringPool { get; } = new Dictionary<string, string>();
 
+		readonly List<MapDirectoryTracker> mapDirectoryTrackers = new List<MapDirectoryTracker>();
+
+		/// <summary>
+		/// If a map was added oldUID will be null, if updated oldUId will point to the outdated map
+		/// Event is not called when map is deleted
+		/// </summary>
+		public event Action<string, string> MapUpdated = (oldUID, newUID) => { };
+
 		public MapCache(ModData modData)
 		{
 			this.modData = modData;
@@ -48,11 +56,19 @@ namespace OpenRA
 			sheetBuilder = new SheetBuilder(SheetType.BGRA);
 		}
 
+		public void UpdateMaps()
+		{
+			foreach (var tracker in mapDirectoryTrackers)
+				tracker.UpdateMaps(this);
+		}
+
 		public void LoadMaps()
 		{
 			// Utility mod that does not support maps
 			if (!modData.Manifest.Contains<MapGrid>())
 				return;
+
+			var mapGrid = modData.Manifest.Get<MapGrid>();
 
 			// Enumerate map directories
 			foreach (var kv in modData.Manifest.MapFolders)
@@ -85,35 +101,41 @@ namespace OpenRA
 				}
 
 				mapLocations.Add(package, classification);
+				mapDirectoryTrackers.Add(new MapDirectoryTracker(mapGrid, package, classification));
 			}
 
-			var mapGrid = modData.Manifest.Get<MapGrid>();
 			foreach (var kv in MapLocations)
 			{
 				foreach (var map in kv.Key.Contents)
-				{
-					IReadOnlyPackage mapPackage = null;
-					try
-					{
-						using (new Support.PerfTimer(map))
-						{
-							mapPackage = kv.Key.OpenPackage(map, modData.ModFiles);
-							if (mapPackage == null)
-								continue;
+					LoadMap(map, kv.Key, kv.Value, mapGrid, null);
+			}
+		}
 
-							var uid = Map.ComputeUID(mapPackage);
-							previews[uid].UpdateFromMap(mapPackage, kv.Key, kv.Value, modData.Manifest.MapCompatibility, mapGrid.Type);
-						}
-					}
-					catch (Exception e)
+		public void LoadMap(string map, IReadOnlyPackage package, MapClassification classification, MapGrid mapGrid, string oldMap)
+		{
+			IReadOnlyPackage mapPackage = null;
+			try
+			{
+				using (new Support.PerfTimer(map))
+				{
+					mapPackage = package.OpenPackage(map, modData.ModFiles);
+					if (mapPackage != null)
 					{
-						mapPackage?.Dispose();
-						Console.WriteLine("Failed to load map: {0}", map);
-						Console.WriteLine("Details: {0}", e);
-						Log.Write("debug", "Failed to load map: {0}", map);
-						Log.Write("debug", "Details: {0}", e);
+						var uid = Map.ComputeUID(mapPackage);
+						previews[uid].UpdateFromMap(mapPackage, package, classification, modData.Manifest.MapCompatibility, mapGrid.Type);
+
+						if (oldMap != uid)
+							MapUpdated(oldMap, uid);
 					}
 				}
+			}
+			catch (Exception e)
+			{
+				mapPackage?.Dispose();
+				Console.WriteLine("Failed to load map: {0}", map);
+				Console.WriteLine("Details: {0}", e);
+				Log.Write("debug", "Failed to load map: {0}", map);
+				Log.Write("debug", "Details: {0}", e);
 			}
 		}
 
@@ -345,10 +367,18 @@ namespace OpenRA
 			return initialUid;
 		}
 
-		public MapPreview this[string key] => previews[key];
+		public MapPreview this[string key]
+		{
+			get
+			{
+				UpdateMaps();
+				return previews[key];
+			}
+		}
 
 		public IEnumerator<MapPreview> GetEnumerator()
 		{
+			UpdateMaps();
 			return previews.Values.GetEnumerator();
 		}
 
@@ -367,6 +397,9 @@ namespace OpenRA
 
 			foreach (var p in previews.Values)
 				p.Dispose();
+
+			foreach (var t in mapDirectoryTrackers)
+				t.Dispose();
 
 			// We need to let the loader thread exit before we can dispose our sheet builder.
 			// Ideally we should dispose our resources before returning, but we don't to block waiting on the loader thread to exit.

--- a/OpenRA.Game/Map/MapDirectoryTracker.cs
+++ b/OpenRA.Game/Map/MapDirectoryTracker.cs
@@ -1,0 +1,129 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using OpenRA.FileSystem;
+
+namespace OpenRA
+{
+	public sealed class MapDirectoryTracker : IDisposable
+	{
+		readonly FileSystemWatcher watcher;
+		readonly MapGrid mapGrid;
+		readonly IReadOnlyPackage package;
+		readonly MapClassification classification;
+
+		enum MapAction { Add, Delete, Update }
+		readonly Dictionary<string, MapAction> mapActionQueue = new Dictionary<string, MapAction>();
+
+		bool dirty = false;
+
+		public MapDirectoryTracker(MapGrid mapGrid, IReadOnlyPackage package, MapClassification classification)
+		{
+			this.mapGrid = mapGrid;
+			this.package = package;
+			this.classification = classification;
+
+			watcher = new FileSystemWatcher(package.Name);
+			watcher.Changed += (object sender, FileSystemEventArgs e) => AddMapAction(MapAction.Update, e.FullPath);
+			watcher.Created += (object sender, FileSystemEventArgs e) => AddMapAction(MapAction.Add, e.FullPath);
+			watcher.Deleted += (object sender, FileSystemEventArgs e) => AddMapAction(MapAction.Delete, e.FullPath);
+			watcher.Renamed += (object sender, RenamedEventArgs e) => AddMapAction(MapAction.Add, e.FullPath, e.OldFullPath);
+
+			watcher.IncludeSubdirectories = true;
+			watcher.EnableRaisingEvents = true;
+		}
+
+		public void Dispose()
+		{
+			watcher.Dispose();
+		}
+
+		void AddMapAction(MapAction mapAction, string fullpath, string oldFullPath = null)
+		{
+			lock (mapActionQueue)
+			{
+				dirty = true;
+
+				// if path is not root, update map instead
+				var path = RemoveSubDirs(fullpath);
+				if (fullpath == path)
+					mapActionQueue[path] = mapAction;
+				else
+					mapActionQueue[path] = MapAction.Update;
+
+				// called when file has been renamed / changed location
+				if (oldFullPath != null)
+				{
+					var oldpath = RemoveSubDirs(oldFullPath);
+					if (oldpath != null)
+						if (oldFullPath == oldpath)
+							mapActionQueue[oldpath] = MapAction.Delete;
+						else
+							mapActionQueue[oldpath] = MapAction.Update;
+				}
+			}
+		}
+
+		public void UpdateMaps(MapCache mapcache)
+		{
+			lock (mapActionQueue)
+			{
+				if (!dirty)
+					return;
+
+				dirty = false;
+				foreach (var mapAction in mapActionQueue)
+				{
+					var map = mapcache.FirstOrDefault(x => x.Package?.Name == mapAction.Key && x.Status == MapStatus.Available);
+					if (map != null)
+					{
+						if (mapAction.Value == MapAction.Delete)
+						{
+							Console.WriteLine(mapAction.Key + " was deleted");
+							map.Invalidate();
+						}
+						else
+						{
+							Console.WriteLine(mapAction.Key + " was updated");
+							map.Invalidate();
+							mapcache.LoadMap(mapAction.Key.Replace(package.Name + Path.DirectorySeparatorChar, ""), package, classification, mapGrid, map.Uid);
+						}
+					}
+					else
+					{
+						if (mapAction.Value != MapAction.Delete)
+						{
+							Console.WriteLine(mapAction.Key + " was added");
+							mapcache.LoadMap(mapAction.Key.Replace(package?.Name + Path.DirectorySeparatorChar, ""), package, classification, mapGrid, null);
+						}
+					}
+				}
+
+				mapActionQueue.Clear();
+			}
+		}
+
+		string RemoveSubDirs(string path)
+		{
+			var endPath = path.Replace(package.Name + Path.DirectorySeparatorChar, "");
+
+			// if file moved from out outside directory, ignore it
+			if (path == endPath)
+				return null;
+
+			return package.Name + Path.DirectorySeparatorChar + endPath.Split(Path.DirectorySeparatorChar)[0];
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of
@@ -178,10 +178,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				var combinedPath = Platform.ResolvePath(Path.Combine(selectedDirectory.Folder.Name, filename.Text + fileTypes[fileType].Extension));
 
-				// Invalidate the old map metadata
-				if (map.Uid != null && map.Package != null && map.Package.Name == combinedPath)
-					modData.MapCache[map.Uid].Invalidate();
-
 				try
 				{
 					if (!(map.Package is IReadWritePackage package) || package.Name != combinedPath)
@@ -194,9 +190,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					}
 
 					map.Save(package);
-
-					// Update the map cache so it can be loaded without restarting the game
-					modData.MapCache[map.Uid].UpdateFromMap(map.Package, selectedDirectory.Folder, selectedDirectory.Classification, null, map.Grid.Type);
 
 					Console.WriteLine("Saved current map at {0}", combinedPath);
 					Ui.CloseWindow();

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of
@@ -158,7 +158,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			// Loading into the map editor
 			Game.BeforeGameStart += RemoveShellmapUI;
 
-			var onSelect = new Action<string>(uid => LoadMapIntoEditor(modData.MapCache[uid].Uid));
+			var onSelect = new Action<string>(uid =>
+			{
+				if (modData.MapCache[uid].Status != MapStatus.Available)
+					SwitchMenu(MenuType.Extras);
+				else
+					LoadMapIntoEditor(modData.MapCache[uid].Uid);
+			});
 
 			var newMapButton = widget.Get<ButtonWidget>("NEW_MAP_BUTTON");
 			newMapButton.OnClick = () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var deleteMapButton = widget.Get<ButtonWidget>("DELETE_MAP_BUTTON");
-			deleteMapButton.IsDisabled = () => modData.MapCache[selectedUid].Class != MapClassification.User;
+			deleteMapButton.IsDisabled = () => currentTab != MapClassification.User;
 			deleteMapButton.IsVisible = () => currentTab == MapClassification.User;
 			deleteMapButton.OnClick = () =>
 			{


### PR DESCRIPTION
Closes #19420

This is my first code contribution to ORA, so there's probably a lot of room for improvement

The way map refresh works:
`MapCache` has 2 instances of `MapDirectoryTracker` tracking both the custom and official maps folders for changes respectively. When they detect something, they analyse what and if they need to take action, then they put or edit appropriate actions in `mapActionQueue`. Whenever `MapCache` is queried for maps, it is updated from the records in `mapActionQueue`

I needed to queue actions because `FileSystemWatcher` is spamming quite a lot and those actions are often in an illogical order. F.e. when I add a file it calls `Changed`,  then `Created`. Another example is when I add / edit an uncompressed map, then it spams a ton of actions. Furthermore maps are never deleted from `MapCache`. So if we were to update `MapCache` at every `FileSystemWatcher` event it would likely clog up memory with very similar maps. The queue is designed to address all of this by updating `MapCache` only when it is required

Map editor no longer updates the cache, since it already happens when when MapDirectoryTracker kicks in

The game now selects the last edited map when entering map chooser. If in lobby the selected map is updated it, it will switch to the updated version. I'm not sure if this change is necessary, but it would be fairly convenient.