### PR TITLE
Fix linter crashing when collections with ActorReference attributes are null

### DIFF
--- a/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
@@ -57,6 +57,9 @@ namespace OpenRA.Mods.Common.Lint
 			FieldInfo fieldInfo, IReadOnlyDictionary<string, ActorInfo> dict, ActorReferenceAttribute attribute)
 		{
 			var values = LintExts.GetFieldValues(traitInfo, fieldInfo, attribute.DictionaryReference);
+			if (values == null)
+				return;
+
 			foreach (var value in values)
 			{
 				if (value == null)

--- a/OpenRA.Mods.Common/Traits/SpawnActorsOnSell.cs
+++ b/OpenRA.Mods.Common/Traits/SpawnActorsOnSell.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Primitives;
@@ -29,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[ActorReference]
 		[Desc("Actors to spawn on sell. Be sure to use lowercase.")]
-		public readonly string[] GuaranteedActorTypes = null;
+		public readonly string[] GuaranteedActorTypes = Array.Empty<string>();
 
 		[Desc("Spawns actors only if the selling player's faction is in this list. " +
 			"Leave empty to allow all factions by default.")]
@@ -80,18 +81,18 @@ namespace OpenRA.Mods.Common.Traits
 			if (eligibleLocations.Count == 0)
 				return;
 
-			var guaranteedActorTypes = Info.GuaranteedActorTypes?.Select(a =>
+			if (Info.GuaranteedActorTypes.Length > 0)
 			{
-				var av = self.World.Map.Rules.Actors[a].TraitInfoOrDefault<ValuedInfo>();
-				return new
+				var guaranteedActorTypes = Info.GuaranteedActorTypes.Select(a =>
 				{
-					Name = a,
-					Cost = av?.Cost ?? 0
-				};
-			}).ToList();
+					var av = self.World.Map.Rules.Actors[a].TraitInfoOrDefault<ValuedInfo>();
+					return new
+					{
+						Name = a,
+						Cost = av?.Cost ?? 0
+					};
+				}).ToList();
 
-			if (guaranteedActorTypes != null)
-			{
 				while (eligibleLocations.Count > 0 && guaranteedActorTypes.Count > 0)
 				{
 					var at = guaranteedActorTypes.Random(self.World.SharedRandom);
@@ -107,10 +108,10 @@ namespace OpenRA.Mods.Common.Traits
 						new OwnerInit(self.Owner),
 					}));
 				}
-			}
 
-			if (eligibleLocations.Count == 0)
-				return;
+				if (eligibleLocations.Count == 0)
+					return;
+			}
 
 			var actorTypes = Info.ActorTypes.Select(a =>
 			{


### PR DESCRIPTION
Moved the fix from https://github.com/OpenRA/OpenRA/pull/20899#discussion_r1219669089

The current crash makes optional fields into not-optional. The linter crash is triggered when a trait is used without defining the "optional" field.

There are 2 ways to fix the issue, I included both of them in this PR

- Recommended to review with whitespace changes hidden


