### PR TITLE
Recommend the MiniYAML language server extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
 	"recommendations": [
 		"ms-dotnettools.csharp",
+		"openra.oraide-vscode",
 		"openra.vscode-openra-lua",
 		"EditorConfig.EditorConfig",
 	]


### PR DESCRIPTION
Recommends the [MiniYAML language server](https://github.com/penev92/Oraide.LanguageServer/) as a [VSCode extension](https://marketplace.visualstudio.com/items?itemName=openra.oraide-vscode) for the OpenRA workspace.