### PR TITLE
Improve loading performance for loader/compression classes.

### DIFF
--- a/OpenRA.Mods.Cnc/Graphics/VoxelLoader.cs
+++ b/OpenRA.Mods.Cnc/Graphics/VoxelLoader.cs
@@ -108,10 +108,10 @@ namespace OpenRA.Mods.Cnc.Graphics
 					return null;
 
 				var v = l.VoxelMap[(byte)x, (byte)y];
-				if (v == null || !v.ContainsKey((byte)z))
+				if (v == null || !v.TryGetValue((byte)z, out var element))
 					return null;
 
-				return l.VoxelMap[(byte)x, (byte)y][(byte)z];
+				return element;
 			}
 
 			// Cull slices without any visible faces

--- a/OpenRA.Mods.Cnc/SpriteLoaders/TmpTSLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/TmpTSLoader.cs
@@ -120,8 +120,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			for (var j = 0; j < size.Height; j++)
 			{
 				var start = (j - frameBounds.Y) * frameBounds.Width + (size.Width - width) / 2 - frameBounds.X;
-				for (var i = 0; i < width; i++)
-					data[start + i] = s.ReadUInt8();
+				s.ReadBytes(data, start, width);
 
 				width += (j < size.Height / 2 - 1 ? 1 : -1) * 4;
 			}

--- a/OpenRA.Mods.Common/FileFormats/RLEZerosCompression.cs
+++ b/OpenRA.Mods.Common/FileFormats/RLEZerosCompression.cs
@@ -9,6 +9,8 @@
  */
 #endregion
 
+using System;
+
 namespace OpenRA.Mods.Common.FileFormats
 {
 	// Run length encoded sequences of zeros (aka Format2)
@@ -24,8 +26,8 @@ namespace OpenRA.Mods.Common.FileFormats
 				if (cmd == 0)
 				{
 					var count = r.ReadByte();
-					while (count-- > 0)
-						dest[destIndex++] = 0;
+					Array.Clear(dest, destIndex, count);
+					destIndex += count;
 				}
 				else
 					dest[destIndex++] = cmd;


### PR DESCRIPTION
- In LCWCompression, RLEZerosCompression use dedicated Array.Fill, Array.Copy and Array.Clear methods instead of open-coded loops. Resolve TODO in VqaVideo.
- In VoxelLoader.GenerateSlicePlanes.Get use TryGetValue to avoid repeated array and dictionary lookups.
- In TmpTSLoader.UnpackTileData use ReadBytes to populate array with less overhead compared to repeated one byte reads.

----
~~The LCWCompression changes improve the load time in CNC for this method from 0.4% to 0.3%.~~
The other changes combined improve the load time in TS for those methods from 3.8% to 2.1%.
