### PR TITLE
Enforce code rule IDE0048

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -127,6 +127,12 @@ csharp_style_expression_bodied_local_functions = when_on_single_line
 # Remove unused parameters on non public methods, ignore unused parameters on public methods.
 dotnet_code_quality_unused_parameters = non_public
 
+# Parentheses preferences.
+dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+
 ## Others:
 
 # Show an IDE warning when default access modifiers are explicitly specified.
@@ -200,6 +206,9 @@ dotnet_diagnostic.IDE0044.severity = warning
 
 # Remove unnecessary parentheses.
 dotnet_diagnostic.IDE0047.severity = warning
+
+# Add parentheses for clarity.
+dotnet_diagnostic.IDE0048.severity = warning
 
 # Remove unused private member.
 dotnet_diagnostic.IDE0051.severity = warning

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -1248,8 +1248,8 @@ namespace OpenRA
 			if (allProjected.Length > 0)
 			{
 				var puv = allProjected.First();
-				var horizontalBound = ((puv.U - Bounds.Left) < Bounds.Width / 2) ? Bounds.Left : Bounds.Right;
-				var verticalBound = ((puv.V - Bounds.Top) < Bounds.Height / 2) ? Bounds.Top : Bounds.Bottom;
+				var horizontalBound = (puv.U - Bounds.Left < Bounds.Width / 2) ? Bounds.Left : Bounds.Right;
+				var verticalBound = (puv.V - Bounds.Top < Bounds.Height / 2) ? Bounds.Top : Bounds.Bottom;
 
 				var du = Math.Abs(horizontalBound - puv.U);
 				var dv = Math.Abs(verticalBound - puv.V);

--- a/OpenRA.Game/Primitives/PriorityQueue.cs
+++ b/OpenRA.Game/Primitives/PriorityQueue.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Primitives
 
 			items[addLevel][addIndex] = item;
 
-			if (++index >= (1 << level))
+			if (++index >= 1 << level)
 			{
 				index = 0;
 				if (items.Count <= ++level)

--- a/OpenRA.Game/Traits/Player/Shroud.cs
+++ b/OpenRA.Game/Traits/Player/Shroud.cs
@@ -382,7 +382,7 @@ namespace OpenRA.Traits
 			{
 				var index = touched.Index(puv);
 				touched[index] = true;
-				explored[index] = (visibleCount[index] + passiveVisibleCount[index]) > 0;
+				explored[index] = visibleCount[index] + passiveVisibleCount[index] > 0;
 			}
 
 			anyCellTouched = true;

--- a/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
@@ -228,7 +228,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 			InitBigNum(n1, 0, len);
 			nTwoBitLen = (int)BitLenBigNum(n2, len);
 			bit = 1U << (nTwoBitLen % 32);
-			var j = ((nTwoBitLen + 32) / 32) - 1;
+			var j = (nTwoBitLen + 32) / 32 - 1;
 			nTwoByteLen = (uint)((nTwoBitLen - 1) / 32) * 4;
 			nTmp[nTwoByteLen / 4] |= 1U << ((nTwoBitLen - 1) & 0x1f);
 
@@ -293,7 +293,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 					tmp = 0;
 					for (i = 0; i < len; i++)
 					{
-						tmp = mul * (*pn2) + (*pn1) + tmp;
+						tmp = mul * *pn2 + *pn1 + tmp;
 						*pn1 = (ushort)tmp;
 						pn1++;
 						pn2++;
@@ -371,8 +371,8 @@ namespace OpenRA.Mods.Cnc.FileFormats
 						IncrementBigNum(globTwo, len * 2 + 1);
 						NegBigNum(globTwo, len * 2 + 1);
 						lenDiff = globTwoXtwo + 1 - globOneLenXTwo;
-						var esi = ((ushort*)g2) + (1 + globTwoXtwo - globOneLenXTwo);
-						var edi = ((ushort*)g2) + (globTwoXtwo + 1);
+						var esi = (ushort*)g2 + (1 + globTwoXtwo - globOneLenXTwo);
+						var edi = (ushort*)g2 + (globTwoXtwo + 1);
 						for (; lenDiff != 0; lenDiff--)
 						{
 							edi--;

--- a/OpenRA.Mods.Cnc/FileFormats/LZOCompression.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/LZOCompression.cs
@@ -218,7 +218,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 						goto match_done;
 					}
 
-					if (t >= 2 * 4 - (3 - 1) && (op - mPos) >= 4)
+					if (t >= 2 * 4 - (3 - 1) && op - mPos >= 4)
 					{
 						*(uint*)op = *(uint*)mPos;
 						op += 4; mPos += 4; t -= 4 - (3 - 1);

--- a/OpenRA.Mods.Cnc/FileSystem/MixFile.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/MixFile.cs
@@ -164,7 +164,7 @@ namespace OpenRA.Mods.Cnc.FileSystem
 				if (count < 0)
 					throw new ArgumentOutOfRangeException(nameof(count), "Non-negative number required.");
 
-				if (offset + (count * 2) > s.Length)
+				if (offset + count * 2 > s.Length)
 					throw new ArgumentException($"Bytes to read {count * 2} and offset {offset} greater than stream length {s.Length}.");
 
 				s.Seek(offset, SeekOrigin.Begin);

--- a/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
@@ -304,8 +304,8 @@ namespace OpenRA.Mods.Common.Widgets
 				for (var x = previousCell.X; x <= nextCell.X; x += terrainTemplate.Size.X)
 				{
 					PaintSingleCell(new CPos(x, queuedCell.Y));
-					var upperCell = new CPos(x, queuedCell.Y - (1 * terrainTemplate.Size.Y));
-					var lowerCell = new CPos(x, queuedCell.Y + (1 * terrainTemplate.Size.Y));
+					var upperCell = new CPos(x, queuedCell.Y - 1 * terrainTemplate.Size.Y);
+					var lowerCell = new CPos(x, queuedCell.Y + 1 * terrainTemplate.Size.Y);
 
 					if (ShouldPaint(upperCell))
 						MaybeEnqueue(upperCell);

--- a/OpenRA.Mods.Common/FileFormats/WavReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/WavReader.cs
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Common.FileFormats
 			{
 				this.channels = channels;
 				numBlocks = dataSize / blockAlign;
-				blockDataSize = blockAlign - (channels * 4);
+				blockDataSize = blockAlign - channels * 4;
 				outputSize = uncompressedSize * channels * 2;
 				predictor = new int[channels];
 				index = new int[channels];
@@ -268,7 +268,7 @@ namespace OpenRA.Mods.Common.FileFormats
 			// This code contains elements from libsndfile
 			short DecodeNibble(short nibble, byte bpred, ref short idelta, ref short s1, ref short s2)
 			{
-				var predict = ((s1 * AdaptCoeff1[bpred]) + (s2 * AdaptCoeff2[bpred])) >> 8;
+				var predict = (s1 * AdaptCoeff1[bpred] + s2 * AdaptCoeff2[bpred]) >> 8;
 
 				var twosCompliment = (nibble & 0x8) > 0
 					? nibble - 0x10

--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -376,7 +376,7 @@ namespace OpenRA.Mods.Common.Graphics
 					for (var frame = 0; frame < length; frame++)
 					{
 						var i = transpose ? frame % length * facings + facing :
-							(facing * stride) + (frame % length);
+							facing * stride + frame % length;
 
 						usedFrames.Add(frames != null ? frames[i] : start + i);
 					}
@@ -530,7 +530,7 @@ namespace OpenRA.Mods.Common.Graphics
 				for (var frame = 0; frame < length; frame++)
 				{
 					var i = transpose ? frame % length * facings + facing :
-								(facing * stride) + (frame % length);
+								facing * stride + frame % length;
 					var s = frames != null ? sprites[frames[i]] : sprites[start + i];
 					if (!s.Bounds.IsEmpty)
 						yield return new Rectangle(
@@ -574,7 +574,7 @@ namespace OpenRA.Mods.Common.Graphics
 				f = (facings - f) % facings;
 
 			var i = transpose ? frame % length * facings + f :
-				(f * stride) + (frame % length);
+				f * stride + frame % length;
 
 			var j = frames != null ? frames[i] : start + i;
 			if (sprites[j] == null)

--- a/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
+++ b/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
@@ -699,8 +699,8 @@ namespace OpenRA.Mods.Common.Pathfinder
 		static CPos GetGridTopLeft(CPos cellInGrid, Grid mapBounds)
 		{
 			return new CPos(
-				((cellInGrid.X - mapBounds.TopLeft.X) / GridSize * GridSize) + mapBounds.TopLeft.X,
-				((cellInGrid.Y - mapBounds.TopLeft.Y) / GridSize * GridSize) + mapBounds.TopLeft.Y,
+				(cellInGrid.X - mapBounds.TopLeft.X) / GridSize * GridSize + mapBounds.TopLeft.X,
+				(cellInGrid.Y - mapBounds.TopLeft.Y) / GridSize * GridSize + mapBounds.TopLeft.Y,
 				cellInGrid.Layer);
 		}
 

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -223,8 +223,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool HasSufficientPowerForActor(ActorInfo actorInfo)
 		{
-			return playerPower == null || (actorInfo.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault)
-				.Sum(p => p.Amount) + playerPower.ExcessPower) >= baseBuilder.Info.MinimumExcessPower;
+			return playerPower == null || actorInfo.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault)
+				.Sum(p => p.Amount) + playerPower.ExcessPower >= baseBuilder.Info.MinimumExcessPower;
 		}
 
 		ActorInfo ChooseBuildingToBuild(ProductionQueue queue)

--- a/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
@@ -186,11 +186,11 @@ namespace OpenRA.Mods.Common.Traits
 
 			var checkRadius = powerDecision.CoarseScanRadius;
 			var fineCheck = powerDecision.FineScanRadius;
-			for (var i = 0 - extendedRange; i <= (checkRadius + extendedRange); i += fineCheck)
+			for (var i = 0 - extendedRange; i <= checkRadius + extendedRange; i += fineCheck)
 			{
 				var x = checkPos.X + i;
 
-				for (var j = 0 - extendedRange; j <= (checkRadius + extendedRange); j += fineCheck)
+				for (var j = 0 - extendedRange; j <= checkRadius + extendedRange; j += fineCheck)
 				{
 					var y = checkPos.Y + j;
 					var pos = world.Map.CenterOfCell(new CPos(x, y));

--- a/OpenRA.Mods.Common/Traits/Crates/GiveCashCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GiveCashCrateAction.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override int GetSelectionShares(Actor collector)
 		{
 			var pr = collector.Owner.PlayerActor.Trait<PlayerResources>();
-			if (info.Amount < 0 && (pr.Cash + pr.Resources) == 0)
+			if (info.Amount < 0 && pr.Cash + pr.Resources == 0)
 				return 0;
 
 			return base.GetSelectionShares(collector);

--- a/OpenRA.Mods.Common/Widgets/LineGraphWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LineGraphWidget.cs
@@ -185,7 +185,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 				var xAxisText = GetXAxisValueFormat().F(n / XAxisTicksPerLabel);
 				var xAxisTickTextWidth = labelFont.Measure(xAxisText).X;
-				var xLocation = x - (xAxisTickTextWidth / 2);
+				var xLocation = x - xAxisTickTextWidth / 2;
 				labelFont.DrawTextWithShadow(xAxisText, graphOrigin + new float2(xLocation, 2), Color.White, BackgroundColorDark, BackgroundColorLight, 1);
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
@@ -58,8 +58,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					layerPreview.ResourceType = resourceType;
 					layerPreview.Bounds.Width = size.Width;
 					layerPreview.Bounds.Height = size.Height;
-					newResourcePreviewTemplate.Bounds.Width = size.Width + (layerPreview.Bounds.X * 2);
-					newResourcePreviewTemplate.Bounds.Height = size.Height + (layerPreview.Bounds.Y * 2);
+					newResourcePreviewTemplate.Bounds.Width = size.Width + layerPreview.Bounds.X * 2;
+					newResourcePreviewTemplate.Bounds.Height = size.Height + layerPreview.Bounds.Y * 2;
 					newResourcePreviewTemplate.IsVisible = () => true;
 					newResourcePreviewTemplate.GetTooltipText = () => resourceType;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ClassicProductionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ClassicProductionLogic.cs
@@ -148,7 +148,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (scrollDown != null)
 			{
 				scrollDown.OnClick = palette.ScrollDown;
-				scrollDown.IsVisible = () => palette.TotalIconCount > (palette.MaxIconRowOffset * palette.Columns);
+				scrollDown.IsVisible = () => palette.TotalIconCount > palette.MaxIconRowOffset * palette.Columns;
 				scrollDown.IsDisabled = () => !palette.CanScrollDown;
 			}
 
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (scrollUp != null)
 			{
 				scrollUp.OnClick = palette.ScrollUp;
-				scrollUp.IsVisible = () => palette.TotalIconCount > (palette.MaxIconRowOffset * palette.Columns);
+				scrollUp.IsVisible = () => palette.TotalIconCount > palette.MaxIconRowOffset * palette.Columns;
 				scrollUp.IsDisabled = () => !palette.CanScrollUp;
 			}
 
@@ -179,7 +179,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			// Check if icon heights exceed y resolution
 			var maxItemsHeight = screenHeight - sidebarProductionHeight;
 
-			var maxIconRowOffest = (maxItemsHeight / productionPalette.IconSize.Y) - 1;
+			var maxIconRowOffest = maxItemsHeight / productionPalette.IconSize.Y - 1;
 			productionPalette.MaxIconRowOffset = Math.Min(maxIconRowOffest, productionPalette.MaximumRows);
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -116,7 +116,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					var power = actor.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(i => i.Amount);
 					powerLabel.Text = power.ToString();
-					powerLabel.GetColor = () => ((pm.PowerProvided - pm.PowerDrained) >= -power || power > 0)
+					powerLabel.GetColor = () => (pm.PowerProvided - pm.PowerDrained >= -power || power > 0)
 						? Color.White : Color.Red;
 					powerLabel.Visible = power != 0;
 					powerIcon.Visible = power != 0;

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -843,7 +843,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (game.State == (int)ServerState.WaitingPlayers && !filters.HasFlag(MPGameFilters.Waiting) && game.Players != 0)
 				return true;
 
-			if ((game.Players + game.Spectators) == 0 && !filters.HasFlag(MPGameFilters.Empty))
+			if (game.Players + game.Spectators == 0 && !filters.HasFlag(MPGameFilters.Empty))
 				return true;
 
 			if (!game.IsCompatible && !filters.HasFlag(MPGameFilters.Incompatible))

--- a/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
@@ -372,7 +372,7 @@ namespace OpenRA.Mods.Common.Widgets
 				var thumbHeight = ContentHeight == 0 ? 0 : Math.Max(MinimumThumbSize, (int)(scrollbarHeight * Math.Min(rb.Height * 1f / ContentHeight, 1f)));
 				var oldOffset = currentListOffset;
 
-				var newOffset = currentListOffset + ((int)((lastMouseLocation.Y - mi.Location.Y) * (ContentHeight - rb.Height) * 1f / (scrollbarHeight - thumbHeight)));
+				var newOffset = currentListOffset + (int)((lastMouseLocation.Y - mi.Location.Y) * (ContentHeight - rb.Height) * 1f / (scrollbarHeight - thumbHeight));
 				newOffset = Math.Min(0, Math.Max(rb.Height - ContentHeight, newOffset));
 				SetListOffset(newOffset, false);
 

--- a/OpenRA.Mods.Common/Widgets/SliderWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SliderWidget.cs
@@ -128,7 +128,7 @@ namespace OpenRA.Mods.Common.Widgets
 			for (var i = 0; i < Ticks; i++)
 			{
 				var tickPos = new float2(
-					trackOrigin + (i * (trackRect.Width - (int)tick.Size.X) / (Ticks - 1)) - tick.Size.X / 2,
+					trackOrigin + i * (trackRect.Width - (int)tick.Size.X) / (Ticks - 1) - tick.Size.X / 2,
 					trackRect.Bottom);
 
 				WidgetUtils.DrawSprite(tick, tickPos);

--- a/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
@@ -584,7 +584,7 @@ namespace OpenRA.Mods.Common.Widgets
 				var highlightEndX = font.Measure(apparentText.Substring(0, visualSelectionEndIndex)).X;
 
 				WidgetUtils.FillRectWithColor(
-					new Rectangle(textPos.X + highlightStartX, textPos.Y, highlightEndX - highlightStartX, Bounds.Height - (verticalMargin * 2)), TextColorHighlight);
+					new Rectangle(textPos.X + highlightStartX, textPos.Y, highlightEndX - highlightStartX, Bounds.Height - verticalMargin * 2), TextColorHighlight);
 			}
 
 			var color =

--- a/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
@@ -409,8 +409,8 @@ namespace OpenRA.Mods.D2k.UtilityCommands
 		{
 			var tileIndex = (int)stream.Position / 4 - 2;
 
-			var x = (tileIndex % mapSize.Width) + MapCordonWidth;
-			var y = (tileIndex / mapSize.Width) + MapCordonWidth;
+			var x = tileIndex % mapSize.Width + MapCordonWidth;
+			var y = tileIndex / mapSize.Width + MapCordonWidth;
 
 			return new CPos(x, y);
 		}


### PR DESCRIPTION
Enforces IDE0048 Add parentheses for clarity
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0047-ide0048

This works in tandem with the existing rule: IDE0047 Remove unnecessary parentheses. I have set the four available `dotnet_style_parentheses` options to settings that best match the prevailing style, but feel free to suggest changes if these seem off. See the docs above for details of the settings.