### PR TITLE
Add the expected parameter(s) to the ExtractFilesCommand description

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/ExtractFilesCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractFilesCommand.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			return args.Length >= 2;
 		}
 
-		[Desc("Extract files from mod packages to the current directory")]
+		[Desc("FILENAME", "[FILENAME...]", "Extract files from mod packages to the current directory")]
 		void IUtilityCommand.Run(Utility utility, string[] args)
 		{
 			var files = args.Skip(1);


### PR DESCRIPTION
Previously it didn't report that at least one parameter is required.