### PR TITLE
WithDecoration: fixed crash when Palette is null

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		protected virtual PaletteReference GetPalette(Actor self, WorldRenderer wr)
 		{
-			return wr.Palette(Info.Palette + (Info.IsPlayerPalette ? self.Owner.InternalName : ""));
+			return wr.Palette(Info.IsPlayerPalette ? Info.Palette + self.Owner.InternalName : Info.Palette);
 		}
 
 		protected override IEnumerable<IRenderable> RenderDecoration(Actor self, WorldRenderer wr, int2 screenPos)


### PR DESCRIPTION
In current code, when `Palette` is null, `WorldRenderer.Palette` is invoked with empty string and in conjunction with how palettes are retrieved in `HardwarePalette`:

```csharp
public IPalette GetPalette(string name)
{
	if (mutablePalettes.TryGetValue(name, out var mutable))
		return mutable.AsReadOnly();
	if (palettes.TryGetValue(name, out var immutable))
		return immutable;
	throw new InvalidOperationException($"Palette `{name}` does not exist");
}
```

results in crash. This PR changes how the palette name is constructed so that with `Palette == null` it doesn't result in empty string.
