### PR TITLE
WorldRenderer: use string.IsNullOrEmpty for check in Palette method

### DIFF
--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Graphics
 		{
 			// HACK: This is working around the fact that palettes are defined on traits rather than sequences
 			// and can be removed once this has been fixed.
-			return name == null ? null : palettes.GetOrAdd(name, createPaletteReference);
+			return string.IsNullOrEmpty(name) ? null : palettes.GetOrAdd(name, createPaletteReference);
 		}
 
 		public void AddPalette(string name, ImmutablePalette pal, bool allowModifiers = false, bool allowOverwrite = false)

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -161,7 +161,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (Cloaked && IsVisible(self, self.World.RenderPlayer))
 			{
-				var palette = string.IsNullOrEmpty(Info.Palette) ? null : Info.IsPlayerPalette ? wr.Palette(Info.Palette + self.Owner.InternalName) : wr.Palette(Info.Palette);
+				var palette = wr.Palette(Info.IsPlayerPalette ? Info.Palette + self.Owner.InternalName : Info.Palette);
+
 				if (palette == null)
 					return r;
 				else

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingRepairDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingRepairDecoration.cs
@@ -47,10 +47,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		protected override PaletteReference GetPalette(Actor self, WorldRenderer wr)
 		{
-			if (!info.IsPlayerPalette)
-				return wr.Palette(info.Palette);
-
-			return wr.Palette(info.Palette + rb.Repairers[shownPlayer % rb.Repairers.Count].InternalName);
+			return wr.Palette(info.IsPlayerPalette ? info.Palette + rb.Repairers[shownPlayer % rb.Repairers.Count].InternalName : info.Palette);
 		}
 
 		void CycleRepairer()

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -51,10 +51,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				yield break;
 
 			if (Palette != null)
-			{
-				var ownerName = init.Get<OwnerInit>().InternalName;
-				p = init.WorldRenderer.Palette(IsPlayerPalette ? Palette + ownerName : Palette);
-			}
+				p = init.WorldRenderer.Palette(IsPlayerPalette ? Palette + init.Get<OwnerInit>().InternalName : Palette);
 
 			Func<WAngle> facing;
 			var dynamicfacingInit = init.GetOrDefault<DynamicFacingInit>();


### PR DESCRIPTION
Also unified usage of `WorldRenderer.Palette` method when it comes to appending player name (in case of player palette).