### PR TITLE
ProductionPaletteWidget: make queued count customizable

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -48,6 +48,9 @@ namespace OpenRA.Mods.Common.Widgets
 		public readonly int2 IconMargin = int2.Zero;
 		public readonly int2 IconSpriteOffset = int2.Zero;
 
+		public readonly float2 QueuedOffset = new float2(4, 2);
+		public readonly TextAlign QueuedTextAlign = TextAlign.Left;
+
 		public readonly string ClickSound = ChromeMetrics.Get<string>("ClickSound");
 		public readonly string ClickDisabledSound = ChromeMetrics.Get<string>("ClickDisabledSound");
 		public readonly string TooltipContainer;
@@ -119,7 +122,7 @@ namespace OpenRA.Mods.Common.Widgets
 		readonly WorldRenderer worldRenderer;
 
 		SpriteFont overlayFont, symbolFont;
-		float2 iconOffset, holdOffset, readyOffset, timeOffset, queuedOffset, infiniteOffset;
+		float2 iconOffset, holdOffset, readyOffset, timeOffset, infiniteOffset;
 
 		Player cachedQueueOwner;
 		IProductionIconOverlay[] pios;
@@ -172,14 +175,13 @@ namespace OpenRA.Mods.Common.Widgets
 			Game.Renderer.Fonts.TryGetValue(SymbolsFont, out symbolFont);
 
 			iconOffset = 0.5f * IconSize.ToFloat2() + IconSpriteOffset;
-			queuedOffset = new float2(4, 2);
 			holdOffset = iconOffset - overlayFont.Measure(HoldText) / 2;
 			readyOffset = iconOffset - overlayFont.Measure(ReadyText) / 2;
 
 			if (ChromeMetrics.TryGet("InfiniteOffset", out infiniteOffset))
-				infiniteOffset += queuedOffset;
+				infiniteOffset += QueuedOffset;
 			else
-				infiniteOffset = queuedOffset;
+				infiniteOffset = QueuedOffset;
 		}
 
 		public void ScrollDown()
@@ -578,9 +580,21 @@ namespace OpenRA.Mods.Common.Widgets
 							icon.Pos + infiniteOffset,
 							TextColor, Color.Black, 1);
 					else if (total > 1 || waiting)
+					{
+						var pos = QueuedOffset;
+						if (QueuedTextAlign != TextAlign.Left)
+						{
+							var size = overlayFont.Measure(total.ToString());
+
+							pos = QueuedTextAlign == TextAlign.Center ?
+								new float2(QueuedOffset.X - size.X / 2, QueuedOffset.Y) :
+								new float2(QueuedOffset.X - size.X, QueuedOffset.Y);
+						}
+
 						overlayFont.DrawTextWithContrast(total.ToString(),
-							icon.Pos + queuedOffset,
+							icon.Pos + pos,
 							TextColor, Color.Black, 1);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This PR makes it possible to change offset of queued count in chrome YAML and also align text (relative to the specified offset). Default offset is taken from the original code (4,2) and default align is left (i.e. no align).

With these changes production item on the palette widget might look like this:

![top-right](https://user-images.githubusercontent.com/119738087/217953845-6de2c6a9-3d1d-4871-9837-6e60f29f99cc.png)
![bottom-right](https://user-images.githubusercontent.com/119738087/217953854-48fe5e9b-e8e0-4b1b-bf61-a84e4c74cf02.png)
![bottom-center](https://user-images.githubusercontent.com/119738087/217953857-dbc9b0df-fbe9-4469-82ce-00f2f6d10b40.png)
