### PR TITLE
Allow WithDamageOverlay to loop multiple times.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly string Image = "smoke_m";
 
 		[SequenceReference(nameof(Image))]
-		public readonly string IdleSequence = "idle";
+		public readonly string StartSequence = "start";
 
 		[SequenceReference(nameof(Image))]
 		public readonly string LoopSequence = "loop";
@@ -54,8 +54,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public IEnumerable<string> GetSequences(MersenneTwister random)
 		{
-			if (!string.IsNullOrEmpty(IdleSequence))
-				yield return IdleSequence;
+			if (!string.IsNullOrEmpty(StartSequence))
+				yield return StartSequence;
 
 			if (!string.IsNullOrEmpty(LoopSequence))
 			{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20231010/WithDamageOverlayPropertyRename.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20231010/WithDamageOverlayPropertyRename.cs
@@ -1,0 +1,54 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class WithDamageOverlayPropertyRename : UpdateRule, IBeforeUpdateActors
+	{
+		public override string Name => "Renamed `WithDamageOverlay`'s `IdleSequence` to `StartSequence`.";
+
+		public override string Description => "WithDamageOverlay's property `IdleSequence` was renamed to `StartSequence` and functionality of WithDamageOverlay changed.";
+
+		readonly List<(string, string)> hasDefault = new();
+
+		public IEnumerable<string> BeforeUpdateActors(ModData modData, List<MiniYamlNodeBuilder> resolvedActors)
+		{
+			foreach (var actorNode in resolvedActors)
+				foreach (var damage in actorNode.ChildrenMatching("WithDamageOverlay"))
+					if (damage.LastChildMatching("IdleSequence", false) != null)
+						hasDefault.Add((actorNode.Key, damage.Key));
+
+			yield break;
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
+		{
+			foreach (var damage in actorNode.ChildrenMatching("WithDamageOverlay"))
+			{
+				var renamed = false;
+				foreach (var start in damage.ChildrenMatching("IdleSequence"))
+				{
+					start.RenameKey("StartSequence");
+					renamed = true;
+				}
+
+				if (!renamed && !hasDefault.Contains((actorNode.Key, damage.Key)))
+					damage.AddNode("StartSequence", "idle");
+
+				damage.AddNode("LoopCount", 1);
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -89,6 +89,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				// Execute these rules last to avoid premature yaml merge crashes.
 				new ReplaceCloakPalette(),
 				new AbstractDocking(),
+				new WithDamageOverlayPropertyRename(),
 			}),
 		};
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -963,16 +963,19 @@
 	WithDamageOverlay@SmallBurn:
 		DamageTypes: Incendiary
 		Image: burn-s
+		LoopCount: 1, 4
 		MinimumDamageState: Light
 		MaximumDamageState: Medium
 	WithDamageOverlay@MediumBurn:
 		DamageTypes: Incendiary
 		Image: burn-m
+		LoopCount: 1, 4
 		MinimumDamageState: Medium
 		MaximumDamageState: Heavy
 	WithDamageOverlay@LargeBurn:
 		DamageTypes: Incendiary
 		Image: burn-l
+		LoopCount: 1, 4
 		MinimumDamageState: Heavy
 		MaximumDamageState: Dead
 	HiddenUnderShroud:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -252,6 +252,7 @@
 	HiddenUnderFog:
 	AttackMove:
 	WithDamageOverlay:
+		EndSequence:
 	WithFacingSpriteBody:
 	Explodes:
 		Weapon: UnitExplodeSmall
@@ -660,6 +661,7 @@
 		TextNotification: notification-unit-lost
 	AttackMove:
 	WithDamageOverlay:
+		EndSequence:
 	Explodes:
 		Weapon: UnitExplodeShip
 		EmptyWeapon: UnitExplodeShip

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -78,10 +78,6 @@ smoke_m:
 		Length: 42
 		Offset: 2, -5
 		ZOffset: 512
-	end:
-		Frames: 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0
-		Offset: 2, -5
-		ZOffset: 512
 
 scorch_flames:
 	large_flame:

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -19,8 +19,8 @@ fire:
 burn-l:
 	Defaults:
 		Filename: burn-l.shp
-	idle:
-		Length: *
+	start:
+		Length: 16
 		ZOffset: 512
 	loop:
 		Start: 16
@@ -34,8 +34,8 @@ burn-l:
 burn-m:
 	Defaults:
 		Filename: burn-m.shp
-	idle:
-		Length: *
+	start:
+		Length: 16
 		ZOffset: 512
 	loop:
 		Start: 16
@@ -49,8 +49,8 @@ burn-m:
 burn-s:
 	Defaults:
 		Filename: burn-s.shp
-	idle:
-		Length: *
+	start:
+		Length: 12
 		ZOffset: 512
 	loop:
 		Start: 12
@@ -71,6 +71,10 @@ smoke_m:
 		Filename: smoke_m.shp
 	idle:
 		Length: *
+		Offset: 2, -5
+		ZOffset: 512
+	start:
+		Length: 49
 		Offset: 2, -5
 		ZOffset: 512
 	loop:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -274,6 +274,7 @@
 	GpsDot:
 		String: Vehicle
 	WithDamageOverlay:
+		EndSequence:
 	Guard:
 	Guardable:
 	Tooltip:
@@ -531,6 +532,7 @@
 	GpsDot:
 		String: Ship
 	WithDamageOverlay:
+		EndSequence:
 	Explodes:
 		Weapon: UnitExplodeShip
 		EmptyWeapon: UnitExplodeShip
@@ -570,6 +572,7 @@
 	-MustBeDestroyed:
 	WithDamageOverlay:
 		MinimumDamageState: Critical
+		EndSequence:
 
 ^NeutralPlane:
 	Inherits@1: ^ExistsInWorld

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -979,18 +979,21 @@
 	WithDamageOverlay@SmallBurn:
 		DamageTypes: Incendiary
 		Image: burn-s
+		LoopCount: 1, 4
 		Palette: effect
 		MinimumDamageState: Light
 		MaximumDamageState: Medium
 	WithDamageOverlay@MediumBurn:
 		DamageTypes: Incendiary
 		Image: burn-m
+		LoopCount: 1, 4
 		Palette: effect
 		MinimumDamageState: Medium
 		MaximumDamageState: Heavy
 	WithDamageOverlay@LargeBurn:
 		DamageTypes: Incendiary
 		Image: burn-l
+		LoopCount: 1, 4
 		Palette: effect
 		MinimumDamageState: Heavy
 		MaximumDamageState: Dead

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -231,10 +231,6 @@ smoke_m:
 		Length: 42
 		Offset: 2, -5
 		ZOffset: 512
-	end:
-		Frames: 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0
-		Offset: 2, -5
-		ZOffset: 512
 
 scorch_flames:
 	large_flame:

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -83,8 +83,8 @@ explosion:
 burn-l:
 	Defaults:
 		Filename: burn-l.shp
-	idle:
-		Length: *
+	start:
+		Length: 16
 		ZOffset: 512
 	loop:
 		Start: 16
@@ -98,8 +98,8 @@ burn-l:
 burn-m:
 	Defaults:
 		Filename: burn-m.shp
-	idle:
-		Length: *
+	start:
+		Length: 16
 		ZOffset: 512
 	loop:
 		Start: 16
@@ -113,8 +113,8 @@ burn-m:
 burn-s:
 	Defaults:
 		Filename: burn-s.shp
-	idle:
-		Length: *
+	start:
+		Length: 12
 		ZOffset: 512
 	loop:
 		Start: 12
@@ -224,6 +224,10 @@ smoke_m:
 		Filename: smoke_m.shp
 	idle:
 		Length: *
+		Offset: 2, -5
+		ZOffset: 512
+	start:
+		Length: 49
 		Offset: 2, -5
 		ZOffset: 512
 	loop:


### PR DESCRIPTION
Supersedes #20749

* Loop sequence can be played a specified or random amount
* Sequences can now be null
* Renamed `IdleSequence` to `StartSequence` and redefined sequences.
* Removed `smoke_m` `EndSequence` (because it looks absolutely terrible)
* Trees now burn a random duration