### PR TITLE
Unhardcode reference to TileSet.TerrainPaletteInternalName in several traits

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -64,6 +64,10 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Ammo the minelayer consumes per mine.")]
 		public readonly int AmmoUsage = 1;
 
+		[PaletteReference]
+		[Desc("Palette used for rendering sprites.")]
+		public readonly string Palette = TileSet.TerrainPaletteInternalName;
+
 		public override object Create(ActorInitializer init) { return new Minelayer(init.Self, this); }
 	}
 
@@ -308,7 +312,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 				var movement = minelayer.Trait<IPositionable>();
 				var mobile = movement as Mobile;
-				var pal = wr.Palette(TileSet.TerrainPaletteInternalName);
+				var pal = wr.Palette(this.minelayer.Info.Palette);
 				foreach (var c in minefield)
 				{
 					var tile = validTile;

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -51,6 +51,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Types of damage that this bridge causes to units over/in path of it while being destroyed/repaired. Leave empty for no damage types.")]
 		public readonly BitSet<DamageType> DamageTypes = default;
 
+		[PaletteReference]
+		[Desc("Palette used for rendering sprites.")]
+		public readonly string Palette = TileSet.TerrainPaletteInternalName;
+
 		public override object Create(ActorInitializer init) { return new Bridge(init.Self, this); }
 
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
@@ -227,7 +231,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (!initialized)
 			{
-				var palette = wr.Palette(TileSet.TerrainPaletteInternalName);
+				var palette = wr.Palette(info.Palette);
 				renderables = new Dictionary<ushort, IRenderable[]>();
 				foreach (var t in info.Templates)
 					renderables.Add(t.Template, TemplateRenderables(wr, palette, t.Template));

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
@@ -56,6 +56,10 @@ namespace OpenRA.Mods.Common.Traits
 		[SequenceReference(nameof(FootprintImage))]
 		public readonly string FootprintSequence = "target-select";
 
+		[PaletteReference]
+		[Desc("Palette used for rendering sprites.")]
+		public readonly string Palette = TileSet.TerrainPaletteInternalName;
+
 		public override object Create(ActorInitializer init) { return new GrantExternalConditionPower(init.Self, this); }
 	}
 
@@ -168,7 +172,7 @@ namespace OpenRA.Mods.Common.Traits
 			protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world)
 			{
 				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
-				var pal = wr.Palette(TileSet.TerrainPaletteInternalName);
+				var pal = wr.Palette(power.info.Palette);
 
 				foreach (var t in power.CellsMatching(xy, footprint, dimensions))
 					yield return new SpriteRenderable(tile, wr.World.Map.CenterOfCell(t), WVec.Zero, -511, pal, 1f, alpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);


### PR DESCRIPTION
This PR fixes several remaining places, where hardcoded reference to `TileSet.TerrainPaletteInternalName` is used.