### PR TITLE
MapPreview, visual assignment of spawn points to a team.

### DIFF
--- a/OpenRA.Game/Server/ProtocolVersion.cs
+++ b/OpenRA.Game/Server/ProtocolVersion.cs
@@ -77,6 +77,6 @@ namespace OpenRA.Server
 		// The protocol for server and world orders
 		// This applies after the handshake has completed, and is provided to support
 		// alternative server implementations that wish to support multiple versions in parallel
-		public const int Orders = 20;
+		public const int Orders = 21;
 	}
 }

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -174,6 +174,7 @@ namespace OpenRA.Mods.Common.Server
 			{ "team", Team },
 			{ "handicap", Handicap },
 			{ "spawn", Spawn },
+			{ "team_set_spawn_points", TeamSetSpawnPoints },
 			{ "clear_spawn", ClearPlayerSpawn },
 			{ "color", PlayerColor },
 			{ "sync_lobby", SyncLobby }
@@ -955,10 +956,17 @@ namespace OpenRA.Mods.Common.Server
 				if (server.LobbyInfo.Slots[targetClient.Slot].LockTeam)
 					return true;
 
-				if (!Exts.TryParseIntegerInvariant(parts[1], out var team))
+				var team = 0;
+				if (client.SpawnPoint > 0 && server.LobbyInfo.SpawnPointInfos.TryGetValue(client.SpawnPoint, out var si) && si.Team > 0)
+					team = si.Team;
+
+				if (team == 0)
 				{
-					Log.Write("server", "Invalid team: {0}", s);
-					return false;
+					if (!Exts.TryParseIntegerInvariant(parts[1], out team))
+					{
+						Log.Write("server", "Invalid team: {0}", s);
+						return false;
+					}
 				}
 
 				targetClient.Team = team;
@@ -1089,10 +1097,53 @@ namespace OpenRA.Mods.Common.Server
 						server.SendLocalizedMessageTo(conn, SpawnLocked);
 						return true;
 					}
+
+					if (server.LobbyInfo.SpawnPointInfos.TryGetValue(spawnPoint, out var si) && si.Team > 0)
+						targetClient.Team = si.Team;
 				}
 
 				targetClient.SpawnPoint = spawnPoint;
 				server.SyncLobbyClients();
+
+				return true;
+			}
+		}
+
+		static bool TeamSetSpawnPoints(S server, Connection conn, Session.Client client, string s)
+		{
+			lock (server.LobbyInfo)
+			{
+				if (!client.IsAdmin)
+				{
+					server.SendLocalizedMessageTo(conn, AdminLobbyInfo);
+					return true;
+				}
+
+				try
+				{
+					// Format: <team> [<spawnPoint>...]
+					var parts = s.Split(' ');
+					if (Exts.TryParseIntegerInvariant(parts[0], out var team) && team >= 0)
+					{
+						for (var i = 1; i < parts.Length; i++)
+						{
+							if (Exts.TryParseIntegerInvariant(parts[i], out var spawnPoint) && spawnPoint > 0)
+							{
+								server.LobbyInfo.SpawnPointInfos[spawnPoint] = new Session.SpawnPointInfo(spawnPoint, team);
+
+								var targetClient = server.LobbyInfo.Clients.FirstOrDefault(cc => cc.SpawnPoint == spawnPoint);
+								if (targetClient != null)
+									targetClient.Team = team;
+							}
+						}
+					}
+
+					server.SyncLobbyInfo();
+				}
+				catch (Exception)
+				{
+					server.SendLocalizedMessageTo(conn, InvalidLobbyInfo);
+				}
 
 				return true;
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -181,6 +181,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{ "getSpawnOccupants", (Func<Dictionary<int, SpawnOccupant>>)(() => spawnOccupants) },
 				{ "getDisabledSpawnPoints", (Func<HashSet<int>>)(() => orderManager.LobbyInfo.DisabledSpawnPoints) },
 				{ "showUnoccupiedSpawnpoints", true },
+				{ "getSpawnPointInfos", (Func<Dictionary<int, Session.SpawnPointInfo>>)(() => orderManager.LobbyInfo.SpawnPointInfos) },
+				{ "isHost", (Func<bool>)(() => Game.IsHost) }
 			});
 
 			mapContainer.IsVisible = () => panel != PanelType.Servers;
@@ -675,7 +677,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					LobbyUtils.SetupEditableColorWidget(template, slot, client, orderManager, worldRenderer, colorManager);
 					LobbyUtils.SetupEditableFactionWidget(template, slot, client, orderManager, factions);
-					LobbyUtils.SetupEditableTeamWidget(template, slot, client, orderManager, map);
+
+					Session.SpawnPointInfo spawnPointInfo = null;
+					if (client.SpawnPoint > 0)
+						orderManager.LobbyInfo.SpawnPointInfos.TryGetValue(client.SpawnPoint, out spawnPointInfo);
+
+					LobbyUtils.SetupEditableTeamWidget(template, slot, client, spawnPointInfo, orderManager, map);
 					LobbyUtils.SetupEditableHandicapWidget(template, slot, client, orderManager);
 					LobbyUtils.SetupEditableSpawnWidget(template, slot, client, orderManager, map);
 					LobbyUtils.SetupEditableReadyWidget(template, client, orderManager, map, MapIsPlayable);
@@ -692,7 +699,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					if (isHost)
 					{
-						LobbyUtils.SetupEditableTeamWidget(template, slot, client, orderManager, map);
+						Session.SpawnPointInfo spawnPointInfo = null;
+						if (client.SpawnPoint > 0)
+							orderManager.LobbyInfo.SpawnPointInfos.TryGetValue(client.SpawnPoint, out spawnPointInfo);
+
+						LobbyUtils.SetupEditableTeamWidget(template, slot, client, spawnPointInfo, orderManager, map);
 						LobbyUtils.SetupEditableHandicapWidget(template, slot, client, orderManager);
 						LobbyUtils.SetupEditableSpawnWidget(template, slot, client, orderManager, map);
 						LobbyUtils.SetupPlayerActionWidget(template, client, orderManager, worldRenderer,

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -294,7 +294,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				orderManager.IssueOrder(Order.Command($"clear_spawn {selectedSpawn}"));
 		}
 
-		static int DetermineSelectedSpawnPoint(MapPreviewWidget mapPreview, MapPreview preview, MouseInput mi)
+		public static int DetermineSelectedSpawnPoint(MapPreviewWidget mapPreview, MapPreview preview, MouseInput mi)
 		{
 			var spawnSize = ChromeProvider.GetImage("lobby-bits", "spawn-unclaimed").Size.XY;
 			var selectedSpawn = preview.SpawnPoints
@@ -586,11 +586,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			factionFlag.GetImageCollection = () => "flags";
 		}
 
-		public static void SetupEditableTeamWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, MapPreview map)
+		public static void SetupEditableTeamWidget(Widget parent, Session.Slot s, Session.Client c, Session.SpawnPointInfo si, OrderManager orderManager, MapPreview map)
 		{
 			var dropdown = parent.Get<DropDownButtonWidget>("TEAM_DROPDOWN");
 			dropdown.IsVisible = () => true;
-			dropdown.IsDisabled = () => s.LockTeam || orderManager.LocalClient.IsReady;
+			dropdown.IsDisabled = () => s.LockTeam || orderManager.LocalClient.IsReady || (si != null && si.Team > 0);
 			dropdown.OnMouseDown = _ => ShowTeamDropDown(dropdown, c, orderManager, map.PlayerCount);
 			dropdown.GetText = () => (c.Team == 0) ? "-" : c.Team.ToString();
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
@@ -37,15 +37,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference("author")]
 		const string CreatedBy = "created-by";
 
+		readonly List<int> selectedSpawnPoints = new List<int>();
 		readonly int blinkTickLength = 10;
+		readonly Func<bool> isHost;
 		bool installHighlighted;
 		int blinkTick;
+		MapPreviewWidget mapPreviewWidget;
+		readonly OrderManager orderManager;
 
 		[ObjectCreator.UseCtor]
 		internal MapPreviewLogic(Widget widget, ModData modData, OrderManager orderManager, Func<(MapPreview Map, Session.MapStatus Status)> getMap,
 			Action<MapPreviewWidget, MapPreview, MouseInput> onMouseDown, Func<Dictionary<int, SpawnOccupant>> getSpawnOccupants,
-			Func<HashSet<int>> getDisabledSpawnPoints, bool showUnoccupiedSpawnpoints)
+			Func<HashSet<int>> getDisabledSpawnPoints, bool showUnoccupiedSpawnpoints, Func<Dictionary<int, Session.SpawnPointInfo>> getSpawnPointInfos, Func<bool> isHost)
 		{
+			this.orderManager = orderManager;
+			this.isHost = isHost;
+
 			var mapRepository = modData.Manifest.Get<WebServices>().MapRepository;
 
 			var available = widget.GetOrNull("MAP_AVAILABLE");
@@ -58,7 +65,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return map.Status == MapStatus.Available && isPlayable;
 				};
 
-				SetupWidgets(available, modData, getMap, onMouseDown, getSpawnOccupants, getDisabledSpawnPoints, showUnoccupiedSpawnpoints);
+				SetupWidgets(available, modData, getMap, onMouseDown, getSpawnOccupants, getDisabledSpawnPoints, showUnoccupiedSpawnpoints, getSpawnPointInfos);
 			}
 
 			var invalid = widget.GetOrNull("MAP_INVALID");
@@ -70,7 +77,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return map.Status == MapStatus.Available && (serverStatus & Session.MapStatus.Incompatible) != 0;
 				};
 
-				SetupWidgets(invalid, modData, getMap, onMouseDown, getSpawnOccupants, getDisabledSpawnPoints, showUnoccupiedSpawnpoints);
+				SetupWidgets(invalid, modData, getMap, onMouseDown, getSpawnOccupants, getDisabledSpawnPoints, showUnoccupiedSpawnpoints, getSpawnPointInfos);
 			}
 
 			var validating = widget.GetOrNull("MAP_VALIDATING");
@@ -82,7 +89,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return map.Status == MapStatus.Available && (serverStatus & Session.MapStatus.Validating) != 0;
 				};
 
-				SetupWidgets(validating, modData, getMap, onMouseDown, getSpawnOccupants, getDisabledSpawnPoints, showUnoccupiedSpawnpoints);
+				SetupWidgets(validating, modData, getMap, onMouseDown, getSpawnOccupants, getDisabledSpawnPoints, showUnoccupiedSpawnpoints, getSpawnPointInfos);
 			}
 
 			var download = widget.GetOrNull("MAP_DOWNLOADABLE");
@@ -90,7 +97,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				download.IsVisible = () => getMap().Map.Status == MapStatus.DownloadAvailable;
 
-				SetupWidgets(download, modData, getMap, onMouseDown, getSpawnOccupants, getDisabledSpawnPoints, showUnoccupiedSpawnpoints);
+				SetupWidgets(download, modData, getMap, onMouseDown, getSpawnOccupants, getDisabledSpawnPoints, showUnoccupiedSpawnpoints, getSpawnPointInfos);
 
 				var install = download.GetOrNull<ButtonWidget>("MAP_INSTALL");
 				if (install != null)
@@ -117,7 +124,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return map.Status != MapStatus.Available && map.Status != MapStatus.DownloadAvailable;
 				};
 
-				SetupWidgets(progress, modData, getMap, onMouseDown, getSpawnOccupants, getDisabledSpawnPoints, showUnoccupiedSpawnpoints);
+				SetupWidgets(progress, modData, getMap, onMouseDown, getSpawnOccupants, getDisabledSpawnPoints, showUnoccupiedSpawnpoints, getSpawnPointInfos);
 
 				var statusSearching = progress.GetOrNull("MAP_STATUS_SEARCHING");
 				if (statusSearching != null)
@@ -209,21 +216,124 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				installHighlighted ^= true;
 				blinkTick = 0;
 			}
+
+			// Ensure the previous host is not stuck in team view.
+			if (mapPreviewWidget?.View == MapPreviewWidget.ViewMode.Team && !isHost())
+				mapPreviewWidget.View = MapPreviewWidget.ViewMode.SpawnPoint;
 		}
 
-		static void SetupWidgets(Widget parent, ModData modData,
+		void SetupWidgets(Widget parent, ModData modData,
 			Func<(MapPreview Map, Session.MapStatus Status)> getMap,
 			Action<MapPreviewWidget, MapPreview, MouseInput> onMouseDown,
 			Func<Dictionary<int, SpawnOccupant>> getSpawnOccupants,
 			Func<HashSet<int>> getDisabledSpawnPoints,
-			bool showUnoccupiedSpawnpoints)
+			bool showUnoccupiedSpawnpoints,
+			Func<Dictionary<int, Session.SpawnPointInfo>> getSpawnPointInfos)
 		{
-			var preview = parent.Get<MapPreviewWidget>("MAP_PREVIEW");
+			mapPreviewWidget = parent.Get<MapPreviewWidget>("MAP_PREVIEW");
+			var preview = mapPreviewWidget;
 			preview.Preview = () => getMap().Map;
-			preview.OnMouseDown = mi => onMouseDown(preview, getMap().Map, mi);
+			preview.OnMouseDown = mi =>
+			{
+				if (preview.View == MapPreviewWidget.ViewMode.Team && isHost())
+				{
+					if (mi.Event == MouseInputEvent.Down)
+					{
+						var spawnPoint = LobbyUtils.DetermineSelectedSpawnPoint(preview, getMap().Map, mi);
+						if (spawnPoint > 0)
+						{
+							if (mi.Modifiers.HasFlag(Modifiers.Shift))
+							{
+								var wasSelected = selectedSpawnPoints.Remove(spawnPoint);
+								if (!wasSelected)
+									selectedSpawnPoints.Add(spawnPoint);
+							}
+							else
+							{
+								selectedSpawnPoints.Clear();
+								selectedSpawnPoints.Add(spawnPoint);
+							}
+						}
+						else if (!mi.Modifiers.HasFlag(Modifiers.Shift))
+							selectedSpawnPoints.Clear();
+					}
+				}
+				else
+					onMouseDown(preview, getMap().Map, mi);
+			};
+
+			preview.OnKeyDown = e =>
+			{
+				if (!isHost())
+					return false;
+
+				if (e.Event != KeyInputEvent.Up)
+					return false;
+
+				if (e.Key == Keycode.TAB)
+				{
+					preview.View = preview.View == MapPreviewWidget.ViewMode.SpawnPoint ? MapPreviewWidget.ViewMode.Team : MapPreviewWidget.ViewMode.SpawnPoint;
+					if (preview.View != MapPreviewWidget.ViewMode.Team)
+						selectedSpawnPoints.Clear();
+
+					return true;
+				}
+
+				if (selectedSpawnPoints.Count > 0)
+				{
+					var team = 0;
+					var numberKey = true;
+					switch (e.Key)
+					{
+					case Keycode.NUMBER_1:
+						team = 1;
+						break;
+					case Keycode.NUMBER_2:
+						team = 2;
+						break;
+					case Keycode.NUMBER_3:
+						team = 3;
+						break;
+					case Keycode.NUMBER_4:
+						team = 4;
+						break;
+					case Keycode.NUMBER_5:
+						team = 5;
+						break;
+					case Keycode.NUMBER_6:
+						team = 6;
+						break;
+					case Keycode.NUMBER_7:
+						team = 7;
+						break;
+					case Keycode.NUMBER_8:
+						team = 8;
+						break;
+					case Keycode.NUMBER_9:
+						team = 9;
+						break;
+					case Keycode.NUMBER_0:
+						break;
+					default:
+						numberKey = false;
+						break;
+					}
+
+					if (numberKey)
+					{
+						var strSpawnPoints = string.Join(" ", selectedSpawnPoints.ToArray());
+						Game.RunAfterTick(() => orderManager.IssueOrder(Order.Command($"team_set_spawn_points {team} {strSpawnPoints}")));
+					}
+				}
+
+				return false;
+			};
+
 			preview.SpawnOccupants = getSpawnOccupants;
 			preview.DisabledSpawnPoints = getDisabledSpawnPoints;
 			preview.ShowUnoccupiedSpawnpoints = showUnoccupiedSpawnpoints;
+			preview.SpawnPointInfos = getSpawnPointInfos;
+			preview.SelectedSpawnPoints = () => selectedSpawnPoints;
 
 			var titleLabel = parent.GetOrNull<LabelWithTooltipWidget>("MAP_TITLE");
 			if (titleLabel != null)


### PR DESCRIPTION

Admin can use Tab button to switch between default and team assignment mode.

When in team assignment mode the admin can
- Click to select a spawn point
- Shift click to select multiple spawn points
- Click without shift - to deselect 
- Hit 1-9 to assign a team number with a spawn point
- Hit 0 to clean team assignment - to a spawn point
- Hit Tab to go back to default mode.

Assigning a team a spawn points has the impact that:
- If a player slow was already assigned to the spawn point - the team of the player will be changed
- If no player is assigned to the slot. No impact. Apart from that the team number is associated with the spawn point.
- The player can not longer select a team him/herself. The team pull down is disabled.

Implementation details:
- Adds SpawnPointInfo as Session/LobbyInfo object.
- Protocol version upgraded.
- SpawnPointInfo.Team is a hint. All Lobby commands still work as in the past. Team hint/preference is used when optionally set.
- SpawnPointInfo only set if admin has assigned at least one team.

Why?
- Lots of time wasted on picking teams by players.
- Lots of time wasted by restarting games because one person selected the wrong team.
- Visually team selection is easier/faster. I.e. useful with 8+ players, where you loose track.

How does it work?
- Admin either during start or end of lobby sessions assigns teams - overriding whatever anyone picked.

Future possible improvements (not this pull request, perhaps someone else could help make it look nice):
- Feedback to admin about the two modes.
- Visual feedback which mode is active.
- Some nicer visual for spawn point selection in team assignment mode. 
- Rectangular selection of multiple spawn points.



