### PR TITLE
Fix network desync

### DIFF
--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -59,6 +59,7 @@ namespace OpenRA.Network
 		bool generateSyncReport = false;
 		int sentOrdersFrame = 0;
 		float tickScale = 1f;
+		bool outOfSync = false;
 
 		public struct ClientOrder
 		{
@@ -73,8 +74,14 @@ namespace OpenRA.Network
 
 		void OutOfSync(int frame)
 		{
+			if (outOfSync)
+				return;
+
 			syncReport.DumpSyncReport(frame);
-			throw new InvalidOperationException($"Out of sync in frame {frame}.\n Compare syncreport.log with other players.");
+			World.OutOfSync();
+			outOfSync = true;
+
+			TextNotificationsManager.AddSystemLine($"Out of sync in frame {frame}.\nCompare syncreport.log with other players.");
 		}
 
 		public void StartGame()

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -598,6 +598,13 @@ namespace OpenRA
 
 			Game.FinishBenchmark();
 		}
+
+		public void OutOfSync()
+		{
+			EndGame();
+			SetPauseState(true);
+			PauseStateLocked = true;
+		}
 	}
 
 	public readonly struct TraitPair<T> : IEquatable<TraitPair<T>>


### PR DESCRIPTION
Fixes the problem with desync crashes only happens on one client.

The problem was that we added the local sync packets before we had sent them to the server, so it crashed directly when we revived the sync packet from the other player, before we had the chance to send ours. 