### PR TITLE
Weapon shouldn't check warheads in IsValidAgainst

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -99,6 +99,9 @@ namespace OpenRA.GameRules
 		[Desc("Number of shots in a single ammo magazine.")]
 		public readonly int Burst = 1;
 
+		[Desc("Can this weapon target attacker itself.")]
+		public readonly bool CanTargetSelf = false;
+
 		[Desc("What types of targets are affected.")]
 		public readonly BitSet<TargetableType> ValidTargets = new BitSet<TargetableType>("Ground", "Water");
 
@@ -206,6 +209,9 @@ namespace OpenRA.GameRules
 		/// <summary>Checks if the weapon is valid against (can target) the actor.</summary>
 		public bool IsValidAgainst(Actor victim, Actor firedBy)
 		{
+			if (!CanTargetSelf && victim == firedBy)
+				return false;
+
 			var targetTypes = victim.GetEnabledTargetTypes();
 
 			if (!IsValidTarget(targetTypes))
@@ -222,6 +228,9 @@ namespace OpenRA.GameRules
 		/// <summary>Checks if the weapon is valid against (can target) the frozen actor.</summary>
 		public bool IsValidAgainst(FrozenActor victim, Actor firedBy)
 		{
+			if (!CanTargetSelf && victim.Actor == firedBy)
+				return false;
+
 			if (!IsValidTarget(victim.TargetTypes))
 				return false;
 

--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -220,6 +220,9 @@ namespace OpenRA.GameRules
 		/// <summary>Checks if the weapon is valid against (can target) the frozen actor.</summary>
 		public bool IsValidAgainst(FrozenActor victim, Actor firedBy)
 		{
+			if (!victim.IsValid)
+				return false;
+
 			if (!CanTargetSelf && victim.Actor == firedBy)
 				return false;
 

--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -99,7 +99,7 @@ namespace OpenRA.GameRules
 		[Desc("Number of shots in a single ammo magazine.")]
 		public readonly int Burst = 1;
 
-		[Desc("Can this weapon target attacker itself.")]
+		[Desc("Can this weapon target the attacker itself?")]
 		public readonly bool CanTargetSelf = false;
 
 		[Desc("What types of targets are affected.")]
@@ -214,15 +214,7 @@ namespace OpenRA.GameRules
 
 			var targetTypes = victim.GetEnabledTargetTypes();
 
-			if (!IsValidTarget(targetTypes))
-				return false;
-
-			// PERF: Avoid LINQ.
-			foreach (var warhead in Warheads)
-				if (warhead.IsValidAgainst(victim, firedBy))
-					return true;
-
-			return false;
+			return IsValidTarget(targetTypes);
 		}
 
 		/// <summary>Checks if the weapon is valid against (can target) the frozen actor.</summary>
@@ -231,13 +223,7 @@ namespace OpenRA.GameRules
 			if (!CanTargetSelf && victim.Actor == firedBy)
 				return false;
 
-			if (!IsValidTarget(victim.TargetTypes))
-				return false;
-
-			if (!Warheads.Any(w => w.IsValidAgainst(victim, firedBy)))
-				return false;
-
-			return true;
+			return IsValidTarget(victim.TargetTypes);
 		}
 
 		/// <summary>Applies all the weapon's warheads to the target.</summary>


### PR DESCRIPTION
Warheads should not block weapon from firing, since we already has InvalidTarget&ValidTarget in weapon. In this case, considering warheads block fire will be very confusing to user.

With this, we can also get more pref when weapon check fire.

Closes #16023