### PR TITLE
Use Stop button on (production) buildings to reset rally point fixes …

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -118,6 +118,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void ResolveOrder(Actor self, Order order)
 		{
+			if (order.OrderString == "Stop")
+			{
+				Path.Clear();
+				return;
+			}
+
 			if (order.OrderString != OrderID)
 				return;
 

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -1387,7 +1387,7 @@ Container@PLAYER_WIDGETS:
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Stop
-					TooltipDesc: Selected units will stop their current activity.\n\nActs immediately on selected units.
+					TooltipDesc: Selected units will stop their current activity.\nSelected buildings will reset their rally point.\n\nActs immediately on selected targets.
 					TooltipContainer: TOOLTIP_CONTAINER
 					TooltipTemplate: BUTTON_TOOLTIP_FACTIONSUFFIX
 					Children:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -330,6 +330,8 @@ PYLE:
 		Range: 5c0
 	WithBuildingBib:
 	RallyPoint:
+	CommandBarBlacklist:
+		DisableStop: false
 	Exit@1:
 		SpawnOffset: -426,85,0
 		ExitCell: 0,1
@@ -389,6 +391,8 @@ HAND:
 		Range: 5c0
 	WithBuildingBib:
 	RallyPoint:
+	CommandBarBlacklist:
+		DisableStop: false
 	Exit@1:
 		Priority: 2
 		SpawnOffset: 512,1024,0
@@ -450,6 +454,8 @@ AFLD:
 	RevealsShroud:
 		Range: 7c0
 	RallyPoint:
+	CommandBarBlacklist:
+		DisableStop: false
 	Exit@1:
 		SpawnOffset: -1024,0,0
 		ExitCell: 3,1
@@ -516,6 +522,8 @@ WEAP:
 		RequiresCondition: !build-incomplete
 		Sequence: build-top
 	RallyPoint:
+	CommandBarBlacklist:
+		DisableStop: false
 	Exit@1:
 		SpawnOffset: -512,-512,0
 		ExitCell: 0,1
@@ -584,6 +592,8 @@ HPAD:
 	WithResupplyAnimation:
 		RequiresCondition: !build-incomplete
 	RallyPoint:
+	CommandBarBlacklist:
+		DisableStop: false
 	ProductionQueue@GDI:
 		Type: Aircraft.GDI
 		DisplayOrder: 4
@@ -731,6 +741,8 @@ FIX:
 		StartRepairingNotification: Repairing
 		StartRepairingTextNotification: Repairing.
 	RallyPoint:
+	CommandBarBlacklist:
+		DisableStop: false
 	Power:
 		Amount: -20
 	ProvidesPrerequisite@buildingname:

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -154,7 +154,7 @@ Container@PLAYER_WIDGETS:
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Stop
-					TooltipDesc: Selected units will stop their current activity.\n\nActs immediately on selected units.
+					TooltipDesc: Selected units will stop their current activity.\nSelected buildings will reset their rally point.\n\nActs immediately on selected targets.
 					TooltipContainer: TOOLTIP_CONTAINER
 					Children:
 						Image@ICON:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -204,6 +204,8 @@ barracks:
 		Range: 3c768
 	RallyPoint:
 		ForceSetType: Infantry
+	CommandBarBlacklist:
+		DisableStop: false
 	Exit@1:
 		SpawnOffset: 352,576,0
 		ExitCell: 0,2
@@ -424,6 +426,8 @@ light_factory:
 		Sequence: production-welding
 	RallyPoint:
 		ForceSetType: Vehicle
+	CommandBarBlacklist:
+		DisableStop: false
 	Exit@1:
 		SpawnOffset: 544,-224,0
 		ExitCell: 2,1
@@ -496,6 +500,8 @@ heavy_factory:
 		Range: 4c768
 	RallyPoint:
 		ForceSetType: Armor
+	CommandBarBlacklist:
+		DisableStop: false
 	Exit@1:
 		SpawnOffset: 256,192,0
 		ExitCell: 0,2
@@ -641,6 +647,8 @@ starport:
 		Range: 3c768
 	RallyPoint:
 		ForceSetType: Starport
+	CommandBarBlacklist:
+		DisableStop: false
 	Exit@1:
 		SpawnOffset: 0,-480,0
 		ExitCell: 2,2
@@ -900,6 +908,8 @@ repair_pad:
 		FinishRepairingTextNotification: Unit repaired.
 		PlayerExperience: 15
 	RallyPoint:
+	CommandBarBlacklist:
+		DisableStop: false
 	RenderSprites:
 		Image: repair_pad.ordos
 		FactionImages:
@@ -1076,6 +1086,8 @@ palace:
 	Tooltip:
 		Name: Palace
 	RallyPoint:
+	CommandBarBlacklist:
+		DisableStop: false
 	D2kBuilding:
 		Footprint: xx= xxx =xx
 		Dimensions: 3,3

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -176,7 +176,7 @@ Container@PLAYER_WIDGETS:
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Stop
-					TooltipDesc: Selected units will stop their current activity.\n\nActs immediately on selected units.
+					TooltipDesc: Selected units will stop their current activity.\nSelected buildings will reset their rally point.\n\nActs immediately on selected targets.
 					TooltipContainer: TOOLTIP_CONTAINER
 					Children:
 						Image@ICON:

--- a/mods/ra/maps/soviet-01/rules.yaml
+++ b/mods/ra/maps/soviet-01/rules.yaml
@@ -42,6 +42,8 @@ AFLD:
 	ParatroopersPower@paratroopers:
 		Prerequisites: ~disabled
 	-RallyPoint:
+	CommandBarBlacklist:
+		DisableStop: true
 	-Sellable:
 	Demolishable:
 		-Condition:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -217,6 +217,8 @@ SPEN:
 		PlayerExperience: 15
 	RallyPoint:
 		ForceSetType: Ship
+	CommandBarBlacklist:
+		DisableStop: false
 	ProductionBar:
 		ProductionType: Ship
 	Power:
@@ -334,6 +336,8 @@ SYRD:
 		PlayerExperience: 15
 	RallyPoint:
 		ForceSetType: Ship
+	CommandBarBlacklist:
+		DisableStop: false
 	ProductionBar:
 		ProductionType: Ship
 	Power:
@@ -1053,6 +1057,8 @@ WEAP:
 		Sequence: build-top
 	RallyPoint:
 		ForceSetType: Vehicle
+	CommandBarBlacklist:
+		DisableStop: false
 	Exit@1:
 		RequiresCondition: !being-captured
 		SpawnOffset: 213,-128,0
@@ -1412,6 +1418,8 @@ HPAD:
 		Facing: 896
 	RallyPoint:
 		ForceSetType: Helicopter
+	CommandBarBlacklist:
+		DisableStop: false
 	Production:
 		Produces: Aircraft, Helicopter
 	Reservable:
@@ -1494,6 +1502,8 @@ AFLD:
 		Facing: 768
 	RallyPoint:
 		ForceSetType: Plane
+	CommandBarBlacklist:
+		DisableStop: false
 	Production:
 		Produces: Aircraft, Plane
 	Reservable:
@@ -1765,6 +1775,8 @@ BARR:
 	WithBuildingBib:
 	RallyPoint:
 		ForceSetType: Infantry
+	CommandBarBlacklist:
+		DisableStop: false
 	Exit@1:
 		RequiresCondition: !being-captured
 		SpawnOffset: -170,810,0
@@ -1841,6 +1853,8 @@ KENN:
 		HasMinibib: True
 	RallyPoint:
 		ForceSetType: Dog
+	CommandBarBlacklist:
+		DisableStop: false
 	Exit@0:
 		RequiresCondition: !being-captured
 		SpawnOffset: -280,400,0
@@ -1928,6 +1942,8 @@ TENT:
 	WithBuildingBib:
 	RallyPoint:
 		ForceSetType: Infantry
+	CommandBarBlacklist:
+		DisableStop: false
 	Exit@1:
 		RequiresCondition: !being-captured
 		SpawnOffset: -42,810,0
@@ -2014,6 +2030,8 @@ FIX:
 		Range: 4c0
 	Reservable:
 	RallyPoint:
+	CommandBarBlacklist:
+		DisableStop: false
 	RepairsUnits:
 		HpPerStep: 1000
 		Interval: 7

--- a/mods/ts/chrome/ingame-player.yaml
+++ b/mods/ts/chrome/ingame-player.yaml
@@ -171,7 +171,7 @@ Container@PLAYER_WIDGETS:
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Stop
-					TooltipDesc: Selected units will stop their current activity.\n\nActs immediately on selected units.
+					TooltipDesc: Selected units will stop their current activity.\nSelected buildings will reset their rally point.\n\nActs immediately on selected targets.
 					TooltipContainer: TOOLTIP_CONTAINER
 					Children:
 						Image@ICON:

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -134,6 +134,8 @@ GAPILE:
 		IsPlayerPalette: false
 		LineWidth: 2
 		ForceSetType: Infantry
+	CommandBarBlacklist:
+		DisableStop: false
 	Exit@1:
 		SpawnOffset: -512,768,0
 		ExitCell: 1,2
@@ -228,6 +230,8 @@ GAWEAP:
 		IsPlayerPalette: false
 		LineWidth: 2
 		ForceSetType: Vehicle
+	CommandBarBlacklist:
+		DisableStop: false
 	Exit@1:
 		SpawnOffset: -384,-384,0
 		ExitCell: 3,1
@@ -303,6 +307,8 @@ GAHPAD:
 		IsPlayerPalette: false
 		LineWidth: 2
 		ForceSetType: Air
+	CommandBarBlacklist:
+		DisableStop: false
 	Production:
 		Produces: Air
 		PauseOnCondition: empdisable
@@ -369,6 +375,8 @@ GADEPT:
 		Palette: mouse
 		IsPlayerPalette: false
 		LineWidth: 2
+	CommandBarBlacklist:
+		DisableStop: false
 	WithIdleOverlay@LIGHT:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-light

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -160,6 +160,8 @@ NAHAND:
 		IsPlayerPalette: false
 		LineWidth: 2
 		ForceSetType: Infantry
+	CommandBarBlacklist:
+		DisableStop: false
 	Production:
 		Produces: Infantry
 		PauseOnCondition: empdisable
@@ -207,6 +209,8 @@ NAWEAP:
 		IsPlayerPalette: false
 		LineWidth: 2
 		ForceSetType: Vehicle
+	CommandBarBlacklist:
+		DisableStop: false
 	Exit@1:
 		SpawnOffset: -384,-384,0
 		ExitCell: 3,1
@@ -267,6 +271,8 @@ NAHPAD:
 		IsPlayerPalette: false
 		LineWidth: 2
 		ForceSetType: Air
+	CommandBarBlacklist:
+		DisableStop: false
 	Production:
 		Produces: Air
 		PauseOnCondition: empdisable


### PR DESCRIPTION
Fixes #20414

This PR adds the stop button to all buildings which can have a rally point. You now can use the Stop button to clear the rally point.

The Stop button remains active even if there isn't a rally point set. This is consistent with vehicles or infantry which have the Stop button active at all times, even if they are stopped at the moment. 
Also don't checking if the Stop button should be active everytime we're switching actors saves us a few cpu cycles.
