### PR TITLE
Enable 2 more Code Quality Rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -772,6 +772,9 @@ dotnet_diagnostic.CA1849.severity = warning
 # Prefer static HashData method over ComputeHash. (Not available on mono)
 dotnet_diagnostic.CA1850.severity = none
 
+# Seal internal types.
+dotnet_diagnostic.CA1852.severity = warning
+
 # Unnecessary call to 'Dictionary.ContainsKey(key)'.
 dotnet_diagnostic.CA1853.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -689,6 +689,10 @@ dotnet_diagnostic.CA1717.severity = warning
 # Remove empty finalizers.
 dotnet_diagnostic.CA1821.severity = warning
 
+# Mark members as static.
+dotnet_code_quality.CA1822.api_surface = private,internal
+dotnet_diagnostic.CA1822.severity = warning
+
 # Avoid unused private fields.
 dotnet_diagnostic.CA1823.severity = warning
 

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -81,7 +81,7 @@ namespace OpenRA
 		/// <summary>Value used to represent an invalid token.</summary>
 		public static readonly int InvalidConditionToken = -1;
 
-		class ConditionState
+		sealed class ConditionState
 		{
 			/// <summary>Delegates that have registered to be notified when this condition changes.</summary>
 			public readonly List<VariableObserverNotifier> Notifiers = new();

--- a/OpenRA.Game/ExternalMods.cs
+++ b/OpenRA.Game/ExternalMods.cs
@@ -257,7 +257,7 @@ namespace OpenRA
 			}
 		}
 
-		IEnumerable<string> GetSupportDirs(ModRegistration registration)
+		static IEnumerable<string> GetSupportDirs(ModRegistration registration)
 		{
 			var sources = new HashSet<string>(4);
 			if (registration.HasFlag(ModRegistration.System))

--- a/OpenRA.Game/FileFormats/Png.cs
+++ b/OpenRA.Game/FileFormats/Png.cs
@@ -271,7 +271,7 @@ namespace OpenRA.FileFormats
 			throw new InvalidDataException("Unknown pixel format");
 		}
 
-		void WritePngChunk(Stream output, string type, Stream input)
+		static void WritePngChunk(Stream output, string type, Stream input)
 		{
 			input.Position = 0;
 

--- a/OpenRA.Game/FileSystem/ZipFile.cs
+++ b/OpenRA.Game/FileSystem/ZipFile.cs
@@ -190,7 +190,7 @@ namespace OpenRA.FileSystem
 			public void Dispose() { /* nothing to do */ }
 		}
 
-		class StaticStreamDataSource : IStaticDataSource
+		sealed class StaticStreamDataSource : IStaticDataSource
 		{
 			readonly Stream s;
 			public StaticStreamDataSource(Stream s)

--- a/OpenRA.Game/Graphics/CursorManager.cs
+++ b/OpenRA.Game/Graphics/CursorManager.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Graphics
 {
 	public sealed class CursorManager
 	{
-		class Cursor
+		sealed class Cursor
 		{
 			public string Name;
 			public int2 PaddedSize;

--- a/OpenRA.Game/Graphics/Model.cs
+++ b/OpenRA.Game/Graphics/Model.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Graphics
 	{
 		public Action<string> OnMissingModelError { get; set; }
 
-		class PlaceholderModelCache : IModelCache
+		sealed class PlaceholderModelCache : IModelCache
 		{
 			public IVertexBuffer<Vertex> VertexBuffer => throw new NotImplementedException();
 

--- a/OpenRA.Game/Graphics/ModelRenderer.cs
+++ b/OpenRA.Game/Graphics/ModelRenderer.cs
@@ -302,7 +302,7 @@ namespace OpenRA.Graphics
 			return fbo;
 		}
 
-		void DisableFrameBuffer(IFrameBuffer fbo)
+		static void DisableFrameBuffer(IFrameBuffer fbo)
 		{
 			Game.Renderer.Flush();
 			Game.Renderer.Context.DisableDepthBuffer();

--- a/OpenRA.Game/Graphics/Palette.cs
+++ b/OpenRA.Game/Graphics/Palette.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Graphics
 			return new ReadOnlyPalette(palette);
 		}
 
-		class ReadOnlyPalette : IPalette
+		sealed class ReadOnlyPalette : IPalette
 		{
 			readonly IPalette palette;
 			public ReadOnlyPalette(IPalette palette) { this.palette = palette; }

--- a/OpenRA.Game/Graphics/RgbaColorRenderer.cs
+++ b/OpenRA.Game/Graphics/RgbaColorRenderer.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Graphics
 		/// Will behave badly if the lines are parallel.
 		/// Z position is the average of a and b (ignores actual intersection point if it exists).
 		/// </summary>
-		float3 IntersectionOf(in float3 a, in float3 da, in float3 b, in float3 db)
+		static float3 IntersectionOf(in float3 a, in float3 da, in float3 b, in float3 db)
 		{
 			var crossA = a.X * (a.Y + da.Y) - a.Y * (a.X + da.X);
 			var crossB = b.X * (b.Y + db.Y) - b.Y * (b.X + db.X);

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Graphics
 			}
 		}
 
-		float2 Rotate(float2 v, float sina, float cosa, float2 offset)
+		static float2 Rotate(float2 v, float sina, float cosa, float2 offset)
 		{
 			return new float2(
 				v.X * cosa - v.Y * sina + offset.X,

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -427,7 +427,7 @@ namespace OpenRA.Graphics
 		}
 	}
 
-	class GlyphInfo
+	sealed class GlyphInfo
 	{
 		public float Advance;
 		public int2 Offset;

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Graphics
 			return new int2(sheetIndex, secondarySheetIndex);
 		}
 
-		float ResolveTextureIndex(Sprite s, PaletteReference pal)
+		static float ResolveTextureIndex(Sprite s, PaletteReference pal)
 		{
 			if (pal == null)
 				return 0;

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -172,7 +172,7 @@ namespace OpenRA.Graphics
 				UpdateViewportZooms();
 		}
 
-		float CalculateMinimumZoom(float minHeight, float maxHeight)
+		static float CalculateMinimumZoom(float minHeight, float maxHeight)
 		{
 			var h = Game.Renderer.NativeResolution.Height;
 

--- a/OpenRA.Game/InstalledMods.cs
+++ b/OpenRA.Game/InstalledMods.cs
@@ -54,7 +54,7 @@ namespace OpenRA
 			return mods;
 		}
 
-		Manifest LoadMod(string id, string path)
+		static Manifest LoadMod(string id, string path)
 		{
 			IReadOnlyPackage package = null;
 			try
@@ -79,7 +79,7 @@ namespace OpenRA
 			return null;
 		}
 
-		Dictionary<string, Manifest> GetInstalledMods(IEnumerable<string> searchPaths, IEnumerable<string> explicitPaths)
+		static Dictionary<string, Manifest> GetInstalledMods(IEnumerable<string> searchPaths, IEnumerable<string> explicitPaths)
 		{
 			var ret = new Dictionary<string, Manifest>();
 			var candidates = GetCandidateMods(searchPaths)

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -65,7 +65,7 @@ namespace OpenRA
 		MissionSelector = 4
 	}
 
-	class MapField
+	sealed class MapField
 	{
 		enum Type { Normal, NodeList, MiniYaml }
 		readonly FieldInfo field;

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -64,7 +64,7 @@ namespace OpenRA
 	public class MapPreview : IDisposable, IReadOnlyFileSystem
 	{
 		/// <summary>Wrapper that enables map data to be replaced in an atomic fashion.</summary>
-		class InnerData
+		sealed class InnerData
 		{
 			public int MapFormat;
 			public string Title;

--- a/OpenRA.Game/Network/GeoIP.cs
+++ b/OpenRA.Game/Network/GeoIP.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Network
 {
 	public class GeoIP
 	{
-		class IP2LocationReader
+		sealed class IP2LocationReader
 		{
 			public readonly DateTime Date;
 			readonly Stream stream;

--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Network
 {
 	public sealed class ReplayConnection : IConnection
 	{
-		class Chunk
+		sealed class Chunk
 		{
 			public int Frame;
 			public (int ClientId, byte[] Packet)[] Packets;

--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -19,7 +19,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Network
 {
-	class SyncReport
+	sealed class SyncReport
 	{
 		const int NumSyncReports = 7;
 		static readonly Cache<Type, TypeInfo> TypeInfoCache = new(t => new TypeInfo(t));
@@ -161,7 +161,7 @@ namespace OpenRA.Network
 				Log.Write("sync", $"Recorded frames do not contain the frame {frame}. No sync report available!");
 		}
 
-		class Report
+		sealed class Report
 		{
 			public int Frame;
 			public int SyncedRandom;

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -49,7 +49,7 @@ namespace OpenRA
 			assemblies = assemblyList.SelectMany(asm => asm.GetNamespaces().Select(ns => (asm, ns))).ToArray();
 		}
 
-		void LoadAssembly(List<Assembly> assemblyList, string resolvedPath)
+		static void LoadAssembly(List<Assembly> assemblyList, string resolvedPath)
 		{
 			// .NET doesn't provide any way of querying the metadata of an assembly without either:
 			//   (a) loading duplicate data into the application domain, breaking the world.

--- a/OpenRA.Game/Primitives/SpatiallyPartitioned.cs
+++ b/OpenRA.Game/Primitives/SpatiallyPartitioned.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Primitives
 			itemBoundsBins = Exts.MakeArray(rows * cols, _ => new Dictionary<T, Rectangle>());
 		}
 
-		void ValidateBounds(T actor, Rectangle bounds)
+		static void ValidateBounds(T actor, Rectangle bounds)
 		{
 			if (bounds.Width == 0 || bounds.Height == 0)
 				throw new ArgumentException($"Bounds of actor {actor} are empty.", nameof(bounds));

--- a/OpenRA.Game/Server/OrderBuffer.cs
+++ b/OpenRA.Game/Server/OrderBuffer.cs
@@ -112,7 +112,7 @@ namespace OpenRA.Server
 			}
 		}
 
-		long Median(long[] a)
+		static long Median(long[] a)
 		{
 			Array.Sort(a);
 			var n = a.Length;

--- a/OpenRA.Game/Server/PlayerMessageTracker.cs
+++ b/OpenRA.Game/Server/PlayerMessageTracker.cs
@@ -14,7 +14,7 @@ using System.Collections.Generic;
 
 namespace OpenRA.Server
 {
-	class PlayerMessageTracker
+	sealed class PlayerMessageTracker
 	{
 		[TranslationReference("remaining")]
 		const string ChatTemporaryDisabled = "notification-chat-temp-disabled";

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -702,7 +702,7 @@ namespace OpenRA.Server
 			}
 		}
 
-		byte[] CreateFrame(int client, int frame, byte[] data)
+		static byte[] CreateFrame(int client, int frame, byte[] data)
 		{
 			var ms = new MemoryStream(data.Length + 12);
 			ms.WriteArray(BitConverter.GetBytes(data.Length + 4));
@@ -712,7 +712,7 @@ namespace OpenRA.Server
 			return ms.GetBuffer();
 		}
 
-		byte[] CreateAckFrame(int frame, byte count)
+		static byte[] CreateAckFrame(int frame, byte count)
 		{
 			var ms = new MemoryStream(14);
 			ms.WriteArray(BitConverter.GetBytes(6));
@@ -723,7 +723,7 @@ namespace OpenRA.Server
 			return ms.GetBuffer();
 		}
 
-		byte[] CreateTickScaleFrame(float scale)
+		static byte[] CreateTickScaleFrame(float scale)
 		{
 			var ms = new MemoryStream(17);
 			ms.WriteArray(BitConverter.GetBytes(9));

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -1441,7 +1441,7 @@ namespace OpenRA.Server
 
 		interface IServerEvent { void Invoke(Server server); }
 
-		class ConnectionConnectEvent : IServerEvent
+		sealed class ConnectionConnectEvent : IServerEvent
 		{
 			readonly Socket socket;
 			public ConnectionConnectEvent(Socket socket)
@@ -1455,7 +1455,7 @@ namespace OpenRA.Server
 			}
 		}
 
-		class ConnectionDisconnectEvent : IServerEvent
+		sealed class ConnectionDisconnectEvent : IServerEvent
 		{
 			readonly Connection connection;
 			public ConnectionDisconnectEvent(Connection connection)
@@ -1469,7 +1469,7 @@ namespace OpenRA.Server
 			}
 		}
 
-		class ConnectionPacketEvent : IServerEvent
+		sealed class ConnectionPacketEvent : IServerEvent
 		{
 			readonly Connection connection;
 			readonly int frame;
@@ -1488,7 +1488,7 @@ namespace OpenRA.Server
 			}
 		}
 
-		class ConnectionPingEvent : IServerEvent
+		sealed class ConnectionPingEvent : IServerEvent
 		{
 			readonly Connection connection;
 			readonly int[] pingHistory;
@@ -1511,7 +1511,7 @@ namespace OpenRA.Server
 			}
 		}
 
-		class CallbackEvent : IServerEvent
+		sealed class CallbackEvent : IServerEvent
 		{
 			readonly Action action;
 

--- a/OpenRA.Game/Support/AssemblyLoader.cs
+++ b/OpenRA.Game/Support/AssemblyLoader.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Support
 		}
 	}
 
-	class ManagedLoadContext : AssemblyLoadContext
+	sealed class ManagedLoadContext : AssemblyLoadContext
 	{
 		readonly string basePath;
 		readonly Dictionary<string, ManagedLibrary> managedAssemblies;

--- a/OpenRA.Game/Support/Benchmark.cs
+++ b/OpenRA.Game/Support/Benchmark.cs
@@ -14,7 +14,7 @@ using System.Globalization;
 
 namespace OpenRA.Support
 {
-	class Benchmark
+	sealed class Benchmark
 	{
 		readonly string prefix;
 		readonly Dictionary<string, List<BenchmarkPoint>> samples = new();
@@ -30,7 +30,7 @@ namespace OpenRA.Support
 				samples.GetOrAdd(item.Key).Add(new BenchmarkPoint(localTick, item.Value.LastValue));
 		}
 
-		class BenchmarkPoint
+		sealed class BenchmarkPoint
 		{
 			public int Tick { get; }
 			public double Value { get; }

--- a/OpenRA.Game/Support/VariableExpression.cs
+++ b/OpenRA.Game/Support/VariableExpression.cs
@@ -551,7 +551,7 @@ namespace OpenRA.Support
 			}
 		}
 
-		class VariableToken : Token
+		sealed class VariableToken : Token
 		{
 			public readonly string Name;
 
@@ -561,7 +561,7 @@ namespace OpenRA.Support
 				: base(TokenType.Variable, index) { Name = symbol; }
 		}
 
-		class NumberToken : Token
+		sealed class NumberToken : Token
 		{
 			public readonly int Value;
 			readonly string symbol;
@@ -714,7 +714,7 @@ namespace OpenRA.Support
 			return Expressions.Expression.Condition(test, ifTrue, ifFalse);
 		}
 
-		class AstStack
+		sealed class AstStack
 		{
 			readonly List<Expression> expressions = new();
 			readonly List<ExpressionType> types = new();
@@ -772,7 +772,7 @@ namespace OpenRA.Support
 			}
 		}
 
-		class Compiler
+		sealed class Compiler
 		{
 			readonly AstStack ast = new();
 

--- a/OpenRA.Game/TraitDictionary.cs
+++ b/OpenRA.Game/TraitDictionary.cs
@@ -39,7 +39,7 @@ namespace OpenRA
 	/// <summary>
 	/// Provides efficient ways to query a set of actors by their traits.
 	/// </summary>
-	class TraitDictionary
+	sealed class TraitDictionary
 	{
 		static readonly Func<Type, ITraitContainer> CreateTraitContainer = t =>
 			(ITraitContainer)typeof(TraitContainer<>).MakeGenericType(t).GetConstructor(Type.EmptyTypes).Invoke(null);
@@ -141,7 +141,7 @@ namespace OpenRA
 			int Queries { get; }
 		}
 
-		class TraitContainer<T> : ITraitContainer
+		sealed class TraitContainer<T> : ITraitContainer
 		{
 			readonly List<Actor> actors = new();
 			readonly List<T> traits = new();
@@ -185,7 +185,7 @@ namespace OpenRA
 				return new MultipleEnumerable(this, actor);
 			}
 
-			class MultipleEnumerable : IEnumerable<T>
+			sealed class MultipleEnumerable : IEnumerable<T>
 			{
 				readonly TraitContainer<T> container;
 				readonly uint actor;

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -278,7 +278,7 @@ namespace OpenRA.Traits
 			frozenActorsById.Remove(fa.ID);
 		}
 
-		Rectangle FootprintBounds(FrozenActor fa)
+		static Rectangle FootprintBounds(FrozenActor fa)
 		{
 			var p1 = fa.Footprint[0];
 			var minU = p1.U;

--- a/OpenRA.Game/Traits/Player/Shroud.cs
+++ b/OpenRA.Game/Traits/Player/Shroud.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Traits
 		public int RevealedCells { get; private set; }
 
 		enum ShroudCellType : byte { Shroud, Fog, Visible }
-		class ShroudSource
+		sealed class ShroudSource
 		{
 			public readonly SourceType Type;
 			public readonly PPos[] ProjectedCells;

--- a/OpenRA.Game/UtilityCommands/ClearInvalidModRegistrationsCommand.cs
+++ b/OpenRA.Game/UtilityCommands/ClearInvalidModRegistrationsCommand.cs
@@ -13,7 +13,7 @@ using System.Linq;
 
 namespace OpenRA.UtilityCommands
 {
-	class ClearInvalidModRegistrationsCommand : IUtilityCommand
+	sealed class ClearInvalidModRegistrationsCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--clear-invalid-mod-registrations";
 

--- a/OpenRA.Game/UtilityCommands/RegisterModCommand.cs
+++ b/OpenRA.Game/UtilityCommands/RegisterModCommand.cs
@@ -13,7 +13,7 @@ using System.Linq;
 
 namespace OpenRA.UtilityCommands
 {
-	class RegisterModCommand : IUtilityCommand
+	sealed class RegisterModCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--register-mod";
 

--- a/OpenRA.Game/UtilityCommands/UnregisterModCommand.cs
+++ b/OpenRA.Game/UtilityCommands/UnregisterModCommand.cs
@@ -13,7 +13,7 @@ using System.Linq;
 
 namespace OpenRA.UtilityCommands
 {
-	class UnregisterModCommand : IUtilityCommand
+	sealed class UnregisterModCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--unregister-mod";
 

--- a/OpenRA.Mods.Cnc/Activities/Infiltrate.cs
+++ b/OpenRA.Mods.Cnc/Activities/Infiltrate.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Activities
 {
-	class Infiltrate : Enter
+	sealed class Infiltrate : Enter
 	{
 		readonly Infiltrates infiltrates;
 		readonly INotifyInfiltration[] notifiers;

--- a/OpenRA.Mods.Cnc/AudioLoaders/AudLoader.cs
+++ b/OpenRA.Mods.Cnc/AudioLoaders/AudLoader.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Cnc.AudioLoaders
 {
 	public class AudLoader : ISoundLoader
 	{
-		bool IsAud(Stream s)
+		static bool IsAud(Stream s)
 		{
 			var start = s.Position;
 			s.Position += 11;

--- a/OpenRA.Mods.Cnc/Effects/GpsDotEffect.cs
+++ b/OpenRA.Mods.Cnc/Effects/GpsDotEffect.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Effects
 {
-	class GpsDotEffect : IEffect, IEffectAnnotation
+	sealed class GpsDotEffect : IEffect, IEffectAnnotation
 	{
 		readonly Actor actor;
 		readonly GpsDotInfo info;
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Cnc.Effects
 		readonly PlayerDictionary<DotState> dotStates;
 		readonly IVisibilityModifier[] visibilityModifiers;
 
-		class DotState
+		sealed class DotState
 		{
 			public readonly GpsWatcher Watcher;
 			public readonly bool FrozenActorWithRenderables;

--- a/OpenRA.Mods.Cnc/Effects/GpsSatellite.cs
+++ b/OpenRA.Mods.Cnc/Effects/GpsSatellite.cs
@@ -16,7 +16,7 @@ using OpenRA.Mods.Cnc.Traits;
 
 namespace OpenRA.Mods.Cnc.Effects
 {
-	class GpsSatellite : IEffect, ISpatiallyPartitionable
+	sealed class GpsSatellite : IEffect, ISpatiallyPartitionable
 	{
 		readonly Player launcher;
 		readonly Animation anim;

--- a/OpenRA.Mods.Cnc/Effects/SatelliteLaunch.cs
+++ b/OpenRA.Mods.Cnc/Effects/SatelliteLaunch.cs
@@ -16,7 +16,7 @@ using OpenRA.Mods.Cnc.Traits;
 
 namespace OpenRA.Mods.Cnc.Effects
 {
-	class SatelliteLaunch : IEffect, ISpatiallyPartitionable
+	sealed class SatelliteLaunch : IEffect, ISpatiallyPartitionable
 	{
 		readonly GpsPowerInfo info;
 		readonly Actor launcher;

--- a/OpenRA.Mods.Cnc/FileFormats/Blowfish.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/Blowfish.cs
@@ -11,7 +11,7 @@
 
 namespace OpenRA.Mods.Cnc.FileFormats
 {
-	class Blowfish
+	sealed class Blowfish
 	{
 		public Blowfish(byte[] key)
 		{

--- a/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
@@ -16,11 +16,11 @@ namespace OpenRA.Mods.Cnc.FileFormats
 {
 	/* TODO: Convert this direct C port into readable code. */
 
-	class BlowfishKeyProvider
+	sealed class BlowfishKeyProvider
 	{
 		const string PublicKeyString = "AihRvNoIbTn85FZRYNZRcT+i6KpU+maCsEqr3Q5q+LDB5tH7Tz2qQ38V";
 
-		class PublicKey
+		sealed class PublicKey
 		{
 			public readonly uint[] KeyOne = new uint[64];
 			public readonly uint[] KeyTwo = new uint[64];

--- a/OpenRA.Mods.Cnc/FileSystem/BigFile.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/BigFile.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Cnc.FileSystem
 				}
 			}
 
-			class Entry
+			sealed class Entry
 			{
 				public readonly uint Offset;
 				public readonly uint Size;

--- a/OpenRA.Mods.Cnc/Graphics/TeslaZapRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/TeslaZapRenderable.cs
@@ -17,7 +17,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Cnc.Graphics
 {
-	class TeslaZapRenderable : IPalettedRenderable, IFinalizedRenderable
+	sealed class TeslaZapRenderable : IPalettedRenderable, IFinalizedRenderable
 	{
 		static readonly int[][] Steps = new[]
 		{

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpD2Loader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpD2Loader.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			VariableLengthTable = 4
 		}
 
-		class ShpD2Frame : ISpriteFrame
+		sealed class ShpD2Frame : ISpriteFrame
 		{
 			public SpriteFrameType Type => SpriteFrameType.Indexed8;
 			public Size Size { get; }

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpD2Loader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpD2Loader.cs
@@ -89,7 +89,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			}
 		}
 
-		bool IsShpD2(Stream s)
+		static bool IsShpD2(Stream s)
 		{
 			var start = s.Position;
 
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			return b == 5 || b <= 3;
 		}
 
-		ShpD2Frame[] ParseFrames(Stream s)
+		static ShpD2Frame[] ParseFrames(Stream s)
 		{
 			var start = s.Position;
 

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpRemasteredLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpRemasteredLoader.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 		static readonly Regex FilenameRegex = new(@"^(?<prefix>.+?[\-_])(?<frame>\d{4})\.tga$");
 		static readonly Regex MetaRegex = new(@"^\{""size"":\[(?<width>\d+),(?<height>\d+)\],""crop"":\[(?<left>\d+),(?<top>\d+),(?<right>\d+),(?<bottom>\d+)\]\}$");
 
-		int ParseGroup(Match match, string group)
+		static int ParseGroup(Match match, string group)
 		{
 			return int.Parse(match.Groups[group].Value);
 		}

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpTDLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpTDLoader.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 	{
 		enum Format { XORPrev = 0x20, XORLCW = 0x40, LCW = 0x80 }
 
-		class ImageHeader : ISpriteFrame
+		sealed class ImageHeader : ISpriteFrame
 		{
 			public SpriteFrameType Type => SpriteFrameType.Indexed8;
 			public Size Size => reader.Size;

--- a/OpenRA.Mods.Cnc/SpriteLoaders/TmpRALoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/TmpRALoader.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			}
 		}
 
-		bool IsTmpRA(Stream s)
+		static bool IsTmpRA(Stream s)
 		{
 			var start = s.Position;
 
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			return a == 0 && b == 0x2c73;
 		}
 
-		TmpRAFrame[] ParseFrames(Stream s)
+		static TmpRAFrame[] ParseFrames(Stream s)
 		{
 			var start = s.Position;
 			var width = s.ReadUInt16();

--- a/OpenRA.Mods.Cnc/SpriteLoaders/TmpRALoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/TmpRALoader.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 {
 	public class TmpRALoader : ISpriteLoader
 	{
-		class TmpRAFrame : ISpriteFrame
+		sealed class TmpRAFrame : ISpriteFrame
 		{
 			public SpriteFrameType Type => SpriteFrameType.Indexed8;
 			public Size Size { get; }

--- a/OpenRA.Mods.Cnc/SpriteLoaders/TmpTDLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/TmpTDLoader.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			}
 		}
 
-		bool IsTmpTD(Stream s)
+		static bool IsTmpTD(Stream s)
 		{
 			var start = s.Position;
 
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			return a == 0 && b == 0x0D1AFFFF;
 		}
 
-		TmpTDFrame[] ParseFrames(Stream s)
+		static TmpTDFrame[] ParseFrames(Stream s)
 		{
 			var start = s.Position;
 			var width = s.ReadUInt16();

--- a/OpenRA.Mods.Cnc/SpriteLoaders/TmpTDLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/TmpTDLoader.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 {
 	public class TmpTDLoader : ISpriteLoader
 	{
-		class TmpTDFrame : ISpriteFrame
+		sealed class TmpTDFrame : ISpriteFrame
 		{
 			public SpriteFrameType Type => SpriteFrameType.Indexed8;
 			public Size Size { get; }

--- a/OpenRA.Mods.Cnc/SpriteLoaders/TmpTSLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/TmpTSLoader.cs
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			}
 		}
 
-		bool IsTmpTS(Stream s)
+		static bool IsTmpTS(Stream s)
 		{
 			var start = s.Position;
 			s.Position += 8;
@@ -152,7 +152,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			return test == sx * sy / 2 + 52;
 		}
 
-		ISpriteFrame[] ParseFrames(Stream s)
+		static ISpriteFrame[] ParseFrames(Stream s)
 		{
 			var start = s.Position;
 			var templateWidth = s.ReadUInt32();

--- a/OpenRA.Mods.Cnc/SpriteLoaders/TmpTSLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/TmpTSLoader.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 {
 	public class TmpTSLoader : ISpriteLoader
 	{
-		class TmpTSDepthFrame : ISpriteFrame
+		sealed class TmpTSDepthFrame : ISpriteFrame
 		{
 			readonly TmpTSFrame parent;
 
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			}
 		}
 
-		class TmpTSFrame : ISpriteFrame
+		sealed class TmpTSFrame : ISpriteFrame
 		{
 			public SpriteFrameType Type => SpriteFrameType.Indexed8;
 			public Size Size { get; }

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackPopupTurreted.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Actor's turret rises from the ground before attacking.")]
-	class AttackPopupTurretedInfo : AttackTurretedInfo, Requires<BuildingInfo>, Requires<WithEmbeddedTurretSpriteBodyInfo>
+	sealed class AttackPopupTurretedInfo : AttackTurretedInfo, Requires<BuildingInfo>, Requires<WithEmbeddedTurretSpriteBodyInfo>
 	{
 		[Desc("How many game ticks should pass before closing the actor's turret.")]
 		public readonly int CloseDelay = 125;
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new AttackPopupTurreted(init, this); }
 	}
 
-	class AttackPopupTurreted : AttackTurreted, INotifyIdle, IDamageModifier
+	sealed class AttackPopupTurreted : AttackTurreted, INotifyIdle, IDamageModifier
 	{
 		enum PopupState { Open, Rotating, Transitioning, Closed }
 

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTDGunboatTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTDGunboatTurreted.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			return new AttackTDGunboatTurretedActivity(self, newTarget, forceAttack, targetLineColor);
 		}
 
-		class AttackTDGunboatTurretedActivity : Activity
+		sealed class AttackTDGunboatTurretedActivity : Activity
 		{
 			readonly AttackTDGunboatTurreted attack;
 			readonly Target target;

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Implements the charge-then-burst attack logic specific to the RA tesla coil.")]
-	class AttackTeslaInfo : AttackBaseInfo
+	sealed class AttackTeslaInfo : AttackBaseInfo
 	{
 		[Desc("How many charges this actor has to attack with, once charged.")]
 		public readonly int MaxCharges = 1;
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new AttackTesla(init.Self, this); }
 	}
 
-	class AttackTesla : AttackBase, ITick, INotifyAttack
+	sealed class AttackTesla : AttackBase, ITick, INotifyAttack
 	{
 		readonly AttackTeslaInfo info;
 
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			return new ChargeAttack(this, newTarget, forceAttack, targetLineColor);
 		}
 
-		class ChargeAttack : Activity, IActivityNotifyStanceChanged
+		sealed class ChargeAttack : Activity, IActivityNotifyStanceChanged
 		{
 			readonly AttackTesla attack;
 			readonly Target target;
@@ -144,7 +144,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		class ChargeFire : Activity
+		sealed class ChargeFire : Activity
 		{
 			readonly AttackTesla attack;
 			readonly Target target;

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -20,12 +20,12 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Overrides the default Tooltip when this actor is disguised (aids in deceiving enemy players).")]
-	class DisguiseTooltipInfo : TooltipInfo, Requires<DisguiseInfo>
+	sealed class DisguiseTooltipInfo : TooltipInfo, Requires<DisguiseInfo>
 	{
 		public override object Create(ActorInitializer init) { return new DisguiseTooltip(init.Self, this); }
 	}
 
-	class DisguiseTooltip : ConditionalTrait<DisguiseTooltipInfo>, ITooltip
+	sealed class DisguiseTooltip : ConditionalTrait<DisguiseTooltipInfo>, ITooltip
 	{
 		readonly Actor self;
 		readonly Disguise disguise;
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	}
 
 	[Desc("Provides access to the disguise command, which makes the actor appear to be another player's actor.")]
-	class DisguiseInfo : TraitInfo
+	sealed class DisguiseInfo : TraitInfo
 	{
 		[VoiceReference]
 		public readonly string Voice = "Action";
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new Disguise(init.Self, this); }
 	}
 
-	class Disguise : IEffectiveOwner, IIssueOrder, IResolveOrder, IOrderVoice, IRadarColorModifier, INotifyAttack,
+	sealed class Disguise : IEffectiveOwner, IIssueOrder, IResolveOrder, IOrderVoice, IRadarColorModifier, INotifyAttack,
 		INotifyDamage, INotifyUnload, INotifyDemolition, INotifyInfiltration, ITick
 	{
 		public ActorInfo AsActor { get; private set; }
@@ -280,7 +280,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		}
 	}
 
-	class DisguiseOrderTargeter : UnitOrderTargeter
+	sealed class DisguiseOrderTargeter : UnitOrderTargeter
 	{
 		readonly DisguiseInfo info;
 

--- a/OpenRA.Mods.Cnc/Traits/FrozenUnderFogUpdatedByGps.cs
+++ b/OpenRA.Mods.Cnc/Traits/FrozenUnderFogUpdatedByGps.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			gps.UnregisterForOnGpsRefreshed(fufubg.self, fufubg);
 		};
 
-		class Traits
+		sealed class Traits
 		{
 			public readonly FrozenActorLayer FrozenActorLayer;
 			public readonly GpsWatcher GpsWatcher;

--- a/OpenRA.Mods.Cnc/Traits/GpsDot.cs
+++ b/OpenRA.Mods.Cnc/Traits/GpsDot.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Show an indicator revealing the actor underneath the fog when a GPSWatcher is activated.")]
-	class GpsDotInfo : TraitInfo
+	sealed class GpsDotInfo : TraitInfo
 	{
 		[Desc("Sprite collection for symbols.")]
 		public readonly string Image = "gpsdot";
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new GpsDot(this); }
 	}
 
-	class GpsDot : INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld
+	sealed class GpsDot : INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld
 	{
 		readonly GpsDotInfo info;
 		GpsDotEffect effect;

--- a/OpenRA.Mods.Cnc/Traits/GpsWatcher.cs
+++ b/OpenRA.Mods.Cnc/Traits/GpsWatcher.cs
@@ -18,14 +18,14 @@ namespace OpenRA.Mods.Cnc.Traits
 {
 	[TraitLocation(SystemActors.Player)]
 	[Desc("Required for `GpsPower`. Attach this to the player actor.")]
-	class GpsWatcherInfo : TraitInfo
+	sealed class GpsWatcherInfo : TraitInfo
 	{
 		public override object Create(ActorInitializer init) { return new GpsWatcher(init.Self.Owner); }
 	}
 
 	interface IOnGpsRefreshed { void OnGpsRefresh(Actor self, Player player); }
 
-	class GpsWatcher : ISync, IPreventsShroudReset
+	sealed class GpsWatcher : ISync, IPreventsShroudReset
 	{
 		[Sync]
 		public bool Launched { get; private set; }

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForCash.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForCash.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Funds are transferred from the owner to the infiltrator.")]
-	class InfiltrateForCashInfo : TraitInfo
+	sealed class InfiltrateForCashInfo : TraitInfo
 	{
 		[Desc("The `TargetTypes` from `Targetable` that are allowed to enter.")]
 		public readonly BitSet<TargetableType> Types = default;
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new InfiltrateForCash(this); }
 	}
 
-	class InfiltrateForCash : INotifyInfiltrated
+	sealed class InfiltrateForCash : INotifyInfiltrated
 	{
 		readonly InfiltrateForCashInfo info;
 

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForDecoration.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForDecoration.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Reveals a decoration sprite to the indicated players when infiltrated.")]
-	class InfiltrateForDecorationInfo : WithDecorationInfo
+	sealed class InfiltrateForDecorationInfo : WithDecorationInfo
 	{
 		[Desc("The `TargetTypes` from `Targetable` that are allowed to enter.")]
 		public readonly BitSet<TargetableType> Types = default;
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new InfiltrateForDecoration(init.Self, this); }
 	}
 
-	class InfiltrateForDecoration : WithDecoration, INotifyInfiltrated
+	sealed class InfiltrateForDecoration : WithDecoration, INotifyInfiltrated
 	{
 		readonly HashSet<Player> infiltrators = new();
 		readonly InfiltrateForDecorationInfo info;

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForExploration.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForExploration.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Steal and reset the owner's exploration.")]
-	class InfiltrateForExplorationInfo : TraitInfo
+	sealed class InfiltrateForExplorationInfo : TraitInfo
 	{
 		[Desc("The `TargetTypes` from `Targetable` that are allowed to enter.")]
 		public readonly BitSet<TargetableType> Types = default;
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new InfiltrateForExploration(this); }
 	}
 
-	class InfiltrateForExploration : INotifyInfiltrated
+	sealed class InfiltrateForExploration : INotifyInfiltrated
 	{
 		readonly InfiltrateForExplorationInfo info;
 

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForPowerOutage.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForPowerOutage.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	class InfiltrateForPowerOutageInfo : TraitInfo
+	sealed class InfiltrateForPowerOutageInfo : TraitInfo
 	{
 		[Desc("The `TargetTypes` from `Targetable` that are allowed to enter.")]
 		public readonly BitSet<TargetableType> Types = default;
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new InfiltrateForPowerOutage(init.Self, this); }
 	}
 
-	class InfiltrateForPowerOutage : INotifyOwnerChanged, INotifyInfiltrated
+	sealed class InfiltrateForPowerOutage : INotifyOwnerChanged, INotifyInfiltrated
 	{
 		readonly InfiltrateForPowerOutageInfo info;
 		PowerManager playerPower;

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPower.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	class InfiltrateForSupportPowerInfo : TraitInfo
+	sealed class InfiltrateForSupportPowerInfo : TraitInfo
 	{
 		[ActorReference]
 		[FieldLoader.Require]
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new InfiltrateForSupportPower(this); }
 	}
 
-	class InfiltrateForSupportPower : INotifyInfiltrated
+	sealed class InfiltrateForSupportPower : INotifyInfiltrated
 	{
 		readonly InfiltrateForSupportPowerInfo info;
 

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPowerReset.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPowerReset.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	class InfiltrateForSupportPowerResetInfo : TraitInfo
+	sealed class InfiltrateForSupportPowerResetInfo : TraitInfo
 	{
 		[Desc("The `TargetTypes` from `Targetable` that are allowed to enter.")]
 		public readonly BitSet<TargetableType> Types = default;
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new InfiltrateForSupportPowerReset(this); }
 	}
 
-	class InfiltrateForSupportPowerReset : INotifyInfiltrated
+	sealed class InfiltrateForSupportPowerReset : INotifyInfiltrated
 	{
 		readonly InfiltrateForSupportPowerResetInfo info;
 

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForTransform.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForTransform.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Transform into a different actor type.")]
-	class InfiltrateForTransformInfo : TraitInfo
+	sealed class InfiltrateForTransformInfo : TraitInfo
 	{
 		[ActorReference]
 		[FieldLoader.Require]
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new InfiltrateForTransform(init, this); }
 	}
 
-	class InfiltrateForTransform : INotifyInfiltrated
+	sealed class InfiltrateForTransform : INotifyInfiltrated
 	{
 		readonly InfiltrateForTransformInfo info;
 		readonly string faction;

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		}
 	}
 
-	class InfiltrationOrderTargeter : UnitOrderTargeter
+	sealed class InfiltrationOrderTargeter : UnitOrderTargeter
 	{
 		readonly InfiltratesInfo info;
 

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -21,7 +21,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	class MadTankInfo : TraitInfo, IRulesetLoaded, Requires<ExplodesInfo>, Requires<WithFacingSpriteBodyInfo>
+	sealed class MadTankInfo : TraitInfo, IRulesetLoaded, Requires<ExplodesInfo>, Requires<WithFacingSpriteBodyInfo>
 	{
 		[SequenceReference]
 		public readonly string ThumpSequence = "piston";
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		}
 	}
 
-	class MadTank : IIssueOrder, IResolveOrder, IOrderVoice, IIssueDeployOrder
+	sealed class MadTank : IIssueOrder, IResolveOrder, IOrderVoice, IIssueDeployOrder
 	{
 		readonly MadTankInfo info;
 
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				self.QueueActivity(order.Queued, new DetonationSequence(self, this));
 		}
 
-		class DetonationSequence : Activity
+		sealed class DetonationSequence : Activity
 		{
 			readonly Actor self;
 			readonly MadTank mad;

--- a/OpenRA.Mods.Cnc/Traits/Mine.cs
+++ b/OpenRA.Mods.Cnc/Traits/Mine.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	class MineInfo : TraitInfo
+	sealed class MineInfo : TraitInfo
 	{
 		public readonly BitSet<CrushClass> CrushClasses = default;
 		public readonly bool AvoidFriendly = true;
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new Mine(this); }
 	}
 
-	class Mine : ICrushable, INotifyCrushed
+	sealed class Mine : ICrushable, INotifyCrushed
 	{
 		readonly MineInfo info;
 
@@ -70,6 +70,6 @@ namespace OpenRA.Mods.Cnc.Traits
 	}
 
 	[Desc("Tag trait for stuff that should not trigger mines.")]
-	class MineImmuneInfo : TraitInfo<MineImmune> { }
-	class MineImmune { }
+	sealed class MineImmuneInfo : TraitInfo<MineImmune> { }
+	sealed class MineImmune { }
 }

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -204,7 +204,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			return Info.TerrainTypes.Contains(terrainType);
 		}
 
-		class MinefieldOrderGenerator : OrderGenerator
+		sealed class MinefieldOrderGenerator : OrderGenerator
 		{
 			readonly List<Actor> minelayers;
 			readonly Minelayer minelayer;
@@ -347,7 +347,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		class BeginMinefieldOrderTargeter : IOrderTargeter
+		sealed class BeginMinefieldOrderTargeter : IOrderTargeter
 		{
 			public string OrderID => "BeginMinefield";
 			public int OrderPriority => 5;
@@ -377,7 +377,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				return modifiers.HasModifier(TargetModifiers.ForceAttack);
 			}
 
-			public bool IsQueued { get; protected set; }
+			public bool IsQueued { get; private set; }
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Traits/PaletteEffects/LightPaletteRotator.cs
+++ b/OpenRA.Mods.Cnc/Traits/PaletteEffects/LightPaletteRotator.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Cnc.Traits
 {
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Palette effect used for blinking \"animations\" on actors.")]
-	class LightPaletteRotatorInfo : TraitInfo
+	sealed class LightPaletteRotatorInfo : TraitInfo
 	{
 		[Desc("Palettes this effect should not apply to.")]
 		public readonly HashSet<string> ExcludePalettes = new();
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new LightPaletteRotator(this); }
 	}
 
-	class LightPaletteRotator : ITick, IPaletteModifier
+	sealed class LightPaletteRotator : ITick, IPaletteModifier
 	{
 		readonly LightPaletteRotatorInfo info;
 		float t = 0;

--- a/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
@@ -21,7 +21,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	class PortableChronoInfo : PausableConditionalTraitInfo, Requires<IMoveInfo>
+	sealed class PortableChronoInfo : PausableConditionalTraitInfo, Requires<IMoveInfo>
 	{
 		[Desc("Cooldown in ticks until the unit can teleport.")]
 		public readonly int ChargeDelay = 500;
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new PortableChrono(init.Self, this); }
 	}
 
-	class PortableChrono : PausableConditionalTrait<PortableChronoInfo>, IIssueOrder, IResolveOrder, ITick, ISelectionBar, IOrderVoice, ISync
+	sealed class PortableChrono : PausableConditionalTrait<PortableChronoInfo>, IIssueOrder, IResolveOrder, ITick, ISelectionBar, IOrderVoice, ISync
 	{
 		readonly IMove move;
 		[Sync]
@@ -177,7 +177,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		}
 	}
 
-	class PortableChronoOrderTargeter : IOrderTargeter
+	sealed class PortableChronoOrderTargeter : IOrderTargeter
 	{
 		readonly string targetCursor;
 
@@ -188,7 +188,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public string OrderID => "PortableChronoTeleport";
 		public int OrderPriority => 5;
-		public bool IsQueued { get; protected set; }
+		public bool IsQueued { get; private set; }
 		public bool TargetOverridesSelection(Actor self, in Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
 
 		public bool CanTarget(Actor self, in Target target, ref TargetModifiers modifiers, ref string cursor)
@@ -212,7 +212,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		}
 	}
 
-	class PortableChronoOrderGenerator : OrderGenerator
+	sealed class PortableChronoOrderGenerator : OrderGenerator
 	{
 		readonly Actor self;
 		readonly PortableChrono portableChrono;

--- a/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
@@ -133,5 +133,5 @@ namespace OpenRA.Mods.Cnc.Traits
 		}
 	}
 
-	class HideBibPreviewInit : RuntimeFlagInit { }
+	sealed class HideBibPreviewInit : RuntimeFlagInit { }
 }

--- a/OpenRA.Mods.Cnc/Traits/Render/WithDisguisingInfantryBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithDisguisingInfantryBody.cs
@@ -15,12 +15,12 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits.Render
 {
-	class WithDisguisingInfantryBodyInfo : WithInfantryBodyInfo, Requires<DisguiseInfo>
+	sealed class WithDisguisingInfantryBodyInfo : WithInfantryBodyInfo, Requires<DisguiseInfo>
 	{
 		public override object Create(ActorInitializer init) { return new WithDisguisingInfantryBody(init, this); }
 	}
 
-	class WithDisguisingInfantryBody : WithInfantryBody
+	sealed class WithDisguisingInfantryBody : WithInfantryBody
 	{
 		readonly Disguise disguise;
 		readonly RenderSprites rs;

--- a/OpenRA.Mods.Cnc/Traits/Render/WithGunboatBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithGunboatBody.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits.Render
 {
-	class WithGunboatBodyInfo : WithSpriteBodyInfo, Requires<BodyOrientationInfo>, Requires<IFacingInfo>, Requires<TurretedInfo>
+	sealed class WithGunboatBodyInfo : WithSpriteBodyInfo, Requires<BodyOrientationInfo>, Requires<IFacingInfo>, Requires<TurretedInfo>
 	{
 		[Desc("Turreted 'Turret' key to display")]
 		public readonly string Turret = "primary";
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithGunboatBody(init, this); }
 	}
 
-	class WithGunboatBody : WithSpriteBody, ITick
+	sealed class WithGunboatBody : WithSpriteBody, ITick
 	{
 		readonly WithGunboatBodyInfo info;
 		readonly Animation wake;

--- a/OpenRA.Mods.Cnc/Traits/Render/WithSplitAttackPaletteInfantryBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithSplitAttackPaletteInfantryBody.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits.Render
 {
-	class WithSplitAttackPaletteInfantryBodyInfo : WithInfantryBodyInfo
+	sealed class WithSplitAttackPaletteInfantryBodyInfo : WithInfantryBodyInfo
 	{
 		[PaletteReference]
 		[Desc("Palette to use for the split attack rendering.")]
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithSplitAttackPaletteInfantryBody(init, this); }
 	}
 
-	class WithSplitAttackPaletteInfantryBody : WithInfantryBody
+	sealed class WithSplitAttackPaletteInfantryBody : WithInfantryBody
 	{
 		readonly WithSplitAttackPaletteInfantryBodyInfo info;
 		readonly Animation splitAnimation;

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	class AttackOrderPowerInfo : SupportPowerInfo, Requires<AttackBaseInfo>
+	sealed class AttackOrderPowerInfo : SupportPowerInfo, Requires<AttackBaseInfo>
 	{
 		[Desc("Range circle color.")]
 		public readonly Color CircleColor = Color.Red;
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new AttackOrderPower(init.Self, this); }
 	}
 
-	class AttackOrderPower : SupportPower, INotifyCreated, INotifyBurstComplete
+	sealed class AttackOrderPower : SupportPower, INotifyCreated, INotifyBurstComplete
 	{
 		readonly AttackOrderPowerInfo info;
 		AttackBase attack;

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	class ChronoshiftPowerInfo : SupportPowerInfo
+	sealed class ChronoshiftPowerInfo : SupportPowerInfo
 	{
 		[FieldLoader.Require]
 		[Desc("Size of the footprint of the affected area.")]
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new ChronoshiftPower(init.Self, this); }
 	}
 
-	class ChronoshiftPower : SupportPower
+	sealed class ChronoshiftPower : SupportPower
 	{
 		readonly char[] footprint;
 		readonly CVec dimensions;
@@ -140,7 +140,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			return true;
 		}
 
-		class SelectChronoshiftTarget : OrderGenerator
+		sealed class SelectChronoshiftTarget : OrderGenerator
 		{
 			readonly ChronoshiftPower power;
 			readonly char[] footprint;
@@ -218,7 +218,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		class SelectDestination : OrderGenerator
+		sealed class SelectDestination : OrderGenerator
 		{
 			readonly ChronoshiftPower power;
 			readonly CPos sourceLocation;

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/GpsPower.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Requires `GpsWatcher` on the player actor.")]
-	class GpsPowerInfo : SupportPowerInfo
+	sealed class GpsPowerInfo : SupportPowerInfo
 	{
 		[Desc("Delay in ticks between launching and revealing the map.")]
 		public readonly int RevealDelay = 0;
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new GpsPower(init.Self, this); }
 	}
 
-	class GpsPower : SupportPower, INotifyKilled, INotifySold, INotifyOwnerChanged, ITick
+	sealed class GpsPower : SupportPower, INotifyKilled, INotifySold, INotifyOwnerChanged, ITick
 	{
 		readonly Actor self;
 		readonly GpsPowerInfo info;

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/IonCannonPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/IonCannonPower.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	class IonCannonPowerInfo : SupportPowerInfo, IRulesetLoaded
+	sealed class IonCannonPowerInfo : SupportPowerInfo, IRulesetLoaded
 	{
 		[ActorReference]
 		[Desc("Actor to spawn when the attack starts")]
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		}
 	}
 
-	class IonCannonPower : SupportPower
+	sealed class IonCannonPower : SupportPower
 	{
 		readonly IonCannonPowerInfo info;
 

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -148,7 +148,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			return MoveStep(MovementSpeed, facing);
 		}
 
-		WVec MoveStep(int speed, WAngle facing)
+		static WVec MoveStep(int speed, WAngle facing)
 		{
 			var dir = new WVec(0, -1024, 0).Rotate(WRot.FromYaw(facing));
 			return speed * dir / 1024;

--- a/OpenRA.Mods.Cnc/Traits/World/ShroudPalette.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/ShroudPalette.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Cnc.Traits
 {
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Adds the hard-coded shroud palette to the game")]
-	class ShroudPaletteInfo : TraitInfo
+	sealed class ShroudPaletteInfo : TraitInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new ShroudPalette(this); }
 	}
 
-	class ShroudPalette : ILoadsPalettes, IProvidesAssetBrowserPalettes
+	sealed class ShroudPalette : ILoadsPalettes, IProvidesAssetBrowserPalettes
 	{
 		readonly ShroudPaletteInfo info;
 

--- a/OpenRA.Mods.Cnc/Traits/World/TSEditorResourceLayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSEditorResourceLayer.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[TraitLocation(SystemActors.EditorWorld)]
-	class TSEditorResourceLayerInfo : EditorResourceLayerInfo, Requires<EditorActorLayerInfo>
+	sealed class TSEditorResourceLayerInfo : EditorResourceLayerInfo, Requires<EditorActorLayerInfo>
 	{
 		public readonly string VeinType = "Veins";
 
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new TSEditorResourceLayer(init.Self, this); }
 	}
 
-	class TSEditorResourceLayer : EditorResourceLayer
+	sealed class TSEditorResourceLayer : EditorResourceLayer
 	{
 		readonly TSEditorResourceLayerInfo info;
 		readonly EditorActorLayer actorLayer;

--- a/OpenRA.Mods.Cnc/Traits/World/TSResourceLayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSResourceLayer.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[TraitLocation(SystemActors.World)]
-	class TSResourceLayerInfo : ResourceLayerInfo
+	sealed class TSResourceLayerInfo : ResourceLayerInfo
 	{
 		public readonly string VeinType = "Veins";
 
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new TSResourceLayer(init.Self, this); }
 	}
 
-	class TSResourceLayer : ResourceLayer, INotifyActorDisposing
+	sealed class TSResourceLayer : ResourceLayer, INotifyActorDisposing
 	{
 		readonly TSResourceLayerInfo info;
 		readonly HashSet<CPos> veinholeCells = new();

--- a/OpenRA.Mods.Cnc/Traits/World/TSShroudPalette.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSShroudPalette.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Cnc.Traits
 {
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Adds the hard-coded shroud palette to the game")]
-	class TSShroudPaletteInfo : TraitInfo
+	sealed class TSShroudPaletteInfo : TraitInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new TSShroudPalette(this); }
 	}
 
-	class TSShroudPalette : ILoadsPalettes, IProvidesAssetBrowserPalettes
+	sealed class TSShroudPalette : ILoadsPalettes, IProvidesAssetBrowserPalettes
 	{
 		readonly TSShroudPaletteInfo info;
 

--- a/OpenRA.Mods.Cnc/UtilityCommands/ConvertPngToShpCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ConvertPngToShpCommand.cs
@@ -20,7 +20,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Cnc.UtilityCommands
 {
-	class ConvertPngToShpCommand : IUtilityCommand
+	sealed class ConvertPngToShpCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--shp";
 

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertMapCommand.cs
@@ -19,7 +19,7 @@ using OpenRA.Mods.Common.FileFormats;
 
 namespace OpenRA.Mods.Cnc.UtilityCommands
 {
-	class ImportRedAlertMapCommand : ImportGen1MapCommand, IUtilityCommand
+	sealed class ImportRedAlertMapCommand : ImportGen1MapCommand, IUtilityCommand
 	{
 		// TODO: 128x128 is probably not true for "mega maps" from the expansions.
 		public ImportRedAlertMapCommand()

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianDawnMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianDawnMapCommand.cs
@@ -17,7 +17,7 @@ using OpenRA.Mods.Common.FileFormats;
 
 namespace OpenRA.Mods.Cnc.UtilityCommands
 {
-	class ImportTiberianDawnMapCommand : ImportGen1MapCommand, IUtilityCommand
+	sealed class ImportTiberianDawnMapCommand : ImportGen1MapCommand, IUtilityCommand
 	{
 		// NOTE: 64x64 map size is a C&C95 engine limitation
 		public ImportTiberianDawnMapCommand()

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianSunMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianSunMapCommand.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.UtilityCommands
 {
-	class ImportTiberianSunMapCommand : ImportGen2MapCommand, IUtilityCommand
+	sealed class ImportTiberianSunMapCommand : ImportGen2MapCommand, IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--import-ts-map";
 

--- a/OpenRA.Mods.Cnc/UtilityCommands/LegacyRulesImporter.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/LegacyRulesImporter.cs
@@ -17,7 +17,7 @@ using OpenRA.Mods.Common.FileFormats;
 
 namespace OpenRA.Mods.Cnc.UtilityCommands
 {
-	class LegacyRulesImporter : IUtilityCommand
+	sealed class LegacyRulesImporter : IUtilityCommand
 	{
 		bool IUtilityCommand.ValidateArguments(string[] args)
 		{

--- a/OpenRA.Mods.Cnc/UtilityCommands/LegacySequenceImporter.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/LegacySequenceImporter.cs
@@ -252,7 +252,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			Console.WriteLine();
 		}
 
-		void ConvertStartLengthFacings(string input)
+		static void ConvertStartLengthFacings(string input)
 		{
 			var splitting = input.Split(',');
 			if (splitting.Length >= 3)

--- a/OpenRA.Mods.Cnc/UtilityCommands/LegacySequenceImporter.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/LegacySequenceImporter.cs
@@ -16,7 +16,7 @@ using OpenRA.Mods.Common.FileFormats;
 
 namespace OpenRA.Mods.Cnc.UtilityCommands
 {
-	class ImportLegacySequenceCommand : IUtilityCommand
+	sealed class ImportLegacySequenceCommand : IUtilityCommand
 	{
 		bool IUtilityCommand.ValidateArguments(string[] args)
 		{

--- a/OpenRA.Mods.Cnc/UtilityCommands/LegacyTilesetImporter.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/LegacyTilesetImporter.cs
@@ -18,7 +18,7 @@ using OpenRA.Mods.Common.FileFormats;
 
 namespace OpenRA.Mods.Cnc.UtilityCommands
 {
-	class ImportLegacyTilesetCommand : IUtilityCommand
+	sealed class ImportLegacyTilesetCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--tileset-import";
 

--- a/OpenRA.Mods.Cnc/UtilityCommands/RemapShpCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/RemapShpCommand.cs
@@ -20,7 +20,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Cnc.UtilityCommands
 {
-	class RemapShpCommand : IUtilityCommand
+	sealed class RemapShpCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--remap";
 

--- a/OpenRA.Mods.Cnc/Widgets/Logic/PreReleaseWarningPrompt.cs
+++ b/OpenRA.Mods.Cnc/Widgets/Logic/PreReleaseWarningPrompt.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 				ShowMainMenu(world);
 		}
 
-		void ShowMainMenu(World world)
+		static void ShowMainMenu(World world)
 		{
 			promptAccepted = true;
 			Ui.ResetAll();

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -212,7 +212,7 @@ namespace OpenRA.Mods.Common.Activities
 		}
 	}
 
-	class FlyAttackRun : Activity
+	sealed class FlyAttackRun : Activity
 	{
 		readonly AttackAircraft attack;
 		readonly WDist exitRange;
@@ -261,7 +261,7 @@ namespace OpenRA.Mods.Common.Activities
 		}
 	}
 
-	class StrafeAttackRun : Activity
+	sealed class StrafeAttackRun : Activity
 	{
 		readonly AttackAircraft attackAircraft;
 		readonly Aircraft aircraft;

--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Activities
 				yield return new TargetLineNode(destination, targetLineColor.Value);
 		}
 
-		class ReleaseUnit : Activity
+		sealed class ReleaseUnit : Activity
 		{
 			readonly Carryall carryall;
 			readonly BodyOrientation body;

--- a/OpenRA.Mods.Common/Activities/Demolish.cs
+++ b/OpenRA.Mods.Common/Activities/Demolish.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
-	class Demolish : Enter
+	sealed class Demolish : Enter
 	{
 		readonly int delay;
 		readonly int flashes;

--- a/OpenRA.Mods.Common/Activities/DonateCash.cs
+++ b/OpenRA.Mods.Common/Activities/DonateCash.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
-	class DonateCash : Enter
+	sealed class DonateCash : Enter
 	{
 		readonly int payload;
 		readonly int playerExperience;

--- a/OpenRA.Mods.Common/Activities/DonateExperience.cs
+++ b/OpenRA.Mods.Common/Activities/DonateExperience.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
-	class DonateExperience : Enter
+	sealed class DonateExperience : Enter
 	{
 		readonly int level;
 		readonly int playerExperience;

--- a/OpenRA.Mods.Common/Activities/InstantRepair.cs
+++ b/OpenRA.Mods.Common/Activities/InstantRepair.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
-	class InstantRepair : Enter
+	sealed class InstantRepair : Enter
 	{
 		readonly InstantlyRepairsInfo info;
 

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -312,7 +312,7 @@ namespace OpenRA.Mods.Common.Activities
 			path = null;
 		}
 
-		bool CellIsEvacuating(Actor self, CPos cell)
+		static bool CellIsEvacuating(Actor self, CPos cell)
 		{
 			foreach (var actor in self.World.ActorMap.GetActorsAt(cell))
 			{

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -486,7 +486,7 @@ namespace OpenRA.Mods.Common.Activities
 			}
 		}
 
-		class MoveFirstHalf : MovePart
+		sealed class MoveFirstHalf : MovePart
 		{
 			public MoveFirstHalf(Move move, WPos from, WPos to, WAngle fromFacing, WAngle toFacing,
 				WRot? fromTerrainOrientation, WRot? toTerrainOrientation, int terrainOrientationMargin, int carryoverProgress, bool shouldArc, bool movingOnGroundLayer)
@@ -569,7 +569,7 @@ namespace OpenRA.Mods.Common.Activities
 			}
 		}
 
-		class MoveSecondHalf : MovePart
+		sealed class MoveSecondHalf : MovePart
 		{
 			public MoveSecondHalf(Move move, WPos from, WPos to, WAngle fromFacing, WAngle toFacing,
 				WRot? fromTerrainOrientation, WRot? toTerrainOrientation, int terrainOrientationMargin, int carryoverProgress, bool shouldArc, bool movingOnGroundLayer)

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -135,7 +135,7 @@ namespace OpenRA.Mods.Common.Activities
 				yield return new TargetLineNode(Target.FromActor(cargo), targetLineColor.Value);
 		}
 
-		class AttachUnit : Activity
+		sealed class AttachUnit : Activity
 		{
 			readonly Actor cargo;
 			readonly Carryable carryable;

--- a/OpenRA.Mods.Common/Activities/RepairBridge.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBridge.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
-	class RepairBridge : Enter
+	sealed class RepairBridge : Enter
 	{
 		readonly EnterBehaviour enterBehaviour;
 		readonly string speechNotification;

--- a/OpenRA.Mods.Common/Activities/RideTransport.cs
+++ b/OpenRA.Mods.Common/Activities/RideTransport.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
-	class RideTransport : Enter
+	sealed class RideTransport : Enter
 	{
 		readonly Passenger passenger;
 

--- a/OpenRA.Mods.Common/Activities/Sell.cs
+++ b/OpenRA.Mods.Common/Activities/Sell.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
-	class Sell : Activity
+	sealed class Sell : Activity
 	{
 		readonly IHealth health;
 		readonly SellableInfo sellableInfo;

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -162,7 +162,7 @@ namespace OpenRA.Mods.Common.Activities
 		}
 	}
 
-	class IssueOrderAfterTransform : Activity
+	sealed class IssueOrderAfterTransform : Activity
 	{
 		readonly string orderString;
 		readonly Target target;

--- a/OpenRA.Mods.Common/ActorInitializer.cs
+++ b/OpenRA.Mods.Common/ActorInitializer.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common
 			: base(value) { }
 	}
 
-	class ActorInitLoader : TypeConverter
+	sealed class ActorInitLoader : TypeConverter
 	{
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 		{

--- a/OpenRA.Mods.Common/AudioLoaders/Mp3Loader.cs
+++ b/OpenRA.Mods.Common/AudioLoaders/Mp3Loader.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.AudioLoaders
 {
 	public class Mp3Loader : ISoundLoader
 	{
-		bool IsMp3(Stream s)
+		static bool IsMp3(Stream s)
 		{
 			var start = s.Position;
 
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.AudioLoaders
 			}
 		}
 
-		Stream Clone(Mp3Format cloneFrom)
+		static Stream Clone(Mp3Format cloneFrom)
 		{
 			return SegmentStream.CreateWithoutOwningStream(cloneFrom.stream, 0, (int)cloneFrom.stream.Length);
 		}

--- a/OpenRA.Mods.Common/AudioLoaders/WavLoader.cs
+++ b/OpenRA.Mods.Common/AudioLoaders/WavLoader.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.AudioLoaders
 {
 	public class WavLoader : ISoundLoader
 	{
-		bool IsWave(Stream s)
+		static bool IsWave(Stream s)
 		{
 			var start = s.Position;
 			var type = s.ReadASCII(4);

--- a/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Widgets
 		}
 	}
 
-	class AddActorAction : IEditorAction
+	sealed class AddActorAction : IEditorAction
 	{
 		public string Text { get; private set; }
 

--- a/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
@@ -174,7 +174,7 @@ namespace OpenRA.Mods.Common.Widgets
 		}
 	}
 
-	class CopyPasteEditorAction : IEditorAction
+	sealed class CopyPasteEditorAction : IEditorAction
 	{
 		[TranslationReference("amount")]
 		const string CopiedTiles = "notification-copied-tiles";
@@ -271,7 +271,7 @@ namespace OpenRA.Mods.Common.Widgets
 		}
 	}
 
-	class UndoCopyPaste
+	sealed class UndoCopyPaste
 	{
 		public CPos Cell { get; }
 		public TerrainTile MapTile { get; }

--- a/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
@@ -108,7 +108,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public void Dispose() { }
 	}
 
-	class RemoveActorAction : IEditorAction
+	sealed class RemoveActorAction : IEditorAction
 	{
 		[TranslationReference("name", "id")]
 		const string RemovedActor = "notification-removed-actor";
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Common.Widgets
 		}
 	}
 
-	class RemoveResourceAction : IEditorAction
+	sealed class RemoveResourceAction : IEditorAction
 	{
 		[TranslationReference("type")]
 		const string RemovedResource = "notification-removed-resource";

--- a/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
@@ -103,7 +103,7 @@ namespace OpenRA.Mods.Common.Widgets
 		}
 	}
 
-	class AddResourcesEditorAction : IEditorAction
+	sealed class AddResourcesEditorAction : IEditorAction
 	{
 		[TranslationReference("amount", "type")]
 		const string AddedResource = "notification-added-resource";

--- a/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
@@ -153,7 +153,7 @@ namespace OpenRA.Mods.Common.Widgets
 		}
 	}
 
-	class PaintTileEditorAction : IEditorAction
+	sealed class PaintTileEditorAction : IEditorAction
 	{
 		[TranslationReference("id")]
 		const string AddedTile = "notification-added-tile";
@@ -225,7 +225,7 @@ namespace OpenRA.Mods.Common.Widgets
 		}
 	}
 
-	class FloodFillEditorAction : IEditorAction
+	sealed class FloodFillEditorAction : IEditorAction
 	{
 		[TranslationReference("id")]
 		const string FilledTile = "notification-filled-tile";
@@ -363,7 +363,7 @@ namespace OpenRA.Mods.Common.Widgets
 		}
 	}
 
-	class UndoTile
+	sealed class UndoTile
 	{
 		public CPos Cell { get; }
 		public TerrainTile MapTile { get; }

--- a/OpenRA.Mods.Common/Effects/FloatingSprite.cs
+++ b/OpenRA.Mods.Common/Effects/FloatingSprite.cs
@@ -15,7 +15,7 @@ using OpenRA.Graphics;
 
 namespace OpenRA.Mods.Common.Effects
 {
-	class FloatingSprite : IEffect, ISpatiallyPartitionable
+	sealed class FloatingSprite : IEffect, ISpatiallyPartitionable
 	{
 		readonly WDist[] speed;
 		readonly WDist[] gravity;

--- a/OpenRA.Mods.Common/FileFormats/Blast.cs
+++ b/OpenRA.Mods.Common/FileFormats/Blast.cs
@@ -200,7 +200,7 @@ namespace OpenRA.Mods.Common.FileFormats
 		}
 	}
 
-	class BitReader
+	sealed class BitReader
 	{
 		readonly Stream stream;
 		byte bitBuffer = 0;
@@ -242,7 +242,7 @@ namespace OpenRA.Mods.Common.FileFormats
 	 * codes.  Those tables are the number of codes of each length, and the symbols
 	 * sorted by length, retaining their original order within each length.
 	 */
-	class Huffman
+	sealed class Huffman
 	{
 		public short[] Count; // number of symbols of each length
 		public short[] Symbol; // canonically ordered symbols

--- a/OpenRA.Mods.Common/FileFormats/InstallShieldCABCompression.cs
+++ b/OpenRA.Mods.Common/FileFormats/InstallShieldCABCompression.cs
@@ -242,7 +242,7 @@ namespace OpenRA.Mods.Common.FileFormats
 			}
 		}
 
-		class CabExtracter
+		sealed class CabExtracter
 		{
 			readonly FileDescriptor file;
 			readonly Dictionary<int, Stream> volumes;

--- a/OpenRA.Mods.Common/FileFormats/MSCabCompression.cs
+++ b/OpenRA.Mods.Common/FileFormats/MSCabCompression.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.FileFormats
 {
 	public sealed class MSCabCompression
 	{
-		class CabFolder
+		sealed class CabFolder
 		{
 			public readonly uint BlockOffset;
 			public readonly ushort BlockCount;
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.FileFormats
 			}
 		}
 
-		class CabFile
+		sealed class CabFile
 		{
 			public readonly string FileName;
 			public readonly uint DecompressedLength;

--- a/OpenRA.Mods.Common/FileFormats/WavReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/WavReader.cs
@@ -258,7 +258,7 @@ namespace OpenRA.Mods.Common.FileFormats
 				return ++currentBlock >= numBlocks;
 			}
 
-			short WriteSample(short t, Queue<byte> data)
+			static short WriteSample(short t, Queue<byte> data)
 			{
 				data.Enqueue((byte)t);
 				data.Enqueue((byte)(t >> 8));
@@ -266,7 +266,7 @@ namespace OpenRA.Mods.Common.FileFormats
 			}
 
 			// This code contains elements from libsndfile
-			short DecodeNibble(short nibble, byte bpred, ref short idelta, ref short s1, ref short s2)
+			static short DecodeNibble(short nibble, byte bpred, ref short idelta, ref short s1, ref short s2)
 			{
 				var predict = (s1 * AdaptCoeff1[bpred] + s2 * AdaptCoeff2[bpred]) >> 8;
 

--- a/OpenRA.Mods.Common/Graphics/ModelRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/ModelRenderable.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.Graphics
 			return new FinalizedModelRenderable(wr, this);
 		}
 
-		class FinalizedModelRenderable : IFinalizedRenderable
+		sealed class FinalizedModelRenderable : IFinalizedRenderable
 		{
 			readonly ModelRenderable model;
 			readonly ModelRenderProxy renderProxy;

--- a/OpenRA.Mods.Common/Graphics/SelectionBarsAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBarsAnnotationRenderable.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Graphics
 			}
 		}
 
-		void DrawSelectionBar(float2 start, float2 end, float value, Color barColor)
+		static void DrawSelectionBar(float2 start, float2 end, float value, Color barColor)
 		{
 			var c = Color.FromArgb(128, 30, 30, 30);
 			var c2 = Color.FromArgb(128, 10, 10, 10);

--- a/OpenRA.Mods.Common/Graphics/UIModelRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/UIModelRenderable.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Graphics
 			return new FinalizedUIModelRenderable(wr, this);
 		}
 
-		class FinalizedUIModelRenderable : IFinalizedRenderable
+		sealed class FinalizedUIModelRenderable : IFinalizedRenderable
 		{
 			readonly UIModelRenderable model;
 			readonly ModelRenderProxy renderProxy;

--- a/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Lint
 					CheckTrait(emitError, actorInfo.Value, traitInfo, mapRules);
 		}
 
-		void CheckTrait(Action<string> emitError, ActorInfo actorInfo, TraitInfo traitInfo, Ruleset rules)
+		static void CheckTrait(Action<string> emitError, ActorInfo actorInfo, TraitInfo traitInfo, Ruleset rules)
 		{
 			var actualType = traitInfo.GetType();
 			foreach (var field in Utility.GetFields(actualType))
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Lint
 			}
 		}
 
-		void CheckActorReference(Action<string> emitError, ActorInfo actorInfo, TraitInfo traitInfo,
+		static void CheckActorReference(Action<string> emitError, ActorInfo actorInfo, TraitInfo traitInfo,
 			FieldInfo fieldInfo, IReadOnlyDictionary<string, ActorInfo> dict, ActorReferenceAttribute attribute)
 		{
 			var values = LintExts.GetFieldValues(traitInfo, fieldInfo, attribute.DictionaryReference);
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Lint
 			}
 		}
 
-		void CheckWeaponReference(Action<string> emitError, ActorInfo actorInfo, TraitInfo traitInfo,
+		static void CheckWeaponReference(Action<string> emitError, ActorInfo actorInfo, TraitInfo traitInfo,
 			FieldInfo fieldInfo, IReadOnlyDictionary<string, WeaponInfo> dict)
 		{
 			var values = LintExts.GetFieldValues(traitInfo, fieldInfo);
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Lint
 			}
 		}
 
-		void CheckVoiceReference(Action<string> emitError, ActorInfo actorInfo, TraitInfo traitInfo,
+		static void CheckVoiceReference(Action<string> emitError, ActorInfo actorInfo, TraitInfo traitInfo,
 			FieldInfo fieldInfo, IReadOnlyDictionary<string, SoundInfo> dict)
 		{
 			var values = LintExts.GetFieldValues(traitInfo, fieldInfo);

--- a/OpenRA.Mods.Common/Lint/CheckAngle.cs
+++ b/OpenRA.Mods.Common/Lint/CheckAngle.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, mapRules);
 		}
 
-		void Run(Action<string> emitError, Ruleset rules)
+		static void Run(Action<string> emitError, Ruleset rules)
 		{
 			foreach (var weaponInfo in rules.Weapons)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckAngle.cs
+++ b/OpenRA.Mods.Common/Lint/CheckAngle.cs
@@ -15,7 +15,7 @@ using OpenRA.Server;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckAngle : ILintRulesPass, ILintServerMapPass
+	sealed class CheckAngle : ILintRulesPass, ILintServerMapPass
 	{
 		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{

--- a/OpenRA.Mods.Common/Lint/CheckChromeHotkeys.cs
+++ b/OpenRA.Mods.Common/Lint/CheckChromeHotkeys.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Lint
 	[AttributeUsage(AttributeTargets.Method)]
 	public sealed class CustomLintableHotkeyNames : Attribute { }
 
-	class CheckChromeHotkeys : ILintPass
+	sealed class CheckChromeHotkeys : ILintPass
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData)
 		{

--- a/OpenRA.Mods.Common/Lint/CheckChromeLogic.cs
+++ b/OpenRA.Mods.Common/Lint/CheckChromeLogic.cs
@@ -15,7 +15,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckChromeLogic : ILintPass
+	sealed class CheckChromeLogic : ILintPass
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData)
 		{

--- a/OpenRA.Mods.Common/Lint/CheckConditions.cs
+++ b/OpenRA.Mods.Common/Lint/CheckConditions.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, emitWarning, mapRules);
 		}
 
-		void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		static void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckCursors.cs
+++ b/OpenRA.Mods.Common/Lint/CheckCursors.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, modData, mapRules);
 		}
 
-		void Run(Action<string> emitError, ModData modData, Ruleset rules)
+		static void Run(Action<string> emitError, ModData modData, Ruleset rules)
 		{
 			var fileSystem = modData.DefaultFileSystem;
 			var sequenceYaml = MiniYaml.Merge(modData.Manifest.Cursors.Select(s => MiniYaml.FromStream(fileSystem.Open(s), s)));

--- a/OpenRA.Mods.Common/Lint/CheckCursors.cs
+++ b/OpenRA.Mods.Common/Lint/CheckCursors.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckCursors : ILintRulesPass, ILintServerMapPass
+	sealed class CheckCursors : ILintRulesPass, ILintServerMapPass
 	{
 		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{

--- a/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
+++ b/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, mapRules);
 		}
 
-		void Run(Action<string> emitError, Ruleset rules)
+		static void Run(Action<string> emitError, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
+++ b/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckDefaultVisibility : ILintRulesPass, ILintServerMapPass
+	sealed class CheckDefaultVisibility : ILintRulesPass, ILintServerMapPass
 	{
 		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{

--- a/OpenRA.Mods.Common/Lint/CheckHitShapes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckHitShapes.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, mapRules);
 		}
 
-		void Run(Action<string> emitError, Ruleset rules)
+		static void Run(Action<string> emitError, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckHitShapes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckHitShapes.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckHitShapes : ILintRulesPass, ILintServerMapPass
+	sealed class CheckHitShapes : ILintRulesPass, ILintServerMapPass
 	{
 		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{

--- a/OpenRA.Mods.Common/Lint/CheckInteractable.cs
+++ b/OpenRA.Mods.Common/Lint/CheckInteractable.cs
@@ -16,7 +16,7 @@ using OpenRA.Server;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckInteractable : ILintRulesPass, ILintServerMapPass
+	sealed class CheckInteractable : ILintRulesPass, ILintServerMapPass
 	{
 		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{

--- a/OpenRA.Mods.Common/Lint/CheckInteractable.cs
+++ b/OpenRA.Mods.Common/Lint/CheckInteractable.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, mapRules, modData);
 		}
 
-		void Run(Action<string> emitError, Ruleset rules, ModData modData)
+		static void Run(Action<string> emitError, Ruleset rules, ModData modData)
 		{
 			// As the map has not been created we need to get MapGrid info directly from manifest.
 			var grid = modData.Manifest.Get<MapGrid>();

--- a/OpenRA.Mods.Common/Lint/CheckLocomotorReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckLocomotorReferences.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, mapRules);
 		}
 
-		void Run(Action<string> emitError, Ruleset rules)
+		static void Run(Action<string> emitError, Ruleset rules)
 		{
 			var worldActor = rules.Actors[SystemActors.World];
 			var locomotorInfos = worldActor.TraitInfos<LocomotorInfo>().ToArray();
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Lint
 			}
 		}
 
-		void CheckLocomotors(ActorInfo actorInfo, Action<string> emitError, LocomotorInfo[] locomotorInfos, string locomotor)
+		static void CheckLocomotors(ActorInfo actorInfo, Action<string> emitError, LocomotorInfo[] locomotorInfos, string locomotor)
 		{
 			if (!locomotorInfos.Any(l => l.Name == locomotor))
 				emitError($"Actor `{actorInfo.Name}` defines Locomotor `{locomotor}` not found on World actor.");

--- a/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
+++ b/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, map.MapFormat, map.Author, map.Title, map.Categories);
 		}
 
-		void Run(Action<string> emitError, int mapFormat, string author, string title, string[] categories)
+		static void Run(Action<string> emitError, int mapFormat, string author, string title, string[] categories)
 		{
 			if (mapFormat < Map.SupportedMapFormat)
 				emitError($"Map format `{mapFormat}` does not match the supported version `{Map.CurrentMapFormat}`.");

--- a/OpenRA.Mods.Common/Lint/CheckNotifications.cs
+++ b/OpenRA.Mods.Common/Lint/CheckNotifications.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, mapRules);
 		}
 
-		void Run(Action<string> emitError, Ruleset rules)
+		static void Run(Action<string> emitError, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckNotifications.cs
+++ b/OpenRA.Mods.Common/Lint/CheckNotifications.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckNotifications : ILintRulesPass, ILintServerMapPass
+	sealed class CheckNotifications : ILintRulesPass, ILintServerMapPass
 	{
 		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{

--- a/OpenRA.Mods.Common/Lint/CheckPalettes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPalettes.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckPalettes : ILintRulesPass, ILintServerMapPass
+	sealed class CheckPalettes : ILintRulesPass, ILintServerMapPass
 	{
 		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{

--- a/OpenRA.Mods.Common/Lint/CheckPalettes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPalettes.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, mapRules);
 		}
 
-		void Run(Action<string> emitError, Ruleset rules)
+		static void Run(Action<string> emitError, Ruleset rules)
 		{
 			var palettes = new List<string>();
 			var playerPalettes = new List<string>();
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Lint
 			}
 		}
 
-		void GetPalettes(Ruleset rules, List<string> palettes, List<string> playerPalettes, Action<string> emitError)
+		static void GetPalettes(Ruleset rules, List<string> palettes, List<string> playerPalettes, Action<string> emitError)
 		{
 			// Palettes are only defined on the world actor.
 			var worldActorInfo = rules.Actors[SystemActors.World];

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, emitWarning, map.Players, map.Visibility, map.WorldActorInfo, map.SpawnPoints);
 		}
 
-		void Run(Action<string> emitError, Action<string> emitWarning, MapPlayers players, MapVisibility visibility, ActorInfo worldActorInfo, CPos[] spawnPoints)
+		static void Run(Action<string> emitError, Action<string> emitWarning, MapPlayers players, MapVisibility visibility, ActorInfo worldActorInfo, CPos[] spawnPoints)
 		{
 			if (players.Players.Count > 64)
 				emitError("Defining more than 64 players is not allowed.");

--- a/OpenRA.Mods.Common/Lint/CheckRangeLimit.cs
+++ b/OpenRA.Mods.Common/Lint/CheckRangeLimit.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, mapRules);
 		}
 
-		void Run(Action<string> emitError, Ruleset rules)
+		static void Run(Action<string> emitError, Ruleset rules)
 		{
 			foreach (var weaponInfo in rules.Weapons)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckRangeLimit.cs
+++ b/OpenRA.Mods.Common/Lint/CheckRangeLimit.cs
@@ -15,7 +15,7 @@ using OpenRA.Server;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckRangeLimit : ILintRulesPass, ILintServerMapPass
+	sealed class CheckRangeLimit : ILintRulesPass, ILintServerMapPass
 	{
 		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{

--- a/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
+++ b/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, mapRules);
 		}
 
-		void Run(Action<string> emitError, Ruleset rules)
+		static void Run(Action<string> emitError, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
+++ b/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckRevealFootprint : ILintRulesPass, ILintServerMapPass
+	sealed class CheckRevealFootprint : ILintRulesPass, ILintServerMapPass
 	{
 		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckSequences : ILintSequencesPass, ILintServerMapPass
+	sealed class CheckSequences : ILintSequencesPass, ILintServerMapPass
 	{
 		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
 		{

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, emitWarning, rules, sequences);
 		}
 
-		void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules, SequenceSet sequences)
+		static void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules, SequenceSet sequences)
 		{
 			var factions = rules.Actors[SystemActors.World].TraitInfos<FactionInfo>().Select(f => f.InternalName).ToArray();
 			foreach (var actorInfo in rules.Actors)

--- a/OpenRA.Mods.Common/Lint/CheckSpriteBodies.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSpriteBodies.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, mapRules);
 		}
 
-		void Run(Action<string> emitError, Ruleset rules)
+		static void Run(Action<string> emitError, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckSpriteBodies.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSpriteBodies.cs
@@ -16,7 +16,7 @@ using OpenRA.Server;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckSpriteBodies : ILintRulesPass, ILintServerMapPass
+	sealed class CheckSpriteBodies : ILintRulesPass, ILintServerMapPass
 	{
 		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{

--- a/OpenRA.Mods.Common/Lint/CheckSyncAnnotations.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSyncAnnotations.cs
@@ -16,7 +16,7 @@ using System.Reflection;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckSyncAnnotations : ILintPass
+	sealed class CheckSyncAnnotations : ILintPass
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData)
 		{

--- a/OpenRA.Mods.Common/Lint/CheckTooltips.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTooltips.cs
@@ -16,7 +16,7 @@ using OpenRA.Server;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckTooltips : ILintRulesPass, ILintServerMapPass
+	sealed class CheckTooltips : ILintRulesPass, ILintServerMapPass
 	{
 		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{

--- a/OpenRA.Mods.Common/Lint/CheckTooltips.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTooltips.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, mapRules);
 		}
 
-		void Run(Action<string> emitError, Ruleset rules)
+		static void Run(Action<string> emitError, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckTraitPrerequisites.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTraitPrerequisites.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, emitWarning, mapRules);
 		}
 
-		void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		static void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckTranslationReference : ILintPass, ILintMapPass
+	sealed class CheckTranslationReference : ILintPass, ILintMapPass
 	{
 		const BindingFlags Binding = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
 

--- a/OpenRA.Mods.Common/Lint/CheckTranslationSyntax.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTranslationSyntax.cs
@@ -18,7 +18,7 @@ using OpenRA.FileSystem;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckTranslationSyntax : ILintPass, ILintMapPass
+	sealed class CheckTranslationSyntax : ILintPass, ILintMapPass
 	{
 		void ILintMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
 		{

--- a/OpenRA.Mods.Common/Lint/CheckUnknownTraitFields.cs
+++ b/OpenRA.Mods.Common/Lint/CheckUnknownTraitFields.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Lint
 			CheckMapYaml(emitError, modData, map, map.RuleDefinitions);
 		}
 
-		string NormalizeName(string key)
+		static string NormalizeName(string key)
 		{
 			var name = key.Split('@')[0];
 			if (name.StartsWith("-", StringComparison.Ordinal))
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Lint
 			return name;
 		}
 
-		void CheckActors(IEnumerable<MiniYamlNode> actors, Action<string> emitError, ModData modData)
+		static void CheckActors(IEnumerable<MiniYamlNode> actors, Action<string> emitError, ModData modData)
 		{
 			foreach (var actor in actors)
 			{
@@ -89,7 +89,7 @@ namespace OpenRA.Mods.Common.Lint
 			}
 		}
 
-		void CheckMapYaml(Action<string> emitError, ModData modData, IReadOnlyFileSystem fileSystem, MiniYaml ruleDefinitions)
+		static void CheckMapYaml(Action<string> emitError, ModData modData, IReadOnlyFileSystem fileSystem, MiniYaml ruleDefinitions)
 		{
 			if (ruleDefinitions == null)
 				return;

--- a/OpenRA.Mods.Common/Lint/CheckUnknownTraitFields.cs
+++ b/OpenRA.Mods.Common/Lint/CheckUnknownTraitFields.cs
@@ -16,7 +16,7 @@ using OpenRA.Server;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckUnknownTraitFields : ILintPass, ILintMapPass, ILintServerMapPass
+	sealed class CheckUnknownTraitFields : ILintPass, ILintMapPass, ILintServerMapPass
 	{
 		void ILintPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData)
 		{

--- a/OpenRA.Mods.Common/Lint/CheckUnknownWeaponFields.cs
+++ b/OpenRA.Mods.Common/Lint/CheckUnknownWeaponFields.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Lint
 			CheckMapYaml(emitError, emitWarning, modData, map, map.WeaponDefinitions);
 		}
 
-		string NormalizeName(string key)
+		static string NormalizeName(string key)
 		{
 			var name = key.Split('@')[0];
 			if (name.StartsWith("-", StringComparison.Ordinal))
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Lint
 			return name;
 		}
 
-		void CheckWeapons(IEnumerable<MiniYamlNode> weapons, Action<string> emitError, Action<string> emitWarning, ModData modData)
+		static void CheckWeapons(IEnumerable<MiniYamlNode> weapons, Action<string> emitError, Action<string> emitWarning, ModData modData)
 		{
 			var weaponInfo = typeof(WeaponInfo);
 			foreach (var weapon in weapons)
@@ -110,7 +110,7 @@ namespace OpenRA.Mods.Common.Lint
 			}
 		}
 
-		void CheckMapYaml(Action<string> emitError, Action<string> emitWarning, ModData modData, IReadOnlyFileSystem fileSystem, MiniYaml weaponDefinitions)
+		static void CheckMapYaml(Action<string> emitError, Action<string> emitWarning, ModData modData, IReadOnlyFileSystem fileSystem, MiniYaml weaponDefinitions)
 		{
 			if (weaponDefinitions == null)
 				return;

--- a/OpenRA.Mods.Common/Lint/CheckUnknownWeaponFields.cs
+++ b/OpenRA.Mods.Common/Lint/CheckUnknownWeaponFields.cs
@@ -17,7 +17,7 @@ using OpenRA.Server;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class CheckUnknownWeaponFields : ILintPass, ILintMapPass, ILintServerMapPass
+	sealed class CheckUnknownWeaponFields : ILintPass, ILintMapPass, ILintServerMapPass
 	{
 		void ILintPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData)
 		{

--- a/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, mapRules);
 		}
 
-		void Run(Action<string> emitError, Ruleset rules)
+		static void Run(Action<string> emitError, Ruleset rules)
 		{
 			foreach (var actorInfo in rules.Actors)
 			{
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Lint
 			}
 		}
 
-		void CheckVoices(ActorInfo actorInfo, Action<string> emitError, Ruleset rules, string voiceSet)
+		static void CheckVoices(ActorInfo actorInfo, Action<string> emitError, Ruleset rules, string voiceSet)
 		{
 			var soundInfo = rules.Voices[voiceSet.ToLowerInvariant()];
 

--- a/OpenRA.Mods.Common/Lint/CheckWorldAndPlayerInherits.cs
+++ b/OpenRA.Mods.Common/Lint/CheckWorldAndPlayerInherits.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Lint
 			CheckMapYaml(emitError, modData, map, map.RuleDefinitions);
 		}
 
-		void CheckMapYaml(Action<string> emitError, ModData modData, IReadOnlyFileSystem fileSystem, MiniYaml ruleDefinitions)
+		static void CheckMapYaml(Action<string> emitError, ModData modData, IReadOnlyFileSystem fileSystem, MiniYaml ruleDefinitions)
 		{
 			if (ruleDefinitions == null)
 				return;
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, nodes);
 		}
 
-		void Run(Action<string> emitError, List<MiniYamlNode> nodes)
+		static void Run(Action<string> emitError, List<MiniYamlNode> nodes)
 		{
 			// Build a list of all inheritance relationships.
 			var inheritsMap = new Dictionary<string, List<string>>();
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Lint
 			CheckInheritance(emitError, "Player", inheritsMap);
 		}
 
-		void CheckInheritance(Action<string> emitError, string actor, Dictionary<string, List<string>> inheritsMap)
+		static void CheckInheritance(Action<string> emitError, string actor, Dictionary<string, List<string>> inheritsMap)
 		{
 			var toResolve = new Queue<string>(inheritsMap.Keys.Where(k => string.Equals(k, actor, StringComparison.InvariantCultureIgnoreCase)));
 			while (toResolve.TryDequeue(out var key))

--- a/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
+++ b/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, mapRules);
 		}
 
-		void Run(Action<string> emitError, Ruleset rules)
+		static void Run(Action<string> emitError, Ruleset rules)
 		{
 			var providedPrereqs = rules.Actors.SelectMany(a => a.Value.TraitInfos<ITechTreePrerequisiteInfo>().SelectMany(p => p.Prerequisites(a.Value)));
 

--- a/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
+++ b/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
@@ -16,7 +16,7 @@ using OpenRA.Server;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	class LintBuildablePrerequisites : ILintRulesPass, ILintServerMapPass
+	sealed class LintBuildablePrerequisites : ILintRulesPass, ILintServerMapPass
 	{
 		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
 		{

--- a/OpenRA.Mods.Common/LoadScreens/ModContentLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/ModContentLoadScreen.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.LoadScreens
 			}
 		}
 
-		bool IsModInstalled(ModContent content)
+		static bool IsModInstalled(ModContent content)
 		{
 			return content.Packages
 				.Where(p => p.Value.Required)

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Orders
 	{
 		readonly string worldDefaultCursor = ChromeMetrics.Get<string>("WorldDefaultCursor");
 
-		class VariantWrapper
+		sealed class VariantWrapper
 		{
 			public readonly ActorInfo ActorInfo;
 			public readonly BuildingInfo BuildingInfo;

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.Common.Orders
 			this.variants = variants.ToArray();
 		}
 
-		PlaceBuildingCellType MakeCellType(bool valid, bool lineBuild = false)
+		static PlaceBuildingCellType MakeCellType(bool valid, bool lineBuild = false)
 		{
 			var cell = valid ? PlaceBuildingCellType.Valid : PlaceBuildingCellType.Invalid;
 			if (lineBuild)

--- a/OpenRA.Mods.Common/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/UnitOrderGenerator.cs
@@ -193,7 +193,7 @@ namespace OpenRA.Mods.Common.Orders
 			return order;
 		}
 
-		class UnitOrderResult
+		sealed class UnitOrderResult
 		{
 			public readonly Actor Actor;
 			public readonly IOrderTargeter Order;

--- a/OpenRA.Mods.Common/Pathfinder/CellInfoLayerPool.cs
+++ b/OpenRA.Mods.Common/Pathfinder/CellInfoLayerPool.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 					pool.Push(layer);
 		}
 
-		public class PooledCellInfoLayer : IDisposable
+		public sealed class PooledCellInfoLayer : IDisposable
 		{
 			CellInfoLayerPool layerPool;
 			List<CellLayer<CellInfo>> layers = new();

--- a/OpenRA.Mods.Common/Scripting/Global/ActorGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ActorGlobal.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Scripting
 		public ActorGlobal(ScriptContext context)
 			: base(context) { }
 
-		ActorInit CreateInit(string initName, LuaValue value)
+		static ActorInit CreateInit(string initName, LuaValue value)
 		{
 			// Find the requested type
 			var initInstance = initName.Split(ActorInfo.TraitInstanceSeparator);

--- a/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Scripting
 			return a;
 		}
 
-		void Move(Actor actor, CPos dest)
+		static void Move(Actor actor, CPos dest)
 		{
 			var move = actor.TraitOrDefault<IMove>();
 			if (move == null)

--- a/OpenRA.Mods.Common/SpriteLoaders/DdsLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/DdsLoader.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 
 	public class DdsSprite
 	{
-		class DdsFrame : ISpriteFrame
+		sealed class DdsFrame : ISpriteFrame
 		{
 			public SpriteFrameType Type { get; }
 			public Size Size { get; }

--- a/OpenRA.Mods.Common/SpriteLoaders/PngSheetLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/PngSheetLoader.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 			return true;
 		}
 
-		void RegionsFromFrames(Png png, out List<Rectangle> regions, out List<float2> offsets)
+		static void RegionsFromFrames(Png png, out List<Rectangle> regions, out List<float2> offsets)
 		{
 			regions = new List<Rectangle>();
 			offsets = new List<float2>();
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 			}
 		}
 
-		void RegionsFromSlices(Png png, out List<Rectangle> regions, out List<float2> offsets)
+		static void RegionsFromSlices(Png png, out List<Rectangle> regions, out List<float2> offsets)
 		{
 			// Default: whole image is 1 frame.
 			var frameSize = new Size(png.Width, png.Height);

--- a/OpenRA.Mods.Common/SpriteLoaders/PngSheetLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/PngSheetLoader.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 
 	public class PngSheetLoader : ISpriteLoader
 	{
-		class PngSheetFrame : ISpriteFrame
+		sealed class PngSheetFrame : ISpriteFrame
 		{
 			public SpriteFrameType Type { get; set; }
 			public Size Size { get; set; }

--- a/OpenRA.Mods.Common/SpriteLoaders/ShpTSLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/ShpTSLoader.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 			}
 		}
 
-		bool IsShpTS(Stream s)
+		static bool IsShpTS(Stream s)
 		{
 			var start = s.Position;
 
@@ -128,7 +128,7 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 			return f == imageCount || type < 4;
 		}
 
-		ShpTSFrame[] ParseFrames(Stream s)
+		static ShpTSFrame[] ParseFrames(Stream s)
 		{
 			var start = s.Position;
 

--- a/OpenRA.Mods.Common/SpriteLoaders/ShpTSLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/ShpTSLoader.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 {
 	public class ShpTSLoader : ISpriteLoader
 	{
-		class ShpTSFrame : ISpriteFrame
+		sealed class ShpTSFrame : ISpriteFrame
 		{
 			public SpriteFrameType Type => SpriteFrameType.Indexed8;
 			public Size Size { get; }

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -1230,7 +1230,7 @@ namespace OpenRA.Mods.Common.Traits
 			return new AssociateWithAirfieldActivity(self, creationActivityDelay);
 		}
 
-		class AssociateWithAirfieldActivity : Activity
+		sealed class AssociateWithAirfieldActivity : Activity
 		{
 			readonly Aircraft aircraft;
 			readonly int delay;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -411,7 +411,7 @@ namespace OpenRA.Mods.Common.Traits
 			return stances;
 		}
 
-		class AttackOrderTargeter : IOrderTargeter
+		sealed class AttackOrderTargeter : IOrderTargeter
 		{
 			readonly AttackBase ab;
 
@@ -514,7 +514,7 @@ namespace OpenRA.Mods.Common.Traits
 				}
 			}
 
-			public bool IsQueued { get; protected set; }
+			public bool IsQueued { get; private set; }
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -226,7 +226,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		class AttackActivity : Activity, IActivityNotifyStanceChanged
+		sealed class AttackActivity : Activity, IActivityNotifyStanceChanged
 		{
 			readonly AttackFollow attack;
 			readonly RevealsShroud[] revealsShroud;

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Provides access to the attack-move command, which will make the actor automatically engage viable targets while moving to the destination.")]
-	class AttackMoveInfo : TraitInfo, Requires<IMoveInfo>
+	sealed class AttackMoveInfo : TraitInfo, Requires<IMoveInfo>
 	{
 		[VoiceReference]
 		public readonly string Voice = "Action";
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new AttackMove(init.Self, this); }
 	}
 
-	class AttackMove : IResolveOrder, IOrderVoice
+	sealed class AttackMove : IResolveOrder, IOrderVoice
 	{
 		public readonly AttackMoveInfo Info;
 		readonly IMove move;

--- a/OpenRA.Mods.Common/Traits/AttackWander.cs
+++ b/OpenRA.Mods.Common/Traits/AttackWander.cs
@@ -16,12 +16,12 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Will AttackMove to a random location within MoveRadius when idle.",
 		"This conflicts with player orders and should only be added to animal creeps.")]
-	class AttackWanderInfo : WandersInfo, Requires<AttackMoveInfo>
+	sealed class AttackWanderInfo : WandersInfo, Requires<AttackMoveInfo>
 	{
 		public override object Create(ActorInitializer init) { return new AttackWander(init.Self, this); }
 	}
 
-	class AttackWander : Wanders
+	sealed class AttackWander : Wanders
 	{
 		readonly AttackMove attackMove;
 

--- a/OpenRA.Mods.Common/Traits/AutoCarryall.cs
+++ b/OpenRA.Mods.Common/Traits/AutoCarryall.cs
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		class FerryUnit : Activity
+		sealed class FerryUnit : Activity
 		{
 			readonly Actor cargo;
 			readonly Carryable carryable;

--- a/OpenRA.Mods.Common/Traits/AutoCrusher.cs
+++ b/OpenRA.Mods.Common/Traits/AutoCrusher.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class AutoCrusherInfo : PausableConditionalTraitInfo, Requires<IMoveInfo>
+	sealed class AutoCrusherInfo : PausableConditionalTraitInfo, Requires<IMoveInfo>
 	{
 		[Desc("Maximum range to scan for targets.")]
 		public readonly WDist ScanRadius = WDist.FromCells(5);
@@ -36,20 +36,20 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new AutoCrusher(init.Self, this); }
 	}
 
-	class AutoCrusher : PausableConditionalTrait<AutoCrusherInfo>, INotifyIdle
+	sealed class AutoCrusher : PausableConditionalTrait<AutoCrusherInfo>, INotifyIdle
 	{
 		int nextScanTime;
 		readonly IMoveInfo moveInfo;
 		readonly bool isAircraft;
-		protected readonly IMove Move;
+		readonly IMove move;
 
 		public AutoCrusher(Actor self, AutoCrusherInfo info)
 			: base(info)
 		{
-			Move = self.Trait<IMove>();
+			move = self.Trait<IMove>();
 			moveInfo = self.Info.TraitInfo<IMoveInfo>();
 			nextScanTime = self.World.SharedRandom.Next(Info.MinimumScanTimeInterval, Info.MaximumScanTimeInterval);
-			isAircraft = Move is Aircraft;
+			isAircraft = move is Aircraft;
 		}
 
 		void INotifyIdle.TickIdle(Actor self)
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (isAircraft)
 				self.QueueActivity(new Land(self, Target.FromActor(crushableActor), targetLineColor: moveInfo.GetTargetLineColor()));
 			else
-				self.QueueActivity(Move.MoveTo(crushableActor.Location, targetLineColor: moveInfo.GetTargetLineColor()));
+				self.QueueActivity(move.MoveTo(crushableActor.Location, targetLineColor: moveInfo.GetTargetLineColor()));
 
 			nextScanTime = self.World.SharedRandom.Next(Info.MinimumScanTimeInterval, Info.MaximumScanTimeInterval);
 		}

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -444,7 +444,7 @@ namespace OpenRA.Mods.Common.Traits
 			return chosenTarget;
 		}
 
-		bool PreventsAutoTarget(Actor attacker, Actor target)
+		static bool PreventsAutoTarget(Actor attacker, Actor target)
 		{
 			foreach (var deat in target.TraitsImplementing<IDisableEnemyAutoTarget>())
 				if (deat.DisableEnemyAutoTarget(target, attacker))

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class BaseBuilderQueueManager
+	sealed class BaseBuilderQueueManager
 	{
 		readonly string category;
 

--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class HarvesterBotModule : ConditionalTrait<HarvesterBotModuleInfo>, IBotTick
 	{
-		class HarvesterTraitWrapper
+		sealed class HarvesterTraitWrapper
 		{
 			public readonly Actor Actor;
 			public readonly Harvester Harvester;

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/StateMachine.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/StateMachine.cs
@@ -11,7 +11,7 @@
 
 namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 {
-	class StateMachine
+	sealed class StateMachine
 	{
 		IState currentState;
 		IState previousState;

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		}
 	}
 
-	class AirIdleState : AirStateBase, IState
+	sealed class AirIdleState : AirStateBase, IState
 	{
 		public void Activate(Squad owner) { }
 
@@ -141,7 +141,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		public void Deactivate(Squad owner) { }
 	}
 
-	class AirAttackState : AirStateBase, IState
+	sealed class AirAttackState : AirStateBase, IState
 	{
 		public void Activate(Squad owner) { }
 
@@ -195,7 +195,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		public void Deactivate(Squad owner) { }
 	}
 
-	class AirFleeState : AirStateBase, IState
+	sealed class AirFleeState : AirStateBase, IState
 	{
 		public void Activate(Squad owner) { }
 

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			return ShouldFlee(owner, enemies => !AttackOrFleeFuzzy.Default.CanAttack(owner.Units, enemies));
 		}
 
-		protected Actor FindClosestEnemy(Squad owner)
+		protected static Actor FindClosestEnemy(Squad owner)
 		{
 			return owner.SquadManager.FindClosestEnemy(owner.Units.First().CenterPosition);
 		}

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		}
 	}
 
-	class GroundUnitsIdleState : GroundStateBase, IState
+	sealed class GroundUnitsIdleState : GroundStateBase, IState
 	{
 		public void Activate(Squad owner) { }
 
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		public void Deactivate(Squad owner) { }
 	}
 
-	class GroundUnitsAttackMoveState : GroundStateBase, IState
+	sealed class GroundUnitsAttackMoveState : GroundStateBase, IState
 	{
 		int lastUpdatedTick;
 		CPos? lastLeaderLocation;
@@ -148,7 +148,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		public void Deactivate(Squad owner) { }
 	}
 
-	class GroundUnitsAttackState : GroundStateBase, IState
+	sealed class GroundUnitsAttackState : GroundStateBase, IState
 	{
 		int lastUpdatedTick;
 		CPos? lastLeaderLocation;
@@ -206,7 +206,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		public void Deactivate(Squad owner) { }
 	}
 
-	class GroundUnitsFleeState : GroundStateBase, IState
+	sealed class GroundUnitsFleeState : GroundStateBase, IState
 	{
 		public void Activate(Squad owner) { }
 

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/NavyStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/NavyStates.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			return ShouldFlee(owner, enemies => !AttackOrFleeFuzzy.Default.CanAttack(owner.Units, enemies));
 		}
 
-		protected Actor FindClosestEnemy(Squad owner)
+		protected static Actor FindClosestEnemy(Squad owner)
 		{
 			var first = owner.Units.First();
 

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/NavyStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/NavyStates.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		}
 	}
 
-	class NavyUnitsIdleState : NavyStateBase, IState
+	sealed class NavyUnitsIdleState : NavyStateBase, IState
 	{
 		public void Activate(Squad owner) { }
 
@@ -89,7 +89,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		public void Deactivate(Squad owner) { }
 	}
 
-	class NavyUnitsAttackMoveState : NavyStateBase, IState
+	sealed class NavyUnitsAttackMoveState : NavyStateBase, IState
 	{
 		int lastUpdatedTick;
 		CPos? lastLeaderLocation;
@@ -172,7 +172,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		public void Deactivate(Squad owner) { }
 	}
 
-	class NavyUnitsAttackState : NavyStateBase, IState
+	sealed class NavyUnitsAttackState : NavyStateBase, IState
 	{
 		int lastUpdatedTick;
 		CPos? lastLeaderLocation;
@@ -230,7 +230,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		public void Deactivate(Squad owner) { }
 	}
 
-	class NavyUnitsFleeState : NavyStateBase, IState
+	sealed class NavyUnitsFleeState : NavyStateBase, IState
 	{
 		public void Activate(Squad owner) { }
 

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/ProtectionStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/ProtectionStates.cs
@@ -13,14 +13,14 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 {
-	class UnitsForProtectionIdleState : GroundStateBase, IState
+	sealed class UnitsForProtectionIdleState : GroundStateBase, IState
 	{
 		public void Activate(Squad owner) { }
 		public void Tick(Squad owner) { owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionAttackState(), true); }
 		public void Deactivate(Squad owner) { }
 	}
 
-	class UnitsForProtectionAttackState : GroundStateBase, IState
+	sealed class UnitsForProtectionAttackState : GroundStateBase, IState
 	{
 		public const int BackoffTicks = 4;
 		internal int Backoff = BackoffTicks;
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		public void Deactivate(Squad owner) { }
 	}
 
-	class UnitsForProtectionFleeState : GroundStateBase, IState
+	sealed class UnitsForProtectionFleeState : GroundStateBase, IState
 	{
 		public void Activate(Squad owner) { }
 

--- a/OpenRA.Mods.Common/Traits/Buildings/BridgePlaceholder.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BridgePlaceholder.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Placeholder actor used for dead segments and bridge end ramps.")]
-	class BridgePlaceholderInfo : TraitInfo
+	sealed class BridgePlaceholderInfo : TraitInfo
 	{
 		public readonly string Type = "GroundLevelBridge";
 
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new BridgePlaceholder(init.Self, this); }
 	}
 
-	class BridgePlaceholder : IBridgeSegment, INotifyAddedToWorld, INotifyRemovedFromWorld
+	sealed class BridgePlaceholder : IBridgeSegment, INotifyAddedToWorld, INotifyRemovedFromWorld
 	{
 		public readonly BridgePlaceholderInfo Info;
 		readonly Actor self;

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class BuildingInfluence
 	{
-		class InfluenceNode
+		sealed class InfluenceNode
 		{
 			public InfluenceNode Next;
 			public Actor Actor;

--- a/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Bridge actor that can't be passed underneath.")]
-	class GroundLevelBridgeInfo : TraitInfo, IRulesetLoaded, Requires<BuildingInfo>, Requires<IHealthInfo>
+	sealed class GroundLevelBridgeInfo : TraitInfo, IRulesetLoaded, Requires<BuildingInfo>, Requires<IHealthInfo>
 	{
 		public readonly string TerrainType = "Bridge";
 
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new GroundLevelBridge(init.Self, this); }
 	}
 
-	class GroundLevelBridge : IBridgeSegment, INotifyAddedToWorld, INotifyRemovedFromWorld
+	sealed class GroundLevelBridge : IBridgeSegment, INotifyAddedToWorld, INotifyRemovedFromWorld
 	{
 		public readonly GroundLevelBridgeInfo Info;
 		readonly Actor self;

--- a/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new ProductionAirdrop(init, this); }
 	}
 
-	class ProductionAirdrop : Production
+	sealed class ProductionAirdrop : Production
 	{
 		public ProductionAirdrop(ActorInitializer init, ProductionAirdropInfo info)
 			: base(init, info) { }

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -138,7 +138,7 @@ namespace OpenRA.Mods.Common.Traits
 			return order.OrderString == OrderID && order.ExtraData == ForceSet;
 		}
 
-		class RallyPointOrderTargeter : IOrderTargeter
+		sealed class RallyPointOrderTargeter : IOrderTargeter
 		{
 			readonly RallyPointInfo info;
 
@@ -151,7 +151,7 @@ namespace OpenRA.Mods.Common.Traits
 			public int OrderPriority => 0;
 			public bool TargetOverridesSelection(Actor self, in Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
 			public bool ForceSet { get; private set; }
-			public bool IsQueued { get; protected set; }
+			public bool IsQueued { get; private set; }
 
 			public bool CanTarget(Actor self, in Target target, ref TargetModifiers modifiers, ref string cursor)
 			{

--- a/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Reserve landing places for aircraft.")]
-	class ReservableInfo : TraitInfo<Reservable> { }
+	sealed class ReservableInfo : TraitInfo<Reservable> { }
 
 	public class Reservable : ITick, INotifyOwnerChanged, INotifySold, INotifyActorDisposing, INotifyCreated
 	{

--- a/OpenRA.Mods.Common/Traits/Buildings/SequencePlaceBuildingPreview.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/SequencePlaceBuildingPreview.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class SequencePlaceBuildingPreview { }
 
-	class SequencePlaceBuildingPreviewPreview : FootprintPlaceBuildingPreviewPreview
+	sealed class SequencePlaceBuildingPreviewPreview : FootprintPlaceBuildingPreviewPreview
 	{
 		readonly SequencePlaceBuildingPreviewInfo info;
 		readonly Animation preview;

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
@@ -178,7 +178,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		class AircraftMoveOrderTargeter : IOrderTargeter
+		sealed class AircraftMoveOrderTargeter : IOrderTargeter
 		{
 			readonly TransformsIntoAircraft aircraft;
 
@@ -198,7 +198,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public string OrderID => "Move";
 			public int OrderPriority => 4;
-			public bool IsQueued { get; protected set; }
+			public bool IsQueued { get; private set; }
 
 			public bool CanTarget(Actor self, in Target target, ref TargetModifiers modifiers, ref string cursor)
 			{

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
@@ -166,7 +166,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		class MoveOrderTargeter : IOrderTargeter
+		sealed class MoveOrderTargeter : IOrderTargeter
 		{
 			readonly TransformsIntoMobile mobile;
 			readonly bool rejectMove;
@@ -187,7 +187,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public string OrderID => "Move";
 			public int OrderPriority => 4;
-			public bool IsQueued { get; protected set; }
+			public bool IsQueued { get; private set; }
 
 			public bool CanTarget(Actor self, in Target target, ref TargetModifiers modifiers, ref string cursor)
 			{

--- a/OpenRA.Mods.Common/Traits/CapturableProgressBar.cs
+++ b/OpenRA.Mods.Common/Traits/CapturableProgressBar.cs
@@ -17,14 +17,14 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Visualize capture progress.")]
-	class CapturableProgressBarInfo : ConditionalTraitInfo, Requires<CapturableInfo>
+	sealed class CapturableProgressBarInfo : ConditionalTraitInfo, Requires<CapturableInfo>
 	{
 		public readonly Color Color = Color.Orange;
 
 		public override object Create(ActorInitializer init) { return new CapturableProgressBar(this); }
 	}
 
-	class CapturableProgressBar : ConditionalTrait<CapturableProgressBarInfo>, ISelectionBar, ICaptureProgressWatcher
+	sealed class CapturableProgressBar : ConditionalTrait<CapturableProgressBarInfo>, ISelectionBar, ICaptureProgressWatcher
 	{
 		readonly Dictionary<Actor, (int Current, int Total)> progress = new();
 

--- a/OpenRA.Mods.Common/Traits/CapturableProgressBlink.cs
+++ b/OpenRA.Mods.Common/Traits/CapturableProgressBlink.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Blinks the actor and captor when it is being captured.")]
-	class CapturableProgressBlinkInfo : ConditionalTraitInfo, Requires<CapturableInfo>
+	sealed class CapturableProgressBlinkInfo : ConditionalTraitInfo, Requires<CapturableInfo>
 	{
 		[Desc("Number of ticks to wait between repeating blinks.")]
 		public readonly int Interval = 50;
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new CapturableProgressBlink(this); }
 	}
 
-	class CapturableProgressBlink : ConditionalTrait<CapturableProgressBlinkInfo>, ITick, ICaptureProgressWatcher
+	sealed class CapturableProgressBlink : ConditionalTrait<CapturableProgressBlinkInfo>, ITick, ICaptureProgressWatcher
 	{
 		readonly List<Player> captorOwners = new();
 		readonly HashSet<Actor> captors = new();

--- a/OpenRA.Mods.Common/Traits/CaptureProgressBar.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureProgressBar.cs
@@ -15,14 +15,14 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Visualize the progress of this actor being captured.")]
-	class CaptureProgressBarInfo : ConditionalTraitInfo, Requires<CapturesInfo>
+	sealed class CaptureProgressBarInfo : ConditionalTraitInfo, Requires<CapturesInfo>
 	{
 		public readonly Color Color = Color.Orange;
 
 		public override object Create(ActorInitializer init) { return new CaptureProgressBar(this); }
 	}
 
-	class CaptureProgressBar : ConditionalTrait<CaptureProgressBarInfo>, ISelectionBar, ICaptureProgressWatcher
+	sealed class CaptureProgressBar : ConditionalTrait<CaptureProgressBarInfo>, ISelectionBar, ICaptureProgressWatcher
 	{
 		int current;
 		int total;

--- a/OpenRA.Mods.Common/Traits/Captures.cs
+++ b/OpenRA.Mods.Common/Traits/Captures.cs
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.Traits
 		protected override void TraitEnabled(Actor self) { captureManager.RefreshCaptures(); }
 		protected override void TraitDisabled(Actor self) { captureManager.RefreshCaptures(); }
 
-		class CaptureOrderTargeter : UnitOrderTargeter
+		sealed class CaptureOrderTargeter : UnitOrderTargeter
 		{
 			readonly Captures captures;
 

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -378,7 +378,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		class CarryallPickupOrderTargeter : UnitOrderTargeter
+		sealed class CarryallPickupOrderTargeter : UnitOrderTargeter
 		{
 			public CarryallPickupOrderTargeter(CarryallInfo info)
 				: base("PickupUnit", 5, info.PickUpCursor, false, true)
@@ -411,14 +411,14 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		class CarryallDeliverUnitTargeter : IOrderTargeter
+		sealed class CarryallDeliverUnitTargeter : IOrderTargeter
 		{
 			readonly AircraftInfo aircraftInfo;
 			readonly CarryallInfo info;
 
 			public string OrderID => "DeliverUnit";
 			public int OrderPriority => 6;
-			public bool IsQueued { get; protected set; }
+			public bool IsQueued { get; private set; }
 			public bool TargetOverridesSelection(Actor self, in Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
 
 			public CarryallDeliverUnitTargeter(AircraftInfo aircraftInfo, CarryallInfo info)

--- a/OpenRA.Mods.Common/Traits/ChangesHealth.cs
+++ b/OpenRA.Mods.Common/Traits/ChangesHealth.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Attach this to actors which should regenerate or lose health points over time.")]
-	class ChangesHealthInfo : ConditionalTraitInfo, Requires<IHealthInfo>
+	sealed class ChangesHealthInfo : ConditionalTraitInfo, Requires<IHealthInfo>
 	{
 		[Desc("Absolute amount of health points added in each step.",
 			"Use negative values to apply damage.")]
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new ChangesHealth(init.Self, this); }
 	}
 
-	class ChangesHealth : ConditionalTrait<ChangesHealthInfo>, ITick, INotifyDamage, ISync
+	sealed class ChangesHealth : ConditionalTrait<ChangesHealthInfo>, ITick, INotifyDamage, ISync
 	{
 		readonly IHealth health;
 

--- a/OpenRA.Mods.Common/Traits/ChangesTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/ChangesTerrain.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Modifies the terrain type underneath the actors location.")]
-	class ChangesTerrainInfo : TraitInfo, Requires<ImmobileInfo>
+	sealed class ChangesTerrainInfo : TraitInfo, Requires<ImmobileInfo>
 	{
 		[FieldLoader.Require]
 		public readonly string TerrainType = null;
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new ChangesTerrain(this); }
 	}
 
-	class ChangesTerrain : INotifyAddedToWorld, INotifyRemovedFromWorld
+	sealed class ChangesTerrain : INotifyAddedToWorld, INotifyRemovedFromWorld
 	{
 		readonly ChangesTerrainInfo info;
 		byte previousTerrain;

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantCondition.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Grants a condition while the trait is active.")]
-	class GrantConditionInfo : ConditionalTraitInfo
+	sealed class GrantConditionInfo : ConditionalTraitInfo
 	{
 		[FieldLoader.Require]
 		[GrantedConditionReference]
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new GrantCondition(this); }
 	}
 
-	class GrantCondition : ConditionalTrait<GrantConditionInfo>
+	sealed class GrantCondition : ConditionalTrait<GrantConditionInfo>
 	{
 		int conditionToken = Actor.InvalidConditionToken;
 

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnAttack.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnAttack.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		bool TargetChanged(in Target lastTarget, in Target target)
+		static bool TargetChanged(in Target lastTarget, in Target target)
 		{
 			// Invalidate reveal changing the target.
 			if (lastTarget.Type == TargetType.FrozenActor && target.Type == TargetType.Actor)

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnFaction.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnFaction.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Grants a condition while the trait is active.")]
-	class GrantConditionOnFactionInfo : ConditionalTraitInfo
+	sealed class GrantConditionOnFactionInfo : ConditionalTraitInfo
 	{
 		[FieldLoader.Require]
 		[GrantedConditionReference]
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new GrantConditionOnFaction(init, this); }
 	}
 
-	class GrantConditionOnFaction : ConditionalTrait<GrantConditionOnFactionInfo>, INotifyOwnerChanged
+	sealed class GrantConditionOnFaction : ConditionalTrait<GrantConditionOnFactionInfo>, INotifyOwnerChanged
 	{
 		int conditionToken = Actor.InvalidConditionToken;
 		string faction;

--- a/OpenRA.Mods.Common/Traits/Crates/DuplicateUnitCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/DuplicateUnitCrateAction.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Creates duplicates of the actor that collects the crate.")]
-	class DuplicateUnitCrateActionInfo : CrateActionInfo
+	sealed class DuplicateUnitCrateActionInfo : CrateActionInfo
 	{
 		[Desc("The maximum number of duplicates to make.")]
 		public readonly int MaxAmount = 2;
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new DuplicateUnitCrateAction(init.Self, this); }
 	}
 
-	class DuplicateUnitCrateAction : CrateAction
+	sealed class DuplicateUnitCrateAction : CrateAction
 	{
 		readonly DuplicateUnitCrateActionInfo info;
 

--- a/OpenRA.Mods.Common/Traits/Crates/ExplodeCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/ExplodeCrateAction.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Fires a weapon at the location when collected.")]
-	class ExplodeCrateActionInfo : CrateActionInfo
+	sealed class ExplodeCrateActionInfo : CrateActionInfo
 	{
 		[WeaponReference]
 		[FieldLoader.Require]
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new ExplodeCrateAction(init.Self, this); }
 	}
 
-	class ExplodeCrateAction : CrateAction
+	sealed class ExplodeCrateAction : CrateAction
 	{
 		readonly ExplodeCrateActionInfo info;
 

--- a/OpenRA.Mods.Common/Traits/Crates/GiveCashCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GiveCashCrateAction.cs
@@ -14,7 +14,7 @@ using OpenRA.Mods.Common.Effects;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Gives cash to the collector.")]
-	class GiveCashCrateActionInfo : CrateActionInfo
+	sealed class GiveCashCrateActionInfo : CrateActionInfo
 	{
 		[Desc("Amount of cash to give.")]
 		public readonly int Amount = 2000;
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new GiveCashCrateAction(init.Self, this); }
 	}
 
-	class GiveCashCrateAction : CrateAction
+	sealed class GiveCashCrateAction : CrateAction
 	{
 		readonly GiveCashCrateActionInfo info;
 		public GiveCashCrateAction(Actor self, GiveCashCrateActionInfo info)

--- a/OpenRA.Mods.Common/Traits/Crates/GiveMcvCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GiveMcvCrateAction.cs
@@ -14,7 +14,7 @@ using System.Linq;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Spawns units when collected.", "Adjust selection shares when player has no base.")]
-	class GiveBaseBuilderCrateActionInfo : GiveUnitCrateActionInfo
+	sealed class GiveBaseBuilderCrateActionInfo : GiveUnitCrateActionInfo
 	{
 		[Desc("The selection shares to use if the collector has no actor with `" + nameof(BaseBuilding) + ".")]
 		public readonly int NoBaseSelectionShares = 1000;
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new GiveBaseBuilderCrateAction(init.Self, this); }
 	}
 
-	class GiveBaseBuilderCrateAction : GiveUnitCrateAction
+	sealed class GiveBaseBuilderCrateAction : GiveUnitCrateAction
 	{
 		readonly GiveBaseBuilderCrateActionInfo info;
 		public GiveBaseBuilderCrateAction(Actor self, GiveBaseBuilderCrateActionInfo info)

--- a/OpenRA.Mods.Common/Traits/Crates/HealActorsCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/HealActorsCrateAction.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Heals all actors that belong to the owner of the collector.")]
-	class HealActorsCrateActionInfo : CrateActionInfo
+	sealed class HealActorsCrateActionInfo : CrateActionInfo
 	{
 		[Desc("The target type(s) of the actors this crate action will heal. Leave empty to heal all actors.")]
 		public readonly BitSet<TargetableType> TargetTypes = default;
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new HealActorsCrateAction(init.Self, this); }
 	}
 
-	class HealActorsCrateAction : CrateAction
+	sealed class HealActorsCrateAction : CrateAction
 	{
 		readonly HealActorsCrateActionInfo info;
 

--- a/OpenRA.Mods.Common/Traits/Crates/HideMapCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/HideMapCrateAction.cs
@@ -14,7 +14,7 @@ using System.Linq;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Hides the entire map in shroud.")]
-	class HideMapCrateActionInfo : CrateActionInfo
+	sealed class HideMapCrateActionInfo : CrateActionInfo
 	{
 		[Desc("Should the map also be hidden for the allies of the collector's owner?")]
 		public readonly bool IncludeAllies = false;
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new HideMapCrateAction(init.Self, this); }
 	}
 
-	class HideMapCrateAction : CrateAction
+	sealed class HideMapCrateAction : CrateAction
 	{
 		readonly HideMapCrateActionInfo info;
 

--- a/OpenRA.Mods.Common/Traits/Crates/LevelUpCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/LevelUpCrateAction.cs
@@ -14,7 +14,7 @@ using System.Linq;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Gives experience levels to the collector.")]
-	class LevelUpCrateActionInfo : CrateActionInfo
+	sealed class LevelUpCrateActionInfo : CrateActionInfo
 	{
 		[Desc("Number of experience levels to give.")]
 		public readonly int Levels = 1;
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new LevelUpCrateAction(init.Self, this); }
 	}
 
-	class LevelUpCrateAction : CrateAction
+	sealed class LevelUpCrateAction : CrateAction
 	{
 		readonly Actor self;
 		readonly LevelUpCrateActionInfo info;

--- a/OpenRA.Mods.Common/Traits/Crates/RevealMapCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/RevealMapCrateAction.cs
@@ -12,7 +12,7 @@
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Reveals the entire map.")]
-	class RevealMapCrateActionInfo : CrateActionInfo
+	sealed class RevealMapCrateActionInfo : CrateActionInfo
 	{
 		[Desc("Should the map also be revealed for the allies of the collector's owner?")]
 		public readonly bool IncludeAllies = false;
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new RevealMapCrateAction(init.Self, this); }
 	}
 
-	class RevealMapCrateAction : CrateAction
+	sealed class RevealMapCrateAction : CrateAction
 	{
 		readonly RevealMapCrateActionInfo info;
 

--- a/OpenRA.Mods.Common/Traits/Crates/SupportPowerCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/SupportPowerCrateAction.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Gives a supportpower to the collector.")]
-	class SupportPowerCrateActionInfo : CrateActionInfo
+	sealed class SupportPowerCrateActionInfo : CrateActionInfo
 	{
 		[ActorReference]
 		[FieldLoader.Require]
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new SupportPowerCrateAction(init.Self, this); }
 	}
 
-	class SupportPowerCrateAction : CrateAction
+	sealed class SupportPowerCrateAction : CrateAction
 	{
 		readonly SupportPowerCrateActionInfo info;
 		public SupportPowerCrateAction(Actor self, SupportPowerCrateActionInfo info)

--- a/OpenRA.Mods.Common/Traits/Crushable.cs
+++ b/OpenRA.Mods.Common/Traits/Crushable.cs
@@ -14,7 +14,7 @@ using OpenRA.Primitives;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor is crushable.")]
-	class CrushableInfo : ConditionalTraitInfo
+	sealed class CrushableInfo : ConditionalTraitInfo
 	{
 		[Desc("Sound to play when being crushed.")]
 		public readonly string CrushSound = null;
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Crushable(init.Self, this); }
 	}
 
-	class Crushable : ConditionalTrait<CrushableInfo>, ICrushable, INotifyCrushed
+	sealed class Crushable : ConditionalTrait<CrushableInfo>, ICrushable, INotifyCrushed
 	{
 		readonly Actor self;
 

--- a/OpenRA.Mods.Common/Traits/DeliversCash.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversCash.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Donate money to actors with the `" + nameof(AcceptsDeliveredCash) + "` trait.")]
-	class DeliversCashInfo : TraitInfo
+	sealed class DeliversCashInfo : TraitInfo
 	{
 		[Desc("The amount of cash the owner receives.")]
 		public readonly int Payload = 500;
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new DeliversCash(this); }
 	}
 
-	class DeliversCash : IIssueOrder, IResolveOrder, IOrderVoice, INotifyCashTransfer
+	sealed class DeliversCash : IIssueOrder, IResolveOrder, IOrderVoice, INotifyCashTransfer
 	{
 		readonly DeliversCashInfo info;
 
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Traits
 				Game.Sound.Play(SoundType.World, info.Sounds, self.World, self.CenterPosition);
 		}
 
-		public class DeliversCashOrderTargeter : UnitOrderTargeter
+		public sealed class DeliversCashOrderTargeter : UnitOrderTargeter
 		{
 			public DeliversCashOrderTargeter(DeliversCashInfo info)
 				: base("DeliverCash", 5, info.Cursor, false, true) { }

--- a/OpenRA.Mods.Common/Traits/DeliversExperience.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversExperience.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor can grant experience levels equal to it's own current level via entering to other actors with the `" + nameof(AcceptsDeliveredExperience) + "` trait.")]
-	class DeliversExperienceInfo : TraitInfo, Requires<GainsExperienceInfo>
+	sealed class DeliversExperienceInfo : TraitInfo, Requires<GainsExperienceInfo>
 	{
 		[Desc("The amount of experience the donating player receives.")]
 		public readonly int PlayerExperience = 0;
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new DeliversExperience(init, this); }
 	}
 
-	class DeliversExperience : IIssueOrder, IResolveOrder, IOrderVoice
+	sealed class DeliversExperience : IIssueOrder, IResolveOrder, IOrderVoice
 	{
 		readonly DeliversExperienceInfo info;
 		readonly Actor self;
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Common.Traits
 			self.ShowTargetLines();
 		}
 
-		public class DeliversExperienceOrderTargeter : UnitOrderTargeter
+		public sealed class DeliversExperienceOrderTargeter : UnitOrderTargeter
 		{
 			public DeliversExperienceOrderTargeter(DeliversExperienceInfo info)
 				: base("DeliverExperience", 5, info.Cursor, true, true) { }

--- a/OpenRA.Mods.Common/Traits/Demolishable.cs
+++ b/OpenRA.Mods.Common/Traits/Demolishable.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class Demolishable : ConditionalTrait<DemolishableInfo>, IDemolishable, ITick, INotifyOwnerChanged
 	{
-		class DemolishAction
+		sealed class DemolishAction
 		{
 			public readonly Actor Saboteur;
 			public readonly int Token;

--- a/OpenRA.Mods.Common/Traits/Demolition.cs
+++ b/OpenRA.Mods.Common/Traits/Demolition.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class DemolitionInfo : ConditionalTraitInfo
+	sealed class DemolitionInfo : ConditionalTraitInfo
 	{
 		[Desc("Delay to demolish the target once the explosive device is planted. " +
 			"Measured in game ticks. Default is 1.8 seconds.")]
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Demolition(this); }
 	}
 
-	class Demolition : ConditionalTrait<DemolitionInfo>, IIssueOrder, IResolveOrder, IOrderVoice
+	sealed class Demolition : ConditionalTrait<DemolitionInfo>, IIssueOrder, IResolveOrder, IOrderVoice
 	{
 		public Demolition(DemolitionInfo info)
 			: base(info) { }
@@ -111,7 +111,7 @@ namespace OpenRA.Mods.Common.Traits
 			return order.OrderString == "C4" ? Info.Voice : null;
 		}
 
-		class DemolitionOrderTargeter : UnitOrderTargeter
+		sealed class DemolitionOrderTargeter : UnitOrderTargeter
 		{
 			readonly DemolitionInfo info;
 

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -150,7 +150,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	class ExperienceInit : ValueActorInit<int>
+	sealed class ExperienceInit : ValueActorInit<int>
 	{
 		public ExperienceInit(TraitInfo info, int value)
 			: base(info, value) { }

--- a/OpenRA.Mods.Common/Traits/GivesBounty.cs
+++ b/OpenRA.Mods.Common/Traits/GivesBounty.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("When killed, this actor causes the attacking player to receive money.")]
-	class GivesBountyInfo : ConditionalTraitInfo
+	sealed class GivesBountyInfo : ConditionalTraitInfo
 	{
 		[Desc("Percentage of the killed actor's Cost or CustomSellValue to be given.")]
 		public readonly int Percentage = 10;
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new GivesBounty(this); }
 	}
 
-	class GivesBounty : ConditionalTrait<GivesBountyInfo>, INotifyKilled, INotifyPassengerEntered, INotifyPassengerExited
+	sealed class GivesBounty : ConditionalTrait<GivesBountyInfo>, INotifyKilled, INotifyPassengerEntered, INotifyPassengerExited
 	{
 		readonly Dictionary<Actor, GivesBounty[]> passengerBounties = new();
 

--- a/OpenRA.Mods.Common/Traits/GivesExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GivesExperience.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor gives experience to a GainsExperience actor when they are killed.")]
-	class GivesExperienceInfo : TraitInfo
+	sealed class GivesExperienceInfo : TraitInfo
 	{
 		[Desc("If -1, use the value of the unit cost.")]
 		public readonly int Experience = -1;
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new GivesExperience(this); }
 	}
 
-	class GivesExperience : INotifyKilled, INotifyCreated
+	sealed class GivesExperience : INotifyKilled, INotifyCreated
 	{
 		readonly GivesExperienceInfo info;
 

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -381,11 +381,11 @@ namespace OpenRA.Mods.Common.Traits
 				conditionToken = self.RevokeCondition(conditionToken);
 		}
 
-		class HarvestOrderTargeter : IOrderTargeter
+		sealed class HarvestOrderTargeter : IOrderTargeter
 		{
 			public string OrderID => "Harvest";
 			public int OrderPriority => 10;
-			public bool IsQueued { get; protected set; }
+			public bool IsQueued { get; private set; }
 			public bool TargetOverridesSelection(Actor self, in Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
 
 			public bool CanTarget(Actor self, in Target target, ref TargetModifiers modifiers, ref string cursor)

--- a/OpenRA.Mods.Common/Traits/IgnoresCloak.cs
+++ b/OpenRA.Mods.Common/Traits/IgnoresCloak.cs
@@ -14,6 +14,6 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor does not care about any type of cloak its targets might have, regardless of distance.")]
-	class IgnoresCloakInfo : TraitInfo<IgnoresCloak> { }
-	class IgnoresCloak { }
+	sealed class IgnoresCloakInfo : TraitInfo<IgnoresCloak> { }
+	sealed class IgnoresCloak { }
 }

--- a/OpenRA.Mods.Common/Traits/IgnoresDisguise.cs
+++ b/OpenRA.Mods.Common/Traits/IgnoresDisguise.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Allows automatic targeting of disguised actors.")]
-	class IgnoresDisguiseInfo : TraitInfo<IgnoresDisguise> { }
+	sealed class IgnoresDisguiseInfo : TraitInfo<IgnoresDisguise> { }
 
-	class IgnoresDisguise { }
+	sealed class IgnoresDisguise { }
 }

--- a/OpenRA.Mods.Common/Traits/Immobile.cs
+++ b/OpenRA.Mods.Common/Traits/Immobile.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class ImmobileInfo : TraitInfo, IOccupySpaceInfo
+	sealed class ImmobileInfo : TraitInfo, IOccupySpaceInfo
 	{
 		public readonly bool OccupiesSpace = true;
 		public override object Create(ActorInitializer init) { return new Immobile(init, this); }
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		bool IOccupySpaceInfo.SharesCell => false;
 	}
 
-	class Immobile : IOccupySpace, ISync, INotifyAddedToWorld, INotifyRemovedFromWorld
+	sealed class Immobile : IOccupySpace, ISync, INotifyAddedToWorld, INotifyRemovedFromWorld
 	{
 		[Sync]
 		readonly CPos location;

--- a/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Makes the unit automatically run around when taking damage.")]
-	class ScaredyCatInfo : TraitInfo, Requires<MobileInfo>
+	sealed class ScaredyCatInfo : TraitInfo, Requires<MobileInfo>
 	{
 		[Desc("Chance (out of 100) the unit has to enter panic mode when attacked.")]
 		public readonly int PanicChance = 100;
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new ScaredyCat(init.Self, this); }
 	}
 
-	class ScaredyCat : ITick, INotifyIdle, INotifyDamage, INotifyAttack, ISpeedModifier, ISync, IRenderInfantrySequenceModifier
+	sealed class ScaredyCat : ITick, INotifyIdle, INotifyDamage, INotifyAttack, ISpeedModifier, ISync, IRenderInfantrySequenceModifier
 	{
 		readonly ScaredyCatInfo info;
 		readonly Mobile mobile;

--- a/OpenRA.Mods.Common/Traits/InstantlyRepairs.cs
+++ b/OpenRA.Mods.Common/Traits/InstantlyRepairs.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Traits
 			self.ShowTargetLines();
 		}
 
-		class InstantRepairOrderTargeter : UnitOrderTargeter
+		sealed class InstantRepairOrderTargeter : UnitOrderTargeter
 		{
 			readonly InstantlyRepairsInfo info;
 

--- a/OpenRA.Mods.Common/Traits/KillsSelf.cs
+++ b/OpenRA.Mods.Common/Traits/KillsSelf.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class KillsSelfInfo : ConditionalTraitInfo
+	sealed class KillsSelfInfo : ConditionalTraitInfo
 	{
 		[Desc("Remove the actor from the world (and destroy it) instead of killing it.")]
 		public readonly bool RemoveInstead = false;
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new KillsSelf(init.Self, this); }
 	}
 
-	class KillsSelf : ConditionalTrait<KillsSelfInfo>, INotifyAddedToWorld, ITick
+	sealed class KillsSelf : ConditionalTrait<KillsSelfInfo>, INotifyAddedToWorld, ITick
 	{
 		int lifetime;
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -969,7 +969,7 @@ namespace OpenRA.Mods.Common.Traits
 			return returnToCellOnCreation ? new ReturnToCellActivity(self, creationActivityDelay, returnToCellOnCreationRecalculateSubCell) : null;
 		}
 
-		class MoveOrderTargeter : IOrderTargeter
+		sealed class MoveOrderTargeter : IOrderTargeter
 		{
 			readonly Mobile mobile;
 			readonly LocomotorInfo locomotorInfo;
@@ -992,7 +992,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public string OrderID => "Move";
 			public int OrderPriority => 4;
-			public bool IsQueued { get; protected set; }
+			public bool IsQueued { get; private set; }
 
 			public bool CanTarget(Actor self, in Target target, ref TargetModifiers modifiers, ref string cursor)
 			{

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 		bool isRendering;
 		bool created;
 
-		class FrozenState
+		sealed class FrozenState
 		{
 			public readonly FrozenActor FrozenActor;
 			public bool IsVisible;

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/RotationPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/RotationPaletteEffect.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Palette effect used for sprinkle \"animations\".")]
-	class RotationPaletteEffectInfo : TraitInfo
+	sealed class RotationPaletteEffectInfo : TraitInfo
 	{
 		[Desc("Defines to which palettes this effect should be applied to.",
 			"If none specified, it applies to all palettes not explicitly excluded.")]
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new RotationPaletteEffect(init.World, this); }
 	}
 
-	class RotationPaletteEffect : ITick, IPaletteModifier
+	sealed class RotationPaletteEffect : ITick, IPaletteModifier
 	{
 		readonly RotationPaletteEffectInfo info;
 		readonly uint[] rotationBuffer;

--- a/OpenRA.Mods.Common/Traits/Palettes/ColorPickerPalette.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/ColorPickerPalette.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Create a color picker palette from another palette.")]
-	class ColorPickerPaletteInfo : TraitInfo
+	sealed class ColorPickerPaletteInfo : TraitInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new ColorPickerPalette(this); }
 	}
 
-	class ColorPickerPalette : ILoadsPalettes, IProvidesAssetBrowserColorPickerPalettes, ITickRender
+	sealed class ColorPickerPalette : ILoadsPalettes, IProvidesAssetBrowserColorPickerPalettes, ITickRender
 	{
 		readonly ColorPickerPaletteInfo info;
 		Color color;

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromFile.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromFile.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Load VGA palette (.pal) registers.")]
-	class PaletteFromFileInfo : TraitInfo, ITilesetSpecificPaletteInfo, IProvidesCursorPaletteInfo
+	sealed class PaletteFromFileInfo : TraitInfo, ITilesetSpecificPaletteInfo, IProvidesCursorPaletteInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	class PaletteFromFile : ILoadsPalettes, IProvidesAssetBrowserPalettes
+	sealed class PaletteFromFile : ILoadsPalettes, IProvidesAssetBrowserPalettes
 	{
 		readonly World world;
 		readonly PaletteFromFileInfo info;

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromGimpOrJascFile.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromGimpOrJascFile.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Load a GIMP .gpl or JASC .pal palette file. Supports per-color alpha.")]
-	class PaletteFromGimpOrJascFileInfo : TraitInfo, IProvidesCursorPaletteInfo
+	sealed class PaletteFromGimpOrJascFileInfo : TraitInfo, IProvidesCursorPaletteInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -110,7 +110,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	class PaletteFromGimpOrJascFile : ILoadsPalettes, IProvidesAssetBrowserPalettes
+	sealed class PaletteFromGimpOrJascFile : ILoadsPalettes, IProvidesAssetBrowserPalettes
 	{
 		readonly World world;
 		readonly PaletteFromGimpOrJascFileInfo info;

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromGrayscale.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromGrayscale.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Creates a greyscale palette without any base palette file.")]
-	class PaletteFromGrayscaleInfo : TraitInfo, ITilesetSpecificPaletteInfo
+	sealed class PaletteFromGrayscaleInfo : TraitInfo, ITilesetSpecificPaletteInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new PaletteFromGrayscale(init.World, this); }
 	}
 
-	class PaletteFromGrayscale : ILoadsPalettes
+	sealed class PaletteFromGrayscale : ILoadsPalettes
 	{
 		readonly World world;
 		readonly PaletteFromGrayscaleInfo info;

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromPaletteWithAlpha.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromPaletteWithAlpha.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Create a palette by applying alpha transparency to another palette.")]
-	class PaletteFromPaletteWithAlphaInfo : TraitInfo
+	sealed class PaletteFromPaletteWithAlphaInfo : TraitInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new PaletteFromPaletteWithAlpha(this); }
 	}
 
-	class PaletteFromPaletteWithAlpha : ILoadsPalettes, IProvidesAssetBrowserPalettes
+	sealed class PaletteFromPaletteWithAlpha : ILoadsPalettes, IProvidesAssetBrowserPalettes
 	{
 		readonly PaletteFromPaletteWithAlphaInfo info;
 
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 		public IEnumerable<string> PaletteNames { get { yield return info.Name; } }
 	}
 
-	class AlphaPaletteRemap : IPaletteRemap
+	sealed class AlphaPaletteRemap : IPaletteRemap
 	{
 		readonly float alpha;
 		readonly bool premultiply;

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromPlayerPaletteWithAlpha.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromPlayerPaletteWithAlpha.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Create player palettes by applying alpha transparency to another player palette.")]
-	class PaletteFromPlayerPaletteWithAlphaInfo : TraitInfo
+	sealed class PaletteFromPlayerPaletteWithAlphaInfo : TraitInfo
 	{
 		[FieldLoader.Require]
 		[PaletteDefinition(true)]
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new PaletteFromPlayerPaletteWithAlpha(this); }
 	}
 
-	class PaletteFromPlayerPaletteWithAlpha : ILoadsPlayerPalettes
+	sealed class PaletteFromPlayerPaletteWithAlpha : ILoadsPlayerPalettes
 	{
 		readonly PaletteFromPlayerPaletteWithAlphaInfo info;
 

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromPng.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromPng.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Load a PNG and use its embedded palette.")]
-	class PaletteFromPngInfo : TraitInfo, ITilesetSpecificPaletteInfo, IProvidesCursorPaletteInfo
+	sealed class PaletteFromPngInfo : TraitInfo, ITilesetSpecificPaletteInfo, IProvidesCursorPaletteInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	class PaletteFromPng : ILoadsPalettes, IProvidesAssetBrowserPalettes
+	sealed class PaletteFromPng : ILoadsPalettes, IProvidesAssetBrowserPalettes
 	{
 		readonly World world;
 		readonly PaletteFromPngInfo info;

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromRGBA.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromRGBA.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Creates a single color palette without any base palette file.")]
-	class PaletteFromRGBAInfo : TraitInfo, ITilesetSpecificPaletteInfo
+	sealed class PaletteFromRGBAInfo : TraitInfo, ITilesetSpecificPaletteInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new PaletteFromRGBA(init.World, this); }
 	}
 
-	class PaletteFromRGBA : ILoadsPalettes
+	sealed class PaletteFromRGBA : ILoadsPalettes
 	{
 		readonly World world;
 		readonly PaletteFromRGBAInfo info;

--- a/OpenRA.Mods.Common/Traits/Player/AllyRepair.cs
+++ b/OpenRA.Mods.Common/Traits/Player/AllyRepair.cs
@@ -15,9 +15,9 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.Player)]
 	[Desc("Attach this to the player actor to allow building repair by team mates.")]
-	class AllyRepairInfo : TraitInfo<AllyRepair> { }
+	sealed class AllyRepairInfo : TraitInfo<AllyRepair> { }
 
-	class AllyRepair : IResolveOrder
+	sealed class AllyRepair : IResolveOrder
 	{
 		public void ResolveOrder(Actor self, Order order)
 		{

--- a/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
+++ b/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 	[TraitLocation(SystemActors.Player)]
 	[Desc("Tracks neutral and enemy actors' visibility and notifies the player.",
 		"Attach this to the player actor. The actors to track need the 'AnnounceOnSeen' trait.")]
-	class EnemyWatcherInfo : TraitInfo
+	sealed class EnemyWatcherInfo : TraitInfo
 	{
 		[Desc("Interval in ticks between scanning for enemies.")]
 		public readonly int ScanInterval = 25;
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new EnemyWatcher(this); }
 	}
 
-	class EnemyWatcher : ITick
+	sealed class EnemyWatcher : ITick
 	{
 		readonly EnemyWatcherInfo info;
 		readonly HashSet<Player> discoveredPlayers;

--- a/OpenRA.Mods.Common/Traits/Player/TechTree.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TechTree.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Player Owner { get; }
 
-		class Watcher
+		sealed class Watcher
 		{
 			public readonly string Key;
 			public ITechTreeElement RegisteredBy { get; }

--- a/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
@@ -17,12 +17,12 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Produce a unit on the closest map edge cell and move into the world.")]
-	class ProductionFromMapEdgeInfo : ProductionInfo
+	sealed class ProductionFromMapEdgeInfo : ProductionInfo
 	{
 		public override object Create(ActorInitializer init) { return new ProductionFromMapEdge(init, this); }
 	}
 
-	class ProductionFromMapEdge : Production
+	sealed class ProductionFromMapEdge : Production
 	{
 		readonly CPos? spawnLocation;
 		readonly IPathFinder pathFinder;

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new ProductionParadrop(init, this); }
 	}
 
-	class ProductionParadrop : Production
+	sealed class ProductionParadrop : Production
 	{
 		readonly Lazy<RallyPoint> rp;
 

--- a/OpenRA.Mods.Common/Traits/ProductionQueueFromSelection.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionQueueFromSelection.cs
@@ -18,7 +18,7 @@ using OpenRA.Widgets;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World)]
-	class ProductionQueueFromSelectionInfo : TraitInfo
+	sealed class ProductionQueueFromSelectionInfo : TraitInfo
 	{
 		public readonly string ProductionTabsWidget = null;
 		public readonly string ProductionPaletteWidget = null;
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new ProductionQueueFromSelection(init.World, this); }
 	}
 
-	class ProductionQueueFromSelection : INotifySelection
+	sealed class ProductionQueueFromSelection : INotifySelection
 	{
 		readonly World world;
 		readonly Lazy<ProductionTabsWidget> tabsWidget;

--- a/OpenRA.Mods.Common/Traits/Render/CashTricklerBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/CashTricklerBar.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Display the time remaining until the next cash is given by actor's CashTrickler trait.")]
-	class CashTricklerBarInfo : TraitInfo, Requires<CashTricklerInfo>
+	sealed class CashTricklerBarInfo : TraitInfo, Requires<CashTricklerInfo>
 	{
 		[Desc("Defines to which players the bar is to be shown.")]
 		public readonly PlayerRelationship DisplayRelationships = PlayerRelationship.Ally;
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new CashTricklerBar(init.Self, this); }
 	}
 
-	class CashTricklerBar : ISelectionBar
+	sealed class CashTricklerBar : ISelectionBar
 	{
 		readonly Actor self;
 		readonly CashTricklerBarInfo info;

--- a/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
@@ -19,14 +19,14 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World)]
 	[Desc("Displays custom terrain types.")]
-	class CustomTerrainDebugOverlayInfo : TraitInfo
+	sealed class CustomTerrainDebugOverlayInfo : TraitInfo
 	{
 		public readonly string Font = "TinyBold";
 
 		public override object Create(ActorInitializer init) { return new CustomTerrainDebugOverlay(this); }
 	}
 
-	class CustomTerrainDebugOverlay : IWorldLoaded, IChatCommand, IRenderAnnotations
+	sealed class CustomTerrainDebugOverlay : IWorldLoaded, IChatCommand, IRenderAnnotations
 	{
 		const string CommandName = "custom-terrain";
 

--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits
 			return RenderAboveShroud(self, wr);
 		}
 
-		IEnumerable<IRenderable> RenderAboveShroud(Actor self, WorldRenderer wr)
+		static IEnumerable<IRenderable> RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
 			var pal = wr.Palette(TileSet.TerrainPaletteInternalName);
 			var a = self.CurrentActivity;

--- a/OpenRA.Mods.Common/Traits/Render/ProductionBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/ProductionBar.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Visualizes the remaining build time of actor produced here.")]
-	class ProductionBarInfo : ConditionalTraitInfo, Requires<ProductionInfo>, IRulesetLoaded
+	sealed class ProductionBarInfo : ConditionalTraitInfo, Requires<ProductionInfo>, IRulesetLoaded
 	{
 		[FieldLoader.Require]
 		[Desc("Production queue type, for actors with multiple queues.")]
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new ProductionBar(init.Self, this); }
 	}
 
-	class ProductionBar : ConditionalTrait<ProductionBarInfo>, ISelectionBar, ITick, INotifyOwnerChanged
+	sealed class ProductionBar : ConditionalTrait<ProductionBarInfo>, ISelectionBar, ITick, INotifyOwnerChanged
 	{
 		readonly Actor self;
 		ProductionQueue queue;

--- a/OpenRA.Mods.Common/Traits/Render/ReloadArmamentsBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/ReloadArmamentsBar.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Visualizes the minimum remaining time for reloading the armaments.")]
-	class ReloadArmamentsBarInfo : TraitInfo
+	sealed class ReloadArmamentsBarInfo : TraitInfo
 	{
 		[Desc("Armament names")]
 		public readonly string[] Armaments = { "primary", "secondary" };
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new ReloadArmamentsBar(init.Self, this); }
 	}
 
-	class ReloadArmamentsBar : ISelectionBar, INotifyCreated
+	sealed class ReloadArmamentsBar : ISelectionBar, INotifyCreated
 	{
 		readonly ReloadArmamentsBarInfo info;
 		readonly Actor self;

--- a/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
@@ -19,14 +19,14 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Displays the actor's type and ID above the actor.")]
-	class RenderDebugStateInfo : TraitInfo
+	sealed class RenderDebugStateInfo : TraitInfo
 	{
 		public readonly string Font = "TinyBold";
 
 		public override object Create(ActorInitializer init) { return new RenderDebugState(init.Self, this); }
 	}
 
-	class RenderDebugState : INotifyAddedToWorld, INotifyOwnerChanged, INotifyCreated, IRenderAnnotationsWhenSelected
+	sealed class RenderDebugState : INotifyAddedToWorld, INotifyOwnerChanged, INotifyCreated, IRenderAnnotationsWhenSelected
 	{
 		readonly DebugVisualizations debugVis;
 		readonly SpriteFont font;

--- a/OpenRA.Mods.Common/Traits/Render/RenderJammerCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderJammerCircle.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	// TODO: remove all the Render*Circle duplication
-	class RenderJammerCircleInfo : ConditionalTraitInfo, IPlaceBuildingDecorationInfo
+	sealed class RenderJammerCircleInfo : ConditionalTraitInfo, IPlaceBuildingDecorationInfo
 	{
 		[Desc("Range circle color.")]
 		public readonly Color Color = Color.FromArgb(128, Color.Red);
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new RenderJammerCircle(this); }
 	}
 
-	class RenderJammerCircle : ConditionalTrait<RenderJammerCircleInfo>, IRenderAnnotationsWhenSelected
+	sealed class RenderJammerCircle : ConditionalTrait<RenderJammerCircleInfo>, IRenderAnnotationsWhenSelected
 	{
 		readonly RenderJammerCircleInfo info;
 

--- a/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 	public enum RangeCircleMode { Maximum, Minimum }
 
 	[Desc("Draw a circle indicating my weapon's range.")]
-	class RenderRangeCircleInfo : TraitInfo, IPlaceBuildingDecorationInfo, IRulesetLoaded, Requires<AttackBaseInfo>
+	sealed class RenderRangeCircleInfo : TraitInfo, IPlaceBuildingDecorationInfo, IRulesetLoaded, Requires<AttackBaseInfo>
 	{
 		public readonly string RangeCircleType = null;
 
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	class RenderRangeCircle : IRenderAnnotationsWhenSelected
+	sealed class RenderRangeCircle : IRenderAnnotationsWhenSelected
 	{
 		public readonly RenderRangeCircleInfo Info;
 		readonly Actor self;

--- a/OpenRA.Mods.Common/Traits/Render/RenderShroudCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderShroudCircle.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class RenderShroudCircleInfo : ConditionalTraitInfo, IPlaceBuildingDecorationInfo
+	sealed class RenderShroudCircleInfo : ConditionalTraitInfo, IPlaceBuildingDecorationInfo
 	{
 		[Desc("Color of the circle.")]
 		public readonly Color Color = Color.FromArgb(128, Color.Cyan);
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new RenderShroudCircle(this); }
 	}
 
-	class RenderShroudCircle : ConditionalTrait<RenderShroudCircleInfo>, INotifyCreated, IRenderAnnotationsWhenSelected
+	sealed class RenderShroudCircle : ConditionalTrait<RenderShroudCircleInfo>, INotifyCreated, IRenderAnnotationsWhenSelected
 	{
 		readonly RenderShroudCircleInfo info;
 		WDist range;

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			(DamageState.Light, "scuffed-")
 		};
 
-		class AnimationWrapper
+		sealed class AnimationWrapper
 		{
 			public readonly AnimationWithOffset Animation;
 			public readonly string Palette;

--- a/OpenRA.Mods.Common/Traits/Render/RenderSpritesEditorOnly.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSpritesEditorOnly.cs
@@ -15,12 +15,12 @@ using OpenRA.Graphics;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Invisible during games.")]
-	class RenderSpritesEditorOnlyInfo : RenderSpritesInfo
+	sealed class RenderSpritesEditorOnlyInfo : RenderSpritesInfo
 	{
 		public override object Create(ActorInitializer init) { return new RenderSpritesEditorOnly(init, this); }
 	}
 
-	class RenderSpritesEditorOnly : RenderSprites
+	sealed class RenderSpritesEditorOnly : RenderSprites
 	{
 		public RenderSpritesEditorOnly(ActorInitializer init, RenderSpritesEditorOnlyInfo info)
 			: base(init, info) { }

--- a/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 	public class RenderVoxels : IRender, ITick, INotifyOwnerChanged
 	{
-		class AnimationWrapper
+		sealed class AnimationWrapper
 		{
 			readonly ModelAnimation model;
 			bool cachedVisible;

--- a/OpenRA.Mods.Common/Traits/Render/SelectionDecorationsBase.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SelectionDecorationsBase.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			decorations = selectedDecorations.Where(d => !d.RequiresSelection).ToArray();
 		}
 
-		IEnumerable<WPos> ActivityTargetPath(Actor self)
+		static IEnumerable<WPos> ActivityTargetPath(Actor self)
 		{
 			if (!self.IsInWorld || self.IsDead)
 				yield break;

--- a/OpenRA.Mods.Common/Traits/Render/SupportPowerChargeBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SupportPowerChargeBar.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Display the time remaining until the super weapon attached to the actor is ready.")]
-	class SupportPowerChargeBarInfo : ConditionalTraitInfo
+	sealed class SupportPowerChargeBarInfo : ConditionalTraitInfo
 	{
 		[Desc("Defines to which players the bar is to be shown.")]
 		public readonly PlayerRelationship DisplayRelationships = PlayerRelationship.Ally;
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new SupportPowerChargeBar(init.Self, this); }
 	}
 
-	class SupportPowerChargeBar : ConditionalTrait<SupportPowerChargeBarInfo>, ISelectionBar, INotifyOwnerChanged
+	sealed class SupportPowerChargeBar : ConditionalTrait<SupportPowerChargeBarInfo>, ISelectionBar, INotifyOwnerChanged
 	{
 		readonly Actor self;
 		SupportPowerManager spm;

--- a/OpenRA.Mods.Common/Traits/Render/TimedConditionBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/TimedConditionBar.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Visualizes the remaining time for a condition.")]
-	class TimedConditionBarInfo : TraitInfo
+	sealed class TimedConditionBarInfo : TraitInfo
 	{
 		[FieldLoader.Require]
 		[Desc("Condition that this bar corresponds to")]
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new TimedConditionBar(init.Self, this); }
 	}
 
-	class TimedConditionBar : ISelectionBar, IConditionTimerWatcher
+	sealed class TimedConditionBar : ISelectionBar, IConditionTimerWatcher
 	{
 		readonly TimedConditionBarInfo info;
 		readonly Actor self;

--- a/OpenRA.Mods.Common/Traits/Render/WithBridgeSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBridgeSpriteBody.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
 {
-	class WithBridgeSpriteBodyInfo : WithSpriteBodyInfo
+	sealed class WithBridgeSpriteBodyInfo : WithSpriteBodyInfo
 	{
 		public readonly string Type = "GroundLevelBridge";
 
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	class WithBridgeSpriteBody : WithSpriteBody, INotifyRemovedFromWorld
+	sealed class WithBridgeSpriteBody : WithSpriteBody, INotifyRemovedFromWorld
 	{
 		readonly WithBridgeSpriteBodyInfo bridgeInfo;
 		readonly BridgeLayer bridgeLayer;

--- a/OpenRA.Mods.Common/Traits/Render/WithChargeOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithChargeOverlay.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Render overlay that varies the animation frame based on the AttackCharges trait's charge level.")]
-	class WithChargeOverlayInfo : PausableConditionalTraitInfo, Requires<WithSpriteBodyInfo>, Requires<RenderSpritesInfo>
+	sealed class WithChargeOverlayInfo : PausableConditionalTraitInfo, Requires<WithSpriteBodyInfo>, Requires<RenderSpritesInfo>
 	{
 		[SequenceReference]
 		[Desc("Sequence to use for the charge levels.")]
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithChargeOverlay(init.Self, this); }
 	}
 
-	class WithChargeOverlay : PausableConditionalTrait<WithChargeOverlayInfo>, INotifyDamageStateChanged
+	sealed class WithChargeOverlay : PausableConditionalTrait<WithChargeOverlayInfo>, INotifyDamageStateChanged
 	{
 		readonly Animation overlay;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Renders crates with both water and land variants.")]
-	class WithCrateBodyInfo : TraitInfo, Requires<RenderSpritesInfo>, IRenderActorPreviewSpritesInfo
+	sealed class WithCrateBodyInfo : TraitInfo, Requires<RenderSpritesInfo>, IRenderActorPreviewSpritesInfo
 	{
 		[Desc("Easteregg sequences to use in December.")]
 		public readonly string[] XmasImages = Array.Empty<string>();
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	class WithCrateBody : INotifyParachute, INotifyAddedToWorld
+	sealed class WithCrateBody : INotifyParachute, INotifyAddedToWorld
 	{
 		readonly Actor self;
 		readonly Animation anim;

--- a/OpenRA.Mods.Common/Traits/Render/WithDeadBridgeSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeadBridgeSpriteBody.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
 {
-	class WithDeadBridgeSpriteBodyInfo : WithSpriteBodyInfo
+	sealed class WithDeadBridgeSpriteBodyInfo : WithSpriteBodyInfo
 	{
 		[ActorReference]
 		public readonly string[] RampActors = Array.Empty<string>();
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	class WithDeadBridgeSpriteBody : WithSpriteBody
+	sealed class WithDeadBridgeSpriteBody : WithSpriteBody
 	{
 		readonly WithDeadBridgeSpriteBodyInfo bridgeInfo;
 		readonly BridgeLayer bridgeLayer;

--- a/OpenRA.Mods.Common/Traits/Render/WithGateSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithGateSpriteBody.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("This actor visually connects to walls and changes appearance when actors walk through it.")]
-	class WithGateSpriteBodyInfo : WithSpriteBodyInfo, IWallConnectorInfo, Requires<GateInfo>
+	sealed class WithGateSpriteBodyInfo : WithSpriteBodyInfo, IWallConnectorInfo, Requires<GateInfo>
 	{
 		[Desc("Cells (outside the gate footprint) that contain wall cells that can connect to the gate")]
 		public readonly CVec[] WallConnections = Array.Empty<CVec>();
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	class WithGateSpriteBody : WithSpriteBody, INotifyRemovedFromWorld, IWallConnector, ITick
+	sealed class WithGateSpriteBody : WithSpriteBody, INotifyRemovedFromWorld, IWallConnector, ITick
 	{
 		readonly WithGateSpriteBodyInfo gateBodyInfo;
 		readonly Gate gate;

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Displays an overlay whenever resources are harvested by the actor.")]
-	class WithHarvestOverlayInfo : TraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
+	sealed class WithHarvestOverlayInfo : TraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
 		[SequenceReference]
 		[Desc("Sequence name to use")]
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithHarvestOverlay(init.Self, this); }
 	}
 
-	class WithHarvestOverlay : INotifyHarvesterAction
+	sealed class WithHarvestOverlay : INotifyHarvesterAction
 	{
 		readonly WithHarvestOverlayInfo info;
 		readonly Animation anim;

--- a/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Renders the MuzzleSequence from the Armament trait.")]
-	class WithMuzzleOverlayInfo : ConditionalTraitInfo, Requires<RenderSpritesInfo>, Requires<AttackBaseInfo>, Requires<ArmamentInfo>
+	sealed class WithMuzzleOverlayInfo : ConditionalTraitInfo, Requires<RenderSpritesInfo>, Requires<AttackBaseInfo>, Requires<ArmamentInfo>
 	{
 		[Desc("Ignore the weapon position, and always draw relative to the center of the actor")]
 		public readonly bool IgnoreOffset = false;
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithMuzzleOverlay(init.Self, this); }
 	}
 
-	class WithMuzzleOverlay : ConditionalTrait<WithMuzzleOverlayInfo>, INotifyAttack, IRender, ITick
+	sealed class WithMuzzleOverlay : ConditionalTrait<WithMuzzleOverlayInfo>, INotifyAttack, IRender, ITick
 	{
 		readonly Dictionary<Barrel, bool> visible = new();
 		readonly Dictionary<Barrel, AnimationWithOffset> anims = new();

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Play an animation when a unit exits or blocks the exit after production finished.")]
-	class WithProductionDoorOverlayInfo : ConditionalTraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>, Requires<BuildingInfo>
+	sealed class WithProductionDoorOverlayInfo : ConditionalTraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>, Requires<BuildingInfo>
 	{
 		[SequenceReference]
 		public readonly string Sequence = "build-door";
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithProductionDoorOverlay(init.Self, this); }
 	}
 
-	class WithProductionDoorOverlay : ConditionalTrait<WithProductionDoorOverlayInfo>, ITick, INotifyProduction, INotifyDamageStateChanged
+	sealed class WithProductionDoorOverlay : ConditionalTrait<WithProductionDoorOverlayInfo>, ITick, INotifyProduction, INotifyDamageStateChanged
 	{
 		readonly Animation door;
 		int desiredFrame;

--- a/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 	public enum RangeCircleVisibility { Always, WhenSelected }
 
 	[Desc("Renders an arbitrary circle when selected or placing a structure")]
-	class WithRangeCircleInfo : ConditionalTraitInfo, IPlaceBuildingDecorationInfo
+	sealed class WithRangeCircleInfo : ConditionalTraitInfo, IPlaceBuildingDecorationInfo
 	{
 		[Desc("Type of range circle. used to decide which circles to draw on other structures during building placement.")]
 		public readonly string Type = null;
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithRangeCircle(init.Self, this); }
 	}
 
-	class WithRangeCircle : ConditionalTrait<WithRangeCircleInfo>, IRenderAnnotationsWhenSelected, IRenderAnnotations
+	sealed class WithRangeCircle : ConditionalTrait<WithRangeCircleInfo>, IRenderAnnotationsWhenSelected, IRenderAnnotations
 	{
 		readonly Actor self;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithResourceLevelOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResourceLevelOverlay.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Displays the fill status of PlayerResources with an extra sprite overlay on the actor.")]
-	class WithResourceLevelOverlayInfo : ConditionalTraitInfo, Requires<WithSpriteBodyInfo>, Requires<RenderSpritesInfo>
+	sealed class WithResourceLevelOverlayInfo : ConditionalTraitInfo, Requires<WithSpriteBodyInfo>, Requires<RenderSpritesInfo>
 	{
 		[SequenceReference]
 		[Desc("Sequence name to use")]
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithResourceLevelOverlay(init.Self, this); }
 	}
 
-	class WithResourceLevelOverlay : ConditionalTrait<WithResourceLevelOverlayInfo>, INotifyOwnerChanged, INotifyDamageStateChanged
+	sealed class WithResourceLevelOverlay : ConditionalTrait<WithResourceLevelOverlayInfo>, INotifyOwnerChanged, INotifyDamageStateChanged
 	{
 		readonly AnimationWithOffset anim;
 		readonly RenderSprites rs;

--- a/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 	}
 
 	[Desc("Render trait for actors that change sprites if neighbors with the same trait are present.")]
-	class WithWallSpriteBodyInfo : WithSpriteBodyInfo, IWallConnectorInfo, Requires<BuildingInfo>
+	sealed class WithWallSpriteBodyInfo : WithSpriteBodyInfo, IWallConnectorInfo, Requires<BuildingInfo>
 	{
 		public readonly string Type = "wall";
 
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	class WithWallSpriteBody : WithSpriteBody, INotifyRemovedFromWorld, IWallConnector, ITick
+	sealed class WithWallSpriteBody : WithSpriteBody, INotifyRemovedFromWorld, IWallConnector, ITick
 	{
 		readonly WithWallSpriteBodyInfo wallInfo;
 		int adjacent = 0;

--- a/OpenRA.Mods.Common/Traits/RepairsBridges.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsBridges.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		class RepairBridgeOrderTargeter : UnitOrderTargeter
+		sealed class RepairBridgeOrderTargeter : UnitOrderTargeter
 		{
 			readonly RepairsBridgesInfo info;
 

--- a/OpenRA.Mods.Common/Traits/RevealOnFire.cs
+++ b/OpenRA.Mods.Common/Traits/RevealOnFire.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		Player GetTargetPlayer(in Target target)
+		static Player GetTargetPlayer(in Target target)
 		{
 			if (target.Type == TargetType.Actor)
 				return target.Actor.Owner;

--- a/OpenRA.Mods.Common/Traits/SeedsResource.cs
+++ b/OpenRA.Mods.Common/Traits/SeedsResource.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Lets the actor spread resources around it in a circle.")]
-	class SeedsResourceInfo : ConditionalTraitInfo
+	sealed class SeedsResourceInfo : ConditionalTraitInfo
 	{
 		public readonly int Interval = 75;
 		public readonly string ResourceType = "Ore";
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new SeedsResource(init.Self, this); }
 	}
 
-	class SeedsResource : ConditionalTrait<SeedsResourceInfo>, ITick, ISeedableResource
+	sealed class SeedsResource : ConditionalTrait<SeedsResourceInfo>, ITick, ISeedableResource
 	{
 		readonly SeedsResourceInfo info;
 		readonly IResourceLayer resourceLayer;

--- a/OpenRA.Mods.Common/Traits/Sound/ActorLostNotification.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/ActorLostNotification.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Sound
 {
-	class ActorLostNotificationInfo : ConditionalTraitInfo
+	sealed class ActorLostNotificationInfo : ConditionalTraitInfo
 	{
 		[NotificationReference("Speech")]
 		[Desc("Speech notification to play.")]
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		public override object Create(ActorInitializer init) { return new ActorLostNotification(this); }
 	}
 
-	class ActorLostNotification : ConditionalTrait<ActorLostNotificationInfo>, INotifyKilled
+	sealed class ActorLostNotification : ConditionalTrait<ActorLostNotificationInfo>, INotifyKilled
 	{
 		public ActorLostNotification(ActorLostNotificationInfo info)
 			: base(info) { }

--- a/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Sound
 {
 	[Desc("Plays a looping audio file at the actor position. Attach this to the `World` actor to cover the whole map.")]
-	class AmbientSoundInfo : ConditionalTraitInfo
+	sealed class AmbientSoundInfo : ConditionalTraitInfo
 	{
 		[FieldLoader.Require]
 		public readonly string[] SoundFiles = null;
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		public override object Create(ActorInitializer init) { return new AmbientSound(init.Self, this); }
 	}
 
-	class AmbientSound : ConditionalTrait<AmbientSoundInfo>, ITick, INotifyRemovedFromWorld
+	sealed class AmbientSound : ConditionalTrait<AmbientSoundInfo>, ITick, INotifyRemovedFromWorld
 	{
 		readonly bool loop;
 		readonly HashSet<ISound> currentSounds = new();

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
@@ -110,7 +110,7 @@ namespace OpenRA.Mods.Common.Traits
 			});
 		}
 
-		class SelectConditionTarget : OrderGenerator
+		sealed class SelectConditionTarget : OrderGenerator
 		{
 			readonly GrantExternalConditionPower power;
 			readonly char[] footprint;

--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -138,7 +138,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	class NukePower : SupportPower
+	sealed class NukePower : SupportPower
 	{
 		readonly NukePowerInfo info;
 		BodyOrientation body;

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SelectDirectionalTarget.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SelectDirectionalTarget.cs
@@ -176,7 +176,7 @@ namespace OpenRA.Mods.Common.Traits
 			return points;
 		}
 
-		class Arrow
+		sealed class Arrow
 		{
 			public Sprite Sprite { get; }
 			public double EndAngle { get; }

--- a/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class ThrowsParticleInfo : TraitInfo, Requires<WithSpriteBodyInfo>, Requires<BodyOrientationInfo>
+	sealed class ThrowsParticleInfo : TraitInfo, Requires<WithSpriteBodyInfo>, Requires<BodyOrientationInfo>
 	{
 		[FieldLoader.Require]
 		public readonly string Anim = null;
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new ThrowsParticle(init, this); }
 	}
 
-	class ThrowsParticle : ITick
+	sealed class ThrowsParticle : ITick
 	{
 		WVec pos;
 		readonly WVec initialPos;

--- a/OpenRA.Mods.Common/Traits/ThrowsShrapnel.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsShrapnel.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	class ThrowsShrapnel : ConditionalTrait<ThrowsShrapnelInfo>, INotifyKilled
+	sealed class ThrowsShrapnel : ConditionalTrait<ThrowsShrapnelInfo>, INotifyKilled
 	{
 		public ThrowsShrapnel(ThrowsShrapnelInfo info)
 			: base(info) { }

--- a/OpenRA.Mods.Common/Traits/TurnOnIdle.cs
+++ b/OpenRA.Mods.Common/Traits/TurnOnIdle.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Turns actor randomly when idle.")]
-	class TurnOnIdleInfo : ConditionalTraitInfo, Requires<MobileInfo>
+	sealed class TurnOnIdleInfo : ConditionalTraitInfo, Requires<MobileInfo>
 	{
 		[Desc("Minimum amount of ticks the actor will wait before the turn.")]
 		public readonly int MinDelay = 400;
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new TurnOnIdle(init, this); }
 	}
 
-	class TurnOnIdle : ConditionalTrait<TurnOnIdleInfo>, INotifyIdle
+	sealed class TurnOnIdle : ConditionalTrait<TurnOnIdleInfo>, INotifyIdle
 	{
 		int currentDelay;
 		WAngle targetFacing;

--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -345,7 +345,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		// NOTE: pos required to be in map bounds
-		bool AnyActorsAt(InfluenceNode influenceNode, CPos a, SubCell sub, bool checkTransient)
+		static bool AnyActorsAt(InfluenceNode influenceNode, CPos a, SubCell sub, bool checkTransient)
 		{
 			var always = sub == SubCell.FullCell || sub == SubCell.Any;
 			for (var i = influenceNode; i != null; i = i.Next)
@@ -376,7 +376,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		// NOTE: can not check aircraft
-		bool AnyActorsAt(InfluenceNode influenceNode, SubCell sub, Func<Actor, bool> withCondition)
+		static bool AnyActorsAt(InfluenceNode influenceNode, SubCell sub, Func<Actor, bool> withCondition)
 		{
 			var always = sub == SubCell.FullCell || sub == SubCell.Any;
 

--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -29,20 +29,20 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class ActorMap : IActorMap, ITick, INotifyCreated
 	{
-		class InfluenceNode
+		sealed class InfluenceNode
 		{
 			public InfluenceNode Next;
 			public SubCell SubCell;
 			public Actor Actor;
 		}
 
-		class Bin
+		sealed class Bin
 		{
 			public readonly List<Actor> Actors = new();
 			public readonly List<ProximityTrigger> ProximityTriggers = new();
 		}
 
-		class CellTrigger
+		sealed class CellTrigger
 		{
 			public readonly CPos[] Footprint;
 			public bool Dirty;
@@ -89,7 +89,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		class ProximityTrigger : IDisposable
+		sealed class ProximityTrigger : IDisposable
 		{
 			public WPos TopLeft { get; private set; }
 			public WPos BottomRight { get; private set; }

--- a/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
@@ -27,12 +27,12 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[TraitLocation(SystemActors.World)]
-	class BridgeLayerInfo : TraitInfo
+	sealed class BridgeLayerInfo : TraitInfo
 	{
 		public override object Create(ActorInitializer init) { return new BridgeLayer(init.World); }
 	}
 
-	class BridgeLayer
+	sealed class BridgeLayer
 	{
 		readonly CellLayer<Actor> bridges;
 

--- a/OpenRA.Mods.Common/Traits/World/CliffBackImpassabilityLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/CliffBackImpassabilityLayer.cs
@@ -18,14 +18,14 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Sets a custom terrain type for cells that are obscured by back-facing cliffs.",
 		"This trait replicates the default CliffBackImpassability=2 behaviour from the TS/RA2 rules.ini.")]
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
-	class CliffBackImpassabilityLayerInfo : TraitInfo
+	sealed class CliffBackImpassabilityLayerInfo : TraitInfo
 	{
 		public readonly string TerrainType = "Impassable";
 
 		public override object Create(ActorInitializer init) { return new CliffBackImpassabilityLayer(this); }
 	}
 
-	class CliffBackImpassabilityLayer : IWorldLoaded
+	sealed class CliffBackImpassabilityLayer : IWorldLoaded
 	{
 		readonly CliffBackImpassabilityLayerInfo info;
 

--- a/OpenRA.Mods.Common/Traits/World/EditorActionManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActionManager.cs
@@ -144,7 +144,7 @@ namespace OpenRA.Mods.Common.Traits
 		string Text { get; }
 	}
 
-	class OpenMapAction : IEditorAction
+	sealed class OpenMapAction : IEditorAction
 	{
 		[TranslationReference]
 		const string Opened = "notification-opened";

--- a/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits
 				SeparateTeamSpawnsCheckboxLocked);
 		}
 
-		class AssignSpawnLocationsState
+		sealed class AssignSpawnLocationsState
 		{
 			public CPos[] SpawnLocations;
 			public List<int> AvailableSpawnPoints;

--- a/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
+++ b/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Traits
 				&& world.Map.Rules.Music[song].Exists;
 		}
 
-		bool SongExists(MusicInfo song)
+		static bool SongExists(MusicInfo song)
 		{
 			return song != null && song.Exists;
 		}

--- a/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		bool PreventMapSpawn(World world, ActorReference actorReference, IEnumerable<IPreventMapSpawn> preventMapSpawns)
+		static bool PreventMapSpawn(World world, ActorReference actorReference, IEnumerable<IPreventMapSpawn> preventMapSpawns)
 		{
 			foreach (var pms in preventMapSpawns)
 				if (pms.PreventMapSpawn(world, actorReference))

--- a/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
+++ b/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World)]
-	class StartGameNotificationInfo : TraitInfo
+	sealed class StartGameNotificationInfo : TraitInfo
 	{
 		[NotificationReference("Speech")]
 		public readonly string Notification = "StartGame";
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new StartGameNotification(this); }
 	}
 
-	class StartGameNotification : IWorldLoaded, INotifyGameLoaded, INotifyGameSaved
+	sealed class StartGameNotification : IWorldLoaded, INotifyGameLoaded, INotifyGameSaved
 	{
 		readonly StartGameNotificationInfo info;
 		public StartGameNotification(StartGameNotificationInfo info)

--- a/OpenRA.Mods.Common/Traits/World/TerrainLighting.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainLighting.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public sealed class TerrainLighting : ITerrainLighting
 	{
-		class LightSource
+		sealed class LightSource
 		{
 			public readonly WPos Pos;
 			public readonly CPos Cell;

--- a/OpenRA.Mods.Common/Traits/World/TerrainLighting.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainLighting.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 				info.BinSize * tileScale);
 		}
 
-		Rectangle Bounds(LightSource source)
+		static Rectangle Bounds(LightSource source)
 		{
 			var c = source.Pos;
 			var r = source.Range.Length;

--- a/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class WarheadDebugOverlay : IRenderAnnotations
 	{
-		class WHImpact
+		sealed class WHImpact
 		{
 			public readonly WPos CenterPosition;
 			public readonly WDist[] Range;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ChangeTargetLineDelayToMilliseconds.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ChangeTargetLineDelayToMilliseconds.cs
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {
-	class ChangeTargetLineDelayToMilliseconds : UpdateRule
+	sealed class ChangeTargetLineDelayToMilliseconds : UpdateRule
 	{
 		public override string Name => "Changed DrawLineToTarget.Delay interpretation from ticks to milliseconds.";
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RenameInfiltrationNotifications.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RenameInfiltrationNotifications.cs
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {
-	class RenameInfiltrationNotifications : UpdateRule
+	sealed class RenameInfiltrationNotifications : UpdateRule
 	{
 		public override string Name => "Renamed InfiltrateForCash Notification to InfiltratedNotification.";
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RenameWithNukeLaunch.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RenameWithNukeLaunch.cs
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {
-	class RenameWithNukeLaunch : UpdateRule
+	sealed class RenameWithNukeLaunch : UpdateRule
 	{
 		public override string Name => "Renamed WithNukeLaunchAnimation and Overlay";
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ReplaceFacingAngles.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ReplaceFacingAngles.cs
@@ -14,7 +14,7 @@ using System.Linq;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {
-	class ReplaceFacingAngles : UpdateRule
+	sealed class ReplaceFacingAngles : UpdateRule
 	{
 		static readonly Dictionary<string, string[]> TraitFields = new()
 		{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/SpawnActorPowerDefaultEffect.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/SpawnActorPowerDefaultEffect.cs
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {
-	class SpawnActorPowerDefaultEffect : UpdateRule
+	sealed class SpawnActorPowerDefaultEffect : UpdateRule
 	{
 		public override string Name => "Set SpawnActorPower EffectSequence to it's previous default value.";
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/UpdateMapInits.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/UpdateMapInits.cs
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {
-	class UpdateMapInits : UpdateRule
+	sealed class UpdateMapInits : UpdateRule
 	{
 		public override string Name => "Update map actor definitions";
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/UpdateTilesetColors.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/UpdateTilesetColors.cs
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {
-	class UpdateTilesetColors : UpdateRule
+	sealed class UpdateTilesetColors : UpdateRule
 	{
 		public override string Name => "Rename Tileset LeftColor and RightColor";
 

--- a/OpenRA.Mods.Common/UtilityCommands/CheckMissingSprites.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckMissingSprites.cs
@@ -16,7 +16,7 @@ using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class CheckMissingSprites : IUtilityCommand
+	sealed class CheckMissingSprites : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--check-missing-sprites";
 

--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -18,7 +18,7 @@ using OpenRA.Mods.Common.Lint;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class CheckYaml : IUtilityCommand
+	sealed class CheckYaml : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--check-yaml";
 

--- a/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
@@ -18,7 +18,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class ConvertSpriteToPngCommand : IUtilityCommand
+	sealed class ConvertSpriteToPngCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--png";
 

--- a/OpenRA.Mods.Common/UtilityCommands/CreateManPage.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CreateManPage.cs
@@ -14,7 +14,7 @@ using System.Linq;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class CreateManPage : IUtilityCommand
+	sealed class CreateManPage : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--man-page";
 

--- a/OpenRA.Mods.Common/UtilityCommands/DebugChromeRegions.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/DebugChromeRegions.cs
@@ -17,7 +17,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class DebugChromeRegions : IUtilityCommand
+	sealed class DebugChromeRegions : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--debug-chrome-regions";
 

--- a/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
@@ -15,7 +15,7 @@ using OpenRA.Graphics;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class DumpSequenceSheetsCommand : IUtilityCommand
+	sealed class DumpSequenceSheetsCommand : IUtilityCommand
 	{
 		static readonly int[] ChannelMasks = { 2, 1, 0, 3 };
 

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractEmmyLuaAPI.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractEmmyLuaAPI.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.UtilityCommands
 {
 	// See https://emmylua.github.io/annotation.html for reference
-	class ExtractEmmyLuaAPI : IUtilityCommand
+	sealed class ExtractEmmyLuaAPI : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--emmy-lua-api";
 

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractFilesCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractFilesCommand.cs
@@ -15,7 +15,7 @@ using System.Linq;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class ExtractFilesCommand : IUtilityCommand
+	sealed class ExtractFilesCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--extract";
 

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
@@ -15,7 +15,7 @@ using OpenRA.Scripting;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class ExtractLuaDocsCommand : IUtilityCommand
+	sealed class ExtractLuaDocsCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--lua-docs";
 

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractMapRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractMapRules.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		string IUtilityCommand.Name => "--map-rules";
 		bool IUtilityCommand.ValidateArguments(string[] args) { return args.Length == 2; }
 
-		void MergeAndPrint(Map map, string key, MiniYaml value)
+		static void MergeAndPrint(Map map, string key, MiniYaml value)
 		{
 			var nodes = new List<MiniYamlNode>();
 			var includes = new List<string>();

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractSettingsDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractSettingsDocsCommand.cs
@@ -14,7 +14,7 @@ using System.Linq;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class ExtractSettingsDocsCommand : IUtilityCommand
+	sealed class ExtractSettingsDocsCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--settings-docs";
 

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractSpriteSequenceDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractSpriteSequenceDocsCommand.cs
@@ -20,7 +20,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class ExtractSpriteSequenceDocsCommand : IUtilityCommand
+	sealed class ExtractSpriteSequenceDocsCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--sprite-sequence-docs";
 

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class ExtractTraitDocsCommand : IUtilityCommand
+	sealed class ExtractTraitDocsCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--docs";
 

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractWeaponDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractWeaponDocsCommand.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class ExtractWeaponDocsCommand : IUtilityCommand
+	sealed class ExtractWeaponDocsCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--weapon-docs";
 

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractZeroBraneStudioLuaAPI.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractZeroBraneStudioLuaAPI.cs
@@ -17,7 +17,7 @@ using OpenRA.Scripting;
 namespace OpenRA.Mods.Common.UtilityCommands
 {
 	// See https://studio.zerobrane.com/doc-api-auto-complete for reference
-	class ExtractZeroBraneStudioLuaAPI : IUtilityCommand
+	sealed class ExtractZeroBraneStudioLuaAPI : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--zbstudio-lua-api";
 

--- a/OpenRA.Mods.Common/UtilityCommands/GetMapHashCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/GetMapHashCommand.cs
@@ -14,7 +14,7 @@ using OpenRA.FileSystem;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class GetMapHashCommand : IUtilityCommand
+	sealed class GetMapHashCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--map-hash";
 

--- a/OpenRA.Mods.Common/UtilityCommands/ListInstallShieldCabContentsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ListInstallShieldCabContentsCommand.cs
@@ -16,7 +16,7 @@ using OpenRA.Mods.Common.FileFormats;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class ListInstallShieldCabContentsCommand : IUtilityCommand
+	sealed class ListInstallShieldCabContentsCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--list-installshield-cab";
 

--- a/OpenRA.Mods.Common/UtilityCommands/ListMSCabContentsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ListMSCabContentsCommand.cs
@@ -15,7 +15,7 @@ using OpenRA.Mods.Common.FileFormats;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class ListMSCabContentsCommand : IUtilityCommand
+	sealed class ListMSCabContentsCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--list-mscab";
 

--- a/OpenRA.Mods.Common/UtilityCommands/RefreshMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/RefreshMapCommand.cs
@@ -13,7 +13,7 @@ using OpenRA.FileSystem;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class RefreshMapCommand : IUtilityCommand
+	sealed class RefreshMapCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--refresh-map";
 

--- a/OpenRA.Mods.Common/UtilityCommands/ReplayMetadataCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ReplayMetadataCommand.cs
@@ -15,7 +15,7 @@ using OpenRA.FileFormats;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class ReplayMetadataCommand : IUtilityCommand
+	sealed class ReplayMetadataCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--replay-metadata";
 

--- a/OpenRA.Mods.Common/UtilityCommands/Rgba2Hex.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/Rgba2Hex.cs
@@ -13,7 +13,7 @@ using System;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class Rgba2Hex : IUtilityCommand
+	sealed class Rgba2Hex : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--rgba2hex";
 
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		}
 	}
 
-	class Argb2Hex : IUtilityCommand
+	sealed class Argb2Hex : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--argb2hex";
 

--- a/OpenRA.Mods.Common/UtilityCommands/Rgba2Hex.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/Rgba2Hex.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			return !invalid || PrintUsage();
 		}
 
-		bool PrintUsage()
+		static bool PrintUsage()
 		{
 			Console.WriteLine("");
 			Console.WriteLine("Usage:");
@@ -137,7 +137,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			return !invalid || PrintUsage();
 		}
 
-		bool PrintUsage()
+		static bool PrintUsage()
 		{
 			Console.WriteLine("");
 			Console.WriteLine("Usage:");

--- a/OpenRA.Mods.Common/UtilityCommands/UpdateMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpdateMapCommand.cs
@@ -18,7 +18,7 @@ using OpenRA.Mods.Common.UpdateRules;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class UpdateMapCommand : IUtilityCommand
+	sealed class UpdateMapCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--update-map";
 

--- a/OpenRA.Mods.Common/UtilityCommands/UpdateModCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpdateModCommand.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 {
 	using YamlFileSet = List<(IReadWritePackage, string, List<MiniYamlNode>)>;
 
-	class UpdateModCommand : IUtilityCommand
+	sealed class UpdateModCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--update-mod";
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -461,7 +461,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		bool ShouldDoOnSave { get; }
 	}
 
-	class EditActorEditorAction : IEditorAction
+	sealed class EditActorEditorAction : IEditorAction
 	{
 		[TranslationReference("name", "id")]
 		const string EditedActor = "notification-edited-actor";
@@ -502,7 +502,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 	}
 
-	class EditActorPreview
+	sealed class EditActorPreview
 	{
 		readonly EditorActorPreview actor;
 		readonly SetActorIdAction setActorIdAction;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference("actorType")]
 		const string ActorTypeTooltip = "label-actor-type";
 
-		class ActorSelectorActor
+		sealed class ActorSelectorActor
 		{
 			public readonly ActorInfo Actor;
 			public readonly string[] Categories;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			public string UiLabel;
 		}
 
-		class SaveDirectory
+		sealed class SaveDirectory
 		{
 			public readonly Folder Folder;
 			public readonly string DisplayName;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class TileSelectorLogic : CommonSelectorLogic
 	{
-		class TileSelectorTemplate
+		sealed class TileSelectorTemplate
 		{
 			public readonly TerrainTemplateInfo Template;
 			public readonly string[] Categories;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoBriefingLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoBriefingLogic.cs
@@ -14,7 +14,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	class GameInfoBriefingLogic : ChromeLogic
+	sealed class GameInfoBriefingLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public GameInfoBriefingLogic(Widget widget, ModData modData, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public enum IngameInfoPanel { AutoSelect, Map, Objectives, Debug, Chat, LobbbyOptions }
 
-	class GameInfoLogic : ChromeLogic
+	sealed class GameInfoLogic : ChromeLogic
 	{
 		[TranslationReference]
 		const string Objectives = "menu-game-info.objectives";

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoObjectivesLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoObjectivesLogic.cs
@@ -16,7 +16,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	class GameInfoObjectivesLogic : ChromeLogic
+	sealed class GameInfoObjectivesLogic : ChromeLogic
 	{
 		[TranslationReference]
 		const string InProgress = "label-mission-in-progress";

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -20,7 +20,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	class GameInfoStatsLogic : ChromeLogic
+	sealed class GameInfoStatsLogic : ChromeLogic
 	{
 		[TranslationReference]
 		const string Unmute = "label-unmute-player";

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		CameraOption selected;
 		readonly LabelWidget shroudLabel;
 
-		class CameraOption
+		sealed class CameraOption
 		{
 			public readonly Player Player;
 			public readonly string Label;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -595,7 +595,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		// HACK The height of the templates and the scrollpanel needs to be kept in synch
 		bool ShowScrollBar => players.Count() + (hasTeams ? teams.Count() : 0) > 10;
 
-		class StatsDropDownOption
+		sealed class StatsDropDownOption
 		{
 			public string Title;
 			public Func<bool> IsSelected;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ScriptErrorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ScriptErrorLogic.cs
@@ -14,7 +14,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	class ScriptErrorLogic : ChromeLogic
+	sealed class ScriptErrorLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public ScriptErrorLogic(Widget widget, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickClientLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickClientLogic.cs
@@ -14,7 +14,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	class KickClientLogic : ChromeLogic
+	sealed class KickClientLogic : ChromeLogic
 	{
 		[TranslationReference("player")]
 		const string KickClient = "dialog-kick-client.prompt";

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickSpectatorsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickSpectatorsLogic.cs
@@ -14,7 +14,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	class KickSpectatorsLogic : ChromeLogic
+	sealed class KickSpectatorsLogic : ChromeLogic
 	{
 		[TranslationReference("count")]
 		const string KickSpectators = "dialog-kick-spectators.prompt";

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -895,7 +895,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		public string Side;
 	}
 
-	class DropDownOption
+	sealed class DropDownOption
 	{
 		public string Title;
 		public Func<bool> IsSelected = () => false;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference]
 		const string Slot = "options-lobby-slot.slot";
 
-		class SlotDropDownOption
+		sealed class SlotDropDownOption
 		{
 			public readonly string Title;
 			public readonly string Order;
@@ -677,7 +677,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 	}
 
-	class ShowPlayerActionDropDownOption
+	sealed class ShowPlayerActionDropDownOption
 	{
 		public Action Click { get; set; }
 		public string Title;

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -378,7 +378,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			newsStatus.GetText = () => message;
 		}
 
-		class NewsItem
+		sealed class NewsItem
 		{
 			public string Title;
 			public string Author;

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -446,7 +446,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Game.CreateAndStartLocalServer(selectedMap.Uid, orders);
 		}
 
-		class DropDownOption
+		sealed class DropDownOption
 		{
 			public string Title;
 			public Func<bool> IsSelected;

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -819,13 +819,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			base.Dispose(disposing);
 		}
 
-		class ReplayState
+		sealed class ReplayState
 		{
 			public bool Visible;
 			public ScrollItemWidget Item;
 		}
 
-		class Filter
+		sealed class Filter
 		{
 			public GameType Type;
 			public DateType Date;

--- a/OpenRA.Mods.Common/Widgets/ObserverArmyIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverArmyIconsWidget.cs
@@ -201,7 +201,7 @@ namespace OpenRA.Mods.Common.Widgets
 			TooltipUnit = null;
 		}
 
-		class ArmyIcon
+		sealed class ArmyIcon
 		{
 			public Rectangle Bounds { get; set; }
 			public ArmyUnit Unit { get; set; }

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -481,7 +481,7 @@ namespace OpenRA.Mods.Common.Widgets
 			return world.OrderGenerator.HandleKeyPress(e);
 		}
 
-		ScrollDirection CheckForDirections()
+		static ScrollDirection CheckForDirections()
 		{
 			var margin = Game.Settings.Game.ViewportEdgeScrollMargin;
 			var directions = ScrollDirection.None;

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.D2k.Activities
 {
 	enum AttackState { Uninitialized, Burrowed, Attacking }
 
-	class SwallowActor : Activity
+	sealed class SwallowActor : Activity
 	{
 		const int NearEnough = 1;
 

--- a/OpenRA.Mods.D2k/SpriteLoaders/R8Loader.cs
+++ b/OpenRA.Mods.D2k/SpriteLoaders/R8Loader.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.D2k.SpriteLoaders
 {
 	public class R8Loader : ISpriteLoader
 	{
-		class R8Frame : ISpriteFrame
+		sealed class R8Frame : ISpriteFrame
 		{
 			public SpriteFrameType Type => SpriteFrameType.Indexed8;
 			public Size Size { get; }

--- a/OpenRA.Mods.D2k/SpriteLoaders/R8Loader.cs
+++ b/OpenRA.Mods.D2k/SpriteLoaders/R8Loader.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.D2k.SpriteLoaders
 			}
 		}
 
-		bool IsR8(Stream s)
+		static bool IsR8(Stream s)
 		{
 			var start = s.Position;
 

--- a/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
+++ b/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
@@ -21,7 +21,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.D2k.Traits
 {
 	[Desc("Sandworms use this attack model.")]
-	class AttackSwallowInfo : AttackFrontalInfo
+	sealed class AttackSwallowInfo : AttackFrontalInfo
 	{
 		[Desc("The number of ticks it takes to return underground.")]
 		public readonly int ReturnDelay = 60;
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.D2k.Traits
 		public override object Create(ActorInitializer init) { return new AttackSwallow(init.Self, this); }
 	}
 
-	class AttackSwallow : AttackFrontal
+	sealed class AttackSwallow : AttackFrontal
 	{
 		public new readonly AttackSwallowInfo Info;
 
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.D2k.Traits
 			return new SwallowTarget(self, newTarget, allowMove, forceAttack);
 		}
 
-		public class SwallowTarget : Attack
+		public sealed class SwallowTarget : Attack
 		{
 			public SwallowTarget(Actor self, in Target target, bool allowMovement, bool forceAttack)
 				: base(self, target, allowMovement, forceAttack) { }

--- a/OpenRA.Mods.D2k/Traits/Buildings/D2kActorPreviewPlaceBuildingPreview.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/D2kActorPreviewPlaceBuildingPreview.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 	public class D2kActorPreviewPlaceBuildingPreview { }
 
-	class D2kActorPreviewPlaceBuildingPreviewPreview : ActorPreviewPlaceBuildingPreviewPreview
+	sealed class D2kActorPreviewPlaceBuildingPreviewPreview : ActorPreviewPlaceBuildingPreviewPreview
 	{
 		readonly D2kActorPreviewPlaceBuildingPreviewInfo info;
 		readonly bool checkUnsafeTiles;

--- a/OpenRA.Mods.D2k/Traits/Sandworm.cs
+++ b/OpenRA.Mods.D2k/Traits/Sandworm.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits
 {
-	class SandwormInfo : WandersInfo, Requires<MobileInfo>, Requires<AttackBaseInfo>
+	sealed class SandwormInfo : WandersInfo, Requires<MobileInfo>, Requires<AttackBaseInfo>
 	{
 		[Desc("Time between rescanning for targets (in ticks).")]
 		public readonly int TargetRescanInterval = 125;
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.D2k.Traits
 		public override object Create(ActorInitializer init) { return new Sandworm(init.Self, this); }
 	}
 
-	class Sandworm : Wanders, ITick, INotifyActorDisposing
+	sealed class Sandworm : Wanders, ITick, INotifyActorDisposing
 	{
 		public readonly SandwormInfo WormInfo;
 

--- a/OpenRA.Mods.D2k/Traits/World/D2kFogPalette.cs
+++ b/OpenRA.Mods.D2k/Traits/World/D2kFogPalette.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.D2k.Traits
 {
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
-	class D2kFogPaletteInfo : TraitInfo
+	sealed class D2kFogPaletteInfo : TraitInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.D2k.Traits
 		public override object Create(ActorInitializer init) { return new D2kFogPalette(this); }
 	}
 
-	class D2kFogPalette : ILoadsPalettes, IProvidesAssetBrowserPalettes
+	sealed class D2kFogPalette : ILoadsPalettes, IProvidesAssetBrowserPalettes
 	{
 		readonly D2kFogPaletteInfo info;
 		public D2kFogPalette(D2kFogPaletteInfo info) { this.info = info; }

--- a/OpenRA.Mods.D2k/Traits/World/PaletteFromScaledPalette.cs
+++ b/OpenRA.Mods.D2k/Traits/World/PaletteFromScaledPalette.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.D2k.Traits
 {
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Create a palette by applying a scale and offset to the colors in another palette.")]
-	class PaletteFromScaledPaletteInfo : TraitInfo
+	sealed class PaletteFromScaledPaletteInfo : TraitInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.D2k.Traits
 		public override object Create(ActorInitializer init) { return new PaletteFromScaledPalette(this); }
 	}
 
-	class PaletteFromScaledPalette : ILoadsPalettes, IProvidesAssetBrowserPalettes
+	sealed class PaletteFromScaledPalette : ILoadsPalettes, IProvidesAssetBrowserPalettes
 	{
 		readonly PaletteFromScaledPaletteInfo info;
 		public PaletteFromScaledPalette(PaletteFromScaledPaletteInfo info) { this.info = info; }
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.D2k.Traits
 		public IEnumerable<string> PaletteNames { get { yield return info.Name; } }
 	}
 
-	class ScaledPaletteRemap : IPaletteRemap
+	sealed class ScaledPaletteRemap : IPaletteRemap
 	{
 		readonly float scale;
 		readonly int offset;

--- a/OpenRA.Mods.D2k/UtilityCommands/ImportD2kMapCommand.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/ImportD2kMapCommand.cs
@@ -15,7 +15,7 @@ using OpenRA.FileSystem;
 
 namespace OpenRA.Mods.D2k.UtilityCommands
 {
-	class ImportD2kMapCommand : IUtilityCommand
+	sealed class ImportD2kMapCommand : IUtilityCommand
 	{
 		string IUtilityCommand.Name => "--import-d2k-map";
 

--- a/OpenRA.Platforms.Default/DummySoundEngine.cs
+++ b/OpenRA.Platforms.Default/DummySoundEngine.cs
@@ -61,12 +61,12 @@ namespace OpenRA.Platforms.Default
 		public void Dispose() { }
 	}
 
-	class NullSoundSource : ISoundSource
+	sealed class NullSoundSource : ISoundSource
 	{
 		public void Dispose() { }
 	}
 
-	class NullSound : ISound
+	sealed class NullSound : ISound
 	{
 		public float Volume { get; set; }
 		public float SeekPosition => 0;

--- a/OpenRA.Platforms.Default/MultiTapDetection.cs
+++ b/OpenRA.Platforms.Default/MultiTapDetection.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Platforms.Default
 		}
 	}
 
-	class TapHistory
+	sealed class TapHistory
 	{
 		public (DateTime Time, int2 Location) FirstRelease, SecondRelease, ThirdRelease;
 

--- a/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
+++ b/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
@@ -291,7 +291,7 @@ namespace OpenRA.Platforms.Default
 				PauseSound(source, paused);
 		}
 
-		void PauseSound(uint source, bool paused)
+		static void PauseSound(uint source, bool paused)
 		{
 			AL10.alGetSourcei(source, AL10.AL_SOURCE_STATE, out var state);
 			if (paused)

--- a/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
+++ b/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Platforms.Default
 			return defaultDevices.Concat(physicalDevices).ToArray();
 		}
 
-		class PoolSlot
+		sealed class PoolSlot
 		{
 			public bool IsActive;
 			public int FrameStarted;
@@ -386,7 +386,7 @@ namespace OpenRA.Platforms.Default
 		}
 	}
 
-	class OpenAlSoundSource : ISoundSource
+	sealed class OpenAlSoundSource : ISoundSource
 	{
 		uint buffer;
 		bool disposed;
@@ -401,7 +401,7 @@ namespace OpenRA.Platforms.Default
 			AL10.alBufferData(buffer, OpenAlSoundEngine.MakeALFormat(channels, sampleBits), data, byteCount, sampleRate);
 		}
 
-		protected virtual void Dispose(bool disposing)
+		void Dispose(bool _)
 		{
 			if (!disposed)
 			{
@@ -538,7 +538,7 @@ namespace OpenRA.Platforms.Default
 		}
 	}
 
-	class OpenAlAsyncLoadSound : OpenAlSound
+	sealed class OpenAlAsyncLoadSound : OpenAlSound
 	{
 		static readonly byte[] SilentData = new byte[2];
 		readonly CancellationTokenSource cts = new();

--- a/OpenRA.Platforms.Default/Sdl2Input.cs
+++ b/OpenRA.Platforms.Default/Sdl2Input.cs
@@ -16,7 +16,7 @@ using SDL2;
 
 namespace OpenRA.Platforms.Default
 {
-	class Sdl2Input
+	sealed class Sdl2Input
 	{
 		MouseButton lastButtonBits = MouseButton.None;
 

--- a/OpenRA.Platforms.Default/Sdl2Input.cs
+++ b/OpenRA.Platforms.Default/Sdl2Input.cs
@@ -20,8 +20,8 @@ namespace OpenRA.Platforms.Default
 	{
 		MouseButton lastButtonBits = MouseButton.None;
 
-		public string GetClipboardText() { return SDL.SDL_GetClipboardText(); }
-		public bool SetClipboardText(string text) { return SDL.SDL_SetClipboardText(text) == 0; }
+		public static string GetClipboardText() { return SDL.SDL_GetClipboardText(); }
+		public static bool SetClipboardText(string text) { return SDL.SDL_SetClipboardText(text) == 0; }
 
 		static MouseButton MakeButton(byte b)
 		{
@@ -40,7 +40,7 @@ namespace OpenRA.Platforms.Default
 				 | ((raw & (int)SDL.SDL_Keymod.KMOD_SHIFT) != 0 ? Modifiers.Shift : 0);
 		}
 
-		int2 EventPosition(Sdl2PlatformWindow device, int x, int y)
+		static int2 EventPosition(Sdl2PlatformWindow device, int x, int y)
 		{
 			// On Windows and Linux (X11) events are given in surface coordinates
 			// These must be scaled to our effective window coordinates

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -351,7 +351,7 @@ namespace OpenRA.Platforms.Default
 			input = new Sdl2Input();
 		}
 
-		byte[] DoublePixelData(byte[] data, Size size)
+		static byte[] DoublePixelData(byte[] data, Size size)
 		{
 			var scaledData = new byte[4 * data.Length];
 			for (var y = 0; y < size.Height; y++)
@@ -498,13 +498,13 @@ namespace OpenRA.Platforms.Default
 		public string GetClipboardText()
 		{
 			VerifyThreadAffinity();
-			return input.GetClipboardText();
+			return Sdl2Input.GetClipboardText();
 		}
 
 		public bool SetClipboardText(string text)
 		{
 			VerifyThreadAffinity();
-			return input.SetClipboardText(text);
+			return Sdl2Input.SetClipboardText(text);
 		}
 
 		static void SetSDLAttributes(GLProfile profile)

--- a/OpenRA.Platforms.Default/Shader.cs
+++ b/OpenRA.Platforms.Default/Shader.cs
@@ -16,7 +16,7 @@ using System.Text;
 
 namespace OpenRA.Platforms.Default
 {
-	class Shader : ThreadAffine, IShader
+	sealed class Shader : ThreadAffine, IShader
 	{
 		public const int VertexPosAttributeIndex = 0;
 		public const int TexCoordAttributeIndex = 1;
@@ -29,7 +29,7 @@ namespace OpenRA.Platforms.Default
 		readonly Queue<int> unbindTextures = new();
 		readonly uint program;
 
-		protected static uint CompileShaderObject(int type, string name)
+		static uint CompileShaderObject(int type, string name)
 		{
 			var ext = type == OpenGL.GL_VERTEX_SHADER ? "vert" : "frag";
 			var filename = Path.Combine(Platform.EngineDir, "glsl", name + "." + ext);

--- a/OpenRA.Platforms.Default/Shader.cs
+++ b/OpenRA.Platforms.Default/Shader.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Platforms.Default
 		readonly Queue<int> unbindTextures = new();
 		readonly uint program;
 
-		protected uint CompileShaderObject(int type, string name)
+		protected static uint CompileShaderObject(int type, string name)
 		{
 			var ext = type == OpenGL.GL_VERTEX_SHADER ? "vert" : "frag";
 			var filename = Path.Combine(Platform.EngineDir, "glsl", name + "." + ext);

--- a/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
+++ b/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
@@ -155,7 +155,7 @@ namespace OpenRA.Platforms.Default
 					verticesPool.Push(vertices);
 		}
 
-		class Message
+		sealed class Message
 		{
 			public Message(ThreadedGraphicsContext device)
 			{
@@ -450,7 +450,7 @@ namespace OpenRA.Platforms.Default
 		}
 	}
 
-	class ThreadedFrameBuffer : IFrameBuffer
+	sealed class ThreadedFrameBuffer : IFrameBuffer
 	{
 		readonly ThreadedGraphicsContext device;
 		readonly Func<ITexture> getTexture;
@@ -500,7 +500,7 @@ namespace OpenRA.Platforms.Default
 		}
 	}
 
-	class ThreadedVertexBuffer : IVertexBuffer<Vertex>
+	sealed class ThreadedVertexBuffer : IVertexBuffer<Vertex>
 	{
 		readonly ThreadedGraphicsContext device;
 		readonly Action bind;
@@ -563,7 +563,7 @@ namespace OpenRA.Platforms.Default
 		}
 	}
 
-	class ThreadedTexture : ITextureInternal
+	sealed class ThreadedTexture : ITextureInternal
 	{
 		readonly ThreadedGraphicsContext device;
 		readonly Func<object> getScaleFilter;
@@ -658,7 +658,7 @@ namespace OpenRA.Platforms.Default
 		}
 	}
 
-	class ThreadedShader : IShader
+	sealed class ThreadedShader : IShader
 	{
 		readonly ThreadedGraphicsContext device;
 		readonly Action prepareRender;

--- a/OpenRA.Server/Program.cs
+++ b/OpenRA.Server/Program.cs
@@ -19,7 +19,7 @@ using OpenRA.Support;
 
 namespace OpenRA.Server
 {
-	class Program
+	sealed class Program
 	{
 		static void Main(string[] args)
 		{

--- a/OpenRA.Test/OpenRA.Game/ActionQueueTest.cs
+++ b/OpenRA.Test/OpenRA.Game/ActionQueueTest.cs
@@ -17,7 +17,7 @@ using OpenRA.Primitives;
 namespace OpenRA.Test
 {
 	[TestFixture]
-	class ActionQueueTest
+	sealed class ActionQueueTest
 	{
 		[TestCase(TestName = "ActionQueue performs actions in order of time, then insertion order.")]
 		public void ActionsArePerformedOrderedByTimeThenByInsertionOrder()

--- a/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
+++ b/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
@@ -19,21 +19,21 @@ namespace OpenRA.Test
 	class MockTraitInfo : TraitInfo { public override object Create(ActorInitializer init) { return null; } }
 	class MockInheritInfo : MockTraitInfo { }
 
-	class MockAInfo : MockInheritInfo, IMock { }
-	class MockBInfo : MockTraitInfo, Requires<IMock>, Requires<MockInheritInfo> { }
-	class MockCInfo : MockTraitInfo, Requires<MockBInfo> { }
+	sealed class MockAInfo : MockInheritInfo, IMock { }
+	sealed class MockBInfo : MockTraitInfo, Requires<IMock>, Requires<MockInheritInfo> { }
+	sealed class MockCInfo : MockTraitInfo, Requires<MockBInfo> { }
 
-	class MockDInfo : MockTraitInfo, Requires<MockEInfo> { }
-	class MockEInfo : MockTraitInfo, Requires<MockFInfo> { }
-	class MockFInfo : MockTraitInfo, Requires<MockDInfo> { }
+	sealed class MockDInfo : MockTraitInfo, Requires<MockEInfo> { }
+	sealed class MockEInfo : MockTraitInfo, Requires<MockFInfo> { }
+	sealed class MockFInfo : MockTraitInfo, Requires<MockDInfo> { }
 
-	class MockGInfo : MockInheritInfo, IMock, NotBefore<MockAInfo> { }
-	class MockHInfo : MockTraitInfo, NotBefore<IMock>, NotBefore<MockInheritInfo>, NotBefore<MockBInfo> { }
-	class MockIInfo : MockTraitInfo, NotBefore<MockHInfo>, NotBefore<MockCInfo> { }
+	sealed class MockGInfo : MockInheritInfo, IMock, NotBefore<MockAInfo> { }
+	sealed class MockHInfo : MockTraitInfo, NotBefore<IMock>, NotBefore<MockInheritInfo>, NotBefore<MockBInfo> { }
+	sealed class MockIInfo : MockTraitInfo, NotBefore<MockHInfo>, NotBefore<MockCInfo> { }
 
-	class MockJInfo : MockTraitInfo, NotBefore<MockKInfo> { }
-	class MockKInfo : MockTraitInfo, NotBefore<MockLInfo> { }
-	class MockLInfo : MockTraitInfo, NotBefore<MockJInfo> { }
+	sealed class MockJInfo : MockTraitInfo, NotBefore<MockKInfo> { }
+	sealed class MockKInfo : MockTraitInfo, NotBefore<MockLInfo> { }
+	sealed class MockLInfo : MockTraitInfo, NotBefore<MockJInfo> { }
 
 	[TestFixture]
 	public class ActorInfoTest

--- a/OpenRA.Test/OpenRA.Game/OrderTest.cs
+++ b/OpenRA.Test/OpenRA.Game/OrderTest.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Test
 	[TestFixture]
 	public class OrderTest
 	{
-		byte[] RoundTripOrder(byte[] bytes)
+		static byte[] RoundTripOrder(byte[] bytes)
 		{
 			return Order.Deserialize(null, new BinaryReader(new MemoryStream(bytes))).Serialize();
 		}

--- a/OpenRA.Test/OpenRA.Game/PriorityQueueTest.cs
+++ b/OpenRA.Test/OpenRA.Game/PriorityQueueTest.cs
@@ -19,7 +19,7 @@ using OpenRA.Support;
 namespace OpenRA.Test
 {
 	[TestFixture]
-	class PriorityQueueTest
+	sealed class PriorityQueueTest
 	{
 		readonly struct Int32Comparer : IComparer<int>
 		{

--- a/OpenRA.Test/OpenRA.Game/SpatiallyPartitionedTest.cs
+++ b/OpenRA.Test/OpenRA.Game/SpatiallyPartitionedTest.cs
@@ -15,7 +15,7 @@ using OpenRA.Primitives;
 namespace OpenRA.Test
 {
 	[TestFixture]
-	class SpatiallyPartitionedTest
+	sealed class SpatiallyPartitionedTest
 	{
 		[TestCase(TestName = "SpatiallyPartitioned.At works")]
 		public void SpatiallyPartitionedAtTest()

--- a/OpenRA.Test/OpenRA.Game/StreamExtsTests.cs
+++ b/OpenRA.Test/OpenRA.Game/StreamExtsTests.cs
@@ -17,7 +17,7 @@ using NUnit.Framework;
 namespace OpenRA.Test
 {
 	[TestFixture]
-	class StreamExtsTests
+	sealed class StreamExtsTests
 	{
 		[TestCase(TestName = "ReadAllLines is equivalent to ReadAllLinesAsMemory")]
 		public void ReadAllLines()

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -36,7 +36,7 @@ namespace OpenRA
 		}
 	}
 
-	class Program
+	sealed class Program
 	{
 		static void Main(string[] args)
 		{

--- a/OpenRA.WindowsLauncher/Program.cs
+++ b/OpenRA.WindowsLauncher/Program.cs
@@ -21,7 +21,7 @@ using SDL2;
 
 namespace OpenRA.WindowsLauncher
 {
-	class WindowsLauncher
+	sealed class WindowsLauncher
 	{
 		[DllImport("user32.dll")]
 		static extern bool SetForegroundWindow(IntPtr hWnd);


### PR DESCRIPTION
Following on from #20802, #20812

Enforces 2 code quality rules across the project. I have batched together a PR for these rules as the diff is large but boring.

See https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ for explanation of each rule.