### PR TITLE
Deserialize mod rules only once when loading all maps.

### DIFF
--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -123,10 +123,12 @@ namespace OpenRA
 				mapDirectoryTrackers.Add(new MapDirectoryTracker(mapGrid, package, classification));
 			}
 
+			// PERF: Load the mod YAML once outside the loop, and reuse it when resolving each maps custom YAML.
+			var modDataRules = modData.GetRulesYaml();
 			foreach (var kv in MapLocations)
 			{
 				foreach (var map in kv.Key.Contents)
-					LoadMap(map, kv.Key, kv.Value, mapGrid, null);
+					LoadMapInternal(map, kv.Key, kv.Value, mapGrid, null, modDataRules);
 			}
 
 			// We only want to track maps in runtime, not at loadtime
@@ -134,6 +136,11 @@ namespace OpenRA
 		}
 
 		public void LoadMap(string map, IReadOnlyPackage package, MapClassification classification, MapGrid mapGrid, string oldMap)
+		{
+			LoadMapInternal(map, package, classification, mapGrid, oldMap, null);
+		}
+
+		void LoadMapInternal(string map, IReadOnlyPackage package, MapClassification classification, MapGrid mapGrid, string oldMap, IEnumerable<List<MiniYamlNode>> modDataRules)
 		{
 			IReadOnlyPackage mapPackage = null;
 			try
@@ -144,7 +151,7 @@ namespace OpenRA
 					if (mapPackage != null)
 					{
 						var uid = Map.ComputeUID(mapPackage);
-						previews[uid].UpdateFromMap(mapPackage, package, classification, modData.Manifest.MapCompatibility, mapGrid.Type);
+						previews[uid].UpdateFromMap(mapPackage, package, classification, modData.Manifest.MapCompatibility, mapGrid.Type, modDataRules);
 
 						if (oldMap != uid)
 						{

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -166,6 +166,11 @@ namespace OpenRA
 			return map;
 		}
 
+		public List<MiniYamlNode>[] GetRulesYaml()
+		{
+			return Manifest.Rules.Select(s => MiniYaml.FromStream(DefaultFileSystem.Open(s), s)).ToArray();
+		}
+
 		public void Dispose()
 		{
 			LoadScreen?.Dispose();


### PR DESCRIPTION
This avoids loading, parsing and merging YAML rules for the mod during loading of each individual map. This saves significant time resolving custom rules on each map loaded.

----

Threading the extra parameter through all the methods is pretty ugly, but hopefully the perfomance savings justify it. Time spent in `SetCustomRules` during loading goes from 15.0% to 8.9%. `GetRulesYaml` adds 0.2% to this figure giving 9.1% as the "after" result.