### PR TITLE
Code style rules readonly

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -63,7 +63,7 @@ dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = warning
 dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
 dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
-# IDE1006, IDE-only counterpart of StyleCopAnalyzers - SA1311: StaticReadonlyFieldsMustBeginWithUpperCaseLetter.
+# IDE1006, IDE-only counterpart of StyleCopAnalyzers - SA1311: StaticReadonlyFieldsMustBeginWithUpperCaseLetter (silenced in OpenRA.ruleset).
 dotnet_naming_rule.static_private_or_internal_field_should_be_pascal_case.severity = none
 dotnet_naming_rule.static_private_or_internal_field_should_be_pascal_case.symbols = static_private_or_internal_field
 dotnet_naming_rule.static_private_or_internal_field_should_be_pascal_case.style = pascal_case
@@ -123,6 +123,9 @@ dotnet_diagnostic.IDE0036.severity = warning
 
 # Raise a warning on build when default access modifiers are explicitly specified.
 dotnet_diagnostic.IDE0040.severity = warning
+
+# Make field readonly.
+dotnet_diagnostic.IDE0044.severity = warning
 
 # Avoid unnecessary zero-length array allocations.
 dotnet_diagnostic.CA1825.severity = warning

--- a/OpenRA.Game/Activities/CallFunc.cs
+++ b/OpenRA.Game/Activities/CallFunc.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Activities
 			IsInterruptible = interruptible;
 		}
 
-		Action a;
+		readonly Action a;
 
 		public override bool Tick(Actor self)
 		{

--- a/OpenRA.Game/Effects/AsyncAction.cs
+++ b/OpenRA.Game/Effects/AsyncAction.cs
@@ -17,8 +17,8 @@ namespace OpenRA.Effects
 {
 	public class AsyncAction : IEffect
 	{
-		Action a;
-		IAsyncResult ar;
+		readonly Action a;
+		readonly IAsyncResult ar;
 
 		public AsyncAction(IAsyncResult ar, Action a)
 		{

--- a/OpenRA.Game/Effects/DelayedAction.cs
+++ b/OpenRA.Game/Effects/DelayedAction.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Effects
 {
 	public class DelayedAction : IEffect
 	{
-		Action a;
+		readonly Action a;
 		int delay;
 
 		public DelayedAction(int delay, Action a)

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -119,7 +119,7 @@ namespace OpenRA
 		}
 
 		// More accurate replacement for Environment.TickCount
-		static Stopwatch stopwatch = Stopwatch.StartNew();
+		static readonly Stopwatch stopwatch = Stopwatch.StartNew();
 		public static long RunTime => stopwatch.ElapsedMilliseconds;
 
 		public static int RenderFrame = 0;

--- a/OpenRA.Game/Graphics/CursorManager.cs
+++ b/OpenRA.Game/Graphics/CursorManager.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Graphics
 		Cursor cursor;
 		bool isLocked = false;
 		int2 lockedPosition;
-		bool hardwareCursorsDisabled = false;
+		readonly bool hardwareCursorsDisabled = false;
 		bool hardwareCursorsDoubled = false;
 
 		public CursorManager(CursorProvider cursorProvider)

--- a/OpenRA.Game/Graphics/Palette.cs
+++ b/OpenRA.Game/Graphics/Palette.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Graphics
 
 		class ReadOnlyPalette : IPalette
 		{
-			IPalette palette;
+			readonly IPalette palette;
 			public ReadOnlyPalette(IPalette palette) { this.palette = palette; }
 			public uint this[int index] => palette[index];
 

--- a/OpenRA.Game/Map/ActorReference.cs
+++ b/OpenRA.Game/Map/ActorReference.cs
@@ -25,7 +25,7 @@ namespace OpenRA
 	public class ActorReference : IEnumerable
 	{
 		public string Type;
-		Lazy<TypeDictionary> initDict;
+		readonly Lazy<TypeDictionary> initDict;
 
 		internal TypeDictionary InitDict => initDict.Value;
 

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -34,8 +34,8 @@ namespace OpenRA
 		readonly SheetBuilder sheetBuilder;
 		Thread previewLoaderThread;
 		bool previewLoaderThreadShutDown = true;
-		object syncRoot = new object();
-		Queue<MapPreview> generateMinimap = new Queue<MapPreview>();
+		readonly object syncRoot = new object();
+		readonly Queue<MapPreview> generateMinimap = new Queue<MapPreview>();
 
 		public Dictionary<string, string> StringPool { get; } = new Dictionary<string, string>();
 

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -128,7 +128,7 @@ namespace OpenRA
 		}
 
 		// HACK: Only update the loading screen if we're in the main thread.
-		int initialThreadId;
+		readonly int initialThreadId;
 		internal void HandleLoadingProgress()
 		{
 			if (LoadScreen != null && IsOnMainThread)

--- a/OpenRA.Game/Network/ReplayRecorder.cs
+++ b/OpenRA.Game/Network/ReplayRecorder.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Network
 
 		public ReplayMetadata Metadata;
 		BinaryWriter writer;
-		Func<string> chooseFilename;
+		readonly Func<string> chooseFilename;
 		MemoryStream preStartBuffer = new MemoryStream();
 
 		static bool IsGameStart(byte[] data)

--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Network
 	class SyncReport
 	{
 		const int NumSyncReports = 5;
-		static Cache<Type, TypeInfo> typeInfoCache = new Cache<Type, TypeInfo>(t => new TypeInfo(t));
+		static readonly Cache<Type, TypeInfo> typeInfoCache = new Cache<Type, TypeInfo>(t => new TypeInfo(t));
 
 		readonly OrderManager orderManager;
 
@@ -154,9 +154,9 @@ namespace OpenRA.Network
 			public int Frame;
 			public int SyncedRandom;
 			public int TotalCount;
-			public List<TraitReport> Traits = new List<TraitReport>();
-			public List<EffectReport> Effects = new List<EffectReport>();
-			public List<OrderManager.ClientOrder> Orders = new List<OrderManager.ClientOrder>();
+			public readonly List<TraitReport> Traits = new List<TraitReport>();
+			public readonly List<EffectReport> Effects = new List<EffectReport>();
+			public readonly List<OrderManager.ClientOrder> Orders = new List<OrderManager.ClientOrder>();
 		}
 
 		struct TraitReport

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -25,7 +25,7 @@ namespace OpenRA
 		public static PlatformType CurrentPlatform => currentPlatform.Value;
 		public static readonly Guid SessionGUID = Guid.NewGuid();
 
-		static Lazy<PlatformType> currentPlatform = Exts.Lazy(GetCurrentPlatform);
+		static readonly Lazy<PlatformType> currentPlatform = Exts.Lazy(GetCurrentPlatform);
 
 		static bool engineDirAccessed;
 		static string engineDir;

--- a/OpenRA.Game/Primitives/DisposableAction.cs
+++ b/OpenRA.Game/Primitives/DisposableAction.cs
@@ -21,8 +21,8 @@ namespace OpenRA.Primitives
 			this.onFinalize = onFinalize;
 		}
 
-		Action onDispose;
-		Action onFinalize;
+		readonly Action onDispose;
+		readonly Action onFinalize;
 		bool disposed;
 
 		public void Dispose()

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Server
 		ReplayRecorder recorder;
 		GameInformation gameInfo;
 		readonly List<GameInformation.Player> worldPlayers = new List<GameInformation.Player>();
-		Stopwatch pingUpdated = Stopwatch.StartNew();
+		readonly Stopwatch pingUpdated = Stopwatch.StartNew();
 
 		public ServerState State
 		{

--- a/OpenRA.Game/Support/Arguments.cs
+++ b/OpenRA.Game/Support/Arguments.cs
@@ -16,7 +16,7 @@ namespace OpenRA
 {
 	public class Arguments
 	{
-		Dictionary<string, string> args = new Dictionary<string, string>();
+		readonly Dictionary<string, string> args = new Dictionary<string, string>();
 
 		public static Arguments Empty => new Arguments();
 

--- a/OpenRA.Game/Support/PerfItem.cs
+++ b/OpenRA.Game/Support/PerfItem.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Support
 	{
 		public readonly Color C;
 		public readonly string Name;
-		double[] samples = new double[100];
+		readonly double[] samples = new double[100];
 		public double Val = 0.0;
 		int head = 1, tail = 0;
 		public bool HasNormalTick = true;

--- a/OpenRA.Game/Support/PerfTimer.cs
+++ b/OpenRA.Game/Support/PerfTimer.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Support
 		List<PerfTimer> children;
 		long ticks;
 
-		static ThreadLocal<PerfTimer> parentThreadLocal = new ThreadLocal<PerfTimer>();
+		static readonly ThreadLocal<PerfTimer> parentThreadLocal = new ThreadLocal<PerfTimer>();
 
 		public PerfTimer(string name, float thresholdMs = 0)
 		{

--- a/OpenRA.Game/Traits/World/ScreenShaker.cs
+++ b/OpenRA.Game/Traits/World/ScreenShaker.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Traits
 	{
 		readonly ScreenShakerInfo info;
 		WorldRenderer worldRenderer;
-		List<ShakeEffect> shakeEffects = new List<ShakeEffect>();
+		readonly List<ShakeEffect> shakeEffects = new List<ShakeEffect>();
 		int ticks = 0;
 
 		public ScreenShaker(ScreenShakerInfo info)

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -370,7 +370,7 @@ namespace OpenRA
 
 		public int WorldTick { get; private set; }
 
-		Dictionary<int, MiniYaml> gameSaveTraitData = new Dictionary<int, MiniYaml>();
+		readonly Dictionary<int, MiniYaml> gameSaveTraitData = new Dictionary<int, MiniYaml>();
 		internal void AddGameSaveTraitData(int traitIndex, MiniYaml yaml)
 		{
 			gameSaveTraitData[traitIndex] = yaml;

--- a/OpenRA.Mods.Cnc/Activities/Teleport.cs
+++ b/OpenRA.Mods.Cnc/Activities/Teleport.cs
@@ -27,9 +27,9 @@ namespace OpenRA.Mods.Cnc.Activities
 		readonly bool killOnFailure;
 		readonly BitSet<DamageType> killDamageTypes;
 		CPos destination;
-		bool killCargo;
-		bool screenFlash;
-		string sound;
+		readonly bool killCargo;
+		readonly bool screenFlash;
+		readonly string sound;
 
 		public Teleport(Actor teleporter, CPos destination, int? maximumDistance,
 			bool killCargo, bool screenFlash, string sound, bool interruptable = true,

--- a/OpenRA.Mods.Cnc/FileFormats/Blowfish.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/Blowfish.cs
@@ -130,7 +130,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 			return i;
 		}
 
-		uint[] lookupMfromP =
+		readonly uint[] lookupMfromP =
 		{
 			0x243f6a88, 0x85a308d3, 0x13198a2e, 0x03707344,
 			0xa4093822, 0x299f31d0, 0x082efa98, 0xec4e6c89,
@@ -139,7 +139,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 			0x9216d5d9, 0x8979fb1b
 		};
 
-		uint[,] lookupMfromS =
+		readonly uint[,] lookupMfromS =
 		{
 			{
 				0xd1310ba6, 0x98dfb5ac, 0x2ffd72db, 0xd01adfb7,

--- a/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
@@ -22,18 +22,18 @@ namespace OpenRA.Mods.Cnc.FileFormats
 
 		class PublicKey
 		{
-			public uint[] KeyOne = new uint[64];
-			public uint[] KeyTwo = new uint[64];
+			public readonly uint[] KeyOne = new uint[64];
+			public readonly uint[] KeyTwo = new uint[64];
 			public uint Len;
 		}
 
-		PublicKey pubkey = new PublicKey();
+		readonly PublicKey pubkey = new PublicKey();
 
-		uint[] globOne = new uint[64];
+		readonly uint[] globOne = new uint[64];
 		uint globOneBitLen, globOneLenXTwo;
-		uint[] globTwo = new uint[130];
-		uint[] globOneHigh = new uint[4];
-		uint[] globOneHighInv = new uint[4];
+		readonly uint[] globTwo = new uint[130];
+		readonly uint[] globOneHigh = new uint[4];
+		readonly uint[] globOneHighInv = new uint[4];
 		uint globOneHighBitLen;
 		uint globOneHighInvLow, globOneHighInvHigh;
 

--- a/OpenRA.Mods.Cnc/FileFormats/VqaVideo.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/VqaVideo.cs
@@ -45,21 +45,21 @@ namespace OpenRA.Mods.Cnc.FileFormats
 
 		// Stores a list of subpixels, referenced by the VPTZ chunk
 		byte[] cbf;
-		byte[] cbp;
-		byte[] cbfBuffer;
+		readonly byte[] cbp;
+		readonly byte[] cbfBuffer;
 		bool cbpIsCompressed;
 
 		// Buffer for loading file subchunks, the maximum chunk size of a file is not defined
 		// and the header definition for the size of the biggest chunks (color data) isn't accurate.
 		// But 256k is large enough for all TS videos(< 200k).
-		byte[] fileBuffer = new byte[256000];
-		int maxCbfzSize = 256000;
+		readonly byte[] fileBuffer = new byte[256000];
+		readonly int maxCbfzSize = 256000;
 		int vtprSize = 0;
 		int currentChunkBuffer = 0;
 		int chunkBufferOffset = 0;
 
 		// Top half contains block info, bottom half contains references to cbf array
-		byte[] origData;
+		readonly byte[] origData;
 
 		public VqaVideo(Stream stream, bool useFramePadding)
 		{

--- a/OpenRA.Mods.Cnc/FileFormats/VxlReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/VxlReader.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 		public readonly uint LimbCount;
 		public VxlLimb[] Limbs;
 
-		uint bodySize;
+		readonly uint bodySize;
 
 		static void ReadVoxelData(Stream s, VxlLimb l)
 		{

--- a/OpenRA.Mods.Cnc/FileSystem/PackageEntry.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/PackageEntry.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Cnc.FileSystem
 			}
 		}
 
-		static Dictionary<uint, string> names = new Dictionary<uint, string>();
+		static readonly Dictionary<uint, string> names = new Dictionary<uint, string>();
 
 		public static void AddStandardName(string s)
 		{

--- a/OpenRA.Mods.Cnc/Graphics/TeslaZapRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/TeslaZapRenderable.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 {
 	class TeslaZapRenderable : IPalettedRenderable, IFinalizedRenderable
 	{
-		static int[][] steps = new[]
+		static readonly int[][] steps = new[]
 		{
 			new int[] { 8, 8, 4, 4, 0 },
 			new int[] { -8, -8, -4, -4, 0 },
@@ -40,8 +40,8 @@ namespace OpenRA.Mods.Cnc.Graphics
 		readonly string brightSequence;
 		readonly int brightZaps, dimZaps;
 
-		WPos cachedPos;
-		WVec cachedLength;
+		readonly WPos cachedPos;
+		readonly WVec cachedLength;
 		IEnumerable<IFinalizedRenderable> cache;
 
 		public TeslaZapRenderable(WPos pos, int zOffset, in WVec length, string image, string brightSequence, int brightZaps, string dimSequence, int dimZaps, string palette)

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpTDLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpTDLoader.cs
@@ -87,11 +87,11 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			public uint FileOffset;
 			public Format Format;
 
-			public uint RefOffset;
-			public Format RefFormat;
+			public readonly uint RefOffset;
+			public readonly Format RefFormat;
 			public ImageHeader RefImage;
 
-			ShpTDSprite reader;
+			readonly ShpTDSprite reader;
 
 			// Used by ShpWriter
 			public ImageHeader() { }

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackPopupTurreted.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		int idleTicks = 0;
 		PopupState state = PopupState.Open;
-		bool skippedMakeAnimation;
+		readonly bool skippedMakeAnimation;
 
 		public AttackPopupTurreted(ActorInitializer init, AttackPopupTurretedInfo info)
 			: base(init.Self, info)

--- a/OpenRA.Mods.Cnc/Traits/ConyardChronoReturn.cs
+++ b/OpenRA.Mods.Cnc/Traits/ConyardChronoReturn.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		int conditionToken = Actor.InvalidConditionToken;
 
 		Actor chronosphere;
-		int duration;
+		readonly int duration;
 		bool returnOriginal;
 		bool selling;
 
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		int returnTicks = 0;
 
 		[Sync]
-		CPos origin;
+		readonly CPos origin;
 
 		[Sync]
 		bool triggered;

--- a/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		readonly IFacing facing;
 		WAngle cachedFacing;
 
-		Dictionary<Actor, IActorPreview[]> previews = new Dictionary<Actor, IActorPreview[]>();
+		readonly Dictionary<Actor, IActorPreview[]> previews = new Dictionary<Actor, IActorPreview[]>();
 
 		public WithCargo(Actor self, WithCargoInfo info)
 		{

--- a/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
@@ -51,7 +51,8 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		readonly ModelAnimation modelAnimation;
 		readonly RenderVoxels rv;
 
-		uint tick, frame, frames;
+		uint tick, frame;
+		readonly uint frames;
 
 		public WithVoxelWalkerBody(Actor self, WithVoxelWalkerBodyInfo info)
 		{

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertLegacyMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertLegacyMapCommand.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 		}
 
 		// Mapping from RA95 overlay index to type string
-		static string[] redAlertOverlayNames =
+		static readonly string[] redAlertOverlayNames =
 		{
 			"sbag", "cycl", "brik", "fenc", "wood",
 			"gold01", "gold02", "gold03", "gold04",
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			"fpls", "wcrate", "scrate", "barb", "sbag",
 		};
 
-		static Dictionary<string, (byte Type, byte Index)> overlayResourceMapping = new Dictionary<string, (byte, byte)>()
+		static readonly Dictionary<string, (byte Type, byte Index)> overlayResourceMapping = new Dictionary<string, (byte, byte)>()
 		{
 			// RA ore & crystals
 			{ "gold01", (1, 0) },
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 					Map.Tiles[new CPos(i, j)] = new TerrainTile(types[i, j], ms.ReadUInt8());
 		}
 
-		static string[] overlayActors = new string[]
+		static readonly string[] overlayActors = new string[]
 		{
 			// Fences
 			"sbag", "cycl", "brik", "fenc", "wood",

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianDawnLegacyMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianDawnLegacyMapCommand.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			}
 		}
 
-		static Dictionary<string, (byte Type, byte Index)> overlayResourceMapping = new Dictionary<string, (byte, byte)>()
+		static readonly Dictionary<string, (byte Type, byte Index)> overlayResourceMapping = new Dictionary<string, (byte, byte)>()
 		{
 			// Tiberium
 			{ "ti1", (1, 0) },
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			}
 		}
 
-		static string[] overlayActors = new string[]
+		static readonly string[] overlayActors = new string[]
 		{
 			// Fences
 			"sbag", "cycl", "brik", "fenc", "wood",

--- a/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly Aircraft aircraft;
 		readonly FallsToEarthInfo info;
 
-		int acceleration;
+		readonly int acceleration;
 		int spin;
 
 		public FallToEarth(Actor self, FallsToEarthInfo info)

--- a/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly INotifyIdle[] tickIdles;
 		readonly bool idleTurn;
 		int remainingTicks;
-		bool isIdleTurner;
+		readonly bool isIdleTurner;
 
 		public FlyIdle(Actor self, int ticks = -1, bool idleTurn = true)
 		{

--- a/OpenRA.Mods.Common/Activities/Move/Drag.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Drag.cs
@@ -21,10 +21,11 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly IPositionable positionable;
 		readonly IDisabledTrait disableable;
-		WPos start, end;
-		int length;
+		readonly WPos start;
+		readonly WPos end;
+		readonly int length;
 		int ticks = 0;
-		WAngle? desiredFacing;
+		readonly WAngle? desiredFacing;
 
 		public Drag(Actor self, WPos start, WPos end, int length, WAngle? facing = null)
 		{

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Activities
 		int waitTicksRemaining;
 
 		// To work around queued activity issues while minimizing changes to legacy behaviour
-		bool evaluateNearestMovableCell;
+		readonly bool evaluateNearestMovableCell;
 
 		// Scriptable move order
 		// Ignores lane bias and nearby units

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -111,7 +111,7 @@ namespace OpenRA.Mods.Common.Activities
 			return TickChild(self);
 		}
 
-		List<CPos> searchCells = new List<CPos>();
+		readonly List<CPos> searchCells = new List<CPos>();
 		int searchCellsTick = -1;
 
 		List<CPos> CalculatePathToTarget(Actor self, BlockedByActor check)

--- a/OpenRA.Mods.Common/Activities/Sell.cs
+++ b/OpenRA.Mods.Common/Activities/Sell.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly IHealth health;
 		readonly SellableInfo sellableInfo;
 		readonly PlayerResources playerResources;
-		bool showTicks;
+		readonly bool showTicks;
 
 		public Sell(Actor self, bool showTicks)
 		{

--- a/OpenRA.Mods.Common/Activities/SimpleTeleport.cs
+++ b/OpenRA.Mods.Common/Activities/SimpleTeleport.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class SimpleTeleport : Activity
 	{
-		CPos destination;
+		readonly CPos destination;
 
 		public SimpleTeleport(CPos destination) { this.destination = destination; }
 

--- a/OpenRA.Mods.Common/Activities/Wait.cs
+++ b/OpenRA.Mods.Common/Activities/Wait.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Activities
 
 	public class WaitFor : Activity
 	{
-		Func<bool> f;
+		readonly Func<bool> f;
 
 		public WaitFor(Func<bool> f) { this.f = f; }
 		public WaitFor(Func<bool> f, bool interruptible)

--- a/OpenRA.Mods.Common/Effects/ContrailFader.cs
+++ b/OpenRA.Mods.Common/Effects/ContrailFader.cs
@@ -18,8 +18,8 @@ namespace OpenRA.Mods.Common.Effects
 {
 	public class ContrailFader : IEffect
 	{
-		WPos pos;
-		ContrailRenderable trail;
+		readonly WPos pos;
+		readonly ContrailRenderable trail;
 		int ticks;
 
 		public ContrailFader(WPos pos, ContrailRenderable trail)

--- a/OpenRA.Mods.Common/Effects/FloatingText.cs
+++ b/OpenRA.Mods.Common/Effects/FloatingText.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Effects
 
 		readonly SpriteFont font;
 		readonly string text;
-		Color color;
+		readonly Color color;
 		int remaining;
 		WPos pos;
 

--- a/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Effects
 		readonly Animation flag;
 		readonly Animation circles;
 
-		List<WPos> targetLineNodes = new List<WPos> { };
+		readonly List<WPos> targetLineNodes = new List<WPos> { };
 		List<CPos> cachedLocations;
 
 		public RallyPointIndicator(Actor building, RallyPoint rp)

--- a/OpenRA.Mods.Common/FileFormats/Blast.cs
+++ b/OpenRA.Mods.Common/FileFormats/Blast.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.FileFormats
 		public static readonly int MAXBITS = 13; // maximum code length
 		public static readonly int MAXWIN = 4096; // maximum window size
 
-		static byte[] litlen =
+		static readonly byte[] litlen =
 		{
 			11, 124, 8, 7, 28, 7, 188, 13, 76, 4,
 			10, 8, 12, 10, 12, 10, 8, 23, 8, 9,
@@ -40,28 +40,28 @@ namespace OpenRA.Mods.Common.FileFormats
 		};
 
 		// bit lengths of length codes 0..15
-		static byte[] lenlen = { 2, 35, 36, 53, 38, 23 };
+		static readonly byte[] lenlen = { 2, 35, 36, 53, 38, 23 };
 
 		// bit lengths of distance codes 0..63
-		static byte[] distlen = { 2, 20, 53, 230, 247, 151, 248 };
+		static readonly byte[] distlen = { 2, 20, 53, 230, 247, 151, 248 };
 
 		// base for length codes
-		static short[] lengthbase =
+		static readonly short[] lengthbase =
 		{
 			3, 2, 4, 5, 6, 7, 8, 9, 10, 12,
 			16, 24, 40, 72, 136, 264
 		};
 
 		// extra bits for length codes
-		static byte[] extra =
+		static readonly byte[] extra =
 		{
 			0, 0, 0, 0, 0, 0, 0, 0, 1, 2,
 			3, 4, 5, 6, 7, 8
 		};
 
-		static Huffman litcode = new Huffman(litlen, litlen.Length, 256);
-		static Huffman lencode = new Huffman(lenlen, lenlen.Length, 16);
-		static Huffman distcode = new Huffman(distlen, distlen.Length, 64);
+		static readonly Huffman litcode = new Huffman(litlen, litlen.Length, 256);
+		static readonly Huffman lencode = new Huffman(lenlen, lenlen.Length, 16);
+		static readonly Huffman distcode = new Huffman(distlen, distlen.Length, 64);
 
 		/// <summary>PKWare Compression Library stream.</summary>
 		/// <param name="input">Compressed input stream.</param>

--- a/OpenRA.Mods.Common/FileFormats/IniFile.cs
+++ b/OpenRA.Mods.Common/FileFormats/IniFile.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.FileFormats
 {
 	public class IniFile
 	{
-		Dictionary<string, IniSection> sections = new Dictionary<string, IniSection>();
+		readonly Dictionary<string, IniSection> sections = new Dictionary<string, IniSection>();
 
 		public IniFile(Stream s)
 		{
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.FileFormats
 			}
 		}
 
-		Regex sectionPattern = new Regex(@"^\[([^]]*)\]");
+		readonly Regex sectionPattern = new Regex(@"^\[([^]]*)\]");
 
 		IniSection ProcessSection(string line)
 		{
@@ -111,7 +111,7 @@ namespace OpenRA.Mods.Common.FileFormats
 	public class IniSection : IEnumerable<KeyValuePair<string, string>>
 	{
 		public string Name { get; private set; }
-		Dictionary<string, string> values = new Dictionary<string, string>();
+		readonly Dictionary<string, string> values = new Dictionary<string, string>();
 
 		public IniSection(string name)
 		{

--- a/OpenRA.Mods.Common/Graphics/ContrailRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/ContrailRenderable.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Graphics
 		readonly WDist width;
 		int next;
 		int length;
-		int skip;
+		readonly int skip;
 
 		public ContrailRenderable(World world, Color color, WDist width, int length, int skip, int zOffset)
 			: this(world, new WPos[length], width, 0, 0, skip, color, zOffset) { }

--- a/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Orders
 {
 	public abstract class GlobalButtonOrderGenerator<T> : OrderGenerator
 	{
-		string order;
+		readonly string order;
 
 		public GlobalButtonOrderGenerator(string order)
 		{

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -124,7 +124,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		readonly float3 shadowColor;
 		readonly float shadowAlpha;
 
-		ContrailRenderable contrail;
+		readonly ContrailRenderable contrail;
 
 		[Sync]
 		WPos pos, lastPos, target, source;

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -189,16 +189,16 @@ namespace OpenRA.Mods.Common.Projectiles
 		int ticks;
 
 		int ticksToNextSmoke;
-		ContrailRenderable contrail;
-		string trailPalette;
+		readonly ContrailRenderable contrail;
+		readonly string trailPalette;
 
 		States state;
 		bool targetPassedBy;
-		bool lockOn;
+		readonly bool lockOn;
 		bool allowPassBy; // TODO: use this also with high minimum launch angle settings
 
 		WPos targetPosition;
-		WVec offset;
+		readonly WVec offset;
 
 		WVec tarVel;
 		WVec predVel;
@@ -210,7 +210,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		int speed;
 		int loopRadius;
 		WDist distanceCovered;
-		WDist rangeLimit;
+		readonly WDist rangeLimit;
 
 		WAngle renderFacing;
 

--- a/OpenRA.Mods.Common/Scripting/Properties/GuardProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GuardProperties.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Scripting
 	[ScriptPropertyGroup("Combat")]
 	public class GuardProperties : ScriptActorProperties, Requires<GuardInfo>, Requires<IMoveInfo>
 	{
-		Guard guard;
+		readonly Guard guard;
 		public GuardProperties(ScriptContext context, Actor self)
 			: base(context, self)
 		{

--- a/OpenRA.Mods.Common/Scripting/Properties/HealthProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/HealthProperties.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Scripting
 	[ScriptPropertyGroup("General")]
 	public class HealthProperties : ScriptActorProperties, Requires<IHealthInfo>
 	{
-		IHealth health;
+		readonly IHealth health;
 		public HealthProperties(ScriptContext context, Actor self)
 			: base(context, self)
 		{

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -78,12 +78,12 @@ namespace OpenRA.Mods.Common.Traits
 	public class AttackGarrisoned : AttackFollow, INotifyPassengerEntered, INotifyPassengerExited, IRender
 	{
 		public new readonly AttackGarrisonedInfo Info;
-		Lazy<BodyOrientation> coords;
-		List<Armament> armaments;
-		List<AnimationWithOffset> muzzles;
-		Dictionary<Actor, IFacing> paxFacing;
-		Dictionary<Actor, IPositionable> paxPos;
-		Dictionary<Actor, RenderSprites> paxRender;
+		readonly Lazy<BodyOrientation> coords;
+		readonly List<Armament> armaments;
+		readonly List<AnimationWithOffset> muzzles;
+		readonly Dictionary<Actor, IFacing> paxFacing;
+		readonly Dictionary<Actor, IPositionable> paxPos;
+		readonly Dictionary<Actor, RenderSprites> paxRender;
 
 		public AttackGarrisoned(Actor self, AttackGarrisonedInfo info)
 			: base(self, info)

--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -154,7 +154,7 @@ namespace OpenRA.Mods.Common.Traits
 		CPos initialBaseCenter;
 		CPos defenseCenter;
 
-		List<BaseBuilderQueueManager> builders = new List<BaseBuilderQueueManager>();
+		readonly List<BaseBuilderQueueManager> builders = new List<BaseBuilderQueueManager>();
 
 		public BaseBuilderBotModule(Actor self, BaseBuilderBotModuleInfo info)
 			: base(info)

--- a/OpenRA.Mods.Common/Traits/BotModules/CaptureManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/CaptureManagerBotModule.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 		int minCaptureDelayTicks;
 
 		// Units that the bot already knows about and has given a capture order. Any unit not on this list needs to be given a new order.
-		List<Actor> activeCapturers = new List<Actor>();
+		readonly List<Actor> activeCapturers = new List<Actor>();
 
 		public CaptureManagerBotModule(Actor self, CaptureManagerBotModuleInfo info)
 			: base(info)

--- a/OpenRA.Mods.Common/Traits/CapturableProgressBar.cs
+++ b/OpenRA.Mods.Common/Traits/CapturableProgressBar.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	class CapturableProgressBar : ConditionalTrait<CapturableProgressBarInfo>, ISelectionBar, ICaptureProgressWatcher
 	{
-		Dictionary<Actor, (int Current, int Total)> progress = new Dictionary<Actor, (int, int)>();
+		readonly Dictionary<Actor, (int Current, int Total)> progress = new Dictionary<Actor, (int, int)>();
 
 		public CapturableProgressBar(Actor self, CapturableProgressBarInfo info)
 			: base(info) { }

--- a/OpenRA.Mods.Common/Traits/CapturableProgressBlink.cs
+++ b/OpenRA.Mods.Common/Traits/CapturableProgressBlink.cs
@@ -27,8 +27,8 @@ namespace OpenRA.Mods.Common.Traits
 
 	class CapturableProgressBlink : ConditionalTrait<CapturableProgressBlinkInfo>, ITick, ICaptureProgressWatcher
 	{
-		List<Player> captorOwners = new List<Player>();
-		HashSet<Actor> captors = new HashSet<Actor>();
+		readonly List<Player> captorOwners = new List<Player>();
+		readonly HashSet<Actor> captors = new HashSet<Actor>();
 		int tick = 0;
 
 		public CapturableProgressBlink(CapturableProgressBlinkInfo info)

--- a/OpenRA.Mods.Common/Traits/CaptureManager.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureManager.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 		int beingCapturedToken = Actor.InvalidConditionToken;
 		bool enteringCurrentTarget;
 
-		HashSet<Actor> currentCaptors = new HashSet<Actor>();
+		readonly HashSet<Actor> currentCaptors = new HashSet<Actor>();
 
 		public bool BeingCaptured { get; private set; }
 

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -104,7 +104,7 @@ namespace OpenRA.Mods.Common.Traits
 		int reservedWeight = 0;
 		Aircraft aircraft;
 		int loadingToken = Actor.InvalidConditionToken;
-		Stack<int> loadedTokens = new Stack<int>();
+		readonly Stack<int> loadedTokens = new Stack<int>();
 		bool takeOffAfterLoad;
 		bool initialised;
 

--- a/OpenRA.Mods.Common/Traits/Crates/SupportPowerCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/SupportPowerCrateAction.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	class SupportPowerCrateAction : CrateAction
 	{
-		SupportPowerCrateActionInfo info;
+		readonly SupportPowerCrateActionInfo info;
 		public SupportPowerCrateAction(Actor self, SupportPowerCrateActionInfo info)
 			: base(self, info)
 		{

--- a/OpenRA.Mods.Common/Traits/Demolishable.cs
+++ b/OpenRA.Mods.Common/Traits/Demolishable.cs
@@ -46,8 +46,8 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		List<DemolishAction> actions = new List<DemolishAction>();
-		List<DemolishAction> removeActions = new List<DemolishAction>();
+		readonly List<DemolishAction> actions = new List<DemolishAction>();
+		readonly List<DemolishAction> removeActions = new List<DemolishAction>();
 
 		public Demolishable(DemolishableInfo info)
 			: base(info) { }

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		class EngineerRepairOrderTargeter : UnitOrderTargeter
 		{
-			EngineerRepairInfo info;
+			readonly EngineerRepairInfo info;
 
 			public EngineerRepairOrderTargeter(EngineerRepairInfo info)
 				: base("EngineerRepair", 6, info.Cursor, true, true)

--- a/OpenRA.Mods.Common/Traits/ExperienceTrickler.cs
+++ b/OpenRA.Mods.Common/Traits/ExperienceTrickler.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class ExperienceTrickler : PausableConditionalTrait<ExperienceTricklerInfo>, ITick, ISync
 	{
 		readonly ExperienceTricklerInfo info;
-		GainsExperience gainsExperience;
+		readonly GainsExperience gainsExperience;
 
 		[Sync]
 		int ticks;

--- a/OpenRA.Mods.Common/Traits/GivesBounty.cs
+++ b/OpenRA.Mods.Common/Traits/GivesBounty.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	class GivesBounty : ConditionalTrait<GivesBountyInfo>, INotifyKilled, INotifyPassengerEntered, INotifyPassengerExited
 	{
-		Dictionary<Actor, GivesBounty[]> passengerBounties = new Dictionary<Actor, GivesBounty[]>();
+		readonly Dictionary<Actor, GivesBounty[]> passengerBounties = new Dictionary<Actor, GivesBounty[]>();
 
 		public GivesBounty(GivesBountyInfo info)
 			: base(info) { }

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -649,7 +649,7 @@ namespace OpenRA.Mods.Common.Traits
 			CPos cell;
 			SubCell subCell;
 			WPos pos;
-			int delay;
+			readonly int delay;
 
 			public ReturnToCellActivity(Actor self, int delay = 0, bool recalculateSubCell = false)
 			{

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/CloakPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/CloakPaletteEffect.cs
@@ -22,9 +22,9 @@ namespace OpenRA.Mods.Common.Traits
 	public class CloakPaletteEffect : IPaletteModifier, ITick
 	{
 		float t = 0;
-		string paletteName = "cloak";
+		readonly string paletteName = "cloak";
 
-		Color[] colors =
+		readonly Color[] colors =
 		{
 			Color.FromArgb(55, 205, 205, 220),
 			Color.FromArgb(120, 205, 205, 230),

--- a/OpenRA.Mods.Common/Traits/Player/TechTree.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TechTree.cs
@@ -118,7 +118,7 @@ namespace OpenRA.Mods.Common.Traits
 			readonly string[] prerequisites;
 			readonly ITechTreeElement watcher;
 			bool hasPrerequisites;
-			int limit;
+			readonly int limit;
 			bool hidden;
 			bool initialized = false;
 

--- a/OpenRA.Mods.Common/Traits/Pluggable.cs
+++ b/OpenRA.Mods.Common/Traits/Pluggable.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		readonly string initialPlug;
 		int conditionToken = Actor.InvalidConditionToken;
-		Dictionary<string, bool> plugTypesAvailability = null;
+		readonly Dictionary<string, bool> plugTypesAvailability = null;
 
 		string active;
 

--- a/OpenRA.Mods.Common/Traits/Render/VeteranProductionIconOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/VeteranProductionIconOverlay.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		readonly Sprite sprite;
 		readonly VeteranProductionIconOverlayInfo info;
 
-		Dictionary<ActorInfo, bool> overlayActive = new Dictionary<ActorInfo, bool>();
+		readonly Dictionary<ActorInfo, bool> overlayActive = new Dictionary<ActorInfo, bool>();
 
 		public VeteranProductionIconOverlay(ActorInitializer init, VeteranProductionIconOverlayInfo info)
 		{

--- a/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 	class AmbientSound : ConditionalTrait<AmbientSoundInfo>, ITick, INotifyRemovedFromWorld
 	{
 		readonly bool loop;
-		HashSet<ISound> currentSounds = new HashSet<ISound>();
+		readonly HashSet<ISound> currentSounds = new HashSet<ISound>();
 		WPos cachedPosition;
 		int delay;
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SelectDirectionalTarget.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SelectDirectionalTarget.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 		bool activated;
 		bool dragStarted;
 		Arrow currentArrow;
-		MouseAttachmentWidget mouseAttachment;
+		readonly MouseAttachmentWidget mouseAttachment;
 
 		public SelectDirectionalTarget(World world, string order, SupportPowerManager manager, string cursor,
 			string directionArrowAnimation, string directionArrowPalette)

--- a/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
@@ -48,16 +48,16 @@ namespace OpenRA.Mods.Common.Traits
 	class ThrowsParticle : ITick
 	{
 		WVec pos;
-		WVec initialPos;
-		WVec finalPos;
-		WAngle angle;
+		readonly WVec initialPos;
+		readonly WVec finalPos;
+		readonly WAngle angle;
 
 		int tick = 0;
-		int length;
+		readonly int length;
 
 		WAngle facing;
 		WAngle rotation;
-		int direction;
+		readonly int direction;
 
 		public ThrowsParticle(ActorInitializer init, ThrowsParticleInfo info)
 		{

--- a/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
+++ b/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	class StartGameNotification : IWorldLoaded, INotifyGameLoaded, INotifyGameSaved
 	{
-		StartGameNotificationInfo info;
+		readonly StartGameNotificationInfo info;
 		public StartGameNotification(StartGameNotificationInfo info)
 		{
 			this.info = info;

--- a/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
@@ -331,7 +331,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		}
 
 		// TODO: fix this -- will have bitrotted pretty badly.
-		static Dictionary<string, Color> namedColorMapping = new Dictionary<string, Color>()
+		static readonly Dictionary<string, Color> namedColorMapping = new Dictionary<string, Color>()
 		{
 			{ "gold", Color.FromArgb(246, 214, 121) },
 			{ "blue", Color.FromArgb(226, 230, 246) },

--- a/OpenRA.Mods.Common/Widgets/GridLayout.cs
+++ b/OpenRA.Mods.Common/Widgets/GridLayout.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.Widgets
 {
 	public class GridLayout : ILayout
 	{
-		ScrollPanelWidget widget;
+		readonly ScrollPanelWidget widget;
 		int2 pos;
 
 		public GridLayout(ScrollPanelWidget w) { widget = w; }

--- a/OpenRA.Mods.Common/Widgets/ImageWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ImageWidget.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public string TooltipText;
 
-		Lazy<TooltipContainerWidget> tooltipContainer;
+		readonly Lazy<TooltipContainerWidget> tooltipContainer;
 		public Func<string> GetTooltipText;
 
 		public ImageWidget()

--- a/OpenRA.Mods.Common/Widgets/ListLayout.cs
+++ b/OpenRA.Mods.Common/Widgets/ListLayout.cs
@@ -15,7 +15,7 @@ namespace OpenRA.Mods.Common.Widgets
 {
 	public class ListLayout : ILayout
 	{
-		ScrollPanelWidget widget;
+		readonly ScrollPanelWidget widget;
 
 		public ListLayout(ScrollPanelWidget w) { widget = w; }
 

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -34,12 +34,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly World world;
 		readonly ModData modData;
 
-		Widget panel;
+		readonly Widget panel;
 
-		TextFieldWidget filenameInput;
-		SliderWidget frameSlider;
-		ScrollPanelWidget assetList;
-		ScrollItemWidget template;
+		readonly TextFieldWidget filenameInput;
+		readonly SliderWidget frameSlider;
+		readonly ScrollPanelWidget assetList;
+		readonly ScrollItemWidget template;
 
 		IReadOnlyPackage assetSource = null;
 		bool animateFrames = false;
@@ -385,7 +385,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				currentFrame = currentSprites.Length - 1;
 		}
 
-		Dictionary<string, bool> assetVisByName = new Dictionary<string, bool>();
+		readonly Dictionary<string, bool> assetVisByName = new Dictionary<string, bool>();
 
 		bool FilterAsset(string filename)
 		{

--- a/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
@@ -17,8 +17,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class ConnectionLogic : ChromeLogic
 	{
-		Action onConnect, onAbort;
-		Action<string> onRetry;
+		readonly Action onConnect;
+		readonly Action onAbort;
+		readonly Action<string> onRetry;
 
 		void ConnectionStateChanged(OrderManager om, string password, NetworkConnection connection)
 		{
@@ -81,7 +82,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 	public class ConnectionFailedLogic : ChromeLogic
 	{
-		PasswordFieldWidget passwordField;
+		readonly PasswordFieldWidget passwordField;
 		bool passwordOffsetAdjusted;
 
 		[ObjectCreator.UseCtor]

--- a/OpenRA.Mods.Common/Widgets/Logic/CreditsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/CreditsLogic.cs
@@ -22,8 +22,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly ScrollPanelWidget scrollPanel;
 		readonly LabelWidget template;
 
-		bool showModTab;
-		bool showEngineTab;
+		readonly bool showModTab;
+		readonly bool showEngineTab;
 		bool isShowingModTab;
 		readonly IEnumerable<string> modLines;
 		readonly IEnumerable<string> engineLines;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class NewMapLogic : ChromeLogic
 	{
-		Widget panel;
+		readonly Widget panel;
 
 		[ObjectCreator.UseCtor]
 		public NewMapLogic(Action onExit, Action<string> onSelect, Widget widget, World world, ModData modData)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly Action<bool> hideMenu;
 		readonly IObjectivesPanel iop;
 		IngameInfoPanel activePanel;
-		bool hasError;
+		readonly bool hasError;
 
 		[ObjectCreator.UseCtor]
 		public GameInfoLogic(Widget widget, ModData modData, World world, IngameInfoPanel initialPanel, Action<bool> hideMenu)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/CycleStatusBarsHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/CycleStatusBarsHotkeyLogic.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 	[ChromeLogicArgsHotkeys("CycleStatusBarsKey")]
 	public class CycleStatusBarsHotkeyLogic : SingleHotkeyBaseLogic
 	{
-		StatusBarsType[] options = { StatusBarsType.Standard, StatusBarsType.DamageShow, StatusBarsType.AlwaysShow };
+		readonly StatusBarsType[] options = { StatusBarsType.Standard, StatusBarsType.DamageShow, StatusBarsType.AlwaysShow };
 
 		[ObjectCreator.UseCtor]
 		public CycleStatusBarsHotkeyLogic(Widget widget, ModData modData, Dictionary<string, MiniYaml> logicArgs)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly WorldRenderer worldRenderer;
 		readonly MenuPaletteEffect mpe;
 		readonly bool isSinglePlayer;
-		bool hasError;
+		readonly bool hasError;
 		bool leaving;
 		bool hideMenu;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly World world;
 
 		CameraOption selected;
-		LabelWidget shroudLabel;
+		readonly LabelWidget shroudLabel;
 
 		class CameraOption
 		{

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -25,9 +25,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	{
 		class SlotDropDownOption
 		{
-			public string Title;
-			public string Order;
-			public Func<bool> Selected;
+			public readonly string Title;
+			public readonly string Order;
+			public readonly Func<bool> Selected;
 
 			public SlotDropDownOption(string title, string order, Func<bool> selected)
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -24,13 +24,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		MapClassification currentTab;
 
-		Dictionary<MapClassification, ScrollPanelWidget> scrollpanels = new Dictionary<MapClassification, ScrollPanelWidget>();
+		readonly Dictionary<MapClassification, ScrollPanelWidget> scrollpanels = new Dictionary<MapClassification, ScrollPanelWidget>();
 
-		Dictionary<MapClassification, MapPreview[]> tabMaps = new Dictionary<MapClassification, MapPreview[]>();
+		readonly Dictionary<MapClassification, MapPreview[]> tabMaps = new Dictionary<MapClassification, MapPreview[]>();
 		string[] visibleMaps;
 
 		string selectedUid;
-		Action<string> onSelect;
+		readonly Action<string> onSelect;
 
 		string category;
 		string mapFilter;

--- a/OpenRA.Mods.Common/Widgets/LogicKeyListenerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LogicKeyListenerWidget.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Widgets
 {
 	public class LogicKeyListenerWidget : Widget
 	{
-		List<Func<KeyInput, bool>> handlers = new List<Func<KeyInput, bool>>();
+		readonly List<Func<KeyInput, bool>> handlers = new List<Func<KeyInput, bool>>();
 
 		public override bool HandleKeyPress(KeyInput e)
 		{

--- a/OpenRA.Mods.Common/Widgets/ObserverArmyIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverArmyIconsWidget.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public int IconHeight = 24;
 		public int IconSpacing = 1;
 
-		float2 iconSize;
+		readonly float2 iconSize;
 		public int MinWidth = 240;
 
 		public ArmyUnit TooltipUnit { get; private set; }

--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -39,12 +39,12 @@ namespace OpenRA.Mods.Common.Widgets
 		public ProductionIcon TooltipIcon { get; private set; }
 		public Func<ProductionIcon> GetTooltipIcon;
 
-		Dictionary<ProductionQueue, Animation> clocks;
+		readonly Dictionary<ProductionQueue, Animation> clocks;
 		readonly Lazy<TooltipContainerWidget> tooltipContainer;
 		readonly List<ProductionIcon> productionIcons = new List<ProductionIcon>();
 		readonly List<Rectangle> productionIconsBounds = new List<Rectangle>();
 
-		float2 iconSize;
+		readonly float2 iconSize;
 		int lastIconIdx;
 		public int MinWidth = 240;
 		int currentTooltipToken;

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public int IconRowOffset = 0;
 		public int MaxIconRowOffset = int.MaxValue;
 
-		Lazy<TooltipContainerWidget> tooltipContainer;
+		readonly Lazy<TooltipContainerWidget> tooltipContainer;
 		ProductionQueue currentQueue;
 		HotkeyReference[] hotkeys;
 
@@ -111,7 +111,8 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override Rectangle EventBounds => eventBounds;
 		Dictionary<Rectangle, ProductionIcon> icons = new Dictionary<Rectangle, ProductionIcon>();
-		Animation cantBuild, clock;
+		readonly Animation cantBuild;
+		readonly Animation clock;
 		Rectangle eventBounds = Rectangle.Empty;
 
 		readonly WorldRenderer worldRenderer;

--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.Widgets
 		SpriteFont font;
 		Rectangle leftButtonRect;
 		Rectangle rightButtonRect;
-		Lazy<ProductionPaletteWidget> paletteWidget;
+		readonly Lazy<ProductionPaletteWidget> paletteWidget;
 		string queueGroup;
 
 		[ObjectCreator.UseCtor]

--- a/OpenRA.Mods.Common/Widgets/ResourceBarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ResourceBarWidget.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Widgets
 	{
 		public readonly string TooltipTemplate;
 		public readonly string TooltipContainer;
-		Lazy<TooltipContainerWidget> tooltipContainer;
+		readonly Lazy<TooltipContainerWidget> tooltipContainer;
 
 		public string TooltipFormat = "";
 		public ResourceBarOrientation Orientation = ResourceBarOrientation.Vertical;
@@ -31,8 +31,8 @@ namespace OpenRA.Mods.Common.Widgets
 		public Func<float> GetProvided = () => 0;
 		public Func<float> GetUsed = () => 0;
 		public Func<Color> GetBarColor = () => Color.White;
-		EWMA providedLerp = new EWMA(0.3f);
-		EWMA usedLerp = new EWMA(0.3f);
+		readonly EWMA providedLerp = new EWMA(0.3f);
+		readonly EWMA usedLerp = new EWMA(0.3f);
 		readonly World world;
 		Sprite indicator;
 

--- a/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
@@ -53,12 +53,12 @@ namespace OpenRA.Mods.Common.Widgets
 		readonly SupportPowerManager spm;
 
 		Animation icon;
-		Animation clock;
+		readonly Animation clock;
 		Dictionary<Rectangle, SupportPowerIcon> icons = new Dictionary<Rectangle, SupportPowerIcon>();
 
 		public SupportPowerIcon TooltipIcon { get; private set; }
 		public Func<SupportPowerIcon> GetTooltipIcon;
-		Lazy<TooltipContainerWidget> tooltipContainer;
+		readonly Lazy<TooltipContainerWidget> tooltipContainer;
 		HotkeyReference[] hotkeys;
 
 		Rectangle eventBounds;

--- a/OpenRA.Platforms.Default/MultiTapDetection.cs
+++ b/OpenRA.Platforms.Default/MultiTapDetection.cs
@@ -16,9 +16,9 @@ namespace OpenRA.Platforms.Default
 {
 	static class MultiTapDetection
 	{
-		static Cache<(Keycode Key, Modifiers Mods), TapHistory> keyHistoryCache =
+		static readonly Cache<(Keycode Key, Modifiers Mods), TapHistory> keyHistoryCache =
 			new Cache<(Keycode, Modifiers), TapHistory>(_ => new TapHistory(DateTime.Now - TimeSpan.FromSeconds(1)));
-		static Cache<byte, TapHistory> clickHistoryCache =
+		static readonly Cache<byte, TapHistory> clickHistoryCache =
 			new Cache<byte, TapHistory>(_ => new TapHistory(DateTime.Now - TimeSpan.FromSeconds(1)));
 
 		public static int DetectFromMouse(byte button, int2 xy)

--- a/OpenRA.Test/OpenRA.Game/VariableExpressionTest.cs
+++ b/OpenRA.Test/OpenRA.Game/VariableExpressionTest.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Test
 	[TestFixture]
 	public class VariableExpressionTest
 	{
-		IReadOnlyDictionary<string, int> testValues = new Dictionary<string, int>
+		readonly IReadOnlyDictionary<string, int> testValues = new Dictionary<string, int>
 		{
 			{ "t", 5 },
 			{ "t-1", 7 },

--- a/OpenRA.ruleset
+++ b/OpenRA.ruleset
@@ -55,6 +55,7 @@
     <Rule Id="SA1132" Action="None" /><!-- DoNotCombineFields -->
     <Rule Id="SA1204" Action="None" /><!-- StaticElementsMustAppearBeforeInstanceElements -->
     <Rule Id="SA1214" Action="None" /><!-- ReadonlyElementsMustAppearBeforeNonReadonlyElements -->
+    <Rule Id="SA1311" Action="None" /><!-- StaticReadonlyFieldsMustBeginWithUpperCaseLetter - silenced to match IDE1006 in .editorconfig -->
     <Rule Id="SA1413" Action="None" /><!-- UseTrailingCommasInMultiLineInitializers -->
     <Rule Id="SA1516" Action="None" /><!-- ElementsMustBeSeparatedByBlankLine -->
     <Rule Id="SA1604" Action="None" /><!-- ElementDocumentationShouldHaveSummary -->


### PR DESCRIPTION
Step Nth in our quest for ***moar code style rules!!!*** Now we finally take on the infamous `readonly` modifier that gets skipped so often.

Activating the rule (IDE0044) and fixing the subsequent issues lead to a new batch of issues - there are a bunch of places that light up with `error SA1311: Static readonly fields should begin with upper-case letter`, which left me with two choices - silence that rule or fix these issues as well. I started fixing them, but at some point realized that rule IDE1006 (also configured [in the `.editorconfig`](https://github.com/OpenRA/OpenRA/blob/a67cfabd1ec7b10436ffa439eba00000db18ca02/.editorconfig#L67)) is the IDE version of the same thing and it is explicitly silenced, so as a first option I went with that. If people decide against it then I'll change it.

P.S.: Big but incredibly easy to review PR 😛 

Pinging @RoosterDragon for a review please.