### PR TITLE
Don't enforce style rules that require .NET 7.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -714,7 +714,7 @@ dotnet_diagnostic.CA1305.severity = warning
 dotnet_diagnostic.CA1310.severity = warning
 
 # Specify a culture or use an invariant version.
-dotnet_diagnostic.CA1311.severity = warning
+dotnet_diagnostic.CA1311.severity = suggestion # TODO: Change to warning once using .NET 7 or later.
 
 ### Portability and Interoperability Rules
 ### https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/interoperability-warnings
@@ -829,28 +829,28 @@ dotnet_diagnostic.CA1846.severity = warning
 dotnet_diagnostic.CA1847.severity = warning
 
 # Call async methods when in an async method.
-dotnet_diagnostic.CA1849.severity = warning
+dotnet_diagnostic.CA1849.severity = suggestion # TODO: Change to warning once using .NET 7 or later.
 
 # Prefer static HashData method over ComputeHash. (Not available on mono)
-dotnet_diagnostic.CA1850.severity = none
+dotnet_diagnostic.CA1850.severity = none # TODO: Change to warning once using .NET 7 or later AND once supported by mono.
 
 # Possible multiple enumerations of IEnumerable collection.
 #dotnet_code_quality.CA1851.enumeration_methods =
 dotnet_code_quality.CA1851.linq_chain_methods = M:OpenRA.Traits.IRenderModifier.Modify*
 dotnet_code_quality.CA1851.assume_method_enumerates_parameters = true
-dotnet_diagnostic.CA1851.severity = warning
+dotnet_diagnostic.CA1851.severity = suggestion # TODO: Change to warning once using .NET 7 or later.
 
 # Seal internal types.
-dotnet_diagnostic.CA1852.severity = warning
+dotnet_diagnostic.CA1852.severity = suggestion # TODO: Change to warning once using .NET 7 or later.
 
 # Unnecessary call to 'Dictionary.ContainsKey(key)'.
-dotnet_diagnostic.CA1853.severity = warning
+dotnet_diagnostic.CA1853.severity = suggestion # TODO: Change to warning once using .NET 7 or later.
 
 # Prefer the IDictionary.TryGetValue(TKey, out TValue) method.
-dotnet_diagnostic.CA1854.severity = warning
+dotnet_diagnostic.CA1854.severity = suggestion # TODO: Change to warning once using .NET 7 or later.
 
 # Use Span<T>.Clear() instead of Span<T>.Fill().
-dotnet_diagnostic.CA1855.severity = warning
+dotnet_diagnostic.CA1855.severity = suggestion # TODO: Change to warning once using .NET 7 or later.
 
 # Use StartsWith instead of IndexOf.
 dotnet_diagnostic.CA1858.severity = warning
@@ -880,7 +880,7 @@ dotnet_diagnostic.CA2016.severity = warning
 dotnet_diagnostic.CA2018.severity = warning
 
 # ThreadStatic fields should not use inline initialization.
-dotnet_diagnostic.CA2019.severity = warning
+dotnet_diagnostic.CA2019.severity = suggestion # TODO: Change to warning once using .NET 7 or later.
 
 ### Security Rules
 ### https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/security-warnings
@@ -948,7 +948,7 @@ dotnet_diagnostic.CA2250.severity = warning
 dotnet_diagnostic.CA2251.severity = warning
 
 # Ensure ThreadStatic is only used with static fields.
-dotnet_diagnostic.CA2259.severity = warning
+dotnet_diagnostic.CA2259.severity = suggestion # TODO: Change to warning once using .NET 7 or later.
 
 ### Roslynator
 ### https://github.com/JosefPihrt/Roslynator/tree/main/docs/analyzers


### PR DESCRIPTION
As the solution currently targets .NET 6, a variety of style rules only introduced in .NET 7 are not suitable for enforcing as warnings (which are treated as errors in the CI pipeline). Anybody compiling locally with a .NET 6 SDK won't be able to trigger these rules locally, but the Linux CI agent comes with the .NET 7 SDK and will trigger these rules. This provides a poor dev experience as the CI run will report errors that don't reproduce locally.

To remove this developer friction, reduce the severity of these rules to avoid CI runs failing.

----

Fixes https://github.com/OpenRA/OpenRA/pull/20996#issuecomment-1685929929