### PR TITLE
Added Launch parameters to Settings documentation

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/ExtractSettingsDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractSettingsDocsCommand.cs
@@ -56,13 +56,19 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			Console.WriteLine();
 
 			var sections = new Settings(null, new Arguments()).Sections;
+			sections.Add("Launch", new LaunchArguments(new Arguments(Array.Empty<string>())));
 			foreach (var section in sections.OrderBy(s => s.Key))
 			{
 				var fields = section.Value.GetType().GetFields();
 				if (fields.Any(field => field.GetCustomAttributes<DescAttribute>(false).Length > 0))
+				{
 					Console.WriteLine($"## {section.Key}");
-				else
-					Console.WriteLine();
+					if (section.Key == "Launch")
+					{
+						Console.WriteLine("These are runtime parameters which can't be defined in `settings.yaml`.");
+						Console.WriteLine();
+					}
+				}
 
 				foreach (var field in fields)
 				{
@@ -87,8 +93,6 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						Console.WriteLine($"\t{field.Name}: {value}");
 						Console.WriteLine("```");
 					}
-					else
-						Console.WriteLine();
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractSettingsDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractSettingsDocsCommand.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			Console.WriteLine(
 				"This documentation displays annotated settings with default values and description. " +
 				"Please do not edit it directly, but add new `[Desc(\"String\")]` tags to the source code. This file has been " +
-				"automatically generated for version {0} of OpenRA.", version);
+				$"automatically generated for version {version} of OpenRA.");
 			Console.WriteLine();
 			Console.WriteLine("All settings can be changed by starting the game via a command-line parameter like `Game.Mod=ra`.");
 			Console.WriteLine();
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					var value = field.GetValue(section.Value);
 					if (value != null && !value.ToString().StartsWith("System."))
 					{
-						Console.WriteLine("**Default Value:** {0}", value);
+						Console.WriteLine($"**Default Value:** {value}");
 						Console.WriteLine();
 						Console.WriteLine("```miniyaml");
 						Console.WriteLine($"{section.Key}: ");


### PR DESCRIPTION
I think https://github.com/OpenRA/OpenRA/pull/19982 shows that the existing `Launch` parameters are largely invisible to the player base. This adds them to the wiki, like we do for the Linux man pages.