### PR TITLE
Fix ScriptContext crashing without a Tick function

### DIFF
--- a/OpenRA.Game/Scripting/ScriptContext.cs
+++ b/OpenRA.Game/Scripting/ScriptContext.cs
@@ -284,17 +284,20 @@ namespace OpenRA.Scripting
 
 		public void WorldLoaded()
 		{
-			if (FatalErrorOccurred)
+			if (FatalErrorOccurred || runtime.Globals["WorldLoaded"] is not LuaFunction worldLoaded)
 				return;
 
 			try
 			{
-				using (var worldLoaded = (LuaFunction)runtime.Globals["WorldLoaded"])
-					worldLoaded.Call().Dispose();
+				worldLoaded.Call().Dispose();
 			}
 			catch (LuaException e)
 			{
 				FatalError(e);
+			}
+			finally
+			{
+				worldLoaded?.Dispose();
 			}
 		}
 

--- a/OpenRA.Game/Scripting/ScriptContext.cs
+++ b/OpenRA.Game/Scripting/ScriptContext.cs
@@ -176,10 +176,8 @@ namespace OpenRA.Scripting
 			};
 
 			foreach (var fieldName in runtime.Globals.Keys)
-			{
 				if (!allowedGlobals.Contains(fieldName.ToString()))
 					runtime.Globals[fieldName] = null;
-			}
 
 			var forbiddenMath = new string[]
 			{
@@ -189,10 +187,8 @@ namespace OpenRA.Scripting
 
 			var mathGlobal = (LuaTable)runtime.Globals["math"];
 			foreach (var mathFunction in mathGlobal.Keys)
-			{
 				if (forbiddenMath.Contains(mathFunction.ToString()))
 					mathGlobal[mathFunction] = null;
-			}
 
 			// Register globals
 			runtime.Globals["EngineDir"] = Platform.EngineDir;
@@ -237,7 +233,7 @@ namespace OpenRA.Scripting
 				return;
 			}
 
-			tick = (LuaFunction)runtime.Globals["Tick"];
+			tick = runtime.Globals["Tick"] as LuaFunction;
 		}
 
 		void LogDebugMessage(string message)
@@ -304,7 +300,7 @@ namespace OpenRA.Scripting
 
 		public void Tick()
 		{
-			if (FatalErrorOccurred || disposed)
+			if (FatalErrorOccurred || disposed || tick == null)
 				return;
 
 			try


### PR DESCRIPTION
Also fixes `ScriptContext` crashing without a `WorldLoaded` function.

Closes #20879.