### PR TITLE
[Superseded] Allow removal of YAML (sub)nodes from overriding nodes

### DIFF
--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -443,7 +443,7 @@ namespace OpenRA
 				overrideDict.TryGetValue(key, out var overrideNode);
 
 				var loc = overrideNode?.Location ?? default;
-				var comment = (overrideNode ?? existingNode).Comment;
+				var comment = overrideNode?.Comment ?? existingNode?.Comment;
 				var merged = (existingNode == null || overrideNode == null) ? overrideNode ?? existingNode :
 					new MiniYamlNode(key, MergePartial(existingNode.Value, overrideNode.Value), comment, loc);
 				ret.Add(merged);

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -154,8 +154,10 @@ namespace OpenRA
 			if (stringPool == null)
 				stringPool = new Dictionary<string, string>();
 
-			var levels = new List<List<MiniYamlNode>>();
-			levels.Add(new List<MiniYamlNode>());
+			var levels = new List<List<MiniYamlNode>>
+			{
+				new List<MiniYamlNode>()
+			};
 
 			var lineNo = 0;
 			foreach (var ll in lines)
@@ -323,8 +325,10 @@ namespace OpenRA
 			var resolved = new Dictionary<string, MiniYaml>(tree.Count);
 			foreach (var kv in tree)
 			{
-				var inherited = new Dictionary<string, MiniYamlNode.SourceLocation>();
-				inherited.Add(kv.Key, default(MiniYamlNode.SourceLocation));
+				var inherited = new Dictionary<string, MiniYamlNode.SourceLocation>
+				{
+					{ kv.Key, default }
+				};
 
 				var children = ResolveInherits(kv.Value, tree, inherited);
 				resolved.Add(kv.Key, new MiniYaml(kv.Value.Value, children));

--- a/mods/d2k/maps/atreides-01a/rules.yaml
+++ b/mods/d2k/maps/atreides-01a/rules.yaml
@@ -19,6 +19,13 @@ World:
 			normal: Normal
 			hard: Hard
 		Default: easy
+	D2kResourceRenderer:
+		-ResourceTypes:
+		ResourceTypes:
+			Unobtaineum:
+				Sequences: spicea, spiceb, spicec, spiced
+				Palette: chrome
+				Name: Unobtaineum
 
 upgrade.conyard:
 	Buildable:


### PR DESCRIPTION
Adds the ability to remove subnodes (like trait properties) in order to redefine them. While the current merging handles overriding value nodes, it merges/adds list nodes and there is no option to replace one list with another.
 - The first commit is pyre syntax sugar.
 - The second commit is an unrelated but long-overdue bug fix _(P.S.: looking at it now I'm not completely sure that's the right way to go)_.
 - The third commit changes how MiniYAML merging works to allow for subnode removals.
 - And then a test commit to showcase the feature:
   - normally the test commit will make the game crash because of the attempted node removal
   - skipping the node removal line and simply adding the new resource type would result in having 2 resource types
   - this makes sure that the new `Unobtaineum` resource replaces the regular `Spice` resource entirely _(best tested by adding a breakpoint `ResourceRendererInfo.LoadResourceTypes()` and seeing what happens there)_

Also is a prerequisite for #18007, prompted by https://github.com/OpenRA/OpenRA/pull/18007#issuecomment-1012588025.

Pinging @RoosterDragon for a review.