### PR TITLE
PerfTickLogger, reduce overhead of logging long ticks.

### DIFF
--- a/OpenRA.Game/TraitDictionary.cs
+++ b/OpenRA.Game/TraitDictionary.cs
@@ -145,7 +145,6 @@ namespace OpenRA
 		{
 			readonly List<Actor> actors = new();
 			readonly List<T> traits = new();
-			readonly PerfTickLogger perfLogger = new();
 
 			public int Queries { get; private set; }
 
@@ -305,14 +304,14 @@ namespace OpenRA
 
 			public void ApplyToAllTimed(Action<Actor, T> action, string text)
 			{
-				perfLogger.Start();
+				var start = PerfTickLogger.GetTimestamp();
 				for (var i = 0; i < actors.Count; i++)
 				{
 					var actor = actors[i];
 					var trait = traits[i];
 					action(actor, trait);
 
-					perfLogger.LogTickAndRestartTimer(text, trait);
+					start = PerfTickLogger.LogLongTick(start, text, trait);
 				}
 			}
 		}

--- a/OpenRA.Game/Traits/ActivityUtils.cs
+++ b/OpenRA.Game/Traits/ActivityUtils.cs
@@ -19,21 +19,19 @@ namespace OpenRA.Traits
 		public static Activity RunActivity(Actor self, Activity act)
 		{
 			// PERF: This is a hot path and must run with minimal added overhead.
-			// If there are no activities we can bail straight away and save ourselves the overhead of setting up the perf logging.
 			if (act == null)
 				return act;
 
-			var perfLogger = new PerfTickLogger();
-			perfLogger.Start();
-			while (act != null)
+			var start = PerfTickLogger.GetTimestamp();
+			do
 			{
 				var prev = act;
 				act = act.TickOuter(self);
-				perfLogger.LogTickAndRestartTimer("Activity", prev);
-
+				start = PerfTickLogger.LogLongTick(start, "Activity", prev);
 				if (act == prev)
 					break;
 			}
+			while (act != null);
 
 			return act;
 		}

--- a/OpenRA.Game/WorldUtils.cs
+++ b/OpenRA.Game/WorldUtils.cs
@@ -66,14 +66,13 @@ namespace OpenRA
 		{
 			// PERF: This is a hot path and must run with minimal added overhead, so we enumerate manually
 			// to allow us to call PerfTickLogger only once per iteration in the normal case.
-			var perfLogger = new PerfTickLogger();
 			using (var enumerator = e.GetEnumerator())
 			{
-				perfLogger.Start();
+				var start = PerfTickLogger.GetTimestamp();
 				while (enumerator.MoveNext())
 				{
 					a(enumerator.Current);
-					perfLogger.LogTickAndRestartTimer(text, enumerator.Current);
+					start = PerfTickLogger.LogLongTick(start, text, enumerator.Current);
 				}
 			}
 		}


### PR DESCRIPTION

Make PerfTickLogger static. Do not allocate PerfLogTicker object on hot paths.

Would be nice if settings could send out notifications on changes of either any, sections of or specific setting values.
