### PR TITLE
Adjust the ValidTargets of DuplicateUnitCrateAction in RA

### DIFF
--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -44,6 +44,7 @@ CRATE:
 		MaxAmount: 5
 		MinAmount: 1
 		MaxDuplicateValue: 1500
+		ValidTargets: GroundActor, WaterActor, Submarine
 	GiveBaseBuilderCrateAction:
 		SelectionShares: 0
 		NoBaseSelectionShares: 100


### PR DESCRIPTION
Reported by @dsimmons87 on Discord. #18068 changed the target types of actors, but didn't change the default values in `DuplicateUnitCrateAction`. That crate action was probably broken in RA since then.