### PR TITLE
Add RAGL S12 balance

### DIFF
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -446,6 +446,7 @@
 		DamageModifiers:
 			Prone50Percent: 50
 		DamageTriggers: TriggerProne
+		Duration: 50
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		StandSequences: stand,stand2

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -1,6 +1,6 @@
 ^FireWeapon:
 	ValidTargets: Ground, Water, GroundActor, WaterActor, Trees
-	ReloadDelay: 65
+	ReloadDelay: 70
 	Range: 5c0
 	Warhead@1Dam: SpreadDamage
 		Spread: 213

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -56,7 +56,7 @@ FLAK-23-AG:
 		InvalidTargets: Bridge
 
 ^HeavyMG:
-	ReloadDelay: 30
+	ReloadDelay: 35
 	Range: 6c0
 	Report: gun13.aud
 	ValidTargets: Ground, Water, GroundActor, WaterActor


### PR DESCRIPTION
- Pillbox attack speed increased from 30 to 35
- Flame Tower attack speed increased from 65 to 70
- Infantry prone duration reduced from 100 to 50 (from 4 to 2 seconds)

These changes have been tested across various balance maps and I'd say are pretty safe. IMO it's best to merge these right before the first playtest, as RAGL is starting right now there's naturally going to be more testing so there's no hurt in waiting