### PR TITLE
Add hotkey filtering functionality (by name and by context)

### DIFF
--- a/OpenRA.Game/HotkeyManager.cs
+++ b/OpenRA.Game/HotkeyManager.cs
@@ -40,7 +40,7 @@ namespace OpenRA
 			}
 
 			foreach (var hd in definitions)
-				hd.Value.HasDuplicates = GetFirstDuplicate(hd.Value.Name, this[hd.Value.Name].GetValue(), hd.Value) != null;
+				hd.Value.HasDuplicates = GetFirstDuplicate(hd.Value, this[hd.Value.Name].GetValue()) != null;
 		}
 
 		internal Func<Hotkey> GetHotkeyReference(string name)
@@ -68,7 +68,7 @@ namespace OpenRA
 				settings.Remove(name);
 
 			var hadDuplicates = definition.HasDuplicates;
-			definition.HasDuplicates = GetFirstDuplicate(definition.Name, this[definition.Name].GetValue(), definition) != null;
+			definition.HasDuplicates = GetFirstDuplicate(definition, this[definition.Name].GetValue()) != null;
 
 			if (hadDuplicates || definition.HasDuplicates)
 			{
@@ -77,16 +77,19 @@ namespace OpenRA
 					if (hd.Value == definition)
 						continue;
 
-					hd.Value.HasDuplicates = GetFirstDuplicate(hd.Value.Name, this[hd.Value.Name].GetValue(), hd.Value) != null;
+					hd.Value.HasDuplicates = GetFirstDuplicate(hd.Value, this[hd.Value.Name].GetValue()) != null;
 				}
 			}
 		}
 
-		public HotkeyDefinition GetFirstDuplicate(string name, Hotkey value, HotkeyDefinition definition)
+		public HotkeyDefinition GetFirstDuplicate(HotkeyDefinition definition, Hotkey value)
 		{
+			if (definition == null)
+				return null;
+
 			foreach (var kv in keys)
 			{
-				if (kv.Key == name)
+				if (kv.Key == definition.Name)
 					continue;
 
 				if (kv.Value == value && definitions[kv.Key].Contexts.Overlaps(definition.Contexts))

--- a/mods/cnc/chrome/settings-hotkeys.yaml
+++ b/mods/cnc/chrome/settings-hotkeys.yaml
@@ -25,9 +25,31 @@ Container@HOTKEYS_PANEL:
 	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM
 	Children:
+		Label@FILTER_INPUT_LABEL:
+			Width: 100
+			Height: 25
+			Font: Bold
+			Text: Filter by name:
+		TextField@FILTER_INPUT:
+			X: 108
+			Width: 180
+			Height: 25
+		Label@CONTEXT_DROPDOWN_LABEL:
+			X: PARENT_RIGHT - WIDTH - 195 - 5
+			Width: 100
+			Height: 25
+			Font: Bold
+			Text: Context:
+			Align: Right
+		DropDownButton@CONTEXT_DROPDOWN:
+			X: PARENT_RIGHT - WIDTH
+			Width: 195
+			Height: 25
+			Font: Bold
 		ScrollPanel@HOTKEY_LIST:
+			Y: 35
 			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM - 65
+			Height: PARENT_BOTTOM - 65 - 35
 			TopBottomSpacing: 5
 			ItemSpacing: 5
 			Children:
@@ -60,64 +82,78 @@ Container@HOTKEYS_PANEL:
 							Width: 90
 							Height: 25
 							TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
-		Background@HOTKEY_DIALOG_ROOT:
+		Container@HOTKEY_EMPTY_LIST:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Visible: false
+			Children:
+				Label@HOTKEY_EMPTY_LIST_MESSAGE:
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
+					Align: Center
+					Text: No hotkeys match the filter criteria.
+		Background@HOTKEY_REMAP_BGND:
 			Y: PARENT_BOTTOM - HEIGHT - 1
 			Width: PARENT_RIGHT
 			Height: 65 + 1
 			Background: panel-gray
 			Children:
-				Label@HOTKEY_LABEL:
-					X: 15
-					Y: 19
-					Width: 200
-					Height: 25
-					Font: Bold
-					Align: Right
-				HotkeyEntry@HOTKEY_ENTRY:
-					X: 15 + 200 + 5
-					Y: 20
-					Width: 220
-					Height: 25
-				Container@NOTICES:
-					X: 15 + 200 + 5
-					Y: 42
-					Width: 220
-					Height: 25
+				Container@HOTKEY_REMAP_DIALOG:
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
 					Children:
-						Label@ORIGINAL_NOTICE:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
-							Font: Tiny
-							Text: The default is "{0}"
-						Label@DUPLICATE_NOTICE:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
-							Font: Tiny
-							Text: This is already used for "{0}"
-				Button@OVERRIDE_HOTKEY_BUTTON:
-					X: PARENT_RIGHT - 3 * WIDTH - 30
-					Y: 20
-					Width: 70
-					Height: 25
-					Text: Override
-					Font: Bold
-				Button@CLEAR_HOTKEY_BUTTON:
-					X: PARENT_RIGHT - 2 * WIDTH - 30
-					Y: 20
-					Width: 65
-					Height: 25
-					Text: Clear
-					Font: Bold
-					TooltipText: Unbind the hotkey
-					TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
-					TooltipTemplate: SIMPLE_TOOLTIP
-				Button@RESET_HOTKEY_BUTTON:
-					X: PARENT_RIGHT - WIDTH - 20
-					Y: 20
-					Width: 65
-					Height: 25
-					Text: Reset
-					Font: Bold
-					TooltipText: Reset to default
-					TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
-					TooltipTemplate: SIMPLE_TOOLTIP
+						Label@HOTKEY_LABEL:
+							X: 15
+							Y: 19
+							Width: 200
+							Height: 25
+							Font: Bold
+							Align: Right
+						HotkeyEntry@HOTKEY_ENTRY:
+							X: 15 + 200 + 5
+							Y: 20
+							Width: 220
+							Height: 25
+						Container@NOTICES:
+							X: 15 + 200 + 5
+							Y: 42
+							Width: 220
+							Height: 25
+							Children:
+								Label@ORIGINAL_NOTICE:
+									Width: PARENT_RIGHT
+									Height: PARENT_BOTTOM
+									Font: Tiny
+									Text: The default is "{0}"
+								Label@DUPLICATE_NOTICE:
+									Width: PARENT_RIGHT
+									Height: PARENT_BOTTOM
+									Font: Tiny
+									Text: This is already used for "{0}" in the {1} context
+						Button@OVERRIDE_HOTKEY_BUTTON:
+							X: PARENT_RIGHT - 3 * WIDTH - 30
+							Y: 20
+							Width: 70
+							Height: 25
+							Text: Override
+							Font: Bold
+						Button@CLEAR_HOTKEY_BUTTON:
+							X: PARENT_RIGHT - 2 * WIDTH - 30
+							Y: 20
+							Width: 65
+							Height: 25
+							Text: Clear
+							Font: Bold
+							TooltipText: Unbind the hotkey
+							TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
+						Button@RESET_HOTKEY_BUTTON:
+							X: PARENT_RIGHT - WIDTH - 20
+							Y: 20
+							Width: 65
+							Height: 25
+							Text: Reset
+							Font: Bold
+							TooltipText: Reset to default
+							TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP

--- a/mods/cnc/chrome/settings-hotkeys.yaml
+++ b/mods/cnc/chrome/settings-hotkeys.yaml
@@ -20,7 +20,6 @@ Container@HOTKEYS_PANEL:
 			Chat Commands:
 				Types: Chat
 			Control Groups:
-				Template: TWO_COLUMN
 				Types: ControlGroups
 	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM

--- a/mods/common/chrome/settings-hotkeys.yaml
+++ b/mods/common/chrome/settings-hotkeys.yaml
@@ -20,7 +20,6 @@ Container@HOTKEYS_PANEL:
 			Chat Commands:
 				Types: Chat
 			Control Groups:
-				Template: TWO_COLUMN
 				Types: ControlGroups
 	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM

--- a/mods/common/chrome/settings-hotkeys.yaml
+++ b/mods/common/chrome/settings-hotkeys.yaml
@@ -25,9 +25,31 @@ Container@HOTKEYS_PANEL:
 	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM
 	Children:
+		Label@FILTER_INPUT_LABEL:
+			Width: 100
+			Height: 25
+			Font: Bold
+			Text: Filter by name:
+		TextField@FILTER_INPUT:
+			X: 108
+			Width: 180
+			Height: 25
+		Label@CONTEXT_DROPDOWN_LABEL:
+			X: PARENT_RIGHT - WIDTH - 195 - 5
+			Width: 100
+			Height: 25
+			Font: Bold
+			Text: Context:
+			Align: Right
+		DropDownButton@CONTEXT_DROPDOWN:
+			X: PARENT_RIGHT - WIDTH
+			Width: 195
+			Height: 25
+			Font: Bold
 		ScrollPanel@HOTKEY_LIST:
+			Y: 35
 			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM - 65
+			Height: PARENT_BOTTOM - 65 - 35
 			TopBottomSpacing: 5
 			ItemSpacing: 5
 			Children:
@@ -60,64 +82,78 @@ Container@HOTKEYS_PANEL:
 							Width: 120
 							Height: 25
 							TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
-		Background@HOTKEY_DIALOG_ROOT:
+		Container@HOTKEY_EMPTY_LIST:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Visible: false
+			Children:
+				Label@HOTKEY_EMPTY_LIST_MESSAGE:
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
+					Align: Center
+					Text: No hotkeys match the filter criteria.
+		Background@HOTKEY_REMAP_BGND:
 			Y: PARENT_BOTTOM - HEIGHT
 			Width: PARENT_RIGHT
 			Height: 65
 			Background: dialog3
 			Children:
-				Label@HOTKEY_LABEL:
-					X: 15
-					Y: 19
-					Width: 200
-					Height: 25
-					Font: Bold
-					Align: Right
-				HotkeyEntry@HOTKEY_ENTRY:
-					X: 15 + 200 + 5
-					Y: 20
-					Width: 300
-					Height: 25
-				Container@NOTICES:
-					X: 15 + 200 + 5
-					Y: 42
-					Width: 300
-					Height: 25
+				Container@HOTKEY_REMAP_DIALOG:
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
 					Children:
-						Label@ORIGINAL_NOTICE:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
-							Font: Tiny
-							Text: The default is "{0}"
-						Label@DUPLICATE_NOTICE:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
-							Font: Tiny
-							Text: This is already used for "{0}"
-				Button@OVERRIDE_HOTKEY_BUTTON:
-					X: PARENT_RIGHT - 3 * WIDTH - 30
-					Y: 20
-					Width: 70
-					Height: 25
-					Text: Override
-					Font: Bold
-				Button@CLEAR_HOTKEY_BUTTON:
-					X: PARENT_RIGHT - 2 * WIDTH - 30
-					Y: 20
-					Width: 65
-					Height: 25
-					Text: Clear
-					Font: Bold
-					TooltipText: Unbind the hotkey
-					TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
-					TooltipTemplate: SIMPLE_TOOLTIP
-				Button@RESET_HOTKEY_BUTTON:
-					X: PARENT_RIGHT - WIDTH - 20
-					Y: 20
-					Width: 65
-					Height: 25
-					Text: Reset
-					Font: Bold
-					TooltipText: Reset to default
-					TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
-					TooltipTemplate: SIMPLE_TOOLTIP
+						Label@HOTKEY_LABEL:
+							X: 15
+							Y: 19
+							Width: 200
+							Height: 25
+							Font: Bold
+							Align: Right
+						HotkeyEntry@HOTKEY_ENTRY:
+							X: 15 + 200 + 5
+							Y: 20
+							Width: 300
+							Height: 25
+						Container@NOTICES:
+							X: 15 + 200 + 5
+							Y: 42
+							Width: 300
+							Height: 25
+							Children:
+								Label@ORIGINAL_NOTICE:
+									Width: PARENT_RIGHT
+									Height: PARENT_BOTTOM
+									Font: Tiny
+									Text: The default is "{0}"
+								Label@DUPLICATE_NOTICE:
+									Width: PARENT_RIGHT
+									Height: PARENT_BOTTOM
+									Font: Tiny
+									Text: This is already used for "{0}" in the {1} context
+						Button@OVERRIDE_HOTKEY_BUTTON:
+							X: PARENT_RIGHT - 3 * WIDTH - 30
+							Y: 20
+							Width: 70
+							Height: 25
+							Text: Override
+							Font: Bold
+						Button@CLEAR_HOTKEY_BUTTON:
+							X: PARENT_RIGHT - 2 * WIDTH - 30
+							Y: 20
+							Width: 65
+							Height: 25
+							Text: Clear
+							Font: Bold
+							TooltipText: Unbind the hotkey
+							TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
+						Button@RESET_HOTKEY_BUTTON:
+							X: PARENT_RIGHT - WIDTH - 20
+							Y: 20
+							Width: 65
+							Height: 25
+							Text: Reset
+							Font: Bold
+							TooltipText: Reset to default
+							TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP

--- a/mods/ts/chrome/settings-hotkeys.yaml
+++ b/mods/ts/chrome/settings-hotkeys.yaml
@@ -20,7 +20,6 @@ Container@HOTKEYS_PANEL:
 			Chat Commands:
 				Types: Chat
 			Control Groups:
-				Template: TWO_COLUMN
 				Types: ControlGroups
 			Depth Preview Debug:
 				Types: DepthDebug

--- a/mods/ts/chrome/settings-hotkeys.yaml
+++ b/mods/ts/chrome/settings-hotkeys.yaml
@@ -27,9 +27,31 @@ Container@HOTKEYS_PANEL:
 	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM
 	Children:
+		Label@FILTER_INPUT_LABEL:
+			Width: 100
+			Height: 25
+			Font: Bold
+			Text: Filter by name:
+		TextField@FILTER_INPUT:
+			X: 108
+			Width: 180
+			Height: 25
+		Label@CONTEXT_DROPDOWN_LABEL:
+			X: PARENT_RIGHT - WIDTH - 195 - 5
+			Width: 100
+			Height: 25
+			Font: Bold
+			Text: Context:
+			Align: Right
+		DropDownButton@CONTEXT_DROPDOWN:
+			X: PARENT_RIGHT - WIDTH
+			Width: 195
+			Height: 25
+			Font: Bold
 		ScrollPanel@HOTKEY_LIST:
+			Y: 35
 			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM - 65
+			Height: PARENT_BOTTOM - 65 - 35
 			TopBottomSpacing: 5
 			ItemSpacing: 5
 			Children:
@@ -62,64 +84,78 @@ Container@HOTKEYS_PANEL:
 							Width: 120
 							Height: 25
 							TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
-		Background@HOTKEY_DIALOG_ROOT:
+		Container@HOTKEY_EMPTY_LIST:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Visible: false
+			Children:
+				Label@HOTKEY_EMPTY_LIST_MESSAGE:
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
+					Align: Center
+					Text: No hotkeys match the filter criteria.
+		Background@HOTKEY_REMAP_BGND:
 			Y: PARENT_BOTTOM - HEIGHT
 			Width: PARENT_RIGHT
 			Height: 65
 			Background: dialog3
 			Children:
-				Label@HOTKEY_LABEL:
-					X: 15
-					Y: 19
-					Width: 200
-					Height: 25
-					Font: Bold
-					Align: Right
-				HotkeyEntry@HOTKEY_ENTRY:
-					X: 15 + 200 + 5
-					Y: 20
-					Width: 300
-					Height: 25
-				Container@NOTICES:
-					X: 15 + 200 + 5
-					Y: 42
-					Width: 300
-					Height: 25
+				Container@HOTKEY_REMAP_DIALOG:
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
 					Children:
-						Label@ORIGINAL_NOTICE:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
-							Font: Tiny
-							Text: The default is "{0}"
-						Label@DUPLICATE_NOTICE:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
-							Font: Tiny
-							Text: This is already used for "{0}"
-				Button@OVERRIDE_HOTKEY_BUTTON:
-					X: PARENT_RIGHT - 3 * WIDTH - 30
-					Y: 20
-					Width: 70
-					Height: 25
-					Text: Override
-					Font: Bold
-				Button@CLEAR_HOTKEY_BUTTON:
-					X: PARENT_RIGHT - 2 * WIDTH - 30
-					Y: 20
-					Width: 65
-					Height: 25
-					Text: Clear
-					Font: Bold
-					TooltipText: Unbind the hotkey
-					TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
-					TooltipTemplate: SIMPLE_TOOLTIP
-				Button@RESET_HOTKEY_BUTTON:
-					X: PARENT_RIGHT - WIDTH - 20
-					Y: 20
-					Width: 65
-					Height: 25
-					Text: Reset
-					Font: Bold
-					TooltipText: Reset to default
-					TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
-					TooltipTemplate: SIMPLE_TOOLTIP
+						Label@HOTKEY_LABEL:
+							X: 15
+							Y: 19
+							Width: 200
+							Height: 25
+							Font: Bold
+							Align: Right
+						HotkeyEntry@HOTKEY_ENTRY:
+							X: 15 + 200 + 5
+							Y: 20
+							Width: 300
+							Height: 25
+						Container@NOTICES:
+							X: 15 + 200 + 5
+							Y: 42
+							Width: 300
+							Height: 25
+							Children:
+								Label@ORIGINAL_NOTICE:
+									Width: PARENT_RIGHT
+									Height: PARENT_BOTTOM
+									Font: Tiny
+									Text: The default is "{0}"
+								Label@DUPLICATE_NOTICE:
+									Width: PARENT_RIGHT
+									Height: PARENT_BOTTOM
+									Font: Tiny
+									Text: This is already used for "{0}" in the {1} context
+						Button@OVERRIDE_HOTKEY_BUTTON:
+							X: PARENT_RIGHT - 3 * WIDTH - 30
+							Y: 20
+							Width: 70
+							Height: 25
+							Text: Override
+							Font: Bold
+						Button@CLEAR_HOTKEY_BUTTON:
+							X: PARENT_RIGHT - 2 * WIDTH - 30
+							Y: 20
+							Width: 65
+							Height: 25
+							Text: Clear
+							Font: Bold
+							TooltipText: Unbind the hotkey
+							TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
+						Button@RESET_HOTKEY_BUTTON:
+							X: PARENT_RIGHT - WIDTH - 20
+							Y: 20
+							Width: 65
+							Height: 25
+							Text: Reset
+							Font: Bold
+							TooltipText: Reset to default
+							TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP


### PR DESCRIPTION
This implements the UI part of #19898 (back-end part was done in #19900). Hotkey can be filtered by name and by context. Context overlap is used for validation so this new UI should make it clearer to the user how hotkeys are validated. The error message for duplicate bindings is expanded to clarify that.

![image](https://user-images.githubusercontent.com/1355810/163568343-27a1bec8-71af-47e4-8402-8500f1e9e254.png)
_Filtering by context_

![image](https://user-images.githubusercontent.com/1355810/163568361-853769b5-0769-43be-b4ff-a88d2a7c83c1.png)
_Filtering by name and a warning for duplicate binding_

![image](https://user-images.githubusercontent.com/1355810/163568372-061644c9-cdd9-46d5-8dca-8f72a86771a0.png)
_No matching hotkeys_

Closes #19898 