### PR TITLE
Make Bullet projectile extensible

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -134,14 +134,14 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("The alpha value [from 0 to 255] of color at the contrail end.")]
 		public readonly int ContrailEndColorAlpha = 0;
 
-		public IProjectile Create(ProjectileArgs args) { return new Bullet(this, args); }
+		public virtual IProjectile Create(ProjectileArgs args) { return new Bullet(this, args); }
 	}
 
 	public class Bullet : IProjectile, ISync
 	{
 		readonly BulletInfo info;
-		readonly ProjectileArgs args;
-		readonly Animation anim;
+		protected readonly ProjectileArgs Args;
+		protected readonly Animation Animation;
 		readonly WAngle facing;
 		readonly WAngle angle;
 		readonly WDist speed;
@@ -153,16 +153,18 @@ namespace OpenRA.Mods.Common.Projectiles
 		readonly ContrailRenderable contrail;
 
 		[Sync]
-		WPos pos, lastPos, target, source;
+		protected WPos pos, lastPos, target, source;
 
 		int length;
 		int ticks, smokeTicks;
 		int remainingBounces;
 
+		protected bool FlightLengthReached => ticks >= length;
+
 		public Bullet(BulletInfo info, ProjectileArgs args)
 		{
 			this.info = info;
-			this.args = args;
+			Args = args;
 			pos = args.Source;
 			source = args.Source;
 
@@ -193,8 +195,8 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			if (!string.IsNullOrEmpty(info.Image))
 			{
-				anim = new Animation(world, info.Image, new Func<WAngle>(GetEffectiveFacing));
-				anim.PlayRepeating(info.Sequences.Random(world.SharedRandom));
+				Animation = new Animation(world, info.Image, new Func<WAngle>(GetEffectiveFacing));
+				Animation.PlayRepeating(info.Sequences.Random(world.SharedRandom));
 			}
 
 			if (info.ContrailLength > 0)
@@ -230,21 +232,26 @@ namespace OpenRA.Mods.Common.Projectiles
 			return new WAngle(effective);
 		}
 
-		public void Tick(World world)
+		public virtual void Tick(World world)
 		{
-			anim?.Tick();
+			Animation?.Tick();
 
 			lastPos = pos;
 			pos = WPos.LerpQuadratic(source, target, angle, ticks, length);
 
 			if (ShouldExplode(world))
+			{
+				if (info.ContrailLength > 0)
+					world.AddFrameEndTask(w => w.Add(new ContrailFader(pos, contrail)));
+
 				Explode(world);
+			}
 		}
 
 		bool ShouldExplode(World world)
 		{
 			// Check for walls or other blocking obstacles
-			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, args.SourceActor.Owner, lastPos, pos, info.Width, out var blockedPos))
+			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, Args.SourceActor.Owner, lastPos, pos, info.Width, out var blockedPos))
 			{
 				pos = blockedPos;
 				return true;
@@ -274,7 +281,7 @@ namespace OpenRA.Mods.Common.Projectiles
 				if (info.InvalidBounceTerrain.Contains(world.Map.GetTerrainInfo(cell).Type))
 					return true;
 
-				if (AnyValidTargetsInRadius(world, pos, info.Width, args.SourceActor, true))
+				if (AnyValidTargetsInRadius(world, pos, info.Width, Args.SourceActor, true))
 					return true;
 
 				target += (pos - source) * info.BounceRangeModifier / 100;
@@ -297,26 +304,35 @@ namespace OpenRA.Mods.Common.Projectiles
 				return true;
 
 			// After first bounce, check for targets each tick
-			if (remainingBounces < info.BounceCount && AnyValidTargetsInRadius(world, pos, info.Width, args.SourceActor, true))
+			if (remainingBounces < info.BounceCount && AnyValidTargetsInRadius(world, pos, info.Width, Args.SourceActor, true))
 				return true;
 
 			return false;
 		}
 
-		public IEnumerable<IRenderable> Render(WorldRenderer wr)
+		public virtual IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
 			if (info.ContrailLength > 0)
 				yield return contrail;
 
-			if (anim == null || ticks >= length)
+			if (FlightLengthReached)
 				yield break;
 
-			var world = args.SourceActor.World;
+			foreach (var r in RenderAnimation(wr))
+				yield return r;
+		}
+
+		protected IEnumerable<IRenderable> RenderAnimation(WorldRenderer wr)
+		{
+			if (Animation == null)
+				yield break;
+
+			var world = Args.SourceActor.World;
 			if (!world.FogObscures(pos))
 			{
 				var paletteName = info.Palette;
 				if (paletteName != null && info.IsPlayerPalette)
-					paletteName += args.SourceActor.Owner.InternalName;
+					paletteName += Args.SourceActor.Owner.InternalName;
 
 				var palette = wr.Palette(paletteName);
 
@@ -324,31 +340,28 @@ namespace OpenRA.Mods.Common.Projectiles
 				{
 					var dat = world.Map.DistanceAboveTerrain(pos);
 					var shadowPos = pos - new WVec(0, 0, dat.Length);
-					foreach (var r in anim.Render(shadowPos, palette))
+					foreach (var r in Animation.Render(shadowPos, palette))
 						yield return ((IModifyableRenderable)r)
 							.WithTint(shadowColor, ((IModifyableRenderable)r).TintModifiers | TintModifiers.ReplaceColor)
 							.WithAlpha(shadowAlpha);
 				}
 
-				foreach (var r in anim.Render(pos, palette))
+				foreach (var r in Animation.Render(pos, palette))
 					yield return r;
 			}
 		}
 
-		void Explode(World world)
+		protected virtual void Explode(World world)
 		{
-			if (info.ContrailLength > 0)
-				world.AddFrameEndTask(w => w.Add(new ContrailFader(pos, contrail)));
-
 			world.AddFrameEndTask(w => w.Remove(this));
 
-			var warheadArgs = new WarheadArgs(args)
+			var warheadArgs = new WarheadArgs(Args)
 			{
-				ImpactOrientation = new WRot(WAngle.Zero, Util.GetVerticalAngle(lastPos, pos), args.Facing),
+				ImpactOrientation = new WRot(WAngle.Zero, Util.GetVerticalAngle(lastPos, pos), Args.Facing),
 				ImpactPosition = pos,
 			};
 
-			args.Weapon.Impact(Target.FromPos(pos), warheadArgs);
+			Args.Weapon.Impact(Target.FromPos(pos), warheadArgs);
 		}
 
 		bool AnyValidTargetsInRadius(World world, WPos pos, WDist radius, Actor firedBy, bool checkTargetType)


### PR DESCRIPTION
This PR makes `Bullet` projectile extensible, so mods can adjust and modify its behavior.

Proposed changes would be used in OpenE2140 mod to implement debris flying out of spot, where original projectile (i.e. the one fired by actor's weapon), hits the target.

Draft implementation of new `FreezingBullet` projectile (based on the new, extensible `Bullet`) can be seen in this commit: https://github.com/michaeldgg2/OpenE2140/commit/5a37d20009509370cd657cf032b1c94e405833ab. This commit, however, contains only the use of this new projectile (not the entire implementation of the debris).

This is how the debris with `FreezingBullet` looks like. Heavy tank with three cannons shooting at the ground. Notice the small pieces of debris flying out of spots, where the bullets from the tank's cannons hit the ground.

![opene2140_freezingbullet](https://github.com/OpenRA/OpenRA/assets/119738087/f2835bc7-e74e-45d9-b362-ebdb14d0341b)

Current version of this feature in OpenE2140 uses `CreateEffect` warhead as can be seen here:

https://github.com/OpenE2140/OpenE2140/blob/master/mods/e2140/content/core/weapons/debris.yaml#L14

This implementation has however two bugs:
1) there's one tick delay before `CreateEffect` warhead kicks in and creates `SpriteEffect`
2) sometimes the appearance of `Bullet` and `SpriteEffect` created by `CreateEffectWarhead` doesn't match

First issue is visible only on low FPS. The second is caused by both `Bullet` *and* `CreateEffectWarhead` picking different random sequence for rendering.

![opene2140_debris_current](https://github.com/OpenRA/OpenRA/assets/119738087/beb9785b-6d38-458e-bbae-bd348d1e1b86)

Both issues cannot be worked around and require changes in OpenRA (unless `Bullet` and `CreateEffectWarhead` are reimplemented from scratch).
