### PR TITLE
RallyPoint: allow overriding offset of first point of the rally point path

### DIFF
--- a/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Effects
 				return;
 
 			var exit = building.NearestExitOrDefault(targetLineNodes[0]);
-			targetLineNodes.Insert(0, building.CenterPosition + (exit?.Info.SpawnOffset ?? WVec.Zero));
+			targetLineNodes.Insert(0, building.CenterPosition + (rp.Info.InitialOffset ?? exit?.Info.SpawnOffset ?? WVec.Zero));
 		}
 
 		IEnumerable<IRenderable> IEffect.Render(WorldRenderer wr) { return SpriteRenderable.None; }

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -45,6 +45,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("A list of 0 or more offsets defining the initial rally point path.")]
 		public readonly CVec[] Path = Array.Empty<CVec>();
 
+		[Desc("Override offset at which the first point of rally point path is drawn relative relative to the center of the producing actor.",
+			"If not specified, " + nameof(ExitInfo.SpawnOffset) + " from " + nameof(Exit) + " trait with nearest " + nameof(ExitInfo.ExitCell) + " is used.")]
+		public readonly WVec? InitialOffset = null;
+
 		[NotificationReference("Speech")]
 		[Desc("Speech notification to play when setting a new rallypoint.")]
 		public readonly string Notification = null;


### PR DESCRIPTION
This PR makes it possible to override offset of first point of the rally point path. This can be used by mods to change the position of the first point independently of `Exit`'s `SpawnOffset`.

In OpenE2140 we use custom `Production` trait that dynamically calculates precise spawn offset of the actor and thus specifying `SpawnOffset` in `Exit` trait is redundant and error-prone (since in our case `SpawnOffset` is the same of all exits). If we could specify this custom offset in `RallyPoint`, it would've looked like this:

```miniyaml
ed_buildings_tech_house:
    Inherits: ^CoreElevatorFactory
    # ...
    # Custom Production trait
    ElevatorProduction:
        Image: ed_elevator
        Position: 992, -104, 0
        # ... 
    RallyPoint:
        InitialOffset: 1024,0,0
    # SpawnOffset is not used in ElevatorProduction (spawn offset is calculated precisely from elevator cell's center).
    Exit@Exit1:
        ExitCell: 1,2
        Facing: 384
    Exit@Exit2:
        ExitCell: 2,2
        Facing: 512
    Exit@Exit3:
        ExitCell: 3,2
        Facing: 640
    # ... more exits ...
```