### PR TITLE
Remove the unused MONO_TAG variable from the MacOS buildpackage script

### DIFF
--- a/packaging/macos/buildpackage.sh
+++ b/packaging/macos/buildpackage.sh
@@ -16,8 +16,6 @@
 
 set -o errexit -o pipefail || exit $?
 
-MONO_TAG="osx-launcher-20201222"
-
 if [ $# -ne "2" ]; then
 	echo "Usage: $(basename "$0") tag outputdir"
 	exit 1


### PR DESCRIPTION
The last usage was removed in https://github.com/OpenRA/OpenRA/commit/7bedba5837283b98aa7d04c8aec23d3a9622828d and https://github.com/OpenRA/OpenRALauncherOSX is archived.