### PR TITLE
Fix lobby error messages from the server being untranslated

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -286,26 +286,25 @@ namespace OpenRA.Mods.Common.Server
 			{
 				if (!client.IsAdmin)
 				{
-					server.SendOrderTo(conn, "Message", OnlyHostStartGame);
+					server.SendLocalizedMessageTo(conn, OnlyHostStartGame);
 					return true;
 				}
 
-				if (server.LobbyInfo.Slots.Any(sl => sl.Value.Required &&
-													 server.LobbyInfo.ClientInSlot(sl.Key) == null))
+				if (server.LobbyInfo.Slots.Any(sl => sl.Value.Required && server.LobbyInfo.ClientInSlot(sl.Key) == null))
 				{
-					server.SendOrderTo(conn, "Message", NoStartUntilRequiredSlotsFull);
+					server.SendLocalizedMessageTo(conn, NoStartUntilRequiredSlotsFull);
 					return true;
 				}
 
 				if (!server.LobbyInfo.GlobalSettings.EnableSingleplayer && server.LobbyInfo.NonBotPlayers.Count() < 2)
 				{
-					server.SendOrderTo(conn, "Message", TwoHumansRequired);
+					server.SendLocalizedMessageTo(conn, TwoHumansRequired);
 					return true;
 				}
 
 				if (LobbyUtils.InsufficientEnabledSpawnPoints(server.Map, server.LobbyInfo))
 				{
-					server.SendOrderTo(conn, "Message", InsufficientEnabledSpawnPoints);
+					server.SendLocalizedMessageTo(conn, InsufficientEnabledSpawnPoints);
 					return true;
 				}
 


### PR DESCRIPTION
Resolves https://github.com/OpenRA/OpenRA/pull/20086#discussion_r913857381. Apparently those were forgotten when the other server messages were translated.

Testcase: Change https://github.com/OpenRA/OpenRA/blob/0a36d6f9958286938536a7a80475cd9bcfc1dfc7/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs#L390-L393 to just `startGameButton.IsDisabled = () => false;` and start a game with an invalid configuration (for example by disabling all spawnpoints).