### PR TITLE
Fix infinite worm re-spawn in campaign

### DIFF
--- a/mods/d2k/rules/campaign-rules.yaml
+++ b/mods/d2k/rules/campaign-rules.yaml
@@ -30,7 +30,7 @@ World:
 	ObjectivesPanel:
 		PanelName: MISSION_OBJECTIVES
 	ActorSpawnManager:
-		Minimum: 1
+		Minimum: 0
 		Maximum: 1
 	MapCreeps:
 		CheckboxVisible: False
@@ -59,6 +59,10 @@ World:
 ^AutoTargetAllAssaultMove:
 	GrantConditionOnBotOwner@BOTOWNER:
 		Bots: campaign
+
+sandworm:
+	Sandworm:
+		ChanceToDisappear: 40
 
 harvester:
 	-MustBeDestroyed:


### PR DESCRIPTION
Current worm behavior in campaing is that worm respawn right after he eat something. This is annoying if worm spawn point is next to your base.
Original worm behavior in d2k campaing was that worm dissappear after he eat 3 vehicles and respawn after some time.  We can get closer to this behavior by changing ChanceToDisappear to 40 % and ActorSpawnManager Minimum amount to 0.