### PR TITLE
Allow manual installer source picking.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -212,6 +212,10 @@ distributed under the MIT license.
 Using Linguini by the Space Station 14 team
 licensed under Apache and MIT terms.
 
+Using Native File Dialog Sharp created by milleniumbug
+based on Native File Dialog created by Michael Labbe
+and released under the zlib license.
+
 This site or product includes IP2Location LITE data
 available from http://www.ip2location.com.
 

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Linguini.Bundle" Version="0.4.0" />
     <PackageReference Include="OpenRA-Eluant" Version="1.0.20" />
     <PackageReference Include="Mono.NAT" Version="3.0.4" />
+    <PackageReference Include="NativeFileDialogSharp" Version="0.5.0" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Threading.Channels" Version="6.0.0" />

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -14,6 +14,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using NativeFileDialogSharp;
 
 namespace OpenRA
 {
@@ -253,6 +254,21 @@ namespace OpenRA
 				path = BinDir + path.Substring(8);
 
 			return path;
+		}
+
+		/// <summary>Allow the user to pick a path.</summary>
+		public static bool TryPickPath(out string path)
+		{
+			var result = Dialog.FolderPicker();
+
+			if (result.IsCancelled || result.IsError)
+			{
+				path = null;
+				return false;
+			}
+
+			path = result.Path;
+			return true;
 		}
 	}
 }

--- a/mods/common/languages/en.ftl
+++ b/mods/common/languages/en.ftl
@@ -1,6 +1,7 @@
 ## Buttons
 button-cancel = Cancel
 button-retry = Retry
+button-locate = Locate
 button-back = Back
 button-continue = Continue
 button-quit = Quit

--- a/mods/modcontent/content.yaml
+++ b/mods/modcontent/content.yaml
@@ -317,6 +317,13 @@ Background@SOURCE_INSTALL_PANEL:
 			Height: 32
 			Font: Bold
 			Key: escape
+		Button@SELECT_PATH_BUTTON:
+			X: PARENT_RIGHT / 2 - 55
+			Y: PARENT_BOTTOM - 52
+			Background: button-highlighted
+			Width: 110
+			Height: 32
+			Font: Bold
 		TooltipContainer@TOOLTIP_CONTAINER:
 
 Background@CONTENT_PROMPT_PANEL:


### PR DESCRIPTION
This PR implements this button:
![image](https://user-images.githubusercontent.com/1322277/230023177-92698e39-e506-42be-ac8c-1d536708599d.png)

Upon clicking, it uses NativeFileDialogSharp (windows, linux, osx) to manualy locate a directory.
It then checks for id files and continues the process process as before:
![image](https://user-images.githubusercontent.com/1322277/230023415-e88236af-c902-454f-8b33-aa6be5302168.png)

Besides that, the native dialog might be interesting for future stuff like importing or exporting assets etc.