### PR TITLE
Fix DischargeableSupportPowerInstance crashing without instances

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/GrantPrerequisiteChargeDrainPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/GrantPrerequisiteChargeDrainPower.cs
@@ -183,19 +183,20 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			public override string IconOverlayTextOverride()
 			{
-				if (!Active)
-					return null;
-
-				var info = (GrantPrerequisiteChargeDrainPowerInfo)Info;
-				return active ? info.ActiveText : available ? info.AvailableText : null;
+				return GetTextOverride();
 			}
 
 			public override string TooltipTimeTextOverride()
 			{
-				if (!Active)
+				return GetTextOverride();
+			}
+
+			string GetTextOverride()
+			{
+				// NB: Info might return null if there are no instances
+				if (!Active || Info is not GrantPrerequisiteChargeDrainPowerInfo info)
 					return null;
 
-				var info = (GrantPrerequisiteChargeDrainPowerInfo)Info;
 				return active ? info.ActiveText : available ? info.AvailableText : null;
 			}
 		}


### PR DESCRIPTION
Fixes #20822.

Drawing the support power icon overlay text occurred before the support power deactivated itself when the host disappears. Since `Info` is a `FirstOrDefault` on the `Instances` list that returns null when there are no instances. `Active` is only set to false in a `Tick` happening after the `Draw`.

Testcase commit changes the War Factory in RA to grant the Service Depot prerequisite. Sell the building while the power is active (or ready) and the crash will happen on bleed but not on this branch.