### PR TITLE
Split NukePower MissileImage from MissileWeapon and make it optional

### DIFF
--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -25,18 +25,20 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[WeaponReference]
 		[FieldLoader.Require]
-		[Desc("Weapon to use for the impact.",
-			"Also image to use for the missile.")]
+		[Desc("Weapon to use for the impact.")]
 		public readonly string MissileWeapon = "";
 
 		[Desc("Delay (in ticks) after launch until the missile is spawned.")]
 		public readonly int MissileDelay = 0;
 
-		[SequenceReference(nameof(MissileWeapon))]
+		[Desc("Image to use for the missile.")]
+		public readonly string MissileImage = null;
+
+		[SequenceReference(nameof(MissileImage))]
 		[Desc("Sprite sequence for the ascending missile.")]
 		public readonly string MissileUp = "up";
 
-		[SequenceReference(nameof(MissileWeapon))]
+		[SequenceReference(nameof(MissileImage))]
 		[Desc("Sprite sequence for the descending missile.")]
 		public readonly string MissileDown = "down";
 
@@ -168,7 +170,7 @@ namespace OpenRA.Mods.Common.Traits
 			var skipAscent = info.SkipAscent || body == null;
 			var launchPos = skipAscent ? WPos.Zero : self.CenterPosition + body.LocalToWorld(info.SpawnOffset);
 
-			var missile = new NukeLaunch(self.Owner, info.MissileWeapon, info.WeaponInfo, palette, info.MissileUp, info.MissileDown,
+			var missile = new NukeLaunch(self.Owner, info.MissileImage, info.WeaponInfo, palette, info.MissileUp, info.MissileDown,
 				launchPos,
 				targetPosition, info.DetonationAltitude, info.RemoveMissileOnDetonation,
 				info.FlightVelocity, info.MissileDelay, info.FlightDelay, skipAscent,

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20201213/SplitNukePowerMissileImage.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20201213/SplitNukePowerMissileImage.cs
@@ -1,0 +1,40 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class SplitNukePowerMissileImage : UpdateRule
+	{
+		public override string Name => "NukePower now defines the image for the missile with MissileImage.";
+
+		public override string Description =>
+			"NukePower used MissileWeapon field for as the name for missile image too.\n" +
+			"This function has been moved to its own MissileImage field.";
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var nukePowerNode in actorNode.ChildrenMatching("NukePower"))
+			{
+				var missileWeaponNode = nukePowerNode.ChildrenMatching("MissileWeapon").FirstOrDefault();
+				if (missileWeaponNode != null)
+				{
+					var weapon = missileWeaponNode.NodeValue<string>();
+					nukePowerNode.AddNode(new MiniYamlNode("MissileImage", weapon));
+				}
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -92,6 +92,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new AttackBomberFacingTolerance(),
 				new AttackFrontalFacingTolerance(),
 				new RenameCloakTypes(),
+				new SplitNukePowerMissileImage(),
 			})
 		};
 

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -806,6 +806,7 @@ TMPL:
 		LaunchSpeechNotification: NuclearWeaponLaunched
 		IncomingSpeechNotification: NuclearWarheadApproaching
 		MissileWeapon: atomic
+		MissileImage: atomic
 		MissileDelay: 11
 		SpawnOffset: 3c0,0,-1c512
 		DisplayBeacon: True

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -1066,6 +1066,7 @@ palace:
 		EndChargeSpeechNotification: DeathHandMissileReady
 		IncomingSpeechNotification: MissileLaunchDetected
 		MissileWeapon: deathhand
+		MissileImage: deathhand
 		MissileDelay: 18
 		SpawnOffset: 32,816,0
 		DetonationAltitude: 3c0

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -45,6 +45,7 @@ MSLO:
 		InsufficientPowerSpeechNotification: InsufficientPower
 		IncomingSpeechNotification: AbombLaunchDetected
 		MissileWeapon: atomic
+		MissileImage: atomic
 		MissileDelay: 5
 		SpawnOffset: 1c0,427,0
 		DisplayTimerRelationships: Ally, Neutral, Enemy

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -527,6 +527,7 @@ NAMISL:
 		IncomingSpeechNotification: MissileLaunchDetected
 		LaunchSound: icbm1.aud
 		MissileWeapon: ClusterMissile
+		MissileImage: ClusterMissile
 		MissileDelay: 18
 		DetonationAltitude: 5c0
 		SpawnOffset: 0, 0c128, 0c512


### PR DESCRIPTION
Something i had noticed while editing MissileWeapon to use SW Level logic i have in RV Engine.

I also made it optional, not sure what his exact reasoning was but dnqbob had changed most SWs in SP to NukePower mostly with a dummy image, so making it optional here would remove need for the dummy image there. Not sure if there would be a more legit usecase of not having a missile image. I'm a bit unsure with how i handled it tho, as i had to add null or empty checks to 5 places in that file.

Also would be nice, if someone can reword the update rule name/descs, i dunno if i like what i wrote there.