### PR TITLE
Fix MiniYaml source locations being lost when merging.

### DIFF
--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -83,7 +83,7 @@ namespace OpenRA
 
 		public MiniYamlNode Clone()
 		{
-			return new MiniYamlNode(Key, Value.Clone());
+			return new MiniYamlNode(Key, Value.Clone(), Comment, Location);
 		}
 	}
 


### PR DESCRIPTION
Various types of miniyaml errors don't generate proper error messages. It turns out that this was due to a trivial error in `MiniYamlNode.Clone`. This will be useful for modders, so it would be good to take this for prep.

Testcase: change TD's mod.yaml to duplicate one of the TilesetExtensions definitions, e.g.
```miniyaml
SpriteSequenceFormat: ClassicTilesetSpecificSpriteSequence
	TilesetExtensions:
		TEMPERAT: .tem
		TEMPERAT: .tem
		WINTER: .win
		SNOW: .sno
		DESERT: .des
		JUNGLE: .jun
```
and try to run the game.

Before: `System.IO.InvalidDataException: Duplicate key 'TEMPERAT' in :0`

After: `System.IO.InvalidDataException: Duplicate key 'TEMPERAT' in mod.yaml:243`

