### PR TITLE
Fix handling of empty values on documentation generation

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Buildings/ClonesProducedUnits.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ClonesProducedUnits.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		[FieldLoader.Require]
 		[Desc("e.g. Infantry, Vehicles, Aircraft, Buildings")]
-		public readonly string ProductionType = "";
+		public readonly string ProductionType = null;
 
 		public override object Create(ActorInitializer init) { return new ClonesProducedUnits(init, this); }
 	}

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		[FieldLoader.Require]
 		[Desc("Actual footprint. Cells marked as x will be affected.")]
-		public readonly string Footprint = string.Empty;
+		public readonly string Footprint = null;
 
 		[Desc("Ticks until returning after teleportation.")]
 		public readonly int Duration = 750;

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[FieldLoader.Require]
 		[Desc("Actual footprint. Cells marked as x will be affected.")]
-		public readonly string Footprint = string.Empty;
+		public readonly string Footprint = null;
 
 		[Desc("Sound to instantly play at the targeted area.")]
 		public readonly string OnFireSound = null;

--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		[WeaponReference]
 		[FieldLoader.Require]
 		[Desc("Weapon to use for the impact.")]
-		public readonly string MissileWeapon = "";
+		public readonly string MissileWeapon = null;
 
 		[Desc("Delay (in ticks) after launch until the missile is spawned.")]
 		public readonly int MissileDelay = 0;

--- a/OpenRA.Mods.Common/Traits/World/TerrainTunnel.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainTunnel.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[FieldLoader.Require]
 		[Desc("Tunnel footprint.", "_ is passable, x is blocked, and o are tunnel portals.")]
-		public readonly string Footprint = string.Empty;
+		public readonly string Footprint = null;
 
 		[FieldLoader.Require]
 		[Desc("Terrain type of the tunnel floor.")]

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractWeaponDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractWeaponDocsCommand.cs
@@ -62,31 +62,42 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						.Where(y => y != type.Name && y != $"{type.Name}Info" && y != "Object"),
 					Properties = FieldLoader.GetTypeLoadInfo(type)
 						.Where(fi => fi.Field.IsPublic && fi.Field.IsInitOnly && !fi.Field.IsStatic)
-						.Select(fi => new
+						.Select(fi =>
 						{
-							PropertyName = fi.YamlName,
-							DefaultValue = FieldSaver.SaveField(objectCreator.CreateBasic(type), fi.Field.Name).Value.Value,
-							InternalType = Util.InternalTypeName(fi.Field.FieldType),
-							UserFriendlyType = Util.FriendlyTypeName(fi.Field.FieldType),
-							Description = string.Join(" ", fi.Field.GetCustomAttributes<DescAttribute>(true).SelectMany(d => d.Lines)),
-							OtherAttributes = fi.Field.CustomAttributes
-								.Where(a => a.AttributeType.Name != nameof(DescAttribute) && a.AttributeType.Name != nameof(FieldLoader.LoadUsingAttribute))
-								.Select(a =>
-								{
-									var name = a.AttributeType.Name;
-									name = name.EndsWith("Attribute") ? name.Substring(0, name.Length - 9) : name;
+							var typeInstance = objectCreator.CreateBasic(type);
+							var defaultValue = FieldSaver.SaveField(typeInstance, fi.Field.Name).Value.Value;
 
-									return new
+							// HACK: FieldSaver always produces an empty string if there is no value, but it can be important to distinguish between "" and null.
+							// If the field is a string we need to make sure what the value is. If not, then the value can only be null.
+							if (string.IsNullOrWhiteSpace(defaultValue))
+								defaultValue = fi.Field.FieldType == typeof(string) ? fi.Field.GetValue(typeInstance)?.ToString() : null;
+
+							return new
+							{
+								PropertyName = fi.YamlName,
+								DefaultValue = defaultValue,
+								InternalType = Util.InternalTypeName(fi.Field.FieldType),
+								UserFriendlyType = Util.FriendlyTypeName(fi.Field.FieldType),
+								Description = string.Join(" ", fi.Field.GetCustomAttributes<DescAttribute>(true).SelectMany(d => d.Lines)),
+								OtherAttributes = fi.Field.CustomAttributes
+									.Where(a => a.AttributeType.Name != nameof(DescAttribute) && a.AttributeType.Name != nameof(FieldLoader.LoadUsingAttribute))
+									.Select(a =>
 									{
-										Name = name,
-										Parameters = a.Constructor.GetParameters()
-											.Select(pi => new
-											{
-												pi.Name,
-												Value = Util.GetAttributeParameterValue(a.ConstructorArguments[pi.Position])
-											})
-									};
-								})
+										var name = a.AttributeType.Name;
+										name = name.EndsWith("Attribute") ? name.Substring(0, name.Length - 9) : name;
+
+										return new
+										{
+											Name = name,
+											Parameters = a.Constructor.GetParameters()
+												.Select(pi => new
+												{
+													pi.Name,
+													Value = Util.GetAttributeParameterValue(a.ConstructorArguments[pi.Position])
+												})
+										};
+									})
+							};
 						})
 				});
 

--- a/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Warheads
 		[FieldLoader.Require]
 		[Desc("Cluster footprint. Cells marked as X will be attacked.",
 			"Cells marked as x will be attacked randomly until RandomClusterCount is reached.")]
-		public readonly string Footprint = string.Empty;
+		public readonly string Footprint = null;
 
 		WeaponInfo weapon;
 

--- a/packaging/format-docs.py
+++ b/packaging/format-docs.py
@@ -83,7 +83,7 @@ def format_docs(version, collectionName, types):
 
                         print(f'| {prop["PropertyName"]} | {defaultValue} | {prop["UserFriendlyType"]} | {prop["Description"]} |')
                     else:
-                        print(f'| {prop["PropertyName"]} | {prop["DefaultValue"]} | {prop["UserFriendlyType"]} | {prop["Description"]} |')
+                        print(f'| {prop["PropertyName"]} | {prop["DefaultValue"] or ""} | {prop["UserFriendlyType"]} | {prop["Description"]} |')
 
 if __name__ == "__main__":
     input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8-sig')


### PR DESCRIPTION
I noticed something we missed in #19948 - we never had `null` as a default value for a trait or a weapon field. The reason being how `FieldSaver.SaveField()` works.
Since the distinction between an empty string and `null` can be important for consumers of the documentation, I added a quick "hack" to fix it. Also no values, including empty strings, make sense on fields with `FieldLoader.RequireAttribute`, so I changed those to `null`. No update rules needed either.

I suggest reviewing with whitespace changes hidden - https://github.com/OpenRA/OpenRA/pull/20250/files?w=1