### PR TITLE
Bump Linguini.Bundle to 0.5.0.

### DIFF
--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Linguini.Bundle" Version="0.4.0" />
+    <PackageReference Include="Linguini.Bundle" Version="0.5.0" />
     <PackageReference Include="OpenRA-Eluant" Version="1.0.21" />
     <PackageReference Include="Mono.NAT" Version="3.0.4" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />


### PR DESCRIPTION
This version contains performance improvements for the parser, improving the loading time of translations.

----

For the RA mod, reduces time spent in `ParseTranslations` during loading from 2.5% to 1.4%. See https://github.com/Ygg01/Linguini/pull/29 for changes.