### PR TITLE
Loading memory tweaks

### DIFF
--- a/OpenRA.Game/Primitives/TypeDictionary.cs
+++ b/OpenRA.Game/Primitives/TypeDictionary.cs
@@ -101,6 +101,7 @@ namespace OpenRA.Primitives
 
 		public void TrimExcess()
 		{
+			data.TrimExcess();
 			foreach (var objs in data.Values)
 				objs.TrimExcess();
 		}

--- a/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
+++ b/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
@@ -350,6 +350,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 				? (Func<CPos, int>)null
 				: c => cellsWithBlockingActor.Contains(c) ? PathGraph.PathCostForInvalidPath : 0;
 
+			var accessibleCells = new HashSet<CPos>(GridSize * GridSize);
 			for (byte gridLayer = 0; gridLayer < customMovementLayers.Length; gridLayer++)
 			{
 				if (gridLayer != 0 &&
@@ -358,7 +359,6 @@ namespace OpenRA.Mods.Common.Pathfinder
 					continue;
 
 				var grid = GetGrid(new CPos(gridX, gridY, gridLayer), mapBounds);
-				var accessibleCells = new HashSet<CPos>();
 				for (var y = gridY; y < grid.BottomRight.Y; y++)
 				{
 					for (var x = gridX; x < grid.BottomRight.X; x++)


### PR DESCRIPTION
Two minor changes to assist with memory usage identifed during profiling of loading performance.

----

In HierarchicalPathFinder.BuildGrid, presize and reuse accessible cell set.

Most cells are accessible, so presizing to the full size of the grid is sensible to avoid allocations to resize as it is filled up. The set can also be reused across all layers to avoid allocating it many times.

----

In TypeDictionary.TrimExcess, also TrimExcess on the internal data dictionary size.

As TypeDictionary instances tend to live a long time without edits after being initially populated, this will reduce their long term memory footprint.