### PR TITLE
Fix MapCache mapUpdates 

### DIFF
--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -131,7 +131,7 @@ namespace OpenRA
 						{
 							LastModifiedMap = uid;
 							if (oldMap != null)
-								mapUpdates.Add(oldMap, uid);
+								mapUpdates[oldMap] = uid;
 						}
 					}
 				}


### PR DESCRIPTION
We didn't handle repeating entries to `mapUpdates` dictionary, so when repeated entries came it crashed in try catch and broke everything that relied on `GetUpdatedMap`

steps to reproduce the crash

- edit a map
- trigger a MapCache update
- do another edit
- trigger a MapCache update
- revert the last edit
- trigger a MapCache update
- crash message in terminal