### PR TITLE
Fix update rules UnhardcodeSquadManager and  UnhardcodeBaseBuilderBotModule

### DIFF
--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UnhardcodeBaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UnhardcodeBaseBuilderBotModule.cs
@@ -11,27 +11,88 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {
 	public class UnhardcodeBaseBuilderBotModule : UpdateRule
 	{
+		MiniYamlNode defences;
+
+		// Excludes AttackBomber and AttackTDGunboatTurreted as actors with these AttackBase traits aren't supposed to be controlled.
+		readonly string[] attackBase = { "AttackLeap", "AttackPopupTurreted", "AttackAircraft", "AttackTesla", "AttackCharges", "AttackFollow", "AttackTurreted", "AttackFrontal", "AttackGarrisoned", "AttackOmni", "AttackSwallow" };
+		readonly string[] buildings = { "Building", "EnergyWall", "D2kBuilding" };
+
+		bool anyAdded;
+
 		public override string Name => "BaseBuilderBotModule got new fields to configure buildings that are defenses.";
 
 		public override string Description => "DefenseTypes were added.";
 
+		public override IEnumerable<string> BeforeUpdateActors(ModData modData, List<MiniYamlNode> resolvedActors)
+		{
+			var defences = new List<string>();
+
+			foreach (var actor in resolvedActors)
+			{
+				if (actor.Key.StartsWith('^'))
+					continue;
+
+				var isBuildable = false;
+				var isBuilding = false;
+				var canAttack = false;
+
+				foreach (var trait in actor.Value.Nodes)
+				{
+					if (trait.IsRemoval())
+						continue;
+
+					if (trait.KeyMatches("Buildable", includeRemovals: false))
+					{
+						isBuildable = true;
+						continue;
+					}
+
+					if (buildings.Any(v => trait.KeyMatches(v, includeRemovals: false)))
+					{
+						isBuilding = true;
+						continue;
+					}
+
+					if (attackBase.Any(ab => trait.KeyMatches(ab, includeRemovals: false)))
+						canAttack = true;
+				}
+
+				if (isBuildable && isBuilding && canAttack)
+				{
+					var name = actor.Key.ToLower();
+					if (!defences.Contains(name))
+						defences.Add(name);
+				}
+			}
+
+			this.defences = new MiniYamlNode("DefenseTypes", FieldSaver.FormatValue(defences));
+
+			yield break;
+		}
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (anyAdded)
+				yield return "`BaseBuilderBotModule` was unhardcoded and a new field added: `DefenseTypes`. Please verify the automated changes.";
+
+			anyAdded = false;
+		}
+
 		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
 		{
-			var addNodes = new List<MiniYamlNode>();
-
-			var defense = modData.DefaultRules.Actors.Values.Where(a => a.HasTraitInfo<BuildingInfo>() && a.HasTraitInfo<AttackBaseInfo>()).Select(a => a.Name);
-			var defensetypes = new MiniYamlNode("DefenseTypes", FieldSaver.FormatValue(defense.ToList()));
-			addNodes.Add(defensetypes);
-
-			foreach (var baseBuilderManager in actorNode.ChildrenMatching("BaseBuilderBotModule"))
-				foreach (var addNode in addNodes)
-					baseBuilderManager.AddNode(addNode);
+			foreach (var squadManager in actorNode.ChildrenMatching("BaseBuilderBotModule", includeRemovals: false))
+			{
+				if (!squadManager.ChildrenMatching(defences.Key, includeRemovals: false).Any())
+				{
+					squadManager.AddNode(defences);
+					anyAdded = true;
+				}
+			}
 
 			yield break;
 		}

--- a/OpenRA.Mods.Common/UpdateRules/UpdateRule.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateRule.cs
@@ -36,5 +36,9 @@ namespace OpenRA.Mods.Common.UpdateRules
 
 		public virtual IEnumerable<string> BeforeUpdate(ModData modData) { yield break; }
 		public virtual IEnumerable<string> AfterUpdate(ModData modData) { yield break; }
+
+		public virtual IEnumerable<string> BeforeUpdateActors(ModData modData, List<MiniYamlNode> resolvedActors) { yield break; }
+		public virtual IEnumerable<string> BeforeUpdateWeapons(ModData modData, List<MiniYamlNode> resolvedWeapons) { yield break; }
+		public virtual IEnumerable<string> BeforeUpdateSequences(ModData modData, List<MiniYamlNode> resolvedImages) { yield break; }
 	}
 }

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -74,7 +74,7 @@ Player:
 		ExcludeFromSquadsTypes: harv, mcv, dpod, hunter
 		ConstructionYardTypes: gacnst
 		AirUnitsTypes: orca, orcab, scrin, apache, jumpjet
-		ProtectionTypes: gapowr, gapowrup, gapile, gaweap, gahpad, gadept, garadr, gatech, gaplug, gagate_a, gagate_b, gactwr, gavulc, garock, gacsam, napowr, naapwr, nahand, naweap, nahpad, naradr, natech, nastlh, natmpl, namisl, nawast, nagate_a, nagate_b, nalasr, naobel, nasam, weed, gacnst, proc, gasilo, napuls, mcv, harv
+		ProtectionTypes: gapowr, gapile, gaweap, gahpad, gadept, garadr, gatech, gaplug, gagate_a, gagate_b, gactwr, napowr, naapwr, nahand, naweap, nahpad, naradr, natech, nastlh, natmpl, namisl, nawast, nagate_a, nagate_b, nalasr, naobel, nasam, weed, gacnst, proc, gasilo, napuls, mcv, harv
 		IgnoredEnemyTargetTypes: Air
 	UnitBuilderBotModule@test:
 		RequiresCondition: enable-test-ai


### PR DESCRIPTION
supersedes #20590

Update rules should should not read `modData.DefaultRules` as that can crash the game. To fix that that I've taken a commit from #20580. I also hardcoded traits as to stop these rules from ageing and for a cleaner integration with the new update rule method