### PR TITLE
Misc mission fixes

### DIFF
--- a/mods/ra/maps/siberian-conflict-3-wasteland/wasteland.lua
+++ b/mods/ra/maps/siberian-conflict-3-wasteland/wasteland.lua
@@ -44,7 +44,7 @@ Tick = function()
 		USSR.MarkCompletedObjective(SovietObj)
 	end
 
-	if USSR.HasNoRequiredUnits() then
+	if USSR.HasNoRequiredUnits() and BadGuy.HasNoRequiredUnits() then
 		Allies.MarkCompletedObjective(DestroyAll)
 	end
 end

--- a/mods/ra/maps/soviet-11a/rules.yaml
+++ b/mods/ra/maps/soviet-11a/rules.yaml
@@ -27,6 +27,9 @@ AFLD:
 	ParatroopersPower@paratroopers:
 		DropItems: E1,E1,E1,E2,E2
 
+HELI:
+	-MustBeDestroyed:
+
 ATEK:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/soviet-11b/rules.yaml
+++ b/mods/ra/maps/soviet-11b/rules.yaml
@@ -27,6 +27,9 @@ AFLD:
 	ParatroopersPower@paratroopers:
 		DropItems: E1,E1,E1,E2,E2
 
+HELI:
+	-MustBeDestroyed:
+
 ATEK:
 	Buildable:
 		Prerequisites: ~disabled


### PR DESCRIPTION
This fixes a couple of issues brought up in Discord with the playtest missions: 

- Siberian Conflict 3 needed both Soviet factions to have `HasNoRequiredUnits`.
- It is possible for a longbow to unnecessarily prolong the mission, as mission Soviets have no anti-air outside of Sam Sites. Removed `MustBeDestroyed` from them.