### PR TITLE
Make editor overlay dropdown optional and crash when BuildableTerrainOverlay trait is missing

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
@@ -144,17 +144,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				if (cat.HasFlag(MapOverlays.Buildable))
 				{
-					var buildableTerrainTrait = world.WorldActor.TraitOrDefault<BuildableTerrainOverlay>();
-					if (buildableTerrainTrait != null)
+					var buildableTerrainTrait = world.WorldActor.Trait<BuildableTerrainOverlay>();
+					category.OnClick = () =>
 					{
-						category.OnClick = () =>
-						{
-							overlays ^= cat;
-							buildableTerrainTrait.Enabled = overlays.HasFlag(MapOverlays.Buildable);
-						};
-					}
-					else
-						continue;
+						overlays ^= cat;
+						buildableTerrainTrait.Enabled = overlays.HasFlag(MapOverlays.Buildable);
+					};
 				}
 
 				categoriesPanel.AddChild(category);

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
@@ -71,12 +71,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				};
 			}
 
-			var copyOverlayDropdown = widget.Get<DropDownButtonWidget>("OVERLAY_BUTTON");
-			copyOverlayDropdown.OnMouseDown = _ =>
+			var overlayDropdown = widget.GetOrNull<DropDownButtonWidget>("OVERLAY_BUTTON");
+			if (overlayDropdown != null)
 			{
-				copyOverlayDropdown.RemovePanel();
-				copyOverlayDropdown.AttachPanel(CreateOverlaysPanel(world));
-			};
+				overlayDropdown.OnMouseDown = _ =>
+				{
+					overlayDropdown.RemovePanel();
+					overlayDropdown.AttachPanel(CreateOverlaysPanel(world));
+				};
+			}
 
 			var cashLabel = widget.GetOrNull<LabelWidget>("CASH_LABEL");
 			if (cashLabel != null)


### PR DESCRIPTION
follow up to #19895 

now instead of Buildable checkbox not appearing the game will crash with the log

> Exception of type \`System.InvalidOperationException\`: Actor editorworld does not have trait of type \`OpenRA.Mods.Common.Traits.BuildableTerrainOverlay\`