### PR TITLE
rename Harvester DeliveryBuildings for parity with code function

### DIFF
--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public class HarvesterInfo : ConditionalTraitInfo, Requires<MobileInfo>
 	{
-		public readonly HashSet<string> DeliveryBuildings = new HashSet<string>();
+		public readonly HashSet<string> DeliveryActors = new HashSet<string>();
 
 		[Desc("How long (in ticks) to wait until (re-)checking for a nearby available DeliveryBuilding if not yet linked to one.")]
 		public readonly int SearchForDeliveryBuildingDelay = 125;
@@ -175,8 +175,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool IsAcceptableProcType(Actor proc)
 		{
-			return Info.DeliveryBuildings.Count == 0 ||
-				Info.DeliveryBuildings.Contains(proc.Info.Name);
+			return Info.DeliveryActors.Count == 0 ||
+				Info.DeliveryActors.Contains(proc.Info.Name);
 		}
 
 		public Actor ClosestProc(Actor self, Actor ignore)

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20220916/RenameDeliveryBuildings.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20220916/RenameDeliveryBuildings.cs
@@ -1,0 +1,47 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RenameDeliveryBuildings : UpdateRule
+	{
+		public override string Name => "Change 'DeliveryBuildings' to 'DeliveryActors' in the Harvester trait definitions.";
+
+		public override string Description =>
+			"'DeliveryBuildings' is no longer valid. " +
+			"Use 'DeliveryActors' instead.";
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var traitNode in actorNode.Value.Nodes)
+			{
+				if (string.Equals(traitNode.Key, "DeliveryBuildings", System.StringComparison.InvariantCultureIgnoreCase))
+					traitNode.Key = "DeliveryActors";
+			}
+
+			yield break;
+		}
+
+		bool displayed;
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (displayed)
+				yield break;
+
+			displayed = true;
+			yield return "'DeliveryBuildings' has been renamed to 'DeliveryActors' in the mod rules. "
+			             + "Chrome yaml files may need a manual update.";
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -96,6 +96,12 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new ReplaceSequenceEmbeddedPalette(),
 				new UnhardcodeBaseBuilderBotModule(),
 				new UnhardcodeVeteranProductionIconOverlay(),
+			}),
+
+			new UpdatePath("release-20220916", new UpdateRule[]
+			{
+				// Bleed only changes here
+				new RenameDeliveryBuildings(),
 			})
 		};
 

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -351,7 +351,7 @@ WEED:
 		Prerequisites: ~naweap, nawast, ~techlevel.superweapons
 		Description: Collects veins for processing.\n  Unarmed
 	Harvester:
-		DeliveryBuildings: nawast
+		DeliveryActors: nawast
 		Capacity: 7
 		Resources: Veins
 		BaleUnloadDelay: 20

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -59,7 +59,7 @@ HARV:
 		Bounds: 1086, 2172
 		DecorationBounds: 1086, 2172
 	Harvester:
-		DeliveryBuildings: proc
+		DeliveryActors: proc
 		Capacity: 28
 		Resources: Tiberium, BlueTiberium
 		BaleLoadDelay: 15


### PR DESCRIPTION
This change is to reduce confusion and also make it look less hacky when someone uses the `Harvester` Info `Delivery'''Buildings'''` on an Actor that is not a `Building`.

Context:
In my own project, I've added `Refinery` functionality to an Infantry unit, without modifying any C# code. Therefore, I think it's more accurate to rename `DeliveryBuildings` -> `DeliveryActors`, since a `Harvester` can deliver to more types of Actors than just `Buildings`.

Housekeeping:
- [x] Read guidelines for contributing
- [x] `make test`
- [x] `make check`