### PR TITLE
Move game speed lobby dropdown before time limit dropdown

### DIFF
--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -202,7 +202,7 @@ World:
 	MapOptions:
 		ShortGameCheckboxDisplayOrder: 2
 		TechLevelDropdownDisplayOrder: 2
-		GameSpeedDropdownDisplayOrder: 3
+		GameSpeedDropdownDisplayOrder: 1
 	MapStartingLocations:
 		SeparateTeamSpawnsCheckboxDisplayOrder: 6
 	CreateMapPlayers:
@@ -248,7 +248,6 @@ World:
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e1,e1,e2,e2,e2,e3,e3,apc,mtnk
 	SpawnStartingUnits:
-		DropdownDisplayOrder: 0
 	CrateSpawner:
 		Minimum: 1
 		Maximum: 6
@@ -267,6 +266,7 @@ World:
 	ScriptTriggers:
 	CellTriggerOverlay:
 	TimeLimitManager:
+		TimeLimitDisplayOrder: 2
 	ColorPickerManager:
 		PreviewActor: fact.colorpicker
 		PresetHues: 0, 0.125, 0.185, 0.4, 0.54, 0.66, 0.79, 0.875, 0, 0.14, 0.23, 0.43, 0.54, 0.625, 0.77, 0.85

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -167,7 +167,7 @@ World:
 	MapOptions:
 		ShortGameCheckboxDisplayOrder: 2
 		TechLevelDropdownDisplayOrder: 2
-		GameSpeedDropdownDisplayOrder: 3
+		GameSpeedDropdownDisplayOrder: 1
 	CreateMapPlayers:
 	MapStartingLocations:
 		SeparateTeamSpawnsCheckboxDisplayOrder: 6
@@ -225,7 +225,6 @@ World:
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
 	SpawnStartingUnits:
-		DropdownDisplayOrder: 1
 	PathFinder:
 	ValidateOrder:
 	DebugPauseState:
@@ -238,6 +237,7 @@ World:
 	CellTriggerOverlay:
 	StartGameNotification:
 	TimeLimitManager:
+		TimeLimitDisplayOrder: 2
 	ColorPickerManager:
 		PreviewActor: carryall.colorpicker
 		PresetHues: 0, 0.13, 0.18, 0.3, 0.475, 0.625, 0.82, 0.89, 0.97, 0.05, 0.23, 0.375, 0.525, 0.6, 0.75, 0.85

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -224,7 +224,7 @@ World:
 	MapOptions:
 		ShortGameCheckboxDisplayOrder: 2
 		TechLevelDropdownDisplayOrder: 2
-		GameSpeedDropdownDisplayOrder: 3
+		GameSpeedDropdownDisplayOrder: 1
 	CreateMapPlayers:
 	StartingUnits@mcvonly:
 		Class: none
@@ -266,7 +266,6 @@ World:
 	MapStartingLocations:
 		SeparateTeamSpawnsCheckboxDisplayOrder: 6
 	SpawnStartingUnits:
-		DropdownDisplayOrder: 1
 	PathFinder:
 	ValidateOrder:
 	DebugPauseState:
@@ -278,6 +277,7 @@ World:
 	ScriptTriggers:
 	CellTriggerOverlay:
 	TimeLimitManager:
+		TimeLimitDisplayOrder: 2
 		TimeLimitWarnings:
 			40: FourtyMinutesRemaining
 			30: ThirtyMinutesRemaining

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -303,7 +303,7 @@ World:
 	MapOptions:
 		ShortGameCheckboxDisplayOrder: 2
 		TechLevelDropdownDisplayOrder: 2
-		GameSpeedDropdownDisplayOrder: 3
+		GameSpeedDropdownDisplayOrder: 1
 	CreateMapPlayers:
 	StartingUnits@MCV:
 		Class: none
@@ -361,7 +361,6 @@ World:
 	MapStartingLocations:
 		SeparateTeamSpawnsCheckboxDisplayOrder: 6
 	SpawnStartingUnits:
-		DropdownDisplayOrder: 1
 	CrateSpawner:
 		Minimum: 1
 		Maximum: 6
@@ -383,6 +382,7 @@ World:
 	ScriptTriggers:
 	CellTriggerOverlay:
 	TimeLimitManager:
+		TimeLimitDisplayOrder: 2
 	ColorPickerManager:
 		PreviewActor: harv.colorpicker
 		FactionPreviewActors:


### PR DESCRIPTION
Game speed is the more frequently changed option and with the current layout it was buried below the fold.

Before this PR:
![Screenshot from 2022-09-01 10-05-53](https://user-images.githubusercontent.com/1355810/187853505-0c481bff-c42f-4327-aa20-2f131fd76535.png)

After this PR:
![Screenshot from 2022-09-01 10-03-41](https://user-images.githubusercontent.com/1355810/187853531-d6d348df-744f-4719-81d2-5fdce21c7591.png)

