### PR TITLE
Apply player relationship colors to all player colors

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -22,6 +22,16 @@ namespace OpenRA
 {
 	public static class Exts
 	{
+		/// <summary>Returns <see cref="Color"/> of the <paramref name="actor"/>, taking <see cref="Actor.EffectiveOwner"/> into account.</summary>
+		public static Color OwnerColor(this Actor actor)
+		{
+			var effectiveOwner = actor.EffectiveOwner;
+			if (effectiveOwner != null && effectiveOwner.Disguised && actor.World.RenderPlayer != null)
+				return effectiveOwner.Owner.Color;
+
+			return actor.Owner.Color;
+		}
+
 		public static string FormatInvariant(this string format, params object[] args)
 		{
 			return string.Format(CultureInfo.InvariantCulture, format, args);

--- a/OpenRA.Game/GameInformation.cs
+++ b/OpenRA.Game/GameInformation.cs
@@ -122,7 +122,7 @@ namespace OpenRA
 				FactionId = runtimePlayer.Faction.InternalName,
 				DisplayFactionName = runtimePlayer.DisplayFaction.Name,
 				DisplayFactionId = runtimePlayer.DisplayFaction.InternalName,
-				Color = runtimePlayer.Color,
+				Color = OpenRA.Player.GetColor(runtimePlayer),
 				Team = client.Team,
 				Handicap = client.Handicap,
 				SpawnPoint = runtimePlayer.SpawnPoint,

--- a/OpenRA.Game/Graphics/HardwarePalette.cs
+++ b/OpenRA.Game/Graphics/HardwarePalette.cs
@@ -85,7 +85,10 @@ namespace OpenRA.Graphics
 		public void ReplacePalette(string name, IPalette p)
 		{
 			if (mutablePalettes.ContainsKey(name))
+			{
+				palettes[name] = new ImmutablePalette(p);
 				CopyPaletteToBuffer(indices[name], mutablePalettes[name] = new MutablePalette(p));
+			}
 			else if (palettes.ContainsKey(name))
 				CopyPaletteToBuffer(indices[name], palettes[name] = new ImmutablePalette(p));
 			else

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -62,10 +62,7 @@ namespace OpenRA.Graphics
 			foreach (var pal in world.TraitDict.ActorsWithTrait<ILoadsPalettes>())
 				pal.Trait.LoadPalettes(this);
 
-			foreach (var p in world.Players)
-				UpdatePalettesForPlayer(p.InternalName, p.Color, false);
-
-			Player.SetupRelationshipColors(world.Players, world.LocalPlayer);
+			Player.SetupRelationshipColors(world.Players, world.LocalPlayer, this, true);
 
 			palette.Initialize();
 

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -65,6 +65,8 @@ namespace OpenRA.Graphics
 			foreach (var p in world.Players)
 				UpdatePalettesForPlayer(p.InternalName, p.Color, false);
 
+			Player.SetupRelationshipColors(world.Players, world.LocalPlayer);
+
 			palette.Initialize();
 
 			TerrainLighting = world.WorldActor.TraitOrDefault<ITerrainLighting>();

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -37,14 +37,6 @@ namespace OpenRA
 
 	public class Player : IScriptBindable, IScriptNotifyBind, ILuaTableBinding, ILuaEqualityBinding, ILuaToStringBinding
 	{
-		struct StanceColors
-		{
-			public Color Self;
-			public Color Allies;
-			public Color Enemies;
-			public Color Neutrals;
-		}
-
 		public readonly Actor PlayerActor;
 		public readonly Color Color;
 
@@ -100,8 +92,6 @@ namespace OpenRA
 				return WinState != WinState.Undefined && !inMissionMap;
 			}
 		}
-
-		readonly StanceColors stanceColors;
 
 		public static FactionInfo ResolveFaction(string factionName, IEnumerable<FactionInfo> factionInfos, MersenneTwister playerRandom, bool requireSelectable = true)
 		{
@@ -221,11 +211,6 @@ namespace OpenRA
 					logic.Activate(this);
 			}
 
-			stanceColors.Self = ChromeMetrics.Get<Color>("PlayerStanceColorSelf");
-			stanceColors.Allies = ChromeMetrics.Get<Color>("PlayerStanceColorAllies");
-			stanceColors.Enemies = ChromeMetrics.Get<Color>("PlayerStanceColorEnemies");
-			stanceColors.Neutrals = ChromeMetrics.Get<Color>("PlayerStanceColorNeutrals");
-
 			unlockRenderPlayer = PlayerActor.TraitsImplementing<IUnlocksRenderPlayer>().ToArray();
 			notifyDisconnected = PlayerActor.TraitsImplementing<INotifyPlayerDisconnected>().ToArray();
 		}
@@ -259,7 +244,7 @@ namespace OpenRA
 			return RelationshipWith(p) == PlayerRelationship.Ally;
 		}
 
-		public Color PlayerRelationshipColor(Actor a)
+		public static Color PlayerRelationshipColor(Actor a)
 		{
 			var renderPlayer = a.World.RenderPlayer;
 			var player = renderPlayer ?? a.World.LocalPlayer;
@@ -271,16 +256,16 @@ namespace OpenRA
 					apparentOwner = effectiveOwner.Owner;
 
 				if (apparentOwner == player)
-					return stanceColors.Self;
+					return ChromeMetrics.Get<Color>("PlayerStanceColorSelf");
 
 				if (apparentOwner.IsAlliedWith(player))
-					return stanceColors.Allies;
+					return ChromeMetrics.Get<Color>("PlayerStanceColorAllies");
 
 				if (!apparentOwner.NonCombatant)
-					return stanceColors.Enemies;
+					return ChromeMetrics.Get<Color>("PlayerStanceColorEnemies");
 			}
 
-			return stanceColors.Neutrals;
+			return ChromeMetrics.Get<Color>("PlayerStanceColorNeutrals");
 		}
 
 		internal void PlayerDisconnected(Player p)

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Eluant;
 using Eluant.ObjectBinding;
+using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Primitives;
 using OpenRA.Scripting;
@@ -252,10 +253,13 @@ namespace OpenRA
 		/// <summary>Returns <see cref="color"/>, ignoring player relationship colors.</summary>
 		public static Color GetColor(Player p) => p.color;
 
-		public static void SetupRelationshipColors(Player[] players, Player viewer)
+		public static void SetupRelationshipColors(Player[] players, Player viewer, WorldRenderer worldRenderer, bool firstRun)
 		{
 			foreach (var p in players)
+			{
 				p.Color = PlayerRelationshipColor(p, viewer);
+				worldRenderer.UpdatePalettesForPlayer(p.InternalName, p.Color, !firstRun);
+			}
 		}
 
 		public static Color PlayerRelationshipColor(Player player, Player viewer)

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -38,8 +38,6 @@ namespace OpenRA
 	public class Player : IScriptBindable, IScriptNotifyBind, ILuaTableBinding, ILuaEqualityBinding, ILuaToStringBinding
 	{
 		public readonly Actor PlayerActor;
-		public readonly Color Color;
-
 		public readonly string PlayerName;
 		public readonly string InternalName;
 		public readonly FactionInfo Faction;
@@ -53,6 +51,11 @@ namespace OpenRA
 		public readonly string BotType;
 		public readonly Shroud Shroud;
 		public readonly FrozenActorLayer FrozenActorLayer;
+
+		readonly Color color;
+
+		/// <summary>Returns player color with relationship colors applied.</summary>
+		public Color Color { get; private set; }
 
 		/// <summary>The faction (including Random, etc.) that was selected in the lobby.</summary>
 		public readonly FactionInfo DisplayFaction;
@@ -152,7 +155,8 @@ namespace OpenRA
 			if (client != null)
 			{
 				ClientIndex = client.Index;
-				Color = client.Color;
+				color = client.Color;
+				Color = color;
 				PlayerName = ResolvePlayerName(client, world.LobbyInfo.Clients, world.Map.Rules.Actors[SystemActors.Player].TraitInfos<IBotInfo>());
 
 				BotType = client.Bot;
@@ -170,6 +174,7 @@ namespace OpenRA
 			{
 				// Map player
 				ClientIndex = world.LobbyInfo.Clients.FirstOrDefault(c => c.IsAdmin)?.Index ?? 0; // Owned by the host (TODO: fix this)
+				color = pr.Color;
 				Color = pr.Color;
 				PlayerName = pr.Name;
 				NonCombatant = pr.NonCombatant;
@@ -244,28 +249,30 @@ namespace OpenRA
 			return RelationshipWith(p) == PlayerRelationship.Ally;
 		}
 
-		public static Color PlayerRelationshipColor(Actor a)
+		/// <summary>Returns <see cref="color"/>, ignoring player relationship colors.</summary>
+		public static Color GetColor(Player p) => p.color;
+
+		public static void SetupRelationshipColors(Player[] players, Player viewer)
 		{
-			var renderPlayer = a.World.RenderPlayer;
-			var player = renderPlayer ?? a.World.LocalPlayer;
-			if (player != null && !player.Spectating)
-			{
-				var effectiveOwner = a.EffectiveOwner;
-				var apparentOwner = a.Owner;
-				if (effectiveOwner != null && effectiveOwner.Disguised && !a.Owner.IsAlliedWith(renderPlayer))
-					apparentOwner = effectiveOwner.Owner;
+			foreach (var p in players)
+				p.Color = PlayerRelationshipColor(p, viewer);
+		}
 
-				if (apparentOwner == player)
-					return ChromeMetrics.Get<Color>("PlayerStanceColorSelf");
+		public static Color PlayerRelationshipColor(Player player, Player viewer)
+		{
+			if (!Game.Settings.Game.UsePlayerStanceColors || viewer == null || viewer.Spectating)
+				return player.color;
 
-				if (apparentOwner.IsAlliedWith(player))
-					return ChromeMetrics.Get<Color>("PlayerStanceColorAllies");
+			if (viewer == player)
+				return ChromeMetrics.Get<Color>("PlayerStanceColorSelf");
 
-				if (!apparentOwner.NonCombatant)
-					return ChromeMetrics.Get<Color>("PlayerStanceColorEnemies");
-			}
+			if (player.IsAlliedWith(viewer))
+				return ChromeMetrics.Get<Color>("PlayerStanceColorAllies");
 
-			return ChromeMetrics.Get<Color>("PlayerStanceColorNeutrals");
+			if (player.NonCombatant)
+				return ChromeMetrics.Get<Color>("PlayerStanceColorNeutrals");
+
+			return ChromeMetrics.Get<Color>("PlayerStanceColorEnemies");
 		}
 
 		internal void PlayerDisconnected(Player p)

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -163,7 +163,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (!Disguised || self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				return color;
 
-			return Game.Settings.Game.UsePlayerStanceColors ? AsPlayer.PlayerRelationshipColor(self) : AsPlayer.Color;
+			return Game.Settings.Game.UsePlayerStanceColors ? Player.PlayerRelationshipColor(self) : AsPlayer.Color;
 		}
 
 		public void DisguiseAs(Actor target)

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new Disguise(init.Self, this); }
 	}
 
-	sealed class Disguise : IEffectiveOwner, IIssueOrder, IResolveOrder, IOrderVoice, IRadarColorModifier, INotifyAttack,
+	sealed class Disguise : IEffectiveOwner, IIssueOrder, IResolveOrder, IOrderVoice, INotifyAttack,
 		INotifyDamage, INotifyLoadCargo, INotifyUnloadCargo, INotifyDemolition, INotifyInfiltration, ITick
 	{
 		public ActorInfo AsActor { get; private set; }
@@ -156,14 +156,6 @@ namespace OpenRA.Mods.Cnc.Traits
 		string IOrderVoice.VoicePhraseForOrder(Actor self, Order order)
 		{
 			return order.OrderString == "Disguise" ? info.Voice : null;
-		}
-
-		Color IRadarColorModifier.RadarColorOverride(Actor self, Color color)
-		{
-			if (!Disguised || self.Owner.IsAlliedWith(self.World.RenderPlayer))
-				return color;
-
-			return Game.Settings.Game.UsePlayerStanceColors ? Player.PlayerRelationshipColor(self) : AsPlayer.Color;
 		}
 
 		public void DisguiseAs(Actor target)

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForCash.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForCash.cs
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			TextNotificationsManager.AddTransientLine(infiltrator.Owner, info.InfiltrationTextNotification);
 
 			if (info.ShowTicks)
-				self.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, infiltrator.Owner.Color, FloatingText.FormatCashTick(toGive), 30)));
+				self.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, infiltrator.OwnerColor(), FloatingText.FormatCashTick(toGive), 30)));
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Traits/ResourcePurifier.cs
+++ b/OpenRA.Mods.Cnc/Traits/ResourcePurifier.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			{
 				var temp = currentDisplayValue;
 				if (self.Owner.IsAlliedWith(self.World.RenderPlayer))
-					self.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, self.Owner.Color, FloatingText.FormatCashTick(temp), Info.TickLifetime)));
+					self.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, self.OwnerColor(), FloatingText.FormatCashTick(temp), Info.TickLifetime)));
 
 				currentDisplayTick = Info.TickRate;
 				currentDisplayValue = 0;

--- a/OpenRA.Mods.Common/Activities/DonateCash.cs
+++ b/OpenRA.Mods.Common/Activities/DonateCash.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Activities
 				exp.GiveExperience(playerExperience);
 
 			if (self.Owner.IsAlliedWith(self.World.RenderPlayer))
-				self.World.AddFrameEndTask(w => w.Add(new FloatingText(targetActor.CenterPosition, targetOwner.Color, FloatingText.FormatCashTick(donated), 30)));
+				self.World.AddFrameEndTask(w => w.Add(new FloatingText(targetActor.CenterPosition, targetActor.OwnerColor(), FloatingText.FormatCashTick(donated), 30)));
 
 			foreach (var nct in targetActor.TraitsImplementing<INotifyCashTransfer>())
 				nct.OnAcceptingCash(targetActor, self);

--- a/OpenRA.Mods.Common/Activities/Sell.cs
+++ b/OpenRA.Mods.Common/Activities/Sell.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Activities
 				ns.Sold(self);
 
 			if (showTicks && refund > 0 && self.Owner.IsAlliedWith(self.World.RenderPlayer))
-				self.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, self.Owner.Color, FloatingText.FormatCashTick(refund), 30)));
+				self.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, self.OwnerColor(), FloatingText.FormatCashTick(refund), 30)));
 
 			Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", sellableInfo.Notification, self.Owner.Faction.InternalName);
 			TextNotificationsManager.AddTransientLine(self.Owner, sellableInfo.TextNotification);

--- a/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.Common.Effects
 			{
 				var targetLine = new[] { prev, pos };
 				prev = pos;
-				yield return new TargetLineRenderable(targetLine, building.Owner.Color, rp.Info.LineWidth, 1);
+				yield return new TargetLineRenderable(targetLine, building.OwnerColor(), rp.Info.LineWidth, 1);
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Graphics/IsometricSelectionBarsAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/IsometricSelectionBarsAnnotationRenderable.cs
@@ -124,11 +124,8 @@ namespace OpenRA.Mods.Common.Graphics
 			}
 		}
 
-		Color GetHealthColor(IHealth health)
+		static Color GetHealthColor(IHealth health)
 		{
-			if (Game.Settings.Game.UsePlayerStanceColors)
-				return Player.PlayerRelationshipColor(actor);
-
 			return health.DamageState == DamageState.Critical ? Color.Red :
 				health.DamageState == DamageState.Heavy ? Color.Yellow : Color.LimeGreen;
 		}

--- a/OpenRA.Mods.Common/Graphics/IsometricSelectionBarsAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/IsometricSelectionBarsAnnotationRenderable.cs
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Common.Graphics
 		Color GetHealthColor(IHealth health)
 		{
 			if (Game.Settings.Game.UsePlayerStanceColors)
-				return actor.Owner.PlayerRelationshipColor(actor);
+				return Player.PlayerRelationshipColor(actor);
 
 			return health.DamageState == DamageState.Critical ? Color.Red :
 				health.DamageState == DamageState.Heavy ? Color.Yellow : Color.LimeGreen;

--- a/OpenRA.Mods.Common/Graphics/SelectionBarsAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBarsAnnotationRenderable.cs
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.Common.Graphics
 		Color GetHealthColor(IHealth health)
 		{
 			if (Game.Settings.Game.UsePlayerStanceColors)
-				return actor.Owner.PlayerRelationshipColor(actor);
+				return Player.PlayerRelationshipColor(actor);
 
 			return health.DamageState == DamageState.Critical ? Color.Red :
 				health.DamageState == DamageState.Heavy ? Color.Yellow : Color.LimeGreen;

--- a/OpenRA.Mods.Common/Graphics/SelectionBarsAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBarsAnnotationRenderable.cs
@@ -81,16 +81,13 @@ namespace OpenRA.Mods.Common.Graphics
 			cr.DrawLine(start + r, z + r, 1, barColor2);
 		}
 
-		Color GetHealthColor(IHealth health)
+		static Color GetHealthColor(IHealth health)
 		{
-			if (Game.Settings.Game.UsePlayerStanceColors)
-				return Player.PlayerRelationshipColor(actor);
-
 			return health.DamageState == DamageState.Critical ? Color.Red :
 				health.DamageState == DamageState.Heavy ? Color.Yellow : Color.LimeGreen;
 		}
 
-		void DrawHealthBar(IHealth health, float2 start, float2 end)
+		static void DrawHealthBar(IHealth health, float2 start, float2 end)
 		{
 			if (health == null || health.IsDead)
 				return;

--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		public IProjectile Create(ProjectileArgs args)
 		{
-			var c = UsePlayerColor ? args.SourceActor.Owner.Color : Color;
+			var c = UsePlayerColor ? args.SourceActor.OwnerColor() : Color;
 			return new AreaBeam(this, args, c);
 		}
 	}

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -201,9 +201,14 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			if (info.ContrailLength > 0)
 			{
-				var startcolor = info.ContrailStartColorUsePlayerColor ? Color.FromArgb(info.ContrailStartColorAlpha, Player.ActorColor(args.SourceActor)) : Color.FromArgb(info.ContrailStartColorAlpha, info.ContrailStartColor);
-				var endcolor = info.ContrailEndColorUsePlayerColor ? Color.FromArgb(info.ContrailEndColorAlpha, Player.ActorColor(args.SourceActor)) : Color.FromArgb(info.ContrailEndColorAlpha, info.ContrailEndColor ?? startcolor);
-				contrail = new ContrailRenderable(world, startcolor, endcolor, info.ContrailStartWidth, info.ContrailEndWidth ?? info.ContrailStartWidth, info.ContrailLength, info.ContrailDelay, info.ContrailZOffset);
+				var startcolor = Color.FromArgb(info.ContrailStartColorAlpha, info.ContrailStartColor);
+				var endcolor = Color.FromArgb(info.ContrailEndColorAlpha, info.ContrailEndColor ?? startcolor);
+				contrail = new ContrailRenderable(world, args.SourceActor,
+					startcolor, info.ContrailStartColorUsePlayerColor,
+					endcolor, info.ContrailEndColor == null ? info.ContrailStartColorUsePlayerColor : info.ContrailEndColorUsePlayerColor,
+					info.ContrailStartWidth,
+					info.ContrailEndWidth ?? info.ContrailStartWidth,
+					info.ContrailLength, info.ContrailDelay, info.ContrailZOffset);
 			}
 
 			trailPalette = info.TrailPalette;

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -201,8 +201,8 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			if (info.ContrailLength > 0)
 			{
-				var startcolor = info.ContrailStartColorUsePlayerColor ? Color.FromArgb(info.ContrailStartColorAlpha, args.SourceActor.Owner.Color) : Color.FromArgb(info.ContrailStartColorAlpha, info.ContrailStartColor);
-				var endcolor = info.ContrailEndColorUsePlayerColor ? Color.FromArgb(info.ContrailEndColorAlpha, args.SourceActor.Owner.Color) : Color.FromArgb(info.ContrailEndColorAlpha, info.ContrailEndColor ?? startcolor);
+				var startcolor = info.ContrailStartColorUsePlayerColor ? Color.FromArgb(info.ContrailStartColorAlpha, Player.ActorColor(args.SourceActor)) : Color.FromArgb(info.ContrailStartColorAlpha, info.ContrailStartColor);
+				var endcolor = info.ContrailEndColorUsePlayerColor ? Color.FromArgb(info.ContrailEndColorAlpha, Player.ActorColor(args.SourceActor)) : Color.FromArgb(info.ContrailEndColorAlpha, info.ContrailEndColor ?? startcolor);
 				contrail = new ContrailRenderable(world, startcolor, endcolor, info.ContrailStartWidth, info.ContrailEndWidth ?? info.ContrailStartWidth, info.ContrailLength, info.ContrailDelay, info.ContrailZOffset);
 			}
 

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		public IProjectile Create(ProjectileArgs args)
 		{
-			var c = UsePlayerColor ? args.SourceActor.Owner.Color : Color;
+			var c = UsePlayerColor ? args.SourceActor.OwnerColor() : Color;
 			return new LaserZap(this, args, c);
 		}
 	}
@@ -126,7 +126,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			this.args = args;
 			this.info = info;
 			this.color = color;
-			secondaryColor = info.SecondaryBeamUsePlayerColor ? args.SourceActor.Owner.Color : info.SecondaryBeamColor;
+			secondaryColor = info.SecondaryBeamUsePlayerColor ? args.SourceActor.OwnerColor() : info.SecondaryBeamColor;
 			target = args.PassiveTarget;
 			source = args.Source;
 

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -285,8 +285,8 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			if (info.ContrailLength > 0)
 			{
-				var startcolor = info.ContrailStartColorUsePlayerColor ? Color.FromArgb(info.ContrailStartColorAlpha, args.SourceActor.Owner.Color) : Color.FromArgb(info.ContrailStartColorAlpha, info.ContrailStartColor);
-				var endcolor = info.ContrailEndColorUsePlayerColor ? Color.FromArgb(info.ContrailEndColorAlpha, args.SourceActor.Owner.Color) : Color.FromArgb(info.ContrailEndColorAlpha, info.ContrailEndColor ?? startcolor);
+				var startcolor = info.ContrailStartColorUsePlayerColor ? Color.FromArgb(info.ContrailStartColorAlpha, Player.ActorColor(args.SourceActor)) : Color.FromArgb(info.ContrailStartColorAlpha, info.ContrailStartColor);
+				var endcolor = info.ContrailEndColorUsePlayerColor ? Color.FromArgb(info.ContrailEndColorAlpha, Player.ActorColor(args.SourceActor)) : Color.FromArgb(info.ContrailEndColorAlpha, info.ContrailEndColor ?? startcolor);
 				contrail = new ContrailRenderable(world, startcolor, endcolor, info.ContrailStartWidth, info.ContrailEndWidth ?? info.ContrailStartWidth, info.ContrailLength, info.ContrailDelay, info.ContrailZOffset);
 			}
 

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -285,9 +285,14 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			if (info.ContrailLength > 0)
 			{
-				var startcolor = info.ContrailStartColorUsePlayerColor ? Color.FromArgb(info.ContrailStartColorAlpha, Player.ActorColor(args.SourceActor)) : Color.FromArgb(info.ContrailStartColorAlpha, info.ContrailStartColor);
-				var endcolor = info.ContrailEndColorUsePlayerColor ? Color.FromArgb(info.ContrailEndColorAlpha, Player.ActorColor(args.SourceActor)) : Color.FromArgb(info.ContrailEndColorAlpha, info.ContrailEndColor ?? startcolor);
-				contrail = new ContrailRenderable(world, startcolor, endcolor, info.ContrailStartWidth, info.ContrailEndWidth ?? info.ContrailStartWidth, info.ContrailLength, info.ContrailDelay, info.ContrailZOffset);
+				var startcolor = Color.FromArgb(info.ContrailStartColorAlpha, info.ContrailStartColor);
+				var endcolor = Color.FromArgb(info.ContrailEndColorAlpha, info.ContrailEndColor ?? startcolor);
+				contrail = new ContrailRenderable(world, args.SourceActor,
+					startcolor, info.ContrailStartColorUsePlayerColor,
+					endcolor, info.ContrailEndColor == null ? info.ContrailStartColorUsePlayerColor : info.ContrailEndColorUsePlayerColor,
+					info.ContrailStartWidth,
+					info.ContrailEndWidth ?? info.ContrailStartWidth,
+					info.ContrailLength, info.ContrailDelay, info.ContrailZOffset);
 			}
 
 			trailPalette = info.TrailPalette;

--- a/OpenRA.Mods.Common/Projectiles/Railgun.cs
+++ b/OpenRA.Mods.Common/Projectiles/Railgun.cs
@@ -95,8 +95,8 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		public IProjectile Create(ProjectileArgs args)
 		{
-			var bc = BeamPlayerColor ? Color.FromArgb(BeamColor.A, args.SourceActor.Owner.Color) : BeamColor;
-			var hc = HelixPlayerColor ? Color.FromArgb(HelixColor.A, args.SourceActor.Owner.Color) : HelixColor;
+			var bc = BeamPlayerColor ? Color.FromArgb(BeamColor.A, args.SourceActor.OwnerColor()) : BeamColor;
+			var hc = HelixPlayerColor ? Color.FromArgb(HelixColor.A, args.SourceActor.OwnerColor()) : HelixColor;
 			return new Railgun(args, this, bc, hc);
 		}
 	}

--- a/OpenRA.Mods.Common/Scripting/Properties/PlayerProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/PlayerProperties.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Scripting
 		public string Name => Player.PlayerName;
 
 		[Desc("The player's color.")]
-		public Color Color => Player.Color;
+		public Color Color => Player.GetColor(Player);
 
 		[Desc("The player's faction.")]
 		public string Faction => Player.Faction.InternalName;

--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				var temp = currentDisplayValue;
 				if (self.Owner.IsAlliedWith(self.World.RenderPlayer))
-					self.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, self.Owner.Color, FloatingText.FormatCashTick(temp), 30)));
+					self.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, self.OwnerColor(), FloatingText.FormatCashTick(temp), 30)));
 				currentDisplayTick = info.TickRate;
 				currentDisplayValue = 0;
 			}

--- a/OpenRA.Mods.Common/Traits/CashTrickler.cs
+++ b/OpenRA.Mods.Common/Traits/CashTrickler.cs
@@ -91,7 +91,7 @@ namespace OpenRA.Mods.Common.Traits
 		void AddCashTick(Actor self, int amount)
 		{
 			self.World.AddFrameEndTask(w => w.Add(
-				new FloatingText(self.CenterPosition, self.Owner.Color, FloatingText.FormatCashTick(amount), info.DisplayDuration)));
+				new FloatingText(self.CenterPosition, self.OwnerColor(), FloatingText.FormatCashTick(amount), info.DisplayDuration)));
 		}
 
 		void ModifyCash(Actor self, int amount)

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -132,7 +132,7 @@ namespace OpenRA.Mods.Common.Traits
 			var maxHP = healthInfo.MaxHP > 0 ? healthInfo.MaxHP : 1;
 			var damageText = $"{-e.Damage.Value} ({e.Damage.Value * 100 / maxHP}%)";
 
-			self.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, e.Attacker.Owner.Color, damageText, 30)));
+			self.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, e.Attacker.OwnerColor(), damageText, 30)));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Crates/GiveCashCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GiveCashCrateAction.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 				var amount = collector.Owner.PlayerActor.Trait<PlayerResources>().ChangeCash(info.Amount);
 
 				if (info.UseCashTick)
-					w.Add(new FloatingText(collector.CenterPosition, collector.Owner.Color, FloatingText.FormatCashTick(amount), 30));
+					w.Add(new FloatingText(collector.CenterPosition, collector.OwnerColor(), FloatingText.FormatCashTick(amount), 30));
 			});
 
 			base.Activate(collector);

--- a/OpenRA.Mods.Common/Traits/ExitsDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/ExitsDebugOverlay.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				foreach (var exitCell in exitCells)
 				{
-					var color = self.Owner.Color;
+					var color = self.OwnerColor();
 					var vec = exitCell - self.Location;
 					var center = wr.World.Map.CenterOfCell(exitCell);
 					yield return new TextAnnotationRenderable(manager.Font, center, 0, color, vec.ToString());
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.Traits
 						continue;
 
 					var exitCellCenter = self.World.Map.CenterOfCell(exitCells[i]);
-					yield return new LineAnnotationRenderable(spawnPos, exitCellCenter, 1, self.Owner.Color);
+					yield return new LineAnnotationRenderable(spawnPos, exitCellCenter, 1, self.OwnerColor());
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/GivesBounty.cs
+++ b/OpenRA.Mods.Common/Traits/GivesBounty.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var displayedBounty = GetDisplayedBountyValue(self);
 			if (Info.ShowBounty && self.IsInWorld && displayedBounty != 0 && e.Attacker.Owner.IsAlliedWith(self.World.RenderPlayer))
-				e.Attacker.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, e.Attacker.Owner.Color, FloatingText.FormatCashTick(displayedBounty), 30)));
+				e.Attacker.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, e.Attacker.OwnerColor(), FloatingText.FormatCashTick(displayedBounty), 30)));
 
 			e.Attacker.Owner.PlayerActor.Trait<PlayerResources>().ChangeCash(GetBountyValue(self));
 		}

--- a/OpenRA.Mods.Common/Traits/GivesCashOnCapture.cs
+++ b/OpenRA.Mods.Common/Traits/GivesCashOnCapture.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			self.World.AddFrameEndTask(w => w.Add(
-				new FloatingText(self.CenterPosition, self.Owner.Color, FloatingText.FormatCashTick(amount), info.DisplayDuration)));
+				new FloatingText(self.CenterPosition, self.OwnerColor(), FloatingText.FormatCashTick(amount), info.DisplayDuration)));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.Common.Traits
 					playerRadarPing = radarPings.Add(
 						() => self.Owner.IsAlliedWith(self.World.RenderPlayer),
 						order.Target.CenterPosition,
-						self.Owner.Color,
+						self.OwnerColor(),
 						info.Duration);
 				}
 			});

--- a/OpenRA.Mods.Common/Traits/Radar/AppearsOnRadar.cs
+++ b/OpenRA.Mods.Common/Traits/Radar/AppearsOnRadar.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits.Radar
 			if (IsTraitDisabled || (viewer != null && !Info.ValidRelationships.HasRelationship(self.Owner.RelationshipWith(viewer))))
 				return;
 
-			var color = Game.Settings.Game.UsePlayerStanceColors ? self.Owner.PlayerRelationshipColor(self) : self.Owner.Color;
+			var color = Game.Settings.Game.UsePlayerStanceColors ? Player.PlayerRelationshipColor(self) : self.Owner.Color;
 			if (modifier != null)
 				color = modifier.RadarColorOverride(self, color);
 

--- a/OpenRA.Mods.Common/Traits/Radar/AppearsOnRadar.cs
+++ b/OpenRA.Mods.Common/Traits/Radar/AppearsOnRadar.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits.Radar
 			if (IsTraitDisabled || (viewer != null && !Info.ValidRelationships.HasRelationship(self.Owner.RelationshipWith(viewer))))
 				return;
 
-			var color = Game.Settings.Game.UsePlayerStanceColors ? Player.PlayerRelationshipColor(self) : self.Owner.Color;
+			var color = self.OwnerColor();
 			if (modifier != null)
 				color = modifier.RadarColorOverride(self, color);
 

--- a/OpenRA.Mods.Common/Traits/Render/Contrail.cs
+++ b/OpenRA.Mods.Common/Traits/Render/Contrail.cs
@@ -75,8 +75,8 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.info = info;
 
-			startcolor = info.StartColorUsePlayerColor ? Color.FromArgb(info.StartColorAlpha, self.Owner.Color) : Color.FromArgb(info.StartColorAlpha, info.StartColor);
-			endcolor = info.EndColorUsePlayerColor ? Color.FromArgb(info.EndColorAlpha, self.Owner.Color) : Color.FromArgb(info.EndColorAlpha, info.EndColor ?? startcolor);
+			startcolor = info.StartColorUsePlayerColor ? Color.FromArgb(info.StartColorAlpha, Player.ActorColor(self)) : Color.FromArgb(info.StartColorAlpha, info.StartColor);
+			endcolor = info.EndColorUsePlayerColor ? Color.FromArgb(info.EndColorAlpha, Player.ActorColor(self)) : Color.FromArgb(info.EndColorAlpha, info.EndColor ?? startcolor);
 			trail = new ContrailRenderable(self.World, startcolor, endcolor, info.StartWidth, info.EndWidth ?? info.StartWidth, info.TrailLength, info.TrailDelay, info.ZOffset);
 
 			body = self.Trait<BodyOrientation>();

--- a/OpenRA.Mods.Common/Traits/Render/Contrail.cs
+++ b/OpenRA.Mods.Common/Traits/Render/Contrail.cs
@@ -75,9 +75,14 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.info = info;
 
-			startcolor = info.StartColorUsePlayerColor ? Color.FromArgb(info.StartColorAlpha, Player.ActorColor(self)) : Color.FromArgb(info.StartColorAlpha, info.StartColor);
-			endcolor = info.EndColorUsePlayerColor ? Color.FromArgb(info.EndColorAlpha, Player.ActorColor(self)) : Color.FromArgb(info.EndColorAlpha, info.EndColor ?? startcolor);
-			trail = new ContrailRenderable(self.World, startcolor, endcolor, info.StartWidth, info.EndWidth ?? info.StartWidth, info.TrailLength, info.TrailDelay, info.ZOffset);
+			startcolor = Color.FromArgb(info.StartColorAlpha, info.StartColor);
+			endcolor = Color.FromArgb(info.EndColorAlpha, info.EndColor ?? startcolor);
+			trail = new ContrailRenderable(self.World, self,
+				startcolor, info.StartColorUsePlayerColor,
+				endcolor, info.EndColor == null ? info.StartColorUsePlayerColor : info.EndColorUsePlayerColor,
+				info.StartWidth,
+				info.EndWidth ?? info.StartWidth,
+				info.TrailLength, info.TrailDelay, info.ZOffset);
 
 			body = self.Trait<BodyOrientation>();
 		}
@@ -106,7 +111,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
-			trail = new ContrailRenderable(self.World, startcolor, endcolor, info.StartWidth, info.EndWidth ?? info.StartWidth, info.TrailLength, info.TrailDelay, info.ZOffset);
+			trail = new ContrailRenderable(self.World, self,
+				startcolor, info.StartColorUsePlayerColor,
+				endcolor, info.EndColor == null ? info.StartColorUsePlayerColor : info.EndColorUsePlayerColor,
+				info.StartWidth,
+				info.EndWidth ?? info.StartWidth,
+				info.TrailLength, info.TrailDelay, info.ZOffset);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
@@ -13,7 +13,6 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
@@ -26,14 +25,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new RenderDebugState(init.Self, this); }
 	}
 
-	sealed class RenderDebugState : INotifyAddedToWorld, INotifyOwnerChanged, INotifyCreated, IRenderAnnotationsWhenSelected
+	sealed class RenderDebugState : INotifyAddedToWorld, INotifyCreated, IRenderAnnotationsWhenSelected
 	{
 		readonly DebugVisualizations debugVis;
 		readonly SpriteFont font;
 		readonly WVec offset;
 		SquadManagerBotModule[] squadManagerModules;
 
-		Color color;
 		string tagString;
 
 		public RenderDebugState(Actor self, RenderDebugStateInfo info)
@@ -42,7 +40,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var yOffset = buildingInfo?.Dimensions.Y ?? 1;
 			offset = new WVec(0, 512 * yOffset, 0);
 
-			color = self.OwnerColor();
 			font = Game.Renderer.Fonts[info.Font];
 
 			debugVis = self.World.WorldActor.TraitOrDefault<DebugVisualizations>();
@@ -58,13 +55,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 			tagString = self.ToString();
 		}
 
-		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner) => color = self.OwnerColor();
-
 		IEnumerable<IRenderable> IRenderAnnotationsWhenSelected.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			if (debugVis == null || !debugVis.ActorTags)
 				yield break;
 
+			var color = self.OwnerColor();
 			yield return new TextAnnotationRenderable(font, self.CenterPosition - offset, 0, color, tagString);
 
 			// Get the actor's activity.

--- a/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
@@ -30,7 +30,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 	{
 		readonly DebugVisualizations debugVis;
 		readonly SpriteFont font;
-		readonly Actor self;
 		readonly WVec offset;
 		SquadManagerBotModule[] squadManagerModules;
 
@@ -43,8 +42,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var yOffset = buildingInfo?.Dimensions.Y ?? 1;
 			offset = new WVec(0, 512 * yOffset, 0);
 
-			this.self = self;
-			color = GetColor();
+			color = self.OwnerColor();
 			font = Game.Renderer.Fonts[info.Font];
 
 			debugVis = self.World.WorldActor.TraitOrDefault<DebugVisualizations>();
@@ -60,15 +58,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			tagString = self.ToString();
 		}
 
-		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
-		{
-			color = GetColor();
-		}
-
-		Color GetColor()
-		{
-			return self.EffectiveOwner != null && self.EffectiveOwner.Disguised ? self.EffectiveOwner.Owner.Color : self.Owner.Color;
-		}
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner) => color = self.OwnerColor();
 
 		IEnumerable<IRenderable> IRenderAnnotationsWhenSelected.RenderAnnotations(Actor self, WorldRenderer wr)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/WithNameTagDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithNameTagDecoration.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			: base(self, info)
 		{
 			font = Game.Renderer.Fonts[info.Font];
-			color = info.UsePlayerColor ? self.Owner.Color : info.Color;
+			color = info.UsePlayerColor ? self.OwnerColor() : info.Color;
 
 			name = self.Owner.PlayerName;
 			if (name.Length > info.MaxLength)
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			if (Info.UsePlayerColor)
-				color = newOwner.Color;
+				color = self.OwnerColor();
 
 			name = self.Owner.PlayerName;
 			if (name.Length > Info.MaxLength)

--- a/OpenRA.Mods.Common/Traits/Render/WithNameTagDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithNameTagDecoration.cs
@@ -45,14 +45,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 	public class WithNameTagDecoration : WithDecorationBase<WithNameTagDecorationInfo>, INotifyOwnerChanged
 	{
 		readonly SpriteFont font;
+		readonly WithNameTagDecorationInfo info;
 		string name;
-		Color color;
 
 		public WithNameTagDecoration(Actor self, WithNameTagDecorationInfo info)
 			: base(self, info)
 		{
 			font = Game.Renderer.Fonts[info.Font];
-			color = info.UsePlayerColor ? self.OwnerColor() : info.Color;
+			this.info = info;
 
 			name = self.Owner.PlayerName;
 			if (name.Length > info.MaxLength)
@@ -67,15 +67,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var size = font.Measure(name);
 			return new IRenderable[]
 			{
-				new UITextRenderable(font, self.CenterPosition, screenPos - size / 2, 0, color, name)
+				new UITextRenderable(font, self.CenterPosition, screenPos - size / 2, 0, info.UsePlayerColor ? self.OwnerColor() : info.Color, name)
 			};
 		}
 
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
-			if (Info.UsePlayerColor)
-				color = self.OwnerColor();
-
 			name = self.Owner.PlayerName;
 			if (name.Length > Info.MaxLength)
 				name = name[..Info.MaxLength];

--- a/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 					self.CenterPosition,
 					Info.Range,
 					0,
-					Info.UsePlayerColor ? self.Owner.Color : Info.Color,
+					Info.UsePlayerColor ? self.OwnerColor() : Info.Color,
 					Info.Width,
 					Info.BorderColor,
 					Info.BorderWidth);

--- a/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			this.info = info;
 			font = Game.Renderer.Fonts[info.Font];
-			color = info.UsePlayerColor ? self.Owner.Color : info.Color;
+			color = info.UsePlayerColor ? self.OwnerColor() : info.Color;
 
 			label = new CachedTransform<int, string>(g => self.World.ControlGroups.Groups[g]);
 		}
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			if (info.UsePlayerColor)
-				color = newOwner.Color;
+				color = self.OwnerColor();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
@@ -45,20 +45,16 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithTextControlGroupDecoration(init.Self, this); }
 	}
 
-	public class WithTextControlGroupDecoration : IDecoration, INotifyOwnerChanged
+	public class WithTextControlGroupDecoration : IDecoration
 	{
 		readonly WithTextControlGroupDecorationInfo info;
 		readonly SpriteFont font;
 		readonly CachedTransform<int, string> label;
 
-		Color color;
-
 		public WithTextControlGroupDecoration(Actor self, WithTextControlGroupDecorationInfo info)
 		{
 			this.info = info;
 			font = Game.Renderer.Fonts[info.Font];
-			color = info.UsePlayerColor ? self.OwnerColor() : info.Color;
-
 			label = new CachedTransform<int, string>(g => self.World.ControlGroups.Groups[g]);
 		}
 
@@ -74,14 +70,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var screenPos = container.GetDecorationOrigin(self, wr, info.Position, info.Margin);
 			return new IRenderable[]
 			{
-				new UITextRenderable(font, self.CenterPosition, screenPos, 0, color, text)
+				new UITextRenderable(font, self.CenterPosition, screenPos, 0, info.UsePlayerColor ? self.OwnerColor() : info.Color, text)
 			};
-		}
-
-		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
-		{
-			if (info.UsePlayerColor)
-				color = self.OwnerColor();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			: base(self, info)
 		{
 			font = Game.Renderer.Fonts[info.Font];
-			color = info.UsePlayerColor ? self.Owner.Color : info.Color;
+			color = info.UsePlayerColor ? self.OwnerColor() : info.Color;
 		}
 
 		protected override IEnumerable<IRenderable> RenderDecoration(Actor self, WorldRenderer wr, int2 screenPos)
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			if (Info.UsePlayerColor)
-				color = newOwner.Color;
+				color = self.OwnerColor();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/TogglePlayerStanceColorHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/TogglePlayerStanceColorHotkeyLogic.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using OpenRA.Graphics;
 using OpenRA.Mods.Common.Lint;
 using OpenRA.Widgets;
 
@@ -19,18 +20,20 @@ namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 	public class TogglePlayerStanceColorHotkeyLogic : SingleHotkeyBaseLogic
 	{
 		readonly World world;
+		readonly WorldRenderer worldRenderer;
 
 		[ObjectCreator.UseCtor]
-		public TogglePlayerStanceColorHotkeyLogic(Widget widget, World world, ModData modData, Dictionary<string, MiniYaml> logicArgs)
+		public TogglePlayerStanceColorHotkeyLogic(Widget widget, World world, WorldRenderer worldRenderer, ModData modData, Dictionary<string, MiniYaml> logicArgs)
 			: base(widget, modData, "TogglePlayerStanceColorKey", "WORLD_KEYHANDLER", logicArgs)
 		{
 			this.world = world;
+			this.worldRenderer = worldRenderer;
 		}
 
 		protected override bool OnHotkeyActivated(KeyInput e)
 		{
 			Game.Settings.Game.UsePlayerStanceColors ^= true;
-			Player.SetupRelationshipColors(world.Players, world.LocalPlayer);
+			Player.SetupRelationshipColors(world.Players, world.LocalPlayer, worldRenderer, false);
 
 			return true;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/TogglePlayerStanceColorHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/TogglePlayerStanceColorHotkeyLogic.cs
@@ -18,13 +18,19 @@ namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 	[ChromeLogicArgsHotkeys("TogglePlayerStanceColorKey")]
 	public class TogglePlayerStanceColorHotkeyLogic : SingleHotkeyBaseLogic
 	{
+		readonly World world;
+
 		[ObjectCreator.UseCtor]
-		public TogglePlayerStanceColorHotkeyLogic(Widget widget, ModData modData, Dictionary<string, MiniYaml> logicArgs)
-			: base(widget, modData, "TogglePlayerStanceColorKey", "WORLD_KEYHANDLER", logicArgs) { }
+		public TogglePlayerStanceColorHotkeyLogic(Widget widget, World world, ModData modData, Dictionary<string, MiniYaml> logicArgs)
+			: base(widget, modData, "TogglePlayerStanceColorKey", "WORLD_KEYHANDLER", logicArgs)
+		{
+			this.world = world;
+		}
 
 		protected override bool OnHotkeyActivated(KeyInput e)
 		{
 			Game.Settings.Game.UsePlayerStanceColors ^= true;
+			Player.SetupRelationshipColors(world.Players, world.LocalPlayer);
 
 			return true;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -515,8 +515,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		static void SetupPlayerColor(Player player, ScrollItemWidget template, ColorBlockWidget colorBlockWidget, GradientColorBlockWidget gradientColorBlockWidget)
 		{
-			var color = Color.FromArgb(128, player.Color.R, player.Color.G, player.Color.B);
-			var hoverColor = Color.FromArgb(192, player.Color.R, player.Color.G, player.Color.B);
+			var pColor = player.Color;
+			var color = Color.FromArgb(128, pColor.R, pColor.G, pColor.B);
+			var hoverColor = Color.FromArgb(192, pColor.R, pColor.G, pColor.B);
 
 			var isMouseOver = new CachedTransform<Widget, bool>(w => w == template || template.Children.Contains(w));
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
@@ -69,6 +69,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						o = viewport.ActorTooltip.Owner;
 						showOwner = o != null && !o.NonCombatant && viewport.ActorTooltip.TooltipInfo.IsOwnerRowVisible;
 
+						if (showOwner)
+							ownerColor = o.Color;
+
 						var stance = o == null || world.RenderPlayer == null ? PlayerRelationship.None : o.RelationshipWith(world.RenderPlayer);
 						labelText = viewport.ActorTooltip.TooltipInfo.TooltipForPlayerStance(stance);
 						break;
@@ -78,6 +81,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						o = viewport.FrozenActorTooltip.TooltipOwner;
 						showOwner = o != null && !o.NonCombatant && viewport.FrozenActorTooltip.TooltipInfo.IsOwnerRowVisible;
+
+						if (showOwner)
+							ownerColor = o.Color;
 
 						var stance = o == null || world.RenderPlayer == null ? PlayerRelationship.None : o.RelationshipWith(world.RenderPlayer);
 						labelText = viewport.FrozenActorTooltip.TooltipInfo.TooltipForPlayerStance(stance);
@@ -107,7 +113,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					flagFaction = o.Faction.InternalName;
 					ownerName = o.PlayerName;
-					ownerColor = o.Color;
 					widget.Bounds.Height = doubleHeight;
 					widget.Bounds.Width = Math.Max(widget.Bounds.Width,
 						owner.Bounds.X + ownerFont.Measure(ownerName).X + label.Bounds.X);

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -152,7 +152,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			cb.OnClick = () =>
 			{
 				gs.UsePlayerStanceColors = cb.IsChecked() ^ true;
-				Player.SetupRelationshipColors(world.Players, world.LocalPlayer);
+				Player.SetupRelationshipColors(world.Players, world.LocalPlayer, worldRenderer, false);
 			};
 
 			if (panel.GetOrNull<CheckboxWidget>("PAUSE_SHELLMAP_CHECKBOX") != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -137,6 +137,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var ds = Game.Settings.Graphics;
 			var gs = Game.Settings.Game;
+			var world = worldRenderer.World;
 			var scrollPanel = panel.Get<ScrollPanelWidget>("SETTINGS_SCROLLPANEL");
 
 			SettingsUtils.BindCheckboxPref(panel, "CURSORDOUBLE_CHECKBOX", ds, "CursorDouble");
@@ -145,6 +146,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SettingsUtils.BindCheckboxPref(panel, "FRAME_LIMIT_GAMESPEED_CHECKBOX", ds, "CapFramerateToGameFps");
 			SettingsUtils.BindIntSliderPref(panel, "FRAME_LIMIT_SLIDER", ds, "MaxFramerate");
 			SettingsUtils.BindCheckboxPref(panel, "PLAYER_STANCE_COLORS_CHECKBOX", gs, "UsePlayerStanceColors");
+
+			var cb = panel.Get<CheckboxWidget>("PLAYER_STANCE_COLORS_CHECKBOX");
+			cb.IsChecked = () => gs.UsePlayerStanceColors;
+			cb.OnClick = () =>
+			{
+				gs.UsePlayerStanceColors = cb.IsChecked() ^ true;
+				Player.SetupRelationshipColors(world.Players, world.LocalPlayer);
+			};
+
 			if (panel.GetOrNull<CheckboxWidget>("PAUSE_SHELLMAP_CHECKBOX") != null)
 				SettingsUtils.BindCheckboxPref(panel, "PAUSE_SHELLMAP_CHECKBOX", gs, "PauseShellmap");
 
@@ -208,7 +218,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var minResolution = viewportSizes.MinEffectiveResolution;
 			var resolution = Game.Renderer.Resolution;
-			var disableUIScale = worldRenderer.World.Type != WorldType.Shellmap ||
+			var disableUIScale = world.Type != WorldType.Shellmap ||
 				resolution.Width * ds.UIScale < 1.25f * minResolution.Width ||
 				resolution.Height * ds.UIScale < 1.25f * minResolution.Height;
 
@@ -240,7 +250,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var escPressed = false;
 			var nameTextfield = panel.Get<TextFieldWidget>("PLAYERNAME");
-			nameTextfield.IsDisabled = () => worldRenderer.World.Type != WorldType.Shellmap;
+			nameTextfield.IsDisabled = () => world.Type != WorldType.Shellmap;
 			nameTextfield.Text = Settings.SanitizedPlayerName(ps.Name);
 			nameTextfield.OnLoseFocus = () =>
 			{
@@ -272,7 +282,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var colorManager = modData.DefaultRules.Actors[SystemActors.World].TraitInfo<IColorPickerManagerInfo>();
 
 			var colorDropdown = panel.Get<DropDownButtonWidget>("PLAYERCOLOR");
-			colorDropdown.IsDisabled = () => worldRenderer.World.Type != WorldType.Shellmap;
+			colorDropdown.IsDisabled = () => world.Type != WorldType.Shellmap;
 			colorDropdown.OnMouseDown = _ => colorManager.ShowColorDropDown(colorDropdown, ps.Color, null, worldRenderer, color =>
 			{
 				ps.Color = color;

--- a/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
@@ -61,11 +61,7 @@ namespace OpenRA.Mods.Common.Widgets
 				var time = WidgetUtils.FormatTime(p.RemainingTicks, false, self.World.Timestep);
 				var text = TranslationProvider.GetString(Format, Translation.Arguments("player", self.Owner.PlayerName, "support-power", p.Name, "time", time));
 
-				var playerColor = self.Owner.Color;
-
-				if (Game.Settings.Game.UsePlayerStanceColors)
-					playerColor = self.Owner.PlayerRelationshipColor(self);
-
+				var playerColor = Game.Settings.Game.UsePlayerStanceColors ? Player.PlayerRelationshipColor(self) : self.Owner.Color;
 				var color = !p.Ready || Game.LocalTick % 50 < 25 ? playerColor : Color.White;
 
 				return (text, color);

--- a/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
@@ -61,8 +61,7 @@ namespace OpenRA.Mods.Common.Widgets
 				var time = WidgetUtils.FormatTime(p.RemainingTicks, false, self.World.Timestep);
 				var text = TranslationProvider.GetString(Format, Translation.Arguments("player", self.Owner.PlayerName, "support-power", p.Name, "time", time));
 
-				var playerColor = Game.Settings.Game.UsePlayerStanceColors ? Player.PlayerRelationshipColor(self) : self.Owner.Color;
-				var color = !p.Ready || Game.LocalTick % 50 < 25 ? playerColor : Color.White;
+				var color = !p.Ready || Game.LocalTick % 50 < 25 ? self.OwnerColor() : Color.White;
 
 				return (text, color);
 			}).ToArray();

--- a/mods/cnc/languages/chrome/en.ftl
+++ b/mods/cnc/languages/chrome/en.ftl
@@ -643,7 +643,7 @@ label-status-bar-dropdown-container-bars = Status Bars:
 
 checkbox-player-stance-colors-container =
    .label = Player Relationship Colors
-   .tooltip = Change minimap and health bar colors based on relationship (own, enemy, ally, neutral)
+   .tooltip = Change player colors based on relationship (own, enemy, ally, neutral)
 
 checkbox-ui-feedback-container =
    .label = Show UI Feedback Notifications

--- a/mods/common/languages/chrome/en.ftl
+++ b/mods/common/languages/chrome/en.ftl
@@ -468,7 +468,7 @@ label-status-bar-dropdown-container-bars = Status Bars:
 
 checkbox-player-stance-colors-container =
    .label = Player Relationship Colors
-   .tooltip = Change minimap and health bar colors based on relationship (own, enemy, ally, neutral)
+   .tooltip = Change player colors based on relationship (own, enemy, ally, neutral)
 
 checkbox-ui-feedback-container =
    .label = Show UI Feedback Notifications


### PR DESCRIPTION
Related #15027, #15833, #7497, #2053

I'm additionally removing the colouring on healthbars. Now with units being accordingly colored, having healthbars match feels weird. Also the removal of contrails color cache might need a rethink, though it should not really cause any performance concerns.

This PR can be seen as a jumping off point for future ingame player color changing PR's

