### PR TITLE
Fix combined sequences using frames being broken

### DIFF
--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -423,7 +423,7 @@ namespace OpenRA.Mods.Common.Graphics
 					var subOffset = LoadField(Offset, subData, NoData);
 					var subFlipX = LoadField(FlipX, subData, NoData);
 					var subFlipY = LoadField(FlipY, subData, NoData);
-					var subFrames = LoadField(Frames, data);
+					var subFrames = LoadField(Frames, subData);
 
 					foreach (var f in ParseCombineFilenames(modData, tileset, subFrames, subData))
 					{


### PR DESCRIPTION
Testcase is Tanya in RA. On bleed her firing animation is completely broken, with this it displays like before again.
The code fix should speak for itself, `Frames` for combined sequences weren't read from the node itself but its parent.