### PR TITLE
Fix a wrong team parameter being used for ObserverStatsLogic translations

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -274,7 +274,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var teamLabel = tt.Get<LabelWidget>("TEAM");
 					var teamText = modData.Translation.GetString(Team, Translation.Arguments("team", team.Key));
 					teamLabel.GetText = () => teamText;
-					tt.Bounds.Width = teamLabel.Bounds.Width = Game.Renderer.Fonts[tt.Font].Measure(tt.Get<LabelWidget>("TEAM").GetText()).X;
+					tt.Bounds.Width = teamLabel.Bounds.Width = Game.Renderer.Fonts[tt.Font].Measure(teamText).X;
 
 					var colorBlockWidget = tt.Get<ColorBlockWidget>("TEAM_COLOR");
 					var scrollBarOffset = playerStatsPanel.ScrollBar != ScrollBar.Hidden

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -272,7 +272,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					tt.IgnoreMouseOver = true;
 
 					var teamLabel = tt.Get<LabelWidget>("TEAM");
-					var teamText = modData.Translation.GetString(Team, Translation.Arguments("team-no-team", team.Key));
+					var teamText = modData.Translation.GetString(Team, Translation.Arguments("team", team.Key));
 					teamLabel.GetText = () => teamText;
 					tt.Bounds.Width = teamLabel.Bounds.Width = Game.Renderer.Fonts[tt.Font].Measure(tt.Get<LabelWidget>("TEAM").GetText()).X;
 

--- a/mods/common/languages/en.ftl
+++ b/mods/common/languages/en.ftl
@@ -130,7 +130,7 @@ complete = { $percentage }% complete
 ## LobbyLogic, InGameChatLogic
 chat-availability =
     { $seconds ->
-        [zero] Chat Disabled
+        [0] Chat Disabled
         [one] Chat available in { $seconds } second...
         *[other] Chat available in { $seconds } seconds...
     }
@@ -165,7 +165,7 @@ unrevealed-terrain = Unrevealed Terrain
 ## ServerlistLogic, GameInfoStatsLogic, ObserverShroudSelectorLogic, SpawnSelectorTooltipLogic
 team-no-team =
     { $team ->
-        [zero] No Team
+        [0] No Team
        *[other] Team { $team }
     }
 


### PR DESCRIPTION
Closes #20229.

However, I noticed this displays `Team 0` instead of `No Team` now. I don't understand fluent well enough to see right away what the problem is here, maybe @Mailaender can give some insight. EDIT: See https://github.com/OpenRA/OpenRA/pull/20230#issuecomment-1230165304.