### PR TITLE
Add truncation to FactionLabel

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -97,17 +97,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					var flag = item.Get<ImageWidget>("FACTIONFLAG");
 					flag.GetImageCollection = () => "flags";
+
+					var factionName = pp.DisplayFaction.Name;
 					if (player == null || player.RelationshipWith(pp) == PlayerRelationship.Ally || player.WinState != WinState.Undefined)
 					{
 						flag.GetImageName = () => pp.Faction.InternalName;
-						var factionName = pp.Faction.Name != pp.DisplayFaction.Name ? $"{pp.DisplayFaction.Name} ({pp.Faction.Name})" : pp.Faction.Name;
-						item.Get<LabelWidget>("FACTION").GetText = () => factionName;
+						factionName = pp.Faction.Name != factionName ? $"{factionName} ({pp.Faction.Name})" : pp.Faction.Name;
 					}
 					else
-					{
 						flag.GetImageName = () => pp.DisplayFaction.InternalName;
-						item.Get<LabelWidget>("FACTION").GetText = () => pp.DisplayFaction.Name;
-					}
+
+					WidgetUtils.TruncateLabelToTooltip(item.Get<LabelWithTooltipWidget>("FACTION"), factionName);
 
 					var scoreCache = new CachedTransform<int, string>(s => s.ToString());
 					item.Get<LabelWidget>("SCORE").GetText = () => scoreCache.Update(p.PlayerStatistics?.Experience ?? 0);

--- a/mods/cnc/chrome/ingame-infostats.yaml
+++ b/mods/cnc/chrome/ingame-infostats.yaml
@@ -109,11 +109,13 @@ Container@SKIRMISH_STATS:
 							Y: 4
 							Width: 32
 							Height: 16
-						Label@FACTION:
+						LabelWithTooltip@FACTION:
 							X: 264
 							Width: 86
 							Height: 25
 							Shadow: True
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
 						Label@SCORE:
 							X: 360
 							Width: 75

--- a/mods/common/chrome/ingame-infostats.yaml
+++ b/mods/common/chrome/ingame-infostats.yaml
@@ -107,11 +107,13 @@ Container@SKIRMISH_STATS:
 							Y: 5
 							Width: 32
 							Height: 16
-						Label@FACTION:
+						LabelWithTooltip@FACTION:
 							X: 264
 							Width: 86
 							Height: 25
 							Shadow: True
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
 						Label@SCORE:
 							X: 360
 							Width: 75

--- a/mods/d2k/chrome/ingame-infostats.yaml
+++ b/mods/d2k/chrome/ingame-infostats.yaml
@@ -108,11 +108,13 @@ Container@SKIRMISH_STATS:
 							Y: 4
 							Width: 32
 							Height: 16
-						Label@FACTION:
+						LabelWithTooltip@FACTION:
 							X: 264
 							Width: 86
 							Height: 25
 							Shadow: True
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
 						Label@SCORE:
 							X: 360
 							Width: 75


### PR DESCRIPTION
~~With a more cramped UI in #20100~~ comes the issue of too long faction names. I've added truncation from over `WidgetUtils.BindPlayerNameAndStatus`. 

Regular names without prefixes aren't truncated, but with prefixes often are. As you can see in the images below it doesn't look the greatest as UI sizes aren't set up correctly, this is fixed in #20100 so I didn't bother here

<img width="596" alt="Screenshot 2022-08-08 at 19 37 43" src="https://user-images.githubusercontent.com/37534529/183469256-da7f4d94-462e-4f7b-b4fd-69c24ec9214d.png">

<img width="582" alt="Screenshot 2022-08-08 at 19 18 40" src="https://user-images.githubusercontent.com/37534529/183469274-ccf7d1e7-a04b-4d5f-b024-3573dda9f397.png">
 