### PR TITLE
fix: aircraft pause in sky when cruise at undulating ground

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -763,9 +763,7 @@ namespace OpenRA.Mods.Common.Traits
 					return;
 				}
 
-				if (Info.IdleBehavior != IdleBehaviorType.Land && dat != Info.CruiseAltitude)
-					self.QueueActivity(new TakeOff(self));
-				else if (Info.IdleBehavior == IdleBehaviorType.Land && Info.LandableTerrainTypes.Count > 0)
+				if (Info.IdleBehavior == IdleBehaviorType.Land && Info.LandableTerrainTypes.Count > 0)
 					self.QueueActivity(new Land(self));
 				else
 					self.QueueActivity(new FlyIdle(self));


### PR DESCRIPTION
Fixed by milk.
This fix when circle-flying aircraft fly on undulating terrain, they will stop circling and can stack with each other and ignores the repulse settings.
![bug](https://github.com/OpenRA/OpenRA/assets/13763394/29182753-4c09-4ce9-bb9d-3a1ab78c0f17)
