### PR TITLE
Prevent folders from getting replaced with files when renaming zipped maps

### DIFF
--- a/OpenRA.Game/FileSystem/ZipFile.cs
+++ b/OpenRA.Game/FileSystem/ZipFile.cs
@@ -55,7 +55,8 @@ namespace OpenRA.FileSystem
 				get
 				{
 					foreach (ZipEntry entry in pkg)
-						yield return entry.Name;
+						if (entry.IsFile)
+							yield return entry.Name;
 				}
 			}
 


### PR DESCRIPTION
Bug fix for issue whereby renaming a zipped map file with the map editor would create folders as binary files in the process of creating the new zip.