### PR TITLE
Make RA transport chronoshiftable

### DIFF
--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -288,7 +288,6 @@ LST:
 		MaxWeight: 5
 		PassengerFacing: 0
 		LoadingCondition: notmobile
-	-Chronoshiftable:
 	Selectable:
 		DecorationBounds: 1536, 1536
 


### PR DESCRIPTION
Supersedes #11869

In vanilla red alert transport wasn't chronoshiftable, so subsequently it wasn't chronoshiftable in openra as well. We don't know why, it might be a hacky westwood solution, or transport was just forgotten, or both. All other ships / vehicles are chronoshiftable, and Transport is even iron curtainable. I don't really see why this exception needs to continue existing.

Then if we are to make transport chronoshiftable we need to decide what to do with the cargo #15321. There are 4 options:

1. Leave cargo
2. Leave cargo and apply chrono-return to cargo
3. Kill cargo
4. Kill only infantry (and demo truck) cargo 

The first option contradicts red alert lore. APC's cargo in vanilla RA is cleared out, however in future games (RA2, RA3), cargo is safe. If we were to pick this option we'd also have to make apc keep cargo. It also poses balance issues as you could effectively chrono 13 * (1 + 5 * (1 + 5)) = 403 instead of 13 units.

For the second option: the sequels had one-way chrono, meaning they didn't have to deal with chronoing back the cargo. We could implement this by adding a teleport-back init to all actors stored inside cargo. In a similar way mcv keeps its chrono effect after transforming into a construction yard. Additional question, what should we do with unchronoshiftable cargo?

The third option is lore-friendly, I haven't found anything in red alert that states that chrono only kills infantry. It just so happens that apc could only store infantry. Handling of vehicle cargo is handled isn't clarified. 

The last option is lore-friendly and a combination of the other 3 options. It could be implemented by only keeping chronoable cargo and killing the rest. We'd also have to hierarchically scan for cargo (apc's inside transport need their cargo cleared).

<hr>

For this PR I picked the 3rd solution as its by far the easiest, cleanest and causes the least issues.