### PR TITLE
Return an empty path when a search with no locations is made.

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var sourcesList = sources.ToList();
 			if (sourcesList.Count == 0)
-				throw new ArgumentException($"{nameof(sources)} must not be empty.", nameof(sources));
+				return NoPath;
 
 			var locomotor = GetLocomotor(self);
 


### PR DESCRIPTION
The restores the previous behaviour before FindUnitPathToTargetCell was introduced (#19911). This prevents callers such as the harvester code crashing when a harvester tries to route home to a refinery, but there are no refineries.

Fixes #19992