### PR TITLE
Fix reversed path searches from inaccessible locations.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -127,9 +127,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (searchCells.Count == 0)
 				return PathFinder.NoPath;
 
-			var path = Mobile.PathFinder.FindPathToTargetCell(self, searchCells, loc, check);
-			path.Reverse();
-			return path;
+			return Mobile.PathFinder.FindPathToTargetCells(self, loc, searchCells, check);
 		}
 
 		public override IEnumerable<Target> GetTargets(Actor self)

--- a/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
+++ b/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
@@ -73,13 +73,13 @@ namespace OpenRA.Mods.Common.Pathfinder
 	/// nodes, but uses a heuristic informed from the previous level to guide the search in the right direction.</para>
 	///
 	/// <para>This implementation is aware of movement costs over terrain given by
-	/// <see cref="Locomotor.MovementCostToEnterCell(Actor, CPos, CPos, BlockedByActor, Actor)"/>. It is aware of
+	/// <see cref="Locomotor.MovementCostToEnterCell(Actor, CPos, CPos, BlockedByActor, Actor, bool)"/>. It is aware of
 	/// changes to the costs in terrain and able to update the abstract graph when this occurs. It is able to search
 	/// the abstract graph as if <see cref="BlockedByActor.None"/> had been specified. If
 	/// <see cref="BlockedByActor.Immovable"/> is given in the constructor, the abstract graph will additionally
 	/// account for a subset of immovable actors using the same rules as
-	/// <see cref="Locomotor.CanMoveFreelyInto(Actor, CPos, SubCell, BlockedByActor, Actor)"/>. It will be aware of
-	/// changes to actors on the map and update the abstract graph when this occurs. Other types of blocking actors
+	/// <see cref="Locomotor.CanMoveFreelyInto(Actor, CPos, SubCell, BlockedByActor, Actor, bool)"/>. It will be aware
+	/// of changes to actors on the map and update the abstract graph when this occurs. Other types of blocking actors
 	/// will not be accounted for in the heuristic.</para>
 	///
 	/// <para>If the obstacle on the map is from terrain (e.g. a cliff or lake) the heuristic will work well. If the
@@ -633,14 +633,14 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 		/// <summary>
 		/// <see cref="BlockedByActor.Immovable"/> defines immovability based on the mobile trait. The blocking rules
-		/// in <see cref="Locomotor.CanMoveFreelyInto(Actor, CPos, SubCell, BlockedByActor, Actor)"/> allow units to
-		/// pass these immovable actors if they are temporary blockers (e.g. gates) or crushable by the locomotor.
+		/// in <see cref="Locomotor.CanMoveFreelyInto(Actor, CPos, SubCell, BlockedByActor, Actor, bool)"/> allow units
+		/// to pass these immovable actors if they are temporary blockers (e.g. gates) or crushable by the locomotor.
 		/// Since our abstract graph must work for any actor, we have to be conservative and can only consider a subset
 		/// of the immovable actors in the graph - ones we know cannot be passed by some actors due to these rules.
 		/// Both this and <see cref="ActorCellIsBlocking"/> must be true for a cell to be blocked.
 		///
 		/// This method is dependant on the logic in
-		/// <see cref="Locomotor.CanMoveFreelyInto(Actor, CPos, SubCell, BlockedByActor, Actor)"/> and
+		/// <see cref="Locomotor.CanMoveFreelyInto(Actor, CPos, SubCell, BlockedByActor, Actor, bool)"/> and
 		/// <see cref="Locomotor.UpdateCellBlocking"/>. This method must be kept in sync with changes in the locomotor
 		/// rules.
 		/// </summary>

--- a/OpenRA.Mods.Common/Pathfinder/IPathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/IPathGraph.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// <remarks>PERF: Returns a <see cref="List{T}"/> rather than an <see cref="IEnumerable{T}"/> as enumerating
 		/// this efficiently is important for pathfinding performance. Callers should interact with this as an
 		/// <see cref="IEnumerable{T}"/> and not mutate the result.</remarks>
-		List<GraphConnection> GetConnections(CPos source);
+		List<GraphConnection> GetConnections(CPos source, Func<CPos, bool> targetPredicate);
 
 		/// <summary>
 		/// Gets or sets the pathfinding information for a given node.

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			var graph = new MapPathGraph(LayerPoolForWorld(world), locomotor, self, world, check, customCost, ignoreActor, laneBias, false);
 			var search = new PathSearch(graph, loc => 0, 0, targetPredicate, recorder);
 
-			AddInitialCells(world, locomotor, froms, customCost, search);
+			AddInitialCells(world, locomotor, self, froms, check, customCost, ignoreActor, false, search);
 
 			return search;
 		}
@@ -71,11 +71,22 @@ namespace OpenRA.Mods.Common.Pathfinder
 			heuristic = heuristic ?? DefaultCostEstimator(locomotor, target);
 			var search = new PathSearch(graph, heuristic, heuristicWeightPercentage, loc => loc == target, recorder);
 
-			AddInitialCells(world, locomotor, froms, customCost, search);
+			AddInitialCells(world, locomotor, self, froms, check, customCost, ignoreActor, inReverse, search);
 
 			return search;
 		}
 
+		/// <summary>
+		/// Determines if a cell is a valid pathfinding location.
+		/// <list type="bullet">
+		/// <item>It is in the world.</item>
+		/// <item>It is either on the ground layer (0) or on an *enabled* custom movement layer.</item>
+		/// <item>It has not been excluded by the <paramref name="customCost"/>.</item>
+		/// </list>
+		/// If required, follow this with a call to
+		/// <see cref="Locomotor.MovementCostToEnterCell(Actor, CPos, CPos, BlockedByActor, Actor, bool)"/> to
+		/// determine if the cell is accessible.
+		/// </summary>
 		public static bool CellAllowsMovement(World world, Locomotor locomotor, CPos cell, Func<CPos, int> customCost)
 		{
 			return world.Map.Contains(cell) &&
@@ -83,10 +94,18 @@ namespace OpenRA.Mods.Common.Pathfinder
 				(customCost == null || customCost(cell) != PathGraph.PathCostForInvalidPath);
 		}
 
-		static void AddInitialCells(World world, Locomotor locomotor, IEnumerable<CPos> froms, Func<CPos, int> customCost, PathSearch search)
+		static void AddInitialCells(World world, Locomotor locomotor, Actor self, IEnumerable<CPos> froms,
+			BlockedByActor check, Func<CPos, int> customCost, Actor ignoreActor, bool inReverse, PathSearch search)
 		{
+			// A source cell is allowed to have an unreachable movement cost.
+			// Therefore we don't need to check if the cell is accessible, only that it allows movement.
+			// *Unless* the search is being done in reverse, in this case the source is really a target,
+			// and a target is required to have a reachable cost.
+			// We also need to ignore self, so we don't consider the location blocked by ourselves!
 			foreach (var sl in froms)
-				if (CellAllowsMovement(world, locomotor, sl, customCost))
+				if (CellAllowsMovement(world, locomotor, sl, customCost) &&
+					(!inReverse || locomotor.MovementCostToEnterCell(self, sl, check, ignoreActor, true)
+						!= PathGraph.MovementCostForUnreachableCell))
 					search.AddInitialCell(sl, customCost);
 		}
 
@@ -229,7 +248,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			var currentInfo = Graph[currentMinNode];
 			Graph[currentMinNode] = new CellInfo(CellStatus.Closed, currentInfo.CostSoFar, currentInfo.EstimatedTotalCost, currentInfo.PreviousNode);
 
-			foreach (var connection in Graph.GetConnections(currentMinNode))
+			foreach (var connection in Graph.GetConnections(currentMinNode, TargetPredicate))
 			{
 				// Calculate the cost up to that point
 				var costSoFarToNeighbor = currentInfo.CostSoFar + connection.Cost;

--- a/OpenRA.Mods.Common/Pathfinder/SparsePathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/SparsePathGraph.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			info = new Dictionary<CPos, CellInfo>(estimatedSearchSize);
 		}
 
-		public List<GraphConnection> GetConnections(CPos position)
+		public List<GraphConnection> GetConnections(CPos position, Func<CPos, bool> targetPredicate)
 		{
 			return edges(position) ?? new List<GraphConnection>();
 		}

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -198,8 +198,8 @@ namespace OpenRA.Mods.Common.Traits
 				return null;
 
 			// Start a search from each refinery's delivery location:
-			var path = mobile.PathFinder.FindPathToTargetCell(
-				self, refineries.Select(r => r.Key), self.Location, BlockedByActor.None,
+			var path = mobile.PathFinder.FindPathToTargetCells(
+				self, self.Location, refineries.Select(r => r.Key), BlockedByActor.None,
 				location =>
 				{
 					if (!refineries.ContainsKey(location))
@@ -211,7 +211,7 @@ namespace OpenRA.Mods.Common.Traits
 				});
 
 			if (path.Count > 0)
-				return refineries[path.Last()].Actor;
+				return refineries[path[0]].Actor;
 
 			return null;
 		}

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -125,7 +125,7 @@ namespace OpenRA.Mods.Common.Traits
 				   .SingleOrDefault(l => l.Info.Name == Locomotor);
 
 			return locomotor.MovementCostToEnterCell(
-				self, cell, check, ignoreActor, subCell) != PathGraph.MovementCostForUnreachableCell;
+				self, cell, check, ignoreActor, false, subCell) != PathGraph.MovementCostForUnreachableCell;
 		}
 
 		public bool CanStayInCell(World world, CPos cell)

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -797,8 +797,25 @@ namespace OpenRA.Mods.Common.Traits
 		/// Returned path is *reversed* and given target to source.
 		/// The shortest path between a source and the target is returned.
 		/// </summary>
+		/// <remarks>Path searches are not guaranteed to by symmetric,
+		/// the source and target locations cannot be swapped.
+		/// Call <see cref="FindPathToTargetCells"/> instead.</remarks>
 		List<CPos> FindPathToTargetCell(
 			Actor self, IEnumerable<CPos> sources, CPos target, BlockedByActor check,
+			Func<CPos, int> customCost = null,
+			Actor ignoreActor = null,
+			bool laneBias = true);
+
+		/// <summary>
+		/// Calculates a path for the actor from source to multiple possible targets.
+		/// Returned path is *reversed* and given target to source.
+		/// The shortest path between the source and a target is returned.
+		/// </summary>
+		/// <remarks>Path searches are not guaranteed to by symmetric,
+		/// the source and target locations cannot be swapped.
+		/// Call <see cref="FindPathToTargetCell"/> instead.</remarks>
+		List<CPos> FindPathToTargetCells(
+			Actor self, CPos source, IEnumerable<CPos> targets, BlockedByActor check,
 			Func<CPos, int> customCost = null,
 			Actor ignoreActor = null,
 			bool laneBias = true);
@@ -819,6 +836,8 @@ namespace OpenRA.Mods.Common.Traits
 		/// Only terrain is taken into account, i.e. as if <see cref="BlockedByActor.None"/> was given.
 		/// This would apply for any actor using the given <see cref="Locomotor"/>.
 		/// </summary>
+		/// <remarks>Path searches are not guaranteed to by symmetric,
+		/// the source and target locations cannot be swapped.</remarks>
 		bool PathExistsForLocomotor(Locomotor locomotor, CPos source, CPos target);
 	}
 }


### PR DESCRIPTION
The Harvester trait and MoveAdjacentTo activity called the pathfinder but had a single source and multiple targets. The pathfinder interface only allows for the opposite: multiple sources and a single target. To work around this they would swap the inputs. This works in most cases but not all cases. One aspect of asymmetry is that an actor may move out of an inaccessible source cell, but not onto an inaccessible target cell.

Searches that involved an inaccessible source cell and that applied this swapping method would therefore fail to return a path, when a valid path was possible. Although a rare case, once good way to reproduce is to use a production building that spawns actors on inaccessible cells around it, such as the RA naval yard. A move order uses the pathfinder correctly and the unit will move out. Using a force attack causes the unit to use the broken "swapped" mechanism in MoveAdjacentTo and it will be stuck.

This asymmetry has been longstanding but the pathfinding infrastructure only sporadically accounted for it. It is now documented and applied consistently. Create a new overload on the pathfinder trait that allows a single source and multiple targets, so callers have an overload that does what they need and won't be tempted to swap the positions and run into this issue.

----

Recommended for prep.

Broken behaviour on bleed - a ship built by the naval yard spawns on an inaccessible location. Force attacking to the other side results in a failing to find a path due to the bug. The fallback path ignores actors on the map and suggests moving through the yard. The ship is stuck.

![image](https://user-images.githubusercontent.com/3399086/228022331-6b26f253-48ca-42a2-8425-495f590c06b5.png)

Working behaviour on this PR - the path search goes around the naval yard and correctly ignores the inaccessible locations the naval yard occupies.

![image](https://user-images.githubusercontent.com/3399086/228022901-3aa99ce0-9d66-4891-98e1-e0392a963600.png)
