### PR TITLE
[Superseded] Added try/catch to CheckRevealFootprint

### DIFF
--- a/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
+++ b/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
@@ -32,16 +32,23 @@ namespace OpenRA.Mods.Common.Lint
 		{
 			foreach (var actorInfo in rules.Actors)
 			{
-				var ios = actorInfo.Value.TraitInfoOrDefault<IOccupySpaceInfo>();
-				foreach (var rsi in actorInfo.Value.TraitInfos<RevealsShroudInfo>())
+				try
 				{
-					if (rsi.Type != VisibilityType.Footprint)
-						continue;
+					var ios = actorInfo.Value.TraitInfoOrDefault<IOccupySpaceInfo>();
+					foreach (var rsi in actorInfo.Value.TraitInfos<RevealsShroudInfo>())
+					{
+						if (rsi.Type != VisibilityType.Footprint)
+							continue;
 
-					if (ios == null)
-						emitError($"Actor type `{actorInfo.Key}` defines VisibilityType.Footprint in `{rsi.GetType()}` but has no IOccupySpace traits!");
-					else if (ios.OccupiedCells(actorInfo.Value, CPos.Zero).Count == 0)
-						emitError($"Actor type `{actorInfo.Key}` defines VisibilityType.Footprint in `{rsi.GetType()}`  but does not have any footprint cells!");
+						if (ios == null)
+							emitError($"Actor type `{actorInfo.Key}` defines VisibilityType.Footprint in `{rsi.GetType()}` but has no IOccupySpace traits!");
+						else if (ios.OccupiedCells(actorInfo.Value, CPos.Zero).Count == 0)
+							emitError($"Actor type `{actorInfo.Key}` defines VisibilityType.Footprint in `{rsi.GetType()}` but does not have any footprint cells!");
+					}
+				}
+				catch (Exception e)
+				{
+					emitError($"Actor type `{actorInfo.Key}` caused an exception: {e}");
 				}
 			}
 		}


### PR DESCRIPTION
Exceptions like "OpenRA.Utility(1,1): Error: OpenRA.Mods.Common.Lint.CheckDefaultVisibility failed with exception: System.InvalidOperationException: TypeDictionary contains multiple instances of type OpenRA.Traits.IOccupySpaceInfo" are very hard to diagnose, so we'd like to have the actor name to help.

P.S.: Best seen without the whitespace changes: https://github.com/OpenRA/OpenRA/pull/20080/files?w=1