### PR TITLE
Scripts: Disable markup in error messages

### DIFF
--- a/launch-game.sh
+++ b/launch-game.sh
@@ -46,9 +46,9 @@ if [ $? != 0 ] && [ $? != 1 ]; then
 	fi
 
 	test -d Support/Logs && LOGS="${PWD}/Support/Logs"
-	ERROR_MESSAGE="OpenRA has encountered a fatal error.\nPlease refer to the crash logs and FAQ for more information.\n\nLog files are located in ${LOGS}\nThe FAQ is available at http://wiki.openra.net/FAQ"
+	ERROR_MESSAGE=$(printf "%s has encountered a fatal error.\nPlease refer to the crash logs and FAQ for more information.\n\nLog files are located in %s\nThe FAQ is available at http://wiki.openra.net/FAQ" "OpenRA" "${LOGS}")
 	if command -v zenity > /dev/null; then
-		zenity --no-wrap --error --title "OpenRA" --text "${ERROR_MESSAGE}" 2> /dev/null
+		zenity --no-wrap --error --title "OpenRA" --no-markup --text "${ERROR_MESSAGE}" 2> /dev/null
 	elif command -v kdialog > /dev/null; then
 		kdialog --title "OpenRA" --error "${ERROR_MESSAGE}"
 	else

--- a/packaging/linux/gtk-dialog.py
+++ b/packaging/linux/gtk-dialog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 """A simple GTK3 graphical dialog helper that can be used as a fallback if zenity is not available
    Compatible with python 2 or 3 with the gi bindings.
 

--- a/packaging/linux/gtk-dialog.py
+++ b/packaging/linux/gtk-dialog.py
@@ -43,6 +43,6 @@ if __name__ == "__main__":
     parser.add_argument('--text', type=str, required=False, default='')
     args = parser.parse_args()
     if args.type == 'question':
-        Question(args.title, args.text.replace('\\n', '\n'))
+        Question(args.title, args.text)
     elif args.type == 'error':
-        Error(args.title, args.text.replace('\\n', '\n'))
+        Error(args.title, args.text)

--- a/packaging/linux/openra.appimage.in
+++ b/packaging/linux/openra.appimage.in
@@ -53,15 +53,15 @@ if [ $? != 0 ] && [ $? != 1 ]; then
 	fi
 
 	test -d Support/Logs && LOGS="${PWD}/Support/Logs"
-	ERROR_MESSAGE="{MODNAME} has encountered a fatal error.\nPlease refer to the crash logs and FAQ for more information.\n\nLog files are located in ${LOGS}\nThe FAQ is available at http://wiki.openra.net/FAQ"
+	ERROR_MESSAGE=$(printf "%s has encountered a fatal error.\nPlease refer to the crash logs and FAQ for more information.\n\nLog files are located in %s\nThe FAQ is available at http://wiki.openra.net/FAQ" "{MODNAME}" "${LOGS}")
 	if command -v zenity > /dev/null; then
-		zenity --no-wrap --error --title "{MODNAME}" --text "${ERROR_MESSAGE}" 2> /dev/null
+		zenity --no-wrap --error --title "{MODNAME}" --no-markup --text "${ERROR_MESSAGE}" 2> /dev/null
 	elif command -v kdialog > /dev/null; then
 		kdialog --title "{MODNAME}" --error "${ERROR_MESSAGE}"
 	elif "${HERE}/gtk-dialog.py" test > /dev/null; then
 		"${HERE}/gtk-dialog.py" error --title "{MODNAME}" --text "${ERROR_MESSAGE}" 2> /dev/null
 	else
-		printf "${ERROR_MESSAGE}\n"
+		echo "${ERROR_MESSAGE}"
 	fi
 	exit 1
 fi

--- a/packaging/linux/openra.in
+++ b/packaging/linux/openra.in
@@ -19,13 +19,13 @@ if [ $? != 0 ] && [ $? != 1 ]; then
 	fi
 
 	test -d Support/Logs && LOGS="${PWD}/Support/Logs"
-	ERROR_MESSAGE="{MODNAME} has encountered a fatal error.\nPlease refer to the crash logs and FAQ for more information.\n\nLog files are located in ${LOGS}\nThe FAQ is available at http://wiki.openra.net/FAQ"
+	ERROR_MESSAGE=$(printf "%s has encountered a fatal error.\nPlease refer to the crash logs and FAQ for more information.\n\nLog files are located in %s\nThe FAQ is available at http://wiki.openra.net/FAQ" "{MODNAME}" "${LOGS}")
 	if command -v zenity > /dev/null; then
-		zenity --no-wrap --error --title "{MODNAME}" --text "${ERROR_MESSAGE}" 2> /dev/null
+		zenity --no-wrap --error --title "{MODNAME}" --no-markup --text "${ERROR_MESSAGE}" 2> /dev/null
 	elif command -v kdialog > /dev/null; then
 		kdialog --title "{MODNAME}" --error "${ERROR_MESSAGE}"
 	else
-		printf "${ERROR_MESSAGE}\n"
+		echo "${ERROR_MESSAGE}"
 	fi
 	exit 1
 fi


### PR DESCRIPTION
Error messages are displayed using the following methods:

* **zenity** parses pango markup and replaces escaped characters
* **kdialog** replaces (some) escaped characters
* **gtk-dialog.py** replaces `\n`
* **printf** interprets format strings and replaces escaped characters
* **echo** just displays the text

The error messages themself contain escaped characters and paths from variables.

This PR unifies the behavior by:

* Use **printf** to format error messages and replace escaped characters
* Setting `--no-markup` for **zenity** to disable pango markup and escaped characters
* Remove `\n` replacement from **gtk-dialog.py**.
* Use plain **echo** instead of **printf**