### PR TITLE
Palette enhancements

### DIFF
--- a/OpenRA.Mods.Common/Traits/Palettes/ColorPickerPalette.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/ColorPickerPalette.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -31,7 +32,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The name of the palette to base off.")]
 		public readonly string BasePalette = null;
 
-		[FieldLoader.Require]
 		[Desc("Remap these indices to player colors.")]
 		public readonly int[] RemapIndex = Array.Empty<int>();
 
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			color = colorManager.Color;
 			var (_, h, s, _) = color.ToAhsv();
-			var remap = new PlayerColorRemap(info.RemapIndex, h, s);
+			var remap = new PlayerColorRemap(info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToArray() : info.RemapIndex, h, s);
 			wr.AddPalette(info.Name, new ImmutablePalette(wr.Palette(info.BasePalette).Palette, remap), info.AllowModifiers);
 		}
 
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			color = colorManager.Color;
 			var (_, h, s, _) = color.ToAhsv();
-			var remap = new PlayerColorRemap(info.RemapIndex, h, s);
+			var remap = new PlayerColorRemap(info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToArray() : info.RemapIndex, h, s);
 			wr.ReplacePalette(info.Name, new ImmutablePalette(wr.Palette(info.BasePalette).Palette, remap));
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Palettes/FixedColorPalette.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/FixedColorPalette.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -53,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var (_, h, s, _) = info.Color.ToAhsv();
 
-			var remap = new PlayerColorRemap(info.RemapIndex, h, s);
+			var remap = new PlayerColorRemap(info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToArray() : info.RemapIndex, h, s);
 			wr.AddPalette(info.Name, new ImmutablePalette(wr.Palette(info.Base).Palette, remap), info.AllowModifiers);
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Palettes/IndexedPlayerPalette.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/IndexedPlayerPalette.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -42,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
 			foreach (var p in PlayerIndex)
-				if (p.Value.Length != RemapIndex.Length)
+				if (p.Value.Length != (RemapIndex.Length == 0 ? 256 : RemapIndex.Length))
 					throw new YamlException($"PlayerIndex for player `{p.Key}` length does not match RemapIndex!");
 		}
 	}
@@ -62,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 			ImmutablePalette pal;
 
 			if (info.PlayerIndex.TryGetValue(playerName, out var remap))
-				pal = new ImmutablePalette(basePalette, new IndexedColorRemap(basePalette, info.RemapIndex, remap));
+				pal = new ImmutablePalette(basePalette, new IndexedColorRemap(basePalette, info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToArray() : info.RemapIndex, remap));
 			else
 				pal = new ImmutablePalette(basePalette);
 

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromFile.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromFile.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
-		[Desc("internal palette name")]
+		[Desc("Internal palette name")]
 		public readonly string Name = null;
 
 		[Desc("If defined, load the palette only for this tileset.")]

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromGrayscale.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromGrayscale.cs
@@ -1,0 +1,58 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
+	[Desc("Creates a greyscale palette without any base palette file.")]
+	class PaletteFromGrayscaleInfo : TraitInfo
+	{
+		[PaletteDefinition]
+		[FieldLoader.Require]
+		[Desc("internal palette name")]
+		public readonly string Name = null;
+
+		[Desc("If defined, load the palette only for this tileset.")]
+		public readonly string Tileset = null;
+
+		public readonly bool AllowModifiers = true;
+
+		[Desc("Index set to be fully transparent/invisible.")]
+		public readonly int TransparentIndex = 0;
+
+		public override object Create(ActorInitializer init) { return new PaletteFromGrayscale(init.World, this); }
+	}
+
+	class PaletteFromGrayscale : ILoadsPalettes
+	{
+		readonly World world;
+		readonly PaletteFromGrayscaleInfo info;
+		public PaletteFromGrayscale(World world, PaletteFromGrayscaleInfo info)
+		{
+			this.world = world;
+			this.info = info;
+		}
+
+		public void LoadPalettes(WorldRenderer wr)
+		{
+			// Enable palette only for a specific tileset
+			if (info.Tileset != null && !string.Equals(info.Tileset, world.Map.Tileset, System.StringComparison.InvariantCultureIgnoreCase))
+				return;
+
+			wr.AddPalette(info.Name, new ImmutablePalette(Enumerable.Range(0, Palette.Size).Select(i => (i == info.TransparentIndex) ? 0 : (uint)Color.FromArgb(255, i, i, i).ToArgb())), info.AllowModifiers);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromGrayscale.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromGrayscale.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2021 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
@@ -22,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
-		[Desc("internal palette name")]
+		[Desc("Internal palette name")]
 		public readonly string Name = null;
 
 		[Desc("If defined, load the palette only for this tileset.")]
@@ -49,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void LoadPalettes(WorldRenderer wr)
 		{
 			// Enable palette only for a specific tileset
-			if (info.Tileset != null && !string.Equals(info.Tileset, world.Map.Tileset, System.StringComparison.InvariantCultureIgnoreCase))
+			if (info.Tileset != null && !string.Equals(info.Tileset, world.Map.Tileset, StringComparison.InvariantCultureIgnoreCase))
 				return;
 
 			wr.AddPalette(info.Name, new ImmutablePalette(Enumerable.Range(0, Palette.Size).Select(i => (i == info.TransparentIndex) ? 0 : (uint)Color.FromArgb(255, i, i, i).ToArgb())), info.AllowModifiers);

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromRGBA.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromRGBA.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
@@ -22,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
-		[Desc("internal palette name")]
+		[Desc("Internal palette name")]
 		public readonly string Name = null;
 
 		[Desc("If defined, load the palette only for this tileset.")]
@@ -61,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void LoadPalettes(WorldRenderer wr)
 		{
 			// Enable palette only for a specific tileset
-			if (info.Tileset != null && !string.Equals(info.Tileset, world.Map.Tileset, System.StringComparison.InvariantCultureIgnoreCase))
+			if (info.Tileset != null && !string.Equals(info.Tileset, world.Map.Tileset, StringComparison.InvariantCultureIgnoreCase))
 				return;
 
 			var a = info.A / 255f;

--- a/OpenRA.Mods.Common/Traits/Palettes/PlayerColorPalette.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PlayerColorPalette.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -50,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var (_, h, s, _) = color.ToAhsv();
 
-			var remap = new PlayerColorRemap(info.RemapIndex, h, s);
+			var remap = new PlayerColorRemap(info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToArray() : info.RemapIndex, h, s);
 			var pal = new ImmutablePalette(wr.Palette(info.BasePalette).Palette, remap);
 			wr.AddPalette(info.BaseName + playerName, pal, info.AllowModifiers, replaceExisting);
 		}


### PR DESCRIPTION
I added the `PaletteFromGrayscale` palette trait, which generates a nice black-to-white palette.
This palette can have multiple usages. One of them would be to be a base-palette for image masks, another would be simply greyscale content.

I changed the `ColorPickerPalette`, `FixedColorPalette`, `IndexedPlayerPalette`, `PlayerColorPalette` traits to use the whole 0-255 range if no `RemapIndex` is set.
Why? Well, a remap does not make any sense without a single `RemapIndex`. But remapping a whole palette on the other side does. This however requires you to list the full 0, 1, 2, ... 255 range, which is definitely a better default. This also perfectly aligns with the `PaletteFromGrayscale` trait to produce a full player-color range palette.