### PR TITLE
Fix tab completion to work for all available commands.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var disableTeamChat = alwaysDisabled || (world.LocalPlayer != null && !players.Any(p => p.IsAlliedWith(world.LocalPlayer)));
 			var teamChat = !disableTeamChat;
 
-			tabCompletion.Commands = chatTraits.OfType<ChatCommands>().SelectMany(x => x.Commands.Keys).ToList();
+			tabCompletion.Commands = chatTraits.OfType<ChatCommands>().ToArray().SelectMany(x => x.Commands.Keys);
 			tabCompletion.Names = orderManager.LobbyInfo.Clients.Select(c => c.Name).Distinct().ToList();
 
 			if (logicArgs.TryGetValue("Templates", out var templateIds))

--- a/OpenRA.Mods.Common/Widgets/Logic/TabCompletionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/TabCompletionLogic.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		string prefix;
 		string suffix;
 
-		public IList<string> Commands { get; set; }
+		public IEnumerable<string> Commands { get; set; }
 
 		public IList<string> Names { get; set; }
 


### PR DESCRIPTION
Commands are registered in WorldLoaded event handlers, and IngameChatLogic takes all registered commands and provides tab completion. However IngameChatLogic is also created during WorldLoaded via LoadWidgetAtGameStart. No initialization order is enforced between commands and LoadWidgetAtGameStart, so they can appear in any order.

If a command gets registered before LoadWidgetAtGameStart runs, then it will get tab completion. If it gets registered after then no tab completion is available, even though the command can still be used and appears when using '/help'.

To fix this, we allow the tab completion to check for available commands lazily, meaning it will check for available commands every time the tab key is pressed. This means it will always have the full list of commands available regardless of the initialization order.

----

Testcase: In RA, the `/triggers` command won't tab complete on bleed, but will work with this PR.