### PR TITLE
Add contexts for hotkey validation

### DIFF
--- a/OpenRA.Game/HotkeyDefinition.cs
+++ b/OpenRA.Game/HotkeyDefinition.cs
@@ -20,6 +20,7 @@ namespace OpenRA
 		public readonly Hotkey Default = Hotkey.Invalid;
 		public readonly string Description = "";
 		public readonly HashSet<string> Types = new HashSet<string>();
+		public readonly HashSet<string> Contexts = new HashSet<string>();
 		public bool HasDuplicates { get; internal set; }
 
 		public HotkeyDefinition(string name, MiniYaml node)
@@ -36,6 +37,10 @@ namespace OpenRA
 			var typesNode = node.Nodes.FirstOrDefault(n => n.Key == "Types");
 			if (typesNode != null)
 				Types = FieldLoader.GetValue<HashSet<string>>("Types", typesNode.Value.Value);
+
+			var contextsNode = node.Nodes.FirstOrDefault(n => n.Key == "Contexts");
+			if (contextsNode != null)
+				Contexts = FieldLoader.GetValue<HashSet<string>>("Contexts", contextsNode.Value.Value);
 		}
 	}
 }

--- a/OpenRA.Game/HotkeyManager.cs
+++ b/OpenRA.Game/HotkeyManager.cs
@@ -89,7 +89,7 @@ namespace OpenRA
 				if (kv.Key == name)
 					continue;
 
-				if (kv.Value == value && definitions[kv.Key].Types.Overlaps(definition.Types))
+				if (kv.Value == value && definitions[kv.Key].Contexts.Overlaps(definition.Contexts))
 					return definitions[kv.Key];
 			}
 

--- a/mods/cnc/hotkeys.yaml
+++ b/mods/cnc/hotkeys.yaml
@@ -1,19 +1,24 @@
 ProductionTypeBuilding: E
 	Description: Building Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 ProductionTypeDefense: R
 	Description: Defense Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 ProductionTypeInfantry: T
 	Description: Infantry Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 ProductionTypeVehicle: Y
 	Description: Vehicle Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 ProductionTypeAircraft: U
 	Description: Aircraft Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player

--- a/mods/common/hotkeys/chat.yaml
+++ b/mods/common/hotkeys/chat.yaml
@@ -1,7 +1,9 @@
 OpenTeamChat: Return
 	Description: Open Team Chat
-	Types: Chat, Player, Spectator
+	Types: Chat
+	Contexts: Player, Spectator
 
 OpenGeneralChat: Return Shift
 	Description: Open General Chat
-	Types: Chat, Player, Spectator
+	Types: Chat
+	Contexts: Player, Spectator

--- a/mods/common/hotkeys/control-groups.yaml
+++ b/mods/common/hotkeys/control-groups.yaml
@@ -1,203 +1,254 @@
 ControlGroupSelect01: NUMBER_1
 	Description: Select group 1
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupSelect02: NUMBER_2
 	Description: Select group 2
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupSelect03: NUMBER_3
 	Description: Select group 3
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupSelect04: NUMBER_4
 	Description: Select group 4
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupSelect05: NUMBER_5
 	Description: Select group 5
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupSelect06: NUMBER_6
 	Description: Select group 6
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupSelect07: NUMBER_7
 	Description: Select group 7
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupSelect08: NUMBER_8
 	Description: Select group 8
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupSelect09: NUMBER_9
 	Description: Select group 9
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupSelect10: NUMBER_0
 	Description: Select group 0
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupCreate01: NUMBER_1 Ctrl
 	Description: Create group 1
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupCreate02: NUMBER_2 Ctrl
 	Description: Create group 2
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupCreate03: NUMBER_3 Ctrl
 	Description: Create group 3
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupCreate04: NUMBER_4 Ctrl
 	Description: Create group 4
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupCreate05: NUMBER_5 Ctrl
 	Description: Create group 5
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupCreate06: NUMBER_6 Ctrl
 	Description: Create group 6
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupCreate07: NUMBER_7 Ctrl
 	Description: Create group 7
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupCreate08: NUMBER_8 Ctrl
 	Description: Create group 8
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupCreate09: NUMBER_9 Ctrl
 	Description: Create group 9
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupCreate10: NUMBER_0 Ctrl
 	Description: Create group 0
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupAddTo01: NUMBER_1 Ctrl, Shift
 	Description: Add to group 1
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupAddTo02: NUMBER_2 Ctrl, Shift
 	Description: Add to group 2
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupAddTo03: NUMBER_3 Ctrl, Shift
 	Description: Add to group 3
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupAddTo04: NUMBER_4 Ctrl, Shift
 	Description: Add to group 4
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupAddTo05: NUMBER_5 Ctrl, Shift
 	Description: Add to group 5
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupAddTo06: NUMBER_6 Ctrl, Shift
 	Description: Add to group 6
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupAddTo07: NUMBER_7 Ctrl, Shift
 	Description: Add to group 7
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupAddTo08: NUMBER_8 Ctrl, Shift
 	Description: Add to group 8
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupAddTo09: NUMBER_9 Ctrl, Shift
 	Description: Add to group 9
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupAddTo10: NUMBER_0 Ctrl, Shift
 	Description: Add to group 0
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupCombineWith01: NUMBER_1 Shift
 	Description: Combine with group 1
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupCombineWith02: NUMBER_2 Shift
 	Description: Combine with group 2
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupCombineWith03: NUMBER_3 Shift
 	Description: Combine with group 3
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupCombineWith04: NUMBER_4 Shift
 	Description: Combine with group 4
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupCombineWith05: NUMBER_5 Shift
 	Description: Combine with group 5
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupCombineWith06: NUMBER_6 Shift
 	Description: Combine with group 6
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupCombineWith07: NUMBER_7 Shift
 	Description: Combine with group 7
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupCombineWith08: NUMBER_8 Shift
 	Description: Combine with group 8
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupCombineWith09: NUMBER_9 Shift
 	Description: Combine with group 9
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupCombineWith10: NUMBER_0 Shift
 	Description: Combine with group 0
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupJumpTo01: NUMBER_1 Alt
 	Description: Jump to group 1
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupJumpTo02: NUMBER_2 Alt
 	Description: Jump to group 2
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupJumpTo03: NUMBER_3 Alt
 	Description: Jump to group 3
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupJumpTo04: NUMBER_4 Alt
 	Description: Jump to group 4
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupJumpTo05: NUMBER_5 Alt
 	Description: Jump to group 5
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupJumpTo06: NUMBER_6 Alt
 	Description: Jump to group 6
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupJumpTo07: NUMBER_7 Alt
 	Description: Jump to group 7
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupJumpTo08: NUMBER_8 Alt
 	Description: Jump to group 8
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupJumpTo09: NUMBER_9 Alt
 	Description: Jump to group 9
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 ControlGroupJumpTo10: NUMBER_0 Alt
 	Description: Jump to group 0
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player
 
 RemoveFromControlGroup:
 	Description: Remove from control group
-	Types: ControlGroups, Player
+	Types: ControlGroups
+	Contexts: Player, Spectator

--- a/mods/common/hotkeys/game.yaml
+++ b/mods/common/hotkeys/game.yaml
@@ -1,107 +1,134 @@
 CycleBase: H
 	Description: Jump to base
-	Types: World, Player, Spectator
+	Types: World
+	Contexts: Player, Spectator
 
 ToLastEvent: SPACE
 	Description: Jump to last radar event
-	Types: World, Player, Spectator
+	Types: World
+	Contexts: Player, Spectator
 
 ToSelection: HOME
 	Description: Jump to selection
-	Types: World, Player, Spectator
+	Types: World
+	Contexts: Player, Spectator
 
 SelectAllUnits: Q
 	Description: Select all combat units
-	Types: World, Player, Spectator
+	Types: World
+	Contexts: Player, Spectator
 
 SelectUnitsByType: W
 	Description: Select units by type
-	Types: World, Player, Spectator
+	Types: World
+	Contexts: Player, Spectator
 
 CycleHarvesters: N
 	Description: Cycle Harvesters
-	Types: World, Player, Spectator
+	Types: World
+	Contexts: Player, Spectator
 
 Pause: PAUSE
 	Description: Pause / Unpause
-	Types: World, Player, Spectator
+	Types: World
+	Contexts: Player, Spectator
 
 Sell: Z
 	Description: Sell mode
-	Types: OrderGenerator, Player
+	Types: OrderGenerator
+	Contexts: Player
 
 Repair: C
 	Description: Repair mode
-	Types: OrderGenerator, Player
+	Types: OrderGenerator
+	Contexts: Player
 
 PlaceBeacon: B
 	Description: Place beacon
-	Types: OrderGenerator, Player, Spectator
+	Types: OrderGenerator
+	Contexts: Player
 
 CycleStatusBars: COMMA
 	Description: Cycle status bars display
-	Types: World, Player, Spectator
+	Types: World
+	Contexts: Player, Spectator
 
 ToggleMute: M
 	Description: Toggle audio mute
-	Types: World, Menu, Player, Spectator
+	Types: World
+	Contexts: Menu, Player, Spectator
 
 TogglePlayerStanceColor: COMMA Ctrl
 	Description: Toggle player stance colors
-	Types: World, Player, Spectator
+	Types: World
+	Contexts: Player, Spectator
 
 TakeScreenshot: P Ctrl
 	Description: Take screenshot
-	Types: World, Menu, Player, Spectator
+	Types: World
+	Contexts: Menu, Player, Spectator
 
 AttackMove: A
 	Description: Attack Move
-	Types: Unit, Player
+	Types: Unit
+	Contexts: Player
 
 Stop: S
 	Description: Stop
-	Types: Unit, Player
+	Types: Unit
+	Contexts: Player
 
 Scatter: X Ctrl
 	Description: Scatter
-	Types: Unit, Player
+	Types: Unit
+	Contexts: Player
 
 Deploy: F
 	Description: Deploy
-	Types: Unit, Player
+	Types: Unit
+	Contexts: Player
 
 Guard: D
 	Description: Guard
-	Types: Unit, Player
+	Types: Unit
+	Contexts: Player
 
 StanceAttackAnything: A Alt
 	Description: Attack anything
-	Types: Stance, Player
+	Types: Stance
+	Contexts: Player
 
 StanceDefend: S Alt
 	Description: Defend
-	Types: Stance, Player
+	Types: Stance
+	Contexts: Player
 
 StanceReturnFire: D Alt
 	Description: Return fire
-	Types: Stance, Player
+	Types: Stance
+	Contexts: Player
 
 StanceHoldFire: F Alt
 	Description: Hold fire
-	Types: Stance, Player
+	Types: Stance
+	Contexts: Player
 
 StopMusic: AUDIOSTOP
 	Description: Stop
-	Types: Music, Player, Spectator
+	Types: Music
+	Contexts: Menu, Player, Spectator
 
 PauseMusic: AUDIOPLAY
 	Description: Pause or Resume
-	Types: Music, Player, Spectator
+	Types: Music
+	Contexts: Menu, Player, Spectator
 
 PrevMusic: AUDIOPREV
 	Description: Previous
-	Types: Music, Player, Spectator
+	Types: Music
+	Contexts: Menu, Player, Spectator
 
 NextMusic: AUDIONEXT
 	Description: Next
-	Types: Music, Player, Spectator
+	Types: Music
+	Contexts: Menu, Player, Spectator

--- a/mods/common/hotkeys/observer.yaml
+++ b/mods/common/hotkeys/observer.yaml
@@ -1,59 +1,74 @@
 ObserverCombinedView: MINUS
 	Description: All Players
-	Types: Observer, Spectator
+	Types: Observer
+	Contexts: Spectator
 
 ObserverWorldView: EQUALS
 	Description: Disable Shroud
-	Types: Observer, Spectator
+	Types: Observer
+	Contexts: Spectator
 
 ReplaySpeedSlow: F9
 	Description: Slow speed
-	Types: Replay, Spectator
+	Types: Replay
+	Contexts: Spectator
 
 ReplaySpeedRegular: F10
 	Description: Regular speed
-	Types: Replay, Spectator
+	Types: Replay
+	Contexts: Spectator
 
 ReplaySpeedFast: F11
 	Description: Fast speed
-	Types: Replay, Spectator
+	Types: Replay
+	Contexts: Spectator
 
 ReplaySpeedMax: F12
 	Description: Maximum speed
-	Types: Replay, Spectator
+	Types: Replay
+	Contexts: Spectator
 
 StatisticsNone: F1
 	Description: Disable statistics
-	Types: Observer, Replay
+	Types: Observer
+	Contexts: Spectator
 
 StatisticsBasic: F2
 	Description: Basic statistics
-	Types: Observer, Replay, Spectator
+	Types: Observer
+	Contexts: Spectator
 
 StatisticsEconomy: F3
 	Description: Economy statistics
-	Types: Observer, Replay, Spectator
+	Types: Observer
+	Contexts: Spectator
 
 StatisticsProduction: F4
 	Description: Production statistics
-	Types: Observer, Replay, Spectator
+	Types: Observer
+	Contexts: Spectator
 
 StatisticsSupportPowers: F5
 	Description: Support Power statistics
-	Types: Observer, Replay
+	Types: Observer
+	Contexts: Spectator
 
 StatisticsCombat: F6
 	Description: Combat statistics
-	Types: Observer, Replay, Spectator
+	Types: Observer
+	Contexts: Spectator
 
 StatisticsArmy: F7
 	Description: Army statistics
-	Types: Observer, Replay, Spectator
+	Types: Observer
+	Contexts: Spectator
 
 StatisticsGraph:
 	Description: Statistics graph
-	Types: Observer, Replay, Spectator
+	Types: Observer
+	Contexts: Spectator
 
 StatisticsArmyGraph:
 	Description: Army value graph
-	Types: Observer, Replay, Spectator
+	Types: Observer
+	Contexts: Spectator

--- a/mods/common/hotkeys/production-common.yaml
+++ b/mods/common/hotkeys/production-common.yaml
@@ -1,103 +1,129 @@
 CycleProductionBuildings: TAB Ctrl
 	Description: Next facility
-	Types: Production, Player, Spectator
+	Types: Production
+	Contexts: Player, Spectator
 
 SelectProductionBuilding: TAB
 	Description: Current facility
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 Production01: F1
 	Description: Slot 01
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production02: F2
 	Description: Slot 02
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production03: F3
 	Description: Slot 03
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production04: F4
 	Description: Slot 04
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production05: F5
 	Description: Slot 05
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production06: F6
 	Description: Slot 06
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production07: F7
 	Description: Slot 07
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production08: F8
 	Description: Slot 08
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production09: F9
 	Description: Slot 09
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production10: F10
 	Description: Slot 10
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production11: F11
 	Description: Slot 11
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production12: F12
 	Description: Slot 12
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production13: F1 CTRL
 	Description: Slot 13
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production14: F2 CTRL
 	Description: Slot 14
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production15: F3 CTRL
 	Description: Slot 15
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production16: F4 CTRL
 	Description: Slot 16
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production17: F5 CTRL
 	Description: Slot 17
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production18: F6 CTRL
 	Description: Slot 18
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production19: F7 CTRL
 	Description: Slot 19
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production20: F8 CTRL
 	Description: Slot 20
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production21: F9 CTRL
 	Description: Slot 21
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production22: F10 CTRL
 	Description: Slot 22
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production23: F11 CTRL
 	Description: Slot 23
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player
 
 Production24: F12 CTRL
 	Description: Slot 24
-	Types: ProductionSlot, Player
+	Types: ProductionSlot
+	Contexts: Player

--- a/mods/common/hotkeys/production-peractor.yaml
+++ b/mods/common/hotkeys/production-peractor.yaml
@@ -1,7 +1,9 @@
 NextProductionTab: PAGEDOWN
 	Description: Next tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 PreviousProductionTab: PAGEUP
 	Description: Previous tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player

--- a/mods/common/hotkeys/supportpowers.yaml
+++ b/mods/common/hotkeys/supportpowers.yaml
@@ -1,23 +1,29 @@
 SupportPower01:
 	Description: Slot 01
-	Types: SupportPower, Player
+	Types: SupportPower
+	Contexts: Player
 
 SupportPower02:
 	Description: Slot 02
-	Types: SupportPower, Player
+	Types: SupportPower
+	Contexts: Player
 
 SupportPower03:
 	Description: Slot 03
-	Types: SupportPower, Player
+	Types: SupportPower
+	Contexts: Player
 
 SupportPower04:
 	Description: Slot 04
-	Types: SupportPower, Player
+	Types: SupportPower
+	Contexts: Player
 
 SupportPower05:
 	Description: Slot 05
-	Types: SupportPower, Player
+	Types: SupportPower
+	Contexts: Player
 
 SupportPower06:
 	Description: Slot 06
-	Types: SupportPower, Player
+	Types: SupportPower
+	Contexts: Player

--- a/mods/common/hotkeys/viewport.yaml
+++ b/mods/common/hotkeys/viewport.yaml
@@ -1,75 +1,94 @@
 MapScrollUp: UP
 	Description: Scroll up
-	Types: Viewport, Player, Spectator
+	Types: Viewport
+	Contexts: Player, Spectator, Editor
 
 MapScrollDown: DOWN
 	Description: Scroll down
-	Types: Viewport, Player, Spectator
+	Types: Viewport
+	Contexts: Player, Spectator, Editor
 
 MapScrollLeft: LEFT
 	Description: Scroll left
-	Types: Viewport, Player, Spectator
+	Types: Viewport
+	Contexts: Player, Spectator, Editor
 
 MapScrollRight: RIGHT
 	Description: Scroll right
-	Types: Viewport, Player, Spectator
+	Types: Viewport
+	Contexts: Player, Spectator, Editor
 
 MapJumpToTopEdge: UP Alt
 	Description: Jump to top edge
-	Types: Viewport, Player, Spectator
+	Types: Viewport
+	Contexts: Player, Spectator, Editor
 
 MapJumpToBottomEdge: DOWN Alt
 	Description: Jump to bottom edge
-	Types: Viewport, Player, Spectator
+	Types: Viewport
+	Contexts: Player, Spectator, Editor
 
 MapJumpToLeftEdge: LEFT Alt
 	Description: Jump to left edge
-	Types: Viewport, Player, Spectator
+	Types: Viewport
+	Contexts: Player, Spectator, Editor
 
 MapJumpToRightEdge: RIGHT Alt
 	Description: Jump to right edge
-	Types: Viewport, Player, Spectator
+	Types: Viewport
+	Contexts: Player, Spectator, Editor
 
 MapBookmarkSave01: Q Ctrl
 	Description: Record bookmark 1
-	Types: Viewport, Player, Spectator
+	Types: Viewport
+	Contexts: Player, Spectator, Editor
 
 MapBookmarkRestore01: Q Alt
 	Description: Jump to bookmark 1
-	Types: Viewport, Player, Spectator
+	Types: Viewport
+	Contexts: Player, Spectator, Editor
 
 MapBookmarkSave02: W Ctrl
 	Description: Record bookmark 2
-	Types: Viewport, Player, Spectator
+	Types: Viewport
+	Contexts: Player, Spectator, Editor
 
 MapBookmarkRestore02: W Alt
 	Description: Jump to bookmark 2
-	Types: Viewport, Player, Spectator
+	Types: Viewport
+	Contexts: Player, Spectator, Editor
 
 MapBookmarkSave03: E Ctrl
 	Description: Record bookmark 3
-	Types: Viewport, Player, Spectator
+	Types: Viewport
+	Contexts: Player, Spectator, Editor
 
 MapBookmarkRestore03: E Alt
 	Description: Jump to bookmark 3
-	Types: Viewport, Player, Spectator
+	Types: Viewport
+	Contexts: Player, Spectator, Editor
 
 MapBookmarkSave04: R Ctrl
 	Description: Record bookmark 4
-	Types: Viewport, Player, Spectator
+	Types: Viewport
+	Contexts: Player, Spectator, Editor
 
 MapBookmarkRestore04: R Alt
 	Description: Jump to bookmark 4
-	Types: Viewport, Player, Spectator
+	Types: Viewport
+	Contexts: Player, Spectator, Editor
 
 ZoomIn: RIGHTBRACKET
 	Description: Zoom in
-	Types: Viewport, Player, Spectator
+	Types: Viewport
+	Contexts: Player, Spectator, Editor
 
 ZoomOut: LEFTBRACKET
 	Description: Zoom out
-	Types: Viewport, Player, Spectator
+	Types: Viewport
+	Contexts: Player, Spectator, Editor
 
 ResetZoom: PERIOD
 	Description: Reset zoom
-	Types: Viewport, Player, Spectator
+	Types: Viewport
+	Contexts: Player, Spectator, Editor

--- a/mods/d2k/hotkeys.yaml
+++ b/mods/d2k/hotkeys.yaml
@@ -1,31 +1,39 @@
 ProductionTypeBuilding: E
 	Description: Building Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 ProductionTypeUpgrade: R
 	Description: Upgrade Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 ProductionTypeInfantry: T
 	Description: Infantry Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 ProductionTypeVehicle: Y
 	Description: Vehicle Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 ProductionTypeAircraft: U
 	Description: Aircraft Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 ProductionTypeTank: I
 	Description: Tank Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 ProductionTypeMerchant: O
 	Description: Starport Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 PowerDown: X
 	Description: Power-down mode
-	Types: OrderGenerator, Player
+	Types: OrderGenerator
+	Contexts: Player

--- a/mods/ra/hotkeys.yaml
+++ b/mods/ra/hotkeys.yaml
@@ -1,27 +1,34 @@
 ProductionTypeBuilding: E
 	Description: Building Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 ProductionTypeDefense: R
 	Description: Defense Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 ProductionTypeInfantry: T
 	Description: Infantry Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 ProductionTypeVehicle: Y
 	Description: Vehicle Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 ProductionTypeAircraft: U
 	Description: Aircraft Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 ProductionTypeNaval: I
 	Description: Naval Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 PowerDown: X
 	Description: Power-down mode
-	Types: OrderGenerator, Player
+	Types: OrderGenerator
+	Contexts: Player

--- a/mods/ts/hotkeys.yaml
+++ b/mods/ts/hotkeys.yaml
@@ -1,43 +1,54 @@
 ProductionTypeBuilding: E
 	Description: Building Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 ProductionTypeDefense: R
 	Description: Defense Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 ProductionTypeInfantry: T
 	Description: Infantry Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 ProductionTypeVehicle: Y
 	Description: Vehicle Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 ProductionTypeAircraft: U
 	Description: Aircraft Tab
-	Types: Production, Player
+	Types: Production
+	Contexts: Player
 
 PowerDown: X
 	Description: Power-down mode
-	Types: OrderGenerator, Player
+	Types: OrderGenerator
+	Contexts: Player
 
 DecreaseDepthPreviewContrast: LEFTBRACKET SHIFT
 	Description: Decrease Contrast
 	Types: DepthDebug
+	Contexts: Player
 
 IncreaseDepthPreviewContrast: RIGHTBRACKET SHIFT
 	Description: Increase Contrast
 	Types: DepthDebug
+	Contexts: Player
 
 DecreaseDepthPreviewOffset: SEMICOLON SHIFT
 	Description: Decrease Offset
 	Types: DepthDebug
+	Contexts: Player
 
 IncreaseDepthPreviewOffset: QUOTE SHIFT
 	Description: Increase Offset
 	Types: DepthDebug
+	Contexts: Player
 
 ToggleDepthPreview: BACKSLASH SHIFT
 	Description: Toggle Preview
 	Types: DepthDebug
+	Contexts: Player


### PR DESCRIPTION
This implements the logic for hotkey contexts. It adds a `Contexts` field to hotkeys which is used for validation (i.e. hotkeys that share a context cannot overlap). The `Types` field is now used solely for grouping in the settings panel. 

The code changes here are fairly simple, the bulk of the diff is yaml and I used the opportunity to review whether hotkeys are added to the relevant contexts. I pondered at adding a "Replay" context (because of the replay speed keys) but I decided to keep it simple and just use the "Spectator" context.

This is the first part of  #19898. The other (and trickier part) is to implement a UI for the settings panel that displays the contexts to the user. 