### PR TITLE
Use MacOS 11 for release packaging

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -63,7 +63,7 @@ jobs:
 
   macos:
     name: macOS Disk Images
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - name: Clone Repository
         uses: actions/checkout@v2


### PR DESCRIPTION
MacOS 10.15 is being depecated for GitHub Actions on 1st Dec 2022, and will have intermittent brownouts until then: https://github.com/actions/runner-images/issues/5583

This just updates the release packaging to use MacOS 11 instead.