### PR TITLE
Minor D2k encyclopedia UI polish

### DIFF
--- a/mods/d2k/chrome/encyclopedia.yaml
+++ b/mods/d2k/chrome/encyclopedia.yaml
@@ -54,7 +54,7 @@ Background@ENCYCLOPEDIA_PANEL:
 					Children:
 						Background@ACTOR_BG:
 							Width: 150
-							Height: 150
+							Height: 170
 							Background: dialog3
 							Children:
 								ActorPreview@ACTOR_PREVIEW:
@@ -65,13 +65,13 @@ Background@ENCYCLOPEDIA_PANEL:
 						ScrollPanel@ACTOR_DESCRIPTION_PANEL:
 							X: 150 + 10
 							Width: PARENT_RIGHT - 150 - 10
-							Height: 150
+							Height: 170
 							TopBottomSpacing: 8
 							Children:
 								Label@ACTOR_DESCRIPTION:
 									X: 8
 									Y: 8
-									Width: PARENT_RIGHT - 32
+									Width: PARENT_RIGHT - 40
 									VAlign: Top
 									Font: Regular
 		Button@BACK_BUTTON:


### PR DESCRIPTION
- Make the text area taller so all the current text fits without a scroll.
- Limit label width so text doesn't press against the scrollbar.

I know the values are arbitrary, but the previous values were also arbitrary. This way we have some polish at least for the current default descriptions.
Since this is the first time we'll be releasing the Encyclopedia, this should go to `prep`.