### PR TITLE
Fix landed aircraft above ground level not removing influence on take off

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
+++ b/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (aircraft.ForceLanding)
 				return;
 
-			if (self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition).Length >= aircraft.Info.MinAirborneAltitude)
+			if (!aircraft.HasInfluence())
 				return;
 
 			// We are taking off, so remove influence in ground cells.

--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -86,8 +86,6 @@ namespace OpenRA.Mods.Common.Activities
 				if (carryall.Carryable == null)
 					return;
 
-				self.Trait<Aircraft>().RemoveInfluence();
-
 				var localOffset = carryall.CarryableOffset.Rotate(body.QuantizeOrientation(self.Orientation));
 				var targetPosition = self.CenterPosition + body.LocalToWorld(localOffset);
 				var targetLocation = self.World.Map.CellContaining(targetPosition);

--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -248,8 +248,7 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					current = node.Actor;
 					node = node.Next;
-					if (!current.Disposed)
-						return true;
+					return true;
 				}
 
 				return false;
@@ -284,7 +283,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var always = sub == SubCell.FullCell || sub == SubCell.Any;
 			for (var i = layer[uv]; i != null; i = i.Next)
-				if (!i.Actor.Disposed && (i.SubCell == sub || i.SubCell == SubCell.FullCell || always))
+				if (i.SubCell == sub || i.SubCell == SubCell.FullCell || always)
 					yield return i.Actor;
 		}
 
@@ -386,7 +385,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var always = sub == SubCell.FullCell || sub == SubCell.Any;
 			for (var i = layer[uv]; i != null; i = i.Next)
-				if ((always || i.SubCell == sub || i.SubCell == SubCell.FullCell) && !i.Actor.Disposed && withCondition(i.Actor))
+				if ((always || i.SubCell == sub || i.SubCell == SubCell.FullCell) && withCondition(i.Actor))
 					return true;
 
 			return false;


### PR DESCRIPTION
Fixes #18268
Fixes #20255.

When the Land activity is run, the aircraft adds influence to the cell so it cannot be used by other actors. When the TakeOff activity runs, it removes the influence so the cell can be used by other actors.

However, when a Carryall picks up a unit, it is told to Land with a vertical offset - it never reaches ground level. When the TakeOff activity runs, it saw the aircraft was above ground level and bailed out. The means the influence is never removed. The cell is now unusable despite the fact the Carryall has left.

To fix this, TakeOff now checks if influence was applied instead of checking if the aircraft is above ground level. If so, we know the Land activity had decided that influence was required, even if the aircraft has not made it to ground level. When TakeOff runs, it will treat it as a proper take off event even though the aircraft is already above ground level. This means influence will be removed and the cell will become accessible as intended.

In ActorMap, we also fix a design flaw where disposed actors where excluded from queries. This caused cache inconsistencies with clients using ActorMap.CellUpdated event to rely on updates. This event will not get called when the actor was disposed, so the downsteam client may have cached the actors at that location, only for them to "change" when the actor is later disposed. This could cause the Locomotor and HierarchicalPathFInder to have inconsistent views of the actors on the map, causing crashes if the inconsistent state broken some internal invariants. The only reason to exclude disposed actors would be to cover up for the actors not being removed properly from the map, which is fixed now aircraft are handled correctly. If ever an actor isn't removed from the actor map, then the caller needs fixing rather than having the actor map exclude it.