### PR TITLE
Adjust faction label width in lobby to fit better when truncated

### DIFF
--- a/mods/cnc/chrome/dialogs.yaml
+++ b/mods/cnc/chrome/dialogs.yaml
@@ -75,7 +75,7 @@ ScrollPanel@FACTION_DROPDOWN_TEMPLATE:
 					Height: 16
 				Label@LABEL:
 					X: 40
-					Width: 60
+					Width: 50
 					Height: 25
 
 ScrollPanel@TEAM_DROPDOWN_TEMPLATE:

--- a/mods/cnc/chrome/lobby-players.yaml
+++ b/mods/cnc/chrome/lobby-players.yaml
@@ -141,7 +141,7 @@ Container@LOBBY_PLAYER_BIN:
 									Height: 16
 								Label@FACTIONNAME:
 									X: 40
-									Width: 60
+									Width: 50
 									Height: 25
 									Text: Faction
 						DropDownButton@TEAM_DROPDOWN:
@@ -252,7 +252,7 @@ Container@LOBBY_PLAYER_BIN:
 									Height: 15
 								Label@FACTIONNAME:
 									X: 40
-									Width: 60
+									Width: 50
 									Height: 25
 									Text: Faction
 						Label@TEAM:

--- a/mods/common/chrome/lobby-players.yaml
+++ b/mods/common/chrome/lobby-players.yaml
@@ -138,7 +138,7 @@ Container@LOBBY_PLAYER_BIN:
 									Height: 15
 								Label@FACTIONNAME:
 									X: 40
-									Width: 60
+									Width: 70
 									Height: 25
 									Text: Faction
 						DropDownButton@TEAM_DROPDOWN:
@@ -248,7 +248,7 @@ Container@LOBBY_PLAYER_BIN:
 									Height: 15
 								Label@FACTIONNAME:
 									X: 40
-									Width: 60
+									Width: 70
 									Height: 25
 									Text: Faction
 						Label@TEAM:
@@ -501,5 +501,5 @@ ScrollPanel@FACTION_DROPDOWN_TEMPLATE:
 					Height: 15
 				Label@LABEL:
 					X: 40
-					Width: 60
+					Width: 70
 					Height: 25

--- a/mods/d2k/chrome/lobby-players.yaml
+++ b/mods/d2k/chrome/lobby-players.yaml
@@ -138,7 +138,7 @@ Container@LOBBY_PLAYER_BIN:
 									Height: 23
 								Label@FACTIONNAME:
 									X: 34
-									Width: 70
+									Width: 80
 									Height: 25
 									Text: Faction
 						DropDownButton@TEAM_DROPDOWN:
@@ -248,7 +248,7 @@ Container@LOBBY_PLAYER_BIN:
 									Height: 23
 								Label@FACTIONNAME:
 									X: 34
-									Width: 70
+									Width: 80
 									Height: 25
 									Text: Faction
 						Label@TEAM:
@@ -501,5 +501,5 @@ ScrollPanel@FACTION_DROPDOWN_TEMPLATE:
 					Height: 15
 				Label@LABEL:
 					X: 30
-					Width: 70
+					Width: 80
 					Height: 25


### PR DESCRIPTION
Follow up to #20196 to address https://github.com/OpenRA/OpenRA/pull/20196#issuecomment-1226376890
![Screenshot from 2022-08-25 09-55-30](https://user-images.githubusercontent.com/1355810/186606223-b08f8c54-2978-4bda-9e5c-35f207e439e3.png)
![Screenshot from 2022-08-25 09-55-13](https://user-images.githubusercontent.com/1355810/186606225-207fb53a-f04e-4339-a87d-24ec53ca598c.png)
![Screenshot from 2022-08-25 09-54-55](https://user-images.githubusercontent.com/1355810/186606227-8d64f3ec-55c7-4650-a0e9-427b1f571b72.png)
![Screenshot from 2022-08-25 09-54-36](https://user-images.githubusercontent.com/1355810/186606230-1eb9f32a-38ae-4787-862d-8cc68682852f.png)

