### PR TITLE
Fix Armament not working properly with value 0 in BurstDelays

### DIFF
--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -255,7 +255,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			if (!attack.IsTraitPaused)
 				foreach (var a in armaments)
-					a.CheckFire(self, facing, target);
+					a.CheckFire(self, facing, target, false);
 		}
 
 		void IActivityNotifyStanceChanged.StanceChanged(Actor self, AutoTarget autoTarget, UnitStance oldStance, UnitStance newStance)

--- a/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 						continue;
 
 					inAttackRange = true;
-					a.CheckFire(self, facing, target);
+					a.CheckFire(self, facing, target, false);
 				}
 
 				// Actors without armaments may want to trigger an action when it passes the target

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -166,7 +166,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			foreach (var a in Armaments)
-				a.CheckFire(self, facing, target);
+				a.CheckFire(self, facing, target, false);
 		}
 
 		IEnumerable<IOrderTargeter> IIssueOrder.Orders

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -78,7 +78,6 @@ namespace OpenRA.Mods.Common.Traits
 	public class AttackGarrisoned : AttackFollow, INotifyPassengerEntered, INotifyPassengerExited, IRender
 	{
 		public new readonly AttackGarrisonedInfo Info;
-		INotifyAttack[] notifyAttacks;
 		readonly Lazy<BodyOrientation> coords;
 		readonly List<Armament> armaments;
 		readonly List<AnimationWithOffset> muzzles;
@@ -96,12 +95,6 @@ namespace OpenRA.Mods.Common.Traits
 			paxFacing = new Dictionary<Actor, IFacing>();
 			paxPos = new Dictionary<Actor, IPositionable>();
 			paxRender = new Dictionary<Actor, RenderSprites>();
-		}
-
-		protected override void Created(Actor self)
-		{
-			notifyAttacks = self.TraitsImplementing<INotifyAttack>().ToArray();
-			base.Created(self);
 		}
 
 		protected override Func<IEnumerable<Armament>> InitializeGetArmaments(Actor self)
@@ -171,8 +164,7 @@ namespace OpenRA.Mods.Common.Traits
 				paxFacing[a.Actor].Facing = targetYaw;
 				paxPos[a.Actor].SetCenterPosition(a.Actor, pos + PortOffset(self, port));
 
-				var barrel = a.CheckFire(a.Actor, facing, target);
-				if (barrel == null)
+				if (!a.CheckFire(a.Actor, facing, target, true))
 					continue;
 
 				if (a.Info.MuzzleSequence != null)
@@ -188,9 +180,6 @@ namespace OpenRA.Mods.Common.Traits
 					muzzles.Add(muzzleFlash);
 					muzzleAnim.PlayThen(sequence, () => muzzles.Remove(muzzleFlash));
 				}
-
-				foreach (var npa in notifyAttacks)
-					npa.Attacking(self, target, a, barrel);
 			}
 		}
 

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -85,15 +85,7 @@ namespace OpenRA.Mods.D2k.Activities
 			if (affectedPlayers.Contains(self.World.LocalPlayer))
 				TextNotificationsManager.AddTransientLine(self.World.LocalPlayer, swallow.Info.WormAttackTextNotification);
 
-			var barrel = armament.CheckFire(self, facing, target);
-			if (barrel == null)
-				return false;
-
-			// armament.CheckFire already calls INotifyAttack.PreparingAttack
-			foreach (var notify in self.TraitsImplementing<INotifyAttack>())
-				notify.Attacking(self, target, armament, barrel);
-
-			return true;
+			return armament.CheckFire(self, facing, target, true);
 		}
 
 		public override bool Tick(Actor self)

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -594,13 +594,9 @@ MSAM:
 	Turreted:
 		TurnSpeed: 512
 		Offset: -256,0,128
-	Armament@PRIMARY:
+	Armament:
 		Weapon: 227mm
 		LocalOffset: 213,128,0, 213,-128,0
-	Armament@SECONDARY:
-		Name: secondary
-		Weapon: 227mm
-		LocalOffset: 213,-128,0, 213,128,0
 	AttackFrontal:
 		TargetFrozenActors: True
 		ForceFireIgnoresActors: True

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -147,7 +147,7 @@ MammothMissiles:
 	Range: 11c0
 	MinRange: 3c0
 	Burst: 4
-	BurstDelays: 4
+	BurstDelays: 0, 4, 0
 	Report: rocket1.aud
 	ValidTargets: Ground, Water
 	TargetActorCenter: true

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -164,15 +164,9 @@ YAK:
 	RevealsShroud@GAPGEN:
 		Range: 9c0
 		Type: GroundPosition
-	Armament@PRIMARY:
+	Armament:
 		Weapon: ChainGun.Yak
-		LocalOffset: 256,-213,0
-		MuzzleSequence: muzzle
-		PauseOnCondition: !ammo
-	Armament@SECONDARY:
-		Name: secondary
-		Weapon: ChainGun.Yak
-		LocalOffset: 256,213,0
+		LocalOffset: 256,-213,0, 256,213,0
 		MuzzleSequence: muzzle
 		PauseOnCondition: !ammo
 	AttackAircraft:
@@ -383,15 +377,9 @@ HIND:
 	RevealsShroud@GAPGEN:
 		Range: 8c0
 		Type: GroundPosition
-	Armament@PRIMARY:
+	Armament:
 		Weapon: ChainGun
 		LocalOffset: 85,-213,-85, 85,213,-85
-		MuzzleSequence: muzzle
-		PauseOnCondition: !ammo
-	Armament@SECONDARY:
-		Name: secondary
-		Weapon: ChainGun
-		LocalOffset: 85,213,-85, 85,-213,-85
 		MuzzleSequence: muzzle
 		PauseOnCondition: !ammo
 	AttackAircraft:
@@ -507,15 +495,9 @@ MH60:
 	RevealsShroud@GAPGEN:
 		Range: 8c0
 		Type: GroundPosition
-	Armament@PRIMARY:
+	Armament:
 		Weapon: ChainGun
 		LocalOffset: 85,-213,-85, 85,213,-85
-		MuzzleSequence: muzzle
-		PauseOnCondition: !ammo
-	Armament@SECONDARY:
-		Name: secondary
-		Weapon: ChainGun
-		LocalOffset: 85,213,-85, 85,-213,-85
 		MuzzleSequence: muzzle
 		PauseOnCondition: !ammo
 	AttackAircraft:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -427,9 +427,6 @@ E7:
 	Armament@PRIMARY:
 		Weapon: Colt45
 		LocalOffset: 0,0,0, 0,0,0
-	Armament@SECONDARY:
-		Weapon: Colt45
-		LocalOffset: 0,0,0, 0,0,0
 	Armament@GARRISONED:
 		Name: garrisoned
 		Weapon: Colt45

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -771,7 +771,7 @@ DTRK:
 		DamageSource: Killer
 	AttackFrontal:
 		FacingTolerance: 512
-	Armament@PRIMARY:
+	Armament:
 		Weapon: DemoTruckTargeting
 	GrantConditionOnAttack:
 		Condition: triggered
@@ -812,14 +812,10 @@ CTNK:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 4c0
-	Armament@PRIMARY:
+	Armament:
 		Weapon: APTusk
-		LocalOffset: -160,-276,232
-		LocalYaw: 60
-	Armament@SECONDARY:
-		Weapon: APTusk
-		LocalOffset: -160,276,232
-		LocalYaw: -60
+		LocalOffset: -160,-276,232, -160,276,232
+		LocalYaw: 60, -60
 	AttackFrontal:
 		FacingTolerance: 0
 	PortableChrono:

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -209,6 +209,8 @@ APTusk:
 	Inherits: ^AntiGroundMissile
 	ReloadDelay: 60
 	Range: 6c0
+	Burst: 2
+	BurstDelays: 0
 	Projectile: Missile
 		Speed: 298
 		TrailImage: smokey
@@ -218,6 +220,7 @@ APTusk:
 APTusk.stnk:
 	Inherits: APTusk
 	ReloadDelay: 100
+	Burst: 1
 
 TorpTube:
 	ReloadDelay: 100

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -210,6 +210,8 @@ Vulcan:
 
 ChainGun:
 	Inherits: ^HeavyMG
+	Burst: 2
+	BurstDelays: 0
 	ReloadDelay: 10
 	Range: 5c0
 	MinRange: 0c768
@@ -221,6 +223,8 @@ ChainGun:
 
 ChainGun.Yak:
 	Inherits: ^HeavyMG
+	Burst: 2
+	BurstDelays: 0
 	ReloadDelay: 3
 	Range: 5c0
 	MinRange: 3c0
@@ -325,5 +329,5 @@ Colt45:
 	ReloadDelay: 7
 	Range: 7c0
 	Warhead@1Dam: SpreadDamage
-		Damage: 5000
+		Damage: 10000
 

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -91,16 +91,10 @@ GACTWR:
 		RequiresCondition: !build-incomplete && tower.sam
 		Recoils: false
 		Sequence: turret-sam
-	Armament@VULCPRIMARY:
+	Armament@VULCAN:
 		RequiresCondition: tower.vulcan
 		Weapon: VulcanTower
-		LocalOffset: 588,120,1358
-		MuzzleSequence: muzzle
-	Armament@VULCSECONDARY:
-		RequiresCondition: tower.vulcan
-		Name: secondary
-		Weapon: VulcanTower
-		LocalOffset: 588,-120,1358
+		LocalOffset: 588,120,1358, 588,-120,1358
 		MuzzleSequence: muzzle
 	Armament@ROCKET:
 		RequiresCondition: tower.rocket

--- a/mods/ts/rules/nod-infantry.yaml
+++ b/mods/ts/rules/nod-infantry.yaml
@@ -20,7 +20,7 @@ E3:
 		HP: 10000
 	Mobile:
 		Speed: 56
-	Armament@PRIMARY:
+	Armament:
 		Weapon: Bazooka
 		LocalOffset: 356,0,967
 	TakeCover:

--- a/mods/ts/weapons/smallguns.yaml
+++ b/mods/ts/weapons/smallguns.yaml
@@ -62,6 +62,8 @@ VulcanTower:
 	Inherits: ^MG
 	ReloadDelay: 26
 	Range: 6c0
+	Burst: 2
+	BurstDelays: 0
 	Report: chaingn1.aud
 	Warhead@1Dam: SpreadDamage
 		Damage: 1800


### PR DESCRIPTION
Supersedes: #20601

This allows us to simplify yaml definitions, as I've done in all non-d2k mods. 
It will also make it easier for the encyclopedia to read armament definitions when we get to it.