### PR TITLE
Add more map editor hotkeys

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
@@ -11,25 +11,14 @@
 
 using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.Lint;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	[ChromeLogicArgsHotkeys("ChangeZoomKey")]
 	public class MapEditorLogic : ChromeLogic
 	{
 		MapCopyFilters copyFilters = MapCopyFilters.All;
-
-		enum MapOverlays
-		{
-			None = 0,
-			Grid = 1,
-			Buildable = 2,
-		}
-
-		MapOverlays overlays = MapOverlays.None;
 
 		[ObjectCreator.UseCtor]
 		public MapEditorLogic(Widget widget, World world, WorldRenderer worldRenderer)
@@ -60,16 +49,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var cell = worldRenderer.Viewport.ViewToWorld(Viewport.LastMousePos);
 					var map = worldRenderer.World.Map;
 					return map.Height.Contains(cell) ? $"{cell},{map.Height[cell]} ({map.Tiles[cell].Type})" : "";
-				};
-			}
-
-			var overlayDropdown = widget.GetOrNull<DropDownButtonWidget>("OVERLAY_BUTTON");
-			if (overlayDropdown != null)
-			{
-				overlayDropdown.OnMouseDown = _ =>
-				{
-					overlayDropdown.RemovePanel();
-					overlayDropdown.AttachPanel(CreateOverlaysPanel(world));
 				};
 			}
 
@@ -106,46 +85,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				category.IsChecked = () => copyFilters.HasFlag(cat);
 				category.IsVisible = () => true;
 				category.OnClick = () => copyFilters ^= cat;
-
-				categoriesPanel.AddChild(category);
-			}
-
-			return categoriesPanel;
-		}
-
-		Widget CreateOverlaysPanel(World world)
-		{
-			var categoriesPanel = Ui.LoadWidget("OVERLAY_PANEL", null, new WidgetArgs());
-			var categoryTemplate = categoriesPanel.Get<CheckboxWidget>("CATEGORY_TEMPLATE");
-
-			MapOverlays[] allCategories = { MapOverlays.Grid, MapOverlays.Buildable };
-			foreach (var cat in allCategories)
-			{
-				var category = (CheckboxWidget)categoryTemplate.Clone();
-				category.GetText = () => cat.ToString();
-				category.IsChecked = () => overlays.HasFlag(cat);
-				category.IsVisible = () => true;
-				category.OnClick = () => overlays ^= cat;
-
-				if (cat.HasFlag(MapOverlays.Grid))
-				{
-					var terrainGeometryTrait = world.WorldActor.Trait<TerrainGeometryOverlay>();
-					category.OnClick = () =>
-					{
-						overlays ^= cat;
-						terrainGeometryTrait.Enabled = overlays.HasFlag(MapOverlays.Grid);
-					};
-				}
-
-				if (cat.HasFlag(MapOverlays.Buildable))
-				{
-					var buildableTerrainTrait = world.WorldActor.Trait<BuildableTerrainOverlay>();
-					category.OnClick = () =>
-					{
-						overlays ^= cat;
-						buildableTerrainTrait.Enabled = overlays.HasFlag(MapOverlays.Buildable);
-					};
-				}
 
 				categoriesPanel.AddChild(category);
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapOverlaysLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapOverlaysLogic.cs
@@ -1,0 +1,109 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Mods.Common.Lint;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+	[ChromeLogicArgsHotkeys("ToggleGridOverlayKey", "ToggleBuildableOverlayKey")]
+	public class MapOverlaysLogic : ChromeLogic
+	{
+		enum MapOverlays
+		{
+			None = 0,
+			Grid = 1,
+			Buildable = 2,
+		}
+
+		readonly TerrainGeometryOverlay terrainGeometryTrait;
+		readonly BuildableTerrainOverlay buildableTerrainTrait;
+
+		[ObjectCreator.UseCtor]
+		public MapOverlaysLogic(Widget widget, World world, ModData modData, Dictionary<string, MiniYaml> logicArgs)
+		{
+			terrainGeometryTrait = world.WorldActor.Trait<TerrainGeometryOverlay>();
+			buildableTerrainTrait = world.WorldActor.Trait<BuildableTerrainOverlay>();
+
+			var toggleGridKey = new HotkeyReference();
+			if (logicArgs.TryGetValue("ToggleGridOverlayKey", out var yaml))
+				toggleGridKey = modData.Hotkeys[yaml.Value];
+
+			var toggleBuildableKey = new HotkeyReference();
+			if (logicArgs.TryGetValue("ToggleBuildableOverlayKey", out yaml))
+				toggleBuildableKey = modData.Hotkeys[yaml.Value];
+
+			var keyhandler = widget.Get<LogicKeyListenerWidget>("OVERLAY_KEYHANDLER");
+			keyhandler.AddHandler(e =>
+			{
+				if (e.Event != KeyInputEvent.Down)
+					return false;
+
+				if (toggleGridKey.IsActivatedBy(e))
+				{
+					terrainGeometryTrait.Enabled ^= true;
+					return true;
+				}
+
+				if (toggleBuildableKey.IsActivatedBy(e))
+				{
+					buildableTerrainTrait.Enabled ^= true;
+					return true;
+				}
+
+				return false;
+			});
+
+			var overlayPanel = CreateOverlaysPanel();
+
+			var overlayDropdown = widget.GetOrNull<DropDownButtonWidget>("OVERLAY_BUTTON");
+			if (overlayDropdown != null)
+			{
+				overlayDropdown.OnMouseDown = _ =>
+				{
+					overlayDropdown.RemovePanel();
+					overlayDropdown.AttachPanel(overlayPanel);
+				};
+			}
+		}
+
+		Widget CreateOverlaysPanel()
+		{
+			var categoriesPanel = Ui.LoadWidget("OVERLAY_PANEL", null, new WidgetArgs());
+			var categoryTemplate = categoriesPanel.Get<CheckboxWidget>("CATEGORY_TEMPLATE");
+
+			MapOverlays[] allCategories = { MapOverlays.Grid, MapOverlays.Buildable };
+			foreach (var cat in allCategories)
+			{
+				var category = (CheckboxWidget)categoryTemplate.Clone();
+				category.GetText = () => cat.ToString();
+				category.IsVisible = () => true;
+
+				if (cat.HasFlag(MapOverlays.Grid))
+				{
+					category.IsChecked = () => terrainGeometryTrait.Enabled;
+					category.OnClick = () => terrainGeometryTrait.Enabled ^= true;
+				}
+				else if (cat.HasFlag(MapOverlays.Buildable))
+				{
+					category.IsChecked = () => buildableTerrainTrait.Enabled;
+					category.OnClick = () => buildableTerrainTrait.Enabled ^= true;
+				}
+
+				categoriesPanel.AddChild(category);
+			}
+
+			return categoriesPanel;
+		}
+	}
+}

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -213,7 +213,6 @@ Container@EDITOR_ROOT:
 
 Container@EDITOR_WORLD_ROOT:
 	Logic: LoadIngamePerfLogic, MapEditorLogic, ActorEditLogic
-		EditPanelPadding: 5
 	Children:
 		Container@PERF_ROOT:
 		EditorViewportController@MAP_EDITOR:

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -212,8 +212,11 @@ Container@EDITOR_ROOT:
 		TooltipContainer@TOOLTIP_CONTAINER:
 
 Container@EDITOR_WORLD_ROOT:
-	Logic: LoadIngamePerfLogic, MapEditorLogic, ActorEditLogic
+	Logic: LoadIngamePerfLogic, MapEditorLogic, ActorEditLogic, MapOverlaysLogic
+		ToggleGridOverlayKey: EditorToggleGridOverlay
+		ToggleBuildableOverlayKey: EditorToggleBuildableOverlay
 	Children:
+		LogicKeyListener@OVERLAY_KEYHANDLER:
 		Container@PERF_ROOT:
 		EditorViewportController@MAP_EDITOR:
 			Width: WINDOW_RIGHT

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -565,24 +565,40 @@ Container@EDITOR_WORLD_ROOT:
 					Height: 25
 					Text: Tiles
 					Font: Bold
+					Key: EditorTilesTab
+					TooltipTemplate: BUTTON_TOOLTIP
+					TooltipText: Tiles
+					TooltipContainer: TOOLTIP_CONTAINER
 				Button@OVERLAYS_TAB:
 					X: 70
 					Width: 80
 					Height: 25
 					Text: Overlays
 					Font: Bold
+					Key: EditorOverlaysTab
+					TooltipTemplate: BUTTON_TOOLTIP
+					TooltipText: Overlays
+					TooltipContainer: TOOLTIP_CONTAINER
 				Button@ACTORS_TAB:
 					X: 149
 					Width: 71
 					Height: 25
 					Text: Actors
 					Font: Bold
+					Key: EditorActorsTab
+					TooltipTemplate: BUTTON_TOOLTIP
+					TooltipText: Actors
+					TooltipContainer: TOOLTIP_CONTAINER
 				Button@HISTORY_TAB:
 					X: 219
 					Width: 71
 					Height: 25
 					Text: History
 					Font: Bold
+					Key: EditorHistoryTab
+					TooltipTemplate: BUTTON_TOOLTIP
+					TooltipText: History
+					TooltipContainer: TOOLTIP_CONTAINER
 		Button@UNDO_BUTTON:
 			X: WINDOW_RIGHT - 800
 			Y: 5

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -203,8 +203,11 @@ Container@EDITOR_ROOT:
 		TooltipContainer@TOOLTIP_CONTAINER:
 
 Container@EDITOR_WORLD_ROOT:
-	Logic: LoadIngamePerfLogic, MapEditorLogic, ActorEditLogic
+	Logic: LoadIngamePerfLogic, MapEditorLogic, ActorEditLogic, MapOverlaysLogic
+		ToggleGridOverlayKey: EditorToggleGridOverlay
+		ToggleBuildableOverlayKey: EditorToggleBuildableOverlay
 	Children:
+		LogicKeyListener@OVERLAY_KEYHANDLER:
 		Container@PERF_ROOT:
 		EditorViewportController@MAP_EDITOR:
 			Width: WINDOW_RIGHT

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -204,7 +204,6 @@ Container@EDITOR_ROOT:
 
 Container@EDITOR_WORLD_ROOT:
 	Logic: LoadIngamePerfLogic, MapEditorLogic, ActorEditLogic
-		EditPanelPadding: 14
 	Children:
 		Container@PERF_ROOT:
 		EditorViewportController@MAP_EDITOR:

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -533,24 +533,40 @@ Container@EDITOR_WORLD_ROOT:
 					Height: 25
 					Text: Tiles
 					Font: Bold
+					Key: EditorTilesTab
+					TooltipTemplate: BUTTON_TOOLTIP
+					TooltipText: Tiles
+					TooltipContainer: TOOLTIP_CONTAINER
 				Button@OVERLAYS_TAB:
 					X: 70
 					Width: 90
 					Height: 25
 					Text: Overlays
 					Font: Bold
+					Key: EditorOverlaysTab
+					TooltipTemplate: BUTTON_TOOLTIP
+					TooltipText: Overlays
+					TooltipContainer: TOOLTIP_CONTAINER
 				Button@ACTORS_TAB:
 					X: 160
 					Width: 70
 					Height: 25
 					Text: Actors
 					Font: Bold
+					Key: EditorActorsTab
+					TooltipTemplate: BUTTON_TOOLTIP
+					TooltipText: Actors
+					TooltipContainer: TOOLTIP_CONTAINER
 				Button@HISTORY_TAB:
 					X: 230
 					Width: 70
 					Height: 25
 					Text: History
 					Font: Bold
+					Key: EditorHistoryTab
+					TooltipTemplate: BUTTON_TOOLTIP
+					TooltipText: History
+					TooltipContainer: TOOLTIP_CONTAINER
 		MenuButton@OPTIONS_BUTTON:
 			Logic: MenuButtonsChromeLogic
 			MenuContainer: INGAME_MENU

--- a/mods/common/hotkeys/editor.yaml
+++ b/mods/common/hotkeys/editor.yaml
@@ -19,3 +19,23 @@ EditorCopy: C Ctrl
 	Contexts: Editor
 	Platform:
 		OSX: C Meta
+
+EditorTilesTab: E
+	Description: Tiles Tab
+	Types: Editor
+	Contexts: Editor
+
+EditorOverlaysTab: R
+	Description: Overlays Tab
+	Types: Editor
+	Contexts: Editor
+
+EditorActorsTab: T
+	Description: Actors Tab
+	Types: Editor
+	Contexts: Editor
+
+EditorHistoryTab: Y
+	Description: History Tab
+	Types: Editor
+	Contexts: Editor

--- a/mods/common/hotkeys/editor.yaml
+++ b/mods/common/hotkeys/editor.yaml
@@ -39,3 +39,13 @@ EditorHistoryTab: Y
 	Description: History Tab
 	Types: Editor
 	Contexts: Editor
+
+EditorToggleGridOverlay: F1
+	Description: Grid Overlay
+	Types: Editor
+	Contexts: Editor
+
+EditorToggleBuildableOverlay: F2
+	Description: Buildable Terrain Overlay
+	Types: Editor
+	Contexts: Editor


### PR DESCRIPTION
Adds hotkeys to map editor tabs (Tiles, Actors, Overlays, History) and overlay toggles (Grid, Buildable Terrain).

![image](https://user-images.githubusercontent.com/1355810/167206652-6b501eb8-3574-48f7-aebc-cc5e6aca6e59.png)

Depends on #20028 (not really dependent on it, but the copy, undo/redo keys are)