### PR TITLE
Fixed missing libfuse2 in Ubuntu 22.04 for AppImage creation

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Package AppImages
         run: |
           mkdir -p build/linux
+          sudo apt install libfuse2
           ./packaging/linux/buildpackage.sh "${GIT_TAG}" "${PWD}/build/linux"
 
       - name: Upload Packages


### PR DESCRIPTION
Followup to https://github.com/OpenRA/OpenRA/pull/20360.