### PR TITLE
RA naval balance May 2023

### DIFF
--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -39,7 +39,7 @@ SS:
 		ValidTargets: WaterActor, Underwater
 	DetectCloaked:
 		DetectionTypes: Underwater
-		Range: 4c0
+		Range: 5c0
 	RenderDetectionCircle:
 	Explodes:
 		Weapon: UnitExplodeSubmarine

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -156,9 +156,8 @@ TurretGun:
 	Range: 5c512
 	Report: cannon2.aud
 	InvalidTargets: Underwater
-	Projectile: Bullet
-		Speed: 426
 	Warhead@1Dam: SpreadDamage
+		Spread: 256
 		Damage: 2500
 		Versus:
 			None: 28

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -191,7 +191,7 @@ Stinger:
 		Versus:
 			None: 36
 			Wood: 88
-			Light: 88
+			Light: 66
 			Heavy: 120
 			Concrete: 60
 
@@ -277,9 +277,9 @@ TorpTube:
 		Damage: 2500
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
-			None: 40
+			None: 80
 			Wood: 50
-			Light: 30
+			Light: 48
 			Heavy: 30
 			Concrete: 100
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
@@ -296,7 +296,7 @@ SubMissile:
 	TargetActorCenter: true
 	-Projectile:
 	Projectile: Bullet
-		Speed: 162
+		Speed: 215
 		Blockable: false
 		LaunchAngle: 120
 		Inaccuracy: 0c614
@@ -311,6 +311,8 @@ SubMissileAA:
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: AirborneActor
 		Damage: 1500
+		Versus:
+			Light: 30
 
 SCUD:
 	Inherits: ^AntiGroundMissile


### PR DESCRIPTION
Myself and @BlackenedRA are slowly working on a naval balance patch. I've decided that it would be a good idea to merge the safe and non-experimental changes into the next release. While these values aren't set in stone, I am fairly confident with them.

---

### Gunboat  2Inch
* Spread 256 (from 128)
* Projectile Speed 682 (from 426)

Gunboats currently are mostly a waste of resources. Their only redeeming quality is the ability with good micro to win versus a submarine in a honourable 1 on 1. These buffs doesn't fully address the issue, I didn't want to make this patch allied favoured when allies are already favoured for naval play. This just addresses the inability of gunboats to hit moving targets, often doing 0 damage. The Spread damage buff feeds into that idea and also slightly buffs them vs infantry.

---

### Missile Submarine Anti-ground
* Projectile Speed 215 (from 162)
* Versus none 80% (from 40%)
* Versus light 48% (from 30%)

Damage versus infantry and light vehicles is lower than one would expect when comparing to other artillery-like units. These buffs make submarines able to kill infantry rather than bruising them. Though it will still not be as great as anti-infantry option as other artillery options.

Projectile speed was increased was increase to make aiming easier. This better matches the speed of other artillery units.

---

###  Destroyer
* Versus light 66% (from 88%)

Destroyer is currently the best naval unit in the game, one could argue, the only one worth building in maps that don't force naval play. While this patch doesn't completely address the destroyer, the combined buffs to other units and the nerf to its absolutely insane damage vs aircraft should help mitigate the issues.

---

### Submarine
* Cloak detection 5 cells (from 4)

Submarine is left for last. This is a simple quality of life / micro change. It should allow for more engaging submarine on submarine battles.

