### PR TITLE
Enforce code rule IDE0032

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -165,6 +165,9 @@ dotnet_diagnostic.IDE0030.severity = warning
 # Use null propagation.
 dotnet_diagnostic.IDE0031.severity = warning
 
+# Use auto-implemented property.
+dotnet_diagnostic.IDE0032.severity = warning
+
 # Use explicitly provided tuple name.
 dotnet_diagnostic.IDE0033.severity = warning
 

--- a/OpenRA.Game/FileSystem/Folder.cs
+++ b/OpenRA.Game/FileSystem/Folder.cs
@@ -18,24 +18,22 @@ namespace OpenRA.FileSystem
 {
 	public sealed class Folder : IReadWritePackage
 	{
-		readonly string path;
+		public string Name { get; }
 
 		public Folder(string path)
 		{
-			this.path = path;
+			Name = path;
 			if (!Directory.Exists(path))
 				Directory.CreateDirectory(path);
 		}
-
-		public string Name => path;
 
 		public IEnumerable<string> Contents
 		{
 			get
 			{
 				// Order may vary on different file systems and it matters for hashing.
-				return Directory.GetFiles(path, "*", SearchOption.TopDirectoryOnly)
-					.Concat(Directory.GetDirectories(path))
+				return Directory.GetFiles(Name, "*", SearchOption.TopDirectoryOnly)
+					.Concat(Directory.GetDirectories(Name))
 					.Select(Path.GetFileName)
 					.OrderBy(f => f);
 			}
@@ -43,14 +41,14 @@ namespace OpenRA.FileSystem
 
 		public Stream GetStream(string filename)
 		{
-			try { return File.OpenRead(Path.Combine(path, filename)); }
+			try { return File.OpenRead(Path.Combine(Name, filename)); }
 			catch { return null; }
 		}
 
 		public bool Contains(string filename)
 		{
-			var combined = Path.Combine(path, filename);
-			return combined.StartsWith(path, StringComparison.Ordinal) && File.Exists(combined);
+			var combined = Path.Combine(Name, filename);
+			return combined.StartsWith(Name, StringComparison.Ordinal) && File.Exists(combined);
 		}
 
 		public IReadOnlyPackage OpenPackage(string filename, FileSystem context)
@@ -82,7 +80,7 @@ namespace OpenRA.FileSystem
 			// in FileSystem.OpenPackage.  Their internal name therefore contains the
 			// full parent path too.  We need to be careful to not add a second path
 			// prefix to these hacked packages.
-			var filePath = filename.StartsWith(path) ? filename : Path.Combine(path, filename);
+			var filePath = filename.StartsWith(Name) ? filename : Path.Combine(Name, filename);
 
 			Directory.CreateDirectory(Path.GetDirectoryName(filePath));
 			using (var s = File.Create(filePath))
@@ -96,7 +94,7 @@ namespace OpenRA.FileSystem
 			// in FileSystem.OpenPackage.  Their internal name therefore contains the
 			// full parent path too.  We need to be careful to not add a second path
 			// prefix to these hacked packages.
-			var filePath = filename.StartsWith(path) ? filename : Path.Combine(path, filename);
+			var filePath = filename.StartsWith(Name) ? filename : Path.Combine(Name, filename);
 			if (Directory.Exists(filePath))
 				Directory.Delete(filePath, true);
 			else if (File.Exists(filePath))

--- a/OpenRA.Game/FileSystem/ZipFile.cs
+++ b/OpenRA.Game/FileSystem/ZipFile.cs
@@ -142,23 +142,22 @@ namespace OpenRA.FileSystem
 
 		sealed class ZipFolder : IReadOnlyPackage
 		{
-			public string Name => path;
+			public string Name { get; }
 			public ReadOnlyZipFile Parent { get; }
-			readonly string path;
 
 			public ZipFolder(ReadOnlyZipFile parent, string path)
 			{
 				if (path.EndsWith("/", StringComparison.Ordinal))
 					path = path.Substring(0, path.Length - 1);
 
+				Name = path;
 				Parent = parent;
-				this.path = path;
 			}
 
 			public Stream GetStream(string filename)
 			{
 				// Zip files use '/' as a path separator
-				return Parent.GetStream(path + '/' + filename);
+				return Parent.GetStream(Name + '/' + filename);
 			}
 
 			public IEnumerable<string> Contents
@@ -167,9 +166,9 @@ namespace OpenRA.FileSystem
 				{
 					foreach (var entry in Parent.Contents)
 					{
-						if (entry.StartsWith(path, StringComparison.Ordinal) && entry != path)
+						if (entry.StartsWith(Name, StringComparison.Ordinal) && entry != Name)
 						{
-							var filename = entry.Substring(path.Length + 1);
+							var filename = entry.Substring(Name.Length + 1);
 							var dirLevels = filename.Split('/').Count(c => !string.IsNullOrEmpty(c));
 							if (dirLevels == 1)
 								yield return filename;
@@ -180,12 +179,12 @@ namespace OpenRA.FileSystem
 
 			public bool Contains(string filename)
 			{
-				return Parent.Contains(path + '/' + filename);
+				return Parent.Contains(Name + '/' + filename);
 			}
 
 			public IReadOnlyPackage OpenPackage(string filename, FileSystem context)
 			{
-				return Parent.OpenPackage(path + '/' + filename, context);
+				return Parent.OpenPackage(Name + '/' + filename, context);
 			}
 
 			public void Dispose() { /* nothing to do */ }

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -37,11 +37,12 @@ namespace OpenRA.Graphics
 		readonly List<Sheet> sheets = new List<Sheet>();
 		readonly Func<Sheet> allocateSheet;
 		readonly int margin;
-
-		Sheet current;
-		TextureChannel channel;
 		int rowHeight = 0;
 		int2 p;
+
+		public Sheet Current { get; private set; }
+		public TextureChannel CurrentChannel { get; private set; }
+		public IEnumerable<Sheet> AllSheets => sheets;
 
 		public static Sheet AllocateSheet(SheetType type, int sheetSize)
 		{
@@ -73,10 +74,10 @@ namespace OpenRA.Graphics
 
 		public SheetBuilder(SheetType t, Func<Sheet> allocateSheet, int margin = 1)
 		{
-			channel = t == SheetType.Indexed ? TextureChannel.Red : TextureChannel.RGBA;
+			CurrentChannel = t == SheetType.Indexed ? TextureChannel.Red : TextureChannel.RGBA;
 			Type = t;
-			current = allocateSheet();
-			sheets.Add(current);
+			Current = allocateSheet();
+			sheets.Add(Current);
 			this.allocateSheet = allocateSheet;
 			this.margin = margin;
 		}
@@ -87,11 +88,11 @@ namespace OpenRA.Graphics
 		{
 			// Don't bother allocating empty sprites
 			if (size.Width == 0 || size.Height == 0)
-				return new Sprite(current, Rectangle.Empty, 0, spriteOffset, channel, BlendMode.Alpha);
+				return new Sprite(Current, Rectangle.Empty, 0, spriteOffset, CurrentChannel, BlendMode.Alpha);
 
 			var rect = Allocate(size, zRamp, spriteOffset);
 			Util.FastCopyIntoChannel(rect, src, type);
-			current.CommitBufferedData();
+			Current.CommitBufferedData();
 			return rect;
 		}
 
@@ -99,7 +100,7 @@ namespace OpenRA.Graphics
 		{
 			var rect = Allocate(new Size(src.Width, src.Height),  scale);
 			Util.FastCopyIntoSprite(rect, src);
-			current.CommitBufferedData();
+			Current.CommitBufferedData();
 			return rect;
 		}
 
@@ -115,7 +116,7 @@ namespace OpenRA.Graphics
 		public Sprite Allocate(Size imageSize, float scale = 1f) { return Allocate(imageSize, 0, float3.Zero, scale); }
 		public Sprite Allocate(Size imageSize, float zRamp, in float3 spriteOffset, float scale = 1f)
 		{
-			if (imageSize.Width + p.X + margin > current.Size.Width)
+			if (imageSize.Width + p.X + margin > Current.Size.Width)
 			{
 				p = new int2(0, p.Y + rowHeight + margin);
 				rowHeight = imageSize.Height;
@@ -124,32 +125,28 @@ namespace OpenRA.Graphics
 			if (imageSize.Height > rowHeight)
 				rowHeight = imageSize.Height;
 
-			if (p.Y + imageSize.Height + margin > current.Size.Height)
+			if (p.Y + imageSize.Height + margin > Current.Size.Height)
 			{
-				var next = NextChannel(channel);
+				var next = NextChannel(CurrentChannel);
 				if (next == null)
 				{
-					current.ReleaseBuffer();
-					current = allocateSheet();
-					sheets.Add(current);
-					channel = Type == SheetType.Indexed ? TextureChannel.Red : TextureChannel.RGBA;
+					Current.ReleaseBuffer();
+					Current = allocateSheet();
+					sheets.Add(Current);
+					CurrentChannel = Type == SheetType.Indexed ? TextureChannel.Red : TextureChannel.RGBA;
 				}
 				else
-					channel = next.Value;
+					CurrentChannel = next.Value;
 
 				rowHeight = imageSize.Height;
 				p = int2.Zero;
 			}
 
-			var rect = new Sprite(current, new Rectangle(p.X + margin, p.Y + margin, imageSize.Width, imageSize.Height), zRamp, spriteOffset, channel, BlendMode.Alpha, scale);
+			var rect = new Sprite(Current, new Rectangle(p.X + margin, p.Y + margin, imageSize.Width, imageSize.Height), zRamp, spriteOffset, CurrentChannel, BlendMode.Alpha, scale);
 			p += new int2(imageSize.Width + margin, 0);
 
 			return rect;
 		}
-
-		public Sheet Current => current;
-		public TextureChannel CurrentChannel => channel;
-		public IEnumerable<Sheet> AllSheets => sheets;
 
 		public void Dispose()
 		{

--- a/OpenRA.Game/Graphics/UISpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/UISpriteRenderable.cs
@@ -16,10 +16,7 @@ namespace OpenRA.Graphics
 	public class UISpriteRenderable : IRenderable, IPalettedRenderable, IFinalizedRenderable
 	{
 		readonly Sprite sprite;
-		readonly WPos effectiveWorldPos;
 		readonly int2 screenPos;
-		readonly int zOffset;
-		readonly PaletteReference palette;
 		readonly float scale;
 		readonly float alpha;
 		readonly float rotation = 0f;
@@ -27,10 +24,10 @@ namespace OpenRA.Graphics
 		public UISpriteRenderable(Sprite sprite, WPos effectiveWorldPos, int2 screenPos, int zOffset, PaletteReference palette, float scale = 1f, float alpha = 1f, float rotation = 0f)
 		{
 			this.sprite = sprite;
-			this.effectiveWorldPos = effectiveWorldPos;
+			Pos = effectiveWorldPos;
 			this.screenPos = screenPos;
-			this.zOffset = zOffset;
-			this.palette = palette;
+			ZOffset = zOffset;
+			Palette = palette;
 			this.scale = scale;
 			this.alpha = alpha;
 			this.rotation = rotation;
@@ -39,18 +36,18 @@ namespace OpenRA.Graphics
 			// HACK: This is working around the fact that palettes are defined on traits rather than sequences
 			// and can be removed once this has been fixed
 			if (sprite.Channel == TextureChannel.RGBA && !(palette?.HasColorShift ?? false))
-				this.palette = null;
+				Palette = null;
 		}
 
 		// Does not exist in the world, so a world positions don't make sense
-		public WPos Pos => effectiveWorldPos;
+		public WPos Pos { get; }
 		public WVec Offset => WVec.Zero;
 		public bool IsDecoration => true;
 
-		public PaletteReference Palette => palette;
-		public int ZOffset => zOffset;
+		public PaletteReference Palette { get; }
+		public int ZOffset { get; }
 
-		public IPalettedRenderable WithPalette(PaletteReference newPalette) { return new UISpriteRenderable(sprite, effectiveWorldPos, screenPos, zOffset, newPalette, scale, alpha, rotation); }
+		public IPalettedRenderable WithPalette(PaletteReference newPalette) { return new UISpriteRenderable(sprite, Pos, screenPos, ZOffset, newPalette, scale, alpha, rotation); }
 		public IRenderable WithZOffset(int newOffset) { return this; }
 		public IRenderable OffsetBy(in WVec vec) { return this; }
 		public IRenderable AsDecoration() { return this; }
@@ -58,7 +55,7 @@ namespace OpenRA.Graphics
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
 		public void Render(WorldRenderer wr)
 		{
-			Game.Renderer.SpriteRenderer.DrawSprite(sprite, palette, screenPos, scale, float3.Ones, alpha, rotation);
+			Game.Renderer.SpriteRenderer.DrawSprite(sprite, Palette, screenPos, scale, float3.Ones, alpha, rotation);
 		}
 
 		public void RenderDebugGeometry(WorldRenderer wr)

--- a/OpenRA.Game/Map/CellRegion.cs
+++ b/OpenRA.Game/Map/CellRegion.cs
@@ -126,15 +126,12 @@ namespace OpenRA
 			// Current position, in map coordinates
 			int u, v;
 
-			// Current position, in cell coordinates
-			CPos current;
-
 			public CellRegionEnumerator(CellRegion region)
 				: this()
 			{
 				r = region;
 				Reset();
-				current = new MPos(u, v).ToCPos(r.gridType);
+				Current = new MPos(u, v).ToCPos(r.gridType);
 			}
 
 			public bool MoveNext()
@@ -152,7 +149,8 @@ namespace OpenRA
 						return false;
 				}
 
-				current = new MPos(u, v).ToCPos(r.gridType);
+				// Current position, in cell coordinates
+				Current = new MPos(u, v).ToCPos(r.gridType);
 				return true;
 			}
 
@@ -163,7 +161,7 @@ namespace OpenRA
 				v = r.mapTopLeft.V;
 			}
 
-			public CPos Current => current;
+			public CPos Current { get; private set; }
 			object IEnumerator.Current => Current;
 			public void Dispose() { }
 		}

--- a/OpenRA.Game/Map/MapCoordsRegion.cs
+++ b/OpenRA.Game/Map/MapCoordsRegion.cs
@@ -19,7 +19,6 @@ namespace OpenRA
 		public struct MapCoordsEnumerator : IEnumerator<MPos>
 		{
 			readonly MapCoordsRegion r;
-			MPos current;
 
 			public MapCoordsEnumerator(MapCoordsRegion region)
 				: this()
@@ -30,41 +29,38 @@ namespace OpenRA
 
 			public bool MoveNext()
 			{
-				var u = current.U + 1;
-				var v = current.V;
+				var u = Current.U + 1;
+				var v = Current.V;
 
 				// Check for column overflow
-				if (u > r.bottomRight.U)
+				if (u > r.BottomRight.U)
 				{
 					v += 1;
-					u = r.topLeft.U;
+					u = r.TopLeft.U;
 
 					// Check for row overflow
-					if (v > r.bottomRight.V)
+					if (v > r.BottomRight.V)
 						return false;
 				}
 
-				current = new MPos(u, v);
+				Current = new MPos(u, v);
 				return true;
 			}
 
 			public void Reset()
 			{
-				current = new MPos(r.topLeft.U - 1, r.topLeft.V);
+				Current = new MPos(r.TopLeft.U - 1, r.TopLeft.V);
 			}
 
-			public MPos Current => current;
+			public MPos Current { get; private set; }
 			object IEnumerator.Current => Current;
 			public void Dispose() { }
 		}
 
-		readonly MPos topLeft;
-		readonly MPos bottomRight;
-
 		public MapCoordsRegion(MPos mapTopLeft, MPos mapBottomRight)
 		{
-			topLeft = mapTopLeft;
-			bottomRight = mapBottomRight;
+			TopLeft = mapTopLeft;
+			BottomRight = mapBottomRight;
 		}
 
 		public override string ToString()
@@ -87,7 +83,7 @@ namespace OpenRA
 			return GetEnumerator();
 		}
 
-		public MPos TopLeft => topLeft;
-		public MPos BottomRight => bottomRight;
+		public MPos TopLeft { get; }
+		public MPos BottomRight { get; }
 	}
 }

--- a/OpenRA.Game/Map/ProjectedCellRegion.cs
+++ b/OpenRA.Game/Map/ProjectedCellRegion.cs
@@ -83,14 +83,12 @@ namespace OpenRA
 			// Current position, in projected map coordinates
 			int u, v;
 
-			PPos current;
-
 			public ProjectedCellRegionEnumerator(ProjectedCellRegion region)
 				: this()
 			{
 				r = region;
 				Reset();
-				current = new PPos(u, v);
+				Current = new PPos(u, v);
 			}
 
 			public bool MoveNext()
@@ -108,7 +106,7 @@ namespace OpenRA
 						return false;
 				}
 
-				current = new PPos(u, v);
+				Current = new PPos(u, v);
 				return true;
 			}
 
@@ -119,7 +117,7 @@ namespace OpenRA
 				v = r.TopLeft.V;
 			}
 
-			public PPos Current => current;
+			public PPos Current { get; private set; }
 			object IEnumerator.Current => Current;
 			public void Dispose() { }
 		}

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -329,6 +329,8 @@ namespace OpenRA
 
 				case OrderType.Fields:
 				{
+					var targetState = Target.SerializableState;
+
 					var fields = OrderFields.None;
 					if (Subject != null)
 						fields |= OrderFields.Subject;
@@ -339,7 +341,7 @@ namespace OpenRA
 					if (ExtraData != 0)
 						fields |= OrderFields.ExtraData;
 
-					if (Target.SerializableType != TargetType.Invalid)
+					if (targetState.Type != TargetType.Invalid)
 						fields |= OrderFields.Target;
 
 					if (Queued)
@@ -354,7 +356,7 @@ namespace OpenRA
 					if (ExtraLocation != CPos.Zero)
 						fields |= OrderFields.ExtraLocation;
 
-					if (Target.SerializableCell != null)
+					if (targetState.Cell != null)
 						fields |= OrderFields.TargetIsCell;
 
 					w.Write((short)fields);
@@ -364,12 +366,12 @@ namespace OpenRA
 
 					if (fields.HasField(OrderFields.Target))
 					{
-						w.Write((byte)Target.SerializableType);
-						switch (Target.SerializableType)
+						w.Write((byte)targetState.Type);
+						switch (targetState.Type)
 						{
 							case TargetType.Actor:
-								w.Write(UIntFromActor(Target.SerializableActor));
-								w.Write(Target.SerializableGeneration);
+								w.Write(UIntFromActor(targetState.Actor));
+								w.Write(targetState.Generation);
 								break;
 							case TargetType.FrozenActor:
 								w.Write(Target.FrozenActor.Viewer.PlayerActor.ActorID);
@@ -378,14 +380,14 @@ namespace OpenRA
 							case TargetType.Terrain:
 								if (fields.HasField(OrderFields.TargetIsCell))
 								{
-									w.Write(Target.SerializableCell.Value.Bits);
-									w.Write((byte)Target.SerializableSubCell);
+									w.Write(targetState.Cell.Value.Bits);
+									w.Write((byte)targetState.SubCell);
 								}
 								else
 								{
-									w.Write(Target.SerializablePos.X);
-									w.Write(Target.SerializablePos.Y);
-									w.Write(Target.SerializablePos.Z);
+									w.Write(targetState.Pos.X);
+									w.Write(targetState.Pos.Y);
+									w.Write(targetState.Pos.Z);
 								}
 
 								break;

--- a/OpenRA.Game/Network/TickTime.cs
+++ b/OpenRA.Game/Network/TickTime.cs
@@ -17,19 +17,13 @@ namespace OpenRA.Network
 	{
 		readonly Func<int> timestep;
 
-		long lastTickTime;
-
 		public TickTime(Func<int> timestep, long lastTickTime)
 		{
 			this.timestep = timestep;
-			this.lastTickTime = lastTickTime;
+			Value = lastTickTime;
 		}
 
-		public long Value
-		{
-			get => lastTickTime;
-			set => lastTickTime = value;
-		}
+		public long Value { get; set; }
 
 		public bool ShouldAdvance(long tick)
 		{
@@ -38,18 +32,18 @@ namespace OpenRA.Network
 			if (i == 0)
 				return false;
 
-			var tickDelta = tick - lastTickTime;
+			var tickDelta = tick - Value;
 			return tickDelta >= i;
 		}
 
 		public void AdvanceTickTime(long tick)
 		{
-			var tickDelta = tick - lastTickTime;
+			var tickDelta = tick - Value;
 
 			var currentTimestep = timestep();
 
 			var integralTickTimestep = tickDelta / currentTimestep * currentTimestep;
-			lastTickTime += integralTickTimestep >= Game.TimestepJankThreshold
+			Value += integralTickTimestep >= Game.TimestepJankThreshold
 				? integralTickTimestep
 				: currentTimestep;
 		}

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -52,12 +52,11 @@ namespace OpenRA
 		IFrameBuffer worldBuffer;
 		Sheet worldSheet;
 		Sprite worldSprite;
-		int worldDownscaleFactor = 1;
 		Size lastMaximumViewportSize;
 		Size lastWorldViewportSize;
 
 		public Size WorldFrameBufferSize => worldSheet.Size;
-		public int WorldDownscaleFactor => worldDownscaleFactor;
+		public int WorldDownscaleFactor { get; private set; } = 1;
 
 		SheetBuilder fontSheetBuilder;
 		readonly IPlatform platform;
@@ -240,11 +239,11 @@ namespace OpenRA
 				var vh = worldViewport.Size.Height;
 				var bw = worldSheet.Size.Width;
 				var bh = worldSheet.Size.Height;
-				worldDownscaleFactor = 1;
-				while (vw / worldDownscaleFactor > bw || vh / worldDownscaleFactor > bh)
-					worldDownscaleFactor++;
+				WorldDownscaleFactor = 1;
+				while (vw / WorldDownscaleFactor > bw || vh / WorldDownscaleFactor > bh)
+					WorldDownscaleFactor++;
 
-				var s = new Size(vw / worldDownscaleFactor, vh / worldDownscaleFactor);
+				var s = new Size(vw / WorldDownscaleFactor, vh / WorldDownscaleFactor);
 				worldSprite = new Sprite(worldSheet, new Rectangle(int2.Zero, s), TextureChannel.RGBA);
 				lastWorldViewportSize = worldViewport.Size;
 			}
@@ -253,7 +252,7 @@ namespace OpenRA
 
 			if (lastWorldViewport != worldViewport)
 			{
-				WorldSpriteRenderer.SetViewportParams(worldSheet.Size, worldDownscaleFactor, depthMargin, worldViewport.Location);
+				WorldSpriteRenderer.SetViewportParams(worldSheet.Size, WorldDownscaleFactor, depthMargin, worldViewport.Location);
 				WorldModelRenderer.SetViewportParams();
 
 				lastWorldViewport = worldViewport;
@@ -391,10 +390,10 @@ namespace OpenRA
 			if (renderType == RenderType.World)
 			{
 				var r = Rectangle.FromLTRB(
-					rect.Left / worldDownscaleFactor,
-					rect.Top / worldDownscaleFactor,
-					(rect.Right + worldDownscaleFactor - 1) / worldDownscaleFactor,
-					(rect.Bottom + worldDownscaleFactor - 1) / worldDownscaleFactor);
+					rect.Left / WorldDownscaleFactor,
+					rect.Top / WorldDownscaleFactor,
+					(rect.Right + WorldDownscaleFactor - 1) / WorldDownscaleFactor,
+					(rect.Bottom + WorldDownscaleFactor - 1) / WorldDownscaleFactor);
 				worldBuffer.EnableScissor(r);
 			}
 			else
@@ -415,10 +414,10 @@ namespace OpenRA
 				{
 					var rect = scissorState.Peek();
 					var r = Rectangle.FromLTRB(
-						rect.Left / worldDownscaleFactor,
-						rect.Top / worldDownscaleFactor,
-						(rect.Right + worldDownscaleFactor - 1) / worldDownscaleFactor,
-						(rect.Bottom + worldDownscaleFactor - 1) / worldDownscaleFactor);
+						rect.Left / WorldDownscaleFactor,
+						rect.Top / WorldDownscaleFactor,
+						(rect.Right + WorldDownscaleFactor - 1) / WorldDownscaleFactor,
+						(rect.Bottom + WorldDownscaleFactor - 1) / WorldDownscaleFactor);
 					worldBuffer.EnableScissor(r);
 				}
 				else

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -43,7 +43,6 @@ namespace OpenRA
 		ISoundSource videoSource;
 		ISound music;
 		ISound video;
-		MusicInfo currentMusic;
 		readonly Dictionary<uint, ISound> currentSounds = new Dictionary<uint, ISound>();
 		readonly Dictionary<string, ISound> currentNotifications = new Dictionary<string, ISound>();
 		public bool DummyEngine { get; }
@@ -226,7 +225,7 @@ namespace OpenRA
 
 		Action onMusicComplete;
 		public bool MusicPlaying { get; private set; }
-		public MusicInfo CurrentMusic => currentMusic;
+		public MusicInfo CurrentMusic { get; private set; }
 
 		public void PlayMusicThen(MusicInfo m, Action then)
 		{
@@ -235,7 +234,7 @@ namespace OpenRA
 
 			onMusicComplete = then;
 
-			if (m == currentMusic && music != null)
+			if (m == CurrentMusic && music != null)
 			{
 				soundEngine.PauseSound(music, false);
 				MusicPlaying = true;
@@ -263,7 +262,7 @@ namespace OpenRA
 				return;
 			}
 
-			currentMusic = m;
+			CurrentMusic = m;
 			MusicPlaying = true;
 		}
 
@@ -290,7 +289,7 @@ namespace OpenRA
 				music = null;
 			}
 
-			currentMusic = null;
+			CurrentMusic = null;
 			MusicPlaying = false;
 		}
 

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -38,10 +38,10 @@ namespace OpenRA.Traits
 		public readonly WPos CenterPosition;
 		readonly Actor actor;
 		readonly ICreatesFrozenActors frozenTrait;
-		readonly Player viewer;
 		readonly Shroud shroud;
 		readonly List<WPos> targetablePositions = new List<WPos>();
 
+		public Player Viewer { get; }
 		public Player Owner { get; private set; }
 		public BitSet<TargetableType> TargetTypes { get; private set; }
 		public IEnumerable<WPos> TargetablePositions => targetablePositions;
@@ -86,7 +86,7 @@ namespace OpenRA.Traits
 		{
 			this.actor = actor;
 			this.frozenTrait = frozenTrait;
-			this.viewer = viewer;
+			Viewer = viewer;
 			shroud = viewer.Shroud;
 			NeedRenderables = startsRevealed;
 
@@ -119,7 +119,6 @@ namespace OpenRA.Traits
 		public bool IsValid => Owner != null;
 		public ActorInfo Info => actor.Info;
 		public Actor Actor => !actor.IsDead ? actor : null;
-		public Player Viewer => viewer;
 
 		public void RefreshState()
 		{
@@ -147,7 +146,7 @@ namespace OpenRA.Traits
 			Hidden = false;
 			foreach (var visibilityModifier in visibilityModifiers)
 			{
-				if (!visibilityModifier.IsVisible(actor, viewer))
+				if (!visibilityModifier.IsVisible(actor, Viewer))
 				{
 					Hidden = true;
 					break;

--- a/OpenRA.Mods.Cnc/Graphics/TeslaZapRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/TeslaZapRenderable.cs
@@ -30,9 +30,6 @@ namespace OpenRA.Mods.Cnc.Graphics
 			new int[] { -8, 8, -4, 4, 3 },
 			new int[] { 8, -8, 4, -4, 3 }
 		};
-
-		readonly WPos pos;
-		readonly int zOffset;
 		readonly WVec length;
 		readonly string image;
 		readonly string palette;
@@ -46,8 +43,8 @@ namespace OpenRA.Mods.Cnc.Graphics
 
 		public TeslaZapRenderable(WPos pos, int zOffset, in WVec length, string image, string brightSequence, int brightZaps, string dimSequence, int dimZaps, string palette)
 		{
-			this.pos = pos;
-			this.zOffset = zOffset;
+			Pos = pos;
+			ZOffset = zOffset;
 			this.length = length;
 			this.image = image;
 			this.palette = palette;
@@ -61,28 +58,28 @@ namespace OpenRA.Mods.Cnc.Graphics
 			cache = Array.Empty<IFinalizedRenderable>();
 		}
 
-		public WPos Pos => pos;
+		public WPos Pos { get; }
 		public PaletteReference Palette => null;
-		public int ZOffset => zOffset;
+		public int ZOffset { get; }
 		public bool IsDecoration => true;
 
 		public IPalettedRenderable WithPalette(PaletteReference newPalette)
 		{
-			return new TeslaZapRenderable(pos, zOffset, length, image, brightSequence, brightZaps, dimSequence, dimZaps, palette);
+			return new TeslaZapRenderable(Pos, ZOffset, length, image, brightSequence, brightZaps, dimSequence, dimZaps, palette);
 		}
 
-		public IRenderable WithZOffset(int newOffset) { return new TeslaZapRenderable(pos, zOffset, length, image, brightSequence, brightZaps, dimSequence, dimZaps, palette); }
-		public IRenderable OffsetBy(in WVec vec) { return new TeslaZapRenderable(pos + vec, zOffset, length, image, brightSequence, brightZaps, dimSequence, dimZaps, palette); }
+		public IRenderable WithZOffset(int newOffset) { return new TeslaZapRenderable(Pos, ZOffset, length, image, brightSequence, brightZaps, dimSequence, dimZaps, palette); }
+		public IRenderable OffsetBy(in WVec vec) { return new TeslaZapRenderable(Pos + vec, ZOffset, length, image, brightSequence, brightZaps, dimSequence, dimZaps, palette); }
 		public IRenderable AsDecoration() { return this; }
 
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
 		public void RenderDebugGeometry(WorldRenderer wr) { }
 		public void Render(WorldRenderer wr)
 		{
-			if (wr.World.FogObscures(pos) && wr.World.FogObscures(pos + length))
+			if (wr.World.FogObscures(Pos) && wr.World.FogObscures(Pos + length))
 				return;
 
-			if (!cache.Any() || length != cachedLength || pos != cachedPos)
+			if (!cache.Any() || length != cachedLength || Pos != cachedPos)
 				cache = GenerateRenderables(wr);
 
 			foreach (var renderable in cache)
@@ -96,8 +93,8 @@ namespace OpenRA.Mods.Cnc.Graphics
 			var bright = wr.World.Map.Rules.Sequences.GetSequence(image, brightSequence);
 			var dim = wr.World.Map.Rules.Sequences.GetSequence(image, dimSequence);
 
-			var source = wr.ScreenPosition(pos);
-			var target = wr.ScreenPosition(pos + length);
+			var source = wr.ScreenPosition(Pos);
+			var target = wr.ScreenPosition(Pos + length);
 
 			for (var n = 0; n < dimZaps; n++)
 				foreach (var z in DrawZapWandering(wr, source, target, dim, palette))

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -64,16 +64,14 @@ namespace OpenRA.Mods.Cnc.Traits
 		IEnumerable<int> speedModifiers;
 		INotifyCenterPositionChanged[] notifyCenterPositionChanged;
 
-		WRot orientation;
-
 		[Sync]
 		public WAngle Facing
 		{
-			get => orientation.Yaw;
-			set => orientation = orientation.WithYaw(value);
+			get => Orientation.Yaw;
+			set => Orientation = Orientation.WithYaw(value);
 		}
 
-		public WRot Orientation => orientation;
+		public WRot Orientation { get; private set; }
 
 		[Sync]
 		public WPos CenterPosition { get; private set; }

--- a/OpenRA.Mods.Common/AudioLoaders/Mp3Loader.cs
+++ b/OpenRA.Mods.Common/AudioLoaders/Mp3Loader.cs
@@ -79,13 +79,12 @@ namespace OpenRA.Mods.Common.AudioLoaders
 
 		public class StreamAbstraction : TagLib.File.IFileAbstraction
 		{
-			readonly Stream s;
 			public StreamAbstraction(Stream s)
 			{
-				this.s = s;
+				ReadStream = s;
 			}
 
-			public Stream ReadStream => s;
+			public Stream ReadStream { get; }
 
 			public Stream WriteStream => throw new NotImplementedException();
 

--- a/OpenRA.Mods.Common/Graphics/BeamRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/BeamRenderable.cs
@@ -17,8 +17,6 @@ namespace OpenRA.Mods.Common.Graphics
 	public enum BeamRenderableShape { Cylindrical, Flat }
 	public class BeamRenderable : IRenderable, IFinalizedRenderable
 	{
-		readonly WPos pos;
-		readonly int zOffset;
 		readonly WVec length;
 		readonly BeamRenderableShape shape;
 		readonly WDist width;
@@ -26,20 +24,20 @@ namespace OpenRA.Mods.Common.Graphics
 
 		public BeamRenderable(WPos pos, int zOffset, in WVec length, BeamRenderableShape shape, WDist width, Color color)
 		{
-			this.pos = pos;
-			this.zOffset = zOffset;
+			Pos = pos;
+			ZOffset = zOffset;
 			this.length = length;
 			this.shape = shape;
 			this.width = width;
 			this.color = color;
 		}
 
-		public WPos Pos => pos;
-		public int ZOffset => zOffset;
+		public WPos Pos { get; }
+		public int ZOffset { get; }
 		public bool IsDecoration => true;
 
-		public IRenderable WithZOffset(int newOffset) { return new BeamRenderable(pos, zOffset, length, shape, width, color); }
-		public IRenderable OffsetBy(in WVec vec) { return new BeamRenderable(pos + vec, zOffset, length, shape, width, color); }
+		public IRenderable WithZOffset(int newOffset) { return new BeamRenderable(Pos, ZOffset, length, shape, width, color); }
+		public IRenderable OffsetBy(in WVec vec) { return new BeamRenderable(Pos + vec, ZOffset, length, shape, width, color); }
 		public IRenderable AsDecoration() { return this; }
 
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
@@ -53,16 +51,16 @@ namespace OpenRA.Mods.Common.Graphics
 			{
 				var delta = length * width.Length / (2 * vecLength);
 				var corner = new WVec(-delta.Y, delta.X, delta.Z);
-				var a = wr.Screen3DPosition(pos - corner);
-				var b = wr.Screen3DPosition(pos + corner);
-				var c = wr.Screen3DPosition(pos + corner + length);
-				var d = wr.Screen3DPosition(pos - corner + length);
+				var a = wr.Screen3DPosition(Pos - corner);
+				var b = wr.Screen3DPosition(Pos + corner);
+				var c = wr.Screen3DPosition(Pos + corner + length);
+				var d = wr.Screen3DPosition(Pos - corner + length);
 				Game.Renderer.WorldRgbaColorRenderer.FillRect(a, b, c, d, color);
 			}
 			else
 			{
-				var start = wr.Screen3DPosition(pos);
-				var end = wr.Screen3DPosition(pos + length);
+				var start = wr.Screen3DPosition(Pos);
+				var end = wr.Screen3DPosition(Pos + length);
 				var screenWidth = wr.ScreenVector(new WVec(width, WDist.Zero, WDist.Zero))[0];
 				Game.Renderer.WorldRgbaColorRenderer.DrawLine(start, end, screenWidth, color);
 			}

--- a/OpenRA.Mods.Common/Graphics/CircleAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/CircleAnnotationRenderable.cs
@@ -18,8 +18,6 @@ namespace OpenRA.Mods.Common.Graphics
 	{
 		const int CircleSegments = 32;
 		static readonly WVec[] FacingOffsets = Exts.MakeArray(CircleSegments, i => new WVec(1024, 0, 0).Rotate(WRot.FromFacing(i * 256 / CircleSegments)));
-
-		readonly WPos centerPosition;
 		readonly WDist radius;
 		readonly int width;
 		readonly Color color;
@@ -27,19 +25,19 @@ namespace OpenRA.Mods.Common.Graphics
 
 		public CircleAnnotationRenderable(WPos centerPosition, WDist radius, int width, Color color, bool filled = false)
 		{
-			this.centerPosition = centerPosition;
+			Pos = centerPosition;
 			this.radius = radius;
 			this.width = width;
 			this.color = color;
 			this.filled = filled;
 		}
 
-		public WPos Pos => centerPosition;
+		public WPos Pos { get; }
 		public int ZOffset => 0;
 		public bool IsDecoration => true;
 
-		public IRenderable WithZOffset(int newOffset) { return new CircleAnnotationRenderable(centerPosition, radius, width, color, filled); }
-		public IRenderable OffsetBy(in WVec vec) { return new CircleAnnotationRenderable(centerPosition + vec, radius, width, color, filled); }
+		public IRenderable WithZOffset(int newOffset) { return new CircleAnnotationRenderable(Pos, radius, width, color, filled); }
+		public IRenderable OffsetBy(in WVec vec) { return new CircleAnnotationRenderable(Pos + vec, radius, width, color, filled); }
 		public IRenderable AsDecoration() { return this; }
 
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
@@ -49,18 +47,18 @@ namespace OpenRA.Mods.Common.Graphics
 			if (filled)
 			{
 				var offset = new WVec(radius.Length, radius.Length, 0);
-				var tl = wr.Viewport.WorldToViewPx(wr.ScreenPosition(centerPosition - offset));
-				var br = wr.Viewport.WorldToViewPx(wr.ScreenPosition(centerPosition + offset));
+				var tl = wr.Viewport.WorldToViewPx(wr.ScreenPosition(Pos - offset));
+				var br = wr.Viewport.WorldToViewPx(wr.ScreenPosition(Pos + offset));
 
 				cr.FillEllipse(tl, br, color);
 			}
 			else
 			{
 				var r = radius.Length;
-				var a = wr.Viewport.WorldToViewPx(wr.ScreenPosition(centerPosition + r * FacingOffsets[CircleSegments - 1] / 1024));
+				var a = wr.Viewport.WorldToViewPx(wr.ScreenPosition(Pos + r * FacingOffsets[CircleSegments - 1] / 1024));
 				for (var i = 0; i < CircleSegments; i++)
 				{
-					var b = wr.Viewport.WorldToViewPx(wr.ScreenPosition(centerPosition + r * FacingOffsets[i] / 1024));
+					var b = wr.Viewport.WorldToViewPx(wr.ScreenPosition(Pos + r * FacingOffsets[i] / 1024));
 					cr.DrawLine(a, b, width, color);
 					a = b;
 				}

--- a/OpenRA.Mods.Common/Graphics/ContrailRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/ContrailRenderable.cs
@@ -24,7 +24,6 @@ namespace OpenRA.Mods.Common.Graphics
 		readonly World world;
 		readonly Color startcolor;
 		readonly Color endcolor;
-		readonly int zOffset;
 
 		// Store trail positions in a circular buffer
 		readonly WPos[] trail;
@@ -46,11 +45,11 @@ namespace OpenRA.Mods.Common.Graphics
 			this.skip = skip;
 			this.startcolor = startcolor;
 			this.endcolor = endcolor;
-			this.zOffset = zOffset;
+			ZOffset = zOffset;
 		}
 
 		public WPos Pos => trail[Index(next - 1)];
-		public int ZOffset => zOffset;
+		public int ZOffset { get; }
 		public bool IsDecoration => true;
 
 		public IRenderable WithZOffset(int newOffset) { return new ContrailRenderable(world, (WPos[])trail.Clone(), width, next, length, skip, startcolor, endcolor, newOffset); }
@@ -58,7 +57,7 @@ namespace OpenRA.Mods.Common.Graphics
 		{
 			// Lambdas can't use 'in' variables, so capture a copy for later
 			var offset = vec;
-			return new ContrailRenderable(world, trail.Select(pos => pos + offset).ToArray(), width, next, length, skip, startcolor, endcolor, zOffset);
+			return new ContrailRenderable(world, trail.Select(pos => pos + offset).ToArray(), width, next, length, skip, startcolor, endcolor, ZOffset);
 		}
 
 		public IRenderable AsDecoration() { return this; }

--- a/OpenRA.Mods.Common/Graphics/DetectionCircleAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/DetectionCircleAnnotationRenderable.cs
@@ -16,9 +16,7 @@ namespace OpenRA.Mods.Common.Graphics
 {
 	public class DetectionCircleAnnotationRenderable : IRenderable, IFinalizedRenderable
 	{
-		readonly WPos centerPosition;
 		readonly WDist radius;
-		readonly int zOffset;
 		readonly int trailCount;
 		readonly WAngle trailSeparation;
 		readonly WAngle trailAngle;
@@ -30,9 +28,9 @@ namespace OpenRA.Mods.Common.Graphics
 		public DetectionCircleAnnotationRenderable(WPos centerPosition, WDist radius, int zOffset,
 			int lineTrails, WAngle trailSeparation, WAngle trailAngle, Color color, float width, Color borderColor, float borderWidth)
 		{
-			this.centerPosition = centerPosition;
+			Pos = centerPosition;
 			this.radius = radius;
-			this.zOffset = zOffset;
+			ZOffset = zOffset;
 			trailCount = lineTrails;
 			this.trailSeparation = trailSeparation;
 			this.trailAngle = trailAngle;
@@ -42,19 +40,19 @@ namespace OpenRA.Mods.Common.Graphics
 			this.borderWidth = borderWidth;
 		}
 
-		public WPos Pos => centerPosition;
-		public int ZOffset => zOffset;
+		public WPos Pos { get; }
+		public int ZOffset { get; }
 		public bool IsDecoration => true;
 
 		public IRenderable WithZOffset(int newOffset)
 		{
-			return new DetectionCircleAnnotationRenderable(centerPosition, radius, newOffset,
+			return new DetectionCircleAnnotationRenderable(Pos, radius, newOffset,
 				trailCount, trailSeparation, trailAngle, color, width, borderColor, borderWidth);
 		}
 
 		public IRenderable OffsetBy(in WVec vec)
 		{
-			return new DetectionCircleAnnotationRenderable(centerPosition + vec, radius, zOffset,
+			return new DetectionCircleAnnotationRenderable(Pos + vec, radius, ZOffset,
 				trailCount, trailSeparation, trailAngle, color, width, borderColor, borderWidth);
 		}
 
@@ -64,19 +62,19 @@ namespace OpenRA.Mods.Common.Graphics
 		public void Render(WorldRenderer wr)
 		{
 			var cr = Game.Renderer.RgbaColorRenderer;
-			var center = wr.Viewport.WorldToViewPx(wr.Screen3DPosition(centerPosition));
+			var center = wr.Viewport.WorldToViewPx(wr.Screen3DPosition(Pos));
 
 			for (var i = 0; i < trailCount; i++)
 			{
 				var angle = trailAngle - new WAngle(i * (trailSeparation.Angle <= 512 ? 1 : -1));
 				var length = radius.Length * new WVec(angle.Cos(), angle.Sin(), 0) / 1024;
-				var end = wr.Viewport.WorldToViewPx(wr.Screen3DPosition(centerPosition + length));
+				var end = wr.Viewport.WorldToViewPx(wr.Screen3DPosition(Pos + length));
 				var alpha = color.A - i * color.A / trailCount;
 				cr.DrawLine(center, end, borderWidth, Color.FromArgb(alpha, borderColor));
 				cr.DrawLine(center, end, width, Color.FromArgb(alpha, color));
 			}
 
-			RangeCircleAnnotationRenderable.DrawRangeCircle(wr, centerPosition, radius, width, color, borderWidth, borderColor);
+			RangeCircleAnnotationRenderable.DrawRangeCircle(wr, Pos, radius, width, color, borderWidth, borderColor);
 		}
 
 		public void RenderDebugGeometry(WorldRenderer wr) { }

--- a/OpenRA.Mods.Common/Graphics/IsometricSelectionBarsAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/IsometricSelectionBarsAnnotationRenderable.cs
@@ -25,36 +25,32 @@ namespace OpenRA.Mods.Common.Graphics
 		static readonly Color DarkEmptyColor = Color.FromArgb(160, 15, 15, 15);
 		static readonly Color DarkenColor = Color.FromArgb(24, 0, 0, 0);
 		static readonly Color LightenColor = Color.FromArgb(24, 255, 255, 255);
-
-		readonly WPos pos;
 		readonly Actor actor;
-		readonly bool displayHealth;
-		readonly bool displayExtra;
 		readonly Polygon bounds;
 
 		public IsometricSelectionBarsAnnotationRenderable(Actor actor, Polygon bounds, bool displayHealth, bool displayExtra)
 			: this(actor.CenterPosition, actor, bounds)
 		{
-			this.displayHealth = displayHealth;
-			this.displayExtra = displayExtra;
+			DisplayHealth = displayHealth;
+			DisplayExtra = displayExtra;
 		}
 
 		public IsometricSelectionBarsAnnotationRenderable(WPos pos, Actor actor, Polygon bounds)
 		{
-			this.pos = pos;
+			Pos = pos;
 			this.actor = actor;
 			this.bounds = bounds;
 		}
 
-		public WPos Pos => pos;
-		public bool DisplayHealth => displayHealth;
-		public bool DisplayExtra => displayExtra;
+		public WPos Pos { get; }
+		public bool DisplayHealth { get; }
+		public bool DisplayExtra { get; }
 
 		public int ZOffset => 0;
 		public bool IsDecoration => true;
 
 		public IRenderable WithZOffset(int newOffset) { return this; }
-		public IRenderable OffsetBy(in WVec vec) { return new IsometricSelectionBarsAnnotationRenderable(pos + vec, actor, bounds); }
+		public IRenderable OffsetBy(in WVec vec) { return new IsometricSelectionBarsAnnotationRenderable(Pos + vec, actor, bounds); }
 		public IRenderable AsDecoration() { return this; }
 
 		void DrawExtraBars(WorldRenderer wr)

--- a/OpenRA.Mods.Common/Graphics/IsometricSelectionBoxAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/IsometricSelectionBoxAnnotationRenderable.cs
@@ -29,32 +29,30 @@ namespace OpenRA.Mods.Common.Graphics
 			-TROffset, TOffset, TLOffset,
 			TLOffset, -TOffset, -TROffset
 		};
-
-		readonly WPos pos;
 		readonly Polygon bounds;
 		readonly Color color;
 
 		public IsometricSelectionBoxAnnotationRenderable(Actor actor, in Polygon bounds, Color color)
 		{
-			pos = actor.CenterPosition;
+			Pos = actor.CenterPosition;
 			this.bounds = bounds;
 			this.color = color;
 		}
 
 		public IsometricSelectionBoxAnnotationRenderable(WPos pos, in Polygon bounds, Color color)
 		{
-			this.pos = pos;
+			Pos = pos;
 			this.bounds = bounds;
 			this.color = color;
 		}
 
-		public WPos Pos => pos;
+		public WPos Pos { get; }
 
 		public int ZOffset => 0;
 		public bool IsDecoration => true;
 
 		public IRenderable WithZOffset(int newOffset) { return this; }
-		public IRenderable OffsetBy(in WVec vec) { return new IsometricSelectionBoxAnnotationRenderable(pos + vec, bounds, color); }
+		public IRenderable OffsetBy(in WVec vec) { return new IsometricSelectionBoxAnnotationRenderable(Pos + vec, bounds, color); }
 		public IRenderable AsDecoration() { return this; }
 
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }

--- a/OpenRA.Mods.Common/Graphics/LineAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/LineAnnotationRenderable.cs
@@ -16,7 +16,6 @@ namespace OpenRA.Mods.Common.Graphics
 {
 	public class LineAnnotationRenderable : IRenderable, IFinalizedRenderable
 	{
-		readonly WPos start;
 		readonly WPos end;
 		readonly float width;
 		readonly Color startColor;
@@ -24,7 +23,7 @@ namespace OpenRA.Mods.Common.Graphics
 
 		public LineAnnotationRenderable(WPos start, WPos end, float width, Color color)
 		{
-			this.start = start;
+			Pos = start;
 			this.end = end;
 			this.width = width;
 			startColor = endColor = color;
@@ -32,26 +31,26 @@ namespace OpenRA.Mods.Common.Graphics
 
 		public LineAnnotationRenderable(WPos start, WPos end, float width, Color startColor, Color endColor)
 		{
-			this.start = start;
+			Pos = start;
 			this.end = end;
 			this.width = width;
 			this.startColor = startColor;
 			this.endColor = endColor;
 		}
 
-		public WPos Pos => start;
+		public WPos Pos { get; }
 		public int ZOffset => 0;
 		public bool IsDecoration => true;
 
-		public IRenderable WithZOffset(int newOffset) { return new LineAnnotationRenderable(start, end, width, startColor, endColor); }
-		public IRenderable OffsetBy(in WVec vec) { return new LineAnnotationRenderable(start + vec, end + vec, width, startColor, endColor); }
+		public IRenderable WithZOffset(int newOffset) { return new LineAnnotationRenderable(Pos, end, width, startColor, endColor); }
+		public IRenderable OffsetBy(in WVec vec) { return new LineAnnotationRenderable(Pos + vec, end + vec, width, startColor, endColor); }
 		public IRenderable AsDecoration() { return this; }
 
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
 		public void Render(WorldRenderer wr)
 		{
 			Game.Renderer.RgbaColorRenderer.DrawLine(
-				wr.Viewport.WorldToViewPx(wr.ScreenPosition(start)),
+				wr.Viewport.WorldToViewPx(wr.ScreenPosition(Pos)),
 				wr.Viewport.WorldToViewPx(wr.Screen3DPosition(end)),
 				width, startColor, endColor);
 		}

--- a/OpenRA.Mods.Common/Graphics/ModelRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/ModelRenderable.cs
@@ -20,19 +20,13 @@ namespace OpenRA.Mods.Common.Graphics
 	public class ModelRenderable : IPalettedRenderable, IModifyableRenderable
 	{
 		readonly IEnumerable<ModelAnimation> models;
-		readonly WPos pos;
-		readonly int zOffset;
 		readonly WRot camera;
 		readonly WRot lightSource;
 		readonly float[] lightAmbientColor;
 		readonly float[] lightDiffuseColor;
-		readonly PaletteReference palette;
 		readonly PaletteReference normalsPalette;
 		readonly PaletteReference shadowPalette;
 		readonly float scale;
-		readonly float alpha;
-		readonly float3 tint;
-		readonly TintModifiers tintModifiers;
 
 		public ModelRenderable(
 			IEnumerable<ModelAnimation> models, WPos pos, int zOffset, in WRot camera, float scale,
@@ -50,52 +44,52 @@ namespace OpenRA.Mods.Common.Graphics
 			float alpha, in float3 tint, TintModifiers tintModifiers)
 		{
 			this.models = models;
-			this.pos = pos;
-			this.zOffset = zOffset;
+			Pos = pos;
+			ZOffset = zOffset;
 			this.scale = scale;
 			this.camera = camera;
 			this.lightSource = lightSource;
 			this.lightAmbientColor = lightAmbientColor;
 			this.lightDiffuseColor = lightDiffuseColor;
-			palette = color;
+			Palette = color;
 			normalsPalette = normals;
 			shadowPalette = shadow;
-			this.alpha = alpha;
-			this.tint = tint;
-			this.tintModifiers = tintModifiers;
+			Alpha = alpha;
+			Tint = tint;
+			TintModifiers = tintModifiers;
 		}
 
-		public WPos Pos => pos;
-		public PaletteReference Palette => palette;
-		public int ZOffset => zOffset;
+		public WPos Pos { get; }
+		public PaletteReference Palette { get; }
+		public int ZOffset { get; }
 		public bool IsDecoration => false;
 
-		public float Alpha => alpha;
-		public float3 Tint => tint;
-		public TintModifiers TintModifiers => tintModifiers;
+		public float Alpha { get; }
+		public float3 Tint { get; }
+		public TintModifiers TintModifiers { get; }
 
 		public IPalettedRenderable WithPalette(PaletteReference newPalette)
 		{
 			return new ModelRenderable(
-				models, pos, zOffset, camera, scale,
+				models, Pos, ZOffset, camera, scale,
 				lightSource, lightAmbientColor, lightDiffuseColor,
-				newPalette, normalsPalette, shadowPalette, alpha, tint, tintModifiers);
+				newPalette, normalsPalette, shadowPalette, Alpha, Tint, TintModifiers);
 		}
 
 		public IRenderable WithZOffset(int newOffset)
 		{
 			return new ModelRenderable(
-				models, pos, newOffset, camera, scale,
+				models, Pos, newOffset, camera, scale,
 				lightSource, lightAmbientColor, lightDiffuseColor,
-				palette, normalsPalette, shadowPalette, alpha, tint, tintModifiers);
+				Palette, normalsPalette, shadowPalette, Alpha, Tint, TintModifiers);
 		}
 
 		public IRenderable OffsetBy(in WVec vec)
 		{
 			return new ModelRenderable(
-				models, pos + vec, zOffset, camera, scale,
+				models, Pos + vec, ZOffset, camera, scale,
 				lightSource, lightAmbientColor, lightDiffuseColor,
-				palette, normalsPalette, shadowPalette, alpha, tint, tintModifiers);
+				Palette, normalsPalette, shadowPalette, Alpha, Tint, TintModifiers);
 		}
 
 		public IRenderable AsDecoration() { return this; }
@@ -103,17 +97,17 @@ namespace OpenRA.Mods.Common.Graphics
 		public IModifyableRenderable WithAlpha(float newAlpha)
 		{
 			return new ModelRenderable(
-				models, pos, zOffset, camera, scale,
+				models, Pos, ZOffset, camera, scale,
 				lightSource, lightAmbientColor, lightDiffuseColor,
-				palette, normalsPalette, shadowPalette, newAlpha, tint, tintModifiers);
+				Palette, normalsPalette, shadowPalette, newAlpha, Tint, TintModifiers);
 		}
 
 		public IModifyableRenderable WithTint(in float3 newTint, TintModifiers newTintModifiers)
 		{
 			return new ModelRenderable(
-				models, pos, zOffset, camera, scale,
+				models, Pos, ZOffset, camera, scale,
 				lightSource, lightAmbientColor, lightDiffuseColor,
-				palette, normalsPalette, shadowPalette, alpha, newTint, newTintModifiers);
+				Palette, normalsPalette, shadowPalette, Alpha, newTint, newTintModifiers);
 		}
 
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr)
@@ -132,21 +126,21 @@ namespace OpenRA.Mods.Common.Graphics
 				var draw = model.models.Where(v => v.IsVisible);
 
 				var map = wr.World.Map;
-				var groundOrientation = map.TerrainOrientation(map.CellContaining(model.pos));
+				var groundOrientation = map.TerrainOrientation(map.CellContaining(model.Pos));
 				renderProxy = Game.Renderer.WorldModelRenderer.RenderAsync(
 					wr, draw, model.camera, model.scale, groundOrientation, model.lightSource,
 					model.lightAmbientColor, model.lightDiffuseColor,
-					model.palette, model.normalsPalette, model.shadowPalette);
+					model.Palette, model.normalsPalette, model.shadowPalette);
 			}
 
 			public void Render(WorldRenderer wr)
 			{
 				var map = wr.World.Map;
-				var groundPos = model.pos - new WVec(0, 0, map.DistanceAboveTerrain(model.pos).Length);
+				var groundPos = model.Pos - new WVec(0, 0, map.DistanceAboveTerrain(model.Pos).Length);
 				var tileScale = map.Grid.Type == MapGridType.RectangularIsometric ? 1448f : 1024f;
 
-				var groundZ = map.Grid.TileSize.Height * (groundPos.Z - model.pos.Z) / tileScale;
-				var pxOrigin = wr.Screen3DPosition(model.pos);
+				var groundZ = map.Grid.TileSize.Height * (groundPos.Z - model.Pos.Z) / tileScale;
+				var pxOrigin = wr.Screen3DPosition(model.Pos);
 
 				// HACK: We don't have enough texture channels to pass the depth data to the shader
 				// so for now just offset everything forward so that the back corner is rendered at pos.
@@ -154,7 +148,7 @@ namespace OpenRA.Mods.Common.Graphics
 
 				// HACK: The previous hack isn't sufficient for the ramp type that is half flat and half
 				// sloped towards the camera. Offset it by another half cell to avoid clipping.
-				var cell = map.CellContaining(model.pos);
+				var cell = map.CellContaining(model.Pos);
 				if (map.Ramp.Contains(cell) && map.Ramp[cell] == 7)
 					pxOrigin += new float3(0, 0, 0.5f * map.Grid.TileSize.Height);
 
@@ -167,13 +161,13 @@ namespace OpenRA.Mods.Common.Graphics
 				var sd = shadowOrigin + psb[3];
 
 				var wrsr = Game.Renderer.WorldRgbaSpriteRenderer;
-				var t = model.tint;
-				if (wr.TerrainLighting != null && (model.tintModifiers & TintModifiers.IgnoreWorldTint) == 0)
-					t *= wr.TerrainLighting.TintAt(model.pos);
+				var t = model.Tint;
+				if (wr.TerrainLighting != null && (model.TintModifiers & TintModifiers.IgnoreWorldTint) == 0)
+					t *= wr.TerrainLighting.TintAt(model.Pos);
 
 				// Shader interprets negative alpha as a flag to use the tint colour directly instead of multiplying the sprite colour
-				var a = model.alpha;
-				if ((model.tintModifiers & TintModifiers.ReplaceColor) != 0)
+				var a = model.Alpha;
+				if ((model.TintModifiers & TintModifiers.ReplaceColor) != 0)
 					a *= -1;
 
 				wrsr.DrawSprite(renderProxy.ShadowSprite, sa, sb, sc, sd, t, a);
@@ -182,9 +176,9 @@ namespace OpenRA.Mods.Common.Graphics
 
 			public void RenderDebugGeometry(WorldRenderer wr)
 			{
-				var groundPos = model.pos - new WVec(0, 0, wr.World.Map.DistanceAboveTerrain(model.pos).Length);
-				var groundZ = wr.World.Map.Grid.TileSize.Height * (groundPos.Z - model.pos.Z) / 1024f;
-				var pxOrigin = wr.Screen3DPosition(model.pos);
+				var groundPos = model.Pos - new WVec(0, 0, wr.World.Map.DistanceAboveTerrain(model.Pos).Length);
+				var groundZ = wr.World.Map.Grid.TileSize.Height * (groundPos.Z - model.Pos.Z) / 1024f;
+				var pxOrigin = wr.Screen3DPosition(model.Pos);
 				var shadowOrigin = pxOrigin - groundZ * new float2(renderProxy.ShadowDirection, 1);
 
 				// Draw sprite rect
@@ -256,7 +250,7 @@ namespace OpenRA.Mods.Common.Graphics
 
 			(Rectangle Bounds, float2 Z) Screen3DBounds(WorldRenderer wr)
 			{
-				var pxOrigin = wr.ScreenPosition(model.pos);
+				var pxOrigin = wr.ScreenPosition(model.Pos);
 				var draw = model.models.Where(v => v.IsVisible);
 				var scaleTransform = OpenRA.Graphics.Util.ScaleMatrix(model.scale, model.scale, model.scale);
 				var cameraTransform = OpenRA.Graphics.Util.MakeFloatMatrix(model.camera.AsMatrix());

--- a/OpenRA.Mods.Common/Graphics/PolygonAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/PolygonAnnotationRenderable.cs
@@ -18,29 +18,28 @@ namespace OpenRA.Mods.Common.Graphics
 	public class PolygonAnnotationRenderable : IRenderable, IFinalizedRenderable
 	{
 		readonly WPos[] vertices;
-		readonly WPos effectivePos;
 		readonly int width;
 		readonly Color color;
 
 		public PolygonAnnotationRenderable(WPos[] vertices, WPos effectivePos, int width, Color color)
 		{
 			this.vertices = vertices;
-			this.effectivePos = effectivePos;
+			Pos = effectivePos;
 			this.width = width;
 			this.color = color;
 		}
 
-		public WPos Pos => effectivePos;
+		public WPos Pos { get; }
 		public int ZOffset => 0;
 		public bool IsDecoration => true;
 
-		public IRenderable WithZOffset(int newOffset) { return new PolygonAnnotationRenderable(vertices, effectivePos, width, color); }
+		public IRenderable WithZOffset(int newOffset) { return new PolygonAnnotationRenderable(vertices, Pos, width, color); }
 
 		public IRenderable OffsetBy(in WVec vec)
 		{
 			// Lambdas can't use 'in' variables, so capture a copy for later
 			var offset = vec;
-			return new PolygonAnnotationRenderable(vertices.Select(v => v + offset).ToArray(), effectivePos + vec, width, color);
+			return new PolygonAnnotationRenderable(vertices.Select(v => v + offset).ToArray(), Pos + vec, width, color);
 		}
 
 		public IRenderable AsDecoration() { return this; }

--- a/OpenRA.Mods.Common/Graphics/RailgunRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/RailgunRenderable.cs
@@ -17,8 +17,6 @@ namespace OpenRA.Mods.Common.Graphics
 {
 	public class RailgunHelixRenderable : IRenderable, IFinalizedRenderable
 	{
-		readonly WPos pos;
-		readonly int zOffset;
 		readonly Railgun railgun;
 		readonly RailgunInfo info;
 		readonly WDist helixRadius;
@@ -29,8 +27,8 @@ namespace OpenRA.Mods.Common.Graphics
 
 		public RailgunHelixRenderable(WPos pos, int zOffset, Railgun railgun, RailgunInfo railgunInfo, int ticks)
 		{
-			this.pos = pos;
-			this.zOffset = zOffset;
+			Pos = pos;
+			ZOffset = zOffset;
 			this.railgun = railgun;
 			info = railgunInfo;
 			this.ticks = ticks;
@@ -40,12 +38,12 @@ namespace OpenRA.Mods.Common.Graphics
 			angle = new WAngle(ticks * info.HelixAngleDeltaPerTick.Angle);
 		}
 
-		public WPos Pos => pos;
-		public int ZOffset => zOffset;
+		public WPos Pos { get; }
+		public int ZOffset { get; }
 		public bool IsDecoration => true;
 
-		public IRenderable WithZOffset(int newOffset) { return new RailgunHelixRenderable(pos, newOffset, railgun, info, ticks); }
-		public IRenderable OffsetBy(in WVec vec) { return new RailgunHelixRenderable(pos + vec, zOffset, railgun, info, ticks); }
+		public IRenderable WithZOffset(int newOffset) { return new RailgunHelixRenderable(Pos, newOffset, railgun, info, ticks); }
+		public IRenderable OffsetBy(in WVec vec) { return new RailgunHelixRenderable(Pos + vec, ZOffset, railgun, info, ticks); }
 		public IRenderable AsDecoration() { return this; }
 
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
@@ -57,7 +55,7 @@ namespace OpenRA.Mods.Common.Graphics
 			var screenWidth = wr.ScreenVector(new WVec(info.HelixThickness.Length, 0, 0))[0];
 
 			// Move forward from self to target to draw helix
-			var centerPos = pos;
+			var centerPos = Pos;
 			var points = new float3[railgun.CycleCount * info.QuantizationCount];
 			for (var i = points.Length - 1; i >= 0; i--)
 			{

--- a/OpenRA.Mods.Common/Graphics/RangeCircleAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/RangeCircleAnnotationRenderable.cs
@@ -19,10 +19,7 @@ namespace OpenRA.Mods.Common.Graphics
 		const int RangeCircleSegments = 32;
 		static readonly Int32Matrix4x4[] RangeCircleStartRotations = Exts.MakeArray(RangeCircleSegments, i => WRot.FromFacing(8 * i).AsMatrix());
 		static readonly Int32Matrix4x4[] RangeCircleEndRotations = Exts.MakeArray(RangeCircleSegments, i => WRot.FromFacing(8 * i + 6).AsMatrix());
-
-		readonly WPos centerPosition;
 		readonly WDist radius;
-		readonly int zOffset;
 		readonly Color color;
 		readonly float width;
 		readonly Color borderColor;
@@ -30,27 +27,27 @@ namespace OpenRA.Mods.Common.Graphics
 
 		public RangeCircleAnnotationRenderable(WPos centerPosition, WDist radius, int zOffset, Color color, float width, Color borderColor, float borderWidth)
 		{
-			this.centerPosition = centerPosition;
+			Pos = centerPosition;
 			this.radius = radius;
-			this.zOffset = zOffset;
+			ZOffset = zOffset;
 			this.color = color;
 			this.width = width;
 			this.borderColor = borderColor;
 			this.borderWidth = borderWidth;
 		}
 
-		public WPos Pos => centerPosition;
-		public int ZOffset => zOffset;
+		public WPos Pos { get; }
+		public int ZOffset { get; }
 		public bool IsDecoration => true;
 
-		public IRenderable WithZOffset(int newOffset) { return new RangeCircleAnnotationRenderable(centerPosition, radius, newOffset, color, width, borderColor, borderWidth); }
-		public IRenderable OffsetBy(in WVec vec) { return new RangeCircleAnnotationRenderable(centerPosition + vec, radius, zOffset, color, width, borderColor, borderWidth); }
+		public IRenderable WithZOffset(int newOffset) { return new RangeCircleAnnotationRenderable(Pos, radius, newOffset, color, width, borderColor, borderWidth); }
+		public IRenderable OffsetBy(in WVec vec) { return new RangeCircleAnnotationRenderable(Pos + vec, radius, ZOffset, color, width, borderColor, borderWidth); }
 		public IRenderable AsDecoration() { return this; }
 
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
 		public void Render(WorldRenderer wr)
 		{
-			DrawRangeCircle(wr, centerPosition, radius, width, color, borderWidth, borderColor);
+			DrawRangeCircle(wr, Pos, radius, width, color, borderWidth, borderColor);
 		}
 
 		public static void DrawRangeCircle(WorldRenderer wr, WPos centerPosition, WDist radius,

--- a/OpenRA.Mods.Common/Graphics/SelectionBarsAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBarsAnnotationRenderable.cs
@@ -17,35 +17,32 @@ namespace OpenRA.Mods.Common.Graphics
 {
 	public class SelectionBarsAnnotationRenderable : IRenderable, IFinalizedRenderable
 	{
-		readonly WPos pos;
 		readonly Actor actor;
-		readonly bool displayHealth;
-		readonly bool displayExtra;
 		readonly Rectangle decorationBounds;
 
 		public SelectionBarsAnnotationRenderable(Actor actor, Rectangle decorationBounds, bool displayHealth, bool displayExtra)
 			: this(actor.CenterPosition, actor, decorationBounds)
 		{
-			this.displayHealth = displayHealth;
-			this.displayExtra = displayExtra;
+			DisplayHealth = displayHealth;
+			DisplayExtra = displayExtra;
 		}
 
 		public SelectionBarsAnnotationRenderable(WPos pos, Actor actor, Rectangle decorationBounds)
 		{
-			this.pos = pos;
+			Pos = pos;
 			this.actor = actor;
 			this.decorationBounds = decorationBounds;
 		}
 
-		public WPos Pos => pos;
-		public bool DisplayHealth => displayHealth;
-		public bool DisplayExtra => displayExtra;
+		public WPos Pos { get; }
+		public bool DisplayHealth { get; }
+		public bool DisplayExtra { get; }
 
 		public int ZOffset => 0;
 		public bool IsDecoration => true;
 
 		public IRenderable WithZOffset(int newOffset) { return this; }
-		public IRenderable OffsetBy(in WVec vec) { return new SelectionBarsAnnotationRenderable(pos + vec, actor, decorationBounds); }
+		public IRenderable OffsetBy(in WVec vec) { return new SelectionBarsAnnotationRenderable(Pos + vec, actor, decorationBounds); }
 		public IRenderable AsDecoration() { return this; }
 
 		void DrawExtraBars(float2 start, float2 end)

--- a/OpenRA.Mods.Common/Graphics/SelectionBoxAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBoxAnnotationRenderable.cs
@@ -16,7 +16,6 @@ namespace OpenRA.Mods.Common.Graphics
 {
 	public class SelectionBoxAnnotationRenderable : IRenderable, IFinalizedRenderable
 	{
-		readonly WPos pos;
 		readonly Rectangle decorationBounds;
 		readonly Color color;
 
@@ -25,18 +24,18 @@ namespace OpenRA.Mods.Common.Graphics
 
 		public SelectionBoxAnnotationRenderable(WPos pos, Rectangle decorationBounds, Color color)
 		{
-			this.pos = pos;
+			Pos = pos;
 			this.decorationBounds = decorationBounds;
 			this.color = color;
 		}
 
-		public WPos Pos => pos;
+		public WPos Pos { get; }
 
 		public int ZOffset => 0;
 		public bool IsDecoration => true;
 
 		public IRenderable WithZOffset(int newOffset) { return this; }
-		public IRenderable OffsetBy(in WVec vec) { return new SelectionBoxAnnotationRenderable(pos + vec, decorationBounds, color); }
+		public IRenderable OffsetBy(in WVec vec) { return new SelectionBoxAnnotationRenderable(Pos + vec, decorationBounds, color); }
 		public IRenderable AsDecoration() { return this; }
 
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }

--- a/OpenRA.Mods.Common/Graphics/TextAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/TextAnnotationRenderable.cs
@@ -18,8 +18,6 @@ namespace OpenRA.Mods.Common.Graphics
 	public class TextAnnotationRenderable : IRenderable, IFinalizedRenderable
 	{
 		readonly SpriteFont font;
-		readonly WPos pos;
-		readonly int zOffset;
 		readonly Color color;
 		readonly Color bgDark;
 		readonly Color bgLight;
@@ -28,8 +26,8 @@ namespace OpenRA.Mods.Common.Graphics
 		public TextAnnotationRenderable(SpriteFont font, WPos pos, int zOffset, Color color, Color bgDark, Color bgLight, string text)
 		{
 			this.font = font;
-			this.pos = pos;
-			this.zOffset = zOffset;
+			Pos = pos;
+			ZOffset = zOffset;
 			this.color = color;
 			this.bgDark = bgDark;
 			this.bgLight = bgLight;
@@ -42,25 +40,25 @@ namespace OpenRA.Mods.Common.Graphics
 				ChromeMetrics.Get<Color>("TextContrastColorLight"),
 				text) { }
 
-		public WPos Pos => pos;
-		public int ZOffset => zOffset;
+		public WPos Pos { get; }
+		public int ZOffset { get; }
 		public bool IsDecoration => true;
 
-		public IRenderable WithZOffset(int newOffset) { return new TextAnnotationRenderable(font, pos, zOffset, color, text); }
-		public IRenderable OffsetBy(in WVec vec) { return new TextAnnotationRenderable(font, pos + vec, zOffset, color, text); }
+		public IRenderable WithZOffset(int newOffset) { return new TextAnnotationRenderable(font, Pos, ZOffset, color, text); }
+		public IRenderable OffsetBy(in WVec vec) { return new TextAnnotationRenderable(font, Pos + vec, ZOffset, color, text); }
 		public IRenderable AsDecoration() { return this; }
 
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
 		public void Render(WorldRenderer wr)
 		{
-			var screenPos = wr.Viewport.WorldToViewPx(wr.ScreenPosition(pos)) - 0.5f * font.Measure(text).ToFloat2();
+			var screenPos = wr.Viewport.WorldToViewPx(wr.ScreenPosition(Pos)) - 0.5f * font.Measure(text).ToFloat2();
 			font.DrawTextWithContrast(text, screenPos, color, bgDark, bgLight, 1);
 		}
 
 		public void RenderDebugGeometry(WorldRenderer wr)
 		{
 			var size = font.Measure(text).ToFloat2();
-			var screenPos = wr.Viewport.WorldToViewPx(wr.ScreenPosition(pos));
+			var screenPos = wr.Viewport.WorldToViewPx(wr.ScreenPosition(Pos));
 			Game.Renderer.RgbaColorRenderer.DrawRect(screenPos - 0.5f * size, screenPos + 0.5f * size, 1, Color.Red);
 		}
 

--- a/OpenRA.Mods.Common/Graphics/UIModelRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/UIModelRenderable.cs
@@ -20,14 +20,11 @@ namespace OpenRA.Mods.Common.Graphics
 	public class UIModelRenderable : IRenderable, IPalettedRenderable
 	{
 		readonly IEnumerable<ModelAnimation> models;
-		readonly WPos effectiveWorldPos;
 		readonly int2 screenPos;
-		readonly int zOffset;
 		readonly WRot camera;
 		readonly WRot lightSource;
 		readonly float[] lightAmbientColor;
 		readonly float[] lightDiffuseColor;
-		readonly PaletteReference palette;
 		readonly PaletteReference normalsPalette;
 		readonly PaletteReference shadowPalette;
 		readonly float scale;
@@ -38,28 +35,28 @@ namespace OpenRA.Mods.Common.Graphics
 			PaletteReference color, PaletteReference normals, PaletteReference shadow)
 		{
 			this.models = models;
-			this.effectiveWorldPos = effectiveWorldPos;
+			Pos = effectiveWorldPos;
 			this.screenPos = screenPos;
-			this.zOffset = zOffset;
+			ZOffset = zOffset;
 			this.scale = scale;
 			this.camera = camera;
 			this.lightSource = lightSource;
 			this.lightAmbientColor = lightAmbientColor;
 			this.lightDiffuseColor = lightDiffuseColor;
-			palette = color;
+			Palette = color;
 			normalsPalette = normals;
 			shadowPalette = shadow;
 		}
 
-		public WPos Pos => effectiveWorldPos;
-		public PaletteReference Palette => palette;
-		public int ZOffset => zOffset;
+		public WPos Pos { get; }
+		public PaletteReference Palette { get; }
+		public int ZOffset { get; }
 		public bool IsDecoration => false;
 
 		public IPalettedRenderable WithPalette(PaletteReference newPalette)
 		{
 			return new UIModelRenderable(
-				models, effectiveWorldPos, screenPos, zOffset, camera, scale,
+				models, Pos, screenPos, ZOffset, camera, scale,
 				lightSource, lightAmbientColor, lightDiffuseColor,
 				newPalette, normalsPalette, shadowPalette);
 		}
@@ -86,7 +83,7 @@ namespace OpenRA.Mods.Common.Graphics
 				renderProxy = Game.Renderer.WorldModelRenderer.RenderAsync(
 					wr, draw, model.camera, model.scale, WRot.None, model.lightSource,
 					model.lightAmbientColor, model.lightDiffuseColor,
-					model.palette, model.normalsPalette, model.shadowPalette);
+					model.Palette, model.normalsPalette, model.shadowPalette);
 			}
 
 			public void Render(WorldRenderer wr)

--- a/OpenRA.Mods.Common/Graphics/UITextRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/UITextRenderable.cs
@@ -18,9 +18,7 @@ namespace OpenRA.Mods.Common.Graphics
 	public class UITextRenderable : IRenderable, IFinalizedRenderable
 	{
 		readonly SpriteFont font;
-		readonly WPos effectiveWorldPos;
 		readonly int2 screenPos;
-		readonly int zOffset;
 		readonly Color color;
 		readonly Color bgDark;
 		readonly Color bgLight;
@@ -29,9 +27,9 @@ namespace OpenRA.Mods.Common.Graphics
 		public UITextRenderable(SpriteFont font, WPos effectiveWorldPos, int2 screenPos, int zOffset, Color color, Color bgDark, Color bgLight, string text)
 		{
 			this.font = font;
-			this.effectiveWorldPos = effectiveWorldPos;
+			Pos = effectiveWorldPos;
 			this.screenPos = screenPos;
-			this.zOffset = zOffset;
+			ZOffset = zOffset;
 			this.color = color;
 			this.bgDark = bgDark;
 			this.bgLight = bgLight;
@@ -44,12 +42,12 @@ namespace OpenRA.Mods.Common.Graphics
 				ChromeMetrics.Get<Color>("TextContrastColorLight"),
 				text) { }
 
-		public WPos Pos => effectiveWorldPos;
-		public int ZOffset => zOffset;
+		public WPos Pos { get; }
+		public int ZOffset { get; }
 		public bool IsDecoration => true;
 
-		public IRenderable WithZOffset(int newOffset) { return new UITextRenderable(font, effectiveWorldPos, screenPos, zOffset, color, text); }
-		public IRenderable OffsetBy(in WVec vec) { return new UITextRenderable(font, effectiveWorldPos + vec, screenPos, zOffset, color, text); }
+		public IRenderable WithZOffset(int newOffset) { return new UITextRenderable(font, Pos, screenPos, ZOffset, color, text); }
+		public IRenderable OffsetBy(in WVec vec) { return new UITextRenderable(font, Pos + vec, screenPos, ZOffset, color, text); }
 		public IRenderable AsDecoration() { return this; }
 
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }

--- a/OpenRA.Mods.Common/Terrain/DefaultTileCache.cs
+++ b/OpenRA.Mods.Common/Terrain/DefaultTileCache.cs
@@ -37,8 +37,9 @@ namespace OpenRA.Mods.Common.Terrain
 	{
 		readonly Dictionary<ushort, TheaterTemplate> templates = new Dictionary<ushort, TheaterTemplate>();
 		readonly Cache<SheetType, SheetBuilder> sheetBuilders;
-		readonly Sprite missingTile;
 		readonly MersenneTwister random;
+
+		public Sprite MissingTile { get; }
 
 		public DefaultTileCache(DefaultTerrain terrainInfo, Action<uint, string> onMissingImage = null)
 		{
@@ -154,29 +155,27 @@ namespace OpenRA.Mods.Common.Terrain
 				missingSheetType = SheetType.BGRA;
 			}
 
-			missingTile = sheetBuilders[missingSheetType].Add(new byte[missingDataLength], missingFrameType, new Size(1, 1));
+			MissingTile = sheetBuilders[missingSheetType].Add(new byte[missingDataLength], missingFrameType, new Size(1, 1));
 			foreach (var sb in sheetBuilders.Values)
 				sb.Current.ReleaseBuffer();
 		}
 
 		public bool HasTileSprite(TerrainTile r, int? variant = null)
 		{
-			return TileSprite(r, variant) != missingTile;
+			return TileSprite(r, variant) != MissingTile;
 		}
 
 		public Sprite TileSprite(TerrainTile r, int? variant = null)
 		{
 			if (!templates.TryGetValue(r.Type, out var template))
-				return missingTile;
+				return MissingTile;
 
 			if (r.Index >= template.Stride)
-				return missingTile;
+				return MissingTile;
 
 			var start = template.Variants > 1 ? variant ?? random.Next(template.Variants) : 0;
 			return template.Sprites[start * template.Stride + r.Index];
 		}
-
-		public Sprite MissingTile => missingTile;
 
 		public void Dispose()
 		{

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -235,28 +235,26 @@ namespace OpenRA.Mods.Common.Traits
 		INotifyCenterPositionChanged[] notifyCenterPositionChanged;
 		IOverrideAircraftLanding overrideAircraftLanding;
 
-		WRot orientation;
-
 		[Sync]
 		public WAngle Facing
 		{
-			get => orientation.Yaw;
-			set => orientation = orientation.WithYaw(value);
+			get => Orientation.Yaw;
+			set => Orientation = Orientation.WithYaw(value);
 		}
 
 		public WAngle Pitch
 		{
-			get => orientation.Pitch;
-			set => orientation = orientation.WithPitch(value);
+			get => Orientation.Pitch;
+			set => Orientation = Orientation.WithPitch(value);
 		}
 
 		public WAngle Roll
 		{
-			get => orientation.Roll;
-			set => orientation = orientation.WithRoll(value);
+			get => Orientation.Roll;
+			set => Orientation = Orientation.WithRoll(value);
 		}
 
-		public WRot Orientation => orientation;
+		public WRot Orientation { get; private set; }
 
 		[Sync]
 		public WPos CenterPosition { get; private set; }

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -109,8 +109,6 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public readonly WeaponInfo Weapon;
 		public readonly Barrel[] Barrels;
-
-		readonly Actor self;
 		Turreted turret;
 		BodyOrientation coords;
 		INotifyBurstComplete[] notifyBurstComplete;
@@ -136,7 +134,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Armament(Actor self, ArmamentInfo info)
 			: base(info)
 		{
-			this.self = self;
+			Actor = self;
 
 			Weapon = info.WeaponInfo;
 			Burst = Weapon.Burst;
@@ -400,6 +398,6 @@ namespace OpenRA.Mods.Common.Traits
 			return WRot.FromYaw(b.Yaw).Rotate(turret?.WorldOrientation ?? self.Orientation);
 		}
 
-		public Actor Actor => self;
+		public Actor Actor { get; }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -135,15 +135,13 @@ namespace OpenRA.Mods.Common.Traits
 		[Sync]
 		int nextScanTime = 0;
 
-		public UnitStance Stance => stance;
+		public UnitStance Stance { get; private set; }
 
 		[Sync]
 		public Actor Aggressor;
 
 		// NOT SYNCED: do not refer to this anywhere other than UI code
 		public UnitStance PredictedStance;
-
-		UnitStance stance;
 		IOverrideAutoTarget[] overrideAutoTarget;
 		INotifyStanceChanged[] notifyStanceChanged;
 		IEnumerable<AutoTargetPriorityInfo> activeTargetPriorities;
@@ -151,19 +149,19 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void SetStance(Actor self, UnitStance value)
 		{
-			if (stance == value)
+			if (Stance == value)
 				return;
 
-			var oldStance = stance;
-			stance = value;
+			var oldStance = Stance;
+			Stance = value;
 			ApplyStanceCondition(self);
 
 			foreach (var nsc in notifyStanceChanged)
-				nsc.StanceChanged(self, this, oldStance, stance);
+				nsc.StanceChanged(self, this, oldStance, Stance);
 
 			if (self.CurrentActivity != null)
 				foreach (var a in self.CurrentActivity.ActivitiesImplementing<IActivityNotifyStanceChanged>())
-					a.StanceChanged(self, this, oldStance, stance);
+					a.StanceChanged(self, this, oldStance, Stance);
 		}
 
 		void ApplyStanceCondition(Actor self)
@@ -171,7 +169,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (conditionToken != Actor.InvalidConditionToken)
 				conditionToken = self.RevokeCondition(conditionToken);
 
-			if (Info.ConditionByStance.TryGetValue(stance, out var condition))
+			if (Info.ConditionByStance.TryGetValue(Stance, out var condition))
 				conditionToken = self.GrantCondition(condition);
 		}
 
@@ -181,9 +179,9 @@ namespace OpenRA.Mods.Common.Traits
 			var self = init.Self;
 			ActiveAttackBases = self.TraitsImplementing<AttackBase>().ToArray().Where(t => !t.IsTraitDisabled);
 
-			stance = init.GetValue<StanceInit, UnitStance>(self.Owner.IsBot || !self.Owner.Playable ? info.InitialStanceAI : info.InitialStance);
+			Stance = init.GetValue<StanceInit, UnitStance>(self.Owner.IsBot || !self.Owner.Playable ? info.InitialStanceAI : info.InitialStance);
 
-			PredictedStance = stance;
+			PredictedStance = Stance;
 
 			allowMovement = Info.AllowMovement && self.TraitOrDefault<IMove>() != null;
 		}

--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -146,7 +146,7 @@ namespace OpenRA.Mods.Common.Traits
 			return randomConstructionYard?.Location ?? initialBaseCenter;
 		}
 
-		public CPos DefenseCenter => defenseCenter;
+		public CPos DefenseCenter { get; private set; }
 
 		readonly World world;
 		readonly Player player;
@@ -155,8 +155,6 @@ namespace OpenRA.Mods.Common.Traits
 		IResourceLayer resourceLayer;
 		IBotPositionsUpdated[] positionsUpdatedModules;
 		CPos initialBaseCenter;
-		CPos defenseCenter;
-
 		readonly List<BaseBuilderQueueManager> builders = new List<BaseBuilderQueueManager>();
 
 		public BaseBuilderBotModule(Actor self, BaseBuilderBotModuleInfo info)
@@ -189,7 +187,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void IBotPositionsUpdated.UpdatedDefenseCenter(CPos newLocation)
 		{
-			defenseCenter = newLocation;
+			DefenseCenter = newLocation;
 		}
 
 		bool IBotRequestPauseUnitProduction.PauseUnitProduction => !IsTraitDisabled && !HasAdequateRefineryCount;
@@ -273,7 +271,7 @@ namespace OpenRA.Mods.Common.Traits
 			return new List<MiniYamlNode>()
 			{
 				new MiniYamlNode("InitialBaseCenter", FieldSaver.FormatValue(initialBaseCenter)),
-				new MiniYamlNode("DefenseCenter", FieldSaver.FormatValue(defenseCenter))
+				new MiniYamlNode("DefenseCenter", FieldSaver.FormatValue(DefenseCenter))
 			};
 		}
 
@@ -288,7 +286,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var defenseCenterNode = data.FirstOrDefault(n => n.Key == "DefenseCenter");
 			if (defenseCenterNode != null)
-				defenseCenter = FieldLoader.GetValue<CPos>("DefenseCenter", defenseCenterNode.Value.Value);
+				DefenseCenter = FieldLoader.GetValue<CPos>("DefenseCenter", defenseCenterNode.Value.Value);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -96,20 +96,18 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly Actor self;
 		readonly bool checkTerrainType;
-
-		DeployState deployState;
 		INotifyDeployTriggered[] notify;
 		int deployedToken = Actor.InvalidConditionToken;
 		int undeployedToken = Actor.InvalidConditionToken;
 
-		public DeployState DeployState => deployState;
+		public DeployState DeployState { get; private set; }
 
 		public GrantConditionOnDeploy(ActorInitializer init, GrantConditionOnDeployInfo info)
 			: base(info)
 		{
 			self = init.Self;
 			checkTerrainType = info.AllowedTerrainTypes.Count > 0;
-			deployState = init.GetValue<DeployStateInit, DeployState>(DeployState.Undeployed);
+			DeployState = init.GetValue<DeployStateInit, DeployState>(DeployState.Undeployed);
 		}
 
 		protected override void Created(Actor self)
@@ -117,14 +115,14 @@ namespace OpenRA.Mods.Common.Traits
 			notify = self.TraitsImplementing<INotifyDeployTriggered>().ToArray();
 			base.Created(self);
 
-			if (Info.Facing.HasValue && deployState != DeployState.Undeployed)
+			if (Info.Facing.HasValue && DeployState != DeployState.Undeployed)
 			{
 				var facing = self.TraitOrDefault<IFacing>();
 				if (facing != null)
 					facing.Facing = Info.Facing.Value;
 			}
 
-			switch (deployState)
+			switch (DeployState)
 			{
 				case DeployState.Undeployed:
 					OnUndeployCompleted();
@@ -155,10 +153,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool IDelayCarryallPickup.TryLockForPickup(Actor self, Actor carrier)
 		{
-			if (!Info.UndeployOnPickup || deployState == DeployState.Undeployed || IsTraitDisabled)
+			if (!Info.UndeployOnPickup || DeployState == DeployState.Undeployed || IsTraitDisabled)
 				return true;
 
-			if (deployState == DeployState.Deployed && !IsTraitPaused)
+			if (DeployState == DeployState.Deployed && !IsTraitPaused)
 				Undeploy();
 
 			return false;
@@ -210,7 +208,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (IsTraitPaused || IsTraitDisabled)
 				return false;
 
-			return IsValidTerrain(self.Location) || (deployState == DeployState.Deployed);
+			return IsValidTerrain(self.Location) || (DeployState == DeployState.Deployed);
 		}
 
 		public bool IsValidTerrain(CPos location)
@@ -255,7 +253,7 @@ namespace OpenRA.Mods.Common.Traits
 		void Deploy(bool init)
 		{
 			// Something went wrong, most likely due to deploy order spam and the fact that this is a delayed action.
-			if (!init && deployState != DeployState.Undeployed)
+			if (!init && DeployState != DeployState.Undeployed)
 				return;
 
 			if (!IsValidTerrain(self.Location))
@@ -282,7 +280,7 @@ namespace OpenRA.Mods.Common.Traits
 		void Undeploy(bool init)
 		{
 			// Something went wrong, most likely due to deploy order spam and the fact that this is a delayed action.
-			if (!init && deployState != DeployState.Deployed)
+			if (!init && DeployState != DeployState.Deployed)
 				return;
 
 			if (Info.UndeploySounds != null && Info.UndeploySounds.Length > 0)
@@ -305,7 +303,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (undeployedToken != Actor.InvalidConditionToken)
 				undeployedToken = self.RevokeCondition(undeployedToken);
 
-			deployState = DeployState.Deploying;
+			DeployState = DeployState.Deploying;
 		}
 
 		void OnDeployCompleted()
@@ -313,7 +311,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (deployedToken == Actor.InvalidConditionToken)
 				deployedToken = self.GrantCondition(Info.DeployedCondition);
 
-			deployState = DeployState.Deployed;
+			DeployState = DeployState.Deployed;
 		}
 
 		void OnUndeployStarted()
@@ -321,7 +319,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (deployedToken != Actor.InvalidConditionToken)
 				deployedToken = self.RevokeCondition(deployedToken);
 
-			deployState = DeployState.Deploying;
+			DeployState = DeployState.Deploying;
 		}
 
 		void OnUndeployCompleted()
@@ -329,7 +327,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (undeployedToken == Actor.InvalidConditionToken)
 				undeployedToken = self.GrantCondition(Info.UndeployedCondition);
 
-			deployState = DeployState.Undeployed;
+			DeployState = DeployState.Undeployed;
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -67,16 +67,14 @@ namespace OpenRA.Mods.Common.Traits
 		[Sync]
 		public WPos CenterPosition { get; private set; }
 
-		WRot orientation;
-
 		[Sync]
 		public WAngle Facing
 		{
-			get => orientation.Yaw;
-			set => orientation = orientation.WithYaw(value);
+			get => Orientation.Yaw;
+			set => Orientation = Orientation.WithYaw(value);
 		}
 
-		public WRot Orientation => orientation;
+		public WRot Orientation { get; private set; }
 
 		public WAngle TurnSpeed => WAngle.Zero;
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SpawnActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SpawnActorPower.cs
@@ -121,10 +121,9 @@ namespace OpenRA.Mods.Common.Traits
 		readonly SpawnActorPower power;
 		readonly SpawnActorPowerInfo info;
 		readonly SupportPowerManager manager;
-		readonly string order;
 		readonly MouseButton expectedButton;
 
-		public string OrderKey { get { return order; } }
+		public string OrderKey { get; }
 
 		public SelectSpawnActorPowerTarget(string order, SupportPowerManager manager, SpawnActorPower power, MouseButton button)
 		{
@@ -134,7 +133,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			this.manager = manager;
 			this.power = power;
-			this.order = order;
+			OrderKey = order;
 			expectedButton = button;
 
 			info = (SpawnActorPowerInfo)power.Info;
@@ -148,13 +147,13 @@ namespace OpenRA.Mods.Common.Traits
 				yield break;
 
 			if (mi.Button == expectedButton)
-				yield return new Order(order, manager.Self, Target.FromCell(world, cell), false) { SuppressVisualFeedback = true };
+				yield return new Order(OrderKey, manager.Self, Target.FromCell(world, cell), false) { SuppressVisualFeedback = true };
 		}
 
 		protected override void Tick(World world)
 		{
 			// Cancel the OG if we can't use the power
-			if (!manager.Powers.ContainsKey(order))
+			if (!manager.Powers.ContainsKey(OrderKey))
 				world.CancelInputMode();
 		}
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -279,11 +279,10 @@ namespace OpenRA.Mods.Common.Traits
 	public class SelectGenericPowerTarget : OrderGenerator
 	{
 		readonly SupportPowerManager manager;
-		readonly string order;
 		readonly string cursor;
 		readonly MouseButton expectedButton;
 
-		public string OrderKey => order;
+		public string OrderKey { get; }
 
 		public SelectGenericPowerTarget(string order, SupportPowerManager manager, string cursor, MouseButton button)
 		{
@@ -292,7 +291,7 @@ namespace OpenRA.Mods.Common.Traits
 				manager.Self.World.Selection.Clear();
 
 			this.manager = manager;
-			this.order = order;
+			OrderKey = order;
 			this.cursor = cursor;
 			expectedButton = button;
 		}
@@ -301,13 +300,13 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			world.CancelInputMode();
 			if (mi.Button == expectedButton && world.Map.Contains(cell))
-				yield return new Order(order, manager.Self, Target.FromCell(world, cell), false) { SuppressVisualFeedback = true };
+				yield return new Order(OrderKey, manager.Self, Target.FromCell(world, cell), false) { SuppressVisualFeedback = true };
 		}
 
 		protected override void Tick(World world)
 		{
 			// Cancel the OG if we can't use the power
-			if (!manager.Powers.TryGetValue(order, out var p) || !p.Active || !p.Ready)
+			if (!manager.Powers.TryGetValue(OrderKey, out var p) || !p.Active || !p.Ready)
 				world.CancelInputMode();
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -229,24 +229,23 @@ namespace OpenRA.Mods.Common.Traits
 		struct ActorsAtEnumerator : IEnumerator<Actor>
 		{
 			InfluenceNode node;
-			Actor current;
 
 			public ActorsAtEnumerator(InfluenceNode node)
 			{
 				this.node = node;
-				current = null;
+				Current = null;
 			}
 
 			public void Reset() { throw new NotSupportedException(); }
-			public Actor Current => current;
+			public Actor Current { get; private set; }
 
-			object IEnumerator.Current => current;
+			object IEnumerator.Current => Current;
 			public void Dispose() { }
 			public bool MoveNext()
 			{
 				while (node != null)
 				{
-					current = node.Actor;
+					Current = node.Actor;
 					node = node.Next;
 					return true;
 				}

--- a/OpenRA.Mods.Common/Widgets/VideoPlayerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/VideoPlayerWidget.cs
@@ -26,19 +26,17 @@ namespace OpenRA.Mods.Common.Widgets
 		public bool DrawOverlay = true;
 		public bool Skippable = true;
 
-		public bool Paused => paused;
-		public IVideo Video => video;
+		public bool Paused { get; private set; }
+		public IVideo Video { get; private set; } = null;
 
 		Sprite videoSprite, overlaySprite;
 		Sheet overlaySheet;
-		IVideo video = null;
 		string cachedVideoFileName;
 		float invLength;
 		float2 videoOrigin, videoSize;
 		float2 overlayOrigin, overlaySize;
 		float overlayScale;
 		bool stopped;
-		bool paused;
 		int textureSize;
 
 		Action onComplete;
@@ -110,13 +108,13 @@ namespace OpenRA.Mods.Common.Widgets
 		/// <param name="video">An <see cref="IVideo"/> instance.</param>
 		public void Play(IVideo video)
 		{
-			this.video = video;
+			Video = video;
 
 			if (video == null)
 				return;
 
 			stopped = true;
-			paused = true;
+			Paused = true;
 			Game.Sound.StopVideo();
 			onComplete = () => { };
 
@@ -148,34 +146,34 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override void Draw()
 		{
-			if (video == null)
+			if (Video == null)
 				return;
 
-			if (!stopped && !paused)
+			if (!stopped && !Paused)
 			{
 				int nextFrame;
-				if (video.HasAudio && !Game.Sound.DummyEngine)
-					nextFrame = (int)float2.Lerp(0, video.FrameCount, Game.Sound.VideoSeekPosition * invLength);
+				if (Video.HasAudio && !Game.Sound.DummyEngine)
+					nextFrame = (int)float2.Lerp(0, Video.FrameCount, Game.Sound.VideoSeekPosition * invLength);
 				else
-					nextFrame = video.CurrentFrameIndex + 1;
+					nextFrame = Video.CurrentFrameIndex + 1;
 
 				// Without the 2nd check the sound playback sometimes ends before the final frame is displayed which causes the player to be stuck on the first frame
-				if (nextFrame > video.FrameCount || nextFrame < video.CurrentFrameIndex)
+				if (nextFrame > Video.FrameCount || nextFrame < Video.CurrentFrameIndex)
 				{
 					Stop();
 					return;
 				}
 
 				var skippedFrames = 0;
-				while (nextFrame > video.CurrentFrameIndex)
+				while (nextFrame > Video.CurrentFrameIndex)
 				{
-					video.AdvanceFrame();
-					videoSprite.Sheet.GetTexture().SetData(video.CurrentFrameData, textureSize, textureSize);
+					Video.AdvanceFrame();
+					videoSprite.Sheet.GetTexture().SetData(Video.CurrentFrameData, textureSize, textureSize);
 					skippedFrames++;
 				}
 
 				if (skippedFrames > 1)
-					Log.Write("perf", $"{nameof(VideoPlayerWidget)}: {cachedVideoFileName} skipped {skippedFrames} frames at position {video.CurrentFrameIndex}");
+					Log.Write("perf", $"{nameof(VideoPlayerWidget)}: {cachedVideoFileName} skipped {skippedFrames} frames at position {Video.CurrentFrameIndex}");
 			}
 
 			WidgetUtils.DrawSprite(videoSprite, videoOrigin, videoSize);
@@ -196,7 +194,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 					// Calculate the scan line height by converting the video scale (copied from Open()) to screen
 					// pixels, halving it (scan lines cover half the pixel height), and rounding to the nearest integer.
-					var videoScale = Math.Min((float)RenderBounds.Width / video.Width, RenderBounds.Height / (video.Height * AspectRatio));
+					var videoScale = Math.Min((float)RenderBounds.Width / Video.Width, RenderBounds.Height / (Video.Height * AspectRatio));
 					var halfRowHeight = (int)(videoScale * scale / 2 + 0.5f);
 
 					// If the video is "too tightly packed" into the player and there is no room for drawing an overlay disable it.
@@ -255,37 +253,37 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public void PlayThen(Action after)
 		{
-			if (video == null)
+			if (Video == null)
 				return;
 
 			onComplete = after;
-			if (stopped && video.HasAudio)
-				Game.Sound.PlayVideo(video.AudioData, video.AudioChannels, video.SampleBits, video.SampleRate);
+			if (stopped && Video.HasAudio)
+				Game.Sound.PlayVideo(Video.AudioData, Video.AudioChannels, Video.SampleBits, Video.SampleRate);
 			else
 				Game.Sound.PlayVideo();
 
-			stopped = paused = false;
+			stopped = Paused = false;
 		}
 
 		public void Pause()
 		{
-			if (stopped || paused || video == null)
+			if (stopped || Paused || Video == null)
 				return;
 
-			paused = true;
+			Paused = true;
 			Game.Sound.PauseVideo();
 		}
 
 		public void Stop()
 		{
-			if (stopped || video == null)
+			if (stopped || Video == null)
 				return;
 
 			stopped = true;
-			paused = true;
+			Paused = true;
 			Game.Sound.StopVideo();
-			video.Reset();
-			videoSprite.Sheet.GetTexture().SetData(video.CurrentFrameData, textureSize, textureSize);
+			Video.Reset();
+			videoSprite.Sheet.GetTexture().SetData(Video.CurrentFrameData, textureSize, textureSize);
 			Game.RunAfterTick(() =>
 			{
 				if (onComplete != null)
@@ -299,7 +297,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public void CloseVideo()
 		{
 			Stop();
-			video = null;
+			Video = null;
 		}
 	}
 }

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -22,10 +22,9 @@ namespace OpenRA.Platforms.Default
 {
 	sealed class Sdl2PlatformWindow : ThreadAffine, IPlatformWindow
 	{
-		readonly IGraphicsContext context;
 		readonly Sdl2Input input;
 
-		public IGraphicsContext Context => context;
+		public IGraphicsContext Context { get; }
 
 		readonly IntPtr window;
 		bool disposed;
@@ -341,12 +340,12 @@ namespace OpenRA.Platforms.Default
 			{
 				var ctx = new Sdl2GraphicsContext(this);
 				ctx.InitializeOpenGL();
-				context = ctx;
+				Context = ctx;
 			}
 			else
-				context = new ThreadedGraphicsContext(new Sdl2GraphicsContext(this), batchSize);
+				Context = new ThreadedGraphicsContext(new Sdl2GraphicsContext(this), batchSize);
 
-			context.SetVSyncEnabled(Game.Settings.Graphics.VSync);
+			Context.SetVSyncEnabled(Game.Settings.Graphics.VSync);
 
 			SDL.SDL_SetModState(SDL.SDL_Keymod.KMOD_NONE);
 			input = new Sdl2Input();
@@ -467,7 +466,7 @@ namespace OpenRA.Platforms.Default
 
 			disposed = true;
 
-			context?.Dispose();
+			Context?.Dispose();
 
 			if (Window != IntPtr.Zero)
 				SDL.SDL_DestroyWindow(Window);

--- a/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
+++ b/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
@@ -566,7 +566,6 @@ namespace OpenRA.Platforms.Default
 	class ThreadedTexture : ITextureInternal
 	{
 		readonly ThreadedGraphicsContext device;
-		readonly uint id;
 		readonly Func<object> getScaleFilter;
 		readonly Action<object> setScaleFilter;
 		readonly Func<object> getSize;
@@ -581,7 +580,7 @@ namespace OpenRA.Platforms.Default
 		public ThreadedTexture(ThreadedGraphicsContext device, ITextureInternal texture)
 		{
 			this.device = device;
-			id = texture.ID;
+			ID = texture.ID;
 			getScaleFilter = () => texture.ScaleFilter;
 			setScaleFilter = value => texture.ScaleFilter = (TextureScaleFilter)value;
 			getSize = () => texture.Size;
@@ -594,7 +593,7 @@ namespace OpenRA.Platforms.Default
 			dispose = texture.Dispose;
 		}
 
-		public uint ID => id;
+		public uint ID { get; }
 
 		public TextureScaleFilter ScaleFilter
 		{


### PR DESCRIPTION
Enforces IDE0032 Use auto-implemented property
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0032

After the fixer ran, I adjusting the location of some properties in the files to more natural locations, however there may be more tweaks we want to make here.

Additionally in `Target.cs` it felt like we didn't want to make the fields "public" via the serialization stuff. So I introduced a `SerializableState` method so that we can keep private fields without the rule wanting to turn them into auto-props.

