### PR TITLE
Fix carryables vanishing when another unit is picked up

### DIFF
--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override bool Tick(Actor self)
 		{
-			if (IsCanceling)
+			if (IsCanceling || cargo != carryall.Carryable)
 			{
 				if (carryall.State == Carryall.CarryallState.Reserved)
 					carryall.UnreserveCarryable(self);
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 			}
 
-			if (cargo != carryall.Carryable || cargo.IsDead || carryable.IsTraitDisabled || !cargo.AppearsFriendlyTo(self))
+			if (cargo.IsDead || carryable.IsTraitDisabled || !cargo.AppearsFriendlyTo(self))
 			{
 				carryall.UnreserveCarryable(self);
 				Cancel(self, true);


### PR DESCRIPTION
Closes #20504.

We can't unconditionally call `carryall.UnreserveCarryable(self);` when the cargo changes. The cargo will not change while the pickup activity is running unless the activity is cancelling already, so we can move the check onto that same level. (We just can't have the check before the `IsCanceling` check which was the original bug.)