### PR TITLE
HitShape, query trait via actor cached targetable positions.

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -68,6 +68,7 @@ namespace OpenRA
 		public IEffectiveOwner EffectiveOwner { get; }
 		public IOccupySpace OccupiesSpace { get; }
 		public ITargetable[] Targetables { get; }
+		public IEnumerable<ITargetablePositions> EnabledTargetablePositions { get; private set; }
 
 		public bool IsIdle => CurrentActivity == null;
 		public bool IsDead => Disposed || (health != null && health.IsDead);
@@ -114,7 +115,6 @@ namespace OpenRA
 		readonly IDefaultVisibility defaultVisibility;
 		readonly INotifyBecomingIdle[] becomingIdles;
 		readonly INotifyIdle[] tickIdles;
-		readonly IEnumerable<ITargetablePositions> enabledTargetablePositions;
 		readonly IEnumerable<WPos> enabledTargetableWorldPositions;
 		bool created;
 
@@ -192,8 +192,8 @@ namespace OpenRA
 				tickIdles = tickIdlesList.ToArray();
 				Targetables = targetablesList.ToArray();
 				var targetablePositions = targetablePositionsList.ToArray();
-				enabledTargetablePositions = targetablePositions.Where(Exts.IsTraitEnabled);
-				enabledTargetableWorldPositions = enabledTargetablePositions.SelectMany(tp => tp.TargetablePositions(this));
+				EnabledTargetablePositions = targetablePositions.Where(Exts.IsTraitEnabled);
+				enabledTargetableWorldPositions = EnabledTargetablePositions.SelectMany(tp => tp.TargetablePositions(this));
 				SyncHashes = syncHashesList.ToArray();
 			}
 		}
@@ -530,7 +530,7 @@ namespace OpenRA
 
 		public IEnumerable<WPos> GetTargetablePositions()
 		{
-			if (enabledTargetablePositions.Any())
+			if (EnabledTargetablePositions.Any())
 				return enabledTargetableWorldPositions;
 
 			return new[] { CenterPosition };

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Effects;
@@ -336,9 +335,11 @@ namespace OpenRA.Mods.Common.Projectiles
 					continue;
 
 				// If the impact position is within any actor's HitShape, we have a direct hit
-				var activeShapes = victim.TraitsImplementing<HitShape>().Where(Exts.IsTraitEnabled);
-				if (activeShapes.Any(i => i.DistanceFromEdge(victim, pos).Length <= 0))
-					return true;
+				// PERF: Avoid using TraitsImplementing<HitShape> that needs to find the actor in the trait dictionary.
+				foreach (var targetPos in victim.EnabledTargetablePositions)
+					if (targetPos is HitShape h)
+						if (h.DistanceFromEdge(victim, pos).Length <= 0)
+							return true;
 			}
 
 			return false;

--- a/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
@@ -50,8 +50,14 @@ namespace OpenRA.Mods.Common.Warheads
 				if (!IsValidAgainst(victim, firedBy))
 					return;
 
-				var closestActiveShape = victim.TraitsImplementing<HitShape>().Where(Exts.IsTraitEnabled)
-					.MinByOrDefault(t => t.DistanceFromEdge(victim, victim.CenterPosition));
+				// PERF: Avoid using TraitsImplementing<HitShape> that needs to find the actor in the trait dictionary.
+				var closestActiveShape = (HitShape)victim.EnabledTargetablePositions.MinByOrDefault(t =>
+				{
+					if (t is HitShape h)
+						return h.DistanceFromEdge(victim, victim.CenterPosition);
+					else
+						return WDist.MaxValue;
+				});
 
 				// Cannot be damaged without an active HitShape
 				if (closestActiveShape == null)

--- a/OpenRA.Mods.Common/WorldExtensions.cs
+++ b/OpenRA.Mods.Common/WorldExtensions.cs
@@ -9,8 +9,8 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.Common
@@ -49,9 +49,11 @@ namespace OpenRA.Mods.Common
 			foreach (var currActor in actorsInSquare)
 			{
 				var actorWidth = 0;
-				var shapes = currActor.TraitsImplementing<HitShape>().Where(Exts.IsTraitEnabled);
-				if (shapes.Any())
-					actorWidth = shapes.Max(h => h.Info.Type.OuterRadius.Length);
+
+				// PERF: Avoid using TraitsImplementing<HitShape> that needs to find the actor in the trait dictionary.
+				foreach (var targetPos in currActor.EnabledTargetablePositions)
+					if (targetPos is HitShape hitshape)
+						actorWidth = Math.Max(actorWidth, hitshape.Info.Type.OuterRadius.Length);
 
 				var projection = lineStart.MinimumPointLineProjection(lineEnd, currActor.CenterPosition);
 				var distance = (currActor.CenterPosition - projection).HorizontalLength;


### PR DESCRIPTION
HitShape is the most looked up trait per per actor using `TraitsImplementing`. 

Using this method will search the global `TraitDictionary` for all actors with the trait and after search for the actor on which the method was called. 

Changes:
- Rather than using `TraitsImplementing` use the already available `enabledTargetablePositions` to find `HitShape` traits. 
- Add `Actor.GetEnabledTargetablePositions`.
- Because of this some Linq statements rewritten to foreach loops. 

Optional suggestions:
- Optionally rename `Actor.GetTargetablePositions` to `Actor.GetEnabledTargetableWorldPositions`
-  Move IHitShape to OpenRA.Game `TraitInterfaces`.  Add `ITargertablePositionsInterface.TargetableShapes()` to return an enumeration of HitShapes.

Assumptions:
- Casting `ITargetablePositions` to `HitShape` is faster than each time searching for an actor in the trait container.

Advantage:
- Save 300k times searching for a actor in the trait container. 

Statistics on traits being most often queried for an actor using `TraitDictionary.WithInterface`. Shelllmap + a short bot game,.
````
    391 OpenRA.Mods.Common.Traits.IGainsExperienceModifier
    429 OpenRA.Mods.Common.Traits.INotifyProduction
    458 OpenRA.Mods.Common.Traits.Tooltip
    607 OpenRA.Mods.Common.Traits.ISpeedModifier
    719 OpenRA.Mods.Common.Traits.ExternalCondition
    764 OpenRA.Mods.Common.Traits.Locomotor
    932 OpenRA.Mods.Common.Traits.IWallConnector
   1225 OpenRA.Mods.Common.Traits.SquadManagerBotModule
   1355 OpenRA.Mods.Common.Traits.Exit
   1384 OpenRA.Mods.Common.Traits.INotifyDamage
   1384 OpenRA.Mods.Common.Traits.INotifyKilled
   1400 OpenRA.Mods.Common.Traits.INotifyDocking
   1487 OpenRA.Mods.Common.Traits.SupportPower
   1489 OpenRA.Traits.INotifyAddedToWorld
   1661 OpenRA.Mods.Common.Traits.IDamageModifier
   1852 OpenRA.Mods.Common.Traits.Power
   1980 OpenRA.Traits.IProvideTooltipInfo
   1980 OpenRA.Traits.ITooltip
   2308 OpenRA.Mods.Common.Traits.AttackFrontal
   2363 OpenRA.Mods.Common.Traits.GivesBuildableArea
   2819 OpenRA.Traits.ISelectionBar
   6124 OpenRA.Mods.Common.Traits.SmudgeLayer
   6607 OpenRA.Mods.Common.Traits.AttackBase
   6763 OpenRA.Mods.Common.Traits.INotifyHarvesterAction
   8088 OpenRA.Mods.Common.Traits.RevealsShroud
   8374 OpenRA.Mods.Common.Traits.Armament
  16677 OpenRA.Mods.Common.Traits.Armor
  18434 OpenRA.Traits.IVisibilityModifier
  20703 OpenRA.Mods.Common.Traits.IBlocksProjectiles
  26319 OpenRA.Traits.IIssueOrder
  27066 OpenRA.Traits.IRenderAboveShroudWhenSelected
  27066 OpenRA.Traits.IRenderAnnotationsWhenSelected
  46052 OpenRA.Mods.Common.Traits.INotifyAppliedDamage
  57296 (not
  64625 OpenRA.Mods.Common.Traits.RejectsOrders
  77929 OpenRA.Traits.IRenderOverlay
  77931 OpenRA.Traits.IPaletteModifier
  93490 OpenRA.Mods.Common.Traits.IDisableEnemyAutoTarget
  98184 OpenRA.Mods.Common.Traits.ICrushable
 185125 OpenRA.Mods.Common.Traits.INotifyBlockingMove
 324904 OpenRA.Mods.Common.Traits.HitShape
````

