### PR TITLE
Rework PriorityQueue for performance.

### DIFF
--- a/OpenRA.Mods.Common/Pathfinder/IPathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/IPathGraph.cs
@@ -77,12 +77,8 @@ namespace OpenRA.Mods.Common.Pathfinder
 	/// </summary>
 	public readonly struct GraphConnection
 	{
-		public static readonly CostComparer ConnectionCostComparer = CostComparer.Instance;
-
-		public sealed class CostComparer : IComparer<GraphConnection>
+		public readonly struct CostComparer : IComparer<GraphConnection>
 		{
-			public static readonly CostComparer Instance = new CostComparer();
-			CostComparer() { }
 			public int Compare(GraphConnection x, GraphConnection y)
 			{
 				return x.Cost.CompareTo(y.Cost);

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -170,7 +170,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			this.heuristicWeightPercentage = heuristicWeightPercentage;
 			TargetPredicate = targetPredicate;
 			this.recorder = recorder;
-			openQueue = new PriorityQueue<GraphConnection>(GraphConnection.ConnectionCostComparer);
+			openQueue = new Primitives.PriorityQueue<GraphConnection, GraphConnection.CostComparer>(default);
 		}
 
 		void AddInitialCell(CPos location, Func<CPos, int> customCost)

--- a/OpenRA.Test/OpenRA.Game/PriorityQueueTest.cs
+++ b/OpenRA.Test/OpenRA.Game/PriorityQueueTest.cs
@@ -10,10 +10,10 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using OpenRA.Mods.Common;
-using OpenRA.Primitives;
 using OpenRA.Support;
 
 namespace OpenRA.Test
@@ -21,6 +21,11 @@ namespace OpenRA.Test
 	[TestFixture]
 	class PriorityQueueTest
 	{
+		readonly struct Int32Comparer : IComparer<int>
+		{
+			public int Compare(int x, int y) => x.CompareTo(y);
+		}
+
 		[TestCase(1, 123)]
 		[TestCase(1, 1234)]
 		[TestCase(1, 12345)]
@@ -51,7 +56,7 @@ namespace OpenRA.Test
 			var values = Enumerable.Range(0, count);
 			var shuffledValues = values.Shuffle(mt).ToArray();
 
-			var queue = new PriorityQueue<int>();
+			var queue = new Primitives.PriorityQueue<int, Int32Comparer>(default);
 
 			Assert.IsTrue(queue.Empty, "New queue should start out empty.");
 			Assert.Throws<InvalidOperationException>(() => queue.Peek(), "Peeking at an empty queue should throw.");
@@ -95,7 +100,7 @@ namespace OpenRA.Test
 			var mt = new MersenneTwister(seed);
 			var shuffledValues = Enumerable.Range(0, count).Shuffle(mt).ToArray();
 
-			var queue = new PriorityQueue<int>();
+			var queue = new Primitives.PriorityQueue<int, Int32Comparer>(default);
 
 			Assert.IsTrue(queue.Empty, "New queue should start out empty.");
 			Assert.Throws<InvalidOperationException>(() => queue.Peek(), "Peeking at an empty queue should throw.");


### PR DESCRIPTION
- Providing the comparer as a type argument that is a struct allows the calls to be devirtualised, leading to approx a 3x performance improvement.
- Use a single backing array, rather than a list of arrays.

----

Supersedes #20117, as requested. See https://github.com/OpenRA/OpenRA/pull/20117#issuecomment-1474392600 for original performance analysis.

|                                     Method |     Mean |   Error |  StdDev |
|--------------------------------- |---------:|--------:|--------:|
| `PriorityQueue<T, TComparer>` | 224.5 us | 2.00 us | 1.87 us |
|                   `PriorityQueue<T>` | 727.5 us | 4.74 us | 4.44 us |

