### PR TITLE
Allow checking if calling "Capture" would succeed

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/CaptureProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CaptureProperties.cs
@@ -37,8 +37,6 @@ namespace OpenRA.Mods.Common.Scripting
 				return false;
 			}
 
-			// throw new LuaException("Actor '{0}' cannot capture actor '{1}'!".F(Self, target));
-
 			// NB: Scripted actions get no visible targetlines.
 			Self.QueueActivity(new CaptureActor(Self, Target.FromActor(target), null));
 			return true;

--- a/OpenRA.Mods.Common/Scripting/Properties/CaptureProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CaptureProperties.cs
@@ -31,18 +31,19 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Captures the target actor.")]
 		public bool Capture(Actor target)
 		{
-			var targetManager = target.TraitOrDefault<CaptureManager>();
-			if (targetManager == null || !targetManager.CanBeTargetedBy(target, Self, captureManager))
+			if (!CanCapture(target))
 			{
-				Console.WriteLine($"Actor '{Self}' cannot capture actor '{target}'!");
+				Log.Write("lua", "Actor '{0}' cannot capture actor '{1}'!", Self, target);
 				return false;
 			}
+
+			// throw new LuaException("Actor '{0}' cannot capture actor '{1}'!".F(Self, target));
 
 			// NB: Scripted actions get no visible targetlines.
 			Self.QueueActivity(new CaptureActor(Self, Target.FromActor(target), null));
 			return true;
 		}
-		
+
 		[Desc("Checks if the target actor can be catured.")]
 		public bool CanCapture(Actor target)
 		{

--- a/OpenRA.Mods.Common/Scripting/Properties/CaptureProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CaptureProperties.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using Eluant;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Scripting;

--- a/OpenRA.Mods.Common/Scripting/Properties/CaptureProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CaptureProperties.cs
@@ -29,14 +29,25 @@ namespace OpenRA.Mods.Common.Scripting
 		}
 
 		[Desc("Captures the target actor.")]
-		public void Capture(Actor target)
+		public bool Capture(Actor target)
 		{
 			var targetManager = target.TraitOrDefault<CaptureManager>();
 			if (targetManager == null || !targetManager.CanBeTargetedBy(target, Self, captureManager))
-				throw new LuaException($"Actor '{Self}' cannot capture actor '{target}'!");
+			{
+				Console.WriteLine($"Actor '{Self}' cannot capture actor '{target}'!");
+				return false;
+			}
 
 			// NB: Scripted actions get no visible targetlines.
 			Self.QueueActivity(new CaptureActor(Self, Target.FromActor(target), null));
+			return true;
+		}
+		
+		[Desc("Checks if the target actor can be catured.")]
+		public bool CanCapture(Actor target)
+		{
+			var targetManager = target.TraitOrDefault<CaptureManager>();
+			return targetManager != null && targetManager.CanBeTargetedBy(target, Self, captureManager);
 		}
 	}
 }


### PR DESCRIPTION
Currently calling `engineer.Capture(target)` will cause lua to throw an exception when a building is a state between "selling" or transforming to from an MCV to ConYard.
There is nothing critical about having capture fail. So it should return a boolean letting the user know that the requested succeeded or not and don't throw an exception.

Also it since this is something that could fail, we should expose a functionality to just check if the action is even possible.

