### PR TITLE
Changed `anypower` tag name to Any Power Generation to reduce confusion.

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -1199,10 +1199,10 @@ ANYPOWER:
 	AlwaysVisible:
 	Interactable:
 	Tooltip:
-		Name: Power Plant
+		Name: Any Power Generation
 
 ANYHQ:
 	AlwaysVisible:
 	Interactable:
 	Tooltip:
-		Name: a communications center
+		Name: A Communications Center

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -2167,4 +2167,4 @@ ANYPOWER:
 	AlwaysVisible:
 	Interactable:
 	Tooltip:
-		Name: Power Plant
+		Name: Any Power Generation

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -232,7 +232,7 @@ ANYPOWER:
 	AlwaysVisible:
 	Interactable:
 	Tooltip:
-		Name: Power Plant
+		Name: Any Power Generation
 
 BARRACKS:
 	AlwaysVisible:


### PR DESCRIPTION
Typically in the RA mod the requirements for building a building is the building name and not the building type. This PR aims to fix confusion that might arise with buildings that require power plants as they break this rule.