### PR TITLE
Enable Code Quality rule CA1851

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -836,8 +836,8 @@ dotnet_diagnostic.CA1850.severity = none
 
 # Possible multiple enumerations of IEnumerable collection.
 #dotnet_code_quality.CA1851.enumeration_methods =
-#dotnet_code_quality.CA1851.linq_chain_methods =
-#dotnet_code_quality.CA1851.assume_method_enumerates_parameters = false
+dotnet_code_quality.CA1851.linq_chain_methods = M:OpenRA.Traits.IRenderModifier.Modify*
+dotnet_code_quality.CA1851.assume_method_enumerates_parameters = true
 dotnet_diagnostic.CA1851.severity = warning
 
 # Seal internal types.

--- a/.editorconfig
+++ b/.editorconfig
@@ -834,6 +834,12 @@ dotnet_diagnostic.CA1849.severity = warning
 # Prefer static HashData method over ComputeHash. (Not available on mono)
 dotnet_diagnostic.CA1850.severity = none
 
+# Possible multiple enumerations of IEnumerable collection.
+#dotnet_code_quality.CA1851.enumeration_methods =
+#dotnet_code_quality.CA1851.linq_chain_methods =
+#dotnet_code_quality.CA1851.assume_method_enumerates_parameters = false
+dotnet_diagnostic.CA1851.severity = warning
+
 # Seal internal types.
 dotnet_diagnostic.CA1852.severity = warning
 

--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -147,7 +147,7 @@ namespace OpenRA
 
 		static T Random<T>(IEnumerable<T> ts, MersenneTwister r, bool throws)
 		{
-			var xs = ts as ICollection<T>;
+			var xs = ts as IReadOnlyCollection<T>;
 			xs ??= ts.ToList();
 			if (xs.Count == 0)
 			{

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -523,10 +523,11 @@ namespace OpenRA
 				.Where(m => m.Status == MapStatus.Available && m.Visibility.HasFlag(MapVisibility.Shellmap))
 				.Select(m => m.Uid);
 
-			if (!shellmaps.Any())
+			var shellmap = shellmaps.RandomOrDefault(CosmeticRandom);
+			if (shellmap == null)
 				throw new InvalidDataException("No valid shellmaps available");
 
-			return shellmaps.Random(CosmeticRandom);
+			return shellmap;
 		}
 
 		public static void SwitchToExternalMod(ExternalMod mod, string[] launchArguments = null, Action onFailed = null)

--- a/OpenRA.Game/GameRules/ActorInfo.cs
+++ b/OpenRA.Game/GameRules/ActorInfo.cs
@@ -185,7 +185,7 @@ namespace OpenRA
 		public bool HasTraitInfo<T>() where T : ITraitInfoInterface { return traits.Contains<T>(); }
 		public T TraitInfo<T>() where T : ITraitInfoInterface { return traits.Get<T>(); }
 		public T TraitInfoOrDefault<T>() where T : ITraitInfoInterface { return traits.GetOrDefault<T>(); }
-		public IEnumerable<T> TraitInfos<T>() where T : ITraitInfoInterface { return traits.WithInterface<T>(); }
+		public IReadOnlyCollection<T> TraitInfos<T>() where T : ITraitInfoInterface { return traits.WithInterface<T>(); }
 
 		public BitSet<TargetableType> GetAllTargetTypes()
 		{

--- a/OpenRA.Game/GameRules/ActorInfo.cs
+++ b/OpenRA.Game/GameRules/ActorInfo.cs
@@ -130,6 +130,7 @@ namespace OpenRA
 
 			// Continue resolving traits as long as possible.
 			// Each time we resolve some traits, this means dependencies for other traits may then be possible to satisfy in the next pass.
+#pragma warning disable CA1851 // Possible multiple enumerations of 'IEnumerable' collection
 			var readyToResolve = more.ToList();
 			while (readyToResolve.Count != 0)
 			{
@@ -138,6 +139,7 @@ namespace OpenRA
 				readyToResolve.Clear();
 				readyToResolve.AddRange(more);
 			}
+#pragma warning restore CA1851
 
 			if (unresolved.Count != 0)
 			{

--- a/OpenRA.Game/Graphics/ChromeProvider.cs
+++ b/OpenRA.Game/Graphics/ChromeProvider.cs
@@ -234,7 +234,7 @@ namespace OpenRA.Graphics
 			{
 				// PERF: We don't need to search for images if there are no definitions.
 				// PERF: It's more efficient to send an empty array rather than an array of 9 nulls.
-				if (!collection.Regions.Any())
+				if (collection.Regions.Count == 0)
 					return Array.Empty<Sprite>();
 
 				// Support manual definitions for unusual dialog layouts

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -299,10 +299,13 @@ namespace OpenRA.Graphics
 
 		public void Center(IEnumerable<Actor> actors)
 		{
-			if (!actors.Any())
+			var actorsCollection = actors as IReadOnlyCollection<Actor>;
+			actorsCollection ??= actors.ToList();
+
+			if (actorsCollection.Count == 0)
 				return;
 
-			Center(actors.Select(a => a.CenterPosition).Average());
+			Center(actorsCollection.Select(a => a.CenterPosition).Average());
 		}
 
 		public void Center(WPos pos)

--- a/OpenRA.Game/Map/ActorReference.cs
+++ b/OpenRA.Game/Map/ActorReference.cs
@@ -139,7 +139,7 @@ namespace OpenRA
 			return removed;
 		}
 
-		public IEnumerable<T> GetAll<T>() where T : ActorInit
+		public IReadOnlyCollection<T> GetAll<T>() where T : ActorInit
 		{
 			return initDict.Value.WithInterface<T>();
 		}

--- a/OpenRA.Game/Map/CellRegion.cs
+++ b/OpenRA.Game/Map/CellRegion.cs
@@ -12,7 +12,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace OpenRA
 {
@@ -64,9 +63,9 @@ namespace OpenRA
 		}
 
 		/// <summary>Returns the minimal region that covers at least the specified cells.</summary>
-		public static CellRegion BoundingRegion(MapGridType shape, IEnumerable<CPos> cells)
+		public static CellRegion BoundingRegion(MapGridType shape, IReadOnlyCollection<CPos> cells)
 		{
-			if (cells == null || !cells.Any())
+			if (cells == null || cells.Count == 0)
 				throw new ArgumentException("cells must not be null or empty.", nameof(cells));
 
 			var minU = int.MaxValue;

--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -201,8 +201,12 @@ namespace OpenRA.Network
 			public TypeInfo(Type type)
 			{
 				const BindingFlags Flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
-				var fields = type.GetFields(Flags).Where(fi => !fi.IsLiteral && !fi.IsStatic && fi.HasAttribute<SyncAttribute>());
-				var properties = type.GetProperties(Flags).Where(pi => pi.HasAttribute<SyncAttribute>());
+				var fields = type.GetFields(Flags)
+					.Where(fi => !fi.IsLiteral && !fi.IsStatic && fi.HasAttribute<SyncAttribute>())
+					.ToList();
+				var properties = type.GetProperties(Flags)
+					.Where(pi => pi.HasAttribute<SyncAttribute>())
+					.ToList();
 
 				foreach (var prop in properties)
 					if (!prop.CanRead || prop.GetIndexParameters().Length > 0)

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -134,8 +134,8 @@ namespace OpenRA
 		public ConstructorInfo GetCtor(Type type)
 		{
 			var flags = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance;
-			var ctors = type.GetConstructors(flags).Where(x => x.HasAttribute<UseCtorAttribute>());
-			if (ctors.Count() > 1)
+			var ctors = type.GetConstructors(flags).Where(x => x.HasAttribute<UseCtorAttribute>()).ToList();
+			if (ctors.Count > 1)
 				throw new InvalidOperationException("ObjectCreator: UseCtor on multiple constructors; invalid.");
 			return ctors.FirstOrDefault();
 		}

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -133,7 +133,7 @@ namespace OpenRA
 
 		static FactionInfo ResolveDisplayFaction(World world, string factionName)
 		{
-			var factions = world.Map.Rules.Actors[SystemActors.World].TraitInfos<FactionInfo>().ToArray();
+			var factions = world.Map.Rules.Actors[SystemActors.World].TraitInfos<FactionInfo>();
 
 			return factions.FirstOrDefault(f => f.InternalName == factionName) ?? factions.First();
 		}

--- a/OpenRA.Game/SelectableExts.cs
+++ b/OpenRA.Game/SelectableExts.cs
@@ -62,10 +62,7 @@ namespace OpenRA.Traits
 
 		public static Actor WithHighestSelectionPriority(this IEnumerable<ActorBoundsPair> actors, int2 selectionPixel, Modifiers modifiers)
 		{
-			if (!actors.Any())
-				return null;
-
-			return actors.MaxBy(a => CalculateActorSelectionPriority(a.Actor.Info, a.Bounds, selectionPixel, modifiers)).Actor;
+			return actors.MaxByOrDefault(a => CalculateActorSelectionPriority(a.Actor.Info, a.Bounds, selectionPixel, modifiers)).Actor;
 		}
 
 		public static FrozenActor WithHighestSelectionPriority(this IEnumerable<FrozenActor> actors, int2 selectionPixel, Modifiers modifiers)

--- a/OpenRA.Game/Support/AssemblyLoader.cs
+++ b/OpenRA.Game/Support/AssemblyLoader.cs
@@ -349,7 +349,7 @@ namespace OpenRA.Support
 			return Enumerable.Concat(new[] { runtimeGraph.Runtime }, runtimeGraph?.Fallbacks ?? Enumerable.Empty<string>());
 		}
 
-		static IEnumerable<string> SelectAssets(IEnumerable<string> rids, IEnumerable<RuntimeAssetGroup> groups)
+		static IEnumerable<string> SelectAssets(IEnumerable<string> rids, IReadOnlyCollection<RuntimeAssetGroup> groups)
 		{
 			foreach (var rid in rids)
 			{

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -455,7 +455,7 @@ namespace OpenRA.Traits
 	public interface ISelection
 	{
 		int Hash { get; }
-		IEnumerable<Actor> Actors { get; }
+		IReadOnlyCollection<Actor> Actors { get; }
 
 		void Add(Actor a);
 		void Remove(Actor a);

--- a/OpenRA.Game/WPos.cs
+++ b/OpenRA.Game/WPos.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Eluant;
 using Eluant.ObjectBinding;
 using OpenRA.Scripting;
@@ -139,19 +138,20 @@ namespace OpenRA
 	{
 		public static WPos Average(this IEnumerable<WPos> source)
 		{
-			var length = source.Count();
-			if (length == 0)
-				return WPos.Zero;
-
+			var length = 0;
 			var x = 0L;
 			var y = 0L;
 			var z = 0L;
 			foreach (var pos in source)
 			{
+				length++;
 				x += pos.X;
 				y += pos.Y;
 				z += pos.Z;
 			}
+
+			if (length == 0)
+				return WPos.Zero;
 
 			x /= length;
 			y /= length;

--- a/OpenRA.Mods.Cnc/Activities/Teleport.cs
+++ b/OpenRA.Mods.Cnc/Activities/Teleport.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Cnc.Traits;
 using OpenRA.Mods.Common.Traits;
@@ -120,7 +119,7 @@ namespace OpenRA.Mods.Cnc.Activities
 			if (teleporter == null)
 				return null;
 
-			var restrictTo = maximumDistance == null ? null : self.World.Map.FindTilesInCircle(self.Location, maximumDistance.Value);
+			var restrictTo = maximumDistance == null ? null : self.World.Map.FindTilesInCircle(self.Location, maximumDistance.Value).ToHashSet();
 
 			if (maximumDistance != null)
 				destination = restrictTo.MinBy(x => (x - destination).LengthSquared);

--- a/OpenRA.Mods.Cnc/Traits/GpsWatcher.cs
+++ b/OpenRA.Mods.Cnc/Traits/GpsWatcher.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			var wasGranted = Granted;
 			var wasGrantedAllies = GrantedAllies;
-			var allyWatchers = owner.World.ActorsWithTrait<GpsWatcher>().Where(kv => kv.Actor.Owner.IsAlliedWith(owner));
+			var allyWatchers = owner.World.ActorsWithTrait<GpsWatcher>().Where(kv => kv.Actor.Owner.IsAlliedWith(owner)).ToList();
 
 			Granted = actors.Count > 0 && Launched;
 			GrantedAllies = allyWatchers.Any(w => w.Trait.Granted);

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -358,14 +358,11 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			bool IsValidTarget(CPos xy)
 			{
-				// Don't teleport if there are no units in range (either all moved out of range, or none yet moved into range)
-				var unitsInRange = power.UnitsInRange(sourceLocation);
-				if (!unitsInRange.Any())
-					return false;
-
 				var canTeleport = false;
-				foreach (var unit in unitsInRange)
+				var anyUnitsInRange = false;
+				foreach (var unit in power.UnitsInRange(sourceLocation))
 				{
+					anyUnitsInRange = true;
 					var targetCell = unit.Location + (xy - sourceLocation);
 					if (manager.Self.Owner.Shroud.IsExplored(targetCell) && unit.Trait<Chronoshiftable>().CanChronoshiftTo(unit, targetCell))
 					{
@@ -373,6 +370,10 @@ namespace OpenRA.Mods.Cnc.Traits
 						break;
 					}
 				}
+
+				// Don't teleport if there are no units in range (either all moved out of range, or none yet moved into range)
+				if (!anyUnitsInRange)
+					return false;
 
 				if (!canTeleport)
 				{

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
@@ -211,7 +212,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (!landingInitiated)
 			{
-				var blockingCells = clearCells.Append(landingCell);
+				var blockingCells = clearCells.Append(landingCell).ToList();
 
 				if (!aircraft.CanLand(blockingCells, target.Actor))
 				{

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -196,8 +196,8 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Update ranges. Exclude paused armaments except when ALL weapons are paused
 			// (e.g. out of ammo), in which case use the paused, valid weapon with highest range.
-			var activeArmaments = armaments.Where(x => !x.IsTraitPaused);
-			if (activeArmaments.Any())
+			var activeArmaments = armaments.Where(x => !x.IsTraitPaused).ToList();
+			if (activeArmaments.Count != 0)
 			{
 				minRange = activeArmaments.Max(a => a.Weapon.MinRange);
 				maxRange = activeArmaments.Min(a => a.MaxRange());

--- a/OpenRA.Mods.Common/Lint/CheckConditions.cs
+++ b/OpenRA.Mods.Common/Lint/CheckConditions.cs
@@ -66,12 +66,12 @@ namespace OpenRA.Mods.Common.Lint
 							granted.Add(g);
 				}
 
-				var unconsumed = granted.Except(consumed);
-				if (unconsumed.Any())
+				var unconsumed = granted.Except(consumed).ToList();
+				if (unconsumed.Count != 0)
 					emitWarning($"Actor type `{actorInfo.Key}` grants conditions that are not consumed: {unconsumed.JoinWith(", ")}.");
 
-				var ungranted = consumed.Except(granted);
-				if (ungranted.Any())
+				var ungranted = consumed.Except(granted).ToList();
+				if (ungranted.Count != 0)
 					emitError($"Actor type `{actorInfo.Key}` consumes conditions that are not granted: {ungranted.JoinWith(", ")}.");
 			}
 		}

--- a/OpenRA.Mods.Common/Lint/CheckConflictingMouseBounds.cs
+++ b/OpenRA.Mods.Common/Lint/CheckConflictingMouseBounds.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Linq;
 using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.Common.Lint
@@ -21,8 +20,8 @@ namespace OpenRA.Mods.Common.Lint
 		{
 			foreach (var actorInfo in rules.Actors)
 			{
-				var selectable = actorInfo.Value.TraitInfos<SelectableInfo>().Count();
-				var interactable = actorInfo.Value.TraitInfos<InteractableInfo>().Count();
+				var selectable = actorInfo.Value.TraitInfos<SelectableInfo>().Count;
+				var interactable = actorInfo.Value.TraitInfos<InteractableInfo>().Count;
 				if (selectable > 0 && selectable != interactable)
 					emitWarning($"Actor `{actorInfo.Value.Name}` defines both Interactable and Selectable traits. This may cause unexpected results.");
 			}

--- a/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
+++ b/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Lint
 				try
 				{
 					var visibilityTypes = actorInfo.Value.TraitInfos<IDefaultVisibilityInfo>();
-					var count = visibilityTypes.Count();
+					var count = visibilityTypes.Count;
 
 					if (count == 0)
 						emitError($"Actor type `{actorInfo.Key}` does not define a default visibility type.");

--- a/OpenRA.Mods.Common/Lint/CheckHitShapes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckHitShapes.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Server;
 using OpenRA.Traits;
@@ -41,7 +40,7 @@ namespace OpenRA.Mods.Common.Lint
 						continue;
 
 					var hitShapes = actorInfo.Value.TraitInfos<HitShapeInfo>();
-					if (!hitShapes.Any())
+					if (hitShapes.Count == 0)
 						emitError($"Actor type `{actorInfo.Key}` has a Health trait but no HitShape trait.");
 				}
 				catch (InvalidOperationException e)

--- a/OpenRA.Mods.Common/Lint/CheckSpriteBodies.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSpriteBodies.cs
@@ -32,10 +32,12 @@ namespace OpenRA.Mods.Common.Lint
 		{
 			foreach (var actorInfo in rules.Actors)
 			{
-				var wsbs = actorInfo.Value.TraitInfos<WithSpriteBodyInfo>();
-				foreach (var wsb in wsbs)
-					if (wsbs.Any(w => w != wsb && w.Name == wsb.Name))
-						emitError($"Actor type `{actorInfo.Key}` has more than one *SpriteBody with Name: {wsb.Name}.");
+				var duplicateNames = actorInfo.Value.TraitInfos<WithSpriteBodyInfo>()
+					.GroupBy(wsb => wsb.Name)
+					.Where(g => g.Count() > 1)
+					.Select(g => g.Key);
+				foreach (var duplicateName in duplicateNames)
+					emitError($"Actor type `{actorInfo.Key}` has more than one *SpriteBody with Name: {duplicateName}.");
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Lint/CheckSyncAnnotations.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSyncAnnotations.cs
@@ -21,8 +21,7 @@ namespace OpenRA.Mods.Common.Lint
 		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData)
 		{
 			var modTypes = modData.ObjectCreator.GetTypes();
-			CheckTypesWithSyncableMembersImplementSyncInterface(modTypes, emitWarning);
-			CheckTypesImplementingSyncInterfaceHaveSyncableMembers(modTypes, emitWarning);
+			CheckTypes(modTypes, emitWarning);
 		}
 
 		static readonly Type SyncInterface = typeof(ISync);
@@ -45,18 +44,18 @@ namespace OpenRA.Mods.Common.Lint
 			return false;
 		}
 
-		static void CheckTypesWithSyncableMembersImplementSyncInterface(IEnumerable<Type> types, Action<string> emitWarning)
+		static void CheckTypes(IEnumerable<Type> types, Action<string> emitWarning)
 		{
 			foreach (var type in types)
-				if (!TypeImplementsSync(type) && AnyTypeMemberIsSynced(type))
-					emitWarning($"{type.FullName} has members with the Sync attribute but does not implement ISync.");
-		}
+			{
+				var typeImplementsSync = TypeImplementsSync(type);
+				var anyTypeMemberIsSynced = AnyTypeMemberIsSynced(type);
 
-		static void CheckTypesImplementingSyncInterfaceHaveSyncableMembers(IEnumerable<Type> types, Action<string> emitWarning)
-		{
-			foreach (var type in types)
-				if (TypeImplementsSync(type) && !AnyTypeMemberIsSynced(type))
+				if (!typeImplementsSync && anyTypeMemberIsSynced)
+					emitWarning($"{type.FullName} has members with the Sync attribute but does not implement ISync.");
+				else if (typeImplementsSync && !anyTypeMemberIsSynced)
 					emitWarning($"{type.FullName} implements ISync but does not use the Sync attribute on any members.");
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/UnitOrderGenerator.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Orders
 					return cursorOrder.Cursor;
 
 				useSelect = target.Type == TargetType.Actor && target.Actor.Info.HasTraitInfo<ISelectableInfo>() &&
-					(mi.Modifiers.HasModifier(Modifiers.Shift) || !world.Selection.Actors.Any());
+					(mi.Modifiers.HasModifier(Modifiers.Shift) || world.Selection.Actors.Count == 0);
 			}
 
 			return useSelect ? worldSelectCursor : worldDefaultCursor;

--- a/OpenRA.Mods.Common/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/UnitOrderGenerator.cs
@@ -50,13 +50,13 @@ namespace OpenRA.Mods.Common.Orders
 				.Where(o => o != null)
 				.ToList();
 
-			var actorsInvolved = orders.Select(o => o.Actor).Distinct();
-			if (!actorsInvolved.Any())
+			var actorsInvolved = orders.Select(o => o.Actor).Distinct().ToArray();
+			if (actorsInvolved.Length == 0)
 				yield break;
 
 			// HACK: This is required by the hacky player actions-per-minute calculation
 			// TODO: Reimplement APM properly and then remove this
-			yield return new Order("CreateGroup", actorsInvolved.First().Owner.PlayerActor, false, actorsInvolved.ToArray());
+			yield return new Order("CreateGroup", actorsInvolved.First().Owner.PlayerActor, false, actorsInvolved);
 
 			foreach (var o in orders)
 				yield return CheckSameOrder(o.Order, o.Trait.IssueOrder(o.Actor, o.Order, o.Target, mi.Modifiers.HasModifier(Modifiers.Shift)));
@@ -165,7 +165,8 @@ namespace OpenRA.Mods.Common.Orders
 			var orders = self.TraitsImplementing<IIssueOrder>()
 				.SelectMany(trait => trait.Orders.Select(x => new { Trait = trait, Order = x }))
 				.Select(x => x)
-				.OrderByDescending(x => x.Order.OrderPriority);
+				.OrderByDescending(x => x.Order.OrderPriority)
+				.ToList();
 
 			for (var i = 0; i < 2; i++)
 			{

--- a/OpenRA.Mods.Common/Scripting/Global/ActorGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ActorGlobal.cs
@@ -72,7 +72,8 @@ namespace OpenRA.Mods.Common.Scripting
 			}
 
 			var initializers = initType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-				.Where(m => m.Name == "Initialize" && m.GetParameters().Length == 1);
+				.Where(m => m.Name == "Initialize" && m.GetParameters().Length == 1)
+				.ToList();
 
 			foreach (var initializer in initializers)
 			{

--- a/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
@@ -245,7 +245,7 @@ namespace OpenRA.Mods.Common.Scripting
 			foreach (var actorType in actorTypes.Distinct())
 				typeToQueueMap.Add(actorType, GetBuildableInfo(actorType).Queue.First());
 
-			var queueTypes = typeToQueueMap.Values.Distinct();
+			var queueTypes = typeToQueueMap.Values.Distinct().ToList();
 
 			if (queueTypes.Any(t => !queues.ContainsKey(t) || productionHandlers.ContainsKey(t)))
 				return false;

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -748,10 +748,11 @@ namespace OpenRA.Mods.Common.Server
 				teamCount = teamCount.Clamp(0, maxTeams);
 				var clients = server.LobbyInfo.Slots
 					.Select(slot => server.LobbyInfo.ClientInSlot(slot.Key))
-					.Where(c => c != null && !server.LobbyInfo.Slots[c.Slot].LockTeam);
+					.Where(c => c != null && !server.LobbyInfo.Slots[c.Slot].LockTeam)
+					.ToList();
 
 				var assigned = 0;
-				var clientCount = clients.Count();
+				var clientCount = clients.Count;
 				foreach (var player in clients)
 				{
 					// Free for all

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -530,9 +530,9 @@ namespace OpenRA.Mods.Common.Server
 
 					// Pick a random color for the bot
 					var colorManager = server.ModData.DefaultRules.Actors[SystemActors.World].TraitInfo<IColorPickerManagerInfo>();
-					var terrainColors = server.ModData.DefaultTerrainInfo[server.Map.TileSet].RestrictedPlayerColors;
+					var terrainColors = server.ModData.DefaultTerrainInfo[server.Map.TileSet].RestrictedPlayerColors.ToList();
 					var playerColors = server.LobbyInfo.Clients.Select(c => c.Color)
-						.Concat(server.Map.Players.Players.Values.Select(p => p.Color));
+						.Concat(server.Map.Players.Players.Values.Select(p => p.Color)).ToList();
 
 					bot.Color = bot.PreferredColor = colorManager.RandomPresetColor(server.Random, terrainColors, playerColors);
 
@@ -935,7 +935,8 @@ namespace OpenRA.Mods.Common.Server
 					return true;
 
 				var factions = server.Map.WorldActorInfo.TraitInfos<FactionInfo>()
-					.Where(f => f.Selectable).Select(f => f.InternalName);
+					.Where(f => f.Selectable).Select(f => f.InternalName)
+					.ToList();
 
 				var faction = parts[1];
 				if (!factions.Contains(faction))
@@ -1250,7 +1251,7 @@ namespace OpenRA.Mods.Common.Server
 						server.SendLocalizedMessageTo(connectionToEcho, message);
 				}
 
-				var terrainColors = server.ModData.DefaultTerrainInfo[server.Map.TileSet].RestrictedPlayerColors;
+				var terrainColors = server.ModData.DefaultTerrainInfo[server.Map.TileSet].RestrictedPlayerColors.ToList();
 				var playerColors = server.LobbyInfo.Clients.Where(c => c.Index != playerIndex).Select(c => c.Color)
 					.Concat(server.Map.Players.Players.Values.Select(p => p.Color)).ToList();
 

--- a/OpenRA.Mods.Common/Traits/AppearsOnMapPreview.cs
+++ b/OpenRA.Mods.Common/Traits/AppearsOnMapPreview.cs
@@ -41,8 +41,8 @@ namespace OpenRA.Mods.Common.Traits
 			else
 			{
 				var owner = map.PlayerDefinitions.Single(p => s.Get<OwnerInit>().InternalName == p.Value.Nodes.Last(k => k.Key == "Name").Value.Value);
-				var colorValue = owner.Value.Nodes.Where(n => n.Key == "Color");
-				var ownerColor = colorValue.Any() ? colorValue.First().Value.Value : "FFFFFF";
+				var colorValue = owner.Value.Nodes.FirstOrDefault(n => n.Key == "Color");
+				var ownerColor = colorValue?.Value.Value ?? "FFFFFF";
 				Color.TryParse(ownerColor, out color);
 			}
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -445,15 +445,15 @@ namespace OpenRA.Mods.Common.Traits
 					modifiers |= TargetModifiers.ForceAttack;
 
 				var forceAttack = modifiers.HasModifier(TargetModifiers.ForceAttack);
-				var armaments = ab.ChooseArmamentsForTarget(target, forceAttack);
-				if (!armaments.Any())
-					return false;
 
 				// Use valid armament with highest range out of those that have ammo
 				// If all are out of ammo, just use valid armament with highest range
-				armaments = armaments.OrderByDescending(x => x.MaxRange());
-				var a = armaments.FirstOrDefault(x => !x.IsTraitPaused);
-				a ??= armaments.First();
+				var a = ab.ChooseArmamentsForTarget(target, forceAttack)
+					.OrderBy(x => x.IsTraitPaused)
+					.ThenByDescending(x => x.MaxRange())
+					.FirstOrDefault();
+				if (a == null)
+					return false;
 
 				var outOfRange = !target.IsInRange(self.CenterPosition, a.MaxRange()) ||
 					(!forceAttack && target.Type == TargetType.FrozenActor && !ab.Info.TargetFrozenActors);
@@ -482,15 +482,15 @@ namespace OpenRA.Mods.Common.Traits
 					return false;
 
 				var target = Target.FromCell(self.World, location);
-				var armaments = ab.ChooseArmamentsForTarget(target, true);
-				if (!armaments.Any())
-					return false;
 
 				// Use valid armament with highest range out of those that have ammo
 				// If all are out of ammo, just use valid armament with highest range
-				armaments = armaments.OrderByDescending(x => x.MaxRange());
-				var a = armaments.FirstOrDefault(x => !x.IsTraitPaused);
-				a ??= armaments.First();
+				var a = ab.ChooseArmamentsForTarget(target, true)
+					.OrderBy(x => x.IsTraitPaused)
+					.ThenByDescending(x => x.MaxRange())
+					.FirstOrDefault();
+				if (a == null)
+					return false;
 
 				cursor = !target.IsInRange(self.CenterPosition, a.MaxRange())
 					? ab.Info.OutsideRangeCursor ?? a.Info.OutsideRangeCursor

--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -239,9 +239,10 @@ namespace OpenRA.Mods.Common.Traits
 		CPos ChooseRallyLocationNear(Actor producer)
 		{
 			var possibleRallyPoints = world.Map.FindTilesInCircle(producer.Location, Info.RallyPointScanRadius)
-				.Where(c => IsRallyPointValid(c, producer.Info.TraitInfoOrDefault<BuildingInfo>()));
+				.Where(c => IsRallyPointValid(c, producer.Info.TraitInfoOrDefault<BuildingInfo>()))
+				.ToList();
 
-			if (!possibleRallyPoints.Any())
+			if (possibleRallyPoints.Count == 0)
 			{
 				AIUtils.BotDebug("{0} has no possible rallypoint near {1}", producer.Owner, producer.Location);
 				return producer.Location;

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -229,7 +229,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		ActorInfo ChooseBuildingToBuild(ProductionQueue queue)
 		{
-			var buildableThings = queue.BuildableItems();
+			var buildableThings = queue.BuildableItems().ToList();
 
 			// This gets used quite a bit, so let's cache it here
 			var power = GetProducibleBuilding(baseBuilder.Info.PowerTypes, buildableThings,

--- a/OpenRA.Mods.Common/Traits/BotModules/CaptureManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/CaptureManagerBotModule.cs
@@ -154,12 +154,13 @@ namespace OpenRA.Mods.Common.Traits
 			if (Info.CapturableActorTypes.Count > 0)
 				capturableTargetOptions = capturableTargetOptions.Where(target => Info.CapturableActorTypes.Contains(target.Info.Name.ToLowerInvariant()));
 
-			if (!capturableTargetOptions.Any())
+			var capturableTargetOptionsList = capturableTargetOptions.ToList();
+			if (capturableTargetOptionsList.Count == 0)
 				return;
 
 			foreach (var capturer in capturers)
 			{
-				var targetActor = capturableTargetOptions.MinByOrDefault(target => (target.CenterPosition - capturer.Actor.CenterPosition).LengthSquared);
+				var targetActor = capturableTargetOptionsList.MinByOrDefault(target => (target.CenterPosition - capturer.Actor.CenterPosition).LengthSquared);
 				if (targetActor == null)
 					continue;
 

--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -197,7 +197,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		internal Actor FindClosestEnemy(WPos pos)
 		{
-			var units = World.Actors.Where(IsPreferredEnemyUnit);
+			var units = World.Actors.Where(IsPreferredEnemyUnit).ToList();
 			return units.Where(IsNotHiddenUnit).ClosestTo(pos) ?? units.ClosestTo(pos);
 		}
 

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/AttackOrFleeFuzzy.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/AttackOrFleeFuzzy.cs
@@ -163,7 +163,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			fuzzyEngine.Rules.Add(fuzzyEngine.ParseRule(rule));
 		}
 
-		public bool CanAttack(IEnumerable<Actor> ownUnits, IEnumerable<Actor> enemyUnits)
+		public bool CanAttack(IReadOnlyCollection<Actor> ownUnits, IReadOnlyCollection<Actor> enemyUnits)
 		{
 			double attackChance;
 			var inputValues = new Dictionary<FuzzyVariable, double>();
@@ -201,7 +201,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			return (int)((long)sumOfHp * normalizeByValue / sumOfMaxHp);
 		}
 
-		static float RelativePower(IEnumerable<Actor> own, IEnumerable<Actor> enemy)
+		static float RelativePower(IReadOnlyCollection<Actor> own, IReadOnlyCollection<Actor> enemy)
 		{
 			return RelativeValue(own, enemy, 100, SumOfValues<AttackBaseInfo>, a =>
 			{
@@ -225,18 +225,18 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			});
 		}
 
-		static float RelativeSpeed(IEnumerable<Actor> own, IEnumerable<Actor> enemy)
+		static float RelativeSpeed(IReadOnlyCollection<Actor> own, IReadOnlyCollection<Actor> enemy)
 		{
 			return RelativeValue(own, enemy, 100, Average<MobileInfo>, (Actor a) => a.Info.TraitInfo<MobileInfo>().Speed);
 		}
 
-		static float RelativeValue(IEnumerable<Actor> own, IEnumerable<Actor> enemy, float normalizeByValue,
-					Func<IEnumerable<Actor>, Func<Actor, int>, float> relativeFunc, Func<Actor, int> getValue)
+		static float RelativeValue(IReadOnlyCollection<Actor> own, IReadOnlyCollection<Actor> enemy, float normalizeByValue,
+					Func<IReadOnlyCollection<Actor>, Func<Actor, int>, float> relativeFunc, Func<Actor, int> getValue)
 		{
-			if (!enemy.Any())
+			if (enemy.Count == 0)
 				return 999.0f;
 
-			if (!own.Any())
+			if (own.Count == 0)
 				return 0.0f;
 
 			var relative = relativeFunc(own, getValue) / relativeFunc(enemy, getValue) * normalizeByValue;

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
@@ -22,9 +22,9 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 
 		protected const int MissileUnitMultiplier = 3;
 
-		protected static int CountAntiAirUnits(IEnumerable<Actor> units)
+		protected static int CountAntiAirUnits(IReadOnlyCollection<Actor> units)
 		{
-			if (!units.Any())
+			if (units.Count == 0)
 				return 0;
 
 			var missileUnitsCount = 0;

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/NavyStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/NavyStates.cs
@@ -35,10 +35,9 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				&& mobile.PathFinder.PathExistsForLocomotor(mobile.Locomotor, first.Location, a.Location)
 				&& a.AppearsHostileTo(first));
 
-			if (navalProductions.Any())
+			var nearest = navalProductions.ClosestTo(first);
+			if (nearest != null)
 			{
-				var nearest = navalProductions.ClosestTo(first);
-
 				// Return nearest when it is FAR enough.
 				// If the naval production is within MaxBaseRadius, it implies that
 				// this squad is close to enemy territory and they should expect a naval combat;

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/StateBase.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/StateBase.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			return false;
 		}
 
-		protected virtual bool ShouldFlee(Squad squad, Func<IEnumerable<Actor>, bool> flee)
+		protected virtual bool ShouldFlee(Squad squad, Func<IReadOnlyCollection<Actor>, bool> flee)
 		{
 			if (!squad.IsValid)
 				return false;
@@ -95,8 +95,10 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				if (u.Owner == squad.Bot.Player && u.Info.HasTraitInfo<BuildingInfo>())
 					return false;
 
-			var enemyAroundUnit = units.Where(unit => squad.SquadManager.IsPreferredEnemyUnit(unit) && unit.Info.HasTraitInfo<AttackBaseInfo>());
-			if (!enemyAroundUnit.Any())
+			var enemyAroundUnit = units
+				.Where(unit => squad.SquadManager.IsPreferredEnemyUnit(unit) && unit.Info.HasTraitInfo<AttackBaseInfo>())
+				.ToList();
+			if (enemyAroundUnit.Count == 0)
 				return false;
 
 			return flee(enemyAroundUnit);

--- a/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
@@ -172,17 +172,18 @@ namespace OpenRA.Mods.Common.Traits
 
 		ActorInfo ChooseUnitToBuild(ProductionQueue queue)
 		{
-			var buildableThings = queue.BuildableItems();
-			if (!buildableThings.Any())
+			var buildableThings = queue.BuildableItems().Select(b => b.Name).ToHashSet();
+			if (buildableThings.Count == 0)
 				return null;
 
 			var myUnits = player.World
 				.ActorsHavingTrait<IPositionable>()
 				.Where(a => a.Owner == player)
-				.Select(a => a.Info.Name).ToList();
+				.Select(a => a.Info.Name)
+				.ToList();
 
 			foreach (var unit in Info.UnitsToBuild.Shuffle(world.LocalRandom))
-				if (buildableThings.Any(b => b.Name == unit.Key))
+				if (buildableThings.Contains(unit.Key))
 					if (myUnits.Count(a => a == unit.Key) * 100 < unit.Value * myUnits.Count)
 						if (HasAdequateAirUnitReloadBuildings(world.Map.Rules.Actors[unit.Key]))
 							return world.Map.Rules.Actors[unit.Key];

--- a/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
@@ -163,11 +163,8 @@ namespace OpenRA.Mods.Common.Traits
 		ActorInfo ChooseRandomUnitToBuild(ProductionQueue queue)
 		{
 			var buildableThings = queue.BuildableItems();
-			if (!buildableThings.Any())
-				return null;
-
-			var unit = buildableThings.Random(world.LocalRandom);
-			return HasAdequateAirUnitReloadBuildings(unit) ? unit : null;
+			var unit = buildableThings.RandomOrDefault(world.LocalRandom);
+			return unit != null && HasAdequateAirUnitReloadBuildings(unit) ? unit : null;
 		}
 
 		ActorInfo ChooseUnitToBuild(ProductionQueue queue)

--- a/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
@@ -80,9 +80,6 @@ namespace OpenRA.Mods.Common.Traits
 				return null;
 
 			var allOfType = Exits(actor, productionType);
-			if (!allOfType.Any())
-				return null;
-
 			foreach (var g in allOfType.GroupBy(e => e.Info.Priority))
 			{
 				var shuffled = g.Shuffle(world.SharedRandom);

--- a/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (Repairers.Remove(player))
 			{
 				UpdateCondition(self);
-				if (!Repairers.Any())
+				if (Repairers.Count == 0)
 				{
 					Game.Sound.PlayNotification(self.World.Map.Rules, player, "Speech", Info.RepairingStoppedNotification, player.Faction.InternalName);
 					TextNotificationsManager.AddTransientLine(self.Owner, Info.RepairingStoppedTextNotification);

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
@@ -54,12 +54,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
-			var locomotorInfos = rules.Actors[SystemActors.World].TraitInfos<LocomotorInfo>();
-			LocomotorInfo = locomotorInfos.FirstOrDefault(li => li.Name == Locomotor);
-			if (LocomotorInfo == null)
+			var locomotorInfos = rules.Actors[SystemActors.World].TraitInfos<LocomotorInfo>()
+				.Where(li => li.Name == Locomotor).ToList();
+			if (locomotorInfos.Count == 0)
 				throw new YamlException($"A locomotor named '{Locomotor}' doesn't exist.");
-			else if (locomotorInfos.Count(li => li.Name == Locomotor) > 1)
+			else if (locomotorInfos.Count > 1)
 				throw new YamlException($"There is more than one locomotor named '{Locomotor}'.");
+
+			LocomotorInfo = locomotorInfos[0];
 
 			base.RulesetLoaded(rules, ai);
 		}

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -113,23 +113,32 @@ namespace OpenRA.Mods.Common.Traits
 		void INotifyParachute.OnLanded(Actor self)
 		{
 			// Check whether the crate landed on anything
-			var landedOn = self.World.ActorMap.GetActorsAt(self.Location)
-				.Where(a => a != self);
-
-			if (!landedOn.Any())
-				return;
-
-			var collector = landedOn.FirstOrDefault(a =>
+			var anyOtherActors = false;
+			Actor collector = null;
+			foreach (var otherActor in self.World.ActorMap.GetActorsAt(self.Location))
 			{
+				if (self == otherActor)
+					continue;
+
+				anyOtherActors = true;
+
 				// Mobile is (currently) the only trait that supports crushing
-				var mi = a.Info.TraitInfoOrDefault<MobileInfo>();
+				var mi = otherActor.Info.TraitInfoOrDefault<MobileInfo>();
 				if (mi == null)
-					return false;
+					continue;
 
 				// Make sure that the actor can collect this crate type
 				// Crate can only be crushed if it is not in the air.
-				return self.IsAtGroundLevel() && mi.LocomotorInfo.Crushes.Contains(info.CrushClass);
-			});
+				if (self.IsAtGroundLevel() && mi.LocomotorInfo.Crushes.Contains(info.CrushClass))
+				{
+					collector = otherActor;
+					break;
+				}
+			}
+
+			// The crate can land unhindered.
+			if (!anyOtherActors)
+				return;
 
 			// Destroy the crate if none of the units in the cell are valid collectors
 			if (collector != null)
@@ -148,10 +157,11 @@ namespace OpenRA.Mods.Common.Traits
 			self.Dispose();
 			collected = true;
 
-			if (crateActions.Any())
+			var shares = crateActions
+				.Select(a => (Action: a, Shares: a.GetSelectionSharesOuter(crusher)))
+				.ToList();
+			if (shares.Count != 0)
 			{
-				var shares = crateActions.Select(a => (Action: a, Shares: a.GetSelectionSharesOuter(crusher)));
-
 				var totalShares = shares.Sum(a => a.Shares);
 				var n = self.World.SharedRandom.Next(totalShares);
 

--- a/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
@@ -111,11 +111,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		CPos? ChooseEmptyCellNear(Actor a, string unit)
 		{
-			var possibleCells = GetSuitableCells(a.Location, unit);
-			if (!possibleCells.Any())
-				return null;
-
-			return possibleCells.Random(self.World.SharedRandom);
+			return GetSuitableCells(a.Location, unit)
+				.Cast<CPos?>()
+				.RandomOrDefault(self.World.SharedRandom);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Crates/GrantExternalConditionCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GrantExternalConditionCrateAction.cs
@@ -76,7 +76,8 @@ namespace OpenRA.Mods.Common.Traits
 		void GrantCondition(Actor actor)
 		{
 			var externals = actor.TraitsImplementing<ExternalCondition>()
-				.Where(t => t.Info.Condition == info.Condition);
+				.Where(t => t.Info.Condition == info.Condition)
+				.ToList();
 
 			ExternalCondition external = null;
 			for (var n = 0; n < info.Levels; n++)

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -104,12 +104,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
-			var locomotorInfos = rules.Actors[SystemActors.World].TraitInfos<LocomotorInfo>();
-			LocomotorInfo = locomotorInfos.FirstOrDefault(li => li.Name == Locomotor);
-			if (LocomotorInfo == null)
+			var locomotorInfos = rules.Actors[SystemActors.World].TraitInfos<LocomotorInfo>()
+				.Where(li => li.Name == Locomotor).ToList();
+			if (locomotorInfos.Count == 0)
 				throw new YamlException($"A locomotor named '{Locomotor}' doesn't exist.");
-			else if (locomotorInfos.Count(li => li.Name == Locomotor) > 1)
+			else if (locomotorInfos.Count > 1)
 				throw new YamlException($"There is more than one locomotor named '{Locomotor}'.");
+
+			LocomotorInfo = locomotorInfos[0];
 
 			// We need to reset the reference to the locomotor between each worlds, otherwise we are reference the previous state.
 			locomotor = null;

--- a/OpenRA.Mods.Common/Traits/Player/ClassicParallelProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicParallelProductionQueue.cs
@@ -133,15 +133,15 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override TraitPair<Production> MostLikelyProducer()
 		{
-			var productionActors = self.World.ActorsWithTrait<Production>()
+			var productionActor = self.World.ActorsWithTrait<Production>()
 				.Where(x => x.Actor.Owner == self.Owner
 					&& !x.Trait.IsTraitDisabled && x.Trait.Info.Produces.Contains(Info.Type))
-				.OrderByDescending(x => x.Actor.IsPrimaryBuilding())
+				.OrderBy(x => x.Trait.IsTraitPaused)
+				.ThenByDescending(x => x.Actor.IsPrimaryBuilding())
 				.ThenByDescending(x => x.Actor.ActorID)
-				.ToList();
+				.FirstOrDefault();
 
-			var unpaused = productionActors.FirstOrDefault(a => !a.Trait.IsTraitPaused);
-			return unpaused.Trait != null ? unpaused : productionActors.FirstOrDefault();
+			return productionActor;
 		}
 
 		protected override bool BuildUnit(ActorInfo unit)
@@ -159,14 +159,10 @@ namespace OpenRA.Mods.Common.Traits
 				.OrderByDescending(x => x.Actor.IsPrimaryBuilding())
 				.ThenByDescending(x => x.Actor.ActorID);
 
-			if (!producers.Any())
-			{
-				CancelProduction(unit.Name, 1);
-				return false;
-			}
-
+			var anyProducers = false;
 			foreach (var p in producers)
 			{
+				anyProducers = true;
 				if (p.Trait.IsTraitPaused)
 					continue;
 
@@ -182,6 +178,12 @@ namespace OpenRA.Mods.Common.Traits
 					EndProduction(item);
 					return true;
 				}
+			}
+
+			if (!anyProducers)
+			{
+				CancelProduction(unit.Name, 1);
+				return false;
 			}
 
 			return false;

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -81,13 +81,14 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			var myTeam = self.World.LobbyInfo.ClientWithIndex(self.Owner.ClientIndex).Team;
-			var teams = self.World.Players.Where(p => !p.NonCombatant && p.Playable)
+			var victoriousTeam = self.World.Players.Where(p => !p.NonCombatant && p.Playable)
 				.Select(p => (Player: p, PlayerStatistics: p.PlayerActor.TraitOrDefault<PlayerStatistics>()))
 				.OrderByDescending(p => p.PlayerStatistics?.Experience ?? 0)
 				.GroupBy(p => (self.World.LobbyInfo.ClientWithIndex(p.Player.ClientIndex) ?? new Session.Client()).Team)
-				.OrderByDescending(g => g.Sum(gg => gg.PlayerStatistics?.Experience ?? 0));
+				.OrderByDescending(g => g.Sum(gg => gg.PlayerStatistics?.Experience ?? 0))
+				.First();
 
-			if (teams.First().Key == myTeam && (myTeam != 0 || teams.First().First().Player == self.Owner))
+			if (victoriousTeam.Key == myTeam && (myTeam != 0 || victoriousTeam.First().Player == self.Owner))
 			{
 				mo.MarkCompleted(self.Owner, objectiveID);
 				return;

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -594,9 +594,11 @@ namespace OpenRA.Mods.Common.Traits
 		// Returns the actor/trait that is most likely (but not necessarily guaranteed) to produce something in this queue
 		public virtual TraitPair<Production> MostLikelyProducer()
 		{
-			var traits = productionTraits.Where(p => !p.IsTraitDisabled && p.Info.Produces.Contains(Info.Type));
-			var unpaused = traits.FirstOrDefault(a => !a.IsTraitPaused);
-			return new TraitPair<Production>(Actor, unpaused ?? traits.FirstOrDefault());
+			var trait = productionTraits
+				.Where(p => !p.IsTraitDisabled && p.Info.Produces.Contains(Info.Type))
+				.OrderBy(p => p.IsTraitPaused)
+				.FirstOrDefault();
+			return new TraitPair<Production>(Actor, trait);
 		}
 
 		// Builds a unit from the actor that holds this queue (1 queue per building)

--- a/OpenRA.Mods.Common/Traits/RejectsOrders.cs
+++ b/OpenRA.Mods.Common/Traits/RejectsOrders.cs
@@ -44,10 +44,19 @@ namespace OpenRA.Mods.Common.Traits
 			if (rejectsOrdersTraits.Length == 0)
 				return true;
 
-			var reject = rejectsOrdersTraits.SelectMany(t => t.Reject);
-			var except = rejectsOrdersTraits.SelectMany(t => t.Except);
+			foreach (var rejectsOrdersTrait in rejectsOrdersTraits)
+				if (rejectsOrdersTrait.Except.Contains(orderString))
+					return true;
 
-			return except.Contains(orderString) || (reject.Any() && !reject.Contains(orderString));
+			var anyRejects = false;
+			foreach (var rejectsOrdersTrait in rejectsOrdersTraits)
+			{
+				anyRejects = anyRejects || rejectsOrdersTrait.Reject.Count > 0;
+				if (rejectsOrdersTrait.Reject.Contains(orderString))
+					return false;
+			}
+
+			return anyRejects;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithShadow.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithShadow.cs
@@ -51,29 +51,27 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (IsTraitDisabled)
 				return r;
 
+			var renderables = r.ToList();
 			var height = self.World.Map.DistanceAboveTerrain(self.CenterPosition).Length;
-			var shadowSprites = r.Where(s => !s.IsDecoration && s is IModifyableRenderable)
+			var shadowSprites = renderables.Where(s => !s.IsDecoration && s is IModifyableRenderable)
 				.Select(ma => ((IModifyableRenderable)ma).WithTint(shadowColor, ((IModifyableRenderable)ma).TintModifiers | TintModifiers.ReplaceColor)
 					.WithAlpha(shadowAlpha)
 					.OffsetBy(info.Offset - new WVec(0, 0, height))
 					.WithZOffset(ma.ZOffset + height + info.ZOffset)
 					.AsDecoration());
 
-			return shadowSprites.Concat(r);
+			return shadowSprites.Concat(renderables);
 		}
 
 		IEnumerable<Rectangle> IRenderModifier.ModifyScreenBounds(Actor self, WorldRenderer wr, IEnumerable<Rectangle> bounds)
 		{
-			foreach (var r in bounds)
-				yield return r;
-
 			if (IsTraitDisabled)
-				yield break;
+				return bounds;
 
+			var boundsList = bounds.ToList();
 			var height = self.World.Map.DistanceAboveTerrain(self.CenterPosition).Length;
 			var offset = wr.ScreenPxOffset(info.Offset - new WVec(0, 0, height));
-			foreach (var r in bounds)
-				yield return new Rectangle(r.X + offset.X, r.Y + offset.Y, r.Width, r.Height);
+			return boundsList.Concat(boundsList.Select(r => new Rectangle(r.X + offset.X, r.Y + offset.Y, r.Width, r.Height)));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -205,8 +205,8 @@ namespace OpenRA.Mods.Common.Traits
 			actorShouldBeRemoved = removeActorPosition.Contains;
 
 			LargestActorRadius = map.Rules.Actors.SelectMany(a => a.Value.TraitInfos<HitShapeInfo>()).Max(h => h.Type.OuterRadius);
-			var blockers = map.Rules.Actors.Where(a => a.Value.HasTraitInfo<IBlocksProjectilesInfo>());
-			LargestBlockingActorRadius = blockers.Any() ? blockers.SelectMany(a => a.Value.TraitInfos<HitShapeInfo>()).Max(h => h.Type.OuterRadius) : WDist.Zero;
+			var blockers = map.Rules.Actors.Where(a => a.Value.HasTraitInfo<IBlocksProjectilesInfo>()).ToList();
+			LargestBlockingActorRadius = blockers.Count != 0 ? blockers.SelectMany(a => a.Value.TraitInfos<HitShapeInfo>()).Max(h => h.Type.OuterRadius) : WDist.Zero;
 		}
 
 		void INotifyCreated.Created(Actor self)

--- a/OpenRA.Mods.Common/Traits/World/ColorPickerManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/ColorPickerManager.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits
 			return false;
 		}
 
-		Color MakeValid(float hue, float sat, float val, MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors, Action<string> onError)
+		Color MakeValid(float hue, float sat, float val, MersenneTwister random, IReadOnlyCollection<Color> terrainColors, IReadOnlyCollection<Color> playerColors, Action<string> onError)
 		{
 			// Clamp saturation without triggering a warning
 			// This can only happen due to rounding errors (common) or modified clients (rare)
@@ -132,7 +132,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		Color[] IColorPickerManagerInfo.PresetColors => PresetColors;
 
-		Color IColorPickerManagerInfo.RandomPresetColor(MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors)
+		Color IColorPickerManagerInfo.RandomPresetColor(MersenneTwister random, IReadOnlyCollection<Color> terrainColors, IReadOnlyCollection<Color> playerColors)
 		{
 			foreach (var color in PresetColors.Shuffle(random))
 			{
@@ -148,13 +148,13 @@ namespace OpenRA.Mods.Common.Traits
 			return MakeValid(randomHue, randomSat, randomVal, random, terrainColors, playerColors, null);
 		}
 
-		Color IColorPickerManagerInfo.MakeValid(Color color, MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors, Action<string> onError)
+		Color IColorPickerManagerInfo.MakeValid(Color color, MersenneTwister random, IReadOnlyCollection<Color> terrainColors, IReadOnlyCollection<Color> playerColors, Action<string> onError)
 		{
 			var (_, h, s, v) = color.ToAhsv();
 			return MakeValid(h, s, v, random, terrainColors, playerColors, onError);
 		}
 
-		Color IColorPickerManagerInfo.RandomValidColor(MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors)
+		Color IColorPickerManagerInfo.RandomValidColor(MersenneTwister random, IReadOnlyCollection<Color> terrainColors, IReadOnlyCollection<Color> playerColors)
 		{
 			var h = random.NextFloat();
 			var s = float2.Lerp(HsvSaturationRange[0], HsvSaturationRange[1], random.NextFloat());

--- a/OpenRA.Mods.Common/Traits/World/ControlGroups.cs
+++ b/OpenRA.Mods.Common/Traits/World/ControlGroups.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void CreateControlGroup(int group)
 		{
-			if (!world.Selection.Actors.Any())
+			if (world.Selection.Actors.Count == 0)
 				return;
 
 			controlGroups[group].Clear();
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void AddSelectionToControlGroup(int group)
 		{
-			if (!world.Selection.Actors.Any())
+			if (world.Selection.Actors.Count == 0)
 				return;
 
 			RemoveActorsFromAllControlGroups(world.Selection.Actors);

--- a/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs
+++ b/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		/// </summary>
 		void ICreatePlayersInfo.CreateServerPlayers(MapPreview map, Session lobbyInfo, List<GameInformation.Player> players, MersenneTwister playerRandom)
 		{
-			var factions = map.WorldActorInfo.TraitInfos<FactionInfo>().ToArray();
+			var factions = map.WorldActorInfo.TraitInfos<FactionInfo>();
 			var assignSpawnLocations = map.WorldActorInfo.TraitInfoOrDefault<IAssignSpawnPointsInfo>();
 			var spawnState = assignSpawnLocations?.InitializeState(map, lobbyInfo);
 
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// Create the regular playable players.
-			var bots = map.PlayerActorInfo.TraitInfos<IBotInfo>().ToArray();
+			var bots = map.PlayerActorInfo.TraitInfos<IBotInfo>();
 
 			foreach (var kv in lobbyInfo.Slots)
 			{

--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -178,7 +178,7 @@ namespace OpenRA.Mods.Common.Traits
 			return reference.GetOrDefault<T>(info);
 		}
 
-		public IEnumerable<T> GetInits<T>() where T : ActorInit
+		public IReadOnlyCollection<T> GetInits<T>() where T : ActorInit
 		{
 			return reference.GetAll<T>();
 		}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -380,9 +380,9 @@ namespace OpenRA.Mods.Common.Traits
 		(float VMin, float VMax) ValueRange { get; }
 		event Action<Color> OnColorPickerColorUpdate;
 		Color[] PresetColors { get; }
-		Color RandomPresetColor(MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors);
-		Color RandomValidColor(MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors);
-		Color MakeValid(Color color, MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors, Action<string> onError = null);
+		Color RandomPresetColor(MersenneTwister random, IReadOnlyCollection<Color> terrainColors, IReadOnlyCollection<Color> playerColors);
+		Color RandomValidColor(MersenneTwister random, IReadOnlyCollection<Color> terrainColors, IReadOnlyCollection<Color> playerColors);
+		Color MakeValid(Color color, MersenneTwister random, IReadOnlyCollection<Color> terrainColors, IReadOnlyCollection<Color> playerColors, Action<string> onError = null);
 		void ShowColorDropDown(DropDownButtonWidget dropdownButton, Color initialColor, string initialFaction, WorldRenderer worldRenderer, Action<Color> onExit);
 	}
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UnhardcodeVeteranProductionIconOverlay.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UnhardcodeVeteranProductionIconOverlay.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {
@@ -24,7 +23,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override IEnumerable<string> AfterUpdate(ModData modData)
 		{
-			if (locations.Any())
+			if (locations.Count != 0)
 				yield return "Icon overlay logic has been split from ProducibleWithLevel to WithProductionIconOverlay trait.\n" +
 					"If you have been using VeteranProductionIconOverlay trait, add WithProductionIconOverlay to following actors:\n" +
 					UpdateUtils.FormatMessageList(locations);

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230225/ExplicitSequenceFilenames.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230225/ExplicitSequenceFilenames.cs
@@ -45,16 +45,16 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				foreach (var sequenceNode in imageNode.Value.Nodes)
 				{
 					var useTilesetExtensionNode = sequenceNode.LastChildMatching("UseTilesetExtension");
-					if (useTilesetExtensionNode != null && !tilesetExtensions.Any())
+					if (useTilesetExtensionNode != null && tilesetExtensions.Count == 0)
 						requiredMetadata.Add("TilesetExtensions");
 
 					var useTilesetCodeNode = sequenceNode.LastChildMatching("UseTilesetCode");
-					if (useTilesetCodeNode != null && !tilesetCodes.Any())
+					if (useTilesetCodeNode != null && tilesetCodes.Count == 0)
 						requiredMetadata.Add("TilesetCodes");
 				}
 			}
 
-			if (requiredMetadata.Any())
+			if (requiredMetadata.Count != 0)
 			{
 				yield return $"The ExplicitSequenceFilenames rule requires {requiredMetadata.JoinWith(", ")}\n" +
 				             "to be defined under the SpriteSequenceFormat definition in mod.yaml.\n" +
@@ -317,7 +317,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 						if (allSequencesHaveTilesetFilenames)
 							sequenceNode.RemoveNodes("TilesetFilenames");
 
-						if (!sequenceNode.Value.Nodes.Any())
+						if (sequenceNode.Value.Nodes.Count == 0)
 							imageNode.RemoveNode(sequenceNode);
 					}
 
@@ -328,13 +328,13 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 						sequenceNode.RemoveNodes("TilesetFilenames");
 
 					var tilesetFilenamesNode = sequenceNode.LastChildMatching("TilesetFilenames");
-					if (allSequencesHaveTilesetFilenames && tilesetFilenamesNode != null && !tilesetFilenamesNode.Value.Nodes.Any())
+					if (allSequencesHaveTilesetFilenames && tilesetFilenamesNode != null && tilesetFilenamesNode.Value.Nodes.Count == 0)
 						sequenceNode.RemoveNode(tilesetFilenamesNode);
 				}
 			}
 
 			foreach (var sequenceNode in imageNode.Value.Nodes.ToList())
-				if (implicitInheritedSequences.Contains(sequenceNode.Key) && !sequenceNode.Value.Nodes.Any())
+				if (implicitInheritedSequences.Contains(sequenceNode.Key) && sequenceNode.Value.Nodes.Count == 0)
 					imageNode.RemoveNode(sequenceNode);
 		}
 
@@ -424,7 +424,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 						if (overrideNode.Value.Value == filenameNode.Value.Value)
 							tilesetFilenamesNode.Value.Nodes.Remove(overrideNode);
 
-					if (!tilesetFilenamesNode.Value.Nodes.Any())
+					if (tilesetFilenamesNode.Value.Nodes.Count == 0)
 						sequenceNode.RemoveNode(tilesetFilenamesNode);
 
 					sequenceNode.Value.Nodes.Insert(0, filenameNode);

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 			}),
 		};
 
-		public static IEnumerable<UpdateRule> FromSource(ObjectCreator objectCreator, string source, bool chain = true)
+		public static IReadOnlyCollection<UpdateRule> FromSource(ObjectCreator objectCreator, string source, bool chain = true)
 		{
 			// Use reflection to identify types
 			var namedType = objectCreator.FindType(source);
@@ -143,12 +143,12 @@ namespace OpenRA.Mods.Common.UpdateRules
 			this.chainToSource = chainToSource;
 		}
 
-		IEnumerable<UpdateRule> Rules(bool chain = true)
+		IReadOnlyCollection<UpdateRule> Rules(bool chain = true)
 		{
 			if (chainToSource != null && chain)
 			{
 				var child = Paths.First(p => p.source == chainToSource);
-				return rules.Concat(child.Rules(chain));
+				return rules.Concat(child.Rules(chain)).ToList();
 			}
 
 			return rules;

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractEmmyLuaAPI.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractEmmyLuaAPI.cs
@@ -271,7 +271,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				if (isActivity)
 					Console.WriteLine("    --- *Queued Activity*");
 
-				if (requiredTraits.Any())
+				if (requiredTraits.Length != 0)
 					Console.WriteLine($"    --- **Requires {(requiredTraits.Length == 1 ? "Trait" : "Traits")}:** {requiredTraits.Select(GetDocumentationUrl).JoinWith(", ")}");
 
 				if (memberInfo is MethodInfo methodInfo)

--- a/OpenRA.Mods.Common/UtilityCommands/UpdateMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpdateMapCommand.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			if (folder.OpenPackage(args[1], modData.ModFiles) is not IReadWritePackage package)
 				throw new FileNotFoundException(args[1]);
 
-			IEnumerable<UpdateRule> rules = null;
+			IReadOnlyCollection<UpdateRule> rules = null;
 			if (args.Length > 2)
 				rules = UpdatePath.FromSource(modData.ObjectCreator, args[2]);
 
@@ -77,9 +77,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				}
 
 				var other = UpdatePath.KnownRules(modData.ObjectCreator)
-					.Where(r => !ruleGroups.Values.Any(g => g.Contains(r)));
+					.Where(r => !ruleGroups.Values.Any(g => g.Contains(r)))
+					.ToList();
 
-				if (other.Any())
+				if (other.Count != 0)
 				{
 					Console.WriteLine("      Other:");
 					foreach (var r in other)

--- a/OpenRA.Mods.Common/UtilityCommands/UpdateModCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpdateModCommand.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			// HACK: The engine code assumes that Game.modData is set.
 			var modData = Game.ModData = utility.ModData;
 
-			IEnumerable<UpdateRule> rules = null;
+			IReadOnlyCollection<UpdateRule> rules = null;
 			if (args.Length > 1)
 				rules = UpdatePath.FromSource(modData.ObjectCreator, args[1]);
 
@@ -71,9 +71,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				}
 
 				var other = UpdatePath.KnownRules(modData.ObjectCreator)
-					.Where(r => !ruleGroups.Values.Any(g => g.Contains(r)));
+					.Where(r => !ruleGroups.Values.Any(g => g.Contains(r)))
+					.ToList();
 
-				if (other.Any())
+				if (other.Count != 0)
 				{
 					Console.WriteLine("      Other:");
 					foreach (var r in other)
@@ -111,9 +112,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				PrintSummary(rules, args.Contains("--detailed"));
 		}
 
-		public static void PrintSummary(IEnumerable<UpdateRule> rules, bool detailed)
+		public static void PrintSummary(IReadOnlyCollection<UpdateRule> rules, bool detailed)
 		{
-			var count = rules.Count();
+			var count = rules.Count;
 			if (count == 1)
 				Console.WriteLine("Found 1 API change:");
 			else

--- a/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
@@ -60,9 +60,9 @@ namespace OpenRA.Mods.Common.Warheads
 
 			if (RandomClusterCount != 0)
 			{
-				var randomTargetCells = CellsMatching(targetCell, true);
-				var clusterCount = RandomClusterCount < 0 ? randomTargetCells.Count() : RandomClusterCount;
-				if (randomTargetCells.Any())
+				var randomTargetCells = CellsMatching(targetCell, true).ToList();
+				var clusterCount = RandomClusterCount < 0 ? randomTargetCells.Count : RandomClusterCount;
+				if (randomTargetCells.Count != 0)
 					for (var i = 0; i < clusterCount; i++)
 						FireProjectileAtCell(map, firedBy, target, randomTargetCells.Random(firedBy.World.SharedRandom), args);
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					.SelectMany(t => t.Value.RestrictedPlayerColors)
 					.Distinct()
 					.ToList();
-				var playerColors = Enumerable.Empty<Color>();
+				var playerColors = Array.Empty<Color>();
 				randomButton.OnClick = () =>
 				{
 					var randomColor = colorManager.RandomValidColor(world.LocalRandom, terrainColors, playerColors);
@@ -140,7 +140,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var colorIndex = j * paletteCols + i;
 
 					var newSwatch = (ColorBlockWidget)customColorTemplate.Clone();
-					var getColor = new CachedTransform<Color, Color>(c => colorManager.MakeValid(c, world.LocalRandom, Enumerable.Empty<Color>(), Enumerable.Empty<Color>()));
+					var getColor = new CachedTransform<Color, Color>(c => colorManager.MakeValid(c, world.LocalRandom, Array.Empty<Color>(), Array.Empty<Color>()));
 
 					newSwatch.GetColor = () => getColor.Update(Game.Settings.Player.CustomColors[colorIndex]);
 					newSwatch.IsVisible = () => Game.Settings.Player.CustomColors.Length > colorIndex;

--- a/OpenRA.Mods.Common/Widgets/Logic/EncyclopediaLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/EncyclopediaLogic.cs
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var actors = new List<KeyValuePair<ActorInfo, EncyclopediaInfo>>();
 			foreach (var actor in modData.DefaultRules.Actors.Values)
 			{
-				if (!actor.TraitInfos<IRenderActorPreviewSpritesInfo>().Any())
+				if (actor.TraitInfos<IRenderActorPreviewSpritesInfo>().Count == 0)
 					continue;
 
 				var statistics = actor.TraitInfoOrDefault<UpdatesPlayerStatisticsInfo>();

--- a/OpenRA.Mods.Common/Widgets/Logic/EncyclopediaLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/EncyclopediaLogic.cs
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 		}
 
-		IEnumerable<KeyValuePair<ActorInfo, EncyclopediaInfo>> GetFilteredActorEncyclopediaPairs()
+		IReadOnlyCollection<KeyValuePair<ActorInfo, EncyclopediaInfo>> GetFilteredActorEncyclopediaPairs()
 		{
 			var actors = new List<KeyValuePair<ActorInfo, EncyclopediaInfo>>();
 			foreach (var actor in modData.DefaultRules.Actors.Values)
@@ -149,9 +149,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var buildable = actor.TraitInfoOrDefault<BuildableInfo>();
 			if (buildable != null)
 			{
-				var prerequisites = buildable.Prerequisites.Select(a => ActorName(modData.DefaultRules, a))
-					.Where(s => !s.StartsWith('~') && !s.StartsWith('!'));
-				if (prerequisites.Any())
+				var prerequisites = buildable.Prerequisites
+					.Select(a => ActorName(modData.DefaultRules, a))
+					.Where(s => !s.StartsWith('~') && !s.StartsWith('!'))
+					.ToList();
+				if (prerequisites.Count != 0)
 					text += $"Requires {prerequisites.JoinWith(", ")}\n\n";
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -113,7 +113,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				.Select(p => (Player: p, PlayerStatistics: p.PlayerActor.TraitOrDefault<PlayerStatistics>()))
 				.OrderByDescending(p => p.PlayerStatistics?.Experience ?? 0)
 				.GroupBy(p => (world.LobbyInfo.ClientWithIndex(p.Player.ClientIndex) ?? new Session.Client()).Team)
-				.OrderByDescending(g => g.Sum(gg => gg.PlayerStatistics?.Experience ?? 0));
+				.OrderByDescending(g => g.Sum(gg => gg.PlayerStatistics?.Experience ?? 0))
+				.ToList();
 
 			void KickAction(Session.Client client)
 			{
@@ -133,7 +134,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			foreach (var t in teams)
 			{
-				if (teams.Count() > 1)
+				if (teams.Count > 1)
 				{
 					var teamHeader = ScrollItemWidget.Setup(teamTemplate, () => false, () => { });
 					var team = t.Key > 0

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/SelectAllUnitsHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/SelectAllUnitsHotkeyLogic.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 			var newSelection = SelectionUtils.SelectActorsOnScreen(world, worldRenderer, null, eligiblePlayers).SubsetWithHighestSelectionPriority(e.Modifiers).ToList();
 
 			// Check if selecting actors on the screen has selected new units
-			if (newSelection.Count > selection.Actors.Count())
+			if (newSelection.Count > selection.Actors.Count)
 				TextNotificationsManager.AddFeedbackLine(SelectedUnitsAcrossScreen, Translation.Arguments("units", newSelection.Count));
 			else
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/SelectUnitsByTypeHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/SelectUnitsByTypeHotkeyLogic.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 			if (world.IsGameOver)
 				return false;
 
-			if (!selection.Actors.Any())
+			if (selection.Actors.Count == 0)
 			{
 				TextNotificationsManager.AddFeedbackLine(NothingSelected);
 				Game.Sound.PlayNotification(world.Map.Rules, world.LocalPlayer, "Sounds", ClickDisabledSound, null);
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 			var newSelection = SelectionUtils.SelectActorsOnScreen(world, worldRenderer, selectedClasses, eligiblePlayers).ToList();
 
 			// Check if selecting actors on the screen has selected new units
-			if (newSelection.Count > selection.Actors.Count())
+			if (newSelection.Count > selection.Actors.Count)
 				TextNotificationsManager.AddFeedbackLine(SelectedUnitsAcrossScreen, Translation.Arguments("units", newSelection.Count));
 			else
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
@@ -114,9 +114,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				.GroupBy(p => (world.LobbyInfo.ClientWithIndex(p.Player.ClientIndex) ?? new Session.Client()).Team)
 				.OrderBy(g => g.Key);
 
-			var noTeams = teams.Count() == 1;
+			var teamsList = teams.ToList();
+			var noTeams = teamsList.Count == 1;
 			var totalPlayers = 0;
-			foreach (var t in teams)
+			foreach (var t in teamsList)
 			{
 				totalPlayers += t.Count();
 				var label = noTeams ? TranslationProvider.GetString(Players) : t.Key > 0
@@ -209,12 +210,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (e.Key >= Keycode.NUMBER_0 && e.Key <= Keycode.NUMBER_9)
 				{
 					var key = (int)e.Key - (int)Keycode.NUMBER_0;
-					var team = teams.Where(t => t.Key == key).SelectMany(s => s);
-					if (!team.Any())
+					var team = teams.Where(t => t.Key == key).SelectMany(s => s).ToList();
+					if (team.Count == 0)
 						return false;
 
 					if (e.Modifiers == Modifiers.Shift)
-						team = team.Reverse();
+						team.Reverse();
 
 					selected = team.SkipWhile(t => t.Player != selected.Player).Skip(1).FirstOrDefault() ?? team.FirstOrDefault();
 					selected.OnClick();

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromSourceLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromSourceLogic.cs
@@ -183,7 +183,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						selectedPackages = availablePackages.ToDictionary(x => x.Identifier, y => y.Required);
 
 						// Ignore source if content is already installed
-						if (availablePackages.Any())
+						if (availablePackages.Length != 0)
 						{
 							Game.RunAfterTick(() =>
 							{
@@ -218,10 +218,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				var options = new Dictionary<string, IEnumerable<string>>();
 
-				if (gameSources.Any())
+				if (gameSources.Count != 0)
 					options.Add(TranslationProvider.GetString(GameSources), gameSources);
 
-				if (digitalInstalls.Any())
+				if (digitalInstalls.Count != 0)
 					options.Add(TranslationProvider.GetString(DigitalInstalls), digitalInstalls);
 
 				Game.RunAfterTick(() =>

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
@@ -112,9 +112,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				requiredWidget.IsVisible = () => p.Value.Required;
 
 				var sourceWidget = container.Get<ImageWidget>("SOURCE");
-				var sourceTitles = p.Value.Sources.Select(s => sources[s].Title).Distinct();
+				var sourceTitles = p.Value.Sources.Select(s => sources[s].Title).Distinct().ToList();
 				var sourceList = sourceTitles.JoinWith("\n");
-				var isSourceAvailable = sourceTitles.Any();
+				var isSourceAvailable = sourceTitles.Count != 0;
 				sourceWidget.GetTooltipText = () => sourceList;
 				sourceWidget.IsVisible = () => isSourceAvailable;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -322,18 +322,19 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (!int.TryParse(mapFilter, out var playerCountFilter))
 				playerCountFilter = -1;
 
-			var validMaps = tabMaps[tab]
+			var maps = tabMaps[tab]
 				.Where(m => category == null || m.Categories.Contains(category))
 				.Where(m => mapFilter == null ||
 					(m.Title != null && m.Title.Contains(mapFilter, StringComparison.CurrentCultureIgnoreCase)) ||
 					(m.Author != null && m.Author.Contains(mapFilter, StringComparison.CurrentCultureIgnoreCase)) ||
 					m.PlayerCount == playerCountFilter);
 
-			IOrderedEnumerable<MapPreview> maps;
 			if (orderByFunc == null)
-				maps = validMaps.OrderBy(m => m.Title);
+				maps = maps.OrderBy(m => m.Title);
 			else
-				maps = validMaps.OrderBy(orderByFunc).ThenBy(m => m.Title);
+				maps = maps.OrderBy(orderByFunc).ThenBy(m => m.Title);
+
+			maps = maps.ToList();
 
 			scrollpanels[tab].RemoveChildren();
 			foreach (var loop in maps)

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -136,9 +136,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						})
 						.Where(x => x.Index != -1)
 						.OrderBy(x => x.Index)
-						.Select(x => x.Preview);
+						.Select(x => x.Preview)
+						.ToList();
 
-					if (previews.Any())
+					if (previews.Count != 0)
 					{
 						CreateMissionGroup(kv.Key, previews, onExit);
 						allPreviews.AddRange(previews);
@@ -148,9 +149,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			// Add an additional group for loose missions
 			var loosePreviews = modData.MapCache
-				.Where(p => p.Status == MapStatus.Available && p.Visibility.HasFlag(MapVisibility.MissionSelector) && !allPreviews.Any(a => a.Uid == p.Uid));
+				.Where(p => p.Status == MapStatus.Available &&
+					p.Visibility.HasFlag(MapVisibility.MissionSelector) &&
+					!allPreviews.Any(a => a.Uid == p.Uid))
+				.ToList();
 
-			if (loosePreviews.Any())
+			if (loosePreviews.Count != 0)
 			{
 				CreateMissionGroup("Missions", loosePreviews, onExit);
 				allPreviews.AddRange(loosePreviews);

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -715,10 +715,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				var players = replay.GameInfo.Players
 					.GroupBy(p => p.Team)
-					.OrderBy(g => g.Key);
+					.OrderBy(g => g.Key)
+					.ToList();
 
 				var teams = new Dictionary<string, IEnumerable<GameInformation.Player>>();
-				var noTeams = players.Count() == 1;
+				var noTeams = players.Count == 1;
 				foreach (var p in players)
 				{
 					var label = noTeams ? TranslationProvider.GetString(Players) : p.Key > 0

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -572,10 +572,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var players = server.Clients
 				.Where(c => !c.IsSpectator)
 				.GroupBy(p => p.Team)
-				.OrderBy(g => g.Key);
+				.OrderBy(g => g.Key)
+				.ToList();
 
 			var teams = new Dictionary<string, IEnumerable<GameClient>>();
-			var noTeams = players.Count() == 1;
+			var noTeams = players.Count == 1;
 			foreach (var p in players)
 			{
 				var label = noTeams ? TranslationProvider.GetString(Players) : p.Key > 0

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
@@ -183,9 +183,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				var typesInGroup = hg.Value;
 				var keysInGroup = modData.Hotkeys.Definitions
-					.Where(hd => IsHotkeyVisibleInFilter(hd) && hd.Types.Overlaps(typesInGroup));
+					.Where(hd => IsHotkeyVisibleInFilter(hd) && hd.Types.Overlaps(typesInGroup))
+					.ToList();
 
-				if (!keysInGroup.Any())
+				if (keysInGroup.Count == 0)
 					continue;
 
 				var header = headerTemplate.Clone();

--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -102,14 +102,15 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var queues = world.ActorsWithTrait<ProductionQueue>()
 				.Where(a => a.Actor.Owner == player)
-				.Select((a, i) => new { a.Trait, i });
+				.Select(a => a.Trait)
+				.ToList();
 
 			foreach (var queue in queues)
-				if (!clocks.ContainsKey(queue.Trait))
-					clocks.Add(queue.Trait, new Animation(world, ClockAnimation));
+				if (!clocks.ContainsKey(queue))
+					clocks.Add(queue, new Animation(world, ClockAnimation));
 
 			var currentItemsByItem = queues
-					.Select(a => a.Trait.CurrentItem())
+					.Select(q => q.CurrentItem())
 					.Where(pi => pi != null)
 					.GroupBy(pr => pr.Item)
 					.OrderBy(g => g.First().Queue.Info.DisplayOrder)

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -443,7 +443,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (facility == null || facility.OccupiesSpace == null)
 				return true;
 
-			if (selection.Actors.Count() == 1 && selection.Contains(facility))
+			if (selection.Actors.Count == 1 && selection.Contains(facility))
 				viewport.Center(selection.Actors);
 			else
 				selection.Combine(World, new[] { facility }, false, true);

--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -183,9 +183,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override void Draw()
 		{
-			var tabs = Groups[queueGroup].Tabs.Where(t => t.Queue.BuildableItems().Any());
+			var tabs = Groups[queueGroup].Tabs.Where(t => t.Queue.BuildableItems().Any()).ToList();
 
-			if (!tabs.Any())
+			if (tabs.Count == 0)
 				return;
 
 			var rb = RenderBounds;

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				if (useClassicMouseStyle && HasMouseFocus)
 				{
-					if (!IsValidDragbox && World.Selection.Actors.Any() && !multiClick && uog.InputOverridesSelection(World, mousePos, mi))
+					if (!IsValidDragbox && World.Selection.Actors.Count != 0 && !multiClick && uog.InputOverridesSelection(World, mousePos, mi))
 					{
 						// Order units instead of selecting
 						ApplyOrders(World, mi);

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.D2k.Activities
 			swallow = self.Trait<AttackSwallow>();
 		}
 
-		bool AttackTargets(Actor self, IEnumerable<Actor> targets)
+		bool AttackTargets(Actor self, IReadOnlyCollection<Actor> targets)
 		{
 			var targetLocation = target.Actor.Location;
 			foreach (var t in targets)
@@ -129,9 +129,10 @@ namespace OpenRA.Mods.D2k.Activities
 					}
 
 					var targets = self.World.ActorMap.GetActorsAt(targetLocation)
-						.Where(t => !t.Equals(self) && weapon.IsValidAgainst(t, self));
+						.Where(t => !t.Equals(self) && weapon.IsValidAgainst(t, self))
+						.ToList();
 
-					if (!targets.Any())
+					if (targets.Count == 0)
 					{
 						RevokeCondition(self);
 						return true;

--- a/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
+++ b/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.D2k.Traits
 			if (pieces < info.Pieces[0])
 				pieces = info.Pieces[0];
 
-			var cells = self.World.Map.FindTilesInAnnulus(self.Location, 1, info.Range);
+			var cells = self.World.Map.FindTilesInAnnulus(self.Location, 1, info.Range).ToList();
 
 			for (var i = 0; i < pieces; i++)
 			{

--- a/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
@@ -509,17 +509,12 @@ namespace OpenRA.Mods.D2k.UtilityCommands
 
 			// HACK: The arrakis.yaml tileset file seems to be missing some tiles, so just get a replacement for them
 			// Also used for duplicate tiles that are taken from only tileset
-			if (template == null)
+			// Just get a template that contains a tile with the same ID as requested
+			template ??= terrainInfo.Templates.FirstOrDefault(t =>
 			{
-				// Just get a template that contains a tile with the same ID as requested
-				var templates = terrainInfo.Templates.Where(t =>
-				{
-					var templateInfo = (DefaultTerrainTemplateInfo)t.Value;
-					return templateInfo.Frames != null && templateInfo.Frames.Contains(tileIndex);
-				});
-				if (templates.Any())
-					template = templates.First().Value;
-			}
+				var templateInfo = (DefaultTerrainTemplateInfo)t.Value;
+				return templateInfo.Frames != null && templateInfo.Frames.Contains(tileIndex);
+			}).Value;
 
 			if (template == null)
 			{

--- a/OpenRA.Test/OpenRA.Game/PriorityQueueTest.cs
+++ b/OpenRA.Test/OpenRA.Game/PriorityQueueTest.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Test
 		public void PriorityQueueAddThenRemoveTest(int count, int seed)
 		{
 			var mt = new MersenneTwister(seed);
-			var values = Enumerable.Range(0, count);
+			var values = Enumerable.Range(0, count).ToList();
 			var shuffledValues = values.Shuffle(mt).ToArray();
 
 			var queue = new Primitives.PriorityQueue<int, Int32Comparer>(default);


### PR DESCRIPTION
Following on from #20957

Enforces https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1851

We fix violations in a few ways:

1. Enumerating the input only once. This provides the best result - we can continue to accept any enumerable and don't have to allocate memory to materialize a list.
2. Changing the input to `IReadOnlyCollection<T>`. This reduces the flexibility of inputs, but often input is already a materialized collection and thus this isn't a problem in many callsites. We can safely enumerate a collection multiple times.
3. Materialize the source via `ToList`. This means allocating an intermediate list but is always an option if the above options cannot be employed.

Specific changes of interest:
- ActorInfo.cs - as we want to enumerate this enumerable fresh each time due to the changing results, we suppress the warning.
- TypeDictionary.cs - we borrow a technique already employed in TraitDictionary of a container interface. This allows us to access the backing list after casting the container. In turn we can expose the list as `IReadOnlyCollection` which helps a lot of callsites not have to deal with `IEnumerable`.