### PR TITLE
Implement proper trimming in asset browser sources dropdown.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (sourceDropdown != null)
 			{
 				sourceDropdown.OnMouseDown = _ => ShowSourceDropdown(sourceDropdown);
-				var sourceName = new CachedTransform<IReadOnlyPackage, string>(GetSourceDisplayName);
+				var sourceName = new CachedTransform<IReadOnlyPackage, string>(source => GetSourceDisplayName(source, sourceDropdown));
 				sourceDropdown.GetText = () => sourceName.Update(assetSource);
 			}
 
@@ -591,7 +591,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		bool ShowSourceDropdown(DropDownButtonWidget dropdown)
 		{
-			var sourceName = new CachedTransform<IReadOnlyPackage, string>(GetSourceDisplayName);
+			var sourceName = new CachedTransform<IReadOnlyPackage, string>(source => GetSourceDisplayName(source, dropdown));
 			ScrollItemWidget SetupItem(IReadOnlyPackage source, ScrollItemWidget itemTemplate)
 			{
 				var item = ScrollItemWidget.Setup(itemTemplate,
@@ -662,7 +662,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			return true;
 		}
 
-		string GetSourceDisplayName(IReadOnlyPackage source)
+		string GetSourceDisplayName(IReadOnlyPackage source, DropDownButtonWidget dropdown)
 		{
 			if (source == null)
 				return allPackages;
@@ -684,10 +684,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					name = "^" + name[Platform.SupportDir.Length..];
 			}
 
-			if (name.Length > 18)
-				name = "..." + name[^15..];
-
-			return name;
+			return WidgetUtils.TruncateText(name, dropdown.UsableWidth - dropdown.LeftMargin - dropdown.RightMargin, Game.Renderer.Fonts[dropdown.Font], false);
 		}
 
 		// Mute/UnMute code copied from MissionBrowserLogic.

--- a/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
@@ -269,7 +269,7 @@ namespace OpenRA.Mods.Common.Widgets
 			return text;
 		}
 
-		public static string TruncateText(string text, int width, SpriteFont font)
+		public static string TruncateText(string text, int width, SpriteFont font, bool truncateEnd = true)
 		{
 			var trimmedWidth = font.Measure(text).X;
 			if (trimmedWidth <= width)
@@ -278,16 +278,20 @@ namespace OpenRA.Mods.Common.Widgets
 			var trimmed = text;
 			while (trimmedWidth > width && trimmed.Length > 3)
 			{
-				trimmed = text[..(trimmed.Length - 4)] + "...";
+				if (truncateEnd)
+					trimmed = trimmed[..^4] + "...";
+				else
+					trimmed = "..." + trimmed[4..];
+
 				trimmedWidth = font.Measure(trimmed).X;
 			}
 
 			return trimmed;
 		}
 
-		public static void TruncateLabelToTooltip(LabelWithTooltipWidget label, string text)
+		public static void TruncateLabelToTooltip(LabelWithTooltipWidget label, string text, bool truncateEnd = true)
 		{
-			var truncatedText = TruncateText(text, label.Bounds.Width, Game.Renderer.Fonts[label.Font]);
+			var truncatedText = TruncateText(text, label.Bounds.Width, Game.Renderer.Fonts[label.Font], truncateEnd);
 
 			label.GetText = () => truncatedText;
 
@@ -297,9 +301,9 @@ namespace OpenRA.Mods.Common.Widgets
 				label.GetTooltipText = null;
 		}
 
-		public static void TruncateButtonToTooltip(ButtonWidget button, string text)
+		public static void TruncateButtonToTooltip(ButtonWidget button, string text, bool truncateEnd = true)
 		{
-			var truncatedText = TruncateText(text, button.Bounds.Width - button.LeftMargin - button.RightMargin, Game.Renderer.Fonts[button.Font]);
+			var truncatedText = TruncateText(text, button.Bounds.Width - button.LeftMargin - button.RightMargin, Game.Renderer.Fonts[button.Font], truncateEnd);
 
 			button.GetText = () => truncatedText;
 


### PR DESCRIPTION
When defining a custom asset browser layout with wider dropdown, the max length of a source is still hardcoded to 18. This simple change changes that, so the maximum length is automaticaly calculated.