### PR TITLE
Fix issues preventing suboptimal path searches.

### DIFF
--- a/OpenRA.Game/Primitives/PriorityQueue.cs
+++ b/OpenRA.Game/Primitives/PriorityQueue.cs
@@ -102,7 +102,7 @@ namespace OpenRA.Primitives
 				return;
 			}
 
-			if (downLevel <= level && downIndex < index - 1 &&
+			if ((downLevel < level || (downLevel == level && downIndex < index - 1)) &&
 				comparer.Compare(At(downLevel, downIndex), At(downLevel, downIndex + 1)) >= 0)
 				++downIndex;
 

--- a/OpenRA.Test/OpenRA.Game/PriorityQueueTest.cs
+++ b/OpenRA.Test/OpenRA.Game/PriorityQueueTest.cs
@@ -10,30 +10,133 @@
 #endregion
 
 using System;
+using System.Linq;
 using NUnit.Framework;
+using OpenRA.Mods.Common;
 using OpenRA.Primitives;
+using OpenRA.Support;
 
 namespace OpenRA.Test
 {
 	[TestFixture]
 	class PriorityQueueTest
 	{
-		[TestCase(TestName = "PriorityQueue maintains invariants when adding and removing items.")]
-		public void PriorityQueueGeneralTest()
+		[TestCase(1, 123)]
+		[TestCase(1, 1234)]
+		[TestCase(1, 12345)]
+		[TestCase(2, 123)]
+		[TestCase(2, 1234)]
+		[TestCase(2, 12345)]
+		[TestCase(10, 123)]
+		[TestCase(10, 1234)]
+		[TestCase(10, 12345)]
+		[TestCase(15, 123)]
+		[TestCase(15, 1234)]
+		[TestCase(15, 12345)]
+		[TestCase(16, 123)]
+		[TestCase(16, 1234)]
+		[TestCase(16, 12345)]
+		[TestCase(17, 123)]
+		[TestCase(17, 1234)]
+		[TestCase(17, 12345)]
+		[TestCase(100, 123)]
+		[TestCase(100, 1234)]
+		[TestCase(100, 12345)]
+		[TestCase(1000, 123)]
+		[TestCase(1000, 1234)]
+		[TestCase(1000, 12345)]
+		public void PriorityQueueAddThenRemoveTest(int count, int seed)
 		{
+			var mt = new MersenneTwister(seed);
+			var values = Enumerable.Range(0, count);
+			var shuffledValues = values.Shuffle(mt).ToArray();
+
 			var queue = new PriorityQueue<int>();
 
 			Assert.IsTrue(queue.Empty, "New queue should start out empty.");
 			Assert.Throws<InvalidOperationException>(() => queue.Peek(), "Peeking at an empty queue should throw.");
 			Assert.Throws<InvalidOperationException>(() => queue.Pop(), "Popping an empty queue should throw.");
 
-			foreach (var value in new[] { 4, 3, 5, 1, 2 })
+			foreach (var value in shuffledValues)
 			{
 				queue.Add(value);
 				Assert.IsFalse(queue.Empty, "Queue should not be empty - items have been added.");
 			}
 
-			foreach (var value in new[] { 1, 2, 3, 4, 5 })
+			foreach (var value in values)
+			{
+				Assert.AreEqual(value, queue.Peek(), "Peek returned the wrong item - should be in order.");
+				Assert.IsFalse(queue.Empty, "Queue should not be empty yet.");
+				Assert.AreEqual(value, queue.Pop(), "Pop returned the wrong item - should be in order.");
+			}
+
+			Assert.IsTrue(queue.Empty, "Queue should now be empty.");
+			Assert.Throws<InvalidOperationException>(() => queue.Peek(), "Peeking at an empty queue should throw.");
+			Assert.Throws<InvalidOperationException>(() => queue.Pop(), "Popping an empty queue should throw.");
+		}
+
+		[TestCase(15, 123)]
+		[TestCase(15, 1234)]
+		[TestCase(15, 12345)]
+		[TestCase(16, 123)]
+		[TestCase(16, 1234)]
+		[TestCase(16, 12345)]
+		[TestCase(17, 123)]
+		[TestCase(17, 1234)]
+		[TestCase(17, 12345)]
+		[TestCase(100, 123)]
+		[TestCase(100, 1234)]
+		[TestCase(100, 12345)]
+		[TestCase(1000, 123)]
+		[TestCase(1000, 1234)]
+		[TestCase(1000, 12345)]
+		public void PriorityQueueAddAndRemoveInterleavedTest(int count, int seed)
+		{
+			var mt = new MersenneTwister(seed);
+			var shuffledValues = Enumerable.Range(0, count).Shuffle(mt).ToArray();
+
+			var queue = new PriorityQueue<int>();
+
+			Assert.IsTrue(queue.Empty, "New queue should start out empty.");
+			Assert.Throws<InvalidOperationException>(() => queue.Peek(), "Peeking at an empty queue should throw.");
+			Assert.Throws<InvalidOperationException>(() => queue.Pop(), "Popping an empty queue should throw.");
+
+			foreach (var value in shuffledValues.Take(10))
+			{
+				queue.Add(value);
+				Assert.IsFalse(queue.Empty, "Queue should not be empty - items have been added.");
+			}
+
+			foreach (var value in shuffledValues.Take(10).OrderBy(x => x).Take(5))
+			{
+				Assert.AreEqual(value, queue.Peek(), "Peek returned the wrong item - should be in order.");
+				Assert.IsFalse(queue.Empty, "Queue should not be empty yet.");
+				Assert.AreEqual(value, queue.Pop(), "Pop returned the wrong item - should be in order.");
+			}
+
+			foreach (var value in shuffledValues.Skip(10).Take(5))
+			{
+				queue.Add(value);
+				Assert.IsFalse(queue.Empty, "Queue should not be empty - items have been added.");
+			}
+
+			foreach (var value in shuffledValues.Take(10).OrderBy(x => x).Skip(5)
+				.Concat(shuffledValues.Skip(10).Take(5)).OrderBy(x => x).Take(5))
+			{
+				Assert.AreEqual(value, queue.Peek(), "Peek returned the wrong item - should be in order.");
+				Assert.IsFalse(queue.Empty, "Queue should not be empty yet.");
+				Assert.AreEqual(value, queue.Pop(), "Pop returned the wrong item - should be in order.");
+			}
+
+			foreach (var value in shuffledValues.Skip(15))
+			{
+				queue.Add(value);
+				Assert.IsFalse(queue.Empty, "Queue should not be empty - items have been added.");
+			}
+
+			foreach (var value in shuffledValues.Take(10).OrderBy(x => x).Skip(5)
+				.Concat(shuffledValues.Skip(10).Take(5)).OrderBy(x => x).Skip(5)
+				.Concat(shuffledValues.Skip(15)).OrderBy(x => x))
 			{
 				Assert.AreEqual(value, queue.Peek(), "Peek returned the wrong item - should be in order.");
 				Assert.IsFalse(queue.Empty, "Queue should not be empty yet.");


### PR DESCRIPTION
Two different issues were causing a path search to not explore cells in order of the cheapest estimated route first. This meant the search could sometimes miss a cheaper route and return a suboptimal path.

- PriorityQueue had a bug which would cause it to not check some elements when restoring the heap property of its internal data structure. Failing to do this would invalidate the heap property, meaning it would not longer return the items in correct priority order. Additional tests ensure this is covered.
- When a path search encountered the same cell again with a lower cost, it would not update the priority queue with the new cost. This meant the cell was not explored early enough as it was in the queue with its original, higher cost. Exploring other paths might close off surrounding cells, preventing the cell with the lower cost from progressing. Instead we now add a duplicate with the lower cost to ensure it gets explored at the right time. We remove the duplicate with the higher cost in CanExpand by checking for already Closed cells.

----

The following test case can be used:

- Set `DefaultHeuristicWeightPercentage` to 100 to force optimal paths to be found. https://github.com/OpenRA/OpenRA/blob/e22b6de4e89c783b77697d6e0abd5aa0d5b455b2/OpenRA.Mods.Common/Pathfinder/PathSearch.cs#L23-L27
- Load on the Tiers of Sorrow map in TS, spawn B.
- Create a Jumpjet Infantry and move them from 100,5 to 100,-10 as shown. (Use the "Show Terrain Geometry" debug mode to make this easier by showing the cell coordinates)
![image](https://user-images.githubusercontent.com/3399086/167315170-482ec64d-be4a-4771-bfe3-ab244f0072dd.png)

On bleed, the unit with walk the route. With this PR, the unit will use the jumpjet to cover the distance instead.

The unit moves faster when using the jumpet and therefore should use that for decent length route (there is a small cost to jet up and down, so for very short paths it isn't always worth flying). The bugs prevent this optimal path from being detected, and once resolved allow the unit to move much faster by jumpjetting the whole way.