### PR TITLE
Minelaying: added extensibility points + move to Common

### DIFF
--- a/OpenRA.Mods.Common/Activities/LayMines.cs
+++ b/OpenRA.Mods.Common/Activities/LayMines.cs
@@ -12,13 +12,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
-using OpenRA.Mods.Cnc.Traits;
-using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.Cnc.Activities
+namespace OpenRA.Mods.Common.Activities
 {
 	// Assumes you have Minelayer on that unit
 	public class LayMines : Activity

--- a/OpenRA.Mods.Common/Activities/LayMines.cs
+++ b/OpenRA.Mods.Common/Activities/LayMines.cs
@@ -147,11 +147,20 @@ namespace OpenRA.Mods.Common.Activities
 				pool.TakeAmmo(self, minelayer.Info.AmmoUsage);
 			}
 
-			self.World.AddFrameEndTask(w => w.CreateActor(minelayer.Info.Mine, new TypeDictionary
+			foreach (var t in self.TraitsImplementing<INotifyMineLaying>())
+				t.MineLaying(self, self.Location);
+
+			self.World.AddFrameEndTask(w =>
 			{
-				new LocationInit(self.Location),
-				new OwnerInit(self.Owner),
-			}));
+				var mine = w.CreateActor(minelayer.Info.Mine, new TypeDictionary
+				{
+					new LocationInit(self.Location),
+					new OwnerInit(self.Owner),
+				});
+
+				foreach (var t in self.TraitsImplementing<INotifyMineLaying>())
+					t.MineLaid(self, mine);
+			});
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Mine.cs
+++ b/OpenRA.Mods.Common/Traits/Mine.cs
@@ -9,11 +9,10 @@
  */
 #endregion
 
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.Cnc.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	sealed class MineInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/Mine.cs
+++ b/OpenRA.Mods.Common/Traits/Mine.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	sealed class MineInfo : TraitInfo
+	public sealed class MineInfo : TraitInfo
 	{
 		public readonly BitSet<CrushClass> CrushClasses = default;
 		public readonly bool AvoidFriendly = true;
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Mine(this); }
 	}
 
-	sealed class Mine : ICrushable, INotifyCrushed
+	public sealed class Mine : ICrushable, INotifyCrushed
 	{
 		readonly MineInfo info;
 
@@ -69,6 +69,6 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[Desc("Tag trait for stuff that should not trigger mines.")]
-	sealed class MineImmuneInfo : TraitInfo<MineImmune> { }
-	sealed class MineImmune { }
+	public sealed class MineImmuneInfo : TraitInfo<MineImmune> { }
+	public sealed class MineImmune { }
 }

--- a/OpenRA.Mods.Common/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Common/Traits/Minelayer.cs
@@ -13,13 +13,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Mods.Cnc.Activities;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.Cnc.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	public class MinelayerInfo : TraitInfo, Requires<RearmableInfo>
 	{

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -159,6 +159,9 @@ namespace OpenRA.Mods.Common.Traits
 	public interface INotifyDelivery { void IncomingDelivery(Actor self); void Delivered(Actor self); }
 
 	[RequireExplicitImplementation]
+	public interface INotifyMineLaying { void MineLaying(Actor self, CPos location); void MineLaid(Actor self, Actor mine); }
+
+	[RequireExplicitImplementation]
 	public interface INotifyDockHost { void Docked(Actor self, Actor client); void Undocked(Actor self, Actor client); }
 	[RequireExplicitImplementation]
 	public interface INotifyDockClient { void Docked(Actor self, Actor host); void Undocked(Actor self, Actor host); }


### PR DESCRIPTION
This PR adds extensibility points to `LayMines` activity using two callbacks defined by `INotifyMineLaying` interface: 
- `MineLaying` (just before laying a mine)
- `MineLaid` after mine actor has been created (in `FrameEndTask`)

Plus the PR moves Minelaying-related classes to `OpenRA.Mods.Common` and makes `Mine`-related classes public.