### PR TITLE
HierarchicalPathFinder.PathExists checks the locations are in map bounds.

### DIFF
--- a/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
+++ b/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
@@ -749,6 +749,9 @@ namespace OpenRA.Mods.Common.Pathfinder
 			if (costEstimator == null)
 				return false;
 
+			if (!world.Map.Contains(source) || !world.Map.Contains(target))
+				return false;
+
 			RebuildDomains();
 
 			var sourceGridInfo = gridInfos[GridIndex(source)];


### PR DESCRIPTION
Without this, passing locations outside the map could cause a crash instead of reporting no path.

Fixes #20197 