### PR TITLE
Fix Linux display scaling

### DIFF
--- a/OpenRA.Platforms.Default/Sdl2Input.cs
+++ b/OpenRA.Platforms.Default/Sdl2Input.cs
@@ -42,17 +42,17 @@ namespace OpenRA.Platforms.Default
 
 		static int2 EventPosition(Sdl2PlatformWindow device, int x, int y)
 		{
-			// On Windows and Linux (X11) events are given in surface coordinates
+			// On Windows and Linux (X11), events are given in surface coordinates
 			// These must be scaled to our effective window coordinates
 			// Round fractional components up to avoid rounding small deltas to 0
-			if (Platform.CurrentPlatform != PlatformType.OSX && device.EffectiveWindowSize != device.SurfaceSize)
+			if (!device.UseDeviceIndependentPixels && device.EffectiveWindowSize != device.SurfaceSize)
 			{
 				var s = 1 / device.EffectiveWindowScale;
 				return new int2((int)(Math.Sign(x) / 2f + x * s), (int)(Math.Sign(x) / 2f + y * s));
 			}
 
-			// On macOS we must still account for the user-requested scale modifier
-			if (Platform.CurrentPlatform == PlatformType.OSX && device.EffectiveWindowScale != device.NativeWindowScale)
+			// Otherwise, we must still account for the user-requested scale modifier
+			if (device.UseDeviceIndependentPixels && device.EffectiveWindowScale != device.NativeWindowScale)
 			{
 				var s = device.NativeWindowScale / device.EffectiveWindowScale;
 				return new int2((int)(Math.Sign(x) / 2f + x * s), (int)(Math.Sign(x) / 2f + y * s));

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -302,6 +302,11 @@ namespace OpenRA.Platforms.Default
 				}
 				else if (windowMode == WindowMode.PseudoFullscreen)
 				{
+					// Gnome >= 44 does not consider SDL_WINDOW_FULLSCREEN_DESKTOP to be borderless!
+					// This must be called before SetWindowFullscreen for the workaround to function.
+					if (Platform.CurrentPlatform == PlatformType.Linux)
+						SDL.SDL_SetWindowBordered(Window, SDL.SDL_bool.SDL_FALSE);
+
 					SDL.SDL_SetWindowFullscreen(Window, (uint)SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN_DESKTOP);
 					SDL.SDL_SetHint(SDL.SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0");
 


### PR DESCRIPTION
Closes #20863 and improves scaling behaviour with `SDL_VIDEODRIVER=wayland`.

I find that the hardware cursors don't work properly under Wayland (graphical corruption on the main menu and inconsistent switching between cursor types ingame) but I suspect/hope that this is an SDL issue rather than OpenRA.