### PR TITLE
Only consider non-paused armaments (if any exist) when determining max range for attack

### DIFF
--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -191,9 +191,19 @@ namespace OpenRA.Mods.Common.Activities
 			if (armaments.Count == 0)
 				return AttackStatus.UnableToAttack;
 
-			// Update ranges
-			minRange = armaments.Max(a => a.Weapon.MinRange);
-			maxRange = armaments.Min(a => a.MaxRange());
+			// Update ranges. Exclude paused armaments except when ALL weapons are paused
+			// (e.g. out of ammo), in which case use the paused, valid weapon with highest range.
+			var activeArmaments = armaments.Where(x => !x.IsTraitPaused);
+			if (activeArmaments.Any())
+			{
+				minRange = activeArmaments.Max(a => a.Weapon.MinRange);
+				maxRange = activeArmaments.Min(a => a.MaxRange());
+			}
+			else
+			{
+				minRange = WDist.Zero;
+				maxRange = armaments.Max(a => a.MaxRange());
+			}
 
 			var pos = self.CenterPosition;
 			if (!target.IsInRange(pos, maxRange)


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/issues/20901

AttackBase has this:

```cs
// Use valid armament with highest range out of those that have ammo
// If all are out of ammo, just use valid armament with highest range
armaments = armaments.OrderByDescending(x => x.MaxRange());
var a = armaments.FirstOrDefault(x => !x.IsTraitPaused);
if (a == null)
	a = armaments.First();
```

Whereas in the Attack activity paused armaments are still considered when calculating the max range, which means, if a paused armament has less range than the active armaments, the unit will stop when reaching the real max range, but not shoot because the Attack activity is using the max range of a paused armament.