### PR TITLE
Disable IDE0039 code style rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -144,6 +144,9 @@ dotnet_diagnostic.IDE0034.severity = warning
 # Modifiers are not ordered.
 dotnet_diagnostic.IDE0036.severity = warning
 
+# Use local function instead of lambda.
+dotnet_diagnostic.IDE0039.severity = silent
+
 # Raise a warning on build when default access modifiers are explicitly specified.
 dotnet_diagnostic.IDE0040.severity = warning
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0039

Disable code style rule `Use local function instead of lambda.`

In our codebase it's common practice to define lambdas, we avoid unnecessary casts to lambdas this way. To me, keeping this rule as a warning makes no sense.