### PR TITLE
Installer fixes and enhancements.

### DIFF
--- a/OpenRA.Mods.Cnc/Installer/ExtractMixSourceAction.cs
+++ b/OpenRA.Mods.Cnc/Installer/ExtractMixSourceAction.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Cnc.Installer
 						if (stream.Length < InstallFromSourceLogic.ShowPercentageThreshold)
 							updateMessage(modData.Translation.GetString(InstallFromSourceLogic.Extracing, Translation.Arguments("filename", displayFilename)));
 						else
-							onProgress = b => updateMessage(modData.Translation.GetString(InstallFromSourceLogic.ExtracingProgress, Translation.Arguments("filename", displayFilename, "progress", 100 * b / stream.Length)));
+							onProgress = b => updateMessage(modData.Translation.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", 100 * b / stream.Length)));
 
 						using (var target = File.OpenWrite(targetPath))
 						{

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractBlastSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractBlastSourceAction.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Installer
 					if (length < InstallFromSourceLogic.ShowPercentageThreshold)
 						updateMessage(modData.Translation.GetString(InstallFromSourceLogic.Extracing, Translation.Arguments("filename", displayFilename)));
 					else
-						onProgress = b => updateMessage(modData.Translation.GetString(InstallFromSourceLogic.ExtracingProgress, Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
+						onProgress = b => updateMessage(modData.Translation.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
 
 					using (var target = File.OpenWrite(targetPath))
 					{

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractIscabSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractIscabSourceAction.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Installer
 						{
 							Log.Write("install", $"Extracting {sourcePath} -> {targetPath}");
 							var displayFilename = Path.GetFileName(Path.GetFileName(targetPath));
-							void OnProgress(int percent) => updateMessage(modData.Translation.GetString(InstallFromSourceLogic.ExtracingProgress, Translation.Arguments("filename", displayFilename, "progress", percent)));
+							void OnProgress(int percent) => updateMessage(modData.Translation.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", percent)));
 							reader.ExtractFile(node.Value.Value, target, OnProgress);
 						}
 					}

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractMscabSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractMscabSourceAction.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Installer
 					{
 						Log.Write("install", $"Extracting {sourcePath} -> {targetPath}");
 						var displayFilename = Path.GetFileName(Path.GetFileName(targetPath));
-						void OnProgress(int percent) => updateMessage(modData.Translation.GetString(InstallFromSourceLogic.ExtracingProgress, Translation.Arguments("filename", displayFilename, "progress", percent)));
+						void OnProgress(int percent) => updateMessage(modData.Translation.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", percent)));
 						reader.ExtractFile(node.Value.Value, target, OnProgress);
 					}
 				}

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractRawSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractRawSourceAction.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Installer
 					if (length < InstallFromSourceLogic.ShowPercentageThreshold)
 						updateMessage(modData.Translation.GetString(InstallFromSourceLogic.Extracing, Translation.Arguments("filename", displayFilename)));
 					else
-						onProgress = b => updateMessage(modData.Translation.GetString(InstallFromSourceLogic.ExtracingProgress, Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
+						onProgress = b => updateMessage(modData.Translation.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
 
 					using (var target = File.OpenWrite(targetPath))
 					{

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractZipSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractZipSourceAction.cs
@@ -1,0 +1,59 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using ICSharpCode.SharpZipLib.Zip;
+using OpenRA.Mods.Common.Widgets.Logic;
+using FS = OpenRA.FileSystem.FileSystem;
+
+namespace OpenRA.Mods.Common.Installer
+{
+	public class ExtractZipSourceAction : ISourceAction
+	{
+		public void RunActionOnSource(MiniYaml actionYaml, string path, ModData modData, List<string> extracted,
+			Action<string> updateMessage)
+		{
+			var zipPath = actionYaml.Value.StartsWith("^")
+				? Platform.ResolvePath(actionYaml.Value)
+				: FS.ResolveCaseInsensitivePath(Path.Combine(path, actionYaml.Value));
+
+			using (var zipFile = new ZipFile(File.OpenRead(zipPath)))
+			{
+				foreach (var node in actionYaml.Nodes)
+				{
+					var targetPath = Platform.ResolvePath(node.Key);
+					var sourcePath = node.Value.Value;
+					var displayFilename = Path.GetFileName(targetPath);
+
+					if (File.Exists(targetPath))
+					{
+						Log.Write("install", "Skipping installed file " + targetPath);
+						continue;
+					}
+
+					Log.Write("install", $"Extracting {sourcePath} -> {targetPath}");
+
+					Directory.CreateDirectory(Path.GetDirectoryName(targetPath));
+
+					var sourceStream = zipFile.GetInputStream(zipFile.GetEntry(sourcePath));
+					using (var targetStream = File.OpenWrite(targetPath))
+						sourceStream.CopyTo(targetStream);
+
+					updateMessage(modData.Translation.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", 100)));
+
+					extracted.Add(targetPath);
+				}
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Installer/SourceResolvers/GogSourceResolver.cs
+++ b/OpenRA.Mods.Common/Installer/SourceResolvers/GogSourceResolver.cs
@@ -34,8 +34,13 @@ namespace OpenRA.Mods.Common.Installer
 			var prefixes = new[] { "HKEY_LOCAL_MACHINE\\Software\\", "HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\" };
 
 			foreach (var prefix in prefixes)
-				if (Registry.GetValue($"{prefix}GOG.com\\Games\\{appId.Value}", "path", null) is string installDir)
+			{
+				if (!(Registry.GetValue($"{prefix}GOG.com\\Games\\{appId.Value}", "path", null) is string installDir))
+					continue;
+
+				if (InstallerUtils.IsValidSourcePath(installDir, modSource))
 					return installDir;
+			}
 
 			return null;
 		}

--- a/OpenRA.Mods.Common/Installer/SourceResolvers/SteamSourceResolver.cs
+++ b/OpenRA.Mods.Common/Installer/SourceResolvers/SteamSourceResolver.cs
@@ -43,8 +43,13 @@ namespace OpenRA.Mods.Common.Installer
 				if (!data.TryGetValue("installdir", out var installDir))
 					continue;
 
-				if (installDir != null)
-					return Path.Combine(steamDirectory, "steamapps", "common", installDir);
+				if (installDir == null)
+					continue;
+
+				var path = Path.Combine(steamDirectory, "steamapps", "common", installDir);
+
+				if (InstallerUtils.IsValidSourcePath(path, modSource))
+					return path;
 			}
 
 			return null;

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromSourceLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromSourceLogic.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		public const string Extracing = "label-extracting-filename";
 
 		[TranslationReference("filename", "progress")]
-		public const string ExtracingProgress = "label-extracting-filename-progress";
+		public const string ExtractingProgress = "label-extracting-filename-progress";
 
 		[TranslationReference]
 		public const string Continue = "button-continue";


### PR DESCRIPTION
1. GoG and Steam installations may have DLCs. This results in optional files. We already have the IDFiles entry to verify a specific file exists, but currently both implementations will ignore the IDFiles entry completely. This PR fixes that. This not only fixes DLC files, but also ensures the installer no longer crashes when you delete the game folder, but keep the app manifest file (steam) or the registry (gog) intact.

2. We already have a bunch of extractors but we were missing the most basic one: zip files! I also added that. (Used for OpenE2140, as the GoG version ships the soundtrack as .zip)
