### PR TITLE
Remove wrong definitions from TD's notifications.yaml

### DIFF
--- a/mods/cnc/audio/notifications.yaml
+++ b/mods/cnc/audio/notifications.yaml
@@ -74,8 +74,6 @@ Sounds:
 		Construction: constru2
 		Country1: country1
 		Country4: country4
-		DisablePower: bleep11
-		EnablePower: bleep12
 		HeavyDoor: hvydoor1
 		Keystroke: keystrok
 		LevelUp: text2
@@ -83,11 +81,6 @@ Sounds:
 		RadarDown: powrdn1
 		RadarUp: comcntr1
 		Sell: cashturn
-		SignalFlare: flare1
-		SignalFlareEast: flaree1
-		SignalFlareNorth: flaren1
-		SignalFlareSouth: flares1
-		SignalFlareWest: flarew1
 		Target1: target1
 		Target2: target2
 		Target3: target3


### PR DESCRIPTION
Seems like #2801 and #8123 copied these from RA. I don't see the referenced sound files in the assets browser, so I don't think they exist in TD. Also seems like all those definitions aren't used (probably because they don't work).