### PR TITLE
Add Docker files to compile and launch games inside container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# non-visible files
+.git
+.github
+.vscode
+.gitignore
+.dockerignore
+.editorconfig
+.gitattributes
+.kateproject
+
+# files that are not related to dotnet restore
+COPYING
+AUTHORS
+VERSION
+Dockerfile
+omnisharp.json
+*.md
+*.sh
+*.cmd
+*.ps1
+*.dat
+*.log
+
+# previous builds' files
+/bin
+IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP
+/in-container-config

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ update.log
 
 # IntelliJ files
 .idea
+
+# Docker volume directories
+/in-container-config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy
+
+# install dependencies
+RUN apt-get update --quiet \
+ && apt-get install --no-install-recommends --yes --quiet \
+    libfreetype6 \
+    libgl1-mesa-dri \
+    libgl1-mesa-glx \
+    liblua5.1-0 \
+    libopenal1 \
+    libsdl2-2.0-0 \
+    make \
+    python3-minimal \
+    zenity \
+ && rm --recursive --force /var/lib/apt/lists/*
+
+# restore NuGet packages
+WORKDIR /nuget-packages
+COPY . /nuget-packages
+RUN make clean \
+ && dotnet restore \
+ && rm --recursive --force /nuget-packages/
+
+WORKDIR /openra
+
+CMD ["sh", "-c", "make; ./launch-game.sh"]

--- a/docker-launch.sh
+++ b/docker-launch.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+docker run --rm --interactive --tty \
+    --volume $(pwd):/openra \
+    --volume $(pwd)/in-container-config:/root/.config/openra \
+    --volume "${HOME}/.Xauthority:/root/.Xauthority" \
+    --env DISPLAY=unix${DISPLAY} \
+    --device /dev/dri \
+    --device /dev/snd \
+    --net host \
+    openra:latest $@


### PR DESCRIPTION
Minimally invasive Docker files and shell scripts to compile the code, launch the games inside the container and to work with Linux's visual and audio devices, download necessary external files and see the Multiplayer servers from container.

I've tried not to change the rest of the code, to make this stand-alone as possible as a first phase. It is not optimized to work for publishing the games, it is more of a development image; though compiled games run performantly in container for Linux.

I have tried to create small interface for this. For example, when below commands run from the terminal:
```
make clean
docker build . --tag openra
chmod -v +x docker-launch.sh
./docker-launch.sh
```
it should compile and launch the initial zenity's Game Mod's choice prompt.

You can interact with and get in the container with:
```
./docker-launch.sh bash
```
and it should give you
`
/openra# 
`
prompt. Then, you can work with it however you want, e.g.:
```
/openra# make && ./launch-game.sh Game.Mod=ra
``` 
and you can enter the OpenRA directly.


Related to #20997.

---
**A known situation**: If any internet browser (Firefox in my case), audio/video players are open, the container cannot access the audio devices, it is locked out. For that situation, audio does not work. Other than that, audio works without a problem.