### PR TITLE
Fix move orders requiring forcemove when transforming

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
@@ -191,7 +191,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public bool CanTarget(Actor self, in Target target, ref TargetModifiers modifiers, ref string cursor)
 			{
-				if (rejectMove || target.Type != TargetType.Terrain || (mobile.Info.RequiresForceMove && !modifiers.HasModifier(TargetModifiers.ForceMove)))
+				if (rejectMove || target.Type != TargetType.Terrain || (mobile.Info.RequiresForceMove && !modifiers.HasModifier(TargetModifiers.ForceMove) && !(self.CurrentActivity is Transform)))
 					return false;
 
 				var location = self.World.Map.CellContaining(target.CenterPosition);


### PR DESCRIPTION
To give move orders for an MCV you need to hold alt. The way it should act is you should only need alt for the first order, and while it's transforming followup orders not require alt