### PR TITLE
Normalise anti-air weapon values

### DIFF
--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -110,8 +110,9 @@ OrcaAAMissiles:
 		Speed: 341
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: Air
+		Damage: 2100
 		Versus:
-			Light: 84
+			Light: 100
 	-Warhead@2Smu:
 
 MammothMissiles:
@@ -273,8 +274,9 @@ TowerAAMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 682
 		ValidTargets: Air
+		Damage: 3500
 		Versus:
-			Light: 140
+			Light: 100
 	-Warhead@2Smu:
 	Warhead@4EffAir: CreateEffect
 		Explosions: small_building
@@ -297,11 +299,7 @@ Patriot:
 		Damage: 5000
 		ValidTargets: Air
 		Versus:
-			None: 20
-			Wood: 84
 			Light: 100
-			Heavy: 74
-			Concrete: 74
 	-Warhead@2Smu:
 	Warhead@4EffAir: CreateEffect
 		Explosions: poof

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -85,8 +85,9 @@ HeliAAGun:
 	ValidTargets: Air
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: Air
+		Damage: 1100
 		Versus:
-			Light: 55
+			Light: 100
 
 ^LightMG:
 	Inherits: ^HeavyMG
@@ -180,7 +181,8 @@ APCGun.AA:
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: Air
+		Damage: 1250
 		Versus:
-			Light: 125
+			Light: 100
 	Warhead@2Eff: CreateEffect
 		Explosions: small_poof

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -201,10 +201,10 @@ DepthCharge:
 		Inaccuracy: 128
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 8000
+		Damage: 6000
 		ValidTargets: Submarine
 		Versus:
-			Light: 75
+			Light: 100
 		DamageTypes: ExplosionDeath
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -43,6 +43,8 @@
 	ValidTargets: AirborneActor
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: AirborneActor
+		Versus:
+			Light: 100
 	Warhead@3Eff: CreateEffect
 		ImpactActors: false
 
@@ -105,10 +107,7 @@ HellfireAA:
 		RangeLimit: 7c0
 		CloseEnough: 0c600
 	Warhead@1Dam: SpreadDamage
-		Damage: 4000
-		Versus:
-			Wood: 75
-			Light: 75
+		Damage: 3000
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion_air
 
@@ -153,9 +152,7 @@ Nike:
 		RangeLimit: 11c0
 		Speed: 341
 	Warhead@1Dam: SpreadDamage
-		Damage: 5000
-		Versus:
-			Light: 90
+		Damage: 4500
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion_air
 		ImpactSounds: kaboom25.aud
@@ -168,9 +165,7 @@ RedEye:
 		HorizontalRateOfTurn: 80
 		Speed: 298
 	Warhead@1Dam: SpreadDamage
-		Damage: 4000
-		Versus:
-			Light: 60
+		Damage: 2400
 
 Stinger:
 	Inherits: ^AntiGroundMissile
@@ -203,6 +198,9 @@ StingerAA:
 		CloseEnough: 298
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: AirborneActor
+		Damage: 1650
+		Versus:
+			Light: 100
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion_air
 		ImpactSounds: kaboom25.aud
@@ -310,9 +308,9 @@ SubMissileAA:
 	ValidTargets: AirborneActor
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: AirborneActor
-		Damage: 1500
+		Damage: 450
 		Versus:
-			Light: 30
+			Light: 100
 
 SCUD:
 	Inherits: ^AntiGroundMissile

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -6,14 +6,8 @@
 	Projectile: InstantHit
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 2000
+		Damage: 900
 		ValidTargets: AirborneActor
-		Versus:
-			None: 40
-			Wood: 10
-			Light: 60
-			Heavy: 10
-			Concrete: 20
 		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: small_explosion_air
@@ -25,19 +19,11 @@ ZSU-23:
 	BurstDelays: 0
 	ReloadDelay: 6
 	Range: 10c0
-	Warhead@1Dam: SpreadDamage
-		Damage: 1200
-		Versus:
-			None: 25
-			Wood: 75
-			Light: 75
-			Heavy: 100
-			Concrete: 50
 
 FLAK-23-AA:
 	Inherits: ^AACannon
 	Warhead@1Dam: SpreadDamage
-		ValidTargets: AirborneActor, GroundActor, WaterActor
+		Damage: 1200
 
 FLAK-23-AG:
 	Inherits: ^AACannon
@@ -46,7 +32,14 @@ FLAK-23-AG:
 	Projectile: InstantHit
 		Blockable: true
 	Warhead@1Dam: SpreadDamage
+		Damage: 2000
 		ValidTargets: AirborneActor, GroundActor, WaterActor
+		Versus:
+			None: 40
+			Wood: 10
+			Light: 60
+			Heavy: 10
+			Concrete: 20
 	Warhead@2Eff: CreateEffect
 		Explosions: flak_explosion_ground
 		ValidTargets: Ground, GroundActor, Air, AirborneActor, WaterActor, Trees


### PR DESCRIPTION
When a weapon only targets a single armour type, that armour type should be at 100% percent. This makes it much easier to know how much damage exactly it will do. When making balance changes this has always bothered me.

I've also removed some redundant modifiers.