### PR TITLE
Pathing considers reachability of source and destination cells consistently

### DIFF
--- a/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
+++ b/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
@@ -73,13 +73,14 @@ namespace OpenRA.Mods.Common.Pathfinder
 	/// nodes, but uses a heuristic informed from the previous level to guide the search in the right direction.</para>
 	///
 	/// <para>This implementation is aware of movement costs over terrain given by
-	/// <see cref="Locomotor.MovementCostToEnterCell"/>. It is aware of changes to the costs in terrain and able to
-	/// update the abstract graph when this occurs. It is able to search the abstract graph as if
-	/// <see cref="BlockedByActor.None"/> had been specified. If <see cref="BlockedByActor.Immovable"/> is given in the
-	/// constructor, the abstract graph will additionally account for a subset of immovable actors using the same rules
-	/// as <see cref="Locomotor.CanMoveFreelyInto(Actor, CPos, BlockedByActor, Actor)"/>. It will be aware of changes
-	/// to actors on the map and update the abstract graph when this occurs. Other types of blocking actors will not be
-	/// accounted for in the heuristic.</para>
+	/// <see cref="Locomotor.MovementCostToEnterCell(Actor, CPos, CPos, BlockedByActor, Actor)"/>. It is aware of
+	/// changes to the costs in terrain and able to update the abstract graph when this occurs. It is able to search
+	/// the abstract graph as if <see cref="BlockedByActor.None"/> had been specified. If
+	/// <see cref="BlockedByActor.Immovable"/> is given in the constructor, the abstract graph will additionally
+	/// account for a subset of immovable actors using the same rules as
+	/// <see cref="Locomotor.CanMoveFreelyInto(Actor, CPos, SubCell, BlockedByActor, Actor)"/>. It will be aware of
+	/// changes to actors on the map and update the abstract graph when this occurs. Other types of blocking actors
+	/// will not be accounted for in the heuristic.</para>
 	///
 	/// <para>If the obstacle on the map is from terrain (e.g. a cliff or lake) the heuristic will work well. If the
 	/// obstacle is from the subset of immovable actors (e.g. trees, walls, buildings) and
@@ -620,14 +621,14 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 		/// <summary>
 		/// <see cref="BlockedByActor.Immovable"/> defines immovability based on the mobile trait. The blocking rules
-		/// in <see cref="Locomotor.CanMoveFreelyInto(Actor, CPos, BlockedByActor, Actor)"/> allow units to pass these
-		/// immovable actors if they are temporary blockers (e.g. gates) or crushable by the locomotor. Since our
-		/// abstract graph must work for any actor, we have to be conservative and can only consider a subset of the
-		/// immovable actors in the graph - ones we know cannot be passed by some actors due to these rules.
+		/// in <see cref="Locomotor.CanMoveFreelyInto(Actor, CPos, SubCell, BlockedByActor, Actor)"/> allow units to
+		/// pass these immovable actors if they are temporary blockers (e.g. gates) or crushable by the locomotor.
+		/// Since our abstract graph must work for any actor, we have to be conservative and can only consider a subset
+		/// of the immovable actors in the graph - ones we know cannot be passed by some actors due to these rules.
 		/// Both this and <see cref="ActorCellIsBlocking"/> must be true for a cell to be blocked.
 		///
 		/// This method is dependant on the logic in
-		/// <see cref="Locomotor.CanMoveFreelyInto(Actor, CPos, BlockedByActor, Actor)"/> and
+		/// <see cref="Locomotor.CanMoveFreelyInto(Actor, CPos, SubCell, BlockedByActor, Actor)"/> and
 		/// <see cref="Locomotor.UpdateCellBlocking"/>. This method must be kept in sync with changes in the locomotor
 		/// rules.
 		/// </summary>

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
@@ -211,10 +211,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			bool CanEnterCell(Actor self, CPos cell)
 			{
-				if (mobile.locomotor.MovementCostForCell(cell) == PathGraph.MovementCostForUnreachableCell)
-					return false;
-
-				return mobile.locomotor.CanMoveFreelyInto(self, cell, BlockedByActor.All, null);
+				return mobile.locomotor.MovementCostToEnterCell(
+					self, cell, BlockedByActor.All, null) != PathGraph.MovementCostForUnreachableCell;
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -124,10 +124,8 @@ namespace OpenRA.Mods.Common.Traits
 				locomotor = world.WorldActor.TraitsImplementing<Locomotor>()
 				   .SingleOrDefault(l => l.Info.Name == Locomotor);
 
-			if (locomotor.MovementCostForCell(cell) == PathGraph.MovementCostForUnreachableCell)
-				return false;
-
-			return locomotor.CanMoveFreelyInto(self, cell, subCell, check, ignoreActor);
+			return locomotor.MovementCostToEnterCell(
+				self, cell, check, ignoreActor, subCell) != PathGraph.MovementCostForUnreachableCell;
 		}
 
 		public bool CanStayInCell(World world, CPos cell)

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -204,24 +204,30 @@ namespace OpenRA.Mods.Common.Traits
 			return terrainInfos[index].Speed;
 		}
 
+		public short MovementCostToEnterCell(Actor actor, CPos destNode, BlockedByActor check, Actor ignoreActor, SubCell subCell = SubCell.FullCell)
+		{
+			var cellCost = MovementCostForCell(destNode);
+
+			if (cellCost == PathGraph.MovementCostForUnreachableCell ||
+				!CanMoveFreelyInto(actor, destNode, subCell, check, ignoreActor))
+				return PathGraph.MovementCostForUnreachableCell;
+
+			return cellCost;
+		}
+
 		public short MovementCostToEnterCell(Actor actor, CPos srcNode, CPos destNode, BlockedByActor check, Actor ignoreActor)
 		{
 			var cellCost = MovementCostForCell(destNode, srcNode);
 
 			if (cellCost == PathGraph.MovementCostForUnreachableCell ||
-				!CanMoveFreelyInto(actor, destNode, check, ignoreActor))
+				!CanMoveFreelyInto(actor, destNode, SubCell.FullCell, check, ignoreActor))
 				return PathGraph.MovementCostForUnreachableCell;
 
 			return cellCost;
 		}
 
 		// Determines whether the actor is blocked by other Actors
-		public bool CanMoveFreelyInto(Actor actor, CPos cell, BlockedByActor check, Actor ignoreActor)
-		{
-			return CanMoveFreelyInto(actor, cell, SubCell.FullCell, check, ignoreActor);
-		}
-
-		public bool CanMoveFreelyInto(Actor actor, CPos cell, SubCell subCell, BlockedByActor check, Actor ignoreActor)
+		bool CanMoveFreelyInto(Actor actor, CPos cell, SubCell subCell, BlockedByActor check, Actor ignoreActor)
 		{
 			// If the check allows: We are not blocked by other actors.
 			if (check == BlockedByActor.None)

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -93,11 +93,7 @@ namespace OpenRA.Mods.Common.Traits
 			var locomotor = GetActorLocomotor(self);
 
 			// If the target cell is inaccessible, bail early.
-			var inaccessible =
-				!world.Map.Contains(target) ||
-				!locomotor.CanMoveFreelyInto(self, target, check, ignoreActor) ||
-				(customCost != null && customCost(target) == PathGraph.PathCostForInvalidPath);
-			if (inaccessible)
+			if (!PathSearch.CellAllowsMovement(self.World, locomotor, self, target, check, customCost, ignoreActor))
 				return NoPath;
 
 			// When searching from only one source cell, some optimizations are possible.
@@ -109,8 +105,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (source.Layer == target.Layer && (source - target).LengthSquared < 3)
 				{
 					// If the source cell is inaccessible, there is no path.
-					if (!world.Map.Contains(source) ||
-						(customCost != null && customCost(source) == PathGraph.PathCostForInvalidPath))
+					if (!PathSearch.CellAllowsMovement(self.World, locomotor, self, target, check, customCost, ignoreActor))
 						return NoPath;
 					return new List<CPos>(2) { target, source };
 				}


### PR DESCRIPTION
Previously, you could not find a path to an unreachable destination cell, however it was possible to find a path from an unreachable source cell if there was a reachable cells adjacent to it.

This led to an asymmetric behaviour which could be an issue in some use cases which perform a path search with the source and destination swapped and then reverse the resulting path. Callers that reverse a path in this fashion could be told there is a valid path to an unreachable destination cell. This would occur if before reversing the source cell was unreachable, but a path could be found from it anyway.

We unify the behaviour to treat both source and destination cells that are unreachable in the same fashion, that there is no path is either is unreachable.

----

Recommend #20367 is merged first. This PR will exacerbate the issue that PR resolves as both the local pathfinder and HPF will reject paths from the exit cell that is inaccessible as it is located within the barracks. This means where units would previously ignore a rally point >20 cells north of the barracks they will now ignore a rally point to the north regardless of how far away it is. This is because HPF kicks in at >20 cells.