### PR TITLE
Add BurstsPerFire to Armament

### DIFF
--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -281,7 +281,7 @@ namespace OpenRA.Mods.Common.Traits
 				barrel = Weapon.Burst == 1 ? Barrels[currentBarrel] : Barrels[Burst % Barrels.Length];
 				currentBarrel++;
 
-				FireBarrel(self, facing, target, barrel);
+				FireBarrel(self, facing, target, barrel, Burst == Weapon.Burst, i == 0);
 				Burst--;
 			}
 
@@ -290,7 +290,7 @@ namespace OpenRA.Mods.Common.Traits
 			return barrel;
 		}
 
-		protected virtual void FireBarrel(Actor self, IFacing facing, in Target target, Barrel barrel)
+		protected virtual void FireBarrel(Actor self, IFacing facing, in Target target, Barrel barrel, bool reportFirstBurst, bool reportBurstFire)
 		{
 			foreach (var na in notifyAttacks)
 				na.PreparingAttack(self, target, this, barrel);
@@ -345,10 +345,10 @@ namespace OpenRA.Mods.Common.Traits
 					if (projectile != null)
 						self.World.Add(projectile);
 
-					if (args.Weapon.Report != null && args.Weapon.Report.Length > 0)
+					if (reportBurstFire && args.Weapon.Report != null && args.Weapon.Report.Length > 0)
 						Game.Sound.Play(SoundType.World, args.Weapon.Report, self.World, self.CenterPosition);
 
-					if (burst == args.Weapon.Burst && args.Weapon.StartBurstReport != null && args.Weapon.StartBurstReport.Length > 0)
+					if (reportFirstBurst && args.Weapon.StartBurstReport != null && args.Weapon.StartBurstReport.Length > 0)
 						Game.Sound.Play(SoundType.World, args.Weapon.StartBurstReport, self.World, self.CenterPosition);
 
 					foreach (var na in notifyAttacks)

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -81,6 +81,8 @@ HVR:
 	Armament:
 		Weapon: HoverMissile
 		LocalOffset: 0,242,543, 0,-242,543
+		LocalYaw: -110, 110
+		BurstsPerFire: 2
 	Turreted:
 		TurnSpeed: 28
 		Offset: -128,0,85

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -69,7 +69,7 @@ BIKE:
 		RequiresCondition: !rank-elite
 		LocalOffset: -153,-204,509, -153,204,509
 	Armament@ELITE:
-		Weapon: HoverMissile
+		Weapon: BikeMissile
 		RequiresCondition: rank-elite
 		LocalOffset: -153,-204,509, -153,204,509
 	AttackFrontal:

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -54,10 +54,16 @@ Bazooka:
 
 HoverMissile:
 	Inherits: ^DefaultMissile
-	ReloadDelay: 68
-	Burst: 2
+	ReloadDelay: 100
+	Burst: 8
+	BurstDelays: 10, 20, 30
 	Range: 8c0
 	Report: hovrmis1.aud
+	StartBurstReport: samshot1.aud
+	Projectile: Missile
+		HorizontalRateOfTurn: 13
+		RangeLimit: 25c0
+		Speed: 400
 	Warhead@1Dam: SpreadDamage
 		Damage: 3000
 


### PR DESCRIPTION
## Summary 
### Fire at the same time at different sides
This PR is to solve the problem that we need to use mutiple `Armament` traits to make actor fires the weapon from different side at the same time, as well as improve perf when `AttackBase` or bot modules search armaments. With this PR, we can write only one Armament trait on the gif example below:

![arm-showcase1](https://user-images.githubusercontent.com/13763394/194864578-fcafb2cc-fc79-4bb5-9f09-eea63d6422f9.gif)

Previous:
```
<Rule.yaml>
	Armament@1:
		Weapon: FalconMissile
		LocalOffset: 0, -600, 0
		LocalYaw: 100
		PauseOnCondition: !ammo
	Armament@2:
		Weapon: FalconMissileMute
		LocalOffset: 0, 600, 0
		LocalYaw: -100
		PauseOnCondition: !ammo
	Armament@3:
		Weapon: FalconMissileMute
		LocalOffset: 0, -300, 0
		LocalYaw: 64
		PauseOnCondition: !ammo
	Armament@4:
		Weapon: FalconMissileMute
		LocalOffset: 0, 300, 0
		LocalYaw: -64
		PauseOnCondition: !ammo


<Weapon.yaml>
FalconMissile:
...

FalconMissileMute:
	Inherits: FalconMissile
	-Report:
```


Now:
```
<Rule.yaml>
	Armament@1:
		Weapon: FalconMissile
		LocalOffset: 0, -600, 0, 0, 600, 0, 0, -300, 0, 0, 300, 0
		LocalYaw: 100, -100, 64, -64
		BurstsPerFire: 4
		PauseOnCondition: !ammo

<Weapon.yaml>
FalconMissile:
	Bursts: 4
	StartBurstReport: ...
	...
```

### Fire all burst at the same time
We can also use this function to make a shotgun effect to let all bursts come out at once, which is previously impossible:
![shotgun](https://user-images.githubusercontent.com/13763394/219261210-fa0d198d-e468-432e-b5b8-cb2fa6841668.gif)
