### PR TITLE
Health, calculate DamageState once, remove ITick.

### DIFF
--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -193,9 +193,9 @@ namespace OpenRA.Mods.Common
 		public static int ApplyPercentageModifiers(int number, IEnumerable<int> percentages)
 		{
 			// See the comments of PR#6079 for a faster algorithm if this becomes a performance bottleneck
-			var a = (decimal)number;
+			var a = (float)number;
 			foreach (var p in percentages)
-				a *= p / 100m;
+				a *= p / 100f;
 
 			return (int)a;
 		}


### PR DESCRIPTION


- Calculate `DamageState` when `hp` is updated - rather than each time the `DamageState` property is read. Reading seems to be contineous in game.
- Calculate `DisplayHP` when `hp` is updated. Allow removal of `ITick`.
- Remove `ITick`.
- Use `float` over `decimal` precision. 
- Use `int` over `long` precision.
