### PR TITLE
Updated Apple notarisation to XCode 13

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -61,8 +61,8 @@ jobs:
           file_glob: true
           file: build/linux/*
 
-  macos:
-    name: macOS Disk Images
+  macos-net:
+    name: macOS .NET
     runs-on: macos-11
     steps:
       - name: Clone Repository
@@ -76,7 +76,7 @@ jobs:
       - name: Prepare Environment
         run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> ${GITHUB_ENV}
 
-      - name: Package Disk Images
+      - name: Package Disk Image
         env:
           MACOS_DEVELOPER_IDENTITY: ${{ secrets.MACOS_DEVELOPER_IDENTITY }}
           MACOS_DEVELOPER_CERTIFICATE_BASE64: ${{ secrets.MACOS_DEVELOPER_CERTIFICATE_BASE64 }}
@@ -85,9 +85,45 @@ jobs:
           MACOS_DEVELOPER_PASSWORD: ${{ secrets.MACOS_DEVELOPER_PASSWORD }}
         run: |
           mkdir -p build/macos
-          ./packaging/macos/buildpackage.sh "${GIT_TAG}" "${PWD}/build/macos"
+          ./packaging/macos/buildpackage.sh "${GIT_TAG}" "${PWD}/build/macos" "standard" "build.dmg"
 
-      - name: Upload Packages
+      - name: Upload Package
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true
+          file: build/macos/*
+
+  macos-mono:
+    name: macOS Mono
+    runs-on: macos-11
+
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v3
+
+      - name: Install .NET 6
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+
+      - name: Prepare Environment
+        run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> ${GITHUB_ENV}
+
+      - name: Package Disk Image
+        env:
+          MACOS_DEVELOPER_IDENTITY: ${{ secrets.MACOS_DEVELOPER_IDENTITY }}
+          MACOS_DEVELOPER_CERTIFICATE_BASE64: ${{ secrets.MACOS_DEVELOPER_CERTIFICATE_BASE64 }}
+          MACOS_DEVELOPER_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_DEVELOPER_CERTIFICATE_PASSWORD }}
+          MACOS_DEVELOPER_USERNAME: ${{ secrets.MACOS_DEVELOPER_USERNAME }}
+          MACOS_DEVELOPER_PASSWORD: ${{ secrets.MACOS_DEVELOPER_PASSWORD }}
+        run: |
+          mkdir -p build/macos
+          ./packaging/macos/buildpackage.sh "${GIT_TAG}" "${PWD}/build/macos" "mono" "build-mono.dmg"
+
+      - name: Upload Package
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As [`notarytool` command line utility replaces `altool`](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow/notarizing_apps_when_developing_with_xcode_12_and_earlier) this updates the packaging scripts and simplifies them a lot. It also removes all needs for manual querying for results. The parallelization is now handled in GitHub actions instead of Bash. See [devtest-20221127](https://github.com/Mailaender/OpenRA/releases/tag/devtest-20221127) for a test build.