### PR TITLE
Fix crash caused by aircraft checking if they're blocked by dead actors.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -688,8 +688,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool IsBlockedBy(Actor self, Actor otherActor, Actor ignoreActor, bool blockedByMobile = true)
 		{
-			// We are not blocked by the actor we are ignoring.
-			if (otherActor == self || otherActor == ignoreActor)
+			// We are not blocked by self, the actor we are ignoring, or by disposed actors.
+			if (otherActor == self || otherActor == ignoreActor || otherActor.Disposed)
 				return false;
 
 			// We are not blocked by actors we can nudge out of the way


### PR DESCRIPTION
I can't seem to replicate the crash, but it's seems straightforward from the exception log.

```
Exception of type `System.InvalidOperationException`: Attempted to get trait from destroyed object (a10 3414 (not in world))
   at OpenRA.TraitDictionary.CheckDestroyed(Actor actor) in J:\Modding\OpenRA\Repositories\Darkademic\CAmod\engine\OpenRA.Game\TraitDictionary.cs:line 84
   at OpenRA.Mods.Common.Traits.Aircraft.IsBlockedBy(Actor self, Actor otherActor, Actor ignoreActor, Boolean blockedByMobile) in J:\Modding\OpenRA\Repositories\Darkademic\CAmod\engine\OpenRA.Mods.Common\Traits\Air\Aircraft.cs:line 711
   at OpenRA.Mods.Common.Traits.Aircraft.CanLand(CPos cell, Actor dockingActor, Boolean blockedByMobile) in J:\Modding\OpenRA\Repositories\Darkademic\CAmod\engine\OpenRA.Mods.Common\Traits\Air\Aircraft.cs:line 684
   at OpenRA.Mods.Common.Traits.Aircraft.CanLand(IEnumerable`1 cells, Actor dockingActor, Boolean blockedByMobile) in J:\Modding\OpenRA\Repositories\Darkademic\CAmod\engine\OpenRA.Mods.Common\Traits\Air\Aircraft.cs:line 672
   at OpenRA.Mods.Common.Activities.Land.Tick(Actor self) in J:\Modding\OpenRA\Repositories\Darkademic\CAmod\engine\OpenRA.Mods.Common\Activities\Air\Land.cs:line 216
   at OpenRA.Activities.Activity.TickOuter(Actor self) in J:\Modding\OpenRA\Repositories\Darkademic\CAmod\engine\OpenRA.Game\Activities\Activity.cs:line 108
   at OpenRA.Traits.ActivityUtils.RunActivity(Actor self, Activity act) in J:\Modding\OpenRA\Repositories\Darkademic\CAmod\engine\OpenRA.Game\Traits\ActivityUtils.cs:line 31
   at OpenRA.Activities.Activity.TickChild(Actor self) in J:\Modding\OpenRA\Repositories\Darkademic\CAmod\engine\OpenRA.Game\Activities\Activity.cs:line 144
   at OpenRA.Activities.Activity.TickOuter(Actor self) in J:\Modding\OpenRA\Repositories\Darkademic\CAmod\engine\OpenRA.Game\Activities\Activity.cs:line 108
   at OpenRA.Traits.ActivityUtils.RunActivity(Actor self, Activity act) in J:\Modding\OpenRA\Repositories\Darkademic\CAmod\engine\OpenRA.Game\Traits\ActivityUtils.cs:line 31
   at OpenRA.Actor.Tick() in J:\Modding\OpenRA\Repositories\Darkademic\CAmod\engine\OpenRA.Game\Actor.cs:line 262
   at OpenRA.World.Tick() in J:\Modding\OpenRA\Repositories\Darkademic\CAmod\engine\OpenRA.Game\World.cs:line 441
   at OpenRA.Game.InnerLogicTick(OrderManager orderManager) in J:\Modding\OpenRA\Repositories\Darkademic\CAmod\engine\OpenRA.Game\Game.cs:line 636
   at OpenRA.Game.LogicTick() in J:\Modding\OpenRA\Repositories\Darkademic\CAmod\engine\OpenRA.Game\Game.cs:line 651
   at OpenRA.Game.Loop() in J:\Modding\OpenRA\Repositories\Darkademic\CAmod\engine\OpenRA.Game\Game.cs:line 820
   at OpenRA.Game.Run() in J:\Modding\OpenRA\Repositories\Darkademic\CAmod\engine\OpenRA.Game\Game.cs:line 873
   at OpenRA.Game.InitializeAndRun(String[] args) in J:\Modding\OpenRA\Repositories\Darkademic\CAmod\engine\OpenRA.Game\Game.cs:line 308
   at OpenRA.Launcher.Program.Main(String[] args) in J:\Modding\OpenRA\Repositories\Darkademic\CAmod\engine\OpenRA.Launcher\Program.cs:line 32
```

The first line in Aircraft.cs (711 in the log, but 705 on bleed, as CA has some unrelated tweaks) is:

```var temporaryBlocker = otherActor.TraitOrDefault<ITemporaryBlocker>();```

And it seems like otherActor can be dead/disposed, which causes an exception to be thrown.

So this fix should prevent the crash.