### PR TITLE
Disallow Join button without IP address input

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/DirectConnectLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/DirectConnectLogic.cs
@@ -39,7 +39,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				portField.Text = text.Substring(last + 1);
 			}
 
-			panel.Get<ButtonWidget>("JOIN_BUTTON").OnClick = () =>
+			var joinButton = panel.Get<ButtonWidget>("JOIN_BUTTON");
+
+			joinButton.IsDisabled = () => string.IsNullOrEmpty(ipField.Text);
+
+			joinButton.OnClick = () =>
 			{
 				var port = Exts.WithDefault(1234, () => Exts.ParseIntegerInvariant(portField.Text));
 


### PR DESCRIPTION
Closes #20234

Trying to join a server with an empty address crashes the game.  This fix disallows pressing join button without ip address field input.