### PR TITLE
Added ITilesetSpecificPaletteInfo for linting

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -245,6 +245,12 @@ namespace OpenRA.Traits
 	}
 
 	[RequireExplicitImplementation]
+	public interface ITilesetSpecificPaletteInfo : ITraitInfoInterface
+	{
+		string Tileset { get; }
+	}
+
+	[RequireExplicitImplementation]
 	public interface IProvidesCursorPaletteInfo : ITraitInfoInterface
 	{
 		string Palette { get; }

--- a/OpenRA.Mods.Common/Lint/CheckPalettes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPalettes.cs
@@ -12,7 +12,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Server;
 using OpenRA.Traits;
 
@@ -146,11 +145,11 @@ namespace OpenRA.Mods.Common.Lint
 						}
 						else
 						{
-							// PaletteFromFile might only be active for a single tileset
-							// So ignore any duplicate palette names as long as they are on different tilesets
-							if (traitInfo is PaletteFromFileInfo paletteFromFileInfo && paletteFromFileInfo.Tileset != null)
+							// Tileset-specific palettes can share a name, so check combinations.
+							// NOTE: This does not check PaletteFromGimpOrJascFile!
+							if (traitInfo is ITilesetSpecificPaletteInfo tilesetSpecificPaletteInfo && tilesetSpecificPaletteInfo.Tileset != null)
 							{
-								var tilesetPalette = (paletteFromFileInfo.Tileset, value);
+								var tilesetPalette = (tilesetSpecificPaletteInfo.Tileset, value);
 								if (tilesetPalettes.Contains(tilesetPalette))
 									emitError($"Duplicate palette definition for palette name {value}");
 								else

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromFile.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromFile.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Load VGA palette (.pal) registers.")]
-	class PaletteFromFileInfo : TraitInfo, IProvidesCursorPaletteInfo
+	class PaletteFromFileInfo : TraitInfo, ITilesetSpecificPaletteInfo, IProvidesCursorPaletteInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -45,6 +45,8 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool CursorPalette = false;
 
 		public override object Create(ActorInitializer init) { return new PaletteFromFile(init.World, this); }
+
+		string ITilesetSpecificPaletteInfo.Tileset => Tileset;
 
 		string IProvidesCursorPaletteInfo.Palette => CursorPalette ? Name : null;
 

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromGrayscale.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromGrayscale.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Creates a greyscale palette without any base palette file.")]
-	class PaletteFromGrayscaleInfo : TraitInfo
+	class PaletteFromGrayscaleInfo : TraitInfo, ITilesetSpecificPaletteInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -33,6 +33,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Index set to be fully transparent/invisible.")]
 		public readonly int TransparentIndex = 0;
+
+		string ITilesetSpecificPaletteInfo.Tileset => Tileset;
 
 		public override object Create(ActorInitializer init) { return new PaletteFromGrayscale(init.World, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromPng.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromPng.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Load a PNG and use its embedded palette.")]
-	class PaletteFromPngInfo : TraitInfo, IProvidesCursorPaletteInfo
+	class PaletteFromPngInfo : TraitInfo, ITilesetSpecificPaletteInfo, IProvidesCursorPaletteInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -43,6 +43,8 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool CursorPalette = false;
 
 		public override object Create(ActorInitializer init) { return new PaletteFromPng(init.World, this); }
+
+		string ITilesetSpecificPaletteInfo.Tileset => Tileset;
 
 		string IProvidesCursorPaletteInfo.Palette => CursorPalette ? Name : null;
 

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromRGBA.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromRGBA.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Creates a single color palette without any base palette file.")]
-	class PaletteFromRGBAInfo : TraitInfo
+	class PaletteFromRGBAInfo : TraitInfo, ITilesetSpecificPaletteInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -45,6 +45,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Index set to be fully transparent/invisible.")]
 		public readonly int TransparentIndex = 0;
+
+		string ITilesetSpecificPaletteInfo.Tileset => Tileset;
 
 		public override object Create(ActorInitializer init) { return new PaletteFromRGBA(init.World, this); }
 	}


### PR DESCRIPTION
Fixes #20605.

I really wanted to use the existing `PaletteDefinitionAttribute` instead of adding a new interface, but in order to get the tileset name we need a type to cast the `TraitInfo` to. I also don't like having the hardcoded assumption that `PaletteFromFile` is inherently related to tilesets (is tileset-specific), but I couldn't come up with a clean and simple way to change that.

@drogoganor please test with OpenDR if this fixes the problem for you.