### PR TITLE
Added enum export to documentation generation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           ./utility.sh all --docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/playtest/traits.md"
           ./utility.sh all --weapon-docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/playtest/weapons.md"
-          ./utility.sh all --sequence-docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/playtest/sequences.md"
+          ./utility.sh all --sprite-sequence-docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/playtest/sprite-sequences.md"
           ./utility.sh all --lua-docs "${GIT_TAG}" > "docs/api/playtest/lua.md"
 
       - name: Update docs.openra.net (Release)
@@ -103,7 +103,7 @@ jobs:
         run: |
           ./utility.sh all --docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/release/traits.md"
           ./utility.sh all --weapon-docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/release/weapons.md"
-          ./utility.sh all --sequence-docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/release/sequences.md"
+          ./utility.sh all --sprite-sequence-docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/release/sprite-sequences.md"
           ./utility.sh all --lua-docs "${GIT_TAG}" > "docs/api/release/lua.md"
 
       - name: Push docs.openra.net

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -236,6 +236,9 @@ namespace OpenRA.Mods.Common
 
 		public static string FriendlyTypeName(Type t)
 		{
+			if (t.IsEnum)
+				return $"{t.Name} (enum)";
+
 			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(HashSet<>))
 				return $"Set of {t.GetGenericArguments().Select(FriendlyTypeName).First()}";
 

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractSequenceDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractSequenceDocsCommand.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				version = args[1];
 
 			var objectCreator = utility.ModData.ObjectCreator;
-			var spriteSequenceTypes = objectCreator.GetTypesImplementing<ISpriteSequence>().OrderBy(t => t.Namespace);
+			var spriteSequenceTypes = objectCreator.GetTypesImplementing<ISpriteSequence>().OrderBy(t => t.Namespace).ThenBy(t => t.Name);
 
 			var json = GenerateJson(version, spriteSequenceTypes);
 			Console.WriteLine(json);
@@ -91,7 +91,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						})
 				});
 
-			var relatedEnums = relatedEnumTypes.Select(type => new
+			var relatedEnums = relatedEnumTypes.OrderBy(t => t.Name).Select(type => new
 			{
 				type.Namespace,
 				type.Name,

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractSpriteSequenceDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractSpriteSequenceDocsCommand.cs
@@ -20,9 +20,9 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class ExtractSequenceDocsCommand : IUtilityCommand
+	class ExtractSpriteSequenceDocsCommand : IUtilityCommand
 	{
-		string IUtilityCommand.Name => "--sequence-docs";
+		string IUtilityCommand.Name => "--sprite-sequence-docs";
 
 		bool IUtilityCommand.ValidateArguments(string[] args)
 		{

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				version = args[1];
 
 			var objectCreator = utility.ModData.ObjectCreator;
-			var traitInfos = objectCreator.GetTypesImplementing<TraitInfo>().OrderBy(t => t.Namespace);
+			var traitInfos = objectCreator.GetTypesImplementing<TraitInfo>().OrderBy(t => t.Namespace).ThenBy(t => t.Name);
 
 			var json = GenerateJson(version, traitInfos, objectCreator);
 			Console.WriteLine(json);
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						})
 				});
 
-			var relatedEnums = relatedEnumTypes.Select(type => new
+			var relatedEnums = relatedEnumTypes.OrderBy(t => t.Name).Select(type => new
 			{
 				type.Namespace,
 				type.Name,

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractWeaponDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractWeaponDocsCommand.cs
@@ -40,8 +40,8 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			var objectCreator = utility.ModData.ObjectCreator;
 			var weaponInfo = new[] { typeof(WeaponInfo) };
-			var warheads = objectCreator.GetTypesImplementing<IWarhead>().OrderBy(t => t.Namespace);
-			var projectiles = objectCreator.GetTypesImplementing<IProjectileInfo>().OrderBy(t => t.Namespace);
+			var warheads = objectCreator.GetTypesImplementing<IWarhead>().OrderBy(t => t.Namespace).ThenBy(t => t.Name);
+			var projectiles = objectCreator.GetTypesImplementing<IProjectileInfo>().OrderBy(t => t.Namespace).ThenBy(t => t.Name);
 
 			var weaponTypes = weaponInfo.Concat(projectiles).Concat(warheads);
 
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						})
 				});
 
-			var relatedEnums = relatedEnumTypes.Select(type => new
+			var relatedEnums = relatedEnumTypes.OrderBy(t => t.Name).Select(type => new
 			{
 				type.Namespace,
 				type.Name,

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractWeaponDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractWeaponDocsCommand.cs
@@ -51,7 +51,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 		static string GenerateJson(string version, IEnumerable<Type> weaponTypes, ObjectCreator objectCreator)
 		{
-			var weaponTypesInfo = weaponTypes.Where(x => !x.ContainsGenericParameters && !x.IsAbstract)
+			var relatedEnumTypes = new HashSet<Type>();
+
+			var weaponTypesInfo = weaponTypes
+				.Where(x => !x.ContainsGenericParameters && !x.IsAbstract)
 				.Select(type => new
 				{
 					type.Namespace,
@@ -62,38 +65,56 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						.Where(y => y != type.Name && y != $"{type.Name}Info" && y != "Object"),
 					Properties = FieldLoader.GetTypeLoadInfo(type)
 						.Where(fi => fi.Field.IsPublic && fi.Field.IsInitOnly && !fi.Field.IsStatic)
-						.Select(fi => new
+						.Select(fi =>
 						{
-							PropertyName = fi.YamlName,
-							DefaultValue = FieldSaver.SaveField(objectCreator.CreateBasic(type), fi.Field.Name).Value.Value,
-							InternalType = Util.InternalTypeName(fi.Field.FieldType),
-							UserFriendlyType = Util.FriendlyTypeName(fi.Field.FieldType),
-							Description = string.Join(" ", fi.Field.GetCustomAttributes<DescAttribute>(true).SelectMany(d => d.Lines)),
-							OtherAttributes = fi.Field.CustomAttributes
-								.Where(a => a.AttributeType.Name != nameof(DescAttribute) && a.AttributeType.Name != nameof(FieldLoader.LoadUsingAttribute))
-								.Select(a =>
-								{
-									var name = a.AttributeType.Name;
-									name = name.EndsWith("Attribute") ? name.Substring(0, name.Length - 9) : name;
+							if (fi.Field.FieldType.IsEnum)
+								relatedEnumTypes.Add(fi.Field.FieldType);
 
-									return new
+							return new
+							{
+								PropertyName = fi.YamlName,
+								DefaultValue = FieldSaver.SaveField(objectCreator.CreateBasic(type), fi.Field.Name).Value.Value,
+								InternalType = Util.InternalTypeName(fi.Field.FieldType),
+								UserFriendlyType = Util.FriendlyTypeName(fi.Field.FieldType),
+								Description = string.Join(" ", fi.Field.GetCustomAttributes<DescAttribute>(true).SelectMany(d => d.Lines)),
+								OtherAttributes = fi.Field.CustomAttributes
+									.Where(a => a.AttributeType.Name != nameof(DescAttribute) && a.AttributeType.Name != nameof(FieldLoader.LoadUsingAttribute))
+									.Select(a =>
 									{
-										Name = name,
-										Parameters = a.Constructor.GetParameters()
-											.Select(pi => new
-											{
-												pi.Name,
-												Value = Util.GetAttributeParameterValue(a.ConstructorArguments[pi.Position])
-											})
-									};
-								})
+										var name = a.AttributeType.Name;
+										name = name.EndsWith("Attribute") ? name.Substring(0, name.Length - 9) : name;
+
+										return new
+										{
+											Name = name,
+											Parameters = a.Constructor.GetParameters()
+												.Select(pi => new
+												{
+													pi.Name,
+													Value = Util.GetAttributeParameterValue(a.ConstructorArguments[pi.Position])
+												})
+										};
+									})
+							};
 						})
 				});
+
+			var relatedEnums = relatedEnumTypes.Select(type => new
+			{
+				type.Namespace,
+				type.Name,
+				Values = Enum.GetNames(type).Select(x => new
+				{
+					Key = Convert.ToInt32(Enum.Parse(type, x)),
+					Value = x
+				})
+			});
 
 			var result = new
 			{
 				Version = version,
-				WeaponTypes = weaponTypesInfo
+				WeaponTypes = weaponTypesInfo,
+				RelatedEnums = relatedEnums
 			};
 
 			return JsonConvert.SerializeObject(result);

--- a/packaging/format-docs.py
+++ b/packaging/format-docs.py
@@ -73,7 +73,8 @@ def format_docs(version, collectionName, types, relatedEnums):
                     print("###### Inherits from: " + ", ".join([format_type_name(x, is_known_type(x, types)) for x in inheritedTypes]) + '.')
 
             if "RequiresTraits" in currentType and currentType["RequiresTraits"]:
-                print("###### Requires trait(s): " + ", ".join([format_type_name(x, is_known_type(x, types)) for x in currentType["RequiresTraits"]]) + '.')
+                formattedRequiredTraits = [format_type_name(x, is_known_type(x, types)) for x in currentType["RequiresTraits"]]
+                print("###### Requires trait(s): " + ", ".join(sorted(formattedRequiredTraits)) + '.')
 
             if len(currentType["Properties"]) > 0:
                 print()
@@ -113,7 +114,7 @@ def format_docs(version, collectionName, types, relatedEnums):
             values = [f"`{value['Value']}`" for value in relatedEnum["Values"]]
             print(f"### {relatedEnum['Name']}")
             print(f"Possible values: {', '.join(values)}\n")
-            distinctReferencingTypes = set(enumReferences[relatedEnum['Name']])
+            distinctReferencingTypes = sorted(set(enumReferences[relatedEnum['Name']]))
             formattedReferencingTypes = [format_type_name(x, is_known_type(x, types)) for x in distinctReferencingTypes]
             print(f"Referenced by: {', '.join(formattedReferencingTypes)}\n")
 

--- a/packaging/format-docs.py
+++ b/packaging/format-docs.py
@@ -38,14 +38,19 @@ def format_docs(version, collectionName, types, relatedEnums):
     # Map the `relatedEnums` collection to a list of strings.
     enumNames = [enum['Name'] for enum in relatedEnums]
 
+    title = ""
     explanation = ""
     if collectionName == "TraitInfos":
+        title = "Traits"
         explanation = "all traits with their properties and their default values plus developer commentary"
     elif collectionName == "WeaponTypes":
+        title = "Weapons"
         explanation = "a template for weapon definitions and the types it can use (warheads and projectiles) with default values and developer commentary"
     elif collectionName == "SpriteSequenceTypes":
+        title = "Sprite sequences"
         explanation = "all sprite sequence types with their properties and their default values plus developer commentary"
 
+    print(f"# {title}\n")
     print(f"This documentation is aimed at modders and has been automatically generated for version `{version}` of OpenRA. " +
 				"Please do not edit it directly, but instead add new `[Desc(\"String\")]` tags to the source code.\n")
 

--- a/packaging/format-docs.py
+++ b/packaging/format-docs.py
@@ -37,6 +37,7 @@ def format_docs(version, collectionName, types, relatedEnums):
 
     # Map the `relatedEnums` collection to a list of strings.
     enumNames = [enum['Name'] for enum in relatedEnums]
+    enumReferences = OrderedDict()
 
     title = ""
     explanation = ""
@@ -86,6 +87,10 @@ def format_docs(version, collectionName, types, relatedEnums):
                     typeName = prop["UserFriendlyType"]
                     if prop["InternalType"] in enumNames:
                         typeName = format_type_name(prop["InternalType"], True)
+                        if prop["InternalType"] in enumReferences:
+                            enumReferences[prop["InternalType"]].append(currentType["Name"])
+                        else:
+                            enumReferences[prop["InternalType"]] = [currentType["Name"]]
 
                     if "OtherAttributes" in prop:
                         attributes = []
@@ -108,6 +113,9 @@ def format_docs(version, collectionName, types, relatedEnums):
             values = [f"`{value['Value']}`" for value in relatedEnum["Values"]]
             print(f"### {relatedEnum['Name']}")
             print(f"Possible values: {', '.join(values)}\n")
+            distinctReferencingTypes = set(enumReferences[relatedEnum['Name']])
+            formattedReferencingTypes = [format_type_name(x, is_known_type(x, types)) for x in distinctReferencingTypes]
+            print(f"Referenced by: {', '.join(formattedReferencingTypes)}\n")
 
 if __name__ == "__main__":
     input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8-sig')


### PR DESCRIPTION
The last* (planned) step of the documentation rework for this release cycle, it follows up on https://github.com/OpenRA/OpenRA/pull/19948, https://github.com/OpenRA/OpenRA/pull/19986, https://github.com/OpenRA/OpenRA/pull/20087, https://github.com/OpenRA/OpenRA/pull/20250 and https://github.com/OpenRA/OpenRA/pull/20268 by listing relevant enum types and their possible values. By "relevant" I mean those being referenced by traits/weapons/sequences as a field type.

*Depending on whether and how much time allows, I may continue with other things like `ISpriteSequenceLoader`s (those in particular should be trivial).

Reviewing with whitespace diff disabled is recommended.

P.S.: I have updated the `Dev` versions of the trait/weapon/sequence docs on the test version of the website:  https://docs.openra.net/en/test/