### PR TITLE
Manually add game speeds to the linter.

### DIFF
--- a/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
@@ -32,6 +32,15 @@ namespace OpenRA.Mods.Common.Lint
 			var language = "en";
 			var translation = new Translation(language, modData.Manifest.Translations, modData.DefaultFileSystem);
 
+			var gameSpeeds = modData.Manifest.Get<GameSpeeds>();
+			foreach (var speed in gameSpeeds.Speeds.Values)
+			{
+				if (!translation.HasMessage(speed.Name))
+					emitError($"{speed.Name} not present in {language} translation.");
+
+				referencedKeys.Add(speed.Name);
+			}
+
 			foreach (var modType in modData.ObjectCreator.GetTypes())
 			{
 				foreach (var fieldInfo in modType.GetFields(Binding).Where(m => m.HasAttribute<TranslationReferenceAttribute>()))


### PR DESCRIPTION
Taken from #20400 and rebased for prep branch

The main difference is that we don't add `TranslationReference` attribute. In the current linting implementation it crashes