### PR TITLE
Fix crash in TSEditorResourceLayer when adding resources.

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/World/TSEditorResourceLayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSEditorResourceLayer.cs
@@ -99,6 +99,9 @@ namespace OpenRA.Mods.Cnc.Traits
 			var resourceIsVeins = resourceType == info.VeinType;
 			foreach (var c in Common.Util.ExpandFootprint(cell, false))
 			{
+				if (!Map.Resources.Contains(c))
+					continue;
+
 				var resourceIndex = Map.Resources[c].Type;
 				if (resourceIndex == 0 || !ResourceTypesByIndex.TryGetValue(resourceIndex, out var neighourResourceType))
 					neighourResourceType = null;


### PR DESCRIPTION
Ensure cells are within map bounds when checking if adjacent cells should be cleared during resource placement.

Fixes #19957