### PR TITLE
Fixed No Players No Bots No Spectators label overlapping

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -417,9 +417,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		string PlayerLabel(GameServer game)
 		{
-			return players.Update(game.Players)
-				+ bots.Update(game.Bots)
-				+ spectators.Update(game.Spectators);
+			var label = players.Update(game.Players);
+
+			if (game.Bots > 0)
+				label += " " + bots.Update(game.Bots);
+
+			if (game.Spectators > 0)
+				label += " " + spectators.Update(game.Spectators);
+
+			return label;
 		}
 
 		public void RefreshServerList()


### PR DESCRIPTION
Reported by @Orb370 in https://discord.com/channels/153649279762694144/388282819371204608/1023452554878791720. I misinterpreted https://github.com/OpenRA/OpenRA/commit/0b67b5bfaea9d65ca0114b8e63bbf761759c504e#diff-3d5dfbd38868fde4ca45f20d13e0f7160d0b91552c8edb6d831b3f832bd11fa9L325 which only shows `No Players` on empty servers.