### PR TITLE
Refactor ScrollItemWidget to use stateful image names

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -181,7 +181,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void CreateMissionGroup(string title, IEnumerable<MapPreview> previews, Action onExit)
 		{
-			var header = ScrollItemWidget.Setup(headerTemplate, () => true, () => { });
+			var header = ScrollItemWidget.Setup(headerTemplate, () => false, () => { });
 			header.Get<LabelWidget>("LABEL").GetText = () => title;
 			missionList.AddChild(header);
 

--- a/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
@@ -41,6 +41,18 @@ namespace OpenRA.Mods.Common.Widgets
 					});
 		}
 
+		// TODO: refactor buttons and related UI to use this function
+		public static CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted), Sprite[]> GetCachedStatefulPanelImages(string collection)
+		{
+			return new CachedTransform<(bool, bool, bool, bool, bool), Sprite[]>(
+				((bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted) args) =>
+					{
+						var collectionName = collection + (args.Highlighted ? "-highlighted" : "");
+						var variantCollectionName = GetStatefulImageName(collectionName, args.Disabled, args.Pressed, args.Hover, args.Focused);
+						return ChromeProvider.GetPanelImages(variantCollectionName) ?? ChromeProvider.GetPanelImages(collectionName);
+					});
+		}
+
 		public static void DrawSprite(Sprite s, float2 pos)
 		{
 			Game.Renderer.RgbaSpriteRenderer.DrawSprite(s, pos);

--- a/mods/cnc/chrome.yaml
+++ b/mods/cnc/chrome.yaml
@@ -205,16 +205,23 @@ scrollpanel-button-gdi-disabled:
 scrollpanel-button-gdi-pressed:
 	Inherits: button-gdi-pressed
 
+scrollitem:
+
 scrollitem-hover:
 	Inherits: button
 
-scrollitem-selected:
+scrollitem-highlighted:
 	Inherits: button-pressed
 
 scrollitem-nohover:
 
-scrollitem-nohover-hover:
+scrollitem-nohover-highlighted:
 
+scrollheader:
+	Inherits: button
+
+scrollheader-highlighted:
+	Inherits: button
 
 #
 # Slider

--- a/mods/cnc/chrome/missionbrowser.yaml
+++ b/mods/cnc/chrome/missionbrowser.yaml
@@ -24,6 +24,7 @@ Container@MISSIONBROWSER_PANEL:
 					Height: PARENT_BOTTOM - 30
 					Children:
 						ScrollItem@HEADER:
+							BaseName: scrollheader
 							Width: PARENT_RIGHT - 27
 							Height: 13
 							X: 2

--- a/mods/d2k/chrome.yaml
+++ b/mods/d2k/chrome.yaml
@@ -446,18 +446,23 @@ checkbox-toggle-highlighted-hover:
 checkbox-toggle-highlighted-pressed:
 	Inherits: checkbox-highlighted-pressed
 
-scrollitem-selected:
-	Inherits: button-pressed
+scrollitem:
 
 scrollitem-hover:
 	Inherits: button
 
-scrollheader-selected:
-	Inherits: button
+scrollitem-highlighted:
+	Inherits: button-pressed
 
 scrollitem-nohover:
 
-scrollitem-nohover-hover:
+scrollitem-nohover-highlighted:
+
+scrollheader:
+	Inherits: button
+
+scrollheader-highlighted:
+	Inherits: button
 
 scrollpanel-decorations:
 	Inherits: ^Glyphs

--- a/mods/ra/chrome.yaml
+++ b/mods/ra/chrome.yaml
@@ -575,18 +575,23 @@ checkbox-toggle-highlighted-hover:
 checkbox-toggle-highlighted-pressed:
 	Inherits: checkbox-highlighted-pressed
 
-scrollitem-selected:
-	Inherits: button-pressed
+scrollitem:
 
 scrollitem-hover:
 	Inherits: button
 
-scrollheader-selected:
-	Inherits: button
+scrollitem-highlighted:
+	Inherits: button-pressed
 
 scrollitem-nohover:
 
-scrollitem-nohover-hover:
+scrollitem-nohover-highlighted:
+
+scrollheader:
+	Inherits: button
+
+scrollheader-highlighted:
+	Inherits: button
 
 logos:
 	Inherits: ^LoadScreen

--- a/mods/ts/chrome.yaml
+++ b/mods/ts/chrome.yaml
@@ -708,17 +708,22 @@ checkbox-toggle-highlighted-hover:
 checkbox-toggle-highlighted-pressed:
 	Inherits: checkbox-highlighted-pressed
 
-scrollitem-selected:
-	Inherits: button-pressed
+scrollitem:
 
 scrollitem-hover:
 	Inherits: button
 
+scrollitem-highlighted:
+	Inherits: button-pressed
+
 scrollitem-nohover:
 
-scrollitem-nohover-hover:
+scrollitem-nohover-highlighted:
 
-scrollheader-selected:
+scrollheader:
+	Inherits: button
+
+scrollheader-highlighted:
 	Inherits: button
 
 mainmenu-border:


### PR DESCRIPTION
Split from #20200

I cache the image collection as well. I figure that the added method in WidgetUtils will be great for other UI elements as well