### PR TITLE
Fix an NRE in ConnectionLogic and throw an ArgumentException when trying to translate null keys

### DIFF
--- a/OpenRA.Game/Translation.cs
+++ b/OpenRA.Game/Translation.cs
@@ -88,6 +88,9 @@ namespace OpenRA
 
 		public bool TryGetString(string key, out string value, IDictionary<string, object> arguments = null)
 		{
+			if (string.IsNullOrEmpty(key))
+				throw new ArgumentException("A translation key must not be null or empty.", nameof(key));
+
 			try
 			{
 				if (!HasMessage(key))

--- a/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
@@ -124,7 +124,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			widget.Get<LabelWidget>("CONNECTING_DESC").GetText = () => connectingDescText;
 
 			var connectionError = widget.Get<LabelWidget>("CONNECTION_ERROR");
-			var connectionErrorText = modData.Translation.GetString(orderManager.ServerError) ?? connection.ErrorMessage ?? modData.Translation.GetString(UnknownError);
+			var connectionErrorText = orderManager.ServerError != null ? modData.Translation.GetString(orderManager.ServerError) : connection.ErrorMessage ?? modData.Translation.GetString(UnknownError);
 			connectionError.GetText = () => connectionErrorText;
 
 			var panelTitle = widget.Get<LabelWidget>("TITLE");


### PR DESCRIPTION
Reported by @penev92 on Discord. We might have more cases, but throwing here is Imho better and cleaner than causing an exception inside the Linguini library.