### PR TITLE
DefeatMusic uses the unused Firestorm Map Selection rather then the regular Map Selection

### DIFF
--- a/mods/ts/audio/music.yaml
+++ b/mods/ts/audio/music.yaml
@@ -24,6 +24,8 @@ whatlurk: What Lurks
 maps: Map Selection
 	Hidden: true
 #Firestorm
+fsmap: Firestorm Map Selection
+	Hidden: true
 dmachine: Deploy Machines
 elusive: Elusive
 hacker: Hacker

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -7,7 +7,7 @@
 	ControlGroups:
 	MusicPlaylist:
 		VictoryMusic: score
-		DefeatMusic: maps
+		DefeatMusic: fsmap
 	TerrainRenderer:
 	TerrainLighting:
 	ShroudRenderer:


### PR DESCRIPTION
A really basic modification to .ymal files to play `fsmap.aud` rather than `maps.aud` when a player gets defeated.

Closes #19950