### PR TITLE
Make the exit cells of the GDI Barracks transient

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -321,7 +321,7 @@ PYLE:
 		Queue: Building.GDI
 		Description: Trains infantry
 	Building:
-		Footprint: xx xx ==
+		Footprint: xx ++ ==
 		Dimensions: 2,3
 		LocalCenterOffset: 0,-512,0
 	Health:

--- a/mods/cnc/sequences/structures.yaml
+++ b/mods/cnc/sequences/structures.yaml
@@ -132,10 +132,12 @@ pyle:
 	idle:
 		Length: 10
 		Tick: 100
+		ZOffset: -511
 	damaged-idle:
 		Start: 10
 		Length: 10
 		Tick: 100
+		ZOffset: -511
 	dead:
 		Start: 20
 		Tick: 800


### PR DESCRIPTION
Closes #20366.

The problem is that the HPF search does not return a valid path if the source cell is not accessible. While that should be investigated differently, spawning units on occupied/impassable cells is a bit weird in its own. Changing those cells to be passable looks visually ok to me and works around the issue. Changing the exit cells to be further south would also work, but doesn't look/feel as good imo:
![pyleExits](https://user-images.githubusercontent.com/7704140/195319224-d4bd486d-b285-48c6-95f8-2474a30b903c.gif)

One unfortunate side-effect is that bigger units can clip through the flag pole now.