### PR TITLE
Add vote kick

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -86,8 +86,9 @@ namespace OpenRA
 
 		static void JoinInner(OrderManager om)
 		{
-			// Refresh TextNotificationsManager before the game starts.
+			// Refresh static classes before the game starts.
 			TextNotificationsManager.Clear();
+			UnitOrders.Clear();
 
 			// HACK: The shellmap World and OrderManager are owned by the main menu's WorldRenderer instead of Game.
 			// This allows us to switch Game.OrderManager from the shellmap to the new network connection when joining

--- a/OpenRA.Game/Server/VoteKickTracker.cs
+++ b/OpenRA.Game/Server/VoteKickTracker.cs
@@ -1,0 +1,223 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using OpenRA.Network;
+
+namespace OpenRA.Server
+{
+	public sealed class VoteKickTracker
+	{
+		[TranslationReference("kickee")]
+		const string InsufficientVotes = "notification-insufficient-votes-to-kick";
+
+		[TranslationReference]
+		const string AlreadyVoted = "notification-kick-already-voted";
+
+		[TranslationReference("kicker", "kickee")]
+		const string VoteKickStarted = "notification-vote-kick-started";
+
+		[TranslationReference]
+		const string UnableToStartAVote = "notification-unable-to-start-a-vote";
+
+		[TranslationReference("kickee", "percentage")]
+		const string VoteKickProgress = "notification-vote-kick-in-progress";
+
+		[TranslationReference("kickee")]
+		const string VoteKickEnded = "notification-vote-kick-ended";
+
+		readonly Dictionary<int, bool> voteTracker = new();
+		readonly Dictionary<Session.Client, long> failedVoteKickers = new();
+		readonly Server server;
+
+		Stopwatch voteKickTimer;
+		(Session.Client Client, Connection Conn) kickee;
+		(Session.Client Client, Connection Conn) voteKickerStarter;
+
+		public VoteKickTracker(Server server)
+		{
+			this.server = server;
+		}
+
+		// Only admins and alive players can participate in a vote kick.
+		bool ClientHasPower(Session.Client client) => client.IsAdmin || (!client.IsObserver && !server.HasClientWonOrLost(client));
+
+		public void Tick()
+		{
+			if (voteKickTimer == null)
+				return;
+
+			if (!server.Conns.Contains(kickee.Conn))
+			{
+				EndKickVote();
+				return;
+			}
+
+			if (voteKickTimer.ElapsedMilliseconds > server.Settings.VoteKickTimer)
+				EndKickVoteAndBlockKicker();
+		}
+
+		public bool VoteKick(Connection conn, Session.Client kicker, Connection kickeeConn, Session.Client kickee, int kickeeID, bool vote)
+		{
+			var voteInProgress = voteKickTimer != null;
+
+			if (server.State != ServerState.GameStarted
+				|| (kickee.IsAdmin && server.Type != ServerType.Dedicated)
+				|| (!voteInProgress && !vote) // Disallow starting a vote with a downvote
+				|| (voteInProgress && this.kickee.Client != kickee) // Disallow starting new votes when one is already ongoing.
+				|| !ClientHasPower(kicker))
+			{
+				server.SendLocalizedMessageTo(conn, UnableToStartAVote);
+				return false;
+			}
+
+			short eligiblePlayers = 0;
+			var isKickeeOnline = false;
+			var adminIsDeadButOnline = false;
+			foreach (var c in server.Conns)
+			{
+				var client = server.GetClient(c);
+				if (client != kickee && ClientHasPower(client))
+					eligiblePlayers++;
+
+				if (c == kickeeConn)
+					isKickeeOnline = true;
+
+				if (client.IsAdmin && (client.IsObserver || server.HasClientWonOrLost(client)))
+					adminIsDeadButOnline = true;
+			}
+
+			if (!isKickeeOnline)
+			{
+				EndKickVote();
+				return false;
+			}
+
+			if (eligiblePlayers < 2 || (adminIsDeadButOnline && !kickee.IsAdmin && eligiblePlayers < 3))
+			{
+				if (!kickee.IsObserver && !server.HasClientWonOrLost(kickee))
+				{
+					// Vote kick cannot be the sole deciding factor for a game.
+					server.SendLocalizedMessageTo(conn, InsufficientVotes, Translation.Arguments("kickee", kickee.Name));
+					EndKickVote();
+					return false;
+				}
+				else if (vote)
+				{
+					// If only a single player is playing, allow him to kick observers.
+					EndKickVote(false);
+					return true;
+				}
+			}
+
+			if (!voteInProgress)
+			{
+				// Prevent vote kick spam abuse.
+				if (failedVoteKickers.TryGetValue(kicker, out var time))
+				{
+					if (time + server.Settings.VoteKickerCooldown > kickeeConn.ConnectionTimer.ElapsedMilliseconds)
+					{
+						server.SendLocalizedMessageTo(conn, UnableToStartAVote);
+						return false;
+					}
+					else
+						failedVoteKickers.Remove(kicker);
+				}
+
+				Log.Write("server", $"Vote kick started on {kickeeID}.");
+				voteKickTimer = Stopwatch.StartNew();
+				server.SendLocalizedMessage(VoteKickStarted, Translation.Arguments("kicker", kicker.Name, "kickee", kickee.Name));
+				server.DispatchServerOrdersToClients(new Order("StartKickVote", null, false) { ExtraData = (uint)kickeeID }.Serialize());
+				this.kickee = (kickee, kickeeConn);
+				voteKickerStarter = (kicker, conn);
+			}
+
+			if (!voteTracker.ContainsKey(conn.PlayerIndex))
+				voteTracker[conn.PlayerIndex] = vote;
+			else
+			{
+				server.SendLocalizedMessageTo(conn, AlreadyVoted, null);
+				return false;
+			}
+
+			short votesFor = 0;
+			short votesAgainst = 0;
+			foreach (var c in voteTracker)
+			{
+				if (c.Value)
+					votesFor++;
+				else
+					votesAgainst++;
+			}
+
+			// Include the kickee in eligeablePlayers, so that in a 2v2 or any other even team
+			// matchup one team could not vote out the other team's player.
+			if (ClientHasPower(kickee))
+			{
+				eligiblePlayers++;
+				votesAgainst++;
+			}
+
+			var votesNeeded = eligiblePlayers / 2 + 1;
+			server.SendLocalizedMessage(VoteKickProgress, Translation.Arguments(
+				"kickee", kickee.Name,
+				"percentage", votesFor * 100 / eligiblePlayers));
+
+			// If a player or players during a vote lose or disconnect, it is possible that a downvote will
+			// kick a client. Guard against that situation.
+			if (vote && (votesFor >= votesNeeded))
+			{
+				EndKickVote(false);
+				return true;
+			}
+
+			// End vote if it can never succeed.
+			if (eligiblePlayers - votesAgainst < votesNeeded)
+			{
+				EndKickVoteAndBlockKicker();
+				return false;
+			}
+
+			voteKickTimer.Restart();
+			return false;
+		}
+
+		void EndKickVoteAndBlockKicker()
+		{
+			// Make sure vote kick is in progress.
+			if (voteKickTimer == null)
+				return;
+
+			if (server.Conns.Contains(voteKickerStarter.Conn))
+				failedVoteKickers[voteKickerStarter.Client] = voteKickerStarter.Conn.ConnectionTimer.ElapsedMilliseconds;
+
+			EndKickVote();
+		}
+
+		void EndKickVote(bool sendMessage = true)
+		{
+			// Make sure vote kick is in progress.
+			if (voteKickTimer == null)
+				return;
+
+			if (sendMessage)
+				server.SendLocalizedMessage(VoteKickEnded, Translation.Arguments("kickee", kickee.Client.Name));
+
+			server.DispatchServerOrdersToClients(new Order("EndKickVote", null, false) { ExtraData = (uint)kickee.Client.Index }.Serialize());
+
+			voteKickTimer = null;
+			voteKickerStarter = (null, null);
+			kickee = (null, null);
+			voteTracker.Clear();
+		}
+	}
+}

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -114,6 +114,15 @@ namespace OpenRA
 		[Desc("Delay in milliseconds before players can send chat messages after flood was detected.")]
 		public int FloodLimitCooldown = 15000;
 
+		[Desc("Can players vote to kick other players?")]
+		public bool EnableVoteKick = true;
+
+		[Desc("After how much time in miliseconds should the vote kick fail after idling?")]
+		public int VoteKickTimer = 30000;
+
+		[Desc("If a vote kick was unsuccessful for how long should the player who started the vote not be able to start new votes?")]
+		public int VoteKickerCooldown = 120000;
+
 		public ServerSettings Clone()
 		{
 			return (ServerSettings)MemberwiseClone();

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -22,7 +22,7 @@ using S = OpenRA.Server.Server;
 
 namespace OpenRA.Mods.Common.Server
 {
-	public class LobbyCommands : ServerTrait, IInterpretCommand, INotifyServerStart, INotifyServerEmpty, IClientJoined
+	public class LobbyCommands : ServerTrait, IInterpretCommand, INotifyServerStart, INotifyServerEmpty, IClientJoined, OpenRA.Server.ITick
 	{
 		[TranslationReference]
 		const string CustomRules = "notification-custom-rules";
@@ -55,6 +55,9 @@ namespace OpenRA.Mods.Common.Server
 		const string NoKickGameStarted = "notification-no-kick-game-started";
 
 		[TranslationReference("admin", "player")]
+		const string AdminKicked = "notification-admin-kicked";
+
+		[TranslationReference("player")]
 		const string Kicked = "notification-kicked";
 
 		[TranslationReference("admin", "player")]
@@ -156,6 +159,9 @@ namespace OpenRA.Mods.Common.Server
 		[TranslationReference]
 		const string YouWereKicked = "notification-you-were-kicked";
 
+		[TranslationReference]
+		const string VoteKickDisabled = "notification-vote-kick-disabled";
+
 		readonly IDictionary<string, Func<S, Connection, Session.Client, string, bool>> commandHandlers = new Dictionary<string, Func<S, Connection, Session.Client, string, bool>>
 		{
 			{ "state", State },
@@ -170,6 +176,7 @@ namespace OpenRA.Mods.Common.Server
 			{ "option", Option },
 			{ "assignteams", AssignTeams },
 			{ "kick", Kick },
+			{ "vote_kick", VoteKick },
 			{ "make_admin", MakeAdmin },
 			{ "make_spectator", MakeSpectator },
 			{ "name", Name },
@@ -207,7 +214,7 @@ namespace OpenRA.Mods.Common.Server
 			lock (server.LobbyInfo)
 			{
 				// Kick command is always valid for the host
-				if (command.StartsWith("kick ", StringComparison.Ordinal))
+				if (command.StartsWith("kick ", StringComparison.Ordinal) || command.StartsWith("vote_kick ", StringComparison.Ordinal))
 					return true;
 
 				if (server.State == ServerState.GameStarted)
@@ -805,14 +812,14 @@ namespace OpenRA.Mods.Common.Server
 					return true;
 				}
 
-				if (!server.CanKickClient(kickClient))
+				if (server.State == ServerState.GameStarted && !kickClient.IsObserver && !server.HasClientWonOrLost(kickClient))
 				{
 					server.SendLocalizedMessageTo(conn, NoKickGameStarted);
 					return true;
 				}
 
 				Log.Write("server", $"Kicking client {kickClientID}.");
-				server.SendLocalizedMessage(Kicked, Translation.Arguments("admin", client.Name, "player", kickClient.Name));
+				server.SendLocalizedMessage(AdminKicked, Translation.Arguments("admin", client.Name, "player", kickClient.Name));
 				server.SendOrderTo(kickConn, "ServerError", YouWereKicked);
 				server.DropClient(kickConn);
 
@@ -829,6 +836,62 @@ namespace OpenRA.Mods.Common.Server
 				return true;
 			}
 		}
+
+		static bool VoteKick(S server, Connection conn, Session.Client client, string s)
+		{
+			lock (server.LobbyInfo)
+			{
+				var split = s.Split(' ');
+				if (split.Length != 2)
+				{
+					server.SendLocalizedMessageTo(conn, MalformedCommand, Translation.Arguments("command", "vote_kick"));
+					return true;
+				}
+
+				if (!server.Settings.EnableVoteKick)
+				{
+					server.SendLocalizedMessageTo(conn, VoteKickDisabled);
+					return true;
+				}
+
+				var kickConn = Exts.TryParseInt32Invariant(split[0], out var kickClientID)
+					? server.Conns.SingleOrDefault(c => server.GetClient(c)?.Index == kickClientID) : null;
+
+				if (kickConn == null)
+				{
+					server.SendLocalizedMessageTo(conn, KickNone);
+					return true;
+				}
+
+				var kickClient = server.GetClient(kickConn);
+				if (client == kickClient)
+				{
+					server.SendLocalizedMessageTo(conn, NoKickSelf);
+					return true;
+				}
+
+				if (!bool.TryParse(split[1], out var vote))
+				{
+					server.SendLocalizedMessageTo(conn, MalformedCommand, Translation.Arguments("command", "vote_kick"));
+					return true;
+				}
+
+				if (server.VoteKickTracker.VoteKick(conn, client, kickConn, kickClient, kickClientID, vote))
+				{
+					Log.Write("server", $"Kicking client {kickClientID}.");
+					server.SendLocalizedMessage(Kicked, Translation.Arguments("player", kickClient.Name));
+					server.SendOrderTo(kickConn, "ServerError", YouWereKicked);
+					server.DropClient(kickConn);
+
+					server.SyncLobbyClients();
+					server.SyncLobbySlots();
+				}
+
+				return true;
+			}
+		}
+
+		void OpenRA.Server.ITick.Tick(S server) => server.VoteKickTracker.Tick();
 
 		static bool MakeAdmin(S server, Connection conn, Session.Client client, string s)
 		{

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -40,12 +40,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly World world;
 		readonly ModData modData;
 		readonly Action<bool> hideMenu;
+		readonly Action closeMenu;
 		readonly IObjectivesPanel iop;
 		IngameInfoPanel activePanel;
 		readonly bool hasError;
 
 		[ObjectCreator.UseCtor]
-		public GameInfoLogic(Widget widget, ModData modData, World world, IngameInfoPanel initialPanel, Action<bool> hideMenu)
+		public GameInfoLogic(Widget widget, ModData modData, World world, IngameInfoPanel initialPanel, Action<bool> hideMenu, Action closeMenu)
 		{
 			var panels = new Dictionary<IngameInfoPanel, (string Panel, string Label, Action<ButtonWidget, Widget> Setup)>()
 			{
@@ -59,6 +60,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.world = world;
 			this.modData = modData;
 			this.hideMenu = hideMenu;
+			this.closeMenu = closeMenu;
 			activePanel = initialPanel;
 
 			var visiblePanels = new List<IngameInfoPanel>();
@@ -140,7 +142,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var panel = hasError ? "SCRIPT_ERROR_PANEL" : iop.PanelName;
 			Game.LoadWidget(world, panel, objectivesPanelContainer, new WidgetArgs()
 			{
-				{ "hideMenu", hideMenu }
+				{ "hideMenu", hideMenu },
+				{ "closeMenu", closeMenu },
 			});
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		const string VoteKickVoteCancel = "dialog-vote-kick.vote-cancel";
 
 		[ObjectCreator.UseCtor]
-		public GameInfoStatsLogic(Widget widget, ModData modData, World world, OrderManager orderManager, WorldRenderer worldRenderer, Action<bool> hideMenu)
+		public GameInfoStatsLogic(Widget widget, ModData modData, World world, OrderManager orderManager, WorldRenderer worldRenderer, Action<bool> hideMenu, Action closeMenu)
 		{
 			var player = world.LocalPlayer;
 			var playerPanel = widget.Get<ScrollPanelWidget>("PLAYER_LIST");
@@ -165,6 +165,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							{
 								orderManager.IssueOrder(Order.Command($"vote_kick {client.Index} {true}"));
 								hideMenu(false);
+								closeMenu();
 							},
 							confirmText: VoteKickVoteStart,
 							onCancel: () => hideMenu(false));
@@ -180,6 +181,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						{
 							orderManager.IssueOrder(Order.Command($"vote_kick {client.Index} {true}"));
 							hideMenu(false);
+							closeMenu();
 						},
 						confirmText: VoteKickVoteFor,
 						onOther: () =>
@@ -187,6 +189,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							Ui.CloseWindow();
 							orderManager.IssueOrder(Order.Command($"vote_kick {client.Index} {false}"));
 							hideMenu(false);
+							closeMenu();
 						},
 						otherText: VoteKickVoteAgainst,
 						onCancel: () => hideMenu(false),

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -225,7 +225,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var gameInfoPanel = Game.LoadWidget(world, "GAME_INFO_PANEL", panelRoot, new WidgetArgs()
 				{
 					{ "initialPanel", initialPanel },
-					{ "hideMenu", requestHideMenu }
+					{ "hideMenu", requestHideMenu },
+					{ "closeMenu", CloseMenu },
 				});
 
 				gameInfoPanel.IsVisible = () => !hideMenu;

--- a/mods/cnc/chrome/ingame-infostats.yaml
+++ b/mods/cnc/chrome/ingame-infostats.yaml
@@ -139,7 +139,6 @@ Container@SKIRMISH_STATS:
 							Height: 25
 							Background: checkbox-toggle
 							TooltipContainer: TOOLTIP_CONTAINER
-							TooltipText: Kick this player
 							Children:
 								Image:
 									ImageCollection: lobby-bits
@@ -182,7 +181,6 @@ Container@SKIRMISH_STATS:
 							Height: 25
 							Background: checkbox-toggle
 							TooltipContainer: TOOLTIP_CONTAINER
-							TooltipText: Kick this player
 							Children:
 								Image:
 									ImageCollection: lobby-bits

--- a/mods/common/chrome/ingame-infostats.yaml
+++ b/mods/common/chrome/ingame-infostats.yaml
@@ -136,7 +136,6 @@ Container@SKIRMISH_STATS:
 							Height: 25
 							Background: checkbox-toggle
 							TooltipContainer: TOOLTIP_CONTAINER
-							TooltipText: Kick this player
 							Children:
 								Image:
 									ImageCollection: lobby-bits
@@ -179,7 +178,6 @@ Container@SKIRMISH_STATS:
 							Height: 25
 							Background: checkbox-toggle
 							TooltipContainer: TOOLTIP_CONTAINER
-							TooltipText: Kick this player
 							Children:
 								Image:
 									ImageCollection: lobby-bits

--- a/mods/common/languages/en.ftl
+++ b/mods/common/languages/en.ftl
@@ -32,7 +32,8 @@ notification-admin-change-configuration = Only the host can change the configura
 notification-changed-map = { $player } changed the map to { $map }
 notification-option-changed = { $player } changed { $name } to { $value }.
 notification-you-were-kicked = You have been kicked from the server.
-notification-kicked = { $admin } kicked { $player } from the server.
+notification-admin-kicked = { $admin } kicked { $player } from the server.
+notification-kicked = { $player } was kicked from the server.
 notification-temp-ban = { $admin } temporarily banned { $player } from the server.
 notification-admin-transfer-admin = Only admins can transfer admin to another player.
 notification-admin-move-spectators = Only the host can move players to spectators.
@@ -103,6 +104,14 @@ notification-chat-temp-disabled =
        *[other] Chat is disabled. Please try again in { $remaining } seconds.
     }
 
+## VoteKickTracker
+notification-unable-to-start-a-vote = Unable to start a vote.
+notification-insufficient-votes-to-kick = Insufficient votes to kick player { $kickee }.
+notification-kick-already-voted = You have already voted.
+notification-vote-kick-started = Player { $kicker } has started a vote to kick player { $kickee }.
+notification-vote-kick-in-progress = { $percentage }% of players have voted to kick player { $kickee }.
+notification-vote-kick-ended = Vote to kick player { $kickee } has failed.
+
 ## ActorEditLogic
 label-duplicate-actor-id = Duplicate Actor ID
 label-actor-id = Enter an Actor ID
@@ -157,11 +166,28 @@ label-mission-failed = Failed
 label-client-state-disconnected = Gone
 label-mute-player = Mute this player
 label-unmute-player = Unmute this player
+button-kick-player = Kick this player
+button-vote-kick-player = Vote to kick this player
 
 dialog-kick =
     .title = Kick { $player }?
-    .prompt = They will not be able to rejoin this game.
+    .prompt = This player will not be able to rejoin the game.
     .confirm = Kick
+
+dialog-vote-kick =
+    .title = Vote to kick { $player }?
+    .prompt = This player will not be able to rejoin the game.
+    .prompt-break-bots =
+    { $bots ->
+        [one] Kicking the game admin will also kick 1 bot.
+       *[other] Kicking the game admin will also kick { $bots } bots.
+    }
+    .vote-start = Start Vote
+    .vote-for = Vote For
+    .vote-against = Vote Against
+    .vote-cancel = Abstain
+
+notification-vote-kick-disabled = Vote kick is disabled on this server.
 
 ## GameTimerLogic
 label-paused = Paused


### PR DESCRIPTION
Fixes #21002 and https://forum.openra.net/viewtopic.php?f=82&t=21779 in an indirect way

This PR is aimed at stable we need to nail all details in 1 go.

This system works by requiring more than 50% of players to be in agreement on the kick, if admin is a spectator he is included in the count. I've also added an exception that allows a single player to kick any spectator if he's the only one playing.

The logic is: if a single player is intent on trolling, others can kick him in agreement. But if over 50% of the players are intent on trolling then the game is forfeit anyway.