### PR TITLE
Looped sounds can now be unlooped to avoid cut-offs.

### DIFF
--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -129,6 +129,11 @@ namespace OpenRA
 			soundEngine.StopAllSounds();
 		}
 
+		public void EndLoop(ISound sound)
+		{
+			soundEngine.SetSoundLooping(false, sound);
+		}
+
 		public void MuteAudio()
 		{
 			soundEngine.Volume = 0f;


### PR DESCRIPTION
Looped sounds can only be stopped currently. This gives it a hard-cut at the end.
Ending the loop ensures they are played till the end.
This sounds way better for example for mech movement sounds.
