### PR TITLE
Remove redundant jumps and other style nits from the update rules

### DIFF
--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200202/RemoveInitialFacingHardcoding.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200202/RemoveInitialFacingHardcoding.cs
@@ -53,8 +53,6 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 				nonVTOLs.Add(Tuple.Create(actorNode.Key, actorNode.Location.Filename));
 			}
-
-			yield break;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ChangeTargetLineDelayToMilliseconds.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ChangeTargetLineDelayToMilliseconds.cs
@@ -26,11 +26,8 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			foreach (var dltt in actorNode.ChildrenMatching("DrawLineToTarget", includeRemovals: false))
 			{
 				var delayNode = dltt.LastChildMatching("Delay", false);
-				if (delayNode != null)
-				{
-					if (Exts.TryParseIntegerInvariant(delayNode.Value.Value, out var delay))
-						delayNode.ReplaceValue((delay * 1000 / 25).ToString());
-				}
+				if (delayNode != null && Exts.TryParseIntegerInvariant(delayNode.Value.Value, out var delay))
+					delayNode.ReplaceValue((delay * 1000 / 25).ToString());
 			}
 
 			yield break;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RemoveTurnToDock.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RemoveTurnToDock.cs
@@ -50,8 +50,6 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 				turningAircraft.Add(Tuple.Create(actorNode.Key, actorNode.Location.Filename));
 			}
-
-			yield break;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/SplitDamagedByTerrain.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/SplitDamagedByTerrain.cs
@@ -28,8 +28,6 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				if (damaged.RemoveNodes("StartOnThreshold") > 0)
 					yield return $"'StartOnThreshold' was removed from {actorNode.Key} ({actorNode.Location.Filename}) without replacement.\n";
 			}
-
-			yield break;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/ReplaceCrateSecondsWithTicks.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/ReplaceCrateSecondsWithTicks.cs
@@ -35,9 +35,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			}
 
 			foreach (var scNode in actorNode.ChildrenMatching("ScaredyCat"))
-			{
 				scNode.RenameChildrenMatching("PanicLength", "PanicDuration");
-			}
 
 			yield break;
 		}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20221203/ExplicitSequenceFilenames.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20221203/ExplicitSequenceFilenames.cs
@@ -315,8 +315,6 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			foreach (var sequenceNode in imageNode.Value.Nodes.ToList())
 				if (implicitInheritedSequences.Contains(sequenceNode.Key) && !sequenceNode.Value.Nodes.Any())
 					imageNode.RemoveNode(sequenceNode);
-
-			yield break;
 		}
 
 		void ProcessNode(ModData modData, MiniYamlNode sequenceNode, MiniYamlNode resolvedSequenceNode, string imageName)

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20221203/ProductionTabsWidgetAddTabButtonCollection.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20221203/ProductionTabsWidgetAddTabButtonCollection.cs
@@ -33,11 +33,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			}
 
 			if (buttonCollection != null)
-			{
 				chromeNode.AddNode(new MiniYamlNode("ArrowButton", buttonCollection));
-			}
-
-			yield break;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20221203/TextNotificationsDisplayWidgetRemoveTime.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20221203/TextNotificationsDisplayWidgetRemoveTime.cs
@@ -32,8 +32,6 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				var durationMilliseconds = field.NodeValue<int>() * 40;
 				field.ReplaceValue(FieldSaver.FormatValue(durationMilliseconds));
 			}
-
-			yield break;
 		}
 	}
 }


### PR DESCRIPTION
See https://github.com/OpenRA/OpenRA/pull/20668#discussion_r1109702122.

We can't remove `yield break;` from every method since we need to yield at least once.