### PR TITLE
Adding Rotation Logic to Renderer for use with Interpolated Facings

### DIFF
--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -50,37 +50,41 @@ namespace OpenRA.Graphics
 		}
 
 		public int CurrentFrame => backwards ? CurrentSequence.Length - frame - 1 : frame;
+
 		public Sprite Image => CurrentSequence.GetSprite(CurrentFrame, facingFunc());
 
 		public IRenderable[] Render(WPos pos, in WVec offset, int zOffset, PaletteReference palette)
 		{
 			var tintModifiers = CurrentSequence.IgnoreWorldTint ? TintModifiers.IgnoreWorldTint : TintModifiers.None;
 			var alpha = CurrentSequence.GetAlpha(CurrentFrame);
-			var imageRenderable = new SpriteRenderable(Image, pos, offset, CurrentSequence.ZOffset + zOffset, palette, CurrentSequence.Scale, alpha, float3.Ones, tintModifiers, IsDecoration);
+			var (image, rotation) = CurrentSequence.GetSpriteWithRotation(CurrentFrame, facingFunc());
+			var imageRenderable = new SpriteRenderable(image, pos, offset, CurrentSequence.ZOffset + zOffset, palette, CurrentSequence.Scale, alpha, float3.Ones, tintModifiers, IsDecoration,
+				rotation);
 
 			if (CurrentSequence.ShadowStart >= 0)
 			{
 				var shadow = CurrentSequence.GetShadow(CurrentFrame, facingFunc());
-				var shadowRenderable = new SpriteRenderable(shadow, pos, offset, CurrentSequence.ShadowZOffset + zOffset, palette, CurrentSequence.Scale, 1f, float3.Ones, tintModifiers, true);
+				var shadowRenderable = new SpriteRenderable(shadow, pos, offset, CurrentSequence.ShadowZOffset + zOffset, palette, CurrentSequence.Scale, 1f, float3.Ones, tintModifiers,
+					true, rotation);
 				return new IRenderable[] { shadowRenderable, imageRenderable };
 			}
 
 			return new IRenderable[] { imageRenderable };
 		}
 
-		public IRenderable[] RenderUI(WorldRenderer wr, int2 pos, in WVec offset, int zOffset, PaletteReference palette, float scale = 1f)
+		public IRenderable[] RenderUI(WorldRenderer wr, int2 pos, in WVec offset, int zOffset, PaletteReference palette, float scale = 1f, float rotation = 0f)
 		{
 			scale *= CurrentSequence.Scale;
 			var screenOffset = (scale * wr.ScreenVectorComponents(offset)).XY.ToInt2();
 			var imagePos = pos + screenOffset - new int2((int)(scale * Image.Size.X / 2), (int)(scale * Image.Size.Y / 2));
 			var alpha = CurrentSequence.GetAlpha(CurrentFrame);
-			var imageRenderable = new UISpriteRenderable(Image, WPos.Zero + offset, imagePos, CurrentSequence.ZOffset + zOffset, palette, scale, alpha);
+			var imageRenderable = new UISpriteRenderable(Image, WPos.Zero + offset, imagePos, CurrentSequence.ZOffset + zOffset, palette, scale, alpha, rotation);
 
 			if (CurrentSequence.ShadowStart >= 0)
 			{
 				var shadow = CurrentSequence.GetShadow(CurrentFrame, facingFunc());
 				var shadowPos = pos - new int2((int)(scale * shadow.Size.X / 2), (int)(scale * shadow.Size.Y / 2));
-				var shadowRenderable = new UISpriteRenderable(shadow, WPos.Zero + offset, shadowPos, CurrentSequence.ShadowZOffset + zOffset, palette, scale);
+				var shadowRenderable = new UISpriteRenderable(shadow, WPos.Zero + offset, shadowPos, CurrentSequence.ShadowZOffset + zOffset, palette, scale, 1f, rotation);
 				return new IRenderable[] { shadowRenderable, imageRenderable };
 			}
 

--- a/OpenRA.Game/Graphics/RgbaSpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/RgbaSpriteRenderer.cs
@@ -22,28 +22,28 @@ namespace OpenRA.Graphics
 			this.parent = parent;
 		}
 
-		public void DrawSprite(Sprite s, in float3 location, in float3 scale)
+		public void DrawSprite(Sprite s, in float3 location, in float3 scale, float rotation = 0f)
 		{
 			if (s.Channel != TextureChannel.RGBA)
 				throw new InvalidOperationException("DrawRGBASprite requires a RGBA sprite.");
 
-			parent.DrawSprite(s, 0, location, scale);
+			parent.DrawSprite(s, 0, location, scale, rotation);
 		}
 
-		public void DrawSprite(Sprite s, in float3 location, float scale = 1f)
+		public void DrawSprite(Sprite s, in float3 location, float scale = 1f, float rotation = 0f)
 		{
 			if (s.Channel != TextureChannel.RGBA)
 				throw new InvalidOperationException("DrawRGBASprite requires a RGBA sprite.");
 
-			parent.DrawSprite(s, 0, location, scale);
+			parent.DrawSprite(s, 0, location, scale, rotation);
 		}
 
-		public void DrawSprite(Sprite s, in float3 location, float scale, in float3 tint, float alpha)
+		public void DrawSprite(Sprite s, in float3 location, float scale, in float3 tint, float alpha, float rotation = 0f)
 		{
 			if (s.Channel != TextureChannel.RGBA)
 				throw new InvalidOperationException("DrawRGBASprite requires a RGBA sprite.");
 
-			parent.DrawSprite(s, 0, location, scale, tint, alpha);
+			parent.DrawSprite(s, 0, location, scale, tint, alpha, rotation);
 		}
 
 		public void DrawSprite(Sprite s, in float3 a, in float3 b, in float3 c, in float3 d, in float3 tint, float alpha)

--- a/OpenRA.Game/Graphics/SequenceProvider.cs
+++ b/OpenRA.Game/Graphics/SequenceProvider.cs
@@ -26,6 +26,7 @@ namespace OpenRA.Graphics
 		int Length { get; }
 		int Stride { get; }
 		int Facings { get; }
+		int InterpolatedFacings { get; }
 		int Tick { get; }
 		int ZOffset { get; }
 		int ShadowStart { get; }
@@ -37,6 +38,7 @@ namespace OpenRA.Graphics
 
 		Sprite GetSprite(int frame);
 		Sprite GetSprite(int frame, WAngle facing);
+		(Sprite, WAngle) GetSpriteWithRotation(int frame, WAngle facing);
 		Sprite GetShadow(int frame, WAngle facing);
 		float GetAlpha(int frame);
 	}

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -126,35 +126,40 @@ namespace OpenRA.Graphics
 			return pal.TextureIndex;
 		}
 
-		internal void DrawSprite(Sprite s, float paletteTextureIndex, in float3 location, in float3 scale)
+		internal void DrawSprite(Sprite s, float paletteTextureIndex, in float3 location, in float3 scale, float rotation = 0f)
 		{
 			var samplers = SetRenderStateForSprite(s);
-			Util.FastCreateQuad(vertices, location + scale * s.Offset, s, samplers, paletteTextureIndex, nv, scale * s.Size, float3.Ones, 1f);
+			Util.FastCreateQuad(vertices, location + scale * s.Offset, s, samplers, paletteTextureIndex, nv, scale * s.Size, float3.Ones,
+								1f, rotation);
 			nv += 6;
 		}
 
-		internal void DrawSprite(Sprite s, float paletteTextureIndex, in float3 location, float scale)
+		internal void DrawSprite(Sprite s, float paletteTextureIndex, in float3 location, float scale, float rotation = 0f)
 		{
 			var samplers = SetRenderStateForSprite(s);
-			Util.FastCreateQuad(vertices, location + scale * s.Offset, s, samplers, paletteTextureIndex, nv, scale * s.Size, float3.Ones, 1f);
+			Util.FastCreateQuad(vertices, location + scale * s.Offset, s, samplers, paletteTextureIndex, nv, scale * s.Size, float3.Ones,
+								1f, rotation);
 			nv += 6;
 		}
 
-		public void DrawSprite(Sprite s, PaletteReference pal, in float3 location, float scale = 1f)
+		public void DrawSprite(Sprite s, PaletteReference pal, in float3 location, float scale = 1f, float rotation = 0f)
 		{
-			DrawSprite(s, ResolveTextureIndex(s, pal), location, scale);
+			DrawSprite(s, ResolveTextureIndex(s, pal), location, scale, rotation);
 		}
 
-		internal void DrawSprite(Sprite s, float paletteTextureIndex, in float3 location, float scale, in float3 tint, float alpha)
+		internal void DrawSprite(Sprite s, float paletteTextureIndex, in float3 location, float scale, in float3 tint, float alpha,
+			float rotation = 0f)
 		{
 			var samplers = SetRenderStateForSprite(s);
-			Util.FastCreateQuad(vertices, location + scale * s.Offset, s, samplers, paletteTextureIndex, nv, scale * s.Size, tint, alpha);
+			Util.FastCreateQuad(vertices, location + scale * s.Offset, s, samplers, paletteTextureIndex, nv, scale * s.Size, tint, alpha,
+								rotation);
 			nv += 6;
 		}
 
-		public void DrawSprite(Sprite s, PaletteReference pal, in float3 location, float scale, in float3 tint, float alpha)
+		public void DrawSprite(Sprite s, PaletteReference pal, in float3 location, float scale, in float3 tint, float alpha,
+			float rotation = 0f)
 		{
-			DrawSprite(s, ResolveTextureIndex(s, pal), location, scale, tint, alpha);
+			DrawSprite(s, ResolveTextureIndex(s, pal), location, scale, tint, alpha, rotation);
 		}
 
 		internal void DrawSprite(Sprite s, float paletteTextureIndex, in float3 a, in float3 b, in float3 c, in float3 d, in float3 tint, float alpha)

--- a/OpenRA.Mods.Common/Traits/QuantizeFacingsFromSequence.cs
+++ b/OpenRA.Mods.Common/Traits/QuantizeFacingsFromSequence.cs
@@ -29,7 +29,8 @@ namespace OpenRA.Mods.Common.Traits
 				throw new InvalidOperationException("Actor " + ai.Name + " is missing sequence to quantize facings from.");
 
 			var rsi = ai.TraitInfo<RenderSpritesInfo>();
-			return sequenceProvider.GetSequence(rsi.GetImage(ai, race), Sequence).Facings;
+			var seq = sequenceProvider.GetSequence(rsi.GetImage(ai, race), Sequence);
+			return seq.InterpolatedFacings == -1 ? seq.Facings : seq.InterpolatedFacings;
 		}
 
 		public override object Create(ActorInitializer init) { return new QuantizeFacingsFromSequence(this); }

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -67,9 +67,26 @@ namespace OpenRA.Mods.Common
 		/// </summary>
 		public static int IndexFacing(WAngle facing, int numFrames)
 		{
+			// 1024 here is the max angle, so we divide the max angle by the total number of facings (numFrames)
 			var step = 1024 / numFrames;
 			var a = (facing.Angle + step / 2) & 1023;
 			return a / step;
+		}
+
+		/// <summary>
+		/// Returns the remainder angle after rounding to the nearest whole step / facing
+		/// </summary>
+		public static WAngle AngleDiffToStep(WAngle facing, int numFrames)
+		{
+			var step = 1024 / numFrames;
+			var a = (facing.Angle + step / 2) & 1023;
+			return new WAngle(a % step - step / 2);
+		}
+
+		public static WAngle GetInterpolatedFacing(WAngle facing, int facings, int interpolatedFacings)
+		{
+			var step = 1024 / interpolatedFacings;
+			return new WAngle(AngleDiffToStep(facing, facings).Angle / step * step);
 		}
 
 		/// <summary>Rounds the given facing value to the nearest quantized step.</summary>

--- a/mods/ra/sequences/aircraft.yaml
+++ b/mods/ra/sequences/aircraft.yaml
@@ -1,11 +1,13 @@
 mig:
 	idle:
 		Facings: 16
+		InterpolatedFacings: 64
 	icon: migicon
 
 yak:
 	idle:
 		Facings: 16
+		InterpolatedFacings: 64
 	muzzle: minigun
 		Length: 6
 		Facings: 8
@@ -66,10 +68,12 @@ tran2husk:
 u2:
 	idle:
 		Facings: 16
+		InterpolatedFacings: 64
 
 badr:
 	idle:
 		Facings: 16
+		InterpolatedFacings: 64
 
 mh60:
 	idle:


### PR DESCRIPTION
This PR adds the ability for sprites to be rotated by the renderer, in order for additional interpolated facings to be created in between existing facings.

E.g.: 16 facings can be interpolated to 32 by adding an additional 16 interpolated facings. These interpolated facings are derived from the existing faces, by applying a fixed rotation that is proportionate to the gap between each facing.

***Add Interpolated Facings***
YAML flag: InterpolatedFacings
YAML options: Any number between 2 and 1024, that is greater than the number of Facings, and a power of 2.

Since sprites typically only have a set number of facings (e.g. 16 or 32), units that can rotate or move in more directions than they have facings will not have smooth movement between these facings. However, if we are able to rotate the sprite graphic between facings, we can create 'intermediate' facings between facings, as shown below. The code here takes the delta between the actual facing and the next intended interpolated facing (depending on how many are required), and applies this as a rotation to the sprite. The most common number of intended interpolated facings is 1024, as this is the maximum number of facings, however any number that is greater than the existing number of facings, that is also a power of 2 can be used as the InterpolatedFacings amount.

This rotation logic was used in the original red alert to smoothen the rotation of all aircraft with 16 facings. So to mimic the original game, I have added this flag to all aircraft that currently have 16 facings. As you can see in the below video, the movement is much smoother once this flag is enabled (right side of the video). By request I have also added this to the carry-all in D2K, in an attempt to smoothen jitters this unit appears to have in the current build.

https://www.dropbox.com/s/u7cucyvd3hjvti0/mig_orig_interp_compare.mp4?dl=0

A second use for this same feature is to use just 1 facing, and rely entirely on the InterpolatedFacings flag to create all remaining faces (e.g. 16, 32, or any number up to 1024). This enables sprites to rely entirely on the renderer's new rotation for their facings. While this is not as suitable for units that have perspective (since the shadows and lighting are not rotated, it will look a bit off), it is highly useful for flat or top-down viewed objects such as projectiles, or top-down units such as in the indie RTS Rusted Warfare (in fact this feature was my original motivation for this PR). This solves the following issue: https://github.com/OpenRA/OpenRA/issues/19146. This also greatly reduces the time required to develop such sprites, since only 1 facing (north) needs to be produced instead of 16 or 32. The below video shows what this feature may look like applied to the existing medium tank. While the tank here is not fully suited to the feature, it shows that the tank can appear and function almost like the original, despite only 1 facing being used (since all other facings are rotations).

https://www.dropbox.com/s/qsfa0fv7oe3dtp0/2tnk_userotationsforfacings.mkv?dl=0

**Caveat**
All of my tests have been in Red Alert and D2K. While the feature is not needed for other mods, I am unsure how it would interact with them, e.g. if there would be any unintended side effects. I don't think this is likely, but it is still possible.

