### PR TITLE
Close the release-20210321 UpdatePath

### DIFF
--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveLaysTerrain(),
 			}),
 
-			new UpdatePath("release-20210321", new UpdateRule[]
+			new UpdatePath("release-20210321", "devtest-20221007", new UpdateRule[]
 			{
 				// Bleed only changes here
 				new RenameMPTraits(),
@@ -97,7 +97,9 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new UnhardcodeBaseBuilderBotModule(),
 				new UnhardcodeVeteranProductionIconOverlay(),
 				new RenameContrailProperties(),
-			})
+			}),
+
+			new UpdatePath("devtest-20221007", new UpdateRule[] { })
 		};
 
 		public static IEnumerable<UpdateRule> FromSource(ObjectCreator objectCreator, string source, bool chain = true)


### PR DESCRIPTION
Since the prep branch was made we can close the UpdatePath for release-20210321. 

I want to do this asap as I will need to rebase a bunch of PR's on top of this