### PR TITLE
Extract StoresResources from Harvester

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -173,7 +173,31 @@ namespace OpenRA.Traits
 	}
 
 	[RequireExplicitImplementation]
-	public interface IStoreResources { int Capacity { get; } }
+	public interface IStoresResourcesInfo : ITraitInfoInterface
+	{
+		string[] ResourceTypes { get; }
+	}
+
+	public interface IStoresResources
+	{
+		bool HasType(string resourceType);
+
+		/// <summary>The amount of resources that can be stored.</summary>
+		int Capacity { get; }
+
+		/// <summary>Stored resources.</summary>
+		/// <remarks>Dictionary key refers to resourceType, value refers to resource amount.</remarks>
+		IReadOnlyDictionary<string, int> Contents { get; }
+
+		/// <summary>A performance cheap method of getting the total sum of contents.</summary>
+		int ContentsSum { get; }
+
+		/// <summary>Returns the amount of <paramref name="value"/> that was not added.</summary>
+		int AddResource(string resourceType, int value);
+
+		/// <summary>Returns the amount of <paramref name="value"/> that was not removed.</summary>
+		int RemoveResource(string resourceType, int value);
+	}
 
 	public interface IEffectiveOwner
 	{

--- a/OpenRA.Mods.Common/Activities/HarvestResource.cs
+++ b/OpenRA.Mods.Common/Activities/HarvestResource.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (resource.Type == null || resourceLayer.RemoveResource(resource.Type, self.Location) != 1)
 				return true;
 
-			harv.AcceptResource(self, resource.Type);
+			harv.AddResource(self, resource.Type);
 
 			foreach (var t in notifyHarvestActions)
 				t.Harvested(self, resource.Type);

--- a/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
@@ -206,12 +206,12 @@ namespace OpenRA.Mods.Common.Traits
 			return true;
 		}
 
-		public void AddStorage(int capacity)
+		public void AddStorageCapacity(int capacity)
 		{
 			ResourceCapacity += capacity;
 		}
 
-		public void RemoveStorage(int capacity)
+		public void RemoveStorageCapacity(int capacity)
 		{
 			ResourceCapacity -= capacity;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithStoresResourcesPipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithStoresResourcesPipsDecoration.cs
@@ -10,12 +10,13 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
 {
-	public class WithHarvesterPipsDecorationInfo : WithDecorationBaseInfo, Requires<HarvesterInfo>
+	public class WithStoresResourcesPipsDecorationInfo : WithDecorationBaseInfo, Requires<IStoresResourcesInfo>
 	{
 		[FieldLoader.Require]
 		[Desc("Number of pips to display how filled unit is.")]
@@ -42,26 +43,27 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[PaletteReference]
 		public readonly string Palette = "chrome";
 
-		public override object Create(ActorInitializer init) { return new WithHarvesterPipsDecoration(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithStoresResourcesPipsDecoration(init.Self, this); }
 	}
 
-	public class WithHarvesterPipsDecoration : WithDecorationBase<WithHarvesterPipsDecorationInfo>
+	public class WithStoresResourcesPipsDecoration : WithDecorationBase<WithStoresResourcesPipsDecorationInfo>
 	{
-		readonly Harvester harvester;
+		readonly IStoresResources storesResources;
 		readonly Animation pips;
 
-		public WithHarvesterPipsDecoration(Actor self, WithHarvesterPipsDecorationInfo info)
+		public WithStoresResourcesPipsDecoration(Actor self, WithStoresResourcesPipsDecorationInfo info)
 			: base(self, info)
 		{
-			harvester = self.Trait<Harvester>();
+			// TODO: allow to choose which stores resources trait to target.
+			storesResources = self.TraitsImplementing<IStoresResources>().First();
 			pips = new Animation(self.World, info.Image);
 		}
 
 		string GetPipSequence(int i)
 		{
-			var n = i * harvester.Info.Capacity / Info.PipCount;
+			var n = i * storesResources.Capacity / Info.PipCount;
 
-			foreach (var rt in harvester.Contents)
+			foreach (var rt in storesResources.Contents)
 			{
 				if (n < rt.Value)
 				{

--- a/OpenRA.Mods.Common/Traits/StoresPlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/StoresPlayerResources.cs
@@ -1,0 +1,67 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Adds capacity to a player's harvested resource limit.")]
+	public class StoresPlayerResourcesInfo : TraitInfo
+	{
+		[FieldLoader.Require]
+		public readonly int Capacity = 0;
+
+		public override object Create(ActorInitializer init) { return new StoresPlayerResources(init.Self, this); }
+	}
+
+	public class StoresPlayerResources : INotifyOwnerChanged, INotifyCapture, INotifyKilled, INotifyAddedToWorld, INotifyRemovedFromWorld
+	{
+		readonly StoresPlayerResourcesInfo info;
+		PlayerResources player;
+
+		public int Stored => player.ResourceCapacity == 0 ? 0 : (int)((long)info.Capacity * player.Resources / player.ResourceCapacity);
+
+		public StoresPlayerResources(Actor self, StoresPlayerResourcesInfo info)
+		{
+			this.info = info;
+			player = self.Owner.PlayerActor.Trait<PlayerResources>();
+		}
+
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		{
+			player = newOwner.PlayerActor.Trait<PlayerResources>();
+		}
+
+		void INotifyCapture.OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner, BitSet<CaptureType> captureTypes)
+		{
+			var resources = Stored;
+			oldOwner.PlayerActor.Trait<PlayerResources>().TakeResources(resources);
+			newOwner.PlayerActor.Trait<PlayerResources>().GiveResources(resources);
+		}
+
+		void INotifyKilled.Killed(Actor self, AttackInfo e)
+		{
+			// Lose the stored resources.
+			player.TakeResources(Stored);
+		}
+
+		void INotifyAddedToWorld.AddedToWorld(Actor self)
+		{
+			player.AddStorageCapacity(info.Capacity);
+		}
+
+		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
+		{
+			player.RemoveStorageCapacity(info.Capacity);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230801/ExtractResourceStorageFromHarvester.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230801/ExtractResourceStorageFromHarvester.cs
@@ -1,0 +1,49 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class ExtractResourceStorageFromHarvester : UpdateRule
+	{
+		public override string Name => "Renames StoresResources to StoresPlayerResources and extracts StoresResources from Harvester.";
+
+		public override string Description =>
+			"Resource storage was extracted from Harvester. WithHarvesterPipsDecoration was also renamed to WithStoresResourcesPipsDecoration.";
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
+		{
+			actorNode.RenameChildrenMatching("StoresResources", "StoresPlayerResources");
+			actorNode.RenameChildrenMatching("WithHarvesterPipsDecoration", "WithStoresResourcesPipsDecoration");
+
+			var harvester = actorNode.LastChildMatching("Harvester", false);
+			if (harvester == null)
+				yield break;
+
+			var storesResources = new MiniYamlNodeBuilder("StoresResources", "");
+			var capacity = harvester.LastChildMatching("Capacity", false);
+			if (capacity != null)
+			{
+				storesResources.AddNode(capacity);
+				harvester.RemoveNode(capacity);
+			}
+
+			var resources = harvester.LastChildMatching("Resources", false);
+			if (resources != null)
+				storesResources.AddNode(resources);
+
+			actorNode.AddNode(storesResources);
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -109,6 +109,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 			{
 				// bleed only changes here.
 				new RemoveValidRelationsFromCapturable(),
+				new ExtractResourceStorageFromHarvester(),
 
 				// Execute these rules last to avoid premature yaml merge crashes.
 				new AbstractDocking(),

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -219,7 +219,7 @@
 			red: pip-red
 
 ^StoresResources:
-	StoresResources:
+	StoresPlayerResources:
 	WithResourceStoragePipsDecoration:
 		Position: BottomLeft
 		Margin: 4, 3

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -247,7 +247,7 @@ PROC:
 		IsDragRequired: True
 		DragOffset: -554,512,0
 		DragLength: 12
-	StoresResources:
+	StoresPlayerResources:
 		Capacity: 1000
 	Selectable:
 		Bounds: 3072, 2389
@@ -291,7 +291,7 @@ SILO:
 	-WithSpriteBody:
 	WithResourceLevelSpriteBody:
 		Sequence: stages
-	StoresResources:
+	StoresPlayerResources:
 		Capacity: 3000
 	-SpawnActorsOnSell:
 	Power:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -56,13 +56,15 @@ HARV:
 		DecorationBounds: 1536, 1536
 	Harvester:
 		Resources: Tiberium, BlueTiberium
-		Capacity: 20
 		BaleLoadDelay: 12
 		BaleUnloadDelay: 6
 		SearchFromProcRadius: 15
 		SearchFromHarvesterRadius: 8
 		HarvestFacings: 8
 		EmptyCondition: no-tiberium
+	StoresResources:
+		Capacity: 20
+		Resources: Tiberium, BlueTiberium
 	DockClientManager:
 	Mobile:
 		Speed: 72
@@ -89,7 +91,7 @@ HARV:
 	Explodes:
 		RequiresCondition: !no-tiberium
 		Weapon: TiberiumExplosion
-	WithHarvesterPipsDecoration:
+	WithStoresResourcesPipsDecoration:
 		Position: BottomLeft
 		Margin: 4, 3
 		RequiresSelection: true

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -287,7 +287,7 @@ refinery:
 		Type: Unload
 		DockAngle: 640
 		DockOffset: 1c0,512,0
-	StoresResources:
+	StoresPlayerResources:
 		Capacity: 2000
 	CustomSellValue:
 		Value: 500
@@ -357,7 +357,7 @@ silo:
 	-WithSpriteBody:
 	WithResourceLevelSpriteBody:
 		Sequence: stages
-	StoresResources:
+	StoresPlayerResources:
 		Capacity: 2000
 	-SpawnActorsOnSell:
 	Power:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -70,12 +70,14 @@ harvester:
 		Class: harvester
 		DecorationBounds: 1344, 1344
 	Harvester:
-		Capacity: 28
 		HarvestFacings: 8
 		Resources: Spice
 		BaleUnloadDelay: 5
 		SearchFromProcRadius: 30
 		SearchFromHarvesterRadius: 15
+	StoresResources:
+		Capacity: 28
+		Resources: Spice
 	DockClientManager:
 	CarryableHarvester:
 	Health:
@@ -107,7 +109,7 @@ harvester:
 		Delay: 3
 		StartIfBelow: 50
 	-RevealOnFire:
-	WithHarvesterPipsDecoration:
+	WithStoresResourcesPipsDecoration:
 		Position: BottomLeft
 		Margin: 1, 4
 		RequiresSelection: true

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1290,7 +1290,7 @@ PROC:
 		Type: Unload
 		DockAngle: 256
 		DockOffset: 0, 1c0, 0
-	StoresResources:
+	StoresPlayerResources:
 		Capacity: 2000
 	CustomSellValue:
 		Value: 300
@@ -1375,7 +1375,7 @@ SILO:
 	-WithSpriteBody:
 	WithResourceLevelSpriteBody:
 		Sequence: stages
-	StoresResources:
+	StoresPlayerResources:
 		Capacity: 3000
 	-SpawnActorsOnSell:
 	Power:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -320,13 +320,15 @@ HARV:
 	Selectable:
 		DecorationBounds: 1792, 1792
 	Harvester:
-		Capacity: 20
 		Resources: Ore,Gems
 		BaleUnloadDelay: 1
 		SearchFromProcRadius: 15
 		SearchFromHarvesterRadius: 8
 		HarvestFacings: 8
 		EmptyCondition: no-ore
+	StoresResources:
+		Capacity: 20
+		Resources: Ore,Gems
 	DockClientManager:
 	Health:
 		HP: 60000
@@ -357,7 +359,7 @@ HARV:
 	WithHarvesterSpriteBody:
 		ImageByFullness: harvempty, harvhalf, harv
 	-WithFacingSpriteBody:
-	WithHarvesterPipsDecoration:
+	WithStoresResourcesPipsDecoration:
 		Position: BottomLeft
 		Margin: 4, 3
 		RequiresSelection: true

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -593,7 +593,7 @@ NAWAST:
 		Type: UnloadWeed
 		DockAngle: 640
 		DockOffset: 724,724,0
-	StoresResources:
+	StoresPlayerResources:
 		Capacity: 56
 	Power:
 		Amount: -40

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -352,13 +352,15 @@ WEED:
 		Description: Collects veins for processing.\n  Unarmed
 	Harvester:
 		Type: UnloadWeed
-		Capacity: 7
 		Resources: Veins
 		BaleUnloadDelay: 20
 		BaleLoadDelay: 40
 		SearchFromProcRadius: 72
 		SearchFromHarvesterRadius: 36
 		HarvestVoice: Attack
+	StoresResources:
+		Capacity: 7
+		Resources: Veins
 	DockClientManager:
 		Voice: Move
 	Mobile:
@@ -381,7 +383,7 @@ WEED:
 	WithVoxelUnloadBody:
 	-DamagedByTerrain@VEINS:
 	-LeavesTrails@VEINS:
-	WithHarvesterPipsDecoration:
+	WithStoresResourcesPipsDecoration:
 		Position: BottomLeft
 		RequiresSelection: true
 		Margin: 5, 2

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -125,7 +125,7 @@ PROC:
 		Type: Unload
 		DockAngle: 640
 		DockOffset: 362,362,0
-	StoresResources:
+	StoresPlayerResources:
 		Capacity: 2000
 	CustomSellValue:
 		Value: 600
@@ -211,7 +211,7 @@ GASILO:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-lights-bright
 		Palette: bright
-	StoresResources:
+	StoresPlayerResources:
 		Capacity: 1500
 	Power:
 		Amount: -10

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -59,7 +59,6 @@ HARV:
 		Bounds: 1086, 2172
 		DecorationBounds: 1086, 2172
 	Harvester:
-		Capacity: 28
 		Resources: Tiberium, BlueTiberium
 		BaleLoadDelay: 15
 		BaleUnloadDelay: 15
@@ -68,6 +67,9 @@ HARV:
 		SearchFromHarvesterRadius: 18
 		HarvestVoice: Attack
 		EmptyCondition: no-tiberium
+	StoresResources:
+		Capacity: 28
+		Resources: Tiberium, BlueTiberium
 	DockClientManager:
 		Voice: Move
 	Mobile:
@@ -100,7 +102,7 @@ HARV:
 			nod: harv.nod
 	-DamagedByTerrain@VEINS:
 	-LeavesTrails@VEINS:
-	WithHarvesterPipsDecoration:
+	WithStoresResourcesPipsDecoration:
 		Position: BottomLeft
 		RequiresSelection: true
 		Margin: 5, 2


### PR DESCRIPTION
This is the first PR of the resource refactor. 

- Renamed StoresResources -> StoresPlayerResources
- Extracted StoresResources from Harvester (StoresResources diff is messed up)
- Renamed WithHarvesterPipsDecoration -> WithStoresResourcesPipsDecoration

This was an easy first step that could be done before docking refactor or the massive systematic changes to player resources.

With this PR harvesters will be able to have multiple storage containers, although the pips will be shown for only the one (consistent with most of our UI traits). We may want to create a way of tying those traits together somehow in the future.

We may also want to consider adding per-resource conditions so enable features such as TS harvester exploding when containing blue tib. I can add this feature in this PR if requested.