### PR TITLE
Fixed client crashing when joining a game directly after asset installation

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -419,7 +419,6 @@ namespace OpenRA
 				Console.WriteLine("\t{0}: {1} ({2})", mod.Key, mod.Value.Title, mod.Value.Version);
 
 			InitializeMod(modID, args);
-			Ui.InitializeTranslation();
 		}
 
 		public static void InitializeMod(string mod, Arguments args)

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -21,7 +21,6 @@ using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Traits;
-using OpenRA.Widgets;
 
 namespace OpenRA
 {
@@ -1370,7 +1369,7 @@ namespace OpenRA
 		public string Translate(string key, IDictionary<string, object> args = null, string attribute = null)
 		{
 			if (Translation.GetFormattedMessage(key, args, attribute) == key)
-				return Ui.Translate(key, args, attribute);
+				return modData.Translation.GetFormattedMessage(key, args, attribute);
 
 			return Translation.GetFormattedMessage(key, args, attribute);
 		}

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -36,6 +36,7 @@ namespace OpenRA
 		public readonly IModelSequenceLoader ModelSequenceLoader;
 		public readonly IVideoLoader[] VideoLoaders;
 		public readonly HotkeyManager Hotkeys;
+		public readonly Translation Translation;
 		public ILoadScreen LoadScreen { get; private set; }
 		public CursorProvider CursorProvider { get; private set; }
 		public FS ModFiles;
@@ -95,7 +96,7 @@ namespace OpenRA
 
 			var modelFormat = Manifest.Get<ModelSequenceFormat>();
 			var modelLoader = ObjectCreator.FindType(modelFormat.Type + "Loader");
-			var modelCtor = modelLoader != null ? modelLoader.GetConstructor(new[] { typeof(ModData) }) : null;
+			var modelCtor = modelLoader?.GetConstructor(new[] { typeof(ModData) });
 			if (modelLoader == null || !modelLoader.GetInterfaces().Contains(typeof(IModelSequenceLoader)) || modelCtor == null)
 				throw new InvalidOperationException($"Unable to find a model loader for type '{modelFormat.Type}'.");
 
@@ -103,6 +104,8 @@ namespace OpenRA
 			ModelSequenceLoader.OnMissingModelError = s => Log.Write("debug", s);
 
 			Hotkeys = new HotkeyManager(ModFiles, Game.Settings.Keys, Manifest);
+
+			Translation = new Translation(Game.Settings.Player.Language, Manifest.Translations, DefaultFileSystem);
 
 			defaultRules = Exts.Lazy(() => Ruleset.LoadDefaults(this));
 			defaultTerrainInfo = Exts.Lazy(() =>

--- a/OpenRA.Game/Network/LocalizedMessage.cs
+++ b/OpenRA.Game/Network/LocalizedMessage.cs
@@ -14,7 +14,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Fluent.Net;
-using OpenRA.Widgets;
 
 namespace OpenRA.Network
 {
@@ -119,7 +118,7 @@ namespace OpenRA.Network
 				.JoinWith("\n");
 		}
 
-		public string Translate()
+		public string Translate(ModData modData)
 		{
 			var argumentDictionary = new Dictionary<string, object>();
 			foreach (var argument in Arguments)
@@ -130,7 +129,7 @@ namespace OpenRA.Network
 					argumentDictionary.Add(argument.Key, new FluentString(argument.Value));
 			}
 
-			return Ui.Translate(Key, argumentDictionary);
+			return modData.Translation.GetFormattedMessage(Key, argumentDictionary);
 		}
 	}
 }

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Network
 						foreach (var node in yaml)
 						{
 							var localizedMessage = new LocalizedMessage(node.Value);
-							TextNotificationsManager.AddSystemLine(localizedMessage.Translate());
+							TextNotificationsManager.AddSystemLine(localizedMessage.Translate(Game.ModData));
 						}
 
 						break;

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -27,7 +27,6 @@ using OpenRA.Network;
 using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Traits;
-using OpenRA.Widgets;
 
 namespace OpenRA.Server
 {
@@ -936,7 +935,7 @@ namespace OpenRA.Server
 			DispatchServerOrdersToClients(Order.FromTargetString("LocalizedMessage", text, true));
 
 			if (Type == ServerType.Dedicated)
-				Console.WriteLine($"[{DateTime.Now.ToString(Settings.TimestampFormat)}] {Ui.Translate(key, arguments)}");
+				Console.WriteLine($"[{DateTime.Now.ToString(Settings.TimestampFormat)}] {ModData.Translation.GetFormattedMessage(key, arguments)}");
 		}
 
 		public void SendLocalizedMessageTo(Connection conn, string key, Dictionary<string, object> arguments = null)

--- a/OpenRA.Game/Translation.cs
+++ b/OpenRA.Game/Translation.cs
@@ -44,7 +44,7 @@ namespace OpenRA
 			messageContexts = GetMessageContext(language, translations, fileSystem).ToList();
 		}
 
-		IEnumerable<MessageContext> GetMessageContext(string language, string[] translations, IReadOnlyFileSystem fileSystem)
+		static IEnumerable<MessageContext> GetMessageContext(string language, string[] translations, IReadOnlyFileSystem fileSystem)
 		{
 			var backfall = translations.Where(t => t.EndsWith("en.ftl"));
 			var paths = translations.Where(t => t.EndsWith(language + ".ftl"));

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -33,8 +33,6 @@ namespace OpenRA.Widgets
 		public static Widget KeyboardFocusWidget;
 		public static Widget MouseOverWidget;
 
-		internal static Translation Translation;
-
 		public static void CloseWindow()
 		{
 			if (WindowList.Count > 0)
@@ -157,27 +155,6 @@ namespace OpenRA.Widgets
 			// Issue a no-op mouse move to force any tooltips to be recalculated
 			HandleInput(new MouseInput(MouseInputEvent.Move, MouseButton.None,
 				Viewport.LastMousePos, int2.Zero, Modifiers.None, 0));
-		}
-
-		public static void InitializeTranslation()
-		{
-			Translation = new Translation(Game.Settings.Player.Language, Game.ModData.Manifest.Translations, Game.ModData.DefaultFileSystem);
-		}
-
-		public static string Translate(string key, IDictionary<string, object> args = null, string attribute = null)
-		{
-			if (Translation == null)
-				return null;
-
-			return Translation.GetFormattedMessage(key, args, attribute);
-		}
-
-		public static string TranslationAttribute(string key, string attribute = null)
-		{
-			if (Translation == null)
-				return null;
-
-			return Translation.GetAttribute(key, attribute);
 		}
 	}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		bool passwordOffsetAdjusted;
 
 		[ObjectCreator.UseCtor]
-		public ConnectionFailedLogic(Widget widget, OrderManager orderManager, NetworkConnection connection, string password, Action onAbort, Action<string> onRetry)
+		public ConnectionFailedLogic(Widget widget, ModData modData, OrderManager orderManager, NetworkConnection connection, string password, Action onAbort, Action<string> onRetry)
 		{
 			var panel = widget;
 			var abortButton = panel.Get<ButtonWidget>("ABORT_BUTTON");
@@ -107,7 +107,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			widget.Get<LabelWidget>("CONNECTING_DESC").GetText = () => $"Could not connect to {connection.Target}";
 
 			var connectionError = widget.Get<LabelWidget>("CONNECTION_ERROR");
-			connectionError.GetText = () => Ui.Translate(orderManager.ServerError) ?? connection.ErrorMessage ?? "Unknown error";
+			connectionError.GetText = () => modData.Translation.GetFormattedMessage(orderManager.ServerError) ?? connection.ErrorMessage ?? "Unknown error";
 
 			var panelTitle = widget.Get<LabelWidget>("TITLE");
 			panelTitle.GetText = () => orderManager.AuthenticationFailed ? "Password Required" : "Connection Failed";


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/issues/19973. To reproduce, create a `Support` directory in the OpenRA main folder and join a local dedicated server with 2 players then start the game.