### PR TITLE
Apply Deviator ChangeOwner warhead only for Enemy and Neutral targets.

### DIFF
--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -165,5 +165,6 @@ DeviatorMissile:
 		Range: 512
 		Duration: 375
 		InvalidTargets: Infantry, Structure
+		ValidRelationships: Enemy, Neutral
 	Warhead@4Concrete: DamagesConcrete
 		Damage: 1000


### PR DESCRIPTION
This PR fix deviator cheating vector where Ordos player can capture ally  MCV and get free double tech in team games.
Pls merge for prep.