### PR TITLE
When running a server, don't load minimap previews into memory.

### DIFF
--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -28,6 +28,7 @@ namespace OpenRA
 		public static readonly MapPreview UnknownMap = new MapPreview(null, null, MapGridType.Rectangular, null);
 		public IReadOnlyDictionary<IReadOnlyPackage, MapClassification> MapLocations => mapLocations;
 		readonly Dictionary<IReadOnlyPackage, MapClassification> mapLocations = new Dictionary<IReadOnlyPackage, MapClassification>();
+		public bool LoadPreviewImages = true;
 
 		readonly Cache<string, MapPreview> previews;
 		readonly ModData modData;

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -393,7 +393,7 @@ namespace OpenRA
 
 			newData.SetCustomRules(modData, this, yaml);
 
-			if (p.Contains("map.png"))
+			if (cache.LoadPreviewImages && p.Contains("map.png"))
 				using (var dataStream = p.GetStream("map.png"))
 					newData.Preview = new Png(dataStream);
 
@@ -435,14 +435,17 @@ namespace OpenRA
 						spawns[j / 2] = new CPos(r.spawnpoints[j], r.spawnpoints[j + 1]);
 					newData.SpawnPoints = spawns;
 					newData.GridType = r.map_grid_type;
-					try
+					if (cache.LoadPreviewImages)
 					{
-						newData.Preview = new Png(new MemoryStream(Convert.FromBase64String(r.minimap)));
-					}
-					catch (Exception e)
-					{
-						Log.Write("debug", "Failed parsing mapserver minimap response: {0}", e);
-						newData.Preview = null;
+						try
+						{
+							newData.Preview = new Png(new MemoryStream(Convert.FromBase64String(r.minimap)));
+						}
+						catch (Exception e)
+						{
+							Log.Write("debug", "Failed parsing mapserver minimap response: {0}", e);
+							newData.Preview = null;
+						}
 					}
 
 					var playersString = Encoding.UTF8.GetString(Convert.FromBase64String(r.players_block));

--- a/OpenRA.Server/Program.cs
+++ b/OpenRA.Server/Program.cs
@@ -83,6 +83,7 @@ namespace OpenRA.Server
 			{
 				// HACK: The engine code *still* assumes that Game.ModData is set
 				var modData = Game.ModData = new ModData(mods[modID], mods);
+				modData.MapCache.LoadPreviewImages = false; // PERF: Server doesn't need previews, save memory by not loading them.
 				modData.MapCache.LoadMaps();
 
 				settings.Map = modData.MapCache.ChooseInitialMap(settings.Map, new MersenneTwister());


### PR DESCRIPTION
This reduces memory usage when starting up a server for the ra mod from 113 MB to 88 MB.