### PR TITLE
Fix pseudo-fullscreen window size on macs with a notch.

### DIFF
--- a/packaging/macos/Info.plist.in
+++ b/packaging/macos/Info.plist.in
@@ -49,6 +49,6 @@
 	<key>NSRequiresAquaSystemAppearance</key>
 	<false/>
 	<key>NSPrefersDisplaySafeAreaCompatibilityMode</key>
-	<true/>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
Followup to #20484. The `NSPrefersDisplaySafeAreaCompatibilityMode` workaround is a big improvement over losing the command bar off the bottom of the screen, but has two annoying limitations:
* Works by scaling the whole window by ~0.96, losing some horizontal resolution and making the display blurry.
* Does not work when running `launch-game.sh`.

This PR implements a code-based solution that allows us to disable the compatibility mode and avoid these issues.