### PR TITLE
Specify targetable offsets for the repair pad in Dune 2000

### DIFF
--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -885,6 +885,7 @@ repair_pad:
 	Health:
 		HP: 30000
 	HitShape:
+		TargetableOffsets: 1024,0,0, 0,-1024,0, 0,1024,0, -1024,0,0
 		Type: Rectangle
 			TopLeft: -1536, -512
 			BottomRight: 1536, 512


### PR DESCRIPTION
Usually the targetable cells are used directly, but the footprint of the repair pad was changed from `x` to `+`, so it just had one target at the center of the building, which meant engineers couldn't enter the building.

Closes #20586.

Before:
![grafik](https://user-images.githubusercontent.com/7704140/209664794-c49ae2cb-ac46-41ec-a5d3-cce181fa4aa5.png)

After:
![grafik](https://user-images.githubusercontent.com/7704140/209664787-96cc513b-670c-4277-8c1a-7fd00ab1a852.png)
