### PR TITLE
Add text fix, minor polish to Controlled Burn

### DIFF
--- a/mods/ra/maps/sarin-gas-3-controlled-burn/controlledburn-AI.lua
+++ b/mods/ra/maps/sarin-gas-3-controlled-burn/controlledburn-AI.lua
@@ -100,6 +100,7 @@ GroundWavesDelays =
 	normal = 3,
 	hard = 2
 }
+GroundWavesDelay = GroundWavesDelays[Difficulty]
 
 GroundWaves = function()
 	if not ForwardCommand.IsDead then
@@ -107,7 +108,7 @@ GroundWaves = function()
 		local units = Reinforcements.Reinforce(BadGuy, Utils.Random(GroundAttackUnits), path)
 		Utils.Do(units, IdleHunt)
 
-		Trigger.AfterDelay(DateTime.Minutes(GroundWavesDelays), GroundWaves)
+		Trigger.AfterDelay(DateTime.Minutes(GroundWavesDelay), GroundWaves)
 	end
 end
 
@@ -132,8 +133,6 @@ ProduceAircraft = function()
 end
 
 ActivateAI = function()
-	GroundWavesDelays = GroundWavesDelays[Difficulty]
-
 	local buildings = Utils.Where(Map.ActorsInWorld, function(self) return self.Owner == USSR and self.HasProperty("StartBuildingRepairs") end)
 	Utils.Do(buildings, function(actor)
 		Trigger.OnDamaged(actor, function(building)
@@ -146,6 +145,6 @@ ActivateAI = function()
 	ProduceBadGuyInfantry()
 	ProduceUSSRInfantry()
 	ProduceVehicles()
-	Trigger.AfterDelay(DateTime.Minutes(GroundWavesDelays), GroundWaves)
+	Trigger.AfterDelay(DateTime.Minutes(GroundWavesDelay), GroundWaves)
 	Trigger.AfterDelay(DateTime.Minutes(5), ProduceAircraft)
 end

--- a/mods/ra/maps/sarin-gas-3-controlled-burn/rules.yaml
+++ b/mods/ra/maps/sarin-gas-3-controlled-burn/rules.yaml
@@ -19,6 +19,9 @@ Player:
 	PlayerResources:
 		DefaultCash: 7500
 
+HARV:
+	-MustBeDestroyed:
+
 APC:
 	Buildable:
 		Prerequisites: ~vehicles.allies


### PR DESCRIPTION
These are some changes prompted by feedback from Henskelion on the discord. The main aim was a timely translation fix, so the changes are light.

---

Fixed some text that was left untranslated after the strings were extracted.

![ControlledBurn-Text-1](https://github.com/OpenRA/OpenRA/assets/4985264/640e8566-35fe-44c3-bca7-3bdb62dd134c)


Once all structures in the main base (aside from sarin plants) are killed or captured, USSR's units will hunt to speed up the ending.
  - This is not original behavior for the map, but this or [fire sales](https://cnc.fandom.com/wiki/Fire_sale) are common with "Destroy all X" objectives.
  - Idle harvesters won't need to be killed to "Destroy the enemy compound." I figure that lines up with [the earlier BadGuy change](https://github.com/OpenRA/OpenRA/pull/18430#issuecomment-663767150).

The Allies' signal flare is announced, as in the original.

Fixed the linter's complaint about `GroundWavesDelays` being used as a table _and_ integer.
