### PR TITLE
GpsDotEffect, ShouldRender, optimization.

### DIFF
--- a/OpenRA.Game/Traits/Player/Shroud.cs
+++ b/OpenRA.Game/Traits/Player/Shroud.cs
@@ -434,6 +434,11 @@ namespace OpenRA.Traits
 			return explored.Contains(uv);
 		}
 
+		public CellVisibility GetVisibility(WPos pos)
+		{
+			return GetVisibility(map.ProjectedCellCovering(pos));
+		}
+
 		// PERF: Combine IsExplored and IsVisible.
 		public CellVisibility GetVisibility(PPos puv)
 		{

--- a/OpenRA.Mods.Cnc/Traits/GpsWatcher.cs
+++ b/OpenRA.Mods.Cnc/Traits/GpsWatcher.cs
@@ -85,8 +85,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			Granted = actors.Count > 0 && Launched;
 			GrantedAllies = allyWatchers.Any(w => w.Trait.Granted);
 
-			var allyLaunched = allyWatchers.Any(w => w.Trait.Launched);
-			if ((Launched || allyLaunched) && !explored)
+			if (!explored && (Launched || allyWatchers.Any(w => w.Trait.Launched)))
 			{
 				explored = true;
 				owner.Shroud.ExploreAll();


### PR DESCRIPTION


- change order of checks, assuming the visiblity modifiers may do the more heavy calculations to determine if visible
- get Shroud.GetVisibility
- and also avoid a double WPos to PPos conversion
- fix, do not do a double check on isExplored

first time i realize that gps dots are not on the radar, only displayed on map.

Updating this for each player each effect tick seems expensive. But I assume that since the effective owner can change anytime this is needed. 

Side note. You see a lot of the same code that gets the owner of an actor, either effective or actual. Perhaps introduce Actor.GetOwner(bool effective) that will return the effective owner if set.
