### PR TITLE
Rework trait and weapon docs page generation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -91,7 +91,7 @@ jobs:
         env:
           GIT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          ./utility.sh all --docs "${GIT_TAG}" > "docs/api/playtest/traits.md"
+          ./utility.sh all --docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/playtest/traits.md"
           ./utility.sh all --weapon-docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/playtest/weapons.md"
           ./utility.sh all --lua-docs "${GIT_TAG}" > "docs/api/playtest/lua.md"
 
@@ -100,7 +100,7 @@ jobs:
         env:
           GIT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          ./utility.sh all --docs "${GIT_TAG}" > "docs/api/release/traits.md"
+          ./utility.sh all --docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/release/traits.md"
           ./utility.sh all --weapon-docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/release/weapons.md"
           ./utility.sh all --lua-docs "${GIT_TAG}" > "docs/api/release/lua.md"
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -92,7 +92,7 @@ jobs:
           GIT_TAG: ${{ github.event.inputs.tag }}
         run: |
           ./utility.sh all --docs "${GIT_TAG}" > "docs/api/playtest/traits.md"
-          ./utility.sh all --weapon-docs "${GIT_TAG}" > "docs/api/playtest/weapons.md"
+          ./utility.sh all --weapon-docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/playtest/weapons.md"
           ./utility.sh all --lua-docs "${GIT_TAG}" > "docs/api/playtest/lua.md"
 
       - name: Update docs.openra.net (Release)
@@ -101,7 +101,7 @@ jobs:
           GIT_TAG: ${{ github.event.inputs.tag }}
         run: |
           ./utility.sh all --docs "${GIT_TAG}" > "docs/api/release/traits.md"
-          ./utility.sh all --weapon-docs "${GIT_TAG}" > "docs/api/release/weapons.md"
+          ./utility.sh all --weapon-docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/release/weapons.md"
           ./utility.sh all --lua-docs "${GIT_TAG}" > "docs/api/release/lua.md"
 
       - name: Push docs.openra.net
@@ -111,7 +111,7 @@ jobs:
           cd docs
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"
-          git add --all
+          git add *.md
           git commit -m "Update auto-generated documentation for ${GIT_TAG}"
           git push origin master
 

--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -127,6 +127,11 @@ namespace OpenRA.GameRules
 		[FieldLoader.LoadUsing(nameof(LoadWarheads))]
 		public readonly List<IWarhead> Warheads = new List<IWarhead>();
 
+		/// <summary>
+		/// This constructor is used solely for documentation generation!
+		/// </summary>
+		public WeaponInfo() { }
+
 		public WeaponInfo(MiniYaml content)
 		{
 			// Resolve any weapon-level yaml inheritance or removals

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -226,6 +226,13 @@ namespace OpenRA.Mods.Common
 			return random.Next(range[0], range[1]);
 		}
 
+		public static string InternalTypeName(Type t)
+		{
+			return t.IsGenericType
+				? $"{t.Name.Substring(0, t.Name.IndexOf('`'))}<{string.Join(", ", t.GenericTypeArguments.Select(arg => arg.Name))}>"
+				: t.Name;
+		}
+
 		public static string FriendlyTypeName(Type t)
 		{
 			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(HashSet<>))

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -234,7 +234,7 @@ namespace OpenRA.Mods.Common
 			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Dictionary<,>))
 			{
 				var args = t.GetGenericArguments().Select(FriendlyTypeName).ToArray();
-				return $"Dictionary with Key: {args[0]}, Value {args[1]}";
+				return $"Dictionary with Key: {args[0]}, Value: {args[1]}";
 			}
 
 			if (t.IsSubclassOf(typeof(Array)))

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Reflection;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
@@ -296,6 +297,23 @@ namespace OpenRA.Mods.Common
 				return "Warhead";
 
 			return t.Name;
+		}
+
+		public static string GetAttributeParameterValue(CustomAttributeTypedArgument value)
+		{
+			if (value.ArgumentType.IsEnum)
+				return Enum.Parse(value.ArgumentType, value.Value.ToString()).ToString();
+
+			if (value.ArgumentType == typeof(Type) && value.Value != null)
+				return (value.Value as Type).Name;
+
+			if (value.ArgumentType.IsArray)
+			{
+				var names = (value.Value as IReadOnlyCollection<CustomAttributeTypedArgument>).Select(x => (x.Value as Type).Name);
+				return string.Join(", ", names);
+			}
+
+			return value.Value?.ToString();
 		}
 
 		public static int GetProjectileInaccuracy(int baseInaccuracy, InaccuracyType inaccuracyType, ProjectileArgs args)

--- a/packaging/format-docs.py
+++ b/packaging/format-docs.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
+# This file is part of OpenRA, which is free software. It is made
+# available to you under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version. For more
+# information, see COPYING.
+
+import io
+import sys
+import json
+from collections import OrderedDict
+
+def format_type_name(typeName, isKnownType):
+    name = typeName
+    if name.endswith("Info"):
+        name = name[0:-4]
+
+    return f'[`{name}`](#{name.lower()})' if isKnownType else f'`{name}`'
+
+def is_known_type(typeName, types):
+    name = typeName
+    if name.endswith("Info"):
+        name = name[0:-4]
+
+    result = [t for t in types if name == t["Name"]]
+    return len(result) > 0
+
+def format_docs(version, collectionName, types):
+    typesByNamespace = OrderedDict()
+    for currentType in types:
+        if currentType["Namespace"] in typesByNamespace:
+            typesByNamespace[currentType["Namespace"]].append(currentType)
+        else:
+            typesByNamespace[currentType["Namespace"]] = [currentType]
+
+    explanation = ""
+    if collectionName == "TraitInfos":
+        explanation = "all traits with their properties and their default values plus developer commentary"
+    elif collectionName == "WeaponTypes":
+        explanation = "a template for weapon definitions and the types it can use (warheads and projectiles) with default values and developer commentary"
+    elif collectionName == "SequenceTypes":
+        explanation = "all sequence types with their properties and their default values plus developer commentary"
+
+    print(f"This documentation is aimed at modders and has been automatically generated for version `{version}` of OpenRA. " +
+				"Please do not edit it directly, but instead add new `[Desc(\"String\")]` tags to the source code.\n")
+
+    print(f"Listed below are {explanation}.")
+
+    for namespace in typesByNamespace:
+        print(f'\n## {namespace}')
+
+        for currentType in typesByNamespace[namespace]:
+            print(f'\n### {currentType["Name"]}')
+
+            if currentType["Description"]:
+                print(f'**{currentType["Description"]}**')
+
+            if "InheritedTypes" in currentType and currentType["InheritedTypes"]:
+                inheritedTypes = [t for t in currentType["InheritedTypes"] if t not in ['TraitInfo', 'Warhead']] # Remove blacklisted types.
+                if inheritedTypes:
+                    print("###### Inherits from: " + ", ".join([format_type_name(x, is_known_type(x, types)) for x in inheritedTypes]) + '.')
+
+            if "RequiresTraits" in currentType and currentType["RequiresTraits"]:
+                print("###### Requires trait(s): " + ", ".join([format_type_name(x, is_known_type(x, types)) for x in currentType["RequiresTraits"]]) + '.')
+
+            if len(currentType["Properties"]) > 0:
+                print()
+                print(f'| Property | Default Value | Type | Description |')
+                print(f'| -------- | ------------- | ---- | ----------- |')
+
+                for prop in currentType["Properties"]:
+                    if "OtherAttributes" in prop:
+                        attributes = []
+                        for attribute in prop["OtherAttributes"]:
+                            attributes.append(attribute["Name"])
+
+                        defaultValue = ''
+                        if prop["DefaultValue"]:
+                            defaultValue = prop["DefaultValue"]
+                        elif 'Require' in attributes:
+                            defaultValue = '*(required)*'
+
+                        print(f'| {prop["PropertyName"]} | {defaultValue} | {prop["UserFriendlyType"]} | {prop["Description"]} |')
+                    else:
+                        print(f'| {prop["PropertyName"]} | {prop["DefaultValue"]} | {prop["UserFriendlyType"]} | {prop["Description"]} |')
+
+if __name__ == "__main__":
+    input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8-sig')
+    jsonInfo = json.load(input_stream)
+
+    keys = list(jsonInfo)
+    if len(keys) == 2 and keys[0] == 'Version':
+        format_docs(jsonInfo[keys[0]], keys[1], jsonInfo[keys[1]])


### PR DESCRIPTION
Initially I just wanted a flag to export the weapon docs info as JSON so that [the OpenRA Language Server (oraide)](https://github.com/penev92/Oraide.LanguageServer/) can use it in certain scenarios, but after a request by @pchote [on Discord](https://discord.com/channels/153649279762694144/388282819371204608/951233132215013457) I landed on the current solution of switching all exports to JSON and having a Python script to generate Markdown.
 - The first commit is a straight up improvement of the current code and needs to get in no matter what.
~~- After this PR is done, I'll need to do the same thing for the traits docs. (I also have the same thing lined up for sequences documentation)~~

There are two goals here:
 - To slightly update https://docs.openra.net/en/latest/release/weapons/ (without introducing any major changes). You can see the generated Markdown (generated from the generated JSON) here: https://github.com/penev92/OpenRA/wiki/Weapon-properties-documentation.
 - Same for https://docs.openra.net/en/latest/release/traits with the new Markdown showcased here: https://github.com/penev92/OpenRA/wiki/Trait-documentation-example.
 - The JSON will also be used by [oraide](https://github.com/penev92/Oraide.LanguageServer/).

P.S.: The final result is now also available on a test version of the docs site:
https://docs.openra.net/en/test/dev/traits/
https://docs.openra.net/en/test/dev/weapons/