### PR TITLE
Add StartProductionAI to ProductionQueue to fix duplicated production on AI module caused by order latency

### DIFF
--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -272,6 +272,11 @@ namespace OpenRA
 			return new Order("StartProduction", subject, queued) { ExtraData = (uint)count, TargetString = item };
 		}
 
+		public static Order StartProductionAI(Actor subject, string item, int count, bool queued = true)
+		{
+			return new Order("StartProductionAI", subject, queued) { ExtraData = (uint)count, TargetString = item };
+		}
+
 		public static Order PauseProduction(Actor subject, string item, bool pause)
 		{
 			return new Order("PauseProduction", subject, false) { ExtraData = pause ? 1u : 0u, TargetString = item };

--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -79,8 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 			"StructureProductionRandomBonusDelay is added to this.")]
 		public readonly int StructureProductionInactiveDelay = 125;
 
-		[Desc("Additional delay (in ticks) added between structure production checks when actively building things.",
-			"Note: this should be at least as large as the typical order latency to avoid duplicated build choices.")]
+		[Desc("Additional delay (in ticks) added between structure production checks when actively building things.")]
 		public readonly int StructureProductionActiveDelay = 25;
 
 		[Desc("A random delay (in ticks) of up to this is added to active/inactive production delays.")]

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -125,7 +125,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (item == null)
 					return false;
 
-				bot.QueueOrder(Order.StartProduction(queue.Actor, item.Name, 1));
+				bot.QueueOrder(Order.StartProductionAI(queue.Actor, item.Name, 1));
 			}
 			else if (currentBuilding != null && currentBuilding.Done)
 			{

--- a/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
@@ -41,7 +41,10 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class UnitBuilderBotModule : ConditionalTrait<UnitBuilderBotModuleInfo>, IBotTick, IBotNotifyIdleBaseUnits, IBotRequestUnitProduction, IGameSaveTraitData
 	{
-		public const int FeedbackTime = 30; // ticks; = a bit over 1s. must be >= netlag.
+		/// <summary>
+		/// Feedback time in ticks.
+		/// </summary>
+		public const int FeedbackTime = 30;
 
 		readonly World world;
 		readonly Player player;
@@ -130,7 +133,7 @@ namespace OpenRA.Mods.Common.Traits
 				world.Actors.Count(a => a.Owner == player && a.Info.Name == name) >= limit)
 				return;
 
-			bot.QueueOrder(Order.StartProduction(queue.Actor, name, 1));
+			bot.QueueOrder(Order.StartProductionAI(queue.Actor, name, 1));
 		}
 
 		// In cases where we want to build a specific unit but don't know the queue name (because there's more than one possibility)
@@ -154,7 +157,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (queue != null)
 			{
-				bot.QueueOrder(Order.StartProduction(queue.Actor, name, 1));
+				bot.QueueOrder(Order.StartProductionAI(queue.Actor, name, 1));
 				AIUtils.BotDebug("{0} decided to build {1} (external request)", queue.Actor.Owner, name);
 			}
 		}

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -256,27 +256,27 @@ GameSpeeds:
 		slowest:
 			Name: options-game-speed.slowest
 			Timestep: 80
-			OrderLatency: 2
+			OrderLatency: 10
 		slower:
 			Name: options-game-speed.slower
 			Timestep: 50
-			OrderLatency: 3
+			OrderLatency: 15
 		default:
 			Name: options-game-speed.normal
 			Timestep: 40
-			OrderLatency: 3
+			OrderLatency: 15
 		fast:
 			Name: options-game-speed.fast
 			Timestep: 35
-			OrderLatency: 4
+			OrderLatency: 18
 		faster:
 			Name: options-game-speed.faster
 			Timestep: 30
-			OrderLatency: 4
+			OrderLatency: 18
 		fastest:
 			Name: options-game-speed.fastest
 			Timestep: 20
-			OrderLatency: 6
+			OrderLatency: 20
 
 ModContent:
 	InstallPromptMessage: Red Alert requires artwork and audio from the original game.\n\nQuick Install will automatically download this content (without music\nor videos) from a mirror of the 2008 Red Alert freeware release.\n\nAdvanced Install includes options for copying the music, videos, and\nother content from an original game disc or digital installation.


### PR DESCRIPTION
This PR fix the duplicated production due to order latency (or other methods to handle "network lags")

## How to test
Testcase (Fixed)
1. Runing this PR twice, you get two game program(A and B).
2. Enable AI debug message
3. A create a room in mutiplayer game, B join it.
4. Get at least one AI player in game, and start the game
Result: you will find AI module always produce duplicatedly in debug message, but it has no effect on AI gameplay.

Testcase (Unfixed)
1. Revert the fixing commit, and do 1~5 steps in "Testcase (Fixed)"
Result: you will find AI module always produce duplicatedly.

## Alternative Solutions And Why I Don't Take

#### Calculate a delay from orderlantency to override the `StructureProductionActiveDelay`
This idea has following problem:

1. The calculation itself is very difficult.
The best and adaptive result I get is `Ticks = OrderLatency * 10 / 3` to testcase, but Idk if it is the correct answer for all.

2. Calculated delay is always too large for singleplayer gameplay. 
Singleplayer mode actually don't have order latency and if you apply calculated delay AI will looks slow and stupid (delay > 50 ticks). Unless we expose detail of singleplayer state to AI modules.

3. No longer works in the future plan.
If the order latency setting becomes dynamic or dropped in the future (see "Server.cs", line 1407),  this idea will no longer work because the delay will be unpredicable.


#### Allow user set up mutiple `StructureProductionActiveDelay` for each game speed
This idea has following problem:
1. User will have a difficult time to set up those delays, and hard to maintain.
Each delay needs testing from local to server, and if order latency is changed user have to do this again.

2. Singleplayer gameplay needs another delay. 
Singleplayer mode actually don't have orderlatency, and we need to expose singleplayer state to AI modules.

3. No longer works in the future plan.
If the order latency setting becomes dynamic or dropped in the future (see "Server.cs", line 1407),  this idea will no longer work because the delay will be unpredicable.