### PR TITLE
Fix a crash with BlockingCollection in Connection

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -434,7 +434,7 @@ namespace OpenRA.Server
 				var ms = new MemoryStream(8);
 				ms.WriteArray(BitConverter.GetBytes(ProtocolVersion.Handshake));
 				ms.WriteArray(BitConverter.GetBytes(newConn.PlayerIndex));
-				newConn.SendData(ms.ToArray());
+				newConn.TrySendData(ms.ToArray());
 
 				// Dispatch a handshake order
 				var request = new HandshakeRequest
@@ -737,14 +737,10 @@ namespace OpenRA.Server
 
 		void DispatchFrameToClient(Connection c, int client, byte[] frameData)
 		{
-			try
-			{
-				c.SendData(frameData);
-			}
-			catch (Exception e)
+			if (!c.TrySendData(frameData))
 			{
 				DropClient(c);
-				Log.Write("server", $"Dropping client {client.ToString(CultureInfo.InvariantCulture)} because dispatching orders failed: {e}");
+				Log.Write("server", $"Dropping client {client.ToString(CultureInfo.InvariantCulture)} because dispatching orders failed!");
 			}
 		}
 


### PR DESCRIPTION
The BlockingCollection would have `IsAddingCompleted` to true, but `IsComplete` to false, slipping through the cracks and causing an InvalidOperationException ("The collection has been marked as complete with regards to additions.") when trying to add to it.
```
System.InvalidOperationException
  HResult=0x80131509
  Message=The collection has been marked as complete with regards to additions.
  Source=System.Collections.Concurrent
  StackTrace:
   at System.Collections.Concurrent.BlockingCollection`1.TryAddWithNoTimeValidation(T item, Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Collections.Concurrent.BlockingCollection`1.Add(T item)
   at OpenRA.Server.Connection.SendReceiveLoop(Object s) in D:\Work.Personal\OpenRA\OpenRA\OpenRA.Game\Server\Connection.cs:line 158
   at System.Threading.Thread.StartCallback()
```
![image](https://user-images.githubusercontent.com/7137365/171989572-48c4507c-7f2e-4e88-8a64-18c032477200.png)


***TO TEST:***
Launch the game, open Skirmish, open the map browser, click OK without selecting a map and then click Start Game.
In 95% of times you get this dialog:
![image](https://user-images.githubusercontent.com/7137365/171989739-d74cc30f-6a1f-43eb-8613-300c7b0f4324.png)
(which I guess is a separate bug that should be addressed)
But *sometimes* the game will crash with the above.
I suggest also adding
```cs
	if (sendQueue.IsAddingCompleted && lastPingSent.ElapsedMilliseconds > 1000)
	{
		var a = 1;
	}
```
with a breakpoint just below the changed `if` to catch when it would have crashed if you're feeling lucky.