### PR TITLE
Fix RemoveTurnToDock update rule

### DIFF
--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RemoveTurnToDock.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RemoveTurnToDock.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			if (aircraft != null)
 			{
 				var turnToDock = aircraft.LastChildMatching("TurnToDock");
-				if (turnToDock != null || turnToDock.NodeValue<bool>())
+				if (turnToDock == null || !turnToDock.NodeValue<bool>())
 					yield break;
 
 				turningAircraft.Add(Tuple.Create(actorNode.Key, actorNode.Location.Filename));


### PR DESCRIPTION
I have no idea how that got through a full release cycle, didn't come up when the official mods were updated AND didn't come up when I was updating RA2, but it did come up now while I was working on https://github.com/KOYK/OpenRA-Tiberian-Dawn-Apolyton/pull/27 and with a ton of exceptions.