### PR TITLE
Fix colors in gamma space being treated as if they were in linear space

### DIFF
--- a/OpenRA.Game/Graphics/PlayerColorRemap.cs
+++ b/OpenRA.Game/Graphics/PlayerColorRemap.cs
@@ -21,11 +21,12 @@ namespace OpenRA.Graphics
 		readonly float hue;
 		readonly float saturation;
 
-		public PlayerColorRemap(int[] remapIndices, float hue, float saturation)
+		public PlayerColorRemap(int[] remapIndices, Color color)
 		{
 			this.remapIndices = remapIndices;
-			this.hue = hue;
-			this.saturation = saturation;
+
+			var (r, g, b) = color.ToLinear();
+			(hue, saturation, _) = Color.RgbToHsv(r, g, b);
 		}
 
 		public Color GetRemappedColor(Color original, int index)

--- a/OpenRA.Mods.Common/Traits/Palettes/ColorPickerPalette.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/ColorPickerPalette.cs
@@ -57,8 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 		void ILoadsPalettes.LoadPalettes(WorldRenderer wr)
 		{
 			color = colorManager.Color;
-			var (_, h, s, _) = color.ToAhsv();
-			var remap = new PlayerColorRemap(info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToArray() : info.RemapIndex, h, s);
+			var remap = new PlayerColorRemap(info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToArray() : info.RemapIndex, color);
 			wr.AddPalette(info.Name, new ImmutablePalette(wr.Palette(info.BasePalette).Palette, remap), info.AllowModifiers);
 		}
 
@@ -70,8 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			color = colorManager.Color;
-			var (_, h, s, _) = color.ToAhsv();
-			var remap = new PlayerColorRemap(info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToArray() : info.RemapIndex, h, s);
+			var remap = new PlayerColorRemap(info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToArray() : info.RemapIndex, color);
 			wr.ReplacePalette(info.Name, new ImmutablePalette(wr.Palette(info.BasePalette).Palette, remap));
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Palettes/FixedColorPalette.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/FixedColorPalette.cs
@@ -52,9 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void LoadPalettes(WorldRenderer wr)
 		{
-			var (_, h, s, _) = info.Color.ToAhsv();
-
-			var remap = new PlayerColorRemap(info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToArray() : info.RemapIndex, h, s);
+			var remap = new PlayerColorRemap(info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToArray() : info.RemapIndex, info.Color);
 			wr.AddPalette(info.Name, new ImmutablePalette(wr.Palette(info.Base).Palette, remap), info.AllowModifiers);
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Palettes/PlayerColorPalette.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PlayerColorPalette.cs
@@ -49,9 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void LoadPlayerPalettes(WorldRenderer wr, string playerName, Color color, bool replaceExisting)
 		{
-			var (_, h, s, _) = color.ToAhsv();
-
-			var remap = new PlayerColorRemap(info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToArray() : info.RemapIndex, h, s);
+			var remap = new PlayerColorRemap(info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToArray() : info.RemapIndex, color);
 			var pal = new ImmutablePalette(wr.Palette(info.BasePalette).Palette, remap);
 			wr.AddPalette(info.BaseName + playerName, pal, info.AllowModifiers, replaceExisting);
 		}


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/issues/20415#issuecomment-1445467353

PlayerColorRemap expected colors in linear space yet we provided them in gamma. We fix this by instead expecting gamma space colors and then converting them into linear space ourselves.

Fix proposed by @pchote 