### PR TITLE
Create overlays dropdown

### DIFF
--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -584,19 +584,8 @@ Container@EDITOR_WORLD_ROOT:
 					Height: 25
 					Text: History
 					Font: Bold
-		Button@BUILDABLE_BUTTON:
-			X: WINDOW_RIGHT - 1020
-			Y: 5
-			Width: 100
-			Height: 25
-			Text: Buildable
-			Font: Bold
-			Key: f2
-			TooltipTemplate: BUTTON_TOOLTIP
-			TooltipText: Toggle unbuildable cells
-			TooltipContainer: TOOLTIP_CONTAINER
 		Button@UNDO_BUTTON:
-			X: WINDOW_RIGHT - 910
+			X: WINDOW_RIGHT - 800
 			Y: 5
 			Height: 25
 			Width: 100
@@ -607,7 +596,7 @@ Container@EDITOR_WORLD_ROOT:
 			TooltipText: Undo last step
 			TooltipContainer: TOOLTIP_CONTAINER
 		Button@REDO_BUTTON:
-			X: WINDOW_RIGHT - 800
+			X: WINDOW_RIGHT - 690
 			Y: 5
 			Height: 25
 			Width: 100
@@ -616,17 +605,6 @@ Container@EDITOR_WORLD_ROOT:
 			Key: y ctrl
 			TooltipTemplate: BUTTON_TOOLTIP
 			TooltipText: Redo last step
-			TooltipContainer: TOOLTIP_CONTAINER
-		Button@GRID_BUTTON:
-			X: WINDOW_RIGHT - 690
-			Y: 5
-			Width: 100
-			Height: 25
-			Text: Grid
-			Font: Bold
-			Key: f1
-			TooltipTemplate: BUTTON_TOOLTIP
-			TooltipText: Toggle the terrain grid
 			TooltipContainer: TOOLTIP_CONTAINER
 		Button@COPYPASTE_BUTTON:
 			X: WINDOW_RIGHT - 580
@@ -644,6 +622,13 @@ Container@EDITOR_WORLD_ROOT:
 			Width: 140
 			Height: 25
 			Text: Copy Filters
+			Font: Bold
+		DropDownButton@OVERLAY_BUTTON:
+			X: WINDOW_RIGHT - 950
+			Y: 5
+			Width: 140
+			Height: 25
+			Text: Overlays
 			Font: Bold
 		Label@COORDINATE_LABEL:
 			X: 10
@@ -690,6 +675,17 @@ ScrollPanel@CATEGORY_FILTER_PANEL:
 ScrollPanel@COPY_FILTER_PANEL:
 	Width: 140
 	Height: 65
+	Children:
+		Checkbox@CATEGORY_TEMPLATE:
+			X: 5
+			Y: 5
+			Width: PARENT_RIGHT - 29
+			Height: 20
+			Visible: false
+
+ScrollPanel@OVERLAY_PANEL:
+	Width: 140
+	Height: 45
 	Children:
 		Checkbox@CATEGORY_TEMPLATE:
 			X: 5

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -580,18 +580,8 @@ Container@EDITOR_WORLD_ROOT:
 			Height: 25
 			Text: Copy Filters
 			Font: Bold
-		Button@GRID_BUTTON:
-			X: 420
-			Width: 70
-			Height: 25
-			Text: Grid
-			TooltipTemplate: BUTTON_TOOLTIP
-			TooltipText: Toggle the terrain grid
-			TooltipContainer: TOOLTIP_CONTAINER
-			Font: Bold
-			Key: f1
 		Button@UNDO_BUTTON:
-			X: 500
+			X: 420
 			Height: 25
 			Width: 90
 			Text: Undo
@@ -601,7 +591,7 @@ Container@EDITOR_WORLD_ROOT:
 			TooltipText: Undo last step
 			TooltipContainer: TOOLTIP_CONTAINER
 		Button@REDO_BUTTON:
-			X: 600
+			X: 520
 			Height: 25
 			Width: 90
 			Text: Redo
@@ -610,25 +600,21 @@ Container@EDITOR_WORLD_ROOT:
 			TooltipTemplate: BUTTON_TOOLTIP
 			TooltipText: Redo last step
 			TooltipContainer: TOOLTIP_CONTAINER
-		Button@BUILDABLE_BUTTON:
-			X: 700
-			Width: 90
+		DropDownButton@OVERLAY_BUTTON:
+			X: 620
+			Width: 140
 			Height: 25
-			Text: Buildable
+			Text: Overlays
 			Font: Bold
-			Key: f2
-			TooltipTemplate: BUTTON_TOOLTIP
-			TooltipText: Toggle unbuildable cells
-			TooltipContainer: TOOLTIP_CONTAINER
 		Label@COORDINATE_LABEL:
-			X: 835
+			X: 770
 			Width: 50
 			Height: 25
 			Align: Left
 			Font: Bold
 			Contrast: true
 		Label@CASH_LABEL:
-			X: 950
+			X: 885
 			Width: 50
 			Height: 25
 			Align: Left
@@ -667,6 +653,17 @@ ScrollPanel@CATEGORY_FILTER_PANEL:
 ScrollPanel@COPY_FILTER_PANEL:
 	Width: 140
 	Height: 65
+	Children:
+		Checkbox@CATEGORY_TEMPLATE:
+			X: 5
+			Y: 5
+			Width: PARENT_RIGHT - 29
+			Height: 20
+			Visible: false
+
+ScrollPanel@OVERLAY_PANEL:
+	Width: 140
+	Height: 45
 	Children:
 		Checkbox@CATEGORY_TEMPLATE:
 			X: 5


### PR DESCRIPTION
I think it makes sense to group overlays, I made Grid and Buildable into a dropdown. This is also future proofing incase we want to add more overlays

<img width="992" alt="Screenshot 2022-01-23 at 12 43 16" src="https://user-images.githubusercontent.com/37534529/150674838-428b9908-28c4-4159-a597-f0453de7245c.png">

<img width="869" alt="Screenshot 2022-01-23 at 12 38 15" src="https://user-images.githubusercontent.com/37534529/150674816-6d639720-abfd-4511-a9d9-a22923543ab2.png">

