### PR TITLE
Minor adjustment for D2k

### DIFF
--- a/mods/d2k/rules/campaign-rules.yaml
+++ b/mods/d2k/rules/campaign-rules.yaml
@@ -59,3 +59,6 @@ World:
 ^AutoTargetAllAssaultMove:
 	GrantConditionOnBotOwner@BOTOWNER:
 		Bots: campaign
+
+harvester:
+	-MustBeDestroyed:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -394,7 +394,6 @@
 		UseLocation: true
 	HiddenUnderFog:
 		Type: GroundPosition
-		AlwaysVisibleRelationships: None
 	ActorLostNotification:
 		TextNotification: Unit lost.
 	AttackMove:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -991,6 +991,7 @@ high_tech_factory:
 		UnitType: ornithopter
 		DisplayBeacon: True
 		CameraActor: camera
+		CameraRemoveDelay: 60
 		ArrowSequence: arrow
 		CircleSequence: circles
 		UseDirectionalTarget: True
@@ -1074,6 +1075,7 @@ palace:
 		Cost: 1600
 	Tooltip:
 		Name: Palace
+	RallyPoint:
 	D2kBuilding:
 		Footprint: xx= xxx =xx
 		Dimensions: 3,3
@@ -1155,6 +1157,7 @@ palace:
 		DisplayBeacon: True
 		DisplayRadarPing: True
 		CameraRange: 10c0
+		CameraRemoveDelay: 60
 		ArrowSequence: arrow
 		CircleSequence: circles
 		FlightVelocity: 384


### PR DESCRIPTION
I propose these small changes that make gameplay easier in d2k

- Add rally point for Palace: usefull for Saboteur and Fremen support powers. Downside: Rally point will be also available for harkonnen palace which has no use for it. (Adding RequiresCondition for Rallypoint is beyond my scope)
- Remove harvester _MustBeDestroyed_ trait for campaings: looking for every single harvester on fog of war maps can be annoying. 
- Allow Carryalls owned by player to be visible under the fog: so you know where your harvesters are going.
- Increased CameraRemoveDelay on Superweapons. On default values view was removed before you can see impact. 