### PR TITLE
Resurrect old color picker

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -529,10 +529,11 @@ namespace OpenRA.Mods.Common.Server
 					};
 
 					// Pick a random color for the bot
-					var colorManager = server.ModData.DefaultRules.Actors[SystemActors.World].TraitInfo<ColorPickerManagerInfo>();
+					var colorManager = server.ModData.DefaultRules.Actors[SystemActors.World].TraitInfo<IColorPickerManagerInfo>();
 					var terrainColors = server.ModData.DefaultTerrainInfo[server.Map.TileSet].RestrictedPlayerColors;
 					var playerColors = server.LobbyInfo.Clients.Select(c => c.Color)
 						.Concat(server.Map.Players.Players.Values.Select(p => p.Color));
+
 					bot.Color = bot.PreferredColor = colorManager.RandomPresetColor(server.Random, terrainColors, playerColors);
 
 					server.LobbyInfo.Clients.Add(bot);
@@ -1239,7 +1240,7 @@ namespace OpenRA.Mods.Common.Server
 		{
 			lock (server.LobbyInfo)
 			{
-				var colorManager = server.ModData.DefaultRules.Actors[SystemActors.World].TraitInfo<ColorPickerManagerInfo>();
+				var colorManager = server.ModData.DefaultRules.Actors[SystemActors.World].TraitInfo<IColorPickerManagerInfo>();
 				var askColor = askedColor;
 
 				void OnError(string message)

--- a/OpenRA.Mods.Common/Traits/World/ColorPickerManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/ColorPickerManager.cs
@@ -12,15 +12,18 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Widgets;
 using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Traits;
+using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World)]
 	[Desc("Configuration options for the lobby player color picker. Attach this to the world actor.")]
-	public class ColorPickerManagerInfo : TraitInfo<ColorPickerManager>
+	public class ColorPickerManagerInfo : TraitInfo<ColorPickerManager>, IColorPickerManagerInfo
 	{
 		[TranslationReference]
 		const string PlayerColorTerrain = "notification-player-color-terrain";
@@ -52,9 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 			"A dictionary of [faction name]: [actor name].")]
 		public readonly Dictionary<string, string> FactionPreviewActors = new Dictionary<string, string>();
 
-		public Color Color;
-
-		bool TryGetBlockingColor((float R, float G, float B) color, List<(float R, float G, float B)> candidateBlockers, out (float R, float G, float B) closestBlocker)
+		public bool TryGetBlockingColor((float R, float G, float B) color, List<(float R, float G, float B)> candidateBlockers, out (float R, float G, float B) closestBlocker)
 		{
 			var closestDistance = SimilarityThreshold;
 			closestBlocker = default;
@@ -80,40 +81,6 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			return closestDistance < SimilarityThreshold;
-		}
-
-		public Color RandomPresetColor(MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors)
-		{
-			var terrainLinear = terrainColors.Select(c => c.ToLinear()).ToList();
-			var playerLinear = playerColors.Select(c => c.ToLinear()).ToList();
-
-			foreach (var color in PresetColors.Shuffle(random))
-			{
-				// Color may already be taken
-				var linear = color.ToLinear();
-				if (!TryGetBlockingColor(linear, terrainLinear, out _) && !TryGetBlockingColor(linear, playerLinear, out _))
-					return color;
-			}
-
-			// Fall back to a random non-preset color
-			var randomHue = random.NextFloat();
-			var randomSat = float2.Lerp(HsvSaturationRange[0], HsvSaturationRange[1], random.NextFloat());
-			var randomVal = float2.Lerp(HsvValueRange[0], HsvValueRange[1], random.NextFloat());
-			return MakeValid(randomHue, randomSat, randomVal, random, terrainLinear, playerLinear, null);
-		}
-
-		public Color RandomValidColor(MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors)
-		{
-			var h = random.NextFloat();
-			var s = float2.Lerp(HsvSaturationRange[0], HsvSaturationRange[1], random.NextFloat());
-			var v = float2.Lerp(HsvValueRange[0], HsvValueRange[1], random.NextFloat());
-			return MakeValid(h, s, v, random, terrainColors, playerColors, null);
-		}
-
-		public Color MakeValid(Color color, MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors, Action<string> onError = null)
-		{
-			var (_, h, s, v) = color.ToAhsv();
-			return MakeValid(h, s, v, random, terrainColors, playerColors, onError);
 		}
 
 		Color MakeValid(float hue, float sat, float val, MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors, Action<string> onError)
@@ -164,6 +131,97 @@ namespace OpenRA.Mods.Common.Traits
 			var randomVal = float2.Lerp(HsvValueRange[0], HsvValueRange[1], random.NextFloat());
 			return Color.FromAhsv(random.NextFloat(), randomSat, randomVal);
 		}
+
+		#region IColorPickerManagerInfo
+
+		public event Action<Color> OnColorPickerColorUpdate;
+
+		(float sMin, float sMax) IColorPickerManagerInfo.SaturationRange => (HsvSaturationRange[0], HsvSaturationRange[1]);
+		(float vMin, float vMax) IColorPickerManagerInfo.ValueRange => (HsvValueRange[0], HsvValueRange[1]);
+
+		Color[] IColorPickerManagerInfo.PresetColors => PresetColors;
+
+		Color IColorPickerManagerInfo.RandomPresetColor(MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors)
+		{
+			var terrainLinear = terrainColors.Select(c => c.ToLinear()).ToList();
+			var playerLinear = playerColors.Select(c => c.ToLinear()).ToList();
+
+			foreach (var color in PresetColors.Shuffle(random))
+			{
+				// Color may already be taken
+				var linear = color.ToLinear();
+				if (!TryGetBlockingColor(linear, terrainLinear, out _) && !TryGetBlockingColor(linear, playerLinear, out _))
+					return color;
+			}
+
+			// Fall back to a random non-preset color
+			var randomHue = random.NextFloat();
+			var randomSat = float2.Lerp(HsvSaturationRange[0], HsvSaturationRange[1], random.NextFloat());
+			var randomVal = float2.Lerp(HsvValueRange[0], HsvValueRange[1], random.NextFloat());
+			return MakeValid(randomHue, randomSat, randomVal, random, terrainLinear, playerLinear, null);
+		}
+
+		Color IColorPickerManagerInfo.MakeValid(Color color, MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors, Action<string> onError)
+		{
+			var (_, h, s, v) = color.ToAhsv();
+			return MakeValid(h, s, v, random, terrainColors, playerColors, onError);
+		}
+
+		Color IColorPickerManagerInfo.RandomValidColor(MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors)
+		{
+			var h = random.NextFloat();
+			var s = float2.Lerp(HsvSaturationRange[0], HsvSaturationRange[1], random.NextFloat());
+			var v = float2.Lerp(HsvValueRange[0], HsvValueRange[1], random.NextFloat());
+			return MakeValid(h, s, v, random, terrainColors, playerColors, null);
+		}
+
+		void IColorPickerManagerInfo.ShowColorDropDown(DropDownButtonWidget dropdownButton, Color initialColor, string initialFaction, WorldRenderer worldRenderer, Action<Color> onExit)
+		{
+			dropdownButton.RemovePanel();
+
+			// We do not want to force other ColorPickerManager implementations to have an Actor preview.
+			// We achieve this by fully encapsulating its initialisation.
+			void AddActorPreview(Widget parent)
+			{
+				var preview = parent.GetOrNull<ActorPreviewWidget>("PREVIEW");
+				if (preview == null)
+					return;
+
+				if (initialFaction == null || !FactionPreviewActors.TryGetValue(initialFaction, out var actorType))
+				{
+					if (PreviewActor == null)
+						throw new YamlException($"{nameof(ColorPickerManager)} does not define a preview actor" + (initialFaction == null ? "." : $"for faction {initialFaction}."));
+
+					actorType = PreviewActor;
+				}
+
+				var actor = worldRenderer.World.Map.Rules.Actors[actorType];
+
+				var td = new TypeDictionary
+				{
+					new OwnerInit(worldRenderer.World.WorldActor.Owner),
+					new FactionInit(worldRenderer.World.WorldActor.Owner.PlayerReference.Faction)
+				};
+
+				foreach (var api in actor.TraitInfos<IActorPreviewInitInfo>())
+					foreach (var o in api.ActorPreviewInits(actor, ActorPreviewType.ColorPicker))
+						td.Add(o);
+
+				preview.SetPreview(actor, td);
+			}
+
+			var finalColor = initialColor;
+			var colorChooser = Game.LoadWidget(worldRenderer.World, "COLOR_CHOOSER", null, new WidgetArgs()
+			{
+				{ "onChange", (Action<Color>)(c => { finalColor = c; OnColorPickerColorUpdate(c); }) },
+				{ "initialColor", initialColor },
+				{ "extraLogic", (Action<Widget>)AddActorPreview },
+			});
+
+			dropdownButton.AttachPanel(colorChooser, () => onExit(finalColor));
+		}
+
+		#endregion
 	}
 
 	public class ColorPickerManager { }

--- a/OpenRA.Mods.Common/Traits/World/ColorPickerManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/ColorPickerManager.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World)]
 	[Desc("Configuration options for the lobby player color picker. Attach this to the world actor.")]
-	public class ColorPickerManagerInfo : TraitInfo<ColorPickerManager>, IRulesetLoaded
+	public class ColorPickerManagerInfo : TraitInfo<ColorPickerManager>
 	{
 		[TranslationReference]
 		const string PlayerColorTerrain = "notification-player-color-terrain";
@@ -34,17 +34,14 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Minimum and maximum saturation levels that are valid for use.")]
 		public readonly float[] HsvSaturationRange = { 0.3f, 0.95f };
 
-		[Desc("HSV value component for player colors.")]
-		public readonly float V = 0.95f;
+		[Desc("Minimum and maximum value levels that are valid for use.")]
+		public readonly float[] HsvValueRange = { 0.3f, 0.95f };
 
 		[Desc("Perceptual color threshold for determining whether two colors are too similar.")]
 		public readonly float SimilarityThreshold = 0.314f;
 
-		[Desc("List of hue components for the preset colors in the palette tab. Each entry must have a corresponding PresetSaturations definition.")]
-		public readonly float[] PresetHues = Array.Empty<float>();
-
-		[Desc("List of saturation components for the preset colors in the palette tab. Each entry must have a corresponding PresetHues definition.")]
-		public readonly float[] PresetSaturations = Array.Empty<float>();
+		[Desc("List of colors to be displayed in the palette tab.")]
+		public readonly Color[] PresetColors = Array.Empty<Color>();
 
 		[ActorReference]
 		[Desc("Actor type to show in the color picker. This can be overridden for specific factions with FactionPreviewActors.")]
@@ -54,18 +51,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Actor type to show in the color picker for specific factions. Overrides PreviewActor.",
 			"A dictionary of [faction name]: [actor name].")]
 		public readonly Dictionary<string, string> FactionPreviewActors = new Dictionary<string, string>();
-
-		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
-		{
-			if (PresetHues.Length != PresetSaturations.Length)
-				throw new YamlException("PresetHues and PresetSaturations must have the same number of elements.");
-		}
-
-		public IEnumerable<Color> PresetColors()
-		{
-			for (var i = 0; i < PresetHues.Length; i++)
-				yield return Color.FromAhsv(PresetHues[i], PresetSaturations[i], V);
-		}
 
 		public Color Color;
 
@@ -102,60 +87,56 @@ namespace OpenRA.Mods.Common.Traits
 			var terrainLinear = terrainColors.Select(c => c.ToLinear()).ToList();
 			var playerLinear = playerColors.Select(c => c.ToLinear()).ToList();
 
-			if (PresetHues.Length > 0)
+			foreach (var color in PresetColors.Shuffle(random))
 			{
-				foreach (var i in Exts.MakeArray(PresetHues.Length, x => x).Shuffle(random))
-				{
-					var h = PresetHues[i];
-					var s = PresetSaturations[i];
-					var preset = Color.FromAhsv(h, s, V);
-
-					// Color may already be taken
-					var linear = preset.ToLinear();
-					if (!TryGetBlockingColor(linear, terrainLinear, out _) && !TryGetBlockingColor(linear, playerLinear, out _))
-						return preset;
-				}
+				// Color may already be taken
+				var linear = color.ToLinear();
+				if (!TryGetBlockingColor(linear, terrainLinear, out _) && !TryGetBlockingColor(linear, playerLinear, out _))
+					return color;
 			}
 
 			// Fall back to a random non-preset color
 			var randomHue = random.NextFloat();
 			var randomSat = float2.Lerp(HsvSaturationRange[0], HsvSaturationRange[1], random.NextFloat());
-			return MakeValid(randomHue, randomSat, random, terrainLinear, playerLinear, null);
+			var randomVal = float2.Lerp(HsvValueRange[0], HsvValueRange[1], random.NextFloat());
+			return MakeValid(randomHue, randomSat, randomVal, random, terrainLinear, playerLinear, null);
 		}
 
 		public Color RandomValidColor(MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors)
 		{
 			var h = random.NextFloat();
 			var s = float2.Lerp(HsvSaturationRange[0], HsvSaturationRange[1], random.NextFloat());
-			return MakeValid(h, s, random, terrainColors, playerColors, null);
+			var v = float2.Lerp(HsvValueRange[0], HsvValueRange[1], random.NextFloat());
+			return MakeValid(h, s, v, random, terrainColors, playerColors, null);
 		}
 
 		public Color MakeValid(Color color, MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors, Action<string> onError = null)
 		{
-			var (_, h, s, _) = color.ToAhsv();
-			return MakeValid(h, s, random, terrainColors, playerColors, onError);
+			var (_, h, s, v) = color.ToAhsv();
+			return MakeValid(h, s, v, random, terrainColors, playerColors, onError);
 		}
 
-		Color MakeValid(float hue, float sat, MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors, Action<string> onError)
+		Color MakeValid(float hue, float sat, float val, MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors, Action<string> onError)
 		{
 			var terrainLinear = terrainColors.Select(c => c.ToLinear()).ToList();
 			var playerLinear = playerColors.Select(c => c.ToLinear()).ToList();
 
-			return MakeValid(hue, sat, random, terrainLinear, playerLinear, onError);
+			return MakeValid(hue, sat, val, random, terrainLinear, playerLinear, onError);
 		}
 
-		Color MakeValid(float hue, float sat, MersenneTwister random, List<(float R, float G, float B)> terrainLinear, List<(float R, float G, float B)> playerLinear, Action<string> onError)
+		Color MakeValid(float hue, float sat, float val, MersenneTwister random, List<(float R, float G, float B)> terrainLinear, List<(float R, float G, float B)> playerLinear, Action<string> onError)
 		{
 			// Clamp saturation without triggering a warning
 			// This can only happen due to rounding errors (common) or modified clients (rare)
 			sat = sat.Clamp(HsvSaturationRange[0], HsvSaturationRange[1]);
+			val = val.Clamp(HsvValueRange[0], HsvValueRange[1]);
 
 			// Limit to 100 attempts, which is enough to move all the way around the hue range
 			string errorMessage = null;
 			var stepSign = 0;
 			for (var i = 0; i < 101; i++)
 			{
-				var linear = Color.FromAhsv(hue, sat, V).ToLinear();
+				var linear = Color.FromAhsv(hue, sat, val).ToLinear();
 				if (TryGetBlockingColor(linear, terrainLinear, out var blocker))
 					errorMessage = PlayerColorTerrain;
 				else if (TryGetBlockingColor(linear, playerLinear, out blocker))
@@ -165,7 +146,7 @@ namespace OpenRA.Mods.Common.Traits
 					if (errorMessage != null)
 						onError?.Invoke(errorMessage);
 
-					return Color.FromAhsv(hue, sat, V);
+					return Color.FromAhsv(hue, sat, val);
 				}
 
 				// Pick a direction based on the first blocking color and step in hue
@@ -179,7 +160,9 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Failed to find a solution within a reasonable time: return a random color without any validation
 			onError?.Invoke(InvalidPlayerColor);
-			return Color.FromAhsv(random.NextFloat(), float2.Lerp(HsvSaturationRange[0], HsvSaturationRange[1], random.NextFloat()), V);
+			var randomSat = float2.Lerp(HsvSaturationRange[0], HsvSaturationRange[1], random.NextFloat());
+			var randomVal = float2.Lerp(HsvValueRange[0], HsvValueRange[1], random.NextFloat());
+			return Color.FromAhsv(random.NextFloat(), randomSat, randomVal);
 		}
 	}
 

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -16,7 +16,9 @@ using OpenRA.Graphics;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Common.Terrain;
+using OpenRA.Mods.Common.Widgets;
 using OpenRA.Primitives;
+using OpenRA.Support;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -288,6 +290,18 @@ namespace OpenRA.Mods.Common.Traits
 	public interface IProvidesAssetBrowserColorPickerPalettes
 	{
 		IEnumerable<string> ColorPickerPaletteNames { get; }
+	}
+
+	public interface IColorPickerManagerInfo : ITraitInfoInterface
+	{
+		(float sMin, float sMax) SaturationRange { get; }
+		(float vMin, float vMax) ValueRange { get; }
+		event Action<Color> OnColorPickerColorUpdate;
+		Color[] PresetColors { get; }
+		Color RandomPresetColor(MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors);
+		Color RandomValidColor(MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors);
+		Color MakeValid(Color color, MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors, Action<string> onError = null);
+		void ShowColorDropDown(DropDownButtonWidget dropdownButton, Color initialColor, string initialFaction, WorldRenderer worldRenderer, Action<Color> onExit);
 	}
 
 	public interface ICallForTransport

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20221203/AddColorPickerValueRange.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20221203/AddColorPickerValueRange.cs
@@ -1,0 +1,48 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Primitives;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class AddColorPickerValueRange : UpdateRule
+	{
+		public override string Name => "ColorPickerManager's PresetHues, PresetSaturations and V were replaced with PresetColors.";
+
+		public override string Description =>
+			"Each preset color can now have their brightness specified.";
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var manager = actorNode.LastChildMatching("ColorPickerManager");
+			if (manager == null)
+				yield break;
+
+			var v = manager.LastChildMatching("V")?.NodeValue<float>() ?? 0.95f;
+			var hues = manager.LastChildMatching("PresetHues")?.NodeValue<float[]>();
+			var saturations = manager.LastChildMatching("PresetSaturations")?.NodeValue<float[]>();
+
+			manager.RemoveNodes("V");
+			manager.RemoveNodes("PresetHues");
+			manager.RemoveNodes("PresetSaturations");
+
+			if (hues == null || saturations == null)
+				yield break;
+
+			var colors = new Color[hues.Length];
+			for (var i = 0; i < colors.Length; i++)
+				colors[i] = Color.FromAhsv(hues[i], saturations[i], v);
+
+			manager.AddNode("PresetColors", colors);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public float H { get; private set; }
 		public float S { get; private set; }
 		public float V { get; private set; }
-		float minSat, maxSat;
+		float minSat, maxSat, minVal, maxVal;
 
 		Sheet mixerSheet;
 		Sprite mixerSprite;
@@ -37,7 +37,6 @@ namespace OpenRA.Mods.Common.Widgets
 		public ColorMixerWidget(ModData modData)
 		{
 			modRules = modData.DefaultRules;
-			V = 1.0f;
 		}
 
 		public ColorMixerWidget(ColorMixerWidget other)
@@ -51,13 +50,19 @@ namespace OpenRA.Mods.Common.Widgets
 			V = other.V;
 			minSat = other.minSat;
 			maxSat = other.maxSat;
+			minVal = other.minVal;
+			maxVal = other.maxVal;
 		}
 
-		public void SetColorLimits(float minSaturation, float maxSaturation, float v)
+		public void SetColorLimits(float minSaturation, float maxSaturation, float minValue, float maxValue, float? newHue = null)
 		{
 			minSat = minSaturation;
 			maxSat = maxSaturation;
-			V = v;
+			minVal = minValue;
+			maxVal = maxValue;
+
+			if (newHue == null)
+				newHue = H;
 
 			var buffer = new byte[4 * 256 * 256];
 			unsafe
@@ -66,19 +71,25 @@ namespace OpenRA.Mods.Common.Widgets
 				fixed (byte* cc = &buffer[0])
 				{
 					var c = (int*)cc;
-					for (var s = 0; s < 256; s++)
-						for (var h = 0; h < 256; h++)
+					for (var v = 0; v < 256; v++)
+					{
+						for (var s = 0; s < 256; s++)
 						{
 							#pragma warning disable IDE0047
-							(*(c + s * 256 + h)) = Color.FromAhsv(h / 255f, 1 - s / 255f, V).ToArgb();
+							(*(c + s * 256 + v)) = Color.FromAhsv(newHue.Value, 1 - s / 255f, v / 255f).ToArgb();
 							#pragma warning restore IDE0047
 						}
+					}
 				}
 			}
 
-			var rect = new Rectangle(0, (int)(255 * (1 - maxSat)), 255, (int)(255 * (maxSat - minSat)) + 1);
-			mixerSprite = new Sprite(mixerSheet, rect, TextureChannel.RGBA);
+			var rect = new Rectangle(
+				(int)(255 * minVal),
+				(int)(255 * (1 - maxSat)),
+				(int)(255 * (maxVal - minVal)),
+				(int)(255 * (maxSat - minSat)) + 1);
 
+			mixerSprite = new Sprite(mixerSheet, rect, TextureChannel.RGBA);
 			mixerSheet.GetTexture().SetData(buffer, 256, 256);
 		}
 
@@ -87,7 +98,7 @@ namespace OpenRA.Mods.Common.Widgets
 			base.Initialize(args);
 
 			mixerSheet = new Sheet(SheetType.BGRA, new Size(256, 256));
-			SetColorLimits(minSat, maxSat, V);
+			SetColorLimits(minSat, maxSat, minVal, maxVal);
 		}
 
 		public override void Draw()
@@ -103,17 +114,17 @@ namespace OpenRA.Mods.Common.Widgets
 		void SetValueFromPx(int2 xy)
 		{
 			var rb = RenderBounds;
-			var h = xy.X * 1f / rb.Width;
+			var v = float2.Lerp(minVal, maxVal, xy.X * 1f / rb.Width);
 			var s = float2.Lerp(minSat, maxSat, 1 - xy.Y * 1f / rb.Height);
-			H = h.Clamp(0, 1f);
+			V = v.Clamp(minVal, maxVal);
 			S = s.Clamp(minSat, maxSat);
 		}
 
 		int2 PxFromValue()
 		{
 			var rb = RenderBounds;
-			var x = RenderBounds.Width * H;
-			var y = RenderBounds.Height * (1 - (S - minSat) / (maxSat - minSat));
+			var x = rb.Width * (V - minVal) / (maxVal - minVal);
+			var y = rb.Height * (1 - (S - minSat) / (maxSat - minSat));
 			return new int2((int)x.Clamp(0, rb.Width), (int)y.Clamp(0, rb.Height));
 		}
 
@@ -162,12 +173,13 @@ namespace OpenRA.Mods.Common.Widgets
 		/// </summary>
 		public void Set(Color color)
 		{
-			var (_, h, s, _) = color.ToAhsv();
+			var (_, h, s, v) = color.ToAhsv();
 
-			if (H != h || S != s)
+			if (H != h || S != s || V != v)
 			{
 				H = h;
 				S = s.Clamp(minSat, maxSat);
+				V = v.Clamp(minVal, maxVal);
 				OnChange();
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/HueSliderWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/HueSliderWidget.cs
@@ -1,0 +1,69 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Graphics;
+using OpenRA.Primitives;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets
+{
+	public class HueSliderWidget : SliderWidget
+	{
+		Sprite hueSprite;
+		Sprite pickerSprite;
+
+		public HueSliderWidget() { }
+		public HueSliderWidget(HueSliderWidget other)
+			: base(other) { }
+
+		public override void Initialize(WidgetArgs args)
+		{
+			base.Initialize(args);
+
+			var hueSheet = new Sheet(SheetType.BGRA, new Size(256, 1));
+
+			var buffer = new byte[4 * 256];
+
+			unsafe
+			{
+				fixed (byte* cc = &buffer[0])
+				{
+					var c = (int*)cc;
+					for (var h = 0; h < 256; h++)
+					{
+						#pragma warning disable IDE0047
+						(*(c + 0 * 256 + h)) = Color.FromAhsv(h / 255f, 1, 1).ToArgb();
+						#pragma warning restore IDE0047
+					}
+				}
+			}
+
+			var rect = new Rectangle(0, 0, 256, 1);
+			hueSprite = new Sprite(hueSheet, new Rectangle(0, 0, 256, 1), TextureChannel.RGBA);
+			hueSheet.GetTexture().SetData(buffer, 256, 1);
+
+			pickerSprite = ChromeProvider.GetImage("lobby-bits", "huepicker");
+		}
+
+		public override void Draw()
+		{
+			if (!IsVisible())
+				return;
+
+			var ro = RenderOrigin;
+			var rb = RenderBounds;
+			WidgetUtils.DrawSprite(hueSprite, ro, rb.Size);
+
+			var pos = RenderOrigin + new int2(PxFromValue(Value).Clamp(0, rb.Width - 1) - (int)pickerSprite.Size.X / 2, (rb.Height - (int)pickerSprite.Size.Y) / 2);
+			WidgetUtils.DrawSprite(pickerSprite, pos);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -177,16 +177,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				panel.GetOrNull<LabelWidget>("PALETTE_DESC").IsVisible = () => currentSprites != null || currentVoxel != null;
 			}
 
-			var colorManager = modData.DefaultRules.Actors[SystemActors.World].TraitInfo<ColorPickerManagerInfo>();
-			colorManager.Color = Game.Settings.Player.Color;
+			var colorManager = modData.DefaultRules.Actors[SystemActors.World].TraitInfo<IColorPickerManagerInfo>();
 
 			var colorDropdown = panel.GetOrNull<DropDownButtonWidget>("COLOR");
 			if (colorDropdown != null)
 			{
+				var color = Game.Settings.Player.Color;
 				colorDropdown.IsDisabled = () => !colorPickerPalettes.Contains(currentPalette);
-				colorDropdown.OnMouseDown = _ => ColorPickerLogic.ShowColorDropDown(colorDropdown, colorManager, worldRenderer);
+				colorDropdown.OnMouseDown = _ => colorManager.ShowColorDropDown(colorDropdown, color, null, worldRenderer, c => color = c);
 				colorDropdown.IsVisible = () => currentSprites != null || currentVoxel != null;
-				panel.Get<ColorBlockWidget>("COLORBLOCK").GetColor = () => colorManager.Color;
+
+				panel.Get<ColorBlockWidget>("COLORBLOCK").GetColor = () => color;
 			}
 
 			filenameInput = panel.Get<TextFieldWidget>("FILENAME_INPUT");

--- a/OpenRA.Mods.Common/Widgets/Logic/IntroductionPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/IntroductionPromptLogic.cs
@@ -76,9 +76,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return true;
 			};
 
-			var colorManager = modData.DefaultRules.Actors[SystemActors.World].TraitInfo<ColorPickerManagerInfo>();
-			colorManager.Color = ps.Color;
-
 			var mouseControlDescClassic = widget.Get("MOUSE_CONTROL_DESC_CLASSIC");
 			mouseControlDescClassic.IsVisible = () => gs.UseClassicMouseStyle;
 
@@ -114,11 +111,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			SettingsUtils.BindCheckboxPref(widget, "EDGESCROLL_CHECKBOX", gs, "ViewportEdgeScroll");
 
+			var colorManager = modData.DefaultRules.Actors[SystemActors.World].TraitInfo<IColorPickerManagerInfo>();
+
 			var colorDropdown = widget.Get<DropDownButtonWidget>("PLAYERCOLOR");
 			colorDropdown.IsDisabled = () => worldRenderer.World.Type != WorldType.Shellmap;
-			colorDropdown.OnMouseDown = _ => ColorPickerLogic.ShowColorDropDown(colorDropdown, colorManager, worldRenderer, () =>
+			colorDropdown.OnMouseDown = _ => colorManager.ShowColorDropDown(colorDropdown, ps.Color, null, worldRenderer, color =>
 			{
-				Game.Settings.Player.Color = colorManager.Color;
+				ps.Color = color;
 				Game.Settings.Save();
 			});
 			colorDropdown.Get<ColorBlockWidget>("COLORBLOCK").GetColor = () => ps.Color;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		readonly Dictionary<string, LobbyFaction> factions = new Dictionary<string, LobbyFaction>();
 
-		readonly ColorPickerManagerInfo colorManager;
+		readonly IColorPickerManagerInfo colorManager;
 
 		readonly TabCompletionLogic tabCompletion = new TabCompletionLogic();
 
@@ -198,8 +198,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			editableSpectatorTemplate = players.Get("TEMPLATE_EDITABLE_SPECTATOR");
 			nonEditableSpectatorTemplate = players.Get("TEMPLATE_NONEDITABLE_SPECTATOR");
 			newSpectatorTemplate = players.Get("TEMPLATE_NEW_SPECTATOR");
-			colorManager = modRules.Actors[SystemActors.World].TraitInfo<ColorPickerManagerInfo>();
-			colorManager.Color = Game.Settings.Player.Color;
+			colorManager = modRules.Actors[SystemActors.World].TraitInfo<IColorPickerManagerInfo>();
 
 			foreach (var f in modRules.Actors[SystemActors.World].TraitInfos<FactionInfo>())
 				factions.Add(f.InternalName, new LobbyFaction { Selectable = f.Selectable, Name = f.Name, Side = f.Side, Description = f.Description });

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -241,31 +241,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			dropdown.ShowDropDown("FACTION_DROPDOWN_TEMPLATE", 154, options, SetupItem);
 		}
 
-		public static void ShowColorDropDown(DropDownButtonWidget color, Session.Client client,
-			OrderManager orderManager, WorldRenderer worldRenderer, ColorPickerManagerInfo colorManager)
-		{
-			void OnExit()
-			{
-				if (client == orderManager.LocalClient)
-				{
-					Game.Settings.Player.Color = colorManager.Color;
-					Game.Settings.Save();
-				}
-
-				color.RemovePanel();
-				orderManager.IssueOrder(Order.Command($"color {client.Index} {colorManager.Color}"));
-			}
-
-			var colorChooser = Game.LoadWidget(worldRenderer.World, "COLOR_CHOOSER", null, new WidgetArgs()
-			{
-				{ "onChange", (Action<Color>)(c => colorManager.Color = c) },
-				{ "initialColor", client.Color },
-				{ "initialFaction", client.Faction }
-			});
-
-			color.AttachPanel(colorChooser, OnExit);
-		}
-
 		public static void SelectSpawnPoint(OrderManager orderManager, MapPreviewWidget mapPreview, MapPreview preview, MouseInput mi)
 		{
 			if (orderManager.LocalClient.State == Session.ClientState.Ready)
@@ -544,13 +519,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 		}
 
-		public static void SetupEditableColorWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, WorldRenderer worldRenderer, ColorPickerManagerInfo colorManager)
+		public static void SetupEditableColorWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, WorldRenderer worldRenderer, IColorPickerManagerInfo colorManager)
 		{
-			var color = parent.Get<DropDownButtonWidget>("COLOR");
-			color.IsDisabled = () => (s != null && s.LockColor) || orderManager.LocalClient.IsReady;
-			color.OnMouseDown = _ => ShowColorDropDown(color, c, orderManager, worldRenderer, colorManager);
+			var colorDropdown = parent.Get<DropDownButtonWidget>("COLOR");
+			colorDropdown.IsDisabled = () => (s != null && s.LockColor) || orderManager.LocalClient.IsReady;
+			colorDropdown.OnMouseDown = _ => colorManager.ShowColorDropDown(colorDropdown, c.Color, c.Faction, worldRenderer, color =>
+			{
+				if (c == orderManager.LocalClient)
+				{
+					Game.Settings.Player.Color = color;
+					Game.Settings.Save();
+				}
 
-			SetupColorWidget(color, c);
+				orderManager.IssueOrder(Order.Command($"color {c.Index} {color}"));
+			});
+
+			SetupColorWidget(colorDropdown, c);
 		}
 
 		public static void SetupColorWidget(Widget parent, Session.Client c)

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -268,14 +268,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return true;
 			};
 
-			var colorManager = modData.DefaultRules.Actors[SystemActors.World].TraitInfo<ColorPickerManagerInfo>();
-			colorManager.Color = ps.Color;
+			var colorManager = modData.DefaultRules.Actors[SystemActors.World].TraitInfo<IColorPickerManagerInfo>();
 
 			var colorDropdown = panel.Get<DropDownButtonWidget>("PLAYERCOLOR");
 			colorDropdown.IsDisabled = () => worldRenderer.World.Type != WorldType.Shellmap;
-			colorDropdown.OnMouseDown = _ => ColorPickerLogic.ShowColorDropDown(colorDropdown, colorManager, worldRenderer, () =>
+			colorDropdown.OnMouseDown = _ => colorManager.ShowColorDropDown(colorDropdown, ps.Color, null, worldRenderer, color =>
 			{
-				Game.Settings.Player.Color = colorManager.Color;
+				ps.Color = color;
 				Game.Settings.Save();
 			});
 			colorDropdown.Get<ColorBlockWidget>("COLORBLOCK").GetColor = () => ps.Color;

--- a/mods/cnc/chrome/color-picker.yaml
+++ b/mods/cnc/chrome/color-picker.yaml
@@ -47,12 +47,25 @@ Background@COLOR_CHOOSER:
 			Width: PARENT_RIGHT - 91
 			Height: PARENT_BOTTOM - 34
 			Children:
-				Background@MIXERBG:
+				Background@HUEBG:
 					Background: panel-black
 					X: 0
 					Y: 0
 					Width: PARENT_RIGHT
-					Height: 114
+					Height: 17
+					Children:
+						HueSlider@HUE_SLIDER:
+							X: 2
+							Y: 2
+							Width: PARENT_RIGHT - 4
+							Height: PARENT_BOTTOM - 4
+							Ticks: 5
+				Background@MIXERBG:
+					Background: panel-black
+					X: 0
+					Y: 21
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM - 21
 					Children:
 						ColorMixer@MIXER:
 							X: 2

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -269,8 +269,7 @@ World:
 		TimeLimitDisplayOrder: 2
 	ColorPickerManager:
 		PreviewActor: fact.colorpicker
-		PresetHues: 0, 0.125, 0.185, 0.4, 0.54, 0.66, 0.79, 0.875, 0, 0.14, 0.23, 0.43, 0.54, 0.625, 0.77, 0.85
-		PresetSaturations: 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.4, 0.5, 0.4, 0.5, 0.4, 0.5, 0.4, 0.5
+		PresetColors: F21818, F2BC18, DAF218, 18F26F, 18BEF2, 1821F2, BA18F2, F218BC, F29191, F2DF79, CDF291, 79F2BF, 91DBF2, 7997F2, CD91F2, F279E6
 	OrderEffects:
 		TerrainFlashImage: moveflsh
 		TerrainFlashSequence: idle

--- a/mods/cnc/sequences/civilian.yaml
+++ b/mods/cnc/sequences/civilian.yaml
@@ -145,7 +145,7 @@ moebius:
 		Length: 4
 		Tick: 1600
 
-chan:	
+chan:
 	Inherits: moebius
 	Defaults:
 		Filename: chan.shp

--- a/mods/common/chrome/color-picker.yaml
+++ b/mods/common/chrome/color-picker.yaml
@@ -41,18 +41,37 @@ Background@COLOR_CHOOSER:
 			Width: 80
 			Text: Palette
 			Font: Bold
-		Background@MIXER_TAB:
-			Background: dialog3
+		Container@MIXER_TAB:
 			X: 5
 			Y: 5
 			Width: PARENT_RIGHT - 90
 			Height: PARENT_BOTTOM - 34
 			Children:
-				ColorMixer@MIXER:
-					X: 2
-					Y: 2
-					Width: PARENT_RIGHT - 4
-					Height: PARENT_BOTTOM - 4
+				Background@HUEBG:
+					Background: dialog3
+					X: 0
+					Y: 0
+					Width: PARENT_RIGHT
+					Height: 17
+					Children:
+						HueSlider@HUE_SLIDER:
+							X: 2
+							Y: 2
+							Width: PARENT_RIGHT - 4
+							Height: PARENT_BOTTOM - 4
+							Ticks: 5
+				Background@MIXERBG:
+					Background: dialog3
+					X: 0
+					Y: 22
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM - 22
+					Children:
+						ColorMixer@MIXER:
+							X: 2
+							Y: 2
+							Width: PARENT_RIGHT - 4
+							Height: PARENT_BOTTOM - 4
 		Background@PALETTE_TAB:
 			Background: dialog3
 			X: 5

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -240,8 +240,7 @@ World:
 		TimeLimitDisplayOrder: 2
 	ColorPickerManager:
 		PreviewActor: carryall.colorpicker
-		PresetHues: 0, 0.13, 0.18, 0.3, 0.475, 0.625, 0.82, 0.89, 0.97, 0.05, 0.23, 0.375, 0.525, 0.6, 0.75, 0.85
-		PresetSaturations: 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.5, 0.35, 0.4, 0.4, 0.5, 0.5, 0.4, 0.35
+		PresetColors: F21818, F2C218, E1F218, 44F218, 18F2D2, 184FF2, E118F2, F218A8, F2798F, F2B79D, CDF291, 91F2AA, 79E0F2, 79AAF2, C291F2, F29DEA
 	OrderEffects:
 		TerrainFlashImage: moveflsh
 		TerrainFlashSequence: idle

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -290,8 +290,7 @@ World:
 			1: WarningOneMinuteRemaining
 	ColorPickerManager:
 		PreviewActor: fact.colorpicker
-		PresetHues: 0, 0.125, 0.22, 0.375, 0.5, 0.56, 0.8, 0.88, 0, 0.15, 0.235, 0.4, 0.47, 0.55, 0.75, 0.85
-		PresetSaturations: 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.4, 0.5, 0.4, 0.5, 0.4, 0.5, 0.4, 0.5
+		PresetColors: F21818, F2BC18, ACF218, 18F24F, 18F2F2, 18A4F2, C718F2, F218B5, F29191, F2E679, CBF291, 79F2AA, 91F2E1, 79CEF2, C291F2, F279E6
 	OrderEffects:
 		TerrainFlashImage: moveflsh
 		TerrainFlashSequence: idle

--- a/mods/ts/chrome/color-picker.yaml
+++ b/mods/ts/chrome/color-picker.yaml
@@ -42,18 +42,37 @@ Background@COLOR_CHOOSER:
 			Width: 80
 			Text: Palette
 			Font: Bold
-		Background@MIXER_TAB:
-			Background: dialog3
+		Container@MIXER_TAB:
 			X: 5
 			Y: 5
 			Width: PARENT_RIGHT - 94
 			Height: PARENT_BOTTOM - 34
 			Children:
-				ColorMixer@MIXER:
-					X: 2
-					Y: 2
-					Width: PARENT_RIGHT - 4
-					Height: PARENT_BOTTOM - 4
+				Background@HUEBG:
+					Background: dialog3
+					X: 0
+					Y: 0
+					Width: PARENT_RIGHT
+					Height: 17
+					Children:
+						HueSlider@HUE_SLIDER:
+							X: 2
+							Y: 2
+							Width: PARENT_RIGHT - 4
+							Height: PARENT_BOTTOM - 4
+							Ticks: 5
+				Background@MIXERBG:
+					Background: dialog3
+					X: 0
+					Y: 22
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM - 22
+					Children:
+						ColorMixer@MIXER:
+							X: 2
+							Y: 2
+							Width: PARENT_RIGHT - 4
+							Height: PARENT_BOTTOM - 4
 		Background@PALETTE_TAB:
 			Background: dialog3
 			X: 5

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -388,8 +388,7 @@ World:
 		FactionPreviewActors:
 			gdi: hvr.colorpicker
 			nod: stnk.colorpicker
-		PresetHues: 0, 0.125, 0.185, 0.4, 0.54, 0.66, 0.79, 0.875, 0, 0.14, 0.23, 0.43, 0.54, 0.625, 0.77, 0.85
-		PresetSaturations: 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.4, 0.5, 0.4, 0.5, 0.4, 0.5, 0.4, 0.5
+		PresetColors: F21818, F2BC18, DAF218, 18F26F, 18BEF2, 1821F2, BA18F2, F218BC, F29191, F2DF79, CDF291, 79F2BF, 91DBF2, 7997F2, CD91F2, F279E6
 	OrderEffects:
 		TerrainFlashImage: moveflsh
 		TerrainFlashSequence: idle


### PR DESCRIPTION
Closes #20415

Credit to @darkademic. I just added a few of the missing bits such as the update rule.

Color picker in this PR
<img width="222" alt="Screenshot 2023-03-12 at 20 37 22" src="https://user-images.githubusercontent.com/37534529/224565256-37045873-bff2-42c4-a05b-827a495a8b71.png">

Old color picker
<img width="222" alt="Screenshot 2023-02-27 at 22 45 54" src="https://user-images.githubusercontent.com/37534529/224565064-b0e55fd8-d248-4b22-8952-54179a6fc7db.png">

Bleed color picker
<img width="222" alt="Screenshot 2023-02-27 at 22 45 40" src="https://user-images.githubusercontent.com/37534529/224565047-d5c3d897-5004-4d7d-b490-ebe48a30900f.png">

As you can see the the color picker looks better with S and V axes flipped.

I also implemented `IColorPickerManagerInfo` interface so that third party mods would be able to implement their own color pickers. When reviewing the second commit I recommend to start with the interface.