### PR TITLE
Added ResourceAccumulator

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class RefineryInfo : TraitInfo, Requires<WithSpriteBodyInfo>, IAcceptResourcesInfo
+	public class RefineryInfo : TraitInfo, Requires<WithSpriteBodyInfo>, Requires<IResourceAccumulatorInfo>, IAcceptResourcesInfo
 	{
 		[Desc("Actual harvester facing when docking.")]
 		public readonly WAngle DockAngle = WAngle.Zero;
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Refinery(init.Self, this); }
 	}
 
-	public class Refinery : ITick, IAcceptResources, INotifyCreated, INotifySold, INotifyCapture,
+	public class Refinery : INotifyCreated, ITick, IAcceptResources, INotifySold, INotifyCapture,
 		INotifyOwnerChanged, ISync, INotifyActorDisposing
 	{
 		readonly Actor self;

--- a/OpenRA.Mods.Common/Traits/Player/ResourceAccumulator.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ResourceAccumulator.cs
@@ -1,0 +1,80 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Accepts resources and disburses them to the player as credits.")]
+	public class ResourceAccumulatorInfo : TraitInfo, IResourceAccumulatorInfo
+	{
+		[Desc("Store resources in silos. Adds cash directly without storing if set to false.")]
+		public readonly bool UseStorage = true;
+
+		[Desc("Discard resources once silo capacity has been reached.")]
+		public readonly bool DiscardExcessResources = false;
+
+		public override object Create(ActorInitializer init) { return new ResourceAccumulator(this); }
+	}
+
+	public class ResourceAccumulator : INotifyCreated, INotifyOwnerChanged, IResourceAccumulator
+	{
+		readonly ResourceAccumulatorInfo info;
+		PlayerResources playerResources;
+		IEnumerable<int> resourceValueModifiers;
+
+		public ResourceAccumulator(ResourceAccumulatorInfo info)
+		{
+			this.info = info;
+		}
+
+		void INotifyCreated.Created(Actor self)
+		{
+			resourceValueModifiers = self.TraitsImplementing<IResourceValueModifier>().ToArray().Select(m => m.GetResourceValueModifier());
+			playerResources = self.Owner.PlayerActor.Trait<PlayerResources>();
+		}
+
+		int IResourceAccumulator.AcceptResources(string resourceType, int count)
+		{
+			if (!playerResources.Info.ResourceValues.TryGetValue(resourceType, out var resourceValue))
+				return 0;
+
+			var value = Util.ApplyPercentageModifiers(count * resourceValue, resourceValueModifiers);
+
+			if (info.UseStorage)
+			{
+				var storageLimit = Math.Max(playerResources.ResourceCapacity - playerResources.Resources, 0);
+				if (!info.DiscardExcessResources)
+				{
+					// Reduce amount if needed until it will fit the available storage
+					while (value > storageLimit)
+						value = Util.ApplyPercentageModifiers(--count * resourceValue, resourceValueModifiers);
+				}
+				else
+					value = Math.Min(value, playerResources.ResourceCapacity - playerResources.Resources);
+
+				playerResources.GiveResources(value);
+			}
+			else
+				value = playerResources.ChangeCash(value);
+
+			return value;
+		}
+
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		{
+			playerResources = newOwner.PlayerActor.Trait<PlayerResources>();
+		}
+	}
+}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -269,6 +269,12 @@ namespace OpenRA.Mods.Common.Traits
 		void Undeploy(Actor self, bool skipMakeAnim);
 	}
 
+	public interface IResourceAccumulatorInfo : ITraitInfoInterface { }
+	public interface IResourceAccumulator
+	{
+		int AcceptResources(string resourceType, int count = 1);
+	}
+
 	public interface IAcceptResourcesInfo : ITraitInfoInterface { }
 	public interface IAcceptResources
 	{

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -272,7 +272,7 @@ namespace OpenRA.Mods.Common.Traits
 	public interface IResourceAccumulatorInfo : ITraitInfoInterface { }
 	public interface IResourceAccumulator
 	{
-		int AcceptResources(string resourceType, int count = 1);
+		int AcceptResources(string resourceType, int count);
 	}
 
 	public interface IAcceptResourcesInfo : ITraitInfoInterface { }

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/AddResourceAccumulator.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/AddResourceAccumulator.cs
@@ -1,0 +1,61 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class AddResourceAccumulator : UpdateRule
+	{
+		public override string Name => "Refinery had changes to use a ResourceAccumulator trait for altering player resources.";
+
+		public override string Description => "DefaultResourceAccumulator was added and traits UseStorage and DiscardExcessResources were moved from Refinery.";
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			MiniYamlNode resourceAccumulatorNode = null;
+
+			var refineries = actorNode.ChildrenMatching("Refinery");
+			var tiberianSunRefineries = actorNode.ChildrenMatching("TiberianSunRefinery");
+			var allRefineries = new List<MiniYamlNode>(refineries);
+			allRefineries.AddRange(tiberianSunRefineries);
+
+			foreach (var refineryNode in allRefineries)
+			{
+				resourceAccumulatorNode = new MiniYamlNode("ResourceAccumulator", "");
+
+				var useStorageNode = refineryNode.LastChildMatching("UseStorage");
+				var discardExcessResourcesNode = refineryNode.LastChildMatching("DiscardExcessResources");
+
+				if (useStorageNode != null)
+				{
+					refineryNode.RemoveNode(useStorageNode);
+					resourceAccumulatorNode.AddNode("UseStorage", useStorageNode.NodeValue<bool>());
+				}
+
+				if (discardExcessResourcesNode != null)
+				{
+					refineryNode.RemoveNode(discardExcessResourcesNode);
+					resourceAccumulatorNode.AddNode("DiscardExcessResources", discardExcessResourcesNode.NodeValue<bool>());
+				}
+
+				break;
+			}
+
+			if (resourceAccumulatorNode != null)
+			{
+				actorNode.AddNode(resourceAccumulatorNode);
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/AddResourceAccumulator.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/AddResourceAccumulator.cs
@@ -17,23 +17,17 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 	{
 		public override string Name => "Refinery had changes to use a ResourceAccumulator trait for altering player resources.";
 
-		public override string Description => "DefaultResourceAccumulator was added and traits UseStorage and DiscardExcessResources were moved from Refinery.";
+		public override string Description => "ResourceAccumulator was added and fields UseStorage and DiscardExcessResources were moved there from Refinery.";
 
 		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
 		{
-			MiniYamlNode resourceAccumulatorNode = null;
-
-			var refineries = actorNode.ChildrenMatching("Refinery");
-			var tiberianSunRefineries = actorNode.ChildrenMatching("TiberianSunRefinery");
-			var allRefineries = new List<MiniYamlNode>(refineries);
-			allRefineries.AddRange(tiberianSunRefineries);
-
-			foreach (var refineryNode in allRefineries)
+			var refineryNode = actorNode.LastChildMatching("Refinery") ?? actorNode.LastChildMatching("TiberianSunRefinery");
+			if (refineryNode != null)
 			{
-				resourceAccumulatorNode = new MiniYamlNode("ResourceAccumulator", "");
+				var resourceAccumulatorNode = new MiniYamlNode("ResourceAccumulator", "");
+				refineryNode.AddNode(resourceAccumulatorNode);
 
 				var useStorageNode = refineryNode.LastChildMatching("UseStorage");
-				var discardExcessResourcesNode = refineryNode.LastChildMatching("DiscardExcessResources");
 
 				if (useStorageNode != null)
 				{
@@ -41,18 +35,13 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 					resourceAccumulatorNode.AddNode("UseStorage", useStorageNode.NodeValue<bool>());
 				}
 
+				var discardExcessResourcesNode = refineryNode.LastChildMatching("DiscardExcessResources");
+
 				if (discardExcessResourcesNode != null)
 				{
 					refineryNode.RemoveNode(discardExcessResourcesNode);
 					resourceAccumulatorNode.AddNode("DiscardExcessResources", discardExcessResourcesNode.NodeValue<bool>());
 				}
-
-				break;
-			}
-
-			if (resourceAccumulatorNode != null)
-			{
-				actorNode.AddNode(resourceAccumulatorNode);
 			}
 
 			yield break;

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -262,6 +262,7 @@ PROC:
 	Power:
 		Amount: -40
 	ProvidesPrerequisite@buildingname:
+	ResourceAccumulator:
 
 SILO:
 	Inherits: ^BaseBuilding

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -291,6 +291,7 @@ refinery:
 		Margin: 1, 4
 		RequiresSelection: true
 		PipCount: 10
+	ResourceAccumulator:
 
 silo:
 	Inherits: ^Building

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1321,6 +1321,7 @@ PROC:
 		RequiresSelection: true
 		PipCount: 17
 		FullSequence: pip-yellow
+	ResourceAccumulator:
 
 SILO:
 	Inherits: ^Building

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -609,3 +609,4 @@ NAWAST:
 		PipStride: 4, 2
 		PipCount: 15
 		Palette: pips
+	ResourceAccumulator:

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -122,7 +122,6 @@ PROC:
 	TiberianSunRefinery:
 		DockAngle: 640
 		DockOffset: 2,1
-		DiscardExcessResources: true
 	StoresResources:
 		Capacity: 2000
 	CustomSellValue:
@@ -171,6 +170,8 @@ PROC:
 		PipStride: 4, 2
 		PipCount: 25
 		Palette: pips
+	ResourceAccumulator:
+		DiscardExcessResources: True
 
 GASILO:
 	Inherits: ^Building


### PR DESCRIPTION
Hi,

This PR moves the Refinery's responsibility for crediting the player into a new IResourceAccumulator. This will allow modders to change how resources are converted into credits for the player more easily. This is useful in DR where the harvested water resource is pooled until it reaches a threshold and is then converted into credits.