### PR TITLE
Let the documentation workflow fetch the required git branch

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -82,19 +82,29 @@ jobs:
         run: |
           make all
 
-      - name: Clone docs.openra.net
+      - name: Clone docs.openra.net (Playtest)
+        if: startsWith(github.event.inputs.tag, 'playtest-')
         uses: actions/checkout@v2
         with:
           repository: openra/docs
           token: ${{ secrets.DOCS_TOKEN }}
           path: docs
+          ref: playtest
+
+      - name: Clone docs.openra.net (Release)
+        if: startsWith(github.event.inputs.tag, 'release-')
+        uses: actions/checkout@v2
+        with:
+          repository: openra/docs
+          token: ${{ secrets.DOCS_TOKEN }}
+          path: docs
+          ref: release
 
       - name: Update docs.openra.net (Playtest)
         if: startsWith(github.event.inputs.tag, 'playtest-')
         env:
           GIT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          git checkout playtest
           ./utility.sh all --docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/traits.md"
           ./utility.sh all --weapon-docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/weapons.md"
           ./utility.sh all --sprite-sequence-docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/sprite-sequences.md"
@@ -105,7 +115,6 @@ jobs:
         env:
           GIT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          git checkout release
           ./utility.sh all --docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/traits.md"
           ./utility.sh all --weapon-docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/weapons.md"
           ./utility.sh all --sprite-sequence-docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/sprite-sequences.md"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -133,9 +133,11 @@ jobs:
       - name: Push docs.openra.net (Release)
         if: startsWith(github.event.inputs.tag, 'release-')
         run: |
+          cd docs
           git push origin release
 
       - name: Push docs.openra.net (Playtest)
         if: startsWith(github.event.inputs.tag, 'playtest-')
         run: |
+          cd docs
           git push origin playtest


### PR DESCRIPTION
We still failed with `error: pathspec 'playtest' did not match any file(s) known to git` (see https://github.com/OpenRA/OpenRA/pull/20506#issuecomment-1338166919). The problem is that the checkout action does not download all branches (and that it downloads it into the `docs` subfolder, which we would need to cd into before being able to check a branch out). Adjusted the checkout to download the branch we require, see https://github.com/actions/checkout#Checkout-a-different-branch. The downloaded branch is automatically checked out, so we don't need to do that in the next step. However, we need to go into the folder of the repository again before pushing.

The workflow works: https://github.com/OpenRA/OpenRA/actions/runs/3768195648 (https://github.com/OpenRA/docs/tree/playtest is updated now.)