### PR TITLE
ShroudRenderer, fix, render Shroud if fog disabled.

### DIFF
--- a/OpenRA.Game/Traits/Player/Shroud.cs
+++ b/OpenRA.Game/Traits/Player/Shroud.cs
@@ -441,7 +441,7 @@ namespace OpenRA.Traits
 
 			if (Disabled)
 			{
-				if (FogEnabled)
+				if (fogEnabled)
 				{
 					// Shroud disabled, Fog enabled
 					if (resolvedType.Contains(puv))
@@ -457,7 +457,7 @@ namespace OpenRA.Traits
 			}
 			else
 			{
-				if (FogEnabled)
+				if (fogEnabled)
 				{
 					// Shroud and Fog enabled
 					if (resolvedType.Contains(puv))

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -280,7 +280,7 @@ namespace OpenRA.Mods.Common.Traits
 			var cv = cellVisibility(puv);
 
 			// If a cell is covered by shroud, then all neigbhors are covered by shroud and fog.
-			if (cv == Shroud.CellVisibility.Hidden)
+			if (!cv.HasFlag(Shroud.CellVisibility.Explored))
 				return notVisibleEdgesPair;
 
 			var ncv = GetNeighborsVisbility(puv);
@@ -288,7 +288,7 @@ namespace OpenRA.Mods.Common.Traits
 			// If a cell is covered by fog, then all neigbhors are as well.
 			var edgesFog = cv.HasFlag(Shroud.CellVisibility.Visible) ? GetEdges(ncv, Shroud.CellVisibility.Visible) : notVisibleEdgesPair.Item2;
 
-			var edgesShroud = GetEdges(ncv, Shroud.CellVisibility.Explored | Shroud.CellVisibility.Visible);
+			var edgesShroud = GetEdges(ncv, Shroud.CellVisibility.Explored);
 			return (edgesShroud, edgesFog);
 		}
 

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -255,7 +255,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			var color = 0;
 			var cv = currentPlayer.Shroud.GetVisibility(puv);
-			if (cv == Shroud.CellVisibility.Hidden)
+			if (!cv.HasFlag(Shroud.CellVisibility.Explored))
 				color = ColorShroud;
 			else if (!cv.HasFlag(Shroud.CellVisibility.Visible))
 				color = ColorFog;


### PR DESCRIPTION

Closes #20243. 

- Fix: only check for (visible under) Explored not both Visible or Explored. 
- Fix: shroud covered == not explored, visible may still be true when fog is disabled
- Optimization: fogEnabled over FogEnabled


