### PR TITLE
ProductionTabsWidget: customize scroll decorations

### DIFF
--- a/OpenRA.Mods.Common/UpdateRules/Rules/20221203/ProductionTabsWidgetAddTabButtonCollection.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20221203/ProductionTabsWidgetAddTabButtonCollection.cs
@@ -1,0 +1,43 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class ProductionTabsWidgetAddTabButtonCollection : UpdateRule
+	{
+		public override string Name => "Change name of Button field of ProductionTabsWidget and add ArrowButton if necessary.";
+
+		public override string Description =>
+			"Change the field name from Button to TabButton and add ArrowButton, if Button field was set.";
+
+		public override IEnumerable<string> UpdateChromeNode(ModData modData, MiniYamlNode chromeNode)
+		{
+			if (!chromeNode.KeyMatches("ProductionTabs"))
+				yield break;
+
+			string buttonCollection = null;
+			foreach (var field in chromeNode.ChildrenMatching("Button"))
+			{
+				field.RenameKey("TabButton");
+				buttonCollection = field.Value.Value;
+			}
+
+			if (buttonCollection != null)
+			{
+				chromeNode.AddNode(new MiniYamlNode("ArrowButton", buttonCollection));
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -105,6 +105,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new TextNotificationsDisplayWidgetRemoveTime(),
 				new ExplicitSequenceFilenames(),
 				new RenameEngineerRepair(),
+				new ProductionTabsWidgetAddTabButtonCollection()
 			})
 		};
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/AddFactionSuffixLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/AddFactionSuffixLogic.cs
@@ -45,6 +45,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				ptw.ArrowButton += suffix;
 				ptw.TabButton += suffix;
+
+				// TODO: This isn't functional, ProductionTabsWidget's caches aren't updated with the new values.
+				ptw.Decorations += suffix;
 				ptw.Background += suffix;
 			}
 			else

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/AddFactionSuffixLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/AddFactionSuffixLogic.cs
@@ -43,7 +43,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 			else if (widget is ProductionTabsWidget ptw)
 			{
-				ptw.Button += suffix;
+				ptw.ArrowButton += suffix;
+				ptw.TabButton += suffix;
 				ptw.Background += suffix;
 			}
 			else

--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public string TabButton = "button";
 
 		public string Background = "panel-black";
-		public readonly string Decorations = "scrollpanel-decorations";
+		public string Decorations = "scrollpanel-decorations";
 		public readonly string DecorationScrollLeft = "left";
 		public readonly string DecorationScrollRight = "right";
 		CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted), Sprite> getLeftArrowImage;

--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -81,7 +81,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public readonly Dictionary<string, ProductionTabGroup> Groups;
 
-		public string Button = "button";
+		public string ArrowButton = "button";
+		public string TabButton = "button";
+
 		public string Background = "panel-black";
 		public readonly string Decorations = "scrollpanel-decorations";
 		public readonly string DecorationScrollLeft = "left";
@@ -190,8 +192,8 @@ namespace OpenRA.Mods.Common.Widgets
 			var rightHover = Ui.MouseOverWidget == this && rightButtonRect.Contains(Viewport.LastMousePos);
 
 			WidgetUtils.DrawPanel(Background, rb);
-			ButtonWidget.DrawBackground(Button, leftButtonRect, leftDisabled, leftPressed, leftHover, false);
-			ButtonWidget.DrawBackground(Button, rightButtonRect, rightDisabled, rightPressed, rightHover, false);
+			ButtonWidget.DrawBackground(ArrowButton, leftButtonRect, leftDisabled, leftPressed, leftHover, false);
+			ButtonWidget.DrawBackground(ArrowButton, rightButtonRect, rightDisabled, rightPressed, rightHover, false);
 
 			var leftArrowImage = getLeftArrowImage.Update((leftDisabled, leftPressed, leftHover, false, false));
 			WidgetUtils.DrawSprite(leftArrowImage,
@@ -211,7 +213,7 @@ namespace OpenRA.Mods.Common.Widgets
 				var rect = new Rectangle(origin.X + contentWidth, origin.Y, TabWidth, rb.Height);
 				var hover = !leftHover && !rightHover && Ui.MouseOverWidget == this && rect.Contains(Viewport.LastMousePos);
 				var highlighted = tab.Queue == CurrentQueue;
-				ButtonWidget.DrawBackground(Button, rect, false, false, hover, highlighted);
+				ButtonWidget.DrawBackground(TabButton, rect, false, false, hover, highlighted);
 				contentWidth += TabWidth - 1;
 
 				var textSize = font.Measure(tab.Name);

--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -197,11 +197,11 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var leftArrowImage = getLeftArrowImage.Update((leftDisabled, leftPressed, leftHover, false, false));
 			WidgetUtils.DrawSprite(leftArrowImage,
-				new float2(leftButtonRect.Left + 2, leftButtonRect.Top + 2));
+				new float2(leftButtonRect.Left + (int)((leftButtonRect.Width - leftArrowImage.Size.X) / 2), leftButtonRect.Top + (int)((leftButtonRect.Height - leftArrowImage.Size.Y) / 2)));
 
 			var rightArrowImage = getRightArrowImage.Update((rightDisabled, rightPressed, rightHover, false, false));
 			WidgetUtils.DrawSprite(rightArrowImage,
-				new float2(rightButtonRect.Left + 2, rightButtonRect.Top + 2));
+				new float2(rightButtonRect.Left + (int)((rightButtonRect.Width - rightArrowImage.Size.X) / 2), rightButtonRect.Top + (int)((rightButtonRect.Height - rightArrowImage.Size.Y) / 2)));
 
 			// Draw tab buttons
 			Game.Renderer.EnableScissor(new Rectangle(leftButtonRect.Right, rb.Y + 1, rightButtonRect.Left - leftButtonRect.Right - 1, rb.Height));

--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -86,8 +86,8 @@ namespace OpenRA.Mods.Common.Widgets
 		public readonly string Decorations = "scrollpanel-decorations";
 		public readonly string DecorationScrollLeft = "left";
 		public readonly string DecorationScrollRight = "right";
-		readonly CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted), Sprite> getLeftArrowImage;
-		readonly CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted), Sprite> getRightArrowImage;
+		CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted), Sprite> getLeftArrowImage;
+		CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted), Sprite> getRightArrowImage;
 
 		int contentWidth = 0;
 		float listOffset = 0;
@@ -111,9 +111,6 @@ namespace OpenRA.Mods.Common.Widgets
 			IsVisible = () => queueGroup != null && Groups[queueGroup].Tabs.Count > 0;
 
 			paletteWidget = Exts.Lazy(() => Ui.Root.Get<ProductionPaletteWidget>(PaletteWidget));
-
-			getLeftArrowImage = WidgetUtils.GetCachedStatefulImage(Decorations, DecorationScrollLeft);
-			getRightArrowImage = WidgetUtils.GetCachedStatefulImage(Decorations, DecorationScrollRight);
 		}
 
 		public override void Initialize(WidgetArgs args)
@@ -124,6 +121,9 @@ namespace OpenRA.Mods.Common.Widgets
 			leftButtonRect = new Rectangle(rb.X, rb.Y, ArrowWidth, rb.Height);
 			rightButtonRect = new Rectangle(rb.Right - ArrowWidth, rb.Y, ArrowWidth, rb.Height);
 			font = Game.Renderer.Fonts["TinyBold"];
+
+			getLeftArrowImage = WidgetUtils.GetCachedStatefulImage(Decorations, DecorationScrollLeft);
+			getRightArrowImage = WidgetUtils.GetCachedStatefulImage(Decorations, DecorationScrollRight);
 		}
 
 		public bool SelectNextTab(bool reverse)


### PR DESCRIPTION
Makes it possible to customize left/right arrow buttons and panels for left/right buttons and tab buttons.

Other changes:
- centers left/right arrow images on left/right buttons thus removing hack necessary for CNC mod
- `AddFactionSuffixLogic` adds suffix to both `TabButton` and `ArrowButton` and also for `Decorations` fields on `ProductionTabsWidget`

Adding faction suffix to `Decorations` doesn't break CNC mod as `chrome.yaml` defines both [`scrollpanel-decorations-nod` and `scrollpanel-decorations-gdi`](https://github.com/OpenRA/OpenRA/blob/bleed/mods/cnc/chrome.yaml#L491).

Fixes #20619.