### PR TITLE
PathSearch, make TargetPredicate a readonly private field.

### DIFF
--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		public IPathGraph Graph { get; }
 		readonly Func<CPos, int> heuristic;
 		readonly int heuristicWeightPercentage;
-		public Func<CPos, bool> TargetPredicate { get; set; }
+		readonly Func<CPos, bool> targetPredicate;
 		readonly IPriorityQueue<GraphConnection> openQueue;
 
 		/// <summary>
@@ -137,7 +137,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			Graph = graph;
 			this.heuristic = heuristic;
 			this.heuristicWeightPercentage = heuristicWeightPercentage;
-			TargetPredicate = targetPredicate;
+			this.targetPredicate = targetPredicate;
 			openQueue = new PriorityQueue<GraphConnection>(GraphConnection.ConnectionCostComparer);
 		}
 
@@ -224,7 +224,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			while (CanExpand())
 			{
 				var p = Expand();
-				if (TargetPredicate(p))
+				if (targetPredicate(p))
 					return MakePath(Graph, p);
 			}
 


### PR DESCRIPTION

Trivial optimization. Save a call to `get_TargetPredicate` each iteration of the loop in `FindPath`. 

The property was not used publically. 

The compiler is not able to optimize this in a release build on my system. Likely because the property can change over time.

(It may also be beneficial to have a seperate FindPath where not a predicate/lambda-callback is used but where a target CPos comparison is made directly. Since in most searches the predicate is `pos == target`.  The lambda call cannot be optmized away as it refences a dynamic value target.)
