### PR TITLE
TD Fall 2022 Balance

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -17,7 +17,7 @@ TRAN:
 		Speed: 150
 		AltitudeVelocity: 0c100
 	Health:
-		HP: 9000
+		HP: 12500
 	Armor:
 		Type: Light
 	RevealsShroud:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -52,7 +52,7 @@
 		Conditions:
 			250: rank-veteran
 			500: rank-veteran
-			750: rank-veteran
+			700: rank-veteran
 		LevelUpImage: crate-effects
 	GrantCondition@RANK-ELITE:
 		RequiresCondition: rank-veteran >= 3
@@ -65,13 +65,13 @@
 		Modifier: 125
 	FirepowerMultiplier@RANK-ELITE:
 		RequiresCondition: rank-elite
-		Modifier: 125
+		Modifier: 150
 	DamageMultiplier@RANK-2:
 		RequiresCondition: rank-veteran == 2
 		Modifier: 80
 	DamageMultiplier@RANK-ELITE:
 		RequiresCondition: rank-elite
-		Modifier: 80
+		Modifier: 65
 	SpeedMultiplier@RANK-ELITE:
 		RequiresCondition: rank-elite
 		Modifier: 125

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -223,7 +223,7 @@ RMBO:
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Inherits@DECORATIONS: ^InfantryExperienceHospitalHazmatOverrides
 	Valued:
-		Cost: 1800
+		Cost: 1500
 	Tooltip:
 		Name: Commando
 	UpdatesPlayerStatistics:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -893,7 +893,7 @@ GUN:
 	Health:
 		HP: 41000
 	Armor:
-		Type: Heavy
+		Type: Concrete
 	RevealsShroud:
 		Range: 6c0
 	WithBuildingBib:
@@ -950,7 +950,7 @@ SAM:
 	Health:
 		HP: 40000
 	Armor:
-		Type: Heavy
+		Type: Concrete
 	RevealsShroud:
 		Range: 8c0
 	Turreted:
@@ -996,7 +996,7 @@ OBLI:
 	Health:
 		HP: 75000
 	Armor:
-		Type: Heavy
+		Type: Concrete
 	RevealsShroud:
 		Range: 8c0
 	WithBuildingBib:
@@ -1040,6 +1040,8 @@ GTWR:
 	Building:
 	Health:
 		HP: 40000
+	Armor:
+		Type: Concrete
 	RevealsShroud:
 		Range: 7c0
 	WithBuildingBib:
@@ -1058,7 +1060,7 @@ GTWR:
 	Turreted:
 		TurnSpeed: 512
 	Power:
-		Amount: -20
+		Amount: -10
 
 ATWR:
 	Inherits: ^Defense
@@ -1080,7 +1082,7 @@ ATWR:
 	Health:
 		HP: 55000
 	Armor:
-		Type: Heavy
+		Type: Concrete
 	RevealsShroud:
 		Range: 8c0
 	-RenderRangeCircle:
@@ -1166,12 +1168,12 @@ BRIK:
 		BuildPaletteOrder: 30
 		Prerequisites: vehicleproduction
 		Queue: Defence.GDI, Defence.Nod
-		BuildDuration: 330
+		BuildDuration: 230
 		Description: Stops infantry and most tanks.\nBlocks some projectiles.
 	Health:
-		HP: 25000
+		HP: 20000
 	Armor:
-		Type: Heavy
+		Type: Concrete
 	BlocksProjectiles:
 	Crushable:
 		CrushClasses: heavywall

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -7,7 +7,6 @@ MCV:
 		Name: Mobile Construction Vehicle
 	Buildable:
 		BuildPaletteOrder: 100
-		Prerequisites: anyhq, ~techlevel.medium, fix
 		Queue: Vehicle.GDI, Vehicle.Nod
 		Description: Deploys into another Construction Yard.\n  Unarmed
 	Selectable:
@@ -424,7 +423,7 @@ LTNK:
 		TurnSpeed: 28
 		Speed: 102
 	Health:
-		HP: 34000
+		HP: 32000
 	Repairable:
 		HpPerStep: 2062
 	Armor:
@@ -519,7 +518,7 @@ HTNK:
 	Mobile:
 		Locomotor: heavytracked
 		Speed: 46
-		TurnSpeed: 12
+		TurnSpeed: 14
 	Health:
 		HP: 87000
 	Repairable:
@@ -530,7 +529,7 @@ HTNK:
 		Range: 6c0
 	WithSpriteTurret:
 	Turreted:
-		TurnSpeed: 12
+		TurnSpeed: 14
 	Armament@PRIMARY:
 		Weapon: 120mmDual
 		LocalOffset: 900,180,340, 900,-180,340
@@ -590,7 +589,7 @@ MSAM:
 	Armor:
 		Type: Light
 	RevealsShroud:
-		Range: 5c0
+		Range: 6c0
 	Turreted:
 		TurnSpeed: 512
 		Offset: -256,0,128

--- a/mods/cnc/weapons/ballistics.yaml
+++ b/mods/cnc/weapons/ballistics.yaml
@@ -37,6 +37,7 @@
 			Wood: 88
 			Light: 100
 			Heavy: 88
+			Concrete: 88
 
 120mm:
 	Inherits: ^BallisticWeapon
@@ -56,7 +57,7 @@ TurretGun:
 	Warhead@1Dam: SpreadDamage
 		Versus:
 			None: 20
-			Wood: 25
+			Wood: 50
 			Light: 100
 			Heavy: 100
 
@@ -77,10 +78,11 @@ ArtilleryShell:
 		Spread: 341
 		Damage: 10000
 		Versus:
-			None: 150
+			None: 140
 			Wood: 100
 			Light: 112
 			Heavy: 75
+			Concrete: 75
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@3Eff: CreateEffect
 		Explosions: poof
@@ -105,6 +107,7 @@ Grenade:
 			Wood: 50
 			Light: 80
 			Heavy: 34
+			Concrete: 50
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@3Eff: CreateEffect
 		Explosions: small_poof

--- a/mods/cnc/weapons/explosions.yaml
+++ b/mods/cnc/weapons/explosions.yaml
@@ -24,6 +24,7 @@
 			Wood: 75
 			Light: 60
 			Heavy: 25
+			Concrete: 25
 
 FlametankExplode:
 	Inherits: ^DamagingExplosion
@@ -54,6 +55,7 @@ UnitExplode:
 		Versus:
 			Wood: 74
 			Heavy: 24
+			Concrete: 24
 	Warhead@2Eff: CreateEffect
 		ImpactSounds: xplobig6.aud
 
@@ -64,6 +66,7 @@ UnitExplodeShip:
 		Versus:
 			Wood: 74
 			Heavy: 24
+			Concrete: 24
 	Warhead@2Eff: CreateEffect
 		Explosions: building
 		ImpactSounds: xplobig6.aud
@@ -105,6 +108,7 @@ GrenadierExplode:
 		Versus:
 			Wood: 70
 			Heavy: 20
+			Concrete: 20
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		ImpactSounds: xplosml2.aud
@@ -126,6 +130,7 @@ Napalm.Crate:
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
 			Wood: 100
+			Concrete: 100
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@2Eff: CreateEffect
@@ -142,6 +147,7 @@ TiberiumExplosion:
 		Versus:
 			Wood: 70
 			Heavy: 20
+			Concrete: 20
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: chemball

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -24,6 +24,7 @@
 			Wood: 116
 			Light: 140
 			Heavy: 140
+			Concrete: 140
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
@@ -57,11 +58,13 @@ Dragon:
 			None: 140
 			Wood: 140
 			Heavy: 104
+			Concrete: 104
 	Warhead@4EffAir: CreateEffect
 		Explosions: small_building
 
 Rockets:
 	Inherits: ^MissileWeapon
+	ReloadDelay: 55
 
 BikeRockets:
 	Inherits: ^MissileWeapon
@@ -77,6 +80,7 @@ BikeRockets:
 			Wood: 92
 			Light: 124
 			Heavy: 124
+			Concrete: 124
 
 OrcaAGMissiles:
 	Inherits: ^MissileWeapon
@@ -96,6 +100,7 @@ OrcaAGMissiles:
 			Wood: 112
 			Light: 112
 			Heavy: 84
+			Concrete: 84
 
 OrcaAAMissiles:
 	Inherits: OrcaAGMissiles
@@ -128,6 +133,7 @@ MammothMissiles:
 			Wood: 66
 			Light: 90
 			Heavy: 44
+			Concrete: 44
 	Warhead@3Eff: CreateEffect
 		Explosions: small_poof
 		ImpactSounds: xplobig4.aud
@@ -163,6 +169,7 @@ MammothMissiles:
 			Wood: 60
 			Light: 100
 			Heavy: 48
+			Concrete: 48
 	Warhead@3Eff: CreateEffect
 		Explosions: med_frag
 		ImpactSounds: xplobig4.aud
@@ -187,6 +194,7 @@ MammothMissiles:
 			Wood: 75
 			Light: 100
 			Heavy: 90
+			Concrete: 90
 
 227mm.stnkAA:
 	Inherits: 227mm.stnk
@@ -213,6 +221,7 @@ BoatMissile:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+			Concrete: 25
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@3Eff: CreateEffect
 		Explosions: small_poof
@@ -234,12 +243,14 @@ TowerMissile:
 		RangeLimit: 8c409
 	Warhead@1Dam: SpreadDamage
 		Spread: 483
+		Damage: 3000
 		ValidTargets: Ground
 		Versus:
 			None: 52
 			Wood: 24
 			Light: 100
 			Heavy: 100
+			Concrete: 100
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@3Eff: CreateEffect
 		Explosions: big_frag
@@ -290,6 +301,7 @@ Patriot:
 			Wood: 84
 			Light: 100
 			Heavy: 74
+			Concrete: 74
 	-Warhead@2Smu:
 	Warhead@4EffAir: CreateEffect
 		Explosions: poof

--- a/mods/cnc/weapons/other.yaml
+++ b/mods/cnc/weapons/other.yaml
@@ -16,6 +16,7 @@
 			Wood: 100
 			Light: 100
 			Heavy: 10
+			Concrete: 100
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
@@ -43,6 +44,7 @@ BigFlamer:
 			Wood: 75
 			Light: 75
 			Heavy: 18
+			Concrete: 75
 	Warhead@3Eff: CreateEffect
 		Explosions: med_napalm
 
@@ -58,6 +60,7 @@ Chemspray:
 			Wood: 35
 			Light: 75
 			Heavy: 75
+			Concrete: 75
 		DamageTypes: Prone50Percent, TriggerProne, TiberiumDeath
 	Warhead@3Eff: CreateEffect
 		Explosions: chemball
@@ -80,6 +83,7 @@ Napalm:
 		Versus:
 			Wood: 35
 			Heavy: 80
+			Concrete: 80
 	Warhead@3Eff: CreateEffect
 		Explosions: med_napalm
 
@@ -115,6 +119,7 @@ Laser:
 			Wood: 10
 			Light: 30
 			Heavy: 10
+			Concrete: 10
 		DamageTypes: Prone50Percent, TriggerProne, RippedApartDeath
 
 Tail:

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -30,6 +30,7 @@ Sniper:
 			Wood: 50
 			Light: 70
 			Heavy: 30
+			Concrete: 30
 		DamageTypes: Prone50Percent, TriggerProne, RippedApartDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
@@ -56,6 +57,7 @@ Vulcan:
 			Wood: 15
 			Light: 35
 			Heavy: 35
+			Concrete: 35
 
 HeliAGGun:
 	Inherits: ^HeavyMG
@@ -75,6 +77,7 @@ HeliAGGun:
 			Wood: 75
 			Light: 75
 			Heavy: 25
+			Concrete: 25
 		DamageTypes: Prone80Percent, TriggerProne, RippedApartDeath
 
 HeliAAGun:
@@ -100,6 +103,7 @@ HeliAAGun:
 			Wood: 30
 			Light: 40
 			Heavy: 10
+			Concrete: 10
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piff
@@ -142,8 +146,9 @@ MachineGun:
 MachineGunH:
 	Inherits: MachineGun
 	Warhead@1Dam: SpreadDamage
+		Damage: 1150
 		Versus:
-			Light: 80
+			Light: 70
 
 APCGun:
 	ReloadDelay: 9
@@ -159,6 +164,7 @@ APCGun:
 			Wood: 25
 			Light: 75
 			Heavy: 25
+			Concrete: 25
 		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: small_frag

--- a/mods/cnc/weapons/superweapons.yaml
+++ b/mods/cnc/weapons/superweapons.yaml
@@ -12,6 +12,7 @@ Atomic:
 			Wood: 100
 			Light: 60
 			Heavy: 50
+			Concrete: 50
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@2Eff_impact: CreateEffect
 		Explosions: nuke_explosion
@@ -29,6 +30,7 @@ Atomic:
 			Wood: 100
 			Light: 60
 			Heavy: 50
+			Concrete: 50
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@4Res_areanukea: DestroyResource
 		Size: 3
@@ -54,6 +56,7 @@ Atomic:
 			Wood: 100
 			Light: 60
 			Heavy: 50
+			Concrete: 50
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@8Res_areanukeb: DestroyResource
 		Size: 4
@@ -75,6 +78,7 @@ Atomic:
 			Wood: 100
 			Light: 60
 			Heavy: 50
+			Concrete: 50
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@11Res_areanukec: DestroyResource
 		Size: 5


### PR DESCRIPTION
Building off of #19778

So another year, another balance PR. This is the accumulation of some off and on work over the year. Nod has been found to be over performing, so a fair amount of GDI buffs were done to address this.

**Concrete Armor**

_Concrete armor has been added to the game_
 Adding a new armor type requires a lot of changes, so hopefully I didn't miss anything. The idea behind this was to make defenses more vulnerable to certain types of weapons, ie flames and grenades. All defenses should have concrete armor, and damage values against concrete should match heavy values (except for flame weapons/grenades: they match wood damage). I did not specify concrete damage when the heavy damage was 100 (as the default value is 100 for armor types). Let me know if there's an issue with this styling wise.

_Guard Tower power was reverted back to -10 from -20_
I didn't like it that much in the first place, and guard towers now having concrete (instead of wood) armor is a nerf.

_Turret damage vs wood increased from 25 -> 50_
It was very low and base pushing has a few more counters now.

**GDI Buffs**

_MRLS Vision 5c0 -> 6c0_
MRLS were far too easy to pick off out in the field. This gives them a little more self sufficiency.

_AGT Damage 2500 -> 3000_
When the fire rate was changed in #19778, it nerfed DPS by ~30%. At the time, AGTs were over performing so this made sense. I reasoned GDI players could pick up the slack with T1 defenses. However, GDI has a difficult time leaving their base at T2 without the strength of AGTs. Nod players can harass and then defend GDI attacks fairly easily. Buffing the damage by 20% brings them closer to their previous strength. This also allows the AGT to 4 shot bikes (two volleys), which are a particular thorn for GDI.

_Commando Cost 1800 -> 1500_
I finally gave in on this. The commando is just overpriced at the moment. Losing one is too easy for how much it costs. This will also help make late game more volatile with its C4 ability.

_Mammoth Turn Speed (and Turret) 12 -> 14_
Mammoths are currently out of meta in 1vs1's. Even in GDI mirrors players will backtech out of Mammoths at T3. This change further emphasizes their sustainability without affecting team games too much (where players mass Mammoths). This will make it easier to kite or retreat for repairs.

_Hum-vee Damage 1000 -> 1150, Light 80 -> 70_

Hum-vees cost more than buggies but only have increased damage vs light armor. This change addresses this by buffing their damage in other categories but leaving their light damage about the same. They now have more utility for killing infantry in particular (can one volley minigunners).

**Nod Nerfs**

_Artillery None 150 -> 140_
A slight nudge to infantry damage to make heavy infantry in Nod mirrors more viable.

_Light Tank Health 34000 -> 32000_
Light tanks are beating medium tanks when they really shouldn't. This health change reduces the # of shots a medium tank needs to kill a light tank by 1. It also reduces the # of volleys stealth tanks need to kill it from 4 -> 3, which will hopefully encourage more T3 usage in Nod mirrors.

_Rocket Soldier Reload 50 -> 55_
This does affect both factions, but Nod in particular relies on rocket soldiers in their composition. This reduces their damage output a bit without affecting the alpha strike. Heavier armor (GDI units) should be more viable as a consequence. This also indirectly makes the Chem trooper a more attractive option.

**Other Changes**

_Elite Damage/Armor bonuses doubled: FirepowerMultiplier 125 -> 150, DamageMultiplier 80 -> 65_

In addition to the range/vision/speed buffs, Elite units now get another buff to damage (25% -> 50%) and another buff to damage resist (80% -> 65%). This was the final push needed to make Elite units potential game changers on the battlefield. I've been having a lot of fun using them when I get one.

_Elite exp requirement: 750 -> 700_
As a reminder, vet levels are: 250, 500, 700. This is just a nudge to make elite units more common. Vet 2 units are also more important to protect now.

_MCV build requirements: Fix + Comm -> just wf_

This change allows for more back and forth games. Losing an MCV forces you into an all-in position, which isn't great. This doesn't particularly affect multi-MCV builds as the cost (3000) is too high to build before comm center anyway. This also opens up more aggressive play styles with MCV sells (with the ability to recover).

_Chinook Health: 9000 -> 12500_
Chinook health is really too low. Especially since in TD there are plentiful air-air units. It's health value has moved from ~Orca to Apache level. There shouldn't be a Chinook apocalypse, as they have very little crash damage.

_Concrete Wall: Health 25000 -> 20000, BuildTime 330 -> 230_
Makes walling off easier without buffing AGT/Obelisk + concrete pushing too hard.
