### PR TITLE
Enable more code style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -147,6 +147,9 @@ dotnet_diagnostic.IDE0018.severity = warning
 # Use pattern matching to avoid 'as' followed by a 'null' check.
 dotnet_diagnostic.IDE0019.severity = warning
 
+# Use pattern matching to avoid 'is' check followed by a cast.
+dotnet_diagnostic.IDE0020.severity = warning
+
 # Collection initialization can be simplified
 dotnet_diagnostic.IDE0028.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -207,6 +207,9 @@ dotnet_diagnostic.IDE0075.severity = warning
 # Convert typeof to nameof.
 dotnet_diagnostic.IDE0082.severity = warning
 
+# Remove unnecessary equality operator.
+dotnet_diagnostic.IDE0100.severity = warning
+
 # Naming rule violation.
 dotnet_diagnostic.IDE1006.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -156,6 +156,9 @@ dotnet_diagnostic.IDE0028.severity = warning
 # Use coalesce expression (non-nullable types).
 dotnet_diagnostic.IDE0029.severity = warning
 
+# Use coalesce expression (nullable types).
+dotnet_diagnostic.IDE0030.severity = warning
+
 # Simplify 'default' expression
 dotnet_diagnostic.IDE0034.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -144,6 +144,9 @@ dotnet_diagnostic.IDE0017.severity = warning
 # Inline variable declaration.
 dotnet_diagnostic.IDE0018.severity = warning
 
+# Use pattern matching to avoid 'as' followed by a 'null' check.
+dotnet_diagnostic.IDE0019.severity = warning
+
 # Collection initialization can be simplified
 dotnet_diagnostic.IDE0028.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -198,6 +198,9 @@ dotnet_diagnostic.IDE0060.severity = warning
 # Use expression body for local functions.
 dotnet_diagnostic.IDE0061.severity = warning
 
+# Simplify interpolation.
+dotnet_diagnostic.IDE0071.severity = warning
+
 # Naming rule violation.
 dotnet_diagnostic.IDE1006.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -204,6 +204,9 @@ dotnet_diagnostic.IDE0071.severity = warning
 # Simplify conditional expression.
 dotnet_diagnostic.IDE0075.severity = warning
 
+# Convert typeof to nameof.
+dotnet_diagnostic.IDE0082.severity = warning
+
 # Naming rule violation.
 dotnet_diagnostic.IDE1006.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -129,6 +129,9 @@ dotnet_style_require_accessibility_modifiers = omit_if_default:warning
 # Simplify name.
 dotnet_diagnostic.IDE0001.severity = warning
 
+# Simplify member access.
+dotnet_diagnostic.IDE0002.severity = warning
+
 # use 'var' instead of explicit type
 dotnet_diagnostic.IDE0007.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -213,6 +213,9 @@ dotnet_diagnostic.IDE0100.severity = warning
 # Simplify LINQ expression.
 dotnet_diagnostic.IDE0120.severity = warning
 
+# Use tuple to swap values.
+dotnet_diagnostic.IDE0180.severity = warning
+
 # Naming rule violation.
 dotnet_diagnostic.IDE1006.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -171,6 +171,9 @@ dotnet_diagnostic.IDE0036.severity = warning
 # Raise a warning on build when default access modifiers are explicitly specified.
 dotnet_diagnostic.IDE0040.severity = warning
 
+# Use 'is null' check.
+dotnet_diagnostic.IDE0041.severity = warning
+
 # Make field readonly.
 dotnet_diagnostic.IDE0044.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -126,6 +126,9 @@ dotnet_style_predefined_type_for_locals_parameters_members = true
 # Show an IDE warning when default access modifiers are explicitly specified.
 dotnet_style_require_accessibility_modifiers = omit_if_default:warning
 
+# Simplify name.
+dotnet_diagnostic.IDE0001.severity = warning
+
 # use 'var' instead of explicit type
 dotnet_diagnostic.IDE0007.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -210,6 +210,9 @@ dotnet_diagnostic.IDE0082.severity = warning
 # Remove unnecessary equality operator.
 dotnet_diagnostic.IDE0100.severity = warning
 
+# Simplify LINQ expression.
+dotnet_diagnostic.IDE0120.severity = warning
+
 # Naming rule violation.
 dotnet_diagnostic.IDE1006.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -153,6 +153,9 @@ dotnet_diagnostic.IDE0020.severity = warning
 # Collection initialization can be simplified
 dotnet_diagnostic.IDE0028.severity = warning
 
+# Use coalesce expression (non-nullable types).
+dotnet_diagnostic.IDE0029.severity = warning
+
 # Simplify 'default' expression
 dotnet_diagnostic.IDE0034.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -121,6 +121,9 @@ dotnet_style_predefined_type_for_member_access = true
 # IDE0049, IDE-only counterpart of StyleCopAnalyzers - SA1121: UseBuiltInTypeAlias.
 dotnet_style_predefined_type_for_locals_parameters_members = true
 
+# Use expression body if a local function is a single line.
+csharp_style_expression_bodied_local_functions = when_on_single_line
+
 ## Others:
 
 # Show an IDE warning when default access modifiers are explicitly specified.
@@ -191,6 +194,9 @@ dotnet_diagnostic.IDE0059.severity = warning
 
 # Unused parameter.
 dotnet_diagnostic.IDE0060.severity = warning
+
+# Use expression body for local functions.
+dotnet_diagnostic.IDE0061.severity = warning
 
 # Naming rule violation.
 dotnet_diagnostic.IDE1006.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -177,7 +177,10 @@ dotnet_diagnostic.IDE0041.severity = warning
 # Make field readonly.
 dotnet_diagnostic.IDE0044.severity = warning
 
-# Unused private member.
+# Remove unused private member.
+dotnet_diagnostic.IDE0051.severity = warning
+
+# Remove unread private member.
 dotnet_diagnostic.IDE0052.severity = warning
 
 # Unnecessary value assignment.

--- a/.editorconfig
+++ b/.editorconfig
@@ -201,6 +201,9 @@ dotnet_diagnostic.IDE0061.severity = warning
 # Simplify interpolation.
 dotnet_diagnostic.IDE0071.severity = warning
 
+# Simplify conditional expression.
+dotnet_diagnostic.IDE0075.severity = warning
+
 # Naming rule violation.
 dotnet_diagnostic.IDE1006.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -141,6 +141,9 @@ dotnet_diagnostic.IDE0011.severity = silent
 # Object initialization can be simplified / Use object initializer.
 dotnet_diagnostic.IDE0017.severity = warning
 
+# Inline variable declaration.
+dotnet_diagnostic.IDE0018.severity = warning
+
 # Collection initialization can be simplified
 dotnet_diagnostic.IDE0028.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -183,6 +183,9 @@ dotnet_diagnostic.IDE0051.severity = warning
 # Remove unread private member.
 dotnet_diagnostic.IDE0052.severity = warning
 
+# Use compound assignment.
+dotnet_diagnostic.IDE0054.severity = warning
+
 # Unnecessary value assignment.
 dotnet_diagnostic.IDE0059.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -216,6 +216,9 @@ dotnet_diagnostic.IDE0120.severity = warning
 # Use tuple to swap values.
 dotnet_diagnostic.IDE0180.severity = warning
 
+# Make struct 'readonly'.
+dotnet_diagnostic.IDE0250.severity = warning
+
 # Naming rule violation.
 dotnet_diagnostic.IDE1006.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -159,6 +159,9 @@ dotnet_diagnostic.IDE0029.severity = warning
 # Use coalesce expression (nullable types).
 dotnet_diagnostic.IDE0030.severity = warning
 
+# Use explicitly provided tuple name.
+dotnet_diagnostic.IDE0033.severity = warning
+
 # Simplify 'default' expression
 dotnet_diagnostic.IDE0034.severity = warning
 

--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -266,7 +266,7 @@ namespace OpenRA.Graphics
 			if (rotation == 0f)
 				return new Rectangle((int)offset.X, (int)offset.Y, (int)size.X, (int)size.Y);
 
-			var rotatedQuad = Util.RotateQuad(offset, size, rotation);
+			var rotatedQuad = RotateQuad(offset, size, rotation);
 			var minX = rotatedQuad[0].X;
 			var maxX = rotatedQuad[0].X;
 			var minY = rotatedQuad[0].Y;

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -121,23 +121,6 @@ namespace OpenRA.Graphics
 		public static long LastMoveRunTime = 0;
 		public static int2 LastMousePos;
 
-		float ClosestTo(float[] collection, float target)
-		{
-			var closestValue = collection.First();
-			var subtractResult = Math.Abs(closestValue - target);
-
-			foreach (var element in collection)
-			{
-				if (Math.Abs(element - target) < subtractResult)
-				{
-					subtractResult = Math.Abs(element - target);
-					closestValue = element;
-				}
-			}
-
-			return closestValue;
-		}
-
 		public ScrollDirection GetBlockedDirections()
 		{
 			var ret = ScrollDirection.None;

--- a/OpenRA.Game/Input/Hotkey.cs
+++ b/OpenRA.Game/Input/Hotkey.cs
@@ -84,7 +84,7 @@ namespace OpenRA
 			return obj is Hotkey o && (Hotkey?)o == this;
 		}
 
-		public override string ToString() { return $"{Key} {Modifiers.ToString("F")}"; }
+		public override string ToString() { return $"{Key} {Modifiers:F}"; }
 
 		public string DisplayString()
 		{

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -748,7 +748,7 @@ namespace OpenRA
 		public byte[] SavePreview()
 		{
 			var actorTypes = Rules.Actors.Values.Where(a => a.HasTraitInfo<IMapPreviewSignatureInfo>());
-			var actors = ActorDefinitions.Where(a => actorTypes.Where(ai => ai.Name == a.Value.Value).Any());
+			var actors = ActorDefinitions.Where(a => actorTypes.Any(ai => ai.Name == a.Value.Value));
 			var positions = new List<(MPos Position, Color Color)>();
 			foreach (var actor in actors)
 			{

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -137,7 +137,7 @@ namespace OpenRA
 			IReadOnlyPackage mapPackage = null;
 			try
 			{
-				using (new Support.PerfTimer(map))
+				using (new PerfTimer(map))
 				{
 					mapPackage = package.OpenPackage(map, modData.ModFiles);
 					if (mapPackage != null)

--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -188,7 +188,7 @@ namespace OpenRA.Network
 			public (string[] Names, Values Values) NamesValues;
 		}
 
-		struct TypeInfo
+		readonly struct TypeInfo
 		{
 			static readonly ParameterExpression SyncParam = Expression.Parameter(typeof(ISync), "sync");
 			static readonly ConstantExpression NullString = Expression.Constant(null, typeof(string));

--- a/OpenRA.Game/Scripting/ScriptTypes.cs
+++ b/OpenRA.Game/Scripting/ScriptTypes.cs
@@ -176,9 +176,8 @@ namespace OpenRA.Scripting
 				return new LuaCustomClrObject(obj);
 			}
 
-			if (obj is Array)
+			if (obj is Array array)
 			{
-				var array = (Array)obj;
 				var i = 1;
 				var table = context.CreateTable();
 

--- a/OpenRA.Game/Server/PlayerMessageTracker.cs
+++ b/OpenRA.Game/Server/PlayerMessageTracker.cs
@@ -47,10 +47,7 @@ namespace OpenRA.Server
 			var tracker = messageTracker[conn.PlayerIndex];
 			tracker.RemoveAll(t => t + settings.FloodLimitInterval < time);
 
-			long CalculateRemaining(long cooldown)
-			{
-				return (cooldown - time + 999) / 1000;
-			}
+			long CalculateRemaining(long cooldown) => (cooldown - time + 999) / 1000;
 
 			// Block messages until join cooldown times out
 			if (!isAdmin && time < settings.FloodLimitJoinCooldown)

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Traits
 	}
 
 	/// <summary>
-	/// Type tag for DamageTypes <see cref="Primitives.BitSet{T}"/>.
+	/// Type tag for DamageTypes <see cref="BitSet{T}"/>.
 	/// </summary>
 	public sealed class DamageType { DamageType() { } }
 
@@ -483,7 +483,7 @@ namespace OpenRA.Traits
 	}
 
 	/// <summary>
-	/// Indicates target types as defined on <see cref="Traits.ITargetable"/> are present in a <see cref="Primitives.BitSet{T}"/>.
+	/// Indicates target types as defined on <see cref="ITargetable"/> are present in a <see cref="BitSet{T}"/>.
 	/// </summary>
 	public sealed class TargetableType { TargetableType() { } }
 

--- a/OpenRA.Game/WPos.cs
+++ b/OpenRA.Game/WPos.cs
@@ -66,7 +66,7 @@ namespace OpenRA
 			// Add an additional quadratic variation to height
 			// Uses decimal to avoid integer overflow
 			var offset = (decimal)(b - a).Length * pitch.Tan() * mul * (div - mul) / (1024 * div * div);
-			var clampedOffset = (int)(offset + (decimal)ret.Z).Clamp<decimal>((decimal)int.MinValue, (decimal)int.MaxValue);
+			var clampedOffset = (int)(offset + (decimal)ret.Z).Clamp((decimal)int.MinValue, (decimal)int.MaxValue);
 
 			return new WPos(ret.X, ret.Y, clampedOffset);
 		}

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -516,12 +516,12 @@ namespace OpenRA
 
 		public void ApplyToActorsWithTraitTimed<T>(Action<Actor, T> action, string text)
 		{
-			TraitDict.ApplyToActorsWithTraitTimed<T>(action, text);
+			TraitDict.ApplyToActorsWithTraitTimed(action, text);
 		}
 
 		public void ApplyToActorsWithTrait<T>(Action<Actor, T> action)
 		{
-			TraitDict.ApplyToActorsWithTrait<T>(action);
+			TraitDict.ApplyToActorsWithTrait(action);
 		}
 
 		public IEnumerable<Actor> ActorsHavingTrait<T>()

--- a/OpenRA.Mods.Cnc/Effects/GpsDotEffect.cs
+++ b/OpenRA.Mods.Cnc/Effects/GpsDotEffect.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Cnc.Effects
 				if (frozenLayer != null)
 				{
 					var frozenActor = frozenLayer.FromID(a.ActorID);
-					FrozenActorWithRenderables = frozenActor != null ? frozenActor.HasRenderables : false;
+					FrozenActorWithRenderables = frozenActor != null && frozenActor.HasRenderables;
 				}
 			}
 		}

--- a/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
@@ -144,7 +144,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 			{
 				for (i = 0; i < len - i2; i++) n[i] = n[i + i2];
 				for (; i < len; i++) n[i] = 0;
-				bits = bits % 32;
+				bits %= 32;
 			}
 
 			if (bits == 0) return;
@@ -161,7 +161,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 			{
 				for (i = len - 1; i > i2; i--) n[i] = n[i - i2];
 				for (; i > 0; i--) n[i] = 0;
-				bits = bits % 32;
+				bits %= 32;
 			}
 
 			if (bits == 0) return;

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -146,11 +146,10 @@ namespace OpenRA.Mods.Cnc.Traits
 				minefieldStart = order.ExtraLocation;
 
 				var movement = self.Trait<IPositionable>();
-				var mobile = movement as Mobile;
 
 				var minefield = GetMinefieldCells(minefieldStart, cell, Info.MinefieldDepth)
 					.Where(c => IsCellAcceptable(self, c) && self.Owner.Shroud.IsExplored(c)
-						&& movement.CanEnterCell(c, null, BlockedByActor.Immovable) && (mobile != null && mobile.CanStayInCell(c)))
+						&& movement.CanEnterCell(c, null, BlockedByActor.Immovable) && (movement is Mobile mobile && mobile.CanStayInCell(c)))
 					.OrderBy(c => (c - minefieldStart).LengthSquared).ToList();
 
 				self.QueueActivity(order.Queued, new LayMines(self, minefield));

--- a/OpenRA.Mods.Cnc/UtilityCommands/LegacyRulesImporter.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/LegacyRulesImporter.cs
@@ -151,10 +151,8 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 							Console.WriteLine("\t\tDimensions: " + dimensions.First() + "," + dimensions.Last());
 
 							Console.Write("\t\tFootprint:");
-							var width = 0;
-							int.TryParse(dimensions.First(), out width);
-							var height = 0;
-							int.TryParse(dimensions.Last(), out height);
+							int.TryParse(dimensions.First(), out var width);
+							int.TryParse(dimensions.Last(), out var height);
 							for (var y = 0; y < height; y++)
 							{
 								Console.Write(" ");

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -225,7 +225,7 @@ namespace OpenRA.Mods.Common.Activities
 					// Move to CruiseAltitude, if not already there
 					if (dat != aircraft.Info.CruiseAltitude)
 					{
-						Fly.VerticalTakeOffOrLandTick(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);
+						VerticalTakeOffOrLandTick(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);
 						return false;
 					}
 				}

--- a/OpenRA.Mods.Common/Installer/SourceResolvers/GogSourceResolver.cs
+++ b/OpenRA.Mods.Common/Installer/SourceResolvers/GogSourceResolver.cs
@@ -34,12 +34,8 @@ namespace OpenRA.Mods.Common.Installer
 			var prefixes = new[] { "HKEY_LOCAL_MACHINE\\Software\\", "HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\" };
 
 			foreach (var prefix in prefixes)
-			{
-				var installDir = Registry.GetValue($"{prefix}GOG.com\\Games\\{appId.Value}", "path", null) as string;
-
-				if (installDir != null)
+				if (Registry.GetValue($"{prefix}GOG.com\\Games\\{appId.Value}", "path", null) is string installDir)
 					return installDir;
-			}
 
 			return null;
 		}

--- a/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
+++ b/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
@@ -646,8 +646,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// </summary>
 		bool ActorIsBlocking(Actor actor)
 		{
-			var mobile = actor.OccupiesSpace as Mobile;
-			var isMovable = mobile != null && !mobile.IsTraitDisabled && !mobile.IsTraitPaused && !mobile.IsImmovable;
+			var isMovable = actor.OccupiesSpace is Mobile mobile && !mobile.IsTraitDisabled && !mobile.IsTraitPaused && !mobile.IsImmovable;
 			if (isMovable)
 				return false;
 

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -162,6 +162,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// The search can skip some areas of the search space, meaning it has less work to do.
 		/// </param>
 		/// <param name="targetPredicate">Determines if the given cell is the target.</param>
+		/// <param name="recorder">If provided, will record all nodes explored by searches performed.</param>
 		PathSearch(IPathGraph graph, Func<CPos, int> heuristic, int heuristicWeightPercentage, Func<CPos, bool> targetPredicate, IRecorder recorder)
 		{
 			Graph = graph;

--- a/OpenRA.Mods.Common/Scripting/Global/UserInterfaceGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/UserInterfaceGlobal.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Scripting.Global
 			var luaLabel = Ui.Root.Get("INGAME_ROOT").Get<LabelWidget>("MISSION_TEXT");
 			luaLabel.GetText = () => text;
 
-			var c = color.HasValue ? color.Value : Color.White;
+			var c = color ?? Color.White;
 			luaLabel.GetColor = () => c;
 		}
 

--- a/OpenRA.Mods.Common/Terrain/DefaultTileCache.cs
+++ b/OpenRA.Mods.Common/Terrain/DefaultTileCache.cs
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.Common.Terrain
 					}
 
 					var frameCount = terrainInfo.EnableDepth && depthFrames == null ? allFrames.Length / 2 : allFrames.Length;
-					var indices = templateInfo.Frames != null ? templateInfo.Frames : Exts.MakeArray(t.Value.TilesCount, j => j);
+					var indices = templateInfo.Frames ?? Exts.MakeArray(t.Value.TilesCount, j => j);
 
 					var start = indices.Min();
 					var end = indices.Max();

--- a/OpenRA.Mods.Common/Terrain/DefaultTileCache.cs
+++ b/OpenRA.Mods.Common/Terrain/DefaultTileCache.cs
@@ -172,7 +172,7 @@ namespace OpenRA.Mods.Common.Terrain
 			if (r.Index >= template.Stride)
 				return missingTile;
 
-			var start = template.Variants > 1 ? variant.HasValue ? variant.Value : random.Next(template.Variants) : 0;
+			var start = template.Variants > 1 ? variant ?? random.Next(template.Variants) : 0;
 			return template.Sprites[start * template.Stride + r.Index];
 		}
 

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromGimpOrJascFile.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromGimpOrJascFile.cs
@@ -89,7 +89,7 @@ namespace OpenRA.Mods.Common.Traits
 
 						// Check if color has a (valid) alpha value.
 						// Note: We can't throw on "rgba.Length > 3 but parse failed", because in GIMP palettes the 'invalid' value is probably a color name string.
-						var noAlpha = rgba.Length > 3 ? !byte.TryParse(rgba[3], out a) : true;
+						var noAlpha = rgba.Length <= 3 || !byte.TryParse(rgba[3], out a);
 
 						// Index should be completely transparent/background color
 						if (i == TransparentIndex)

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -591,7 +591,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var traits = productionTraits.Where(p => !p.IsTraitDisabled && p.Info.Produces.Contains(Info.Type));
 			var unpaused = traits.FirstOrDefault(a => !a.IsTraitPaused);
-			return new TraitPair<Production>(self, unpaused != null ? unpaused : traits.FirstOrDefault());
+			return new TraitPair<Production>(self, unpaused ?? traits.FirstOrDefault());
 		}
 
 		// Builds a unit from the actor that holds this queue (1 queue per building)

--- a/OpenRA.Mods.Common/Traits/Render/ProductionIconOverlayManager.cs
+++ b/OpenRA.Mods.Common/Traits/Render/ProductionIconOverlayManager.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public virtual void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
-			if (rules.Actors[SystemActors.Player].TraitInfos<ProductionIconOverlayManagerInfo>().Where(piom => piom != this && piom.Type == Type).Any())
+			if (rules.Actors[SystemActors.Player].TraitInfos<ProductionIconOverlayManagerInfo>().Any(piom => piom != this && piom.Type == Type))
 				throw new YamlException($"Multiple 'ProductionIconOverlayManager's with type '{Type}' exist.");
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionIconOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionIconOverlay.cs
@@ -27,10 +27,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			foreach (var type in Types)
 			{
-				if (!rules.Actors[SystemActors.Player].TraitInfos<ProductionIconOverlayManagerInfo>().Where(piom => piom.Type == type).Any())
+				if (!rules.Actors[SystemActors.Player].TraitInfos<ProductionIconOverlayManagerInfo>().Any(piom => piom.Type == type))
 					throw new YamlException($"A 'ProductionIconOverlayManager' with type '{type}' doesn't exist.");
 
-				if (ai.TraitInfos<WithProductionIconOverlayInfo>().Where(wpio => wpio != this && wpio.Types.Contains(type)).Any())
+				if (ai.TraitInfos<WithProductionIconOverlayInfo>().Any(wpio => wpio != this && wpio.Types.Contains(type)))
 					throw new YamlException($"Multiple 'WithProductionIconOverlay's with type '{type}' exist on the actor.");
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Traits
 			var altitude = self.World.Map.Rules.Actors[info.UnitType].TraitInfo<AircraftInfo>().CruiseAltitude.Length;
 			var attackRotation = WRot.FromYaw(facing.Value);
 			var delta = new WVec(0, -1024, 0).Rotate(attackRotation);
-			target = target + new WVec(0, 0, altitude);
+			target += new WVec(0, 0, altitude);
 			var startEdge = target - (self.World.Map.DistanceToEdge(target, -delta) + info.Cordon).Length * delta / 1024;
 			var finishEdge = target + (self.World.Map.DistanceToEdge(target, delta) + info.Cordon).Length * delta / 1024;
 

--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -274,7 +274,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool Equals(EditorActorPreview other)
 		{
-			if (ReferenceEquals(null, other))
+			if (other is null)
 				return false;
 			if (ReferenceEquals(this, other))
 				return true;
@@ -284,7 +284,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override bool Equals(object obj)
 		{
-			if (ReferenceEquals(null, obj))
+			if (obj is null)
 				return false;
 			if (ReferenceEquals(this, obj))
 				return true;

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public struct ResourceLayerContents
+	public readonly struct ResourceLayerContents
 	{
 		public static readonly ResourceLayerContents Empty = default;
 		public readonly string Type;

--- a/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (unitGroup.BaseActor != null)
 			{
-				var facing = unitGroup.BaseActorFacing.HasValue ? unitGroup.BaseActorFacing.Value : new WAngle(w.SharedRandom.Next(1024));
+				var facing = unitGroup.BaseActorFacing ?? new WAngle(w.SharedRandom.Next(1024));
 				w.CreateActor(unitGroup.BaseActor.ToLowerInvariant(), new TypeDictionary
 				{
 					new LocationInit(p.HomeLocation + unitGroup.BaseActorOffset),
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				var subCell = ip.SharesCell ? w.ActorMap.FreeSubCell(validCell) : 0;
-				var facing = unitGroup.SupportActorsFacing.HasValue ? unitGroup.SupportActorsFacing.Value : new WAngle(w.SharedRandom.Next(1024));
+				var facing = unitGroup.SupportActorsFacing ?? new WAngle(w.SharedRandom.Next(1024));
 
 				w.CreateActor(s.ToLowerInvariant(), new TypeDictionary
 				{

--- a/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
@@ -376,7 +376,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 			return node.Value.Nodes.RemoveAll(n => n.KeyMatches(match, ignoreSuffix, includeRemovals));
 		}
 
-		/// <summary>Returns true if the node is of the form <match> or <match>@arbitrary</summary>
+		/// <summary>Returns true if the node is of the form [match] or [match]@[arbitrary suffix]</summary>
 		public static bool KeyMatches(this MiniYamlNode node, string match, bool ignoreSuffix = true, bool includeRemovals = true)
 		{
 			if (node.Key == null)
@@ -394,7 +394,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 			return atPosition > 0 && node.Key.Substring(0, atPosition) == prefix + match;
 		}
 
-		/// <summary>Returns true if the node is of the form <*match*>, <*match*>@arbitrary or <arbitrary>@*match*</summary>
+		/// <summary>Returns true if the node is of the form [match], [match]@[arbitrary suffix] or [arbitrary suffix]@[match]</summary>
 		public static bool KeyContains(this MiniYamlNode node, string match, bool ignoreSuffix = true, bool includeRemovals = true)
 		{
 			if (node.Key == null)

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -142,10 +142,8 @@ namespace OpenRA.Mods.Common
 			for (var i = 0; i < items.Length - 1; i++)
 			{
 				var j = random.Next(items.Length - i);
-				var item = items[i + j];
-				items[i + j] = items[i];
-				items[i] = item;
-				yield return item;
+				(items[i], items[i + j]) = (items[i + j], items[i]);
+				yield return items[i];
 			}
 
 			if (items.Length > 0)

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 				var required = ScriptMemberWrapper.RequiredTraitNames(cg);
 				return ScriptMemberWrapper.WrappableMembers(cg).Select(mi => (category, mi, required));
-			}).GroupBy(g => g.Item1).OrderBy(g => g.Key);
+			}).GroupBy(g => g.category).OrderBy(g => g.Key);
 
 			foreach (var kv in actorCategories)
 			{
@@ -102,10 +102,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				Console.WriteLine("| Function | Description |");
 				Console.WriteLine("|---------:|-------------|");
 
-				foreach (var property in kv.OrderBy(p => p.Item2.Name))
+				foreach (var property in kv.OrderBy(p => p.mi.Name))
 				{
-					var mi = property.Item2;
-					var required = property.Item3;
+					var mi = property.mi;
+					var required = property.required;
 					var hasDesc = mi.HasAttribute<DescAttribute>();
 					var hasRequires = required.Length > 0;
 					var isActivity = mi.HasAttribute<ScriptActorPropertyActivityAttribute>();
@@ -141,7 +141,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 				var required = ScriptMemberWrapper.RequiredTraitNames(cg);
 				return ScriptMemberWrapper.WrappableMembers(cg).Select(mi => (category, mi, required));
-			}).GroupBy(g => g.Item1).OrderBy(g => g.Key);
+			}).GroupBy(g => g.category).OrderBy(g => g.Key);
 
 			foreach (var kv in playerCategories)
 			{
@@ -151,10 +151,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				Console.WriteLine("| Function | Description |");
 				Console.WriteLine("|---------:|-------------|");
 
-				foreach (var property in kv.OrderBy(p => p.Item2.Name))
+				foreach (var property in kv.OrderBy(p => p.mi.Name))
 				{
-					var mi = property.Item2;
-					var required = property.Item3;
+					var mi = property.mi;
+					var required = property.required;
 					var hasDesc = mi.HasAttribute<DescAttribute>();
 					var hasRequires = required.Length > 0;
 					var isActivity = mi.HasAttribute<ScriptActorPropertyActivityAttribute>();

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -269,7 +269,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 									{
 										var bot = botTypes.Random(Game.CosmeticRandom);
 										var c = orderManager.LobbyInfo.ClientInSlot(slot.Key);
-										if (slot.Value.AllowBots == true && (c == null || c.Bot != null))
+										if (slot.Value.AllowBots && (c == null || c.Bot != null))
 											orderManager.IssueOrder(Order.Command($"slot_bot {slot.Key} {botController.Index} {bot}"));
 									}
 								}

--- a/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
@@ -323,7 +323,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var nameFont = Game.Renderer.Fonts[label.Font];
 			var name = new CachedTransform<(string Name, WinState WinState, Session.ClientState ClientState), string>(c =>
 			{
-				var suffix = c.WinState == WinState.Undefined ? "" : " (" + c.Item2 + ")";
+				var suffix = c.WinState == WinState.Undefined ? "" : " (" + c.WinState + ")";
 				if (c.ClientState == Session.ClientState.Disconnected)
 					suffix = " (Gone)";
 

--- a/OpenRA.Mods.Common/WorldExtensions.cs
+++ b/OpenRA.Mods.Common/WorldExtensions.cs
@@ -24,6 +24,8 @@ namespace OpenRA.Mods.Common
 		/// <param name="lineStart">The position the line should start at</param>
 		/// <param name="lineEnd">The position the line should end at</param>
 		/// <param name="lineWidth">How close an actor's health radius needs to be to the line to be considered 'intersected' by the line</param>
+		/// <param name="onlyBlockers">If set, only considers the size of actors that have an <see cref="IBlocksProjectiles"/>
+		/// trait which may improve search performance. However does NOT filter the returned actors on this trait.</param>
 		/// <returns>A list of all the actors intersected by the line</returns>
 		public static IEnumerable<Actor> FindActorsOnLine(this World world, WPos lineStart, WPos lineEnd, WDist lineWidth, bool onlyBlockers = false)
 		{

--- a/OpenRA.Platforms.Default/Texture.cs
+++ b/OpenRA.Platforms.Default/Texture.cs
@@ -148,9 +148,7 @@ namespace OpenRA.Platforms.Default
 				{
 					for (var i = 0; i < 4 * Size.Width * Size.Height; i += 4)
 					{
-						var temp = data[i];
-						data[i] = data[i + 2];
-						data[i + 2] = temp;
+						(data[i + 2], data[i]) = (data[i], data[i + 2]);
 					}
 				}
 

--- a/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
+++ b/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
@@ -82,10 +82,10 @@ namespace OpenRA.Test
 			var actorInfo = new ActorInfo("test", new MockBInfo(), new MockCInfo());
 			var ex = Assert.Throws<YamlException>(() => actorInfo.TraitsInConstructOrder());
 
-			StringAssert.Contains(typeof(MockBInfo).Name, ex.Message, "Exception message did not report a missing dependency.");
-			StringAssert.Contains(typeof(MockCInfo).Name, ex.Message, "Exception message did not report a missing dependency.");
-			StringAssert.Contains(typeof(MockInheritInfo).Name, ex.Message, "Exception message did not report a missing dependency (from a base class).");
-			StringAssert.Contains(typeof(IMock).Name, ex.Message, "Exception message did not report a missing dependency (from an interface).");
+			StringAssert.Contains(nameof(MockBInfo), ex.Message, "Exception message did not report a missing dependency.");
+			StringAssert.Contains(nameof(MockCInfo), ex.Message, "Exception message did not report a missing dependency.");
+			StringAssert.Contains(nameof(MockInheritInfo), ex.Message, "Exception message did not report a missing dependency (from a base class).");
+			StringAssert.Contains(nameof(IMock), ex.Message, "Exception message did not report a missing dependency (from an interface).");
 		}
 
 		[TestCase(TestName = "Trait ordering allows optional dependencies to be missing")]
@@ -104,9 +104,9 @@ namespace OpenRA.Test
 			var actorInfo = new ActorInfo("test", new MockDInfo(), new MockEInfo(), new MockFInfo());
 			var ex = Assert.Throws<YamlException>(() => actorInfo.TraitsInConstructOrder());
 
-			StringAssert.Contains(typeof(MockDInfo).Name, ex.Message, "Exception message should report all cyclic dependencies.");
-			StringAssert.Contains(typeof(MockEInfo).Name, ex.Message, "Exception message should report all cyclic dependencies.");
-			StringAssert.Contains(typeof(MockFInfo).Name, ex.Message, "Exception message should report all cyclic dependencies.");
+			StringAssert.Contains(nameof(MockDInfo), ex.Message, "Exception message should report all cyclic dependencies.");
+			StringAssert.Contains(nameof(MockEInfo), ex.Message, "Exception message should report all cyclic dependencies.");
+			StringAssert.Contains(nameof(MockFInfo), ex.Message, "Exception message should report all cyclic dependencies.");
 		}
 
 		[TestCase(TestName = "Trait ordering exception reports cyclic optional dependencies")]
@@ -115,9 +115,9 @@ namespace OpenRA.Test
 			var actorInfo = new ActorInfo("test", new MockJInfo(), new MockKInfo(), new MockLInfo());
 			var ex = Assert.Throws<YamlException>(() => actorInfo.TraitsInConstructOrder());
 
-			StringAssert.Contains(typeof(MockJInfo).Name, ex.Message, "Exception message should report all cyclic dependencies.");
-			StringAssert.Contains(typeof(MockKInfo).Name, ex.Message, "Exception message should report all cyclic dependencies.");
-			StringAssert.Contains(typeof(MockLInfo).Name, ex.Message, "Exception message should report all cyclic dependencies.");
+			StringAssert.Contains(nameof(MockJInfo), ex.Message, "Exception message should report all cyclic dependencies.");
+			StringAssert.Contains(nameof(MockKInfo), ex.Message, "Exception message should report all cyclic dependencies.");
+			StringAssert.Contains(nameof(MockLInfo), ex.Message, "Exception message should report all cyclic dependencies.");
 		}
 	}
 }

--- a/OpenRA.Test/OpenRA.Game/VariableExpressionTest.cs
+++ b/OpenRA.Test/OpenRA.Game/VariableExpressionTest.cs
@@ -42,11 +42,6 @@ namespace OpenRA.Test
 			Assert.AreEqual(value, new IntegerExpression(expression).Evaluate(testValues), expression);
 		}
 
-		void AssertParseFailure(string expression)
-		{
-			Assert.Throws(typeof(InvalidDataException), () => new IntegerExpression(expression).Evaluate(testValues), expression);
-		}
-
 		void AssertParseFailure(string expression, string errorMessage)
 		{
 			var actualErrorMessage = Assert.Throws(typeof(InvalidDataException),

--- a/OpenRA.ruleset
+++ b/OpenRA.ruleset
@@ -6,7 +6,6 @@
   <!-- Rules related to generating XML documentation that we need to silence. -->
   <!-- These are here because of GenerateDocumentationFile, which is a workaround for forcing rule IDE0005 to work outside of an IDE. -->
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
-    <Rule Id="CS1570" Action="None" /><!-- Invalid XML in XML comment. -->
     <Rule Id="CS1573" Action="None" /><!-- Parameter has no matching param tag in the XML comment. -->
     <Rule Id="CS1591" Action="None" /><!-- Missing XML comment for publicly visible type or member. -->
   </Rules>

--- a/OpenRA.ruleset
+++ b/OpenRA.ruleset
@@ -6,7 +6,6 @@
   <!-- Rules related to generating XML documentation that we need to silence. -->
   <!-- These are here because of GenerateDocumentationFile, which is a workaround for forcing rule IDE0005 to work outside of an IDE. -->
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
-    <Rule Id="CS1573" Action="None" /><!-- Parameter has no matching param tag in the XML comment. -->
     <Rule Id="CS1591" Action="None" /><!-- Missing XML comment for publicly visible type or member. -->
   </Rules>
 


### PR DESCRIPTION
Enforces ~21~ 19 style rules across the project, and 2 complier warnings related to XML docs.

I have batched together a PR for these rules as they each had limited existing violations (4 files or less) to resolve. However fixes are arranged per commit so we can easily bikeshed over rules as desired.

See https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ for explanation of each rule.