### PR TITLE
Unify docking interfaces

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/VoxelHarvesterDockSequence.cs
+++ b/OpenRA.Mods.Cnc/Activities/VoxelHarvesterDockSequence.cs
@@ -30,9 +30,10 @@ namespace OpenRA.Mods.Cnc.Activities
 		public override void OnStateDock(Actor self)
 		{
 			body.Docked = true;
-			foreach (var trait in self.TraitsImplementing<INotifyHarvesterAction>())
-				trait.Docked();
-			foreach (var nd in Refinery.TraitsImplementing<INotifyDocking>())
+			foreach (var nd in self.TraitsImplementing<INotifyDockClient>())
+				nd.Docked(self, Refinery);
+
+			foreach (var nd in Refinery.TraitsImplementing<INotifyDockHost>())
 				nd.Docked(Refinery, self);
 
 			if (spriteOverlay != null && !spriteOverlay.Visible)
@@ -63,11 +64,11 @@ namespace OpenRA.Mods.Cnc.Activities
 					body.Docked = false;
 					spriteOverlay.Visible = false;
 
-					foreach (var trait in self.TraitsImplementing<INotifyHarvesterAction>())
-						trait.Undocked();
+					foreach (var nd in self.TraitsImplementing<INotifyDockClient>())
+						nd.Undocked(self, Refinery);
 
 					if (Refinery.IsInWorld && !Refinery.IsDead)
-						foreach (var nd in Refinery.TraitsImplementing<INotifyDocking>())
+						foreach (var nd in Refinery.TraitsImplementing<INotifyDockHost>())
 							nd.Undocked(Refinery, self);
 				});
 			}
@@ -76,11 +77,11 @@ namespace OpenRA.Mods.Cnc.Activities
 				dockingState = DockingState.Complete;
 				body.Docked = false;
 
-				foreach (var trait in self.TraitsImplementing<INotifyHarvesterAction>())
-					trait.Undocked();
+				foreach (var nd in self.TraitsImplementing<INotifyDockClient>())
+					nd.Undocked(self, Refinery);
 
 				if (Refinery.IsInWorld && !Refinery.IsDead)
-					foreach (var nd in Refinery.TraitsImplementing<INotifyDocking>())
+					foreach (var nd in Refinery.TraitsImplementing<INotifyDockHost>())
 						nd.Undocked(Refinery, self);
 			}
 		}

--- a/OpenRA.Mods.Common/Activities/SpriteHarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/SpriteHarvesterDockSequence.cs
@@ -29,10 +29,10 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override void OnStateDock(Actor self)
 		{
-			foreach (var trait in self.TraitsImplementing<INotifyHarvesterAction>())
-				trait.Docked();
+			foreach (var nd in self.TraitsImplementing<INotifyDockClient>())
+				nd.Docked(self, Refinery);
 
-			foreach (var nd in Refinery.TraitsImplementing<INotifyDocking>())
+			foreach (var nd in Refinery.TraitsImplementing<INotifyDockHost>())
 				nd.Docked(Refinery, self);
 
 			if (wda != null)
@@ -62,11 +62,11 @@ namespace OpenRA.Mods.Common.Activities
 		void NotifyUndock(Actor self)
 		{
 			dockingState = DockingState.Complete;
-			foreach (var trait in self.TraitsImplementing<INotifyHarvesterAction>())
-				trait.Undocked();
+			foreach (var nd in self.TraitsImplementing<INotifyDockClient>())
+				nd.Undocked(self, Refinery);
 
 			if (Refinery.IsInWorld && !Refinery.IsDead)
-				foreach (var nd in Refinery.TraitsImplementing<INotifyDocking>())
+				foreach (var nd in Refinery.TraitsImplementing<INotifyDockHost>())
 					nd.Undocked(Refinery, self);
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/CarryableHarvester.cs
+++ b/OpenRA.Mods.Common/Traits/CarryableHarvester.cs
@@ -49,7 +49,5 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		void INotifyHarvesterAction.Harvested(Actor self, string resourceType) { }
-		void INotifyHarvesterAction.Docked() { }
-		void INotifyHarvesterAction.Undocked() { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public class Cloak : PausableConditionalTrait<CloakInfo>, IRenderModifier, INotifyDamage, INotifyUnload, INotifyDemolition, INotifyInfiltration,
-		INotifyAttack, ITick, IVisibilityModifier, IRadarColorModifier, INotifyCreated, INotifyDockClient, INotifyBeingResupplied
+		INotifyAttack, ITick, IVisibilityModifier, IRadarColorModifier, INotifyCreated, INotifyDockClient
 	{
 		[Sync]
 		int remainingTime;
@@ -281,7 +281,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyDockClient.Undocked(Actor self, Actor host)
 		{
-			isDocking = false;
+			if (Info.UncloakOn.HasFlag(UncloakType.Dock))
+				isDocking = false;
 		}
 
 		void INotifyUnload.Unloading(Actor self)
@@ -300,21 +301,6 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (Info.UncloakOn.HasFlag(UncloakType.Infiltrate))
 				Uncloak();
-		}
-
-		void INotifyBeingResupplied.StartingResupply(Actor self, Actor host)
-		{
-			if (Info.UncloakOn.HasFlag(UncloakType.Dock))
-			{
-				isDocking = true;
-				Uncloak();
-			}
-		}
-
-		void INotifyBeingResupplied.StoppingResupply(Actor self, Actor host)
-		{
-			if (Info.UncloakOn.HasFlag(UncloakType.Dock))
-				isDocking = false;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public class Cloak : PausableConditionalTrait<CloakInfo>, IRenderModifier, INotifyDamage, INotifyUnload, INotifyDemolition, INotifyInfiltration,
-		INotifyAttack, ITick, IVisibilityModifier, IRadarColorModifier, INotifyCreated, INotifyHarvesterAction, INotifyBeingResupplied
+		INotifyAttack, ITick, IVisibilityModifier, IRadarColorModifier, INotifyCreated, INotifyDockClient, INotifyBeingResupplied
 	{
 		[Sync]
 		int remainingTime;
@@ -270,15 +270,7 @@ namespace OpenRA.Mods.Common.Traits
 			return color;
 		}
 
-		void INotifyHarvesterAction.MovingToResources(Actor self, CPos targetCell) { }
-
-		void INotifyHarvesterAction.MovingToRefinery(Actor self, Actor refineryActor) { }
-
-		void INotifyHarvesterAction.MovementCancelled(Actor self) { }
-
-		void INotifyHarvesterAction.Harvested(Actor self, string resourceType) { }
-
-		void INotifyHarvesterAction.Docked()
+		void INotifyDockClient.Docked(Actor self, Actor host)
 		{
 			if (Info.UncloakOn.HasFlag(UncloakType.Dock))
 			{
@@ -287,7 +279,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		void INotifyHarvesterAction.Undocked()
+		void INotifyDockClient.Undocked(Actor self, Actor host)
 		{
 			isDocking = false;
 		}

--- a/OpenRA.Mods.Common/Traits/Rearmable.cs
+++ b/OpenRA.Mods.Common/Traits/Rearmable.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Rearmable(this); }
 	}
 
-	public class Rearmable : INotifyCreated, INotifyResupply
+	public class Rearmable : INotifyCreated, INotifyDockClient
 	{
 		public readonly RearmableInfo Info;
 
@@ -44,17 +44,14 @@ namespace OpenRA.Mods.Common.Traits
 			RearmableAmmoPools = self.TraitsImplementing<AmmoPool>().Where(p => Info.AmmoPools.Contains(p.Info.Name)).ToArray();
 		}
 
-		void INotifyResupply.BeforeResupply(Actor self, Actor target, ResupplyType types)
+		void INotifyDockClient.Docked(Actor self, Actor dock)
 		{
-			if (!types.HasFlag(ResupplyType.Rearm))
-				return;
-
 			// Reset the ReloadDelay to avoid any issues with early cancellation
 			// from previous reload attempts (explicit order, host building died, etc).
 			foreach (var pool in RearmableAmmoPools)
 				pool.RemainingTicks = pool.Info.ReloadDelay;
 		}
 
-		void INotifyResupply.ResupplyTick(Actor self, Actor target, ResupplyType types) { }
+		void INotifyDockClient.Undocked(Actor self, Actor dock) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithDockedOverlay(init.Self, this); }
 	}
 
-	public class WithDockedOverlay : PausableConditionalTrait<WithDockedOverlayInfo>, INotifyDocking
+	public class WithDockedOverlay : PausableConditionalTrait<WithDockedOverlayInfo>, INotifyDockHost
 	{
 		readonly AnimationWithOffset anim;
 		bool docked;
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				anim.Animation.PlayThen(Info.Sequence, PlayDockingOverlay);
 		}
 
-		void INotifyDocking.Docked(Actor self, Actor harvester) { docked = true; PlayDockingOverlay(); }
-		void INotifyDocking.Undocked(Actor self, Actor harvester) { docked = false; }
+		void INotifyDockHost.Docked(Actor self, Actor client) { docked = true; PlayDockingOverlay(); }
+		void INotifyDockHost.Undocked(Actor self, Actor client) { docked = false; }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
@@ -44,8 +44,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 				wsb.PlayCustomAnimation(self, sequence);
 		}
 
-		void INotifyHarvesterAction.Docked() { }
-		void INotifyHarvesterAction.Undocked() { }
 		void INotifyHarvesterAction.MovingToResources(Actor self, CPos targetCell) { }
 		void INotifyHarvesterAction.MovingToRefinery(Actor self, Actor refineryActor) { }
 		void INotifyHarvesterAction.MovementCancelled(Actor self) { }

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
@@ -66,8 +66,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		void INotifyHarvesterAction.MovingToResources(Actor self, CPos targetCell) { }
 		void INotifyHarvesterAction.MovingToRefinery(Actor self, Actor targetRefinery) { }
 		void INotifyHarvesterAction.MovementCancelled(Actor self) { }
-		void INotifyHarvesterAction.Docked() { }
-		void INotifyHarvesterAction.Undocked() { }
 
 		public static int ZOffsetFromCenter(Actor self, WPos pos, int offset)
 		{

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -162,7 +162,11 @@ namespace OpenRA.Mods.Common.Traits
 	public interface INotifyProduction { void UnitProduced(Actor self, Actor other, CPos exit); }
 	public interface INotifyOtherProduction { void UnitProducedByOther(Actor self, Actor producer, Actor produced, string productionType, TypeDictionary init); }
 	public interface INotifyDelivery { void IncomingDelivery(Actor self); void Delivered(Actor self); }
-	public interface INotifyDocking { void Docked(Actor self, Actor harvester); void Undocked(Actor self, Actor harvester); }
+
+	[RequireExplicitImplementation]
+	public interface INotifyDockHost { void Docked(Actor self, Actor client); void Undocked(Actor self, Actor client); }
+	[RequireExplicitImplementation]
+	public interface INotifyDockClient { void Docked(Actor self, Actor host); void Undocked(Actor self, Actor host); }
 
 	[RequireExplicitImplementation]
 	public interface INotifyResourceAccepted { void OnResourceAccepted(Actor self, Actor refinery, string resourceType, int count, int value); }
@@ -202,8 +206,6 @@ namespace OpenRA.Mods.Common.Traits
 		void MovingToRefinery(Actor self, Actor refineryActor);
 		void MovementCancelled(Actor self);
 		void Harvested(Actor self, string resourceType);
-		void Docked();
-		void Undocked();
 	}
 
 	[RequireExplicitImplementation]

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -141,13 +141,6 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[RequireExplicitImplementation]
-	public interface INotifyBeingResupplied
-	{
-		void StartingResupply(Actor self, Actor host);
-		void StoppingResupply(Actor self, Actor host);
-	}
-
-	[RequireExplicitImplementation]
 	public interface INotifyTakeOff { void TakeOff(Actor self); }
 	[RequireExplicitImplementation]
 	public interface INotifyLanding { void Landing(Actor self); }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -328,14 +328,6 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[RequireExplicitImplementation]
-	public interface INotifyRearm
-	{
-		void RearmingStarted(Actor host, Actor other);
-		void Rearming(Actor host, Actor other);
-		void RearmingFinished(Actor host, Actor other);
-	}
-
-	[RequireExplicitImplementation]
 	public interface IRenderInfantrySequenceModifier
 	{
 		bool IsModifyingSequence { get; }


### PR DESCRIPTION
Split from #20168.

I unify and cleanup docking interfaces. Due to current inconsistent naming it's pretty easy to get confused. `Rearmable` is one victim I found, it had unfunctional code because of implementing a wrong interface.

The idea behind the current interface names is

- DockHost - an actor to which a unit docks to
- DockClient - an actor which docks to a DockHost

Thus I chose the names `INotifyDockHost` and `INotifyDockClient`.
I plan to have `DockHost` trait and `DockClientBase` abstract trait, so in the future the interface names will get more precedence

I also plan to merge `INotifyResupply` into `INotifyDockHost`. It's a bigger change and one is that quite nasty if done at this point in time so it will happen sometime later.

I advise to review commit by commit