### PR TITLE
Consider AutoTarget ScanRadius when attack moving

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
+++ b/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				// Use the standard ScanForTarget rate limit while we are running the move activity to save performance.
 				// Override the rate limit if our attack activity has completed so we can immediately acquire a new target instead of moving.
-				target = autoTarget.ScanForTarget(self, false, true, !runningMoveActivity);
+				target = autoTarget.ScanForTarget(self, autoTarget.AllowMove, true, !runningMoveActivity);
 
 				// Cancel the current move activity and queue attack activities if we find a new target.
 				if (target.Type != TargetType.Invalid)
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Activities
 					ChildActivity?.Cancel(self);
 
 					foreach (var ab in autoTarget.ActiveAttackBases)
-						QueueChild(ab.GetAttackActivity(self, AttackSource.AttackMove, target, false, false));
+						QueueChild(ab.GetAttackActivity(self, AttackSource.AttackMove, target, autoTarget.AllowMove, false));
 				}
 
 				// Continue with the move activity (or queue a new one) when there are no targets.

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -136,6 +136,7 @@ namespace OpenRA.Mods.Common.Traits
 		int nextScanTime = 0;
 
 		public UnitStance Stance { get; private set; }
+		public bool AllowMove => allowMovement && Stance > UnitStance.Defend;
 
 		[Sync]
 		public Actor Aggressor;
@@ -240,8 +241,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// Don't fire at an invisible enemy when we can't move to reveal it
-			var allowMove = allowMovement && Stance > UnitStance.Defend;
-			if (!allowMove && !attacker.CanBeViewedByPlayer(self.Owner))
+			if (!AllowMove && !attacker.CanBeViewedByPlayer(self.Owner))
 				return;
 
 			// Not a lot we can do about things we can't hurt... although maybe we should automatically run away?
@@ -256,7 +256,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Respect AutoAttack priorities.
 			if (Stance > UnitStance.ReturnFire)
 			{
-				var autoTarget = ScanForTarget(self, allowMove, true);
+				var autoTarget = ScanForTarget(self, AllowMove, true);
 
 				if (autoTarget != Target.Invalid)
 					attacker = autoTarget.Actor;
@@ -264,7 +264,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			Aggressor = attacker;
 
-			Attack(Target.FromActor(Aggressor), allowMove);
+			Attack(Target.FromActor(Aggressor), AllowMove);
 		}
 
 		void INotifyIdle.TickIdle(Actor self)
@@ -272,9 +272,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (IsTraitDisabled || !Info.ScanOnIdle || Stance < UnitStance.Defend)
 				return;
 
-			var allowMove = allowMovement && Stance > UnitStance.Defend;
 			var allowTurn = Info.AllowTurning && Stance > UnitStance.HoldFire;
-			ScanAndAttack(self, allowMove, allowTurn);
+			ScanAndAttack(self, AllowMove, allowTurn);
 		}
 
 		void ITick.Tick(Actor self)


### PR DESCRIPTION
closes #17503

After 4 years melee units will be able to attack move again

This PR basically reverts #16942 for units on AttackAnything stance