### PR TITLE
Align weapons to better match original d2k

### DIFF
--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -759,7 +759,7 @@ medium_gun_turret:
 large_gun_turret:
 	Inherits: ^Defense
 	Inherits@IDISABLE: ^DisableOnLowPowerOrPowerDown
-	Inherits@AUTOTARGET: ^AutoTargetGround
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	AttackTurreted:
 		PauseOnCondition: disabled || build-incomplete
 	Buildable:

--- a/mods/d2k/weapons/largeguns.yaml
+++ b/mods/d2k/weapons/largeguns.yaml
@@ -4,15 +4,15 @@
 	Report: MEDTANK1.WAV
 	Projectile: Bullet
 		Speed: 562
-		Inaccuracy: 128
+		Inaccuracy: 135
 		InaccuracyType: PerCellIncrement
 		Image: 120mm
 	Warhead@1Dam: SpreadDamage
 		Damage: 2700
-		Spread: 512
+		Spread: 756
 		Falloff: 100, 0
 		Versus:
-			none: 20
+			none: 30
 			wall: 50
 			building: 50
 			wood: 60
@@ -65,7 +65,7 @@ DevBullet:
 	Warhead@1Dam: SpreadDamage
 		Damage: 6500
 		Versus:
-			none: 50
+			none: 65
 			wall: 100
 			building: 75
 			wood: 60
@@ -93,7 +93,7 @@ DevBullet:
 		Image: 155mm
 	Warhead@1Dam: SpreadDamage
 		Damage: 4500
-		Spread: 1c0
+		Spread: 2c0
 		Versus:
 			none: 125
 			wall: 100
@@ -104,7 +104,11 @@ DevBullet:
 			invulnerable: 0
 			cy: 20
 			harvester: 25
-		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+		DamageTypes: Prone50Percent, ExplosionDeath
+	Warhead@proneeffect: TargetDamage
+		DamageTypes: TriggerProne
+		Damage: 1
+		Spread: 1c512
 	Warhead@4Concrete: DamagesConcrete
 		Damage: 5625
 	Warhead@3Eff: CreateEffect

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -5,7 +5,7 @@
 	Projectile: Bullet
 		Blockable: false
 		Speed: 281
-		Inaccuracy: 128
+		Inaccuracy: 140
 		InaccuracyType: PerCellIncrement
 		Image: RPG
 		TrailImage: bazooka_trail2
@@ -13,10 +13,10 @@
 		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
 		Damage: 3000
-		Spread: 512
+		Spread: 700
 		Falloff: 100, 0
 		Versus:
-			none: 8
+			none: 15
 			wall: 75
 			building: 40
 			wood: 45
@@ -44,8 +44,10 @@
 	MinRange: 0c512
 	Projectile: Missile
 		Shadow: true
-		HorizontalRateOfTurn: 12
-		RangeLimit: 6c614
+		InaccuracyType: Maximum
+		Inaccuracy: 250
+		HorizontalRateOfTurn: 22
+		RangeLimit: 7c614
 		CruiseAltitude: 1c0
 		MinimumLaunchAngle: 64
 		VerticalRateOfTurn: 40
@@ -54,6 +56,7 @@
 		Speed: 288
 	Warhead@1Dam: SpreadDamage
 		Damage: 4800
+		Spread: 1c0
 		Versus:
 			none: 15
 			wall: 75
@@ -64,6 +67,11 @@
 			invulnerable: 0
 			cy: 30
 			harvester: 50
+		DamageTypes: Prone50Percent, SmallExplosionDeath
+	Warhead@proneeffect: TargetDamage
+		Damage: 1
+		Spread: 600
+		DamageTypes: TriggerProne
 	Warhead@4Concrete: DamagesConcrete
 		Damage: 720
 	Warhead@3Eff: CreateEffect
@@ -103,8 +111,6 @@ TowerMissile:
 	Burst: 2
 	BurstDelays: 60
 	ValidTargets: Ground, Air
-	Projectile: Missile
-		HorizontalRateOfTurn: 4
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: Ground, Air
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -8,35 +8,18 @@ Sound:
 		InaccuracyType: PerCellIncrement
 		Duration: 4 # Has a length of 0c512
 		DamageInterval: 3 # Travels 0c384 between impacts, will hit a target roughly three times
-		Width: 0c512
-		Shape: Flat
-		Falloff: 100, 100, 50
-		Range: 0, 6c0, 11c0
+		Width: 0c756 # in original d2k width is 2c0, but damage is 100% only at the center and fades out linearly towards the edges
+		Shape: Cylindrical
+		Falloff: 0, 0, 100, 0
+		Range: 0, 0c450, 4c0, 8c0
 		BeyondTargetRange: 1c0
 		Color: 00FFFFC8
 	Warhead@1Dam: SpreadDamage
 		Range: 0, 32
 		Falloff: 100, 100
-		Damage: 860
+		Damage: 960
 		AffectsParent: false
-		ValidRelationships: Neutral, Enemy
-		Versus:
-			none: 200
-			wall: 50
-			building: 60
-			wood: 110
-			light: 110
-			heavy: 60
-			invulnerable: 0
-			cy: 20
-			harvester: 50
-		DamageTypes: Prone50Percent, TriggerProne, SoundDeath
-	Warhead@2Dam: SpreadDamage
-		Range: 0, 32
-		Falloff: 100, 100
-		Damage: 430 # Only does half damage to friendly units
-		AffectsParent: false
-		ValidRelationships: Ally
+		ValidRelationships: Neutral, Enemy, Ally
 		Versus:
 			none: 200
 			wall: 50
@@ -70,7 +53,7 @@ OrniBomb:
 		Shadow: true
 	Warhead@1Dam: SpreadDamage
 		Damage: 7500 #400 in original, reduce when bombers can do multiple passes
-		Spread: 1c0
+		Spread: 2c0
 		Falloff: 100, 0
 		Versus:
 			none: 90
@@ -136,6 +119,7 @@ DeathHandCluster:
 		BounceCount: 0
 	Warhead@1Dam: SpreadDamage
 		Damage: 4500
+		Spread: 2c0
 		Versus:
 			none: 90
 			wall: 50
@@ -224,18 +208,22 @@ grenade:
 		Shadow: true
 	Warhead@1Dam: SpreadDamage
 		Damage: 1500
-		Spread: 1c0
+		Spread: 1c512
 		Falloff: 100, 0
 		Versus:
-			none: 125
+			none: 135
 			wood: 70
 			light: 30
 			heavy: 20
 			invulnerable: 0
 			cy: 20
 			harvester: 25
-		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+		DamageTypes: Prone50Percent, ExplosionDeath
 		DamageCalculationType: ClosestTargetablePosition
+	Warhead@proneeffect: TargetDamage
+		Damage: 1
+		Spread: 1c0
+		DamageTypes: TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater
 		InvalidTargets: Vehicle, Structure

--- a/mods/d2k/weapons/smallguns.yaml
+++ b/mods/d2k/weapons/smallguns.yaml
@@ -3,18 +3,19 @@
 	Range: 2c512
 	Report: MGUN2.WAV
 	Projectile: InstantHit
-		Inaccuracy: 128
+		Inaccuracy: 135
 		InaccuracyType: PerCellIncrement
 	Warhead@1Dam: SpreadDamage
 		Damage: 1250
 		Spread: 480
 		Falloff: 100, 0
 		Versus:
+			none: 110
 			wall: 10
 			building: 25
 			wood: 75
 			light: 40
-			heavy: 20
+			heavy: 18
 			invulnerable: 0
 			cy: 20
 			harvester: 25


### PR DESCRIPTION
closes #20021
This PR aim to bring ORA D2k closer to original D2k with minimum changes possible. Based on research here: https://github.com/OpenRA/OpenRA/issues/20021. Testing method was by shooting with each unit into unit blobs of every type from various range. Prone effect applies random in original D2k. To compensate this some weapons have smaller prone effect AoE. Most difference between ORA D2k and orig D2k was with all units VS infantry. (probably because random prone effect or random Prone50Percent triggering). To compensate this, some weapons have more damage against none armor

Detailed statistic are here:


[damage comparision.pdf](https://github.com/OpenRA/OpenRA/files/9173707/damage.comparision.pdf)

Changes are inline with #17972