### PR TITLE
Fix ZRamp only allowing integer values

### DIFF
--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -184,7 +184,7 @@ namespace OpenRA.Mods.Common.Graphics
 				ShadowStart = LoadField(d, "ShadowStart", -1);
 				ShadowZOffset = LoadField(d, "ShadowZOffset", DefaultShadowSpriteZOffset).Length;
 				ZOffset = LoadField(d, "ZOffset", WDist.Zero).Length;
-				ZRamp = LoadField(d, "ZRamp", 0);
+				ZRamp = LoadField(d, "ZRamp", 0f);
 				Tick = LoadField(d, "Tick", 40);
 				transpose = LoadField(d, "Transpose", false);
 				Frames = LoadField<int[]>(d, "Frames", null);


### PR DESCRIPTION
This was one of the unrelated issues raised in #19920, i finally got around to handle it. I'm not sure what ZRamp does, but it is stored as Float in the code, so i assume it was meant to accept Float values.