### PR TITLE
Unhardcoded SpriteSequence properties

### DIFF
--- a/OpenRA.Mods.Cnc/Graphics/ClassicSpriteSequence.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ClassicSpriteSequence.cs
@@ -26,24 +26,28 @@ namespace OpenRA.Mods.Cnc.Graphics
 		}
 	}
 
+	[Desc("A sprite sequence that has the oddities that come with first-generation Westwood titles.")]
 	public class ClassicSpriteSequence : DefaultSpriteSequence
 	{
-		readonly bool useClassicFacings;
+		// This needs to be a public property for the documentation generation to work.
+		[Desc("Incorporate a compensation factor due to the distortion caused by 3D-Studio " +
+		      "when it tried to render 45% angles which was used by Westwood Studios at that time.")]
+		public bool UseClassicFacings { get; }
 
 		public ClassicSpriteSequence(ModData modData, string tileSet, SpriteCache cache, ISpriteSequenceLoader loader, string sequence, string animation, MiniYaml info)
 			: base(modData, tileSet, cache, loader, sequence, animation, info)
 		{
 			var d = info.ToDictionary();
-			useClassicFacings = LoadField(d, "UseClassicFacings", false);
+			UseClassicFacings = LoadField(d, nameof(UseClassicFacings), UseClassicFacings);
 
-			if (useClassicFacings && Facings != 32)
+			if (UseClassicFacings && Facings != 32)
 				throw new InvalidOperationException(
 					$"{info.Nodes[0].Location}: Sequence {sequence}.{animation}: UseClassicFacings is only valid for 32 facings");
 		}
 
 		protected override int GetFacingFrameOffset(WAngle facing)
 		{
-			return useClassicFacings ? Util.ClassicIndexFacing(facing, Facings) : Common.Util.IndexFacing(facing, Facings);
+			return UseClassicFacings ? Util.ClassicIndexFacing(facing, Facings) : Common.Util.IndexFacing(facing, Facings);
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Graphics/ClassicTilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ClassicTilesetSpecificSpriteSequence.cs
@@ -41,14 +41,32 @@ namespace OpenRA.Mods.Cnc.Graphics
 		}
 	}
 
+	[Desc("A sprite sequence that can have tileset-specific variants and has the oddities " +
+	      "that come with first-generation Westwood titles.")]
 	public class ClassicTilesetSpecificSpriteSequence : ClassicSpriteSequence
 	{
+		// These need to be public properties for the documentation generation to work.
+		[Desc("Dictionary of <string: string> with tileset name to override -> tileset name to use instead.")]
+		public static Dictionary<string, string> TilesetOverrides => null;
+
+		[Desc("Use `TilesetCodes` as defined in `mod.yaml` to add a letter as a second character " +
+		      "into the sprite filename like the Westwood 2.5D titles did for tileset-specific variants.")]
+		public static bool UseTilesetCode => false;
+
+		[Desc("Append a tileset-specific extension to the file name " +
+			  "- either as defined in `mod.yaml`'s `TilesetExtensions` (if `UseTilesetExtension` is used) " +
+		      "or the default hardcoded one for this sequence type (.shp).")]
+		public static bool AddExtension => true;
+
+		[Desc("Whether `mod.yaml`'s `TilesetExtensions` should be used with the sequence's file name.")]
+		public static bool UseTilesetExtension { get; private set; }
+
 		public ClassicTilesetSpecificSpriteSequence(ModData modData, string tileSet, SpriteCache cache, ISpriteSequenceLoader loader, string sequence, string animation, MiniYaml info)
 			: base(modData, tileSet, cache, loader, sequence, animation, info) { }
 
-		string ResolveTilesetId(string tileSet, Dictionary<string, MiniYaml> d)
+		static string ResolveTilesetId(string tileSet, Dictionary<string, MiniYaml> d)
 		{
-			if (d.TryGetValue("TilesetOverrides", out var yaml))
+			if (d.TryGetValue(nameof(TilesetOverrides), out var yaml))
 			{
 				var tsNode = yaml.Nodes.FirstOrDefault(n => n.Key == tileSet);
 				if (tsNode != null)
@@ -64,17 +82,16 @@ namespace OpenRA.Mods.Cnc.Graphics
 
 			var spriteName = sprite ?? sequence;
 
-			if (LoadField(d, "UseTilesetCode", false))
+			if (LoadField(d, nameof(UseTilesetCode), UseTilesetCode))
 			{
 				if (loader.TilesetCodes.TryGetValue(ResolveTilesetId(tileSet, d), out var code))
 					spriteName = spriteName.Substring(0, 1) + code + spriteName.Substring(2, spriteName.Length - 2);
 			}
 
-			if (LoadField(d, "AddExtension", true))
+			if (LoadField(d, nameof(AddExtension), AddExtension))
 			{
-				var useTilesetExtension = LoadField(d, "UseTilesetExtension", false);
-
-				if (useTilesetExtension && loader.TilesetExtensions.TryGetValue(ResolveTilesetId(tileSet, d), out var tilesetExtension))
+				UseTilesetExtension = LoadField(d, nameof(UseTilesetExtension), UseTilesetExtension);
+				if (UseTilesetExtension && loader.TilesetExtensions.TryGetValue(ResolveTilesetId(tileSet, d), out var tilesetExtension))
 					return spriteName + tilesetExtension;
 
 				return spriteName + loader.DefaultSpriteExtension;

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromEmbeddedSpritePalette.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromEmbeddedSpritePalette.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 		ImmutablePalette IProvidesCursorPaletteInfo.ReadPalette(IReadOnlyFileSystem fileSystem)
 		{
 			var sequence = (DefaultSpriteSequence)Game.ModData.DefaultSequences.Values.First().GetSequence(Image, Sequence);
-			return new ImmutablePalette(sequence.EmbeddedPalette);
+			return new ImmutablePalette(sequence.EmbeddedPaletteData);
 		}
 	}
 
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void LoadPalettes(WorldRenderer wr)
 		{
 			var sequence = (DefaultSpriteSequence)wr.World.Map.Rules.Sequences.GetSequence(info.Image, info.Sequence);
-			wr.AddPalette(info.Name, new ImmutablePalette(sequence.EmbeddedPalette), info.AllowModifiers);
+			wr.AddPalette(info.Name, new ImmutablePalette(sequence.EmbeddedPaletteData), info.AllowModifiers);
 		}
 
 		public IEnumerable<string> PaletteNames { get { yield return info.Name; } }


### PR DESCRIPTION
To prepare them for documentation generation.

~~This is obviously not 100% done, but then again we don't have 100% `DescAttribute` coverage of our traits and weapons either...
I'd be happy to add any initial descriptions that people come up with, but that probably shouldn't block merging this, because the real fun starts in the follow-up PR.~~

~~The empty `DescAttribute`s everywhere are both placeholders for actual descriptions and because the docs generation will only care for properties with the attribute.~~

Also added `DescAttribute`s to SpriteSequence types and their properties.
Also some code style fixes.