### PR TITLE
don't notify players a Harvester is under attack when it's healing

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
@@ -57,6 +57,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (e.Attacker != null && e.Attacker.Owner == self.Owner)
 				return;
 
+			// Don't track healing
+			if (e.Damage.Value < 0)
+			 	return;
+
 			// Only track last hit against our harvesters
 			if (!self.Info.HasTraitInfo<HarvesterInfo>())
 				return;


### PR DESCRIPTION
When making a Harvester out of an unconventional unit (e.g. Infantry) that also has the inherited Trait `^HealsOnTiberium`, it will constantly notify players the Harvester is 'under attack' when it's actually healing from standing around in Tiberium.

This is a niche scenario, I realise, but for this and other edge-cases where the Harvester might be healing from other sources, it makes sense to exit-out of the damage notif function early if the '''damage''' is no concern.

That, or perhaps we should introduce a separate healing mechanic if we don't want negative damage (healing) to go through all the regular "I was damaged" channels when that's not appropriate.