### PR TITLE
Pathing considers reachability of source cells consistently.

### DIFF
--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -76,11 +76,17 @@ namespace OpenRA.Mods.Common.Pathfinder
 			return search;
 		}
 
+		public static bool CellAllowsMovement(World world, Locomotor locomotor, CPos cell, Func<CPos, int> customCost)
+		{
+			return world.Map.Contains(cell) &&
+				(cell.Layer == 0 || world.GetCustomMovementLayers()[cell.Layer].EnabledForLocomotor(locomotor.Info)) &&
+				(customCost == null || customCost(cell) != PathGraph.PathCostForInvalidPath);
+		}
+
 		static void AddInitialCells(World world, Locomotor locomotor, IEnumerable<CPos> froms, Func<CPos, int> customCost, PathSearch search)
 		{
-			var customMovementLayers = world.GetCustomMovementLayers();
 			foreach (var sl in froms)
-				if (world.Map.Contains(sl) && (sl.Layer == 0 || customMovementLayers[sl.Layer].EnabledForLocomotor(locomotor.Info)))
+				if (CellAllowsMovement(world, locomotor, sl, customCost))
 					search.AddInitialCell(sl, customCost);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
@@ -211,10 +211,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			bool CanEnterCell(Actor self, CPos cell)
 			{
-				if (mobile.locomotor.MovementCostForCell(cell) == PathGraph.MovementCostForUnreachableCell)
-					return false;
-
-				return mobile.locomotor.CanMoveFreelyInto(self, cell, BlockedByActor.All, null);
+				return mobile.locomotor.MovementCostToEnterCell(
+					self, cell, BlockedByActor.All, null) != PathGraph.MovementCostForUnreachableCell;
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -124,10 +124,8 @@ namespace OpenRA.Mods.Common.Traits
 				locomotor = world.WorldActor.TraitsImplementing<Locomotor>()
 				   .SingleOrDefault(l => l.Info.Name == Locomotor);
 
-			if (locomotor.MovementCostForCell(cell) == PathGraph.MovementCostForUnreachableCell)
-				return false;
-
-			return locomotor.CanMoveFreelyInto(self, cell, subCell, check, ignoreActor);
+			return locomotor.MovementCostToEnterCell(
+				self, cell, check, ignoreActor, subCell) != PathGraph.MovementCostForUnreachableCell;
 		}
 
 		public bool CanStayInCell(World world, CPos cell)

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -204,24 +204,30 @@ namespace OpenRA.Mods.Common.Traits
 			return terrainInfos[index].Speed;
 		}
 
+		public short MovementCostToEnterCell(Actor actor, CPos destNode, BlockedByActor check, Actor ignoreActor, SubCell subCell = SubCell.FullCell)
+		{
+			var cellCost = MovementCostForCell(destNode);
+
+			if (cellCost == PathGraph.MovementCostForUnreachableCell ||
+				!CanMoveFreelyInto(actor, destNode, subCell, check, ignoreActor))
+				return PathGraph.MovementCostForUnreachableCell;
+
+			return cellCost;
+		}
+
 		public short MovementCostToEnterCell(Actor actor, CPos srcNode, CPos destNode, BlockedByActor check, Actor ignoreActor)
 		{
 			var cellCost = MovementCostForCell(destNode, srcNode);
 
 			if (cellCost == PathGraph.MovementCostForUnreachableCell ||
-				!CanMoveFreelyInto(actor, destNode, check, ignoreActor))
+				!CanMoveFreelyInto(actor, destNode, SubCell.FullCell, check, ignoreActor))
 				return PathGraph.MovementCostForUnreachableCell;
 
 			return cellCost;
 		}
 
 		// Determines whether the actor is blocked by other Actors
-		public bool CanMoveFreelyInto(Actor actor, CPos cell, BlockedByActor check, Actor ignoreActor)
-		{
-			return CanMoveFreelyInto(actor, cell, SubCell.FullCell, check, ignoreActor);
-		}
-
-		public bool CanMoveFreelyInto(Actor actor, CPos cell, SubCell subCell, BlockedByActor check, Actor ignoreActor)
+		bool CanMoveFreelyInto(Actor actor, CPos cell, SubCell subCell, BlockedByActor check, Actor ignoreActor)
 		{
 			// If the check allows: We are not blocked by other actors.
 			if (check == BlockedByActor.None)


### PR DESCRIPTION
Using the local pathfinder, you could not find a path to an unreachable destination cell, but it was possible to find a path from an unreachable source cell if there was a reachable cells adjacent to it.

The hierarchical pathfinder did not have this behaviour and considering an unreachable source cell to block attempts to find a path.

Now, we unify the pathfinders to use a consistent behaviour, allowing paths from unreachable source cells to be found.

----

Test case: Revert #20367 thus causing #20366 again.

Set a rally point more to the north of the barracks in TD and produce some infantry.

If the rally point is within 20 cells, units will move towards it.
If the rally point is more than 20 cells and the fix is not applied, units fail to move towards the rally point.
If the rally point is more than 20 cells and the fix is applied, units will move to the rally point again.

More generally, any scenario where a unit on an invalid cell was able to path if moving < 20 cells but was stuck for > 20 cells will now be fixed to always allow a path.