### PR TITLE
Make minor AssetBrowser fixes

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -378,10 +378,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var assetBrowserModData = modData.Manifest.Get<AssetBrowser>();
-			allowedSpriteExtensions = assetBrowserModData.SpriteExtensions;
-			allowedModelExtensions = assetBrowserModData.ModelExtensions;
-			allowedAudioExtensions = assetBrowserModData.AudioExtensions;
-			allowedVideoExtensions = assetBrowserModData.VideoExtensions;
+			allowedSpriteExtensions = assetBrowserModData.SpriteExtensions.Select(x => x.ToLowerInvariant()).ToArray();
+			allowedModelExtensions = assetBrowserModData.ModelExtensions.Select(x => x.ToLowerInvariant()).ToArray();
+			allowedAudioExtensions = assetBrowserModData.AudioExtensions.Select(x => x.ToLowerInvariant()).ToArray();
+			allowedVideoExtensions = assetBrowserModData.VideoExtensions.Select(x => x.ToLowerInvariant()).ToArray();
 			allowedExtensions = allowedSpriteExtensions
 				.Union(allowedModelExtensions)
 				.Union(allowedAudioExtensions)

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var spriteWidget = panel.GetOrNull<SpriteWidget>("SPRITE");
 			if (spriteWidget != null)
 			{
-				spriteWidget.GetSprite = () => currentSprites?[currentFrame];
+				spriteWidget.GetSprite = () => currentSprites?.Length > 0 ? currentSprites[currentFrame] : null;
 				currentPalette = spriteWidget.Palette;
 				spriteScale = spriteWidget.Scale;
 				spriteWidget.GetPalette = () => currentPalette;
@@ -507,7 +507,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					currentSprites = world.Map.Rules.Sequences.SpriteCache[prefix + filename];
 					currentFrame = 0;
 
-					if (frameSlider != null)
+					if (frameSlider != null && currentSprites?.Length > 0)
 					{
 						frameSlider.MaximumValue = (float)currentSprites.Length - 1;
 						frameSlider.Ticks = currentSprites.Length;


### PR DESCRIPTION
Currently TDHD doesn't show HD sprites in its AsssetBrowser because of ".dds" vs ".DDS" - https://github.com/pchote/TiberianDawnHD/blob/master/mods/cnc/mod.yaml#L281
That could be changed in the mod definition, but I feel it makes no sense to leave the AssetBrowser doing this when it already `.ToLowerInvariant`s the current file's extension right before comparing with the allowed types - https://github.com/pchote/TiberianDawnHD/blob/master/mods/cnc/mod.yaml#L281