### PR TITLE
Support dos paths in registry.

### DIFF
--- a/OpenRA.Mods.Common/Installer/SourceResolvers/RegistryDirectorySourceResolver.cs
+++ b/OpenRA.Mods.Common/Installer/SourceResolvers/RegistryDirectorySourceResolver.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace OpenRA.Mods.Common.Installer
@@ -32,6 +33,9 @@ namespace OpenRA.Mods.Common.Installer
 			{
 				if (!(Microsoft.Win32.Registry.GetValue(prefix + source.RegistryKey, source.RegistryValue, null) is string path))
 					continue;
+
+				// Resolve 8.3 format (DOS-style) paths to the full path.
+				path = Path.GetFullPath(path);
 
 				return InstallerUtils.IsValidSourcePath(path, source) ? path : null;
 			}


### PR DESCRIPTION
Not much to say. Some games might actualy use an old installer which stores paths like this in the registry:
![image](https://user-images.githubusercontent.com/1322277/229800056-a387b8f9-1739-4890-87f9-837a86e7b081.png)

the path itself works flawless under windows, and the inserted line properly resolves those.