### PR TITLE
Fixed notarisation stalling the build process

### DIFF
--- a/packaging/macos/buildpackage.sh
+++ b/packaging/macos/buildpackage.sh
@@ -281,14 +281,9 @@ fi
 
 if [ -n "${MACOS_DEVELOPER_USERNAME}" ] && [ -n "${MACOS_DEVELOPER_PASSWORD}" ]; then
 	# Parallelize processing
-	(notarize_package "build.dmg") || exit 1 &
-	(notarize_package "build-mono.dmg") || exit 1 &
-	while wait -n; rc=$?; [ "${rc}" != 127 ]; do
-		if [ "${rc}" != 0 ]; then
-			wait
-			exit "${rc}"
-		fi
-	done
+	(notarize_package "build.dmg") &
+	(notarize_package "build-mono.dmg") &
+	wait
 fi
 
 finalize_package "standard" "build.dmg" "${OUTPUTDIR}/OpenRA-${TAG}.dmg"


### PR DESCRIPTION
This reverts https://github.com/OpenRA/OpenRA/pull/20059. Running the packaging script locally causes
> ./packaging/macos/buildpackage.sh: line 286: wait -n: invalid option
> wait: usage: wait [n]

On the GitHub Actions cloud builders that causes a freeze/disconnect.