### PR TITLE
Add BurstsPerFire to Armament

### DIFF
--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -33,6 +33,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Has to be defined in weapons.yaml as well.")]
 		public readonly string Weapon = null;
 
+		[Desc("The number of bursts fired per shot.")]
+		public readonly int BurstsPerFire = 1;
+
 		[Desc("Which turret (if present) should this armament be assigned to.")]
 		public readonly string Turret = "primary";
 
@@ -98,8 +101,13 @@ namespace OpenRA.Mods.Common.Traits
 				WeaponInfo.Range.Length,
 				ai.TraitInfos<IRangeModifierInfo>().Select(m => m.GetRangeModifierDefault())));
 
-			if (WeaponInfo.Burst > 1 && WeaponInfo.BurstDelays.Length > 1 && (WeaponInfo.BurstDelays.Length != WeaponInfo.Burst - 1))
-				throw new YamlException($"Weapon '{weaponToLower}' has an invalid number of BurstDelays, must be single entry or Burst - 1.");
+			if (BurstsPerFire <= 0)
+				throw new YamlException("BurstsPerFire in Armament has to be greater than 0");
+
+			var expectedLength = WeaponInfo.Burst % BurstsPerFire > 0 ? WeaponInfo.Burst / BurstsPerFire : WeaponInfo.Burst / BurstsPerFire - 1;
+
+			if (WeaponInfo.Burst > 1 && WeaponInfo.BurstDelays.Length > 1 && expectedLength != WeaponInfo.BurstDelays.Length)
+				throw new YamlException($"Weapon '{weaponToLower}' has an invalid number of BurstDelays, must be single entry or the ceil of \"Weapon.Burst / Armament.BurstsPerFire - 1\".");
 
 			base.RulesetLoaded(rules, ai);
 		}
@@ -253,24 +261,28 @@ namespace OpenRA.Mods.Common.Traits
 
 		// Note: facing is only used by the legacy positioning code
 		// The world coordinate model uses Actor.Orientation
+		Barrel barrel;
 		public virtual Barrel CheckFire(Actor self, IFacing facing, in Target target)
 		{
 			if (!CanFire(self, target))
 				return null;
-
 			if (ticksSinceLastShot >= Weapon.ReloadDelay)
 				Burst = Weapon.Burst;
 
 			ticksSinceLastShot = 0;
 
-			// If Weapon.Burst == 1, cycle through all LocalOffsets, otherwise use the offset corresponding to current Burst
-			currentBarrel %= barrelCount;
-			var barrel = Weapon.Burst == 1 ? Barrels[currentBarrel] : Barrels[Burst % Barrels.Length];
-			currentBarrel++;
+			for (var i = 0; i < Info.BurstsPerFire && Burst > 0; i++)
+			{
+				// If Weapon.Burst == 1, cycle through all LocalOffsets, otherwise use the offset corresponding to current Burst
+				currentBarrel %= barrelCount;
+				barrel = Weapon.Burst == 1 ? Barrels[currentBarrel] : Barrels[Burst % Barrels.Length];
+				currentBarrel++;
 
-			FireBarrel(self, facing, target, barrel);
+				FireBarrel(self, facing, target, barrel);
+				Burst--;
+			}
 
-			UpdateBurst(self, target);
+			AfterFire(self, target);
 
 			return barrel;
 		}
@@ -344,14 +356,14 @@ namespace OpenRA.Mods.Common.Traits
 			});
 		}
 
-		protected virtual void UpdateBurst(Actor self, in Target target)
+		protected virtual void AfterFire(Actor self, in Target target)
 		{
-			if (--Burst > 0)
+			if (Burst > 0)
 			{
 				if (Weapon.BurstDelays.Length == 1)
 					FireDelay = Weapon.BurstDelays[0];
 				else
-					FireDelay = Weapon.BurstDelays[Weapon.Burst - (Burst + 1)];
+					FireDelay = Weapon.BurstDelays[(Weapon.Burst - Burst) / Info.BurstsPerFire - 1];
 			}
 			else
 			{

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -81,6 +81,8 @@ HVR:
 	Armament:
 		Weapon: HoverMissile
 		LocalOffset: 0,242,543, 0,-242,543
+		LocalYaw: -110, 110
+		BurstsPerFire: 2
 	Turreted:
 		TurnSpeed: 28
 		Offset: -128,0,85

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -69,7 +69,7 @@ BIKE:
 		RequiresCondition: !rank-elite
 		LocalOffset: -153,-204,509, -153,204,509
 	Armament@ELITE:
-		Weapon: HoverMissile
+		Weapon: BikeMissile
 		RequiresCondition: rank-elite
 		LocalOffset: -153,-204,509, -153,204,509
 	AttackFrontal:

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -54,10 +54,15 @@ Bazooka:
 
 HoverMissile:
 	Inherits: ^DefaultMissile
-	ReloadDelay: 68
-	Burst: 2
+	ReloadDelay: 100
+	Burst: 8
+	BurstDelays: 10, 20, 30
 	Range: 8c0
 	Report: hovrmis1.aud
+	Projectile: Missile
+		HorizontalRateOfTurn: 13
+		RangeLimit: 25c0
+		Speed: 400
 	Warhead@1Dam: SpreadDamage
 		Damage: 3000
 


### PR DESCRIPTION
## Summary 
This PR is to solve the problem that we need to use mutiple `Armament` traits to make actor fires the weapon from different side at the same time, as well as improve perf when `AttackBase` or bot modules search armaments. With this PR, we can write only one Armament trait on the gif example below:

![arm-showcase1](https://user-images.githubusercontent.com/13763394/194864578-fcafb2cc-fc79-4bb5-9f09-eea63d6422f9.gif)

Previous:
```
<Rule.yaml>
	Armament@1:
		Weapon: FalconMissile
		LocalOffset: 0, -600, 0
		LocalYaw: 100
		PauseOnCondition: !ammo
	Armament@2:
		Weapon: FalconMissileMute
		LocalOffset: 0, 600, 0
		LocalYaw: -100
		PauseOnCondition: !ammo
	Armament@3:
		Weapon: FalconMissileMute
		LocalOffset: 0, -300, 0
		LocalYaw: 64
		PauseOnCondition: !ammo
	Armament@4:
		Weapon: FalconMissileMute
		LocalOffset: 0, 300, 0
		LocalYaw: -64
		PauseOnCondition: !ammo


<Weapon.yaml>
FalconMissile:
...

FalconMissileMute:
	Inherits: FalconMissile
	-Report:
```


Now:
```
<Rule.yaml>
	Armament@1:
		Weapon: FalconMissile
		LocalOffset: 0, -600, 0, 0, 600, 0, 0, -300, 0, 0, 300, 0
		LocalYaw: 100, -100, 64, -64
		BurstsPerFire: 4
		PauseOnCondition: !ammo

<Weapon.yaml>
FalconMissile:
	Bursts: 4
	StartBurstReport: ...
	...
```
