### PR TITLE
GraphConnectionQueue, reduces path finding time by 22%.

### DIFF
--- a/OpenRA.Mods.Common/Pathfinder/GraphConnectionQueue.cs
+++ b/OpenRA.Mods.Common/Pathfinder/GraphConnectionQueue.cs
@@ -1,0 +1,158 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace OpenRA.Mods.Common.Pathfinder
+{
+	/// <summary>
+	/// Priority queue that stores graph connections in priority of their cost.
+	/// PERF: Do not use generics. Compare cost fields directly. Use an array for storage over a list of arrays.
+	/// </summary>
+	public sealed class GraphConnectionQueue
+	{
+		/// <summary>
+		/// Array devided into sub arrays called levels. At each level the size of a level array doubles.
+		/// Elements stored one one level are near sorted. The top level array at index zero
+		/// has length one and stores the element with the higest priority.
+		/// After popping the top element, elements from lower level bubble up into higher levels.
+		/// </summary>
+		GraphConnection[] items;
+
+		/// <summary>
+		/// Index of deepest level.
+		/// </summary>
+		int level;
+
+		/// <summary>
+		/// Number of elements in the deepest level array.
+		/// </summary>
+		int index;
+
+		// Intial capacity of 512 matches eight levels.
+		public GraphConnectionQueue(int initialCapacity = 512)
+		{
+			items = new GraphConnection[initialCapacity > 0 ? initialCapacity : 1];
+		}
+
+		public void Add(GraphConnection item)
+		{
+			var span = items.AsSpan();
+			var addLevel = level;
+			var addIndex = index;
+
+			while (addLevel >= 1)
+			{
+				var above = span[AboveIndex(addLevel, addIndex)];
+				if (above.Cost > item.Cost)
+				{
+					span[Index(addLevel, addIndex)] = above;
+					--addLevel;
+					addIndex >>= 1;
+				}
+				else
+					break;
+			}
+
+			span[Index(addLevel, addIndex)] = item;
+
+			if (++index >= (1 << level))
+			{
+				index = 0;
+				var levelWidth = 1 << ++level;
+				if (levelWidth + levelWidth - 1 >= items.Length)
+					GrowCapacity();
+			}
+		}
+
+		void GrowCapacity()
+		{
+			var newItems = new GraphConnection[(1 << level) * 2];
+			Array.Copy(items, newItems, items.Length);
+			items = newItems;
+		}
+
+		public bool Empty => level == 0;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		static int Index(int level, int index) { return ((1 << level) - 1) + index; }
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		static int AboveIndex(int level, int index) { return ((1 << (level - 1)) - 1) + (index >> 1); }
+
+		int IndexLast()
+		{
+			var lastLevel = level;
+			var lastIndex = index;
+
+			if (--lastIndex < 0)
+				lastIndex = (1 << --lastLevel) - 1;
+
+			return Index(lastLevel, lastIndex);
+		}
+
+		public GraphConnection Peek()
+		{
+			if (level <= 0 && index <= 0)
+				throw new InvalidOperationException("PriorityQueue empty.");
+
+			// PERF: Index(0, 0) = 0
+			return items[0];
+		}
+
+		public GraphConnection Pop()
+		{
+			var ret = Peek();
+			BubbleInto(0, 0, items[IndexLast()]);
+			if (--index < 0)
+				index = (1 << --level) - 1;
+			return ret;
+		}
+
+		void BubbleInto(int intoLevel, int intoIndex, GraphConnection val)
+		{
+			var span = items.AsSpan();
+			while (true)
+			{
+				var downLevel = intoLevel + 1;
+				var downIndex = intoIndex << 1;
+
+				if (downLevel > level || (downLevel == level && downIndex >= index))
+				{
+					span[Index(intoLevel, intoIndex)] = val;
+					return;
+				}
+
+				var down = span[Index(downLevel, downIndex)];
+				if (downLevel < level || (downLevel == level && downIndex < index - 1))
+				{
+					var downRight = span[Index(downLevel, downIndex + 1)];
+					if (down.Cost >= downRight.Cost)
+					{
+						down = downRight;
+						++downIndex;
+					}
+				}
+
+				if (val.Cost <= down.Cost)
+				{
+					span[Index(intoLevel, intoIndex)] = val;
+					return;
+				}
+
+				span[Index(intoLevel, intoIndex)] = down;
+				intoLevel = downLevel;
+				intoIndex = downIndex;
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -14,7 +14,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.Pathfinder
 {
@@ -140,7 +139,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		readonly Func<CPos, int> heuristic;
 		readonly int heuristicWeightPercentage;
 		readonly IRecorder recorder;
-		readonly IPriorityQueue<GraphConnection> openQueue;
+		readonly GraphConnectionQueue openQueue;
 
 		/// <summary>
 		/// Initialize a new search.
@@ -163,7 +162,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			this.heuristicWeightPercentage = heuristicWeightPercentage;
 			TargetPredicate = targetPredicate;
 			this.recorder = recorder;
-			openQueue = new PriorityQueue<GraphConnection>(GraphConnection.ConnectionCostComparer);
+			openQueue = new GraphConnectionQueue();
 		}
 
 		void AddInitialCell(CPos location, Func<CPos, int> customCost)

--- a/OpenRA.Test/OpenRA.Mods.Common/GraphConnectionQueueTest.cs
+++ b/OpenRA.Test/OpenRA.Mods.Common/GraphConnectionQueueTest.cs
@@ -1,0 +1,151 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Pathfinder;
+using OpenRA.Support;
+
+namespace OpenRA.Test
+{
+	[TestFixture]
+	class GraphConnectionQueueTest
+	{
+		[TestCase(1, 123)]
+		[TestCase(1, 1234)]
+		[TestCase(1, 12345)]
+		[TestCase(2, 123)]
+		[TestCase(2, 1234)]
+		[TestCase(2, 12345)]
+		[TestCase(10, 123)]
+		[TestCase(10, 1234)]
+		[TestCase(10, 12345)]
+		[TestCase(15, 123)]
+		[TestCase(15, 1234)]
+		[TestCase(15, 12345)]
+		[TestCase(16, 123)]
+		[TestCase(16, 1234)]
+		[TestCase(16, 12345)]
+		[TestCase(17, 123)]
+		[TestCase(17, 1234)]
+		[TestCase(17, 12345)]
+		[TestCase(100, 123)]
+		[TestCase(100, 1234)]
+		[TestCase(100, 12345)]
+		[TestCase(1000, 123)]
+		[TestCase(1000, 1234)]
+		[TestCase(1000, 12345)]
+		public void GraphConnectionQueueAddThenRemoveTest(int count, int seed)
+		{
+			var mt = new MersenneTwister(seed);
+			var values = Enumerable.Range(0, count);
+			var shuffledValues = values.Shuffle(mt).ToArray();
+
+			var queue = new GraphConnectionQueue(1);
+
+			Assert.IsTrue(queue.Empty, "New queue should start out empty.");
+			Assert.Throws<InvalidOperationException>(() => queue.Peek(), "Peeking at an empty queue should throw.");
+			Assert.Throws<InvalidOperationException>(() => queue.Pop(), "Popping an empty queue should throw.");
+
+			foreach (var value in shuffledValues)
+			{
+				queue.Add(new GraphConnection(CPos.Zero, value));
+				Assert.IsFalse(queue.Empty, "Queue should not be empty - items have been added.");
+			}
+
+			foreach (var value in values)
+			{
+				Assert.AreEqual(new GraphConnection(CPos.Zero, value), queue.Peek(), "Peek returned the wrong item - should be in order.");
+				Assert.IsFalse(queue.Empty, "Queue should not be empty yet.");
+				Assert.AreEqual(new GraphConnection(CPos.Zero, value), queue.Pop(), "Pop returned the wrong item - should be in order.");
+			}
+
+			Assert.IsTrue(queue.Empty, "Queue should now be empty.");
+			Assert.Throws<InvalidOperationException>(() => queue.Peek(), "Peeking at an empty queue should throw.");
+			Assert.Throws<InvalidOperationException>(() => queue.Pop(), "Popping an empty queue should throw.");
+		}
+
+		[TestCase(15, 123)]
+		[TestCase(15, 1234)]
+		[TestCase(15, 12345)]
+		[TestCase(16, 123)]
+		[TestCase(16, 1234)]
+		[TestCase(16, 12345)]
+		[TestCase(17, 123)]
+		[TestCase(17, 1234)]
+		[TestCase(17, 12345)]
+		[TestCase(100, 123)]
+		[TestCase(100, 1234)]
+		[TestCase(100, 12345)]
+		[TestCase(1000, 123)]
+		[TestCase(1000, 1234)]
+		[TestCase(1000, 12345)]
+		public void GraphConnectionQueueAddAndRemoveInterleavedTest(int count, int seed)
+		{
+			var mt = new MersenneTwister(seed);
+			var shuffledValues = Enumerable.Range(0, count).Shuffle(mt).ToArray();
+
+			var queue = new GraphConnectionQueue();
+
+			Assert.IsTrue(queue.Empty, "New queue should start out empty.");
+			Assert.Throws<InvalidOperationException>(() => queue.Peek(), "Peeking at an empty queue should throw.");
+			Assert.Throws<InvalidOperationException>(() => queue.Pop(), "Popping an empty queue should throw.");
+
+			foreach (var value in shuffledValues.Take(10))
+			{
+				queue.Add(new GraphConnection(CPos.Zero, value));
+				Assert.IsFalse(queue.Empty, "Queue should not be empty - items have been added.");
+			}
+
+			foreach (var value in shuffledValues.Take(10).OrderBy(x => x).Take(5))
+			{
+				Assert.AreEqual(new GraphConnection(CPos.Zero, value), queue.Peek(), "Peek returned the wrong item - should be in order.");
+				Assert.IsFalse(queue.Empty, "Queue should not be empty yet.");
+				Assert.AreEqual(new GraphConnection(CPos.Zero, value), queue.Pop(), "Pop returned the wrong item - should be in order.");
+			}
+
+			foreach (var value in shuffledValues.Skip(10).Take(5))
+			{
+				queue.Add(new GraphConnection(CPos.Zero, value));
+				Assert.IsFalse(queue.Empty, "Queue should not be empty - items have been added.");
+			}
+
+			foreach (var value in shuffledValues.Take(10).OrderBy(x => x).Skip(5)
+				.Concat(shuffledValues.Skip(10).Take(5)).OrderBy(x => x).Take(5))
+			{
+				Assert.AreEqual(new GraphConnection(CPos.Zero, value), queue.Peek(), "Peek returned the wrong item - should be in order.");
+				Assert.IsFalse(queue.Empty, "Queue should not be empty yet.");
+				Assert.AreEqual(new GraphConnection(CPos.Zero, value), queue.Pop(), "Pop returned the wrong item - should be in order.");
+			}
+
+			foreach (var value in shuffledValues.Skip(15))
+			{
+				queue.Add(new GraphConnection(CPos.Zero, value));
+				Assert.IsFalse(queue.Empty, "Queue should not be empty - items have been added.");
+			}
+
+			foreach (var value in shuffledValues.Take(10).OrderBy(x => x).Skip(5)
+				.Concat(shuffledValues.Skip(10).Take(5)).OrderBy(x => x).Skip(5)
+				.Concat(shuffledValues.Skip(15)).OrderBy(x => x))
+			{
+				Assert.AreEqual(new GraphConnection(CPos.Zero, value), queue.Peek(), "Peek returned the wrong item - should be in order.");
+				Assert.IsFalse(queue.Empty, "Queue should not be empty yet.");
+				Assert.AreEqual(new GraphConnection(CPos.Zero, value), queue.Pop(), "Pop returned the wrong item - should be in order.");
+			}
+
+			Assert.IsTrue(queue.Empty, "Queue should now be empty.");
+			Assert.Throws<InvalidOperationException>(() => queue.Peek(), "Peeking at an empty queue should throw.");
+			Assert.Throws<InvalidOperationException>(() => queue.Pop(), "Popping an empty queue should throw.");
+		}
+	}
+}


### PR DESCRIPTION


Reduce path searching time by 22-25%.(factor 0.781 - 0.745 in ticks, bot game, 8 bots, Ascent map, AI nog generating that much path activity, i.e. no planes, units not travelling far).

Replace PriorityQueue with GraphConnectionQueue.

- Do not use generic PriorityQueue
- Replace `List<T[]>` implementation of queue levels with an array. Reducing allocation. Faster with longer wider searches. Also since the number of items/levels would already never decrease.
- Direct comparison of int cost field. Avoid call to Comparer to compare cost of queue elements.
- Use Span
- Do not call `BubbleInto` recursively but in while loop
- Less frequent lookup of items at a certain index.
- Added test compatible to existing `PriorityQueueTest`. 
- Compatible with implemetatation of  'bubble into' `PriorityQueue`. 
- Equals and Comparer for `GrahhConnection` not implemented. Relying on default implentation of struct comparison.
- Add comments, explaining a bit of the bubble magic. 
- Initial capacity set to 8 layers based on game showing on average 6-7 layers are in use.
- No added value for `GraphConnectionQueue` to implement `IPriorityQueue` even though it does. 
- 
Proposal to remove `IPriorityQueue`, `PriorityQueue`, `PriorityQueueTest` and `GraphConnection.ConnectionCostComparer`. Not used in other parts of the code.

(Open question, if using a single flat array using binary search wouldn't be faster than "bubbling". Although it would require a lof of element moving in the items array to insert in the mid.)

Would be nice to get a confirmation on the measurements from other systems.
