### PR TITLE
More minelaying improvements

### DIFF
--- a/OpenRA.Mods.Common/Activities/LayMines.cs
+++ b/OpenRA.Mods.Common/Activities/LayMines.cs
@@ -157,8 +157,9 @@ namespace OpenRA.Mods.Common.Activities
 			if (nextCell != null)
 				yield return new TargetLineNode(Target.FromCell(self.World, nextCell.Value), minelayer.Info.TargetLineColor);
 
-			foreach (var c in minefield)
-				yield return new TargetLineNode(Target.FromCell(self.World, c), minelayer.Info.TargetLineColor, tile: minelayer.Tile);
+			if (minefield.Count > 1)
+				foreach (var c in minefield)
+					yield return new TargetLineNode(Target.FromCell(self.World, c), minelayer.Info.TargetLineColor, tile: minelayer.Tile);
 		}
 
 		static bool CanLayMine(Actor self, CPos p)

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnMinelaying.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnMinelaying.cs
@@ -1,0 +1,44 @@
+﻿using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public class GrantConditionOnMinelayingInfo : ConditionalTraitInfo, Requires<MinelayerInfo>
+	{
+		[FieldLoader.Require]
+		[GrantedConditionReference]
+		[Desc("Condition to grant.")]
+		public readonly string Condition = null;
+
+		public override object Create(ActorInitializer init)
+		{
+			return new GrantConditionOnMinelaying(this);
+		}
+	}
+
+	public class GrantConditionOnMinelaying : ConditionalTrait<GrantConditionOnMinelayingInfo>, INotifyMineLaying
+	{
+		int conditionToken = Actor.InvalidConditionToken;
+
+		public GrantConditionOnMinelaying(GrantConditionOnMinelayingInfo info)
+			: base(info)
+		{
+		}
+
+		void INotifyMineLaying.MineLaid(Actor self, Actor mine)
+		{
+			if (conditionToken != Actor.InvalidConditionToken)
+				conditionToken = self.RevokeCondition(conditionToken);
+		}
+
+		void INotifyMineLaying.MineLaying(Actor self, CPos location)
+		{
+			conditionToken = self.GrantCondition(Info.Condition);
+		}
+
+		void INotifyMineLaying.MineLayingCanceled(Actor self, CPos location)
+		{
+			if (conditionToken != Actor.InvalidConditionToken)
+				conditionToken = self.RevokeCondition(conditionToken);
+		}
+	}
+}


### PR DESCRIPTION
Third round of improvements for `Minelayer`:
- `LayMines` renders minefield cells only if the minefield has more than 1 cell
- `GrantConditionOnMinelaying` trait for making a condition that is granted when minelayer is laying a mine
