### PR TITLE
Dispose all connections when shutting down a server

### DIFF
--- a/OpenRA.Game/Server/Connection.cs
+++ b/OpenRA.Game/Server/Connection.cs
@@ -21,7 +21,7 @@ using System.Threading;
 
 namespace OpenRA.Server
 {
-	public class Connection : IDisposable
+	public sealed class Connection : IDisposable
 	{
 		public const int MaxOrderLength = 131072;
 

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Server
 		public readonly MersenneTwister Random = new MersenneTwister();
 		public readonly ServerType Type;
 
-		public List<Connection> Conns = new List<Connection>();
+		public readonly List<Connection> Conns = new List<Connection>();
 
 		public Session LobbyInfo;
 		public ServerSettings Settings;
@@ -391,6 +391,10 @@ namespace OpenRA.Server
 
 				foreach (var t in serverTraits.WithInterface<INotifyServerShutdown>())
 					t.ServerShutdown(this);
+
+				// Make sure to immediately close connections after the server is shutdown, we don't want to keep clients waiting
+				foreach (var c in Conns)
+					c.Dispose();
 
 				Conns.Clear();
 			})


### PR DESCRIPTION
Fixes a regression from #19429 (https://github.com/OpenRA/OpenRA/commit/2a26ddc622ee5b786d6fe4c6de207d0a6ec96128 specifically).

Testcase:
- Start two local clients, open a server with one and start a game on it with both clients
- Let the hosting client disconnect (but don't close the game yet)
- The game for the remaining client on the server stops, but no error dialogue is shown
- Close the hosting client
- The error dialogue appears now on the remaining client

Correct is showing the "connection lost" error dialogue right when the host leaves the game. By calling dispose on the `Server.Connection` objects we ensure that those signal to their internal `SendReceiveLoop` thread that the socket should be closed.