### PR TITLE
Enable more Code Quality Rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -634,6 +634,9 @@ dotnet_diagnostic.CA1050.severity = warning
 # Do not hide base class methods.
 dotnet_diagnostic.CA1061.severity = warning
 
+# Exceptions should be public.
+dotnet_diagnostic.CA1064.severity = warning
+
 # Override 'Equals' when implementing 'IEquatable'.
 dotnet_diagnostic.CA1067.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -825,6 +825,9 @@ dotnet_diagnostic.CA2208.severity = warning
 # Dispose methods should call base class dispose.
 dotnet_diagnostic.CA2215.severity = warning
 
+# Disposable types should declare finalizer.
+dotnet_diagnostic.CA2216.severity = warning
+
 # Override GetHashCode on overriding Equals.
 dotnet_diagnostic.CA2218.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -741,6 +741,9 @@ dotnet_diagnostic.CA1839.severity = warning
 # Use Environment.CurrentManagedThreadId instead of Thread.CurrentThread.ManagedThreadId.
 dotnet_diagnostic.CA1840.severity = warning
 
+# Prefer Dictionary Contains methods.
+dotnet_diagnostic.CA1841.severity = warning
+
 # Do not use 'WhenAll' with a single task.
 dotnet_diagnostic.CA1842.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -765,6 +765,9 @@ dotnet_diagnostic.CA1847.severity = warning
 # Call async methods when in an async method.
 dotnet_diagnostic.CA1849.severity = warning
 
+# Prefer static HashData method over ComputeHash. (Not available on mono)
+dotnet_diagnostic.CA1850.severity = none
+
 # Unnecessary call to 'Dictionary.ContainsKey(key)'.
 dotnet_diagnostic.CA1853.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -756,6 +756,9 @@ dotnet_diagnostic.CA1844.severity = warning
 # Use span-based 'string.Concat'.
 dotnet_diagnostic.CA1845.severity = warning
 
+# Prefer AsSpan over Substring.
+dotnet_diagnostic.CA1846.severity = warning
+
 # Use string.Contains(char) instead of string.Contains(string) with single characters.
 dotnet_diagnostic.CA1847.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -612,6 +612,10 @@ dotnet_code_quality.api_surface = all
 ### Design Rules
 ### https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/design-warnings
 
+# Collections should implement generic interface.
+#dotnet_code_quality.CA1010.additional_required_generic_interfaces =
+dotnet_diagnostic.CA1010.severity = warning
+
 # Provide ObsoleteAttribute message.
 dotnet_diagnostic.CA1041.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -616,6 +616,9 @@ dotnet_code_quality.api_surface = all
 #dotnet_code_quality.CA1010.additional_required_generic_interfaces =
 dotnet_diagnostic.CA1010.severity = warning
 
+# Mark attributes with 'AttributeUsageAttribute'.
+dotnet_diagnostic.CA1018.severity = warning
+
 # Provide ObsoleteAttribute message.
 dotnet_diagnostic.CA1041.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -637,6 +637,9 @@ dotnet_diagnostic.CA1061.severity = warning
 # Exceptions should be public.
 dotnet_diagnostic.CA1064.severity = warning
 
+# Implement 'IEquatable' when overriding 'Equals'.
+dotnet_diagnostic.CA1066.severity = warning
+
 # Override 'Equals' when implementing 'IEquatable'.
 dotnet_diagnostic.CA1067.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -735,6 +735,9 @@ dotnet_diagnostic.CA1837.severity = warning
 # Avoid StringBuilder parameters for P/Invokes.
 dotnet_diagnostic.CA1838.severity = warning
 
+# Use Environment.ProcessPath instead of Process.GetCurrentProcess().MainModule.FileName.
+dotnet_diagnostic.CA1839.severity = warning
+
 # Use Environment.CurrentManagedThreadId instead of Thread.CurrentThread.ManagedThreadId.
 dotnet_diagnostic.CA1840.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -819,6 +819,9 @@ dotnet_diagnostic.CA2200.severity = warning
 # Initialize value type static fields inline.
 dotnet_diagnostic.CA2207.severity = warning
 
+# Instantiate argument exceptions correctly.
+dotnet_diagnostic.CA2208.severity = warning
+
 # Dispose methods should call base class dispose.
 dotnet_diagnostic.CA2215.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -819,6 +819,9 @@ dotnet_diagnostic.CA2200.severity = warning
 # Initialize value type static fields inline.
 dotnet_diagnostic.CA2207.severity = warning
 
+# Dispose methods should call base class dispose.
+dotnet_diagnostic.CA2215.severity = warning
+
 # Override GetHashCode on overriding Equals.
 dotnet_diagnostic.CA2218.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -720,6 +720,9 @@ dotnet_diagnostic.CA1832.severity = warning
 # Use AsSpan or AsMemory instead of Range-based indexers for getting Span or Memory portion of an array.
 dotnet_diagnostic.CA1833.severity = warning
 
+# Use StringBuilder.Append(char) for single character strings.
+dotnet_diagnostic.CA1834.severity = warning
+
 # Prefer the memory-based overloads of ReadAsync/WriteAsync methods in stream-based classes.
 dotnet_diagnostic.CA1835.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -619,6 +619,9 @@ dotnet_diagnostic.CA1010.severity = warning
 # Mark attributes with 'AttributeUsageAttribute'.
 dotnet_diagnostic.CA1018.severity = warning
 
+# Override methods on comparable types.
+dotnet_diagnostic.CA1036.severity = warning
+
 # Provide ObsoleteAttribute message.
 dotnet_diagnostic.CA1041.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -762,6 +762,9 @@ dotnet_diagnostic.CA1846.severity = warning
 # Use string.Contains(char) instead of string.Contains(string) with single characters.
 dotnet_diagnostic.CA1847.severity = warning
 
+# Call async methods when in an async method.
+dotnet_diagnostic.CA1849.severity = warning
+
 # Unnecessary call to 'Dictionary.ContainsKey(key)'.
 dotnet_diagnostic.CA1853.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -801,6 +801,9 @@ dotnet_diagnostic.CA2016.severity = warning
 # The 'count' argument to Buffer.BlockCopy should specify the number of bytes to copy.
 dotnet_diagnostic.CA2018.severity = warning
 
+# ThreadStatic fields should not use inline initialization.
+dotnet_diagnostic.CA2019.severity = warning
+
 ### Security Rules
 ### https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/security-warnings
 

--- a/OpenRA.Game/Map/ActorReference.cs
+++ b/OpenRA.Game/Map/ActorReference.cs
@@ -22,7 +22,7 @@ namespace OpenRA
 {
 	public interface ISuppressInitExport { }
 
-	public class ActorReference : IEnumerable
+	public class ActorReference : IEnumerable<object>
 	{
 		public string Type;
 		readonly Lazy<TypeDictionary> initDict;
@@ -104,7 +104,9 @@ namespace OpenRA
 			return ret;
 		}
 
-		public IEnumerator GetEnumerator() { return initDict.Value.GetEnumerator(); }
+		public IEnumerator<object> GetEnumerator() { return initDict.Value.GetEnumerator(); }
+
+		IEnumerator IEnumerable.GetEnumerator() { return GetEnumerator(); }
 
 		public ActorReference Clone()
 		{

--- a/OpenRA.Game/Primitives/ActionQueue.cs
+++ b/OpenRA.Game/Primitives/ActionQueue.cs
@@ -56,17 +56,27 @@ namespace OpenRA.Primitives
 		int Index(DelayedAction action)
 		{
 			// Returns the index of the next action with a strictly greater time.
-			var index = actions.BinarySearch(action);
+			var index = actions.BinarySearch(action, DelayedAction.TimeComparer);
 			if (index < 0)
 				return ~index;
-			while (index < actions.Count && action.CompareTo(actions[index]) >= 0)
+			while (index < actions.Count && DelayedAction.TimeComparer.Compare(action, actions[index]) >= 0)
 				index++;
 			return index;
 		}
 	}
 
-	readonly struct DelayedAction : IComparable<DelayedAction>
+	readonly struct DelayedAction
 	{
+		sealed class DelayedActionTimeComparer : IComparer<DelayedAction>
+		{
+			public int Compare(DelayedAction x, DelayedAction y)
+			{
+				return x.Time.CompareTo(y.Time);
+			}
+		}
+
+		public static IComparer<DelayedAction> TimeComparer = new DelayedActionTimeComparer();
+
 		public readonly long Time;
 		public readonly Action Action;
 
@@ -74,11 +84,6 @@ namespace OpenRA.Primitives
 		{
 			Action = action;
 			Time = time;
-		}
-
-		public int CompareTo(DelayedAction other)
-		{
-			return Time.CompareTo(other.Time);
 		}
 
 		public override string ToString()

--- a/OpenRA.Game/Primitives/Color.cs
+++ b/OpenRA.Game/Primitives/Color.cs
@@ -168,13 +168,13 @@ namespace OpenRA.Primitives
 				return false;
 
 			byte alpha = 255;
-			if (!byte.TryParse(value[0..2], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var red)
-			    || !byte.TryParse(value[2..4], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var green)
-			    || !byte.TryParse(value[4..6], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var blue))
+			if (!byte.TryParse(value.AsSpan(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var red)
+			    || !byte.TryParse(value.AsSpan(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var green)
+			    || !byte.TryParse(value.AsSpan(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var blue))
 				return false;
 
 			if (value.Length == 8
-			    && !byte.TryParse(value[6..8], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out alpha))
+			    && !byte.TryParse(value.AsSpan(6, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out alpha))
 				return false;
 
 			color = FromArgb(alpha, red, green, blue);

--- a/OpenRA.Game/Primitives/TypeDictionary.cs
+++ b/OpenRA.Game/Primitives/TypeDictionary.cs
@@ -16,7 +16,7 @@ using System.Linq;
 
 namespace OpenRA.Primitives
 {
-	public class TypeDictionary : IEnumerable
+	public class TypeDictionary : IEnumerable<object>
 	{
 		static readonly Func<Type, List<object>> CreateList = type => new List<object>();
 		readonly Dictionary<Type, List<object>> data = new();
@@ -105,9 +105,14 @@ namespace OpenRA.Primitives
 				objs.TrimExcess();
 		}
 
-		public IEnumerator GetEnumerator()
+		public IEnumerator<object> GetEnumerator()
 		{
 			return WithInterface<object>().GetEnumerator();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return GetEnumerator();
 		}
 	}
 

--- a/OpenRA.Game/Scripting/ScriptContext.cs
+++ b/OpenRA.Game/Scripting/ScriptContext.cs
@@ -33,6 +33,7 @@ namespace OpenRA.Scripting
 	}
 
 	// For traitinfos that provide actor / player commands
+	[AttributeUsage(AttributeTargets.Class)]
 	public sealed class ScriptPropertyGroupAttribute : Attribute
 	{
 		public readonly string Category;
@@ -40,8 +41,10 @@ namespace OpenRA.Scripting
 	}
 
 	// For property groups that are safe to initialize invoke on destroyed actors
+	[AttributeUsage(AttributeTargets.Class)]
 	public sealed class ExposedForDestroyedActors : Attribute { }
 
+	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Method)]
 	public sealed class ScriptActorPropertyActivityAttribute : Attribute { }
 
 	public abstract class ScriptActorProperties
@@ -115,6 +118,7 @@ namespace OpenRA.Scripting
 		}
 	}
 
+	[AttributeUsage(AttributeTargets.Class)]
 	public sealed class ScriptGlobalAttribute : Attribute
 	{
 		public readonly string Name;

--- a/OpenRA.Game/Support/HttpQueryBuilder.cs
+++ b/OpenRA.Game/Support/HttpQueryBuilder.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Support
 		{
 			var builder = new StringBuilder(url);
 
-			builder.Append("?");
+			builder.Append('?');
 
 			foreach (var parameter in parameters)
 				builder.Append($"{parameter.Key}={parameter.Value}&");

--- a/OpenRA.Game/Support/HttpQueryBuilder.cs
+++ b/OpenRA.Game/Support/HttpQueryBuilder.cs
@@ -16,10 +16,10 @@ using System.Text;
 
 namespace OpenRA.Support
 {
-	public class HttpQueryBuilder : IEnumerable
+	public class HttpQueryBuilder : IEnumerable<KeyValuePair<string, string>>
 	{
 		readonly string url;
-		readonly List<Parameter> parameters = new();
+		readonly List<KeyValuePair<string, string>> parameters = new();
 
 		public HttpQueryBuilder(string url)
 		{
@@ -28,11 +28,9 @@ namespace OpenRA.Support
 
 		public void Add(string name, object value)
 		{
-			parameters.Add(new Parameter
-			{
-				Name = name,
-				Value = Uri.EscapeDataString(value.ToString())
-			});
+			parameters.Add(KeyValuePair.Create(
+				name,
+				Uri.EscapeDataString(value.ToString())));
 		}
 
 		public override string ToString()
@@ -42,20 +40,19 @@ namespace OpenRA.Support
 			builder.Append("?");
 
 			foreach (var parameter in parameters)
-				builder.Append($"{parameter.Name}={parameter.Value}&");
+				builder.Append($"{parameter.Key}={parameter.Value}&");
 
 			return builder.ToString();
 		}
 
-		class Parameter
+		public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
 		{
-			public string Name { get; set; }
-			public string Value { get; set; }
+			return parameters.GetEnumerator();
 		}
 
-		public IEnumerator GetEnumerator()
+		IEnumerator IEnumerable.GetEnumerator()
 		{
-			throw new NotImplementedException();
+			return GetEnumerator();
 		}
 	}
 }

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -16,7 +16,7 @@ using System.Linq;
 namespace OpenRA.Traits
 {
 	public enum TargetType : byte { Invalid, Actor, Terrain, FrozenActor }
-	public readonly struct Target
+	public readonly struct Target : IEquatable<Target>
 	{
 		public static readonly Target[] None = Array.Empty<Target>();
 		public static readonly Target Invalid = default;

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -23,6 +23,7 @@ using OpenRA.Support;
 
 namespace OpenRA.Traits
 {
+	[AttributeUsage(AttributeTargets.Interface)]
 	public sealed class RequireExplicitImplementationAttribute : Attribute { }
 
 	[Flags]

--- a/OpenRA.Mods.Common/AudioLoaders/OggLoader.cs
+++ b/OpenRA.Mods.Common/AudioLoaders/OggLoader.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.AudioLoaders
 
 			// This buffer can be static because it can only be used by 1 instance per thread.
 			[ThreadStatic]
-			static float[] conversionBuffer = null;
+			static float[] conversionBuffer;
 
 			public OggStream(OggFormat format)
 			{

--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -255,6 +255,6 @@ namespace OpenRA.Mods.Common.Commands
 		}
 
 		[Serializable]
-		class DevException : Exception { }
+		public class DevException : Exception { }
 	}
 }

--- a/OpenRA.Mods.Common/FileFormats/InstallShieldCABCompression.cs
+++ b/OpenRA.Mods.Common/FileFormats/InstallShieldCABCompression.cs
@@ -22,6 +22,7 @@ namespace OpenRA.Mods.Common.FileFormats
 	{
 		const uint MaxFileGroupCount = 71;
 
+		[Flags]
 		enum CABFlags : ushort
 		{
 			FileSplit = 0x1,

--- a/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Lint
 						if (string.IsNullOrEmpty(voice))
 							continue;
 
-						if (!soundInfo.Voices.Keys.Contains(voice))
+						if (!soundInfo.Voices.ContainsKey(voice))
 							emitError($"Actor {actorInfo.Name} using voice set {voiceSet} does not define {voice} voice required by {traitInfo}.");
 					}
 				}

--- a/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
@@ -263,11 +263,10 @@ namespace OpenRA.Mods.Common.Widgets
 				case TextAlign.Left:
 					return new int2(rb.X + LeftMargin, y);
 				case TextAlign.Center:
+				default:
 					return new int2(rb.X + (UsableWidth - textSize.X) / 2, y);
 				case TextAlign.Right:
 					return new int2(rb.X + UsableWidth - textSize.X - RightMargin, y);
-				default:
-					throw new ArgumentOutOfRangeException("Align");
 			}
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameSaveLoadingLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameSaveLoadingLogic.cs
@@ -44,6 +44,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		protected override void Dispose(bool disposing)
 		{
 			Game.HideCursor = false;
+			base.Dispose(disposing);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
@@ -239,7 +239,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 										using (var zz = package.GetStream(kv.Value))
 										using (var f = File.Create(targetPath))
-											zz.CopyTo(f);
+											await zz.CopyToAsync(f);
 									}
 
 									package.Dispose();

--- a/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
@@ -19,8 +19,9 @@ namespace OpenRA.Platforms.Default
 	sealed class Sdl2GraphicsContext : ThreadAffine, IGraphicsContext
 	{
 		readonly Sdl2PlatformWindow window;
-		bool disposed;
 		IntPtr context;
+
+		public string GLVersion => OpenGL.Version;
 
 		public Sdl2GraphicsContext(Sdl2PlatformWindow window)
 		{
@@ -269,10 +270,12 @@ namespace OpenRA.Platforms.Default
 
 		public void Dispose()
 		{
-			if (disposed)
-				return;
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
 
-			disposed = true;
+		void Dispose(bool _)
+		{
 			if (context != IntPtr.Zero)
 			{
 				SDL.SDL_GL_DeleteContext(context);
@@ -280,6 +283,9 @@ namespace OpenRA.Platforms.Default
 			}
 		}
 
-		public string GLVersion => OpenGL.Version;
+		~Sdl2GraphicsContext()
+		{
+			Dispose(false);
+		}
 	}
 }

--- a/OpenRA.Platforms.Default/Sdl2HardwareCursor.cs
+++ b/OpenRA.Platforms.Default/Sdl2HardwareCursor.cs
@@ -46,6 +46,12 @@ namespace OpenRA.Platforms.Default
 
 		public void Dispose()
 		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		void Dispose(bool _)
+		{
 			if (Cursor != IntPtr.Zero)
 			{
 				SDL.SDL_FreeCursor(Cursor);
@@ -57,6 +63,11 @@ namespace OpenRA.Platforms.Default
 				SDL.SDL_FreeSurface(surface);
 				surface = IntPtr.Zero;
 			}
+		}
+
+		~Sdl2HardwareCursor()
+		{
+			Dispose(false);
 		}
 	}
 }

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -209,7 +209,7 @@ namespace OpenRA.Platforms.Default
 							var lines = p.StandardOutput.ReadToEnd().Split('\n');
 
 							foreach (var line in lines)
-								if (line.StartsWith("Xft.dpi") && int.TryParse(line[8..], out var dpi))
+								if (line.StartsWith("Xft.dpi") && int.TryParse(line.AsSpan(8), out var dpi))
 									windowScale = dpi / 96f;
 						}
 						catch { }

--- a/OpenRA.WindowsLauncher/Program.cs
+++ b/OpenRA.WindowsLauncher/Program.cs
@@ -86,7 +86,7 @@ namespace OpenRA.WindowsLauncher
 
 		static int RunInnerLauncher(string[] args)
 		{
-			var launcherPath = Process.GetCurrentProcess().MainModule.FileName;
+			var launcherPath = Environment.ProcessPath;
 			var launcherArgs = args.ToList();
 
 			if (!launcherArgs.Any(x => x.StartsWith("Engine.LaunchPath=", StringComparison.Ordinal)))


### PR DESCRIPTION
Enforces 15 code quality rules across the project.

I have batched together a PR for these rules as they each had limited existing violations (3 files or less) to resolve. However fixes are arranged per commit so we can easily bikeshed over rules as desired.

See https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ for explanation of each rule.
