### PR TITLE
Fix misaligned TD combat observer tab

### DIFF
--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -1093,14 +1093,14 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@ARMY_VALUE:
-									X: 605
+									X: 610
 									Y: 0
-									Width: 85
+									Width: 90
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@VISION:
-									X: 690
+									X: 700
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM


### PR DESCRIPTION
Very likely caused by a copy paste error

before
<img width="860" alt="Screenshot 2023-07-07 at 23 27 43" src="https://github.com/OpenRA/OpenRA/assets/37534529/53ae34a6-4123-4ec5-b423-ab4d91ed9823">

after
<img width="929" alt="Screenshot 2023-08-03 at 21 03 54" src="https://github.com/OpenRA/OpenRA/assets/37534529/ba521a2e-f0a3-44d0-a316-8f3dfe70689c">
