### PR TITLE
Fix empty mission objectives getting translated

### DIFF
--- a/mods/common/scripts/utils.lua
+++ b/mods/common/scripts/utils.lua
@@ -18,7 +18,11 @@ end
 ---@param description string key of the translation string
 ---@return number id used to query for the objective later
 AddPrimaryObjective = function(player, description)
-	local translation = UserInterface.Translate(description)
+	local translation = description
+	if translation ~= "" then
+		translation = UserInterface.Translate(description)
+	end
+
 	Media.DisplayMessageToPlayer(player, translation, UserInterface.Translate("new-primary-objective"))
 	return player.AddObjective(translation, UserInterface.Translate("primary"), true)
 end
@@ -28,7 +32,11 @@ end
 ---@param description string key of the translation string
 ---@return number id used to query for the objective later
 AddSecondaryObjective = function(player, description)
-	local translation = UserInterface.Translate(description)
+	local translation = description
+	if translation ~= "" then
+		translation = UserInterface.Translate(description)
+	end
+
 	Media.DisplayMessageToPlayer(player, translation, UserInterface.Translate("new-secondary-objective"))
 	return player.AddObjective(translation, UserInterface.Translate("secondary"), false)
 end


### PR DESCRIPTION
Since #20638 we no longer allow translation keys to be empty, so all missions which define objectives for the enemy with `""` as description run into a crash at the moment (start allies02 for example).