### PR TITLE
Add descriptions to all projectiles and warheads

### DIFF
--- a/OpenRA.Mods.Cnc/Projectiles/TeslaZap.cs
+++ b/OpenRA.Mods.Cnc/Projectiles/TeslaZap.cs
@@ -17,6 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Projectiles
 {
+	[Desc("Instant-hit projectile used to create electricity-like effects.")]
 	public class TeslaZapInfo : IProjectileInfo
 	{
 		public readonly string Image = "litning";

--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -21,6 +21,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Projectiles
 {
+	[Desc("Beam projectile that travels in a straight line.")]
 	public class AreaBeamInfo : IProjectileInfo
 	{
 		[Desc("Projectile speed in WDist / tick, two values indicate a randomly picked velocity per beam.")]

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -22,6 +22,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Projectiles
 {
+	[Desc("Projectile that travels in a straight line or arc.")]
 	public class BulletInfo : IProjectileInfo
 	{
 		[Desc("Projectile speed in WDist / tick, two values indicate variable velocity.")]

--- a/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
@@ -17,6 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Projectiles
 {
+	[Desc("Projectile with customisable acceleration vector.")]
 	public class GravityBombInfo : IProjectileInfo
 	{
 		public readonly string Image = null;

--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Projectiles
 {
-	[Desc("Simple, invisible, usually direct-on-target projectile.")]
+	[Desc("Instant, invisible, usually direct-on-target projectile.")]
 	public class InstantHitInfo : IProjectileInfo
 	{
 		[Desc("The maximum/constant/incremental inaccuracy used in conjunction with the InaccuracyType property.")]

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -21,6 +21,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Projectiles
 {
+	[Desc("Projectile with smart tracking.")]
 	public class MissileInfo : IProjectileInfo
 	{
 		[Desc("Name of the image containing the projectile sequence.")]

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -19,6 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Warheads
 {
+	[Desc("Spawn a sprite with sound.")]
 	public class CreateEffectWarhead : Warhead
 	{
 		[SequenceReference(nameof(Image), allowNullImage: true)]

--- a/OpenRA.Mods.Common/Warheads/CreateResourceWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateResourceWarhead.cs
@@ -15,6 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Warheads
 {
+	[Desc("Creates resources in a circle.")]
 	public class CreateResourceWarhead : Warhead
 	{
 		[Desc("Size of the area. The resources are seeded within this area.", "Provide 2 values for a ring effect (outer/inner).")]

--- a/OpenRA.Mods.Common/Warheads/DestroyResourceWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DestroyResourceWarhead.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Warheads
 {
+	[Desc("Destroys resources in a circle.")]
 	public class DestroyResourceWarhead : Warhead
 	{
 		[Desc("Size of the area. The resources are removed within this area.", "Provide 2 values for a ring effect (outer/inner).")]

--- a/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
@@ -17,6 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Warheads
 {
+	[Desc("Fires weapons from the point of impact.")]
 	public class FireClusterWarhead : Warhead, IRulesetLoaded<WeaponInfo>
 	{
 		[WeaponReference]

--- a/OpenRA.Mods.Common/Warheads/GrantExternalConditionWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/GrantExternalConditionWarhead.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Warheads
 {
+	[Desc("Grant an external condition to hit actors.")]
 	public class GrantExternalConditionWarhead : Warhead
 	{
 		[FieldLoader.Require]

--- a/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
@@ -15,6 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Warheads
 {
+	[Desc("Apply damage based on the target's health.")]
 	public class HealthPercentageDamageWarhead : TargetDamageWarhead
 	{
 		protected override void InflictDamage(Actor victim, Actor firedBy, HitShape shape, WarheadArgs args)

--- a/OpenRA.Mods.Common/Warheads/LeaveSmudgeWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/LeaveSmudgeWarhead.cs
@@ -18,6 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Warheads
 {
+	[Desc("Creates a smudge in `SmudgeLayer`.")]
 	public class LeaveSmudgeWarhead : Warhead
 	{
 		[Desc("Size of the area. A smudge will be created in each tile.", "Provide 2 values for a ring effect (outer/inner).")]

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -18,6 +18,7 @@ namespace OpenRA.Mods.Common.Warheads
 {
 	public enum DamageCalculationType { HitShape, ClosestTargetablePosition, CenterPosition }
 
+	[Desc("Apply damage in a specified range.")]
 	public class SpreadDamageWarhead : DamageWarhead, IRulesetLoaded<WeaponInfo>
 	{
 		[Desc("Range between falloff steps.")]

--- a/OpenRA.Mods.Common/Warheads/TargetDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/TargetDamageWarhead.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Warheads
 {
+	[Desc("Apply damage to the targeted actor.")]
 	public class TargetDamageWarhead : DamageWarhead
 	{
 		[Desc("Damage will be applied to actors in this area. A value of zero means only targeted actor will be damaged.")]


### PR DESCRIPTION
I add definitions to all projectiles and warheads, even if some of them don't need it.

This PR has 2 goals: 
- Improve documentation
- Improve the formatting of our docks page by making sure all elements have descriptions