### PR TITLE
Change click sound InterruptType to Overlap

### DIFF
--- a/mods/cnc/audio/notifications.yaml
+++ b/mods/cnc/audio/notifications.yaml
@@ -66,9 +66,9 @@ Sounds:
 		ChatLine: scold1
 			InterruptType: Interrupt
 		ClickDisabledSound: scold2
-			InterruptType: Interrupt
+			InterruptType: Overlap
 		ClickSound: button
-			InterruptType: Interrupt
+			InterruptType: Overlap
 		Cloak: trans1
 		Clock: clock1
 		Construction: constru2

--- a/mods/d2k/audio/notifications.yaml
+++ b/mods/d2k/audio/notifications.yaml
@@ -76,10 +76,10 @@ Sounds:
 		BuildPaletteOpen: BUTTON1
 		BuildPaletteClose: BUTTON1
 		TabClick: SIDEBAR1
-			InterruptType: Interrupt
+			InterruptType: Overlap
 		ClickSound: BUTTON1
-			InterruptType: Interrupt
+			InterruptType: Overlap
 		ClickDisabledSound: ENDLIST1
-			InterruptType: Interrupt
+			InterruptType: Overlap
 		Beacon: CHAT1
 			InterruptType: Interrupt

--- a/mods/ra/audio/notifications.yaml
+++ b/mods/ra/audio/notifications.yaml
@@ -130,7 +130,7 @@ Sounds:
 		ChatLine: rabeep1
 			InterruptType: Interrupt
 		ClickSound: ramenu1
-			InterruptType: Interrupt
+			InterruptType: Overlap
 		ClickDisabledSound:
 		Beacon: beepslct
 			InterruptType: Interrupt

--- a/mods/ts/audio/sounds-generic.yaml
+++ b/mods/ts/audio/sounds-generic.yaml
@@ -18,9 +18,9 @@ Sounds:
 		ChatLine: message1
 			InterruptType: Interrupt
 		ClickDisabledSound: wrong1
-			InterruptType: Interrupt
+			InterruptType: Overlap
 		ClickSound: clicky1
-			InterruptType: Interrupt
+			InterruptType: Overlap
 		GameForming: gamefrm1
 		Gdiclose: gdiclose
 		Gdiopen: gdiopen


### PR DESCRIPTION
Closes #20682
Followup to #20363

The only things left on Interrupt are - beacons and chat. These are the ones we will want to keep as these events can get spammed and released all at once in case of network issues

Fix confirmed by [UppsAlert](https://github.com/UppsAlert) (but not the PR)