### PR TITLE
Issue20373 aicraft hangs midair

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -104,7 +104,7 @@ namespace OpenRA.Mods.Common.Activities
 				}
 
 				// Prevent an infinite loop in case we'd return to the activity that called ReturnToBase in the first place. Go idle instead.
-				self.CancelActivity();
+				QueueChild(new FlyIdle(self, aircraft.Info.NumberOfTicksToVerifyAvailableAirport));
 				return true;
 			}
 


### PR DESCRIPTION
Fixes #20373 

CancelActivity() leads to an Aircraft which stands midair if the IdleBehavior is set to ReturnToBase. Copters can do that, Aicrafts can't.

So I let the aircraft start it's idle activity, this will fix standing in midair.
To make sure that I don't start idle activity on the ground I test if the aircraft is moving (flying) and only start idle if it really is flying.
I wanted to prevent something like idle activity on the airfield.