### PR TITLE
Fix 1st generation map importer crashing on invalid tiles

### DIFF
--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportGen1MapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportGen1MapCommand.cs
@@ -103,6 +103,8 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			if (Map.Rules.TerrainInfo is ITerrainInfoNotifyMapCreated notifyMapCreated)
 				notifyMapCreated.MapCreated(Map);
 
+			ReplaceInvalidTerrainTiles(Map);
+
 			var dest = Path.GetFileNameWithoutExtension(args[1]) + ".oramap";
 
 			Map.Save(ZipFileLoader.Create(dest));
@@ -157,6 +159,19 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			}
 
 			missionData.Value.Nodes.Add(new MiniYamlNode("Briefing", briefing.Replace("\n", " ").ToString()));
+		}
+
+		static void ReplaceInvalidTerrainTiles(Map map)
+		{
+			var terrainInfo = map.Rules.TerrainInfo;
+			foreach (var uv in map.AllCells.MapCoords)
+			{
+				if (!terrainInfo.TryGetTerrainInfo(map.Tiles[uv], out _))
+				{
+					map.Tiles[uv] = terrainInfo.DefaultTerrainTile;
+					Console.WriteLine($"Replaced invalid terrain tile at {uv}");
+				}
+			}
 		}
 
 		static void SetBounds(Map map, IniSection mapSection)

--- a/OpenRA.Mods.Common/Terrain/DefaultTerrain.cs
+++ b/OpenRA.Mods.Common/Terrain/DefaultTerrain.cs
@@ -170,18 +170,15 @@ namespace OpenRA.Mods.Common.Terrain
 
 		void ITerrainInfoNotifyMapCreated.MapCreated(Map map)
 		{
-			// Randomize PickAny tile variants
+			// Randomize PickAny tile variants.
 			var r = new MersenneTwister();
-			for (var j = map.Bounds.Top; j < map.Bounds.Bottom; j++)
+			foreach (var uv in map.AllCells.MapCoords)
 			{
-				for (var i = map.Bounds.Left; i < map.Bounds.Right; i++)
-				{
-					var type = map.Tiles[new MPos(i, j)].Type;
-					if (!Templates.TryGetValue(type, out var template) || !template.PickAny)
-						continue;
+				var type = map.Tiles[uv].Type;
+				if (!Templates.TryGetValue(type, out var template) || !template.PickAny)
+					continue;
 
-					map.Tiles[new MPos(i, j)] = new TerrainTile(type, (byte)r.Next(0, template.TilesCount));
-				}
+				map.Tiles[uv] = new TerrainTile(type, (byte)r.Next(0, template.TilesCount));
 			}
 		}
 	}


### PR DESCRIPTION
Fix mirrors #18927

`ITerrainInfoNotifyMapCreated.MapCreated` change shouldn't do any harm, I'm not sure why out of bounds cells were skipped

I've only tested running the utility with [UGC_011000010104BD13_000000007F52264E_MAPDATA.MPR.zip](https://github.com/OpenRA/OpenRA/files/12269472/UGC_011000010104BD13_000000007F52264E_MAPDATA.MPR.zip)
