### PR TITLE
Replace custom MONO symbol with compiler-provided NET5_0_OR_GREATER.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,8 +17,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(Mono)' == ''">net6.0</TargetFramework>
-    <TargetFramework Condition="'$(Mono)' != ''">netstandard2.1</TargetFramework>
+    <TargetFramework Condition="'$(MSBuildRuntimeType)'!='Mono'">net6.0</TargetFramework>
+    <TargetFramework Condition="'$(MSBuildRuntimeType)'=='Mono'">netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ all:
 	@echo "Compiling in ${CONFIGURATION} mode..."
 ifeq ($(RUNTIME), mono)
 	@command -v $(firstword $(MSBUILD)) >/dev/null || (echo "OpenRA requires the '$(MSBUILD)' tool provided by Mono >= 6.4."; exit 1)
-	@$(MSBUILD) -t:Build -restore -p:Configuration=${CONFIGURATION} -p:TargetPlatform=$(TARGETPLATFORM) -p:Mono=true
+	@$(MSBUILD) -t:Build -restore -p:Configuration=${CONFIGURATION} -p:TargetPlatform=$(TARGETPLATFORM)
 else
 	@$(DOTNET) build -c ${CONFIGURATION} -nologo -p:TargetPlatform=$(TARGETPLATFORM)
 endif
@@ -100,7 +100,7 @@ check:
 	@echo "Compiling in Debug mode..."
 ifeq ($(RUNTIME), mono)
 # Enabling EnforceCodeStyleInBuild and GenerateDocumentationFile as a workaround for some code style rules (in particular IDE0005) being bugged and not reporting warnings/errors otherwise.
-	@$(MSBUILD) -t:build -restore -p:Configuration=Debug -warnaserror -p:TargetPlatform=$(TARGETPLATFORM) -p:Mono=true -p:EnforceCodeStyleInBuild=true -p:GenerateDocumentationFile=true
+	@$(MSBUILD) -t:build -restore -p:Configuration=Debug -warnaserror -p:TargetPlatform=$(TARGETPLATFORM) -p:EnforceCodeStyleInBuild=true -p:GenerateDocumentationFile=true
 else
 # Enabling EnforceCodeStyleInBuild and GenerateDocumentationFile as a workaround for some code style rules (in particular IDE0005) being bugged and not reporting warnings/errors otherwise.
 	@$(DOTNET) build -c Debug -nologo -warnaserror -p:TargetPlatform=$(TARGETPLATFORM) -p:EnforceCodeStyleInBuild=true -p:GenerateDocumentationFile=true

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -351,7 +351,7 @@ namespace OpenRA
 				{
 					var rendererPath = Path.Combine(Platform.BinDir, "OpenRA.Platforms." + p + ".dll");
 
-#if !MONO
+#if NET5_0_OR_GREATER
 					var loader = new AssemblyLoader(rendererPath);
 					var platformType = loader.LoadDefaultAssembly().GetTypes().SingleOrDefault(t => typeof(IPlatform).IsAssignableFrom(t));
 

--- a/OpenRA.Game/HttpExtension.cs
+++ b/OpenRA.Game/HttpExtension.cs
@@ -26,7 +26,7 @@ namespace OpenRA
 			var total = response.Content.Headers.ContentLength ?? -1;
 			var canReportProgress = total > 0;
 
-#if !MONO
+#if NET5_0_OR_GREATER
 			using (var contentStream = await response.Content.ReadAsStreamAsync(token))
 #else
 			using (var contentStream = await response.Content.ReadAsStreamAsync())

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -60,7 +60,11 @@ namespace OpenRA
 
 			if (!ResolvedAssemblies.TryGetValue(hash, out var assembly))
 			{
-#if MONO
+#if NET5_0_OR_GREATER
+				var loader = new AssemblyLoader(resolvedPath);
+				assembly = loader.LoadDefaultAssembly();
+				ResolvedAssemblies.Add(hash, assembly);
+#else
 				assembly = Assembly.LoadFile(resolvedPath);
 				ResolvedAssemblies.Add(hash, assembly);
 
@@ -75,10 +79,6 @@ namespace OpenRA
 							LoadAssembly(assemblyList, depedencyPath);
 					}
 				}
-#else
-				var loader = new AssemblyLoader(resolvedPath);
-				assembly = loader.LoadDefaultAssembly();
-				ResolvedAssemblies.Add(hash, assembly);
 #endif
 			}
 

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -2,10 +2,7 @@
   <PropertyGroup>
     <RootNamespace>OpenRA</RootNamespace>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Mono)' != ''">
-    <DefineConstants>MONO</DefineConstants>
-  </PropertyGroup>
-  <ItemGroup Condition="'$(Mono)' == ''">
+  <ItemGroup Condition="'$(MSBuildRuntimeType)'!='Mono'">
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/OpenRA.Game/Support/AssemblyLoader.cs
+++ b/OpenRA.Game/Support/AssemblyLoader.cs
@@ -11,7 +11,7 @@
 
 // Not used/usable on Mono. Only used for Dotnet Core.
 // Based on https://github.com/natemcmaster/DotNetCorePlugins and used under the terms of the Apache 2.0 license
-#if !MONO
+#if NET5_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/OpenRA.Game/Support/HttpClientFactory.cs
+++ b/OpenRA.Game/Support/HttpClientFactory.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Support
 {
 	public class HttpClientFactory
 	{
-#if !MONO
+#if NET5_0_OR_GREATER
 		const int MaxConnectionPerServer = 20;
 		static readonly TimeSpan ConnectionLifeTime = TimeSpan.FromMinutes(1);
 #endif
@@ -30,7 +30,7 @@ namespace OpenRA.Support
 
 		static HttpMessageHandler GetHandler()
 		{
-#if !MONO
+#if NET5_0_OR_GREATER
 			return new SocketsHttpHandler
 			{
 				// https://github.com/dotnet/corefx/issues/26895

--- a/packaging/functions.sh
+++ b/packaging/functions.sh
@@ -40,7 +40,7 @@ install_assemblies() {
 		rm -rf "${SRC_PATH}/OpenRA."*/obj
 		rm -rf "${SRC_PATH:?}/bin"
 
-		msbuild -verbosity:m -nologo -t:Build -restore -p:Configuration=Release -p:TargetPlatform="${TARGETPLATFORM}" -p:Mono=true
+		msbuild -verbosity:m -nologo -t:Build -restore -p:Configuration=Release -p:TargetPlatform="${TARGETPLATFORM}"
 		if [ "${TARGETPLATFORM}" = "unix-generic" ]; then
 			./configure-system-libraries.sh
 		fi


### PR DESCRIPTION
This PR replaces a small piece of redundant custom plumbing with toolchain-provided behaviour.