### PR TITLE
Add support for readonly hotkeys and expose chat input hotkeys

### DIFF
--- a/OpenRA.Game/HotkeyDefinition.cs
+++ b/OpenRA.Game/HotkeyDefinition.cs
@@ -21,6 +21,7 @@ namespace OpenRA
 		public readonly string Description = "";
 		public readonly HashSet<string> Types = new HashSet<string>();
 		public readonly HashSet<string> Contexts = new HashSet<string>();
+		public readonly bool Readonly = false;
 		public bool HasDuplicates { get; internal set; }
 
 		public HotkeyDefinition(string name, MiniYaml node)
@@ -49,6 +50,10 @@ namespace OpenRA
 				if (platformOverride != null)
 					Default = FieldLoader.GetValue<Hotkey>("value", platformOverride.Value.Value);
 			}
+
+			var readonlyNode = node.Nodes.FirstOrDefault(n => n.Key == "Readonly");
+			if (readonlyNode != null)
+				Readonly = FieldLoader.GetValue<bool>("Readonly", readonlyNode.Value.Value);
 		}
 	}
 }

--- a/OpenRA.Game/HotkeyManager.cs
+++ b/OpenRA.Game/HotkeyManager.cs
@@ -35,7 +35,7 @@ namespace OpenRA
 
 			foreach (var kv in settings)
 			{
-				if (definitions.ContainsKey(kv.Key))
+				if (definitions.ContainsKey(kv.Key) && !definitions[kv.Key].Readonly)
 					keys[kv.Key] = kv.Value;
 			}
 
@@ -59,6 +59,9 @@ namespace OpenRA
 		public void Set(string name, Hotkey value)
 		{
 			if (!definitions.TryGetValue(name, out var definition))
+				return;
+
+			if (definition.Readonly)
 				return;
 
 			keys[name] = value;

--- a/mods/cnc/chrome/ingame-chat.yaml
+++ b/mods/cnc/chrome/ingame-chat.yaml
@@ -32,7 +32,7 @@ Container@CHAT_PANEL:
 					Height: 25
 					Text: Team
 					Font: Bold
-					Key: Tab SHIFT
+					Key: ToggleChatMode
 					TooltipText: Toggle chat mode
 					TooltipTemplate: BUTTON_TOOLTIP_FACTIONSUFFIX
 					TooltipContainer: TOOLTIP_CONTAINER

--- a/mods/cnc/chrome/ingame-infochat.yaml
+++ b/mods/cnc/chrome/ingame-infochat.yaml
@@ -19,7 +19,7 @@ Container@CHAT_CONTAINER:
 					Height: 25
 					Text: Team
 					Font: Bold
-					Key: Tab SHIFT
+					Key: ToggleChatMode
 					TooltipText: Toggle chat mode
 					TooltipContainer: TOOLTIP_CONTAINER
 				TextField@CHAT_TEXTFIELD:

--- a/mods/cnc/chrome/lobby.yaml
+++ b/mods/cnc/chrome/lobby.yaml
@@ -110,7 +110,7 @@ Container@SERVER_LOBBY:
 							Height: 25
 							Text: Team
 							Font: Bold
-							Key: Tab SHIFT
+							Key: ToggleChatMode
 							TooltipText: Toggle chat mode
 							TooltipContainer: TOOLTIP_CONTAINER
 						TextField@CHAT_TEXTFIELD:

--- a/mods/cnc/chrome/settings-hotkeys.yaml
+++ b/mods/cnc/chrome/settings-hotkeys.yaml
@@ -131,6 +131,11 @@ Container@HOTKEYS_PANEL:
 									Height: PARENT_BOTTOM
 									Font: Tiny
 									Text: This is already used for "{0}" in the {1} context
+								Label@READONLY_NOTICE:
+									Width: PARENT_RIGHT
+									Height: PARENT_BOTTOM
+									Font: Tiny
+									Text: This hotkey cannot be modified
 						Button@OVERRIDE_HOTKEY_BUTTON:
 							X: PARENT_RIGHT - 3 * WIDTH - 30
 							Y: 20

--- a/mods/common/chrome/ingame-chat.yaml
+++ b/mods/common/chrome/ingame-chat.yaml
@@ -31,7 +31,7 @@ Container@CHAT_PANEL:
 					Height: 25
 					Text: Team
 					Font: Bold
-					Key: Tab SHIFT
+					Key: ToggleChatMode
 					TooltipText: Toggle chat mode
 					TooltipContainer: TOOLTIP_CONTAINER
 				TextField@CHAT_TEXTFIELD:

--- a/mods/common/chrome/ingame-infochat.yaml
+++ b/mods/common/chrome/ingame-infochat.yaml
@@ -19,7 +19,7 @@ Container@CHAT_CONTAINER:
 					Height: 25
 					Text: Team
 					Font: Bold
-					Key: Tab SHIFT
+					Key: ToggleChatMode
 					TooltipText: Toggle chat mode
 					TooltipContainer: TOOLTIP_CONTAINER
 				TextField@CHAT_TEXTFIELD:

--- a/mods/common/chrome/lobby.yaml
+++ b/mods/common/chrome/lobby.yaml
@@ -114,7 +114,7 @@ Background@SERVER_LOBBY:
 					Height: 25
 					Text: Team
 					Font: Bold
-					Key: Tab SHIFT
+					Key: ToggleChatMode
 					TooltipText: Toggle chat mode
 					TooltipContainer: TOOLTIP_CONTAINER
 				TextField@CHAT_TEXTFIELD:

--- a/mods/common/chrome/settings-hotkeys.yaml
+++ b/mods/common/chrome/settings-hotkeys.yaml
@@ -131,6 +131,11 @@ Container@HOTKEYS_PANEL:
 									Height: PARENT_BOTTOM
 									Font: Tiny
 									Text: This is already used for "{0}" in the {1} context
+								Label@READONLY_NOTICE:
+									Width: PARENT_RIGHT
+									Height: PARENT_BOTTOM
+									Font: Tiny
+									Text: This hotkey cannot be modified
 						Button@OVERRIDE_HOTKEY_BUTTON:
 							X: PARENT_RIGHT - 3 * WIDTH - 30
 							Y: 20

--- a/mods/common/hotkeys/chat.yaml
+++ b/mods/common/hotkeys/chat.yaml
@@ -7,3 +7,15 @@ OpenGeneralChat: Return Shift
 	Description: Open General Chat
 	Types: Chat
 	Contexts: Player, Spectator
+
+ToggleChatMode: Tab Shift
+	Description: Toggle Chat Mode
+	Types: Chat
+	Contexts: Chat Input, Menu
+	Readonly: True
+
+Autocomplete: Tab
+	Description: Autocomplete
+	Types: Chat
+	Contexts: Chat Input
+	Readonly: True

--- a/mods/ts/chrome/settings-hotkeys.yaml
+++ b/mods/ts/chrome/settings-hotkeys.yaml
@@ -133,6 +133,11 @@ Container@HOTKEYS_PANEL:
 									Height: PARENT_BOTTOM
 									Font: Tiny
 									Text: This is already used for "{0}" in the {1} context
+								Label@READONLY_NOTICE:
+									Width: PARENT_RIGHT
+									Height: PARENT_BOTTOM
+									Font: Tiny
+									Text: This hotkey cannot be modified
 						Button@OVERRIDE_HOTKEY_BUTTON:
 							X: PARENT_RIGHT - 3 * WIDTH - 30
 							Y: 20


### PR DESCRIPTION
This is another in my line of hotkey related PRs but I guess this one's gonna be a bit controversial. The motivation for this feature is to expose the hard-coded chat input hotkeys to the user.

![image](https://user-images.githubusercontent.com/1355810/167684104-599b9e5d-0521-47cc-8237-c42cf87b506a.png)
Read-only hotkey in the new "Chat Input" context

![image](https://user-images.githubusercontent.com/1355810/167684316-f8c1a5e1-00cc-401f-a2a0-d2f9b6062eea.png)
A conflict with a read-only hotkey
