### PR TITLE
Removed an using, redundant when building on Mono

### DIFF
--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -15,7 +15,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using OpenRA.Primitives;
-using OpenRA.Support;
 
 namespace OpenRA
 {
@@ -61,7 +60,7 @@ namespace OpenRA
 			if (!ResolvedAssemblies.TryGetValue(hash, out var assembly))
 			{
 #if NET5_0_OR_GREATER
-				var loader = new AssemblyLoader(resolvedPath);
+				var loader = new Support.AssemblyLoader(resolvedPath);
 				assembly = loader.LoadDefaultAssembly();
 				ResolvedAssemblies.Add(hash, assembly);
 #else


### PR DESCRIPTION
The build would fail on Mono with this:
![image](https://user-images.githubusercontent.com/7137365/171932788-4443c264-1ac9-4aca-94b4-248e69fed180.png)
