### PR TITLE
Fix default expressions in commit 75f642bd094e77b1c829b1a54803ea14a2c4279f

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -545,7 +545,7 @@ namespace OpenRA
 				if (!t.IsTraitDisabled)
 					return t;
 
-			return default(T);
+			return default;
 		}
 
 		public static T FirstEnabledConditionalTraitOrDefault<T>(this T[] ts) where T : IDisabledTrait
@@ -555,7 +555,7 @@ namespace OpenRA
 				if (!t.IsTraitDisabled)
 					return t;
 
-			return default(T);
+			return default;
 		}
 
 		public static LineSplitEnumerator SplitLines(this string str, char separator)


### PR DESCRIPTION
75f642bd094e77b1c829b1a54803ea14a2c4279f didn't comply with the new style rule and I completely forgot to double check after #20364 was merged