### PR TITLE
Tweak handling of nullable types in LUA doc generation.

### DIFF
--- a/OpenRA.Game/Scripting/ScriptMemberExts.cs
+++ b/OpenRA.Game/Scripting/ScriptMemberExts.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Scripting
 				ret = t.Name;
 
 			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Nullable<>))
-				ret = $"{t.GetGenericArguments().Select(p => p.Name).First()}?";
+				ret = $"{t.GetGenericArguments()[0].LuaDocString()}?";
 
 			return ret;
 		}


### PR DESCRIPTION
The types for `Int32` and `Boolean` are currently replaced with friendly names of `int` and `bool` for the docs. Ensure we apply the same handling when these are nullable types, changing the output from `Int32?` and `Boolean?` to `int?` and `bool?`

----

You can see the friendly names a few lines above the diff in `LuaTypeNameReplacements`. We don't currently have any such signatures exposed, so this is just future-proofing.