### PR TITLE
Map Editor: Region selection stats tooltip (and bugfix)

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
@@ -182,6 +182,26 @@ namespace OpenRA.Mods.Common.Traits
 				NetWorth += (newDensity + 1) * newResourceValue;
 		}
 
+		public int CalculateRegionValue(CellRegion sourceRegion)
+		{
+			var resourceValueInRegion = 0;
+			foreach (var cell in sourceRegion)
+			{
+				var mcell = cell.ToMPos(Map);
+
+				if (Map.Resources.Contains(mcell) && Map.Resources[mcell].Type != 0)
+				{
+					var rcell = Map.Resources[mcell];
+					if (ResourceTypesByIndex.TryGetValue(rcell.Type, out var resourceType) && resourceValues.TryGetValue(resourceType, out var resourceValuePerUnit))
+					{
+						resourceValueInRegion += Tiles[mcell].Density * resourceValuePerUnit;
+					}
+				}
+			}
+
+			return resourceValueInRegion;
+		}
+
 		protected virtual int CalculateCellDensity(ResourceLayerContents contents, CPos c)
 		{
 			var resources = Map.Resources;

--- a/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
@@ -176,10 +176,10 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// Density + 1 as workaround for fixing ResourceLayer.Harvest as it would be very disruptive to balancing
 			if (oldResourceType != null && oldDensity > 0 && resourceValues.TryGetValue(oldResourceType, out var oldResourceValue))
-				NetWorth -= (oldDensity + 1) * oldResourceValue;
+				NetWorth -= oldDensity * oldResourceValue;
 
 			if (newResourceType != null && newDensity > 0 && resourceValues.TryGetValue(newResourceType, out var newResourceValue))
-				NetWorth += (newDensity + 1) * newResourceValue;
+				NetWorth += newDensity * newResourceValue;
 		}
 
 		public int CalculateRegionValue(CellRegion sourceRegion)


### PR DESCRIPTION
With some inspiration from the unmerged #14055, I have a PR which offers solutions for #14771 and #18222, presents more information when selecting a region, and fixes a bug I found in the `NetWorth` calculation in the process of testing.

On selection of a region using the copy tool, a tooltip appears showing

- X,Y position in cells of the start and end of the selected region
- Horizontal and vertical dimensions of the selected region (in cells; corner-to-corner, not centre-to-centre)
- Diagonal distance, in cells, from corner to corner. This **implements #18222**.
- Resources in the selected region. This **implements #14771**.
- The complementary coordinates of a region, i.e. its position rotated 180 degrees about the centre of the map, because symmetry is a useful tool for balancing and subtraction is hard for humans.
- X,Y position in cells of the 'target' region into which the contents of the selected region would be pasted
- The complementary coordinates of the target region
- The distance moved horizontally and vertically, in cells, from the selected region

In the following image, I have selected the area between the bottom-right spawn and the 'effective centre' - the middle of the channel between cliffs and the lake, and comparing it to the area heading towards the top-left spawn. You can see from the 'Complement' that the centre of the two spawns is almost (but not quite) the centre of this map.

![openra-region-select](https://user-images.githubusercontent.com/28204734/183312750-bec8ff70-43b0-4ea1-9a75-d4b3caa30e8f.png)

Additionally, I noticed during testing this that there is an error in the calculation of `NetWorth`, which is a bug in the live release, i.e. the total value of all resources on the map. An isolated tile of RA1 ore has a value of 25 (see `mods/ra/rules/player.yaml` - also confirmed by testing with a harvester), but adding an isolated tile to a map changes the value reported in the global total by 50. Every ore tile had a reported value of 25 plus the correct value, so 2 connected tiles contributed 150 to `NetWorth`, instead of the expected 100. I have fixed this in a separate commit. For maps with rotational symmetry in units of 90 degrees or reflectional symmetry across a horizontal or vertical line, ore values would be balanced regardless of the bug, but where players have access to ore patches of different shapes, these may need to be adjusted if they're intended to have been of the same value.