### PR TITLE
Refactor MapPreviewLogic

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -423,14 +423,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					modData.MapCache.UpdateMaps();
 			}
 
+			bool StartDisabled() => map.Status != MapStatus.Available ||
+				orderManager.LobbyInfo.Slots.Any(sl => sl.Value.Required && orderManager.LobbyInfo.ClientInSlot(sl.Key) == null) ||
+				orderManager.LobbyInfo.Slots.All(sl => orderManager.LobbyInfo.ClientInSlot(sl.Key) == null) ||
+				(!orderManager.LobbyInfo.GlobalSettings.EnableSingleplayer && orderManager.LobbyInfo.NonBotPlayers.Count() < 2) ||
+				insufficientPlayerSpawns;
+
 			var startGameButton = lobby.GetOrNull<ButtonWidget>("START_GAME_BUTTON");
 			if (startGameButton != null)
 			{
-				startGameButton.IsDisabled = () => configurationDisabled() || map.Status != MapStatus.Available ||
-					orderManager.LobbyInfo.Slots.Any(sl => sl.Value.Required && orderManager.LobbyInfo.ClientInSlot(sl.Key) == null) ||
-					orderManager.LobbyInfo.Slots.All(sl => orderManager.LobbyInfo.ClientInSlot(sl.Key) == null) ||
-					(!orderManager.LobbyInfo.GlobalSettings.EnableSingleplayer && orderManager.LobbyInfo.NonBotPlayers.Count() < 2) ||
-					insufficientPlayerSpawns;
+				startGameButton.IsDisabled = () => configurationDisabled() || StartDisabled();
 
 				startGameButton.OnClick = () =>
 				{
@@ -445,7 +447,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var forceStartBin = Ui.LoadWidget("FORCE_START_DIALOG", lobby.Get("TOP_PANELS_ROOT"), new WidgetArgs());
 			forceStartBin.IsVisible = () => panel == PanelType.ForceStart;
 			forceStartBin.Get("KICK_WARNING").IsVisible = () => orderManager.LobbyInfo.Clients.Any(c => c.IsInvalid);
-			forceStartBin.Get<ButtonWidget>("OK_BUTTON").OnClick = StartGame;
+			var forceStartButton = forceStartBin.Get<ButtonWidget>("OK_BUTTON");
+			forceStartButton.OnClick = StartGame;
+			forceStartButton.IsDisabled = StartDisabled;
+
 			forceStartBin.Get<ButtonWidget>("CANCEL_BUTTON").OnClick = () => panel = PanelType.Players;
 
 			var disconnectButton = lobby.Get<ButtonWidget>("DISCONNECT_BUTTON");

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -182,6 +182,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{ "getSpawnOccupants", (Func<Dictionary<int, SpawnOccupant>>)(() => spawnOccupants) },
 				{ "getDisabledSpawnPoints", (Func<HashSet<int>>)(() => orderManager.LobbyInfo.DisabledSpawnPoints) },
 				{ "showUnoccupiedSpawnpoints", true },
+				{ "mapUpdatesEnabled", true },
+				{
+					"onMapUpdate", (Action<string>)(uid =>
+					{
+						orderManager.IssueOrder(Order.Command("map " + uid));
+						Game.Settings.Server.Map = uid;
+						Game.Settings.Save();
+					})
+				},
 			});
 
 			mapContainer.IsVisible = () => panel != PanelType.Servers;
@@ -234,7 +243,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						{ "initialMap", modData.MapCache.PickLastModifiedMap(MapVisibility.Lobby) ?? map.Uid },
 						{ "initialTab", MapClassification.System },
-						{ "onExit", Game.IsHost ? UpdateSelectedMap : modData.MapCache.UpdateMaps },
+						{ "onExit", modData.MapCache.UpdateMaps },
 						{ "onSelect", Game.IsHost ? onSelect : null },
 						{ "filter", MapVisibility.Lobby },
 					});
@@ -411,7 +420,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					orderManager.IssueOrder(Order.Command("startgame"));
 				}
 				else
-					UpdateSelectedMap();
+					modData.MapCache.UpdateMaps();
 			}
 
 			var startGameButton = lobby.GetOrNull<ButtonWidget>("START_GAME_BUTTON");
@@ -870,20 +879,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			DiscordService.UpdateStatus(state, details);
 
 			onStart();
-		}
-
-		void UpdateSelectedMap()
-		{
-			if (modData.MapCache[map.Uid].Status == MapStatus.Available)
-				return;
-
-			var uid = modData.MapCache.GetUpdatedMap(map.Uid);
-			if (uid != null)
-			{
-				orderManager.IssueOrder(Order.Command("map " + uid));
-				Game.Settings.Server.Map = uid;
-				Game.Settings.Save();
-			}
 		}
 	}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -176,6 +176,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{ "getSpawnOccupants", (Func<Dictionary<int, SpawnOccupant>>)(() => spawnOccupants.Update(selectedReplay)) },
 				{ "getDisabledSpawnPoints", (Func<HashSet<int>>)(() => disabledSpawnPoints.Update(selectedReplay)) },
 				{ "showUnoccupiedSpawnpoints", false },
+				{ "mapUpdatesEnabled", false },
+				{ "onMapUpdate", (Action<string>)(_ => { }) },
 			});
 
 			var replayDuration = new CachedTransform<ReplayMetadata, string>(r =>

--- a/mods/cnc/chrome/lobby-mappreview.yaml
+++ b/mods/cnc/chrome/lobby-mappreview.yaml
@@ -3,7 +3,7 @@ Container@MAP_PREVIEW:
 	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM
 	Children:
-		Container@MAP_AVAILABLE:
+		Container@MAP_LARGE:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
 			Children:
@@ -26,6 +26,33 @@ Container@MAP_PREVIEW:
 					Align: Center
 					TooltipContainer: TOOLTIP_CONTAINER
 					TooltipTemplate: SIMPLE_TOOLTIP
+		Container@MAP_SMALL:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Children:
+				Background@MAP_BG:
+					Width: PARENT_RIGHT
+					Height: 142
+					Background: panel-gray
+					Children:
+						MapPreview@MAP_PREVIEW:
+							X: 1
+							Y: 1
+							Width: PARENT_RIGHT - 2
+							Height: PARENT_BOTTOM - 2
+							TooltipContainer: TOOLTIP_CONTAINER
+				LabelWithTooltip@MAP_TITLE:
+					Y: 143
+					Width: PARENT_RIGHT
+					Height: 25
+					Font: Bold
+					Align: Center
+					TooltipContainer: TOOLTIP_CONTAINER
+					TooltipTemplate: SIMPLE_TOOLTIP
+		Container@MAP_AVAILABLE:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Children:
 				Label@MAP_TYPE:
 					Y: 188
 					Width: PARENT_RIGHT
@@ -39,29 +66,10 @@ Container@MAP_PREVIEW:
 					Height: 25
 					Font: Tiny
 					Align: Center
-		Container@MAP_INVALID:
+		Container@MAP_INCOMPATIBLE:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
 			Children:
-				Background@MAP_BG:
-					Width: PARENT_RIGHT
-					Height: 174
-					Background: panel-gray
-					Children:
-						MapPreview@MAP_PREVIEW:
-							X: 1
-							Y: 1
-							Width: PARENT_RIGHT - 2
-							Height: PARENT_BOTTOM - 2
-							TooltipContainer: TOOLTIP_CONTAINER
-				LabelWithTooltip@MAP_TITLE:
-					Y: 173
-					Width: PARENT_RIGHT
-					Height: 25
-					Font: Bold
-					Align: Center
-					TooltipContainer: TOOLTIP_CONTAINER
-					TooltipTemplate: SIMPLE_TOOLTIP
 				Label@MAP_STATUS_A:
 					Y: 188
 					Width: PARENT_RIGHT
@@ -81,25 +89,6 @@ Container@MAP_PREVIEW:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
 			Children:
-				Background@MAP_BG:
-					Width: PARENT_RIGHT
-					Height: 158
-					Background: panel-gray
-					Children:
-						MapPreview@MAP_PREVIEW:
-							X: 1
-							Y: 1
-							Width: PARENT_RIGHT - 2
-							Height: PARENT_BOTTOM - 2
-							TooltipContainer: TOOLTIP_CONTAINER
-				LabelWithTooltip@MAP_TITLE:
-					Y: 159
-					Width: PARENT_RIGHT
-					Height: 25
-					Font: Bold
-					Align: Center
-					TooltipContainer: TOOLTIP_CONTAINER
-					TooltipTemplate: SIMPLE_TOOLTIP
 				Label@MAP_STATUS_VALIDATING:
 					Y: 174
 					Width: PARENT_RIGHT
@@ -108,34 +97,15 @@ Container@MAP_PREVIEW:
 					Align: Center
 					Text: Validating...
 					IgnoreMouseOver: true
-				ProgressBar@MAP_PROGRESSBAR:
+				ProgressBar@MAP_VALIDATING_BAR:
 					Y: 194
 					Width: PARENT_RIGHT
 					Height: 25
 					Indeterminate: True
-		Container@MAP_DOWNLOADABLE:
+		Container@MAP_DOWNLOAD_AVAILABLE:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
 			Children:
-				Background@MAP_BG:
-					Width: PARENT_RIGHT
-					Height: 142
-					Background: panel-gray
-					Children:
-						MapPreview@MAP_PREVIEW:
-							X: 1
-							Y: 1
-							Width: PARENT_RIGHT - 2
-							Height: PARENT_BOTTOM - 2
-							TooltipContainer: TOOLTIP_CONTAINER
-				LabelWithTooltip@MAP_TITLE:
-					Y: 143
-					Width: PARENT_RIGHT
-					Height: 25
-					Font: Bold
-					Align: Center
-					TooltipContainer: TOOLTIP_CONTAINER
-					TooltipTemplate: SIMPLE_TOOLTIP
 				Label@MAP_TYPE:
 					Y: 158
 					Width: PARENT_RIGHT
@@ -154,61 +124,56 @@ Container@MAP_PREVIEW:
 					Width: PARENT_RIGHT
 					Height: 25
 					Text: Install Map
-		Container@MAP_PROGRESS:
+		Button@MAP_UPDATE:
+			Y: 195
+			Width: PARENT_RIGHT
+			Height: 25
+			Text: Update Map
+		Container@MAP_UPDATE_DOWNLOAD_AVAILABLE:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
 			Children:
-				Background@MAP_BG:
-					Width: PARENT_RIGHT
-					Height: 142
-					Background: panel-gray
-					Children:
-						MapPreview@MAP_PREVIEW:
-							X: 1
-							Y: 1
-							Width: PARENT_RIGHT - 2
-							Height: PARENT_BOTTOM - 2
-							TooltipContainer: TOOLTIP_CONTAINER
-				LabelWithTooltip@MAP_TITLE:
-					Y: 143
+				Button@MAP_INSTALL:
+					Y: 166
 					Width: PARENT_RIGHT
 					Height: 25
-					Font: Bold
-					Align: Center
-					TooltipContainer: TOOLTIP_CONTAINER
-					TooltipTemplate: SIMPLE_TOOLTIP
-				Label@MAP_STATUS_SEARCHING:
+					Text: Install Map
+		Label@MAP_SEARCHING:
+			Y: 158
+			Width: PARENT_RIGHT
+			Height: 25
+			Font: Tiny
+			Align: Center
+			Text: Searching OpenRA Resource Center...
+			IgnoreMouseOver: true
+		Container@MAP_UNAVAILABLE:
+			Width: PARENT_RIGHT
+			Children:
+				Label@a:
 					Y: 158
 					Width: PARENT_RIGHT
 					Height: 25
 					Font: Tiny
 					Align: Center
-					Text: Searching OpenRA Resource Center...
-					IgnoreMouseOver: true
-				Container@MAP_STATUS_UNAVAILABLE:
-					Width: PARENT_RIGHT
-					Children:
-						Label@a:
-							Y: 158
-							Width: PARENT_RIGHT
-							Height: 25
-							Font: Tiny
-							Align: Center
-							Text: This map was not found on the
-						Label@b:
-							Y: 171
-							Width: PARENT_RIGHT
-							Height: 25
-							Font: Tiny
-							Align: Center
-							Text: OpenRA Resource Center
-				Label@MAP_STATUS_ERROR:
-					Y: 158
+					Text: This map was not found on the
+				Label@b:
+					Y: 171
 					Width: PARENT_RIGHT
 					Height: 25
 					Font: Tiny
 					Align: Center
-					Text: An error occurred during installation
+					Text: OpenRA Resource Center
+		Label@MAP_ERROR:
+			Y: 158
+			Width: PARENT_RIGHT
+			Height: 25
+			Font: Tiny
+			Align: Center
+			Text: An error occurred during installation
+		Container@MAP_DOWNLOADING:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Children:
 				Label@MAP_STATUS_DOWNLOADING:
 					Y: 158
 					Width: PARENT_RIGHT
@@ -220,7 +185,24 @@ Container@MAP_PREVIEW:
 					Width: PARENT_RIGHT
 					Height: 25
 					Indeterminate: True
-				Button@MAP_RETRY:
-					Y: 194
+		Button@MAP_RETRY:
+			Y: 194
+			Width: PARENT_RIGHT
+			Height: 25
+		Container@MAP_UPDATE_AVAILABLE:
+			Width: PARENT_RIGHT
+			Children:
+				Label@a:
+					Y: 158
 					Width: PARENT_RIGHT
 					Height: 25
+					Font: Tiny
+					Align: Center
+					Text: A new version of the map
+				Label@b:
+					Y: 171
+					Width: PARENT_RIGHT
+					Height: 25
+					Font: Tiny
+					Align: Center
+					Text: was found on your computer

--- a/mods/common/chrome/lobby-mappreview.yaml
+++ b/mods/common/chrome/lobby-mappreview.yaml
@@ -3,7 +3,7 @@ Container@MAP_PREVIEW:
 	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM
 	Children:
-		Container@MAP_AVAILABLE:
+		Container@MAP_LARGE:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
 			Children:
@@ -26,6 +26,33 @@ Container@MAP_PREVIEW:
 					Align: Center
 					TooltipContainer: TOOLTIP_CONTAINER
 					TooltipTemplate: SIMPLE_TOOLTIP
+		Container@MAP_SMALL:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Children:
+				Background@MAP_BG:
+					Width: PARENT_RIGHT
+					Height: 142
+					Background: dialog3
+					Children:
+						MapPreview@MAP_PREVIEW:
+							X: 1
+							Y: 1
+							Width: PARENT_RIGHT - 2
+							Height: PARENT_BOTTOM - 2
+							TooltipContainer: TOOLTIP_CONTAINER
+				LabelWithTooltip@MAP_TITLE:
+					Y: 143
+					Width: PARENT_RIGHT
+					Height: 25
+					Font: Bold
+					Align: Center
+					TooltipContainer: TOOLTIP_CONTAINER
+					TooltipTemplate: SIMPLE_TOOLTIP
+		Container@MAP_AVAILABLE:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Children:
 				Label@MAP_TYPE:
 					Y: 188
 					Width: PARENT_RIGHT
@@ -39,29 +66,10 @@ Container@MAP_PREVIEW:
 					Height: 25
 					Font: Tiny
 					Align: Center
-		Container@MAP_INVALID:
+		Container@MAP_INCOMPATIBLE:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
 			Children:
-				Background@MAP_BG:
-					Width: PARENT_RIGHT
-					Height: 174
-					Background: dialog3
-					Children:
-						MapPreview@MAP_PREVIEW:
-							X: 1
-							Y: 1
-							Width: PARENT_RIGHT - 2
-							Height: PARENT_BOTTOM - 2
-							TooltipContainer: TOOLTIP_CONTAINER
-				LabelWithTooltip@MAP_TITLE:
-					Y: 173
-					Width: PARENT_RIGHT
-					Height: 25
-					Font: Bold
-					Align: Center
-					TooltipContainer: TOOLTIP_CONTAINER
-					TooltipTemplate: SIMPLE_TOOLTIP
 				Label@MAP_STATUS_A:
 					Y: 188
 					Width: PARENT_RIGHT
@@ -81,25 +89,6 @@ Container@MAP_PREVIEW:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
 			Children:
-				Background@MAP_BG:
-					Width: PARENT_RIGHT
-					Height: 158
-					Background: dialog3
-					Children:
-						MapPreview@MAP_PREVIEW:
-							X: 1
-							Y: 1
-							Width: PARENT_RIGHT - 2
-							Height: PARENT_BOTTOM - 2
-							TooltipContainer: TOOLTIP_CONTAINER
-				LabelWithTooltip@MAP_TITLE:
-					Y: 159
-					Width: PARENT_RIGHT
-					Height: 25
-					Font: Bold
-					Align: Center
-					TooltipContainer: TOOLTIP_CONTAINER
-					TooltipTemplate: SIMPLE_TOOLTIP
 				Label@MAP_STATUS_VALIDATING:
 					Y: 174
 					Width: PARENT_RIGHT
@@ -108,34 +97,15 @@ Container@MAP_PREVIEW:
 					Align: Center
 					Text: Validating...
 					IgnoreMouseOver: true
-				ProgressBar@MAP_PROGRESSBAR:
+				ProgressBar@MAP_VALIDATING_BAR:
 					Y: 194
 					Width: PARENT_RIGHT
 					Height: 25
 					Indeterminate: True
-		Container@MAP_DOWNLOADABLE:
+		Container@MAP_DOWNLOAD_AVAILABLE:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
 			Children:
-				Background@MAP_BG:
-					Width: PARENT_RIGHT
-					Height: 142
-					Background: dialog3
-					Children:
-						MapPreview@MAP_PREVIEW:
-							X: 1
-							Y: 1
-							Width: PARENT_RIGHT - 2
-							Height: PARENT_BOTTOM - 2
-							TooltipContainer: TOOLTIP_CONTAINER
-				LabelWithTooltip@MAP_TITLE:
-					Y: 143
-					Width: PARENT_RIGHT
-					Height: 25
-					Font: Bold
-					Align: Center
-					TooltipContainer: TOOLTIP_CONTAINER
-					TooltipTemplate: SIMPLE_TOOLTIP
 				Label@MAP_TYPE:
 					Y: 158
 					Width: PARENT_RIGHT
@@ -155,61 +125,58 @@ Container@MAP_PREVIEW:
 					Height: 25
 					Font: Bold
 					Text: Install Map
-		Container@MAP_PROGRESS:
+		Button@MAP_UPDATE:
+			Y: 195
+			Width: PARENT_RIGHT
+			Height: 25
+			Font: Bold
+			Text: Update Map
+		Container@MAP_UPDATE_DOWNLOAD_AVAILABLE:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
 			Children:
-				Background@MAP_BG:
-					Width: PARENT_RIGHT
-					Height: 142
-					Background: dialog3
-					Children:
-						MapPreview@MAP_PREVIEW:
-							X: 1
-							Y: 1
-							Width: PARENT_RIGHT - 2
-							Height: PARENT_BOTTOM - 2
-							TooltipContainer: TOOLTIP_CONTAINER
-				LabelWithTooltip@MAP_TITLE:
-					Y: 143
+				Button@MAP_INSTALL:
+					Y: 166
 					Width: PARENT_RIGHT
 					Height: 25
 					Font: Bold
-					Align: Center
-					TooltipContainer: TOOLTIP_CONTAINER
-					TooltipTemplate: SIMPLE_TOOLTIP
-				Label@MAP_STATUS_SEARCHING:
+					Text: Install Map
+		Label@MAP_SEARCHING:
+			Y: 158
+			Width: PARENT_RIGHT
+			Height: 25
+			Font: Tiny
+			Align: Center
+			Text: Searching OpenRA Resource Center...
+			IgnoreMouseOver: true
+		Container@MAP_UNAVAILABLE:
+			Width: PARENT_RIGHT
+			Children:
+				Label@a:
 					Y: 158
 					Width: PARENT_RIGHT
 					Height: 25
 					Font: Tiny
 					Align: Center
-					Text: Searching OpenRA Resource Center...
-					IgnoreMouseOver: true
-				Container@MAP_STATUS_UNAVAILABLE:
-					Width: PARENT_RIGHT
-					Children:
-						Label@a:
-							Y: 158
-							Width: PARENT_RIGHT
-							Height: 25
-							Font: Tiny
-							Align: Center
-							Text: This map was not found on the
-						Label@b:
-							Y: 171
-							Width: PARENT_RIGHT
-							Height: 25
-							Font: Tiny
-							Align: Center
-							Text: OpenRA Resource Center
-				Label@MAP_STATUS_ERROR:
-					Y: 158
+					Text: This map was not found on the
+				Label@b:
+					Y: 171
 					Width: PARENT_RIGHT
 					Height: 25
 					Font: Tiny
 					Align: Center
-					Text: An error occurred during installation
+					Text: OpenRA Resource Center
+		Label@MAP_ERROR:
+			Y: 158
+			Width: PARENT_RIGHT
+			Height: 25
+			Font: Tiny
+			Align: Center
+			Text: An error occurred during installation
+		Container@MAP_DOWNLOADING:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Children:
 				Label@MAP_STATUS_DOWNLOADING:
 					Y: 158
 					Width: PARENT_RIGHT
@@ -221,8 +188,25 @@ Container@MAP_PREVIEW:
 					Width: PARENT_RIGHT
 					Height: 25
 					Indeterminate: True
-				Button@MAP_RETRY:
-					Y: 194
+		Button@MAP_RETRY:
+			Y: 194
+			Width: PARENT_RIGHT
+			Height: 25
+			Font: Bold
+		Container@MAP_UPDATE_AVAILABLE:
+			Width: PARENT_RIGHT
+			Children:
+				Label@a:
+					Y: 158
 					Width: PARENT_RIGHT
 					Height: 25
-					Font: Bold
+					Font: Tiny
+					Align: Center
+					Text: A new version of the map
+				Label@b:
+					Y: 171
+					Width: PARENT_RIGHT
+					Height: 25
+					Font: Tiny
+					Align: Center
+					Text: was found on your computer


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/pull/20101#issuecomment-1232078829
And adds a button for updating the map via `MapCache.GetUpdatedMap`

`MapPreviewLogic` is completely refactored, but on the user end is should work and look almost exactly the same. This new system is based on `Dictionary<enum PreviewStatus, Widget[]>`. This allows us to easily choose what widgets are visible on what on status, and detect status changes.

I removed much of the duplicate widgets, as well as improved how they are handled. Now all the inner widgets are hardcoded, instead of *some* of them being optional. This allows me to have much better quality code and makes debugging for modders much easier.

This refactor paves way for the eventual continuous updating of MapCache. It would be impossible to implement it cleanly with the current code.