### PR TITLE
Add pressed state to RA and TS ScrollItemWidget

### DIFF
--- a/mods/ra/chrome.yaml
+++ b/mods/ra/chrome.yaml
@@ -287,11 +287,16 @@ observer-scrollheader:
 observer-scrollheader-highlighted:
 	Inherits: observer-scrollpanel-button-disabled
 
-observer-scrollitem-highlighted:
-	Inherits: observer-scrollpanel-button-pressed
+observer-scrollitem:
 
 observer-scrollitem-hover:
 	Inherits: observer-scrollpanel-button
+
+observer-scrollitem-pressed:
+	Inherits: observer-scrollpanel-button
+
+observer-scrollitem-highlighted:
+	Inherits: observer-scrollpanel-button-pressed
 
 # Used for the main menu frame
 dialog:
@@ -581,6 +586,9 @@ checkbox-toggle-highlighted-pressed:
 scrollitem:
 
 scrollitem-hover:
+	Inherits: button
+
+scrollitem-pressed:
 	Inherits: button
 
 scrollitem-highlighted:

--- a/mods/ts/chrome.yaml
+++ b/mods/ts/chrome.yaml
@@ -713,6 +713,9 @@ scrollitem:
 scrollitem-hover:
 	Inherits: button
 
+scrollitem-pressed:
+	Inherits: button
+
 scrollitem-highlighted:
 	Inherits: button-pressed
 


### PR DESCRIPTION
Split from #20285

As of #20218 scroll item has no pressed state. I personally prefer that, as it makes the widget more interactive and to me looks pretty good. However as this was not an intentional change and @dragunoff is against not having anything displayed I'm reverting it.

before

https://user-images.githubusercontent.com/37534529/189659704-a51122c7-5db9-419b-8d04-b828964e25a6.mov

after

https://user-images.githubusercontent.com/37534529/189659720-dedc93e0-26b6-4ae0-9c10-fe3cc8cca43b.mov

before 

https://user-images.githubusercontent.com/37534529/189659867-358b9e98-8b03-44bf-bd8f-232446346213.mov

after

https://user-images.githubusercontent.com/37534529/189659885-e851f321-db8e-4c14-9eb5-0c8593780be5.mov 