### PR TITLE
Add place variant building for BaseBuilderBotModule.

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -135,11 +135,13 @@ namespace OpenRA.Mods.Common.Traits
 				// TODO: Derive this from BuildingCommonNames instead
 				var type = BuildingType.Building;
 				CPos? location = null;
+				var actorVariant = 0;
 				string orderString = "PlaceBuilding";
 
 				// Check if Building is a plug for other Building
 				var actorInfo = world.Map.Rules.Actors[currentBuilding.Item];
 				var plugInfo = actorInfo.TraitInfoOrDefault<PlugInfo>();
+
 				if (plugInfo != null)
 				{
 					var possibleBuilding = world.ActorsWithTrait<Pluggable>().FirstOrDefault(a =>
@@ -159,7 +161,9 @@ namespace OpenRA.Mods.Common.Traits
 					else if (baseBuilder.Info.RefineryTypes.Contains(actorInfo.Name))
 						type = BuildingType.Refinery;
 
-					location = ChooseBuildLocation(currentBuilding.Item, true, type);
+					var pack = ChooseBuildLocation(currentBuilding.Item, true, type);
+					location = pack.Location;
+					actorVariant = pack.Variant;
 				}
 
 				if (location == null)
@@ -183,6 +187,9 @@ namespace OpenRA.Mods.Common.Traits
 					{
 						// Building to place
 						TargetString = currentBuilding.Item,
+
+						// Actor variant will always be small enough to safely pack in a CPos
+						ExtraLocation = new CPos(actorVariant, 0),
 
 						// Actor ID to associate the placement with
 						ExtraData = queue.Actor.ActorID,
@@ -325,8 +332,14 @@ namespace OpenRA.Mods.Common.Traits
 				if (!buildableThings.Any(b => b.Name == name))
 					continue;
 
+				// Check the number of this structure and its variants
+				var actorInfo = world.Map.Rules.Actors[name];
+				var buildingVariantInfo = actorInfo.TraitInfoOrDefault<PlaceBuildingVariantsInfo>();
+				var variants = buildingVariantInfo?.Actors ?? Array.Empty<string>();
+
+				var count = playerBuildings.Count(a => a.Info.Name == name || variants.Contains(a.Info.Name));
+
 				// Do we want to build this structure?
-				var count = playerBuildings.Count(a => a.Info.Name == name);
 				if (count * 100 > frac.Value * playerBuildings.Length)
 					continue;
 
@@ -368,36 +381,86 @@ namespace OpenRA.Mods.Common.Traits
 			return null;
 		}
 
-		CPos? ChooseBuildLocation(string actorType, bool distanceToBaseIsImportant, BuildingType type)
+		(CPos? Location, int Variant) ChooseBuildLocation(string actorType, bool distanceToBaseIsImportant, BuildingType type)
 		{
 			var actorInfo = world.Map.Rules.Actors[actorType];
 			var bi = actorInfo.TraitInfoOrDefault<BuildingInfo>();
+
 			if (bi == null)
-				return null;
+				return (null, 0);
 
 			// Find the buildable cell that is closest to pos and centered around center
-			Func<CPos, CPos, int, int, CPos?> findPos = (center, target, minRange, maxRange) =>
+			Func<CPos, CPos, int, int, (CPos? Location, int Variant)> findPos = (center, target, minRange, maxRange) =>
 			{
+				var actorVariant = 0;
+				var buildingVariantInfo = actorInfo.TraitInfoOrDefault<PlaceBuildingVariantsInfo>();
+				var variantActorInfo = actorInfo;
+				var vbi = bi;
+
 				var cells = world.Map.FindTilesInAnnulus(center, minRange, maxRange);
 
 				// Sort by distance to target if we have one
 				if (center != target)
+				{
 					cells = cells.OrderBy(c => (c - target).LengthSquared);
+
+					// Rotate building if we have a Facings in buildingVariantInfo.
+					// If we don't have Facings in buildingVariantInfo, use a random variant
+					if (buildingVariantInfo?.Actors != null)
+					{
+						if (buildingVariantInfo.Facings != null)
+						{
+							var vector = world.Map.CenterOfCell(target) - world.Map.CenterOfCell(center);
+
+							// The rotation Y point to upside vertically, so -Y = Y(rotation)
+							var desireFacing = new WAngle(WAngle.ArcSin((int)((long)Math.Abs(vector.X) * 1024 / vector.Length)).Angle);
+							if (vector.X > 0 && vector.Y >= 0)
+								desireFacing = new WAngle(512) - desireFacing;
+							else if (vector.X < 0 && vector.Y >= 0)
+								desireFacing = new WAngle(512) + desireFacing;
+							else if (vector.X < 0 && vector.Y < 0)
+								desireFacing = -desireFacing;
+
+							for (int i = 0, e = 1024; i < buildingVariantInfo.Facings.Length; i++)
+							{
+								var minDelta = Math.Min((desireFacing - buildingVariantInfo.Facings[i]).Angle, (buildingVariantInfo.Facings[i] - desireFacing).Angle);
+								if (e > minDelta)
+								{
+									e = minDelta;
+									actorVariant = i;
+								}
+							}
+						}
+						else
+							actorVariant = world.LocalRandom.Next(buildingVariantInfo.Actors.Length + 1);
+					}
+				}
 				else
+				{
 					cells = cells.Shuffle(world.LocalRandom);
+
+					if (buildingVariantInfo?.Actors != null)
+						actorVariant = world.LocalRandom.Next(buildingVariantInfo.Actors.Length + 1);
+				}
+
+				if (actorVariant != 0)
+				{
+					variantActorInfo = world.Map.Rules.Actors[buildingVariantInfo.Actors[actorVariant - 1]];
+					vbi = variantActorInfo.TraitInfoOrDefault<BuildingInfo>();
+				}
 
 				foreach (var cell in cells)
 				{
-					if (!world.CanPlaceBuilding(cell, actorInfo, bi, null))
+					if (!world.CanPlaceBuilding(cell, variantActorInfo, vbi, null))
 						continue;
 
-					if (distanceToBaseIsImportant && !bi.IsCloseEnoughToBase(world, player, actorInfo, cell))
+					if (distanceToBaseIsImportant && !vbi.IsCloseEnoughToBase(world, player, variantActorInfo, cell))
 						continue;
 
-					return cell;
+					return (cell, actorVariant);
 				}
 
-				return null;
+				return (null, 0);
 			};
 
 			var baseCenter = baseBuilder.GetRandomBaseCenter();
@@ -411,6 +474,7 @@ namespace OpenRA.Mods.Common.Traits
 						.ClosestTo(world.Map.CenterOfCell(baseBuilder.DefenseCenter));
 
 					var targetCell = closestEnemy != null ? closestEnemy.Location : baseCenter;
+
 					return findPos(baseBuilder.DefenseCenter, targetCell, baseBuilder.Info.MinimumDefenseRadius, baseBuilder.Info.MaximumDefenseRadius);
 
 				case BuildingType.Refinery:
@@ -425,7 +489,7 @@ namespace OpenRA.Mods.Common.Traits
 						foreach (var r in nearbyResources)
 						{
 							var found = findPos(baseCenter, r, baseBuilder.Info.MinBaseRadius, baseBuilder.Info.MaxBaseRadius);
-							if (found != null)
+							if (found.Location != null)
 								return found;
 						}
 					}
@@ -439,7 +503,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// Can't find a build location
-			return null;
+			return (null, 0);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Buildings/PlaceBuildingVariants.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PlaceBuildingVariants.cs
@@ -21,6 +21,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Variant actors that can be cycled between when placing a structure.")]
 		public readonly string[] Actors = null;
 
+		[Desc("Facing of the non-variant actor, followed by facings for each variant actor. The length equals the length of Actors + 1.")]
+		public readonly WAngle[] Facings = null;
+
 		public override object Create(ActorInitializer init) { return new PlaceBuildingVariants(); }
 	}
 


### PR DESCRIPTION
Add place variant building for BaseBuilderBotModule.

1. If it follow the refinery placing logic, then we can use Facings in PlaceBuildingVariants to help BaseBuilderBotModule "rotates" it to minefield.

2. If it is a normal building, BaseBuilderBotModule will place a random variant actor.

## Ingame Picture
![QQ图片20220220212022](https://user-images.githubusercontent.com/13763394/154844656-6120cca4-ed19-47f8-85d9-2f8ec896a4ed.jpg)
![QQ图片20220220212022](https://user-images.githubusercontent.com/13763394/154844729-ff6c2223-91f0-4acd-9170-3faf5d13512c.jpg)
![1](https://user-images.githubusercontent.com/13763394/156339083-6ecd11f9-0f42-4bb3-8838-cc0b1d101629.PNG)
![2](https://user-images.githubusercontent.com/13763394/156339320-b4fbc95d-5aa4-47cc-b5dd-b72d4e91f820.PNG)
![3](https://user-images.githubusercontent.com/13763394/156339442-4d72084a-a740-40f1-9d37-82c61f3caf9d.PNG)
![4](https://user-images.githubusercontent.com/13763394/156339582-5a48388c-6881-449f-9a7e-e4f9caf9feaa.PNG)


## Usage
1. Add Facing to refinery with facings like:
```
	PlaceBuildingVariants:
		Actors: refinery-nw, refinery-ne, refinery-se
		Facings: 640, 896, 128, 384 ## 640 is the actor itself facing
```

2. In AI.yaml, add All related building variants to those lines below:
```
		RefineryTypes: refinery, refinery-nw, refinery-ne, refinery-se
		PowerTypes: pwrplt, advpwr, pwrplt-3x2
		BarracksTypes: barracks, nhand, nhand-2x3
		VehiclesFactoryTypes: warfactory, airstrip
		ProductionTypes: barracks, nhand, warfactory, airstrip, helipad, nhand-2x3
```