### PR TITLE
Add missing RA balance changes

### DIFF
--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -77,7 +77,7 @@ MIG:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 10000
+		HP: 8000
 	RevealsShroud:
 		MinRange: 11c0
 		Range: 13c0

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -426,7 +426,7 @@ JEEP:
 		Type: Light
 	Mobile:
 		TurnSpeed: 40
-		Speed: 160
+		Speed: 164
 		PauseOnCondition: notmobile || being-captured
 	RevealsShroud:
 		MinRange: 4c0


### PR DESCRIPTION
When making #20007 I missed the MiG health nerf. It happened in between patches and overall the change was apparently quite stealthy.

As for ranger, it was adjusted for the new unit speeds. I had not done that in #19792, and fairly recently @tttppp figured out the correct speed for the ranger.