### PR TITLE
HarvesterBotModule should not command harvesters that cannot be ordered

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Find new harvesters
 			// TODO: Look for a more performance-friendly way to update this list
-			var newHarvesters = world.ActorsHavingTrait<Harvester>().Where(a => a.Owner == player && !harvesters.ContainsKey(a));
+			var newHarvesters = world.ActorsHavingTrait<Harvester>().Where(a => !unitCannotBeOrdered(a) && !harvesters.ContainsKey(a));
 			foreach (var a in newHarvesters)
 				harvesters[a] = new HarvesterTraitWrapper(a);
 


### PR DESCRIPTION
When removing units "that cannot be ordered", we remove units that are dead/in world (see line 97), but later when we search new units, we add them back (see line 105). We should avoid add them back.