### PR TITLE
Improve logging in DownloadPackageLogic

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
@@ -226,7 +226,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 									foreach (var kv in download.Extract)
 									{
 										if (!package.Contains(kv.Value))
+										{
+											Log.Write("install", $"Downloaded package does not contain {kv.Value} - skipping.");
 											continue;
+										}
 
 										onExtractProgress(modData.Translation.GetString(ExtractingEntry, Translation.Arguments("entry", kv.Value)));
 										Log.Write("install", "Extracting " + kv.Value);


### PR DESCRIPTION
Adding log message when entry is not found in the .zip file.

It may help detect accidental typos in `.yaml` files, which may cause some resources not to be downloaded. 