### PR TITLE
Fixed untranslated strings in skirmish objectives

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -79,8 +79,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					checkbox.GetText = () => mo.Objectives.First().Description;
 				}
 
-				statusLabel.GetText = () => player.WinState == WinState.Won ? Accomplished :
-					player.WinState == WinState.Lost ? Failed : InProgress;
+				var failed = modData.Translation.GetString(Failed);
+				var inProgress = modData.Translation.GetString(InProgress);
+				var accomplished = modData.Translation.GetString(Accomplished);
+				statusLabel.GetText = () => player.WinState == WinState.Won ? accomplished :
+					player.WinState == WinState.Lost ? failed : inProgress;
 				statusLabel.GetColor = () => player.WinState == WinState.Won ? Color.LimeGreen :
 					player.WinState == WinState.Lost ? Color.Red : Color.White;
 			}


### PR DESCRIPTION
As reported in https://discord.com/channels/153649279762694144/388282819371204608/1016726659413590046 by @MustaphaTR.