### PR TITLE
Fix return fire logic ignoring AutoAttack priotities

### DIFF
--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -256,6 +256,15 @@ namespace OpenRA.Mods.Common.Traits
 			if (attacker.AppearsFriendlyTo(self))
 				return;
 
+			// Respect AutoAttack priorities.
+			if (stance > UnitStance.ReturnFire)
+			{
+				var autoTarget = ScanForTarget(self, allowMove, true);
+
+				if (autoTarget != Target.Invalid)
+					attacker = autoTarget.Actor;
+			}
+
 			Aggressor = attacker;
 
 			Attack(Target.FromActor(Aggressor), allowMove);


### PR DESCRIPTION
Closes #20731

Change when stop order is given:
-When stance is return fire, units keeps retaliating.
-When you change to defense it's keeps retaliating till you give the order.
-Once the order is given it retargets to the closest unit.

If you go back to returnfire it retaliate again.