### PR TITLE
Minelaying improvements

### DIFF
--- a/OpenRA.Mods.Common/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Common/Traits/Minelayer.cs
@@ -109,18 +109,23 @@ namespace OpenRA.Mods.Common.Traits
 			switch (order.OrderID)
 			{
 				case "BeginMinefield":
-					var start = self.World.Map.CellContaining(target.CenterPosition);
-					if (self.World.OrderGenerator is MinefieldOrderGenerator generator)
-						generator.AddMinelayer(self);
-					else
-						self.World.OrderGenerator = new MinefieldOrderGenerator(self, start, queued);
-
-					return new Order("BeginMinefield", self, Target.FromCell(self.World, start), queued);
+					return BeginMinefield(self, target, queued);
 				case "PlaceMine":
 					return new Order("PlaceMine", self, Target.FromCell(self.World, self.Location), queued);
 				default:
 					return null;
 			}
+		}
+
+		public static Order BeginMinefield(Actor self, Target target, bool queued)
+		{
+			var start = self.World.Map.CellContaining(target.CenterPosition);
+			if (self.World.OrderGenerator is MinefieldOrderGenerator generator)
+				generator.AddMinelayer(self);
+			else
+				self.World.OrderGenerator = new MinefieldOrderGenerator(self, start, queued);
+
+			return new Order("BeginMinefield", self, Target.FromCell(self.World, start), queued);
 		}
 
 		Order IIssueDeployOrder.IssueDeployOrder(Actor self, bool queued)

--- a/OpenRA.Mods.Common/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Common/Traits/Minelayer.cs
@@ -63,6 +63,12 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Ammo the minelayer consumes per mine.")]
 		public readonly int AmmoUsage = 1;
 
+		[Desc("Number of ticks it takes to lay a mine.")]
+		public readonly int PreLayDelay = 0;
+
+		[Desc("Number of ticks for the minelayer to wait after laying a mine. The wait can be interrupted by a player order.")]
+		public readonly int AfterLayingDelay = 20;
+
 		public override object Create(ActorInitializer init) { return new Minelayer(init.Self, this); }
 	}
 

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -159,7 +159,12 @@ namespace OpenRA.Mods.Common.Traits
 	public interface INotifyDelivery { void IncomingDelivery(Actor self); void Delivered(Actor self); }
 
 	[RequireExplicitImplementation]
-	public interface INotifyMineLaying { void MineLaying(Actor self, CPos location); void MineLaid(Actor self, Actor mine); }
+	public interface INotifyMineLaying
+	{
+		void MineLaying(Actor self, CPos location);
+		void MineLaid(Actor self, Actor mine);
+		void MineLayingCanceled(Actor self, CPos location);
+	}
 
 	[RequireExplicitImplementation]
 	public interface INotifyDockHost { void Docked(Actor self, Actor client); void Undocked(Actor self, Actor client); }


### PR DESCRIPTION
Second PR with `Minelayer` improvements:

1) option to specify time it takes to lay a mine
2) delay after mine has been laid is now customizable (previously hardcoded to 20 ticks)
3) `Minelayer` exposes static method for creating `BeginMinefield` order

No. 3 is useful for mods that would want to change the way this feature is activated.
