### PR TITLE
Error handling in shell scripts

### DIFF
--- a/configure-system-libraries.sh
+++ b/configure-system-libraries.sh
@@ -6,6 +6,8 @@
 # Copy-paste the entire script into http://shellcheck.net to check.
 ####
 
+set -o errexit || exit $?
+
 patch_config()
 {
 	LABEL=$1

--- a/fetch-geoip.sh
+++ b/fetch-geoip.sh
@@ -10,7 +10,7 @@ set -o errexit || exit $?
 
 # Set the working directory to the location of this script
 HERE=$(dirname "$0")
-cd "${HERE}" || exit 1
+cd "${HERE}"
 
 # Database does not exist or is older than 30 days.
 if [ -z "$(find . -path ./IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP -mtime -30 -print)" ]; then

--- a/fetch-geoip.sh
+++ b/fetch-geoip.sh
@@ -6,12 +6,14 @@
 # Copy-paste the entire script into http://shellcheck.net to check.
 ####
 
+set -o errexit || exit $?
+
 # Set the working directory to the location of this script
 cd "$(dirname "$0")" || exit 1
 
 # Database does not exist or is older than 30 days.
 if [ -z "$(find . -path ./IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP -mtime -30 -print)" ]; then
-	rm -f IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP
+	rm -f IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP || :
 	echo "Downloading IP2Location GeoIP database."
 	if command -v curl >/dev/null 2>&1; then
 		curl -s -L -O https://github.com/OpenRA/GeoIP-Database/releases/download/monthly/IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP || echo "Warning: Download failed"

--- a/fetch-geoip.sh
+++ b/fetch-geoip.sh
@@ -9,7 +9,8 @@
 set -o errexit || exit $?
 
 # Set the working directory to the location of this script
-cd "$(dirname "$0")" || exit 1
+HERE=$(dirname "$0")
+cd "${HERE}" || exit 1
 
 # Database does not exist or is older than 30 days.
 if [ -z "$(find . -path ./IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP -mtime -30 -print)" ]; then

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -6,6 +6,8 @@
 #  $ Mod="d2k" ./launch-dedicated.sh # Launch a dedicated server with default settings but override the Mod
 #  Read the file to see which settings you can override
 
+set -o errexit || exit $?
+
 ENGINEDIR=$(dirname "$0")
 if command -v mono >/dev/null 2>&1 && [ "$(grep -c .NETCoreApp,Version= "${ENGINEDIR}/bin/OpenRA.Server.dll")" = "0" ]; then
 	RUNTIME_LAUNCHER="mono --debug"
@@ -50,5 +52,5 @@ while true; do
      Server.EnableLintChecks="$EnableLintChecks" \
      Server.ShareAnonymizedIPs="$ShareAnonymizedIPs" \
      Server.JoinChatDelay="$JoinChatDelay" \
-     Engine.SupportDir="$SupportDir"
+     Engine.SupportDir="$SupportDir" || :
 done

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -7,7 +7,7 @@
 #  Read the file to see which settings you can override
 
 ENGINEDIR=$(dirname "$0")
-if command -v mono >/dev/null 2>&1 && [ "$(grep -c .NETCoreApp,Version= ${ENGINEDIR}/bin/OpenRA.Server.dll)" = "0" ]; then
+if command -v mono >/dev/null 2>&1 && [ "$(grep -c .NETCoreApp,Version= "${ENGINEDIR}/bin/OpenRA.Server.dll")" = "0" ]; then
 	RUNTIME_LAUNCHER="mono --debug"
 else
 	RUNTIME_LAUNCHER="dotnet"
@@ -35,7 +35,7 @@ JoinChatDelay="${JoinChatDelay:-"5000"}"
 SupportDir="${SupportDir:-""}"
 
 while true; do
-     ${RUNTIME_LAUNCHER} ${ENGINEDIR}/bin/OpenRA.Server.dll Engine.EngineDir=".." Game.Mod="$Mod" \
+     ${RUNTIME_LAUNCHER} "${ENGINEDIR}/bin/OpenRA.Server.dll" Engine.EngineDir=".." Game.Mod="$Mod" \
      Server.Name="$Name" \
      Server.ListenPort="$ListenPort" \
      Server.AdvertiseOnline="$AdvertiseOnline" \

--- a/launch-game.sh
+++ b/launch-game.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -o errexit || exit $?
+
 ENGINEDIR=$(dirname "$0")
 if command -v mono >/dev/null 2>&1 && [ "$(grep -c .NETCoreApp,Version= "${ENGINEDIR}/bin/OpenRA.dll")" = "0" ]; then
 	RUNTIME_LAUNCHER="mono --debug"
@@ -32,10 +34,10 @@ then
 fi
 
 # Launch the engine with the appropriate arguments
-${RUNTIME_LAUNCHER} "${ENGINEDIR}/bin/OpenRA.dll" Engine.EngineDir=".." Engine.LaunchPath="${LAUNCHPATH}" ${MODARG} "$@"
+${RUNTIME_LAUNCHER} "${ENGINEDIR}/bin/OpenRA.dll" Engine.EngineDir=".." Engine.LaunchPath="${LAUNCHPATH}" ${MODARG} "$@" && rc=0 || rc=$?
 
 # Show a crash dialog if something went wrong
-if [ $? != 0 ] && [ $? != 1 ]; then
+if [ "${rc}" != 0 ] && [ "${rc}" != 1 ]; then
 	if [ "$(uname -s)" = "Darwin" ]; then
 		LOGS="${HOME}/Library/Application Support/OpenRA/Logs/"
 	else
@@ -45,12 +47,14 @@ if [ $? != 0 ] && [ $? != 1 ]; then
 		fi
 	fi
 
-	test -d Support/Logs && LOGS="${PWD}/Support/Logs"
+	if [ -d Support/Logs ]; then
+		LOGS="${PWD}/Support/Logs"
+	fi
 	ERROR_MESSAGE=$(printf "%s has encountered a fatal error.\nPlease refer to the crash logs and FAQ for more information.\n\nLog files are located in %s\nThe FAQ is available at http://wiki.openra.net/FAQ" "OpenRA" "${LOGS}")
 	if command -v zenity > /dev/null; then
-		zenity --no-wrap --error --title "OpenRA" --no-markup --text "${ERROR_MESSAGE}" 2> /dev/null
+		zenity --no-wrap --error --title "OpenRA" --no-markup --text "${ERROR_MESSAGE}" 2> /dev/null || :
 	elif command -v kdialog > /dev/null; then
-		kdialog --title "OpenRA" --error "${ERROR_MESSAGE}"
+		kdialog --title "OpenRA" --error "${ERROR_MESSAGE}" || :
 	else
 		echo "${ERROR_MESSAGE}"
 	fi

--- a/launch-game.sh
+++ b/launch-game.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 ENGINEDIR=$(dirname "$0")
-if command -v mono >/dev/null 2>&1 && [ "$(grep -c .NETCoreApp,Version= ${ENGINEDIR}/bin/OpenRA.dll)" = "0" ]; then
+if command -v mono >/dev/null 2>&1 && [ "$(grep -c .NETCoreApp,Version= "${ENGINEDIR}/bin/OpenRA.dll")" = "0" ]; then
 	RUNTIME_LAUNCHER="mono --debug"
 else
 	RUNTIME_LAUNCHER="dotnet"
 fi
 
 if command -v python3 >/dev/null 2>&1; then
-	 LAUNCHPATH=$(python3 -c "import os; print(os.path.realpath('$0'))")
+	 LAUNCHPATH=$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$0")
 else
-	 LAUNCHPATH=$(python -c "import os; print(os.path.realpath('$0'))")
+	 LAUNCHPATH=$(python -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$0")
 fi
 
 # Prompt for a mod to launch if one is not already specified
@@ -32,7 +32,7 @@ then
 fi
 
 # Launch the engine with the appropriate arguments
-${RUNTIME_LAUNCHER} ${ENGINEDIR}/bin/OpenRA.dll Engine.EngineDir=".." Engine.LaunchPath="${LAUNCHPATH}" ${MODARG} "$@"
+${RUNTIME_LAUNCHER} "${ENGINEDIR}/bin/OpenRA.dll" Engine.EngineDir=".." Engine.LaunchPath="${LAUNCHPATH}" ${MODARG} "$@"
 
 # Show a crash dialog if something went wrong
 if [ $? != 0 ] && [ $? != 1 ]; then

--- a/packaging/functions.sh
+++ b/packaging/functions.sh
@@ -23,7 +23,9 @@
 #   Mod SDK Windows packaging
 #   Mod SDK macOS packaging
 #   Mod SDK Linux AppImage packaging
-install_assemblies() {
+install_assemblies() (
+	set -o errexit || exit $?
+
 	SRC_PATH="${1}"
 	DEST_PATH="${2}"
 	TARGETPLATFORM="${3}"
@@ -37,8 +39,8 @@ install_assemblies() {
 
 	if [ "${RUNTIME}" = "mono" ]; then
 		echo "Building assemblies"
-		rm -rf "${SRC_PATH}/OpenRA."*/obj
-		rm -rf "${SRC_PATH:?}/bin"
+		rm -rf "${SRC_PATH}/OpenRA."*/obj || :
+		rm -rf "${SRC_PATH:?}/bin" || :
 
 		msbuild -verbosity:m -nologo -t:Build -restore -p:Configuration=Release -p:TargetPlatform="${TARGETPLATFORM}"
 		if [ "${TARGETPLATFORM}" = "unix-generic" ]; then
@@ -81,7 +83,7 @@ install_assemblies() {
 		dotnet publish -c Release -p:TargetPlatform="${TARGETPLATFORM}" -p:CopyGenericLauncher="${COPY_GENERIC_LAUNCHER}" -p:CopyCncDll="${COPY_CNC_DLL}" -p:CopyD2kDll="${COPY_D2K_DLL}" -r "${TARGETPLATFORM}" -o "${DEST_PATH}" --self-contained true
 	fi
 	cd "${ORIG_PWD}" || exit 1
-}
+)
 
 # Copy the core engine and specified mod data to the target directory
 # Arguments:
@@ -96,7 +98,9 @@ install_assemblies() {
 #   Mod SDK Linux AppImage packaging
 #   Mod SDK macOS packaging
 #   Mod SDK Windows packaging
-install_data() {
+install_data() (
+	set -o errexit || exit $?
+
 	SRC_PATH="${1}"
 	DEST_PATH="${2}"
 	shift 2
@@ -125,7 +129,7 @@ install_data() {
 
 		shift
 	done
-}
+)
 
 # Compile and publish (using Mono) a windows launcher with the specified mod details to the target directory
 # Arguments:
@@ -140,8 +144,9 @@ install_data() {
 # Used by:
 #   Windows packaging
 #   Mod SDK Windows packaging
-install_windows_launcher()
-{
+install_windows_launcher() (
+	set -o errexit || exit $?
+
 	SRC_PATH="${1}"
 	DEST_PATH="${2}"
 	TARGETPLATFORM="${3}"
@@ -150,14 +155,14 @@ install_windows_launcher()
 	MOD_NAME="${6}"
 	FAQ_URL="${7}"
 
-	rm -rf "${SRC_PATH}/OpenRA.WindowsLauncher/obj"
+	rm -rf "${SRC_PATH}/OpenRA.WindowsLauncher/obj" || :
 	dotnet publish "${SRC_PATH}/OpenRA.WindowsLauncher/OpenRA.WindowsLauncher.csproj" -c Release -r "${TARGETPLATFORM}" -p:LauncherName="${LAUNCHER_NAME}" -p:TargetPlatform="${TARGETPLATFORM}" -p:ModID="${MOD_ID}" -p:DisplayName="${MOD_NAME}" -p:FaqUrl="${FAQ_URL}" -o "${DEST_PATH}" --self-contained true
 
 	# NET 6 is unable to customize the application host for windows when compiling from Linux,
 	# so we must patch the properties we need in the PE header.
 	# Setting the application icon requires an external tool, so is left to the calling code
 	python3 "${SRC_PATH}/packaging/windows/fixlauncher.py" "${DEST_PATH}/${LAUNCHER_NAME}.exe"
-}
+)
 
 # Write a version string to the engine VERSION file
 # Arguments:
@@ -171,11 +176,13 @@ install_windows_launcher()
 #   Mod SDK Linux AppImage packaging
 #   Mod SDK macOS packaging
 #   Mod SDK Windows packaging
-set_engine_version() {
+set_engine_version() (
+	set -o errexit || exit $?
+
 	VERSION="${1}"
 	DEST_PATH="${2}"
 	echo "${VERSION}" > "${DEST_PATH}/VERSION"
-}
+)
 
 # Write a version string to a list of specified mod.yamls
 # Arguments:
@@ -189,7 +196,9 @@ set_engine_version() {
 #   Mod SDK Linux AppImage packaging
 #   Mod SDK macOS packaging
 #   Mod SDK Windows packaging
-set_mod_version() {
+set_mod_version() (
+	set -o errexit || exit $?
+
 	VERSION="${1}"
 	shift
 	while [ -n "${1}" ]; do
@@ -199,7 +208,7 @@ set_mod_version() {
 		rm "${MOD_YAML_PATH}.tmp"
 		shift
 	done
-}
+)
 
 # Copy launch wrappers, application icons, desktop, and MIME files to the target directory
 # Arguments:
@@ -212,7 +221,9 @@ set_mod_version() {
 #   MOD [MOD...]: One or more mod ids to copy (cnc, d2k, ra)
 # Used by:
 #   Makefile (install-linux-shortcuts target for local installs and downstream packaging)
-install_linux_shortcuts() {
+install_linux_shortcuts() (
+	set -o errexit || exit $?
+
 	SRC_PATH="${1}"
 	BUILD_PATH="${2}"
 	OPENRA_PATH="${3}"
@@ -270,7 +281,7 @@ install_linux_shortcuts() {
 
 		shift
 	done
-}
+)
 
 # Copy AppStream metadata to the target directory
 # Arguments:
@@ -280,7 +291,9 @@ install_linux_shortcuts() {
 #   MOD [MOD...]: One or more mod ids to copy (cnc, d2k, ra)
 # Used by:
 #   Makefile (install-linux-appdata target for local installs and downstream packaging)
-install_linux_appdata() {
+install_linux_appdata() (
+	set -o errexit || exit $?
+
 	SRC_PATH="${1}"
 	BUILD_PATH="${2}"
 	SHARE_PATH="${3}"
@@ -315,4 +328,4 @@ install_linux_appdata() {
 
 		shift
 	done
-}
+)

--- a/packaging/functions.sh
+++ b/packaging/functions.sh
@@ -35,7 +35,7 @@ install_assemblies() (
 	COPY_D2K_DLL="${7}"
 
 	ORIG_PWD=$(pwd)
-	cd "${SRC_PATH}" || exit 1
+	cd "${SRC_PATH}"
 
 	if [ "${RUNTIME}" = "mono" ]; then
 		echo "Building assemblies"
@@ -59,7 +59,7 @@ install_assemblies() (
 			rm "${SRC_PATH}/bin/OpenRA.Mods.D2k.dll"
 		fi
 
-		cd "${ORIG_PWD}" || exit 1
+		cd "${ORIG_PWD}"
 
 		echo "Installing engine to ${DEST_PATH}"
 		install -d "${DEST_PATH}"
@@ -82,7 +82,7 @@ install_assemblies() (
 	else
 		dotnet publish -c Release -p:TargetPlatform="${TARGETPLATFORM}" -p:CopyGenericLauncher="${COPY_GENERIC_LAUNCHER}" -p:CopyCncDll="${COPY_CNC_DLL}" -p:CopyD2kDll="${COPY_D2K_DLL}" -r "${TARGETPLATFORM}" -o "${DEST_PATH}" --self-contained true
 	fi
-	cd "${ORIG_PWD}" || exit 1
+	cd "${ORIG_PWD}"
 )
 
 # Copy the core engine and specified mod data to the target directory

--- a/packaging/functions.sh
+++ b/packaging/functions.sh
@@ -249,15 +249,15 @@ install_linux_shortcuts() (
 
 			# wrapper scripts
 			install -d "${BUILD_PATH}/${BIN_PATH}"
-			sed 's/{DEBUG}/--debug/' "${SRC_PATH}/packaging/linux/openra.in" | sed "s|{GAME_INSTALL_DIR}|${OPENRA_PATH}|" | sed "s|{BIN_DIR}|${BIN_PATH}|" | sed "s/{MODID}/${MOD_ID}/g" | sed "s/{TAG}/${VERSION}/g" | sed "s/{MODNAME}/${MOD_NAME}/g" > "${SRC_PATH}/packaging/linux/openra-${MOD_ID}"
-			sed 's/{DEBUG}/--debug/' "${SRC_PATH}/packaging/linux/openra-server.in" | sed "s|{GAME_INSTALL_DIR}|${OPENRA_PATH}|" | sed "s/{MODID}/${MOD_ID}/g" > "${SRC_PATH}/packaging/linux/openra-${MOD_ID}-server"
+			sed -e 's/{DEBUG}/--debug/' -e "s|{GAME_INSTALL_DIR}|${OPENRA_PATH}|" -e "s|{BIN_DIR}|${BIN_PATH}|" -e "s/{MODID}/${MOD_ID}/g" -e "s/{TAG}/${VERSION}/g" -e "s/{MODNAME}/${MOD_NAME}/g" "${SRC_PATH}/packaging/linux/openra.in" > "${SRC_PATH}/packaging/linux/openra-${MOD_ID}"
+			sed -e 's/{DEBUG}/--debug/' -e "s|{GAME_INSTALL_DIR}|${OPENRA_PATH}|" -e "s/{MODID}/${MOD_ID}/g" "${SRC_PATH}/packaging/linux/openra-server.in" > "${SRC_PATH}/packaging/linux/openra-${MOD_ID}-server"
 			install -m755 "${SRC_PATH}/packaging/linux/openra-${MOD_ID}" "${BUILD_PATH}/${BIN_PATH}"
 			install -m755 "${SRC_PATH}/packaging/linux/openra-${MOD_ID}-server" "${BUILD_PATH}/${BIN_PATH}"
 			rm "${SRC_PATH}/packaging/linux/openra-${MOD_ID}" "${SRC_PATH}/packaging/linux/openra-${MOD_ID}-server"
 
 			# desktop files
 			install -d "${BUILD_PATH}${SHARE_PATH}/applications"
-			sed "s/{MODID}/${MOD_ID}/g" "${SRC_PATH}/packaging/linux/openra.desktop.in" | sed "s/{MODNAME}/${MOD_NAME}/g" | sed "s/{TAG}/${VERSION}/g" > "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.desktop"
+			sed -e "s/{MODID}/${MOD_ID}/g" -e "s/{MODNAME}/${MOD_NAME}/g" -e "s/{TAG}/${VERSION}/g" "${SRC_PATH}/packaging/linux/openra.desktop.in" > "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.desktop"
 			install -m644 "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.desktop" "${BUILD_PATH}${SHARE_PATH}/applications"
 			rm "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.desktop"
 
@@ -274,7 +274,7 @@ install_linux_shortcuts() (
 
 			# MIME info
 			install -d "${BUILD_PATH}${SHARE_PATH}/mime/packages"
-			sed "s/{MODID}/${MOD_ID}/g" "${SRC_PATH}/packaging/linux/openra-mimeinfo.xml.in" | sed "s/{TAG}/${VERSION}/g" > "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.xml"
+			sed -e "s/{MODID}/${MOD_ID}/g" -e "s/{TAG}/${VERSION}/g" "${SRC_PATH}/packaging/linux/openra-mimeinfo.xml.in" > "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.xml"
 			install -m644 "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.xml" "${BUILD_PATH}${SHARE_PATH}/mime/packages/openra-${MOD_ID}.xml"
 			rm "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.xml"
 		fi
@@ -322,7 +322,7 @@ install_linux_appdata() (
 
 		install -d "${BUILD_PATH}${SHARE_PATH}/metainfo"
 
-		sed "s/{MODID}/${MOD_ID}/g" "${SRC_PATH}/packaging/linux/openra.metainfo.xml.in" | sed "s/{MOD_NAME}/${MOD_NAME}/g" | sed "s/{SCREENSHOT_RA}/${SCREENSHOT_RA}/g" | sed "s/{SCREENSHOT_CNC}/${SCREENSHOT_CNC}/g" | sed "s/{SCREENSHOT_D2K}/${SCREENSHOT_D2K}/g"> "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.metainfo.xml"
+		sed -e "s/{MODID}/${MOD_ID}/g" -e "s/{MOD_NAME}/${MOD_NAME}/g" -e "s/{SCREENSHOT_RA}/${SCREENSHOT_RA}/g" -e "s/{SCREENSHOT_CNC}/${SCREENSHOT_CNC}/g" -e "s/{SCREENSHOT_D2K}/${SCREENSHOT_D2K}/g" "${SRC_PATH}/packaging/linux/openra.metainfo.xml.in" > "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.metainfo.xml"
 		install -m644 "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.metainfo.xml" "${BUILD_PATH}${SHARE_PATH}/metainfo"
 		rm "${SRC_PATH}/packaging/linux/openra-${MOD_ID}.metainfo.xml"
 

--- a/packaging/linux/AppRun.in
+++ b/packaging/linux/AppRun.in
@@ -1,7 +1,8 @@
 #!/bin/sh
 set -o errexit || exit $?
 
-HERE="$(dirname "$(readlink -f "${0}")")"
+LAUNCHER=$(readlink -f "${0}")
+HERE=$(dirname "${LAUNCHER}")
 
 # Run the game or server
 if [ -n "$1" ] && [ "$1" = "--server" ]; then

--- a/packaging/linux/AppRun.in
+++ b/packaging/linux/AppRun.in
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -o errexit || exit $?
 
 HERE="$(dirname "$(readlink -f "${0}")")"
 

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -14,7 +14,8 @@ if [ $# -eq "0" ]; then
 fi
 
 # Set the working dir to the location of this script
-cd "$(dirname "$0")" || exit 1
+HERE=$(dirname "$0")
+cd "${HERE}" || exit 1
 . ../functions.sh
 
 TAG="$1"

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # OpenRA packaging script for Linux (AppImage)
-set -e
+
+set -o errexit || exit $?
 
 command -v tar >/dev/null 2>&1 || { echo >&2 "Linux packaging requires tar."; exit 1; }
 command -v curl >/dev/null 2>&1 || command -v wget > /dev/null 2>&1 || { echo >&2 "Linux packaging requires curl or wget."; exit 1; }

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # OpenRA packaging script for Linux (AppImage)
 
-set -o errexit || exit $?
+set -o errexit -o pipefail || exit $?
 
 command -v tar >/dev/null 2>&1 || { echo >&2 "Linux packaging requires tar."; exit 1; }
 command -v curl >/dev/null 2>&1 || command -v wget > /dev/null 2>&1 || { echo >&2 "Linux packaging requires curl or wget."; exit 1; }

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -15,7 +15,7 @@ fi
 
 # Set the working dir to the location of this script
 HERE=$(dirname "$0")
-cd "${HERE}" || exit 1
+cd "${HERE}"
 . ../functions.sh
 
 TAG="$1"
@@ -36,7 +36,7 @@ elif [[ ${TAG} == pkgtest* ]]; then
 	SUFFIX="-pkgtest"
 fi
 
-pushd "${TEMPLATE_ROOT}" > /dev/null || exit 1
+pushd "${TEMPLATE_ROOT}" > /dev/null
 
 if [ ! -d "${OUTPUTDIR}" ]; then
 	echo "Output directory '${OUTPUTDIR}' does not exist.";
@@ -46,9 +46,9 @@ fi
 # Add native libraries
 echo "Downloading appimagetool"
 if command -v curl >/dev/null 2>&1; then
-	curl -s -L -O https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage || exit 3
+	curl -s -L -O https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
 else
-	wget -cq https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage || exit 3
+	wget -cq https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
 fi
 
 chmod a+x appimagetool-x86_64.AppImage

--- a/packaging/linux/openra-server.appimage.in
+++ b/packaging/linux/openra-server.appimage.in
@@ -1,7 +1,8 @@
 #!/bin/sh
 set -o errexit || exit $?
 
-HERE="$(dirname "$(readlink -f "${0}")")"
+LAUNCHER=$(readlink -f "${0}")
+HERE=$(dirname "${LAUNCHER}")
 cd "${HERE}/../lib/openra" || exit 1
 
 ./OpenRA.Server Game.Mod="{MODID}" "$@"

--- a/packaging/linux/openra-server.appimage.in
+++ b/packaging/linux/openra-server.appimage.in
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -o errexit || exit $?
+
 HERE="$(dirname "$(readlink -f "${0}")")"
 cd "${HERE}/../lib/openra" || exit 1
 

--- a/packaging/linux/openra-server.appimage.in
+++ b/packaging/linux/openra-server.appimage.in
@@ -3,6 +3,6 @@ set -o errexit || exit $?
 
 LAUNCHER=$(readlink -f "${0}")
 HERE=$(dirname "${LAUNCHER}")
-cd "${HERE}/../lib/openra" || exit 1
+cd "${HERE}/../lib/openra"
 
 ./OpenRA.Server Game.Mod="{MODID}" "$@"

--- a/packaging/linux/openra-server.in
+++ b/packaging/linux/openra-server.in
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -o errexit || exit $?
+
 cd "{GAME_INSTALL_DIR}"
 
 mono {DEBUG} OpenRA.Server.dll Game.Mod={MODID} "$@"

--- a/packaging/linux/openra-utility.appimage.in
+++ b/packaging/linux/openra-utility.appimage.in
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -o errexit || exit $?
 
 # OpenRA.Utility relies on keeping the original working directory, so don't change directory
 HERE="$(dirname "$(readlink -f "${0}")")"

--- a/packaging/linux/openra-utility.appimage.in
+++ b/packaging/linux/openra-utility.appimage.in
@@ -2,5 +2,6 @@
 set -o errexit || exit $?
 
 # OpenRA.Utility relies on keeping the original working directory, so don't change directory
-HERE="$(dirname "$(readlink -f "${0}")")"
+LAUNCHER=$(readlink -f "${0}")
+HERE=$(dirname "${LAUNCHER}")
 "${HERE}/../lib/openra/OpenRA.Utility" {MODID} "$@"

--- a/packaging/linux/openra.appimage.in
+++ b/packaging/linux/openra.appimage.in
@@ -3,7 +3,7 @@ set -o errexit || exit $?
 
 LAUNCHER=$(readlink -f "${0}")
 HERE="$(dirname "${LAUNCHER}")"
-cd "${HERE}/../lib/openra" || exit 1
+cd "${HERE}/../lib/openra"
 
 # APPIMAGE is an environment variable set by the runtime
 # defining the absolute path to the .AppImage file

--- a/packaging/linux/openra.appimage.in
+++ b/packaging/linux/openra.appimage.in
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -o errexit || exit $?
+
 LAUNCHER=$(readlink -f "${0}")
 HERE="$(dirname "${LAUNCHER}")"
 cd "${HERE}/../lib/openra" || exit 1
@@ -43,21 +45,23 @@ fi
 
 # Run the game
 export SDL_VIDEO_X11_WMCLASS="openra-{MODID}-{TAG}"
-./OpenRA Game.Mod={MODID} Engine.LaunchPath="${LAUNCHER}" "${JOIN_SERVER}" "$@"
+./OpenRA Game.Mod={MODID} Engine.LaunchPath="${LAUNCHER}" "${JOIN_SERVER}" "$@" && rc=0 || rc=$?
 
 # Show a crash dialog if something went wrong
-if [ $? != 0 ] && [ $? != 1 ]; then
+if [ "${rc}" != 0 ] && [ "${rc}" != 1 ]; then
 	LOGS="${XDG_CONFIG_HOME:-${HOME}/.config}/openra/Logs"
 	if [ ! -d "${LOGS}" ] && [ -d "${HOME}/.openra/Logs" ]; then
 		LOGS="${HOME}/.openra/Logs"
 	fi
 
-	test -d Support/Logs && LOGS="${PWD}/Support/Logs"
+	if [ -d Support/Logs ]; then
+		LOGS="${PWD}/Support/Logs"
+	fi
 	ERROR_MESSAGE=$(printf "%s has encountered a fatal error.\nPlease refer to the crash logs and FAQ for more information.\n\nLog files are located in %s\nThe FAQ is available at http://wiki.openra.net/FAQ" "{MODNAME}" "${LOGS}")
 	if command -v zenity > /dev/null; then
-		zenity --no-wrap --error --title "{MODNAME}" --no-markup --text "${ERROR_MESSAGE}" 2> /dev/null
+		zenity --no-wrap --error --title "{MODNAME}" --no-markup --text "${ERROR_MESSAGE}" 2> /dev/null || :
 	elif command -v kdialog > /dev/null; then
-		kdialog --title "{MODNAME}" --error "${ERROR_MESSAGE}"
+		kdialog --title "{MODNAME}" --error "${ERROR_MESSAGE}" || :
 	elif "${HERE}/gtk-dialog.py" test > /dev/null; then
 		"${HERE}/gtk-dialog.py" error --title "{MODNAME}" --text "${ERROR_MESSAGE}" 2> /dev/null
 	else

--- a/packaging/linux/openra.appimage.in
+++ b/packaging/linux/openra.appimage.in
@@ -11,6 +11,7 @@ if [ -n "${APPIMAGE}" ]; then
 	LAUNCHER=${APPIMAGE}
 
 	APPIMAGEID=$(printf "file://%s" "${APPIMAGE}" | md5sum | cut -d' ' -f1)
+	test -n "${APPIMAGEID}"
 	LAUNCHER_NAME="appimagekit_${APPIMAGEID}-openra-{MODID}.desktop"
 	LAUNCHER_PATH="${HOME}/.local/share/applications/${LAUNCHER_NAME}"
 	export SDL_VIDEO_X11_WMCLASS="openra-{MODID}-{TAG}"

--- a/packaging/linux/openra.in
+++ b/packaging/linux/openra.in
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -o errexit || exit $?
+
 cd "{GAME_INSTALL_DIR}"
 
 # Search for server connection
@@ -9,21 +11,23 @@ if [ "${1#${PROTOCOL_PREFIX}}" != "${1}" ]; then
 fi
 
 # Run the game
-mono {DEBUG} OpenRA.dll Game.Mod={MODID} Engine.LaunchPath="{BIN_DIR}/openra-{MODID}" "${JOIN_SERVER}" "$@"
+mono {DEBUG} OpenRA.dll Game.Mod={MODID} Engine.LaunchPath="{BIN_DIR}/openra-{MODID}" "${JOIN_SERVER}" "$@" && rc=0 || rc=$?
 
 # Show a crash dialog if something went wrong
-if [ $? != 0 ] && [ $? != 1 ]; then
+if [ "${rc}" != 0 ] && [ "${rc}" != 1 ]; then
 	LOGS="${XDG_CONFIG_HOME:-${HOME}/.config}/openra/Logs"
 	if [ ! -d "${LOGS}" ] && [ -d "${HOME}/.openra/Logs" ]; then
 		LOGS="${HOME}/.openra/Logs"
 	fi
 
-	test -d Support/Logs && LOGS="${PWD}/Support/Logs"
+	if [ -d Support/Logs ]; then
+		LOGS="${PWD}/Support/Logs"
+	fi
 	ERROR_MESSAGE=$(printf "%s has encountered a fatal error.\nPlease refer to the crash logs and FAQ for more information.\n\nLog files are located in %s\nThe FAQ is available at http://wiki.openra.net/FAQ" "{MODNAME}" "${LOGS}")
 	if command -v zenity > /dev/null; then
-		zenity --no-wrap --error --title "{MODNAME}" --no-markup --text "${ERROR_MESSAGE}" 2> /dev/null
+		zenity --no-wrap --error --title "{MODNAME}" --no-markup --text "${ERROR_MESSAGE}" 2> /dev/null || :
 	elif command -v kdialog > /dev/null; then
-		kdialog --title "{MODNAME}" --error "${ERROR_MESSAGE}"
+		kdialog --title "{MODNAME}" --error "${ERROR_MESSAGE}" || :
 	else
 		echo "${ERROR_MESSAGE}"
 	fi

--- a/packaging/macos/buildpackage.sh
+++ b/packaging/macos/buildpackage.sh
@@ -30,7 +30,7 @@ fi
 
 # Set the working dir to the location of this script
 HERE=$(dirname "${0}")
-cd "${HERE}" || exit 1
+cd "${HERE}"
 . ../functions.sh
 
 # Import code signing certificate

--- a/packaging/macos/buildpackage.sh
+++ b/packaging/macos/buildpackage.sh
@@ -13,7 +13,8 @@
 #   MACOS_DEVELOPER_USERNAME: Email address for the developer account
 #   MACOS_DEVELOPER_PASSWORD: App-specific password for the developer account
 #
-set -e
+
+set -o errexit || exit $?
 
 MONO_TAG="osx-launcher-20201222"
 

--- a/packaging/macos/buildpackage.sh
+++ b/packaging/macos/buildpackage.sh
@@ -14,7 +14,7 @@
 #   MACOS_DEVELOPER_PASSWORD: App-specific password for the developer account
 #
 
-set -o errexit || exit $?
+set -o errexit -o pipefail || exit $?
 
 MONO_TAG="osx-launcher-20201222"
 
@@ -189,8 +189,8 @@ build_platform() {
 		for MOD in "Red Alert" "Tiberian Dawn"; do
 			for f in $(find /Volumes/OpenRA/OpenRA\ -\ ${MOD}.app/Contents/MacOS/*); do
 				g="/Volumes/OpenRA/OpenRA - Dune 2000.app/Contents/MacOS/"$(basename "${f}")
-				hashf=$(shasum "${f}" | awk '{ print $1 }')
-				hashg=$(shasum "${g}" | awk '{ print $1 }')
+				hashf=$(shasum "${f}" | awk '{ print $1 }') || :
+				hashg=$(shasum "${g}" | awk '{ print $1 }') || :
 				if [ "${hashf}" = "${hashg}" ]; then
 					echo "Deduplicating ${f}"
 					rm "${f}"

--- a/packaging/macos/buildpackage.sh
+++ b/packaging/macos/buildpackage.sh
@@ -29,7 +29,8 @@ if [[ "${OSTYPE}" != "darwin"* ]]; then
 fi
 
 # Set the working dir to the location of this script
-cd "$(dirname "${0}")" || exit 1
+HERE=$(dirname "${0}")
+cd "${HERE}" || exit 1
 . ../functions.sh
 
 # Import code signing certificate

--- a/packaging/macos/buildpackage.sh
+++ b/packaging/macos/buildpackage.sh
@@ -284,9 +284,14 @@ fi
 
 if [ -n "${MACOS_DEVELOPER_USERNAME}" ] && [ -n "${MACOS_DEVELOPER_PASSWORD}" ]; then
 	# Parallelize processing
-	(notarize_package "build.dmg") &
-	(notarize_package "build-mono.dmg") &
-	wait
+	(notarize_package "build.dmg") || exit 1 &
+	(notarize_package "build-mono.dmg") || exit 1 &
+	while wait -n; rc=$?; [ "${rc}" != 127 ]; do
+		if [ "${rc}" != 0 ]; then
+			wait
+			exit "${rc}"
+		fi
+	done
 fi
 
 finalize_package "standard" "build.dmg" "${OUTPUTDIR}/OpenRA-${TAG}.dmg"

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # OpenRA master packaging script
 
+set -o errexit || exit $?
+
 if [ $# -ne "2" ]; then
 	echo "Usage: ${0##*/} version outputdir."
 	exit 1
@@ -19,14 +21,12 @@ function build_package() (
 	}
 	#trap function executes on any error in the following commands
 	trap "on_build $1" ERR
-	set -e
 	echo "Building $1 package(s)."
 	cd "$1"
 	./buildpackage.sh "${GIT_TAG}" "${BUILD_OUTPUT_DIR}"
 )
 
 #exit on any non-zero exited (failed) command
-set -e
 if [[ "$OSTYPE" == "darwin"* ]]; then
   build_package macos
 else

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # OpenRA master packaging script
 
-set -o errexit || exit $?
+set -o errexit -o pipefail || exit $?
 
 if [ $# -ne "2" ]; then
 	echo "Usage: ${0##*/} version outputdir."

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -12,7 +12,7 @@ export GIT_TAG="$1"
 export BUILD_OUTPUT_DIR="$2"
 
 # Set the working dir to the location of this script using bash parameter expansion
-cd "${0%/*}" || exit 1
+cd "${0%/*}"
 
 #build packages using a subshell so directory changes do not persist beyond the function
 function build_package() (

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -26,7 +26,6 @@ function build_package() (
 	./buildpackage.sh "${GIT_TAG}" "${BUILD_OUTPUT_DIR}"
 )
 
-#exit on any non-zero exited (failed) command
 if [[ "$OSTYPE" == "darwin"* ]]; then
   build_package macos
 else

--- a/packaging/source/buildpackage.sh
+++ b/packaging/source/buildpackage.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # OpenRA packaging script for versioned source tarball
 
+set -o errexit || exit $?
+
 if [ $# -ne "2" ]; then
 	echo "Usage: $(basename "$0") tag outputdir"
 	exit 1
@@ -19,7 +21,7 @@ make version VERSION="${TAG}"
 # The output from `git ls-tree` is too long to fit in a single command (overflows MAX_ARG_STRLEN)
 # so `xargs` will automatically split the input across multiple `tar` commands.
 # Use the amend flag (r) to prevent each call erasing the output from earlier calls.
-rm "${OUTPUTDIR}/OpenRA-${TAG}-source.tar"
+rm "${OUTPUTDIR}/OpenRA-${TAG}-source.tar" || :
 git ls-tree HEAD --name-only -r -z | xargs -0 tar vrf "${OUTPUTDIR}/OpenRA-${TAG}-source.tar"
 bzip2 "${OUTPUTDIR}/OpenRA-${TAG}-source.tar"
 

--- a/packaging/source/buildpackage.sh
+++ b/packaging/source/buildpackage.sh
@@ -9,7 +9,8 @@ if [ $# -ne "2" ]; then
 fi
 
 # Set the working dir to the location of this script
-cd "$(dirname "$0")" || exit 1
+HERE=$(dirname "$0")
+cd "${HERE}" || exit 1
 
 TAG="$1"
 OUTPUTDIR="$2"

--- a/packaging/source/buildpackage.sh
+++ b/packaging/source/buildpackage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # OpenRA packaging script for versioned source tarball
 
-set -o errexit || exit $?
+set -o errexit -o pipefail || exit $?
 
 if [ $# -ne "2" ]; then
 	echo "Usage: $(basename "$0") tag outputdir"

--- a/packaging/source/buildpackage.sh
+++ b/packaging/source/buildpackage.sh
@@ -10,13 +10,13 @@ fi
 
 # Set the working dir to the location of this script
 HERE=$(dirname "$0")
-cd "${HERE}" || exit 1
+cd "${HERE}"
 
 TAG="$1"
 OUTPUTDIR="$2"
 SRCDIR="$(pwd)/../.."
 
-pushd "${SRCDIR}" > /dev/null || exit 1
+pushd "${SRCDIR}" > /dev/null
 make version VERSION="${TAG}"
 
 # The output from `git ls-tree` is too long to fit in a single command (overflows MAX_ARG_STRLEN)
@@ -26,4 +26,4 @@ rm "${OUTPUTDIR}/OpenRA-${TAG}-source.tar" || :
 git ls-tree HEAD --name-only -r -z | xargs -0 tar vrf "${OUTPUTDIR}/OpenRA-${TAG}-source.tar"
 bzip2 "${OUTPUTDIR}/OpenRA-${TAG}-source.tar"
 
-popd > /dev/null || exit 1
+popd > /dev/null

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -16,7 +16,7 @@ fi
 
 # Set the working dir to the location of this script
 HERE=$(dirname "$0")
-cd "${HERE}" || exit 1
+cd "${HERE}"
 . ../functions.sh
 
 TAG="$1"
@@ -35,9 +35,9 @@ elif [[ ${TAG} == playtest* ]]; then
 fi
 
 if command -v curl >/dev/null 2>&1; then
-	curl -s -L -O https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe || exit 3
+	curl -s -L -O https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe
 else
-	wget -cq https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe || exit 3
+	wget -cq https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe
 fi
 
 function makelauncher()
@@ -75,7 +75,7 @@ function build_platform()
 	makelauncher "Dune2000" "Dune 2000" "d2k" "${PLATFORM}"
 
 	echo "Building Windows setup.exe ($1)"
-	makensis -V2 -DSRCDIR="${BUILTDIR}" -DTAG="${TAG}" -DSUFFIX="${SUFFIX}" -DOUTFILE="${OUTPUTDIR}/OpenRA-${TAG}-${PLATFORM}.exe" ${USE_PROGRAMFILES32} OpenRA.nsi || exit 1
+	makensis -V2 -DSRCDIR="${BUILTDIR}" -DTAG="${TAG}" -DSUFFIX="${SUFFIX}" -DOUTFILE="${OUTPUTDIR}/OpenRA-${TAG}-${PLATFORM}.exe" ${USE_PROGRAMFILES32} OpenRA.nsi
 
 	echo "Packaging zip archive ($1)"
 	pushd "${BUILTDIR}" > /dev/null

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -78,7 +78,7 @@ function build_platform()
 
 	echo "Packaging zip archive ($1)"
 	pushd "${BUILTDIR}" > /dev/null
-	zip "OpenRA-${TAG}-${PLATFORM}-winportable.zip" -r -9 * --quiet
+	zip "OpenRA-${TAG}-${PLATFORM}-winportable.zip" -r -9 ./* --quiet
 	mv "OpenRA-${TAG}-${PLATFORM}-winportable.zip" "${OUTPUTDIR}"
 	popd > /dev/null
 

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -15,7 +15,8 @@ if [ $# -ne "2" ]; then
 fi
 
 # Set the working dir to the location of this script
-cd "$(dirname "$0")" || exit 1
+HERE=$(dirname "$0")
+cd "${HERE}" || exit 1
 . ../functions.sh
 
 TAG="$1"

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # OpenRA packaging script for Windows
 
-set -o errexit || exit $?
+set -o errexit -o pipefail || exit $?
 
 command -v curl >/dev/null 2>&1 || command -v wget > /dev/null 2>&1 || { echo >&2 "Windows packaging requires curl or wget."; exit 1; }
 command -v makensis >/dev/null 2>&1 || { echo >&2 "Windows packaging requires makensis."; exit 1; }

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # OpenRA packaging script for Windows
 
-set -e
+set -o errexit || exit $?
 
 command -v curl >/dev/null 2>&1 || command -v wget > /dev/null 2>&1 || { echo >&2 "Windows packaging requires curl or wget."; exit 1; }
 command -v makensis >/dev/null 2>&1 || { echo >&2 "Windows packaging requires makensis."; exit 1; }

--- a/utility.sh
+++ b/utility.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -o errexit || exit $?
+
 ENGINEDIR=$(dirname "$0")
 if command -v mono >/dev/null 2>&1 && [ "$(grep -c .NETCoreApp,Version= "${ENGINEDIR}/bin/OpenRA.Utility.dll")" = "0" ]; then
 	RUNTIME_LAUNCHER="mono --debug"

--- a/utility.sh
+++ b/utility.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 ENGINEDIR=$(dirname "$0")
-if command -v mono >/dev/null 2>&1 && [ "$(grep -c .NETCoreApp,Version= ${ENGINEDIR}/bin/OpenRA.Utility.dll)" = "0" ]; then
+if command -v mono >/dev/null 2>&1 && [ "$(grep -c .NETCoreApp,Version= "${ENGINEDIR}/bin/OpenRA.Utility.dll")" = "0" ]; then
 	RUNTIME_LAUNCHER="mono --debug"
 else
 	RUNTIME_LAUNCHER="dotnet"
 fi
 
-ENGINE_DIR=.. ${RUNTIME_LAUNCHER} ${ENGINEDIR}/bin/OpenRA.Utility.dll "$@"
+ENGINE_DIR=.. ${RUNTIME_LAUNCHER} "${ENGINEDIR}/bin/OpenRA.Utility.dll" "$@"


### PR DESCRIPTION
Most errors in the shell scripts for building, packaging and launching are ignored. (e.g. `make install` succeeds even when compiling fails).

This PR tries to mitigate the problem by always enabling `errexit`.

In bash scripts `pipefail` is enabled. In plain sh scripts I removed pipes or checked the output.

I removed some of the subshells used in program arguments, as errors are ignored even with `errexit`.

Besides the main focus of this PR, I added some missing quotes around path variables and replaced an instance of`*` with `./*` for globbing (preventing paths from being interpreted as options).