### PR TITLE
IDFiles should be optional.

### DIFF
--- a/OpenRA.Mods.Common/Installer/InstallerUtils.cs
+++ b/OpenRA.Mods.Common/Installer/InstallerUtils.cs
@@ -20,6 +20,9 @@ namespace OpenRA.Mods.Common.Installer
 	{
 		public static bool IsValidSourcePath(string path, ModContent.ModSource source)
 		{
+			if (source.IDFiles == null)
+				return true;
+
 			try
 			{
 				foreach (var kv in source.IDFiles.Nodes)


### PR DESCRIPTION
Fixes a crash when an installer source does not use IDFiles.
Old: Due to the crash, the installation is always ignored, even when the source was properly resolved.
New: Installer sources without IDFiles entry will always match when the source was properly resolved.
