### PR TITLE
Syncreport outputs some more infomation

### DIFF
--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -117,6 +117,8 @@ namespace OpenRA.Network
 					desyncFrameFound = true;
 					var mod = Game.ModData.Manifest.Metadata;
 					Log.Write("sync", "Player: {0} ({1} {2} {3})", Game.Settings.Player.Name, Platform.CurrentPlatform, Environment.OSVersion, Platform.RuntimeVersion);
+					if (Game.IsHost)
+						Log.Write("sync", "Player is host.");
 					Log.Write("sync", "Game ID: {0} (Mod: {1} at Version {2})", orderManager.LobbyInfo.GlobalSettings.GameUid, mod.Title, mod.Version);
 					Log.Write("sync", "Sync for net frame {0} -------------", r.Frame);
 					Log.Write("sync", "SharedRandom: {0} (#{1})", r.SyncedRandom, r.TotalCount);
@@ -149,11 +151,11 @@ namespace OpenRA.Network
 			}
 
 			Log.Write("sync", "Sync Report System Info:");
-			Log.Write("sync", "Out of sync frame: {0}", frame);
+			Log.Write("sync", $"Out of sync frame: {frame}");
 			Log.Write("sync", "Recorded frames: " + string.Join(",", recordedFrames));
 
 			if (!desyncFrameFound)
-				Log.Write("sync", "Recorded frames do not contain the frame {0}. No sync report available!", frame);
+				Log.Write("sync", $"Recorded frames do not contain the frame {frame}. No sync report available!");
 		}
 
 		class Report

--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Network
 {
 	class SyncReport
 	{
-		const int NumSyncReports = 5;
+		const int NumSyncReports = 7;
 		static readonly Cache<Type, TypeInfo> TypeInfoCache = new Cache<Type, TypeInfo>(t => new TypeInfo(t));
 
 		readonly OrderManager orderManager;

--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -104,7 +104,7 @@ namespace OpenRA.Network
 
 		internal void DumpSyncReport(int frame)
 		{
-			var reportName = "syncreport-" + DateTime.UtcNow.ToString("yyyy-MM-ddTHHmmssZ", CultureInfo.InvariantCulture) + ".log";
+			var reportName = "syncreport-" + DateTime.UtcNow.ToString("yyyy-MM-ddTHHmmssZ", CultureInfo.InvariantCulture) + "-" + orderManager.LocalClient.Index + ".log";
 			Log.AddChannel("sync", reportName);
 
 			var recordedFrames = new List<int>();

--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -107,10 +107,14 @@ namespace OpenRA.Network
 			var reportName = "syncreport-" + DateTime.UtcNow.ToString("yyyy-MM-ddTHHmmssZ", CultureInfo.InvariantCulture) + ".log";
 			Log.AddChannel("sync", reportName);
 
+			var recordedFrames = new List<int>();
+			var desyncFrameFound = false;
 			foreach (var r in syncReports)
 			{
+				recordedFrames.Add(r.Frame);
 				if (r.Frame == frame)
 				{
+					desyncFrameFound = true;
 					var mod = Game.ModData.Manifest.Metadata;
 					Log.Write("sync", "Player: {0} ({1} {2} {3})", Game.Settings.Player.Name, Platform.CurrentPlatform, Environment.OSVersion, Platform.RuntimeVersion);
 					Log.Write("sync", "Game ID: {0} (Mod: {1} at Version {2})", orderManager.LobbyInfo.GlobalSettings.GameUid, mod.Title, mod.Version);
@@ -141,12 +145,15 @@ namespace OpenRA.Network
 					Log.Write("sync", "Orders Issued:");
 					foreach (var o in r.Orders)
 						Log.Write("sync", "\t {0}", o.ToString());
-
-					return;
 				}
 			}
 
-			Log.Write("sync", "No sync report available!");
+			Log.Write("sync", "Sync Report System Info:");
+			Log.Write("sync", "Out of sync frame: {0}", frame);
+			Log.Write("sync", "Recorded frames: " + string.Join(",", recordedFrames));
+
+			if (!desyncFrameFound)
+				Log.Write("sync", "Recorded frames do not contain the frame {0}. No sync report available!", frame);
 		}
 
 		class Report


### PR DESCRIPTION
1. [SyncReport: Output the frames recorded for better debug.](https://github.com/OpenRA/OpenRA/commit/2a9cc065d4105cf1a5055f78c33042d7251bbc9f) and let the devs know why there is "No sync report available!" better

2. [SyncReport filename contains index of local client](https://github.com/OpenRA/OpenRA/commit/21cf3db665fa75dc600a9952ef1a73aa21f1ff7a) helps sync report generation on mutiplayer local test (when I run 2 game on 1 pc to debug a desync issue), otherwise there will be only one sync report generated.