### PR TITLE
Clean up usage of DomainIndex

### DIFF
--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -24,7 +24,6 @@ namespace OpenRA.Mods.Common.Activities
 		readonly HarvesterInfo harvInfo;
 		readonly Mobile mobile;
 		readonly ResourceClaimLayer claimLayer;
-		readonly DomainIndex domainIndex;
 
 		Actor deliverActor;
 		CPos? orderLocation;
@@ -41,7 +40,6 @@ namespace OpenRA.Mods.Common.Activities
 			harvInfo = self.Info.TraitInfo<HarvesterInfo>();
 			mobile = self.Trait<Mobile>();
 			claimLayer = self.World.WorldActor.Trait<ResourceClaimLayer>();
-			domainIndex = self.World.WorldActor.Trait<DomainIndex>();
 			this.deliverActor = deliverActor;
 		}
 
@@ -188,7 +186,6 @@ namespace OpenRA.Mods.Common.Activities
 			using (var search = PathSearch.ToTargetCellByPredicate(
 				self.World, mobile.Locomotor, self, new[] { searchFromLoc, self.Location },
 				loc =>
-					domainIndex.IsPassable(self.Location, loc, mobile.Locomotor) &&
 					harv.CanHarvestCell(self, loc) &&
 					claimLayer.CanClaimCell(self, loc),
 				BlockedByActor.Stationary,

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -22,7 +22,6 @@ namespace OpenRA.Mods.Common.Activities
 	public class MoveAdjacentTo : Activity
 	{
 		protected readonly Mobile Mobile;
-		readonly DomainIndex domainIndex;
 		readonly Color? targetLineColor;
 
 		protected Target Target => useLastVisibleTarget ? lastVisibleTarget : target;
@@ -37,7 +36,6 @@ namespace OpenRA.Mods.Common.Activities
 			this.target = target;
 			this.targetLineColor = targetLineColor;
 			Mobile = self.Trait<Mobile>();
-			domainIndex = self.World.WorldActor.Trait<DomainIndex>();
 			ChildHasPriority = false;
 
 			// The target may become hidden between the initial order request and the first tick (e.g. if queued)
@@ -123,7 +121,7 @@ namespace OpenRA.Mods.Common.Activities
 				searchCells.Clear();
 				searchCellsTick = self.World.WorldTick;
 				foreach (var cell in CandidateMovementCells(self))
-					if (domainIndex.IsPassable(loc, cell, Mobile.Locomotor) && Mobile.CanEnterCell(cell))
+					if (Mobile.CanEnterCell(cell))
 						searchCells.Add(cell);
 			}
 

--- a/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
@@ -25,12 +25,9 @@ namespace OpenRA.Mods.Common.Scripting
 	[ScriptGlobal("Reinforcements")]
 	public class ReinforcementsGlobal : ScriptGlobal
 	{
-		readonly DomainIndex domainIndex;
-
 		public ReinforcementsGlobal(ScriptContext context)
 			: base(context)
 		{
-			domainIndex = context.World.WorldActor.Trait<DomainIndex>();
 		}
 
 		Actor CreateActor(Player owner, string actorType, bool addToWorld, CPos? entryLocation = null, CPos? nextLocation = null)

--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -62,7 +62,6 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Dictionary<Actor, HarvesterTraitWrapper> harvesters = new Dictionary<Actor, HarvesterTraitWrapper>();
 
 		IPathFinder pathfinder;
-		DomainIndex domainIndex;
 		IResourceLayer resourceLayer;
 		ResourceClaimLayer claimLayer;
 		IBotRequestUnitProduction[] requestUnitProduction;
@@ -84,7 +83,6 @@ namespace OpenRA.Mods.Common.Traits
 		protected override void TraitEnabled(Actor self)
 		{
 			pathfinder = world.WorldActor.Trait<IPathFinder>();
-			domainIndex = world.WorldActor.Trait<DomainIndex>();
 			resourceLayer = world.WorldActor.TraitOrDefault<IResourceLayer>();
 			claimLayer = world.WorldActor.TraitOrDefault<ResourceClaimLayer>();
 
@@ -145,7 +143,6 @@ namespace OpenRA.Mods.Common.Traits
 		Target FindNextResource(Actor actor, HarvesterTraitWrapper harv)
 		{
 			Func<CPos, bool> isValidResource = cell =>
-				domainIndex.IsPassable(actor.Location, cell, harv.Locomotor) &&
 				harv.Harvester.CanHarvestCell(actor, cell) &&
 				claimLayer.CanClaimCell(actor, cell);
 

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -325,8 +325,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			// If this bridge repair operation connects two pathfinding domains,
 			// update the domain index.
-			var domainIndex = self.World.WorldActor.TraitOrDefault<DomainIndex>();
-			domainIndex?.UpdateCells(self.World, footprint.Keys);
+			var domainIndex = self.World.WorldActor.Trait<DomainIndex>();
+			domainIndex.UpdateCells(self.World, footprint.Keys);
 
 			if (LongBridgeSegmentIsDead() && !killedUnits)
 			{

--- a/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var cell in cells)
 				self.World.Map.CustomTerrain[cell] = terrainIndex;
 
-			self.World.WorldActor.TraitOrDefault<DomainIndex>()?.UpdateCells(self.World, cells);
+			self.World.WorldActor.Trait<DomainIndex>().UpdateCells(self.World, cells);
 		}
 
 		void INotifyAddedToWorld.AddedToWorld(Actor self)


### PR DESCRIPTION
- When a path search is being performed the path search will not attempt route to inaccessible cells, so domain index checks to avoid inaccessible cells in the search predicate are redundant and can be removed.
- DomainIndex is a required world trait, so we don't need to use TraitOrDefault and therefore can avoid dealing with the null case.