### PR TITLE
Don't change cursor when mousing over label widgets

### DIFF
--- a/OpenRA.Mods.Common/Widgets/LabelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LabelWidget.cs
@@ -112,5 +112,7 @@ namespace OpenRA.Mods.Common.Widgets
 		}
 
 		public override Widget Clone() { return new LabelWidget(this); }
+
+		public override string GetCursor(int2 pos) { return null; }
 	}
 }


### PR DESCRIPTION
Labels don't handle input so the cursor should not change over them.

Fixes #20800 