### PR TITLE
Fix AutoTarget ignoring frozen actor bot targeting hack

### DIFF
--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -387,6 +387,12 @@ namespace OpenRA.Mods.Common.Traits
 					if (attackStances == PlayerRelationship.Enemy && self.Owner.RelationshipWith(target.FrozenActor.Owner) == PlayerRelationship.Ally)
 						continue;
 
+					// Bot-controlled units aren't yet capable of understanding visibility changes
+					// Prevent that bot-controlled units endlessly fire at frozen actors.
+					// TODO: Teach the AI to support long range artillery units with units that provide line of sight
+					if (self.Owner.IsBot && target.FrozenActor.Actor == null)
+						continue;
+
 					targetTypes = target.FrozenActor.TargetTypes;
 					owner = target.FrozenActor.Owner;
 				}


### PR DESCRIPTION
The behaviour mismatch can cause an AI unit which has attack range longer that vision range to freeze in place. The check added in https://github.com/OpenRA/OpenRA/commit/db2fded24d700ab5015b80ce004c0a2d98da4700 made the bug less common, but as #20257 was merged the checks now hide the bug in way fewer cases

The fix is to mirror these checks to AutoTarget

https://github.com/OpenRA/OpenRA/blob/c093e7c90bdf8361c9e8b1aa46ec0023680f20f4/OpenRA.Mods.Common/TargetExtensions.cs#L42-L57
