### PR TITLE
Fix the actor edit panel not always getting closed properly

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -377,11 +377,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				actorEditPanel.Bounds.X = origin.X + editPanelPadding;
 				actorEditPanel.Bounds.Y = origin.Y;
 			}
-			else
+			else if (CurrentActor != null)
 			{
 				// Selected actor is null, hide the border and edit panel.
-				actorIDField.YieldKeyboardFocus();
-				CurrentActor = null;
+				Close();
 			}
 		}
 


### PR DESCRIPTION
Follow-up to #20513. Testcase: Open the actor edit panel, then enter a value into one of its fields, but not not press escape or enter. Do not click "Ok" or "Cancel" either but just click outside of the panel which will make it disappear. On bleed the input fields still retain focus (e.g. you need to press escape or enter first before being able to use other hotkeys).