### PR TITLE
Add an option to guarantee actors on sell

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -744,6 +744,7 @@
 		AreaTypes: building
 	SpawnActorsOnSell:
 		ActorTypes: e6,e1,e1,e1
+		GuaranteedActorTypes: e1
 	EngineerRepairable:
 	Demolishable:
 		Condition: being-demolished

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -454,6 +454,7 @@
 		RepairingNotification: Repairing
 	SpawnActorsOnSell:
 		ActorTypes: light_inf
+		GuaranteedActorTypes: light_inf
 	MustBeDestroyed:
 		RequiredForShortGame: true
 	FrozenUnderFog:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -93,7 +93,8 @@ construction_yard:
 	CustomSellValue:
 		Value: 2000
 	SpawnActorsOnSell:
-		ActorTypes: light_inf, light_inf, engineer
+		ActorTypes: light_inf
+		GuaranteedActorTypes: light_inf, engineer
 	BaseBuilding:
 	ProductionBar:
 		ProductionType: Building

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -716,6 +716,7 @@
 	CapturableProgressBlink:
 	SpawnActorsOnSell:
 		ActorTypes: e1,e1,e1,tecn,tecn2
+		GuaranteedActorTypes: e1
 	MustBeDestroyed:
 		RequiredForShortGame: true
 	GpsDot:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1191,7 +1191,8 @@ FACT:
 	Tooltip:
 		Name: Construction Yard
 	SpawnActorsOnSell:
-		ActorTypes: e1,e1,e1,tecn,tecn2,e6
+		ActorTypes: e1,e1,e1,tecn,tecn2
+		GuaranteedActorTypes: e1, e6
 	BaseBuilding:
 	Transforms:
 		RequiresCondition: factundeploy

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -379,9 +379,11 @@
 		UseDeathTypeSuffix: false
 	SpawnActorsOnSell@gdi:
 		ActorTypes: e1, e1, e2, medic
+		GuaranteedActorTypes: e1
 		Factions: gdi
 	SpawnActorsOnSell@nod:
 		ActorTypes: e1, e1, e1, e3, e3
+		GuaranteedActorTypes: e1
 		Factions: nod
 	MustBeDestroyed:
 		RequiredForShortGame: true


### PR DESCRIPTION
Closes #13240

This is a long requested minor feature.

I've taken the liberty and made all structures that use `SpawnActorsOnSell` spawn a riflemen. For RA and D2K construction yards I've also made engineer a guarantee. Wether we want to guarantee more spawns is up for a balance debate