### PR TITLE
Fix for Windows uninstaller to remove reg entries from the 64 bit registry

### DIFF
--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -226,6 +226,10 @@ Function ${UN}Clean
 
 	RMDir /r $INSTDIR\Support
 
+	!ifndef USE_PROGRAMFILES32
+		SetRegView 64
+	!endif
+
 	DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenRA${SUFFIX}"
 	DeleteRegKey HKLM "Software\Classes\openra-ra-${TAG}"
 	DeleteRegKey HKLM "Software\Classes\openra-cnc-${TAG}"


### PR DESCRIPTION
On Windows, uninstalling the 64-bit version of OpenRA leaves the registry entries behind. This leaves an entry in the Add/Remove Programs list which can't be removed unless you registry hack.

![image](https://user-images.githubusercontent.com/1639681/211813936-ad3cf14a-8d86-42c4-9e6c-3742989df4d8.png)

The fix was to call `SetRegView 64` when uninstalling to specify the 64-bit registry. I tested both the 64 bit and 32 bit uninstall and they both function correctly and remove the registry entries OK.