### PR TITLE
Fix CrushableBy considering IsAtGroundLevel

### DIFF
--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -120,11 +120,8 @@ namespace OpenRA.Mods.Common.Activities
 					var move = actor.Trait<IMove>();
 					var pos = actor.Trait<IPositionable>();
 
-					// HACK: Call SetCenterPosition before SetPosition
-					// So when SetPosition calls ActorMap.CellUpdated
-					// the listeners see the new CenterPosition.
-					pos.SetCenterPosition(actor, spawn);
 					pos.SetPosition(actor, exitSubCell.Value.Cell, exitSubCell.Value.SubCell);
+					pos.SetCenterPosition(actor, spawn);
 
 					actor.CancelActivity();
 					w.Add(actor);

--- a/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
@@ -46,12 +46,9 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Moves from outside the world into the cell grid.")]
 		public void MoveIntoWorld(CPos cell)
 		{
-			// HACK: Call SetCenterPosition before SetPosition
-			// So when SetPosition calls ActorMap.CellUpdated
-			// the listeners see the new CenterPosition.
 			var pos = Self.CenterPosition;
-			mobile.SetCenterPosition(Self, pos);
 			mobile.SetPosition(Self, cell);
+			mobile.SetCenterPosition(Self, pos);
 			Self.QueueActivity(mobile.ReturnToCell(Self));
 		}
 

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -103,8 +103,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyCrushed.OnCrush(Actor self, Actor crusher, BitSet<CrushClass> crushClasses)
 		{
-			// Crate can only be crushed if it is not in the air.
-			if (!self.IsAtGroundLevel() || !crushClasses.Contains(info.CrushClass))
+			if (!crushClasses.Contains(info.CrushClass))
 				return;
 
 			OnCrushInner(crusher);
@@ -231,13 +230,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool ICrushable.CrushableBy(Actor self, Actor crusher, BitSet<CrushClass> crushClasses)
 		{
-			// Crate can only be crushed if it is not in the air.
-			return self.IsAtGroundLevel() && crushClasses.Contains(info.CrushClass);
+			return crushClasses.Contains(info.CrushClass);
 		}
 
 		LongBitSet<PlayerBitMask> ICrushable.CrushableBy(Actor self, BitSet<CrushClass> crushClasses)
 		{
-			return self.IsAtGroundLevel() && crushClasses.Contains(info.CrushClass) ? self.World.AllPlayersMask : self.World.NoPlayersMask;
+			return crushClasses.Contains(info.CrushClass) ? self.World.AllPlayersMask : self.World.NoPlayersMask;
 		}
 
 		void INotifyAddedToWorld.AddedToWorld(Actor self)

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -183,22 +183,16 @@ namespace OpenRA.Mods.Common.Traits
 		// Sets the location (Location) and position (CenterPosition)
 		public void SetPosition(Actor self, WPos pos)
 		{
-			// HACK: Call SetCenterPosition before SetLocation
-			// So when SetLocation calls ActorMap.CellUpdated
-			// the listeners see the new CenterPosition.
 			var cell = self.World.Map.CellContaining(pos);
-			SetCenterPosition(self, self.World.Map.CenterOfCell(cell) + new WVec(WDist.Zero, WDist.Zero, self.World.Map.DistanceAboveTerrain(pos)));
 			SetLocation(self, cell);
+			SetCenterPosition(self, self.World.Map.CenterOfCell(cell) + new WVec(WDist.Zero, WDist.Zero, self.World.Map.DistanceAboveTerrain(pos)));
 		}
 
 		// Sets the location (Location) and position (CenterPosition)
 		public void SetPosition(Actor self, CPos cell, SubCell subCell = SubCell.Any)
 		{
-			// HACK: Call SetCenterPosition before SetLocation
-			// So when SetLocation calls ActorMap.CellUpdated
-			// the listeners see the new CenterPosition.
-			SetCenterPosition(self, self.World.Map.CenterOfCell(cell));
 			SetLocation(self, cell);
+			SetCenterPosition(self, self.World.Map.CenterOfCell(cell));
 		}
 
 		// Sets only the CenterPosition

--- a/OpenRA.Mods.Common/Traits/Crushable.cs
+++ b/OpenRA.Mods.Common/Traits/Crushable.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		LongBitSet<PlayerBitMask> ICrushable.CrushableBy(Actor self, BitSet<CrushClass> crushClasses)
 		{
-			if (IsTraitDisabled || !self.IsAtGroundLevel() || !Info.CrushClasses.Overlaps(crushClasses))
+			if (IsTraitDisabled || !Info.CrushClasses.Overlaps(crushClasses))
 				return self.World.NoPlayersMask;
 
 			return Info.CrushedByFriendlies ? self.World.AllPlayersMask : self.World.AllPlayersMask.Except(self.Owner.AlliedPlayersMask);
@@ -76,10 +76,6 @@ namespace OpenRA.Mods.Common.Traits
 		bool CrushableInner(BitSet<CrushClass> crushClasses, Player crushOwner)
 		{
 			if (IsTraitDisabled)
-				return false;
-
-			// Only make actor crushable if it is on the ground.
-			if (!self.IsAtGroundLevel())
 				return false;
 
 			if (!Info.CrushedByFriendlies && crushOwner.IsAlliedWith(self.Owner))

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -567,30 +567,23 @@ namespace OpenRA.Mods.Common.Traits
 				foreach (var n in notifyFinishedMoving)
 					n.FinishedMoving(self, fromCell.Layer, toCell.Layer);
 
-			// Only make actor crush if it is on the ground
+			// Only crush actors on having landed
 			if (!self.IsAtGroundLevel())
 				return;
 
-			var actors = self.World.ActorMap.GetActorsAt(ToCell, ToSubCell).Where(a => a != self).ToList();
-			if (!AnyCrushables(actors))
-				return;
-
-			var notifiers = actors.SelectMany(a => a.TraitsImplementing<INotifyCrushed>().Select(t => new TraitPair<INotifyCrushed>(a, t)));
-			foreach (var notifyCrushed in notifiers)
-				notifyCrushed.Trait.OnCrush(notifyCrushed.Actor, self, Info.LocomotorInfo.Crushes);
+			CrushAction(self, (notifyCrushed) => notifyCrushed.OnCrush);
 		}
 
-		bool AnyCrushables(List<Actor> actors)
+		void CrushAction(Actor self, Func<INotifyCrushed, Action<Actor, Actor, BitSet<CrushClass>>> action)
 		{
-			var crushables = actors.SelectMany(a => a.TraitsImplementing<ICrushable>().Select(t => new TraitPair<ICrushable>(a, t))).ToList();
-			if (crushables.Count == 0)
-				return false;
+			var crushables = self.World.ActorMap.GetActorsAt(ToCell, ToSubCell).Where(a => a != self)
+				.SelectMany(a => a.TraitsImplementing<ICrushable>().Select(t => new TraitPair<ICrushable>(a, t)));
 
-			foreach (var crushes in crushables)
-				if (crushes.Trait.CrushableBy(crushes.Actor, self, Info.LocomotorInfo.Crushes))
-					return true;
-
-			return false;
+			// Only crush actors that are on the ground level
+			foreach (var crushable in crushables)
+				if (crushable.Trait.CrushableBy(crushable.Actor, self, Info.LocomotorInfo.Crushes) && crushable.Actor.IsAtGroundLevel())
+					foreach (var notifyCrushed in crushable.Actor.TraitsImplementing<INotifyCrushed>())
+						action(notifyCrushed)(crushable.Actor, self, Info.LocomotorInfo.Crushes);
 		}
 
 		public void AddInfluence()
@@ -792,17 +785,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void EnteringCell(Actor self)
 		{
-			// Only make actor crush if it is on the ground
+			// Only crush actors on having landed
 			if (!self.IsAtGroundLevel())
 				return;
 
-			var actors = self.World.ActorMap.GetActorsAt(ToCell).Where(a => a != self).ToList();
-			if (!AnyCrushables(actors))
-				return;
-
-			var notifiers = actors.SelectMany(a => a.TraitsImplementing<INotifyCrushed>().Select(t => new TraitPair<INotifyCrushed>(a, t)));
-			foreach (var notifyCrushed in notifiers)
-				notifyCrushed.Trait.WarnCrush(notifyCrushed.Actor, self, Info.LocomotorInfo.Crushes);
+			CrushAction(self, (notifyCrushed) => notifyCrushed.WarnCrush);
 		}
 
 		public Activity MoveTo(Func<BlockedByActor, List<CPos>> pathFunc) { return new Move(self, pathFunc); }

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -468,28 +468,22 @@ namespace OpenRA.Mods.Common.Traits
 		public void SetPosition(Actor self, CPos cell, SubCell subCell = SubCell.Any)
 		{
 			subCell = GetValidSubCell(subCell);
+			SetLocation(cell, subCell, cell, subCell);
 
 			var position = cell.Layer == 0 ? self.World.Map.CenterOfCell(cell) :
 				self.World.GetCustomMovementLayers()[cell.Layer].CenterOfCell(cell);
 
-			// HACK: Call SetCenterPosition before SetLocation
-			// So when SetLocation calls ActorMap.CellUpdated
-			// the listeners see the new CenterPosition.
 			var subcellOffset = self.World.Map.Grid.OffsetOfSubCell(subCell);
 			SetCenterPosition(self, position + subcellOffset);
-			SetLocation(cell, subCell, cell, subCell);
 			FinishedMoving(self);
 		}
 
 		// Sets the location (fromCell, toCell, FromSubCell, ToSubCell) and CenterPosition
 		public void SetPosition(Actor self, WPos pos)
 		{
-			// HACK: Call SetCenterPosition before SetLocation
-			// So when SetLocation calls ActorMap.CellUpdated
-			// the listeners see the new CenterPosition.
 			var cell = self.World.Map.CellContaining(pos);
-			SetCenterPosition(self, self.World.Map.CenterOfSubCell(cell, FromSubCell) + new WVec(0, 0, self.World.Map.DistanceAboveTerrain(pos).Length));
 			SetLocation(cell, FromSubCell, cell, FromSubCell);
+			SetCenterPosition(self, self.World.Map.CenterOfSubCell(cell, FromSubCell) + new WVec(0, 0, self.World.Map.DistanceAboveTerrain(pos).Length));
 			FinishedMoving(self);
 		}
 
@@ -692,11 +686,8 @@ namespace OpenRA.Mods.Common.Traits
 					subCell = self.World.Map.Grid.DefaultSubCell;
 
 				// Reserve the exit cell
-				// HACK: Call SetCenterPosition before SetPosition
-				// So when SetPosition calls ActorMap.CellUpdated
-				// the listeners see the new CenterPosition.
-				mobile.SetCenterPosition(self, pos);
 				mobile.SetPosition(self, cell, subCell);
+				mobile.SetCenterPosition(self, pos);
 
 				if (delay > 0)
 					QueueChild(new Wait(delay));

--- a/OpenRA.Mods.Common/Traits/ParaDrop.cs
+++ b/OpenRA.Mods.Common/Traits/ParaDrop.cs
@@ -102,12 +102,10 @@ namespace OpenRA.Mods.Common.Traits
 
 			self.World.AddFrameEndTask(w =>
 			{
-				// HACK: Call SetCenterPosition before SetPosition
-				// So when SetPosition calls ActorMap.CellUpdated
-				// the listeners see the new CenterPosition.
+				dropPositionable.SetPosition(dropActor, dropCell, dropSubCell);
+
 				var dropPosition = dropActor.CenterPosition + new WVec(0, 0, self.CenterPosition.Z - dropActor.CenterPosition.Z);
 				dropPositionable.SetCenterPosition(dropActor, dropPosition);
-				dropPositionable.SetPosition(dropActor, dropCell, dropSubCell);
 				w.Add(dropActor);
 			});
 


### PR DESCRIPTION
Reverts #20312, which caused ParaDrop to stop working, and replaces it with a better solution.

Fixes #9555
Fixes #20326
Fixes #20343

Supersedes #20329

The bug was that Crushability Cache wasn't updated once the crate landed. This caused HPF to freak out at it saw the crate as uncrushable while local pathfinder understood it as crushable. 

I fix this by simply removing IsAtGroundLevel from Crate CrushableBy checks. Not only does this fix the crash, but also fixes my long time annoyance of not allowing units to drive under the crate to catch it. 

While I'm at it I also fix crushing vehicles not being able to drive under paratroopers / infantry dropped from dead aircraft (which is probably another crash waiting to happen)