### PR TITLE
Refactor harvesting code

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/VoxelHarvesterDockSequence.cs
+++ b/OpenRA.Mods.Cnc/Activities/VoxelHarvesterDockSequence.cs
@@ -20,11 +20,11 @@ namespace OpenRA.Mods.Cnc.Activities
 		readonly WithVoxelUnloadBody body;
 		readonly WithDockingOverlay spriteOverlay;
 
-		public VoxelHarvesterDockSequence(Actor self, Actor refinery, WAngle dockAngle, bool isDragRequired, in WVec dragOffset, int dragLength)
+		public VoxelHarvesterDockSequence(Harvester self, IAcceptResources refinery, WAngle dockAngle, bool isDragRequired, in WVec dragOffset, int dragLength)
 			: base(self, refinery, dockAngle, isDragRequired, dragOffset, dragLength)
 		{
-			body = self.Trait<WithVoxelUnloadBody>();
-			spriteOverlay = refinery.TraitOrDefault<WithDockingOverlay>();
+			body = self.Self.Trait<WithVoxelUnloadBody>();
+			spriteOverlay = refinery.Self.TraitOrDefault<WithDockingOverlay>();
 		}
 
 		public override void OnStateDock(Actor self)
@@ -32,8 +32,8 @@ namespace OpenRA.Mods.Cnc.Activities
 			body.Docked = true;
 			foreach (var trait in self.TraitsImplementing<INotifyHarvesterAction>())
 				trait.Docked();
-			foreach (var nd in Refinery.TraitsImplementing<INotifyDocking>())
-				nd.Docked(Refinery, self);
+			foreach (var nd in Proc.Self.TraitsImplementing<INotifyDocking>())
+				nd.Docked(Proc, self);
 
 			if (spriteOverlay != null && !spriteOverlay.Visible)
 			{
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Cnc.Activities
 			// If body.Docked wasn't set, we didn't actually dock and have to skip the undock overlay
 			if (!body.Docked)
 				dockingState = DockingState.Complete;
-			else if (Refinery.IsInWorld && !Refinery.IsDead && spriteOverlay != null && !spriteOverlay.Visible)
+			else if (Proc.IsAliveAndInWorld && spriteOverlay != null && !spriteOverlay.Visible)
 			{
 				dockingState = DockingState.Wait;
 				spriteOverlay.Visible = true;
@@ -66,9 +66,9 @@ namespace OpenRA.Mods.Cnc.Activities
 					foreach (var trait in self.TraitsImplementing<INotifyHarvesterAction>())
 						trait.Undocked();
 
-					if (Refinery.IsInWorld && !Refinery.IsDead)
-						foreach (var nd in Refinery.TraitsImplementing<INotifyDocking>())
-							nd.Undocked(Refinery, self);
+					if (Proc.IsAliveAndInWorld)
+						foreach (var nd in Proc.Self.TraitsImplementing<INotifyDocking>())
+							nd.Undocked(Proc, self);
 				});
 			}
 			else
@@ -79,9 +79,9 @@ namespace OpenRA.Mods.Cnc.Activities
 				foreach (var trait in self.TraitsImplementing<INotifyHarvesterAction>())
 					trait.Undocked();
 
-				if (Refinery.IsInWorld && !Refinery.IsDead)
-					foreach (var nd in Refinery.TraitsImplementing<INotifyDocking>())
-						nd.Undocked(Refinery, self);
+				if (Proc.IsAliveAndInWorld)
+					foreach (var nd in Proc.Self.TraitsImplementing<INotifyDocking>())
+						nd.Undocked(Proc, self);
 			}
 		}
 	}

--- a/OpenRA.Mods.Cnc/Traits/Buildings/TiberianSunRefinery.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/TiberianSunRefinery.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public TiberianSunRefinery(Actor self, RefineryInfo info)
 			: base(self, info) { }
 
-		public override Activity DockSequence(Actor harv, Actor self)
+		public override Activity DockSequence(Harvester harv, IAcceptResources self)
 		{
 			return new VoxelHarvesterDockSequence(harv, self, DeliveryAngle, IsDragRequired, DragOffset, DragLength);
 		}

--- a/OpenRA.Mods.Common/Activities/SpriteHarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/SpriteHarvesterDockSequence.cs
@@ -20,11 +20,11 @@ namespace OpenRA.Mods.Common.Activities
 		readonly WithDockingAnimationInfo wda;
 		protected bool dockAnimPlayed;
 
-		public SpriteHarvesterDockSequence(Actor self, Actor refinery, WAngle dockAngle, bool isDragRequired, in WVec dragOffset, int dragLength)
+		public SpriteHarvesterDockSequence(Harvester self, IAcceptResources refinery, WAngle dockAngle, bool isDragRequired, in WVec dragOffset, int dragLength)
 			: base(self, refinery, dockAngle, isDragRequired, dragOffset, dragLength)
 		{
-			wsb = self.Trait<WithSpriteBody>();
-			wda = self.Info.TraitInfoOrDefault<WithDockingAnimationInfo>();
+			wsb = self.Self.Trait<WithSpriteBody>();
+			wda = self.Self.Info.TraitInfoOrDefault<WithDockingAnimationInfo>();
 		}
 
 		public override void OnStateDock(Actor self)
@@ -32,8 +32,8 @@ namespace OpenRA.Mods.Common.Activities
 			foreach (var trait in self.TraitsImplementing<INotifyHarvesterAction>())
 				trait.Docked();
 
-			foreach (var nd in Refinery.TraitsImplementing<INotifyDocking>())
-				nd.Docked(Refinery, self);
+			foreach (var nd in Proc.Self.TraitsImplementing<INotifyDocking>())
+				nd.Docked(Proc, self);
 
 			if (wda != null)
 				wsb.PlayCustomAnimation(self, wda.DockSequence, () => wsb.PlayCustomAnimationRepeating(self, wda.DockLoopSequence));
@@ -65,9 +65,9 @@ namespace OpenRA.Mods.Common.Activities
 			foreach (var trait in self.TraitsImplementing<INotifyHarvesterAction>())
 				trait.Undocked();
 
-			if (Refinery.IsInWorld && !Refinery.IsDead)
-				foreach (var nd in Refinery.TraitsImplementing<INotifyDocking>())
-					nd.Undocked(Refinery, self);
+			if (Proc.IsAliveAndInWorld)
+				foreach (var nd in Proc.Self.TraitsImplementing<INotifyDocking>())
+					nd.Undocked(Proc, self);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/Properties/HarvesterProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/HarvesterProperties.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Search for nearby resources and begin harvesting.")]
 		public void FindResources()
 		{
-			Self.QueueActivity(new FindAndDeliverResources(Self));
+			Self.QueueActivity(new FindAndDeliverResources(Self.Trait<Harvester>()));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/CarryableHarvester.cs
+++ b/OpenRA.Mods.Common/Traits/CarryableHarvester.cs
@@ -34,10 +34,9 @@ namespace OpenRA.Mods.Common.Traits
 				t.RequestTransport(self, targetCell);
 		}
 
-		void INotifyHarvesterAction.MovingToRefinery(Actor self, Actor refineryActor)
+		void INotifyHarvesterAction.MovingToRefinery(Actor self, IAcceptResources refinery)
 		{
-			var iao = refineryActor.Trait<IAcceptResources>();
-			var location = refineryActor.Location + iao.DeliveryOffset;
+			var location = refinery.Location;
 			foreach (var t in transports)
 				t.RequestTransport(self, location);
 		}

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -272,7 +272,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyHarvesterAction.MovingToResources(Actor self, CPos targetCell) { }
 
-		void INotifyHarvesterAction.MovingToRefinery(Actor self, Actor refineryActor) { }
+		void INotifyHarvesterAction.MovingToRefinery(Actor self, IAcceptResources refinery) { }
 
 		void INotifyHarvesterAction.MovementCancelled(Actor self) { }
 

--- a/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				anim.Animation.PlayThen(Info.Sequence, PlayDockingOverlay);
 		}
 
-		void INotifyDocking.Docked(Actor self, Actor harvester) { docked = true; PlayDockingOverlay(); }
-		void INotifyDocking.Undocked(Actor self, Actor harvester) { docked = false; }
+		void INotifyDocking.Docked(IAcceptResources self, Actor harvester) { docked = true; PlayDockingOverlay(); }
+		void INotifyDocking.Undocked(IAcceptResources self, Actor harvester) { docked = false; }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		void INotifyHarvesterAction.Docked() { }
 		void INotifyHarvesterAction.Undocked() { }
 		void INotifyHarvesterAction.MovingToResources(Actor self, CPos targetCell) { }
-		void INotifyHarvesterAction.MovingToRefinery(Actor self, Actor refineryActor) { }
+		void INotifyHarvesterAction.MovingToRefinery(Actor self, IAcceptResources refineryActor) { }
 		void INotifyHarvesterAction.MovementCancelled(Actor self) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 
 		void INotifyHarvesterAction.MovingToResources(Actor self, CPos targetCell) { }
-		void INotifyHarvesterAction.MovingToRefinery(Actor self, Actor targetRefinery) { }
+		void INotifyHarvesterAction.MovingToRefinery(Actor self, IAcceptResources target) { }
 		void INotifyHarvesterAction.MovementCancelled(Actor self) { }
 		void INotifyHarvesterAction.Docked() { }
 		void INotifyHarvesterAction.Undocked() { }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.Common.Traits
 	public interface INotifyProduction { void UnitProduced(Actor self, Actor other, CPos exit); }
 	public interface INotifyOtherProduction { void UnitProducedByOther(Actor self, Actor producer, Actor produced, string productionType, TypeDictionary init); }
 	public interface INotifyDelivery { void IncomingDelivery(Actor self); void Delivered(Actor self); }
-	public interface INotifyDocking { void Docked(Actor self, Actor harvester); void Undocked(Actor self, Actor harvester); }
+	public interface INotifyDocking { void Docked(IAcceptResources proc, Actor harvester); void Undocked(IAcceptResources proc, Actor harvester); }
 
 	[RequireExplicitImplementation]
 	public interface INotifyResourceAccepted { void OnResourceAccepted(Actor self, Actor refinery, string resourceType, int count, int value); }
@@ -194,7 +194,7 @@ namespace OpenRA.Mods.Common.Traits
 	public interface INotifyHarvesterAction
 	{
 		void MovingToResources(Actor self, CPos targetCell);
-		void MovingToRefinery(Actor self, Actor refineryActor);
+		void MovingToRefinery(Actor self, IAcceptResources refinery);
 		void MovementCancelled(Actor self);
 		void Harvested(Actor self, string resourceType);
 		void Docked();
@@ -267,10 +267,16 @@ namespace OpenRA.Mods.Common.Traits
 	public interface IAcceptResourcesInfo : ITraitInfoInterface { }
 	public interface IAcceptResources
 	{
-		void OnDock(Actor harv, DeliverResources dockOrder);
+		void OnDock(Harvester harv, DeliverResources dockOrder);
 		int AcceptResources(string resourceType, int count = 1);
-		CVec DeliveryOffset { get; }
+		CPos Location { get; }
+		bool LinkHarvester(Harvester harvester);
+		void UnlinkHarvester(Harvester harvester);
+		void RefreshLinkedHarvesters();
 		bool AllowDocking { get; }
+		int Occupancy { get; }
+		Actor Self { get; }
+		bool IsAliveAndInWorld { get; }
 	}
 
 	public interface IProvidesAssetBrowserPalettes


### PR DESCRIPTION
This refactor should have any new functionality, but it fixes up and cleans up the code.

- In many places `Actor` reference has been turned into `Harvester` or `IAcceptsResources`
   - Often the trait was more useful than the `Actor`
   - This prepares for new `IDockable` and `IDock` interfaces that `Harvester` or `IAcceptsResources` are going to implement respectfully
- Linking code has been moved from `Harvester` to `Refinery` so that `Occupancy` is easily accessible
- Some repeating checks have been made into easily available functions