### PR TITLE
Reduce impact of max order length checks

### DIFF
--- a/OpenRA.Game/Server/Connection.cs
+++ b/OpenRA.Game/Server/Connection.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Server
 									frame = BitConverter.ToInt32(bytes, 4);
 									state = ReceiveState.Data;
 
-									if (expectLength < 0 || expectLength > MaxOrderLength)
+									if (expectLength < 0 || (server.Type != ServerType.Local && expectLength > MaxOrderLength))
 									{
 										Log.Write("server", $"Closing socket connection to {EndPoint} because of excessive order length: {expectLength}");
 										return;


### PR DESCRIPTION
This PR adds ~~two~~ one simple workaround~~s~~ to reduce the chances of #19849 occurring.

The ~~first commit raises the limit by a factor of 4 for MP games, and the second~~ commit removes the limit completely for skirmish.