### PR TITLE
Include Linux DE in OS sysinfo string.

### DIFF
--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -85,11 +85,18 @@ namespace OpenRA
 			{
 				if (CurrentPlatform == PlatformType.Linux)
 				{
+					var desktopType = Environment.GetEnvironmentVariable("XDG_CURRENT_DESKTOP");
 					var sessionType = Environment.GetEnvironmentVariable("XDG_SESSION_TYPE");
-					if (!string.IsNullOrEmpty(sessionType))
-						sessionType = $" ({sessionType})";
+
+					string suffix;
+					if (!string.IsNullOrEmpty(desktopType) && !string.IsNullOrEmpty(sessionType))
+						suffix = $" ({desktopType};{sessionType})";
+					else if (!string.IsNullOrEmpty(desktopType))
+						suffix = $" ({desktopType})";
+					else if (!string.IsNullOrEmpty(sessionType))
+						suffix = $" ({sessionType})";
 					else
-						sessionType = "";
+						suffix = "";
 
 					try
 					{
@@ -103,14 +110,14 @@ namespace OpenRA
 						string line;
 						while ((line = p.StandardOutput.ReadLine()) != null)
 							if (line.StartsWith("Operating System: "))
-								return line[18..] + sessionType;
+								return line[18..] + suffix;
 					}
 					catch { }
 
 					if (File.Exists("/etc/os-release"))
 						foreach (var line in File.ReadLines("/etc/os-release"))
 							if (line.StartsWith("PRETTY_NAME="))
-								return line[13..^1] + sessionType;
+								return line[13..^1] + suffix;
 				}
 				else if (CurrentPlatform == PlatformType.OSX)
 				{


### PR DESCRIPTION
This PR adds the current desktop environment alongside the OS and display server on Linux. This can inform discussions about whether / how much effort to put into supporting a given DE is worthwhile.

<img width="334" alt="Screenshot 2023-06-12 at 17 25 03" src="https://github.com/OpenRA/OpenRA/assets/167819/0e8fb1b9-ec8a-41a1-84e0-b8e3ac0a47ba">


From the [Arch wiki](https://wiki.archlinux.org/title/Environment_variables#Examples):
> XDG_CURRENT_DESKTOP is a [freedesktop.org](https://wiki.archlinux.org/title/Freedesktop.org) variable containing a colon separated list of strings that the current [desktop environment](https://wiki.archlinux.org/title/Desktop_environment) identifies as [[3]](https://specifications.freedesktop.org/mime-apps-spec/1.0.1/ar01s02.html). Standardized values for actively developed environments are GNOME, GNOME-Flashback, KDE, LXDE, LXQt, MATE, TDE, Unity, XFCE, EDE, Cinnamon, Pantheon, and DDE [[4]](https://specifications.freedesktop.org/menu-spec/latest/apb.html).


