### PR TITLE
Fix Fog color on Radar.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -257,7 +257,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var cv = currentPlayer.Shroud.GetVisibility(puv);
 			if (cv == Shroud.CellVisibility.Hidden)
 				color = ColorShroud;
-			else if (cv.HasFlag(Shroud.CellVisibility.Visible))
+			else if (!cv.HasFlag(Shroud.CellVisibility.Visible))
 				color = ColorFog;
 
 			var stride = radarSheet.Size.Width;


### PR DESCRIPTION
Fixes a regression from #19599. I noticed while engine updating RV, the colors for visible and under FoW areas were reversed. An easy fix so decided to just make a PR with the fix.