### PR TITLE
Change color of labels that correspond to disabled inputs

### DIFF
--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -606,6 +606,25 @@ namespace OpenRA.Widgets
 		}
 	}
 
+	public class InputWidget : Widget
+	{
+		public bool Disabled = false;
+		public Func<bool> IsDisabled = () => false;
+
+		public InputWidget()
+		{
+			IsDisabled = () => Disabled;
+		}
+
+		public InputWidget(InputWidget other)
+			: base(other)
+		{
+			IsDisabled = () => other.Disabled;
+		}
+
+		public override Widget Clone() { return new InputWidget(this); }
+	}
+
 	public class WidgetArgs : Dictionary<string, object>
 	{
 		public WidgetArgs() { }

--- a/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
@@ -16,7 +16,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets
 {
-	public class ButtonWidget : Widget
+	public class ButtonWidget : InputWidget
 	{
 		public readonly string TooltipContainer;
 		public readonly string TooltipTemplate = "BUTTON_TOOLTIP";
@@ -42,14 +42,12 @@ namespace OpenRA.Mods.Common.Widgets
 		public int ContrastRadius = ChromeMetrics.Get<int>("ButtonTextContrastRadius");
 		public string ClickSound = ChromeMetrics.Get<string>("ClickSound");
 		public string ClickDisabledSound = ChromeMetrics.Get<string>("ClickDisabledSound");
-		public bool Disabled = false;
 		public bool Highlighted = false;
 		public Func<string> GetText;
 		public Func<Color> GetColor;
 		public Func<Color> GetColorDisabled;
 		public Func<Color> GetContrastColorDark;
 		public Func<Color> GetContrastColorLight;
-		public Func<bool> IsDisabled;
 		public Func<bool> IsHighlighted;
 		public Action<MouseInput> OnMouseDown = _ => { };
 		public Action<MouseInput> OnMouseUp = _ => { };
@@ -83,7 +81,6 @@ namespace OpenRA.Mods.Common.Widgets
 			GetContrastColorLight = () => ContrastColorLight;
 			OnMouseUp = _ => OnClick();
 			OnKeyPress = _ => OnClick();
-			IsDisabled = () => Disabled;
 			IsHighlighted = () => Highlighted;
 			GetTooltipText = () => TooltipText;
 			GetTooltipDesc = () => TooltipDesc;
@@ -118,7 +115,6 @@ namespace OpenRA.Mods.Common.Widgets
 			GetContrastColorLight = other.GetContrastColorLight;
 			OnMouseDown = other.OnMouseDown;
 			Disabled = other.Disabled;
-			IsDisabled = other.IsDisabled;
 			Highlighted = other.Highlighted;
 			IsHighlighted = other.IsHighlighted;
 

--- a/OpenRA.Mods.Common/Widgets/CheckboxWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/CheckboxWidget.cs
@@ -29,6 +29,10 @@ namespace OpenRA.Mods.Common.Widgets
 			: base(modData)
 		{
 			GetCheckType = () => CheckType;
+			TextColor = ChromeMetrics.Get<Color>("TextColor");
+			TextColorDisabled = ChromeMetrics.Get<Color>("TextDisabledColor");
+			GetColor = () => TextColor;
+			GetColorDisabled = () => TextColorDisabled;
 		}
 
 		protected CheckboxWidget(CheckboxWidget other)
@@ -39,6 +43,10 @@ namespace OpenRA.Mods.Common.Widgets
 			IsChecked = other.IsChecked;
 			CheckOffset = other.CheckOffset;
 			HasPressedState = other.HasPressedState;
+			TextColor = other.TextColor;
+			TextColorDisabled = other.TextColorDisabled;
+			GetColor = other.GetColor;
+			GetColorDisabled = other.GetColorDisabled;
 		}
 
 		public override void Draw()

--- a/OpenRA.Mods.Common/Widgets/HotkeyEntryWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/HotkeyEntryWidget.cs
@@ -16,7 +16,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets
 {
-	public class HotkeyEntryWidget : Widget
+	public class HotkeyEntryWidget : InputWidget
 	{
 		public Hotkey Key;
 
@@ -27,7 +27,6 @@ namespace OpenRA.Mods.Common.Widgets
 		public Action<KeyInput> OnEscKey = _ => { };
 		public Action OnLoseFocus = () => { };
 
-		public Func<bool> IsDisabled = () => false;
 		public Func<bool> IsValid = () => false;
 		public string Font = ChromeMetrics.Get<string>("HotkeyFont");
 		public Color TextColor = ChromeMetrics.Get<Color>("HotkeyColor");

--- a/OpenRA.Mods.Common/Widgets/LabelForInputWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LabelForInputWidget.cs
@@ -1,0 +1,48 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using OpenRA.Graphics;
+using OpenRA.Primitives;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets
+{
+	public class LabelForInputWidget : LabelWidget
+	{
+		public string For = null;
+		public readonly Color TextDisabledColor = ChromeMetrics.Get<Color>("TextDisabledColor");
+		readonly Lazy<InputWidget> inputWidget;
+		readonly CachedTransform<bool, Color> textColor;
+
+		[ObjectCreator.UseCtor]
+		public LabelForInputWidget()
+			: base()
+		{
+			inputWidget = Exts.Lazy(() => Parent.Get<InputWidget>(For));
+			textColor = new CachedTransform<bool, Color>(disabled => disabled ? TextDisabledColor : TextColor);
+		}
+
+		protected LabelForInputWidget(LabelForInputWidget other)
+			: base(other)
+		{
+			inputWidget = Exts.Lazy(() => Parent.Get<InputWidget>(other.For));
+			textColor = new CachedTransform<bool, Color>(disabled => disabled ? TextDisabledColor : TextColor);
+		}
+
+		protected override void DrawInner(string text, SpriteFont font, Color color, int2 position)
+		{
+			font.DrawText(text, position, textColor.Update(inputWidget.Value.IsDisabled()));
+		}
+
+		public override Widget Clone() { return new LabelForInputWidget(this); }
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/SliderWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SliderWidget.cs
@@ -16,9 +16,8 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets
 {
-	public class SliderWidget : Widget
+	public class SliderWidget : InputWidget
 	{
-		public Func<bool> IsDisabled = () => false;
 		public event Action<float> OnChange = _ => { };
 		public int Ticks = 0;
 		public int TrackHeight = 5;

--- a/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
@@ -18,7 +18,7 @@ using OpenRA.Widgets;
 namespace OpenRA.Mods.Common.Widgets
 {
 	public enum TextFieldType { General, Filename, Integer }
-	public class TextFieldWidget : Widget
+	public class TextFieldWidget : InputWidget
 	{
 		string text = "";
 		public string Text
@@ -38,8 +38,6 @@ namespace OpenRA.Mods.Common.Widgets
 		public int LeftMargin = 5;
 		public int RightMargin = 5;
 		public string Background = "textfield";
-
-		public bool Disabled = false;
 
 		TextFieldType type = TextFieldType.General;
 		public TextFieldType Type
@@ -64,7 +62,6 @@ namespace OpenRA.Mods.Common.Widgets
 		public Action OnTextEdited = () => { };
 		public int CursorPosition { get; set; }
 
-		public Func<bool> IsDisabled;
 		public Func<bool> IsValid = () => true;
 		public string Font = ChromeMetrics.Get<string>("TextfieldFont");
 		public Color TextColor = ChromeMetrics.Get<Color>("TextfieldColor");
@@ -76,10 +73,7 @@ namespace OpenRA.Mods.Common.Widgets
 		protected int selectionEndIndex = -1;
 		protected bool mouseSelectionActive = false;
 
-		public TextFieldWidget()
-		{
-			IsDisabled = () => Disabled;
-		}
+		public TextFieldWidget() { }
 
 		protected TextFieldWidget(TextFieldWidget widget)
 			: base(widget)
@@ -95,7 +89,6 @@ namespace OpenRA.Mods.Common.Widgets
 			TextColorInvalid = widget.TextColorInvalid;
 			TextColorHighlight = widget.TextColorHighlight;
 			VisualHeight = widget.VisualHeight;
-			IsDisabled = widget.IsDisabled;
 		}
 
 		public override bool YieldKeyboardFocus()

--- a/mods/cnc/chrome/ingame-info-lobby-options.yaml
+++ b/mods/cnc/chrome/ingame-info-lobby-options.yaml
@@ -35,11 +35,12 @@ Container@LOBBY_OPTIONS_PANEL:
 							Height: 60
 							Width: PARENT_RIGHT
 							Children:
-								Label@A_DESC:
+								LabelForInput@A_DESC:
 									X: 10
 									Width: PARENT_RIGHT / 2 - 20
 									Height: 20
 									Visible: False
+									For: A
 								DropDownButton@A:
 									X: 10
 									Y: 25
@@ -48,11 +49,12 @@ Container@LOBBY_OPTIONS_PANEL:
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
-								Label@B_DESC:
+								LabelForInput@B_DESC:
 									X: PARENT_RIGHT / 2 + 10
 									Width: PARENT_RIGHT / 2 - 20
 									Height: 20
 									Visible: False
+									For: B
 								DropDownButton@B:
 									X: PARENT_RIGHT / 2 + 10
 									Y: 25

--- a/mods/cnc/chrome/lobby-options.yaml
+++ b/mods/cnc/chrome/lobby-options.yaml
@@ -47,11 +47,12 @@ Container@LOBBY_OPTIONS_BIN:
 							Height: 60
 							Width: PARENT_RIGHT
 							Children:
-								Label@A_DESC:
+								LabelForInput@A_DESC:
 									X: 10
 									Width: PARENT_RIGHT / 3 - 20
 									Height: 20
 									Visible: False
+									For: A
 								DropDownButton@A:
 									X: 10
 									Width: PARENT_RIGHT / 3 - 20
@@ -60,11 +61,12 @@ Container@LOBBY_OPTIONS_BIN:
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
-								Label@B_DESC:
+								LabelForInput@B_DESC:
 									X: PARENT_RIGHT / 3 + 10
 									Width: PARENT_RIGHT / 3 - 20
 									Height: 20
 									Visible: False
+									For: B
 								DropDownButton@B:
 									X: PARENT_RIGHT / 3 + 10
 									Width: PARENT_RIGHT / 3 - 20
@@ -73,11 +75,12 @@ Container@LOBBY_OPTIONS_BIN:
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
-								Label@C_DESC:
+								LabelForInput@C_DESC:
 									X: (PARENT_RIGHT / 3) * 2 + 10
 									Width: PARENT_RIGHT / 3 - 20
 									Height: 20
 									Visible: False
+									For: C
 								DropDownButton@C:
 									X: (PARENT_RIGHT / 3) * 2 + 10
 									Width: PARENT_RIGHT / 3 - 20

--- a/mods/cnc/chrome/settings-display.yaml
+++ b/mods/cnc/chrome/settings-display.yaml
@@ -30,10 +30,11 @@ Container@DISPLAY_PANEL:
 							X: 10
 							Width: PARENT_RIGHT / 2 - 20
 							Children:
-								Label@PLAYER:
+								LabelForInput@PLAYER:
 									Width: PARENT_RIGHT
 									Height: 20
 									Text: Player Name:
+									For: PLAYERNAME
 								TextField@PLAYERNAME:
 									Y: 25
 									Width: PARENT_RIGHT
@@ -44,10 +45,11 @@ Container@DISPLAY_PANEL:
 							X: PARENT_RIGHT / 2 + 10
 							Width: PARENT_RIGHT / 2 - 20
 							Children:
-								Label@COLOR:
+								LabelForInput@COLOR:
 									Width: PARENT_RIGHT
 									Height: 20
 									Text: Preferred Color:
+									For: PLAYERCOLOR
 								DropDownButton@PLAYERCOLOR:
 									Y: 25
 									Width: 75
@@ -111,10 +113,11 @@ Container@DISPLAY_PANEL:
 							X: 10
 							Width: PARENT_RIGHT / 2 - 20
 							Children:
-								Label@UI_SCALE:
+								LabelForInput@UI_SCALE:
 									Width: PARENT_RIGHT
 									Height: 20
 									Text: UI Scale:
+									For: UI_SCALE_DROPDOWN
 								DropDownButton@UI_SCALE_DROPDOWN:
 									Y: 25
 									Width: PARENT_RIGHT

--- a/mods/common/chrome/ingame-info-lobby-options.yaml
+++ b/mods/common/chrome/ingame-info-lobby-options.yaml
@@ -33,11 +33,12 @@ Container@LOBBY_OPTIONS_PANEL:
 							Height: 60
 							Width: PARENT_RIGHT
 							Children:
-								Label@A_DESC:
+								LabelForInput@A_DESC:
 									X: 10
 									Width: PARENT_RIGHT / 2 - 20
 									Height: 20
 									Visible: False
+									For: A
 								DropDownButton@A:
 									X: 10
 									Y: 25
@@ -46,11 +47,12 @@ Container@LOBBY_OPTIONS_PANEL:
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
-								Label@B_DESC:
+								LabelForInput@B_DESC:
 									X: PARENT_RIGHT / 2 + 10
 									Width: PARENT_RIGHT / 2 - 20
 									Height: 20
 									Visible: False
+									For: B
 								DropDownButton@B:
 									X: PARENT_RIGHT / 2 + 10
 									Y: 25

--- a/mods/common/chrome/lobby-options.yaml
+++ b/mods/common/chrome/lobby-options.yaml
@@ -44,11 +44,12 @@ Container@LOBBY_OPTIONS_BIN:
 							Height: 60
 							Width: PARENT_RIGHT
 							Children:
-								Label@A_DESC:
+								LabelForInput@A_DESC:
 									X: 10
 									Width: PARENT_RIGHT / 3 - 20
 									Height: 20
 									Visible: False
+									For: A
 								DropDownButton@A:
 									X: 10
 									Width: PARENT_RIGHT / 3 - 20
@@ -56,11 +57,12 @@ Container@LOBBY_OPTIONS_BIN:
 									Height: 25
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
-								Label@B_DESC:
+								LabelForInput@B_DESC:
 									X: PARENT_RIGHT / 3 + 10
 									Width: PARENT_RIGHT / 3 - 20
 									Height: 20
 									Visible: False
+									For: B
 								DropDownButton@B:
 									X: PARENT_RIGHT / 3 + 10
 									Width: PARENT_RIGHT / 3 - 20
@@ -68,11 +70,12 @@ Container@LOBBY_OPTIONS_BIN:
 									Height: 25
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
-								Label@C_DESC:
+								LabelForInput@C_DESC:
 									X: (PARENT_RIGHT / 3) * 2 + 10
 									Width: PARENT_RIGHT / 3 - 20
 									Height: 20
 									Visible: False
+									For: C
 								DropDownButton@C:
 									X: (PARENT_RIGHT / 3) * 2 + 10
 									Width: PARENT_RIGHT / 3 - 20

--- a/mods/common/chrome/settings-display.yaml
+++ b/mods/common/chrome/settings-display.yaml
@@ -30,10 +30,11 @@ Container@DISPLAY_PANEL:
 							X: 10
 							Width: PARENT_RIGHT / 2 - 20
 							Children:
-								Label@PLAYER:
+								LabelForInput@PLAYER:
 									Width: PARENT_RIGHT
 									Height: 20
 									Text: Player Name:
+									For: PLAYERNAME
 								TextField@PLAYERNAME:
 									Y: 25
 									Width: PARENT_RIGHT
@@ -44,10 +45,11 @@ Container@DISPLAY_PANEL:
 							X: PARENT_RIGHT / 2 + 10
 							Width: PARENT_RIGHT / 2 - 20
 							Children:
-								Label@COLOR:
+								LabelForInput@COLOR:
 									Width: PARENT_RIGHT
 									Height: 20
 									Text: Preferred Color:
+									For: PLAYERCOLOR
 								DropDownButton@PLAYERCOLOR:
 									Y: 25
 									Width: 75
@@ -111,10 +113,11 @@ Container@DISPLAY_PANEL:
 							X: 10
 							Width: PARENT_RIGHT / 2 - 20
 							Children:
-								Label@UI_SCALE:
+								LabelForInput@UI_SCALE:
 									Width: PARENT_RIGHT
 									Height: 20
 									Text: UI Scale:
+									For: UI_SCALE_DROPDOWN
 								DropDownButton@UI_SCALE_DROPDOWN:
 									Y: 25
 									Width: PARENT_RIGHT

--- a/mods/common/metrics.yaml
+++ b/mods/common/metrics.yaml
@@ -30,6 +30,7 @@ Metrics:
 	SpawnLabelOffset: 0,1
 	TextColor: FFFFFF
 	TextHighlightColor: FFFF00
+	TextDisabledColor: 808080
 	TextContrast: false
 	TextContrastColorDark: 000000
 	TextContrastColorLight: 7F7F7F


### PR DESCRIPTION

![Screenshot-20220222173425-1282x807](https://user-images.githubusercontent.com/1355810/155183747-2b054b1b-6649-45f4-a6e8-35b539fba7d4.png)
![Screenshot-20220222173441-1282x807](https://user-images.githubusercontent.com/1355810/155183752-6caf12e2-ca3e-4cd4-93c5-345410f05bea.png)


- Add a new widget type for input and extend it from other input widgets
- Add a new label type that can be linked to an input widget
- Change the label color when the input's disabled state changes

Closes #19860