### PR TITLE
Fix Folder.GetStream using FileNotFoundExceptions to detect if a file exists

### DIFF
--- a/OpenRA.Game/FileSystem/Folder.cs
+++ b/OpenRA.Game/FileSystem/Folder.cs
@@ -41,7 +41,11 @@ namespace OpenRA.FileSystem
 
 		public Stream GetStream(string filename)
 		{
-			try { return File.OpenRead(Path.Combine(Name, filename)); }
+			var combined = Path.Combine(Name, filename);
+			if (!File.Exists(combined))
+				return null;
+
+			try { return File.OpenRead(combined); }
 			catch { return null; }
 		}
 


### PR DESCRIPTION
This happens relatively often as we first try to load sprite files from the map package and fall back to the default mod files if the file does not exist in the map package. We don't need to rely on exceptions for that. (The difference is actually quite noticeable for me when debugging with VS and not ignoring exceptions.)