### PR TITLE
WorldTooltipLogic. Update tooltip content only every second.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var extraHeightOnDouble = extras.Bounds.Y;
 			var extraHeightOnSingle = extraHeightOnDouble - (doubleHeight - singleHeight);
 
-			tooltipContainer.BeforeRender = () =>
+			tooltipContainer.InitializeTooltipContent = () =>
 			{
 				if (viewport == null || viewport.TooltipType == WorldTooltipType.None)
 					return;
@@ -54,6 +54,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				showOwner = false;
 
 				Player o = null;
+
 				switch (viewport.TooltipType)
 				{
 					case WorldTooltipType.Unexplored:

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 using OpenRA.Widgets;
@@ -18,111 +19,65 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class WorldTooltipLogic : ChromeLogic
 	{
+		const int CellTriggerNone = int.MinValue;
+
 		[TranslationReference]
 		static readonly string UnrevealedTerrain = "unrevealed-terrain";
 
+		readonly Widget widget;
+		readonly ModData modData;
+		readonly World world;
+		readonly ViewportControllerWidget viewport;
+		readonly WorldRenderer worldRenderer;
+
+		readonly LabelWidget label;
+		readonly ImageWidget flag;
+		readonly LabelWidget owner;
+		readonly LabelWidget extras;
+		readonly SpriteFont font;
+		readonly SpriteFont ownerFont;
+		readonly int singleHeight;
+		readonly int doubleHeight;
+		readonly int extraHeightOnDouble;
+		readonly int extraHeightOnSingle;
+
+		string labelText = "";
+		bool showOwner = false;
+		string flagFaction = "";
+		Color ownerColor = Color.White;
+		string ownerName = "";
+		string extraText = "";
+
+		int cellTrigger = CellTriggerNone;
+		CPos lastMapPos = CPos.Zero;
+
 		[ObjectCreator.UseCtor]
-		public WorldTooltipLogic(Widget widget, ModData modData, World world, TooltipContainerWidget tooltipContainer, ViewportControllerWidget viewport)
+		public WorldTooltipLogic(Widget widget, ModData modData, World world, WorldRenderer worldRenderer, TooltipContainerWidget tooltipContainer, ViewportControllerWidget viewport)
 		{
+			this.widget = widget;
+			this.modData = modData;
+			this.world = world;
+			this.worldRenderer = worldRenderer;
+			this.viewport = viewport;
 			widget.IsVisible = () => viewport.TooltipType != WorldTooltipType.None;
-			var label = widget.Get<LabelWidget>("LABEL");
-			var flag = widget.Get<ImageWidget>("FLAG");
-			var owner = widget.Get<LabelWidget>("OWNER");
-			var extras = widget.Get<LabelWidget>("EXTRA");
 
-			var font = Game.Renderer.Fonts[label.Font];
-			var ownerFont = Game.Renderer.Fonts[owner.Font];
-			var labelText = "";
-			var showOwner = false;
-			var flagFaction = "";
-			var ownerName = "";
-			var ownerColor = Color.White;
-			var extraText = "";
+			label = widget.Get<LabelWidget>("LABEL");
+			flag = widget.Get<ImageWidget>("FLAG");
+			owner = widget.Get<LabelWidget>("OWNER");
+			extras = widget.Get<LabelWidget>("EXTRA");
 
-			var singleHeight = widget.Get("SINGLE_HEIGHT").Bounds.Height;
-			var doubleHeight = widget.Get("DOUBLE_HEIGHT").Bounds.Height;
-			var extraHeightOnDouble = extras.Bounds.Y;
-			var extraHeightOnSingle = extraHeightOnDouble - (doubleHeight - singleHeight);
+			font = Game.Renderer.Fonts[label.Font];
+			ownerFont = Game.Renderer.Fonts[owner.Font];
+
+			singleHeight = widget.Get("SINGLE_HEIGHT").Bounds.Height;
+			doubleHeight = widget.Get("DOUBLE_HEIGHT").Bounds.Height;
+			extraHeightOnDouble = extras.Bounds.Y;
+			extraHeightOnSingle = extraHeightOnDouble - (doubleHeight - singleHeight);
 
 			tooltipContainer.InitializeTooltipContent = () =>
 			{
-				if (viewport == null || viewport.TooltipType == WorldTooltipType.None)
-					return;
-
-				var index = 0;
-				extraText = "";
-				showOwner = false;
-
-				Player o = null;
-
-				switch (viewport.TooltipType)
-				{
-					case WorldTooltipType.Unexplored:
-						labelText = modData.Translation.GetString(UnrevealedTerrain);
-						break;
-					case WorldTooltipType.Resource:
-						labelText = viewport.ResourceTooltip;
-						break;
-					case WorldTooltipType.Actor:
-						{
-							o = viewport.ActorTooltip.Owner;
-							showOwner = o != null && !o.NonCombatant && viewport.ActorTooltip.TooltipInfo.IsOwnerRowVisible;
-
-							var stance = o == null || world.RenderPlayer == null ? PlayerRelationship.None : o.RelationshipWith(world.RenderPlayer);
-							labelText = viewport.ActorTooltip.TooltipInfo.TooltipForPlayerStance(stance);
-							break;
-						}
-
-					case WorldTooltipType.FrozenActor:
-						{
-							o = viewport.FrozenActorTooltip.TooltipOwner;
-							showOwner = o != null && !o.NonCombatant && viewport.FrozenActorTooltip.TooltipInfo.IsOwnerRowVisible;
-
-							var stance = o == null || world.RenderPlayer == null ? PlayerRelationship.None : o.RelationshipWith(world.RenderPlayer);
-							labelText = viewport.FrozenActorTooltip.TooltipInfo.TooltipForPlayerStance(stance);
-							break;
-						}
-				}
-
-				if (viewport.ActorTooltipExtra != null)
-				{
-					foreach (var info in viewport.ActorTooltipExtra)
-					{
-						if (info.IsTooltipVisible(world.RenderPlayer))
-						{
-							if (index != 0)
-								extraText += "\n";
-							extraText += info.TooltipText;
-							index++;
-						}
-					}
-				}
-
-				var textWidth = Math.Max(font.Measure(labelText).X, font.Measure(extraText).X);
-				label.Bounds.Width = textWidth;
-				widget.Bounds.Width = 2 * label.Bounds.X + textWidth;
-
-				if (showOwner)
-				{
-					flagFaction = o.Faction.InternalName;
-					ownerName = o.PlayerName;
-					ownerColor = o.Color;
-					widget.Bounds.Height = doubleHeight;
-					widget.Bounds.Width = Math.Max(widget.Bounds.Width,
-						owner.Bounds.X + ownerFont.Measure(ownerName).X + label.Bounds.X);
-					index++;
-				}
-				else
-					widget.Bounds.Height = singleHeight;
-
-				if (extraText != "")
-				{
-					widget.Bounds.Height += font.Measure(extraText).Y + extras.Bounds.Height;
-					if (showOwner)
-						extras.Bounds.Y = extraHeightOnDouble;
-					else
-						extras.Bounds.Y = extraHeightOnSingle;
-				}
+				AddCellTrigger();
+				InitializeTooltipContent();
 			};
 
 			label.GetText = () => labelText;
@@ -133,6 +88,114 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			owner.GetText = () => ownerName;
 			owner.GetColor = () => ownerColor;
 			extras.GetText = () => extraText;
+		}
+
+		void InitializeTooltipContent()
+		{
+			if (viewport == null || viewport.TooltipType == WorldTooltipType.None)
+				return;
+
+			var index = 0;
+			extraText = "";
+			showOwner = false;
+
+			Player o = null;
+			switch (viewport.TooltipType)
+			{
+				case WorldTooltipType.Unexplored:
+					labelText = modData.Translation.GetString(UnrevealedTerrain);
+					break;
+				case WorldTooltipType.Resource:
+					labelText = viewport.ResourceTooltip;
+					break;
+				case WorldTooltipType.Actor:
+					{
+						o = viewport.ActorTooltip.Owner;
+						showOwner = o != null && !o.NonCombatant && viewport.ActorTooltip.TooltipInfo.IsOwnerRowVisible;
+
+						var stance = o == null || world.RenderPlayer == null ? PlayerRelationship.None : o.RelationshipWith(world.RenderPlayer);
+						labelText = viewport.ActorTooltip.TooltipInfo.TooltipForPlayerStance(stance);
+						break;
+					}
+
+				case WorldTooltipType.FrozenActor:
+					{
+						o = viewport.FrozenActorTooltip.TooltipOwner;
+						showOwner = o != null && !o.NonCombatant && viewport.FrozenActorTooltip.TooltipInfo.IsOwnerRowVisible;
+
+						var stance = o == null || world.RenderPlayer == null ? PlayerRelationship.None : o.RelationshipWith(world.RenderPlayer);
+						labelText = viewport.FrozenActorTooltip.TooltipInfo.TooltipForPlayerStance(stance);
+						break;
+					}
+			}
+
+			if (viewport.ActorTooltipExtra != null)
+			{
+				foreach (var info in viewport.ActorTooltipExtra)
+				{
+					if (info.IsTooltipVisible(world.RenderPlayer))
+					{
+						if (index != 0)
+							extraText += "\n";
+						extraText += info.TooltipText;
+						index++;
+					}
+				}
+			}
+
+			var textWidth = Math.Max(font.Measure(labelText).X, font.Measure(extraText).X);
+			label.Bounds.Width = textWidth;
+			widget.Bounds.Width = 2 * label.Bounds.X + textWidth;
+
+			if (showOwner)
+			{
+				flagFaction = o.Faction.InternalName;
+				ownerName = o.PlayerName;
+				ownerColor = o.Color;
+				widget.Bounds.Height = doubleHeight;
+				widget.Bounds.Width = Math.Max(widget.Bounds.Width,
+					owner.Bounds.X + ownerFont.Measure(ownerName).X + label.Bounds.X);
+				index++;
+			}
+			else
+				widget.Bounds.Height = singleHeight;
+
+			if (extraText != "")
+			{
+				widget.Bounds.Height += font.Measure(extraText).Y + extras.Bounds.Height;
+				if (showOwner)
+					extras.Bounds.Y = extraHeightOnDouble;
+				else
+					extras.Bounds.Y = extraHeightOnSingle;
+			}
+		}
+
+		void RemoveCellTrigger()
+		{
+			if (cellTrigger != CellTriggerNone)
+			{
+				world.ActorMap.RemoveCellTrigger(cellTrigger);
+				cellTrigger = CellTriggerNone;
+				lastMapPos = CPos.Zero;
+			}
+		}
+
+		void AddCellTrigger()
+		{
+			var pos = worldRenderer.Viewport.ViewToWorld(Viewport.LastMousePos);
+			if (lastMapPos != pos)
+			{
+				RemoveCellTrigger();
+				cellTrigger = world.ActorMap.AddCellTrigger(new CPos[] { pos },
+					_ => InitializeTooltipContent(),
+					_ => InitializeTooltipContent());
+				lastMapPos = pos;
+			}
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			RemoveCellTrigger();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -202,6 +202,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						{ "onExit", Game.IsHost ? (Action)UpdateSelectedMap : modData.MapCache.UpdateMaps },
 						{ "onSelect", Game.IsHost ? onSelect : null },
 						{ "filter", MapVisibility.Lobby },
+						{ "worldRenderer", worldRenderer },
 					});
 				};
 			}

--- a/OpenRA.Mods.Common/Widgets/TooltipContainerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TooltipContainerWidget.cs
@@ -34,9 +34,12 @@ namespace OpenRA.Mods.Common.Widgets
 
 		/// <summary>First time the current tooltip is to be rendered after the last mouse move/event.</summary>
 		bool initialRender;
+		readonly WorldRenderer worldRenderer;
 
-		public TooltipContainerWidget()
+		[ObjectCreator.UseCtor]
+		public TooltipContainerWidget(WorldRenderer worldRenderer)
 		{
+			this.worldRenderer = worldRenderer;
 			graphicSettings = Game.Settings.Graphics;
 			initialRender = true;
 
@@ -58,7 +61,11 @@ namespace OpenRA.Mods.Common.Widgets
 			if (id == null || tooltip != null)
 				return;
 
-			tooltip = Ui.LoadWidget(id, this, new WidgetArgs(widgetArgs) { { "tooltipContainer", this } });
+			tooltip = Ui.LoadWidget(id, this, new WidgetArgs(widgetArgs)
+			{
+				{ "tooltipContainer", this },
+				{ "worldRenderer", worldRenderer }
+			});
 		}
 
 		public int SetTooltip(string id, WidgetArgs args)


### PR DESCRIPTION

Avoid upating tooltip text and dimension each render frame - i.e. 60 times per second. Calculating the dimensions of the text is relatively expensive. The user will not notice a delay of 1 second.

Extends #20129. 