### PR TITLE
Define and measure duration for text notifications in milliseconds

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/TimeLimitManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/TimeLimitManager.cs
@@ -125,7 +125,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (countdownLabel != null)
 			{
 				countdown = new CachedTransform<int, string>(t =>
-					info.CountdownText.F(WidgetUtils.FormatTime(t, true, w.Timestep)));
+					info.CountdownText.F(WidgetUtils.FormatTime(t, w.Timestep)));
 				countdownLabel.GetText = () => TimeLimit > 0 ? countdown.Update(ticksRemaining) : "";
 			}
 		}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20221203/TextNotificationsDisplayWidgetRemoveTime.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20221203/TextNotificationsDisplayWidgetRemoveTime.cs
@@ -1,0 +1,39 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2022 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class TextNotificationsDisplayWidgetRemoveTime : UpdateRule
+	{
+		public override string Name => "Change name and unit of RemoveTime field of TextNotificationsDisplayWidget.";
+
+		public override string Description =>
+			"Change the field name from RemoveTime to DisplayDurationMs and convert the value from ticks to milliseconds";
+
+		public override IEnumerable<string> UpdateChromeNode(ModData modData, MiniYamlNode chromeNode)
+		{
+			if (!chromeNode.KeyMatches("TextNotificationsDisplay"))
+				yield break;
+
+			foreach (var field in chromeNode.ChildrenMatching("RemoveTime"))
+			{
+				field.RenameKey("DisplayDurationMs");
+
+				var durationMilliseconds = field.NodeValue<int>() * 40;
+				field.ReplaceValue(FieldSaver.FormatValue(durationMilliseconds));
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -72,9 +72,8 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveLaysTerrain(),
 			}),
 
-			new UpdatePath("release-20210321", new UpdateRule[]
+			new UpdatePath("release-20210321", "playtest-20221203", new UpdateRule[]
 			{
-				// Bleed only changes here
 				new RenameMPTraits(),
 				new RemovePlayerHighlightPalette(),
 				new ReplaceWithColoredOverlayPalette(),
@@ -97,6 +96,11 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new UnhardcodeBaseBuilderBotModule(),
 				new UnhardcodeVeteranProductionIconOverlay(),
 				new RenameContrailProperties(),
+			}),
+
+			new UpdatePath("playtest-20221203", new UpdateRule[]
+			{
+				new TextNotificationsDisplayWidgetRemoveTime(),
 			})
 		};
 

--- a/OpenRA.Mods.Common/Widgets/TextNotificationsDisplayWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TextNotificationsDisplayWidget.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Widgets
 {
 	public class TextNotificationsDisplayWidget : Widget
 	{
-		public readonly int RemoveTime = 0;
+		public readonly int DisplayDurationMs = 0;
 		public readonly int ItemSpacing = 4;
 		public readonly int BottomSpacing = 0;
 		public readonly int LogLength = 8;
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public string TransientsTemplate = "TRANSIENT_LINE_TEMPLATE";
 		readonly Dictionary<TextNotificationPool, Widget> templates = new Dictionary<TextNotificationPool, Widget>();
 
-		readonly List<int> expirations = new List<int>();
+		readonly List<long> expirations = new List<long>();
 
 		Rectangle overflowDrawBounds = Rectangle.Empty;
 		public override Rectangle EventBounds => Rectangle.Empty;
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 
 			AddChild(notificationWidget);
-			expirations.Add(Game.LocalTick + RemoveTime);
+			expirations.Add(Game.RunTime + DisplayDurationMs);
 
 			while (Children.Count > LogLength)
 				RemoveNotification();
@@ -127,11 +127,11 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override void Tick()
 		{
-			if (RemoveTime == 0)
+			if (DisplayDurationMs == 0)
 				return;
 
 			// This takes advantage of the fact that recentLines is ordered by expiration, from sooner to later
-			while (Children.Count > 0 && Game.LocalTick >= expirations[0])
+			while (Children.Count > 0 && Game.RunTime >= expirations[0])
 				RemoveNotification();
 		}
 	}

--- a/mods/cnc/chrome/ingame-chat.yaml
+++ b/mods/cnc/chrome/ingame-chat.yaml
@@ -19,7 +19,7 @@ Container@CHAT_PANEL:
 				TextNotificationsDisplay@CHAT_DISPLAY:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM
-					RemoveTime: 250
+					DisplayDurationMs: 10000
 					BottomSpacing: 3
 		Container@CHAT_CHROME:
 			Width: PARENT_RIGHT

--- a/mods/common/chrome/ingame-chat.yaml
+++ b/mods/common/chrome/ingame-chat.yaml
@@ -19,7 +19,7 @@ Container@CHAT_PANEL:
 				TextNotificationsDisplay@CHAT_DISPLAY:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM
-					RemoveTime: 250
+					DisplayDurationMs: 10000
 					BottomSpacing: 3
 		Container@CHAT_CHROME:
 			Width: PARENT_RIGHT

--- a/mods/common/chrome/ingame-transients.yaml
+++ b/mods/common/chrome/ingame-transients.yaml
@@ -8,6 +8,6 @@ Container@TRANSIENTS_PANEL:
 		TextNotificationsDisplay@TRANSIENTS_DISPLAY:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
-			RemoveTime: 100
+			DisplayDurationMs: 4000
 			LogLength: 5
 			HideOverflow: False

--- a/mods/ts/chrome/ingame-transients.yaml
+++ b/mods/ts/chrome/ingame-transients.yaml
@@ -8,6 +8,6 @@ Container@TRANSIENTS_PANEL:
 		TextNotificationsDisplay@TRANSIENTS_DISPLAY:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
-			RemoveTime: 100
+			DisplayDurationMs: 4000
 			LogLength: 5
 			HideOverflow: False


### PR DESCRIPTION
Notification duration should be the same regardless of game speed. Switch to using wall-clock time defined in milliseconds instead of game ticks. Also use the opportunity to rename the field to "Duration" because "RemoveTime" is not so clear.

Closes #20501 