### PR TITLE
Fix Army Spectator tab not using FactionImages

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -159,7 +159,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (BuildableInfo != null && rsi != null)
 			{
-				var image = rsi.GetImage(actorInfo, owner.Faction.Name);
+				var image = rsi.GetImage(actorInfo, owner.Faction.InternalName);
 				Icon = new Animation(owner.World, image);
 				Icon.Play(BuildableInfo.Icon);
 				IconPalette = BuildableInfo.IconPalette;


### PR DESCRIPTION
Fixes #18433. I had not investigated the issue when i first noticed it, seems like it was just because the visible name of the faction was being passed in GetImage, instead of the InternalName.

Added a testcase that makes D2k buildings appear on the Army tab.