### PR TITLE
Fix frozen actors lacking tooltips if they have the cloak ability.

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/FrozenUnderFogUpdatedByGps.cs
+++ b/OpenRA.Mods.Cnc/Traits/FrozenUnderFogUpdatedByGps.cs
@@ -32,11 +32,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			// This only makes sense if the frozen actor has already been revealed (i.e. has renderables)
 			if (fa.HasRenderables)
 			{
-				// HACK: RefreshState updated *all* actor state, not just the owner
-				// This is generally bogus, and specifically breaks cursors and tooltips by setting Hidden to false
-				var hidden = fa.Hidden;
 				fa.RefreshState();
-				fa.Hidden = hidden;
 				fa.NeedRenderables = true;
 			}
 		};

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -81,13 +81,11 @@ namespace OpenRA.Mods.Common.Traits
 				for (var playerIndex = 0; playerIndex < frozenStates.Count; playerIndex++)
 				{
 					var state = frozenStates[playerIndex];
+					var frozen = state.FrozenActor;
 					if (startsRevealed || state.IsVisible)
-					{
-						UpdateFrozenActor(state.FrozenActor, playerIndex);
+						UpdateFrozenActor(frozen, playerIndex);
 
-						// Needed so tooltips appear.
-						state.FrozenActor.Hidden = false;
-					}
+					frozen.RefreshHidden();
 				}
 			});
 
@@ -113,6 +111,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (isVisible)
 				UpdateFrozenActor(frozen, frozen.Viewer.World.Players.IndexOf(frozen.Viewer));
+
+			frozen.RefreshHidden();
 		}
 
 		bool IsVisibleInner(Player byPlayer)
@@ -176,7 +176,9 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// Force a state update for the old owner so the tooltip etc doesn't show them as the owner
 			var oldOwnerIndex = self.World.Players.IndexOf(oldOwner);
-			UpdateFrozenActor(frozenStates[oldOwnerIndex].FrozenActor, oldOwnerIndex);
+			var frozen = frozenStates[oldOwnerIndex].FrozenActor;
+			UpdateFrozenActor(frozen, oldOwnerIndex);
+			frozen.RefreshHidden();
 		}
 
 		void INotifyActorDisposing.Disposing(Actor self)


### PR DESCRIPTION
Since bbf5970bc16a41ac5f7a7324c99dd0c3a917418d we update frozen actors only when required.

In 8339c6843ed122fb093b2f22e17a2c26e483b64d a regression was fixed where actors created in line of sight would be invisible.

Here, we fix a related regression where cloaked units that are revealed, and then frozen when you move out of line of sight would lack tooltips.

The fix centers around the setting of the Hidden flag. In the old code this used CanBeViewedByPlayer which checks for visibility modifiers and then uses the default visibility. The bug with this code is that when a visibility modifier was not hiding the actor, then we would report the default visibility state instead. However the frozen visibility state applies here which means if the frozen actor is visible, then we consider the actor to be hidden and therefore tooltips will not appear. In the fixed version we only consider the modifiers. This means a visibility modifier such as Cloak can hide the frozen actor tooltips. But otherwise we do not consider the frozen actor to be hidden. This prevents a frozen actor from hiding its own tooltips in some unintended circular logic. Hidden now becomes just a flag to indicate if the visibility modifiers are overriding things, as intended.

----

Fixes #20206. Regressed in #20156. See related regression #20179 and resolution in #20182

Ensure the following condition is met during the test scenarios:
- When frozen buildings are visible and you hover over one, they do not have healthbars and do have tooltips.

Test scenarios:
- When a building is created within line of sight, ensure it appears. Then move out of sight, and the frozen building appears.
- When a building is created out of line of sight, nothing is seen. Then move into line of sight and the building appears. Then move out of sight, and the frozen building appears.
- When using Explored Map = true, frozen buildings can be seen on the map when the game starts and can be targeted. e.g. oil derricks.
- When moving out of line of sight of a cloakable building that is cloaked, the frozen building does not appear.
- When moving out of line of sight of a cloakable building that is uncloaked, the frozen building appears.
- When enabling and then later disabling the `/visibility` cheat, frozen buildings appear for everything.