### PR TITLE
Cloak should be detected by horizontal range.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -263,7 +263,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			return self.World.ActorsWithTrait<DetectCloaked>().Any(a => a.Actor.Owner.IsAlliedWith(viewer)
 				&& Info.DetectionTypes.Overlaps(a.Trait.Info.DetectionTypes)
-				&& (self.CenterPosition - a.Actor.CenterPosition).LengthSquared <= a.Trait.Range.LengthSquared);
+				&& (self.CenterPosition - a.Actor.CenterPosition).HorizontalLengthSquared <= a.Trait.Range.LengthSquared);
 		}
 
 		Color IRadarColorModifier.RadarColorOverride(Actor self, Color color)

--- a/OpenRA.Mods.Common/Traits/Render/RenderDetectionCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDetectionCircle.cs
@@ -43,6 +43,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("When to show the detection circle. Valid values are `Always`, and `WhenSelected`")]
 		public readonly DetectionCircleVisibility Visible = DetectionCircleVisibility.WhenSelected;
 
+		[Desc("Render the circle on the ground regardless of actors height.")]
+		public readonly bool RenderOnGround = false;
+
 		public override object Create(ActorInitializer init) { return new RenderDetectionCircle(init.Self, this); }
 	}
 
@@ -70,8 +73,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (range == WDist.Zero)
 				yield break;
 
+			var position = self.CenterPosition;
+			if (info.RenderOnGround)
+				position -= new WVec(0, 0, self.World.Map.DistanceAboveTerrain(position).Length);
+
 			yield return new DetectionCircleAnnotationRenderable(
-				self.CenterPosition,
+				position,
 				range,
 				0,
 				info.TrailCount,


### PR DESCRIPTION
or it doesn't match the circle shown by `RenderDetectionCircle` in TS mod. Meanwhile, this will mess up aircraft stealth detection when they changing height.

Fix https://github.com/OpenRA/OpenRA/issues/20973