### PR TITLE
AutoCarryall can receive manual order and auto action can be turn on/off by condition

### DIFF
--- a/OpenRA.Mods.Common/Traits/Carryable.cs
+++ b/OpenRA.Mods.Common/Traits/Carryable.cs
@@ -48,14 +48,12 @@ namespace OpenRA.Mods.Common.Traits
 		int carriedToken = Actor.InvalidConditionToken;
 		int lockedToken = Actor.InvalidConditionToken;
 
-		Mobile mobile;
 		IDelayCarryallPickup[] delayPickups;
 
 		public Actor Carrier { get; private set; }
 		public bool Reserved => state != State.Free;
-		public CPos? Destination { get; protected set; }
-		public bool WantsTransport => Destination != null && !IsTraitDisabled;
 
+		protected Mobile Mobile { get; private set; }
 		protected enum State { Free, Reserved, Locked }
 		protected State state = State.Free;
 		protected bool attached;
@@ -65,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override void Created(Actor self)
 		{
-			mobile = self.TraitOrDefault<Mobile>();
+			Mobile = self.TraitOrDefault<Mobile>();
 			delayPickups = self.TraitsImplementing<IDelayCarryallPickup>().ToArray();
 
 			base.Created(self);
@@ -129,7 +127,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (delayPickups.Any(d => d.IsTraitEnabled() && !d.TryLockForPickup(self, carrier)))
 				return LockResponse.Pending;
 
-			if (mobile != null && !mobile.CanStayInCell(self.Location))
+			if (Mobile != null && !Mobile.CanStayInCell(self.Location))
 				return LockResponse.Pending;
 
 			if (state != State.Locked)
@@ -142,7 +140,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// Make sure we are not moving and at our normal position with respect to the cell grid
-			if (mobile != null && mobile.IsMovingBetweenCells)
+			if (Mobile != null && Mobile.IsMovingBetweenCells)
 				return LockResponse.Pending;
 
 			return LockResponse.Success;

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.Common.Traits
 			Carrying
 		}
 
-		readonly AircraftInfo aircraftInfo;
+		protected readonly AircraftInfo AircraftInfo;
 		readonly Aircraft aircraft;
 		readonly BodyOrientation body;
 		readonly IFacing facing;
@@ -102,8 +102,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		// The actor we are currently carrying.
 		[Sync]
-		public Actor Carryable { get; private set; }
-		public CarryallState State { get; private set; }
+		public Actor Carryable { get; protected set; }
+		public CarryallState State { get; protected set; }
 
 		WAngle cachedFacing;
 		IActorPreview[] carryablePreview;
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Common.Traits
 			Carryable = null;
 			State = CarryallState.Idle;
 
-			aircraftInfo = self.Info.TraitInfoOrDefault<AircraftInfo>();
+			AircraftInfo = self.Info.TraitInfoOrDefault<AircraftInfo>();
 			aircraft = self.Trait<Aircraft>();
 			body = self.Trait<BodyOrientation>();
 			facing = self.Trait<IFacing>();
@@ -183,11 +183,6 @@ namespace OpenRA.Mods.Common.Traits
 			UnreserveCarryable(self);
 		}
 
-		public virtual bool RequestTransportNotify(Actor self, Actor carryable, CPos destination)
-		{
-			return false;
-		}
-
 		public virtual WVec OffsetForCarryable(Actor self, Actor carryable)
 		{
 			return Info.LocalOffset - carryable.Info.TraitInfo<CarryableInfo>().LocalOffset;
@@ -239,7 +234,7 @@ namespace OpenRA.Mods.Common.Traits
 			CarryableOffset = WVec.Zero;
 		}
 
-		public virtual bool ReserveCarryable(Actor self, Actor carryable)
+		public bool ReserveCarryable(Actor self, Actor carryable)
 		{
 			if (State == CarryallState.Reserved)
 				UnreserveCarryable(self);
@@ -327,7 +322,7 @@ namespace OpenRA.Mods.Common.Traits
 				yield return new CarryallPickupOrderTargeter(Info);
 				yield return new DeployOrderTargeter("Unload", 10,
 				() => CanUnload() ? Info.UnloadCursor : Info.UnloadBlockedCursor);
-				yield return new CarryallDeliverUnitTargeter(aircraftInfo, Info);
+				yield return new CarryallDeliverUnitTargeter(AircraftInfo, Info);
 			}
 		}
 
@@ -354,7 +349,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (order.OrderString == "DeliverUnit")
 			{
 				var cell = self.World.Map.Clamp(self.World.Map.CellContaining(order.Target.CenterPosition));
-				if (!aircraftInfo.MoveIntoShroud && !self.Owner.Shroud.IsExplored(cell))
+				if (!AircraftInfo.MoveIntoShroud && !self.Owner.Shroud.IsExplored(cell))
 					return;
 
 				self.QueueActivity(order.Queued, new DeliverUnit(self, order.Target, Info.DropRange, Info.TargetLineColor));


### PR DESCRIPTION
### Summary
![carryall-esc-showcase](https://user-images.githubusercontent.com/13763394/198034144-d9bf9946-5793-44d8-9f7c-1cb1d5d252e5.gif)
(1). Autocarryall can receive manual order, make a controllable carryall (unlike the one in D2k) with AutoCarryall easier to manipulate for player.


![carryall2-showcase](https://user-images.githubusercontent.com/13763394/197808115-33d43cb3-1832-403b-91f8-f4b04f76e650.gif)
 (2). Autocarryall's auto action can be turn on/off by condition, make (1) even easier to manipulate. In test case, you can use "Deploy" to disable and enable the auto action of TS carryall (when they has no passenger).

The change here is mainly to make `AutoCarryall` work like `AutoTarget`-- even if actor can automatically find their own target, player can still order them to attack elsewhere, and you can change to "HoldFire" for a better micromanage on you own.

### Side effect
No side effect currently. The carryall in D2K cannot be selected so they are just like before, unless you find bugs or some unexpected behaviors due to this PR.

### Some thoughts
I think we can change D2K carryall into my testcase and make it selectable, they are hard to use currently with full auto action.