### PR TITLE
Simplify 'default' expression (IDE0034)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -135,6 +135,9 @@ dotnet_diagnostic.IDE0017.severity = warning
 # Collection initialization can be simplified
 dotnet_diagnostic.IDE0028.severity = warning
 
+# Simplify 'default' expression
+dotnet_diagnostic.IDE0034.severity = warning
+
 # Modifiers are not ordered.
 dotnet_diagnostic.IDE0036.severity = warning
 

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -481,7 +481,7 @@ namespace OpenRA
 			health.InflictDamage(this, attacker, damage, false);
 		}
 
-		public void Kill(Actor attacker, BitSet<DamageType> damageTypes = default(BitSet<DamageType>))
+		public void Kill(Actor attacker, BitSet<DamageType> damageTypes = default)
 		{
 			if (Disposed || health == null)
 				return;

--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -155,7 +155,7 @@ namespace OpenRA
 				if (throws)
 					throw new ArgumentException("Collection must not be empty.", nameof(ts));
 				else
-					return default(T);
+					return default;
 			}
 			else
 				return xs.ElementAt(r.Next(xs.Count));
@@ -232,7 +232,7 @@ namespace OpenRA
 					if (throws)
 						throw new ArgumentException("Collection must not be empty.", nameof(ts));
 					else
-						return default(T);
+						return default;
 				t = e.Current;
 				u = selector(t);
 				while (e.MoveNext())
@@ -525,7 +525,7 @@ namespace OpenRA
 				if (t.IsTraitEnabled())
 					return t;
 
-			return default(T);
+			return default;
 		}
 
 		public static T FirstEnabledTraitOrDefault<T>(this T[] ts)
@@ -535,7 +535,7 @@ namespace OpenRA
 				if (t.IsTraitEnabled())
 					return t;
 
-			return default(T);
+			return default;
 		}
 
 		public static LineSplitEnumerator SplitLines(this string str, char separator)
@@ -596,7 +596,7 @@ namespace OpenRA
 
 			if (values.Any(x => !names.Contains(x)))
 			{
-				value = default(T);
+				value = default;
 				return false;
 			}
 

--- a/OpenRA.Game/LocalPlayerProfile.cs
+++ b/OpenRA.Game/LocalPlayerProfile.cs
@@ -157,7 +157,7 @@ namespace OpenRA
 			}
 
 			innerState = LinkState.Uninitialized;
-			parameters = default(RSAParameters);
+			parameters = default;
 			innerFingerprint = null;
 			innerData = null;
 		}

--- a/OpenRA.Game/Map/CellLayer.cs
+++ b/OpenRA.Game/Map/CellLayer.cs
@@ -105,7 +105,7 @@ namespace OpenRA
 			// so we pre-filter these to avoid returning the wrong result
 			if (GridType == MapGridType.RectangularIsometric && cell.X < cell.Y)
 			{
-				value = default(T);
+				value = default;
 				return false;
 			}
 
@@ -116,7 +116,7 @@ namespace OpenRA
 				return true;
 			}
 
-			value = default(T);
+			value = default;
 			return false;
 		}
 

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -327,7 +327,7 @@ namespace OpenRA
 			{
 				var inherited = new Dictionary<string, MiniYamlNode.SourceLocation>
 				{
-					{ kv.Key, default(MiniYamlNode.SourceLocation) }
+					{ kv.Key, default }
 				};
 
 				var children = ResolveInherits(kv.Value, tree, inherited);

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -112,7 +112,7 @@ namespace OpenRA
 				else
 					throw new InvalidOperationException($"Cannot locate type: {className}");
 
-				return default(T);
+				return default;
 			}
 
 			var ctor = ctorCache[type];

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -87,8 +87,8 @@ namespace OpenRA
 		// Each player is identified with a unique bit in the set
 		// Cache masks for the player's index and ally/enemy player indices for performance.
 		public LongBitSet<PlayerBitMask> PlayerMask;
-		public LongBitSet<PlayerBitMask> AlliedPlayersMask = default(LongBitSet<PlayerBitMask>);
-		public LongBitSet<PlayerBitMask> EnemyPlayersMask = default(LongBitSet<PlayerBitMask>);
+		public LongBitSet<PlayerBitMask> AlliedPlayersMask = default;
+		public LongBitSet<PlayerBitMask> EnemyPlayersMask = default;
 
 		public bool UnlockedRenderPlayer
 		{

--- a/OpenRA.Game/Primitives/TypeDictionary.cs
+++ b/OpenRA.Game/Primitives/TypeDictionary.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Primitives
 		{
 			var result = Get(typeof(T), false);
 			if (result == null)
-				return default(T);
+				return default;
 			return (T)result;
 		}
 

--- a/OpenRA.Game/Scripting/ScriptTypes.cs
+++ b/OpenRA.Game/Scripting/ScriptTypes.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Scripting
 		public static bool TryGetClrValue<T>(this LuaValue value, out T clrObject)
 		{
 			var ret = value.TryGetClrValue(typeof(T), out object temp);
-			clrObject = ret ? (T)temp : default(T);
+			clrObject = ret ? (T)temp : default;
 			return ret;
 		}
 

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -62,7 +62,7 @@ namespace OpenRA
 			if (!fileSystem.Exists(filename))
 			{
 				Log.Write("sound", "LoadSound, file does not exist: {0}", filename);
-				return default(T);
+				return default;
 			}
 
 			using (var stream = fileSystem.Open(filename))

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Traits
 	public readonly struct Target
 	{
 		public static readonly Target[] None = Array.Empty<Target>();
-		public static readonly Target Invalid = default(Target);
+		public static readonly Target Invalid = default;
 
 		readonly TargetType type;
 		readonly Actor actor;

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Traits
 		public Damage(int damage)
 		{
 			Value = damage;
-			DamageTypes = default(BitSet<DamageType>);
+			DamageTypes = default;
 		}
 	}
 

--- a/OpenRA.Game/Widgets/ChromeMetrics.cs
+++ b/OpenRA.Game/Widgets/ChromeMetrics.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Widgets
 		{
 			if (!data.TryGetValue(key, out var s))
 			{
-				result = default(T);
+				result = default;
 				return false;
 			}
 

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -340,7 +340,7 @@ namespace OpenRA.Widgets
 
 		void ForceYieldMouseFocus()
 		{
-			if (Ui.MouseFocusWidget == this && !YieldMouseFocus(default(MouseInput)))
+			if (Ui.MouseFocusWidget == this && !YieldMouseFocus(default))
 				Ui.MouseFocusWidget = null;
 		}
 

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -50,8 +50,8 @@ namespace OpenRA
 		public readonly MersenneTwister SharedRandom;
 		public readonly MersenneTwister LocalRandom;
 		public readonly IModelCache ModelCache;
-		public LongBitSet<PlayerBitMask> AllPlayersMask = default(LongBitSet<PlayerBitMask>);
-		public readonly LongBitSet<PlayerBitMask> NoPlayersMask = default(LongBitSet<PlayerBitMask>);
+		public LongBitSet<PlayerBitMask> AllPlayersMask = default;
+		public readonly LongBitSet<PlayerBitMask> NoPlayersMask = default;
 
 		public Player[] Players = Array.Empty<Player>();
 

--- a/OpenRA.Mods.Cnc/Activities/Teleport.cs
+++ b/OpenRA.Mods.Cnc/Activities/Teleport.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Cnc.Activities
 
 		public Teleport(Actor teleporter, CPos destination, int? maximumDistance,
 			bool killCargo, bool screenFlash, string sound, bool interruptable = true,
-			bool killOnFailure = false, BitSet<DamageType> killDamageTypes = default(BitSet<DamageType>))
+			bool killOnFailure = false, BitSet<DamageType> killDamageTypes = default)
 		{
 			var max = teleporter.World.Map.Grid.MaximumTileSearchRange;
 			if (maximumDistance > max)

--- a/OpenRA.Mods.Cnc/Traits/Buildings/ClonesProducedUnits.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ClonesProducedUnits.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	{
 		[FieldLoader.Require]
 		[Desc("Uses the \"Cloneable\" trait to determine whether or not we should clone a produced unit.")]
-		public readonly BitSet<CloneableType> CloneableTypes = default(BitSet<CloneableType>);
+		public readonly BitSet<CloneableType> CloneableTypes = default;
 
 		[FieldLoader.Require]
 		[Desc("e.g. Infantry, Vehicles, Aircraft, Buildings")]

--- a/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
+++ b/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		[Desc("Types of damage that this trait causes to self when 'ExplodeInstead' is true",
 			"or the return-to-origin is blocked. Leave empty for no damage types.")]
-		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DamageTypes = default;
 
 		public readonly string ChronoshiftSound = "chrono2.aud";
 

--- a/OpenRA.Mods.Cnc/Traits/Cloneable.cs
+++ b/OpenRA.Mods.Cnc/Traits/Cloneable.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	{
 		[FieldLoader.Require]
 		[Desc("This unit's cloneable type is:")]
-		public readonly BitSet<CloneableType> Types = default(BitSet<CloneableType>);
+		public readonly BitSet<CloneableType> Types = default;
 	}
 
 	public class Cloneable { }

--- a/OpenRA.Mods.Cnc/Traits/ConyardChronoReturn.cs
+++ b/OpenRA.Mods.Cnc/Traits/ConyardChronoReturn.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public readonly int Damage = 1000;
 
 		[Desc("Apply the damage using these damagetypes.")]
-		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DamageTypes = default;
 
 		[ConsumedConditionReference]
 		[Desc("Boolean expression defining the condition under which to teleport a replacement actor instead of triggering the vortex.")]

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForCash.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForCash.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	class InfiltrateForCashInfo : TraitInfo
 	{
 		[Desc("The `TargetTypes` from `Targetable` that are allowed to enter.")]
-		public readonly BitSet<TargetableType> Types = default(BitSet<TargetableType>);
+		public readonly BitSet<TargetableType> Types = default;
 
 		[Desc("Percentage of the victim's resources that will be stolen.")]
 		public readonly int Percentage = 100;

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForDecoration.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForDecoration.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	class InfiltrateForDecorationInfo : WithDecorationInfo
 	{
 		[Desc("The `TargetTypes` from `Targetable` that are allowed to enter.")]
-		public readonly BitSet<TargetableType> Types = default(BitSet<TargetableType>);
+		public readonly BitSet<TargetableType> Types = default;
 
 		public override object Create(ActorInitializer init) { return new InfiltrateForDecoration(init.Self, this); }
 	}

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForExploration.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForExploration.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	class InfiltrateForExplorationInfo : TraitInfo
 	{
 		[Desc("The `TargetTypes` from `Targetable` that are allowed to enter.")]
-		public readonly BitSet<TargetableType> Types = default(BitSet<TargetableType>);
+		public readonly BitSet<TargetableType> Types = default;
 
 		[NotificationReference("Speech")]
 		[Desc("Sound the victim will hear when they get sabotaged.")]

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForPowerOutage.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForPowerOutage.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	class InfiltrateForPowerOutageInfo : TraitInfo
 	{
 		[Desc("The `TargetTypes` from `Targetable` that are allowed to enter.")]
-		public readonly BitSet<TargetableType> Types = default(BitSet<TargetableType>);
+		public readonly BitSet<TargetableType> Types = default;
 
 		[Desc("Measured in ticks.")]
 		public readonly int Duration = 500;

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPower.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public readonly string Proxy = null;
 
 		[Desc("The `TargetTypes` from `Targetable` that are allowed to enter.")]
-		public readonly BitSet<TargetableType> Types = default(BitSet<TargetableType>);
+		public readonly BitSet<TargetableType> Types = default;
 
 		[NotificationReference("Speech")]
 		[Desc("Sound the victim will hear when technology gets stolen.")]

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPowerReset.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPowerReset.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	class InfiltrateForSupportPowerResetInfo : TraitInfo
 	{
 		[Desc("The `TargetTypes` from `Targetable` that are allowed to enter.")]
-		public readonly BitSet<TargetableType> Types = default(BitSet<TargetableType>);
+		public readonly BitSet<TargetableType> Types = default;
 
 		[NotificationReference("Speech")]
 		[Desc("Sound the victim will hear when they get sabotaged.")]

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForTransform.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForTransform.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public readonly bool SkipMakeAnims = true;
 
 		[Desc("The `TargetTypes` from `Targetable` that are allowed to enter.")]
-		public readonly BitSet<TargetableType> Types = default(BitSet<TargetableType>);
+		public readonly BitSet<TargetableType> Types = default;
 
 		public override object Create(ActorInitializer init) { return new InfiltrateForTransform(init, this); }
 	}

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	public class InfiltratesInfo : ConditionalTraitInfo
 	{
 		[Desc("The `TargetTypes` from `Targetable` that are allowed to enter.")]
-		public readonly BitSet<TargetableType> Types = default(BitSet<TargetableType>);
+		public readonly BitSet<TargetableType> Types = default;
 
 		[VoiceReference]
 		public readonly string Voice = "Action";

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public WeaponInfo DetonationWeaponInfo { get; private set; }
 
 		[Desc("Types of damage that this trait causes to self while self-destructing. Leave empty for no damage types.")]
-		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DamageTypes = default;
 
 		[CursorReference]
 		[Desc("Cursor to display when targeting.")]

--- a/OpenRA.Mods.Cnc/Traits/Mine.cs
+++ b/OpenRA.Mods.Cnc/Traits/Mine.cs
@@ -17,10 +17,10 @@ namespace OpenRA.Mods.Cnc.Traits
 {
 	class MineInfo : TraitInfo
 	{
-		public readonly BitSet<CrushClass> CrushClasses = default(BitSet<CrushClass>);
+		public readonly BitSet<CrushClass> CrushClasses = default;
 		public readonly bool AvoidFriendly = true;
 		public readonly bool BlockFriendly = true;
-		public readonly BitSet<CrushClass> DetonateClasses = default(BitSet<CrushClass>);
+		public readonly BitSet<CrushClass> DetonateClasses = default;
 
 		public override object Create(ActorInitializer init) { return new Mine(this); }
 	}
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (mobile != null && !info.DetonateClasses.Overlaps(mobile.Info.LocomotorInfo.Crushes))
 				return;
 
-			self.Kill(crusher, mobile != null ? mobile.Info.LocomotorInfo.CrushDamageTypes : default(BitSet<DamageType>));
+			self.Kill(crusher, mobile != null ? mobile.Info.LocomotorInfo.CrushDamageTypes : default);
 		}
 
 		bool ICrushable.CrushableBy(Actor self, Actor crusher, BitSet<CrushClass> crushClasses)

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -86,10 +86,10 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool MoveIntoShroud = true;
 
 		[Desc("e.g. crate, wall, infantry")]
-		public readonly BitSet<CrushClass> Crushes = default(BitSet<CrushClass>);
+		public readonly BitSet<CrushClass> Crushes = default;
 
 		[Desc("Types of damage that are caused while crushing. Leave empty for no damage types.")]
-		public readonly BitSet<DamageType> CrushDamageTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> CrushDamageTypes = default;
 
 		[VoiceReference]
 		public readonly string Voice = "Action";

--- a/OpenRA.Mods.Common/Traits/AppearsOnMapPreview.cs
+++ b/OpenRA.Mods.Common/Traits/AppearsOnMapPreview.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class AppearsOnMapPreviewInfo : TraitInfo<AppearsOnMapPreview>, IMapPreviewSignatureInfo, Requires<IOccupySpaceInfo>
 	{
 		[Desc("Use this color to render the actor, instead of owner player color.")]
-		public readonly Color Color = default(Color);
+		public readonly Color Color = default;
 
 		[Desc("Use this terrain color to render the actor, instead of owner player color.",
 			"Overrides `Color` if both set.")]

--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int ProtectionScanRadius = 8;
 
 		[Desc("Enemy target types to never target.")]
-		public readonly BitSet<TargetableType> IgnoredEnemyTargetTypes = default(BitSet<TargetableType>);
+		public readonly BitSet<TargetableType> IgnoredEnemyTargetTypes = default;
 
 		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 		public WeaponInfo DemolishWeaponInfo { get; private set; }
 
 		[Desc("Types of damage that this bridge causes to units over/in path of it while being destroyed/repaired. Leave empty for no damage types.")]
-		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DamageTypes = default;
 
 		public override object Create(ActorInitializer init) { return new Bridge(init.Self, this); }
 

--- a/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 		public WeaponInfo DemolishWeaponInfo { get; private set; }
 
 		[Desc("Types of damage that this bridge causes to units over/in path of it while being destroyed/repaired. Leave empty for no damage types.")]
-		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DamageTypes = default;
 
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{

--- a/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int RepairStep = 7;
 
 		[Desc("Damage types used for the repair.")]
-		public readonly BitSet<DamageType> RepairDamageTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> RepairDamageTypes = default;
 
 		[Desc("The percentage repair bonus applied with increasing numbers of repairers.")]
 		public readonly int[] RepairBonuses = { 100, 150, 175, 200, 220, 240, 260, 280, 300 };

--- a/OpenRA.Mods.Common/Traits/Capturable.cs
+++ b/OpenRA.Mods.Common/Traits/Capturable.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[FieldLoader.Require]
 		[Desc("CaptureTypes (from the Captures trait) that are able to capture this.")]
-		public readonly BitSet<CaptureType> Types = default(BitSet<CaptureType>);
+		public readonly BitSet<CaptureType> Types = default;
 
 		[Desc("What player relationships the target's owner needs to be captured by this actor.")]
 		public readonly PlayerRelationship ValidRelationships = PlayerRelationship.Neutral | PlayerRelationship.Enemy;

--- a/OpenRA.Mods.Common/Traits/CaptureManager.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureManager.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void RefreshCapturable()
 		{
-			allyCapturableTypes = neutralCapturableTypes = enemyCapturableTypes = default(BitSet<CaptureType>);
+			allyCapturableTypes = neutralCapturableTypes = enemyCapturableTypes = default;
 			foreach (var c in enabledCapturable)
 			{
 				if (c.Info.ValidRelationships.HasRelationship(PlayerRelationship.Ally))

--- a/OpenRA.Mods.Common/Traits/Captures.cs
+++ b/OpenRA.Mods.Common/Traits/Captures.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[FieldLoader.Require]
 		[Desc("Types of actors that it can capture, as long as the type also exists in the Capturable Type: trait.")]
-		public readonly BitSet<CaptureType> CaptureTypes = default(BitSet<CaptureType>);
+		public readonly BitSet<CaptureType> CaptureTypes = default;
 
 		[Desc("Targets with health above this percentage will be sabotaged instead of captured.",
 			"Set to 0 to disable sabotaging.")]
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int SabotageHPRemoval = 50;
 
 		[Desc("Damage types that applied with the sabotage damage.")]
-		public readonly BitSet<DamageType> SabotageDamageTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> SabotageDamageTypes = default;
 
 		[Desc("Delay (in ticks) that to wait next to the target before initiating the capture.")]
 		public readonly int CaptureDelay = 0;

--- a/OpenRA.Mods.Common/Traits/ChangesHealth.cs
+++ b/OpenRA.Mods.Common/Traits/ChangesHealth.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int DamageCooldown = 0;
 
 		[Desc("Apply the health change when encountering these damage types.")]
-		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DamageTypes = default;
 
 		public override object Create(ActorInitializer init) { return new ChangesHealth(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Crates/HealActorsCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/HealActorsCrateAction.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 	class HealActorsCrateActionInfo : CrateActionInfo
 	{
 		[Desc("The target type(s) of the actors this crate action will heal. Leave empty to heal all actors.")]
-		public readonly BitSet<TargetableType> TargetTypes = default(BitSet<TargetableType>);
+		public readonly BitSet<TargetableType> TargetTypes = default;
 
 		public override object Create(ActorInitializer init) { return new HealActorsCrateAction(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Crushable.cs
+++ b/OpenRA.Mods.Common/Traits/Crushable.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using OpenRA.Primitives;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
@@ -57,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 			Game.Sound.Play(SoundType.World, Info.CrushSound, crusher.CenterPosition);
 
 			var crusherMobile = crusher.TraitOrDefault<Mobile>();
-			self.Kill(crusher, crusherMobile != null ? crusherMobile.Info.LocomotorInfo.CrushDamageTypes : default(BitSet<DamageType>));
+			self.Kill(crusher, crusherMobile != null ? crusherMobile.Info.LocomotorInfo.CrushDamageTypes : default);
 		}
 
 		bool ICrushable.CrushableBy(Actor self, Actor crusher, BitSet<CrushClass> crushClasses)

--- a/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int DamageInterval = 0;
 
 		[Desc("Apply the damage using these damagetypes.")]
-		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DamageTypes = default;
 
 		[FieldLoader.Require]
 		[Desc("Terrain types where the actor will take damage.")]

--- a/OpenRA.Mods.Common/Traits/Demolition.cs
+++ b/OpenRA.Mods.Common/Traits/Demolition.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly EnterBehaviour EnterBehaviour = EnterBehaviour.Exit;
 
 		[Desc("Types of damage that this trait causes. Leave empty for no damage types.")]
-		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DamageTypes = default;
 
 		[VoiceReference]
 		[Desc("Voice string when planting explosive charges.")]

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class EngineerRepairInfo : ConditionalTraitInfo
 	{
 		[Desc("Uses the \"EngineerRepairable\" trait to determine repairability.")]
-		public readonly BitSet<EngineerRepairType> Types = default(BitSet<EngineerRepairType>);
+		public readonly BitSet<EngineerRepairType> Types = default;
 
 		[VoiceReference]
 		public readonly string Voice = "Action";

--- a/OpenRA.Mods.Common/Traits/EngineerRepairable.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepairable.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class EngineerRepairableInfo : ConditionalTraitInfo
 	{
 		[Desc("Actors with these Types under EngineerRepair trait can repair me.")]
-		public readonly BitSet<EngineerRepairType> Types = default(BitSet<EngineerRepairType>);
+		public readonly BitSet<EngineerRepairType> Types = default;
 
 		public override object Create(ActorInitializer init) { return new EngineerRepairable(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Explodes.cs
+++ b/OpenRA.Mods.Common/Traits/Explodes.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int DamageThreshold = 0;
 
 		[Desc("DeathType(s) that trigger the explosion. Leave empty to always trigger an explosion.")]
-		public readonly BitSet<DamageType> DeathTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DeathTypes = default;
 
 		[Desc("Who is counted as source of damage for explosion.",
 			"Possible values are Self and Killer.")]

--- a/OpenRA.Mods.Common/Traits/GivesBounty.cs
+++ b/OpenRA.Mods.Common/Traits/GivesBounty.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("DeathTypes for which a bounty should be granted.",
 			"Use an empty list (the default) to allow all DeathTypes.")]
-		public readonly BitSet<DamageType> DeathTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DeathTypes = default;
 
 		public override object Create(ActorInitializer init) { return new GivesBounty(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/GivesCashOnCapture.cs
+++ b/OpenRA.Mods.Common/Traits/GivesCashOnCapture.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int Amount = 0;
 
 		[Desc("Award cash only if the capturer's CaptureTypes overlap with these types. Leave empty to allow all types.")]
-		public readonly BitSet<CaptureType> CaptureTypes = default(BitSet<CaptureType>);
+		public readonly BitSet<CaptureType> CaptureTypes = default;
 
 		public override object Create(ActorInitializer init) { return new GivesCashOnCapture(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/HitShape.cs
+++ b/OpenRA.Mods.Common/Traits/HitShape.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Defines which Armor types apply when the actor receives damage to this HitShape.",
 			"If none specified, all armor types the actor has are valid.")]
-		public readonly BitSet<ArmorType> ArmorTypes = default(BitSet<ArmorType>);
+		public readonly BitSet<ArmorType> ArmorTypes = default;
 
 		[FieldLoader.LoadUsing(nameof(LoadShape))]
 		[Desc("Engine comes with support for `Circle`, `Capsule`, `Polygon` and `Rectangle`. Defaults to `Circle` when left empty.")]

--- a/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Damage types that trigger prone state. Defined on the warheads.",
 			"If Duration is negative (permanent), you can leave this empty to trigger prone state immediately.")]
-		public readonly BitSet<DamageType> DamageTriggers = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DamageTriggers = default;
 
 		[Desc("Damage modifiers for each damage type (defined on the warheads) while the unit is prone.")]
 		public readonly Dictionary<string, int> DamageModifiers = new Dictionary<string, int>();

--- a/OpenRA.Mods.Common/Traits/KillsSelf.cs
+++ b/OpenRA.Mods.Common/Traits/KillsSelf.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int[] Delay = { 0 };
 
 		[Desc("Types of damage that this trait causes. Leave empty for no damage types.")]
-		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DamageTypes = default;
 
 		[GrantedConditionReference]
 		[Desc("The condition to grant moments before suiciding.")]

--- a/OpenRA.Mods.Common/Traits/OwnerLostAction.cs
+++ b/OpenRA.Mods.Common/Traits/OwnerLostAction.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Owner = "Neutral";
 
 		[Desc("The deathtypes used when 'Action' is 'Kill'.")]
-		public readonly BitSet<DamageType> DeathTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DeathTypes = default;
 
 		public override object Create(ActorInitializer init) { return new OwnerLostAction(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool KilledOnImpassableTerrain = true;
 
 		[Desc("Types of damage that this trait causes to self when 'KilledOnImpassableTerrain' is true. Leave empty for no damage types.")]
-		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DamageTypes = default;
 
 		[Desc("Image where Ground/WaterCorpseSequence is looked up.")]
 		public readonly string Image = "explosion";

--- a/OpenRA.Mods.Common/Traits/ProximityCaptor.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCaptor.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class ProximityCaptorInfo : TraitInfo<ProximityCaptor>
 	{
 		[FieldLoader.Require]
-		public readonly BitSet<CaptureType> Types = default(BitSet<CaptureType>);
+		public readonly BitSet<CaptureType> Types = default;
 	}
 
 	public class ProximityCaptor { }

--- a/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		[Desc("Damage types that this should be used for (defined on the warheads).",
 			"Leave empty to disable all filtering.")]
-		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DamageTypes = default;
 
 		[Desc("Trigger when Undamaged, Light, Medium, Heavy, Critical or Dead.")]
 		public readonly DamageState MinimumDamageState = DamageState.Heavy;

--- a/OpenRA.Mods.Common/Traits/RepairsUnits.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsUnits.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int Interval = 24;
 
 		[Desc("Damage types used for the repair.")]
-		public readonly BitSet<DamageType> RepairDamageTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> RepairDamageTypes = default;
 
 		[NotificationReference("Speech")]
 		[Desc("Speech notification played when starting to repair a unit.")]

--- a/OpenRA.Mods.Common/Traits/RevealOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/RevealOnDeath.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("DeathTypes for which shroud will be revealed.",
 			"Use an empty list (the default) to allow all DeathTypes.")]
-		public readonly BitSet<DamageType> DeathTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DeathTypes = default;
 
 		public override object Create(ActorInitializer init) { return new RevealOnDeath(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/ShakeOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/ShakeOnDeath.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class ShakeOnDeathInfo : TraitInfo
 	{
 		[Desc("DeathType(s) that trigger the shake. Leave empty to always trigger a shake.")]
-		public readonly BitSet<DamageType> DeathTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DeathTypes = default;
 
 		public readonly int Duration = 10;
 		public readonly int Intensity = 1;

--- a/OpenRA.Mods.Common/Traits/Sound/DeathSounds.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/DeathSounds.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 
 		[Desc("Damage types that this should be used for (defined on the warheads).",
 			"If empty, this will be used as the default sound for all death types.")]
-		public readonly BitSet<DamageType> DeathTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DeathTypes = default;
 
 		public override object Create(ActorInitializer init) { return new DeathSounds(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Sound/SoundOnDamageTransition.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/SoundOnDamageTransition.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		public readonly string[] DestroyedSounds = Array.Empty<string>();
 
 		[Desc("DamageType(s) that trigger the sounds. Leave empty to always trigger a sound.")]
-		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DamageTypes = default;
 
 		public override object Create(ActorInitializer init) { return new SoundOnDamageTransition(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/TransformCrusherOnCrush.cs
+++ b/OpenRA.Mods.Common/Traits/TransformCrusherOnCrush.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly bool SkipMakeAnims = true;
 
-		public readonly BitSet<CrushClass> CrushClasses = default(BitSet<CrushClass>);
+		public readonly BitSet<CrushClass> CrushClasses = default;
 
 		public override object Create(ActorInitializer init) { return new TransformCrusherOnCrush(init, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/TransformOnCapture.cs
+++ b/OpenRA.Mods.Common/Traits/TransformOnCapture.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool SkipMakeAnims = true;
 
 		[Desc("Transform only if the capturer's CaptureTypes overlap with these types. Leave empty to allow all types.")]
-		public readonly BitSet<CaptureType> CaptureTypes = default(BitSet<CaptureType>);
+		public readonly BitSet<CaptureType> CaptureTypes = default;
 
 		public override object Create(ActorInitializer init) { return new TransformOnCapture(init, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -73,10 +73,10 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool MoveIntoShroud = true;
 
 		[Desc("e.g. crate, wall, infantry")]
-		public readonly BitSet<CrushClass> Crushes = default(BitSet<CrushClass>);
+		public readonly BitSet<CrushClass> Crushes = default;
 
 		[Desc("Types of damage that are caused while crushing. Leave empty for no damage types.")]
-		public readonly BitSet<DamageType> CrushDamageTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> CrushDamageTypes = default;
 
 		[FieldLoader.LoadUsing(nameof(LoadSpeeds), true)]
 		[Desc("Lower the value on rough terrain. Leave out entries for impassable terrain.")]
@@ -134,7 +134,7 @@ namespace OpenRA.Mods.Common.Traits
 			public readonly LongBitSet<PlayerBitMask> Crushable;
 			public readonly CellFlag CellFlag;
 
-			public CellCache(LongBitSet<PlayerBitMask> immovable, CellFlag cellFlag, LongBitSet<PlayerBitMask> crushable = default(LongBitSet<PlayerBitMask>))
+			public CellCache(LongBitSet<PlayerBitMask> immovable, CellFlag cellFlag, LongBitSet<PlayerBitMask> crushable = default)
 			{
 				Immovable = immovable;
 				Crushable = crushable;
@@ -467,13 +467,13 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (!actors.Any())
 				{
-					cache[cell] = new CellCache(default(LongBitSet<PlayerBitMask>), cellFlag);
+					cache[cell] = new CellCache(default, cellFlag);
 					return;
 				}
 
 				if (sharesCell && actorMap.HasFreeSubCell(cell))
 				{
-					cache[cell] = new CellCache(default(LongBitSet<PlayerBitMask>), cellFlag);
+					cache[cell] = new CellCache(default, cellFlag);
 					return;
 				}
 

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -180,7 +180,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!world.Map.Contains(loc))
 				return;
 
-			var tile = dirty.ContainsKey(loc) ? dirty[loc] : default(Smudge);
+			var tile = dirty.ContainsKey(loc) ? dirty[loc] : default;
 
 			// Setting Sequence to null to indicate a deleted smudge.
 			tile.Sequence = null;

--- a/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Warheads
 		public readonly int Damage = 0;
 
 		[Desc("Types of damage that this warhead causes. Leave empty for no damage types.")]
-		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DamageTypes = default;
 
 		[Desc("Damage percentage versus each armor type.")]
 		public readonly Dictionary<string, int> Versus = new Dictionary<string, int>();

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -836,10 +836,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			public string Faction;
 
 			public bool IsEmpty =>
-				Type == default(GameType)
-				&& Date == default(DateType)
-				&& Duration == default(DurationType)
-				&& Outcome == default(WinState)
+				Type == default
+				&& Date == default
+				&& Duration == default
+				&& Outcome == default
 				&& string.IsNullOrEmpty(PlayerName)
 				&& string.IsNullOrEmpty(MapName)
 				&& string.IsNullOrEmpty(Faction);

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -443,7 +443,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public void RefreshIcons()
 		{
 			icons = new Dictionary<Rectangle, ProductionIcon>();
-			var producer = CurrentQueue != null ? CurrentQueue.MostLikelyProducer() : default(TraitPair<Production>);
+			var producer = CurrentQueue != null ? CurrentQueue.MostLikelyProducer() : default;
 			if (CurrentQueue == null || producer.Trait == null)
 			{
 				if (DisplayedIconCount != 0)

--- a/OpenRA.Mods.D2k/Traits/Buildings/D2kBuilding.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/D2kBuilding.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.D2k.Traits.Buildings
 		public readonly int DamageInterval = 100;
 
 		[Desc("Apply the damage using these damagetypes.")]
-		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
+		public readonly BitSet<DamageType> DamageTypes = default;
 
 		[Desc("Terrain types where the actor will take damage.")]
 		public readonly string[] DamageTerrainTypes = { "Rock" };


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0034

There's no point in defining value types when they can be inferred. 

This rule has always been enabled with `severity = suggestion` and annoyed me for as long as I've worked on ora code