### PR TITLE
Immutable MiniYaml

### DIFF
--- a/OpenRA.Game/ExternalMods.cs
+++ b/OpenRA.Game/ExternalMods.cs
@@ -122,7 +122,7 @@ namespace OpenRA
 				return;
 
 			var key = ExternalMod.MakeKey(mod);
-			var yaml = new MiniYamlNode("Registration", new MiniYaml("", new List<MiniYamlNode>()
+			var yaml = new MiniYamlNode("Registration", new MiniYaml("", new[]
 			{
 				new MiniYamlNode("Id", mod.Id),
 				new MiniYamlNode("Version", mod.Metadata.Version),
@@ -131,17 +131,21 @@ namespace OpenRA
 				new MiniYamlNode("LaunchArgs", new[] { "Game.Mod=" + mod.Id }.Concat(launchArgs).JoinWith(", "))
 			}));
 
+			var iconNodes = new List<MiniYamlNode>();
+
 			using (var stream = mod.Package.GetStream("icon.png"))
 				if (stream != null)
-					yaml.Value.Nodes.Add(new MiniYamlNode("Icon", Convert.ToBase64String(stream.ReadAllBytes())));
+					iconNodes.Add(new MiniYamlNode("Icon", Convert.ToBase64String(stream.ReadAllBytes())));
 
 			using (var stream = mod.Package.GetStream("icon-2x.png"))
 				if (stream != null)
-					yaml.Value.Nodes.Add(new MiniYamlNode("Icon2x", Convert.ToBase64String(stream.ReadAllBytes())));
+					iconNodes.Add(new MiniYamlNode("Icon2x", Convert.ToBase64String(stream.ReadAllBytes())));
 
 			using (var stream = mod.Package.GetStream("icon-3x.png"))
 				if (stream != null)
-					yaml.Value.Nodes.Add(new MiniYamlNode("Icon3x", Convert.ToBase64String(stream.ReadAllBytes())));
+					iconNodes.Add(new MiniYamlNode("Icon3x", Convert.ToBase64String(stream.ReadAllBytes())));
+
+			yaml = yaml.WithValue(yaml.Value.WithNodesAppended(iconNodes));
 
 			var sources = new HashSet<string>();
 			if (registration.HasFlag(ModRegistration.System))

--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -500,7 +500,7 @@ namespace OpenRA
 			if (yaml == null)
 				return Activator.CreateInstance(fieldType);
 
-			var dict = Activator.CreateInstance(fieldType, yaml.Nodes.Count);
+			var dict = Activator.CreateInstance(fieldType, yaml.Nodes.Length);
 			var arguments = fieldType.GetGenericArguments();
 			var addMethod = fieldType.GetMethod(nameof(Dictionary<object, object>.Add), arguments);
 			var addArgs = new object[2];

--- a/OpenRA.Game/FieldSaver.cs
+++ b/OpenRA.Game/FieldSaver.cs
@@ -58,7 +58,7 @@ namespace OpenRA
 
 			return new MiniYaml(
 				null,
-				fields.Select(info => new MiniYamlNode(info.YamlName, FormatValue(o, info.Field))).ToList());
+				fields.Select(info => new MiniYamlNode(info.YamlName, FormatValue(o, info.Field))));
 		}
 
 		public static MiniYamlNode SaveField(object o, string field)

--- a/OpenRA.Game/GameRules/Ruleset.cs
+++ b/OpenRA.Game/GameRules/Ruleset.cs
@@ -226,10 +226,10 @@ namespace OpenRA
 
 		static bool AnyCustomYaml(MiniYaml yaml)
 		{
-			return yaml != null && (yaml.Value != null || yaml.Nodes.Count > 0);
+			return yaml != null && (yaml.Value != null || yaml.Nodes.Length > 0);
 		}
 
-		static bool AnyFlaggedTraits(ModData modData, List<MiniYamlNode> actors)
+		static bool AnyFlaggedTraits(ModData modData, IEnumerable<MiniYamlNode> actors)
 		{
 			foreach (var actorNode in actors)
 			{

--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -139,7 +139,7 @@ namespace OpenRA.GameRules
 		{
 			// Resolve any weapon-level yaml inheritance or removals
 			// HACK: The "Defaults" sequence syntax prevents us from doing this generally during yaml parsing
-			content.Nodes = MiniYaml.Merge(new[] { content.Nodes });
+			content = content.WithNodes(MiniYaml.Merge(new IReadOnlyCollection<MiniYamlNode>[] { content.Nodes }));
 			FieldLoader.Load(this, content);
 		}
 

--- a/OpenRA.Game/Map/ActorReference.cs
+++ b/OpenRA.Game/Map/ActorReference.cs
@@ -84,7 +84,7 @@ namespace OpenRA
 
 		public MiniYaml Save(Func<ActorInit, bool> initFilter = null)
 		{
-			var ret = new MiniYaml(Type);
+			var nodes = new List<MiniYamlNode>();
 			foreach (var o in initDict.Value)
 			{
 				if (o is not ActorInit init || o is ISuppressInitExport)
@@ -98,10 +98,10 @@ namespace OpenRA
 				if (!string.IsNullOrEmpty(init.InstanceName))
 					initName += ActorInfo.TraitInstanceSeparator + init.InstanceName;
 
-				ret.Nodes.Add(new MiniYamlNode(initName, init.Save()));
+				nodes.Add(new MiniYamlNode(initName, init.Save()));
 			}
 
-			return ret;
+			return new MiniYaml(Type, nodes);
 		}
 
 		public IEnumerator<object> GetEnumerator() { return initDict.Value.GetEnumerator(); }

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -90,11 +91,11 @@ namespace OpenRA
 				throw new InvalidOperationException("Map does not have a field/property " + fieldName);
 
 			var t = field != null ? field.FieldType : property.PropertyType;
-			type = t == typeof(List<MiniYamlNode>) ? Type.NodeList :
+			type = t == typeof(IReadOnlyCollection<MiniYamlNode>) ? Type.NodeList :
 				t == typeof(MiniYaml) ? Type.MiniYaml : Type.Normal;
 		}
 
-		public void Deserialize(Map map, List<MiniYamlNode> nodes)
+		public void Deserialize(Map map, ImmutableArray<MiniYamlNode> nodes)
 		{
 			var node = nodes.FirstOrDefault(n => n.Key == key);
 			if (node == null)
@@ -130,14 +131,14 @@ namespace OpenRA
 			var value = field != null ? field.GetValue(map) : property.GetValue(map, null);
 			if (type == Type.NodeList)
 			{
-				var listValue = (List<MiniYamlNode>)value;
+				var listValue = (IReadOnlyCollection<MiniYamlNode>)value;
 				if (required || listValue.Count > 0)
 					nodes.Add(new MiniYamlNode(key, null, listValue));
 			}
 			else if (type == Type.MiniYaml)
 			{
 				var yamlValue = (MiniYaml)value;
-				if (required || (yamlValue != null && (yamlValue.Value != null || yamlValue.Nodes.Count > 0)))
+				if (required || (yamlValue != null && (yamlValue.Value != null || yamlValue.Nodes.Length > 0)))
 					nodes.Add(new MiniYamlNode(key, yamlValue));
 			}
 			else
@@ -197,18 +198,18 @@ namespace OpenRA
 		public int2 MapSize { get; private set; }
 
 		// Player and actor yaml. Public for access by the map importers and lint checks.
-		public List<MiniYamlNode> PlayerDefinitions = new();
-		public List<MiniYamlNode> ActorDefinitions = new();
+		public IReadOnlyCollection<MiniYamlNode> PlayerDefinitions = ImmutableArray<MiniYamlNode>.Empty;
+		public IReadOnlyCollection<MiniYamlNode> ActorDefinitions = ImmutableArray<MiniYamlNode>.Empty;
 
 		// Custom map yaml. Public for access by the map importers and lint checks
-		public readonly MiniYaml RuleDefinitions;
-		public readonly MiniYaml TranslationDefinitions;
-		public readonly MiniYaml SequenceDefinitions;
-		public readonly MiniYaml ModelSequenceDefinitions;
-		public readonly MiniYaml WeaponDefinitions;
-		public readonly MiniYaml VoiceDefinitions;
-		public readonly MiniYaml MusicDefinitions;
-		public readonly MiniYaml NotificationDefinitions;
+		public MiniYaml RuleDefinitions;
+		public MiniYaml TranslationDefinitions;
+		public MiniYaml SequenceDefinitions;
+		public MiniYaml ModelSequenceDefinitions;
+		public MiniYaml WeaponDefinitions;
+		public MiniYaml VoiceDefinitions;
+		public MiniYaml MusicDefinitions;
+		public MiniYaml NotificationDefinitions;
 
 		public readonly Dictionary<CPos, TerrainTile> ReplacedInvalidTerrainTiles = new();
 

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -142,7 +142,7 @@ namespace OpenRA
 						var sources =
 							modDataRules.Select(x => x.Where(IsLoadableRuleDefinition).ToList())
 							.Concat(files.Select(s => MiniYaml.FromStream(fileSystem.Open(s), s).Where(IsLoadableRuleDefinition).ToList()));
-						if (RuleDefinitions.Nodes.Count > 0)
+						if (RuleDefinitions.Nodes.Length > 0)
 							sources = sources.Append(RuleDefinitions.Nodes.Where(IsLoadableRuleDefinition).ToList());
 
 						var yamlNodes = MiniYaml.Merge(sources);

--- a/OpenRA.Game/Network/GameServer.cs
+++ b/OpenRA.Game/Network/GameServer.cs
@@ -251,10 +251,8 @@ namespace OpenRA.Network
 				root.Add(new MiniYamlNode("Mods", Mod + "@" + Version));
 			}
 
-			var clientsNode = new MiniYaml("");
-			var i = 0;
-			foreach (var c in Clients)
-				clientsNode.Nodes.Add(new MiniYamlNode("Client@" + i++.ToString(), FieldSaver.Save(c)));
+			var clientsNode = new MiniYaml("", Clients.Select((c, i) =>
+				new MiniYamlNode("Client@" + i, FieldSaver.Save(c))));
 
 			root.Add(new MiniYamlNode("Clients", clientsNode));
 			return new MiniYaml("", root)

--- a/OpenRA.Game/Network/LocalizedMessage.cs
+++ b/OpenRA.Game/Network/LocalizedMessage.cs
@@ -108,10 +108,9 @@ namespace OpenRA.Network
 
 			if (arguments != null)
 			{
-				var argumentsNode = new MiniYaml("");
-				var i = 0;
-				foreach (var argument in arguments.Select(a => new FluentArgument(a.Key, a.Value)))
-					argumentsNode.Nodes.Add(new MiniYamlNode("Argument@" + i++, FieldSaver.Save(argument)));
+				var argumentsNode = new MiniYaml("", arguments
+					.Select(a => new FluentArgument(a.Key, a.Value))
+					.Select((argument, i) => new MiniYamlNode("Argument@" + i, FieldSaver.Save(argument))));
 
 				root.Add(new MiniYamlNode("Arguments", argumentsNode));
 			}

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -238,8 +238,9 @@ namespace OpenRA.Network
 			public MiniYamlNode Serialize()
 			{
 				var data = new MiniYamlNode("GlobalSettings", FieldSaver.Save(this));
-				var options = LobbyOptions.Select(kv => new MiniYamlNode(kv.Key, FieldSaver.Save(kv.Value))).ToList();
-				data.Value.Nodes.Add(new MiniYamlNode("Options", new MiniYaml(null, options)));
+				var options = LobbyOptions.Select(kv => new MiniYamlNode(kv.Key, FieldSaver.Save(kv.Value)));
+				data = data.WithValue(data.Value.WithNodesAppended(
+					new[] { new MiniYamlNode("Options", new MiniYaml(null, options)) }));
 				return data;
 			}
 

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -349,7 +350,7 @@ namespace OpenRA.Traits
 	public interface IGameSaveTraitData
 	{
 		List<MiniYamlNode> IssueTraitData(Actor self);
-		void ResolveTraitData(Actor self, List<MiniYamlNode> data);
+		void ResolveTraitData(Actor self, ImmutableArray<MiniYamlNode> data);
 	}
 
 	[RequireExplicitImplementation]

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportGen2MapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportGen2MapCommand.cs
@@ -171,6 +171,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 				}
 			}
 
+			var nodes = new List<MiniYamlNode>();
 			foreach (var cell in map.AllCells)
 			{
 				var overlayType = overlayPack[overlayIndex[cell]];
@@ -180,7 +181,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 				if (TryHandleOverlayToActorInner(cell, overlayPack, overlayIndex, overlayType, out var ar))
 				{
 					if (ar != null)
-						map.ActorDefinitions.Add(new MiniYamlNode("Actor" + map.ActorDefinitions.Count, ar.Save()));
+						nodes.Add(new MiniYamlNode("Actor" + (map.ActorDefinitions.Count + nodes.Count), ar.Save()));
 
 					continue;
 				}
@@ -196,10 +197,13 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 
 				Console.WriteLine($"Cell {cell}: unknown overlay {overlayType}");
 			}
+
+			map.ActorDefinitions = map.ActorDefinitions.Concat(nodes).ToArray();
 		}
 
 		protected virtual void ReadWaypoints(Map map, IniFile file, int2 fullSize)
 		{
+			var nodes = new List<MiniYamlNode>();
 			var waypointsSection = file.GetSection("Waypoints", true);
 			foreach (var kv in waypointsSection)
 			{
@@ -214,12 +218,15 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 					new OwnerInit("Neutral")
 				};
 
-				map.ActorDefinitions.Add(new MiniYamlNode("Actor" + map.ActorDefinitions.Count, ar.Save()));
+				nodes.Add(new MiniYamlNode("Actor" + (map.ActorDefinitions.Count + nodes.Count), ar.Save()));
 			}
+
+			map.ActorDefinitions = map.ActorDefinitions.Concat(nodes).ToArray();
 		}
 
 		protected virtual void ReadTerrainActors(Map map, IniFile file, int2 fullSize)
 		{
+			var nodes = new List<MiniYamlNode>();
 			var terrainSection = file.GetSection("Terrain", true);
 			foreach (var kv in terrainSection)
 			{
@@ -238,12 +245,15 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 				if (!map.Rules.Actors.ContainsKey(name))
 					Console.WriteLine($"Ignoring unknown actor type: `{name}`");
 				else
-					map.ActorDefinitions.Add(new MiniYamlNode("Actor" + map.ActorDefinitions.Count, ar.Save()));
+					nodes.Add(new MiniYamlNode("Actor" + (map.ActorDefinitions.Count + nodes.Count), ar.Save()));
 			}
+
+			map.ActorDefinitions = map.ActorDefinitions.Concat(nodes).ToArray();
 		}
 
 		protected virtual void ReadActors(Map map, IniFile file, string type, int2 fullSize)
 		{
+			var nodes = new List<MiniYamlNode>();
 			var structuresSection = file.GetSection(type, true);
 			foreach (var kv in structuresSection)
 			{
@@ -296,8 +306,10 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 				if (!map.Rules.Actors.ContainsKey(name))
 					Console.WriteLine($"Ignoring unknown actor type: `{name}`");
 				else
-					map.ActorDefinitions.Add(new MiniYamlNode("Actor" + map.ActorDefinitions.Count, ar.Save()));
+					nodes.Add(new MiniYamlNode("Actor" + (map.ActorDefinitions.Count + nodes.Count), ar.Save()));
 			}
+
+			map.ActorDefinitions = map.ActorDefinitions.Concat(nodes).ToArray();
 		}
 
 		protected virtual void ReadLighting(Map map, IniFile file)
@@ -340,10 +352,13 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 
 			if (lightingNodes.Count > 0)
 			{
-				map.RuleDefinitions.Nodes.Add(new MiniYamlNode("^BaseWorld", new MiniYaml("", new List<MiniYamlNode>()
+				map.RuleDefinitions = map.RuleDefinitions.WithNodesAppended(new[]
 				{
-					new MiniYamlNode("TerrainLighting", new MiniYaml("", lightingNodes))
-				})));
+					new MiniYamlNode("^BaseWorld", new MiniYaml("", new[]
+					{
+						new MiniYamlNode("TerrainLighting", new MiniYaml("", lightingNodes))
+					}))
+				});
 			}
 		}
 
@@ -357,6 +372,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 				{ "LightBlueTint", "BlueTint" },
 			};
 
+			var nodes = new List<MiniYamlNode>();
 			foreach (var lamp in LampActors)
 			{
 				var lightingSection = file.GetSection(lamp, true);
@@ -380,12 +396,14 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 
 				if (lightingNodes.Count > 0)
 				{
-					map.RuleDefinitions.Nodes.Add(new MiniYamlNode(lamp, new MiniYaml("", new List<MiniYamlNode>()
+					nodes.Add(new MiniYamlNode(lamp, new MiniYaml("", new[]
 					{
 						new MiniYamlNode("TerrainLightSource", new MiniYaml("", lightingNodes))
 					})));
 				}
 			}
+
+			map.RuleDefinitions = map.RuleDefinitions.WithNodesAppended(nodes);
 		}
 
 		protected virtual void SetInteractableBounds(Map map, int[] iniBounds)

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertMapCommand.cs
@@ -94,6 +94,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 
 		void UnpackOverlayData(MemoryStream ms)
 		{
+			var nodes = new List<MiniYamlNode>();
 			for (var j = 0; j < MapSize; j++)
 			{
 				for (var i = 0; i < MapSize; i++)
@@ -115,11 +116,12 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 							new OwnerInit("Neutral")
 						};
 
-						var actorCount = Map.ActorDefinitions.Count;
-						Map.ActorDefinitions.Add(new MiniYamlNode("Actor" + actorCount++, ar.Save()));
+						nodes.Add(new MiniYamlNode("Actor" + (Map.ActorDefinitions.Count + nodes.Count), ar.Save()));
 					}
 				}
 			}
+
+			Map.ActorDefinitions = Map.ActorDefinitions.Concat(nodes).ToArray();
 		}
 
 		public override string ParseTreeActor(string input)
@@ -241,12 +243,12 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			LoadActors(file, "SHIPS", Players, Map);
 		}
 
-		public override void SaveWaypoint(int waypointNumber, ActorReference waypointReference)
+		public override MiniYamlNode SaveWaypoint(int waypointNumber, ActorReference waypointReference)
 		{
 			var waypointName = "waypoint" + waypointNumber;
 			if (waypointNumber == 98)
 				waypointName = "DefaultCameraPosition";
-			Map.ActorDefinitions.Add(new MiniYamlNode(waypointName, waypointReference.Save()));
+			return new MiniYamlNode(waypointName, waypointReference.Save());
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianDawnMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianDawnMapCommand.cs
@@ -86,6 +86,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			if (overlay == null)
 				return;
 
+			var nodes = new List<MiniYamlNode>();
 			foreach (var kv in overlay)
 			{
 				var loc = Exts.ParseIntegerInvariant(kv.Key);
@@ -105,10 +106,11 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 						new OwnerInit("Neutral")
 					};
 
-					var actorCount = Map.ActorDefinitions.Count;
-					Map.ActorDefinitions.Add(new MiniYamlNode("Actor" + actorCount++, ar.Save()));
+					nodes.Add(new MiniYamlNode("Actor" + (Map.ActorDefinitions.Count + nodes.Count), ar.Save()));
 				}
 			}
+
+			Map.ActorDefinitions = Map.ActorDefinitions.Concat(nodes).ToArray();
 		}
 
 		public override string ParseTreeActor(string input)
@@ -170,7 +172,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			ReadOverlay(file);
 		}
 
-		public override void SaveWaypoint(int waypointNumber, ActorReference waypointReference)
+		public override MiniYamlNode SaveWaypoint(int waypointNumber, ActorReference waypointReference)
 		{
 			var waypointName = "waypoint" + waypointNumber;
 			if (waypointNumber == 25)
@@ -179,7 +181,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 				waypointName = "DefaultCameraPosition";
 			else if (waypointNumber == 27)
 				waypointName = "DefaultChinookTarget";
-			Map.ActorDefinitions.Add(new MiniYamlNode(waypointName, waypointReference.Save()));
+			return new MiniYamlNode(waypointName, waypointReference.Save());
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Graphics
 			var sequences = new Dictionary<string, ISpriteSequence>();
 			var node = imageNode.Value.Nodes.SingleOrDefault(n => n.Key == "Defaults");
 			var defaults = node?.Value ?? NoData;
-			imageNode.Value.Nodes.Remove(node);
+			imageNode = imageNode.WithValue(imageNode.Value.WithNodes(imageNode.Value.Nodes.Remove(node)));
 
 			foreach (var sequenceNode in imageNode.Value.Nodes)
 			{
@@ -262,7 +262,7 @@ namespace OpenRA.Mods.Common.Graphics
 
 		protected static T LoadField<T>(string key, T fallback, MiniYaml data, MiniYaml defaults = null)
 		{
-			var node = data.Nodes.Find(n => n.Key == key) ?? defaults?.Nodes.Find(n => n.Key == key);
+			var node = data.Nodes.FirstOrDefault(n => n.Key == key) ?? defaults?.Nodes.FirstOrDefault(n => n.Key == key);
 			if (node == null)
 				return fallback;
 
@@ -276,7 +276,7 @@ namespace OpenRA.Mods.Common.Graphics
 
 		protected static T LoadField<T>(SpriteSequenceField<T> field, MiniYaml data, MiniYaml defaults, out MiniYamlNode.SourceLocation location)
 		{
-			var node = data.Nodes.Find(n => n.Key == field.Key) ?? defaults?.Nodes.Find(n => n.Key == field.Key);
+			var node = data.Nodes.FirstOrDefault(n => n.Key == field.Key) ?? defaults?.Nodes.FirstOrDefault(n => n.Key == field.Key);
 			if (node == null)
 			{
 				location = default;
@@ -414,10 +414,10 @@ namespace OpenRA.Mods.Common.Graphics
 			var offset = LoadField(Offset, data, defaults);
 			var blendMode = LoadField(BlendMode, data, defaults);
 
-			var combineNode = data.Nodes.Find(n => n.Key == Combine.Key);
+			var combineNode = data.Nodes.FirstOrDefault(n => n.Key == Combine.Key);
 			if (combineNode != null)
 			{
-				for (var i = 0; i < combineNode.Value.Nodes.Count; i++)
+				for (var i = 0; i < combineNode.Value.Nodes.Length; i++)
 				{
 					var subData = combineNode.Value.Nodes[i].Value;
 					var subOffset = LoadField(Offset, subData, NoData);

--- a/OpenRA.Mods.Common/Lint/CheckChromeHotkeys.cs
+++ b/OpenRA.Mods.Common/Lint/CheckChromeHotkeys.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Widgets;
 
@@ -64,7 +65,7 @@ namespace OpenRA.Mods.Common.Lint
 		}
 
 		void CheckInner(ModData modData, string[] namedKeys, (string Widget, string Field)[] checkWidgetFields, Dictionary<string, List<string>> customLintMethods,
-			List<MiniYamlNode> nodes, string filename, MiniYamlNode parent, Action<string> emitError)
+			IEnumerable<MiniYamlNode> nodes, string filename, MiniYamlNode parent, Action<string> emitError)
 		{
 			foreach (var node in nodes)
 			{
@@ -94,7 +95,7 @@ namespace OpenRA.Mods.Common.Lint
 				}
 
 				// Logic classes can declare the data key names that specify hotkeys.
-				if (node.Key == "Logic" && node.Value.Nodes.Count > 0)
+				if (node.Key == "Logic" && node.Value.Nodes.Length > 0)
 				{
 					var typeNames = FieldLoader.GetValue<string[]>(node.Key, node.Value.Value);
 					var checkArgKeys = new List<string>();

--- a/OpenRA.Mods.Common/Lint/CheckChromeIntegerExpressions.cs
+++ b/OpenRA.Mods.Common/Lint/CheckChromeIntegerExpressions.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Lint
 				CheckInner(MiniYaml.FromStream(modData.DefaultFileSystem.Open(filename), filename), filename, emitError);
 		}
 
-		void CheckInner(List<MiniYamlNode> nodes, string filename, Action<string> emitError)
+		void CheckInner(IEnumerable<MiniYamlNode> nodes, string filename, Action<string> emitError)
 		{
 			var substitutions = new Dictionary<string, int>();
 			var readOnlySubstitutions = new ReadOnlyDictionary<string, int>(substitutions);

--- a/OpenRA.Mods.Common/Lint/CheckChromeLogic.cs
+++ b/OpenRA.Mods.Common/Lint/CheckChromeLogic.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Lint
 				CheckInner(MiniYaml.FromStream(modData.DefaultFileSystem.Open(filename), filename), filename, emitError);
 		}
 
-		void CheckInner(List<MiniYamlNode> nodes, string filename, Action<string> emitError)
+		void CheckInner(IEnumerable<MiniYamlNode> nodes, string filename, Action<string> emitError)
 		{
 			foreach (var node in nodes)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckUnknownTraitFields.cs
+++ b/OpenRA.Mods.Common/Lint/CheckUnknownTraitFields.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Lint
 					// Removals can never define children or values.
 					if (t.Key.StartsWith("-", StringComparison.Ordinal))
 					{
-						if (t.Value.Nodes.Count > 0)
+						if (t.Value.Nodes.Length > 0)
 							emitError($"{t.Location} `{t.Key}` defines child nodes, which are not valid for removals.");
 
 						if (!string.IsNullOrEmpty(t.Value.Value))
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Lint
 					// Inherits can never define children.
 					if (traitName == "Inherits")
 					{
-						if (t.Value.Nodes.Count > 0)
+						if (t.Value.Nodes.Length > 0)
 							emitError($"{t.Location} defines child nodes, which are not valid for Inherits.");
 
 						continue;
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Lint
 			foreach (var f in mapFiles)
 				CheckActors(MiniYaml.FromStream(fileSystem.Open(f), f), emitError, modData);
 
-			if (ruleDefinitions.Nodes.Count > 0)
+			if (ruleDefinitions.Nodes.Length > 0)
 				CheckActors(ruleDefinitions.Nodes, emitError, modData);
 		}
 	}

--- a/OpenRA.Mods.Common/Lint/CheckUnknownWeaponFields.cs
+++ b/OpenRA.Mods.Common/Lint/CheckUnknownWeaponFields.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Lint
 					// Removals can never define children or values
 					if (field.Key.StartsWith("-", StringComparison.Ordinal))
 					{
-						if (field.Value.Nodes.Count > 0)
+						if (field.Value.Nodes.Length > 0)
 							emitError($"{field.Location} `{field.Key}` defines child nodes, which is not valid for removals.");
 
 						if (!string.IsNullOrEmpty(field.Value.Value))
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Lint
 			foreach (var f in mapFiles)
 				CheckWeapons(MiniYaml.FromStream(fileSystem.Open(f), f), emitError, emitWarning, modData);
 
-			if (weaponDefinitions.Nodes.Count > 0)
+			if (weaponDefinitions.Nodes.Length > 0)
 				CheckWeapons(weaponDefinitions.Nodes, emitError, emitWarning, modData);
 		}
 	}

--- a/OpenRA.Mods.Common/Lint/CheckWorldAndPlayerInherits.cs
+++ b/OpenRA.Mods.Common/Lint/CheckWorldAndPlayerInherits.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Lint
 			foreach (var actorNode in nodes)
 			{
 				var inherits = inheritsMap.GetOrAdd(actorNode.Key, _ => new List<string>());
-				foreach (var inheritsNode in actorNode.ChildrenMatching("Inherits"))
+				foreach (var inheritsNode in new MiniYamlNodeBuilder(actorNode).ChildrenMatching("Inherits"))
 					inherits.Add(inheritsNode.Value.Value);
 			}
 

--- a/OpenRA.Mods.Common/ModContent.cs
+++ b/OpenRA.Mods.Common/ModContent.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 
@@ -56,7 +57,7 @@ namespace OpenRA
 			public readonly MiniYaml IDFiles;
 
 			[FieldLoader.Ignore]
-			public readonly List<MiniYamlNode> Install;
+			public readonly ImmutableArray<MiniYamlNode> Install;
 
 			public readonly string TooltipText;
 

--- a/OpenRA.Mods.Common/Terrain/TerrainInfo.cs
+++ b/OpenRA.Mods.Common/Terrain/TerrainInfo.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Terrain
 			}
 			else
 			{
-				tileInfo = new TerrainTileInfo[nodes.Count];
+				tileInfo = new TerrainTileInfo[nodes.Length];
 
 				var i = 0;
 				foreach (var node in nodes)

--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -275,7 +276,7 @@ namespace OpenRA.Mods.Common.Traits
 			};
 		}
 
-		void IGameSaveTraitData.ResolveTraitData(Actor self, List<MiniYamlNode> data)
+		void IGameSaveTraitData.ResolveTraitData(Actor self, ImmutableArray<MiniYamlNode> data)
 		{
 			if (self.World.IsReplay)
 				return;

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -211,7 +212,7 @@ namespace OpenRA.Mods.Common.Traits
 			};
 		}
 
-		void IGameSaveTraitData.ResolveTraitData(Actor self, List<MiniYamlNode> data)
+		void IGameSaveTraitData.ResolveTraitData(Actor self, ImmutableArray<MiniYamlNode> data)
 		{
 			if (self.World.IsReplay)
 				return;

--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Mods.Common.Traits.BotModules.Squads;
 using OpenRA.Primitives;
@@ -407,7 +408,7 @@ namespace OpenRA.Mods.Common.Traits
 			};
 		}
 
-		void IGameSaveTraitData.ResolveTraitData(Actor self, List<MiniYamlNode> data)
+		void IGameSaveTraitData.ResolveTraitData(Actor self, ImmutableArray<MiniYamlNode> data)
 		{
 			if (self.World.IsReplay)
 				return;

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/Squad.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/Squad.cs
@@ -84,16 +84,15 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 
 		public MiniYaml Serialize()
 		{
-			var nodes = new MiniYaml("", new List<MiniYamlNode>()
+			var nodes = new List<MiniYamlNode>()
 			{
 				new MiniYamlNode("Type", FieldSaver.FormatValue(Type)),
 				new MiniYamlNode("Units", FieldSaver.FormatValue(Units.Select(a => a.ActorID).ToArray())),
-			});
-
+			};
 			if (Target.Type == TargetType.Actor)
-				nodes.Nodes.Add(new MiniYamlNode("Target", FieldSaver.FormatValue(Target.Actor.ActorID)));
+				nodes.Add(new MiniYamlNode("Target", FieldSaver.FormatValue(Target.Actor.ActorID)));
 
-			return nodes;
+			return new MiniYaml("", nodes);
 		}
 
 		public static Squad Deserialize(IBot bot, SquadManagerBotModule squadManager, MiniYaml yaml)

--- a/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -222,7 +223,7 @@ namespace OpenRA.Mods.Common.Traits
 			};
 		}
 
-		void IGameSaveTraitData.ResolveTraitData(Actor self, List<MiniYamlNode> data)
+		void IGameSaveTraitData.ResolveTraitData(Actor self, ImmutableArray<MiniYamlNode> data)
 		{
 			if (self.World.IsReplay)
 				return;

--- a/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -221,7 +222,7 @@ namespace OpenRA.Mods.Common.Traits
 			};
 		}
 
-		void IGameSaveTraitData.ResolveTraitData(Actor self, List<MiniYamlNode> data)
+		void IGameSaveTraitData.ResolveTraitData(Actor self, ImmutableArray<MiniYamlNode> data)
 		{
 			if (self.World.IsReplay)
 				return;

--- a/OpenRA.Mods.Common/Traits/Player/GameSaveViewportManager.cs
+++ b/OpenRA.Mods.Common/Traits/Player/GameSaveViewportManager.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Traits;
@@ -49,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 			return nodes;
 		}
 
-		void IGameSaveTraitData.ResolveTraitData(Actor self, List<MiniYamlNode> data)
+		void IGameSaveTraitData.ResolveTraitData(Actor self, ImmutableArray<MiniYamlNode> data)
 		{
 			var viewportNode = data.FirstOrDefault(n => n.Key == "Viewport");
 			if (viewportNode != null)

--- a/OpenRA.Mods.Common/Traits/World/ControlGroups.cs
+++ b/OpenRA.Mods.Common/Traits/World/ControlGroups.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -132,7 +133,7 @@ namespace OpenRA.Mods.Common.Traits
 			};
 		}
 
-		void IGameSaveTraitData.ResolveTraitData(Actor self, List<MiniYamlNode> data)
+		void IGameSaveTraitData.ResolveTraitData(Actor self, ImmutableArray<MiniYamlNode> data)
 		{
 			var groupsNode = data.FirstOrDefault(n => n.Key == "Groups");
 			if (groupsNode != null)

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Traits
 		protected static object LoadSpeeds(MiniYaml y)
 		{
 			var speeds = y.ToDictionary()["TerrainSpeeds"].Nodes;
-			var ret = new Dictionary<string, TerrainInfo>(speeds.Count);
+			var ret = new Dictionary<string, TerrainInfo>(speeds.Length);
 			foreach (var t in speeds)
 			{
 				var speed = FieldLoader.GetValue<int>("speed", t.Value.Value);

--- a/OpenRA.Mods.Common/Traits/World/Selection.cs
+++ b/OpenRA.Mods.Common/Traits/World/Selection.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -182,7 +183,7 @@ namespace OpenRA.Mods.Common.Traits
 			};
 		}
 
-		void IGameSaveTraitData.ResolveTraitData(Actor self, List<MiniYamlNode> data)
+		void IGameSaveTraitData.ResolveTraitData(Actor self, ImmutableArray<MiniYamlNode> data)
 		{
 			var selectionNode = data.FirstOrDefault(n => n.Key == "Selection");
 			if (selectionNode != null)

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/AddPipDecorationTraits.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/AddPipDecorationTraits.cs
@@ -72,9 +72,9 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			harvesterPipLocations.Clear();
 		}
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
-			var addNodes = new List<MiniYamlNode>();
+			var addNodes = new List<MiniYamlNodeBuilder>();
 
 			foreach (var selectionDecorations in actorNode.ChildrenMatching("SelectionDecorations"))
 			{
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 			foreach (var ammoPool in actorNode.ChildrenMatching("AmmoPool"))
 			{
-				var ammoPips = new MiniYamlNode("WithAmmoPipsDecoration", "");
+				var ammoPips = new MiniYamlNodeBuilder("WithAmmoPipsDecoration", "");
 				ammoPips.AddNode("Position", "BottomLeft");
 				ammoPips.AddNode("RequiresSelection", "true");
 
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 					var pipCount = pipCountNode.NodeValue<int>();
 					if (pipCount == 0)
 					{
-						addNodes.Add(new MiniYamlNode("-" + ammoPips.Key, ""));
+						addNodes.Add(new MiniYamlNodeBuilder("-" + ammoPips.Key, ""));
 						continue;
 					}
 
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 			foreach (var cargo in actorNode.ChildrenMatching("Cargo"))
 			{
-				var cargoPips = new MiniYamlNode("WithCargoPipsDecoration", "");
+				var cargoPips = new MiniYamlNodeBuilder("WithCargoPipsDecoration", "");
 				cargoPips.AddNode("Position", "BottomLeft");
 				cargoPips.AddNode("RequiresSelection", "true");
 
@@ -141,7 +141,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 					var pipCount = pipCountNode.NodeValue<int>();
 					if (pipCount == 0)
 					{
-						addNodes.Add(new MiniYamlNode("-" + cargoPips.Key, ""));
+						addNodes.Add(new MiniYamlNodeBuilder("-" + cargoPips.Key, ""));
 						continue;
 					}
 
@@ -171,7 +171,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 			foreach (var harvester in actorNode.ChildrenMatching("Harvester"))
 			{
-				var harvesterPips = new MiniYamlNode("WithHarvesterPipsDecoration", "");
+				var harvesterPips = new MiniYamlNodeBuilder("WithHarvesterPipsDecoration", "");
 				harvesterPips.AddNode("Position", "BottomLeft");
 				harvesterPips.AddNode("RequiresSelection", "true");
 
@@ -189,7 +189,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 					var pipCount = pipCountNode.NodeValue<int>();
 					if (pipCount == 0)
 					{
-						addNodes.Add(new MiniYamlNode("-" + harvesterPips.Key, ""));
+						addNodes.Add(new MiniYamlNodeBuilder("-" + harvesterPips.Key, ""));
 						continue;
 					}
 
@@ -220,7 +220,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 			foreach (var storesResources in actorNode.ChildrenMatching("StoresResources"))
 			{
-				var storagePips = new MiniYamlNode("WithResourceStoragePipsDecoration", "");
+				var storagePips = new MiniYamlNodeBuilder("WithResourceStoragePipsDecoration", "");
 				storagePips.AddNode("Position", "BottomLeft");
 				storagePips.AddNode("RequiresSelection", "true");
 
@@ -231,7 +231,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 					var pipCount = pipCountNode.NodeValue<int>();
 					if (pipCount == 0)
 					{
-						addNodes.Add(new MiniYamlNode("-" + storagePips.Key, ""));
+						addNodes.Add(new MiniYamlNodeBuilder("-" + storagePips.Key, ""));
 						continue;
 					}
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ChangeTargetLineDelayToMilliseconds.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ChangeTargetLineDelayToMilliseconds.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			"Going forward, the value of the `Delay` attribute of the `DrawLineToTarget` trait will be\n" +
 			"interpreted as milliseconds instead of ticks.\n";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var dltt in actorNode.ChildrenMatching("DrawLineToTarget", includeRemovals: false))
 			{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ConvertSupportPowerRangesToFootprint.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ConvertSupportPowerRangesToFootprint.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		static readonly string[] AffectedTraits = new string[] { "GrantExternalConditionPower", "ChronoshiftPower" };
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var at in AffectedTraits)
 				foreach (var trait in actorNode.ChildrenMatching(at))
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			yield break;
 		}
 
-		void UpdatePower(MiniYamlNode power)
+		void UpdatePower(MiniYamlNodeBuilder power)
 		{
 			var range = 1;
 			var rangeNode = power.LastChildMatching("Range");
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			}
 
 			var size = 2 * range + 1;
-			power.AddNode(new MiniYamlNode("Dimensions", size.ToString() + ", " + size.ToString()));
+			power.AddNode(new MiniYamlNodeBuilder("Dimensions", size.ToString() + ", " + size.ToString()));
 
 			var footprint = string.Empty;
 
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				footprint += ' ';
 			}
 
-			power.AddNode(new MiniYamlNode("Footprint", footprint));
+			power.AddNode(new MiniYamlNodeBuilder("Footprint", footprint));
 		}
 
 		readonly List<string> locations = new();

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/CreateFlashPaletteEffectWarhead.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/CreateFlashPaletteEffectWarhead.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		readonly List<Tuple<string, string, string>> weaponsToUpdate = new();
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			var nukePowerTraits = actorNode.ChildrenMatching("NukePower");
 			foreach (var nukePowerTrait in nukePowerTraits)

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ModernizeDecorationTraits.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ModernizeDecorationTraits.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			locations.Clear();
 		}
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			var locationKey = $"{actorNode.Key} ({actorNode.Location.Filename})";
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/MoveClassicFacingFudge.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/MoveClassicFacingFudge.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			locations.Clear();
 		}
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var bo in actorNode.ChildrenMatching("BodyOrientation"))
 			{
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			yield break;
 		}
 
-		public override IEnumerable<string> UpdateSequenceNode(ModData modData, MiniYamlNode sequenceNode)
+		public override IEnumerable<string> UpdateSequenceNode(ModData modData, MiniYamlNodeBuilder sequenceNode)
 		{
 			foreach (var sequence in sequenceNode.Value.Nodes)
 			{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RemoveConditionManager.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RemoveConditionManager.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "ConditionManager trait has been removed. Its functionality has been integrated into the actor itself.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			actorNode.RemoveNodes("ConditionManager");
 			yield break;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RemoveLaysTerrain.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RemoveLaysTerrain.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "'LaysTerrain' was removed.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			if (actorNode.RemoveNodes("LaysTerrain") > 0)
 				yield return $"'LaysTerrain' was removed from {actorNode.Key} ({actorNode.Location.Filename}) without replacement.\n";

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RemoveMuzzleSplitFacings.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RemoveMuzzleSplitFacings.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			"The same result can be created by using `Combine` in the sequence definitions to\n" +
 			"assemble the different facings sprites into a single sequence.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var a in actorNode.ChildrenMatching("Armament"))
 			{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RemoveTurnToDock.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RemoveTurnToDock.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			turningAircraft.Clear();
 		}
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			var aircraft = actorNode.LastChildMatching("Aircraft");
 			if (aircraft != null)

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RenameCircleOutline.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RenameCircleOutline.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "RenderDetectionCircle and RenderShroudCircle ContrastColor have been renamed to BorderColor for consistency.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var rdc in actorNode.ChildrenMatching("RenderDetectionCircle"))
 				rdc.RenameChildrenMatching("ContrastColor", "BorderColor");

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RenameHealCrateAction.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RenameHealCrateAction.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "The 'HealUnitsCrateAction' has been renamed to 'HealActorsCrateAction'.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var huca in actorNode.ChildrenMatching("HealUnitsCrateAction"))
 				huca.RenameKey("HealActorsCrateAction");

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RenameInfiltrationNotifications.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RenameInfiltrationNotifications.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "The InfiltrateForCash Notification has been renamed to be in line with new notification properties added.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var rp in actorNode.ChildrenMatching("InfiltrateForCash"))
 				rp.RenameChildrenMatching("Notification", "InfiltratedNotification");

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RenameSelfHealing.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RenameSelfHealing.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			"SelfHealing was renamed to ChangesHealth\n" +
 			"HealIfBelow was renamed to StartIfBelow.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var sh in actorNode.ChildrenMatching("SelfHealing"))
 			{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RenameSmudgeSmokeFields.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RenameSmudgeSmokeFields.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			"Renamed smoke-related properties on SmudgeLayer to be in line with comparable properties.\n" +
 			"Additionally, set the *Chance, *Image and *Sequences defaults to null.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var layer in actorNode.ChildrenMatching("SmudgeLayer"))
 			{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RenameStances.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RenameStances.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			("TooltipDescription", "ValidStances", "ValidRelationships")
 		};
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var (traitName, oldName, newName) in traits)
 				foreach (var traitNode in actorNode.ChildrenMatching(traitName))
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			yield break;
 		}
 
-		public override IEnumerable<string> UpdateWeaponNode(ModData modData, MiniYamlNode weaponNode)
+		public override IEnumerable<string> UpdateWeaponNode(ModData modData, MiniYamlNodeBuilder weaponNode)
 		{
 			foreach (var projectileNode in weaponNode.ChildrenMatching("Projectile"))
 				projectileNode.RenameChildrenMatching("ValidBounceBlockerStances", "ValidBounceBlockerRelationships");

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RenameWithNukeLaunch.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RenameWithNukeLaunch.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "`WithNukeLaunchAnimation` has been renamed to `WithSupportPowerActivationAnimation` and `WithNukeLaunchOverlay` to `WithSupportPowerActivationOverlay`.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			actorNode.RenameChildrenMatching("WithNukeLaunchAnimation", "WithSupportPowerActivationAnimation", true);
 			actorNode.RenameChildrenMatching("WithNukeLaunchOverlay", "WithSupportPowerActivationOverlay", true);

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ReplaceBurns.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ReplaceBurns.cs
@@ -19,9 +19,9 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "Burns can be replaced using WithIdleOverlay and ChangesHealth.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
-			var addNodes = new List<MiniYamlNode>();
+			var addNodes = new List<MiniYamlNodeBuilder>();
 
 			foreach (var burns in actorNode.ChildrenMatching("Burns"))
 			{
@@ -34,13 +34,13 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				var interval = burns.LastChildMatching("Interval");
 				var intervalValue = interval != null ? interval.NodeValue<int>() : 8;
 
-				var overlay = new MiniYamlNode("WithIdleOverlay@Burns", "");
+				var overlay = new MiniYamlNodeBuilder("WithIdleOverlay@Burns", "");
 				overlay.AddNode("Image", FieldSaver.FormatValue("fire"));
 				overlay.AddNode("Sequence", FieldSaver.FormatValue(animValue));
 				overlay.AddNode("IsDecoration", FieldSaver.FormatValue(true));
 				addNodes.Add(overlay);
 
-				var changesHealth = new MiniYamlNode("ChangesHealth", "");
+				var changesHealth = new MiniYamlNodeBuilder("ChangesHealth", "");
 				changesHealth.AddNode("Step", FieldSaver.FormatValue(-damageValue));
 				changesHealth.AddNode("StartIfBelow", FieldSaver.FormatValue(101));
 				changesHealth.AddNode("Delay", FieldSaver.FormatValue(intervalValue));

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ReplaceFacingAngles.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ReplaceFacingAngles.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			}
 		}
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var kv in TraitFields)
 			{
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			yield break;
 		}
 
-		public override IEnumerable<string> UpdateWeaponNode(ModData modData, MiniYamlNode weaponNode)
+		public override IEnumerable<string> UpdateWeaponNode(ModData modData, MiniYamlNodeBuilder weaponNode)
 		{
 			foreach (var projectileNode in weaponNode.ChildrenMatching("Projectile"))
 			{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/SpawnActorPowerDefaultEffect.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/SpawnActorPowerDefaultEffect.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "The 'EffectSequence' of 'SpawnActorPower' is unset by default.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var spawnActorPower in actorNode.ChildrenMatching("SpawnActorPower"))
 			{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/SplitDamagedByTerrain.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/SplitDamagedByTerrain.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "'DamageThreshold' and 'StartOnThreshold' are no longer supported and removed from 'DamagedByTerrain'.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var damaged in actorNode.ChildrenMatching("DamagedByTerrain", includeRemovals: false))
 			{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/UpdateMapInits.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/UpdateMapInits.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			}
 		}
 
-		public override IEnumerable<string> UpdateMapActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateMapActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			if (actorNode.RemoveNodes("Plugs") > 0)
 				yield return $"Initial plugs for actor {actorNode.Key} will need to be reconfigured using the map editor.";
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				facing.ReplaceValue(FieldSaver.FormatValue(bodyFacing));
 			}
 
-			var removeNodes = new List<MiniYamlNode>();
+			var removeNodes = new List<MiniYamlNodeBuilder>();
 			foreach (var facing in actorNode.ChildrenMatching("TurretFacing"))
 			{
 				var turretFacing = WAngle.FromFacing(facing.NodeValue<int>()) - bodyFacing;
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				actorNode.Value.Nodes.Remove(node);
 		}
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var turret in actorNode.ChildrenMatching("Turreted"))
 				turret.RemoveNodes("PreviewFacing");

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/UpdateTilesetColors.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/UpdateTilesetColors.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "The LeftColor and RightColor keys in tilesets have been renamed to MinColor and MaxColor to reflect their proper usage.";
 
-		public override IEnumerable<string> UpdateTilesetNode(ModData modData, MiniYamlNode tilesetNode)
+		public override IEnumerable<string> UpdateTilesetNode(ModData modData, MiniYamlNodeBuilder tilesetNode)
 		{
 			if (tilesetNode.Key == "Templates")
 			{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/AddControlGroups.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/AddControlGroups.cs
@@ -20,11 +20,11 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "A new trait ControlGroups was added, splitting logic away from Selection.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			if (actorNode.ChildrenMatching("Selection").Any(x => !x.IsRemoval())
 			    && !actorNode.ChildrenMatching("ControlGroups").Any())
-				actorNode.AddNode(new MiniYamlNode("ControlGroups", ""));
+				actorNode.AddNode(new MiniYamlNodeBuilder("ControlGroups", ""));
 
 			yield break;
 		}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/AttackBomberFacingTolerance.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/AttackBomberFacingTolerance.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "The tolerance for attack angle was defined twice on AttackBomber. This override has to be defined in the rules now.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var attackBomber in actorNode.ChildrenMatching("AttackBomber", includeRemovals: false))
 			{
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				if (facingTolerance != null)
 					continue;
 
-				var facingToleranceNode = new MiniYamlNode("FacingTolerance", FieldSaver.FormatValue(new WAngle(8)));
+				var facingToleranceNode = new MiniYamlNodeBuilder("FacingTolerance", FieldSaver.FormatValue(new WAngle(8)));
 				attackBomber.AddNode(facingToleranceNode);
 			}
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/AttackFrontalFacingTolerance.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/AttackFrontalFacingTolerance.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "The tolerance for the attack angle was defined twice on AttackFrontal. This override has to be defined in the rules now.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var attackFrontal in actorNode.ChildrenMatching("AttackFrontal", includeRemovals: false))
 			{
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				if (facingTolerance != null)
 					continue;
 
-				var facingToleranceNode = new MiniYamlNode("FacingTolerance", FieldSaver.FormatValue(WAngle.Zero));
+				var facingToleranceNode = new MiniYamlNodeBuilder("FacingTolerance", FieldSaver.FormatValue(WAngle.Zero));
 				attackFrontal.AddNode(facingToleranceNode);
 			}
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/ConvertBoundsToWDist.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/ConvertBoundsToWDist.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 		readonly string[] traits = { "Interactable", "Selectable", "IsometricSelectable" };
 		readonly string[] fields = { "Bounds", "DecorationBounds" };
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			var grid = modData.Manifest.Get<MapGrid>();
 			var tileSize = grid.TileSize;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RemoveDomainIndex.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RemoveDomainIndex.cs
@@ -19,12 +19,12 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "The DomainIndex trait was removed from World. Two overlay traits were added at the same time.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			if (actorNode.RemoveNodes("DomainIndex") > 0)
 			{
-				actorNode.AddNode(new MiniYamlNode("PathFinderOverlay", ""));
-				actorNode.AddNode(new MiniYamlNode("HierarchicalPathFinderOverlay", ""));
+				actorNode.AddNode(new MiniYamlNodeBuilder("PathFinderOverlay", ""));
+				actorNode.AddNode(new MiniYamlNodeBuilder("HierarchicalPathFinderOverlay", ""));
 			}
 
 			yield break;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RemovePlaceBuildingPalette.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RemovePlaceBuildingPalette.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			locations.Clear();
 		}
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			var removed = 0;
 			foreach (var node in actorNode.ChildrenMatching("ActorPreviewPlaceBuildingPreview"))

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RemovePlayerHighlightPalette.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RemovePlayerHighlightPalette.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "PlayerHighlightPalette trait has been removed. Its functionality is now automatically provided by the engine.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			actorNode.RemoveNodes("PlayerHighlightPalette");
 			yield break;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RemoveRenderSpritesScale.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RemoveRenderSpritesScale.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "The Scale option was removed from RenderSprites. Scale can now be defined on individual sequence definitions.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var renderSprites in actorNode.ChildrenMatching("RenderSprites"))
 				if (renderSprites.RemoveNodes("Scale") > 0)

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RemoveResourceType.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RemoveResourceType.cs
@@ -21,15 +21,15 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			"The ResourceType trait has been removed, and resource definitions moved to the\n" +
 			"ResourceLayer, EditorResourceLayer, ResourceRenderer, and PlayerResources traits.";
 
-		MiniYaml resourceLayer;
-		MiniYaml resourceRenderer;
-		MiniYaml values;
+		MiniYamlBuilder resourceLayer;
+		MiniYamlBuilder resourceRenderer;
+		MiniYamlBuilder values;
 
 		public override IEnumerable<string> BeforeUpdate(ModData modData)
 		{
-			resourceLayer = new MiniYaml("");
-			resourceRenderer = new MiniYaml("");
-			values = new MiniYaml("");
+			resourceLayer = new MiniYamlBuilder("");
+			resourceRenderer = new MiniYamlBuilder("");
+			values = new MiniYamlBuilder("");
 			yield break;
 		}
 
@@ -54,17 +54,17 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 					"You must define a custom ResourceLayer subclass if you want to customize the default behaviour.";
 		}
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var resourceNode in actorNode.ChildrenMatching("ResourceType"))
 			{
 				var typeNode = resourceNode.LastChildMatching("Type");
 				if (typeNode != null)
 				{
-					var resourceLayerNode = new MiniYamlNode(typeNode.Value.Value, "");
+					var resourceLayerNode = new MiniYamlNodeBuilder(new MiniYamlNode(typeNode.Value.Value, ""));
 					resourceLayer.Nodes.Add(resourceLayerNode);
 
-					var resourceRendererNode = new MiniYamlNode(typeNode.Value.Value, "");
+					var resourceRendererNode = new MiniYamlNodeBuilder(new MiniYamlNode(typeNode.Value.Value, ""));
 					resourceRenderer.Nodes.Add(resourceRendererNode);
 
 					var indexNode = resourceNode.LastChildMatching("ResourceType");
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 					var valueNode = resourceNode.LastChildMatching("ValuePerUnit");
 					if (valueNode != null)
-						values.Nodes.Add(new MiniYamlNode(typeNode.Value.Value, valueNode.Value.Value));
+						values.Nodes.Add(new MiniYamlNodeBuilder(typeNode.Value.Value, valueNode.Value.Value));
 
 					var imageNode = resourceNode.LastChildMatching("Image");
 					if (imageNode != null)

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RemoveSmokeTrailWhenDamaged.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RemoveSmokeTrailWhenDamaged.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			locations.Clear();
 		}
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			var locationKey = $"{actorNode.Key} ({actorNode.Location.Filename})";
 			var anyConditionalSmokeTrail = false;
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 			if (anyConditionalSmokeTrail)
 			{
-				var grantCondition = new MiniYamlNode("GrantConditionOnDamageState@SmokeTrail", "");
+				var grantCondition = new MiniYamlNodeBuilder("GrantConditionOnDamageState@SmokeTrail", "");
 				grantCondition.AddNode("Condition", FieldSaver.FormatValue("enable-smoke"));
 				actorNode.AddNode(grantCondition);
 			}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RenameCloakTypes.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RenameCloakTypes.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "Rename 'CloakTypes' to 'DetectionTypes' in order to make it clearer as well as make space for 'CloakType' in Cloak";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var traitNode in actorNode.ChildrenMatching("Cloak"))
 				traitNode.RenameChildrenMatching("CloakTypes", "DetectionTypes");

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RenameContrailProperties.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RenameContrailProperties.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "Rename contrail color properties `Color` to `StartColor` and `UsePlayerColor` to `StartColorUsePlayerColor` in traits and weapons to account for added `EndColor` functionality";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var traitNode in actorNode.ChildrenMatching("Contrail"))
 			{
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			yield break;
 		}
 
-		public override IEnumerable<string> UpdateWeaponNode(ModData modData, MiniYamlNode weaponNode)
+		public override IEnumerable<string> UpdateWeaponNode(ModData modData, MiniYamlNodeBuilder weaponNode)
 		{
 			foreach (var traitNode in weaponNode.ChildrenMatching("Projectile").Where(n => n.Value.Value == "Missile"))
 			{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RenameMPTraits.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RenameMPTraits.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			"'SpawnMPUnits' was renamed to 'SpawnStartingUnits', 'MPStartUnits' to 'StartingUnits', 'MPStartLocations' to " +
 			"'MapStartingLocations', and 'CreateMPPlayers' to 'CreateMapPlayers'.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			actorNode.RenameChildrenMatching("SpawnMPUnits", "SpawnStartingUnits");
 			actorNode.RenameChildrenMatching("MPStartUnits", "StartingUnits");

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RenameSupportPowerDescription.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RenameSupportPowerDescription.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 		public override string Name => "Support powers now use 'Name' and 'Description' fields like units.";
 		public override string Description => "'Description' was renamed to 'Name' and 'LongDesc' was renamed to 'Description'.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var traitNode in actorNode.ChildrenContaining("Power"))
 			{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/ReplaceCrateSecondsWithTicks.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/ReplaceCrateSecondsWithTicks.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			"by multiplying with 25 internally. Converted to use ticks like everything else.\n" +
 			"Also renamed Lifetime to Duration and ScaredyCat.PanicLength to PanicDuration to match other places.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var crateNode in actorNode.ChildrenMatching("Crate"))
 			{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/ReplaceResourceValueModifiers.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/ReplaceResourceValueModifiers.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 		public override string Description => "The HarvesterResourceMultiplier trait has been removed, and the RefineryResourceMultiplier trait renamed to ResourceValueMultiplier.";
 
 		bool notified;
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			if (actorNode.RemoveNodes("HarvesterResourceModifier") > 0 && !notified)
 			{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/ReplaceSequenceEmbeddedPalette.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/ReplaceSequenceEmbeddedPalette.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "The EmbeddedPalette sequence option was replaced with a boolean HasEmbeddedPalette.";
 
-		public override IEnumerable<string> UpdateSequenceNode(ModData modData, MiniYamlNode sequenceNode)
+		public override IEnumerable<string> UpdateSequenceNode(ModData modData, MiniYamlNodeBuilder sequenceNode)
 		{
 			foreach (var sequence in sequenceNode.Value.Nodes)
 				if (sequence.RemoveNodes("EmbeddedPalette") > 0)

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/ReplaceShadowPalette.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/ReplaceShadowPalette.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			locations.Clear();
 		}
 
-		public override IEnumerable<string> UpdateWeaponNode(ModData modData, MiniYamlNode weaponNode)
+		public override IEnumerable<string> UpdateWeaponNode(ModData modData, MiniYamlNodeBuilder weaponNode)
 		{
 			foreach (var projectileNode in weaponNode.ChildrenMatching("Projectile"))
 				if (projectileNode.RemoveNodes("ShadowPalette") > 0)
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			yield break;
 		}
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var node in actorNode.ChildrenMatching("WithShadow"))
 				if (node.RemoveNodes("Palette") > 0)

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/ReplaceWithColoredOverlayPalette.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/ReplaceWithColoredOverlayPalette.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			locations.Clear();
 		}
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var node in actorNode.ChildrenMatching("WithColoredOverlay"))
 				if (node.RemoveNodes("Palette") > 0)

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/SplitNukePowerMissileImage.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/SplitNukePowerMissileImage.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			"NukePower used MissileWeapon field for as the name for missile image too.\n" +
 			"This function has been moved to its own MissileImage field.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var nukePowerNode in actorNode.ChildrenMatching("NukePower"))
 			{
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				if (missileWeaponNode != null)
 				{
 					var weapon = missileWeaponNode.NodeValue<string>();
-					nukePowerNode.AddNode(new MiniYamlNode("MissileImage", weapon));
+					nukePowerNode.AddNode(new MiniYamlNodeBuilder("MissileImage", weapon));
 				}
 			}
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UnhardcodeBaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UnhardcodeBaseBuilderBotModule.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 {
 	public class UnhardcodeBaseBuilderBotModule : UpdateRule, IBeforeUpdateActors
 	{
-		MiniYamlNode defences;
+		MiniYamlNodeBuilder defences;
 
 		// Excludes AttackBomber and AttackTDGunboatTurreted as actors with these AttackBase traits aren't supposed to be controlled.
 		readonly string[] attackBase = { "AttackLeap", "AttackPopupTurreted", "AttackAircraft", "AttackTesla", "AttackCharges", "AttackFollow", "AttackTurreted", "AttackFrontal", "AttackGarrisoned", "AttackOmni", "AttackSwallow" };
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "DefenseTypes were added.";
 
-		public IEnumerable<string> BeforeUpdateActors(ModData modData, List<MiniYamlNode> resolvedActors)
+		public IEnumerable<string> BeforeUpdateActors(ModData modData, List<MiniYamlNodeBuilder> resolvedActors)
 		{
 			var defences = new List<string>();
 
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				}
 			}
 
-			this.defences = new MiniYamlNode("DefenseTypes", FieldSaver.FormatValue(defences));
+			this.defences = new MiniYamlNodeBuilder("DefenseTypes", FieldSaver.FormatValue(defences));
 
 			yield break;
 		}
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			anyAdded = false;
 		}
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var squadManager in actorNode.ChildrenMatching("BaseBuilderBotModule", includeRemovals: false))
 			{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UnhardcodeSquadManager.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UnhardcodeSquadManager.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 {
 	public class UnhardcodeSquadManager : UpdateRule, IBeforeUpdateActors
 	{
-		readonly List<MiniYamlNode> addNodes = new();
+		readonly List<MiniYamlNodeBuilder> addNodes = new();
 
 		// Excludes AttackBomber and AttackTDGunboatTurreted as actors with these AttackBase traits aren't supposed to be controlled.
 		readonly string[] attackBase = { "AttackLeap", "AttackPopupTurreted", "AttackAircraft", "AttackTesla", "AttackCharges", "AttackFollow", "AttackTurreted", "AttackFrontal", "AttackGarrisoned", "AttackOmni", "AttackSwallow" };
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "AirUnitsTypes and ProtectionTypes were added.";
 
-		public IEnumerable<string> BeforeUpdateActors(ModData modData, List<MiniYamlNode> resolvedActors)
+		public IEnumerable<string> BeforeUpdateActors(ModData modData, List<MiniYamlNodeBuilder> resolvedActors)
 		{
 			var aircraft = new List<string>();
 			var vips = new List<string>();
@@ -106,15 +106,15 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				}
 			}
 
-			addNodes.Add(new MiniYamlNode("AirUnitsTypes", FieldSaver.FormatValue(aircraft)));
-			addNodes.Add(new MiniYamlNode("ProtectionTypes", FieldSaver.FormatValue(vips)));
+			addNodes.Add(new MiniYamlNodeBuilder("AirUnitsTypes", FieldSaver.FormatValue(aircraft)));
+			addNodes.Add(new MiniYamlNodeBuilder("ProtectionTypes", FieldSaver.FormatValue(vips)));
 
 			yield break;
 		}
 
 		bool anyAdded = false;
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var squadManager in actorNode.ChildrenMatching("SquadManagerBotModule", includeRemovals: false))
 			{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UnhardcodeVeteranProductionIconOverlay.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UnhardcodeVeteranProductionIconOverlay.cs
@@ -32,12 +32,12 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			locations.Clear();
 		}
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var veteranProductionIconOverlay in actorNode.ChildrenMatching("VeteranProductionIconOverlay"))
 			{
 				veteranProductionIconOverlay.RenameKey("ProductionIconOverlayManager");
-				veteranProductionIconOverlay.AddNode(new MiniYamlNode("Type", "Veterancy"));
+				veteranProductionIconOverlay.AddNode(new MiniYamlNodeBuilder("Type", "Veterancy"));
 			}
 
 			foreach (var producibleWithLevel in actorNode.ChildrenMatching("ProducibleWithLevel"))

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UseMillisecondsForSounds.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UseMillisecondsForSounds.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			"PowerManager.AdviceInterval and PlayerResources.InsufficientFundsNotificationDelay were using ticks.\n" +
 			"Converted all of those to use real milliseconds instead.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var announce in actorNode.ChildrenMatching("AnnounceOnKill"))
 			{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230225/AddColorPickerValueRange.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230225/AddColorPickerValueRange.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 		public override string Description =>
 			"Each preset color can now have their brightness specified. SimilarityThreshold range was changed.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			var manager = actorNode.LastChildMatching("ColorPickerManager");
 			if (manager == null)

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230225/ProductionTabsWidgetAddTabButtonCollection.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230225/ProductionTabsWidgetAddTabButtonCollection.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 		public override string Description =>
 			"Change the field name from Button to TabButton and add ArrowButton, if Button field was set.";
 
-		public override IEnumerable<string> UpdateChromeNode(ModData modData, MiniYamlNode chromeNode)
+		public override IEnumerable<string> UpdateChromeNode(ModData modData, MiniYamlNodeBuilder chromeNode)
 		{
 			if (!chromeNode.KeyMatches("ProductionTabs"))
 				yield break;
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			}
 
 			if (buttonCollection != null)
-				chromeNode.AddNode(new MiniYamlNode("ArrowButton", buttonCollection));
+				chromeNode.AddNode(new MiniYamlNodeBuilder("ArrowButton", buttonCollection));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230225/RemoveExperienceFromInfiltrates.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230225/RemoveExperienceFromInfiltrates.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			locations.Clear();
 		}
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			var removed = false;
 			foreach (var node in actorNode.ChildrenMatching("Infiltrates"))

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230225/RemoveNegativeSequenceLength.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230225/RemoveNegativeSequenceLength.cs
@@ -21,9 +21,9 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "Negative sequence length is no longer allowed, define individual frames in reverse instead.";
 
-		List<MiniYamlNode> resolvedImagesNodes;
+		List<MiniYamlNodeBuilder> resolvedImagesNodes;
 
-		public IEnumerable<string> BeforeUpdateSequences(ModData modData, List<MiniYamlNode> resolvedImagesNodes)
+		public IEnumerable<string> BeforeUpdateSequences(ModData modData, List<MiniYamlNodeBuilder> resolvedImagesNodes)
 		{
 			this.resolvedImagesNodes = resolvedImagesNodes;
 			yield break;
@@ -31,12 +31,12 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		readonly Queue<Action> actionQueue = new();
 
-		static MiniYamlNode GetNode(string key, MiniYamlNode node, MiniYamlNode defaultNode)
+		static MiniYamlNodeBuilder GetNode(string key, MiniYamlNodeBuilder node, MiniYamlNodeBuilder defaultNode)
 		{
 			return node.LastChildMatching(key, includeRemovals: false) ?? defaultNode?.LastChildMatching(key, includeRemovals: false);
 		}
 
-		public override IEnumerable<string> UpdateSequenceNode(ModData modData, MiniYamlNode sequenceNode)
+		public override IEnumerable<string> UpdateSequenceNode(ModData modData, MiniYamlNodeBuilder sequenceNode)
 		{
 			var defaultNode = sequenceNode.LastChildMatching("Defaults");
 			var defaultLengthNode = defaultNode == null ? null : GetNode("Length", defaultNode, null);

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230225/RemoveSequenceHasEmbeddedPalette.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230225/RemoveSequenceHasEmbeddedPalette.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			locations.Clear();
 		}
 
-		public override IEnumerable<string> UpdateSequenceNode(ModData modData, MiniYamlNode imageNode)
+		public override IEnumerable<string> UpdateSequenceNode(ModData modData, MiniYamlNodeBuilder imageNode)
 		{
 			foreach (var sequenceNode in imageNode.Value.Nodes)
 				sequenceNode.RemoveNodes("HasEmbeddedPalette");
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			yield break;
 		}
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var traitNode in actorNode.ChildrenMatching("PaletteFromEmbeddedSpritePalette"))
 			{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230225/RemoveTSRefinery.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230225/RemoveTSRefinery.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "TiberianSunRefinery was removed, use Refinery instead.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			actorNode.RenameChildrenMatching("TiberianSunRefinery", "Refinery");
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230225/RenameContrailWidth.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230225/RenameContrailWidth.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "Rename contrail `TrailWidth` to `StartWidth` in traits and weapons to acount for added `EndWidth` functionality";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var traitNode in actorNode.ChildrenMatching("Contrail"))
 				traitNode.RenameChildrenMatching("TrailWidth", "StartWidth");
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			yield break;
 		}
 
-		public override IEnumerable<string> UpdateWeaponNode(ModData modData, MiniYamlNode weaponNode)
+		public override IEnumerable<string> UpdateWeaponNode(ModData modData, MiniYamlNodeBuilder weaponNode)
 		{
 			foreach (var traitNode in weaponNode.ChildrenMatching("Projectile").Where(n => n.Value.Value == "Missile"))
 				traitNode.RenameChildrenMatching("ContrailWidth", "ContrailStartWidth");

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230225/RenameEngineerRepair.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230225/RenameEngineerRepair.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			"'EngineerRepair' was renamed to 'InstantlyRepairs' " +
 			"and 'EngineerRepairable' to 'InstantlyRepairable'.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			actorNode.RenameChildrenMatching("EngineerRepair", "InstantlyRepairs");
 			actorNode.RenameChildrenMatching("EngineerRepairable", "InstantlyRepairable");

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230225/RenameMcvCrateAction.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230225/RenameMcvCrateAction.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override string Description => "The 'GiveMcvCrateAction' has been renamed to 'GiveBaseBuilderCrateAction'.";
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			foreach (var node in actorNode.ChildrenMatching("GiveMcvCrateAction"))
 				node.RenameKey("GiveBaseBuilderCrateAction");

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230225/TextNotificationsDisplayWidgetRemoveTime.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230225/TextNotificationsDisplayWidgetRemoveTime.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 		public override string Description =>
 			"Change the field name from RemoveTime to DisplayDurationMs and convert the value from ticks to milliseconds";
 
-		public override IEnumerable<string> UpdateChromeNode(ModData modData, MiniYamlNode chromeNode)
+		public override IEnumerable<string> UpdateChromeNode(ModData modData, MiniYamlNodeBuilder chromeNode)
 		{
 			if (!chromeNode.KeyMatches("TextNotificationsDisplay"))
 				yield break;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/CopyIsometricSelectableHeight.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/CopyIsometricSelectableHeight.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			yield break;
 		}
 
-		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{
 			if (complete || actorNode.LastChildMatching("IsometricSelectable") != null)
 				yield break;
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			if (height == 24)
 				yield break;
 
-			var selection = new MiniYamlNode("IsometricSelectable", "");
+			var selection = new MiniYamlNodeBuilder("IsometricSelectable", "");
 			selection.AddNode("Height", FieldSaver.FormatValue(height));
 
 			actorNode.AddNode(selection);

--- a/OpenRA.Mods.Common/UpdateRules/UpdateRule.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateRule.cs
@@ -20,19 +20,19 @@ namespace OpenRA.Mods.Common.UpdateRules
 
 		/// <summary>Defines a transformation that is run on each top-level node in a yaml file set.</summary>
 		/// <returns>An enumerable of manual steps to be run by the user.</returns>
-		public delegate IEnumerable<string> TopLevelNodeTransform(ModData modData, MiniYamlNode node);
+		public delegate IEnumerable<string> TopLevelNodeTransform(ModData modData, MiniYamlNodeBuilder node);
 
 		/// <summary>Defines a transformation that is run on each widget node in a chrome yaml file set.</summary>
 		/// <returns>An enumerable of manual steps to be run by the user.</returns>
-		public delegate IEnumerable<string> ChromeNodeTransform(ModData modData, MiniYamlNode widgetNode);
+		public delegate IEnumerable<string> ChromeNodeTransform(ModData modData, MiniYamlNodeBuilder widgetNode);
 
-		public virtual IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode) { yield break; }
-		public virtual IEnumerable<string> UpdateWeaponNode(ModData modData, MiniYamlNode weaponNode) { yield break; }
-		public virtual IEnumerable<string> UpdateSequenceNode(ModData modData, MiniYamlNode sequenceNode) { yield break; }
-		public virtual IEnumerable<string> UpdateChromeNode(ModData modData, MiniYamlNode chromeNode) { yield break; }
-		public virtual IEnumerable<string> UpdateTilesetNode(ModData modData, MiniYamlNode tilesetNode) { yield break; }
-		public virtual IEnumerable<string> UpdateChromeProviderNode(ModData modData, MiniYamlNode chromeProviderNode) { yield break; }
-		public virtual IEnumerable<string> UpdateMapActorNode(ModData modData, MiniYamlNode actorNode) { yield break; }
+		public virtual IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode) { yield break; }
+		public virtual IEnumerable<string> UpdateWeaponNode(ModData modData, MiniYamlNodeBuilder weaponNode) { yield break; }
+		public virtual IEnumerable<string> UpdateSequenceNode(ModData modData, MiniYamlNodeBuilder sequenceNode) { yield break; }
+		public virtual IEnumerable<string> UpdateChromeNode(ModData modData, MiniYamlNodeBuilder chromeNode) { yield break; }
+		public virtual IEnumerable<string> UpdateTilesetNode(ModData modData, MiniYamlNodeBuilder tilesetNode) { yield break; }
+		public virtual IEnumerable<string> UpdateChromeProviderNode(ModData modData, MiniYamlNodeBuilder chromeProviderNode) { yield break; }
+		public virtual IEnumerable<string> UpdateMapActorNode(ModData modData, MiniYamlNodeBuilder actorNode) { yield break; }
 
 		public virtual IEnumerable<string> BeforeUpdate(ModData modData) { yield break; }
 		public virtual IEnumerable<string> AfterUpdate(ModData modData) { yield break; }
@@ -41,16 +41,16 @@ namespace OpenRA.Mods.Common.UpdateRules
 	// These aren't part of the UpdateRule class as to avoid premature yaml merge crashes when updating maps.
 	public interface IBeforeUpdateActors
 	{
-		IEnumerable<string> BeforeUpdateActors(ModData modData, List<MiniYamlNode> resolvedActors) { yield break; }
+		IEnumerable<string> BeforeUpdateActors(ModData modData, List<MiniYamlNodeBuilder> resolvedActors) { yield break; }
 	}
 
 	public interface IBeforeUpdateWeapons
 	{
-		IEnumerable<string> BeforeUpdateWeapons(ModData modData, List<MiniYamlNode> resolvedWeapons) { yield break; }
+		IEnumerable<string> BeforeUpdateWeapons(ModData modData, List<MiniYamlNodeBuilder> resolvedWeapons) { yield break; }
 	}
 
 	public interface IBeforeUpdateSequences
 	{
-		IEnumerable<string> BeforeUpdateSequences(ModData modData, List<MiniYamlNode> resolvedImages) { yield break; }
+		IEnumerable<string> BeforeUpdateSequences(ModData modData, List<MiniYamlNodeBuilder> resolvedImages) { yield break; }
 	}
 }

--- a/OpenRA.Mods.Common/UtilityCommands/ResizeMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ResizeMapCommand.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.FileSystem;
 
 namespace OpenRA.Mods.Common.UtilityCommands
@@ -68,8 +69,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				}
 			}
 
-			foreach (var kv in forRemoval)
-				map.ActorDefinitions.Remove(kv);
+			map.ActorDefinitions = map.ActorDefinitions.Except(forRemoval).ToArray();
 
 			map.Save((IReadWritePackage)map.Package);
 		}

--- a/OpenRA.Mods.Common/UtilityCommands/UpdateModCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpdateModCommand.cs
@@ -18,7 +18,7 @@ using OpenRA.Mods.Common.UpdateRules;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	using YamlFileSet = List<(IReadWritePackage, string, List<MiniYamlNode>)>;
+	using YamlFileSet = List<(IReadWritePackage, string, List<MiniYamlNodeBuilder>)>;
 
 	sealed class UpdateModCommand : IUtilityCommand
 	{

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		[ObjectCreator.UseCtor]
 		public SaveMapLogic(Widget widget, ModData modData, Map map, Action<string> onSave, Action onExit,
-			World world, List<MiniYamlNode> playerDefinitions, List<MiniYamlNode> actorDefinitions)
+			World world, IReadOnlyCollection<MiniYamlNode> playerDefinitions, IReadOnlyCollection<MiniYamlNode> actorDefinitions)
 		{
 			var title = widget.Get<TextFieldWidget>("TITLE");
 			title.Text = map.Title;

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -486,7 +486,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						if (string.IsNullOrEmpty(bl.Data))
 							continue;
 
-						var game = MiniYaml.FromString(bl.Data)[0].Value;
+						var game = new MiniYamlBuilder(MiniYaml.FromString(bl.Data)[0].Value);
 						var idNode = game.Nodes.FirstOrDefault(n => n.Key == "Id");
 
 						// Skip beacons created by this instance and replace Id by expected int value
@@ -499,9 +499,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							if (addressNode != null)
 								addressNode.Value.Value = bl.Address.ToString().Split(':')[0] + ":" + addressNode.Value.Value.Split(':')[1];
 
-							game.Nodes.Add(new MiniYamlNode("Location", "Local Network"));
+							game.Nodes.Add(new MiniYamlNodeBuilder("Location", "Local Network"));
 
-							lanGames.Add(new GameServer(game));
+							lanGames.Add(new GameServer(game.Build()));
 						}
 					}
 					catch

--- a/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
+++ b/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
@@ -18,6 +18,112 @@ namespace OpenRA.Test
 	[TestFixture]
 	public class MiniYamlTest
 	{
+		[TestCase(TestName = "Parse tree roundtrips")]
+		public void TestParseRoundtrip()
+		{
+			var yaml =
+@"1:
+2: Test
+3: # Test
+4:
+	4.1:
+5: Test
+	5.1:
+6: # Test
+	6.1:
+7:
+	7.1.1:
+	7.1.2: Test
+	7.1.3: # Test
+8: Test
+	8.1.1:
+	8.1.2: Test
+	8.1.3: # Test
+9: # Test
+	9.1.1:
+	9.1.2: Test
+	9.1.3: # Test
+";
+			var serialized = MiniYaml.FromString(yaml, discardCommentsAndWhitespace: false).WriteToString();
+			Console.WriteLine();
+			Assert.That(serialized, Is.EqualTo(yaml));
+		}
+
+		[TestCase(TestName = "Parse tree can handle empty lines")]
+		public void TestParseEmptyLines()
+		{
+			var yaml =
+@"1:
+
+2: Test
+
+3: # Test
+
+4:
+
+	4.1:
+
+5: Test
+
+	5.1:
+
+6: # Test
+
+	6.1:
+
+7:
+
+	7.1.1:
+
+	7.1.2: Test
+
+	7.1.3: # Test
+
+8: Test
+
+	8.1.1:
+
+	8.1.2: Test
+
+	8.1.3: # Test
+
+9: # Test
+
+	9.1.1:
+
+	9.1.2: Test
+
+	9.1.3: # Test
+
+";
+
+			var expectedYaml =
+@"1:
+2: Test
+3:
+4:
+	4.1:
+5: Test
+	5.1:
+6:
+	6.1:
+7:
+	7.1.1:
+	7.1.2: Test
+	7.1.3:
+8: Test
+	8.1.1:
+	8.1.2: Test
+	8.1.3:
+9:
+	9.1.1:
+	9.1.2: Test
+	9.1.3:
+";
+			var serialized = MiniYaml.FromString(yaml).WriteToString();
+			Assert.That(serialized, Is.EqualTo(expectedYaml));
+		}
+
 		[TestCase(TestName = "Mixed tabs & spaces indents")]
 		public void TestIndents()
 		{
@@ -220,7 +326,7 @@ Test:
 			var fieldNodes = traitNode.Value.Nodes;
 			var fieldSubNodes = fieldNodes.Single().Value.Nodes;
 
-			Assert.IsTrue(fieldSubNodes.Count == 1, "Collection of strings should only contain the overriding subnode.");
+			Assert.IsTrue(fieldSubNodes.Length == 1, "Collection of strings should only contain the overriding subnode.");
 			Assert.IsTrue(fieldSubNodes.Single(n => n.Key == "StringC").Value.Value == "C",
 				"CollectionOfStrings value has not been set with the correct override value for StringC.");
 		}
@@ -254,7 +360,7 @@ Test:
 			var fieldNodes = traitNode.Value.Nodes;
 			var fieldSubNodes = fieldNodes.Single().Value.Nodes;
 
-			Assert.IsTrue(fieldSubNodes.Count == 1, "Collection of strings should only contain the overriding subnode.");
+			Assert.IsTrue(fieldSubNodes.Length == 1, "Collection of strings should only contain the overriding subnode.");
 			Assert.IsTrue(fieldSubNodes.Single(n => n.Key == "StringC").Value.Value == "C",
 				"CollectionOfStrings value has not been set with the correct override value for StringC.");
 		}


### PR DESCRIPTION
This changeset is motivated by a simple concept - get rid of the `MiniYaml.Clone` and `MiniYamlNode.Clone` methods to avoid deep copying yaml trees during merging. MiniYaml becoming immutable allows the merge function to reuse existing yaml trees rather than cloning them, saving on memory and improving merge performance. On initial loading the YAML for all maps is processed, so this provides a small reduction in initial loading time.

The rest of the changeset is dealing with the change in the exposed API surface. Some With* helper methods are introduced to allow creating new YAML from existing YAML. Areas of code that generated small amounts of YAML are able to transition directly to the immutable model without too much ceremony. Some use cases are far less ergonomic even with these helper methods and so a MiniYamlBuilder is introduced to retain mutable creation functionality. This allows those areas to continue to use the old mutable structures. The main users are the update rules and linting capabilities.

----

CPU measures the percentage of time during the initial loading screen this is spent in the MiniYaml.Merge method. Memory measures the amount of inclusive memory (i.e. their memory plus everything they reference, recursively)  retained by MiniYamlNodes once loading has completed.

| Mod | CPU Bleed | CPU PR | Memory Bleed | Memory PR |
| ----- | ----------: | -------: | ---------------: | -----------: |
| RA | 8.3% | 4.6% | 9.8 MB | 7.8 MB |
| TD | 5.3% | 3.6% | 10.1 MB | 8.0 MB |
| TS | 4.4% | 2.8% | 10.0 MB | 7.9 MB |
| D2K | 3.6% | 2.3% | 9.7 MB | 7.7 MB |

If you have a 3 second load time, this saves 0.04s to 0.11s. Users with many custom maps will see more improvement.