### PR TITLE
DrawLineToTarget: make palette for rendering sprites customizable (and thus optional too)

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -35,6 +35,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Width (in pixels) of the queued end node markers.")]
 		public readonly int QueuedMarkerWidth = 2;
 
+		[PaletteReference]
+		[Desc("Palette used for rendering sprites.")]
+		public readonly string Palette = TileSet.TerrainPaletteInternalName;
+
 		public override object Create(ActorInitializer init) { return new DrawLineToTarget(this); }
 	}
 
@@ -82,9 +86,9 @@ namespace OpenRA.Mods.Common.Traits
 			return RenderAboveShroud(self, wr);
 		}
 
-		static IEnumerable<IRenderable> RenderAboveShroud(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
-			var pal = wr.Palette(TileSet.TerrainPaletteInternalName);
+			var pal = wr.Palette(info.Palette);
 			var a = self.CurrentActivity;
 			for (; a != null; a = a.NextActivity)
 				if (!a.IsCanceling)


### PR DESCRIPTION
Title is self-explanatory. This fix is useful for mods that use 32-bit assets (i.e. without palettes).