### PR TITLE
Fix syncreport crash caused by getting LocalClient index from ReplayConnection

### DIFF
--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -104,7 +104,10 @@ namespace OpenRA.Network
 
 		internal void DumpSyncReport(int frame)
 		{
-			var reportName = "syncreport-" + DateTime.UtcNow.ToString("yyyy-MM-ddTHHmmssZ", CultureInfo.InvariantCulture) + "-" + orderManager.LocalClient.Index + ".log";
+			var timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHHmmssZ", CultureInfo.InvariantCulture);
+
+			var reportName = $"syncreport-{timestamp}-{orderManager.LocalClient?.Index}.log";
+
 			Log.AddChannel("sync", reportName);
 
 			var recordedFrames = new List<int>();


### PR DESCRIPTION
Fix syncreport crash caused by getting LocalClient index from ReplayConnection.

Crash reproduction:
1. select any mod with replay
2. change the mcv's HP or anything like that
3. play replay, get a null reference crash