### PR TITLE
Scaled ButtonPrompt confirmation dialog based on message size

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ConfirmationDialogs.cs
+++ b/OpenRA.Mods.Common/Widgets/ConfirmationDialogs.cs
@@ -45,16 +45,23 @@ namespace OpenRA.Mods.Common.Widgets
 			var headerLines = textMessage.Split('\n');
 			var headerHeight = 0;
 			var maxWidth = 0;
+			var headerLabels = new List<LabelWidget>(headerLines.Length);
 			foreach (var l in headerLines)
 			{
 				var line = (LabelWidget)headerTemplate.Clone();
 				line.GetText = () => l;
 				line.Bounds.Y += headerHeight;
-				maxWidth = Math.Max(maxWidth, line.Bounds.Width / 2);
-				line.Bounds.X += maxWidth / 2;
 
 				prompt.AddChild(line);
+				headerLabels.Add(line);
+
 				headerHeight += headerTemplate.Bounds.Height;
+				maxWidth = Math.Max(maxWidth, line.Bounds.Width / 2);
+			}
+
+			foreach (var label in headerLabels)
+			{
+				label.Bounds.X += maxWidth / 2;
 			}
 
 			titleLabel.Bounds.X += maxWidth / 2;

--- a/OpenRA.Mods.Common/Widgets/ConfirmationDialogs.cs
+++ b/OpenRA.Mods.Common/Widgets/ConfirmationDialogs.cs
@@ -37,22 +37,29 @@ namespace OpenRA.Mods.Common.Widgets
 			var otherButton = prompt.GetOrNull<ButtonWidget>("OTHER_BUTTON");
 
 			var titleMessage = TranslationProvider.GetString(title, titleArguments);
-			prompt.Get<LabelWidget>("PROMPT_TITLE").GetText = () => titleMessage;
+			var titleLabel = prompt.Get<LabelWidget>("PROMPT_TITLE");
+			titleLabel.GetText = () => titleMessage;
 
 			var headerTemplate = prompt.Get<LabelWidget>("PROMPT_TEXT");
 			var textMessage = TranslationProvider.GetString(text, textArguments);
 			var headerLines = textMessage.Split('\n');
 			var headerHeight = 0;
+			var maxWidth = 0;
 			foreach (var l in headerLines)
 			{
 				var line = (LabelWidget)headerTemplate.Clone();
 				line.GetText = () => l;
 				line.Bounds.Y += headerHeight;
-				prompt.AddChild(line);
+				maxWidth = Math.Max(maxWidth, line.Bounds.Width / 2);
+				line.Bounds.X += maxWidth / 2;
 
+				prompt.AddChild(line);
 				headerHeight += headerTemplate.Bounds.Height;
 			}
 
+			titleLabel.Bounds.X += maxWidth / 2;
+			prompt.Bounds.Width += maxWidth;
+			prompt.Bounds.X -= maxWidth / 2;
 			prompt.Bounds.Height += headerHeight;
 			prompt.Bounds.Y -= headerHeight / 2;
 
@@ -60,6 +67,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				confirmButton.Visible = true;
 				confirmButton.Bounds.Y += headerHeight;
+				confirmButton.Bounds.X += maxWidth;
 				confirmButton.OnClick = () =>
 				{
 					Ui.CloseWindow();
@@ -94,6 +102,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				otherButton.Visible = true;
 				otherButton.Bounds.Y += headerHeight;
+				otherButton.Bounds.X += maxWidth;
 				otherButton.OnClick = onOther;
 
 				if (!string.IsNullOrEmpty(otherText))


### PR DESCRIPTION
Closes #20886 

As stated in the linked issue, the confirm dialog that showed for deleting a map with a long map title would cause the message to overflow:
![An image showing the confirm dialog for deleting a map overflows if the map title is too long](https://github.com/OpenRA/OpenRA/assets/3174205/5ae28951-c80e-4fb3-b3bc-9af6baf696cb)

To fix this, I edited the `ConfirmationDialog.ButtonPrompt` function to adjust to the maximum width of the text (based on lines split by a newline character.

This is how it looks now:
![An image showing the confirm dialog not overflowing](https://github.com/OpenRA/OpenRA/assets/3174205/7739f88c-d64d-42ed-8092-e622add3c48c)

And this is the same dialog but I spliced in a newline character:
![An image showing the confirm dialog not overflowing with a newline character](https://github.com/OpenRA/OpenRA/assets/3174205/91c9b145-3883-4204-ab59-a35e0626bf7e)
