### PR TITLE
Fix shroud selector dropdown

### DIFF
--- a/mods/ra/chrome.yaml
+++ b/mods/ra/chrome.yaml
@@ -281,10 +281,13 @@ observer-scrollpanel-button-disabled:
 	Inherits: ^Dialog
 	PanelRegion: 769, 385, 2, 2, 122, 122, 2, 2
 
-observer-scrollheader-selected:
+observer-scrollheader:
 	Inherits: observer-scrollpanel-button-disabled
 
-observer-scrollitem-selected:
+observer-scrollheader-highlighted:
+	Inherits: observer-scrollpanel-button-disabled
+
+observer-scrollitem-highlighted:
 	Inherits: observer-scrollpanel-button-pressed
 
 observer-scrollitem-hover:


### PR DESCRIPTION
fixes
![grafik](https://user-images.githubusercontent.com/37534529/187203264-368956e2-1051-4336-b810-16934ec93128.png)

`common` was using custom scroll headers that weren't updated in #20218
