### PR TITLE
Load campaign and utils Lua scripts before map scripts

### DIFF
--- a/mods/d2k/maps/shellmap/rules.yaml
+++ b/mods/d2k/maps/shellmap/rules.yaml
@@ -17,7 +17,7 @@ World:
 		AllowMuteBackgroundMusic: true
 		DisableWorldSounds: true
 	LuaScript:
-		Scripts: d2k-shellmap.lua, utils.lua
+		Scripts: utils.lua, d2k-shellmap.lua
 
 ^ExistsInWorld:
 	-GivesExperience:

--- a/mods/ra/maps/allies-01/rules.yaml
+++ b/mods/ra/maps/allies-01/rules.yaml
@@ -1,6 +1,6 @@
 World:
 	LuaScript:
-		Scripts: allies01.lua, campaign.lua, utils.lua
+		Scripts: campaign.lua, utils.lua, allies01.lua
 	MissionData:
 		Briefing: Rescue Einstein from the Headquarters inside this Soviet complex.\n\nOnce found, evacuate him via the helicopter at the signal flare.\n\nEinstein and Tanya must be kept alive at all costs.\n\nBeware the Soviet's Tesla Coils.\n\nDirect Tanya to destroy the westmost power plants to take them off-line.\n
 		BackgroundVideo: prolog.vqa

--- a/mods/ra/maps/allies-02/rules.yaml
+++ b/mods/ra/maps/allies-02/rules.yaml
@@ -4,7 +4,7 @@ Player:
 
 World:
 	LuaScript:
-		Scripts: allies02.lua, campaign.lua, utils.lua
+		Scripts: campaign.lua, utils.lua, allies02.lua
 	MissionData:
 		Briefing: A critical supply convoy is due through this area in 10 minutes, but Soviet forces have blocked the road in several places.\n\nUnless you can clear them out, those supplies will never make it to the front.\n\nThe convoy will come from the northwest, and time is short so work quickly.
 		BriefingVideo: ally2.vqa

--- a/mods/ra/maps/allies-03a/rules.yaml
+++ b/mods/ra/maps/allies-03a/rules.yaml
@@ -1,6 +1,6 @@
 World:
 	LuaScript:
-		Scripts: allies03a.lua, campaign.lua, utils.lua
+		Scripts: campaign.lua, utils.lua, allies03a.lua
 	MissionData:
 		Briefing: LANDCOM 16 HQS.\nTOP SECRET.\nTO: FIELD COMMANDER A9\n\nINTELLIGENCE RECON SHOWS HEAVY\nSOVIET MOVEMENT IN YOUR AREA.\nNEARBY BRIDGES ARE KEY TO SOVIET\nADVANCEMENT. DESTROY ALL BRIDGES\nASAP. TANYA WILL ASSIST. KEEP HER\nALIVE AT ALL COSTS.\n\nCONFIRMATION CODE 1612.\n\nTRANSMISSION ENDS.\n
 		StartVideo: brdgtilt.vqa

--- a/mods/ra/maps/allies-03b/rules.yaml
+++ b/mods/ra/maps/allies-03b/rules.yaml
@@ -1,6 +1,6 @@
 World:
 	LuaScript:
-		Scripts: allies03b.lua, campaign.lua, utils.lua
+		Scripts: campaign.lua, utils.lua, allies03b.lua
 	MissionData:
 		Briefing: LANDCOM 16 HQS.\nTOP SECRET.\nTO: FIELD COMMANDER A9\n\nINTELLIGENCE RECON SHOWS HEAVY\nSOVIET MOVEMENT IN YOUR AREA.\nNEARBY BRIDGES ARE KEY TO SOVIET\nADVANCEMENT. DESTROY ALL BRIDGES\nASAP. TANYA WILL ASSIST. KEEP HER\nALIVE AT ALL COSTS.\n\nCONFIRMATION CODE 1612.\n\nTRANSMISSION ENDS.\n
 		StartVideo: brdgtilt.vqa

--- a/mods/ra/maps/allies-05b/rules.yaml
+++ b/mods/ra/maps/allies-05b/rules.yaml
@@ -1,6 +1,6 @@
 World:
 	LuaScript:
-		Scripts: allies05b.lua, allies05b-AI.lua, campaign.lua, utils.lua
+		Scripts: campaign.lua, utils.lua, allies05b.lua, allies05b-AI.lua
 	MissionData:
 		BriefingVideo: ally5.vqa
 		WinVideo: tanya2.vqa

--- a/mods/ra/maps/allies-05c/rules.yaml
+++ b/mods/ra/maps/allies-05c/rules.yaml
@@ -1,6 +1,6 @@
 World:
 	LuaScript:
-		Scripts: allies05c.lua, allies05c-AI.lua, campaign.lua, utils.lua
+		Scripts: campaign.lua, utils.lua, allies05c.lua, allies05c-AI.lua
 	MissionData:
 		BriefingVideo: ally5.vqa
 		WinVideo: tanya2.vqa

--- a/mods/ra/maps/allies-10a/rules.yaml
+++ b/mods/ra/maps/allies-10a/rules.yaml
@@ -1,6 +1,6 @@
 World:
 	LuaScript:
-		Scripts: allies10a.lua, allies10a-AI.lua, campaign.lua, utils.lua
+		Scripts: campaign.lua, utils.lua, allies10a.lua, allies10a-AI.lua
 	MissionData:
 		BriefingVideo: ally10.vqa
 		LossVideo: trinity.vqa

--- a/mods/ra/maps/ant-01/rules.yaml
+++ b/mods/ra/maps/ant-01/rules.yaml
@@ -12,7 +12,7 @@ World:
 			hard: Hard
 		Default: normal
 	LuaScript:
-		Scripts: ant-01.lua, ant-attack.lua, campaign.lua, utils.lua
+		Scripts: campaign.lua, utils.lua, ant-01.lua, ant-attack.lua
 	MissionData:
 		BackgroundVideo: antintro.vqa
 		Briefing: We've lost contact with one of our outposts. Before it went off-line, we received a brief communique about giant ants. We're unsure what to make of this report, so we want you to investigate.  \n\nScout the area, bring the outpost back on-line, and report your findings. If there is a threat, reinforcements will be sent in to help you.  \n\nKeep the base functional and radio contact open -- we don't want to lose the outpost again.

--- a/mods/ra/maps/ant-03/rules.yaml
+++ b/mods/ra/maps/ant-03/rules.yaml
@@ -1,6 +1,6 @@
 World:
 	LuaScript:
-		Scripts: ant-03.lua, ant-03-AI.lua, campaign.lua, utils.lua
+		Scripts: campaign.lua, utils.lua, ant-03.lua, ant-03-AI.lua
 	MissionData:
 		Briefing: The source of the ant's activity has been pinpointed in this area. We suspect that their nests are in this area -- they must be destroyed!\n\nA team of civilian specialists are en-route to your location. Use them to gas all the ant nests in the area. In addition, destroy all ants that you encounter.\n\nBe careful -- these things can chew through anything. Good luck.
 	ScriptLobbyDropdown@difficulty:

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -27,7 +27,7 @@ World:
 	FlashPaletteEffect@LIGHTNINGSTRIKE:
 		Type: LightningStrike
 	LuaScript:
-		Scripts: fort-lonestar.lua, fort-lonestar-AI.lua, campaign.lua
+		Scripts: campaign.lua, fort-lonestar.lua, fort-lonestar-AI.lua
 	MapBuildRadius:
 		AllyBuildRadiusCheckboxVisible: False
 		BuildRadiusCheckboxVisible: False


### PR DESCRIPTION
The ordering here is important, as loading the map scripts first means the campaign and utils methods can't be overwritten by the map scripts and can't be referenced by the map scripts before the world has been loaded.

A good test case is the second allied mission: On bleed the timer is 1:03 (hardest difficulty) for all difficulties, as the script queries the difficulty variable before it is defined in `campaign.lua`.