### PR TITLE
Split Repairable logic into Rearmable

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (repairableInfo != null && repairableInfo.RepairActors.Contains(dest.Info.Name) && self.GetDamageState() != DamageState.Undamaged)
 				return true;
 
-			return rearmable != null && rearmable.Info.RearmActors.Contains(dest.Info.Name)
+			return rearmable != null && rearmable.CanRearmAt(dest)
 					&& rearmable.RearmableAmmoPools.Any(p => !p.HasFullAmmo);
 		}
 

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			var cannotRepairAtHost = health == null || health.DamageState == DamageState.Undamaged
 				|| allRepairsUnits.Length == 0
-				|| ((repairable == null || !repairable.Info.RepairActors.Contains(host.Info.Name))
+				|| ((repairable == null || !repairable.CanRepairAt(host))
 					&& (repairableNear == null || !repairableNear.Info.RepairActors.Contains(host.Info.Name)));
 
 			if (!cannotRepairAtHost)
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Activities
 				wasRepaired = true;
 			}
 
-			var cannotRearmAtHost = rearmable == null || !rearmable.Info.RearmActors.Contains(host.Info.Name) || rearmable.RearmableAmmoPools.All(p => p.HasFullAmmo);
+			var cannotRearmAtHost = rearmable == null || !rearmable.CanRearmAt(host) || !rearmable.CanRearm();
 			if (!cannotRearmAtHost)
 				activeResupplyTypes |= ResupplyType.Rearm;
 		}

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -596,10 +596,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (self.AppearsHostileTo(a))
 				return false;
 
-			var canRearmAtActor = rearmable != null && rearmable.Info.RearmActors.Contains(a.Info.Name);
-			var canRepairAtActor = repairable != null && repairable.Info.RepairActors.Contains(a.Info.Name);
-
-			return canRearmAtActor || canRepairAtActor;
+			return (rearmable != null && rearmable.CanRearmAt(a)) ||
+				(repairable != null && repairable.CanRepairAt(a));
 		}
 
 		bool AircraftCanResupplyAt(Actor a, bool allowedToForceEnter = false)
@@ -607,13 +605,14 @@ namespace OpenRA.Mods.Common.Traits
 			if (self.AppearsHostileTo(a))
 				return false;
 
-			var canRearmAtActor = rearmable != null && rearmable.Info.RearmActors.Contains(a.Info.Name);
-			var canRepairAtActor = repairable != null && repairable.Info.RepairActors.Contains(a.Info.Name);
-
+			var canRearmAtActor = rearmable != null && rearmable.CanRearmAt(a);
 			var allowedToEnterRearmer = canRearmAtActor && (allowedToForceEnter || rearmable.RearmableAmmoPools.Any(p => !p.HasFullAmmo));
-			var allowedToEnterRepairer = canRepairAtActor && (allowedToForceEnter || self.GetDamageState() != DamageState.Undamaged);
+			if (allowedToEnterRearmer)
+				return true;
 
-			return allowedToEnterRearmer || allowedToEnterRepairer;
+			var canRepairAtActor = repairable != null && repairable.CanRepairAt(a);
+			var allowedToEnterRepairer = canRepairAtActor && (allowedToForceEnter || self.GetDamageState() != DamageState.Undamaged);
+			return allowedToEnterRepairer;
 		}
 
 		public int MovementSpeed => !IsTraitDisabled && !IsTraitPaused ? Util.ApplyPercentageModifiers(Info.Speed, speedModifiers) : 0;
@@ -723,12 +722,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool CanRearmAt(Actor host)
 		{
-			return rearmable != null && rearmable.Info.RearmActors.Contains(host.Info.Name) && rearmable.RearmableAmmoPools.Any(p => !p.HasFullAmmo);
+			return rearmable != null && rearmable.CanRearmAt(host) && rearmable.RearmableAmmoPools.Any(p => !p.HasFullAmmo);
 		}
 
 		public bool CanRepairAt(Actor host)
 		{
-			return repairable != null && repairable.Info.RepairActors.Contains(host.Info.Name) && self.GetDamageState() != DamageState.Undamaged;
+			return repairable != null && repairable.CanRepairAt(host) && self.GetDamageState() != DamageState.Undamaged;
 		}
 
 		public void ModifyDeathActorInit(Actor self, TypeDictionary init)

--- a/OpenRA.Mods.Common/Traits/Rearmable.cs
+++ b/OpenRA.Mods.Common/Traits/Rearmable.cs
@@ -11,24 +11,42 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Orders;
+using OpenRA.Support;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class RearmableInfo : TraitInfo
+	public class RearmableInfo : TraitInfo, Requires<AmmoPoolInfo>
 	{
 		[ActorReference]
 		[FieldLoader.Require]
 		[Desc("Actors that this actor can dock to and get rearmed by.")]
 		public readonly HashSet<string> RearmActors = new HashSet<string> { };
 
+		[VoiceReference]
+		public readonly string Voice = "Action";
+
 		[Desc("Name(s) of AmmoPool(s) that use this trait to rearm.")]
 		public readonly HashSet<string> AmmoPools = new HashSet<string> { "primary" };
+
+		[ConsumedConditionReference]
+		[Desc("Boolean expression defining the condition under which the regular (non-force) enter cursor is disabled.")]
+		public readonly BooleanExpression RequireForceMoveCondition = null;
+
+		[CursorReference]
+		[Desc("Cursor to display when able to be repaired at target actor.")]
+		public readonly string EnterCursor = "enter";
+
+		[CursorReference]
+		[Desc("Cursor to display when unable to be repaired at target actor.")]
+		public readonly string EnterBlockedCursor = "enter-blocked";
 
 		public override object Create(ActorInitializer init) { return new Rearmable(this); }
 	}
 
-	public class Rearmable : INotifyCreated, INotifyResupply
+	public class Rearmable : IIssueOrder, IResolveOrder, IOrderVoice, INotifyCreated, INotifyResupply, IObservesVariables
 	{
 		public readonly RearmableInfo Info;
 
@@ -39,9 +57,56 @@ namespace OpenRA.Mods.Common.Traits
 
 		public AmmoPool[] RearmableAmmoPools { get; private set; }
 
+		bool isAircraft;
+		bool isRepairable;
+		bool requireForceMove;
+
 		void INotifyCreated.Created(Actor self)
 		{
 			RearmableAmmoPools = self.TraitsImplementing<AmmoPool>().Where(p => Info.AmmoPools.Contains(p.Info.Name)).ToArray();
+			isAircraft = self.Info.HasTraitInfo<AircraftInfo>();
+			isRepairable = self.Info.HasTraitInfo<RepairableInfo>();
+		}
+
+		IEnumerable<IOrderTargeter> IIssueOrder.Orders
+		{
+			get
+			{
+				if (!isAircraft || !isRepairable)
+					yield return new EnterAlliedActorTargeter<BuildingInfo>(
+						"Rearm",
+						5,
+						Info.EnterCursor,
+						Info.EnterBlockedCursor,
+						CanRearmAt,
+						_ => CanRearm());
+			}
+		}
+
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
+		{
+			if (order.OrderID == "Rearm")
+				return new Order(order.OrderID, self, target, queued);
+
+			return null;
+		}
+
+		public bool CanRearmAt(Actor target)
+		{
+			return Info.RearmActors.Contains(target.Info.Name);
+		}
+
+		public bool CanRearmAt(Actor target, TargetModifiers modifiers)
+		{
+			if (requireForceMove && !modifiers.HasModifier(TargetModifiers.ForceMove))
+				return false;
+
+			return CanRearmAt(target);
+		}
+
+		public bool CanRearm()
+		{
+			return RearmableAmmoPools.Any(p => !p.HasFullAmmo);
 		}
 
 		void INotifyResupply.BeforeResupply(Actor self, Actor target, ResupplyType types)
@@ -56,5 +121,43 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		void INotifyResupply.ResupplyTick(Actor self, Actor target, ResupplyType types) { }
+
+		string IOrderVoice.VoicePhraseForOrder(Actor self, Order order)
+		{
+			return order.OrderString == "Rearm" && CanRearm() ? Info.Voice : null;
+		}
+
+		void IResolveOrder.ResolveOrder(Actor self, Order order)
+		{
+			if (order.OrderString != "Rearm")
+				return;
+
+			// Repair orders are only valid for own/allied actors,
+			// which are guaranteed to never be frozen.
+			if (order.Target.Type != TargetType.Actor)
+				return;
+
+			// Aircraft handle Repair orders directly in the Aircraft trait
+			// TODO: Move the order handling of both this trait and Aircraft to a generalistic DockManager
+			if (isAircraft || isRepairable)
+				return;
+
+			if (!CanRearmAt(order.Target.Actor) || !CanRearm())
+				return;
+
+			self.QueueActivity(order.Queued, new Resupply(self, order.Target.Actor, new WDist(512)));
+			self.ShowTargetLines();
+		}
+
+		IEnumerable<VariableObserver> IObservesVariables.GetVariableObservers()
+		{
+			if (Info.RequireForceMoveCondition != null)
+				yield return new VariableObserver(RequireForceMoveConditionChanged, Info.RequireForceMoveCondition.Variables);
+		}
+
+		void RequireForceMoveConditionChanged(Actor self, IReadOnlyDictionary<string, int> conditions)
+		{
+			requireForceMove = Info.RequireForceMoveCondition.Evaluate(conditions);
+		}
 	}
 }

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -173,6 +173,7 @@ ORCA:
 		RequiresCondition: empdisable
 	Rearmable:
 		RearmActors: gahpad, nahpad
+		Voice: Move
 	WithAmmoPipsDecoration:
 		Position: BottomLeft
 		RequiresSelection: true
@@ -240,6 +241,7 @@ ORCAB:
 		RequiresCondition: empdisable
 	Rearmable:
 		RearmActors: gahpad, nahpad
+		Voice: Move
 	WithAmmoPipsDecoration:
 		Position: BottomLeft
 		RequiresSelection: true
@@ -391,6 +393,7 @@ SCRIN:
 		RequiresCondition: empdisable
 	Rearmable:
 		RearmActors: gahpad, nahpad
+		Voice: Move
 	WithAmmoPipsDecoration:
 		Position: BottomLeft
 		RequiresSelection: true
@@ -462,6 +465,7 @@ APACHE:
 		RequiresCondition: empdisable
 	Rearmable:
 		RearmActors: gahpad, nahpad
+		Voice: Move
 	WithAmmoPipsDecoration:
 		Position: BottomLeft
 		RequiresSelection: true


### PR DESCRIPTION
fixes #20065 
related #11806 #12493 #18645

I populate `Rearmable` with `Repairable`s logic. Now actors can exist with either having just 1 of the 2 traits or both. When an actor has both traits `Rearmable` is turned off similarly to how `Aircraft` does it, so all collisions are handled in `Repairable`

test cases: 

- add `-Repairable` to `MNLY` and minelayer will still be able to rearm
- change `RearmActors` on `MNLY` to something else and minelayer will still be able to rearm at service depot