### PR TITLE
Automatically order units away when trying to deploy transform

### DIFF
--- a/OpenRA.Mods.Common/AIUtils.cs
+++ b/OpenRA.Mods.Common/AIUtils.cs
@@ -79,5 +79,39 @@ namespace OpenRA.Mods.Common
 			if (Game.Settings.Debug.BotDebug)
 				TextNotificationsManager.Debug(format, args);
 		}
+
+		public static IEnumerable<Order> ClearBlockersOrders(IEnumerable<CPos> tiles, Player owner, Actor ignoreActor = null)
+		{
+			var world = owner.World;
+			var adjacentTiles = Util.ExpandFootprint(tiles, true).Except(tiles)
+				.Where(world.Map.Contains).ToList();
+
+			var blockers = tiles.SelectMany(world.ActorMap.GetActorsAt)
+				.Where(a => a.Owner == owner && a.IsIdle && (ignoreActor == null || a != ignoreActor))
+				.Select(a => new TraitPair<IMove>(a, a.TraitOrDefault<IMove>()))
+				.Where(x => x.Trait != null);
+
+			foreach (var blocker in blockers)
+			{
+				CPos moveCell;
+				if (blocker.Trait is Mobile mobile)
+				{
+					var availableCells = adjacentTiles.Where(t => mobile.CanEnterCell(t)).ToList();
+					if (availableCells.Count == 0)
+						continue;
+
+					moveCell = blocker.Actor.ClosestCell(availableCells);
+				}
+				else if (blocker.Trait is Aircraft)
+					moveCell = blocker.Actor.Location;
+				else
+					continue;
+
+				yield return new Order("Move", blocker.Actor, Target.FromCell(world, moveCell), false)
+				{
+					SuppressVisualFeedback = true
+				};
+			}
+		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
@@ -97,6 +98,11 @@ namespace OpenRA.Mods.Common.Traits
 			return buildingInfo == null || self.World.CanPlaceBuilding(self.Location + Info.Offset, actorInfo, buildingInfo, self);
 		}
 
+		IEnumerable<Order> ClearBlockersOrders(CPos topLeft)
+		{
+			return AIUtils.ClearBlockersOrders(buildingInfo.Tiles(topLeft).ToList(), self.Owner, self);
+		}
+
 		public Activity GetTransformActivity()
 		{
 			return new Transform(Info.IntoActor)
@@ -139,6 +145,9 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (!queued && !CanDeploy())
 			{
+				foreach (var order in ClearBlockersOrders(self.Location + Info.Offset))
+					self.World.IssueOrder(order);
+
 				// Only play the "Cannot deploy here" audio
 				// for non-queued orders
 				foreach (var s in Info.NoTransformSounds)


### PR DESCRIPTION
This expands on https://github.com/OpenRA/OpenRA/pull/9239.