### PR TITLE
DeveloperMode, cache trait.

### DIFF
--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -61,6 +61,7 @@ namespace OpenRA
 		public readonly string BotType;
 		public readonly Shroud Shroud;
 		public readonly FrozenActorLayer FrozenActorLayer;
+		public readonly IDeveloperMode DeveloperMode;
 
 		/// <summary>The faction (including Random, etc.) that was selected in the lobby.</summary>
 		public readonly FactionInfo DisplayFaction;
@@ -210,6 +211,7 @@ namespace OpenRA
 
 			Shroud = PlayerActor.Trait<Shroud>();
 			FrozenActorLayer = PlayerActor.TraitOrDefault<FrozenActorLayer>();
+			DeveloperMode = PlayerActor.Trait<IDeveloperMode>();
 
 			// Enable the bot logic on the host
 			if (IsBot && Game.IsHost)

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -603,4 +603,16 @@ namespace OpenRA.Traits
 	{
 		void PlayerDisconnected(Actor self, Player p);
 	}
+
+	public interface IDeveloperMode
+	{
+		bool Enabled { get; }
+		bool FastCharge { get; }
+		bool AllTech { get; }
+		bool FastBuild { get; }
+		bool DisableShroud { get; }
+		bool PathDebug { get; }
+		bool UnlimitedPower { get; }
+		bool BuildAnywhere { get; }
+	}
 }

--- a/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Commands
 		};
 
 		DebugVisualizations debugVis;
-		DeveloperMode devMode;
+		IDeveloperMode devMode;
 
 		public void WorldLoaded(World w, WorldRenderer wr)
 		{
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Commands
 			debugVis = world.WorldActor.TraitOrDefault<DebugVisualizations>();
 
 			if (world.LocalPlayer != null)
-				devMode = world.LocalPlayer.PlayerActor.Trait<DeveloperMode>();
+				devMode = world.LocalPlayer.DeveloperMode;
 
 			if (debugVis == null)
 				return;
@@ -59,28 +59,28 @@ namespace OpenRA.Mods.Common.Commands
 			}
 		}
 
-		static void CombatGeometry(DebugVisualizations debugVis, DeveloperMode devMode)
+		static void CombatGeometry(DebugVisualizations debugVis, IDeveloperMode devMode)
 		{
 			debugVis.CombatGeometry ^= true;
 		}
 
-		static void RenderGeometry(DebugVisualizations debugVis, DeveloperMode devMode)
+		static void RenderGeometry(DebugVisualizations debugVis, IDeveloperMode devMode)
 		{
 			debugVis.RenderGeometry ^= true;
 		}
 
-		static void ScreenMap(DebugVisualizations debugVis, DeveloperMode devMode)
+		static void ScreenMap(DebugVisualizations debugVis, IDeveloperMode devMode)
 		{
 			if (devMode == null || devMode.Enabled)
 				debugVis.ScreenMap ^= true;
 		}
 
-		static void DepthBuffer(DebugVisualizations debugVis, DeveloperMode devMode)
+		static void DepthBuffer(DebugVisualizations debugVis, IDeveloperMode devMode)
 		{
 			debugVis.DepthBuffer ^= true;
 		}
 
-		static void ActorTags(DebugVisualizations debugVis, DeveloperMode devMode)
+		static void ActorTags(DebugVisualizations debugVis, IDeveloperMode devMode)
 		{
 			debugVis.ActorTags ^= true;
 		}
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Commands
 		public void InvokeCommand(string name, string arg)
 		{
 			if (commandHandlers.TryGetValue(name, out var command))
-				command.Handler(debugVis, devMode);
+				command.Handler(debugVis, (DeveloperMode)devMode);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Commands
 			world = w;
 
 			if (world.LocalPlayer != null)
-				developerMode = world.LocalPlayer.PlayerActor.Trait<DeveloperMode>();
+				developerMode = (DeveloperMode)world.LocalPlayer.DeveloperMode;
 
 			var console = world.WorldActor.Trait<ChatCommands>();
 			var help = world.WorldActor.Trait<HelpCommand>();

--- a/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class BaseProvider : PausableConditionalTrait<BaseProviderInfo>, ITick, IRenderAnnotationsWhenSelected, ISelectionBar
 	{
-		readonly DeveloperMode devMode;
+		readonly IDeveloperMode devMode;
 		readonly Actor self;
 		readonly bool allyBuildEnabled;
 		readonly bool buildRadiusEnabled;
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 			: base(info)
 		{
 			this.self = self;
-			devMode = self.Owner.PlayerActor.Trait<DeveloperMode>();
+			devMode = self.Owner.DeveloperMode;
 			progress = total = info.InitialDelay;
 			var mapBuildRadius = self.World.WorldActor.TraitOrDefault<MapBuildRadius>();
 			allyBuildEnabled = mapBuildRadius != null && mapBuildRadius.AllyBuildRadiusEnabled;

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -205,7 +205,7 @@ namespace OpenRA.Mods.Common.Traits
 			var requiresBuildableArea = ai.TraitInfoOrDefault<RequiresBuildableAreaInfo>();
 			var mapBuildRadius = world.WorldActor.TraitOrDefault<MapBuildRadius>();
 
-			if (requiresBuildableArea == null || p.PlayerActor.Trait<DeveloperMode>().BuildAnywhere)
+			if (requiresBuildableArea == null || p.DeveloperMode.BuildAnywhere)
 				return true;
 
 			if (mapBuildRadius != null && mapBuildRadius.BuildRadiusEnabled && RequiresBaseProvider && FindBaseProvider(world, p, topLeft) == null)

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -133,7 +133,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (order.OrderString == "DevLevelUp")
 			{
-				var developerMode = self.Owner.PlayerActor.Trait<DeveloperMode>();
+				var developerMode = self.Owner.DeveloperMode;
 				if (!developerMode.Enabled)
 					return;
 

--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new DeveloperMode(this); }
 	}
 
-	public class DeveloperMode : IResolveOrder, ISync, INotifyCreated, IUnlocksRenderPlayer
+	public class DeveloperMode : IDeveloperMode, IResolveOrder, ISync, INotifyCreated, IUnlocksRenderPlayer
 	{
 		readonly DeveloperModeInfo info;
 		public bool Enabled { get; private set; }

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -139,7 +139,7 @@ namespace OpenRA.Mods.Common.Traits
 		// Will change if the owner changes
 		PowerManager playerPower;
 		protected PlayerResources playerResources;
-		protected DeveloperMode developerMode;
+		protected IDeveloperMode developerMode;
 		protected TechTree techTree;
 
 		public Actor Actor => self;
@@ -169,7 +169,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			playerPower = self.Owner.PlayerActor.TraitOrDefault<PowerManager>();
 			playerResources = self.Owner.PlayerActor.Trait<PlayerResources>();
-			developerMode = self.Owner.PlayerActor.Trait<DeveloperMode>();
+			developerMode = self.Owner.DeveloperMode;
 			techTree = self.Owner.PlayerActor.Trait<TechTree>();
 
 			productionTraits = self.TraitsImplementing<Production>().Where(p => p.Info.Produces.Contains(Info.Type)).ToArray();
@@ -190,7 +190,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			playerPower = newOwner.PlayerActor.TraitOrDefault<PowerManager>();
 			playerResources = newOwner.PlayerActor.Trait<PlayerResources>();
-			developerMode = newOwner.PlayerActor.Trait<DeveloperMode>();
+			developerMode = newOwner.DeveloperMode;
 			techTree = newOwner.PlayerActor.Trait<TechTree>();
 
 			if (!Info.Sticky)

--- a/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly Actor self;
 		readonly PowerManagerInfo info;
-		readonly DeveloperMode devMode;
+		readonly IDeveloperMode devMode;
 
 		readonly Dictionary<Actor, int> powerDrain = new Dictionary<Actor, int>();
 
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.self = self;
 			this.info = info;
 
-			devMode = self.Trait<DeveloperMode>();
+			devMode = self.Trait<IDeveloperMode>();
 			wasHackEnabled = devMode.UnlimitedPower;
 		}
 

--- a/OpenRA.Mods.Common/Traits/PowerTooltip.cs
+++ b/OpenRA.Mods.Common/Traits/PowerTooltip.cs
@@ -23,13 +23,13 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly Actor self;
 		PowerManager powerManager;
-		DeveloperMode developerMode;
+		IDeveloperMode developerMode;
 
 		public PowerTooltip(Actor self)
 		{
 			this.self = self;
 			powerManager = self.Owner.PlayerActor.Trait<PowerManager>();
-			developerMode = self.Owner.PlayerActor.Trait<DeveloperMode>();
+			developerMode = self.Owner.DeveloperMode;
 		}
 
 		public bool IsTooltipVisible(Player forPlayer)
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			powerManager = newOwner.PlayerActor.Trait<PowerManager>();
-			developerMode = newOwner.PlayerActor.Trait<DeveloperMode>();
+			developerMode = newOwner.DeveloperMode;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -30,14 +30,14 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly Actor Self;
 		public readonly Dictionary<string, SupportPowerInstance> Powers = new Dictionary<string, SupportPowerInstance>();
 
-		public readonly DeveloperMode DevMode;
+		public readonly IDeveloperMode DevMode;
 		public readonly TechTree TechTree;
 		public readonly Lazy<RadarPings> RadarPings;
 
 		public SupportPowerManager(ActorInitializer init)
 		{
 			Self = init.Self;
-			DevMode = Self.Trait<DeveloperMode>();
+			DevMode = Self.Trait<IDeveloperMode>();
 			TechTree = Self.Trait<TechTree>();
 			RadarPings = Exts.Lazy(() => init.World.WorldActor.TraitOrDefault<RadarPings>());
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/DebugMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/DebugMenuLogic.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[ObjectCreator.UseCtor]
 		public DebugMenuLogic(Widget widget, World world)
 		{
-			var devTrait = world.LocalPlayer.PlayerActor.Trait<DeveloperMode>();
+			var devTrait = world.LocalPlayer.DeveloperMode;
 			var debugVis = world.WorldActor.TraitOrDefault<DebugVisualizations>();
 
 			var visibilityCheckbox = widget.GetOrNull<CheckboxWidget>("DISABLE_VISIBILITY_CHECKS");

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameRadarDisplayLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameRadarDisplayLogic.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Linq;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Radar;
 using OpenRA.Primitives;
 using OpenRA.Widgets;
@@ -27,7 +26,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var blockColor = Color.Transparent;
 			var radar = widget.Get<RadarWidget>("RADAR_MINIMAP");
 			radar.IsEnabled = () => radarEnabled;
-			var devMode = world.LocalPlayer.PlayerActor.Trait<DeveloperMode>();
+			var devMode = world.LocalPlayer.DeveloperMode;
 
 			var ticker = widget.Get<LogicTickerWidget>("RADAR_TICKER");
 			ticker.OnTick = () =>


### PR DESCRIPTION

Selection rendering. Avoid lookup of DeveloperMode trait each selection render.

Like `Shroud`, cache it on the player, not `PlayerActor`.

Assuming the trait dictionary has an entry for each player - it avoids searching for the trait in a list of player actors each render.