### PR TITLE
Update referenced NuGet packages

### DIFF
--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Linguini.Bundle" Version="0.4.0" />
-    <PackageReference Include="OpenRA-Eluant" Version="1.0.20" />
+    <PackageReference Include="OpenRA-Eluant" Version="1.0.21" />
     <PackageReference Include="Mono.NAT" Version="3.0.4" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -7,10 +7,10 @@
     <PackageReference Include="OpenRA-FuzzyLogicLibrary" Version="1.0.1" />
     <PackageReference Include="DiscordRichPresence" Version="1.1.3.18" />
     <PackageReference Include="MP3Sharp" Version="1.0.5" />
-    <PackageReference Include="NVorbis" Version="0.10.4" />
-    <PackageReference Include="TagLibSharp" Version="2.2.0" />
+    <PackageReference Include="NVorbis" Version="0.10.5" />
+    <PackageReference Include="TagLibSharp" Version="2.3.0" />
     <PackageReference Include="rix0rrr.BeaconLib" Version="1.0.2" />
-    <PackageReference Include="Pfim" Version="0.10.3" />
+    <PackageReference Include="Pfim" Version="0.11.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>

--- a/OpenRA.Platforms.Default/OpenRA.Platforms.Default.csproj
+++ b/OpenRA.Platforms.Default/OpenRA.Platforms.Default.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj" />
-    <PackageReference Include="OpenRA-Freetype6" Version="1.0.9" />
-    <PackageReference Include="OpenRA-OpenAL-CS" Version="1.0.19" />
-    <PackageReference Include="OpenRA-SDL2-CS" Version="1.0.37" />
+    <PackageReference Include="OpenRA-Freetype6" Version="1.0.11" />
+    <PackageReference Include="OpenRA-OpenAL-CS" Version="1.0.21" />
+    <PackageReference Include="OpenRA-SDL2-CS" Version="1.0.39" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="OpenRA.Platforms.Default.dll.config" Condition="'$(TargetPlatform)' != 'win-x64' And '$(TargetPlatform)' != 'win-x86'">

--- a/OpenRA.Test/OpenRA.Test.csproj
+++ b/OpenRA.Test/OpenRA.Test.csproj
@@ -8,9 +8,9 @@
     <ProjectReference Include="..\OpenRA.Mods.Common\OpenRA.Mods.Common.csproj">
       <Private>True</Private>
     </ProjectReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit.Console" Version="3.13.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit.Console" Version="3.16.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/OpenRA.WindowsLauncher/OpenRA.WindowsLauncher.csproj
+++ b/OpenRA.WindowsLauncher/OpenRA.WindowsLauncher.csproj
@@ -21,7 +21,7 @@
     </AssemblyAttribute>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="OpenRA-SDL2-CS" Version="1.0.37" />
+    <PackageReference Include="OpenRA-SDL2-CS" Version="1.0.39" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj" />

--- a/configure-system-libraries.sh
+++ b/configure-system-libraries.sh
@@ -65,12 +65,12 @@ if [ "$(uname -s)" = "Darwin" ]; then
 	fi
 	patch_config "Lua 5.1" "${SEARCHDIRS}" bin/Eluant.dll.config lua51.dylib liblua5.1.dylib
 	patch_config SDL2 "${SEARCHDIRS}" bin/SDL2-CS.dll.config SDL2.dylib libSDL2-2.0.0.dylib
-	patch_config OpenAL "${SEARCHDIRS}" bin/OpenAL-CS.Core.dll.config soft_oal.dylib libopenal.1.dylib
+	patch_config OpenAL "${SEARCHDIRS}" bin/OpenAL-CS.dll.config soft_oal.dylib libopenal.1.dylib
 	patch_config FreeType "${SEARCHDIRS}" bin/OpenRA.Platforms.Default.dll.config freetype6.dylib libfreetype.6.dylib
 else
 	SEARCHDIRS="/lib /lib64 /usr/lib /usr/lib64 /usr/lib/x86_64-linux-gnu /usr/lib/i386-linux-gnu /usr/lib/arm-linux-gnueabihf /usr/lib/aarch64-linux-gnu /usr/lib/powerpc64le-linux-gnu /usr/lib/mipsel-linux-gnu /usr/local/lib /opt/lib /opt/local/lib /app/lib"
 	patch_config "Lua 5.1" "${SEARCHDIRS}" bin/Eluant.dll.config lua51.so "liblua.so.5.1.5 liblua5.1.so.5.1 liblua5.1.so.0 liblua.so.5.1 liblua-5.1.so liblua5.1.so"
 	patch_config SDL2 "${SEARCHDIRS}" bin/SDL2-CS.dll.config SDL2.so "libSDL2-2.0.so.0 libSDL2-2.0.so libSDL2.so"
-	patch_config OpenAL "${SEARCHDIRS}" bin/OpenAL-CS.Core.dll.config soft_oal.so "libopenal.so.1 libopenal.so"
+	patch_config OpenAL "${SEARCHDIRS}" bin/OpenAL-CS.dll.config soft_oal.so "libopenal.so.1 libopenal.so"
 	patch_config FreeType "${SEARCHDIRS}" bin/OpenRA.Platforms.Default.dll.config freetype6.so "libfreetype.so.6 libfreetype.so"
 fi


### PR DESCRIPTION
Finally we can move on to using NuGet packages produced by
https://github.com/OpenRA/Eluant
https://github.com/OpenRA/FreeType
https://github.com/OpenRA/SDL2-CS
https://github.com/OpenRA/OpenAL-CS

As a side bonus I updated (almost) all other NuGets.

Testing should be done on:
- [X] Windows
- [x] Linux
  - [x] x64
    - [x] Mono
    - [x] .NET
  - [X] arm64
    - [X] Mono
    - [X] .NET
- [X] MacOS
  - [X] Mono
  - [X] .NET

and then probably on a dozen obscure and obsolete Linux distros just to be safe.
Also the `configure-native-libraries.sh` scripts will need to be tested with both Mono and .NET.