### PR TITLE
RA Naval balance June 2023

### DIFF
--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -18,7 +18,7 @@ SS:
 	Armor:
 		Type: Light
 	Mobile:
-		TurnSpeed: 16
+		TurnSpeed: 20
 		Speed: 78
 	RevealsShroud:
 		MinRange: 5c0
@@ -125,11 +125,11 @@ DD:
 		TurnSpeed: 28
 		Speed: 92
 	RevealsShroud:
-		MinRange: 5c0
-		Range: 6c0
+		MinRange: 4c0
+		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
-		Range: 5c0
+		Range: 4c0
 	Turreted:
 		TurnSpeed: 28
 		Offset: 469,0,128
@@ -279,11 +279,11 @@ PT:
 		TurnSpeed: 28
 		Speed: 142
 	RevealsShroud:
-		MinRange: 5c0
-		Range: 7c0
+		MinRange: 6c0
+		Range: 8c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
-		Range: 5c0
+		Range: 6c0
 	Turreted:
 		TurnSpeed: 28
 		Offset: 512,0,0

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -227,7 +227,7 @@ TorpTube:
 	Report: torpedo1.aud
 	ValidTargets: Water, WaterActor, Underwater, Bridge
 	Burst: 2
-	BurstDelays: 20
+	BurstDelays: 15
 	Projectile: Missile
 		Image: torpedo
 		Arm: 3


### PR DESCRIPTION
Follow up to #20884. This batch contains standalone and fairly safe changes

---

### Submarine
- BurstDelays 15 (from 20)
- Turn speed 20 (from 16)

Buffing the microability of submarines. It should make Soviet vs Soviet matchups more engaging, and it does help a bit vs allies.

---

### Gunboat
- Vision 8 cells (from 7)

### Destroyer
- Vision 5 cells (from 6)

Shuffling vision for more diversity. Pushing destroyer farther from an all-in-one unit, and gunboat more to a naval dominance / scout unit.