### PR TITLE
Don't disable chat in replays

### DIFF
--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -53,7 +53,8 @@ namespace OpenRA.Network
 				case "DisableChatEntry":
 					{
 						// Order must originate from the server
-						if (clientId != 0)
+						// Don't disable chat in replays
+						if (clientId != 0 || (world != null && world.IsReplay))
 							break;
 
 						// Server may send MaxValue to indicate that it is disabled until further notice

--- a/OpenRA.Game/TextNotificationsManager.cs
+++ b/OpenRA.Game/TextNotificationsManager.cs
@@ -95,6 +95,7 @@ namespace OpenRA
 
 		public static void Clear()
 		{
+			ChatDisabledUntil = Game.RunTime;
 			NotificationsCache.Clear();
 			MutedPlayers.Clear();
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -312,7 +312,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		public override void Tick()
 		{
 			var chatWasEnabled = chatEnabled;
-			chatEnabled = Game.RunTime >= TextNotificationsManager.ChatDisabledUntil && TextNotificationsManager.ChatDisabledUntil != uint.MaxValue;
+			chatEnabled = world.IsReplay || (Game.RunTime >= TextNotificationsManager.ChatDisabledUntil && TextNotificationsManager.ChatDisabledUntil != uint.MaxValue);
 
 			if (chatEnabled && !chatWasEnabled)
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -548,7 +548,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				panel = PanelType.Players;
 
 			var chatWasEnabled = chatEnabled;
-			chatEnabled = Game.RunTime >= TextNotificationsManager.ChatDisabledUntil && TextNotificationsManager.ChatDisabledUntil != uint.MaxValue;
+			chatEnabled = worldRenderer.World.IsReplay || (Game.RunTime >= TextNotificationsManager.ChatDisabledUntil && TextNotificationsManager.ChatDisabledUntil != uint.MaxValue);
 
 			if (chatEnabled && !chatWasEnabled)
 			{


### PR DESCRIPTION
Bug reported by SarahSicaria on discord

In replays we should not consume the "DisableChatEntry" order.

The way orders are handled don't always allow me the know wether the world is a replay as the world may have not even been created when some of the orders are being processed. So I've added an additional solution at a UI level

I've also included an additional small fix in this PR. If the server was not submitting a "DisableChatEntry" order then it would persist between servers.

testcase for the small fix
On bleed: get muted in multiplayer lobby -> enter singleplayer -> still muted
On this PR: get muted in multiplayer lobby -> enter singleplayer -> not muted