### PR TITLE
Make FormatTime() independent from game speed.

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Global/UtilsGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/UtilsGlobal.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Returns the ticks formatted to HH:MM:SS.")]
 		public string FormatTime(int ticks, bool leadingMinuteZero = true)
 		{
-			return WidgetUtils.FormatTime(ticks, leadingMinuteZero, 40);
+			return WidgetUtils.FormatTime(ticks, leadingMinuteZero, Context.World.Timestep);
 		}
 	}
 }


### PR DESCRIPTION
Currently if you use Utils.FormatTime() to convert ticks into a time it will assume normal game speed (40 timestep). This means on Fastest for example seconds will tick twice as fast.

This change just passes the world timestep so it's independent from game speed.