### PR TITLE
Move BlockedByActor, IPositionableInfo, IPositionable to Mods.Common.

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -37,62 +37,6 @@ namespace OpenRA.Traits
 	}
 
 	/// <summary>
-	/// When performing locomotion or pathfinding related checks,
-	/// determines whether the blocking rules will be applied when encountering other actors.
-	/// </summary>
-	public enum BlockedByActor
-	{
-		/// <summary>
-		/// Actors on the map are ignored, as if they were not present.
-		/// An actor can only be blocked by impassable terrain.
-		/// An actor can never be blocked by other actors. The blocking rules will never be evaluated.
-		/// </summary>
-		None,
-
-		/// <summary>
-		/// Actors on the map that are moving, or moveable &amp; allied are ignored.
-		/// An actor is Immovable is any of the following applies:
-		/// <list type="bullet">
-		/// <item>Lacks the Mobile trait.</item>
-		/// <item>The Mobile trait is disabled or paused.</item>
-		/// <item>The Mobile trait property IsImmovable is true.</item>
-		/// </list>
-		/// Note the above definition means an actor can be Movable, but may not be Moving, i.e. it is Stationary.
-		/// Actors are allied if their owners have the <see cref="PlayerRelationship.Ally"/> relationship.
-		/// An actor can be blocked by impassable terrain.
-		/// An actor can be blocked by immovable actors *if* they are deemed as blocking by the blocking rules.
-		/// An actor can be blocked by an actor capable of moving, if it is not an ally and *if* they are deemed as
-		/// blocking by the blocking rules.
-		/// An actor can never be blocked by an allied actor capable of moving, even if the other actor is stationary.
-		/// An actor can never be blocked by a moving actor.
-		/// </summary>
-		Immovable,
-
-		/// <summary>
-		/// Actors on the map that are moving are ignored.
-		/// An actor is moving if both of the following apply:
-		/// <list type="bullet">
-		/// <item>It is a Moveable actor (see <see cref="Immovable"/>).</item>
-		/// <item>The Mobile trait property CurrentMovementTypes contains the flag Horizontal.</item>
-		/// </list>
-		/// Otherwise the actor is deemed to be Stationary.
-		/// An actor can be blocked by impassable terrain.
-		/// An actor can be blocked by immovable actors and stationary actors *if* they are deemed as blocking by the
-		/// blocking rules.
-		/// An actor can never be blocked by a moving actor.
-		/// </summary>
-		Stationary,
-
-		/// <summary>
-		/// Actors on the map are not ignored.
-		/// An actor can be blocked by impassable terrain.
-		/// An actor can be blocked by immovable actors, stationary actors and moving actors *if* they are deemed as
-		/// blocking by the blocking rules.
-		/// </summary>
-		All
-	}
-
-	/// <summary>
 	/// Type tag for DamageTypes <see cref="Primitives.BitSet{T}"/>.
 	/// </summary>
 	public sealed class DamageType { DamageType() { } }
@@ -338,23 +282,6 @@ namespace OpenRA.Traits
 
 	public enum SubCell : byte { Invalid = byte.MaxValue, Any = byte.MaxValue - 1, FullCell = 0, First = 1 }
 
-	public interface IPositionableInfo : IOccupySpaceInfo
-	{
-		bool CanEnterCell(World world, Actor self, CPos cell, SubCell subCell = SubCell.FullCell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All);
-	}
-
-	public interface IPositionable : IOccupySpace
-	{
-		bool CanExistInCell(CPos location);
-		bool IsLeavingCell(CPos location, SubCell subCell = SubCell.Any);
-		bool CanEnterCell(CPos location, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All);
-		SubCell GetValidSubCell(SubCell preferred = SubCell.Any);
-		SubCell GetAvailableSubCell(CPos location, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All);
-		void SetPosition(Actor self, CPos cell, SubCell subCell = SubCell.Any);
-		void SetPosition(Actor self, WPos pos);
-		void SetCenterPosition(Actor self, WPos pos);
-	}
-
 	public interface ITemporaryBlockerInfo : ITraitInfoInterface { }
 
 	[RequireExplicitImplementation]
@@ -566,7 +493,6 @@ namespace OpenRA.Traits
 	public interface ITargetablePositions
 	{
 		IEnumerable<WPos> TargetablePositions(Actor self);
-		bool AlwaysEnabled { get; }
 	}
 
 	public interface IMoveInfo : ITraitInfoInterface

--- a/OpenRA.Mods.Common/Activities/Parachute.cs
+++ b/OpenRA.Mods.Common/Activities/Parachute.cs
@@ -11,7 +11,6 @@
 
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {

--- a/OpenRA.Mods.Common/Activities/SimpleTeleport.cs
+++ b/OpenRA.Mods.Common/Activities/SimpleTeleport.cs
@@ -10,7 +10,7 @@
 #endregion
 
 using OpenRA.Activities;
-using OpenRA.Traits;
+using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {

--- a/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
@@ -13,7 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Pathfinder
 {

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -15,7 +15,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Pathfinder
 {


### PR DESCRIPTION
Actor previously cached targetable locations for static actors as an optimization. As we can no longer reference the IPositionable interface, move this optimization to HitShape instead. Although we lose some of the efficiency of caching the final result on the actor, we gain some by allowing HitShape to cache the results as long as they have not changed. So instead of being limited to static actors, we can extend the caching to currently stationary actor.

As suggested in https://github.com/OpenRA/OpenRA/pull/19913#issuecomment-1025157731