### PR TITLE
TooltipWidgetContainer, load tooltip ui only when visible.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/TooltipContainerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TooltipContainerWidget.cs
@@ -28,20 +28,38 @@ namespace OpenRA.Mods.Common.Widgets
 		Widget tooltip;
 		int nextToken = 1;
 		int currentToken;
+		string id;
+		WidgetArgs widgetArgs;
 
 		public TooltipContainerWidget()
 		{
 			graphicSettings = Game.Settings.Graphics;
-			IsVisible = () => Game.RunTime > Viewport.LastMoveRunTime + TooltipDelayMilliseconds;
+			IsVisible = () =>
+			{
+				// PERF: Only load widget once visible.
+				var visible = Game.RunTime > Viewport.LastMoveRunTime + TooltipDelayMilliseconds;
+				if (visible)
+					LoadWidget();
+
+				return visible;
+			};
+		}
+
+		void LoadWidget()
+		{
+			if (id == null || tooltip != null)
+				return;
+
+			tooltip = Ui.LoadWidget(id, this, new WidgetArgs(widgetArgs) { { "tooltipContainer", this } });
 		}
 
 		public int SetTooltip(string id, WidgetArgs args)
 		{
 			RemoveTooltip();
 			currentToken = nextToken++;
-
-			tooltip = Ui.LoadWidget(id, this, new WidgetArgs(args) { { "tooltipContainer", this } });
-
+			tooltip = null;
+			this.id = id;
+			widgetArgs = args;
 			return currentToken;
 		}
 
@@ -49,6 +67,10 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			if (currentToken != token)
 				return;
+
+			tooltip = null;
+			id = null;
+			widgetArgs = null;
 
 			RemoveChildren();
 			BeforeRender = Nothing;
@@ -59,7 +81,10 @@ namespace OpenRA.Mods.Common.Widgets
 			RemoveTooltip(currentToken);
 		}
 
-		public override void Draw() { BeforeRender(); }
+		public override void Draw()
+		{
+			BeforeRender();
+		}
 
 		public override bool EventBoundsContains(int2 location) { return false; }
 


### PR DESCRIPTION

Background:

TooltipWidgetContainer maintains/has always zero or one child - the currently active tooltip.

Tooltips are set for a widget each time when the mouse enters that widget. The tooltip ui (widget) for the previously active widget is removed.

Tooltips are only shown if the user does not moved the mouse for at least 200 milliseconds. 

Loading of the tooltip ui is relatively expensive. Takes 1ms on average up to 7+ ms. 

One tooltip widget instance is used to show tooltips iin the world view. It is recreated each time when the user moves the mouse back to the world view - i.e. from the production queue icons back to world. Depending on which actor the mouse is over - different tooltip content is shown for that instance. 

Changes:

1. Only load the tooltip UI once the tooltip is visible. 
2. Only call `BeforeRender` once the tooltip is visible. In this method the text and bounds of the tooltip is typically calculated/updated.

`container` is used as parent for the tooltip widget to ensure the child list of the current widget does not change during enumeration.

Advantage:
1. Fast hovering the mouse over production queue items - widgets in general - avoid loading/constructing the tooltip UI.
2. Inside the world - less calls to BeforeRender where the text and dimension of the tooltip is calculated.


Further possible improvements:
1. Let `TooltipWidgetContainer` maintain a map/list/cache of multiple tooltips of which only one is visible. Return the tooltip widget and allow callers to reset the same tooltip widget visible once more. This to reduce the number of calls to `UI.LoadWidget`.
2. Let production queue widget share a tooltip widget so they also can take benifit of 1. Each icon now set it's own tooltip based on the same template. 
Not feasible:
Let `TooltipWidgetContainer` maintain a cache of loaded tooltip ui widgets per template id. Since each widget that sets a tooltip will use different widget constructor arguments.








