### PR TITLE
Remove a bogus CanDeploy check from order resolving for charge deploys

### DIFF
--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeployWithCharge.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeployWithCharge.cs
@@ -147,7 +147,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void ResolveOrder(Actor self, Order order)
 		{
-			if (order.OrderString == "DeployWithCharge" && CanDeploy())
+			if (order.OrderString == "DeployWithCharge")
 				self.QueueActivity(order.Queued, new DeployForGrantedConditionWithCharge(self, this));
 		}
 


### PR DESCRIPTION
Fixes an oversight from #20824. The deploy state cannot be checked at this time for (queued) orders. To reproduce simply let a Saboteur run out of charge, order the unit to move and immediately queue a deploy. On bleed it will not deploy when finishing the move activity. With this PR it will.