### PR TITLE
Add a Lua function to concat two tables and fix IdlingUnits definitions for multiple reinforcements

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Global/UtilsGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/UtilsGlobal.cs
@@ -85,6 +85,20 @@ namespace OpenRA.Mods.Common.Scripting
 			return t;
 		}
 
+		[Desc("Concatenates two Lua tables into a single table.")]
+		public LuaTable Concat(LuaValue[] firstCollection, LuaValue[] secondCollection)
+		{
+			var t = Context.CreateTable();
+
+			foreach (var e in firstCollection)
+				t.Add(t.Count + 1, e);
+
+			foreach (var e in secondCollection)
+				t.Add(t.Count + 1, e);
+
+			return t;
+		}
+
 		[Desc("Returns a random value from a collection.")]
 		public LuaValue Random(LuaValue[] collection)
 		{

--- a/mods/d2k/maps/harkonnen-04/harkonnen04-AI.lua
+++ b/mods/d2k/maps/harkonnen-04/harkonnen04-AI.lua
@@ -27,7 +27,7 @@ AtreidesTankType = { "combat_tank_a" }
 
 ActivateAI = function()
 	IdlingUnits[Fremen] = { }
-	IdlingUnits[Atreides] = Reinforcements.Reinforce(Atreides, InitialAtreidesReinforcements[1], AtreidesPaths[2]), Reinforcements.Reinforce(Atreides, InitialAtreidesReinforcements[2], AtreidesPaths[3])
+	IdlingUnits[Atreides] = Utils.Concat(Reinforcements.Reinforce(Atreides, InitialAtreidesReinforcements[1], AtreidesPaths[2]), Reinforcements.Reinforce(Atreides, InitialAtreidesReinforcements[2], AtreidesPaths[3]))
 	FremenProduction()
 
 	DefendAndRepairBase(Atreides, AtreidesBase, 0.75, AttackGroupSize[Difficulty])

--- a/mods/d2k/maps/harkonnen-05/harkonnen05-AI.lua
+++ b/mods/d2k/maps/harkonnen-05/harkonnen05-AI.lua
@@ -26,7 +26,7 @@ OrdosVehicleTypes = { "raider", "raider", "quad" }
 OrdosTankType = { "combat_tank_o" }
 
 ActivateAI = function()
-	IdlingUnits[OrdosMain] = Reinforcements.Reinforce(OrdosMain, InitialOrdosReinforcements[1], InitialOrdosPaths[1]), Reinforcements.Reinforce(OrdosMain, InitialOrdosReinforcements[2], InitialOrdosPaths[2])
+	IdlingUnits[OrdosMain] = Utils.Concat(Reinforcements.Reinforce(OrdosMain, InitialOrdosReinforcements[1], InitialOrdosPaths[1]), Reinforcements.Reinforce(OrdosMain, InitialOrdosReinforcements[2], InitialOrdosPaths[2]))
 	IdlingUnits[OrdosSmall] = Reinforcements.Reinforce(OrdosSmall, InitialOrdosReinforcements[1], InitialOrdosPaths[3])
 	IdlingUnits[Corrino] = { CSaraukar1, CSaraukar2, CSaraukar3, CSaraukar4, CSaraukar5 }
 

--- a/mods/d2k/maps/harkonnen-06a/harkonnen06a-AI.lua
+++ b/mods/d2k/maps/harkonnen-06a/harkonnen06a-AI.lua
@@ -27,7 +27,7 @@ OrdosTankTypes = { "combat_tank_o", "combat_tank_o", "siege_tank" }
 OrdosStarportTypes = { "trike.starport", "trike.starport", "quad.starport", "combat_tank_o.starport", "combat_tank_o.starport", "siege_tank.starport", "missile_tank.starport" }
 
 ActivateAI = function()
-	IdlingUnits[OrdosMain] = Reinforcements.Reinforce(OrdosMain, InitialOrdosReinforcements[1], InitialOrdosPaths[1]), Reinforcements.Reinforce(OrdosMain, InitialOrdosReinforcements[2], InitialOrdosPaths[2])
+	IdlingUnits[OrdosMain] = Utils.Concat(Reinforcements.Reinforce(OrdosMain, InitialOrdosReinforcements[1], InitialOrdosPaths[1]), Reinforcements.Reinforce(OrdosMain, InitialOrdosReinforcements[2], InitialOrdosPaths[2]))
 	IdlingUnits[OrdosSmall] = Reinforcements.Reinforce(OrdosSmall, InitialOrdosReinforcements[1], InitialOrdosPaths[3])
 
 	DefendAndRepairBase(OrdosMain, OrdosMainBase, 0.75, AttackGroupSize[Difficulty])

--- a/mods/d2k/maps/harkonnen-06b/harkonnen06b-AI.lua
+++ b/mods/d2k/maps/harkonnen-06b/harkonnen06b-AI.lua
@@ -27,7 +27,7 @@ OrdosTankTypes = { "combat_tank_o", "combat_tank_o", "siege_tank" }
 OrdosStarportTypes = { "trike.starport", "trike.starport", "quad.starport", "combat_tank_o.starport", "combat_tank_o.starport", "siege_tank.starport", "missile_tank.starport" }
 
 ActivateAI = function()
-	IdlingUnits[OrdosMain] = Reinforcements.Reinforce(OrdosMain, InitialOrdosReinforcements[1], InitialOrdosPaths[1]), Reinforcements.Reinforce(OrdosMain, InitialOrdosReinforcements[2], InitialOrdosPaths[2])
+	IdlingUnits[OrdosMain] = Utils.Concat(Reinforcements.Reinforce(OrdosMain, InitialOrdosReinforcements[1], InitialOrdosPaths[1]), Reinforcements.Reinforce(OrdosMain, InitialOrdosReinforcements[2], InitialOrdosPaths[2]))
 	IdlingUnits[OrdosSmall] = Reinforcements.Reinforce(OrdosSmall, InitialOrdosReinforcements[1], InitialOrdosPaths[3])
 
 	DefendAndRepairBase(OrdosMain, OrdosMainBase, 0.75, AttackGroupSize[Difficulty])

--- a/mods/d2k/maps/harkonnen-07/harkonnen07-AI.lua
+++ b/mods/d2k/maps/harkonnen-07/harkonnen07-AI.lua
@@ -37,7 +37,7 @@ AtreidesStarportTypes = { "trike.starport", "trike.starport", "quad.starport", "
 CorrinoInfantryTypes = { "light_inf", "trooper", "sardaukar" }
 
 ActivateAI = function()
-	IdlingUnits[AtreidesMain] = Reinforcements.Reinforce(AtreidesMain, InitialAtreidesReinforcements[Difficulty][1], InitialAtreidesPaths[1]), Reinforcements.Reinforce(AtreidesMain, InitialAtreidesReinforcements[Difficulty][2], InitialAtreidesPaths[2])
+	IdlingUnits[AtreidesMain] = Utils.Concat(Reinforcements.Reinforce(AtreidesMain, InitialAtreidesReinforcements[Difficulty][1], InitialAtreidesPaths[1]), Reinforcements.Reinforce(AtreidesMain, InitialAtreidesReinforcements[Difficulty][2], InitialAtreidesPaths[2]))
 	IdlingUnits[AtreidesSmall] = Reinforcements.Reinforce(AtreidesSmall, InitialAtreidesReinforcements[Difficulty][1], InitialAtreidesPaths[3])
 	IdlingUnits[Corrino] = Reinforcements.Reinforce(Corrino, InitialCorrinoReinforcements, InitialCorrinoPath)
 

--- a/mods/d2k/maps/harkonnen-08/harkonnen08-AI.lua
+++ b/mods/d2k/maps/harkonnen-08/harkonnen08-AI.lua
@@ -34,7 +34,7 @@ AtreidesStarportTypes = { "trike.starport", "trike.starport", "quad.starport", "
 MercenaryTankTypes = { "combat_tank_o", "combat_tank_o", "siege_tank" }
 
 ActivateAI = function()
-	IdlingUnits[Ordos] = Reinforcements.Reinforce(Ordos, InitialOrdosReinforcements[1], InitialOrdosPaths[1]), Reinforcements.Reinforce(Ordos, InitialOrdosReinforcements[2], InitialOrdosPaths[2])
+	IdlingUnits[Ordos] = Utils.Concat(Reinforcements.Reinforce(Ordos, InitialOrdosReinforcements[1], InitialOrdosPaths[1]), Reinforcements.Reinforce(Ordos, InitialOrdosReinforcements[2], InitialOrdosPaths[2]))
 	IdlingUnits[AtreidesEnemy] = Reinforcements.Reinforce(AtreidesEnemy, InitialAtreidesReinforcements, InitialAtreidesPath)
 	IdlingUnits[AtreidesNeutral] = { }
 	IdlingUnits[MercenaryEnemy] = Reinforcements.Reinforce(MercenaryEnemy, InitialMercenaryReinforcements, InitialMercenaryPath)

--- a/mods/d2k/maps/harkonnen-09a/harkonnen09a-AI.lua
+++ b/mods/d2k/maps/harkonnen-09a/harkonnen09a-AI.lua
@@ -34,8 +34,8 @@ CorrinoSmallTankTypes = { "combat_tank_h", "combat_tank_h", "siege_tank" }
 CorrinoStarportTypes = { "trike.starport", "trike.starport", "quad.starport", "combat_tank_h.starport", "combat_tank_h.starport", "siege_tank.starport", "missile_tank.starport" }
 
 ActivateAI = function()
-	IdlingUnits[AtreidesMain] = Reinforcements.Reinforce(AtreidesMain, InitialAtreidesReinforcements[1], InitialAtreidesPaths[1]), Reinforcements.Reinforce(AtreidesMain, InitialAtreidesReinforcements[2], InitialAtreidesPaths[2]), Reinforcements.Reinforce(AtreidesMain, InitialAtreidesReinforcements[3], InitialAtreidesPaths[3])
-	IdlingUnits[AtreidesSmall1] = Reinforcements.Reinforce(AtreidesSmall1, InitialAtreidesReinforcements[4], InitialAtreidesPaths[4]), Reinforcements.Reinforce(AtreidesSmall1, InitialAtreidesReinforcements[5], InitialAtreidesPaths[5])
+	IdlingUnits[AtreidesMain] = Utils.Concat(Reinforcements.Reinforce(AtreidesMain, InitialAtreidesReinforcements[1], InitialAtreidesPaths[1]), Utils.Concat(Reinforcements.Reinforce(AtreidesMain, InitialAtreidesReinforcements[2], InitialAtreidesPaths[2]), Reinforcements.Reinforce(AtreidesMain, InitialAtreidesReinforcements[3], InitialAtreidesPaths[3])))
+	IdlingUnits[AtreidesSmall1] = Utils.Concat(Reinforcements.Reinforce(AtreidesSmall1, InitialAtreidesReinforcements[4], InitialAtreidesPaths[4]), Reinforcements.Reinforce(AtreidesSmall1, InitialAtreidesReinforcements[5], InitialAtreidesPaths[5]))
 	IdlingUnits[AtreidesSmall2] = Reinforcements.Reinforce(AtreidesSmall2, InitialAtreidesReinforcements[6], InitialAtreidesPaths[6])
 	IdlingUnits[CorrinoMain] = Reinforcements.Reinforce(CorrinoMain, InitialCorrinoReinforcements, InitialCorrinoPaths[1])
 	IdlingUnits[CorrinoSmall] = Reinforcements.Reinforce(CorrinoMain, InitialCorrinoReinforcements, InitialCorrinoPaths[2])

--- a/mods/d2k/maps/harkonnen-09b/harkonnen09b-AI.lua
+++ b/mods/d2k/maps/harkonnen-09b/harkonnen09b-AI.lua
@@ -33,9 +33,9 @@ CorrinoTankTypes = { "combat_tank_h", "combat_tank_h", "siege_tank", "missile_ta
 CorrinoStarportTypes = { "trike.starport", "trike.starport", "quad.starport", "combat_tank_h.starport", "combat_tank_h.starport", "siege_tank.starport", "missile_tank.starport" }
 
 ActivateAI = function()
-	IdlingUnits[AtreidesMain] = Reinforcements.Reinforce(AtreidesMain, InitialAtreidesReinforcements[1], InitialAtreidesPaths[1]), Reinforcements.Reinforce(AtreidesMain, InitialAtreidesReinforcements[2], InitialAtreidesPaths[2])
+	IdlingUnits[AtreidesMain] = Utils.Concat(Reinforcements.Reinforce(AtreidesMain, InitialAtreidesReinforcements[1], InitialAtreidesPaths[1]), Reinforcements.Reinforce(AtreidesMain, InitialAtreidesReinforcements[2], InitialAtreidesPaths[2]))
 	IdlingUnits[AtreidesSmall] = Reinforcements.Reinforce(AtreidesSmall, InitialAtreidesReinforcements[3], InitialAtreidesPaths[3])
-	IdlingUnits[CorrinoMain] = Reinforcements.Reinforce(CorrinoMain, InitialCorrinoReinforcements[1], InitialCorrinoPaths[1]), Reinforcements.Reinforce(CorrinoMain, InitialCorrinoReinforcements[2], InitialCorrinoPaths[2])
+	IdlingUnits[CorrinoMain] = Utils.Concat(Reinforcements.Reinforce(CorrinoMain, InitialCorrinoReinforcements[1], InitialCorrinoPaths[1]), Reinforcements.Reinforce(CorrinoMain, InitialCorrinoReinforcements[2], InitialCorrinoPaths[2]))
 	IdlingUnits[CorrinoSmall] = Reinforcements.Reinforce(CorrinoMain, InitialCorrinoReinforcements[3], InitialCorrinoPaths[3])
 
 	DefendAndRepairBase(AtreidesMain, AtreidesMainBase, 0.75, AttackGroupSize[Difficulty])


### PR DESCRIPTION
Lua has no built in method to concat two tables, so this introduces an utility method. Then this fixes some reinforcements in D2k missions not being added to the `IdlingUnits` table.