### PR TITLE
Refactor RepairableBuilding to use 100x values and change XP gains

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/RepairableBuildingProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/RepairableBuildingProperties.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Scripting
 		{
 			repairer = repairer ?? Self.Owner;
 
-			if (!rb.Repairers.Contains(repairer))
+			if (!rb.Repairers.Contains(repairer.PlayerActor.Trait<PlayerResources>()))
 				rb.RepairBuilding(Self, repairer);
 		}
 
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Scripting
 		{
 			repairer = repairer ?? Self.Owner;
 
-			if (rb.RepairActive && rb.Repairers.Contains(repairer))
+			if (rb.RepairActive && rb.Repairers.Contains(repairer.PlayerActor.Trait<PlayerResources>()))
 				rb.RepairBuilding(Self, repairer);
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
@@ -74,12 +74,12 @@ namespace OpenRA.Mods.Common.Traits
 	public class PlayerResources : ISync
 	{
 		public readonly PlayerResourcesInfo Info;
-		readonly Player owner;
+		public readonly Player Owner;
 
 		public PlayerResources(Actor self, PlayerResourcesInfo info)
 		{
 			Info = info;
-			owner = self.Owner;
+			Owner = self.Owner;
 
 			var startingCash = self.World.LobbyInfo.GlobalSettings
 				.OptionOrDefault("startingcash", info.DefaultCash.ToString());
@@ -178,19 +178,27 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public bool TakeCash(int num, bool notifyLowFunds = false)
+		public bool CanTakeCash(int num, bool notifyLowFunds = false)
 		{
 			if (Cash + Resources < num)
 			{
 				if (notifyLowFunds && Game.RunTime > lastNotificationTime + Info.InsufficientFundsNotificationInterval)
 				{
 					lastNotificationTime = Game.RunTime;
-					Game.Sound.PlayNotification(owner.World.Map.Rules, owner, "Speech", Info.InsufficientFundsNotification, owner.Faction.InternalName);
-					TextNotificationsManager.AddTransientLine(Info.InsufficientFundsTextNotification, owner);
+					Game.Sound.PlayNotification(Owner.World.Map.Rules, Owner, "Speech", Info.InsufficientFundsNotification, Owner.Faction.InternalName);
+					TextNotificationsManager.AddTransientLine(Info.InsufficientFundsTextNotification, Owner);
 				}
 
 				return false;
 			}
+
+			return true;
+		}
+
+		public bool TakeCash(int num, bool notifyLowFunds = false)
+		{
+			if (!CanTakeCash(num, notifyLowFunds))
+				return false;
 
 			// Spend ore before cash
 			Resources -= num;

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingRepairDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingRepairDecoration.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (!info.IsPlayerPalette)
 				return wr.Palette(info.Palette);
 
-			return wr.Palette(info.Palette + rb.Repairers[shownPlayer % rb.Repairers.Count].InternalName);
+			return wr.Palette(info.Palette + rb.Repairers[shownPlayer % rb.Repairers.Count].Owner.InternalName);
 		}
 
 		void CycleRepairer()

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UpdateRepairableBuildingProperty.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UpdateRepairableBuildingProperty.cs
@@ -1,0 +1,54 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class UpdateRepairableBuildingProperty : UpdateRule
+	{
+		public override string Name => "Replaces PlayerExperience property with PlayerExperiencePercentage.";
+
+		public override string Description => "PlayerExperience was replaced with PlayerExperiencePercentage which bases score on cash spent.";
+
+		readonly List<string> locations = new List<string>();
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (locations.Count > 0)
+				yield return "'PlayerExperience' was replaced with 'PlayerExperiencePercentage' which bases score\n" +
+					"on cash spent. You may want to review score gains.\n" +
+					UpdateUtils.FormatMessageList(locations);
+
+			locations.Clear();
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var removed = false;
+
+			foreach (var actor in actorNode.ChildrenMatching("RepairableBuilding"))
+			{
+				foreach (var p in actor.ChildrenMatching("PlayerExperience"))
+				{
+					p.Key = "PlayerExperiencePercentage";
+					p.Value.Value = "5";
+					removed = true;
+				}
+			}
+
+			if (removed)
+				locations.Add($"{actorNode.Key} ({actorNode.Location.Filename})");
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -72,9 +72,8 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveLaysTerrain(),
 			}),
 
-			new UpdatePath("release-20210321", new UpdateRule[]
+			new UpdatePath("release-20210321", "devtest-20221007", new UpdateRule[]
 			{
-				// Bleed only changes here
 				new RenameMPTraits(),
 				new RemovePlayerHighlightPalette(),
 				new ReplaceWithColoredOverlayPalette(),
@@ -97,6 +96,12 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new UnhardcodeBaseBuilderBotModule(),
 				new UnhardcodeVeteranProductionIconOverlay(),
 				new RenameContrailProperties(),
+			}),
+
+			new UpdatePath("release-20210321", "devtest-20221007", new UpdateRule[]
+			{
+				// Bleed only changes here
+				new UpdateRepairableBuildingProperty(),
 			})
 		};
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -735,7 +735,7 @@
 	RepairableBuilding:
 		RepairPercent: 40
 		RepairStep: 1400
-		PlayerExperience: 5
+		PlayerExperiencePercentage: 5
 		RepairingNotification: Repairing
 	WithDeathAnimation:
 		DeathSequence: dead
@@ -803,7 +803,7 @@
 	RepairableBuilding:
 		RepairPercent: 40
 		RepairStep: 1400
-		PlayerExperience: 5
+		PlayerExperiencePercentage: 5
 		RepairingNotification: Repairing
 	EngineerRepairable:
 	RevealsShroud:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -450,7 +450,7 @@
 		EmptyWeapon: BuildingExplode
 	RepairableBuilding:
 		RepairStep: 500
-		PlayerExperience: 5
+		PlayerExperiencePercentage: 5
 		RepairingNotification: Repairing
 	SpawnActorsOnSell:
 		ActorTypes: light_inf

--- a/mods/ra/maps/oil-spill/rules.yaml
+++ b/mods/ra/maps/oil-spill/rules.yaml
@@ -17,7 +17,7 @@ FCOM:
 		Produces: Building, Defense
 	RepairableBuilding:
 		RepairStep: 700
-		PlayerExperience: 5
+		PlayerExperiencePercentage: 5
 		RepairingNotification: Repairing
 	WithBuildingRepairDecoration:
 		Image: allyrepair

--- a/mods/ra/rules/campaign-rules.yaml
+++ b/mods/ra/rules/campaign-rules.yaml
@@ -96,7 +96,7 @@ FCOM:
 		Range: 0
 	RepairableBuilding:
 		RepairStep: 700
-		PlayerExperience: 5
+		PlayerExperiencePercentage: 5
 		RepairingNotification: Repairing
 	WithBuildingRepairDecoration:
 		Image: allyrepair

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -701,7 +701,7 @@
 		AreaTypes: building, fake
 	RepairableBuilding:
 		RepairStep: 700
-		PlayerExperience: 5
+		PlayerExperiencePercentage: 5
 		RepairingNotification: Repairing
 	EngineerRepairable:
 	AcceptsDeliveredCash:

--- a/mods/ra/rules/disable-player-experience.yaml
+++ b/mods/ra/rules/disable-player-experience.yaml
@@ -4,7 +4,7 @@
 
 ^Building:
 	RepairableBuilding:
-		PlayerExperience: 0
+		PlayerExperiencePercentage: 0
 
 E6:
 	Captures:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -372,7 +372,7 @@
 		Types: building
 	RepairableBuilding:
 		RepairStep: 700
-		PlayerExperience: 5
+		PlayerExperiencePercentage: 5
 		RepairingNotification: Repairing
 	WithDeathAnimation:
 		DeathSequence: dead


### PR DESCRIPTION
With the current system the cash drain for repair is bollocks as well as XP gain

Due to low integer numbers every repair tick costed 1$ instead of expected values (20% of the structures cost). I fixed it by building up a cost value that is 100x as big over time and reducing by -100 it whenever it reaches 100

Due to reduced effectiveness of additional people repairing the cost was also supposed to become lesser. But the code didn't account for it (not that it mattered since you payed 1$ anyway)

Exp gains were also bollocks, after completing a repair you gained +5 exp (Gains were nerfed in #20421, it was +25) , meaning by shooting with a riflemen at an allied structure and immediately repairing you boosted your score by insane margins. Do note that 5 = 500$ of assets killed. 

To fix that I made exp gain 5% of cash spent repairing. It's set it to 5 as the cost is already reduces cash by 20%. 0.2% * 0.05% = 0.01%, meaning from a repairing a construction yard you can theoretically get 20XP