### PR TITLE
Fix OnAllKilled crash for allies05b and allies05c

### DIFF
--- a/mods/ra/maps/allies-05b/allies05b-AI.lua
+++ b/mods/ra/maps/allies-05b/allies05b-AI.lua
@@ -94,7 +94,8 @@ ActivateAI = function()
 	Trigger.AfterDelay(DateTime.Minutes(1), ProduceUSSRVehicles)
 	Trigger.AfterDelay(DateTime.Minutes(2), ProduceAircraft)
 
-	Trigger.OnAllKilled(SovietProduction, function()
+	local intactProduction = Utils.Where(SovietProduction, function(self) return not self.IsDead end)
+	Trigger.OnAllKilled(intactProduction, function()
 		Utils.Do(USSR.GetGroundAttackers(), IdleHunt)
 	end)
 end

--- a/mods/ra/maps/allies-05c/allies05c-AI.lua
+++ b/mods/ra/maps/allies-05c/allies05c-AI.lua
@@ -94,7 +94,8 @@ ActivateAI = function()
 	Trigger.AfterDelay(DateTime.Minutes(2), ProduceUSSRVehicles)
 	Trigger.AfterDelay(DateTime.Minutes(4), ProduceAircraft)
 
-	Trigger.OnAllKilled(SovietProduction, function()
+	local intactProduction = Utils.Where(SovietProduction, function(self) return not self.IsDead end)
+	Trigger.OnAllKilled(intactProduction, function()
 		Utils.Do(USSR.GetGroundAttackers(), IdleHunt)
 	end)
 end


### PR DESCRIPTION
This fixes a crash reported for `allies05c` by Ten_Tacles on the discord. It occurs if certain buildings are destroyed before Tanya leaves the map. The same crash could show up in `allies05b`, so the same fix is added there.

`allies05a`'s script happens to be by a different author, and this issue doesn't apply.