### PR TITLE
Fix aircraft with TakeOffOnCreation=false not freeing exit

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -1249,7 +1249,11 @@ namespace OpenRA.Mods.Common.Traits
 			public override bool Tick(Actor self)
 			{
 				if (!aircraft.Info.TakeOffOnCreation)
+				{
+					// Freshly created aircraft shouldn't block the exit, so we allow them to yield their reservation
+					aircraft.AllowYieldingReservation();
 					return true;
+				}
 
 				if (self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition).Length <= aircraft.LandAltitude.Length)
 					QueueChild(new TakeOff(self));

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -921,43 +921,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Activity ReturnToCell(Actor self) { return null; }
 
-		class AssociateWithAirfieldActivity : Activity
-		{
-			readonly Actor self;
-			readonly Aircraft aircraft;
-			readonly int delay;
-
-			public AssociateWithAirfieldActivity(Actor self, int delay = 0)
-			{
-				this.self = self;
-				aircraft = self.Trait<Aircraft>();
-				IsInterruptible = false;
-				this.delay = delay;
-			}
-
-			protected override void OnFirstRun(Actor self)
-			{
-				var host = aircraft.GetActorBelow();
-				if (host != null)
-					aircraft.MakeReservation(host);
-
-				if (delay > 0)
-					QueueChild(new Wait(delay));
-			}
-
-			public override bool Tick(Actor self)
-			{
-				if (!aircraft.Info.TakeOffOnCreation)
-					return true;
-
-				if (self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition).Length <= aircraft.LandAltitude.Length)
-					QueueChild(new TakeOff(self));
-
-				aircraft.UnReserve();
-				return true;
-			}
-		}
-
 		public Activity MoveToTarget(Actor self, in Target target,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
@@ -1257,6 +1220,43 @@ namespace OpenRA.Mods.Common.Traits
 		Activity ICreationActivity.GetCreationActivity()
 		{
 			return new AssociateWithAirfieldActivity(self, creationActivityDelay);
+		}
+
+		class AssociateWithAirfieldActivity : Activity
+		{
+			readonly Actor self;
+			readonly Aircraft aircraft;
+			readonly int delay;
+
+			public AssociateWithAirfieldActivity(Actor self, int delay = 0)
+			{
+				this.self = self;
+				aircraft = self.Trait<Aircraft>();
+				IsInterruptible = false;
+				this.delay = delay;
+			}
+
+			protected override void OnFirstRun(Actor self)
+			{
+				var host = aircraft.GetActorBelow();
+				if (host != null)
+					aircraft.MakeReservation(host);
+
+				if (delay > 0)
+					QueueChild(new Wait(delay));
+			}
+
+			public override bool Tick(Actor self)
+			{
+				if (!aircraft.Info.TakeOffOnCreation)
+					return true;
+
+				if (self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition).Length <= aircraft.LandAltitude.Length)
+					QueueChild(new TakeOff(self));
+
+				aircraft.UnReserve();
+				return true;
+			}
 		}
 
 		public class AircraftMoveOrderTargeter : IOrderTargeter


### PR DESCRIPTION
Split the uncontroversial commits from #19452 (which can be used as test case).

On its own, this is a hypothetical fix right now, because #18444 prevents us from even getting to that point, but it means a PR fixing #18444 will be able to focus on that and have a smaller diff.

This should only get a WIP changelog entry under the Engine/Modding section for now, as this fix won't show its benefit until #18444 is fixed as well.