### PR TITLE
Fix ProximityExternalCondition ignoring the owner change event

### DIFF
--- a/OpenRA.Mods.Common/Traits/Conditions/ExternalCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ExternalCondition.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new ExternalCondition(this); }
 	}
 
-	public class ExternalCondition : ITick, INotifyCreated
+	public class ExternalCondition : ITick, INotifyCreated, INotifyOwnerChanged
 	{
 		readonly struct TimedToken
 		{
@@ -221,6 +221,12 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		bool Notifies(IConditionTimerWatcher watcher) { return watcher.Condition == Info.Condition; }
+
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		{
+			foreach (var pair in self.World.ActorsWithTrait<INotifyProximityOwnerChanged>())
+				pair.Trait.OnProximityOwnerChanged(self, oldOwner, newOwner);
+		}
 
 		void INotifyCreated.Created(Actor self)
 		{

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -177,6 +177,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	[RequireExplicitImplementation]
 	public interface INotifyCapture { void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner, BitSet<CaptureType> captureTypes); }
+	public interface INotifyProximityOwnerChanged { void OnProximityOwnerChanged(Actor actor, Player oldOwner, Player newOwner); }
 	public interface INotifyDiscovered { void OnDiscovered(Actor self, Player discoverer, bool playNotification); }
 	public interface IRenderActorPreviewInfo : ITraitInfoInterface { IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init); }
 	public interface ICruiseAltitudeInfo : ITraitInfoInterface { WDist GetCruiseAltitude(); }


### PR DESCRIPTION
Fixes #18891

Implemented in a similar style to `UnitProducedByOther` workaround