### PR TITLE
Fix crushables and parachuted crates causing HPF to crash.

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Mine.cs
+++ b/OpenRA.Mods.Cnc/Traits/Mine.cs
@@ -53,19 +53,11 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		bool ICrushable.CrushableBy(Actor self, Actor crusher, BitSet<CrushClass> crushClasses)
 		{
+			// Friendly units should move around! (unless immune)
 			if (info.BlockFriendly && !crusher.Info.HasTraitInfo<MineImmuneInfo>() && self.Owner.RelationshipWith(crusher.Owner) == PlayerRelationship.Ally)
 				return false;
 
 			return info.CrushClasses.Overlaps(crushClasses);
-		}
-
-		LongBitSet<PlayerBitMask> ICrushable.CrushableBy(Actor self, BitSet<CrushClass> crushClasses)
-		{
-			if (!info.CrushClasses.Overlaps(crushClasses))
-				return self.World.NoPlayersMask;
-
-			// Friendly units should move around!
-			return info.BlockFriendly ? self.World.AllPlayersMask.Except(self.Owner.AlliedPlayersMask) : self.World.AllPlayersMask;
 		}
 	}
 

--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -120,11 +120,8 @@ namespace OpenRA.Mods.Common.Activities
 					var move = actor.Trait<IMove>();
 					var pos = actor.Trait<IPositionable>();
 
-					// HACK: Call SetCenterPosition before SetPosition
-					// So when SetPosition calls ActorMap.CellUpdated
-					// the listeners see the new CenterPosition.
-					pos.SetCenterPosition(actor, spawn);
 					pos.SetPosition(actor, exitSubCell.Value.Cell, exitSubCell.Value.SubCell);
+					pos.SetCenterPosition(actor, spawn);
 
 					actor.CancelActivity();
 					w.Add(actor);

--- a/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
+++ b/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
@@ -621,9 +621,9 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// <summary>
 		/// <see cref="BlockedByActor.Immovable"/> defines immovability based on the mobile trait. The blocking rules
 		/// in <see cref="Locomotor.CanMoveFreelyInto(Actor, CPos, BlockedByActor, Actor)"/> allow units to pass these
-		/// immovable actors if they are temporary blockers (e.g. gates) or crushable by the locomotor. Since our
-		/// abstract graph must work for any actor, we have to be conservative and can only consider a subset of the
-		/// immovable actors in the graph - ones we know cannot be passed by some actors due to these rules.
+		/// immovable actors if they are temporary blockers (e.g. gates) or potentially crushable. Since our abstract
+		/// graph must work for any actor, we have to be conservative and can only consider a subset of the immovable
+		/// actors in the graph - ones we know cannot be passed by some actors due to these rules.
 		/// Both this and <see cref="ActorCellIsBlocking"/> must be true for a cell to be blocked.
 		///
 		/// This method is dependant on the logic in
@@ -643,9 +643,8 @@ namespace OpenRA.Mods.Common.Pathfinder
 				return false;
 
 			var crushables = actor.TraitsImplementing<ICrushable>();
-			foreach (var crushable in crushables)
-				if (world.NoPlayersMask != crushable.CrushableBy(actor, locomotor.Info.Crushes))
-					return false;
+			if (crushables.Any())
+				return false;
 
 			return true;
 		}

--- a/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
@@ -46,12 +46,9 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Moves from outside the world into the cell grid.")]
 		public void MoveIntoWorld(CPos cell)
 		{
-			// HACK: Call SetCenterPosition before SetPosition
-			// So when SetPosition calls ActorMap.CellUpdated
-			// the listeners see the new CenterPosition.
 			var pos = Self.CenterPosition;
-			mobile.SetCenterPosition(Self, pos);
 			mobile.SetPosition(Self, cell);
+			mobile.SetCenterPosition(Self, pos);
 			Self.QueueActivity(mobile.ReturnToCell(Self));
 		}
 

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -183,22 +183,16 @@ namespace OpenRA.Mods.Common.Traits
 		// Sets the location (Location) and position (CenterPosition)
 		public void SetPosition(Actor self, WPos pos)
 		{
-			// HACK: Call SetCenterPosition before SetLocation
-			// So when SetLocation calls ActorMap.CellUpdated
-			// the listeners see the new CenterPosition.
 			var cell = self.World.Map.CellContaining(pos);
-			SetCenterPosition(self, self.World.Map.CenterOfCell(cell) + new WVec(WDist.Zero, WDist.Zero, self.World.Map.DistanceAboveTerrain(pos)));
 			SetLocation(self, cell);
+			SetCenterPosition(self, self.World.Map.CenterOfCell(cell) + new WVec(WDist.Zero, WDist.Zero, self.World.Map.DistanceAboveTerrain(pos)));
 		}
 
 		// Sets the location (Location) and position (CenterPosition)
 		public void SetPosition(Actor self, CPos cell, SubCell subCell = SubCell.Any)
 		{
-			// HACK: Call SetCenterPosition before SetLocation
-			// So when SetLocation calls ActorMap.CellUpdated
-			// the listeners see the new CenterPosition.
-			SetCenterPosition(self, self.World.Map.CenterOfCell(cell));
 			SetLocation(self, cell);
+			SetCenterPosition(self, self.World.Map.CenterOfCell(cell));
 		}
 
 		// Sets only the CenterPosition

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -235,11 +235,6 @@ namespace OpenRA.Mods.Common.Traits
 			return self.IsAtGroundLevel() && crushClasses.Contains(info.CrushClass);
 		}
 
-		LongBitSet<PlayerBitMask> ICrushable.CrushableBy(Actor self, BitSet<CrushClass> crushClasses)
-		{
-			return self.IsAtGroundLevel() && crushClasses.Contains(info.CrushClass) ? self.World.AllPlayersMask : self.World.NoPlayersMask;
-		}
-
 		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
 			self.World.AddToMaps(self, this);

--- a/OpenRA.Mods.Common/Traits/Crushable.cs
+++ b/OpenRA.Mods.Common/Traits/Crushable.cs
@@ -65,14 +65,6 @@ namespace OpenRA.Mods.Common.Traits
 			return CrushableInner(crushClasses, crusher.Owner);
 		}
 
-		LongBitSet<PlayerBitMask> ICrushable.CrushableBy(Actor self, BitSet<CrushClass> crushClasses)
-		{
-			if (IsTraitDisabled || !self.IsAtGroundLevel() || !Info.CrushClasses.Overlaps(crushClasses))
-				return self.World.NoPlayersMask;
-
-			return Info.CrushedByFriendlies ? self.World.AllPlayersMask : self.World.AllPlayersMask.Except(self.Owner.AlliedPlayersMask);
-		}
-
 		bool CrushableInner(BitSet<CrushClass> crushClasses, Player crushOwner)
 		{
 			if (IsTraitDisabled)

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -468,28 +468,22 @@ namespace OpenRA.Mods.Common.Traits
 		public void SetPosition(Actor self, CPos cell, SubCell subCell = SubCell.Any)
 		{
 			subCell = GetValidSubCell(subCell);
+			SetLocation(cell, subCell, cell, subCell);
 
 			var position = cell.Layer == 0 ? self.World.Map.CenterOfCell(cell) :
 				self.World.GetCustomMovementLayers()[cell.Layer].CenterOfCell(cell);
 
-			// HACK: Call SetCenterPosition before SetLocation
-			// So when SetLocation calls ActorMap.CellUpdated
-			// the listeners see the new CenterPosition.
 			var subcellOffset = self.World.Map.Grid.OffsetOfSubCell(subCell);
 			SetCenterPosition(self, position + subcellOffset);
-			SetLocation(cell, subCell, cell, subCell);
 			FinishedMoving(self);
 		}
 
 		// Sets the location (fromCell, toCell, FromSubCell, ToSubCell) and CenterPosition
 		public void SetPosition(Actor self, WPos pos)
 		{
-			// HACK: Call SetCenterPosition before SetLocation
-			// So when SetLocation calls ActorMap.CellUpdated
-			// the listeners see the new CenterPosition.
 			var cell = self.World.Map.CellContaining(pos);
-			SetCenterPosition(self, self.World.Map.CenterOfSubCell(cell, FromSubCell) + new WVec(0, 0, self.World.Map.DistanceAboveTerrain(pos).Length));
 			SetLocation(cell, FromSubCell, cell, FromSubCell);
+			SetCenterPosition(self, self.World.Map.CenterOfSubCell(cell, FromSubCell) + new WVec(0, 0, self.World.Map.DistanceAboveTerrain(pos).Length));
 			FinishedMoving(self);
 		}
 
@@ -692,11 +686,8 @@ namespace OpenRA.Mods.Common.Traits
 					subCell = self.World.Map.Grid.DefaultSubCell;
 
 				// Reserve the exit cell
-				// HACK: Call SetCenterPosition before SetPosition
-				// So when SetPosition calls ActorMap.CellUpdated
-				// the listeners see the new CenterPosition.
-				mobile.SetCenterPosition(self, pos);
 				mobile.SetPosition(self, cell, subCell);
+				mobile.SetCenterPosition(self, pos);
 
 				if (delay > 0)
 					QueueChild(new Wait(delay));

--- a/OpenRA.Mods.Common/Traits/ParaDrop.cs
+++ b/OpenRA.Mods.Common/Traits/ParaDrop.cs
@@ -102,12 +102,10 @@ namespace OpenRA.Mods.Common.Traits
 
 			self.World.AddFrameEndTask(w =>
 			{
-				// HACK: Call SetCenterPosition before SetPosition
-				// So when SetPosition calls ActorMap.CellUpdated
-				// the listeners see the new CenterPosition.
+				dropPositionable.SetPosition(dropActor, dropCell, dropSubCell);
+
 				var dropPosition = dropActor.CenterPosition + new WVec(0, 0, self.CenterPosition.Z - dropActor.CenterPosition.Z);
 				dropPositionable.SetCenterPosition(dropActor, dropPosition);
-				dropPositionable.SetPosition(dropActor, dropCell, dropSubCell);
 				w.Add(dropActor);
 			});
 

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -99,7 +99,6 @@ namespace OpenRA.Mods.Common.Traits
 	public interface ICrushable
 	{
 		bool CrushableBy(Actor self, Actor crusher, BitSet<CrushClass> crushClasses);
-		LongBitSet<PlayerBitMask> CrushableBy(Actor self, BitSet<CrushClass> crushClasses);
 	}
 
 	[RequireExplicitImplementation]


### PR DESCRIPTION
Reverts #20312, which caused `ParaDrop` to stop working, and replaces it with a better solution.

Fixes #20307, fixes #20308, fixes #20309, fixes #20326

Test scenarios:
- Ensure crates are paradropped correctly from planes in RA, to ensure the regression is resolved.
- When a create is on the ground, ensure you can path through it and collect it from a long distance away (>20 cells) to check the original issue with HPF is resolved. If using `/path-debug` you'll know the path is long enough if you see the green lines appear for the HPF grid. Yellow lines only means it was too short.

----

Remove caching of crushability in Locomotor.

Previously, Locomotor would cache the results of ICrushable.CrushableBy which would be used to to quickly determine if all actors in the cell could be crushed. This allowed for fast checks in CanMoveFreelyInto if the cell contained crushable actors.

However Crushable and Crate both implemented CrushableBy checks by checking IsAtGroundLevel. This relies on the CenterPosition of the actor. The CenterPosition of the actor is allowed to change without triggering updates via ActorMap.CellUpdated. In turn, this meant Locomotor would not be aware to update its cache. This means the Locomotor cache can become out-of-date. If a crate is airdropped then when it reaches the ground it becomes crushable. However Locomotor is not informed that is has reached the ground, and may have already cached that it was uncrushable whilst it was airborne.

Ultimately this leads to Locomotor producing incorrect results if CanMoveFreelyInto is called. This could lead to bugs such as a crate on the ground being considered uncrushable, even if they should be crushable. When HierarchicalPathFinder was introduced, it implemented caching logic that mirrored the Locomotor cache. However its cache refreshed at a different time. This could lead to the two caches being out of sync depending on when they refreshed despite using the same logic. This meant we could see a crash when HPF attempted to find a path and then realised it had an inconsistent understanding with Locomotor about the passability of a location.

To resolve the problem, we no longer cache the crushability information. We can instead only cache whether the actor has any ICrushable traits. This weakens the performance benefit of the Locmotor cache. Locomotor must now always use the slower checks if the actor has any ICrushable traits to see if the actor will block. The HierarchicalPathFinder cache is significantly weakened in the face of actors with ICrushable traits. It must assume these are passable for all Locomotors whereas previously it was able to determine on a per-Locomotor basis if the actor could block. This means for example that walls which could only be crushed by one in 10 Locomotors must now be assumed passable for all 10 Locomotors.

Although these are potentially significant performance drawbacks, they were based on incorrect assumptions and thus were not valid in the first place, thus removing them is required for correctness.