### PR TITLE
Fixed benchmark CSV export using inconsistent formatting

### DIFF
--- a/OpenRA.Game/Support/Benchmark.cs
+++ b/OpenRA.Game/Support/Benchmark.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace OpenRA.Support
 {
@@ -50,7 +51,7 @@ namespace OpenRA.Support
 				Log.Write(name, "tick,time [ms]");
 
 				foreach (var point in sample.Value)
-					Log.Write(name, $"{point.Tick},{point.Value}");
+					Log.Write(name, $"{point.Tick},{point.Value.ToString(CultureInfo.InvariantCulture)}");
 			}
 		}
 


### PR DESCRIPTION
The file is comma separated. However, in Germany the decimal separator is too, which gave me
```csv
tick,time [ms]
1,0
2,174,166101
3,42,039462
4,7,129702
```

this fixes it to:

```csv
tick,time [ms]
1,0
2,174.166101
3,42.039462
4,7.129702
```