### PR TITLE
Add TurningWhileMoving to mobile

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -158,9 +158,15 @@ namespace OpenRA.Mods.Common.Activities
 				return false;
 
 			var firstFacing = self.World.Map.FacingBetween(mobile.FromCell, nextCell.Value.Cell, mobile.Facing);
+			var goBackward = false;
 
-			if (mobile.Info.CanMoveBackward && self.World.WorldTick - startTicks < mobile.Info.BackwardDuration && Math.Abs(firstFacing.Angle - mobile.Facing.Angle) > 256)
+			if (mobile.Info.CanMoveBackward &&
+				self.World.WorldTick - startTicks < mobile.Info.BackwardDuration &&
+				Math.Abs(firstFacing.Angle - mobile.Facing.Angle) > 256)
+			{
+				goBackward = true;
 				firstFacing = new WAngle(firstFacing.Angle + 512);
+			}
 
 			if (firstFacing != mobile.Facing)
 			{
@@ -186,7 +192,12 @@ namespace OpenRA.Mods.Common.Activities
 				toTerrainOrientation = WRot.SLerp(map.TerrainOrientation(mobile.FromCell), map.TerrainOrientation(mobile.ToCell), 1, 2);
 
 			var movingOnGroundLayer = mobile.FromCell.Layer == 0 && mobile.ToCell.Layer == 0;
-			QueueChild(new MoveFirstHalf(this, from, to, mobile.Facing, mobile.Facing, null, toTerrainOrientation, margin, carryoverProgress, movingOnGroundLayer));
+
+			var actorFacingModifier = WAngle.Zero;
+			if (goBackward)
+				actorFacingModifier = new WAngle(512);
+
+			QueueChild(new MoveFirstHalf(this, actorFacingModifier, from, to, mobile.Facing - actorFacingModifier, mobile.Facing - actorFacingModifier, null, toTerrainOrientation, margin, carryoverProgress, movingOnGroundLayer));
 			carryoverProgress = 0;
 			return false;
 		}
@@ -351,6 +362,7 @@ namespace OpenRA.Mods.Common.Activities
 		abstract class MovePart : Activity
 		{
 			protected readonly Move Move;
+			protected readonly WAngle ActorFacingModifier;
 			protected readonly WPos From, To;
 			protected readonly WAngle FromFacing, ToFacing;
 			protected readonly WRot? FromTerrainOrientation, ToTerrainOrientation;
@@ -365,10 +377,11 @@ namespace OpenRA.Mods.Common.Activities
 			readonly int terrainOrientationMargin;
 			protected int progress;
 
-			public MovePart(Move move, WPos from, WPos to, WAngle fromFacing, WAngle toFacing,
+			public MovePart(Move move, WAngle actorFacingModifier, WPos from, WPos to, WAngle fromFacing, WAngle toFacing,
 				WRot? fromTerrainOrientation, WRot? toTerrainOrientation, int terrainOrientationMargin, int carryoverProgress, bool movingOnGroundLayer)
 			{
 				Move = move;
+				ActorFacingModifier = actorFacingModifier;
 				From = from;
 				To = to;
 				FromFacing = fromFacing;
@@ -421,7 +434,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (progress >= Distance)
 				{
 					mobile.SetCenterPosition(self, To);
-					mobile.Facing = ToFacing;
+					mobile.Facing = ToFacing + ActorFacingModifier;
 
 					Move.lastMovePartCompletedTick = self.World.WorldTick;
 					Queue(OnComplete(self, mobile, Move));
@@ -460,7 +473,8 @@ namespace OpenRA.Mods.Common.Activities
 					mobile.SetTerrainRampOrientation(orientation);
 				}
 
-				mobile.Facing = WAngle.Lerp(FromFacing, ToFacing, progress, Distance);
+				mobile.Facing = WAngle.Lerp(FromFacing + ActorFacingModifier, ToFacing + ActorFacingModifier, progress, Distance);
+
 				return false;
 			}
 
@@ -474,9 +488,9 @@ namespace OpenRA.Mods.Common.Activities
 
 		class MoveFirstHalf : MovePart
 		{
-			public MoveFirstHalf(Move move, WPos from, WPos to, WAngle fromFacing, WAngle toFacing,
+			public MoveFirstHalf(Move move, WAngle actorFacingModifier, WPos from, WPos to, WAngle fromFacing, WAngle toFacing,
 				WRot? fromTerrainOrientation, WRot? toTerrainOrientation, int terrainOrientationMargin, int carryoverProgress, bool movingOnGroundLayer)
-				: base(move, from, to, fromFacing, toFacing, fromTerrainOrientation, toTerrainOrientation, terrainOrientationMargin, carryoverProgress, movingOnGroundLayer) { }
+				: base(move, actorFacingModifier, from, to, fromFacing, toFacing, fromTerrainOrientation, toTerrainOrientation, terrainOrientationMargin, carryoverProgress, movingOnGroundLayer) { }
 
 			static bool IsTurn(Mobile mobile, CPos nextCell, Map map)
 			{
@@ -510,10 +524,11 @@ namespace OpenRA.Mods.Common.Activities
 
 						var ret = new MoveFirstHalf(
 							Move,
+							ActorFacingModifier,
 							Util.BetweenCells(self.World, mobile.FromCell, mobile.ToCell) + (fromSubcellOffset + toSubcellOffset) / 2,
 							Util.BetweenCells(self.World, mobile.ToCell, nextCell.Value.Cell) + (toSubcellOffset + nextSubcellOffset) / 2,
-							mobile.Facing,
-							map.FacingBetween(mobile.ToCell, nextCell.Value.Cell, mobile.Facing),
+							mobile.Facing - ActorFacingModifier,
+							map.FacingBetween(mobile.ToCell, nextCell.Value.Cell, mobile.Facing - ActorFacingModifier),
 							ToTerrainOrientation,
 							nextToTerrainOrientation,
 							margin,
@@ -533,10 +548,11 @@ namespace OpenRA.Mods.Common.Activities
 
 				var ret2 = new MoveSecondHalf(
 					Move,
+					ActorFacingModifier,
 					Util.BetweenCells(self.World, mobile.FromCell, mobile.ToCell) + (fromSubcellOffset + toSubcellOffset) / 2,
 					toPos + toSubcellOffset,
-					mobile.Facing,
-					mobile.Facing,
+					mobile.Facing - ActorFacingModifier,
+					mobile.Facing - ActorFacingModifier,
 					ToTerrainOrientation,
 					null,
 					mobile.Info.TerrainOrientationAdjustmentMargin.Length,
@@ -551,9 +567,9 @@ namespace OpenRA.Mods.Common.Activities
 
 		class MoveSecondHalf : MovePart
 		{
-			public MoveSecondHalf(Move move, WPos from, WPos to, WAngle fromFacing, WAngle toFacing,
+			public MoveSecondHalf(Move move, WAngle actorFacingModifier, WPos from, WPos to, WAngle fromFacing, WAngle toFacing,
 				WRot? fromTerrainOrientation, WRot? toTerrainOrientation, int terrainOrientationMargin, int carryoverProgress, bool movingOnGroundLayer)
-				: base(move, from, to, fromFacing, toFacing, fromTerrainOrientation, toTerrainOrientation, terrainOrientationMargin, carryoverProgress, movingOnGroundLayer) { }
+				: base(move, actorFacingModifier, from, to, fromFacing, toFacing, fromTerrainOrientation, toTerrainOrientation, terrainOrientationMargin, carryoverProgress, movingOnGroundLayer) { }
 
 			protected override MovePart OnComplete(Actor self, Mobile mobile, Move parent)
 			{

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -197,6 +197,13 @@ namespace OpenRA.Mods.Common.Activities
 			if (goBackward)
 				actorFacingModifier += new WAngle(512);
 
+			// We introduce this equation:
+			// Actor Facing = Moving Direction Facing + Actor Facing Modifier
+			// among those vars,
+			// 1. we can get Actor Facing from "mobile.Facing".
+			// 2. we know Actor Facing Modifier from "actorFacingModifier".
+			// 3. then we can calculate Moving Direction Facing, which is "mobile.Facing - actorFacingModifier"
+			// the same below.
 			QueueChild(new MoveFirstHalf(this, actorFacingModifier, from, to, mobile.Facing - actorFacingModifier, mobile.Facing - actorFacingModifier, null, toTerrainOrientation, margin, carryoverProgress, movingOnGroundLayer));
 			carryoverProgress = 0;
 			return false;

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -195,7 +195,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			var actorFacingModifier = WAngle.Zero;
 			if (goBackward)
-				actorFacingModifier = new WAngle(512);
+				actorFacingModifier += new WAngle(512);
 
 			QueueChild(new MoveFirstHalf(this, actorFacingModifier, from, to, mobile.Facing - actorFacingModifier, mobile.Facing - actorFacingModifier, null, toTerrainOrientation, margin, carryoverProgress, movingOnGroundLayer));
 			carryoverProgress = 0;

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -40,6 +40,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("If set to true, this unit will always turn in place instead of following a curved trajectory (like infantry).")]
 		public readonly bool AlwaysTurnInPlace = false;
 
+		[Desc("If set to true, this unit won't stop to turn, it will turn while moving instead.")]
+		public readonly bool TurnsWhileMoving = false;
+
 		[CursorReference]
 		[Desc("Cursor to display when a move order can be issued at target location.")]
 		public readonly string Cursor = "move";

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -68,6 +68,9 @@ HVR:
 		Speed: 99
 		Locomotor: hover
 		TerrainOrientationAdjustmentMargin: -1
+		TurnsWhileMoving: true
+		CanMoveBackward: true
+		BackwardDuration: 5
 	Selectable:
 		Bounds: 1206, 1448, 0, -603
 	Health:


### PR DESCRIPTION
Now it depends on #20429, a correctness on actor's facing when backward moving .

This is a function that 2nd generation of CNC has, too, mainly used for hover unit

![turn3-showcase](https://user-images.githubusercontent.com/13763394/198988161-57992097-e5d9-4d99-8b40-7ff310995e02.gif)

![turn2-showcase](https://user-images.githubusercontent.com/13763394/198988172-149cb30d-d7c7-4bbc-a2df-695fbaffb794.gif)
