### PR TITLE
Fixed problems with localized floating values

### DIFF
--- a/OpenRA.Game/Network/LocalizedMessage.cs
+++ b/OpenRA.Game/Network/LocalizedMessage.cs
@@ -124,7 +124,10 @@ namespace OpenRA.Network
 			foreach (var argument in Arguments)
 			{
 				if (argument.Type == FluentArgument.FluentArgumentType.Number)
-					argumentDictionary.Add(argument.Key, new FluentNumber(argument.Value));
+				{
+					if (Exts.TryParseIntegerInvariant(argument.Value, out var number))
+						argumentDictionary.Add(argument.Key, new FluentNumber(number.ToString()));
+				}
 				else
 					argumentDictionary.Add(argument.Key, new FluentString(argument.Value));
 			}


### PR DESCRIPTION
Until https://github.com/blushingpenguin/Fluent.Net/pull/12 is merged and published I think this is a good compromise as of now we only have string or integer parameters. While Fluent is designed to do rounding, we can do this within C# for the few cases we need it.