### PR TITLE
Fix MiniYAML merging not allowing removal of trait fields

### DIFF
--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -434,18 +434,39 @@ namespace OpenRA
 
 			var existingDict = existingNodes.ToDictionaryWithConflictLog(x => x.Key, "MiniYaml.Merge", null, x => $"{x.Key} (at {x.Location})");
 			var overrideDict = overrideNodes.ToDictionaryWithConflictLog(x => x.Key, "MiniYaml.Merge", null, x => $"{x.Key} (at {x.Location})");
-			var allKeys = existingDict.Keys.Union(overrideDict.Keys);
 
-			foreach (var key in allKeys)
+			foreach (var node in existingNodes.Concat(overrideNodes))
 			{
-				existingDict.TryGetValue(key, out var existingNode);
-				overrideDict.TryGetValue(key, out var overrideNode);
+				// Append Removal nodes to the result.
+				// Therefore: we know the remainder of the loop deals with plain nodes.
+				if (node.Key.StartsWith("-", StringComparison.Ordinal))
+				{
+					ret.Add(node);
+					continue;
+				}
 
-				var loc = overrideNode?.Location ?? default;
-				var comment = (overrideNode ?? existingNode).Comment;
-				var merged = (existingNode == null || overrideNode == null) ? overrideNode ?? existingNode :
-					new MiniYamlNode(key, MergePartial(existingNode.Value, overrideNode.Value), comment, loc);
-				ret.Add(merged);
+				// If no previous node with this key is present, it is new and can just be appended.
+				var previousNodeIndex = ret.FindLastIndex(n => n.Key == node.Key);
+				if (previousNodeIndex == -1)
+				{
+					ret.Add(node);
+					continue;
+				}
+
+				// A Removal node is closer than the previous node.
+				// We should not merge the new node, as the data being merged will jump before the Removal.
+				// Instead, append it so the previous node is applied, then removed, then the new node is applied.
+				var removalKey = $"-{node.Key}";
+				var previousRemovalNodeIndex = ret.FindLastIndex(n => n.Key == removalKey);
+				if (previousRemovalNodeIndex != -1 && previousRemovalNodeIndex > previousNodeIndex)
+				{
+					ret.Add(node);
+					continue;
+				}
+
+				// A previous node is present with no intervening Removal.
+				// We should merge the new one into it, in place.
+				ret[previousNodeIndex] = new MiniYamlNode(node.Key, MergePartial(ret[previousNodeIndex].Value, node.Value), node.Comment, node.Location);
 			}
 
 			ret.TrimExcess();

--- a/mods/d2k/maps/atreides-01a/rules.yaml
+++ b/mods/d2k/maps/atreides-01a/rules.yaml
@@ -19,6 +19,13 @@ World:
 			normal: Normal
 			hard: Hard
 		Default: easy
+	D2kResourceRenderer:
+		-ResourceTypes:
+		ResourceTypes:
+			Unobtaineum:
+				Sequences: spicea, spiceb, spicec, spiced
+				Palette: chrome
+				Name: Unobtaineum
 
 upgrade.conyard:
 	Buildable:

--- a/mods/ra/maps/allies-01/rules.yaml
+++ b/mods/ra/maps/allies-01/rules.yaml
@@ -8,6 +8,13 @@ World:
 		StartVideo: landing.vqa
 		WinVideo: snowbomb.vqa
 		LossVideo: bmap.vqa
+	ResourceRenderer:
+		-ResourceTypes:
+		ResourceTypes:
+			Unobtaineum:
+				Sequences: gold01, gold02, gold03, gem04
+				Palette: player
+				Name: Unobtaineum
 
 TRAN.Extraction:
 	Inherits: TRAN


### PR DESCRIPTION
Just over an year after I struggled with it and not even an year after @RoosterDragon so generously provided a fix, we finally get a PR!

Looks like we can already remove Warhead fields (and we do), but those are loaded differently than traits... _\*sigh\*_

This is a successor of  #19987, which came up as a prerequisite to #18007, prompted by https://github.com/OpenRA/OpenRA/pull/18007#issuecomment-1012588025.

On `bleed` two of the new unit tests would fail - `ChildSubNodeCanBeRemovedAndImmediatelyOverridden` and `ChildSubNodeCanBeRemovedAndLaterOverridden` (which is why they are in the first commit - for easier testing), and then all pass with the second commit. There are also two in-game test cases for easier understanding.