### PR TITLE
Make yaml node resolving optional

### DIFF
--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UnhardcodeBaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UnhardcodeBaseBuilderBotModule.cs
@@ -14,7 +14,7 @@ using System.Linq;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {
-	public class UnhardcodeBaseBuilderBotModule : UpdateRule
+	public class UnhardcodeBaseBuilderBotModule : UpdateRule, IBeforeUpdateActors
 	{
 		MiniYamlNode defences;
 
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "DefenseTypes were added.";
 
-		public override IEnumerable<string> BeforeUpdateActors(ModData modData, List<MiniYamlNode> resolvedActors)
+		public IEnumerable<string> BeforeUpdateActors(ModData modData, List<MiniYamlNode> resolvedActors)
 		{
 			var defences = new List<string>();
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UnhardcodeSquadManager.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UnhardcodeSquadManager.cs
@@ -14,7 +14,7 @@ using System.Linq;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {
-	public class UnhardcodeSquadManager : UpdateRule
+	public class UnhardcodeSquadManager : UpdateRule, IBeforeUpdateActors
 	{
 		readonly List<MiniYamlNode> addNodes = new();
 
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "AirUnitsTypes and ProtectionTypes were added.";
 
-		public override IEnumerable<string> BeforeUpdateActors(ModData modData, List<MiniYamlNode> resolvedActors)
+		public IEnumerable<string> BeforeUpdateActors(ModData modData, List<MiniYamlNode> resolvedActors)
 		{
 			var aircraft = new List<string>();
 			var vips = new List<string>();

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230225/ExplicitSequenceFilenames.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230225/ExplicitSequenceFilenames.cs
@@ -15,7 +15,7 @@ using System.Reflection;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {
-	public class ExplicitSequenceFilenames : UpdateRule
+	public class ExplicitSequenceFilenames : UpdateRule, IBeforeUpdateSequences
 	{
 		public override string Name => "Sequence filenames must be specified explicitly.";
 
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 		bool reportModYamlChanges;
 		bool disabled;
 
-		public override IEnumerable<string> BeforeUpdateSequences(ModData modData, List<MiniYamlNode> resolvedImagesNodes)
+		public IEnumerable<string> BeforeUpdateSequences(ModData modData, List<MiniYamlNode> resolvedImagesNodes)
 		{
 			// Keep a resolved copy of the sequences so we can account for values imported through inheritance or Defaults.
 			// This will be modified during processing, so take a deep copy to avoid side-effects on other update rules.

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230225/RemoveNegativeSequenceLength.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230225/RemoveNegativeSequenceLength.cs
@@ -15,7 +15,7 @@ using System.Linq;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {
-	public class RemoveNegativeSequenceLength : UpdateRule
+	public class RemoveNegativeSequenceLength : UpdateRule, IBeforeUpdateSequences
 	{
 		public override string Name => "Negative sequence length is no longer allowed.";
 
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		List<MiniYamlNode> resolvedImagesNodes;
 
-		public override IEnumerable<string> BeforeUpdateSequences(ModData modData, List<MiniYamlNode> resolvedImagesNodes)
+		public IEnumerable<string> BeforeUpdateSequences(ModData modData, List<MiniYamlNode> resolvedImagesNodes)
 		{
 			this.resolvedImagesNodes = resolvedImagesNodes;
 			yield break;

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -72,34 +72,38 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveSmokeTrailWhenDamaged(),
 				new ReplaceCrateSecondsWithTicks(),
 				new UseMillisecondsForSounds(),
-				new UnhardcodeSquadManager(),
 				new RenameSupportPowerDescription(),
 				new AttackBomberFacingTolerance(),
 				new AttackFrontalFacingTolerance(),
 				new RenameCloakTypes(),
 				new SplitNukePowerMissileImage(),
 				new ReplaceSequenceEmbeddedPalette(),
-				new UnhardcodeBaseBuilderBotModule(),
 				new UnhardcodeVeteranProductionIconOverlay(),
 				new RenameContrailProperties(),
 				new RemoveDomainIndex(),
 				new AddControlGroups(),
+
+				// Execute these rules last to avoid premature yaml merge crashes.
+				new UnhardcodeSquadManager(),
+				new UnhardcodeBaseBuilderBotModule(),
 			}),
 
 			new UpdatePath("release-20230225", new UpdateRule[]
 			{
 				// bleed only changes here
 				new TextNotificationsDisplayWidgetRemoveTime(),
-				new ExplicitSequenceFilenames(),
 				new RenameEngineerRepair(),
 				new ProductionTabsWidgetAddTabButtonCollection(),
 				new RemoveTSRefinery(),
 				new RenameMcvCrateAction(),
-				new RemoveSequenceHasEmbeddedPalette(),
 				new RenameContrailWidth(),
-				new RemoveNegativeSequenceLength(),
 				new RemoveExperienceFromInfiltrates(),
 				new AddColorPickerValueRange(),
+
+				// Execute these rules last to avoid premature yaml merge crashes.
+				new ExplicitSequenceFilenames(),
+				new RemoveSequenceHasEmbeddedPalette(),
+				new RemoveNegativeSequenceLength(),
 			})
 		};
 

--- a/OpenRA.Mods.Common/UpdateRules/UpdateRule.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateRule.cs
@@ -36,9 +36,21 @@ namespace OpenRA.Mods.Common.UpdateRules
 
 		public virtual IEnumerable<string> BeforeUpdate(ModData modData) { yield break; }
 		public virtual IEnumerable<string> AfterUpdate(ModData modData) { yield break; }
+	}
 
-		public virtual IEnumerable<string> BeforeUpdateActors(ModData modData, List<MiniYamlNode> resolvedActors) { yield break; }
-		public virtual IEnumerable<string> BeforeUpdateWeapons(ModData modData, List<MiniYamlNode> resolvedWeapons) { yield break; }
-		public virtual IEnumerable<string> BeforeUpdateSequences(ModData modData, List<MiniYamlNode> resolvedImages) { yield break; }
+	// These aren't part of the UpdateRule class as to avoid premature yaml merge crashes when updating maps.
+	public interface IBeforeUpdateActors
+	{
+		IEnumerable<string> BeforeUpdateActors(ModData modData, List<MiniYamlNode> resolvedActors) { yield break; }
+	}
+
+	public interface IBeforeUpdateWeapons
+	{
+		IEnumerable<string> BeforeUpdateWeapons(ModData modData, List<MiniYamlNode> resolvedWeapons) { yield break; }
+	}
+
+	public interface IBeforeUpdateSequences
+	{
+		IEnumerable<string> BeforeUpdateSequences(ModData modData, List<MiniYamlNode> resolvedImages) { yield break; }
 	}
 }

--- a/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
@@ -114,8 +114,11 @@ namespace OpenRA.Mods.Common.UpdateRules
 				var mapRulesNode = yaml.Nodes.FirstOrDefault(n => n.Key == "Rules");
 				if (mapRulesNode != null)
 				{
-					var resolvedActors = LoadMapYaml(modData.DefaultFileSystem, mapPackage, modData.Manifest.Rules, mapRulesNode.Value);
-					manualSteps.AddRange(rule.BeforeUpdateActors(modData, resolvedActors));
+					if (rule is IBeforeUpdateActors before)
+					{
+						var resolvedActors = LoadMapYaml(modData.DefaultFileSystem, mapPackage, modData.Manifest.Rules, mapRulesNode.Value);
+						manualSteps.AddRange(before.BeforeUpdateActors(modData, resolvedActors));
+					}
 
 					var mapRules = LoadInternalMapYaml(modData, mapPackage, mapRulesNode.Value, externalFilenames);
 					manualSteps.AddRange(ApplyTopLevelTransform(modData, mapRules, rule.UpdateActorNode));
@@ -125,8 +128,11 @@ namespace OpenRA.Mods.Common.UpdateRules
 				var mapWeaponsNode = yaml.Nodes.FirstOrDefault(n => n.Key == "Weapons");
 				if (mapWeaponsNode != null)
 				{
-					var resolvedWeapons = LoadMapYaml(modData.DefaultFileSystem, mapPackage, modData.Manifest.Weapons, mapWeaponsNode.Value);
-					manualSteps.AddRange(rule.BeforeUpdateWeapons(modData, resolvedWeapons));
+					if (rule is IBeforeUpdateWeapons before)
+					{
+						var resolvedWeapons = LoadMapYaml(modData.DefaultFileSystem, mapPackage, modData.Manifest.Weapons, mapWeaponsNode.Value);
+						manualSteps.AddRange(before.BeforeUpdateWeapons(modData, resolvedWeapons));
+					}
 
 					var mapWeapons = LoadInternalMapYaml(modData, mapPackage, mapWeaponsNode.Value, externalFilenames);
 					manualSteps.AddRange(ApplyTopLevelTransform(modData, mapWeapons, rule.UpdateWeaponNode));
@@ -136,8 +142,11 @@ namespace OpenRA.Mods.Common.UpdateRules
 				var mapSequencesNode = yaml.Nodes.FirstOrDefault(n => n.Key == "Sequences");
 				if (mapSequencesNode != null)
 				{
-					var resolvedImages = LoadMapYaml(modData.DefaultFileSystem, mapPackage, modData.Manifest.Sequences, mapSequencesNode.Value);
-					manualSteps.AddRange(rule.BeforeUpdateSequences(modData, resolvedImages));
+					if (rule is IBeforeUpdateSequences before)
+					{
+						var resolvedImages = LoadMapYaml(modData.DefaultFileSystem, mapPackage, modData.Manifest.Sequences, mapSequencesNode.Value);
+						manualSteps.AddRange(before.BeforeUpdateSequences(modData, resolvedImages));
+					}
 
 					var mapSequences = LoadInternalMapYaml(modData, mapPackage, mapSequencesNode.Value, externalFilenames);
 					manualSteps.AddRange(ApplyTopLevelTransform(modData, mapSequences, rule.UpdateSequenceNode));
@@ -229,16 +238,28 @@ namespace OpenRA.Mods.Common.UpdateRules
 
 			manualSteps.AddRange(rule.BeforeUpdate(modData));
 
-			var resolvedActors = MiniYaml.Load(modData.DefaultFileSystem, modData.Manifest.Rules, null);
-			manualSteps.AddRange(rule.BeforeUpdateActors(modData, resolvedActors));
+			if (rule is IBeforeUpdateActors beforeActors)
+			{
+				var resolvedActors = MiniYaml.Load(modData.DefaultFileSystem, modData.Manifest.Rules, null);
+				manualSteps.AddRange(beforeActors.BeforeUpdateActors(modData, resolvedActors));
+			}
+
 			manualSteps.AddRange(ApplyTopLevelTransform(modData, modRules, rule.UpdateActorNode));
 
-			var resolvedWeapons = MiniYaml.Load(modData.DefaultFileSystem, modData.Manifest.Weapons, null);
-			manualSteps.AddRange(rule.BeforeUpdateWeapons(modData, resolvedWeapons));
+			if (rule is IBeforeUpdateWeapons beforeWeapons)
+			{
+				var resolvedWeapons = MiniYaml.Load(modData.DefaultFileSystem, modData.Manifest.Weapons, null);
+				manualSteps.AddRange(beforeWeapons.BeforeUpdateWeapons(modData, resolvedWeapons));
+			}
+
 			manualSteps.AddRange(ApplyTopLevelTransform(modData, modWeapons, rule.UpdateWeaponNode));
 
-			var resolvedSequences = MiniYaml.Load(modData.DefaultFileSystem, modData.Manifest.Sequences, null);
-			manualSteps.AddRange(rule.BeforeUpdateSequences(modData, resolvedSequences));
+			if (rule is IBeforeUpdateSequences beforeSequences)
+			{
+				var resolvedImages = MiniYaml.Load(modData.DefaultFileSystem, modData.Manifest.Sequences, null);
+				manualSteps.AddRange(beforeSequences.BeforeUpdateSequences(modData, resolvedImages));
+			}
+
 			manualSteps.AddRange(ApplyTopLevelTransform(modData, modSequences, rule.UpdateSequenceNode));
 
 			manualSteps.AddRange(ApplyTopLevelTransform(modData, modTilesets, rule.UpdateTilesetNode));


### PR DESCRIPTION
Partially fixes #20847

As we can't come up with a perfect solution the goal of this PR is just to make the situation much better.
* The first solution is to resolve rules as infrequently as possible with the introduction of `IBeforeUpdate*` interfaces.
* Second solution is to delay revolving in hopes that other update rules will fix the causes for crash

As a side effect this should make the update rules run faster as we resolve way way less yaml