### PR TITLE
Make Captures grant experience based on targets cost

### DIFF
--- a/OpenRA.Mods.Common/Activities/CaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/CaptureActor.cs
@@ -125,7 +125,7 @@ namespace OpenRA.Mods.Common.Activities
 					t.OnCapture(enterActor, self, oldOwner, self.Owner, captures.Info.CaptureTypes);
 
 				if (self.Owner.RelationshipWith(oldOwner).HasRelationship(captures.Info.PlayerExperienceRelationships))
-					self.Owner.PlayerActor.TraitOrDefault<PlayerExperience>()?.GiveExperience(captures.Info.PlayerExperience);
+					self.Owner.PlayerActor.TraitOrDefault<PlayerExperience>()?.GiveExperience(captures.Info.PlayerExperience + captures.Info.PlayerExperiencePercentage * (enterActor.Info.TraitInfoOrDefault<ValuedInfo>()?.Cost ?? 0) / 100);
 
 				if (captures.Info.ConsumedByCapture)
 					self.Dispose();

--- a/OpenRA.Mods.Common/Activities/CaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/CaptureActor.cs
@@ -125,7 +125,25 @@ namespace OpenRA.Mods.Common.Activities
 					t.OnCapture(enterActor, self, oldOwner, self.Owner, captures.Info.CaptureTypes);
 
 				if (self.Owner.RelationshipWith(oldOwner).HasRelationship(captures.Info.PlayerExperienceRelationships))
-					self.Owner.PlayerActor.TraitOrDefault<PlayerExperience>()?.GiveExperience(captures.Info.PlayerExperience + captures.Info.PlayerExperiencePercentage * (enterActor.Info.TraitInfoOrDefault<ValuedInfo>()?.Cost ?? 0) / 100);
+				{
+					var pe = self.Owner.PlayerActor.TraitOrDefault<PlayerExperience>();
+					if (pe != null)
+					{
+						var cost = 0;
+						var valued = enterActor.TraitOrDefault<Valued>();
+						if (valued != null)
+							cost = valued.Info.Cost;
+
+						if (cost == 0)
+						{
+							var valuedInit = valued.Init.GetOrDefault<ValuedInit>();
+							if (valuedInit != null)
+								cost = valuedInit.Cost;
+						}
+
+						pe.GiveExperience(captures.Info.PlayerExperience + captures.Info.PlayerExperiencePercentage * cost / 100);
+					}
+				}
 
 				if (captures.Info.ConsumedByCapture)
 					self.Dispose();

--- a/OpenRA.Mods.Common/Traits/Captures.cs
+++ b/OpenRA.Mods.Common/Traits/Captures.cs
@@ -43,6 +43,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Experience granted to the capturing player.")]
 		public readonly int PlayerExperience = 0;
 
+		[Desc("Experience granted to the capturing player based on the cost of the captured structure.")]
+		public readonly int PlayerExperiencePercentage = 0;
+
 		[Desc("Relationships that the structure's previous owner needs to have for the capturing player to receive Experience.")]
 		public readonly PlayerRelationship PlayerExperienceRelationships = PlayerRelationship.Enemy;
 

--- a/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
@@ -140,6 +140,10 @@ namespace OpenRA.Mods.Common.Traits
 				.Select(ihm => ihm.HuskActor(self))
 				.FirstOrDefault(a => a != null);
 
+			var valued = self.Info.TraitInfoOrDefault<ValuedInfo>();
+			if (valued != null)
+				td.Add(valued.Cost);
+
 			self.World.AddFrameEndTask(w => w.CreateActor(huskActor ?? Info.Actor, td));
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Valued.cs
+++ b/OpenRA.Mods.Common/Traits/Valued.cs
@@ -14,12 +14,35 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("How much the unit is worth.")]
-	public class ValuedInfo : TraitInfo<Valued>
+	public class ValuedInfo : TraitInfo
 	{
 		[FieldLoader.Require]
 		[Desc("Used in production, but also for bounties so remember to set it > 0 even for NPCs.")]
 		public readonly int Cost = 0;
+
+		public override object Create(ActorInitializer init) { return new Valued(init, this); }
 	}
 
-	public class Valued { }
+	public class Valued
+	{
+		public ActorInitializer Init;
+		public ValuedInfo Info;
+		public Valued(ActorInitializer init, ValuedInfo info)
+		{
+			Init = init;
+			Info = info;
+		}
+	}
+
+	public class ValuedInit : ActorInit, ISingleInstanceInit
+	{
+		public readonly int Cost = 0;
+
+		public ValuedInit(int cost)
+		{
+			Cost = cost;
+		}
+
+		public override MiniYaml Save() { return new MiniYaml(Cost.ToStringInvariant()); }
+	}
 }

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -211,10 +211,13 @@ E6:
 	Captures@SABOTAGE:
 		CaptureTypes: building-sabotage
 		SabotageThreshold: 55
-		PlayerExperience: 10
+		PlayerExperiencePercentage: 2
 	Captures@CAPTURES:
-		CaptureTypes: building, husk
-		PlayerExperience: 10
+		CaptureTypes: building
+		PlayerExperiencePercentage: 2
+	Captures@CAPTURESHUSK:
+		CaptureTypes: husk
+		PlayerExperiencePercentage: 1
 	-AttackFrontal:
 
 RMBO:

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -51,7 +51,7 @@ engineer:
 	CaptureManager:
 	Captures:
 		CaptureTypes: building
-		PlayerExperience: 10
+		PlayerExperiencePercentage: 2
 	Encyclopedia:
 		Description: Engineers can be used to capture enemy buildings.\n\nEngineers are resistant to anti-tank weaponry but very vulnerable to high-explosives, fire and bullet weapons.
 		Order: 30

--- a/mods/ra/rules/disable-player-experience.yaml
+++ b/mods/ra/rules/disable-player-experience.yaml
@@ -9,10 +9,20 @@
 E6:
 	Captures:
 		PlayerExperience: 0
+		PlayerExperiencePercentage: 0
+	Captures@REUSABLE:
+		PlayerExperience: 0
+		PlayerExperiencePercentage: 0
+
+MECH:
+	Captures:
+		PlayerExperience: 0
+		PlayerExperiencePercentage: 0
 
 THF:
 	Captures:
 		PlayerExperience: 0
+		PlayerExperiencePercentage: 0
 
 SPEN:
 	RepairsUnits:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -306,12 +306,12 @@ E6:
 	Captures:
 		RequiresCondition: !global-reusable-engineers
 		CaptureTypes: building
-		PlayerExperience: 10
+		PlayerExperiencePercentage: 2
 		CaptureDelay: 200
 	Captures@REUSABLE:
 		RequiresCondition: global-reusable-engineers
 		CaptureTypes: building
-		PlayerExperience: 10
+		PlayerExperiencePercentage: 2
 		CaptureDelay: 375
 		ConsumedByCapture: False
 		EnterCursor: ability
@@ -536,7 +536,7 @@ MECH:
 	CaptureManager:
 	Captures:
 		CaptureTypes: husk
-		PlayerExperience: 10
+		PlayerExperiencePercentage: 1
 	Infiltrates:
 		Types: Husk
 		ValidRelationships: Ally
@@ -641,7 +641,7 @@ THF:
 	CaptureManager:
 	Captures:
 		CaptureTypes: vehicle, aircraft
-		PlayerExperience: 10
+		PlayerExperiencePercentage: 2
 	Infiltrates:
 		Types: ThiefInfiltrate
 		Notification: BuildingInfiltrated

--- a/mods/ts/rules/nod-infantry.yaml
+++ b/mods/ts/rules/nod-infantry.yaml
@@ -138,6 +138,6 @@ MHIJACK:
 	CaptureManager:
 	Captures:
 		CaptureTypes: Vehicle
-		PlayerExperience: 10
+		PlayerExperiencePercentage: 2
 	RevealsShroud:
 		Range: 6c0

--- a/mods/ts/rules/shared-infantry.yaml
+++ b/mods/ts/rules/shared-infantry.yaml
@@ -77,7 +77,7 @@ ENGINEER:
 	CaptureManager:
 	Captures:
 		CaptureTypes: building
-		PlayerExperience: 10
+		PlayerExperiencePercentage: 2
 	RenderSprites:
 		Image: engineer.gdi
 		FactionImages:


### PR DESCRIPTION
Killing a unit grants experience based of 1% of the cost

Capturing will now give 2% of the captured cost, with the exception of RA mechanic and TD engineer capturing husks, as you already get 1% from the initial kill.