### PR TITLE
Trait multiplicity attribute

### DIFF
--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -241,6 +241,7 @@ namespace OpenRA.Traits
 		}
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class FrozenActorLayer : IRender, ITick, ISync
 	{
 		[Sync]

--- a/OpenRA.Game/Traits/Player/Shroud.cs
+++ b/OpenRA.Game/Traits/Player/Shroud.cs
@@ -15,7 +15,6 @@ using System.Collections.Generic;
 namespace OpenRA.Traits
 {
 	[TraitLocation(SystemActors.Player | SystemActors.EditorPlayer)]
-	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	[Desc("Required for shroud and fog visibility checks. Add this to the player actor.")]
 	public class ShroudInfo : TraitInfo, ILobbyOptions
 	{
@@ -66,6 +65,7 @@ namespace OpenRA.Traits
 		public override object Create(ActorInitializer init) { return new Shroud(init.Self, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class Shroud : ISync, INotifyCreated, ITick
 	{
 		public enum SourceType : byte { PassiveVisibility, Shroud, Visibility }

--- a/OpenRA.Game/Traits/Player/Shroud.cs
+++ b/OpenRA.Game/Traits/Player/Shroud.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 namespace OpenRA.Traits
 {
 	[TraitLocation(SystemActors.Player | SystemActors.EditorPlayer)]
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	[Desc("Required for shroud and fog visibility checks. Add this to the player actor.")]
 	public class ShroudInfo : TraitInfo, ILobbyOptions
 	{

--- a/OpenRA.Game/Traits/TraitAttributes.cs
+++ b/OpenRA.Game/Traits/TraitAttributes.cs
@@ -1,0 +1,34 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+
+namespace OpenRA.Traits
+{
+	public enum TraitMultiplicity
+	{
+		None = 0,
+		OnePerActor,
+		ManyPerActor,
+	}
+
+	/// <summary>
+	/// Declare wether one or multiple instances of a trait can be associated with a single actor. If only a single instance
+	/// of a trait can be associated with an actor - the traits of this type will be stored in dictionary rather than a list
+	/// allowing for faster an linear lookup times per actor.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Interface | AttributeTargets.Class)]
+	public sealed class TraitMultiplicityAttribute : Attribute
+	{
+		public readonly TraitMultiplicity Multiplicity;
+		public TraitMultiplicityAttribute(TraitMultiplicity multiplicity) { Multiplicity = multiplicity; }
+	}
+}

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -203,6 +203,7 @@ namespace OpenRA.Traits
 	public interface IDefaultVisibility { bool IsVisible(Actor self, Player byPlayer); }
 	public interface IVisibilityModifier { bool IsVisible(Actor self, Player byPlayer); }
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public interface IActorMap
 	{
 		IEnumerable<Actor> GetActorsAt(CPos a);
@@ -256,6 +257,7 @@ namespace OpenRA.Traits
 	public interface IPaletteModifier { void AdjustPalette(IReadOnlyDictionary<string, MutablePalette> b); }
 
 	[RequireExplicitImplementation]
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public interface ISelectionBar { float GetValue(); Color GetColor(); bool DisplayWhenEmpty { get; } }
 
 	public interface ISelectionDecorations
@@ -457,6 +459,7 @@ namespace OpenRA.Traits
 		void SetRollover(IEnumerable<Actor> actors);
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public interface IControlGroupsInfo : ITraitInfoInterface
 	{
 		string[] Groups { get; }

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -257,7 +257,6 @@ namespace OpenRA.Traits
 	public interface IPaletteModifier { void AdjustPalette(IReadOnlyDictionary<string, MutablePalette> b); }
 
 	[RequireExplicitImplementation]
-	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public interface ISelectionBar { float GetValue(); Color GetColor(); bool DisplayWhenEmpty { get; } }
 
 	public interface ISelectionDecorations

--- a/OpenRA.Game/Traits/World/ScreenMap.cs
+++ b/OpenRA.Game/Traits/World/ScreenMap.cs
@@ -31,6 +31,7 @@ namespace OpenRA.Traits
 	}
 
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class ScreenMapInfo : TraitInfo
 	{
 		[Desc("Size of partition bins (world pixels)")]

--- a/OpenRA.Game/Traits/World/ScreenShaker.cs
+++ b/OpenRA.Game/Traits/World/ScreenShaker.cs
@@ -25,6 +25,7 @@ namespace OpenRA.Traits
 		public override object Create(ActorInitializer init) { return new ScreenShaker(this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class ScreenShaker : ITick, IWorldLoaded
 	{
 		readonly ScreenShakerInfo info;

--- a/OpenRA.Mods.Common/Commands/ChatCommands.cs
+++ b/OpenRA.Mods.Common/Commands/ChatCommands.cs
@@ -20,6 +20,7 @@ namespace OpenRA.Mods.Common.Commands
 	[Desc("Enables commands triggered by typing them into the chatbox. Attach this to the world actor.")]
 	public class ChatCommandsInfo : TraitInfo<ChatCommands> { }
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class ChatCommands : INotifyChat
 	{
 		public Dictionary<string, IChatCommand> Commands { get; }

--- a/OpenRA.Mods.Common/Commands/HelpCommand.cs
+++ b/OpenRA.Mods.Common/Commands/HelpCommand.cs
@@ -19,6 +19,7 @@ namespace OpenRA.Mods.Common.Commands
 	[Desc("Shows a list of available commands in the chatbox. Attach this to the world actor.")]
 	public class HelpCommandInfo : TraitInfo<HelpCommand> { }
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class HelpCommand : IChatCommand, IWorldLoaded
 	{
 		readonly Dictionary<string, string> helpDescriptions;

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -220,6 +220,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class Aircraft : PausableConditionalTrait<AircraftInfo>, ITick, ISync, IFacing, IPositionable, IMove,
 		INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyActorDisposing, INotifyBecomingIdle, ICreationActivity,
 		IActorPreviewInitModifier, IDeathActorInitModifier, IIssueDeployOrder, IIssueOrder, IResolveOrder, IOrderVoice

--- a/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
@@ -36,6 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new AttackAircraft(init.Self, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class AttackAircraft : AttackFollow
 	{
 		public new readonly AttackAircraftInfo Info;

--- a/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
@@ -22,6 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new AttackBomber(init.Self, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class AttackBomber : AttackBase, ITick, ISync, INotifyRemovedFromWorld
 	{
 		readonly AttackBomberInfo info;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackCharges.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackCharges.cs
@@ -32,6 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new AttackCharges(init.Self, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class AttackCharges : AttackOmni, INotifyAttack, INotifySold
 	{
 		readonly AttackChargesInfo info;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -33,6 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new AttackFollow(init.Self, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class AttackFollow : AttackBase, INotifyOwnerChanged, IOverrideAutoTarget, INotifyStanceChanged
 	{
 		public new readonly AttackFollowInfo Info;

--- a/OpenRA.Mods.Common/Traits/BodyOrientation.cs
+++ b/OpenRA.Mods.Common/Traits/BodyOrientation.cs
@@ -58,6 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new BodyOrientation(init, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class BodyOrientation : ISync
 	{
 		readonly BodyOrientationInfo info;

--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -221,19 +221,20 @@ namespace OpenRA.Mods.Common.Traits
 
 		void SetRallyPointsForNewProductionBuildings(IBot bot)
 		{
-			foreach (var rp in world.ActorsWithTrait<RallyPoint>())
+			// PERF: Apply is faster than enumerating over trait pairs.
+			world.ApplyToActorsWithTrait<RallyPoint>((actor, trait) =>
 			{
-				if (rp.Actor.Owner != player)
-					continue;
+				if (actor.Owner != player)
+					return;
 
-				if (rp.Trait.Path.Count == 0 || !IsRallyPointValid(rp.Trait.Path[0], rp.Actor.Info.TraitInfoOrDefault<BuildingInfo>()))
+				if (trait.Path.Count == 0 || !IsRallyPointValid(trait.Path[0], actor.Info.TraitInfoOrDefault<BuildingInfo>()))
 				{
-					bot.QueueOrder(new Order("SetRallyPoint", rp.Actor, Target.FromCell(world, ChooseRallyLocationNear(rp.Actor)), false)
+					bot.QueueOrder(new Order("SetRallyPoint", actor, Target.FromCell(world, ChooseRallyLocationNear(actor)), false)
 					{
 						SuppressVisualFeedback = true
 					});
 				}
-			}
+			});
 		}
 
 		// Won't work for shipyards...

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -93,6 +93,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class Bridge : IRender, INotifyDamageStateChanged, IRadarSignature
 	{
 		readonly BuildingInfo buildingInfo;

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -263,6 +263,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class Building : IOccupySpace, ITargetableCells, INotifySold, INotifyTransform, ISync,
 		INotifyAddedToWorld, INotifyRemovedFromWorld
 	{

--- a/OpenRA.Mods.Common/Traits/Buildings/Gate.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Gate.cs
@@ -36,6 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Gate(init, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class Gate : PausableConditionalTrait<GateInfo>, ITick, ITemporaryBlocker, IBlocksProjectiles,
 		INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyBlockingMove
 	{

--- a/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
@@ -51,6 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new PrimaryBuilding(this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class PrimaryBuilding : ConditionalTrait<PrimaryBuildingInfo>, IIssueOrder, IResolveOrder
 	{
 		const string OrderID = "PrimaryProducer";

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -58,6 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new RallyPoint(init.Self, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class RallyPoint : IIssueOrder, IResolveOrder, INotifyOwnerChanged, INotifyCreated
 	{
 		const string OrderID = "SetRallyPoint";

--- a/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
@@ -54,6 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new RepairableBuilding(init.Self, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class RepairableBuilding : ConditionalTrait<RepairableBuildingInfo>, ITick
 	{
 		readonly IHealth health;

--- a/OpenRA.Mods.Common/Traits/CaptureManager.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureManager.cs
@@ -54,6 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class CaptureManager : INotifyCreated, INotifyCapture, ITick, IDisableEnemyAutoTarget
 	{
 		readonly CaptureManagerInfo info;

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -88,6 +88,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Cargo(init, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class Cargo : IIssueOrder, IResolveOrder, IOrderVoice, INotifyCreated, INotifyKilled,
 		INotifyOwnerChanged, INotifySold, INotifyActorDisposing, IIssueDeployOrder,
 		ITransformActorInitModifier

--- a/OpenRA.Mods.Common/Traits/Carryable.cs
+++ b/OpenRA.Mods.Common/Traits/Carryable.cs
@@ -42,6 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		bool TryLockForPickup(Actor self, Actor carrier);
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class Carryable : ConditionalTrait<CarryableInfo>
 	{
 		int reservedToken = Actor.InvalidConditionToken;

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -83,6 +83,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Carryall(init.Self, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class Carryall : INotifyKilled, ISync, ITick, IRender, INotifyActorDisposing, IIssueOrder, IResolveOrder,
 		IOrderVoice, IIssueDeployOrder, IAircraftCenterPositionOffset, IOverrideAircraftLanding
 	{

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -54,6 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new GainsExperience(init, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class GainsExperience : INotifyCreated, ISync, IResolveOrder, ITransformActorInitModifier
 	{
 		readonly Actor self;

--- a/OpenRA.Mods.Common/Traits/Guard.cs
+++ b/OpenRA.Mods.Common/Traits/Guard.cs
@@ -27,6 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Guard(this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class Guard : IResolveOrder, IOrderVoice, INotifyCreated
 	{
 		readonly GuardInfo info;

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -104,6 +104,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Harvester(init.Self, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class Harvester : ConditionalTrait<HarvesterInfo>, IIssueOrder, IResolveOrder, IOrderVoice,
 		ISpeedModifier, ISync, INotifyCreated
 	{

--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -49,6 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class Health : IHealth, ISync, ITick, INotifyCreated, INotifyOwnerChanged
 	{
 		public readonly HealthInfo Info;

--- a/OpenRA.Mods.Common/Traits/Interactable.cs
+++ b/OpenRA.Mods.Common/Traits/Interactable.cs
@@ -32,6 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Interactable(this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class Interactable : INotifyCreated, IMouseBounds
 	{
 		readonly InteractableInfo info;

--- a/OpenRA.Mods.Common/Traits/IsometricSelectable.cs
+++ b/OpenRA.Mods.Common/Traits/IsometricSelectable.cs
@@ -69,6 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class IsometricSelectable : IMouseBounds, ISelectable
 	{
 		readonly IsometricSelectableInfo info;

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -162,6 +162,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class Mobile : PausableConditionalTrait<MobileInfo>, IIssueOrder, IResolveOrder, IOrderVoice, IPositionable, IMove, ITick, ICreationActivity,
 		IFacing, IDeathActorInitModifier, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyBlockingMove, IActorPreviewInitModifier, INotifyBecomingIdle
 	{

--- a/OpenRA.Mods.Common/Traits/ParaDrop.cs
+++ b/OpenRA.Mods.Common/Traits/ParaDrop.cs
@@ -29,6 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new ParaDrop(init.Self, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class ParaDrop : ITick, ISync, INotifyRemovedFromWorld
 	{
 		readonly ParaDropInfo info;

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -57,6 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Parachutable(init.Self, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class Parachutable : INotifyParachute
 	{
 		readonly ParachutableInfo info;

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -61,6 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Passenger(this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class Passenger : IIssueOrder, IResolveOrder, IOrderVoice, INotifyRemovedFromWorld, INotifyEnteredCargo, INotifyExitedCargo, INotifyKilled, IObservesVariables
 	{
 		public readonly PassengerInfo Info;

--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
@@ -70,6 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new DeveloperMode(this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class DeveloperMode : IResolveOrder, ISync, INotifyCreated, IUnlocksRenderPlayer
 	{
 		readonly DeveloperModeInfo info;

--- a/OpenRA.Mods.Common/Traits/Player/GrantConditionOnPrerequisiteManager.cs
+++ b/OpenRA.Mods.Common/Traits/Player/GrantConditionOnPrerequisiteManager.cs
@@ -22,6 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new GrantConditionOnPrerequisiteManager(init); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class GrantConditionOnPrerequisiteManager : ITechTreeElement
 	{
 		readonly Actor self;

--- a/OpenRA.Mods.Common/Traits/Player/MissionObjectives.cs
+++ b/OpenRA.Mods.Common/Traits/Player/MissionObjectives.cs
@@ -69,6 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new MissionObjectives(init.Self.Owner, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class MissionObjectives : INotifyWinStateChanged, ISync, IResolveOrder, IWorldLoaded
 	{
 		public readonly MissionObjectivesInfo Info;

--- a/OpenRA.Mods.Common/Traits/Player/PlayerExperience.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerExperience.cs
@@ -22,6 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new PlayerExperience(); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class PlayerExperience : ISync
 	{
 		[Sync]

--- a/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
@@ -71,6 +71,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new PlayerResources(init.Self, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class PlayerResources : ISync
 	{
 		public readonly PlayerResourcesInfo Info;

--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -25,6 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new PlayerStatistics(init.Self); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class PlayerStatistics : ITick, IResolveOrder, INotifyCreated, IWorldLoaded
 	{
 		PlayerResources resources;

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -44,6 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new StrategicVictoryConditions(init.Self, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class StrategicVictoryConditions : ITick, ISync, INotifyWinStateChanged, INotifyTimeLimit
 	{
 		readonly StrategicVictoryConditionsInfo info;

--- a/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
@@ -30,6 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new PowerManager(init.Self, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class PowerManager : INotifyCreated, ITick, ISync, IResolveOrder
 	{
 		readonly Actor self;

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -78,6 +78,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class RenderSprites : IRender, ITick, INotifyOwnerChanged, INotifyEffectiveOwnerChanged, IActorPreviewInitModifier
 	{
 		static readonly (DamageState DamageState, string Prefix)[] DamagePrefixes =

--- a/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
@@ -76,6 +76,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class RenderVoxels : IRender, ITick, INotifyOwnerChanged
 	{
 		class AnimationWrapper

--- a/OpenRA.Mods.Common/Traits/Sellable.cs
+++ b/OpenRA.Mods.Common/Traits/Sellable.cs
@@ -49,6 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Sellable(init.Self, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class Sellable : ConditionalTrait<SellableInfo>, IResolveOrder, IProvideTooltipInfo
 	{
 		readonly Actor self;

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -25,6 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new SupportPowerManager(init); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class SupportPowerManager : ITick, IResolveOrder, ITechTreeElement
 	{
 		public readonly Actor Self;

--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -66,6 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Transforms(init, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class Transforms : PausableConditionalTrait<TransformsInfo>, IIssueOrder, IResolveOrder, IOrderVoice, IIssueDeployOrder
 	{
 		readonly Actor self;

--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -27,6 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new ActorMap(init.World, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class ActorMap : IActorMap, ITick, INotifyCreated
 	{
 		class InfluenceNode

--- a/OpenRA.Mods.Common/Traits/World/BuildableTerrainOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/BuildableTerrainOverlay.cs
@@ -42,6 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class BuildableTerrainOverlay : IRenderAboveWorld, IWorldLoaded, INotifyActorDisposing
 	{
 		readonly BuildableTerrainOverlayInfo info;

--- a/OpenRA.Mods.Common/Traits/World/EditorActionManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActionManager.cs
@@ -19,6 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 	[TraitLocation(SystemActors.EditorWorld)]
 	public class EditorActionManagerInfo : TraitInfo<EditorActionManager> { }
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class EditorActionManager : IWorldLoaded
 	{
 		readonly Stack<EditorActionContainer> undoStack = new Stack<EditorActionContainer>();

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -36,6 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new EditorActorLayer(this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class EditorActorLayer : IWorldLoaded, ITickRender, IRender, IRadarSignature, ICreatePlayers, IRenderAnnotations
 	{
 		readonly EditorActorLayerInfo info;

--- a/OpenRA.Mods.Common/Traits/World/EditorCursorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorCursorLayer.cs
@@ -28,6 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new EditorCursorLayer(init.Self, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class EditorCursorLayer : IWorldLoaded, ITickRender, IRenderAboveShroud, IRenderAnnotations
 	{
 		readonly EditorCursorLayerInfo info;

--- a/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
@@ -40,6 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new EditorSelectionLayer(init.Self, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class EditorSelectionLayer : IWorldLoaded, IRenderAboveShroud
 	{
 		readonly EditorSelectionLayerInfo info;

--- a/OpenRA.Mods.Common/Traits/World/HierarchicalPathFinderOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/HierarchicalPathFinderOverlay.cs
@@ -32,6 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new HierarchicalPathFinderOverlay(this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class HierarchicalPathFinderOverlay : IRenderAnnotations, IWorldLoaded, IChatCommand
 	{
 		const string CommandName = "hpf";

--- a/OpenRA.Mods.Common/Traits/World/LegacyBridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/LegacyBridgeLayer.cs
@@ -61,8 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 				ConvertBridgeToActor(w, cell);
 
 			// Link adjacent (long)-bridges so that artwork is updated correctly
-			foreach (var p in w.ActorsWithTrait<Bridge>())
-				p.Trait.LinkNeighbouringBridges(this);
+			w.ApplyToActorsWithTrait<Bridge>((_, trait) => trait.LinkNeighbouringBridges(this));
 		}
 
 		void ConvertBridgeToActor(World w, CPos cell)

--- a/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
@@ -44,6 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new MapCreeps(this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class MapCreeps : INotifyCreated
 	{
 		readonly MapCreepsInfo info;

--- a/OpenRA.Mods.Common/Traits/World/MapOptions.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapOptions.cs
@@ -103,6 +103,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new MapOptions(this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class MapOptions : INotifyCreated
 	{
 		readonly MapOptionsInfo info;

--- a/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
+++ b/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
@@ -43,6 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new MusicPlaylist(init.World, this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class MusicPlaylist : INotifyActorDisposing, IGameOver, IWorldLoaded, INotifyGameLoaded
 	{
 		readonly MusicPlaylistInfo info;

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -28,6 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class PathFinder : IPathFinder, IWorldLoaded
 	{
 		public static readonly List<CPos> NoPath = new List<CPos>(0);

--- a/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
@@ -20,6 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Spawns the initial units for each player upon game start.")]
 	public class SpawnMapActorsInfo : TraitInfo<SpawnMapActors> { }
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class SpawnMapActors : IWorldLoaded
 	{
 		public Dictionary<string, Actor> Actors = new Dictionary<string, Actor>();

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -22,6 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Renders a debug overlay showing the terrain cells. Attach this to the world actor.")]
 	public class TerrainGeometryOverlayInfo : TraitInfo<TerrainGeometryOverlay> { }
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class TerrainGeometryOverlay : IRenderAnnotations, IWorldLoaded, IChatCommand
 	{
 		const string CommandName = "terrain-geometry";

--- a/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
@@ -26,6 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new WarheadDebugOverlay(this); }
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public class WarheadDebugOverlay : IRenderAnnotations
 	{
 		class WHImpact

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -780,11 +780,13 @@ namespace OpenRA.Mods.Common.Traits
 		All
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public interface IPositionableInfo : IOccupySpaceInfo
 	{
 		bool CanEnterCell(World world, Actor self, CPos cell, SubCell subCell = SubCell.FullCell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All);
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public interface IPositionable : IOccupySpace
 	{
 		bool CanExistInCell(CPos location);
@@ -797,6 +799,7 @@ namespace OpenRA.Mods.Common.Traits
 		void SetCenterPosition(Actor self, WPos pos);
 	}
 
+	[TraitMultiplicity(TraitMultiplicity.OnePerActor)]
 	public interface IPathFinder
 	{
 		/// <summary>


### PR DESCRIPTION

For consideration. Performance benefit untested. 

Introduction of `TraitMultiplicityAttribute` that allows you to declare that one instance of a trait is only ever assigned to a single actor. 

Allow use of Dictionary over double List to store the actor trait pairs in the `TraitDictionary`. The attribute is checked once per trait type when creating a trait container for the trait the first time. 

Benefit:
- Improves readability and intent of trait code.
- Faster and linear lookup times of single traits by actor. No need to find the actor using binary search in a list of all actors.
- Likely faster Insert and Remove times - assuming entDictionary 
- More fair. Lookup times for each player and actor the same.

Down side:
- TraitDictionary may pre allocate more memory.
- ActorsWithTrait<T>() becomes slower as dictionary `KeyValuePair` structs need to be converted to `TraitPair` structs. These queries are rarely done.
- Enumation of dictionary values may change the order of actor trait pairs. Might bring to light some interesting bugs/features in rare cases where the traits or trait pairs are iterated. 

Considerations:
- Some actors may only expect a trait to occur once per actors. While other actors accept multiple occurances. I.e. `WithSpriteBody` where i had to remove the attribute. In thise case some traits may have been marked `OnePerActor` incorrectly.
- Relies on GetCustomAttribute<>(false) to return the attribute only if set on the current type and not parent or sub types.
- By default the attribute is not set. Assumes mutlitple instances of a trait can be assigned to an actor. 
Unknown:
- I have not measured if this does benefit performance. Could well be that it makes little impact - or is even slower.
(- For traits that are known to only exist on a single actor (i.e. World) you could create custom ITraitContainer that does not maintain a Dictionary.)
- Both the class and their parent interfaces need to have the attribute set. As trait lookup can be done via either.

Traits queried via `Actor.Trait<T>()` have been marked as `OnePerActor`. The game already raised an exception if this function would return multiple trait instances for one actor. 

Below a list of OnePerActor traits (at least considered this way by one type of actor). In these situations a call to `Actor.Trait<T>()` likely has become faster. For some it is not relevant as they are being stores/cached by the actor as fields upon creation.
```
IAcceptResources
IFacing
IHealth
IMove
Interactable
IPathFinder
IPositionable
IPositionableInfo
IResourceLayer
IsometricSelectable
ITiledTerrainRenderer
MapCreeps
MapOptions
MissionObjectives
Mobile
MusicPlaylist
Parachutable
ParaDrop
Passenger
PathFinder
PlayerExperience
PlayerResources
PlayerStatistics
PowerManager
PrimaryBuilding
RallyPoint
RenderSprites
RenderVoxels
RepairableBuilding
ResourceClaimLayer
ScaredyCat
ScreenShaker
Sellable
Shroud
SpawnMapActors
StrategicVictoryConditions
SupportPowerManager
TechTree
TerrainGeometryOverlay
TerrainLighting
Transforms
WarheadDebugOverlay
WithSpriteBody

```


From the traits above `ActorWithTraits` is called on. The ones marked with a plus could not be rewritten. In these cases the performance is known to have decreased. The queries do not very efficient to being with, comments suggest the need for rewrites.

```
Bridge
Building
+Carryable
+Carryall
Harvester
+IAcceptResources
IHealth
PrimaryBuilding
RallyPoint
SupportPowerManage
```


