### PR TITLE
Improve AI squad pathing and regrouping behavior. 

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -149,10 +149,13 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			var targetTypes = a.GetEnabledTargetTypes();
-			return !targetTypes.IsEmpty && !targetTypes.Overlaps(Info.IgnoredEnemyTargetTypes);
+			if (targetTypes.IsEmpty || targetTypes.Overlaps(Info.IgnoredEnemyTargetTypes))
+				return false;
+
+			return IsNotHiddenUnit(a);
 		}
 
-		public bool IsNotHiddenUnit(Actor a)
+		bool IsNotHiddenUnit(Actor a)
 		{
 			var hasModifier = false;
 			var visModifiers = a.TraitsImplementing<IVisibilityModifier>();
@@ -240,7 +243,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Then check which are in weapons range of the source.
 			var activeAttackBases = sourceActor.TraitsImplementing<AttackBase>().Where(Exts.IsTraitEnabled).ToArray();
 			var enemiesAndSourceAttackRanges = actors
-				.Where(a => IsPreferredEnemyUnit(a) && IsNotHiddenUnit(a))
+				.Where(IsPreferredEnemyUnit)
 				.Select(a => (Actor: a, AttackBases: activeAttackBases.Where(ab => ab.HasAnyValidWeapons(Target.FromActor(a))).ToList()))
 				.Where(x => x.AttackBases.Count > 0)
 				.Select(x => (x.Actor, Range: x.AttackBases.Max(ab => ab.GetMaximumRangeVersusTarget(Target.FromActor(x.Actor)))))
@@ -458,7 +461,7 @@ namespace OpenRA.Mods.Common.Traits
 			var protectSq = GetSquadOfType(SquadType.Protection);
 			protectSq ??= RegisterNewSquad(bot, SquadType.Protection, (attacker, WVec.Zero));
 
-			if (protectSq.IsValid && !protectSq.IsTargetValid())
+			if (protectSq.IsValid && !protectSq.IsTargetValid(protectSq.CenterUnit()))
 				protectSq.SetActorToTarget((attacker, WVec.Zero));
 
 			if (!protectSq.IsValid)

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/Squad.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/Squad.cs
@@ -95,12 +95,12 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		/// <summary>
 		/// Checks the target is still valid, and updates the <see cref="Target"/> location if it is still valid.
 		/// </summary>
-		public bool IsTargetValid()
+		public bool IsTargetValid(Actor squadUnit)
 		{
 			var valid =
 				TargetActor != null &&
 				TargetActor.IsInWorld &&
-				TargetActor.IsTargetableBy(Units.FirstOrDefault()) &&
+				Units.Any(Target.IsValidFor) &&
 				!TargetActor.Info.HasTraitInfo<HuskInfo>();
 			if (!valid)
 				return false;
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			// e.g. a ship targeting a land unit, but the land unit moved north.
 			// We need to update our location to move north as well.
 			// If we can reach the actor directly, we'll just target it directly.
-			var target = SquadManager.FindEnemies(new[] { TargetActor }, Units.First()).FirstOrDefault();
+			var target = SquadManager.FindEnemies(new[] { TargetActor }, squadUnit).FirstOrDefault();
 			SetActorToTarget(target);
 			return target.Actor != null;
 		}
@@ -122,7 +122,16 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			TargetActor != null &&
 			TargetActor.CanBeViewedByPlayer(Bot.Player);
 
-		public WPos CenterPosition { get { return Units.Select(u => u.CenterPosition).Average(); } }
+		public WPos CenterPosition()
+		{
+			return Units.Select(a => a.CenterPosition).Average();
+		}
+
+		public Actor CenterUnit()
+		{
+			var centerPosition = CenterPosition();
+			return Units.MinByOrDefault(a => (a.CenterPosition - centerPosition).LengthSquared);
+		}
 
 		public MiniYaml Serialize()
 		{

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
@@ -150,10 +150,10 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			if (!owner.IsValid)
 				return;
 
-			if (!owner.IsTargetValid())
+			var leader = owner.CenterUnit();
+			if (!owner.IsTargetValid(leader))
 			{
-				var a = owner.Units.Random(owner.Random);
-				var closestEnemy = owner.SquadManager.FindClosestEnemy(a);
+				var closestEnemy = owner.SquadManager.FindClosestEnemy(leader);
 				owner.SetActorToTarget(closestEnemy);
 				if (closestEnemy.Actor == null)
 				{

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/ProtectionStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/ProtectionStates.cs
@@ -32,9 +32,10 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			if (!owner.IsValid)
 				return;
 
-			if (!owner.IsTargetValid())
+			var leader = Leader(owner);
+			if (!owner.IsTargetValid(leader))
 			{
-				var target = owner.SquadManager.FindClosestEnemy(owner.Units.First(), WDist.FromCells(owner.SquadManager.Info.ProtectionScanRadius));
+				var target = owner.SquadManager.FindClosestEnemy(leader, WDist.FromCells(owner.SquadManager.Info.ProtectionScanRadius));
 				owner.SetActorToTarget(target);
 				if (target.Actor == null)
 				{

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/StateBase.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/StateBase.cs
@@ -85,9 +85,8 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			if (!squad.IsValid)
 				return false;
 
-			var randomSquadUnit = squad.Units.Random(squad.Random);
 			var dangerRadius = squad.SquadManager.Info.DangerScanRadius;
-			var units = squad.World.FindActorsInCircle(randomSquadUnit.CenterPosition, WDist.FromCells(dangerRadius)).ToList();
+			var units = squad.World.FindActorsInCircle(squad.CenterPosition(), WDist.FromCells(dangerRadius)).ToList();
 
 			// If there are any own buildings within the DangerRadius, don't flee
 			// PERF: Avoid LINQ


### PR DESCRIPTION
Depends on #20227. Fixes #17327 and https://github.com/OpenRA/OpenRA/issues/17327#issuecomment-554163061. Fixes #3763.

----

Ensure the target location can be pathed to by all units in the squad, so the squad won't get stuck if some units can't make it. Improve the choice of leader for the squad. We attempt to a choose a leader whose locomotor is the most restrictive in terms of passable terrain. This maximises the chance that the squad will be able to follow the leader along the path to the target. ~~We also choose a leader based on the remaining movement length to the target rather than by physical distance. This avoids the squad regrouping backwards and getting stuck if the squad has to move away from the target to go around an obstacle.~~ We also keep this choice of leader as the squad advances, this avoids the squad constantly switching leaders and regrouping backwards in some cases.