### PR TITLE
Fix the ExplicitSequenceFilenames rule breaking when updating single maps

### DIFF
--- a/OpenRA.Mods.Common/UpdateRules/Rules/20221203/ExplicitSequenceFilenames.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20221203/ExplicitSequenceFilenames.cs
@@ -132,8 +132,14 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			var implicitInheritedSequences = new List<string>();
 			foreach (var resolvedSequenceNode in resolvedImageNode.Value.Nodes)
 			{
-				if (resolvedSequenceNode.Key != "Defaults" && string.IsNullOrEmpty(resolvedSequenceNode.Value.Value) &&
-				    imageNode.LastChildMatching(resolvedSequenceNode.Key) == null)
+				if (resolvedSequenceNode.Key == "Defaults")
+					continue;
+
+				// Ignore nodes that are not implicitly named or already processed
+				if (!string.IsNullOrEmpty(resolvedSequenceNode.Value.Value) || resolvedSequenceNode.LastChildMatching("Filename") != null)
+					continue;
+
+				if (imageNode.LastChildMatching(resolvedSequenceNode.Key) == null)
 				{
 					imageNode.AddNode(resolvedSequenceNode.Key, "");
 					implicitInheritedSequences.Add(resolvedSequenceNode.Key);

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20221203/ExplicitSequenceFilenames.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20221203/ExplicitSequenceFilenames.cs
@@ -336,6 +336,10 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		void ProcessNode(ModData modData, MiniYamlNode sequenceNode, MiniYamlNode resolvedSequenceNode, string imageName)
 		{
+			// "Filename" was introduced with this update rule, so that means this node was already processed and can be skipped
+			if (sequenceNode.LastChildMatching("Filename") != null)
+				return;
+
 			var addExtension = true;
 			var addExtensionNode = resolvedSequenceNode.LastChildMatching("AddExtension");
 			if (addExtensionNode != null)


### PR DESCRIPTION
Reported by @PunkPun on Discord. Testcase is adding the following to any D2k `map.yaml` and running the `ExplicitSequenceFilenames` rule on that map.
```miniyaml
Sequences:
	frigate:
		icon: DATA.R8
			Start: 4290
			Offset: -30,-24
```

Bleed will give:
```miniyaml
Sequences:
	frigate:
		icon:
			Filename: DATA.R8
			Start: 4290
			Offset: -30,-24
		idle:
			Filename: frigate
```

And running it a second time will produce:
```miniyaml
Sequences:
	frigate:
		icon:
			Filename: frigate
			Filename: DATA.R8
			Start: 4290
			Offset: -30,-24
		idle:
			Filename: frigate
			Filename: frigate
```

The expected result in both cases is:
```miniyaml
Sequences:
	frigate:
		icon:
			Filename: DATA.R8
			Start: 4290
			Offset: -30,-24
```

Seems like #20580 both introduced `Filename` and the update rule, so it is save to say that sequence nodes that already have a `Filename` node are already processed and can be ignored.

The issue in the example happens because the mod sequence `idle` is already updated and the map only defined the extra `icon` sequence. The update rule was trying to update the already updated sequence from the mod code again instead of just the map sequence.