### PR TITLE
Fix carryall not removing influence when cargo dies

### DIFF
--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -92,8 +92,7 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			// Wait until we are near the target before we try to lock it
-			var distSq = (cargo.CenterPosition - self.CenterPosition).HorizontalLengthSquared;
-			if (state == PickupState.Intercept && distSq <= targetLockRange.LengthSquared)
+			if (state == PickupState.Intercept && (cargo.CenterPosition - self.CenterPosition).HorizontalLengthSquared <= targetLockRange.LengthSquared)
 				state = PickupState.LockCarryable;
 
 			if (state == PickupState.LockCarryable)

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -160,7 +160,7 @@ namespace OpenRA.Mods.Common.Activities
 			protected override void OnFirstRun(Actor self)
 			{
 				// The cargo might have become invalid while we were moving towards it.
-				if (cargo == null || cargo.IsDead || carryable.IsTraitDisabled || !cargo.AppearsFriendlyTo(self))
+				if (cargo == null || cargo.IsDead || carryable.IsTraitDisabled || carryall.Carryable != cargo || !cargo.AppearsFriendlyTo(self))
 					return;
 
 				self.World.AddFrameEndTask(w =>

--- a/OpenRA.Mods.Common/Traits/AutoCarryall.cs
+++ b/OpenRA.Mods.Common/Traits/AutoCarryall.cs
@@ -106,30 +106,31 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			readonly Actor cargo;
 			readonly Carryable carryable;
-			readonly CarryallInfo carryallInfo;
+			readonly Carryall carryall;
 
 			public FerryUnit(Actor self, Actor cargo)
 			{
 				this.cargo = cargo;
 				carryable = cargo.Trait<Carryable>();
-				carryallInfo = self.Trait<Carryall>().Info;
+				carryall = self.Trait<Carryall>();
 			}
 
 			protected override void OnFirstRun(Actor self)
 			{
 				if (!cargo.IsDead)
-					QueueChild(new PickupUnit(self, cargo, 0, carryallInfo.TargetLineColor));
+					QueueChild(new PickupUnit(self, cargo, 0, carryall.Info.TargetLineColor));
 			}
 
 			public override bool Tick(Actor self)
 			{
-				if (cargo.IsDead)
+				// Cargo may have become invalid or PickupUnit cancelled.
+				if (carryall.Carryable == null || carryall.Carryable.IsDead)
 					return true;
 
-				var dropRange = carryallInfo.DropRange;
+				var dropRange = carryall.Info.DropRange;
 				var destination = carryable.Destination;
 				if (destination != null)
-					self.QueueActivity(true, new DeliverUnit(self, Target.FromCell(self.World, destination.Value), dropRange, carryallInfo.TargetLineColor));
+					self.QueueActivity(true, new DeliverUnit(self, Target.FromCell(self.World, destination.Value), dropRange, carryall.Info.TargetLineColor));
 
 				return true;
 			}

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -142,13 +142,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ITick.Tick(Actor self)
 		{
-			// Cargo may be killed in the same tick as, but after they are attached
-			if (Carryable != null && Carryable.IsDead)
+			// Cargo may be killed in the same tick as, but after they are attached.
+			if (State == CarryallState.Carrying && (Carryable == null || Carryable.IsDead))
 				DetachCarryable(self);
 
 			// HACK: We don't have an efficient way to know when the preview
 			// bounds change, so assume that we need to update the screen map
-			// (only) when the facing changes
+			// (only) when the facing changes.
 			if (facing.Facing != cachedFacing && carryablePreview != null)
 			{
 				self.World.ScreenMap.AddOrUpdate(self);

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -256,7 +256,11 @@ namespace OpenRA.Mods.Common.Traits
 		public virtual void UnreserveCarryable(Actor self)
 		{
 			if (Carryable != null && Carryable.IsInWorld && !Carryable.IsDead)
-				Carryable.Trait<Carryable>().UnReserve(Carryable);
+			{
+				var carryable = Carryable.Trait<Carryable>();
+				if (carryable.Carrier == self)
+					carryable.UnReserve(Carryable);
+			}
 
 			Carryable = null;
 			State = CarryallState.Idle;


### PR DESCRIPTION
Fixes #20468
An oversight from #16509 and then #20403

Here we make sure we properly handle cancelling regardless of where it was called. We cancel all child activities then set `ChildHasPriority` to true and `IsInterruptible` to false so that the `Takeoff` would run regardless of PickupUnit code and condition.