### PR TITLE
Turn some code style rule severity from suggestion to warning

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -135,7 +135,7 @@ dotnet_diagnostic.IDE0001.severity = warning
 # Simplify member access.
 dotnet_diagnostic.IDE0002.severity = warning
 
-# use 'var' instead of explicit type
+# Use 'var' instead of explicit type.
 dotnet_diagnostic.IDE0007.severity = warning
 
 # Don't prefer braces (for one liners).
@@ -153,7 +153,7 @@ dotnet_diagnostic.IDE0019.severity = warning
 # Use pattern matching to avoid 'is' check followed by a cast.
 dotnet_diagnostic.IDE0020.severity = warning
 
-# Collection initialization can be simplified
+# Collection initialization can be simplified.
 dotnet_diagnostic.IDE0028.severity = warning
 
 # Use coalesce expression (non-nullable types).
@@ -165,7 +165,7 @@ dotnet_diagnostic.IDE0030.severity = warning
 # Use explicitly provided tuple name.
 dotnet_diagnostic.IDE0033.severity = warning
 
-# Simplify 'default' expression
+# Simplify 'default' expression.
 dotnet_diagnostic.IDE0034.severity = warning
 
 # Modifiers are not ordered.

--- a/.editorconfig
+++ b/.editorconfig
@@ -183,6 +183,9 @@ dotnet_diagnostic.IDE0041.severity = warning
 # Make field readonly.
 dotnet_diagnostic.IDE0044.severity = warning
 
+# Remove unnecessary parentheses.
+dotnet_diagnostic.IDE0047.severity = warning
+
 # Remove unused private member.
 dotnet_diagnostic.IDE0051.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -162,6 +162,9 @@ dotnet_diagnostic.IDE0029.severity = warning
 # Use coalesce expression (nullable types).
 dotnet_diagnostic.IDE0030.severity = warning
 
+# Use null propagation.
+dotnet_diagnostic.IDE0031.severity = warning
+
 # Use explicitly provided tuple name.
 dotnet_diagnostic.IDE0033.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -240,6 +240,9 @@ dotnet_diagnostic.CA1827.severity = warning
 # Use Length/Count property instead of Enumerable.Count method.
 dotnet_diagnostic.CA1829.severity = warning
 
+# Use span-based 'string.Concat' (incompatible with mono builds).
+dotnet_diagnostic.CA1845.severity = none
+
 # Use string.Contains(char) instead of string.Contains(string) with single characters.
 dotnet_diagnostic.CA1847.severity = warning
 

--- a/OpenRA.Game/Graphics/ChromeProvider.cs
+++ b/OpenRA.Game/Graphics/ChromeProvider.cs
@@ -100,9 +100,7 @@ namespace OpenRA.Graphics
 
 		static void LoadCollection(string name, MiniYaml yaml)
 		{
-			if (Game.ModData.LoadScreen != null)
-				Game.ModData.LoadScreen.Display();
-
+			Game.ModData.LoadScreen?.Display();
 			collections.Add(name, FieldLoader.Load<Collection>(yaml));
 		}
 

--- a/OpenRA.Game/Graphics/CursorManager.cs
+++ b/OpenRA.Game/Graphics/CursorManager.cs
@@ -111,8 +111,7 @@ namespace OpenRA.Graphics
 				var template = kv.Value;
 				for (var i = 0; i < template.Sprites.Length; i++)
 				{
-					if (template.Cursors[i] != null)
-						template.Cursors[i].Dispose();
+					template.Cursors[i]?.Dispose();
 
 					// Calculate the padding to position the frame within sequenceBounds
 					var paddingTL = -(template.Bounds.Location - template.Sprites[i].Offset.XY.ToInt2());

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -233,7 +233,7 @@ namespace OpenRA.Graphics
 			else
 				Zoom = Zoom.Clamp(minZoom, maxZoom);
 
-			var maxSize = (1f / (unlockMinZoom ? unlockedMinZoom : minZoom) * new float2(Game.Renderer.NativeResolution));
+			var maxSize = 1f / (unlockMinZoom ? unlockedMinZoom : minZoom) * new float2(Game.Renderer.NativeResolution);
 			Game.Renderer.SetMaximumViewportSize(new Size((int)maxSize.X, (int)maxSize.Y));
 
 			foreach (var t in worldRenderer.World.WorldActor.TraitsImplementing<INotifyViewportZoomExtentsChanged>())
@@ -296,8 +296,8 @@ namespace OpenRA.Graphics
 		}
 
 		public int2 ViewToWorldPx(int2 view) { return (graphicSettings.UIScale / Zoom * view.ToFloat2()).ToInt2() + TopLeft; }
-		public int2 WorldToViewPx(int2 world) { return ((Zoom / graphicSettings.UIScale) * (world - TopLeft).ToFloat2()).ToInt2(); }
-		public int2 WorldToViewPx(in float3 world) { return ((Zoom / graphicSettings.UIScale) * (world - TopLeft).XY).ToInt2(); }
+		public int2 WorldToViewPx(int2 world) { return (Zoom / graphicSettings.UIScale * (world - TopLeft).ToFloat2()).ToInt2(); }
+		public int2 WorldToViewPx(in float3 world) { return (Zoom / graphicSettings.UIScale * (world - TopLeft).XY).ToInt2(); }
 
 		public void Center(IEnumerable<Actor> actors)
 		{

--- a/OpenRA.Game/Map/ActorInitializer.cs
+++ b/OpenRA.Game/Map/ActorInitializer.cs
@@ -54,7 +54,7 @@ namespace OpenRA
 			// Traits tagged with an instance name prefer inits with the same name.
 			// If a more specific init is not available, fall back to an unnamed init.
 			// If duplicate inits are defined, take the last to match standard yaml override expectations
-			if (info != null && !string.IsNullOrEmpty(info.InstanceName))
+			if (!string.IsNullOrEmpty(info?.InstanceName))
 				return inits.LastOrDefault(i => i.InstanceName == info.InstanceName) ??
 					inits.LastOrDefault(i => string.IsNullOrEmpty(i.InstanceName));
 
@@ -159,9 +159,9 @@ namespace OpenRA
 
 		public virtual void Initialize(T value)
 		{
-			var field = typeof(ValueActorInit<T>).GetField(nameof(value), BindingFlags.NonPublic | BindingFlags.Instance);
-			if (field != null)
-				field.SetValue(this, value);
+			typeof(ValueActorInit<T>)
+				.GetField(nameof(value), BindingFlags.NonPublic | BindingFlags.Instance)
+				?.SetValue(this, value);
 		}
 
 		public override MiniYaml Save()
@@ -246,16 +246,16 @@ namespace OpenRA
 
 		public void Initialize(MiniYaml yaml)
 		{
-			var field = typeof(OwnerInit).GetField(nameof(InternalName), BindingFlags.Public | BindingFlags.Instance);
-			if (field != null)
-				field.SetValue(this, yaml.Value);
+			typeof(OwnerInit)
+				.GetField(nameof(InternalName), BindingFlags.Public | BindingFlags.Instance)
+				?.SetValue(this, yaml.Value);
 		}
 
 		public void Initialize(Player player)
 		{
-			var field = typeof(OwnerInit).GetField(nameof(value), BindingFlags.NonPublic | BindingFlags.Instance);
-			if (field != null)
-				field.SetValue(this, player);
+			typeof(OwnerInit)
+				.GetField(nameof(value), BindingFlags.NonPublic | BindingFlags.Instance)
+				?.SetValue(this, player);
 		}
 
 		public override MiniYaml Save()

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -390,7 +390,7 @@ namespace OpenRA
 
 							// TODO: Remember to remove this when rewriting tile variants / PickAny
 							if (index == byte.MaxValue)
-								index = (byte)(i % 4 + (j % 4) * 4);
+								index = (byte)(i % 4 + j % 4 * 4);
 
 							Tiles[new MPos(i, j)] = new TerrainTile(tile, index);
 						}

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -118,13 +118,13 @@ namespace OpenRA
 					items.Add(t.Id, t);
 				}
 
-				return (IReadOnlyDictionary<string, ITerrainInfo>)(new ReadOnlyDictionary<string, ITerrainInfo>(items));
+				return (IReadOnlyDictionary<string, ITerrainInfo>)new ReadOnlyDictionary<string, ITerrainInfo>(items);
 			});
 
 			defaultSequences = Exts.Lazy(() =>
 			{
 				var items = DefaultTerrainInfo.ToDictionary(t => t.Key, t => new SequenceProvider(DefaultFileSystem, this, t.Key, null));
-				return (IReadOnlyDictionary<string, SequenceProvider>)(new ReadOnlyDictionary<string, SequenceProvider>(items));
+				return (IReadOnlyDictionary<string, SequenceProvider>)new ReadOnlyDictionary<string, SequenceProvider>(items);
 			});
 
 			initialThreadId = Environment.CurrentManagedThreadId;

--- a/OpenRA.Game/Network/GameServer.cs
+++ b/OpenRA.Game/Network/GameServer.cs
@@ -254,7 +254,7 @@ namespace OpenRA.Network
 			var clientsNode = new MiniYaml("");
 			var i = 0;
 			foreach (var c in Clients)
-				clientsNode.Nodes.Add(new MiniYamlNode("Client@" + (i++).ToString(), FieldSaver.Save(c)));
+				clientsNode.Nodes.Add(new MiniYamlNode("Client@" + i++.ToString(), FieldSaver.Save(c)));
 
 			root.Add(new MiniYamlNode("Clients", clientsNode));
 			return new MiniYaml("", root)

--- a/OpenRA.Game/Network/TickTime.cs
+++ b/OpenRA.Game/Network/TickTime.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Network
 
 			var currentTimestep = timestep();
 
-			var integralTickTimestep = (tickDelta / currentTimestep) * currentTimestep;
+			var integralTickTimestep = tickDelta / currentTimestep * currentTimestep;
 			lastTickTime += integralTickTimestep >= Game.TimestepJankThreshold
 				? integralTickTimestep
 				: currentTimestep;

--- a/OpenRA.Game/Traits/World/ScreenShaker.cs
+++ b/OpenRA.Game/Traits/World/ScreenShaker.cs
@@ -63,8 +63,8 @@ namespace OpenRA.Traits
 		float2 GetScrollOffset()
 		{
 			return GetMultiplier() * GetIntensity() * new float2(
-				(float)Math.Sin((ticks * 2 * Math.PI) / 4),
-				(float)Math.Cos((ticks * 2 * Math.PI) / 5));
+				(float)Math.Sin(ticks * 2 * Math.PI / 4),
+				(float)Math.Cos(ticks * 2 * Math.PI / 5));
 		}
 
 		float2 GetMultiplier()

--- a/OpenRA.Game/WPos.cs
+++ b/OpenRA.Game/WPos.cs
@@ -74,7 +74,7 @@ namespace OpenRA
 		public override int GetHashCode() { return X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode(); }
 
 		public bool Equals(WPos other) { return other == this; }
-		public override bool Equals(object obj) { return obj is WPos && Equals((WPos)obj); }
+		public override bool Equals(object obj) { return obj is WPos pos && Equals(pos); }
 
 		public override string ToString() { return X + "," + Y + "," + Z; }
 

--- a/OpenRA.Mods.Cnc/FileFormats/LZOCompression.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/LZOCompression.cs
@@ -250,7 +250,11 @@ namespace OpenRA.Mods.Cnc.FileFormats
 					{
 						*op++ = *ip++;
 						if (t > 2)
+						{
+							#pragma warning disable IDE0047
 							(*op++) = *ip++;
+							#pragma warning restore IDE0047
+						}
 					}
 
 					t = *ip++;

--- a/OpenRA.Mods.Cnc/Graphics/TeslaZapRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/TeslaZapRenderable.cs
@@ -110,13 +110,13 @@ namespace OpenRA.Mods.Cnc.Graphics
 		static IEnumerable<IFinalizedRenderable> DrawZapWandering(WorldRenderer wr, float2 from, float2 to, ISpriteSequence s, string pal)
 		{
 			var dist = to - from;
-			var norm = (1f / dist.Length) * new float2(-dist.Y, dist.X);
+			var norm = 1f / dist.Length * new float2(-dist.Y, dist.X);
 
 			var renderables = new List<IFinalizedRenderable>();
 			if (Game.CosmeticRandom.Next(2) != 0)
 			{
-				var p1 = from + (1 / 3f) * dist + WDist.FromPDF(Game.CosmeticRandom, 2).Length * dist.Length / 4096 * norm;
-				var p2 = from + (2 / 3f) * dist + WDist.FromPDF(Game.CosmeticRandom, 2).Length * dist.Length / 4096 * norm;
+				var p1 = from + 1 / 3f * dist + WDist.FromPDF(Game.CosmeticRandom, 2).Length * dist.Length / 4096 * norm;
+				var p2 = from + 2 / 3f * dist + WDist.FromPDF(Game.CosmeticRandom, 2).Length * dist.Length / 4096 * norm;
 
 				renderables.AddRange(DrawZap(wr, from, p1, s, out p1, pal));
 				renderables.AddRange(DrawZap(wr, p1, p2, s, out p2, pal));
@@ -124,7 +124,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 			}
 			else
 			{
-				var p1 = from + (1 / 2f) * dist + WDist.FromPDF(Game.CosmeticRandom, 2).Length * dist.Length / 4096 * norm;
+				var p1 = from + 1 / 2f * dist + WDist.FromPDF(Game.CosmeticRandom, 2).Length * dist.Length / 4096 * norm;
 
 				renderables.AddRange(DrawZap(wr, from, p1, s, out p1, pal));
 				renderables.AddRange(DrawZap(wr, p1, to, s, out _, pal));

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -149,7 +149,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 				var minefield = GetMinefieldCells(minefieldStart, cell, Info.MinefieldDepth)
 					.Where(c => IsCellAcceptable(self, c) && self.Owner.Shroud.IsExplored(c)
-						&& movement.CanEnterCell(c, null, BlockedByActor.Immovable) && (movement is Mobile mobile && mobile.CanStayInCell(c)))
+						&& movement.CanEnterCell(c, null, BlockedByActor.Immovable) && movement is Mobile mobile && mobile.CanStayInCell(c))
 					.OrderBy(c => (c - minefieldStart).LengthSquared).ToList();
 
 				self.QueueActivity(order.Queued, new LayMines(self, minefield));
@@ -180,7 +180,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			// TODO: proper endcaps, if anyone cares (which won't happen unless depth is large)
 			var p = end - start;
 			var q = new float2(p.Y, -p.X);
-			q = (start != end) ? (1 / q.Length) * q : new float2(1, 0);
+			q = (start != end) ? 1 / q.Length * q : new float2(1, 0);
 			var c = -float2.Dot(q, new float2(start.X, start.Y));
 
 			// return all points such that |ax + by + c| < depth

--- a/OpenRA.Mods.Cnc/UtilityCommands/LegacyTilesetImporter.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/LegacyTilesetImporter.cs
@@ -146,7 +146,8 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 
 								data.AppendLine($"\t\t\t\tMinColor: {s.ReadUInt8():X2}{s.ReadUInt8():X2}{s.ReadUInt8():X2}");
 								data.AppendLine($"\t\t\t\tMaxColor: {s.ReadUInt8():X2}{s.ReadUInt8():X2}{s.ReadUInt8():X2}");
-								data.AppendLine($"\t\t\t\tZOffset: {(-tileSize.Height / 2.0f)}");
+								var zOffset = -tileSize.Height / 2.0f;
+								data.AppendLine($"\t\t\t\tZOffset: {zOffset}");
 								data.AppendLine("\t\t\t\tZRamp: 0");
 							}
 						}

--- a/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
@@ -37,11 +37,8 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			if (self.World.Map.DistanceAboveTerrain(self.CenterPosition).Length <= 0)
 			{
-				if (info.ExplosionWeapon != null)
-				{
-					// Use .FromPos since this actor is killed. Cannot use Target.FromActor
-					info.ExplosionWeapon.Impact(Target.FromPos(self.CenterPosition), self);
-				}
+				// Use .FromPos since this actor is killed. Cannot use Target.FromActor
+				info.ExplosionWeapon?.Impact(Target.FromPos(self.CenterPosition), self);
 
 				self.Kill(self);
 				Cancel(self);

--- a/OpenRA.Mods.Common/Activities/RepairBridge.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBridge.cs
@@ -74,8 +74,8 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (enterLegacyHut != null)
 				enterLegacyHut.Repair(self);
-			else if (enterHut != null)
-				enterHut.Repair(self);
+			else
+				enterHut?.Repair(self);
 
 			Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", speechNotification, self.Owner.Faction.InternalName);
 			TextNotificationsManager.AddTransientLine(textNotification, self.Owner);

--- a/OpenRA.Mods.Common/Activities/Sell.cs
+++ b/OpenRA.Mods.Common/Activities/Sell.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Activities
 			// Cast to long to avoid overflow when multiplying by the health
 			var hp = health != null ? (long)health.HP : 1L;
 			var maxHP = health != null ? (long)health.MaxHP : 1L;
-			var refund = (int)((sellValue * sellableInfo.RefundPercent * hp) / (100 * maxHP));
+			var refund = (int)(sellValue * sellableInfo.RefundPercent * hp / (100 * maxHP));
 			refund = playerResources.ChangeCash(refund);
 
 			foreach (var ns in self.TraitsImplementing<INotifySold>())

--- a/OpenRA.Mods.Common/ActorInitializer.cs
+++ b/OpenRA.Mods.Common/ActorInitializer.cs
@@ -53,9 +53,9 @@ namespace OpenRA.Mods.Common
 
 		public void Initialize(int value)
 		{
-			var field = GetType().GetField(nameof(value), BindingFlags.NonPublic | BindingFlags.Instance);
-			if (field != null)
-				field.SetValue(this, value);
+			GetType()
+				.GetField(nameof(value), BindingFlags.NonPublic | BindingFlags.Instance)
+				?.SetValue(this, value);
 		}
 
 		public override MiniYaml Save()

--- a/OpenRA.Mods.Common/FileFormats/ImaAdpcmReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/ImaAdpcmReader.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.FileFormats
 			var sb = (b & 8) != 0;
 			b &= 7;
 
-			var delta = (StepTable[index] * b) / 4 + StepTable[index] / 8;
+			var delta = StepTable[index] * b / 4 + StepTable[index] / 8;
 			if (sb)
 				delta = -delta;
 

--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -376,7 +376,7 @@ namespace OpenRA.Mods.Common.Graphics
 				{
 					for (var frame = 0; frame < length; frame++)
 					{
-						var i = transpose ? (frame % length) * facings + facing :
+						var i = transpose ? frame % length * facings + facing :
 							(facing * stride) + (frame % length);
 
 						usedFrames.Add(frames != null ? frames[i] : start + i);
@@ -530,7 +530,7 @@ namespace OpenRA.Mods.Common.Graphics
 			{
 				for (var frame = 0; frame < length; frame++)
 				{
-					var i = transpose ? (frame % length) * facings + facing :
+					var i = transpose ? frame % length * facings + facing :
 								(facing * stride) + (frame % length);
 					var s = frames != null ? sprites[frames[i]] : sprites[start + i];
 					if (!s.Bounds.IsEmpty)
@@ -574,7 +574,7 @@ namespace OpenRA.Mods.Common.Graphics
 			if (reverseFacings)
 				f = (facings - f) % facings;
 
-			var i = transpose ? (frame % length) * facings + f :
+			var i = transpose ? frame % length * facings + f :
 				(f * stride) + (frame % length);
 
 			var j = frames != null ? frames[i] : start + i;

--- a/OpenRA.Mods.Common/Graphics/ModelRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/ModelRenderable.cs
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.Common.Graphics
 				if (map.Ramp.Contains(cell) && map.Ramp[cell] == 7)
 					pxOrigin += new float3(0, 0, 0.5f * map.Grid.TileSize.Height);
 
-				var shadowOrigin = pxOrigin - groundZ * (new float2(renderProxy.ShadowDirection, 1));
+				var shadowOrigin = pxOrigin - groundZ * new float2(renderProxy.ShadowDirection, 1);
 
 				var psb = renderProxy.ProjectedShadowBounds;
 				var sa = shadowOrigin + psb[0];
@@ -185,7 +185,7 @@ namespace OpenRA.Mods.Common.Graphics
 				var groundPos = model.pos - new WVec(0, 0, wr.World.Map.DistanceAboveTerrain(model.pos).Length);
 				var groundZ = wr.World.Map.Grid.TileSize.Height * (groundPos.Z - model.pos.Z) / 1024f;
 				var pxOrigin = wr.Screen3DPosition(model.pos);
-				var shadowOrigin = pxOrigin - groundZ * (new float2(renderProxy.ShadowDirection, 1));
+				var shadowOrigin = pxOrigin - groundZ * new float2(renderProxy.ShadowDirection, 1);
 
 				// Draw sprite rect
 				var offset = pxOrigin + renderProxy.Sprite.Offset - 0.5f * renderProxy.Sprite.Size;

--- a/OpenRA.Mods.Common/HitShapes/Capsule.cs
+++ b/OpenRA.Mods.Common/HitShapes/Capsule.cs
@@ -74,8 +74,8 @@ namespace OpenRA.Mods.Common.HitShapes
 				return new WDist(Math.Max(0, (PointB - p).Length - Radius.Length));
 
 			var projection = PointA + new int2(
-				(ab.X * t) / 1024,
-				(ab.Y * t) / 1024);
+				ab.X * t / 1024,
+				ab.Y * t / 1024);
 
 			var distance = (projection - p).Length;
 

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -126,7 +126,7 @@ namespace OpenRA.Mods.Common.Lint
 						continue;
 
 					// All weapon sequences must specify their corresponding image
-					var image = ((string)fields.First(f => f.Name == sequenceReference.ImageReference).GetValue(projectileInfo));
+					var image = (string)fields.First(f => f.Name == sequenceReference.ImageReference).GetValue(projectileInfo);
 					if (string.IsNullOrEmpty(image))
 					{
 						if (!sequenceReference.AllowNullImage)

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -217,7 +217,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			var at = (float)ticks / (length - 1);
 			var attitude = angle.Tan() * (1 - 2 * at) / (4 * 1024);
 
-			var u = (facing.Angle % 512) / 512f;
+			var u = facing.Angle % 512 / 512f;
 			var scale = 2048 * u * (1 - u);
 
 			var effective = (int)(facing.Angle < 512

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -301,7 +301,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			// angular speed in radians per tick = rot in facing units per tick * (pi radians / 128 facing units)
 			// pi = 314 / 100
 			// ==> loopRadius = (speed * 128 * 100) / (314 * rot)
-			return (speed * 6400) / (157 * rot);
+			return speed * 6400 / (157 * rot);
 		}
 
 		void DetermineLaunchSpeedAndAngleForIncline(int predClfDist, int diffClfMslHgt, int relTarHorDist,
@@ -315,9 +315,9 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			// Compute minimum speed necessary to both be able to face directly upwards and have enough space
 			// to hit the target without passing it by (and thus having to do horizontal loops)
-			var minSpeed = ((System.Math.Min(predClfDist * 1024 / (1024 - WAngle.FromFacing(vFacing).Sin()),
+			var minSpeed = (System.Math.Min(predClfDist * 1024 / (1024 - WAngle.FromFacing(vFacing).Sin()),
 					(relTarHorDist + predClfDist) * 1024 / (2 * (2048 - WAngle.FromFacing(vFacing).Sin())))
-				* info.VerticalRateOfTurn.Facing * 157) / 6400).Clamp(minLaunchSpeed, maxLaunchSpeed);
+				* info.VerticalRateOfTurn.Facing * 157 / 6400).Clamp(minLaunchSpeed, maxLaunchSpeed);
 
 			if ((sbyte)vFacing < 0)
 				speed = minSpeed;

--- a/OpenRA.Mods.Common/Projectiles/Railgun.cs
+++ b/OpenRA.Mods.Common/Projectiles/Railgun.cs
@@ -159,7 +159,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			// Forward step, pointing from src to target.
 			// QuantizationCont * forwardStep == One cycle of beam in src2target direction.
-			ForwardStep = (info.HelixPitch.Length * SourceToTarget) / (info.QuantizationCount * SourceToTarget.Length);
+			ForwardStep = info.HelixPitch.Length * SourceToTarget / (info.QuantizationCount * SourceToTarget.Length);
 
 			// An easy vector to find which is perpendicular vector to forwardStep, with 0 Z component
 			LeftVector = new WVec(ForwardStep.Y, -ForwardStep.X, 0);

--- a/OpenRA.Mods.Common/SpriteLoaders/PngSheetLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/PngSheetLoader.cs
@@ -125,7 +125,7 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 				if (png.EmbeddedData.ContainsKey("FrameAmount"))
 					frameAmount = FieldLoader.GetValue<int>("FrameAmount", png.EmbeddedData["FrameAmount"]);
 				else
-					frameAmount = (png.Width / frameSize.Width) * (png.Height / frameSize.Height);
+					frameAmount = png.Width / frameSize.Width * (png.Height / frameSize.Height);
 			}
 			else if (png.EmbeddedData.ContainsKey("FrameAmount"))
 			{

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -539,7 +539,7 @@ namespace OpenRA.Mods.Common.Traits
 				return new WVec(1024, 0, 0).Rotate(rot);
 			}
 
-			return (d * 1024 * 8) / (int)distSq;
+			return d * 1024 * 8 / (int)distSq;
 		}
 
 		public Actor GetActorBelow()

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/AttackOrFleeFuzzy.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/AttackOrFleeFuzzy.cs
@@ -218,7 +218,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 					var totalReloadDelay = arm.Weapon.ReloadDelay + (arm.Weapon.BurstDelays[0] * (burst - 1)).Clamp(1, 200);
 					var damageWarheads = arm.Weapon.Warheads.OfType<DamageWarhead>();
 					foreach (var warhead in damageWarheads)
-						sumOfDamage += (warhead.Damage * burst / totalReloadDelay) * 100;
+						sumOfDamage += warhead.Damage * burst / totalReloadDelay * 100;
 				}
 
 				return sumOfDamage;
@@ -239,7 +239,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			if (!own.Any())
 				return 0.0f;
 
-			var relative = (relativeFunc(own, getValue) / relativeFunc(enemy, getValue)) * normalizeByValue;
+			var relative = relativeFunc(own, getValue) / relativeFunc(enemy, getValue) * normalizeByValue;
 			return relative.Clamp(0.0f, 999.0f);
 		}
 

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			var checkIndices = Exts.MakeArray(columnCount * rowCount, i => i).Shuffle(owner.World.LocalRandom);
 			foreach (var i in checkIndices)
 			{
-				var pos = new MPos((i % columnCount) * dangerRadius + dangerRadius / 2, (i / columnCount) * dangerRadius + dangerRadius / 2).ToCPos(map);
+				var pos = new MPos(i % columnCount * dangerRadius + dangerRadius / 2, i / columnCount * dangerRadius + dangerRadius / 2).ToCPos(map);
 
 				if (NearToPosSafely(owner, map.CenterOfCell(pos), out detectedEnemyTarget))
 				{

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -215,10 +215,10 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var offset = buildingInfo.CenterOffset(self.World).Y + 1024;
 
-			return footprint.Select(c => (IRenderable)(new SpriteRenderable(
+			return footprint.Select(c => (IRenderable)new SpriteRenderable(
 				terrainRenderer.TileSprite(new TerrainTile(template, c.Value)),
 				wr.World.Map.CenterOfCell(c.Key), WVec.Zero, -offset, palette, 1f, 1f,
-				float3.Ones, TintModifiers.None, true))).ToArray();
+				float3.Ones, TintModifiers.None, true)).ToArray();
 		}
 
 		bool initialized;

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -153,7 +153,7 @@ namespace OpenRA.Mods.Common.Traits
 		public WVec CenterOffset(World w)
 		{
 			var off = (w.Map.CenterOfCell(new CPos(Dimensions.X, Dimensions.Y)) - w.Map.CenterOfCell(new CPos(1, 1))) / 2;
-			return (off - new WVec(0, 0, off.Z)) + LocalCenterOffset;
+			return off - new WVec(0, 0, off.Z) + LocalCenterOffset;
 		}
 
 		public BaseProvider FindBaseProvider(World world, Player p, CPos topLeft)

--- a/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 				var bounds = map.Bounds;
 				var center = new MPos(bounds.Left + bounds.Width / 2, bounds.Top + bounds.Height / 2).ToCPos(map);
 				var spawnVec = owner.HomeLocation - center;
-				startPos = owner.HomeLocation + spawnVec * (Exts.ISqrt((bounds.Height * bounds.Height + bounds.Width * bounds.Width) / (4 * spawnVec.LengthSquared)));
+				startPos = owner.HomeLocation + spawnVec * Exts.ISqrt((bounds.Height * bounds.Height + bounds.Width * bounds.Width) / (4 * spawnVec.LengthSquared));
 				endPos = startPos;
 				var spawnDirection = new WVec((self.Location - startPos).X, (self.Location - startPos).Y, 0);
 				spawnFacing = spawnDirection.Yaw;

--- a/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
@@ -151,7 +151,7 @@ namespace OpenRA.Mods.Common.Traits
 				var hpToRepair = Math.Min(Info.RepairStep, health.MaxHP - health.HP);
 
 				// Cast to long to avoid overflow when multiplying by the health
-				var cost = Math.Max(1, (int)(((long)hpToRepair * Info.RepairPercent * buildingValue) / (health.MaxHP * 100L)));
+				var cost = Math.Max(1, (int)((long)hpToRepair * Info.RepairPercent * buildingValue / (health.MaxHP * 100L)));
 
 				// TakeCash will return false if the player can't pay, and will stop him from contributing this Tick
 				var activePlayers = Repairers.Count(player => player.PlayerActor.Trait<PlayerResources>().TakeCash(cost, true));

--- a/OpenRA.Mods.Common/Traits/Player/ClassicParallelProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicParallelProductionQueue.cs
@@ -208,7 +208,7 @@ namespace OpenRA.Mods.Common.Traits
 					.Count(p => !p.Trait.IsTraitDisabled && !p.Trait.IsTraitPaused && p.Actor.Owner == self.Owner && p.Trait.Info.Produces.Contains(type));
 
 				var speedModifier = selfsameProductionsCount.Clamp(1, info.BuildingCountBuildTimeMultipliers.Length) - 1;
-				time = (time * info.BuildingCountBuildTimeMultipliers[speedModifier]) / 100;
+				time = time * info.BuildingCountBuildTimeMultipliers[speedModifier] / 100;
 			}
 
 			return time;

--- a/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
@@ -152,7 +152,7 @@ namespace OpenRA.Mods.Common.Traits
 					.Count(p => !p.Trait.IsTraitDisabled && !p.Trait.IsTraitPaused && p.Actor.Owner == self.Owner && p.Trait.Info.Produces.Contains(type));
 
 				var speedModifier = selfsameProductionsCount.Clamp(1, info.BuildTimeSpeedReduction.Length) - 1;
-				time = (time * info.BuildTimeSpeedReduction[speedModifier]) / 100;
+				time = time * info.BuildTimeSpeedReduction[speedModifier] / 100;
 			}
 
 			return time;

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
@@ -74,8 +74,7 @@ namespace OpenRA.Mods.Common.Traits
 				self.World.Add(playerBeacon);
 
 				if (self.Owner.IsAlliedWith(self.World.RenderPlayer))
-					Game.Sound.PlayNotification(self.World.Map.Rules, null, info.NotificationType, info.Notification,
-						self.World.RenderPlayer != null ? self.World.RenderPlayer.Faction.InternalName : null);
+					Game.Sound.PlayNotification(self.World.Map.Rules, null, info.NotificationType, info.Notification, self.World.RenderPlayer?.Faction.InternalName);
 
 				if (radarPings != null)
 				{

--- a/OpenRA.Mods.Common/Traits/Render/WithDecorationBase.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecorationBase.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			if (blinkPattern != null && blinkPattern.Length > 0)
 			{
-				var i = (self.World.WorldTick / Info.BlinkInterval) % blinkPattern.Length;
+				var i = self.World.WorldTick / Info.BlinkInterval % blinkPattern.Length;
 				if (blinkPattern[i] != BlinkState.On)
 					return false;
 			}

--- a/OpenRA.Mods.Common/Traits/Render/WithResourceLevelOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResourceLevelOverlay.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var a = new Animation(self.World, rs.GetImage(self));
 			a.PlayFetchIndex(info.Sequence, () =>
 				playerResources.ResourceCapacity != 0 ?
-				((10 * a.CurrentSequence.Length - 1) * playerResources.Resources) / (10 * playerResources.ResourceCapacity) :
+				(10 * a.CurrentSequence.Length - 1) * playerResources.Resources / (10 * playerResources.ResourceCapacity) :
 				0);
 
 			anim = new AnimationWithOffset(a, null, () => IsTraitDisabled, 1024);

--- a/OpenRA.Mods.Common/Traits/Render/WithResourceLevelSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResourceLevelSpriteBody.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			DefaultAnimation.PlayFetchIndex(NormalizeSequence(self, Info.Sequence),
 				() => playerResources.ResourceCapacity != 0
-					? ((info.Stages * DefaultAnimation.CurrentSequence.Length - 1) * playerResources.Resources) / (info.Stages * playerResources.ResourceCapacity)
+					? (info.Stages * DefaultAnimation.CurrentSequence.Length - 1) * playerResources.Resources / (info.Stages * playerResources.ResourceCapacity)
 					: 0);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithShadow.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithShadow.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				.Select(ma => ((IModifyableRenderable)ma).WithTint(shadowColor, ((IModifyableRenderable)ma).TintModifiers | TintModifiers.ReplaceColor)
 					.WithAlpha(shadowAlpha)
 					.OffsetBy(info.Offset - new WVec(0, 0, height))
-					.WithZOffset(ma.ZOffset + (height + info.ZOffset))
+					.WithZOffset(ma.ZOffset + height + info.ZOffset)
 					.AsDecoration());
 
 			return shadowSprites.Concat(r);

--- a/OpenRA.Mods.Common/Traits/Sellable.cs
+++ b/OpenRA.Mods.Common/Traits/Sellable.cs
@@ -111,7 +111,7 @@ namespace OpenRA.Mods.Common.Traits
 				// Cast to long to avoid overflow when multiplying by the health
 				var hp = health != null ? (long)health.Value.HP : 1L;
 				var maxHP = health != null ? (long)health.Value.MaxHP : 1L;
-				var refund = (int)((sellValue * info.RefundPercent * hp) / (100 * maxHP));
+				var refund = (int)(sellValue * info.RefundPercent * hp / (100 * maxHP));
 
 				return "Refund: $" + refund;
 			}

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -91,9 +91,9 @@ namespace OpenRA.Mods.Common.Traits
 				if (speed > 0)
 				{
 					var nodesDict = t.Value.ToDictionary();
-					var cost = (nodesDict.ContainsKey("PathingCost")
+					var cost = nodesDict.ContainsKey("PathingCost")
 						? FieldLoader.GetValue<short>("cost", nodesDict["PathingCost"].Value)
-						: 10000 / speed);
+						: 10000 / speed;
 					ret.Add(t.Key, new TerrainInfo(speed, (short)cost));
 				}
 			}

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -214,9 +214,9 @@ namespace OpenRA.Mods.Common.Traits
 
 			// All tiles are visible in the editor
 			if (w.Type == WorldType.Editor)
-				cellVisibility = puv => (map.Contains(puv) ? Shroud.CellVisibility.Visible | Shroud.CellVisibility.Explored : Shroud.CellVisibility.Explored);
+				cellVisibility = puv => map.Contains(puv) ? Shroud.CellVisibility.Visible | Shroud.CellVisibility.Explored : Shroud.CellVisibility.Explored;
 			else
-				cellVisibility = puv => (map.Contains(puv) ? Shroud.CellVisibility.Visible | Shroud.CellVisibility.Explored : Shroud.CellVisibility.Hidden);
+				cellVisibility = puv => map.Contains(puv) ? Shroud.CellVisibility.Visible | Shroud.CellVisibility.Explored : Shroud.CellVisibility.Hidden;
 
 			var shroudBlend = shroudSprites[0].Sprite.BlendMode;
 			if (shroudSprites.Any(s => s.Sprite.BlendMode != shroudBlend))
@@ -309,7 +309,7 @@ namespace OpenRA.Mods.Common.Traits
 				else
 				{
 					// Visible under shroud: Explored. Visible under fog: Visible.
-					cellVisibility = puv => (map.Contains(puv) ? Shroud.CellVisibility.Visible | Shroud.CellVisibility.Explored : Shroud.CellVisibility.Hidden);
+					cellVisibility = puv => map.Contains(puv) ? Shroud.CellVisibility.Visible | Shroud.CellVisibility.Explored : Shroud.CellVisibility.Hidden;
 				}
 
 				shroud = newShroud;

--- a/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
+++ b/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (!world.IsLoadingGameSave)
 			{
-				Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", info.Notification, world.RenderPlayer == null ? null : world.RenderPlayer.Faction.InternalName);
+				Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", info.Notification, world.RenderPlayer?.Faction.InternalName);
 				TextNotificationsManager.AddTransientLine(info.TextNotification, null);
 			}
 		}
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (!world.IsReplay)
 			{
-				Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", info.LoadedNotification, world.RenderPlayer == null ? null : world.RenderPlayer.Faction.InternalName);
+				Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", info.LoadedNotification, world.RenderPlayer?.Faction.InternalName);
 				TextNotificationsManager.AddTransientLine(info.LoadedTextNotification, null);
 			}
 		}
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (!world.IsReplay)
 			{
-				Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", info.SavedNotification, world.RenderPlayer == null ? null : world.RenderPlayer.Faction.InternalName);
+				Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", info.SavedNotification, world.RenderPlayer?.Faction.InternalName);
 				TextNotificationsManager.AddTransientLine(info.SavedTextNotification, null);
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
@@ -140,7 +140,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				for (var x = 0; x < template.Size.X; x++)
 				{
-					var tile = new TerrainTile(template.Id, (byte)(i++));
+					var tile = new TerrainTile(template.Id, (byte)i++);
 					if (!terrainInfo.TryGetTileInfo(tile, out var tileInfo))
 						continue;
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20221203/ExplicitSequenceFilenames.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20221203/ExplicitSequenceFilenames.cs
@@ -357,7 +357,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				foreach (var node in combineNode.Value.Nodes)
 				{
 					ProcessNode(modData, node, node, node.Key);
-					node.Key = (i++).ToString();
+					node.Key = i++.ToString();
 				}
 
 				return;

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -117,8 +117,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 			if (namedType != null && namedType.IsSubclassOf(typeof(UpdateRule)))
 				return new[] { (UpdateRule)objectCreator.CreateBasic(namedType) };
 
-			var namedPath = Paths.FirstOrDefault(p => p.source == source);
-			return namedPath != null ? namedPath.Rules(chain) : null;
+			return Paths.FirstOrDefault(p => p.source == source)?.Rules(chain);
 		}
 
 		public static IEnumerable<string> KnownPaths { get { return Paths.Select(p => p.source); } }

--- a/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
@@ -79,7 +79,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				}
 
 				var png = new Png(pngData, SpriteFrameType.Indexed8, frameSize.Width, frameSize.Height, palColors);
-				png.Save($"{prefix}-{(count++):D4}.png");
+				#pragma warning disable SA1003
+				png.Save($"{prefix}-{count++:D4}.png");
+				#pragma warning restore SA1003
 			}
 
 			Console.WriteLine("Saved {0}-[0..{1}].png", prefix, count - 1);

--- a/OpenRA.Mods.Common/UtilityCommands/PngSheetImportMetadataCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/PngSheetImportMetadataCommand.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				if (frameAmountField != null)
 				{
 					var frameAmount = FieldLoader.GetValue<int>("FrameAmount", frameAmountField);
-					if (frameAmount > (png.Width / frameSize.Width) * (png.Height / frameSize.Height))
+					if (frameAmount > png.Width / frameSize.Width * (png.Height / frameSize.Height))
 						throw new InvalidDataException(".png file is too small for given FrameSize and FrameAmount.");
 				}
 			}

--- a/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
@@ -68,7 +68,11 @@ namespace OpenRA.Mods.Common.Widgets
 					var c = (int*)cc;
 					for (var s = 0; s < 256; s++)
 					for (var h = 0; h < 256; h++)
+					{
+						#pragma warning disable IDE0047
 						(*(c + s * 256 + h)) = Color.FromAhsv(h / 255f, 1 - s / 255f, V).ToArgb();
+						#pragma warning restore IDE0047
+					}
 				}
 			}
 

--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var panelY = RenderOrigin.Y + Bounds.Height - panelRoot.RenderOrigin.Y;
 			if (panelY + oldBounds.Height > Game.Renderer.Resolution.Height)
-				panelY -= (Bounds.Height + oldBounds.Height);
+				panelY -= Bounds.Height + oldBounds.Height;
 
 			panel.Bounds = new Rectangle(
 				panelX,

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -126,7 +126,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var buildTime = tooltipIcon.ProductionQueue?.GetBuildTime(actor, buildable) ?? 0;
 				var timeModifier = pm != null && pm.PowerState != PowerState.Normal ? tooltipIcon.ProductionQueue.Info.LowPowerModifier : 100;
 
-				timeLabel.Text = formatBuildTime.Update((buildTime * timeModifier) / 100);
+				timeLabel.Text = formatBuildTime.Update(buildTime * timeModifier / 100);
 				timeLabel.TextColor = (pm != null && pm.PowerState != PowerState.Normal && tooltipIcon.ProductionQueue.Info.LowPowerModifier > 100) ? Color.Red : Color.White;
 				var timeSize = font.Measure(timeLabel.Text);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -283,7 +283,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var selectedSpawn = DetermineSelectedSpawnPoint(mapPreview, preview, mi);
 
 			var locals = orderManager.LobbyInfo.Clients.Where(c => c.Index == orderManager.LocalClient.Index || (Game.IsHost && c.Bot != null));
-			var playerToMove = locals.FirstOrDefault(c => ((selectedSpawn == 0) ^ (c.SpawnPoint == 0) && !c.IsObserver));
+			var playerToMove = locals.FirstOrDefault(c => (selectedSpawn == 0) ^ (c.SpawnPoint == 0) && !c.IsObserver);
 			SetSpawnPoint(orderManager, playerToMove, selectedSpawn);
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/AudioSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/AudioSettingsLogic.cs
@@ -154,7 +154,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void ShowAudioDeviceDropdown(DropDownButtonWidget dropdown, SoundDevice[] devices, ScrollPanelWidget scrollPanel)
 		{
 			var i = 0;
-			var options = devices.ToDictionary(d => (i++).ToString(), d => d);
+			var options = devices.ToDictionary(d => i++.ToString(), d => d);
 
 			Func<string, ScrollItemWidget, ScrollItemWidget> setupItem = (o, itemTemplate) =>
 			{

--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -171,7 +171,7 @@ namespace OpenRA.Mods.Common.Widgets
 			set
 			{
 				paletteWidget.Value.CurrentQueue = value;
-				queueGroup = value != null ? value.Info.Group : null;
+				queueGroup = value?.Info.Group;
 
 				// TODO: Scroll tabs so selected queue is visible
 			}

--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Widgets
 			foreach (var queue in queues)
 				tabs.Add(new ProductionTab()
 				{
-					Name = (NextQueueName++).ToString(),
+					Name = NextQueueName++.ToString(),
 					Queue = queue
 				});
 			Tabs = tabs;

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			currentPlayer = player;
 
-			var newShroud = player != null ? player.Shroud : null;
+			var newShroud = player?.Shroud;
 
 			if (newShroud != shroud)
 			{
@@ -146,8 +146,7 @@ namespace OpenRA.Mods.Common.Widgets
 				shroud = newShroud;
 			}
 
-			var newPlayerRadarTerrain =
-				currentPlayer != null ? currentPlayer.PlayerActor.TraitOrDefault<PlayerRadarTerrain>() : null;
+			var newPlayerRadarTerrain = currentPlayer?.PlayerActor.TraitOrDefault<PlayerRadarTerrain>();
 
 			if (forceUpdate || newPlayerRadarTerrain != playerRadarTerrain)
 			{

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -207,7 +207,7 @@ namespace OpenRA.Mods.Common.Widgets
 					var deltaScale = Math.Min(Game.RunTime - lastScrollTime, 25f);
 
 					var length = Math.Max(1, scroll.Length);
-					scroll *= (deltaScale / (25 * length)) * Game.Settings.Game.ViewportEdgeScrollStep;
+					scroll *= deltaScale / (25 * length) * Game.Settings.Game.ViewportEdgeScrollStep;
 
 					worldRenderer.Viewport.Scroll(scroll, false);
 					lastScrollTime = Game.RunTime;


### PR DESCRIPTION
Use null propagation
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0031

Remove unnecessary parentheses
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0047-ide0048

Silencing `Use span-based 'string.Concat'` suggestion as span it is incompatible with MONO
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1845