### PR TITLE
Add missing PlayerReferences in D2k map import

### DIFF
--- a/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
@@ -22,6 +22,20 @@ namespace OpenRA.Mods.D2k.UtilityCommands
 	{
 		const int MapCordonWidth = 2;
 
+		// PlayerReference colors in D2k missions only affect chat text and minimap colors because actors use specific palette colors.
+		// So using the colors from the original game's minimap.
+		public static Dictionary<string, (string Faction, Color Color)> PlayerReferenceDataByPlayerName = new Dictionary<string, (string, Color)>
+		{
+			{ "Neutral", ("Random", Color.White) },
+			{ "Atreides", ("atreides", Color.FromArgb(90, 115, 148)) },
+			{ "Harkonnen", ("harkonnen", Color.FromArgb(214, 74, 66)) },
+			{ "Ordos", ("ordos", Color.FromArgb(90, 148, 115)) },
+			{ "Corrino", ("corrino", Color.FromArgb(115, 0, 123)) },
+			{ "Fremen", ("fremen", Color.FromArgb(132, 132, 132)) },
+			{ "Smugglers", ("smuggler", Color.FromArgb(123, 41, 16)) },
+			{ "Mercenaries", ("mercenary", Color.FromArgb(156, 132, 8)) }
+		};
+
 		public static Dictionary<int, (string Actor, string Owner)> ActorDataByActorCode = new Dictionary<int, (string, string)>
 		{
 			{ 20, ("wormspawner", "Creeps") },
@@ -366,6 +380,22 @@ namespace OpenRA.Mods.D2k.UtilityCommands
 					};
 
 					map.ActorDefinitions.Add(new MiniYamlNode("Actor" + map.ActorDefinitions.Count, a.Save()));
+
+					if (map.PlayerDefinitions.All(x => x.Value.Nodes.Single(y => y.Key == "Name").Value.Value != kvp.Owner))
+					{
+						var playerInfo = PlayerReferenceDataByPlayerName[kvp.Owner];
+						var playerReference = new PlayerReference
+						{
+							Name = kvp.Owner,
+							OwnsWorld = kvp.Owner == "Neutral",
+							NonCombatant = kvp.Owner == "Neutral",
+							Faction = playerInfo.Faction,
+							Color = playerInfo.Color
+						};
+
+						var node = new MiniYamlNode($"{nameof(PlayerReference)}@{kvp.Owner}", FieldSaver.SaveDifferences(playerReference, new PlayerReference()));
+						map.PlayerDefinitions.Add(node);
+					}
 
 					if (kvp.Actor == "mpspawn")
 						playerCount++;

--- a/mods/d2k/maps/atreides-01a/map.yaml
+++ b/mods/d2k/maps/atreides-01a/map.yaml
@@ -34,14 +34,14 @@ Players:
 		Playable: true
 		Faction: atreides
 		LockFaction: true
-		Color: 9191FF
+		Color: 5A7394
 		LockColor: true
 		Enemies: Harkonnen, Creeps
 	PlayerReference@Harkonnen:
 		Name: Harkonnen
 		Faction: harkonnen
 		LockFaction: true
-		Color: FE0000
+		Color: D64A42
 		LockColor: true
 		Enemies: Atreides, Creeps
 		Bot: campaign

--- a/mods/d2k/maps/atreides-01b/map.yaml
+++ b/mods/d2k/maps/atreides-01b/map.yaml
@@ -34,14 +34,14 @@ Players:
 		Playable: true
 		Faction: atreides
 		LockFaction: true
-		Color: 9191FF
+		Color: 5A7394
 		LockColor: true
 		Enemies: Harkonnen, Creeps
 	PlayerReference@Harkonnen:
 		Name: Harkonnen
 		Faction: harkonnen
 		LockFaction: true
-		Color: FE0000
+		Color: D64A42
 		LockColor: true
 		Enemies: Atreides, Creeps
 		Bot: campaign

--- a/mods/d2k/maps/atreides-02a/map.yaml
+++ b/mods/d2k/maps/atreides-02a/map.yaml
@@ -33,14 +33,14 @@ Players:
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Enemies: Harkonnen, Creeps
 	PlayerReference@Harkonnen:
 		Name: Harkonnen
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Atreides, Creeps
 		Bot: campaign
 

--- a/mods/d2k/maps/atreides-02b/map.yaml
+++ b/mods/d2k/maps/atreides-02b/map.yaml
@@ -33,14 +33,14 @@ Players:
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Enemies: Harkonnen, Creeps
 	PlayerReference@Harkonnen:
 		Name: Harkonnen
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Atreides, Creeps
 		Bot: campaign
 

--- a/mods/d2k/maps/atreides-03a/map.yaml
+++ b/mods/d2k/maps/atreides-03a/map.yaml
@@ -33,14 +33,14 @@ Players:
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Enemies: Ordos, Creeps
 	PlayerReference@Ordos:
 		Name: Ordos
 		LockFaction: True
 		Faction: ordos
 		LockColor: True
-		Color: B3EAA5
+		Color: 5A9473
 		Enemies: Atreides, Creeps
 		Bot: campaign
 

--- a/mods/d2k/maps/atreides-03b/map.yaml
+++ b/mods/d2k/maps/atreides-03b/map.yaml
@@ -33,14 +33,14 @@ Players:
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Enemies: Ordos, Creeps
 	PlayerReference@Ordos:
 		Name: Ordos
 		LockFaction: True
 		Faction: ordos
 		LockColor: True
-		Color: B3EAA5
+		Color: 5A9473
 		Enemies: Atreides, Creeps
 		Bot: campaign
 

--- a/mods/d2k/maps/atreides-04/map.yaml
+++ b/mods/d2k/maps/atreides-04/map.yaml
@@ -35,7 +35,7 @@ Players:
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Allies: Fremen
 		Enemies: Harkonnen, Creeps
 	PlayerReference@Harkonnen:
@@ -43,7 +43,7 @@ Players:
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Atreides, Creeps, Fremen
 		Bot: campaign
 	PlayerReference@Fremen:
@@ -51,7 +51,7 @@ Players:
 		LockFaction: True
 		Faction: fremen
 		LockColor: True
-		Color: DDDDDD
+		Color: 848484
 		Allies: Atreides
 		Enemies: Harkonnen, Creeps
 		Bot: campaign

--- a/mods/d2k/maps/atreides-05/map.yaml
+++ b/mods/d2k/maps/atreides-05/map.yaml
@@ -35,14 +35,14 @@ Players:
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Enemies: Harkonnen, Smugglers, Mercenaries, Creeps
 	PlayerReference@Harkonnen:
 		Name: Harkonnen
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Atreides, Creeps
 		Bot: campaign
 	PlayerReference@Smugglers:
@@ -50,7 +50,7 @@ Players:
 		LockFaction: True
 		Faction: smuggler
 		LockColor: True
-		Color: 542209
+		Color: 7B2910
 		Allies: Mercenaries
 		Enemies: Atreides, Creeps
 		Bot: campaign
@@ -59,7 +59,7 @@ Players:
 		LockFaction: True
 		Faction: mercenary
 		LockColor: True
-		Color: DDDD00
+		Color: 9C8408
 		Allies: Smugglers
 		Enemies: Atreides, Creeps
 		Bot: campaign

--- a/mods/d2k/maps/harkonnen-01a/map.yaml
+++ b/mods/d2k/maps/harkonnen-01a/map.yaml
@@ -34,14 +34,14 @@ Players:
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Atreides, Creeps
 	PlayerReference@Atreides:
 		Name: Atreides
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Enemies: Harkonnen, Creeps
 		Bot: campaign
 

--- a/mods/d2k/maps/harkonnen-01b/map.yaml
+++ b/mods/d2k/maps/harkonnen-01b/map.yaml
@@ -34,14 +34,14 @@ Players:
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Atreides, Creeps
 	PlayerReference@Atreides:
 		Name: Atreides
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Enemies: Harkonnen, Creeps
 		Bot: campaign
 

--- a/mods/d2k/maps/harkonnen-02a/map.yaml
+++ b/mods/d2k/maps/harkonnen-02a/map.yaml
@@ -33,14 +33,14 @@ Players:
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Atreides, Creeps
 	PlayerReference@Atreides:
 		Name: Atreides
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Enemies: Harkonnen, Creeps
 		Bot: campaign
 

--- a/mods/d2k/maps/harkonnen-02b/map.yaml
+++ b/mods/d2k/maps/harkonnen-02b/map.yaml
@@ -33,14 +33,14 @@ Players:
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Atreides, Creeps
 	PlayerReference@Atreides:
 		Name: Atreides
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Enemies: Harkonnen, Creeps
 		Bot: campaign
 

--- a/mods/d2k/maps/harkonnen-03a/map.yaml
+++ b/mods/d2k/maps/harkonnen-03a/map.yaml
@@ -33,14 +33,14 @@ Players:
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Atreides, Creeps
 	PlayerReference@Atreides:
 		Name: Atreides
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Enemies: Harkonnen, Creeps
 		Bot: campaign
 

--- a/mods/d2k/maps/harkonnen-03b/map.yaml
+++ b/mods/d2k/maps/harkonnen-03b/map.yaml
@@ -33,14 +33,14 @@ Players:
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Atreides, Creeps
 	PlayerReference@Atreides:
 		Name: Atreides
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Enemies: Harkonnen, Creeps
 		Bot: campaign
 

--- a/mods/d2k/maps/harkonnen-04/map.yaml
+++ b/mods/d2k/maps/harkonnen-04/map.yaml
@@ -33,14 +33,14 @@ Players:
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Atreides, Fremen, Creeps
 	PlayerReference@Atreides:
 		Name: Atreides
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Allies: Fremen
 		Enemies: Harkonnen, Creeps
 		Bot: campaign
@@ -49,7 +49,7 @@ Players:
 		LockFaction: True
 		Faction: fremen
 		LockColor: True
-		Color: DDDDDD
+		Color: 848484
 		Allies: Atreides
 		Enemies: Harkonnen, Creeps
 		Bot: campaign

--- a/mods/d2k/maps/harkonnen-05/map.yaml
+++ b/mods/d2k/maps/harkonnen-05/map.yaml
@@ -33,14 +33,14 @@ Players:
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Ordos Main Base, Ordos Small Base, Corrino, Creeps
 	PlayerReference@Ordos Main Base:
 		Name: Ordos Main Base
 		LockFaction: True
 		Faction: ordos
 		LockColor: True
-		Color: B3EAA5
+		Color: 5A9473
 		Allies: Ordos Small Base, Corrino
 		Enemies: Harkonnen, Creeps
 		Bot: campaign
@@ -49,7 +49,7 @@ Players:
 		LockFaction: True
 		Faction: ordos
 		LockColor: True
-		Color: B3EAA5
+		Color: 5A9473
 		Allies: Ordos Main Base, Corrino
 		Enemies: Harkonnen, Creeps
 		Bot: campaign
@@ -58,7 +58,7 @@ Players:
 		LockFaction: True
 		Faction: corrino
 		LockColor: True
-		Color: 7D00FE
+		Color: 73007B
 		Allies: Ordos Main Base, Ordos Small Base
 		Enemies: Harkonnen, Creeps
 		Bot: campaign

--- a/mods/d2k/maps/harkonnen-06a/map.yaml
+++ b/mods/d2k/maps/harkonnen-06a/map.yaml
@@ -33,14 +33,14 @@ Players:
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Ordos Main Base, Ordos Small Base, Smugglers - Enemy to Harkonnen, Smugglers - Enemy to Both, Creeps
 	PlayerReference@Ordos Main Base:
 		Name: Ordos Main Base
 		LockFaction: True
 		Faction: ordos
 		LockColor: True
-		Color: B3EAA5
+		Color: 5A9473
 		Allies: Ordos Small Base
 		Enemies: Harkonnen, Smugglers - Enemy to Ordos, Smugglers - Enemy to Both, Creeps
 		Bot: campaign
@@ -49,7 +49,7 @@ Players:
 		LockFaction: True
 		Faction: ordos
 		LockColor: True
-		Color: B3EAA5
+		Color: 5A9473
 		Allies: Ordos Main Base
 		Enemies: Harkonnen, Smugglers - Enemy to Ordos, Smugglers - Enemy to Both, Creeps
 		Bot: campaign
@@ -59,7 +59,7 @@ Players:
 		LockFaction: True
 		Faction: smuggler
 		LockColor: True
-		Color: 542209
+		Color: 7B2910
 		Bot: campaign
 		Enemies: Creeps
 	PlayerReference@Smugglers - Enemy to Harkonnen:
@@ -68,7 +68,7 @@ Players:
 		LockFaction: True
 		Faction: smuggler
 		LockColor: True
-		Color: 542209
+		Color: 7B2910
 		Enemies: Harkonnen, Creeps
 		Bot: campaign
 	PlayerReference@Smugglers - Enemy to Ordos:
@@ -77,7 +77,7 @@ Players:
 		LockFaction: True
 		Faction: smuggler
 		LockColor: True
-		Color: 542209
+		Color: 7B2910
 		Enemies: Ordos Main Base, Ordos Small Base, Creeps
 		Bot: campaign
 	PlayerReference@Smugglers - Enemy to Both:
@@ -86,7 +86,7 @@ Players:
 		LockFaction: True
 		Faction: smuggler
 		LockColor: True
-		Color: 542209
+		Color: 7B2910
 		Enemies: Harkonnen, Ordos Main Base, Ordos Small Base, Creeps
 		Bot: campaign
 

--- a/mods/d2k/maps/harkonnen-06b/map.yaml
+++ b/mods/d2k/maps/harkonnen-06b/map.yaml
@@ -33,14 +33,14 @@ Players:
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Ordos Main Base, Ordos Small Base, Smugglers - Enemy to Harkonnen, Smugglers - Enemy to Both, Creeps
 	PlayerReference@Ordos Main Base:
 		Name: Ordos Main Base
 		LockFaction: True
 		Faction: ordos
 		LockColor: True
-		Color: B3EAA5
+		Color: 5A9473
 		Allies: Ordos Small Base
 		Enemies: Harkonnen, Smugglers - Enemy to Ordos, Smugglers - Enemy to Both, Creeps
 		Bot: campaign
@@ -49,7 +49,7 @@ Players:
 		LockFaction: True
 		Faction: ordos
 		LockColor: True
-		Color: B3EAA5
+		Color: 5A9473
 		Allies: Ordos Main Base
 		Enemies: Harkonnen, Smugglers - Enemy to Ordos, Smugglers - Enemy to Both, Creeps
 		Bot: campaign
@@ -59,7 +59,7 @@ Players:
 		LockFaction: True
 		Faction: smuggler
 		LockColor: True
-		Color: 542209
+		Color: 7B2910
 		Bot: campaign
 		Enemies: Creeps
 	PlayerReference@Smugglers - Enemy to Harkonnen:
@@ -68,7 +68,7 @@ Players:
 		LockFaction: True
 		Faction: smuggler
 		LockColor: True
-		Color: 542209
+		Color: 7B2910
 		Enemies: Harkonnen, Creeps
 		Bot: campaign
 	PlayerReference@Smugglers - Enemy to Ordos:
@@ -77,7 +77,7 @@ Players:
 		LockFaction: True
 		Faction: smuggler
 		LockColor: True
-		Color: 542209
+		Color: 7B2910
 		Enemies: Ordos Main Base, Ordos Small Base, Creeps
 		Bot: campaign
 	PlayerReference@Smugglers - Enemy to Both:
@@ -86,7 +86,7 @@ Players:
 		LockFaction: True
 		Faction: smuggler
 		LockColor: True
-		Color: 542209
+		Color: 7B2910
 		Enemies: Harkonnen, Ordos Main Base, Ordos Small Base, Creeps
 		Bot: campaign
 

--- a/mods/d2k/maps/harkonnen-07/map.yaml
+++ b/mods/d2k/maps/harkonnen-07/map.yaml
@@ -33,14 +33,14 @@ Players:
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Atreides Main Base, Atreides Small Base, Corrino, Creeps
 	PlayerReference@Atreides Main Base:
 		Name: Atreides Main Base
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Allies: Atreides Small Base, Corrino
 		Enemies: Harkonnen, Creeps
 		Bot: campaign
@@ -49,7 +49,7 @@ Players:
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Allies: Atreides Main Base, Corrino
 		Enemies: Harkonnen, Creeps
 		Bot: campaign
@@ -58,7 +58,7 @@ Players:
 		LockFaction: True
 		Faction: corrino
 		LockColor: True
-		Color: 7D00FE
+		Color: 73007B
 		Allies: Atreides Main Base, Atreides Small Base
 		Enemies: Harkonnen, Creeps
 		Bot: campaign

--- a/mods/d2k/maps/harkonnen-08/map.yaml
+++ b/mods/d2k/maps/harkonnen-08/map.yaml
@@ -33,7 +33,7 @@ Players:
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Allies: Harkonnen Aligned Mercenaries
 		Enemies: Ordos Aligned Atreides, Ordos, Ordos Aligned Mercenaries, Creeps
 	PlayerReference@Ordos Aligned Atreides:
@@ -41,7 +41,7 @@ Players:
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Allies: Ordos, Ordos Aligned Mercenaries
 		Enemies: Harkonnen, Harkonnen Aligned Mercenaries, Creeps
 		Bot: campaign
@@ -50,7 +50,7 @@ Players:
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Bot: campaign
 		Enemies: Creeps
 	PlayerReference@Ordos:
@@ -58,7 +58,7 @@ Players:
 		LockFaction: True
 		Faction: ordos
 		LockColor: True
-		Color: B3EAA5
+		Color: 5A9473
 		Allies: Ordos Aligned Atreides, Ordos Aligned Mercenaries
 		Enemies: Harkonnen, Harkonnen Aligned Mercenaries, Creeps
 		Bot: campaign
@@ -67,7 +67,7 @@ Players:
 		LockFaction: True
 		Faction: mercenary
 		LockColor: True
-		Color: DDDD00
+		Color: 9C8408
 		Allies: Ordos, Ordos Aligned Atreides
 		Enemies: Harkonnen, Creeps
 		Bot: campaign
@@ -76,7 +76,7 @@ Players:
 		LockFaction: True
 		Faction: mercenary
 		LockColor: True
-		Color: DDDD00
+		Color: 9C8408
 		Allies: Harkonnen
 		Enemies: Ordos, Ordos Aligned Atreides, Creeps
 		Bot: campaign

--- a/mods/d2k/maps/harkonnen-09a/map.yaml
+++ b/mods/d2k/maps/harkonnen-09a/map.yaml
@@ -33,14 +33,14 @@ Players:
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Atreides Main Base, Atreides Small Base 1, Atreides Small Base 2, Corrino Main Base, Corrino Small Base, Creeps
 	PlayerReference@Atreides Main Base:
 		Name: Atreides Main Base
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Allies: Atreides Small Base 1, Atreides Small Base 2, Corrino Main Base, Corrino Small Base
 		Enemies: Harkonnen, Creeps
 		Bot: campaign
@@ -49,7 +49,7 @@ Players:
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Allies: Atreides Main Base, Atreides Small Base 2, Corrino Main Base, Corrino Small Base
 		Enemies: Harkonnen, Creeps
 		Bot: campaign
@@ -58,7 +58,7 @@ Players:
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Allies: Atreides Main Base, Atreides Small Base 1, Corrino Main Base, Corrino Small Base
 		Enemies: Harkonnen, Creeps
 		Bot: campaign
@@ -67,7 +67,7 @@ Players:
 		LockFaction: True
 		Faction: corrino
 		LockColor: True
-		Color: 7D00FE
+		Color: 73007B
 		Allies: Atreides Main Base, Atreides Small Base 1, Atreides Small Base 2, Corrino Small Base
 		Enemies: Harkonnen, Creeps
 		Bot: campaign
@@ -76,7 +76,7 @@ Players:
 		LockFaction: True
 		Faction: corrino
 		LockColor: True
-		Color: 7D00FE
+		Color: 73007B
 		Allies: Atreides Main Base, Atreides Small Base 1, Atreides Small Base 2, Corrino Main Base
 		Enemies: Harkonnen, Creeps
 		Bot: campaign

--- a/mods/d2k/maps/harkonnen-09b/map.yaml
+++ b/mods/d2k/maps/harkonnen-09b/map.yaml
@@ -33,14 +33,14 @@ Players:
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Atreides Main Base, Atreides Small Base, Corrino Main Base, Corrino Small Base, Smugglers - Enemy to Harkonnen, Smugglers - Enemy to Both, Creeps
 	PlayerReference@Atreides Main Base:
 		Name: Atreides Main Base
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Allies: Atreides Small Base, Corrino Main Base, Corrino Small Base
 		Enemies: Harkonnen, Smugglers - Enemy to AI, Smugglers - Enemy to Both, Creeps
 		Bot: campaign
@@ -49,7 +49,7 @@ Players:
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Allies: Atreides Main Base, Corrino Main Base, Corrino Small Base
 		Enemies: Harkonnen, Smugglers - Enemy to AI, Smugglers - Enemy to Both, Creeps
 		Bot: campaign
@@ -58,7 +58,7 @@ Players:
 		LockFaction: True
 		Faction: corrino
 		LockColor: True
-		Color: 7D00FE
+		Color: 73007B
 		Allies: Atreides Main Base, Atreides Small Base, Corrino Small Base
 		Enemies: Harkonnen, Smugglers - Enemy to AI, Smugglers - Enemy to Both, Creeps
 		Bot: campaign
@@ -67,7 +67,7 @@ Players:
 		LockFaction: True
 		Faction: corrino
 		LockColor: True
-		Color: 7D00FE
+		Color: 73007B
 		Allies: Atreides Main Base, Atreides Small Base, Corrino Main Base
 		Enemies: Harkonnen, Smugglers - Enemy to AI, Smugglers - Enemy to Both, Creeps
 		Bot: campaign
@@ -77,7 +77,7 @@ Players:
 		LockFaction: True
 		Faction: smuggler
 		LockColor: True
-		Color: 542209
+		Color: 7B2910
 		Bot: campaign
 		Enemies: Creeps
 	PlayerReference@Smugglers - Enemy to Harkonnen:
@@ -86,7 +86,7 @@ Players:
 		LockFaction: True
 		Faction: smuggler
 		LockColor: True
-		Color: 542209
+		Color: 7B2910
 		Enemies: Harkonnen, Creeps
 		Bot: campaign
 	PlayerReference@Smugglers - Enemy to AI:
@@ -95,7 +95,7 @@ Players:
 		LockFaction: True
 		Faction: smuggler
 		LockColor: True
-		Color: 542209
+		Color: 7B2910
 		Enemies: Atreides Main Base, Atreides Small Base, Corrino Main Base, Corrino Small Base, Creeps
 		Bot: campaign
 	PlayerReference@Smugglers - Enemy to Both:
@@ -104,7 +104,7 @@ Players:
 		LockFaction: True
 		Faction: smuggler
 		LockColor: True
-		Color: 542209
+		Color: 7B2910
 		Enemies: Harkonnen, Atreides Main Base, Atreides Small Base, Corrino Main Base, Corrino Small Base, Creeps
 		Bot: campaign
 

--- a/mods/d2k/maps/ordos-01a/map.yaml
+++ b/mods/d2k/maps/ordos-01a/map.yaml
@@ -35,14 +35,14 @@ Players:
 		LockFaction: True
 		Faction: ordos
 		LockColor: True
-		Color: B3EAA5
+		Color: 5A9473
 		Enemies: Harkonnen, Creeps
 	PlayerReference@Harkonnen:
 		Name: Harkonnen
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Ordos, Creeps
 		Bot: campaign
 

--- a/mods/d2k/maps/ordos-01b/map.yaml
+++ b/mods/d2k/maps/ordos-01b/map.yaml
@@ -35,14 +35,14 @@ Players:
 		LockFaction: True
 		Faction: ordos
 		LockColor: True
-		Color: B3EAA5
+		Color: 5A9473
 		Enemies: Harkonnen, Creeps
 	PlayerReference@Harkonnen:
 		Name: Harkonnen
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Ordos, Creeps
 		Bot: campaign
 

--- a/mods/d2k/maps/ordos-02a/map.yaml
+++ b/mods/d2k/maps/ordos-02a/map.yaml
@@ -35,14 +35,14 @@ Players:
 		LockFaction: True
 		Faction: ordos
 		LockColor: True
-		Color: B3EAA5
+		Color: 5A9473
 		Enemies: Harkonnen, Creeps
 	PlayerReference@Harkonnen:
 		Name: Harkonnen
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Ordos, Creeps
 		Bot: campaign
 

--- a/mods/d2k/maps/ordos-02b/map.yaml
+++ b/mods/d2k/maps/ordos-02b/map.yaml
@@ -35,14 +35,14 @@ Players:
 		LockFaction: True
 		Faction: ordos
 		LockColor: True
-		Color: B3EAA5
+		Color: 5A9473
 		Enemies: Harkonnen, Creeps
 	PlayerReference@Harkonnen:
 		Name: Harkonnen
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Ordos, Creeps
 		Bot: campaign
 

--- a/mods/d2k/maps/ordos-03a/map.yaml
+++ b/mods/d2k/maps/ordos-03a/map.yaml
@@ -35,14 +35,14 @@ Players:
 		LockFaction: True
 		Faction: ordos
 		LockColor: True
-		Color: B3EAA5
+		Color: 5A9473
 		Enemies: Harkonnen, Creeps
 	PlayerReference@Harkonnen:
 		Name: Harkonnen
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Ordos, Creeps
 		Bot: campaign
 

--- a/mods/d2k/maps/ordos-03b/map.yaml
+++ b/mods/d2k/maps/ordos-03b/map.yaml
@@ -35,14 +35,14 @@ Players:
 		LockFaction: True
 		Faction: ordos
 		LockColor: True
-		Color: B3EAA5
+		Color: 5A9473
 		Enemies: Harkonnen, Creeps
 	PlayerReference@Harkonnen:
 		Name: Harkonnen
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Enemies: Ordos, Creeps
 		Bot: campaign
 

--- a/mods/d2k/maps/ordos-04/map.yaml
+++ b/mods/d2k/maps/ordos-04/map.yaml
@@ -35,14 +35,14 @@ Players:
 		LockFaction: True
 		Faction: ordos
 		LockColor: True
-		Color: B3EAA5
+		Color: 5A9473
 		Enemies: Harkonnen, Smugglers, Creeps
 	PlayerReference@Harkonnen:
 		Name: Harkonnen
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Allies: Smugglers
 		Enemies: Ordos, Creeps
 		Bot: campaign
@@ -51,7 +51,7 @@ Players:
 		LockFaction: True
 		Faction: smuggler
 		LockColor: True
-		Color: 542209
+		Color: 7B2910
 		Allies: Harkonnen
 		Enemies: Ordos, Creeps
 		Bot: campaign

--- a/mods/d2k/maps/ordos-05/map.yaml
+++ b/mods/d2k/maps/ordos-05/map.yaml
@@ -35,14 +35,14 @@ Players:
 		LockFaction: True
 		Faction: ordos
 		LockColor: True
-		Color: B3EAA5
+		Color: 5A9473
 		Enemies: AtreidesMainBase, AtreidesSmallBase1, AtreidesSmallBase2, AtreidesSmallBase3, Creeps
 	PlayerReference@AtreidesMainBase:
 		Name: AtreidesMainBase
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Allies: AtreidesSmallBase1, AtreidesSmallBase2
 		Enemies: Ordos, Creeps
 		Bot: campaign
@@ -51,7 +51,7 @@ Players:
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Allies: AtreidesMainBase, AtreidesSmallBase2, AtreidesSmallBase3
 		Enemies: Ordos, Creeps
 		Bot: campaign
@@ -60,7 +60,7 @@ Players:
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Allies: AtreidesMainBase, AtreidesSmallBase1, AtreidesSmallBase3
 		Enemies: Ordos, Creeps
 		Bot: campaign
@@ -69,7 +69,7 @@ Players:
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Allies: AtreidesMainBase, AtreidesSmallBase1, AtreidesSmallBase2
 		Enemies: Ordos, Creeps
 		Bot: campaign

--- a/mods/d2k/maps/ordos-06a/map.yaml
+++ b/mods/d2k/maps/ordos-06a/map.yaml
@@ -35,14 +35,14 @@ Players:
 		LockFaction: True
 		Faction: ordos
 		LockColor: True
-		Color: B3EAA5
+		Color: 5A9473
 		Enemies: Atreides, Harkonnen, Creeps
 	PlayerReference@Atreides:
 		Name: Atreides
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
-		Color: 9191FF
+		Color: 5A7394
 		Allies: Harkonnen
 		Enemies: Ordos, Creeps
 	PlayerReference@Harkonnen:
@@ -50,7 +50,7 @@ Players:
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True
-		Color: FE0000
+		Color: D64A42
 		Allies: Atreides
 		Enemies: Ordos, Creeps
 

--- a/mods/d2k/maps/shellmap/map.yaml
+++ b/mods/d2k/maps/shellmap/map.yaml
@@ -20,27 +20,27 @@ Players:
 	PlayerReference@Atreides:
 		Name: Atreides
 		Faction: atreides
-		Color: 9191FF
+		Color: 5A7394
 		Enemies: Corrino, Ordos, Harkonnen, Creeps
 	PlayerReference@Corrino:
 		Name: Corrino
 		Faction: corrino
-		Color: EF00FE
+		Color: 73007B
 		Enemies: Atreides, Ordos, Harkonnen, Creeps
 	PlayerReference@Ordos:
 		Name: Ordos
 		Faction: ordos
-		Color: B3EAA5
+		Color: 5A9473
 		Enemies: Atreides, Corrino, Harkonnen, Creeps
 	PlayerReference@Harkonnen:
 		Name: Harkonnen
 		Faction: harkonnen
-		Color: FE0000
+		Color: D64A42
 		Enemies: Atreides, Corrino, Ordos, Creeps
 	PlayerReference@Smugglers:
 		Name: Smugglers
 		Faction: smuggler
-		Color: 542209
+		Color: 7B2910
 		Enemies: Creeps
 	PlayerReference@Neutral:
 		Name: Neutral


### PR DESCRIPTION
Fixes #19783 by adding the relevant player references, which allows the map import process to finish. Then the user is free to manually fix the automated player references as needed.