### PR TITLE
Add platform override support for hotkeys and unhardcode editor hotkeys

### DIFF
--- a/OpenRA.Game/HotkeyDefinition.cs
+++ b/OpenRA.Game/HotkeyDefinition.cs
@@ -41,6 +41,14 @@ namespace OpenRA
 			var contextsNode = node.Nodes.FirstOrDefault(n => n.Key == "Contexts");
 			if (contextsNode != null)
 				Contexts = FieldLoader.GetValue<HashSet<string>>("Contexts", contextsNode.Value.Value);
+
+			var platformNode = node.Nodes.FirstOrDefault(n => n.Key == "Platform");
+			if (platformNode != null)
+			{
+				var platformOverride = platformNode.Value.Nodes.FirstOrDefault(n => n.Key == Platform.CurrentPlatform.ToString());
+				if (platformOverride != null)
+					Default = FieldLoader.GetValue<Hotkey>("value", platformOverride.Value.Value);
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
@@ -39,15 +39,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var copypasteButton = widget.GetOrNull<ButtonWidget>("COPYPASTE_BUTTON");
 			if (copypasteButton != null)
 			{
-				// HACK: Replace Ctrl with Cmd on macOS
-				// TODO: Add platform-specific override support to HotkeyManager
-				// and then port the editor hotkeys to this system.
 				var copyPasteKey = copypasteButton.Key.GetValue();
-				if (Platform.CurrentPlatform == PlatformType.OSX && copyPasteKey.Modifiers.HasModifier(Modifiers.Ctrl))
-				{
-					var modified = new Hotkey(copyPasteKey.Key, copyPasteKey.Modifiers & ~Modifiers.Ctrl | Modifiers.Meta);
-					copypasteButton.Key = FieldLoader.GetValue<HotkeyReference>("Key", modified.ToString());
-				}
 
 				copypasteButton.OnClick = () => editorViewport.SetBrush(new EditorCopyPasteBrush(editorViewport, worldRenderer, () => copyFilters));
 				copypasteButton.IsHighlighted = () => editorViewport.CurrentBrush is EditorCopyPasteBrush;

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -591,7 +591,7 @@ Container@EDITOR_WORLD_ROOT:
 			Width: 100
 			Text: Undo
 			Font: Bold
-			Key: z ctrl
+			Key: EditorUndo
 			TooltipTemplate: BUTTON_TOOLTIP
 			TooltipText: Undo last step
 			TooltipContainer: TOOLTIP_CONTAINER
@@ -602,7 +602,7 @@ Container@EDITOR_WORLD_ROOT:
 			Width: 100
 			Text: Redo
 			Font: Bold
-			Key: y ctrl
+			Key: EditorRedo
 			TooltipTemplate: BUTTON_TOOLTIP
 			TooltipText: Redo last step
 			TooltipContainer: TOOLTIP_CONTAINER
@@ -612,7 +612,7 @@ Container@EDITOR_WORLD_ROOT:
 			Width: 96
 			Height: 25
 			Text: Copy/Paste
-			Key: c ctrl
+			Key: EditorCopy
 			TooltipTemplate: BUTTON_TOOLTIP
 			TooltipText: Copy
 			TooltipContainer: TOOLTIP_CONTAINER

--- a/mods/cnc/chrome/settings-hotkeys.yaml
+++ b/mods/cnc/chrome/settings-hotkeys.yaml
@@ -21,6 +21,8 @@ Container@HOTKEYS_PANEL:
 				Types: Chat
 			Control Groups:
 				Types: ControlGroups
+			Editor Commands:
+				Types: Editor
 	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM
 	Children:

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -162,6 +162,7 @@ Hotkeys:
 	common|hotkeys/supportpowers.yaml
 	common|hotkeys/viewport.yaml
 	common|hotkeys/chat.yaml
+	common|hotkeys/editor.yaml
 	common|hotkeys/control-groups.yaml
 	cnc|hotkeys.yaml
 

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -573,7 +573,7 @@ Container@EDITOR_WORLD_ROOT:
 			TooltipText: Copy
 			TooltipContainer: TOOLTIP_CONTAINER
 			Font: Bold
-			Key: c ctrl
+			Key: EditorCopy
 		DropDownButton@COPYFILTER_BUTTON:
 			X: 170
 			Width: 140
@@ -586,7 +586,7 @@ Container@EDITOR_WORLD_ROOT:
 			Width: 70
 			Text: Undo
 			Font: Bold
-			Key: z ctrl
+			Key: EditorUndo
 			TooltipTemplate: BUTTON_TOOLTIP
 			TooltipText: Undo last step
 			TooltipContainer: TOOLTIP_CONTAINER
@@ -596,7 +596,7 @@ Container@EDITOR_WORLD_ROOT:
 			Width: 70
 			Text: Redo
 			Font: Bold
-			Key: y ctrl
+			Key: EditorRedo
 			TooltipTemplate: BUTTON_TOOLTIP
 			TooltipText: Redo last step
 			TooltipContainer: TOOLTIP_CONTAINER

--- a/mods/common/chrome/settings-hotkeys.yaml
+++ b/mods/common/chrome/settings-hotkeys.yaml
@@ -21,6 +21,8 @@ Container@HOTKEYS_PANEL:
 				Types: Chat
 			Control Groups:
 				Types: ControlGroups
+			Editor Commands:
+				Types: Editor
 	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM
 	Children:

--- a/mods/common/hotkeys/editor.yaml
+++ b/mods/common/hotkeys/editor.yaml
@@ -1,0 +1,21 @@
+EditorUndo: Z Ctrl
+	Description: Undo
+	Types: Editor
+	Contexts: Editor
+	Platform:
+		OSX: Z Meta
+
+EditorRedo: Y Ctrl
+	Description: Redo
+	Types: Editor
+	Contexts: Editor
+	Platform:
+		OSX: Z Meta, Shift
+		Linux: Z Ctrl, Shift
+
+EditorCopy: C Ctrl
+	Description: Copy
+	Types: Editor
+	Contexts: Editor
+	Platform:
+		OSX: C Meta

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -147,6 +147,7 @@ Hotkeys:
 	common|hotkeys/supportpowers.yaml
 	common|hotkeys/viewport.yaml
 	common|hotkeys/chat.yaml
+	common|hotkeys/editor.yaml
 	common|hotkeys/control-groups.yaml
 	d2k|hotkeys.yaml
 

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -165,6 +165,7 @@ Hotkeys:
 	common|hotkeys/supportpowers.yaml
 	common|hotkeys/viewport.yaml
 	common|hotkeys/chat.yaml
+	common|hotkeys/editor.yaml
 	common|hotkeys/control-groups.yaml
 	ra|hotkeys.yaml
 

--- a/mods/ts/chrome/settings-hotkeys.yaml
+++ b/mods/ts/chrome/settings-hotkeys.yaml
@@ -21,6 +21,8 @@ Container@HOTKEYS_PANEL:
 				Types: Chat
 			Control Groups:
 				Types: ControlGroups
+			Editor Commands:
+				Types: Editor
 			Depth Preview Debug:
 				Types: DepthDebug
 	Width: PARENT_RIGHT

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -204,6 +204,7 @@ Hotkeys:
 	common|hotkeys/supportpowers.yaml
 	common|hotkeys/viewport.yaml
 	common|hotkeys/chat.yaml
+	common|hotkeys/editor.yaml
 	common|hotkeys/control-groups.yaml
 	ts|hotkeys.yaml
 


### PR DESCRIPTION
Add platform specific hotkey default values and use that to make the editor hotkeys rebindable. This allows for example the "Redo" key to be <kbd>Ctrl</kbd> + <kbd>Y</kbd> on Windows, <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Z</kbd> on Linux and <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>Z</kbd> on MacOS.

![image](https://user-images.githubusercontent.com/1355810/167027427-2778d1a6-3c92-4bd2-b165-f8fa58329b3b.png)
