### PR TITLE
Ensure editorconfig naming styles align with StyleCop SA13XX style rules.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,64 +28,75 @@ csharp_space_around_binary_operators = before_and_after
 ## Naming styles:
 
 dotnet_naming_style.camel_case.capitalization = camel_case
+
 dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.i_prefix_pascal_case.capitalization = pascal_case
+dotnet_naming_style.i_prefix_pascal_case.required_prefix = I
 
 ## Symbol specifications:
 
-dotnet_naming_symbols.interface.applicable_kinds = interface
-dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal
+dotnet_naming_symbols.const_locals.applicable_kinds = local
+dotnet_naming_symbols.const_locals.applicable_accessibilities = *
+dotnet_naming_symbols.const_locals.required_modifiers = const
 
-dotnet_naming_symbols.const_private_field.applicable_kinds = field
-dotnet_naming_symbols.const_private_field.required_modifiers = const
-dotnet_naming_symbols.const_private_field.applicable_accessibilities = private
+dotnet_naming_symbols.const_fields.applicable_kinds = field
+dotnet_naming_symbols.const_fields.applicable_accessibilities = *
+dotnet_naming_symbols.const_fields.required_modifiers = const
 
-dotnet_naming_symbols.internal_field.applicable_kinds = field
-dotnet_naming_symbols.internal_field.applicable_accessibilities = internal
+dotnet_naming_symbols.static_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.static_readonly_fields.applicable_accessibilities = *
+dotnet_naming_symbols.static_readonly_fields.required_modifiers = static, readonly
 
-dotnet_naming_symbols.static_private_or_internal_field.required_modifiers = static
-dotnet_naming_symbols.static_private_or_internal_field.applicable_accessibilities = internal, private
+dotnet_naming_symbols.non_private_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_readonly_fields.applicable_accessibilities = public, internal, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_private_readonly_fields.required_modifiers = readonly
 
-dotnet_naming_symbols.private_or_internal_field.applicable_kinds = field
-dotnet_naming_symbols.private_or_internal_field.applicable_accessibilities = internal, private
+dotnet_naming_symbols.private_or_protected_fields.applicable_kinds = field
+dotnet_naming_symbols.private_or_protected_fields.applicable_accessibilities = private, protected, private_protected
 
-dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
-dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal
+dotnet_naming_symbols.interfaces.applicable_kinds = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = *
 
-dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
-dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal
+dotnet_naming_symbols.parameters_and_locals.applicable_kinds = parameter, local
+dotnet_naming_symbols.parameters_and_locals.applicable_accessibilities = *
 
-dotnet_naming_symbols.parameters.applicable_kinds = parameter
+dotnet_naming_symbols.most_symbols.applicable_kinds = namespace, class, struct, enum, field, property, method, local_function, event, delegate, type_parameter
+dotnet_naming_symbols.most_symbols.applicable_accessibilities = *
 
 ## Naming rules:
 
-# IDE1006, IDE-only counterpart of StyleCopAnalyzers - SA1300: ElementMustBeginWithUpperCaseLetter.
-dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = warning
-dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
-dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+dotnet_naming_rule.const_locals_should_be_pascal_case.symbols = const_locals
+dotnet_naming_rule.const_locals_should_be_pascal_case.style = pascal_case
+dotnet_naming_rule.const_locals_should_be_pascal_case.severity = warning
 
-# IDE1006, IDE-only counterpart of StyleCopAnalyzers - SA1311: StaticReadonlyFieldsMustBeginWithUpperCaseLetter (silenced in OpenRA.ruleset).
-dotnet_naming_rule.static_private_or_internal_field_should_be_pascal_case.severity = none
-dotnet_naming_rule.static_private_or_internal_field_should_be_pascal_case.symbols = static_private_or_internal_field
-dotnet_naming_rule.static_private_or_internal_field_should_be_pascal_case.style = pascal_case
+dotnet_naming_rule.const_fields_should_be_pascal_case.symbols = const_fields
+dotnet_naming_rule.const_fields_should_be_pascal_case.style = pascal_case
+dotnet_naming_rule.const_fields_should_be_pascal_case.severity = warning
 
-# IDE1006, IDE-only counterpart of StyleCopAnalyzers - SA1303: ConstFieldNamesMustBeginWithUpperCaseLetter.
-dotnet_naming_rule.const_private_field_should_be_pascal_case.severity = warning
-dotnet_naming_rule.const_private_field_should_be_pascal_case.symbols = const_private_field
-dotnet_naming_rule.const_private_field_should_be_pascal_case.style = pascal_case
+dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.symbols = static_readonly_fields
+dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.style = pascal_case
+dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.severity = warning
 
-dotnet_naming_rule.const_private_or_internal_field_should_be_pascal_case.severity = warning
-dotnet_naming_rule.const_private_or_internal_field_should_be_pascal_case.symbols = internal_field
-dotnet_naming_rule.const_private_or_internal_field_should_be_pascal_case.style = pascal_case
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.symbols = non_private_readonly_fields
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.style = pascal_case
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.severity = warning
 
-# IDE1006, IDE-only counterpart of StyleCopAnalyzers - SA1306: FieldNamesMustBeginWithLowerCaseLetter.
-dotnet_naming_rule.private_or_internal_field_should_be_camel_case.severity = warning
-dotnet_naming_rule.private_or_internal_field_should_be_camel_case.symbols = private_or_internal_field
-dotnet_naming_rule.private_or_internal_field_should_be_camel_case.style = camel_case
+dotnet_naming_rule.private_or_protected_fields_should_be_camel_case.symbols = private_or_protected_fields
+dotnet_naming_rule.private_or_protected_fields_should_be_camel_case.style = camel_case
+dotnet_naming_rule.private_or_protected_fields_should_be_camel_case.severity = warning
 
-# IDE1006, IDE-only counterpart of StyleCopAnalyzers - SA1313: ParameterNamesMustBeginWithLowerCaseLetter.
-dotnet_naming_rule.parameters.severity = warning
-dotnet_naming_rule.parameters.symbols = parameters
-dotnet_naming_rule.parameters.style = camel_case
+dotnet_naming_rule.interfaces_should_be_i_prefix_pascal_case.symbols = interfaces
+dotnet_naming_rule.interfaces_should_be_i_prefix_pascal_case.style = i_prefix_pascal_case
+dotnet_naming_rule.interfaces_should_be_i_prefix_pascal_case.severity = warning
+
+dotnet_naming_rule.parameters_and_locals_should_be_camel_case.symbols = parameters_and_locals
+dotnet_naming_rule.parameters_and_locals_should_be_camel_case.style = camel_case
+dotnet_naming_rule.parameters_and_locals_should_be_camel_case.severity = warning
+
+dotnet_naming_rule.most_symbols_should_be_pascal_case.symbols = most_symbols
+dotnet_naming_rule.most_symbols_should_be_pascal_case.style = pascal_case
+dotnet_naming_rule.most_symbols_should_be_pascal_case.severity = warning
 
 ## Formatting:
 
@@ -129,6 +140,9 @@ dotnet_diagnostic.IDE0040.severity = warning
 
 # Make field readonly.
 dotnet_diagnostic.IDE0044.severity = warning
+
+# Naming rule violation.
+dotnet_diagnostic.IDE1006.severity = warning
 
 # Avoid unnecessary zero-length array allocations.
 dotnet_diagnostic.CA1825.severity = warning

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -119,8 +119,8 @@ namespace OpenRA
 		}
 
 		// More accurate replacement for Environment.TickCount
-		static readonly Stopwatch stopwatch = Stopwatch.StartNew();
-		public static long RunTime => stopwatch.ElapsedMilliseconds;
+		static readonly Stopwatch Stopwatch = Stopwatch.StartNew();
+		public static long RunTime => Stopwatch.ElapsedMilliseconds;
 
 		public static int RenderFrame = 0;
 		public static int NetFrameNumber => OrderManager.NetFrameNumber;

--- a/OpenRA.Game/Map/ActorInitializer.cs
+++ b/OpenRA.Game/Map/ActorInitializer.cs
@@ -140,7 +140,7 @@ namespace OpenRA
 
 	public abstract class ValueActorInit<T> : ActorInit
 	{
-		protected readonly T value;
+		readonly T value;
 
 		protected ValueActorInit(TraitInfo info, T value)
 			: base(info.InstanceName) { this.value = value; }
@@ -159,7 +159,7 @@ namespace OpenRA
 
 		public virtual void Initialize(T value)
 		{
-			var field = GetType().GetField(nameof(value), BindingFlags.NonPublic | BindingFlags.Instance);
+			var field = typeof(ValueActorInit<T>).GetField(nameof(value), BindingFlags.NonPublic | BindingFlags.Instance);
 			if (field != null)
 				field.SetValue(this, value);
 		}
@@ -226,7 +226,7 @@ namespace OpenRA
 	public class OwnerInit : ActorInit, ISingleInstanceInit
 	{
 		public readonly string InternalName;
-		protected readonly Player value;
+		readonly Player value;
 
 		public OwnerInit(Player value)
 		{
@@ -246,14 +246,14 @@ namespace OpenRA
 
 		public void Initialize(MiniYaml yaml)
 		{
-			var field = GetType().GetField(nameof(InternalName), BindingFlags.Public | BindingFlags.Instance);
+			var field = typeof(OwnerInit).GetField(nameof(InternalName), BindingFlags.Public | BindingFlags.Instance);
 			if (field != null)
 				field.SetValue(this, yaml.Value);
 		}
 
 		public void Initialize(Player player)
 		{
-			var field = GetType().GetField(nameof(value), BindingFlags.NonPublic | BindingFlags.Instance);
+			var field = typeof(OwnerInit).GetField(nameof(value), BindingFlags.NonPublic | BindingFlags.Instance);
 			if (field != null)
 				field.SetValue(this, player);
 		}

--- a/OpenRA.Game/Map/CellLayer.cs
+++ b/OpenRA.Game/Map/CellLayer.cs
@@ -75,11 +75,11 @@ namespace OpenRA
 		/// <summary>Gets or sets the <see cref="CellLayer"/> using cell coordinates</summary>
 		public T this[CPos cell]
 		{
-			get => entries[Index(cell)];
+			get => Entries[Index(cell)];
 
 			set
 			{
-				entries[Index(cell)] = value;
+				Entries[Index(cell)] = value;
 
 				CellEntryChanged?.Invoke(cell);
 			}
@@ -88,11 +88,11 @@ namespace OpenRA
 		/// <summary>Gets or sets the layer contents using raw map coordinates (not CPos!)</summary>
 		public T this[MPos uv]
 		{
-			get => entries[Index(uv)];
+			get => Entries[Index(uv)];
 
 			set
 			{
-				entries[Index(uv)] = value;
+				Entries[Index(uv)] = value;
 
 				CellEntryChanged?.Invoke(uv.ToCPos(GridType));
 			}
@@ -111,7 +111,7 @@ namespace OpenRA
 
 		public bool Contains(MPos uv)
 		{
-			return bounds.Contains(uv.U, uv.V);
+			return Bounds.Contains(uv.U, uv.V);
 		}
 
 		public CPos Clamp(CPos uv)

--- a/OpenRA.Game/Map/CellLayerBase.cs
+++ b/OpenRA.Game/Map/CellLayerBase.cs
@@ -21,8 +21,8 @@ namespace OpenRA
 		public readonly Size Size;
 		public readonly MapGridType GridType;
 
-		protected readonly T[] entries;
-		protected readonly Rectangle bounds;
+		protected readonly T[] Entries;
+		protected readonly Rectangle Bounds;
 
 		public CellLayerBase(Map map)
 			: this(map.Grid.Type, new Size(map.MapSize.X, map.MapSize.Y)) { }
@@ -30,9 +30,9 @@ namespace OpenRA
 		public CellLayerBase(MapGridType gridType, Size size)
 		{
 			Size = size;
-			bounds = new Rectangle(0, 0, Size.Width, Size.Height);
+			Bounds = new Rectangle(0, 0, Size.Width, Size.Height);
 			GridType = gridType;
-			entries = new T[size.Width * size.Height];
+			Entries = new T[size.Width * size.Height];
 		}
 
 		public virtual void CopyValuesFrom(CellLayerBase<T> anotherLayer)
@@ -40,24 +40,24 @@ namespace OpenRA
 			if (Size != anotherLayer.Size || GridType != anotherLayer.GridType)
 				throw new ArgumentException("Layers must have a matching size and shape (grid type).", nameof(anotherLayer));
 
-			Array.Copy(anotherLayer.entries, entries, entries.Length);
+			Array.Copy(anotherLayer.Entries, Entries, Entries.Length);
 		}
 
 		/// <summary>Clears the layer contents with their default value</summary>
 		public virtual void Clear()
 		{
-			Array.Clear(entries, 0, entries.Length);
+			Array.Clear(Entries, 0, Entries.Length);
 		}
 
 		/// <summary>Clears the layer contents with a known value</summary>
 		public virtual void Clear(T clearValue)
 		{
-			Array.Fill(entries, clearValue);
+			Array.Fill(Entries, clearValue);
 		}
 
 		public IEnumerator<T> GetEnumerator()
 		{
-			return ((IEnumerable<T>)entries).GetEnumerator();
+			return ((IEnumerable<T>)Entries).GetEnumerator();
 		}
 
 		IEnumerator IEnumerable.GetEnumerator()

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -39,13 +39,10 @@ namespace OpenRA
 	}
 
 	[SuppressMessage("StyleCop.CSharp.NamingRules",
-		"SA1307:AccessibleFieldsMustBeginWithUpperCaseLetter",
-		Justification = "Fields names must match the with the remote API.")]
-	[SuppressMessage("StyleCop.CSharp.NamingRules",
-		"SA1304:NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter",
-		Justification = "Fields names must match the with the remote API.")]
-	[SuppressMessage("StyleCop.CSharp.NamingRules",
 		"SA1310:FieldNamesMustNotContainUnderscore",
+		Justification = "Fields names must match the with the remote API.")]
+	[SuppressMessage("Style",
+		"IDE1006:Naming Styles",
 		Justification = "Fields names must match the with the remote API.")]
 	public class RemoteMapData
 	{

--- a/OpenRA.Game/Map/ProjectedCellLayer.cs
+++ b/OpenRA.Game/Map/ProjectedCellLayer.cs
@@ -36,22 +36,22 @@ namespace OpenRA
 
 		public T this[int index]
 		{
-			get => entries[index];
+			get => Entries[index];
 
-			set => entries[index] = value;
+			set => Entries[index] = value;
 		}
 
 		/// <summary>Gets or sets the layer contents using projected map coordinates.</summary>
 		public T this[PPos uv]
 		{
-			get => entries[Index(uv)];
+			get => Entries[Index(uv)];
 
-			set => entries[Index(uv)] = value;
+			set => Entries[Index(uv)] = value;
 		}
 
 		public bool Contains(PPos uv)
 		{
-			return bounds.Contains(uv.U, uv.V);
+			return Bounds.Contains(uv.U, uv.V);
 		}
 	}
 }

--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Network
 	class SyncReport
 	{
 		const int NumSyncReports = 5;
-		static readonly Cache<Type, TypeInfo> typeInfoCache = new Cache<Type, TypeInfo>(t => new TypeInfo(t));
+		static readonly Cache<Type, TypeInfo> TypeInfoCache = new Cache<Type, TypeInfo>(t => new TypeInfo(t));
 
 		readonly OrderManager orderManager;
 
@@ -33,8 +33,8 @@ namespace OpenRA.Network
 		{
 			var type = sync.GetType();
 			TypeInfo typeInfo;
-			lock (typeInfoCache)
-				typeInfo = typeInfoCache[type];
+			lock (TypeInfoCache)
+				typeInfo = TypeInfoCache[type];
 			var values = new Values(typeInfo.Names.Length);
 			var index = 0;
 

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -22,10 +22,10 @@ namespace OpenRA
 
 	public static class Platform
 	{
-		public static PlatformType CurrentPlatform => currentPlatform.Value;
+		public static PlatformType CurrentPlatform => LazyCurrentPlatform.Value;
 		public static readonly Guid SessionGUID = Guid.NewGuid();
 
-		static readonly Lazy<PlatformType> currentPlatform = Exts.Lazy(GetCurrentPlatform);
+		static readonly Lazy<PlatformType> LazyCurrentPlatform = Exts.Lazy(GetCurrentPlatform);
 
 		static bool engineDirAccessed;
 		static string engineDir;

--- a/OpenRA.Game/Primitives/float2.cs
+++ b/OpenRA.Game/Primitives/float2.cs
@@ -16,7 +16,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA
 {
-	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Mimic a built-in type alias.")]
+	[SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Mimic a built-in type alias.")]
 	[StructLayout(LayoutKind.Sequential)]
 	public readonly struct float2 : IEquatable<float2>
 	{

--- a/OpenRA.Game/Primitives/float3.cs
+++ b/OpenRA.Game/Primitives/float3.cs
@@ -15,7 +15,7 @@ using System.Runtime.InteropServices;
 
 namespace OpenRA
 {
-	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Mimic a built-in type alias.")]
+	[SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Mimic a built-in type alias.")]
 	[StructLayout(LayoutKind.Sequential)]
 	public readonly struct float3 : IEquatable<float3>
 	{

--- a/OpenRA.Game/Primitives/int2.cs
+++ b/OpenRA.Game/Primitives/int2.cs
@@ -15,7 +15,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA
 {
-	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Mimic a built-in type alias.")]
+	[SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Mimic a built-in type alias.")]
 	public readonly struct int2 : IEquatable<int2>
 	{
 		public readonly int X, Y;

--- a/OpenRA.Game/Support/PerfTimer.cs
+++ b/OpenRA.Game/Support/PerfTimer.cs
@@ -31,16 +31,16 @@ namespace OpenRA.Support
 		List<PerfTimer> children;
 		long ticks;
 
-		static readonly ThreadLocal<PerfTimer> parentThreadLocal = new ThreadLocal<PerfTimer>();
+		static readonly ThreadLocal<PerfTimer> ParentThreadLocal = new ThreadLocal<PerfTimer>();
 
 		public PerfTimer(string name, float thresholdMs = 0)
 		{
 			this.name = name;
 			this.thresholdMs = thresholdMs;
 
-			parent = parentThreadLocal.Value;
+			parent = ParentThreadLocal.Value;
 			depth = parent == null ? (byte)0 : (byte)(parent.depth + 1);
-			parentThreadLocal.Value = this;
+			ParentThreadLocal.Value = this;
 
 			ticks = Stopwatch.GetTimestamp();
 		}
@@ -49,7 +49,7 @@ namespace OpenRA.Support
 		{
 			ticks = Stopwatch.GetTimestamp() - ticks;
 
-			parentThreadLocal.Value = parent;
+			ParentThreadLocal.Value = parent;
 
 			if (parent == null)
 				Write();

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -345,7 +345,7 @@ namespace OpenRA.Traits
 
 	public interface ILobbyCustomRulesIgnore { }
 
-	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1302:InterfaceNamesMustBeginWithI", Justification = "Not a real interface, but more like a tag.")]
+	[SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Not a real interface, but more like a tag.")]
 	public interface Requires<T> where T : class, ITraitInfoInterface { }
 
 	public interface IActivityInterface { }

--- a/OpenRA.Mods.Cnc/FileSystem/PackageEntry.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/PackageEntry.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Cnc.FileSystem
 
 		public override string ToString()
 		{
-			if (names.TryGetValue(Hash, out var filename))
+			if (Names.TryGetValue(Hash, out var filename))
 				return $"{filename} - offset 0x{Offset:x8} - length 0x{Length:x8}";
 			else
 				return $"0x{Hash:x8} - offset 0x{Offset:x8} - length 0x{Length:x8}";
@@ -105,14 +105,14 @@ namespace OpenRA.Mods.Cnc.FileSystem
 			}
 		}
 
-		static readonly Dictionary<uint, string> names = new Dictionary<uint, string>();
+		static readonly Dictionary<uint, string> Names = new Dictionary<uint, string>();
 
 		public static void AddStandardName(string s)
 		{
 			var hash = HashFilename(s, PackageHashType.Classic); // RA1 and TD
-			names.Add(hash, s);
+			Names.Add(hash, s);
 			var crcHash = HashFilename(s, PackageHashType.CRC32); // TS
-			names.Add(crcHash, s);
+			Names.Add(crcHash, s);
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Graphics/TeslaZapRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/TeslaZapRenderable.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 {
 	class TeslaZapRenderable : IPalettedRenderable, IFinalizedRenderable
 	{
-		static readonly int[][] steps = new[]
+		static readonly int[][] Steps = new[]
 		{
 			new int[] { 8, 8, 4, 4, 0 },
 			new int[] { -8, -8, -4, -4, 0 },
@@ -144,7 +144,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 
 			while ((to - z).X > 5 || (to - z).X < -5 || (to - z).Y > 5 || (to - z).Y < -5)
 			{
-				var step = steps.Where(t => (to - (z + new float2(t[0], t[1]))).LengthSquared < (to - z).LengthSquared)
+				var step = Steps.Where(t => (to - (z + new float2(t[0], t[1]))).LengthSquared < (to - z).LengthSquared)
 					.MinBy(t => Math.Abs(float2.Dot(z + new float2(t[0], t[1]), q) + c));
 
 				var pos = wr.ProjectedPosition((z + new float2(step[2], step[3])).ToInt2());

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertLegacyMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertLegacyMapCommand.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 		}
 
 		// Mapping from RA95 overlay index to type string
-		static readonly string[] redAlertOverlayNames =
+		static readonly string[] RedAlertOverlayNames =
 		{
 			"sbag", "cycl", "brik", "fenc", "wood",
 			"gold01", "gold02", "gold03", "gold04",
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			"fpls", "wcrate", "scrate", "barb", "sbag",
 		};
 
-		static readonly Dictionary<string, (byte Type, byte Index)> overlayResourceMapping = new Dictionary<string, (byte, byte)>()
+		static readonly Dictionary<string, (byte Type, byte Index)> OverlayResourceMapping = new Dictionary<string, (byte, byte)>()
 		{
 			// RA ore & crystals
 			{ "gold01", (1, 0) },
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 					Map.Tiles[new CPos(i, j)] = new TerrainTile(types[i, j], ms.ReadUInt8());
 		}
 
-		static readonly string[] overlayActors = new string[]
+		static readonly string[] OverlayActors = new string[]
 		{
 			// Fences
 			"sbag", "cycl", "brik", "fenc", "wood",
@@ -102,15 +102,15 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 					var o = ms.ReadUInt8();
 					var res = (Type: (byte)0, Index: (byte)0);
 
-					if (o != 255 && overlayResourceMapping.ContainsKey(redAlertOverlayNames[o]))
-						res = overlayResourceMapping[redAlertOverlayNames[o]];
+					if (o != 255 && OverlayResourceMapping.ContainsKey(RedAlertOverlayNames[o]))
+						res = OverlayResourceMapping[RedAlertOverlayNames[o]];
 
 					var cell = new CPos(i, j);
 					Map.Resources[cell] = new ResourceTile(res.Type, res.Index);
 
-					if (o != 255 && overlayActors.Contains(redAlertOverlayNames[o]))
+					if (o != 255 && OverlayActors.Contains(RedAlertOverlayNames[o]))
 					{
-						var ar = new ActorReference(redAlertOverlayNames[o])
+						var ar = new ActorReference(RedAlertOverlayNames[o])
 						{
 							new LocationInit(cell),
 							new OwnerInit("Neutral")

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianDawnLegacyMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianDawnLegacyMapCommand.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			}
 		}
 
-		static readonly Dictionary<string, (byte Type, byte Index)> overlayResourceMapping = new Dictionary<string, (byte, byte)>()
+		static readonly Dictionary<string, (byte Type, byte Index)> OverlayResourceMapping = new Dictionary<string, (byte, byte)>()
 		{
 			// Tiberium
 			{ "ti1", (1, 0) },
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			}
 		}
 
-		static readonly string[] overlayActors = new string[]
+		static readonly string[] OverlayActors = new string[]
 		{
 			// Fences
 			"sbag", "cycl", "brik", "fenc", "wood",
@@ -94,11 +94,11 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 
 				var res = (Type: (byte)0, Index: (byte)0);
 				var type = kv.Value.ToLowerInvariant();
-				if (overlayResourceMapping.ContainsKey(type))
-					res = overlayResourceMapping[type];
+				if (OverlayResourceMapping.ContainsKey(type))
+					res = OverlayResourceMapping[type];
 
 				Map.Resources[cell] = new ResourceTile(res.Type, res.Index);
-				if (overlayActors.Contains(type))
+				if (OverlayActors.Contains(type))
 				{
 					var ar = new ActorReference(type)
 					{

--- a/OpenRA.Mods.Common/FileFormats/Blast.cs
+++ b/OpenRA.Mods.Common/FileFormats/Blast.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.FileFormats
 		public static readonly int MAXBITS = 13; // maximum code length
 		public static readonly int MAXWIN = 4096; // maximum window size
 
-		static readonly byte[] litlen =
+		static readonly byte[] LitLen =
 		{
 			11, 124, 8, 7, 28, 7, 188, 13, 76, 4,
 			10, 8, 12, 10, 12, 10, 8, 23, 8, 9,
@@ -40,28 +40,28 @@ namespace OpenRA.Mods.Common.FileFormats
 		};
 
 		// bit lengths of length codes 0..15
-		static readonly byte[] lenlen = { 2, 35, 36, 53, 38, 23 };
+		static readonly byte[] LenLen = { 2, 35, 36, 53, 38, 23 };
 
 		// bit lengths of distance codes 0..63
-		static readonly byte[] distlen = { 2, 20, 53, 230, 247, 151, 248 };
+		static readonly byte[] DistLen = { 2, 20, 53, 230, 247, 151, 248 };
 
 		// base for length codes
-		static readonly short[] lengthbase =
+		static readonly short[] LengthBase =
 		{
 			3, 2, 4, 5, 6, 7, 8, 9, 10, 12,
 			16, 24, 40, 72, 136, 264
 		};
 
 		// extra bits for length codes
-		static readonly byte[] extra =
+		static readonly byte[] Extra =
 		{
 			0, 0, 0, 0, 0, 0, 0, 0, 1, 2,
 			3, 4, 5, 6, 7, 8
 		};
 
-		static readonly Huffman litcode = new Huffman(litlen, litlen.Length, 256);
-		static readonly Huffman lencode = new Huffman(lenlen, lenlen.Length, 16);
-		static readonly Huffman distcode = new Huffman(distlen, distlen.Length, 64);
+		static readonly Huffman LitCode = new Huffman(LitLen, LitLen.Length, 256);
+		static readonly Huffman LenCode = new Huffman(LenLen, LenLen.Length, 16);
+		static readonly Huffman DistCode = new Huffman(DistLen, DistLen.Length, 64);
 
 		/// <summary>PKWare Compression Library stream.</summary>
 		/// <param name="input">Compressed input stream.</param>
@@ -98,8 +98,8 @@ namespace OpenRA.Mods.Common.FileFormats
 				if (br.ReadBits(1) == 1)
 				{
 					// Length
-					var symbol = Decode(lencode, br);
-					var len = lengthbase[symbol] + br.ReadBits(extra[symbol]);
+					var symbol = Decode(LenCode, br);
+					var len = LengthBase[symbol] + br.ReadBits(Extra[symbol]);
 
 					// Magic number for "done"
 					if (len == 519)
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.FileFormats
 
 					// Distance
 					symbol = len == 2 ? 2 : dict;
-					var dist = Decode(distcode, br) << symbol;
+					var dist = Decode(DistCode, br) << symbol;
 					dist += br.ReadBits(symbol);
 					dist++;
 
@@ -162,7 +162,7 @@ namespace OpenRA.Mods.Common.FileFormats
 				else
 				{
 					// literal value
-					var symbol = encodedLiterals ? Decode(litcode, br) : br.ReadBits(8);
+					var symbol = encodedLiterals ? Decode(LitCode, br) : br.ReadBits(8);
 					outBuffer[next++] = (byte)symbol;
 					if (next == MAXWIN)
 					{

--- a/OpenRA.Mods.Common/Traits/Buildings/ActorPreviewPlaceBuildingPreview.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ActorPreviewPlaceBuildingPreview.cs
@@ -55,8 +55,8 @@ namespace OpenRA.Mods.Common.Traits
 			: base(wr, ai, info, init)
 		{
 			this.info = info;
-			var previewInit = new ActorPreviewInitializer(actorInfo, wr, init);
-			preview = actorInfo.TraitInfos<IRenderActorPreviewInfo>()
+			var previewInit = new ActorPreviewInitializer(ActorInfo, wr, init);
+			preview = ActorInfo.TraitInfos<IRenderActorPreviewInfo>()
 				.SelectMany(rpi => rpi.RenderPreview(previewInit))
 				.ToArray();
 		}
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override IEnumerable<IRenderable> RenderInner(WorldRenderer wr, CPos topLeft, Dictionary<CPos, PlaceBuildingCellType> footprint)
 		{
-			var centerPosition = wr.World.Map.CenterOfCell(topLeft) + centerOffset;
+			var centerPosition = wr.World.Map.CenterOfCell(topLeft) + CenterOffset;
 			var previewRenderables = preview
 				.SelectMany(p => p.Render(wr, centerPosition));
 

--- a/OpenRA.Mods.Common/Traits/Buildings/FootprintPlaceBuildingPreview.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FootprintPlaceBuildingPreview.cs
@@ -46,8 +46,8 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class FootprintPlaceBuildingPreviewPreview : IPlaceBuildingPreview
 	{
-		protected readonly ActorInfo actorInfo;
-		protected readonly WVec centerOffset;
+		protected readonly ActorInfo ActorInfo;
+		protected readonly WVec CenterOffset;
 		readonly FootprintPlaceBuildingPreviewInfo info;
 		readonly IPlaceBuildingDecorationInfo[] decorations;
 		readonly int2 topLeftScreenOffset;
@@ -56,13 +56,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		public FootprintPlaceBuildingPreviewPreview(WorldRenderer wr, ActorInfo ai, FootprintPlaceBuildingPreviewInfo info, TypeDictionary init)
 		{
-			actorInfo = ai;
+			ActorInfo = ai;
 			this.info = info;
-			decorations = actorInfo.TraitInfos<IPlaceBuildingDecorationInfo>().ToArray();
+			decorations = ActorInfo.TraitInfos<IPlaceBuildingDecorationInfo>().ToArray();
 
 			var world = wr.World;
-			centerOffset = actorInfo.TraitInfo<BuildingInfo>().CenterOffset(world);
-			topLeftScreenOffset = -wr.ScreenPxOffset(centerOffset);
+			CenterOffset = ActorInfo.TraitInfo<BuildingInfo>().CenterOffset(world);
+			topLeftScreenOffset = -wr.ScreenPxOffset(CenterOffset);
 
 			var tileset = world.Map.Tileset.ToLowerInvariant();
 			if (world.Map.Rules.Sequences.HasSequence("overlay", $"build-valid-{tileset}"))
@@ -106,9 +106,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected virtual IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, CPos topLeft)
 		{
-			var centerPosition = wr.World.Map.CenterOfCell(topLeft) + centerOffset;
+			var centerPosition = wr.World.Map.CenterOfCell(topLeft) + CenterOffset;
 			foreach (var d in decorations)
-				foreach (var r in d.RenderAnnotations(wr, wr.World, actorInfo, centerPosition))
+				foreach (var r in d.RenderAnnotations(wr, wr.World, ActorInfo, centerPosition))
 					yield return r;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/LineBuild.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/LineBuild.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 				return parents;
 
 			var sma = world.WorldActor.Trait<SpawnMapActors>();
-			return value.Select(n => sma.Actors[n]).ToArray();
+			return Value.Select(n => sma.Actors[n]).ToArray();
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/SequencePlaceBuildingPreview.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/SequencePlaceBuildingPreview.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 				foreach (var r in RenderFootprint(wr, topLeft, footprint, info.FootprintUnderPreview))
 					yield return r;
 
-			var centerPosition = wr.World.Map.CenterOfCell(topLeft) + centerOffset;
+			var centerPosition = wr.World.Map.CenterOfCell(topLeft) + CenterOffset;
 			foreach (var r in preview.Render(centerPosition, WVec.Zero, 0, palette))
 			{
 				if (info.SequenceAlpha < 1f && r is IModifyableRenderable mr)

--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -252,6 +252,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
+				var value = base.Value;
 				if (value < 0 || (value == 0 && !allowZero))
 					return 1;
 

--- a/OpenRA.Mods.Common/Traits/Render/SelectionDecorationsBase.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SelectionDecorationsBase.cs
@@ -27,11 +27,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 		IDecoration[] decorations;
 		IDecoration[] selectedDecorations;
 
-		protected readonly SelectionDecorationsBaseInfo info;
+		protected readonly SelectionDecorationsBaseInfo Info;
 
 		public SelectionDecorationsBase(SelectionDecorationsBaseInfo info)
 		{
-			this.info = info;
+			Info = info;
 		}
 
 		void INotifyCreated.Created(Actor self)
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var displayExtra = selected || rollover || (regularWorld && statusBars != StatusBarsType.Standard);
 
 			if (selected)
-				foreach (var r in RenderSelectionBox(self, wr, info.SelectionBoxColor))
+				foreach (var r in RenderSelectionBox(self, wr, Info.SelectionBoxColor))
 					yield return r;
 
 			if (displayHealth || displayExtra)

--- a/OpenRA.Mods.Common/Traits/Render/WithDecorationBase.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecorationBase.cs
@@ -57,14 +57,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 	public abstract class WithDecorationBase<InfoType> : ConditionalTrait<InfoType>, IDecoration where InfoType : WithDecorationBaseInfo
 	{
-		protected readonly Actor self;
+		protected readonly Actor Self;
 		int2 conditionalOffset;
 		BlinkState[] blinkPattern;
 
 		public WithDecorationBase(Actor self, InfoType info)
 			: base(info)
 		{
-			this.self = self;
+			Self = self;
 			blinkPattern = info.BlinkPattern;
 		}
 

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using OpenRA.Mods.Common.UpdateRules.Rules;
 
@@ -30,8 +29,6 @@ namespace OpenRA.Mods.Common.UpdateRules
 		// can be merged back into bleed by replacing the forking-playtest-to-bleed path
 		// with the prep playtest-to-playtest-to-release paths and finally a new/modified
 		// release-to-bleed path.
-		[SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines",
-			Justification = "Extracting update lists to temporary variables obfuscates the definitions.")]
 		static readonly UpdatePath[] Paths =
 		{
 			new UpdatePath("release-20200202", "release-20200503", new UpdateRule[]

--- a/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
@@ -331,7 +331,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		}
 
 		// TODO: fix this -- will have bitrotted pretty badly.
-		static readonly Dictionary<string, Color> namedColorMapping = new Dictionary<string, Color>()
+		static readonly Dictionary<string, Color> NamedColorMapping = new Dictionary<string, Color>()
 		{
 			{ "gold", Color.FromArgb(246, 214, 121) },
 			{ "blue", Color.FromArgb(226, 230, 246) },
@@ -353,7 +353,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				OwnsWorld = section == "Neutral",
 				NonCombatant = section == "Neutral",
 				Faction = faction,
-				Color = namedColorMapping[color]
+				Color = NamedColorMapping[color]
 			};
 
 			var neutral = new[] { "Neutral" };

--- a/OpenRA.Mods.Common/Widgets/Logic/SystemInfoPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SystemInfoPromptLogic.cs
@@ -11,15 +11,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	[SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1203:ConstantsMustAppearBeforeFields",
-		Justification = "SystemInformation version should be defined next to the dictionary it refers to.")]
 	public class SystemInfoPromptLogic : ChromeLogic
 	{
 		// Increment the version number when adding new stats

--- a/OpenRA.Platforms.Default/FreeTypeFont.cs
+++ b/OpenRA.Platforms.Default/FreeTypeFont.cs
@@ -17,8 +17,6 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Platforms.Default
 {
-	[SuppressMessage("Microsoft.StyleCop.CSharp.NamingRules", "SA1307:AccessibleFieldsMustBeginWithUpperCaseLetter",
-		Justification = "C-style naming is kept for consistency with the underlying native API.")]
 	[SuppressMessage("Microsoft.StyleCop.CSharp.NamingRules", "SA1310:FieldNamesMustNotContainUnderscore",
 		Justification = "C-style naming is kept for consistency with the underlying native API.")]
 	static class FreeType

--- a/OpenRA.Platforms.Default/MultiTapDetection.cs
+++ b/OpenRA.Platforms.Default/MultiTapDetection.cs
@@ -16,29 +16,29 @@ namespace OpenRA.Platforms.Default
 {
 	static class MultiTapDetection
 	{
-		static readonly Cache<(Keycode Key, Modifiers Mods), TapHistory> keyHistoryCache =
+		static readonly Cache<(Keycode Key, Modifiers Mods), TapHistory> KeyHistoryCache =
 			new Cache<(Keycode, Modifiers), TapHistory>(_ => new TapHistory(DateTime.Now - TimeSpan.FromSeconds(1)));
-		static readonly Cache<byte, TapHistory> clickHistoryCache =
+		static readonly Cache<byte, TapHistory> ClickHistoryCache =
 			new Cache<byte, TapHistory>(_ => new TapHistory(DateTime.Now - TimeSpan.FromSeconds(1)));
 
 		public static int DetectFromMouse(byte button, int2 xy)
 		{
-			return clickHistoryCache[button].GetTapCount(xy);
+			return ClickHistoryCache[button].GetTapCount(xy);
 		}
 
 		public static int InfoFromMouse(byte button)
 		{
-			return clickHistoryCache[button].LastTapCount();
+			return ClickHistoryCache[button].LastTapCount();
 		}
 
 		public static int DetectFromKeyboard(Keycode key, Modifiers mods)
 		{
-			return keyHistoryCache[(key, mods)].GetTapCount(int2.Zero);
+			return KeyHistoryCache[(key, mods)].GetTapCount(int2.Zero);
 		}
 
 		public static int InfoFromKeyboard(Keycode key, Modifiers mods)
 		{
-			return keyHistoryCache[(key, mods)].LastTapCount();
+			return KeyHistoryCache[(key, mods)].LastTapCount();
 		}
 	}
 

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -19,10 +19,9 @@ using SDL2;
 
 namespace OpenRA.Platforms.Default
 {
-	#pragma warning disable IDE1006 // Naming Styles
-	[SuppressMessage("Microsoft.StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter",
-		Justification = "C-style naming is kept for consistency with the underlying native API.")]
 	[SuppressMessage("Microsoft.StyleCop.CSharp.NamingRules", "SA1310:FieldNamesMustNotContainUnderscore",
+		Justification = "C-style naming is kept for consistency with the underlying native API.")]
+	[SuppressMessage("Style", "IDE1006:Naming Styles",
 		Justification = "C-style naming is kept for consistency with the underlying native API.")]
 	static class OpenGL
 	{

--- a/OpenRA.ruleset
+++ b/OpenRA.ruleset
@@ -18,6 +18,17 @@
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SX1101" Action="Warning" /><!-- DoNotPrefixLocalMembersWithThis -->
 
+    <!-- Rules that are covered by IDE1006 -->
+    <Rule Id="SA1300" Action="None" /><!-- ElementMustBeginWithUpperCaseLetter -->
+    <Rule Id="SA1302" Action="None" /><!-- InterfaceNamesMustBeginWithI -->
+    <Rule Id="SA1303" Action="None" /><!-- ConstFieldNamesMustBeginWithUpperCaseLetter -->
+    <Rule Id="SA1304" Action="None" /><!-- NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter -->
+    <Rule Id="SA1306" Action="None" /><!-- FieldNamesMustBeginWithLowerCaseLetter -->
+    <Rule Id="SA1307" Action="None" /><!-- AccessibleFieldsMustBeginWithUpperCaseLetter -->
+    <Rule Id="SA1311" Action="None" /><!-- StaticReadonlyFieldsMustBeginWithUpperCaseLetter -->
+    <Rule Id="SA1312" Action="None" /><!-- VariableNamesMustBeginWithLowerCaseLetter -->
+    <Rule Id="SA1313" Action="None" /><!-- ParameterNamesMustBeginWithLowerCaseLetter -->
+
     <!-- Rules that conflict with OpenRA project style conventions -->
     <Rule Id="SA0001" Action="None" /><!-- XmlCommentAnalysisDisabled -->
     <Rule Id="SA1101" Action="None" /><!-- PrefixLocalCallsWithThis -->
@@ -55,7 +66,6 @@
     <Rule Id="SA1132" Action="None" /><!-- DoNotCombineFields -->
     <Rule Id="SA1204" Action="None" /><!-- StaticElementsMustAppearBeforeInstanceElements -->
     <Rule Id="SA1214" Action="None" /><!-- ReadonlyElementsMustAppearBeforeNonReadonlyElements -->
-    <Rule Id="SA1311" Action="None" /><!-- StaticReadonlyFieldsMustBeginWithUpperCaseLetter - silenced to match IDE1006 in .editorconfig -->
     <Rule Id="SA1413" Action="None" /><!-- UseTrailingCommasInMultiLineInitializers -->
     <Rule Id="SA1516" Action="None" /><!-- ElementsMustBeSeparatedByBlankLine -->
     <Rule Id="SA1604" Action="None" /><!-- ElementDocumentationShouldHaveSummary -->


### PR DESCRIPTION
Aligns the naming conventions defined in editorconfig (dotnet_naming_style, dotnet_naming_symbols, dotnet_naming_rule) which are reported under the IDE1006 rule with the existing StyleCop rules from the SA13XX range.

This ensures the two rulesets agree when rejecting and accepting naming conventions within the IDE, with a few edges cases where only one ruleset can enforce the convention. IDE1006 allows use to specify a naming convention for type parameters, const locals and protected readonly fields which SA13XX cannot enforce. Some StyleCop SA13XX rules such as SA1309 'Field names should not begin with underscore' are not possible to enforce with the naming rules of IDE1006.

Therefore we enable the IDE1006 as a build time warning to enforce conventions and extend them. We disable SA13XX rules that can now be covered by IDE1006 to avoid double-reporting but leave the remaining SA13XX rules that cover additional cases enabled.

We also re-enable the SA1311 rule convention but enforce it via IDE1006, requiring some violations to be fixed or duplication of existing suppressions. Most violations fixes are trivial renames with the following exception. In ActorInitializer.cs, we prefer to make the fields private instead. ValueActorInit provides a publicly accessible property for access and OwnerInit provides a publicly accessible method. Health.cs is adjusted to access the property base instead when overriding. The reflection calls must be adjusted to target the base class specifically, as searching for a private field from the derived class will fail to locate it on the base class.

Unused suppressions were removed.

----

I used the following file to discover the StyleCop conventions and then ensure editorconfig enforced the same. The first namespace passes for each declaration, and the second namespaces fails for each declaration. Except for a few lines where noted where StyleCop is lax but I have chosen to enforce something in the editorconfig ruleset. It may prove useful for anybody who wishes to test this.

```c#
using System;

// Turn off some rules about unused code, etc so the only things reported in this file are style related.
#pragma warning disable CS0067
#pragma warning disable CS0168
#pragma warning disable CS0169
#pragma warning disable CS0649
#pragma warning disable CS8321
#pragma warning disable SA1403
#pragma warning disable CS0219
#pragma warning disable IDE0044
#pragma warning disable IDE0051
#pragma warning disable IDE0059
#pragma warning disable IDE0060
#pragma warning disable CA1822

// Comment/uncomment this line to test the naming rules in editorconfig.
#pragma warning disable IDE1006 // Naming Styles
namespace PascalCase
{
	class PascalCaseClass<PascalCaseTypeParameter>
	{
		public const int PascalCasePublicConstField = 0;
		const int PascalCaseConstField = 0;
		public static readonly int PascalCasePublicStaticReadonlyField;
		static readonly int PascalCaseStaticReadonlyField;
		public readonly int PascalCasePublicReadonlyField;
		readonly int camelCaseReadonlyField;
		public static int PascalCasePublicStaticField;
		static int camelCaseStaticField;
		protected static readonly int PascalCaseProtectedStaticReadonlyField;
		protected readonly int PascalCaseProtectedReadonlyField;
		protected int camelCaseProtectedField;
		internal static readonly int PascalCaseInternalStaticReadonlyField;
		internal readonly int PascalCaseInternalReadonlyField;
		internal int PascalCaseInternalField;
		int camelCaseField;
		int PascalCaseProperty { get; }
		event Action PascalCaseEvent;
		delegate void PascalCaseDelegate();

		void PascalCaseMethod(int camelCaseParameter)
		{
			const int PascalCaseConst = 0;
			int camelCaseLocal;
			void PascalCaseLocalFunction()
			{
			}
		}
	}

	interface IPascalCaseInterface
	{
	}

	struct PascalCaseStruct
	{
	}

	enum PascalCaseEnum
	{
	}
}

namespace camelCase
{
	class camelCaseClass<camelCaseTypeParameter> // StyleCop allows any casing for type parameters.
	{
		public const int camelCasePublicConstField = 0;
		const int camelCaseConstField = 0;
		public static readonly int camelCasePublicStaticReadonlyField;
		static readonly int camelCaseStaticReadonlyField;
		public readonly int camelCasePublicReadonlyField;
		readonly int PascalCaseReadonlyField;
		public static int camelCasePublicStaticField;
		static int PascalCaseStaticField;
		protected static readonly int camelCaseProtectedStaticReadonlyField;
		protected readonly int camelCaseProtectedReadonlyField; // StyleCop allows any casing for protected readonly fields.
		protected int PascalCaseProtectedField;
		internal static readonly int camelCaseInternalStaticReadonlyField;
		internal readonly int camelCaseInternalReadonlyField;
		internal int camelCaseInternalField;
		int PascalCaseField;
		int camelCaseProperty { get; }
		event Action camelCaseEvent;
		delegate void camelCaseDelegate();

		void camelCaseMethod(int PascalCaseParameter)
		{
			const int camelCaseConst = 1; // StyleCop allows any casing for local consts.
			int PascalCaseLocal;
			void camelCaseLocalFunction()
			{
			}
		}
	}

	interface PascalCaseInterface // StyleCop enforces interfaces have must begin with I prefix
	{
	}

	interface camelCaseInterface
	{
	}

	struct camelCaseStruct
	{
	}

	enum camelCaseEnum
	{
	}
}
```