### PR TITLE
Abstract docking from Refinery & Harvester

### DIFF
--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -61,13 +61,13 @@ namespace OpenRA.Mods.Common.Activities
 				// We have to make sure the actual "harvest" order is not skipped if a third order is queued,
 				// so we keep deliveredLoad false.
 				if (harv.IsFull)
-					QueueChild(new DeliverResources(self));
+					QueueChild(new MoveToDock(self));
 			}
 
 			// If an explicit "deliver" order is given, the harvester goes immediately to the refinery.
 			if (deliverActor != null)
 			{
-				QueueChild(new DeliverResources(self, deliverActor));
+				QueueChild(new MoveToDock(self, deliverActor));
 				hasDeliveredLoad = true;
 				deliverActor = null;
 			}
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.Common.Activities
 			// Are we full or have nothing more to gather? Deliver resources.
 			if (harv.IsFull || (!harv.IsEmpty && LastSearchFailed))
 			{
-				QueueChild(new DeliverResources(self));
+				QueueChild(new MoveToDock(self));
 				hasDeliveredLoad = true;
 				return false;
 			}

--- a/OpenRA.Mods.Common/Activities/GenericDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/GenericDockSequence.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
-	public class HarvesterDockSequence : Activity
+	public class GenericDockSequence : Activity
 	{
 		protected enum DockingState { Wait, Drag, Dock, Loop, Undock, Complete }
 
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		bool dockInitiated = false;
 
-		public HarvesterDockSequence(Actor self, Actor refineryActor, Refinery refinery)
+		public GenericDockSequence(Actor self, Actor refineryActor, Refinery refinery)
 		{
 			dockingState = DockingState.Drag;
 			RefineryActor = refineryActor;

--- a/OpenRA.Mods.Common/Activities/HarvestResource.cs
+++ b/OpenRA.Mods.Common/Activities/HarvestResource.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly BodyOrientation body;
 		readonly IMove move;
 		readonly CPos targetCell;
-		readonly INotifyHarvesterAction[] notifyHarvesterActions;
+		readonly INotifyHarvestAction[] notifyHarvestActions;
 
 		public HarvestResource(Actor self, CPos targetCell)
 		{
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Activities
 			claimLayer = self.World.WorldActor.Trait<ResourceClaimLayer>();
 			resourceLayer = self.World.WorldActor.Trait<IResourceLayer>();
 			this.targetCell = targetCell;
-			notifyHarvesterActions = self.TraitsImplementing<INotifyHarvesterAction>().ToArray();
+			notifyHarvestActions = self.TraitsImplementing<INotifyHarvestAction>().ToArray();
 		}
 
 		protected override void OnFirstRun(Actor self)
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Activities
 			// Move towards the target cell
 			if (self.Location != targetCell)
 			{
-				foreach (var n in notifyHarvesterActions)
+				foreach (var n in notifyHarvestActions)
 					n.MovingToResources(self, targetCell);
 
 				QueueChild(move.MoveTo(targetCell, 0));
@@ -89,7 +89,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			harv.AcceptResource(self, resource.Type);
 
-			foreach (var t in notifyHarvesterActions)
+			foreach (var t in notifyHarvestActions)
 				t.Harvested(self, resource.Type);
 
 			QueueChild(new Wait(harvInfo.BaleLoadDelay));
@@ -103,7 +103,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override void Cancel(Actor self, bool keepQueue = false)
 		{
-			foreach (var n in notifyHarvesterActions)
+			foreach (var n in notifyHarvestActions)
 				n.MovementCancelled(self);
 
 			base.Cancel(self, keepQueue);

--- a/OpenRA.Mods.Common/Activities/MoveToDock.cs
+++ b/OpenRA.Mods.Common/Activities/MoveToDock.cs
@@ -22,14 +22,14 @@ namespace OpenRA.Mods.Common.Activities
 		readonly DockClientManager dockClient;
 		Actor dockHostActor;
 		IDockHost dockHost;
-		readonly INotifyHarvesterAction[] notifyHarvesterActions;
+		readonly INotifyDockClientMoving[] notifyDockClientMoving;
 
 		public MoveToDock(Actor self, Actor dockHostActor = null, IDockHost dockHost = null)
 		{
 			dockClient = self.Trait<DockClientManager>();
 			this.dockHostActor = dockHostActor;
 			this.dockHost = dockHost;
-			notifyHarvesterActions = self.TraitsImplementing<INotifyHarvesterAction>().ToArray();
+			notifyDockClientMoving = self.TraitsImplementing<INotifyDockClientMoving>().ToArray();
 		}
 
 		public override bool Tick(Actor self)
@@ -64,8 +64,8 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				if (dockHost.QueueMoveActivity(this, dockHostActor, self, dockClient))
 				{
-					foreach (var n in notifyHarvesterActions)
-						n.MovingToRefinery(self, dockHostActor);
+					foreach (var ndcm in notifyDockClientMoving)
+						ndcm.MovingToDock(self, dockHostActor, dockHost);
 
 					return false;
 				}
@@ -84,8 +84,8 @@ namespace OpenRA.Mods.Common.Activities
 		public override void Cancel(Actor self, bool keepQueue = false)
 		{
 			dockClient.UnreserveHost();
-			foreach (var n in notifyHarvesterActions)
-				n.MovementCancelled(self);
+			foreach (var ndcm in notifyDockClientMoving)
+				ndcm.MovementCancelled(self);
 
 			base.Cancel(self, keepQueue);
 		}

--- a/OpenRA.Mods.Common/Activities/MoveToDock.cs
+++ b/OpenRA.Mods.Common/Activities/MoveToDock.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
-	public class DeliverResources : Activity
+	public class MoveToDock : Activity
 	{
 		readonly IMove movement;
 		readonly Harvester harv;
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		Actor proc;
 
-		public DeliverResources(Actor self, Actor targetActor = null)
+		public MoveToDock(Actor self, Actor targetActor = null)
 		{
 			movement = self.Trait<IMove>();
 			harv = self.Trait<Harvester>();

--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -159,7 +159,7 @@ namespace OpenRA.Mods.Common.Traits
 				harv.Trait.UnlinkProc(harv.Actor, self);
 		}
 
-		public void OnDock(Actor harv, DeliverResources dockOrder)
+		public void OnDock(Actor harv, MoveToDock dockOrder)
 		{
 			if (!preventDock)
 			{

--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -12,32 +12,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Activities;
-using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits.Render;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class RefineryInfo : TraitInfo, Requires<WithSpriteBodyInfo>, IAcceptResourcesInfo
+	public class RefineryInfo : TraitInfo, Requires<WithSpriteBodyInfo>, Requires<IDockHostInfo>
 	{
-		[Desc("Actual harvester facing when docking.")]
-		public readonly WAngle DockAngle = WAngle.Zero;
-
-		[Desc("Docking cell relative to top-left cell.")]
-		public readonly CVec DockOffset = CVec.Zero;
-
-		[Desc("Does the refinery require the harvester to be dragged in?")]
-		public readonly bool IsDragRequired = false;
-
-		[Desc("Vector by which the harvester will be dragged when docking.")]
-		public readonly WVec DragOffset = WVec.Zero;
-
-		[Desc("In how many steps to perform the dragging?")]
-		public readonly int DragLength = 0;
-
 		[Desc("Store resources in silos. Adds cash directly without storing if set to false.")]
 		public readonly bool UseStorage = true;
 
@@ -50,33 +32,16 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Refinery(init.Self, this); }
 	}
 
-	public class Refinery : INotifyCreated, ITick, IAcceptResources, INotifySold, INotifyCapture,
-		INotifyOwnerChanged, ISync, INotifyActorDisposing
+	public class Refinery : IAcceptResources, INotifyCreated, ITick, INotifyOwnerChanged
 	{
-		readonly Actor self;
 		readonly RefineryInfo info;
 		PlayerResources playerResources;
 		IEnumerable<int> resourceValueModifiers;
 
 		int currentDisplayTick = 0;
 		int currentDisplayValue = 0;
-
-		[Sync]
-		Actor dockedHarv = null;
-
-		[Sync]
-		bool preventDock = false;
-
-		public bool AllowDocking => !preventDock;
-		public WPos DeliveryPosition => self.World.Map.CenterOfCell(self.Location + info.DockOffset);
-		public WAngle DeliveryAngle => info.DockAngle;
-		public bool IsDragRequired => info.IsDragRequired;
-		public WVec DragOffset => info.DragOffset;
-		public int DragLength => info.DragLength;
-
 		public Refinery(Actor self, RefineryInfo info)
 		{
-			this.self = self;
 			this.info = info;
 			playerResources = self.Owner.PlayerActor.Trait<PlayerResources>();
 			currentDisplayTick = info.TickRate;
@@ -87,13 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 			resourceValueModifiers = self.TraitsImplementing<IResourceValueModifier>().ToArray().Select(m => m.GetResourceValueModifier());
 		}
 
-		public IEnumerable<TraitPair<Harvester>> GetLinkedHarvesters()
-		{
-			return self.World.ActorsWithTrait<Harvester>()
-				.Where(a => a.Trait.LinkedProc == self);
-		}
-
-		int IAcceptResources.AcceptResources(string resourceType, int count)
+		int IAcceptResources.AcceptResources(Actor self, string resourceType, int count)
 		{
 			if (!playerResources.Info.ResourceValues.TryGetValue(resourceType, out var resourceValue))
 				return 0;
@@ -131,17 +90,8 @@ namespace OpenRA.Mods.Common.Traits
 			return count;
 		}
 
-		void CancelDock()
-		{
-			preventDock = true;
-		}
-
 		void ITick.Tick(Actor self)
 		{
-			// Harvester was killed while unloading
-			if (dockedHarv != null && dockedHarv.IsDead)
-				dockedHarv = null;
-
 			if (info.ShowTicks && currentDisplayValue > 0 && --currentDisplayTick <= 0)
 			{
 				var temp = currentDisplayValue;
@@ -152,49 +102,9 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		void INotifyActorDisposing.Disposing(Actor self)
-		{
-			CancelDock();
-			foreach (var harv in GetLinkedHarvesters())
-				harv.Trait.UnlinkProc(harv.Actor, self);
-		}
-
-		public void OnDock(Actor harv, MoveToDock dockOrder)
-		{
-			if (!preventDock)
-			{
-				dockOrder.QueueChild(new CallFunc(() => dockedHarv = harv, false));
-				dockOrder.QueueChild(new HarvesterDockSequence(harv, self, this));
-				dockOrder.QueueChild(new CallFunc(() => dockedHarv = null, false));
-			}
-		}
-
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
-			// Unlink any harvesters
-			foreach (var harv in GetLinkedHarvesters())
-				harv.Trait.UnlinkProc(harv.Actor, self);
-
 			playerResources = newOwner.PlayerActor.Trait<PlayerResources>();
-		}
-
-		void INotifyCapture.OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner, BitSet<CaptureType> captureTypes)
-		{
-			// Steal any docked harv too
-			if (dockedHarv != null)
-			{
-				dockedHarv.ChangeOwner(newOwner);
-
-				// Relink to this refinery
-				dockedHarv.Trait<Harvester>().LinkProc(self);
-			}
-		}
-
-		void INotifySold.Selling(Actor self) { CancelDock(); }
-		void INotifySold.Sold(Actor self)
-		{
-			foreach (var harv in GetLinkedHarvesters())
-				harv.Trait.UnlinkProc(harv.Actor, self);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -45,8 +45,6 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool DiscardExcessResources = false;
 
 		public readonly bool ShowTicks = true;
-		public readonly int TickLifetime = 30;
-		public readonly int TickVelocity = 2;
 		public readonly int TickRate = 10;
 
 		public override object Create(ActorInitializer init) { return new Refinery(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/CarryableHarvester.cs
+++ b/OpenRA.Mods.Common/Traits/CarryableHarvester.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new CarryableHarvester(); }
 	}
 
-	public class CarryableHarvester : INotifyCreated, INotifyHarvesterAction
+	public class CarryableHarvester : INotifyCreated, INotifyHarvestAction, INotifyDockClientMoving
 	{
 		ICallForTransport[] transports;
 
@@ -28,25 +28,30 @@ namespace OpenRA.Mods.Common.Traits
 			transports = self.TraitsImplementing<ICallForTransport>().ToArray();
 		}
 
-		void INotifyHarvesterAction.MovingToResources(Actor self, CPos targetCell)
+		void INotifyHarvestAction.MovingToResources(Actor self, CPos targetCell)
 		{
 			foreach (var t in transports)
 				t.RequestTransport(self, targetCell);
 		}
 
-		void INotifyHarvesterAction.MovingToRefinery(Actor self, Actor refineryActor)
-		{
-			var dock = refineryActor.Trait<IDockHost>();
-			foreach (var t in transports)
-				t.RequestTransport(self, self.World.Map.CellContaining(dock.DockPosition));
-		}
-
-		void INotifyHarvesterAction.MovementCancelled(Actor self)
+		void INotifyHarvestAction.MovementCancelled(Actor self)
 		{
 			foreach (var t in transports)
 				t.MovementCancelled(self);
 		}
 
-		void INotifyHarvesterAction.Harvested(Actor self, string resourceType) { }
+		void INotifyDockClientMoving.MovingToDock(Actor self, Actor hostActor, IDockHost host)
+		{
+			foreach (var t in transports)
+				t.RequestTransport(self, self.World.Map.CellContaining(host.DockPosition));
+		}
+
+		void INotifyDockClientMoving.MovementCancelled(Actor self)
+		{
+			foreach (var t in transports)
+				t.MovementCancelled(self);
+		}
+
+		void INotifyHarvestAction.Harvested(Actor self, string resourceType) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/CarryableHarvester.cs
+++ b/OpenRA.Mods.Common/Traits/CarryableHarvester.cs
@@ -36,10 +36,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyHarvesterAction.MovingToRefinery(Actor self, Actor refineryActor)
 		{
-			var iao = refineryActor.Trait<IAcceptResources>();
-			var location = self.World.Map.CellContaining(iao.DeliveryPosition);
+			var dock = refineryActor.Trait<IDockHost>();
 			foreach (var t in transports)
-				t.RequestTransport(self, location);
+				t.RequestTransport(self, self.World.Map.CellContaining(dock.DockPosition));
 		}
 
 		void INotifyHarvesterAction.MovementCancelled(Actor self)

--- a/OpenRA.Mods.Common/Traits/DockClientBase.cs
+++ b/OpenRA.Mods.Common/Traits/DockClientBase.cs
@@ -1,0 +1,54 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public abstract class DockClientBaseInfo : ConditionalTraitInfo, IDockClientInfo, Requires<DockClientManagerInfo> { }
+
+	public abstract class DockClientBase<InfoType> : ConditionalTrait<InfoType>, IDockClient, INotifyCreated where InfoType : DockClientBaseInfo
+	{
+		readonly Actor self;
+
+		public abstract BitSet<DockType> GetDockType { get; }
+		public DockClientManager DockClientManager { get; }
+
+		protected DockClientBase(Actor self, InfoType info)
+			: base(info)
+		{
+			this.self = self;
+			DockClientManager = self.Trait<DockClientManager>();
+		}
+
+		protected virtual bool CanDock()
+		{
+			return true;
+		}
+
+		public virtual bool IsDockingPossible(BitSet<DockType> type, bool forceEnter = false)
+		{
+			return !IsTraitDisabled && GetDockType.Overlaps(type) && (forceEnter || CanDock());
+		}
+
+		public virtual bool CanDockAt(Actor hostActor, IDockHost host, bool forceEnter = false, bool ignoreOccupancy = false)
+		{
+			return (forceEnter || self.Owner.IsAlliedWith(hostActor.Owner)) && IsDockingPossible(host.GetDockType, forceEnter) && host.IsDockingPossible(self, this, ignoreOccupancy);
+		}
+
+		public virtual void OnDockStarted(Actor self, Actor hostActor, IDockHost host) { }
+
+		public virtual bool OnDockTick(Actor self, Actor hostActor, IDockHost host) { return false; }
+
+		public virtual void OnDockCompleted(Actor self, Actor hostActor, IDockHost host) { }
+	}
+}

--- a/OpenRA.Mods.Common/Traits/DockClientManager.cs
+++ b/OpenRA.Mods.Common/Traits/DockClientManager.cs
@@ -1,0 +1,334 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Orders;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Manages DockClients on the actor.")]
+	public class DockClientManagerInfo : ConditionalTraitInfo
+	{
+		[Desc("How long (in ticks) to wait until (re-)checking for a nearby available DockHost.")]
+		public readonly int SearchForDockDelay = 125;
+
+		[Desc("The pathfinding cost penalty applied for each dock client waiting to unload at a DockHost.")]
+		public readonly int OccupancyCostModifier = 12;
+
+		[CursorReference]
+		[Desc("Cursor to display when able to dock at target actor.")]
+		public readonly string EnterCursor = "enter";
+
+		[CursorReference]
+		[Desc("Cursor to display when unable to dock at target actor.")]
+		public readonly string EnterBlockedCursor = "enter-blocked";
+
+		[VoiceReference]
+		[Desc("Voice to be played when ordered to dock.")]
+		public readonly string Voice = "Action";
+
+		[Desc("Color to use for the target line of docking orders.")]
+		public readonly Color DockLineColor = Color.Green;
+
+		public override object Create(ActorInitializer init) { return new DockClientManager(init.Self, this); }
+	}
+
+	public class DockClientManager : ConditionalTrait<DockClientManagerInfo>, IResolveOrder, IOrderVoice, IIssueOrder, INotifyKilled, INotifyActorDisposing
+	{
+		readonly Actor self;
+		protected IDockClient[] dockClients;
+		public Color DockLineColor => Info.DockLineColor;
+		public int OccupancyCostModifier => Info.OccupancyCostModifier;
+
+		public DockClientManager(Actor self, DockClientManagerInfo info)
+			: base(info)
+		{
+			this.self = self;
+		}
+
+		protected override void Created(Actor self)
+		{
+			base.Created(self);
+			dockClients = self.TraitsImplementing<IDockClient>().ToArray();
+		}
+
+		public Actor ReservedHostActor { get; protected set; }
+		public IDockHost ReservedHost { get; protected set; }
+
+		IDockHost lastReservedDockHost = null;
+		public IDockHost LastReservedHost
+		{
+			get
+			{
+				if (lastReservedDockHost != null)
+				{
+					if (!lastReservedDockHost.IsEnabledAndInWorld)
+						lastReservedDockHost = null;
+					else
+						return lastReservedDockHost;
+				}
+
+				return ReservedHost;
+			}
+		}
+
+		public void UnreserveHost()
+		{
+			if (ReservedHost != null)
+			{
+				lastReservedDockHost = ReservedHost;
+				ReservedHost = null;
+				ReservedHostActor = null;
+				lastReservedDockHost.Unreserve(this);
+			}
+		}
+
+		/// <summary>In addition returns true if reservation was succesful or we have already been reserved at <paramref name="host"/>.</summary>
+		public bool ReserveHost(Actor hostActor, IDockHost host)
+		{
+			if (host == null)
+				return false;
+
+			if (ReservedHost == host)
+				return true;
+
+			UnreserveHost();
+			if (host.Reserve(hostActor, this))
+			{
+				ReservedHost = host;
+				ReservedHostActor = hostActor;
+
+				// After we have reserved a new Host we want to forget our old host.
+				lastReservedDockHost = null;
+				return true;
+			}
+
+			return false;
+		}
+
+		public void OnDockStarted(Actor self, Actor hostActor, IDockHost host)
+		{
+			foreach (var client in dockClients)
+				client.OnDockStarted(self, hostActor, host);
+		}
+
+		public bool OnDockTick(Actor self, Actor hostActor, IDockHost host)
+		{
+			if (IsTraitDisabled)
+				return true;
+
+			var cancel = true;
+			foreach (var client in dockClients)
+				if (!client.OnDockTick(self, hostActor, host))
+					cancel = false;
+
+			return cancel;
+		}
+
+		public void OnDockCompleted(Actor self, Actor hostActor, IDockHost host)
+		{
+			foreach (var client in dockClients)
+				client.OnDockCompleted(self, hostActor, host);
+
+			UnreserveHost();
+		}
+
+		IEnumerable<IOrderTargeter> IIssueOrder.Orders
+		{
+			get
+			{
+				yield return new EnterAlliedActorTargeter<IDockHostInfo>(
+					"ForceDock",
+					6,
+					Info.EnterCursor,
+					Info.EnterBlockedCursor,
+					DockingPossible,
+					target => CanDockAt(target, true, true));
+				yield return new EnterAlliedActorTargeter<IDockHostInfo>(
+					"Dock",
+					5,
+					Info.EnterCursor,
+					Info.EnterBlockedCursor,
+					(actor, modifiers) => DockingPossible(actor),
+					target => CanDockAt(target, false, true));
+			}
+		}
+
+		void IResolveOrder.ResolveOrder(Actor self, Order order)
+		{
+			if (order.OrderString == "Dock")
+			{
+				var target = order.Target;
+
+				// Deliver orders are only valid for own/allied actors,
+				// which are guaranteed to never be frozen.
+				// TODO: support frozen actors
+				if (target.Type != TargetType.Actor)
+					return;
+
+				if (IsTraitDisabled)
+					return;
+
+				var dock = AvailableDockHosts(target.Actor, false, true).ClosestDock(self, this);
+				if (!dock.HasValue)
+					return;
+
+				self.QueueActivity(order.Queued, new MoveToDock(self, dock.Value.Actor, dock.Value.Trait));
+				self.ShowTargetLines();
+			}
+			else if (order.OrderString == "ForceDock")
+			{
+				var target = order.Target;
+
+				// Deliver orders are only valid for own/allied actors,
+				// which are guaranteed to never be frozen.
+				// TODO: support frozen actors
+				if (target.Type != TargetType.Actor)
+					return;
+
+				if (IsTraitDisabled)
+					return;
+
+				var dock = AvailableDockHosts(target.Actor, true, true).ClosestDock(self, this);
+				if (!dock.HasValue)
+					return;
+
+				self.QueueActivity(order.Queued, new MoveToDock(self, dock.Value.Actor, dock.Value.Trait));
+				self.ShowTargetLines();
+			}
+		}
+
+		string IOrderVoice.VoicePhraseForOrder(Actor self, Order order)
+		{
+			if (order.Target.Type != TargetType.Actor || IsTraitDisabled)
+				return null;
+
+			if (order.OrderString == "Dock" && CanDockAt(order.Target.Actor, false, true))
+				return Info.Voice;
+			else if (order.OrderString == "ForceDock" && CanDockAt(order.Target.Actor, true, true))
+				return Info.Voice;
+
+			return null;
+		}
+
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
+		{
+			if (order.OrderID == "Dock" || order.OrderID == "ForceDock")
+				return new Order(order.OrderID, self, target, queued);
+
+			return null;
+		}
+
+		/// <summary>Do we have an enabled client with matching <paramref name="type"/>.</summary>
+		public bool DockingPossible(BitSet<DockType> type, bool forceEnter = false)
+		{
+			return !IsTraitDisabled && dockClients.Any(client => client.IsDockingPossible(type, forceEnter));
+		}
+
+		/// <summary>Does this <paramref name="target"/> contain at least one enabled <see cref="IDockHost"/> with maching <see cref="DockType"/>.</summary>
+		public bool DockingPossible(Actor target)
+		{
+			return !IsTraitDisabled && target.TraitsImplementing<IDockHost>().Any(host => dockClients.Any(client => client.IsDockingPossible(host.GetDockType)));
+		}
+
+		/// <summary>Does this <paramref name="target"/> contain at least one enabled <see cref="IDockHost"/> with maching <see cref="DockType"/>.</summary>
+		public bool DockingPossible(Actor target, TargetModifiers modifiers)
+		{
+			var forceEnter = modifiers.HasModifier(TargetModifiers.ForceMove);
+			return !IsTraitDisabled && target.TraitsImplementing<IDockHost>().Any(host => dockClients.Any(client => client.IsDockingPossible(host.GetDockType, forceEnter)));
+		}
+
+		/// <summary>Can we dock to this <paramref name="host"/>.</summary>
+		public bool CanDockAt(Actor hostActor, IDockHost host, bool forceEnter = false, bool ignoreOccupancy = false)
+		{
+			return !IsTraitDisabled && dockClients.Any(client => client.CanDockAt(hostActor, host, forceEnter, ignoreOccupancy));
+		}
+
+		/// <summary>Can we dock to this <paramref name="target"/>.</summary>
+		public bool CanDockAt(Actor target, bool forceEnter = false, bool ignoreOccupancy = false)
+		{
+			return !IsTraitDisabled && target.TraitsImplementing<IDockHost>().Any(host => dockClients.Any(client => client.CanDockAt(target, host, forceEnter, ignoreOccupancy)));
+		}
+
+		/// <summary>Find the closest viable <see cref="IDockHost"/>.</summary>
+		/// <remarks>If <paramref name="type"/> is not set, scans all clients. Does not check if <see cref="DockClientManager"/> is enabled.</remarks>
+		public TraitPair<IDockHost>? ClosestDock(IDockHost ignore, BitSet<DockType> type = default, bool forceEnter = false, bool ignoreOccupancy = false)
+		{
+			var clients = type.IsEmpty ? dockClients : AvailableDockClients(type);
+			return self.World.ActorsWithTrait<IDockHost>()
+				.Where(host => host.Trait != ignore && clients.Any(client => client.CanDockAt(host.Actor, host.Trait, forceEnter, ignoreOccupancy)))
+				.ClosestDock(self, this);
+		}
+
+		/// <summary>Get viable <see cref="IDockHost"/>'s on the <paramref name="target"/>.</summary>
+		/// <remarks>Does not check if <see cref="DockClientManager"/> is enabled.</remarks>
+		public IEnumerable<TraitPair<IDockHost>> AvailableDockHosts(Actor target, bool forceEnter = false, bool ignoreOccupancy = false)
+		{
+			return target.TraitsImplementing<IDockHost>()
+				.Where(host => dockClients.Any(client => client.CanDockAt(target, host, forceEnter, ignoreOccupancy)))
+				.Select(host => new TraitPair<IDockHost>(target, host));
+		}
+
+		/// <summary>Get clients of matching <paramref name="type"/>.</summary>
+		/// <remarks>Does not check if <see cref="DockClientManager"/> is enabled.</remarks>
+		public IEnumerable<IDockClient> AvailableDockClients(BitSet<DockType> type)
+		{
+			return dockClients.Where(client => client.IsDockingPossible(type));
+		}
+
+		void INotifyKilled.Killed(Actor self, AttackInfo e) { UnreserveHost(); }
+
+		void INotifyActorDisposing.Disposing(Actor self) { UnreserveHost(); }
+	}
+
+	public static class DockExts
+	{
+		public static TraitPair<IDockHost>? ClosestDock(this IEnumerable<TraitPair<IDockHost>> docks, Actor clientActor, DockClientManager client)
+		{
+			var mobile = clientActor.TraitOrDefault<Mobile>();
+			if (mobile != null)
+			{
+				// Overlapping docks can become hidden.
+				var lookup = docks.ToDictionary(dock => clientActor.World.Map.CellContaining(dock.Trait.DockPosition));
+
+				// Start a search from each docks position:
+				var path = mobile.PathFinder.FindPathToTargetCell(
+					clientActor, lookup.Keys, clientActor.Location, BlockedByActor.None,
+					location =>
+					{
+						if (!lookup.ContainsKey(location))
+							return 0;
+
+						var dock = lookup[location];
+
+						// Prefer docks with less occupancy (multiplier is to offset distance cost):
+						// TODO: add custom wieghts. E.g. owner vs allied.
+						return dock.Trait.ReservationCount * client.OccupancyCostModifier;
+					});
+
+				if (path.Count > 0)
+					return lookup[path.Last()];
+			}
+			else
+			{
+				return docks
+					.OrderBy(dock => (clientActor.Location - clientActor.World.Map.CellContaining(dock.Trait.DockPosition)).LengthSquared + dock.Trait.ReservationCount * client.OccupancyCostModifier)
+					.FirstOrDefault();
+			}
+
+			return null;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/DockHost.cs
+++ b/OpenRA.Mods.Common/Traits/DockHost.cs
@@ -1,0 +1,183 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+using System.Collections.Generic;
+using OpenRA.Activities;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public sealed class DockType { DockType() { } }
+
+	[Desc("A generic dock that services DockClients.")]
+	public class DockHostInfo : ConditionalTraitInfo, IDockHostInfo
+	{
+		[Desc("Docking type.")]
+		public readonly BitSet<DockType> Type;
+
+		[Desc("How many clients can this dock be reserved for?")]
+		public readonly int MaxQueueLength = 3;
+
+		[Desc("How long should the client wait before starting the docking sequence.")]
+		public readonly int DockWait = 10;
+
+		[Desc("Actual client facing when docking.")]
+		public readonly WAngle DockAngle = WAngle.Zero;
+
+		[Desc("Docking cell relative to the centre of the actor.")]
+		public readonly WVec DockOffset = WVec.Zero;
+
+		[Desc("Does client need to be dragged in?")]
+		public readonly bool IsDragRequired = false;
+
+		[Desc("Vector by which the client will be dragged when docking.")]
+		public readonly WVec DragOffset = WVec.Zero;
+
+		[Desc("In how many steps to perform the dragging?")]
+		public readonly int DragLength = 0;
+
+		public override object Create(ActorInitializer init) { return new DockHost(init.Self, this); }
+	}
+
+	public class DockHost : ConditionalTrait<DockHostInfo>, IDockHost, IDockHostDrag, ITick, INotifySold, INotifyCapture, INotifyOwnerChanged, ISync, INotifyKilled, INotifyActorDisposing
+	{
+		readonly Actor self;
+
+		public BitSet<DockType> GetDockType => Info.Type;
+		public bool IsEnabledAndInWorld => !preventDock && !IsTraitDisabled && !self.IsDead && self.IsInWorld;
+		public int ReservationCount => ReservedDockClients.Count;
+		public bool CanBeReserved => ReservationCount < Info.MaxQueueLength;
+		protected readonly List<DockClientManager> ReservedDockClients = new();
+
+		public WPos DockPosition => self.CenterPosition + Info.DockOffset;
+		public int DockWait => Info.DockWait;
+		public WAngle DockAngle => Info.DockAngle;
+
+		bool IDockHostDrag.IsDragRequired => Info.IsDragRequired;
+		WVec IDockHostDrag.DragOffset => Info.DragOffset;
+		int IDockHostDrag.DragLength => Info.DragLength;
+
+		[Sync]
+		bool preventDock = false;
+
+		[Sync]
+		protected Actor dockedClientActor = null;
+		protected DockClientManager dockedClient = null;
+
+		public DockHost(Actor self, DockHostInfo info)
+			: base(info)
+		{
+			this.self = self;
+		}
+
+		public virtual bool IsDockingPossible(Actor clientActor, IDockClient client, bool ignoreReservations = false)
+		{
+			return !IsTraitDisabled && (ignoreReservations || CanBeReserved || ReservedDockClients.Contains(client.DockClientManager));
+		}
+
+		public virtual bool Reserve(Actor self, DockClientManager client)
+		{
+			if (CanBeReserved && !ReservedDockClients.Contains(client))
+			{
+				ReservedDockClients.Add(client);
+				client.ReserveHost(self, this);
+				return true;
+			}
+
+			return false;
+		}
+
+		public virtual void UnreserveAll()
+		{
+			while (ReservedDockClients.Count > 0)
+				Unreserve(ReservedDockClients[0]);
+		}
+
+		public virtual void Unreserve(DockClientManager client)
+		{
+			if (ReservedDockClients.Contains(client))
+			{
+				ReservedDockClients.Remove(client);
+				client.UnreserveHost();
+			}
+		}
+
+		public virtual void OnDockStarted(Actor self, Actor clientActor, DockClientManager client)
+		{
+			dockedClientActor = clientActor;
+			dockedClient = client;
+		}
+
+		public virtual void OnDockCompleted(Actor self, Actor clientActor, DockClientManager client)
+		{
+			dockedClientActor = null;
+			dockedClient = null;
+		}
+
+		void ITick.Tick(Actor self)
+		{
+			Tick(self);
+		}
+
+		protected virtual void Tick(Actor self)
+		{
+			// Client was killed during docking.
+			if (dockedClientActor != null && (dockedClientActor.IsDead || !dockedClientActor.IsInWorld))
+				OnDockCompleted(self, dockedClientActor, dockedClient);
+		}
+
+		public virtual bool QueueMoveActivity(Activity moveToDockActivity, Actor self, Actor clientActor, DockClientManager client)
+		{
+			var move = clientActor.Trait<IMove>();
+
+			// Make sure the actor is at dock, at correct facing, and aircraft are landed.
+			// Mobile cannot freely move in WPos, so when we calculate close enough we convert to CPos.
+			if ((move is Mobile ? clientActor.Location != clientActor.World.Map.CellContaining(DockPosition) : clientActor.CenterPosition != DockPosition)
+				|| move is not IFacing facing || facing.Facing != DockAngle)
+			{
+				moveToDockActivity.QueueChild(move.MoveOntoTarget(clientActor, Target.FromActor(self), DockPosition - self.CenterPosition, DockAngle));
+				return true;
+			}
+
+			return false;
+		}
+
+		public virtual void QueueDockActivity(Activity moveToDockActivity, Actor self, Actor clientActor, DockClientManager client)
+		{
+			moveToDockActivity.QueueChild(new GenericDockSequence(clientActor, client, self, this));
+		}
+
+		protected override void TraitDisabled(Actor self) { UnreserveAll(); }
+
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner) { UnreserveAll(); }
+
+		void INotifyCapture.OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner, BitSet<CaptureType> captureTypes)
+		{
+			// Steal any docked unit too.
+			if (dockedClientActor != null && !dockedClientActor.IsDead && dockedClientActor.IsInWorld)
+			{
+				dockedClientActor.ChangeOwner(newOwner);
+
+				// On capture OnOwnerChanged event is called first, so we need to re-reserve.
+				dockedClient.ReserveHost(self, this);
+			}
+		}
+
+		void INotifySold.Selling(Actor self) { preventDock = true; }
+
+		void INotifySold.Sold(Actor self) { UnreserveAll(); }
+
+		void INotifyKilled.Killed(Actor self, AttackInfo e) { UnreserveAll(); }
+
+		void INotifyActorDisposing.Disposing(Actor self) { preventDock = true; UnreserveAll(); }
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithHarvestAnimation(init, this); }
 	}
 
-	public class WithHarvestAnimation : INotifyHarvesterAction
+	public class WithHarvestAnimation : INotifyHarvestAction
 	{
 		public readonly WithHarvestAnimationInfo Info;
 		readonly WithSpriteBody wsb;
@@ -37,15 +37,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 			wsb = init.Self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == Info.Body);
 		}
 
-		void INotifyHarvesterAction.Harvested(Actor self, string resourceType)
+		void INotifyHarvestAction.Harvested(Actor self, string resourceType)
 		{
 			var sequence = wsb.NormalizeSequence(self, Info.HarvestSequence);
 			if (wsb.DefaultAnimation.HasSequence(sequence) && wsb.DefaultAnimation.CurrentSequence.Name != sequence)
 				wsb.PlayCustomAnimation(self, sequence);
 		}
 
-		void INotifyHarvesterAction.MovingToResources(Actor self, CPos targetCell) { }
-		void INotifyHarvesterAction.MovingToRefinery(Actor self, Actor refineryActor) { }
-		void INotifyHarvesterAction.MovementCancelled(Actor self) { }
+		void INotifyHarvestAction.MovingToResources(Actor self, CPos targetCell) { }
+		void INotifyHarvestAction.MovementCancelled(Actor self) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithHarvestOverlay(init.Self, this); }
 	}
 
-	sealed class WithHarvestOverlay : INotifyHarvesterAction
+	sealed class WithHarvestOverlay : INotifyHarvestAction
 	{
 		readonly WithHarvestOverlayInfo info;
 		readonly Animation anim;
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				p => ZOffsetFromCenter(self, p, 0)), info.Palette);
 		}
 
-		void INotifyHarvesterAction.Harvested(Actor self, string resourceType)
+		void INotifyHarvestAction.Harvested(Actor self, string resourceType)
 		{
 			if (visible)
 				return;
@@ -63,9 +63,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 			anim.PlayThen(info.Sequence, () => visible = false);
 		}
 
-		void INotifyHarvesterAction.MovingToResources(Actor self, CPos targetCell) { }
-		void INotifyHarvesterAction.MovingToRefinery(Actor self, Actor targetRefinery) { }
-		void INotifyHarvesterAction.MovementCancelled(Actor self) { }
+		void INotifyHarvestAction.MovingToResources(Actor self, CPos targetCell) { }
+		void INotifyHarvestAction.MovementCancelled(Actor self) { }
 
 		public static int ZOffsetFromCenter(Actor self, WPos pos, int offset)
 		{

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -283,7 +283,7 @@ namespace OpenRA.Mods.Common.Traits
 	public interface IAcceptResourcesInfo : ITraitInfoInterface { }
 	public interface IAcceptResources
 	{
-		void OnDock(Actor harv, DeliverResources dockOrder);
+		void OnDock(Actor harv, MoveToDock dockOrder);
 		int AcceptResources(string resourceType, int count = 1);
 		WPos DeliveryPosition { get; }
 		WAngle DeliveryAngle { get; }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -171,6 +171,13 @@ namespace OpenRA.Mods.Common.Traits
 	public interface INotifyDockClient { void Docked(Actor self, Actor host); void Undocked(Actor self, Actor host); }
 
 	[RequireExplicitImplementation]
+	public interface INotifyDockClientMoving
+	{
+		void MovingToDock(Actor self, Actor hostActor, IDockHost host);
+		void MovementCancelled(Actor self);
+	}
+
+	[RequireExplicitImplementation]
 	public interface INotifyResourceAccepted { void OnResourceAccepted(Actor self, Actor refinery, string resourceType, int count, int value); }
 	public interface INotifyParachute { void OnParachute(Actor self); void OnLanded(Actor self); }
 
@@ -202,12 +209,11 @@ namespace OpenRA.Mods.Common.Traits
 	[RequireExplicitImplementation]
 	public interface INotifyExitedCargo { void OnExitedCargo(Actor self, Actor cargo); }
 
-	public interface INotifyHarvesterAction
+	public interface INotifyHarvestAction
 	{
-		void MovingToResources(Actor self, CPos targetCell);
-		void MovingToRefinery(Actor self, Actor refineryActor);
-		void MovementCancelled(Actor self);
 		void Harvested(Actor self, string resourceType);
+		void MovingToResources(Actor self, CPos targetCell);
+		void MovementCancelled(Actor self);
 	}
 
 	public interface IDockClientInfo : ITraitInfoInterface { }

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230801/AbstractDocking.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230801/AbstractDocking.cs
@@ -1,0 +1,166 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class AbstractDocking : UpdateRule, IBeforeUpdateActors
+	{
+		readonly string[] moveRefineyValues = { "DockAngle", "IsDragRequired", "DragOffset", "DragLength" };
+		readonly string[] moveHarvesterValues = { "EnterCursor", "EnterBlockedCursor" };
+		readonly string[] buildings = { "Building", "D2kBuilding" };
+		readonly string[,] moveAndRenameHarvesterValues = new string[4, 2]
+		{
+			{ "DeliverVoice", "Voice" },
+			{ "DeliverLineColor", "DockLineColor" },
+			{ "UnloadQueueCostModifier", "OccupancyCostModifier" },
+			{ "SearchForDeliveryBuildingDelay", "SearchForDockDelay" }
+		};
+
+		readonly Dictionary<string, List<MiniYamlNodeBuilder>> refineryNodes = new();
+		public override string Name => "Docking was abstracted from Refinery & Harvester.";
+
+		public override string Description =>
+			"Fields moved from Refinery to new trait DockHost, fields moved from Harvester to new trait DockClientManager and to DockHost";
+
+		public IEnumerable<string> BeforeUpdateActors(ModData modData, List<MiniYamlNodeBuilder> resolvedActors)
+		{
+			grid = modData.Manifest.Get<MapGrid>();
+			var harvesters = new Dictionary<string, HashSet<string>>();
+			var refineries = new List<string>();
+			foreach (var actorNode in resolvedActors)
+			{
+				var harvesterNode = actorNode.ChildrenMatching("Harvester", includeRemovals: false).FirstOrDefault();
+				if (harvesterNode != null)
+					harvesters[actorNode.Key] = harvesterNode.ChildrenMatching("DeliveryBuildings", includeRemovals: false)
+						.FirstOrDefault()?.NodeValue<HashSet<string>>() ?? new HashSet<string>();
+
+				if (actorNode.ChildrenMatching("Refinery", includeRemovals: false).FirstOrDefault() != null)
+					refineries.Add(actorNode.Key.ToLowerInvariant());
+			}
+
+			foreach (var harvester in harvesters)
+			{
+				foreach (var deliveryBuildingHigh in harvester.Value)
+				{
+					var deliveryBuilding = deliveryBuildingHigh.ToLowerInvariant();
+					foreach (var refinery in refineries)
+					{
+						if (refinery == deliveryBuilding)
+						{
+							if (!refineryNodes.ContainsKey(refinery))
+								refineryNodes[refinery] = new List<MiniYamlNodeBuilder>();
+
+							var node = new MiniYamlNodeBuilder("Type", deliveryBuilding.ToString());
+							if (!refineryNodes[refinery].Any(n => n.Key == node.Key))
+								refineryNodes[refinery].Add(node);
+						}
+					}
+				}
+			}
+
+			yield break;
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
+		{
+			var refineryNode = actorNode.ChildrenMatching("Refinery", includeRemovals: false).FirstOrDefault();
+			if (refineryNode != null)
+			{
+				var dockNode = new MiniYamlNodeBuilder("DockHost", "");
+
+				var lowActorName = actorNode.Key.ToLowerInvariant();
+				if (!refineryNodes.ContainsKey(lowActorName) || !refineryNodes[lowActorName].Any(n => n.Key == "Type"))
+					dockNode.AddNode("Type", "Unload");
+				else
+					dockNode.AddNode(refineryNodes[lowActorName].First(n => n.Key == "Type"));
+
+				foreach (var value in moveRefineyValues)
+				{
+					foreach (var node in refineryNode.ChildrenMatching(value).ToList())
+					{
+						dockNode.AddNode(node);
+						refineryNode.RemoveNode(node);
+					}
+				}
+
+				var oldOffset = CVec.Zero;
+				var dockOffsetNode = refineryNode.ChildrenMatching("DockOffset", includeRemovals: false).FirstOrDefault();
+				if (dockOffsetNode != null)
+				{
+					oldOffset = dockOffsetNode.NodeValue<CVec>();
+					refineryNode.RemoveNode(dockOffsetNode);
+				}
+
+				var buildingNode = actorNode.Value.Nodes.FirstOrDefault(n => buildings.Any(b => n.KeyMatches(b, includeRemovals: false)));
+				if (buildingNode != null)
+				{
+					var dimensions = buildingNode.ChildrenMatching("Dimensions", includeRemovals: false).FirstOrDefault()?.NodeValue<CVec>() ?? new CVec(1, 1);
+					var localCenterOffset = buildingNode.ChildrenMatching("LocalCenterOffset", includeRemovals: false).FirstOrDefault()?.NodeValue<WVec>() ?? WVec.Zero;
+
+					var offset = CenterOfCell(oldOffset) - CenterOfCell(CVec.Zero) - BuildingCenter(dimensions, localCenterOffset);
+					if (offset != WVec.Zero)
+						dockNode.AddNode("DockOffset", offset);
+				}
+
+				actorNode.AddNode(dockNode);
+			}
+
+			var harvesterNode = actorNode.ChildrenMatching("Harvester", includeRemovals: false).FirstOrDefault();
+			if (harvesterNode != null)
+			{
+				var dockClientNode = new MiniYamlNodeBuilder("DockClientManager", "");
+
+				foreach (var value in moveHarvesterValues)
+				{
+					foreach (var node in harvesterNode.ChildrenMatching(value).ToList())
+					{
+						dockClientNode.AddNode(node);
+						harvesterNode.RemoveNode(node);
+					}
+				}
+
+				for (var i = 0; i < moveAndRenameHarvesterValues.GetLength(0); i++)
+				{
+					foreach (var node in harvesterNode.ChildrenMatching(moveAndRenameHarvesterValues[i, 0]).ToList())
+					{
+						harvesterNode.RemoveNode(node);
+						node.RenameKey(moveAndRenameHarvesterValues[i, 1]);
+						dockClientNode.AddNode(node);
+					}
+				}
+
+				harvesterNode.RenameChildrenMatching("DeliveryBuildings", "DockType");
+				harvesterNode.RemoveNodes("MaxUnloadQueue");
+
+				actorNode.AddNode(dockClientNode);
+			}
+
+			yield break;
+		}
+
+		MapGrid grid;
+		public WVec CenterOfCell(CVec cell)
+		{
+			if (grid.Type == MapGridType.Rectangular)
+				return new WVec(1024 * cell.X + 512, 1024 * cell.Y + 512, 0);
+
+			return new WVec(724 * (cell.X - cell.Y + 1), 724 * (cell.X + cell.Y + 1), 0);
+		}
+
+		public WVec BuildingCenter(CVec dimensions, WVec localCenterOffset)
+		{
+			return (CenterOfCell(dimensions) - CenterOfCell(new CVec(1, 1))) / 2 + localCenterOffset;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -88,9 +88,8 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new UnhardcodeBaseBuilderBotModule(),
 			}),
 
-			new UpdatePath("release-20230225", new UpdateRule[]
+			new UpdatePath("release-20230225", "playtest-20230801", new UpdateRule[]
 			{
-				// bleed only changes here
 				new TextNotificationsDisplayWidgetRemoveTime(),
 				new RenameEngineerRepair(),
 				new ProductionTabsWidgetAddTabButtonCollection(),
@@ -104,7 +103,15 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new ExplicitSequenceFilenames(),
 				new RemoveSequenceHasEmbeddedPalette(),
 				new RemoveNegativeSequenceLength(),
-			})
+			}),
+
+			new UpdatePath("playtest-20230801", new UpdateRule[]
+			{
+				// bleed only changes here.
+
+				// Execute these rules last to avoid premature yaml merge crashes.
+				new AbstractDocking(),
+			}),
 		};
 
 		public static IEnumerable<UpdateRule> FromSource(ObjectCreator objectCreator, string source, bool chain = true)

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -239,12 +239,14 @@ PROC:
 	RevealsShroud:
 		Range: 6c0
 	Refinery:
+		TickRate: 15
+	DockHost:
+		Type: Unload
 		DockAngle: 448
-		DockOffset: 0,2
+		DockOffset: -1c0, 1c0, 0
 		IsDragRequired: True
 		DragOffset: -554,512,0
 		DragLength: 12
-		TickRate: 15
 	StoresResources:
 		Capacity: 1000
 	Selectable:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -63,6 +63,7 @@ HARV:
 		SearchFromHarvesterRadius: 8
 		HarvestFacings: 8
 		EmptyCondition: no-tiberium
+	DockClientManager:
 	Mobile:
 		Speed: 72
 	Health:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -282,9 +282,11 @@ refinery:
 	RevealsShroud:
 		Range: 3c768
 	Refinery:
-		DockAngle: 640
-		DockOffset: 2,1
 		TickRate: 20
+	DockHost:
+		Type: Unload
+		DockAngle: 640
+		DockOffset: 1c0,512,0
 	StoresResources:
 		Capacity: 2000
 	CustomSellValue:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -76,6 +76,7 @@ harvester:
 		BaleUnloadDelay: 5
 		SearchFromProcRadius: 30
 		SearchFromHarvesterRadius: 15
+	DockClientManager:
 	CarryableHarvester:
 	Health:
 		HP: 45000

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1287,8 +1287,10 @@ PROC:
 	RevealsShroud@GAPGEN:
 		Range: 4c0
 	Refinery:
+	DockHost:
+		Type: Unload
 		DockAngle: 256
-		DockOffset: 1,2
+		DockOffset: 0, 1c0, 0
 	StoresResources:
 		Capacity: 2000
 	CustomSellValue:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -327,6 +327,7 @@ HARV:
 		SearchFromHarvesterRadius: 8
 		HarvestFacings: 8
 		EmptyCondition: no-ore
+	DockClientManager:
 	Health:
 		HP: 60000
 	Armor:

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -589,8 +589,10 @@ NAWAST:
 		Range: 6c0
 		MaxHeightDelta: 3
 	Refinery:
+	DockHost:
+		Type: UnloadWeed
 		DockAngle: 640
-		DockOffset: 2,1
+		DockOffset: 724,724,0
 	StoresResources:
 		Capacity: 56
 	Power:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -351,7 +351,7 @@ WEED:
 		Prerequisites: ~naweap, nawast, ~techlevel.superweapons
 		Description: Collects veins for processing.\n  Unarmed
 	Harvester:
-		DeliveryBuildings: nawast
+		Type: UnloadWeed
 		Capacity: 7
 		Resources: Veins
 		BaleUnloadDelay: 20
@@ -359,7 +359,8 @@ WEED:
 		SearchFromProcRadius: 72
 		SearchFromHarvesterRadius: 36
 		HarvestVoice: Attack
-		DeliverVoice: Move
+	DockClientManager:
+		Voice: Move
 	Mobile:
 		Speed: 71
 		TurnSpeed: 20

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -120,9 +120,11 @@ PROC:
 		Range: 6c0
 		MaxHeightDelta: 3
 	Refinery:
-		DockAngle: 640
-		DockOffset: 2,1
 		DiscardExcessResources: true
+	DockHost:
+		Type: Unload
+		DockAngle: 640
+		DockOffset: 362,362,0
 	StoresResources:
 		Capacity: 2000
 	CustomSellValue:

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -59,7 +59,6 @@ HARV:
 		Bounds: 1086, 2172
 		DecorationBounds: 1086, 2172
 	Harvester:
-		DeliveryBuildings: proc
 		Capacity: 28
 		Resources: Tiberium, BlueTiberium
 		BaleLoadDelay: 15
@@ -68,8 +67,9 @@ HARV:
 		SearchFromProcRadius: 36
 		SearchFromHarvesterRadius: 18
 		HarvestVoice: Attack
-		DeliverVoice: Move
 		EmptyCondition: no-tiberium
+	DockClientManager:
+		Voice: Move
 	Mobile:
 		Speed: 71
 	Health:


### PR DESCRIPTION
Closes #20288
Closes #16464
Split from #20168
Supersedes #20181

Replaced search by actor name to search by `BitSet<DockType>`
Linking refactored and renamed to reserving
Abstracted `DockHost` : `IDockHost` from `Refinery`
Abstracted `DockClientBase<>` : `IDockClient` and `DockClientManager` from `Harvester`
Abstracted `INotifyDockClientMoving` from `INotifyHarvesterAction`

There are still a lot of features than need to be added to this codebase for it to be able to absorb Rearm / Repair docking.

I advise to review commit by commit as git diff doesn't deal with file renames well