### PR TITLE
Disallow saving game with an empty name field

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -112,6 +112,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				}
 
 				var saveButton = panel.Get<ButtonWidget>("SAVE_BUTTON");
+				saveButton.IsDisabled = () => string.IsNullOrWhiteSpace(saveTextField.Text);
 				saveButton.OnClick = () => { Save(world); };
 				saveButton.IsVisible = () => true;
 


### PR DESCRIPTION
Fixes #20233

Disallow game save with empty name field by disabling save button until text input is present.