### PR TITLE
Fixed production airdrop not using all possible exits

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
@@ -111,6 +111,7 @@ namespace OpenRA.Mods.Common.Traits
 					foreach (var cargo in self.TraitsImplementing<INotifyDelivery>())
 						cargo.Delivered(self);
 
+					exit = SelectExit(self, producee, productionType);
 					self.World.AddFrameEndTask(ww => DoProduction(self, producee, exit?.Info, productionType, inits));
 					Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.ReadyAudio, self.Owner.Faction.InternalName);
 					TextNotificationsManager.AddTransientLine(info.ReadyTextNotification, self.Owner);


### PR DESCRIPTION
Dune 2000 defines two exits:

https://github.com/OpenRA/OpenRA/blob/fe72dd4140a1ade3e7557d2f2c9c8840ebcf2c3f/mods/d2k/rules/structures.yaml#L644-L649

plus don't crash when there is no exit trait as the requires was also forgotten.