### PR TITLE
add immortal dev command

### DIFF
--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -75,6 +75,9 @@ namespace OpenRA.Mods.Common.Commands
 		[TranslationReference]
 		static readonly string DisposeSelectedActorsDescription = "dispose-selected-actors";
 
+		[TranslationReference]
+		static readonly string ImmortalDescription = "immortal";
+
 		readonly IDictionary<string, (string Description, Action<string, World> Handler)> commandHandlers = new Dictionary<string, (string, Action<string, World>)>
 		{
 			{ "visibility", (ToggleVisiblityDescription, Visibility) },
@@ -91,7 +94,8 @@ namespace OpenRA.Mods.Common.Commands
 			{ "player-experience", (PlayerExperienceDescription, PlayerExperience) },
 			{ "power-outage", (PowerOutageDescription, PowerOutage) },
 			{ "kill", (KillSelectedActorsDescription, Kill) },
-			{ "dispose", (DisposeSelectedActorsDescription, Dispose) }
+			{ "dispose", (DisposeSelectedActorsDescription, Dispose) },
+			{ "immortal", (ImmortalDescription, Immortal) }
 		};
 
 		World world;
@@ -247,6 +251,11 @@ namespace OpenRA.Mods.Common.Commands
 
 				world.IssueOrder(new Order("DevDispose", world.LocalPlayer.PlayerActor, Target.FromActor(actor), false));
 			}
+		}
+
+		static void Immortal(string arg, World world)
+		{
+			IssueDevCommand(world, "DevImmortal");
 		}
 
 		static void IssueDevCommand(World world, string command)

--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -159,6 +159,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void InflictDamage(Actor self, Actor attacker, Damage damage, bool ignoreModifiers)
 		{
+			if (self.Owner.PlayerActor.Trait<DeveloperMode>().Immortal)
+				return;
+
 			// Overkill! Don't count extra hits as more kills!
 			if (IsDead)
 				return;

--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
@@ -62,6 +62,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Enable the path debug overlay by default.")]
 		public readonly bool PathDebug;
 
+		[Desc("Enable the immortal cheat by default.")]
+		public readonly bool Immortal;
+
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
 			yield return new LobbyBooleanOption("cheats", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
@@ -96,6 +99,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Sync]
 		bool buildAnywhere;
 
+		[Sync]
+		bool immortal;
+
 		public bool FastCharge => Enabled && fastCharge;
 		public bool AllTech => Enabled && allTech;
 		public bool FastBuild => Enabled && fastBuild;
@@ -103,6 +109,7 @@ namespace OpenRA.Mods.Common.Traits
 		public bool PathDebug => Enabled && pathDebug;
 		public bool UnlimitedPower => Enabled && unlimitedPower;
 		public bool BuildAnywhere => Enabled && buildAnywhere;
+		public bool Immortal => Enabled && immortal;
 
 		bool enableAll;
 
@@ -118,6 +125,7 @@ namespace OpenRA.Mods.Common.Traits
 			pathDebug = info.PathDebug;
 			unlimitedPower = info.UnlimitedPower;
 			buildAnywhere = info.BuildAnywhere;
+			immortal = info.Immortal;
 		}
 
 		void INotifyCreated.Created(Actor self)
@@ -137,7 +145,7 @@ namespace OpenRA.Mods.Common.Traits
 				case "DevAll":
 				{
 					enableAll ^= true;
-					allTech = fastCharge = fastBuild = disableShroud = unlimitedPower = buildAnywhere = enableAll;
+					allTech = fastCharge = fastBuild = disableShroud = unlimitedPower = buildAnywhere = enableAll = immortal;
 
 					if (enableAll)
 					{
@@ -269,6 +277,12 @@ namespace OpenRA.Mods.Common.Traits
 						break;
 
 					order.Target.Actor.Dispose();
+					break;
+				}
+
+				case "DevImmortal":
+				{
+					immortal ^= true;
 					break;
 				}
 

--- a/mods/common/languages/en.ftl
+++ b/mods/common/languages/en.ftl
@@ -633,6 +633,7 @@ player-experience = adds a specified amount of player experience to the owner(s)
 power-outage = causes owner(s) of selected actors to have a 5 second power outage.
 kill-selected-actors = kills selected actors.
 dispose-selected-actors = disposes selected actors.
+immortal = make own actors immortal
 
 ## HelpCommands
 available-commands = Here are the available commands:


### PR DESCRIPTION
Adds the `/immortal` Command which prevents all your actors from using health points when debugging.
This PR is by no means complete but a rough outline to talk about - it's doing what it's supposed to be, though.