### PR TITLE
Refactor checkbox

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoObjectivesLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoObjectivesLogic.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				var checkbox = widget.Get<CheckboxWidget>("OBJECTIVE_STATUS");
 				checkbox.IsChecked = () => objective.State != ObjectiveState.Incomplete;
-				checkbox.GetCheckType = () => objective.State == ObjectiveState.Completed ? "checked" : "crossed";
+				checkbox.GetCheckmark = () => objective.State == ObjectiveState.Completed ? "tick" : "cross";
 				checkbox.GetText = () => objective.Description;
 
 				parent.AddChild(widget);

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -34,8 +34,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var statusLabel = widget.Get<LabelWidget>("STATS_STATUS");
 
 				checkbox.IsChecked = () => player.WinState != WinState.Undefined;
-				checkbox.GetCheckType = () => player.WinState == WinState.Won ?
-					"checked" : "crossed";
+				checkbox.GetCheckmark = () => player.WinState == WinState.Won ? "tick" : "cross";
 
 				if (player.HasObjectives)
 				{

--- a/mods/cnc/chrome.yaml
+++ b/mods/cnc/chrome.yaml
@@ -394,13 +394,29 @@ reload-icon:
 		disabled-10: 955, 34, 16, 16
 		disabled-11: 972, 34, 16, 16
 
-checkbox-bits:
+checkmark-tick:
 	Inherits: ^Chrome
 	Regions:
 		checked: 972, 17, 16, 16
+		checked-pressed: 989, 17, 16, 16
 		checked-disabled: 989, 17, 16, 16
-		crossed: 972, 0, 16, 16
-		crossed-disabled: 989, 0, 16, 16
+		unchecked: 0, 0, 0, 0
+		unchecked-pressed: 989, 17, 16, 16
+
+checkmark-highlighted-tick:
+	Inherits: checkmark-tick
+
+checkmark-cross:
+	Inherits: ^Chrome
+	Regions:
+		checked: 972, 0, 16, 16
+		checked-pressed: 989, 0, 16, 16
+		checked-disabled: 989, 0, 16, 16
+		unchecked: 0, 0, 0, 0
+		unchecked-pressed: 989, 0, 16, 16
+
+checkmark-highlighted-cross:
+	Inherits: checkmark-cross
 
 flags:
 	Inherits: ^Chrome

--- a/mods/cnc/chrome/lobby-players.yaml
+++ b/mods/cnc/chrome/lobby-players.yaml
@@ -166,7 +166,7 @@ Container@LOBBY_PLAYER_BIN:
 							Y: 4
 							Width: 20
 							Height: 20
-							ImageCollection: checkbox-bits
+							ImageCollection: checkmark-tick
 							ImageName: checked
 							Visible: false
 						Checkbox@STATUS_CHECKBOX:
@@ -294,7 +294,7 @@ Container@LOBBY_PLAYER_BIN:
 							Y: 4
 							Width: 20
 							Height: 20
-							ImageCollection: checkbox-bits
+							ImageCollection: checkmark-tick
 							ImageName: checked
 							Visible: false
 				Container@TEMPLATE_EMPTY:
@@ -376,7 +376,7 @@ Container@LOBBY_PLAYER_BIN:
 							Y: 4
 							Width: 20
 							Height: 20
-							ImageCollection: checkbox-bits
+							ImageCollection: checkmark-tick
 							ImageName: checked
 							Visible: false
 						Checkbox@STATUS_CHECKBOX:
@@ -457,7 +457,7 @@ Container@LOBBY_PLAYER_BIN:
 							Y: 4
 							Width: 20
 							Height: 20
-							ImageCollection: checkbox-bits
+							ImageCollection: checkmark-tick
 							ImageName: checked
 							Visible: false
 				Container@TEMPLATE_NEW_SPECTATOR:

--- a/mods/cnc/metrics.yaml
+++ b/mods/cnc/metrics.yaml
@@ -3,5 +3,4 @@
 Metrics:
 	ButtonDepth: 0
 	ButtonFont: Bold
-	CheckboxPressedState: true
 	TextfieldColorHighlight: 800000

--- a/mods/common/chrome/lobby-players.yaml
+++ b/mods/common/chrome/lobby-players.yaml
@@ -168,7 +168,7 @@ Container@LOBBY_PLAYER_BIN:
 							Y: 4
 							Width: 20
 							Height: 20
-							ImageCollection: checkbox-bits
+							ImageCollection: checkmark-tick
 							ImageName: checked
 							Visible: false
 				Container@TEMPLATE_NONEDITABLE_PLAYER:
@@ -288,7 +288,7 @@ Container@LOBBY_PLAYER_BIN:
 							Y: 4
 							Width: 20
 							Height: 20
-							ImageCollection: checkbox-bits
+							ImageCollection: checkmark-tick
 							ImageName: checked
 							Visible: false
 				Container@TEMPLATE_EMPTY:
@@ -373,7 +373,7 @@ Container@LOBBY_PLAYER_BIN:
 							Y: 4
 							Width: 20
 							Height: 20
-							ImageCollection: checkbox-bits
+							ImageCollection: checkmark-tick
 							ImageName: checked
 							Visible: false
 				Container@TEMPLATE_NONEDITABLE_SPECTATOR:
@@ -448,7 +448,7 @@ Container@LOBBY_PLAYER_BIN:
 							Y: 4
 							Width: 20
 							Height: 20
-							ImageCollection: checkbox-bits
+							ImageCollection: checkmark-tick
 							ImageName: checked
 							Visible: false
 				Container@TEMPLATE_NEW_SPECTATOR:

--- a/mods/common/metrics.yaml
+++ b/mods/common/metrics.yaml
@@ -8,7 +8,6 @@ Metrics:
 	ButtonTextContrastColorLight: 7F7F7F
 	ButtonTextContrastRadius: 1
 	ButtonTextShadow: false
-	CheckboxPressedState: false
 	GameStartedColor: FFA500
 	HotkeyColor: FFFFFF
 	HotkeyColorDisabled: 808080

--- a/mods/d2k/chrome.yaml
+++ b/mods/d2k/chrome.yaml
@@ -373,17 +373,34 @@ slider-thumb-disabled:
 checkbox:
 	Inherits: button-pressed
 
-checkbox-bits:
+checkmark-tick:
 	Inherits: ^Glyphs
 	Regions:
 		checked: 187, 0, 16, 16
-		checked-disabled: 204, 0, 16, 16
-		crossed: 221, 0, 16, 16
-		crossed-disabled: 238, 0, 16, 16
+		checked-pressed: 204, 0, 16, 16
+		unchecked: 0, 0, 0, 0
+		unchecked-pressed: 204, 0, 16, 16
+
+checkmark-highlighted-tick:
+	Inherits: checkmark-tick
+
+checkmark-cross:
+	Inherits: ^Glyphs
+	Regions:
+		checked: 221, 0, 16, 16
+		checked-pressed: 238, 0, 16, 16
+		unchecked: 0, 0, 0, 0
+		unchecked-pressed: 238, 0, 16, 16
+
+checkmark-highlighted-cross:
+	Inherits: checkmark-cross
 
 checkbox-hover:
 	Inherits: ^Dialog
 	PanelRegion: 641, 129, 2, 2, 122, 122, 2, 2
+
+checkbox-pressed:
+	Inherits: checkbox-hover
 
 # Same as a button-disabled-pressed
 checkbox-disabled:
@@ -394,6 +411,9 @@ checkbox-highlighted:
 	Inherits: button-highlighted-pressed
 
 checkbox-highlighted-hover:
+	Inherits: checkbox-highlighted
+
+checkbox-highlighted-pressed:
 	Inherits: checkbox-highlighted
 
 checkbox-highlighted-disabled:

--- a/mods/d2k/chrome/lobby-players.yaml
+++ b/mods/d2k/chrome/lobby-players.yaml
@@ -168,7 +168,7 @@ Container@LOBBY_PLAYER_BIN:
 							Y: 4
 							Width: 20
 							Height: 20
-							ImageCollection: checkbox-bits
+							ImageCollection: checkmark-tick
 							ImageName: checked
 							Visible: false
 				Container@TEMPLATE_NONEDITABLE_PLAYER:
@@ -288,7 +288,7 @@ Container@LOBBY_PLAYER_BIN:
 							Y: 4
 							Width: 20
 							Height: 20
-							ImageCollection: checkbox-bits
+							ImageCollection: checkmark-tick
 							ImageName: checked
 							Visible: false
 				Container@TEMPLATE_EMPTY:
@@ -373,7 +373,7 @@ Container@LOBBY_PLAYER_BIN:
 							Y: 4
 							Width: 20
 							Height: 20
-							ImageCollection: checkbox-bits
+							ImageCollection: checkmark-tick
 							ImageName: checked
 							Visible: false
 				Container@TEMPLATE_NONEDITABLE_SPECTATOR:
@@ -448,7 +448,7 @@ Container@LOBBY_PLAYER_BIN:
 							Y: 4
 							Width: 20
 							Height: 20
-							ImageCollection: checkbox-bits
+							ImageCollection: checkmark-tick
 							ImageName: checked
 							Visible: false
 				Container@TEMPLATE_NEW_SPECTATOR:

--- a/mods/modcontent/metrics.yaml
+++ b/mods/modcontent/metrics.yaml
@@ -3,7 +3,6 @@
 Metrics:
 	ButtonDepth: 0
 	ButtonFont: Bold
-	CheckboxPressedState: true
 	ChatLineSound: ChatLine
 	ClickDisabledSound: ClickDisabledSound
 	ClickSound: ClickSound

--- a/mods/ra/chrome.yaml
+++ b/mods/ra/chrome.yaml
@@ -502,17 +502,34 @@ slider-thumb-disabled:
 checkbox:
 	Inherits: button-pressed
 
-checkbox-bits:
+checkmark-tick:
 	Inherits: ^Glyphs
 	Regions:
 		checked: 187, 0, 16, 16
-		checked-disabled: 204, 0, 16, 16
-		crossed: 221, 0, 16, 16
-		crossed-disabled: 238, 0, 16, 16
+		checked-pressed: 204, 0, 16, 16
+		unchecked: 0, 0, 0, 0
+		unchecked-pressed: 204, 0, 16, 16
+
+checkmark-highlighted-tick:
+	Inherits: checkmark-tick
+
+checkmark-cross:
+	Inherits: ^Glyphs
+	Regions:
+		checked: 221, 0, 16, 16
+		checked-pressed: 238, 0, 16, 16
+		unchecked: 0, 0, 0, 0
+		unchecked-pressed: 238, 0, 16, 16
+
+checkmark-highlighted-cross:
+	Inherits: checkmark-cross
 
 checkbox-hover:
 	Inherits: ^Dialog
 	PanelRegion: 641, 129, 2, 2, 122, 122, 2, 2
+
+checkbox-pressed:
+	Inherits: checkbox-hover
 
 checkbox-disabled:
 	Inherits: ^Dialog
@@ -523,6 +540,9 @@ checkbox-highlighted:
 	PanelRegion: 897, 1, 2, 2, 122, 122, 2, 2
 
 checkbox-highlighted-hover:
+	Inherits: checkbox-highlighted
+
+checkbox-highlighted-pressed:
 	Inherits: checkbox-highlighted
 
 checkbox-highlighted-disabled:

--- a/mods/ts/chrome.yaml
+++ b/mods/ts/chrome.yaml
@@ -635,17 +635,34 @@ slider-thumb-disabled:
 checkbox:
 	Inherits: button-pressed
 
-checkbox-bits:
+checkmark-tick:
 	Inherits: ^Glyphs
 	Regions:
 		checked: 187, 0, 16, 16
-		checked-disabled: 204, 0, 16, 16
-		crossed: 221, 0, 16, 16
-		crossed-disabled: 238, 0, 16, 16
+		checked-pressed: 204, 0, 16, 16
+		unchecked: 0, 0, 0, 0
+		unchecked-pressed: 204, 0, 16, 16
+
+checkmark-highlighted-tick:
+	Inherits: checkmark-tick
+
+checkmark-cross:
+	Inherits: ^Glyphs
+	Regions:
+		checked: 221, 0, 16, 16
+		checked-pressed: 238, 0, 16, 16
+		unchecked: 0, 0, 0, 0
+		unchecked-pressed: 238, 0, 16, 16
+
+checkmark-highlighted-cross:
+	Inherits: checkmark-cross
 
 checkbox-hover:
 	Inherits: ^Dialog
 	PanelRegion: 641, 129, 2, 2, 122, 122, 2, 2
+
+checkbox-pressed:
+	Inherits: checkbox-hover
 
 checkbox-disabled:
 	Inherits: ^Dialog
@@ -656,6 +673,9 @@ checkbox-highlighted:
 	PanelRegion: 897, 1, 2, 2, 122, 122, 2, 2
 
 checkbox-highlighted-hover:
+	Inherits: checkbox-highlighted
+
+checkbox-highlighted-pressed:
 	Inherits: checkbox-highlighted
 
 checkbox-highlighted-disabled:


### PR DESCRIPTION
The goal of this pr is first and foremost to make checkbox widget more customisable

I add the ability to
- define checkbox background (or remove it)
- define checkmark image when it is checked / unchecked
- define checkmark image for all states supported by `WidgetUtils.GetCachedStatefulImage`

This PR also greatly improves the quality of the checkbox code as well as clarity of yaml