### PR TITLE
Improve UnitBuilderBotModule and BaseBuilderBotModule multi-queue performance

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -18,7 +18,8 @@ namespace OpenRA.Mods.Common.Traits
 {
 	sealed class BaseBuilderQueueManager
 	{
-		readonly string category;
+		public readonly string Category;
+		public int WaitTicks;
 
 		readonly BaseBuilderBotModule baseBuilder;
 		readonly World world;
@@ -27,7 +28,6 @@ namespace OpenRA.Mods.Common.Traits
 		readonly PlayerResources playerResources;
 		readonly IResourceLayer resourceLayer;
 
-		int waitTicks;
 		Actor[] playerBuildings;
 		int failCount;
 		int failRetryTicks;
@@ -35,6 +35,8 @@ namespace OpenRA.Mods.Common.Traits
 		int cachedBases;
 		int cachedBuildings;
 		int minimumExcessPower;
+
+		bool itemQueuedThisTick = false;
 
 		WaterCheck waterState = WaterCheck.NotChecked;
 
@@ -47,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 			playerPower = pm;
 			playerResources = pr;
 			resourceLayer = rl;
-			this.category = category;
+			Category = category;
 			failRetryTicks = baseBuilder.Info.StructureProductionResumeDelay;
 			minimumExcessPower = baseBuilder.Info.MinimumExcessPower;
 			if (baseBuilder.Info.NavalProductionTypes.Count == 0)
@@ -94,23 +96,27 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// Only update once per second or so
-			if (--waitTicks > 0)
+			if (WaitTicks > 0)
 				return;
 
 			playerBuildings = world.ActorsHavingTrait<Building>().Where(a => a.Owner == player).ToArray();
 			var excessPowerBonus = baseBuilder.Info.ExcessPowerIncrement * (playerBuildings.Length / baseBuilder.Info.ExcessPowerIncreaseThreshold.Clamp(1, int.MaxValue));
 			minimumExcessPower = (baseBuilder.Info.MinimumExcessPower + excessPowerBonus).Clamp(baseBuilder.Info.MinimumExcessPower, baseBuilder.Info.MaximumExcessPower);
 
+			// PERF: Queue only one actor at a time per category
+			itemQueuedThisTick = false;
 			var active = false;
-			foreach (var queue in AIUtils.FindQueues(player, category))
+			foreach (var queue in AIUtils.FindQueues(player, Category))
+			{
 				if (TickQueue(bot, queue))
 					active = true;
+			}
 
 			// Add a random factor so not every AI produces at the same tick early in the game.
 			// Minimum should not be negative as delays in HackyAI could be zero.
 			var randomFactor = world.LocalRandom.Next(0, baseBuilder.Info.StructureProductionRandomBonusDelay);
 
-			waitTicks = active ? baseBuilder.Info.StructureProductionActiveDelay + randomFactor
+			WaitTicks = active ? baseBuilder.Info.StructureProductionActiveDelay + randomFactor
 				: baseBuilder.Info.StructureProductionInactiveDelay + randomFactor;
 		}
 
@@ -121,11 +127,16 @@ namespace OpenRA.Mods.Common.Traits
 			// Waiting to build something
 			if (currentBuilding == null && failCount < baseBuilder.Info.MaximumFailedPlacementAttempts)
 			{
+				// PERF: We shouldn't be queueing new units when we're low on cash
+				if (playerResources.GetCashAndResources() < baseBuilder.Info.ProductionMinCashRequirement || itemQueuedThisTick)
+					return false;
+
 				var item = ChooseBuildingToBuild(queue);
 				if (item == null)
 					return false;
 
 				bot.QueueOrder(Order.StartProduction(queue.Actor, item.Name, 1));
+				itemQueuedThisTick = true;
 			}
 			else if (currentBuilding != null && currentBuilding.Done)
 			{
@@ -335,7 +346,7 @@ namespace OpenRA.Mods.Common.Traits
 				var buildingVariantInfo = actorInfo.TraitInfoOrDefault<PlaceBuildingVariantsInfo>();
 				var variants = buildingVariantInfo?.Actors ?? Array.Empty<string>();
 
-				var count = playerBuildings.Count(a => a.Info.Name == name || variants.Contains(a.Info.Name));
+				var count = playerBuildings.Count(a => a.Info.Name == name || variants.Contains(a.Info.Name)) + (baseBuilder.BuildingsBeingProduced.TryGetValue(name, out var num) ? num : 0);
 
 				// Do we want to build this structure?
 				if (count * 100 > frac.Value * playerBuildings.Length)

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -263,7 +263,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// Make sure that we can spend as fast as we are earning
-			if (baseBuilder.Info.NewProductionCashThreshold > 0 && playerResources.Resources > baseBuilder.Info.NewProductionCashThreshold)
+			if (baseBuilder.Info.NewProductionCashThreshold > 0 && playerResources.GetCashAndResources() > baseBuilder.Info.NewProductionCashThreshold)
 			{
 				var production = GetProducibleBuilding(baseBuilder.Info.ProductionTypes, buildableThings);
 				if (production != null && HasSufficientPowerForActor(production))
@@ -281,7 +281,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Only consider building this if there is enough water inside the base perimeter and there are close enough adjacent buildings
 			if (waterState == WaterCheck.EnoughWater && baseBuilder.Info.NewProductionCashThreshold > 0
-				&& playerResources.Resources > baseBuilder.Info.NewProductionCashThreshold
+				&& playerResources.GetCashAndResources() > baseBuilder.Info.NewProductionCashThreshold
 				&& AIUtils.IsAreaAvailable<GivesBuildableArea>(world, player, world.Map, baseBuilder.Info.CheckForWaterRadius, baseBuilder.Info.WaterTerrainTypes))
 			{
 				var navalproduction = GetProducibleBuilding(baseBuilder.Info.NavalProductionTypes, buildableThings);

--- a/OpenRA.Mods.Common/Traits/Crates/GiveCashCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GiveCashCrateAction.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override int GetSelectionShares(Actor collector)
 		{
 			var pr = collector.Owner.PlayerActor.Trait<PlayerResources>();
-			if (info.Amount < 0 && pr.Cash + pr.Resources == 0)
+			if (info.Amount < 0 && pr.GetCashAndResources() == 0)
 				return 0;
 
 			return base.GetSelectionShares(collector);

--- a/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.Traits
 			else
 			{
 				// Don't put the player into negative funds
-				amount = Math.Max(-(Cash + Resources), amount);
+				amount = Math.Max(-GetCashAndResources(), amount);
 
 				TakeCash(-amount);
 			}
@@ -182,7 +182,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool TakeCash(int num, bool notifyLowFunds = false)
 		{
-			if (Cash + Resources < num)
+			if (GetCashAndResources() < num)
 			{
 				if (notifyLowFunds && Game.RunTime > lastNotificationTime + Info.InsufficientFundsNotificationInterval)
 				{

--- a/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
@@ -218,5 +218,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (Resources > ResourceCapacity)
 				Resources = ResourceCapacity;
 		}
+
+		public int GetCashAndResources()
+		{
+			return Cash + Resources;
+		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.world = world;
 			player = world.LocalPlayer;
 			playerResources = player.PlayerActor.Trait<PlayerResources>();
-			displayResources = playerResources.Cash + playerResources.Resources;
+			displayResources = playerResources.GetCashAndResources();
 
 			siloUsageTooltipCache = new CachedTransform<(int Resources, int Capacity), string>(x =>
 				TranslationProvider.GetString(SiloUsage, Translation.Arguments("usage", x.Resources, "capacity", x.Capacity)));
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (nextCashTickTime > 0)
 				nextCashTickTime--;
 
-			var actual = playerResources.Cash + playerResources.Resources;
+			var actual = playerResources.GetCashAndResources();
 
 			var diff = Math.Abs(actual - displayResources);
 			var move = Math.Min(Math.Max((int)(diff * DisplayFracPerFrame), DisplayDeltaPerFrame), diff);

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -432,7 +432,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var res = player.PlayerActor.Trait<PlayerResources>();
 			var cashText = new CachedTransform<int, string>(i => "$" + i);
-			template.Get<LabelWidget>("CASH").GetText = () => cashText.Update(res.Cash + res.Resources);
+			template.Get<LabelWidget>("CASH").GetText = () => cashText.Update(res.GetCashAndResources());
 
 			var incomeText = new CachedTransform<int, string>(i => "$" + i);
 			template.Get<LabelWidget>("INCOME").GetText = () => incomeText.Update(stats.DisplayIncome);
@@ -477,7 +477,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var res = player.PlayerActor.Trait<PlayerResources>();
 			var cashText = new CachedTransform<int, string>(i => "$" + i);
-			template.Get<LabelWidget>("CASH").GetText = () => cashText.Update(res.Cash + res.Resources);
+			template.Get<LabelWidget>("CASH").GetText = () => cashText.Update(res.GetCashAndResources());
 
 			var powerRes = player.PlayerActor.TraitOrDefault<PowerManager>();
 			if (powerRes != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -134,7 +134,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var timeSize = font.Measure(timeLabel.Text);
 
 				costLabel.Text = cost.ToString(NumberFormatInfo.CurrentInfo);
-				costLabel.GetColor = () => pr.Cash + pr.Resources >= cost ? Color.White : Color.Red;
+				costLabel.GetColor = () => pr.GetCashAndResources() >= cost ? Color.White : Color.Red;
 				var costSize = font.Measure(costLabel.Text);
 
 				descLabel.Text = buildable.Description.Replace("\\n", "\n");


### PR DESCRIPTION
UnitBuilderBotModule and BaseBuilderBotModule fix on muti-queue performance:

1. Only allow new item being queued when cash above a certain number

2. Only tick one kind of queues at one tick, reduce the pressure on the actived tick

3. 'BaseBuilderBotModule' will check all buildings in producing, avoid queue mutiple same buildings.

About to make a testcase in cnc mod
