### PR TITLE
Fix sequences only being checked on actors with RenderSprites

### DIFF
--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -40,19 +40,18 @@ namespace OpenRA.Mods.Common.Lint
 			var factions = rules.Actors[SystemActors.World].TraitInfos<FactionInfo>().Select(f => f.InternalName).ToArray();
 			foreach (var actorInfo in rules.Actors)
 			{
+				var images = new HashSet<string>();
+
 				// Actors may have 0 or 1 RenderSprites traits
 				var renderInfo = actorInfo.Value.TraitInfoOrDefault<RenderSpritesInfo>();
-				if (renderInfo == null)
-					continue;
-
-				var images = new HashSet<string>()
+				if (renderInfo != null)
 				{
-					renderInfo.GetImage(actorInfo.Value, null).ToLowerInvariant()
-				};
+					images.Add(renderInfo.GetImage(actorInfo.Value, null).ToLowerInvariant());
 
-				// Some actors define faction-specific artwork
-				foreach (var faction in factions)
-					images.Add(renderInfo.GetImage(actorInfo.Value, faction).ToLowerInvariant());
+					// Some actors define faction-specific artwork
+					foreach (var faction in factions)
+						images.Add(renderInfo.GetImage(actorInfo.Value, faction).ToLowerInvariant());
+				}
 
 				foreach (var traitInfo in actorInfo.Value.TraitInfos<TraitInfo>())
 				{
@@ -77,6 +76,7 @@ namespace OpenRA.Mods.Common.Lint
 							{
 								if (!sequenceReference.AllowNullImage)
 									emitError($"Actor type `{actorInfo.Value.Name}` trait `{traitName}` must define a value for `{sequenceReference.ImageReference}`");
+
 								continue;
 							}
 

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Smoke sprite image name")]
 		public readonly string SmokeImage = null;
 
-		[SequenceReference(nameof(SmokeImage))]
+		[SequenceReference(nameof(SmokeImage), allowNullImage: true)]
 		[Desc("Smoke sprite sequences randomly chosen from")]
 		public readonly string[] SmokeSequences = Array.Empty<string>();
 


### PR DESCRIPTION
The world actor has no `RenderSprites` trait, so sequences and images on traits on the world actor were never checked, despite offering image overrides. The first commit fixes an issue discovered after enabling linting on the world actor. `SmokeImage` is not required (and not set up in D2k).