### PR TITLE
Fix crash in OrderBuffer

### DIFF
--- a/OpenRA.Game/Server/OrderBuffer.cs
+++ b/OpenRA.Game/Server/OrderBuffer.cs
@@ -88,6 +88,9 @@ namespace OpenRA.Server
 
 			nextUpdate = now + Interval;
 
+			if (deltas.IsEmpty)
+				yield break;
+
 			if (deltas.Values.Any(q => q.Count != NumberOfFrames))
 				yield break;
 

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -1339,7 +1339,6 @@ namespace OpenRA.Server
 				}
 
 				SyncLobbyInfo();
-				State = ServerState.GameStarted;
 
 				var gameSpeeds = Game.ModData.Manifest.Get<GameSpeeds>();
 				var gameSpeedName = LobbyInfo.GlobalSettings.OptionOrDefault("gamespeed", gameSpeeds.DefaultSpeed);
@@ -1348,6 +1347,8 @@ namespace OpenRA.Server
 
 				orderBuffer = new OrderBuffer();
 				orderBuffer.Start(gameSpeed, Conns.Where(c => c.Validated).Select(c => c.PlayerIndex));
+
+				State = ServerState.GameStarted;
 
 				if (Type != ServerType.Local)
 					OrderLatency = gameSpeed.OrderLatency;


### PR DESCRIPTION
Should fix the crash reported by baxxter on discord. My guess it that it was caused by setting the state to `ServerState.GameStarted` before we had initialize a new orderBuffer and started  to call `GetTickScales()` with no clients.

```
Unhandled exception. System.ArgumentException: Collection must not be empty. (Parameter 'ts')
   at OpenRA.Exts.CompareBy[T,U](IEnumerable1 ts, Func2 selector, Int32 modifier, Boolean throws) in /home/runner/work/OpenRA/OpenRA/OpenRA.Game/Exts.cs:line 233
   at OpenRA.Server.OrderBuffer.GetTickScales()+MoveNext() in /home/runner/work/OpenRA/OpenRA/OpenRA.Game/Server/OrderBuffer.cs:line 97
   at OpenRA.Server.Server.<>cDisplayClass54_0.<.ctor>b2(Object _) in /home/runner/work/OpenRA/OpenRA/OpenRA.Game/Server/Server.cs:line 372
```