### PR TITLE
Allow mods to implement new building placement conditions.

### DIFF
--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Orders
 		}
 
 		readonly World world;
-		readonly ProductionQueue queue;
+		protected readonly ProductionQueue Queue;
 		readonly PlaceBuildingInfo placeBuildingInfo;
 		readonly IResourceLayer resourceLayer;
 		readonly Viewport viewport;
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.Common.Orders
 
 		public PlaceBuildingOrderGenerator(ProductionQueue queue, string name, WorldRenderer worldRenderer)
 		{
-			this.queue = queue;
+			Queue = queue;
 			world = queue.Actor.World;
 			placeBuildingInfo = queue.Actor.Owner.PlayerActor.Info.TraitInfo<PlaceBuildingInfo>();
 			resourceLayer = world.WorldActor.TraitOrDefault<IResourceLayer>();
@@ -158,12 +158,12 @@ namespace OpenRA.Mods.Common.Orders
 			}
 		}
 
-		IEnumerable<Order> InnerOrder(World world, CPos cell, MouseInput mi)
+		protected virtual IEnumerable<Order> InnerOrder(World world, CPos cell, MouseInput mi)
 		{
 			if (world.Paused)
 				yield break;
 
-			var owner = queue.Actor.Owner;
+			var owner = Queue.Actor.Owner;
 			var ai = variants[variant].ActorInfo;
 			var bi = variants[variant].BuildingInfo;
 
@@ -204,7 +204,7 @@ namespace OpenRA.Mods.Common.Orders
 					TargetString = variants[0].ActorInfo.Name,
 
 					// Actor ID to associate with placement may be quite large, so it gets its own uint
-					ExtraData = queue.Actor.ActorID,
+					ExtraData = Queue.Actor.ActorID,
 
 					// Actor variant will always be small enough to safely pack in a CPos
 					ExtraLocation = new CPos(variant, 0),
@@ -216,7 +216,7 @@ namespace OpenRA.Mods.Common.Orders
 
 		void IOrderGenerator.Tick(World world)
 		{
-			if (queue.AllQueued().All(i => !i.Done || i.Item != variants[0].ActorInfo.Name))
+			if (Queue.AllQueued().All(i => !i.Done || i.Item != variants[0].ActorInfo.Name))
 				world.CancelInputMode();
 
 			foreach (var v in variants)
@@ -246,7 +246,7 @@ namespace OpenRA.Mods.Common.Orders
 			var plugInfo = activeVariant.PlugInfo;
 			var lineBuildInfo = activeVariant.LineBuildInfo;
 			var preview = activeVariant.Preview;
-			var owner = queue.Actor.Owner;
+			var owner = Queue.Actor.Owner;
 
 			if (plugInfo != null)
 			{
@@ -291,7 +291,7 @@ namespace OpenRA.Mods.Common.Orders
 			return preview?.RenderAnnotations(wr, TopLeft) ?? Enumerable.Empty<IRenderable>();
 		}
 
-		string IOrderGenerator.GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		public virtual string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			return worldDefaultCursor;
 		}
@@ -318,7 +318,7 @@ namespace OpenRA.Mods.Common.Orders
 				.Where(world.Map.Contains).ToList();
 
 			var blockers = allTiles.SelectMany(world.ActorMap.GetActorsAt)
-				.Where(a => a.Owner == queue.Actor.Owner && a.IsIdle)
+				.Where(a => a.Owner == Queue.Actor.Owner && a.IsIdle)
 				.Select(a => new TraitPair<IMove>(a, a.TraitOrDefault<IMove>()))
 				.Where(x => x.Trait != null);
 


### PR DESCRIPTION
Not much to say here. In openKrush buildings are constructed after placement, and i need this changes to implement this:
```csharp
protected override IEnumerable<Order> InnerOrder(World world, CPos cell, MouseInput mi)
{
	return this.Queue.Actor.Owner.PlayerActor.TraitOrDefault<PlayerResources>() is { Cash: 0 } ? Array.Empty<Order>() : base.InnerOrder(world, cell, mi);
}

public override string? GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
{
	return this.Queue.Actor.Owner.PlayerActor.TraitOrDefault<PlayerResources>() is { Cash: 0 } ? "no-oil" : null;
}
```
