### PR TITLE
ProductionQueue: make PauseProduction, CancelProduction virtual

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -507,19 +507,19 @@ namespace OpenRA.Mods.Common.Traits
 			return Util.ApplyPercentageModifiers(valued.Cost, modifiers);
 		}
 
-		protected void PauseProduction(string itemName, bool paused)
+		protected virtual void PauseProduction(string itemName, bool paused)
 		{
 			Queue.FirstOrDefault(a => a.Item == itemName)?.Pause(paused);
 		}
 
-		protected void CancelProduction(string itemName, uint numberToCancel)
+		protected virtual void CancelProduction(string itemName, uint numberToCancel)
 		{
 			for (var i = 0; i < numberToCancel; i++)
 				if (!CancelProductionInner(itemName))
 					break;
 		}
 
-		bool CancelProductionInner(string itemName)
+		protected bool CancelProductionInner(string itemName)
 		{
 			var item = Queue.LastOrDefault(a => a.Item == itemName);
 


### PR DESCRIPTION
This PR makes it possible to change behavior of custom `ProductionQueue` when `PauseProduction` or `CancelProduction` order is issued. The PR also changes `CancelProductionInner` accessibility to protected, so custom `ProductionQueue` can properly handle result of `CancelProductionInner`.

Original behavior of `ProductionQueue` and OpenRA's existing implementations is not affected.