### PR TITLE
Fix crushables and parachuted crates causing HPF to crash.

### DIFF
--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -120,8 +120,11 @@ namespace OpenRA.Mods.Common.Activities
 					var move = actor.Trait<IMove>();
 					var pos = actor.Trait<IPositionable>();
 
-					pos.SetPosition(actor, exitSubCell.Value.Cell, exitSubCell.Value.SubCell);
+					// HACK: Call SetCenterPosition before SetPosition
+					// So when SetPosition calls ActorMap.CellUpdated
+					// the listeners see the new CenterPosition.
 					pos.SetCenterPosition(actor, spawn);
+					pos.SetPosition(actor, exitSubCell.Value.Cell, exitSubCell.Value.SubCell);
 
 					actor.CancelActivity();
 					w.Add(actor);

--- a/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
@@ -46,9 +46,12 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Moves from outside the world into the cell grid.")]
 		public void MoveIntoWorld(CPos cell)
 		{
+			// HACK: Call SetCenterPosition before SetPosition
+			// So when SetPosition calls ActorMap.CellUpdated
+			// the listeners see the new CenterPosition.
 			var pos = Self.CenterPosition;
-			mobile.SetPosition(Self, cell);
 			mobile.SetCenterPosition(Self, pos);
+			mobile.SetPosition(Self, cell);
 			Self.QueueActivity(mobile.ReturnToCell(Self));
 		}
 

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -183,16 +183,22 @@ namespace OpenRA.Mods.Common.Traits
 		// Sets the location (Location) and position (CenterPosition)
 		public void SetPosition(Actor self, WPos pos)
 		{
+			// HACK: Call SetCenterPosition before SetLocation
+			// So when SetLocation calls ActorMap.CellUpdated
+			// the listeners see the new CenterPosition.
 			var cell = self.World.Map.CellContaining(pos);
-			SetLocation(self, cell);
 			SetCenterPosition(self, self.World.Map.CenterOfCell(cell) + new WVec(WDist.Zero, WDist.Zero, self.World.Map.DistanceAboveTerrain(pos)));
+			SetLocation(self, cell);
 		}
 
 		// Sets the location (Location) and position (CenterPosition)
 		public void SetPosition(Actor self, CPos cell, SubCell subCell = SubCell.Any)
 		{
-			SetLocation(self, cell);
+			// HACK: Call SetCenterPosition before SetLocation
+			// So when SetLocation calls ActorMap.CellUpdated
+			// the listeners see the new CenterPosition.
 			SetCenterPosition(self, self.World.Map.CenterOfCell(cell));
+			SetLocation(self, cell);
 		}
 
 		// Sets only the CenterPosition

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -468,22 +468,28 @@ namespace OpenRA.Mods.Common.Traits
 		public void SetPosition(Actor self, CPos cell, SubCell subCell = SubCell.Any)
 		{
 			subCell = GetValidSubCell(subCell);
-			SetLocation(cell, subCell, cell, subCell);
 
 			var position = cell.Layer == 0 ? self.World.Map.CenterOfCell(cell) :
 				self.World.GetCustomMovementLayers()[cell.Layer].CenterOfCell(cell);
 
+			// HACK: Call SetCenterPosition before SetLocation
+			// So when SetLocation calls ActorMap.CellUpdated
+			// the listeners see the new CenterPosition.
 			var subcellOffset = self.World.Map.Grid.OffsetOfSubCell(subCell);
 			SetCenterPosition(self, position + subcellOffset);
+			SetLocation(cell, subCell, cell, subCell);
 			FinishedMoving(self);
 		}
 
 		// Sets the location (fromCell, toCell, FromSubCell, ToSubCell) and CenterPosition
 		public void SetPosition(Actor self, WPos pos)
 		{
+			// HACK: Call SetCenterPosition before SetLocation
+			// So when SetLocation calls ActorMap.CellUpdated
+			// the listeners see the new CenterPosition.
 			var cell = self.World.Map.CellContaining(pos);
-			SetLocation(cell, FromSubCell, cell, FromSubCell);
 			SetCenterPosition(self, self.World.Map.CenterOfSubCell(cell, FromSubCell) + new WVec(0, 0, self.World.Map.DistanceAboveTerrain(pos).Length));
+			SetLocation(cell, FromSubCell, cell, FromSubCell);
 			FinishedMoving(self);
 		}
 
@@ -686,8 +692,11 @@ namespace OpenRA.Mods.Common.Traits
 					subCell = self.World.Map.Grid.DefaultSubCell;
 
 				// Reserve the exit cell
-				mobile.SetPosition(self, cell, subCell);
+				// HACK: Call SetCenterPosition before SetPosition
+				// So when SetPosition calls ActorMap.CellUpdated
+				// the listeners see the new CenterPosition.
 				mobile.SetCenterPosition(self, pos);
+				mobile.SetPosition(self, cell, subCell);
 
 				if (delay > 0)
 					QueueChild(new Wait(delay));

--- a/OpenRA.Mods.Common/Traits/ParaDrop.cs
+++ b/OpenRA.Mods.Common/Traits/ParaDrop.cs
@@ -102,10 +102,12 @@ namespace OpenRA.Mods.Common.Traits
 
 			self.World.AddFrameEndTask(w =>
 			{
-				dropPositionable.SetPosition(dropActor, dropCell, dropSubCell);
-
+				// HACK: Call SetCenterPosition before SetPosition
+				// So when SetPosition calls ActorMap.CellUpdated
+				// the listeners see the new CenterPosition.
 				var dropPosition = dropActor.CenterPosition + new WVec(0, 0, self.CenterPosition.Z - dropActor.CenterPosition.Z);
 				dropPositionable.SetCenterPosition(dropActor, dropPosition);
+				dropPositionable.SetPosition(dropActor, dropCell, dropSubCell);
 				w.Add(dropActor);
 			});
 


### PR DESCRIPTION
Fixes #20307, fixes #20308, fixes #20309

When crushables and crates change their Location/TopLeft, their crushability is cached, but when their CenterPosition is changed, their cached crushability is not refreshed. Since their CrushableBy functions depends on IsAtGroundLevel, which depends on the CenterPosition, this means that when the crushability is cached it will depend on the current height of the object. If the height of the object changes, the cache is not refreshed and now contains out of date information.

The Locomotor cache and the HPF both cache this same information, but at different times. HPF caches immediately, but Locomotor caches on demand which means there can be a delay. This means they can have inconsistent, differing views of the crushability information. This eventually surfaces in a "The abstract path should never be searched for an unreachable point." error from HPF when it detects the inconsistency.

The bug is that Locomotor was caching information without refreshing it when required. Fixing this to refresh the cache when the CenterPosition changes is likely to have negative performance impacts. As would removing crushability from the cache. These would both be fixes that address the underlying bug.

The high impacts of a proper fix lead us to a workaround instead. If we set the CenterPosition before setting the Location, then when the Location is set and the caches are refreshed, the new CenterPosition is available when caching the crushability information. This means logic depending on IsAtGroundLevel will get the new information and cache a more up-to-date view of things. This means when changing both the CenterPosition and Location together we now cache correct information. However calls that set only the CenterPosition and not the Location can still result in a bad cache state. Although this is imperfect it is an improvement over current affairs, and has less impact.

----

Sequence of events causing issue on bleed:

- A crate is airdropped and lands
- The crate's Location is set
- ActorMap.CellUpdated is fired.
- Locomotor notes the cell as dirty in the cache
- HPF caches the crushability of the cell. As the crate is not IsAtGroundLevel, it cannot be crushed.
- The crate's CenterPosition is set (IsAtGroundLevel would now be true)
- ActorMap.CellUpdated does NOT get fired for CenterPosition updates. So Locomotor and HPF do nothing.
- Later, a path search begins that goes through the cell with the crate in.
- Locomotor notes it has a dirty cache and refreshes. It caches the crushability of the cell. As the crate IsAtGroundLevel, it can be crushed.
- The path search tries to enter the cell, as Locomotor thinks it can be entered, because the crate can be crushed. HPF throws a wobbly because it sees the cell as unreachable - it contains an uncrushable crate.

Sequence in this PR
- A crate is airdropped and lands
- The crate's CenterPosition is set (IsAtGroundLevel would now be true)
- ActorMap.CellUpdated does NOT get fired for CenterPosition updates. So Locomotor and HPF do nothing.
- The crate's Location is set
- ActorMap.CellUpdated is fired.
- Locomotor notes the cell as dirty in the cache
- HPF caches the crushability of the cell. As the crate IsAtGroundLevel, it *can* be crushed.
- Later, a path search begins that goes through the cell with the crate in.
- Locomotor notes it has a dirty cache and refreshes. It caches the crushability of the cell. As the crate IsAtGroundLevel, it can be crushed.
- The path search tries to enter the cell, as Locomotor thinks it can be entered, because the crate can be crushed. HPF also sees the cell can be entered because the crate can be crushed. No error.