### PR TITLE
Nerf supply truck XP gain

### DIFF
--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -781,7 +781,7 @@ TRUCK:
 		Range: 4c0
 	DeliversCash:
 		Payload: 1000
-		PlayerExperience: 100
+		PlayerExperience: 10
 	SpawnActorOnDeath:
 		Actor: TRUCK.Husk
 		OwnerType: InternalName

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -549,7 +549,7 @@ TRUK:
 		Range: 4c0
 	DeliversCash:
 		Payload: 500
-		PlayerExperience: 50
+		PlayerExperience: 5
 	SpawnActorOnDeath:
 		Actor: moneycrate
 


### PR DESCRIPTION
This yet another case where players can unreasonably effectively boost their score.

For RA 50 -> 5
For TD 100 -> 10

do note that 50 = 5000$ assets killed