### PR TITLE
ActorMap, do not look up influence node up to three times in cell layer.

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -298,14 +298,15 @@ namespace OpenRA.Mods.Common.Traits
 			if (!layer.Contains(uv))
 				return preferredSubCell != SubCell.Any ? preferredSubCell : SubCell.First;
 
-			if (preferredSubCell != SubCell.Any && !AnyActorsAt(uv, cell, layer, preferredSubCell, checkTransient))
+			var influenceNode = layer[uv];
+			if (preferredSubCell != SubCell.Any && !AnyActorsAt(influenceNode, cell, preferredSubCell, checkTransient))
 				return preferredSubCell;
 
-			if (!AnyActorsAt(uv, layer))
+			if (influenceNode == null)
 				return map.Grid.DefaultSubCell;
 
 			for (var i = (int)SubCell.First; i < map.Grid.SubCellOffsets.Length; i++)
-				if (i != (int)preferredSubCell && !AnyActorsAt(uv, cell, layer, (SubCell)i, checkTransient))
+				if (i != (int)preferredSubCell && !AnyActorsAt(influenceNode, cell, (SubCell)i, checkTransient))
 					return (SubCell)i;
 
 			return SubCell.Invalid;
@@ -318,23 +319,18 @@ namespace OpenRA.Mods.Common.Traits
 			if (!layer.Contains(uv))
 				return preferredSubCell != SubCell.Any ? preferredSubCell : SubCell.First;
 
-			if (preferredSubCell != SubCell.Any && !AnyActorsAt(uv, layer, preferredSubCell, checkIfBlocker))
+			var influenceNode = layer[uv];
+			if (preferredSubCell != SubCell.Any && !AnyActorsAt(influenceNode, preferredSubCell, checkIfBlocker))
 				return preferredSubCell;
 
-			if (!AnyActorsAt(uv, layer))
+			if (influenceNode == null)
 				return map.Grid.DefaultSubCell;
 
 			for (var i = (byte)SubCell.First; i < map.Grid.SubCellOffsets.Length; i++)
-				if (i != (byte)preferredSubCell && !AnyActorsAt(uv, layer, (SubCell)i, checkIfBlocker))
+				if (i != (byte)preferredSubCell && !AnyActorsAt(influenceNode, (SubCell)i, checkIfBlocker))
 					return (SubCell)i;
 
 			return SubCell.Invalid;
-		}
-
-		// NOTE: pos required to be in map bounds
-		bool AnyActorsAt(MPos uv, CellLayer<InfluenceNode> layer)
-		{
-			return layer[uv] != null;
 		}
 
 		// NOTE: always includes transients with influence
@@ -345,14 +341,14 @@ namespace OpenRA.Mods.Common.Traits
 			if (!layer.Contains(uv))
 				return false;
 
-			return AnyActorsAt(uv, layer);
+			return layer[uv] != null;
 		}
 
 		// NOTE: pos required to be in map bounds
-		bool AnyActorsAt(MPos uv, CPos a, CellLayer<InfluenceNode> layer, SubCell sub, bool checkTransient)
+		bool AnyActorsAt(InfluenceNode influenceNode, CPos a, SubCell sub, bool checkTransient)
 		{
 			var always = sub == SubCell.FullCell || sub == SubCell.Any;
-			for (var i = layer[uv]; i != null; i = i.Next)
+			for (var i = influenceNode; i != null; i = i.Next)
 			{
 				if (always || i.SubCell == sub || i.SubCell == SubCell.FullCell)
 				{
@@ -376,14 +372,15 @@ namespace OpenRA.Mods.Common.Traits
 			if (!layer.Contains(uv))
 				return false;
 
-			return AnyActorsAt(uv, a, layer, sub, checkTransient);
+			return AnyActorsAt(layer[uv], a, sub, checkTransient);
 		}
 
 		// NOTE: can not check aircraft
-		bool AnyActorsAt(MPos uv, CellLayer<InfluenceNode> layer, SubCell sub, Func<Actor, bool> withCondition)
+		bool AnyActorsAt(InfluenceNode influenceNode, SubCell sub, Func<Actor, bool> withCondition)
 		{
 			var always = sub == SubCell.FullCell || sub == SubCell.Any;
-			for (var i = layer[uv]; i != null; i = i.Next)
+
+			for (var i = influenceNode; i != null; i = i.Next)
 				if ((always || i.SubCell == sub || i.SubCell == SubCell.FullCell) && withCondition(i.Actor))
 					return true;
 
@@ -398,7 +395,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!layer.Contains(uv))
 				return false;
 
-			return AnyActorsAt(uv, layer, sub, withCondition);
+			return AnyActorsAt(layer[uv], sub, withCondition);
 		}
 
 		public IEnumerable<Actor> AllActors()


### PR DESCRIPTION

partial successor of #20351, which will be closed. 


- in find free cell, avoid potential 3 times lookup of influence node in influence cell layer, by pasing the head influence node directly.

- do no call function recursively to remove element from list. avoid cell layer cell update if head element did not change.