### PR TITLE
Revert Hunt to move within 2 cells of the target

### DIFF
--- a/OpenRA.Mods.Common/Activities/Hunt.cs
+++ b/OpenRA.Mods.Common/Activities/Hunt.cs
@@ -40,14 +40,8 @@ namespace OpenRA.Mods.Common.Activities
 			if (targetActor == null)
 				return false;
 
-			var target = Target.FromActor(targetActor);
-			var range = self.TraitsImplementing<AttackBase>().Max(ab => ab.GetMaximumRangeVersusTarget(target));
-
-			// We want to keep at least 2 cells of distance from the target to prevent the pathfinder from thinking the target position is blocked.
-			if (range.Length < 2048)
-				range = WDist.FromCells(2);
-
-			QueueChild(new AttackMoveActivity(self, () => move.MoveWithinRange(Target.FromCell(self.World, targetActor.Location), range)));
+			// We want to keep 2 cells of distance from the target to prevent the pathfinder from thinking the target position is blocked.
+			QueueChild(new AttackMoveActivity(self, () => move.MoveWithinRange(Target.FromCell(self.World, targetActor.Location), WDist.FromCells(2))));
 			QueueChild(new Wait(25));
 			return false;
 		}

--- a/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Scripting
 		}
 
 		[ScriptActorPropertyActivity]
-		[Desc("Seek out and attack nearby targets.")]
+		[Desc("Ignoring visibility, find the closest hostile target and attack move to within 2 cells of it.")]
 		public void Hunt()
 		{
 			Self.QueueActivity(new Hunt(Self));


### PR DESCRIPTION
Regression from #20974

When testing missions I noticed that AI's infantry will quite often wait and do nothing. For example move within weapon range of a flame tower and bravely die without firing a shot. Or move into mammoth tanks just to proudly demonstrate their resolve.

There are definitely better solutions out there, but all require a lot of work to implement and will likely have cost in maintenance. As Hunt's sole purpose is to give AI's units in missions a purpose, I think the 2 cells range is perfectly acceptable. I've also edited the description of the Lua's function to be more descriptive.