### PR TITLE
On Locomotor initialization, update blocked cells.

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -365,16 +365,18 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var map = w.Map;
 			actorMap = w.ActorMap;
+			map.CustomTerrain.CellEntryChanged += UpdateCellCost;
+			map.Tiles.CellEntryChanged += UpdateCellCost;
 			actorMap.CellUpdated += CellUpdated;
 
 			cellsCost = new[] { new CellLayer<short>(map) };
 			blockingCache = new[] { new CellLayer<CellCache>(map) };
 
 			foreach (var cell in map.AllCells)
+			{
 				UpdateCellCost(cell);
-
-			map.CustomTerrain.CellEntryChanged += UpdateCellCost;
-			map.Tiles.CellEntryChanged += UpdateCellCost;
+				UpdateCellBlocking(cell);
+			}
 
 			// NotBefore<> ensures all custom movement layers have been initialized.
 			var customMovementLayers = world.GetCustomMovementLayers();


### PR DESCRIPTION
Prior to ef44c31a72eab61a597cf539ee4b138e94b254fe, `Locomotor` would be earlier in the trait initialization sequence than `SpawnMapActors`. `Locomotor` would assume no actors on the map, and register to update blocked cells when new ones were added. When `SpawnMapActors` created actors, `Locomotor` was made aware and kept up-to-date.

After this commit, the initialization sequence was perturbed and `SpawnMapActors` would initialize first. `Locomotor` would assume no actors on the map and thus be unaware of these starting units, meaning those starting units would not cause blocking, allowing units to pass through them.

There are two possible fixes. `SpawnMapActorsInfo` can initialize `NotBefore<LocomotorInfo>`, enforcing that actors are spawned after locomotor is ready. Or we can remove the assumption in `Locomotor` that the map starts empty, and have it update blocked cells on startup. The latter seems cleaner, so any other traits that may want to spawn actors don't have to be aware sequencing their initialization with the `Locomotor` trait, instead things would "just work".

Fixes #20002