### PR TITLE
Fix \r\n-style line endings not being properly handled for script errors

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ScriptErrorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ScriptErrorLogic.cs
@@ -26,7 +26,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var luaScript = world.WorldActor.TraitOrDefault<LuaScript>();
 			if (luaScript != null)
 			{
-				var text = WidgetUtils.WrapText(luaScript.Context.ErrorMessage, label.Bounds.Width, font);
+				// Native exceptions have OS-dependend line endings, so strip these away as WrapText doesn't handle them
+				var errorMessage = luaScript.Context.ErrorMessage.Replace("\r\n", "\n");
+
+				var text = WidgetUtils.WrapText(errorMessage, label.Bounds.Width, font);
 				label.Text = text;
 				label.Bounds.Height = font.Measure(text).Y;
 				panel.ScrollToTop();


### PR DESCRIPTION
Otherwise the `\r` characters remain on their own (without `\n` characters) and display as artifacts.