### PR TITLE
Clear cached notifications when initializing a new map/mod

### DIFF
--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -97,6 +97,7 @@ namespace OpenRA
 				soundFormat.GetPCMInputStream().ReadAllBytes(), soundFormat.Channels, soundFormat.SampleBits, soundFormat.SampleRate);
 			sounds = new Cache<string, ISoundSource>(filename => LoadSound(filename, loadIntoMemory));
 			currentSounds.Clear();
+			currentNotifications.Clear();
 			video = null;
 		}
 

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -401,9 +401,8 @@ namespace OpenRA
 
 			if (!string.IsNullOrEmpty(name) && (p == null || p == p.World.LocalPlayer))
 			{
-				if (currentNotifications.ContainsKey(name))
+				if (currentNotifications.TryGetValue(name, out var currentNotification))
 				{
-					var currentNotification = currentNotifications[name];
 					if (!currentNotification.Complete)
 					{
 						if (pool.AllowInterrupt)
@@ -412,9 +411,8 @@ namespace OpenRA
 							return false;
 					}
 				}
-				else if (currentSounds.ContainsKey(actorId))
+				else if (currentSounds.TryGetValue(actorId, out var currentSound))
 				{
-					var currentSound = currentSounds[actorId];
 					if (!currentSound.Complete)
 					{
 						if (pool.AllowInterrupt)

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -44,7 +44,7 @@ namespace OpenRA
 		ISound music;
 		ISound video;
 		MusicInfo currentMusic;
-		Dictionary<uint, ISound> currentSounds = new Dictionary<uint, ISound>();
+		readonly Dictionary<uint, ISound> currentSounds = new Dictionary<uint, ISound>();
 		readonly Dictionary<string, ISound> currentNotifications = new Dictionary<string, ISound>();
 		public bool DummyEngine { get; private set; }
 
@@ -96,7 +96,7 @@ namespace OpenRA
 			Func<ISoundFormat, ISoundSource> loadIntoMemory = soundFormat => soundEngine.AddSoundSourceFromMemory(
 				soundFormat.GetPCMInputStream().ReadAllBytes(), soundFormat.Channels, soundFormat.SampleBits, soundFormat.SampleRate);
 			sounds = new Cache<string, ISoundSource>(filename => LoadSound(filename, loadIntoMemory));
-			currentSounds = new Dictionary<uint, ISound>();
+			currentSounds.Clear();
 			video = null;
 		}
 


### PR DESCRIPTION
Sounds were cleared, so not clearing notifications as well just seems to be an oversight/bug.