### PR TITLE
Fixed utility exiting with 0 on error

### DIFF
--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -119,7 +119,7 @@ namespace OpenRA
 				}
 				else
 				{
-					Console.WriteLine("Invalid arguments for '{0}'", command);
+					Console.WriteLine($"Invalid arguments for '{command}'");
 					GetActionUsage(command, action);
 					Environment.Exit(1);
 				}
@@ -127,8 +127,8 @@ namespace OpenRA
 			catch (Exception e)
 			{
 				Log.AddChannel("utility", "utility.log");
-				Log.Write("utility", "Received args: {0}", args.JoinWith(" "));
-				Log.Write("utility", "{0}", e);
+				Log.Write("utility", $"Received args: {args.JoinWith(" ")}");
+				Log.Write("utility", e);
 
 				if (e is NoSuchCommandException)
 				{

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -121,6 +121,7 @@ namespace OpenRA
 				{
 					Console.WriteLine("Invalid arguments for '{0}'", command);
 					GetActionUsage(command, action);
+					Environment.Exit(1);
 				}
 			}
 			catch (Exception e)
@@ -130,7 +131,10 @@ namespace OpenRA
 				Log.Write("utility", "{0}", e);
 
 				if (e is NoSuchCommandException)
+				{
 					Console.WriteLine(e.Message);
+					Environment.Exit(1);
+				}
 				else
 				{
 					Console.WriteLine("Error: Utility application crashed. See utility.log for details");


### PR DESCRIPTION
I was confused when VS Code showed me a blue indicator despite my typo. It is red when the command indicates it failed.

![image](https://user-images.githubusercontent.com/756669/192157659-2556fbf5-2f0e-474c-ac2a-b145113d35f4.png)
