### PR TITLE
Fix terrain positions for targets not being serialized for Orders

### DIFF
--- a/OpenRA.Game/Server/ProtocolVersion.cs
+++ b/OpenRA.Game/Server/ProtocolVersion.cs
@@ -77,6 +77,6 @@ namespace OpenRA.Server
 		// The protocol for server and world orders
 		// This applies after the handshake has completed, and is provided to support
 		// alternative server implementations that wish to support multiple versions in parallel
-		public const int Orders = 20;
+		public const int Orders = 21;
 	}
 }

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -291,11 +291,13 @@ namespace OpenRA.Traits
 
 		// Expose internal state for serialization by the orders code *only*
 		internal static Target FromSerializedActor(Actor a, int generation) { return a != null ? new Target(a, generation) : Invalid; }
+		internal static Target FromSerializedTerrainPosition(WPos centerPosition, WPos[] terrainPositions) { return new Target(centerPosition, terrainPositions); }
 		internal TargetType SerializableType => type;
 		internal Actor SerializableActor => actor;
 		internal int SerializableGeneration => generation;
 		internal CPos? SerializableCell => cell;
 		internal SubCell? SerializableSubCell => subCell;
 		internal WPos SerializablePos => terrainCenterPosition;
+		internal WPos[] SerializableTerrainPositions => terrainPositions;
 	}
 }


### PR DESCRIPTION
Follow-up to #20084.

It appears we currently do not send any orders with targets that have `terrainPositions` set to anything else than `{ terrainCenterPosition }` (which is restored by the default constructor), but this makes sure we don't run into desyncs in the future if targets with other `terrainPositions` are ever sent over the network.