### PR TITLE
Notarize macOS builds sequentially

### DIFF
--- a/packaging/macos/buildpackage.sh
+++ b/packaging/macos/buildpackage.sh
@@ -278,10 +278,9 @@ if [ -n "${MACOS_DEVELOPER_CERTIFICATE_BASE64}" ] && [ -n "${MACOS_DEVELOPER_CER
 fi
 
 if [ -n "${MACOS_DEVELOPER_USERNAME}" ] && [ -n "${MACOS_DEVELOPER_PASSWORD}" ]; then
-	# Parallelize processing
-	(notarize_package "build.dmg") &
-	(notarize_package "build-mono.dmg") &
-	wait
+	# Notarize sequentially to avoid issues with waiting for the submissions to finish in the background
+	notarize_package "build.dmg"
+	notarize_package "build-mono.dmg"
 fi
 
 finalize_package "standard" "build.dmg" "${OUTPUTDIR}/OpenRA-${TAG}.dmg"


### PR DESCRIPTION
Processing in parallel seems to cause issues with notarization (either something is failing silently or the process is not awaited and log outputs are missing), and we're still "fast" enough to afford sequential notarization (it takes quite some time either way).