### PR TITLE
Cache reflection calls when running utility lints and commands.

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -45,21 +45,16 @@ namespace OpenRA
 			return a.GetTypes().Select(t => t.Namespace).Distinct().Where(n => n != null);
 		}
 
-		public static bool HasAttribute<T>(this MemberInfo mi)
+		public static bool HasAttribute<TAttribute>(this MemberInfo mi)
+			where TAttribute : Attribute
 		{
-			return Attribute.IsDefined(mi, typeof(T));
+			return Attribute.IsDefined(mi, typeof(TAttribute));
 		}
 
-		public static T[] GetCustomAttributes<T>(this MemberInfo mi, bool inherit)
-			where T : class
+		public static TAttribute[] GetCustomAttributes<TAttribute>(this MemberInfo mi, bool inherit)
+			where TAttribute : Attribute
 		{
-			return (T[])mi.GetCustomAttributes(typeof(T), inherit);
-		}
-
-		public static T[] GetCustomAttributes<T>(this ParameterInfo mi)
-			where T : class
-		{
-			return (T[])mi.GetCustomAttributes(typeof(T), true);
+			return (TAttribute[])mi.GetCustomAttributes(typeof(TAttribute), inherit);
 		}
 
 		public static T Clamp<T>(this T val, T min, T max) where T : IComparable<T>

--- a/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
@@ -39,16 +39,16 @@ namespace OpenRA.Mods.Common.Lint
 		void CheckTrait(Action<string> emitError, ActorInfo actorInfo, TraitInfo traitInfo, Ruleset rules)
 		{
 			var actualType = traitInfo.GetType();
-			foreach (var field in actualType.GetFields())
+			foreach (var field in Utility.GetFields(actualType))
 			{
-				if (field.HasAttribute<ActorReferenceAttribute>())
+				if (Utility.HasAttribute<ActorReferenceAttribute>(field))
 					CheckActorReference(emitError, actorInfo, traitInfo, field, rules.Actors,
-						field.GetCustomAttributes<ActorReferenceAttribute>(true)[0]);
+						Utility.GetCustomAttributes<ActorReferenceAttribute>(field, true)[0]);
 
-				if (field.HasAttribute<WeaponReferenceAttribute>())
+				if (Utility.HasAttribute<WeaponReferenceAttribute>(field))
 					CheckWeaponReference(emitError, actorInfo, traitInfo, field, rules.Weapons);
 
-				if (field.HasAttribute<VoiceSetReferenceAttribute>())
+				if (Utility.HasAttribute<VoiceSetReferenceAttribute>(field))
 					CheckVoiceReference(emitError, actorInfo, traitInfo, field, rules.Voices);
 			}
 		}

--- a/OpenRA.Mods.Common/Lint/CheckChromeHotkeys.cs
+++ b/OpenRA.Mods.Common/Lint/CheckChromeHotkeys.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Lint
 
 			// Build the list of widget keys to validate
 			var checkWidgetFields = modData.ObjectCreator.GetTypesImplementing<Widget>()
-				.SelectMany(w => w.GetFields()
+				.SelectMany(w => Utility.GetFields(w)
 					.Where(f => f.FieldType == typeof(HotkeyReference))
 					.Select(f => (w.Name.Substring(0, w.Name.Length - 6), f.Name)))
 				.ToArray();
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Lint
 
 			foreach (var w in modData.ObjectCreator.GetTypesImplementing<Widget>())
 			{
-				foreach (var m in w.GetMethods().Where(m => m.HasAttribute<CustomLintableHotkeyNames>()))
+				foreach (var m in w.GetMethods().Where(m => Utility.HasAttribute<CustomLintableHotkeyNames>(m)))
 				{
 					var p = m.GetParameters();
 					if (p.Length == 3 && p[0].ParameterType == typeof(MiniYamlNode) && p[1].ParameterType == typeof(Action<string>)
@@ -104,7 +104,7 @@ namespace OpenRA.Mods.Common.Lint
 						if (type == null)
 							continue;
 
-						checkArgKeys.AddRange(type.GetCustomAttributes<ChromeLogicArgsHotkeys>(true).SelectMany(x => x.LogicArgKeys));
+						checkArgKeys.AddRange(Utility.GetCustomAttributes<ChromeLogicArgsHotkeys>(type, true).SelectMany(x => x.LogicArgKeys));
 					}
 
 					foreach (var n in node.Value.Nodes)

--- a/OpenRA.Mods.Common/Lint/CheckConditions.cs
+++ b/OpenRA.Mods.Common/Lint/CheckConditions.cs
@@ -38,20 +38,23 @@ namespace OpenRA.Mods.Common.Lint
 
 				foreach (var trait in actorInfo.Value.TraitInfos<TraitInfo>())
 				{
-					var fieldConsumed = trait.GetType().GetFields()
-						.Where(x => x.HasAttribute<ConsumedConditionReferenceAttribute>())
+					var fields = Utility.GetFields(trait.GetType());
+					var properties = trait.GetType().GetProperties();
+
+					var fieldConsumed = fields
+						.Where(x => Utility.HasAttribute<ConsumedConditionReferenceAttribute>(x))
 						.SelectMany(f => LintExts.GetFieldValues(trait, f));
 
-					var propertyConsumed = trait.GetType().GetProperties()
-						.Where(x => x.HasAttribute<ConsumedConditionReferenceAttribute>())
+					var propertyConsumed = properties
+						.Where(x => Utility.HasAttribute<ConsumedConditionReferenceAttribute>(x))
 						.SelectMany(p => LintExts.GetPropertyValues(trait, p));
 
-					var fieldGranted = trait.GetType().GetFields()
-						.Where(x => x.HasAttribute<GrantedConditionReferenceAttribute>())
+					var fieldGranted = fields
+						.Where(x => Utility.HasAttribute<GrantedConditionReferenceAttribute>(x))
 						.SelectMany(f => LintExts.GetFieldValues(trait, f));
 
-					var propertyGranted = trait.GetType().GetProperties()
-						.Where(x => x.HasAttribute<GrantedConditionReferenceAttribute>())
+					var propertyGranted = properties
+						.Where(x => Utility.HasAttribute<GrantedConditionReferenceAttribute>(x))
 						.SelectMany(f => LintExts.GetPropertyValues(trait, f));
 
 					foreach (var c in fieldConsumed.Concat(propertyConsumed))

--- a/OpenRA.Mods.Common/Lint/CheckCursors.cs
+++ b/OpenRA.Mods.Common/Lint/CheckCursors.cs
@@ -45,10 +45,10 @@ namespace OpenRA.Mods.Common.Lint
 			{
 				foreach (var traitInfo in actorInfo.Value.TraitInfos<TraitInfo>())
 				{
-					var fields = traitInfo.GetType().GetFields();
+					var fields = Utility.GetFields(traitInfo.GetType());
 					foreach (var field in fields)
 					{
-						var cursorReference = field.GetCustomAttributes<CursorReferenceAttribute>(true).FirstOrDefault();
+						var cursorReference = Utility.GetCustomAttributes<CursorReferenceAttribute>(field, true).FirstOrDefault();
 						if (cursorReference == null)
 							continue;
 

--- a/OpenRA.Mods.Common/Lint/CheckLocomotorReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckLocomotorReferences.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Lint
 			{
 				foreach (var traitInfo in actorInfo.Value.TraitInfos<TraitInfo>())
 				{
-					var fields = traitInfo.GetType().GetFields().Where(f => f.HasAttribute<LocomotorReferenceAttribute>());
+					var fields = Utility.GetFields(traitInfo.GetType()).Where(f => Utility.HasAttribute<LocomotorReferenceAttribute>(f));
 					foreach (var field in fields)
 					{
 						var locomotors = LintExts.GetFieldValues(traitInfo, field);

--- a/OpenRA.Mods.Common/Lint/CheckNotifications.cs
+++ b/OpenRA.Mods.Common/Lint/CheckNotifications.cs
@@ -35,11 +35,11 @@ namespace OpenRA.Mods.Common.Lint
 			{
 				foreach (var traitInfo in actorInfo.Value.TraitInfos<TraitInfo>())
 				{
-					var fields = traitInfo.GetType().GetFields();
-					foreach (var field in fields.Where(x => x.HasAttribute<NotificationReferenceAttribute>()))
+					var fields = Utility.GetFields(traitInfo.GetType());
+					foreach (var field in fields.Where(x => Utility.HasAttribute<NotificationReferenceAttribute>(x)))
 					{
 						string type = null;
-						var notificationReference = field.GetCustomAttributes<NotificationReferenceAttribute>(true).First();
+						var notificationReference = Utility.GetCustomAttributes<NotificationReferenceAttribute>(field, true).First();
 						if (!string.IsNullOrEmpty(notificationReference.NotificationTypeFieldName))
 						{
 							var fieldInfo = fields.First(f => f.Name == notificationReference.NotificationTypeFieldName);

--- a/OpenRA.Mods.Common/Lint/CheckPalettes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPalettes.cs
@@ -39,10 +39,10 @@ namespace OpenRA.Mods.Common.Lint
 			{
 				foreach (var traitInfo in actorInfo.Value.TraitInfos<TraitInfo>())
 				{
-					var fields = traitInfo.GetType().GetFields();
+					var fields = Utility.GetFields(traitInfo.GetType());
 					foreach (var field in fields)
 					{
-						var paletteReference = field.GetCustomAttributes<PaletteReferenceAttribute>(true).FirstOrDefault();
+						var paletteReference = Utility.GetCustomAttributes<PaletteReferenceAttribute>(field, true).FirstOrDefault();
 						if (paletteReference == null)
 							continue;
 
@@ -82,10 +82,10 @@ namespace OpenRA.Mods.Common.Lint
 				if (projectileInfo == null)
 					continue;
 
-				var fields = projectileInfo.GetType().GetFields();
+				var fields = Utility.GetFields(projectileInfo.GetType());
 				foreach (var field in fields)
 				{
-					var paletteReference = field.GetCustomAttributes<PaletteReferenceAttribute>(true).FirstOrDefault();
+					var paletteReference = Utility.GetCustomAttributes<PaletteReferenceAttribute>(field, true).FirstOrDefault();
 					if (paletteReference == null)
 						continue;
 
@@ -126,10 +126,10 @@ namespace OpenRA.Mods.Common.Lint
 			var tilesetPalettes = new List<(string Tileset, string PaletteName)>();
 			foreach (var traitInfo in worldActorInfo.TraitInfos<TraitInfo>())
 			{
-				var fields = traitInfo.GetType().GetFields();
+				var fields = Utility.GetFields(traitInfo.GetType());
 				foreach (var field in fields)
 				{
-					var paletteDefinition = field.GetCustomAttributes<PaletteDefinitionAttribute>(true).FirstOrDefault();
+					var paletteDefinition = Utility.GetCustomAttributes<PaletteDefinitionAttribute>(field, true).FirstOrDefault();
 					if (paletteDefinition == null)
 						continue;
 

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -47,10 +47,10 @@ namespace OpenRA.Mods.Common.Lint
 						var traitName = traitInfo.GetType().Name;
 						traitName = traitName.Remove(traitName.Length - 4);
 
-						var fields = traitInfo.GetType().GetFields();
+						var fields = Utility.GetFields(traitInfo.GetType());
 						foreach (var field in fields)
 						{
-							var sequenceReference = field.GetCustomAttributes<SequenceReferenceAttribute>(true).FirstOrDefault();
+							var sequenceReference = Utility.GetCustomAttributes<SequenceReferenceAttribute>(field, true).FirstOrDefault();
 							if (sequenceReference == null)
 								continue;
 
@@ -103,10 +103,10 @@ namespace OpenRA.Mods.Common.Lint
 				if (projectileInfo == null)
 					continue;
 
-				var fields = projectileInfo.GetType().GetFields();
+				var fields = Utility.GetFields(projectileInfo.GetType());
 				foreach (var field in fields)
 				{
-					var sequenceReference = field.GetCustomAttributes<SequenceReferenceAttribute>(true).FirstOrDefault();
+					var sequenceReference = Utility.GetCustomAttributes<SequenceReferenceAttribute>(field, true).FirstOrDefault();
 					if (sequenceReference == null)
 						continue;
 

--- a/OpenRA.Mods.Common/Lint/CheckSyncAnnotations.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSyncAnnotations.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Lint
 			const BindingFlags Flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
 			while (type != null)
 			{
-				if (((MemberInfo[])type.GetFields(Flags)).Concat(type.GetProperties(Flags)).Any(x => x.HasAttribute<SyncAttribute>()))
+				if (((MemberInfo[])type.GetFields(Flags)).Concat(type.GetProperties(Flags)).Any(x => Utility.HasAttribute<SyncAttribute>(x)))
 					return true;
 				type = type.BaseType;
 			}

--- a/OpenRA.Mods.Common/Lint/CheckTraitLocation.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTraitLocation.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Lint
 			{
 				foreach (var traitInfo in actorInfo.Value.TraitInfos<TraitInfo>())
 				{
-					var traitLocation = traitInfo.GetType().GetCustomAttributes<TraitLocationAttribute>(true).FirstOrDefault();
+					var traitLocation = Utility.GetCustomAttributes<TraitLocationAttribute>(traitInfo.GetType(), true).FirstOrDefault();
 					if (traitLocation == null)
 						continue;
 

--- a/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
@@ -39,10 +39,10 @@ namespace OpenRA.Mods.Common.Lint
 			{
 				foreach (var traitInfo in actorInfo.Value.TraitInfos<TraitInfo>())
 				{
-					var fields = traitInfo.GetType().GetFields();
+					var fields = Utility.GetFields(traitInfo.GetType());
 					foreach (var field in fields)
 					{
-						var translationReference = field.GetCustomAttributes<TranslationReferenceAttribute>(true).FirstOrDefault();
+						var translationReference = Utility.GetCustomAttributes<TranslationReferenceAttribute>(field, true).FirstOrDefault();
 						if (translationReference == null)
 							continue;
 
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Lint
 
 			foreach (var modType in modData.ObjectCreator.GetTypes())
 			{
-				foreach (var fieldInfo in modType.GetFields(Binding).Where(m => m.HasAttribute<TranslationReferenceAttribute>()))
+				foreach (var fieldInfo in modType.GetFields(Binding).Where(m => Utility.HasAttribute<TranslationReferenceAttribute>(m)))
 				{
 					if (fieldInfo.FieldType != typeof(string))
 						emitError($"Translation attribute on non string field {fieldInfo.Name}.");
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Lint
 					if (!translation.HasMessage(key))
 						emitError($"{key} not present in {language} translation.");
 
-					var translationReference = fieldInfo.GetCustomAttributes<TranslationReferenceAttribute>(true)[0];
+					var translationReference = Utility.GetCustomAttributes<TranslationReferenceAttribute>(fieldInfo, true)[0];
 					if (translationReference.RequiredVariableNames != null && translationReference.RequiredVariableNames.Length > 0)
 						referencedVariablesPerKey.GetOrAdd(key, translationReference.RequiredVariableNames);
 

--- a/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Lint
 			{
 				foreach (var traitInfo in actorInfo.Value.TraitInfos<TraitInfo>())
 				{
-					var fields = traitInfo.GetType().GetFields().Where(f => f.HasAttribute<VoiceSetReferenceAttribute>());
+					var fields = Utility.GetFields(traitInfo.GetType()).Where(f => Utility.HasAttribute<VoiceSetReferenceAttribute>(f));
 					foreach (var field in fields)
 					{
 						var voiceSets = LintExts.GetFieldValues(traitInfo, field);
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Lint
 
 			foreach (var traitInfo in actorInfo.TraitInfos<TraitInfo>())
 			{
-				var fields = traitInfo.GetType().GetFields().Where(f => f.HasAttribute<VoiceReferenceAttribute>());
+				var fields = Utility.GetFields(traitInfo.GetType()).Where(f => Utility.HasAttribute<VoiceReferenceAttribute>(f));
 				foreach (var field in fields)
 				{
 					var voices = LintExts.GetFieldValues(traitInfo, field);

--- a/OpenRA.Mods.Common/UtilityCommands/CheckExplicitInterfacesCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckExplicitInterfacesCommand.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				var interfaces = implementingType.GetInterfaces();
 				foreach (var interfaceType in interfaces)
 				{
-					if (!interfaceType.HasAttribute<RequireExplicitImplementationAttribute>())
+					if (!Utility.HasAttribute<RequireExplicitImplementationAttribute>(interfaceType))
 						continue;
 
 					var interfaceMembers = interfaceType.GetMembers();

--- a/OpenRA.Mods.Common/UtilityCommands/CreateManPage.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CreateManPage.cs
@@ -41,10 +41,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			sections.Add("Launch", new LaunchArguments(new Arguments(Array.Empty<string>())));
 			foreach (var section in sections.OrderBy(s => s.Key))
 			{
-				var fields = section.Value.GetType().GetFields();
+				var fields = Utility.GetFields(section.Value.GetType());
 				foreach (var field in fields)
 				{
-					if (!field.HasAttribute<DescAttribute>())
+					if (!Utility.HasAttribute<DescAttribute>(field))
 						continue;
 
 					Console.WriteLine(".TP");
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					else
 						Console.WriteLine();
 
-					var lines = field.GetCustomAttributes<DescAttribute>(false).SelectMany(d => d.Lines);
+					var lines = Utility.GetCustomAttributes<DescAttribute>(field, false).SelectMany(d => d.Lines);
 					foreach (var line in lines)
 						Console.WriteLine(line);
 				}

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractEmmyLuaAPI.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractEmmyLuaAPI.cs
@@ -151,7 +151,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		{
 			foreach (var t in globalTables)
 			{
-				var name = t.GetCustomAttributes<ScriptGlobalAttribute>(true).First().Name;
+				var name = Utility.GetCustomAttributes<ScriptGlobalAttribute>(t, true).First().Name;
 				Console.WriteLine("---Global variable provided by the game scripting engine.");
 
 				foreach (var obsolete in t.GetCustomAttributes(false).OfType<ObsoleteAttribute>())
@@ -169,9 +169,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 					var body = "";
 
-					if (member.HasAttribute<DescAttribute>())
+					if (Utility.HasAttribute<DescAttribute>(member))
 					{
-						var lines = member.GetCustomAttributes<DescAttribute>(true).First().Lines;
+						var lines = Utility.GetCustomAttributes<DescAttribute>(member, true).First().Lines;
 						foreach (var line in lines)
 							Console.WriteLine($"    --- {line}");
 					}
@@ -230,11 +230,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			{
 				Console.WriteLine();
 
-				var isActivity = memberInfo.HasAttribute<ScriptActorPropertyActivityAttribute>();
+				var isActivity = Utility.HasAttribute<ScriptActorPropertyActivityAttribute>(memberInfo);
 
-				if (memberInfo.HasAttribute<DescAttribute>())
+				if (Utility.HasAttribute<DescAttribute>(memberInfo))
 				{
-					var lines = memberInfo.GetCustomAttributes<DescAttribute>(true).First().Lines;
+					var lines = Utility.GetCustomAttributes<DescAttribute>(memberInfo, true).First().Lines;
 					foreach (var line in lines)
 						Console.WriteLine($"    --- {line}");
 				}

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			foreach (var t in tables)
 			{
-				var name = t.GetCustomAttributes<ScriptGlobalAttribute>(true).First().Name;
+				var name = Utility.GetCustomAttributes<ScriptGlobalAttribute>(t, true).First().Name;
 				var members = ScriptMemberWrapper.WrappableMembers(t);
 
 				Console.WriteLine();
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				Console.WriteLine("|---------:|-------------|");
 				foreach (var m in members.OrderBy(m => m.Name))
 				{
-					var desc = m.HasAttribute<DescAttribute>() ? m.GetCustomAttributes<DescAttribute>(true).First().Lines.JoinWith("<br />") : "";
+					var desc = Utility.HasAttribute<DescAttribute>(m) ? Utility.GetCustomAttributes<DescAttribute>(m, true).First().Lines.JoinWith("<br />") : "";
 					Console.WriteLine($"| **{m.LuaDocString()}** | {desc} |");
 				}
 			}
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			var actorCategories = utility.ModData.ObjectCreator.GetTypesImplementing<ScriptActorProperties>().SelectMany(cg =>
 			{
-				var catAttr = cg.GetCustomAttributes<ScriptPropertyGroupAttribute>(false).FirstOrDefault();
+				var catAttr = Utility.GetCustomAttributes<ScriptPropertyGroupAttribute>(cg, false).FirstOrDefault();
 				var category = catAttr != null ? catAttr.Category : "Unsorted";
 
 				var required = ScriptMemberWrapper.RequiredTraitNames(cg);
@@ -106,9 +106,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				{
 					var mi = property.mi;
 					var required = property.required;
-					var hasDesc = mi.HasAttribute<DescAttribute>();
+					var hasDesc = Utility.HasAttribute<DescAttribute>(mi);
 					var hasRequires = required.Length > 0;
-					var isActivity = mi.HasAttribute<ScriptActorPropertyActivityAttribute>();
+					var isActivity = Utility.HasAttribute<ScriptActorPropertyActivityAttribute>(mi);
 
 					Console.Write($"| **{mi.LuaDocString()}**");
 
@@ -118,7 +118,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					Console.Write(" | ");
 
 					if (hasDesc)
-						Console.Write(mi.GetCustomAttributes<DescAttribute>(false).First().Lines.JoinWith("<br />"));
+						Console.Write(Utility.GetCustomAttributes<DescAttribute>(mi, false).First().Lines.JoinWith("<br />"));
 
 					if (hasDesc && hasRequires)
 						Console.Write("<br />");
@@ -136,7 +136,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			var playerCategories = utility.ModData.ObjectCreator.GetTypesImplementing<ScriptPlayerProperties>().SelectMany(cg =>
 			{
-				var catAttr = cg.GetCustomAttributes<ScriptPropertyGroupAttribute>(false).FirstOrDefault();
+				var catAttr = Utility.GetCustomAttributes<ScriptPropertyGroupAttribute>(cg, false).FirstOrDefault();
 				var category = catAttr != null ? catAttr.Category : "Unsorted";
 
 				var required = ScriptMemberWrapper.RequiredTraitNames(cg);
@@ -155,9 +155,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				{
 					var mi = property.mi;
 					var required = property.required;
-					var hasDesc = mi.HasAttribute<DescAttribute>();
+					var hasDesc = Utility.HasAttribute<DescAttribute>(mi);
 					var hasRequires = required.Length > 0;
-					var isActivity = mi.HasAttribute<ScriptActorPropertyActivityAttribute>();
+					var isActivity = Utility.HasAttribute<ScriptActorPropertyActivityAttribute>(mi);
 
 					Console.Write($"| **{mi.LuaDocString()}**");
 
@@ -167,7 +167,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					Console.Write(" | ");
 
 					if (hasDesc)
-						Console.Write(mi.GetCustomAttributes<DescAttribute>(false).First().Lines.JoinWith("<br />"));
+						Console.Write(Utility.GetCustomAttributes<DescAttribute>(mi, false).First().Lines.JoinWith("<br />"));
 
 					if (hasDesc && hasRequires)
 						Console.Write("<br />");

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractSettingsDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractSettingsDocsCommand.cs
@@ -59,8 +59,8 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			sections.Add("Launch", new LaunchArguments(new Arguments(Array.Empty<string>())));
 			foreach (var section in sections.OrderBy(s => s.Key))
 			{
-				var fields = section.Value.GetType().GetFields();
-				if (fields.Any(field => field.GetCustomAttributes<DescAttribute>(false).Length > 0))
+				var fields = Utility.GetFields(section.Value.GetType());
+				if (fields.Any(field => Utility.GetCustomAttributes<DescAttribute>(field, false).Length > 0))
 				{
 					Console.WriteLine($"## {section.Key}");
 					if (section.Key == "Launch")
@@ -72,11 +72,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 				foreach (var field in fields)
 				{
-					if (!field.HasAttribute<DescAttribute>())
+					if (!Utility.HasAttribute<DescAttribute>(field))
 						continue;
 
 					Console.WriteLine($"### {field.Name}");
-					var lines = field.GetCustomAttributes<DescAttribute>(false).SelectMany(d => d.Lines);
+					var lines = Utility.GetCustomAttributes<DescAttribute>(field, false).SelectMany(d => d.Lines);
 					foreach (var line in lines)
 					{
 						Console.WriteLine(line);

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractSpriteSequenceDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractSpriteSequenceDocsCommand.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				{
 					type.Namespace,
 					type.Name,
-					Description = string.Join(" ", type.GetCustomAttributes<DescAttribute>(false).SelectMany(d => d.Lines)),
+					Description = string.Join(" ", Utility.GetCustomAttributes<DescAttribute>(type, false).SelectMany(d => d.Lines)),
 					InheritedTypes = type.BaseTypes()
 						.Select(y => y.Name)
 						.Where(y => y != type.Name && y != "Object"),
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						.Where(fi => fi.FieldType.IsGenericType && fi.FieldType.GetGenericTypeDefinition() == typeof(SpriteSequenceField<>))
 						.Select(fi =>
 						{
-							var description = string.Join(" ", fi.GetCustomAttributes<DescAttribute>(false)
+							var description = string.Join(" ", Utility.GetCustomAttributes<DescAttribute>(fi, false)
 								.SelectMany(d => d.Lines));
 
 							var valueType = fi.FieldType.GetGenericArguments()[0];

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				{
 					type.Namespace,
 					Name = type.Name.EndsWith("Info") ? type.Name.Substring(0, type.Name.Length - 4) : type.Name,
-					Description = string.Join(" ", type.GetCustomAttributes<DescAttribute>(false).SelectMany(d => d.Lines)),
+					Description = string.Join(" ", Utility.GetCustomAttributes<DescAttribute>(type, false).SelectMany(d => d.Lines)),
 					RequiresTraits = RequiredTraitTypes(type)
 						.Select(y => y.Name),
 					InheritedTypes = type.BaseTypes()
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 								DefaultValue = FieldSaver.SaveField(objectCreator.CreateBasic(type), fi.Field.Name).Value.Value,
 								InternalType = Util.InternalTypeName(fi.Field.FieldType),
 								UserFriendlyType = Util.FriendlyTypeName(fi.Field.FieldType),
-								Description = string.Join(" ", fi.Field.GetCustomAttributes<DescAttribute>(true).SelectMany(d => d.Lines)),
+								Description = string.Join(" ", Utility.GetCustomAttributes<DescAttribute>(fi.Field, true).SelectMany(d => d.Lines)),
 								OtherAttributes = fi.Field.CustomAttributes
 									.Where(a => a.AttributeType.Name != nameof(DescAttribute) && a.AttributeType.Name != nameof(FieldLoader.LoadUsingAttribute))
 									.Select(a =>

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractWeaponDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractWeaponDocsCommand.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				{
 					type.Namespace,
 					Name = type.Name.EndsWith("Info") ? type.Name.Substring(0, type.Name.Length - 4) : type.Name,
-					Description = string.Join(" ", type.GetCustomAttributes<DescAttribute>(false).SelectMany(d => d.Lines)),
+					Description = string.Join(" ", Utility.GetCustomAttributes<DescAttribute>(type, false).SelectMany(d => d.Lines)),
 					InheritedTypes = type.BaseTypes()
 						.Select(y => y.Name)
 						.Where(y => y != type.Name && y != $"{type.Name}Info" && y != "Object"),
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 								DefaultValue = FieldSaver.SaveField(objectCreator.CreateBasic(type), fi.Field.Name).Value.Value,
 								InternalType = Util.InternalTypeName(fi.Field.FieldType),
 								UserFriendlyType = Util.FriendlyTypeName(fi.Field.FieldType),
-								Description = string.Join(" ", fi.Field.GetCustomAttributes<DescAttribute>(true).SelectMany(d => d.Lines)),
+								Description = string.Join(" ", Utility.GetCustomAttributes<DescAttribute>(fi.Field, true).SelectMany(d => d.Lines)),
 								OtherAttributes = fi.Field.CustomAttributes
 									.Where(a => a.AttributeType.Name != nameof(DescAttribute) && a.AttributeType.Name != nameof(FieldLoader.LoadUsingAttribute))
 									.Select(a =>

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractZeroBraneStudioLuaAPI.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractZeroBraneStudioLuaAPI.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			var tables = utility.ModData.ObjectCreator.GetTypesImplementing<ScriptGlobal>().OrderBy(t => t.Name);
 			foreach (var t in tables)
 			{
-				var name = t.GetCustomAttributes<ScriptGlobalAttribute>(true).First().Name;
+				var name = Utility.GetCustomAttributes<ScriptGlobalAttribute>(t, true).First().Name;
 				Console.WriteLine("  " + name + " = {");
 				Console.WriteLine("    type = \"class\",");
 				Console.WriteLine("    childs = {");
@@ -64,9 +64,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					if (propertyInfo != null)
 						Console.WriteLine("        type = \"value\",");
 
-					if (member.HasAttribute<DescAttribute>())
+					if (Utility.HasAttribute<DescAttribute>(member))
 					{
-						var desc = member.GetCustomAttributes<DescAttribute>(true).First().Lines.JoinWith("\n");
+						var desc = Utility.GetCustomAttributes<DescAttribute>(member, true).First().Lines.JoinWith("\n");
 						Console.WriteLine("        description = [[{0}]],", desc);
 					}
 
@@ -105,9 +105,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				if (propertyInfo != null)
 					Console.WriteLine("    type = \"value\",");
 
-				if (property.HasAttribute<DescAttribute>())
+				if (Utility.HasAttribute<DescAttribute>(property))
 				{
-					var desc = property.GetCustomAttributes<DescAttribute>(true).First().Lines.JoinWith("\n");
+					var desc = Utility.GetCustomAttributes<DescAttribute>(property, true).First().Lines.JoinWith("\n");
 					Console.WriteLine("    description = [[{0}]],", desc);
 				}
 

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -162,7 +162,7 @@ namespace OpenRA
 
 		static void GetActionUsage(string key, Action<Utility, string[]> action)
 		{
-			var descParts = action.Method.GetCustomAttributes<DescAttribute>(true)
+			var descParts = Utility.GetCustomAttributes<DescAttribute>(action.Method, true)
 					.SelectMany(d => d.Lines).ToArray();
 
 			if (descParts.Length == 0)


### PR DESCRIPTION
Reduces runtime of --check-yaml command to 70% of original. Will save time when running `make test` locally, and during CI runs.

| Timings                | Before | After | Relative |
| ------------------ | ------: | -----: | -------: |
| `ra --check-yaml` | 27.95s | 18.58s | 67% |
| `cnc --check-yaml` | 11.11s | 7.75s | 70% |
| `ts --check-yaml` | 9.28s | 6.26s | 68% |
| `d2k --check-yaml` | 6.63s | 4.54s | 69% |