### PR TITLE
Add ability to override CannotPlaceNotification per queue

### DIFF
--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -166,6 +166,7 @@ namespace OpenRA.Mods.Common.Orders
 			var owner = Queue.Actor.Owner;
 			var ai = variants[variant].ActorInfo;
 			var bi = variants[variant].BuildingInfo;
+			var notification = Queue.Info.CannotPlaceAudio ?? placeBuildingInfo.CannotPlaceNotification;
 
 			if (mi.Button == MouseButton.Left)
 			{
@@ -178,7 +179,7 @@ namespace OpenRA.Mods.Common.Orders
 					orderType = "PlacePlug";
 					if (!AcceptsPlug(topLeft, plugInfo))
 					{
-						Game.Sound.PlayNotification(world.Map.Rules, owner, "Speech", placeBuildingInfo.CannotPlaceNotification, owner.Faction.InternalName);
+						Game.Sound.PlayNotification(world.Map.Rules, owner, "Speech", notification, owner.Faction.InternalName);
 						yield break;
 					}
 				}
@@ -190,7 +191,7 @@ namespace OpenRA.Mods.Common.Orders
 						foreach (var order in ClearBlockersOrders(world, topLeft))
 							yield return order;
 
-						Game.Sound.PlayNotification(world.Map.Rules, owner, "Speech", placeBuildingInfo.CannotPlaceNotification, owner.Faction.InternalName);
+						Game.Sound.PlayNotification(world.Map.Rules, owner, "Speech", notification, owner.Faction.InternalName);
 						yield break;
 					}
 

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -74,6 +74,12 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string LimitedAudio = null;
 
 		[NotificationReference("Speech")]
+		[Desc("Notification played when you can't place a building.",
+			"Overrides PlaceBuilding.CannotPlaceNotification for this queue.",
+			"The filename of the audio is defined per faction in notifications.yaml.")]
+		public readonly string CannotPlaceAudio = null;
+
+		[NotificationReference("Speech")]
 		[Desc("Notification played when user clicks on the build palette icon.",
 			"The filename of the audio is defined per faction in notifications.yaml.")]
 		public readonly string QueuedAudio = null;


### PR DESCRIPTION
Some old change i did back in Generals Alpha to allow each "dozer" to get their own notifications for it. Decided to finally try getting it to upstream. GenAlpha also had these along with rest of ProductionQueue notifications also overridable per unit under Buildable: but that was more complicated as i remember, so that'll be for later perhaps.

Added a Testcase for TD that replaces the Cannot Deploy Here notification with Structure Lost for GDI and Civilian Building Captured for Nod Building Queues; Defence ones still use the default one.

Closes #16089