### PR TITLE
Remove dependency on VCRUNTIME140.dll.

### DIFF
--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Linguini.Bundle" Version="0.3.2" />
-    <PackageReference Include="OpenRA-Eluant" Version="1.0.19" />
+    <PackageReference Include="OpenRA-Eluant" Version="1.0.20" />
     <PackageReference Include="Mono.NAT" Version="3.0.3" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />


### PR DESCRIPTION
Closes #20631. `dumpbin` confirms that the updated dlls depend only on `msvcrt.dll` and `KERNEL32.dll`.

Built using https://github.com/pchote/native-dependencies/commit/1d3c76a258bf79d2b7e509cfa2a9cbb4cffa515f.

⚠️ *not actually tested ingame*. Both x64 and x86 builds should be confirmed to work before merging ⚠️ 