### PR TITLE
Use Attribute.IsDefined over GetCustomAttributes

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -53,7 +53,7 @@ namespace OpenRA
 
 		public static bool HasAttribute<T>(this MemberInfo mi)
 		{
-			return mi.GetCustomAttributes(typeof(T), true).Length != 0;
+			return Attribute.IsDefined(mi, typeof(T));
 		}
 
 		public static T[] GetCustomAttributes<T>(this MemberInfo mi, bool inherit)


### PR DESCRIPTION
This should be slightly faster: https://stackoverflow.com/questions/14719104/is-there-a-benefit-of-using-isdefined-over-getcustomattributes

(I also did some VS 2022 profiler runs on the Utility run with `ra --check-yaml` and it seems to give a slight improvements, but I haven't used benchmarking tools so take it with a grain of salt.)