### PR TITLE
Additional performance graph colors

### DIFF
--- a/OpenRA.Game/Support/PerfHistory.cs
+++ b/OpenRA.Game/Support/PerfHistory.cs
@@ -20,8 +20,10 @@ namespace OpenRA.Support
 			Color.Red, Color.Green,
 			Color.Orange, Color.Yellow,
 			Color.Fuchsia, Color.Lime,
-			Color.LightBlue, Color.Blue,
-			Color.White, Color.Teal
+			Color.Cyan, Color.Blue,
+			Color.White, Color.Teal,
+			Color.Pink, Color.MediumPurple,
+			Color.Olive, Color.CornflowerBlue
 		};
 
 		static int nextColor;


### PR DESCRIPTION
The performance graph has 10 colours defined but there are more than 10 lines shown, so some of the colours are used twice and you can't tell which thing is spiking.

This simply adds a few more colours that are easy to distinguish from the existing ones.