### PR TITLE
After NotBefore<> support to control initialization order.

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -322,6 +322,9 @@ namespace OpenRA.Traits
 	[SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Not a real interface, but more like a tag.")]
 	public interface Requires<T> where T : class, ITraitInfoInterface { }
 
+	[SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Not a real interface, but more like a tag.")]
+	public interface NotBefore<T> where T : class, ITraitInfoInterface { }
+
 	public interface IActivityInterface { }
 
 	[RequireExplicitImplementation]

--- a/OpenRA.Mods.Common/Traits/World/ElevatedBridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ElevatedBridgeLayer.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World)]
-	public class ElevatedBridgeLayerInfo : TraitInfo, Requires<DomainIndexInfo>, ILobbyCustomRulesIgnore
+	public class ElevatedBridgeLayerInfo : TraitInfo, Requires<DomainIndexInfo>, ILobbyCustomRulesIgnore, ICustomMovementLayerInfo
 	{
 		[Desc("Terrain type used by cells outside any elevated bridge footprint.")]
 		public readonly string ImpassableTerrainType = "Impassable";

--- a/OpenRA.Mods.Common/Traits/World/JumpjetActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/JumpjetActorLayer.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World)]
-	public class JumpjetActorLayerInfo : TraitInfo
+	public class JumpjetActorLayerInfo : TraitInfo, ICustomMovementLayerInfo
 	{
 		[Desc("Terrain type of the airborne layer.")]
 		public readonly string TerrainType = "Jumpjet";

--- a/OpenRA.Mods.Common/Traits/World/SubterraneanActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SubterraneanActorLayer.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World)]
-	public class SubterraneanActorLayerInfo : TraitInfo
+	public class SubterraneanActorLayerInfo : TraitInfo, ICustomMovementLayerInfo
 	{
 		[Desc("Terrain type of the underground layer.")]
 		public readonly string TerrainType = "Subterranean";

--- a/OpenRA.Mods.Common/Traits/World/TerrainTunnelLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainTunnelLayer.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World)]
-	public class TerrainTunnelLayerInfo : TraitInfo, Requires<DomainIndexInfo>, ILobbyCustomRulesIgnore
+	public class TerrainTunnelLayerInfo : TraitInfo, Requires<DomainIndexInfo>, ILobbyCustomRulesIgnore, ICustomMovementLayerInfo
 	{
 		[Desc("Terrain type used by cells outside any tunnel footprint.")]
 		public readonly string ImpassableTerrainType = "Impassable";

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -411,6 +411,8 @@ namespace OpenRA.Mods.Common.Traits
 		WPos CenterOfCell(CPos cell);
 	}
 
+	public interface ICustomMovementLayerInfo : ITraitInfoInterface { }
+
 	// For traits that want to be exposed to the "Deploy" UI button / hotkey
 	[RequireExplicitImplementation]
 	public interface IIssueDeployOrder

--- a/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
+++ b/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
@@ -18,12 +18,22 @@ namespace OpenRA.Test
 	interface IMock : ITraitInfoInterface { }
 	class MockTraitInfo : TraitInfo { public override object Create(ActorInitializer init) { return null; } }
 	class MockInheritInfo : MockTraitInfo { }
+
 	class MockAInfo : MockInheritInfo, IMock { }
-	class MockBInfo : MockTraitInfo, Requires<MockAInfo>, Requires<IMock>, Requires<MockInheritInfo> { }
+	class MockBInfo : MockTraitInfo, Requires<IMock>, Requires<MockInheritInfo> { }
 	class MockCInfo : MockTraitInfo, Requires<MockBInfo> { }
+
 	class MockDInfo : MockTraitInfo, Requires<MockEInfo> { }
 	class MockEInfo : MockTraitInfo, Requires<MockFInfo> { }
 	class MockFInfo : MockTraitInfo, Requires<MockDInfo> { }
+
+	class MockGInfo : MockInheritInfo, IMock, NotBefore<MockAInfo> { }
+	class MockHInfo : MockTraitInfo, NotBefore<IMock>, NotBefore<MockInheritInfo>, NotBefore<MockBInfo> { }
+	class MockIInfo : MockTraitInfo, NotBefore<MockHInfo>, NotBefore<MockCInfo> { }
+
+	class MockJInfo : MockTraitInfo, NotBefore<MockKInfo> { }
+	class MockKInfo : MockTraitInfo, NotBefore<MockLInfo> { }
+	class MockLInfo : MockTraitInfo, NotBefore<MockJInfo> { }
 
 	[TestFixture]
 	public class ActorInfoTest
@@ -39,7 +49,27 @@ namespace OpenRA.Test
 
 			for (var i = 0; i < orderedTraits.Length; i++)
 			{
-				var traitTypesThatMustOccurBeforeThisTrait = ActorInfo.PrerequisitesOf(orderedTraits[i]);
+				var traitTypesThatMustOccurBeforeThisTrait =
+					ActorInfo.PrerequisitesOf(orderedTraits[i]).Concat(ActorInfo.OptionalPrerequisitesOf(orderedTraits[i]));
+				var traitTypesThatOccurAfterThisTrait = orderedTraits.Skip(i + 1).Select(ti => ti.GetType());
+				var traitTypesThatShouldOccurEarlier = traitTypesThatOccurAfterThisTrait.Intersect(traitTypesThatMustOccurBeforeThisTrait);
+				CollectionAssert.IsEmpty(traitTypesThatShouldOccurEarlier, "Dependency order has not been satisfied.");
+			}
+		}
+
+		[TestCase(TestName = "Trait ordering sorts in optional dependency order correctly")]
+		public void OptionalTraitOrderingSortsCorrectly()
+		{
+			var unorderedTraits = new TraitInfo[] { new MockHInfo(), new MockIInfo(), new MockGInfo(), new MockHInfo() };
+			var actorInfo = new ActorInfo("test", unorderedTraits);
+			var orderedTraits = actorInfo.TraitsInConstructOrder().ToArray();
+
+			CollectionAssert.AreEquivalent(unorderedTraits, orderedTraits);
+
+			for (var i = 0; i < orderedTraits.Length; i++)
+			{
+				var traitTypesThatMustOccurBeforeThisTrait =
+					ActorInfo.PrerequisitesOf(orderedTraits[i]).Concat(ActorInfo.OptionalPrerequisitesOf(orderedTraits[i]));
 				var traitTypesThatOccurAfterThisTrait = orderedTraits.Skip(i + 1).Select(ti => ti.GetType());
 				var traitTypesThatShouldOccurEarlier = traitTypesThatOccurAfterThisTrait.Intersect(traitTypesThatMustOccurBeforeThisTrait);
 				CollectionAssert.IsEmpty(traitTypesThatShouldOccurEarlier, "Dependency order has not been satisfied.");
@@ -52,11 +82,20 @@ namespace OpenRA.Test
 			var actorInfo = new ActorInfo("test", new MockBInfo(), new MockCInfo());
 			var ex = Assert.Throws<YamlException>(() => actorInfo.TraitsInConstructOrder());
 
-			StringAssert.Contains(typeof(MockAInfo).Name, ex.Message, "Exception message did not report a missing dependency.");
 			StringAssert.Contains(typeof(MockBInfo).Name, ex.Message, "Exception message did not report a missing dependency.");
 			StringAssert.Contains(typeof(MockCInfo).Name, ex.Message, "Exception message did not report a missing dependency.");
 			StringAssert.Contains(typeof(MockInheritInfo).Name, ex.Message, "Exception message did not report a missing dependency (from a base class).");
 			StringAssert.Contains(typeof(IMock).Name, ex.Message, "Exception message did not report a missing dependency (from an interface).");
+		}
+
+		[TestCase(TestName = "Trait ordering allows optional dependencies to be missing")]
+		public void TraitOrderingAllowsMissingOptionalDependencies()
+		{
+			var unorderedTraits = new TraitInfo[] { new MockHInfo(), new MockIInfo() };
+			var actorInfo = new ActorInfo("test", unorderedTraits);
+			var orderedTraits = actorInfo.TraitsInConstructOrder().ToArray();
+
+			CollectionAssert.AreEquivalent(unorderedTraits, orderedTraits);
 		}
 
 		[TestCase(TestName = "Trait ordering exception reports cyclic dependencies")]
@@ -68,6 +107,17 @@ namespace OpenRA.Test
 			StringAssert.Contains(typeof(MockDInfo).Name, ex.Message, "Exception message should report all cyclic dependencies.");
 			StringAssert.Contains(typeof(MockEInfo).Name, ex.Message, "Exception message should report all cyclic dependencies.");
 			StringAssert.Contains(typeof(MockFInfo).Name, ex.Message, "Exception message should report all cyclic dependencies.");
+		}
+
+		[TestCase(TestName = "Trait ordering exception reports cyclic optional dependencies")]
+		public void TraitOrderingReportsCyclicOptionalDependencies()
+		{
+			var actorInfo = new ActorInfo("test", new MockJInfo(), new MockKInfo(), new MockLInfo());
+			var ex = Assert.Throws<YamlException>(() => actorInfo.TraitsInConstructOrder());
+
+			StringAssert.Contains(typeof(MockJInfo).Name, ex.Message, "Exception message should report all cyclic dependencies.");
+			StringAssert.Contains(typeof(MockKInfo).Name, ex.Message, "Exception message should report all cyclic dependencies.");
+			StringAssert.Contains(typeof(MockLInfo).Name, ex.Message, "Exception message should report all cyclic dependencies.");
 		}
 	}
 }


### PR DESCRIPTION
`Requires<T>` means that trait of type `T` will be initialized first, and asserts that at least one exists. The new `NotBefore<T>` means that trait of type `T` will be initialized first, but allows no traits.

This allows traits to control initialization order for optional dependencies. They want to be initialized second so they can rely on the dependencies having been initialized. But if the dependencies are optional then to not throw if none are present.

We apply this to `Locomotor` which was previously using `AddFrameEndTask` to work around trait order initialization. This improves the user experience as the initialization is applied whilst the loading screen is still visible, rather than the game starting and creating jank by performing initialization on the first tick.

----

Recommend using the `Hide Whitespace` option when looking at `Locomotor.cs` for clarity.

Changelog notes will want to cover:
- New `NotBefore<T>` interface to complement `Requires<T>`.
- Any traits implementing `ICustomMovementLayer` should now also tag their `TraitInfo` with `ICustomMovementLayerInfo`.