### PR TITLE
Issue Pause/Unpause orders immediately to avoid unexpected paused game after cycling Menu with [Esc]

### DIFF
--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -396,7 +396,10 @@ namespace OpenRA
 			if (PauseStateLocked)
 				return;
 
-			IssueOrder(Order.FromTargetString("PauseGame", paused ? "Pause" : "UnPause", false));
+			// In single player opening and closing ingame menu in a rapid succession might mess up
+			// the orders and leave us in an incorrect state. To fix that we send immediate orders.
+			// See https://github.com/OpenRA/OpenRA/pull/20336
+			IssueOrder(Order.FromTargetString("PauseGame", paused ? "Pause" : "UnPause", LobbyInfo.NonBotClients.Count() == 1));
 			PredictedPaused = paused;
 		}
 


### PR DESCRIPTION
Fixes #20331 

IsImmediate=true on an Order prioritizes these Orders before those with that flag set to false. As a rule of thumb it looks like (and has been formulated by @penev92 on Discord) "not-world-related things should be immediate".

The underlying cause of bug https://github.com/OpenRA/OpenRA/issues/20331 is the following:

pressing [ESC] repeatingly toggles between:
1. store current Paused state value, pause game, open menu
2. close menu, reset paused-stated of the game to the previously stored value

The reset in the 2nd case was done by IssueOrder without issing that immediately. This could lead to case 1 storing an outdated "current pause state" because the non-immediate-unpause had not been applied yet.