### PR TITLE
Allow mods to customise the default rendering scale.

### DIFF
--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -227,14 +227,14 @@ namespace OpenRA.Graphics
 
 			var vd = graphicSettings.ViewportDistance;
 			if (viewportSizes.AllowNativeZoom && vd == WorldViewport.Native)
-				minZoom = 1;
+				minZoom = viewportSizes.DefaultScale;
 			else
 			{
 				var range = viewportSizes.GetSizeRange(vd);
-				minZoom = CalculateMinimumZoom(range.X, range.Y);
+				minZoom = CalculateMinimumZoom(range.X, range.Y) * viewportSizes.DefaultScale;
 			}
 
-			maxZoom = Math.Min(minZoom * viewportSizes.MaxZoomScale, Game.Renderer.NativeResolution.Height * 1f / viewportSizes.MaxZoomWindowHeight);
+			maxZoom = Math.Min(minZoom * viewportSizes.MaxZoomScale, Game.Renderer.NativeResolution.Height * viewportSizes.DefaultScale / viewportSizes.MaxZoomWindowHeight);
 
 			if (unlockMinZoom)
 			{

--- a/OpenRA.Game/WorldViewportSizes.cs
+++ b/OpenRA.Game/WorldViewportSizes.cs
@@ -19,6 +19,7 @@ namespace OpenRA
 		public readonly int2 MediumWindowHeights = new int2(600, 900);
 		public readonly int2 FarWindowHeights = new int2(900, 1300);
 
+		public readonly float DefaultScale = 1.0f;
 		public readonly float MaxZoomScale = 2.0f;
 		public readonly int MaxZoomWindowHeight = 240;
 		public readonly bool AllowNativeZoom = true;

--- a/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
@@ -177,10 +177,10 @@ namespace OpenRA.Mods.Common.Traits
 					var sprite = tileCache.TileSprite(tile, 0);
 					var u = gridType == MapGridType.Rectangular ? x : (x - y) / 2f;
 					var v = gridType == MapGridType.Rectangular ? y : (x + y) / 2f;
-					var offset = (new float2(u * ts.Width, (v - 0.5f * tileInfo.Height) * ts.Height) - 0.5f * sprite.Size.XY).ToInt2();
+					var offset = scale * (new float2(u * ts.Width, (v - 0.5f * tileInfo.Height) * ts.Height) - 0.5f * sprite.Size.XY);
 					var palette = template.Palette ?? terrainInfo.Palette;
 
-					yield return new UISpriteRenderable(sprite, WPos.Zero, origin + offset, 0, wr.Palette(palette), scale);
+					yield return new UISpriteRenderable(sprite, WPos.Zero, origin + offset.ToInt2(), 0, wr.Palette(palette), scale);
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
@@ -25,14 +25,16 @@ namespace OpenRA.Mods.Common.Widgets
 		public Func<float> GetScale = () => 1f;
 
 		readonly WorldRenderer worldRenderer;
+		readonly WorldViewportSizes viewportSizes;
 
 		IActorPreview[] preview = Array.Empty<IActorPreview>();
 		public int2 PreviewOffset { get; private set; }
 		public int2 IdealPreviewSize { get; private set; }
 
 		[ObjectCreator.UseCtor]
-		public ActorPreviewWidget(WorldRenderer worldRenderer)
+		public ActorPreviewWidget(ModData modData, WorldRenderer worldRenderer)
 		{
+			viewportSizes = modData.Manifest.Get<WorldViewportSizes>();
 			this.worldRenderer = worldRenderer;
 		}
 
@@ -41,6 +43,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			preview = other.preview;
 			worldRenderer = other.worldRenderer;
+			viewportSizes = other.viewportSizes;
 		}
 
 		public override Widget Clone() { return new ActorPreviewWidget(this); }
@@ -55,14 +58,14 @@ namespace OpenRA.Mods.Common.Widgets
 			// Calculate the preview bounds
 			var r = preview.SelectMany(p => p.ScreenBounds(worldRenderer, WPos.Zero));
 			var b = r.Union();
-			IdealPreviewSize = new int2(b.Width, b.Height);
-			PreviewOffset = -new int2(b.Left, b.Top) - IdealPreviewSize / 2;
+			IdealPreviewSize = new int2((int)(b.Width * viewportSizes.DefaultScale), (int)(b.Height * viewportSizes.DefaultScale));
+			PreviewOffset = -new int2((int)(b.Left * viewportSizes.DefaultScale), (int)(b.Top * viewportSizes.DefaultScale)) - IdealPreviewSize / 2;
 		}
 
 		IFinalizedRenderable[] renderables;
 		public override void PrepareRenderables()
 		{
-			var scale = GetScale();
+			var scale = GetScale() * viewportSizes.DefaultScale;
 			var origin = RenderOrigin + PreviewOffset + new int2(RenderBounds.Size.Width / 2, RenderBounds.Size.Height / 2);
 
 			renderables = preview

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
@@ -41,8 +41,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void IntializeLayerPreview()
 		{
 			layerTemplateList.RemoveChildren();
-			var rules = worldRenderer.World.Map.Rules;
-			var tileSize = worldRenderer.World.Map.Grid.TileSize;
 			foreach (var resourceRenderer in worldRenderer.World.WorldActor.TraitsImplementing<IResourceRenderer>())
 			{
 				foreach (var resourceType in resourceRenderer.ResourceTypes)
@@ -55,12 +53,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					newResourcePreviewTemplate.Bounds.Y = 0;
 
 					var layerPreview = newResourcePreviewTemplate.Get<ResourcePreviewWidget>("LAYER_PREVIEW");
+					var size = layerPreview.IdealPreviewSize;
 					layerPreview.IsVisible = () => true;
 					layerPreview.ResourceType = resourceType;
-					layerPreview.Bounds.Width = tileSize.Width;
-					layerPreview.Bounds.Height = tileSize.Height;
-					newResourcePreviewTemplate.Bounds.Width = tileSize.Width + (layerPreview.Bounds.X * 2);
-					newResourcePreviewTemplate.Bounds.Height = tileSize.Height + (layerPreview.Bounds.Y * 2);
+					layerPreview.Bounds.Width = size.Width;
+					layerPreview.Bounds.Height = size.Height;
+					newResourcePreviewTemplate.Bounds.Width = size.Width + (layerPreview.Bounds.X * 2);
+					newResourcePreviewTemplate.Bounds.Height = size.Height + (layerPreview.Bounds.Y * 2);
 					newResourcePreviewTemplate.IsVisible = () => true;
 					newResourcePreviewTemplate.GetTooltipText = () => resourceType;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
@@ -38,7 +38,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 
 		readonly ITemplatedTerrainInfo terrainInfo;
-		readonly ITiledTerrainRenderer terrainRenderer;
 		readonly TileSelectorTemplate[] allTemplates;
 		readonly EditorCursorLayer editorCursor;
 
@@ -49,10 +48,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			terrainInfo = world.Map.Rules.TerrainInfo as ITemplatedTerrainInfo;
 			if (terrainInfo == null)
 				throw new InvalidDataException("TileSelectorLogic requires a template-based tileset.");
-
-			terrainRenderer = world.WorldActor.TraitOrDefault<ITiledTerrainRenderer>();
-			if (terrainRenderer == null)
-				throw new InvalidDataException("TileSelectorLogic requires a tile-based terrain renderer.");
 
 			allTemplates = terrainInfo.Templates.Values.Select(t => new TileSelectorTemplate(t)).ToArray();
 			editorCursor = world.WorldActor.Trait<EditorCursorLayer>();
@@ -115,18 +110,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					() => Editor.SetBrush(new EditorTileBrush(Editor, tileId, WorldRenderer)));
 
 				var preview = item.Get<TerrainTemplatePreviewWidget>("TILE_PREVIEW");
-				var template = terrainInfo.Templates[tileId];
-				var bounds = terrainRenderer.TemplateBounds(template);
+				preview.SetTemplate(terrainInfo.Templates[tileId]);
 
 				// Scale templates to fit within the panel
 				var scale = 1f;
-				while (scale * bounds.Width > ItemTemplate.Bounds.Width)
-					scale /= 2;
+				if (scale * preview.IdealPreviewSize.X > ItemTemplate.Bounds.Width)
+					scale = (ItemTemplate.Bounds.Width - Panel.ItemSpacing) / (float)preview.IdealPreviewSize.X;
 
-				preview.Template = template;
 				preview.GetScale = () => scale;
-				preview.Bounds.Width = (int)(scale * bounds.Width);
-				preview.Bounds.Height = (int)(scale * bounds.Height);
+				preview.Bounds.Width = (int)(scale * preview.IdealPreviewSize.X);
+				preview.Bounds.Height = (int)(scale * preview.IdealPreviewSize.Y);
 
 				item.Bounds.Width = preview.Bounds.Width + 2 * preview.Bounds.X;
 				item.Bounds.Height = preview.Bounds.Height + 2 * preview.Bounds.Y;


### PR DESCRIPTION
This PR implements the last major feature needed to create HiDPI mods where the default zoom level is zoomed out relative to the native sprite size.

Fixes #19744.
Fixes #19512.


Testcase 1: add the following to mod.yaml and notice that the viewport is now larger
```
WorldViewportSizes:
	DefaultScale: 0.5
```

Testcase 2: https://github.com/pchote/TiberianDawnHD/commit/7eed99a155996bc554f4e9b115305259339f87cf