### PR TITLE
Split out Terrain target type to enable non-cell based position targets

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -178,7 +178,7 @@ namespace OpenRA.GameRules
 			if (target.Type == TargetType.FrozenActor)
 				return IsValidAgainst(target.FrozenActor, firedBy);
 
-			if (target.Type == TargetType.Terrain)
+			if (target.IsTerrainCellType())
 			{
 				var dat = world.Map.DistanceAboveTerrain(target.CenterPosition);
 				if (dat > AirThreshold)

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -144,8 +144,7 @@ namespace OpenRA
 									break;
 								}
 
-								case TargetType.Terrain:
-								{
+								case TargetType.TerrainCell:
 									if (flags.HasField(OrderFields.TargetIsCell))
 									{
 										var cell = new CPos(r.ReadInt32());
@@ -153,12 +152,23 @@ namespace OpenRA
 										if (world != null)
 											target = Target.FromCell(world, cell, subCell);
 									}
-									else
+
+									break;
+								case TargetType.TerrainCellPos:
+									if (flags.HasField(OrderFields.TargetIsCell))
 									{
+										var cell = new CPos(r.ReadInt32());
+										var subCell = (SubCell)r.ReadByte();
 										var pos = new WPos(r.ReadInt32(), r.ReadInt32(), r.ReadInt32());
-										target = Target.FromPos(pos);
+										if (world != null)
+											target = Target.FromCellWithTerrainPos(cell, subCell, pos);
 									}
 
+									break;
+								case TargetType.TerrainPos:
+								{
+									var pos2 = new WPos(r.ReadInt32(), r.ReadInt32(), r.ReadInt32());
+									target = Target.FromPos(pos2);
 									break;
 								}
 							}
@@ -368,27 +378,51 @@ namespace OpenRA
 						switch (Target.SerializableType)
 						{
 							case TargetType.Actor:
+							{
 								w.Write(UIntFromActor(Target.SerializableActor));
 								w.Write(Target.SerializableGeneration);
 								break;
+							}
+
 							case TargetType.FrozenActor:
+							{
 								w.Write(Target.FrozenActor.Viewer.PlayerActor.ActorID);
 								w.Write(Target.FrozenActor.ID);
 								break;
-							case TargetType.Terrain:
+							}
+
+							case TargetType.TerrainCell:
+							{
 								if (fields.HasField(OrderFields.TargetIsCell))
 								{
 									w.Write(Target.SerializableCell.Value.Bits);
 									w.Write((byte)Target.SerializableSubCell);
 								}
-								else
+
+								break;
+							}
+
+							case TargetType.TerrainCellPos:
+							{
+								if (fields.HasField(OrderFields.TargetIsCell))
 								{
+									w.Write(Target.SerializableCell.Value.Bits);
+									w.Write((byte)Target.SerializableSubCell);
 									w.Write(Target.SerializablePos.X);
 									w.Write(Target.SerializablePos.Y);
 									w.Write(Target.SerializablePos.Z);
 								}
 
 								break;
+							}
+
+							case TargetType.TerrainPos:
+							{
+								w.Write(Target.SerializablePos.X);
+								w.Write(Target.SerializablePos.Y);
+								w.Write(Target.SerializablePos.Z);
+								break;
+							}
 						}
 					}
 

--- a/OpenRA.Game/Sync.cs
+++ b/OpenRA.Game/Sync.cs
@@ -134,22 +134,24 @@ namespace OpenRA
 			return 0;
 		}
 
-		public static int HashTarget(Target t)
+		public static int HashTarget(Target target)
 		{
-			switch (t.Type)
+			switch (target.Type)
 			{
 				case TargetType.Actor:
-					return (int)(t.Actor.ActorID << 16) * 0x567;
+					return (int)(target.Actor.ActorID << 16) * 0x567;
 
 				case TargetType.FrozenActor:
-					var actor = t.FrozenActor.Actor;
+					var actor = target.FrozenActor.Actor;
 					if (actor == null)
 						return 0;
 
 					return (int)(actor.ActorID << 16) * 0x567;
 
-				case TargetType.Terrain:
-					return HashUsingHashCode(t.CenterPosition);
+				case TargetType.TerrainCell:
+				case TargetType.TerrainCellPos:
+				case TargetType.TerrainPos:
+					return HashUsingHashCode(target.CenterPosition);
 
 				default:
 				case TargetType.Invalid:

--- a/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
+++ b/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Cnc.Activities
 			// The target may become hidden between the initial order request and the first tick (e.g. if queued)
 			// Moving to any position (even if quite stale) is still better than immediately giving up
 			if ((target.Type == TargetType.Actor && target.Actor.CanBeViewedByPlayer(self.Owner))
-			    || target.Type == TargetType.FrozenActor || target.Type == TargetType.Terrain)
+			    || target.Type == TargetType.FrozenActor || target.IsTerrainType())
 			{
 				lastVisibleTarget = Target.FromPos(target.CenterPosition);
 				lastVisibleMinRange = attack.GetMinimumRangeVersusTarget(target);

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -362,7 +362,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			public bool CanTarget(Actor self, in Target target, ref TargetModifiers modifiers, ref string cursor)
 			{
-				if (target.Type != TargetType.Terrain)
+				if (!target.IsTerrainType())
 					return false;
 
 				var location = self.World.Map.CellContaining(target.CenterPosition);

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Activities
 			// The target may become hidden between the initial order request and the first tick (e.g. if queued)
 			// Moving to any position (even if quite stale) is still better than immediately giving up
 			if ((target.Type == TargetType.Actor && target.Actor.CanBeViewedByPlayer(self.Owner))
-			    || target.Type == TargetType.FrozenActor || target.Type == TargetType.Terrain)
+			    || target.Type == TargetType.FrozenActor || target.IsTerrainType())
 				lastVisibleTarget = Target.FromPos(target.CenterPosition);
 			else if (initialTargetPosition.HasValue)
 				lastVisibleTarget = Target.FromPos(initialTargetPosition.Value);

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Activities
 			// The target may become hidden between the initial order request and the first tick (e.g. if queued)
 			// Moving to any position (even if quite stale) is still better than immediately giving up
 			if ((target.Type == TargetType.Actor && target.Actor.CanBeViewedByPlayer(self.Owner))
-				|| target.Type == TargetType.FrozenActor || target.Type == TargetType.Terrain)
+				|| target.Type == TargetType.FrozenActor || target.IsTerrainType())
 			{
 				lastVisibleTarget = Target.FromPos(target.CenterPosition);
 				lastVisibleMaximumRange = attackAircraft.GetMaximumRangeVersusTarget(target);

--- a/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Activities
 			// The target may become hidden between the initial order request and the first tick (e.g. if queued)
 			// Moving to any position (even if quite stale) is still better than immediately giving up
 			if ((target.Type == TargetType.Actor && target.Actor.CanBeViewedByPlayer(self.Owner))
-			    || target.Type == TargetType.FrozenActor || target.Type == TargetType.Terrain)
+			    || target.Type == TargetType.FrozenActor || target.IsTerrainType())
 				lastVisibleTarget = Target.FromPos(target.CenterPosition);
 			else if (initialTargetPosition.HasValue)
 				lastVisibleTarget = Target.FromPos(initialTargetPosition.Value);

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 
 			// Look for free landing cell
-			if (target.Type == TargetType.Terrain && !landingInitiated)
+			if (target.IsTerrainCellType() && !landingInitiated)
 			{
 				var newLocation = aircraft.FindLandingLocation(landingCell, landRange);
 

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Activities
 			// The target may become hidden between the initial order request and the first tick (e.g. if queued)
 			// Moving to any position (even if quite stale) is still better than immediately giving up
 			if ((target.Type == TargetType.Actor && target.Actor.CanBeViewedByPlayer(self.Owner))
-			    || target.Type == TargetType.FrozenActor || target.Type == TargetType.Terrain)
+			    || target.Type == TargetType.FrozenActor || target.IsTerrainType())
 			{
 				lastVisibleTarget = Target.FromPos(target.CenterPosition);
 

--- a/OpenRA.Mods.Common/Activities/Move/Follow.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Follow.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Activities
 			// The target may become hidden between the initial order request and the first tick (e.g. if queued)
 			// Moving to any position (even if quite stale) is still better than immediately giving up
 			if ((target.Type == TargetType.Actor && target.Actor.CanBeViewedByPlayer(self.Owner))
-			    || target.Type == TargetType.FrozenActor || target.Type == TargetType.Terrain)
+			    || target.Type == TargetType.FrozenActor || target.IsTerrainType())
 				lastVisibleTarget = Target.FromPos(target.CenterPosition);
 			else if (initialTargetPosition.HasValue)
 				lastVisibleTarget = Target.FromPos(initialTargetPosition.Value);

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Activities
 			// The target may become hidden between the initial order request and the first tick (e.g. if queued)
 			// Moving to any position (even if quite stale) is still better than immediately giving up
 			if ((target.Type == TargetType.Actor && target.Actor.CanBeViewedByPlayer(self.Owner))
-			    || target.Type == TargetType.FrozenActor || target.Type == TargetType.Terrain)
+			    || target.Type == TargetType.FrozenActor || target.IsTerrainType())
 			{
 				lastVisibleTarget = Target.FromPos(target.CenterPosition);
 				lastVisibleTargetLocation = self.World.Map.CellContaining(target.CenterPosition);

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -1288,7 +1288,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public virtual bool CanTarget(Actor self, in Target target, ref TargetModifiers modifiers, ref string cursor)
 			{
-				if (target.Type != TargetType.Terrain || (aircraft.requireForceMove && !modifiers.HasModifier(TargetModifiers.ForceMove)))
+				if (!target.IsTerrainType() || (aircraft.requireForceMove && !modifiers.HasModifier(TargetModifiers.ForceMove)))
 					return false;
 
 				var location = self.World.Map.CellContaining(target.CenterPosition);

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -359,26 +359,26 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		// Enumerates all armaments, that this actor possesses, that can be used against Target t
-		public IEnumerable<Armament> ChooseArmamentsForTarget(Target t, bool forceAttack)
+		public IEnumerable<Armament> ChooseArmamentsForTarget(Target target, bool forceAttack)
 		{
 			// If force-fire is not used, and the target requires force-firing or the target is
 			// terrain or invalid, no armaments can be used
-			if (!forceAttack && (t.Type == TargetType.Terrain || t.Type == TargetType.Invalid || t.RequiresForceFire))
+			if (!forceAttack && (target.IsTerrainType() || target.Type == TargetType.Invalid || target.RequiresForceFire))
 				return Enumerable.Empty<Armament>();
 
 			// Get target's owner; in case of terrain or invalid target there will be no problems
 			// with owner == null since forceFire will have to be true in this part of the method
 			// (short-circuiting in the logical expression below)
 			Player owner = null;
-			if (t.Type == TargetType.FrozenActor)
-				owner = t.FrozenActor.Owner;
-			else if (t.Type == TargetType.Actor)
-				owner = t.Actor.Owner;
+			if (target.Type == TargetType.FrozenActor)
+				owner = target.FrozenActor.Owner;
+			else if (target.Type == TargetType.Actor)
+				owner = target.Actor.Owner;
 
 			return Armaments.Where(a =>
 				!a.IsTraitDisabled
 				&& (owner == null || (forceAttack ? a.Info.ForceTargetRelationships : a.Info.TargetRelationships).HasRelationship(self.Owner.RelationshipWith(owner)))
-				&& a.Weapon.IsValidAgainst(t, self.World, self));
+				&& a.Weapon.IsValidAgainst(target, self.World, self));
 		}
 
 		public void AttackTarget(in Target target, AttackSource source, bool queued, bool allowMove, bool forceAttack = false, Color? targetLineColor = null)
@@ -511,7 +511,8 @@ namespace OpenRA.Mods.Common.Traits
 					case TargetType.Actor:
 					case TargetType.FrozenActor:
 						return CanTargetActor(self, target, ref modifiers, ref cursor);
-					case TargetType.Terrain:
+					case TargetType.TerrainCell:
+					case TargetType.TerrainCellPos:
 						return CanTargetLocation(self, self.World.Map.CellContaining(target.CenterPosition), modifiers, ref cursor);
 					default:
 						return false;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -253,7 +253,7 @@ namespace OpenRA.Mods.Common.Traits
 				// The target may become hidden between the initial order request and the first tick (e.g. if queued)
 				// Moving to any position (even if quite stale) is still better than immediately giving up
 				if ((target.Type == TargetType.Actor && target.Actor.CanBeViewedByPlayer(self.Owner))
-				    || target.Type == TargetType.FrozenActor || target.Type == TargetType.Terrain)
+				    || target.Type == TargetType.FrozenActor || target.IsTerrainCellType())
 				{
 					lastVisibleTarget = Target.FromPos(target.CenterPosition);
 					lastVisibleMaximumRange = attack.GetMaximumRangeVersusTarget(target);

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -149,7 +149,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public bool CanTarget(Actor self, in Target target, ref TargetModifiers modifiers, ref string cursor)
 			{
-				if (target.Type != TargetType.Terrain)
+				if (!target.IsTerrainType())
 					return false;
 
 				IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
@@ -202,7 +202,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public bool CanTarget(Actor self, in Target target, ref TargetModifiers modifiers, ref string cursor)
 			{
-				if (target.Type != TargetType.Terrain || (aircraft.Info.RequiresForceMove && !modifiers.HasModifier(TargetModifiers.ForceMove)))
+				if (!target.IsTerrainCellType() || (aircraft.Info.RequiresForceMove && !modifiers.HasModifier(TargetModifiers.ForceMove)))
 					return false;
 
 				var location = self.World.Map.CellContaining(target.CenterPosition);

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
@@ -191,7 +191,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public bool CanTarget(Actor self, in Target target, ref TargetModifiers modifiers, ref string cursor)
 			{
-				if (rejectMove || target.Type != TargetType.Terrain || (mobile.Info.RequiresForceMove && !modifiers.HasModifier(TargetModifiers.ForceMove)))
+				if (rejectMove || !target.IsTerrainCellType() || (mobile.Info.RequiresForceMove && !modifiers.HasModifier(TargetModifiers.ForceMove)))
 					return false;
 
 				var location = self.World.Map.CellContaining(target.CenterPosition);

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnAttack.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnAttack.cs
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (lastTarget.FrozenActor != target.FrozenActor)
 					return true;
 
-			if (lastTarget.Type == TargetType.Terrain && target.Type == TargetType.Terrain)
+			if (lastTarget.IsTerrainType() && target.IsTerrainType())
 				if (lastTarget.CenterPosition != target.CenterPosition)
 					return true;
 

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -390,7 +390,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public bool CanTarget(Actor self, in Target target, ref TargetModifiers modifiers, ref string cursor)
 			{
-				if (target.Type != TargetType.Terrain)
+				if (target.IsTerrainType())
 					return false;
 
 				if (modifiers.HasModifier(TargetModifiers.ForceMove))

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -1006,7 +1006,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public bool CanTarget(Actor self, in Target target, ref TargetModifiers modifiers, ref string cursor)
 			{
-				if (rejectMove || target.Type != TargetType.Terrain || (mobile.requireForceMove && !modifiers.HasModifier(TargetModifiers.ForceMove)))
+				if (rejectMove || !target.IsTerrainCellType() || (mobile.requireForceMove && !modifiers.HasModifier(TargetModifiers.ForceMove)))
 					return false;
 
 				var location = self.World.Map.CellContaining(target.CenterPosition);

--- a/OpenRA.Mods.Common/Traits/World/OrderEffects.cs
+++ b/OpenRA.Mods.Common/Traits/World/OrderEffects.cs
@@ -93,7 +93,9 @@ namespace OpenRA.Mods.Common.Traits
 					return true;
 				}
 
-				case TargetType.Terrain:
+				case TargetType.TerrainCell:
+				case TargetType.TerrainCellPos:
+				case TargetType.TerrainPos:
 				{
 					world.AddFrameEndTask(w => w.Add(new SpriteAnnotation(target.CenterPosition, world, info.TerrainFlashImage, info.TerrainFlashSequence, info.TerrainFlashPalette)));
 					return true;


### PR DESCRIPTION
This PR splits out the current `Terrain` target type into three target types: `TerrainCell`, which contains only a terrain cell as a target, `TerrainPos`, which contains only a terrain position (i.e. a `WPos`) as a target, and `TerrainCellPos`, which contains both a cell and a position. This distinction is necessary for non-cell based orders to be used, such as non-cell based pathfinders like the one used in my pet project [Jire](https://github.com/AspectInteractive/Jire). The `Target` class now has a few additional constructors taking in a position parameter for this purpose. Due to multiple terrain types existing, I have created the `IsTerrainType()` function for checking whether any of these terrain type are used, and the more specific `IsTerrainCellType()` for checking specifically the cell terrain types, to replace the existing checks against the current singular terrain target type. The two aforementioned functions are largely interchangeable since they will both return True for all cell terrain types, however I have used `IsTerrainType()` for most functions to make it easier to remove cell-based logic in the future if necessary.