### PR TITLE
Fixed multiplayer spawn being allowed outside of the map in the editor

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -74,7 +74,11 @@ namespace OpenRA.Mods.Common.Traits
 			var subCellInit = reference.GetOrDefault<SubCellInit>();
 			var subCell = subCellInit != null ? subCellInit.Value : SubCell.Any;
 
-			Footprint = ios?.OccupiedCells(Info, location, subCell) ?? new Dictionary<CPos, SubCell>() { { location, SubCell.FullCell } };
+			var occupiedCells = ios?.OccupiedCells(Info, location, subCell);
+			if (occupiedCells == null || occupiedCells.Count == 0)
+				Footprint = new Dictionary<CPos, SubCell>() { { location, SubCell.FullCell } };
+			else
+				Footprint = occupiedCells;
 
 			tooltip = Info.TraitInfos<EditorOnlyTooltipInfo>().FirstOrDefault(info => info.EnabledByDefault) as TooltipInfoBase
 				?? Info.TraitInfos<TooltipInfo>().FirstOrDefault(info => info.EnabledByDefault);


### PR DESCRIPTION
Originally reported at https://github.com/OpenHV/OpenHV/issues/632. What happens here is `mpspawn` leaving no footprint:

https://github.com/OpenRA/OpenRA/blob/bc676fbf7882505650257041cabae5bef9cf42d8/mods/ra/rules/misc.yaml#L420-L421

which creates an empty dictionary

https://github.com/OpenRA/OpenRA/blob/6a31b1f9f368109cc1916ba6513f4c0eb30cf8b6/OpenRA.Mods.Common/Traits/Immobile.cs#L25-L26

which breaks this check

https://github.com/OpenRA/OpenRA/blob/6a31b1f9f368109cc1916ba6513f4c0eb30cf8b6/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs#L62-L63

therefore allowing invalid placements that will later crash.