### PR TITLE
Prevent game from starting via checkboxes with unavailable map

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -259,6 +259,22 @@ namespace OpenRA.Mods.Common.Server
 				if (server.LobbyInfo.Slots.All(sl => server.LobbyInfo.ClientInSlot(sl.Key) == null))
 					return;
 
+				// Does the host have the map installed?
+				if (server.Type != ServerType.Dedicated && server.ModData.MapCache[server.Map.Uid].Status != MapStatus.Available)
+				{
+					// Client 0 will always be the Host
+					// In some cases client 0 doesn't exist, so we untick all players
+					var host = server.LobbyInfo.Clients.FirstOrDefault(c => c.Index == 0);
+					if (host != null)
+						host.State = Session.ClientState.NotReady;
+					else
+						foreach (var client in server.LobbyInfo.Clients)
+							client.State = Session.ClientState.NotReady;
+
+					server.SyncLobbyClients();
+					return;
+				}
+
 				if (LobbyUtils.InsufficientEnabledSpawnPoints(server.Map, server.LobbyInfo))
 					return;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
@@ -173,6 +173,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					retry.OnClick = () =>
 					{
+						modData.MapCache.UpdateMaps();
 						var (map, _) = getMap();
 						if (map.Status == MapStatus.DownloadError)
 						{


### PR DESCRIPTION
Currently the player gets kicked from the multiplayer lobby