### PR TITLE
Use more efficient search in MergeIntoResolved

### DIFF
--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -338,7 +338,7 @@ namespace OpenRA
 		static void MergeIntoResolved(MiniYamlNode overrideNode, List<MiniYamlNode> existingNodes,
 			Dictionary<string, MiniYaml> tree, Dictionary<string, MiniYamlNode.SourceLocation> inherited)
 		{
-			var existingNode = existingNodes.FirstOrDefault(n => n.Key == overrideNode.Key);
+			var existingNode = existingNodes.Find(n => n.Key == overrideNode.Key);
 			if (existingNode != null)
 			{
 				existingNode.Value = MergePartial(existingNode.Value, overrideNode.Value);


### PR DESCRIPTION
Switch Enumerable.FirstOrDefault to List.Find. The latter can avoid some allocations because the concrete collection type is known.

This saves some allocations in MiniYaml parsing.