### PR TITLE
Fix the desync related to owner changes

### DIFF
--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -118,8 +118,10 @@ namespace OpenRA
 							{
 								case TargetType.Actor:
 								{
-									if (world != null && TryGetActorFromUInt(world, r.ReadUInt32(), out var targetActor))
-										target = Target.FromActor(targetActor);
+									var actorID = r.ReadUInt32();
+									var actorGeneration = r.ReadInt32();
+									if (world != null && TryGetActorFromUInt(world, actorID, out var targetActor))
+										target = Target.FromSerializedActor(targetActor, actorGeneration);
 
 									break;
 								}
@@ -367,6 +369,7 @@ namespace OpenRA
 						{
 							case TargetType.Actor:
 								w.Write(UIntFromActor(Target.SerializableActor));
+								w.Write(Target.SerializableGeneration);
 								break;
 							case TargetType.FrozenActor:
 								w.Write(Target.FrozenActor.Viewer.PlayerActor.ActorID);

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -117,47 +117,48 @@ namespace OpenRA
 							switch ((TargetType)r.ReadByte())
 							{
 								case TargetType.Actor:
-									{
-										if (world != null && TryGetActorFromUInt(world, r.ReadUInt32(), out var targetActor))
-											target = Target.FromActor(targetActor);
-										break;
-									}
+								{
+									if (world != null && TryGetActorFromUInt(world, r.ReadUInt32(), out var targetActor))
+										target = Target.FromActor(targetActor);
+
+									break;
+								}
 
 								case TargetType.FrozenActor:
-									{
-										var playerActorID = r.ReadUInt32();
-										var frozenActorID = r.ReadUInt32();
+								{
+									var playerActorID = r.ReadUInt32();
+									var frozenActorID = r.ReadUInt32();
 
-										if (world == null || !TryGetActorFromUInt(world, playerActorID, out var playerActor))
-											break;
-
-										if (playerActor.Owner.FrozenActorLayer == null)
-											break;
-
-										var frozen = playerActor.Owner.FrozenActorLayer.FromID(frozenActorID);
-										if (frozen != null)
-											target = Target.FromFrozenActor(frozen);
-
+									if (world == null || !TryGetActorFromUInt(world, playerActorID, out var playerActor))
 										break;
-									}
+
+									if (playerActor.Owner.FrozenActorLayer == null)
+										break;
+
+									var frozen = playerActor.Owner.FrozenActorLayer.FromID(frozenActorID);
+									if (frozen != null)
+										target = Target.FromFrozenActor(frozen);
+
+									break;
+								}
 
 								case TargetType.Terrain:
+								{
+									if (flags.HasField(OrderFields.TargetIsCell))
 									{
-										if (flags.HasField(OrderFields.TargetIsCell))
-										{
-											var cell = new CPos(r.ReadInt32());
-											var subCell = (SubCell)r.ReadByte();
-											if (world != null)
-												target = Target.FromCell(world, cell, subCell);
-										}
-										else
-										{
-											var pos = new WPos(r.ReadInt32(), r.ReadInt32(), r.ReadInt32());
-											target = Target.FromPos(pos);
-										}
-
-										break;
+										var cell = new CPos(r.ReadInt32());
+										var subCell = (SubCell)r.ReadByte();
+										if (world != null)
+											target = Target.FromCell(world, cell, subCell);
 									}
+									else
+									{
+										var pos = new WPos(r.ReadInt32(), r.ReadInt32(), r.ReadInt32());
+										target = Target.FromPos(pos);
+									}
+
+									break;
+								}
 							}
 						}
 

--- a/OpenRA.Game/Server/ProtocolVersion.cs
+++ b/OpenRA.Game/Server/ProtocolVersion.cs
@@ -77,6 +77,6 @@ namespace OpenRA.Server
 		// The protocol for server and world orders
 		// This applies after the handshake has completed, and is provided to support
 		// alternative server implementations that wish to support multiple versions in parallel
-		public const int Orders = 19;
+		public const int Orders = 20;
 	}
 }

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -56,11 +56,11 @@ namespace OpenRA.Traits
 			generation = 0;
 		}
 
-		Target(Actor a)
+		Target(Actor a, int generation)
 		{
 			type = TargetType.Actor;
 			actor = a;
-			generation = a.Generation;
+			this.generation = generation;
 
 			terrainCenterPosition = WPos.Zero;
 			terrainPositions = null;
@@ -85,7 +85,7 @@ namespace OpenRA.Traits
 		public static Target FromPos(WPos p) { return new Target(p); }
 		public static Target FromTargetPositions(in Target t) { return new Target(t.CenterPosition, t.Positions.ToArray()); }
 		public static Target FromCell(World w, CPos c, SubCell subCell = SubCell.FullCell) { return new Target(w, c, subCell); }
-		public static Target FromActor(Actor a) { return a != null ? new Target(a) : Invalid; }
+		public static Target FromActor(Actor a) { return a != null ? new Target(a, a.Generation) : Invalid; }
 		public static Target FromFrozenActor(FrozenActor fa) { return new Target(fa); }
 
 		public Actor Actor => actor;
@@ -225,8 +225,10 @@ namespace OpenRA.Traits
 		}
 
 		// Expose internal state for serialization by the orders code *only*
+		internal static Target FromSerializedActor(Actor a, int generation) { return a != null ? new Target(a, generation) : Invalid; }
 		internal TargetType SerializableType => type;
 		internal Actor SerializableActor => actor;
+		internal int SerializableGeneration => generation;
 		internal CPos? SerializableCell => cell;
 		internal SubCell? SerializableSubCell => subCell;
 		internal WPos SerializablePos => terrainCenterPosition;


### PR DESCRIPTION
Closes #19930.

"[Serialize the actor generation for network orders](https://github.com/OpenRA/OpenRA/pull/20084/commits/b961b700ae214f9a08002836da8d80fd58be0b8b)" is the commit with the relevant changes.

Explanation:
`Target` has an internal `type` field, which is used for order serialization (via `Target.SerializableType`). This field is readonly which means a target of type `Actor` always has that `SerializableType` locked in as `TargetType.Actor`. `Target.Type` however is not locked, and does not necessarily return the readonly `type`. For example, when the actor generation is changed, `TargetType.Invalid` is returned no matter what `type` is.
We did not serialize (and deserialize) the actor generation and thus did not send it over the network with the orders. Since our network changes, orders are no longer serialized and deserialized for the client issuing them.
That means that an order can be send with a target that is or becomes invalid for the local client (due to the generation changing), but remains valid for other receiving clients (since they do not know about the generation change). Obviously having one client with an invalid target while the other one(s) have a valid target does not play well with syncing.

If this fix is not enough, we can always fall back to just serializing and deserializing local orders again.

Removing `SerializableType` and the likes is an idea for a follow-up, but not needed for this fix.

Testcase:
Included in a separate commit which adds `ChangeOwnerWarhead`s. I usually start an 8 AI game with two teams on max speed and max starting units with two spectating clients. Without the fix it usually desyncs within at least 5 minutes.
