### PR TITLE
Enforce use of 'var' instead of explicit type

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -126,6 +126,9 @@ dotnet_style_predefined_type_for_locals_parameters_members = true
 # Show an IDE warning when default access modifiers are explicitly specified.
 dotnet_style_require_accessibility_modifiers = omit_if_default:warning
 
+# use 'var' instead of explicit type
+dotnet_diagnostic.IDE0007.severity = warning
+
 # Don't prefer braces (for one liners).
 dotnet_diagnostic.IDE0011.severity = silent
 

--- a/OpenRA.Game/Graphics/Palette.cs
+++ b/OpenRA.Game/Graphics/Palette.cs
@@ -108,7 +108,7 @@ namespace OpenRA.Graphics
 
 		public ImmutablePalette(IPalette p)
 		{
-			for (int i = 0; i < Palette.Size; i++)
+			for (var i = 0; i < Palette.Size; i++)
 				colors[i] = p[i];
 		}
 

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -344,7 +344,7 @@ namespace OpenRA
 			if (yaml.TryGetValue("Visibility", out temp))
 				newData.Visibility = FieldLoader.GetValue<MapVisibility>("Visibility", temp.Value);
 
-			string requiresMod = string.Empty;
+			var requiresMod = string.Empty;
 			if (yaml.TryGetValue("RequiresMod", out temp))
 				requiresMod = temp.Value;
 

--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -131,7 +131,7 @@ namespace OpenRA.Network
 						Log.Write("sync", $"\t {a.ActorID} {a.Type} {a.Owner} {a.Trait} ({a.Hash})");
 
 						var nvp = a.NamesValues;
-						for (int i = 0; i < nvp.Names.Length; i++)
+						for (var i = 0; i < nvp.Names.Length; i++)
 							if (nvp.Values[i] != null)
 								Log.Write("sync", $"\t\t {nvp.Names[i]}: {nvp.Values[i]}");
 					}
@@ -142,7 +142,7 @@ namespace OpenRA.Network
 						Log.Write("sync", "\t {0} ({1})", e.Name, e.Hash);
 
 						var nvp = e.NamesValues;
-						for (int i = 0; i < nvp.Names.Length; i++)
+						for (var i = 0; i < nvp.Names.Length; i++)
 							if (nvp.Values[i] != null)
 								Log.Write("sync", $"\t\t {nvp.Names[i]}: {nvp.Values[i]}");
 					}

--- a/OpenRA.Game/Scripting/ScriptTypes.cs
+++ b/OpenRA.Game/Scripting/ScriptTypes.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Scripting
 
 		public static bool TryGetClrValue<T>(this LuaValue value, out T clrObject)
 		{
-			var ret = value.TryGetClrValue(typeof(T), out object temp);
+			var ret = value.TryGetClrValue(typeof(T), out var temp);
 			clrObject = ret ? (T)temp : default;
 			return ret;
 		}

--- a/OpenRA.Mods.Cnc/FileFormats/LZOCompression.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/LZOCompression.cs
@@ -77,12 +77,12 @@ namespace OpenRA.Mods.Cnc.FileFormats
 			byte* ip;
 			uint t;
 			byte* mPos;
-			byte* ipEnd = @in + inLen;
+			var ipEnd = @in + inLen;
 			outLen = 0;
 			op = @out;
 			ip = @in;
-			bool gtFirstLiteralRun = false;
-			bool gtMatchDone = false;
+			var gtFirstLiteralRun = false;
+			var gtMatchDone = false;
 			if (*ip > 17)
 			{
 				t = (uint)(*ip++ - 17);

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportTSMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportTSMapCommand.cs
@@ -338,8 +338,8 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			var mapSection = file.GetSection("IsoMapPack5");
 
 			var data = Convert.FromBase64String(string.Concat(mapSection.Select(kvp => kvp.Value)));
-			int cells = (fullSize.X * 2 - 1) * fullSize.Y;
-			int lzoPackSize = cells * 11 + 4; // last 4 bytes contains a lzo pack header saying no more data is left
+			var cells = (fullSize.X * 2 - 1) * fullSize.Y;
+			var lzoPackSize = cells * 11 + 4; // last 4 bytes contains a lzo pack header saying no more data is left
 			var isoMapPack = new byte[lzoPackSize];
 			UnpackLZO(data, isoMapPack);
 
@@ -354,8 +354,8 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 				var z = mf.ReadUInt8();
 				/*var zero2 = */mf.ReadUInt8();
 
-				int dx = rx - ry + fullSize.X - 1;
-				int dy = rx + ry - fullSize.X - 1;
+				var dx = rx - ry + fullSize.X - 1;
+				var dy = rx + ry - fullSize.X - 1;
 				var mapCell = new MPos(dx / 2, dy);
 				var cell = mapCell.ToCPos(map);
 

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -760,10 +760,10 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		WVec HomingTick(World world, in WVec tarDistVec, int relTarHorDist)
 		{
-			int predClfHgt = 0;
-			int predClfDist = 0;
-			int lastHtChg = 0;
-			int lastHt = 0;
+			var predClfHgt = 0;
+			var predClfDist = 0;
+			var lastHtChg = 0;
+			var lastHt = 0;
 
 			if (info.TerrainHeightAware)
 				InclineLookahead(world, relTarHorDist, out predClfHgt, out predClfDist, out lastHtChg, out lastHt);

--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -175,8 +175,8 @@ namespace OpenRA.Mods.Common.Scripting
 				return false;
 			}
 
-			AsyncLoader l = new AsyncLoader(Media.LoadVideo);
-			IAsyncResult ar = l.BeginInvoke(s, null, null);
+			var l = new AsyncLoader(Media.LoadVideo);
+			var ar = l.BeginInvoke(s, null, null);
 			Action onLoadComplete = () =>
 			{
 				Media.StopFMVInRadar();

--- a/OpenRA.Mods.Common/TargetExtensions.cs
+++ b/OpenRA.Mods.Common/TargetExtensions.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common
 		/// /// </summary>
 		public static Target RecalculateInvalidatingHiddenTargets(this Target t, Player viewer)
 		{
-			var updated = t.Recalculate(viewer, out bool targetIsHiddenActor);
+			var updated = t.Recalculate(viewer, out var targetIsHiddenActor);
 			return targetIsHiddenActor ? Target.Invalid : updated;
 		}
 

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -342,7 +342,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var chosenTarget = Target.Invalid;
 			var chosenTargetPriority = int.MinValue;
-			int chosenTargetRange = 0;
+			var chosenTargetRange = 0;
 
 			var activePriorities = activeTargetPriorities.ToList();
 			if (activePriorities.Count == 0)

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -136,7 +136,7 @@ namespace OpenRA.Mods.Common.Traits
 				var type = BuildingType.Building;
 				CPos? location = null;
 				var actorVariant = 0;
-				string orderString = "PlaceBuilding";
+				var orderString = "PlaceBuilding";
 
 				// Check if Building is a plug for other Building
 				var actorInfo = world.Map.Rules.Actors[currentBuilding.Item];

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -376,7 +376,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var availCells = new List<CPos>();
 			var notStupidCells = new List<CPos>();
-			foreach (CVec direction in CVec.Directions)
+			foreach (var direction in CVec.Directions)
 			{
 				var p = ToCell + direction;
 				if (CanEnterCell(p) && CanStayInCell(p) && (preferToAvoid == null || !preferToAvoid(p)))

--- a/OpenRA.Mods.Common/UtilityCommands/Extensions.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/Extensions.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		public static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
 		{
 			var knownKeys = new HashSet<TKey>();
-			foreach (TSource element in source)
+			foreach (var element in source)
 			{
 				if (knownKeys.Add(keySelector(element)))
 					yield return element;

--- a/OpenRA.Mods.Common/UtilityCommands/Rgba2Hex.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/Rgba2Hex.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				return PrintUsage();
 
 			var invalid = false;
-			for (int i = 1; i < args.Length; i++)
+			for (var i = 1; i < args.Length; i++)
 			{
 				var parts = args[i].Split(Comma, StringSplitOptions.RemoveEmptyEntries);
 				if (parts.Length != 3 && parts.Length != 4)
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		[Desc("Convert r,g,b[,a] triples/quads into hex colors")]
 		void IUtilityCommand.Run(Utility utility, string[] args)
 		{
-			for (int i = 1; i < args.Length;)
+			for (var i = 1; i < args.Length;)
 			{
 				var parts = args[i].Split(Comma, StringSplitOptions.RemoveEmptyEntries);
 				if (parts.Length == 3)
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				return PrintUsage();
 
 			var invalid = false;
-			for (int i = 1; i < args.Length; i++)
+			for (var i = 1; i < args.Length; i++)
 			{
 				var parts = args[i].Split(Comma, StringSplitOptions.RemoveEmptyEntries);
 				if (parts.Length != 3 && parts.Length != 4)
@@ -180,7 +180,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		[Desc("Convert a,r,g,b legacy colors into hex colors")]
 		void IUtilityCommand.Run(Utility utility, string[] args)
 		{
-			for (int i = 1; i < args.Length;)
+			for (var i = 1; i < args.Length;)
 			{
 				var parts = args[i].Split(Comma, StringSplitOptions.RemoveEmptyEntries);
 				if (parts.Length == 3)

--- a/OpenRA.Mods.Common/Widgets/ModelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ModelWidget.cs
@@ -188,7 +188,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var animations = new ModelAnimation[] { animation };
 
-			ModelPreview preview = new ModelPreview(
+			var preview = new ModelPreview(
 				new ModelAnimation[] { animation }, WVec.Zero, 0,
 				cachedScale,
 				new WAngle(cachedLightPitch),


### PR DESCRIPTION
Has been part of the code style since forever and is currently only manually enforced.