### PR TITLE
Fix lua sanity check crashing on dedicated servers

### DIFF
--- a/OpenRA.Mods.Common/Lint/CheckLuaScript.cs
+++ b/OpenRA.Mods.Common/Lint/CheckLuaScript.cs
@@ -10,32 +10,21 @@
 #endregion
 
 using System;
-using OpenRA.FileSystem;
 using OpenRA.Mods.Common.Scripting;
-using OpenRA.Server;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	public class CheckLuaScript : ILintMapPass, ILintServerMapPass
+	public class CheckLuaScript : ILintMapPass
 	{
 		void ILintMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
 		{
-			CheckLuaScriptFileExistance(emitError, map.Package, modData.DefaultFileSystem, map.Rules);
-		}
-
-		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
-		{
-			CheckLuaScriptFileExistance(emitError, map.Package, modData.DefaultFileSystem, mapRules);
-		}
-
-		static void CheckLuaScriptFileExistance(Action<string> emitError, IReadOnlyPackage package, IReadOnlyFileSystem fileSystem, Ruleset mapRules)
-		{
-			var luaScriptInfo = mapRules.Actors[SystemActors.World].TraitInfoOrDefault<LuaScriptInfo>();
+			var luaScriptInfo = map.Rules.Actors[SystemActors.World].TraitInfoOrDefault<LuaScriptInfo>();
 			if (luaScriptInfo == null)
 				return;
 
+			// We aren't running this lint on servers as they don't create map packages.
 			foreach (var script in luaScriptInfo.Scripts)
-				if (!package.Contains(script) && !fileSystem.Exists(script))
+				if (!map.Package.Contains(script) && !modData.DefaultFileSystem.Exists(script))
 					emitError($"Lua script `{script}` does not exist.");
 		}
 	}


### PR DESCRIPTION
Dedicated servers don't create map packages making this check crash with null exception. 

As `ILintServerMapPass` is mainly only run on dedicated, it makes more sense to remove the pass rather than adding a null check