### PR TITLE
AttackBase.DoAttack check 'forceFire' to fix wrong target relationship weapon fire all at once to target

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/Leap.cs
+++ b/OpenRA.Mods.Cnc/Activities/Leap.cs
@@ -26,6 +26,7 @@ namespace OpenRA.Mods.Cnc.Activities
 		readonly AttackLeap attack;
 		readonly EdibleByLeap edible;
 		readonly Target target;
+		readonly bool forceAttack;
 
 		CPos destinationCell;
 		SubCell destinationSubCell = SubCell.Any;
@@ -36,7 +37,7 @@ namespace OpenRA.Mods.Cnc.Activities
 		int ticks = 0;
 		WPos targetPosition;
 
-		public Leap(in Target target, Mobile mobile, Mobile targetMobile, int speed, AttackLeap attack, EdibleByLeap edible)
+		public Leap(in Target target, Mobile mobile, Mobile targetMobile, int speed, AttackLeap attack, EdibleByLeap edible, bool forceAttack)
 		{
 			this.mobile = mobile;
 			this.targetMobile = targetMobile;
@@ -44,6 +45,7 @@ namespace OpenRA.Mods.Cnc.Activities
 			this.target = target;
 			this.edible = edible;
 			this.speed = speed;
+			this.forceAttack = forceAttack;
 		}
 
 		protected override void OnFirstRun(Actor self)
@@ -97,7 +99,7 @@ namespace OpenRA.Mods.Cnc.Activities
 
 				// Revoke the condition before attacking, as it is usually used to pause the attack trait
 				attack.RevokeLeapCondition(self);
-				attack.DoAttack(self, target);
+				attack.DoAttack(self, target, forceAttack);
 
 				jumpComplete = true;
 				QueueChild(mobile.LocalMove(self, position, self.World.Map.CenterOfSubCell(destinationCell, destinationSubCell)));

--- a/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
+++ b/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
@@ -138,7 +138,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				return false;
 			}
 
-			QueueChild(new Leap(target, mobile, targetMobile, info.Speed.Length, attack, edible));
+			QueueChild(new Leap(target, mobile, targetMobile, info.Speed.Length, attack, edible, forceAttack));
 
 			// Re-queue the child activities to kill the target if it didn't die in one go
 			return false;

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					Game.Sound.Play(SoundType.World, attack.info.ChargeAudio, self.CenterPosition);
 
 				QueueChild(new Wait(attack.info.InitialChargeDelay));
-				QueueChild(new ChargeFire(attack, target));
+				QueueChild(new ChargeFire(attack, target, forceAttack));
 				return false;
 			}
 
@@ -148,11 +148,13 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			readonly AttackTesla attack;
 			readonly Target target;
+			readonly bool forceAttack;
 
-			public ChargeFire(AttackTesla attack, in Target target)
+			public ChargeFire(AttackTesla attack, in Target target, bool forceAttack)
 			{
 				this.attack = attack;
 				this.target = target;
+				this.forceAttack = forceAttack;
 			}
 
 			public override bool Tick(Actor self)
@@ -163,7 +165,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				if (attack.charges == 0)
 					return true;
 
-				attack.DoAttack(self, target);
+				attack.DoAttack(self, target, forceAttack);
 
 				QueueChild(new Wait(attack.info.ChargeDelay));
 				return false;

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -30,9 +30,8 @@ namespace OpenRA.Mods.Common.Activities
 		readonly IMove move;
 		readonly IFacing facing;
 		readonly IPositionable positionable;
-		readonly bool forceAttack;
 		readonly Color? targetLineColor;
-
+		protected readonly bool ForceAttack;
 		protected Target target;
 		Target lastVisibleTarget;
 		WDist lastVisibleMaximumRange;
@@ -49,7 +48,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			this.target = target;
 			this.targetLineColor = targetLineColor;
-			this.forceAttack = forceAttack;
+			ForceAttack = forceAttack;
 
 			attackTraits = self.TraitsImplementing<AttackFrontal>().ToArray().Where(Exts.IsTraitEnabled);
 			revealsShroud = self.TraitsImplementing<RevealsShroud>().ToArray();
@@ -169,7 +168,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (attack.Info.AttackRequiresEnteringCell && !positionable.CanEnterCell(target.Actor.Location, null, BlockedByActor.None))
 				return AttackStatus.UnableToAttack;
 
-			if (!attack.Info.TargetFrozenActors && !forceAttack && target.Type == TargetType.FrozenActor)
+			if (!attack.Info.TargetFrozenActors && !ForceAttack && target.Type == TargetType.FrozenActor)
 			{
 				// Try to move within range, drop the target otherwise
 				if (move == null)
@@ -188,7 +187,7 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			// Drop the target once none of the weapons are effective against it
-			var armaments = attack.ChooseArmamentsForTarget(target, forceAttack).ToList();
+			var armaments = attack.ChooseArmamentsForTarget(target, ForceAttack).ToList();
 			if (armaments.Count == 0)
 				return AttackStatus.UnableToAttack;
 
@@ -242,7 +241,7 @@ namespace OpenRA.Mods.Common.Activities
 		void IActivityNotifyStanceChanged.StanceChanged(Actor self, AutoTarget autoTarget, UnitStance oldStance, UnitStance newStance)
 		{
 			// Cancel non-forced targets when switching to a more restrictive stance if they are no longer valid for auto-targeting
-			if (newStance > oldStance || forceAttack)
+			if (newStance > oldStance || ForceAttack)
 				return;
 
 			// If lastVisibleTarget is invalid we could never view the target in the first place, so we just drop it here too

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -161,12 +161,16 @@ namespace OpenRA.Mods.Common.Traits
 			return true;
 		}
 
-		public virtual void DoAttack(Actor self, in Target target)
+		public virtual void DoAttack(Actor self, in Target target, bool forceAttack)
 		{
 			if (!CanAttack(self, target))
 				return;
 
-			foreach (var a in Armaments)
+			var armaments = ChooseArmamentsForTarget(target, forceAttack).ToList();
+			if (armaments.Count == 0)
+				return;
+
+			foreach (var a in armaments)
 				a.CheckFire(self, facing, target);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				IsAiming = CanAimAtTarget(self, RequestedTarget, requestedForceAttack);
 				if (IsAiming)
-					DoAttack(self, RequestedTarget);
+					DoAttack(self, RequestedTarget, requestedForceAttack);
 			}
 			else
 			{
@@ -148,7 +148,7 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				if (IsAiming)
-					DoAttack(self, OpportunityTarget);
+					DoAttack(self, OpportunityTarget, opportunityForceAttack);
 			}
 
 			base.Tick(self);

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Common.Traits
 			return coords.Value.LocalToWorld(p.Offset.Rotate(bodyOrientation));
 		}
 
-		public override void DoAttack(Actor self, in Target target)
+		public override void DoAttack(Actor self, in Target target, bool forceAttack)
 		{
 			if (!CanAttack(self, target))
 				return;
@@ -152,7 +152,11 @@ namespace OpenRA.Mods.Common.Traits
 			var targetedPosition = GetTargetPosition(pos, target);
 			var targetYaw = (targetedPosition - pos).Yaw;
 
-			foreach (var a in Armaments)
+			var armaments = ChooseArmamentsForTarget(target, forceAttack).ToList();
+			if (armaments.Count == 0)
+				return;
+
+			foreach (var a in armaments)
 			{
 				if (a.IsTraitDisabled)
 					continue;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (IsCanceling || !target.IsValidFor(self) || !attack.IsReachableTarget(target, allowMove))
 					return true;
 
-				attack.DoAttack(self, target);
+				attack.DoAttack(self, target, forceAttack);
 				return false;
 			}
 

--- a/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
+++ b/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.D2k.Traits
 			Info = info;
 		}
 
-		public override void DoAttack(Actor self, in Target target)
+		public override void DoAttack(Actor self, in Target target, bool forceAttack)
 		{
 			// This is so that the worm does not launch an attack against a target that has reached solid rock
 			if (target.Type != TargetType.Actor || !CanAttack(self, target))
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.D2k.Traits
 				return;
 			}
 
-			var a = ChooseArmamentsForTarget(target, true).FirstOrDefault();
+			var a = ChooseArmamentsForTarget(target, forceAttack).FirstOrDefault();
 			if (a == null)
 				return;
 
@@ -74,7 +74,8 @@ namespace OpenRA.Mods.D2k.Traits
 
 		public override Activity GetAttackActivity(Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
 		{
-			return new SwallowTarget(self, newTarget, allowMove, forceAttack);
+			// HACK: we need to make it always true
+			return new SwallowTarget(self, newTarget, allowMove, true);
 		}
 
 		public class SwallowTarget : Attack
@@ -91,7 +92,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 			protected override void DoAttack(Actor self, AttackFrontal attack, IEnumerable<Armament> armaments)
 			{
-				attack.DoAttack(self, target);
+				attack.DoAttack(self, target, ForceAttack);
 			}
 		}
 	}

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -326,11 +326,15 @@ REPAIR:
 		Cursor: repair
 		OutsideRangeCursor: repair
 		TargetRelationships: Ally
-		ForceTargetRelationships: None
-	AttackFrontal:
+		ForceTargetRelationships: Ally
+	Armament@PRIMARY:
+		Weapon: MRVMissile
+		TargetRelationships: Enemy
+		ForceTargetRelationships: Neutral, Enemy
+	AttackTurreted:
 		Voice: Attack
 		PauseOnCondition: empdisable
-		FacingTolerance: 0
+	Turreted:
 	AutoTarget:
 		ScanRadius: 8
 		InitialStance: AttackAnything

--- a/mods/ts/weapons/healweapons.yaml
+++ b/mods/ts/weapons/healweapons.yaml
@@ -15,7 +15,7 @@ Heal:
 
 Repair:
 	Inherits: ^HealWeapon
-	Range: 1c819
+	Range: 4c0
 	Report: repair11.aud
 	ValidTargets: Repair
 	Warhead@1Dam: TargetDamage

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -138,3 +138,12 @@ RedEye2:
 		Explosions: large_grey_explosion
 		ImpactSounds: expnew13.aud
 		ImpactActors: false
+
+MRVMissile:
+	Inherits: ^DefaultMissile
+	Range: 5c0
+	Report: misl1.aud
+	ValidTargets: Ground
+	Warhead@1Dam: SpreadDamage
+		Damage: 4000
+		ValidTargets: Ground, Air


### PR DESCRIPTION
This is working as the fix solution supersedes #20352.

But it has bug now: attackfollow acivity cannot be cancelled properly, you can try testcase to find the bug