### PR TITLE
Fix a rare crash when actor in IBotRespondToAttack is dead

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/BuildingRepairBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BuildingRepairBotModule.cs
@@ -28,8 +28,8 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// HACK: We don't want D2k bots to repair all their buildings on placement
 			// where half their HP is removed via neutral terrain damage.
-			// TODO: Implement concrete placement for D2k bots and remove this hack.
-			if (self.Owner.RelationshipWith(e.Attacker.Owner) == PlayerRelationship.Neutral)
+			// TODO: Implement concrete placement for D2k bots and remove this hack on players relationship check.
+			if (self.IsDead || self.Owner.RelationshipWith(e.Attacker.Owner) == PlayerRelationship.Neutral)
 				return;
 
 			var rb = self.TraitOrDefault<RepairableBuilding>();


### PR DESCRIPTION
During @EoralMilk's development on Meow he gets a rare crash:

![QQ图片20230520212035](https://github.com/OpenRA/OpenRA/assets/13763394/8bd100a5-f9b6-4b88-b20c-52d6269c06e3)

I guess we missed a work around here to check dead/null unit