### PR TITLE
TechTree.GatherOwnedPrerequisites performance improvements.

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/GrantPrerequisiteChargeDrainPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/GrantPrerequisiteChargeDrainPower.cs
@@ -43,6 +43,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	public class GrantPrerequisiteChargeDrainPower : SupportPower, ITechTreePrerequisite, INotifyOwnerChanged
 	{
 		readonly GrantPrerequisiteChargeDrainPowerInfo info;
+		readonly string[] prerequisites;
 		TechTree techTree;
 		bool active;
 
@@ -50,6 +51,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			: base(self, info)
 		{
 			this.info = info;
+			prerequisites = new[] { info.Prerequisite };
 		}
 
 		protected override void Created(Actor self)
@@ -82,16 +84,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			techTree.ActorChanged(self);
 		}
 
-		IEnumerable<string> ITechTreePrerequisite.ProvidesPrerequisites
-		{
-			get
-			{
-				if (!active)
-					yield break;
-
-				yield return info.Prerequisite;
-			}
-		}
+		IEnumerable<string> ITechTreePrerequisite.ProvidesPrerequisites => active ? prerequisites : Enumerable.Empty<string>();
 
 		public class DischargeableSupportPowerInstance : SupportPowerInstance
 		{

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -39,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class ProvidesPrerequisite : ConditionalTrait<ProvidesPrerequisiteInfo>, ITechTreePrerequisite, INotifyOwnerChanged, INotifyCreated
 	{
-		readonly string prerequisite;
+		readonly string[] prerequisites;
 
 		bool enabled;
 		TechTree techTree;
@@ -48,24 +49,15 @@ namespace OpenRA.Mods.Common.Traits
 		public ProvidesPrerequisite(ActorInitializer init, ProvidesPrerequisiteInfo info)
 			: base(info)
 		{
-			prerequisite = info.Prerequisite;
-
-			if (string.IsNullOrEmpty(prerequisite))
-				prerequisite = init.Self.Info.Name;
+			if (string.IsNullOrEmpty(info.Prerequisite))
+				prerequisites = new[] { init.Self.Info.Name };
+			else
+				prerequisites = new[] { info.Prerequisite };
 
 			faction = init.GetValue<FactionInit, string>(init.Self.Owner.Faction.InternalName);
 		}
 
-		public IEnumerable<string> ProvidesPrerequisites
-		{
-			get
-			{
-				if (!enabled)
-					yield break;
-
-				yield return prerequisite;
-			}
-		}
+		public IEnumerable<string> ProvidesPrerequisites => enabled ? prerequisites : Enumerable.Empty<string>();
 
 		protected override void Created(Actor self)
 		{

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -38,11 +39,9 @@ namespace OpenRA.Mods.Common.Traits
 		readonly ProvidesTechPrerequisiteInfo info;
 		readonly bool enabled;
 
-		static readonly string[] NoPrerequisites = Array.Empty<string>();
-
 		public string Name => info.Name;
 
-		public IEnumerable<string> ProvidesPrerequisites => enabled ? info.Prerequisites : NoPrerequisites;
+		public IEnumerable<string> ProvidesPrerequisites => enabled ? info.Prerequisites : Enumerable.Empty<string>();
 
 		public ProvidesTechPrerequisite(ProvidesTechPrerequisiteInfo info, ActorInitializer init)
 		{


### PR DESCRIPTION
- Consuming methods cared only about the count and not the actual actors, so only counts the actors rather that creating lists.
- ProvidesPrerequisites implementations return cached objects rather then allocating new enumerables on each call.

Reduces time spent in this method during loading from 1.16% to 0.42%