### PR TITLE
Videoplayer fixes

### DIFF
--- a/OpenRA.Mods.Cnc/FileFormats/WsaVideo.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/WsaVideo.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 	public class WsaVideo : IVideo
 	{
 		public ushort FrameCount { get; }
-		public byte Framerate => 1;
+		public byte Framerate => 15;
 		public ushort Width { get; }
 		public ushort Height { get; }
 

--- a/OpenRA.Mods.Common/Widgets/VideoPlayerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/VideoPlayerWidget.cs
@@ -37,7 +37,8 @@ namespace OpenRA.Mods.Common.Widgets
 		float2 overlayOrigin, overlaySize;
 		float overlayScale;
 		bool stopped;
-		int textureSize;
+		int textureWidth;
+		int textureHeight;
 
 		Action onComplete;
 
@@ -120,12 +121,12 @@ namespace OpenRA.Mods.Common.Widgets
 
 			invLength = video.Framerate * 1f / video.FrameCount;
 
-			var size = Math.Max(video.Width, video.Height);
-			textureSize = Exts.NextPowerOf2(size);
-			var videoSheet = new Sheet(SheetType.BGRA, new Size(textureSize, textureSize));
+			textureWidth = Exts.NextPowerOf2(video.Width);
+			textureHeight = Exts.NextPowerOf2(video.Height);
+			var videoSheet = new Sheet(SheetType.BGRA, new Size(textureWidth, textureHeight));
 
 			videoSheet.GetTexture().ScaleFilter = TextureScaleFilter.Linear;
-			videoSheet.GetTexture().SetData(video.CurrentFrameData, textureSize, textureSize);
+			videoSheet.GetTexture().SetData(video.CurrentFrameData, textureWidth, textureHeight);
 
 			videoSprite = new Sprite(videoSheet,
 				new Rectangle(
@@ -168,7 +169,7 @@ namespace OpenRA.Mods.Common.Widgets
 				while (nextFrame > Video.CurrentFrameIndex)
 				{
 					Video.AdvanceFrame();
-					videoSprite.Sheet.GetTexture().SetData(Video.CurrentFrameData, textureSize, textureSize);
+					videoSprite.Sheet.GetTexture().SetData(Video.CurrentFrameData, textureWidth, textureHeight);
 					skippedFrames++;
 				}
 
@@ -283,7 +284,7 @@ namespace OpenRA.Mods.Common.Widgets
 			Paused = true;
 			Game.Sound.StopVideo();
 			Video.Reset();
-			videoSprite.Sheet.GetTexture().SetData(Video.CurrentFrameData, textureSize, textureSize);
+			videoSprite.Sheet.GetTexture().SetData(Video.CurrentFrameData, textureWidth, textureHeight);
 			Game.RunAfterTick(() =>
 			{
 				if (onComplete != null)


### PR DESCRIPTION
1. Video sizes.
Imagine a video with the size of 320x160. It should fit flawless in a 512x256 region. However due to the way the video player adresses the sizing, he came up with a 512x512 region, wasting a lot (2x) of memory here. I fixed that by taking width and height into account individualy.

2. FrameRate
The video FrameRate was only taken into account when the video has audio data, as it relied on the audio playback position.