### PR TITLE
Remove map editor `save` debug message

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -190,9 +190,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					map.Save(package);
 
-					Console.WriteLine($"Saved current map at {combinedPath}");
 					Ui.CloseWindow();
-
 					onSave(map.Uid);
 				}
 				catch (Exception e)


### PR DESCRIPTION
When a map is saved / created there's not need for the map editor to print a debug message as it is already done by `MapDirectoryTracker`