### PR TITLE
Fixed exception about invalid cursors not mentioning the cursor name

### DIFF
--- a/OpenRA.Game/Graphics/CursorSequence.cs
+++ b/OpenRA.Game/Graphics/CursorSequence.cs
@@ -31,7 +31,8 @@ namespace OpenRA.Graphics
 			Palette = palette;
 			Name = name;
 
-			Frames = cache[cursorSrc].Skip(Start).ToArray();
+			var cursorSprites = cache[cursorSrc];
+			Frames = cursorSprites.Skip(Start).ToArray();
 
 			if ((d.ContainsKey("Length") && d["Length"].Value == "*") || (d.ContainsKey("End") && d["End"].Value == "*"))
 				Length = Frames.Length;
@@ -43,6 +44,12 @@ namespace OpenRA.Graphics
 				Length = 1;
 
 			Frames = Frames.Take(Length).ToArray();
+
+			if (Start > cursorSprites.Length)
+				throw new YamlException($"Cursor {name}: {nameof(Start)} is greater than the length of the sprite sequence.");
+
+			if (Length > cursorSprites.Length)
+				throw new YamlException($"Cursor {name}: {nameof(Length)} is greater than the length of the sprite sequence.");
 
 			if (d.ContainsKey("X"))
 			{


### PR DESCRIPTION
It will divide by zero and throw when the sprite definition for the cursor is broken, and then you have to guess what's wrong. The new exception tells you which cursor is wrong, which makes hunting the error easier.

### Test case

```diff
@@ -72,7 +72,7 @@ Cursors:
 		generic-blocked-minimap:
 			Start: 33
 		move:
-			Start: 10
+			Start: 1000
 			Length: 4
 		move-minimap:
 			Start: 29
```
and click the MCV.