### PR TITLE
Mobile's Backward setting: Add MaxBackwardCells

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -160,7 +160,10 @@ namespace OpenRA.Mods.Common.Activities
 
 			var firstFacing = self.World.Map.FacingBetween(mobile.FromCell, nextCell.Value.Cell, mobile.Facing);
 
-			if (mobile.Info.CanMoveBackward && path.Count < mobile.Info.MaxBackwardCells && self.World.WorldTick - startTicks < mobile.Info.BackwardDuration && Math.Abs(firstFacing.Angle - mobile.Facing.Angle) > 256)
+			if (mobile.Info.CanMoveBackward
+				&& (mobile.Info.MaxBackwardCells < 0 || path.Count < mobile.Info.MaxBackwardCells)
+				&& (mobile.Info.BackwardDuration < 0 || self.World.WorldTick - startTicks < mobile.Info.BackwardDuration)
+				&& Math.Abs(firstFacing.Angle - mobile.Facing.Angle) > 256)
 			{
 				ActorFacingModifier = new WAngle(512);
 				firstFacing += ActorFacingModifier;

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -160,7 +160,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			var firstFacing = self.World.Map.FacingBetween(mobile.FromCell, nextCell.Value.Cell, mobile.Facing);
 
-			if (mobile.Info.CanMoveBackward && self.World.WorldTick - startTicks < mobile.Info.BackwardDuration && Math.Abs(firstFacing.Angle - mobile.Facing.Angle) > 256)
+			if (mobile.Info.CanMoveBackward && path.Count < mobile.Info.MaxBackwardCells && self.World.WorldTick - startTicks < mobile.Info.BackwardDuration && Math.Abs(firstFacing.Angle - mobile.Facing.Angle) > 256)
 			{
 				ActorFacingModifier = new WAngle(512);
 				firstFacing += ActorFacingModifier;

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -71,10 +71,12 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Can move backward if possible")]
 		public readonly bool CanMoveBackward = false;
 
-		[Desc("After how many ticks the actor will turn forward during backoff")]
+		[Desc("After how many ticks the actor will turn forward during backoff.",
+			"If set to -1 the unit will be allowed to move backwards without time limit.")]
 		public readonly int BackwardDuration = 40;
 
-		[Desc("Actor will try to move backward if the number of the cells in path lower than this")]
+		[Desc("Actor will only try to move backwards when the path (in cells) is shorter than this value.",
+			"If set to -1 the unit will be allowed to move backwards without range limit.")]
 		public readonly int MaxBackwardCells = 15;
 
 		[ConsumedConditionReference]

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -74,6 +74,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("After how many ticks the actor will turn forward during backoff")]
 		public readonly int BackwardDuration = 40;
 
+		[Desc("Actor will try to move backward if the number of the cells in path lower than this")]
+		public readonly int MaxBackwardCells = 15;
+
 		[ConsumedConditionReference]
 		[Desc("Boolean expression defining the condition under which the regular (non-force) move cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;


### PR DESCRIPTION
As https://github.com/OpenRA/OpenRA/pull/20441 is merged, some of my PRs can move forward.

Introducing MaxBackwardCells helps actor backward moving only when necessary, which is more realistic and practical. We can use it on harvester like CNC3 harvester.