### PR TITLE
Remove exception throwing from AddInfluence and have PickupUnit always run a TakeOff activity

### DIFF
--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -65,15 +65,12 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override bool Tick(Actor self)
 		{
-			if (cargo != carryall.Carryable)
-				return true;
-
 			if (IsCanceling)
 			{
 				if (carryall.State == Carryall.CarryallState.Reserved)
 					carryall.UnreserveCarryable(self);
 
-				// Make sure we run the TakeOff activity if we are / have landed
+				// Make sure we run the TakeOff activity if we are/have landed
 				if (self.Trait<Aircraft>().HasInfluence())
 				{
 					ChildHasPriority = true;
@@ -85,10 +82,11 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 			}
 
-			if (cargo.IsDead || carryable.IsTraitDisabled || !cargo.AppearsFriendlyTo(self))
+			if (cargo != carryall.Carryable || cargo.IsDead || carryable.IsTraitDisabled || !cargo.AppearsFriendlyTo(self))
 			{
 				carryall.UnreserveCarryable(self);
-				return true;
+				Cancel(self, true);
+				return false;
 			}
 
 			// Wait until we are near the target before we try to lock it
@@ -100,7 +98,10 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				var lockResponse = carryable.LockForPickup(cargo, self);
 				if (lockResponse == LockResponse.Failed)
-					Cancel(self);
+				{
+					Cancel(self, true);
+					return false;
+				}
 				else if (lockResponse == LockResponse.Success)
 				{
 					// Pickup position and facing are now known - swap the fly/wait activity with Land

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -868,8 +868,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void AddInfluence((CPos, SubCell)[] landingCells)
 		{
 			if (HasInfluence())
-				throw new InvalidOperationException(
-					$"Cannot {nameof(AddInfluence)} until previous influence is removed with {nameof(RemoveInfluence)}");
+				self.World.ActorMap.RemoveInfluence(self, this);
 
 			this.landingCells = landingCells;
 			if (self.IsInWorld)

--- a/OpenRA.Mods.Common/Traits/AutoCarryall.cs
+++ b/OpenRA.Mods.Common/Traits/AutoCarryall.cs
@@ -106,30 +106,33 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			readonly Actor cargo;
 			readonly Carryable carryable;
-			readonly CarryallInfo carryallInfo;
+			readonly Carryall carryall;
 
 			public FerryUnit(Actor self, Actor cargo)
 			{
 				this.cargo = cargo;
 				carryable = cargo.Trait<Carryable>();
-				carryallInfo = self.Trait<Carryall>().Info;
+				carryall = self.Trait<Carryall>();
 			}
 
 			protected override void OnFirstRun(Actor self)
 			{
 				if (!cargo.IsDead)
-					QueueChild(new PickupUnit(self, cargo, 0, carryallInfo.TargetLineColor));
+					QueueChild(new PickupUnit(self, cargo, 0, carryall.Info.TargetLineColor));
 			}
 
 			public override bool Tick(Actor self)
 			{
 				if (cargo.IsDead)
+				{
+					carryall.UnreserveCarryable(self);
 					return true;
+				}
 
-				var dropRange = carryallInfo.DropRange;
+				var dropRange = carryall.Info.DropRange;
 				var destination = carryable.Destination;
 				if (destination != null)
-					self.QueueActivity(true, new DeliverUnit(self, Target.FromCell(self.World, destination.Value), dropRange, carryallInfo.TargetLineColor));
+					self.QueueActivity(true, new DeliverUnit(self, Target.FromCell(self.World, destination.Value), dropRange, carryall.Info.TargetLineColor));
 
 				return true;
 			}

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -256,7 +256,11 @@ namespace OpenRA.Mods.Common.Traits
 		public virtual void UnreserveCarryable(Actor self)
 		{
 			if (Carryable != null && Carryable.IsInWorld && !Carryable.IsDead)
-				Carryable.Trait<Carryable>().UnReserve(Carryable);
+			{
+				var carryable = Carryable.Trait<Carryable>();
+				if (carryable.Carrier == self)
+					carryable.UnReserve(Carryable);
+			}
 
 			Carryable = null;
 			State = CarryallState.Idle;


### PR DESCRIPTION
Fixes an oversight in #20403. #16509 very deliberately kept the `IsCancelling` block distinct from the other "cancel" conditions, so I didn't remove that distinction here either. Also makes Aircraft's `AddInfluence` no longer throw an exception but replace the influence instead, which can lead to bugs but is acceptable over throwing for the prep branch.

~~Closes #20468.~~