### PR TITLE
Add pressed state to D2K ScrollItemWidget

### DIFF
--- a/mods/d2k/chrome.yaml
+++ b/mods/d2k/chrome.yaml
@@ -451,6 +451,9 @@ scrollitem:
 scrollitem-hover:
 	Inherits: button
 
+scrollitem-pressed:
+	Inherits: button-hover
+
 scrollitem-highlighted:
 	Inherits: button-pressed
 


### PR DESCRIPTION
Split from #20285

As of #20218 scroll item has no pressed state and it doesn't look great. 
Instead of reverting it to `button` like it is on release, I'm improving it by defining it as `button-hover`. I think it's a nice polish