### PR TITLE
Enforce StyleCop rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -520,7 +520,7 @@ dotnet_naming_rule.most_symbols_should_be_pascal_case.severity = warning
 
 
 ### StyleCop.Analyzers
-### https://github.com/DotNetAnalyzers/StyleCopAnalyzers/tree/master/documentation
+### https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/DOCUMENTATION.md
 
 # Below we enable rule categories by setting severity to warning.
 # We'll only list rules to disable.
@@ -536,6 +536,15 @@ dotnet_analyzer_diagnostic.category-StyleCop.CSharp.ReadabilityRules.severity = 
 dotnet_analyzer_diagnostic.category-StyleCop.CSharp.SpacingRules.severity = warning
 dotnet_analyzer_diagnostic.category-StyleCop.CSharp.SpecialRules.severity = warning
 
+# Rules that are covered by IDE0001 Simplify name
+dotnet_diagnostic.SA1125.severity = none # UseShorthandForNullableTypes
+
+# Rules that are covered by IDE0047 Remove unnecessary parentheses
+dotnet_diagnostic.SA1119.severity = none # StatementMustNotUseUnnecessaryParenthesis
+
+# Rules that are covered by IDE0055 Formatting Rules
+dotnet_diagnostic.SA1027.severity = none # UseTabsCorrectly
+
 # Rules that are covered by IDE1006 Naming Rules
 dotnet_diagnostic.SA1300.severity = none # ElementMustBeginWithUpperCaseLetter
 dotnet_diagnostic.SA1302.severity = none # InterfaceNamesMustBeginWithI
@@ -549,50 +558,45 @@ dotnet_diagnostic.SA1313.severity = none # ParameterNamesMustBeginWithLowerCaseL
 
 # Rules that conflict with OpenRA project style conventions
 dotnet_diagnostic.SA1101.severity = none # PrefixLocalCallsWithThis
+dotnet_diagnostic.SA1107.severity = none # CodeMustNotContainMultipleStatementsOnOneLine
+dotnet_diagnostic.SA1116.severity = none # SplitParametersMustStartOnLineAfterDeclaration
 dotnet_diagnostic.SA1117.severity = none # ParametersMustBeOnSameLineOrSeparateLines
 dotnet_diagnostic.SA1118.severity = none # ParameterMustNotSpanMultipleLines
 dotnet_diagnostic.SA1122.severity = none # UseStringEmptyForEmptyStrings
 dotnet_diagnostic.SA1124.severity = none # DoNotUseRegions
 dotnet_diagnostic.SA1127.severity = none # GenericTypeConstraintsMustBeOnOwnLine
+dotnet_diagnostic.SA1132.severity = none # DoNotCombineFields
 dotnet_diagnostic.SA1135.severity = none # UsingDirectivesMustBeQualified
 dotnet_diagnostic.SA1136.severity = none # EnumValuesShouldBeOnSeparateLines
 dotnet_diagnostic.SA1200.severity = none # UsingDirectivesMustBePlacedCorrectly
 dotnet_diagnostic.SA1201.severity = none # ElementsMustAppearInTheCorrectOrder
 dotnet_diagnostic.SA1202.severity = none # ElementsMustBeOrderedByAccess
+dotnet_diagnostic.SA1204.severity = none # StaticElementsMustAppearBeforeInstanceElements
+dotnet_diagnostic.SA1214.severity = none # ReadonlyElementsMustAppearBeforeNonReadonlyElements
+dotnet_diagnostic.SX1309.severity = none # FieldNamesMustBeginWithUnderscore
+dotnet_diagnostic.SX1309S.severity = none # StaticFieldNamesMustBeginWithUnderscore
 dotnet_diagnostic.SA1314.severity = none # TypeParameterNamesMustBeginWithT
 dotnet_diagnostic.SA1400.severity = none # AccessModifierMustBeDeclared
 dotnet_diagnostic.SA1401.severity = none # FieldsMustBePrivate
 dotnet_diagnostic.SA1402.severity = none # FileMayOnlyContainASingleType
 dotnet_diagnostic.SA1407.severity = none # ArithmeticExpressionsMustDeclarePrecedence
+dotnet_diagnostic.SA1413.severity = none # UseTrailingCommasInMultiLineInitializers
 dotnet_diagnostic.SA1501.severity = none # StatementMustNotBeOnSingleLine
 dotnet_diagnostic.SA1502.severity = none # ElementMustNotBeOnSingleLine
 dotnet_diagnostic.SA1503.severity = none # BracesMustNotBeOmitted
+dotnet_diagnostic.SA1516.severity = none # ElementsMustBeSeparatedByBlankLine
 dotnet_diagnostic.SA1519.severity = none # BracesMustNotBeOmittedFromMultiLineChildStatement
 dotnet_diagnostic.SA1520.severity = none # UseBracesConsistently
 dotnet_diagnostic.SA1600.severity = none # ElementsMustBeDocumented
 dotnet_diagnostic.SA1601.severity = none # PartialElementsMustBeDocumented
 dotnet_diagnostic.SA1602.severity = none # EnumerationItemsMustBeDocumented
-dotnet_diagnostic.SA1633.severity = none # FileMustHaveHeader
-dotnet_diagnostic.SA1649.severity = none # FileNameMustMatchTypeName
-
-# Rules that could potentially be enabled after existing violations are fixed
-dotnet_diagnostic.SA1027.severity = none # UseTabsCorrectly
-dotnet_diagnostic.SA1107.severity = none # CodeMustNotContainMultipleStatementsOnOneLine
-dotnet_diagnostic.SA1116.severity = none # SplitParametersMustStartOnLineAfterDeclaration
-dotnet_diagnostic.SA1119.severity = none # StatementMustNotUseUnnecessaryParenthesis
-dotnet_diagnostic.SA1132.severity = none # DoNotCombineFields
-dotnet_diagnostic.SA1204.severity = none # StaticElementsMustAppearBeforeInstanceElements
-dotnet_diagnostic.SA1214.severity = none # ReadonlyElementsMustAppearBeforeNonReadonlyElements
-dotnet_diagnostic.SA1413.severity = none # UseTrailingCommasInMultiLineInitializers
-dotnet_diagnostic.SA1516.severity = none # ElementsMustBeSeparatedByBlankLine
-dotnet_diagnostic.SA1604.severity = none # ElementDocumentationShouldHaveSummary
 dotnet_diagnostic.SA1611.severity = none # ElementParametersShouldBeDocumented
 dotnet_diagnostic.SA1615.severity = none # ElementReturnValueShouldBeDocumented
 dotnet_diagnostic.SA1618.severity = none # GenericTypeParametersShouldBeDocumented
 dotnet_diagnostic.SA1623.severity = none # PropertySummaryDocumentationShouldMatchAccessors
-dotnet_diagnostic.SA1629.severity = none # DocumentationTextShouldEndWithAPeriod
+dotnet_diagnostic.SA1633.severity = none # FileMustHaveHeader
 dotnet_diagnostic.SA1642.severity = none # ConstructorSummaryDocumentationShouldBeginWithStandardText
-
+dotnet_diagnostic.SA1649.severity = none # FileNameMustMatchTypeName
 
 #### Code Quality Rules
 #### https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -587,7 +587,7 @@ namespace OpenRA
 			return InvalidConditionToken;
 		}
 
-		/// <summary>Returns whether the specified token is valid for RevokeCondition</summary>
+		/// <summary>Returns whether the specified token is valid for RevokeCondition.</summary>
 		public bool TokenValid(int token)
 		{
 			return conditionTokens.ContainsKey(token);

--- a/OpenRA.Game/ExternalMods.cs
+++ b/OpenRA.Game/ExternalMods.cs
@@ -181,10 +181,12 @@ namespace OpenRA
 
 		/// <summary>
 		/// Removes invalid mod registrations:
-		/// * LaunchPath no longer exists
-		/// * LaunchPath and mod id matches the active mod, but the version is different
-		/// * Filename doesn't match internal key
-		/// * Fails to parse as a mod registration
+		/// <list type="bullet">
+		/// <item>LaunchPath no longer exists.</item>
+		/// <item>LaunchPath and mod id matches the active mod, but the version is different.</item>
+		/// <item>Filename doesn't match internal key.</item>
+		/// <item>Fails to parse as a mod registration.</item>
+		/// </list>
 		/// </summary>
 		internal void ClearInvalidRegistrations(ModRegistration registration)
 		{

--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -271,7 +271,7 @@ namespace OpenRA.FileSystem
 		}
 
 		/// <summary>
-		/// Returns true if the given filename references an external mod via an explicit mount
+		/// Returns true if the given filename references an external mod via an explicit mount.
 		/// </summary>
 		public bool IsExternalModFile(string filename)
 		{

--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -131,7 +131,7 @@ namespace OpenRA.GameRules
 		public readonly List<IWarhead> Warheads = new List<IWarhead>();
 
 		/// <summary>
-		/// This constructor is used solely for documentation generation!
+		/// This constructor is used solely for documentation generation.
 		/// </summary>
 		public WeaponInfo() { }
 

--- a/OpenRA.Game/Graphics/Model.cs
+++ b/OpenRA.Game/Graphics/Model.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Graphics
 		float[] Bounds(uint frame);
 		ModelRenderData RenderData(uint section);
 
-		/// <summary>Returns the smallest rectangle that covers all rotations of all frames in a model</summary>
+		/// <summary>Returns the smallest rectangle that covers all rotations of all frames in a model.</summary>
 		Rectangle AggregateBounds { get; }
 	}
 

--- a/OpenRA.Game/Graphics/RgbaColorRenderer.cs
+++ b/OpenRA.Game/Graphics/RgbaColorRenderer.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Graphics
 		/// <summary>
 		/// Calculate the 2D intersection of two lines.
 		/// Will behave badly if the lines are parallel.
-		/// Z position is the average of a and b (ignores actual intersection point if it exists)
+		/// Z position is the average of a and b (ignores actual intersection point if it exists).
 		/// </summary>
 		float3 IntersectionOf(in float3 a, in float3 da, in float3 b, in float3 db)
 		{

--- a/OpenRA.Game/Graphics/SpriteLoader.cs
+++ b/OpenRA.Game/Graphics/SpriteLoader.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Graphics
 	/// <summary>
 	/// Describes the format of the pixel data in a ISpriteFrame.
 	/// Note that the channel order is defined for little-endian bytes, so BGRA corresponds
-	/// to a 32bit ARGB value, such as that returned by Color.ToArgb()!
+	/// to a 32bit ARGB value, such as that returned by Color.ToArgb().
 	/// </summary>
 	public enum SpriteFrameType
 	{

--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -224,10 +224,10 @@ namespace OpenRA.Graphics
 		}
 
 		/// <summary>Rotates a quad about its center in the x-y plane.</summary>
-		/// <param name="tl">The top left vertex of the quad</param>
-		/// <param name="size">A float3 containing the X, Y, and Z lengths of the quad</param>
-		/// <param name="rotation">The number of radians to rotate by</param>
-		/// <returns>An array of four vertices representing the rotated quad (top-left, top-right, bottom-right, bottom-left)</returns>
+		/// <param name="tl">The top left vertex of the quad.</param>
+		/// <param name="size">A float3 containing the X, Y, and Z lengths of the quad.</param>
+		/// <param name="rotation">The number of radians to rotate by.</param>
+		/// <returns>An array of four vertices representing the rotated quad (top-left, top-right, bottom-right, bottom-left).</returns>
 		public static float3[] RotateQuad(float3 tl, float3 size, float rotation)
 		{
 			var center = tl + 0.5f * size;
@@ -258,9 +258,9 @@ namespace OpenRA.Graphics
 		/// <summary>
 		/// Returns the bounds of an object. Used for determining which objects need to be rendered on screen, and which do not.
 		/// </summary>
-		/// <param name="offset">The top left vertex of the object</param>
-		/// <param name="size">A float 3 containing the X, Y, and Z lengths of the object</param>
-		/// <param name="rotation">The angle to rotate the object by (use 0f if there is no rotation)</param>
+		/// <param name="offset">The top left vertex of the object.</param>
+		/// <param name="size">A float 3 containing the X, Y, and Z lengths of the object.</param>
+		/// <param name="rotation">The angle to rotate the object by (use 0f if there is no rotation).</param>
 		public static Rectangle BoundingRectangle(float3 offset, float3 size, float rotation)
 		{
 			if (rotation == 0f)

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -278,7 +278,7 @@ namespace OpenRA.Graphics
 			return worldRenderer.World.Map.CellContaining(worldRenderer.ProjectedPosition(ViewToWorldPx(view)));
 		}
 
-		/// <summary> Returns an unfiltered list of all cells that could potentially contain the mouse cursor</summary>
+		/// <summary>Returns an unfiltered list of all cells that could potentially contain the mouse cursor.</summary>
 		IEnumerable<MPos> CandidateMouseoverCells(int2 world)
 		{
 			var map = worldRenderer.World.Map;

--- a/OpenRA.Game/Input/HotkeyReference.cs
+++ b/OpenRA.Game/Input/HotkeyReference.cs
@@ -14,7 +14,7 @@ using System;
 namespace OpenRA
 {
 	/// <summary>
-	/// A reference to either a named hotkey (defined in the game settings) or a statically assigned hotkey
+	/// A reference to either a named hotkey (defined in the game settings) or a statically assigned hotkey.
 	/// </summary>
 	public class HotkeyReference
 	{

--- a/OpenRA.Game/MPos.cs
+++ b/OpenRA.Game/MPos.cs
@@ -64,7 +64,7 @@ namespace OpenRA
 	}
 
 	/// <summary>
-	/// Projected map position
+	/// Projected map position.
 	/// </summary>
 	public readonly struct PPos : IEquatable<PPos>
 	{

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -64,7 +64,7 @@ namespace OpenRA
 		public bool Hidden;
 	}
 
-	/// <summary> Describes what is to be loaded in order to run a mod. </summary>
+	/// <summary>Describes what is to be loaded in order to run a mod.</summary>
 	public class Manifest : IDisposable
 	{
 		public readonly string Id;

--- a/OpenRA.Game/Map/CellLayer.cs
+++ b/OpenRA.Game/Map/CellLayer.cs
@@ -72,7 +72,7 @@ namespace OpenRA
 			return uv.V * Size.Width + uv.U;
 		}
 
-		/// <summary>Gets or sets the <see cref="CellLayer"/> using cell coordinates</summary>
+		/// <summary>Gets or sets the <see cref="CellLayer"/> using cell coordinates.</summary>
 		public T this[CPos cell]
 		{
 			get => Entries[Index(cell)];
@@ -85,7 +85,7 @@ namespace OpenRA
 			}
 		}
 
-		/// <summary>Gets or sets the layer contents using raw map coordinates (not CPos!)</summary>
+		/// <summary>Gets or sets the layer contents using raw map coordinates (not CPos!).</summary>
 		public T this[MPos uv]
 		{
 			get => Entries[Index(uv)];

--- a/OpenRA.Game/Map/CellLayerBase.cs
+++ b/OpenRA.Game/Map/CellLayerBase.cs
@@ -43,13 +43,13 @@ namespace OpenRA
 			Array.Copy(anotherLayer.Entries, Entries, Entries.Length);
 		}
 
-		/// <summary>Clears the layer contents with their default value</summary>
+		/// <summary>Clears the layer contents with their default value.</summary>
 		public virtual void Clear()
 		{
 			Array.Clear(Entries, 0, Entries.Length);
 		}
 
-		/// <summary>Clears the layer contents with a known value</summary>
+		/// <summary>Clears the layer contents with a known value.</summary>
 		public virtual void Clear(T clearValue)
 		{
 			Array.Fill(Entries, clearValue);

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -155,7 +155,7 @@ namespace OpenRA
 		public const int CurrentMapFormat = 12;
 		const short InvalidCachedTerrainIndex = -1;
 
-		/// <summary>Defines the order of the fields in map.yaml</summary>
+		/// <summary>Defines the order of the fields in map.yaml.</summary>
 		static readonly MapField[] YamlFields =
 		{
 			new MapField("MapFormat"),
@@ -993,7 +993,7 @@ namespace OpenRA
 		}
 
 		/// <summary>
-		/// The size of the map Height step in world units
+		/// The size of the map Height step in world units.
 		/// </summary>
 		/// RectangularIsometric defines 1024 units along the diagonal axis,
 		/// giving a half-tile height step of sqrt(2) * 512

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -43,7 +43,7 @@ namespace OpenRA
 		readonly List<MapDirectoryTracker> mapDirectoryTrackers = new List<MapDirectoryTracker>();
 
 		/// <summary>
-		/// The most recently modified or loaded map at runtime
+		/// The most recently modified or loaded map at runtime.
 		/// </summary>
 		public string LastModifiedMap { get; private set; } = null;
 		readonly Dictionary<string, string> mapUpdates = new Dictionary<string, string>();
@@ -51,7 +51,7 @@ namespace OpenRA
 		string lastLoadedLastModifiedMap;
 
 		/// <summary>
-		/// If LastModifiedMap was picked already, returns a null
+		/// If LastModifiedMap was picked already, returns a null.
 		/// </summary>
 		public string PickLastModifiedMap(MapVisibility visibility)
 		{

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -63,7 +63,7 @@ namespace OpenRA
 
 	public class MapPreview : IDisposable, IReadOnlyFileSystem
 	{
-		/// <summary>Wrapper that enables map data to be replaced in an atomic fashion</summary>
+		/// <summary>Wrapper that enables map data to be replaced in an atomic fashion.</summary>
 		class InnerData
 		{
 			public int MapFormat;

--- a/OpenRA.Game/Map/PlayerReference.cs
+++ b/OpenRA.Game/Map/PlayerReference.cs
@@ -36,7 +36,7 @@ namespace OpenRA
 		/// <summary>
 		/// Sets the "Home" location, which can be used by traits and scripts to e.g. set the initial camera
 		/// location or choose the map edge for reinforcements.
-		/// This will usually be overridden for client (lobby slot) players with a location based on the Spawn index
+		/// This will usually be overridden for client (lobby slot) players with a location based on the Spawn index.
 		/// </summary>
 		public CPos HomeLocation = CPos.Zero;
 

--- a/OpenRA.Game/Network/GameServer.cs
+++ b/OpenRA.Game/Network/GameServer.cs
@@ -61,34 +61,34 @@ namespace OpenRA.Network
 
 		public const int ProtocolVersion = 2;
 
-		/// <summary>Online game number or -1 for LAN games</summary>
+		/// <summary>Online game number or -1 for LAN games.</summary>
 		public readonly int Id = -1;
 
-		/// <summary>Name of the server</summary>
+		/// <summary>Name of the server.</summary>
 		public readonly string Name = null;
 
 		/// <summary>ip:port string to connect to.</summary>
 		public readonly string Address = null;
 
-		/// <summary>Port of the server</summary>
+		/// <summary>Port of the server.</summary>
 		public readonly int Port = 0;
 
-		/// <summary>The current state of the server (waiting/playing/completed)</summary>
+		/// <summary>The current state of the server (waiting/playing/completed).</summary>
 		public readonly int State = 0;
 
-		/// <summary>The number of slots available for non-bot players</summary>
+		/// <summary>The number of slots available for non-bot players.</summary>
 		public readonly int MaxPlayers = 0;
 
-		/// <summary>UID of the map</summary>
+		/// <summary>UID of the map.</summary>
 		public readonly string Map = null;
 
-		/// <summary>Mod ID</summary>
+		/// <summary>Mod ID.</summary>
 		public readonly string Mod = "";
 
-		/// <summary>Mod Version</summary>
+		/// <summary>Mod Version.</summary>
 		public readonly string Version = "";
 
-		/// <summary>Human-readable mod title</summary>
+		/// <summary>Human-readable mod title.</summary>
 		public readonly string ModTitle = "";
 
 		/// <summary>URL to show in game listings for custom/unknown mods.</summary>
@@ -100,13 +100,13 @@ namespace OpenRA.Network
 		/// <summary>GeoIP resolved server location.</summary>
 		public readonly string Location = "";
 
-		/// <summary>Password protected</summary>
+		/// <summary>Password protected.</summary>
 		public readonly bool Protected = false;
 
-		/// <summary>Players must be authenticated with the OpenRA forum</summary>
+		/// <summary>Players must be authenticated with the OpenRA forum.</summary>
 		public readonly bool Authentication = false;
 
-		/// <summary>UTC datetime string when the game changed to the Playing state</summary>
+		/// <summary>UTC datetime string when the game changed to the Playing state.</summary>
 		public readonly string Started = null;
 
 		/// <summary>Number of non-spectator, non-bot players. Only defined if GameServer is parsed from yaml.</summary>
@@ -132,7 +132,7 @@ namespace OpenRA.Network
 		[FieldLoader.LoadUsing(nameof(LoadClients))]
 		public readonly GameClient[] Clients;
 
-		/// <summary>The list of spawnpoints that are disabled for this game</summary>
+		/// <summary>The list of spawnpoints that are disabled for this game.</summary>
 		public readonly int[] DisabledSpawnPoints = Array.Empty<int>();
 
 		public string ModLabel => $"{ModTitle} ({Version})";

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Network
 
 		public Session LobbyInfo = new Session();
 
-		/// <summary> Null when watching a replay </summary>
+		/// <summary>Null when watching a replay.</summary>
 		public Session.Client LocalClient => LobbyInfo.ClientWithIndex(Connection.LocalClientId);
 		public World World;
 		public int OrderQueueLength => pendingOrders.Count > 0 ? pendingOrders.Min(q => q.Value.Count) : 0;
@@ -58,7 +58,11 @@ namespace OpenRA.Network
 		int sentOrdersFrame = 0;
 		float tickScale = 1f;
 
-		/// <Remarks> Should only be set in <see cref="OutOfSync"/></Remarks>
+		/// <summary>
+		/// Indicates if the world state of other players or a replay has diverged from the local state.
+		/// The game cannot reliably continue in this condition and is unusable.
+		/// </summary>
+		/// <remarks>Should only be set in <see cref="OutOfSync"/>.</remarks>
 		public bool IsOutOfSync { get; private set; } = false;
 
 		public struct ClientOrder

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -253,7 +253,7 @@ namespace OpenRA
 			return PlayerRelationship.Neutral;
 		}
 
-		/// <summary> returns true if player is null </summary>
+		/// <summary>Returns true if player is null.</summary>
 		public bool IsAlliedWith(Player p)
 		{
 			return RelationshipWith(p) == PlayerRelationship.Ally;

--- a/OpenRA.Game/WAngle.cs
+++ b/OpenRA.Game/WAngle.cs
@@ -102,7 +102,7 @@ namespace OpenRA
 
 		/// <summary>
 		/// Find the index of CosineTable that has the value closest to the given value.
-		/// The first or last index will be returned for values above or below the valid range
+		/// The first or last index will be returned for values above or below the valid range.
 		/// </summary>
 		static int ClosestCosineIndex(int value)
 		{

--- a/OpenRA.Game/WPos.cs
+++ b/OpenRA.Game/WPos.cs
@@ -37,12 +37,12 @@ namespace OpenRA
 		public static bool operator !=(in WPos me, in WPos other) { return !(me == other); }
 
 		/// <summary>
-		/// Returns the linear interpolation between points 'a' and 'b'
+		/// Returns the linear interpolation between points 'a' and 'b'.
 		/// </summary>
 		public static WPos Lerp(in WPos a, in WPos b, int mul, int div) { return a + (b - a) * mul / div; }
 
 		/// <summary>
-		/// Returns the linear interpolation between points 'a' and 'b'
+		/// Returns the linear interpolation between points 'a' and 'b'.
 		/// </summary>
 		public static WPos Lerp(in WPos a, in WPos b, long mul, long div)
 		{

--- a/OpenRA.Game/WRot.cs
+++ b/OpenRA.Game/WRot.cs
@@ -53,7 +53,7 @@ namespace OpenRA
 
 		/// <summary>
 		/// Construct a rotation from an axis and angle.
-		/// The axis is expected to be normalized to length 1024
+		/// The axis is expected to be normalized to length 1024.
 		/// </summary>
 		public WRot(WVec axis, WAngle angle)
 		{

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -125,9 +125,9 @@ namespace OpenRA.Widgets
 			return handled;
 		}
 
-		/// <summary>Possibly handle keyboard input (if this widget has keyboard focus)</summary>
-		/// <returns><c>true</c>, if keyboard input was handled, <c>false</c> if the input should bubble to the parent widget</returns>
-		/// <param name="e">Key input data</param>
+		/// <summary>Possibly handle keyboard input (if this widget has keyboard focus).</summary>
+		/// <returns><c>true</c>, if keyboard input was handled, <c>false</c> if the input should bubble to the parent widget.</returns>
+		/// <param name="e">Key input data.</param>
 		public static bool HandleKeyPress(KeyInput e)
 		{
 			if (KeyboardFocusWidget != null)
@@ -395,8 +395,8 @@ namespace OpenRA.Widgets
 		public virtual void MouseExited() { }
 
 		/// <summary>Possibly handles mouse input (click, drag, scroll, etc).</summary>
-		/// <returns><c>true</c>, if mouse input was handled, <c>false</c> if the input should bubble to the parent widget</returns>
-		/// <param name="mi">Mouse input data</param>
+		/// <returns><c>true</c>, if mouse input was handled, <c>false</c> if the input should bubble to the parent widget.</returns>
+		/// <param name="mi">Mouse input data.</param>
 		public virtual bool HandleMouseInput(MouseInput mi) { return false; }
 
 		public bool HandleMouseInputOuter(MouseInput mi)

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -69,7 +69,8 @@ namespace OpenRA
 
 		public event Action GameOver = () => { };
 
-		/// <Remarks> Should only be set in <see cref="EndGame"/></Remarks>
+		/// <summary>Indicates that the game has ended.</summary>
+		/// <remarks>Should only be set in <see cref="EndGame"/>.</remarks>
 		public bool IsGameOver { get; private set; }
 		public void EndGame()
 		{

--- a/OpenRA.Mods.Cnc/FileFormats/CRC32.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/CRC32.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 	public static class CRC32
 	{
 		/// <summary>
-		/// The CRC32 lookup table
+		/// The CRC32 lookup table.
 		/// </summary>
 		static readonly uint[] LookUp = new uint[256]
 		{

--- a/OpenRA.Mods.Cnc/FileSystem/MegFile.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/MegFile.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Cnc.FileSystem
 {
 	/// <summary>
 	/// This class supports loading unencrypted V3 .meg files using
-	/// reference documentation from here https://modtools.petrolution.net/docs/MegFileFormat
+	/// reference documentation from here https://modtools.petrolution.net/docs/MegFileFormat.
 	/// </summary>
 	public class MegV3Loader : IPackageLoader
 	{

--- a/OpenRA.Mods.Common/Activities/Enter.cs
+++ b/OpenRA.Mods.Common/Activities/Enter.cs
@@ -41,14 +41,14 @@ namespace OpenRA.Mods.Common.Activities
 
 		/// <summary>
 		/// Called early in the activity tick to allow subclasses to update state.
-		/// Call Cancel(self, true) if it is no longer valid to enter
+		/// Call Cancel(self, true) if it is no longer valid to enter.
 		/// </summary>
 		protected virtual void TickInner(Actor self, in Target target, bool targetIsDeadOrHiddenActor) { }
 
 		/// <summary>
 		/// Called when the actor is ready to transition from approaching to entering the target actor.
 		/// Return true to start entering, or false to wait in the WaitingToEnter state.
-		/// Call Cancel(self, true) before returning false if it is no longer valid to enter
+		/// Call Cancel(self, true) before returning false if it is no longer valid to enter.
 		/// </summary>
 		protected virtual bool TryStartEnter(Actor self, Actor targetActor) { return true; }
 

--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -152,7 +152,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		/// <summary>
 		/// Finds the closest harvestable pos between the current position of the harvester
-		/// and the last order location
+		/// and the last order location.
 		/// </summary>
 		CPos? ClosestHarvestablePos(Actor self)
 		{

--- a/OpenRA.Mods.Common/Pathfinder/CellInfo.cs
+++ b/OpenRA.Mods.Common/Pathfinder/CellInfo.cs
@@ -15,7 +15,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 {
 	/// <summary>
 	/// Describes the three states that a node in the graph can have.
-	/// Based on A* algorithm specification
+	/// Based on A* algorithm specification.
 	/// </summary>
 	public enum CellStatus : byte
 	{

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -219,9 +219,9 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 		/// <summary>
 		/// This function analyzes the neighbors of the most promising node in the pathfinding graph
-		/// using the A* algorithm (A-star) and returns that node
+		/// using the A* algorithm (A-star) and returns that node.
 		/// </summary>
-		/// <returns>The most promising node of the iteration</returns>
+		/// <returns>The most promising node of the iteration.</returns>
 		CPos Expand()
 		{
 			var currentMinNode = openQueue.Pop().Destination;

--- a/OpenRA.Mods.Common/TargetExtensions.cs
+++ b/OpenRA.Mods.Common/TargetExtensions.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common
 		/// <summary>
 		/// Update (Frozen)Actor targets to account for visibility changes or actor replacement.
 		/// If the target actor becomes hidden without a FrozenActor, the target is invalidated.
-		/// /// </summary>
+		/// </summary>
 		public static Target RecalculateInvalidatingHiddenTargets(this Target t, Player viewer)
 		{
 			var updated = t.Recalculate(viewer, out var targetIsHiddenActor);

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 			return ret;
 		}
 
-		/// <summary>Evaluates the attractiveness of a position according to all considerations</summary>
+		/// <summary>Evaluates the attractiveness of a position according to all considerations.</summary>
 		public int GetAttractiveness(WPos pos, Player firedBy)
 		{
 			var answer = 0;
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Traits
 			return answer;
 		}
 
-		/// <summary>Evaluates the attractiveness of a group of actors according to all considerations</summary>
+		/// <summary>Evaluates the attractiveness of a group of actors according to all considerations.</summary>
 		public int GetAttractiveness(IEnumerable<Actor> actors, Player firedBy)
 		{
 			var answer = 0;
@@ -137,7 +137,7 @@ namespace OpenRA.Mods.Common.Traits
 				FieldLoader.Load(this, yaml);
 			}
 
-			/// <summary>Evaluates a single actor according to the rules defined in this consideration</summary>
+			/// <summary>Evaluates a single actor according to the rules defined in this consideration.</summary>
 			public int GetAttractiveness(Actor a, PlayerRelationship stance, Player firedBy)
 			{
 				if (stance != Against)

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -111,7 +111,7 @@ namespace OpenRA.Mods.Common.Traits
 		int carryConditionToken = Actor.InvalidConditionToken;
 		int carryableConditionToken = Actor.InvalidConditionToken;
 
-		/// <summary>Offset between the carryall's and the carried actor's CenterPositions</summary>
+		/// <summary>Offset between the carryall's and the carried actor's CenterPositions.</summary>
 		public WVec CarryableOffset { get; private set; }
 
 		public Carryall(Actor self, CarryallInfo info)

--- a/OpenRA.Mods.Common/UpdateRules/UpdateRule.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateRule.cs
@@ -19,11 +19,11 @@ namespace OpenRA.Mods.Common.UpdateRules
 		public abstract string Description { get; }
 
 		/// <summary>Defines a transformation that is run on each top-level node in a yaml file set.</summary>
-		/// <returns>An enumerable of manual steps to be run by the user</returns>
+		/// <returns>An enumerable of manual steps to be run by the user.</returns>
 		public delegate IEnumerable<string> TopLevelNodeTransform(ModData modData, MiniYamlNode node);
 
 		/// <summary>Defines a transformation that is run on each widget node in a chrome yaml file set.</summary>
-		/// <returns>An enumerable of manual steps to be run by the user</returns>
+		/// <returns>An enumerable of manual steps to be run by the user.</returns>
 		public delegate IEnumerable<string> ChromeNodeTransform(ModData modData, MiniYamlNode widgetNode);
 
 		public virtual IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode) { yield break; }

--- a/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
@@ -315,13 +315,13 @@ namespace OpenRA.Mods.Common.UpdateRules
 			}
 		}
 
-		/// <summary>Checks if node is a removal (has '-' prefix)</summary>
+		/// <summary>Checks if node is a removal (has '-' prefix).</summary>
 		public static bool IsRemoval(this MiniYamlNode node)
 		{
 			return node.Key[0].ToString() == "-";
 		}
 
-		/// <summary>Renames a yaml key preserving any @suffix</summary>
+		/// <summary>Renames a yaml key preserving any @suffix.</summary>
 		public static void RenameKey(this MiniYamlNode node, string newKey, bool preserveSuffix = true, bool includeRemovals = true)
 		{
 			var prefix = includeRemovals && node.IsRemoval() ? "-" : "";
@@ -370,13 +370,13 @@ namespace OpenRA.Mods.Common.UpdateRules
 			node.MoveNode(fromNode, toNode);
 		}
 
-		/// <summary>Removes children with keys equal to [match] or [match]@[arbitrary suffix]</summary>
+		/// <summary>Removes children with keys equal to [match] or [match]@[arbitrary suffix].</summary>
 		public static int RemoveNodes(this MiniYamlNode node, string match, bool ignoreSuffix = true, bool includeRemovals = true)
 		{
 			return node.Value.Nodes.RemoveAll(n => n.KeyMatches(match, ignoreSuffix, includeRemovals));
 		}
 
-		/// <summary>Returns true if the node is of the form [match] or [match]@[arbitrary suffix]</summary>
+		/// <summary>Returns true if the node is of the form [match] or [match]@[arbitrary suffix].</summary>
 		public static bool KeyMatches(this MiniYamlNode node, string match, bool ignoreSuffix = true, bool includeRemovals = true)
 		{
 			if (node.Key == null)
@@ -394,7 +394,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 			return atPosition > 0 && node.Key.Substring(0, atPosition) == prefix + match;
 		}
 
-		/// <summary>Returns true if the node is of the form [match], [match]@[arbitrary suffix] or [arbitrary suffix]@[match]</summary>
+		/// <summary>Returns true if the node is of the form [match], [match]@[arbitrary suffix] or [arbitrary suffix]@[match].</summary>
 		public static bool KeyContains(this MiniYamlNode node, string match, bool ignoreSuffix = true, bool includeRemovals = true)
 		{
 			if (node.Key == null)
@@ -409,13 +409,13 @@ namespace OpenRA.Mods.Common.UpdateRules
 			return false;
 		}
 
-		/// <summary>Returns children with keys equal to [match] or [match]@[arbitrary suffix]</summary>
+		/// <summary>Returns children with keys equal to [match] or [match]@[arbitrary suffix].</summary>
 		public static IEnumerable<MiniYamlNode> ChildrenMatching(this MiniYamlNode node, string match, bool ignoreSuffix = true, bool includeRemovals = true)
 		{
 			return node.Value.Nodes.Where(n => n.KeyMatches(match, ignoreSuffix, includeRemovals));
 		}
 
-		/// <summary>Returns children whose keys contain 'match' (optionally in the suffix)</summary>
+		/// <summary>Returns children whose keys contain 'match' (optionally in the suffix).</summary>
 		public static IEnumerable<MiniYamlNode> ChildrenContaining(this MiniYamlNode node, string match, bool ignoreSuffix = true, bool includeRemovals = true)
 		{
 			return node.Value.Nodes.Where(n => n.KeyContains(match, ignoreSuffix, includeRemovals));

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common
 		/// <summary>
 		/// Adds step angle units to facing in the direction that takes it closer to desiredFacing.
 		/// If facing is already within step of desiredFacing then desiredFacing is returned.
-		/// Step is given as an integer to allow negative values (step away from the desired facing)
+		/// Step is given as an integer to allow negative values (step away from the desired facing).
 		/// </summary>
 		public static WAngle TickFacing(WAngle facing, WAngle desiredFacing, WAngle step)
 		{
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common
 
 		/// <summary>
 		/// Determines whether desiredFacing is clockwise (-1) or anticlockwise (+1) of facing.
-		/// If desiredFacing is equal to facing or directly behind facing we treat it as being anticlockwise
+		/// If desiredFacing is equal to facing or directly behind facing we treat it as being anticlockwise.
 		/// </summary>
 		public static int GetTurnDirection(WAngle facing, WAngle desiredFacing)
 		{
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common
 		}
 
 		/// <summary>
-		/// Returns the remainder angle after rounding to the nearest whole step / facing
+		/// Returns the remainder angle after rounding to the nearest whole step / facing.
 		/// </summary>
 		public static WAngle AngleDiffToStep(WAngle facing, int numFrames)
 		{
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common
 			return new WAngle(IndexFacing(facing, facings) * (1024 / facings));
 		}
 
-		/// <summary>Wraps an arbitrary integer facing value into the range 0 - 255</summary>
+		/// <summary>Wraps an arbitrary integer facing value into the range 0 - 255.</summary>
 		public static int NormalizeFacing(int f)
 		{
 			if (f >= 0)

--- a/OpenRA.Mods.Common/UtilityCommands/Utilities.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/Utilities.cs
@@ -18,7 +18,6 @@ namespace OpenRA.Mods.Common.UtilityCommands
 {
 	public static class Utilities
 	{
-		/// <exception cref="ArgumentNullException">Thrown if manifestPropertySelector is null.</exception>
 		public static MiniYamlNode GetTopLevelNodeByKey(ModData modData, string key,
 			Func<Manifest, string[]> manifestPropertySelector,
 			Func<Map, MiniYaml> mapPropertySelector = null,

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
@@ -19,7 +19,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets
 {
-	/// <summary> Contains all functions that are unit-specific. </summary>
+	/// <summary>Contains all functions that are unit-specific.</summary>
 	public class CommandBarLogic : ChromeLogic
 	{
 		readonly World world;

--- a/OpenRA.Mods.Common/WorldExtensions.cs
+++ b/OpenRA.Mods.Common/WorldExtensions.cs
@@ -21,12 +21,12 @@ namespace OpenRA.Mods.Common
 		/// Finds all the actors of which their health radius is intersected by a line (with a definable width) between two points.
 		/// </summary>
 		/// <param name="world">The engine world the line intersection is to be done in.</param>
-		/// <param name="lineStart">The position the line should start at</param>
-		/// <param name="lineEnd">The position the line should end at</param>
-		/// <param name="lineWidth">How close an actor's health radius needs to be to the line to be considered 'intersected' by the line</param>
+		/// <param name="lineStart">The position the line should start at.</param>
+		/// <param name="lineEnd">The position the line should end at.</param>
+		/// <param name="lineWidth">How close an actor's health radius needs to be to the line to be considered 'intersected' by the line.</param>
 		/// <param name="onlyBlockers">If set, only considers the size of actors that have an <see cref="IBlocksProjectiles"/>
 		/// trait which may improve search performance. However does NOT filter the returned actors on this trait.</param>
-		/// <returns>A list of all the actors intersected by the line</returns>
+		/// <returns>A list of all the actors intersected by the line.</returns>
 		public static IEnumerable<Actor> FindActorsOnLine(this World world, WPos lineStart, WPos lineEnd, WDist lineWidth, bool onlyBlockers = false)
 		{
 			// This line intersection check is done by first just finding all actors within a square that starts at the source, and ends at the target.
@@ -84,10 +84,10 @@ namespace OpenRA.Mods.Common
 		/// <summary>
 		/// Find the point (D) on a line (A-B) that is closest to the target point (C).
 		/// </summary>
-		/// <param name="lineStart">The source point (tail) of the line</param>
-		/// <param name="lineEnd">The target point (head) of the line</param>
-		/// <param name="point">The target point that the minimum distance should be found to</param>
-		/// <returns>The WPos that is the point on the line that is closest to the target point</returns>
+		/// <param name="lineStart">The source point (tail) of the line.</param>
+		/// <param name="lineEnd">The target point (head) of the line.</param>
+		/// <param name="point">The target point that the minimum distance should be found to.</param>
+		/// <returns>The WPos that is the point on the line that is closest to the target point.</returns>
 		public static WPos MinimumPointLineProjection(this WPos lineStart, WPos lineEnd, WPos point)
 		{
 			var squaredLength = (lineEnd - lineStart).HorizontalLengthSquared;


### PR DESCRIPTION
Review StyleCop rules.

- Enforce SA1604 ElementDocumentationShouldHaveSummary.
- Enforce SA1629 DocumentationTextShouldEndWithAPeriod.
- Turn off some rules covered by IDExxxx rules.
- Remaining rules are treated as part of OpenRA style.

~~Disable IDExxxx rules by default. This prevents new rules from triggering until we are ready to enable them.~~