### PR TITLE
Clarify the wording and explain the meaning of some labels in settings

### DIFF
--- a/mods/cnc/chrome/settings-audio.yaml
+++ b/mods/cnc/chrome/settings-audio.yaml
@@ -84,7 +84,9 @@ Container@AUDIO_PANEL:
 									Width: PARENT_RIGHT
 									Height: 20
 									Font: Regular
-									Text: Mute Background Music
+									Text: Mute Menu Music
+									TooltipText: Mute background music when no specific track is playing
+									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 						Container@MUSIC_VOLUME_CONTAINER:
 							X: PARENT_RIGHT / 2 + 10
 							Width: PARENT_RIGHT / 2 - 20

--- a/mods/cnc/chrome/settings-display.yaml
+++ b/mods/cnc/chrome/settings-display.yaml
@@ -159,7 +159,9 @@ Container@DISPLAY_PANEL:
 									Width: PARENT_RIGHT
 									Height: 20
 									Font: Regular
-									Text: Player Stance Colors
+									Text: Player Relationship Colors
+									TooltipText: Change minimap and health bar colors based on relationship (own, enemy, ally, neutral)
+									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 				Container@ROW:
 					Width: PARENT_RIGHT - 24
 					Height: 20
@@ -173,6 +175,8 @@ Container@DISPLAY_PANEL:
 									Height: 20
 									Font: Regular
 									Text: Show UI Feedback Notifications
+									TooltipText: Show transient text notifications for UI events
+									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 						Container@TRANSIENTS_CHECKBOX_CONTAINER:
 							X: PARENT_RIGHT / 2 + 10
 							Width: PARENT_RIGHT / 2 - 20
@@ -182,6 +186,8 @@ Container@DISPLAY_PANEL:
 									Height: 20
 									Font: Regular
 									Text: Show Game Event Notifications
+									TooltipText: Show transient text notifications for game events
+									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 				Container@ROW:
 					Width: PARENT_RIGHT - 24
 					Height: 20

--- a/mods/common/chrome/settings-audio.yaml
+++ b/mods/common/chrome/settings-audio.yaml
@@ -84,7 +84,9 @@ Container@AUDIO_PANEL:
 									Width: PARENT_RIGHT
 									Height: 20
 									Font: Regular
-									Text: Mute Background Music
+									Text: Mute Menu Music
+									TooltipText: Mute background music when no specific track is playing
+									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 						Container@MUSIC_VOLUME_CONTAINER:
 							X: PARENT_RIGHT / 2 + 10
 							Width: PARENT_RIGHT / 2 - 20

--- a/mods/common/chrome/settings-display.yaml
+++ b/mods/common/chrome/settings-display.yaml
@@ -159,7 +159,9 @@ Container@DISPLAY_PANEL:
 									Width: PARENT_RIGHT
 									Height: 20
 									Font: Regular
-									Text: Player Stance Colors
+									Text: Player Relationship Colors
+									TooltipText: Change minimap and health bar colors based on relationship (own, enemy, ally, neutral)
+									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 				Container@ROW:
 					Width: PARENT_RIGHT - 24
 					Height: 20
@@ -173,6 +175,8 @@ Container@DISPLAY_PANEL:
 									Height: 20
 									Font: Regular
 									Text: Show UI Feedback Notifications
+									TooltipText: Show transient text notifications for UI events
+									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 						Container@TRANSIENTS_CHECKBOX_CONTAINER:
 							X: PARENT_RIGHT / 2 + 10
 							Width: PARENT_RIGHT / 2 - 20
@@ -182,6 +186,8 @@ Container@DISPLAY_PANEL:
 									Height: 20
 									Font: Regular
 									Text: Show Game Event Notifications
+									TooltipText: Show transient text notifications for game events
+									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 				Container@ROW:
 					Width: PARENT_RIGHT - 24
 					Height: 20


### PR DESCRIPTION
The wording on some of the labels in settings panel is not so clear. This has come up in conversations and player feedback on Discord several times. This PR:

- Changes the label "Mute Background Music" to "Mute Menu Music" and adds a tooltip to make it clear that this is about the music in the menu when no specific track is playing. Technically this can also mute the background music in a map if it has `AllowMuteBackgroundMusic` set to `true` and hence the previous label.
- Changes the label "Player Stance Colors" to "Player Relationship Colors" and adds a tooltip explaining what the feature does. I always found this confusing as a player and had to guess what it does. Also the term *stances* is used for unit stances and not for player relationships (it was also changed in code - see #18677 and #18678).
- Add tooltips explaining the new transient notification options. This came up repeatedly on Discord (people couldn't figure out what the labels mean and how the changes would manifest) and was the initial motivation for this PR.