### PR TITLE
Implement further customisation options for ProductionIconOverlays.

### DIFF
--- a/OpenRA.Mods.Common/Traits/ProducibleWithLevel.cs
+++ b/OpenRA.Mods.Common/Traits/ProducibleWithLevel.cs
@@ -15,8 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Actors possessing this trait should define the GainsExperience trait. When the prerequisites are fulfilled, ",
-		"this trait grants a level-up to newly spawned actors. If additionally the actor's owning player defines the ProductionIconOverlay ",
-		"trait, the production queue icon renders with an overlay defined in that trait.")]
+		"this trait grants a level-up to newly spawned actors.")]
 	public class ProducibleWithLevelInfo : TraitInfo, Requires<GainsExperienceInfo>
 	{
 		public readonly string[] Prerequisites = Array.Empty<string>();

--- a/OpenRA.Mods.Common/Traits/Render/ProductionIconOverlayManager.cs
+++ b/OpenRA.Mods.Common/Traits/Render/ProductionIconOverlayManager.cs
@@ -10,17 +10,20 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[TraitLocation(SystemActors.Player)]
-	[Desc("Attach this to the player actor. When attached, enables all actors possessing the ProducibleWithLevel ",
-		"trait to have their production queue icons render with an overlay defined in this trait. ",
-		"The icon change occurs when ProducibleWithLevel.Prerequisites are met.")]
-	public class VeteranProductionIconOverlayInfo : TraitInfo, Requires<TechTreeInfo>
+	[Desc("Attach this to the player actor. Required for WithProductionIconOverlay trait on actors to work.")]
+	public class ProductionIconOverlayManagerInfo : TraitInfo, Requires<TechTreeInfo>, IRulesetLoaded
 	{
+		[FieldLoader.Require]
+		[Desc("Type of the overlay. Prerequisites from WithProductionIconOverlay traits with matching types determine when this overlay will be enabled.")]
+		public readonly string Type = null;
+
 		[FieldLoader.Require]
 		[Desc("Image used for the overlay.")]
 		public readonly string Image = null;
@@ -33,24 +36,30 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Palette to render the sprite in. Reference the world actor's PaletteFrom* traits.")]
 		public readonly string Palette = "chrome";
 
-		public override object Create(ActorInitializer init) { return new VeteranProductionIconOverlay(init, this); }
+		public virtual void RulesetLoaded(Ruleset rules, ActorInfo ai)
+		{
+			if (rules.Actors[SystemActors.Player].TraitInfos<ProductionIconOverlayManagerInfo>().Where(piom => piom != this && piom.Type == Type).Any())
+				throw new YamlException($"Multiple 'ProductionIconOverlayManager's with type '{Type}' exist.");
+		}
+
+		public override object Create(ActorInitializer init) { return new ProductionIconOverlayManager(init, this); }
 	}
 
-	public class VeteranProductionIconOverlay : ITechTreeElement, IProductionIconOverlay
+	public class ProductionIconOverlayManager : ITechTreeElement, IProductionIconOverlay
 	{
+		readonly Actor self;
+		readonly Sprite sprite;
+		readonly ProductionIconOverlayManagerInfo info;
+
 		// HACK: TechTree doesn't associate Watcher.Key with the registering ITechTreeElement.
 		// So in a situation where multiple ITechTreeElements register Watchers with the same Key,
 		// and one removes its Watcher, all other ITechTreeElements' Watchers get removed too.
 		// This makes sure that the keys are unique with respect to the registering ITechTreeElement.
-		const string Prefix = "ProductionIconOverlay.";
-
-		readonly Actor self;
-		readonly Sprite sprite;
-		readonly VeteranProductionIconOverlayInfo info;
+		readonly string prefix;
 
 		readonly Dictionary<ActorInfo, bool> overlayActive = new Dictionary<ActorInfo, bool>();
 
-		public VeteranProductionIconOverlay(ActorInitializer init, VeteranProductionIconOverlayInfo info)
+		public ProductionIconOverlayManager(ActorInitializer init, ProductionIconOverlayManagerInfo info)
 		{
 			self = init.Self;
 
@@ -60,13 +69,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			this.info = info;
 
+			prefix = info.Type + ".";
 			var ttc = self.Trait<TechTree>();
 
 			foreach (var a in self.World.Map.Rules.Actors.Values)
 			{
-				var uwc = a.TraitInfoOrDefault<ProducibleWithLevelInfo>();
-				if (uwc != null)
-					ttc.Add(MakeKey(a.Name), uwc.Prerequisites, 0, this);
+				foreach (var wpio in a.TraitInfos<WithProductionIconOverlayInfo>().Where(wpio => wpio.Types.Contains(info.Type)))
+					ttc.Add(MakeKey(a.Name), wpio.Prerequisites, 0, this);
 			}
 		}
 
@@ -88,14 +97,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return isActive;
 		}
 
-		static string MakeKey(string name)
+		string MakeKey(string name)
 		{
-			return Prefix + name;
+			return prefix + name;
 		}
 
-		static string GetName(string key)
+		string GetName(string key)
 		{
-			return key.Substring(Prefix.Length);
+			return key.Substring(prefix.Length);
 		}
 
 		public void PrerequisitesAvailable(string key)

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionIconOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionIconOverlay.cs
@@ -1,0 +1,40 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits.Render
+{
+	[Desc("Displays overlays from `ProductionIconOverlayManager` with matching types when defined prerequisites are granted.")]
+	public class WithProductionIconOverlayInfo : TraitInfo<WithProductionIconOverlay>, IRulesetLoaded
+	{
+		[FieldLoader.Require]
+		public readonly string[] Types = Array.Empty<string>();
+
+		public readonly string[] Prerequisites = Array.Empty<string>();
+
+		public virtual void RulesetLoaded(Ruleset rules, ActorInfo ai)
+		{
+			foreach (var type in Types)
+			{
+				if (!rules.Actors[SystemActors.Player].TraitInfos<ProductionIconOverlayManagerInfo>().Where(piom => piom.Type == type).Any())
+					throw new YamlException($"A 'ProductionIconOverlayManager' with type '{type}' doesn't exist.");
+
+				if (ai.TraitInfos<WithProductionIconOverlayInfo>().Where(wpio => wpio != this && wpio.Types.Contains(type)).Any())
+					throw new YamlException($"Multiple 'WithProductionIconOverlay's with type '{type}' exist on the actor.");
+			}
+		}
+	}
+
+	public class WithProductionIconOverlay { }
+}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20201213/UnhardcodeVeteranProductionIconOverlay.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20201213/UnhardcodeVeteranProductionIconOverlay.cs
@@ -1,0 +1,49 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class UnhardcodeVeteranProductionIconOverlay : UpdateRule
+	{
+		public override string Name => "VeteranProductionIconOverlay is changed to ProductionIconOverlayManager giving it more customisation.";
+
+		public override string Description => "ProductionIconOverlayManager now works with the new WithProductionIconOverlay trait, instead of ProducibleWithLevel.";
+
+		readonly List<string> locations = new List<string>();
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (locations.Any())
+				yield return "Icon overlay logic has been split from ProducibleWithLevel to WithProductionIconOverlay trait.\n" +
+					"If you have been using VeteranProductionIconOverlay trait, add WithProductionIconOverlay to following actors:\n" +
+					UpdateUtils.FormatMessageList(locations);
+
+			locations.Clear();
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var veteranProductionIconOverlay in actorNode.ChildrenMatching("VeteranProductionIconOverlay"))
+			{
+				veteranProductionIconOverlay.RenameKey("ProductionIconOverlayManager");
+				veteranProductionIconOverlay.AddNode(new MiniYamlNode("Type", "Veterancy"));
+			}
+
+			foreach (var producibleWithLevel in actorNode.ChildrenMatching("ProducibleWithLevel"))
+				locations.Add($"{actorNode.Key}: {producibleWithLevel.Key} ({actorNode.Location.Filename})");
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -95,6 +95,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new SplitNukePowerMissileImage(),
 				new ReplaceSequenceEmbeddedPalette(),
 				new UnhardcodeBaseBuilderBotModule(),
+				new UnhardcodeVeteranProductionIconOverlay(),
 			})
 		};
 

--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -157,10 +157,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 				productionIconsBounds.Add(rect);
 
-				var pio = queue.Actor.Owner.PlayerActor.TraitsImplementing<IProductionIconOverlay>()
-					.FirstOrDefault(p => p.IsOverlayActive(actor));
+				var pios = queue.Actor.Owner.PlayerActor.TraitsImplementing<IProductionIconOverlay>();
 
-				if (pio != null)
+				foreach (var pio in pios.Where(p => p.IsOverlayActive(actor)))
 					WidgetUtils.DrawSpriteCentered(pio.Sprite, worldRenderer.Palette(pio.Palette),
 						centerPosition + pio.Offset(iconSize), 0.5f);
 

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -513,9 +513,8 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				WidgetUtils.DrawSpriteCentered(icon.Sprite, icon.Palette, icon.Pos + iconOffset);
 
-				// Draw the ProductionIconOverlay's sprite
-				var pio = pios.FirstOrDefault(p => p.IsOverlayActive(icon.Actor));
-				if (pio != null)
+				// Draw the ProductionIconOverlay's sprites
+				foreach (var pio in pios.Where(p => p.IsOverlayActive(icon.Actor)))
 					WidgetUtils.DrawSpriteCentered(pio.Sprite, worldRenderer.Palette(pio.Palette), icon.Pos + iconOffset + pio.Offset(IconSize));
 
 				// Build progress

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -131,6 +131,9 @@ MIG:
 		RequiresSelection: true
 	GrantConditionOnDamageState@SmokeTrail:
 		Condition: enable-smoke
+	WithProductionIconOverlay:
+		Types: Veterancy
+		Prerequisites: aircraft.upgraded
 
 YAK:
 	Inherits: ^Plane
@@ -210,6 +213,9 @@ YAK:
 		PipCount: 6
 	GrantConditionOnDamageState@SmokeTrail:
 		Condition: enable-smoke
+	WithProductionIconOverlay:
+		Types: Veterancy
+		Prerequisites: aircraft.upgraded
 
 TRAN:
 	Inherits: ^Helicopter
@@ -343,6 +349,9 @@ HELI:
 		RequiresSelection: true
 	GrantConditionOnDamageState@SmokeTrail:
 		Condition: enable-smoke
+	WithProductionIconOverlay:
+		Types: Veterancy
+		Prerequisites: aircraft.upgraded
 
 HIND:
 	Inherits: ^Helicopter
@@ -426,6 +435,9 @@ HIND:
 		PipCount: 6
 	GrantConditionOnDamageState@SmokeTrail:
 		Condition: enable-smoke
+	WithProductionIconOverlay:
+		Types: Veterancy
+		Prerequisites: aircraft.upgraded
 
 U2:
 	Inherits: ^NeutralPlane
@@ -544,3 +556,6 @@ MH60:
 		PipCount: 6
 	GrantConditionOnDamageState@SmokeTrail:
 		Condition: enable-smoke
+	WithProductionIconOverlay:
+		Types: Veterancy
+		Prerequisites: aircraft.upgraded

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -103,6 +103,9 @@ E1:
 		IsPlayerPalette: true
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded
+	WithProductionIconOverlay:
+		Types: Veterancy
+		Prerequisites: barracks.upgraded
 
 E1R1:
 	Inherits: E1
@@ -114,6 +117,9 @@ E1R1:
 	UpdatesPlayerStatistics:
 		OverrideActor: e1
 	-Buildable:
+	WithProductionIconOverlay:
+		Types: Veterancy
+		Prerequisites: techlevel.infonly
 
 E2:
 	Inherits: ^Soldier
@@ -157,6 +163,9 @@ E2:
 		EmptyWeapon: UnitExplodeSmall
 		DamageSource: Killer
 	ProducibleWithLevel:
+		Prerequisites: barracks.upgraded
+	WithProductionIconOverlay:
+		Types: Veterancy
 		Prerequisites: barracks.upgraded
 
 E3:
@@ -202,6 +211,9 @@ E3:
 		Prerequisites: barracks.upgraded
 	AutoTarget:
 		ScanRadius: 5
+	WithProductionIconOverlay:
+		Types: Veterancy
+		Prerequisites: barracks.upgraded
 
 E3R1:
 	Inherits: E3
@@ -213,6 +225,9 @@ E3R1:
 	UpdatesPlayerStatistics:
 		OverrideActor: e3
 	-Buildable:
+	WithProductionIconOverlay:
+		Types: Veterancy
+		Prerequisites: techlevel.infonly
 
 E4:
 	Inherits: ^Soldier
@@ -253,6 +268,9 @@ E4:
 		Palette: player-noshadow
 		IsPlayerPalette: true
 	ProducibleWithLevel:
+		Prerequisites: barracks.upgraded
+	WithProductionIconOverlay:
+		Types: Veterancy
 		Prerequisites: barracks.upgraded
 
 E6:
@@ -435,6 +453,9 @@ E7:
 	Voiced:
 		VoiceSet: TanyaVoice
 	ProducibleWithLevel:
+		Prerequisites: barracks.upgraded
+	WithProductionIconOverlay:
+		Types: Veterancy
 		Prerequisites: barracks.upgraded
 
 MEDI:
@@ -706,6 +727,9 @@ SHOK:
 		VoiceSet: ShokVoice
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded
+	WithProductionIconOverlay:
+		Types: Veterancy
+		Prerequisites: barracks.upgraded
 
 SNIPER:
 	Inherits: ^Soldier
@@ -758,6 +782,9 @@ SNIPER:
 		ValidDamageStates: Critical
 	-MustBeDestroyed:
 	ProducibleWithLevel:
+		Prerequisites: barracks.upgraded
+	WithProductionIconOverlay:
+		Types: Veterancy
 		Prerequisites: barracks.upgraded
 
 Zombie:

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -172,7 +172,8 @@ Player:
 		Id: unrestricted
 	GrantConditionOnPrerequisiteManager:
 	EnemyWatcher:
-	VeteranProductionIconOverlay:
+	ProductionIconOverlayManager:
+		Type: Veterancy
 		Image: iconchevrons
 		Sequence: veteran
 	ResourceStorageWarning:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -47,6 +47,9 @@ V2RL:
 		Prerequisites: vehicles.upgraded
 	Selectable:
 		DecorationBounds: 1194, 1194
+	WithProductionIconOverlay:
+		Types: Veterancy
+		Prerequisites: vehicles.upgraded
 
 1TNK:
 	Inherits: ^TrackedVehicle
@@ -88,6 +91,9 @@ V2RL:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
 	ProducibleWithLevel:
+		Prerequisites: vehicles.upgraded
+	WithProductionIconOverlay:
+		Types: Veterancy
 		Prerequisites: vehicles.upgraded
 
 2TNK:
@@ -135,6 +141,9 @@ V2RL:
 		Prerequisites: vehicles.upgraded
 	Selectable:
 		DecorationBounds: 1194, 1194
+	WithProductionIconOverlay:
+		Types: Veterancy
+		Prerequisites: vehicles.upgraded
 
 3TNK:
 	Inherits: ^TrackedVehicle
@@ -181,6 +190,9 @@ V2RL:
 		Prerequisites: vehicles.upgraded
 	Selectable:
 		DecorationBounds: 1194, 1194
+	WithProductionIconOverlay:
+		Types: Veterancy
+		Prerequisites: vehicles.upgraded
 
 4TNK:
 	Inherits: ^TrackedVehicle
@@ -240,6 +252,9 @@ V2RL:
 		Prerequisites: vehicles.upgraded
 	Selectable:
 		DecorationBounds: 1877, 1621, 0, -170
+	WithProductionIconOverlay:
+		Types: Veterancy
+		Prerequisites: vehicles.upgraded
 
 ARTY:
 	Inherits: ^TrackedVehicle
@@ -284,6 +299,9 @@ ARTY:
 		EmptyWeapon: UnitExplodeSmall
 		LoadedChance: 75
 	ProducibleWithLevel:
+		Prerequisites: vehicles.upgraded
+	WithProductionIconOverlay:
+		Types: Veterancy
 		Prerequisites: vehicles.upgraded
 
 HARV:
@@ -432,6 +450,9 @@ JEEP:
 		LoadingCondition: notmobile
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
+	WithProductionIconOverlay:
+		Types: Veterancy
+		Prerequisites: vehicles.upgraded
 
 APC:
 	Inherits: ^TrackedVehicle
@@ -474,6 +495,9 @@ APC:
 		MaxWeight: 5
 		LoadingCondition: notmobile
 	ProducibleWithLevel:
+		Prerequisites: vehicles.upgraded
+	WithProductionIconOverlay:
+		Types: Veterancy
 		Prerequisites: vehicles.upgraded
 
 MNLY:
@@ -663,6 +687,9 @@ TTNK:
 		Prerequisites: vehicles.upgraded
 	Selectable:
 		DecorationBounds: 1280, 1280
+	WithProductionIconOverlay:
+		Types: Veterancy
+		Prerequisites: vehicles.upgraded
 
 FTRK:
 	Inherits: ^Vehicle
@@ -712,6 +739,9 @@ FTRK:
 		Prerequisites: vehicles.upgraded
 	Selectable:
 		DecorationBounds: 1194, 1194
+	WithProductionIconOverlay:
+		Types: Veterancy
+		Prerequisites: vehicles.upgraded
 
 DTRK:
 	Inherits: ^Vehicle
@@ -797,6 +827,9 @@ CTNK:
 		Prerequisites: vehicles.upgraded
 	Selectable:
 		DecorationBounds: 1280, 1280
+	WithProductionIconOverlay:
+		Types: Veterancy
+		Prerequisites: vehicles.upgraded
 
 QTNK:
 	Inherits: ^TrackedVehicle
@@ -895,4 +928,7 @@ STNK:
 		ValidDamageStates: Critical
 	-MustBeDestroyed:
 	ProducibleWithLevel:
+		Prerequisites: vehicles.upgraded
+	WithProductionIconOverlay:
+		Types: Veterancy
 		Prerequisites: vehicles.upgraded


### PR DESCRIPTION
This PR replaces VeteranProductionIconOverlay with ProductionIconOverlayManager and splits the IconOverlay stuff related to ProducibleWithLevel to its own WithProductionIconOverlay trait. Both traits get a `Type(s)=` value allowing the mod to define multiple Icon Overlays. I have added a few RulesetLoaded checks to ensure that the types are unique and there is a manager for the types defined at actors. Types need to be unique since `<type>.<actor name>` are being used as Tech Tree watcher keys, i don't think the `.` was necessary but i kept it because old code from VeteranProductionIconOverlay had it.

Also, not sure about some naming, so feel free to suggest better ones if you have.

I added 2 testcases, one makes T1 vehicles built at 2nd level of veterancy when a WFac is infiltrated. Other one makes Grenadiers start as rank 1 for Russia, but if a Russian player infiltrates a Barracks with a spy they become rank 2 (with some prerequisite shinanigans you can make the lv1 icon appear at top for both cases, but i didn't bother for the testcase, such prerequisite stuff can also be used to workaround that you can't have multiple WithProductionIconOverlays of same Type with different prerequisites on the same actor).

Closes #14270.

(Also, For RV i did this changes so i can add upgraded/taken overlays for Upgrades/Commander's Powers to diffirentiate them from currently unavailable ones. We could do the same for D2k upgrades, probably with the star icon that you get on the affected buildings when you select them)