### PR TITLE
Armament + WithMuzzleOverlay: option to specify separate offset for muzzle overlay

### DIFF
--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -40,8 +40,9 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int FireDelay = 0;
 
 		[Desc("Muzzle position relative to turret or body, (forward, right, up) triples.",
-			"If weapon Burst = 1, it cycles through all listed offsets, otherwise the offset corresponding to current burst is used.")]
-		public readonly WVec[] LocalOffset = Array.Empty<WVec>();
+			"Each offset defines one barrel of the armament. If none is specified, defaults to 1 barrel (with offset 0,0,0).",
+			"If weapon " + nameof(GameRules.WeaponInfo.Burst) + " = 1, it cycles through all listed offsets, otherwise the offset corresponding to current burst is used.")]
+		public readonly WVec[] LocalOffsets = Array.Empty<WVec>();
 
 		[Desc("Muzzle yaw relative to turret or body.")]
 		public readonly WAngle[] LocalYaw = Array.Empty<WAngle>();
@@ -140,11 +141,11 @@ namespace OpenRA.Mods.Common.Traits
 			Burst = Weapon.Burst;
 
 			var barrels = new List<Barrel>();
-			for (var i = 0; i < info.LocalOffset.Length; i++)
+			for (var i = 0; i < info.LocalOffsets.Length; i++)
 			{
 				barrels.Add(new Barrel
 				{
-					Offset = info.LocalOffset[i],
+					Offset = info.LocalOffsets[i],
 					Yaw = info.LocalYaw.Length > i ? info.LocalYaw[i] : WAngle.Zero
 				});
 			}

--- a/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 					visible.Add(barrel, false);
 					anims.Add(barrel,
 						new AnimationWithOffset(muzzleFlash,
-							() => info.IgnoreOffset ? WVec.Zero : arm.MuzzleOffset(self, barrel),
+							() => info.IgnoreOffset ? WVec.Zero : arm.MuzzleOverlayOffset(self, barrel),
 							() => IsTraitDisabled || !visible[barrel],
 							p => RenderUtils.ZOffsetFromCenter(self, p, 2)));
 				}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230225/RenameArmamentLocalOffset.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230225/RenameArmamentLocalOffset.cs
@@ -1,0 +1,31 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RenameArmamentLocalOffset : UpdateRule
+	{
+		public override string Name => "Rename 'LocalOffset' field on `Armament` trait to 'LocalOffsets'.";
+
+		public override string Description => "The 'LocalOffset' field on `Armament` trait has been renamed to 'LocalOffsets'.";
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var armamentNode in actorNode.ChildrenMatching("Armament"))
+				foreach (var localOffsetNode in armamentNode.ChildrenMatching("LocalOffset"))
+					localOffsetNode.RenameKey("LocalOffsets");
+
+			yield break;
+		}
+	}
+}

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -76,13 +76,13 @@ HELI:
 		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: HeliAGGun
-		LocalOffset: 128,-213,-85, 128,213,-85
+		LocalOffsets: 128,-213,-85, 128,213,-85
 		MuzzleSequence: muzzle
 		PauseOnCondition: !ammo
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: HeliAAGun
-		LocalOffset: 128,-213,-85, 128,213,-85
+		LocalOffsets: 128,-213,-85, 128,213,-85
 		MuzzleSequence: muzzle
 		PauseOnCondition: !ammo
 	AttackMove:
@@ -147,11 +147,11 @@ ORCA:
 		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: OrcaAGMissiles
-		LocalOffset: 427,-171,-213, 427,171,-213
+		LocalOffsets: 427,-171,-213, 427,171,-213
 		PauseOnCondition: !ammo
 	Armament@SECONDARY:
 		Weapon: OrcaAAMissiles
-		LocalOffset: 427,-171,-213, 427,171,-213
+		LocalOffsets: 427,-171,-213, 427,171,-213
 		PauseOnCondition: !ammo
 	AttackMove:
 		Voice: Attack
@@ -247,12 +247,12 @@ A10:
 	Armament@GUNS:
 		Name: gun
 		Weapon: Vulcan
-		LocalOffset: 1024,0,-85
+		LocalOffsets: 1024,0,-85
 	WithMuzzleOverlay:
 	Armament@BOMBS:
 		Name: bombs
 		Weapon: Napalm
-		LocalOffset: 0,-256,-43, 0,256,-43
+		LocalOffsets: 0,-256,-43, 0,256,-43
 	Contrail@1:
 		Offset: -640,171,0
 		TrailLength: 15

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -590,7 +590,7 @@
 		Name: Visceroid
 	Armament:
 		Weapon: Chemspray
-		LocalOffset: 384,0,0
+		LocalOffsets: 384,0,0
 		MuzzleSequence: muzzle
 	AttackFrontal:
 		Voice: Attack

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -55,7 +55,7 @@ E2:
 		ScanRadius: 4
 	Armament:
 		Weapon: Grenade
-		LocalOffset: 0,0,427
+		LocalOffsets: 0,0,427
 		FireDelay: 15
 	AttackFrontal:
 		Voice: Attack
@@ -95,7 +95,7 @@ E3:
 		ScanRadius: 6
 	Armament:
 		Weapon: Rockets
-		LocalOffset: 256,43,341
+		LocalOffsets: 256,43,341
 		FireDelay: 5
 	AttackFrontal:
 		Voice: Attack
@@ -131,7 +131,7 @@ E4:
 		ScanRadius: 4
 	Armament:
 		Weapon: Flamethrower
-		LocalOffset: 341,0,256
+		LocalOffsets: 341,0,256
 		FireDelay: 3
 		MuzzleSequence: muzzle
 	AttackFrontal:
@@ -170,7 +170,7 @@ E5:
 		ScanRadius: 4
 	Armament:
 		Weapon: Chemspray
-		LocalOffset: 341,0,256
+		LocalOffsets: 341,0,256
 		FireDelay: 3
 		MuzzleSequence: muzzle
 	AttackFrontal:

--- a/mods/cnc/rules/ships.yaml
+++ b/mods/cnc/rules/ships.yaml
@@ -23,7 +23,7 @@ BOAT:
 		Offset: 0,896,171
 	Armament:
 		Weapon: BoatMissile
-		LocalOffset: 85,-85,0, 85,85,0
+		LocalOffsets: 85,-85,0, 85,85,0
 	AttackMove:
 		Voice: Attack
 	AttackTDGunboatTurreted:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -922,7 +922,7 @@ GUN:
 		Sequence: recoil
 	Armament:
 		Weapon: TurretGun
-		LocalOffset: 512,0,112
+		LocalOffsets: 512,0,112
 		MuzzleSequence: muzzle
 	AttackTurreted:
 		PauseOnCondition: build-incomplete
@@ -1018,7 +1018,7 @@ OBLI:
 		Sequence: active
 	Armament:
 		Weapon: Laser
-		LocalOffset: 0,-85,1280
+		LocalOffsets: 0,-85,1280
 	AttackCharges:
 		PauseOnCondition: lowpower || build-incomplete
 		ChargeLevel: 50
@@ -1060,7 +1060,7 @@ GTWR:
 		HasMinibib: true
 	Armament:
 		Weapon: HighV
-		LocalOffset: 256,0,256
+		LocalOffsets: 256,0,256
 		MuzzleSequence: muzzle
 	AttackTurreted:
 		PauseOnCondition: build-incomplete
@@ -1108,11 +1108,11 @@ ATWR:
 		Offset: 128,128,384
 	Armament@PRIMARY:
 		Weapon: TowerMissile
-		LocalOffset: 256,128,0, 256,-128,0
+		LocalOffsets: 256,128,0, 256,-128,0
 		LocalYaw: -100,100
 	Armament@SECONDARY:
 		Weapon: TowerAAMissile
-		LocalOffset: 256,128,0, 256,-128,0
+		LocalOffsets: 256,128,0, 256,-128,0
 		LocalYaw: -100,100
 	AttackTurreted:
 		PauseOnCondition: lowpower || build-incomplete

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -135,7 +135,7 @@ APC:
 		Weapon: APCGun
 		Recoil: 48
 		RecoilRecovery: 18
-		LocalOffset: 255,100,189, 255,-100,189
+		LocalOffsets: 255,100,189, 255,-100,189
 		MuzzleSequence: muzzle
 		PauseOnCondition: reload-air
 		ReloadingCondition: reload-ground
@@ -144,7 +144,7 @@ APC:
 		Weapon: APCGun.AA
 		Recoil: 48
 		RecoilRecovery: 18
-		LocalOffset: 175,100,299, 175,-100,299
+		LocalOffsets: 175,100,299, 175,-100,299
 		MuzzleSequence: muzzle-air
 		PauseOnCondition: reload-ground
 		ReloadingCondition: reload-air
@@ -206,7 +206,7 @@ ARTY:
 		Range: 5c0
 	Armament:
 		Weapon: ArtilleryShell
-		LocalOffset: 624,0,208
+		LocalOffsets: 624,0,208
 		MuzzleSequence: muzzle
 	AttackFrontal:
 		TargetFrozenActors: True
@@ -255,7 +255,7 @@ FTNK:
 		Range: 6c0
 	Armament:
 		Weapon: BigFlamer
-		LocalOffset: 512,128,42, 512,-128,42
+		LocalOffsets: 512,128,42, 512,-128,42
 		MuzzleSequence: muzzle
 	AttackFrontal:
 		Voice: Attack
@@ -303,7 +303,7 @@ BGGY:
 		Offset: -43,0,128
 	Armament:
 		Weapon: MachineGun
-		LocalOffset: 171,0,43
+		LocalOffsets: 171,0,43
 		MuzzleSequence: muzzle
 	AttackMove:
 		Voice: Attack
@@ -346,7 +346,7 @@ BIKE:
 		Range: 8c0
 	Armament:
 		Weapon: BikeRockets
-		LocalOffset: -128, -170, 170, -128, 170, 170
+		LocalOffsets: -128, -170, 170, -128, 170, 170
 		LocalYaw: 100, -100
 	AttackFrontal:
 		Voice: Attack
@@ -390,7 +390,7 @@ JEEP:
 		Offset: -85,0,128
 	Armament:
 		Weapon: MachineGunH
-		LocalOffset: 171,0,85
+		LocalOffsets: 171,0,85
 		MuzzleSequence: muzzle
 	AttackMove:
 		Voice: Attack
@@ -436,7 +436,7 @@ LTNK:
 		Weapon: 70mm
 		Recoil: 85
 		RecoilRecovery: 17
-		LocalOffset: 720,0,90
+		LocalOffsets: 720,0,90
 		MuzzleSequence: muzzle
 	AttackMove:
 		Voice: Attack
@@ -481,7 +481,7 @@ MTNK:
 		Weapon: 120mm
 		Recoil: 128
 		RecoilRecovery: 26
-		LocalOffset: 768,0,90
+		LocalOffsets: 768,0,90
 		MuzzleSequence: muzzle
 	AttackMove:
 		Voice: Attack
@@ -532,14 +532,14 @@ HTNK:
 		TurnSpeed: 14
 	Armament@PRIMARY:
 		Weapon: 120mmDual
-		LocalOffset: 900,180,340, 900,-180,340
+		LocalOffsets: 900,180,340, 900,-180,340
 		Recoil: 170
 		RecoilRecovery: 42
 		MuzzleSequence: muzzle
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: MammothMissiles
-		LocalOffset: -85,384,340, -85,-384,340
+		LocalOffsets: -85,384,340, -85,-384,340
 		LocalYaw: -100, 100
 		Recoil: 10
 		MuzzleSequence: muzzle
@@ -595,11 +595,11 @@ MSAM:
 		Offset: -256,0,128
 	Armament@PRIMARY:
 		Weapon: 227mm
-		LocalOffset: 213,128,0, 213,-128,0
+		LocalOffsets: 213,128,0, 213,-128,0
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: 227mm
-		LocalOffset: 213,-128,0, 213,128,0
+		LocalOffsets: 213,-128,0, 213,128,0
 	AttackFrontal:
 		TargetFrozenActors: True
 		ForceFireIgnoresActors: True
@@ -651,7 +651,7 @@ MLRS:
 		RealignDelay: 0
 	Armament:
 		Weapon: Patriot
-		LocalOffset: 0,-171,0, 0,171,0
+		LocalOffsets: 0,-171,0, 0,171,0
 	AmmoPool:
 		Ammo: 2
 		AmmoCondition: ammo
@@ -716,10 +716,10 @@ STNK:
 		ValidDamageStates: Critical
 	Armament@PRIMARY:
 		Weapon: 227mm.stnk
-		LocalOffset: 213,43,128, 213,-43,128
+		LocalOffsets: 213,43,128, 213,-43,128
 	Armament@SECONDARY:
 		Weapon: 227mm.stnkAA
-		LocalOffset: 213,43,128, 213,-43,128
+		LocalOffsets: 213,43,128, 213,-43,128
 	AttackFrontal:
 		Voice: Attack
 		FacingTolerance: 0

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -85,7 +85,7 @@ trooper:
 		Speed: 31
 	Armament:
 		Weapon: Bazooka
-		LocalOffset: 128,0,256
+		LocalOffsets: 128,0,256
 	Encyclopedia:
 		Description: Armed with missile launchers, Troopers fire wire guided armor-piercing warheads. These units are particularly effective against vehicles (especially armored ones) and buildings. However, this unit is largely useless against infantry.\n\nTroopers are resistant to anti-tank weaponry but very vulnerable to high-explosives, fire and bullet weapons.
 		Order: 10
@@ -217,7 +217,7 @@ grenadier:
 		Speed: 43
 	Armament:
 		Weapon: grenade
-		LocalOffset: 192,0,224
+		LocalOffsets: 192,0,224
 		FireDelay: 3
 	Encyclopedia:
 		Description: Grenadiers are an infantry artillery unit which are strong against buildings. They have a chance to explode on death, so don't group them together.

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -808,7 +808,7 @@ medium_gun_turret:
 		RealignDelay: -1
 	Armament:
 		Weapon: 110mm_Gun
-		LocalOffset: 512,0,432
+		LocalOffsets: 512,0,432
 		MuzzleSequence: muzzle
 	Power:
 		Amount: -50
@@ -851,7 +851,7 @@ large_gun_turret:
 		QuantizedFacings: 32
 	Armament:
 		Weapon: TowerMissile
-		LocalOffset: 256,384,768, 256,-384,768
+		LocalOffsets: 256,384,768, 256,-384,768
 	Turreted:
 		TurnSpeed: 32
 		InitialFacing: 512

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -148,10 +148,10 @@ trike:
 	WithMuzzleOverlay:
 	Armament@damage:
 		Weapon: HMG
-		LocalOffset: 180,0,110
+		LocalOffsets: 180,0,110
 	Armament@muzzle:
 		Weapon: HMG_muzzle
-		LocalOffset: -544,0,0
+		LocalOffsets: -544,0,0
 		MuzzleSequence: muzzle
 	AttackFrontal:
 		FacingTolerance: 0
@@ -189,7 +189,7 @@ quad:
 		Range: 4c768
 	Armament:
 		Weapon: Rocket
-		LocalOffset: 128,64,64, 128,-64,64
+		LocalOffsets: 128,64,64, 128,-64,64
 	Encyclopedia:
 		Description: Stronger than the Trike in both armor and firepower, the Quad is a four-wheeled vehicle firing armor-piercing rockets. The Quad is effective against most vehicles.\n\nQuads are resistant to bullets and explosives, to a lesser degree. However, Quads are vulnerable to missiles and high-caliber guns.
 		Order: 110
@@ -241,7 +241,7 @@ siege_tank:
 		Weapon: 155mm
 		Recoil: 150
 		RecoilRecovery: 19
-		LocalOffset: 512,0,320
+		LocalOffsets: 512,0,320
 		MuzzleSequence: muzzle
 	AttackFrontal:
 		FacingTolerance: 0
@@ -293,7 +293,7 @@ missile_tank:
 		Range: 6c768
 	Armament:
 		Weapon: mtank_pri
-		LocalOffset: -128,128,171, -128,-128,171
+		LocalOffsets: -128,128,171, -128,-128,171
 	AttackFrontal:
 		FacingTolerance: 0
 	AutoTarget:
@@ -338,7 +338,7 @@ sonic_tank:
 		Range: 5c768
 	Armament:
 		Weapon: Sound
-		LocalOffset: 600,0,427
+		LocalOffsets: 600,0,427
 	Encyclopedia:
 		Description: The Sonic Tank is most effective against infantry and lightly armored vehicles - but weaker against armored targets.\n\nThe Sonic Tank will damage all units in its firing path.\n\nThey are very resistant to bullets and small-explosives, but vulnerable to missiles and high-caliber guns.
 		Order: 200
@@ -388,7 +388,7 @@ devastator:
 		Range: 4c768
 	Armament:
 		Weapon: DevBullet
-		LocalOffset: 640,0,32
+		LocalOffsets: 640,0,32
 		MuzzleSequence: muzzle
 	Encyclopedia:
 		Description: The Devastator is the most powerful tank on Dune - powerfully effective against most units, but slow - and slow to fire. Nuclear powered, the Devastator fires dual plasma charges and may be ordered to self-destruct, damaging surrounding units and structures.\n\nThe Devastator is very resistant to bullet and high-explosives, but vulnerable to missiles and high-caliber guns.
@@ -465,10 +465,10 @@ raider:
 	WithMuzzleOverlay:
 	Armament@damage:
 		Weapon: HMGo
-		LocalOffset: 170,0,0
+		LocalOffsets: 170,0,0
 	Armament@muzzle:
 		Weapon: HMGo_muzzle
-		LocalOffset: 170,0,0
+		LocalOffsets: 170,0,0
 		MuzzleSequence: muzzle
 	AttackFrontal:
 		FacingTolerance: 0
@@ -542,7 +542,7 @@ deviator:
 		Range: 4c768
 	Armament:
 		Weapon: DeviatorMissile
-		LocalOffset: -299,0,85
+		LocalOffsets: -299,0,85
 	AttackFrontal:
 		FacingTolerance: 0
 	AutoTarget:
@@ -589,7 +589,7 @@ deviator:
 		Weapon: 80mm_A
 		Recoil: 128
 		RecoilRecovery: 32
-		LocalOffset: 256,0,0
+		LocalOffsets: 256,0,0
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleOverlay:

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -354,7 +354,7 @@ FTRK:
 	Armament:
 		Weapon: FLAK-23
 		Recoil: 85
-		LocalOffset: 512,0,192
+		LocalOffsets: 512,0,192
 		MuzzleSequence: muzzle
 
 ARTY:

--- a/mods/ra/maps/monster-tank-madness/rules.yaml
+++ b/mods/ra/maps/monster-tank-madness/rules.yaml
@@ -141,14 +141,14 @@ PBOX:
 		TurnSpeed: 4
 	Armament@PRIMARY:
 		Weapon: SuperTankPrimary
-		LocalOffset: 900,180,340, 900,-180,340
+		LocalOffsets: 900,180,340, 900,-180,340
 		Recoil: 171
 		RecoilRecovery: 30
 		MuzzleSequence: muzzle
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: MammothTusk
-		LocalOffset: -85,384,340, -85,-384,340
+		LocalOffsets: -85,384,340, -85,-384,340
 		LocalYaw: -100,100
 		Recoil: 43
 		MuzzleSequence: muzzle

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -88,7 +88,7 @@ MIG:
 		Type: GroundPosition
 	Armament:
 		Weapon: Maverick
-		LocalOffset: 0,-640,0, 0,640,0
+		LocalOffsets: 0,-640,0, 0,640,0
 		LocalYaw: -40, 24
 		PauseOnCondition: !ammo
 	AttackAircraft:
@@ -166,13 +166,13 @@ YAK:
 		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: ChainGun.Yak
-		LocalOffset: 256,-213,0
+		LocalOffsets: 256,-213,0
 		MuzzleSequence: muzzle
 		PauseOnCondition: !ammo
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: ChainGun.Yak
-		LocalOffset: 256,213,0
+		LocalOffsets: 256,213,0
 		MuzzleSequence: muzzle
 		PauseOnCondition: !ammo
 	AttackAircraft:
@@ -303,11 +303,11 @@ HELI:
 		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: HellfireAA
-		LocalOffset: 0,-213,-85, 0,213,-85
+		LocalOffsets: 0,-213,-85, 0,213,-85
 		PauseOnCondition: !ammo
 	Armament@SECONDARY:
 		Weapon: HellfireAG
-		LocalOffset: 0,213,-85, 0,-213,-85
+		LocalOffsets: 0,213,-85, 0,-213,-85
 		PauseOnCondition: !ammo
 	AttackAircraft:
 		FacingTolerance: 80
@@ -385,13 +385,13 @@ HIND:
 		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: ChainGun
-		LocalOffset: 85,-213,-85, 85,213,-85
+		LocalOffsets: 85,-213,-85, 85,213,-85
 		MuzzleSequence: muzzle
 		PauseOnCondition: !ammo
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: ChainGun
-		LocalOffset: 85,213,-85, 85,-213,-85
+		LocalOffsets: 85,213,-85, 85,-213,-85
 		MuzzleSequence: muzzle
 		PauseOnCondition: !ammo
 	AttackAircraft:
@@ -509,13 +509,13 @@ MH60:
 		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: ChainGun
-		LocalOffset: 85,-213,-85, 85,213,-85
+		LocalOffsets: 85,-213,-85, 85,213,-85
 		MuzzleSequence: muzzle
 		PauseOnCondition: !ammo
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: ChainGun
-		LocalOffset: 85,213,-85, 85,-213,-85
+		LocalOffsets: 85,213,-85, 85,-213,-85
 		MuzzleSequence: muzzle
 		PauseOnCondition: !ammo
 	AttackAircraft:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -142,7 +142,7 @@ E2:
 		Speed: 68
 	Armament@PRIMARY:
 		Weapon: Grenade
-		LocalOffset: 0,0,555
+		LocalOffsets: 0,0,555
 		FireDelay: 15
 	Armament@GARRISONED:
 		Name: garrisoned
@@ -189,11 +189,11 @@ E3:
 		HP: 4500
 	Armament@PRIMARY:
 		Weapon: RedEye
-		LocalOffset: 0,0,555
+		LocalOffsets: 0,0,555
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: Dragon
-		LocalOffset: 0,0,555
+		LocalOffsets: 0,0,555
 	Armament@GARRISONED:
 		Name: garrisoned
 		Weapon: Dragon
@@ -248,7 +248,7 @@ E4:
 		HP: 4000
 	Armament@PRIMARY:
 		Weapon: Flamer
-		LocalOffset: 700,0,500
+		LocalOffsets: 700,0,500
 		FireDelay: 8
 	Armament@GARRISONED:
 		Name: garrisoned
@@ -427,10 +427,10 @@ E7:
 		Voice: Move
 	Armament@PRIMARY:
 		Weapon: Colt45
-		LocalOffset: 0,0,0, 0,0,0
+		LocalOffsets: 0,0,0, 0,0,0
 	Armament@SECONDARY:
 		Weapon: Colt45
-		LocalOffset: 0,0,0, 0,0,0
+		LocalOffsets: 0,0,0, 0,0,0
 	Armament@GARRISONED:
 		Name: garrisoned
 		Weapon: Colt45
@@ -700,7 +700,7 @@ SHOK:
 		Range: 5c0
 	Armament@PRIMARY:
 		Weapon: PortaTesla
-		LocalOffset: 427,0,341
+		LocalOffsets: 427,0,341
 	Armament@GARRISONED:
 		Name: garrisoned
 		Weapon: PortaTesla

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -46,7 +46,7 @@ SS:
 		ValidDamageStates: Critical
 	Armament:
 		Weapon: TorpTube
-		LocalOffset: 0,-171,0, 0,171,0
+		LocalOffsets: 0,-171,0, 0,171,0
 		FireDelay: 2
 	AttackFrontal:
 		FacingTolerance: 0
@@ -114,11 +114,11 @@ MSUB:
 		ValidDamageStates: Critical
 	Armament@PRIMARY:
 		Weapon: SubMissile
-		LocalOffset: 0,-171,0, 0,171,0
+		LocalOffsets: 0,-171,0, 0,171,0
 		FireDelay: 2
 	Armament@SECONDARY:
 		Weapon: SubMissileAA
-		LocalOffset: 0,-171,0, 0,171,0
+		LocalOffsets: 0,-171,0, 0,171,0
 		FireDelay: 2
 	AttackFrontal:
 		TargetFrozenActors: True
@@ -171,15 +171,15 @@ DD:
 		Offset: 469,0,128
 	Armament@PRIMARY:
 		Weapon: Stinger
-		LocalOffset: 0,-100,0, 0,100,0
+		LocalOffsets: 0,-100,0, 0,100,0
 		LocalYaw: 64, -64
 	Armament@SECONDARY:
 		Weapon: DepthCharge
-		LocalOffset: 0,-100,0, 0,100,0
+		LocalOffsets: 0,-100,0, 0,100,0
 		LocalYaw: 80, -80
 	Armament@TERTIARY:
 		Weapon: StingerAA
-		LocalOffset: 0,-100,0, 0,100,0
+		LocalOffsets: 0,-100,0, 0,100,0
 		LocalYaw: 64, -64
 	AttackTurreted:
 	WithSpriteTurret:
@@ -229,7 +229,7 @@ CA:
 	Armament@PRIMARY:
 		Turret: primary
 		Weapon: 8Inch
-		LocalOffset: 480,-100,40, 480,100,40
+		LocalOffsets: 480,-100,40, 480,100,40
 		Recoil: 171
 		RecoilRecovery: 34
 		MuzzleSequence: muzzle
@@ -237,7 +237,7 @@ CA:
 		Name: secondary
 		Turret: secondary
 		Weapon: 8Inch
-		LocalOffset: 480,-100,40, 480,100,40
+		LocalOffsets: 480,-100,40, 480,100,40
 		Recoil: 171
 		RecoilRecovery: 34
 		MuzzleSequence: muzzle
@@ -325,7 +325,7 @@ PT:
 		Offset: 512,0,0
 	Armament@PRIMARY:
 		Weapon: 2Inch
-		LocalOffset: 208,0,48
+		LocalOffsets: 208,0,48
 		MuzzleSequence: muzzle
 	Armament@SECONDARY:
 		Name: secondary

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -586,7 +586,7 @@ TSLA:
 	WithTeslaChargeAnimation:
 	Armament:
 		Weapon: TeslaZap
-		LocalOffset: 0,0,896
+		LocalOffsets: 0,0,896
 	AttackTesla:
 		PauseOnCondition: disabled || build-incomplete
 		ChargeAudio: tslachg2.aud
@@ -637,7 +637,7 @@ AGUN:
 		Recoils: false
 	Armament:
 		Weapon: ZSU-23
-		LocalOffset: 520,100,450, 520,-150,450
+		LocalOffsets: 520,100,450, 520,-150,450
 		MuzzleSequence: muzzle
 	AttackTurreted:
 		PauseOnCondition: disabled || build-incomplete
@@ -855,7 +855,7 @@ GUN:
 		Sequence: recoil
 	Armament:
 		Weapon: TurretGun
-		LocalOffset: 512,0,112
+		LocalOffsets: 512,0,112
 		MuzzleSequence: muzzle
 	AttackTurreted:
 		PauseOnCondition: build-incomplete
@@ -897,7 +897,7 @@ FTUR:
 		Offset: 0,0,112
 	Armament:
 		Weapon: FireballLauncher
-		LocalOffset: 512,0,0
+		LocalOffsets: 512,0,0
 	AttackTurreted:
 		PauseOnCondition: build-incomplete
 	-QuantizeFacingsFromSequence:
@@ -957,7 +957,7 @@ SAM:
 		Recoils: false
 	Armament:
 		Weapon: Nike
-		LocalOffset: 0,0,320
+		LocalOffsets: 0,0,320
 		MuzzleSequence: muzzle
 	AttackTurreted:
 		PauseOnCondition: disabled || build-incomplete

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -85,7 +85,7 @@ V2RL:
 		Weapon: 25mm
 		Recoil: 85
 		RecoilRecovery: 25
-		LocalOffset: 768,0,90
+		LocalOffsets: 768,0,90
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleOverlay:
@@ -130,7 +130,7 @@ V2RL:
 		Weapon: 90mm
 		Recoil: 128
 		RecoilRecovery: 38
-		LocalOffset: 720,0,80
+		LocalOffsets: 720,0,80
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleOverlay:
@@ -179,7 +179,7 @@ V2RL:
 		Weapon: 105mm
 		Recoil: 128
 		RecoilRecovery: 38
-		LocalOffset: 768,85,90, 768,-85,90
+		LocalOffsets: 768,85,90, 768,-85,90
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleOverlay:
@@ -227,14 +227,14 @@ V2RL:
 		TurnSpeed: 8
 	Armament@PRIMARY:
 		Weapon: 120mm
-		LocalOffset: 900,180,340, 900,-180,340
+		LocalOffsets: 900,180,340, 900,-180,340
 		Recoil: 171
 		RecoilRecovery: 30
 		MuzzleSequence: muzzle
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: MammothTusk
-		LocalOffset: -85,384,340, -85,-384,340
+		LocalOffsets: -85,384,340, -85,-384,340
 		LocalYaw: -100,100
 		Recoil: 43
 		MuzzleSequence: muzzle
@@ -287,7 +287,7 @@ ARTY:
 		Range: 4c0
 	Armament:
 		Weapon: 155mm
-		LocalOffset: 624,0,208
+		LocalOffsets: 624,0,208
 		MuzzleSequence: muzzle
 	AttackFrontal:
 		TargetFrozenActors: True
@@ -440,7 +440,7 @@ JEEP:
 	Armament:
 		Weapon: M60mg
 		MuzzleSequence: muzzle
-		LocalOffset: 128,0,43
+		LocalOffsets: 128,0,43
 	AttackTurreted:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
@@ -485,7 +485,7 @@ APC:
 		Range: 4c0
 	Armament:
 		Weapon: M60mg
-		LocalOffset: 85,0,171
+		LocalOffsets: 85,0,171
 		MuzzleSequence: muzzle
 	AttackFrontal:
 		FacingTolerance: 0
@@ -678,7 +678,7 @@ TTNK:
 		Range: 6c0
 	Armament:
 		Weapon: TTankZap
-		LocalOffset: 0,0,213
+		LocalOffsets: 0,0,213
 	AttackTurreted:
 	Turreted:
 	WithIdleOverlay@SPINNER:
@@ -725,12 +725,12 @@ FTRK:
 	Armament@AA:
 		Weapon: FLAK-23-AA
 		Recoil: 85
-		LocalOffset: 512,0,192
+		LocalOffsets: 512,0,192
 		MuzzleSequence: muzzle
 	Armament@AG:
 		Weapon: FLAK-23-AG
 		Recoil: 85
-		LocalOffset: 512,0,192
+		LocalOffsets: 512,0,192
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleOverlay:
@@ -813,11 +813,11 @@ CTNK:
 		Range: 4c0
 	Armament@PRIMARY:
 		Weapon: APTusk
-		LocalOffset: -160,-276,232
+		LocalOffsets: -160,-276,232
 		LocalYaw: 60
 	Armament@SECONDARY:
 		Weapon: APTusk
-		LocalOffset: -160,276,232
+		LocalOffsets: -160,276,232
 		LocalYaw: -60
 	AttackFrontal:
 		FacingTolerance: 0
@@ -906,7 +906,7 @@ STNK:
 		InitialStanceAI: ReturnFire
 	Armament:
 		Weapon: APTusk.stnk
-		LocalOffset: 192,0,176
+		LocalOffsets: 192,0,176
 	Turreted:
 		TurnSpeed: 20
 	AttackTurreted:

--- a/mods/ts/rules/civilian-infantry.yaml
+++ b/mods/ts/rules/civilian-infantry.yaml
@@ -14,7 +14,7 @@ WEEDGUY:
 		CrushSound: squishy2.aud
 	Armament:
 		Weapon: FireballLauncher
-		LocalOffset: 317,0,453
+		LocalOffsets: 317,0,453
 	TakeCover:
 		ProneOffset: 128,0,-320
 	AttackFrontal:

--- a/mods/ts/rules/civilian-vehicles.yaml
+++ b/mods/ts/rules/civilian-vehicles.yaml
@@ -22,11 +22,11 @@
 		TurnSpeed: 12
 	Armament@PRIMARY:
 		Weapon: 120mmx
-		LocalOffset: 707,85,509, 707,-120,509
+		LocalOffsets: 707,85,509, 707,-120,509
 		MuzzleSequence: muzzle
 	Armament@SECONDARY:
 		Weapon: MammothTusk
-		LocalOffset: 0,283,580, 0,-283,580
+		LocalOffsets: 0,283,580, 0,-283,580
 	AttackTurreted:
 		Voice: Attack
 		PauseOnCondition: empdisable

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -20,7 +20,7 @@ E2:
 		Speed: 56
 	Armament:
 		Weapon: Grenade
-		LocalOffset: 0,0,785
+		LocalOffsets: 0,0,785
 		FireDelay: 5
 	TakeCover:
 		ProneOffset: 160,128,-555
@@ -244,7 +244,7 @@ GHOST:
 		Range: 6c0
 	Armament:
 		Weapon: LtRail
-		LocalOffset: 120,0,543
+		LocalOffsets: 120,0,543
 	TakeCover:
 		ProneOffset: 256,32,-384
 	Crushable:

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -94,22 +94,22 @@ GACTWR:
 	Armament@VULCPRIMARY:
 		RequiresCondition: tower.vulcan
 		Weapon: VulcanTower
-		LocalOffset: 588,120,1358
+		LocalOffsets: 588,120,1358
 		MuzzleSequence: muzzle
 	Armament@VULCSECONDARY:
 		RequiresCondition: tower.vulcan
 		Name: secondary
 		Weapon: VulcanTower
-		LocalOffset: 588,-120,1358
+		LocalOffsets: 588,-120,1358
 		MuzzleSequence: muzzle
 	Armament@ROCKET:
 		RequiresCondition: tower.rocket
 		Weapon: RPGTower
-		LocalOffset: 272,-92,1493
+		LocalOffsets: 272,-92,1493
 	Armament@SAM:
 		RequiresCondition: tower.sam
 		Weapon: RedEye2
-		LocalOffset: 543,0,1697
+		LocalOffsets: 543,0,1697
 	WithMuzzleOverlay:
 		RequiresCondition: !build-incomplete && tower.vulcan
 	WithIdleOverlay@LIGHTS:

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -80,7 +80,7 @@ HVR:
 		MaxHeightDelta: 3
 	Armament:
 		Weapon: HoverMissile
-		LocalOffset: 0,242,543, 0,-242,543
+		LocalOffsets: 0,242,543, 0,-242,543
 	Turreted:
 		TurnSpeed: 28
 		Offset: -128,0,85
@@ -208,7 +208,7 @@ MMCH:
 		MuzzleSequence: muzzle
 		Recoil: 128
 		RecoilRecovery: 32
-		LocalOffset: 1024,272,1216
+		LocalOffsets: 1024,272,1216
 	DetectCloaked:
 		Range: 1c768
 		RequiresCondition: rank-elite
@@ -258,10 +258,10 @@ HMEC:
 		FacingTolerance: 0
 	Armament@MISSILES:
 		Weapon: MammothTusk
-		LocalOffset: -243,-368,1208, -243,368,1208
+		LocalOffsets: -243,-368,1208, -243,368,1208
 	Armament@RAILGUN:
 		Weapon: MechRailgun
-		LocalOffset: 368,-311,1030, 368,311,1030
+		LocalOffsets: 368,-311,1030, 368,311,1030
 	-WithVoxelBody:
 	WithVoxelWalkerBody:
 		TickRate: 1
@@ -301,7 +301,7 @@ SONIC:
 		MaxHeightDelta: 3
 	Armament:
 		Weapon: SonicZap
-		LocalOffset: -71,0,580
+		LocalOffsets: -71,0,580
 	AttackTurreted:
 		Voice: Attack
 		PauseOnCondition: empdisable
@@ -415,7 +415,7 @@ JUGG:
 		Name: deployed
 		Turret: deployed
 		Weapon: Jugg90mm
-		LocalOffset: 820,203,1386, 820,0,1386, 820,-203,1386
+		LocalOffsets: 820,203,1386, 820,0,1386, 820,-203,1386
 		RequiresCondition: deployed
 		MuzzleSequence: muzzle
 	WithMuzzleOverlay:

--- a/mods/ts/rules/nod-infantry.yaml
+++ b/mods/ts/rules/nod-infantry.yaml
@@ -22,7 +22,7 @@ E3:
 		Speed: 56
 	Armament@PRIMARY:
 		Weapon: Bazooka
-		LocalOffset: 356,0,967
+		LocalOffsets: 356,0,967
 	TakeCover:
 		ProneOffset: 52,64,-652
 	AttackFrontal:
@@ -106,7 +106,7 @@ CYC2:
 		Range: 7c0
 	Armament:
 		Weapon: CyCannon
-		LocalOffset: 240,120,966
+		LocalOffsets: 240,120,966
 	AttackFrontal:
 		Voice: Attack
 		FacingTolerance: 0

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -197,7 +197,7 @@ NALASR:
 		PauseOnCondition: empdisable || disabled || build-incomplete
 	Armament:
 		Weapon: TurretLaserFire
-		LocalOffset: 498,0,317
+		LocalOffsets: 498,0,317
 	RenderVoxels:
 	WithVoxelTurret:
 		RequiresCondition: !build-incomplete
@@ -231,7 +231,7 @@ NAOBEL:
 		Range: 8c0
 	Armament:
 		Weapon: ObeliskLaserFire
-		LocalOffset: 1980,297,1131
+		LocalOffsets: 1980,297,1131
 	AttackCharges:
 		PauseOnCondition: empdisable || disabled || build-incomplete
 		ChargeLevel: 65
@@ -282,6 +282,6 @@ NASAM:
 		Recoils: false
 	Armament:
 		Weapon: RedEye2
-		LocalOffset: 543,0,815
+		LocalOffsets: 543,0,815
 	Power:
 		Amount: -30

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -27,7 +27,7 @@ BGGY:
 		MaxHeightDelta: 3
 	Armament:
 		Weapon: RaiderCannon
-		LocalOffset: 0,-61,543, 0,61,543
+		LocalOffsets: 0,-61,543, 0,61,543
 		MuzzleSequence: muzzle
 	AttackFrontal:
 		Voice: Attack
@@ -67,11 +67,11 @@ BIKE:
 	Armament@PRIMARY:
 		Weapon: BikeMissile
 		RequiresCondition: !rank-elite
-		LocalOffset: -153,-204,509, -153,204,509
+		LocalOffsets: -153,-204,509, -153,204,509
 	Armament@ELITE:
 		Weapon: HoverMissile
 		RequiresCondition: rank-elite
-		LocalOffset: -153,-204,509, -153,204,509
+		LocalOffsets: -153,-204,509, -153,204,509
 	AttackFrontal:
 		Voice: Attack
 		PauseOnCondition: empdisable
@@ -113,12 +113,12 @@ TTNK:
 		RequiresCondition: undeployed
 	Armament@PRIMARY:
 		Weapon: 90mm
-		LocalOffset: 407,0,362
+		LocalOffsets: 407,0,362
 		RequiresCondition: !rank-elite
 		MuzzleSequence: muzzle
 	Armament@ELITE:
 		Weapon: 120mmx
-		LocalOffset: 407,0,362
+		LocalOffsets: 407,0,362
 		RequiresCondition: rank-elite
 		MuzzleSequence: muzzle
 	WithMuzzleOverlay:
@@ -181,14 +181,14 @@ TTNK:
 		Name: deployed
 		Turret: deployed
 		Weapon: 90mm
-		LocalOffset: 543,0,362
+		LocalOffsets: 543,0,362
 		RequiresCondition: !rank-elite
 		MuzzleSequence: muzzle
 	Armament@deployedElite:
 		Name: deployed
 		Turret: deployed
 		Weapon: 120mmx
-		LocalOffset: 543,0,362
+		LocalOffsets: 543,0,362
 		RequiresCondition: rank-elite
 		MuzzleSequence: muzzle
 	Armor@deployed:
@@ -291,7 +291,7 @@ ART2:
 		Name: deployed
 		Turret: deployed
 		Weapon: 155mm
-		LocalOffset: 820,0,1386
+		LocalOffsets: 820,0,1386
 		RequiresCondition: deployed
 		MuzzleSequence: muzzle
 	WithMuzzleOverlay:
@@ -532,7 +532,7 @@ STNK:
 		ValidDamageStates: Critical
 	Armament:
 		Weapon: Dragon
-		LocalOffset: 301,61,421, 301,-61,421
+		LocalOffsets: 301,61,421, 301,-61,421
 	AttackFrontal:
 		Voice: Attack
 		PauseOnCondition: empdisable

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -28,7 +28,7 @@ NAPULS:
 		RequiresCondition: !build-incomplete && !empdisable && !disabled
 	Armament:
 		Weapon: EMPulseCannon
-		LocalOffset: 212,0,1768
+		LocalOffsets: 212,0,1768
 		LocalYaw: 0,100
 	WithSpriteTurret:
 		RequiresCondition: !build-incomplete


### PR DESCRIPTION
Currently `Armament` always calculates muzzle offset using `LocalOffset` as base, even when the offset is used for `WithMuzzleOverlay`. However when using sprites for muzzle flashes that are precisely for specific turret/weapon for all facings, it does not make sense calculate offset for muzzle overlay from `Armament` offset. In case of OpenE2140, this is actually wrong and when offset for muzzle overlay uses Armament's `LocalOffset` as base for calculating, it looks really bad:

Muzzle overlay without applied PR:

![opene2140_muzzleoffset_broken](https://user-images.githubusercontent.com/119738087/228196573-fbe8d986-2a8b-4c43-9e6e-88dfec933170.gif)

This PR allows specifying custom `MuzzleOverlayOffset` on `Armament`:

```
Armament@PRIMARY:
	Weapon: ed_vehicles_mt200
	Recoil: 80
	RecoilRecovery: 38
	LocalOffset: 750,-50,0
	LocalYaw: 0, 0
	MuzzlePalette:
	MuzzleSequence: muzzle
	MuzzleOverlayOffset: 0,0,0
WithMuzzleOverlay@muzzle:
```

This is how muzzle overlay looks when with changes in PR applied:

![MuzzleOverlayOffset_PR](https://cdn.discordapp.com/attachments/1080450424726884414/1089651797615980584/opene2140_muzzleoverlayoffset.gif)

(in both GIFs bullet and muzzle sequence speed were slowed down to better demonstrate effect the changes in PR have)

`IgnoreOffset` on `WithMuzzleOverlay` can't be used, because muzzle effect position still needs to be calculated based on turret direction.

Compatibility with existing `Armament`s (that don't need to use this), is not affected (`LocalOffset` is used instead).

