### PR TITLE
Use nameof instead of hardcoded strings in reflection calls.

### DIFF
--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -479,7 +479,7 @@ namespace OpenRA
 
 			var parts = value.Split(SplitComma, StringSplitOptions.RemoveEmptyEntries);
 			var arguments = fieldType.GetGenericArguments();
-			var addMethod = fieldType.GetMethod("Add", arguments);
+			var addMethod = fieldType.GetMethod(nameof(List<object>.Add), arguments);
 			var addArgs = new object[1];
 			for (var i = 0; i < parts.Length; i++)
 			{
@@ -494,7 +494,7 @@ namespace OpenRA
 		{
 			var dict = Activator.CreateInstance(fieldType);
 			var arguments = fieldType.GetGenericArguments();
-			var addMethod = fieldType.GetMethod("Add", arguments);
+			var addMethod = fieldType.GetMethod(nameof(Dictionary<object, object>.Add), arguments);
 			var addArgs = new object[2];
 			foreach (var node in yaml.Nodes)
 			{

--- a/OpenRA.Game/GameRules/Ruleset.cs
+++ b/OpenRA.Game/GameRules/Ruleset.cs
@@ -248,7 +248,7 @@ namespace OpenRA
 					{
 						var traitName = traitNode.Key.Split('@')[0];
 						var traitType = modData.ObjectCreator.FindType(traitName + "Info");
-						if (traitType != null && traitType.GetInterface("ILobbyCustomRulesIgnore") == null)
+						if (traitType != null && traitType.GetInterface(nameof(ILobbyCustomRulesIgnore)) == null)
 							return true;
 					}
 					catch (Exception ex)

--- a/OpenRA.Game/Map/ActorReference.cs
+++ b/OpenRA.Game/Map/ActorReference.cs
@@ -72,7 +72,7 @@ namespace OpenRA
 
 			var init = (ActorInit)FormatterServices.GetUninitializedObject(type);
 			if (initInstance.Length > 1)
-				type.GetField("InstanceName").SetValue(init, initInstance[1]);
+				type.GetField(nameof(ActorInit.InstanceName)).SetValue(init, initInstance[1]);
 
 			var loader = type.GetMethod("Initialize", new[] { typeof(MiniYaml) });
 			if (loader == null)

--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -238,7 +238,7 @@ namespace OpenRA.Network
 			{
 				// The lambda generated is shown below.
 				// TSync is actual type of the ISync object. Foo is a field or property with the Sync attribute applied.
-				var toString = memberType.GetMethod("ToString", Type.EmptyTypes);
+				var toString = memberType.GetMethod(nameof(object.ToString), Type.EmptyTypes);
 				Expression getString;
 				if (memberType.IsValueType)
 				{

--- a/OpenRA.Game/Scripting/ScriptContext.cs
+++ b/OpenRA.Game/Scripting/ScriptContext.cs
@@ -287,7 +287,7 @@ namespace OpenRA.Scripting
 
 		Type[] FilterCommands(ActorInfo ai, Type[] knownCommands)
 		{
-			var method = typeof(ActorInfo).GetMethod("HasTraitInfo");
+			var method = typeof(ActorInfo).GetMethod(nameof(ActorInfo.HasTraitInfo));
 			return knownCommands.Where(c => ExtractRequiredTypes(c)
 				.All(t => (bool)method.MakeGenericMethod(t).Invoke(ai, NoArguments)))
 				.ToArray();

--- a/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
+++ b/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				// work around the cancellation bug.
 				// HACK: this is manipulating private internal actor state
 				if (self.CurrentActivity is Move)
-					typeof(Actor).GetProperty("CurrentActivity").SetValue(self, null);
+					typeof(Actor).GetProperty(nameof(Actor.CurrentActivity)).SetValue(self, null);
 
 				// The actor is killed using Info.DamageTypes if the teleport fails
 				self.QueueActivity(false, new Teleport(chronosphere ?? self, Origin, null, true, killCargo, Info.ChronoshiftSound,

--- a/OpenRA.Mods.Common/DiscordService.cs
+++ b/OpenRA.Mods.Common/DiscordService.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common
 
 			// HACK: We need to set HasRegisteredUriScheme to bypass the check that is done when calling SetPresence with a joinSecret.
 			// DiscordRpc lib expect us to register uri handlers with RegisterUriScheme(), we are doing it ourselves in our installers/launchers.
-			client.GetType().GetProperty("HasRegisteredUriScheme").SetValue(client, true);
+			client.GetType().GetProperty(nameof(DiscordRpcClient.HasRegisteredUriScheme)).SetValue(client, true);
 
 			client.SetSubscription(EventType.Join | EventType.JoinRequest);
 			client.Initialize();

--- a/OpenRA.Mods.Common/Scripting/Global/ActorGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ActorGlobal.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Scripting
 			// Construct the ActorInit.
 			var init = (ActorInit)FormatterServices.GetUninitializedObject(initType);
 			if (initInstance.Length > 1)
-				initType.GetField("InstanceName").SetValue(init, initInstance[1]);
+				initType.GetField(nameof(ActorInit.InstanceName)).SetValue(init, initInstance[1]);
 
 			if (value is LuaTable tableValue && init is CompositeActorInit compositeInit)
 			{


### PR DESCRIPTION
This helps improve the safety of code the uses reflection when methods may get renamed, and helps navigating code as the nameof will show up when searching for references to members.