### PR TITLE
Remove reference to deleted lua directory

### DIFF
--- a/packaging/functions.sh
+++ b/packaging/functions.sh
@@ -113,7 +113,6 @@ install_data() (
 	done
 
 	cp -r "${SRC_PATH}/glsl" "${DEST_PATH}"
-	cp -r "${SRC_PATH}/lua" "${DEST_PATH}"
 
 	echo "Installing common mod files to ${DEST_PATH}"
 	install -d "${DEST_PATH}/mods"


### PR DESCRIPTION
Lua directory was deleted a few commits ago and this just updates packaging/functions.sh to reflect this change. Without this change, packaging on Linux is a pain.