### PR TITLE
Fix a crash when there is no briefing text

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoBriefingLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoBriefingLogic.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var missionData = world.Map.Rules.Actors[SystemActors.World].TraitInfoOrDefault<MissionDataInfo>();
 			if (missionData != null)
 			{
-				var text = WidgetUtils.WrapText(missionData.Briefing.Replace("\\n", "\n"), mapDescription.Bounds.Width, mapFont);
+				var text = WidgetUtils.WrapText(missionData.Briefing?.Replace("\\n", "\n"), mapDescription.Bounds.Width, mapFont);
 				mapDescription.Text = text;
 				mapDescription.Bounds.Height = mapFont.Measure(text).Y;
 				mapDescriptionPanel.ScrollToTop();

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -234,7 +234,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					infoVideo = missionData.BackgroundVideo;
 					infoVideoVisible = infoVideo != null;
 
-					var briefing = WidgetUtils.WrapText(missionData.Briefing.Replace("\\n", "\n"), description.Bounds.Width, descriptionFont);
+					var briefing = WidgetUtils.WrapText(missionData.Briefing?.Replace("\\n", "\n"), description.Bounds.Width, descriptionFont);
 					var height = descriptionFont.Measure(briefing).Y;
 					Game.RunAfterTick(() =>
 					{


### PR DESCRIPTION
Closes #20132.

The change in `GameInfoBriefingLogic` is more or less "cosmetic". https://github.com/OpenRA/OpenRA/blob/804bff1b0ee9afa95517e4b8c71f3afb2cefdc89/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs#L59-L62 ensures all current usages of `GameInfoBriefingLogic` have a briefing present. But I figured while I was here I can also make `GameInfoBriefingLogic` a bit more robust by not solely relying on code in `GameInfoLogic`.