### PR TITLE
Fix GrantConditionOnPrerequisite behaviour/crash.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPrerequisite.cs
@@ -70,12 +70,16 @@ namespace OpenRA.Mods.Common.Traits
 			if (available == wasAvailable)
 				return;
 
-			if (available && conditionToken == Actor.InvalidConditionToken)
-				conditionToken = self.GrantCondition(info.Condition);
-			else if (!available && conditionToken != Actor.InvalidConditionToken)
-				conditionToken = self.RevokeCondition(conditionToken);
+			// Workaround (putting inside AddFrameEndTask) to prevent crash and odd behaviour when actors initially exist on map
+			self.World.AddFrameEndTask(w =>
+			{
+				if (available && conditionToken == Actor.InvalidConditionToken)
+					conditionToken = self.GrantCondition(info.Condition);
+				else if (!available && conditionToken != Actor.InvalidConditionToken)
+					conditionToken = self.RevokeCondition(conditionToken);
 
-			wasAvailable = available;
+				wasAvailable = available;
+			});
 		}
 	}
 }


### PR DESCRIPTION
This is a small fix which prevents a crashing bug, and some weird behaviour when using GrantConditionOnPrerequisite whereby pre-existing buildings have conditions based on prerequisites applied permanently.

Map for replication: http://www.darkademic.co.uk/uploads/testgcop.oramap

Steps to replicate the incorrect behaviour, followed by the crash:

1. Sell walls (blocked MCVs in to prevent AI doing stuff while I was testing). Note that the initial war factory has "has mcv" text.
2. Deploy conyard. Note "has mcv" remains, and "has conyard" appears (the former should not be there after deploying).
3. Build a second war factory. Note that it only has "has conyard".
4. Undeploy conyard. Both have "has mcv" only, which is correct.
5. Deploy conyard. Again, the first conyard incorrectly still shows "has mcv".
6. Sell conyard. Game crashes with following exception:

```
Exception of type `System.InvalidOperationException`: Attempting to revoke condition with invalid token 4 for weap 34.
   at OpenRA.Actor.RevokeCondition(Int32 token) in J:\OpenRA\OpenRA.Game\Actor.cs:line 583
   at OpenRA.Mods.Common.Traits.GrantConditionOnPrerequisiteManager.PrerequisitesUnavailable(String key) in J:\OpenRA\OpenRA.Mods.Common\Traits\Player\GrantConditionOnPrerequisiteManager.cs:line 85
   at OpenRA.Mods.Common.Traits.TechTree.Watcher.Update(Cache`2 ownedPrerequisites) in J:\OpenRA\OpenRA.Mods.Common\Traits\Player\TechTree.cs:line 193
   at OpenRA.Mods.Common.Traits.TechTree.Update() in J:\OpenRA\OpenRA.Mods.Common\Traits\Player\TechTree.cs:line 50
   at OpenRA.Actor.UpdateConditionState(String condition, Int32 token, Boolean isRevoke) in J:\OpenRA\OpenRA.Game\Actor.cs:line 556
   at OpenRA.Actor.RevokeCondition(Int32 token) in J:\OpenRA\OpenRA.Game\Actor.cs:line 586
   at OpenRA.Mods.Common.Traits.GrantConditionOnPrerequisiteManager.PrerequisitesUnavailable(String key) in J:\OpenRA\OpenRA.Mods.Common\Traits\Player\GrantConditionOnPrerequisiteManager.cs:line 85
   at OpenRA.Mods.Common.Traits.TechTree.Watcher.Update(Cache`2 ownedPrerequisites) in J:\OpenRA\OpenRA.Mods.Common\Traits\Player\TechTree.cs:line 193
   at OpenRA.Mods.Common.Traits.TechTree.Update() in J:\OpenRA\OpenRA.Mods.Common\Traits\Player\TechTree.cs:line 50
   at OpenRA.World.Remove(Actor a) in J:\OpenRA\OpenRA.Game\World.cs:line 329
   at OpenRA.Actor.<Dispose>b__91_0(World w) in J:\OpenRA\OpenRA.Game\Actor.cs:line 415
   at OpenRA.World.Tick() in J:\OpenRA\OpenRA.Game\World.cs:line 435
   at OpenRA.Game.InnerLogicTick(OrderManager orderManager) in J:\OpenRA\OpenRA.Game\Game.cs:line 622
   at OpenRA.Game.LogicTick() in J:\OpenRA\OpenRA.Game\Game.cs:line 637
   at OpenRA.Game.Loop() in J:\OpenRA\OpenRA.Game\Game.cs:line 802
   at OpenRA.Game.Run() in J:\OpenRA\OpenRA.Game\Game.cs:line 855
   at OpenRA.Game.InitializeAndRun(String[] args) in J:\OpenRA\OpenRA.Game\Game.cs:line 294
   at OpenRA.Launcher.Program.Main(String[] args) in J:\OpenRA\OpenRA.Launcher\Program.cs:line 32
```

After the fix, the conditions are applied correctly based on prerequisites, and the game doesn't crash anymore.