### PR TITLE
Consistently apply LastModifiedMap

### DIFF
--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -47,6 +47,24 @@ namespace OpenRA
 		public string LastModifiedMap { get; private set; } = null;
 		readonly Dictionary<string, string> mapUpdates = new Dictionary<string, string>();
 
+		string lastLoadedLastModifiedMap;
+
+		/// <summary>
+		/// If LastModifiedMap was picked already, returns a null
+		/// </summary>
+		public string PickLastModifiedMap(MapVisibility visibility)
+		{
+			UpdateMaps();
+			var map = string.IsNullOrEmpty(LastModifiedMap) ? null : this[LastModifiedMap];
+			if (map != null && map.Status == MapStatus.Available && map.Visibility.HasFlag(visibility) && lastLoadedLastModifiedMap != LastModifiedMap)
+			{
+				lastLoadedLastModifiedMap = LastModifiedMap;
+				return lastLoadedLastModifiedMap;
+			}
+
+			return null;
+		}
+
 		public MapCache(ModData modData)
 		{
 			this.modData = modData;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -469,8 +469,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				Ui.OpenWindow("SAVE_MAP_PANEL", new WidgetArgs()
 				{
-					{ "onSave", (Action<string>)(_ => { hideMenu = false; actionManager.Modified = false; }) },
-					{ "onExit", () => hideMenu = false },
+					{ "onSave", (Action<string>)(_ => { ShowMenu(); actionManager.Modified = false; }) },
+					{ "onExit", ShowMenu },
 					{ "map", world.Map },
 					{ "playerDefinitions", playerDefinitions },
 					{ "actorDefinitions", editorActorLayer.Save() }

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -61,8 +61,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		MapPreview map;
 		Session.MapStatus mapStatus;
 
-		string lastUpdatedMap = null;
-
 		bool chatEnabled;
 		bool addBotOnMapLoad;
 		bool disableTeamChat;
@@ -234,7 +232,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					Ui.OpenWindow("MAPCHOOSER_PANEL", new WidgetArgs()
 					{
-						{ "initialMap", SelectRecentMap(map.Uid) },
+						{ "initialMap", modData.MapCache.PickLastModifiedMap(MapVisibility.Lobby) ?? map.Uid },
 						{ "initialTab", MapClassification.System },
 						{ "onExit", Game.IsHost ? (Action)UpdateSelectedMap : modData.MapCache.UpdateMaps },
 						{ "onSelect", Game.IsHost ? onSelect : null },
@@ -885,17 +883,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Game.Settings.Server.Map = uid;
 				Game.Settings.Save();
 			}
-		}
-
-		string SelectRecentMap(string currentUid)
-		{
-			if (lastUpdatedMap != modData.MapCache.LastModifiedMap)
-			{
-				lastUpdatedMap = modData.MapCache.LastModifiedMap;
-				return lastUpdatedMap;
-			}
-
-			return currentUid;
 		}
 	}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -104,7 +104,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			singleplayerMenu.IsVisible = () => menuType == MenuType.Singleplayer;
 
 			var missionsButton = singleplayerMenu.Get<ButtonWidget>("MISSIONS_BUTTON");
-			missionsButton.OnClick = OpenMissionBrowserPanel;
+			missionsButton.OnClick = () => OpenMissionBrowserPanel(modData.MapCache.PickLastModifiedMap(MapVisibility.MissionSelector));
 
 			var hasCampaign = modData.Manifest.Missions.Length > 0;
 			var hasMissions = modData.MapCache
@@ -455,13 +455,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				() => { Game.CloseServer(); SwitchMenu(MenuType.Main); });
 		}
 
-		void OpenMissionBrowserPanel()
+		void OpenMissionBrowserPanel(string map)
 		{
 			SwitchMenu(MenuType.None);
 			Game.OpenWindow("MISSIONBROWSER_PANEL", new WidgetArgs
 			{
 				{ "onExit", () => SwitchMenu(MenuType.Singleplayer) },
-				{ "onStart", () => { RemoveShellmapUI(); lastGameState = MenuPanel.Missions; } }
+				{ "onStart", () => { RemoveShellmapUI(); lastGameState = MenuPanel.Missions; } },
+				{ "initialMap", map }
 			});
 		}
 
@@ -526,7 +527,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			switch (lastGameState)
 			{
 				case MenuPanel.Missions:
-					OpenMissionBrowserPanel();
+					OpenMissionBrowserPanel(null);
 					break;
 
 				case MenuPanel.Replays:

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -303,8 +303,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 								var url = new HttpQueryBuilder(webServices.GameNews)
 								{
 									{ "version", Game.EngineVersion },
-									{ "mod", Game.ModData.Manifest.Id },
-									{ "modversion", Game.ModData.Manifest.Metadata.Version }
+									{ "mod", modData.Manifest.Id },
+									{ "modversion", modData.Manifest.Metadata.Version }
 								}.ToString();
 
 								// Parameter string is blank if the player has opted out
@@ -445,7 +445,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void StartSkirmishGame()
 		{
-			var map = Game.ModData.MapCache.ChooseInitialMap(Game.Settings.Server.Map, Game.CosmeticRandom);
+			var map = modData.MapCache.ChooseInitialMap(modData.MapCache.PickLastModifiedMap(MapVisibility.Lobby) ?? Game.Settings.Server.Map, Game.CosmeticRandom);
 			Game.Settings.Server.Map = map;
 			Game.Settings.Save();
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		string gameSpeed;
 
 		[ObjectCreator.UseCtor]
-		public MissionBrowserLogic(Widget widget, ModData modData, World world, Action onStart, Action onExit)
+		public MissionBrowserLogic(Widget widget, ModData modData, World world, Action onStart, Action onExit, string initialMap)
 		{
 			this.modData = modData;
 			this.onStart = onStart;
@@ -154,7 +154,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			if (allPreviews.Count > 0)
-				SelectMap(allPreviews.First());
+			{
+				var uid = modData.MapCache.GetUpdatedMap(initialMap);
+				var map = uid == null ? null : modData.MapCache[uid];
+				if (map != null && map.Visibility.HasFlag(MapVisibility.MissionSelector))
+				{
+					SelectMap(map);
+					missionList.ScrollToSelectedItem();
+				}
+				else
+					SelectMap(allPreviews.First());
+			}
 
 			// Preload map preview to reduce jank
 			new Thread(() =>
@@ -401,7 +411,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			StopVideo(videoPlayer);
 
 			// If selected mission becomes unavailable, exit MissionBrowser to refresh
-			if (modData.MapCache[selectedMap.Uid].Status != MapStatus.Available)
+			var map = modData.MapCache.GetUpdatedMap(selectedMap.Uid);
+			if (map == null)
 			{
 				Game.Disconnect();
 				Ui.CloseWindow();
@@ -409,6 +420,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return;
 			}
 
+			selectedMap = modData.MapCache[map];
 			var orders = new List<Order>();
 			if (difficulty != null)
 				orders.Add(Order.Command($"option difficulty {difficulty}"));

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.onExit = onExit;
 
 			var settings = Game.Settings;
-			preview = modData.MapCache[modData.MapCache.ChooseInitialMap(Game.Settings.Server.Map, Game.CosmeticRandom)];
+			preview = modData.MapCache[modData.MapCache.ChooseInitialMap(modData.MapCache.PickLastModifiedMap(MapVisibility.Lobby) ?? Game.Settings.Server.Map, Game.CosmeticRandom)];
 
 			panel.Get<ButtonWidget>("BACK_BUTTON").OnClick = () => { Ui.CloseWindow(); onExit(); };
 			panel.Get<ButtonWidget>("CREATE_BUTTON").OnClick = CreateAndJoin;


### PR DESCRIPTION
Split from #20120. I've made the the `LastModifiedMap` preselected when you enter the Lobby and MissionSelector. For this I've moved checks of selecting once from `LobbyLogic` to `MapCache`. This will also fixes bugs relating to the check not working once the lobby unloaded. 