### PR TITLE
Only update changed files when saving maps.

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -648,12 +648,21 @@ namespace OpenRA
 					toPackage.Update(file, Package.GetStream(file).ReadAllBytes());
 
 			if (!LockPreview)
-				toPackage.Update("map.png", SavePreview());
+			{
+				var previewData = SavePreview();
+				if (Package != toPackage || !Enumerable.SequenceEqual(previewData, Package.GetStream("map.png").ReadAllBytes()))
+					toPackage.Update("map.png", previewData);
+			}
 
 			// Update the package with the new map data
-			var s = root.WriteToString();
-			toPackage.Update("map.yaml", Encoding.UTF8.GetBytes(s));
-			toPackage.Update("map.bin", SaveBinaryData());
+			var textData = Encoding.UTF8.GetBytes(root.WriteToString());
+			if (Package != toPackage || !Enumerable.SequenceEqual(textData, Package.GetStream("map.yaml").ReadAllBytes()))
+				toPackage.Update("map.yaml", textData);
+
+			var binaryData = SaveBinaryData();
+			if (Package != toPackage || !Enumerable.SequenceEqual(binaryData, Package.GetStream("map.bin").ReadAllBytes()))
+				toPackage.Update("map.bin", binaryData);
+
 			Package = toPackage;
 
 			// Update UID to match the newly saved data

--- a/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
@@ -305,7 +305,14 @@ namespace OpenRA.Mods.Common.UpdateRules
 		public static void Save(this YamlFileSet files)
 		{
 			foreach (var file in files)
-				file.Item1?.Update(file.Item2, Encoding.UTF8.GetBytes(file.Item3.WriteToString()));
+			{
+				if (file.Item1 == null)
+					continue;
+
+				var textData = Encoding.UTF8.GetBytes(file.Item3.WriteToString());
+				if (!Enumerable.SequenceEqual(textData, file.Item1.GetStream(file.Item2).ReadAllBytes()))
+					file.Item1.Update(file.Item2, textData);
+			}
 		}
 
 		/// <summary>Checks if node is a removal (has '-' prefix)</summary>


### PR DESCRIPTION
This stops all oramap files showing as changed when running update rules.