### PR TITLE
Fix possible underflow in BlowfishKeyProvider.LenBigNum()

### DIFF
--- a/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
@@ -90,8 +90,14 @@ namespace OpenRA.Mods.Cnc.FileFormats
 
 		static uint LenBigNum(uint[] n, uint len)
 		{
-			var i = len - 1;
-			while (n[i] == 0) i--;
+			if (len == 0)
+				return 0;
+
+			var i = len;
+			while (n[--i] == 0)
+				if (i == 0)
+					return 0; // all zero
+
 			return i + 1;
 		}
 


### PR DESCRIPTION
I found this possible underflow while reviewing #20020. It was originally `while ((i >= 0) && (n[i] == 0)) i--;` where `i >= 0` was always `true` since `i` is a `uint`.

To see the difference try
```c#
var n = new uint[] { 0, 0, 8, 1, 0, 0 };
var i = 2U - 1;
while (i < uint.MaxValue && n[i] == 0) i--;
```
versus
```c#
var n = new uint[] { 0, 0, 8, 1, 0, 0 };
var i = 2U - 1;
while (n[i] == 0) i--;
```