### PR TITLE
Ease the continuous lags by attack activity when attack target unreachable

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/LayMines.cs
+++ b/OpenRA.Mods.Cnc/Activities/LayMines.cs
@@ -28,10 +28,12 @@ namespace OpenRA.Mods.Cnc.Activities
 		readonly IMove movement;
 		readonly IMoveInfo moveInfo;
 		readonly RearmableInfo rearmableInfo;
+		readonly Mobile mobile;
 
 		List<CPos> minefield;
 		bool returnToBase;
 		Actor rearmTarget;
+		bool wasMobileMoved = false;
 
 		public LayMines(Actor self, List<CPos> minefield = null)
 		{
@@ -41,6 +43,9 @@ namespace OpenRA.Mods.Cnc.Activities
 			moveInfo = self.Info.TraitInfo<IMoveInfo>();
 			rearmableInfo = self.Info.TraitInfoOrDefault<RearmableInfo>();
 			this.minefield = minefield;
+			mobile = movement as Mobile;
+			if (mobile != null)
+				mobile.MoveResult = MoveResult.SoFarSoGood;
 		}
 
 		protected override void OnFirstRun(Actor self)
@@ -65,6 +70,11 @@ namespace OpenRA.Mods.Cnc.Activities
 			if (IsCanceling)
 				return true;
 
+			if (wasMobileMoved && mobile != null && mobile.MoveResult == MoveResult.StuckByImmovable)
+				return true;
+			else
+				wasMobileMoved = false;
+
 			if ((minefield == null || minefield.Contains(self.Location)) && CanLayMine(self, self.Location))
 			{
 				if (rearmableInfo != null && ammoPools.Any(p => p.Info.Name == minelayer.Info.AmmoPoolName && !p.HasAmmo))
@@ -81,6 +91,7 @@ namespace OpenRA.Mods.Cnc.Activities
 					QueueChild(movement.MoveTo(self.World.Map.CellContaining(rearmTarget.CenterPosition), ignoreActor: rearmTarget));
 					QueueChild(new Resupply(self, rearmTarget, new WDist(512)));
 					returnToBase = true;
+					wasMobileMoved = true;
 					return false;
 				}
 
@@ -93,6 +104,7 @@ namespace OpenRA.Mods.Cnc.Activities
 			var nextCell = NextValidCell(self);
 			if (nextCell != null)
 			{
+				wasMobileMoved = true;
 				QueueChild(movement.MoveTo(nextCell.Value, 0));
 				return false;
 			}

--- a/OpenRA.Mods.Common/Activities/DeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverResources.cs
@@ -20,15 +20,20 @@ namespace OpenRA.Mods.Common.Activities
 	public class DeliverResources : Activity
 	{
 		readonly IMove movement;
+		readonly Mobile mobile;
 		readonly Harvester harv;
 		readonly Actor targetActor;
 		readonly INotifyHarvesterAction[] notifyHarvesterActions;
 
 		Actor proc;
+		bool wasMobileMoved = false;
 
 		public DeliverResources(Actor self, Actor targetActor = null)
 		{
 			movement = self.Trait<IMove>();
+			mobile = movement as Mobile;
+			if (mobile != null)
+				mobile.MoveResult = MoveResult.SoFarSoGood;
 			harv = self.Trait<Harvester>();
 			this.targetActor = targetActor;
 			notifyHarvesterActions = self.TraitsImplementing<INotifyHarvesterAction>().ToArray();
@@ -47,6 +52,11 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (IsCanceling)
 				return true;
+
+			if (wasMobileMoved && mobile != null && mobile.MoveResult == MoveResult.StuckByImmovable)
+				return true;
+			else
+				wasMobileMoved = false;
 
 			// Find the nearest best refinery if not explicitly ordered to a specific refinery:
 			if (harv.LinkedProc == null || !harv.LinkedProc.IsInWorld)
@@ -68,6 +78,7 @@ namespace OpenRA.Mods.Common.Activities
 					n.MovingToRefinery(self, proc);
 
 				var target = Target.FromActor(proc);
+				wasMobileMoved = true;
 				QueueChild(movement.MoveOntoTarget(self, target, iao.DeliveryPosition - proc.CenterPosition, iao.DeliveryAngle));
 				return false;
 			}

--- a/OpenRA.Mods.Common/Activities/Enter.cs
+++ b/OpenRA.Mods.Common/Activities/Enter.cs
@@ -24,16 +24,21 @@ namespace OpenRA.Mods.Common.Activities
 		enum EnterState { Approaching, Entering, Exiting, Finished }
 
 		readonly IMove move;
+		readonly Mobile mobile;
 		readonly Color? targetLineColor;
 
 		Target target;
 		Target lastVisibleTarget;
 		bool useLastVisibleTarget;
 		EnterState lastState = EnterState.Approaching;
+		bool wasMobileMoved = false;
 
 		protected Enter(Actor self, in Target target, Color? targetLineColor = null)
 		{
 			move = self.Trait<IMove>();
+			mobile = move as Mobile;
+			if (mobile != null)
+				mobile.MoveResult = MoveResult.SoFarSoGood;
 			this.target = target;
 			this.targetLineColor = targetLineColor;
 			ChildHasPriority = false;
@@ -72,6 +77,11 @@ namespace OpenRA.Mods.Common.Activities
 			if (!IsCanceling && useLastVisibleTarget && lastState == EnterState.Entering)
 				Cancel(self, true);
 
+			if (wasMobileMoved && mobile != null && mobile.MoveResult == MoveResult.StuckByImmovable)
+				return true;
+			else
+				wasMobileMoved = false;
+
 			TickInner(self, target, useLastVisibleTarget);
 
 			// We need to wait for movement to finish before transitioning to
@@ -99,6 +109,7 @@ namespace OpenRA.Mods.Common.Activities
 						// Target lines are managed by this trait, so we do not pass targetLineColor
 						var initialTargetPosition = (useLastVisibleTarget ? lastVisibleTarget : target).CenterPosition;
 						QueueChild(move.MoveToTarget(self, target, initialTargetPosition));
+						wasMobileMoved = true;
 						return false;
 					}
 
@@ -112,6 +123,7 @@ namespace OpenRA.Mods.Common.Activities
 					{
 						lastState = EnterState.Entering;
 						QueueChild(move.MoveIntoTarget(self, target));
+						wasMobileMoved = true;
 						return false;
 					}
 
@@ -137,6 +149,7 @@ namespace OpenRA.Mods.Common.Activities
 				case EnterState.Exiting:
 				{
 					QueueChild(move.ReturnToCell(self));
+					wasMobileMoved = true;
 					lastState = EnterState.Finished;
 					return false;
 				}

--- a/OpenRA.Mods.Common/Activities/HarvestResource.cs
+++ b/OpenRA.Mods.Common/Activities/HarvestResource.cs
@@ -26,8 +26,11 @@ namespace OpenRA.Mods.Common.Activities
 		readonly IResourceLayer resourceLayer;
 		readonly BodyOrientation body;
 		readonly IMove move;
+		readonly Mobile mobile;
 		readonly CPos targetCell;
 		readonly INotifyHarvesterAction[] notifyHarvesterActions;
+
+		bool wasMobileMoved = false;
 
 		public HarvestResource(Actor self, CPos targetCell)
 		{
@@ -36,6 +39,9 @@ namespace OpenRA.Mods.Common.Activities
 			facing = self.Trait<IFacing>();
 			body = self.Trait<BodyOrientation>();
 			move = self.Trait<IMove>();
+			mobile = move as Mobile;
+			if (mobile != null)
+				mobile.MoveResult = MoveResult.SoFarSoGood;
 			claimLayer = self.World.WorldActor.Trait<ResourceClaimLayer>();
 			resourceLayer = self.World.WorldActor.Trait<IResourceLayer>();
 			this.targetCell = targetCell;
@@ -58,6 +64,11 @@ namespace OpenRA.Mods.Common.Activities
 			if (IsCanceling || harv.IsFull)
 				return true;
 
+			if (wasMobileMoved && mobile != null && mobile.MoveResult == MoveResult.StuckByImmovable)
+				return true;
+			else
+				wasMobileMoved = false;
+
 			// Move towards the target cell
 			if (self.Location != targetCell)
 			{
@@ -65,6 +76,7 @@ namespace OpenRA.Mods.Common.Activities
 					n.MovingToResources(self, targetCell);
 
 				QueueChild(move.MoveTo(targetCell, 0));
+				wasMobileMoved = true;
 				return false;
 			}
 

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -113,6 +113,7 @@ namespace OpenRA.Mods.Common.Activities
 		protected override void OnFirstRun(Actor self)
 		{
 			startTicks = self.World.WorldTick;
+			mobile.MoveResult = MoveResult.SoFarSoGood;
 
 			if (evaluateNearestMovableCell && destination.HasValue)
 			{
@@ -249,6 +250,11 @@ namespace OpenRA.Mods.Common.Activities
 				if (!mobile.CanEnterCell(nextCell, ignoreActor, BlockedByActor.Immovable))
 				{
 					path = EvalPath(BlockedByActor.Immovable);
+
+					// If actor is blocked by immovable actors, suggest parent activiy to give up
+					if (path.Count == 0)
+						mobile.MoveResult = MoveResult.StuckByImmovable;
+
 					return null;
 				}
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -209,6 +209,7 @@ namespace OpenRA.Mods.Common.Traits
 		public bool IsBlocking { get; private set; }
 
 		public bool IsMovingBetweenCells => FromCell != ToCell;
+		public MoveResult MoveResult;
 
 		#region IFacing
 

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -653,6 +653,13 @@ namespace OpenRA.Mods.Common.Traits
 		Turn = 4
 	}
 
+	[Flags]
+	public enum MoveResult
+	{
+		SoFarSoGood = 0,
+		StuckByImmovable = 1,
+	}
+
 	[RequireExplicitImplementation]
 	public interface INotifyMoving
 	{


### PR DESCRIPTION
Greatly ease #20948

before:
![pathfinding-lag](https://github.com/OpenRA/OpenRA/assets/13763394/dc665e8a-88d8-4b7c-a258-da205c7f75bc)

after:
![fix](https://github.com/OpenRA/OpenRA/assets/13763394/167e059b-3d5c-44fa-82a4-5a6ca3c6087f)

Note: All 2 tests make stuck units attack a dog reachable if not consider walls.

Need more tests to see if there is any change to regular gameplay, and I need help on that.