### PR TITLE
Fix a typo in the undefined MapFormat exception message

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -302,7 +302,7 @@ namespace OpenRA
 					return FieldLoader.GetValue<int>("MapFormat", search.Groups[1].Value);
 			}
 
-			throw new InvalidDataException($"MapFormat is not defined\n File: {p.Name}");
+			throw new InvalidDataException("MapFormat is not defined");
 		}
 
 		/// <summary>

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -302,7 +302,7 @@ namespace OpenRA
 					return FieldLoader.GetValue<int>("MapFormat", search.Groups[1].Value);
 			}
 
-			throw new InvalidDataException($"MapFormat is not definedt\n File: {p.Name}");
+			throw new InvalidDataException($"MapFormat is not defined\n File: {p.Name}");
 		}
 
 		/// <summary>

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -294,12 +294,18 @@ namespace OpenRA
 
 		static int GetMapFormat(IReadOnlyPackage p)
 		{
-			foreach (var line in p.GetStream("map.yaml").ReadAllLines())
+			using (var yamlStream = p.GetStream("map.yaml"))
 			{
-				// PERF This is a way to get MapFormat without expensive yaml parsing
-				var search = Regex.Match(line, "^MapFormat:\\s*(\\d*)\\s*$");
-				if (search.Success && search.Groups.Count > 0)
-					return FieldLoader.GetValue<int>("MapFormat", search.Groups[1].Value);
+				if (yamlStream == null)
+					throw new FileNotFoundException("Required file map.yaml not present in this map");
+
+				foreach (var line in yamlStream.ReadAllLines())
+				{
+					// PERF This is a way to get MapFormat without expensive yaml parsing
+					var search = Regex.Match(line, "^MapFormat:\\s*(\\d*)\\s*$");
+					if (search.Success && search.Groups.Count > 0)
+						return FieldLoader.GetValue<int>("MapFormat", search.Groups[1].Value);
+				}
 			}
 
 			throw new InvalidDataException("MapFormat is not defined");


### PR DESCRIPTION
Keeping the filename doesn't make sense since the utility won't run into this exception when running `--check-yaml`, and the map loading already logs the map name.