### PR TITLE
Fix Aircraft not updating influence when changing height

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
+++ b/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
@@ -34,6 +34,9 @@ namespace OpenRA.Mods.Common.Activities
 			// We are taking off, so remove influence in ground cells.
 			aircraft.RemoveInfluence();
 
+			if (self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition).Length > aircraft.Info.MinAirborneAltitude)
+				return;
+
 			if (aircraft.Info.TakeoffSounds.Length > 0)
 				Game.Sound.Play(SoundType.World, aircraft.Info.TakeoffSounds, self.World, aircraft.CenterPosition);
 


### PR DESCRIPTION
Supersedes #20313
Fixes #20370

Occupied cells was defined by height yet we didn't update actor map on changing height. This in some scenarios caused the aircraft to forget to remove its influence from actor map.