### PR TITLE
Add support for dark player colors

### DIFF
--- a/OpenRA.Game/Graphics/HardwarePalette.cs
+++ b/OpenRA.Game/Graphics/HardwarePalette.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Graphics
 			{
 				Height = Exts.NextPowerOf2(index + 1);
 				Array.Resize(ref buffer, Height * Palette.Size * 4);
-				Array.Resize(ref colorShiftBuffer, Height * 4);
+				Array.Resize(ref colorShiftBuffer, Height * 8);
 			}
 
 			if (allowModifiers)
@@ -90,19 +90,20 @@ namespace OpenRA.Graphics
 			CopyBufferToTexture();
 		}
 
-		public void SetColorShift(string name, float hueOffset, float satOffset, float minHue, float maxHue)
+		public void SetColorShift(string name, float hueOffset, float satOffset, float valueMultiplier, float minHue, float maxHue)
 		{
 			var index = GetPaletteIndex(name);
-			colorShiftBuffer[4 * index + 0] = hueOffset;
-			colorShiftBuffer[4 * index + 1] = satOffset;
-			colorShiftBuffer[4 * index + 2] = minHue;
-			colorShiftBuffer[4 * index + 3] = maxHue;
+			colorShiftBuffer[8 * index + 0] = minHue;
+			colorShiftBuffer[8 * index + 1] = maxHue;
+			colorShiftBuffer[8 * index + 4] = hueOffset;
+			colorShiftBuffer[8 * index + 5] = satOffset;
+			colorShiftBuffer[8 * index + 6] = valueMultiplier;
 		}
 
 		public bool HasColorShift(string name)
 		{
 			var index = GetPaletteIndex(name);
-			return colorShiftBuffer[4 * index + 2] != 0 || colorShiftBuffer[4 * index + 3] != 0;
+			return colorShiftBuffer[8 * index] != 0 || colorShiftBuffer[8 * index + 1] != 0;
 		}
 
 		public void Initialize()
@@ -125,7 +126,7 @@ namespace OpenRA.Graphics
 		void CopyBufferToTexture()
 		{
 			Texture.SetData(buffer, Palette.Size, Height);
-			ColorShifts.SetFloatData(colorShiftBuffer, 1, Height);
+			ColorShifts.SetFloatData(colorShiftBuffer, 2, Height);
 		}
 
 		public void ApplyModifiers(IEnumerable<IPaletteModifier> paletteMods)

--- a/OpenRA.Game/Graphics/PlayerColorRemap.cs
+++ b/OpenRA.Game/Graphics/PlayerColorRemap.cs
@@ -20,13 +20,14 @@ namespace OpenRA.Graphics
 		readonly int[] remapIndices;
 		readonly float hue;
 		readonly float saturation;
+		readonly float value;
 
 		public PlayerColorRemap(int[] remapIndices, Color color)
 		{
 			this.remapIndices = remapIndices;
 
 			var (r, g, b) = color.ToLinear();
-			(hue, saturation, _) = Color.RgbToHsv(r, g, b);
+			(hue, saturation, value) = Color.RgbToHsv(r, g, b);
 		}
 
 		public Color GetRemappedColor(Color original, int index)
@@ -43,7 +44,7 @@ namespace OpenRA.Graphics
 			var value = Math.Max(Math.Max(r, g), b);
 
 			// Construct the new RGB color
-			(r, g, b) = Color.HsvToRgb(hue, saturation, value);
+			(r, g, b) = Color.HsvToRgb(hue, saturation, value * this.value);
 
 			// Convert linear back to SRGB and pre-multiply by the alpha
 			return Color.FromLinear(original.A, r, g, b);

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -113,9 +113,9 @@ namespace OpenRA.Graphics
 				palettes[name].Palette = pal;
 		}
 
-		public void SetPaletteColorShift(string name, float hueOffset, float satOffset, float minHue, float maxHue)
+		public void SetPaletteColorShift(string name, float hueOffset, float satOffset, float valueModifier, float minHue, float maxHue)
 		{
-			palette.SetColorShift(name, hueOffset, satOffset, minHue, maxHue);
+			palette.SetColorShift(name, hueOffset, satOffset, valueModifier, minHue, maxHue);
 		}
 
 		// PERF: Avoid LINQ.

--- a/glsl/combined.frag
+++ b/glsl/combined.frag
@@ -211,14 +211,16 @@ vec4 SamplePalettedBilinear(float samplerIndex, vec2 coords, vec2 textureSize)
 vec4 ColorShift(vec4 c, float p)
 {
 	#if __VERSION__ == 120
-	vec4 shift = texture2D(ColorShifts, vec2(0.5, p));
+	vec4 range = texture2D(ColorShifts, vec2(0.25, p));
+ 	vec4 shift = texture2D(ColorShifts, vec2(0.75, p));
 	#else
-	vec4 shift = texture(ColorShifts, vec2(0.5, p));
+	vec4 range = texture(ColorShifts, vec2(0.25, p));
+ 	vec4 shift = texture(ColorShifts, vec2(0.75, p));
 	#endif
 
 	vec3 hsv = rgb2hsv(srgb2linear(c).rgb);
-	if (hsv.r >= shift.b && shift.a >= hsv.r)
-		c = linear2srgb(vec4(hsv2rgb(vec3(hsv.r + shift.r, clamp(hsv.g + shift.g, 0.0, 1.0), hsv.b)), c.a));
+	if (hsv.r > range.r && range.g >= hsv.r)
+		c = linear2srgb(vec4(hsv2rgb(vec3(hsv.r + shift.r, clamp(hsv.g + shift.g, 0.0, 1.0), hsv.b * clamp(shift.b, 0.0, 1.0))), c.a));
 
 	return c;
 }


### PR DESCRIPTION
Follows up #19335
Partly addresses #20415

Some info on HSV color model:
- H - hue  (0° to 360°)
- S - saturation (0% - 100%)
- V - value (0% - 100%)
   - V has the simplest conversion from RGB, it's the value of the most pronounced color amongst the 3
- When stored all are reduced to 0 - 1 float range

This PR adds support for player color brightness. The remapping is done by taking the hue and saturation from the player color, and for brightness multiplying V's of the remapped pixel and player color. In other words multiplying 2 percentages.

As a testcase I included the new WIP color picker. Both the color picker and validator aren't ready yet and will be done in follow up PR's