### PR TITLE
Fixed BuildableTerrainOverlay ignoring scale

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/BuildableTerrainOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/BuildableTerrainOverlay.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sprite definition.")]
 		public readonly string Image = "overlay";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		[Desc("Sequence to use for unbuildable area.")]
 		public readonly string Sequence = "build-invalid";
 

--- a/OpenRA.Mods.Common/Traits/World/BuildableTerrainOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/BuildableTerrainOverlay.cs
@@ -47,6 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly BuildableTerrainOverlayInfo info;
 		readonly World world;
 		readonly Sprite disabledSprite;
+		readonly float disabledSpriteScale;
 
 		public bool Enabled = false;
 		TerrainSpriteLayer render;
@@ -59,7 +60,9 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 			world = self.World;
 
-			disabledSprite = self.World.Map.Sequences.GetSequence(info.Image, info.Sequence).GetSprite(0);
+			var spriteSequence = self.World.Map.Sequences.GetSequence(info.Image, info.Sequence);
+			disabledSprite = spriteSequence.GetSprite(0);
+			disabledSpriteScale = spriteSequence.Scale;
 		}
 
 		void IWorldLoaded.WorldLoaded(World w, WorldRenderer wr)
@@ -85,7 +88,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			var buildableSprite = !info.AllowedTerrainTypes.Contains(world.Map.GetTerrainInfo(cell).Type) || world.Map.Ramp[cell] != 0 ? disabledSprite : null;
-			render.Update(cell, buildableSprite, palette, 1f, info.Alpha);
+			render.Update(cell, buildableSprite, palette, disabledSpriteScale, info.Alpha);
 		}
 
 		void IRenderAboveWorld.RenderAboveWorld(Actor self, WorldRenderer wr)

--- a/OpenRA.Mods.D2k/Traits/Buildings/D2kActorPreviewPlaceBuildingPreview.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/D2kActorPreviewPlaceBuildingPreview.cs
@@ -33,15 +33,15 @@ namespace OpenRA.Mods.D2k.Traits
 		[Desc("Sprite image to use for the overlay.")]
 		public readonly string Image = "overlay";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		[Desc("Sprite overlay to use for valid cells.")]
 		public readonly string TileValidName = "build-valid";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		[Desc("Sprite overlay to use for invalid cells.")]
 		public readonly string TileInvalidName = "build-invalid";
 
-		[SequenceReference("Image")]
+		[SequenceReference(nameof(Image))]
 		[Desc("Sprite overlay to use for blocked cells.")]
 		public readonly string TileUnsafeName = "build-unsafe";
 


### PR DESCRIPTION
Disclaimer: we seem to be pretty inconsistent with the Scale and Alpha arguments of `TerrainSpriteLayer.Update()`, with some calling traits hardcoding `1f`, some getting the values from the relevant sprite sequence and some (this one) having trait info fields for those.