### PR TITLE
Add the possibility to always show detection circles

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/RenderDetectionCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDetectionCircle.cs
@@ -44,11 +44,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 	class RenderDetectionCircle : ITick, IRenderAnnotationsWhenSelected
 	{
 		readonly RenderDetectionCircleInfo info;
+		readonly DetectCloaked[] detectCloaked;
 		WAngle lineAngle;
 
 		public RenderDetectionCircle(Actor self, RenderDetectionCircleInfo info)
 		{
 			this.info = info;
+			detectCloaked = self.TraitsImplementing<DetectCloaked>().ToArray();
 		}
 
 		IEnumerable<IRenderable> IRenderAnnotationsWhenSelected.RenderAnnotations(Actor self, WorldRenderer wr)
@@ -56,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				yield break;
 
-			var range = self.TraitsImplementing<DetectCloaked>()
+			var range = detectCloaked
 				.Select(a => a.Range)
 				.Append(WDist.Zero).Max();
 

--- a/OpenRA.Mods.Common/Traits/Render/RenderDetectionCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDetectionCircle.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of
@@ -18,7 +18,9 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
 {
-	class RenderDetectionCircleInfo : TraitInfo, Requires<DetectCloakedInfo>
+	public enum DetectionCircleVisibility { Always, WhenSelected }
+
+	public class RenderDetectionCircleInfo : TraitInfo, Requires<DetectCloakedInfo>
 	{
 		[Desc("WAngle the Radar update line advances per tick.")]
 		public readonly WAngle UpdateLineTick = new WAngle(-1);
@@ -38,10 +40,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Range circle border width.")]
 		public readonly float BorderWidth = 3;
 
+		[Desc("When to show the detection circle. Valid values are `Always`, and `WhenSelected`")]
+		public readonly DetectionCircleVisibility Visible = DetectionCircleVisibility.WhenSelected;
+
 		public override object Create(ActorInitializer init) { return new RenderDetectionCircle(init.Self, this); }
 	}
 
-	class RenderDetectionCircle : ITick, IRenderAnnotationsWhenSelected
+	public class RenderDetectionCircle : ITick, IRenderAnnotationsWhenSelected, IRenderAnnotations
 	{
 		readonly RenderDetectionCircleInfo info;
 		readonly DetectCloaked[] detectCloaked;
@@ -53,9 +58,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 			detectCloaked = self.TraitsImplementing<DetectCloaked>().ToArray();
 		}
 
-		IEnumerable<IRenderable> IRenderAnnotationsWhenSelected.RenderAnnotations(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> RenderCircle(Actor self, WorldRenderer wr, DetectionCircleVisibility visibility)
 		{
-			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))
+			if (info.Visible != visibility || !self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				yield break;
 
 			var range = detectCloaked
@@ -78,7 +83,19 @@ namespace OpenRA.Mods.Common.Traits.Render
 				info.BorderWidth);
 		}
 
+		IEnumerable<IRenderable> IRenderAnnotationsWhenSelected.RenderAnnotations(Actor self, WorldRenderer wr)
+		{
+			return RenderCircle(self, wr, DetectionCircleVisibility.WhenSelected);
+		}
+
 		bool IRenderAnnotationsWhenSelected.SpatiallyPartitionable => false;
+
+		IEnumerable<IRenderable> IRenderAnnotations.RenderAnnotations(Actor self, WorldRenderer wr)
+		{
+			return RenderCircle(self, wr, DetectionCircleVisibility.Always);
+		}
+
+		bool IRenderAnnotations.SpatiallyPartitionable => false;
 
 		void ITick.Tick(Actor self)
 		{


### PR DESCRIPTION
Closes #19830.

Testcase: Add `Visible: Always` to the `RenderDetectionCircle` traits of minelayers or subs in RA.