### PR TITLE
Make Voiced trait conditional

### DIFF
--- a/OpenRA.Mods.Common/Traits/Voiced.cs
+++ b/OpenRA.Mods.Common/Traits/Voiced.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor has a voice.")]
-	public class VoicedInfo : TraitInfo
+	public class VoicedInfo : ConditionalTraitInfo
 	{
 		[VoiceSetReference]
 		[FieldLoader.Require]
@@ -27,19 +27,18 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Voiced(this); }
 	}
 
-	public class Voiced : IVoiced
+	public class Voiced : ConditionalTrait<VoicedInfo>, IVoiced
 	{
-		public readonly VoicedInfo Info;
-
 		public Voiced(VoicedInfo info)
-		{
-			Info = info;
-		}
+			: base(info) { }
 
 		string IVoiced.VoiceSet => Info.VoiceSet;
 
 		bool IVoiced.PlayVoice(Actor self, string phrase, string variant)
 		{
+			if (IsTraitDisabled)
+				return false;
+
 			if (phrase == null)
 				return false;
 
@@ -53,6 +52,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool IVoiced.PlayVoiceLocal(Actor self, string phrase, string variant, float volume)
 		{
+			if (IsTraitDisabled)
+				return false;
+
 			if (phrase == null)
 				return false;
 
@@ -65,6 +67,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool IVoiced.HasVoice(Actor self, string voice)
 		{
+			if (IsTraitDisabled)
+				return false;
+
 			if (string.IsNullOrEmpty(Info.VoiceSet))
 				return false;
 


### PR DESCRIPTION
Extension methods in `VoiceExts` already support working with multiple `Voiced` traits on an actor, so this change should not be an issue.