### PR TITLE
Make ornithopter targetable by anti-air units

### DIFF
--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -108,6 +108,8 @@ ornithopter:
 		TurnSpeed: 8
 		Repulsable: False
 		CruiseAltitude: 1920
+	Targetable:
+		TargetTypes: Air
 	AmmoPool:
 		Ammo: 5
 	Tooltip:


### PR DESCRIPTION
Ornithopters should be targetable by anti-air units. 
![orni description](https://user-images.githubusercontent.com/100044015/180611491-ae58ac4c-c6d9-4bf5-8fe8-864a2f81fa74.png)

