### PR TITLE
Fix carryall not removing influence when cancelling land activity

### DIFF
--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -121,6 +121,10 @@ namespace OpenRA.Mods.Common.Activities
 				}
 			}
 
+			// We don't want to allow TakeOff to be cancelled
+			if (ChildActivity is TakeOff)
+				ChildHasPriority = true;
+
 			// Return once we are in the pickup state and the pickup activities have completed
 			return TickChild(self) && state == PickupState.Pickup;
 		}

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -73,6 +73,15 @@ namespace OpenRA.Mods.Common.Activities
 				if (carryall.State == Carryall.CarryallState.Reserved)
 					carryall.UnreserveCarryable(self);
 
+				// Make sure we run the TakeOff activity if we are / have landed
+				if (self.Trait<Aircraft>().HasInfluence())
+				{
+					ChildHasPriority = true;
+					IsInterruptible = false;
+					QueueChild(new TakeOff(self));
+					return false;
+				}
+
 				return true;
 			}
 


### PR DESCRIPTION
closes #20402

I think it's a reasonable fix, though it does feel a bit a bit strange as nowhere else is `ChildHasPriority` set during activity runtime.