### PR TITLE
Add support for Flatpak Steam installs.

### DIFF
--- a/OpenRA.Mods.Common/Installer/SourceResolvers/SteamSourceResolver.cs
+++ b/OpenRA.Mods.Common/Installer/SourceResolvers/SteamSourceResolver.cs
@@ -85,11 +85,12 @@ namespace OpenRA.Mods.Common.Installer
 					break;
 
 				case PlatformType.Linux:
+					// Direct distro install
 					candidatePaths.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".steam", "root"));
 
-					break;
+					// Flatpak installed via Flathub
+					candidatePaths.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".var", "app", "com.valvesoftware.Steam", ".steam", "root"));
 
-				default:
 					break;
 			}
 


### PR DESCRIPTION
This allows players who use https://flathub.org/apps/details/com.valvesoftware.Steam to install assets.