### PR TITLE
Use SDL.SDL_OpenURL instead of Process.Start to open FAQ and Logs

### DIFF
--- a/OpenRA.WindowsLauncher/Program.cs
+++ b/OpenRA.WindowsLauncher/Program.cs
@@ -167,7 +167,7 @@ namespace OpenRA.WindowsLauncher
 				{
 					try
 					{
-						Process.Start(faqUrl);
+						SDL.SDL_OpenURL(faqUrl);
 					}
 					catch { }
 					break;
@@ -177,7 +177,7 @@ namespace OpenRA.WindowsLauncher
 				{
 					try
 					{
-						Process.Start(Path.Combine(Platform.SupportDir, "Logs"));
+						SDL.SDL_OpenURL(Path.Combine(Platform.SupportDir, "Logs"));
 					}
 					catch { }
 					break;


### PR DESCRIPTION
`Process.Start` doesn't seem to work as previously any more. Using `Process.Start("explorer.exe", path);` would have worked for the Logs, but `SDL.SDL_OpenURL` works in both cases.