### PR TITLE
Fix the incompatible replay dialogue translations

### DIFF
--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Linguini.Bundle" Version="0.2.2" />
+    <PackageReference Include="Linguini.Bundle" Version="0.3.1" />
     <PackageReference Include="OpenRA-Eluant" Version="1.0.18" />
     <PackageReference Include="Mono.NAT" Version="3.0.3" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
@@ -24,6 +24,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		static readonly string IncompatibleReplayPrompt = "incompatible-replay-prompt";
 
 		[TranslationReference]
+		static readonly string IncompatibleReplayAccept = "incompatible-replay-accept";
+
+		[TranslationReference]
 		static readonly string UnknownVersion = "incompatible-replay-unknown-version";
 
 		[TranslationReference]
@@ -46,12 +49,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				onCancel = DoNothing;
 
 			if (replayMeta == null)
-			{
-				ConfirmationDialogs.ButtonPrompt(modData, IncompatibleReplayTitle,
-					IncompatibleReplayPrompt, onCancel: onCancel);
-
-				return false;
-			}
+				return IncompatibleReplayDialog(IncompatibleReplayPrompt, null, modData, onCancel);
 
 			var version = replayMeta.GameInfo.Version;
 			if (version == null)
@@ -75,7 +73,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		static bool IncompatibleReplayDialog(string text, Dictionary<string, object> textArguments, ModData modData, Action onCancel)
 		{
-			ConfirmationDialogs.ButtonPrompt(modData, IncompatibleReplayTitle, text, textArguments: textArguments, onCancel: onCancel);
+			ConfirmationDialogs.ButtonPrompt(modData, IncompatibleReplayTitle, text, textArguments: textArguments, onCancel: onCancel, cancelText: IncompatibleReplayAccept);
 			return false;
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
@@ -23,10 +23,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference]
 		static readonly string IncompatibleReplayPrompt = "incompatible-replay-prompt";
 
-		[TranslationReference("version")]
+		[TranslationReference]
 		static readonly string UnknownVersion = "incompatible-replay-unknown-version";
 
-		[TranslationReference("mod")]
+		[TranslationReference]
 		static readonly string UnknownMod = "incompatible-replay-unknown-mod";
 
 		[TranslationReference("mod")]
@@ -55,11 +55,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var version = replayMeta.GameInfo.Version;
 			if (version == null)
-				return IncompatibleReplayDialog(UnknownVersion, Translation.Arguments("version", version), modData, onCancel);
+				return IncompatibleReplayDialog(UnknownVersion, null, modData, onCancel);
 
 			var mod = replayMeta.GameInfo.Mod;
 			if (mod == null)
-				return IncompatibleReplayDialog(UnknownMod, Translation.Arguments("mod", mod), modData, onCancel);
+				return IncompatibleReplayDialog(UnknownMod, null, modData, onCancel);
 
 			if (!Game.Mods.ContainsKey(mod))
 				return IncompatibleReplayDialog(UnvailableMod, Translation.Arguments("mod", mod), modData, onCancel);

--- a/mods/common/languages/en.ftl
+++ b/mods/common/languages/en.ftl
@@ -502,9 +502,8 @@ replay-deletion-failed = Failed to delete replay file '{ $file }'. See the debug
 incompatible-replay-title = Incompatible Replay
 incompatible-replay-prompt = Replay metadata could not be read.
 -incompatible-replay-recorded = It was recorded with
-incompatible-replay-unknown-version = { -incompatible-replay-recorded } an unknown version:
-    { $version }.
-incompatible-replay-unknown-mod = { -incompatible-replay-recorded } an unknown mod: { $mod }.
+incompatible-replay-unknown-version = { -incompatible-replay-recorded } an unknown version.
+incompatible-replay-unknown-mod = { -incompatible-replay-recorded } an unknown mod.
 incompatible-replay-unavailable-mod = { -incompatible-replay-recorded } an unavailable mod: { $mod }.
 incompatible-replay-incompatible-version = { -incompatible-replay-recorded } an incompatible version:
     { $version }.

--- a/mods/common/languages/en.ftl
+++ b/mods/common/languages/en.ftl
@@ -502,11 +502,14 @@ replay-deletion-failed = Failed to delete replay file '{ $file }'. See the debug
 incompatible-replay-title = Incompatible Replay
 incompatible-replay-prompt = Replay metadata could not be read.
 -incompatible-replay-recorded = It was recorded with
-incompatible-replay-unknown-version = { -incompatible-replay-recorded } an unknown version: { $version }.
+incompatible-replay-unknown-version = { -incompatible-replay-recorded } an unknown version:
+    { $version }.
 incompatible-replay-unknown-mod = { -incompatible-replay-recorded } an unknown mod: { $mod }.
 incompatible-replay-unavailable-mod = { -incompatible-replay-recorded } an unavailable mod: { $mod }.
-incompatible-replay-incompatible-version = { -incompatible-replay-recorded } an incompatible version: { $version }.
-incompatible-replay-unavailable-map = { -incompatible-replay-recorded } an unavailable map: { $map }.
+incompatible-replay-incompatible-version = { -incompatible-replay-recorded } an incompatible version:
+    { $version }.
+incompatible-replay-unavailable-map = { -incompatible-replay-recorded } an unavailable map:
+    { $map }.
 
 ## ServerCreationLogic
 internet-server-nat-A = Internet Server (UPnP/NAT-PMP

--- a/mods/common/languages/en.ftl
+++ b/mods/common/languages/en.ftl
@@ -501,6 +501,7 @@ replay-deletion-failed = Failed to delete replay file '{ $file }'. See the debug
 ## ReplayUtils
 incompatible-replay-title = Incompatible Replay
 incompatible-replay-prompt = Replay metadata could not be read.
+incompatible-replay-accept = OK
 -incompatible-replay-recorded = It was recorded with
 incompatible-replay-unknown-version = { -incompatible-replay-recorded } an unknown version.
 incompatible-replay-unknown-mod = { -incompatible-replay-recorded } an unknown mod.


### PR DESCRIPTION
Updates Linguini to include the changes from https://github.com/Ygg01/Linguini/pull/24, and adds some new lines to stop the text from overflowing over the dialogue borders:
![grafik](https://user-images.githubusercontent.com/7704140/191269636-09f01d7e-269b-4324-aca0-8e04d27def4e.png)
![grafik](https://user-images.githubusercontent.com/7704140/191269645-0507712b-fc18-49b9-95f6-27536890d6a0.png)
![grafik](https://user-images.githubusercontent.com/7704140/191269656-792c76ed-85ec-496f-a47b-e3067be7378c.png)
![grafik](https://user-images.githubusercontent.com/7704140/191269981-958d808d-661c-4744-8781-3154250ad5ab.png)
