### PR TITLE
Fix crash when non-host exits map chooser and update MapCache when non-host exits MapChooser

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -205,7 +205,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						{ "initialMap", lastUpdatedUid ?? map.Uid },
 						{ "initialTab", MapClassification.System },
-						{ "onExit", Game.IsHost ? new Action(() => UpdateSelectedMap()) : null },
+						{ "onExit", Game.IsHost ? (Action)UpdateSelectedMap : modData.MapCache.UpdateMaps },
 						{ "onSelect", Game.IsHost ? onSelect : null },
 						{ "filter", MapVisibility.Lobby },
 					});


### PR DESCRIPTION
Crash found in Shattered Paradise 

To replicate I used 2 game instances, created a multiplayer lobby, joined both accounts and entered / exited map chooser on the non-host account