### PR TITLE
Introduce MaxRange into the AreaBeam projectile

### DIFF
--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -12,7 +12,8 @@ Sound:
 		Shape: Cylindrical
 		Falloff: 0, 0, 100, 0
 		Range: 0, 0c450, 4c0, 8c0
-		BeyondTargetRange: 1c0
+		BeyondTargetRange: 5c0
+		MaxRange: 5c0
 		Color: 00FFFFC8
 	Warhead@1Dam: SpreadDamage
 		Range: 0, 32


### PR DESCRIPTION
This PR enable Sonic tank to shoot always at maximum range. It do so by changing BeyondTargetRange to the same range as weapon range and limit beam target distance with MaxRange property. 
If MaxRange is 0 its value is equal to weapon range + BeyondTargetRange.
Default value: 0

P.s. As I m total newbie in coding, Im not sure if everything is inline with coding conventions.