### PR TITLE
Update sysinfo data

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/SystemInfoPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SystemInfoPromptLogic.cs
@@ -30,8 +30,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{ "platform", ("OS Type", Platform.CurrentPlatform.ToString()) },
 				{ "os", ("OS Version", Platform.OperatingSystem) },
 				{ "arch", ("Architecture", Platform.CurrentArchitecture.ToString()) },
-				{ "x64", ("OS is 64 bit", Environment.Is64BitOperatingSystem.ToString()) },
-				{ "x64process", ("Process is 64 bit", Environment.Is64BitProcess.ToString()) },
 				{ "runtime", (".NET Runtime", Platform.RuntimeVersion) },
 				{ "gl", ("OpenGL Version", Game.Renderer.GLVersion) },
 				{ "windowsize", ("Window Size", $"{Game.Renderer.NativeResolution.Width}x{Game.Renderer.NativeResolution.Height}") },

--- a/OpenRA.Mods.Common/Widgets/Logic/SystemInfoPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SystemInfoPromptLogic.cs
@@ -20,17 +20,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class SystemInfoPromptLogic : ChromeLogic
 	{
 		// Increment the version number when adding new stats
-		const int SystemInformationVersion = 5;
+		const int SystemInformationVersion = 6;
 
 		static Dictionary<string, (string Label, string Value)> GetSystemInformation()
 		{
-			var lang = CultureInfo.InstalledUICulture.TwoLetterISOLanguageName;
-			return new Dictionary<string, (string, string)>()
+			return new Dictionary<string, (string, string)>
 			{
 				{ "id", ("Anonymous ID", Game.Settings.Debug.UUID) },
 				{ "platform", ("OS Type", Platform.CurrentPlatform.ToString()) },
+				{ "os", ("OS Version", Platform.OperatingSystem) },
 				{ "arch", ("Architecture", Platform.CurrentArchitecture.ToString()) },
-				{ "os", ("OS Version", Environment.OSVersion.ToString()) },
 				{ "x64", ("OS is 64 bit", Environment.Is64BitOperatingSystem.ToString()) },
 				{ "x64process", ("Process is 64 bit", Environment.Is64BitProcess.ToString()) },
 				{ "runtime", (".NET Runtime", Platform.RuntimeVersion) },
@@ -38,7 +37,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{ "windowsize", ("Window Size", $"{Game.Renderer.NativeResolution.Width}x{Game.Renderer.NativeResolution.Height}") },
 				{ "windowscale", ("Window Scale", Game.Renderer.NativeWindowScale.ToString("F2", CultureInfo.InvariantCulture)) },
 				{ "uiscale", ("UI Scale", Game.Settings.Graphics.UIScale.ToString("F2", CultureInfo.InvariantCulture)) },
-				{ "lang", ("System Language", lang) }
+				{ "lang", ("System Language", CultureInfo.InstalledUICulture.TwoLetterISOLanguageName) }
 			};
 		}
 


### PR DESCRIPTION
* Return more useful OS information on macOS and Linux (.NET 5 already fixed Windows).

  | Platform    | Old          | New      |
  | ----------- | ------------ | ---------|
  | macOS | Unix 13.4.0 | macOS 13.4 (22F66) |
  | Linux | Unix 6.2.0.20 | Ubuntu 23.04 (wayland) |
* Remove obsolete 64-bit support info (we're now well and truely committed to supporting it!)