### PR TITLE
Fix not all ammo pools getting rearmed during RearmTick

### DIFF
--- a/OpenRA.Mods.Common/Traits/Rearmable.cs
+++ b/OpenRA.Mods.Common/Traits/Rearmable.cs
@@ -56,6 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool RearmTick(Actor self)
 		{
+			var rearmComplete = true;
 			foreach (var ammoPool in RearmableAmmoPools)
 			{
 				if (!ammoPool.HasFullAmmo)
@@ -69,11 +70,11 @@ namespace OpenRA.Mods.Common.Traits
 						ammoPool.GiveAmmo(self, ammoPool.Info.ReloadCount);
 					}
 
-					return false;
+					rearmComplete = false;
 				}
 			}
 
-			return true;
+			return rearmComplete;
 		}
 	}
 }


### PR DESCRIPTION
Fixes a potential regression from #20172. We don't want to wait for the previous ammo pool to complete reloading before reloading the other ammo pools.