### PR TITLE
Increase Iron Curtain's footprint

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -396,7 +396,7 @@ SYRD:
 IRON:
 	Inherits: ^ScienceBuilding
 	Inherits@IDISABLE: ^DisableOnLowPowerOrPowerDown
-	Inherits@shape: ^2x1Shape
+	Inherits@shape: ^2x2Shape
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 130
@@ -408,11 +408,10 @@ IRON:
 	Tooltip:
 		Name: Iron Curtain
 	Building:
-		Footprint: xx
-		Dimensions: 2,1
+		Footprint: ++ xx
+		Dimensions: 2,2
 	Selectable:
-		Bounds: 2048, 1194, 0, 85
-		DecorationBounds: 2133, 2133, 0, -512
+		Bounds: 2048, 2133, 0, -170
 	Health:
 		HP: 100000
 	Armor:

--- a/mods/ra/sequences/structures.yaml
+++ b/mods/ra/sequences/structures.yaml
@@ -759,21 +759,21 @@ iron:
 	Defaults:
 		Filename: iron.shp
 	idle:
-		Offset: 0,-12
+		Offset: 0,-4
 	active:
 		Length: 11
-		Offset: 0,-12
+		Offset: 0,-4
 	damaged-idle:
 		Start: 11
-		Offset: 0,-12
+		Offset: 0,-4
 	damaged-active:
 		Start: 11
 		Length: 11
-		Offset: 0,-12
+		Offset: 0,-4
 	make:
 		Filename: ironmake.shp
 		Length: *
-		Offset: 0,-12
+		Offset: 0,-4
 	bib:
 		TilesetFilenames:
 			SNOW: mbIRON.sno
@@ -781,7 +781,7 @@ iron:
 			TEMPERAT: mbIRON.tem
 			DESERT: mbIRON.des
 		Length: *
-		Offset: 0,2
+		Offset: 0,-2
 	icon:
 		Filename: ironicon.shp
 


### PR DESCRIPTION
The competitive community has been using this IC for years now, and I think we should implement it into vanilla. I've had mentioned it in #19792 but noone went forward to do the change.

Here's how the IC looks before this PR
<img width="289" alt="Before" src="https://user-images.githubusercontent.com/37534529/235319424-079c4d1b-78b3-454d-9efe-8fb3a3d12d78.png">

Here's after
<img width="288" alt="Screenshot 2023-04-29 at 21 50 43" src="https://user-images.githubusercontent.com/37534529/235319429-0a342b6d-3cbc-439b-b5be-91cf0dd3acf3.png">

The reason why the IC footprint needs to be changed is that the IC can hide a lot of things behind it. The best example is a sam site
<img width="291" alt="Screenshot 2023-04-29 at 21 51 01" src="https://user-images.githubusercontent.com/37534529/235319470-ab049dbc-df3c-45a2-add1-5c486cb400ae.png">

I did a search for IC in missions, but all I could find is the IC in shellmap. It's not close to anything so there's no need to adjust it

The upper to cells are transient
![transient](https://github.com/OpenRA/OpenRA/assets/37534529/9bb423f8-ab4c-4544-bbbb-dc823d557fb2)
