### PR TITLE
Use Building instead of D2kBuilding for the Sietch actor

### DIFF
--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -134,11 +134,11 @@ sietch:
 	Inherits: ^Building
 	Tooltip:
 		Name: Fremen Sietch
-	D2kBuilding:
+	-D2kBuilding:
+	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
 		TerrainTypes: Cliff
-		DamageTerrainTypes:
 	Health:
 		HP: 60000
 	Armor:


### PR DESCRIPTION
Closes #20015.

We indeed neither need auto-concrete nor the foundation damaging mechanism, so using `Building` seems logical. (Which was missed in #18685.)