### PR TITLE
Remove reference to obsolete package

### DIFF
--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="OpenRA-Eluant" Version="1.0.21" />
     <PackageReference Include="Mono.NAT" Version="3.0.4" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -11,6 +11,5 @@
     <PackageReference Include="TagLibSharp" Version="2.3.0" />
     <PackageReference Include="rix0rrr.BeaconLib" Version="1.0.2" />
     <PackageReference Include="Pfim" Version="0.11.2" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Remove reference to System.Net.Http package, because it is a .NET Standard 1.x obsolete package, the System.Net.Http library is inbox on modern .NET (see https://github.com/dotnet/arcade/issues/13315).