### PR TITLE
Disallowed Save Map without Title and Author Input

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -160,6 +160,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var filename = widget.Get<TextFieldWidget>("FILENAME");
 			filename.Text = map.Package == null ? "" : mapIsUnpacked ? Path.GetFileName(map.Package.Name) : Path.GetFileNameWithoutExtension(map.Package.Name);
+			if (string.IsNullOrEmpty(filename.Text))
+				filename.TakeKeyboardFocus();
+
 			var fileType = mapIsUnpacked ? MapFileType.Unpacked : MapFileType.OraMap;
 
 			var fileTypes = new Dictionary<MapFileType, MapFileTypeInfo>()
@@ -231,11 +234,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			var save = widget.Get<ButtonWidget>("SAVE_BUTTON");
+			save.IsDisabled = () => string.IsNullOrWhiteSpace(filename.Text) || string.IsNullOrWhiteSpace(title.Text) || string.IsNullOrWhiteSpace(author.Text);
+
 			save.OnClick = () =>
 			{
-				if (string.IsNullOrEmpty(filename.Text))
-					return;
-
 				var combinedPath = Platform.ResolvePath(Path.Combine(selectedDirectory.Folder.Name, filename.Text + fileTypes[fileType].Extension));
 
 				if (map.Package?.Name != combinedPath)


### PR DESCRIPTION
Fixes #20236

When trying to save a map it is possible to do so without specifying a Title or Author. Previously, the only enforced requirement was a filename, which has been expanded to enforce both a title and author be entered prior to saving the map.

Apologies to PunkPun and abcdefg30 - I had to resubmit this to keep branches in order (I'm a newbie).  I incorporated abcdefg30's changes to not include white space as well.