### PR TITLE
Fixed displayed audio length in the AssetBrowser

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -226,15 +226,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var frameText = panel.GetOrNull<LabelWidget>("FRAME_COUNT");
 			if (frameText != null)
 			{
-				var soundLength = new CachedTransform<int, string>(p =>
-					modData.Translation.GetString(LengthInSeconds, Translation.Arguments("length", p)));
+				var soundLength = new CachedTransform<double, string>(p =>
+					modData.Translation.GetString(LengthInSeconds, Translation.Arguments("length", Math.Round(p, 3))));
+
 				frameText.GetText = () =>
 				{
 					if (isVideoLoaded)
 						return $"{player.Video.CurrentFrameIndex + 1} / {player.Video.FrameCount}";
 
 					if (currentSoundFormat != null)
-						return soundLength.Update((int)currentSoundFormat.LengthInSeconds);
+						return soundLength.Update(currentSoundFormat.LengthInSeconds);
 
 					return $"{currentFrame} / {currentSprites.Length - 1}";
 				};


### PR DESCRIPTION
#20048 changed what was a deliberate feature from #19143, changing the displayed value:
![image](https://user-images.githubusercontent.com/7137365/220077582-30cae960-3263-4adc-9332-0d9ef6f29071.png)

This PR changes that back (while of course keeping the translation changes).