### PR TITLE
Improve translation of power/silo usage tooltip

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		string siloUsageTooltip = "";
 
-		[TranslationReference("resources", "capacity")]
+		[TranslationReference("usage", "capacity")]
 		static readonly string SiloUsage = "silo-usage";
 
 		[ObjectCreator.UseCtor]
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			displayResources = playerResources.Cash + playerResources.Resources;
 
 			siloUsageTooltipCache = new CachedTransform<(int Resources, int Capacity), string>(x =>
-				modData.Translation.GetString(SiloUsage, Translation.Arguments("resources", x.Resources, "capacity", x.Capacity)));
+				modData.Translation.GetString(SiloUsage, Translation.Arguments("usage", x.Resources, "capacity", x.Capacity)));
 			cashLabel = widget.Get<LabelWithTooltipWidget>("CASH");
 			cashLabel.GetTooltipText = () => siloUsageTooltip;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameSiloBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameSiloBarLogic.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class IngameSiloBarLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[TranslationReference("usage", "capacity")]
 		static readonly string SiloUsage = "silo-usage";
 
 		[ObjectCreator.UseCtor]
@@ -28,7 +28,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			siloBar.GetProvided = () => playerResources.ResourceCapacity;
 			siloBar.GetUsed = () => playerResources.Resources;
-			siloBar.TooltipFormat = modData.Translation.GetString(SiloUsage) + ": {0}/{1}";
+			siloBar.TooltipTextCached = new CachedTransform<(float Current, float Capacity), string>(usage =>
+			{
+				return modData.Translation.GetString(
+					SiloUsage,
+					Translation.Arguments("usage", usage.Current, "capacity", usage.Capacity));
+			});
 			siloBar.GetBarColor = () =>
 			{
 				if (playerResources.Resources == playerResources.ResourceCapacity)

--- a/OpenRA.Mods.Common/Widgets/ResourceBarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ResourceBarWidget.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public readonly string TooltipContainer;
 		readonly Lazy<TooltipContainerWidget> tooltipContainer;
 
-		public string TooltipFormat = "";
+		public CachedTransform<(float, float), string> TooltipTextCached;
 		public ResourceBarOrientation Orientation = ResourceBarOrientation.Vertical;
 		public string IndicatorCollection = "sidebar-bits";
 		public string IndicatorImage = "indicator";
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (TooltipContainer == null)
 				return;
 
-			Func<string> getText = () => TooltipFormat.F(GetUsed(), GetProvided());
+			Func<string> getText = () => TooltipTextCached.Update((GetUsed(), GetProvided()));
 			tooltipContainer.Value.SetTooltip(TooltipTemplate, new WidgetArgs() { { "getText", getText }, { "world", world } });
 		}
 

--- a/mods/common/languages/en.ftl
+++ b/mods/common/languages/en.ftl
@@ -202,11 +202,12 @@ exit-map-editor-confirm = Exit
 
 ## IngamePowerBarLogic
 ## IngamePowerCounterLogic
-power-usage = Power Usage
+power-usage = Power Usage: { $usage }/{ $capacity }
+infinite-power = Infinite
 
 ## IngameSiloBarLogic
 ## IngameCashCounterLogic
-silo-usage = Silo Usage: { $resources }/{ $capacity }
+silo-usage = Silo Usage: { $usage }/{ $capacity }
 
 ## ObserverShroudSelectorLogic
 camera-option-all-players = All Players


### PR DESCRIPTION
Improve translation of power/silo usage tooltip

- Fix an instance where "silo-usage" translation was used without arguments
- Use the same translation reference for the "Power usage"
- Make the ResourceBarWidget accept a cached transform with the tooltip text so it won't have to build the string itself
- Display an infinity symbol when the infinite power cheat is used
- Removes a magic number that is no longer used (>1000000 to check for
unlimited power)

![image](https://user-images.githubusercontent.com/1355810/190139542-a2d58da9-bded-4c9b-b702-10c4112945b7.png)

~~The FreeSans font update is here because the version we have currently (20090104) doesn't have the infinity symbol.~~

Fixes #20317