### PR TITLE
Reorganize translation references names

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -30,7 +30,7 @@ namespace OpenRA
 	public static class Game
 	{
 		[TranslationReference("filename")]
-		const string SavedScreenshot = "saved-screenshot";
+		const string SavedScreenshot = "notification-saved-screenshot";
 
 		public const int TimestepJankThreshold = 250; // Don't catch up for delays larger than 250ms
 

--- a/OpenRA.Game/Server/PlayerMessageTracker.cs
+++ b/OpenRA.Game/Server/PlayerMessageTracker.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Server
 	class PlayerMessageTracker
 	{
 		[TranslationReference("remaining")]
-		const string ChatTemporaryDisabled = "chat-temp-disabled";
+		const string ChatTemporaryDisabled = "notification-chat-temp-disabled";
 
 		readonly Dictionary<int, List<long>> messageTracker = new Dictionary<int, List<long>>();
 		readonly Server server;

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -47,73 +47,73 @@ namespace OpenRA.Server
 	public sealed class Server
 	{
 		[TranslationReference]
-		const string CustomRules = "custom-rules";
+		const string CustomRules = "notification-custom-rules";
 
 		[TranslationReference]
-		const string BotsDisabled = "bots-disabled";
+		const string BotsDisabled = "notification-map-bots-disabled";
 
 		[TranslationReference]
-		const string TwoHumansRequired = "two-humans-required";
+		const string TwoHumansRequired = "notification-two-humans-required";
 
 		[TranslationReference]
-		const string ErrorGameStarted = "error-game-started";
+		const string ErrorGameStarted = "notification-error-game-started";
 
 		[TranslationReference]
-		const string RequiresPassword = "requires-password";
+		const string RequiresPassword = "notification-requires-password";
 
 		[TranslationReference]
-		const string IncorrectPassword = "incorrect-password";
+		const string IncorrectPassword = "notification-incorrect-password";
 
 		[TranslationReference]
-		const string IncompatibleMod = "incompatible-mod";
+		const string IncompatibleMod = "notification-incompatible-mod";
 
 		[TranslationReference]
-		const string IncompatibleVersion = "incompatible-version";
+		const string IncompatibleVersion = "notification-incompatible-version";
 
 		[TranslationReference]
-		const string IncompatibleProtocol = "incompatible-protocol";
+		const string IncompatibleProtocol = "notification-incompatible-protocol";
 
 		[TranslationReference]
-		const string Banned = "banned";
+		const string Banned = "notification-you-were-banned";
 
 		[TranslationReference]
-		const string TempBanned = "temp-banned";
+		const string TempBanned = "notification-you-were-temp-banned";
 
 		[TranslationReference]
-		const string Full = "full";
+		const string Full = "notification-game-full";
 
 		[TranslationReference("player")]
-		const string Joined = "joined";
+		const string Joined = "notification-joined";
 
 		[TranslationReference]
-		const string RequiresForumAccount = "requires-forum-account";
+		const string RequiresAuthentication = "notification-requires-authentication";
 
 		[TranslationReference]
-		const string NoPermission = "no-permission";
+		const string NoPermission = "notification-no-permission-to-join";
 
 		[TranslationReference("command")]
-		const string UnknownServerCommand = "unknown-server-command";
+		const string UnknownServerCommand = "notification-unknown-server-command";
 
 		[TranslationReference("player")]
-		const string LobbyDisconnected = "lobby-disconnected";
+		const string LobbyDisconnected = "notification-lobby-disconnected";
 
 		[TranslationReference("player")]
-		const string PlayerDisconnected = "player-disconnected";
+		const string PlayerDisconnected = "notification-player-disconnected";
 
 		[TranslationReference("player", "team")]
-		const string PlayerTeamDisconnected = "player-team-disconnected";
+		const string PlayerTeamDisconnected = "notification-team-player-disconnected";
 
 		[TranslationReference("player")]
-		const string ObserverDisconnected = "observer-disconnected";
+		const string ObserverDisconnected = "notification-observer-disconnected";
 
 		[TranslationReference("player")]
-		const string NewAdmin = "new-admin";
+		const string NewAdmin = "notification-new-admin";
 
 		[TranslationReference]
-		const string YouWereKicked = "you-were-kicked";
+		const string YouWereKicked = "notification-you-were-kicked";
 
 		[TranslationReference]
-		const string GameStarted = "game-started";
+		const string GameStarted = "notification-game-started";
 
 		public readonly MersenneTwister Random = new MersenneTwister();
 		public readonly ServerType Type;
@@ -664,7 +664,7 @@ namespace OpenRA.Server
 							if (notAuthenticated)
 							{
 								Log.Write("server", $"Rejected connection from {newConn.EndPoint}; Not authenticated.");
-								SendOrderTo(newConn, "ServerError", RequiresForumAccount);
+								SendOrderTo(newConn, "ServerError", RequiresAuthentication);
 								DropClient(newConn);
 							}
 							else if (blacklisted || notWhitelisted)
@@ -687,7 +687,7 @@ namespace OpenRA.Server
 					if (Type == ServerType.Dedicated && (Settings.RequireAuthentication || Settings.ProfileIDWhitelist.Length > 0))
 					{
 						Log.Write("server", $"Rejected connection from {newConn.EndPoint}; Not authenticated.");
-						SendOrderTo(newConn, "ServerError", RequiresForumAccount);
+						SendOrderTo(newConn, "ServerError", RequiresAuthentication);
 						DropClient(newConn);
 					}
 					else

--- a/OpenRA.Game/Traits/Player/Shroud.cs
+++ b/OpenRA.Game/Traits/Player/Shroud.cs
@@ -20,11 +20,11 @@ namespace OpenRA.Traits
 	{
 		[TranslationReference]
 		[Desc("Descriptive label for the fog checkbox in the lobby.")]
-		public readonly string FogCheckboxLabel = "fog-of-war.label";
+		public readonly string FogCheckboxLabel = "checkbox-fog-of-war.label";
 
 		[TranslationReference]
 		[Desc("Tooltip description for the fog checkbox in the lobby.")]
-		public readonly string FogCheckboxDescription = "fog-of-war.description";
+		public readonly string FogCheckboxDescription = "checkbox-fog-of-war.description";
 
 		[Desc("Default value of the fog checkbox in the lobby.")]
 		public readonly bool FogCheckboxEnabled = true;
@@ -40,11 +40,11 @@ namespace OpenRA.Traits
 
 		[TranslationReference]
 		[Desc("Descriptive label for the explored map checkbox in the lobby.")]
-		public readonly string ExploredMapCheckboxLabel = "explored-map.label";
+		public readonly string ExploredMapCheckboxLabel = "checkbox-explored-map.label";
 
 		[TranslationReference]
 		[Desc("Tooltip description for the explored map checkbox in the lobby.")]
-		public readonly string ExploredMapCheckboxDescription = "explored-map.description";
+		public readonly string ExploredMapCheckboxDescription = "checkbox-explored-map.description";
 
 		[Desc("Default value of the explore map checkbox in the lobby.")]
 		public readonly bool ExploredMapCheckboxEnabled = false;

--- a/OpenRA.Mods.Common/Commands/ChatCommands.cs
+++ b/OpenRA.Mods.Common/Commands/ChatCommands.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Commands
 	public class ChatCommands : INotifyChat
 	{
 		[TranslationReference("name")]
-		const string InvalidCommand = "invalid-command";
+		const string InvalidCommand = "notification-invalid-command";
 
 		public Dictionary<string, IChatCommand> Commands { get; }
 

--- a/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
@@ -24,19 +24,19 @@ namespace OpenRA.Mods.Common.Commands
 	public class DebugVisualizationCommands : IChatCommand, IWorldLoaded
 	{
 		[TranslationReference]
-		const string CombatGeometryDescription = "combat-geometry-description";
+		const string CombatGeometryDescription = "description-combat-geometry";
 
 		[TranslationReference]
-		const string RenderGeometryDescription = "render-geometry-description";
+		const string RenderGeometryDescription = "description-render-geometry";
 
 		[TranslationReference]
-		const string ScreenMapOverlayDescription = "screen-map-overlay-description";
+		const string ScreenMapOverlayDescription = "description-screen-map-overlay";
 
 		[TranslationReference]
-		const string DepthBufferDescription = "depth-buffer-description";
+		const string DepthBufferDescription = "description-depth-buffer";
 
 		[TranslationReference]
-		const string ActorTagsOverlayDescripition = "actor-tags-overlay-description";
+		const string ActorTagsOverlayDescripition = "description-actor-tags-overlay";
 
 		readonly IDictionary<string, (string Description, Action<DebugVisualizations, DeveloperMode> Handler)> commandHandlers = new Dictionary<string, (string Description, Action<DebugVisualizations, DeveloperMode> Handler)>
 		{

--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -25,55 +25,55 @@ namespace OpenRA.Mods.Common.Commands
 	public class DevCommands : IChatCommand, IWorldLoaded
 	{
 		[TranslationReference]
-		const string CheatsDisabled = "cheats-disabled";
+		const string CheatsDisabled = "notification-cheats-disabled";
 
 		[TranslationReference]
-		const string InvalidCashAmount = "invalid-cash-amount";
+		const string InvalidCashAmount = "notification-invalid-cash-amount";
 
 		[TranslationReference]
-		const string ToggleVisiblityDescription = "toggle-visibility";
+		const string ToggleVisiblityDescription = "description-toggle-visibility";
 
 		[TranslationReference]
-		const string GiveCashDescription = "give-cash";
+		const string GiveCashDescription = "description-give-cash";
 
 		[TranslationReference]
-		const string GiveCashAllDescription = "give-cash-all";
+		const string GiveCashAllDescription = "description-give-cash-all";
 
 		[TranslationReference]
-		const string InstantBuildingDescription = "instant-building";
+		const string InstantBuildingDescription = "description-instant-building";
 
 		[TranslationReference]
-		const string BuildAnywhereDescription = "build-anywhere";
+		const string BuildAnywhereDescription = "description-build-anywhere";
 
 		[TranslationReference]
-		const string UnlimitedPowerDescription = "unlimited-power";
+		const string UnlimitedPowerDescription = "description-unlimited-power";
 
 		[TranslationReference]
-		const string EnableTechDescription = "enable-tech";
+		const string EnableTechDescription = "description-enable-tech";
 
 		[TranslationReference]
-		const string FastChargeDescription = "fast-charge";
+		const string FastChargeDescription = "description-fast-charge";
 
 		[TranslationReference]
-		const string DevCheatAllDescription = "dev-cheat-all";
+		const string DevCheatAllDescription = "description-dev-cheat-all";
 
 		[TranslationReference]
-		const string DevCrashDescription = "dev-crash";
+		const string DevCrashDescription = "description-dev-crash";
 
 		[TranslationReference]
-		const string LevelUpActorDescription = "levelup-actor";
+		const string LevelUpActorDescription = "description-levelup-actor";
 
 		[TranslationReference]
-		const string PlayerExperienceDescription = "player-experience";
+		const string PlayerExperienceDescription = "description-player-experience";
 
 		[TranslationReference]
-		const string PowerOutageDescription = "power-outage";
+		const string PowerOutageDescription = "description-power-outage";
 
 		[TranslationReference]
-		const string KillSelectedActorsDescription = "kill-selected-actors";
+		const string KillSelectedActorsDescription = "description-kill-selected-actors";
 
 		[TranslationReference]
-		const string DisposeSelectedActorsDescription = "dispose-selected-actors";
+		const string DisposeSelectedActorsDescription = "description-dispose-selected-actors";
 
 		readonly IDictionary<string, (string Description, Action<string, World> Handler)> commandHandlers = new Dictionary<string, (string, Action<string, World>)>
 		{

--- a/OpenRA.Mods.Common/Commands/HelpCommand.cs
+++ b/OpenRA.Mods.Common/Commands/HelpCommand.cs
@@ -22,13 +22,13 @@ namespace OpenRA.Mods.Common.Commands
 	public class HelpCommand : IChatCommand, IWorldLoaded
 	{
 		[TranslationReference]
-		const string AvailableCommands = "available-commands";
+		const string AvailableCommands = "notification-available-commands";
 
 		[TranslationReference]
-		const string NoDescription = "no-description";
+		const string NoDescription = "description-no-description";
 
 		[TranslationReference]
-		const string HelpDescription = "help-description";
+		const string HelpDescription = "description-help-description";
 
 		readonly Dictionary<string, string> helpDescriptions;
 

--- a/OpenRA.Mods.Common/Commands/PlayerCommands.cs
+++ b/OpenRA.Mods.Common/Commands/PlayerCommands.cs
@@ -21,10 +21,10 @@ namespace OpenRA.Mods.Common.Commands
 	public class PlayerCommands : IChatCommand, IWorldLoaded
 	{
 		[TranslationReference]
-		const string PauseDescription = "pause-description";
+		const string PauseDescription = "description-pause-description";
 
 		[TranslationReference]
-		const string SurrenderDescription = "surrender-description";
+		const string SurrenderDescription = "description-surrender-description";
 
 		World world;
 

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -25,133 +25,133 @@ namespace OpenRA.Mods.Common.Server
 	public class LobbyCommands : ServerTrait, IInterpretCommand, INotifyServerStart, INotifyServerEmpty, IClientJoined
 	{
 		[TranslationReference]
-		const string CustomRules = "custom-rules";
+		const string CustomRules = "notification-custom-rules";
 
 		[TranslationReference]
-		const string OnlyHostStartGame = "only-only-host-start-game";
+		const string OnlyHostStartGame = "notification-admin-start-game";
 
 		[TranslationReference]
-		const string NoStartUntilRequiredSlotsFull = "no-start-until-required-slots-full";
+		const string NoStartUntilRequiredSlotsFull = "notification-no-start-until-required-slots-full";
 
 		[TranslationReference]
-		const string NoStartWithoutPlayers = "no-start-without-players";
+		const string NoStartWithoutPlayers = "notification-no-start-without-players";
 
 		[TranslationReference]
-		const string TwoHumansRequired = "two-humans-required";
+		const string TwoHumansRequired = "notification-two-humans-required";
 
 		[TranslationReference]
-		const string InsufficientEnabledSpawnPoints = "insufficient-enabled-spawnPoints";
+		const string InsufficientEnabledSpawnPoints = "notification-insufficient-enabled-spawn-points";
 
 		[TranslationReference("command")]
-		const string MalformedCommand = "malformed-command";
+		const string MalformedCommand = "notification-malformed-command";
 
 		[TranslationReference]
-		const string KickNone = "kick-none";
+		const string KickNone = "notification-kick-none";
 
 		[TranslationReference]
-		const string NoKickGameStarted = "no-kick-game-started";
+		const string NoKickGameStarted = "notification-no-kick-game-started";
 
 		[TranslationReference("admin", "player")]
-		const string Kicked = "kicked";
+		const string Kicked = "notification-kicked";
 
 		[TranslationReference("admin", "player")]
-		const string TempBan = "temp-ban";
+		const string TempBan = "notification-temp-ban";
 
 		[TranslationReference]
-		const string NoTransferAdmin = "only-host-transfer-admin";
+		const string NoTransferAdmin = "notification-admin-transfer-admin";
 
 		[TranslationReference]
-		const string EmptySlot = "empty-slot";
+		const string EmptySlot = "notification-empty-slot";
 
 		[TranslationReference("admin", "player")]
-		const string MoveSpectators = "move-spectators";
+		const string MoveSpectators = "notification-move-spectators";
 
 		[TranslationReference("player", "name")]
-		const string Nick = "nick";
+		const string Nick = "notification-nick-changed";
 
 		[TranslationReference]
-		const string StateUnchangedReady = "state-unchanged-ready";
+		const string StateUnchangedReady = "notification-state-unchanged-ready";
 
 		[TranslationReference("command")]
-		const string StateUnchangedGameStarted = "state-unchanged-game-started";
+		const string StateUnchangedGameStarted = "notification-state-unchanged-game-started";
 
 		[TranslationReference("faction")]
-		const string InvalidFactionSelected = "invalid-faction-selected";
+		const string InvalidFactionSelected = "notification-invalid-faction-selected";
 
 		[TranslationReference("factions")]
-		const string SupportedFactions = "supported-factions";
+		const string SupportedFactions = "notification-supported-factions";
 
 		[TranslationReference]
-		const string RequiresHost = "requires-host";
+		const string RequiresHost = "notification-requires-host";
 
 		[TranslationReference]
-		const string InvalidBotSlot = "invalid-bot-slot";
+		const string InvalidBotSlot = "notification-invalid-bot-slot";
 
 		[TranslationReference]
-		const string InvalidBotType = "invalid-bot-type";
+		const string InvalidBotType = "notification-invalid-bot-type";
 
 		[TranslationReference]
-		const string HostChangeMap = "only-host-change-map";
+		const string HostChangeMap = "notification-admin-change-map";
 
 		[TranslationReference]
-		const string UnknownMap = "unknown-map";
+		const string UnknownMap = "notification-unknown-map";
 
 		[TranslationReference]
-		const string SearchingMap = "searching-map";
+		const string SearchingMap = "notification-searching-map";
 
 		[TranslationReference]
-		const string NotAdmin = "only-host-change-configuration";
+		const string NotAdmin = "notification-admin-change-configuration";
 
 		[TranslationReference]
-		const string InvalidConfigurationCommand = "invalid-configuration-command";
+		const string InvalidConfigurationCommand = "notification-invalid-configuration-command";
 
 		[TranslationReference("option")]
-		const string OptionLocked = "option-locked";
+		const string OptionLocked = "notification-option-locked";
 
 		[TranslationReference("player", "map")]
-		const string ChangedMap = "changed-map";
+		const string ChangedMap = "notification-changed-map";
 
 		[TranslationReference]
-		const string MapBotsDisabled = "map-bots-disabled";
+		const string MapBotsDisabled = "notification-map-bots-disabled";
 
 		[TranslationReference("player", "name", "value")]
-		const string ValueChanged = "value-changed";
+		const string ValueChanged = "notification-option-changed";
 
 		[TranslationReference]
-		const string NoMoveSpectators = "only-host-move-spectators";
+		const string NoMoveSpectators = "notification-admin-move-spectators";
 
 		[TranslationReference]
-		const string AdminOption = "admin-option";
+		const string AdminOption = "notification-admin-option";
 
 		[TranslationReference("raw")]
-		const string NumberTeams = "number-teams";
+		const string NumberTeams = "notification-error-number-teams";
 
 		[TranslationReference]
-		const string AdminClearSpawn = "admin-clear-spawn";
+		const string AdminClearSpawn = "notification-admin-clear-spawn";
 
 		[TranslationReference]
-		const string SpawnOccupied = "spawn-occupied";
+		const string SpawnOccupied = "notification-spawn-occupied";
 
 		[TranslationReference]
-		const string SpawnLocked = "spawn-locked";
+		const string SpawnLocked = "notification-spawn-locked";
 
 		[TranslationReference]
-		const string AdminLobbyInfo = "admin-lobby-info";
+		const string AdminLobbyInfo = "notification-admin-lobby-info";
 
 		[TranslationReference]
-		const string InvalidLobbyInfo = "invalid-lobby-info";
+		const string InvalidLobbyInfo = "notification-invalid-lobby-info";
 
 		[TranslationReference]
-		const string AdminKick = "admin-kick";
+		const string AdminKick = "notification-admin-kick";
 
 		[TranslationReference]
-		const string SlotClosed = "slot-closed";
+		const string SlotClosed = "notification-slot-closed";
 
 		[TranslationReference("player")]
-		const string NewAdmin = "new-admin";
+		const string NewAdmin = "notification-new-admin";
 
 		[TranslationReference]
-		const string YouWereKicked = "you-were-kicked";
+		const string YouWereKicked = "notification-you-were-kicked";
 
 		readonly IDictionary<string, Func<S, Connection, Session.Client, string, bool>> commandHandlers = new Dictionary<string, Func<S, Connection, Session.Client, string, bool>>
 		{

--- a/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
@@ -31,22 +31,22 @@ namespace OpenRA.Mods.Common.Server
 		const int RateLimitInterval = 1000;
 
 		[TranslationReference]
-		const string NoPortForward = "no-port-forward";
+		const string NoPortForward = "notification-no-port-forward";
 
 		[TranslationReference]
-		const string BlacklistedTitle = "blacklisted-title";
+		const string BlacklistedTitle = "notification-blacklisted-server-name";
 
 		[TranslationReference]
-		const string InvalidErrorCode = "invalid-error-code";
+		const string InvalidErrorCode = "notification-invalid-error-code";
 
 		[TranslationReference]
-		const string Connected = "master-server-connected";
+		const string Connected = "notification-master-server-connected";
 
 		[TranslationReference]
-		const string Error = "master-server-error";
+		const string Error = "notification-master-server-error";
 
 		[TranslationReference]
-		const string GameOffline = "game-offline";
+		const string GameOffline = "notification-game-offline";
 
 		static readonly Beacon LanGameBeacon;
 		static readonly Dictionary<int, string> MasterServerErrors = new Dictionary<int, string>()

--- a/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
@@ -19,16 +19,16 @@ namespace OpenRA.Mods.Common.Server
 	public class PlayerPinger : ServerTrait, ITick
 	{
 		[TranslationReference]
-		const string PlayerDropped = "player-dropped";
+		const string PlayerDropped = "notification-player-dropped";
 
 		[TranslationReference("player")]
-		const string ConnectionProblems = "connection-problems";
+		const string ConnectionProblems = "notification-connection-problems";
 
 		[TranslationReference("player")]
-		const string Timeout = "timeout";
+		const string Timeout = "notification-timeout-dropped";
 
 		[TranslationReference("player", "timeout")]
-		const string TimeoutIn = "timeout-in";
+		const string TimeoutIn = "notification-timeout-dropped-in";
 
 		static readonly int PingInterval = 5000; // Ping every 5 seconds
 		static readonly int ConnReportInterval = 20000; // Report every 20 seconds

--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
@@ -22,11 +22,11 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[TranslationReference]
 		[Desc("Descriptive label for the developer mode checkbox in the lobby.")]
-		public readonly string CheckboxLabel = "debug-menu.label";
+		public readonly string CheckboxLabel = "checkbox-debug-menu.label";
 
 		[TranslationReference]
 		[Desc("Tooltip description for the developer mode checkbox in the lobby.")]
-		public readonly string CheckboxDescription = "debug-menu.description";
+		public readonly string CheckboxDescription = "checkbox-debug-menu.description";
 
 		[Desc("Default value of the developer mode checkbox in the lobby.")]
 		public readonly bool CheckboxEnabled = false;
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class DeveloperMode : IResolveOrder, ISync, INotifyCreated, IUnlocksRenderPlayer
 	{
 		[TranslationReference("cheat", "player", "suffix")]
-		const string CheatUsed = "cheat-used";
+		const string CheatUsed = "notification-cheat-used";
 
 		readonly DeveloperModeInfo info;
 		public bool Enabled { get; private set; }

--- a/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		const string CommandName = "custom-terrain";
 
 		[TranslationReference]
-		const string CommandDescription = "custom-terrain-debug-overlay-description";
+		const string CommandDescription = "description-custom-terrain-debug-overlay";
 
 		public bool Enabled;
 

--- a/OpenRA.Mods.Common/Traits/World/CellTriggerOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/CellTriggerOverlay.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 		const string CommandName = "triggers";
 
 		[TranslationReference]
-		const string CommandDescription = "cell-trigger-overlay-description";
+		const string CommandDescription = "description-cell-triggers-overlay";
 
 		bool enabled;
 

--- a/OpenRA.Mods.Common/Traits/World/ColorPickerManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/ColorPickerManager.cs
@@ -23,13 +23,13 @@ namespace OpenRA.Mods.Common.Traits
 	public class ColorPickerManagerInfo : TraitInfo<ColorPickerManager>, IRulesetLoaded
 	{
 		[TranslationReference]
-		const string PlayerColorTerrain = "player-color-terrain";
+		const string PlayerColorTerrain = "notification-player-color-terrain";
 
 		[TranslationReference]
-		const string PlayerColorPlayer = "player-color-player";
+		const string PlayerColorPlayer = "notification-player-color-player";
 
 		[TranslationReference]
-		const string InvalidPlayerColor = "invalid-player-color";
+		const string InvalidPlayerColor = "notification-invalid-player-color";
 
 		[Desc("Minimum and maximum saturation levels that are valid for use.")]
 		public readonly float[] HsvSaturationRange = { 0.3f, 0.95f };

--- a/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
@@ -23,11 +23,11 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[TranslationReference]
 		[Desc("Descriptive label for the crates checkbox in the lobby.")]
-		public readonly string CheckboxLabel = "crates.label";
+		public readonly string CheckboxLabel = "checkbox-crates.label";
 
 		[TranslationReference]
 		[Desc("Tooltip description for the crates checkbox in the lobby.")]
-		public readonly string CheckboxDescription = "crates.description";
+		public readonly string CheckboxDescription = "checkbox-crates.description";
 
 		[Desc("Default value of the crates checkbox in the lobby.")]
 		public readonly bool CheckboxEnabled = true;

--- a/OpenRA.Mods.Common/Traits/World/ExitsDebugOverlayManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/ExitsDebugOverlayManager.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		const string CommandName = "exits-overlay";
 
 		[TranslationReference]
-		const string CommandDescription = "exits-debug-overlay-description";
+		const string CommandDescription = "description-exits-overlay";
 
 		public readonly SpriteFont Font;
 		public readonly ExitsDebugOverlayManagerInfo Info;

--- a/OpenRA.Mods.Common/Traits/World/HierarchicalPathFinderOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/HierarchicalPathFinderOverlay.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 		const string CommandName = "hpf";
 
 		[TranslationReference]
-		const string CommandDescription = "hpf-overlay-description";
+		const string CommandDescription = "description-hpf-debug-overlay";
 
 		readonly HierarchicalPathFinderOverlayInfo info;
 		readonly SpriteFont font;

--- a/OpenRA.Mods.Common/Traits/World/MapBuildRadius.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapBuildRadius.cs
@@ -20,11 +20,11 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[TranslationReference]
 		[Desc("Descriptive label for the ally build radius checkbox in the lobby.")]
-		public readonly string AllyBuildRadiusCheckboxLabel = "ally-build-radius.label";
+		public readonly string AllyBuildRadiusCheckboxLabel = "checkbox-ally-build-radius.label";
 
 		[TranslationReference]
 		[Desc("Tooltip description for the ally build radius checkbox in the lobby.")]
-		public readonly string AllyBuildRadiusCheckboxDescription = "ally-build-radius.description";
+		public readonly string AllyBuildRadiusCheckboxDescription = "checkbox-ally-build-radius.description";
 
 		[Desc("Default value of the ally build radius checkbox in the lobby.")]
 		public readonly bool AllyBuildRadiusCheckboxEnabled = true;
@@ -40,11 +40,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		[TranslationReference]
 		[Desc("Tooltip description for the build radius checkbox in the lobby.")]
-		public readonly string BuildRadiusCheckboxLabel = "build-radius.label";
+		public readonly string BuildRadiusCheckboxLabel = "checkbox-build-radius.label";
 
 		[TranslationReference]
 		[Desc("Tooltip description for the build radius checkbox in the lobby.")]
-		public readonly string BuildRadiusCheckboxDescription = "build-radius.description";
+		public readonly string BuildRadiusCheckboxDescription = "checkbox-build-radius.description";
 
 		[Desc("Default value of the build radius checkbox in the lobby.")]
 		public readonly bool BuildRadiusCheckboxEnabled = true;

--- a/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
@@ -20,11 +20,11 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[TranslationReference]
 		[Desc("Descriptive label for the creeps checkbox in the lobby.")]
-		public readonly string CheckboxLabel = "map-creeps.label";
+		public readonly string CheckboxLabel = "dropdown-map-creeps.label";
 
 		[TranslationReference]
 		[Desc("Tooltip description for the creeps checkbox in the lobby.")]
-		public readonly string CheckboxDescription = "map-creeps.description";
+		public readonly string CheckboxDescription = "dropdown-map-creeps.description";
 
 		[Desc("Default value of the creeps checkbox in the lobby.")]
 		public readonly bool CheckboxEnabled = true;

--- a/OpenRA.Mods.Common/Traits/World/MapOptions.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapOptions.cs
@@ -21,11 +21,11 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[TranslationReference]
 		[Desc("Descriptive label for the short game checkbox in the lobby.")]
-		public readonly string ShortGameCheckboxLabel = "short-game.label";
+		public readonly string ShortGameCheckboxLabel = "checkbox-short-game.label";
 
 		[TranslationReference]
 		[Desc("Tooltip description for the short game checkbox in the lobby.")]
-		public readonly string ShortGameCheckboxDescription = "short-game.description";
+		public readonly string ShortGameCheckboxDescription = "checkbox-short-game.description";
 
 		[Desc("Default value of the short game checkbox in the lobby.")]
 		public readonly bool ShortGameCheckboxEnabled = true;
@@ -41,11 +41,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		[TranslationReference]
 		[Desc("Descriptive label for the tech level option in the lobby.")]
-		public readonly string TechLevelDropdownLabel = "tech-level.label";
+		public readonly string TechLevelDropdownLabel = "dropdown-tech-level.label";
 
 		[TranslationReference]
 		[Desc("Tooltip description for the tech level option in the lobby.")]
-		public readonly string TechLevelDropdownDescription = "tech-level.description";
+		public readonly string TechLevelDropdownDescription = "dropdown-tech-level.description";
 
 		[Desc("Default tech level.")]
 		public readonly string TechLevel = "unrestricted";
@@ -61,11 +61,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		[TranslationReference]
 		[Desc("Tooltip description for the game speed option in the lobby.")]
-		public readonly string GameSpeedDropdownLabel = "game-speed.label";
+		public readonly string GameSpeedDropdownLabel = "dropdown-game-speed.label";
 
 		[TranslationReference]
 		[Desc("Description of the game speed option in the lobby.")]
-		public readonly string GameSpeedDropdownDescription = "game-speed.description";
+		public readonly string GameSpeedDropdownDescription = "dropdown-game-speed.description";
 
 		[Desc("Default game speed (leave empty to use the default defined in mod.yaml).")]
 		public readonly string GameSpeed = null;

--- a/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
@@ -27,11 +27,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		[TranslationReference]
 		[Desc("Descriptive label for the spawn positions checkbox in the lobby.")]
-		public readonly string SeparateTeamSpawnsCheckboxLabel = "separate-team-spawns.label";
+		public readonly string SeparateTeamSpawnsCheckboxLabel = "checkbox-separate-team-spawns.label";
 
 		[TranslationReference]
 		[Desc("Tooltip description for the spawn positions checkbox in the lobby.")]
-		public readonly string SeparateTeamSpawnsCheckboxDescription = "separate-team-spawns.description";
+		public readonly string SeparateTeamSpawnsCheckboxDescription = "checkbox-separate-team-spawns.description";
 
 		[Desc("Default value of the spawn positions checkbox in the lobby.")]
 		public readonly bool SeparateTeamSpawnsCheckboxEnabled = true;

--- a/OpenRA.Mods.Common/Traits/World/PathFinderOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinderOverlay.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		const string CommandName = "path-debug";
 
 		[TranslationReference]
-		const string CommandDescription = "path-debug-description";
+		const string CommandDescription = "description-path-debug-overlay";
 
 		sealed class Record : PathSearch.IRecorder, IEnumerable<(CPos Source, CPos Destination, int CostSoFar, int EstimatedRemainingCost)>
 		{

--- a/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
@@ -26,11 +26,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		[TranslationReference]
 		[Desc("Descriptive label for the starting units option in the lobby.")]
-		public readonly string DropdownLabel = "starting-units.label";
+		public readonly string DropdownLabel = "dropdown-starting-units.label";
 
 		[TranslationReference]
 		[Desc("Tooltip description for the starting units option in the lobby.")]
-		public readonly string DropdownDescription = "starting-units.description";
+		public readonly string DropdownDescription = "dropdown-starting-units.description";
 
 		[Desc("Prevent the starting units option from being changed in the lobby.")]
 		public readonly bool DropdownLocked = false;

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		const string CommandName = "terrain-geometry";
 
 		[TranslationReference]
-		const string CommandDescription = "terrain-geometry-overlay";
+		const string CommandDescription = "description-terrain-geometry-overlay";
 
 		public bool Enabled;
 

--- a/OpenRA.Mods.Common/Traits/World/TimeLimitManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/TimeLimitManager.cs
@@ -23,11 +23,11 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[TranslationReference]
 		[Desc("Label that will be shown for the time limit option in the lobby.")]
-		public readonly string TimeLimitLabel = "time-limit.label";
+		public readonly string TimeLimitLabel = "dropdown-time-limit.label";
 
 		[TranslationReference]
 		[Desc("Tooltip description that will be shown for the time limit option in the lobby.")]
-		public readonly string TimeLimitDescription = "time-limit.description";
+		public readonly string TimeLimitDescription = "dropdown-time-limit.description";
 
 		[Desc("Time Limit options that will be shown in the lobby dropdown. Values are in minutes.")]
 		public readonly int[] TimeLimitOptions = { 0, 10, 20, 30, 40, 60, 90 };
@@ -77,10 +77,10 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		[TranslationReference]
-		const string NoTimeLimit = "no-time-limit";
+		const string NoTimeLimit = "options-time-limit.no-limit";
 
 		[TranslationReference("minutes")]
-		const string TimeLimitOption = "time-limit-options";
+		const string TimeLimitOption = "options-time-limit.options";
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class TimeLimitManager : INotifyTimeLimit, ITick, IWorldLoaded
 	{
 		[TranslationReference]
-		const string TimeLimitExpired = "time-limit-expired";
+		const string TimeLimitExpired = "notification-time-limit-expired";
 
 		readonly TimeLimitManagerInfo info;
 		readonly int ticksPerSecond;

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -35,10 +35,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 
 		[TranslationReference("length")]
-		const string LengthInSeconds = "length-in-seconds";
+		const string LengthInSeconds = "label-length-in-seconds";
 
 		[TranslationReference]
-		const string AllPackages = "all-packages";
+		const string AllPackages = "label-all-packages";
 
 		readonly string[] allowedExtensions;
 		readonly string[] allowedSpriteExtensions;

--- a/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class ConnectionLogic : ChromeLogic
 	{
 		[TranslationReference("endpoint")]
-		const string ConnectingToEndpoint = "connecting-to-endpoint";
+		const string ConnectingToEndpoint = "label-connecting-to-endpoint";
 
 		readonly Action onConnect;
 		readonly Action onAbort;
@@ -87,16 +87,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class ConnectionFailedLogic : ChromeLogic
 	{
 		[TranslationReference("target")]
-		const string CouldNotConnectToTarget = "could-not-connect-to-target";
+		const string CouldNotConnectToTarget = "label-could-not-connect-to-target";
 
 		[TranslationReference]
-		const string UnknownError = "unknown-error";
+		const string UnknownError = "label-unknown-error";
 
 		[TranslationReference]
-		const string PasswordRequired = "password-required";
+		const string PasswordRequired = "label-password-required";
 
 		[TranslationReference]
-		const string ConnectionFailed = "connection-failed";
+		const string ConnectionFailed = "label-connection-failed";
 
 		readonly PasswordFieldWidget passwordField;
 		bool passwordOffsetAdjusted;
@@ -171,7 +171,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class ConnectionSwitchModLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string ModSwitchFailed = "mod-switch-failed";
+		const string ModSwitchFailed = "notification-mod-switch-failed";
 
 		[ObjectCreator.UseCtor]
 		public ConnectionSwitchModLogic(Widget widget, OrderManager orderManager, NetworkConnection connection, Action onAbort, Action<string> onRetry)

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -21,13 +21,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class ActorEditLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string DuplicateActorId = "duplicate-actor-id";
+		const string DuplicateActorId = "label-duplicate-actor-id";
 
 		[TranslationReference]
-		const string EnterActorId = "enter-actor-id";
+		const string EnterActorId = "label-actor-id";
 
 		[TranslationReference]
-		const string Owner = "owner";
+		const string Owner = "label-actor-owner";
 
 		// Error states define overlapping bits to simplify panel reflow logic
 		[Flags]

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -21,8 +21,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class ActorSelectorLogic : CommonSelectorLogic
 	{
-		[TranslationReference]
-		const string Type = "type";
+		[TranslationReference("actorType")]
+		const string ActorTypeTooltip = "label-actor-type";
 
 		class ActorSelectorActor
 		{
@@ -115,8 +115,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (tooltip != null)
 					searchTerms.Add(tooltip.Name);
 
-				var type = modData.Translation.GetString(Type);
-				var tooltipText = (tooltip == null ? $"{type}: " : tooltip.Name + $"\n{type}: ") + a.Name;
+				var actorType = modData.Translation.GetString(ActorTypeTooltip, Translation.Arguments("actorType", a.Name));
+				var tooltipText = tooltip == null ? actorType : tooltip.Name + $"\n{actorType}";
 				allActorsTemp.Add(new ActorSelectorActor(a, editorData.Categories, searchTerms.ToArray(), tooltipText));
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/CommonSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/CommonSelectorLogic.cs
@@ -20,16 +20,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public abstract class CommonSelectorLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string None = "none";
+		const string None = "options-common-selector.none";
 
 		[TranslationReference]
-		const string SearchResults = "search-results";
+		const string SearchResults = "options-common-selector.search-results";
 
 		[TranslationReference]
-		const string All = "all";
+		const string All = "options-common-selector.all";
 
 		[TranslationReference]
-		const string Multiple = "multiple";
+		const string Multiple = "options-common-selector.multiple";
 
 		protected readonly Widget Widget;
 		protected readonly ModData ModData;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -43,34 +43,34 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 
 		[TranslationReference]
-		const string SaveMapFailedTitle = "save-map-failed-title";
+		const string SaveMapFailedTitle = "dialog-save-map-failed.title";
 
 		[TranslationReference]
-		const string SaveMapFailedPrompt = "save-map-failed-prompt";
+		const string SaveMapFailedPrompt = "dialog-save-map-failed.prompt";
 
 		[TranslationReference]
-		const string SaveMapFailedAccept = "save-map-failed-accept";
+		const string SaveMapFailedAccept = "dialog-save-map-failed.confirm";
 
 		[TranslationReference]
-		const string Unpacked = "unpacked";
+		const string Unpacked = "label-unpacked-map";
 
 		[TranslationReference]
-		const string OverwriteMapFailedTitle = "overwrite-map-failed-title";
+		const string OverwriteMapFailedTitle = "dialog-overwrite-map-failed.title";
 
 		[TranslationReference]
-		const string OverwriteMapFailedPrompt = "overwrite-map-failed-prompt";
+		const string OverwriteMapFailedPrompt = "dialog-overwrite-map-failed.prompt";
 
 		[TranslationReference]
-		const string SaveMapFailedConfirm = "overwrite-map-failed-confirm";
+		const string SaveMapFailedConfirm = "dialog-overwrite-map-failed.confirm";
 
 		[TranslationReference]
-		const string OverwriteMapOutsideEditTitle = "overwrite-map-outside-edit-title";
+		const string OverwriteMapOutsideEditTitle = "dialog-overwrite-map-outside-edit.title";
 
 		[TranslationReference]
-		const string OverwriteMapOutsideEditPrompt = "overwrite-map-outside-edit-prompt";
+		const string OverwriteMapOutsideEditPrompt = "dialog-overwrite-map-outside-edit.prompt";
 
 		[TranslationReference]
-		const string SaveMapMapOutsideConfirm = "overwrite-map-outside-edit-confirm";
+		const string SaveMapMapOutsideConfirm = "dialog-overwrite-map-outside-edit.confirm";
 
 		[ObjectCreator.UseCtor]
 		public SaveMapLogic(Widget widget, ModData modData, Action<string> onSave, Action onExit,

--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -21,43 +21,43 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class GameSaveBrowserLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string RenameSaveTitle = "rename-save-title";
+		const string RenameSaveTitle = "dialog-rename-save.title";
 
 		[TranslationReference]
-		const string RenameSavePrompt = "rename-save-prompt";
+		const string RenameSavePrompt = "dialog-rename-save.prompt";
 
 		[TranslationReference]
-		const string RenameSaveAccept = "rename-save-accept";
+		const string RenameSaveAccept = "dialog-rename-save.confirm";
 
 		[TranslationReference]
-		const string DeleteSaveTitle = "delete-save-title";
+		const string DeleteSaveTitle = "dialog-delete-save.title";
 
 		[TranslationReference("save")]
-		const string DeleteSavePrompt = "delete-save-prompt";
+		const string DeleteSavePrompt = "dialog-delete-save.prompt";
 
 		[TranslationReference]
-		const string DeleteSaveAccept = "delete-save-accept";
+		const string DeleteSaveAccept = "dialog-delete-save.confirm";
 
 		[TranslationReference]
-		const string DeleteAllSavesTitle = "delete-all-saves-title";
+		const string DeleteAllSavesTitle = "dialog-delete-all-saves.title";
 
 		[TranslationReference("count")]
-		const string DeleteAllSavesPrompt = "delete-all-saves-prompt";
+		const string DeleteAllSavesPrompt = "dialog-delete-all-saves.prompt";
 
 		[TranslationReference]
-		const string DeleteAllSavesAccept = "delete-all-saves-accept";
+		const string DeleteAllSavesAccept = "dialog-delete-all-saves.confirm";
 
 		[TranslationReference("savePath")]
-		const string SaveDeletionFailed = "save-deletion-failed";
+		const string SaveDeletionFailed = "notification-save-deletion-failed";
 
 		[TranslationReference]
-		const string OverwriteSaveTitle = "overwrite-save-title";
+		const string OverwriteSaveTitle = "dialog-overwrite-save.title";
 
 		[TranslationReference("file")]
-		const string OverwriteSavePrompt = "overwrite-save-prompt";
+		const string OverwriteSavePrompt = "dialog-overwrite-save.prompt";
 
 		[TranslationReference]
-		const string OverwriteSaveAccpet = "overwrite-save-accept";
+		const string OverwriteSaveAccpet = "dialog-overwrite-save.confirm";
 
 		readonly Widget panel;
 		readonly ScrollPanelWidget gameList;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -23,19 +23,19 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	class GameInfoLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string Objectives = "objectives";
+		const string Objectives = "menu-game-info.objectives";
 
 		[TranslationReference]
-		const string Briefing = "briefing";
+		const string Briefing = "menu-game-info.briefing";
 
 		[TranslationReference]
-		const string Options = "options";
+		const string Options = "menu-game-info.options";
 
 		[TranslationReference]
-		const string Debug = "debug";
+		const string Debug = "menu-game-info.debug";
 
 		[TranslationReference]
-		const string Chat = "chat";
+		const string Chat = "menu-game-info.chat";
 
 		readonly World world;
 		readonly ModData modData;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoObjectivesLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoObjectivesLogic.cs
@@ -20,13 +20,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	class GameInfoObjectivesLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string InProgress = "in-progress";
+		const string InProgress = "label-mission-in-progress";
 
 		[TranslationReference]
-		const string Accomplished = "accomplished";
+		const string Accomplished = "label-mission-accomplished";
 
 		[TranslationReference]
-		const string Failed = "failed";
+		const string Failed = "label-mission-failed";
 
 		readonly ContainerWidget template;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -23,40 +23,40 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	class GameInfoStatsLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string Unmute = "unmute";
+		const string Unmute = "label-unmute-player";
 
 		[TranslationReference]
-		const string Mute = "mute";
+		const string Mute = "label-mute-player";
 
 		[TranslationReference]
-		const string Accomplished = "accomplished";
+		const string Accomplished = "label-mission-accomplished";
 
 		[TranslationReference]
-		const string Failed = "failed";
+		const string Failed = "label-mission-failed";
 
 		[TranslationReference]
-		const string InProgress = "in-progress";
+		const string InProgress = "label-mission-in-progress";
 
 		[TranslationReference("team")]
-		const string TeamNumber = "team-number";
+		const string TeamNumber = "label-team-name";
 
 		[TranslationReference]
-		const string NoTeam = "no-team";
+		const string NoTeam = "label-no-team";
 
 		[TranslationReference]
-		const string Spectators = "spectators";
+		const string Spectators = "label-spectators";
 
 		[TranslationReference]
-		const string Gone = "gone";
+		const string Gone = "label-client-state-disconnected";
 
 		[TranslationReference("player")]
-		const string KickTitle = "kick-title";
+		const string KickTitle = "dialog-kick.title";
 
 		[TranslationReference]
-		const string KickPrompt = "kick-prompt";
+		const string KickPrompt = "dialog-kick.prompt";
 
 		[TranslationReference]
-		const string KickAccept = "kick-accept";
+		const string KickAccept = "dialog-kick.confirm";
 
 		[ObjectCreator.UseCtor]
 		public GameInfoStatsLogic(Widget widget, ModData modData, World world, OrderManager orderManager, WorldRenderer worldRenderer, Action<bool> hideMenu)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameTimerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameTimerLogic.cs
@@ -19,16 +19,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class GameTimerLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string Paused = "paused";
+		const string Paused = "label-paused";
 
 		[TranslationReference]
-		const string MaxSpeed = "max-speed";
+		const string MaxSpeed = "label-max-speed";
 
 		[TranslationReference("percentage")]
-		const string Speed = "speed";
+		const string Speed = "label-replay-speed";
 
 		[TranslationReference("percentage")]
-		const string Complete = "complete";
+		const string Complete = "label-replay-complete";
 
 		[ObjectCreator.UseCtor]
 		public GameTimerLogic(Widget widget, ModData modData, OrderManager orderManager, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class IngameCashCounterLogic : ChromeLogic
 	{
 		[TranslationReference("usage", "capacity")]
-		const string SiloUsage = "silo-usage";
+		const string SiloUsage = "label-silo-usage";
 
 		const float DisplayFracPerFrame = .07f;
 		const int DisplayDeltaPerFrame = 37;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -24,16 +24,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class IngameChatLogic : ChromeLogic, INotificationHandler<TextNotification>
 	{
 		[TranslationReference]
-		const string Team = "team";
+		const string TeamChat = "button-team-chat";
 
 		[TranslationReference]
-		const string All = "all";
+		const string GeneralChat = "button-general-chat";
 
 		[TranslationReference("seconds")]
-		const string ChatAvailability = "chat-availability";
+		const string ChatAvailability = "label-chat-availability";
 
 		[TranslationReference]
-		const string ChatDisabled = "chat-disabled";
+		const string ChatDisabled = "label-chat-disabled";
 
 		readonly Ruleset modRules;
 		readonly World world;
@@ -70,8 +70,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var disableTeamChat = alwaysDisabled || (world.LocalPlayer != null && !players.Any(p => p.IsAlliedWith(world.LocalPlayer)));
 			var teamChat = !disableTeamChat;
 
-			var teamMessage = modData.Translation.GetString(Team);
-			var allMessage = modData.Translation.GetString(All);
+			var teamMessage = modData.Translation.GetString(TeamChat);
+			var allMessage = modData.Translation.GetString(GeneralChat);
 
 			chatDisabled = modData.Translation.GetString(ChatDisabled);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -22,100 +22,100 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class IngameMenuLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string Leave = "leave";
+		const string Leave = "menu-ingame.leave";
 
 		[TranslationReference]
-		const string AbortMission = "abort-mission";
+		const string AbortMission = "menu-ingame.abort";
 
 		[TranslationReference]
-		const string LeaveMissionTitle = "leave-mission-title";
+		const string LeaveMissionTitle = "dialog-leave-mission.title";
 
 		[TranslationReference]
-		const string LeaveMissionPrompt = "leave-mission-prompt";
+		const string LeaveMissionPrompt = "dialog-leave-mission.prompt";
 
 		[TranslationReference]
-		const string LeaveMissionAccept = "leave-mission-accept";
+		const string LeaveMissionAccept = "dialog-leave-mission.confirm";
 
 		[TranslationReference]
-		const string LeaveMissionCancel = "leave-mission-cancel";
+		const string LeaveMissionCancel = "dialog-leave-mission.cancel";
 
 		[TranslationReference]
-		const string RestartButton = "restart-button";
+		const string RestartButton = "menu-ingame.restart";
 
 		[TranslationReference]
-		const string RestartMissionTitle = "restart-mission-title";
+		const string RestartMissionTitle = "dialog-restart-mission.title";
 
 		[TranslationReference]
-		const string RestartMissionPrompt = "restart-mission-prompt";
+		const string RestartMissionPrompt = "dialog-restart-mission.prompt";
 
 		[TranslationReference]
-		const string RestartMissionAccept = "restart-mission-accept";
+		const string RestartMissionAccept = "dialog-restart-mission.confirm";
 
 		[TranslationReference]
-		const string RestartMissionCancel = "restart-mission-cancel";
+		const string RestartMissionCancel = "dialog-restart-mission.cancel";
 
 		[TranslationReference]
-		const string SurrenderButton = "surrender-button";
+		const string SurrenderButton = "menu-ingame.surrender";
 
 		[TranslationReference]
-		const string SurrenderTitle = "surrender-title";
+		const string SurrenderTitle = "dialog-surrender.title";
 
 		[TranslationReference]
-		const string SurrenderPrompt = "surrender-prompt";
+		const string SurrenderPrompt = "dialog-surrender.prompt";
 
 		[TranslationReference]
-		const string SurrenderAccept = "surrender-accept";
+		const string SurrenderAccept = "dialog-surrender.confirm";
 
 		[TranslationReference]
-		const string SurrenderCancel = "surrender-cancel";
+		const string SurrenderCancel = "dialog-surrender.cancel";
 
 		[TranslationReference]
-		const string LoadGameButton = "load-game-button";
+		const string LoadGameButton = "menu-ingame.load-game";
 
 		[TranslationReference]
-		const string SaveGameButton = "save-game-button";
+		const string SaveGameButton = "menu-ingame.save-game";
 
 		[TranslationReference]
-		const string MusicButton = "music-button";
+		const string MusicButton = "menu-ingame.music";
 
 		[TranslationReference]
-		const string SettingsButton = "settings-button";
+		const string SettingsButton = "menu-ingame.settings";
 
 		[TranslationReference]
-		const string ReturnToMap = "return-to-map";
+		const string ReturnToMap = "menu-ingame.return-to-map";
 
 		[TranslationReference]
-		const string Resume = "resume";
+		const string Resume = "menu-ingame.resume";
 
 		[TranslationReference]
-		const string SaveMapButton = "save-map-button";
+		const string SaveMapButton = "menu-ingame.save-map";
 
 		[TranslationReference]
-		const string ErrorMaxPlayerTitle = "error-max-player-title";
+		const string ErrorMaxPlayerTitle = "dialog-error-max-player.title";
 
 		[TranslationReference("players", "max")]
-		const string ErrorMaxPlayerPrompt = "error-max-player-prompt";
+		const string ErrorMaxPlayerPrompt = "dialog-error-max-player.prompt";
 
 		[TranslationReference]
-		const string ErrorMaxPlayerAccept = "error-max-player-accept";
+		const string ErrorMaxPlayerAccept = "dialog-error-max-player.confirm";
 
 		[TranslationReference]
-		const string ExitMapButton = "exit-map-button";
+		const string ExitMapButton = "menu-ingame.exit-map";
 
 		[TranslationReference]
-		const string ExitMapEditorTitle = "exit-map-editor-title";
+		const string ExitMapEditorTitle = "dialog-exit-map-editor.title";
 
 		[TranslationReference]
-		const string ExitMapEditorPromptUnsaved = "exit-map-editor-prompt-unsaved";
+		const string ExitMapEditorPromptUnsaved = "dialog-exit-map-editor.prompt-unsaved";
 
 		[TranslationReference]
-		const string ExitMapEditorPromptDeleted = "exit-map-editor-prompt-deleted";
+		const string ExitMapEditorPromptDeleted = "dialog-exit-map-editor.prompt-deleted";
 
 		[TranslationReference]
-		const string ExitMapEditorAnywayConfirm = "exit-map-editor-confirm-anyway";
+		const string ExitMapEditorAnywayConfirm = "dialog-exit-map-editor.confirm-anyway";
 
 		[TranslationReference]
-		const string ExitMapEditorConfirm = "exit-map-editor-confirm";
+		const string ExitMapEditorConfirm = "dialog-exit-map-editor.confirm";
 
 		readonly Widget menu;
 		readonly Widget buttonContainer;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerBarLogic.cs
@@ -18,10 +18,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class IngamePowerBarLogic : ChromeLogic
 	{
 		[TranslationReference("usage", "capacity")]
-		const string PowerUsage = "power-usage";
+		const string PowerUsage = "label-power-usage";
 
 		[TranslationReference]
-		const string Infinite = "infinite-power";
+		const string Infinite = "label-infinite-power";
 
 		[ObjectCreator.UseCtor]
 		public IngamePowerBarLogic(Widget widget, ModData modData, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerCounterLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerCounterLogic.cs
@@ -18,10 +18,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class IngamePowerCounterLogic : ChromeLogic
 	{
 		[TranslationReference("usage", "capacity")]
-		const string PowerUsage = "power-usage";
+		const string PowerUsage = "label-power-usage";
 
 		[TranslationReference]
-		const string Infinite = "infinite-power";
+		const string Infinite = "label-infinite-power";
 
 		[ObjectCreator.UseCtor]
 		public IngamePowerCounterLogic(Widget widget, ModData modData, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameSiloBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameSiloBarLogic.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class IngameSiloBarLogic : ChromeLogic
 	{
 		[TranslationReference("usage", "capacity")]
-		const string SiloUsage = "silo-usage";
+		const string SiloUsage = "label-silo-usage";
 
 		[ObjectCreator.UseCtor]
 		public IngameSiloBarLogic(Widget widget, ModData modData, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
@@ -24,22 +24,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class ObserverShroudSelectorLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string CameraOptionAllPlayers = "camera-option-all-players";
+		const string CameraOptionAllPlayers = "options-shroud-selector.all-players";
 
 		[TranslationReference]
-		const string CameraOptionDisableShroud = "camera-option-disable-shroud";
+		const string CameraOptionDisableShroud = "options-shroud-selector.disable-shroud";
 
 		[TranslationReference]
-		const string CameraOptionOther = "camera-option-other";
+		const string CameraOptionOther = "options-shroud-selector.other";
 
 		[TranslationReference]
-		const string Players = "players";
+		const string Players = "label-players";
 
 		[TranslationReference("team")]
-		const string TeamNumber = "team-number";
+		const string TeamNumber = "label-team-name";
 
 		[TranslationReference]
-		const string NoTeam = "no-team";
+		const string NoTeam = "label-no-team";
 
 		readonly CameraOption combined, disableShroud;
 		readonly IOrderedEnumerable<IGrouping<int, CameraOption>> teams;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -28,37 +28,37 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class ObserverStatsLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string InformationNone = "information-none";
+		const string InformationNone = "options-observer-stats.none";
 
 		[TranslationReference]
-		const string Basic = "basic";
+		const string Basic = "options-observer-stats.basic";
 
 		[TranslationReference]
-		const string Economy = "economy";
+		const string Economy = "options-observer-stats.economy";
 
 		[TranslationReference]
-		const string Production = "production";
+		const string Production = "options-observer-stats.production";
 
 		[TranslationReference]
-		const string SupportPowers = "support-powers";
+		const string SupportPowers = "options-observer-stats.support-powers";
 
 		[TranslationReference]
-		const string Combat = "combat";
+		const string Combat = "options-observer-stats.combat";
 
 		[TranslationReference]
-		const string Army = "army";
+		const string Army = "options-observer-stats.army";
 
 		[TranslationReference]
-		const string EarningsGraph = "earnings-graph";
+		const string EarningsGraph = "options-observer-stats.earnings-graph";
 
 		[TranslationReference]
-		const string ArmyGraph = "army-graph";
+		const string ArmyGraph = "options-observer-stats.army-graph";
 
 		[TranslationReference("team")]
-		const string TeamNumber = "team-number";
+		const string TeamNumber = "label-team-name";
 
 		[TranslationReference]
-		const string NoTeam = "no-team";
+		const string NoTeam = "label-no-team";
 
 		readonly ContainerWidget basicStatsHeaders;
 		readonly ContainerWidget economyStatsHeaders;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class WorldTooltipLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string UnrevealedTerrain = "unrevealed-terrain";
+		const string UnrevealedTerrain = "label-unrevealed-terrain";
 
 		[ObjectCreator.UseCtor]
 		public WorldTooltipLogic(Widget widget, ModData modData, World world, TooltipContainerWidget tooltipContainer, ViewportControllerWidget viewport)

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
@@ -24,37 +24,37 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class DownloadPackageLogic : ChromeLogic
 	{
 		[TranslationReference("title")]
-		const string Downloading = "downloading";
+		const string Downloading = "label-downloading";
 
 		[TranslationReference]
-		const string FetchingMirrorList = "fetching-mirror-list";
+		const string FetchingMirrorList = "label-fetching-mirror-list";
 
 		[TranslationReference]
-		const string UnknownHost = "unknown-host";
+		const string UnknownHost = "label-unknown-host";
 
 		[TranslationReference("host", "received", "suffix")]
-		const string DownloadingFrom = "downloading-from";
+		const string DownloadingFrom = "label-downloading-from";
 
 		[TranslationReference("host", "received", "total", "suffix", "progress")]
-		const string DownloadingFromProgress = "downloading-from-progress";
+		const string DownloadingFromProgress = "label-downloading-from-progress";
 
 		[TranslationReference]
-		const string VerifyingArchive = "verifying-archive";
+		const string VerifyingArchive = "label-verifying-archive";
 
 		[TranslationReference]
-		const string ArchiveValidationFailed = "archive-validation-failed";
+		const string ArchiveValidationFailed = "label-archive-validation-failed";
 
 		[TranslationReference]
-		const string Extracting = "extracting";
+		const string Extracting = "label-extracting-archive";
 
 		[TranslationReference("entry")]
-		const string ExtractingEntry = "extracting-entry";
+		const string ExtractingEntry = "label-extracting-archive-entry";
 
 		[TranslationReference]
-		const string ArchiveExtractionFailed = "archive-extraction-failed";
+		const string ArchiveExtractionFailed = "label-archive-extraction-failed";
 
 		[TranslationReference]
-		const string MirrorSelectionFailed = "mirror-selection-failed";
+		const string MirrorSelectionFailed = "label-mirror-selection-failed";
 
 		static readonly string[] SizeSuffixes = { "bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" };
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromSourceLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromSourceLogic.cs
@@ -22,61 +22,61 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class InstallFromSourceLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string DetectingSources = "detecting-sources";
+		const string DetectingSources = "label-detecting-sources";
 
 		[TranslationReference]
-		const string CheckingSources = "checking-sources";
+		const string CheckingSources = "label-checking-sources";
 
 		[TranslationReference("title")]
-		const string SearchingSourceFor = "searching-source-for";
+		const string SearchingSourceFor = "label-searching-source-for";
 
 		[TranslationReference]
-		const string ContentPackageInstallation = "content-package-installation";
+		const string ContentPackageInstallation = "label-content-package-installation";
 
 		[TranslationReference]
-		const string GameSources = "game-sources";
+		const string GameSources = "label-game-sources";
 
 		[TranslationReference]
-		const string DigitalInstalls = "digital-installs";
+		const string DigitalInstalls = "label-digital-installs";
 
 		[TranslationReference]
-		const string GameContentNotFound = "game-content-not-found";
+		const string GameContentNotFound = "label-game-content-not-found";
 
 		[TranslationReference]
-		const string AlternativeContentSources = "alternative-content-sources";
+		const string AlternativeContentSources = "label-alternative-content-sources";
 
 		[TranslationReference]
-		const string InstallingContent = "installing-content";
+		const string InstallingContent = "label-installing-content";
 
 		[TranslationReference("filename")]
-		public const string CopyingFilename = "copying-filename";
+		public const string CopyingFilename = "label-copying-filename";
 
 		[TranslationReference("filename", "progress")]
-		public const string CopyingFilenameProgress = "copying-filename-progress";
+		public const string CopyingFilenameProgress = "label-copying-filename-progress";
 
 		[TranslationReference]
-		const string InstallationFailed = "installation-failed";
+		const string InstallationFailed = "label-installation-failed";
 
 		[TranslationReference]
-		const string CheckInstallLog = "check-install-log";
+		const string CheckInstallLog = "label-check-install-log";
 
 		[TranslationReference("filename")]
-		public const string Extracing = "extracting-filename";
+		public const string Extracing = "label-extracting-filename";
 
 		[TranslationReference("filename", "progress")]
-		public const string ExtracingProgress = "extracting-filename-progress";
+		public const string ExtracingProgress = "label-extracting-filename-progress";
 
 		[TranslationReference]
-		public const string Continue = "continue";
+		public const string Continue = "button-continue";
 
 		[TranslationReference]
-		const string Cancel = "cancel";
+		const string Cancel = "button-cancel";
 
 		[TranslationReference]
-		const string Retry = "retry";
+		const string Retry = "button-retry";
 
 		[TranslationReference]
-		const string Back = "back";
+		const string Back = "button-back";
 
 		// Hide percentage indicators for files smaller than 25 MB
 		public const int ShowPercentageThreshold = 26214400;

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class ModContentLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string ManualInstall = "manual-install";
+		const string ManualInstall = "button-manual-install";
 
 		readonly ModData modData;
 		readonly ModContent content;

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentPromptLogic.cs
@@ -21,10 +21,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class ModContentPromptLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string Continue = "continue";
+		const string Continue = "button-continue";
 
 		[TranslationReference]
-		const string Quit = "quit";
+		const string Quit = "button-quit";
 
 		readonly ModContent content;
 		bool requiredContentInstalled;

--- a/OpenRA.Mods.Common/Widgets/Logic/IntroductionPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/IntroductionPromptLogic.cs
@@ -22,10 +22,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		const int IntroductionVersion = 1;
 
 		[TranslationReference]
-		const string Classic = "classic";
+		const string Classic = "options-control-scheme.classic";
 
 		[TranslationReference]
-		const string Modern = "modern";
+		const string Modern = "options-control-scheme.modern";
 
 		readonly string classic;
 		readonly string modern;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickClientLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickClientLogic.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	class KickClientLogic : ChromeLogic
 	{
 		[TranslationReference("player")]
-		const string KickClient = "kick-client";
+		const string KickClient = "dialog-kick-client.prompt";
 
 		[ObjectCreator.UseCtor]
 		public KickClientLogic(ModData modData, Widget widget, string clientName, Action<bool> okPressed, Action cancelPressed)

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickSpectatorsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickSpectatorsLogic.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	class KickSpectatorsLogic : ChromeLogic
 	{
 		[TranslationReference("count")]
-		const string KickSpectators = "kick-spectators";
+		const string KickSpectators = "dialog-kick-spectators.prompt";
 
 		[ObjectCreator.UseCtor]
 		public KickSpectatorsLogic(ModData modData, Widget widget, int clientCount, Action okPressed, Action cancelPressed)

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -23,40 +23,40 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class LobbyLogic : ChromeLogic, INotificationHandler<TextNotification>
 	{
 		[TranslationReference]
-		const string Add = "add";
+		const string Add = "options-slot-admin.add-bots";
 
 		[TranslationReference]
-		const string Remove = "remove";
+		const string Remove = "options-slot-admin.remove-bots";
 
 		[TranslationReference]
-		const string ConfigureBots = "configure-bots";
+		const string ConfigureBots = "options-slot-admin.configure-bots";
 
 		[TranslationReference("count")]
-		const string NumberTeams = "n-teams";
+		const string NumberTeams = "options-slot-admin.teams-count";
 
 		[TranslationReference]
-		const string HumanVsBots = "humans-vs-bots";
+		const string HumanVsBots = "options-slot-admin.humans-vs-bots";
 
 		[TranslationReference]
-		const string FreeForAll = "free-for-all";
+		const string FreeForAll = "options-slot-admin.free-for-all";
 
 		[TranslationReference]
-		const string ConfigureTeams = "configure-teams";
+		const string ConfigureTeams = "options-slot-admin.configure-teams";
 
 		[TranslationReference]
-		const string Back = "back";
+		const string Back = "button-back";
 
 		[TranslationReference]
-		const string Team = "team";
+		const string TeamChat = "button-team-chat";
 
 		[TranslationReference]
-		const string All = "all";
+		const string GeneralChat = "button-general-chat";
 
 		[TranslationReference("seconds")]
-		const string ChatAvailability = "chat-availability";
+		const string ChatAvailability = "label-chat-availability";
 
 		[TranslationReference]
-		const string ChatDisabled = "chat-disabled";
+		const string ChatDisabled = "label-chat-disabled";
 
 		static readonly Action DoNothing = () => { };
 
@@ -454,8 +454,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var chatMode = lobby.Get<ButtonWidget>("CHAT_MODE");
-			var team = modData.Translation.GetString(Team);
-			var all = modData.Translation.GetString(All);
+			var team = modData.Translation.GetString(TeamChat);
+			var all = modData.Translation.GetString(GeneralChat);
 			chatMode.GetText = () => teamChat ? team : all;
 			chatMode.OnClick = () => teamChat ^= true;
 			chatMode.IsDisabled = () => disableTeamChat || !chatEnabled;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class LobbyOptionsLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string NotAvailable = "not-available";
+		const string NotAvailable = "label-not-available";
 
 		readonly ModData modData;
 		readonly ScrollPanelWidget panel;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -24,19 +24,19 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public static class LobbyUtils
 	{
 		[TranslationReference]
-		const string Open = "open";
+		const string Open = "options-lobby-slot.open";
 
 		[TranslationReference]
-		const string Closed = "closed";
+		const string Closed = "options-lobby-slot.closed";
 
 		[TranslationReference]
-		const string Bots = "bots";
+		const string Bots = "options-lobby-slot.bots";
 
 		[TranslationReference]
-		const string BotsDisabled = "bots-disabled";
+		const string BotsDisabled = "options-lobby-slot.bots-disabled";
 
 		[TranslationReference]
-		const string Slot = "slot";
+		const string Slot = "options-lobby-slot.slot";
 
 		class SlotDropDownOption
 		{

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
@@ -20,22 +20,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class MapPreviewLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string Connecting = "connecting";
+		const string Connecting = "label-connecting";
 
 		[TranslationReference("size")]
-		const string Downloading = "downloading-map";
+		const string Downloading = "label-downloading-map";
 
 		[TranslationReference("size", "progress")]
-		const string DownloadingPercentage = "downloading-map-progress";
+		const string DownloadingPercentage = "label-downloading-map-progress";
 
 		[TranslationReference]
-		const string RetryInstall = "retry-install";
+		const string RetryInstall = "button-retry-install";
 
 		[TranslationReference]
-		const string RetrySearch = "retry-search";
+		const string RetrySearch = "button-retry-search";
 
 		[TranslationReference("author")]
-		const string CreatedBy = "created-by";
+		const string CreatedBy = "label-created-by";
 
 		readonly int blinkTickLength = 10;
 		bool installHighlighted;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/SpawnSelectorTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/SpawnSelectorTooltipLogic.cs
@@ -18,13 +18,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class SpawnSelectorTooltipLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string DisabledSpawn = "disabled-spawn";
+		const string DisabledSpawn = "label-disabled-spawn";
 
 		[TranslationReference]
-		const string AvailableSpawn = "available-spawn";
+		const string AvailableSpawn = "label-available-spawn";
 
 		[TranslationReference("team")]
-		const string TeamNumber = "team-number";
+		const string TeamNumber = "label-team-name";
 
 		readonly CachedTransform<int, string> teamMessage;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -23,13 +23,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class MainMenuLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string LoadingNews = "loading-news";
+		const string LoadingNews = "label-loading-news";
 
 		[TranslationReference("message")]
-		const string NewsRetrivalFailed = "news-retrival-failed";
+		const string NewsRetrivalFailed = "label-news-retrival-failed";
 
 		[TranslationReference("message")]
-		const string NewsParsingFailed = "news-parsing-failed";
+		const string NewsParsingFailed = "label-news-parsing-failed";
 
 		protected enum MenuType { Main, Singleplayer, Extras, MapEditor, StartupPrompts, None }
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -19,55 +19,55 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class MapChooserLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string AllMaps = "all-maps";
+		const string AllMaps = "label-all-maps";
 
 		[TranslationReference]
-		const string NoMatches = "no-matches";
+		const string NoMatches = "label-no-matches";
 
 		[TranslationReference("players")]
-		const string Players = "player-players";
+		const string Players = "label-player-count";
 
 		[TranslationReference("author")]
-		const string CreatedBy = "created-by";
+		const string CreatedBy = "label-created-by";
 
 		[TranslationReference]
-		const string MapSizeHuge = "map-size-huge";
+		const string MapSizeHuge = "label-map-size-huge";
 
 		[TranslationReference]
-		const string MapSizeLarge = "map-size-large";
+		const string MapSizeLarge = "label-map-size-large";
 
 		[TranslationReference]
-		const string MapSizeMedium = "map-size-medium";
+		const string MapSizeMedium = "label-map-size-medium";
 
 		[TranslationReference]
-		const string MapSizeSmall = "map-size-small";
+		const string MapSizeSmall = "label-map-size-small";
 
 		[TranslationReference("map")]
-		const string MapDeletionFailed = "map-deletion-failed";
+		const string MapDeletionFailed = "notification-map-deletion-failed";
 
 		[TranslationReference]
-		const string DeleteMapTitle = "delete-map-title";
+		const string DeleteMapTitle = "dialog-delete-map.title";
 
 		[TranslationReference("title")]
-		const string DeleteMapPrompt = "delete-map-prompt";
+		const string DeleteMapPrompt = "dialog-delete-map.prompt";
 
 		[TranslationReference]
-		const string DeleteMapAccept = "delete-map-accept";
+		const string DeleteMapAccept = "dialog-delete-map.confirm";
 
 		[TranslationReference]
-		const string DeleteAllMapsTitle = "delete-all-maps-title";
+		const string DeleteAllMapsTitle = "dialog-delete-all-maps.title";
 
 		[TranslationReference]
-		const string DeleteAllMapsPrompt = "delete-all-maps-prompt";
+		const string DeleteAllMapsPrompt = "dialog-delete-all-maps.prompt";
 
 		[TranslationReference]
-		const string DeleteAllMapsAccept = "delete-all-maps-accept";
+		const string DeleteAllMapsAccept = "dialog-delete-all-maps.confirm";
 
 		[TranslationReference]
-		const string OrderMapsByPlayers = "order-maps-players";
+		const string OrderMapsByPlayers = "options-order-maps.player-count";
 
 		[TranslationReference]
-		const string OrderMapsByDate = "order-maps-date";
+		const string OrderMapsByDate = "options-order-maps.date";
 
 		readonly string allMaps;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -26,22 +26,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		enum PlayingVideo { None, Info, Briefing, GameStart }
 
 		[TranslationReference]
-		const string NoVideoTitle = "no-video-title";
+		const string NoVideoTitle = "dialog-no-video.title";
 
 		[TranslationReference]
-		const string NoVideoPrompt = "no-video-prompt";
+		const string NoVideoPrompt = "dialog-no-video.prompt";
 
 		[TranslationReference]
-		const string NoVideoCancel = "no-video-cancel";
+		const string NoVideoCancel = "dialog-no-video.cancel";
 
 		[TranslationReference]
-		const string CantPlayTitle = "cant-play-title";
+		const string CantPlayTitle = "dialog-cant-play-video.title";
 
 		[TranslationReference]
-		const string CantPlayPrompt = "cant-play-prompt";
+		const string CantPlayPrompt = "dialog-cant-play-video.prompt";
 
 		[TranslationReference]
-		const string CantPlayCancel = "cant-play-cancel";
+		const string CantPlayCancel = "dialog-cant-play-video.cancel";
 
 		readonly ModData modData;
 		readonly Action onStart;

--- a/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
@@ -19,10 +19,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class MusicPlayerLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string SoundMuted = "sound-muted";
+		const string SoundMuted = "label-sound-muted";
 
 		[TranslationReference]
-		const string NoSongPlaying = "no-song-playing";
+		const string NoSongPlaying = "label-no-song-playing";
 
 		readonly ScrollPanelWidget musicList;
 		readonly ScrollItemWidget itemTemplate;

--- a/OpenRA.Mods.Common/Widgets/Logic/MuteHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MuteHotkeyLogic.cs
@@ -19,10 +19,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class MuteHotkeyLogic : SingleHotkeyBaseLogic
 	{
 		[TranslationReference]
-		const string AudioMuted = "audio-muted";
+		const string AudioMuted = "label-audio-muted";
 
 		[TranslationReference]
-		const string AudioUnmuted = "audio-unmuted";
+		const string AudioUnmuted = "label-audio-unmuted";
 
 		readonly ModData modData;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
@@ -132,10 +132,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class RegisteredProfileTooltipLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string LoadingPlayerProfile = "loading-player-profile";
+		const string LoadingPlayerProfile = "label-loading-player-profile";
 
 		[TranslationReference]
-		const string LoadingPlayerProfileFailed = "loading-player-profile-failed";
+		const string LoadingPlayerProfileFailed = "label-loading-player-profile-failed";
 
 		readonly PlayerDatabase playerDatabase;
 		PlayerProfile profile;

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -26,82 +26,82 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class ReplayBrowserLogic : ChromeLogic
 	{
 		[TranslationReference("time")]
-		const string Duration = "duration";
+		const string Duration = "label-duration";
 
 		[TranslationReference]
-		const string Singleplayer = "singleplayer";
+		const string Singleplayer = "options-replay-type.singleplayer";
 
 		[TranslationReference]
-		const string Multiplayer = "multiplayer";
+		const string Multiplayer = "options-replay-type.multiplayer";
 
 		[TranslationReference]
-		const string Today = "today";
+		const string Today = "options-replay-date.today";
 
 		[TranslationReference]
-		const string LastWeek = "last-week";
+		const string LastWeek = "options-replay-date.last-week";
 
 		[TranslationReference]
-		const string LastFortnight = "last-fortnight";
+		const string LastFortnight = "options-replay-date.last-fortnight";
 
 		[TranslationReference]
-		const string LastMonth = "last-month";
+		const string LastMonth = "options-replay-date.last-month";
 
 		[TranslationReference]
-		const string ReplayDurationVeryShort = "replay-duration-very-short";
+		const string ReplayDurationVeryShort = "options-replay-duration.very-short";
 
 		[TranslationReference]
-		const string ReplayDurationShort = "replay-duration-short";
+		const string ReplayDurationShort = "options-replay-duration.short";
 
 		[TranslationReference]
-		const string ReplayDurationMedium = "replay-duration-medium";
+		const string ReplayDurationMedium = "options-replay-duration.medium";
 
 		[TranslationReference]
-		const string ReplayDurationLong = "replay-duration-long";
+		const string ReplayDurationLong = "options-replay-duration.long";
 
 		[TranslationReference]
-		const string RenameReplayTitle = "rename-replay-title";
+		const string RenameReplayTitle = "dialog-rename-replay.title";
 
 		[TranslationReference]
-		const string RenameReplayPrompt = "rename-replay-prompt";
+		const string RenameReplayPrompt = "dialog-rename-replay.prompt";
 
 		[TranslationReference]
-		const string RenameReplayAccept = "rename-replay-accept";
+		const string RenameReplayAccept = "dialog-rename-replay.confirm";
 
 		[TranslationReference]
-		const string DeleteReplayTitle = "delete-replay-title";
+		const string DeleteReplayTitle = "dialog-delete-replay.title";
 
 		[TranslationReference("replay")]
-		const string DeleteReplayPrompt = "delete-replay-prompt";
+		const string DeleteReplayPrompt = "dialog-delete-replay.prompt";
 
 		[TranslationReference]
-		const string DeleteReplayAccept = "delete-replay-accept";
+		const string DeleteReplayAccept = "dialog-delete-replay.confirm";
 
 		[TranslationReference]
-		const string DeleteAllReplaysTitle = "delete-all-replays-title";
+		const string DeleteAllReplaysTitle = "dialog-delete-all-replays.title";
 
 		[TranslationReference("count")]
-		const string DeleteAllReplaysPrompt = "delete-all-replays-prompt";
+		const string DeleteAllReplaysPrompt = "dialog-delete-all-replays.prompt";
 
 		[TranslationReference]
-		const string DeleteAllReplaysAccept = "delete-all-replays-accept";
+		const string DeleteAllReplaysAccept = "dialog-delete-all-replays.confirm";
 
 		[TranslationReference("file")]
-		const string ReplayDeletionFailed = "replay-deletion-failed";
+		const string ReplayDeletionFailed = "notification-replay-deletion-failed";
 
 		[TranslationReference]
-		const string Players = "players";
+		const string Players = "label-players";
 
 		[TranslationReference("team")]
-		const string TeamNumber = "team-number";
+		const string TeamNumber = "label-team-name";
 
 		[TranslationReference]
-		const string NoTeam = "no-team";
+		const string NoTeam = "label-no-team";
 
 		[TranslationReference]
-		const string Victory = "victory";
+		const string Victory = "options-winstate.victory";
 
 		[TranslationReference]
-		const string Defeat = "defeat";
+		const string Defeat = "options-winstate.defeat";
 
 		static Filter filter = new Filter();
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
@@ -18,28 +18,28 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public static class ReplayUtils
 	{
 		[TranslationReference]
-		const string IncompatibleReplayTitle = "incompatible-replay-title";
+		const string IncompatibleReplayTitle = "dialog-incompatible-replay.title";
 
 		[TranslationReference]
-		const string IncompatibleReplayPrompt = "incompatible-replay-prompt";
+		const string IncompatibleReplayPrompt = "dialog-incompatible-replay.prompt";
 
 		[TranslationReference]
-		const string IncompatibleReplayAccept = "incompatible-replay-accept";
+		const string IncompatibleReplayAccept = "dialog-incompatible-replay.confirm";
 
 		[TranslationReference]
-		const string UnknownVersion = "incompatible-replay-unknown-version";
+		const string UnknownVersion = "dialog-incompatible-replay.prompt-unknown-version";
 
 		[TranslationReference]
-		const string UnknownMod = "incompatible-replay-unknown-mod";
+		const string UnknownMod = "dialog-incompatible-replay.prompt-unknown-mod";
 
 		[TranslationReference("mod")]
-		const string UnvailableMod = "incompatible-replay-unavailable-mod";
+		const string UnvailableMod = "dialog-incompatible-replay.prompt-unavailable-mod";
 
 		[TranslationReference("version")]
-		const string IncompatibleVersion = "incompatible-replay-incompatible-version";
+		const string IncompatibleVersion = "dialog-incompatible-replay.prompt-incompatible-version";
 
 		[TranslationReference("map")]
-		const string UnvailableMap = "incompatible-replay-unavailable-map";
+		const string UnvailableMap = "dialog-incompatible-replay.prompt-unavailable-map";
 
 		static readonly Action DoNothing = () => { };
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -20,37 +20,37 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class ServerCreationLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string InternetServerNatA = "internet-server-nat-A";
+		const string InternetServerNatA = "label-internet-server-nat-A";
 
 		[TranslationReference]
-		const string InternetServerNatBenabled = "internet-server-nat-B-enabled";
+		const string InternetServerNatBenabled = "label-internet-server-nat-B-enabled";
 
 		[TranslationReference]
-		const string InternetServerNatBnotSupported = "internet-server-nat-B-not-supported";
+		const string InternetServerNatBnotSupported = "label-internet-server-nat-B-not-supported";
 
 		[TranslationReference]
-		const string InternetServerNatBdisabled = "internet-server-nat-B-disabled";
+		const string InternetServerNatBdisabled = "label-internet-server-nat-B-disabled";
 
 		[TranslationReference]
-		const string InternetServerNatC = "internet-server-nat-C";
+		const string InternetServerNatC = "label-internet-server-nat-C";
 
 		[TranslationReference]
-		const string LocalServer = "local-server";
+		const string LocalServer = "label-local-server";
 
 		[TranslationReference("port")]
-		const string ServerCreationFailedPrompt = "server-creation-failed-prompt";
+		const string ServerCreationFailedPrompt = "dialog-server-creation-failed.prompt";
 
 		[TranslationReference]
-		const string ServerCreationFailedPortUsed = "server-creation-failed-port-used";
+		const string ServerCreationFailedPortUsed = "dialog-server-creation-failed.prompt-port-used";
 
 		[TranslationReference("message", "code")]
-		const string ServerCreationFailedError = "server-creation-failed-error";
+		const string ServerCreationFailedError = "dialog-server-creation-failed.prompt-error";
 
 		[TranslationReference]
-		const string ServerCreationFailedTitle = "server-creation-failed-title";
+		const string ServerCreationFailedTitle = "dialog-server-creation-failed.title";
 
 		[TranslationReference]
-		const string ServerCreationFailedCancel = "server-creation-failed-cancel";
+		const string ServerCreationFailedCancel = "dialog-server-creation-failed.cancel";
 
 		readonly Widget panel;
 		readonly ModData modData;

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -26,67 +26,67 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class ServerListLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string SearchStatusFailed = "search-status-failed";
+		const string SearchStatusFailed = "label-search-status-failed";
 
 		[TranslationReference]
-		const string SearchStatusNoGames = "search-status-no-games";
+		const string SearchStatusNoGames = "label-search-status-no-games";
 
 		[TranslationReference("players")]
-		const string PlayersOnline = "players-online";
+		const string PlayersOnline = "label-players-online-count";
 
 		[TranslationReference]
-		const string NoServerSelected = "no-server-selected";
+		const string NoServerSelected = "label-no-server-selected";
 
 		[TranslationReference]
-		const string MapStatusSearching = "map-status-searching";
+		const string MapStatusSearching = "label-map-status-searching";
 
 		[TranslationReference]
-		const string MapClassificationUnknown = "map-classification-unknown";
+		const string MapClassificationUnknown = "label-map-classification-unknown";
 
 		[TranslationReference("players")]
-		const string PlayersLabel = "players-label";
+		const string PlayersLabel = "label-players-count";
 
 		[TranslationReference("bots")]
-		const string BotsLabel = "bots-label";
+		const string BotsLabel = "label-bots-count";
 
 		[TranslationReference("spectators")]
-		const string SpectatorsLabel = "spectators-label";
+		const string SpectatorsLabel = "label-spectators-count";
 
 		[TranslationReference]
-		const string Players = "players";
+		const string Players = "label-players";
 
 		[TranslationReference("team")]
-		const string TeamNumber = "team-number";
+		const string TeamNumber = "label-team-name";
 
 		[TranslationReference]
-		const string NoTeam = "no-team";
+		const string NoTeam = "label-no-team";
 
 		[TranslationReference]
-		const string Spectators = "spectators";
+		const string Spectators = "label-spectators";
 
 		[TranslationReference("players")]
-		const string OtherPlayers = "n-other-players";
+		const string OtherPlayers = "label-other-players-count";
 
 		[TranslationReference]
-		const string Playing = "playing";
+		const string Playing = "label-playing";
 
 		[TranslationReference]
-		const string Waiting = "waiting";
+		const string Waiting = "label-waiting";
 
 		[TranslationReference("minutes")]
-		const string InProgress = "in-progress-for";
+		const string InProgress = "label-in-progress-for";
 
 		[TranslationReference]
-		const string PasswordProtected = "password-protected";
+		const string PasswordProtected = "label-password-protected";
 
 		[TranslationReference]
-		const string WaitingForPlayers = "waiting-for-players";
+		const string WaitingForPlayers = "label-waiting-for-players";
 
 		[TranslationReference]
-		const string ServerShuttingDown = "server-shutting-down";
+		const string ServerShuttingDown = "label-server-shutting-down";
 
 		[TranslationReference]
-		const string UnknownServerState = "unknown-server-state";
+		const string UnknownServerState = "label-unknown-server-state";
 
 		readonly string noServerSelected;
 		readonly string mapStatusSearching;

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -23,46 +23,46 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class DisplaySettingsLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string Close = "close";
+		const string Close = "options-camera.close";
 
 		[TranslationReference]
-		const string Medium = "medium";
+		const string Medium = "options-camera.medium";
 
 		[TranslationReference]
-		const string Far = "far";
+		const string Far = "options-camera.far";
 
 		[TranslationReference]
-		const string Furthest = "furthest";
+		const string Furthest = "options-camera.furthest";
 
 		[TranslationReference]
-		const string Windowed = "windowed";
+		const string Windowed = "options-display-mode.windowed";
 
 		[TranslationReference]
-		const string LegacyFullscreen = "legacy-fullscreen";
+		const string LegacyFullscreen = "options-display-mode.legacy-fullscreen";
 
 		[TranslationReference]
-		const string Fullscreen = "fullscreen";
+		const string Fullscreen = "options-display-mode.fullscreen";
 
 		[TranslationReference("number")]
-		const string Display = "display";
+		const string Display = "label-video-display-index";
 
 		[TranslationReference]
-		const string Standard = "standard";
+		const string Standard = "options-status-bars.standard";
 
 		[TranslationReference]
-		const string ShowOnDamage = "show-on-damage";
+		const string ShowOnDamage = "options-status-bars.show-on-damage";
 
 		[TranslationReference]
-		const string AlwaysShow = "always-show";
+		const string AlwaysShow = "options-status-bars.always-show";
 
 		[TranslationReference]
-		const string Automatic = "automatic";
+		const string Automatic = "options-target-lines.automatic";
 
 		[TranslationReference]
-		const string Manual = "manual";
+		const string Manual = "options-target-lines.manual";
 
 		[TranslationReference]
-		const string Disabled = "disabled";
+		const string Disabled = "options-target-lines.disabled";
 
 		static readonly int OriginalVideoDisplay;
 		static readonly WindowMode OriginalGraphicsMode;

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/InputSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/InputSettingsLogic.cs
@@ -18,37 +18,37 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class InputSettingsLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string Classic = "classic";
+		const string Classic = "options-control-scheme.classic";
 
 		[TranslationReference]
-		const string Modern = "modern";
+		const string Modern = "options-control-scheme.modern";
 
 		[TranslationReference]
-		const string Disabled = "disabled";
+		const string Disabled = "options-mouse-scroll-type.disabled";
 
 		[TranslationReference]
-		const string Standard = "standard";
+		const string Standard = "options-mouse-scroll-type.standard";
 
 		[TranslationReference]
-		const string Inverted = "inverted";
+		const string Inverted = "options-mouse-scroll-type.inverted";
 
 		[TranslationReference]
-		const string Joystick = "joystick";
+		const string Joystick = "options-mouse-scroll-type.joystick";
 
 		[TranslationReference]
-		const string Alt = "alt";
+		const string Alt = "options-zoom-modifier.alt";
 
 		[TranslationReference]
-		const string Ctrl = "ctrl";
+		const string Ctrl = "options-zoom-modifier.ctrl";
 
 		[TranslationReference]
-		const string Meta = "meta";
+		const string Meta = "options-zoom-modifier.meta";
 
 		[TranslationReference]
-		const string Shift = "shift";
+		const string Shift = "options-zoom-modifier.shift";
 
 		[TranslationReference]
-		const string None = "none";
+		const string None = "options-zoom-modifier.none";
 
 		static InputSettingsLogic() { }
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
@@ -20,37 +20,37 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class SettingsLogic : ChromeLogic
 	{
 		[TranslationReference]
-		const string SettingsSaveTitle = "settings-save-title";
+		const string SettingsSaveTitle = "dialog-settings-save.title";
 
 		[TranslationReference]
-		const string SettingsSavePrompt = "settings-save-prompt";
+		const string SettingsSavePrompt = "dialog-settings-save.prompt";
 
 		[TranslationReference]
-		const string SettingsSaveCancel = "settings-save-cancel";
+		const string SettingsSaveCancel = "dialog-settings-save.cancel";
 
 		[TranslationReference]
-		const string RestartTitle = "restart-title";
+		const string RestartTitle = "dialog-settings-restart.title";
 
 		[TranslationReference]
-		const string RestartPrompt = "restart-prompt";
+		const string RestartPrompt = "dialog-settings-restart.prompt";
 
 		[TranslationReference]
-		const string RestartAccept = "restart-accept";
+		const string RestartAccept = "dialog-settings-restart.confirm";
 
 		[TranslationReference]
-		const string RestartCancel = "restart-cancel";
+		const string RestartCancel = "dialog-settings-restart.cancel";
 
 		[TranslationReference("panel")]
-		const string ResetTitle = "reset-title";
+		const string ResetTitle = "dialog-settings-reset.title";
 
 		[TranslationReference]
-		const string ResetPrompt = "reset-prompt";
+		const string ResetPrompt = "dialog-settings-reset.prompt";
 
 		[TranslationReference]
-		const string ResetAccept = "reset-accept";
+		const string ResetAccept = "dialog-settings-reset.confirm";
 
 		[TranslationReference]
-		const string ResetCancel = "reset-cancel";
+		const string ResetCancel = "dialog-settings-reset.cancel";
 
 		readonly Dictionary<string, Func<bool>> leavePanelActions = new Dictionary<string, Func<bool>>();
 		readonly Dictionary<string, Action> resetPanelActions = new Dictionary<string, Action>();

--- a/mods/cnc/languages/rules/en.ftl
+++ b/mods/cnc/languages/rules/en.ftl
@@ -1,22 +1,24 @@
 ## Player
-low = Low
-medium = Medium
-no-powers = No Powers
-unrestricted = Unrestricted
+options-tech-level =
+    .low = Low
+    .medium = Medium
+    .no-powers = No Powers
+    .unrestricted = Unrestricted
 
-redeployable-mcvs =
+checkbox-redeployable-mcvs =
     .label = Redeployable MCVs
     .description = Allow undeploying Construction Yard
 
-stealth-deliveries =
+checkbox-stealth-deliveries =
     .label = Stealth Deliveries
     .description = Nod's delivery plane is cloaked
 
 ## World
-mcv-only = MCV Only
-light-support = Light Support
-heavy-support = Heavy Support
+options-starting-units =
+    .mcv-only = MCV Only
+    .light-support = Light Support
+    .heavy-support = Heavy Support
 
-map-creeps =
+dropdown-map-creeps =
     .label = Creep Actors
     .description = Hostile forces spawn on the battlefield

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -255,27 +255,27 @@ GameSpeeds:
 	DefaultSpeed: default
 	Speeds:
 		slowest:
-			Name: slowest
+			Name: options-game-speed.slowest
 			Timestep: 80
 			OrderLatency: 2
 		slower:
-			Name: slower
+			Name: options-game-speed.slower
 			Timestep: 50
 			OrderLatency: 3
 		default:
-			Name: normal
+			Name: options-game-speed.normal
 			Timestep: 40
 			OrderLatency: 3
 		fast:
-			Name: fast
+			Name: options-game-speed.fast
 			Timestep: 35
 			OrderLatency: 4
 		faster:
-			Name: faster
+			Name: options-game-speed.faster
 			Timestep: 30
 			OrderLatency: 4
 		fastest:
-			Name: fastest
+			Name: options-game-speed.fastest
 			Timestep: 20
 			OrderLatency: 6
 

--- a/mods/cnc/rules/player.yaml
+++ b/mods/cnc/rules/player.yaml
@@ -42,15 +42,15 @@ Player:
 		FogCheckboxDisplayOrder: 3
 	LobbyPrerequisiteCheckbox@GLOBALFACTUNDEPLOY:
 		ID: factundeploy
-		Label: redeployable-mcvs.label
-		Description: redeployable-mcvs.description
+		Label: checkbox-redeployable-mcvs.label
+		Description: checkbox-redeployable-mcvs.description
 		Enabled: True
 		DisplayOrder: 7
 		Prerequisites: global-factundeploy
 	LobbyPrerequisiteCheckbox@GLOBALC17STEALTH:
 		ID: C17-Stealth
-		Label: stealth-deliveries.label
-		Description: stealth-deliveries.description
+		Label: checkbox-stealth-deliveries.label
+		Description: checkbox-stealth-deliveries.description
 		Enabled: False
 		DisplayOrder: 8
 		Prerequisites: global-C17-stealth
@@ -58,19 +58,19 @@ Player:
 	FrozenActorLayer:
 	PlaceBeacon:
 	ProvidesTechPrerequisite@low:
-		Name: low
+		Name: options-tech-level.low
 		Prerequisites: techlevel.low
 		Id: low
 	ProvidesTechPrerequisite@medium:
-		Name: medium
+		Name: options-tech-level.medium
 		Prerequisites: techlevel.low, techlevel.medium
 		Id: medium
 	ProvidesTechPrerequisite@nosuper:
-		Name: no-powers
+		Name: options-tech-level.no-powers
 		Prerequisites: techlevel.low, techlevel.medium, techlevel.high
 		Id: nopowers
 	ProvidesTechPrerequisite@all:
-		Name: unrestricted
+		Name: options-tech-level.unrestricted
 		Prerequisites: techlevel.low, techlevel.medium, techlevel.high, techlevel.superweapons
 		Id: unrestricted
 	GrantConditionOnPrerequisiteManager:

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -208,42 +208,42 @@ World:
 	CreateMapPlayers:
 	StartingUnits@mcvonly:
 		Class: none
-		ClassName: mcv-only
+		ClassName: options-starting-units.mcv-only
 		Factions: gdi, nod
 		BaseActor: mcv
 	StartingUnits@defaultgdia:
 		Class: light
-		ClassName: light-support
+		ClassName: options-starting-units.light-support
 		Factions: gdi
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e1,e1,e3,e3,jeep
 	StartingUnits@defaultnoda:
 		Class: light
-		ClassName: light-support
+		ClassName: options-starting-units.light-support
 		Factions: nod
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e1,e1,e1,e3,e3,bggy
 	StartingUnits@heavynoda:
 		Class: heavy
-		ClassName: heavy-support
+		ClassName: options-starting-units.heavy-support
 		Factions: nod
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e1,e3,e3,ltnk,ltnk,ftnk
 	StartingUnits@heavynodb:
 		Class: heavy
-		ClassName: heavy-support
+		ClassName: options-starting-units.heavy-support
 		Factions: nod
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e1,e1,e3,e3,e3,ftnk,ftnk
 	StartingUnits@heavygdia:
 		Class: heavy
-		ClassName: heavy-support
+		ClassName: options-starting-units.heavy-support
 		Factions: gdi
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e1,e3,e3,jeep,mtnk,mtnk
 	StartingUnits@heavygdib:
 		Class: heavy
-		ClassName: heavy-support
+		ClassName: options-starting-units.heavy-support
 		Factions: gdi
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e1,e1,e2,e2,e2,e3,e3,apc,mtnk

--- a/mods/common/languages/en.ftl
+++ b/mods/common/languages/en.ftl
@@ -1,565 +1,587 @@
-## MapOptions, MissionBrowserLogic
-slowest = Slowest
-slower = Slower
-normal = Normal
-fast = Fast
-faster = Faster
-fastest = Fastest
+## Buttons
+button-cancel = Cancel
+button-retry = Retry
+button-back = Back
+button-continue = Continue
+button-quit = Quit
 
 ## Server Orders
-custom-rules = This map contains custom rules. Game experience may change.
-map-bots-disabled = Bots have been disabled on this map.
-two-humans-required = This server requires at least two human players to start a match.
-unknown-server-command = Unknown server command: { $command }
-only-only-host-start-game = Only the host can start the game.
-no-start-until-required-slots-full = Unable to start the game until required slots are full.
-no-start-without-players = Unable to start the game with no players.
-insufficient-enabled-spawnPoints = Unable to start the game until more spawn points are enabled.
-malformed-command = Malformed { $command } command
-state-unchanged-ready = Cannot change state when marked as ready.
-invalid-faction-selected = Invalid faction selected: { $faction }
-supported-factions = Supported values: { $factions }
-state-unchanged-game-started = Cannot change state when game started. ({ $command })
-requires-host = Only the host can do that.
-invalid-bot-slot = Can't add bots to a slot with another client.
-invalid-bot-type = Invalid bot type.
-only-host-change-map = Only the host can change the map.
-lobby-disconnected = { $player } has left.
-player-disconnected = { $player } has disconnected.
-player-team-disconnected = { $player } (Team { $team }) has disconnected.
-observer-disconnected = { $player } (Spectator) has disconnected.
-unknown-map = Map was not found on server.
-searching-map = Searching for map on the Resource Center...
-only-host-change-configuration = Only the host can change the configuration.
-changed-map = { $player } changed the map to { $map }
-value-changed = { $player } changed { $name } to { $value }.
-you-were-kicked = You have been kicked from the server.
-kicked = { $admin } kicked { $player } from the server.
-temp-ban = { $admin } temporarily banned { $player } from the server.
-only-host-transfer-admin = Only admins can transfer admin to another player.
-only-host-move-spectators = Only the host can move players to spectators.
-empty-slot = No-one in that slot.
-move-spectators = { $admin } moved { $player } to spectators.
-nick = { $player } is now known as { $name }.
-player-dropped = A player has been dropped after timing out.
-connection-problems = { $player } is experiencing connection problems.
-timeout = { $player } has been dropped after timing out.
-timeout-in =
+notification-custom-rules = This map contains custom rules. Game experience may change.
+notification-map-bots-disabled = Bots have been disabled on this map.
+notification-two-humans-required = This server requires at least two human players to start a match.
+notification-unknown-server-command = Unknown server command: { $command }
+notification-admin-start-game = Only the host can start the game.
+notification-no-start-until-required-slots-full = Unable to start the game until required slots are full.
+notification-no-start-without-players = Unable to start the game with no players.
+notification-insufficient-enabled-spawn-points = Unable to start the game until more spawn points are enabled.
+notification-malformed-command = Malformed { $command } command
+notification-state-unchanged-ready = Cannot change state when marked as ready.
+notification-invalid-faction-selected = Invalid faction selected: { $faction }
+notification-supported-factions = Supported values: { $factions }
+notification-state-unchanged-game-started = Cannot change state when game started. ({ $command })
+notification-requires-host = Only the host can do that.
+notification-invalid-bot-slot = Can't add bots to a slot with another client.
+notification-invalid-bot-type = Invalid bot type.
+notification-admin-change-map = Only the host can change the map.
+notification-lobby-disconnected = { $player } has left.
+notification-player-disconnected = { $player } has disconnected.
+notification-team-player-disconnected = { $player } (Team { $team }) has disconnected.
+notification-observer-disconnected = { $player } (Spectator) has disconnected.
+notification-unknown-map = Map was not found on server.
+notification-searching-map = Searching for map on the Resource Center...
+notification-admin-change-configuration = Only the host can change the configuration.
+notification-changed-map = { $player } changed the map to { $map }
+notification-option-changed = { $player } changed { $name } to { $value }.
+notification-you-were-kicked = You have been kicked from the server.
+notification-kicked = { $admin } kicked { $player } from the server.
+notification-temp-ban = { $admin } temporarily banned { $player } from the server.
+notification-admin-transfer-admin = Only admins can transfer admin to another player.
+notification-admin-move-spectators = Only the host can move players to spectators.
+notification-empty-slot = No-one in that slot.
+notification-move-spectators = { $admin } moved { $player } to spectators.
+notification-nick-changed = { $player } is now known as { $name }.
+notification-player-dropped = A player has been dropped after timing out.
+notification-connection-problems = { $player } is experiencing connection problems.
+notification-timeout-dropped = { $player } has been dropped after timing out.
+notification-timeout-dropped-in =
     { $timeout ->
         [one] { $player } will be dropped in { $timeout } second.
        *[other] { $player } will be dropped in { $timeout } seconds.
     }
-error-game-started = The game has already started.
-requires-password = Server requires a password.
-incorrect-password = Incorrect password.
-incompatible-mod = Server is running an incompatible mod.
-incompatible-version = Server is running an incompatible version.
-incompatible-protocol = Server is running an incompatible protocol.
-banned = You have been banned from the server.
-temp-banned = You have been temporarily banned from the server.
-full = The game is full.
-joined = { $player } has joined the game.
-new-admin = { $player } is now the admin.
-option-locked = { $option } cannot be changed.
-invalid-configuration-command = Invalid configuration command.
-admin-option = Only the host can set that option.
-number-teams = Number of teams could not be parsed: { $raw }
-admin-kick = Only the host can kick players.
-kick-none = No-one in that slot.
-no-kick-game-started = Only spectators can be kicked after the game has started.
-admin-clear-spawn = Only admins can clear spawn points.
-spawn-occupied = You cannot occupy the same spawn point as another player.
-spawn-locked = The spawn point is locked to another player slot.
-admin-lobby-info = Only the host can set lobby info.
-invalid-lobby-info = Invalid lobby info sent.
-player-color-terrain = Color was adjusted to be less similar to the terrain.
-player-color-player = Color was adjusted to be less similar to another player.
-invalid-player-color = Unable to determine a valid player color. A random color has been selected.
-invalid-error-code = Failed to parse error message.
-master-server-connected = Master server communication established.
-master-server-error = "Master server communication failed."
-game-offline = Game has not been advertised online.
-no-port-forward = Server port is not accessible from the internet.
-blacklisted-title = Server name contains a blacklisted word.
-requires-forum-account = Server requires players to have an OpenRA forum account.
-no-permission = You do not have permission to join this server.
-slot-closed = Your slot was closed by the host.
+notification-error-game-started = The game has already started.
+notification-requires-password = Server requires a password.
+notification-incorrect-password = Incorrect password.
+notification-incompatible-mod = Server is running an incompatible mod.
+notification-incompatible-version = Server is running an incompatible version.
+notification-incompatible-protocol = Server is running an incompatible protocol.
+notification-you-were-banned = You have been banned from the server.
+notification-you-were-temp-banned = You have been temporarily banned from the server.
+notification-game-full = The game is full.
+notification-joined = { $player } has joined the game.
+notification-new-admin = { $player } is now the admin.
+notification-option-locked = { $option } cannot be changed.
+notification-invalid-configuration-command = Invalid configuration command.
+notification-admin-option = Only the host can set that option.
+notification-error-number-teams = Number of teams could not be parsed: { $raw }
+notification-admin-kick = Only the host can kick players.
+notification-kick-none = No-one in that slot.
+notification-no-kick-game-started = Only spectators can be kicked after the game has started.
+notification-admin-clear-spawn = Only admins can clear spawn points.
+notification-spawn-occupied = You cannot occupy the same spawn point as another player.
+notification-spawn-locked = The spawn point is locked to another player slot.
+notification-admin-lobby-info = Only the host can set lobby info.
+notification-invalid-lobby-info = Invalid lobby info sent.
+notification-player-color-terrain = Color was adjusted to be less similar to the terrain.
+notification-player-color-player = Color was adjusted to be less similar to another player.
+notification-invalid-player-color = Unable to determine a valid player color. A random color has been selected.
+notification-invalid-error-code = Failed to parse error message.
+notification-master-server-connected = Master server communication established.
+notification-master-server-error = "Master server communication failed."
+notification-game-offline = Game has not been advertised online.
+notification-no-port-forward = Server port is not accessible from the internet.
+notification-blacklisted-server-name = Server name contains a blacklisted word.
+notification-requires-authentication = Server requires players to have an OpenRA forum account.
+notification-no-permission-to-join = You do not have permission to join this server.
+notification-slot-closed = Your slot was closed by the host.
 
 ## Server
-game-started = Game started
+notification-game-started = Game started
 
 ## PlayerMessageTracker
-chat-temp-disabled =
+notification-chat-temp-disabled =
     { $remaining ->
         [one] Chat is disabled. Please try again in { $remaining } second.
        *[other] Chat is disabled. Please try again in { $remaining } seconds.
     }
 
 ## ActorEditLogic
-duplicate-actor-id = Duplicate Actor ID
-enter-actor-id = Enter an Actor ID
-owner = Owner
+label-duplicate-actor-id = Duplicate Actor ID
+label-actor-id = Enter an Actor ID
+label-actor-owner = Owner
 
 ## ActorSelectorLogic
-type = Type
+label-actor-type = Type: { $actorType }
 
 ## CommonSelectorLogic
-search-results = Search Results
-multiple = Multiple
+options-common-selector =
+    .search-results = Search Results
+    .all = All
+    .multiple = Multiple
+    .none = None
 
 ## SaveMapLogic
-unpacked = unpacked
+label-unpacked-map = unpacked
 
-save-map-failed-title = Failed to save map
-save-map-failed-prompt = See debug.log for details.
-save-map-failed-accept = OK
+dialog-save-map-failed =
+    .title = Failed to save map
+    .prompt = See debug.log for details.
+    .confirm = OK
 
-overwrite-map-failed-title = Warning
-overwrite-map-failed-prompt = By saving you will overwrite
+dialog-overwrite-map-failed =
+    .title = Warning
+    .prompt = By saving you will overwrite
     an already existing map.
-overwrite-map-failed-confirm = Save
+    .confirm = Save
 
-overwrite-map-outside-edit-title = Warning
-overwrite-map-outside-edit-prompt = "The map has been edited from outside the editor.
+dialog-overwrite-map-outside-edit =
+    .title = Warning
+    .prompt = The map has been edited from outside the editor.
     By saving you may overwrite progress
-overwrite-map-outside-edit-confirm = Save
+    .confirm = Save
 
 ## GameInfoLogic
-objectives = Objectives
-briefing = Briefing
-options = Options
-debug = Debug
-chat = Chat
+menu-game-info =
+    .objectives = Objectives
+    .briefing = Briefing
+    .options = Options
+    .debug = Debug
+    .chat = Chat
 
 ## GameInfoObjectivesLogic, GameInfoStatsLogic
-in-progress = In progress
-accomplished = Accomplished
-failed = Failed
+label-mission-in-progress = In progress
+label-mission-accomplished = Accomplished
+label-mission-failed = Failed
 
 ## GameInfoStatsLogic
-mute = Mute this player
-unmute = Unmute this player
+label-client-state-disconnected = Gone
+label-mute-player = Mute this player
+label-unmute-player = Unmute this player
 
-## GameInfoStatsLogic
-gone = Gone
-
-kick-title = Kick { $player }?
-kick-prompt = They will not be able to rejoin this game.
-kick-accept = Kick
+dialog-kick =
+    .title = Kick { $player }?
+    .prompt = They will not be able to rejoin this game.
+    .confirm = Kick
 
 ## GameTimerLogic
-paused = Paused
-max-speed = Max Speed
-speed = { $percentage }% Speed
-complete = { $percentage }% complete
+label-paused = Paused
+label-max-speed = Max Speed
+label-replay-speed = { $percentage }% Speed
+label-replay-complete = { $percentage }% complete
 
 ## LobbyLogic, InGameChatLogic
-chat-disabled = Chat Disabled
-chat-availability =
+label-chat-disabled = Chat Disabled
+label-chat-availability =
     { $seconds ->
         [one] Chat available in { $seconds } second...
-        *[other] Chat available in { $seconds } seconds...
+       *[other] Chat available in { $seconds } seconds...
     }
 
 ## IngameMenuLogic
-leave = Leave
-abort-mission = Abort Mission
+menu-ingame =
+    .leave = Leave
+    .abort = Abort Mission
+    .restart = Restart
+    .surrender = Surrender
+    .load-game = Load Game
+    .save-game = Save Game
+    .music = Music
+    .settings = Settings
+    .return-to-map = Return to map
+    .resume = Resume
+    .save-map = Save Map
+    .exit-map = Exit Map Editor
 
-leave-mission-title = Leave Mission
-leave-mission-prompt = Leave this game and return to the menu?
-leave-mission-accept = Leave
-leave-mission-cancel = Stay
+dialog-leave-mission =
+    .title = Leave Mission
+    .prompt = Leave this game and return to the menu?
+    .confirm = Leave
+    .cancel = Stay
 
-restart-button = Restart
+dialog-restart-mission =
+    .title = Restart
+    .prompt = Are you sure you want to restart?
+    .confirm = Restart
+    .cancel = Stay
 
-restart-mission-title = Restart
-restart-mission-prompt = Are you sure you want to restart?
-restart-mission-accept = Restart
-restart-mission-cancel = Stay
+dialog-surrender =
+    .title = Surrender
+    .prompt = Are you sure you want to surrender?
+    .confirm = Surrender
+    .cancel = Stay
 
-surrender-button = Surrender
+dialog-error-max-player =
+    .title = Error: Max player count exceeded
+    .prompt = There are too many players defined ({ $players }/{ $max }).
+    .confirm = Back
 
-surrender-title = Surrender
-surrender-prompt = Are you sure you want to surrender?
-surrender-accept = Surrender
-surrender-cancel = Stay
-
-load-game-button = Load Game
-save-game-button = Save Game
-
-music-button = Music
-
-settings-button = Settings
-
-return-to-map = Return to map
-resume = Resume
-
-save-map-button = Save Map
-
-error-max-player-title = Error: Max player count exceeded
-error-max-player-prompt = There are too many players defined ({ $players }/{ $max }).
-error-max-player-accept = Back
-
-exit-map-button = Exit Map Editor
-
-exit-map-editor-title = Exit Map Editor
-exit-map-editor-prompt-unsaved = Exit and lose all unsaved changes?
-exit-map-editor-prompt-deleted = The map may have been deleted outside the editor.
-exit-map-editor-confirm-anyway = Exit anyway
-exit-map-editor-confirm = Exit
+dialog-exit-map-editor =
+    .title = Exit Map Editor
+    .prompt-unsaved = Exit and lose all unsaved changes?
+    .prompt-deleted = The map may have been deleted outside the editor.
+    .confirm-anyway = Exit anyway
+    .confirm = Exit
 
 ## IngamePowerBarLogic
 ## IngamePowerCounterLogic
-power-usage = Power Usage: { $usage }/{ $capacity }
-infinite-power = Infinite
+label-power-usage = Power Usage: { $usage }/{ $capacity }
+label-infinite-power = Infinite
 
 ## IngameSiloBarLogic
 ## IngameCashCounterLogic
-silo-usage = Silo Usage: { $usage }/{ $capacity }
+label-silo-usage = Silo Usage: { $usage }/{ $capacity }
 
 ## ObserverShroudSelectorLogic
-camera-option-all-players = All Players
-camera-option-disable-shroud = Disable Shroud
-camera-option-other = Other
+options-shroud-selector =
+    .all-players = All Players
+    .disable-shroud = Disable Shroud
+    .other = Other
 
 ## ObserverStatsLogic
-information-none = Information: None
-basic = Basic
-economy = Economy
-production = Production
-support-powers = Support Powers
-combat = Combat
-army = Army
-earnings-graph = Earnings (graph)
-army-graph = Army (graph)
+options-observer-stats =
+    .none = Information: None
+    .basic = Basic
+    .economy = Economy
+    .production = Production
+    .support-powers = Support Powers
+    .combat = Combat
+    .army = Army
+    .earnings-graph = Earnings (graph)
+    .army-graph = Army (graph)
 
 ## WorldTooltipLogic
-unrevealed-terrain = Unrevealed Terrain
+label-unrevealed-terrain = Unrevealed Terrain
 
 ## DownloadPackageLogic
-downloading = Downloading { $title }
-fetching-mirror-list = Fetching list of mirrors...
-downloading-from = Downloading from { $host } { $received } { $suffix }
-downloading-from-progress = Downloading from { $host } { $received } / { $total } { $suffix } ({ $progress }%)
-unknown-host = unknown host
-verifying-archive = Verifying archive...
-archive-validation-failed = Archive validation failed
-extracting = Extracting...
-extracting-entry = Extracting { $entry }
-archive-extraction-failed = Archive extraction failed
-mirror-selection-failed = Online mirror is not available. Please install from an original source.
+label-downloading = Downloading { $title }
+label-fetching-mirror-list = Fetching list of mirrors...
+label-downloading-from = Downloading from { $host } { $received } { $suffix }
+label-downloading-from-progress = Downloading from { $host } { $received } / { $total } { $suffix } ({ $progress }%)
+label-unknown-host = unknown host
+label-verifying-archive = Verifying archive...
+label-archive-validation-failed = Archive validation failed
+label-extracting-archive = Extracting...
+label-extracting-archive-entry = Extracting { $entry }
+label-archive-extraction-failed = Archive extraction failed
+label-mirror-selection-failed = Online mirror is not available. Please install from an original disc.
 
 ## InstallFromSourceLogic
-detecting-sources = Detecting drives
-checking-sources = Checking Sources
-searching-source-for = Searching for { $title }
-content-package-installation = The following content packages will be installed:
-game-sources = Game Sources
-digital-installs = Digital Installs
-game-content-not-found = Game Content Not Found
-alternative-content-sources = Please insert or install one of the following content sources:
-installing-content = Installing Content
-copying-filename = Copying { $filename }
-copying-filename-progress = Copying { $filename } ({ $progress }%)
-installation-failed = Installation Failed
-check-install-log = Refer to install.log in the logs directory for details.
-extracting-filename = Extracting { $filename }
-extracting-filename-progress = Extracting { $filename } ({ $progress }%)
-cancel = Cancel
-retry = Retry
-
-## InstallFromSourceLogic, LobbyLogic
-back = Back
-
-# InstallFromSourceLogic, ModContentPromptLogic
-continue = Continue
+label-detecting-sources = Detecting drives
+label-checking-sources = Checking Sources
+label-searching-source-for = Searching for { $title }
+label-content-package-installation = The following content packages will be installed:
+label-game-sources = Game Sources
+label-digital-installs = Digital Installs
+label-game-content-not-found = Game Content Not Found
+label-alternative-content-sources = Please insert or install one of the following content sources:
+label-installing-content = Installing Content
+label-copying-filename = Copying { $filename }
+label-copying-filename-progress = Copying { $filename } ({ $progress }%)
+label-installation-failed = Installation Failed
+label-check-install-log = Refer to install.log in the logs directory for details.
+label-extracting-filename = Extracting { $filename }
+label-extracting-filename-progress = Extracting { $filename } ({ $progress }%)
 
 ## ModContentLogic
-manual-install = Manual Install
-
-## ModContentPromptLogic
-quit = Quit
+button-manual-install = Manual Install
 
 ## KickClientLogic
-kick-client = Kick { $player }?
+dialog-kick-client =
+    .prompt = Kick { $player }?
 
 ## KickSpectatorsLogic
-kick-spectators =
+dialog-kick-spectators =
+    .prompt =
     { $count ->
         [one] Are you sure you want to kick one spectator?
        *[other] Are you sure you want to kick { $count } spectators?
     }
 
 ## LobbyLogic
-add = Add
-remove = Remove
-configure-bots = Configure Bots
-n-teams = { $count } Teams
-humans-vs-bots = Humans vs Bots
-free-for-all = Free for all
-configure-teams = Configure Teams
+options-slot-admin =
+    .add-bots = Add
+    .remove-bots = Remove
+    .configure-bots = Configure Bots
+    .teams-count = { $count } Teams
+    .humans-vs-bots = Humans vs Bots
+    .free-for-all = Free for all
+    .configure-teams = Configure Teams
 
-## LobbyLogic, CommonSelectorLogic, InGameChatLogic
-all = All
-
-## InputSettingsLogic, CommonSelectorLogic
-none = None
-
-## LobbyLogic, IngameChatLogic
-team = Team
+## LobbyLogic, InGameChatLogic
+button-general-chat = All
+button-team-chat = Team
 
 ## LobbyOptionsLogic
-not-available = Not Available
+label-not-available = Not Available
 
 ## LobbyUtils
-slot = Slot
-open = Open
-closed = Closed
-bots = Bots
-
-# LobbyUtils, Server
-bots-disabled = Bots Disabled
+options-lobby-slot =
+    .slot = Slot
+    .open = Open
+    .closed = Closed
+    .bots = Bots
+    .bots-disabled = Bots Disabled
 
 ## MapPreviewLogic
-connecting = Connecting...
-downloading-map = Downloading { $size } kB
-downloading-map-progress = Downloading { $size } kB ({ $progress }%)
-retry-install = Retry Install
-retry-search = Retry Search
+label-connecting = Connecting...
+label-downloading-map = Downloading { $size } kB
+label-downloading-map-progress = Downloading { $size } kB ({ $progress }%)
+button-retry-install = Retry Install
+button-retry-search = Retry Search
 ## also MapChooserLogic
-created-by = Created by { $author }
+label-created-by = Created by { $author }
 
 ## SpawnSelectorTooltipLogic
-disabled-spawn = Disabled spawn
-available-spawn = Available spawn
+label-disabled-spawn = Disabled spawn
+label-available-spawn = Available spawn
 
 ## DisplaySettingsLogic
-close = Close
-medium = Medium
-far = Far
-furthest = Furthest
+options-camera =
+    .close = Close
+    .medium = Medium
+    .far = Far
+    .furthest = Furthest
 
-windowed = Windowed
-legacy-fullscreen = Fullscreen (Legacy)
-fullscreen = Fullscreen
+options-display-mode =
+    .windowed = Windowed
+    .legacy-fullscreen = Fullscreen (Legacy)
+    .fullscreen = Fullscreen
 
-display = Display { $number }
+label-video-display-index = Display { $number }
 
-show-on-damage = Show On Damage
-always-show = Always Show
+options-status-bars =
+    .standard = Standard
+    .show-on-damage = Show On Damage
+    .always-show = Always Show
 
-automatic = Automatic
-manual = Manual
+options-target-lines =
+    .automatic = Automatic
+    .manual = Manual
+    .disabled = Disabled
 
-## DisplaySettingsLogic, InputSettingsLogic
-disabled = Disabled
+## InputSettingsLogic
+options-mouse-scroll-type =
+    .disabled = Disabled
+    .standard = Standard
+    .inverted = Inverted
+    .joystick = Joystick
 
-## DisplaySettingsLogic, InputSettingsLogic, IntroductionPromptLogic
-classic = Classic
-modern = Modern
-standard = Standard
+## InputSettingsLogic, IntroductionPromptLogic
+options-control-scheme =
+    .classic = Classic
+    .modern = Modern
 
-## DisplaySettingsLogic, IntroductionPromptLogic
-inverted = Inverted
-joystick = Joystick
-
-alt = Alt
-ctrl = Ctrl
-meta = Meta
-shift = Shift
+options-zoom-modifier =
+    .alt = Alt
+    .ctrl = Ctrl
+    .meta = Meta
+    .shift = Shift
+    .none = None
 
 ## SettingsLogic
-settings-save-title = Restart Required
-settings-save-prompt = Some changes will not be applied until
+dialog-settings-save =
+    .title = Restart Required
+    .prompt = Some changes will not be applied until
     the game is restarted.
-settings-save-cancel = Continue
+    .cancel = Continue
 
-restart-title = Restart Now?
-restart-prompt = Some changes will not be applied until
+dialog-settings-restart =
+    .title = Restart Now?
+    .prompt = Some changes will not be applied until
     the game is restarted. Restart now?
-restart-accept = Restart Now
-restart-cancel = Restart Later
+    .confirm = Restart Now
+    .cancel = Restart Later
 
-reset-title = Reset { $panel }
-reset-prompt = Are you sure you want to reset
+dialog-settings-reset =
+    .title = Reset { $panel }
+    .prompt = Are you sure you want to reset
     all settings in this panel?
-reset-accept = Reset
-reset-cancel = Cancel
+    .confirm = Reset
+    .cancel = Cancel
 
 ## AssetBrowserLogic
-all-packages = All Packages
-length-in-seconds = { $length } sec
+label-all-packages = All Packages
+label-length-in-seconds = { $length } sec
 
 ## ConnectionLogic
-connecting-to-endpoint = Connecting to { $endpoint }...
-could-not-connect-to-target = Could not connect to { $target }
-unknown-error = Unknown error
-password-required = Password Required
-connection-failed = Connection Failed
-mod-switch-failed = Failed to switch mod.
+label-connecting-to-endpoint = Connecting to { $endpoint }...
+label-could-not-connect-to-target = Could not connect to { $target }
+label-unknown-error = Unknown error
+label-password-required = Password Required
+label-connection-failed = Connection Failed
+notification-mod-switch-failed = Failed to switch mod.
 
 ## GameSaveBrowserLogic
-rename-save-title = Rename Save
-rename-save-prompt = Enter a new file name:
-rename-save-accept = Rename
+dialog-rename-save =
+    .title = Rename Save
+    .prompt = Enter a new file name:
+    .confirm = Rename
 
-delete-save-title = Delete selected game save?
-delete-save-prompt = Delete '{ $save }'
-delete-save-accept = Delete
+dialog-delete-save =
+    .title = Delete selected game save?
+    .prompt = Delete '{ $save }'
+    .confirm = Delete
 
-delete-all-saves-title = Delete all game saves?
-delete-all-saves-prompt =
+dialog-delete-all-saves =
+    .title = Delete all game saves?
+    .prompt =
     { $count ->
         [one] Delete { $count } save.
        *[other] Delete { $count } saves.
     }
-delete-all-saves-accept = Delete All
+    .confirm = Delete All
 
-save-deletion-failed = Failed to delete save file '{ $savePath }'. See the logs for details.
+notification-save-deletion-failed = Failed to delete save file '{ $savePath }'. See the logs for details.
 
-overwrite-save-title = Overwrite saved game?
-overwrite-save-prompt = Overwrite { $file }?
-overwrite-save-accept = Overwrite
+dialog-overwrite-save =
+    .title = Overwrite saved game?
+    .prompt = Overwrite { $file }?
+    .confirm = Overwrite
 
 ## MainMenuLogic
-loading-news = Loading news
-news-retrival-failed = Failed to retrieve news: { $message }
-news-parsing-failed = Failed to parse news: { $message }
+label-loading-news = Loading news
+label-news-retrival-failed = Failed to retrieve news: { $message }
+label-news-parsing-failed = Failed to parse news: { $message }
 
 ## MapChooserLogic
-all-maps = All Maps
-no-matches = No matches
-player-players =
+label-all-maps = All Maps
+label-no-matches = No matches
+label-player-count =
     { $players ->
         [one] { $players } Player
        *[other] { $players } Players
     }
-map-size-huge = (Huge)
-map-size-large = (Large)
-map-size-medium = (Medium)
-map-size-small = (Small)
+label-map-size-huge = (Huge)
+label-map-size-large = (Large)
+label-map-size-medium = (Medium)
+label-map-size-small = (Small)
 
-map-deletion-failed = Failed to delete map '{ $map }'. See the debug.log file for details.
+notification-map-deletion-failed = Failed to delete map '{ $map }'. See the debug.log file for details.
 
-delete-map-title = Delete map
-delete-map-prompt = Delete the map '{ $title }'?
-delete-map-accept = Delete
+dialog-delete-map =
+    .title = Delete map
+    .prompt = Delete the map '{ $title }'?
+    .confirm = Delete
 
-delete-all-maps-title = Delete maps
-delete-all-maps-prompt = Delete all maps on this page?
-delete-all-maps-accept = Delete
+dialog-delete-all-maps =
+    .title = Delete maps
+    .prompt = Delete all maps on this page?
+    .confirm = Delete
 
-order-maps-players = Players
-order-maps-date = Map Date
+options-order-maps =
+    .player-count = Players
+    .date = Map Date
 
 ## MissionBrowserLogic
-no-video-title = Video not installed
-no-video-prompt = The game videos can be installed from the
+dialog-no-video =
+    .title = Video not installed
+    .prompt = The game videos can be installed from the
     "Manage Content" menu in the mod chooser.
-no-video-cancel = Back
+    .cancel = Back
 
-cant-play-title = Unable to play video
-cant-play-prompt = Something went wrong during video playback.
-cant-play-cancel = Back
+dialog-cant-play-video =
+    .title = Unable to play video
+    .prompt = Something went wrong during video playback.
+    .cancel = Back
 
 ## MusicPlayerLogic
-sound-muted = Audio has been muted in settings.
-no-song-playing = No song playing
+label-sound-muted = Audio has been muted in settings.
+label-no-song-playing = No song playing
 
 ## MuteHotkeyLogic
-audio-muted = Audio muted.
-audio-unmuted = Audio unmuted.
+label-audio-muted = Audio muted.
+label-audio-unmuted = Audio unmuted.
 
 ## PlayerProfileLogic
-loading-player-profile = Loading player profile...
-loading-player-profile-failed = Failed to load player profile.
+label-loading-player-profile = Loading player profile...
+label-loading-player-profile-failed = Failed to load player profile.
 
 ## ReplayBrowserLogic
-duration = Duration: { $time }
-singleplayer = Singleplayer
-multiplayer = Multiplayer
+label-duration = Duration: { $time }
 
-victory = Victory
-defeat = Defeat
+options-replay-type =
+    .singleplayer = Singleplayer
+    .multiplayer = Multiplayer
 
-today = Today
-last-week = Last 7 days
-last-fortnight = Last 14 days
-last-month = Last 30 days
+options-winstate =
+    .victory = Victory
+    .defeat = Defeat
 
-replay-duration-very-short = Under 5 min
-replay-duration-short = Short (10 min)
-replay-duration-medium = Medium (30 min)
-replay-duration-long = Long (60+ min)
+options-replay-date =
+    .today = Today
+    .last-week = Last 7 days
+    .last-fortnight = Last 14 days
+    .last-month = Last 30 days
 
-rename-replay-title = Rename Replay
-rename-replay-prompt = Enter a new file name:
-rename-replay-accept = Rename
+options-replay-duration =
+    .very-short = Under 5 min
+    .short = Short (10 min)
+    .medium = Medium (30 min)
+    .long = Long (60+ min)
 
-delete-replay-title = Delete selected replay?
-delete-replay-prompt = Delete replay { $replay }?
-delete-replay-accept = Delete
+dialog-rename-replay =
+    .title = Rename Replay
+    .prompt = Enter a new file name:
+    .confirm = Rename
 
-delete-all-replays-title = Delete all selected replays?
-delete-all-replays-prompt =
+dialog-delete-replay =
+    .title = Delete selected replay?
+    .prompt = Delete replay { $replay }?
+    .confirm = Delete
+
+dialog-delete-all-replays =
+    .title = Delete all selected replays?
+    .prompt =
     { $count ->
         [one] Delete { $count } replay.
        *[other] Delete { $count } replays.
     }
-delete-all-replays-accept = Delete All
+    .confirm = Delete All
 
-replay-deletion-failed = Failed to delete replay file '{ $file }'. See the debug.log file for details.
+notification-replay-deletion-failed = Failed to delete replay file '{ $file }'. See the debug.log file for details.
 
 ## ReplayUtils
-incompatible-replay-title = Incompatible Replay
-incompatible-replay-prompt = Replay metadata could not be read.
-incompatible-replay-accept = OK
 -incompatible-replay-recorded = It was recorded with
-incompatible-replay-unknown-version = { -incompatible-replay-recorded } an unknown version.
-incompatible-replay-unknown-mod = { -incompatible-replay-recorded } an unknown mod.
-incompatible-replay-unavailable-mod = { -incompatible-replay-recorded } an unavailable mod: { $mod }.
-incompatible-replay-incompatible-version = { -incompatible-replay-recorded } an incompatible version:
+
+dialog-incompatible-replay =
+    .title = Incompatible Replay
+    .prompt = Replay metadata could not be read.
+    .confirm = OK
+    .prompt-unknown-version = { -incompatible-replay-recorded } an unknown version.
+    .prompt-unknown-mod = { -incompatible-replay-recorded } an unknown mod.
+    .prompt-unavailable-mod = { -incompatible-replay-recorded } an unavailable mod: { $mod }.
+    .prompt-incompatible-version = { -incompatible-replay-recorded } an incompatible version:
     { $version }.
-incompatible-replay-unavailable-map = { -incompatible-replay-recorded } an unavailable map:
+    .prompt-unavailable-map = { -incompatible-replay-recorded } an unavailable map:
     { $map }.
 
 ## ServerCreationLogic
-internet-server-nat-A = Internet Server (UPnP/NAT-PMP
-internet-server-nat-B-enabled = Enabled
-internet-server-nat-B-not-supported = Not Supported
-internet-server-nat-B-disabled = Disabled
-internet-server-nat-C = ):
+label-internet-server-nat-A = Internet Server (UPnP/NAT-PMP
+label-internet-server-nat-B-enabled = Enabled
+label-internet-server-nat-B-not-supported = Not Supported
+label-internet-server-nat-B-disabled = Disabled
+label-internet-server-nat-C = ):
 
-local-server = Local Server:
+label-local-server = Local Server:
 
-server-creation-failed-prompt = Could not listen on port { $port }
-server-creation-failed-port-used = Check if the port is already being used.
-server-creation-failed-error = Error is: "{ $message }" ({ $code })
-server-creation-failed-title = Server Creation Failed
-server-creation-failed-cancel = Back
+dialog-server-creation-failed =
+    .prompt = Could not listen on port { $port }
+    .prompt-port-used = Check if the port is already being used.
+    .prompt-error = Error is: "{ $message }" ({ $code })
+    .title = Server Creation Failed
+    .cancel = Back
 
 ## ServerListLogic
-players-online =
+label-players-online-count =
     { $players ->
         [one] { $players } Player Online
        *[other] { $players } Players Online
     }
 
-search-status-failed = Failed to query server list.
-search-status-no-games = No games found. Try changing filters.
-no-server-selected = No Server Selected
+label-search-status-failed = Failed to query server list.
+label-search-status-no-games = No games found. Try changing filters.
+label-no-server-selected = No Server Selected
 
-map-status-searching = Searching...
-map-classification-unknown = Unknown Map
+label-map-status-searching = Searching...
+label-map-classification-unknown = Unknown Map
 
-players-label =
+label-players-count =
     { $players ->
         [0] No Players
         [one] One Player
        *[other] { $players } Players
     }
 
-bots-label =
+label-bots-count =
     { $bots ->
         [0] No Bots
         [one] One Bot
@@ -567,11 +589,11 @@ bots-label =
     }
 
 ## ServerListLogic, ReplayBrowserLogic, ObserverShroudSelectorLogic
-players = Players
+label-players = Players
 
 ## ServerListLogic, GameInfoStatsLogic
-spectators = Spectators
-spectators-label =
+label-spectators = Spectators
+label-spectators-count =
     { $spectators ->
         [0] No Spectators
         [one] One Spectator
@@ -579,152 +601,163 @@ spectators-label =
     }
 
 ## ServerlistLogic, GameInfoStatsLogic, ObserverShroudSelectorLogic, SpawnSelectorTooltipLogic, ReplayBrowserLogic
-team-number = Team { $team }
-no-team = No Team
+label-team-name = Team { $team }
+label-no-team = No Team
 
-playing = Playing
-waiting = Waiting
+label-playing = Playing
+label-waiting = Waiting
 
-n-other-players =
+label-other-players-count =
     { $players ->
         [one] One other player
        *[other] { $players } other players
     }
 
-in-progress-for =
+label-in-progress-for =
     { $minutes ->
-        [0] In progress
+        [0] In progress for less than a minute.
         [one] In progress for { $minutes } minute.
        *[other] In progress for { $minutes } minutes.
     }
-password-protected = Password protected
-waiting-for-players = Waiting for players
-server-shutting-down = Server shutting down
-unknown-server-state = Unknown server state
+
+label-password-protected = Password protected
+label-waiting-for-players = Waiting for players
+label-server-shutting-down = Server shutting down
+label-unknown-server-state = Unknown server state
 
 ## Game
-saved-screenshot = Saved screenshot { $filename }
+notification-saved-screenshot = Saved screenshot { $filename }
 
 ## ChatCommands
-invalid-command = { $name } is not a valid command.
+notification-invalid-command = { $name } is not a valid command.
 
 ## DebugVisualizationCommands
-combat-geometry-description = toggles combat geometry overlay.
-render-geometry-description = toggles render geometry overlay.
-screen-map-overlay-description = toggles screen map overlay.
-depth-buffer-description = toggles depth buffer overlay.
-actor-tags-overlay-description = toggles actor tags overlay.
+description-combat-geometry = toggles combat geometry overlay.
+description-render-geometry = toggles render geometry overlay.
+description-screen-map-overlay = toggles screen map overlay.
+description-depth-buffer = toggles depth buffer overlay.
+description-actor-tags-overlay = toggles actor tags overlay.
 
 ## DevCommands
-cheats-disabled = Cheats are disabled.
-invalid-cash-amount = Invalid amount of cash.
-toggle-visibility = toggles visibility checks and minimap.
-give-cash = gives the default or specified amount of money.
-give-cash-all = gives the default or specified amount of money to all players and ai.
-instant-building = toggles instant building.
-build-anywhere = toggles the ability to build anywhere.
-unlimited-power = toggles infinite power.
-enable-tech = toggles the ability to build everything.
-fast-charge = toggles almost instant support power charging.
-dev-cheat-all = toggles all cheats and gives you some cash for your trouble.
-dev-crash = crashes the game.
-levelup-actor = adds a specified number of levels to the selected actors.
-player-experience = adds a specified amount of player experience to the owner(s) of selected actors.
-power-outage = causes owner(s) of selected actors to have a 5 second power outage.
-kill-selected-actors = kills selected actors.
-dispose-selected-actors = disposes selected actors.
+notification-cheats-disabled = Cheats are disabled.
+notification-invalid-cash-amount = Invalid amount of cash.
+description-toggle-visibility = toggles visibility checks and minimap.
+description-give-cash = gives the default or specified amount of money.
+description-give-cash-all = gives the default or specified amount of money to all players and ai.
+description-instant-building = toggles instant building.
+description-build-anywhere = toggles the ability to build anywhere.
+description-unlimited-power = toggles infinite power.
+description-enable-tech = toggles the ability to build everything.
+description-fast-charge = toggles almost instant support power charging.
+description-dev-cheat-all = toggles all cheats and gives you some cash for your trouble.
+description-dev-crash = crashes the game.
+description-levelup-actor = adds a specified number of levels to the selected actors.
+description-player-experience = adds a specified amount of player experience to the owner(s) of selected actors.
+description-power-outage = causes owner(s) of selected actors to have a 5 second power outage.
+description-kill-selected-actors = kills selected actors.
+description-dispose-selected-actors = disposes selected actors.
 
 ## HelpCommands
-available-commands = Here are the available commands:
-no-description = no description available.
-help-description = provides useful info about various commands
+notification-available-commands = Here are the available commands:
+description-no-description = no description available.
+description-help-description = provides useful info about various commands
 
 ## PlayerCommands
-pause-description = pause or unpause the game
-surrender-description = self-destruct everything and lose the game
+description-pause-description = pause or unpause the game
+description-surrender-description = self-destruct everything and lose the game
 
 ## DeveloperMode
-cheat-used = Cheat used: { $cheat } by { $player }{ $suffix }
+notification-cheat-used = Cheat used: { $cheat } by { $player }{ $suffix }
 
 ## CustomTerrainDebugOverlay
-custom-terrain-debug-overlay-description = toggles the custom terrain debug overlay.
+description-custom-terrain-debug-overlay = toggles the custom terrain debug overlay.
 
 ## CellTriggerOverlay
-cell-trigger-overlay-description = toggles the script triggers overlay.
+description-cell-triggers-overlay = toggles the script triggers overlay.
 
 ## ExitsDebugOverlay
-exits-debug-overlay-description = Displays exits for factories.
+description-exits-overlay = Displays exits for factories.
 
 ## HierarchicalPathFinderOverlay
-hpf-overlay-description = toggles the hierarchical pathfinder overlay.
+description-hpf-debug-overlay = toggles the hierarchical pathfinder overlay.
 
 ## PathFinderOverlay
-path-debug-description = toggles a visualization of path searching.
+description-path-debug-overlay = toggles a visualization of path searching.
 
 ## TerrainGeometryOverlay
-terrain-geometry-overlay = toggles the terrain geometry overlay.
+description-terrain-geometry-overlay = toggles the terrain geometry overlay.
 
 ## Shroud
-fog-of-war =
+checkbox-fog-of-war =
     .label = Fog of War
     .description = Line of sight is required to view enemy forces
 
-explored-map =
+checkbox-explored-map =
     .label = Explored Map
     .description = Initial map shroud is revealed
 
 ## DeveloperMode
-debug-menu =
+checkbox-debug-menu =
     .label = Debug Menu
     .description = Enables cheats and developer commands
 
 ## CrateSpawner
-crates =
+checkbox-crates =
     .label = Crates
     .description = Collect crates with units to receive random bonuses or penalties
 
 ## MapBuildRadius
-ally-build-radius =
+checkbox-ally-build-radius =
     .label = Build off Allies
     .description = Allow allies to place structures inside your build area
 
-build-radius =
+checkbox-build-radius =
     .label = Limit Build Area
     .description = Limits structure placement to areas around Construction Yards
 
 ## MapOptions
-short-game =
+checkbox-short-game =
     .label = Short Game
     .description = Players are defeated when their bases are destroyed
 
-tech-level =
+dropdown-tech-level =
     .label = Tech Level
     .description = The units and abilities that players can use
 
-game-speed =
+## MapOptions, MissionBrowserLogic
+dropdown-game-speed =
     .label = Game Speed
     .description = The rate at which time passes
 
+options-game-speed =
+    .slowest = Slowest
+    .slower = Slower
+    .normal = Normal
+    .fast = Fast
+    .faster = Faster
+    .fastest = Fastest
+
 ## MapStartingLocations
-separate-team-spawns =
+checkbox-separate-team-spawns =
     .label = Separate Team Spawns
     .description = Players without assigned spawn points will start as far as possible from enemy players
 
 ## SpawnStartingUnits
-starting-units =
+dropdown-starting-units =
     .label = Starting Units
     .description = The units that players start the game with
 
 ## TimeLimitManager
-time-limit =
+dropdown-time-limit =
     .label = Time Limit
     .description = Player or team with the highest score after this time wins
 
-no-time-limit = No limit
-time-limit-options =
-    { $minutes ->
-        [one] { $minutes } minute
-       *[other] { $minutes } minutes
-    }
+options-time-limit =
+    .no-limit = No limit
+    .options =
+        { $minutes ->
+            [one] { $minutes } minute
+           *[other] { $minutes } minutes
+        }
 
-time-limit-expired = Time limit has expired.
+notification-time-limit-expired = Time limit has expired.

--- a/mods/d2k/languages/rules/en.ftl
+++ b/mods/d2k/languages/rules/en.ftl
@@ -1,18 +1,20 @@
 ## Player
-low = Low
-medium = Medium
-no-powers = No Powers
-unrestricted = Unrestricted
+options-tech-level =
+    .low = Low
+    .medium = Medium
+    .no-powers = No Powers
+    .unrestricted = Unrestricted
 
-automatic-concrete =
+checkbox-automatic-concrete =
     .label = Automatic Concrete
     .description = Concrete foundations are automatically created beneath buildings
 
 ## World
-map-worms =
+dropdown-map-worms =
     .label = Worms
     .description = Worms roam the map and devour unprepared forces
 
-mcv-only = MCV Only
-light-support = Light Support
-heavy-support = Heavy Support
+options-starting-units =
+    .mcv-only = MCV Only
+    .light-support = Light Support
+    .heavy-support = Heavy Support

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -231,27 +231,27 @@ GameSpeeds:
 	DefaultSpeed: default
 	Speeds:
 		slowest:
-			Name: slowest
+			Name: options-game-speed.slowest
 			Timestep: 80
 			OrderLatency: 2
 		slower:
-			Name: slower
+			Name: options-game-speed.slower
 			Timestep: 50
 			OrderLatency: 3
 		default:
-			Name: normal
+			Name: options-game-speed.normal
 			Timestep: 40
 			OrderLatency: 3
 		fast:
-			Name: fast
+			Name: options-game-speed.fast
 			Timestep: 35
 			OrderLatency: 4
 		faster:
-			Name: faster
+			Name: options-game-speed.faster
 			Timestep: 30
 			OrderLatency: 4
 		fastest:
-			Name: fastest
+			Name: options-game-speed.fastest
 			Timestep: 20
 			OrderLatency: 6
 

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -126,8 +126,8 @@ Player:
 		FogCheckboxDisplayOrder: 3
 	LobbyPrerequisiteCheckbox@AUTOCONCRETE:
 		ID: autoconcrete
-		Label: automatic-concrete.label
-		Description: automatic-concrete.description
+		Label: checkbox-automatic-concrete.label
+		Description: checkbox-automatic-concrete.description
 		Enabled: False
 		DisplayOrder: 7
 		Prerequisites: global-auto-concrete
@@ -158,19 +158,19 @@ Player:
 		Prerequisite: player.smuggler
 		Factions: smuggler
 	ProvidesTechPrerequisite@low:
-		Name: low
+		Name: options-tech-level.low
 		Prerequisites: techlevel.low
 		Id: low
 	ProvidesTechPrerequisite@medium:
-		Name: medium
+		Name: options-tech-level.medium
 		Prerequisites: techlevel.low, techlevel.medium
 		Id: medium
 	ProvidesTechPrerequisite@nosuper:
-		Name: no-powers
+		Name: options-tech-level.no-powers
 		Prerequisites: techlevel.low, techlevel.medium, techlevel.high
 		Id: nopowers
 	ProvidesTechPrerequisite@all:
-		Name: unrestricted
+		Name: options-tech-level.unrestricted
 		Prerequisites: techlevel.low, techlevel.medium, techlevel.high, techlevel.superweapons
 		Id: unrestricted
 	EnemyWatcher:

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -157,8 +157,8 @@ World:
 		Type: SandCrater
 		Sequence: sandcraters
 	MapCreeps:
-		CheckboxLabel: map-worms.label
-		CheckboxDescription: map-worms.description
+		CheckboxLabel: dropdown-map-worms.label
+		CheckboxDescription: dropdown-map-worms.description
 		CheckboxDisplayOrder: 5
 	SpawnMapActors:
 	MapBuildRadius:
@@ -173,12 +173,12 @@ World:
 		SeparateTeamSpawnsCheckboxDisplayOrder: 6
 	StartingUnits@mcv:
 		Class: none
-		ClassName: mcv-only
+		ClassName: options-starting-units.mcv-only
 		BaseActor: mcv
 		Factions: atreides, ordos, harkonnen
 	StartingUnits@lightatreides:
 		Class: light
-		ClassName: light-support
+		ClassName: options-starting-units.light-support
 		Factions: atreides
 		BaseActor: mcv
 		SupportActors: light_inf, light_inf, light_inf, trooper, grenadier, trike, quad
@@ -186,7 +186,7 @@ World:
 		OuterSupportRadius: 5
 	StartingUnits@lightharkonnen:
 		Class: light
-		ClassName: light-support
+		ClassName: options-starting-units.light-support
 		Factions: harkonnen
 		BaseActor: mcv
 		SupportActors: light_inf, light_inf, light_inf, trooper, trooper, trike, quad
@@ -194,7 +194,7 @@ World:
 		OuterSupportRadius: 5
 	StartingUnits@lightordos:
 		Class: light
-		ClassName: light-support
+		ClassName: options-starting-units.light-support
 		Factions: ordos
 		BaseActor: mcv
 		SupportActors: light_inf, light_inf, light_inf, trooper, engineer, raider, quad
@@ -202,7 +202,7 @@ World:
 		OuterSupportRadius: 5
 	StartingUnits@heavyatreides:
 		Class: heavy
-		ClassName: heavy-support
+		ClassName: options-starting-units.heavy-support
 		Factions: atreides
 		BaseActor: mcv
 		SupportActors: light_inf, light_inf, light_inf, trooper, grenadier, trike, combat_tank_a, missile_tank
@@ -210,7 +210,7 @@ World:
 		OuterSupportRadius: 5
 	StartingUnits@heavyharkonnen:
 		Class: heavy
-		ClassName: heavy-support
+		ClassName: options-starting-units.heavy-support
 		Factions: harkonnen
 		BaseActor: mcv
 		SupportActors: light_inf, light_inf, light_inf, trooper, engineer, quad, combat_tank_h, siege_tank
@@ -218,7 +218,7 @@ World:
 		OuterSupportRadius: 5
 	StartingUnits@heavyordos:
 		Class: heavy
-		ClassName: heavy-support
+		ClassName: options-starting-units.heavy-support
 		Factions: ordos
 		BaseActor: mcv
 		SupportActors: light_inf, light_inf, light_inf, trooper, engineer, raider, combat_tank_o, missile_tank

--- a/mods/ra/languages/rules/en.ftl
+++ b/mods/ra/languages/rules/en.ftl
@@ -1,23 +1,25 @@
 ## Player
-infantry-only = Infantry Only
-low = Low
-medium = Medium
-no-superweapons = No Superweapons
-unrestricted = Unrestricted
+options-tech-level =
+    .infantry-only = Infantry Only
+    .low = Low
+    .medium = Medium
+    .no-superweapons = No Superweapons
+    .unrestricted = Unrestricted
 
-kill-bounties =
+checkbox-kill-bounties =
     .label = Kill Bounties
     .description = Players receive cash bonuses when killing enemy units
 
-redeployable-mcvs =
+checkbox-redeployable-mcvs =
     .label = Redeployable MCVs
     .description = Allow undeploying Construction Yard
 
-reusable-engineers =
+checkbox-reusable-engineers =
     .label = Reusable Engineers
     .description = Engineers remain on the battlefield after capturing a structure
 
 ## World
-mcv-only = MCV Only
-light-support = Light Support
-heavy-support = Heavy Support
+options-starting-units =
+    .mcv-only = MCV Only
+    .light-support = Light Support
+    .heavy-support = Heavy Support

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -257,27 +257,27 @@ GameSpeeds:
 	DefaultSpeed: default
 	Speeds:
 		slowest:
-			Name: slowest
+			Name: options-game-speed.slowest
 			Timestep: 80
 			OrderLatency: 2
 		slower:
-			Name: slower
+			Name: options-game-speed.slower
 			Timestep: 50
 			OrderLatency: 3
 		default:
-			Name: normal
+			Name: options-game-speed.normal
 			Timestep: 40
 			OrderLatency: 3
 		fast:
-			Name: fast
+			Name: options-game-speed.fast
 			Timestep: 35
 			OrderLatency: 4
 		faster:
-			Name: faster
+			Name: options-game-speed.faster
 			Timestep: 30
 			OrderLatency: 4
 		fastest:
-			Name: fastest
+			Name: options-game-speed.fastest
 			Timestep: 20
 			OrderLatency: 6
 

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -125,22 +125,22 @@ Player:
 		FogCheckboxDisplayOrder: 3
 	LobbyPrerequisiteCheckbox@GLOBALBOUNTY:
 		ID: bounty
-		Label: kill-bounties.label
-		Description: kill-bounties.description
+		Label: checkbox-kill-bounties.label
+		Description: checkbox-kill-bounties.description
 		Enabled: False
 		DisplayOrder: 8
 		Prerequisites: global-bounty
 	LobbyPrerequisiteCheckbox@GLOBALFACTUNDEPLOY:
 		ID: factundeploy
-		Label: redeployable-mcvs.label
-		Description: redeployable-mcvs.description
+		Label: checkbox-redeployable-mcvs.label
+		Description: checkbox-redeployable-mcvs.description
 		Enabled: True
 		DisplayOrder: 7
 		Prerequisites: global-factundeploy
 	LobbyPrerequisiteCheckbox@REUSABLEENGINEERS:
 		ID: reusable-engineers
-		Label: reusable-engineers.label
-		Description: reusable-engineers.description
+		Label: checkbox-reusable-engineers.label
+		Description: checkbox-reusable-engineers.description
 		Enabled: False
 		DisplayOrder: 9
 		Prerequisites: global-reusable-engineers
@@ -151,23 +151,23 @@ Player:
 	PlayerStatistics:
 	PlaceBeacon:
 	ProvidesTechPrerequisite@infonly:
-		Name: infantry-only
+		Name: options-tech-level.infantry-only
 		Prerequisites: techlevel.infonly
 		Id: infantryonly
 	ProvidesTechPrerequisite@low:
-		Name: low
+		Name: options-tech-level.low
 		Prerequisites: techlevel.infonly, techlevel.low
 		Id: low
 	ProvidesTechPrerequisite@medium:
-		Name: medium
+		Name: options-tech-level.medium
 		Prerequisites: techlevel.infonly, techlevel.low, techlevel.medium
 		Id: medium
 	ProvidesTechPrerequisite@high:
-		Name: no-superweapons
+		Name: options-tech-level.no-superweapons
 		Prerequisites: techlevel.infonly, techlevel.low, techlevel.medium, techlevel.high
 		Id: nosuperweapons
 	ProvidesTechPrerequisite@unrestricted:
-		Name: unrestricted
+		Name: options-tech-level.unrestricted
 		Prerequisites: techlevel.infonly, techlevel.low, techlevel.medium, techlevel.high, techlevel.unrestricted
 		Id: unrestricted
 	GrantConditionOnPrerequisiteManager:

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -228,12 +228,12 @@ World:
 	CreateMapPlayers:
 	StartingUnits@mcvonly:
 		Class: none
-		ClassName: mcv-only
+		ClassName: options-starting-units.mcv-only
 		Factions: allies, england, france, germany, soviet, russia, ukraine
 		BaseActor: mcv
 	StartingUnits@lightallies:
 		Class: light
-		ClassName: light-support
+		ClassName: options-starting-units.light-support
 		Factions: allies, england, france, germany
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e3,e3,jeep,1tnk
@@ -241,7 +241,7 @@ World:
 		OuterSupportRadius: 5
 	StartingUnits@lightsoviet:
 		Class: light
-		ClassName: light-support
+		ClassName: options-starting-units.light-support
 		Factions: soviet, russia, ukraine
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e3,e3,apc,ftrk
@@ -249,7 +249,7 @@ World:
 		OuterSupportRadius: 5
 	StartingUnits@heavyallies:
 		Class: heavy
-		ClassName: heavy-support
+		ClassName: options-starting-units.heavy-support
 		Factions: allies, england, france, germany
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e3,e3,jeep,1tnk,2tnk,2tnk,2tnk
@@ -257,7 +257,7 @@ World:
 		OuterSupportRadius: 5
 	StartingUnits@heavysoviet:
 		Class: heavy
-		ClassName: heavy-support
+		ClassName: options-starting-units.heavy-support
 		Factions: soviet, russia, ukraine
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e3,e3,apc,ftrk,3tnk,3tnk

--- a/mods/ts/languages/rules/en.ftl
+++ b/mods/ts/languages/rules/en.ftl
@@ -1,18 +1,21 @@
 ## Player
-low = Low
-medium = Medium
-no-powers = No Powers
-unrestricted = Unrestricted
+options-tech-level =
+    .low = Low
+    .medium = Medium
+    .no-powers = No Powers
+    .unrestricted = Unrestricted
 
-redeployable-mcvs =
+checkbox-redeployable-mcvs =
     .label = Redeployable MCVs
     .description = Allow undeploying Construction Yard
 
 ## World
-mcv-only = MCV Only
-light = Light
-heavy = Heavy
+options-starting-units =
+    .mcv-only = MCV Only
+    .light = Light
+    .medium = Medium
+    .heavy = Heavy
 
-map-creeps =
+dropdown-map-creeps =
     .label = Creep Actors
     .description = Hostile forces spawn on the battlefield

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -289,27 +289,27 @@ GameSpeeds:
 	DefaultSpeed: default
 	Speeds:
 		slowest:
-			Name: slowest
+			Name: options-game-speed.slowest
 			Timestep: 80
 			OrderLatency: 2
 		slower:
-			Name: slower
+			Name: options-game-speed.slower
 			Timestep: 50
 			OrderLatency: 3
 		default:
-			Name: normal
+			Name: options-game-speed.normal
 			Timestep: 40
 			OrderLatency: 3
 		fast:
-			Name: fast
+			Name: options-game-speed.fast
 			Timestep: 35
 			OrderLatency: 4
 		faster:
-			Name: faster
+			Name: options-game-speed.faster
 			Timestep: 30
 			OrderLatency: 4
 		fastest:
-			Name: fastest
+			Name: options-game-speed.fastest
 			Timestep: 20
 			OrderLatency: 6
 

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -107,8 +107,8 @@ Player:
 		FogCheckboxDisplayOrder: 3
 	LobbyPrerequisiteCheckbox@GLOBALFACTUNDEPLOY:
 		ID: factundeploy
-		Label: redeployable-mcvs.label
-		Description: redeployable-mcvs.description
+		Label: checkbox-redeployable-mcvs.label
+		Description: checkbox-redeployable-mcvs.description
 		Enabled: True
 		DisplayOrder: 7
 		Prerequisites: global-factundeploy
@@ -127,19 +127,19 @@ Player:
 		ArrowSequence:
 		CircleSequence:
 	ProvidesTechPrerequisite@low:
-		Name: low
+		Name: options-tech-level.low
 		Prerequisites: techlevel.low
 		Id: low
 	ProvidesTechPrerequisite@medium:
-		Name: medium
+		Name: options-tech-level.medium
 		Prerequisites: techlevel.low, techlevel.medium
 		Id: medium
 	ProvidesTechPrerequisite@nosuper:
-		Name: no-powers
+		Name: options-tech-level.no-powers
 		Prerequisites: techlevel.low, techlevel.medium, techlevel.high
 		Id: nopowers
 	ProvidesTechPrerequisite@all:
-		Name: unrestricted
+		Name: options-tech-level.unrestricted
 		Prerequisites: techlevel.low, techlevel.medium, techlevel.high, techlevel.superweapons
 		Id: unrestricted
 	ResourceStorageWarning:

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -307,12 +307,12 @@ World:
 	CreateMapPlayers:
 	StartingUnits@MCV:
 		Class: none
-		ClassName: mcv-only
+		ClassName: options-starting-units.mcv-only
 		Factions: gdi, nod
 		BaseActor: mcv
 	StartingUnits@light.gdi:
 		Class: light
-		ClassName: light
+		ClassName: options-starting-units.light
 		Factions: gdi
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,smech
@@ -320,7 +320,7 @@ World:
 		OuterSupportRadius: 5
 	StartingUnits@light.nod:
 		Class: light
-		ClassName: light
+		ClassName: options-starting-units.light
 		Factions: nod
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,bggy
@@ -328,7 +328,7 @@ World:
 		OuterSupportRadius: 5
 	StartingUnits@med.gdi:
 		Class: medium
-		ClassName: medium
+		ClassName: options-starting-units.medium
 		Factions: gdi
 		BaseActor: mcv
 		SupportActors: e1,e1,e2,e2,jumpjet,smech
@@ -336,7 +336,7 @@ World:
 		OuterSupportRadius: 5
 	StartingUnits@med.nod:
 		Class: medium
-		ClassName: medium
+		ClassName: options-starting-units.medium
 		Factions: nod
 		BaseActor: mcv
 		SupportActors: e1,e1,e3,e3,cyborg,bggy
@@ -344,7 +344,7 @@ World:
 		OuterSupportRadius: 5
 	StartingUnits@heavy.gdi:
 		Class: heavy
-		ClassName: heavy
+		ClassName: options-starting-units.heavy
 		Factions: gdi
 		BaseActor: mcv
 		SupportActors: e1,e1,e2,e2,jumpjet,smech,smech,mmch
@@ -352,7 +352,7 @@ World:
 		OuterSupportRadius: 5
 	StartingUnits@heavy.nod:
 		Class: heavy
-		ClassName: heavy
+		ClassName: options-starting-units.heavy
 		Factions: nod
 		BaseActor: mcv
 		SupportActors: e1,e1,e3,e3,cyborg,bggy,bike,ttnk


### PR DESCRIPTION
The significant part here is the reorganization of the translation IDs in `en.ftl`. They are more descriptive to provide better context. Generally the template is _thing-id_ where "thing" is usually the UI element (label, button, notification, dialog, dropdown, checkbox, etc.). The aim of this PR is primarily to change the names. Later PRs may seek to consolidate some redundant strings and to better organize the translation file.

See this comment further down for more detail on the rationale behind the renaming and prefixing of keys: https://github.com/OpenRA/OpenRA/pull/20207#issuecomment-1239542263

~~Depends on #20048~~
~~Depends on #20400~~