### PR TITLE
The 2nd way to fix desync caused by order parsing difference between local and network

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -612,6 +612,8 @@ namespace OpenRA
 
 					Sound.Tick();
 
+					orderManager.RefreshOrders();
+
 					Sync.RunUnsynced(world, orderManager.TickImmediate);
 
 					if (world == null)
@@ -625,8 +627,6 @@ namespace OpenRA
 						});
 
 						world.Tick();
-
-						orderManager.RefreshOrders();
 
 						PerfHistory.Tick();
 					}

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -626,6 +626,8 @@ namespace OpenRA
 
 						world.Tick();
 
+						orderManager.RefreshOrders();
+
 						PerfHistory.Tick();
 					}
 

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA
@@ -225,6 +226,40 @@ namespace OpenRA
 
 				return null;
 			}
+		}
+
+		public static Order RefreshOrder(Order order)
+		{
+			if (order.Type != OrderType.Fields)
+				return order;
+
+			if (order.Subject != null && !order.Subject.IsInWorld)
+				return null;
+
+			var target = Target.Invalid;
+			Actor[] extraActors = null;
+			Actor[] groupedActors = null;
+
+			if (order.target.Type == TargetType.Actor)
+			{
+				if (order.target.Actor != null && order.target.Actor.IsInWorld)
+					target = order.target;
+			}
+			else if (order.target.Type == TargetType.FrozenActor)
+			{
+				if (order.target.FrozenActor != null)
+					target = order.target;
+			}
+			else
+				target = order.target;
+
+			if (order.ExtraActors != null)
+				extraActors = order.ExtraActors.Where(a => a != null && a.IsInWorld).ToArray();
+
+			if (order.GroupedActors != null)
+				groupedActors = order.GroupedActors.Where(a => a != null && a.IsInWorld).ToArray();
+
+			return new Order(order.OrderString, order.Subject, target, order.TargetString, order.Queued, extraActors, order.ExtraLocation, order.ExtraData, groupedActors);
 		}
 
 		static uint UIntFromActor(Actor a)

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -47,12 +47,12 @@ namespace OpenRA.Network
 		internal int GameSaveLastFrame = -1;
 		internal int GameSaveLastSyncFrame = -1;
 
-		readonly List<Order> localOrders = new List<Order>();
 		readonly List<Order> localImmediateOrders = new List<Order>();
 
 		readonly List<ClientOrder> processClientOrders = new List<ClientOrder>();
 		readonly List<int> processClientsToRemove = new List<int>();
 
+		List<Order> localOrders = new List<Order>();
 		bool disposed;
 		bool generateSyncReport = false;
 		int sentOrdersFrame = 0;
@@ -122,6 +122,19 @@ namespace OpenRA.Network
 				localImmediateOrders.Add(order);
 			else
 				localOrders.Add(order);
+		}
+
+		public void RefreshOrders()
+		{
+			var refreshedOrders = new List<Order>();
+			foreach (var order in localOrders)
+			{
+				var o = Order.RefreshOrder(order);
+				if (o != null)
+					refreshedOrders.Add(o);
+			}
+
+			localOrders = refreshedOrders;
 		}
 
 		void SendImmediateOrders()


### PR DESCRIPTION
Supersedes #20479

Upon https://github.com/OpenRA/OpenRA/issues/20478#issuecomment-1326551041, we know that we can solve this problem by refresh/check the order we are going to send after the game's frame end tasks (we always remove actor from world here).

This can satisfy https://github.com/OpenRA/OpenRA/pull/20479#issuecomment-1325051335, prevent the order being sent at the first place, which will save some perf on network transfering compared with #20479.

However, we still need @pchote to check if the https://github.com/OpenRA/OpenRA/issues/20478#issuecomment-1326551041 is correct, and this PR can hide some underlying issues that we do not discover at present.

Also this PR is being test for now. Will be reopen if the test is successful.