### PR TITLE
New localisation architecture

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -581,7 +581,7 @@ namespace OpenRA
 				Log.Write("debug", "Taking screenshot " + path);
 
 				Renderer.SaveScreenshot(path);
-				TextNotificationsManager.Debug(ModData.Translation.GetString(SavedScreenshot, Translation.Arguments("filename", filename)));
+				TextNotificationsManager.Debug(TranslationProvider.GetString(SavedScreenshot, Translation.Arguments("filename", filename)));
 			}
 		}
 

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -256,8 +256,6 @@ namespace OpenRA
 		CellLayer<byte> projectedHeight;
 		Rectangle projectionSafeBounds;
 
-		internal Translation Translation;
-
 		public static string ComputeUID(IReadOnlyPackage package)
 		{
 			return ComputeUID(package, GetMapFormat(package));
@@ -450,8 +448,6 @@ namespace OpenRA
 			}
 
 			Sequences = new SequenceSet(this, modData, Tileset, SequenceDefinitions);
-			Translation = TranslationDefinitions == null ? null
-				: new Translation(Game.Settings.Player.Language, FieldLoader.GetValue<string[]>("value", TranslationDefinitions.Value), this);
 
 			var tl = new MPos(0, 0).ToCPos(this);
 			var br = new MPos(MapSize.X - 1, MapSize.Y - 1).ToCPos(this);
@@ -1409,14 +1405,6 @@ namespace OpenRA
 				return modData.DefaultFileSystem.IsExternalModFile(filename);
 
 			return false;
-		}
-
-		public string Translate(string key, IDictionary<string, object> args = null)
-		{
-			if (Translation != null && Translation.TryGetString(key, out var message, args))
-				return message;
-
-			return modData.Translation.GetString(key, args);
 		}
 
 		public void Dispose()

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -167,11 +167,11 @@ namespace OpenRA
 			new MapField("Bounds"),
 			new MapField("Visibility"),
 			new MapField("Categories"),
-			new MapField("Translations", required: false, ignoreIfValue: ""),
 			new MapField("LockPreview", required: false, ignoreIfValue: "False"),
 			new MapField("Players", "PlayerDefinitions"),
 			new MapField("Actors", "ActorDefinitions"),
 			new MapField("Rules", "RuleDefinitions", required: false),
+			new MapField("Translations", "TranslationDefinitions", required: false),
 			new MapField("Sequences", "SequenceDefinitions", required: false),
 			new MapField("ModelSequences", "ModelSequenceDefinitions", required: false),
 			new MapField("Weapons", "WeaponDefinitions", required: false),
@@ -193,7 +193,6 @@ namespace OpenRA
 		public Rectangle Bounds;
 		public MapVisibility Visibility = MapVisibility.Lobby;
 		public string[] Categories = { "Conquest" };
-		public string[] Translations;
 
 		public int2 MapSize { get; private set; }
 
@@ -203,6 +202,7 @@ namespace OpenRA
 
 		// Custom map yaml. Public for access by the map importers and lint checks
 		public readonly MiniYaml RuleDefinitions;
+		public readonly MiniYaml TranslationDefinitions;
 		public readonly MiniYaml SequenceDefinitions;
 		public readonly MiniYaml ModelSequenceDefinitions;
 		public readonly MiniYaml WeaponDefinitions;
@@ -450,7 +450,8 @@ namespace OpenRA
 			}
 
 			Sequences = new SequenceSet(this, modData, Tileset, SequenceDefinitions);
-			Translation = new Translation(Game.Settings.Player.Language, Translations, this);
+			Translation = TranslationDefinitions == null ? null
+				: new Translation(Game.Settings.Player.Language, FieldLoader.GetValue<string[]>("value", TranslationDefinitions.Value), this);
 
 			var tl = new MPos(0, 0).ToCPos(this);
 			var br = new MPos(MapSize.X - 1, MapSize.Y - 1).ToCPos(this);
@@ -1412,7 +1413,7 @@ namespace OpenRA
 
 		public string Translate(string key, IDictionary<string, object> args = null)
 		{
-			if (Translation.TryGetString(key, out var message, args))
+			if (Translation != null && Translation.TryGetString(key, out var message, args))
 				return message;
 
 			return modData.Translation.GetString(key, args);

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -199,6 +199,15 @@ namespace OpenRA
 		public long DownloadBytes { get; private set; }
 		public int DownloadPercentage { get; private set; }
 
+		public string GetLocalisedString(string key, IDictionary<string, object> args = null)
+		{
+			// PERF: instead of loading mod level Translation for each MapPreview, reuse the already loaded one in modData.
+			if (modData.Translation.TryGetString(key, out var message, args))
+				return message;
+
+			return innerData.Translation?.GetString(key, args) ?? key;
+		}
+
 		Sprite minimap;
 		bool generatingMinimap;
 		public Sprite GetMinimap()

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -90,6 +90,7 @@ namespace OpenRA
 			public MiniYaml SequenceDefinitions;
 			public MiniYaml ModelSequenceDefinitions;
 
+			public Translation Translation { get; private set; }
 			public ActorInfo WorldActorInfo { get; private set; }
 			public ActorInfo PlayerActorInfo { get; private set; }
 
@@ -119,6 +120,10 @@ namespace OpenRA
 				NotificationDefinitions = LoadRuleSection(yaml, "Notifications");
 				SequenceDefinitions = LoadRuleSection(yaml, "Sequences");
 				ModelSequenceDefinitions = LoadRuleSection(yaml, "ModelSequences");
+
+				Translation = yaml.TryGetValue("Translations", out var node) && node != null
+					? new Translation(Game.Settings.Player.Language, FieldLoader.GetValue<string[]>("value", node.Value), fileSystem)
+					: null;
 
 				try
 				{
@@ -293,6 +298,7 @@ namespace OpenRA
 			innerData.SetCustomRules(modData, this, new Dictionary<string, MiniYaml>()
 			{
 				{ "Rules", map.RuleDefinitions },
+				{ "Translations", map.TranslationDefinitions },
 				{ "Weapons", map.WeaponDefinitions },
 				{ "Voices", map.VoiceDefinitions },
 				{ "Music", map.MusicDefinitions },

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -199,10 +199,14 @@ namespace OpenRA
 		public long DownloadBytes { get; private set; }
 		public int DownloadPercentage { get; private set; }
 
+		/// <summary>
+		/// Functionality mirrors <see cref="TranslationProvider.GetString"/>, except instead of using
+		/// loaded <see cref="Map"/>'s translations as backup, we use this <see cref="MapPreview"/>'s.
+		/// </summary>
 		public string GetLocalisedString(string key, IDictionary<string, object> args = null)
 		{
-			// PERF: instead of loading mod level Translation for each MapPreview, reuse the already loaded one in modData.
-			if (modData.Translation.TryGetString(key, out var message, args))
+			// PERF: instead of loading mod level Translation per each MapPreview, reuse the already loaded one in TranslationProvider.
+			if (TranslationProvider.TryGetModString(key, out var message, args))
 				return message;
 
 			return innerData.Translation?.GetString(key, args) ?? key;

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -36,7 +36,6 @@ namespace OpenRA
 		public readonly IModelSequenceLoader ModelSequenceLoader;
 		public readonly IVideoLoader[] VideoLoaders;
 		public readonly HotkeyManager Hotkeys;
-		public readonly Translation Translation;
 		public ILoadScreen LoadScreen { get; }
 		public CursorProvider CursorProvider { get; private set; }
 		public FS ModFiles;
@@ -102,8 +101,6 @@ namespace OpenRA
 
 			Hotkeys = new HotkeyManager(ModFiles, Game.Settings.Keys, Manifest);
 
-			Translation = new Translation(Game.Settings.Player.Language, Manifest.Translations, DefaultFileSystem);
-
 			defaultRules = Exts.Lazy(() => Ruleset.LoadDefaults(this));
 			defaultTerrainInfo = Exts.Lazy(() =>
 			{
@@ -137,6 +134,7 @@ namespace OpenRA
 			// horribly when you use ModData in unexpected ways.
 			ChromeMetrics.Initialize(this);
 			ChromeProvider.Initialize(this);
+			TranslationProvider.Initialize(this, fileSystem);
 
 			Game.Sound.Initialize(SoundLoaders, fileSystem);
 

--- a/OpenRA.Game/Network/LocalizedMessage.cs
+++ b/OpenRA.Game/Network/LocalizedMessage.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Network
 			return arguments.ToArray();
 		}
 
-		public LocalizedMessage(ModData modData, MiniYaml yaml)
+		public LocalizedMessage(MiniYaml yaml)
 		{
 			// Let the FieldLoader do the dirty work of loading the public fields.
 			FieldLoader.Load(this, yaml);
@@ -95,7 +95,7 @@ namespace OpenRA.Network
 					argumentDictionary.Add(argument.Key, argument.Value);
 			}
 
-			TranslatedText = modData.Translation.GetString(Key, argumentDictionary);
+			TranslatedText = TranslationProvider.GetString(Key, argumentDictionary);
 		}
 
 		public static string Serialize(string key, Dictionary<string, object> arguments = null)

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Network
 						var yaml = MiniYaml.FromString(order.TargetString);
 						foreach (var node in yaml)
 						{
-							var localizedMessage = new LocalizedMessage(Game.ModData, node.Value);
+							var localizedMessage = new LocalizedMessage(node.Value);
 							TextNotificationsManager.AddSystemLine(localizedMessage.TranslatedText);
 						}
 

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -958,7 +958,7 @@ namespace OpenRA.Server
 			DispatchServerOrdersToClients(Order.FromTargetString("LocalizedMessage", text, true));
 
 			if (Type == ServerType.Dedicated)
-				WriteLineWithTimeStamp(ModData.Translation.GetString(key, arguments));
+				WriteLineWithTimeStamp(TranslationProvider.GetString(key, arguments));
 		}
 
 		public void SendLocalizedMessageTo(Connection conn, string key, Dictionary<string, object> arguments = null)
@@ -1312,7 +1312,7 @@ namespace OpenRA.Server
 		{
 			lock (LobbyInfo)
 			{
-				WriteLineWithTimeStamp(ModData.Translation.GetString(GameStarted));
+				WriteLineWithTimeStamp(TranslationProvider.GetString(GameStarted));
 
 				// Drop any players who are not ready
 				foreach (var c in Conns.Where(c => !c.Validated || GetClient(c).IsInvalid).ToArray())

--- a/OpenRA.Game/Traits/Player/Shroud.cs
+++ b/OpenRA.Game/Traits/Player/Shroud.cs
@@ -60,11 +60,9 @@ namespace OpenRA.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
-			yield return new LobbyBooleanOption("explored", Game.ModData.Translation.GetString(ExploredMapCheckboxLabel),
-				Game.ModData.Translation.GetString(ExploredMapCheckboxDescription),
+			yield return new LobbyBooleanOption(map, "explored", ExploredMapCheckboxLabel, ExploredMapCheckboxDescription,
 				ExploredMapCheckboxVisible, ExploredMapCheckboxDisplayOrder, ExploredMapCheckboxEnabled, ExploredMapCheckboxLocked);
-			yield return new LobbyBooleanOption("fog", Game.ModData.Translation.GetString(FogCheckboxLabel),
-				Game.ModData.Translation.GetString(FogCheckboxDescription),
+			yield return new LobbyBooleanOption(map, "fog", FogCheckboxLabel, FogCheckboxDescription,
 				FogCheckboxVisible, FogCheckboxDisplayOrder, FogCheckboxEnabled, FogCheckboxLocked);
 		}
 

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -543,12 +543,12 @@ namespace OpenRA.Traits
 		public readonly bool IsVisible;
 		public readonly int DisplayOrder;
 
-		public LobbyOption(string id, string name, string description, bool visible, int displayorder,
+		public LobbyOption(MapPreview map, string id, string name, string description, bool visible, int displayorder,
 			IReadOnlyDictionary<string, string> values, string defaultValue, bool locked)
 		{
 			Id = id;
-			Name = Game.ModData.Translation.GetString(name);
-			Description = Game.ModData.Translation.GetString(description);
+			Name = map.GetLocalisedString(name);
+			Description = map.GetLocalisedString(description);
 			IsVisible = visible;
 			DisplayOrder = displayorder;
 			Values = values;
@@ -570,8 +570,8 @@ namespace OpenRA.Traits
 			{ false.ToString(), "Disabled" }
 		};
 
-		public LobbyBooleanOption(string id, string name, string description, bool visible, int displayorder, bool defaultValue, bool locked)
-			: base(id, name, description, visible, displayorder, new ReadOnlyDictionary<string, string>(BoolValues), defaultValue.ToString(), locked) { }
+		public LobbyBooleanOption(MapPreview map, string id, string name, string description, bool visible, int displayorder, bool defaultValue, bool locked)
+			: base(map, id, name, description, visible, displayorder, new ReadOnlyDictionary<string, string>(BoolValues), defaultValue.ToString(), locked) { }
 
 		public override string Label(string newValue)
 		{

--- a/OpenRA.Game/Translation.cs
+++ b/OpenRA.Game/Translation.cs
@@ -88,8 +88,8 @@ namespace OpenRA
 
 		public bool TryGetString(string key, out string value, IDictionary<string, object> arguments = null)
 		{
-			if (string.IsNullOrEmpty(key))
-				throw new ArgumentException("A translation key must not be null or empty.", nameof(key));
+			if (key == null)
+				throw new ArgumentNullException(nameof(key));
 
 			try
 			{

--- a/OpenRA.Game/Translation.cs
+++ b/OpenRA.Game/Translation.cs
@@ -110,10 +110,10 @@ namespace OpenRA
 
 				return result;
 			}
-			catch (Exception e)
+			catch (Exception)
 			{
-				Log.Write("debug", $"Translation of {key} failed:");
-				Log.Write("debug", e);
+				Log.Write("debug", $"Failed translation: {key}");
+
 				value = null;
 				return false;
 			}

--- a/OpenRA.Game/TranslationProvider.cs
+++ b/OpenRA.Game/TranslationProvider.cs
@@ -1,0 +1,76 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.FileSystem;
+
+namespace OpenRA
+{
+	public static class TranslationProvider
+	{
+		// Ensure thread-safety.
+		static readonly object SyncObject = new();
+		static Translation modTranslation;
+		static Translation mapTranslation;
+
+		public static void Initialize(ModData modData, IReadOnlyFileSystem fileSystem)
+		{
+			lock (SyncObject)
+			{
+				modTranslation = new Translation(Game.Settings.Player.Language, modData.Manifest.Translations, fileSystem);
+				mapTranslation = fileSystem is Map map && map.TranslationDefinitions != null
+					? new Translation(Game.Settings.Player.Language, FieldLoader.GetValue<string[]>("value", map.TranslationDefinitions.Value), fileSystem)
+					: null;
+			}
+		}
+
+		public static string GetString(string key, IDictionary<string, object> args = null)
+		{
+			lock (SyncObject)
+    		{
+				// By prioritizing mod-level translations we prevent maps from overwriting translation keys. We do not want to
+				// allow maps to change the UI nor any other strings not exposed to the map.
+				if (modTranslation.TryGetString(key, out var message, args))
+					return message;
+
+				if (mapTranslation != null)
+					return mapTranslation.GetString(key, args);
+
+				return key;
+			}
+		}
+
+		public static bool TryGetString(string key, out string message, IDictionary<string, object> args = null)
+		{
+			lock (SyncObject)
+    		{
+				// By prioritizing mod-level translations we prevent maps from overwriting translation keys. We do not want to
+				// allow maps to change the UI nor any other strings not exposed to the map.
+				if (modTranslation.TryGetString(key, out message, args))
+					return true;
+
+				if (mapTranslation != null && mapTranslation.TryGetString(key, out message, args))
+					return true;
+
+				return false;
+			}
+		}
+
+		/// <summary>Should only be used by <see cref="MapPreview"/>.</summary>
+		internal static bool TryGetModString(string key, out string message, IDictionary<string, object> args = null)
+		{
+			lock (SyncObject)
+			{
+				return modTranslation.TryGetString(key, out message, args);
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Cnc/Installer/ExtractMixSourceAction.cs
+++ b/OpenRA.Mods.Cnc/Installer/ExtractMixSourceAction.cs
@@ -49,9 +49,9 @@ namespace OpenRA.Mods.Cnc.Installer
 
 						Action<long> onProgress = null;
 						if (stream.Length < InstallFromSourceLogic.ShowPercentageThreshold)
-							updateMessage(modData.Translation.GetString(InstallFromSourceLogic.Extracing, Translation.Arguments("filename", displayFilename)));
+							updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.Extracing, Translation.Arguments("filename", displayFilename)));
 						else
-							onProgress = b => updateMessage(modData.Translation.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", 100 * b / stream.Length)));
+							onProgress = b => updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", 100 * b / stream.Length)));
 
 						using (var target = File.OpenWrite(targetPath))
 						{

--- a/OpenRA.Mods.Common/Commands/ChatCommands.cs
+++ b/OpenRA.Mods.Common/Commands/ChatCommands.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Commands
 				if (command.Value != null)
 					command.Value.InvokeCommand(name.ToLowerInvariant(), message[(1 + name.Length)..].Trim());
 				else
-					TextNotificationsManager.Debug(Game.ModData.Translation.GetString(InvalidCommand, Translation.Arguments("name", name)));
+					TextNotificationsManager.Debug(TranslationProvider.GetString(InvalidCommand, Translation.Arguments("name", name)));
 
 				return false;
 			}

--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.Common.Commands
 
 			if (!developerMode.Enabled)
 			{
-				TextNotificationsManager.Debug(Game.ModData.Translation.GetString(CheatsDisabled));
+				TextNotificationsManager.Debug(TranslationProvider.GetString(CheatsDisabled));
 				return;
 			}
 
@@ -149,7 +149,7 @@ namespace OpenRA.Mods.Common.Commands
 				giveCashOrder.ExtraData = (uint)cash;
 			else
 			{
-				TextNotificationsManager.Debug(Game.ModData.Translation.GetString(InvalidCashAmount));
+				TextNotificationsManager.Debug(TranslationProvider.GetString(InvalidCashAmount));
 				return;
 			}
 

--- a/OpenRA.Mods.Common/Commands/HelpCommand.cs
+++ b/OpenRA.Mods.Common/Commands/HelpCommand.cs
@@ -51,12 +51,12 @@ namespace OpenRA.Mods.Common.Commands
 
 		public void InvokeCommand(string name, string arg)
 		{
-			TextNotificationsManager.Debug(Game.ModData.Translation.GetString(AvailableCommands));
+			TextNotificationsManager.Debug(TranslationProvider.GetString(AvailableCommands));
 
 			foreach (var key in console.Commands.Keys)
 			{
 				if (!helpDescriptions.TryGetValue(key, out var description))
-					description = Game.ModData.Translation.GetString(NoDescription);
+					description = TranslationProvider.GetString(NoDescription);
 
 				TextNotificationsManager.Debug($"{key}: {description}");
 			}
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Commands
 
 		public void RegisterHelp(string name, string description)
 		{
-			helpDescriptions[name] = Game.ModData.Translation.GetString(description);
+			helpDescriptions[name] = TranslationProvider.GetString(description);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Installer/SourceActions/CopySourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/CopySourceAction.cs
@@ -44,9 +44,9 @@ namespace OpenRA.Mods.Common.Installer
 
 					Action<long> onProgress = null;
 					if (length < InstallFromSourceLogic.ShowPercentageThreshold)
-						updateMessage(modData.Translation.GetString(InstallFromSourceLogic.CopyingFilename, Translation.Arguments("filename", displayFilename)));
+						updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.CopyingFilename, Translation.Arguments("filename", displayFilename)));
 					else
-						onProgress = b => updateMessage(modData.Translation.GetString(InstallFromSourceLogic.CopyingFilenameProgress, Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
+						onProgress = b => updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.CopyingFilenameProgress, Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
 
 					InstallerUtils.CopyStream(source, target, length, onProgress);
 				}

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractBlastSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractBlastSourceAction.cs
@@ -67,9 +67,9 @@ namespace OpenRA.Mods.Common.Installer
 
 					Action<long> onProgress = null;
 					if (length < InstallFromSourceLogic.ShowPercentageThreshold)
-						updateMessage(modData.Translation.GetString(InstallFromSourceLogic.Extracing, Translation.Arguments("filename", displayFilename)));
+						updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.Extracing, Translation.Arguments("filename", displayFilename)));
 					else
-						onProgress = b => updateMessage(modData.Translation.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
+						onProgress = b => updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
 
 					using (var target = File.OpenWrite(targetPath))
 					{

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractIscabSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractIscabSourceAction.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Installer
 						{
 							Log.Write("install", $"Extracting {sourcePath} -> {targetPath}");
 							var displayFilename = Path.GetFileName(Path.GetFileName(targetPath));
-							void OnProgress(int percent) => updateMessage(modData.Translation.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", percent)));
+							void OnProgress(int percent) => updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", percent)));
 							reader.ExtractFile(node.Value.Value, target, OnProgress);
 						}
 					}

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractMscabSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractMscabSourceAction.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Installer
 					{
 						Log.Write("install", $"Extracting {sourcePath} -> {targetPath}");
 						var displayFilename = Path.GetFileName(Path.GetFileName(targetPath));
-						void OnProgress(int percent) => updateMessage(modData.Translation.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", percent)));
+						void OnProgress(int percent) => updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", percent)));
 						reader.ExtractFile(node.Value.Value, target, OnProgress);
 					}
 				}

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractRawSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractRawSourceAction.cs
@@ -60,9 +60,9 @@ namespace OpenRA.Mods.Common.Installer
 
 					Action<long> onProgress = null;
 					if (length < InstallFromSourceLogic.ShowPercentageThreshold)
-						updateMessage(modData.Translation.GetString(InstallFromSourceLogic.Extracing, Translation.Arguments("filename", displayFilename)));
+						updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.Extracing, Translation.Arguments("filename", displayFilename)));
 					else
-						onProgress = b => updateMessage(modData.Translation.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
+						onProgress = b => updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
 
 					using (var target = File.OpenWrite(targetPath))
 					{

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractZipSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractZipSourceAction.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Installer
 					using (var targetStream = File.OpenWrite(targetPath))
 						sourceStream.CopyTo(targetStream);
 
-					updateMessage(modData.Translation.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", 100)));
+					updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", 100)));
 
 					extracted.Add(targetPath);
 				}

--- a/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
@@ -62,8 +62,8 @@ namespace OpenRA.Mods.Common.Lint
 
 			// TODO: Check all available languages.
 			var language = "en";
-			var modTranslation = new Translation(language, modData.Manifest.Translations, modData.DefaultFileSystem);
-			var mapTranslation = new Translation(language, FieldLoader.GetValue<string[]>("value", map.TranslationDefinitions.Value), map);
+			var modTranslation = new Translation(language, modData.Manifest.Translations, modData.DefaultFileSystem, _ => { });
+			var mapTranslation = new Translation(language, FieldLoader.GetValue<string[]>("value", map.TranslationDefinitions.Value), map, error => emitError(error.ToString()));
 
 			TestTraits(map.Rules, key =>
 			{
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Lint
 			// TODO: Check all available languages.
 			var language = "en";
 			Console.WriteLine($"Testing translation: {language}");
-			var translation = new Translation(language, modData.Manifest.Translations, modData.DefaultFileSystem);
+			var translation = new Translation(language, modData.Manifest.Translations, modData.DefaultFileSystem, error => emitError(error.ToString()));
 
 			TestTraits(modData.DefaultRules, key =>
 			{

--- a/OpenRA.Mods.Common/Scripting/Global/UserInterfaceGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/UserInterfaceGlobal.cs
@@ -51,10 +51,10 @@ namespace OpenRA.Mods.Common.Scripting.Global
 					}
 				}
 
-				return Context.World.Map.Translate(text, argumentDictionary);
+				return TranslationProvider.GetString(text, argumentDictionary);
 			}
 
-			return Context.World.Map.Translate(text);
+			return TranslationProvider.GetString(text);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
-			yield return new LobbyBooleanOption("cheats", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
+			yield return new LobbyBooleanOption(map, "cheats", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
 		}
 
 		public override object Create(ActorInitializer init) { return new DeveloperMode(this); }

--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
@@ -279,7 +279,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			var arguments = Translation.Arguments("cheat", order.OrderString, "player", self.Owner.PlayerName, "suffix", debugSuffix);
-			TextNotificationsManager.Debug(Game.ModData.Translation.GetString(CheatUsed, arguments));
+			TextNotificationsManager.Debug(TranslationProvider.GetString(CheatUsed, arguments));
 		}
 
 		bool IUnlocksRenderPlayer.RenderPlayerUnlocked => Enabled;

--- a/OpenRA.Mods.Common/Traits/Player/LobbyPrerequisiteCheckbox.cs
+++ b/OpenRA.Mods.Common/Traits/Player/LobbyPrerequisiteCheckbox.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
-			yield return new LobbyBooleanOption(ID, Label, Description,
+			yield return new LobbyBooleanOption(map, ID, Label, Description,
 				Visible, DisplayOrder, Enabled, Locked);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 			var startingCash = SelectableCash.ToDictionary(c => c.ToString(), c => "$" + c.ToString());
 
 			if (startingCash.Count > 0)
-				yield return new LobbyOption("startingcash", DefaultCashDropdownLabel, DefaultCashDropdownDescription, DefaultCashDropdownVisible, DefaultCashDropdownDisplayOrder,
+				yield return new LobbyOption(map, "startingcash", DefaultCashDropdownLabel, DefaultCashDropdownDescription, DefaultCashDropdownVisible, DefaultCashDropdownDisplayOrder,
 					startingCash, DefaultCash.ToString(), DefaultCashDropdownLocked);
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
-			yield return new LobbyBooleanOption("crates", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
+			yield return new LobbyBooleanOption(map, "crates", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
 		}
 
 		public override object Create(ActorInitializer init) { return new CrateSpawner(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/World/MapBuildRadius.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapBuildRadius.cs
@@ -60,10 +60,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
-			yield return new LobbyBooleanOption("allybuild", AllyBuildRadiusCheckboxLabel, AllyBuildRadiusCheckboxDescription,
+			yield return new LobbyBooleanOption(map, "allybuild", AllyBuildRadiusCheckboxLabel, AllyBuildRadiusCheckboxDescription,
 				AllyBuildRadiusCheckboxVisible, AllyBuildRadiusCheckboxDisplayOrder, AllyBuildRadiusCheckboxEnabled, AllyBuildRadiusCheckboxLocked);
 
-			yield return new LobbyBooleanOption("buildradius", BuildRadiusCheckboxLabel, BuildRadiusCheckboxDescription,
+			yield return new LobbyBooleanOption(map, "buildradius", BuildRadiusCheckboxLabel, BuildRadiusCheckboxDescription,
 				BuildRadiusCheckboxVisible, BuildRadiusCheckboxDisplayOrder, BuildRadiusCheckboxEnabled, BuildRadiusCheckboxLocked);
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
-			yield return new LobbyBooleanOption("creeps", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
+			yield return new LobbyBooleanOption(map, "creeps", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
 		}
 
 		public override object Create(ActorInitializer init) { return new MapCreeps(this); }

--- a/OpenRA.Mods.Common/Traits/World/MapOptions.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapOptions.cs
@@ -81,22 +81,24 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
-			yield return new LobbyBooleanOption("shortgame", ShortGameCheckboxLabel, ShortGameCheckboxDescription,
+			yield return new LobbyBooleanOption(map, "shortgame", ShortGameCheckboxLabel, ShortGameCheckboxDescription,
 				ShortGameCheckboxVisible, ShortGameCheckboxDisplayOrder, ShortGameCheckboxEnabled, ShortGameCheckboxLocked);
 
 			var techLevels = map.PlayerActorInfo.TraitInfos<ProvidesTechPrerequisiteInfo>()
-				.ToDictionary(t => t.Id, t => Game.ModData.Translation.GetString(t.Name));
+				.ToDictionary(t => t.Id, t => map.GetLocalisedString(t.Name));
 
 			if (techLevels.Count > 0)
-				yield return new LobbyOption("techlevel", TechLevelDropdownLabel, TechLevelDropdownDescription, TechLevelDropdownVisible, TechLevelDropdownDisplayOrder,
+				yield return new LobbyOption(map, "techlevel", TechLevelDropdownLabel, TechLevelDropdownDescription, TechLevelDropdownVisible, TechLevelDropdownDisplayOrder,
 					techLevels, TechLevel, TechLevelDropdownLocked);
 
 			var gameSpeeds = Game.ModData.Manifest.Get<GameSpeeds>();
 			var speeds = gameSpeeds.Speeds.ToDictionary(s => s.Key, s => Game.ModData.Translation.GetString(s.Value.Name));
 
-			// NOTE: This is just exposing the UI, the backend logic for this option is hardcoded in World
-			yield return new LobbyOption("gamespeed", GameSpeedDropdownLabel, GameSpeedDropdownDescription, GameSpeedDropdownVisible, GameSpeedDropdownDisplayOrder,
-				speeds, GameSpeed ?? gameSpeeds.DefaultSpeed, GameSpeedDropdownLocked);
+			// NOTE: This is just exposing the UI, the backend logic for this option is hardcoded in World.
+			yield return new LobbyOption(map, "gamespeed",
+				GameSpeedDropdownLabel, GameSpeedDropdownDescription,
+				GameSpeedDropdownVisible, GameSpeedDropdownDisplayOrder, speeds,
+				GameSpeed ?? gameSpeeds.DefaultSpeed, GameSpeedDropdownLocked);
 		}
 
 		void IRulesetLoaded<ActorInfo>.RulesetLoaded(Ruleset rules, ActorInfo info)

--- a/OpenRA.Mods.Common/Traits/World/MapOptions.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapOptions.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.Common.Traits
 					techLevels, TechLevel, TechLevelDropdownLocked);
 
 			var gameSpeeds = Game.ModData.Manifest.Get<GameSpeeds>();
-			var speeds = gameSpeeds.Speeds.ToDictionary(s => s.Key, s => Game.ModData.Translation.GetString(s.Value.Name));
+			var speeds = gameSpeeds.Speeds.ToDictionary(s => s.Key, s => TranslationProvider.GetString(s.Value.Name));
 
 			// NOTE: This is just exposing the UI, the backend logic for this option is hardcoded in World.
 			yield return new LobbyOption(map, "gamespeed",

--- a/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
@@ -50,6 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
 			yield return new LobbyBooleanOption(
+				map,
 				"separateteamspawns",
 				SeparateTeamSpawnsCheckboxLabel,
 				SeparateTeamSpawnsCheckboxDescription,

--- a/OpenRA.Mods.Common/Traits/World/ScriptLobbyDropdown.cs
+++ b/OpenRA.Mods.Common/Traits/World/ScriptLobbyDropdown.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
-			yield return new LobbyOption(ID, Label, Description, Visible, DisplayOrder,
+			yield return new LobbyOption(map, ID, Label, Description, Visible, DisplayOrder,
 				Values, Default, Locked);
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
@@ -47,10 +47,10 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Duplicate classes are defined for different race variants
 			foreach (var t in map.WorldActorInfo.TraitInfos<StartingUnitsInfo>())
-				startingUnits[t.Class] = Game.ModData.Translation.GetString(t.ClassName);
+				startingUnits[t.Class] = map.GetLocalisedString(t.ClassName);
 
 			if (startingUnits.Count > 0)
-				yield return new LobbyOption("startingunits", DropdownLabel, DropdownDescription, DropdownVisible, DropdownDisplayOrder,
+				yield return new LobbyOption(map, "startingunits", DropdownLabel, DropdownDescription, DropdownVisible, DropdownDisplayOrder,
 					startingUnits, StartingUnitsClass, DropdownLocked);
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/TimeLimitManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/TimeLimitManager.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.Common.Traits
 					return Game.ModData.Translation.GetString(TimeLimitOption, Translation.Arguments("minutes", m));
 			});
 
-			yield return new LobbyOption("timelimit", TimeLimitLabel, TimeLimitDescription, TimeLimitDropdownVisible, TimeLimitDisplayOrder,
+			yield return new LobbyOption(map, "timelimit", TimeLimitLabel, TimeLimitDescription, TimeLimitDropdownVisible, TimeLimitDisplayOrder,
 				timelimits, TimeLimitDefault.ToString(), TimeLimitLocked);
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/TimeLimitManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/TimeLimitManager.cs
@@ -87,9 +87,9 @@ namespace OpenRA.Mods.Common.Traits
 			var timelimits = TimeLimitOptions.ToDictionary(m => m.ToString(), m =>
 			{
 				if (m == 0)
-					return Game.ModData.Translation.GetString(NoTimeLimit);
+					return TranslationProvider.GetString(NoTimeLimit);
 				else
-					return Game.ModData.Translation.GetString(TimeLimitOption, Translation.Arguments("minutes", m));
+					return TranslationProvider.GetString(TimeLimitOption, Translation.Arguments("minutes", m));
 			});
 
 			yield return new LobbyOption(map, "timelimit", TimeLimitLabel, TimeLimitDescription, TimeLimitDropdownVisible, TimeLimitDisplayOrder,
@@ -181,7 +181,7 @@ namespace OpenRA.Mods.Common.Traits
 				countdownLabel.GetText = () => null;
 
 			if (!info.SkipTimerExpiredNotification)
-				TextNotificationsManager.AddSystemLine(Game.ModData.Translation.GetString(TimeLimitExpired));
+				TextNotificationsManager.AddSystemLine(TranslationProvider.GetString(TimeLimitExpired));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/ConfirmationDialogs.cs
+++ b/OpenRA.Mods.Common/Widgets/ConfirmationDialogs.cs
@@ -36,11 +36,11 @@ namespace OpenRA.Mods.Common.Widgets
 			var cancelButton = prompt.GetOrNull<ButtonWidget>("CANCEL_BUTTON");
 			var otherButton = prompt.GetOrNull<ButtonWidget>("OTHER_BUTTON");
 
-			var titleMessage = modData.Translation.GetString(title, titleArguments);
+			var titleMessage = TranslationProvider.GetString(title, titleArguments);
 			prompt.Get<LabelWidget>("PROMPT_TITLE").GetText = () => titleMessage;
 
 			var headerTemplate = prompt.Get<LabelWidget>("PROMPT_TEXT");
-			var textMessage = modData.Translation.GetString(text, textArguments);
+			var textMessage = TranslationProvider.GetString(text, textArguments);
 			var headerLines = textMessage.Split('\n');
 			var headerHeight = 0;
 			foreach (var l in headerLines)
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 				if (!string.IsNullOrEmpty(confirmText))
 				{
-					var confirmTextMessage = modData.Translation.GetString(confirmText);
+					var confirmTextMessage = TranslationProvider.GetString(confirmText);
 					confirmButton.GetText = () => confirmTextMessage;
 				}
 			}
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 				if (!string.IsNullOrEmpty(cancelText))
 				{
-					var cancelTextMessage = modData.Translation.GetString(cancelText);
+					var cancelTextMessage = TranslationProvider.GetString(cancelText);
 					cancelButton.GetText = () => cancelTextMessage;
 				}
 			}
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 				if (!string.IsNullOrEmpty(otherText))
 				{
-					var otherTextMessage = modData.Translation.GetString(otherText);
+					var otherTextMessage = TranslationProvider.GetString(otherText);
 					otherButton.GetText = () => otherTextMessage;
 				}
 			}
@@ -114,10 +114,10 @@ namespace OpenRA.Mods.Common.Widgets
 			Func<bool> doValidate = null;
 			ButtonWidget acceptButton = null, cancelButton = null;
 
-			var titleMessage = modData.Translation.GetString(title);
+			var titleMessage = TranslationProvider.GetString(title);
 			panel.Get<LabelWidget>("PROMPT_TITLE").GetText = () => titleMessage;
 
-			var promptMessage = modData.Translation.GetString(prompt);
+			var promptMessage = TranslationProvider.GetString(prompt);
 			panel.Get<LabelWidget>("PROMPT_TEXT").GetText = () => promptMessage;
 
 			var input = panel.Get<TextFieldWidget>("INPUT_TEXT");
@@ -147,7 +147,7 @@ namespace OpenRA.Mods.Common.Widgets
 			acceptButton = panel.Get<ButtonWidget>("ACCEPT_BUTTON");
 			if (!string.IsNullOrEmpty(acceptText))
 			{
-				var acceptTextMessage = modData.Translation.GetString(acceptText);
+				var acceptTextMessage = TranslationProvider.GetString(acceptText);
 				acceptButton.GetText = () => acceptTextMessage;
 			}
 
@@ -163,7 +163,7 @@ namespace OpenRA.Mods.Common.Widgets
 			cancelButton = panel.Get<ButtonWidget>("CANCEL_BUTTON");
 			if (!string.IsNullOrEmpty(cancelText))
 			{
-				var cancelTextMessage = modData.Translation.GetString(cancelText);
+				var cancelTextMessage = TranslationProvider.GetString(cancelText);
 				cancelButton.GetText = () => cancelTextMessage;
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.modData = modData;
 			panel = widget;
 
-			allPackages = modData.Translation.GetString(AllPackages);
+			allPackages = TranslationProvider.GetString(AllPackages);
 
 			var colorPickerPalettes = world.WorldActor.TraitsImplementing<IProvidesAssetBrowserColorPickerPalettes>()
 				.SelectMany(p => p.ColorPickerPaletteNames)
@@ -238,7 +238,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (frameText != null)
 			{
 				var soundLength = new CachedTransform<double, string>(p =>
-					modData.Translation.GetString(LengthInSeconds, Translation.Arguments("length", Math.Round(p, 3))));
+					TranslationProvider.GetString(LengthInSeconds, Translation.Arguments("length", Math.Round(p, 3))));
 
 				frameText.GetText = () =>
 				{

--- a/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var panel = widget;
 			panel.Get<ButtonWidget>("ABORT_BUTTON").OnClick = () => { CloseWindow(); onAbort(); };
 
-			var connectingDesc = modData.Translation.GetString(ConnectingToEndpoint, Translation.Arguments("endpoint", endpoint));
+			var connectingDesc = TranslationProvider.GetString(ConnectingToEndpoint, Translation.Arguments("endpoint", endpoint));
 			widget.Get<LabelWidget>("CONNECTING_DESC").GetText = () => connectingDesc;
 		}
 
@@ -129,15 +129,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				onRetry(pass);
 			};
 
-			var connectingDescText = modData.Translation.GetString(CouldNotConnectToTarget, Translation.Arguments("target", connection.Target));
+			var connectingDescText = TranslationProvider.GetString(CouldNotConnectToTarget, Translation.Arguments("target", connection.Target));
 			widget.Get<LabelWidget>("CONNECTING_DESC").GetText = () => connectingDescText;
 
 			var connectionError = widget.Get<LabelWidget>("CONNECTION_ERROR");
-			var connectionErrorText = orderManager.ServerError != null ? modData.Translation.GetString(orderManager.ServerError) : connection.ErrorMessage ?? modData.Translation.GetString(UnknownError);
+			var connectionErrorText = orderManager.ServerError != null ? TranslationProvider.GetString(orderManager.ServerError) : connection.ErrorMessage ?? TranslationProvider.GetString(UnknownError);
 			connectionError.GetText = () => connectionErrorText;
 
 			var panelTitle = widget.Get<LabelWidget>("TITLE");
-			var panelTitleText = orderManager.AuthenticationFailed ? modData.Translation.GetString(PasswordRequired) : modData.Translation.GetString(ConnectionFailed);
+			var panelTitleText = orderManager.AuthenticationFailed ? TranslationProvider.GetString(PasswordRequired) : TranslationProvider.GetString(ConnectionFailed);
 			panelTitle.GetText = () => panelTitleText;
 
 			passwordField = panel.GetOrNull<PasswordFieldWidget>("PASSWORD");

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -34,7 +34,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		enum ActorIDStatus { Normal = 0, Duplicate = 1, Empty = 3 }
 
 		readonly WorldRenderer worldRenderer;
-		readonly ModData modData;
 		readonly EditorActorLayer editorActorLayer;
 		readonly EditorActionManager editorActionManager;
 		readonly EditorViewportControllerWidget editor;
@@ -86,9 +85,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 
 		[ObjectCreator.UseCtor]
-		public ActorEditLogic(Widget widget, ModData modData, World world, WorldRenderer worldRenderer, Dictionary<string, MiniYaml> logicArgs)
+		public ActorEditLogic(Widget widget, World world, WorldRenderer worldRenderer, Dictionary<string, MiniYaml> logicArgs)
 		{
-			this.modData = modData;
 			this.worldRenderer = worldRenderer;
 
 			editorActorLayer = world.WorldActor.Trait<EditorActorLayer>();
@@ -115,8 +113,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			actorIDErrorLabel = actorEditPanel.Get<LabelWidget>("ACTOR_ID_ERROR_LABEL");
 			actorIDErrorLabel.IsVisible = () => actorIDStatus != ActorIDStatus.Normal;
 			actorIDErrorLabel.GetText = () => actorIDStatus == ActorIDStatus.Duplicate ?
-				modData.Translation.GetString(DuplicateActorId)
-					: modData.Translation.GetString(EnterActorId);
+				TranslationProvider.GetString(DuplicateActorId)
+					: TranslationProvider.GetString(EnterActorId);
 
 			if (logicArgs.TryGetValue("EditPanelPadding", out var yaml))
 				editPanelPadding = FieldLoader.GetValue<int>("EditPanelPadding", yaml.Value);
@@ -146,7 +144,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					if (editorActorLayer[actorId] != null)
 					{
 						nextActorIDStatus = ActorIDStatus.Duplicate;
-						actorIDErrorLabel.Text = modData.Translation.GetString(DuplicateActorId);
+						actorIDErrorLabel.Text = TranslationProvider.GetString(DuplicateActorId);
 						actorIDErrorLabel.Visible = true;
 						return;
 					}
@@ -230,7 +228,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					// Add owner dropdown
 					var ownerContainer = dropdownOptionTemplate.Clone();
-					var owner = modData.Translation.GetString(Owner);
+					var owner = TranslationProvider.GetString(Owner);
 					ownerContainer.Get<LabelWidget>("LABEL").GetText = () => owner;
 					var ownerDropdown = ownerContainer.Get<DropDownButtonWidget>("OPTION");
 					var selectedOwner = actor.Owner;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (tooltip != null)
 					searchTerms.Add(tooltip.Name);
 
-				var actorType = modData.Translation.GetString(ActorTypeTooltip, Translation.Arguments("actorType", a.Name));
+				var actorType = TranslationProvider.GetString(ActorTypeTooltip, Translation.Arguments("actorType", a.Name));
 				var tooltipText = tooltip == null ? actorType : tooltip.Name + $"\n{actorType}";
 				allActorsTemp.Add(new ActorSelectorActor(a, editorData.Categories, searchTerms.ToArray(), tooltipText));
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/CommonSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/CommonSelectorLogic.cs
@@ -71,10 +71,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return true;
 			};
 
-			var none = ModData.Translation.GetString(None);
-			var searchResults = ModData.Translation.GetString(SearchResults);
-			var all = ModData.Translation.GetString(All);
-			var multiple = ModData.Translation.GetString(Multiple);
+			var none = TranslationProvider.GetString(None);
+			var searchResults = TranslationProvider.GetString(SearchResults);
+			var all = TranslationProvider.GetString(All);
+			var multiple = TranslationProvider.GetString(Multiple);
 
 			var categorySelector = widget.Get<DropDownButtonWidget>("CATEGORIES_DROPDOWN");
 			categorySelector.GetText = () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -170,7 +170,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var fileTypes = new Dictionary<MapFileType, MapFileTypeInfo>()
 			{
 				{ MapFileType.OraMap, new MapFileTypeInfo { Extension = ".oramap", UiLabel = ".oramap" } },
-				{ MapFileType.Unpacked, new MapFileTypeInfo { Extension = "", UiLabel = $"({modData.Translation.GetString(Unpacked)})" } }
+				{ MapFileType.Unpacked, new MapFileTypeInfo { Extension = "", UiLabel = $"({TranslationProvider.GetString(Unpacked)})" } }
 			};
 
 			var typeDropdown = widget.Get<DropDownButtonWidget>("TYPE_DROPDOWN");
@@ -316,7 +316,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (actionManager != null)
 					actionManager.Modified = false;
 
-				TextNotificationsManager.AddTransientLine(modData.Translation.GetString(SaveCurrentMap), world.LocalPlayer);
+				TextNotificationsManager.AddTransientLine(TranslationProvider.GetString(SaveCurrentMap), world.LocalPlayer);
 			}
 			catch (Exception e)
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -301,7 +301,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 			catch (Exception ex)
 			{
-				TextNotificationsManager.Debug(modData.Translation.GetString(SaveDeletionFailed, Translation.Arguments("savePath", savePath)));
+				TextNotificationsManager.Debug(TranslationProvider.GetString(SaveDeletionFailed, Translation.Arguments("savePath", savePath)));
 				Log.Write("debug", ex.ToString());
 				return;
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				if (tabButton != null)
 				{
-					tabButton.Text = modData.Translation.GetString(label);
+					tabButton.Text = TranslationProvider.GetString(label);
 					tabButton.OnClick = () =>
 					{
 						if (activePanel == IngameInfoPanel.Chat)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoObjectivesLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoObjectivesLogic.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly ContainerWidget template;
 
 		[ObjectCreator.UseCtor]
-		public GameInfoObjectivesLogic(Widget widget, World world, ModData modData)
+		public GameInfoObjectivesLogic(Widget widget, World world)
 		{
 			var player = world.RenderPlayer ?? world.LocalPlayer;
 
@@ -51,9 +51,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var missionStatus = widget.Get<LabelWidget>("MISSION_STATUS");
-			var inProgress = modData.Translation.GetString(InProgress);
-			var accomplished = modData.Translation.GetString(Accomplished);
-			var failed = modData.Translation.GetString(Failed);
+			var inProgress = TranslationProvider.GetString(InProgress);
+			var accomplished = TranslationProvider.GetString(Accomplished);
+			var failed = TranslationProvider.GetString(Failed);
 			missionStatus.GetText = () => player.WinState == WinState.Undefined ? inProgress :
 				player.WinState == WinState.Won ? accomplished : failed;
 			missionStatus.GetColor = () => player.WinState == WinState.Undefined ? Color.White :

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -79,9 +79,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					checkbox.GetText = () => mo.Objectives[0].Description;
 				}
 
-				var failed = modData.Translation.GetString(Failed);
-				var inProgress = modData.Translation.GetString(InProgress);
-				var accomplished = modData.Translation.GetString(Accomplished);
+				var failed = TranslationProvider.GetString(Failed);
+				var inProgress = TranslationProvider.GetString(InProgress);
+				var accomplished = TranslationProvider.GetString(Accomplished);
 				statusLabel.GetText = () => player.WinState == WinState.Won ? accomplished :
 					player.WinState == WinState.Lost ? failed : inProgress;
 				statusLabel.GetColor = () => player.WinState == WinState.Won ? Color.LimeGreen :
@@ -104,8 +104,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var teamTemplate = playerPanel.Get<ScrollItemWidget>("TEAM_TEMPLATE");
 			var playerTemplate = playerPanel.Get("PLAYER_TEMPLATE");
 			var spectatorTemplate = playerPanel.Get("SPECTATOR_TEMPLATE");
-			var unmuteTooltip = modData.Translation.GetString(Unmute);
-			var muteTooltip = modData.Translation.GetString(Mute);
+			var unmuteTooltip = TranslationProvider.GetString(Unmute);
+			var muteTooltip = TranslationProvider.GetString(Mute);
 			playerPanel.RemoveChildren();
 
 			var teams = world.Players.Where(p => !p.NonCombatant && p.Playable)
@@ -136,8 +136,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					var teamHeader = ScrollItemWidget.Setup(teamTemplate, () => false, () => { });
 					var team = t.Key > 0
-						? modData.Translation.GetString(TeamNumber, Translation.Arguments("team", t.Key))
-						: modData.Translation.GetString(NoTeam);
+						? TranslationProvider.GetString(TeamNumber, Translation.Arguments("team", t.Key))
+						: TranslationProvider.GetString(NoTeam);
 					teamHeader.Get<LabelWidget>("TEAM").GetText = () => team;
 					var teamRating = teamHeader.Get<LabelWidget>("TEAM_SCORE");
 					var scoreCache = new CachedTransform<int, string>(s => s.ToString());
@@ -193,7 +193,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (spectators.Count > 0)
 			{
 				var spectatorHeader = ScrollItemWidget.Setup(teamTemplate, () => false, () => { });
-				var spectatorTeam = modData.Translation.GetString(Spectators);
+				var spectatorTeam = TranslationProvider.GetString(Spectators);
 				spectatorHeader.Get<LabelWidget>("TEAM").GetText = () => spectatorTeam;
 
 				playerPanel.AddChild(spectatorHeader);
@@ -212,7 +212,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					nameLabel.GetText = () =>
 					{
-						var suffix = client.State == Session.ClientState.Disconnected ? $" ({modData.Translation.GetString(Gone)})" : "";
+						var suffix = client.State == Session.ClientState.Disconnected ? $" ({TranslationProvider.GetString(Gone)})" : "";
 						return name.Update((client.Name, suffix));
 					};
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameTimerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameTimerLogic.cs
@@ -43,10 +43,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			bool Paused() => world.Paused || world.ReplayTimestep == 0;
 
-			var pausedText = modData.Translation.GetString(GameTimerLogic.Paused);
-			var maxSpeedText = modData.Translation.GetString(MaxSpeed);
+			var pausedText = TranslationProvider.GetString(GameTimerLogic.Paused);
+			var maxSpeedText = TranslationProvider.GetString(MaxSpeed);
 			var speedText = new CachedTransform<int, string>(p =>
-					modData.Translation.GetString(Speed, Translation.Arguments("percentage", p)));
+					TranslationProvider.GetString(Speed, Translation.Arguments("percentage", p)));
 
 			if (timer != null)
 			{
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var timerText = new CachedTransform<int, string>(p =>
-				modData.Translation.GetString(Complete, Translation.Arguments("percentage", p)));
+				TranslationProvider.GetString(Complete, Translation.Arguments("percentage", p)));
 			if (timer is LabelWithTooltipWidget timerTooltip)
 			{
 				var connection = orderManager.Connection as ReplayConnection;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			displayResources = playerResources.Cash + playerResources.Resources;
 
 			siloUsageTooltipCache = new CachedTransform<(int Resources, int Capacity), string>(x =>
-				modData.Translation.GetString(SiloUsage, Translation.Arguments("usage", x.Resources, "capacity", x.Capacity)));
+				TranslationProvider.GetString(SiloUsage, Translation.Arguments("usage", x.Resources, "capacity", x.Capacity)));
 			cashLabel = widget.Get<LabelWithTooltipWidget>("CASH");
 			cashLabel.GetTooltipText = () => siloUsageTooltip;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -70,10 +70,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var disableTeamChat = alwaysDisabled || (world.LocalPlayer != null && !players.Any(p => p.IsAlliedWith(world.LocalPlayer)));
 			var teamChat = !disableTeamChat;
 
-			var teamMessage = modData.Translation.GetString(TeamChat);
-			var allMessage = modData.Translation.GetString(GeneralChat);
+			var teamMessage = TranslationProvider.GetString(TeamChat);
+			var allMessage = TranslationProvider.GetString(GeneralChat);
 
-			chatDisabled = modData.Translation.GetString(ChatDisabled);
+			chatDisabled = TranslationProvider.GetString(ChatDisabled);
 
 			// Only execute this once, the first time this widget is loaded
 			if (TextNotificationsManager.MutedPlayers.Count == 0)
@@ -194,7 +194,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return true;
 			};
 
-			chatAvailableIn = new CachedTransform<int, string>(x => modData.Translation.GetString(ChatAvailability, Translation.Arguments("seconds", x)));
+			chatAvailableIn = new CachedTransform<int, string>(x => TranslationProvider.GetString(ChatAvailability, Translation.Arguments("seconds", x)));
 
 			if (!isMenuChat)
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -270,7 +270,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			button.Id = id;
 			button.IsDisabled = () => leaving;
-			var translation = modData.Translation.GetString(text);
+			var translation = TranslationProvider.GetString(text);
 			button.GetText = () => translation;
 			buttonContainer.AddChild(button);
 			buttons.Add(button);
@@ -284,8 +284,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return;
 
 			var button = AddButton("ABORT_MISSION", world.IsGameOver
-				? modData.Translation.GetString(Leave)
-				: modData.Translation.GetString(AbortMission));
+				? TranslationProvider.GetString(Leave)
+				: TranslationProvider.GetString(AbortMission));
 
 			button.OnClick = () =>
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerBarLogic.cs
@@ -35,10 +35,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			powerBar.TooltipTextCached = new CachedTransform<(float Current, float Capacity), string>(usage =>
 			{
 				var capacity = developerMode.UnlimitedPower ?
-					modData.Translation.GetString(Infinite) :
+					TranslationProvider.GetString(Infinite) :
 					powerManager.PowerProvided.ToString();
 
-				return modData.Translation.GetString(
+				return TranslationProvider.GetString(
 					PowerUsage,
 					Translation.Arguments("usage", usage.Current, "capacity", capacity));
 			});

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerCounterLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerCounterLogic.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var powerManager = world.LocalPlayer.PlayerActor.Trait<PowerManager>();
 			var power = widget.Get<LabelWithTooltipWidget>("POWER");
 			var powerIcon = widget.Get<ImageWidget>("POWER_ICON");
-			var unlimitedCapacity = modData.Translation.GetString(Infinite);
+			var unlimitedCapacity = TranslationProvider.GetString(Infinite);
 
 			powerIcon.GetImageName = () => powerManager.ExcessPower < 0 ? "power-critical" : "power-normal";
 			power.GetColor = () => powerManager.ExcessPower < 0 ? Color.Red : Color.White;
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var tooltipTextCached = new CachedTransform<(string, string), string>(((string Usage, string Capacity) args) =>
 			{
-				return modData.Translation.GetString(
+				return TranslationProvider.GetString(
 					PowerUsage,
 					Translation.Arguments("usage", args.Usage, "capacity", args.Capacity));
 			});

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameSiloBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameSiloBarLogic.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			siloBar.GetUsed = () => playerResources.Resources;
 			siloBar.TooltipTextCached = new CachedTransform<(float Current, float Capacity), string>(usage =>
 			{
-				return modData.Translation.GetString(
+				return TranslationProvider.GetString(
 					SiloUsage,
 					Translation.Arguments("usage", usage.Current, "capacity", usage.Capacity));
 			});

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
@@ -104,10 +104,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var groups = new Dictionary<string, IEnumerable<CameraOption>>();
 
-			combined = new CameraOption(this, world, modData.Translation.GetString(CameraOptionAllPlayers), world.Players.First(p => p.InternalName == "Everyone"));
-			disableShroud = new CameraOption(this, world, modData.Translation.GetString(CameraOptionDisableShroud), null);
+			combined = new CameraOption(this, world, TranslationProvider.GetString(CameraOptionAllPlayers), world.Players.First(p => p.InternalName == "Everyone"));
+			disableShroud = new CameraOption(this, world, TranslationProvider.GetString(CameraOptionDisableShroud), null);
 			if (!limitViews)
-				groups.Add(modData.Translation.GetString(CameraOptionOther), new List<CameraOption>() { combined, disableShroud });
+				groups.Add(TranslationProvider.GetString(CameraOptionOther), new List<CameraOption>() { combined, disableShroud });
 
 			teams = world.Players.Where(p => !p.NonCombatant && p.Playable)
 				.Select(p => new CameraOption(this, p))
@@ -119,9 +119,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			foreach (var t in teams)
 			{
 				totalPlayers += t.Count();
-				var label = noTeams ? modData.Translation.GetString(Players) : t.Key > 0
-					? modData.Translation.GetString(TeamNumber, Translation.Arguments("team", t.Key))
-					: modData.Translation.GetString(NoTeam);
+				var label = noTeams ? TranslationProvider.GetString(Players) : t.Key > 0
+					? TranslationProvider.GetString(TeamNumber, Translation.Arguments("team", t.Key))
+					: TranslationProvider.GetString(NoTeam);
 
 				groups.Add(label, t);
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -144,10 +144,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var statsDropDown = widget.Get<DropDownButtonWidget>("STATS_DROPDOWN");
 			StatsDropDownOption CreateStatsOption(string title, ObserverStatsPanel panel, ScrollItemWidget template, Action a)
 			{
-				title = modData.Translation.GetString(title);
+				title = TranslationProvider.GetString(title);
 				return new StatsDropDownOption
 				{
-					Title = modData.Translation.GetString(title),
+					Title = TranslationProvider.GetString(title),
 					IsSelected = () => activePanel == panel,
 					OnClick = () =>
 					{
@@ -168,23 +168,23 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				new StatsDropDownOption
 				{
-					Title = modData.Translation.GetString(InformationNone),
+					Title = TranslationProvider.GetString(InformationNone),
 					IsSelected = () => activePanel == ObserverStatsPanel.None,
 					OnClick = () =>
 					{
-						var informationNone = modData.Translation.GetString(InformationNone);
+						var informationNone = TranslationProvider.GetString(InformationNone);
 						statsDropDown.GetText = () => informationNone;
 						playerStatsPanel.Visible = false;
 						ClearStats();
 						activePanel = ObserverStatsPanel.None;
 					}
 				},
-				CreateStatsOption(Basic, ObserverStatsPanel.Basic, basicPlayerTemplate, () => DisplayStats(BasicStats, modData)),
-				CreateStatsOption(Economy, ObserverStatsPanel.Economy, economyPlayerTemplate, () => DisplayStats(EconomyStats, modData)),
-				CreateStatsOption(Production, ObserverStatsPanel.Production, productionPlayerTemplate, () => DisplayStats(ProductionStats, modData)),
-				CreateStatsOption(SupportPowers, ObserverStatsPanel.SupportPowers, supportPowersPlayerTemplate, () => DisplayStats(SupportPowerStats, modData)),
-				CreateStatsOption(Combat, ObserverStatsPanel.Combat, combatPlayerTemplate, () => DisplayStats(CombatStats, modData)),
-				CreateStatsOption(Army, ObserverStatsPanel.Army, armyPlayerTemplate, () => DisplayStats(ArmyStats, modData)),
+				CreateStatsOption(Basic, ObserverStatsPanel.Basic, basicPlayerTemplate, () => DisplayStats(BasicStats)),
+				CreateStatsOption(Economy, ObserverStatsPanel.Economy, economyPlayerTemplate, () => DisplayStats(EconomyStats)),
+				CreateStatsOption(Production, ObserverStatsPanel.Production, productionPlayerTemplate, () => DisplayStats(ProductionStats)),
+				CreateStatsOption(SupportPowers, ObserverStatsPanel.SupportPowers, supportPowersPlayerTemplate, () => DisplayStats(SupportPowerStats)),
+				CreateStatsOption(Combat, ObserverStatsPanel.Combat, combatPlayerTemplate, () => DisplayStats(CombatStats)),
+				CreateStatsOption(Army, ObserverStatsPanel.Army, armyPlayerTemplate, () => DisplayStats(ArmyStats)),
 				CreateStatsOption(EarningsGraph, ObserverStatsPanel.Graph, null, () => IncomeGraph()),
 				CreateStatsOption(ArmyGraph, ObserverStatsPanel.ArmyGraph, null, () => ArmyValueGraph()),
 			};
@@ -265,7 +265,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					(p.PlayerActor.TraitOrDefault<PlayerStatistics>() ?? new PlayerStatistics(p.PlayerActor)).ArmySamples.Select(s => (float)s)));
 		}
 
-		void DisplayStats(Func<Player, ScrollItemWidget> createItem, ModData modData)
+		void DisplayStats(Func<Player, ScrollItemWidget> createItem)
 		{
 			foreach (var team in teams)
 			{
@@ -275,8 +275,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					tt.IgnoreMouseOver = true;
 
 					var teamLabel = tt.Get<LabelWidget>("TEAM");
-					var teamText = team.Key > 0 ? modData.Translation.GetString(TeamNumber, Translation.Arguments("team", team.Key))
-						: modData.Translation.GetString(NoTeam);
+					var teamText = team.Key > 0 ? TranslationProvider.GetString(TeamNumber, Translation.Arguments("team", team.Key))
+						: TranslationProvider.GetString(NoTeam);
 					teamLabel.GetText = () => teamText;
 					tt.Bounds.Width = teamLabel.Bounds.Width = Game.Renderer.Fonts[tt.Font].Measure(teamText).X;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var extraHeightOnDouble = extras.Bounds.Y;
 			var extraHeightOnSingle = extraHeightOnDouble - (doubleHeight - singleHeight);
 
-			var unrevealedTerrain = modData.Translation.GetString(UnrevealedTerrain);
+			var unrevealedTerrain = TranslationProvider.GetString(UnrevealedTerrain);
 
 			tooltipContainer.BeforeRender = () =>
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var status = new CachedTransform<string, string>(s => WidgetUtils.TruncateText(s, statusLabel.Bounds.Width, statusFont));
 			statusLabel.GetText = () => status.Update(getStatusText());
 
-			var text = modData.Translation.GetString(Downloading, Translation.Arguments("title", download.Title));
+			var text = TranslationProvider.GetString(Downloading, Translation.Arguments("title", download.Title));
 			panel.Get<LabelWidget>("TITLE").Text = text;
 
 			ShowDownloadDialog();
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void ShowDownloadDialog()
 		{
-			getStatusText = () => modData.Translation.GetString(FetchingMirrorList);
+			getStatusText = () => TranslationProvider.GetString(FetchingMirrorList);
 			progressBar.Indeterminate = true;
 
 			var retryButton = panel.Get<ButtonWidget>("RETRY_BUTTON");
@@ -107,7 +107,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var dataTotal = 0.0f;
 				var mag = 0;
 				var dataSuffix = "";
-				var host = downloadHost ?? modData.Translation.GetString(UnknownHost);
+				var host = downloadHost ?? TranslationProvider.GetString(UnknownHost);
 
 				if (total < 0)
 				{
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					dataReceived = read / (float)(1L << (mag * 10));
 					dataSuffix = SizeSuffixes[mag];
 
-					getStatusText = () => modData.Translation.GetString(DownloadingFrom,
+					getStatusText = () => TranslationProvider.GetString(DownloadingFrom,
 						Translation.Arguments("host", host, "received", $"{dataReceived:0.00}", "suffix", dataSuffix));
 					progressBar.Indeterminate = true;
 				}
@@ -126,7 +126,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					dataReceived = read / (float)(1L << (mag * 10));
 					dataSuffix = SizeSuffixes[mag];
 
-					getStatusText = () => modData.Translation.GetString(DownloadingFromProgress,
+					getStatusText = () => TranslationProvider.GetString(DownloadingFromProgress,
 						Translation.Arguments("host", host, "received", $"{dataReceived:0.00}", "total", $"{dataTotal:0.00}",
 							"suffix", dataSuffix, "progress", progressPercentage));
 					progressBar.Indeterminate = false;
@@ -139,7 +139,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			void OnError(string s) => Game.RunAfterTick(() =>
 			{
-				var host = downloadHost ?? modData.Translation.GetString(UnknownHost);
+				var host = downloadHost ?? TranslationProvider.GetString(UnknownHost);
 				Log.Write("install", $"Download from {host} failed: " + s);
 
 				progressBar.Indeterminate = false;
@@ -183,7 +183,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						// Validate integrity
 						if (!string.IsNullOrEmpty(download.SHA1))
 						{
-							getStatusText = () => modData.Translation.GetString(VerifyingArchive);
+							getStatusText = () => TranslationProvider.GetString(VerifyingArchive);
 							progressBar.Indeterminate = true;
 
 							var archiveValid = false;
@@ -205,13 +205,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 							if (!archiveValid)
 							{
-								OnError(modData.Translation.GetString(ArchiveValidationFailed));
+								OnError(TranslationProvider.GetString(ArchiveValidationFailed));
 								return;
 							}
 						}
 
 						// Automatically extract
-						getStatusText = () => modData.Translation.GetString(Extracting);
+						getStatusText = () => TranslationProvider.GetString(Extracting);
 						progressBar.Indeterminate = true;
 
 						var extracted = new List<string>();
@@ -231,7 +231,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 											continue;
 										}
 
-										OnExtractProgress(modData.Translation.GetString(ExtractingEntry, Translation.Arguments("entry", kv.Value)));
+										OnExtractProgress(TranslationProvider.GetString(ExtractingEntry, Translation.Arguments("entry", kv.Value)));
 										Log.Write("install", "Extracting " + kv.Value);
 										var targetPath = Platform.ResolvePath(kv.Key);
 										Directory.CreateDirectory(Path.GetDirectoryName(targetPath));
@@ -262,7 +262,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 								File.Delete(f);
 							}
 
-							OnError(modData.Translation.GetString(ArchiveExtractionFailed));
+							OnError(TranslationProvider.GetString(ArchiveExtractionFailed));
 						}
 					}
 					catch (Exception e)
@@ -295,7 +295,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						Log.Write("install", "Mirror selection failed with error:");
 						Log.Write("install", e.ToString());
-						OnError(modData.Translation.GetString(MirrorSelectionFailed));
+						OnError(TranslationProvider.GetString(MirrorSelectionFailed));
 					}
 				});
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromSourceLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromSourceLogic.cs
@@ -159,15 +159,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void DetectContentSources()
 		{
-			var message = modData.Translation.GetString(DetectingSources);
-			ShowProgressbar(modData.Translation.GetString(CheckingSources), () => message);
+			var message = TranslationProvider.GetString(DetectingSources);
+			ShowProgressbar(TranslationProvider.GetString(CheckingSources), () => message);
 			ShowBackRetry(DetectContentSources);
 
 			new Task(() =>
 			{
 				foreach (var kv in sources)
 				{
-					message = modData.Translation.GetString(SearchingSourceFor, Translation.Arguments("title", kv.Value.Title));
+					message = TranslationProvider.GetString(SearchingSourceFor, Translation.Arguments("title", kv.Value.Title));
 
 					var sourceResolver = kv.Value.ObjectCreator.CreateObject<ISourceResolver>($"{kv.Value.Type.Value}SourceResolver");
 
@@ -187,7 +187,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						{
 							Game.RunAfterTick(() =>
 							{
-								ShowList(kv.Value, modData.Translation.GetString(ContentPackageInstallation));
+								ShowList(kv.Value, TranslationProvider.GetString(ContentPackageInstallation));
 								ShowContinueCancel(() => InstallFromSource(path, kv.Value));
 							});
 
@@ -219,14 +219,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var options = new Dictionary<string, IEnumerable<string>>();
 
 				if (gameSources.Any())
-					options.Add(modData.Translation.GetString(GameSources), gameSources);
+					options.Add(TranslationProvider.GetString(GameSources), gameSources);
 
 				if (digitalInstalls.Any())
-					options.Add(modData.Translation.GetString(DigitalInstalls), digitalInstalls);
+					options.Add(TranslationProvider.GetString(DigitalInstalls), digitalInstalls);
 
 				Game.RunAfterTick(() =>
 				{
-					ShowList(modData.Translation.GetString(GameContentNotFound), modData.Translation.GetString(AlternativeContentSources), options);
+					ShowList(TranslationProvider.GetString(GameContentNotFound), TranslationProvider.GetString(AlternativeContentSources), options);
 					ShowBackRetry(DetectContentSources);
 				});
 			}).Start();
@@ -235,7 +235,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void InstallFromSource(string path, ModContent.ModSource modSource)
 		{
 			var message = "";
-			ShowProgressbar(modData.Translation.GetString(InstallingContent), () => message);
+			ShowProgressbar(TranslationProvider.GetString(InstallingContent), () => message);
 			ShowDisabledCancel();
 
 			new Task(() =>
@@ -286,7 +286,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					Game.RunAfterTick(() =>
 					{
-						ShowMessage(modData.Translation.GetString(InstallationFailed), modData.Translation.GetString(CheckInstallLog));
+						ShowMessage(TranslationProvider.GetString(InstallationFailed), TranslationProvider.GetString(CheckInstallLog));
 						ShowBackRetry(() => InstallFromSource(path, modSource));
 					});
 				}
@@ -391,11 +391,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void ShowContinueCancel(Action continueAction)
 		{
 			primaryButton.OnClick = continueAction;
-			primaryButton.Text = modData.Translation.GetString(Continue);
+			primaryButton.Text = TranslationProvider.GetString(Continue);
 			primaryButton.Visible = true;
 
 			secondaryButton.OnClick = Ui.CloseWindow;
-			secondaryButton.Text = modData.Translation.GetString(Cancel);
+			secondaryButton.Text = TranslationProvider.GetString(Cancel);
 			secondaryButton.Visible = true;
 			secondaryButton.Disabled = false;
 			Game.RunAfterTick(Ui.ResetTooltips);
@@ -404,11 +404,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void ShowBackRetry(Action retryAction)
 		{
 			primaryButton.OnClick = retryAction;
-			primaryButton.Text = modData.Translation.GetString(Retry);
+			primaryButton.Text = TranslationProvider.GetString(Retry);
 			primaryButton.Visible = true;
 
 			secondaryButton.OnClick = Ui.CloseWindow;
-			secondaryButton.Text = modData.Translation.GetString(Back);
+			secondaryButton.Text = TranslationProvider.GetString(Back);
 			secondaryButton.Visible = true;
 			secondaryButton.Disabled = false;
 			Game.RunAfterTick(Ui.ResetTooltips);

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
@@ -23,7 +23,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference]
 		const string ManualInstall = "button-manual-install";
 
-		readonly ModData modData;
 		readonly ModContent content;
 		readonly ScrollPanelWidget scrollPanel;
 		readonly Widget template;
@@ -34,9 +33,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		bool sourceAvailable;
 
 		[ObjectCreator.UseCtor]
-		public ModContentLogic(ModData modData, Widget widget, Manifest mod, ModContent content, Action onCancel)
+		public ModContentLogic(Widget widget, Manifest mod, ModContent content, Action onCancel)
 		{
-			this.modData = modData;
 			this.content = content;
 
 			var panel = widget.Get("CONTENT_PANEL");
@@ -143,7 +141,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				requiresSourceWidget.IsVisible = () => !installed && !downloadEnabled;
 				if (!isSourceAvailable)
 				{
-					var manualInstall = modData.Translation.GetString(ManualInstall);
+					var manualInstall = TranslationProvider.GetString(ManualInstall);
 					requiresSourceWidget.GetText = () => manualInstall;
 				}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentPromptLogic.cs
@@ -35,8 +35,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.content = content;
 			CheckRequiredContentInstalled();
 
-			var continueMessage = modData.Translation.GetString(Continue);
-			var quitMessage = modData.Translation.GetString(Quit);
+			var continueMessage = TranslationProvider.GetString(Continue);
+			var quitMessage = TranslationProvider.GetString(Quit);
 
 			var panel = widget.Get("CONTENT_PROMPT_PANEL");
 			var headerTemplate = panel.Get<LabelWidget>("HEADER_TEMPLATE");

--- a/OpenRA.Mods.Common/Widgets/Logic/IntroductionPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/IntroductionPromptLogic.cs
@@ -42,8 +42,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var ds = Game.Settings.Graphics;
 			var gs = Game.Settings.Game;
 
-			classic = modData.Translation.GetString(Classic);
-			modern = modData.Translation.GetString(Modern);
+			classic = TranslationProvider.GetString(Classic);
+			modern = TranslationProvider.GetString(Modern);
 
 			var escPressed = false;
 			var nameTextfield = widget.Get<TextFieldWidget>("PLAYERNAME");
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			mouseControlDescModern.IsVisible = () => !gs.UseClassicMouseStyle;
 
 			var mouseControlDropdown = widget.Get<DropDownButtonWidget>("MOUSE_CONTROL_DROPDOWN");
-			mouseControlDropdown.OnMouseDown = _ => InputSettingsLogic.ShowMouseControlDropdown(modData, mouseControlDropdown, gs);
+			mouseControlDropdown.OnMouseDown = _ => InputSettingsLogic.ShowMouseControlDropdown(mouseControlDropdown, gs);
 			mouseControlDropdown.GetText = () => gs.UseClassicMouseStyle ? classic : modern;
 
 			foreach (var container in new[] { mouseControlDescClassic, mouseControlDescModern })

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickClientLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickClientLogic.cs
@@ -20,9 +20,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		const string KickClient = "dialog-kick-client.prompt";
 
 		[ObjectCreator.UseCtor]
-		public KickClientLogic(ModData modData, Widget widget, string clientName, Action<bool> okPressed, Action cancelPressed)
+		public KickClientLogic(Widget widget, string clientName, Action<bool> okPressed, Action cancelPressed)
 		{
-			var kickMessage = modData.Translation.GetString(KickClient, Translation.Arguments("player", clientName));
+			var kickMessage = TranslationProvider.GetString(KickClient, Translation.Arguments("player", clientName));
 			widget.Get<LabelWidget>("TITLE").GetText = () => kickMessage;
 
 			var tempBan = false;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickSpectatorsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickSpectatorsLogic.cs
@@ -20,9 +20,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		const string KickSpectators = "dialog-kick-spectators.prompt";
 
 		[ObjectCreator.UseCtor]
-		public KickSpectatorsLogic(ModData modData, Widget widget, int clientCount, Action okPressed, Action cancelPressed)
+		public KickSpectatorsLogic(Widget widget, int clientCount, Action okPressed, Action cancelPressed)
 		{
-			var kickMessage = modData.Translation.GetString(KickSpectators, Translation.Arguments("count", clientCount));
+			var kickMessage = TranslationProvider.GetString(KickSpectators, Translation.Arguments("count", clientCount));
 			widget.Get<LabelWidget>("TEXT").GetText = () => kickMessage;
 
 			widget.Get<ButtonWidget>("OK_BUTTON").OnClick = () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -261,7 +261,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						{
 							new DropDownOption()
 							{
-								Title = modData.Translation.GetString(Add),
+								Title = TranslationProvider.GetString(Add),
 								IsSelected = () => false,
 								OnClick = () =>
 								{
@@ -280,7 +280,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						{
 							botOptions.Add(new DropDownOption()
 							{
-								Title = modData.Translation.GetString(Remove),
+								Title = TranslationProvider.GetString(Remove),
 								IsSelected = () => false,
 								OnClick = () =>
 								{
@@ -294,7 +294,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							});
 						}
 
-						options.Add(modData.Translation.GetString(ConfigureBots), botOptions);
+						options.Add(TranslationProvider.GetString(ConfigureBots), botOptions);
 					}
 
 					var teamCount = (orderManager.LobbyInfo.Slots.Count(s => !s.Value.LockTeam && orderManager.LobbyInfo.ClientInSlot(s.Key) != null) + 1) / 2;
@@ -302,7 +302,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						var teamOptions = Enumerable.Range(2, teamCount - 1).Reverse().Select(d => new DropDownOption
 						{
-							Title = modData.Translation.GetString(NumberTeams, Translation.Arguments("count", d)),
+							Title = TranslationProvider.GetString(NumberTeams, Translation.Arguments("count", d)),
 							IsSelected = () => false,
 							OnClick = () => orderManager.IssueOrder(Order.Command($"assignteams {d}"))
 						}).ToList();
@@ -311,7 +311,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						{
 							teamOptions.Add(new DropDownOption
 							{
-								Title = modData.Translation.GetString(HumanVsBots),
+								Title = TranslationProvider.GetString(HumanVsBots),
 								IsSelected = () => false,
 								OnClick = () => orderManager.IssueOrder(Order.Command("assignteams 1"))
 							});
@@ -319,12 +319,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 						teamOptions.Add(new DropDownOption
 						{
-							Title = modData.Translation.GetString(FreeForAll),
+							Title = TranslationProvider.GetString(FreeForAll),
 							IsSelected = () => false,
 							OnClick = () => orderManager.IssueOrder(Order.Command("assignteams 0"))
 						});
 
-						options.Add(modData.Translation.GetString(ConfigureTeams), teamOptions);
+						options.Add(TranslationProvider.GetString(ConfigureTeams), teamOptions);
 					}
 
 					ScrollItemWidget SetupItem(DropDownOption option, ScrollItemWidget template)
@@ -443,7 +443,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			disconnectButton.OnClick = () => { Ui.CloseWindow(); onExit(); };
 
 			if (skirmishMode)
-				disconnectButton.Text = modData.Translation.GetString(Back);
+				disconnectButton.Text = TranslationProvider.GetString(Back);
 
 			if (logicArgs.TryGetValue("ChatTemplates", out var templateIds))
 			{
@@ -455,8 +455,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var chatMode = lobby.Get<ButtonWidget>("CHAT_MODE");
-			var team = modData.Translation.GetString(TeamChat);
-			var all = modData.Translation.GetString(GeneralChat);
+			var team = TranslationProvider.GetString(TeamChat);
+			var all = TranslationProvider.GetString(GeneralChat);
 			chatMode.GetText = () => teamChat ? team : all;
 			chatMode.OnClick = () => teamChat ^= true;
 			chatMode.IsDisabled = () => disableTeamChat || !chatEnabled;
@@ -497,8 +497,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			chatTextField.OnEscKey = _ => chatTextField.YieldKeyboardFocus();
 
-			chatAvailableIn = new CachedTransform<int, string>(x => modData.Translation.GetString(ChatAvailability, Translation.Arguments("seconds", x)));
-			chatDisabled = modData.Translation.GetString(ChatDisabled);
+			chatAvailableIn = new CachedTransform<int, string>(x => TranslationProvider.GetString(ChatAvailability, Translation.Arguments("seconds", x)));
+			chatDisabled = TranslationProvider.GetString(ChatDisabled);
 
 			lobbyChatPanel = lobby.Get<ScrollPanelWidget>("CHAT_DISPLAY");
 			lobbyChatPanel.RemoveChildren();

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
@@ -23,7 +23,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference]
 		const string NotAvailable = "label-not-available";
 
-		readonly ModData modData;
 		readonly ScrollPanelWidget panel;
 		readonly Widget optionsContainer;
 		readonly Widget checkboxRowTemplate;
@@ -36,9 +35,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		MapPreview mapPreview;
 
 		[ObjectCreator.UseCtor]
-		internal LobbyOptionsLogic(ModData modData, Widget widget, OrderManager orderManager, Func<MapPreview> getMap, Func<bool> configurationDisabled)
+		internal LobbyOptionsLogic(Widget widget, OrderManager orderManager, Func<MapPreview> getMap, Func<bool> configurationDisabled)
 		{
-			this.modData = modData;
 			this.getMap = getMap;
 			this.orderManager = orderManager;
 			this.configurationDisabled = configurationDisabled;
@@ -143,7 +141,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var getOptionLabel = new CachedTransform<string, string>(id =>
 				{
 					if (id == null || !option.Values.TryGetValue(id, out var value))
-						return modData.Translation.GetString(NotAvailable);
+						return TranslationProvider.GetString(NotAvailable);
 
 					return value;
 				});

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -55,12 +55,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		public static void ShowSlotDropDown(DropDownButtonWidget dropdown, Session.Slot slot,
 			Session.Client client, OrderManager orderManager, MapPreview map, ModData modData)
 		{
-			var open = modData.Translation.GetString(Open);
-			var closed = modData.Translation.GetString(Closed);
+			var open = TranslationProvider.GetString(Open);
+			var closed = TranslationProvider.GetString(Closed);
 			var options = new Dictionary<string, IEnumerable<SlotDropDownOption>>
 			{
 				{
-					modData.Translation.GetString(Slot), new List<SlotDropDownOption>
+					TranslationProvider.GetString(Slot), new List<SlotDropDownOption>
 					{
 						new SlotDropDownOption(open, "slot_open " + slot.PlayerReference, () => !slot.Closed && client == null),
 						new SlotDropDownOption(closed, "slot_close " + slot.PlayerReference, () => slot.Closed)
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				}
 			}
 
-			options.Add(bots.Count > 0 ? modData.Translation.GetString(Bots) : modData.Translation.GetString(BotsDisabled), bots);
+			options.Add(bots.Count > 0 ? TranslationProvider.GetString(Bots) : TranslationProvider.GetString(BotsDisabled), bots);
 
 			ScrollItemWidget SetupItem(SlotDropDownOption o, ScrollItemWidget itemTemplate)
 			{
@@ -438,8 +438,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				WidgetUtils.TruncateText(name, slot.Bounds.Width - slot.Bounds.Height - slot.LeftMargin - slot.RightMargin,
 				Game.Renderer.Fonts[slot.Font]));
 
-			var closed = modData.Translation.GetString(Closed);
-			var open = modData.Translation.GetString(Open);
+			var closed = TranslationProvider.GetString(Closed);
+			var open = TranslationProvider.GetString(Open);
 			slot.GetText = () => truncated.Update(c != null ? c.Name : s.Closed ? closed : open);
 			slot.OnMouseDown = _ => ShowSlotDropDown(slot, s, c, orderManager, map, modData);
 
@@ -452,8 +452,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var name = parent.Get<LabelWidget>("NAME");
 			name.IsVisible = () => true;
 			name.GetText = () => c != null ? c.Name : s.Closed
-				? modData.Translation.GetString(Closed)
-				: modData.Translation.GetString(Open);
+				? TranslationProvider.GetString(Closed)
+				: TranslationProvider.GetString(Open);
 
 			// Ensure Slot selector (if present) is hidden
 			HideChildWidget(parent, "SLOT_OPTIONS");

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return map.Status == MapStatus.Available && isPlayable;
 				};
 
-				SetupWidgets(available, modData, getMap, onMouseDown, getSpawnOccupants, getDisabledSpawnPoints, showUnoccupiedSpawnpoints);
+				SetupWidgets(available, getMap, onMouseDown, getSpawnOccupants, getDisabledSpawnPoints, showUnoccupiedSpawnpoints);
 			}
 
 			var invalid = widget.GetOrNull("MAP_INVALID");
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return map.Status == MapStatus.Available && (serverStatus & Session.MapStatus.Incompatible) != 0;
 				};
 
-				SetupWidgets(invalid, modData, getMap, onMouseDown, getSpawnOccupants, getDisabledSpawnPoints, showUnoccupiedSpawnpoints);
+				SetupWidgets(invalid, getMap, onMouseDown, getSpawnOccupants, getDisabledSpawnPoints, showUnoccupiedSpawnpoints);
 			}
 
 			var validating = widget.GetOrNull("MAP_VALIDATING");
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return map.Status == MapStatus.Available && (serverStatus & Session.MapStatus.Validating) != 0;
 				};
 
-				SetupWidgets(validating, modData, getMap, onMouseDown, getSpawnOccupants, getDisabledSpawnPoints, showUnoccupiedSpawnpoints);
+				SetupWidgets(validating, getMap, onMouseDown, getSpawnOccupants, getDisabledSpawnPoints, showUnoccupiedSpawnpoints);
 			}
 
 			var download = widget.GetOrNull("MAP_DOWNLOADABLE");
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				download.IsVisible = () => getMap().Map.Status == MapStatus.DownloadAvailable;
 
-				SetupWidgets(download, modData, getMap, onMouseDown, getSpawnOccupants, getDisabledSpawnPoints, showUnoccupiedSpawnpoints);
+				SetupWidgets(download, getMap, onMouseDown, getSpawnOccupants, getDisabledSpawnPoints, showUnoccupiedSpawnpoints);
 
 				var install = download.GetOrNull<ButtonWidget>("MAP_INSTALL");
 				if (install != null)
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return map.Status != MapStatus.Available && map.Status != MapStatus.DownloadAvailable;
 				};
 
-				SetupWidgets(progress, modData, getMap, onMouseDown, getSpawnOccupants, getDisabledSpawnPoints, showUnoccupiedSpawnpoints);
+				SetupWidgets(progress, getMap, onMouseDown, getSpawnOccupants, getDisabledSpawnPoints, showUnoccupiedSpawnpoints);
 
 				var statusSearching = progress.GetOrNull("MAP_STATUS_SEARCHING");
 				if (statusSearching != null)
@@ -152,13 +152,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						var (map, _) = getMap();
 						if (map.DownloadBytes == 0)
-							return modData.Translation.GetString(Connecting);
+							return TranslationProvider.GetString(Connecting);
 
 						// Server does not provide the total file length
 						if (map.DownloadPercentage == 0)
-							modData.Translation.GetString(Downloading, Translation.Arguments("size", map.DownloadBytes / 1024));
+							TranslationProvider.GetString(Downloading, Translation.Arguments("size", map.DownloadBytes / 1024));
 
-						return modData.Translation.GetString(DownloadingPercentage, Translation.Arguments("size", map.DownloadBytes / 1024, "progress", map.DownloadPercentage));
+						return TranslationProvider.GetString(DownloadingPercentage, Translation.Arguments("size", map.DownloadBytes / 1024, "progress", map.DownloadPercentage));
 					};
 				}
 
@@ -188,8 +188,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					};
 
 					retry.GetText = () => getMap().Map.Status == MapStatus.DownloadError
-						? modData.Translation.GetString(RetryInstall)
-						: modData.Translation.GetString(RetrySearch);
+						? TranslationProvider.GetString(RetryInstall)
+						: TranslationProvider.GetString(RetrySearch);
 				}
 
 				var progressbar = progress.GetOrNull<ProgressBarWidget>("MAP_PROGRESSBAR");
@@ -211,7 +211,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 		}
 
-		static void SetupWidgets(Widget parent, ModData modData,
+		static void SetupWidgets(Widget parent,
 			Func<(MapPreview Map, Session.MapStatus Status)> getMap,
 			Action<MapPreviewWidget, MapPreview, MouseInput> onMouseDown,
 			Func<Dictionary<int, SpawnOccupant>> getSpawnOccupants,
@@ -256,7 +256,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				var font = Game.Renderer.Fonts[authorLabel.Font];
 				var author = new CachedTransform<MapPreview, string>(
-					m => WidgetUtils.TruncateText(modData.Translation.GetString(CreatedBy, Translation.Arguments("author", m.Author)), authorLabel.Bounds.Width, font));
+					m => WidgetUtils.TruncateText(TranslationProvider.GetString(CreatedBy, Translation.Arguments("author", m.Author)), authorLabel.Bounds.Width, font));
 				authorLabel.GetText = () => author.Update(getMap().Map);
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/SpawnSelectorTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/SpawnSelectorTooltipLogic.cs
@@ -47,9 +47,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var labelText = "";
 			string playerFaction = null;
 			var playerTeam = -1;
-			teamMessage = new CachedTransform<int, string>(t => modData.Translation.GetString(TeamNumber, Translation.Arguments("team", t)));
-			var disabledSpawn = modData.Translation.GetString(DisabledSpawn);
-			var availableSpawn = modData.Translation.GetString(AvailableSpawn);
+			teamMessage = new CachedTransform<int, string>(t => TranslationProvider.GetString(TeamNumber, Translation.Arguments("team", t)));
+			var disabledSpawn = TranslationProvider.GetString(DisabledSpawn);
+			var availableSpawn = TranslationProvider.GetString(AvailableSpawn);
 
 			tooltipContainer.BeforeRender = () =>
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -221,7 +221,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				newsPanel.RemoveChild(newsTemplate);
 
 				newsStatus = newsPanel.Get<LabelWidget>("NEWS_STATUS");
-				SetNewsStatus(modData.Translation.GetString(LoadingNews));
+				SetNewsStatus(TranslationProvider.GetString(LoadingNews));
 			}
 
 			Game.OnRemoteDirectConnect += OnRemoteDirectConnect;
@@ -333,7 +333,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							catch (Exception e)
 							{
 								Game.RunAfterTick(() => // run on the main thread
-									SetNewsStatus(modData.Translation.GetString(NewsRetrivalFailed, Translation.Arguments("message", e.Message))));
+									SetNewsStatus(TranslationProvider.GetString(NewsRetrivalFailed, Translation.Arguments("message", e.Message))));
 							}
 						});
 					}
@@ -404,7 +404,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 			catch (Exception ex)
 			{
-				SetNewsStatus(modData.Translation.GetString(NewsParsingFailed, Translation.Arguments("message", ex.Message)));
+				SetNewsStatus(TranslationProvider.GetString(NewsParsingFailed, Translation.Arguments("message", ex.Message)));
 			}
 
 			return null;

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -100,9 +100,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.modData = modData;
 			this.onSelect = onSelect;
 
-			allMaps = modData.Translation.GetString(AllMaps);
-			orderByPlayer = modData.Translation.GetString(OrderMapsByPlayers);
-			orderByDate = modData.Translation.GetString(OrderMapsByDate);
+			allMaps = TranslationProvider.GetString(AllMaps);
+			orderByPlayer = TranslationProvider.GetString(OrderMapsByPlayers);
+			orderByDate = TranslationProvider.GetString(OrderMapsByDate);
 
 			var approving = new Action(() =>
 			{
@@ -273,7 +273,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					var item = categories.FirstOrDefault(m => m.Category == category);
 					if (item == default((string, int)))
-						item.Category = modData.Translation.GetString(NoMatches);
+						item.Category = TranslationProvider.GetString(NoMatches);
 
 					return ShowItem(item);
 				};
@@ -363,23 +363,23 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					if (type != null)
 						details = type + " ";
 
-					details += modData.Translation.GetString(Players, Translation.Arguments("players", preview.PlayerCount));
+					details += TranslationProvider.GetString(Players, Translation.Arguments("players", preview.PlayerCount));
 					detailsWidget.GetText = () => details;
 				}
 
 				var authorWidget = item.GetOrNull<LabelWithTooltipWidget>("AUTHOR");
 				if (authorWidget != null && !string.IsNullOrEmpty(preview.Author))
-					WidgetUtils.TruncateLabelToTooltip(authorWidget, modData.Translation.GetString(CreatedBy, Translation.Arguments("author", preview.Author)));
+					WidgetUtils.TruncateLabelToTooltip(authorWidget, TranslationProvider.GetString(CreatedBy, Translation.Arguments("author", preview.Author)));
 
 				var sizeWidget = item.GetOrNull<LabelWidget>("SIZE");
 				if (sizeWidget != null)
 				{
 					var size = preview.Bounds.Width + "x" + preview.Bounds.Height;
 					var numberPlayableCells = preview.Bounds.Width * preview.Bounds.Height;
-					if (numberPlayableCells >= 120 * 120) size += " " + modData.Translation.GetString(MapSizeHuge);
-					else if (numberPlayableCells >= 90 * 90) size += " " + modData.Translation.GetString(MapSizeLarge);
-					else if (numberPlayableCells >= 60 * 60) size += " " + modData.Translation.GetString(MapSizeMedium);
-					else size += " " + modData.Translation.GetString(MapSizeSmall);
+					if (numberPlayableCells >= 120 * 120) size += " " + TranslationProvider.GetString(MapSizeHuge);
+					else if (numberPlayableCells >= 90 * 90) size += " " + TranslationProvider.GetString(MapSizeLarge);
+					else if (numberPlayableCells >= 60 * 60) size += " " + TranslationProvider.GetString(MapSizeMedium);
+					else size += " " + TranslationProvider.GetString(MapSizeSmall);
 					sizeWidget.GetText = () => size;
 				}
 
@@ -407,7 +407,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 			catch (Exception ex)
 			{
-				TextNotificationsManager.Debug(modData.Translation.GetString(MapDeletionFailed, Translation.Arguments("map", map)));
+				TextNotificationsManager.Debug(TranslationProvider.GetString(MapDeletionFailed, Translation.Arguments("map", map)));
 				Log.Write("debug", ex.ToString());
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -314,13 +314,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var speeds = modData.Manifest.Get<GameSpeeds>().Speeds;
 				gameSpeed = "default";
 
-				var speedText = new CachedTransform<string, string>(s => modData.Translation.GetString(speeds[s].Name));
+				var speedText = new CachedTransform<string, string>(s => TranslationProvider.GetString(speeds[s].Name));
 				gameSpeedButton.GetText = () => speedText.Update(gameSpeed);
 				gameSpeedButton.OnMouseDown = _ =>
 				{
 					var options = speeds.Select(s => new DropDownOption
 					{
-						Title = modData.Translation.GetString(s.Value.Name),
+						Title = TranslationProvider.GetString(s.Value.Name),
 						IsSelected = () => gameSpeed == s.Key,
 						OnClick = () => gameSpeed = s.Key
 					});

--- a/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				panel.Get<LabelWidget>("MUTE_LABEL").GetText = () =>
 				{
 					if (Game.Settings.Sound.Mute)
-						return modData.Translation.GetString(SoundMuted);
+						return TranslationProvider.GetString(SoundMuted);
 
 					return "";
 				};
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return $"{minutes:D2}:{seconds:D2} / {totalMinutes:D2}:{totalSeconds:D2}";
 			};
 
-			var noSongPlaying = modData.Translation.GetString(NoSongPlaying);
+			var noSongPlaying = TranslationProvider.GetString(NoSongPlaying);
 			var musicTitle = panel.GetOrNull<LabelWidget>("TITLE_LABEL");
 			if (musicTitle != null)
 				musicTitle.GetText = () => currentSong != null ? currentSong.Title : noSongPlaying;

--- a/OpenRA.Mods.Common/Widgets/Logic/MuteHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MuteHotkeyLogic.cs
@@ -24,14 +24,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference]
 		const string AudioUnmuted = "label-audio-unmuted";
 
-		readonly ModData modData;
-
 		[ObjectCreator.UseCtor]
 		public MuteHotkeyLogic(Widget widget, ModData modData, Dictionary<string, MiniYaml> logicArgs)
-			: base(widget, modData, "MuteAudioKey", "GLOBAL_KEYHANDLER", logicArgs)
-		{
-			this.modData = modData;
-		}
+			: base(widget, modData, "MuteAudioKey", "GLOBAL_KEYHANDLER", logicArgs) { }
 
 		protected override bool OnHotkeyActivated(KeyInput e)
 		{
@@ -40,12 +35,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (Game.Settings.Sound.Mute)
 			{
 				Game.Sound.MuteAudio();
-				TextNotificationsManager.AddFeedbackLine(modData.Translation.GetString(AudioMuted));
+				TextNotificationsManager.AddFeedbackLine(TranslationProvider.GetString(AudioMuted));
 			}
 			else
 			{
 				Game.Sound.UnmuteAudio();
-				TextNotificationsManager.AddFeedbackLine(modData.Translation.GetString(AudioUnmuted));
+				TextNotificationsManager.AddFeedbackLine(TranslationProvider.GetString(AudioUnmuted));
 			}
 
 			return true;

--- a/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
@@ -160,7 +160,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var profileWidth = 0;
 			var maxProfileWidth = widget.Bounds.Width;
-			var messageText = modData.Translation.GetString(LoadingPlayerProfile);
+			var messageText = TranslationProvider.GetString(LoadingPlayerProfile);
 			var messageWidth = messageFont.Measure(messageText).X + 2 * message.Bounds.Left;
 
 			Task.Run(async () =>
@@ -249,7 +249,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					if (profile == null)
 					{
-						messageText = modData.Translation.GetString(LoadingPlayerProfileFailed);
+						messageText = TranslationProvider.GetString(LoadingPlayerProfileFailed);
 						messageWidth = messageFont.Measure(messageText).X + 2 * message.Bounds.Left;
 						header.Bounds.Width = widget.Bounds.Width = messageWidth;
 					}

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -179,7 +179,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			});
 
 			var replayDuration = new CachedTransform<ReplayMetadata, string>(r =>
-				modData.Translation.GetString(Duration, Translation.Arguments("time", WidgetUtils.FormatTimeSeconds((int)selectedReplay.GameInfo.Duration.TotalSeconds))));
+				TranslationProvider.GetString(Duration, Translation.Arguments("time", WidgetUtils.FormatTimeSeconds((int)selectedReplay.GameInfo.Duration.TotalSeconds))));
 			panel.Get<LabelWidget>("DURATION").GetText = () => replayDuration.Update(selectedReplay);
 
 			SetupFilters();
@@ -231,8 +231,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var options = new List<(GameType GameType, string Text)>
 					{
 						(GameType.Any, ddb.GetText()),
-						(GameType.Singleplayer, modData.Translation.GetString(Singleplayer)),
-						(GameType.Multiplayer, modData.Translation.GetString(Multiplayer))
+						(GameType.Singleplayer, TranslationProvider.GetString(Singleplayer)),
+						(GameType.Multiplayer, TranslationProvider.GetString(Multiplayer))
 					};
 
 					var lookup = options.ToDictionary(kvp => kvp.GameType, kvp => kvp.Text);
@@ -264,10 +264,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var options = new List<(DateType DateType, string Text)>
 					{
 						(DateType.Any, ddb.GetText()),
-						(DateType.Today, modData.Translation.GetString(Today)),
-						(DateType.LastWeek, modData.Translation.GetString(LastWeek)),
-						(DateType.LastFortnight, modData.Translation.GetString(LastFortnight)),
-						(DateType.LastMonth, modData.Translation.GetString(LastMonth))
+						(DateType.Today, TranslationProvider.GetString(Today)),
+						(DateType.LastWeek, TranslationProvider.GetString(LastWeek)),
+						(DateType.LastFortnight, TranslationProvider.GetString(LastFortnight)),
+						(DateType.LastMonth, TranslationProvider.GetString(LastMonth))
 					};
 
 					var lookup = options.ToDictionary(kvp => kvp.DateType, kvp => kvp.Text);
@@ -300,10 +300,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var options = new List<(DurationType DurationType, string Text)>
 					{
 						(DurationType.Any, ddb.GetText()),
-						(DurationType.VeryShort, modData.Translation.GetString(ReplayDurationVeryShort)),
-						(DurationType.Short, modData.Translation.GetString(ReplayDurationShort)),
-						(DurationType.Medium, modData.Translation.GetString(ReplayDurationMedium)),
-						(DurationType.Long, modData.Translation.GetString(ReplayDurationLong))
+						(DurationType.VeryShort, TranslationProvider.GetString(ReplayDurationVeryShort)),
+						(DurationType.Short, TranslationProvider.GetString(ReplayDurationShort)),
+						(DurationType.Medium, TranslationProvider.GetString(ReplayDurationMedium)),
+						(DurationType.Long, TranslationProvider.GetString(ReplayDurationLong))
 					};
 
 					var lookup = options.ToDictionary(kvp => kvp.DurationType, kvp => kvp.Text);
@@ -337,8 +337,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var options = new List<(WinState WinState, string Text)>
 					{
 						(WinState.Undefined, ddb.GetText()),
-						(WinState.Lost, modData.Translation.GetString(Defeat)),
-						(WinState.Won, modData.Translation.GetString(Victory))
+						(WinState.Lost, TranslationProvider.GetString(Defeat)),
+						(WinState.Won, TranslationProvider.GetString(Victory))
 					};
 
 					var lookup = options.ToDictionary(kvp => kvp.WinState, kvp => kvp.Text);
@@ -580,7 +580,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 			catch (Exception ex)
 			{
-				TextNotificationsManager.Debug(modData.Translation.GetString(ReplayDeletionFailed, Translation.Arguments("file", replay.FilePath)));
+				TextNotificationsManager.Debug(TranslationProvider.GetString(ReplayDeletionFailed, Translation.Arguments("file", replay.FilePath)));
 				Log.Write("debug", ex.ToString());
 				return;
 			}
@@ -716,9 +716,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var noTeams = players.Count() == 1;
 				foreach (var p in players)
 				{
-					var label = noTeams ? modData.Translation.GetString(Players) : p.Key > 0
-						? modData.Translation.GetString(TeamNumber, Translation.Arguments("team", p.Key))
-						: modData.Translation.GetString(NoTeam);
+					var label = noTeams ? TranslationProvider.GetString(Players) : p.Key > 0
+						? TranslationProvider.GetString(TeamNumber, Translation.Arguments("team", p.Key))
+						: TranslationProvider.GetString(NoTeam);
 
 					teams.Add(label, p);
 				}

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -189,13 +189,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			if (advertiseOnline)
 			{
-				noticesLabelA.Text = modData.Translation.GetString(InternetServerNatA) + " ";
+				noticesLabelA.Text = TranslationProvider.GetString(InternetServerNatA) + " ";
 				var aWidth = Game.Renderer.Fonts[noticesLabelA.Font].Measure(noticesLabelA.Text).X;
 				noticesLabelA.Bounds.Width = aWidth;
 
-				noticesLabelB.Text = Nat.Status == NatStatus.Enabled ? modData.Translation.GetString(InternetServerNatBenabled) :
-					Nat.Status == NatStatus.NotSupported ? modData.Translation.GetString(InternetServerNatBnotSupported)
-						: modData.Translation.GetString(InternetServerNatBdisabled);
+				noticesLabelB.Text = Nat.Status == NatStatus.Enabled ? TranslationProvider.GetString(InternetServerNatBenabled) :
+					Nat.Status == NatStatus.NotSupported ? TranslationProvider.GetString(InternetServerNatBnotSupported)
+						: TranslationProvider.GetString(InternetServerNatBdisabled);
 
 				noticesLabelB.TextColor = Nat.Status == NatStatus.Enabled ? ChromeMetrics.Get<Color>("NoticeSuccessColor") :
 					Nat.Status == NatStatus.NotSupported ? ChromeMetrics.Get<Color>("NoticeErrorColor") :
@@ -206,13 +206,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				noticesLabelB.Bounds.Width = bWidth;
 				noticesLabelB.Visible = true;
 
-				noticesLabelC.Text = modData.Translation.GetString(InternetServerNatC);
+				noticesLabelC.Text = TranslationProvider.GetString(InternetServerNatC);
 				noticesLabelC.Bounds.X = noticesLabelB.Bounds.Right;
 				noticesLabelC.Visible = true;
 			}
 			else
 			{
-				noticesLabelA.Text = modData.Translation.GetString(LocalServer);
+				noticesLabelA.Text = TranslationProvider.GetString(LocalServer);
 				noticesLabelB.Visible = false;
 				noticesLabelC.Visible = false;
 			}
@@ -248,13 +248,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 			catch (System.Net.Sockets.SocketException e)
 			{
-				var message = modData.Translation.GetString(ServerCreationFailedPrompt, Translation.Arguments("port", Game.Settings.Server.ListenPort));
+				var message = TranslationProvider.GetString(ServerCreationFailedPrompt, Translation.Arguments("port", Game.Settings.Server.ListenPort));
 
 				// AddressAlreadyInUse (WSAEADDRINUSE)
 				if (e.ErrorCode == 10048)
-					message += "\n" + modData.Translation.GetString(ServerCreationFailedPortUsed);
+					message += "\n" + TranslationProvider.GetString(ServerCreationFailedPortUsed);
 				else
-					message += $"\n" + modData.Translation.GetString(ServerCreationFailedError,
+					message += $"\n" + TranslationProvider.GetString(ServerCreationFailedError,
 						Translation.Arguments("message", e.Message, "code", e.ErrorCode));
 
 				ConfirmationDialogs.ButtonPrompt(modData, ServerCreationFailedTitle, message,

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -145,8 +145,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			switch (searchStatus)
 			{
-				case SearchStatus.Failed: return modData.Translation.GetString(SearchStatusFailed);
-				case SearchStatus.NoGames: return modData.Translation.GetString(SearchStatusNoGames);
+				case SearchStatus.Failed: return TranslationProvider.GetString(SearchStatusFailed);
+				case SearchStatus.NoGames: return TranslationProvider.GetString(SearchStatusNoGames);
 				default: return "";
 			}
 		}
@@ -157,22 +157,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.modData = modData;
 			this.onJoin = onJoin;
 
-			playing = modData.Translation.GetString(Playing);
-			waiting = modData.Translation.GetString(Waiting);
+			playing = TranslationProvider.GetString(Playing);
+			waiting = TranslationProvider.GetString(Waiting);
 
-			noServerSelected = modData.Translation.GetString(NoServerSelected);
-			mapStatusSearching = modData.Translation.GetString(MapStatusSearching);
-			mapClassificationUnknown = modData.Translation.GetString(MapClassificationUnknown);
+			noServerSelected = TranslationProvider.GetString(NoServerSelected);
+			mapStatusSearching = TranslationProvider.GetString(MapStatusSearching);
+			mapClassificationUnknown = TranslationProvider.GetString(MapClassificationUnknown);
 
-			players = new CachedTransform<int, string>(i => modData.Translation.GetString(PlayersLabel, Translation.Arguments("players", i)));
-			bots = new CachedTransform<int, string>(i => modData.Translation.GetString(BotsLabel, Translation.Arguments("bots", i)));
-			spectators = new CachedTransform<int, string>(i => modData.Translation.GetString(SpectatorsLabel, Translation.Arguments("spectators", i)));
+			players = new CachedTransform<int, string>(i => TranslationProvider.GetString(PlayersLabel, Translation.Arguments("players", i)));
+			bots = new CachedTransform<int, string>(i => TranslationProvider.GetString(BotsLabel, Translation.Arguments("bots", i)));
+			spectators = new CachedTransform<int, string>(i => TranslationProvider.GetString(SpectatorsLabel, Translation.Arguments("spectators", i)));
 
-			minutes = new CachedTransform<double, string>(i => modData.Translation.GetString(InProgress, Translation.Arguments("minutes", i)));
-			passwordProtected = modData.Translation.GetString(PasswordProtected);
-			waitingForPlayers = modData.Translation.GetString(WaitingForPlayers);
-			serverShuttingDown = modData.Translation.GetString(ServerShuttingDown);
-			unknownServerState = modData.Translation.GetString(UnknownServerState);
+			minutes = new CachedTransform<double, string>(i => TranslationProvider.GetString(InProgress, Translation.Arguments("minutes", i)));
+			passwordProtected = TranslationProvider.GetString(PasswordProtected);
+			waitingForPlayers = TranslationProvider.GetString(WaitingForPlayers);
+			serverShuttingDown = TranslationProvider.GetString(ServerShuttingDown);
+			unknownServerState = TranslationProvider.GetString(UnknownServerState);
 
 			services = modData.Manifest.Get<WebServices>();
 
@@ -318,7 +318,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var playersLabel = widget.GetOrNull<LabelWidget>("PLAYER_COUNT");
 			if (playersLabel != null)
 			{
-				var playersText = new CachedTransform<int, string>(p => modData.Translation.GetString(PlayersOnline, Translation.Arguments("players", p)));
+				var playersText = new CachedTransform<int, string>(p => TranslationProvider.GetString(PlayersOnline, Translation.Arguments("players", p)));
 				playersLabel.IsVisible = () => playerCount != 0;
 				playersLabel.GetText = () => playersText.Update(playerCount);
 			}
@@ -578,14 +578,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var noTeams = players.Count() == 1;
 			foreach (var p in players)
 			{
-				var label = noTeams ? modData.Translation.GetString(Players) : p.Key > 0
-					? modData.Translation.GetString(TeamNumber, Translation.Arguments("team", p.Key))
-					: modData.Translation.GetString(NoTeam);
+				var label = noTeams ? TranslationProvider.GetString(Players) : p.Key > 0
+					? TranslationProvider.GetString(TeamNumber, Translation.Arguments("team", p.Key))
+					: TranslationProvider.GetString(NoTeam);
 				teams.Add(label, p);
 			}
 
 			if (server.Clients.Any(c => c.IsSpectator))
-				teams.Add(modData.Translation.GetString(Spectators), server.Clients.Where(c => c.IsSpectator));
+				teams.Add(TranslationProvider.GetString(Spectators), server.Clients.Where(c => c.IsSpectator));
 
 			var factionInfo = modData.DefaultRules.Actors[SystemActors.World].TraitInfos<FactionInfo>();
 			foreach (var kv in teams)
@@ -761,7 +761,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 								if (game.Clients.Length > 10)
 									displayClients = displayClients
 										.Take(9)
-										.Append(modData.Translation.GetString(OtherPlayers, Translation.Arguments("players", game.Clients.Length - 9)));
+										.Append(TranslationProvider.GetString(OtherPlayers, Translation.Arguments("players", game.Clients.Length - 9)));
 
 								var tooltip = displayClients.JoinWith("\n");
 								players.GetTooltipText = () => tooltip;

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -101,17 +101,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.modData = modData;
 			viewportSizes = modData.Manifest.Get<WorldViewportSizes>();
 
-			legacyFullscreen = modData.Translation.GetString(LegacyFullscreen);
-			fullscreen = modData.Translation.GetString(Fullscreen);
+			legacyFullscreen = TranslationProvider.GetString(LegacyFullscreen);
+			fullscreen = TranslationProvider.GetString(Fullscreen);
 
 			registerPanel(panelID, label, InitPanel, ResetPanel);
 
-			showOnDamage = modData.Translation.GetString(ShowOnDamage);
-			alwaysShow = modData.Translation.GetString(AlwaysShow);
+			showOnDamage = TranslationProvider.GetString(ShowOnDamage);
+			alwaysShow = TranslationProvider.GetString(AlwaysShow);
 
-			automatic = modData.Translation.GetString(Automatic);
-			manual = modData.Translation.GetString(Manual);
-			disabled = modData.Translation.GetString(Disabled);
+			automatic = TranslationProvider.GetString(Automatic);
+			manual = TranslationProvider.GetString(Manual);
+			disabled = TranslationProvider.GetString(Disabled);
 		}
 
 		public static string GetViewportSizeName(ModData modData, WorldViewport worldViewport)
@@ -119,13 +119,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			switch (worldViewport)
 			{
 				case WorldViewport.Close:
-					return modData.Translation.GetString(Close);
+					return TranslationProvider.GetString(Close);
 				case WorldViewport.Medium:
-					return modData.Translation.GetString(Medium);
+					return TranslationProvider.GetString(Medium);
 				case WorldViewport.Far:
-					return modData.Translation.GetString(Far);
+					return TranslationProvider.GetString(Far);
 				case WorldViewport.Native:
-					return modData.Translation.GetString(Furthest);
+					return TranslationProvider.GetString(Furthest);
 				default:
 					return "";
 			}
@@ -149,14 +149,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SettingsUtils.BindCheckboxPref(panel, "HIDE_REPLAY_CHAT_CHECKBOX", gs, "HideReplayChat");
 
 			var windowModeDropdown = panel.Get<DropDownButtonWidget>("MODE_DROPDOWN");
-			windowModeDropdown.OnMouseDown = _ => ShowWindowModeDropdown(modData, windowModeDropdown, ds, scrollPanel);
+			windowModeDropdown.OnMouseDown = _ => ShowWindowModeDropdown(windowModeDropdown, ds, scrollPanel);
 			windowModeDropdown.GetText = () => ds.Mode == WindowMode.Windowed
-				? modData.Translation.GetString(Windowed)
+				? TranslationProvider.GetString(Windowed)
 				: ds.Mode == WindowMode.Fullscreen ? legacyFullscreen : fullscreen;
 
 			var displaySelectionDropDown = panel.Get<DropDownButtonWidget>("DISPLAY_SELECTION_DROPDOWN");
 			displaySelectionDropDown.OnMouseDown = _ => ShowDisplaySelectionDropdown(displaySelectionDropDown, ds);
-			var displaySelectionLabel = new CachedTransform<int, string>(i => modData.Translation.GetString(Display, Translation.Arguments("number", i + 1)));
+			var displaySelectionLabel = new CachedTransform<int, string>(i => TranslationProvider.GetString(Display, Translation.Arguments("number", i + 1)));
 			displaySelectionDropDown.GetText = () => displaySelectionLabel.Update(ds.VideoDisplay);
 			displaySelectionDropDown.IsDisabled = () => Game.Renderer.DisplayCount < 2;
 
@@ -168,15 +168,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			glProfileDropdown.IsDisabled = () => disableProfile;
 
 			var statusBarsDropDown = panel.Get<DropDownButtonWidget>("STATUS_BAR_DROPDOWN");
-			statusBarsDropDown.OnMouseDown = _ => ShowStatusBarsDropdown(modData, statusBarsDropDown, gs);
+			statusBarsDropDown.OnMouseDown = _ => ShowStatusBarsDropdown(statusBarsDropDown, gs);
 			statusBarsDropDown.GetText = () => gs.StatusBars == StatusBarsType.Standard
-				? modData.Translation.GetString(Standard)
+				? TranslationProvider.GetString(Standard)
 				: gs.StatusBars == StatusBarsType.DamageShow
 					? showOnDamage
 					: alwaysShow;
 
 			var targetLinesDropDown = panel.Get<DropDownButtonWidget>("TARGET_LINES_DROPDOWN");
-			targetLinesDropDown.OnMouseDown = _ => ShowTargetLinesDropdown(modData, targetLinesDropDown, gs);
+			targetLinesDropDown.OnMouseDown = _ => ShowTargetLinesDropdown(targetLinesDropDown, gs);
 			targetLinesDropDown.GetText = () => gs.TargetLines == TargetLinesType.Automatic
 				? automatic
 				: gs.TargetLines == TargetLinesType.Manual
@@ -332,13 +332,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 		}
 
-		static void ShowWindowModeDropdown(ModData modData, DropDownButtonWidget dropdown, GraphicSettings s, ScrollPanelWidget scrollPanel)
+		static void ShowWindowModeDropdown(DropDownButtonWidget dropdown, GraphicSettings s, ScrollPanelWidget scrollPanel)
 		{
 			var options = new Dictionary<string, WindowMode>()
 			{
-				{ modData.Translation.GetString(Fullscreen), WindowMode.PseudoFullscreen },
-				{ modData.Translation.GetString(LegacyFullscreen), WindowMode.Fullscreen },
-				{ modData.Translation.GetString(Windowed), WindowMode.Windowed },
+				{ TranslationProvider.GetString(Fullscreen), WindowMode.PseudoFullscreen },
+				{ TranslationProvider.GetString(LegacyFullscreen), WindowMode.Fullscreen },
+				{ TranslationProvider.GetString(Windowed), WindowMode.Windowed },
 			};
 
 			ScrollItemWidget SetupItem(string o, ScrollItemWidget itemTemplate)
@@ -381,13 +381,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 		}
 
-		static void ShowStatusBarsDropdown(ModData modData, DropDownButtonWidget dropdown, GameSettings s)
+		static void ShowStatusBarsDropdown(DropDownButtonWidget dropdown, GameSettings s)
 		{
 			var options = new Dictionary<string, StatusBarsType>()
 			{
-				{ modData.Translation.GetString(Standard), StatusBarsType.Standard },
-				{ modData.Translation.GetString(ShowOnDamage), StatusBarsType.DamageShow },
-				{ modData.Translation.GetString(AlwaysShow), StatusBarsType.AlwaysShow },
+				{ TranslationProvider.GetString(Standard), StatusBarsType.Standard },
+				{ TranslationProvider.GetString(ShowOnDamage), StatusBarsType.DamageShow },
+				{ TranslationProvider.GetString(AlwaysShow), StatusBarsType.AlwaysShow },
 			};
 
 			ScrollItemWidget SetupItem(string o, ScrollItemWidget itemTemplate)
@@ -436,13 +436,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, profiles, SetupItem);
 		}
 
-		static void ShowTargetLinesDropdown(ModData modData, DropDownButtonWidget dropdown, GameSettings s)
+		static void ShowTargetLinesDropdown(DropDownButtonWidget dropdown, GameSettings s)
 		{
 			var options = new Dictionary<string, TargetLinesType>()
 			{
-				{ modData.Translation.GetString(Automatic), TargetLinesType.Automatic },
-				{ modData.Translation.GetString(Manual), TargetLinesType.Manual },
-				{ modData.Translation.GetString(Disabled), TargetLinesType.Disabled },
+				{ TranslationProvider.GetString(Automatic), TargetLinesType.Automatic },
+				{ TranslationProvider.GetString(Manual), TargetLinesType.Manual },
+				{ TranslationProvider.GetString(Disabled), TargetLinesType.Disabled },
 			};
 
 			ScrollItemWidget SetupItem(string o, ScrollItemWidget itemTemplate)

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/InputSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/InputSettingsLogic.cs
@@ -55,15 +55,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly string classic;
 		readonly string modern;
 
-		readonly ModData modData;
-
 		[ObjectCreator.UseCtor]
-		public InputSettingsLogic(Action<string, string, Func<Widget, Func<bool>>, Func<Widget, Action>> registerPanel, string panelID, string label, ModData modData)
+		public InputSettingsLogic(Action<string, string, Func<Widget, Func<bool>>, Func<Widget, Action>> registerPanel, string panelID, string label)
 		{
-			this.modData = modData;
-
-			classic = modData.Translation.GetString(Classic);
-			modern = modData.Translation.GetString(Modern);
+			classic = TranslationProvider.GetString(Classic);
+			modern = TranslationProvider.GetString(Modern);
 
 			registerPanel(panelID, label, InitPanel, ResetPanel);
 		}
@@ -81,11 +77,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SettingsUtils.BindSliderPref(panel, "UI_SCROLLSPEED_SLIDER", gs, "UIScrollSpeed");
 
 			var mouseControlDropdown = panel.Get<DropDownButtonWidget>("MOUSE_CONTROL_DROPDOWN");
-			mouseControlDropdown.OnMouseDown = _ => ShowMouseControlDropdown(modData, mouseControlDropdown, gs);
+			mouseControlDropdown.OnMouseDown = _ => ShowMouseControlDropdown(mouseControlDropdown, gs);
 			mouseControlDropdown.GetText = () => gs.UseClassicMouseStyle ? classic : modern;
 
 			var mouseScrollDropdown = panel.Get<DropDownButtonWidget>("MOUSE_SCROLL_TYPE_DROPDOWN");
-			mouseScrollDropdown.OnMouseDown = _ => ShowMouseScrollDropdown(modData, mouseScrollDropdown, gs);
+			mouseScrollDropdown.OnMouseDown = _ => ShowMouseScrollDropdown(mouseScrollDropdown, gs);
 			mouseScrollDropdown.GetText = () => gs.MouseScroll.ToString();
 
 			var mouseControlDescClassic = panel.Get("MOUSE_CONTROL_DESC_CLASSIC");
@@ -130,7 +126,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			var zoomModifierDropdown = panel.Get<DropDownButtonWidget>("ZOOM_MODIFIER");
-			zoomModifierDropdown.OnMouseDown = _ => ShowZoomModifierDropdown(modData, zoomModifierDropdown, gs);
+			zoomModifierDropdown.OnMouseDown = _ => ShowZoomModifierDropdown(zoomModifierDropdown, gs);
 			zoomModifierDropdown.GetText = () => gs.ZoomModifier.ToString();
 
 			SettingsUtils.AdjustSettingsScrollPanelLayout(scrollPanel);
@@ -162,12 +158,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 		}
 
-		public static void ShowMouseControlDropdown(ModData modData, DropDownButtonWidget dropdown, GameSettings s)
+		public static void ShowMouseControlDropdown(DropDownButtonWidget dropdown, GameSettings s)
 		{
 			var options = new Dictionary<string, bool>()
 			{
-				{ modData.Translation.GetString(Classic), true },
-				{ modData.Translation.GetString(Modern), false },
+				{ TranslationProvider.GetString(Classic), true },
+				{ TranslationProvider.GetString(Modern), false },
 			};
 
 			ScrollItemWidget SetupItem(string o, ScrollItemWidget itemTemplate)
@@ -182,14 +178,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, SetupItem);
 		}
 
-		static void ShowMouseScrollDropdown(ModData modData, DropDownButtonWidget dropdown, GameSettings s)
+		static void ShowMouseScrollDropdown(DropDownButtonWidget dropdown, GameSettings s)
 		{
 			var options = new Dictionary<string, MouseScrollType>()
 			{
-				{ modData.Translation.GetString(Disabled), MouseScrollType.Disabled },
-				{ modData.Translation.GetString(Standard), MouseScrollType.Standard },
-				{ modData.Translation.GetString(Inverted), MouseScrollType.Inverted },
-				{ modData.Translation.GetString(Joystick), MouseScrollType.Joystick },
+				{ TranslationProvider.GetString(Disabled), MouseScrollType.Disabled },
+				{ TranslationProvider.GetString(Standard), MouseScrollType.Standard },
+				{ TranslationProvider.GetString(Inverted), MouseScrollType.Inverted },
+				{ TranslationProvider.GetString(Joystick), MouseScrollType.Joystick },
 			};
 
 			ScrollItemWidget SetupItem(string o, ScrollItemWidget itemTemplate)
@@ -204,15 +200,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, SetupItem);
 		}
 
-		static void ShowZoomModifierDropdown(ModData modData, DropDownButtonWidget dropdown, GameSettings s)
+		static void ShowZoomModifierDropdown(DropDownButtonWidget dropdown, GameSettings s)
 		{
 			var options = new Dictionary<string, Modifiers>()
 			{
-				{ modData.Translation.GetString(Alt), Modifiers.Alt },
-				{ modData.Translation.GetString(Ctrl), Modifiers.Ctrl },
-				{ modData.Translation.GetString(Meta), Modifiers.Meta },
-				{ modData.Translation.GetString(Shift), Modifiers.Shift },
-				{ modData.Translation.GetString(None), Modifiers.None }
+				{ TranslationProvider.GetString(Alt), Modifiers.Alt },
+				{ TranslationProvider.GetString(Ctrl), Modifiers.Ctrl },
+				{ TranslationProvider.GetString(Meta), Modifiers.Meta },
+				{ TranslationProvider.GetString(Shift), Modifiers.Shift },
+				{ TranslationProvider.GetString(None), Modifiers.None }
 			};
 
 			ScrollItemWidget SetupItem(string o, ScrollItemWidget itemTemplate)

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -145,6 +145,7 @@ ChromeLayout:
 
 Translations:
 	common|languages/en.ftl
+	common|languages/rules/en.ftl
 	cnc|languages/rules/en.ftl
 
 Voices:

--- a/mods/common/languages/en.ftl
+++ b/mods/common/languages/en.ftl
@@ -690,48 +690,7 @@ description-path-debug-overlay = toggles a visualization of path searching.
 ## TerrainGeometryOverlay
 description-terrain-geometry-overlay = toggles the terrain geometry overlay.
 
-## Shroud
-checkbox-fog-of-war =
-    .label = Fog of War
-    .description = Line of sight is required to view enemy forces
-
-checkbox-explored-map =
-    .label = Explored Map
-    .description = Initial map shroud is revealed
-
-## DeveloperMode
-checkbox-debug-menu =
-    .label = Debug Menu
-    .description = Enables cheats and developer commands
-
-## CrateSpawner
-checkbox-crates =
-    .label = Crates
-    .description = Collect crates with units to receive random bonuses or penalties
-
-## MapBuildRadius
-checkbox-ally-build-radius =
-    .label = Build off Allies
-    .description = Allow allies to place structures inside your build area
-
-checkbox-build-radius =
-    .label = Limit Build Area
-    .description = Limits structure placement to areas around Construction Yards
-
-## MapOptions
-checkbox-short-game =
-    .label = Short Game
-    .description = Players are defeated when their bases are destroyed
-
-dropdown-tech-level =
-    .label = Tech Level
-    .description = The units and abilities that players can use
-
 ## MapOptions, MissionBrowserLogic
-dropdown-game-speed =
-    .label = Game Speed
-    .description = The rate at which time passes
-
 options-game-speed =
     .slowest = Slowest
     .slower = Slower
@@ -740,21 +699,7 @@ options-game-speed =
     .faster = Faster
     .fastest = Fastest
 
-## MapStartingLocations
-checkbox-separate-team-spawns =
-    .label = Separate Team Spawns
-    .description = Players without assigned spawn points will start as far as possible from enemy players
-
-## SpawnStartingUnits
-dropdown-starting-units =
-    .label = Starting Units
-    .description = The units that players start the game with
-
 ## TimeLimitManager
-dropdown-time-limit =
-    .label = Time Limit
-    .description = Player or team with the highest score after this time wins
-
 options-time-limit =
     .no-limit = No limit
     .options =

--- a/mods/common/languages/rules/en.ftl
+++ b/mods/common/languages/rules/en.ftl
@@ -1,0 +1,56 @@
+## Shroud
+checkbox-fog-of-war =
+    .label = Fog of War
+    .description = Line of sight is required to view enemy forces
+
+checkbox-explored-map =
+    .label = Explored Map
+    .description = Initial map shroud is revealed
+
+## DeveloperMode
+checkbox-debug-menu =
+    .label = Debug Menu
+    .description = Enables cheats and developer commands
+
+## CrateSpawner
+checkbox-crates =
+    .label = Crates
+    .description = Collect crates with units to receive random bonuses or penalties
+
+## MapBuildRadius
+checkbox-ally-build-radius =
+    .label = Build off Allies
+    .description = Allow allies to place structures inside your build area
+
+checkbox-build-radius =
+    .label = Limit Build Area
+    .description = Limits structure placement to areas around Construction Yards
+
+## MapOptions
+checkbox-short-game =
+    .label = Short Game
+    .description = Players are defeated when their bases are destroyed
+
+dropdown-tech-level =
+    .label = Tech Level
+    .description = The units and abilities that players can use
+
+## MapOptions
+dropdown-game-speed =
+    .label = Game Speed
+    .description = The rate at which time passes
+
+## MapStartingLocations
+checkbox-separate-team-spawns =
+    .label = Separate Team Spawns
+    .description = Players without assigned spawn points will start as far as possible from enemy players
+
+## SpawnStartingUnits
+dropdown-starting-units =
+    .label = Starting Units
+    .description = The units that players start the game with
+
+## TimeLimitManager
+dropdown-time-limit =
+    .label = Time Limit
+    .description = Player or team with the highest score after this time wins

--- a/mods/common/scripts/utils.lua
+++ b/mods/common/scripts/utils.lua
@@ -38,10 +38,7 @@ end
 ---@param description string key of the translation string
 ---@return number id used to query for the objective later
 AddPrimaryObjective = function(player, description)
-	local translation = description
-	if translation ~= "" then
-		translation = UserInterface.Translate(description)
-	end
+	local translation = UserInterface.Translate(description)
 
 	Media.DisplayMessageToPlayer(player, translation, UserInterface.Translate("new-primary-objective"))
 	return player.AddObjective(translation, UserInterface.Translate("primary"), true)
@@ -52,10 +49,7 @@ end
 ---@param description string key of the translation string
 ---@return number id used to query for the objective later
 AddSecondaryObjective = function(player, description)
-	local translation = description
-	if translation ~= "" then
-		translation = UserInterface.Translate(description)
-	end
+	local translation = UserInterface.Translate(description)
 
 	Media.DisplayMessageToPlayer(player, translation, UserInterface.Translate("new-secondary-objective"))
 	return player.AddObjective(translation, UserInterface.Translate("secondary"), false)

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -125,6 +125,7 @@ ChromeLayout:
 
 Translations:
 	common|languages/en.ftl
+	common|languages/rules/en.ftl
 	d2k|languages/rules/en.ftl
 
 Weapons:

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -141,6 +141,7 @@ ChromeLayout:
 
 Translations:
 	common|languages/en.ftl
+	common|languages/rules/en.ftl
 	ra|languages/rules/en.ftl
 
 Weapons:

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -186,6 +186,7 @@ ChromeLayout:
 
 Translations:
 	common|languages/en.ftl
+	common|languages/rules/en.ftl
 	ts|languages/rules/en.ftl
 
 Voices:


### PR DESCRIPTION
Split from #20725
Supersedes #20779
Reverts #20677 and partly reverts #20638

* Translations will now always be accessible with the new `static TranslationProvider`. There won't be a need to have a reference of moddata nor map. It also saves user the trouble of accidentally using the wrong scope.
* Mod level keys will no longer be overwritable by map level keys, I've even added a lint test to report duplicates. This fixes the issue of UI strings being possibly overwritten by maps.
* I've added a `MapPreview` translation scope. As MapPreviews are portable by nature they needed another method of handling. So far only LobbyCheckboxes use `MapPreview.GetLocalisedString`, but it will be used for map descriptions in the future as well.
* Lastly I'm again allowing empty translation keys. In the future we'll be often passing empty keys so it doesn't really make sense to crash.