### PR TITLE
Polish the save dialogue

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -312,14 +312,21 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void SelectFirstVisible()
 		{
 			Select(isSavePanel ? null : games.FirstOrDefault());
+			if (isSavePanel)
+			{
+				saveTextField.TakeKeyboardFocus();
+				saveTextField.CursorPosition = saveTextField.Text.Length;
+			}
 		}
 
 		void Select(string savePath)
 		{
 			selectedSave = savePath;
 			if (isSavePanel)
-				saveTextField.Text = savePath == null ? defaultSaveFilename :
-					Path.GetFileNameWithoutExtension(savePath);
+			{
+				saveTextField.Text = savePath == null ? defaultSaveFilename : Path.GetFileNameWithoutExtension(savePath);
+				saveTextField.CursorPosition = saveTextField.Text.Length;
+			}
 		}
 
 		void Load()

--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -120,6 +120,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				saveTextField = saveWidgets.Get<TextFieldWidget>("SAVE_TEXTFIELD");
 				gameList.Bounds.Height -= saveWidgets.Bounds.Height;
 				saveWidgets.IsVisible = () => true;
+
+				saveTextField.OnEnterKey = _ =>
+				{
+					if (!string.IsNullOrWhiteSpace(saveTextField.Text))
+						Save(world);
+
+					return true;
+				};
 			}
 			else
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -374,7 +374,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				onExit();
 			};
 
-			if (selectedSave != null || File.Exists(testPath))
+			if (File.Exists(testPath))
 			{
 				ConfirmationDialogs.ButtonPrompt(modData,
 					title: OverwriteSaveTitle,


### PR DESCRIPTION
- Makes the save game title field take focus when opening the save game browser
- Allows to save a game by pressing enter after entering a title/name
- Does no longer display the overwrite warning when not actually overwriting a save
(Testcase: Select a save and change the filename text before saving)