### PR TITLE
add ability for Harvester to artificially wait after unloading

### DIFF
--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -38,6 +38,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("How fast it can dump it's carryage.")]
 		public readonly int BaleUnloadDelay = 4;
 
+		[Desc("Artificial delay to wait after unloading before continuing with next Activity.")]
+		public readonly int UnloadFinishedDelay = 0;
+
 		[Desc("How many bales can it dump at once.")]
 		public readonly int BaleUnloadAmount = 1;
 
@@ -123,6 +126,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Sync]
 		int currentUnloadTicks;
+
+		[Sync]
+		int currentUnloadFinishedDelayTicks;
 
 		[Sync]
 		public int ContentHash
@@ -266,10 +272,15 @@ namespace OpenRA.Mods.Common.Traits
 						contents.Remove(resourceType);
 
 					currentUnloadTicks = Info.BaleUnloadDelay;
+					currentUnloadFinishedDelayTicks = Info.UnloadFinishedDelay;
 					UpdateCondition(self);
 					return false;
 				}
 			}
+
+			// Wait until artificial delay time has passed
+			if (--currentUnloadFinishedDelayTicks > 0)
+				return false;
 
 			return contents.Count == 0;
 		}

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -128,9 +128,6 @@ namespace OpenRA.Mods.Common.Traits
 		int currentUnloadTicks;
 
 		[Sync]
-		int currentUnloadFinishedDelayTicks;
-
-		[Sync]
 		public int ContentHash
 		{
 			get
@@ -272,15 +269,10 @@ namespace OpenRA.Mods.Common.Traits
 						contents.Remove(resourceType);
 
 					currentUnloadTicks = Info.BaleUnloadDelay;
-					currentUnloadFinishedDelayTicks = Info.UnloadFinishedDelay;
 					UpdateCondition(self);
 					return false;
 				}
 			}
-
-			// Wait until artificial delay time has passed
-			if (--currentUnloadFinishedDelayTicks > 0)
-				return false;
 
 			return contents.Count == 0;
 		}


### PR DESCRIPTION
With this addition, `Harvester`s can be told to explicitly wait (at the Refinery) for a number of ticks before continuing to the next Activity (e.g. returning to a Tiberium field).

E.g.
```yaml
Harvester:
	DeliveryActors: proc
	Capacity: 50
	Resources: Tiberium, BlueTiberium
	...
	UnloadFinishedDelay: 30
	...
	EmptyCondition: no-tiberium
```

Context:
For some more complex behaviour for a new unit deriving from `Harvester`, I required this delay. However, instead of cloning the entire stack of `Harvester` classes and related functions, Interfaces, etc., I added these couple of lines to the base code. I figured maybe someone else out there would like a configurable delay for their (new) `Harvester`-like units.

Housekeeping:
- [x] Read guidelines for contributing
- [x] `make test`
- [x] `make check`