### PR TITLE
HPF handles searches from unreachable source cells into cut off areas.

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -243,6 +243,8 @@ namespace OpenRA
 		public CellRegion AllCells { get; private set; }
 		public List<CPos> AllEdgeCells { get; private set; }
 
+		public event Action<CPos> CellProjectionChanged;
+
 		// Internal data
 		readonly ModData modData;
 		CellLayer<short> cachedTerrainIndexes;
@@ -336,11 +338,12 @@ namespace OpenRA
 			Height = new CellLayer<byte>(Grid.Type, size);
 			Ramp = new CellLayer<byte>(Grid.Type, size);
 			Tiles.Clear(terrainInfo.DefaultTerrainTile);
+
 			if (Grid.MaximumTerrainHeight > 0)
 			{
-				Height.CellEntryChanged += UpdateProjection;
-				Tiles.CellEntryChanged += UpdateProjection;
 				Tiles.CellEntryChanged += UpdateRamp;
+				Tiles.CellEntryChanged += UpdateProjection;
+				Height.CellEntryChanged += UpdateProjection;
 			}
 
 			PostInit();
@@ -530,6 +533,7 @@ namespace OpenRA
 				var inverse = inverseCellProjection[uv];
 				inverse.Clear();
 				inverse.Add(uv);
+				CellProjectionChanged?.Invoke(cell);
 				return;
 			}
 
@@ -567,6 +571,8 @@ namespace OpenRA
 					projectedHeight[temp] = height;
 				}
 			}
+
+			CellProjectionChanged?.Invoke(cell);
 		}
 
 		byte ProjectedCellHeightInner(PPos puv)

--- a/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
+++ b/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
@@ -281,6 +281,10 @@ namespace OpenRA.Mods.Common.Pathfinder
 			// When we build the cost table, it depends on the movement costs of the cells at that time.
 			// When this changes, we must update the cost table.
 			locomotor.CellCostChanged += RequireCostRefreshInCell;
+
+			// If the map projection changes, the result of Map.Contains(CPos) may change.
+			// We need to rebuild grids to account for this possibility.
+			this.world.Map.CellProjectionChanged += RequireProjectionRefreshInCell;
 		}
 
 		public (
@@ -617,6 +621,14 @@ namespace OpenRA.Mods.Common.Pathfinder
 				if (cellsWithBlockingActor.Remove(cell))
 					dirtyGridIndexes.Add(GridIndex(cell));
 			}
+		}
+
+		/// <summary>
+		/// When map projection changes for a cell, marks the grid it belongs to as out of date.
+		/// </summary>
+		void RequireProjectionRefreshInCell(CPos cell)
+		{
+			dirtyGridIndexes.Add(GridIndex(cell));
 		}
 
 		/// <summary>


### PR DESCRIPTION
If a path search is performed by the HierarchicalPathFinder when the source cell is unreachable location, a path is still allowed and starts from one of the cells adjacent to the location. If moving into one of these cells results in the actor moving into an isolated area that cannot reach the target this would previously crash as no abstract path could be found. Now we handle such locations by giving them a unreachable cost so the path search will not attempt to explore them.

Imagine a map split into two by a one tile wide line of impassable cliffs. If an actor is on top of these cliffs it is allowed to path because it can "jump off" the cliff and move into the cell immediately either side of it. However it is important which side it chooses to jump into, as one it has moved off the cliff it loses access to the other side. The previous error came about because the path might try and search on the side that couldn't reach the target location. Now we avoid that being considered.

----
Fixes #20475
Fixes #20508
Fixes #20507
Fixes #20528

Testcase: Applying this diff onto the repo from the bug and running the replay no longer crashes, and the replay ends cleanly instead.

Request applying to stable as this is a bugfix for the new pathfinding.

----

Second fix added for 20528, can be confirmed by running the replay on that bug with the fix applied.

HPF is aware of map projection changes.

An event is added to Map to indicate when the cell projection is changed. This is important as this can mean Map.Contains(CPos) could now return different results for the cell. The HierarchicalPathFinder is made aware of these changes so it can rebuild any out-of-date information. This fixes prevent a crash if a cell that was previously outside the map changes height and becomes inside the map. The local path search will explore the cell as it is inside the map - but if the HPF was unaware if had been updated, it will still consider the cell to be outside the map and unreachable, resulting in a crash.