### PR TITLE
ActorMap, avoid IPositionable trait lookup.

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
+++ b/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
@@ -107,7 +107,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		protected override void Created(Actor self)
 		{
-			iPositionable = self.TraitOrDefault<IPositionable>();
+			iPositionable = self.OccupiesSpace as IPositionable;
 			base.Created(self);
 		}
 

--- a/OpenRA.Mods.Common/Activities/Parachute.cs
+++ b/OpenRA.Mods.Common/Activities/Parachute.cs
@@ -23,8 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Parachute(Actor self)
 		{
-			pos = self.TraitOrDefault<IPositionable>();
-
+			pos = self.OccupiesSpace as IPositionable;
 			fallVector = new WVec(0, 0, self.Info.TraitInfo<ParachutableInfo>().FallRate);
 			IsInterruptible = false;
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.Common.Traits
 		protected override void Created(Actor self)
 		{
 			facing = self.TraitOrDefault<IFacing>();
-			positionable = self.TraitOrDefault<IPositionable>();
+			positionable = self.OccupiesSpace as IPositionable;
 			notifyAiming = self.TraitsImplementing<INotifyAiming>().ToArray();
 
 			getArmaments = InitializeGetArmaments(self);

--- a/OpenRA.Mods.Common/Traits/Crates/DuplicateUnitCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/DuplicateUnitCrateAction.cs
@@ -65,8 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!info.ValidTargets.Overlaps(collector.GetEnabledTargetTypes()))
 				return false;
 
-			var positionable = collector.TraitOrDefault<IPositionable>();
-			if (positionable == null)
+			if (collector.OccupiesSpace is not IPositionable positionable)
 				return false;
 
 			return collector.World.Map.FindTilesInCircle(collector.Location, info.MaxRadius)
@@ -83,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override void Activate(Actor collector)
 		{
-			var positionable = collector.Trait<IPositionable>();
+			var positionable = collector.OccupiesSpace as IPositionable;
 			var candidateCells = collector.World.Map.FindTilesInCircle(collector.Location, info.MaxRadius)
 				.Where(c => positionable.CanEnterCell(c)).Shuffle(collector.World.SharedRandom)
 				.ToArray();

--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -359,8 +359,8 @@ namespace OpenRA.Mods.Common.Traits
 					if (checkTransient)
 						return true;
 
-					var pos = i.Actor.TraitOrDefault<IPositionable>();
-					if (pos == null || !pos.IsLeavingCell(a, i.SubCell))
+					// PERF: Avoid trait lookup
+					if (i.Actor.OccupiesSpace is not IPositionable pos || !pos.IsLeavingCell(a, i.SubCell))
 						return true;
 				}
 			}


### PR DESCRIPTION

partial successor of #20351, which will be closed.


avoid trait dictionary lookup of IPositionable - by rather try to cast Actor.OccupiesSpace.

lookup up the trait in the trait dictionary requires a binary search on the actor in a list of all actors. 
