### PR TITLE
Report proper errors instead of NREs during trait and weapon linting

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -139,7 +139,11 @@ namespace OpenRA.GameRules
 		{
 			if (!yaml.ToDictionary().TryGetValue("Projectile", out var proj))
 				return null;
+
 			var ret = Game.CreateObject<IProjectileInfo>(proj.Value + "Info");
+			if (ret == null)
+				return null;
+
 			FieldLoader.Load(ret, proj);
 			return ret;
 		}
@@ -150,6 +154,9 @@ namespace OpenRA.GameRules
 			foreach (var node in yaml.Nodes.Where(n => n.Key.StartsWith("Warhead")))
 			{
 				var ret = Game.CreateObject<IWarhead>(node.Value.Value + "Warhead");
+				if (ret == null)
+					continue;
+
 				FieldLoader.Load(ret, node.Value);
 				retList.Add(ret);
 			}

--- a/OpenRA.Mods.Common/Lint/CheckUnknownTraitFields.cs
+++ b/OpenRA.Mods.Common/Lint/CheckUnknownTraitFields.cs
@@ -71,6 +71,12 @@ namespace OpenRA.Mods.Common.Lint
 					}
 
 					var traitInfo = modData.ObjectCreator.FindType(traitName + "Info");
+					if (traitInfo == null)
+					{
+						emitError($"{t.Location} defines unknown trait `{traitName}`.");
+						continue;
+					}
+
 					foreach (var field in t.Value.Nodes)
 					{
 						var fieldName = NormalizeName(field.Key);

--- a/OpenRA.Mods.Common/Lint/CheckUnknownTraitFields.cs
+++ b/OpenRA.Mods.Common/Lint/CheckUnknownTraitFields.cs
@@ -64,9 +64,11 @@ namespace OpenRA.Mods.Common.Lint
 					var traitName = NormalizeName(t.Key);
 
 					// Inherits can never define children
-					if (traitName == "Inherits" && t.Value.Nodes.Count > 0)
+					if (traitName == "Inherits")
 					{
-						emitError($"{t.Location} defines child nodes, which are not valid for Inherits.");
+						if (t.Value.Nodes.Count > 0)
+							emitError($"{t.Location} defines child nodes, which are not valid for Inherits.");
+
 						continue;
 					}
 

--- a/OpenRA.Mods.Common/Lint/CheckUnknownWeaponFields.cs
+++ b/OpenRA.Mods.Common/Lint/CheckUnknownWeaponFields.cs
@@ -68,6 +68,12 @@ namespace OpenRA.Mods.Common.Lint
 					{
 						var projectileName = NormalizeName(field.Value.Value);
 						var projectileInfo = modData.ObjectCreator.FindType(projectileName + "Info");
+						if (projectileInfo == null)
+						{
+							emitError($"{field.Location} defines unknown projectile `{projectileName}`.");
+							continue;
+						}
+
 						foreach (var projectileField in field.Value.Nodes)
 						{
 							var projectileFieldName = NormalizeName(projectileField.Key);
@@ -85,6 +91,12 @@ namespace OpenRA.Mods.Common.Lint
 
 						var warheadName = NormalizeName(field.Value.Value);
 						var warheadInfo = modData.ObjectCreator.FindType(warheadName + "Warhead");
+						if (warheadInfo == null)
+						{
+							emitError($"{field.Location} defines unknown warhead `{warheadName}`.");
+							continue;
+						}
+
 						foreach (var warheadField in field.Value.Nodes)
 						{
 							var warheadFieldName = NormalizeName(warheadField.Key);


### PR DESCRIPTION
Inspired by #20080. Both `Game.CreateObject` and `modData.ObjectCreator.FindType` return `null` when given an unknown type. That leads to walls of errors like:
<details>

```
OpenRA.Utility(1,1): Error: Missing Type: AsdInfo
OpenRA.Utility(1,1): Error: Missing Type: LeaveSmudgesWarhead
OpenRA.Utility(1,1): Error: Missing Type: BulletsInfo
[...]
OpenRA.Utility(1,1): Error: OpenRA.Mods.Common.Lint.CheckUnknownTraitFields failed with exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at OpenRA.Mods.Common.Lint.CheckUnknownTraitFields.CheckActors(IEnumerable`1 actors, Action`1 emitError, ModData modData) in \OpenRA\OpenRA.Mods.Common\Lint\CheckUnknownTraitFields.cs:line 77
   at OpenRA.Mods.Common.Lint.CheckUnknownTraitFields.OpenRA.Mods.Common.Lint.ILintPass.Run(Action`1 emitError, Action`1 emitWarning, ModData modData) in \OpenRA\OpenRA.Mods.Common\Lint\CheckUnknownTraitFields.cs:line 24
   at OpenRA.Mods.Common.UtilityCommands.CheckYaml.OpenRA.IUtilityCommand.Run(Utility utility, String[] args) in \OpenRA\OpenRA.Mods.Common\UtilityCommands\CheckYaml.cs:line 72
[...]
OpenRA.Utility(1,1): Error: Failed with exception: System.AggregateException: One or more errors occurred. (Object reference not set to an instance of an object.)
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at OpenRA.FieldLoader.Load(Object self, MiniYaml my) in \OpenRA\OpenRA.Game\FieldLoader.cs:line 533
   at OpenRA.GameRules.WeaponInfo.LoadProjectile(MiniYaml yaml) in \OpenRA\OpenRA.Game\GameRules\WeaponInfo.cs:line 143
   at OpenRA.FieldLoader.Load(Object self, MiniYaml my) in \OpenRA\OpenRA.Game\FieldLoader.cs:line 547
   at OpenRA.GameRules.WeaponInfo..ctor(MiniYaml content) in \OpenRA\OpenRA.Game\GameRules\WeaponInfo.cs:line 135
   at OpenRA.Ruleset.<>c.<LoadDefaults>b__12_3(MiniYamlNode k) in \OpenRA\OpenRA.Game\GameRules\Ruleset.cs:line 134
   at OpenRA.Exts.ToDictionaryWithConflictLog[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, String debugName, Func`2 logKey, Func`2 logValue) in \OpenRA\OpenRA.Game\Exts.cs:line 415
   at OpenRA.Ruleset.MergeOrDefault[T](String name, IReadOnlyFileSystem fileSystem, IEnumerable`1 files, MiniYaml additional, IReadOnlyDictionary`2 defaults, Func`2 makeObject, Func`2 filterNode) in \OpenRA\OpenRA.Game\GameRules\Ruleset.cs:line 118
   at OpenRA.Ruleset.<>c__DisplayClass12_0.<LoadDefaults>b__0() in \OpenRA\OpenRA.Game\GameRules\Ruleset.cs:line 133
   at System.Threading.Tasks.Task.InnerInvoke()
   at System.Threading.Tasks.Task.<>c.<.cctor>b__272_0(Object obj)
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout)
   at OpenRA.Ruleset.LoadDefaults(ModData modData) in \OpenRA\OpenRA.Game\GameRules\Ruleset.cs:line 160
   at OpenRA.ModData.<.ctor>b__32_2() in \OpenRA\OpenRA.Game\ModData.cs:line 110
   at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)
   at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication, Boolean useDefaultConstructor)
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.get_Value()
   at OpenRA.ModData.get_DefaultRules() in \OpenRA\OpenRA.Game\ModData.cs:line 46
   at OpenRA.Mods.Common.UtilityCommands.CheckYaml.OpenRA.IUtilityCommand.Run(Utility utility, String[] args) in \OpenRA\OpenRA.Mods.Common\UtilityCommands\CheckYaml.cs:line 64
[...]
OpenRA.Utility(1,1): Error: Failed with exception: System.AggregateException: One or more errors occurred. (Object reference not set to an instance of an object.)
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at OpenRA.FieldLoader.Load(Object self, MiniYaml my) in \OpenRA\OpenRA.Game\FieldLoader.cs:line 533
   at OpenRA.GameRules.WeaponInfo.LoadWarheads(MiniYaml yaml) in \OpenRA\OpenRA.Game\GameRules\WeaponInfo.cs:line 153
   at OpenRA.FieldLoader.Load(Object self, MiniYaml my) in \OpenRA\OpenRA.Game\FieldLoader.cs:line 547
   at OpenRA.GameRules.WeaponInfo..ctor(MiniYaml content) in \OpenRA\OpenRA.Game\GameRules\WeaponInfo.cs:line 135
   at OpenRA.Ruleset.<>c.<LoadDefaults>b__12_3(MiniYamlNode k) in \OpenRA\OpenRA.Game\GameRules\Ruleset.cs:line 134
   at OpenRA.Exts.ToDictionaryWithConflictLog[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, String debugName, Func`2 logKey, Func`2 logValue) in \OpenRA\OpenRA.Game\Exts.cs:line 415
   at OpenRA.Ruleset.MergeOrDefault[T](String name, IReadOnlyFileSystem fileSystem, IEnumerable`1 files, MiniYaml additional, IReadOnlyDictionary`2 defaults, Func`2 makeObject, Func`2 filterNode) in \OpenRA\OpenRA.Game\GameRules\Ruleset.cs:line 118
   at OpenRA.Ruleset.<>c__DisplayClass12_0.<LoadDefaults>b__0() in \OpenRA\OpenRA.Game\GameRules\Ruleset.cs:line 133
   at System.Threading.Tasks.Task.InnerInvoke()
   at System.Threading.Tasks.Task.<>c.<.cctor>b__272_0(Object obj)
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout)
   at OpenRA.Ruleset.LoadDefaults(ModData modData) in \OpenRA\OpenRA.Game\GameRules\Ruleset.cs:line 160
   at OpenRA.ModData.<.ctor>b__32_2() in \OpenRA\OpenRA.Game\ModData.cs:line 110
   at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)
   at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication, Boolean useDefaultConstructor)
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.get_Value()
   at OpenRA.ModData.get_DefaultRules() in \OpenRA\OpenRA.Game\ModData.cs:line 46
   at OpenRA.Mods.Common.UtilityCommands.CheckYaml.OpenRA.IUtilityCommand.Run(Utility utility, String[] args) in \OpenRA\OpenRA.Mods.Common\UtilityCommands\CheckYaml.cs:line 64
```
</details>

Now just the location is provided without a huge stacktrace (since we don't crash in the first place):
```
Testing mod: Red Alert
OpenRA.Utility(1,1): Error: Missing Type: AsdInfo
OpenRA.Utility(1,1): Error: Missing Type: LeaveSmudgesWarhead
OpenRA.Utility(1,1): Error: Missing Type: BulletsInfo
[...]
OpenRA.Utility(1,1): Error: ra|rules/infantry.yaml:70 defines unknown trait `Asd`.
OpenRA.Utility(1,1): Error: ra|weapons/ballistics.yaml:20 defines unknown warhead `LeaveSmudges`.
OpenRA.Utility(1,1): Error: ra|weapons/ballistics.yaml:38 defines unknown projectile `Bullets`.
[...]
```

Testcases included as extra commit.
