### PR TITLE
Add RulesetTranslation scope

### DIFF
--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -73,8 +73,8 @@ namespace OpenRA
 		public readonly string[]
 			Rules, ServerTraits,
 			Sequences, ModelSequences, Cursors, Chrome, Assemblies, ChromeLayout,
-			Weapons, Voices, Notifications, Music, Translations, TileSets,
-			ChromeMetrics, MapCompatibility, Missions, Hotkeys;
+			Weapons, Voices, Notifications, Music, Translations, RulesetTranslations,
+			TileSets, ChromeMetrics, MapCompatibility, Missions, Hotkeys;
 
 		public readonly IReadOnlyDictionary<string, string> Packages;
 		public readonly IReadOnlyDictionary<string, string> MapFolders;
@@ -90,7 +90,7 @@ namespace OpenRA
 		{
 			"Include", "Metadata", "Folders", "MapFolders", "Packages", "Rules",
 			"Sequences", "ModelSequences", "Cursors", "Chrome", "Assemblies", "ChromeLayout", "Weapons",
-			"Voices", "Notifications", "Music", "Translations", "TileSets", "ChromeMetrics", "Missions", "Hotkeys",
+			"Voices", "Notifications", "Music", "Translations", "RulesetTranslations", "TileSets", "ChromeMetrics", "Missions", "Hotkeys",
 			"ServerTraits", "LoadScreen", "DefaultOrderGenerator", "SupportsMapsFrom", "SoundFormats", "SpriteFormats", "VideoFormats",
 			"RequiresMods", "PackageFormats"
 		};
@@ -144,6 +144,7 @@ namespace OpenRA
 			Notifications = YamlList(yaml, "Notifications");
 			Music = YamlList(yaml, "Music");
 			Translations = YamlList(yaml, "Translations");
+			RulesetTranslations = YamlList(yaml, "RulesetTranslations");
 			TileSets = YamlList(yaml, "TileSets");
 			ChromeMetrics = YamlList(yaml, "ChromeMetrics");
 			Missions = YamlList(yaml, "Missions");

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -452,8 +452,8 @@ namespace OpenRA
 
 			Translation = new Translation(Game.Settings.Player.Language,
 				TranslationDefinitions != null
-				? modData.Manifest.Translations.Append(FieldLoader.GetValue<string[]>("value", TranslationDefinitions.Value)).ToArray()
-				: modData.Manifest.Translations, this);
+				? modData.Manifest.RulesetTranslations.Append(FieldLoader.GetValue<string[]>("value", TranslationDefinitions.Value)).ToArray()
+				: modData.Manifest.RulesetTranslations, this);
 
 			var tl = new MPos(0, 0).ToCPos(this);
 			var br = new MPos(MapSize.X - 1, MapSize.Y - 1).ToCPos(this);

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -90,6 +90,8 @@ namespace OpenRA
 			public MiniYaml SequenceDefinitions;
 			public MiniYaml ModelSequenceDefinitions;
 
+			public Translation Translation;
+
 			public ActorInfo WorldActorInfo { get; private set; }
 			public ActorInfo PlayerActorInfo { get; private set; }
 
@@ -119,6 +121,11 @@ namespace OpenRA
 				NotificationDefinitions = LoadRuleSection(yaml, "Notifications");
 				SequenceDefinitions = LoadRuleSection(yaml, "Sequences");
 				ModelSequenceDefinitions = LoadRuleSection(yaml, "ModelSequences");
+
+				Translation = new Translation(Game.Settings.Player.Language,
+					yaml.TryGetValue("Translations", out var node) && node != null
+					? modData.Manifest.Translations.Append(FieldLoader.GetValue<string[]>("value", node.Value)).ToArray()
+					: modData.Manifest.Translations, fileSystem);
 
 				try
 				{
@@ -185,6 +192,7 @@ namespace OpenRA
 
 		public MiniYaml RuleDefinitions => innerData.RuleDefinitions;
 		public MiniYaml WeaponDefinitions => innerData.WeaponDefinitions;
+		public Translation Translation => innerData.Translation;
 
 		public ActorInfo WorldActorInfo => innerData.WorldActorInfo;
 		public ActorInfo PlayerActorInfo => innerData.PlayerActorInfo;
@@ -292,6 +300,7 @@ namespace OpenRA
 			innerData.SetCustomRules(modData, this, new Dictionary<string, MiniYaml>()
 			{
 				{ "Rules", map.RuleDefinitions },
+				{ "Translations", map.TranslationDefinitions },
 				{ "Weapons", map.WeaponDefinitions },
 				{ "Voices", map.VoiceDefinitions },
 				{ "Music", map.MusicDefinitions },

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -124,8 +124,8 @@ namespace OpenRA
 
 				Translation = new Translation(Game.Settings.Player.Language,
 					yaml.TryGetValue("Translations", out var node) && node != null
-					? modData.Manifest.Translations.Append(FieldLoader.GetValue<string[]>("value", node.Value)).ToArray()
-					: modData.Manifest.Translations, fileSystem);
+					? modData.Manifest.RulesetTranslations.Append(FieldLoader.GetValue<string[]>("value", node.Value)).ToArray()
+					: modData.Manifest.RulesetTranslations, fileSystem);
 
 				try
 				{

--- a/OpenRA.Game/Traits/Player/Shroud.cs
+++ b/OpenRA.Game/Traits/Player/Shroud.cs
@@ -60,11 +60,9 @@ namespace OpenRA.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
-			yield return new LobbyBooleanOption("explored", Game.ModData.Translation.GetString(ExploredMapCheckboxLabel),
-				Game.ModData.Translation.GetString(ExploredMapCheckboxDescription),
+			yield return new LobbyBooleanOption(map, "explored", ExploredMapCheckboxLabel, ExploredMapCheckboxDescription,
 				ExploredMapCheckboxVisible, ExploredMapCheckboxDisplayOrder, ExploredMapCheckboxEnabled, ExploredMapCheckboxLocked);
-			yield return new LobbyBooleanOption("fog", Game.ModData.Translation.GetString(FogCheckboxLabel),
-				Game.ModData.Translation.GetString(FogCheckboxDescription),
+			yield return new LobbyBooleanOption(map, "fog", FogCheckboxLabel, FogCheckboxDescription,
 				FogCheckboxVisible, FogCheckboxDisplayOrder, FogCheckboxEnabled, FogCheckboxLocked);
 		}
 

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -542,12 +542,12 @@ namespace OpenRA.Traits
 		public readonly bool IsVisible;
 		public readonly int DisplayOrder;
 
-		public LobbyOption(string id, string name, string description, bool visible, int displayorder,
+		public LobbyOption(MapPreview map, string id, string name, string description, bool visible, int displayorder,
 			IReadOnlyDictionary<string, string> values, string defaultValue, bool locked)
 		{
 			Id = id;
-			Name = Game.ModData.Translation.GetString(name);
-			Description = Game.ModData.Translation.GetString(description);
+			Name = map.Translation.GetString(name);
+			Description = map.Translation.GetString(description);
 			IsVisible = visible;
 			DisplayOrder = displayorder;
 			Values = values;
@@ -569,8 +569,8 @@ namespace OpenRA.Traits
 			{ false.ToString(), "Disabled" }
 		};
 
-		public LobbyBooleanOption(string id, string name, string description, bool visible, int displayorder, bool defaultValue, bool locked)
-			: base(id, name, description, visible, displayorder, new ReadOnlyDictionary<string, string>(BoolValues), defaultValue.ToString(), locked) { }
+		public LobbyBooleanOption(MapPreview map, string id, string name, string description, bool visible, int displayorder, bool defaultValue, bool locked)
+			: base(map, id, name, description, visible, displayorder, new ReadOnlyDictionary<string, string>(BoolValues), defaultValue.ToString(), locked) { }
 
 		public override string Label(string newValue)
 		{

--- a/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckTranslationReference : ILintPass
+	class CheckTranslationReference : ILintPass, ILintMapPass
 	{
 		const BindingFlags Binding = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
 
@@ -28,14 +28,9 @@ namespace OpenRA.Mods.Common.Lint
 		readonly Dictionary<string, string[]> referencedVariablesPerKey = new Dictionary<string, string[]>();
 		readonly List<string> variableReferences = new List<string>();
 
-		void ILintPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData)
+		void TestTraits(Action<string> emitError, Ruleset rules, Translation translation, string language)
 		{
-			// TODO: Check all available languages
-			var language = "en";
-			Console.WriteLine($"Testing translation: {language}");
-			var translation = new Translation(language, modData.Manifest.Translations, modData.DefaultFileSystem);
-
-			foreach (var actorInfo in modData.DefaultRules.Actors)
+			foreach (var actorInfo in rules.Actors)
 			{
 				foreach (var traitInfo in actorInfo.Value.TraitInfos<TraitInfo>())
 				{
@@ -60,6 +55,23 @@ namespace OpenRA.Mods.Common.Lint
 					}
 				}
 			}
+		}
+
+		void ILintMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
+		{
+			// TODO: Check all available languages.
+			var language = "en";
+			TestTraits(emitError, map.Rules, map.Translation, language);
+		}
+
+		void ILintPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData)
+		{
+			// TODO: Check all available languages.
+			var language = "en";
+			Console.WriteLine($"Testing translation: {language}");
+			var translation = new Translation(language, modData.Manifest.Translations, modData.DefaultFileSystem);
+
+			TestTraits(emitError, modData.DefaultRules, translation, language);
 
 			var gameSpeeds = modData.Manifest.Get<GameSpeeds>();
 			foreach (var speed in gameSpeeds.Speeds.Values)

--- a/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
@@ -69,9 +69,10 @@ namespace OpenRA.Mods.Common.Lint
 			// TODO: Check all available languages.
 			var language = "en";
 			Console.WriteLine($"Testing translation: {language}");
-			var translation = new Translation(language, modData.Manifest.Translations, modData.DefaultFileSystem);
 
-			TestTraits(emitError, modData.DefaultRules, translation, language);
+			TestTraits(emitError, modData.DefaultRules, new Translation(language, modData.Manifest.RulesetTranslations, modData.DefaultFileSystem), language);
+
+			var translation = new Translation(language, modData.Manifest.Translations, modData.DefaultFileSystem);
 
 			var gameSpeeds = modData.Manifest.Get<GameSpeeds>();
 			foreach (var speed in gameSpeeds.Speeds.Values)

--- a/OpenRA.Mods.Common/Scripting/Global/UserInterfaceGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/UserInterfaceGlobal.cs
@@ -51,10 +51,10 @@ namespace OpenRA.Mods.Common.Scripting.Global
 					}
 				}
 
-				return Context.World.Map.Translate(text, argumentDictionary);
+				return Context.World.Map.Translation.GetString(text, argumentDictionary);
 			}
 
-			return Context.World.Map.Translate(text);
+			return Context.World.Map.Translation.GetString(text);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
-			yield return new LobbyBooleanOption("cheats", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
+			yield return new LobbyBooleanOption(map, "cheats", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
 		}
 
 		public override object Create(ActorInitializer init) { return new DeveloperMode(this); }

--- a/OpenRA.Mods.Common/Traits/Player/LobbyPrerequisiteCheckbox.cs
+++ b/OpenRA.Mods.Common/Traits/Player/LobbyPrerequisiteCheckbox.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
-			yield return new LobbyBooleanOption(ID, Label, Description,
+			yield return new LobbyBooleanOption(map, ID, Label, Description,
 				Visible, DisplayOrder, Enabled, Locked);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 			var startingCash = SelectableCash.ToDictionary(c => c.ToString(), c => "$" + c.ToString());
 
 			if (startingCash.Count > 0)
-				yield return new LobbyOption("startingcash", DefaultCashDropdownLabel, DefaultCashDropdownDescription, DefaultCashDropdownVisible, DefaultCashDropdownDisplayOrder,
+				yield return new LobbyOption(map, "startingcash", DefaultCashDropdownLabel, DefaultCashDropdownDescription, DefaultCashDropdownVisible, DefaultCashDropdownDisplayOrder,
 					startingCash, DefaultCash.ToString(), DefaultCashDropdownLocked);
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
-			yield return new LobbyBooleanOption("crates", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
+			yield return new LobbyBooleanOption(map, "crates", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
 		}
 
 		public override object Create(ActorInitializer init) { return new CrateSpawner(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/World/MapBuildRadius.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapBuildRadius.cs
@@ -60,10 +60,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
-			yield return new LobbyBooleanOption("allybuild", AllyBuildRadiusCheckboxLabel, AllyBuildRadiusCheckboxDescription,
+			yield return new LobbyBooleanOption(map, "allybuild", AllyBuildRadiusCheckboxLabel, AllyBuildRadiusCheckboxDescription,
 				AllyBuildRadiusCheckboxVisible, AllyBuildRadiusCheckboxDisplayOrder, AllyBuildRadiusCheckboxEnabled, AllyBuildRadiusCheckboxLocked);
 
-			yield return new LobbyBooleanOption("buildradius", BuildRadiusCheckboxLabel, BuildRadiusCheckboxDescription,
+			yield return new LobbyBooleanOption(map, "buildradius", BuildRadiusCheckboxLabel, BuildRadiusCheckboxDescription,
 				BuildRadiusCheckboxVisible, BuildRadiusCheckboxDisplayOrder, BuildRadiusCheckboxEnabled, BuildRadiusCheckboxLocked);
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
-			yield return new LobbyBooleanOption("creeps", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
+			yield return new LobbyBooleanOption(map, "creeps", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
 		}
 
 		public override object Create(ActorInitializer init) { return new MapCreeps(this); }

--- a/OpenRA.Mods.Common/Traits/World/MapOptions.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapOptions.cs
@@ -81,22 +81,24 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
-			yield return new LobbyBooleanOption("shortgame", ShortGameCheckboxLabel, ShortGameCheckboxDescription,
+			yield return new LobbyBooleanOption(map, "shortgame", ShortGameCheckboxLabel, ShortGameCheckboxDescription,
 				ShortGameCheckboxVisible, ShortGameCheckboxDisplayOrder, ShortGameCheckboxEnabled, ShortGameCheckboxLocked);
 
 			var techLevels = map.PlayerActorInfo.TraitInfos<ProvidesTechPrerequisiteInfo>()
-				.ToDictionary(t => t.Id, t => Game.ModData.Translation.GetString(t.Name));
+				.ToDictionary(t => t.Id, t => map.Translation.GetString(t.Name));
 
 			if (techLevels.Count > 0)
-				yield return new LobbyOption("techlevel", TechLevelDropdownLabel, TechLevelDropdownDescription, TechLevelDropdownVisible, TechLevelDropdownDisplayOrder,
+				yield return new LobbyOption(map, "techlevel", TechLevelDropdownLabel, TechLevelDropdownDescription, TechLevelDropdownVisible, TechLevelDropdownDisplayOrder,
 					techLevels, TechLevel, TechLevelDropdownLocked);
 
 			var gameSpeeds = Game.ModData.Manifest.Get<GameSpeeds>();
 			var speeds = gameSpeeds.Speeds.ToDictionary(s => s.Key, s => Game.ModData.Translation.GetString(s.Value.Name));
 
-			// NOTE: This is just exposing the UI, the backend logic for this option is hardcoded in World
-			yield return new LobbyOption("gamespeed", GameSpeedDropdownLabel, GameSpeedDropdownDescription, GameSpeedDropdownVisible, GameSpeedDropdownDisplayOrder,
-				speeds, GameSpeed ?? gameSpeeds.DefaultSpeed, GameSpeedDropdownLocked);
+			// NOTE: This is just exposing the UI, the backend logic for this option is hardcoded in World.
+			yield return new LobbyOption(map, "gamespeed",
+				GameSpeedDropdownLabel, GameSpeedDropdownDescription,
+				GameSpeedDropdownVisible, GameSpeedDropdownDisplayOrder, speeds,
+				GameSpeed ?? gameSpeeds.DefaultSpeed, GameSpeedDropdownLocked);
 		}
 
 		void IRulesetLoaded<ActorInfo>.RulesetLoaded(Ruleset rules, ActorInfo info)

--- a/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
@@ -50,6 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
 			yield return new LobbyBooleanOption(
+				map,
 				"separateteamspawns",
 				SeparateTeamSpawnsCheckboxLabel,
 				SeparateTeamSpawnsCheckboxDescription,

--- a/OpenRA.Mods.Common/Traits/World/ScriptLobbyDropdown.cs
+++ b/OpenRA.Mods.Common/Traits/World/ScriptLobbyDropdown.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
-			yield return new LobbyOption(ID, Label, Description, Visible, DisplayOrder,
+			yield return new LobbyOption(map, ID, Label, Description, Visible, DisplayOrder,
 				Values, Default, Locked);
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
@@ -47,10 +47,10 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Duplicate classes are defined for different race variants
 			foreach (var t in map.WorldActorInfo.TraitInfos<StartingUnitsInfo>())
-				startingUnits[t.Class] = Game.ModData.Translation.GetString(t.ClassName);
+				startingUnits[t.Class] = map.Translation.GetString(t.ClassName);
 
 			if (startingUnits.Count > 0)
-				yield return new LobbyOption("startingunits", DropdownLabel, DropdownDescription, DropdownVisible, DropdownDisplayOrder,
+				yield return new LobbyOption(map, "startingunits", DropdownLabel, DropdownDescription, DropdownVisible, DropdownDisplayOrder,
 					startingUnits, StartingUnitsClass, DropdownLocked);
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/TimeLimitManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/TimeLimitManager.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.Common.Traits
 					return Game.ModData.Translation.GetString(TimeLimitOption, Translation.Arguments("minutes", m));
 			});
 
-			yield return new LobbyOption("timelimit", TimeLimitLabel, TimeLimitDescription, TimeLimitDropdownVisible, TimeLimitDisplayOrder,
+			yield return new LobbyOption(map, "timelimit", TimeLimitLabel, TimeLimitDescription, TimeLimitDropdownVisible, TimeLimitDisplayOrder,
 				timelimits, TimeLimitDefault.ToString(), TimeLimitLocked);
 		}
 

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -145,6 +145,7 @@ ChromeLayout:
 
 Translations:
 	common|languages/en.ftl
+	common|languages/rules/en.ftl
 	cnc|languages/rules/en.ftl
 
 Voices:

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -145,6 +145,8 @@ ChromeLayout:
 
 Translations:
 	common|languages/en.ftl
+
+RulesetTranslations:
 	common|languages/rules/en.ftl
 	cnc|languages/rules/en.ftl
 

--- a/mods/common/languages/en.ftl
+++ b/mods/common/languages/en.ftl
@@ -690,48 +690,7 @@ description-path-debug-overlay = toggles a visualization of path searching.
 ## TerrainGeometryOverlay
 description-terrain-geometry-overlay = toggles the terrain geometry overlay.
 
-## Shroud
-checkbox-fog-of-war =
-    .label = Fog of War
-    .description = Line of sight is required to view enemy forces
-
-checkbox-explored-map =
-    .label = Explored Map
-    .description = Initial map shroud is revealed
-
-## DeveloperMode
-checkbox-debug-menu =
-    .label = Debug Menu
-    .description = Enables cheats and developer commands
-
-## CrateSpawner
-checkbox-crates =
-    .label = Crates
-    .description = Collect crates with units to receive random bonuses or penalties
-
-## MapBuildRadius
-checkbox-ally-build-radius =
-    .label = Build off Allies
-    .description = Allow allies to place structures inside your build area
-
-checkbox-build-radius =
-    .label = Limit Build Area
-    .description = Limits structure placement to areas around Construction Yards
-
-## MapOptions
-checkbox-short-game =
-    .label = Short Game
-    .description = Players are defeated when their bases are destroyed
-
-dropdown-tech-level =
-    .label = Tech Level
-    .description = The units and abilities that players can use
-
 ## MapOptions, MissionBrowserLogic
-dropdown-game-speed =
-    .label = Game Speed
-    .description = The rate at which time passes
-
 options-game-speed =
     .slowest = Slowest
     .slower = Slower
@@ -740,21 +699,7 @@ options-game-speed =
     .faster = Faster
     .fastest = Fastest
 
-## MapStartingLocations
-checkbox-separate-team-spawns =
-    .label = Separate Team Spawns
-    .description = Players without assigned spawn points will start as far as possible from enemy players
-
-## SpawnStartingUnits
-dropdown-starting-units =
-    .label = Starting Units
-    .description = The units that players start the game with
-
 ## TimeLimitManager
-dropdown-time-limit =
-    .label = Time Limit
-    .description = Player or team with the highest score after this time wins
-
 options-time-limit =
     .no-limit = No limit
     .options =

--- a/mods/common/languages/rules/en.ftl
+++ b/mods/common/languages/rules/en.ftl
@@ -1,0 +1,58 @@
+## Shroud
+checkbox-fog-of-war =
+    .label = Fog of War
+    .description = Line of sight is required to view enemy forces
+
+checkbox-explored-map =
+    .label = Explored Map
+    .description = Initial map shroud is revealed
+
+## DeveloperMode
+checkbox-debug-menu =
+    .label = Debug Menu
+    .description = Enables cheats and developer commands
+
+## CrateSpawner
+checkbox-crates =
+    .label = Crates
+    .description = Collect crates with units to receive random bonuses or penalties
+
+## MapBuildRadius
+checkbox-ally-build-radius =
+    .label = Build off Allies
+    .description = Allow allies to place structures inside your build area
+
+checkbox-build-radius =
+    .label = Limit Build Area
+    .description = Limits structure placement to areas around Construction Yards
+
+## MapOptions
+checkbox-short-game =
+    .label = Short Game
+    .description = Players are defeated when their bases are destroyed
+
+dropdown-tech-level =
+    .label = Tech Level
+    .description = The units and abilities that players can use
+
+## MapOptions
+dropdown-game-speed =
+    .label = Game Speed
+    .description = The rate at which time passes
+
+## MapStartingLocations
+checkbox-separate-team-spawns =
+    .label = Separate Team Spawns
+    .description = Players without assigned spawn points will start as far as possible from enemy players
+
+## SpawnStartingUnits
+dropdown-starting-units =
+    .label = Starting Units
+    .description = The units that players start the game with
+
+## TimeLimitManager
+dropdown-time-limit =
+    .label = Time Limit
+    .description = Player or team with the highest score after this time wins
+
+notification-time-limit-expired = Time limit has expired.

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -125,6 +125,7 @@ ChromeLayout:
 
 Translations:
 	common|languages/en.ftl
+	common|languages/rules/en.ftl
 	d2k|languages/rules/en.ftl
 
 Weapons:

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -125,6 +125,8 @@ ChromeLayout:
 
 Translations:
 	common|languages/en.ftl
+
+RulesetTranslations:
 	common|languages/rules/en.ftl
 	d2k|languages/rules/en.ftl
 

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -141,6 +141,7 @@ ChromeLayout:
 
 Translations:
 	common|languages/en.ftl
+	common|languages/rules/en.ftl
 	ra|languages/rules/en.ftl
 
 Weapons:

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -141,6 +141,8 @@ ChromeLayout:
 
 Translations:
 	common|languages/en.ftl
+
+RulesetTranslations:
 	common|languages/rules/en.ftl
 	ra|languages/rules/en.ftl
 

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -186,6 +186,7 @@ ChromeLayout:
 
 Translations:
 	common|languages/en.ftl
+	common|languages/rules/en.ftl
 	ts|languages/rules/en.ftl
 
 Voices:

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -186,6 +186,8 @@ ChromeLayout:
 
 Translations:
 	common|languages/en.ftl
+
+RulesetTranslations:
 	common|languages/rules/en.ftl
 	ts|languages/rules/en.ftl
 


### PR DESCRIPTION
* This adds a new mod level scope for translations that can be overwritten in maps (partly supersedes #20725). For now this scope only contains lobby options and lua translations.
* This PR also fixes a bug where lobby option overwrites weren't translated in game lobby (partly supersedes #20585)
* It also adds map level translation linting