### PR TITLE
Don't cancel attack move cursor when holding shift

### DIFF
--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -125,9 +125,10 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (mi.Button == expectedButton)
 			{
-				world.CancelInputMode();
-
 				var queued = mi.Modifiers.HasModifier(Modifiers.Shift);
+				if (!queued)
+					world.CancelInputMode();
+
 				var orderName = mi.Modifiers.HasModifier(Modifiers.Ctrl) ? "AssaultMove" : "AttackMove";
 
 				// Cells outside the playable area should be clamped to the edge for consistency with move orders


### PR DESCRIPTION
Closes #16924

This how it works in SC2. While you hold down shift the attack cursor remains