### PR TITLE
Make FloatingSprite public

### DIFF
--- a/OpenRA.Mods.Common/Effects/FloatingSprite.cs
+++ b/OpenRA.Mods.Common/Effects/FloatingSprite.cs
@@ -15,7 +15,7 @@ using OpenRA.Graphics;
 
 namespace OpenRA.Mods.Common.Effects
 {
-	sealed class FloatingSprite : IEffect, ISpatiallyPartitionable
+	public sealed class FloatingSprite : IEffect, ISpatiallyPartitionable
 	{
 		readonly WDist[] speed;
 		readonly WDist[] gravity;


### PR DESCRIPTION
Some mods might want to use `FloatingSprite` outside of `FloatingSpriteEmitter`