### PR TITLE
Rename EngineerRepair(able) to InstantlyRepair(able) and fix Dune 2000 engineers

### DIFF
--- a/OpenRA.Mods.Common/Activities/InstantRepair.cs
+++ b/OpenRA.Mods.Common/Activities/InstantRepair.cs
@@ -14,15 +14,15 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
-	class RepairBuilding : Enter
+	class InstantRepair : Enter
 	{
-		readonly EngineerRepairInfo info;
+		readonly InstantlyRepairsInfo info;
 
 		Actor enterActor;
 		IHealth enterHealth;
-		EngineerRepairable enterEngineerRepariable;
+		InstantlyRepairable enterInstantlyRepariable;
 
-		public RepairBuilding(Actor self, in Target target, EngineerRepairInfo info)
+		public InstantRepair(Actor self, in Target target, InstantlyRepairsInfo info)
 			: base(self, target, info.TargetLineColor)
 		{
 			this.info = info;
@@ -32,12 +32,12 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			enterActor = targetActor;
 			enterHealth = targetActor.TraitOrDefault<IHealth>();
-			enterEngineerRepariable = targetActor.TraitOrDefault<EngineerRepairable>();
+			enterInstantlyRepariable = targetActor.TraitOrDefault<InstantlyRepairable>();
 
 			// Make sure we can still repair the target before entering
 			// (but not before, because this may stop the actor in the middle of nowhere)
 			var stance = self.Owner.RelationshipWith(enterActor.Owner);
-			if (enterHealth == null || enterHealth.DamageState == DamageState.Undamaged || enterEngineerRepariable == null || enterEngineerRepariable.IsTraitDisabled || !info.ValidRelationships.HasRelationship(stance))
+			if (enterHealth == null || enterHealth.DamageState == DamageState.Undamaged || enterInstantlyRepariable == null || enterInstantlyRepariable.IsTraitDisabled || !info.ValidRelationships.HasRelationship(stance))
 			{
 				Cancel(self, true);
 				return false;
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (targetActor != enterActor)
 				return;
 
-			if (enterEngineerRepariable.IsTraitDisabled)
+			if (enterInstantlyRepariable.IsTraitDisabled)
 				return;
 
 			if (enterHealth.DamageState == DamageState.Undamaged)

--- a/OpenRA.Mods.Common/Traits/InstantlyRepairable.cs
+++ b/OpenRA.Mods.Common/Traits/InstantlyRepairable.cs
@@ -13,20 +13,20 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class EngineerRepairType { }
+	public class InstantlyRepairType { }
 
 	[Desc("Eligible for instant repair.")]
-	public class EngineerRepairableInfo : ConditionalTraitInfo
+	public class InstantlyRepairableInfo : ConditionalTraitInfo
 	{
 		[Desc("Actors with these Types under EngineerRepair trait can repair me.")]
-		public readonly BitSet<EngineerRepairType> Types = default;
+		public readonly BitSet<InstantlyRepairType> Types = default;
 
-		public override object Create(ActorInitializer init) { return new EngineerRepairable(this); }
+		public override object Create(ActorInitializer init) { return new InstantlyRepairable(this); }
 	}
 
-	public class EngineerRepairable : ConditionalTrait<EngineerRepairableInfo>
+	public class InstantlyRepairable : ConditionalTrait<InstantlyRepairableInfo>
 	{
-		public EngineerRepairable(EngineerRepairableInfo info)
+		public InstantlyRepairable(InstantlyRepairableInfo info)
 			: base(info) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/InstantlyRepairs.cs
+++ b/OpenRA.Mods.Common/Traits/InstantlyRepairs.cs
@@ -18,10 +18,10 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Can instantly repair other actors, but gets consumed afterwards.")]
-	public class EngineerRepairInfo : ConditionalTraitInfo
+	public class InstantlyRepairsInfo : ConditionalTraitInfo
 	{
-		[Desc("Uses the \"EngineerRepairable\" trait to determine repairability.")]
-		public readonly BitSet<EngineerRepairType> Types = default;
+		[Desc("Uses the " + nameof(InstantlyRepairable) + " trait to determine repairability.")]
+		public readonly BitSet<InstantlyRepairType> Types = default;
 
 		[VoiceReference]
 		public readonly string Voice = "Action";
@@ -47,12 +47,12 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Cursor to display when target actor has full health so it can't be repaired.")]
 		public readonly string RepairBlockedCursor = "goldwrench-blocked";
 
-		public override object Create(ActorInitializer init) { return new EngineerRepair(this); }
+		public override object Create(ActorInitializer init) { return new InstantlyRepairs(this); }
 	}
 
-	public class EngineerRepair : ConditionalTrait<EngineerRepairInfo>, IIssueOrder, IResolveOrder, IOrderVoice
+	public class InstantlyRepairs : ConditionalTrait<InstantlyRepairsInfo>, IIssueOrder, IResolveOrder, IOrderVoice
 	{
-		public EngineerRepair(EngineerRepairInfo info)
+		public InstantlyRepairs(InstantlyRepairsInfo info)
 			: base(info) { }
 
 		public IEnumerable<IOrderTargeter> Orders
@@ -62,13 +62,13 @@ namespace OpenRA.Mods.Common.Traits
 				if (IsTraitDisabled)
 					yield break;
 
-				yield return new EngineerRepairOrderTargeter(Info);
+				yield return new InstantRepairOrderTargeter(Info);
 			}
 		}
 
 		public Order IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
-			if (order.OrderID != "EngineerRepair")
+			if (order.OrderID != "InstantRepair")
 				return null;
 
 			return new Order(order.OrderID, self, target, queued);
@@ -87,36 +87,36 @@ namespace OpenRA.Mods.Common.Traits
 
 		public string VoicePhraseForOrder(Actor self, Order order)
 		{
-			return order.OrderString == "EngineerRepair" && IsValidOrder(order)
+			return order.OrderString == "InstantRepair" && IsValidOrder(order)
 				? Info.Voice : null;
 		}
 
 		public void ResolveOrder(Actor self, Order order)
 		{
-			if (order.OrderString != "EngineerRepair" || !IsValidOrder(order))
+			if (order.OrderString != "InstantRepair" || !IsValidOrder(order))
 				return;
 
-			self.QueueActivity(order.Queued, new RepairBuilding(self, order.Target, Info));
+			self.QueueActivity(order.Queued, new InstantRepair(self, order.Target, Info));
 			self.ShowTargetLines();
 		}
 
-		class EngineerRepairOrderTargeter : UnitOrderTargeter
+		class InstantRepairOrderTargeter : UnitOrderTargeter
 		{
-			readonly EngineerRepairInfo info;
+			readonly InstantlyRepairsInfo info;
 
-			public EngineerRepairOrderTargeter(EngineerRepairInfo info)
-				: base("EngineerRepair", 6, info.Cursor, true, true)
+			public InstantRepairOrderTargeter(InstantlyRepairsInfo info)
+				: base("InstantRepair", 6, info.Cursor, true, true)
 			{
 				this.info = info;
 			}
 
 			public override bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor)
 			{
-				var engineerRepairable = target.TraitOrDefault<EngineerRepairable>();
-				if (engineerRepairable == null || engineerRepairable.IsTraitDisabled)
+				var instantlyRepairable = target.TraitOrDefault<InstantlyRepairable>();
+				if (instantlyRepairable == null || instantlyRepairable.IsTraitDisabled)
 					return false;
 
-				if (!engineerRepairable.Info.Types.IsEmpty && !engineerRepairable.Info.Types.Overlaps(info.Types))
+				if (!instantlyRepairable.Info.Types.IsEmpty && !instantlyRepairable.Info.Types.Overlaps(info.Types))
 					return false;
 
 				if (!info.ValidRelationships.HasRelationship(target.Owner.RelationshipWith(self.Owner)))
@@ -131,14 +131,14 @@ namespace OpenRA.Mods.Common.Traits
 			public override bool CanTargetFrozenActor(Actor self, FrozenActor target, TargetModifiers modifiers, ref string cursor)
 			{
 				// TODO: FrozenActors don't yet have a way of caching conditions, so we can't filter disabled traits
-				// This therefore assumes that all EngineerRepairable traits are enabled, which is probably wrong.
-				// Actors with FrozenUnderFog should therefore not disable the EngineerRepairable trait if
+				// This therefore assumes that all InstantlyRepairable traits are enabled, which is probably wrong.
+				// Actors with FrozenUnderFog should therefore not disable the InstantlyRepairable trait if
 				// ValidStances includes Enemy actors.
-				var engineerRepairable = target.Info.TraitInfoOrDefault<EngineerRepairableInfo>();
-				if (engineerRepairable == null)
+				var instantlyRepairable = target.Info.TraitInfoOrDefault<InstantlyRepairableInfo>();
+				if (instantlyRepairable == null)
 					return false;
 
-				if (!engineerRepairable.Types.IsEmpty && !engineerRepairable.Types.Overlaps(info.Types))
+				if (!instantlyRepairable.Types.IsEmpty && !instantlyRepairable.Types.Overlaps(info.Types))
 					return false;
 
 				if (!info.ValidRelationships.HasRelationship(target.Owner.RelationshipWith(self.Owner)))

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RenameEngineerRepair.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RenameEngineerRepair.cs
@@ -1,0 +1,31 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RenameEngineerRepair : UpdateRule
+	{
+		public override string Name => "Traits revolving around instant (building) repairs were renamed.";
+
+		public override string Description =>
+			"'EngineerRepair' was renamed to 'InstantlyRepairs' " +
+			"and 'EngineerRepairable' to 'InstantlyRepairable'.";
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			actorNode.RenameChildrenMatching("EngineerRepair", "InstantlyRepairs");
+			actorNode.RenameChildrenMatching("EngineerRepairable", "InstantlyRepairable");
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -104,6 +104,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 			{
 				new TextNotificationsDisplayWidgetRemoveTime(),
 				new ExplicitSequenceFilenames(),
+				new RenameEngineerRepair(),
 			})
 		};
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -745,7 +745,7 @@
 	SpawnActorsOnSell:
 		ActorTypes: e6,e1,e1,e1
 		GuaranteedActorTypes: e1
-	EngineerRepairable:
+	InstantlyRepairable:
 	Demolishable:
 		Condition: being-demolished
 	Sellable:
@@ -806,7 +806,7 @@
 		RepairStep: 1400
 		PlayerExperience: 5
 		RepairingNotification: Repairing
-	EngineerRepairable:
+	InstantlyRepairable:
 	RevealsShroud:
 		Range: 3c0
 	Tooltip:

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -205,7 +205,7 @@ E6:
 		HP: 3000
 	Passenger:
 		CustomPipType: yellow
-	EngineerRepair:
+	InstantlyRepairs:
 	RepairsBridges:
 	CaptureManager:
 	Captures@SABOTAGE:

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -48,7 +48,6 @@ engineer:
 		Range: 2c768
 	Mobile:
 		Speed: 31
-	InstantlyRepairs:
 	CaptureManager:
 	Captures:
 		CaptureTypes: building

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -48,7 +48,7 @@ engineer:
 		Range: 2c768
 	Mobile:
 		Speed: 31
-	EngineerRepair:
+	InstantlyRepairs:
 	CaptureManager:
 	Captures:
 		CaptureTypes: building

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -165,7 +165,7 @@ FCOM:
 	BaseProvider:
 		PauseOnCondition: being-captured
 		Range: 8c0
-	EngineerRepairable:
+	InstantlyRepairable:
 	Power:
 		Amount: 0
 	ProvidesPrerequisite@buildingname:
@@ -191,7 +191,7 @@ HOSP:
 		Types: building
 	CapturableProgressBar:
 	CapturableProgressBlink:
-	EngineerRepairable:
+	InstantlyRepairable:
 	Tooltip:
 		Name: Hospital
 	TooltipDescription@ally:
@@ -472,7 +472,7 @@ MISS:
 		Types: building
 	CapturableProgressBar:
 	CapturableProgressBlink:
-	EngineerRepairable:
+	InstantlyRepairable:
 	WithDeathAnimation:
 		DeathSequence: dead
 		UseDeathTypeSuffix: false
@@ -498,7 +498,7 @@ BIO:
 	Capturable:
 		Types: building
 	CapturableProgressBar:
-	EngineerRepairable:
+	InstantlyRepairable:
 	Tooltip:
 		Name: Biological Lab
 	TooltipDescription@ally:
@@ -538,7 +538,7 @@ OILB:
 		Types: building
 	CapturableProgressBar:
 	CapturableProgressBlink:
-	EngineerRepairable:
+	InstantlyRepairable:
 	CashTrickler:
 		Interval: 375
 		Amount: 100

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -703,7 +703,7 @@
 		RepairStep: 700
 		PlayerExperience: 5
 		RepairingNotification: Repairing
-	EngineerRepairable:
+	InstantlyRepairable:
 	AcceptsDeliveredCash:
 	WithMakeAnimation:
 		Condition: build-incomplete

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -297,7 +297,7 @@ E6:
 		IsPlayerPalette: true
 	Passenger:
 		CustomPipType: yellow
-	EngineerRepair:
+	InstantlyRepairs:
 	RepairsBridges:
 	CaptureManager:
 	GrantConditionOnPrerequisite@GLOBALREUSABLEENGINEER:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -732,7 +732,7 @@ PBOX:
 	-QuantizeFacingsFromSequence:
 	BodyOrientation:
 		QuantizedFacings: 8
-	EngineerRepairable:
+	InstantlyRepairable:
 		RequiresCondition: damaged
 	GrantConditionOnDamageState@DAMAGED:
 		Condition: damaged
@@ -794,7 +794,7 @@ HBOX:
 	-QuantizeFacingsFromSequence:
 	BodyOrientation:
 		QuantizedFacings: 8
-	EngineerRepairable:
+	InstantlyRepairable:
 		RequiresCondition: damaged
 	GrantConditionOnDamageState@DAMAGED:
 		Condition: damaged

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -344,7 +344,7 @@
 		Weapon: BuildingExplosions
 		EmptyWeapon: BuildingExplosions
 		Type: Footprint
-	EngineerRepairable:
+	InstantlyRepairable:
 	ShakeOnDeath:
 	Guardable:
 		Range: 3c0

--- a/mods/ts/rules/shared-infantry.yaml
+++ b/mods/ts/rules/shared-infantry.yaml
@@ -70,7 +70,7 @@ ENGINEER:
 		HP: 10000
 	Passenger:
 		CustomPipType: yellow
-	EngineerRepair:
+	InstantlyRepairs:
 	RepairsBridges:
 		RepairNotification: BridgeRepaired
 		RepairTextNotification: Bridge repaired.


### PR DESCRIPTION
`EngineerRepairable` and `RepairBuilding` were already too narrow and C&C focussed so this just renames them.

I also discovered by accident that Dune 2000 engineers can repair but buildings won't let them.