### PR TITLE
Add missing assembly information to Windows binaries

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,8 @@
     <ExternalConsole>false</ExternalConsole>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <Nullable>disable</Nullable>
+    <Product>OpenRA</Product>
+    <Copyright>Copyright (c) The OpenRA Developers and Contributors</Copyright>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/packaging/functions.sh
+++ b/packaging/functions.sh
@@ -154,9 +154,16 @@ install_windows_launcher() (
 	LAUNCHER_NAME="${5}"
 	MOD_NAME="${6}"
 	FAQ_URL="${7}"
+	VERSION="${8}"
 
 	rm -rf "${SRC_PATH}/OpenRA.WindowsLauncher/obj" || :
-	dotnet publish "${SRC_PATH}/OpenRA.WindowsLauncher/OpenRA.WindowsLauncher.csproj" -c Release -r "${TARGETPLATFORM}" -p:LauncherName="${LAUNCHER_NAME}" -p:TargetPlatform="${TARGETPLATFORM}" -p:ModID="${MOD_ID}" -p:DisplayName="${MOD_NAME}" -p:FaqUrl="${FAQ_URL}" -p:PublishDir="${DEST_PATH}" --self-contained true
+
+	# See https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-publish for details.
+	# Unfortunately there doesn't seem to be a way to set FileDescription and it uses the value of -p:LauncherName.
+	# -p:Product sets the "Product name" field.
+	# -p:InformationalVersion seems to set the "Product version" field.
+	# -p:DisplayName doesn't seem to have a visible effect?
+	dotnet publish "${SRC_PATH}/OpenRA.WindowsLauncher/OpenRA.WindowsLauncher.csproj" -c Release -r "${TARGETPLATFORM}" -p:LauncherName="${LAUNCHER_NAME}",TargetPlatform="${TARGETPLATFORM}",ModID="${MOD_ID}",PublishDir="${DEST_PATH}",FaqUrl="${FAQ_URL}",InformationalVersion="${VERSION}" --self-contained true
 
 	# NET 6 is unable to customize the application host for windows when compiling from Linux,
 	# so we must patch the properties we need in the PE header.

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -47,9 +47,20 @@ function makelauncher()
 	MOD_ID="${3}"
 	PLATFORM="${4}"
 
+	TAG_TYPE="${TAG%%-*}"
+	TAG_VERSION="${TAG#*-}"
+	BACKWARDS_TAG="${TAG_VERSION}-${TAG_TYPE}"
+
 	convert "${ARTWORK_DIR}/${MOD_ID}_16x16.png" "${ARTWORK_DIR}/${MOD_ID}_24x24.png" "${ARTWORK_DIR}/${MOD_ID}_32x32.png" "${ARTWORK_DIR}/${MOD_ID}_48x48.png" "${ARTWORK_DIR}/${MOD_ID}_256x256.png" "${BUILTDIR}/${MOD_ID}.ico"
 	install_windows_launcher "${SRCDIR}" "${BUILTDIR}" "win-${PLATFORM}" "${MOD_ID}" "${LAUNCHER_NAME}" "${DISPLAY_NAME}" "${FAQ_URL}" "${TAG}"
 
+	# Use rcedit to patch the generated EXE with missing assembly/PortableExecutable information because .NET 6 ignores that when building on Linux.
+	# Using a backwards version tag because rcedit is unable to set versions starting with a letter.
+	wine64 rcedit-x64.exe "${BUILTDIR}/${LAUNCHER_NAME}.exe" --set-product-version "${BACKWARDS_TAG}"
+	wine64 rcedit-x64.exe "${BUILTDIR}/${LAUNCHER_NAME}.exe" --set-version-string "ProductName" "OpenRA"
+	wine64 rcedit-x64.exe "${BUILTDIR}/${LAUNCHER_NAME}.exe" --set-version-string "CompanyName" "The OpenRA team"
+	wine64 rcedit-x64.exe "${BUILTDIR}/${LAUNCHER_NAME}.exe" --set-version-string "FileDescription" "${LAUNCHER_NAME} mod for OpenRA"
+	wine64 rcedit-x64.exe "${BUILTDIR}/${LAUNCHER_NAME}.exe" --set-version-string "LegalCopyright" "Copyright (c) The OpenRA Developers and Contributors"
 	wine64 rcedit-x64.exe "${BUILTDIR}/${LAUNCHER_NAME}.exe" --set-icon "${BUILTDIR}/${MOD_ID}.ico"
 }
 

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -48,7 +48,7 @@ function makelauncher()
 	PLATFORM="${4}"
 
 	convert "${ARTWORK_DIR}/${MOD_ID}_16x16.png" "${ARTWORK_DIR}/${MOD_ID}_24x24.png" "${ARTWORK_DIR}/${MOD_ID}_32x32.png" "${ARTWORK_DIR}/${MOD_ID}_48x48.png" "${ARTWORK_DIR}/${MOD_ID}_256x256.png" "${BUILTDIR}/${MOD_ID}.ico"
-	install_windows_launcher "${SRCDIR}" "${BUILTDIR}" "win-${PLATFORM}" "${MOD_ID}" "${LAUNCHER_NAME}" "${DISPLAY_NAME}" "${FAQ_URL}"
+	install_windows_launcher "${SRCDIR}" "${BUILTDIR}" "win-${PLATFORM}" "${MOD_ID}" "${LAUNCHER_NAME}" "${DISPLAY_NAME}" "${FAQ_URL}" "${TAG}"
 
 	wine64 rcedit-x64.exe "${BUILTDIR}/${LAUNCHER_NAME}.exe" --set-icon "${BUILTDIR}/${MOD_ID}.ico"
 }


### PR DESCRIPTION
The commit messages should explain what is going on.
A combination of the 3 produced the best result I could get while building on Linux.

Fixes #20713 (as much as possible).
Supersedes #20754.

Here is the devtest: https://github.com/penev92/OpenRA/releases/tag/devtest-20230414

<details>
  <summary>For comparison...</summary>
  
- Release-20210321:
![image](https://user-images.githubusercontent.com/7137365/232110051-fa2db755-8316-4a9c-9273-7e5e5437d906.png)

- Release-20230225:
![image](https://user-images.githubusercontent.com/7137365/232110100-6e7a55eb-7ce5-400b-bd69-0a518435337a.png)
 
- With this PR:
![image](https://user-images.githubusercontent.com/7137365/232110156-6181a311-0b59-4b58-a2cc-4fc2165185f5.png)
</details>