### PR TITLE
Allow for flat range and inaccuracy modifiers.

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -22,12 +22,8 @@ namespace OpenRA.GameRules
 	{
 		public WeaponInfo Weapon;
 		public int[] DamageModifiers;
-
-		public WDist[] FlatInaccuracyModifiers;
-		public WDist[] FlatRangeModifiers;
-		public int[] PercentInaccuracyModifiers;
-		public int[] PercentRangeModifiers;
-
+		public IEnumerable<IModifier> RangeModifiers;
+		public IEnumerable<IModifier> InaccuracyModifiers;
 		public WAngle Facing;
 		public Func<WAngle> CurrentMuzzleFacing;
 		public WPos Source;

--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -22,8 +22,12 @@ namespace OpenRA.GameRules
 	{
 		public WeaponInfo Weapon;
 		public int[] DamageModifiers;
-		public int[] InaccuracyModifiers;
-		public int[] RangeModifiers;
+
+		public WDist[] FlatInaccuracyModifiers;
+		public WDist[] FlatRangeModifiers;
+		public int[] PercentInaccuracyModifiers;
+		public int[] PercentRangeModifiers;
+
 		public WAngle Facing;
 		public Func<WAngle> CurrentMuzzleFacing;
 		public WPos Source;

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -602,4 +602,29 @@ namespace OpenRA.Traits
 	{
 		void PlayerDisconnected(Actor self, Player p);
 	}
+
+	public enum ModifierType { Absolute, Relative }
+
+	public interface IModifier
+	{
+		ModifierType Type { get; set; }
+		int Priority { get; set; }
+		int Value { get; set; }
+	}
+
+	public class Modifier : IModifier
+	{
+		public ModifierType Type { get; set; }
+		public int Priority { get; set; }
+		public int Value { get; set; }
+	}
+
+	[RequireExplicitImplementation]
+	public interface IRangeModifier { IModifier GetRangeModifier(); }
+
+	[RequireExplicitImplementation]
+	public interface IRangeModifierInfo : ITraitInfoInterface { int GetRangeModifierDefault(); }
+
+	[RequireExplicitImplementation]
+	public interface IInaccuracyModifier { IModifier GetInaccuracyModifier(); }
 }

--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -124,7 +124,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			tailPos = headPos;
 
 			target = args.PassiveTarget;
-			if (info.Inaccuracy.Length > 0)
+			if (info.Inaccuracy.Length > 0 || args.FlatInaccuracyModifiers.Length > 0)
 			{
 				var maxInaccuracyOffset = Util.GetProjectileInaccuracy(info.Inaccuracy.Length, info.InaccuracyType, args);
 				target += WVec.FromPDF(world.SharedRandom, 2) * maxInaccuracyOffset / 1024;
@@ -138,7 +138,8 @@ namespace OpenRA.Mods.Common.Projectiles
 			target += dir * info.BeyondTargetRange.Length / 1024;
 
 			length = Math.Max((target - headPos).Length / speed.Length, 1);
-			weaponRange = new WDist(Util.ApplyPercentageModifiers(args.Weapon.Range.Length, args.RangeModifiers));
+			weaponRange = new WDist(Util.ApplyPercentageModifiers(args.Weapon.Range.Length, args.PercentRangeModifiers));
+			weaponRange = Util.ApplyFlatDistanceModifiers(weaponRange, args.FlatRangeModifiers);
 		}
 
 		void TrackTarget()

--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -124,7 +124,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			tailPos = headPos;
 
 			target = args.PassiveTarget;
-			if (info.Inaccuracy.Length > 0 || args.FlatInaccuracyModifiers.Length > 0)
+			if (info.Inaccuracy.Length > 0 || args.InaccuracyModifiers.Any(m => m.Type == ModifierType.Absolute))
 			{
 				var maxInaccuracyOffset = Util.GetProjectileInaccuracy(info.Inaccuracy.Length, info.InaccuracyType, args);
 				target += WVec.FromPDF(world.SharedRandom, 2) * maxInaccuracyOffset / 1024;
@@ -138,8 +138,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			target += dir * info.BeyondTargetRange.Length / 1024;
 
 			length = Math.Max((target - headPos).Length / speed.Length, 1);
-			weaponRange = new WDist(Util.ApplyPercentageModifiers(args.Weapon.Range.Length, args.PercentRangeModifiers));
-			weaponRange = Util.ApplyFlatDistanceModifiers(weaponRange, args.FlatRangeModifiers);
+			weaponRange = new WDist(Util.ApplyModifiers(args.Weapon.Range.Length, args.RangeModifiers, 0));
 		}
 
 		void TrackTarget()

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -154,7 +154,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			target = args.PassiveTarget;
 
-			if (info.Inaccuracy.Length > 0 || args.FlatInaccuracyModifiers.Length > 0)
+			if (info.Inaccuracy.Length > 0 || args.InaccuracyModifiers.Any(m => m.Type == ModifierType.Absolute))
 			{
 				var maxInaccuracyOffset = Util.GetProjectileInaccuracy(info.Inaccuracy.Length, info.InaccuracyType, args);
 				target += WVec.FromPDF(world.SharedRandom, 2) * maxInaccuracyOffset / 1024;

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -153,7 +153,8 @@ namespace OpenRA.Mods.Common.Projectiles
 				speed = info.Speed[0];
 
 			target = args.PassiveTarget;
-			if (info.Inaccuracy.Length > 0)
+
+			if (info.Inaccuracy.Length > 0 || args.FlatInaccuracyModifiers.Length > 0)
 			{
 				var maxInaccuracyOffset = Util.GetProjectileInaccuracy(info.Inaccuracy.Length, info.InaccuracyType, args);
 				target += WVec.FromPDF(world.SharedRandom, 2) * maxInaccuracyOffset / 1024;

--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			if (args.Weapon.TargetActorCenter)
 				target = args.GuidedTarget;
-			else if (info.Inaccuracy.Length > 0)
+			else if (info.Inaccuracy.Length > 0 || args.FlatInaccuracyModifiers.Length > 0)
 			{
 				var maxInaccuracyOffset = Util.GetProjectileInaccuracy(info.Inaccuracy.Length, info.InaccuracyType, args);
 				var inaccuracyOffset = WVec.FromPDF(args.SourceActor.World.SharedRandom, 2) * maxInaccuracyOffset / 1024;

--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			if (args.Weapon.TargetActorCenter)
 				target = args.GuidedTarget;
-			else if (info.Inaccuracy.Length > 0 || args.FlatInaccuracyModifiers.Length > 0)
+			else if (info.Inaccuracy.Length > 0 || args.InaccuracyModifiers.Any(m => m.Type == ModifierType.Absolute))
 			{
 				var maxInaccuracyOffset = Util.GetProjectileInaccuracy(info.Inaccuracy.Length, info.InaccuracyType, args);
 				var inaccuracyOffset = WVec.FromPDF(args.SourceActor.World.SharedRandom, 2) * maxInaccuracyOffset / 1024;

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Effects;
@@ -130,7 +131,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			target = args.PassiveTarget;
 			source = args.Source;
 
-			if (info.Inaccuracy.Length > 0 || args.FlatInaccuracyModifiers.Length > 0)
+			if (info.Inaccuracy.Length > 0 || args.InaccuracyModifiers.Any(m => m.Type == ModifierType.Absolute))
 			{
 				var maxInaccuracyOffset = Util.GetProjectileInaccuracy(info.Inaccuracy.Length, info.InaccuracyType, args);
 				target += WVec.FromPDF(args.SourceActor.World.SharedRandom, 2) * maxInaccuracyOffset / 1024;

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -130,7 +130,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			target = args.PassiveTarget;
 			source = args.Source;
 
-			if (info.Inaccuracy.Length > 0)
+			if (info.Inaccuracy.Length > 0 || args.FlatInaccuracyModifiers.Length > 0)
 			{
 				var maxInaccuracyOffset = Util.GetProjectileInaccuracy(info.Inaccuracy.Length, info.InaccuracyType, args);
 				target += WVec.FromPDF(args.SourceActor.World.SharedRandom, 2) * maxInaccuracyOffset / 1024;

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -230,7 +230,8 @@ namespace OpenRA.Mods.Common.Projectiles
 			gravity = new WVec(0, 0, -info.Gravity);
 			targetPosition = args.PassiveTarget;
 			var limit = info.RangeLimit != WDist.Zero ? info.RangeLimit : args.Weapon.Range;
-			rangeLimit = new WDist(Util.ApplyPercentageModifiers(limit.Length, args.RangeModifiers));
+			rangeLimit = new WDist(Util.ApplyPercentageModifiers(limit.Length, args.PercentRangeModifiers));
+			rangeLimit = Util.ApplyFlatDistanceModifiers(rangeLimit, args.FlatRangeModifiers);
 			minLaunchSpeed = info.MinimumLaunchSpeed.Length > -1 ? info.MinimumLaunchSpeed.Length : info.Speed.Length;
 			maxLaunchSpeed = info.MaximumLaunchSpeed.Length > -1 ? info.MaximumLaunchSpeed.Length : info.Speed.Length;
 			maxSpeed = info.Speed.Length;
@@ -243,9 +244,9 @@ namespace OpenRA.Mods.Common.Projectiles
 				lockOn = true;
 
 			var inaccuracy = lockOn && info.LockOnInaccuracy.Length > -1 ? info.LockOnInaccuracy.Length : info.Inaccuracy.Length;
-			if (inaccuracy > 0)
+			if (inaccuracy > 0 || args.FlatInaccuracyModifiers.Length > 0)
 			{
-				var maxInaccuracyOffset = Util.GetProjectileInaccuracy(info.Inaccuracy.Length, info.InaccuracyType, args);
+				var maxInaccuracyOffset = Util.GetProjectileInaccuracy(inaccuracy, info.InaccuracyType, args);
 				offset = WVec.FromPDF(world.SharedRandom, 2) * maxInaccuracyOffset / 1024;
 			}
 

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -230,8 +230,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			gravity = new WVec(0, 0, -info.Gravity);
 			targetPosition = args.PassiveTarget;
 			var limit = info.RangeLimit != WDist.Zero ? info.RangeLimit : args.Weapon.Range;
-			rangeLimit = new WDist(Util.ApplyPercentageModifiers(limit.Length, args.PercentRangeModifiers));
-			rangeLimit = Util.ApplyFlatDistanceModifiers(rangeLimit, args.FlatRangeModifiers);
+			rangeLimit = new WDist(Util.ApplyModifiers(limit.Length, args.RangeModifiers, 0));
 			minLaunchSpeed = info.MinimumLaunchSpeed.Length > -1 ? info.MinimumLaunchSpeed.Length : info.Speed.Length;
 			maxLaunchSpeed = info.MaximumLaunchSpeed.Length > -1 ? info.MaximumLaunchSpeed.Length : info.Speed.Length;
 			maxSpeed = info.Speed.Length;
@@ -244,7 +243,7 @@ namespace OpenRA.Mods.Common.Projectiles
 				lockOn = true;
 
 			var inaccuracy = lockOn && info.LockOnInaccuracy.Length > -1 ? info.LockOnInaccuracy.Length : info.Inaccuracy.Length;
-			if (inaccuracy > 0 || args.FlatInaccuracyModifiers.Length > 0)
+			if (inaccuracy > 0 || args.InaccuracyModifiers.Any(m => m.Type == ModifierType.Absolute))
 			{
 				var maxInaccuracyOffset = Util.GetProjectileInaccuracy(inaccuracy, info.InaccuracyType, args);
 				offset = WVec.FromPDF(world.SharedRandom, 2) * maxInaccuracyOffset / 1024;

--- a/OpenRA.Mods.Common/Projectiles/Railgun.cs
+++ b/OpenRA.Mods.Common/Projectiles/Railgun.cs
@@ -133,7 +133,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			BeamColor = beamColor;
 			HelixColor = helixColor;
 
-			if (info.Inaccuracy.Length > 0)
+			if (info.Inaccuracy.Length > 0 || args.FlatInaccuracyModifiers.Length > 0)
 			{
 				var maxInaccuracyOffset = Util.GetProjectileInaccuracy(info.Inaccuracy.Length, info.InaccuracyType, args);
 				target += WVec.FromPDF(args.SourceActor.World.SharedRandom, 2) * maxInaccuracyOffset / 1024;

--- a/OpenRA.Mods.Common/Projectiles/Railgun.cs
+++ b/OpenRA.Mods.Common/Projectiles/Railgun.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
@@ -133,7 +134,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			BeamColor = beamColor;
 			HelixColor = helixColor;
 
-			if (info.Inaccuracy.Length > 0 || args.FlatInaccuracyModifiers.Length > 0)
+			if (info.Inaccuracy.Length > 0 || args.InaccuracyModifiers.Any(m => m.Type == ModifierType.Absolute))
 			{
 				var maxInaccuracyOffset = Util.GetProjectileInaccuracy(info.Inaccuracy.Length, info.InaccuracyType, args);
 				target += WVec.FromPDF(args.SourceActor.World.SharedRandom, 2) * maxInaccuracyOffset / 1024;

--- a/OpenRA.Mods.Common/Traits/Modifiers/InaccuracyModifier.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/InaccuracyModifier.cs
@@ -1,0 +1,31 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Modifies the inaccuracy of weapons fired by this actor by a flat amount.")]
+	public class InaccuracyModifierInfo : ConditionalTraitInfo
+	{
+		[FieldLoader.Require]
+		[Desc("Amount to increase to inaccuracy (negative to decrease).")]
+		public readonly WDist Modifier = WDist.Zero;
+
+		public override object Create(ActorInitializer init) { return new InaccuracyModifier(this); }
+	}
+
+	public class InaccuracyModifier : ConditionalTrait<InaccuracyModifierInfo>, IFlatInaccuracyModifier
+	{
+		public InaccuracyModifier(InaccuracyModifierInfo info)
+			: base(info) { }
+
+		WDist IFlatInaccuracyModifier.GetInaccuracyModifier() { return IsTraitDisabled ? WDist.Zero : Info.Modifier; }
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Modifiers/InaccuracyModifier.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/InaccuracyModifier.cs
@@ -9,6 +9,8 @@
  */
 #endregion
 
+using OpenRA.Traits;
+
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Modifies the inaccuracy of weapons fired by this actor by a flat amount.")]
@@ -18,14 +20,27 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Amount to increase to inaccuracy (negative to decrease).")]
 		public readonly WDist Modifier = WDist.Zero;
 
+		[Desc("Higher priority modifiers are applied first.")]
+		public readonly int Priority = 0;
+
 		public override object Create(ActorInitializer init) { return new InaccuracyModifier(this); }
 	}
 
-	public class InaccuracyModifier : ConditionalTrait<InaccuracyModifierInfo>, IFlatInaccuracyModifier
+	public class InaccuracyModifier : ConditionalTrait<InaccuracyModifierInfo>, IInaccuracyModifier
 	{
 		public InaccuracyModifier(InaccuracyModifierInfo info)
 			: base(info) { }
 
-		WDist IFlatInaccuracyModifier.GetInaccuracyModifier() { return IsTraitDisabled ? WDist.Zero : Info.Modifier; }
+		IModifier IInaccuracyModifier.GetInaccuracyModifier()
+		{
+			var modifier = new Modifier
+			{
+				Type = ModifierType.Absolute,
+				Priority = Info.Priority,
+				Value = IsTraitDisabled ? 0 : Info.Modifier.Length
+			};
+
+			return modifier;
+		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Modifiers/RangeModifier.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/RangeModifier.cs
@@ -1,0 +1,33 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Modifies the range of weapons fired by this actor by a flat amount.")]
+	public class RangeModifierInfo : ConditionalTraitInfo, IFlatRangeModifierInfo
+	{
+		[FieldLoader.Require]
+		[Desc("Amount to increase to range (negative to decrease).")]
+		public readonly WDist Modifier = WDist.Zero;
+
+		public override object Create(ActorInitializer init) { return new RangeModifier(this); }
+
+		WDist IFlatRangeModifierInfo.GetRangeModifierDefault() { return EnabledByDefault ? Modifier : WDist.Zero; }
+	}
+
+	public class RangeModifier : ConditionalTrait<RangeModifierInfo>, IFlatRangeModifier
+	{
+		public RangeModifier(RangeModifierInfo info)
+			: base(info) { }
+
+		WDist IFlatRangeModifier.GetRangeModifier() { return IsTraitDisabled ? WDist.Zero : Info.Modifier; }
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Modifiers/RangeModifier.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/RangeModifier.cs
@@ -9,25 +9,40 @@
  */
 #endregion
 
+using OpenRA.Traits;
+
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Modifies the range of weapons fired by this actor by a flat amount.")]
-	public class RangeModifierInfo : ConditionalTraitInfo, IFlatRangeModifierInfo
+	public class RangeModifierInfo : ConditionalTraitInfo, IRangeModifierInfo
 	{
 		[FieldLoader.Require]
 		[Desc("Amount to increase to range (negative to decrease).")]
 		public readonly WDist Modifier = WDist.Zero;
 
+		[Desc("Higher priority modifiers are applied first.")]
+		public readonly int Priority = 0;
+
 		public override object Create(ActorInitializer init) { return new RangeModifier(this); }
 
-		WDist IFlatRangeModifierInfo.GetRangeModifierDefault() { return EnabledByDefault ? Modifier : WDist.Zero; }
+		int IRangeModifierInfo.GetRangeModifierDefault() { return EnabledByDefault ? Modifier.Length : 0; }
 	}
 
-	public class RangeModifier : ConditionalTrait<RangeModifierInfo>, IFlatRangeModifier
+	public class RangeModifier : ConditionalTrait<RangeModifierInfo>, IRangeModifier
 	{
 		public RangeModifier(RangeModifierInfo info)
 			: base(info) { }
 
-		WDist IFlatRangeModifier.GetRangeModifier() { return IsTraitDisabled ? WDist.Zero : Info.Modifier; }
+		IModifier IRangeModifier.GetRangeModifier()
+		{
+			var modifier = new Modifier
+			{
+				Type = ModifierType.Absolute,
+				Priority = Info.Priority,
+				Value = IsTraitDisabled ? 0 : Info.Modifier.Length
+			};
+
+			return modifier;
+		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Multipliers/InaccuracyMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/InaccuracyMultiplier.cs
@@ -21,11 +21,11 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new InaccuracyMultiplier(this); }
 	}
 
-	public class InaccuracyMultiplier : ConditionalTrait<InaccuracyMultiplierInfo>, IInaccuracyModifier
+	public class InaccuracyMultiplier : ConditionalTrait<InaccuracyMultiplierInfo>, IPercentInaccuracyModifier
 	{
 		public InaccuracyMultiplier(InaccuracyMultiplierInfo info)
 			: base(info) { }
 
-		int IInaccuracyModifier.GetInaccuracyModifier() { return IsTraitDisabled ? 100 : Info.Modifier; }
+		int IPercentInaccuracyModifier.GetInaccuracyModifier() { return IsTraitDisabled ? 100 : Info.Modifier; }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Multipliers/InaccuracyMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/InaccuracyMultiplier.cs
@@ -9,6 +9,8 @@
  */
 #endregion
 
+using OpenRA.Traits;
+
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Modifies the inaccuracy of weapons fired by this actor.")]
@@ -18,14 +20,27 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Percentage modifier to apply.")]
 		public readonly int Modifier = 100;
 
+		[Desc("Higher priority modifiers are applied first.")]
+		public readonly int Priority = 0;
+
 		public override object Create(ActorInitializer init) { return new InaccuracyMultiplier(this); }
 	}
 
-	public class InaccuracyMultiplier : ConditionalTrait<InaccuracyMultiplierInfo>, IPercentInaccuracyModifier
+	public class InaccuracyMultiplier : ConditionalTrait<InaccuracyMultiplierInfo>, IInaccuracyModifier
 	{
 		public InaccuracyMultiplier(InaccuracyMultiplierInfo info)
 			: base(info) { }
 
-		int IPercentInaccuracyModifier.GetInaccuracyModifier() { return IsTraitDisabled ? 100 : Info.Modifier; }
+		IModifier IInaccuracyModifier.GetInaccuracyModifier()
+		{
+			var modifier = new Modifier
+			{
+				Type = ModifierType.Relative,
+				Priority = Info.Priority,
+				Value = IsTraitDisabled ? 100 : Info.Modifier
+			};
+
+			return modifier;
+		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Multipliers/RangeMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/RangeMultiplier.cs
@@ -23,11 +23,11 @@ namespace OpenRA.Mods.Common.Traits
 		int IRangeModifierInfo.GetRangeModifierDefault() { return EnabledByDefault ? Modifier : 100; }
 	}
 
-	public class RangeMultiplier : ConditionalTrait<RangeMultiplierInfo>, IRangeModifier
+	public class RangeMultiplier : ConditionalTrait<RangeMultiplierInfo>, IPercentRangeModifier
 	{
 		public RangeMultiplier(RangeMultiplierInfo info)
 			: base(info) { }
 
-		int IRangeModifier.GetRangeModifier() { return IsTraitDisabled ? 100 : Info.Modifier; }
+		int IPercentRangeModifier.GetRangeModifier() { return IsTraitDisabled ? 100 : Info.Modifier; }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Multipliers/RangeMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/RangeMultiplier.cs
@@ -9,6 +9,8 @@
  */
 #endregion
 
+using OpenRA.Traits;
+
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Modifies the range of weapons fired by this actor.")]
@@ -18,16 +20,29 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Percentage modifier to apply.")]
 		public readonly int Modifier = 100;
 
+		[Desc("Higher priority modifiers are applied first.")]
+		public readonly int Priority = 0;
+
 		public override object Create(ActorInitializer init) { return new RangeMultiplier(this); }
 
 		int IRangeModifierInfo.GetRangeModifierDefault() { return EnabledByDefault ? Modifier : 100; }
 	}
 
-	public class RangeMultiplier : ConditionalTrait<RangeMultiplierInfo>, IPercentRangeModifier
+	public class RangeMultiplier : ConditionalTrait<RangeMultiplierInfo>, IRangeModifier
 	{
 		public RangeMultiplier(RangeMultiplierInfo info)
 			: base(info) { }
 
-		int IPercentRangeModifier.GetRangeModifier() { return IsTraitDisabled ? 100 : Info.Modifier; }
+		IModifier IRangeModifier.GetRangeModifier()
+		{
+			var modifier = new Modifier
+			{
+				Type = ModifierType.Relative,
+				Priority = Info.Priority,
+				Value = IsTraitDisabled ? 100 : Info.Modifier
+			};
+
+			return modifier;
+		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/ThrowsShrapnel.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsShrapnel.cs
@@ -74,17 +74,8 @@ namespace OpenRA.Mods.Common.Traits
 						DamageModifiers = self.TraitsImplementing<IFirepowerModifier>()
 							.Select(a => a.GetFirepowerModifier()).ToArray(),
 
-						PercentInaccuracyModifiers = self.TraitsImplementing<IPercentInaccuracyModifier>()
-							.Select(a => a.GetInaccuracyModifier()).ToArray(),
-
-						PercentRangeModifiers = self.TraitsImplementing<IPercentRangeModifier>()
-							.Select(a => a.GetRangeModifier()).ToArray(),
-
-						FlatInaccuracyModifiers = self.TraitsImplementing<IFlatInaccuracyModifier>()
-							.Select(a => a.GetInaccuracyModifier()).ToArray(),
-
-						FlatRangeModifiers = self.TraitsImplementing<IFlatRangeModifier>()
-							.Select(a => a.GetRangeModifier()).ToArray(),
+						InaccuracyModifiers = self.TraitsImplementing<IModifier>().ToArray(),
+						RangeModifiers = self.TraitsImplementing<IModifier>().ToArray(),
 
 						Source = self.CenterPosition,
 						CurrentSource = () => self.CenterPosition,

--- a/OpenRA.Mods.Common/Traits/ThrowsShrapnel.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsShrapnel.cs
@@ -74,10 +74,16 @@ namespace OpenRA.Mods.Common.Traits
 						DamageModifiers = self.TraitsImplementing<IFirepowerModifier>()
 							.Select(a => a.GetFirepowerModifier()).ToArray(),
 
-						InaccuracyModifiers = self.TraitsImplementing<IInaccuracyModifier>()
+						PercentInaccuracyModifiers = self.TraitsImplementing<IPercentInaccuracyModifier>()
 							.Select(a => a.GetInaccuracyModifier()).ToArray(),
 
-						RangeModifiers = self.TraitsImplementing<IRangeModifier>()
+						PercentRangeModifiers = self.TraitsImplementing<IPercentRangeModifier>()
+							.Select(a => a.GetRangeModifier()).ToArray(),
+
+						FlatInaccuracyModifiers = self.TraitsImplementing<IFlatInaccuracyModifier>()
+							.Select(a => a.GetInaccuracyModifier()).ToArray(),
+
+						FlatRangeModifiers = self.TraitsImplementing<IFlatRangeModifier>()
 							.Select(a => a.GetRangeModifier()).ToArray(),
 
 						Source = self.CenterPosition,

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -367,24 +367,6 @@ namespace OpenRA.Mods.Common.Traits
 	public interface IReloadAmmoModifier { int GetReloadAmmoModifier(); }
 
 	[RequireExplicitImplementation]
-	public interface IFlatInaccuracyModifier { WDist GetInaccuracyModifier(); }
-
-	[RequireExplicitImplementation]
-	public interface IPercentInaccuracyModifier { int GetInaccuracyModifier(); }
-
-	[RequireExplicitImplementation]
-	public interface IFlatRangeModifier { WDist GetRangeModifier(); }
-
-	[RequireExplicitImplementation]
-	public interface IFlatRangeModifierInfo : ITraitInfoInterface { WDist GetRangeModifierDefault(); }
-
-	[RequireExplicitImplementation]
-	public interface IPercentRangeModifier { int GetRangeModifier(); }
-
-	[RequireExplicitImplementation]
-	public interface IRangeModifierInfo : ITraitInfoInterface { int GetRangeModifierDefault(); }
-
-	[RequireExplicitImplementation]
 	public interface IPowerModifier { int GetPowerModifier(); }
 
 	[RequireExplicitImplementation]

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -367,10 +367,19 @@ namespace OpenRA.Mods.Common.Traits
 	public interface IReloadAmmoModifier { int GetReloadAmmoModifier(); }
 
 	[RequireExplicitImplementation]
-	public interface IInaccuracyModifier { int GetInaccuracyModifier(); }
+	public interface IFlatInaccuracyModifier { WDist GetInaccuracyModifier(); }
 
 	[RequireExplicitImplementation]
-	public interface IRangeModifier { int GetRangeModifier(); }
+	public interface IPercentInaccuracyModifier { int GetInaccuracyModifier(); }
+
+	[RequireExplicitImplementation]
+	public interface IFlatRangeModifier { WDist GetRangeModifier(); }
+
+	[RequireExplicitImplementation]
+	public interface IFlatRangeModifierInfo : ITraitInfoInterface { WDist GetRangeModifierDefault(); }
+
+	[RequireExplicitImplementation]
+	public interface IPercentRangeModifier { int GetRangeModifier(); }
 
 	[RequireExplicitImplementation]
 	public interface IRangeModifierInfo : ITraitInfoInterface { int GetRangeModifierDefault(); }

--- a/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
@@ -81,8 +81,10 @@ namespace OpenRA.Mods.Common.Warheads
 				CurrentMuzzleFacing = () => (map.CenterOfCell(targetCell) - target.CenterPosition).Yaw,
 
 				DamageModifiers = args.DamageModifiers,
-				InaccuracyModifiers = Array.Empty<int>(),
-				RangeModifiers = Array.Empty<int>(),
+				PercentInaccuracyModifiers = Array.Empty<int>(),
+				PercentRangeModifiers = Array.Empty<int>(),
+				FlatInaccuracyModifiers = Array.Empty<WDist>(),
+				FlatRangeModifiers = Array.Empty<WDist>(),
 
 				Source = target.CenterPosition,
 				CurrentSource = () => target.CenterPosition,

--- a/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
@@ -81,10 +81,8 @@ namespace OpenRA.Mods.Common.Warheads
 				CurrentMuzzleFacing = () => (map.CenterOfCell(targetCell) - target.CenterPosition).Yaw,
 
 				DamageModifiers = args.DamageModifiers,
-				PercentInaccuracyModifiers = Array.Empty<int>(),
-				PercentRangeModifiers = Array.Empty<int>(),
-				FlatInaccuracyModifiers = Array.Empty<WDist>(),
-				FlatRangeModifiers = Array.Empty<WDist>(),
+				InaccuracyModifiers = Array.Empty<IModifier>(),
+				RangeModifiers = Array.Empty<IModifier>(),
 
 				Source = target.CenterPosition,
 				CurrentSource = () => target.CenterPosition,

--- a/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
+++ b/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
@@ -141,10 +141,16 @@ namespace OpenRA.Mods.D2k.Traits
 					DamageModifiers = self.TraitsImplementing<IFirepowerModifier>()
 						.Select(a => a.GetFirepowerModifier()).ToArray(),
 
-					InaccuracyModifiers = self.TraitsImplementing<IInaccuracyModifier>()
+					PercentInaccuracyModifiers = self.TraitsImplementing<IPercentInaccuracyModifier>()
 						.Select(a => a.GetInaccuracyModifier()).ToArray(),
 
-					RangeModifiers = self.TraitsImplementing<IRangeModifier>()
+					PercentRangeModifiers = self.TraitsImplementing<IPercentRangeModifier>()
+						.Select(a => a.GetRangeModifier()).ToArray(),
+
+					FlatInaccuracyModifiers = self.TraitsImplementing<IFlatInaccuracyModifier>()
+						.Select(a => a.GetInaccuracyModifier()).ToArray(),
+
+					FlatRangeModifiers = self.TraitsImplementing<IFlatRangeModifier>()
 						.Select(a => a.GetRangeModifier()).ToArray(),
 
 					Source = self.CenterPosition,

--- a/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
+++ b/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
@@ -141,17 +141,8 @@ namespace OpenRA.Mods.D2k.Traits
 					DamageModifiers = self.TraitsImplementing<IFirepowerModifier>()
 						.Select(a => a.GetFirepowerModifier()).ToArray(),
 
-					PercentInaccuracyModifiers = self.TraitsImplementing<IPercentInaccuracyModifier>()
-						.Select(a => a.GetInaccuracyModifier()).ToArray(),
-
-					PercentRangeModifiers = self.TraitsImplementing<IPercentRangeModifier>()
-						.Select(a => a.GetRangeModifier()).ToArray(),
-
-					FlatInaccuracyModifiers = self.TraitsImplementing<IFlatInaccuracyModifier>()
-						.Select(a => a.GetInaccuracyModifier()).ToArray(),
-
-					FlatRangeModifiers = self.TraitsImplementing<IFlatRangeModifier>()
-						.Select(a => a.GetRangeModifier()).ToArray(),
+					InaccuracyModifiers = self.TraitsImplementing<IModifier>().ToArray(),
+					RangeModifiers = self.TraitsImplementing<IModifier>().ToArray(),
 
 					Source = self.CenterPosition,
 					CurrentSource = () => self.CenterPosition,


### PR DESCRIPTION
Currently only percentage based modifiers exist for various things (range, damage etc.).

Weapons can vary a lot when it comes to these values, which means applying a percentage modifier can yield very different amounts added or subtracted.

Weapons also commonly have zero inaccuracy which means the percentage modifier has no effect at all.

I thought it'd be useful to be able to modify these values by a fixed amount rather than a percentage.

This pull request adds flat range and inaccuracy modifiers. Similar could be added for firepower, speed, reload time and vision (and possibly others), but these seemed to be the simplest to implement as a first step.

As part of this I also noticed a mistake (?) in the missile projectile, where it checks whether it should use the LockOnInaccuracy or not, then proceeds to just use the base inaccuracy regardless. This has been fixed.