### PR TITLE
Allow mods to control how looped sounds are used.

### DIFF
--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -129,9 +129,14 @@ namespace OpenRA
 			soundEngine.StopAllSounds();
 		}
 
-		public void EndLoop(ISound sound)
+		public void SetLooped(ISound sound, bool looped)
 		{
-			soundEngine.SetSoundLooping(false, sound);
+			soundEngine.SetSoundLooping(looped, sound);
+		}
+
+		public void SetPosition(ISound sound, WPos position)
+		{
+			soundEngine.SetSoundPosition(sound, position);
 		}
 
 		public void MuteAudio()

--- a/OpenRA.Game/Sound/SoundDevice.cs
+++ b/OpenRA.Game/Sound/SoundDevice.cs
@@ -29,6 +29,7 @@ namespace OpenRA
 		void SetListenerPosition(WPos position);
 		void SetSoundVolume(float volume, ISound music, ISound video);
 		void SetSoundLooping(bool looping, ISound sound);
+		void SetSoundPosition(ISound sound, WPos position);
 	}
 
 	public class SoundDevice

--- a/OpenRA.Platforms.Default/DummySoundEngine.cs
+++ b/OpenRA.Platforms.Default/DummySoundEngine.cs
@@ -57,6 +57,7 @@ namespace OpenRA.Platforms.Default
 		public void StopAllSounds() { }
 		public void SetListenerPosition(WPos position) { }
 		public void SetSoundLooping(bool looping, ISound sound) { }
+		public void SetSoundPosition(ISound sound, WPos position) { }
 		public void Dispose() { }
 	}
 

--- a/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
+++ b/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
@@ -350,6 +350,11 @@ namespace OpenRA.Platforms.Default
 			((OpenAlSound)sound)?.SetLooping(looping);
 		}
 
+		public void SetSoundPosition(ISound sound, WPos position)
+		{
+			((OpenAlSound)sound)?.SetPosition(position);
+		}
+
 		~OpenAlSoundEngine()
 		{
 			Dispose(false);


### PR DESCRIPTION
OpenE2140 uses mechs, which have a looped walk sound.
However when multiple mechs are walking, all their sounds completely overlap eachother.

As a solutionim manualy handling the state of those sounds: When should it be looped and when not?
Hence the need to replace EndLoop by SetLooped. This allows mods to decide when a sound might again be pushed into a looped state. So basicaly the same as before, just in both directions.

The second thing however was the need to manualy assign the looped sound to the actor closest to the viewport center. So it required the option to relocate a sounds position.

All these methods were already in the sound engine. This PR simply makes it usable for mode.