### PR TITLE
Ability to use Mouse 4 and Mouse 5 as hotkeys

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -120,6 +120,7 @@ Also thanks to:
     * Mike Gagné (AngryBirdz)
     * Muh
     * Mustafa Alperen Seki (MustaphaTR)
+    * Nathan Nichols (cracksmoka420)
     * Neil Shivkar (havok13888)
     * Nikolay Fomin (netnazgul)
     * Nooze

--- a/OpenRA.Game/Input/Keycode.cs
+++ b/OpenRA.Game/Input/Keycode.cs
@@ -13,7 +13,8 @@ using System.Collections.Generic;
 
 namespace OpenRA
 {
-	// List of keycodes, duplicated from SDL 2.0.1
+	// List of keycodes. Duplicated from SDL 2.0.1, with the addition
+	// of MOUSE4 and MOUSE5.
 	public enum Keycode
 	{
 		UNKNOWN = 0,
@@ -252,6 +253,8 @@ namespace OpenRA
 		KBDILLUMUP = 280 | (1 << 30),
 		EJECT = 281 | (1 << 30),
 		SLEEP = 282 | (1 << 30),
+		MOUSE4 = 283 | (1 << 30),
+		MOUSE5 = 284 | (1 << 30)
 	}
 
 	public static class KeycodeExts
@@ -494,6 +497,8 @@ namespace OpenRA
 			{ Keycode.KBDILLUMUP, "KBDIllumUp" },
 			{ Keycode.EJECT, "Eject" },
 			{ Keycode.SLEEP, "Sleep" },
+			{ Keycode.MOUSE4, "Mouse 4" },
+			{ Keycode.MOUSE5, "Mouse 5" },
 		};
 
 		public static string DisplayString(Keycode k)


### PR DESCRIPTION
This pull request adds the ability to use mouse 4 and mouse 5 as hotkeys.

Certain models of high-end gaming mice can map the side buttons to keyboard inputs which can be used as hotkeys (e.g., "#" or "%"), so this change makes the game more fair to players that use standard mice.

The reason why mouse4 and mouse5 were previously not usable as hotkeys is because a one-to-one hotkey to keycode mapping was enforced by the input handling code. This was an artificial restriction; there is no technical reason why the internal enum `OpenRA.Keycode` has to correspond bijectively to SDL keycodes.

Thank you and please let me know if you need any additional information 