### PR TITLE
Change terrain type of clear straight bridge tiles

### DIFF
--- a/mods/ra/tilesets/temperat.yaml
+++ b/mods/ra/tilesets/temperat.yaml
@@ -3226,7 +3226,7 @@ Templates:
 			2: Clear
 			9: Clear
 			10: Road
-			11: Rock
+			11: Clear
 	Template@520:
 		Id: 520
 		Images: sbridge1.tem
@@ -3417,12 +3417,12 @@ Templates:
 		Size: 4,4
 		Categories: Bridge
 		Tiles:
-			0: Clear
-			3: Rock
+			0: Rough
+			3: Rough
 			4: Road
 			7: Road
-			8: Clear
-			11: Rock
+			8: Rough
+			11: Rough
 			12: Clear
 			13: River
 			14: River


### PR DESCRIPTION
@Therapist1911 has been working on HD assets for RA, and brought up the issue of our North-South and East-West bridges. Namely, that a few tiles that certainly appear to be passable are blocked.

The East-West bridge in particular looks like the bridge railing overlaps a bit, so I've made them all rough tiles instead of clear. This will allow unit movement but prevent building.

![image](https://user-images.githubusercontent.com/23546299/151679507-185d1c90-abaf-42a4-afe4-a4fb7e39d8fd.png)
