### PR TITLE
Optionally add faction suffix to BuildableInfo.Icon

### DIFF
--- a/OpenRA.Game/Traits/LintAttributes.cs
+++ b/OpenRA.Game/Traits/LintAttributes.cs
@@ -53,14 +53,16 @@ namespace OpenRA.Traits
 		public readonly bool Prefix;
 		public readonly bool AllowNullImage;
 		public readonly LintDictionaryReference DictionaryReference;
+		public readonly bool HasFactionSuffix;
 
 		public SequenceReferenceAttribute(string imageReference = null, bool prefix = false, bool allowNullImage = false,
-			LintDictionaryReference dictionaryReference = LintDictionaryReference.None)
+			bool hasFactionSuffix = false, LintDictionaryReference dictionaryReference = LintDictionaryReference.None)
 		{
 			ImageReference = imageReference;
 			Prefix = prefix;
 			AllowNullImage = allowNullImage;
 			DictionaryReference = dictionaryReference;
+			HasFactionSuffix = hasFactionSuffix;
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Buildable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildable.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Force a specific faction variant, overriding the faction of the producing actor.")]
 		public readonly string ForceFaction = null;
 
-		[SequenceReference]
+		[SequenceReference(hasFactionSuffix: true)]
 		[Desc("Sequence of the actor that contains the icon.")]
 		public readonly string Icon = "icon";
 

--- a/OpenRA.Mods.Common/Traits/Buildable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildable.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using OpenRA.Traits;
+using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Traits
 {
@@ -39,6 +40,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sequence of the actor that contains the icon.")]
 		public readonly string Icon = "icon";
 
+		[Desc("Should faction suffix be added for sequence " + nameof(Icon) + "?")]
+		public readonly bool AddIconFactionSuffix = false;
+
 		[PaletteReference(nameof(IconPaletteIsPlayerPalette))]
 		[Desc("Palette used for the production icon.")]
 		public readonly string IconPalette = "chrome";
@@ -61,6 +65,21 @@ namespace OpenRA.Mods.Common.Traits
 		public static string GetInitialFaction(ActorInfo ai, string defaultFaction)
 		{
 			return ai.TraitInfoOrDefault<BuildableInfo>()?.ForceFaction ?? defaultFaction;
+		}
+
+		public string GetIconSequence(World world, string faction, string image)
+		{
+			if (AddIconFactionSuffix)
+			{
+				if (ChromeMetrics.TryGet("FactionSuffix-" + faction, out string factionOverride))
+					faction = factionOverride;
+
+				var factionSequence = $"{Icon}.{faction}";
+				if (world.Map.Sequences.HasSequence(image, factionSequence))
+					return factionSequence;
+			}
+
+			return Icon;
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -162,7 +162,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				var image = rsi.GetImage(actorInfo, owner.Faction.InternalName);
 				Icon = new Animation(owner.World, image);
-				Icon.Play(BuildableInfo.Icon);
+				Icon.Play(BuildableInfo.GetIconSequence(owner.World, owner.Faction.InternalName, image));
 				IconPalette = BuildableInfo.IconPalette;
 				IconPaletteIsPlayerPalette = BuildableInfo.IconPaletteIsPlayerPalette;
 				BuildPaletteOrder = BuildableInfo.BuildPaletteOrder;

--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -136,10 +136,11 @@ namespace OpenRA.Mods.Common.Widgets
 					continue;
 
 				var rsi = actor.TraitInfo<RenderSpritesInfo>();
-				var icon = new Animation(world, rsi.GetImage(actor, faction));
+				var image = rsi.GetImage(actor, faction);
+				var icon = new Animation(world, image);
 				var bi = actor.TraitInfo<BuildableInfo>();
+				icon.Play(bi.GetIconSequence(world, player.Faction.InternalName, image));
 
-				icon.Play(bi.Icon);
 				var topLeftOffset = new float2(queueCol * (IconWidth + IconSpacing), 0);
 
 				var iconTopLeft = RenderOrigin + topLeftOffset;

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -490,9 +490,10 @@ namespace OpenRA.Mods.Common.Widgets
 				var rect = new Rectangle(rb.X + x * (IconSize.X + IconMargin.X), rb.Y + y * (IconSize.Y + IconMargin.Y), IconSize.X, IconSize.Y);
 
 				var rsi = item.TraitInfo<RenderSpritesInfo>();
-				var icon = new Animation(World, rsi.GetImage(item, faction));
+				var image = rsi.GetImage(item, faction);
+				var icon = new Animation(World, image);
 				var bi = item.TraitInfo<BuildableInfo>();
-				icon.Play(bi.Icon);
+				icon.Play(bi.GetIconSequence(World, World.LocalPlayer.Faction.InternalName, image));
 
 				var palette = bi.IconPaletteIsPlayerPalette ? bi.IconPalette + producer.Actor.Owner.InternalName : bi.IconPalette;
 

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -357,6 +357,7 @@ GADEPT:
 		Prerequisites: factory, ~structures.gdi, ~techlevel.medium
 		Queue: Building
 		Description: Repairs or sells vehicles and aircraft.
+		AddIconFactionSuffix: true
 	Building:
 		Footprint: =+= x++ x+=
 		Dimensions: 3,3
@@ -426,11 +427,6 @@ GADEPT:
 	Power:
 		Amount: -30
 	ProvidesPrerequisite@buildingname:
-	RenderSprites:
-		Image: gadept.gdi
-		FactionImages:
-			gdi: gadept.gdi
-			nod: gadept.nod
 	GrantConditionOnHostDock:
 		Condition: serving
 		AfterDockDuration: 20

--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -32,6 +32,8 @@ harv.colorpicker:
 	Inherits: HARV
 	-Buildable:
 	-MapEditorData:
+	RenderSprites:
+		Image: harv
 	RenderVoxels:
 		Image: harv
 		Palette: colorpicker

--- a/mods/ts/rules/shared-infantry.yaml
+++ b/mods/ts/rules/shared-infantry.yaml
@@ -8,6 +8,7 @@ E1:
 		BuildPaletteOrder: 10
 		Prerequisites: ~barracks, ~techlevel.low
 		Description: General-purpose infantry.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft
+		AddIconFactionSuffix: true
 	Valued:
 		Cost: 120
 	Tooltip:
@@ -31,18 +32,13 @@ E1:
 		DefaultAttackSequence: attack
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded
-	RenderSprites:
-		Image: e1.gdi
-		FactionImages:
-			gdi: e1.gdi
-			nod: e1.nod
 	RevealsShroud:
 		Range: 5c0
 
 E1R3:
 	Inherits: E1
 	RenderSprites:
-		Image: e1.gdi
+		Image: e1
 	ProducibleWithLevel:
 		Prerequisites: techlevel.low
 		InitialLevels: 3
@@ -62,6 +58,7 @@ ENGINEER:
 		BuildPaletteOrder: 40
 		Prerequisites: ~barracks, ~techlevel.low
 		Description: Infiltrates and captures enemy structures.\n  Unarmed
+		AddIconFactionSuffix: true
 	Voiced:
 		VoiceSet: Engineer
 	Mobile:
@@ -78,11 +75,6 @@ ENGINEER:
 	Captures:
 		CaptureTypes: building
 		PlayerExperience: 10
-	RenderSprites:
-		Image: engineer.gdi
-		FactionImages:
-			gdi: engineer.gdi
-			nod: engineer.nod
 
 FLAMEGUY:
 	Inherits@1: ^ExistsInWorld

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -111,6 +111,7 @@ PROC:
 		BuildPaletteOrder: 30
 		Prerequisites: anypower, ~techlevel.low
 		Description: Processes raw Tiberium\ninto useable resources.
+		AddIconFactionSuffix: true
 	Building:
 		Footprint: xxX+ xx++ xxX+
 		Dimensions: 4,3
@@ -154,11 +155,6 @@ PROC:
 	Power:
 		Amount: -30
 	ProvidesPrerequisite@buildingname:
-	RenderSprites:
-		Image: proc.gdi
-		FactionImages:
-			gdi: proc.gdi
-			nod: proc.nod
 	GrantConditionOnPlayerResources:
 		Condition: contains-tiberium
 	Explodes:
@@ -182,6 +178,7 @@ GASILO:
 		BuildPaletteOrder: 60
 		Prerequisites: proc, ~techlevel.low
 		Description: Stores excess Tiberium.
+		AddIconFactionSuffix: true
 	Valued:
 		Cost: 150
 	Tooltip:
@@ -197,11 +194,6 @@ GASILO:
 	RevealsShroud:
 		Range: 4c0
 		MaxHeightDelta: 3
-	RenderSprites:
-		Image: gasilo.gdi
-		FactionImages:
-			gdi: gasilo.gdi
-			nod: gasilo.nod
 	WithResourceLevelOverlay@FILLSTAGE:
 		RequiresCondition: !build-incomplete
 		Sequence: stages

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -11,6 +11,7 @@ NAPULS:
 		BuildPaletteOrder: 110
 		Prerequisites: radar, ~techlevel.superweapons
 		Description: Disables mechanical units in an area.\nRequires power to operate.
+		AddIconFactionSuffix: true
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -35,11 +36,6 @@ NAPULS:
 		Sequence: turret
 	Power:
 		Amount: -150
-	RenderSprites:
-		Image: napuls.gdi
-		FactionImages:
-			gdi: napuls.gdi
-			nod: napuls.nod
 	ProvidesPrerequisite@gdi:
 		ResetOnOwnerChange: true
 	ProvidesPrerequisite@gdi:

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -7,6 +7,7 @@ MCV:
 		BuildPaletteOrder: 160
 		Prerequisites: ~factory, tech, ~techlevel.medium
 		Description: Deploys into another Construction Yard.\n  Unarmed
+		AddIconFactionSuffix: true
 	Valued:
 		Cost: 2500
 	Tooltip:
@@ -36,11 +37,6 @@ MCV:
 		Voice: Move
 		NoTransformNotification: BuildingCannotPlaceAudio
 		NoTransformTextNotification: notification-cannot-deploy-here
-	RenderSprites:
-		Image: mcv.gdi
-		FactionImages:
-			gdi: mcv.gdi
-			nod: mcv.nod
 
 HARV:
 	Inherits: ^Tank
@@ -55,6 +51,7 @@ HARV:
 		BuildPaletteOrder: 10
 		Prerequisites: ~factory, proc, ~techlevel.low
 		Description: Collects Tiberium for processing.\n  Unarmed
+		AddIconFactionSuffix: true
 	Selectable:
 		Bounds: 1086, 2172
 		DecorationBounds: 1086, 2172
@@ -95,11 +92,6 @@ HARV:
 	WithHarvestOverlay:
 		LocalOffset: 543,0,0
 		Palette: effect
-	RenderSprites:
-		Image: harv.gdi
-		FactionImages:
-			gdi: harv.gdi
-			nod: harv.nod
 	-DamagedByTerrain@VEINS:
 	-LeavesTrails@VEINS:
 	WithStoresResourcesPipsDecoration:
@@ -124,6 +116,7 @@ LPST:
 		BuildPaletteOrder: 90
 		Prerequisites: ~factory, radar, ~techlevel.medium
 		Description: Can detect cloaked and subterranean\nunits when deployed.\n  Unarmed
+		AddIconFactionSuffix: true
 	Valued:
 		Cost: 950
 	Tooltip:
@@ -153,11 +146,7 @@ LPST:
 	GrantCondition@PREVIEWWORKAROUND:
 		Condition: real-actor
 	RenderSprites:
-		Image: lpst.gdi
 		PlayerPalette: playertem
-		FactionImages:
-			gdi: lpst.gdi
-			nod: lpst.nod
 	GrantConditionOnDeploy:
 		PauseOnCondition: empdisable || being-captured
 		DeployedCondition: deployed

--- a/mods/ts/sequences/infantry.yaml
+++ b/mods/ts/sequences/infantry.yaml
@@ -77,20 +77,14 @@
 		Facings: 8
 		IgnoreWorldTint: True
 
-e1.gdi:
+e1:
 	Inherits: ^BasicInfantry
 	Inherits@attack: ^BasicInfantryAttack
 	Defaults:
 		Filename: e1.shp
 	icon:
 		Filename: sidebar-gdi|e1icon.shp
-
-e1.nod:
-	Inherits: ^BasicInfantry
-	Inherits@attack: ^BasicInfantryAttack
-	Defaults:
-		Filename: e1.shp
-	icon:
+	icon.nod:
 		Filename: sidebar-nod|e1icon.shp
 
 e2:
@@ -109,18 +103,13 @@ e3:
 	icon:
 		Filename: e4icon.shp
 
-engineer.gdi:
+engineer:
 	Inherits: ^BasicInfantry
 	Defaults:
 		Filename: engineer.shp
 	icon:
 		Filename: sidebar-gdi|engnicon.shp
-
-engineer.nod:
-	Inherits: ^BasicInfantry
-	Defaults:
-		Filename: engineer.shp
-	icon:
+	icon.nod:
 		Filename: sidebar-nod|engnicon.shp
 
 umagon:

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -1591,48 +1591,7 @@ nasam:
 		TilesetFilenames:
 		Offset: 0, 0
 
-napuls.gdi:
-	Defaults:
-		TilesetFilenames:
-			TEMPERATE: ntpuls.shp
-			SNOW: napuls.shp
-		Offset: 0, -24, 24
-		DepthSprite: isodepth.shp
-	idle:
-		ShadowStart: 3
-	damaged-idle:
-		Start: 1
-		ShadowStart: 4
-	dead:
-		Start: 2
-		ShadowStart: 5
-		Tick: 400
-	turret:
-		TilesetFilenames:
-			TEMPERATE: ntpuls_a.shp
-			SNOW: napuls_a.shp
-		Facings: 32
-	make:
-		TilesetFilenames:
-			TEMPERATE: ntpulsmk.shp
-			SNOW: napulsmk.shp
-		Length: 20
-		ShadowStart: 20
-	emp-overlay:
-		Filename: emp_fx01.shp
-		TilesetFilenames:
-		Length: *
-		Offset: 0, 0, 25
-		ZOffset: 512
-		BlendMode: Additive
-		DepthSprite:
-	icon:
-		Filename: sidebar-gdi|empicon.shp
-		TilesetFilenames:
-		Offset: 0, 0
-		DepthSprite:
-
-napuls.nod:
+napuls:
 	Defaults:
 		TilesetFilenames:
 			TEMPERATE: ntpuls.shp
@@ -1668,7 +1627,12 @@ napuls.nod:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
-	icon:
+	icon.gdi:
+		Filename: sidebar-gdi|empicon.shp
+		TilesetFilenames:
+		Offset: 0, 0
+		DepthSprite:
+	icon.nod:
 		Filename: sidebar-nod|empicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
@@ -2079,7 +2043,7 @@ nahpad:
 		TilesetFilenames:
 		Offset: 0, 0
 
-proc.gdi:
+proc:
 	Defaults:
 		TilesetFilenames:
 			TEMPERATE: ntrefn.shp
@@ -2170,94 +2134,7 @@ proc.gdi:
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
-
-proc.nod:
-	Defaults:
-		TilesetFilenames:
-			TEMPERATE: ntrefn.shp
-			SNOW: narefn.shp
-		Offset: -12, -42, 20
-		DepthSpriteOffset: 22, 0
-		DepthSprite: isodepth.shp
-	idle:
-		ShadowStart: 3
-	damaged-idle:
-		Start: 1
-		ShadowStart: 4
-	dead:
-		Start: 2
-		ShadowStart: 5
-		Tick: 400
-	make:
-		TilesetFilenames:
-			TEMPERATE: ntrefnmk.shp
-			SNOW: narefnmk.shp
-		Length: 20
-		ShadowStart: 20
-		Offset: -12, -42, 43
-		DepthSpriteOffset: -12, 0
-	flame:
-		TilesetFilenames:
-			TEMPERATE: ntrefn_b.shp
-			SNOW: narefn_b.shp
-		Length: *
-		IgnoreWorldTint: True
-	unload-overlay:
-		TilesetFilenames:
-			TEMPERATE: ntrefn_a.shp
-			SNOW: narefn_a.shp
-		Length: *
-		ZOffset: 1024
-	idle-lights:
-		TilesetFilenames:
-			TEMPERATE: ntrefn_c.shp
-			SNOW: narefn_c.shp
-		Length: 16
-		Tick: 120
-	idle-lights-bright:
-		TilesetFilenames:
-			TEMPERATE: ntrefn_c.shp
-			SNOW: narefn_c.shp
-		Length: 16
-		Tick: 120
-		IgnoreWorldTint: True
-	bib:
-		TilesetFilenames:
-			TEMPERATE: ntrefnbb.shp
-			SNOW: narefnbb.shp
-		Length: 1
-		ZOffset: -1024
-		Offset: -12, -42, 1
-		ZRamp: 1
-		DepthSprite:
-	damaged-bib:
-		TilesetFilenames:
-			TEMPERATE: ntrefnbb.shp
-			SNOW: narefnbb.shp
-		Start: 1
-		ZOffset: -1024
-		Offset: -12, -42, 1
-		ZRamp: 1
-		DepthSprite:
-	dead-bib:
-		TilesetFilenames:
-			TEMPERATE: ntrefnbb.shp
-			SNOW: narefnbb.shp
-		Start: 2
-		ZOffset: -1024
-		Offset: -12, -42, 1
-		ZRamp: 1
-		DepthSprite:
-	emp-overlay:
-		Filename: emp_fx01.shp
-		TilesetFilenames:
-		Length: *
-		Offset: 0, 0, 21
-		ZOffset: 512
-		BlendMode: Additive
-		IgnoreWorldTint: True
-		DepthSprite:
-	icon:
+	icon.nod:
 		Filename: sidebar-nod|reficon.shp
 		TilesetFilenames:
 		Offset: 0, 0
@@ -2359,7 +2236,7 @@ nawast:
 		Offset: 0, 0
 		DepthSprite:
 
-gasilo.gdi:
+gasilo:
 	Defaults:
 		TilesetFilenames:
 			TEMPERATE: gtsilo.shp
@@ -2433,83 +2310,13 @@ gasilo.gdi:
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
-
-gasilo.nod:
-	Defaults:
-		TilesetFilenames:
-			TEMPERATE: gtsilo.shp
-			SNOW: gasilo.shp
-		Offset: 0, -24, 24
-		DepthSprite: isodepth.shp
-	idle:
-		TilesetFilenames:
-			TEMPERATE: gtsilo_a.shp
-			SNOW: gasilo_a.shp
-	damaged-idle:
-		TilesetFilenames:
-			TEMPERATE: gtsilo_a.shp
-			SNOW: gasilo_a.shp
-		Start: 4
-	stages:
-		TilesetFilenames:
-			TEMPERATE: gtsilo_a.shp
-			SNOW: gasilo_a.shp
-		Length: 4
-	damaged-stages:
-		TilesetFilenames:
-			TEMPERATE: gtsilo_a.shp
-			SNOW: gasilo_a.shp
-		Start: 4
-		Length: 4
-	idle-underlay:
-		ShadowStart: 3
-		ZOffset: -512
-	damaged-idle-underlay:
-		Start: 1
-		ShadowStart: 4
-		ZOffset: -512
-	dead:
-		Start: 2
-		ShadowStart: 5
-		ZOffset: -512
-		Tick: 400
-	idle-lights-bright:
-		TilesetFilenames:
-			TEMPERATE: gtsilo_b.shp
-			SNOW: gasilo_b.shp
-		Length: 16
-		Tick: 120
-		IgnoreWorldTint: True
-	damaged-idle-lights-bright:
-		TilesetFilenames:
-			TEMPERATE: gtsilo_b.shp
-			SNOW: gasilo_b.shp
-		Start: 16
-		Length: 16
-		Tick: 120
-		IgnoreWorldTint: True
-	make:
-		TilesetFilenames:
-			TEMPERATE: gtsilomk.shp
-			SNOW: gasilomk.shp
-		Length: 18
-		ShadowStart: 20
-	emp-overlay:
-		Filename: emp_fx01.shp
-		TilesetFilenames:
-		Length: *
-		Offset: 0, 0, 25
-		ZOffset: 512
-		BlendMode: Additive
-		IgnoreWorldTint: True
-		DepthSprite:
-	icon:
+	icon.nod:
 		Filename: sidebar-nod|siloicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 
-gadept.gdi:
+gadept:
 	Defaults:
 		TilesetFilenames:
 			TEMPERATE: gtdept.shp
@@ -2680,175 +2487,7 @@ gadept.gdi:
 		Filename: sidebar-gdi|fixicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
-
-gadept.nod:
-	Defaults:
-		TilesetFilenames:
-			TEMPERATE: gtdept.shp
-			SNOW: gadept.shp
-		Offset: 0, -36, 1
-		DepthSpriteOffset: 36, 0
-	idle:
-		ShadowStart: 3
-		Offset: 0, -36, 12
-		DepthSprite: isodepth.shp
-	damaged-idle:
-		Start: 1
-		ShadowStart: 4
-		Offset: 0, -36, 12
-		DepthSprite: isodepth.shp
-	dead:
-		Start: 2
-		ShadowStart: 5
-		Tick: 400
-		Offset: 0, -36, 12
-		DepthSprite: isodepth.shp
-	ground:
-		TilesetFilenames:
-			TEMPERATE: gtdeptbb.shp
-			SNOW: gadeptbb.shp
-		ShadowStart: 3
-		ZOffset: -1c611
-		ZRamp: 1
-	damaged-ground:
-		TilesetFilenames:
-			TEMPERATE: gtdeptbb.shp
-			SNOW: gadeptbb.shp
-		Start: 1
-		ShadowStart: 4
-		ZOffset: -1c611
-		ZRamp: 1
-	dead-ground:
-		TilesetFilenames:
-			TEMPERATE: gtdeptbb.shp
-			SNOW: gadeptbb.shp
-		Start: 2
-		ShadowStart: 5
-		ZOffset: -1c611
-		Tick: 400
-		ZRamp: 1
-	idle-light:
-		TilesetFilenames:
-			TEMPERATE: gtdept_b.shp
-			SNOW: gadept_b.shp
-		Offset: 0, -36, 13
-		Length: 7
-		Tick: 120
-		ZRamp: 1
-	idle-light-bright:
-		TilesetFilenames:
-			TEMPERATE: gtdept_b.shp
-			SNOW: gadept_b.shp
-		Offset: 0, -36, 13
-		Length: 7
-		Tick: 120
-		ZRamp: 1
-		IgnoreWorldTint: True
-	circuits:
-		TilesetFilenames:
-			TEMPERATE: gtdept_a.shp
-			SNOW: gadept_a.shp
-		Length: 5
-		ZOffset: -1c511
-		Tick: 120
-		ZRamp: 1
-	circuits-bright:
-		TilesetFilenames:
-			TEMPERATE: gtdept_a.shp
-			SNOW: gadept_a.shp
-		Length: 5
-		ZOffset: -1c511
-		Tick: 120
-		ZRamp: 1
-		IgnoreWorldTint: True
-	damaged-circuits:
-		TilesetFilenames:
-			TEMPERATE: gtdept_a.shp
-			SNOW: gadept_a.shp
-		Start: 5
-		Length: 5
-		ZOffset: -1c511
-		Tick: 120
-		ZRamp: 1
-	damaged-circuits-bright:
-		TilesetFilenames:
-			TEMPERATE: gtdept_a.shp
-			SNOW: gadept_a.shp
-		Start: 5
-		Length: 5
-		ZOffset: -1c511
-		Tick: 120
-		ZRamp: 1
-		IgnoreWorldTint: True
-	crane-start:
-		TilesetFilenames:
-			TEMPERATE: gtdept_c.shp
-			SNOW: gadept_c.shp
-		Length: 6
-		Offset: 0, -36, 12
-		Tick: 60
-		DepthSprite: isodepth.shp
-	crane-loop:
-		TilesetFilenames:
-			TEMPERATE: gtdept_c.shp
-			SNOW: gadept_c.shp
-		Start: 6
-		Length: 5
-		Offset: 0, -36, 12
-		Tick: 60
-		DepthSprite: isodepth.shp
-	crane-loop-bright:
-		TilesetFilenames:
-			TEMPERATE: gtdept_c.shp
-			SNOW: gadept_c.shp
-		Start: 6
-		Length: 5
-		Offset: 0, -36, 12
-		Tick: 60
-		DepthSprite: isodepth.shp
-		IgnoreWorldTint: True
-	crane-end:
-		TilesetFilenames:
-			TEMPERATE: gtdept_c.shp
-			SNOW: gadept_c.shp
-		Start: 10
-		Length: 6
-		Offset: 0, -36, 12
-		DepthSprite: isodepth.shp
-		Tick: 60
-	platform:
-		TilesetFilenames:
-			TEMPERATE: gtdept_d.shp
-			SNOW: gadept_d.shp
-		Length: 7
-		ZOffset: -1c511
-		ZRamp: 1
-	damaged-platform:
-		TilesetFilenames:
-			TEMPERATE: gtdept_d.shp
-			SNOW: gadept_d.shp
-		Start: 7
-		Length: 7
-		ZOffset: -1c511
-		ZRamp: 1
-	make:
-		TilesetFilenames:
-			TEMPERATE: gtdeptmk.shp
-			SNOW: gadeptmk.shp
-		Length: 10
-		Tick: 60
-		ShadowStart: 10
-		Offset: 0, -36, 36
-		ZRamp: 1
-	emp-overlay:
-		Filename: emp_fx01.shp
-		TilesetFilenames:
-		Length: *
-		Offset: 0, 0, 8
-		ZOffset: 512
-		BlendMode: Additive
-		IgnoreWorldTint: True
-	icon:
+	icon.nod:
 		Filename: sidebar-nod|fixicon.shp
 		TilesetFilenames:
 		Offset: 76, 66

--- a/mods/ts/sequences/vehicles.yaml
+++ b/mods/ts/sequences/vehicles.yaml
@@ -6,14 +6,11 @@
 		BlendMode: Additive
 		IgnoreWorldTint: True
 
-mcv.gdi:
+mcv:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: sidebar-gdi|mcvicon.shp
-
-mcv.nod:
-	Inherits: ^VehicleOverlays
-	icon:
+	icon.nod:
 		Filename: sidebar-nod|mcvicon.shp
 
 apc:
@@ -21,7 +18,7 @@ apc:
 	icon:
 		Filename: apcicon.shp
 
-harv.gdi:
+harv:
 	Inherits: ^VehicleOverlays
 	harvest:
 		Filename: harvestr.shp
@@ -30,15 +27,7 @@ harv.gdi:
 		Offset: 0, 0, 1
 	icon:
 		Filename: sidebar-gdi|harvicon.shp
-
-harv.nod:
-	Inherits: ^VehicleOverlays
-	harvest:
-		Filename: harvestr.shp
-		Length: *
-		ZRamp: 1
-		Offset: 0, 0, 1
-	icon:
+	icon.nod:
 		Filename: sidebar-nod|harvicon.shp
 
 hvr:
@@ -53,7 +42,7 @@ hvr:
 		Length: *
 		IgnoreWorldTint: True
 
-lpst.gdi:
+lpst:
 	Inherits: ^VehicleOverlays
 	idle:
 		TilesetFilenames:
@@ -93,10 +82,7 @@ lpst.gdi:
 		IgnoreWorldTint: True
 	icon:
 		Filename: sidebar-gdi|lpsticon.shp
-
-lpst.nod:
-	Inherits: lpst.gdi
-	icon:
+	icon.nod:
 		Filename: sidebar-nod|lpsticon.shp
 
 repair:


### PR DESCRIPTION
Using different icon in `ProductionPaletteWidget` for each faction is little bit cumbersome: it's necessary to create separate unit in sequences,change `icon` sequence and use `FactionImages` field on `RenderSprites` trait.

This makes adding faction-specific icons a bit tiresome and leads to repetitive and redundant YAML definitions.

This PR adds a new feature `ProductionPaletteWidget`, which allows changing icon name of production item using function from outside. `AddFactionSuffixLogic` then leverages this and changes sequence name by adding faction name as suffix.

Changes in ra, d2k are not necessary (each faction image is actually different).

As for TS, Here's a list of actors and sequences I changed:
- Service Depot (gadept.gdi, gadept.nod)
- Light Infantry (e1.gdi, e1.nod)
- Engineer (engineer.gdi, engineer.nod)
- Tiberium Refinery (proc.gdi, proc.nod)
- Silo (gasilo.gdi, gasilo.nod)
- Service Depot (gadept.gdi, gadept.nod)

There's one building that has different sequence configuration for each faction and that is EMP Cannon. `napuls.nod` has extra `IgnoreWorldTint` field:
```
napuls.nod:
	Defaults:
		TilesetFilenames:
        ...
	emp-overlay:
		Filename: emp_fx01.shp
		TilesetFilenames:
		Length: *
		Offset: 0, 0, 25
		ZOffset: 512
		BlendMode: Additive
		IgnoreWorldTint: True
		IgnoreWorldTint: True
		DepthSprite:
	icon:
		Filename: sidebar-nod|empicon.shp
		TilesetFilenames:
		Offset: 0, 0
		DepthSprite:
```

I'm not sure what should I do here. Should I ignore `IgnoreWorldTint` field and merge `napuls.nod` and `napuls.gdi` like other sequence defintions?
