### PR TITLE
Make Red Alert SVG artwork square

### DIFF
--- a/packaging/artwork/ra_scalable.svg
+++ b/packaging/artwork/ra_scalable.svg
@@ -10,8 +10,8 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="128"
-   height="138"
-   viewBox="0 0 128 138"
+   height="128"
+   viewBox="0 0 128 128"
    id="svg2"
    xml:space="preserve"><metadata
    id="metadata28"><rdf:RDF><cc:Work


### PR DESCRIPTION
Fix typo in height (128 instead of 138).