### PR TITLE
Overhaul sequence filename definitions 

### DIFF
--- a/OpenRA.Mods.Cnc/Graphics/ClassicSpriteSequence.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ClassicSpriteSequence.cs
@@ -20,9 +20,9 @@ namespace OpenRA.Mods.Cnc.Graphics
 		public ClassicSpriteSequenceLoader(ModData modData)
 			: base(modData) { }
 
-		public override ISpriteSequence CreateSequence(ModData modData, string tileSet, SpriteCache cache, string sequence, string animation, MiniYaml info)
+		public override ISpriteSequence CreateSequence(ModData modData, string tileset, SpriteCache cache, string image, string sequence, MiniYaml data, MiniYaml defaults)
 		{
-			return new ClassicSpriteSequence(modData, tileSet, cache, this, sequence, animation, info);
+			return new ClassicSpriteSequence(modData, tileset, cache, this, image, sequence, data, defaults);
 		}
 	}
 
@@ -33,15 +33,13 @@ namespace OpenRA.Mods.Cnc.Graphics
 		static readonly SpriteSequenceField<bool> UseClassicFacings = new SpriteSequenceField<bool>(nameof(UseClassicFacings), false);
 		readonly bool useClassicFacings;
 
-		public ClassicSpriteSequence(ModData modData, string tileSet, SpriteCache cache, ISpriteSequenceLoader loader, string sequence, string animation, MiniYaml info)
-			: base(modData, tileSet, cache, loader, sequence, animation, info)
+		public ClassicSpriteSequence(ModData modData, string tileSet, SpriteCache cache, ISpriteSequenceLoader loader, string image, string sequence, MiniYaml data, MiniYaml defaults)
+			: base(modData, tileSet, cache, loader, image, sequence, data, defaults)
 		{
-			var d = info.ToDictionary();
-			useClassicFacings = LoadField(d, UseClassicFacings);
+			useClassicFacings = LoadField(UseClassicFacings, data, defaults);
 
 			if (useClassicFacings && facings != 32)
-				throw new InvalidOperationException(
-					$"{info.Nodes[0].Location}: Sequence {sequence}.{animation}: UseClassicFacings is only valid for 32 facings");
+				throw new InvalidOperationException($"Sequence {image}.{sequence}: UseClassicFacings is only valid for 32 facings");
 		}
 
 		protected override int GetFacingFrameOffset(WAngle facing)

--- a/OpenRA.Mods.Cnc/Graphics/ClassicTilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ClassicTilesetSpecificSpriteSequence.cs
@@ -18,23 +18,8 @@ namespace OpenRA.Mods.Cnc.Graphics
 {
 	public class ClassicTilesetSpecificSpriteSequenceLoader : ClassicSpriteSequenceLoader
 	{
-		public readonly string DefaultSpriteExtension = ".shp";
-		public readonly Dictionary<string, string> TilesetExtensions = new Dictionary<string, string>();
-		public readonly Dictionary<string, string> TilesetCodes = new Dictionary<string, string>();
-
 		public ClassicTilesetSpecificSpriteSequenceLoader(ModData modData)
-			: base(modData)
-		{
-			var metadata = modData.Manifest.Get<SpriteSequenceFormat>().Metadata;
-			if (metadata.TryGetValue("DefaultSpriteExtension", out var yaml))
-				DefaultSpriteExtension = yaml.Value;
-
-			if (metadata.TryGetValue("TilesetExtensions", out yaml))
-				TilesetExtensions = yaml.ToDictionary(kv => kv.Value);
-
-			if (metadata.TryGetValue("TilesetCodes", out yaml))
-				TilesetCodes = yaml.ToDictionary(kv => kv.Value);
-		}
+			: base(modData) { }
 
 		public override ISpriteSequence CreateSequence(ModData modData, string tileset, SpriteCache cache, string image, string sequence, MiniYaml data, MiniYaml defaults)
 		{
@@ -46,49 +31,23 @@ namespace OpenRA.Mods.Cnc.Graphics
 	      "that come with first-generation Westwood titles.")]
 	public class ClassicTilesetSpecificSpriteSequence : ClassicSpriteSequence
 	{
-		[Desc("Dictionary of <string: string> with tileset name to override -> tileset name to use instead.")]
-		static readonly SpriteSequenceField<Dictionary<string, string>> TilesetOverrides = new SpriteSequenceField<Dictionary<string, string>>(nameof(TilesetOverrides), null);
-
-		[Desc("Use `TilesetCodes` as defined in `mod.yaml` to add a letter as a second character " +
-			"into the sprite filename like the Westwood 2.5D titles did for tileset-specific variants.")]
-		static readonly SpriteSequenceField<bool> UseTilesetCode = new SpriteSequenceField<bool>(nameof(UseTilesetCode), false);
-
-		[Desc("Append a tileset-specific extension to the file name " +
-			"- either as defined in `mod.yaml`'s `TilesetExtensions` (if `UseTilesetExtension` is used) " +
-			"or the default hardcoded one for this sequence type (.shp).")]
-		static readonly SpriteSequenceField<bool> AddExtension = new SpriteSequenceField<bool>(nameof(AddExtension), true);
-
-		[Desc("Whether `mod.yaml`'s `TilesetExtensions` should be used with the sequence's file name.")]
-		static readonly SpriteSequenceField<bool> UseTilesetExtension = new SpriteSequenceField<bool>(nameof(UseTilesetExtension), false);
+		[Desc("Dictionary of <tileset name>: filename to override the Filename key.")]
+		static readonly SpriteSequenceField<Dictionary<string, string>> TilesetFilenames = new SpriteSequenceField<Dictionary<string, string>>(nameof(TilesetFilenames), null);
 
 		public ClassicTilesetSpecificSpriteSequence(ModData modData, string tileset, SpriteCache cache, ISpriteSequenceLoader loader, string image, string sequence, MiniYaml data, MiniYaml defaults)
 			: base(modData, tileset, cache, loader, image, sequence, data, defaults) { }
 
-		static string ResolveTilesetId(string tileset, MiniYaml data, MiniYaml defaults)
-		{
-			var node = data.Nodes.FirstOrDefault(n => n.Key == TilesetOverrides.Key) ?? defaults.Nodes.FirstOrDefault(n => n.Key == TilesetOverrides.Key);
-			var overrideNode = node?.Value.Nodes.FirstOrDefault(n => n.Key == tileset);
-			return overrideNode?.Value.Value ?? tileset;
-		}
-
 		protected override string GetSpriteFilename(ModData modData, string tileset, string image, string sequence, MiniYaml data, MiniYaml defaults)
 		{
-			var loader = (ClassicTilesetSpecificSpriteSequenceLoader)Loader;
-			var filename = data.Value ?? defaults.Value ?? image;
-			if (LoadField(UseTilesetCode, data, defaults))
-				if (loader.TilesetCodes.TryGetValue(ResolveTilesetId(tileset, data, defaults), out var tilesetCode))
-					filename = filename.Substring(0, 1) + tilesetCode + filename.Substring(2, filename.Length - 2);
-
-			if (LoadField(AddExtension, data, defaults))
+			var node = data.Nodes.FirstOrDefault(n => n.Key == TilesetFilenames.Key) ?? defaults.Nodes.FirstOrDefault(n => n.Key == TilesetFilenames.Key);
+			if (node != null)
 			{
-				if (LoadField(UseTilesetExtension, data, defaults))
-					if (loader.TilesetExtensions.TryGetValue(ResolveTilesetId(tileset, data, defaults), out var tilesetExtension))
-						return filename + tilesetExtension;
-
-				return filename + loader.DefaultSpriteExtension;
+				var tilesetNode = node.Value.Nodes.FirstOrDefault(n => n.Key == tileset);
+				if (tilesetNode != null)
+					return tilesetNode.Value.Value;
 			}
 
-			return filename;
+			return base.GetSpriteFilename(modData, tileset, image, sequence, data, defaults);
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Graphics/ClassicTilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ClassicTilesetSpecificSpriteSequence.cs
@@ -36,9 +36,9 @@ namespace OpenRA.Mods.Cnc.Graphics
 				TilesetCodes = yaml.ToDictionary(kv => kv.Value);
 		}
 
-		public override ISpriteSequence CreateSequence(ModData modData, string tileSet, SpriteCache cache, string sequence, string animation, MiniYaml info)
+		public override ISpriteSequence CreateSequence(ModData modData, string tileset, SpriteCache cache, string image, string sequence, MiniYaml data, MiniYaml defaults)
 		{
-			return new ClassicTilesetSpecificSpriteSequence(modData, tileSet, cache, this, sequence, animation, info);
+			return new ClassicTilesetSpecificSpriteSequence(modData, tileset, cache, this, image, sequence, data, defaults);
 		}
 	}
 
@@ -61,42 +61,34 @@ namespace OpenRA.Mods.Cnc.Graphics
 		[Desc("Whether `mod.yaml`'s `TilesetExtensions` should be used with the sequence's file name.")]
 		static readonly SpriteSequenceField<bool> UseTilesetExtension = new SpriteSequenceField<bool>(nameof(UseTilesetExtension), false);
 
-		public ClassicTilesetSpecificSpriteSequence(ModData modData, string tileSet, SpriteCache cache, ISpriteSequenceLoader loader, string sequence, string animation, MiniYaml info)
-			: base(modData, tileSet, cache, loader, sequence, animation, info) { }
+		public ClassicTilesetSpecificSpriteSequence(ModData modData, string tileset, SpriteCache cache, ISpriteSequenceLoader loader, string image, string sequence, MiniYaml data, MiniYaml defaults)
+			: base(modData, tileset, cache, loader, image, sequence, data, defaults) { }
 
-		static string ResolveTilesetId(string tileSet, Dictionary<string, MiniYaml> d)
+		static string ResolveTilesetId(string tileset, MiniYaml data, MiniYaml defaults)
 		{
-			if (d.TryGetValue(nameof(TilesetOverrides), out var yaml))
-			{
-				var tsNode = yaml.Nodes.FirstOrDefault(n => n.Key == tileSet);
-				if (tsNode != null)
-					tileSet = tsNode.Value.Value;
-			}
-
-			return tileSet;
+			var node = data.Nodes.FirstOrDefault(n => n.Key == TilesetOverrides.Key) ?? defaults.Nodes.FirstOrDefault(n => n.Key == TilesetOverrides.Key);
+			var overrideNode = node?.Value.Nodes.FirstOrDefault(n => n.Key == tileset);
+			return overrideNode?.Value.Value ?? tileset;
 		}
 
-		protected override string GetSpriteSrc(ModData modData, string tileSet, string sequence, string animation, string sprite, Dictionary<string, MiniYaml> d)
+		protected override string GetSpriteFilename(ModData modData, string tileset, string image, string sequence, MiniYaml data, MiniYaml defaults)
 		{
 			var loader = (ClassicTilesetSpecificSpriteSequenceLoader)Loader;
+			var filename = data.Value ?? defaults.Value ?? image;
+			if (LoadField(UseTilesetCode, data, defaults))
+				if (loader.TilesetCodes.TryGetValue(ResolveTilesetId(tileset, data, defaults), out var tilesetCode))
+					filename = filename.Substring(0, 1) + tilesetCode + filename.Substring(2, filename.Length - 2);
 
-			var spriteName = sprite ?? sequence;
-
-			if (LoadField(d, UseTilesetCode))
+			if (LoadField(AddExtension, data, defaults))
 			{
-				if (loader.TilesetCodes.TryGetValue(ResolveTilesetId(tileSet, d), out var code))
-					spriteName = spriteName.Substring(0, 1) + code + spriteName.Substring(2, spriteName.Length - 2);
+				if (LoadField(UseTilesetExtension, data, defaults))
+					if (loader.TilesetExtensions.TryGetValue(ResolveTilesetId(tileset, data, defaults), out var tilesetExtension))
+						return filename + tilesetExtension;
+
+				return filename + loader.DefaultSpriteExtension;
 			}
 
-			if (LoadField(d, AddExtension))
-			{
-				if (LoadField(d, UseTilesetExtension) && loader.TilesetExtensions.TryGetValue(ResolveTilesetId(tileSet, d), out var tilesetExtension))
-					return spriteName + tilesetExtension;
-
-				return spriteName + loader.DefaultSpriteExtension;
-			}
-
-			return spriteName;
+			return filename;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
@@ -17,23 +17,8 @@ namespace OpenRA.Mods.Common.Graphics
 {
 	public class TilesetSpecificSpriteSequenceLoader : DefaultSpriteSequenceLoader
 	{
-		public readonly string DefaultSpriteExtension = ".shp";
-		public readonly Dictionary<string, string> TilesetExtensions = new Dictionary<string, string>();
-		public readonly Dictionary<string, string> TilesetCodes = new Dictionary<string, string>();
-
 		public TilesetSpecificSpriteSequenceLoader(ModData modData)
-			: base(modData)
-		{
-			var metadata = modData.Manifest.Get<SpriteSequenceFormat>().Metadata;
-			if (metadata.TryGetValue("DefaultSpriteExtension", out var yaml))
-				DefaultSpriteExtension = yaml.Value;
-
-			if (metadata.TryGetValue("TilesetExtensions", out yaml))
-				TilesetExtensions = yaml.ToDictionary(kv => kv.Value);
-
-			if (metadata.TryGetValue("TilesetCodes", out yaml))
-				TilesetCodes = yaml.ToDictionary(kv => kv.Value);
-		}
+			: base(modData) { }
 
 		public override ISpriteSequence CreateSequence(ModData modData, string tileSet, SpriteCache cache, string image, string sequence, MiniYaml data, MiniYaml defaults)
 		{
@@ -44,50 +29,23 @@ namespace OpenRA.Mods.Common.Graphics
 	[Desc("A sprite sequence that can have tileset-specific variants.")]
 	public class TilesetSpecificSpriteSequence : DefaultSpriteSequence
 	{
-		[Desc("Dictionary of <string: string> with tileset name to override -> tileset name to use instead.")]
-		static readonly SpriteSequenceField<Dictionary<string, string>> TilesetOverrides = new SpriteSequenceField<Dictionary<string, string>>(nameof(TilesetOverrides), null);
-
-		[Desc("Use `TilesetCodes` as defined in `mod.yaml` to add a letter as a second character " +
-			"into the sprite filename like the Westwood 2.5D titles did for tileset-specific variants.")]
-		static readonly SpriteSequenceField<bool> UseTilesetCode = new SpriteSequenceField<bool>(nameof(UseTilesetCode), false);
-
-		[Desc("Append a tileset-specific extension to the file name " +
-			"- either as defined in `mod.yaml`'s `TilesetExtensions` (if `UseTilesetExtension` is used) " +
-			"or the default hardcoded one for this sequence type (.shp).")]
-		static readonly SpriteSequenceField<bool> AddExtension = new SpriteSequenceField<bool>(nameof(AddExtension), true);
-
-		[Desc("Whether `mod.yaml`'s `TilesetExtensions` should be used with the sequence's file name.")]
-		static readonly SpriteSequenceField<bool> UseTilesetExtension = new SpriteSequenceField<bool>(nameof(UseTilesetExtension), false);
+		[Desc("Dictionary of <tileset name>: filename to override the Filename key.")]
+		static readonly SpriteSequenceField<Dictionary<string, string>> TilesetFilenames = new SpriteSequenceField<Dictionary<string, string>>(nameof(TilesetFilenames), null);
 
 		public TilesetSpecificSpriteSequence(ModData modData, string tileset, SpriteCache cache, ISpriteSequenceLoader loader, string image, string sequence, MiniYaml data, MiniYaml defaults)
 			: base(modData, tileset, cache, loader, image, sequence, data, defaults) { }
 
-		static string ResolveTilesetId(string tileset, MiniYaml data, MiniYaml defaults)
-		{
-			var node = data.Nodes.FirstOrDefault(n => n.Key == TilesetOverrides.Key) ?? defaults.Nodes.FirstOrDefault(n => n.Key == TilesetOverrides.Key);
-			var overrideNode = node?.Value.Nodes.FirstOrDefault(n => n.Key == tileset);
-			return overrideNode?.Value.Value ?? tileset;
-		}
-
 		protected override string GetSpriteFilename(ModData modData, string tileset, string image, string sequence, MiniYaml data, MiniYaml defaults)
 		{
-			var loader = (TilesetSpecificSpriteSequenceLoader)Loader;
-			var filename = data.Value ?? defaults.Value ?? image;
-
-			if (LoadField(UseTilesetCode, data, defaults))
-				if (loader.TilesetCodes.TryGetValue(ResolveTilesetId(tileset, data, defaults), out var tilesetCode))
-					filename = filename.Substring(0, 1) + tilesetCode + filename.Substring(2, filename.Length - 2);
-
-			if (LoadField(AddExtension, data, defaults))
+			var node = data.Nodes.FirstOrDefault(n => n.Key == TilesetFilenames.Key) ?? defaults.Nodes.FirstOrDefault(n => n.Key == TilesetFilenames.Key);
+			if (node != null)
 			{
-				if (LoadField(UseTilesetExtension, data, defaults))
-					if (loader.TilesetExtensions.TryGetValue(ResolveTilesetId(tileset, data, defaults), out var tilesetExtension))
-						return filename + tilesetExtension;
-
-				return filename + loader.DefaultSpriteExtension;
+				var tilesetNode = node.Value.Nodes.FirstOrDefault(n => n.Key == tileset);
+				if (tilesetNode != null)
+					return tilesetNode.Value.Value;
 			}
 
-			return filename;
+			return base.GetSpriteFilename(modData, tileset, image, sequence, data, defaults);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20221203/ExplicitSequenceFilenames.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20221203/ExplicitSequenceFilenames.cs
@@ -1,0 +1,421 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class ExplicitSequenceFilenames : UpdateRule
+	{
+		public override string Name => "Sequence filenames must be specified explicitly.";
+
+		public override string Description =>
+			"Sequence sprite filenames are no longer automatically inferred, and the AddExtension,\n" +
+			"UseTilesetExtension, UseTilesetNodes and TilesetOverrides fields have been removed.\n\n" +
+			"The sprite filename for each sequence must now be defined using the Filename field.\n" +
+			"Tileset specific overrides can be defined as children of the TilesetFilenames field.";
+
+		string defaultSpriteExtension = ".shp";
+		List<MiniYamlNode> resolvedImagesNodes;
+		readonly Dictionary<string, string> tilesetExtensions = new Dictionary<string, string>();
+		readonly Dictionary<string, string> tilesetCodes = new Dictionary<string, string>();
+		bool parseModYaml = true;
+		bool reportModYamlChanges;
+		bool disabled;
+
+		public override IEnumerable<string> BeforeUpdateSequences(ModData modData, List<MiniYamlNode> resolvedImagesNodes)
+		{
+			// Keep a resolved copy of the sequences so we can account for values imported through inheritance or Defaults.
+			// This will be modified during processing, so take a deep copy to avoid side-effects on other update rules.
+			this.resolvedImagesNodes = MiniYaml.FromString(resolvedImagesNodes.WriteToString());
+
+			var requiredMetadata = new HashSet<string>();
+			foreach (var imageNode in resolvedImagesNodes)
+			{
+				foreach (var sequenceNode in imageNode.Value.Nodes)
+				{
+					var useTilesetExtensionNode = sequenceNode.LastChildMatching("UseTilesetExtension");
+					if (useTilesetExtensionNode != null && !tilesetExtensions.Any())
+						requiredMetadata.Add("TilesetExtensions");
+
+					var useTilesetCodeNode = sequenceNode.LastChildMatching("UseTilesetCode");
+					if (useTilesetCodeNode != null && !tilesetCodes.Any())
+						requiredMetadata.Add("TilesetCodes");
+				}
+			}
+
+			if (requiredMetadata.Any())
+			{
+				yield return $"The ExplicitSequenceFilenames rule requires {requiredMetadata.JoinWith(", ")}\n" +
+				             "to be defined under the SpriteSequenceFormat definition in mod.yaml.\n" +
+				             "Add these definitions back and run the update rule again.";
+				disabled = true;
+			}
+		}
+
+		public override IEnumerable<string> BeforeUpdate(ModData modData)
+		{
+			// Don't reload data when processing maps
+			if (!parseModYaml)
+				yield break;
+
+			parseModYaml = false;
+
+			// HACK: We need to read the obsolete yaml definitions to be able to update the sequences
+			// TilesetSpecificSpriteSequence no longer defines fields for these, so we must take them directly from mod.yaml
+			var yamlField = modData.Manifest.GetType().GetField("yaml", BindingFlags.Instance | BindingFlags.NonPublic);
+			var yaml = (Dictionary<string, MiniYaml>)yamlField?.GetValue(modData.Manifest);
+
+			if (yaml != null && yaml.TryGetValue("SpriteSequenceFormat", out var spriteSequenceFormatYaml))
+			{
+				if (spriteSequenceFormatYaml.Value == "DefaultSpriteSequence")
+				{
+					defaultSpriteExtension = "";
+					yield break;
+				}
+
+				var spriteSequenceFormatNode = new MiniYamlNode("", spriteSequenceFormatYaml);
+				var defaultSpriteExtensionNode = spriteSequenceFormatNode.LastChildMatching("DefaultSpriteExtension");
+				if (defaultSpriteExtensionNode != null)
+				{
+					reportModYamlChanges = true;
+					defaultSpriteExtension = defaultSpriteExtensionNode.Value.Value;
+				}
+
+				var tilesetExtensionsNode = spriteSequenceFormatNode.LastChildMatching("TilesetExtensions");
+				if (tilesetExtensionsNode != null)
+				{
+					reportModYamlChanges = true;
+					foreach (var n in tilesetExtensionsNode.Value.Nodes)
+						tilesetExtensions[n.Key] = n.Value.Value;
+				}
+
+				var tilesetCodesNode = spriteSequenceFormatNode.LastChildMatching("TilesetCodes");
+				if (tilesetCodesNode != null)
+				{
+					reportModYamlChanges = true;
+					foreach (var n in tilesetCodesNode.Value.Nodes)
+						tilesetCodes[n.Key] = n.Value.Value;
+				}
+			}
+		}
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (!reportModYamlChanges)
+				yield break;
+
+			yield return "The DefaultSpriteExtension, TilesetExtensions, and TilesetCodes fields defined\n" +
+				"under SpriteSequenceFormat in your mod.yaml are no longer used, and can be removed.";
+
+			reportModYamlChanges = false;
+		}
+
+		public override IEnumerable<string> UpdateSequenceNode(ModData modData, MiniYamlNode imageNode)
+		{
+			if (disabled)
+				yield break;
+
+			var resolvedImageNode = resolvedImagesNodes.Single(n => n.Key == imageNode.Key);
+
+			// Add a placeholder for inherited sequences that were previously implicitly named
+			var implicitInheritedSequences = new List<string>();
+			foreach (var resolvedSequenceNode in resolvedImageNode.Value.Nodes)
+			{
+				if (resolvedSequenceNode.Key != "Defaults" && string.IsNullOrEmpty(resolvedSequenceNode.Value.Value) &&
+				    imageNode.LastChildMatching(resolvedSequenceNode.Key) == null)
+				{
+					imageNode.AddNode(resolvedSequenceNode.Key, "");
+					implicitInheritedSequences.Add(resolvedSequenceNode.Key);
+				}
+			}
+
+			var resolvedDefaultsNode = resolvedImageNode.LastChildMatching("Defaults");
+			if (resolvedDefaultsNode != null)
+			{
+				foreach (var resolvedSequenceNode in resolvedImageNode.Value.Nodes)
+				{
+					if (resolvedSequenceNode == resolvedDefaultsNode)
+						continue;
+
+					resolvedSequenceNode.Value.Nodes = MiniYaml.Merge(new[] { resolvedDefaultsNode.Value.Nodes, resolvedSequenceNode.Value.Nodes });
+					resolvedSequenceNode.Value.Value = resolvedSequenceNode.Value.Value ?? resolvedDefaultsNode.Value.Value;
+				}
+			}
+
+			// Sequences that explicitly defined a filename may be inherited by others that depend on the explicit name
+			// Keep track of these sequences so we don't remove the filenames later!
+			var explicitlyNamedSequences = new List<string>();
+
+			// Add Filename/TilesetFilenames nodes to every sequence
+			foreach (var sequenceNode in imageNode.Value.Nodes)
+			{
+				if (string.IsNullOrEmpty(sequenceNode.Key) || sequenceNode.KeyMatches("Inherits"))
+					continue;
+
+				if (!string.IsNullOrEmpty(sequenceNode.Value.Value))
+					explicitlyNamedSequences.Add(sequenceNode.Key);
+
+				var resolvedSequenceNode = resolvedImageNode.Value.Nodes.SingleOrDefault(n => n.Key == sequenceNode.Key);
+				if (resolvedSequenceNode == null)
+					continue;
+
+				ProcessNode(modData, sequenceNode, resolvedSequenceNode, imageNode.Key);
+			}
+
+			// Identify a suitable default for deduplication
+			MiniYamlNode defaultFilenameNode = null;
+			MiniYamlNode defaultTilesetFilenamesNode = null;
+			foreach (var defaultsNode in imageNode.ChildrenMatching("Defaults"))
+			{
+				defaultFilenameNode = defaultsNode.LastChildMatching("Filename") ?? defaultFilenameNode;
+				defaultTilesetFilenamesNode = defaultsNode.LastChildMatching("TilesetFilenames") ?? defaultTilesetFilenamesNode;
+			}
+
+			if ((defaultFilenameNode == null || defaultTilesetFilenamesNode == null) && !imageNode.Key.StartsWith("^"))
+			{
+				var duplicateCount = new Dictionary<string, int>();
+				var duplicateTilesetCount = new Dictionary<string, int>();
+
+				foreach (var sequenceNode in imageNode.Value.Nodes)
+				{
+					if (string.IsNullOrEmpty(sequenceNode.Key) || explicitlyNamedSequences.Contains(sequenceNode.Key))
+						continue;
+
+					var tilesetFilenamesNode = sequenceNode.LastChildMatching("TilesetFilenames");
+					if (defaultTilesetFilenamesNode == null && tilesetFilenamesNode != null)
+					{
+						var key = tilesetFilenamesNode.Value.Nodes.WriteToString();
+						duplicateTilesetCount[key] = duplicateTilesetCount.GetValueOrDefault(key, 0) + 1;
+					}
+
+					var filenameNode = sequenceNode.LastChildMatching("Filename");
+					if (defaultFilenameNode == null && filenameNode != null)
+					{
+						var key = filenameNode.Value.Value;
+						duplicateCount[key] = duplicateCount.GetValueOrDefault(key, 0) + 1;
+					}
+				}
+
+				var maxDuplicateTilesetCount = duplicateTilesetCount.MaxByOrDefault(kv => kv.Value).Value;
+				if (maxDuplicateTilesetCount > 1)
+				{
+					if (imageNode.LastChildMatching("Defaults") == null)
+						imageNode.Value.Nodes.Insert(0, new MiniYamlNode("Defaults", ""));
+
+					var nodes = MiniYaml.FromString(duplicateTilesetCount.First(kv => kv.Value == maxDuplicateTilesetCount).Key);
+					defaultTilesetFilenamesNode = new MiniYamlNode("TilesetFilenames", "", nodes);
+					imageNode.LastChildMatching("Defaults").Value.Nodes.Insert(0, defaultTilesetFilenamesNode);
+				}
+
+				var maxDuplicateCount = duplicateCount.MaxByOrDefault(kv => kv.Value).Value;
+				if (maxDuplicateCount > 1)
+				{
+					if (imageNode.LastChildMatching("Defaults") == null)
+						imageNode.Value.Nodes.Insert(0, new MiniYamlNode("Defaults", ""));
+
+					defaultFilenameNode = new MiniYamlNode("Filename", duplicateCount.First(kv => kv.Value == maxDuplicateCount).Key);
+					imageNode.LastChildMatching("Defaults").Value.Nodes.Insert(0, defaultFilenameNode);
+				}
+			}
+
+			// Remove redundant definitions
+			foreach (var sequenceNode in imageNode.Value.Nodes.ToList())
+			{
+				if (sequenceNode.Key == "Defaults" || sequenceNode.Key == "Inherits" || string.IsNullOrEmpty(sequenceNode.Key))
+					continue;
+
+				var combineNode = sequenceNode.LastChildMatching("Combine");
+				var filenameNode = sequenceNode.LastChildMatching("Filename");
+				var tilesetFilenamesNode = sequenceNode.LastChildMatching("TilesetFilenames");
+
+				if (defaultTilesetFilenamesNode != null && combineNode != null)
+					sequenceNode.Value.Nodes.Insert(0, new MiniYamlNode("TilesetFilenames", ""));
+
+				if (defaultFilenameNode != null && combineNode != null)
+					sequenceNode.Value.Nodes.Insert(0, new MiniYamlNode("Filename", ""));
+
+				if (defaultTilesetFilenamesNode != null && tilesetFilenamesNode == null && filenameNode != null)
+				{
+					var index = sequenceNode.Value.Nodes.IndexOf(filenameNode) + 1;
+					sequenceNode.Value.Nodes.Insert(index, new MiniYamlNode("TilesetFilenames", ""));
+				}
+
+				// Remove redundant overrides
+				if (!explicitlyNamedSequences.Contains(sequenceNode.Key))
+				{
+					if (defaultTilesetFilenamesNode != null && tilesetFilenamesNode != null)
+					{
+						var allTilesetsMatch = true;
+						foreach (var overrideNode in tilesetFilenamesNode.Value.Nodes)
+							if (!defaultTilesetFilenamesNode.Value.Nodes.Any(n => n.Key == overrideNode.Key && n.Value.Value == overrideNode.Value.Value))
+								allTilesetsMatch = false;
+
+						if (allTilesetsMatch)
+							sequenceNode.RemoveNode(tilesetFilenamesNode);
+					}
+
+					if (filenameNode?.Value.Value != null && filenameNode?.Value.Value == defaultFilenameNode?.Value.Value)
+						sequenceNode.RemoveNode(filenameNode);
+				}
+			}
+
+			var allSequencesHaveFilename = true;
+			var allSequencesHaveTilesetFilenames = true;
+			foreach (var sequenceNode in imageNode.Value.Nodes.ToList())
+			{
+				if (sequenceNode.Key == "Defaults" || sequenceNode.Key == "Inherits" || string.IsNullOrEmpty(sequenceNode.Key))
+					continue;
+
+				if (sequenceNode.LastChildMatching("Filename") == null)
+					allSequencesHaveFilename = false;
+
+				if (sequenceNode.LastChildMatching("TilesetFilenames") == null)
+					allSequencesHaveTilesetFilenames = false;
+			}
+
+			if (allSequencesHaveFilename || allSequencesHaveTilesetFilenames)
+			{
+				foreach (var sequenceNode in imageNode.Value.Nodes.ToList())
+				{
+					if (sequenceNode.Key == "Defaults")
+					{
+						if (allSequencesHaveFilename)
+							sequenceNode.RemoveNodes("Filename");
+
+						if (allSequencesHaveTilesetFilenames)
+							sequenceNode.RemoveNodes("TilesetFilenames");
+
+						if (!sequenceNode.Value.Nodes.Any())
+							imageNode.RemoveNode(sequenceNode);
+					}
+
+					if (allSequencesHaveFilename && sequenceNode.LastChildMatching("Combine") != null)
+						sequenceNode.RemoveNodes("Filename");
+
+					if (allSequencesHaveTilesetFilenames && sequenceNode.LastChildMatching("Combine") != null)
+						sequenceNode.RemoveNodes("TilesetFilenames");
+
+					var tilesetFilenamesNode = sequenceNode.LastChildMatching("TilesetFilenames");
+					if (allSequencesHaveTilesetFilenames && tilesetFilenamesNode != null && !tilesetFilenamesNode.Value.Nodes.Any())
+						sequenceNode.RemoveNode(tilesetFilenamesNode);
+				}
+			}
+
+			foreach (var sequenceNode in imageNode.Value.Nodes.ToList())
+				if (implicitInheritedSequences.Contains(sequenceNode.Key) && !sequenceNode.Value.Nodes.Any())
+					imageNode.RemoveNode(sequenceNode);
+
+			yield break;
+		}
+
+		void ProcessNode(ModData modData, MiniYamlNode sequenceNode, MiniYamlNode resolvedSequenceNode, string imageName)
+		{
+			var addExtension = true;
+			var addExtensionNode = resolvedSequenceNode.LastChildMatching("AddExtension");
+			if (addExtensionNode != null)
+				addExtension = FieldLoader.GetValue<bool>("AddExtension", addExtensionNode.Value.Value);
+
+			var useTilesetExtension = false;
+			var useTilesetExtensionNode = resolvedSequenceNode.LastChildMatching("UseTilesetExtension");
+			if (useTilesetExtensionNode != null)
+				useTilesetExtension = FieldLoader.GetValue<bool>("UseTilesetExtension", useTilesetExtensionNode.Value.Value);
+
+			var useTilesetCode = false;
+			var useTilesetCodeNode = resolvedSequenceNode.LastChildMatching("UseTilesetCode");
+			if (useTilesetCodeNode != null)
+				useTilesetCode = FieldLoader.GetValue<bool>("UseTilesetCode", useTilesetCodeNode.Value.Value);
+
+			var tilesetOverrides = new Dictionary<string, string>();
+			var tilesetOverridesNode = resolvedSequenceNode.LastChildMatching("TilesetOverrides");
+			if (tilesetOverridesNode != null)
+				foreach (var tilesetNode in tilesetOverridesNode.Value.Nodes)
+					tilesetOverrides[tilesetNode.Key] = tilesetNode.Value.Value;
+
+			sequenceNode.RemoveNodes("AddExtension");
+			sequenceNode.RemoveNodes("UseTilesetExtension");
+			sequenceNode.RemoveNodes("UseTilesetCode");
+			sequenceNode.RemoveNodes("TilesetOverrides");
+
+			// Replace removals with masking
+			foreach (var node in sequenceNode.Value.Nodes)
+				if (node.Key?.StartsWith("-") ?? false)
+					node.Key = node.Key.Substring(1);
+
+			var combineNode = sequenceNode.LastChildMatching("Combine");
+			if (combineNode != null)
+			{
+				var i = 0;
+				foreach (var node in combineNode.Value.Nodes)
+				{
+					ProcessNode(modData, node, node, node.Key);
+					node.Key = (i++).ToString();
+				}
+
+				return;
+			}
+
+			var filename = string.IsNullOrEmpty(resolvedSequenceNode.Value.Value) ? imageName : resolvedSequenceNode.Value.Value;
+			if (filename.StartsWith("^"))
+				return;
+
+			if (useTilesetExtension || useTilesetCode)
+			{
+				var tilesetFilenamesNode = new MiniYamlNode("TilesetFilenames", "");
+				var duplicateCount = new Dictionary<string, int>();
+				foreach (var tileset in modData.DefaultTerrainInfo.Keys)
+				{
+					if (!tilesetOverrides.TryGetValue(tileset, out var sequenceTileset))
+						sequenceTileset = tileset;
+
+					var overrideFilename = filename;
+					if (useTilesetCode)
+						overrideFilename = filename.Substring(0, 1) + tilesetCodes[sequenceTileset] +
+						                   filename.Substring(2, filename.Length - 2);
+
+					if (addExtension)
+						overrideFilename += useTilesetExtension ? tilesetExtensions[sequenceTileset] : defaultSpriteExtension;
+
+					tilesetFilenamesNode.AddNode(tileset, overrideFilename);
+					duplicateCount[overrideFilename] = duplicateCount.GetValueOrDefault(overrideFilename, 0) + 1;
+				}
+
+				sequenceNode.Value.Nodes.Insert(0, tilesetFilenamesNode);
+
+				// Deduplicate tileset overrides
+				var maxDuplicateCount = duplicateCount.MaxByOrDefault(kv => kv.Value).Value;
+				if (maxDuplicateCount > 1)
+				{
+					var filenameNode = new MiniYamlNode("Filename", duplicateCount.First(kv => kv.Value == maxDuplicateCount).Key);
+					foreach (var overrideNode in tilesetFilenamesNode.Value.Nodes.ToList())
+						if (overrideNode.Value.Value == filenameNode.Value.Value)
+							tilesetFilenamesNode.Value.Nodes.Remove(overrideNode);
+
+					if (!tilesetFilenamesNode.Value.Nodes.Any())
+						sequenceNode.RemoveNode(tilesetFilenamesNode);
+
+					sequenceNode.Value.Nodes.Insert(0, filenameNode);
+				}
+			}
+			else
+			{
+				if (addExtension)
+					filename += defaultSpriteExtension;
+
+				sequenceNode.Value.Nodes.Insert(0, new MiniYamlNode("Filename", filename));
+			}
+
+			sequenceNode.ReplaceValue("");
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -103,6 +103,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 			new UpdatePath("playtest-20221203", new UpdateRule[]
 			{
 				new TextNotificationsDisplayWidgetRemoveTime(),
+				new ExplicitSequenceFilenames(),
 			})
 		};
 

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractSpriteSequenceDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractSpriteSequenceDocsCommand.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						.Select(y => y.Name)
 						.Where(y => y != type.Name && y != "Object"),
 					Properties = type.GetFields(BindingFlags.NonPublic | BindingFlags.Static)
-						.Where(fi => fi.FieldType.GetGenericTypeDefinition() == typeof(SpriteSequenceField<>))
+						.Where(fi => fi.FieldType.IsGenericType && fi.FieldType.GetGenericTypeDefinition() == typeof(SpriteSequenceField<>))
 						.Select(fi =>
 						{
 							var description = string.Join(" ", fi.GetCustomAttributes<DescAttribute>(false)

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -238,12 +238,6 @@ VideoFormats: Vqa, Wsa
 TerrainFormat: DefaultTerrain
 
 SpriteSequenceFormat: ClassicTilesetSpecificSpriteSequence
-	TilesetExtensions:
-		TEMPERAT: .tem
-		WINTER: .win
-		SNOW: .sno
-		DESERT: .des
-		JUNGLE: .jun
 
 ModelSequenceFormat: PlaceholderModelSequence
 

--- a/mods/cnc/sequences/aircraft.yaml
+++ b/mods/cnc/sequences/aircraft.yaml
@@ -1,21 +1,29 @@
 c17:
 	idle:
+		Filename: c17.shp
 		Facings: 32
 		UseClassicFacings: True
-	icon: c17icnh
+	icon:
+		Filename: c17icnh.shp
 
 tran:
+	Defaults:
+		Filename: tran.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
-	rotor: lrotor
+	rotor:
+		Filename: lrotor.shp
 		Length: 4
-	rotor2: rrotor
+	rotor2:
+		Filename: rrotor.shp
 		Length: 4
-	slow-rotor: lrotor
+	slow-rotor:
+		Filename: lrotor.shp
 		Start: 4
 		Length: 8
-	slow-rotor2: rrotor
+	slow-rotor2:
+		Filename: rrotor.shp
 		Start: 4
 		Length: 8
 	open:
@@ -23,40 +31,48 @@ tran:
 		Length: 4
 	unload:
 		Start: 35
-	icon: tranicnh.tem
-		AddExtension: False
+	icon:
+		Filename: tranicnh.tem
 
 heli:
 	idle:
+		Filename: heli.shp
 		Facings: 32
 		UseClassicFacings: True
-	rotor: lrotor
+	rotor:
+		Filename: lrotor.shp
 		Length: 4
-	slow-rotor: lrotor
+	slow-rotor:
+		Filename: lrotor.shp
 		Start: 4
 		Length: 8
-	muzzle: minigun
+	muzzle:
+		Filename: minigun.shp
 		Length: 6
 		Facings: 8
-	icon: heliicnh.tem
-		AddExtension: False
+	icon:
+		Filename: heliicnh.tem
 
 orca:
+	Defaults:
+		Filename: orca.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
 	move:
 		Start: 32
 		Facings: 32
-	icon: orcaicnh.tem
-		AddExtension: False
+	icon:
+		Filename: orcaicnh.tem
 
 a10:
 	idle:
+		Filename: a10.shp
 		Facings: 32
 		UseClassicFacings: True
-	muzzle: minigun
+	muzzle:
+		Filename: minigun.shp
 		Length: 6
 		Facings: 8
-	icon: a10icnh.tem
-		AddExtension: False
+	icon:
+		Filename: a10icnh.tem

--- a/mods/cnc/sequences/campaign.yaml
+++ b/mods/cnc/sequences/campaign.yaml
@@ -1,12 +1,15 @@
 lst:
-	idle: lst
+	idle:
+		Filename: lst.shp
 		Start: 0
 		Facings: 1
 		ZOffset: -1024
-	icon: lsticnh.tem
-		AddExtension: False
+	icon:
+		Filename: lsticnh.tem
 
 boat:
+	Defaults:
+		Filename: boat.shp
 	left:
 		Facings: 32
 	damaged-left:
@@ -15,7 +18,8 @@ boat:
 	critical-left:
 		Start: 64
 		Facings: 32
-	wake-left: wake
+	wake-left:
+		Filename: wake.shp
 		Start: 6
 		Length: 6
 		Offset: 1,2
@@ -29,9 +33,10 @@ boat:
 	critical-right:
 		Start: 160
 		Facings: 32
-	wake-right: wake
+	wake-right:
+		Filename: wake.shp
 		Length: 6
 		Offset: -1,2
 		Tick: 120
-	icon: boaticnh.tem
-		AddExtension: False
+	icon:
+		Filename: boaticnh.tem

--- a/mods/cnc/sequences/civilian.yaml
+++ b/mods/cnc/sequences/civilian.yaml
@@ -1,4 +1,6 @@
 c1:
+	Defaults:
+		Filename: c1.shp
 	stand:
 		Facings: 8
 	panic-stand:
@@ -44,43 +46,65 @@ c1:
 		Start: 182
 		Length: 4
 		Tick: 80
-	die-crushed: e1rot
+	die-crushed:
+		Filename: e1rot.shp
 		Start: 16
 		Length: 4
 		Tick: 1600
 
 c2:
+	Defaults:
+		Filename: c2.shp
 	Inherits: c1
 
 c3:
+	Defaults:
+		Filename: c3.shp
 	Inherits: c1
 
 c4:
+	Defaults:
+		Filename: c4.shp
 	Inherits: c1
 
 c5:
+	Defaults:
+		Filename: c5.shp
 	Inherits: c1
 
 c6:
+	Defaults:
+		Filename: c6.shp
 	Inherits: c1
 
 c7:
+	Defaults:
+		Filename: c7.shp
 	Inherits: c1
 
 c8:
+	Defaults:
+		Filename: c8.shp
 	Inherits: c1
 
 c9:
+	Defaults:
+		Filename: c9.shp
 	Inherits: c1
 
 c10:
+	Defaults:
+		Filename: c10.shp
 	Inherits: c1
 
 delphi:
+	Defaults:
+		Filename: delphi.shp
 	Inherits: c1
 
 moebius:
 	Defaults:
+		Filename: moebius.shp
 		Tick: 80
 	stand:
 		Facings: 8
@@ -115,10 +139,13 @@ moebius:
 	die6:
 		Start: 214
 		Length: 3
-	die-crushed: e1rot
+	die-crushed:
+		Filename: e1rot.shp
 		Start: 16
 		Length: 4
 		Tick: 1600
 
 chan:
+	Defaults:
+		Filename: chan.shp
 	Inherits: moebius

--- a/mods/cnc/sequences/decorations.yaml
+++ b/mods/cnc/sequences/decorations.yaml
@@ -1,9 +1,11 @@
 split2:
 	Defaults:
+		Filename: split2.tem
+		TilesetFilenames:
+			WINTER: split2.win
+			SNOW: split2.sno
+			JUNGLE: split2.jun
 		Offset: 11, -15
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
 	make:
 		Length: 30
 		Tick: 120
@@ -15,8 +17,13 @@ split2:
 
 split3:
 	Defaults:
+		TilesetFilenames:
+			DESERT: split3.des
+			WINTER: split3.win
+			SNOW: split3.sno
+			TEMPERAT: split3.tem
+			JUNGLE: split3.jun
 		Offset: 7, -13
-		UseTilesetExtension: true
 	make:
 		Length: 30
 		Tick: 120
@@ -27,47 +34,51 @@ split3:
 		Start: 54
 
 rock1:
-	idle: rock1.des
-		AddExtension: false
+	idle:
+		Filename: rock1.des
 
 rock2:
-	idle: rock2.des
-		AddExtension: false
+	idle:
+		Filename: rock2.des
 
 rock3:
-	idle: rock3.des
-		AddExtension: false
+	idle:
+		Filename: rock3.des
 
 rock4:
-	idle: rock4.des
-		AddExtension: false
+	idle:
+		Filename: rock4.des
 
 rock5:
-	idle: rock5.des
-		AddExtension: false
+	idle:
+		Filename: rock5.des
 
 rock6:
-	idle: rock6.des
-		AddExtension: false
+	idle:
+		Filename: rock6.des
 
 rock7:
-	idle: rock7.des
-		AddExtension: false
+	idle:
+		Filename: rock7.des
 
 tc04:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: tc04.tem
+		TilesetFilenames:
+			WINTER: tc04.win
+			SNOW: tc04.sno
+			JUNGLE: tc04.jun
 	idle:
 	damaged-idle:
 		Start: 1
 
 tc04.husk:
-	Defaults: tc04
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+	Defaults:
+		Filename: tc04.tem
+		TilesetFilenames:
+			WINTER: tc04.win
+			SNOW: tc04.sno
+			JUNGLE: tc04.jun
 	idle:
 		Start: 2
 	dead:
@@ -77,18 +88,22 @@ tc04.husk:
 
 tc05:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: tc05.tem
+		TilesetFilenames:
+			WINTER: tc05.win
+			SNOW: tc05.sno
+			JUNGLE: tc05.jun
 	idle:
 	damaged-idle:
 		Start: 1
 
 tc05.husk:
-	Defaults: tc05
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+	Defaults:
+		Filename: tc05.tem
+		TilesetFilenames:
+			WINTER: tc05.win
+			SNOW: tc05.sno
+			JUNGLE: tc05.jun
 	idle:
 		Start: 2
 	dead:
@@ -98,16 +113,20 @@ tc05.husk:
 
 tc03:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: tc03.tem
+		TilesetFilenames:
+			WINTER: tc03.win
+			SNOW: tc03.sno
+			JUNGLE: tc03.jun
 	idle:
 
 tc03.husk:
-	Defaults: tc03
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+	Defaults:
+		Filename: tc03.tem
+		TilesetFilenames:
+			WINTER: tc03.win
+			SNOW: tc03.sno
+			JUNGLE: tc03.jun
 	idle:
 		Start: 1
 	dead:
@@ -117,16 +136,20 @@ tc03.husk:
 
 tc02:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: tc02.tem
+		TilesetFilenames:
+			WINTER: tc02.win
+			SNOW: tc02.sno
+			JUNGLE: tc02.jun
 	idle:
 
 tc02.husk:
-	Defaults: tc02
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+	Defaults:
+		Filename: tc02.tem
+		TilesetFilenames:
+			WINTER: tc02.win
+			SNOW: tc02.sno
+			JUNGLE: tc02.jun
 	idle:
 		Start: 1
 	dead:
@@ -136,16 +159,20 @@ tc02.husk:
 
 tc01:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: tc01.tem
+		TilesetFilenames:
+			WINTER: tc01.win
+			SNOW: tc01.sno
+			JUNGLE: tc01.jun
 	idle:
 
 tc01.husk:
-	Defaults: tc01
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+	Defaults:
+		Filename: tc01.tem
+		TilesetFilenames:
+			WINTER: tc01.win
+			SNOW: tc01.sno
+			JUNGLE: tc01.jun
 	idle:
 		Start: 1
 	dead:
@@ -154,32 +181,35 @@ tc01.husk:
 		Tick: 80
 
 t18:
-	Defaults:
-		AddExtension: false
-	idle: t18.des
+	idle:
+		Filename: t18.des
 
 t18.husk:
-	Defaults: t18
-		AddExtension: false
-	idle: t18.des
+	idle:
+		Filename: t18.des
 		Start: 1
-	dead: t18.des
+	dead:
+		Filename: t18.des
 		Start: 2
 		Length: 8
 		Tick: 80
 
 t17:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: t17.tem
+		TilesetFilenames:
+			WINTER: t17.win
+			SNOW: t17.sno
+			JUNGLE: t17.jun
 	idle:
 
 t17.husk:
-	Defaults: t17
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+	Defaults:
+		Filename: t17.tem
+		TilesetFilenames:
+			WINTER: t17.win
+			SNOW: t17.sno
+			JUNGLE: t17.jun
 	idle:
 		Start: 1
 	dead:
@@ -189,16 +219,20 @@ t17.husk:
 
 t16:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: t16.tem
+		TilesetFilenames:
+			WINTER: t16.win
+			SNOW: t16.sno
+			JUNGLE: t16.jun
 	idle:
 
 t16.husk:
-	Defaults: t16
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+	Defaults:
+		Filename: t16.tem
+		TilesetFilenames:
+			WINTER: t16.win
+			SNOW: t16.sno
+			JUNGLE: t16.jun
 	idle:
 		Start: 1
 	dead:
@@ -208,16 +242,20 @@ t16.husk:
 
 t15:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: t15.tem
+		TilesetFilenames:
+			WINTER: t15.win
+			SNOW: t15.sno
+			JUNGLE: t15.jun
 	idle:
 
 t15.husk:
-	Defaults: t15
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+	Defaults:
+		Filename: t15.tem
+		TilesetFilenames:
+			WINTER: t15.win
+			SNOW: t15.sno
+			JUNGLE: t15.jun
 	idle:
 		Start: 1
 	dead:
@@ -227,16 +265,20 @@ t15.husk:
 
 t14:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: t14.tem
+		TilesetFilenames:
+			WINTER: t14.win
+			SNOW: t14.sno
+			JUNGLE: t14.jun
 	idle:
 
 t14.husk:
-	Defaults: t14
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+	Defaults:
+		Filename: t14.tem
+		TilesetFilenames:
+			WINTER: t14.win
+			SNOW: t14.sno
+			JUNGLE: t14.jun
 	idle:
 		Start: 1
 	dead:
@@ -246,16 +288,20 @@ t14.husk:
 
 t13:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: t13.tem
+		TilesetFilenames:
+			WINTER: t13.win
+			SNOW: t13.sno
+			JUNGLE: t13.jun
 	idle:
 
 t13.husk:
-	Defaults: t13
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+	Defaults:
+		Filename: t13.tem
+		TilesetFilenames:
+			WINTER: t13.win
+			SNOW: t13.sno
+			JUNGLE: t13.jun
 	idle:
 		Start: 1
 	dead:
@@ -265,16 +311,20 @@ t13.husk:
 
 t12:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: t12.tem
+		TilesetFilenames:
+			WINTER: t12.win
+			SNOW: t12.sno
+			JUNGLE: t12.jun
 	idle:
 
 t12.husk:
-	Defaults: t12
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+	Defaults:
+		Filename: t12.tem
+		TilesetFilenames:
+			WINTER: t12.win
+			SNOW: t12.sno
+			JUNGLE: t12.jun
 	idle:
 		Start: 1
 	dead:
@@ -284,16 +334,20 @@ t12.husk:
 
 t11:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: t11.tem
+		TilesetFilenames:
+			WINTER: t11.win
+			SNOW: t11.sno
+			JUNGLE: t11.jun
 	idle:
 
 t11.husk:
-	Defaults: t11
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+	Defaults:
+		Filename: t11.tem
+		TilesetFilenames:
+			WINTER: t11.win
+			SNOW: t11.sno
+			JUNGLE: t11.jun
 	idle:
 		Start: 1
 	dead:
@@ -303,16 +357,20 @@ t11.husk:
 
 t10:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: t10.tem
+		TilesetFilenames:
+			WINTER: t10.win
+			SNOW: t10.sno
+			JUNGLE: t10.jun
 	idle:
 
 t10.husk:
-	Defaults: t10
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+	Defaults:
+		Filename: t10.tem
+		TilesetFilenames:
+			WINTER: t10.win
+			SNOW: t10.sno
+			JUNGLE: t10.jun
 	idle:
 		Start: 1
 	dead:
@@ -321,28 +379,37 @@ t10.husk:
 		Tick: 80
 
 t09:
-	Defaults:
-		AddExtension: false
-	idle: t09.des
+	idle:
+		Filename: t09.des
 
 t09.husk:
-	Defaults: t09
-		AddExtension: false
-	idle: t09.des
+	idle:
+		Filename: t09.des
 		Start: 1
-	dead: t09.des
+	dead:
+		Filename: t09.des
 		Start: 2
 		Length: 8
 		Tick: 80
 
 t08:
 	Defaults:
-		UseTilesetExtension: true
+		TilesetFilenames:
+			DESERT: t08.des
+			WINTER: t08.win
+			SNOW: t08.sno
+			TEMPERAT: t08.tem
+			JUNGLE: t08.jun
 	idle:
 
 t08.husk:
-	Defaults: t08
-		UseTilesetExtension: true
+	Defaults:
+		TilesetFilenames:
+			DESERT: t08.des
+			WINTER: t08.win
+			SNOW: t08.sno
+			TEMPERAT: t08.tem
+			JUNGLE: t08.jun
 	idle:
 		Start: 1
 	dead:
@@ -352,16 +419,20 @@ t08.husk:
 
 t07:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: t07.tem
+		TilesetFilenames:
+			WINTER: t07.win
+			SNOW: t07.sno
+			JUNGLE: t07.jun
 	idle:
 
 t07.husk:
-	Defaults: t07
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+	Defaults:
+		Filename: t07.tem
+		TilesetFilenames:
+			WINTER: t07.win
+			SNOW: t07.sno
+			JUNGLE: t07.jun
 	idle:
 		Start: 1
 	dead:
@@ -371,16 +442,20 @@ t07.husk:
 
 t06:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: t06.tem
+		TilesetFilenames:
+			WINTER: t06.win
+			SNOW: t06.sno
+			JUNGLE: t06.jun
 	idle:
 
 t06.husk:
-	Defaults: t06
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+	Defaults:
+		Filename: t06.tem
+		TilesetFilenames:
+			WINTER: t06.win
+			SNOW: t06.sno
+			JUNGLE: t06.jun
 	idle:
 		Start: 1
 	dead:
@@ -390,16 +465,20 @@ t06.husk:
 
 t05:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: t05.tem
+		TilesetFilenames:
+			WINTER: t05.win
+			SNOW: t05.sno
+			JUNGLE: t05.jun
 	idle:
 
 t05.husk:
-	Defaults: t05
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+	Defaults:
+		Filename: t05.tem
+		TilesetFilenames:
+			WINTER: t05.win
+			SNOW: t05.sno
+			JUNGLE: t05.jun
 	idle:
 		Start: 1
 	dead:
@@ -408,32 +487,35 @@ t05.husk:
 		Tick: 80
 
 t04:
-	Defaults:
-		AddExtension: false
-	idle: t04.des
+	idle:
+		Filename: t04.des
 
 t04.husk:
-	Defaults: t04
-		AddExtension: false
-	idle: t04.des
+	idle:
+		Filename: t04.des
 		Start: 1
-	dead: t04.des
+	dead:
+		Filename: t04.des
 		Start: 2
 		Length: 8
 		Tick: 80
 
 t03:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: t03.tem
+		TilesetFilenames:
+			WINTER: t03.win
+			SNOW: t03.sno
+			JUNGLE: t03.jun
 	idle:
 
 t03.husk:
-	Defaults: t03
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+	Defaults:
+		Filename: t03.tem
+		TilesetFilenames:
+			WINTER: t03.win
+			SNOW: t03.sno
+			JUNGLE: t03.jun
 	idle:
 		Start: 1
 	dead:
@@ -443,16 +525,20 @@ t03.husk:
 
 t02:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: t02.tem
+		TilesetFilenames:
+			WINTER: t02.win
+			SNOW: t02.sno
+			JUNGLE: t02.jun
 	idle:
 
 t02.husk:
-	Defaults: t02
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+	Defaults:
+		Filename: t02.tem
+		TilesetFilenames:
+			WINTER: t02.win
+			SNOW: t02.sno
+			JUNGLE: t02.jun
 	idle:
 		Start: 1
 	dead:
@@ -462,16 +548,20 @@ t02.husk:
 
 t01:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: t01.tem
+		TilesetFilenames:
+			WINTER: t01.win
+			SNOW: t01.sno
+			JUNGLE: t01.jun
 	idle:
 
 t01.husk:
-	Defaults: t01
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+	Defaults:
+		Filename: t01.tem
+		TilesetFilenames:
+			WINTER: t01.win
+			SNOW: t01.sno
+			JUNGLE: t01.jun
 	idle:
 		Start: 1
 	dead:
@@ -481,185 +571,231 @@ t01.husk:
 
 v01:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: v01.tem
+		TilesetFilenames:
+			WINTER: v01.win
+			SNOW: v01.sno
+			JUNGLE: v01.jun
 	idle:
 	damaged-idle:
 		Start: 1
 
 v01.husk:
-	idle: v01
+	idle:
+		Filename: v01.tem
+		TilesetFilenames:
+			WINTER: v01.win
+			SNOW: v01.sno
+			JUNGLE: v01.jun
 		Start: 2
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
 
 v02:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: v02.tem
+		TilesetFilenames:
+			WINTER: v02.win
+			SNOW: v02.sno
+			JUNGLE: v02.jun
 	idle:
 	damaged-idle:
 		Start: 1
 
 v02.husk:
-	idle: v02
+	idle:
+		Filename: v02.tem
+		TilesetFilenames:
+			WINTER: v02.win
+			SNOW: v02.sno
+			JUNGLE: v02.jun
 		Start: 2
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
 
 v03:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: v03.tem
+		TilesetFilenames:
+			WINTER: v03.win
+			SNOW: v03.sno
+			JUNGLE: v03.jun
 	idle:
 	damaged-idle:
 		Start: 1
 
 v03.husk:
-	idle: v03
+	idle:
+		Filename: v03.tem
+		TilesetFilenames:
+			WINTER: v03.win
+			SNOW: v03.sno
+			JUNGLE: v03.jun
 		Start: 2
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
 
 v04:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: v04.tem
+		TilesetFilenames:
+			WINTER: v04.win
+			SNOW: v04.sno
+			JUNGLE: v04.jun
 	idle:
 	damaged-idle:
 		Start: 1
 
 v04.husk:
-	idle: v04
+	idle:
+		Filename: v04.tem
+		TilesetFilenames:
+			WINTER: v04.win
+			SNOW: v04.sno
+			JUNGLE: v04.jun
 		Start: 2
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
 
 v05:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: v05.tem
+		TilesetFilenames:
+			WINTER: v05.win
+			SNOW: v05.sno
+			JUNGLE: v05.jun
 	idle:
 	damaged-idle:
 		Start: 1
 
 v05.husk:
-	idle: v05
+	idle:
+		Filename: v05.tem
+		TilesetFilenames:
+			WINTER: v05.win
+			SNOW: v05.sno
+			JUNGLE: v05.jun
 		Start: 2
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
 
 v06:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: v06.tem
+		TilesetFilenames:
+			WINTER: v06.win
+			SNOW: v06.sno
+			JUNGLE: v06.jun
 	idle:
 	damaged-idle:
 		Start: 1
 
 v06.husk:
-	idle: v06
+	idle:
+		Filename: v06.tem
+		TilesetFilenames:
+			WINTER: v06.win
+			SNOW: v06.sno
+			JUNGLE: v06.jun
 		Start: 2
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
 
 v07:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: v07.tem
+		TilesetFilenames:
+			WINTER: v07.win
+			SNOW: v07.sno
+			JUNGLE: v07.jun
 	idle:
 	damaged-idle:
 		Start: 2
 
 v07.husk:
-	idle: v07
+	idle:
+		Filename: v07.tem
+		TilesetFilenames:
+			WINTER: v07.win
+			SNOW: v07.sno
+			JUNGLE: v07.jun
 		Start: 2
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
 
 v08:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: v08.tem
+		TilesetFilenames:
+			WINTER: v08.win
+			SNOW: v08.sno
+			JUNGLE: v08.jun
 	idle:
 	damaged-idle:
 		Start: 1
 
 v08.husk:
-	idle: v08
+	idle:
+		Filename: v08.tem
+		TilesetFilenames:
+			WINTER: v08.win
+			SNOW: v08.sno
+			JUNGLE: v08.jun
 		Start: 2
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
 
 v09:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: v09.tem
+		TilesetFilenames:
+			WINTER: v09.win
+			SNOW: v09.sno
+			JUNGLE: v09.jun
 	idle:
 	damaged-idle:
 		Start: 1
 
 v09.husk:
-	idle: v09
+	idle:
+		Filename: v09.tem
+		TilesetFilenames:
+			WINTER: v09.win
+			SNOW: v09.sno
+			JUNGLE: v09.jun
 		Start: 2
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
 
 v10:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: v10.tem
+		TilesetFilenames:
+			WINTER: v10.win
+			SNOW: v10.sno
+			JUNGLE: v10.jun
 	idle:
 	damaged-idle:
 		Start: 1
 
 v10.husk:
-	idle: v10
+	idle:
+		Filename: v10.tem
+		TilesetFilenames:
+			WINTER: v10.win
+			SNOW: v10.sno
+			JUNGLE: v10.jun
 		Start: 2
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
 
 v11:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: v11.tem
+		TilesetFilenames:
+			WINTER: v11.win
+			SNOW: v11.sno
+			JUNGLE: v11.jun
 	idle:
 	damaged-idle:
 		Start: 1
 
 v11.husk:
-	idle: v11
+	idle:
+		Filename: v11.tem
+		TilesetFilenames:
+			WINTER: v11.win
+			SNOW: v11.sno
+			JUNGLE: v11.jun
 		Start: 2
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
 
 v12:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: v12.tem
+		TilesetFilenames:
+			WINTER: v12.win
+			SNOW: v12.sno
+			JUNGLE: v12.jun
 	idle:
 		ZOffset: -2c512
 	damaged-idle:
@@ -667,18 +803,22 @@ v12:
 		ZOffset: -2c512
 
 v12.husk:
-	idle: v12
+	idle:
+		Filename: v12.tem
+		TilesetFilenames:
+			WINTER: v12.win
+			SNOW: v12.sno
+			JUNGLE: v12.jun
 		Start: 2
 		ZOffset: -2c512
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
 
 v13:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: v13.tem
+		TilesetFilenames:
+			WINTER: v13.win
+			SNOW: v13.sno
+			JUNGLE: v13.jun
 	idle:
 		ZOffset: -2c512
 	damaged-idle:
@@ -686,18 +826,22 @@ v13:
 		ZOffset: -2c512
 
 v13.husk:
-	idle: v13
+	idle:
+		Filename: v13.tem
+		TilesetFilenames:
+			WINTER: v13.win
+			SNOW: v13.sno
+			JUNGLE: v13.jun
 		Start: 2
 		ZOffset: -2c512
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
 
 v14:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: v14.tem
+		TilesetFilenames:
+			WINTER: v14.win
+			SNOW: v14.sno
+			JUNGLE: v14.jun
 	idle:
 		ZOffset: -2c512
 	damaged-idle:
@@ -705,18 +849,22 @@ v14:
 		ZOffset: -2c512
 
 v14.husk:
-	idle: v14
+	idle:
+		Filename: v14.tem
+		TilesetFilenames:
+			WINTER: v14.win
+			SNOW: v14.sno
+			JUNGLE: v14.jun
 		Start: 2
 		ZOffset: -2c512
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
 
 v15:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: v15.tem
+		TilesetFilenames:
+			WINTER: v15.win
+			SNOW: v15.sno
+			JUNGLE: v15.jun
 	idle:
 		ZOffset: -2c512
 	damaged-idle:
@@ -724,18 +872,22 @@ v15:
 		ZOffset: -2c512
 
 v15.husk:
-	idle: v15
+	idle:
+		Filename: v15.tem
+		TilesetFilenames:
+			WINTER: v15.win
+			SNOW: v15.sno
+			JUNGLE: v15.jun
 		Start: 2
 		ZOffset: -2c512
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
 
 v16:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: v16.tem
+		TilesetFilenames:
+			WINTER: v16.win
+			SNOW: v16.sno
+			JUNGLE: v16.jun
 	idle:
 		ZOffset: -2c512
 	damaged-idle:
@@ -743,18 +895,22 @@ v16:
 		ZOffset: -2c512
 
 v16.husk:
-	idle: v16
+	idle:
+		Filename: v16.tem
+		TilesetFilenames:
+			WINTER: v16.win
+			SNOW: v16.sno
+			JUNGLE: v16.jun
 		Start: 2
 		ZOffset: -2c512
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
 
 v17:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: v17.tem
+		TilesetFilenames:
+			WINTER: v17.win
+			SNOW: v17.sno
+			JUNGLE: v17.jun
 	idle:
 		ZOffset: -2c512
 	damaged-idle:
@@ -762,18 +918,22 @@ v17:
 		ZOffset: -2c512
 
 v17.husk:
-	idle: v17
+	idle:
+		Filename: v17.tem
+		TilesetFilenames:
+			WINTER: v17.win
+			SNOW: v17.sno
+			JUNGLE: v17.jun
 		Start: 2
 		ZOffset: -2c512
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
 
 v18:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
+		Filename: v18.tem
+		TilesetFilenames:
+			WINTER: v18.win
+			SNOW: v18.sno
+			JUNGLE: v18.jun
 	idle:
 		ZOffset: -2c512
 	damaged-idle:
@@ -781,14 +941,18 @@ v18:
 		ZOffset: -2c512
 
 v18.husk:
-	idle: v18
+	idle:
+		Filename: v18.tem
+		TilesetFilenames:
+			WINTER: v18.win
+			SNOW: v18.sno
+			JUNGLE: v18.jun
 		Start: 2
 		ZOffset: -2c512
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
 
 v19:
+	Defaults:
+		Filename: v19.shp
 	idle:
 		Length: 14
 		Tick: 120
@@ -798,255 +962,261 @@ v19:
 		Tick: 120
 
 v19.husk:
-	idle: v19
+	idle:
+		Filename: v19.shp
 		Start: 28
-	fire-start: flmspt
+	fire-start:
+		Filename: flmspt.shp
 		Length: *
 		Offset: 7,-15
 		ZOffset: 1
-	fire-loop: flmspt
+	fire-loop:
+		Filename: flmspt.shp
 		Start: 50
 		Length: *
 		Offset: 7,-15
 		ZOffset: 1
 
 v20:
-	Defaults:
-		AddExtension: false
-	idle: v20.des
+	idle:
+		Filename: v20.des
 		Length: 3
 		Tick: 120
-	damaged-idle: v20.des
+	damaged-idle:
+		Filename: v20.des
 		Start: 3
 		Length: 3
 		Tick: 120
 
 v20.husk:
-	idle: v20.des
+	idle:
+		Filename: v20.des
 		Start: 6
-		AddExtension: false
 
 v21:
-	Defaults:
-		AddExtension: false
-	idle: v21.des
+	idle:
+		Filename: v21.des
 		Length: 3
 		Tick: 120
-	damaged-idle: v21.des
+	damaged-idle:
+		Filename: v21.des
 		Start: 3
 		Length: 3
 		Tick: 120
 
 v21.husk:
-	idle: v21.des
+	idle:
+		Filename: v21.des
 		Start: 6
-		AddExtension: false
 
 v22:
-	Defaults:
-		AddExtension: false
-	idle: v22.des
+	idle:
+		Filename: v22.des
 		Length: 3
 		Tick: 120
-	damaged-idle: v22.des
+	damaged-idle:
+		Filename: v22.des
 		Start: 3
 		Length: 3
 		Tick: 120
 
 v22.husk:
-	idle: v22.des
+	idle:
+		Filename: v22.des
 		Start: 6
-		AddExtension: false
 
 v23:
-	Defaults:
-		AddExtension: false
-	idle: v23.des
+	idle:
+		Filename: v23.des
 		Length: 3
 		Tick: 120
-	damaged-idle: v23.des
+	damaged-idle:
+		Filename: v23.des
 		Start: 3
 		Length: 3
 		Tick: 120
 
 v23.husk:
-	idle: v23.des
+	idle:
+		Filename: v23.des
 		Start: 6
-		AddExtension: false
 
 v24:
-	Defaults:
-		AddExtension: false
-	idle: v24.des
-	damaged-idle: v24.des
+	idle:
+		Filename: v24.des
+	damaged-idle:
+		Filename: v24.des
 		Start: 1
 
 v24.husk:
-	idle: v24.des
+	idle:
+		Filename: v24.des
 		Start: 2
-		AddExtension: false
 
 v25:
-	Defaults:
-		AddExtension: false
-	idle: v25.des
-	damaged-idle: v25.des
+	idle:
+		Filename: v25.des
+	damaged-idle:
+		Filename: v25.des
 		Start: 1
 
 v25.husk:
-	idle: v25.des
+	idle:
+		Filename: v25.des
 		Start: 2
-		AddExtension: false
 
 v26:
-	Defaults:
-		AddExtension: false
-	idle: v26.des
-	damaged-idle: v26.des
+	idle:
+		Filename: v26.des
+	damaged-idle:
+		Filename: v26.des
 		Start: 1
 
 v26.husk:
-	idle: v26.des
+	idle:
+		Filename: v26.des
 		Start: 2
-		AddExtension: false
 
 v27:
-	Defaults:
-		AddExtension: false
-	idle: v27.des
-	damaged-idle: v27.des
+	idle:
+		Filename: v27.des
+	damaged-idle:
+		Filename: v27.des
 		Start: 1
 
 v27.husk:
-	idle: v27.des
+	idle:
+		Filename: v27.des
 		Start: 2
-		AddExtension: false
 
 v28:
-	Defaults:
-		AddExtension: false
-	idle: v28.des
-	damaged-idle: v28.des
+	idle:
+		Filename: v28.des
+	damaged-idle:
+		Filename: v28.des
 		Start: 1
 
 v28.husk:
-	idle: v28.des
+	idle:
+		Filename: v28.des
 		Start: 2
-		AddExtension: false
 
 v29:
-	Defaults:
-		AddExtension: false
-	idle: v29.des
-	damaged-idle: v29.des
+	idle:
+		Filename: v29.des
+	damaged-idle:
+		Filename: v29.des
 		Start: 1
 
 v29.husk:
-	idle: v29.des
+	idle:
+		Filename: v29.des
 		Start: 2
-		AddExtension: false
 
 v30:
-	Defaults:
-		AddExtension: false
-	idle: v30.des
-	damaged-idle: v30.des
+	idle:
+		Filename: v30.des
+	damaged-idle:
+		Filename: v30.des
 		Start: 2
 
 v30.husk:
-	idle: v30.des
+	idle:
+		Filename: v30.des
 		Start: 2
-		AddExtension: false
 
 v31:
-	Defaults:
-		AddExtension: false
-	idle: v31.des
-	damaged-idle: v31.des
+	idle:
+		Filename: v31.des
+	damaged-idle:
+		Filename: v31.des
 		Start: 1
 
 v31.husk:
-	idle: v31.des
+	idle:
+		Filename: v31.des
 		Start: 2
-		AddExtension: false
 
 v32:
-	Defaults:
-		AddExtension: false
-	idle: v32.des
-	damaged-idle: v32.des
+	idle:
+		Filename: v32.des
+	damaged-idle:
+		Filename: v32.des
 		Start: 1
 
 v32.husk:
-	idle: v32.des
+	idle:
+		Filename: v32.des
 		Start: 2
-		AddExtension: false
 
 v33:
-	Defaults:
-		AddExtension: false
-	idle: v33.des
-	damaged-idle: v33.des
+	idle:
+		Filename: v33.des
+	damaged-idle:
+		Filename: v33.des
 		Start: 1
 
 v33.husk:
-	idle: v33.des
+	idle:
+		Filename: v33.des
 		Start: 2
-		AddExtension: false
 
 v34:
-	Defaults:
-		AddExtension: false
-	idle: v34.des
-	damaged-idle: v34.des
+	idle:
+		Filename: v34.des
+	damaged-idle:
+		Filename: v34.des
 		Start: 1
 
 v34.husk:
-	idle: v34.des
+	idle:
+		Filename: v34.des
 		Start: 2
-		AddExtension: false
 
 v35:
-	Defaults:
-		AddExtension: false
-	idle: v35.des
-	damaged-idle: v35.des
+	idle:
+		Filename: v35.des
+	damaged-idle:
+		Filename: v35.des
 		Start: 1
 
 v35.husk:
-	idle: v35.des
+	idle:
+		Filename: v35.des
 		Start: 2
-		AddExtension: false
 
 v36:
-	Defaults:
-		AddExtension: false
-	idle: v36.des
-	damaged-idle: v36.des
+	idle:
+		Filename: v36.des
+	damaged-idle:
+		Filename: v36.des
 		Start: 1
 
 v36.husk:
-	idle: v36.des
+	idle:
+		Filename: v36.des
 		Start: 2
-		AddExtension: false
 
 v37:
-	Defaults:
-		AddExtension: false
-	idle: v37.des
-	damaged-idle: v37.des
+	idle:
+		Filename: v37.des
+	damaged-idle:
+		Filename: v37.des
 		Start: 1
 
 v37.husk:
-	idle: v37.des
+	idle:
+		Filename: v37.des
 		Start: 2
-		AddExtension: false
 
 arco:
+	Defaults:
+		Filename: arco.shp
 	idle:
 	damaged-idle:
 		Start: 1
 
 arco.husk:
-	idle: arco
+	idle:
+		Filename: arco.shp
 		Start: 1

--- a/mods/cnc/sequences/funpark.yaml
+++ b/mods/cnc/sequences/funpark.yaml
@@ -1,4 +1,6 @@
 steg:
+	Defaults:
+		Filename: steg.shp
 	stand:
 		Facings: 8
 	stand2:
@@ -15,9 +17,12 @@ steg:
 	die:
 		Start: 176
 		Length: 22
-	icon: stegicnh
+	icon:
+		Filename: stegicnh.shp
 
 trex:
+	Defaults:
+		Filename: trex.shp
 	stand:
 		Facings: 8
 	stand2:
@@ -34,9 +39,12 @@ trex:
 	die:
 		Start: 144
 		Length: 40
-	icon: trexicnh
+	icon:
+		Filename: trexicnh.shp
 
 tric:
+	Defaults:
+		Filename: tric.shp
 	stand:
 		Facings: 8
 	stand2:
@@ -53,9 +61,12 @@ tric:
 	die:
 		Start: 176
 		Length: 20
-	icon: tricicnh
+	icon:
+		Filename: tricicnh.shp
 
 rapt:
+	Defaults:
+		Filename: rapt.shp
 	stand:
 		Facings: 8
 	stand2:
@@ -72,4 +83,5 @@ rapt:
 	die:
 		Start: 144
 		Length: 40
-	icon: rapticnh
+	icon:
+		Filename: rapticnh.shp

--- a/mods/cnc/sequences/infantry.yaml
+++ b/mods/cnc/sequences/infantry.yaml
@@ -1,43 +1,58 @@
 vice:
 	idle:
+		Filename: vice.shp
 		Length: *
 	muzzle:
 		Combine:
-			chem-n:
+			0:
+				Filename: chem-n.shp
 				Length: *
 				Offset: 1,2
-			chem-nw:
+			1:
+				Filename: chem-nw.shp
 				Length: *
 				Offset: 8,2
-			chem-w:
+			2:
+				Filename: chem-w.shp
 				Length: *
 				Offset: 8,-3
-			chem-sw:
+			3:
+				Filename: chem-sw.shp
 				Length: *
 				Offset: 7,-6
-			chem-s:
+			4:
+				Filename: chem-s.shp
 				Length: *
 				Offset: 1,-6
-			chem-se:
+			5:
+				Filename: chem-se.shp
 				Length: *
 				Offset: -5,-6
-			chem-e:
+			6:
+				Filename: chem-e.shp
 				Length: *
 				Offset: -7,-3
-			chem-ne:
+			7:
+				Filename: chem-ne.shp
 				Length: *
 				Offset: -3,2
 		Facings: 8
 		Length: 13
-	die: chemball
+	die:
+		Filename: chemball.shp
 		Length: *
 		ZOffset: 2047
-	icon: viceicnh
+	icon:
+		Filename: viceicnh.shp
 
 pvice:
+	Defaults:
+		Filename: pvice.shp
 	Inherits: vice
 
 e1:
+	Defaults:
+		Filename: e1.shp
 	stand:
 		Facings: 8
 	stand2:
@@ -131,15 +146,18 @@ e1:
 		Start: 366
 		Length: 11
 		Tick: 80
-	die-crushed: e1rot
+	die-crushed:
+		Filename: e1rot.shp
 		Start: 16
 		Length: 4
 		Tick: 1600
 		ZOffset: -511
-	icon: e1icnh.tem
-		AddExtension: False
+	icon:
+		Filename: e1icnh.tem
 
 e2:
+	Defaults:
+		Filename: e2.shp
 	stand:
 		Facings: 8
 	stand2:
@@ -224,15 +242,18 @@ e2:
 		Start: 494
 		Length: 11
 		Tick: 80
-	die-crushed: e2rot
+	die-crushed:
+		Filename: e2rot.shp
 		Start: 16
 		Length: 4
 		Tick: 1600
 		ZOffset: -511
-	icon: e2icnh.tem
-		AddExtension: False
+	icon:
+		Filename: e2icnh.tem
 
 e3:
+	Defaults:
+		Filename: e3.shp
 	stand:
 		Facings: 8
 	stand2:
@@ -317,15 +338,18 @@ e3:
 		Start: 382
 		Length: 11
 		Tick: 80
-	die-crushed: e3rot
+	die-crushed:
+		Filename: e3rot.shp
 		Start: 16
 		Length: 4
 		Tick: 1600
 		ZOffset: -511
-	icon: e3icnh.tem
-		AddExtension: False
+	icon:
+		Filename: e3icnh.tem
 
 e4:
+	Defaults:
+		Filename: e4.shp
 	stand:
 		Facings: 8
 	stand2:
@@ -410,43 +434,55 @@ e4:
 		Start: 494
 		Length: 10
 		Tick: 80
-	die-crushed: e4rot
+	die-crushed:
+		Filename: e4rot.shp
 		Start: 16
 		Length: 4
 		Tick: 1600
 		ZOffset: -511
 	muzzle:
+		Filename:
 		Combine:
-			flame-n:
+			0:
+				Filename: flame-n.shp
 				Length: *
 				Offset: 1,6
-			flame-nw:
+			1:
+				Filename: flame-nw.shp
 				Length: *
 				Offset: 8,7
-			flame-w:
+			2:
+				Filename: flame-w.shp
 				Length: *
 				Offset: 8,2
-			flame-sw:
+			3:
+				Filename: flame-sw.shp
 				Length: *
 				Offset: 7,-2
-			flame-s:
+			4:
+				Filename: flame-s.shp
 				Length: *
 				Offset: 1,-2
-			flame-se:
+			5:
+				Filename: flame-se.shp
 				Length: *
 				Offset: -5,-2
-			flame-e:
+			6:
+				Filename: flame-e.shp
 				Length: *
 				Offset: -7,2
-			flame-ne:
+			7:
+				Filename: flame-ne.shp
 				Length: *
 				Offset: -7,8
 		Facings: 8
 		Length: 13
-	icon: e4icnh.tem
-		AddExtension: False
+	icon:
+		Filename: e4icnh.tem
 
 e5:
+	Defaults:
+		Filename: e5.shp
 	stand:
 		Facings: 8
 	stand2:
@@ -531,43 +567,55 @@ e5:
 		Start: 494
 		Length: 10
 		Tick: 80
-	die-crushed: e4rot
+	die-crushed:
+		Filename: e4rot.shp
 		Start: 16
 		Length: 4
 		Tick: 1600
 		ZOffset: -511
 	muzzle:
+		Filename:
 		Combine:
-			chem-n:
+			0:
+				Filename: chem-n.shp
 				Length: *
 				Offset: 1,2
-			chem-nw:
+			1:
+				Filename: chem-nw.shp
 				Length: *
 				Offset: 8,2
-			chem-w:
+			2:
+				Filename: chem-w.shp
 				Length: *
 				Offset: 8,-3
-			chem-sw:
+			3:
+				Filename: chem-sw.shp
 				Length: *
 				Offset: 7,-6
-			chem-s:
+			4:
+				Filename: chem-s.shp
 				Length: *
 				Offset: 1,-6
-			chem-se:
+			5:
+				Filename: chem-se.shp
 				Length: *
 				Offset: -5,-6
-			chem-e:
+			6:
+				Filename: chem-e.shp
 				Length: *
 				Offset: -7,-3
-			chem-ne:
+			7:
+				Filename: chem-ne.shp
 				Length: *
 				Offset: -3,2
 		Facings: 8
 		Length: 13
-	icon: e5icnh.tem
-		AddExtension: False
+	icon:
+		Filename: e5icnh.tem
 
 e6:
+	Defaults:
+		Filename: e6.shp
 	stand:
 		Facings: 8
 	stand2:
@@ -644,15 +692,18 @@ e6:
 		Start: 130
 		Length: 4
 		Tick: 80
-	die-crushed: e1rot
+	die-crushed:
+		Filename: e1rot.shp
 		Start: 16
 		Length: 4
 		Tick: 1600
 		ZOffset: -511
-	icon: e6icnh.tem
-		AddExtension: False
+	icon:
+		Filename: e6icnh.tem
 
 rmbo:
+	Defaults:
+		Filename: rmbo.shp
 	stand:
 		Facings: 8
 	stand2:
@@ -741,10 +792,11 @@ rmbo:
 		Start: 308
 		Length: 4
 		Tick: 80
-	die-crushed: e1rot
+	die-crushed:
+		Filename: e1rot.shp
 		Start: 16
 		Length: 4
 		Tick: 1600
 		ZOffset: -511
-	icon: rmboicnh.tem
-		AddExtension: False
+	icon:
+		Filename: rmboicnh.tem

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -1,19 +1,24 @@
 fb4:
 	idle:
+		Filename: fb4.shp
 		Length: 4
 		ZOffset: 1023
 
 fire:
-	1: fire1
+	1:
+		Filename: fire1.shp
 		Length: *
 		Offset: 0,-3
 		ZOffset: 1023
-	2: fire2
+	2:
+		Filename: fire2.shp
 		Length: *
 		Offset: 0,-3
 		ZOffset: 1023
 
 burn-l:
+	Defaults:
+		Filename: burn-l.shp
 	idle:
 		Length: *
 		ZOffset: 512
@@ -27,6 +32,8 @@ burn-l:
 		ZOffset: 512
 
 burn-m:
+	Defaults:
+		Filename: burn-m.shp
 	idle:
 		Length: *
 		ZOffset: 512
@@ -40,6 +47,8 @@ burn-m:
 		ZOffset: 512
 
 burn-s:
+	Defaults:
+		Filename: burn-s.shp
 	idle:
 		Length: *
 		ZOffset: 512
@@ -54,9 +63,12 @@ burn-s:
 
 120mm:
 	idle:
+		Filename: 120mm.shp
 		ZOffset: 1023
 
 smoke_m:
+	Defaults:
+		Filename: smoke_m.shp
 	idle:
 		Length: *
 		Offset: 2, -5
@@ -73,32 +85,38 @@ smoke_m:
 		ZOffset: 512
 
 laserfire:
-	idle: veh-hit3
+	idle:
+		Filename: veh-hit3.shp
 		Length: *
 		ZOffset: 511
 
 dragon:
 	idle:
+		Filename: dragon.shp
 		Facings: 32
 		ZOffset: 1023
 
 smokey:
 	idle:
+		Filename: smokey.shp
 		Length: *
 		ZOffset: 1023
 
 bomb:
 	idle:
+		Filename: bomb.shp
 		Length: *
 		ZOffset: 1023
 
 missile:
 	idle:
+		Filename: missile.shp
 		Facings: 32
 		ZOffset: 1023
 
 patriot:
 	idle:
+		Filename: patriot.shp
 		Facings: 32
 		ZOffset: 1023
 
@@ -106,25 +124,41 @@ explosion:
 	Defaults:
 		Length: *
 		ZOffset: 2047
-	nuke_explosion: atomsfx
-	piff: piff
-	piffs: piffpiff
-	chemball: chemball
-	small_napalm: napalm1
-	med_napalm: napalm2
-	big_napalm: napalm3
-	small_frag: veh-hit3
-	med_frag: frag1
-	big_frag: frag3
-	small_poof: veh-hit2
-	poof: art-exp1
-	small_building: veh-hit1
-	building: fball1
-	building_napalm: napalm2
+	nuke_explosion:
+		Filename: atomsfx.shp
+	piff:
+		Filename: piff.shp
+	piffs:
+		Filename: piffpiff.shp
+	chemball:
+		Filename: chemball.shp
+	small_napalm:
+		Filename: napalm1.shp
+	med_napalm:
+		Filename: napalm2.shp
+	big_napalm:
+		Filename: napalm3.shp
+	small_frag:
+		Filename: veh-hit3.shp
+	med_frag:
+		Filename: frag1.shp
+	big_frag:
+		Filename: frag3.shp
+	small_poof:
+		Filename: veh-hit2.shp
+	poof:
+		Filename: art-exp1.shp
+	small_building:
+		Filename: veh-hit1.shp
+	building:
+		Filename: fball1.shp
+	building_napalm:
+		Filename: napalm2.shp
 		FlipX: true
 
 rank:
 	Defaults:
+		Filename: rank.shp
 		Offset: 0, 3
 	rank-veteran-1:
 	rank-veteran-2:
@@ -136,67 +170,82 @@ rank:
 		Offset: 1, 3
 
 rallypoint:
-	flag: flagfly
+	flag:
+		Filename: flagfly.shp
 		Length: *
 		Offset: 10,-5
 		ZOffset: 2535
-	circles: fpls
+	circles:
+		Filename: fpls.shp
 		Length: *
 		ZOffset: 2047
 
 beacon:
 	Defaults:
 		ZOffset: 2535
-	arrow: mouse2
+	arrow:
+		Filename: mouse2.shp
 		Start: 5
 		Offset: 1,-12
-	circles: fpls
+	circles:
+		Filename: fpls.shp
 		Length: *
 		ZOffset: 2047
-	airstrike: bombicon
+	airstrike:
+		Filename: bombicon.shp
 		Offset: 0,-42
-	atomic: atomicon
+	atomic:
+		Filename: atomicon.shp
 		Offset: 0,-42
-	clock: beaconclock
+	clock:
+		Filename: beaconclock.shp
 		Length: *
 		Offset: 0,-42
 
 select:
 	repair:
+		Filename: select.shp
 		Start: 2
 
 allyrepair:
 	repair:
+		Filename: allyrepair.shp
 		Length: *
 		Tick: 160
 		ZOffset: 2047
 
 scrate:
 	idle:
+		Filename: scrate.shp
 		Start: 1
 		ZOffset: -511
 
 wcrate:
 	idle:
+		Filename: wcrate.shp
 		Start: 1
 		ZOffset: -511
 
 xcratea:
-	idle: xcrate
+	idle:
+		Filename: xcrate.shp
 		ZOffset: -511
 
 xcrateb:
-	idle: xcrate
+	idle:
+		Filename: xcrate.shp
 		Start: 1
 		ZOffset: -511
 
 xcratec:
-	idle: xcrate
+	idle:
+		Filename: xcrate.shp
 		Start: 2
 		ZOffset: -511
 
 xcrated:
-	idle: xcrate
+	idle:
+		Filename: xcrate.shp
 		Start: 3
 		ZOffset: -511
 
@@ -204,56 +253,79 @@ crate-effects:
 	Defaults:
 		Length: *
 		ZOffset: 2047
-	airstrike: deviator
-	nuke: missile2
-	dollar: dollar
-	reveal-map: radarcrate
-	hide-map: empulse
-	heal: healcrate
-	mine: mine
-	redskull: rapid
-	cloak: cloakcrate
-	levelup: levelup
+	airstrike:
+		Filename: deviator.shp
+	nuke:
+		Filename: missile2.shp
+	dollar:
+		Filename: dollar.shp
+	reveal-map:
+		Filename: radarcrate.shp
+	hide-map:
+		Filename: empulse.shp
+	heal:
+		Filename: healcrate.shp
+	mine:
+		Filename: mine.shp
+	redskull:
+		Filename: rapid.shp
+	cloak:
+		Filename: cloakcrate.shp
+	levelup:
+		Filename: levelup.shp
 		Tick: 200
-	firepowerup: firepowercrate
-	armorup: armorcrate
-	speedup: speedcrate
+	firepowerup:
+		Filename: firepowercrate.shp
+	armorup:
+		Filename: armorcrate.shp
+	speedup:
+		Filename: speedcrate.shp
 
 atomic:
 	Defaults:
 		Length: *
 		ZOffset: 1023
-	up: atomicup
-	down: atomicdn
+	up:
+		Filename: atomicup.shp
+	down:
+		Filename: atomicdn.shp
 
 ionsfx:
 	idle:
+		Filename: ionsfx.shp
 		Length: *
 		Offset: 0, -78
 		ZOffset: 1023
 
 bomblet:
 	idle:
+		Filename: bomblet.shp
 		Length: *
 		ZOffset: 1023
 
 mpspawn:
 	idle:
+		Filename: mpspawn.shp
 		Length: *
 
 waypoint:
 	idle:
+		Filename: waypoint.shp
 		Length: *
 
 camera:
 	idle:
+		Filename: camera.shp
 		Length: *
 
 clock:
-	idle: hclock
+	idle:
+		Filename: hclock.shp
 		Length: *
 
 pips:
+	Defaults:
+		Filename: pips.shp
 	pip-empty:
 	pip-green:
 		Start: 1
@@ -265,18 +337,21 @@ pips:
 		Start: 4
 	pip-blue:
 		Start: 5
-	pip-heal: pip-heal
+	pip-heal:
+		Filename: pip-heal.shp
 		Offset: -1, 1
-	groups: pdigits
+	groups:
+		Filename: pdigits.shp
 		Length: *
 		Offset: 9, 5
 		Frames: 1, 2, 3, 4, 5, 6, 7, 8, 9, 0
-	pip-hazmat: pip-hazmat
+	pip-hazmat:
+		Filename: pip-hazmat.shp
 		Offset: -3, 0
 
 overlay:
-	Defaults: trans.icn
-		AddExtension: False
+	Defaults:
+		Filename: trans.icn
 	build-valid:
 	build-invalid:
 		Start: 2
@@ -287,146 +362,285 @@ overlay:
 		Start: 2
 
 editor-overlay:
-	Defaults: trans.icn
-		AddExtension: False
+	Defaults:
+		Filename: trans.icn
 	copy:
 	paste:
 		Start: 2
 
 poweroff:
 	offline:
+		Filename: poweroff.shp
 		Length: *
 		Tick: 160
 		ZOffset: 2047
 
 icon:
-	Defaults:
-		AddExtension: False
-	airstrike: bombicnh.tem
-	ioncannon: ionicnh.tem
-	abomb: atomicnh.tem
+	airstrike:
+		Filename: bombicnh.tem
+	ioncannon:
+		Filename: ionicnh.tem
+	abomb:
+		Filename: atomicnh.tem
 
 moveflsh:
 	idle:
+		Filename: moveflsh.shp
 		Length: *
 		Tick: 80
 		ZOffset: 2047
 
 resources:
 	Defaults:
-		UseTilesetExtension: true
 		Length: *
-	ti1: ti1
-	ti2: ti2
-	ti3: ti3
-	ti4: ti4
-	ti5: ti5
-	ti6: ti6
-	ti7: ti7
-	ti8: ti8
-	ti9: ti9
-	ti10: ti10
-	ti11: ti11
-	ti12: ti12
-	bti1: rtib1
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
-	bti2: rtib2
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
-	bti3: rtib3
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
-	bti4: rtib4
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
-	bti5: rtib5
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
-	bti6: rtib6
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
-	bti7: rtib7
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
-	bti8: rtib8
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
-	bti9: rtib9
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
-	bti10: rtib10
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
-	bti11: rtib11
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
-	bti12: rtib12
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
+	ti1:
+		TilesetFilenames:
+			DESERT: ti1.des
+			WINTER: ti1.win
+			SNOW: ti1.sno
+			TEMPERAT: ti1.tem
+			JUNGLE: ti1.jun
+	ti2:
+		TilesetFilenames:
+			DESERT: ti2.des
+			WINTER: ti2.win
+			SNOW: ti2.sno
+			TEMPERAT: ti2.tem
+			JUNGLE: ti2.jun
+	ti3:
+		TilesetFilenames:
+			DESERT: ti3.des
+			WINTER: ti3.win
+			SNOW: ti3.sno
+			TEMPERAT: ti3.tem
+			JUNGLE: ti3.jun
+	ti4:
+		TilesetFilenames:
+			DESERT: ti4.des
+			WINTER: ti4.win
+			SNOW: ti4.sno
+			TEMPERAT: ti4.tem
+			JUNGLE: ti4.jun
+	ti5:
+		TilesetFilenames:
+			DESERT: ti5.des
+			WINTER: ti5.win
+			SNOW: ti5.sno
+			TEMPERAT: ti5.tem
+			JUNGLE: ti5.jun
+	ti6:
+		TilesetFilenames:
+			DESERT: ti6.des
+			WINTER: ti6.win
+			SNOW: ti6.sno
+			TEMPERAT: ti6.tem
+			JUNGLE: ti6.jun
+	ti7:
+		TilesetFilenames:
+			DESERT: ti7.des
+			WINTER: ti7.win
+			SNOW: ti7.sno
+			TEMPERAT: ti7.tem
+			JUNGLE: ti7.jun
+	ti8:
+		TilesetFilenames:
+			DESERT: ti8.des
+			WINTER: ti8.win
+			SNOW: ti8.sno
+			TEMPERAT: ti8.tem
+			JUNGLE: ti8.jun
+	ti9:
+		TilesetFilenames:
+			DESERT: ti9.des
+			WINTER: ti9.win
+			SNOW: ti9.sno
+			TEMPERAT: ti9.tem
+			JUNGLE: ti9.jun
+	ti10:
+		TilesetFilenames:
+			DESERT: ti10.des
+			WINTER: ti10.win
+			SNOW: ti10.sno
+			TEMPERAT: ti10.tem
+			JUNGLE: ti10.jun
+	ti11:
+		TilesetFilenames:
+			DESERT: ti11.des
+			WINTER: ti11.win
+			SNOW: ti11.sno
+			TEMPERAT: ti11.tem
+			JUNGLE: ti11.jun
+	ti12:
+		TilesetFilenames:
+			DESERT: ti12.des
+			WINTER: ti12.win
+			SNOW: ti12.sno
+			TEMPERAT: ti12.tem
+			JUNGLE: ti12.jun
+	bti1:
+		Filename: rtib1.tem
+		TilesetFilenames:
+			DESERT: rtib1.des
+	bti2:
+		Filename: rtib2.tem
+		TilesetFilenames:
+			DESERT: rtib2.des
+	bti3:
+		Filename: rtib3.tem
+		TilesetFilenames:
+			DESERT: rtib3.des
+	bti4:
+		Filename: rtib4.tem
+		TilesetFilenames:
+			DESERT: rtib4.des
+	bti5:
+		Filename: rtib5.tem
+		TilesetFilenames:
+			DESERT: rtib5.des
+	bti6:
+		Filename: rtib6.tem
+		TilesetFilenames:
+			DESERT: rtib6.des
+	bti7:
+		Filename: rtib7.tem
+		TilesetFilenames:
+			DESERT: rtib7.des
+	bti8:
+		Filename: rtib8.tem
+		TilesetFilenames:
+			DESERT: rtib8.des
+	bti9:
+		Filename: rtib9.tem
+		TilesetFilenames:
+			DESERT: rtib9.des
+	bti10:
+		Filename: rtib10.tem
+		TilesetFilenames:
+			DESERT: rtib10.des
+	bti11:
+		Filename: rtib11.tem
+		TilesetFilenames:
+			DESERT: rtib11.des
+	bti12:
+		Filename: rtib12.tem
+		TilesetFilenames:
+			DESERT: rtib12.des
 
 shroud:
 	Defaults:
 		Length: 12
-	typea: shadow
-	typeb: shadow
+	typea:
+		Filename: shadow.shp
+	typeb:
+		Filename: shadow.shp
 		Start: 12
-	typec: shadow
+	typec:
+		Filename: shadow.shp
 		Start: 24
-	typed: shadow
+	typed:
+		Filename: shadow.shp
 		Start: 36
-	full: fullshroud
+	full:
+		Filename: fullshroud.shp
 		Length: 1
 
 # Note: The order of smudges and craters determines
 # the index that is mapped to them in maps
 scorches:
 	Defaults:
-		UseTilesetExtension: true
 		Length: *
-	sc1: sc1
-	sc2: sc2
-	sc3: sc3
-	sc4: sc4
-	sc5: sc5
-	sc6: sc6
+	sc1:
+		TilesetFilenames:
+			DESERT: sc1.des
+			WINTER: sc1.win
+			SNOW: sc1.sno
+			TEMPERAT: sc1.tem
+			JUNGLE: sc1.jun
+	sc2:
+		TilesetFilenames:
+			DESERT: sc2.des
+			WINTER: sc2.win
+			SNOW: sc2.sno
+			TEMPERAT: sc2.tem
+			JUNGLE: sc2.jun
+	sc3:
+		TilesetFilenames:
+			DESERT: sc3.des
+			WINTER: sc3.win
+			SNOW: sc3.sno
+			TEMPERAT: sc3.tem
+			JUNGLE: sc3.jun
+	sc4:
+		TilesetFilenames:
+			DESERT: sc4.des
+			WINTER: sc4.win
+			SNOW: sc4.sno
+			TEMPERAT: sc4.tem
+			JUNGLE: sc4.jun
+	sc5:
+		TilesetFilenames:
+			DESERT: sc5.des
+			WINTER: sc5.win
+			SNOW: sc5.sno
+			TEMPERAT: sc5.tem
+			JUNGLE: sc5.jun
+	sc6:
+		TilesetFilenames:
+			DESERT: sc6.des
+			WINTER: sc6.win
+			SNOW: sc6.sno
+			TEMPERAT: sc6.tem
+			JUNGLE: sc6.jun
 
 craters:
 	Defaults:
-		UseTilesetExtension: true
 		Length: *
-	cr1: cr1
-	cr2: cr2
-	cr3: cr3
-	cr4: cr4
-	cr5: cr5
-	cr6: cr6
+	cr1:
+		TilesetFilenames:
+			DESERT: cr1.des
+			WINTER: cr1.win
+			SNOW: cr1.sno
+			TEMPERAT: cr1.tem
+			JUNGLE: cr1.jun
+	cr2:
+		TilesetFilenames:
+			DESERT: cr2.des
+			WINTER: cr2.win
+			SNOW: cr2.sno
+			TEMPERAT: cr2.tem
+			JUNGLE: cr2.jun
+	cr3:
+		TilesetFilenames:
+			DESERT: cr3.des
+			WINTER: cr3.win
+			SNOW: cr3.sno
+			TEMPERAT: cr3.tem
+			JUNGLE: cr3.jun
+	cr4:
+		TilesetFilenames:
+			DESERT: cr4.des
+			WINTER: cr4.win
+			SNOW: cr4.sno
+			TEMPERAT: cr4.tem
+			JUNGLE: cr4.jun
+	cr5:
+		TilesetFilenames:
+			DESERT: cr5.des
+			WINTER: cr5.win
+			SNOW: cr5.sno
+			TEMPERAT: cr5.tem
+			JUNGLE: cr5.jun
+	cr6:
+		TilesetFilenames:
+			DESERT: cr6.des
+			WINTER: cr6.win
+			SNOW: cr6.sno
+			TEMPERAT: cr6.tem
+			JUNGLE: cr6.jun
 
 smokland:
+	Defaults:
+		Filename: smokland.shp
 	open:
 		Length: 72
 		Tick: 120
@@ -438,27 +652,35 @@ smokland:
 		ZOffset: 1023
 
 airstrikedirection:
-	arrow-t: mouse2
+	arrow-t:
+		Filename: mouse2.shp
 		Start: 1
 		Offset: 0, -15, 0
-	arrow-tr: mouse2
+	arrow-tr:
+		Filename: mouse2.shp
 		Start: 2
 		Offset: 7, -7, 0
-	arrow-r: mouse2
+	arrow-r:
+		Filename: mouse2.shp
 		Start: 3
 		Offset: 12, 0, 0
-	arrow-br: mouse2
+	arrow-br:
+		Filename: mouse2.shp
 		Start: 4
 		Offset: 7, 7, 0
-	arrow-b: mouse2
+	arrow-b:
+		Filename: mouse2.shp
 		Start: 5
 		Offset: 0, 15, 0
-	arrow-bl: mouse2
+	arrow-bl:
+		Filename: mouse2.shp
 		Start: 6
 		Offset: -7, 7, 0
-	arrow-l: mouse2
+	arrow-l:
+		Filename: mouse2.shp
 		Start: 7
 		Offset: -12, 0, 0
-	arrow-tl: mouse2
+	arrow-tl:
+		Filename: mouse2.shp
 		Start: 8
 		Offset: -7, -7, 0

--- a/mods/cnc/sequences/structures.yaml
+++ b/mods/cnc/sequences/structures.yaml
@@ -1,4 +1,6 @@
 fact:
+	Defaults:
+		Filename: fact.shp
 	build:
 		Start: 4
 		Length: 20
@@ -17,15 +19,24 @@ fact:
 	dead:
 		Start: 48
 		Tick: 800
-	make: factmake
+	make:
+		Filename: factmake.shp
 		Length: *
 		Tick: 80
-	bib: bib2
-		UseTilesetExtension: true
+	bib:
+		TilesetFilenames:
+			DESERT: bib2.des
+			WINTER: bib2.win
+			SNOW: bib2.sno
+			TEMPERAT: bib2.tem
+			JUNGLE: bib2.jun
 		Length: *
-	icon: facticnh
+	icon:
+		Filename: facticnh.shp
 
 nuke:
+	Defaults:
+		Filename: nuke.shp
 	idle:
 		Length: 4
 		Tick: 1000
@@ -36,16 +47,24 @@ nuke:
 	dead:
 		Start: 8
 		Tick: 800
-	make: nukemake
+	make:
+		Filename: nukemake.shp
 		Length: *
 		Tick: 80
-	bib: bib3
-		UseTilesetExtension: true
+	bib:
+		TilesetFilenames:
+			DESERT: bib3.des
+			WINTER: bib3.win
+			SNOW: bib3.sno
+			TEMPERAT: bib3.tem
+			JUNGLE: bib3.jun
 		Length: *
-	icon: nukeicnh.tem
-		AddExtension: False
+	icon:
+		Filename: nukeicnh.tem
 
 proc:
+	Defaults:
+		Filename: proc.shp
 	idle:
 		Length: 6
 		Tick: 120
@@ -59,24 +78,34 @@ proc:
 		Start: 60
 		Tick: 800
 		Offset: 2,4
-	make: procmake
+	make:
+		Filename: procmake.shp
 		Length: *
 		Tick: 80
 		Offset: 2,4
-	resources: proctwr
+	resources:
+		Filename: proctwr.shp
 		Length: 6
 		Offset: -30,-17
-	damaged-resources: proctwr
+	damaged-resources:
+		Filename: proctwr.shp
 		Start: 6
 		Length: 6
 		Offset: -30,-17
-	bib: bib2
-		UseTilesetExtension: true
+	bib:
+		TilesetFilenames:
+			DESERT: bib2.des
+			WINTER: bib2.win
+			SNOW: bib2.sno
+			TEMPERAT: bib2.tem
+			JUNGLE: bib2.jun
 		Length: *
-	icon: procicnh.tem
-		AddExtension: False
+	icon:
+		Filename: procicnh.tem
 
 silo:
+	Defaults:
+		Filename: silo.shp
 	idle:
 		Offset: 0,-1
 	damaged-idle:
@@ -93,23 +122,23 @@ silo:
 		Start: 5
 		Length: 5
 		Offset: 0,-1
-	make: silomake
+	make:
+		Filename: silomake.shp
 		Length: *
 		Tick: 80
 		Offset: 0,-1
-	bib: mbSILO
-		UseTilesetExtension: true
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
+	bib:
+		Filename: mbSILO.tem
+		TilesetFilenames:
+			DESERT: mbSILO.des
 		Length: *
 		Offset: 0,1
-	icon: siloicnh.tem
-		AddExtension: False
+	icon:
+		Filename: siloicnh.tem
 
 hand:
 	Defaults:
+		Filename: hand.shp
 		Offset: 0,-8
 	idle:
 	damaged-idle:
@@ -117,18 +146,26 @@ hand:
 	dead:
 		Start: 2
 		Tick: 800
-	make: handmake
+	make:
+		Filename: handmake.shp
 		Length: *
 		Tick: 80
-	bib: bib3
-		UseTilesetExtension: true
+	bib:
+		TilesetFilenames:
+			DESERT: bib3.des
+			WINTER: bib3.win
+			SNOW: bib3.sno
+			TEMPERAT: bib3.tem
+			JUNGLE: bib3.jun
 		Length: *
 		Offset: 0,0
-	icon: handicnh.tem
-		AddExtension: False
+	icon:
+		Filename: handicnh.tem
 		Offset: 0,0
 
 pyle:
+	Defaults:
+		Filename: pyle.shp
 	idle:
 		Length: 10
 		Tick: 100
@@ -141,17 +178,24 @@ pyle:
 	dead:
 		Start: 20
 		Tick: 800
-	make: pylemake
+	make:
+		Filename: pylemake.shp
 		Length: *
 		Tick: 80
-	bib: bib3
-		UseTilesetExtension: true
+	bib:
+		TilesetFilenames:
+			DESERT: bib3.des
+			WINTER: bib3.win
+			SNOW: bib3.sno
+			TEMPERAT: bib3.tem
+			JUNGLE: bib3.jun
 		Length: *
-	icon: pyleicnh.tem
-		AddExtension: False
+	icon:
+		Filename: pyleicnh.tem
 
 weap:
 	Defaults:
+		Filename: weap.shp
 		Offset: 0,-12
 	idle:
 		ZOffset: -511
@@ -161,27 +205,38 @@ weap:
 	dead:
 		Start: 2
 		Tick: 800
-	build-top: weap2
+	build-top:
+		Filename: weap2.shp
 		Length: 10
 		ZOffset: -1024
-	damaged-build-top: weap2
+	damaged-build-top:
+		Filename: weap2.shp
 		Start: 10
 		Length: 10
 		ZOffset: -1024
-	place: weapmake
+	place:
+		Filename: weapmake.shp
 		Start: 19
-	make: weapmake
+	make:
+		Filename: weapmake.shp
 		Length: *
 		Tick: 80
-	bib: bib2
-		UseTilesetExtension: true
+	bib:
+		TilesetFilenames:
+			DESERT: bib2.des
+			WINTER: bib2.win
+			SNOW: bib2.sno
+			TEMPERAT: bib2.tem
+			JUNGLE: bib2.jun
 		Length: *
 		Offset: 0,0
-	icon: weapicnh.tem
-		AddExtension: False
+	icon:
+		Filename: weapicnh.tem
 		Offset: 0,0
 
 afld:
+	Defaults:
+		Filename: afld.shp
 	idle:
 		Tick: 120
 		ZOffset: -1023
@@ -198,10 +253,12 @@ afld:
 		Length: 16
 		Tick: 120
 		ZOffset: -1023
-	idle-dish: afld_d
+	idle-dish:
+		Filename: afld_d.shp
 		Length: 16
 		Tick: 160
-	damaged-idle-dish: afld_d
+	damaged-idle-dish:
+		Filename: afld_d.shp
 		Start: 16
 		Length: 16
 		Tick: 160
@@ -209,16 +266,24 @@ afld:
 		Start: 32
 		ZOffset: -1023
 		Tick: 800
-	make: afldmake
+	make:
+		Filename: afldmake.shp
 		Length: *
 		Tick: 80
-	bib: bib1
-		UseTilesetExtension: true
+	bib:
+		TilesetFilenames:
+			DESERT: bib1.des
+			WINTER: bib1.win
+			SNOW: bib1.sno
+			TEMPERAT: bib1.tem
+			JUNGLE: bib1.jun
 		Length: *
-	icon: afldicnh.tem
-		AddExtension: False
+	icon:
+		Filename: afldicnh.tem
 
 hq:
+	Defaults:
+		Filename: hq.shp
 	idle:
 		Length: 16
 		Tick: 100
@@ -229,16 +294,24 @@ hq:
 	dead:
 		Start: 32
 		Tick: 800
-	make: hqmake
+	make:
+		Filename: hqmake.shp
 		Length: *
 		Tick: 80
-	bib: bib3
-		UseTilesetExtension: true
+	bib:
+		TilesetFilenames:
+			DESERT: bib3.des
+			WINTER: bib3.win
+			SNOW: bib3.sno
+			TEMPERAT: bib3.tem
+			JUNGLE: bib3.jun
 		Length: *
-	icon: hqicnh.tem
-		AddExtension: False
+	icon:
+		Filename: hqicnh.tem
 
 nuk2:
+	Defaults:
+		Filename: nuk2.shp
 	idle:
 		Length: 4
 		Tick: 1000
@@ -249,16 +322,24 @@ nuk2:
 	dead:
 		Start: 8
 		Tick: 800
-	make: nuk2make
+	make:
+		Filename: nuk2make.shp
 		Length: *
 		Tick: 80
-	bib: bib3
-		UseTilesetExtension: true
+	bib:
+		TilesetFilenames:
+			DESERT: bib3.des
+			WINTER: bib3.win
+			SNOW: bib3.sno
+			TEMPERAT: bib3.tem
+			JUNGLE: bib3.jun
 		Length: *
-	icon: nuk2icnh.tem
-		AddExtension: False
+	icon:
+		Filename: nuk2icnh.tem
 
 hpad:
+	Defaults:
+		Filename: hpad.shp
 	idle:
 		ZOffset: -1023
 	damaged-idle:
@@ -278,13 +359,16 @@ hpad:
 		Start: 14
 		ZOffset: -1023
 		Tick: 800
-	make: hpadmake
+	make:
+		Filename: hpadmake.shp
 		Length: *
 		Tick: 80
-	icon: hpadicnh.tem
-		AddExtension: False
+	icon:
+		Filename: hpadicnh.tem
 
 fix:
+	Defaults:
+		Filename: fix.shp
 	idle:
 		ZOffset: -1c511
 	damaged-idle:
@@ -301,21 +385,22 @@ fix:
 		Start: 14
 		ZOffset: -1c511
 		Tick: 800
-	make: fixmake
+	make:
+		Filename: fixmake.shp
 		Length: 14
 		Tick: 60
-	bib: mbFIX
-		UseTilesetExtension: true
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
+	bib:
+		Filename: mbFIX.tem
+		TilesetFilenames:
+			DESERT: mbFIX.des
 		Length: *
 		Offset: 0,-9
-	icon: fixicnh.tem
-		AddExtension: False
+	icon:
+		Filename: fixicnh.tem
 
 eye:
+	Defaults:
+		Filename: eye.shp
 	idle:
 		Length: 16
 		Tick: 100
@@ -326,17 +411,24 @@ eye:
 	dead:
 		Start: 32
 		Tick: 800
-	make: eyemake
+	make:
+		Filename: eyemake.shp
 		Length: *
 		Tick: 80
-	bib: bib3
-		UseTilesetExtension: true
+	bib:
+		TilesetFilenames:
+			DESERT: bib3.des
+			WINTER: bib3.win
+			SNOW: bib3.sno
+			TEMPERAT: bib3.tem
+			JUNGLE: bib3.jun
 		Length: *
-	icon: eyeicnh.tem
-		AddExtension: False
+	icon:
+		Filename: eyeicnh.tem
 
 tmpl:
 	Defaults:
+		Filename: tmpl.shp
 		Offset: 0,-12
 	idle:
 	damaged-idle:
@@ -344,7 +436,8 @@ tmpl:
 	active:
 		Length: 5
 		Tick: 200
-	smoke: atomdoor
+	smoke:
+		Filename: atomdoor.shp
 		Length: *
 		Offset: -1,-47
 	damaged-active:
@@ -353,19 +446,26 @@ tmpl:
 	dead:
 		Start: 10
 		Tick: 800
-	make: tmplmake
+	make:
+		Filename: tmplmake.shp
 		Length: *
 		Tick: 60
-	bib: bib2
-		UseTilesetExtension: true
+	bib:
+		TilesetFilenames:
+			DESERT: bib2.des
+			WINTER: bib2.win
+			SNOW: bib2.sno
+			TEMPERAT: bib2.tem
+			JUNGLE: bib2.jun
 		Length: *
 		Offset: 0,0
-	icon: tmplicnh.tem
-		AddExtension: False
+	icon:
+		Filename: tmplicnh.tem
 		Offset: 0,0
 
 obli:
 	Defaults:
+		Filename: obli.shp
 		Offset: 0,-12
 	idle:
 	damaged-idle:
@@ -380,22 +480,23 @@ obli:
 	dead:
 		Start: 8
 		Tick: 800
-	make: oblimake
+	make:
+		Filename: oblimake.shp
 		Length: 13
 		Tick: 80
-	bib: mbOBLI
-		UseTilesetExtension: true
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
+	bib:
+		Filename: mbOBLI.tem
+		TilesetFilenames:
+			DESERT: mbOBLI.des
 		Length: *
 		Offset: -1,-3
-	icon: obliicnh.tem
-		AddExtension: False
+	icon:
+		Filename: obliicnh.tem
 		Offset: 0,0
 
 brik:
+	Defaults:
+		Filename: brik.shp
 	idle:
 		Length: 16
 	scratched-idle:
@@ -404,25 +505,30 @@ brik:
 	damaged-idle:
 		Start: 32
 		Length: 16
-	icon: brikicnh.tem
-		AddExtension: False
+	icon:
+		Filename: brikicnh.tem
 
 sbag:
 	idle:
+		Filename: sbag.shp
 		Length: 16
-	icon: sbagicnh.tem
-		AddExtension: False
+	icon:
+		Filename: sbagicnh.tem
 
 cycl:
+	Defaults:
+		Filename: cycl.shp
 	idle:
 		Length: 16
 	damaged-idle:
 		Start: 16
 		Length: 16
-	icon: cyclicnh.tem
-		AddExtension: False
+	icon:
+		Filename: cyclicnh.tem
 
 barb:
+	Defaults:
+		Filename: barb.shp
 	idle:
 		Length: 16
 	damaged-idle:
@@ -430,6 +536,8 @@ barb:
 		Length: 16
 
 wood:
+	Defaults:
+		Filename: wood.shp
 	idle:
 		Length: 16
 	damaged-idle:
@@ -437,7 +545,10 @@ wood:
 		Length: 16
 
 gun:
-	idle: gunmake # Empty first frame. We need WithSpriteBody for the make anim, and WSB needs at least a placeholder default sequence to work
+	Defaults:
+		Filename: gun.shp
+	idle: # Empty first frame. We need WithSpriteBody for the make anim, and WSB needs at least a placeholder default sequence to work
+		Filename: gunmake.shp
 	turret:
 		Facings: 32
 		UseClassicFacings: True
@@ -453,23 +564,25 @@ gun:
 		Start: 96
 		Facings: 32
 		UseClassicFacings: True
-	make: gunmake
+	make:
+		Filename: gunmake.shp
 		Length: *
 		Tick: 80
-	muzzle: gunfire2
+	muzzle:
+		Filename: gunfire2.shp
 		Length: *
-	bib: mbGUN
-		UseTilesetExtension: true
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
+	bib:
+		Filename: mbGUN.tem
+		TilesetFilenames:
+			DESERT: mbGUN.des
 		Length: *
 		Offset: -1,-1
-	icon: gunicnh.tem
-		AddExtension: False
+	icon:
+		Filename: gunicnh.tem
 
 sam:
+	Defaults:
+		Filename: sam.shp
 	closed-idle:
 		Start: 0
 	opening:
@@ -503,16 +616,20 @@ sam:
 		Tick: 800
 	place:
 		Start: 0
-	make: sammake
+	make:
+		Filename: sammake.shp
 		Length: 20
 		Tick: 50
-	muzzle: samfire
+	muzzle:
+		Filename: samfire.shp
 		Length: 18
 		Facings: 8
-	icon: samicnh.tem
-		AddExtension: False
+	icon:
+		Filename: samicnh.tem
 
 gtwr:
+	Defaults:
+		Filename: gtwr.shp
 	idle:
 	damaged-idle:
 		Start: 1
@@ -520,29 +637,32 @@ gtwr:
 		Start: 2
 		Tick: 800
 	make:
+		Filename:
 		Combine:
-			gtwrmake:
+			0:
+				Filename: gtwrmake.shp
 				Length: 17
-			gtwrmake:
+			1:
+				Filename: gtwrmake.shp
 				Start: 19
 		Length: 18
 		Tick: 80
-	muzzle: minigun
+	muzzle:
+		Filename: minigun.shp
 		Length: 6
 		Facings: 8
-	bib: mbGTWR
-		UseTilesetExtension: true
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
+	bib:
+		Filename: mbGTWR.tem
+		TilesetFilenames:
+			DESERT: mbGTWR.des
 		Length: *
 		Offset: 0,-2
-	icon: gtwricnh.tem
-		AddExtension: False
+	icon:
+		Filename: gtwricnh.tem
 
 atwr:
 	Defaults:
+		Filename: atwr.shp
 		Offset: 0,-13
 	idle:
 	damaged-idle:
@@ -550,24 +670,26 @@ atwr:
 	dead:
 		Start: 2
 		Tick: 800
-	make: atwrmake
+	make:
+		Filename: atwrmake.shp
 		Length: *
 		Tick: 80
-	muzzle: gunfire2
+	muzzle:
+		Filename: gunfire2.shp
 		Length: *
-	bib: mbGTWR
-		UseTilesetExtension: true
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
+	bib:
+		Filename: mbGTWR.tem
+		TilesetFilenames:
+			DESERT: mbGTWR.des
 		Length: *
 		Offset: -3,0
-	icon: atwricnh.tem
-		AddExtension: False
+	icon:
+		Filename: atwricnh.tem
 		Offset: 0,0
 
 hosp:
+	Defaults:
+		Filename: hosp.shp
 	idle:
 		Length: 4
 		Tick: 100
@@ -576,71 +698,74 @@ hosp:
 		Start: 4
 		Length: 4
 		Offset: 0,-2
-	make: hospmake
+	make:
+		Filename: hospmake.shp
 		Length: *
 		Tick: 80
 		Offset: 0,-2
-	bib: mbHOSP
-		UseTilesetExtension: true
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
+	bib:
+		Filename: mbHOSP.tem
+		TilesetFilenames:
+			DESERT: mbHOSP.des
 		Length: *
 		Offset: 0,1
 
 hosp.husk:
-	idle: hosp
+	idle:
+		Filename: hosp.shp
 		Start: 8
-	bib: mbHOSP
-		UseTilesetExtension: true
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
+	bib:
+		Filename: mbHOSP.tem
+		TilesetFilenames:
+			DESERT: mbHOSP.des
 		Length: *
 		Offset: 0,1
 
 bio:
+	Defaults:
+		Filename: bio.shp
 	idle:
 	damaged-idle:
 		Start: 1
-	make: biomake
+	make:
+		Filename: biomake.shp
 		Length: *
 		Tick: 80
 
 bio.husk:
-	idle: bio
+	idle:
+		Filename: bio.shp
 		Start: 2
 
 miss:
+	Defaults:
+		Filename: miss.shp
 	idle:
 		Offset: 0,-1
 	damaged-idle:
 		Start: 1
 		Offset: 0,-1
-	make: missmake
+	make:
+		Filename: missmake.shp
 		Length: *
 		Tick: 80
 		Offset: 0,-1
-	bib: mbMISS
-		UseTilesetExtension: true
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
+	bib:
+		Filename: mbMISS.tem
+		TilesetFilenames:
+			DESERT: mbMISS.des
 		Length: *
 		Offset: 0,1
-	icon: missicnh
+	icon:
+		Filename: missicnh.shp
 
 miss.husk:
-	idle: miss
+	idle:
+		Filename: miss.shp
 		Start: 2
-	bib: mbMISS
-		UseTilesetExtension: true
-		TilesetOverrides:
-			WINTER: TEMPERAT
-			JUNGLE: TEMPERAT
-			SNOW: TEMPERAT
+	bib:
+		Filename: mbMISS.tem
+		TilesetFilenames:
+			DESERT: mbMISS.des
 		Length: *
 		Offset: 0,1

--- a/mods/cnc/sequences/vehicles.yaml
+++ b/mods/cnc/sequences/vehicles.yaml
@@ -1,17 +1,21 @@
 mcv:
 	idle:
+		Filename: mcv.shp
 		Facings: 32
 		UseClassicFacings: True
-	icon: mcvicnh.tem
-		AddExtension: False
+	icon:
+		Filename: mcvicnh.tem
 
 mcv.destroyed:
-	idle: mcv
+	idle:
+		Filename: mcv.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
 
 harv:
+	Defaults:
+		Filename: harv.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
@@ -20,20 +24,25 @@ harv:
 		Length: 4
 		Facings: 8
 		Tick: 60
-	dock: harvdump
+	dock:
+		Filename: harvdump.shp
 		Length: 7
-	dock-loop: harvdump
+	dock-loop:
+		Filename: harvdump.shp
 		Start: 7
-	icon: harvicnh.tem
-		AddExtension: False
+	icon:
+		Filename: harvicnh.tem
 
 harv.destroyed:
-	idle: harv
+	idle:
+		Filename: harv.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
 
 bggy:
+	Defaults:
+		Filename: bggy.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
@@ -41,24 +50,29 @@ bggy:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
-	muzzle: minigun
+	muzzle:
+		Filename: minigun.shp
 		Length: 6
 		Facings: 8
-	icon: bggyicnh.tem
-		AddExtension: False
+	icon:
+		Filename: bggyicnh.tem
 
 bggy.destroyed:
-	idle: bggy
+	idle:
+		Filename: bggy.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
-	turret: bggy
+	turret:
+		Filename: bggy.shp
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
 
 mtnk:
+	Defaults:
+		Filename: mtnk.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
@@ -66,23 +80,28 @@ mtnk:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
-	muzzle: gunfire2
+	muzzle:
+		Filename: gunfire2.shp
 		Length: *
-	icon: mtnkicnh.tem
-		AddExtension: False
+	icon:
+		Filename: mtnkicnh.tem
 
 mtnk.destroyed:
-	idle: mtnk
+	idle:
+		Filename: mtnk.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
-	turret: mtnk
+	turret:
+		Filename: mtnk.shp
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
 
 ltnk:
+	Defaults:
+		Filename: ltnk.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
@@ -90,23 +109,28 @@ ltnk:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
-	muzzle: gunfire2
+	muzzle:
+		Filename: gunfire2.shp
 		Length: *
-	icon: ltnkicnh.tem
-		AddExtension: False
+	icon:
+		Filename: ltnkicnh.tem
 
 ltnk.destroyed:
-	idle: ltnk
+	idle:
+		Filename: ltnk.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
-	turret: ltnk
+	turret:
+		Filename: ltnk.shp
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
 
 htnk:
+	Defaults:
+		Filename: htnk.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
@@ -114,23 +138,28 @@ htnk:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
-	muzzle: gunfire2
+	muzzle:
+		Filename: gunfire2.shp
 		Length: *
-	icon: htnkicnh.tem
-		AddExtension: False
+	icon:
+		Filename: htnkicnh.tem
 
 htnk.destroyed:
-	idle: htnk
+	idle:
+		Filename: htnk.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
-	turret: htnk
+	turret:
+		Filename: htnk.shp
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
 
 jeep:
+	Defaults:
+		Filename: jeep.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
@@ -138,18 +167,21 @@ jeep:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
-	muzzle: minigun
+	muzzle:
+		Filename: minigun.shp
 		Length: 6
 		Facings: 8
-	icon: jeepicnh.tem
-		AddExtension: False
+	icon:
+		Filename: jeepicnh.tem
 
 jeep.destroyed:
-	idle: jeep
+	idle:
+		Filename: jeep.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
-	turret: jeep
+	turret:
+		Filename: jeep.shp
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
@@ -157,68 +189,85 @@ jeep.destroyed:
 
 bike:
 	idle:
+		Filename: bike.shp
 		Facings: 32
 		UseClassicFacings: True
-	icon: bikeicnh.tem
-		AddExtension: False
+	icon:
+		Filename: bikeicnh.tem
 
 bike.destroyed:
-	idle: bike
+	idle:
+		Filename: bike.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
 
 ftnk:
 	idle:
+		Filename: ftnk.shp
 		Facings: 32
 		UseClassicFacings: True
 	muzzle:
 		Combine:
-			flame-n:
+			0:
+				Filename: flame-n.shp
 				Length: *
 				Offset: 3,6
-			flame-nw:
+			1:
+				Filename: flame-nw.shp
 				Length: *
 				Offset: 8,7
-			flame-w:
+			2:
+				Filename: flame-w.shp
 				Length: *
 				Offset: 8,2
-			flame-sw:
+			3:
+				Filename: flame-sw.shp
 				Length: *
 				Offset: 7,-2
-			flame-s:
+			4:
+				Filename: flame-s.shp
 				Length: *
 				Offset: 3,-2
-			flame-se:
+			5:
+				Filename: flame-se.shp
 				Length: *
 				Offset: -5,-2
-			flame-e:
+			6:
+				Filename: flame-e.shp
 				Length: *
 				Offset: -7,2
-			flame-ne:
+			7:
+				Filename: flame-ne.shp
 				Length: *
 				Offset: -7,8
 		Facings: 8
 		Length: 13
-	icon: ftnkicnh.tem
-		AddExtension: False
+	icon:
+		Filename: ftnkicnh.tem
 
 ftnk.destroyed:
-	idle: ftnk
+	idle:
+		Filename: ftnk.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
 
 mhq:
+	Defaults:
+		Filename: mhq.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
 	spinner:
 		Start: 32
 		Length: 32
-	icon: mhqicnh
+	icon:
+		Filename: mhqicnh.shp
 
 msam:
+	Defaults:
+		Filename: msam.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
@@ -234,21 +283,25 @@ msam:
 		Start: 64
 		Facings: 32
 		UseClassicFacings: True
-	icon: msamicnh.tem
-		AddExtension: False
+	icon:
+		Filename: msamicnh.tem
 
 msam.destroyed:
-	idle: msam
+	idle:
+		Filename: msam.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
-	turret: msam
+	turret:
+		Filename: msam.shp
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
 
 mlrs:
+	Defaults:
+		Filename: mlrs.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
@@ -264,15 +317,17 @@ mlrs:
 		Start: 96
 		Facings: 32
 		UseClassicFacings: True
-	icon: mlrsicnh.tem
-		AddExtension: False
+	icon:
+		Filename: mlrsicnh.tem
 
 mlrs.destroyed:
-	idle: mlrs
+	idle:
+		Filename: mlrs.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
-	turret: mlrs
+	turret:
+		Filename: mlrs.shp
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
@@ -280,45 +335,56 @@ mlrs.destroyed:
 
 stnk:
 	idle:
+		Filename: stnk.shp
 		Facings: 32
 		UseClassicFacings: True
-	icon: stnkicnh.tem
-		AddExtension: False
+	icon:
+		Filename: stnkicnh.tem
 
 stnk.destroyed:
-	idle: stnk
+	idle:
+		Filename: stnk.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
 
 arty:
 	idle:
+		Filename: arty.shp
 		Facings: 32
 		UseClassicFacings: True
-	muzzle: gunfire2
+	muzzle:
+		Filename: gunfire2.shp
 		Length: *
-	icon: artyicnh.tem
-		AddExtension: False
+	icon:
+		Filename: artyicnh.tem
 
 arty.destroyed:
-	idle: arty
+	idle:
+		Filename: arty.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
 
 apc:
+	Defaults:
+		Filename: apc.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
-	turret: apctur
+	turret:
+		Filename: apctur.shp
 		Facings: 32
-	turret-air: apctur
+	turret-air:
+		Filename: apctur.shp
 		Start: 32
 		Facings: 32
-	muzzle: minigun
+	muzzle:
+		Filename: minigun.shp
 		Length: 6
 		Facings: 8
-	muzzle-air: apcmuz
+	muzzle-air:
+		Filename: apcmuz.shp
 		Length: 3
 		Stride: 6
 		Facings: 8
@@ -327,26 +393,31 @@ apc:
 		Length: 3
 	unload:
 		Start: 32
-	icon: apcicnh.tem
-		AddExtension: False
+	icon:
+		Filename: apcicnh.tem
 
 apc.destroyed:
-	idle: apc
+	idle:
+		Filename: apc.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
-	turret: apctur
+	turret:
+		Filename: apctur.shp
 		Facings: 32
 		ZOffset: -512
 
 truck:
 	idle:
+		Filename: truck.shp
 		Facings: 32
 		UseClassicFacings: True
-	icon: truckicon
+	icon:
+		Filename: truckicon.shp
 
 truck.destroyed:
-	idle: truck
+	idle:
+		Filename: truck.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512

--- a/mods/d2k/maps/atreides-04/sequences.yaml
+++ b/mods/d2k/maps/atreides-04/sequences.yaml
@@ -1,5 +1,6 @@
 tile475:
-	Defaults: BLOXWAST.R8
+	Defaults:
+		Filename: BLOXWAST.R8
 	idle:
 		Start: 706
 		Offset: -16,-16

--- a/mods/d2k/sequences/aircraft.yaml
+++ b/mods/d2k/sequences/aircraft.yaml
@@ -1,23 +1,28 @@
 carryall:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 1923
 		Facings: -32
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4290
 		Offset: -30,-24
 
 ornithopter:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 1955
 		Facings: -32
 		Length: 3
 		Tick: 120
 		Transpose: true
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4292
 		Offset: -30,-24
 
 frigate:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2517
 		Facings: 1

--- a/mods/d2k/sequences/infantry.yaml
+++ b/mods/d2k/sequences/infantry.yaml
@@ -1,567 +1,693 @@
 light_inf:
-	stand: DATA.R8
+	stand:
+		Filename: DATA.R8
 		Start: 206
 		Facings: -8
 		Transpose: true
-	idle1: DATA.R8
+	idle1:
+		Filename: DATA.R8
 		Frames: 387, 394, 401, 408, 415, 422, 429, 436
 		Length: 8
 		Tick: 80
-	idle2: DATA.R8
+	idle2:
+		Filename: DATA.R8
 		Frames: 388, 395, 402, 409, 416, 423, 430, 437
 		Length: 8
 		Tick: 80
-	run: DATA.R8
+	run:
+		Filename: DATA.R8
 		Start: 214
 		Length: 6
 		Facings: -8
 		Tick: 110
 		Transpose: true
-	shoot: DATA.R8
+	shoot:
+		Filename: DATA.R8
 		Start: 254
 		Length: 6
 		Facings: -8
 		Transpose: true
-	prone-stand: DATA.R8
+	prone-stand:
+		Filename: DATA.R8
 		Start: 310
 		Facings: -8
 		Transpose: true
-	prone-run: DATA.R8
+	prone-run:
+		Filename: DATA.R8
 		Start: 310
 		Length: 3
 		Facings: -8
 		Transpose: true
 		Tick: 110
-	standup: DATA.R8
+	standup:
+		Filename: DATA.R8
 		Start: 302
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	prone-shoot: DATA.R8
+	prone-shoot:
+		Filename: DATA.R8
 		Start: 334
 		Length: 6
 		Facings: -8
 		Transpose: true
-	die1: DATA.R8
+	die1:
+		Filename: DATA.R8
 		Frames: 382, 389, 396, 403, 410, 417, 424, 431, 438, 443, 448, 453
 		Length: 12
 		Tick: 80
-	die2: DATA.R8
+	die2:
+		Filename: DATA.R8
 		Frames: 383, 390, 397, 404, 411, 418, 425, 432, 439, 444, 449, 454
 		Length: 12
 		Tick: 80
-	die3: DATA.R8
+	die3:
+		Filename: DATA.R8
 		Frames: 384, 391, 398, 405, 412, 419, 426, 433, 440, 445, 450, 455
 		Length: 12
 		Tick: 80
-	die4: DATA.R8
+	die4:
+		Filename: DATA.R8
 		Frames: 385, 392, 399, 406, 413, 420, 427, 434, 441, 446, 451, 456
 		Length: 12
 		Tick: 80
-	die-crushed: DATA.R8
+	die-crushed:
+		Filename: DATA.R8
 		Frames: 386, 393, 400, 407, 414, 421, 428, 435, 442, 447, 452, 457
 		Length: 12
 		Tick: 800
 		ZOffset: -511
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4272
 		Offset: -30,-24
 
 trooper:
-	stand: DATA.R8
+	stand:
+		Filename: DATA.R8
 		Start: 458
 		Facings: -8
 		Transpose: true
-	idle1: DATA.R8
+	idle1:
+		Filename: DATA.R8
 		Frames: 639, 646, 653, 660, 667, 674, 681, 688
 		Length: 8
 		Tick: 80
-	idle2: DATA.R8
+	idle2:
+		Filename: DATA.R8
 		Frames: 640, 647, 654, 661, 668, 675, 682, 689
 		Length: 8
 		Tick: 80
-	run: DATA.R8
+	run:
+		Filename: DATA.R8
 		Start: 466
 		Length: 6
 		Facings: -8
 		Tick: 120
 		Transpose: true
-	shoot: DATA.R8
+	shoot:
+		Filename: DATA.R8
 		Start: 506
 		Length: 6
 		Facings: -8
 		Transpose: true
-	prone-stand: DATA.R8
+	prone-stand:
+		Filename: DATA.R8
 		Start: 562
 		Facings: -8
 		Transpose: true
-	prone-run: DATA.R8
+	prone-run:
+		Filename: DATA.R8
 		Start: 570
 		Length: 3
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	standup: DATA.R8
+	standup:
+		Filename: DATA.R8
 		Start: 554
 		Facings: -8
 		Transpose: true
-	prone-shoot: DATA.R8
+	prone-shoot:
+		Filename: DATA.R8
 		Start: 586
 		Length: 6
 		Facings: -8
 		Transpose: true
-	die1: DATA.R8
+	die1:
+		Filename: DATA.R8
 		Frames: 634, 641, 648, 655, 662, 669, 676, 683, 690, 691, 692, 693
 		Length: 12
 		Tick: 80
-	die2: DATA.R8
+	die2:
+		Filename: DATA.R8
 		Frames: 635, 642, 649, 656, 663, 670, 677, 684
 		Length: 8
 		Tick: 80
-	die3: DATA.R8
+	die3:
+		Filename: DATA.R8
 		Frames: 636, 643, 650, 657, 664, 671, 678, 685
 		Length: 8
 		Tick: 80
-	die4: DATA.R8
+	die4:
+		Filename: DATA.R8
 		Frames: 637, 644, 651, 658, 665, 672, 679, 686
 		Length: 8
 		Tick: 80
-	die-crushed: DATA.R8
+	die-crushed:
+		Filename: DATA.R8
 		Frames: 638, 645, 652, 659, 666, 673, 680, 687
 		Length: 8
 		Tick: 800
 		ZOffset: -511
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4273
 		Offset: -30,-24
 
 engineer:
-	stand: DATA.R8
+	stand:
+		Filename: DATA.R8
 		Start: 1166
 		Facings: -8
 		Transpose: true
-	idle1: DATA.R8
+	idle1:
+		Filename: DATA.R8
 		Frames: 1347, 1354, 1361, 1368, 1375, 1382, 1389, 1396
 		Length: 8
 		Tick: 80
-	idle2: DATA.R8
+	idle2:
+		Filename: DATA.R8
 		Frames: 1348, 1355, 1362, 1369, 1376, 1383, 1390, 1397
 		Length: 8
 		Tick: 80
-	run: DATA.R8
+	run:
+		Filename: DATA.R8
 		Start: 1174
 		Length: 6
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	standup: DATA.R8
+	standup:
+		Filename: DATA.R8
 		Start: 1262
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	prone-stand: DATA.R8
+	prone-stand:
+		Filename: DATA.R8
 		Start: 1270
 		Facings: -8
 		Transpose: true
-	prone-run: DATA.R8
+	prone-run:
+		Filename: DATA.R8
 		Start: 1278
 		Length: 3
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	die1: DATA.R8
+	die1:
+		Filename: DATA.R8
 		Frames: 1342, 1349, 1356, 1363, 1370, 1377, 1384, 1391, 1398, 1399, 1400, 1401
 		Length: 12
 		Tick: 80
-	die2: DATA.R8
+	die2:
+		Filename: DATA.R8
 		Frames: 1343, 1350, 1357, 1364, 1371, 1378, 1385, 1392
 		Length: 8
 		Tick: 80
-	die3: DATA.R8
+	die3:
+		Filename: DATA.R8
 		Frames: 1344, 1351, 1358, 1365, 1372, 1379, 1386, 1393
 		Length: 8
 		Tick: 80
-	die4: DATA.R8
+	die4:
+		Filename: DATA.R8
 		Frames: 1345, 1352, 1359, 1366, 1373, 1380, 1387, 1394
 		Length: 8
 		Tick: 80
-	die-crushed: DATA.R8
+	die-crushed:
+		Filename: DATA.R8
 		Frames: 1346, 1353, 1360, 1367, 1374, 1381, 1388, 1395
 		Length: 8
 		Tick: 800
 		ZOffset: -511
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4274
 		Offset: -30,-24
 
 thumper:
-	stand: DATA.R8
+	stand:
+		Filename: DATA.R8
 		Start: 1402
 		Facings: -8
 		Transpose: true
-	idle1: DATA.R8
+	idle1:
+		Filename: DATA.R8
 		Frames: 1548, 1555, 1562, 1569, 1576, 1583, 1590, 1597
 		Length: 8
 		Tick: 80
-	idle2: DATA.R8
+	idle2:
+		Filename: DATA.R8
 		Frames: 1549, 1556, 1563, 1570, 1577, 1584, 1591, 1598
 		Length: 8
 		Tick: 80
-	run: DATA.R8
+	run:
+		Filename: DATA.R8
 		Start: 1410
 		Length: 6
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	standup: DATA.R8
+	standup:
+		Filename: DATA.R8
 		Start: 1462
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	prone-stand: DATA.R8
+	prone-stand:
+		Filename: DATA.R8
 		Start: 1470
 		Facings: -8
 		Transpose: true
-	prone-run: DATA.R8
+	prone-run:
+		Filename: DATA.R8
 		Start: 1478
 		Length: 3
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	deploy: DATA.R8
+	deploy:
+		Filename: DATA.R8
 		Start: 1458
 		Length: 5
-	thump: DATA.R8
+	thump:
+		Filename: DATA.R8
 		Start: 1458
 		Length: 5
 		Tick: 480
-	thump-sand: DATA.R8
+	thump-sand:
+		Filename: DATA.R8
 		Frames: 3882, 3883, 3879, 3880, 3881
 		Length: 5
 		Tick: 480
 		BlendMode: Multiply
-	die1: DATA.R8
+	die1:
+		Filename: DATA.R8
 		Frames: 1543, 1550, 1557, 1564, 1571, 1578, 1585, 1592, 1599, 1600, 1601, 1602
 		Length: 12
 		Tick: 80
-	die2: DATA.R8
+	die2:
+		Filename: DATA.R8
 		Frames: 1544, 1551, 1558, 1565, 1572, 1579, 1586, 1593
 		Length: 8
 		Tick: 80
-	die3: DATA.R8
+	die3:
+		Filename: DATA.R8
 		Frames: 1546, 1552, 1559, 1566, 1573, 1580, 1587, 1594
 		Length: 8
 		Tick: 80
-	die4: DATA.R8
+	die4:
+		Filename: DATA.R8
 		Frames: 1547, 1553, 1560, 1567, 1574, 1581, 1588, 1595
 		Length: 8
 		Tick: 80
-	die-crushed: DATA.R8
+	die-crushed:
+		Filename: DATA.R8
 		Frames: 1548, 1554, 1561, 1568, 1575, 1582, 1589, 1596
 		Length: 8
 		Tick: 800
 		ZOffset: -511
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4275
 		Offset: -30,-24
 
 fremen:
-	stand: DATA.R8
+	stand:
+		Filename: DATA.R8
 		Start: 694
 		Facings: -8
 		Transpose: true
-	idle1: DATA.R8
+	idle1:
+		Filename: DATA.R8
 		Frames: 875, 882, 889, 896, 903, 910, 917, 924
 		Length: 8
 		Tick: 80
-	idle2: DATA.R8
+	idle2:
+		Filename: DATA.R8
 		Frames: 876, 883, 890, 897, 904, 911, 918, 925
 		Length: 8
 		Tick: 80
-	run: DATA.R8
+	run:
+		Filename: DATA.R8
 		Start: 702
 		Length: 6
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	shoot: DATA.R8
+	shoot:
+		Filename: DATA.R8
 		Start: 742
 		Length: 6
 		Facings: -8
 		Transpose: true
-	prone-stand: DATA.R8
+	prone-stand:
+		Filename: DATA.R8
 		Start: 798
 		Facings: -8
 		Transpose: true
-	prone-run: DATA.R8
+	prone-run:
+		Filename: DATA.R8
 		Start: 806
 		Length: 3
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	standup: DATA.R8
+	standup:
+		Filename: DATA.R8
 		Start: 790
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	prone-shoot: DATA.R8
+	prone-shoot:
+		Filename: DATA.R8
 		Start: 822
 		Length: 6
 		Facings: -8
 		Transpose: true
-	die1: DATA.R8
+	die1:
+		Filename: DATA.R8
 		Frames: 870, 877, 884, 891, 898, 905, 912, 919, 926, 927, 928, 929
 		Length: 12
 		Tick: 80
-	die2: DATA.R8
+	die2:
+		Filename: DATA.R8
 		Frames: 871, 878, 885, 892, 899, 906, 913, 920
 		Length: 8
 		Tick: 80
-	die3: DATA.R8
+	die3:
+		Filename: DATA.R8
 		Frames: 872, 879, 886, 893, 900, 907, 914, 921
 		Length: 8
 		Tick: 80
-	die4: DATA.R8
+	die4:
+		Filename: DATA.R8
 		Frames: 873, 880, 887, 894, 901, 908, 915, 922
 		Length: 8
 		Tick: 80
-	die-crushed: DATA.R8
+	die-crushed:
+		Filename: DATA.R8
 		Frames: 874, 881, 888, 895, 902, 909, 916, 923
 		Length: 8
 		Tick: 800
 		ZOffset: -511
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4293
 		Offset: -30,-24
 
 saboteur:
-	stand: DATA.R8
+	stand:
+		Filename: DATA.R8
 		Start: 2149
 		Facings: -8
 		Transpose: true
-	idle1: DATA.R8
+	idle1:
+		Filename: DATA.R8
 		Frames: 2330, 2337, 2344, 2351, 2358, 2365, 2372, 2379
 		Length: 8
 		Tick: 80
-	idle2: DATA.R8
+	idle2:
+		Filename: DATA.R8
 		Frames: 2331, 2338, 2345, 2352, 2359, 2366, 2373, 2380
 		Length: 8
 		Tick: 80
-	run: DATA.R8
+	run:
+		Filename: DATA.R8
 		Start: 2157
 		Length: 6
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	prone-stand: DATA.R8
+	prone-stand:
+		Filename: DATA.R8
 		Start: 2253
 		Facings: -8
 		Transpose: true
-	prone-run: DATA.R8
+	prone-run:
+		Filename: DATA.R8
 		Start: 2261
 		Length: 3
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	standup: DATA.R8
+	standup:
+		Filename: DATA.R8
 		Start: 2245
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	die1: DATA.R8
+	die1:
+		Filename: DATA.R8
 		Frames: 2325, 2332, 2339, 2346, 2353, 2360, 2367, 2374, 2381, 2383, 2385, 2387
 		Length: 12
 		Tick: 80
-	die2: DATA.R8
+	die2:
+		Filename: DATA.R8
 		Frames: 2326, 2333, 2340, 2347, 2354, 2361, 2368, 2375, 2382, 2384, 2386, 2388
 		Length: 12
 		Tick: 80
-	die3: DATA.R8
+	die3:
+		Filename: DATA.R8
 		Frames: 2327, 2334, 2341, 2348, 2355, 2362, 2369, 2376
 		Length: 8
 		Tick: 80
-	die4: DATA.R8
+	die4:
+		Filename: DATA.R8
 		Frames: 2328, 2335, 2342, 2349, 2356, 2363, 2370, 2377
 		Length: 8
 		Tick: 80
-	die-crushed: DATA.R8
+	die-crushed:
+		Filename: DATA.R8
 		Frames: 2329, 2336, 2343, 2350, 2357, 2364, 2371, 2378
 		Length: 8
 		Tick: 800
 		ZOffset: -511
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4295
 		Offset: -30,-24
 
 sardaukar:
-	stand: DATA.R8
+	stand:
+		Filename: DATA.R8
 		Start: 930
 		Facings: -8
 		Transpose: true
-	idle1: DATA.R8
+	idle1:
+		Filename: DATA.R8
 		Frames: 1111, 1118, 1125, 1132, 1139, 1146, 1153, 1160
 		Length: 8
 		Tick: 80
 		Offset: -1,0
-	idle2: DATA.R8
+	idle2:
+		Filename: DATA.R8
 		Frames: 1112, 1119, 1126, 1133, 1140, 1147, 1154, 1161
 		Length: 8
 		Tick: 80
 		Offset: -1,0
-	run: DATA.R8
+	run:
+		Filename: DATA.R8
 		Start: 938
 		Length: 6
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	shoot: DATA.R8
+	shoot:
+		Filename: DATA.R8
 		Start: 978
 		Length: 6
 		Facings: -8
 		Transpose: true
-	prone-stand: DATA.R8
+	prone-stand:
+		Filename: DATA.R8
 		Start: 1034
 		Facings: -8
 		Transpose: true
-	prone-run: DATA.R8
+	prone-run:
+		Filename: DATA.R8
 		Start: 1042
 		Length: 3
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	standup: DATA.R8
+	standup:
+		Filename: DATA.R8
 		Start: 1026
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	prone-shoot: DATA.R8
+	prone-shoot:
+		Filename: DATA.R8
 		Start: 1058
 		Length: 6
 		Facings: -8
 		Transpose: true
-	die1: DATA.R8
+	die1:
+		Filename: DATA.R8
 		Frames: 1106, 1113, 1120, 1127, 1134, 1141, 1148, 1155, 1162, 1163, 1164, 1165
 		Length: 12
 		Tick: 80
-	die2: DATA.R8
+	die2:
+		Filename: DATA.R8
 		Frames: 1107, 1114, 1121, 1128, 1135, 1142, 1149, 1156
 		Length: 8
 		Tick: 80
-	die3: DATA.R8
+	die3:
+		Filename: DATA.R8
 		Frames: 1108, 1115, 1122, 1129, 1136, 1143, 1150, 1157
 		Length: 8
 		Tick: 80
-	die4: DATA.R8
+	die4:
+		Filename: DATA.R8
 		Frames: 1109, 1116, 1123, 1130, 1137, 1144, 1151, 1158
 		Length: 8
 		Tick: 80
-	die-crushed: DATA.R8
+	die-crushed:
+		Filename: DATA.R8
 		Frames: 1110, 1117, 1124, 1131, 1138, 1145, 1152, 1159
 		Length: 8
 		Tick: 800
 		ZOffset: -511
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4276
 		Offset: -30,-24
 
 grenadier:
-	stand: DATA.R8
+	stand:
+		Filename: DATA.R8
 		Start: 2606
 		Facings: -8
 		Transpose: true
-	idle1: DATA.R8
+	idle1:
+		Filename: DATA.R8
 		Frames: 2700, 2707, 2714, 2721, 2728, 2735, 2742, 2749
 		Length: 8
-	idle2: DATA.R8
+	idle2:
+		Filename: DATA.R8
 		Frames: 2699, 2706, 2713, 2720, 2727, 2734, 2741, 2748
 		Length: 8
-	run: DATA.R8
+	run:
+		Filename: DATA.R8
 		Start: 2526
 		Length: 6
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	throw: DATA.R8
+	throw:
+		Filename: DATA.R8
 		Start: 2574
 		Length: 5
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	die1: DATA.R8
+	die1:
+		Filename: DATA.R8
 		Frames: 2694, 2701, 2708, 2715, 2722, 2729, 2736, 2743
 		Length: 8
-	die2: DATA.R8
+	die2:
+		Filename: DATA.R8
 		Frames: 2695, 2702, 2709, 2716, 2723, 2730, 2737, 2744
 		Length: 8
-	die3: DATA.R8
+	die3:
+		Filename: DATA.R8
 		Frames: 2696, 2703, 2710, 2717, 2724, 2731, 2738, 2745
 		Length: 8
-	die4: DATA.R8
+	die4:
+		Filename: DATA.R8
 		Frames: 2697, 2704, 2711, 2718, 2725, 2732, 2738, 2746
 		Length: 8
-	die-crushed: DATA.R8
+	die-crushed:
+		Filename: DATA.R8
 		Frames: 2698, 2705, 2712, 2719, 2726, 2733, 2740, 2747
 		Tick: 800
 		ZOffset: -511
-	prone-stand: DATA.R8
+	prone-stand:
+		Filename: DATA.R8
 		Start: 2622
 		Facings: -8
 		Transpose: true
-	prone-run: DATA.R8
+	prone-run:
+		Filename: DATA.R8
 		Start: 2622
 		Length: 4
 		Facings: -8
 		Tick: 120
 		Transpose: true
-	prone-throw: DATA.R8
+	prone-throw:
+		Filename: DATA.R8
 		Start: 2654
 		Length: 5
 		Facings: -8
 		Tick: 120
 		Transpose: true
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4297
 		Offset: -30,-24
 
 sandworm:
-	mouth: DATA.R8
+	mouth:
+		Filename: DATA.R8
 		Start: 3802
 		Length: 15
 		Tick: 100
-	sand: DATA.R8
+	sand:
+		Filename: DATA.R8
 		Start: 3818
 		Length: 20
 		Tick: 100
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 39
-	lightninga: DATA.R8
+	lightninga:
+		Filename: DATA.R8
 		Start: 3844
 		Length: 5
 		Tick: 80
 		BlendMode: Additive
-	lightningb: DATA.R8
+	lightningb:
+		Filename: DATA.R8
 		Start: 3849
 		Length: 5
 		Tick: 80
 		BlendMode: Additive
-	lightningc: DATA.R8
+	lightningc:
+		Filename: DATA.R8
 		Start: 3854
 		Length: 5
 		Tick: 80
 		BlendMode: Additive
-	lightningd: DATA.R8
+	lightningd:
+		Filename: DATA.R8
 		Start: 3859
 		Length: 5
 		Tick: 80
 		BlendMode: Additive
-	lightninge: DATA.R8
+	lightninge:
+		Filename: DATA.R8
 		Start: 3864
 		Length: 5
 		Tick: 80
 		BlendMode: Additive
-	lightningf: DATA.R8
+	lightningf:
+		Filename: DATA.R8
 		Start: 3869
 		Length: 5
 		Tick: 80
 		BlendMode: Additive
-	icon: wormicon.shp
+	icon:
+		Filename: wormicon.shp

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -3,67 +3,84 @@ explosion:
 		BlendMode: Additive
 		Tick: 80
 		ZOffset: 511
-	piff: DATA.R8
+	piff:
+		Filename: DATA.R8
 		Start: 3879
 		Length: 5
-	piffs: DATA.R8
+	piffs:
+		Filename: DATA.R8
 		Start: 3682
 		Length: 4
-	small_explosion: DATA.R8
+	small_explosion:
+		Filename: DATA.R8
 		Start: 3656
 		Length: 15
-	med_explosion: DATA.R8
+	med_explosion:
+		Filename: DATA.R8
 		Start: 3643
 		Length: 12
-	tiny_explosion: DATA.R8
+	tiny_explosion:
+		Filename: DATA.R8
 		Start: 3639
 		Length: 4
-	nuke: DATA.R8
+	nuke:
+		Filename: DATA.R8
 		Start: 4218
 		Length: 14
-	self_destruct: DATA.R8
+	self_destruct:
+		Filename: DATA.R8
 		Start: 3686
 		Length: 15
-	building: DATA.R8
+	building:
+		Filename: DATA.R8
 		Start: 3701
 		Length: 22
-	large_explosion: DATA.R8
+	large_explosion:
+		Filename: DATA.R8
 		Start: 4241
 		Length: 22
-	small_napalm: DATA.R8
+	small_napalm:
+		Filename: DATA.R8
 		Start: 3674
 		Length: 8
-	rocket_explosion: DATA.R8
+	rocket_explosion:
+		Filename: DATA.R8
 		Start: 3634
 		Length: 5
 		BlendMode: Alpha
-	shockwave: DATA.R8
+	shockwave:
+		Filename: DATA.R8
 		Start: 3940
 		Length: 6
 		Tick: 120
-	deviator: DATA.R8
+	deviator:
+		Filename: DATA.R8
 		Start: 3765
 		Length: 23
 		BlendMode: Alpha
 		Offset: 12, -10
 		Tick: 120
-	corpse: DATA.R8
+	corpse:
+		Filename: DATA.R8
 		ZOffset: -511
 		Start: 430
 		Length: 12
 		Tick: 1600
-	wall_explosion: DATA.R8
+	wall_explosion:
+		Filename: DATA.R8
 		Start: 4130
 		Length: 8
 		Tick: 120
 		BlendMode: Alpha
-	devastator: DATA.R8
+	devastator:
+		Filename: DATA.R8
 		Start: 3947
 		Length: 17
 		Tick: 120
 
 large_trail:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 4126
 		Length: 4
 		Tick: 120
@@ -71,7 +88,8 @@ large_trail:
 		ZOffset: 1023
 
 small_trail:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3988
 		Length: 4
 		Tick: 80
@@ -79,7 +97,8 @@ small_trail:
 		ZOffset: 1023
 
 small_trail2:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3793
 		Length: 4
 		Tick: 80
@@ -87,28 +106,32 @@ small_trail2:
 		ZOffset: 1023
 
 bazooka_trail:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3634
 		Length: 4
 		Tick: 80
 		ZOffset: 1023
 
 bazooka_trail2:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3797
 		Length: 4
 		Tick: 80
 		ZOffset: 1023
 
 deviator_trail:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3788
 		Length: 5
 		Tick: 80
 		ZOffset: 1023
 
 laserfire:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3639
 		Length: 4
 		Tick: 80
@@ -120,57 +143,74 @@ sandtrail:
 		Length: 8
 		Tick: 200
 		ZOffset: -512
-	traila: sandtrail.shp
-	trailb: sandtrail.shp
+	traila:
+		Filename: sandtrail.shp
+	trailb:
+		Filename: sandtrail.shp
 		Frames: 2, 6, 4, 5, 0, 1, 3, 7
-	trailc: sandtrail.shp
+	trailc:
+		Filename: sandtrail.shp
 		Frames: 7, 4, 6, 5, 2, 0, 3, 1
 
 pips:
-	groups: DATA.R8
+	groups:
+		Filename: DATA.R8
 		Length: 10
 		Frames: 18, 19, 20, 21, 22, 23, 24, 25, 26, 17
 		Offset: 3, 3
-	pickup-indicator: DATA.R8
+	pickup-indicator:
+		Filename: DATA.R8
 		Start: 112
 		Offset: -9, -9
-	pip-empty: DATA.R8
+	pip-empty:
+		Filename: DATA.R8
 		Start: 15
-	pip-green: DATA.R8
+	pip-green:
+		Filename: DATA.R8
 		Start: 16
-	tag-upgraded: DATA.R8
+	tag-upgraded:
+		Filename: DATA.R8
 		Start: 110
 		Offset: -8,-8
 
 clock:
-	idle: clock.shp
+	idle:
+		Filename: clock.shp
 		Length: *
 
 powerdown:
-	disabled: speed.shp
+	disabled:
+		Filename: speed.shp
 		Start: 3
 		ZOffset: 2047
 
 poweroff:
-	offline: poweroff.shp
+	offline:
+		Filename: poweroff.shp
 		Length: *
 		Tick: 160
 		ZOffset: 2047
 
 rank:
-	rank-veteran-1: rank.shp
-	rank-veteran-2: rank.shp
+	rank-veteran-1:
+		Filename: rank.shp
+	rank-veteran-2:
+		Filename: rank.shp
 		Start: 1
-	rank-veteran-3: rank.shp
+	rank-veteran-3:
+		Filename: rank.shp
 		Start: 2
-	rank-elite: rank.shp
+	rank-elite:
+		Filename: rank.shp
 		Start: 3
 
 overlay:
-	Defaults: DATA.R8
+	Defaults:
+		Filename: DATA.R8
 		Offset: -16,-16
 	build-valid:
-	build-unsafe: concfoot.shp
+	build-unsafe:
+		Filename: concfoot.shp
 		Offset: 0, 0
 	build-invalid:
 		Start: 1
@@ -181,68 +221,82 @@ overlay:
 		Start: 1
 
 editor-overlay:
-	Defaults: DATA.R8
+	Defaults:
+		Filename: DATA.R8
 		Offset: -16,-16
 	copy:
 	paste:
 		Start: 1
 
 rallypoint:
-	flag: flagfly.shp
+	flag:
+		Filename: flagfly.shp
 		Length: *
 		Offset: 11,-5
 		ZOffset: 2535
-	circles: fpls.shp
+	circles:
+		Filename: fpls.shp
 		Length: *
 		ZOffset: 2047
 
 beacon:
-	arrow: MOUSE.R8
+	arrow:
+		Filename: MOUSE.R8
 		Start: 148
 		Offset: -24,-24
 		ZOffset: 2535
-	circles: fpls.shp
+	circles:
+		Filename: fpls.shp
 		Length: *
 		ZOffset: 2047
 
 rpg:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3263
 		Facings: -32
 		ZOffset: 1023
 
 120mm:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3262
 		BlendMode: Additive
 		ZOffset: 1023
 
 155mm:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3329
 		ZOffset: 1023
 
 crate-effects:
 	Defaults:
 		ZOffset: 2047
-	dollar: DATA.R8
+	dollar:
+		Filename: DATA.R8
 		Start: 3932
 		Length: 8
-	reveal-map: DATA.R8
+	reveal-map:
+		Filename: DATA.R8
 		Start: 4200
 		Length: 18
-	hide-map: DATA.R8
+	hide-map:
+		Filename: DATA.R8
 		Frames: 4217, 4216, 4215, 4214, 4213, 4212, 4211, 4210, 4209, 4208, 4207, 4206, 4205, 4204, 4203, 4202, 4201, 4200
 		Length: 18
-	levelup: levelup.shp
+	levelup:
+		Filename: levelup.shp
 		Length: *
 		Tick: 200
-	cloak: DATA.R8
+	cloak:
+		Filename: DATA.R8
 		Start: 4164
 		Length: 36
 
 allyrepair:
-	repair: DATA.R8
+	repair:
+		Filename: DATA.R8
 		Frames: 3, 39
 		Length: 2
 		Tick: 300
@@ -250,50 +304,59 @@ allyrepair:
 		ZOffset: 2047
 
 missile:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3336
 		Facings: -32
 		ZOffset: 1023
 
 missile2:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3554
 		Facings: -32
 		ZOffset: 1023
 
 deathhand:
-	up: DATA.R8
+	up:
+		Filename: DATA.R8
 		Start: 2147
 		ZOffset: 1023
 		Offset: 2,0
-	down: DATA.R8
+	down:
+		Filename: DATA.R8
 		Start: 2148
 		ZOffset: 1023
 		Offset: -1,0
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4296
 		Offset: -30,-24
 
 fire:
-	1: DATA.R8
+	1:
+		Filename: DATA.R8
 		Start: 3965
 		Length: 10
 		Offset: 4,-17
 		ZOffset: 1023
 		BlendMode: Additive
-	2: DATA.R8
+	2:
+		Filename: DATA.R8
 		Start: 3976
 		Length: 11
 		Offset: 0,-3
 		ZOffset: 1023
 		BlendMode: Additive
-	3: DATA.R8
+	3:
+		Filename: DATA.R8
 		Start: 4138
 		Length: 13
 		Offset: 0,-3
 		ZOffset: 1023
 		BlendMode: Additive
-	4: DATA.R8
+	4:
+		Filename: DATA.R8
 		Start: 3965
 		Length: 10
 		Offset: 0,-3
@@ -303,133 +366,159 @@ fire:
 smoke_m:
 	Defaults:
 		ZOffset: 511
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3671
 		Length: 2
 		BlendMode: Additive
-	loop: DATA.R8
+	loop:
+		Filename: DATA.R8
 		Start: 3671
 		Length: 2
 		BlendMode: Additive
-	end: DATA.R8
+	end:
+		Filename: DATA.R8
 		Start: 3671
 		Length: 3
 		BlendMode: Additive
 
 bombs:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3528
 		Length: 4
 		ZOffset: 1023
 
 grenade:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3618
 		Length: 4
 		Tick: 80
 		ZOffset: 1023
 
 shrapnel:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3538
 		Length: 4
 		ZOffset: 1023
 
 shrapnel2:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3542
 		Length: 1
 		ZOffset: 1023
 
 shrapnel3:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3543
 		Length: 8
 		ZOffset: 1023
 
 shrapnel4:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3551
 		Length: 1
 		ZOffset: 1023
 
 mpspawn:
-	idle: mpspawn.shp
+	idle:
+		Filename: mpspawn.shp
 		Length: *
 
 waypoint:
-	idle: waypoint.shp
+	idle:
+		Filename: waypoint.shp
 		Length: *
 
 camera:
-	idle: camera.shp
+	idle:
+		Filename: camera.shp
 		Length: *
 
 wormspawner:
-	idle: wormspawner.shp
+	idle:
+		Filename: wormspawner.shp
 		Length: *
 
 sietch:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3246
 		Offset: -32,32
 
 doubleblast:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3527
 		Facings: -16
 		BlendMode: Additive
 		ZOffset: 511
 
 doubleblastbullet:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3496
 		Facings: -16
 		BlendMode: Additive
 		ZOffset: 1023
 
 icon:
-	ornistrike: DATA.R8
+	ornistrike:
+		Filename: DATA.R8
 		Start: 4292
 		Offset: -30,-24
-	fremen: DATA.R8
+	fremen:
+		Filename: DATA.R8
 		Start: 4293
 		Offset: -30,-24
-	saboteur: DATA.R8
+	saboteur:
+		Filename: DATA.R8
 		Start: 4295
 		Offset: -30,-24
-	deathhand: DATA.R8
+	deathhand:
+		Filename: DATA.R8
 		Start: 4296
 		Offset: -30,-24
 
 crate:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 102
 		ZOffset: -511
 		Offset: -16,-16
 
 spicebloom:
-	grow0: DATA.R8
+	grow0:
+		Filename: DATA.R8
 		Start: 106
 		Length: 1
 		ZOffset: -1023
 		Offset: -16,-16
-	grow1: DATA.R8
+	grow1:
+		Filename: DATA.R8
 		Start: 107
 		Length: 1
 		ZOffset: -1023
 		Offset: -16,-16
-	grow2: DATA.R8
+	grow2:
+		Filename: DATA.R8
 		Start: 108
 		Length: 1
 		ZOffset: -1023
 		Offset: -16,-16
-	grow3: DATA.R8
+	grow3:
+		Filename: DATA.R8
 		Start: 109
 		Length: 1
 		ZOffset: -1023
 		Offset: -16,-16
-	spurt: DATA.R8
+	spurt:
+		Filename: DATA.R8
 		Start: 4233
 		Length: 8
 		Tick: 80
@@ -438,7 +527,8 @@ spicebloom:
 		Offset: 0, -16
 
 moveflsh:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3874
 		Length: 5
 		Tick: 80
@@ -447,19 +537,23 @@ moveflsh:
 		HasEmbeddedPalette: True
 
 resources:
-	spicea: BLOXBASE.R8
+	spicea:
+		Filename: BLOXBASE.R8
 		Frames: 748, 300, 750, 751, 752, 753, 754, 755, 756, 757, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 300
 		Length: *
 		Offset: -16,-16
-	spiceb: BLOXBASE.R8
+	spiceb:
+		Filename: BLOXBASE.R8
 		Frames: 749, 301, 750, 751, 752, 753, 754, 755, 756, 757, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 301
 		Length: *
 		Offset: -16,-16
-	spicec: BLOXBASE.R8
+	spicec:
+		Filename: BLOXBASE.R8
 		Frames: 793, 320, 750, 751, 752, 753, 754, 755, 756, 757, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 320
 		Length: *
 		Offset: -16,-16
-	spiced: BLOXBASE.R8
+	spiced:
+		Filename: BLOXBASE.R8
 		Frames: 748, 321, 750, 751, 752, 753, 754, 755, 756, 757, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 321
 		Length: *
 		Offset: -16,-16
@@ -469,83 +563,107 @@ shroud:
 		BlendMode: Subtractive
 		Offset: -16,-16
 		Length: 14
-	palette: DATA.R8
+	palette:
+		Filename: DATA.R8
 		Start: 38
 		HasEmbeddedPalette: True
-	shrouda: DATA.R8
+	shrouda:
+		Filename: DATA.R8
 		Start: 40
-	shroudb: DATA.R8
+	shroudb:
+		Filename: DATA.R8
 		Start: 56
-	shroudc: DATA.R8
+	shroudc:
+		Filename: DATA.R8
 		Start: 72
-	shroudd: DATA.R8
+	shroudd:
+		Filename: DATA.R8
 		Start: 88
-	shroudfull: fullshroud.shp
+	shroudfull:
+		Filename: fullshroud.shp
 		Offset: 0,0
 		Length: 1
-	foga: DATA.R8
+	foga:
+		Filename: DATA.R8
 		BlendMode: Multiply
 		Start: 40
-	fogb: DATA.R8
+	fogb:
+		Filename: DATA.R8
 		BlendMode: Multiply
 		Start: 56
-	fogc: DATA.R8
+	fogc:
+		Filename: DATA.R8
 		BlendMode: Multiply
 		Start: 72
-	fogd: DATA.R8
+	fogd:
+		Filename: DATA.R8
 		BlendMode: Multiply
 		Start: 88
-	fogfull: fullshroud.shp
+	fogfull:
+		Filename: fullshroud.shp
 		BlendMode: Multiply
 		Offset: 0,0
 		Length: 1
 
 rockcraters:
-	rockcrater1: DATA.R8
+	rockcrater1:
+		Filename: DATA.R8
 		Start: 114
 		Length: 16
 		Offset: -16,-16
-	rockcrater2: DATA.R8
+	rockcrater2:
+		Filename: DATA.R8
 		Start: 130
 		Length: 16
 		Offset: -16,-16
 
 sandcraters:
-	sandcrater1: DATA.R8
+	sandcrater1:
+		Filename: DATA.R8
 		Start: 146
 		Length: 16
 		Offset: -16,-16
-	sandcrater2: DATA.R8
+	sandcrater2:
+		Filename: DATA.R8
 		Start: 162
 		Length: 16
 		Offset: -16,-16
 
 ornidirection:
-	arrow-t: MOUSE.R8
+	arrow-t:
+		Filename: MOUSE.R8
 		Start: 112
 		Offset: -25, -53, 0
-	arrow-tr: MOUSE.R8
+	arrow-tr:
+		Filename: MOUSE.R8
 		Start: 120
 		Offset: 6, -47, 0
-	arrow-r: MOUSE.R8
+	arrow-r:
+		Filename: MOUSE.R8
 		Start: 128
 		Offset: 17, -26, 0
-	arrow-br: MOUSE.R8
+	arrow-br:
+		Filename: MOUSE.R8
 		Start: 136
 		Offset: 6, -1, 0
-	arrow-b: MOUSE.R8
+	arrow-b:
+		Filename: MOUSE.R8
 		Start: 148
 		Offset: -25, 7, 0
-	arrow-bl: MOUSE.R8
+	arrow-bl:
+		Filename: MOUSE.R8
 		Start: 156
 		Offset: -52, -3, 0
-	arrow-l: MOUSE.R8
+	arrow-l:
+		Filename: MOUSE.R8
 		Start: 164
 		Offset: -61, -26, 0
-	arrow-tl: MOUSE.R8
+	arrow-tl:
+		Filename: MOUSE.R8
 		Start: 172
 		Offset: -52, -44, 0
 
 null:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3552

--- a/mods/d2k/sequences/structures.yaml
+++ b/mods/d2k/sequences/structures.yaml
@@ -1,411 +1,505 @@
 concretea:
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4314
 		Offset: -30,-24
-	preview: BLOXBASE.R8
+	preview:
+		Filename: BLOXBASE.R8
 		Start: 657
 
 concreteb:
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4317
 		Offset: -30,-24
 
 wall:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Frames: 2775, 2778, 2776, 2786, 2779, 2780, 2790, 2783, 2777, 2787, 2781, 2782, 2788, 2784, 2785, 2789
 		Length: 16
 		Offset: -16,16
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Frames: 2791, 2794, 2792, 2802, 2795, 2796, 2806, 2799, 2793, 2803, 2797, 2798, 2804, 2800, 2801, 2805
 		Length: 16
 		Offset: -16,16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4327
 		Offset: -30,-24
 
 medium_gun_turret:
-	invisible: DATA.R8
+	invisible:
+		Filename: DATA.R8
 		Start: 38
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Frames: 2821, 2824, 2822, 2832, 2825, 2826, 2836, 2829, 2823, 2833, 2827, 2828, 2834, 2830, 2831, 2835
 		Length: 16
 		Offset: -24,16
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Frames: 2869, 2872, 2870, 2880, 2873, 2874, 2884, 2877, 2871, 2881, 2875, 2876, 2882, 2878, 2879, 2883
 		Length: 16
 		Offset: -24,16
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4577
 		Length: 8
 		Offset: -16,16
 		ZOffset: 1024
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4585
 		Length: 7
 		Offset: -16,16
 		Tick: 100
 		ZOffset: 1024
-	turret: DATA.R8
+	turret:
+		Filename: DATA.R8
 		Start: 2837
 		Facings: -32
 		Offset: -24,16
-	muzzle: DATA.R8
+	muzzle:
+		Filename: DATA.R8
 		Start: 4028
 		Tick: 60
 		Facings: -32
 		Offset: 0,2
 		BlendMode: Additive
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4333
 		Offset: -30,-24
 
 large_gun_turret:
-	invisible: DATA.R8
+	invisible:
+		Filename: DATA.R8
 		Start: 38
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Frames: 2821, 2824, 2822, 2832, 2825, 2826, 2836, 2829, 2823, 2833, 2827, 2828, 2834, 2830, 2831, 2835
 		Length: 16
 		Offset: -24,16
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Frames: 2869, 2872, 2870, 2880, 2873, 2874, 2884, 2877, 2871, 2881, 2875, 2876, 2882, 2878, 2879, 2883
 		Length: 16
 		Offset: -24,16
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4577
 		Length: 8
 		Offset: -16,16
 		ZOffset: 1024
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4585
 		Length: 7
 		Offset: -16,16
 		Tick: 100
 		ZOffset: 1024
-	turret: DATA.R8
+	turret:
+		Filename: DATA.R8
 		Start: 2885
 		Facings: -32
 		Offset: -24,16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4339
 		Offset: -30,-24
 
 conyard.atreides:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2807
 		Offset: -48,64
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4373
 		Length: 30
 		Offset: -48,64
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4403
 		Length: 12
 		Offset: -48,64
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2808
 		Offset: -48,64
-	crane-overlay: DATA.R8
+	crane-overlay:
+		Filename: DATA.R8
 		Start: 4700
 		Length: 14
 		Offset: -48,64
 		Tick: 80
 		ZOffset: 1023
-	damaged-crane-overlay: DATA.R8
+	damaged-crane-overlay:
+		Filename: DATA.R8
 		Start: 4700
 		Length: 14
 		Offset: -48,64
 		Tick: 80
 		ZOffset: 1023
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4310
 		Offset: -30,-24
 
 repair_pad.atreides:
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4634
 		Length: 11
 		Offset: -48,48
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4645
 		Length: 10
 		Offset: -48,48
 		Tick: 100
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2819
 		Offset: -48,48
 		ZOffset: -1c511
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2820
 		Offset: -48,48
 		ZOffset: -1c511
-	active: DATA.R8
+	active:
+		Filename: DATA.R8
 		Start: 5010
 		Length: 14
 		Offset: -48,48
 		ZOffset: -1c511
-	damaged-active: DATA.R8
+	damaged-active:
+		Filename: DATA.R8
 		Start: 5010
 		Length: 14
 		Tick: 60
 		Offset: -48,48
 		ZOffset: -1c511
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4360
 		Offset: -30,-24
 
 repair_pad.harkonnen:
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4634
 		Length: 11
 		Offset: -48,48
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4645
 		Length: 10
 		Offset: -48,48
 		Tick: 100
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2979
 		Offset: -48,48
 		ZOffset: -1c511
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2980
 		Offset: -48,48
 		ZOffset: -1c511
-	active: DATA.R8
+	active:
+		Filename: DATA.R8
 		Start: 5010
 		Length: 14
 		Offset: -48,48
 		ZOffset: -1c511
-	damaged-active: DATA.R8
+	damaged-active:
+		Filename: DATA.R8
 		Start: 5010
 		Length: 14
 		Tick: 60
 		Offset: -48,48
 		ZOffset: -1c511
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4361
 		Offset: -30,-24
 
 repair_pad.ordos:
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4634
 		Length: 11
 		Offset: -48,48
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4645
 		Length: 10
 		Offset: -48,48
 		Tick: 100
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3139
 		Offset: -48,48
 		ZOffset: -1c511
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 3140
 		Offset: -48,48
 		ZOffset: -1c511
-	active: DATA.R8
+	active:
+		Filename: DATA.R8
 		Start: 5010
 		Length: 14
 		Offset: -48,48
 		ZOffset: -1c511
-	damaged-active: DATA.R8
+	damaged-active:
+		Filename: DATA.R8
 		Start: 5010
 		Length: 14
 		Tick: 60
 		Offset: -48,48
 		ZOffset: -1c511
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4362
 		Offset: -30,-24
 
 starport.atreides:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2919
 		ZOffset: -1c511
 		Offset: -48,48
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2920
 		ZOffset: -1c511
 		Offset: -48,48
-	active: DATA.R8
+	active:
+		Filename: DATA.R8
 		Start: 4986
 		Length: 7
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
-	damaged-active: DATA.R8
+	damaged-active:
+		Filename: DATA.R8
 		Start: 4986
 		Length: 7
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4611
 		Length: 12
 		Offset: -48,48
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4623
 		Length: 11
 		Offset: -48,48
 		Tick: 100
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4356
 		Offset: -30,-24
 
 power.atreides:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2771
 		Offset: -32,64
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4415
 		Length: 11
 		Offset: -32,64
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4426
 		Length: 13
 		Offset: -32,64
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2772
 		Offset: -32,64
-	idle-zaps: DATA.R8
+	idle-zaps:
+		Filename: DATA.R8
 		Start: 4756
 		Length: 10
 		Offset: -32,64
 		Tick: 200
-	damaged-idle-zaps: DATA.R8
+	damaged-idle-zaps:
+		Filename: DATA.R8
 		Start: 4761
 		Length: 5
 		Offset: -32,64
 		Tick: 200
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 617, 618, 637, 638
 		Length: 4
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 649, 650, 669, 670
 		Length: 4
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4320
 		Offset: -30,-24
 
 barracks.atreides:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2773
 		Offset: -32,64
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4439
 		Length: 11
 		Offset: -32,64
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4450
 		Length: 9
 		Offset: -32,64
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2774
 		Offset: -32,64
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 617, 618, 637, 638
 		Length: 4
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 649, 650, 669, 670
 		Length: 4
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4323
 		Offset: -30,-24
 
 outpost.atreides:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2769
 		Offset: -48,64
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4518
 		Length: 11
 		Offset: -48,64
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4529
 		Length: 9
 		Offset: -48,64
 		ZOffset: 1024
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2770
 		Offset: -48,64
-	idle-dish: DATA.R8
+	idle-dish:
+		Filename: DATA.R8
 		Start: 4786
 		Length: 30
 		Offset: -48,64
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4336
 		Offset: -30,-24
 
 refinery.atreides:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2809
 		Offset: -48,64
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4495
 		Length: 11
 		Offset: -48,64
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4506
 		Length: 12
 		Offset: -48,64
 		ZOffset: 1024
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2809
 		Offset: -48,64
-	idle-top: DATA.R8
+	idle-top:
+		Filename: DATA.R8
 		Start: 2810
 		Offset: -48,64
-	damaged-idle-top: DATA.R8
+	damaged-idle-top:
+		Filename: DATA.R8
 		Start: 2811
 		Offset: -48,64
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4330
 		Offset: -30,-24
-	smoke: DATA.R8
+	smoke:
+		Filename: DATA.R8
 		Start: 4138
 		Length: 14
 		Offset: 13,-16
@@ -413,514 +507,635 @@ refinery.atreides:
 		BlendMode: Additive
 
 silo.atreides:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2814
 		Offset: -16,16
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2818
 		Offset: -16,16
-	stages: DATA.R8
+	stages:
+		Filename: DATA.R8
 		Start: 2814
 		Length: 4
 		Offset: -16,16
-	damaged-stages: DATA.R8
+	damaged-stages:
+		Filename: DATA.R8
 		Start: 2818
 		Offset: -16,16
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4577
 		Length: 8
 		Offset: -16,16
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4585
 		Length: 7
 		Offset: -16,16
 		Tick: 100
 		ZOffset: 1024
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4348
 		Offset: -30,-24
 
 hightech.atreides:
 	Defaults:
 		Offset: -48,80
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2812
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4538
 		Length: 11
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4549
 		Length: 10
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2813
-	production-welding: DATA.R8
+	production-welding:
+		Filename: DATA.R8
 		Start: 4878
 		Length: 10
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
-	damaged-production-welding: DATA.R8
+	damaged-production-welding:
+		Filename: DATA.R8
 		Frames: 4878, 4879, 4880, 4881, 4882, 4884, 4885, 4886, 4887
 		Length: 9
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4342
 		Offset: -30,-24
 
 research.atreides:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2917
 		Offset: -48,80
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4655
 		Length: 11
 		Offset: -48,80
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4666
 		Length: 11
 		Offset: -48,80
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2918
 		Offset: -48,80
-	idle-lights: DATA.R8
+	idle-lights:
+		Filename: DATA.R8
 		Start: 5024
 		Length: 60
 		Tick: 80
 		Offset: -48,80
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4363
 		Offset: -30,-24
 
 research.harkonnen:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3077
 		Offset: -48,80
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4655
 		Length: 11
 		Offset: -48,80
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4666
 		Length: 11
 		Offset: -48,80
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 3078
 		Offset: -48,80
-	idle-lights: DATA.R8
+	idle-lights:
+		Filename: DATA.R8
 		Start: 5024
 		Length: 60
 		Tick: 80
 		Offset: -48,80
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4364
 		Offset: -30,-24
 
 research.ordos:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3237
 		Offset: -48,80
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4655
 		Length: 11
 		Offset: -48,80
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4666
 		Length: 11
 		Offset: -48,80
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 3238
 		Offset: -48,80
-	idle-lights: DATA.R8
+	idle-lights:
+		Filename: DATA.R8
 		Start: 5024
 		Length: 60
 		Tick: 80
 		Offset: -48,80
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4365
 		Offset: -30,-24
 
 palace.atreides:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2924
 		Offset: -48,48
-	active: DATA.R8
+	active:
+		Filename: DATA.R8
 		Start: 2924
 		Offset: -48,48
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4677
 		Length: 13
 		Offset: -48,48
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4690
 		Length: 10
 		Offset: -48,48
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2925
 		Offset: -48,48
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 631, 632, 633
 		Length: 3
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 663, 664, 665
 		Length: 3
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4366
 		Offset: -30,-24
 
 light.atreides:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2921
 		Offset: -48,64
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4559
 		Length: 9
 		Offset: -48,64
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4568
 		Length: 9
 		Offset: -48,64
 		ZOffset: 897
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2921
 		Offset: -48,64
-	idle-top: DATA.R8
+	idle-top:
+		Filename: DATA.R8
 		Start: 2922
 		Offset: -48,64
 		ZOffset: 896
-	damaged-idle-top: DATA.R8
+	damaged-idle-top:
+		Filename: DATA.R8
 		Start: 2923
 		Offset: -48,64
 		ZOffset: 896
-	production-welding: DATA.R8
+	production-welding:
+		Filename: DATA.R8
 		Start: 4908
 		Length: 10
 		Offset: -48,64
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
-	damaged-production-welding: DATA.R8
+	damaged-production-welding:
+		Filename: DATA.R8
 		Frames: 4908, 4909, 4910, 4912, 4914, 4917
 		Length: 6
 		Offset: -48,64
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4345
 		Offset: -30,-24
 
 heavy.atreides:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2766
 		Offset: -48,80
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4592
 		Length: 10
 		Offset: -48,80
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4602
 		Length: 9
 		Offset: -48,80
 		ZOffset: 897
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2766
 		Offset: -48,80
-	idle-top: DATA.R8
+	idle-top:
+		Filename: DATA.R8
 		Start: 2767
 		Offset: -48,80
 		ZOffset: 896
-	damaged-idle-top: DATA.R8
+	damaged-idle-top:
+		Filename: DATA.R8
 		Start: 2768
 		Offset: -48,80
 		ZOffset: 896
-	production-welding: DATA.R8
+	production-welding:
+		Filename: DATA.R8
 		Start: 4938
 		Length: 10
 		Offset: -48,80
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4351
 		Offset: -30,-24
 
 conyard.harkonnen:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2967
 		Offset: -48,64
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4373
 		Length: 30
 		Offset: -48,64
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4403
 		Length: 12
 		Offset: -48,64
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2968
 		Offset: -48,64
-	crane-overlay: DATA.R8
+	crane-overlay:
+		Filename: DATA.R8
 		Start: 4714
 		Length: 14
 		Offset: -48,64
 		Tick: 80
 		ZOffset: 1023
-	damaged-crane-overlay: DATA.R8
+	damaged-crane-overlay:
+		Filename: DATA.R8
 		Start: 4714
 		Length: 14
 		Offset: -48,64
 		Tick: 80
 		ZOffset: 1023
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4311
 		Offset: -30,-24
 
 starport.harkonnen:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3079
 		ZOffset: -1c511
 		Offset: -48,48
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 3080
 		Offset: -48,48
 		ZOffset: -1c511
-	active: DATA.R8
+	active:
+		Filename: DATA.R8
 		Start: 4993
 		Length: 7
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
-	damaged-active: DATA.R8
+	damaged-active:
+		Filename: DATA.R8
 		Start: 4993
 		Length: 7
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4611
 		Length: 12
 		Offset: -48,48
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4623
 		Length: 11
 		Offset: -48,48
 		Tick: 100
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4357
 		Offset: -30,-24
 
 power.harkonnen:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2931
 		Offset: -32,64
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4415
 		Length: 11
 		Offset: -32,64
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4426
 		Length: 13
 		Offset: -32,64
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2932
 		Offset: -32,64
-	idle-zaps: DATA.R8
+	idle-zaps:
+		Filename: DATA.R8
 		Start: 4766
 		Length: 10
 		Offset: -32,64
 		Tick: 200
-	damaged-idle-zaps: DATA.R8
+	damaged-idle-zaps:
+		Filename: DATA.R8
 		Start: 4771
 		Length: 5
 		Offset: -32,64
 		Tick: 200
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 617, 618, 637, 638
 		Length: 4
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 649, 650, 669, 670
 		Length: 4
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4321
 		Offset: -30,-24
 
 barracks.harkonnen:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2933
 		Offset: -32,64
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4477
 		Length: 9
 		Offset: -32,64
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4486
 		Length: 9
 		Offset: -32,64
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2934
 		Offset: -32,64
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 617, 618, 637, 638
 		Length: 4
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 649, 650, 669, 670
 		Length: 4
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4324
 		Offset: -30,-24
 
 outpost.harkonnen:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2929
 		Offset: -48,64
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4518
 		Length: 11
 		Offset: -48,64
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4529
 		Length: 9
 		Offset: -48,64
 		ZOffset: 1024
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2930
 		Offset: -48,64
-	idle-dish: DATA.R8
+	idle-dish:
+		Filename: DATA.R8
 		Start: 4817
 		Length: 30
 		Offset: -48,64
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4337
 		Offset: -30,-24
 
 refinery.harkonnen:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2969
 		Offset: -48,64
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4495
 		Length: 11
 		Offset: -48,64
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4506
 		Length: 12
 		Offset: -48,64
 		ZOffset: 1024
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2969
 		Offset: -48,64
-	idle-top: DATA.R8
+	idle-top:
+		Filename: DATA.R8
 		Start: 2970
 		Offset: -48,64
-	damaged-idle-top: DATA.R8
+	damaged-idle-top:
+		Filename: DATA.R8
 		Start: 2971
 		Offset: -48,64
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4331
 		Offset: -30,-24
-	smoke: DATA.R8
+	smoke:
+		Filename: DATA.R8
 		Start: 4138
 		Length: 14
 		Offset: 13,-16
@@ -928,407 +1143,503 @@ refinery.harkonnen:
 		BlendMode: Additive
 
 silo.harkonnen:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2974
 		Offset: -16,16
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2978
 		Offset: -16,16
-	stages: DATA.R8
+	stages:
+		Filename: DATA.R8
 		Start: 2974
 		Length: 4
 		Offset: -16,16
-	damaged-stages: DATA.R8
+	damaged-stages:
+		Filename: DATA.R8
 		Start: 2978
 		Offset: -16,16
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4577
 		Length: 8
 		Offset: -16,16
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4585
 		Length: 7
 		Offset: -16,16
 		Tick: 100
 		ZOffset: 1024
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4349
 		Offset: -30,-24
 
 hightech.harkonnen:
 	Defaults:
 		Offset: -48,80
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2972
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4538
 		Length: 11
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4549
 		Length: 10
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2973
-	production-welding: DATA.R8
+	production-welding:
+		Filename: DATA.R8
 		Start: 4888
 		Length: 10
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4343
 		Offset: -30,-24
 
 palace.harkonnen:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3084
 		Offset: -48,48
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4677
 		Length: 13
 		Offset: -48,48
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4690
 		Length: 10
 		Offset: -48,48
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 3085
 		Offset: -48,48
-	active: DATA.R8
+	active:
+		Filename: DATA.R8
 		Start: 5084
 		Length: 20
 		Offset: -48,48
-	damaged-active: DATA.R8
+	damaged-active:
+		Filename: DATA.R8
 		Start: 5084
 		Length: 20
 		Offset: -48,48
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 631, 632, 633
 		Length: 3
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 663, 664, 665
 		Length: 3
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4367
 		Offset: -30,-24
 
 light.harkonnen:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3081
 		Offset: -48,64
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4559
 		Length: 9
 		Offset: -48,64
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4568
 		Length: 9
 		Offset: -48,64
 		ZOffset: 897
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 3081
 		Offset: -48,64
-	idle-top: DATA.R8
+	idle-top:
+		Filename: DATA.R8
 		Start: 3082
 		Offset: -48,64
 		ZOffset: 896
-	damaged-idle-top: DATA.R8
+	damaged-idle-top:
+		Filename: DATA.R8
 		Start: 3083
 		Offset: -48,64
 		ZOffset: 896
-	production-welding: DATA.R8
+	production-welding:
+		Filename: DATA.R8
 		Start: 4918
 		Length: 10
 		Offset: -48,64
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4346
 		Offset: -30,-24
 
 heavy.harkonnen:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2926
 		Offset: -48,80
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4592
 		Length: 10
 		Offset: -48,80
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4602
 		Length: 9
 		Offset: -48,80
 		ZOffset: 897
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 2926
 		Offset: -48,80
-	idle-top: DATA.R8
+	idle-top:
+		Filename: DATA.R8
 		Start: 2927
 		Offset: -48,80
 		ZOffset: 896
-	damaged-idle-top: DATA.R8
+	damaged-idle-top:
+		Filename: DATA.R8
 		Start: 2928
 		Offset: -48,80
 		ZOffset: 896
-	production-welding: DATA.R8
+	production-welding:
+		Filename: DATA.R8
 		Start: 4948
 		Length: 10
 		Offset: -48,80
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4352
 		Offset: -30,-24
 
 conyard.ordos:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3127
 		Offset: -48,64
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4373
 		Length: 30
 		Offset: -48,64
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4403
 		Length: 12
 		Offset: -48,64
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 3128
 		Offset: -48,64
-	crane-overlay: DATA.R8
+	crane-overlay:
+		Filename: DATA.R8
 		Start: 4728
 		Length: 14
 		Offset: -48,64
 		Tick: 80
 		ZOffset: 1023
-	damaged-crane-overlay: DATA.R8
+	damaged-crane-overlay:
+		Filename: DATA.R8
 		Start: 4728
 		Length: 14
 		Offset: -48,64
 		Tick: 80
 		ZOffset: 1023
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4312
 		Offset: -30,-24
 
 starport.ordos:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3239
 		Offset: -48,48
 		ZOffset: -1c511
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 3240
 		Offset: -48,48
 		ZOffset: -1c511
-	active: DATA.R8
+	active:
+		Filename: DATA.R8
 		Start: 5001
 		Length: 7
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
-	damaged-active: DATA.R8
+	damaged-active:
+		Filename: DATA.R8
 		Start: 5001
 		Length: 7
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4611
 		Length: 12
 		Offset: -48,48
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4623
 		Length: 11
 		Offset: -48,48
 		Tick: 100
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4358
 		Offset: -30,-24
 
 power.ordos:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3091
 		Offset: -32,64
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4415
 		Length: 11
 		Offset: -32,64
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4426
 		Length: 13
 		Offset: -32,64
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 3092
 		Offset: -32,64
-	idle-zaps: DATA.R8
+	idle-zaps:
+		Filename: DATA.R8
 		Start: 4776
 		Length: 10
 		Offset: -32,64
 		Tick: 200
-	damaged-idle-zaps: DATA.R8
+	damaged-idle-zaps:
+		Filename: DATA.R8
 		Start: 4781
 		Length: 5
 		Offset: -32,64
 		Tick: 200
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 617, 618, 637, 638
 		Length: 4
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 649, 650, 669, 670
 		Length: 4
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4322
 		Offset: -30,-24
 
 barracks.ordos:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3093
 		Offset: -32,64
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4477
 		Length: 9
 		Offset: -32,64
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4486
 		Length: 9
 		Offset: -32,64
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 3094
 		Offset: -32,64
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 617, 618, 637, 638
 		Length: 4
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 649, 650, 669, 670
 		Length: 4
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4325
 		Offset: -30,-24
 
 outpost.ordos:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3089
 		Offset: -48,64
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4518
 		Length: 11
 		Offset: -48,64
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4529
 		Length: 9
 		Offset: -48,64
 		ZOffset: 1024
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 3090
 		Offset: -48,64
-	idle-dish: DATA.R8
+	idle-dish:
+		Filename: DATA.R8
 		Start: 4847
 		Length: 30
 		Offset: -48,64
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4338
 		Offset: -30,-24
 
 refinery.ordos:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3129
 		Offset: -48,64
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4495
 		Length: 11
 		Offset: -48,64
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4506
 		Length: 12
 		Offset: -48,64
 		ZOffset: 1024
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 3129
 		Offset: -48,64
-	idle-top: DATA.R8
+	idle-top:
+		Filename: DATA.R8
 		Start: 3130
 		Offset: -48,64
-	damaged-idle-top: DATA.R8
+	damaged-idle-top:
+		Filename: DATA.R8
 		Start: 3131
 		Offset: -48,64
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4332
 		Offset: -30,-24
-	smoke: DATA.R8
+	smoke:
+		Filename: DATA.R8
 		Start: 4138
 		Length: 14
 		Offset: 13,-16
@@ -1336,315 +1647,389 @@ refinery.ordos:
 		BlendMode: Additive
 
 silo.ordos:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3134
 		Offset: -16,16
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 3138
 		Offset: -16,16
-	stages: DATA.R8
+	stages:
+		Filename: DATA.R8
 		Start: 3134
 		Length: 4
 		Offset: -16,16
-	damaged-stages: DATA.R8
+	damaged-stages:
+		Filename: DATA.R8
 		Start: 3138
 		Offset: -16,16
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4577
 		Length: 8
 		Offset: -16,16
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4585
 		Length: 7
 		Offset: -16,16
 		ZOffset: 1024
 		Tick: 100
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4350
 		Offset: -30,-24
 
 hightech.ordos:
 	Defaults:
 		Offset: -48,80
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3132
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4538
 		Length: 11
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4549
 		Length: 10
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 3133
-	production-welding: DATA.R8
+	production-welding:
+		Filename: DATA.R8
 		Start: 4898
 		Length: 10
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4344
 		Offset: -30,-24
 
 palace.ordos:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3244
 		Offset: -48,48
-	active: DATA.R8
+	active:
+		Filename: DATA.R8
 		Start: 3244
 		Offset: -48,48
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4677
 		Length: 13
 		Offset: -48,48
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4690
 		Length: 10
 		Offset: -48,48
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 3245
 		Offset: -48,48
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 631, 632, 633
 		Length: 3
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 663, 664, 665
 		Length: 3
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4368
 		Offset: -30,-24
 
 light.ordos:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3241
 		Offset: -48,64
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4559
 		Length: 9
 		Offset: -48,64
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4568
 		Length: 9
 		Offset: -48,64
 		ZOffset: 897
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 3241
 		Offset: -48,64
-	idle-top: DATA.R8
+	idle-top:
+		Filename: DATA.R8
 		Start: 3242
 		Offset: -48,64
 		ZOffset: 896
-	damaged-idle-top: DATA.R8
+	damaged-idle-top:
+		Filename: DATA.R8
 		Start: 3243
 		Offset: -48,64
 		ZOffset: 896
-	production-welding: DATA.R8
+	production-welding:
+		Filename: DATA.R8
 		Start: 4928
 		Length: 10
 		Offset: -48,64
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4347
 		Offset: -30,-24
 
 heavy.ordos:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3086
 		Offset: -48,80
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4592
 		Length: 10
 		Offset: -48,80
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4602
 		Length: 9
 		Offset: -48,80
 		ZOffset: 897
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 3086
 		Offset: -48,80
-	idle-top: DATA.R8
+	idle-top:
+		Filename: DATA.R8
 		Start: 3087
 		Offset: -48,80
 		ZOffset: 896
-	damaged-idle-top: DATA.R8
+	damaged-idle-top:
+		Filename: DATA.R8
 		Start: 3088
 		Offset: -48,80
 		ZOffset: 896
-	production-welding: DATA.R8
+	production-welding:
+		Filename: DATA.R8
 		Start: 4958
 		Length: 10
 		Offset: -48,80
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4353
 		Offset: -30,-24
 
 palace.corrino:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3252
 		Offset: -48,48
-	active: DATA.R8
+	active:
+		Filename: DATA.R8
 		Start: 3252
 		Offset: -48,48
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 3253
 		Offset: -48,48
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 631, 632, 633
 		Length: 3
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 663, 664, 665
 		Length: 3
 		Offset: -16,-16
-	icon: palacecicon.shp
-	make: DATA.R8
+	icon:
+		Filename: palacecicon.shp
+	make:
+		Filename: DATA.R8
 		Start: 4677
 		Length: 13
 		Offset: -48,48
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4690
 		Length: 10
 		Offset: -48,48
 		Tick: 100
 
 starport.smuggler:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3247
 		Offset: -48,48
 		ZOffset: -1c511
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 3248
 		Offset: -48,48
 		ZOffset: -1c511
-	active: DATA.R8
+	active:
+		Filename: DATA.R8
 		Start: 5002
 		Length: 7
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
-	damaged-active: DATA.R8
+	damaged-active:
+		Filename: DATA.R8
 		Start: 5002
 		Length: 7
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4611
 		Length: 12
 		Offset: -48,48
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4623
 		Length: 11
 		Offset: -48,48
 		Tick: 100
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4358
 		Offset: -30,-24
 
 heavy.mercenary:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3249
 		Offset: -48,80
-	make: DATA.R8
+	make:
+		Filename: DATA.R8
 		Start: 4592
 		Length: 10
 		Offset: -48,80
-	crumble-overlay: DATA.R8
+	crumble-overlay:
+		Filename: DATA.R8
 		Start: 4602
 		Length: 9
 		Offset: -48,80
 		ZOffset: 897
 		Tick: 100
-	damaged-idle: DATA.R8
+	damaged-idle:
+		Filename: DATA.R8
 		Start: 3249
 		Offset: -48,80
-	idle-top: DATA.R8
+	idle-top:
+		Filename: DATA.R8
 		Start: 3250
 		Offset: -48,80
 		ZOffset: 896
-	damaged-idle-top: DATA.R8
+	damaged-idle-top:
+		Filename: DATA.R8
 		Start: 3251
 		Offset: -48,80
 		ZOffset: 896
-	production-welding: DATA.R8
+	production-welding:
+		Filename: DATA.R8
 		Start: 4968
 		Length: 8
 		Offset: -48,80
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
-	damaged-production-welding: DATA.R8
+	damaged-production-welding:
+		Filename: DATA.R8
 		Frames: 4968, 4970, 4972, 4973, 4974, 4975, 4976
 		Length: 7
 		Offset: -48,80
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
-	bib: BLOXBASE.R8
+	bib:
+		Filename: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE.R8
+	bib-Concrete:
+		Filename: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4353
 		Offset: -30,-24
 
 plates: # TODO: unused
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 3256
 		Length: 6
-	4-plates-icon: DATA.R8
+	4-plates-icon:
+		Filename: DATA.R8
 		Start: 4314
 		Offset: -30,-24
-	6-plates-icon: DATA.R8
+	6-plates-icon:
+		Filename: DATA.R8
 		Start: 4317
 		Offset: -30,-24

--- a/mods/d2k/sequences/vehicles.yaml
+++ b/mods/d2k/sequences/vehicles.yaml
@@ -1,260 +1,319 @@
 mcv:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 1795
 		Facings: -32
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4284
 		Offset: -30,-24
 
 mcv.husk:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 1795
 		Facings: -32
 		ZOffset: -1023
 
 harvester:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 1699
 		Facings: -32
-	harvest: DATA.R8
+	harvest:
+		Filename: DATA.R8
 		Start: 3884
 		Length: 6
 		Facings: -8
 		Tick: 80
 		ZOffset: 1
 		BlendMode: Multiply
-	dock: DATA.R8
+	dock:
+		Filename: DATA.R8
 		Start: 3623
 		Length: 10
-	dock-loop: DATA.R8
+	dock-loop:
+		Filename: DATA.R8
 		Start: 3633
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4280
 		Offset: -30,-24
 
 harvester.husk:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 1699
 		Facings: -32
 		ZOffset: -512
 
 trike:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 1635
 		Facings: -32
-	muzzle: DATA.R8
+	muzzle:
+		Filename: DATA.R8
 		Start: 4092
 		Tick: 50
 		Facings: -32
 		BlendMode: Additive
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4305
 		Offset: -30,-24
 
 quad:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 1667
 		Facings: -32
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4279
 		Offset: -30,-24
 
 siege_tank:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 1763
 		Facings: -32
-	turret: DATA.R8
+	turret:
+		Filename: DATA.R8
 		Start: 1891
 		Facings: -32
-	muzzle: DATA.R8
+	muzzle:
+		Filename: DATA.R8
 		Start: 3671
 		Length: 3
 		BlendMode: Additive
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4287
 		Offset: -30,-24
 
 siege_tank.husk:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 1763
 		Facings: -32
 		ZOffset: -512
-	turret: DATA.R8
+	turret:
+		Filename: DATA.R8
 		Start: 1891
 		Facings: -32
 		ZOffset: -512
 
 missile_tank:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 1603
 		Facings: -32
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4285
 		Offset: -30,-24
 
 missile_tank.husk:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 1603
 		Facings: -32
 		ZOffset: -512
 
 sonic_tank:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 1827
 		Facings: -32
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4288
 		Offset: -30,-24
 
 sonic_tank.husk:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 1827
 		Facings: -32
 		ZOffset: -512
 
 combat_tank_a:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 1731
 		Facings: -32
-	turret: DATA.R8
+	turret:
+		Filename: DATA.R8
 		Start: 1859
 		Facings: -32
-	muzzle: DATA.R8
+	muzzle:
+		Filename: DATA.R8
 		Start: 4028
 		Tick: 60
 		Facings: -32
 		BlendMode: Additive
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4281
 		Offset: -30,-24
 
 combat_tank_a.husk:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 1731
 		Facings: -32
 		ZOffset: -512
-	turret: DATA.R8
+	turret:
+		Filename: DATA.R8
 		Start: 1859
 		Facings: -32
 		ZOffset: -512
 
 combat_tank_h:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2051
 		Facings: -32
-	turret: DATA.R8
+	turret:
+		Filename: DATA.R8
 		Start: 2115
 		Facings: -32
-	muzzle: DATA.R8
+	muzzle:
+		Filename: DATA.R8
 		Start: 4028
 		Tick: 60
 		Facings: -32
 		BlendMode: Additive
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4282
 		Offset: -30,-24
 
 combat_tank_h.husk:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2051
 		Facings: -32
 		ZOffset: -512
-	turret: DATA.R8
+	turret:
+		Filename: DATA.R8
 		Start: 2115
 		Facings: -32
 		ZOffset: -512
 
 combat_tank_o:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2453
 		Facings: -32
-	turret: DATA.R8
+	turret:
+		Filename: DATA.R8
 		Start: 2485
 		Facings: -32
-	muzzle: DATA.R8
+	muzzle:
+		Filename: DATA.R8
 		Start: 4028
 		Tick: 60
 		Facings: -32
 		BlendMode: Additive
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4283
 		Offset: -30,-24
 
 combat_tank_o.husk:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2453
 		Facings: -32
 		ZOffset: -512
-	turret: DATA.R8
+	turret:
+		Filename: DATA.R8
 		Start: 2485
 		Facings: -32
 		ZOffset: -512
 
 devastator:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2083
 		Facings: -32
-	muzzle: DATA.R8
+	muzzle:
+		Filename: DATA.R8
 		Start: 4060
 		Tick: 80
 		Facings: -32
 		BlendMode: Additive
-	active: DATA.R8
+	active:
+		Filename: DATA.R8
 		Start: 3839
 		Length: 14
 		Tick: 130
 		BlendMode: Additive
-	active-2: DATA.R8
+	active-2:
+		Filename: DATA.R8
 		Start: 4152
 		Length: 12
 		Tick: 110
 		BlendMode: Additive
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4289
 		Offset: -30,-24
 
 devastator.husk:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2083
 		Facings: -32
 		ZOffset: -512
 
 raider:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2421
 		Facings: -32
-	muzzle: DATA.R8
+	muzzle:
+		Filename: DATA.R8
 		Start: 3996
 		Tick: 50
 		Facings: -32
 		BlendMode: Additive
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4278
 		Offset: -30,-24
 
 stealth_raider:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2421
 		Facings: -32
-	muzzle: DATA.R8
+	muzzle:
+		Filename: DATA.R8
 		Start: 3996
 		Tick: 50
 		Facings: -32
 		BlendMode: Additive
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4298
 		Offset: -30,-24
 
 deviator:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2389
 		Facings: -32
-	icon: DATA.R8
+	icon:
+		Filename: DATA.R8
 		Start: 4286
 		Offset: -30,-24
 
 deviator.husk:
-	idle: DATA.R8
+	idle:
+		Filename: DATA.R8
 		Start: 2389
 		Facings: -32
 		ZOffset: -512

--- a/mods/ra/maps/bomber-john/sequences.yaml
+++ b/mods/ra/maps/bomber-john/sequences.yaml
@@ -1,9 +1,12 @@
 miner:
 	idle:
+		Filename: miner.shp
 		Length: *
 		Tick: 400
 		ZOffset: -512
-	icon: jmin
+	icon:
+		Filename: jmin.shp
 
 brick:
 	idle:
+		Filename: brick.shp

--- a/mods/ra/maps/drop-zone-w/sequences.yaml
+++ b/mods/ra/maps/drop-zone-w/sequences.yaml
@@ -1,8 +1,12 @@
 lst:
-	muzzle: minigun
+	Defaults:
+		Filename: lst.shp
+	muzzle:
+		Filename: minigun.shp
 		Start: 0
 		Length: 6
 		Facings: 8
-	turret: mgun
+	turret:
+		Filename: mgun.shp
 		Start: 0
 		Facings: 32

--- a/mods/ra/maps/fort-lonestar/sequences.yaml
+++ b/mods/ra/maps/fort-lonestar/sequences.yaml
@@ -1,4 +1,6 @@
 sniper:
+	Defaults:
+		Filename: sniper.shp
 	stand:
 		Facings: 8
 	stand2:
@@ -66,24 +68,24 @@ sniper:
 		Start: 452
 		Length: 18
 		Tick: 80
-	die6: electro
+	die6:
+		Filename: electro.tem
+		TilesetFilenames:
+			SNOW: electro.sno
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	garrison-muzzle: minigun
+	garrison-muzzle:
+		Filename: minigun.shp
 		Length: 3
 		Stride: 6
 		Facings: 8
-	icon: snipericon
+	icon:
+		Filename: snipericon.shp

--- a/mods/ra/maps/oil-spill/sequences.yaml
+++ b/mods/ra/maps/oil-spill/sequences.yaml
@@ -1,4 +1,5 @@
 oilb.husk: oilb
-	idle: oilb
+	idle:
+		Filename: oilb.shp
 		Start: 1
 		Offset: 0,-6

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -241,11 +241,6 @@ VideoFormats: Vqa, Wsa
 TerrainFormat: DefaultTerrain
 
 SpriteSequenceFormat: ClassicTilesetSpecificSpriteSequence
-	TilesetExtensions:
-		TEMPERAT: .tem
-		SNOW: .sno
-		INTERIOR: .int
-		DESERT: .des
 
 ModelSequenceFormat: PlaceholderModelSequence
 

--- a/mods/ra/sequences/aircraft.yaml
+++ b/mods/ra/sequences/aircraft.yaml
@@ -1,90 +1,121 @@
 mig:
 	idle:
+		Filename: mig.shp
 		Facings: 16
 		InterpolatedFacings: 64
-	icon: migicon
+	icon:
+		Filename: migicon.shp
 
 yak:
 	idle:
+		Filename: yak.shp
 		Facings: 16
 		InterpolatedFacings: 64
-	muzzle: minigun
+	muzzle:
+		Filename: minigun.shp
 		Length: 6
 		Facings: 8
-	icon: yakicon
+	icon:
+		Filename: yakicon.shp
 
 heli:
 	idle:
+		Filename: heli.shp
 		Facings: 32
 		UseClassicFacings: True
-	rotor: lrotor
+	rotor:
+		Filename: lrotor.shp
 		Length: 4
-	slow-rotor: lrotor
+	slow-rotor:
+		Filename: lrotor.shp
 		Start: 4
 		Length: 8
-	icon: heliicon
+	icon:
+		Filename: heliicon.shp
 
 hind:
 	idle:
+		Filename: hind.shp
 		Facings: 32
 		UseClassicFacings: True
-	rotor: lrotorlg
+	rotor:
+		Filename: lrotorlg.shp
 		Length: 4
-	slow-rotor: lrotorlg
+	slow-rotor:
+		Filename: lrotorlg.shp
 		Start: 4
 		Length: 8
-	muzzle: minigun
+	muzzle:
+		Filename: minigun.shp
 		Length: 6
 		Facings: 8
-	icon: hindicon
+	icon:
+		Filename: hindicon.shp
 
 tran:
-	idle: tran2
+	idle:
+		Filename: tran2.shp
 		Facings: 32
 		UseClassicFacings: True
-	rotor: lrotor
+	rotor:
+		Filename: lrotor.shp
 		Length: 4
-	rotor2: rrotor
+	rotor2:
+		Filename: rrotor.shp
 		Length: 4
-	slow-rotor: lrotor
+	slow-rotor:
+		Filename: lrotor.shp
 		Start: 4
 		Length: 8
-	slow-rotor2: rrotor
+	slow-rotor2:
+		Filename: rrotor.shp
 		Start: 4
 		Length: 8
-	open: tran2
+	open:
+		Filename: tran2.shp
 		Start: 32
 		Length: 4
-	unload: tran2
+	unload:
+		Filename: tran2.shp
 		Start: 35
-	icon: tranicon
+	icon:
+		Filename: tranicon.shp
 
 tran1husk:
 	idle:
+		Filename: tran1husk.shp
 
 tran2husk:
 	idle:
+		Filename: tran2husk.shp
 
 u2:
 	idle:
+		Filename: u2.shp
 		Facings: 16
 		InterpolatedFacings: 64
 
 badr:
 	idle:
+		Filename: badr.shp
 		Facings: 16
 		InterpolatedFacings: 64
 
 mh60:
 	idle:
+		Filename: mh60.shp
 		Facings: 32
 		UseClassicFacings: True
-	rotor: yrotorlg
+	rotor:
+		Filename: yrotorlg.shp
 		Length: 4
-	slow-rotor: yrotorlg
+	slow-rotor:
+		Filename: yrotorlg.shp
 		Start: 4
 		Length: 8
-	muzzle: minigun
+	muzzle:
+		Filename: minigun.shp
 		Length: 6
 		Facings: 8
-	icon: mh60icon
+	icon:
+		Filename: mh60icon.shp

--- a/mods/ra/sequences/decorations.yaml
+++ b/mods/ra/sequences/decorations.yaml
@@ -1,17 +1,15 @@
 tc04:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: tc04.tem
+		TilesetFilenames:
+			SNOW: tc04.sno
 	idle:
 
 tc04.husk:
-	Defaults: tc04
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: tc04.tem
+		TilesetFilenames:
+			SNOW: tc04.sno
 	idle:
 		Start: 1
 	dead:
@@ -21,18 +19,16 @@ tc04.husk:
 
 tc05:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: tc05.tem
+		TilesetFilenames:
+			SNOW: tc05.sno
 	idle:
 
 tc05.husk:
-	Defaults: tc05
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: tc05.tem
+		TilesetFilenames:
+			SNOW: tc05.sno
 	idle:
 		Start: 1
 	dead:
@@ -42,18 +38,16 @@ tc05.husk:
 
 tc03:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: tc03.tem
+		TilesetFilenames:
+			SNOW: tc03.sno
 	idle:
 
 tc03.husk:
-	Defaults: tc03
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: tc03.tem
+		TilesetFilenames:
+			SNOW: tc03.sno
 	idle:
 		Start: 1
 	dead:
@@ -63,18 +57,16 @@ tc03.husk:
 
 tc02:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: tc02.tem
+		TilesetFilenames:
+			SNOW: tc02.sno
 	idle:
 
 tc02.husk:
-	Defaults: tc02
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: tc02.tem
+		TilesetFilenames:
+			SNOW: tc02.sno
 	idle:
 		Start: 1
 	dead:
@@ -84,16 +76,18 @@ tc02.husk:
 
 tc01:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
+		Filename: tc01.tem
+		TilesetFilenames:
+			SNOW: tc01.sno
+			DESERT: tc01.des
 	idle:
 
 tc01.husk:
-	Defaults: tc01
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: tc01.tem
+		TilesetFilenames:
+			SNOW: tc01.sno
+			DESERT: tc01.des
 	idle:
 		Start: 1
 	dead:
@@ -103,18 +97,16 @@ tc01.husk:
 
 t17:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: t17.tem
+		TilesetFilenames:
+			SNOW: t17.sno
 	idle:
 
 t17.husk:
-	Defaults: t17
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: t17.tem
+		TilesetFilenames:
+			SNOW: t17.sno
 	idle:
 		Start: 1
 	dead:
@@ -124,18 +116,16 @@ t17.husk:
 
 t16:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: t16.tem
+		TilesetFilenames:
+			SNOW: t16.sno
 	idle:
 
 t16.husk:
-	Defaults: t16
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: t16.tem
+		TilesetFilenames:
+			SNOW: t16.sno
 	idle:
 		Start: 1
 	dead:
@@ -144,19 +134,17 @@ t16.husk:
 		Tick: 80
 
 t15:
-	Defaults: t15
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: t15.tem
+		TilesetFilenames:
+			SNOW: t15.sno
 	idle:
 
 t15.husk:
-	Defaults: t15
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: t15.tem
+		TilesetFilenames:
+			SNOW: t15.sno
 	idle:
 		Start: 1
 	dead:
@@ -166,18 +154,16 @@ t15.husk:
 
 t14:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: t14.tem
+		TilesetFilenames:
+			SNOW: t14.sno
 	idle:
 
 t14.husk:
-	Defaults: t14
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: t14.tem
+		TilesetFilenames:
+			SNOW: t14.sno
 	idle:
 		Start: 1
 	dead:
@@ -187,18 +173,16 @@ t14.husk:
 
 t13:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: t13.tem
+		TilesetFilenames:
+			SNOW: t13.sno
 	idle:
 
 t13.husk:
-	Defaults: t13
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: t13.tem
+		TilesetFilenames:
+			SNOW: t13.sno
 	idle:
 		Start: 1
 	dead:
@@ -208,18 +192,16 @@ t13.husk:
 
 t12:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: t12.tem
+		TilesetFilenames:
+			SNOW: t12.sno
 	idle:
 
 t12.husk:
-	Defaults: t12
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: t12.tem
+		TilesetFilenames:
+			SNOW: t12.sno
 	idle:
 		Start: 1
 	dead:
@@ -229,18 +211,16 @@ t12.husk:
 
 t11:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: t11.tem
+		TilesetFilenames:
+			SNOW: t11.sno
 	idle:
 
 t11.husk:
-	Defaults: t11
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: t11.tem
+		TilesetFilenames:
+			SNOW: t11.sno
 	idle:
 		Start: 1
 	dead:
@@ -250,18 +230,16 @@ t11.husk:
 
 t10:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: t10.tem
+		TilesetFilenames:
+			SNOW: t10.sno
 	idle:
 
 t10.husk:
-	Defaults: t10
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: t10.tem
+		TilesetFilenames:
+			SNOW: t10.sno
 	idle:
 		Start: 1
 	dead:
@@ -271,16 +249,18 @@ t10.husk:
 
 t08:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
+		Filename: t08.tem
+		TilesetFilenames:
+			SNOW: t08.sno
+			DESERT: t08.des
 	idle:
 
 t08.husk:
-	Defaults: t08
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: t08.tem
+		TilesetFilenames:
+			SNOW: t08.sno
+			DESERT: t08.des
 	idle:
 		Start: 1
 	dead:
@@ -290,18 +270,16 @@ t08.husk:
 
 t07:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: t07.tem
+		TilesetFilenames:
+			SNOW: t07.sno
 	idle:
 
 t07.husk:
-	Defaults: t07
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: t07.tem
+		TilesetFilenames:
+			SNOW: t07.sno
 	idle:
 		Start: 1
 	dead:
@@ -311,18 +289,16 @@ t07.husk:
 
 t06:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: t06.tem
+		TilesetFilenames:
+			SNOW: t06.sno
 	idle:
 
 t06.husk:
-	Defaults: t06
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: t06.tem
+		TilesetFilenames:
+			SNOW: t06.sno
 	idle:
 		Start: 1
 	dead:
@@ -332,18 +308,16 @@ t06.husk:
 
 t05:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: t05.tem
+		TilesetFilenames:
+			SNOW: t05.sno
 	idle:
 
 t05.husk:
-	Defaults: t05
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: t05.tem
+		TilesetFilenames:
+			SNOW: t05.sno
 	idle:
 		Start: 1
 	dead:
@@ -353,18 +327,16 @@ t05.husk:
 
 t03:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: t03.tem
+		TilesetFilenames:
+			SNOW: t03.sno
 	idle:
 
 t03.husk:
-	Defaults: t03
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: t03.tem
+		TilesetFilenames:
+			SNOW: t03.sno
 	idle:
 		Start: 1
 	dead:
@@ -374,18 +346,16 @@ t03.husk:
 
 t02:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: t02.tem
+		TilesetFilenames:
+			SNOW: t02.sno
 	idle:
 
 t02.husk:
-	Defaults: t02
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: t02.tem
+		TilesetFilenames:
+			SNOW: t02.sno
 	idle:
 		Start: 1
 	dead:
@@ -395,18 +365,16 @@ t02.husk:
 
 t01:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: t01.tem
+		TilesetFilenames:
+			SNOW: t01.sno
 	idle:
 
 t01.husk:
-	Defaults: t01
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+	Defaults:
+		Filename: t01.tem
+		TilesetFilenames:
+			SNOW: t01.sno
 	idle:
 		Start: 1
 	dead:
@@ -415,66 +383,62 @@ t01.husk:
 		Tick: 80
 
 ice01:
-	idle: ice01.sno
+	idle:
+		Filename: ice01.sno
 		Length: *
-		AddExtension: false
 
 ice02:
-	idle: ice02.sno
+	idle:
+		Filename: ice02.sno
 		Length: *
-		AddExtension: false
 
 ice03:
-	idle: ice03.sno
+	idle:
+		Filename: ice03.sno
 		Length: *
-		AddExtension: false
 
 ice04:
-	idle: ice04.sno
+	idle:
+		Filename: ice04.sno
 		Length: *
-		AddExtension: false
 
 ice05:
-	idle: ice05.sno
+	idle:
+		Filename: ice05.sno
 		Length: *
-		AddExtension: false
 
 v01:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: v01.tem
+		TilesetFilenames:
+			SNOW: v01.sno
 	idle:
 	damaged-idle:
 		Start: 1
 
 v02:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: v02.tem
+		TilesetFilenames:
+			SNOW: v02.sno
 	idle:
 	damaged-idle:
 		Start: 1
 
 v03:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: v03.tem
+		TilesetFilenames:
+			SNOW: v03.sno
 	idle:
 	damaged-idle:
 		Start: 1
 
 v04:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: v04.tem
+		TilesetFilenames:
+			SNOW: v04.sno
 	idle:
 	damaged-idle:
 		Start: 2
@@ -485,80 +449,72 @@ v04:
 
 v05:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: v05.tem
+		TilesetFilenames:
+			SNOW: v05.sno
 	idle:
 	damaged-idle:
 		Start: 2
 
 v06:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: v06.tem
+		TilesetFilenames:
+			SNOW: v06.sno
 	idle:
 	damaged-idle:
 		Start: 1
 
 v07:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: v07.tem
+		TilesetFilenames:
+			SNOW: v07.sno
 	idle:
 	damaged-idle:
 		Start: 2
 
 v08:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: v08.tem
+		TilesetFilenames:
+			SNOW: v08.sno
 	idle:
 	damaged-idle:
 		Start: 1
 
 v09:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: v09.tem
+		TilesetFilenames:
+			SNOW: v09.sno
 	idle:
 	damaged-idle:
 		Start: 1
 
 v10:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: v10.tem
+		TilesetFilenames:
+			SNOW: v10.sno
 	idle:
 	damaged-idle:
 		Start: 1
 
 v11:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: v11.tem
+		TilesetFilenames:
+			SNOW: v11.sno
 	idle:
 	damaged-idle:
 		Start: 1
 
 v12:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: v12.tem
+		TilesetFilenames:
+			SNOW: v12.sno
 	idle:
 		ZOffset: -2c512
 	damaged-idle:
@@ -567,20 +523,18 @@ v12:
 
 v13:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: v13.tem
+		TilesetFilenames:
+			SNOW: v13.sno
 	idle:
 	damaged-idle:
 		Start: 1
 
 v14:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: v14.tem
+		TilesetFilenames:
+			SNOW: v14.sno
 	idle:
 		ZOffset: -2c512
 	damaged-idle:
@@ -589,10 +543,9 @@ v14:
 
 v15:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: v15.tem
+		TilesetFilenames:
+			SNOW: v15.sno
 	idle:
 		ZOffset: -2c512
 	damaged-idle:
@@ -601,10 +554,9 @@ v15:
 
 v16:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: v16.tem
+		TilesetFilenames:
+			SNOW: v16.sno
 	idle:
 		ZOffset: -2c512
 	damaged-idle:
@@ -613,10 +565,9 @@ v16:
 
 v17:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: v17.tem
+		TilesetFilenames:
+			SNOW: v17.sno
 	idle:
 		ZOffset: -2c512
 	damaged-idle:
@@ -625,10 +576,9 @@ v17:
 
 v18:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
+		Filename: v18.tem
+		TilesetFilenames:
+			SNOW: v18.sno
 	idle:
 		ZOffset: -2c512
 	damaged-idle:
@@ -636,32 +586,38 @@ v18:
 		ZOffset: -2c512
 
 rice:
-	Defaults:
-		AddExtension: false
-	idle: rice.tem
+	idle:
+		Filename: rice.tem
 		ZOffset: -2c512
-	damaged-idle: rice.tem
+	damaged-idle:
+		Filename: rice.tem
 		Start: 1
 		ZOffset: -2c512
 
 v19:
 	idle:
+		Filename: v19.shp
 		Length: 14
 
 v19.husk:
-	idle: v19
+	idle:
+		Filename: v19.shp
 		Start: 28
-	fire-start: flmspt
+	fire-start:
+		Filename: flmspt.shp
 		Length: *
 		Offset: 7,-15
 		ZOffset: 1
-	fire-loop: flmspt
+	fire-loop:
+		Filename: flmspt.shp
 		Start: 50
 		Length: *
 		Offset: 7,-15
 		ZOffset: 1
 
 utilpol1:
+	Defaults:
+		Filename: utilpol1.shp
 	idle:
 	damaged-idle:
 		Start: 1
@@ -669,6 +625,8 @@ utilpol1:
 		Start: 1
 
 utilpol2:
+	Defaults:
+		Filename: utilpol2.shp
 	idle:
 	damaged-idle:
 		Start: 1
@@ -677,30 +635,41 @@ utilpol2:
 
 ammobox1:
 	idle:
+		Filename: ammobox1.shp
 
 ammobox2:
 	idle:
+		Filename: ammobox2.shp
 
 ammobox3:
 	idle:
+		Filename: ammobox3.shp
 
 tanktrap1:
 	idle:
+		Filename: tanktrap1.shp
 
 tanktrap2:
 	idle:
+		Filename: tanktrap2.shp
 
 rushouse:
+	Defaults:
+		Filename: rushouse.shp
 	idle:
 	damaged-idle:
 		Start: 1
 
 asianhut:
+	Defaults:
+		Filename: asianhut.shp
 	idle:
 	damaged-idle:
 		Start: 1
 
 barb:
+	Defaults:
+		Filename: barb.shp
 	idle:
 		Length: 16
 	damaged-idle:
@@ -708,6 +677,8 @@ barb:
 		Length: 16
 
 wood:
+	Defaults:
+		Filename: wood.shp
 	idle:
 		Length: 16
 	damaged-idle:
@@ -716,250 +687,252 @@ wood:
 
 barl:
 	idle:
+		Filename: barl.shp
 
 brl3:
 	idle:
+		Filename: brl3.shp
 
 # Interior Terrain
 boxes01:
-	idle: boxes01.int
-		AddExtension: false
+	idle:
+		Filename: boxes01.int
 
 boxes02:
-	idle: boxes02.int
-		AddExtension: false
+	idle:
+		Filename: boxes02.int
 
 boxes03:
-	idle: boxes03.int
-		AddExtension: false
+	idle:
+		Filename: boxes03.int
 
 boxes04:
-	idle: boxes04.int
-		AddExtension: false
+	idle:
+		Filename: boxes04.int
 
 boxes05:
-	idle: boxes05.int
-		AddExtension: false
+	idle:
+		Filename: boxes05.int
 
 boxes06:
-	idle: boxes06.int
-		AddExtension: false
+	idle:
+		Filename: boxes06.int
 
 boxes07:
-	idle: boxes07.int
-		AddExtension: false
+	idle:
+		Filename: boxes07.int
 
 boxes08:
-	idle: boxes08.int
-		AddExtension: false
+	idle:
+		Filename: boxes08.int
 
 boxes09:
-	idle: boxes09.int
-		AddExtension: false
+	idle:
+		Filename: boxes09.int
 
 # Desert Terrain Expansion
 rock1:
-	idle: rock1.des
-		AddExtension: false
+	idle:
+		Filename: rock1.des
 
 rock2:
-	idle: rock2.des
-		AddExtension: false
+	idle:
+		Filename: rock2.des
 
 rock3:
-	idle: rock3.des
-		AddExtension: false
+	idle:
+		Filename: rock3.des
 
 rock4:
-	idle: rock4.des
-		AddExtension: false
+	idle:
+		Filename: rock4.des
 
 rock5:
-	idle: rock5.des
-		AddExtension: false
+	idle:
+		Filename: rock5.des
 
 rock6:
-	idle: rock6.des
-		AddExtension: false
+	idle:
+		Filename: rock6.des
 
 rock7:
-	idle: rock7.des
-		AddExtension: false
+	idle:
+		Filename: rock7.des
 
 t04:
-	Defaults:
-		AddExtension: false
-	idle: t04.des
+	idle:
+		Filename: t04.des
 
 t04.husk:
-	Defaults: t04.des
-		AddExtension: false
+	Defaults:
+		Filename: t04.des
 	idle:
 		Start: 1
-	dead: t04.des
+	dead:
+		Filename: t04.des
 		Start: 2
 		Length: 8
 		Tick: 80
 
 t09:
-	Defaults:
-		AddExtension: false
-	idle: t09.des
+	idle:
+		Filename: t09.des
 
 t09.husk:
-	Defaults: t09
-		AddExtension: false
-	idle: t09.des
+	idle:
+		Filename: t09.des
 		Start: 1
-	dead: t09.des
+	dead:
+		Filename: t09.des
 		Start: 2
 		Length: 8
 		Tick: 80
 
 v20:
-	Defaults:
-		AddExtension: false
-	idle: v20.des
+	idle:
+		Filename: v20.des
 		Length: 3
 		Tick: 120
-	damaged-idle: v20.des
+	damaged-idle:
+		Filename: v20.des
 		Start: 3
 		Length: 3
 		Tick: 120
 
 v21:
-	Defaults:
-		AddExtension: false
-	idle: v21.des
+	idle:
+		Filename: v21.des
 		Length: 3
 		Tick: 120
-	damaged-idle: v21.des
+	damaged-idle:
+		Filename: v21.des
 		Start: 3
 		Length: 3
 		Tick: 120
 
 v22:
-	Defaults:
-		AddExtension: false
-	idle: v22.des
+	idle:
+		Filename: v22.des
 		Length: 3
 		Tick: 120
-	damaged-idle: v22.des
+	damaged-idle:
+		Filename: v22.des
 		Start: 3
 		Length: 3
 		Tick: 120
 
 v23:
-	Defaults:
-		AddExtension: false
-	idle: v23.des
+	idle:
+		Filename: v23.des
 		Length: 3
 		Tick: 120
-	damaged-idle: v23.des
+	damaged-idle:
+		Filename: v23.des
 		Start: 3
 		Length: 3
 		Tick: 120
 
 v24:
-	Defaults:
-		AddExtension: false
-	idle: v24.des
-	damaged-idle: v24.des
+	idle:
+		Filename: v24.des
+	damaged-idle:
+		Filename: v24.des
 		Start: 1
 
 v25:
-	Defaults:
-		AddExtension: false
-	idle: v25.des
-	damaged-idle: v25.des
+	idle:
+		Filename: v25.des
+	damaged-idle:
+		Filename: v25.des
 		Start: 1
 
 v26:
-	Defaults:
-		AddExtension: false
-	idle: v26.des
-	damaged-idle: v26.des
+	idle:
+		Filename: v26.des
+	damaged-idle:
+		Filename: v26.des
 		Start: 1
 
 v27:
-	Defaults:
-		AddExtension: false
-	idle: v27.des
-	damaged-idle: v27.des
+	idle:
+		Filename: v27.des
+	damaged-idle:
+		Filename: v27.des
 		Start: 1
 
 v28:
-	Defaults:
-		AddExtension: false
-	idle: v28.des
-	damaged-idle: v28.des
+	idle:
+		Filename: v28.des
+	damaged-idle:
+		Filename: v28.des
 		Start: 1
 
 v29:
-	Defaults:
-		AddExtension: false
-	idle: v29.des
-	damaged-idle: v29.des
+	idle:
+		Filename: v29.des
+	damaged-idle:
+		Filename: v29.des
 		Start: 1
 
 v30:
-	Defaults:
-		AddExtension: false
-	idle: v30.des
-	damaged-idle: v30.des
+	idle:
+		Filename: v30.des
+	damaged-idle:
+		Filename: v30.des
 		Start: 2
 
 v31:
-	Defaults:
-		AddExtension: false
-	idle: v31.des
-	damaged-idle: v31.des
+	idle:
+		Filename: v31.des
+	damaged-idle:
+		Filename: v31.des
 		Start: 1
 
 v32:
-	Defaults:
-		AddExtension: false
-	idle: v32.des
-	damaged-idle: v32.des
+	idle:
+		Filename: v32.des
+	damaged-idle:
+		Filename: v32.des
 		Start: 1
 
 v33:
-	Defaults:
-		AddExtension: false
-	idle: v33.des
-	damaged-idle: v33.des
+	idle:
+		Filename: v33.des
+	damaged-idle:
+		Filename: v33.des
 		Start: 1
 
 v34:
-	Defaults:
-		AddExtension: false
-	idle: v34.des
-	damaged-idle: v34.des
+	idle:
+		Filename: v34.des
+	damaged-idle:
+		Filename: v34.des
 		Start: 1
 
 v35:
-	Defaults:
-		AddExtension: false
-	idle: v35.des
-	damaged-idle: v35.des
+	idle:
+		Filename: v35.des
+	damaged-idle:
+		Filename: v35.des
 		Start: 1
 
 v36:
-	Defaults:
-		AddExtension: false
-	idle: v36.des
-	damaged-idle: v36.des
+	idle:
+		Filename: v36.des
+	damaged-idle:
+		Filename: v36.des
 		Start: 1
 
 v37:
-	Defaults:
-		AddExtension: false
-	idle: v37.des
-	damaged-idle: v37.des
+	idle:
+		Filename: v37.des
+	damaged-idle:
+		Filename: v37.des
 		Start: 1
 
 snowhut:
 	Defaults:
+		Filename: snowhut.shp
 		Offset: 0,-5
 		Scale: 0.7
 	idle:
@@ -971,6 +944,7 @@ snowhut:
 
 lhus:
 	Defaults:
+		Filename: lhus.shp
 		Offset: 0,-16
 	idle:
 		Length: 16
@@ -982,6 +956,7 @@ lhus:
 
 windmill:
 	Defaults:
+		Filename: windmill.shp
 		Offset: 0,-16
 	idle:
 		Length: 8

--- a/mods/ra/sequences/infantry.yaml
+++ b/mods/ra/sequences/infantry.yaml
@@ -1,4 +1,6 @@
 e1:
+	Defaults:
+		Filename: e1.shp
 	stand:
 		Facings: 8
 	stand2:
@@ -68,53 +70,63 @@ e1:
 		Start: 324
 		Length: 18
 		Tick: 80
-	die6: electro
+	die6:
+		Filename: electro.tem
+		TilesetFilenames:
+			SNOW: electro.sno
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: *
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
 	garrison-muzzle: minigun
+		Filename:
 		Length: 12
 		Facings: 8
 		Combine:
-			minigun:
+			0:
+				Filename: minigun.shp
 				Length: 12
 				Frames: 0,1,2,3,4,5,0,1,2,3,4,5
-			minigun:
+			1:
+				Filename: minigun.shp
 				Length: 12
 				Frames: 6,7,8,9,10,11,6,7,8,9,10,11
-			minigun:
+			2:
+				Filename: minigun.shp
 				Length: 12
 				Frames: 12,13,14,15,16,17,12,13,14,15,16,17
-			minigun:
+			3:
+				Filename: minigun.shp
 				Length: 12
 				Frames: 18,19,20,21,22,23,18,19,20,21,22,23
-			minigun:
+			4:
+				Filename: minigun.shp
 				Length: 12
 				Frames: 24,25,26,27,28,29,24,25,26,27,28,29
-			minigun:
+			5:
+				Filename: minigun.shp
 				Length: 12
 				Frames: 30,31,32,33,34,35,30,31,32,33,34,35
-			minigun:
+			6:
+				Filename: minigun.shp
 				Length: 12
 				Frames: 36,37,38,39,40,41,36,37,38,39,40,41
-			minigun:
+			7:
+				Filename: minigun.shp
 				Length: 12
 				Frames: 42,43,44,45,46,47,42,43,44,45,46,47
-	icon: e1icon
+	icon:
+		Filename: e1icon.shp
 
 e3:
+	Defaults:
+		Filename: e3.shp
 	stand:
 		Facings: 8
 	stand2:
@@ -159,22 +171,20 @@ e3:
 		Start: 340
 		Length: 18
 		Tick: 80
-	die6: electro
+	die6:
+		Filename: electro.tem
+		TilesetFilenames:
+			SNOW: electro.sno
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
 	prone-stand:
 		Start: 144
 		Stride: 4
@@ -192,9 +202,12 @@ e3:
 		Start: 192
 		Length: 10
 		Facings: 8
-	icon: e3icon
+	icon:
+		Filename: e3icon.shp
 
 e6:
+	Defaults:
+		Filename: e6.shp
 	stand:
 		Facings: 8
 	stand2:
@@ -235,22 +248,20 @@ e6:
 		Start: 182
 		Length: 18
 		Tick: 80
-	die6: electro
+	die6:
+		Filename: electro.tem
+		TilesetFilenames:
+			SNOW: electro.sno
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
 	prone-stand:
 		Start: 82
 		Stride: 4
@@ -264,9 +275,12 @@ e6:
 		Length: 4
 		Facings: 8
 		Tick: 100
-	icon: e6icon
+	icon:
+		Filename: e6icon.shp
 
 medi:
+	Defaults:
+		Filename: medi.shp
 	stand:
 		Facings: 8
 	run:
@@ -306,22 +320,20 @@ medi:
 		Start: 229
 		Length: 18
 		Tick: 80
-	die6: electro
+	die6:
+		Filename: electro.tem
+		TilesetFilenames:
+			SNOW: electro.sno
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
 	prone-stand:
 		Start: 130
 		Stride: 4
@@ -331,9 +343,12 @@ medi:
 		Length: 4
 		Facings: 8
 		Tick: 100
-	icon: mediicon
+	icon:
+		Filename: mediicon.shp
 
 mech:
+	Defaults:
+		Filename: mech.shp
 	stand:
 		Facings: 8
 	run:
@@ -373,22 +388,20 @@ mech:
 		Start: 229
 		Length: 18
 		Tick: 80
-	die6: electro
+	die6:
+		Filename: electro.tem
+		TilesetFilenames:
+			SNOW: electro.sno
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
 	prone-stand:
 		Start: 130
 		Stride: 4
@@ -398,9 +411,12 @@ mech:
 		Length: 4
 		Facings: 8
 		Tick: 100
-	icon: mechicon
+	icon:
+		Filename: mechicon.shp
 
 e2:
+	Defaults:
+		Filename: e2.shp
 	stand:
 		Facings: 8
 	stand2:
@@ -445,22 +461,20 @@ e2:
 		Start: 452
 		Length: 18
 		Tick: 80
-	die6: electro
+	die6:
+		Filename: electro.tem
+		TilesetFilenames:
+			SNOW: electro.sno
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
 	prone-stand:
 		Start: 240
 		Stride: 4
@@ -478,9 +492,12 @@ e2:
 		Start: 288
 		Length: 12
 		Facings: 8
-	icon: e2icon
+	icon:
+		Filename: e2icon.shp
 
 dog:
+	Defaults:
+		Filename: dog.shp
 	stand:
 		Facings: 8
 	walk:
@@ -526,23 +543,27 @@ dog:
 		Start: 251
 		Length: 14
 		Tick: 80
-	die6: electdog
+	die6:
+		Filename: electdog.shp
 		Length: *
 		Tick: 80
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	jump: dogbullt
+	jump:
+		Filename: dogbullt.shp
 		Length: 4
 		Facings: 8
-	icon: dogicon
+	icon:
+		Filename: dogicon.shp
 
 spy:
+	Defaults:
+		Filename: spy.shp
 	stand:
 		Facings: 8
 	stand2:
@@ -585,22 +606,20 @@ spy:
 		Start: 324
 		Length: 18
 		Tick: 80
-	die6: electro
+	die6:
+		Filename: electro.tem
+		TilesetFilenames:
+			SNOW: electro.sno
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
 	prone-stand:
 		Start: 144
 		Stride: 4
@@ -618,9 +637,12 @@ spy:
 		Start: 192
 		Length: 8
 		Facings: 8
-	icon: spyicon
+	icon:
+		Filename: spyicon.shp
 
 thf:
+	Defaults:
+		Filename: thf.shp
 	stand:
 		Facings: 8
 	run:
@@ -652,22 +674,20 @@ thf:
 		Start: 175
 		Length: 18
 		Tick: 80
-	die6: electro
+	die6:
+		Filename: electro.tem
+		TilesetFilenames:
+			SNOW: electro.sno
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
 	prone-stand:
 		Start: 72
 		Stride: 4
@@ -677,9 +697,12 @@ thf:
 		Length: 4
 		Facings: 8
 		Tick: 80
-	icon: thficon
+	icon:
+		Filename: thficon.shp
 
 e7:
+	Defaults:
+		Filename: e7.shp
 	stand:
 		Facings: 8
 	run:
@@ -688,44 +711,56 @@ e7:
 		Facings: 8
 		Tick: 80
 	shoot-left:
+		Filename:
 		Combine:
-			e7:
+			0:
+				Filename: e7.shp
 				Length: 8
 				Frames: 58, 56, 64, 63, 71, 70, 79, 77
-			e7:
+			1:
+				Filename: e7.shp
 				Length: 2
 				Frames: 85, 84
 				Offset: 1, 0
-			e7:
+			2:
+				Filename: e7.shp
 				Length: 2
 				Frames: 92, 91
-			e7:
+			3:
+				Filename: e7.shp
 				Length: 2
 				Frames: 99, 98
 				Offset: 1, -2
-			e7:
+			4:
+				Filename: e7.shp
 				Length: 2
 				Frames: 107, 105
 				Offset: 0, -2
 		Length: 2
 		Facings: 8
 	shoot-right:
+		Filename:
 		Combine:
-			e7:
+			0:
+				Filename: e7.shp
 				Length: 8
 				Frames: 57, 56, 65, 63, 72, 70, 78, 77
-			e7:
+			1:
+				Filename: e7.shp
 				Length: 2
 				Frames: 86, 84
 				Offset: 1, 0
-			e7:
+			2:
+				Filename: e7.shp
 				Length: 2
 				Frames: 93, 91
-			e7:
+			3:
+				Filename: e7.shp
 				Length: 2
 				Frames: 100, 98
 				Offset: 1, -2
-			e7:
+			4:
+				Filename: e7.shp
 				Length: 2
 				Frames: 106, 105
 				Offset: 0, -2
@@ -759,22 +794,20 @@ e7:
 		Start: 298
 		Length: 18
 		Tick: 80
-	die6: electro
+	die6:
+		Filename: electro.tem
+		TilesetFilenames:
+			SNOW: electro.sno
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
 	prone-stand:
 		Start: 128
 		Stride: 4
@@ -792,13 +825,17 @@ e7:
 		Frames: 178, 177, 186, 184, 193, 191, 199, 198, 207, 205, 214, 212, 221, 219, 227, 226
 		Length: 2
 		Facings: 8
-	garrison-muzzle: minigun
+	garrison-muzzle:
+		Filename: minigun.shp
 		Length: 3
 		Stride: 6
 		Facings: 8
-	icon: e7icon
+	icon:
+		Filename: e7icon.shp
 
 e4:
+	Defaults:
+		Filename: e4.shp
 	stand:
 		Facings: 8
 	stand2:
@@ -843,22 +880,20 @@ e4:
 		Start: 452
 		Length: 18
 		Tick: 80
-	die6: electro
+	die6:
+		Filename: electro.tem
+		TilesetFilenames:
+			SNOW: electro.sno
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
 	prone-stand:
 		Start: 208
 		Stride: 4
@@ -876,9 +911,12 @@ e4:
 		Start: 256
 		Length: 16
 		Facings: 8
-	icon: e4icon
+	icon:
+		Filename: e4icon.shp
 
 gnrl:
+	Defaults:
+		Filename: gnrl.shp
 	stand:
 		Facings: 8
 	run:
@@ -931,24 +969,24 @@ gnrl:
 		Start: 246
 		Length: 18
 		Tick: 80
-	die6: electro
+	die6:
+		Filename: electro.tem
+		TilesetFilenames:
+			SNOW: electro.sno
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
 
 shok:
+	Defaults:
+		Filename: shok.shp
 	stand:
 		Facings: 8
 	stand2:
@@ -1018,25 +1056,26 @@ shok:
 		Start: 452
 		Length: 18
 		Tick: 80
-	die6: electro
+	die6:
+		Filename: electro.tem
+		TilesetFilenames:
+			SNOW: electro.sno
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	icon: shokicon
+	icon:
+		Filename: shokicon.shp
 
 c1:
+	Defaults:
+		Filename: c1.shp
 	stand:
 		Facings: 8
 	panic-stand:
@@ -1069,22 +1108,20 @@ c1:
 		Start: 180
 		Length: 18
 		Tick: 80
-	die6: electro
+	die6:
+		Filename: electro.tem
+		TilesetFilenames:
+			SNOW: electro.sno
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
 	run:
 		Start: 56
 		Length: 6
@@ -1092,6 +1129,8 @@ c1:
 		Tick: 80
 
 c2:
+	Defaults:
+		Filename: c2.shp
 	stand:
 		Facings: 8
 	panic-stand:
@@ -1124,22 +1163,20 @@ c2:
 		Start: 180
 		Length: 18
 		Tick: 80
-	die6: electro
+	die6:
+		Filename: electro.tem
+		TilesetFilenames:
+			SNOW: electro.sno
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
 	run:
 		Start: 56
 		Length: 6
@@ -1147,6 +1184,8 @@ c2:
 		Tick: 80
 
 c11:
+	Defaults:
+		Filename: c11.shp
 	stand:
 		Facings: 8
 	panic-stand:
@@ -1179,22 +1218,20 @@ c11:
 		Start: 180
 		Length: 18
 		Tick: 80
-	die6: electro
+	die6:
+		Filename: electro.tem
+		TilesetFilenames:
+			SNOW: electro.sno
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
 	run:
 		Start: 56
 		Length: 6
@@ -1202,6 +1239,8 @@ c11:
 		Tick: 80
 
 einstein:
+	Defaults:
+		Filename: einstein.shp
 	stand:
 		Facings: 8
 	panic-stand:
@@ -1235,24 +1274,24 @@ einstein:
 		Start: 148
 		Length: 17
 		Tick: 80
-	die6: electro
+	die6:
+		Filename: electro.tem
+		TilesetFilenames:
+			SNOW: electro.sno
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
 
 delphi:
+	Defaults:
+		Filename: delphi.shp
 	stand:
 		Facings: 8
 	panic-stand:
@@ -1286,24 +1325,24 @@ delphi:
 		Start: 357
 		Length: 17
 		Tick: 80
-	die6: electro
+	die6:
+		Filename: electro.tem
+		TilesetFilenames:
+			SNOW: electro.sno
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
 
 chan:
+	Defaults:
+		Filename: chan.shp
 	stand:
 		Facings: 8
 	panic-stand:
@@ -1337,24 +1376,24 @@ chan:
 		Start: 148
 		Length: 17
 		Tick: 80
-	die6: electro
+	die6:
+		Filename: electro.tem
+		TilesetFilenames:
+			SNOW: electro.sno
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
 
 zombie:
+	Defaults:
+		Filename: zombie.shp
 	stand:
 		Facings: 8
 	stand2:
@@ -1393,86 +1432,103 @@ zombie:
 		Start: 114
 		Length: 19
 		Tick: 80
-	die6: electro
+	die6:
+		Filename: electro.tem
+		TilesetFilenames:
+			SNOW: electro.sno
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	die-crushed: corpse1
+	die-crushed:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
-	icon: zombicon
+	icon:
+		Filename: zombicon.shp
 
 ant:
-	stand: ant1
+	stand:
+		Filename: ant1.shp
 		Facings: 8
-	run: ant1
+	run:
+		Filename: ant1.shp
 		Start: 8
 		Length: 8
 		Facings: 8
-	bite: ant1
+	bite:
+		Filename: ant1.shp
 		Start: 72
 		Length: 4
 		Facings: 8
-	die: ant1
+	die:
+		Filename: ant1.shp
 		Start: 104
 		Length: 8
 		Tick: 300
-	die-crushed: ant1
+	die-crushed:
+		Filename: ant1.shp
 		Start: 104
 		Length: 8
 		Tick: 400
 		ZOffset: -511
-	icon: anticon
+	icon:
+		Filename: anticon.shp
 
 fireant:
-	stand: ant2
+	stand:
+		Filename: ant2.shp
 		Facings: 8
-	run: ant2
+	run:
+		Filename: ant2.shp
 		Start: 8
 		Length: 8
 		Facings: 8
-	bite: ant2
+	bite:
+		Filename: ant2.shp
 		Start: 72
 		Length: 4
 		Facings: 8
-	die: ant2
+	die:
+		Filename: ant2.shp
 		Start: 104
 		Length: 8
 		Tick: 300
-	die-crushed: ant2
+	die-crushed:
+		Filename: ant2.shp
 		Start: 104
 		Length: 8
 		Tick: 400
 		ZOffset: -511
-	icon: anticon
+	icon:
+		Filename: anticon.shp
 
 scoutant:
-	stand: ant3
+	stand:
+		Filename: ant3.shp
 		Facings: 8
-	run: ant3
+	run:
+		Filename: ant3.shp
 		Start: 8
 		Length: 8
 		Facings: 8
-	bite: ant3
+	bite:
+		Filename: ant3.shp
 		Start: 72
 		Length: 4
 		Facings: 8
-	die: ant3
+	die:
+		Filename: ant3.shp
 		Start: 104
 		Length: 8
 		Tick: 300
-	die-crushed: ant3
+	die-crushed:
+		Filename: ant3.shp
 		Start: 104
 		Length: 8
 		Tick: 400
 		ZOffset: -511
-	icon: anticon
+	icon:
+		Filename: anticon.shp

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -1,61 +1,88 @@
 clock:
 	idle:
+		Filename: clock.shp
 		Length: *
 
 powerdown:
-	disabled: speed
+	disabled:
+		Filename: speed.shp
 		Start: 3
 		ZOffset: 2047
 
 120mm:
 	idle:
+		Filename: 120mm.shp
 		ZOffset: 1023
 
 50cal:
 	idle:
+		Filename: 50cal.shp
 		ZOffset: 1023
 
 explosion:
 	Defaults:
 		Length: *
 		ZOffset: 2047
-	piff: piff
-	piffs: piffpiff
-	water_piff: wpiff
-	water_piffs: wpifpif
-	small_explosion: veh-hit3
-	med_explosion: veh-hit2
-	flak_explosion_ground: flak
-	small_explosion_air: flak
+	piff:
+		Filename: piff.shp
+	piffs:
+		Filename: piffpiff.shp
+	water_piff:
+		Filename: wpiff.shp
+	water_piffs:
+		Filename: wpifpif.shp
+	small_explosion:
+		Filename: veh-hit3.shp
+	med_explosion:
+		Filename: veh-hit2.shp
+	flak_explosion_ground:
+		Filename: flak.shp
+	small_explosion_air:
+		Filename: flak.shp
 		ZOffset: 511 # only used by AA weapons, so a high ZOffset to overlay buildings isn't needed
-	med_explosion_air: veh-hit1
+	med_explosion_air:
+		Filename: veh-hit1.shp
 		ZOffset: 511 # only used by AA weapons, so a high ZOffset to overlay buildings isn't needed
-	large_splash: h2o_exp1
-	napalm: napalm2
-	building_napalm: napalm2
+	large_splash:
+		Filename: h2o_exp1.shp
+	napalm:
+		Filename: napalm2.shp
+	building_napalm:
+		Filename: napalm2.shp
 		FlipX: true
-	nuke: atomsfx
-	med_splash: h2o_exp2
-	self_destruct: art-exp1
-	artillery_explosion: art-exp1
-	building: fball1
+	nuke:
+		Filename: atomsfx.shp
+	med_splash:
+		Filename: h2o_exp2.shp
+	self_destruct:
+		Filename: art-exp1.shp
+	artillery_explosion:
+		Filename: art-exp1.shp
+	building:
+		Filename: fball1.shp
 		Offset: 0,-9
-	small_splash: h2o_exp3
-	large_explosion: frag1
+	small_splash:
+		Filename: h2o_exp3.shp
+	large_explosion:
+		Filename: frag1.shp
 		Offset: -2,0
-	small_napalm: napalm1
-	offset_napalm: napalm1 # Used for E4 Explosion
+	small_napalm:
+		Filename: napalm1.shp
+	offset_napalm: # Used for E4 Explosion
+		Filename: napalm1.shp
 		Offset: 0, -6
-	large_napalm: napalm3
-	corpse: corpse1
+	large_napalm:
+		Filename: napalm3.shp
+	corpse:
+		Filename: corpse1.tem
+		TilesetFilenames:
+			SNOW: corpse1.sno
 		ZOffset: -512
 		Tick: 1600
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
-			INTERIOR: TEMPERAT
 
 burn-l:
+	Defaults:
+		Filename: burn-l.shp
 	idle:
 		Length: *
 		ZOffset: 512
@@ -69,6 +96,8 @@ burn-l:
 		ZOffset: 512
 
 burn-m:
+	Defaults:
+		Filename: burn-m.shp
 	idle:
 		Length: *
 		ZOffset: 512
@@ -82,6 +111,8 @@ burn-m:
 		ZOffset: 512
 
 burn-s:
+	Defaults:
+		Filename: burn-s.shp
 	idle:
 		Length: *
 		ZOffset: 512
@@ -95,6 +126,8 @@ burn-s:
 		ZOffset: 512
 
 pips:
+	Defaults:
+		Filename: pips.shp
 	groups:
 		Length: 10
 		Frames: 9, 10, 11, 12, 13, 14, 15, 16, 17, 8
@@ -112,63 +145,83 @@ pips:
 	tag-primary:
 		Start: 2
 		Offset: 0, 2
-	tag-spy: tag-spy
-	pip-empty: pips2
-	pip-green: pips2
+	tag-spy:
+		Filename: tag-spy.shp
+	pip-empty:
+		Filename: pips2.shp
+	pip-green:
+		Filename: pips2.shp
 		Start: 1
-	pip-yellow: pips2
+	pip-yellow:
+		Filename: pips2.shp
 		Start: 2
-	pip-gray: pips2
+	pip-gray:
+		Filename: pips2.shp
 		Start: 3
-	pip-red: pips2
+	pip-red:
+		Filename: pips2.shp
 		Start: 4
-	pip-blue: pips2
+	pip-blue:
+		Filename: pips2.shp
 		Start: 5
-	pip-disguise: pip-disguise
+	pip-disguise:
+		Filename: pip-disguise.shp
 		Length: *
 		Tick: 300
 		Offset: 0, -6
 
 v2:
 	idle:
+		Filename: v2.shp
 		Facings: 32
 		ZOffset: 1023
 
 rallypoint:
-	flag: flagfly
+	flag:
+		Filename: flagfly.shp
 		Length: *
 		Offset: 11,-5
 		ZOffset: 2535
-	circles: fpls
+	circles:
+		Filename: fpls.shp
 		Length: *
 		ZOffset: 2047
 
 beacon:
 	Defaults:
 		ZOffset: 2535
-	arrow: mouse
+	arrow:
+		Filename: mouse.shp
 		Start: 5
 		Offset: 1,-12
-	circles: fpls
+	circles:
+		Filename: fpls.shp
 		Length: *
 		ZOffset: 2047
-	atomicon: lores|atomicon
+	atomicon:
+		Filename: lores|atomicon.shp
 		Length: *
 		Offset: 0,-42
-	pbmbicon: lores|pbmbicon
+	pbmbicon:
+		Filename: lores|pbmbicon.shp
 		Length: *
 		Offset: 0,-42
-	camicon: lores|camicon
+	camicon:
+		Filename: lores|camicon.shp
 		Length: *
 		Offset: 0,-42
-	pinficon: lores|pinficon
+	pinficon:
+		Filename: lores|pinficon.shp
 		Length: *
 		Offset: 0,-42
-	clock: beaconclock
+	clock:
+		Filename: beaconclock.shp
 		Length: *
 		Offset: 0,-42
 
 smoke_m:
+	Defaults:
+		Filename: smoke_m.shp
 	idle:
 		Length: *
 		Offset: 2, -5
@@ -186,30 +239,37 @@ smoke_m:
 
 dragon:
 	idle:
+		Filename: dragon.shp
 		Facings: 32
 		ZOffset: 1023
 
 smokey:
 	idle:
+		Filename: smokey.shp
 		Length: *
 		ZOffset: 1023
 
 bomb:
 	idle:
+		Filename: bomb.shp
 		Length: *
 		ZOffset: 1023
 
 missile:
 	idle:
+		Filename: missile.shp
 		Facings: 32
 		ZOffset: 1023
 
 torpedo:
-	idle: missile
+	idle:
+		Filename: missile.shp
 		Facings: 32
 		ZOffset: -1023
 
 litning:
+	Defaults:
+		Filename: litning.shp
 	bright:
 		Length: 4
 		ZOffset: 1023
@@ -220,46 +280,56 @@ litning:
 
 fb1:
 	idle:
+		Filename: fb1.shp
 		Length: *
 		ZOffset: 1023
 
 moveflsh:
 	idle:
+		Filename: moveflsh.tem
+		TilesetFilenames:
+			SNOW: moveflsh.sno
+			INTERIOR: moveflsh.int
 		Length: *
 		Tick: 80
 		ZOffset: 2047
-		UseTilesetExtension: true
-		TilesetOverrides:
-			DESERT: TEMPERAT
 
 select:
 	repair:
+		Filename: select.shp
 		Start: 2
 
 poweroff:
 	offline:
+		Filename: poweroff.shp
 		Length: *
 		Tick: 160
 		ZOffset: 2047
 
 allyrepair:
 	repair:
+		Filename: allyrepair.shp
 		Length: *
 		Tick: 160
 		ZOffset: 2047
 
 tabs:
+	Defaults:
+		Filename: tabs.shp
 	left-normal:
 	left-pressed:
 		Start: 1
 
 sputnik:
 	idle:
+		Filename: sputnik.shp
 		Length: *
 		Offset: -4,0
 		ZOffset: 1023
 
 dd-crnr:
+	Defaults:
+		Filename: dd-crnr.shp
 	idle:
 		Length: *
 	top-left:
@@ -272,21 +342,25 @@ dd-crnr:
 
 fb2:
 	idle:
+		Filename: fb2.shp
 		Length: *
 		ZOffset: 1023
 
 fb3:
 	idle:
+		Filename: fb3.shp
 		Facings: 32
 		ZOffset: 1023
 
 fb4:
 	idle:
+		Filename: fb4.shp
 		Length: *
 		ZOffset: 1023
 
 scrate:
 	Defaults:
+		Filename: scrate.shp
 		ZOffset: -511
 	idle:
 	land:
@@ -298,15 +372,19 @@ scrate:
 
 wcrate:
 	Defaults:
+		Filename: wcrate.shp
 		ZOffset: -511
 	idle:
 	land:
 		Start: 1
-	water: wwcrate
+	water:
+		Filename: wwcrate.shp
 		Length: *
 		Tick: 500
 
 xcratea:
+	Defaults:
+		Filename: xcratea.shp
 	idle:
 		ZOffset: -511
 	land:
@@ -319,6 +397,8 @@ xcratea:
 		ZOffset: -511
 
 xcrateb:
+	Defaults:
+		Filename: xcrateb.shp
 	idle:
 		ZOffset: -511
 	land:
@@ -331,6 +411,8 @@ xcrateb:
 		ZOffset: -511
 
 xcratec:
+	Defaults:
+		Filename: xcratec.shp
 	idle:
 		ZOffset: -511
 	land:
@@ -343,6 +425,8 @@ xcratec:
 		ZOffset: -511
 
 xcrated:
+	Defaults:
+		Filename: xcrated.shp
 	idle:
 		ZOffset: -511
 	land:
@@ -358,26 +442,45 @@ crate-effects:
 	Defaults:
 		ZOffset: 2047
 		Length: *
-	speed: speed
-	dollar: dollar
-	reveal-map: earth
-	hide-map: empulse
-	fpower: fpower
-	gps: gpsbox
-	invuln: invulbox
-	heal: invun
-	nuke: missile2
-	parabombs: parabox
-	sonar: sonarbox
-	stealth: stealth2
-	timequake: tquake
-	armor: armor
-	chrono: chronbox
-	airstrike: deviator
-	levelup: levelup
+	speed:
+		Filename: speed.shp
+	dollar:
+		Filename: dollar.shp
+	reveal-map:
+		Filename: earth.shp
+	hide-map:
+		Filename: empulse.shp
+	fpower:
+		Filename: fpower.shp
+	gps:
+		Filename: gpsbox.shp
+	invuln:
+		Filename: invulbox.shp
+	heal:
+		Filename: invun.shp
+	nuke:
+		Filename: missile2.shp
+	parabombs:
+		Filename: parabox.shp
+	sonar:
+		Filename: sonarbox.shp
+	stealth:
+		Filename: stealth2.shp
+	timequake:
+		Filename: tquake.shp
+	armor:
+		Filename: armor.shp
+	chrono:
+		Filename: chronbox.shp
+	airstrike:
+		Filename: deviator.shp
+	levelup:
+		Filename: levelup.shp
 		Tick: 200
 
 parach:
+	Defaults:
+		Filename: parach.shp
 	open:
 		Length: 5
 	idle:
@@ -386,14 +489,18 @@ parach:
 
 parach-shadow:
 	idle:
+		Filename: parach-shadow.shp
 		Length: *
 
 bomblet:
 	idle:
+		Filename: bomblet.shp
 		Length: *
 		ZOffset: 1023
 
 parabomb:
+	Defaults:
+		Filename: parabomb.shp
 	open:
 		Length: 8
 		ZOffset: 1023
@@ -403,36 +510,43 @@ parabomb:
 		ZOffset: 1023
 
 smokland:
-	open: playersmoke
+	open:
+		Filename: playersmoke.shp
 		Length: 72
 		Tick: 120
 		ZOffset: 1023
-	idle: playersmoke
+	idle:
+		Filename: playersmoke.shp
 		Start: 72
 		Length: 20
 		Tick: 120
 		ZOffset: 1023
 
 fire:
-	1: fire1
+	1:
+		Filename: fire1.shp
 		Length: *
 		Offset: 0,-3
 		ZOffset: 1023
-	2: fire2
+	2:
+		Filename: fire2.shp
 		Length: *
 		Offset: 0,-3
 		ZOffset: 1023
-	3: fire3
+	3:
+		Filename: fire3.shp
 		Length: *
 		Offset: 0,-3
 		ZOffset: 1023
-	4: fire4
+	4:
+		Filename: fire4.shp
 		Length: *
 		Offset: 0,-3
 		ZOffset: 1023
 
 rank:
 	Defaults:
+		Filename: rank.shp
 		Offset: 0, 3
 	rank-veteran-1:
 	rank-veteran-2:
@@ -445,34 +559,43 @@ rank:
 
 iconchevrons:
 	veteran:
+		Filename: iconchevrons.shp
 		Offset: 2, 2
 
 atomic:
-	up: atomicup
+	up:
+		Filename: atomicup.shp
 		Length: *
 		ZOffset: 1023
-	down: atomicdn
+	down:
+		Filename: atomicdn.shp
 		Length: *
 		ZOffset: 1023
 
 bubbles:
 	idle:
+		Filename: bubbles.shp
 		Length: *
 		Tick: 220
 
 mpspawn:
 	idle:
+		Filename: mpspawn.shp
 		Length: *
 
 waypoint:
 	idle:
+		Filename: waypoint.shp
 		Length: *
 
 camera:
 	idle:
+		Filename: camera.shp
 		Length: *
 
 gpsdot:
+	Defaults:
+		Filename: gpsdot.shp
 	Infantry:
 	Vehicle:
 		Start: 1
@@ -498,16 +621,26 @@ gpsdot:
 		Start: 11
 
 icon:
-	abomb: atomicon
-	invuln: infxicon
-	chrono: warpicon
-	spyplane: smigicon
-	paratroopers: pinficon
-	gps: gpssicon
-	parabombs: pbmbicon
-	sonar: sonricon
+	abomb:
+		Filename: atomicon.shp
+	invuln:
+		Filename: infxicon.shp
+	chrono:
+		Filename: warpicon.shp
+	spyplane:
+		Filename: smigicon.shp
+	paratroopers:
+		Filename: pinficon.shp
+	gps:
+		Filename: gpssicon.shp
+	parabombs:
+		Filename: pbmbicon.shp
+	sonar:
+		Filename: sonricon.shp
 
 quee:
+	Defaults:
+		Filename: quee.shp
 	idle:
 		Length: 10
 	damaged-idle:
@@ -516,23 +649,29 @@ quee:
 
 lar1:
 	idle:
+		Filename: lar1.shp
 
 lar2:
 	idle:
+		Filename: lar2.shp
 
 minp:
 	idle:
+		Filename: minp.shp
 		ZOffset: -512
-	icon: jmin
+	icon:
+		Filename: jmin.shp
 
 minv:
 	idle:
+		Filename: minv.shp
 		ZOffset: -512
-	icon: jmin
+	icon:
+		Filename: jmin.shp
 
 overlay:
-	Defaults: trans.icn
-		AddExtension: False
+	Defaults:
+		Filename: trans.icn
 	build-valid:
 	build-invalid:
 		Start: 2
@@ -543,8 +682,8 @@ overlay:
 		Start: 2
 
 editor-overlay:
-	Defaults: trans.icn
-		AddExtension: False
+	Defaults:
+		Filename: trans.icn
 	copy:
 	paste:
 		Start: 2
@@ -552,21 +691,42 @@ editor-overlay:
 resources:
 	Defaults:
 		Length: *
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
-			DESERT: TEMPERAT
-	gold01: gold01
-	gold02: gold02
-	gold03: gold03
-	gold04: gold04
-	gem01: gem01
-	gem02: gem02
-	gem03: gem03
-	gem04: gem04
+	gold01:
+		Filename: gold01.tem
+		TilesetFilenames:
+			SNOW: gold01.sno
+	gold02:
+		Filename: gold02.tem
+		TilesetFilenames:
+			SNOW: gold02.sno
+	gold03:
+		Filename: gold03.tem
+		TilesetFilenames:
+			SNOW: gold03.sno
+	gold04:
+		Filename: gold04.tem
+		TilesetFilenames:
+			SNOW: gold04.sno
+	gem01:
+		Filename: gem01.tem
+		TilesetFilenames:
+			SNOW: gem01.sno
+	gem02:
+		Filename: gem02.tem
+		TilesetFilenames:
+			SNOW: gem02.sno
+	gem03:
+		Filename: gem03.tem
+		TilesetFilenames:
+			SNOW: gem03.sno
+	gem04:
+		Filename: gem04.tem
+		TilesetFilenames:
+			SNOW: gem04.sno
 
 shroud:
-	shroud: shadow
+	shroud:
+		Filename: shadow.shp
 		Length: *
 
 # Note: The order of smudges and craters determines
@@ -574,86 +734,150 @@ shroud:
 scorches:
 	Defaults:
 		Length: *
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
-	sc1: sc1
-	sc2: sc2
-	sc3: sc3
-	sc4: sc4
-	sc5: sc5
-	sc6: sc6
+	sc1:
+		Filename: sc1.tem
+		TilesetFilenames:
+			SNOW: sc1.sno
+			DESERT: sc1.des
+	sc2:
+		Filename: sc2.tem
+		TilesetFilenames:
+			SNOW: sc2.sno
+			DESERT: sc2.des
+	sc3:
+		Filename: sc3.tem
+		TilesetFilenames:
+			SNOW: sc3.sno
+			DESERT: sc3.des
+	sc4:
+		Filename: sc4.tem
+		TilesetFilenames:
+			SNOW: sc4.sno
+			DESERT: sc4.des
+	sc5:
+		Filename: sc5.tem
+		TilesetFilenames:
+			SNOW: sc5.sno
+			DESERT: sc5.des
+	sc6:
+		Filename: sc6.tem
+		TilesetFilenames:
+			SNOW: sc6.sno
+			DESERT: sc6.des
 
 craters:
 	Defaults:
 		Length: *
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
-	cr1: cr1
-	cr2: cr2
-	cr3: cr3
-	cr4: cr4
-	cr5: cr5
-	cr6: cr6
+	cr1:
+		Filename: cr1.tem
+		TilesetFilenames:
+			SNOW: cr1.sno
+			DESERT: cr1.des
+	cr2:
+		Filename: cr2.tem
+		TilesetFilenames:
+			SNOW: cr2.sno
+			DESERT: cr2.des
+	cr3:
+		Filename: cr3.tem
+		TilesetFilenames:
+			SNOW: cr3.sno
+			DESERT: cr3.des
+	cr4:
+		Filename: cr4.tem
+		TilesetFilenames:
+			SNOW: cr4.sno
+			DESERT: cr4.des
+	cr5:
+		Filename: cr5.tem
+		TilesetFilenames:
+			SNOW: cr5.sno
+			DESERT: cr5.des
+	cr6:
+		Filename: cr6.tem
+		TilesetFilenames:
+			SNOW: cr6.sno
+			DESERT: cr6.des
 
 mine:
 	idle:
-		UseTilesetExtension: true
+		TilesetFilenames:
+			SNOW: mine.sno
+			INTERIOR: mine.int
+			TEMPERAT: mine.tem
+			DESERT: mine.des
 		ZOffset: -2c512
 
 gmine:
 	idle:
+		Filename: gmine.tem
+		TilesetFilenames:
+			SNOW: gmine.sno
+			DESERT: gmine.des
 		ZOffset: -2c512
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
 
 railmine:
 	idle:
+		Filename: railmine.tem
+		TilesetFilenames:
+			SNOW: railmine.sno
+			DESERT: railmine.des
 		ZOffset: -512
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
 
 ctflag:
 	idle:
+		Filename: ctflag.shp
 		Length: 9
 		Tick: 50
 		Offset: 0,-12
-	bib: mbGAP
+	bib:
+		TilesetFilenames:
+			SNOW: mbGAP.sno
+			INTERIOR: mbGAP.int
+			TEMPERAT: mbGAP.tem
+			DESERT: mbGAP.des
 		Length: *
-		UseTilesetExtension: true
 
 paradirection:
-	arrow-t: mouse
+	arrow-t:
+		Filename: mouse.shp
 		Start: 1
 		Offset: 0, -19, 0
-	arrow-tr: mouse
+	arrow-tr:
+		Filename: mouse.shp
 		Start: 2
 		Offset: 15, -15, 0
-	arrow-r: mouse
+	arrow-r:
+		Filename: mouse.shp
 		Start: 3
 		Offset: 19, 0, 0
-	arrow-br: mouse
+	arrow-br:
+		Filename: mouse.shp
 		Start: 4
 		Offset: 15, 15, 0
-	arrow-b: mouse
+	arrow-b:
+		Filename: mouse.shp
 		Start: 5
 		Offset: 0, 19, 0
-	arrow-bl: mouse
+	arrow-bl:
+		Filename: mouse.shp
 		Start: 6
 		Offset: -15, 15, 0
-	arrow-l: mouse
+	arrow-l:
+		Filename: mouse.shp
 		Start: 7
 		Offset: -19, 0, 0
-	arrow-tl: mouse
+	arrow-tl:
+		Filename: mouse.shp
 		Start: 8
 		Offset: -15, -15, 0
 
 twinkle:
 	Defaults:
 		Length: *
-	twinkle1: twinkle1
-	twinkle2: twinkle2
-	twinkle3: twinkle3
+	twinkle1:
+		Filename: twinkle1.shp
+	twinkle2:
+		Filename: twinkle2.shp
+	twinkle3:
+		Filename: twinkle3.shp

--- a/mods/ra/sequences/ships.yaml
+++ b/mods/ra/sequences/ships.yaml
@@ -1,34 +1,49 @@
 ss:
 	idle:
+		Filename: ss.shp
 		Facings: 16
-	icon: ssicon
+	icon:
+		Filename: ssicon.shp
 
 ca:
 	idle:
+		Filename: ca.shp
 		Facings: 16
-	turret: turr
+	turret:
+		Filename: turr.shp
 		Facings: 32
-	muzzle: gunfire2
+	muzzle:
+		Filename: gunfire2.shp
 		Length: 5
-	icon: caicon
+	icon:
+		Filename: caicon.shp
 
 dd:
 	idle:
+		Filename: dd.shp
 		Facings: 16
-	turret: ssam
+	turret:
+		Filename: ssam.shp
 		Facings: 32
-	icon: ddicon
+	icon:
+		Filename: ddicon.shp
 
 pt:
 	idle:
+		Filename: pt.shp
 		Facings: 16
-	turret: mgun
+	turret:
+		Filename: mgun.shp
 		Facings: 32
-	muzzle: gunfire2
+	muzzle:
+		Filename: gunfire2.shp
 		Length: 5
-	icon: pticon
+	icon:
+		Filename: pticon.shp
 
 lst:
+	Defaults:
+		Filename: lst.shp
 	idle:
 	open:
 		Start: 1
@@ -41,9 +56,12 @@ lst:
 	unload:
 		Start: 4
 		ZOffset: -511
-	icon: lsticon
+	icon:
+		Filename: lsticon.shp
 
 msub:
 	idle:
+		Filename: msub.shp
 		Facings: 16
-	icon: msubicon
+	icon:
+		Filename: msubicon.shp

--- a/mods/ra/sequences/structures.yaml
+++ b/mods/ra/sequences/structures.yaml
@@ -1,16 +1,22 @@
 fcom:
+	Defaults:
+		Filename: fcom.shp
 	idle:
 	damaged-idle:
 		Start: 1
-	make: fcommake
+	make:
+		Filename: fcommake.shp
 		Length: *
-	bib: bib3
+	bib:
+		Filename: bib3.tem
+		TilesetFilenames:
+			SNOW: bib3.sno
+			DESERT: bib3.des
 		Length: *
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
 
 hosp:
+	Defaults:
+		Filename: hosp.shp
 	idle:
 		Length: 4
 	damaged-idle:
@@ -19,146 +25,200 @@ hosp:
 	dead:
 		Start: 8
 		Tick: 800
-	make: hospmake
+	make:
+		Filename: hospmake.shp
 		Length: *
-	bib: mbHOSP
+	bib:
+		TilesetFilenames:
+			SNOW: mbHOSP.sno
+			INTERIOR: mbHOSP.int
+			TEMPERAT: mbHOSP.tem
+			DESERT: mbHOSP.des
 		Length: *
 		Offset: 0,1
-		UseTilesetExtension: true
-	icon: hospicon
+	icon:
+		Filename: hospicon.shp
 
 bio:
+	Defaults:
+		Filename: bio.shp
 	idle:
 	damaged-idle:
 		Start: 1
 	dead:
 		Start: 2
 		Tick: 800
-	make: biomake
+	make:
+		Filename: biomake.shp
 		Length: *
 
 oilb:
 	Defaults:
+		Filename: oilb.shp
 		Offset: 0,-6
 	idle:
 	damaged-idle:
 		Start: 1
 		Length: *
 	make:
-	bib: bib3
+	bib:
+		Filename: bib3.tem
+		TilesetFilenames:
+			SNOW: bib3.sno
+			DESERT: bib3.des
 		Length: *
 		Offset: 0,0
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
 
 fact:
+	Defaults:
+		Filename: fact.shp
 	idle:
-	make: factmake
+	make:
+		Filename: factmake.shp
 		Length: *
 	build:
 		Start: 1
 		Length: 25
-	pdox: factpdox
+	pdox:
+		Filename: factpdox.shp
 		Length: 80
 	damaged-idle:
 		Start: 26
 	damaged-build:
 		Start: 27
 		Length: 25
-	damaged-pdox: factpdox
+	damaged-pdox:
+		Filename: factpdox.shp
 		Start: 80
 		Length: 80
-	dead: factdead
+	dead:
+		Filename: factdead.shp
 		Tick: 800
-	bib: bib2
+	bib:
+		Filename: bib2.tem
+		TilesetFilenames:
+			SNOW: bib2.sno
+			DESERT: bib2.des
 		Length: *
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
-	icon: facticon
-	fake-icon: facficon
+	icon:
+		Filename: facticon.shp
+	fake-icon:
+		Filename: facficon.shp
 
 proc:
+	Defaults:
+		Filename: proc.shp
 	idle:
 		ZOffset: -1c511
 	damaged-idle:
 		Start: 1
 		ZOffset: -1c511
-	idle-top: proctop
+	idle-top:
+		Filename: proctop.shp
 		ZOffset: 0
-	damaged-idle-top: proctop
+	damaged-idle-top:
+		Filename: proctop.shp
 		Start: 1
 		ZOffset: 0
-	make: procmake
+	make:
+		Filename: procmake.shp
 		Length: *
-	dead: procdead
+	dead:
+		Filename: procdead.shp
 		Tick: 800
-	bib: bib2
+	bib:
+		Filename: bib2.tem
+		TilesetFilenames:
+			SNOW: bib2.sno
+			DESERT: bib2.des
 		Length: *
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
-	icon: procicon
+	icon:
+		Filename: procicon.shp
 
 silo:
-	idle: silo2
+	idle:
+		Filename: silo2.shp
 		Offset: 0,-1
-	damaged-idle: silo2
+	damaged-idle:
+		Filename: silo2.shp
 		Start: 9
 		Offset: 0,-1
-	stages: silo2
+	stages:
+		Filename: silo2.shp
 		Length: 9
 		Offset: 0,-1
-	damaged-stages: silo2
+	damaged-stages:
+		Filename: silo2.shp
 		Start: 9
 		Length: 9
 		Offset: 0,-1
-	make: silomake
+	make:
+		Filename: silomake.shp
 		Length: *
 		Offset: 0,-1
-	bib: mbSILO
+	bib:
+		TilesetFilenames:
+			SNOW: mbSILO.sno
+			INTERIOR: mbSILO.int
+			TEMPERAT: mbSILO.tem
+			DESERT: mbSILO.des
 		Length: *
-		UseTilesetExtension: true
-	icon: siloicon
+	icon:
+		Filename: siloicon.shp
 
 powr:
+	Defaults:
+		Filename: powr.shp
 	idle:
 	damaged-idle:
 		Start: 1
-	make: powrmake
+	make:
+		Filename: powrmake.shp
 		Length: *
-	dead: powrdead
+	dead:
+		Filename: powrdead.shp
 		Tick: 800
-	bib: bib3
+	bib:
+		Filename: bib3.tem
+		TilesetFilenames:
+			SNOW: bib3.sno
+			DESERT: bib3.des
 		Length: *
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
-	icon: powricon
-	fake-icon: fpwricon
+	icon:
+		Filename: powricon.shp
+	fake-icon:
+		Filename: fpwricon.shp
 
 apwr:
+	Defaults:
+		Filename: apwr.shp
 	idle:
 		Offset: 0,-10
 	damaged-idle:
 		Start: 1
 		Offset: 0,-10
-	make: apwrmake
+	make:
+		Filename: apwrmake.shp
 		Length: *
 		Offset: 0,-10
-	dead: apwrdead
+	dead:
+		Filename: apwrdead.shp
 		Tick: 800
 		Offset: 0,-10
-	bib: bib2
+	bib:
+		Filename: bib2.tem
+		TilesetFilenames:
+			SNOW: bib2.sno
+			DESERT: bib2.des
 		Length: *
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
-	icon: apwricon
-	fake-icon: fapwicon
+	icon:
+		Filename: apwricon.shp
+	fake-icon:
+		Filename: fapwicon.shp
 
 barr:
+	Defaults:
+		Filename: barr.shp
 	idle:
 		Length: 10
 		Offset: 0,-6
@@ -166,115 +226,166 @@ barr:
 		Start: 10
 		Length: 10
 		Offset: 0,-6
-	make: barrmake
+	make:
+		Filename: barrmake.shp
 		Length: *
 		Offset: 0,-6
-	bib: bib3
+	bib:
+		Filename: bib3.tem
+		TilesetFilenames:
+			SNOW: bib3.sno
+			DESERT: bib3.des
 		Length: *
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
-	icon: barricon
+	icon:
+		Filename: barricon.shp
 
 tent:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
+		Filename: tent.tem
+		TilesetFilenames:
+			SNOW: tent.sno
+			DESERT: tent.des
 	idle:
 		Length: 10
 	damaged-idle:
 		Start: 10
 		Length: 10
-	make: tentmake
+	make:
+		Filename: tentmake.tem
+		TilesetFilenames:
+			SNOW: tentmake.sno
+			DESERT: tentmake.des
 		Length: *
-	bib: bib3
+	bib:
+		Filename: bib3.tem
+		TilesetFilenames:
+			SNOW: bib3.sno
+			DESERT: bib3.des
 		Length: *
-	icon: tenticon
-		UseTilesetExtension: false
-	fake-icon: tenficon
-		UseTilesetExtension: false
+	icon:
+		Filename: tenticon.shp
+		TilesetFilenames:
+	fake-icon:
+		Filename: tenficon.shp
+		TilesetFilenames:
 
 kenn:
+	Defaults:
+		Filename: kenn.shp
 	idle:
 	damaged-idle:
 		Start: 1
-	make: kennmake
+	make:
+		Filename: kennmake.shp
 		Length: *
-	bib: mbSILO
+	bib:
+		TilesetFilenames:
+			SNOW: mbSILO.sno
+			INTERIOR: mbSILO.int
+			TEMPERAT: mbSILO.tem
+			DESERT: mbSILO.des
 		Length: *
-		UseTilesetExtension: true
-	icon: kennicon
+	icon:
+		Filename: kennicon.shp
 
 dome:
+	Defaults:
+		Filename: dome.shp
 	idle:
 		Offset: 0,-4
 	damaged-idle:
 		Start: 1
 		Offset: 0,-4
-	make: domemake
+	make:
+		Filename: domemake.shp
 		Length: *
 		Offset: 0,-4
-	bib: bib3
+	bib:
+		Filename: bib3.tem
+		TilesetFilenames:
+			SNOW: bib3.sno
+			DESERT: bib3.des
 		Length: *
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
-	icon: domeicon
-	fake-icon: domficon
+	icon:
+		Filename: domeicon.shp
+	fake-icon:
+		Filename: domficon.shp
 
 atek:
+	Defaults:
+		Filename: atek.shp
 	idle:
 	damaged-idle:
 		Start: 1
-	make: atekmake
+	make:
+		Filename: atekmake.shp
 		Length: *
-	active: sputdoor
+	active:
+		Filename: sputdoor.shp
 		Length: *
 		Offset: -4,0
-	bib: bib3
+	bib:
+		Filename: bib3.tem
+		TilesetFilenames:
+			SNOW: bib3.sno
+			DESERT: bib3.des
 		Length: *
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
-	icon: atekicon
-	fake-icon: ateficon
+	icon:
+		Filename: atekicon.shp
+	fake-icon:
+		Filename: ateficon.shp
 
 stek:
+	Defaults:
+		Filename: stek.shp
 	idle:
 	damaged-idle:
 		Start: 1
-	make: stekmake
+	make:
+		Filename: stekmake.shp
 		Length: *
-	bib: bib2
+	bib:
+		Filename: bib2.tem
+		TilesetFilenames:
+			SNOW: bib2.sno
+			DESERT: bib2.des
 		Length: *
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
-	icon: stekicon
+	icon:
+		Filename: stekicon.shp
 
 weap:
+	Defaults:
+		Filename: weap.shp
 	idle:
 	damaged-idle:
 		Start: 1
-	place: weapmake
+	place:
+		Filename: weapmake.shp
 		Start: 14
-	make: weapmake
+	make:
+		Filename: weapmake.shp
 		Length: *
-	build-top: weap3
+	build-top:
+		Filename: weap3.shp
 		Length: 10
-	damaged-build-top: weap2
+	damaged-build-top:
+		Filename: weap2.shp
 		Start: 4
 		Length: 4
-	bib: bib2
+	bib:
+		Filename: bib2.tem
+		TilesetFilenames:
+			SNOW: bib2.sno
+			DESERT: bib2.des
 		Length: *
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
-	icon: weapicon
-	fake-icon: weaficon
+	icon:
+		Filename: weapicon.shp
+	fake-icon:
+		Filename: weaficon.shp
 
 hpad:
+	Defaults:
+		Filename: hpad.shp
 	idle:
 		ZOffset: -1023
 	damaged-idle:
@@ -290,22 +401,29 @@ hpad:
 		Length: 6
 		Tick: 100
 		ZOffset: -1023
-	make: hpadmake
+	make:
+		Filename: hpadmake.shp
 		Length: *
-	bib: bib3
+	bib:
+		Filename: bib3.tem
+		TilesetFilenames:
+			SNOW: bib3.sno
+			DESERT: bib3.des
 		Length: *
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
-	icon: hpadicon
+	icon:
+		Filename: hpadicon.shp
 
 afld:
-	idle: afldidle
+	Defaults:
+		Filename: afld.shp
+	idle:
+		Filename: afldidle.shp
 		Length: 8
 		Tick: 160
 		ZOffset: -1023
 		Offset: 0,-4
-	damaged-idle: afldidle
+	damaged-idle:
+		Filename: afldidle.shp
 		Start: 8
 		Length: 8
 		Tick: 160
@@ -322,33 +440,47 @@ afld:
 		Tick: 160
 		ZOffset: -1023
 		Offset: 0,-4
-	make: afldmake
+	make:
+		Filename: afldmake.shp
 		Length: *
 		Offset: 0,-4
-	icon: afldicon
+	icon:
+		Filename: afldicon.shp
 
 spen:
+	Defaults:
+		Filename: spen.shp
 	idle:
 		Offset: 0,2
 	damaged-idle:
 		Start: 1
 		Offset: 0,2
-	make: spenmake
+	make:
+		Filename: spenmake.shp
 		Length: *
 		Offset: 0,2
-	icon: spenicon
-	fake-icon: speficon
+	icon:
+		Filename: spenicon.shp
+	fake-icon:
+		Filename: speficon.shp
 
 syrd:
+	Defaults:
+		Filename: syrd.shp
 	idle:
 	damaged-idle:
 		Start: 1
-	make: syrdmake
+	make:
+		Filename: syrdmake.shp
 		Length: *
-	icon: syrdicon
-	fake-icon: syrficon
+	icon:
+		Filename: syrdicon.shp
+	fake-icon:
+		Filename: syrficon.shp
 
 fix:
+	Defaults:
+		Filename: fix.shp
 	idle:
 		Offset: 0,1
 		ZOffset: -1c511
@@ -366,20 +498,31 @@ fix:
 		Length: 6
 		Offset: 0,1
 		ZOffset: -1c511
-	make: fixmake
+	make:
+		Filename: fixmake.shp
 		Length: *
 		Offset: 0,1
-	bib: mbFIX
+	bib:
+		TilesetFilenames:
+			SNOW: mbFIX.sno
+			INTERIOR: mbFIX.int
+			TEMPERAT: mbFIX.tem
+			DESERT: mbFIX.des
 		Length: *
 		ZOffset: -1c511
 		Offset: 0,-4
-		UseTilesetExtension: true
-	icon: fixicon
-	fake-icon: fixficon
+	icon:
+		Filename: fixicon.shp
+	fake-icon:
+		Filename: fixficon.shp
 
 gun:
-	idle: gunmake # Empty first frame. We need WithSpriteBody for the make anim, and WSB needs at least a placeholder default sequence to work
-	make: gunmake
+	Defaults:
+		Filename: gun.shp
+	idle: # Empty first frame. We need WithSpriteBody for the make anim, and WSB needs at least a placeholder default sequence to work
+		Filename: gunmake.shp
+	make:
+		Filename: gunmake.shp
 		Length: *
 	turret:
 		Facings: 32
@@ -396,17 +539,27 @@ gun:
 		Start: 96
 		Facings: 32
 		UseClassicFacings: True
-	muzzle: gunfire2
+	muzzle:
+		Filename: gunfire2.shp
 		Length: 5
-	bib: mbGUN
+	bib:
+		TilesetFilenames:
+			SNOW: mbGUN.sno
+			INTERIOR: mbGUN.int
+			TEMPERAT: mbGUN.tem
+			DESERT: mbGUN.des
 		Length: *
 		Offset: -1,-1
-		UseTilesetExtension: true
-	icon: gunicon
+	icon:
+		Filename: gunicon.shp
 
 agun:
-	idle: gunmake # Empty first frame (agunmake has no empty frames). We need WithSpriteBody for the make anim, and WSB needs at least a placeholder default sequence to work
-	make: agunmake
+	Defaults:
+		Filename: agun.shp
+	idle: # Empty first frame (agunmake has no empty frames). We need WithSpriteBody for the make anim, and WSB needs at least a placeholder default sequence to work
+		Filename: gunmake.shp
+	make:
+		Filename: agunmake.shp
 		Length: *
 		Offset: 0,-13
 	turret:
@@ -428,59 +581,86 @@ agun:
 		Facings: 32
 		UseClassicFacings: True
 		Offset: 0,-13
-	muzzle: gunfire2
+	muzzle:
+		Filename: gunfire2.shp
 		Start: 1
 		Length: 4
-	bib: mbAGUN
+	bib:
+		TilesetFilenames:
+			SNOW: mbAGUN.sno
+			INTERIOR: mbAGUN.int
+			TEMPERAT: mbAGUN.tem
+			DESERT: mbAGUN.des
 		Length: *
-		UseTilesetExtension: true
-	icon: agunicon
+	icon:
+		Filename: agunicon.shp
 
 sam:
-	idle: gunmake # Empty first frame (sammake has no empty frames). We need WithSpriteBody for the make anim, and WSB needs at least a placeholder default sequence to work
-	turret: sam2
+	idle: # Empty first frame (sammake has no empty frames). We need WithSpriteBody for the make anim, and WSB needs at least a placeholder default sequence to work
+		Filename: gunmake.shp
+	turret:
+		Filename: sam2.shp
 		Facings: 32
 		UseClassicFacings: True
 		Offset: -1,-2
-	damaged-turret: sam2
+	damaged-turret:
+		Filename: sam2.shp
 		Start: 34
 		Facings: 32
 		UseClassicFacings: True
 		Offset: -1,-2
-	make: sammake
+	make:
+		Filename: sammake.shp
 		Length: *
 		Offset: -1,-2
-	muzzle: samfire
+	muzzle:
+		Filename: samfire.shp
 		Length: 18
 		Facings: 8
 		Offset: -1,6
-	bib: mbSAM
+	bib:
+		TilesetFilenames:
+			SNOW: mbSAM.sno
+			INTERIOR: mbSAM.int
+			TEMPERAT: mbSAM.tem
+			DESERT: mbSAM.des
 		Length: *
 		Offset: 0,1
-		UseTilesetExtension: true
-	icon: samicon
+	icon:
+		Filename: samicon.shp
 
 ftur:
+	Defaults:
+		Filename: ftur.shp
 	idle:
 		Offset: 0,-2
 	damaged-idle:
 		Start: 1
 		Offset: 0,-2
-	make: fturmake
+	make:
+		Filename: fturmake.shp
 		Length: *
 		Offset: 0,-2
-	bib: mbFTUR
+	bib:
+		TilesetFilenames:
+			SNOW: mbFTUR.sno
+			INTERIOR: mbFTUR.int
+			TEMPERAT: mbFTUR.tem
+			DESERT: mbFTUR.des
 		Length: *
-		UseTilesetExtension: true
-	icon: fturicon
+	icon:
+		Filename: fturicon.shp
 
 tsla:
+	Defaults:
+		Filename: tsla.shp
 	idle:
 		Offset: 0,-13
 	damaged-idle:
 		Start: 10
 		Offset: 0,-13
-	make: tslamake
+	make:
+		Filename: tslamake.shp
 		Length: *
 		Offset: 0,-13
 	active:
@@ -493,44 +673,67 @@ tsla:
 		Length: 9
 		Tick: 100
 		Offset: 0,-13
-	bib: mbTSLA
+	bib:
+		TilesetFilenames:
+			SNOW: mbTSLA.sno
+			INTERIOR: mbTSLA.int
+			TEMPERAT: mbTSLA.tem
+			DESERT: mbTSLA.des
 		Length: *
-		UseTilesetExtension: true
-	icon: tslaicon
+	icon:
+		Filename: tslaicon.shp
 
 pbox:
+	Defaults:
+		Filename: pbox.shp
 	idle:
 	damaged-idle:
 		Start: 1
-	make: pboxmake
+	make:
+		Filename: pboxmake.shp
 		Length: *
-	muzzle: minigun
+	muzzle:
+		Filename: minigun.shp
 		Length: 6
 		Facings: 8
-	bib: mbPBOX
+	bib:
+		TilesetFilenames:
+			SNOW: mbPBOX.sno
+			INTERIOR: mbPBOX.int
+			TEMPERAT: mbPBOX.tem
+			DESERT: mbPBOX.des
 		Length: *
 		Offset: 0,-2
-		UseTilesetExtension: true
-	icon: pboxicon
+	icon:
+		Filename: pboxicon.shp
 
 hbox:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
+		Filename: hbox.tem
+		TilesetFilenames:
+			SNOW: hbox.sno
+			DESERT: hbox.des
 	idle:
 	damaged-idle:
 		Start: 2
-	make: hboxmake
+	make:
+		Filename: hboxmake.tem
+		TilesetFilenames:
+			SNOW: hboxmake.sno
+			DESERT: hboxmake.des
 		Length: *
-	muzzle: minigun
+	muzzle:
+		Filename: minigun.shp
+		TilesetFilenames:
 		Length: 6
 		Facings: 8
-		UseTilesetExtension: false
-	icon: hboxicon
-		UseTilesetExtension: false
+	icon:
+		Filename: hboxicon.shp
+		TilesetFilenames:
 
 gap:
+	Defaults:
+		Filename: gap.shp
 	idle:
 		Length: 32
 		Offset: 0,-14
@@ -538,15 +741,23 @@ gap:
 		Start: 32
 		Length: 32
 		Offset: 0,-14
-	make: gapmake
+	make:
+		Filename: gapmake.shp
 		Length: *
 		Offset: 0,-14
-	bib: mbGAP
+	bib:
+		TilesetFilenames:
+			SNOW: mbGAP.sno
+			INTERIOR: mbGAP.int
+			TEMPERAT: mbGAP.tem
+			DESERT: mbGAP.des
 		Length: *
-		UseTilesetExtension: true
-	icon: gapicon
+	icon:
+		Filename: gapicon.shp
 
 iron:
+	Defaults:
+		Filename: iron.shp
 	idle:
 		Offset: 0,-12
 	active:
@@ -559,16 +770,24 @@ iron:
 		Start: 11
 		Length: 11
 		Offset: 0,-12
-	make: ironmake
+	make:
+		Filename: ironmake.shp
 		Length: *
 		Offset: 0,-12
-	bib: mbIRON
+	bib:
+		TilesetFilenames:
+			SNOW: mbIRON.sno
+			INTERIOR: mbIRON.int
+			TEMPERAT: mbIRON.tem
+			DESERT: mbIRON.des
 		Length: *
 		Offset: 0,2
-		UseTilesetExtension: true
-	icon: ironicon
+	icon:
+		Filename: ironicon.shp
 
 pdox:
+	Defaults:
+		Filename: pdox.shp
 	idle:
 	damaged-idle:
 		Start: 29
@@ -577,24 +796,36 @@ pdox:
 	damaged-active:
 		Start: 29
 		Length: 29
-	make: pdoxmake
+	make:
+		Filename: pdoxmake.shp
 		Length: *
-	bib: mbPDOX
+	bib:
+		TilesetFilenames:
+			SNOW: mbPDOX.sno
+			INTERIOR: mbPDOX.int
+			TEMPERAT: mbPDOX.tem
+			DESERT: mbPDOX.des
 		Length: *
 		Offset: 0,-4
-		UseTilesetExtension: true
-	icon: pdoxicon
-	fake-icon: pdoficon
+	icon:
+		Filename: pdoxicon.shp
+	fake-icon:
+		Filename: pdoficon.shp
 
 mslo:
 	Defaults:
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
+		Filename: mslo.tem
+		TilesetFilenames:
+			SNOW: mslo.sno
+			DESERT: mslo.des
 	idle:
 	damaged-idle:
 		Start: 8
-	make: mslomake
+	make:
+		Filename: mslomake.tem
+		TilesetFilenames:
+			SNOW: mslomake.sno
+			DESERT: mslomake.des
 		Length: *
 	active:
 		Start: 1
@@ -603,27 +834,35 @@ mslo:
 	damaged-active:
 		Start: 9
 		Length: 7
-	icon: msloicon2
-		UseTilesetExtension: false
-	fake-icon: mslficon
-		UseTilesetExtension: false
+	icon:
+		Filename: msloicon2.shp
+		TilesetFilenames:
+	fake-icon:
+		Filename: mslficon.shp
+		TilesetFilenames:
 
 miss:
+	Defaults:
+		Filename: miss.shp
 	idle:
 	damaged-idle:
 		Start: 1
 	dead:
 		Start: 2
 		Tick: 800
-	make: missmake
+	make:
+		Filename: missmake.shp
 		Length: *
-	bib: bib2
+	bib:
+		Filename: bib2.tem
+		TilesetFilenames:
+			SNOW: bib2.sno
+			DESERT: bib2.des
 		Length: *
-		UseTilesetExtension: true
-		TilesetOverrides:
-			INTERIOR: TEMPERAT
 
 brik:
+	Defaults:
+		Filename: brik.shp
 	idle:
 		Length: 16
 	scratched-idle:
@@ -632,19 +871,26 @@ brik:
 	damaged-idle:
 		Start: 32
 		Length: 16
-	icon: brikicon
+	icon:
+		Filename: brikicon.shp
 
 sbag:
 	idle:
+		Filename: sbag.shp
 		Length: 16
-	icon: sbagicon
+	icon:
+		Filename: sbagicon.shp
 
 fenc:
 	idle:
+		Filename: fenc.shp
 		Length: 16
-	icon: fencicon
+	icon:
+		Filename: fencicon.shp
 
 cycl:
+	Defaults:
+		Filename: cycl.shp
 	idle:
 		Length: 16
 	damaged-idle:

--- a/mods/ra/sequences/vehicles.yaml
+++ b/mods/ra/sequences/vehicles.yaml
@@ -1,22 +1,29 @@
 mcv:
 	idle:
+		Filename: mcv.shp
 		Facings: 32
 		UseClassicFacings: True
-	icon: mcvicon
+	icon:
+		Filename: mcvicon.shp
 
 mcvhusk:
 	idle:
+		Filename: mcvhusk.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -1023
 
 truk:
 	idle:
+		Filename: truk.shp
 		Facings: 32
 		UseClassicFacings: True
-	icon: trukicon
+	icon:
+		Filename: trukicon.shp
 
 harv:
+	Defaults:
+		Filename: harv.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
@@ -24,34 +31,45 @@ harv:
 		Start: 32
 		Length: 8
 		Facings: 8
-	dock: harv
+	dock:
+		Filename: harv.shp
 		Start: 96
 		Length: 8
-	dock-loop: harv
+	dock-loop:
+		Filename: harv.shp
 		Start: 104
 		Length: 7
-	icon: harvicon
+	icon:
+		Filename: harvicon.shp
 		Start: 0
 
 harvempty:
+	Defaults:
+		Filename: harvempty.shp
 	Inherits: harv
 
 harvhalf:
+	Defaults:
+		Filename: harvhalf.shp
 	Inherits: harv
 
 hhusk:
 	idle:
+		Filename: hhusk.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -1023
 
 hhusk2:
 	idle:
+		Filename: hhusk2.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -1023
 
 1tnk:
+	Defaults:
+		Filename: 1tnk.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
@@ -59,22 +77,28 @@ hhusk2:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
-	muzzle: gunfire2
+	muzzle:
+		Filename: gunfire2.shp
 		Length: 2
-	icon: 1tnkicon
+	icon:
+		Filename: 1tnkicon.shp
 
 1tnk.destroyed:
-	idle: 1tnk
+	idle:
+		Filename: 1tnk.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
-	turret: 1tnk
+	turret:
+		Filename: 1tnk.shp
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
 
 2tnk:
+	Defaults:
+		Filename: 2tnk.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
@@ -82,22 +106,28 @@ hhusk2:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
-	muzzle: gunfire2
+	muzzle:
+		Filename: gunfire2.shp
 		Length: 5
-	icon: 2tnkicon
+	icon:
+		Filename: 2tnkicon.shp
 
 2tnk.destroyed:
-	idle: 2tnk
+	idle:
+		Filename: 2tnk.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
-	turret: 2tnk
+	turret:
+		Filename: 2tnk.shp
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
 
 3tnk:
+	Defaults:
+		Filename: 3tnk.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
@@ -105,22 +135,28 @@ hhusk2:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
-	muzzle: gunfire2
+	muzzle:
+		Filename: gunfire2.shp
 		Length: 5
-	icon: 3tnkicon
+	icon:
+		Filename: 3tnkicon.shp
 
 3tnk.destroyed:
-	idle: 3tnk
+	idle:
+		Filename: 3tnk.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
-	turret: 3tnk
+	turret:
+		Filename: 3tnk.shp
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
 
 4tnk:
+	Defaults:
+		Filename: 4tnk.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
@@ -128,22 +164,28 @@ hhusk2:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
-	muzzle: gunfire2
+	muzzle:
+		Filename: gunfire2.shp
 		Length: 5
-	icon: 4tnkicon
+	icon:
+		Filename: 4tnkicon.shp
 
 4tnk.destroyed:
-	idle: 4tnk
+	idle:
+		Filename: 4tnk.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
-	turret: 4tnk
+	turret:
+		Filename: 4tnk.shp
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
 
 v2rl:
+	Defaults:
+		Filename: v2rl.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
@@ -151,17 +193,23 @@ v2rl:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
-	icon: v2rlicon
+	icon:
+		Filename: v2rlicon.shp
 
 arty:
 	idle:
+		Filename: arty.shp
 		Facings: 32
 		UseClassicFacings: True
-	muzzle: gunfire2
+	muzzle:
+		Filename: gunfire2.shp
 		Length: 5
-	icon: artyicon
+	icon:
+		Filename: artyicon.shp
 
 jeep:
+	Defaults:
+		Filename: jeep.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
@@ -169,16 +217,21 @@ jeep:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
-	muzzle: minigun
+	muzzle:
+		Filename: minigun.shp
 		Length: 6
 		Facings: 8
-	icon: jeepicon
+	icon:
+		Filename: jeepicon.shp
 
 apc:
+	Defaults:
+		Filename: apc.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
-	muzzle: minigun
+	muzzle:
+		Filename: minigun.shp
 		Length: 6
 		Facings: 8
 	open:
@@ -186,24 +239,32 @@ apc:
 		Length: 3
 	unload:
 		Start: 32
-	icon: apcicon
+	icon:
+		Filename: apcicon.shp
 
 mnly:
 	idle:
+		Filename: mnly.shp
 		Facings: 32
 		UseClassicFacings: True
-	icon: mnlyicon
+	icon:
+		Filename: mnlyicon.shp
 
 mrj:
+	Defaults:
+		Filename: mrj.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
 	spinner:
 		Start: 32
 		Length: 32
-	icon: mrjicon
+	icon:
+		Filename: mrjicon.shp
 
 mgg:
+	Defaults:
+		Filename: mgg.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
@@ -213,30 +274,39 @@ mgg:
 	spinner-idle:
 		Start: 32
 		Length: 1
-	icon: mggicon
+	icon:
+		Filename: mggicon.shp
 
 mgg.destroyed:
-	idle: mgg
+	idle:
+		Filename: mgg.shp
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
-	spinner: mgg
+	spinner:
+		Filename: mgg.shp
 		Start: 32
 		Length: 8
 		ZOffset: -512
-	spinner-idle: mgg
+	spinner-idle:
+		Filename: mgg.shp
 		Start: 32
 
 ttnk:
+	Defaults:
+		Filename: ttnk.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
 	spinner:
 		Start: 32
 		Length: 32
-	icon: ttnkicon
+	icon:
+		Filename: ttnkicon.shp
 
 ftrk:
+	Defaults:
+		Filename: ftrk.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
@@ -244,25 +314,34 @@ ftrk:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
-	muzzle: gunfire2
+	muzzle:
+		Filename: gunfire2.shp
 		Length: 2
-	icon: ftrkicon
+	icon:
+		Filename: ftrkicon.shp
 
 dtrk:
 	idle:
+		Filename: dtrk.shp
 		Facings: 32
 		UseClassicFacings: True
-	icon: dtrkicon
+	icon:
+		Filename: dtrkicon.shp
 
 ctnk:
 	idle:
+		Filename: ctnk.shp
 		Facings: 32
 		UseClassicFacings: True
-	muzzle: gunfire2
+	muzzle:
+		Filename: gunfire2.shp
 		Length: 5
-	icon: ctnkicon
+	icon:
+		Filename: ctnkicon.shp
 
 qtnk:
+	Defaults:
+		Filename: qtnk.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
@@ -270,9 +349,12 @@ qtnk:
 		Start: 32
 		Facings: 8
 		Length: 8
-	icon: qtnkicon
+	icon:
+		Filename: qtnkicon.shp
 
 stnk:
+	Defaults:
+		Filename: stnk.shp
 	idle:
 		Facings: 32
 		UseClassicFacings: True
@@ -280,4 +362,5 @@ stnk:
 		Start: 38
 		Facings: 32
 		UseClassicFacings: True
-	icon: stnkicon
+	icon:
+		Filename: stnkicon.shp

--- a/mods/ts/maps/sunstroke/sequences.yaml
+++ b/mods/ts/maps/sunstroke/sequences.yaml
@@ -1,5 +1,9 @@
 slav:
-	icon: xxicon
+	Defaults:
+		Filename: slav.shp
+	icon:
+		Filename: xxicon.shp
 
 4tnk:
-	icon: xxicon
+	icon:
+		Filename: xxicon.shp

--- a/mods/ts/maps/sunstroke/sequences.yaml
+++ b/mods/ts/maps/sunstroke/sequences.yaml
@@ -1,6 +1,4 @@
 slav:
-	Defaults:
-		Filename: slav.shp
 	icon:
 		Filename: xxicon.shp
 

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -271,12 +271,6 @@ VideoFormats: Vqa
 TerrainFormat: DefaultTerrain
 
 SpriteSequenceFormat: TilesetSpecificSpriteSequence
-	TilesetExtensions:
-		TEMPERATE: .tem
-		SNOW: .sno
-	TilesetCodes:
-		TEMPERATE: t
-		SNOW: a
 
 ModelSequenceFormat: VoxelModelSequence
 

--- a/mods/ts/sequences/aircraft.yaml
+++ b/mods/ts/sequences/aircraft.yaml
@@ -1,29 +1,36 @@
 orca:
 	Inherits: ^VehicleOverlays
-	icon: orcaicon
+	icon:
+		Filename: orcaicon.shp
 
 orcab:
 	Inherits: ^VehicleOverlays
-	icon: obmbicon
+	icon:
+		Filename: obmbicon.shp
 
 trnsport:
 	Inherits: ^VehicleOverlays
-	icon: otrnicon
+	icon:
+		Filename: otrnicon.shp
 
 scrin:
 	Inherits: ^VehicleOverlays
-	icon: proicon
+	icon:
+		Filename: proicon.shp
 
 apache:
 	Inherits: ^VehicleOverlays
-	icon: apchicon
-	rotor: harpyrotor
+	icon:
+		Filename: apchicon.shp
+	rotor:
+		Filename: harpyrotor.shp
 		Start: 32
 		Length: 31
 		Offset: 0, 0, 32
 		ZRamp: 1
 		Tick: 25
-	slow-rotor: harpyrotor
+	slow-rotor:
+		Filename: harpyrotor.shp
 		Length: 31
 		Offset: 0, 0, 32
 		ZRamp: 1
@@ -31,10 +38,12 @@ apache:
 
 orcatran:
 	Inherits: ^VehicleOverlays
-	icon: crryicon
+	icon:
+		Filename: crryicon.shp
 
 pod:
 	Inherits: ^VehicleOverlays
 	idle:
+		Filename: pod.shp
 		Facings: 1
 		Length: 1

--- a/mods/ts/sequences/bridges.yaml
+++ b/mods/ts/sequences/bridges.yaml
@@ -1,97 +1,200 @@
 ^bridge:
 	Defaults:
 		ZOffset: -1c511
-		UseTilesetExtension: true
 		Start: 1
 		ZRamp: 1
 		Offset: 0, 0, 1
 
 lobrdg_a:
 	Inherits: ^bridge
-	idle: lobrdg10
-	idle2: lobrdg11
-	idle3: lobrdg12
-	idle4: lobrdg13
-	adead: lobrdg15
-	bdead: lobrdg14
-	abdead: lobrdg16
+	idle:
+		TilesetFilenames:
+			TEMPERATE: lobrdg10.tem
+			SNOW: lobrdg10.sno
+	idle2:
+		TilesetFilenames:
+			TEMPERATE: lobrdg11.tem
+			SNOW: lobrdg11.sno
+	idle3:
+		TilesetFilenames:
+			TEMPERATE: lobrdg12.tem
+			SNOW: lobrdg12.sno
+	idle4:
+		TilesetFilenames:
+			TEMPERATE: lobrdg13.tem
+			SNOW: lobrdg13.sno
+	adead:
+		TilesetFilenames:
+			TEMPERATE: lobrdg15.tem
+			SNOW: lobrdg15.sno
+	bdead:
+		TilesetFilenames:
+			TEMPERATE: lobrdg14.tem
+			SNOW: lobrdg14.sno
+	abdead:
+		TilesetFilenames:
+			TEMPERATE: lobrdg16.tem
+			SNOW: lobrdg16.sno
 
 lobrdg_a_d:
 	Inherits: ^bridge
-	idle: lobrdg28
-	aramp: lobrdg17
-	bramp: lobrdg18
-	abramp: lobrdg28
-	editor: lobrdg10
+	idle:
+		TilesetFilenames:
+			TEMPERATE: lobrdg28.tem
+			SNOW: lobrdg28.sno
+	aramp:
+		TilesetFilenames:
+			TEMPERATE: lobrdg17.tem
+			SNOW: lobrdg17.sno
+	bramp:
+		TilesetFilenames:
+			TEMPERATE: lobrdg18.tem
+			SNOW: lobrdg18.sno
+	abramp:
+		TilesetFilenames:
+			TEMPERATE: lobrdg28.tem
+			SNOW: lobrdg28.sno
+	editor:
+		TilesetFilenames:
+			TEMPERATE: lobrdg10.tem
+			SNOW: lobrdg10.sno
 
 lobrdg_b:
 	Inherits: ^bridge
-	idle: lobrdg01
-	idle2: lobrdg02
-	idle3: lobrdg03
-	idle4: lobrdg04
-	adead: lobrdg05
-	bdead: lobrdg06
-	abdead: lobrdg07
+	idle:
+		TilesetFilenames:
+			TEMPERATE: lobrdg01.tem
+			SNOW: lobrdg01.sno
+	idle2:
+		TilesetFilenames:
+			TEMPERATE: lobrdg02.tem
+			SNOW: lobrdg02.sno
+	idle3:
+		TilesetFilenames:
+			TEMPERATE: lobrdg03.tem
+			SNOW: lobrdg03.sno
+	idle4:
+		TilesetFilenames:
+			TEMPERATE: lobrdg04.tem
+			SNOW: lobrdg04.sno
+	adead:
+		TilesetFilenames:
+			TEMPERATE: lobrdg05.tem
+			SNOW: lobrdg05.sno
+	bdead:
+		TilesetFilenames:
+			TEMPERATE: lobrdg06.tem
+			SNOW: lobrdg06.sno
+	abdead:
+		TilesetFilenames:
+			TEMPERATE: lobrdg07.tem
+			SNOW: lobrdg07.sno
 
 lobrdg_b_d:
 	Inherits: ^bridge
-	idle: lobrdg27
-	aramp: lobrdg08
-	bramp: lobrdg09
-	abramp: lobrdg27
-	editor: lobrdg01
+	idle:
+		TilesetFilenames:
+			TEMPERATE: lobrdg27.tem
+			SNOW: lobrdg27.sno
+	aramp:
+		TilesetFilenames:
+			TEMPERATE: lobrdg08.tem
+			SNOW: lobrdg08.sno
+	bramp:
+		TilesetFilenames:
+			TEMPERATE: lobrdg09.tem
+			SNOW: lobrdg09.sno
+	abramp:
+		TilesetFilenames:
+			TEMPERATE: lobrdg27.tem
+			SNOW: lobrdg27.sno
+	editor:
+		TilesetFilenames:
+			TEMPERATE: lobrdg01.tem
+			SNOW: lobrdg01.sno
 
 lobrdg_r_se:
 	Inherits: ^bridge
-	idle: lobrdg19
-	damaged-idle: lobrdg20
+	idle:
+		TilesetFilenames:
+			TEMPERATE: lobrdg19.tem
+			SNOW: lobrdg19.sno
+	damaged-idle:
+		TilesetFilenames:
+			TEMPERATE: lobrdg20.tem
+			SNOW: lobrdg20.sno
 
 lobrdg_r_nw:
 	Inherits: ^bridge
-	idle: lobrdg21
-	damaged-idle: lobrdg22
+	idle:
+		TilesetFilenames:
+			TEMPERATE: lobrdg21.tem
+			SNOW: lobrdg21.sno
+	damaged-idle:
+		TilesetFilenames:
+			TEMPERATE: lobrdg22.tem
+			SNOW: lobrdg22.sno
 
 lobrdg_r_ne:
 	Inherits: ^bridge
-	idle: lobrdg23
-	damaged-idle: lobrdg24
+	idle:
+		TilesetFilenames:
+			TEMPERATE: lobrdg23.tem
+			SNOW: lobrdg23.sno
+	damaged-idle:
+		TilesetFilenames:
+			TEMPERATE: lobrdg24.tem
+			SNOW: lobrdg24.sno
 
 lobrdg_r_sw:
 	Inherits: ^bridge
-	idle: lobrdg25
-	damaged-idle: lobrdg26
+	idle:
+		TilesetFilenames:
+			TEMPERATE: lobrdg25.tem
+			SNOW: lobrdg25.sno
+	damaged-idle:
+		TilesetFilenames:
+			TEMPERATE: lobrdg26.tem
+			SNOW: lobrdg26.sno
 
 bridge1:
-	idle: bridge
+	idle:
+		TilesetFilenames:
+			TEMPERATE: bridge.tem
+			SNOW: bridge.sno
 		# Disabled to avoid glitches until shadow rendering is fixed
 		# ShadowStart: 18
-		UseTilesetExtension: true
 		ZRamp: 1
 		Offset: 0, -13, 49
 
 bridge2:
-	idle: bridge
+	idle:
+		TilesetFilenames:
+			TEMPERATE: bridge.tem
+			SNOW: bridge.sno
 		Start: 9
 		# Disabled to avoid glitches until shadow rendering is fixed
 		# ShadowStart: 27
-		UseTilesetExtension: true
 		ZRamp: 1
 		Offset: 0, -25, 49
 
 railbrdg1:
-	idle: railbrdg
+	idle:
+		TilesetFilenames:
+			TEMPERATE: railbrdg.tem
+			SNOW: railbrdg.sno
 		# Disabled to avoid glitches until shadow rendering is fixed
 		# ShadowStart: 18
-		UseTilesetExtension: true
 		ZRamp: 1
 		Offset: 0, -13, 49
 
 railbrdg2:
-	idle: railbrdg
+	idle:
+		TilesetFilenames:
+			TEMPERATE: railbrdg.tem
+			SNOW: railbrdg.sno
 		Start: 9
 		# Disabled to avoid glitches until shadow rendering is fixed
 		# ShadowStart: 27
-		UseTilesetExtension: true
 		ZRamp: 1
 		Offset: 0, -25, 49

--- a/mods/ts/sequences/civilian.yaml
+++ b/mods/ts/sequences/civilian.yaml
@@ -1,5 +1,6 @@
 ammocrat:
-	idle: ammo01
+	idle:
+		Filename: ammo01.shp
 		DepthSprite: isodepth.shp
 		ShadowStart: 2
 		Offset: 0, -12, 12
@@ -54,67 +55,98 @@ ammocrat:
 		DepthSpriteOffset: -24, 0
 
 aban01:
+	Defaults:
+		Filename: aban01.shp
 	Inherits: ^aban2x6
 
 aban02:
+	Defaults:
+		Filename: aban02.shp
 	Inherits: ^aban5x3
 
 aban03:
+	Defaults:
+		Filename: aban03.shp
 	Inherits: ^aban2x5
 
 aban04:
+	Defaults:
+		Filename: aban04.shp
 	Inherits: ^aban4x2
 
 aban05:
+	Defaults:
+		Filename: aban05.shp
 	Inherits: ^aban3x2
 
 aban06:
+	Defaults:
+		Filename: aban06.shp
 	Inherits: ^aban2x2
 
 aban07:
+	Defaults:
+		Filename: aban07.shp
 	Inherits: ^aban2x2
 
 aban08:
+	Defaults:
+		Filename: aban08.shp
 	Inherits: ^aban2x2
 
 aban09:
 	Inherits: ^aban2x2
 	Defaults:
+		Filename: aban09.shp
 		Offset: 2, -20, 24
 
 aban10:
+	Defaults:
+		Filename: aban10.shp
 	Inherits: ^aban2x2
 
 aban11:
 	Inherits: ^aban2x2
 	Defaults:
+		Filename: aban11.shp
 		Offset: 0, -20, 24
 
 aban12:
 	Inherits: ^aban2x2
 	Defaults:
+		Filename: aban12.shp
 		Offset: 2, -22, 24
 
 aban13:
 	Inherits: ^aban1x1
 	Defaults:
+		Filename: aban13.shp
 		Offset: 0, -10, 12
 
 aban14:
+	Defaults:
+		Filename: aban14.shp
 	Inherits: ^aban1x1
 
 aban15:
 	Inherits: ^aban1x1
 	Defaults:
+		Filename: aban15.shp
 		Offset: 0, -10, 12
 
 aban16:
+	Defaults:
+		Filename: aban16.shp
 	Inherits: ^aban2x2
 
 aban17:
+	Defaults:
+		Filename: aban17.shp
 	Inherits: ^aban1x1
 
 aban18:
+	Defaults:
+		Filename: aban18.shp
 	Inherits: ^aban1x1
 
 ^bboard1x1:
@@ -145,51 +177,83 @@ aban18:
 		ShadowStart: 3
 
 bboard01:
+	Defaults:
+		Filename: bboard01.shp
 	Inherits: ^bboard1x1
 
 bboard02:
+	Defaults:
+		Filename: bboard02.shp
 	Inherits: ^bboard1x1
 
 bboard03:
+	Defaults:
+		Filename: bboard03.shp
 	Inherits: ^bboard1x1
 
 bboard04:
+	Defaults:
+		Filename: bboard04.shp
 	Inherits: ^bboard1x1
 
 bboard05:
+	Defaults:
+		Filename: bboard05.shp
 	Inherits: ^bboard1x1
 
 bboard06:
+	Defaults:
+		Filename: bboard06.shp
 	Inherits: ^bboard1x2
 
 bboard07:
+	Defaults:
+		Filename: bboard07.shp
 	Inherits: ^bboard1x2
 
 bboard08:
+	Defaults:
+		Filename: bboard08.shp
 	Inherits: ^bboard1x2
 
 bboard09:
+	Defaults:
+		Filename: bboard09.shp
 	Inherits: ^bboard1x1
 
 bboard10:
+	Defaults:
+		Filename: bboard10.shp
 	Inherits: ^bboard1x1
 
 bboard11:
+	Defaults:
+		Filename: bboard11.shp
 	Inherits: ^bboard1x1
 
 bboard12:
+	Defaults:
+		Filename: bboard12.shp
 	Inherits: ^bboard1x1
 
 bboard13:
+	Defaults:
+		Filename: bboard13.shp
 	Inherits: ^bboard1x1
 
 bboard14:
+	Defaults:
+		Filename: bboard14.shp
 	Inherits: ^bboard2x1
 
 bboard15:
+	Defaults:
+		Filename: bboard15.shp
 	Inherits: ^bboard2x1
 
 bboard16:
+	Defaults:
+		Filename: bboard16.shp
 	Inherits: ^bboard2x1
 
 ^cabase:
@@ -205,114 +269,195 @@ bboard16:
 	Inherits: ^cabase
 	Defaults:
 		Offset: 0, -12, 12
-		UseTilesetCode: true
 
 ^ca1x2:
 	Inherits: ^cabase
 	Defaults:
 		Offset: 12, -18, 18
 		DepthSpriteOffset: 12, 0
-		UseTilesetCode: true
 
 ^ca2x1:
 	Inherits: ^cabase
 	Defaults:
 		Offset: -12, -18, 18
 		DepthSpriteOffset: -12, 0
-		UseTilesetCode: true
 
 ^ca2x3:
 	Inherits: ^cabase
 	Defaults:
 		Offset: 12, -30, 30
 		DepthSpriteOffset: 12, 0
-		UseTilesetCode: true
 
 ^ca3x3:
 	Inherits: ^cabase
 	Defaults:
 		Offset: 0, -36, 36
-		UseTilesetCode: true
 
 ^ca2x2:
 	Inherits: ^cabase
 	Defaults:
 		Offset: 0, -24, 24
-		UseTilesetCode: true
 
 ca0001:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0001.shp
+			SNOW: ca0001.shp
 	Inherits: ^ca3x3
 
 ca0002:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0002.shp
+			SNOW: ca0002.shp
 	Inherits: ^ca3x3
 
 ca0003:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0003.shp
+			SNOW: ca0003.shp
 	Inherits: ^ca2x2
 
 ca0004:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0004.shp
+			SNOW: ca0004.shp
 	Inherits: ^ca2x2
 
 ca0005:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0005.shp
+			SNOW: ca0005.shp
 	Inherits: ^ca1x2
 
 ca0006:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0006.shp
+			SNOW: ca0006.shp
 	Inherits: ^ca1x2
 
 ca0007:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0007.shp
+			SNOW: ca0007.shp
 	Inherits: ^ca1x2
 
 ca0008:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0008.shp
+			SNOW: ca0008.shp
 	Inherits: ^ca2x3
 
 ca0009:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0009.shp
+			SNOW: ca0009.shp
 	Inherits: ^ca2x3
 
 ca0010:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0010.shp
+			SNOW: ca0010.shp
 	Inherits: ^ca2x2
 
 ca0011:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0011.shp
+			SNOW: ca0011.shp
 	Inherits: ^ca1x2
 
 ca0012:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0012.shp
+			SNOW: ca0012.shp
 	Inherits: ^ca1x2
 
 ca0013:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0013.shp
+			SNOW: ca0013.shp
 	Inherits: ^ca2x1
 
 ca0014:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0014.shp
+			SNOW: ca0014.shp
 	Inherits: ^ca1x1
 
 ca0015:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0015.shp
+			SNOW: ca0015.shp
 	Inherits: ^ca1x1
 
 ca0016:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0016.shp
+			SNOW: ca0016.shp
 	Inherits: ^ca1x1
 
 ca0017:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0017.shp
+			SNOW: ca0017.shp
 	Inherits: ^ca1x1
 
 ca0018:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0018.shp
+			SNOW: ca0018.shp
 	Inherits: ^ca1x2
 
 ca0019:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0019.shp
+			SNOW: ca0019.shp
 	Inherits: ^ca1x2
 
 ca0020:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0020.shp
+			SNOW: ca0020.shp
 	Inherits: ^ca1x2
 
 ca0021:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ct0021.shp
+			SNOW: ca0021.shp
 	Inherits: ^ca1x2
 
 caarmr:
 	Defaults:
 		DepthSprite: isodepth.shp
 		Offset: 0, -48, 48
-	idle: ctarmr
+	idle:
+		Filename: ctarmr.shp
 		ShadowStart: 3
-	damaged-idle: ctarmr
+	damaged-idle:
+		Filename: ctarmr.shp
 		Start: 1
 		ShadowStart: 4
-	critical-idle: ctarmr
+	critical-idle:
+		Filename: ctarmr.shp
 		Start: 2
 		ShadowStart: 5
 
@@ -320,32 +465,41 @@ caaray:
 	Defaults:
 		DepthSprite: isodepth.shp
 		Offset: 0, -24, 24
-	idle: ctaray
+	idle:
+		Filename: ctaray.shp
 		ShadowStart: 3
-	damaged-idle: ctaray
+	damaged-idle:
+		Filename: ctaray.shp
 		Start: 1
 		ShadowStart: 4
-	critical-idle: ctaray
+	critical-idle:
+		Filename: ctaray.shp
 		Start: 2
 		ShadowStart: 5
-	idle-satellite: ctaray_a
+	idle-satellite:
+		Filename: ctaray_a.shp
 		Length: 16
 		Tick: 100
-	idle-radar: ctaray_b
+	idle-radar:
+		Filename: ctaray_b.shp
 		Length: 16
 		Tick: 100
-	idle-scanner: ctaray_c
+	idle-scanner:
+		Filename: ctaray_c.shp
 		Length: 16
 		Tick: 100
-	damaged-idle-scanner: ctaray_c
+	damaged-idle-scanner:
+		Filename: ctaray_c.shp
 		Start: 16
 		Length: 16
 		Tick: 100
-	idle-light-bright: ctaray_d
+	idle-light-bright:
+		Filename: ctaray_d.shp
 		Length: 12
 		Tick: 100
 		IgnoreWorldTint: True
-	damaged-idle-light-bright: ctaray_d
+	damaged-idle-light-bright:
+		Filename: ctaray_d.shp
 		Start: 12
 		Length: 12
 		Tick: 100
@@ -353,36 +507,59 @@ caaray:
 
 cabhut:
 	idle:
+		TilesetFilenames:
+			TEMPERATE: ctbhut.shp
+			SNOW: cabhut.shp
 		DepthSprite: isodepth.shp
-		UseTilesetCode: true
 		Offset: 0, -12, 12
 		ShadowStart: 1
 
 ^cacrsh:
 	idle:
-		UseTilesetCode: true
 		Offset: 0, -12, 12
 
 cacrsh01:
 	Inherits: ^cacrsh
+	idle:
+		TilesetFilenames:
+			TEMPERATE: ctcrsh01.shp
+			SNOW: cacrsh01.shp
 
 cacrsh02:
 	Inherits: ^cacrsh
+	idle:
+		TilesetFilenames:
+			TEMPERATE: ctcrsh02.shp
+			SNOW: cacrsh02.shp
 
 cacrsh03:
 	Inherits: ^cacrsh
+	idle:
+		TilesetFilenames:
+			TEMPERATE: ctcrsh03.shp
+			SNOW: cacrsh03.shp
 
 cacrsh04:
 	Inherits: ^cacrsh
+	idle:
+		TilesetFilenames:
+			TEMPERATE: ctcrsh04.shp
+			SNOW: cacrsh04.shp
 
 cacrsh05:
 	Inherits: ^cacrsh
+	idle:
+		TilesetFilenames:
+			TEMPERATE: ctcrsh05.shp
+			SNOW: cacrsh05.shp
 
 cahosp:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: cthosp.shp
+			SNOW: cahosp.shp
 		DepthSprite: isodepth.shp
 		DepthSpriteOffset: 15, 0
-		UseTilesetCode: true
 		Offset: 15, -36, 36
 	idle:
 		ShadowStart: 3
@@ -394,19 +571,22 @@ cahosp:
 		ShadowStart: 5
 
 capyr01:
-	idle: ctpyr01
+	idle:
+		Filename: ctpyr01.shp
 		DepthSprite: isodepth.shp
 		ShadowStart: 1
 		Offset: 0, -24, 24
 
 capyr02:
-	idle: ctpyr02
+	idle:
+		Filename: ctpyr02.shp
 		DepthSprite: isodepth.shp
 		ShadowStart: 1
 		Offset: 0, -48, 48
 
 capyr03:
-	idle: ctpyr03
+	idle:
+		Filename: ctpyr03.shp
 		DepthSprite: isodepth.shp
 		ShadowStart: 1
 		Offset: 0, -48, 48
@@ -454,102 +634,150 @@ capyr03:
 city01:
 	Inherits: ^city4x2
 	Defaults:
+		Filename: city01.shp
 		Offset: -12, -30, 36
 
 city02:
+	Defaults:
+		Filename: city02.shp
 	Inherits: ^city2x3
 
 city03:
+	Defaults:
+		Filename: city03.shp
 	Inherits: ^city3x2
 
 city04:
+	Defaults:
+		Filename: city04.shp
 	Inherits: ^city3x2
 
 city05:
+	Defaults:
+		Filename: city05.shp
 	Inherits: ^city3x2
 
 city06:
+	Defaults:
+		Filename: city06.shp
 	Inherits: ^city4x2
 
 city07:
 	Inherits: ^city4x2
 	Defaults:
+		Filename: city07.shp
 		Offset: -12, -30, 36
 
 city08:
+	Defaults:
+		Filename: city08.shp
 	Inherits: ^city2x2
 
 city09:
+	Defaults:
+		Filename: city09.shp
 	Inherits: ^city2x2
 
 city10:
+	Defaults:
+		Filename: city10.shp
 	Inherits: ^city2x2
 
 city11:
+	Defaults:
+		Filename: city11.shp
 	Inherits: ^city2x2
 
 city12:
+	Defaults:
+		Filename: city12.shp
 	Inherits: ^city2x2
 
 city13:
+	Defaults:
+		Filename: city13.shp
 	Inherits: ^city2x2
 
 city14:
+	Defaults:
+		Filename: city14.shp
 	Inherits: ^city1x1
 
 city15:
+	Defaults:
+		Filename: city15.shp
 	Inherits: ^city4x2
 
 city16:
 	Inherits: ^city4x2
 	Defaults:
+		Filename: city16.shp
 		Offset: -24, -30, 36
 
 city17:
+	Defaults:
+		Filename: city17.shp
 	Inherits: ^city4x3
 
 city18:
+	Defaults:
+		Filename: city18.shp
 	Inherits: ^city3x5
 
 city19:
+	Defaults:
+		Filename: city19.shp
 	Inherits: ^city2x2
 
 city20:
+	Defaults:
+		Filename: city20.shp
 	Inherits: ^city1x1
 
 city21:
+	Defaults:
+		Filename: city21.shp
 	Inherits: ^city1x1
 
 city22:
+	Defaults:
+		Filename: city22.shp
 	Inherits: ^city2x2
 
 ctdam:
 	Defaults:
+		Filename: ctdam.shp
 		Offset: 36,-42, 42
 	idle:
 	damaged-idle:
 		Start: 1
-	idle-lights-bright: ctdam_a
+	idle-lights-bright:
+		Filename: ctdam_a.shp
 		Length: 10
 		Tick: 200
 		IgnoreWorldTint: True
-	damaged-idle-lights-bright: ctdam_a
+	damaged-idle-lights-bright:
+		Filename: ctdam_a.shp
 		Start: 10
 		Length: 10
 		Tick: 200
 		IgnoreWorldTint: True
-	idle-water-a: ctdam_b
+	idle-water-a:
+		Filename: ctdam_b.shp
 		Length: 8
 		Tick: 200
-	damaged-idle-water-a: ctdam_b
+	damaged-idle-water-a:
+		Filename: ctdam_b.shp
 		Start: 8
 		Length: 8
 		Tick: 200
-	idle-water-b: ctdam_b
+	idle-water-b:
+		Filename: ctdam_b.shp
 		Start: 16
 		Length: 8
 		Tick: 200
-	damaged-idle-water-b: ctdam_b
+	damaged-idle-water-b:
+		Filename: ctdam_b.shp
 		Start: 24
 		Start: 8
 		Length: 8
@@ -557,6 +785,7 @@ ctdam:
 
 ctvega:
 	Defaults:
+		Filename: ctvega.shp
 		DepthSprite: isodepth.shp
 		Offset: 0, -48, 48
 	idle:
@@ -572,32 +801,57 @@ ctvega:
 	idle:
 		ShadowStart: 2
 		DepthSprite: isodepth.shp
-		UseTilesetCode: true
 		Offset: 0, -24, 24
 
 gaoldcc1:
 	Inherits: ^gaoldcc
+	idle:
+		TilesetFilenames:
+			TEMPERATE: gtoldcc1.shp
+			SNOW: gaoldcc1.shp
 
 gaoldcc2:
 	Inherits: ^gaoldcc
+	idle:
+		TilesetFilenames:
+			TEMPERATE: gtoldcc2.shp
+			SNOW: gaoldcc2.shp
 
 gaoldcc3:
 	Inherits: ^gaoldcc
+	idle:
+		TilesetFilenames:
+			TEMPERATE: gtoldcc3.shp
+			SNOW: gaoldcc3.shp
 
 gaoldcc4:
 	Inherits: ^gaoldcc
+	idle:
+		TilesetFilenames:
+			TEMPERATE: gtoldcc4.shp
+			SNOW: gaoldcc4.shp
 
 gaoldcc5:
 	Inherits: ^gaoldcc
+	idle:
+		TilesetFilenames:
+			TEMPERATE: gtoldcc5.shp
+			SNOW: gaoldcc5.shp
 
 gaoldcc6:
 	Inherits: ^gaoldcc
+	idle:
+		TilesetFilenames:
+			TEMPERATE: gtoldcc6.shp
+			SNOW: gaoldcc6.shp
 
 gakodk:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: gtkodk.shp
+			SNOW: gakodk.shp
 		DepthSprite: isodepth.shp
 		DepthSpriteOffset: -24, 0
-		UseTilesetCode: true
 		Offset: -24, -36, 36
 	idle:
 		ShadowStart: 3
@@ -607,41 +861,71 @@ gakodk:
 	critical-idle:
 		Start: 2
 		ShadowStart: 5
-	large-lights: gakodk_a
+	large-lights:
+		TilesetFilenames:
+			TEMPERATE: gtkodk_a.shp
+			SNOW: gakodk_a.shp
 		Length: 12
 		Tick: 200
-	large-lights-bright: gakodk_a
-		Length: 12
-		Tick: 200
-		IgnoreWorldTint: True
-	damaged-large-lights: gakodk_a
-		Start: 12
-		Length: 12
-		Tick: 200
-	damaged-large-lights-bright: gakodk_a
-		Start: 12
+	large-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gtkodk_a.shp
+			SNOW: gakodk_a.shp
 		Length: 12
 		Tick: 200
 		IgnoreWorldTint: True
-	small-light: gakodk_b
+	damaged-large-lights:
+		TilesetFilenames:
+			TEMPERATE: gtkodk_a.shp
+			SNOW: gakodk_a.shp
+		Start: 12
+		Length: 12
+		Tick: 200
+	damaged-large-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gtkodk_a.shp
+			SNOW: gakodk_a.shp
+		Start: 12
+		Length: 12
+		Tick: 200
+		IgnoreWorldTint: True
+	small-light:
+		TilesetFilenames:
+			TEMPERATE: gtkodk_b.shp
+			SNOW: gakodk_b.shp
 		Length: 22
 		Tick: 200
-	small-light-bright: gakodk_b
+	small-light-bright:
+		TilesetFilenames:
+			TEMPERATE: gtkodk_b.shp
+			SNOW: gakodk_b.shp
 		Length: 22
 		Tick: 200
 		IgnoreWorldTint: True
-	small-lights: gakodk_c
+	small-lights:
+		TilesetFilenames:
+			TEMPERATE: gtkodk_c.shp
+			SNOW: gakodk_c.shp
 		Length: 12
 		Tick: 200
-	small-lights-bright: gakodk_c
+	small-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gtkodk_c.shp
+			SNOW: gakodk_c.shp
 		Length: 12
 		Tick: 200
 		IgnoreWorldTint: True
-	damaged-small-lights: gakodk_c
+	damaged-small-lights:
+		TilesetFilenames:
+			TEMPERATE: gtkodk_c.shp
+			SNOW: gakodk_c.shp
 		Start: 12
 		Length: 12
 		Tick: 200
-	damaged-small-lights-bright: gakodk_c
+	damaged-small-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gtkodk_c.shp
+			SNOW: gakodk_c.shp
 		Start: 12
 		Length: 12
 		Tick: 200
@@ -649,9 +933,11 @@ gakodk:
 
 gaspot:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: gtspot.shp
+			SNOW: gaspot.shp
 		DepthSprite: isodepth.shp
 		Offset: 0, -12, 12
-		UseTilesetCode: true
 	idle:
 		ShadowStart: 3
 	damaged-idle:
@@ -661,67 +947,85 @@ gaspot:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	idle-lights-bright: gaspot_a
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gtspot_a.shp
+			SNOW: gaspot_a.shp
 		Length: 8
 		Tick: 200
 		IgnoreWorldTint: True
-	damaged-idle-lights-bright: gaspot_a
+	damaged-idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gtspot_a.shp
+			SNOW: gaspot_a.shp
 		Start: 8
 		Length: 8
 		Tick: 200
 		IgnoreWorldTint: True
-	make: gaspotmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: gtspotmk.shp
+			SNOW: gaspotmk.shp
 		Length: 14
 		ShadowStart: 14
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0
-		-DepthSprite:
-		UseTilesetCode: false
+		DepthSprite:
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-	icon: spoticon
+	icon:
+		Filename: spoticon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 galite:
 	Defaults:
 		DepthSprite: isodepth.shp
 		Offset: 0, -12, 12
-		UseTilesetCode: true
-	idle: gtlite
+	idle:
+		TilesetFilenames:
+			TEMPERATE: gtlite.shp
+			SNOW: galite.shp
 		ShadowStart: 2
-	damaged-idle: gtlite
+	damaged-idle:
+		TilesetFilenames:
+			TEMPERATE: gtlite.shp
+			SNOW: galite.shp
 		Start: 1
 		ShadowStart: 3
-	lighting: alphatst
+	lighting:
+		Filename: alphatst.shp
 		BlendMode: DoubleMultiplicative
-		UseTilesetCode: false
 		IgnoreWorldTint: true
-		-DepthSprite:
+		DepthSprite:
 		Offset: 0, 0, 240
 		ZRamp: 1
 		ZOffset: 10240
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
 		Length: *
 		Offset: 0, 0
-		-DepthSprite:
-		UseTilesetCode: false
+		DepthSprite:
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-	icon: liteicon
+	icon:
+		Filename: liteicon.shp
 		Offset: 0, 0
-		-DepthSprite:
-		UseTilesetCode: false
+		DepthSprite:
 
 namntk:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ntmntk.shp
+			SNOW: namntk.shp
 		DepthSprite: isodepth.shp
 		DepthSpriteOffset: 24, 0
-		UseTilesetCode: true
 		Offset: 24, -24, 24
 	idle:
 		ShadowStart: 3
@@ -731,16 +1035,23 @@ namntk:
 	critical-idle:
 		Start: 2
 		ShadowStart: 5
-	idle-lights: namntk_a
+	idle-lights:
+		TilesetFilenames:
+			TEMPERATE: ntmntk_a.shp
+			SNOW: namntk_a.shp
 		Length: 8
 		Tick: 200
-	idle-lights-bright: namntk_a
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: ntmntk_a.shp
+			SNOW: namntk_a.shp
 		Length: 8
 		Tick: 200
 		IgnoreWorldTint: True
 
 ntpyra:
 	Defaults:
+		Filename: ntpyra.shp
 		DepthSprite: isodepth.shp
 		Offset: 0, -42, 42
 	idle:
@@ -751,16 +1062,18 @@ ntpyra:
 	critical-idle:
 		Start: 2
 		ShadowStart: 5
-	idle-lights: ntpyra_a
+	idle-lights:
+		Filename: ntpyra_a.shp
 		Length: 16
 		Tick: 200
-	damaged-idle-lights: ntpyra_a
+	damaged-idle-lights:
+		Filename: ntpyra_a.shp
 		Start: 16
 		Length: 16
 		Tick: 200
 
 ufo:
-	idle: ufo.tem
+	idle:
+		Filename: ufo.tem
 		DepthSprite: isodepth.shp
 		Offset: -24, -60, 60
-		AddExtension: false

--- a/mods/ts/sequences/critters.yaml
+++ b/mods/ts/sequences/critters.yaml
@@ -1,5 +1,6 @@
 doggie:
 	Defaults:
+		Filename: doggie.shp
 		Tick: 80
 		Offset: 0, 0, 16
 	stand:
@@ -34,7 +35,8 @@ doggie:
 		Start: 99
 		Length: 10
 		ShadowStart: 218
-	die-exploding: s_bang34
+	die-exploding:
+		Filename: s_bang34.shp
 		Length: *
 	die-crushed:
 		Start: 105
@@ -54,6 +56,7 @@ doggie:
 
 vissml:
 	idle:
+		Filename: vissml.shp
 		Length: 90
 		ShadowStart: 90
 		Tick: 80
@@ -61,16 +64,19 @@ vissml:
 
 vislrg:
 	idle:
+		Filename: vislrg.shp
 		Length: 90
 		ShadowStart: 90
 		Tick: 80
 		Offset: 0, 0, 16
 	attack:
 		Combine:
-			vislgatk:
+			0:
+				Filename: vislgatk.shp
 				Start: 5
 				Length: 35
-			vislgatk:
+			1:
+				Filename: vislgatk.shp
 				Start: 0
 				Length: 5
 		Facings: -8
@@ -80,6 +86,8 @@ vislrg:
 #		ShadowStart: 40 # TODO: enable shadow frames
 
 floater:
+	Defaults:
+		Filename: floater.shp
 	idle:
 		Length: 16
 		ShadowStart: 32

--- a/mods/ts/sequences/infantry.yaml
+++ b/mods/ts/sequences/infantry.yaml
@@ -36,7 +36,8 @@
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-	die-exploding: s_bang34
+	die-exploding:
+		Filename: s_bang34.shp
 		Length: *
 	die-crushed:
 		Start: 159
@@ -49,7 +50,8 @@
 		Length: 2
 		Facings: 8
 		ShadowStart: 552
-	die-melting: electro
+	die-melting:
+		Filename: electro.shp
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 
@@ -78,81 +80,125 @@
 e1.gdi:
 	Inherits: ^BasicInfantry
 	Inherits@attack: ^BasicInfantryAttack
-	Defaults: e1
-	icon: sidebar-gdi|e1icon
+	Defaults:
+		Filename: e1.shp
+	icon:
+		Filename: sidebar-gdi|e1icon.shp
 
 e1.nod:
 	Inherits: ^BasicInfantry
 	Inherits@attack: ^BasicInfantryAttack
-	Defaults: e1
-	icon: sidebar-nod|e1icon
+	Defaults:
+		Filename: e1.shp
+	icon:
+		Filename: sidebar-nod|e1icon.shp
 
 e2:
+	Defaults:
+		Filename: e2.shp
 	Inherits: ^BasicInfantry
 	Inherits@attack: ^BasicInfantryAttack
-	icon: e2icon
+	icon:
+		Filename: e2icon.shp
 
 e3:
+	Defaults:
+		Filename: e3.shp
 	Inherits: ^BasicInfantry
 	Inherits@attack: ^BasicInfantryAttack
-	icon: e4icon
+	icon:
+		Filename: e4icon.shp
 
 engineer.gdi:
 	Inherits: ^BasicInfantry
-	Defaults: engineer
-	icon: sidebar-gdi|engnicon
+	Defaults:
+		Filename: engineer.shp
+	icon:
+		Filename: sidebar-gdi|engnicon.shp
 
 engineer.nod:
 	Inherits: ^BasicInfantry
-	Defaults: engineer
-	icon: sidebar-nod|engnicon
+	Defaults:
+		Filename: engineer.shp
+	icon:
+		Filename: sidebar-nod|engnicon.shp
 
 umagon:
+	Defaults:
+		Filename: umagon.shp
 	Inherits: ^BasicInfantry
 	Inherits@attack: ^BasicInfantryAttack
-	icon: umagicon
+	icon:
+		Filename: umagicon.shp
 
 ghost:
+	Defaults:
+		Filename: ghost.shp
 	Inherits: ^BasicInfantry
 	Inherits@attack: ^BasicInfantryAttack
-	icon: gosticon
+	icon:
+		Filename: gosticon.shp
 
 mhijack:
+	Defaults:
+		Filename: mhijack.shp
 	Inherits: ^BasicInfantry
-	icon: chamicon
+	icon:
+		Filename: chamicon.shp
 
 chamspy:
+	Defaults:
+		Filename: chamspy.shp
 	Inherits: ^BasicInfantry
-	icon: chamicon
+	icon:
+		Filename: chamicon.shp
 
 mutant:
+	Defaults:
+		Filename: mutant.shp
 	Inherits: ^BasicInfantry
 	Inherits@attack: ^BasicInfantryAttack
-	icon: mutcicon
+	icon:
+		Filename: mutcicon.shp
 
 mwmn:
+	Defaults:
+		Filename: mwmn.shp
 	Inherits: ^BasicInfantry
 	Inherits@attack: ^BasicInfantryAttack
-	icon: mutcicon
+	icon:
+		Filename: mutcicon.shp
 
 mutant3:
+	Defaults:
+		Filename: mutant3.shp
 	Inherits: ^BasicInfantry
 	Inherits@attack: ^BasicInfantryAttack
-	icon: mutcicon
+	icon:
+		Filename: mutcicon.shp
 
 tratos:
+	Defaults:
+		Filename: tratos.shp
 	Inherits: ^BasicInfantry
-	icon: mutcicon
+	icon:
+		Filename: mutcicon.shp
 
 oxanna:
+	Defaults:
+		Filename: oxanna.shp
 	Inherits: ^BasicInfantry
 	Inherits@attack: ^BasicInfantryAttack
 
 slav:
+	Defaults:
+		Filename: slav.shp
 	Inherits: ^BasicInfantry
 	Inherits@attack: ^BasicInfantryAttack
 
 civ1:
+	Defaults:
+		Filename: civ1.shp
 	Inherits: ^BasicInfantry
 	attack:
 		Start: 164
@@ -175,6 +221,8 @@ civ1:
 		ShadowStart: 292
 
 civ2:
+	Defaults:
+		Filename: civ2.shp
 	Inherits: ^BasicInfantry
 	panic-run:
 		Start: 86
@@ -186,10 +234,13 @@ civ2:
 		ShadowStart: 292
 
 civ3:
+	Defaults:
+		Filename: civ3.shp
 	Inherits: civ1
 
 cyborg:
 	Defaults:
+		Filename: cyborg.shp
 		Tick: 80
 		Offset: 0, 0, 16
 	stand:
@@ -238,15 +289,18 @@ cyborg:
 		Length: 6
 		Facings: 8
 		IgnoreWorldTint: True
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
 		Length: *
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-	icon: cybiicon
+	icon:
+		Filename: cybiicon.shp
 
 cyc2:
 	Defaults:
+		Filename: cyc2.shp
 		Offset: 0, 0, 16
 	stand:
 		Facings: 8
@@ -297,15 +351,18 @@ cyc2:
 		Facings: 8
 		ShadowStart: 568
 		IgnoreWorldTint: True
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
 		Length: *
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-	icon: cybcicon
+	icon:
+		Filename: cybcicon.shp
 
 medic:
 	Defaults:
+		Filename: medic.shp
 		Tick: 80
 		Offset: 0, 0, 16
 	stand:
@@ -342,7 +399,8 @@ medic:
 		Start: 149
 		Length: 15
 		ShadowStart: 455
-	die-exploding: s_bang34
+	die-exploding:
+		Filename: s_bang34.shp
 		Length: *
 	die-crushed:
 		Start: 159
@@ -359,13 +417,16 @@ medic:
 		Start: 292
 		Length: 14
 		ShadowStart: 599
-	die-melting: electro
+	die-melting:
+		Filename: electro.shp
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
-	icon: mediicon
+	icon:
+		Filename: mediicon.shp
 
 jumpjet:
 	Defaults:
+		Filename: jumpjet.shp
 		Tick: 80
 		Offset: 0, 0, 16
 	stand:
@@ -413,9 +474,11 @@ jumpjet:
 		Start: 445
 		Length: 6
 		ShadowStart: 896
-	die-splash: h2o_exp2
+	die-splash:
+		Filename: h2o_exp2.shp
 		Length: *
-	die-exploding: s_bang34
+	die-exploding:
+		Filename: s_bang34.shp
 		Length: *
 	die-crushed:
 		Start: 450
@@ -457,13 +520,16 @@ jumpjet:
 		Length: 2
 		Facings: 8
 		ShadowStart: 711
-	die-melting: electro
+	die-melting:
+		Filename: electro.shp
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
-	icon: jjeticon
+	icon:
+		Filename: jjeticon.shp
 
 weedguy:
-	Defaults: weed
+	Defaults:
+		Filename: weed.shp
 		Tick: 80
 		Offset: 0, 0, 16
 	stand:
@@ -522,7 +588,8 @@ weedguy:
 		Start: 177
 		Length: 20
 		ShadowStart: 379
-	die-melting: electro
+	die-melting:
+		Filename: electro.shp
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 	die-crushed:
@@ -533,6 +600,7 @@ weedguy:
 
 flameguy:
 	Defaults:
+		Filename: flameguy.shp
 		Facings: 8
 		Tick: 80
 		ShadowStart: 148

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -1,5 +1,6 @@
 overlay:
-	Defaults: place
+	Defaults:
+		Filename: place.shp
 		Offset: 0, -12, 1
 		ZRamp: 1
 	build-valid-snow:
@@ -9,7 +10,8 @@ overlay:
 	target-select:
 
 editor-overlay:
-	Defaults: place
+	Defaults:
+		Filename: place.shp
 		Offset: 0, -12, 1
 		ZRamp: 1
 	copy:
@@ -18,100 +20,134 @@ editor-overlay:
 
 poweroff:
 	offline:
+		Filename: poweroff.shp
 		Length: *
 		Tick: 160
 		ZOffset: 2047
 
 allyrepair:
-	repair: wrench
+	repair:
+		Filename: wrench.shp
 		Length: *
 		Tick: 160
 		ZOffset: 2047
 
 rallypoint:
-	flag: mouse
+	flag:
+		Filename: mouse.shp
 		Start: 221
 		Length: 8
 		ZOffset: 3072
-	circles: null
+	circles:
+		Filename: null.shp
 
 beacon:
 	idle:
+		Filename: beacon.shp
 		Length: 5
 		Tick: 200
 		ZOffset: 2047
 
 crate:
 	idle:
+		TilesetFilenames:
+			TEMPERATE: crate.tem
+			SNOW: crate.sno
 		ShadowStart: 1
-		UseTilesetExtension: true
 		Offset: 0, -10, 10
 
 crate-effects:
 	Defaults:
 		Length: *
 		Offset: 0, 0, 96
-	dollar: money
-	reveal-map: reveal
-	hide-map: shroudx
-	firepower: firepowr
-	armor: armor
-	stealth: cloak
-	heal: healall
-	nuke: mltimisl
-	levelup: veteran
+	dollar:
+		Filename: money.shp
+	reveal-map:
+		Filename: reveal.shp
+	hide-map:
+		Filename: shroudx.shp
+	firepower:
+		Filename: firepowr.shp
+	armor:
+		Filename: armor.shp
+	stealth:
+		Filename: cloak.shp
+	heal:
+		Filename: healall.shp
+	nuke:
+		Filename: mltimisl.shp
+	levelup:
+		Filename: veteran.shp
 
 rank:
-	veteran: pips
+	veteran:
+		Filename: pips.shp
 		Start: 7
-	elite: pips
+	elite:
+		Filename: pips.shp
 		Start: 8
 		Offset: 3, 3
 
 mpspawn:
 	idle:
+		Filename: mpspawn.shp
 		Length: *
 		ZRamp: 1
 		Offset: 0, 0, 1
 
 waypoint:
 	idle:
+		Filename: waypoint.shp
 		Length: *
 		ZRamp: 1
 		Offset: 0, 0, 1
 
 camera:
 	idle:
+		Filename: camera.shp
 		Length: *
 		ZRamp: 1
 		Offset: 0, 0, 1
 
 clock:
-	idle: gclock2
+	idle:
+		Filename: gclock2.shp
 		Length: *
 
 darken:
-	idle: gclock2
+	idle:
+		Filename: gclock2.shp
 		Length: 1
 
 pips:
+	Defaults:
+		Filename: pips.shp
 	medic:
 		Start: 6
-	pip-empty: pips2
-	pip-green: pips2
+	pip-empty:
+		Filename: pips2.shp
+	pip-green:
+		Filename: pips2.shp
 		Start: 1
-	pip-yellow: pips2
+	pip-yellow:
+		Filename: pips2.shp
 		Start: 2
-	pip-gray: pips2
+	pip-gray:
+		Filename: pips2.shp
 		Start: 3
-	pip-red: pips2
+	pip-red:
+		Filename: pips2.shp
 		Start: 4
-	pip-blue: pips2
+	pip-blue:
+		Filename: pips2.shp
 		Start: 5
-	pip-ammo: ammopips
-	pip-ammoempty: ammopips
+	pip-ammo:
+		Filename: ammopips.shp
+	pip-ammoempty:
+		Filename: ammopips.shp
 		Start: 1
-	pip-disguise: pip-disguise
+	pip-disguise:
+		Filename: pip-disguise.shp
 		Length: *
 		Tick: 300
 		Offset: 0, -6
@@ -135,129 +171,180 @@ explosion:
 		Offset: 0, 0, 24
 		AlphaFade: True
 		IgnoreWorldTint: True
-	building: twlt070
+	building:
+		Filename: twlt070.shp
 		Offset: 0, 0, 36
-	ionring: ring1
+	ionring:
+		Filename: ring1.shp
 		ZRamp: 1
 		Tick: 100
 		IgnoreWorldTint: False
-	ionbeam: ionbeam
+	ionbeam:
+		Filename: ionbeam.shp
 		Offset: 0, -60, 60
 		Tick: 100
 		IgnoreWorldTint: False
-	ionbeam2: ionbeam
+	ionbeam2:
+		Filename: ionbeam.shp
 		Offset: 0, -180, 60
 		Tick: 100
 		IgnoreWorldTint: False
-	ionbeam3: ionbeam
+	ionbeam3:
+		Filename: ionbeam.shp
 		Offset: 0, -300, 60
 		Tick: 100
 		IgnoreWorldTint: False
-	ionbeam4: ionbeam
+	ionbeam4:
+		Filename: ionbeam.shp
 		Offset: 0, -420, 60
 		Tick: 100
 		IgnoreWorldTint: False
-	ionbeam5: ionbeam
+	ionbeam5:
+		Filename: ionbeam.shp
 		Offset: 0, -540, 60
 		Tick: 100
 		IgnoreWorldTint: False
-	ionbeam6: ionbeam
+	ionbeam6:
+		Filename: ionbeam.shp
 		Offset: 0, -660, 60
 		Tick: 100
 		IgnoreWorldTint: False
-	pulse_explosion: pulsefx2
+	pulse_explosion:
+		Filename: pulsefx2.shp
 		BlendMode: Additive
 		ZRamp: 1
 		Tick: 80
-	small_watersplash: h2o_exp2
+	small_watersplash:
+		Filename: h2o_exp2.shp
 		IgnoreWorldTint: False
 		AlphaFade: False
 		Alpha: 0.5
-	large_watersplash: h2o_exp1
+	large_watersplash:
+		Filename: h2o_exp1.shp
 		Offset: 0, 0, 39
 		IgnoreWorldTint: False
 		AlphaFade: False
 		Alpha: 0.5
-	water_piff: w_piff
+	water_piff:
+		Filename: w_piff.shp
 		IgnoreWorldTint: False
-	water_piffs: w_piffs
+	water_piffs:
+		Filename: w_piffs.shp
 		IgnoreWorldTint: False
-	piff: piff
+	piff:
+		Filename: piff.shp
 		IgnoreWorldTint: False
-	piffs: piffpiff
+	piffs:
+		Filename: piffpiff.shp
 		IgnoreWorldTint: False
-	small_explosion: explosml
-	medium_explosion: explomed
+	small_explosion:
+		Filename: explosml.shp
+	medium_explosion:
+		Filename: explomed.shp
 		Offset: 0, 0, 27
-	large_explosion: explolrg
+	large_explosion:
+		Filename: explolrg.shp
 		Offset: 0, 0, 31
-	tiny_bang: s_bang16
-	small_bang: s_bang24
-	medium_bang: s_bang34
-	large_bang: s_bang48
-	tiny_brnl: s_brnl20
-	small_brnl: s_brnl30
-	medium_brnl: s_brnl40
-	large_brnl: s_brnl58
+	tiny_bang:
+		Filename: s_bang16.shp
+	small_bang:
+		Filename: s_bang24.shp
+	medium_bang:
+		Filename: s_bang34.shp
+	large_bang:
+		Filename: s_bang48.shp
+	tiny_brnl:
+		Filename: s_brnl20.shp
+	small_brnl:
+		Filename: s_brnl30.shp
+	medium_brnl:
+		Filename: s_brnl40.shp
+	large_brnl:
+		Filename: s_brnl58.shp
 		Offset: 0, 0, 30
-	tiny_tumu: s_tumu22
-	small_tumu: s_tumu30
-	medium_tumu: s_tumu42
-	large_tumu: s_tumu60
+	tiny_tumu:
+		Filename: s_tumu22.shp
+	small_tumu:
+		Filename: s_tumu30.shp
+	medium_tumu:
+		Filename: s_tumu42.shp
+	large_tumu:
+		Filename: s_tumu60.shp
 		Offset: 0, 0, 31
-	tiny_clsn: s_clsn16
-	small_clsn: s_clsn22
-	medium_clsn: s_clsn30
-	large_clsn: s_clsn42
-	verylarge_clsn: s_clsn58
+	tiny_clsn:
+		Filename: s_clsn16.shp
+	small_clsn:
+		Filename: s_clsn22.shp
+	medium_clsn:
+		Filename: s_clsn30.shp
+	large_clsn:
+		Filename: s_clsn42.shp
+	verylarge_clsn:
+		Filename: s_clsn58.shp
 		Offset: 0, 0, 30
-	tiny_twlt: twlt026
-	small_twlt: twlt036
-	medium_twlt: twlt050
+	tiny_twlt:
+		Filename: twlt026.shp
+	small_twlt:
+		Filename: twlt036.shp
+	medium_twlt:
+		Filename: twlt050.shp
 		Offset: 0, 0, 26
-	large_twlt: twlt070
+	large_twlt:
+		Filename: twlt070.shp
 		Offset: 0, 0, 36
-	verylarge_twlt: twlt100
+	verylarge_twlt:
+		Filename: twlt100.shp
 		Offset: 0, 0, 51
-	tiny_grey_explosion: xgrysml1
+	tiny_grey_explosion:
+		Filename: xgrysml1.shp
 		IgnoreWorldTint: False
-	small_grey_explosion: xgrysml2
+	small_grey_explosion:
+		Filename: xgrysml2.shp
 		IgnoreWorldTint: False
-	medium_grey_explosion: xgrymed1
+	medium_grey_explosion:
+		Filename: xgrymed1.shp
 		IgnoreWorldTint: False
-	large_grey_explosion: xgrymed2
+	large_grey_explosion:
+		Filename: xgrymed2.shp
 		IgnoreWorldTint: False
-	droppod_explosion: droppod
+	droppod_explosion:
+		Filename: droppod.shp
 		Length: 8
 		Tick: 360
 		IgnoreWorldTint: False
-	droppod2_explosion: droppod2
+	droppod2_explosion:
+		Filename: droppod2.shp
 		Length: 8
 		Tick: 360
 		IgnoreWorldTint: False
-	droppody_explosion: droppody
+	droppody_explosion:
+		Filename: droppody.shp
 		Length: 8
 		Tick: 360
 		IgnoreWorldTint: False
-	droppody2_explosion: droppody2
+	droppody2_explosion:
+		Filename: droppody2.shp
 		Length: 8
 		Tick: 360
 		IgnoreWorldTint: False
 
 discus:
 	idle:
+		Filename: discus.shp
 		Length: *
 		ZOffset: 1023
 		Offset: 0, 0, 12
 
 canister:
 	idle:
+		Filename: canister.shp
 		Length: *
 		ZOffset: 1023
 		Offset: 0, 0, 12
 
 pulsball:
 	idle:
+		Filename: pulsball.shp
 		Length: *
 		BlendMode: Additive
 		ZOffset: 1023
@@ -265,25 +352,30 @@ pulsball:
 
 dragon:
 	idle:
+		Filename: dragon.shp
 		Facings: 32
 		ZOffset: 1023
 		Offset: 0, 0, 6
 
 crystal4:
 	idle:
+		TilesetFilenames:
+			TEMPERATE: crystal4.tem
+			SNOW: crystal4.sno
 		Length: 15
 		ShadowStart: 15
-		UseTilesetExtension: true
 		ZOffset: 1023
 		Offset: 0, 0, 6
 
 120mm:
 	idle:
+		Filename: 120mm.shp
 		ZOffset: 1023
 		Offset: 0, 0, 4
 
 torpedo:
 	idle:
+		Filename: torpedo.shp
 		Length: *
 		ZOffset: 1023
 		Offset: 0, 0, 8
@@ -291,6 +383,7 @@ torpedo:
 
 flameall:
 	idle:
+		Filename: flameall.shp
 		Length: 19
 		Facings: -8
 		Tick: 160
@@ -300,63 +393,72 @@ flameall:
 		Alpha: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1
 
 largesmoke:
-	idle: lgrysmk1
+	idle:
+		Filename: lgrysmk1.shp
 		Length: *
 		ZOffset: 1023
 		Offset: 0, 0, 24
 		AlphaFade: True
 
 smallsmoke:
-	idle: sgrysmk1
+	idle:
+		Filename: sgrysmk1.shp
 		Length: *
 		ZOffset: 1023
 		Offset: 0, 0, 24
 		AlphaFade: True
 
 large_smoke_trail:
-	idle: smokey
+	idle:
+		Filename: smokey.shp
 		Length: *
 		ZOffset: 1023
 		Offset: 0, 0, 24
 		AlphaFade: True
 
 small_smoke_trail:
-	idle: smokey2
+	idle:
+		Filename: smokey2.shp
 		Length: *
 		ZOffset: 1023
 		Offset: 0, 0, 24
 		AlphaFade: True
 
 largefire:
-	idle: fire1
+	idle:
+		Filename: fire1.shp
 		Length: *
 		Offset: 0, 0, 36
 		Alpha: 0.5
 		IgnoreWorldTint: True
 
 mediumfire:
-	idle: fire2
+	idle:
+		Filename: fire2.shp
 		Length: *
 		Offset: 0, 0, 24
 		Alpha: 0.5
 		IgnoreWorldTint: True
 
 smallfire:
-	idle: fire3
+	idle:
+		Filename: fire3.shp
 		Length: *
 		Offset: 0, 0, 24
 		Alpha: 0.5
 		IgnoreWorldTint: True
 
 tinyfire:
-	idle: fire4
+	idle:
+		Filename: fire4.shp
 		Length: *
 		Offset: 0, 0, 24
 		Alpha: 0.75
 		IgnoreWorldTint: True
 
 moveflsh:
-	idle: ring
+	idle:
+		Filename: ring.shp
 		Length: *
 		Tick: 30
 		ZOffset: 2047
@@ -364,7 +466,8 @@ moveflsh:
 		AlphaFade: True
 
 wake:
-	idle: wake2
+	idle:
+		Filename: wake2.shp
 		Length: *
 		Tick: 180
 		ZOffset: -512
@@ -374,193 +477,391 @@ wake:
 
 resources:
 	Defaults:
-		UseTilesetExtension: true
 		Length: 12
 		ShadowStart: 12
 		Offset: 0, -12, 1
 		ZRamp: 1
 		IgnoreWorldTint: true
-	tib01: tib01
-	tib02: tib02
-	tib03: tib03
-	tib04: tib04
-	tib05: tib05
-	tib06: tib06
-	tib07: tib07
-	tib08: tib08
-	tib09: tib09
-	tib10: tib10
-	tib11: tib11
-	tib12: tib12
-	tib13: tib13
-	tib14: tib14
-	tib15: tib15
-	tib16: tib16
-	tib17: tib17
-	tib18: tib18
-	tib19: tib19
-	tib20: tib20
-	veins: veins
+	tib01:
+		TilesetFilenames:
+			TEMPERATE: tib01.tem
+			SNOW: tib01.sno
+	tib02:
+		TilesetFilenames:
+			TEMPERATE: tib02.tem
+			SNOW: tib02.sno
+	tib03:
+		TilesetFilenames:
+			TEMPERATE: tib03.tem
+			SNOW: tib03.sno
+	tib04:
+		TilesetFilenames:
+			TEMPERATE: tib04.tem
+			SNOW: tib04.sno
+	tib05:
+		TilesetFilenames:
+			TEMPERATE: tib05.tem
+			SNOW: tib05.sno
+	tib06:
+		TilesetFilenames:
+			TEMPERATE: tib06.tem
+			SNOW: tib06.sno
+	tib07:
+		TilesetFilenames:
+			TEMPERATE: tib07.tem
+			SNOW: tib07.sno
+	tib08:
+		TilesetFilenames:
+			TEMPERATE: tib08.tem
+			SNOW: tib08.sno
+	tib09:
+		TilesetFilenames:
+			TEMPERATE: tib09.tem
+			SNOW: tib09.sno
+	tib10:
+		TilesetFilenames:
+			TEMPERATE: tib10.tem
+			SNOW: tib10.sno
+	tib11:
+		TilesetFilenames:
+			TEMPERATE: tib11.tem
+			SNOW: tib11.sno
+	tib12:
+		TilesetFilenames:
+			TEMPERATE: tib12.tem
+			SNOW: tib12.sno
+	tib13:
+		TilesetFilenames:
+			TEMPERATE: tib13.tem
+			SNOW: tib13.sno
+	tib14:
+		TilesetFilenames:
+			TEMPERATE: tib14.tem
+			SNOW: tib14.sno
+	tib15:
+		TilesetFilenames:
+			TEMPERATE: tib15.tem
+			SNOW: tib15.sno
+	tib16:
+		TilesetFilenames:
+			TEMPERATE: tib16.tem
+			SNOW: tib16.sno
+	tib17:
+		TilesetFilenames:
+			TEMPERATE: tib17.tem
+			SNOW: tib17.sno
+	tib18:
+		TilesetFilenames:
+			TEMPERATE: tib18.tem
+			SNOW: tib18.sno
+	tib19:
+		TilesetFilenames:
+			TEMPERATE: tib19.tem
+			SNOW: tib19.sno
+	tib20:
+		TilesetFilenames:
+			TEMPERATE: tib20.tem
+			SNOW: tib20.sno
+	veins:
+		TilesetFilenames:
+			TEMPERATE: veins.tem
+			SNOW: veins.sno
 		Length: *
 		ShadowStart: -1
 		IgnoreWorldTint: false
 
 veins:
-	idle: veinatac
+	idle:
+		TilesetFilenames:
+			TEMPERATE: veinatac.tem
+			SNOW: veinatac.sno
 		Length: 12
-		UseTilesetExtension: true
 		ZOffset: 1023
 		Offset: 0, -12, 24
 
 shroud:
 	Defaults:
+		Filename: shroud.shp
 		Offset: 0, -1
 		ZRamp: 1
 	shroud:
 		Length: *
-	fog: fog
+	fog:
+		Filename: fog.shp
 		Length: *
 
 smallscorches:
 	Defaults:
-		UseTilesetExtension: true
 		Offset: 0, -12, 1
 		ZRamp: 1
-	sc1: burnt01
-	sc2: burnt02
-	sc3: burnt03
-	sc4: burnt04
-	sc5: burnt05
-	sc6: burnt06
+	sc1:
+		TilesetFilenames:
+			TEMPERATE: burnt01.tem
+			SNOW: burnt01.sno
+	sc2:
+		TilesetFilenames:
+			TEMPERATE: burnt02.tem
+			SNOW: burnt02.sno
+	sc3:
+		TilesetFilenames:
+			TEMPERATE: burnt03.tem
+			SNOW: burnt03.sno
+	sc4:
+		TilesetFilenames:
+			TEMPERATE: burnt04.tem
+			SNOW: burnt04.sno
+	sc5:
+		TilesetFilenames:
+			TEMPERATE: burnt05.tem
+			SNOW: burnt05.sno
+	sc6:
+		TilesetFilenames:
+			TEMPERATE: burnt06.tem
+			SNOW: burnt06.sno
 
 mediumscorches:
 	Defaults:
-		UseTilesetExtension: true
 		Offset: 0, -18, 1
 		ZRamp: 1
-	sc7: burnt07
-	sc8: burnt08
-	sc9: burnt09
-	sc10: burnt10
+	sc7:
+		TilesetFilenames:
+			TEMPERATE: burnt07.tem
+			SNOW: burnt07.sno
+	sc8:
+		TilesetFilenames:
+			TEMPERATE: burnt08.tem
+			SNOW: burnt08.sno
+	sc9:
+		TilesetFilenames:
+			TEMPERATE: burnt09.tem
+			SNOW: burnt09.sno
+	sc10:
+		TilesetFilenames:
+			TEMPERATE: burnt10.tem
+			SNOW: burnt10.sno
 
 largescorches:
 	Defaults:
-		UseTilesetExtension: true
 		Offset: 0, -24, 1
 		ZRamp: 1
-	sc11: burnt11
-	sc12: burnt12
+	sc11:
+		TilesetFilenames:
+			TEMPERATE: burnt11.tem
+			SNOW: burnt11.sno
+	sc12:
+		TilesetFilenames:
+			TEMPERATE: burnt12.tem
+			SNOW: burnt12.sno
 
 smallcraters:
 	Defaults:
-		UseTilesetExtension: true
 		Offset: 0, -12, 1
 		ZRamp: 1
-	cr1: crater01
-	cr2: crater02
-	cr3: crater03
-	cr4: crater04
-	cr5: crater05
-	cr6: crater06
+	cr1:
+		TilesetFilenames:
+			TEMPERATE: crater01.tem
+			SNOW: crater01.sno
+	cr2:
+		TilesetFilenames:
+			TEMPERATE: crater02.tem
+			SNOW: crater02.sno
+	cr3:
+		TilesetFilenames:
+			TEMPERATE: crater03.tem
+			SNOW: crater03.sno
+	cr4:
+		TilesetFilenames:
+			TEMPERATE: crater04.tem
+			SNOW: crater04.sno
+	cr5:
+		TilesetFilenames:
+			TEMPERATE: crater05.tem
+			SNOW: crater05.sno
+	cr6:
+		TilesetFilenames:
+			TEMPERATE: crater06.tem
+			SNOW: crater06.sno
 
 mediumcraters:
 	Defaults:
-		UseTilesetExtension: true
 		Offset: 0, -12, 1
 		ZRamp: 1
-	cr7: crater07
-	cr8: crater08
-	cr9: crater09
-	cr10: crater10
+	cr7:
+		TilesetFilenames:
+			TEMPERATE: crater07.tem
+			SNOW: crater07.sno
+	cr8:
+		TilesetFilenames:
+			TEMPERATE: crater08.tem
+			SNOW: crater08.sno
+	cr9:
+		TilesetFilenames:
+			TEMPERATE: crater09.tem
+			SNOW: crater09.sno
+	cr10:
+		TilesetFilenames:
+			TEMPERATE: crater10.tem
+			SNOW: crater10.sno
 
 largecraters:
 	Defaults:
-		UseTilesetExtension: true
 		Offset: 0, -24, 1
 		ZRamp: 1
-	cr11: crater11
-	cr12: crater12
+	cr11:
+		TilesetFilenames:
+			TEMPERATE: crater11.tem
+			SNOW: crater11.sno
+	cr12:
+		TilesetFilenames:
+			TEMPERATE: crater12.tem
+			SNOW: crater12.sno
 
 icon:
-	clustermissile: mltiicon
-	ioncannon: ioncicon
-	hunterseeker: detnicon
-	emp: pulsicon
-	droppods: podsicon
+	clustermissile:
+		Filename: mltiicon.shp
+	ioncannon:
+		Filename: ioncicon.shp
+	hunterseeker:
+		Filename: detnicon.shp
+	emp:
+		Filename: pulsicon.shp
+	droppods:
+		Filename: podsicon.shp
 
 clustermissile:
-	up: mltimisl-placeholder # TODO: use voxel
+	up: # TODO: use voxel
+		Filename: mltimisl-placeholder.shp
 		Frames: 0
 		Length: 1
-	down: mltimisl-placeholder # TODO: use voxel
+	down: # TODO: use voxel
+		Filename: mltimisl-placeholder.shp
 		Frames: 1
 		Length: 1
 
 ^rock:
 	idle:
 		ShadowStart: 1
-		UseTilesetExtension: true
 		Offset: 0, -12
 
 trock01:
 	Inherits: ^rock
+	idle:
+		TilesetFilenames:
+			TEMPERATE: trock01.tem
+			SNOW: trock01.sno
 
 trock02:
 	Inherits: ^rock
+	idle:
+		TilesetFilenames:
+			TEMPERATE: trock02.tem
+			SNOW: trock02.sno
 
 trock03:
 	Inherits: ^rock
+	idle:
+		TilesetFilenames:
+			TEMPERATE: trock03.tem
+			SNOW: trock03.sno
 
 trock04:
 	Inherits: ^rock
+	idle:
+		TilesetFilenames:
+			TEMPERATE: trock04.tem
+			SNOW: trock04.sno
 
 trock05:
 	Inherits: ^rock
+	idle:
+		TilesetFilenames:
+			TEMPERATE: trock05.tem
+			SNOW: trock05.sno
 
 srock01:
 	Inherits: ^rock
+	idle:
+		TilesetFilenames:
+			TEMPERATE: srock01.tem
+			SNOW: srock01.sno
 
 srock02:
 	Inherits: ^rock
+	idle:
+		TilesetFilenames:
+			TEMPERATE: srock02.tem
+			SNOW: srock02.sno
 
 srock03:
 	Inherits: ^rock
+	idle:
+		TilesetFilenames:
+			TEMPERATE: srock03.tem
+			SNOW: srock03.sno
 
 srock04:
 	Inherits: ^rock
+	idle:
+		TilesetFilenames:
+			TEMPERATE: srock04.tem
+			SNOW: srock04.sno
 
 srock05:
 	Inherits: ^rock
+	idle:
+		TilesetFilenames:
+			TEMPERATE: srock05.tem
+			SNOW: srock05.sno
 
 dbrissm:
 	Defaults:
 		ZOffset: 1023
 		Length: *
-	1: dbris1sm
-	2: dbris2sm
-	3: dbris3sm
-	4: dbris4sm
-	5: dbris5sm
-	6: dbris6sm
-	7: dbris7sm
-	8: dbris8sm
-	9: dbris9sm
-	10: dbrs10sm
+	1:
+		Filename: dbris1sm.shp
+	2:
+		Filename: dbris2sm.shp
+	3:
+		Filename: dbris3sm.shp
+	4:
+		Filename: dbris4sm.shp
+	5:
+		Filename: dbris5sm.shp
+	6:
+		Filename: dbris6sm.shp
+	7:
+		Filename: dbris7sm.shp
+	8:
+		Filename: dbris8sm.shp
+	9:
+		Filename: dbris9sm.shp
+	10:
+		Filename: dbrs10sm.shp
 
 dbrislg:
 	Defaults:
 		ZOffset: 1023
 		Length: *
-	1: dbris1lg
-	2: dbris2lg
-	3: dbris3lg
-	4: dbris4lg
-	5: dbris5lg
-	6: dbris6lg
-	7: dbris7lg
-	8: dbris8lg
-	9: dbris9lg
-	10: dbrs10lg
+	1:
+		Filename: dbris1lg.shp
+	2:
+		Filename: dbris2lg.shp
+	3:
+		Filename: dbris3lg.shp
+	4:
+		Filename: dbris4lg.shp
+	5:
+		Filename: dbris5lg.shp
+	6:
+		Filename: dbris6lg.shp
+	7:
+		Filename: dbris7lg.shp
+	8:
+		Filename: dbris8lg.shp
+	9:
+		Filename: dbris9lg.shp
+	10:
+		Filename: dbrs10lg.shp
 
 ^crate:
 	idle:
@@ -569,130 +870,233 @@ dbrislg:
 
 crat01:
 	Inherits: ^crate
+	idle:
+		Filename: crat01.shp
 
 crat02:
 	Inherits: ^crate
+	idle:
+		Filename: crat02.shp
 
 crat03:
 	Inherits: ^crate
+	idle:
+		Filename: crat03.shp
 
 crat04:
 	Inherits: ^crate
+	idle:
+		Filename: crat04.shp
 
 crat0a:
 	Inherits: ^crate
+	idle:
+		Filename: crat0a.shp
 
 crat0b:
 	Inherits: ^crate
+	idle:
+		Filename: crat0b.shp
 
 crat0c:
 	Inherits: ^crate
+	idle:
+		Filename: crat0c.shp
 
 drum01:
 	Inherits: ^crate
+	idle:
+		Filename: drum01.shp
 
 drum02:
 	Inherits: ^crate
+	idle:
+		Filename: drum02.shp
 
 palet01:
 	Inherits: ^crate
+	idle:
+		Filename: palet01.shp
 
 palet02:
 	Inherits: ^crate
+	idle:
+		Filename: palet02.shp
 
 palet03:
 	Inherits: ^crate
+	idle:
+		Filename: palet03.shp
 
 palet04:
 	Inherits: ^crate
+	idle:
+		Filename: palet04.shp
 
 ^tracks:
 	idle:
-		UseTilesetExtension: true
 		ZOffset: -1c0
 		Offset: 0, 0, 1
 		ZRamp: 1
 
 tracks01:
 	Inherits: ^tracks
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tracks01.tem
+			SNOW: tracks01.sno
 
 tracks02:
 	Inherits: ^tracks
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tracks02.tem
+			SNOW: tracks02.sno
 
 tracks03:
 	Inherits: ^tracks
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tracks03.tem
+			SNOW: tracks03.sno
 
 tracks04:
 	Inherits: ^tracks
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tracks04.tem
+			SNOW: tracks04.sno
 
 tracks05:
 	Inherits: ^tracks
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tracks05.tem
+			SNOW: tracks05.sno
 
 tracks06:
 	Inherits: ^tracks
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tracks06.tem
+			SNOW: tracks06.sno
 
 tracks07:
 	Inherits: ^tracks
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tracks07.tem
+			SNOW: tracks07.sno
 
 tracks08:
 	Inherits: ^tracks
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tracks08.tem
+			SNOW: tracks08.sno
 
 tracks09:
 	Inherits: ^tracks
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tracks09.tem
+			SNOW: tracks09.sno
 
 tracks10:
 	Inherits: ^tracks
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tracks10.tem
+			SNOW: tracks10.sno
 
 tracks11:
 	Inherits: ^tracks
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tracks11.tem
+			SNOW: tracks11.sno
 
 tracks12:
 	Inherits: ^tracks
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tracks12.tem
+			SNOW: tracks12.sno
 
 tracks13:
 	Inherits: ^tracks
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tracks13.tem
+			SNOW: tracks13.sno
 
 tracks14:
 	Inherits: ^tracks
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tracks14.tem
+			SNOW: tracks14.sno
 
 tracks15:
 	Inherits: ^tracks
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tracks15.tem
+			SNOW: tracks15.sno
 
 tracks16:
 	Inherits: ^tracks
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tracks16.tem
+			SNOW: tracks16.sno
 
 ^tuntop:
 	idle:
 		ZRamp: 1
-		UseTilesetExtension: true
 
 tuntop01:
 	Inherits: ^tuntop
 	idle:
+		TilesetFilenames:
+			TEMPERATE: tuntop01.tem
+			SNOW: tuntop01.sno
 		Offset: 24, -49, 48
 
 tuntop02:
 	Inherits: ^tuntop
 	idle:
+		TilesetFilenames:
+			TEMPERATE: tuntop02.tem
+			SNOW: tuntop02.sno
 		Offset: -24, -49, 48
 
 tuntop03:
 	Inherits: ^tuntop
 	idle:
+		TilesetFilenames:
+			TEMPERATE: tuntop03.tem
+			SNOW: tuntop03.sno
 		Offset: 24, -49, 49
 
 tuntop04:
 	Inherits: ^tuntop
 	idle:
+		TilesetFilenames:
+			TEMPERATE: tuntop04.tem
+			SNOW: tuntop04.sno
 		Offset: -24, -49, 49
 
 dig:
 	idle:
+		Filename: dig.shp
 		Length: *
 		ZOffset: 511
 		Offset: 0, 0, 24
 
 typeglyphs:
+	Defaults:
+		Filename: typeglyphs.shp
 	infantry:
 	vehicle:
 		Start: 1
@@ -705,12 +1109,14 @@ typeglyphs:
 
 podring:
 	idle:
+		Filename: podring.shp
 		Frames: 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
 		Length: *
 		AlphaFade: True
 
 fire1:
 	idle-overlay:
+		Filename: fire1.shp
 		Length: 17
 		BlendMode: Translucent
 		Offset: 0, -24, 24
@@ -718,13 +1124,15 @@ fire1:
 
 fire2:
 	idle-overlay:
+		Filename: fire2.shp
 		Length: 17
 		BlendMode: Translucent
 		Offset: 0, -18, 18
 		ZOffset: 1023
 
 caryland:
-	idle: podring
+	idle:
+		Filename: podring.shp
 		Length: *
 		Tick: 50
 		ZOffset: -512
@@ -733,7 +1141,8 @@ caryland:
 		BlendMode: Translucent
 
 dropland:
-	idle: podring
+	idle:
+		Filename: podring.shp
 		Length: *
 		Tick: 90
 		ZOffset: -512

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -1,7 +1,9 @@
 gacnst:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: gtcnst.shp
+			SNOW: gacnst.shp
 		Offset: 0, -36, 36
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
@@ -12,66 +14,109 @@ gacnst:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	make: gtcnstmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: gtcnstmk.shp
+			SNOW: gacnstmk.shp
 		Length: 24
 		ShadowStart: 24
-	make-bright: gtcnstmk
+	make-bright:
+		TilesetFilenames:
+			TEMPERATE: gtcnstmk.shp
+			SNOW: gacnstmk.shp
 		Length: 24
 		IgnoreWorldTint: True
 		ZOffset: 1023
-	crane-overlay: gtcnst_d
+	crane-overlay:
+		TilesetFilenames:
+			TEMPERATE: gtcnst_d.shp
+			SNOW: gacnst_d.shp
 		Length: 20
 		ZOffset: 1023
-	damaged-crane-overlay: gtcnst_d
+	damaged-crane-overlay:
+		TilesetFilenames:
+			TEMPERATE: gtcnst_d.shp
+			SNOW: gacnst_d.shp
 		Length: 20
 		ZOffset: 1023
-	critical-crane-overlay: gtcnst_d
+	critical-crane-overlay:
+		TilesetFilenames:
+			TEMPERATE: gtcnst_d.shp
+			SNOW: gacnst_d.shp
 		Start: 20
 		Length: 20
 		ZOffset: 1023
-	idle-top: gtcnst_c
+	idle-top:
+		TilesetFilenames:
+			TEMPERATE: gtcnst_c.shp
+			SNOW: gacnst_c.shp
 		Length: 15
 		Tick: 80
-	idle-top-bright: gtcnst_c
-		Length: 15
-		Tick: 80
-		IgnoreWorldTint: True
-	damaged-idle-top: gtcnst_c
-		Start: 15
-		Length: 15
-		Tick: 80
-	damaged-idle-top-bright: gtcnst_c
-		Start: 15
+	idle-top-bright:
+		TilesetFilenames:
+			TEMPERATE: gtcnst_c.shp
+			SNOW: gacnst_c.shp
 		Length: 15
 		Tick: 80
 		IgnoreWorldTint: True
-	idle-side: gtcnst_a
+	damaged-idle-top:
+		TilesetFilenames:
+			TEMPERATE: gtcnst_c.shp
+			SNOW: gacnst_c.shp
+		Start: 15
+		Length: 15
+		Tick: 80
+	damaged-idle-top-bright:
+		TilesetFilenames:
+			TEMPERATE: gtcnst_c.shp
+			SNOW: gacnst_c.shp
+		Start: 15
+		Length: 15
+		Tick: 80
+		IgnoreWorldTint: True
+	idle-side:
+		TilesetFilenames:
+			TEMPERATE: gtcnst_a.shp
+			SNOW: gacnst_a.shp
 		Length: 10
-	damaged-idle-side: gtcnst_a
+	damaged-idle-side:
+		TilesetFilenames:
+			TEMPERATE: gtcnst_a.shp
+			SNOW: gacnst_a.shp
 		Start: 10
 		Length: 10
-	idle-front: gtcnst_b
+	idle-front:
+		TilesetFilenames:
+			TEMPERATE: gtcnst_b.shp
+			SNOW: gacnst_b.shp
 		Length: 10
-	idle-front-bright: gtcnst_b
+	idle-front-bright:
+		TilesetFilenames:
+			TEMPERATE: gtcnst_b.shp
+			SNOW: gacnst_b.shp
 		Length: 10
 		IgnoreWorldTint: True
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 37
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: facticon
+		DepthSprite:
+	icon:
+		Filename: facticon.shp
+		TilesetFilenames:
 		Offset: 0,0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 gapowr:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: gtpowr.shp
+			SNOW: gapowr.shp
 		Offset: 0, -24, 24
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
@@ -82,76 +127,118 @@ gapowr:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	idle-lights: gtpowr_a
+	idle-lights:
+		TilesetFilenames:
+			TEMPERATE: gtpowr_a.shp
+			SNOW: gapowr_a.shp
 		Length: 12
 		Tick: 200
-	idle-lights-bright: gtpowr_a
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gtpowr_a.shp
+			SNOW: gapowr_a.shp
 		Length: 12
 		Tick: 200
 		IgnoreWorldTint: True
-	damaged-idle-lights: gtpowr_a
+	damaged-idle-lights:
+		TilesetFilenames:
+			TEMPERATE: gtpowr_a.shp
+			SNOW: gapowr_a.shp
 		Start: 12
 		Length: 12
 		Tick: 200
-	damaged-idle-lights-bright: gtpowr_a
+	damaged-idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gtpowr_a.shp
+			SNOW: gapowr_a.shp
 		Start: 12
 		Length: 12
 		Tick: 200
 		IgnoreWorldTint: True
-	idle-plug: gtpowr_b
+	idle-plug:
+		TilesetFilenames:
+			TEMPERATE: gtpowr_b.shp
+			SNOW: gapowr_b.shp
 		Length: 12
 		Tick: 200
-	damaged-idle-plug: gtpowr_b
+	damaged-idle-plug:
+		TilesetFilenames:
+			TEMPERATE: gtpowr_b.shp
+			SNOW: gapowr_b.shp
 		Length: 12
 		Tick: 200
-	idle-powrupa: gtpowr_b
+	idle-powrupa:
+		TilesetFilenames:
+			TEMPERATE: gtpowr_b.shp
+			SNOW: gapowr_b.shp
 		Length: 12
 		Tick: 200
 		Offset: -48, -24, 24
-	damaged-idle-powrupa: gtpowr_b
+	damaged-idle-powrupa:
+		TilesetFilenames:
+			TEMPERATE: gtpowr_b.shp
+			SNOW: gapowr_b.shp
 		Length: 12
 		Tick: 200
 		Offset: -48, -24, 24
-	idle-powrupb: gtpowr_b
+	idle-powrupb:
+		TilesetFilenames:
+			TEMPERATE: gtpowr_b.shp
+			SNOW: gapowr_b.shp
 		Length: 12
 		Tick: 200
 		Offset: -24, -12, 24
-	damaged-idle-powrupb: gtpowr_b
+	damaged-idle-powrupb:
+		TilesetFilenames:
+			TEMPERATE: gtpowr_b.shp
+			SNOW: gapowr_b.shp
 		Length: 12
 		Tick: 200
 		Offset: -24, -12, 24
-	make: gtpowrmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: gtpowrmk.shp
+			SNOW: gapowrmk.shp
 		Length: 20
 		ShadowStart: 20
-	make-bright: gtpowrmk
+	make-bright:
+		TilesetFilenames:
+			TEMPERATE: gtpowrmk.shp
+			SNOW: gapowrmk.shp
 		Length: 20
 		ShadowStart: 20
 		IgnoreWorldTint: True
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 25
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: powricon
+		DepthSprite:
+	icon:
+		Filename: powricon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 gapowrup:
-	place: gtpowr_b
+	place:
+		Filename: gtpowr_b.shp
 		Offset: -24, -24, 24
 		Start: 0
 		Length: 11
 		Tick: 200
-	icon: turbicon
+	icon:
+		Filename: turbicon.shp
 
 gapile:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: gtpile.shp
+			SNOW: gapile.shp
 		Offset: 0, -24, 24
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
@@ -162,131 +249,197 @@ gapile:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	idle-lights: gtpile_a
+	idle-lights:
+		TilesetFilenames:
+			TEMPERATE: gtpile_a.shp
+			SNOW: gapile_a.shp
 		Length: 8
 		Tick: 200
 		ZOffset: 1023
-	idle-lights-bright: gtpile_a
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gtpile_a.shp
+			SNOW: gapile_a.shp
 		Length: 8
 		Tick: 200
 		ZOffset: 1023
 		IgnoreWorldTint: True
-	idle-light-bright: gtpile_b
+	idle-light-bright:
+		TilesetFilenames:
+			TEMPERATE: gtpile_b.shp
+			SNOW: gapile_b.shp
 		Length: 8
 		Tick: 200
 		IgnoreWorldTint: True
-	idle-flag: gtpile_c
+	idle-flag:
+		TilesetFilenames:
+			TEMPERATE: gtpile_c.shp
+			SNOW: gapile_c.shp
 		Length: 7
 		Tick: 100
-	damaged-idle-flag: gtpile_c
+	damaged-idle-flag:
+		TilesetFilenames:
+			TEMPERATE: gtpile_c.shp
+			SNOW: gapile_c.shp
 		Start: 7
 		Length: 7
 		Tick: 100
-	make: gtpilemk
+	make:
+		TilesetFilenames:
+			TEMPERATE: gtpilemk.shp
+			SNOW: gapilemk.shp
 		Length: 20
 		ShadowStart: 20
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 25
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: brrkicon
+		DepthSprite:
+	icon:
+		Filename: brrkicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 gaweap:
 	Defaults:
 		Offset: -12, -42, 22
 		DepthSpriteOffset: 32, 0
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
-	idle: gtweap_1
+	idle:
+		TilesetFilenames:
+			TEMPERATE: gtweap_1.shp
+			SNOW: gaweap_1.shp
 		ShadowStart: 2
 		Offset: -12, -42, 1
 		ZOffset: -1024
 		ZRamp: 1
-		-DepthSprite:
-	damaged-idle: gtweap_1
+		DepthSprite:
+	damaged-idle:
+		TilesetFilenames:
+			TEMPERATE: gtweap_1.shp
+			SNOW: gaweap_1.shp
 		Start: 1
 		ShadowStart: 3
 		ZOffset: -1024
 		Offset: -12, -42, 1
 		ZRamp: 1
-		-DepthSprite:
-	idle-roof: gtweap_2
+		DepthSprite:
+	idle-roof:
+		TilesetFilenames:
+			TEMPERATE: gtweap_2.shp
+			SNOW: gaweap_2.shp
 		ShadowStart: 2
-	damaged-idle-roof: gtweap_2
+	damaged-idle-roof:
+		TilesetFilenames:
+			TEMPERATE: gtweap_2.shp
+			SNOW: gaweap_2.shp
 		Start: 1
 		ShadowStart: 3
-	dead: gtweap
+	dead:
+		TilesetFilenames:
+			TEMPERATE: gtweap.shp
+			SNOW: gaweap.shp
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	idle-lights-white: gtweap_a
+	idle-lights-white:
+		TilesetFilenames:
+			TEMPERATE: gtweap_a.shp
+			SNOW: gaweap_a.shp
 		Length: 16
 		Tick: 100
 		ZOffset: 2048
-	idle-lights-white-bright: gtweap_a
+	idle-lights-white-bright:
+		TilesetFilenames:
+			TEMPERATE: gtweap_a.shp
+			SNOW: gaweap_a.shp
 		Length: 16
 		Tick: 100
 		ZOffset: 2048
 		IgnoreWorldTint: True
-	idle-lights-red: gtweap_b
+	idle-lights-red:
+		TilesetFilenames:
+			TEMPERATE: gtweap_b.shp
+			SNOW: gaweap_b.shp
 		Length: 8
 		Tick: 120
 		ZOffset: 2048
-	idle-lights-red-bright: gtweap_b
+	idle-lights-red-bright:
+		TilesetFilenames:
+			TEMPERATE: gtweap_b.shp
+			SNOW: gaweap_b.shp
 		Length: 8
 		Tick: 120
 		ZOffset: 2048
 		IgnoreWorldTint: True
-	idle-turbines: gtweap_c
+	idle-turbines:
+		TilesetFilenames:
+			TEMPERATE: gtweap_c.shp
+			SNOW: gaweap_c.shp
 		Length: 4
 		Tick: 80
 		ZOffset: 2048
-	damaged-idle-turbines: gtweap_c
+	damaged-idle-turbines:
+		TilesetFilenames:
+			TEMPERATE: gtweap_c.shp
+			SNOW: gaweap_c.shp
 		Length: 4
 		Tick: 80
 		ZOffset: 2048
-	build-door: gtweap_d
+	build-door:
+		TilesetFilenames:
+			TEMPERATE: gtweap_d.shp
+			SNOW: gaweap_d.shp
 		Length: 9
 		ShadowStart: 9
-	damaged-build-door: gtweap_d
+	damaged-build-door:
+		TilesetFilenames:
+			TEMPERATE: gtweap_d.shp
+			SNOW: gaweap_d.shp
 		Length: 9
 		ShadowStart: 9
-	make: gtweapmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: gtweapmk.shp
+			SNOW: gaweapmk.shp
 		Length: 20
 		Tick: 80
 		ShadowStart: 20
 		Offset: -12, -42, 43
 		DepthSpriteOffset: -12, 0
-	make-bright: gtweapmk
+	make-bright:
+		TilesetFilenames:
+			TEMPERATE: gtweapmk.shp
+			SNOW: gaweapmk.shp
 		Length: 20
 		Tick: 80
 		Offset: -12, -42, 44
 		DepthSpriteOffset: -12, 0
 		IgnoreWorldTint: True
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
 		Length: *
 		Offset: 0, 0, 23
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: weapicon
+		DepthSprite:
+	icon:
+		Filename: weapicon.shp
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 napowr:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ntpowr.shp
+			SNOW: napowr.shp
 		Offset: 0, -24, 24
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
@@ -297,42 +450,61 @@ napowr:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	idle-lights: ntpowr_a
+	idle-lights:
+		TilesetFilenames:
+			TEMPERATE: ntpowr_a.shp
+			SNOW: napowr_a.shp
 		Length: 9
 		Tick: 200
-	idle-lights-bright: ntpowr_a
-		Length: 9
-		Tick: 200
-		IgnoreWorldTint: True
-	damaged-idle-lights: ntpowr_a
-		Start: 9
-		Length: 9
-		Tick: 200
-	damaged-idle-lights-bright: ntpowr_a
-		Start: 9
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: ntpowr_a.shp
+			SNOW: napowr_a.shp
 		Length: 9
 		Tick: 200
 		IgnoreWorldTint: True
-	make: ntpowrmk
+	damaged-idle-lights:
+		TilesetFilenames:
+			TEMPERATE: ntpowr_a.shp
+			SNOW: napowr_a.shp
+		Start: 9
+		Length: 9
+		Tick: 200
+	damaged-idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: ntpowr_a.shp
+			SNOW: napowr_a.shp
+		Start: 9
+		Length: 9
+		Tick: 200
+		IgnoreWorldTint: True
+	make:
+		TilesetFilenames:
+			TEMPERATE: ntpowrmk.shp
+			SNOW: napowrmk.shp
 		Length: 19
 		ShadowStart: 19
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 25
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: npwricon
+		DepthSprite:
+	icon:
+		Filename: npwricon.shp
+		TilesetFilenames:
 		Offset: 0, 0, 25
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 naapwr:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ntapwr.shp
+			SNOW: naapwr.shp
 		Offset: 12, -30, 30
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 		DepthSpriteOffset: 12, 0
 	idle:
@@ -344,42 +516,61 @@ naapwr:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	idle-lights: ntapwr_a
+	idle-lights:
+		TilesetFilenames:
+			TEMPERATE: ntapwr_a.shp
+			SNOW: naapwr_a.shp
 		Length: 9
 		Tick: 200
-	idle-lights-bright: ntapwr_a
-		Length: 9
-		Tick: 200
-		IgnoreWorldTint: True
-	damaged-idle-lights: ntapwr_a
-		Start: 9
-		Length: 9
-		Tick: 200
-	damaged-idle-lights-bright: ntapwr_a
-		Start: 9
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: ntapwr_a.shp
+			SNOW: naapwr_a.shp
 		Length: 9
 		Tick: 200
 		IgnoreWorldTint: True
-	make: ntapwrmk
+	damaged-idle-lights:
+		TilesetFilenames:
+			TEMPERATE: ntapwr_a.shp
+			SNOW: naapwr_a.shp
+		Start: 9
+		Length: 9
+		Tick: 200
+	damaged-idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: ntapwr_a.shp
+			SNOW: naapwr_a.shp
+		Start: 9
+		Length: 9
+		Tick: 200
+		IgnoreWorldTint: True
+	make:
+		TilesetFilenames:
+			TEMPERATE: ntapwrmk.shp
+			SNOW: naapwrmk.shp
 		Length: 19
 		ShadowStart: 19
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 31
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: apwricon
+		DepthSprite:
+	icon:
+		Filename: apwricon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 nahand:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: nthand.shp
+			SNOW: nahand.shp
 		Offset: -12, -30, 30
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 		DepthSpriteOffset: -12, 0
 	idle:
@@ -391,118 +582,169 @@ nahand:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	idle-light-bright: nthand_a
+	idle-light-bright:
+		TilesetFilenames:
+			TEMPERATE: nthand_a.shp
+			SNOW: nahand_a.shp
 		Length: 10
 		Tick: 100
 		ZOffset: 1023
 		IgnoreWorldTint: True
-	idle-lights-bright: nthand_b
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: nthand_b.shp
+			SNOW: nahand_b.shp
 		Length: 12
 		Tick: 200
 		IgnoreWorldTint: True
-	damaged-idle-lights-bright: nthand_b
+	damaged-idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: nthand_b.shp
+			SNOW: nahand_b.shp
 		Start: 12
 		Length: 12
 		Tick: 200
 		IgnoreWorldTint: True
-	make: nthandmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: nthandmk.shp
+			SNOW: nahandmk.shp
 		Length: 15
 		ShadowStart: 15
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 31
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: handicon
+		DepthSprite:
+	icon:
+		Filename: handicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 naweap:
 	Defaults:
 		Offset: -12, -42, 25
 		DepthSpriteOffset: 24, 0
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
-	idle: ntweap_1
+	idle:
+		TilesetFilenames:
+			TEMPERATE: ntweap_1.shp
+			SNOW: naweap_1.shp
 		ShadowStart: 2
 		ZOffset: -1024
 		Offset: -12, -42, 1
 		ZRamp: 1
-		-DepthSprite:
-	damaged-idle: ntweap_1
+		DepthSprite:
+	damaged-idle:
+		TilesetFilenames:
+			TEMPERATE: ntweap_1.shp
+			SNOW: naweap_1.shp
 		Start: 1
 		ShadowStart: 3
 		ZOffset: -1024
 		Offset: -12, -42, 1
 		ZRamp: 1
-		-DepthSprite:
-	idle-roof: ntweap_2
+		DepthSprite:
+	idle-roof:
+		TilesetFilenames:
+			TEMPERATE: ntweap_2.shp
+			SNOW: naweap_2.shp
 		ShadowStart: 2
 		ZOffset: 512
-	damaged-idle-roof: ntweap_2
+	damaged-idle-roof:
+		TilesetFilenames:
+			TEMPERATE: ntweap_2.shp
+			SNOW: naweap_2.shp
 		Start: 1
 		ShadowStart: 3
 		ZOffset: 512
-	dead: ntweap
+	dead:
+		TilesetFilenames:
+			TEMPERATE: ntweap.shp
+			SNOW: naweap.shp
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	idle-lights: ntweap_a
+	idle-lights:
+		TilesetFilenames:
+			TEMPERATE: ntweap_a.shp
+			SNOW: naweap_a.shp
 		Length: 16
 		Tick: 100
 		ZOffset: 2048
-	idle-lights-bright: ntweap_a
-		Length: 16
-		Tick: 100
-		ZOffset: 2048
-		IgnoreWorldTint: True
-	damaged-idle-lights: ntweap_a
-		Start: 16
-		Length: 16
-		Tick: 100
-		ZOffset: 2048
-	damaged-idle-lights-bright: ntweap_a
-		Start: 16
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: ntweap_a.shp
+			SNOW: naweap_a.shp
 		Length: 16
 		Tick: 100
 		ZOffset: 2048
 		IgnoreWorldTint: True
-	build-door: ntweap_b
+	damaged-idle-lights:
+		TilesetFilenames:
+			TEMPERATE: ntweap_a.shp
+			SNOW: naweap_a.shp
+		Start: 16
+		Length: 16
+		Tick: 100
+		ZOffset: 2048
+	damaged-idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: ntweap_a.shp
+			SNOW: naweap_a.shp
+		Start: 16
+		Length: 16
+		Tick: 100
+		ZOffset: 2048
+		IgnoreWorldTint: True
+	build-door:
+		TilesetFilenames:
+			TEMPERATE: ntweap_b.shp
+			SNOW: naweap_b.shp
 		Length: 10
 		ShadowStart: 10
 		ZOffset: 512
-	damaged-build-door: ntweap_b
+	damaged-build-door:
+		TilesetFilenames:
+			TEMPERATE: ntweap_b.shp
+			SNOW: naweap_b.shp
 		Start: 10
 		Length: 10
 		ShadowStart: 20
 		ZOffset: 512
-	make: ntweapmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: ntweapmk.shp
+			SNOW: naweapmk.shp
 		Length: 22
 		Tick: 80
 		ShadowStart: 22
 		Offset: -12, -42, 43
 		DepthSpriteOffset: -12, 0
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
 		Length: *
 		Offset: 0, 0, 31
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: nwepicon
+		DepthSprite:
+	icon:
+		Filename: nwepicon.shp
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 naradr:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ntradr.shp
+			SNOW: naradr.shp
 		Offset: 0, -24, 30
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
@@ -513,33 +755,46 @@ naradr:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	idle-dish: ntradr_a
+	idle-dish:
+		TilesetFilenames:
+			TEMPERATE: ntradr_a.shp
+			SNOW: naradr_a.shp
 		Length: 24
 		Tick: 120
-	damaged-idle-dish: ntradr_a
+	damaged-idle-dish:
+		TilesetFilenames:
+			TEMPERATE: ntradr_a.shp
+			SNOW: naradr_a.shp
 		Start: 24
 		Length: 24
 		Tick: 120
-	make: ntradrmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: ntradrmk.shp
+			SNOW: naradrmk.shp
 		Length: 20
 		ShadowStart: 20
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 25
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: nradicon
+		DepthSprite:
+	icon:
+		Filename: nradicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 natech:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: nttech.shp
+			SNOW: natech.shp
 		Offset: 0, -24, 24
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
@@ -550,42 +805,61 @@ natech:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	idle-lights: nttech_a
+	idle-lights:
+		TilesetFilenames:
+			TEMPERATE: nttech_a.shp
+			SNOW: natech_a.shp
 		Length: 10
 		Tick: 120
-	idle-lights-bright: nttech_a
-		Length: 10
-		Tick: 120
-		IgnoreWorldTint: True
-	damaged-idle-lights: nttech_a
-		Start: 10
-		Length: 10
-		Tick: 120
-	damaged-idle-lights-bright: nttech_a
-		Start: 10
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: nttech_a.shp
+			SNOW: natech_a.shp
 		Length: 10
 		Tick: 120
 		IgnoreWorldTint: True
-	make: nttechmk
+	damaged-idle-lights:
+		TilesetFilenames:
+			TEMPERATE: nttech_a.shp
+			SNOW: natech_a.shp
+		Start: 10
+		Length: 10
+		Tick: 120
+	damaged-idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: nttech_a.shp
+			SNOW: natech_a.shp
+		Start: 10
+		Length: 10
+		Tick: 120
+		IgnoreWorldTint: True
+	make:
+		TilesetFilenames:
+			TEMPERATE: nttechmk.shp
+			SNOW: natechmk.shp
 		Length: 18
 		ShadowStart: 18
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 25
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: ntchicon
+		DepthSprite:
+	icon:
+		Filename: ntchicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 natmpl:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: nttmpl.shp
+			SNOW: natmpl.shp
 		Offset: -12,-42, 42
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 		DepthSpriteOffset: -12, 0
 	idle:
@@ -597,33 +871,46 @@ natmpl:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	idle-lights: nttmpl_a
+	idle-lights:
+		TilesetFilenames:
+			TEMPERATE: nttmpl_a.shp
+			SNOW: natmpl_a.shp
 		Length: 16
 		Tick: 120
-	idle-lights-bright: nttmpl_a
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: nttmpl_a.shp
+			SNOW: natmpl_a.shp
 		Length: 16
 		Tick: 120
 		IgnoreWorldTint: True
-	make: nttmplmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: nttmplmk.shp
+			SNOW: natmplmk.shp
 		Length: 17
 		ShadowStart: 17
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 43
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: tmplicon
+		DepthSprite:
+	icon:
+		Filename: tmplicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 garadr:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: gtradr.shp
+			SNOW: garadr.shp
 		Offset: 0, -24, 28
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
@@ -634,35 +921,48 @@ garadr:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	idle-dish: gtradr_a
+	idle-dish:
+		TilesetFilenames:
+			TEMPERATE: gtradr_a.shp
+			SNOW: garadr_a.shp
 		Length: 15
 		Reverses: True
 		Tick: 200
-	damaged-idle-dish: gtradr_a
+	damaged-idle-dish:
+		TilesetFilenames:
+			TEMPERATE: gtradr_a.shp
+			SNOW: garadr_a.shp
 		Start: 15
 		Length: 15
 		Reverses: True
 		Tick: 240
-	make: gtradrmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: gtradrmk.shp
+			SNOW: garadrmk.shp
 		Length: 20
 		ShadowStart: 20
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 25
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: radricon
+		DepthSprite:
+	icon:
+		Filename: radricon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 gatech:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: gttech.shp
+			SNOW: gatech.shp
 		Offset: -12, -30, 30
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 		DepthSpriteOffset: -12, 0
 	idle:
@@ -674,42 +974,61 @@ gatech:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	idle-lights: gttech_a
+	idle-lights:
+		TilesetFilenames:
+			TEMPERATE: gttech_a.shp
+			SNOW: gatech_a.shp
 		Length: 8
 		Tick: 200
-	idle-lights-bright: gttech_a
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gttech_a.shp
+			SNOW: gatech_a.shp
 		Length: 8
 		Tick: 200
 		IgnoreWorldTint: True
-	damaged-idle-lights: gttech_a
+	damaged-idle-lights:
+		TilesetFilenames:
+			TEMPERATE: gttech_a.shp
+			SNOW: gatech_a.shp
 		Start: 8
 		Length: 8
 		Tick: 240
-	damaged-idle-lights-bright: gttech_a
+	damaged-idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gttech_a.shp
+			SNOW: gatech_a.shp
 		Start: 8
 		Length: 8
 		Tick: 240
 		IgnoreWorldTint: True
-	make: gttechmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: gttechmk.shp
+			SNOW: gatechmk.shp
 		Length: 20
 		ShadowStart: 20
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 31
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: techicon
+		DepthSprite:
+	icon:
+		Filename: techicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 gasand:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: gtsand.shp
+			SNOW: gasand.shp
 		Offset: 0, -12, 12
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		Length: 16
@@ -718,15 +1037,18 @@ gasand:
 		Start: 16
 		Length: 16
 		ShadowStart: 48
-	icon: sbagicon
+	icon:
+		Filename: sbagicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 gawall:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: gtwall.shp
+			SNOW: gawall.shp
 		Offset: 0, -12, 12
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		Length: 16
@@ -739,16 +1061,19 @@ gawall:
 		Start: 32
 		Length: 16
 		ShadowStart: 80
-	icon: wallicon
+	icon:
+		Filename: wallicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 gagate_a:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: gtgate_a.shp
+			SNOW: gagate_a.shp
 		Offset: -24, -24, 25
 		DepthSpriteOffset: -24, 0
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		Length: 10
@@ -759,7 +1084,7 @@ gagate_a:
 		Offset: -24, -24, 1
 		ZRamp: 1
 		ZOffset: -1024
-		-DepthSprite:
+		DepthSprite:
 	damaged-idle:
 		Start: 10
 		Length: 10
@@ -770,29 +1095,33 @@ gagate_a:
 		Offset: -24, -24, 1
 		ZRamp: 1
 		ZOffset: -1024
-		-DepthSprite:
+		DepthSprite:
 	dead:
 		Start: 20
 		Tick: 400
 		ShadowStart: 41
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 25
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: gateicon
+		DepthSprite:
+	icon:
+		Filename: gateicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 gagate_b:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: gtgate_b.shp
+			SNOW: gagate_b.shp
 		Offset: 24, -24, 25
 		DepthSpriteOffset: 24, 0
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		Length: 10
@@ -803,7 +1132,7 @@ gagate_b:
 		Offset: 24, -24, 1
 		ZOffset: -1024
 		ZRamp: 1
-		-DepthSprite:
+		DepthSprite:
 	damaged-idle:
 		Start: 10
 		Length: 10
@@ -814,29 +1143,33 @@ gagate_b:
 		Offset: 24, -24, 1
 		ZRamp: 1
 		ZOffset: -1024
-		-DepthSprite:
+		DepthSprite:
 	dead:
 		Start: 20
 		Tick: 400
 		ShadowStart: 41
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 25
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: gat2icon
+		DepthSprite:
+	icon:
+		Filename: gat2icon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 nagate_a:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ntgate_a.shp
+			SNOW: nagate_a.shp
 		Offset: -24, -24, 25
 		DepthSpriteOffset: -24, 0
-		UseTilesetCode: true
 		Tick: 80
 		DepthSprite: isodepth.shp
 	idle:
@@ -852,7 +1185,7 @@ nagate_a:
 		Offset: -24, -24, 1
 		ZRamp: 1
 		ZOffset: -1024
-		-DepthSprite:
+		DepthSprite:
 	damaged-idle:
 		Start: 7
 		Length: 7
@@ -863,29 +1196,33 @@ nagate_a:
 		Offset: -24, -24, 1
 		ZRamp: 1
 		ZOffset: -1024
-		-DepthSprite:
+		DepthSprite:
 	dead:
 		Start: 14
 		Tick: 400
 		ShadowStart: 29
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 25
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: ngaticon
+		DepthSprite:
+	icon:
+		Filename: ngaticon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 nagate_b:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ntgate_b.shp
+			SNOW: nagate_b.shp
 		Offset: 24, -24, 25
 		DepthSpriteOffset: 24, 0
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 		Tick: 80
 	idle:
@@ -897,7 +1234,7 @@ nagate_b:
 		Offset: 24, -24, 1
 		ZRamp: 1
 		ZOffset: -1024
-		-DepthSprite:
+		DepthSprite:
 	damaged-idle:
 		Start: 7
 		Length: 7
@@ -908,28 +1245,32 @@ nagate_b:
 		Offset: 24, -24, 1
 		ZRamp: 1
 		ZOffset: -1024
-		-DepthSprite:
+		DepthSprite:
 	dead:
 		Start: 14
 		Tick: 400
 		ShadowStart: 29
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 25
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: nga2icon
+		DepthSprite:
+	icon:
+		Filename: nga2icon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 napost:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ntpost.shp
+			SNOW: napost.shp
 		Offset: 0, -12, 13
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		Start: 0
@@ -937,35 +1278,53 @@ napost:
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
-	lights-bright: napost_b
+	lights-bright:
+		TilesetFilenames:
+			TEMPERATE: ntpost_b.shp
+			SNOW: napost_b.shp
 		Start: 0
 		Length: 7
 		ShadowStart: 14
 		Tick: 80
 		IgnoreWorldTint: True
-	damaged-lights-bright: napost_b
+	damaged-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: ntpost_b.shp
+			SNOW: napost_b.shp
 		Start: 7
 		Length: 7
 		ShadowStart: 21
 		Tick: 80
 		IgnoreWorldTint: True
-	chainoflights: napost_a
+	chainoflights:
+		TilesetFilenames:
+			TEMPERATE: ntpost_a.shp
+			SNOW: napost_a.shp
 		Start: 0
 		Length: 12
 		ShadowStart: 24
 		Tick: 80
-	chainoflights-bright: napost_a
+	chainoflights-bright:
+		TilesetFilenames:
+			TEMPERATE: ntpost_a.shp
+			SNOW: napost_a.shp
 		Start: 0
 		Length: 12
 		ShadowStart: 24
 		Tick: 80
 		IgnoreWorldTint: True
-	damaged-chainoflights: napost_a
+	damaged-chainoflights:
+		TilesetFilenames:
+			TEMPERATE: ntpost_a.shp
+			SNOW: napost_a.shp
 		Start: 12
 		Length: 12
 		ShadowStart: 36
 		Tick: 80
-	damaged-chainoflights-bright: napost_a
+	damaged-chainoflights-bright:
+		TilesetFilenames:
+			TEMPERATE: ntpost_a.shp
+			SNOW: napost_a.shp
 		Start: 12
 		Length: 12
 		ShadowStart: 36
@@ -975,27 +1334,34 @@ napost:
 		Start: 2
 		Tick: 400
 		ShadowStart: 5
-	make: napostmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: ntpostmk.shp
+			SNOW: napostmk.shp
 		Start: 0
 		Length: 12
 		ShadowStart: 12
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 25
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: lasricon
+		DepthSprite:
+	icon:
+		Filename: lasricon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 nafnce:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ntfnce.shp
+			SNOW: nafnce.shp
 		Offset: 0, -12, 19
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		Length: 1
@@ -1004,13 +1370,13 @@ nafnce:
 		Length: 1
 		Offset: 0, -12, 1
 		ZRamp: 1
-		-DepthSprite:
+		DepthSprite:
 	disabled-y:
 		Start: 12
 		Length: 1
 		Offset: 0, -12, 1
 		ZRamp: 1
-		-DepthSprite:
+		DepthSprite:
 	enabled-x:
 		Frames: 3,3,1,1,3,3,1,1,2,2,0,0,2,2,0,0
 		Length: 16
@@ -1029,19 +1395,22 @@ nafnce:
 		Length: 16
 		DepthSpriteOffset: 12, 0
 		IgnoreWorldTint: True
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 13
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
+		DepthSprite:
 
 nawall:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ntwall.shp
+			SNOW: nawall.shp
 		Offset: 0, -12, 12
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		Length: 16
@@ -1054,15 +1423,18 @@ nawall:
 		Start: 32
 		Length: 16
 		ShadowStart: 80
-	icon: nwalicon
+	icon:
+		Filename: nwalicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 gaicbm:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: gticbm.shp
+			SNOW: gaicbm.shp
 		Offset: 0, -12, 12
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 		DepthSpriteOffset: -12, 6
 	idle:
@@ -1070,22 +1442,28 @@ gaicbm:
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 13
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	make: gaicbmmk
+		DepthSprite:
+	make:
+		TilesetFilenames:
+			TEMPERATE: gticbmmk.shp
+			SNOW: gaicbmmk.shp
 		Length: 30
 		ShadowStart: 30
 
 naobel:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ntobel.shp
+			SNOW: naobel.shp
 		Offset: 0, -24, 24
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
@@ -1096,33 +1474,46 @@ naobel:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	active: ntobel_b
+	active:
+		TilesetFilenames:
+			TEMPERATE: ntobel_b.shp
+			SNOW: naobel_b.shp
 		Length: 12
 		Tick: 200
 		ZOffset: 2
-	idle-lights: ntobel_a
+	idle-lights:
+		TilesetFilenames:
+			TEMPERATE: ntobel_a.shp
+			SNOW: naobel_a.shp
 		Length: 12
 		Tick: 80
-	make: ntobelmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: ntobelmk.shp
+			SNOW: naobelmk.shp
 		Length: 19
 		ShadowStart: 19
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 25
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: obliicon
+		DepthSprite:
+	icon:
+		Filename: obliicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 nalasr:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ntlasr.shp
+			SNOW: nalasr.shp
 		Offset: 0, -12, 12
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
@@ -1133,26 +1524,33 @@ nalasr:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	make: ntlasrmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: ntlasrmk.shp
+			SNOW: nalasrmk.shp
 		Length: 21
 		ShadowStart: 21
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 13
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: plticon
+		DepthSprite:
+	icon:
+		Filename: plticon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 nasam:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ntsam.shp
+			SNOW: nasam.shp
 		Offset: 0, -12, 1
-		UseTilesetCode: true
 	idle:
 		ShadowStart: 3
 		ZRamp: 1
@@ -1165,30 +1563,40 @@ nasam:
 		ShadowStart: 5
 		Tick: 400
 		DepthSprite: isodepth.shp
-	turret: gtctwr_d
+	turret:
+		TilesetFilenames:
+			TEMPERATE: gtctwr_d.shp
+			SNOW: gactwr_d.shp
 		Facings: 32
 		DepthSprite: isodepth.shp
 		Offset: 0, 0, 12
-	make: ntsammk
+	make:
+		TilesetFilenames:
+			TEMPERATE: ntsammk.shp
+			SNOW: nasammk.shp
 		Length: 8
 		ShadowStart: 8
 		DepthSprite: isodepth.shp
 		Offset: 0, -12, 12
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 2
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-	icon: samicon
+	icon:
+		Filename: samicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
 
 napuls.gdi:
-	Defaults: ntpuls
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ntpuls.shp
+			SNOW: napuls.shp
 		Offset: 0, -24, 24
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
@@ -1199,27 +1607,37 @@ napuls.gdi:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	turret: ntpuls_a
+	turret:
+		TilesetFilenames:
+			TEMPERATE: ntpuls_a.shp
+			SNOW: napuls_a.shp
 		Facings: 32
-	make: ntpulsmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: ntpulsmk.shp
+			SNOW: napulsmk.shp
 		Length: 20
 		ShadowStart: 20
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 25
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
-		-DepthSprite:
-	icon: sidebar-gdi|empicon
+		DepthSprite:
+	icon:
+		Filename: sidebar-gdi|empicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 napuls.nod:
-	Defaults: ntpuls
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ntpuls.shp
+			SNOW: napuls.shp
 		Offset: 0, -24, 24
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
@@ -1230,29 +1648,39 @@ napuls.nod:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	turret: ntpuls_a
+	turret:
+		TilesetFilenames:
+			TEMPERATE: ntpuls_a.shp
+			SNOW: napuls_a.shp
 		Facings: 32
-	make: ntpulsmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: ntpulsmk.shp
+			SNOW: napulsmk.shp
 		Length: 20
 		ShadowStart: 20
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 25
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: sidebar-nod|empicon
+		DepthSprite:
+	icon:
+		Filename: sidebar-nod|empicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 nastlh:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ntstlh.shp
+			SNOW: nastlh.shp
 		Offset: -12, -30, 30
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 		DepthSpriteOffset: -12, 0
 	idle:
@@ -1264,33 +1692,46 @@ nastlh:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	pulse: ntstlh_a
+	pulse:
+		TilesetFilenames:
+			TEMPERATE: ntstlh_a.shp
+			SNOW: nastlh_a.shp
 		Length: 4
 		Tick: 480
-	damaged-pulse: ntstlh_a
+	damaged-pulse:
+		TilesetFilenames:
+			TEMPERATE: ntstlh_a.shp
+			SNOW: nastlh_a.shp
 		Start: 4
 		Length: 4
 		Tick: 480
-	make: ntstlhmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: ntstlhmk.shp
+			SNOW: nastlhmk.shp
 		Length: 18
 		ShadowStart: 20
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 31
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: clckicon
+		DepthSprite:
+	icon:
+		Filename: clckicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 gactwr:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: gtctwr.shp
+			SNOW: gactwr.shp
 		Offset: 0, -12, 12
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
@@ -1301,91 +1742,132 @@ gactwr:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	invisible: null
-		UseTilesetCode: false
-	idle-lights: gtctwr_a
+	invisible:
+		Filename: null.shp
+		TilesetFilenames:
+	idle-lights:
+		TilesetFilenames:
+			TEMPERATE: gtctwr_a.shp
+			SNOW: gactwr_a.shp
 		Length: 6
 		Tick: 200
-	idle-lights-bright: gtctwr_a
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gtctwr_a.shp
+			SNOW: gactwr_a.shp
 		Length: 6
 		Tick: 200
 		IgnoreWorldTint: True
-	make: gtctwrmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: gtctwrmk.shp
+			SNOW: gactwrmk.shp
 		Length: 11
 		ShadowStart: 11
-	make-bright: gtctwrmk
+	make-bright:
+		TilesetFilenames:
+			TEMPERATE: gtctwrmk.shp
+			SNOW: gactwrmk.shp
 		Length: 11
 		ZOffset: 1
 		IgnoreWorldTint: True
-	turret-vulcan: gtctwr_b
+	turret-vulcan:
+		TilesetFilenames:
+			TEMPERATE: gtctwr_b.shp
+			SNOW: gactwr_b.shp
 		Facings: 32
-	turret-rocket: gtctwr_c
+	turret-rocket:
+		Filename: gtctwr_c.shp
+		TilesetFilenames:
 		Facings: 32
-		UseTilesetCode: false
-	turret-sam: gtctwr_d
+	turret-sam:
+		TilesetFilenames:
+			TEMPERATE: gtctwr_d.shp
+			SNOW: gactwr_d.shp
 		Facings: 32
 	muzzle:
+		TilesetFilenames:
 		Combine:
-			mgun-n:
+			0:
+				Filename: mgun-n.shp
 				Length: 6
-			mgun-nw:
+			1:
+				Filename: mgun-nw.shp
 				Length: 6
-			mgun-w:
+			2:
+				Filename: mgun-w.shp
 				Length: 6
-			mgun-sw:
+			3:
+				Filename: mgun-sw.shp
 				Length: 6
-			mgun-s:
+			4:
+				Filename: mgun-s.shp
 				Length: 6
-			mgun-se:
+			5:
+				Filename: mgun-se.shp
 				Length: 6
-			mgun-e:
+			6:
+				Filename: mgun-e.shp
 				Length: 6
-			mgun-ne:
+			7:
+				Filename: mgun-ne.shp
 				Length: 6
 		Facings: 8
 		Length: 6
 		Offset: 0, 0, 12
-		UseTilesetCode: false
 		IgnoreWorldTint: True
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 13
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: towricon
+		DepthSprite:
+	icon:
+		Filename: towricon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 gavulc:
-	place: gtctwr_b
+	place:
+		TilesetFilenames:
+			TEMPERATE: gtctwr_b.shp
+			SNOW: gactwr_b.shp
 		Offset: 0, -12, 12
-		UseTilesetCode: true
 		Start: 28
-	icon: twr1icon
+	icon:
+		Filename: twr1icon.shp
 
 garock:
-	place: gtctwr_c
+	place:
+		TilesetFilenames:
+			TEMPERATE: gtctwr_c.shp
+			SNOW: gactwr_c.shp
 		Offset: 0, -12, 12
-		UseTilesetCode: true
 		Start: 28
-	icon: twr2icon
+	icon:
+		Filename: twr2icon.shp
 
 gacsam:
-	place: gtctwr_d
+	place:
+		TilesetFilenames:
+			TEMPERATE: gtctwr_d.shp
+			SNOW: gactwr_d.shp
 		Offset: 0, -12, 12
-		UseTilesetCode: true
 		Start: 28
-	icon: twr3icon
+	icon:
+		Filename: twr3icon.shp
 
 gahpad:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: gthpad.shp
+			SNOW: gahpad.shp
 		Offset: 0, -24, 1
 		DepthSpriteOffset: 34, 0
-		UseTilesetCode: true
 	idle:
 		ShadowStart: 3
 		ZOffset: -1c511
@@ -1404,72 +1886,100 @@ gahpad:
 		Tick: 400
 		Offset: 0, -24, 8
 		DepthSprite: isodepth.shp
-	idle-platform: gthpadbb
+	idle-platform:
+		TilesetFilenames:
+			TEMPERATE: gthpadbb.shp
+			SNOW: gahpadbb.shp
 		ShadowStart: 3
 		ZOffset: -1c511
 		ZRamp: 1
-	damaged-idle-platform: gthpadbb
+	damaged-idle-platform:
+		TilesetFilenames:
+			TEMPERATE: gthpadbb.shp
+			SNOW: gahpadbb.shp
 		Start: 1
 		ShadowStart: 4
 		ZOffset: -1c511
 		ZRamp: 1
-	dead-platform: gthpadbb
+	dead-platform:
+		TilesetFilenames:
+			TEMPERATE: gthpadbb.shp
+			SNOW: gahpadbb.shp
 		Start: 2
 		ShadowStart: 5
 		ZOffset: -1c511
 		Tick: 400
 		ZRamp: 1
-	idle-lights: gthpad_a
+	idle-lights:
+		TilesetFilenames:
+			TEMPERATE: gthpad_a.shp
+			SNOW: gahpad_a.shp
 		Length: 8
 		Tick: 100
 		Offset: 0, -36
 		ZOffset: -1c511
 		ZRamp: 1
-	idle-lights-bright: gthpad_a
-		Length: 8
-		Tick: 100
-		Offset: 0, -36
-		ZOffset: -1c511
-		ZRamp: 1
-		IgnoreWorldTint: True
-	damaged-idle-lights: gthpad_a
-		Start: 8
-		Length: 8
-		Tick: 100
-		Offset: 0, -36
-		ZOffset: -1c511
-		ZRamp: 1
-	damaged-idle-lights-bright: gthpad_a
-		Start: 8
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gthpad_a.shp
+			SNOW: gahpad_a.shp
 		Length: 8
 		Tick: 100
 		Offset: 0, -36
 		ZOffset: -1c511
 		ZRamp: 1
 		IgnoreWorldTint: True
-	make: gthpadmk
+	damaged-idle-lights:
+		TilesetFilenames:
+			TEMPERATE: gthpad_a.shp
+			SNOW: gahpad_a.shp
+		Start: 8
+		Length: 8
+		Tick: 100
+		Offset: 0, -36
+		ZOffset: -1c511
+		ZRamp: 1
+	damaged-idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gthpad_a.shp
+			SNOW: gahpad_a.shp
+		Start: 8
+		Length: 8
+		Tick: 100
+		Offset: 0, -36
+		ZOffset: -1c511
+		ZRamp: 1
+		IgnoreWorldTint: True
+	make:
+		TilesetFilenames:
+			TEMPERATE: gthpadmk.shp
+			SNOW: gahpadmk.shp
 		Length: 18
 		ShadowStart: 18
 		ZOffset: -1c511
 		Offset: 0, -24, 24
 		DepthSpriteOffset: 0, 0
 		DepthSprite: isodepth.shp
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 2
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-	icon: heliicon
+	icon:
+		Filename: heliicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
 
 nahpad:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: nthpad.shp
+			SNOW: nahpad.shp
 		Offset: 0, -24, 1
 		DepthSpriteOffset: -24, 0
-		UseTilesetCode: true
 	idle:
 		ShadowStart: 3
 		ZOffset: -1c511
@@ -1488,67 +1998,95 @@ nahpad:
 		Tick: 400
 		Offset: 0, -24, 3
 		DepthSprite: isodepth.shp
-	idle-platform: nthpadbb
+	idle-platform:
+		TilesetFilenames:
+			TEMPERATE: nthpadbb.shp
+			SNOW: nahpadbb.shp
 		ShadowStart: 3
 		ZOffset: -1c511
 		ZRamp: 1
-	damaged-idle-platform: nthpadbb
+	damaged-idle-platform:
+		TilesetFilenames:
+			TEMPERATE: nthpadbb.shp
+			SNOW: nahpadbb.shp
 		Start: 1
 		ShadowStart: 4
 		ZOffset: -1c511
 		ZRamp: 1
-	dead-platform: nthpadbb
+	dead-platform:
+		TilesetFilenames:
+			TEMPERATE: nthpadbb.shp
+			SNOW: nahpadbb.shp
 		Start: 2
 		ShadowStart: 5
 		ZOffset: -1c511
 		Tick: 400
 		ZRamp: 1
-	idle-lights: nthpad_a
+	idle-lights:
+		TilesetFilenames:
+			TEMPERATE: nthpad_a.shp
+			SNOW: nahpad_a.shp
 		Length: 46
 		ZOffset: -1c511
 		Tick: 100
 		ZRamp: 1
-	idle-lights-bright: nthpad_a
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: nthpad_a.shp
+			SNOW: nahpad_a.shp
 		Length: 46
 		ZOffset: -1c511
 		Tick: 100
 		ZRamp: 1
 		IgnoreWorldTint: True
-	damaged-idle-lights: nthpad_a
+	damaged-idle-lights:
+		TilesetFilenames:
+			TEMPERATE: nthpad_a.shp
+			SNOW: nahpad_a.shp
 		Start: 46
 		Length: 46
 		Tick: 100
 		ZOffset: -1c511
 		ZRamp: 1
-	damaged-idle-lights-bright: nthpad_a
+	damaged-idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: nthpad_a.shp
+			SNOW: nahpad_a.shp
 		Start: 46
 		Length: 46
 		Tick: 100
 		ZOffset: -1c511
 		ZRamp: 1
 		IgnoreWorldTint: True
-	make: nthpadmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: nthpadmk.shp
+			SNOW: nahpadmk.shp
 		Length: 20
 		ShadowStart: 20
 		Offset: 0, -24, 24
 		DepthSpriteOffset: 0, 0
 		DepthSprite: isodepth.shp
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 2
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-	icon: nhpdicon
+	icon:
+		Filename: nhpdicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
 
 proc.gdi:
-	Defaults: ntrefn
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ntrefn.shp
+			SNOW: narefn.shp
 		Offset: -12, -42, 20
 		DepthSpriteOffset: 22, 0
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
@@ -1559,60 +2097,88 @@ proc.gdi:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	make: ntrefnmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: ntrefnmk.shp
+			SNOW: narefnmk.shp
 		Length: 20
 		ShadowStart: 20
 		Offset: -12, -42, 43
 		DepthSpriteOffset: -12, 0
-	flame: ntrefn_b
+	flame:
+		TilesetFilenames:
+			TEMPERATE: ntrefn_b.shp
+			SNOW: narefn_b.shp
 		Length: *
 		IgnoreWorldTint: True
-	unload-overlay: narefn_a
+	unload-overlay:
+		TilesetFilenames:
+			TEMPERATE: ntrefn_a.shp
+			SNOW: narefn_a.shp
 		Length: *
 		ZOffset: 1024
-	idle-lights: ntrefn_c
+	idle-lights:
+		TilesetFilenames:
+			TEMPERATE: ntrefn_c.shp
+			SNOW: narefn_c.shp
 		Length: 16
 		Tick: 120
-	idle-lights-bright: ntrefn_c
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: ntrefn_c.shp
+			SNOW: narefn_c.shp
 		Length: 16
 		Tick: 120
 		IgnoreWorldTint: True
-	bib: ntrefnbb
+	bib:
+		TilesetFilenames:
+			TEMPERATE: ntrefnbb.shp
+			SNOW: narefnbb.shp
 		Length: 1
 		ZOffset: -1024
 		Offset: -12, -42, 1
 		ZRamp: 1
-		-DepthSprite:
-	damaged-bib: ntrefnbb
+		DepthSprite:
+	damaged-bib:
+		TilesetFilenames:
+			TEMPERATE: ntrefnbb.shp
+			SNOW: narefnbb.shp
 		Start: 1
 		ZOffset: -1024
 		Offset: -12, -42, 1
 		ZRamp: 1
-		-DepthSprite:
-	dead-bib: ntrefnbb
+		DepthSprite:
+	dead-bib:
+		TilesetFilenames:
+			TEMPERATE: ntrefnbb.shp
+			SNOW: narefnbb.shp
 		Start: 2
 		ZOffset: -1024
 		Offset: -12, -42, 1
 		ZRamp: 1
-		-DepthSprite:
-	emp-overlay: emp_fx01
+		DepthSprite:
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 21
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: sidebar-gdi|reficon
+		DepthSprite:
+	icon:
+		Filename: sidebar-gdi|reficon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 proc.nod:
-	Defaults: ntrefn
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ntrefn.shp
+			SNOW: narefn.shp
 		Offset: -12, -42, 20
 		DepthSpriteOffset: 22, 0
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
@@ -1623,59 +2189,87 @@ proc.nod:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	make: ntrefnmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: ntrefnmk.shp
+			SNOW: narefnmk.shp
 		Length: 20
 		ShadowStart: 20
 		Offset: -12, -42, 43
 		DepthSpriteOffset: -12, 0
-	flame: ntrefn_b
+	flame:
+		TilesetFilenames:
+			TEMPERATE: ntrefn_b.shp
+			SNOW: narefn_b.shp
 		Length: *
 		IgnoreWorldTint: True
-	unload-overlay: narefn_a
+	unload-overlay:
+		TilesetFilenames:
+			TEMPERATE: ntrefn_a.shp
+			SNOW: narefn_a.shp
 		Length: *
 		ZOffset: 1024
-	idle-lights: ntrefn_c
+	idle-lights:
+		TilesetFilenames:
+			TEMPERATE: ntrefn_c.shp
+			SNOW: narefn_c.shp
 		Length: 16
 		Tick: 120
-	idle-lights-bright: ntrefn_c
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: ntrefn_c.shp
+			SNOW: narefn_c.shp
 		Length: 16
 		Tick: 120
 		IgnoreWorldTint: True
-	bib: ntrefnbb
+	bib:
+		TilesetFilenames:
+			TEMPERATE: ntrefnbb.shp
+			SNOW: narefnbb.shp
 		Length: 1
 		ZOffset: -1024
 		Offset: -12, -42, 1
 		ZRamp: 1
-		-DepthSprite:
-	damaged-bib: ntrefnbb
+		DepthSprite:
+	damaged-bib:
+		TilesetFilenames:
+			TEMPERATE: ntrefnbb.shp
+			SNOW: narefnbb.shp
 		Start: 1
 		ZOffset: -1024
 		Offset: -12, -42, 1
 		ZRamp: 1
-		-DepthSprite:
-	dead-bib: ntrefnbb
+		DepthSprite:
+	dead-bib:
+		TilesetFilenames:
+			TEMPERATE: ntrefnbb.shp
+			SNOW: narefnbb.shp
 		Start: 2
 		ZOffset: -1024
 		Offset: -12, -42, 1
 		ZRamp: 1
-		-DepthSprite:
-	emp-overlay: emp_fx01
+		DepthSprite:
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 21
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: sidebar-nod|reficon
+		DepthSprite:
+	icon:
+		Filename: sidebar-nod|reficon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 nawast:
-	Defaults: ntwast
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ntwast.shp
+			SNOW: nawast.shp
 		Offset: 0, -36, 24
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 		DepthSpriteOffset: 16, 0
 	idle:
@@ -1687,70 +2281,110 @@ nawast:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	make: ntwastmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: ntwastmk.shp
+			SNOW: nawastmk.shp
 		Length: 19
 		ShadowStart: 19
 		Offset: 0, -36, 36
 		DepthSpriteOffset: 0, 0
-	idle-glow: ntwast_a
+	idle-glow:
+		TilesetFilenames:
+			TEMPERATE: ntwast_a.shp
+			SNOW: nawast_a.shp
 		Length: 20
 		ShadowStart: 40
 		Tick: 120
-	damaged-idle-glow: ntwast_a
+	damaged-idle-glow:
+		TilesetFilenames:
+			TEMPERATE: ntwast_a.shp
+			SNOW: nawast_a.shp
 		Start: 20
 		Length: 20
 		ShadowStart: 60
 		Tick: 120
-	idle-lights-bright: ntwast_b
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: ntwast_b.shp
+			SNOW: nawast_b.shp
 		Length: 8
 		Tick: 120
 		IgnoreWorldTint: True
-	damaged-idle-lights-bright: ntwast_b
+	damaged-idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: ntwast_b.shp
+			SNOW: nawast_b.shp
 		Start: 8
 		Length: 8
 		Tick: 120
 		IgnoreWorldTint: True
-	bib: ntwastbb
+	bib:
+		TilesetFilenames:
+			TEMPERATE: ntwastbb.shp
+			SNOW: nawastbb.shp
 		ZOffset: -1024
 		ZRamp: 1
-		-DepthSprite:
+		DepthSprite:
 		Offset: 0, -36, 1
-	damaged-bib: ntwastbb
+	damaged-bib:
+		TilesetFilenames:
+			TEMPERATE: ntwastbb.shp
+			SNOW: nawastbb.shp
 		Start: 1
 		ZOffset: -1024
 		ZRamp: 1
-		-DepthSprite:
+		DepthSprite:
 		Offset: 0, -36, 1
-	dead-bib: ntwastbb
+	dead-bib:
+		TilesetFilenames:
+			TEMPERATE: ntwastbb.shp
+			SNOW: nawastbb.shp
 		Start: 2
 		ZOffset: -1024
 		ZRamp: 1
-		-DepthSprite:
+		DepthSprite:
 		Offset: 0, -36, 1
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 25
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: wasticon
+		DepthSprite:
+	icon:
+		Filename: wasticon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 gasilo.gdi:
-	Defaults: gtsilo
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: gtsilo.shp
+			SNOW: gasilo.shp
 		Offset: 0, -24, 24
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
-	idle: gtsilo_a
-	damaged-idle: gtsilo_a
+	idle:
+		TilesetFilenames:
+			TEMPERATE: gtsilo_a.shp
+			SNOW: gasilo_a.shp
+	damaged-idle:
+		TilesetFilenames:
+			TEMPERATE: gtsilo_a.shp
+			SNOW: gasilo_a.shp
 		Start: 4
-	stages: gtsilo_a
+	stages:
+		TilesetFilenames:
+			TEMPERATE: gtsilo_a.shp
+			SNOW: gasilo_a.shp
 		Length: 4
-	damaged-stages: gtsilo_a
+	damaged-stages:
+		TilesetFilenames:
+			TEMPERATE: gtsilo_a.shp
+			SNOW: gasilo_a.shp
 		Start: 4
 		Length: 4
 	idle-underlay:
@@ -1765,42 +2399,67 @@ gasilo.gdi:
 		ShadowStart: 5
 		ZOffset: -512
 		Tick: 400
-	idle-lights-bright: gtsilo_b
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gtsilo_b.shp
+			SNOW: gasilo_b.shp
 		Length: 16
 		Tick: 120
 		IgnoreWorldTint: True
-	damaged-idle-lights-bright: gtsilo_b
+	damaged-idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gtsilo_b.shp
+			SNOW: gasilo_b.shp
 		Start: 16
 		Length: 16
 		Tick: 120
 		IgnoreWorldTint: True
-	make: gtsilomk
+	make:
+		TilesetFilenames:
+			TEMPERATE: gtsilomk.shp
+			SNOW: gasilomk.shp
 		Length: 18
 		ShadowStart: 20
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 25
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: sidebar-gdi|siloicon
+		DepthSprite:
+	icon:
+		Filename: sidebar-gdi|siloicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 gasilo.nod:
-	Defaults: gtsilo
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: gtsilo.shp
+			SNOW: gasilo.shp
 		Offset: 0, -24, 24
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
-	idle: gtsilo_a
-	damaged-idle: gtsilo_a
+	idle:
+		TilesetFilenames:
+			TEMPERATE: gtsilo_a.shp
+			SNOW: gasilo_a.shp
+	damaged-idle:
+		TilesetFilenames:
+			TEMPERATE: gtsilo_a.shp
+			SNOW: gasilo_a.shp
 		Start: 4
-	stages: gtsilo_a
+	stages:
+		TilesetFilenames:
+			TEMPERATE: gtsilo_a.shp
+			SNOW: gasilo_a.shp
 		Length: 4
-	damaged-stages: gtsilo_a
+	damaged-stages:
+		TilesetFilenames:
+			TEMPERATE: gtsilo_a.shp
+			SNOW: gasilo_a.shp
 		Start: 4
 		Length: 4
 	idle-underlay:
@@ -1815,36 +2474,49 @@ gasilo.nod:
 		ShadowStart: 5
 		ZOffset: -512
 		Tick: 400
-	idle-lights-bright: gtsilo_b
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gtsilo_b.shp
+			SNOW: gasilo_b.shp
 		Length: 16
 		Tick: 120
 		IgnoreWorldTint: True
-	damaged-idle-lights-bright: gtsilo_b
+	damaged-idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gtsilo_b.shp
+			SNOW: gasilo_b.shp
 		Start: 16
 		Length: 16
 		Tick: 120
 		IgnoreWorldTint: True
-	make: gtsilomk
+	make:
+		TilesetFilenames:
+			TEMPERATE: gtsilomk.shp
+			SNOW: gasilomk.shp
 		Length: 18
 		ShadowStart: 20
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 25
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: sidebar-nod|siloicon
+		DepthSprite:
+	icon:
+		Filename: sidebar-nod|siloicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 gadept.gdi:
-	Defaults: gtdept
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: gtdept.shp
+			SNOW: gadept.shp
 		Offset: 0, -36, 1
 		DepthSpriteOffset: 36, 0
-		UseTilesetCode: true
 	idle:
 		ShadowStart: 3
 		Offset: 0, -36, 12
@@ -1860,111 +2532,163 @@ gadept.gdi:
 		Tick: 400
 		Offset: 0, -36, 12
 		DepthSprite: isodepth.shp
-	ground: gtdeptbb
+	ground:
+		TilesetFilenames:
+			TEMPERATE: gtdeptbb.shp
+			SNOW: gadeptbb.shp
 		ShadowStart: 3
 		ZOffset: -1c611
 		ZRamp: 1
-	damaged-ground: gtdeptbb
+	damaged-ground:
+		TilesetFilenames:
+			TEMPERATE: gtdeptbb.shp
+			SNOW: gadeptbb.shp
 		Start: 1
 		ShadowStart: 4
 		ZOffset: -1c611
 		ZRamp: 1
-	dead-ground: gtdeptbb
+	dead-ground:
+		TilesetFilenames:
+			TEMPERATE: gtdeptbb.shp
+			SNOW: gadeptbb.shp
 		Start: 2
 		ShadowStart: 5
 		ZOffset: -1c611
 		Tick: 400
 		ZRamp: 1
-	idle-light: gtdept_b
+	idle-light:
+		TilesetFilenames:
+			TEMPERATE: gtdept_b.shp
+			SNOW: gadept_b.shp
 		Offset: 0, -36, 13
 		Length: 7
 		Tick: 120
 		ZRamp: 1
-	idle-light-bright: gtdept_b
+	idle-light-bright:
+		TilesetFilenames:
+			TEMPERATE: gtdept_b.shp
+			SNOW: gadept_b.shp
 		Offset: 0, -36, 13
 		Length: 7
 		Tick: 120
 		ZRamp: 1
 		IgnoreWorldTint: True
-	circuits: gtdept_a
+	circuits:
+		TilesetFilenames:
+			TEMPERATE: gtdept_a.shp
+			SNOW: gadept_a.shp
 		Length: 5
 		ZOffset: -1c511
 		Tick: 120
 		ZRamp: 1
-	circuits-bright: gtdept_a
+	circuits-bright:
+		TilesetFilenames:
+			TEMPERATE: gtdept_a.shp
+			SNOW: gadept_a.shp
 		Length: 5
 		ZOffset: -1c511
 		Tick: 120
 		ZRamp: 1
 		IgnoreWorldTint: True
-	damaged-circuits: gtdept_a
+	damaged-circuits:
+		TilesetFilenames:
+			TEMPERATE: gtdept_a.shp
+			SNOW: gadept_a.shp
 		Start: 5
 		Length: 5
 		ZOffset: -1c511
 		Tick: 120
 		ZRamp: 1
-	damaged-circuits-bright: gtdept_a
+	damaged-circuits-bright:
+		TilesetFilenames:
+			TEMPERATE: gtdept_a.shp
+			SNOW: gadept_a.shp
 		Start: 5
 		Length: 5
 		ZOffset: -1c511
 		Tick: 120
 		ZRamp: 1
 		IgnoreWorldTint: True
-	crane-start: gtdept_c
+	crane-start:
+		TilesetFilenames:
+			TEMPERATE: gtdept_c.shp
+			SNOW: gadept_c.shp
 		Length: 6
 		Offset: 0, -36, 12
 		Tick: 60
 		DepthSprite: isodepth.shp
-	crane-loop: gtdept_c
+	crane-loop:
+		TilesetFilenames:
+			TEMPERATE: gtdept_c.shp
+			SNOW: gadept_c.shp
 		Start: 6
 		Length: 5
 		Offset: 0, -36, 12
 		Tick: 60
 		DepthSprite: isodepth.shp
-	crane-loop-bright: gtdept_c
+	crane-loop-bright:
+		TilesetFilenames:
+			TEMPERATE: gtdept_c.shp
+			SNOW: gadept_c.shp
 		Start: 6
 		Length: 5
 		Offset: 0, -36, 12
 		Tick: 60
 		DepthSprite: isodepth.shp
 		IgnoreWorldTint: True
-	crane-end: gtdept_c
+	crane-end:
+		TilesetFilenames:
+			TEMPERATE: gtdept_c.shp
+			SNOW: gadept_c.shp
 		Start: 10
 		Length: 6
 		Offset: 0, -36, 12
 		Tick: 60
 		DepthSprite: isodepth.shp
-	platform: gtdept_d
+	platform:
+		TilesetFilenames:
+			TEMPERATE: gtdept_d.shp
+			SNOW: gadept_d.shp
 		Length: 7
 		ZOffset: -1c511
 		ZRamp: 1
-	damaged-platform: gtdept_d
+	damaged-platform:
+		TilesetFilenames:
+			TEMPERATE: gtdept_d.shp
+			SNOW: gadept_d.shp
 		Start: 7
 		Length: 7
 		ZOffset: -1c511
 		ZRamp: 1
-	make: gtdeptmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: gtdeptmk.shp
+			SNOW: gadeptmk.shp
 		Length: 10
 		Tick: 60
 		ShadowStart: 10
 		Offset: 0, -36, 36
 		ZRamp: 1
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 8
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-	icon: sidebar-gdi|fixicon
+	icon:
+		Filename: sidebar-gdi|fixicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
 
 gadept.nod:
-	Defaults: gtdept
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: gtdept.shp
+			SNOW: gadept.shp
 		Offset: 0, -36, 1
 		DepthSpriteOffset: 36, 0
-		UseTilesetCode: true
 	idle:
 		ShadowStart: 3
 		Offset: 0, -36, 12
@@ -1980,110 +2704,162 @@ gadept.nod:
 		Tick: 400
 		Offset: 0, -36, 12
 		DepthSprite: isodepth.shp
-	ground: gtdeptbb
+	ground:
+		TilesetFilenames:
+			TEMPERATE: gtdeptbb.shp
+			SNOW: gadeptbb.shp
 		ShadowStart: 3
 		ZOffset: -1c611
 		ZRamp: 1
-	damaged-ground: gtdeptbb
+	damaged-ground:
+		TilesetFilenames:
+			TEMPERATE: gtdeptbb.shp
+			SNOW: gadeptbb.shp
 		Start: 1
 		ShadowStart: 4
 		ZOffset: -1c611
 		ZRamp: 1
-	dead-ground: gtdeptbb
+	dead-ground:
+		TilesetFilenames:
+			TEMPERATE: gtdeptbb.shp
+			SNOW: gadeptbb.shp
 		Start: 2
 		ShadowStart: 5
 		ZOffset: -1c611
 		Tick: 400
 		ZRamp: 1
-	idle-light: gtdept_b
+	idle-light:
+		TilesetFilenames:
+			TEMPERATE: gtdept_b.shp
+			SNOW: gadept_b.shp
 		Offset: 0, -36, 13
 		Length: 7
 		Tick: 120
 		ZRamp: 1
-	idle-light-bright: gtdept_b
+	idle-light-bright:
+		TilesetFilenames:
+			TEMPERATE: gtdept_b.shp
+			SNOW: gadept_b.shp
 		Offset: 0, -36, 13
 		Length: 7
 		Tick: 120
 		ZRamp: 1
 		IgnoreWorldTint: True
-	circuits: gtdept_a
+	circuits:
+		TilesetFilenames:
+			TEMPERATE: gtdept_a.shp
+			SNOW: gadept_a.shp
 		Length: 5
 		ZOffset: -1c511
 		Tick: 120
 		ZRamp: 1
-	circuits-bright: gtdept_a
+	circuits-bright:
+		TilesetFilenames:
+			TEMPERATE: gtdept_a.shp
+			SNOW: gadept_a.shp
 		Length: 5
 		ZOffset: -1c511
 		Tick: 120
 		ZRamp: 1
 		IgnoreWorldTint: True
-	damaged-circuits: gtdept_a
+	damaged-circuits:
+		TilesetFilenames:
+			TEMPERATE: gtdept_a.shp
+			SNOW: gadept_a.shp
 		Start: 5
 		Length: 5
 		ZOffset: -1c511
 		Tick: 120
 		ZRamp: 1
-	damaged-circuits-bright: gtdept_a
+	damaged-circuits-bright:
+		TilesetFilenames:
+			TEMPERATE: gtdept_a.shp
+			SNOW: gadept_a.shp
 		Start: 5
 		Length: 5
 		ZOffset: -1c511
 		Tick: 120
 		ZRamp: 1
 		IgnoreWorldTint: True
-	crane-start: gtdept_c
+	crane-start:
+		TilesetFilenames:
+			TEMPERATE: gtdept_c.shp
+			SNOW: gadept_c.shp
 		Length: 6
 		Offset: 0, -36, 12
 		Tick: 60
 		DepthSprite: isodepth.shp
-	crane-loop: gtdept_c
+	crane-loop:
+		TilesetFilenames:
+			TEMPERATE: gtdept_c.shp
+			SNOW: gadept_c.shp
 		Start: 6
 		Length: 5
 		Offset: 0, -36, 12
 		Tick: 60
 		DepthSprite: isodepth.shp
-	crane-loop-bright: gtdept_c
+	crane-loop-bright:
+		TilesetFilenames:
+			TEMPERATE: gtdept_c.shp
+			SNOW: gadept_c.shp
 		Start: 6
 		Length: 5
 		Offset: 0, -36, 12
 		Tick: 60
 		DepthSprite: isodepth.shp
 		IgnoreWorldTint: True
-	crane-end: gtdept_c
+	crane-end:
+		TilesetFilenames:
+			TEMPERATE: gtdept_c.shp
+			SNOW: gadept_c.shp
 		Start: 10
 		Length: 6
 		Offset: 0, -36, 12
 		DepthSprite: isodepth.shp
 		Tick: 60
-	platform: gtdept_d
+	platform:
+		TilesetFilenames:
+			TEMPERATE: gtdept_d.shp
+			SNOW: gadept_d.shp
 		Length: 7
 		ZOffset: -1c511
 		ZRamp: 1
-	damaged-platform: gtdept_d
+	damaged-platform:
+		TilesetFilenames:
+			TEMPERATE: gtdept_d.shp
+			SNOW: gadept_d.shp
 		Start: 7
 		Length: 7
 		ZOffset: -1c511
 		ZRamp: 1
-	make: gtdeptmk
+	make:
+		TilesetFilenames:
+			TEMPERATE: gtdeptmk.shp
+			SNOW: gadeptmk.shp
 		Length: 10
 		Tick: 60
 		ShadowStart: 10
 		Offset: 0, -36, 36
 		ZRamp: 1
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 8
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-	icon: sidebar-nod|fixicon
+	icon:
+		Filename: sidebar-nod|fixicon.shp
+		TilesetFilenames:
 		Offset: 76, 66
-		UseTilesetCode: false
 
 namisl:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: ntmisl.shp
+			SNOW: namisl.shp
 		Offset: 0, -24, 24
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 	idle:
 	damaged-idle:
@@ -2091,64 +2867,95 @@ namisl:
 	dead:
 		Start: 2
 		Tick: 400
-	idle-lights: ntmisl_b
+	idle-lights:
+		TilesetFilenames:
+			TEMPERATE: ntmisl_b.shp
+			SNOW: namisl_b.shp
 		Length: 10
 		Tick: 120
-	idle-lights-bright: ntmisl_b
-		Length: 10
-		Tick: 120
-		IgnoreWorldTint: True
-	damaged-idle-lights: ntmisl_b
-		Start: 10
-		Length: 10
-		Tick: 120
-	damaged-idle-lights-bright: ntmisl_b
-		Start: 10
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: ntmisl_b.shp
+			SNOW: namisl_b.shp
 		Length: 10
 		Tick: 120
 		IgnoreWorldTint: True
-	make: ntmislmk
+	damaged-idle-lights:
+		TilesetFilenames:
+			TEMPERATE: ntmisl_b.shp
+			SNOW: namisl_b.shp
+		Start: 10
+		Length: 10
+		Tick: 120
+	damaged-idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: ntmisl_b.shp
+			SNOW: namisl_b.shp
+		Start: 10
+		Length: 10
+		Tick: 120
+		IgnoreWorldTint: True
+	make:
+		TilesetFilenames:
+			TEMPERATE: ntmislmk.shp
+			SNOW: namislmk.shp
 		Length: 18
 		ShadowStart: 18
-	active: ntmisl_a
+	active:
+		TilesetFilenames:
+			TEMPERATE: ntmisl_a.shp
+			SNOW: namisl_a.shp
 		Frames: 0, 1, 2, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11
 		Length: 25
 		Tick: 80
 		ZOffset: 2
-	active-bright: ntmisl_a
+	active-bright:
+		TilesetFilenames:
+			TEMPERATE: ntmisl_a.shp
+			SNOW: namisl_a.shp
 		Frames: 11, 12, 13, 14, 14, 14, 14, 14, 15, 16, 16, 16, 16, 17, 17, 17, 17, 17, 17, 17, 17, 18, 19, 20, 12, 22
 		Length: 25
 		Tick: 80
 		ZOffset: 2
 		IgnoreWorldTint: True
-	damaged-active: ntmisl_a
+	damaged-active:
+		TilesetFilenames:
+			TEMPERATE: ntmisl_a.shp
+			SNOW: namisl_a.shp
 		Start: 11
 		Length: 10
 		Tick: 80
 		ZOffset: 1
-	damaged-active-bright: ntmisl_a
+	damaged-active-bright:
+		TilesetFilenames:
+			TEMPERATE: ntmisl_a.shp
+			SNOW: namisl_a.shp
 		Start: 11
 		Length: 10
 		Tick: 80
 		ZOffset: 1
 		IgnoreWorldTint: True
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 25
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: msslicon
+		DepthSprite:
+	icon:
+		Filename: msslicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 gaplug:
 	Defaults:
+		TilesetFilenames:
+			TEMPERATE: gtplug.shp
+			SNOW: gaplug.shp
 		Offset: 12,-30, 30
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
 		DepthSpriteOffset: 12, 0
 	idle:
@@ -2160,118 +2967,186 @@ gaplug:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
-	idle-dish: gaplug_a
+	idle-dish:
+		TilesetFilenames:
+			TEMPERATE: gtplug_a.shp
+			SNOW: gaplug_a.shp
 		Length: 20
 		Tick: 120
-	damaged-idle-dish: gaplug_a
+	damaged-idle-dish:
+		TilesetFilenames:
+			TEMPERATE: gtplug_a.shp
+			SNOW: gaplug_a.shp
 		Start: 20
 		Length: 20
 		Tick: 120
-	idle-lights-bright: gaplug_b
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gtplug_b.shp
+			SNOW: gaplug_b.shp
 		Length: 20
 		Tick: 120
 		IgnoreWorldTint: True
-	damaged-idle-lights-bright: gaplug_b
+	damaged-idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gtplug_b.shp
+			SNOW: gaplug_b.shp
 		Start: 20
 		Length: 20
 		Tick: 120
 		IgnoreWorldTint: True
-	idle-strip: gaplug_c
+	idle-strip:
+		TilesetFilenames:
+			TEMPERATE: gtplug_c.shp
+			SNOW: gaplug_c.shp
 		Length: 8
 		Tick: 120
-	idle-strip-bright: gaplug_c
-		Length: 8
-		Tick: 120
-		IgnoreWorldTint: True
-	damaged-idle-strip: gaplug_c
-		Start: 8
-		Length: 8
-		Tick: 120
-	damaged-idle-strip-bright: gaplug_c
-		Start: 8
+	idle-strip-bright:
+		TilesetFilenames:
+			TEMPERATE: gtplug_c.shp
+			SNOW: gaplug_c.shp
 		Length: 8
 		Tick: 120
 		IgnoreWorldTint: True
-	idle-ioncannona: gaplug_f
+	damaged-idle-strip:
+		TilesetFilenames:
+			TEMPERATE: gtplug_c.shp
+			SNOW: gaplug_c.shp
+		Start: 8
+		Length: 8
+		Tick: 120
+	damaged-idle-strip-bright:
+		TilesetFilenames:
+			TEMPERATE: gtplug_c.shp
+			SNOW: gaplug_c.shp
+		Start: 8
+		Length: 8
+		Tick: 120
+		IgnoreWorldTint: True
+	idle-ioncannona:
+		TilesetFilenames:
+			TEMPERATE: gtplug_f.shp
+			SNOW: gaplug_f.shp
 		Length: 15
 		Tick: 120
 		Reverses: true
 		Offset: -12, -42, 30
-	idle-ioncannonb: gaplug_f
+	idle-ioncannonb:
+		TilesetFilenames:
+			TEMPERATE: gtplug_f.shp
+			SNOW: gaplug_f.shp
 		Length: 15
 		Reverses: true
 		Tick: 120
-	idle-hunterseekera: gaplug_e
+	idle-hunterseekera:
+		TilesetFilenames:
+			TEMPERATE: gtplug_e.shp
+			SNOW: gaplug_e.shp
 		Length: 15
 		Tick: 120
 		Offset: -12, -42, 30
-	idle-hunterseekera-bright: gaplug_e
-		Length: 15
-		Tick: 120
-		Offset: -12, -42, 30
-		IgnoreWorldTint: True
-	idle-hunterseekerb: gaplug_e
-		Length: 15
-		Tick: 120
-	idle-hunterseekerb-bright: gaplug_e
-		Length: 15
-		Tick: 120
-		IgnoreWorldTint: True
-	idle-droppoda: gaplug_d
-		Length: 15
-		Tick: 120
-		Offset: -12, -42, 30
-	idle-droppoda-bright: gaplug_d
+	idle-hunterseekera-bright:
+		TilesetFilenames:
+			TEMPERATE: gtplug_e.shp
+			SNOW: gaplug_e.shp
 		Length: 15
 		Tick: 120
 		Offset: -12, -42, 30
 		IgnoreWorldTint: True
-	idle-droppodb: gaplug_d
+	idle-hunterseekerb:
+		TilesetFilenames:
+			TEMPERATE: gtplug_e.shp
+			SNOW: gaplug_e.shp
 		Length: 15
 		Tick: 120
-	idle-droppodb-bright: gaplug_d
+	idle-hunterseekerb-bright:
+		TilesetFilenames:
+			TEMPERATE: gtplug_e.shp
+			SNOW: gaplug_e.shp
 		Length: 15
 		Tick: 120
 		IgnoreWorldTint: True
-	make: gtplugmk
+	idle-droppoda:
+		TilesetFilenames:
+			TEMPERATE: gtplug_d.shp
+			SNOW: gaplug_d.shp
+		Length: 15
+		Tick: 120
+		Offset: -12, -42, 30
+	idle-droppoda-bright:
+		TilesetFilenames:
+			TEMPERATE: gtplug_d.shp
+			SNOW: gaplug_d.shp
+		Length: 15
+		Tick: 120
+		Offset: -12, -42, 30
+		IgnoreWorldTint: True
+	idle-droppodb:
+		TilesetFilenames:
+			TEMPERATE: gtplug_d.shp
+			SNOW: gaplug_d.shp
+		Length: 15
+		Tick: 120
+	idle-droppodb-bright:
+		TilesetFilenames:
+			TEMPERATE: gtplug_d.shp
+			SNOW: gaplug_d.shp
+		Length: 15
+		Tick: 120
+		IgnoreWorldTint: True
+	make:
+		TilesetFilenames:
+			TEMPERATE: gtplugmk.shp
+			SNOW: gaplugmk.shp
 		Length: 17
 		ShadowStart: 17
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
+		TilesetFilenames:
 		Length: *
 		Offset: 0, 0, 31
-		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
-		-DepthSprite:
-	icon: plugicon
+		DepthSprite:
+	icon:
+		Filename: plugicon.shp
+		TilesetFilenames:
 		Offset: 0, 0
-		UseTilesetCode: false
-		-DepthSprite:
+		DepthSprite:
 
 gaplug2:
-	place: gtplug_e
+	place:
+		TilesetFilenames:
+			TEMPERATE: gtplug_e.shp
+			SNOW: gaplug_e.shp
 		Offset: 24,-48, 48
-		UseTilesetCode: true
 		Reverses: true
 		Length: 14
 		Tick: 120
-	icon: rad2icon
+	icon:
+		Filename: rad2icon.shp
 
 gaplug3:
-	place: gtplug_f
+	place:
+		TilesetFilenames:
+			TEMPERATE: gtplug_f.shp
+			SNOW: gaplug_f.shp
 		Offset: 24,-48, 48
-		UseTilesetCode: true
 		Reverses: true
 		Length: 14
 		Tick: 120
-	icon: rad3icon
+	icon:
+		Filename: rad3icon.shp
 
 gaplug4:
-	place: gtplug_d
+	place:
+		TilesetFilenames:
+			TEMPERATE: gtplug_d.shp
+			SNOW: gaplug_d.shp
 		Offset: 24,-48, 48
-		UseTilesetCode: true
 		Reverses: true
 		Length: 14
 		Tick: 120
-	icon: rad1icon
+	icon:
+		Filename: rad1icon.shp

--- a/mods/ts/sequences/trees.yaml
+++ b/mods/ts/sequences/trees.yaml
@@ -235,82 +235,78 @@ tree25:
 			TEMPERATE: tree25.tem
 			SNOW: tree25.sno
 
-^fona:
-	Inherits: ^tree
-	idle:
-
 fona01:
-	Inherits: ^fona
+	Inherits: ^tree
 	idle:
 		Filename: fona01.tem
 
 fona02:
-	Inherits: ^fona
+	Inherits: ^tree
 	idle:
 		Filename: fona02.tem
 
 fona03:
-	Inherits: ^fona
+	Inherits: ^tree
 	idle:
 		Filename: fona03.tem
 
 fona04:
-	Inherits: ^fona
+	Inherits: ^tree
 	idle:
 		Filename: fona04.tem
 
 fona05:
-	Inherits: ^fona
+	Inherits: ^tree
 	idle:
 		Filename: fona05.tem
 
 fona06:
-	Inherits: ^fona
+	Inherits: ^tree
 	idle:
 		Filename: fona06.tem
 
 fona07:
-	Inherits: ^fona
+	Inherits: ^tree
 	idle:
 		Filename: fona07.tem
 
 fona08:
-	Inherits: ^fona
+	Inherits: ^tree
 	idle:
 		Filename: fona08.tem
 
 fona09:
-	Inherits: ^fona
+	Inherits: ^tree
 	idle:
 		Filename: fona09.tem
 
 fona10:
-	Inherits: ^fona
+	Inherits: ^tree
 	idle:
 		Filename: fona10.tem
 
 fona11:
-	Inherits: ^fona
+	Inherits: ^tree
 	idle:
 		Filename: fona11.tem
 
 fona12:
-	Inherits: ^fona
+	Inherits: ^tree
 	idle:
 		Filename: fona12.tem
 
 fona13:
-	Inherits: ^fona
+	Inherits: ^tree
 	idle:
 		Filename: fona13.tem
 
 fona14:
-	Inherits: ^fona
+	Inherits: ^tree
 	idle:
 		Filename: fona14.tem
 
 fona15:
-	Inherits: ^fona
+	Inherits: ^tree
 	idle:
 		Filename: fona15.tem
 

--- a/mods/ts/sequences/trees.yaml
+++ b/mods/ts/sequences/trees.yaml
@@ -1,6 +1,5 @@
 ^tibtree:
 	Defaults:
-		UseTilesetExtension: true
 		Offset: 0, -12, 12
 	idle:
 		ShadowStart: 11
@@ -11,29 +10,43 @@
 		Tick: 160
 
 tibtre01:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: tibtre01.tem
+			SNOW: tibtre01.sno
 	Inherits: ^tibtree
 
 tibtre02:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: tibtre02.tem
+			SNOW: tibtre02.sno
 	Inherits: ^tibtree
 
 tibtre03:
+	Defaults:
+		TilesetFilenames:
+			TEMPERATE: tibtre03.tem
+			SNOW: tibtre03.sno
 	Inherits: ^tibtree
 
 bigblue:
 	Defaults:
 		Offset: 0, 0, 12
-	idle: bigblue2
+	idle:
+		Filename: bigblue2.shp
 		ShadowStart: 10
-	active: bigblue2
+	active:
+		Filename: bigblue2.shp
 		Start: 1
 		Length: 9
 		ShadowStart: 11
 		Tick: 160
 
 bigblue3:
-	Defaults: bigblue3.tem
+	Defaults:
+		Filename: bigblue3.tem
 		Offset: 0, -12, 12
-		AddExtension: false
 	idle:
 		ShadowStart: 10
 	active:
@@ -45,152 +58,267 @@ bigblue3:
 ^tree:
 	idle:
 		ShadowStart: 1
-		UseTilesetExtension: true
 		Offset: 0, -12, 12
 
 tree01:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree01.tem
+			SNOW: tree01.sno
 
 tree02:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree02.tem
+			SNOW: tree02.sno
 
 tree03:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree03.tem
+			SNOW: tree03.sno
 
 tree04:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree04.tem
+			SNOW: tree04.sno
 
 tree05:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree05.tem
+			SNOW: tree05.sno
 
 tree06:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree06.tem
+			SNOW: tree06.sno
 
 tree07:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree07.tem
+			SNOW: tree07.sno
 
 tree08:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree08.tem
+			SNOW: tree08.sno
 
 tree09:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree09.tem
+			SNOW: tree09.sno
 
 tree10:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree10.tem
+			SNOW: tree10.sno
 
 tree11:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree11.tem
+			SNOW: tree11.sno
 
 tree12:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree12.tem
+			SNOW: tree12.sno
 
 tree13:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree13.tem
+			SNOW: tree13.sno
 
 tree14:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree14.tem
+			SNOW: tree14.sno
 
 tree15:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree15.tem
+			SNOW: tree15.sno
 
 tree16:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree16.tem
+			SNOW: tree16.sno
 
 tree17:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree17.tem
+			SNOW: tree17.sno
 
 tree18:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree18.tem
+			SNOW: tree18.sno
 
 tree19:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree19.tem
+			SNOW: tree19.sno
 
 tree20:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree20.tem
+			SNOW: tree20.sno
 
 tree21:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree21.tem
+			SNOW: tree21.sno
 
 tree22:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree22.tem
+			SNOW: tree22.sno
 
 tree23:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree23.tem
+			SNOW: tree23.sno
 
 tree24:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree24.tem
+			SNOW: tree24.sno
 
 tree25:
 	Inherits: ^tree
+	idle:
+		TilesetFilenames:
+			TEMPERATE: tree25.tem
+			SNOW: tree25.sno
 
 ^fona:
 	Inherits: ^tree
 	idle:
-		AddExtension: false
 
 fona01:
 	Inherits: ^fona
-	Defaults: fona01.tem
+	idle:
+		Filename: fona01.tem
 
 fona02:
 	Inherits: ^fona
-	Defaults: fona02.tem
+	idle:
+		Filename: fona02.tem
 
 fona03:
 	Inherits: ^fona
-	Defaults: fona03.tem
+	idle:
+		Filename: fona03.tem
 
 fona04:
 	Inherits: ^fona
-	Defaults: fona04.tem
+	idle:
+		Filename: fona04.tem
 
 fona05:
 	Inherits: ^fona
-	Defaults: fona05.tem
+	idle:
+		Filename: fona05.tem
 
 fona06:
 	Inherits: ^fona
-	Defaults: fona06.tem
+	idle:
+		Filename: fona06.tem
 
 fona07:
 	Inherits: ^fona
-	Defaults: fona07.tem
+	idle:
+		Filename: fona07.tem
 
 fona08:
 	Inherits: ^fona
-	Defaults: fona08.tem
+	idle:
+		Filename: fona08.tem
 
 fona09:
 	Inherits: ^fona
-	Defaults: fona09.tem
+	idle:
+		Filename: fona09.tem
 
 fona10:
 	Inherits: ^fona
-	Defaults: fona10.tem
+	idle:
+		Filename: fona10.tem
 
 fona11:
 	Inherits: ^fona
-	Defaults: fona11.tem
+	idle:
+		Filename: fona11.tem
 
 fona12:
 	Inherits: ^fona
-	Defaults: fona12.tem
+	idle:
+		Filename: fona12.tem
 
 fona13:
 	Inherits: ^fona
-	Defaults: fona13.tem
+	idle:
+		Filename: fona13.tem
 
 fona14:
 	Inherits: ^fona
-	Defaults: fona14.tem
+	idle:
+		Filename: fona14.tem
 
 fona15:
 	Inherits: ^fona
-	Defaults: fona15.tem
+	idle:
+		Filename: fona15.tem
 
 veinhole:
 	idle:
+		TilesetFilenames:
+			TEMPERATE: veinhole.tem
+			SNOW: veinhole.sno
 		ShadowStart: 1
-		UseTilesetExtension: true
 		Offset: 0, -36, 1
 		ZRamp: 1

--- a/mods/ts/sequences/vehicles.yaml
+++ b/mods/ts/sequences/vehicles.yaml
@@ -1,5 +1,6 @@
 ^VehicleOverlays:
-	emp-overlay: emp_fx01
+	emp-overlay:
+		Filename: emp_fx01.shp
 		Offset: 0, 0, 24
 		Length: *
 		BlendMode: Additive
@@ -7,118 +8,149 @@
 
 mcv.gdi:
 	Inherits: ^VehicleOverlays
-	icon: sidebar-gdi|mcvicon
+	icon:
+		Filename: sidebar-gdi|mcvicon.shp
 
 mcv.nod:
 	Inherits: ^VehicleOverlays
-	icon: sidebar-nod|mcvicon
+	icon:
+		Filename: sidebar-nod|mcvicon.shp
 
 apc:
 	Inherits: ^VehicleOverlays
-	icon: apcicon
+	icon:
+		Filename: apcicon.shp
 
 harv.gdi:
 	Inherits: ^VehicleOverlays
-	harvest: harvestr
+	harvest:
+		Filename: harvestr.shp
 		Length: *
 		ZRamp: 1
 		Offset: 0, 0, 1
-	icon: sidebar-gdi|harvicon
+	icon:
+		Filename: sidebar-gdi|harvicon.shp
 
 harv.nod:
 	Inherits: ^VehicleOverlays
-	harvest: harvestr
+	harvest:
+		Filename: harvestr.shp
 		Length: *
 		ZRamp: 1
 		Offset: 0, 0, 1
-	icon: sidebar-nod|harvicon
+	icon:
+		Filename: sidebar-nod|harvicon.shp
 
 hvr:
 	Inherits: ^VehicleOverlays
-	icon: hovricon
+	icon:
+		Filename: hovricon.shp
 
 4tnk:
 	Inherits: ^VehicleOverlays
-	muzzle: gunfire
+	muzzle:
+		Filename: gunfire.shp
 		Length: *
 		IgnoreWorldTint: True
 
 lpst.gdi:
 	Inherits: ^VehicleOverlays
-	idle: gadpsa
+	idle:
+		TilesetFilenames:
+			TEMPERATE: gtdpsa.shp
+			SNOW: gadpsa.shp
 		DepthSprite: isodepth.shp
 		DepthSpriteOffset: -6, -6
 		Offset: 0, -13, 12
-		UseTilesetCode: true
 		ShadowStart: 3
-	make: gadpsamk
+	make:
+		TilesetFilenames:
+			TEMPERATE: gtdpsamk.shp
+			SNOW: gadpsamk.shp
 		DepthSprite: isodepth.shp
 		DepthSpriteOffset: -6, -6
 		Offset: 0, -13, 12
-		UseTilesetCode: true
 		Length: 36
 		ShadowStart: 36
-	idle-lights: gadpsa_a
+	idle-lights:
+		TilesetFilenames:
+			TEMPERATE: gtdpsa_a.shp
+			SNOW: gadpsa_a.shp
 		DepthSprite: isodepth.shp
 		DepthSpriteOffset: -6, -6
 		Offset: 0, -13, 12
-		UseTilesetCode: true
 		Length: 10
 		Tick: 200
-	idle-lights-bright: gadpsa_a
+	idle-lights-bright:
+		TilesetFilenames:
+			TEMPERATE: gtdpsa_a.shp
+			SNOW: gadpsa_a.shp
 		DepthSprite: isodepth.shp
 		DepthSpriteOffset: -6, -6
 		Offset: 0, -13, 12
-		UseTilesetCode: true
 		Length: 10
 		Tick: 200
 		IgnoreWorldTint: True
-	icon: sidebar-gdi|lpsticon
+	icon:
+		Filename: sidebar-gdi|lpsticon.shp
 
 lpst.nod:
 	Inherits: lpst.gdi
-	icon: sidebar-nod|lpsticon
+	icon:
+		Filename: sidebar-nod|lpsticon.shp
 
 repair:
 	Inherits: ^VehicleOverlays
-	icon: rboticon
+	icon:
+		Filename: rboticon.shp
 
 art2:
 	Inherits: ^VehicleOverlays
-	icon: artyicon
-	idle: gaarty
+	icon:
+		Filename: artyicon.shp
+	idle:
+		TilesetFilenames:
+			TEMPERATE: gtarty.shp
+			SNOW: gaarty.shp
 		ShadowStart: 3
 		Offset: 0, -12, 12
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
-	damaged-idle: gaarty
+	damaged-idle:
+		TilesetFilenames:
+			TEMPERATE: gtarty.shp
+			SNOW: gaarty.shp
 		Start: 1
 		ShadowStart: 4
 		Offset: 0, -12, 12
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
-	make: gaartymk
+	make:
+		TilesetFilenames:
+			TEMPERATE: gtartymk.shp
+			SNOW: gaartymk.shp
 		Length: 16
 		ShadowStart: 16
 		Offset: 0, -12, 12
-		UseTilesetCode: true
 		DepthSprite: isodepth.shp
-	muzzle: gunfire
+	muzzle:
+		Filename: gunfire.shp
 		Length: *
 		Offset: 0, 0, 24
 		IgnoreWorldTint: True
 
 weed:
 	Inherits: ^VehicleOverlays
-	icon: weedicon
+	icon:
+		Filename: weedicon.shp
 
 hmec:
 	Inherits: ^VehicleOverlays
-	icon: hmecicon
+	icon:
+		Filename: hmecicon.shp
 
 bike:
 	Inherits: ^VehicleOverlays
-	icon: cyclicon
+	icon:
+		Filename: cyclicon.shp
 
 bggy:
 	Inherits: ^VehicleOverlays
@@ -126,64 +158,84 @@ bggy:
 		Offset: 0, 0, 24
 	muzzle:
 		Combine:
-			mgun-n:
+			0:
+				Filename: mgun-n.shp
 				Length: 6
-			mgun-nw:
+			1:
+				Filename: mgun-nw.shp
 				Length: 6
-			mgun-w:
+			2:
+				Filename: mgun-w.shp
 				Length: 6
-			mgun-sw:
+			3:
+				Filename: mgun-sw.shp
 				Length: 6
-			mgun-s:
+			4:
+				Filename: mgun-s.shp
 				Length: 6
-			mgun-se:
+			5:
+				Filename: mgun-se.shp
 				Length: 6
-			mgun-e:
+			6:
+				Filename: mgun-e.shp
 				Length: 6
-			mgun-ne:
+			7:
+				Filename: mgun-ne.shp
 				Length: 6
 		Facings: 8
 		Length: 6
 		IgnoreWorldTint: True
-	icon: bggyicon
+	icon:
+		Filename: bggyicon.shp
 		Offset: 0, 0
 
 sapc:
 	Inherits: ^VehicleOverlays
-	icon: sapcicon
+	icon:
+		Filename: sapcicon.shp
 
 subtank:
 	Inherits: ^VehicleOverlays
-	icon: subticon
+	icon:
+		Filename: subticon.shp
 
 sonic:
 	Inherits: ^VehicleOverlays
-	icon: soniicon
+	icon:
+		Filename: soniicon.shp
 
 ttnk:
 	Inherits: ^VehicleOverlays
-	idle: gatick
+	idle:
+		Filename: gatick.shp
 		ShadowStart: 3
 		Offset: 0, -14, 14
-	damaged-idle: gatick
+	damaged-idle:
+		Filename: gatick.shp
 		Start: 1
 		ShadowStart: 4
 		Offset: 0, -14, 14
-	make: gatickmk
+	make:
+		Filename: gatickmk.shp
 		Length: 24
 		ShadowStart: 24
 		Offset: 0, -14, 14
-	muzzle: gunfire
+	muzzle:
+		Filename: gunfire.shp
 		Length: *
 		Offset: 0, 0, 24
 		IgnoreWorldTint: True
-	icon: tickicon
+	icon:
+		Filename: tickicon.shp
 
 stnk:
 	Inherits: ^VehicleOverlays
-	icon: stnkicon
+	icon:
+		Filename: stnkicon.shp
 
 mmch:
+	Defaults:
+		Filename: mmch.shp
 	Inherits: ^VehicleOverlays
 	stand:
 		Facings: -8
@@ -200,41 +252,51 @@ mmch:
 		Start: 120
 		Facings: -32
 		Offset: 0, 0, 12
-	muzzle: gunfire
+	muzzle:
+		Filename: gunfire.shp
 		Length: *
 		Offset: 0, 0, 12
 		IgnoreWorldTint: True
-	icon: mmchicon
+	icon:
+		Filename: mmchicon.shp
 
 jugg:
 	Inherits: ^VehicleOverlays
-	icon: juggicon
-	stand: jugger
+	icon:
+		Filename: juggicon.shp
+	stand:
+		Filename: jugger.shp
 		Facings: -8
 		Stride: 15
 		ShadowStart: 120
 		Offset: 0, 0, 12
-	walk: jugger
+	walk:
+		Filename: jugger.shp
 		Length: 15
 		Facings: -8
 		ShadowStart: 120
 		Offset: 0, 0, 12
 		Tick: 60
-	turret: djugg_a
+	turret:
+		Filename: djugg_a.shp
 		Facings: 32
 		Offset: -4, 0, 12
-	idle: djugg
+	idle:
+		Filename: djugg.shp
 		ShadowStart: 3
 		Offset: 0, -12, 12
-	damaged-idle: djugg
+	damaged-idle:
+		Filename: djugg.shp
 		Start: 1
 		ShadowStart: 4
 		Offset: 0, -12, 12
-	make: djuggmk
+	make:
+		Filename: djuggmk.shp
 		Length: 18
 		ShadowStart: 18
 		Offset: 0, -12, 12
-	muzzle: gunfire
+	muzzle:
+		Filename: gunfire.shp
 		Length: *
 		Offset: 0, 0, 24
 		IgnoreWorldTint: True
@@ -242,6 +304,7 @@ jugg:
 gghunt:
 	Inherits: ^VehicleOverlays
 	idle:
+		Filename: gghunt.shp
 		Facings: 1
 		Length: 8
 		ShadowStart: 8
@@ -249,6 +312,7 @@ gghunt:
 smech:
 	Inherits: ^VehicleOverlays
 	Defaults:
+		Filename: smech.shp
 		Offset: 0,0,8
 	stand:
 		Start: 96
@@ -271,7 +335,8 @@ smech:
 		Facings: -8
 		Tick: 80
 		IgnoreWorldTint: True
-	icon: smchicon
+	icon:
+		Filename: smchicon.shp
 
 trucka:
 	Inherits: ^VehicleOverlays


### PR DESCRIPTION
This is the first in a series of PRs aiming to remove technical debt from the sequence code and add features needed to finish and upstream remastered asset support.

All the magic around sprite filenames is removed in favour of explicitly specifying the full sprite name (per tileset if needed). This allows mods that don't follow the existing C&C conventions (e.g. by putting each tilesets assets in its own directory) to use tileset-specific artwork. It also prepares for a future PR that will add new ways of specifying filenames (e.g. `FilenamePattern: mytank-{:D4}.png`).

The `Defaults` node was previously combined into each sequence using `MiniYaml.Merge` at sequence-parsing time. This prevented us from implementing recursive merging at the `MiniYaml` level (see e.g. [this complaint](https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Game/GameRules/WeaponInfo.cs#L141)) because the raw sequence yaml may be malformed (e.g. trying to remove keys that don't exist) before the defaults have been copied over. This has been replaced with a much simpler fallback convention: the parser first looks for the requested key in the current sequence, and if not found it will look again in `Defaults`. Sequences can override (or more correctly, mask) the `Defaults` value by defining a key with no value.

I suggest reviewing by commit, and reading the commit descriptions for more information.
The yaml changes in the third commit are fully automated, so it shouldn't be necessary to inspect every single line in detail. A small number of manual cleanups are specified in the fourth commit.
