### PR TITLE
Check valid relationship for weapon

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -99,6 +99,9 @@ namespace OpenRA.GameRules
 		[Desc("Number of shots in a single ammo magazine.")]
 		public readonly int Burst = 1;
 
+		[Desc("What player relationships are affected.")]
+		public readonly PlayerRelationship ValidRelationships = PlayerRelationship.Ally | PlayerRelationship.Neutral | PlayerRelationship.Enemy;
+
 		[Desc("What types of targets are affected.")]
 		public readonly BitSet<TargetableType> ValidTargets = new BitSet<TargetableType>("Ground", "Water");
 
@@ -206,8 +209,11 @@ namespace OpenRA.GameRules
 		/// <summary>Checks if the weapon is valid against (can target) the actor.</summary>
 		public bool IsValidAgainst(Actor victim, Actor firedBy)
 		{
-			var targetTypes = victim.GetEnabledTargetTypes();
+			var relationship = firedBy.Owner.RelationshipWith(victim.Owner);
+			if (!ValidRelationships.HasRelationship(relationship))
+				return false;
 
+			var targetTypes = victim.GetEnabledTargetTypes();
 			if (!IsValidTarget(targetTypes))
 				return false;
 
@@ -222,6 +228,10 @@ namespace OpenRA.GameRules
 		/// <summary>Checks if the weapon is valid against (can target) the frozen actor.</summary>
 		public bool IsValidAgainst(FrozenActor victim, Actor firedBy)
 		{
+			var relationship = firedBy.Owner.RelationshipWith(victim.Owner);
+			if (!ValidRelationships.HasRelationship(relationship))
+				return false;
+
 			if (!IsValidTarget(victim.TargetTypes))
 				return false;
 

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -326,11 +326,15 @@ REPAIR:
 		Cursor: repair
 		OutsideRangeCursor: repair
 		TargetRelationships: Ally
-		ForceTargetRelationships: None
-	AttackFrontal:
+		ForceTargetRelationships: Ally
+	Armament@PRIMARY:
+		Weapon: MRVMissile
+		TargetRelationships: Enemy
+		ForceTargetRelationships: Neutral, Enemy
+	AttackTurreted:
 		Voice: Attack
 		PauseOnCondition: empdisable
-		FacingTolerance: 0
+	Turreted:
 	AutoTarget:
 		ScanRadius: 8
 		InitialStance: AttackAnything

--- a/mods/ts/weapons/healweapons.yaml
+++ b/mods/ts/weapons/healweapons.yaml
@@ -15,8 +15,9 @@ Heal:
 
 Repair:
 	Inherits: ^HealWeapon
-	Range: 1c819
+	Range: 4c0
 	Report: repair11.aud
 	ValidTargets: Repair
+	ValidRelationships: Ally
 	Warhead@1Dam: TargetDamage
 		ValidTargets: Repair

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -138,3 +138,13 @@ RedEye2:
 		Explosions: large_grey_explosion
 		ImpactSounds: expnew13.aud
 		ImpactActors: false
+
+MRVMissile:
+	Inherits: ^DefaultMissile
+	Range: 5c0
+	Report: misl1.aud
+	ValidTargets: Ground
+	ValidRelationships: Neutral, Enemy
+	Warhead@1Dam: SpreadDamage
+		Damage: 4000
+		ValidTargets: Ground, Air


### PR DESCRIPTION
### Summary
This can be a solution on fixing `AttackFollow` ignore `Armament`'s `TargetRelationship`. With this, turreted unit with both heal and damage weapons can be set to behave normally.

The test case here without this fix will fire missile when ordered to fix ally, and use fix weapon on enemy when fire missile. `TargetRelationship` is useless in this case, we have no way to make it use correct weapon on actors with different relationship.

### Note
There may be a way to fix `AttackBase` or some activity to supersede this PR, but I don't think that is an easy task for I have already tried many time. Compared to my failed tries, This PR is a relatively most light-weighted (easy to revert if you want) and perf-friendly one.