### PR TITLE
Disallow starting a game without players

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -34,6 +34,9 @@ namespace OpenRA.Mods.Common.Server
 		static readonly string NoStartUntilRequiredSlotsFull = "no-start-until-required-slots-full";
 
 		[TranslationReference]
+		static readonly string NoStartWithoutPlayers = "no-start-without-players";
+
+		[TranslationReference]
 		static readonly string TwoHumansRequired = "two-humans-required";
 
 		[TranslationReference]
@@ -252,6 +255,10 @@ namespace OpenRA.Mods.Common.Server
 				if (server.LobbyInfo.Slots.Any(sl => sl.Value.Required && server.LobbyInfo.ClientInSlot(sl.Key) == null))
 					return;
 
+				// Don't start without any players
+				if (server.LobbyInfo.Slots.All(sl => server.LobbyInfo.ClientInSlot(sl.Key) == null))
+					return;
+
 				if (LobbyUtils.InsufficientEnabledSpawnPoints(server.Map, server.LobbyInfo))
 					return;
 
@@ -293,6 +300,12 @@ namespace OpenRA.Mods.Common.Server
 				if (server.LobbyInfo.Slots.Any(sl => sl.Value.Required && server.LobbyInfo.ClientInSlot(sl.Key) == null))
 				{
 					server.SendLocalizedMessageTo(conn, NoStartUntilRequiredSlotsFull);
+					return true;
+				}
+
+				if (server.LobbyInfo.Slots.All(sl => server.LobbyInfo.ClientInSlot(sl.Key) == null))
+				{
+					server.SendOrderTo(conn, "Message", NoStartWithoutPlayers);
 					return true;
 				}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -383,6 +383,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				startGameButton.IsDisabled = () => configurationDisabled() || map.Status != MapStatus.Available ||
 					orderManager.LobbyInfo.Slots.Any(sl => sl.Value.Required && orderManager.LobbyInfo.ClientInSlot(sl.Key) == null) ||
+					orderManager.LobbyInfo.Slots.All(sl => orderManager.LobbyInfo.ClientInSlot(sl.Key) == null) ||
 					(!orderManager.LobbyInfo.GlobalSettings.EnableSingleplayer && orderManager.LobbyInfo.NonBotPlayers.Count() < 2) ||
 					insufficientPlayerSpawns;
 

--- a/mods/common/languages/en.ftl
+++ b/mods/common/languages/en.ftl
@@ -6,6 +6,7 @@ two-humans-required = This server requires at least two human players to start a
 unknown-server-command = Unknown server command: { $command }
 only-only-host-start-game = Only the host can start the game.
 no-start-until-required-slots-full = Unable to start the game until required slots are full.
+no-start-without-players = Unable to start the game with no players.
 insufficient-enabled-spawnPoints = Unable to start the game until more spawn points are enabled.
 malformed-command = Malformed { $command } command
 chat-disabled =


### PR DESCRIPTION
This prevents people from starting a game without any human player or bot, but just spectators. Solves the problem denoted in https://github.com/OpenRA/OpenRA/issues/14580#issuecomment-355203188.