### PR TITLE
Allow interrupting CashTickDown sounds in TD

### DIFF
--- a/mods/cnc/audio/notifications.yaml
+++ b/mods/cnc/audio/notifications.yaml
@@ -59,6 +59,7 @@ Sounds:
 		Beepy3: beepy3
 		Beepy6: beepy6
 		CashTickDown: tone16
+			AllowInterrupt: true
 		CashTickUp: tone15
 			VolumeModifier: 0.33
 		ChatLine: scold1


### PR DESCRIPTION
Reported by @Orb370 and @JMegaTank on Discord. The audio for cash ticking down is the same as last release now; the other mods are not affected.