### PR TITLE
Detect Apple Silicon even in Rosetta shells

### DIFF
--- a/configure-system-libraries.sh
+++ b/configure-system-libraries.sh
@@ -56,7 +56,7 @@ patch_config()
 }
 
 if [ "$(uname -s)" = "Darwin" ]; then
-	if [ "$(arch)" = "arm64" ]; then
+	if [ "$(arch)" = "arm64" -o "$(sysctl -in sysctl.proc_translated)" = "1" ]; then
 		SEARCHDIRS="/opt/homebrew/lib /opt/homebrew/opt/openal-soft/lib"
 	else
 		SEARCHDIRS="/usr/local/lib /usr/local/opt/openal-soft/lib"


### PR DESCRIPTION
In a shell running in Rosetta on an Apple Silicon Mac, `arch` and `uname -p` both return `i386`, and `uname -m` returns `x86_64`. This fixes `configure-system-libraries.sh` to detect if it is running in Rosetta on ARM hardware.