### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [ bleed ]
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   linux:
     name: Linux (.NET 6.0)

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,6 +8,9 @@ on:
         required: true
         default: 'release-xxxxxxxx'
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   wiki:
     name: Update Wiki

--- a/.github/workflows/itch.yml
+++ b/.github/workflows/itch.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'release-xxxxxxxx'
 
+permissions: {}
 jobs:
   itch:
     name: Deploy to itch.io

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -7,6 +7,9 @@ on:
     - 'playtest-*'
     - 'devtest-*'
 
+permissions:
+  contents: write  #  for release creation (svenstaro/upload-release-action)
+
 jobs:
   source:
     name: Source Tarball


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.