### PR TITLE
Fix EjectOnDeath checks

### DIFF
--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -107,9 +107,9 @@ namespace OpenRA.Mods.Common.Traits
 		bool takeOffAfterLoad;
 		bool initialised;
 
-		readonly CachedTransform<CPos, IEnumerable<CPos>> currentAdjacentCells;
+		readonly CachedTransform<CPos, CPos[]> currentAdjacentCells;
 
-		public IEnumerable<CPos> CurrentAdjacentCells => currentAdjacentCells.Update(self.Location);
+		public CPos[] CurrentAdjacentCells => currentAdjacentCells.Update(self.Location);
 
 		public IEnumerable<Actor> Passengers => cargo;
 		public int PassengerCount => cargo.Count;
@@ -123,8 +123,8 @@ namespace OpenRA.Mods.Common.Traits
 			self = init.Self;
 			checkTerrainType = info.UnloadTerrainTypes.Count > 0;
 
-			currentAdjacentCells = new CachedTransform<CPos, IEnumerable<CPos>>(loc =>
-				Util.AdjacentCells(self.World, Target.FromActor(self)).Where(c => loc != c));
+			currentAdjacentCells = new CachedTransform<CPos, CPos[]>(loc =>
+				Util.AdjacentCells(self.World, Target.FromActor(self)).Where(c => loc != c).ToArray());
 
 			var runtimeCargoInit = init.GetOrDefault<RuntimeCargoInit>(info);
 			var cargoInit = init.GetOrDefault<CargoInit>(info);

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -241,9 +241,10 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (checkTerrainType)
 			{
-				var terrainType = self.World.Map.GetTerrainInfo(self.Location).Type;
+				if (!self.World.Map.Contains(self.Location))
+					return false;
 
-				if (!Info.UnloadTerrainTypes.Contains(terrainType))
+				if (!Info.UnloadTerrainTypes.Contains(self.World.Map.GetTerrainInfo(self.Location).Type))
 					return false;
 			}
 
@@ -409,6 +410,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyKilled.Killed(Actor self, AttackInfo e)
  		{
+			// IsAtGroundLevel contains Map.Contains(self.Location) check.
 			if (Info.EjectOnDeath && self.IsAtGroundLevel() && (!checkTerrainType || Info.UnloadTerrainTypes.Contains(self.World.Map.GetTerrainInfo(self.Location).Type)))
 			{
 				while (!IsEmpty())

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -425,6 +425,9 @@ namespace OpenRA.Mods.Common.Traits
 							var nbms = passenger.TraitsImplementing<INotifyBlockingMove>();
 							foreach (var nbm in nbms)
 								nbm.OnNotifyBlockingMove(passenger, passenger);
+
+							// For show.
+							passenger.QueueActivity(new Nudge(passenger));
 						}
 						else
 							passenger.Kill(e.Attacker);


### PR DESCRIPTION
Without this PR `EjectOnDeath` flag is almost unusable. Both because of ejected troops overlapping, troops being killed when they shouldn't or because of the desyncs

Fixes #16353
Fixes #17863 by removing `CanUnload` and thus `CurrentAdjacentCells` check from `INotifyKilled.Killed`