### PR TITLE
Add PrefersNonDefaultGPU flag to Desktop Entry

### DIFF
--- a/packaging/linux/openra.desktop.in
+++ b/packaging/linux/openra.desktop.in
@@ -10,3 +10,4 @@ Terminal=false
 Categories=Game;StrategyGame;
 StartupWMClass=openra-{MODID}-{TAG}
 MimeType=x-scheme-handler/openra-{MODID}-{TAG};
+PrefersNonDefaultGPU=true


### PR DESCRIPTION
This means that the application will automatically start with the dedicated GPU of laptops, instead of the iGPU. Based on the Linux's FreeDesktop spec: https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html

For reference, I've helped Valve in doing the same for Steam, and applications that I manage on Flathub also have this desktop flag.