### PR TITLE
Remove workaround for old versions of mono.

### DIFF
--- a/OpenRA.Game/Primitives/ObservableCollection.cs
+++ b/OpenRA.Game/Primitives/ObservableCollection.cs
@@ -20,10 +20,7 @@ namespace OpenRA.Primitives
 	{
 		public event Action<IObservableCollection, object> OnAdd = (x, k) => { };
 
-		// TODO Workaround for https://github.com/OpenRA/OpenRA/issues/6101
-		#pragma warning disable 67
 		public event Action<IObservableCollection, object> OnRemove = (x, k) => { };
-		#pragma warning restore
 		public event Action<IObservableCollection, int> OnRemoveAt = (x, i) => { };
 		public event Action<IObservableCollection, object, object> OnSet = (x, o, n) => { };
 		public event Action<IObservableCollection> OnRefresh = x => { };

--- a/OpenRA.Game/Primitives/ObservableDictionary.cs
+++ b/OpenRA.Game/Primitives/ObservableDictionary.cs
@@ -36,11 +36,8 @@ namespace OpenRA.Primitives
 		public event Action<IObservableCollection, object> OnAdd = (x, k) => { };
 		public event Action<IObservableCollection, object> OnRemove = (x, k) => { };
 
-		// TODO Workaround for https://github.com/OpenRA/OpenRA/issues/6101
-		#pragma warning disable 67
 		public event Action<IObservableCollection, int> OnRemoveAt = (x, i) => { };
 		public event Action<IObservableCollection, object, object> OnSet = (x, o, n) => { };
-		#pragma warning restore
 		public event Action<IObservableCollection> OnRefresh = x => { };
 
 		protected void FireOnRefresh()

--- a/OpenRA.Game/Primitives/ObservableList.cs
+++ b/OpenRA.Game/Primitives/ObservableList.cs
@@ -22,11 +22,8 @@ namespace OpenRA.Primitives
 		public event Action<IObservableCollection, object> OnAdd = (x, k) => { };
 		public event Action<IObservableCollection, object> OnRemove = (x, k) => { };
 
-		// TODO Workaround for https://github.com/OpenRA/OpenRA/issues/6101
-		#pragma warning disable 67
 		public event Action<IObservableCollection, int> OnRemoveAt = (x, i) => { };
 		public event Action<IObservableCollection, object, object> OnSet = (x, o, n) => { };
-		#pragma warning restore
 		public event Action<IObservableCollection> OnRefresh = x => { };
 
 		protected void FireOnRefresh()


### PR DESCRIPTION
Removes workaround added in #6313 to deal with #6101.