### PR TITLE
Serialize orders for all clients

### DIFF
--- a/OpenRA.Game/Network/Connection.cs
+++ b/OpenRA.Game/Network/Connection.cs
@@ -57,12 +57,12 @@ namespace OpenRA.Network
 
 		void IConnection.Send(int frame, IEnumerable<Order> o)
 		{
-			orders.Enqueue((frame, new OrderPacket(o.ToArray())));
+			orders.Enqueue((frame, new OrderPacket(o)));
 		}
 
 		void IConnection.SendImmediate(IEnumerable<Order> o)
 		{
-			immediateOrders.Enqueue(new OrderPacket(o.ToArray()));
+			immediateOrders.Enqueue(new OrderPacket(o));
 		}
 
 		void IConnection.SendSync(int frame, int syncHash, ulong defeatState)
@@ -230,14 +230,14 @@ namespace OpenRA.Network
 
 		void IConnection.Send(int frame, IEnumerable<Order> orders)
 		{
-			var o = new OrderPacket(orders.ToArray());
+			var o = new OrderPacket(orders);
 			sentOrders.Enqueue((frame, o));
 			Send(o.Serialize(frame));
 		}
 
 		void IConnection.SendImmediate(IEnumerable<Order> orders)
 		{
-			var o = new OrderPacket(orders.ToArray());
+			var o = new OrderPacket(orders);
 			sentImmediateOrders.Enqueue(o);
 			Send(o.Serialize(0));
 		}

--- a/OpenRA.Game/Network/OrderIO.cs
+++ b/OpenRA.Game/Network/OrderIO.cs
@@ -54,13 +54,14 @@ namespace OpenRA.Network
 
 		public byte[] Serialize(int frame)
 		{
-			if (data != null)
-				return data.ToArray();
-
 			var ms = new MemoryStream();
 			ms.WriteArray(BitConverter.GetBytes(frame));
-			foreach (var o in orders)
-				ms.WriteArray(o.Serialize());
+			if (data != null)
+				data.CopyTo(ms);
+			else
+				foreach (var o in orders)
+					ms.WriteArray(o.Serialize());
+
 			return ms.ToArray();
 		}
 

--- a/OpenRA.Game/Network/OrderIO.cs
+++ b/OpenRA.Game/Network/OrderIO.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Network
 	public class OrderPacket
 	{
 		readonly MemoryStream data;
-		public OrderPacket(Order[] orders)
+		public OrderPacket(IEnumerable<Order> orders)
 		{
 			// Orders may refer to actors that no longer exist by the time
 			// that the order is resolved. In order to ensure consistent


### PR DESCRIPTION
Fixes #20478.
Supersedes #20479.

This implements a cleaner solution that more closely matches the behaviour before the orders rewrite.