### PR TITLE
Resolve an IDE0017 warning in ImportLegacyMapCommand

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
@@ -73,9 +73,8 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				{
 					Title = basic.GetValue("Name", Path.GetFileNameWithoutExtension(filename)),
 					Author = "Westwood Studios",
+					RequiresMod = ModData.Manifest.Id
 				};
-
-				Map.RequiresMod = ModData.Manifest.Id;
 
 				SetBounds(Map, mapSection);
 


### PR DESCRIPTION
It seems like .NET 6.0.300 is a bit more strict on this rule, which is why `make check` fails after the GitHub runners started using that version. (Example: https://github.com/OpenRA/OpenRA/runs/6386856939?check_suite_focus=true#step:4:18)