### PR TITLE
Fix Harvester to Refinery pathfinding

### DIFF
--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 			foreach (var sl in froms)
 				if (world.Map.Contains(sl))
-					search.AddInitialCell(sl);
+					search.AddInitialCell(sl, customCost);
 
 			return search;
 		}
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 			foreach (var sl in froms)
 				if (world.Map.Contains(sl))
-					search.AddInitialCell(sl);
+					search.AddInitialCell(sl, customCost);
 
 			return search;
 		}
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			var graph = new SparsePathGraph(edges, estimatedSearchSize);
 			var search = new PathSearch(graph, DefaultCostEstimator(locomotor, target), 100, loc => loc == target, recorder);
 
-			search.AddInitialCell(from);
+			search.AddInitialCell(from, null);
 
 			return search;
 		}
@@ -162,10 +162,18 @@ namespace OpenRA.Mods.Common.Pathfinder
 			openQueue = new PriorityQueue<GraphConnection>(GraphConnection.ConnectionCostComparer);
 		}
 
-		void AddInitialCell(CPos location)
+		void AddInitialCell(CPos location, Func<CPos, int> customCost)
 		{
+			var initialCost = 0;
+			if (customCost != null)
+			{
+				initialCost = customCost(location);
+				if (initialCost == PathGraph.PathCostForInvalidPath)
+					return;
+			}
+
 			var estimatedCost = heuristic(location) * heuristicWeightPercentage / 100;
-			Graph[location] = new CellInfo(CellStatus.Open, 0, estimatedCost, location);
+			Graph[location] = new CellInfo(CellStatus.Open, initialCost, initialCost + estimatedCost, location);
 			var connection = new GraphConnection(location, estimatedCost);
 			openQueue.Add(connection);
 		}

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -241,6 +241,11 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// <summary>
 		/// Expands the path search until a path is found, and returns whether a path is found successfully.
 		/// </summary>
+		/// <remarks>
+		/// If the path search has previously been expanded it will only return true if a path can be found during
+		/// *this* expansion of the search. If the search was expanded previously and the target is already
+		/// <see cref="CellStatus.Closed"/> then this method will return false.
+		/// </remarks>
 		public bool ExpandToTarget()
 		{
 			while (CanExpand())

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -102,7 +102,9 @@ namespace OpenRA.Mods.Common.Traits
 				// For adjacent cells on the same layer, we can return the path without invoking a full search.
 				if (source.Layer == target.Layer && (source - target).LengthSquared < 3)
 				{
-					if (!world.Map.Contains(source))
+					// If the source cell is inaccessible, there is no path.
+					if (!world.Map.Contains(source) ||
+						(customCost != null && customCost(source) == PathGraph.PathCostForInvalidPath))
 						return NoPath;
 					return new List<CPos>(2) { target, source };
 				}


### PR DESCRIPTION
Two changes here that fix the issues preventing harvesters from using multiple refineries. Fixes #20162

----

Commit 1:
Fix HierarchicalPathFinder failing to consider multiple source locations.

When asked to find a path from multiple source locations, the abstract search is used to determine which source locations are viable. Source locations that cannot be reached on the abstract graph are excluded from the local path search. As we know the locations are unreachable, this prevents the local path search from expanding over the entire search space in an attempt to find these unreachable locations, preventing wasted effort.

In order to determine these reachable locations, the abstract search is expanded successively trying to reach each source location each time. However, this failed to account for a property of the ExpandToTarget for which a comment is now added. If the location was found previously, then expanding to try and find it again will fail. If the source locations were close together, it was likely that the initial expansions of the search space would have included them, and thus they would not be found on a later expansion. This would mean these locations would incorrectly be thought unreachable.

To fix this, we check if the location has already been explored (has CellStatus.Closed in the graph). If so we can check the cost to determine if it is reachable.

Commit 2:
Allow custom cost to exclude source locations in path searches.

During the refactoring to introduce HierarchicalPathFinder, custom costs were no longer applied to source locations. The logic being that if we are already in the source location, then there should be no cost added to it to get there - we are already there!

Path searches support the ability to go from multiple sources to a single target, but the reverse is not supported. Some callers that require a search from a single source to one of multiple targets perform their search in reverse, swapping the source and targets so they can run the search, then reversing the path they are given so things are the correct way around again. For callers that also use a custom cost like the harvester code that do this in order to find free refineries, they might want the custom cost to be applied to the source location. The harvester code uses this to filter out overloaded refineries. It wants to search from a harvester to multiple refineries, and thus reverses this in order to perform the path search. Without the custom cost being applied to the "source" locations, this filtering logic never gets applied.

To fix this, we now apply the custom cost to source locations. If the custom cost provides an invalid path, then the source location is excluded entirely. Although this seems unintuitive on its own, this allows searches done "in reverse" to work again.