### PR TITLE
Fix a crash when trying to pathfind from unusable custom movement layers

### DIFF
--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -46,9 +46,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			var graph = new MapPathGraph(LayerPoolForWorld(world), locomotor, self, world, check, customCost, ignoreActor, laneBias, false);
 			var search = new PathSearch(graph, loc => 0, 0, targetPredicate, recorder);
 
-			foreach (var sl in froms)
-				if (world.Map.Contains(sl))
-					search.AddInitialCell(sl, customCost);
+			AddInitialCells(world, locomotor, froms, customCost, search);
 
 			return search;
 		}
@@ -73,11 +71,17 @@ namespace OpenRA.Mods.Common.Pathfinder
 			heuristic = heuristic ?? DefaultCostEstimator(locomotor, target);
 			var search = new PathSearch(graph, heuristic, heuristicWeightPercentage, loc => loc == target, recorder);
 
-			foreach (var sl in froms)
-				if (world.Map.Contains(sl))
-					search.AddInitialCell(sl, customCost);
+			AddInitialCells(world, locomotor, froms, customCost, search);
 
 			return search;
+		}
+
+		static void AddInitialCells(World world, Locomotor locomotor, IEnumerable<CPos> froms, Func<CPos, int> customCost, PathSearch search)
+		{
+			var customMovementLayers = world.GetCustomMovementLayers();
+			foreach (var sl in froms)
+				if (world.Map.Contains(sl) && (sl.Layer == 0 || customMovementLayers[sl.Layer].EnabledForLocomotor(locomotor.Info)))
+					search.AddInitialCell(sl, customCost);
 		}
 
 		public static PathSearch ToTargetCellOverGraph(


### PR DESCRIPTION
If a path search is attempted from a location outside the map, then PathSearch will filter these out to prevent any crashes. The path search will result in no path. However if the location is within the map but on a custom movement layer that the locomotor cannot use, this currently crashes. To fix this we apply a similar filtering logic to ignore any source locations that cannot be used, and so the path search will result in no path for these as well.

Fixes #19063