### PR TITLE
Fix LineBuild custom segment checks and use of Replacable with LineBuild

### DIFF
--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -263,10 +263,18 @@ namespace OpenRA.Mods.Common.Orders
 
 				if (!Game.GetModifierKeys().HasModifier(Modifiers.Shift))
 				{
+					var segmentInfo = actorInfo;
+					var segmentBuildingInfo = buildingInfo;
+					if (!string.IsNullOrEmpty(lineBuildInfo.SegmentType))
+					{
+						segmentInfo = world.Map.Rules.Actors[lineBuildInfo.SegmentType];
+						segmentBuildingInfo = segmentInfo.TraitInfo<BuildingInfo>();
+					}
+
 					foreach (var t in BuildingUtils.GetLineBuildCells(world, topLeft, actorInfo, buildingInfo, owner))
 					{
-						var lineBuildable = world.IsCellBuildable(t.Cell, actorInfo, buildingInfo);
-						var lineCloseEnough = buildingInfo.IsCloseEnoughToBase(world, world.LocalPlayer, actorInfo, t.Cell);
+						var lineBuildable = world.IsCellBuildable(t.Cell, segmentInfo, segmentBuildingInfo);
+						var lineCloseEnough = segmentBuildingInfo.IsCloseEnoughToBase(world, world.LocalPlayer, segmentInfo, t.Cell);
 						footprint.Add(t.Cell, MakeCellType(lineBuildable && lineCloseEnough, true));
 					}
 				}

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
@@ -112,9 +112,17 @@ namespace OpenRA.Mods.Common.Traits
 					if (dirs[d] != 0)
 						continue;
 
+					var segmentInfo = ai;
+					var segmentBuildingInfo = bi;
+					if (!string.IsNullOrEmpty(lbi.SegmentType))
+					{
+						segmentInfo = world.Map.Rules.Actors[lbi.SegmentType];
+						segmentBuildingInfo = segmentInfo.TraitInfo<BuildingInfo>();
+					}
+
 					// Continue the search if the cell is empty or not visible
 					var c = topLeft + i * vecs[d];
-					if (world.IsCellBuildable(c, ai, bi) || !owner.Shroud.IsExplored(c))
+					if (world.IsCellBuildable(c, segmentInfo, segmentBuildingInfo) || !owner.Shroud.IsExplored(c))
 						continue;
 
 					// Cell contains an actor. Is it the type we want?

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -99,6 +99,16 @@ namespace OpenRA.Mods.Common.Traits
 				if (buildableInfo != null && buildableInfo.ForceFaction != null)
 					faction = buildableInfo.ForceFaction;
 
+				var replaceableTypes = actorInfo.TraitInfos<ReplacementInfo>()
+					.SelectMany(r => r.ReplaceableTypes)
+					.ToHashSet();
+
+				if (replaceableTypes.Any())
+					foreach (var t in buildingInfo.Tiles(targetLocation))
+						foreach (var a in self.World.ActorMap.GetActorsAt(t))
+							if (a.TraitsImplementing<Replaceable>().Any(r => !r.IsTraitDisabled && r.Info.Types.Overlaps(replaceableTypes)))
+								self.World.Remove(a);
+
 				if (os == "LineBuild")
 				{
 					// Build the parent actor first
@@ -123,7 +133,17 @@ namespace OpenRA.Mods.Common.Traits
 						if (t.Cell == targetLocation)
 							continue;
 
-						w.CreateActor(t.Cell == targetLocation ? actorInfo.Name : segmentType, new TypeDictionary
+						var segment = self.World.Map.Rules.Actors[segmentType];
+						var replaceableSegments = segment.TraitInfos<ReplacementInfo>()
+							.SelectMany(r => r.ReplaceableTypes)
+							.ToHashSet();
+
+						if (replaceableSegments.Any())
+							foreach (var a in self.World.ActorMap.GetActorsAt(t.Cell))
+								if (a.TraitsImplementing<Replaceable>().Any(r => !r.IsTraitDisabled && r.Info.Types.Overlaps(replaceableSegments)))
+									self.World.Remove(a);
+
+						w.CreateActor(segmentType, new TypeDictionary
 						{
 							new LocationInit(t.Cell),
 							new OwnerInit(order.Player),
@@ -162,16 +182,6 @@ namespace OpenRA.Mods.Common.Traits
 					if (!self.World.CanPlaceBuilding(targetLocation, actorInfo, buildingInfo, null)
 						|| !buildingInfo.IsCloseEnoughToBase(self.World, order.Player, actorInfo, targetLocation))
 						return;
-
-					var replaceableTypes = actorInfo.TraitInfos<ReplacementInfo>()
-						.SelectMany(r => r.ReplaceableTypes)
-						.ToHashSet();
-
-					if (replaceableTypes.Any())
-						foreach (var t in buildingInfo.Tiles(targetLocation))
-							foreach (var a in self.World.ActorMap.GetActorsAt(t))
-								if (a.TraitsImplementing<Replaceable>().Any(r => !r.IsTraitDisabled && r.Info.Types.Overlaps(replaceableTypes)))
-									self.World.Remove(a);
 
 					var building = w.CreateActor(actorInfo.Name, new TypeDictionary
 					{

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -106,6 +106,9 @@ NAFNCE:
 	EnergyWall:
 		ActiveCondition: active-posts == 2
 		Weapon: LaserFence
+		TerrainTypes: Clear, Rough, Road, DirtRoad, Green, Sand, Pavement
+	RequiresBuildableArea:
+		Adjacent: 4
 	GrantConditionOnLineBuildDirection@X:
 		Direction: X
 		Condition: laserfence-direction-x


### PR DESCRIPTION
I decided to take a look into fixing #19645. Found another issue while doing so, LineBuild code checked placeability of the original actor even if a custom SegmentType was defined.

I tested by adding the following to Laser Fence Post, Laser Fence first seperately then both to ensure either case were working.
```
	Replacement:
		ReplaceableTypes: NodGate
```

Also removed the `t.Cell == targetLocation ? actorInfo.Name : segmentType` check in PlaceBuilding.cs, a few lines above we continue the loop if `t.Cell == targetLocation` and original actor is created at the start of LineBuild case, so it was never true.

Fixes #19645.