### PR TITLE
Enable more code style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -189,6 +189,9 @@ dotnet_diagnostic.IDE0040.severity = warning
 # Use 'is null' check.
 dotnet_diagnostic.IDE0041.severity = warning
 
+# Deconstruct variable declaration.
+dotnet_diagnostic.IDE0042.severity = warning
+
 # Make field readonly.
 dotnet_diagnostic.IDE0044.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -135,6 +135,9 @@ dotnet_diagnostic.IDE0001.severity = warning
 # Simplify member access.
 dotnet_diagnostic.IDE0002.severity = warning
 
+# Remove unnecessary cast.
+dotnet_diagnostic.IDE0004.severity = warning
+
 # Use 'var' instead of explicit type.
 dotnet_diagnostic.IDE0007.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -153,7 +153,7 @@ dotnet_diagnostic.IDE0018.severity = warning
 # Use pattern matching to avoid 'as' followed by a 'null' check.
 dotnet_diagnostic.IDE0019.severity = warning
 
-# Use pattern matching to avoid 'is' check followed by a cast.
+# Use pattern matching to avoid 'is' check followed by a cast (with variable).
 dotnet_diagnostic.IDE0020.severity = warning
 
 # Collection initialization can be simplified.
@@ -176,6 +176,9 @@ dotnet_diagnostic.IDE0034.severity = warning
 
 # Modifiers are not ordered.
 dotnet_diagnostic.IDE0036.severity = warning
+
+# Use pattern matching to avoid 'is' check followed by a cast (without variable).
+dotnet_diagnostic.IDE0038.severity = warning
 
 # Use local function instead of lambda.
 dotnet_diagnostic.IDE0039.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -124,6 +124,9 @@ dotnet_style_predefined_type_for_locals_parameters_members = true
 # Use expression body if a local function is a single line.
 csharp_style_expression_bodied_local_functions = when_on_single_line
 
+# Remove unused parameters on non public methods, ignore unused parameters on public methods.
+dotnet_code_quality_unused_parameters = non_public
+
 ## Others:
 
 # Show an IDE warning when default access modifiers are explicitly specified.

--- a/OpenRA.Game/CPos.cs
+++ b/OpenRA.Game/CPos.cs
@@ -56,7 +56,7 @@ namespace OpenRA
 		public override int GetHashCode() { return Bits.GetHashCode(); }
 
 		public bool Equals(CPos other) { return Bits == other.Bits; }
-		public override bool Equals(object obj) { return obj is CPos && Equals((CPos)obj); }
+		public override bool Equals(object obj) { return obj is CPos cell && Equals(cell); }
 
 		public override string ToString()
 		{

--- a/OpenRA.Game/CVec.cs
+++ b/OpenRA.Game/CVec.cs
@@ -55,7 +55,7 @@ namespace OpenRA
 		public override int GetHashCode() { return X.GetHashCode() ^ Y.GetHashCode(); }
 
 		public bool Equals(CVec other) { return other == this; }
-		public override bool Equals(object obj) { return obj is CVec && Equals((CVec)obj); }
+		public override bool Equals(object obj) { return obj is CVec vec && Equals(vec); }
 
 		public override string ToString() { return X + "," + Y; }
 

--- a/OpenRA.Game/Graphics/Model.cs
+++ b/OpenRA.Game/Graphics/Model.cs
@@ -84,7 +84,6 @@ namespace OpenRA.Graphics
 			}
 		}
 
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "IDE0060:Remove unused parameter", Justification = "Load game API")]
 		public PlaceholderModelSequenceLoader(ModData modData) { }
 
 		public IModelCache CacheModels(IReadOnlyFileSystem fileSystem, ModData modData, IReadOnlyDictionary<string, MiniYamlNode> modelDefinitions)

--- a/OpenRA.Game/MPos.cs
+++ b/OpenRA.Game/MPos.cs
@@ -27,7 +27,7 @@ namespace OpenRA
 		public override int GetHashCode() { return U.GetHashCode() ^ V.GetHashCode(); }
 
 		public bool Equals(MPos other) { return other == this; }
-		public override bool Equals(object obj) { return obj is MPos && Equals((MPos)obj); }
+		public override bool Equals(object obj) { return obj is MPos uv && Equals(uv); }
 
 		public MPos Clamp(Rectangle r)
 		{
@@ -88,7 +88,7 @@ namespace OpenRA
 		public override int GetHashCode() { return U.GetHashCode() ^ V.GetHashCode(); }
 
 		public bool Equals(PPos other) { return other == this; }
-		public override bool Equals(object obj) { return obj is PPos && Equals((PPos)obj); }
+		public override bool Equals(object obj) { return obj is PPos puv && Equals(puv); }
 
 		public override string ToString() { return U + "," + V; }
 	}

--- a/OpenRA.Game/Primitives/Int32Matrix4x4.cs
+++ b/OpenRA.Game/Primitives/Int32Matrix4x4.cs
@@ -58,7 +58,7 @@ namespace OpenRA
 		public override int GetHashCode() { return M11 ^ M22 ^ M33 ^ M44; }
 
 		public bool Equals(Int32Matrix4x4 other) { return other == this; }
-		public override bool Equals(object obj) { return obj is Int32Matrix4x4 && Equals((Int32Matrix4x4)obj); }
+		public override bool Equals(object obj) { return obj is Int32Matrix4x4 matrix && Equals(matrix); }
 
 		public override string ToString()
 		{

--- a/OpenRA.Game/Primitives/LongBitSet.cs
+++ b/OpenRA.Game/Primitives/LongBitSet.cs
@@ -116,7 +116,7 @@ namespace OpenRA.Primitives
 		public static bool operator !=(LongBitSet<T> me, LongBitSet<T> other) { return !(me == other); }
 
 		public bool Equals(LongBitSet<T> other) { return other == this; }
-		public override bool Equals(object obj) { return obj is LongBitSet<T> && Equals((LongBitSet<T>)obj); }
+		public override bool Equals(object obj) { return obj is LongBitSet<T> set && Equals(set); }
 		public override int GetHashCode() { return bits.GetHashCode(); }
 
 		public bool IsEmpty => bits == 0;

--- a/OpenRA.Game/Primitives/float2.cs
+++ b/OpenRA.Game/Primitives/float2.cs
@@ -72,7 +72,7 @@ namespace OpenRA
 		public override int GetHashCode() { return X.GetHashCode() ^ Y.GetHashCode(); }
 
 		public bool Equals(float2 other) { return this == other; }
-		public override bool Equals(object obj) { return obj is float2 && Equals((float2)obj); }
+		public override bool Equals(object obj) { return obj is float2 vec && Equals(vec); }
 
 		public override string ToString() { return X + "," + Y; }
 

--- a/OpenRA.Game/Primitives/int2.cs
+++ b/OpenRA.Game/Primitives/int2.cs
@@ -37,7 +37,7 @@ namespace OpenRA
 		public override int GetHashCode() { return X.GetHashCode() ^ Y.GetHashCode(); }
 
 		public bool Equals(int2 other) { return this == other; }
-		public override bool Equals(object obj) { return obj is int2 && Equals((int2)obj); }
+		public override bool Equals(object obj) { return obj is int2 vec && Equals(vec); }
 
 		public override string ToString() { return X + "," + Y; }
 

--- a/OpenRA.Game/Scripting/ScriptTypes.cs
+++ b/OpenRA.Game/Scripting/ScriptTypes.cs
@@ -109,10 +109,9 @@ namespace OpenRA.Scripting
 			}
 
 			// Translate LuaTable<int, object> -> object[]
-			if (value is LuaTable && t.IsArray)
+			if (value is LuaTable table && t.IsArray)
 			{
 				var innerType = t.GetElementType();
-				var table = (LuaTable)value;
 				var array = Array.CreateInstance(innerType, table.Count);
 				var i = 0;
 
@@ -149,23 +148,25 @@ namespace OpenRA.Scripting
 
 		public static LuaValue ToLuaValue(this object obj, ScriptContext context)
 		{
-			if (obj is LuaValue)
-				return (LuaValue)obj;
+			{
+				if (obj is LuaValue v)
+					return v;
 
-			if (obj == null)
-				return LuaNil.Instance;
+				if (obj == null)
+					return LuaNil.Instance;
 
-			if (obj is double)
-				return (double)obj;
+				if (obj is double d)
+					return d;
 
-			if (obj is int)
-				return (int)obj;
+				if (obj is int i)
+					return i;
 
-			if (obj is bool)
-				return (bool)obj;
+				if (obj is bool b)
+					return b;
 
-			if (obj is string)
-				return (string)obj;
+				if (obj is string s)
+					return s;
+			}
 
 			if (obj is IScriptBindable)
 			{

--- a/OpenRA.Game/WAngle.cs
+++ b/OpenRA.Game/WAngle.cs
@@ -44,7 +44,7 @@ namespace OpenRA
 		public override int GetHashCode() { return Angle.GetHashCode(); }
 
 		public bool Equals(WAngle other) { return other == this; }
-		public override bool Equals(object obj) { return obj is WAngle && Equals((WAngle)obj); }
+		public override bool Equals(object obj) { return obj is WAngle angle && Equals(angle); }
 
 		public int Facing => Angle / 4;
 

--- a/OpenRA.Game/WAngle.cs
+++ b/OpenRA.Game/WAngle.cs
@@ -22,7 +22,7 @@ namespace OpenRA
 	public readonly struct WAngle : IScriptBindable, ILuaAdditionBinding, ILuaSubtractionBinding, ILuaEqualityBinding, IEquatable<WAngle>
 	{
 		public readonly int Angle;
-		public int AngleSquared => (int)Angle * Angle;
+		public int AngleSquared => Angle * Angle;
 
 		public WAngle(int a)
 		{

--- a/OpenRA.Game/WDist.cs
+++ b/OpenRA.Game/WDist.cs
@@ -93,7 +93,7 @@ namespace OpenRA
 		public override int GetHashCode() { return Length.GetHashCode(); }
 
 		public bool Equals(WDist other) { return other == this; }
-		public override bool Equals(object obj) { return obj is WDist && Equals((WDist)obj); }
+		public override bool Equals(object obj) { return obj is WDist dist && Equals(dist); }
 
 		public int CompareTo(object obj)
 		{

--- a/OpenRA.Game/WPos.cs
+++ b/OpenRA.Game/WPos.cs
@@ -66,7 +66,7 @@ namespace OpenRA
 			// Add an additional quadratic variation to height
 			// Uses decimal to avoid integer overflow
 			var offset = (decimal)(b - a).Length * pitch.Tan() * mul * (div - mul) / (1024 * div * div);
-			var clampedOffset = (int)(offset + (decimal)ret.Z).Clamp((decimal)int.MinValue, (decimal)int.MaxValue);
+			var clampedOffset = (int)(offset + ret.Z).Clamp(int.MinValue, int.MaxValue);
 
 			return new WPos(ret.X, ret.Y, clampedOffset);
 		}

--- a/OpenRA.Game/WRot.cs
+++ b/OpenRA.Game/WRot.cs
@@ -190,7 +190,7 @@ namespace OpenRA
 		public override int GetHashCode() { return Roll.GetHashCode() ^ Pitch.GetHashCode() ^ Yaw.GetHashCode(); }
 
 		public bool Equals(WRot other) { return other == this; }
-		public override bool Equals(object obj) { return obj is WRot && Equals((WRot)obj); }
+		public override bool Equals(object obj) { return obj is WRot rot && Equals(rot); }
 
 		public override string ToString() { return Roll + "," + Pitch + "," + Yaw; }
 

--- a/OpenRA.Game/WVec.cs
+++ b/OpenRA.Game/WVec.cs
@@ -102,7 +102,7 @@ namespace OpenRA
 		public override int GetHashCode() { return X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode(); }
 
 		public bool Equals(WVec other) { return other == this; }
-		public override bool Equals(object obj) { return obj is WVec && Equals((WVec)obj); }
+		public override bool Equals(object obj) { return obj is WVec vec && Equals(vec); }
 
 		public override string ToString() { return X + "," + Y + "," + Z; }
 

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -637,7 +637,7 @@ namespace OpenRA
 		public override int GetHashCode() { return Actor.GetHashCode() ^ Trait.GetHashCode(); }
 
 		public bool Equals(TraitPair<T> other) { return this == other; }
-		public override bool Equals(object obj) { return obj is TraitPair<T> && Equals((TraitPair<T>)obj); }
+		public override bool Equals(object obj) { return obj is TraitPair<T> pair && Equals(pair); }
 
 		public override string ToString() { return Actor.Info.Name + "->" + Trait.GetType().Name; }
 	}

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -374,7 +374,7 @@ namespace OpenRA
 		public void RemoveAll(Predicate<IEffect> predicate)
 		{
 			effects.RemoveAll(predicate);
-			unpartitionedEffects.RemoveAll(e => predicate((IEffect)e));
+			unpartitionedEffects.RemoveAll(e => predicate(e));
 			syncedEffects.RemoveAll(e => predicate((IEffect)e));
 		}
 

--- a/OpenRA.Mods.Cnc/Graphics/VoxelModelSequenceLoader.cs
+++ b/OpenRA.Mods.Cnc/Graphics/VoxelModelSequenceLoader.cs
@@ -21,7 +21,6 @@ namespace OpenRA.Mods.Cnc.Graphics
 	{
 		public Action<string> OnMissingModelError { get; set; }
 
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "IDE0060:Remove unused parameter", Justification = "Load game API")]
 		public VoxelModelSequenceLoader(ModData modData) { }
 
 		public IModelCache CacheModels(IReadOnlyFileSystem fileSystem, ModData modData, IReadOnlyDictionary<string, MiniYamlNode> modelSequences)

--- a/OpenRA.Mods.Common/Activities/Sell.cs
+++ b/OpenRA.Mods.Common/Activities/Sell.cs
@@ -37,8 +37,8 @@ namespace OpenRA.Mods.Common.Activities
 			var sellValue = self.GetSellValue();
 
 			// Cast to long to avoid overflow when multiplying by the health
-			var hp = health != null ? (long)health.HP : 1L;
-			var maxHP = health != null ? (long)health.MaxHP : 1L;
+			var hp = health != null ? health.HP : 1L;
+			var maxHP = health != null ? health.MaxHP : 1L;
 			var refund = (int)(sellValue * sellableInfo.RefundPercent * hp / (100 * maxHP));
 			refund = playerResources.ChangeCash(refund);
 

--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -43,7 +43,6 @@ namespace OpenRA.Mods.Common.Graphics
 	{
 		static readonly MiniYaml NoData = new MiniYaml(null);
 
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "IDE0060:Remove unused parameter", Justification = "Load game API")]
 		public DefaultSpriteSequenceLoader(ModData modData) { }
 
 		public virtual ISpriteSequence CreateSequence(ModData modData, string tileset, SpriteCache cache, string image, string sequence, MiniYaml data, MiniYaml defaults)

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractBlastSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractBlastSourceAction.cs
@@ -57,19 +57,19 @@ namespace OpenRA.Mods.Common.Installer
 						continue;
 					}
 
-					var entry = entries[node.Value.Value];
+					var (length, offset) = entries[node.Value.Value];
 
-					source.Position = entry.Offset;
+					source.Position = offset;
 
 					extracted.Add(targetPath);
 					Directory.CreateDirectory(Path.GetDirectoryName(targetPath));
 					var displayFilename = Path.GetFileName(Path.GetFileName(targetPath));
 
 					Action<long> onProgress = null;
-					if (entry.Length < InstallFromSourceLogic.ShowPercentageThreshold)
+					if (length < InstallFromSourceLogic.ShowPercentageThreshold)
 						updateMessage(modData.Translation.GetString(InstallFromSourceLogic.Extracing, Translation.Arguments("filename", displayFilename)));
 					else
-						onProgress = b => updateMessage(modData.Translation.GetString(InstallFromSourceLogic.ExtracingProgress, Translation.Arguments("filename", displayFilename, "progress", 100 * b / entry.Length)));
+						onProgress = b => updateMessage(modData.Translation.GetString(InstallFromSourceLogic.ExtracingProgress, Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
 
 					using (var target = File.OpenWrite(targetPath))
 					{

--- a/OpenRA.Mods.Common/Terrain/DefaultTerrain.cs
+++ b/OpenRA.Mods.Common/Terrain/DefaultTerrain.cs
@@ -20,7 +20,6 @@ namespace OpenRA.Mods.Common.Terrain
 {
 	public class DefaultTerrainLoader : ITerrainLoader
 	{
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "IDE0060:Remove unused parameter", Justification = "Load game API")]
 		public DefaultTerrainLoader(ModData modData) { }
 
 		public ITerrainInfo ParseTerrain(IReadOnlyFileSystem fileSystem, string path)

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -161,9 +161,7 @@ namespace OpenRA.Mods.Common.Traits
 					else if (baseBuilder.Info.RefineryTypes.Contains(actorInfo.Name))
 						type = BuildingType.Refinery;
 
-					var pack = ChooseBuildLocation(currentBuilding.Item, true, type);
-					location = pack.Location;
-					actorVariant = pack.Variant;
+					(location, actorVariant) = ChooseBuildLocation(currentBuilding.Item, true, type);
 				}
 
 				if (location == null)

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/AttackOrFleeFuzzy.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/AttackOrFleeFuzzy.cs
@@ -181,7 +181,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			return !double.IsNaN(attackChance) && attackChance < 30.0;
 		}
 
-		static float NormalizedHealth(IEnumerable<Actor> actors, float normalizeByValue)
+		static float NormalizedHealth(IEnumerable<Actor> actors, int normalizeByValue)
 		{
 			var sumOfMaxHp = 0;
 			var sumOfHp = 0;

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -163,7 +163,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (palette == null)
 					return r;
 				else
-					return r.Select(a => !a.IsDecoration && a is IPalettedRenderable ? ((IPalettedRenderable)a).WithPalette(palette) : a);
+					return r.Select(a => !a.IsDecoration && a is IPalettedRenderable pr ? pr.WithPalette(palette) : a);
 			}
 			else
 				return SpriteRenderable.None;

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -155,15 +155,15 @@ namespace OpenRA.Mods.Common.Traits
 				var totalShares = shares.Sum(a => a.Shares);
 				var n = self.World.SharedRandom.Next(totalShares);
 
-				foreach (var s in shares)
+				foreach (var (action, share) in shares)
 				{
-					if (n < s.Shares)
+					if (n < share)
 					{
-						s.Action.Activate(crusher);
+						action.Activate(crusher);
 						return;
 					}
 
-					n -= s.Shares;
+					n -= share;
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/Player/PlayerRadarTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerRadarTerrain.cs
@@ -90,8 +90,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (rtl.TryGetTerrainColorPair(uv, out var c))
 					return (c.Left.ToArgb(), c.Right.ToArgb());
 
-			var tc = map.GetTerrainColorPair(uv);
-			return (tc.Left.ToArgb(), tc.Right.ToArgb());
+			var (left, right) = map.GetTerrainColorPair(uv);
+			return (left.ToArgb(), right.ToArgb());
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Sellable.cs
+++ b/OpenRA.Mods.Common/Traits/Sellable.cs
@@ -109,8 +109,8 @@ namespace OpenRA.Mods.Common.Traits
 				var sellValue = self.GetSellValue();
 
 				// Cast to long to avoid overflow when multiplying by the health
-				var hp = health != null ? (long)health.Value.HP : 1L;
-				var maxHP = health != null ? (long)health.Value.MaxHP : 1L;
+				var hp = health != null ? health.Value.HP : 1L;
+				var maxHP = health != null ? health.Value.MaxHP : 1L;
 				var refund = (int)(sellValue * info.RefundPercent * hp / (100 * maxHP));
 
 				return "Refund: $" + refund;

--- a/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
@@ -253,7 +253,7 @@ namespace OpenRA.Mods.Common.Traits
 			var content = resources[cell];
 			var oldDensity = content.Type == resourceInfo.ResourceIndex ? content.Index : 0;
 			var density = (byte)Math.Min(resourceInfo.MaxDensity, oldDensity + amount);
-			Map.Resources[cell] = new ResourceTile((byte)resourceInfo.ResourceIndex, density);
+			Map.Resources[cell] = new ResourceTile(resourceInfo.ResourceIndex, density);
 
 			return density - oldDensity;
 		}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RenameStances.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RenameStances.cs
@@ -79,9 +79,9 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
 		{
-			foreach (var field in traits)
-				foreach (var traitNode in actorNode.ChildrenMatching(field.TraitName))
-					traitNode.RenameChildrenMatching(field.OldName, field.NewName);
+			foreach (var (traitName, oldName, newName) in traits)
+				foreach (var traitNode in actorNode.ChildrenMatching(traitName))
+					traitNode.RenameChildrenMatching(oldName, newName);
 
 			yield break;
 		}

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractEmmyLuaAPI.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractEmmyLuaAPI.cs
@@ -226,15 +226,15 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				return ScriptMemberWrapper.WrappableMembers(t).Select(memberInfo => (memberInfo, required));
 			});
 
-			foreach (var property in properties)
+			foreach (var (memberInfo, required) in properties)
 			{
 				Console.WriteLine();
 
-				var isActivity = property.memberInfo.HasAttribute<ScriptActorPropertyActivityAttribute>();
+				var isActivity = memberInfo.HasAttribute<ScriptActorPropertyActivityAttribute>();
 
-				if (property.memberInfo.HasAttribute<DescAttribute>())
+				if (memberInfo.HasAttribute<DescAttribute>())
 				{
-					var lines = property.memberInfo.GetCustomAttributes<DescAttribute>(true).First().Lines;
+					var lines = memberInfo.GetCustomAttributes<DescAttribute>(true).First().Lines;
 					foreach (var line in lines)
 						Console.WriteLine($"    --- {line}");
 				}
@@ -242,10 +242,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				if (isActivity)
 					Console.WriteLine("    --- *Queued Activity*");
 
-				if (property.required.Any())
-					Console.WriteLine($"    --- **Requires {(property.required.Length == 1 ? "Trait" : "Traits")}:** {property.required.Select(GetDocumentationUrl).JoinWith(", ")}");
+				if (required.Any())
+					Console.WriteLine($"    --- **Requires {(required.Length == 1 ? "Trait" : "Traits")}:** {required.Select(GetDocumentationUrl).JoinWith(", ")}");
 
-				if (property.memberInfo is MethodInfo methodInfo)
+				if (memberInfo is MethodInfo methodInfo)
 				{
 					var attributes = methodInfo.GetCustomAttributes(false);
 					foreach (var obsolete in attributes.OfType<ObsoleteAttribute>())
@@ -264,7 +264,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					Console.WriteLine($"    {methodInfo.Name} = function({parameterString}) end;");
 				}
 
-				if (property.memberInfo is PropertyInfo propertyInfo)
+				if (memberInfo is PropertyInfo propertyInfo)
 				{
 					Console.WriteLine($"    ---@type {propertyInfo.PropertyType.EmmyLuaString()}");
 					Console.WriteLine("    " + propertyInfo.Name + " = { };");

--- a/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
@@ -255,13 +255,13 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					Location: LocationFromMapOffset(Exts.ParseIntegerInvariant(kv.Value), MapSize)));
 
 			// Add waypoint actors skipping duplicate entries
-			foreach (var kv in wps.DistinctBy(location => location.Location))
+			foreach (var (waypointNumber, location) in wps.DistinctBy(location => location.Location))
 			{
-				if (!singlePlayer && kv.WaypointNumber <= 7)
+				if (!singlePlayer && waypointNumber <= 7)
 				{
 					var ar = new ActorReference("mpspawn")
 					{
-						new LocationInit((CPos)kv.Location),
+						new LocationInit((CPos)location),
 						new OwnerInit("Neutral")
 					};
 
@@ -272,11 +272,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				{
 					var ar = new ActorReference("waypoint")
 					{
-						new LocationInit((CPos)kv.Location),
+						new LocationInit((CPos)location),
 						new OwnerInit("Neutral")
 					};
 
-					SaveWaypoint(kv.WaypointNumber, ar);
+					SaveWaypoint(waypointNumber, ar);
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -101,12 +101,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			for (var i = 0; i < numTabs; i++)
 			{
 				var type = visiblePanels[i];
-				var info = panels[type];
+				var (panel, label, setup) = panels[type];
 				var tabButton = tabContainer?.Get<ButtonWidget>($"BUTTON{i + 1}");
 
 				if (tabButton != null)
 				{
-					tabButton.Text = modData.Translation.GetString(info.Label);
+					tabButton.Text = modData.Translation.GetString(label);
 					tabButton.OnClick = () =>
 					{
 						if (activePanel == IngameInfoPanel.Chat)
@@ -117,9 +117,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					tabButton.IsHighlighted = () => activePanel == type;
 				}
 
-				var panelContainer = widget.Get<ContainerWidget>(info.Panel);
+				var panelContainer = widget.Get<ContainerWidget>(panel);
 				panelContainer.IsVisible = () => activePanel == type;
-				info.Setup(tabButton, panelContainer);
+				setup(tabButton, panelContainer);
 
 				if (activePanel == IngameInfoPanel.AutoSelect)
 					activePanel = type;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
@@ -126,7 +126,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				if (dropdownColumns.Count == 0)
 				{
-					row = dropdownRowTemplate.Clone() as Widget;
+					row = dropdownRowTemplate.Clone();
 					row.Bounds.Y = optionsContainer.Bounds.Height;
 					optionsContainer.Bounds.Height += row.Bounds.Height;
 					foreach (var child in row.Children)

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -228,9 +228,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				flag.GetImageCollection = () => "flags";
 				flag.GetImageName = () => factionId;
 
-				var tooltip = SplitOnFirstToken(faction.Description);
-				item.GetTooltipText = () => tooltip.First;
-				item.GetTooltipDesc = () => tooltip.Second;
+				var (text, desc) = SplitOnFirstToken(faction.Description);
+				item.GetTooltipText = () => text;
+				item.GetTooltipDesc = () => desc;
 
 				return item;
 			}
@@ -566,9 +566,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			dropdown.IsDisabled = () => s.LockFaction || orderManager.LocalClient.IsReady;
 			dropdown.OnMouseDown = _ => ShowFactionDropDown(dropdown, c, orderManager, factions);
 
-			var tooltip = SplitOnFirstToken(factions[c.Faction].Description);
-			dropdown.GetTooltipText = () => tooltip.First;
-			dropdown.GetTooltipDesc = () => tooltip.Second;
+			var (text, desc) = SplitOnFirstToken(factions[c.Faction].Description);
+			dropdown.GetTooltipText = () => text;
+			dropdown.GetTooltipDesc = () => desc;
 
 			SetupFactionWidget(dropdown, c, factions);
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -253,7 +253,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					.ToList();
 
 				// 'all game types' extra item
-				categories.Insert(0, (null as string, tabMaps[tab].Length));
+				categories.Insert(0, (null, tabMaps[tab].Length));
 
 				string ShowItem((string Category, int Count) x) => (x.Category ?? allMaps) + $" ({x.Count})";
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsUtils.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				throw new InvalidOperationException($"{group.GetType().Name} does not contain a preference type {pref}");
 
 			var ss = parent.Get<SliderWidget>(id);
-			ss.Value = (float)(int)field.GetValue(group);
+			ss.Value = (int)field.GetValue(group);
 			ss.OnChange += x => field.SetValue(group, (int)x);
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/SystemInfoPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SystemInfoPromptLogic.cs
@@ -69,10 +69,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var template = sysInfoData.Get<LabelWidget>("DATA_TEMPLATE");
 			sysInfoData.RemoveChildren();
 
-			foreach (var info in GetSystemInformation().Values)
+			foreach (var (name, value) in GetSystemInformation().Values)
 			{
 				var label = template.Clone() as LabelWidget;
-				var text = info.Label + ": " + info.Value;
+				var text = name + ": " + value;
 				label.GetText = () => text;
 				sysInfoData.AddChild(label);
 			}

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -222,10 +222,8 @@ namespace OpenRA.Mods.Common.Widgets
 
 		void UpdateTerrainColor(MPos uv)
 		{
-			var colorPair = playerRadarTerrain != null && playerRadarTerrain.IsInitialized ?
+			var (leftColor, rightColor) = playerRadarTerrain != null && playerRadarTerrain.IsInitialized ?
 				playerRadarTerrain[uv] : PlayerRadarTerrain.GetColor(world.Map, radarTerrainLayers, uv);
-			var leftColor = colorPair.Left;
-			var rightColor = colorPair.Right;
 
 			var stride = radarSheet.Size.Width;
 

--- a/OpenRA.Platforms.Default/Texture.cs
+++ b/OpenRA.Platforms.Default/Texture.cs
@@ -163,7 +163,7 @@ namespace OpenRA.Platforms.Default
 				{
 					fixed (byte* ptr = &data[0])
 					{
-						var intPtr = new IntPtr((void*)ptr);
+						var intPtr = new IntPtr(ptr);
 						OpenGL.glGetTexImage(OpenGL.GL_TEXTURE_2D, 0, OpenGL.GL_BGRA,
 							OpenGL.GL_UNSIGNED_BYTE, intPtr);
 					}


### PR DESCRIPTION
Following on from #20694

Enforces 3 style rules across the project, and adjusts a rule so we can avoid some supressions.

I have batched together a PR for these rules as they each had some but not too many violating files.

See https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ for explanation of each rule.