### PR TITLE
Make Wanders and AttackWander queue activities instead of resolving orders

### DIFF
--- a/OpenRA.Mods.Common/Traits/AttackWander.cs
+++ b/OpenRA.Mods.Common/Traits/AttackWander.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -32,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override void DoAction(Actor self, CPos targetCell)
 		{
-			attackMove.ResolveOrder(self, new Order("AttackMove", self, Target.FromCell(self.World, targetCell), false));
+			self.QueueActivity(new AttackMoveActivity(self, () => Move.MoveTo(targetCell, targetLineColor: attackMove.Info.TargetLineColor), false));
 		}
 	}
 }


### PR DESCRIPTION
Seems like order resolving was done to allow both `Aircraft` and `Mobile` actors to use the trait(s), but since then the `IMove` interface allows us to create an activity for both.