### PR TITLE
Fix RA assets installation from the Steam C&C:R version

### DIFF
--- a/mods/ra/installer/origin.yaml
+++ b/mods/ra/installer/origin.yaml
@@ -234,7 +234,6 @@ cncr-origin: C&C Remastered Collection (Origin version, English)
 	RegistryValue: Install Dir
 	IDFiles:
 		Data/CNCDATA/RED_ALERT/CD1/REDALERT.MIX: 0e58f4b54f44f6cd29fecf8cf379d33cf2d4caef
-			Length: 4096
 	# The Remastered Collection doesn't include the RA Soviet CD unfortunately, so we can't install Soviet campaign briefings.
 	Install:
 		# Base game files:

--- a/mods/ra/installer/steam.yaml
+++ b/mods/ra/installer/steam.yaml
@@ -3,7 +3,6 @@ cncr-steam: C&C Remastered Collection (Steam version, English)
 		AppId: 1213210
 	IDFiles:
 		Data/CNCDATA/RED_ALERT/CD1/REDALERT.MIX: 0e58f4b54f44f6cd29fecf8cf379d33cf2d4caef
-			Length: 4096
 	# The Remastered Collection doesn't include the RA Soviet CD unfortunately, so we can't install Soviet campaign briefings.
 	Install:
 		# Base game files:


### PR DESCRIPTION
This looks like a copy paste error. The provided hash is for the entire file. (And there exist other nodes in other installer files which have the `4096` length. I assume that is to save a bit of performance as we don't need to read the entire file there to detect if there is a potential match and only load a full file with the second ID file. Here we only have one ID file though, and Imho we don't need that small optimization here as we only look for this file in a Steam specific folder.)