### PR TITLE
Add an option to disable chat in replays

### DIFF
--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Network
 							if (orderManager.LocalClient != null && client != orderManager.LocalClient && client.Team > 0 && client.Team == orderManager.LocalClient.Team)
 								suffix += " (Ally)";
 
-							TextNotificationsManager.AddChatLine(client.Name + suffix, message, client.Color);
+							TextNotificationsManager.AddChatLine(clientId, client.Name + suffix, message, client.Color);
 							break;
 						}
 
@@ -95,7 +95,7 @@ namespace OpenRA.Network
 						{
 							var prefix = order.ExtraData == uint.MaxValue ? "[Spectators] " : "[Team] ";
 							if (orderManager.LocalClient != null && client.Team == orderManager.LocalClient.Team)
-								TextNotificationsManager.AddChatLine(prefix + client.Name, message, client.Color);
+								TextNotificationsManager.AddChatLine(clientId, prefix + client.Name, message, client.Color);
 
 							break;
 						}
@@ -109,7 +109,7 @@ namespace OpenRA.Network
 						{
 							// Validate before adding the line
 							if (client.IsObserver || (player != null && player.WinState != WinState.Undefined))
-								TextNotificationsManager.AddChatLine("[Spectators] " + client.Name, message, client.Color);
+								TextNotificationsManager.AddChatLine(clientId, "[Spectators] " + client.Name, message, client.Color);
 
 							break;
 						}
@@ -119,7 +119,7 @@ namespace OpenRA.Network
 							&& world.LocalPlayer != null && world.LocalPlayer.WinState == WinState.Undefined;
 
 						if (valid && (isSameTeam || world.IsReplay))
-							TextNotificationsManager.AddChatLine("[Team" + (world.IsReplay ? " " + order.ExtraData : "") + "] " + client.Name, message, client.Color);
+							TextNotificationsManager.AddChatLine(clientId, "[Team" + (world.IsReplay ? " " + order.ExtraData : "") + "] " + client.Name, message, client.Color);
 
 						break;
 					}

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -251,6 +251,8 @@ namespace OpenRA
 		public bool UseClassicMouseStyle = false;
 		public bool UseAlternateScrollButton = false;
 
+		public bool HideReplayChat = false;
+
 		public StatusBarsType StatusBars = StatusBarsType.Standard;
 		public TargetLinesType TargetLines = TargetLinesType.Manual;
 		public bool UsePlayerStanceColors = false;

--- a/OpenRA.Game/TextNotification.cs
+++ b/OpenRA.Game/TextNotification.cs
@@ -20,14 +20,16 @@ namespace OpenRA
 	{
 		public readonly TextNotificationPool Pool;
 		public readonly string Prefix;
+		public readonly int ClientId;
 		public readonly string Text;
 		public readonly Color? PrefixColor;
 		public readonly Color? TextColor;
 		public readonly DateTime Time;
 
-		public TextNotification(TextNotificationPool pool, string prefix, string text, Color? prefixColor, Color? textColor)
+		public TextNotification(TextNotificationPool pool, int clientId, string prefix, string text, Color? prefixColor, Color? textColor)
 		{
 			Pool = pool;
+			ClientId = clientId;
 			Prefix = prefix;
 			Text = text;
 			PrefixColor = prefixColor;

--- a/OpenRA.Game/TextNotificationsManager.cs
+++ b/OpenRA.Game/TextNotificationsManager.cs
@@ -16,6 +16,7 @@ namespace OpenRA
 {
 	public static class TextNotificationsManager
 	{
+		public static readonly int SystemClientId = -1;
 		static readonly string SystemMessageLabel;
 
 		public static long ChatDisabledUntil { get; internal set; }
@@ -32,17 +33,17 @@ namespace OpenRA
 				return;
 
 			if (player == null || player == player.World.LocalPlayer)
-				AddTextNotification(TextNotificationPool.Transients, SystemMessageLabel, text);
+				AddTextNotification(TextNotificationPool.Transients, SystemClientId, SystemMessageLabel, text);
 		}
 
 		public static void AddFeedbackLine(string text)
 		{
-			AddTextNotification(TextNotificationPool.Feedback, SystemMessageLabel, text);
+			AddTextNotification(TextNotificationPool.Feedback, SystemClientId, SystemMessageLabel, text);
 		}
 
 		public static void AddMissionLine(string prefix, string text, Color? prefixColor = null)
 		{
-			AddTextNotification(TextNotificationPool.Mission, prefix, text, prefixColor);
+			AddTextNotification(TextNotificationPool.Mission, SystemClientId, prefix, text, prefixColor);
 		}
 
 		public static void AddSystemLine(string text)
@@ -52,12 +53,12 @@ namespace OpenRA
 
 		public static void AddSystemLine(string prefix, string text)
 		{
-			AddTextNotification(TextNotificationPool.System, prefix, text);
+			AddTextNotification(TextNotificationPool.System, SystemClientId, prefix, text);
 		}
 
-		public static void AddChatLine(string prefix, string text, Color? prefixColor = null, Color? textColor = null)
+		public static void AddChatLine(int clientId, string prefix, string text, Color? prefixColor = null, Color? textColor = null)
 		{
-			AddTextNotification(TextNotificationPool.Chat, prefix, text, prefixColor, textColor);
+			AddTextNotification(TextNotificationPool.Chat, clientId, prefix, text, prefixColor, textColor);
 		}
 
 		public static void Debug(string s, params object[] args)
@@ -65,10 +66,10 @@ namespace OpenRA
 			AddSystemLine("Debug", string.Format(s, args));
 		}
 
-		static void AddTextNotification(TextNotificationPool pool, string prefix, string text, Color? prefixColor = null, Color? textColor = null)
+		static void AddTextNotification(TextNotificationPool pool, int clientId, string prefix, string text, Color? prefixColor = null, Color? textColor = null)
 		{
 			if (IsPoolEnabled(pool))
-				Game.OrderManager.AddTextNotification(new TextNotification(pool, prefix, text, prefixColor, textColor));
+				Game.OrderManager.AddTextNotification(new TextNotification(pool, clientId, prefix, text, prefixColor, textColor));
 		}
 
 		static bool IsPoolEnabled(TextNotificationPool pool)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -265,7 +265,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (!IsNotificationEligible(notification))
 				return;
 
-			chatOverlayDisplay?.AddNotification(notification);
+			if (!IsNotificationMuted(notification))
+				chatOverlayDisplay?.AddNotification(notification);
 
 			// HACK: Force disable the chat notification sound for the in-menu chat dialog
 			// This works around our inability to disable the sounds for the in-game dialog when it is hidden
@@ -282,7 +283,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (scrolledToBottom)
 				chatScrollPanel.ScrollToBottom(smooth: true);
 
-			if (!suppressSound)
+			if (!suppressSound && !IsNotificationMuted(notification))
 				Game.Sound.PlayNotification(modRules, null, "Sounds", chatLineSound, null);
 		}
 
@@ -324,6 +325,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			base.Dispose(disposing);
+		}
+
+		bool IsNotificationMuted(TextNotification notification)
+		{
+			return Game.Settings.Game.HideReplayChat && world.IsReplay && notification.ClientId != TextNotificationsManager.SystemClientId;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameTransientNotificationsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameTransientNotificationsLogic.cs
@@ -55,6 +55,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				repetitions++;
 				lineToDisplay = new TextNotification(
 					notification.Pool,
+					notification.ClientId,
 					notification.Prefix,
 					$"{notification.Text} ({repetitions + 1})",
 					notification.PrefixColor,

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -74,6 +74,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (panel.GetOrNull<CheckboxWidget>("PAUSE_SHELLMAP_CHECKBOX") != null)
 				SettingsUtils.BindCheckboxPref(panel, "PAUSE_SHELLMAP_CHECKBOX", gs, "PauseShellmap");
 
+			SettingsUtils.BindCheckboxPref(panel, "HIDE_REPLAY_CHAT_CHECKBOX", gs, "HideReplayChat");
+
 			var windowModeDropdown = panel.Get<DropDownButtonWidget>("MODE_DROPDOWN");
 			windowModeDropdown.OnMouseDown = _ => ShowWindowModeDropdown(windowModeDropdown, ds, scrollPanel);
 			windowModeDropdown.GetText = () => ds.Mode == WindowMode.Windowed ?

--- a/mods/cnc/chrome/settings-display.yaml
+++ b/mods/cnc/chrome/settings-display.yaml
@@ -182,6 +182,19 @@ Container@DISPLAY_PANEL:
 									Height: 20
 									Font: Regular
 									Text: Show Game Event Notifications
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 20
+					Children:
+						Container@HIDE_REPLAY_CHAT_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 10
+							Children:
+								Checkbox@HIDE_REPLAY_CHAT_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Hide Chat in Replays
 				Container@SPACER:
 				Background@SECTION_HEADER:
 					X: 5

--- a/mods/common/chrome/settings-display.yaml
+++ b/mods/common/chrome/settings-display.yaml
@@ -195,6 +195,15 @@ Container@DISPLAY_PANEL:
 									Height: 20
 									Font: Regular
 									Text: Pause Menu Background
+						Container@HIDE_REPLAY_CHAT_CHECKBOX_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 10
+							Children:
+								Checkbox@HIDE_REPLAY_CHAT_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: Hide Chat in Replays
 				Container@SPACER:
 				Background@SECTION_HEADER:
 					X: 5


### PR DESCRIPTION
closes #13182

From all mute options in #20073 I think this is the only one that should be permanent, as in it doesn't change between matches. Muting in live games should be a separate thing and done on per match basis, as IMO that provides the best UX and a clean implementation

This feature will be used by casters or any other person who wants to enjoy a replay without interruptions. 

As for technicalities, I don't know where to place this option. For now I put it next to UI Feedback Notifications