### PR TITLE
Match input modifiers and mouse buttons to SDL ones.

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -114,7 +114,7 @@ namespace OpenRA
 		public static bool HasModifier(this Modifiers k, Modifiers mod)
 		{
 			// PERF: Enum.HasFlag is slower and requires allocations.
-			return (k & mod) == mod;
+			return (k & mod) != 0;
 		}
 
 		public static V GetOrAdd<K, V>(this Dictionary<K, V> d, K k)

--- a/OpenRA.Game/Input/IInputHandler.cs
+++ b/OpenRA.Game/Input/IInputHandler.cs
@@ -42,23 +42,24 @@ namespace OpenRA
 		}
 	}
 
-	[Flags]
+	/// <summary>Values taken from SDL_mouse to allow direct mapping.</summary>
 	public enum MouseButton
 	{
 		None = 0,
 		Left = 1,
-		Right = 2,
-		Middle = 4
+		Middle = 2,
+		Right = 3
 	}
 
+	/// <summary>Mask values taken from SDL_keycode to allow direct mapping.</summary>
 	[Flags]
 	public enum Modifiers
 	{
 		None = 0,
-		Shift = 1,
-		Alt = 2,
-		Ctrl = 4,
-		Meta = 8,
+		Shift = 0x0001 | 0x0002,
+		Ctrl = 0x0040 | 0x0080,
+		Alt = 0x0100 | 0x0200,
+		Meta = 0x0400 | 0x0800,
 	}
 
 	public enum KeyInputEvent { Down, Up }

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -130,7 +130,7 @@ namespace OpenRA.Traits
 		public static bool HasModifier(this TargetModifiers self, TargetModifiers m)
 		{
 			// PERF: Enum.HasFlag is slower and requires allocations.
-			return (self & m) == m;
+			return (self & m) != 0;
 		}
 	}
 

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -38,6 +38,8 @@ namespace OpenRA.Platforms.Default
 		float scaleModifier;
 		readonly GLProfile profile;
 		readonly GLProfile[] supportedProfiles;
+		public readonly bool HasCompatibleKeyModifiers;
+		public readonly bool HasCompatibleMouseButtons;
 
 		internal IntPtr Window
 		{
@@ -327,6 +329,35 @@ namespace OpenRA.Platforms.Default
 
 			SDL.SDL_SetModState(SDL.SDL_Keymod.KMOD_NONE);
 			input = new Sdl2Input();
+			HasCompatibleKeyModifiers = AreKeyModifiersCompatible();
+			HasCompatibleMouseButtons = AreMouseButtonsCompatible();
+		}
+
+		static bool AreKeyModifiersCompatible()
+		{
+			// Expected to be true. Unlikely for SDL values to change across versions.
+			var compatible = (((int)Modifiers.Alt == (int)SDL.SDL_Keymod.KMOD_ALT)
+				&& (int)Modifiers.Ctrl == (int)SDL.SDL_Keymod.KMOD_CTRL)
+				&& (int)Modifiers.Meta == ((int)SDL.SDL_Keymod.KMOD_LGUI | (int)SDL.SDL_Keymod.KMOD_RGUI)
+				&& (int)Modifiers.Shift == ((int)SDL.SDL_Keymod.KMOD_SHIFT);
+
+			if (!compatible)
+				Log.Write("graphics", $"OpenRA input key modifiers differ from those of SDL. Applying indirect mapping.");
+
+			return compatible;
+		}
+
+		static bool AreMouseButtonsCompatible()
+		{
+			// Expected to be true. Unlikely for SDL values to change across versions.
+			var compatible = ((int)MouseButton.Left == (int)SDL.SDL_BUTTON_LEFT
+				&& (int)MouseButton.Right == (int)SDL.SDL_BUTTON_RIGHT
+				&& (int)MouseButton.Middle == (int)SDL.SDL_BUTTON_MIDDLE);
+
+			if (!compatible)
+				 Log.Write("graphics", $"OpenRA input mouse button ID's differ from those of SDL. Applying indirect mapping.");
+
+			return compatible;
 		}
 
 		byte[] DoublePixelData(byte[] data, Size size)


### PR DESCRIPTION

Closes #17172

- Change `Modifiers` and `MouseButtons` enum values to match masks and values of SDL.
- Let SDL platform determine at startup if mapping is compatible.
- Use (trivial) faster direct mapping if possble - fall back on past conversion otherwise. 
- Remove "[flags]"  from MouseButton enum - as it was never a flag - events handled per individual button click. 
- Modifiers are a mask (i.e. Ctrl is either Left or Right control key mask).
- Log an info message if unexpectedly SDL ID/enum values do change over versions.

Implementing it this way avoids generic platform to have to reference SDL. Theoretical future other - non SDL - implementations are not negatively impacted. 


