### PR TITLE
Teach HierarchicalPathFinder about Immovable actors

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -213,6 +213,7 @@ namespace OpenRA.Traits
 		bool AnyActorsAt(CPos a);
 		bool AnyActorsAt(CPos a, SubCell sub, bool checkTransient = true);
 		bool AnyActorsAt(CPos a, SubCell sub, Func<Actor, bool> withCondition);
+		IEnumerable<Actor> AllActors();
 		void AddInfluence(Actor self, IOccupySpace ios);
 		void RemoveInfluence(Actor self, IOccupySpace ios);
 		int AddCellTrigger(CPos[] cells, Action<Actor> onEntry, Action<Actor> onExit);

--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -403,6 +403,18 @@ namespace OpenRA.Mods.Common.Traits
 			return AnyActorsAt(uv, layer, sub, withCondition);
 		}
 
+		public IEnumerable<Actor> AllActors()
+		{
+			foreach (var layer in influence)
+			{
+				if (layer == null)
+					continue;
+				foreach (var node in layer)
+					for (var i = node; i != null; i = i.Next)
+						yield return i.Actor;
+			}
+		}
+
 		public void AddInfluence(Actor self, IOccupySpace ios)
 		{
 			foreach (var c in ios.OccupiedCells())

--- a/OpenRA.Mods.Common/Traits/World/HierarchicalPathFinderOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/HierarchicalPathFinderOverlay.cs
@@ -48,6 +48,11 @@ namespace OpenRA.Mods.Common.Traits
 		/// </summary>
 		public Locomotor Locomotor { get; set; }
 
+		/// <summary>
+		/// The blocking check selected in the UI which the overlay will display.
+		/// </summary>
+		public BlockedByActor Check { get; set; } = BlockedByActor.Immovable;
+
 		public HierarchicalPathFinderOverlay(HierarchicalPathFinderOverlayInfo info)
 		{
 			this.info = info;
@@ -88,7 +93,7 @@ namespace OpenRA.Mods.Common.Traits
 				: new[] { Locomotor };
 			foreach (var locomotor in locomotors)
 			{
-				var (abstractGraph, abstractDomains) = pathFinder.GetOverlayDataForLocomotor(locomotor);
+				var (abstractGraph, abstractDomains) = pathFinder.GetOverlayDataForLocomotor(locomotor, Check);
 
 				// Locomotor doesn't allow movement, nothing to display.
 				if (abstractGraph == null || abstractDomains == null)

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -311,6 +311,9 @@ namespace OpenRA.Mods.Common.Traits
 			return world.ActorMap.FreeSubCell(cell, preferredSubCell);
 		}
 
+		/// <remarks>This logic is replicated in <see cref="HierarchicalPathFinder.ActorIsBlocking"/> and
+		/// <see cref="HierarchicalPathFinder.ActorCellIsBlocking"/>. If this method is updated please update those as
+		/// well.</remarks>
 		bool IsBlockedBy(Actor actor, Actor otherActor, Actor ignoreActor, CPos cell, BlockedByActor check, CellFlag cellFlag)
 		{
 			if (otherActor == ignoreActor)
@@ -450,6 +453,9 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
+		/// <remarks>This logic is replicated in <see cref="HierarchicalPathFinder.ActorIsBlocking"/> and
+		/// <see cref="HierarchicalPathFinder.ActorCellIsBlocking"/>. If this method is updated please update those as
+		/// well.</remarks>
 		void UpdateCellBlocking(CPos cell)
 		{
 			using (new PerfSample("locomotor_cache"))

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -252,8 +252,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (check <= BlockedByActor.Immovable && !cellCache.Immovable.Overlaps(actor.Owner.PlayerMask))
 				return true;
 
-			// Cache doesn't account for ignored actors, temporary blockers, or subcells - these must use the slow path.
-			if (ignoreActor == null && !cellFlag.HasCellFlag(CellFlag.HasTemporaryBlocker) && subCell == SubCell.FullCell)
+			// Cache doesn't account for ignored actors, subcells, temporary blockers or transit only actors.
+			// These must use the slow path.
+			if (ignoreActor == null && subCell == SubCell.FullCell &&
+				!cellFlag.HasCellFlag(CellFlag.HasTemporaryBlocker) && !cellFlag.HasCellFlag(CellFlag.HasTransitOnlyActor))
 			{
 				// We already know there are uncrushable actors in the cell so we are always blocked.
 				if (check == BlockedByActor.All)
@@ -485,10 +487,7 @@ namespace OpenRA.Mods.Common.Traits
 					var isTransitOnly = actor.OccupiesSpace is Building building && building.TransitOnlyCells().Contains(cell);
 
 					if (isTransitOnly)
-					{
 						cellFlag |= CellFlag.HasTransitOnlyActor;
-						continue;
-					}
 
 					if (crushables.Any())
 					{

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -19,8 +19,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World)]
-	[Desc("Calculates routes for mobile units with locomotors based on the A* search algorithm.", " Attach this to the world actor.")]
-	public class PathFinderInfo : TraitInfo, Requires<LocomotorInfo>
+	[Desc("Calculates routes for mobile actors with locomotors based on the A* search algorithm.", " Attach this to the world actor.")]
+	public class PathFinderInfo : TraitInfo, Requires<LocomotorInfo>, Requires<ActorMapInfo>
 	{
 		public override object Create(ActorInitializer init)
 		{
@@ -40,7 +40,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		readonly World world;
 		PathFinderOverlay pathFinderOverlay;
-		Dictionary<Locomotor, HierarchicalPathFinder> hierarchicalPathFindersByLocomotor;
+		Dictionary<Locomotor, HierarchicalPathFinder> hierarchicalPathFindersBlockedByNoneByLocomotor;
+		Dictionary<Locomotor, HierarchicalPathFinder> hierarchicalPathFindersBlockedByImmovableByLocomotor;
 
 		public PathFinder(Actor self)
 		{
@@ -49,9 +50,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public (
 			IReadOnlyDictionary<CPos, List<GraphConnection>> AbstractGraph,
-			IReadOnlyDictionary<CPos, uint> AbstractDomains) GetOverlayDataForLocomotor(Locomotor locomotor)
+			IReadOnlyDictionary<CPos, uint> AbstractDomains) GetOverlayDataForLocomotor(
+			Locomotor locomotor, BlockedByActor check)
 		{
-			return hierarchicalPathFindersByLocomotor[locomotor].GetOverlayData();
+			return GetHierarchicalPathFinder(locomotor, check, null).GetOverlayData();
 		}
 
 		public void WorldLoaded(World w, WorldRenderer wr)
@@ -59,9 +61,13 @@ namespace OpenRA.Mods.Common.Traits
 			pathFinderOverlay = world.WorldActor.TraitOrDefault<PathFinderOverlay>();
 
 			// Requires<LocomotorInfo> ensures all Locomotors have been initialized.
-			hierarchicalPathFindersByLocomotor = w.WorldActor.TraitsImplementing<Locomotor>().ToDictionary(
+			var locomotors = w.WorldActor.TraitsImplementing<Locomotor>().ToList();
+			hierarchicalPathFindersBlockedByNoneByLocomotor = locomotors.ToDictionary(
 				locomotor => locomotor,
-				locomotor => new HierarchicalPathFinder(world, locomotor));
+				locomotor => new HierarchicalPathFinder(world, locomotor, w.ActorMap, BlockedByActor.None));
+			hierarchicalPathFindersBlockedByImmovableByLocomotor = locomotors.ToDictionary(
+				locomotor => locomotor,
+				locomotor => new HierarchicalPathFinder(world, locomotor, w.ActorMap, BlockedByActor.Immovable));
 		}
 
 		/// <summary>
@@ -110,13 +116,23 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				// Use a hierarchical path search, which performs a guided bidirectional search.
-				return hierarchicalPathFindersByLocomotor[locomotor].FindPath(
+				return GetHierarchicalPathFinder(locomotor, check, ignoreActor).FindPath(
 					self, source, target, check, DefaultHeuristicWeightPercentage, customCost, ignoreActor, laneBias, pathFinderOverlay);
 			}
 
 			// Use a hierarchical path search, which performs a guided unidirectional search.
-			return hierarchicalPathFindersByLocomotor[locomotor].FindPath(
+			return GetHierarchicalPathFinder(locomotor, check, ignoreActor).FindPath(
 				self, sourcesList, target, check, DefaultHeuristicWeightPercentage, customCost, ignoreActor, laneBias, pathFinderOverlay);
+		}
+
+		HierarchicalPathFinder GetHierarchicalPathFinder(Locomotor locomotor, BlockedByActor check, Actor ignoreActor)
+		{
+			// If there is an actor to ignore, we cannot use an HPF that accounts for any blocking actors.
+			// One of the blocking actors might be the one we need to ignore!
+			var hpfs = check == BlockedByActor.None || ignoreActor != null
+				? hierarchicalPathFindersBlockedByNoneByLocomotor
+				: hierarchicalPathFindersBlockedByImmovableByLocomotor;
+			return hpfs[locomotor];
 		}
 
 		/// <summary>
@@ -149,7 +165,7 @@ namespace OpenRA.Mods.Common.Traits
 		/// </summary>
 		public bool PathExistsForLocomotor(Locomotor locomotor, CPos source, CPos target)
 		{
-			return hierarchicalPathFindersByLocomotor[locomotor].PathExists(source, target);
+			return hierarchicalPathFindersBlockedByNoneByLocomotor[locomotor].PathExists(source, target);
 		}
 
 		static Locomotor GetActorLocomotor(Actor self)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/HierarchicalPathFinderOverlayLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/HierarchicalPathFinderOverlayLogic.cs
@@ -42,6 +42,23 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				locomotorSelector.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", locomotors.Length * 30, locomotors, setupItem);
 			};
+
+			var checks = new[] { BlockedByActor.None, BlockedByActor.Immovable };
+			var checkSelector = widget.Get<DropDownButtonWidget>("HPF_OVERLAY_CHECK");
+			checkSelector.OnMouseDown = _ =>
+			{
+				Func<BlockedByActor, ScrollItemWidget, ScrollItemWidget> setupItem = (option, template) =>
+				{
+					var item = ScrollItemWidget.Setup(
+						template,
+						() => hpfOverlay.Check == option,
+						() => hpfOverlay.Check = option);
+					item.Get<LabelWidget>("LABEL").GetText = () => option.ToString();
+					return item;
+				};
+
+				checkSelector.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", checks.Length * 30, checks, setupItem);
+			};
 		}
 	}
 }

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -1864,13 +1864,20 @@ Container@PLAYER_WIDGETS:
 			Logic: HierarchicalPathFinderOverlayLogic
 			X: WINDOW_RIGHT - WIDTH - 240
 			Y: 40
-			Width: 150
-			Height: 25
+			Width: 175
+			Height: 60
 			Children:
 				DropDownButton@HPF_OVERLAY_LOCOMOTOR:
+					Y: PARENT_TOP
 					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Height: 25
 					Text: Select Locomotor
+					Font: Regular
+				DropDownButton@HPF_OVERLAY_CHECK:
+					Y: PARENT_TOP + 35
+					Width: PARENT_RIGHT
+					Height: 25
+					Text: Select BlockedByActor
 					Font: Regular
 
 Background@FMVPLAYER:

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -645,11 +645,18 @@ Container@PLAYER_WIDGETS:
 			Logic: HierarchicalPathFinderOverlayLogic
 			X: WINDOW_RIGHT - WIDTH - 231
 			Y: 40
-			Width: 150
-			Height: 25
+			Width: 175
+			Height: 60
 			Children:
 				DropDownButton@HPF_OVERLAY_LOCOMOTOR:
+					Y: PARENT_TOP
 					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Height: 25
 					Text: Select Locomotor
+					Font: Regular
+				DropDownButton@HPF_OVERLAY_CHECK:
+					Y: PARENT_TOP + 35
+					Width: PARENT_RIGHT
+					Height: 25
+					Text: Select BlockedByActor
 					Font: Regular

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -653,12 +653,19 @@ Container@PLAYER_WIDGETS:
 			Logic: HierarchicalPathFinderOverlayLogic
 			X: WINDOW_RIGHT - WIDTH - 260
 			Y: 40
-			Width: 150
-			Height: 25
+			Width: 175
+			Height: 60
 			Children:
 				DropDownButton@HPF_OVERLAY_LOCOMOTOR:
+					Y: PARENT_TOP
 					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Height: 25
 					Text: Select Locomotor
+					Font: Regular
+				DropDownButton@HPF_OVERLAY_CHECK:
+					Y: PARENT_TOP + 35
+					Width: PARENT_RIGHT
+					Height: 25
+					Text: Select BlockedByActor
 					Font: Regular
 

--- a/mods/ts/chrome/ingame-player.yaml
+++ b/mods/ts/chrome/ingame-player.yaml
@@ -623,11 +623,18 @@ Container@PLAYER_WIDGETS:
 			Logic: HierarchicalPathFinderOverlayLogic
 			X: WINDOW_RIGHT - WIDTH - 245
 			Y: 40
-			Width: 150
-			Height: 25
+			Width: 175
+			Height: 60
 			Children:
 				DropDownButton@HPF_OVERLAY_LOCOMOTOR:
+					Y: PARENT_TOP
 					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Height: 25
 					Text: Select Locomotor
+					Font: Regular
+				DropDownButton@HPF_OVERLAY_CHECK:
+					Y: PARENT_TOP + 35
+					Width: PARENT_RIGHT
+					Height: 25
+					Text: Select BlockedByActor
 					Font: Regular


### PR DESCRIPTION
By tracking updates on the ActorMap the HierarchicalPathFinder can be aware of actors moving around the map. We track a subset of immovable actors that always block. These actors can be treated as impassable obstacles just like terrain. When a path needs to be found the abstract path will guide the search around this subset of immovable actors just like it can guide the search around impassable terrain. For path searches that were previously imperformant because some immovable actors created a bottleneck that needed to be routed around, these will now be performant instead. Path searches with bottlenecks created by items such as trees, walls and buildings should see a performance improvement. Bottlenecks created by other units will not benefit.

We now maintain two sets of HPFs. One is aware of immovable actors and will be used for path searches that request BlockedByActor.Immovable, BlockedByActor.Stationary and BlockedByActor.All to guide that around the immovable obstacles. The other is aware of terrain only and will be used for searches that request BlockedByActor.None, or if an ignoreActor is provided. A new UI dropdown when using the `/hpf` command will allow switching between the visuals of the two sets.

----

We can turn on the `/path-debug` command to see the path search for the selected unit.

On bleed, when we try and path around terrain we can see HPF kicking in to guide the route. The yellow & white lines shows the explored cells of the path search. It "knows" to go around the terrain so we don't need to search many cells. Searching less cells means better performance.

![image](https://user-images.githubusercontent.com/3399086/184492904-dba3ff0c-1c16-489e-b40a-612bdcd1c1ab.png)

If we repeat this same search but using actors to block the route, in this case just a wall, we see the search is less efficient. It didn't "know" about the wall in advance, so when it runs into the wall it has to expand the search by blobing outwards until it can find a way around. It searches more cells, which means less performance.

![image](https://user-images.githubusercontent.com/3399086/184492929-ab3be623-6c45-4411-99c9-4f0a5f495d2f.png)


Using the `/hpf` command, we can see a visualisation of the HPF. On this PR, we can also select whether we see it for BlockedByActor.None or BlockedByActor.Immovable.

If we look at our wall example with the BlockedByActor.None setting, we can see it draws orange lines through the wall. It think there are routes between these points.

![image](https://user-images.githubusercontent.com/3399086/184492994-bb288b45-6d8d-4849-b9be-30c8ee8b41c1.png)

If we switch to the BlockedByActor.Immovable setting, we can see it has a new layout. It no longer draws lines between those points because it knows the wall is in the way.

![image](https://user-images.githubusercontent.com/3399086/184493004-1054c176-d7c3-4110-8868-88496421d6a1.png)

Now if we try and find a path with our wall example, we see the improved behaviour, it "knows" about the wall and the search goes around it. We don't see the "blob" from when it didn't know.

![image](https://user-images.githubusercontent.com/3399086/184493027-c0380eb1-7a8f-4d16-bcfb-4292df8dfbd0.png)

Only some immovable actors are considered. Exceptions include anything that can sometimes be passed through:
- Temporary blockers, such as gates.
- Crushable actors. With `/hpf` we can select the `heavytracked` locomotor and we see the concrete wall becomes passable again. This is because `heavytracked` actors such as a Mammoth Tank can crush concrete walls.
- The bibs around buildings.

In general, I would expect blockages such as trees, buildings, uncrushable walls to benefit from the improved behaviour. Blockages from units, gates and crushable walls will continue to show poor performance.

Like the original PR #19591, the value proposition is much the same. We can significantly improve the performance of searching for paths with obstacles in the way. It costs us extra load time at the start of the game plus a small amount of ongoing overhead.