### PR TITLE
Update variables for Flash lua function.

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
@@ -73,11 +73,11 @@ namespace OpenRA.Mods.Common.Scripting
 			return Self.HasScriptProperty(name);
 		}
 
-		[Desc("Render a target flash on the actor. If set, 'asPlayer'",
-			"defines which player palette to use. Duration is in ticks.")]
-		public void Flash(int duration = 4, Player asPlayer = null)
+		[Desc("Render a target flash on the actor.")]
+		public void Flash(Color color, int count = 2, int interval = 2, int delay = 0)
 		{
-			Self.World.Add(new FlashTarget(Self, asPlayer?.Color ?? Color.White, duration));
+			// TODO: We can't use floats with Lua, so use the default 0.5f here
+			Self.World.Add(new FlashTarget(Self, color, 0.5f, count, interval, delay));
 		}
 
 		[Desc("The effective owner of the actor.")]


### PR DESCRIPTION
Another issue that was reported on #19920. The variables doesn't match the effect and Duration was being passed as alpha. I couldn't find any use of this in base mods, i assume that's why the issue wasn't found out so far. 

Also replaced asPlayer with just Color, you can just use Player.Color as color variable.

I asked on Discord about float variables, it seems to be currently not possible in Lua so i left the Alpha value as the default 0.5f instead of making it settable.