### PR TITLE
Reduce casts of traits that are already known to be `IDisabledTrait`s

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -538,6 +538,26 @@ namespace OpenRA
 			return default(T);
 		}
 
+		public static T FirstEnabledConditionalTraitOrDefault<T>(this IEnumerable<T> ts) where T : IDisabledTrait
+		{
+			// PERF: Avoid LINQ.
+			foreach (var t in ts)
+				if (!t.IsTraitDisabled)
+					return t;
+
+			return default(T);
+		}
+
+		public static T FirstEnabledConditionalTraitOrDefault<T>(this T[] ts) where T : IDisabledTrait
+		{
+			// PERF: Avoid LINQ.
+			foreach (var t in ts)
+				if (!t.IsTraitDisabled)
+					return t;
+
+			return default(T);
+		}
+
 		public static LineSplitEnumerator SplitLines(this string str, char separator)
 		{
 			return new LineSplitEnumerator(str.AsSpan(), separator);

--- a/OpenRA.Mods.Cnc/Scripting/Properties/ChronosphereProperties.cs
+++ b/OpenRA.Mods.Cnc/Scripting/Properties/ChronosphereProperties.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Cnc.Scripting
 				}
 
 				var cs = actor.TraitsImplementing<Chronoshiftable>()
-					.FirstEnabledTraitOrDefault();
+					.FirstEnabledConditionalTraitOrDefault();
 
 				if (cs != null && cs.CanChronoshiftTo(actor, cell))
 					cs.Teleport(actor, cell, duration, killCargo, Self);

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			foreach (var target in UnitsInRange(order.ExtraLocation))
 			{
 				var cs = target.TraitsImplementing<Chronoshiftable>()
-					.FirstEnabledTraitOrDefault();
+					.FirstEnabledConditionalTraitOrDefault();
 
 				if (cs == null)
 					continue;

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Activities
 			this.targetLineColor = targetLineColor;
 			this.forceAttack = forceAttack;
 
-			attackTraits = self.TraitsImplementing<AttackFrontal>().ToArray().Where(Exts.IsTraitEnabled);
+			attackTraits = self.TraitsImplementing<AttackFrontal>().ToArray().Where(t => !t.IsTraitDisabled);
 			revealsShroud = self.TraitsImplementing<RevealsShroud>().ToArray();
 			facing = self.Trait<IFacing>();
 			positionable = self.Trait<IPositionable>();
@@ -67,8 +67,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				// Lambdas can't use 'in' variables, so capture a copy for later
 				var rangeTarget = target;
-				lastVisibleMaximumRange = attackTraits.Where(x => !x.IsTraitDisabled)
-					.Min(x => x.GetMaximumRangeVersusTarget(rangeTarget));
+				lastVisibleMaximumRange = attackTraits.Min(x => x.GetMaximumRangeVersusTarget(rangeTarget));
 
 				if (target.Type == TargetType.Actor)
 				{
@@ -176,7 +175,7 @@ namespace OpenRA.Mods.Common.Activities
 					return AttackStatus.UnableToAttack;
 
 				var rs = revealsShroud
-					.Where(Exts.IsTraitEnabled)
+					.Where(t => !t.IsTraitDisabled)
 					.MaxByOrDefault(s => s.Range);
 
 				// Default to 2 cells if there are no active traits

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -310,7 +310,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			foreach (var actor in self.World.ActorMap.GetActorsAt(cell))
 			{
-				if (!(actor.OccupiesSpace is Mobile move) || !move.IsTraitEnabled() || !move.IsLeaving())
+				if (!(actor.OccupiesSpace is Mobile move) || move.IsTraitDisabled || !move.IsLeaving())
 					return false;
 			}
 

--- a/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.Orders
 
 			var cursor = OrderInner(world, mi)
 				.SelectMany(o => o.Subject.TraitsImplementing<Sellable>())
-				.Where(Exts.IsTraitEnabled)
+				.Where(t => !t.IsTraitDisabled)
 				.Select(si => si.Info.Cursor)
 				.FirstOrDefault();
 

--- a/OpenRA.Mods.Common/Scripting/Properties/DemolitionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/DemolitionProperties.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Scripting
 		public void Demolish(Actor target)
 		{
 			// NB: Scripted actions get no visible targetlines.
-			var demolition = demolitions.FirstEnabledTraitOrDefault();
+			var demolition = demolitions.FirstEnabledConditionalTraitOrDefault();
 			if (demolition != null)
 				Self.QueueActivity(demolition.GetDemolishActivity(Self, Target.FromActor(target), null));
 		}

--- a/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
@@ -185,7 +185,7 @@ namespace OpenRA.Mods.Common.Scripting
 		{
 			get
 			{
-				var tooltip = tooltips.FirstEnabledTraitOrDefault();
+				var tooltip = tooltips.FirstEnabledConditionalTraitOrDefault();
 
 				return tooltip?.Info.Name;
 			}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -325,7 +325,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (target.Type == TargetType.FrozenActor && !attack.Info.TargetFrozenActors && !forceAttack)
 				{
 					var rs = revealsShroud
-						.Where(Exts.IsTraitEnabled)
+						.Where(t => !t.IsTraitDisabled)
 						.MaxByOrDefault(s => s.Range);
 
 					// Default to 2 cells if there are no active traits

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -179,7 +179,7 @@ namespace OpenRA.Mods.Common.Traits
 			: base(info)
 		{
 			var self = init.Self;
-			ActiveAttackBases = self.TraitsImplementing<AttackBase>().ToArray().Where(Exts.IsTraitEnabled);
+			ActiveAttackBases = self.TraitsImplementing<AttackBase>().ToArray().Where(t => !t.IsTraitDisabled);
 
 			stance = init.GetValue<StanceInit, UnitStance>(self.Owner.IsBot || !self.Owner.Playable ? info.InitialStanceAI : info.InitialStance);
 
@@ -195,7 +195,7 @@ namespace OpenRA.Mods.Common.Traits
 			activeTargetPriorities =
 				self.TraitsImplementing<AutoTargetPriority>()
 					.OrderByDescending(ati => ati.Info.Priority).ToArray()
-					.Where(Exts.IsTraitEnabled).Select(atp => atp.Info);
+					.Where(t => !t.IsTraitDisabled).Select(atp => atp.Info);
 
 			overrideAutoTarget = self.TraitsImplementing<IOverrideAutoTarget>().ToArray();
 			notifyStanceChanged = self.TraitsImplementing<INotifyStanceChanged>().ToArray();

--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -126,7 +126,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// Less harvesters than refineries - build a new harvester
-			var unitBuilder = requestUnitProduction.FirstOrDefault(Exts.IsTraitEnabled);
+			var unitBuilder = requestUnitProduction.FirstEnabledTraitOrDefault();
 			if (unitBuilder != null && Info.HarvesterTypes.Count > 0)
 			{
 				var harvInfo = AIUtils.GetInfoByCommonName(Info.HarvesterTypes, player);

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -110,7 +110,7 @@ namespace OpenRA.Mods.Common.Traits
 				// No construction yards - Build a new MCV
 				if (ShouldBuildMCV())
 				{
-					var unitBuilder = requestUnitProduction.FirstOrDefault(Exts.IsTraitEnabled);
+					var unitBuilder = requestUnitProduction.FirstEnabledTraitOrDefault();
 					if (unitBuilder != null)
 					{
 						var mcvInfo = AIUtils.GetInfoByCommonName(Info.McvTypes, player);

--- a/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 				return Enumerable.Empty<Exit>();
 
 			var all = actor.TraitsImplementing<Exit>()
-				.Where(Exts.IsTraitEnabled);
+				.Where(t => !t.IsTraitDisabled);
 
 			if (string.IsNullOrEmpty(productionType))
 				return all;

--- a/OpenRA.Mods.Common/Traits/CaptureManager.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureManager.cs
@@ -93,11 +93,11 @@ namespace OpenRA.Mods.Common.Traits
 
 			enabledCapturable = self.TraitsImplementing<Capturable>()
 				.ToArray()
-				.Where(Exts.IsTraitEnabled);
+				.Where(t => !t.IsTraitDisabled);
 
 			enabledCaptures = self.TraitsImplementing<Captures>()
 				.ToArray()
-				.Where(Exts.IsTraitEnabled);
+				.Where(t => !t.IsTraitDisabled);
 
 			RefreshCaptures();
 			RefreshCapturable();

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -604,7 +604,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		Activity WrapMove(Activity inner)
 		{
-			var moveWrapper = moveWrappers.FirstOrDefault(Exts.IsTraitEnabled);
+			var moveWrapper = moveWrappers.FirstEnabledTraitOrDefault();
 			if (moveWrapper != null)
 				return moveWrapper.WrapMove(inner);
 

--- a/OpenRA.Mods.Common/Traits/RejectsOrders.cs
+++ b/OpenRA.Mods.Common/Traits/RejectsOrders.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public static bool AcceptsOrder(this Actor self, string orderString)
 		{
-			var rejectsOrdersTraits = self.TraitsImplementing<RejectsOrders>().Where(Exts.IsTraitEnabled).ToArray();
+			var rejectsOrdersTraits = self.TraitsImplementing<RejectsOrders>().Where(t => !t.IsTraitDisabled).ToArray();
 			if (rejectsOrdersTraits.Length == 0)
 				return true;
 

--- a/OpenRA.Mods.Common/Traits/Render/ReloadArmamentsBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/ReloadArmamentsBar.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		void INotifyCreated.Created(Actor self)
 		{
 			// Name check can be cached but enabled check can't.
-			armaments = self.TraitsImplementing<Armament>().Where(a => info.Armaments.Contains(a.Info.Name)).ToArray().Where(Exts.IsTraitEnabled);
+			armaments = self.TraitsImplementing<Armament>().Where(a => info.Armaments.Contains(a.Info.Name)).ToArray().Where(t => !t.IsTraitDisabled);
 		}
 
 		float ISelectionBar.GetValue()

--- a/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		readonly SpriteFont font;
 		readonly Actor self;
 		readonly WVec offset;
-		SquadManagerBotModule ai;
+		SquadManagerBotModule[] squadManagerModules;
 
 		Color color;
 		string tagString;
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		void INotifyCreated.Created(Actor self)
 		{
-			ai = self.Owner.PlayerActor.TraitsImplementing<SquadManagerBotModule>().FirstOrDefault(Exts.IsTraitEnabled);
+			squadManagerModules = self.Owner.PlayerActor.TraitsImplementing<SquadManagerBotModule>().ToArray();
 		}
 
 		void INotifyAddedToWorld.AddedToWorld(Actor self)
@@ -86,11 +86,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (!self.Owner.IsBot)
 				yield break;
 
-			if (ai == null)
-				yield break;
-
-			var squads = ai.Squads;
-			var squad = squads.FirstOrDefault(x => x.Units.Contains(self));
+			var squads = squadManagerModules.FirstEnabledConditionalTraitOrDefault()?.Squads;
+			var squad = squads?.FirstOrDefault(x => x.Units.Contains(self));
 			if (squad == null)
 				yield break;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (token == Actor.InvalidConditionToken)
 				token = self.GrantCondition(info.Condition);
 
-			var wsb = wsbs.FirstEnabledTraitOrDefault();
+			var wsb = wsbs.FirstEnabledConditionalTraitOrDefault();
 
 			if (wsb == null)
 				return;
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (token == Actor.InvalidConditionToken)
 				token = self.GrantCondition(info.Condition);
 
-			var wsb = wsbs.FirstEnabledTraitOrDefault();
+			var wsb = wsbs.FirstEnabledConditionalTraitOrDefault();
 
 			if (wsb == null)
 				return;
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				// (sell/transform/etc) runs. This causes visual glitches that we attempt to minimize
 				// by forcing the animation to frame 0 and regranting the make condition.
 				// These workarounds will break the actor if the followup activity doesn't dispose it!
-				wsbs.FirstEnabledTraitOrDefault()?.DefaultAnimation.PlayFetchIndex(info.Sequence, () => 0);
+				wsbs.FirstEnabledConditionalTraitOrDefault()?.DefaultAnimation.PlayFetchIndex(info.Sequence, () => 0);
 
 				token = self.GrantCondition(info.Condition);
 

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Warheads
 				if (!AffectsParent && victim == firedBy)
 					continue;
 
-				var activeShapes = victim.TraitsImplementing<HitShape>().Where(Exts.IsTraitEnabled);
+				var activeShapes = victim.TraitsImplementing<HitShape>().Where(t => !t.IsTraitDisabled);
 				if (!activeShapes.Any(s => s.DistanceFromEdge(victim, pos).Length <= 0))
 					continue;
 


### PR DESCRIPTION
`Exts.IsTraitEnabled(this T trait)` uses `trait is IDisabledTrait disabledTrait` (and thus `FirstEnabledTraitOrDefault` does as well). That is not necessary if we already know that `T` is an `IDisabledTrait`.

I introduced a new `FirstEnabledConditionalTraitOrDefault` that directly checks `where T : IDisabledTrait` in the signature and replaced unnecessary usages of `Exts.IsTraitEnabled` with direct calls to `IsTraitDisabled`.