### PR TITLE
Fix ChooseInitialMap

### DIFF
--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -357,10 +357,12 @@ namespace OpenRA
 
 		public string ChooseInitialMap(string initialUid, MersenneTwister random)
 		{
-			if (string.IsNullOrEmpty(initialUid) || previews[initialUid].Status != MapStatus.Available)
+			UpdateMaps();
+			var map = string.IsNullOrEmpty(initialUid) ? null : previews[initialUid];
+			if (map == null || map.Status != MapStatus.Available || !map.Visibility.HasFlag(MapVisibility.Lobby) || (map.Class != MapClassification.System && map.Class != MapClassification.User))
 			{
 				var selected = previews.Values.Where(IsSuitableInitialMap).RandomOrDefault(random) ??
-					previews.Values.FirstOrDefault(m => m.Status == MapStatus.Available && m.Visibility.HasFlag(MapVisibility.Lobby));
+					previews.Values.FirstOrDefault(m => m.Status == MapStatus.Available && m.Visibility.HasFlag(MapVisibility.Lobby) && (m.Class == MapClassification.System || m.Class == MapClassification.User));
 				return selected == null ? string.Empty : selected.Uid;
 			}
 


### PR DESCRIPTION
With the new map preselection I've discovered a few bugs within `ChooseInitialMap`.

The code in various places relies on it to check wether a map can be played in lobby but it didn't have all the checks, in the past we just accidentally gave it correct answers 