### PR TITLE
Fix Locomotor IsMoving checks.

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -329,7 +329,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			// If the check allows: we are not blocked by moving units.
 			if (check <= BlockedByActor.Stationary && cellFlag.HasCellFlag(CellFlag.HasMovingActor) &&
-				IsMoving(actor, otherActor))
+				otherActor.OccupiesSpace is Mobile otherMobile && otherMobile.CurrentMovementTypes.HasMovementType(MovementType.Horizontal))
 				return false;
 
 			if (cellFlag.HasCellFlag(CellFlag.HasTemporaryBlocker))
@@ -359,16 +359,6 @@ namespace OpenRA.Mods.Common.Traits
 					return false;
 
 			return true;
-		}
-
-		static bool IsMoving(Actor self, Actor other)
-		{
-			// PERF: Because we can be sure that OccupiesSpace is Mobile here we can save some performance by avoiding querying for the trait.
-			if (!(other.OccupiesSpace is Mobile otherMobile) || !otherMobile.CurrentMovementTypes.HasMovementType(MovementType.Horizontal))
-				return false;
-
-			// PERF: Same here.
-			return self.OccupiesSpace is Mobile;
 		}
 
 		public void WorldLoaded(World w, WorldRenderer wr)


### PR DESCRIPTION
The Locomotor IsMoving check was allowing us to consider another actor that moving as not a blocker. However for some reason it also considered the actor trying to path being `Mobile` as sufficient for this check to pass which did not make sense. We remove that extra check and inline the method.

This was a regression from 4a609bbee81f4a82bd85ea8244857f02145649c8 which changed the method from IsMovingInMyDirection (which required the lookup of the mobile trait) to just IsMoving. It should have removed the lookup as not required.

This fixes a crash in HPF which was considered the location as blocked when Locomotor considered it unblocked because the logic was not aligned. Removing this check aligns the logic and resolves the crash.

----

Regressed in #16408
Fixes #20443
