### PR TITLE
Ported to Linguini

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,5 +4,6 @@
 		"openra.oraide-vscode",
 		"openra.vscode-openra-lua",
 		"EditorConfig.EditorConfig",
+		"macabeus.vscode-fluent",
 	]
 }

--- a/AUTHORS
+++ b/AUTHORS
@@ -202,6 +202,9 @@ Using ANGLE distributed under the BS3 3-Clause license.
 Using Pfim developed by Nick Babcock
 distributed under the MIT license.
 
+Using Linguini by the Space Station 14 team
+licensed under Apache and MIT terms.
+
 This site or product includes IP2Location LITE data
 available from http://www.ip2location.com.
 

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -1366,12 +1366,12 @@ namespace OpenRA
 			return false;
 		}
 
-		public string Translate(string key, IDictionary<string, object> args = null, string attribute = null)
+		public string Translate(string key, IDictionary<string, object> args = null)
 		{
-			if (Translation.GetFormattedMessage(key, args, attribute) == key)
-				return modData.Translation.GetFormattedMessage(key, args, attribute);
+			if (Translation.TryGetString(key, out var message, args))
+				return message;
 
-			return Translation.GetFormattedMessage(key, args, attribute);
+			return modData.Translation.GetString(key, args);
 		}
 	}
 }

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -43,8 +43,8 @@ namespace OpenRA.Network
 						var yaml = MiniYaml.FromString(order.TargetString);
 						foreach (var node in yaml)
 						{
-							var localizedMessage = new LocalizedMessage(node.Value);
-							TextNotificationsManager.AddSystemLine(localizedMessage.Translate(Game.ModData));
+							var localizedMessage = new LocalizedMessage(Game.ModData, node.Value);
+							TextNotificationsManager.AddSystemLine(localizedMessage.TranslatedText);
 						}
 
 						break;

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fluent.Net" Version="1.0.52" />
+    <PackageReference Include="Linguini.Bundle" Version="0.2.2" />
     <PackageReference Include="OpenRA-Eluant" Version="1.0.18" />
     <PackageReference Include="Mono.NAT" Version="3.0.3" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -935,16 +935,16 @@ namespace OpenRA.Server
 
 		public void SendLocalizedMessage(string key, Dictionary<string, object> arguments = null)
 		{
-			var text = new LocalizedMessage(key, arguments).Serialize();
+			var text = LocalizedMessage.Serialize(key, arguments);
 			DispatchServerOrdersToClients(Order.FromTargetString("LocalizedMessage", text, true));
 
 			if (Type == ServerType.Dedicated)
-				WriteLineWithTimeStamp(ModData.Translation.GetFormattedMessage(key, arguments));
+				WriteLineWithTimeStamp(ModData.Translation.GetString(key, arguments));
 		}
 
 		public void SendLocalizedMessageTo(Connection conn, string key, Dictionary<string, object> arguments = null)
 		{
-			var text = new LocalizedMessage(key, arguments).Serialize();
+			var text = LocalizedMessage.Serialize(key, arguments);
 			DispatchOrdersToClient(conn, 0, 0, Order.FromTargetString("LocalizedMessage", text, true).Serialize());
 		}
 
@@ -1287,7 +1287,7 @@ namespace OpenRA.Server
 		{
 			lock (LobbyInfo)
 			{
-				WriteLineWithTimeStamp(ModData.Translation.GetFormattedMessage(GameStarted));
+				WriteLineWithTimeStamp(ModData.Translation.GetString(GameStarted));
 
 				// Drop any players who are not ready
 				foreach (var c in Conns.Where(c => !c.Validated || GetClient(c).IsInvalid).ToArray())

--- a/OpenRA.Game/TranslationExts.cs
+++ b/OpenRA.Game/TranslationExts.cs
@@ -1,0 +1,45 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using Linguini.Shared.Types.Bundle;
+
+namespace OpenRA
+{
+	public static class TranslationExts
+	{
+		public static IFluentType ToFluentType(this object value)
+		{
+			switch (value)
+			{
+				case byte number:
+					return (FluentNumber)number;
+				case sbyte number:
+					return (FluentNumber)number;
+				case short number:
+					return (FluentNumber)number;
+				case uint number:
+					return (FluentNumber)number;
+				case int number:
+					return (FluentNumber)number;
+				case long number:
+					return (FluentNumber)number;
+				case ulong number:
+					return (FluentNumber)number;
+				case float number:
+					return (FluentNumber)number;
+				case double number:
+					return (FluentNumber)number;
+				default:
+					return (FluentString)value.ToString();
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Lint/CheckTranslationSyntax.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTranslationSyntax.cs
@@ -12,8 +12,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Fluent.Net;
-using Fluent.Net.Ast;
+using Linguini.Syntax.Ast;
+using Linguini.Syntax.Parser;
 
 namespace OpenRA.Mods.Common.Lint
 {
@@ -27,20 +27,19 @@ namespace OpenRA.Mods.Common.Lint
 				using (var reader = new StreamReader(stream))
 				{
 					var ids = new List<string>();
-					var parser = new Parser();
-					var resource = parser.Parse(reader);
-					foreach (var entry in resource.Body)
+					var parser = new LinguiniParser(reader);
+					var resource = parser.Parse();
+					foreach (var entry in resource.Entries)
 					{
 						if (entry is Junk junk)
-							foreach (var annotation in junk.Annotations)
-								emitError($"{annotation.Code}: {annotation.Message} in {file} line {annotation.Span.Start.Line}");
+							emitError($"{junk.GetId()}: {junk.AsStr()} in {file} {junk.Content}");
 
-						if (entry is MessageTermBase message)
+						if (entry is AstMessage message)
 						{
-							if (ids.Contains(message.Id.Name))
-								emitWarning($"Duplicate ID `{message.Id.Name}` in {file} line {message.Span.Start.Line}");
+							if (ids.Contains(message.Id.Name.ToString()))
+								emitWarning($"Duplicate ID `{message.Id.Name}` in {file}.");
 
-							ids.Add(message.Id.Name);
+							ids.Add(message.Id.Name.ToString());
 						}
 					}
 				}

--- a/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
@@ -107,7 +107,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			widget.Get<LabelWidget>("CONNECTING_DESC").GetText = () => $"Could not connect to {connection.Target}";
 
 			var connectionError = widget.Get<LabelWidget>("CONNECTION_ERROR");
-			connectionError.GetText = () => modData.Translation.GetFormattedMessage(orderManager.ServerError) ?? connection.ErrorMessage ?? "Unknown error";
+			connectionError.GetText = () => modData.Translation.GetString(orderManager.ServerError) ?? connection.ErrorMessage ?? "Unknown error";
 
 			var panelTitle = widget.Get<LabelWidget>("TITLE");
 			panelTitle.GetText = () => orderManager.AuthenticationFailed ? "Password Required" : "Connection Failed";


### PR DESCRIPTION
We believe that Fluent.NET is dead and porting from JavaScript may not have been a good idea. This rewrites https://github.com/OpenRA/OpenRA/pull/18965 to use https://www.nuget.org/packages/Linguini.Bundle/ instead and fix https://github.com/OpenRA/OpenRA/issues/19996.