### PR TITLE
Add IndexBuffer and update SpriteRenderer and TerrainSpriteLayer to use it

### DIFF
--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -84,6 +84,7 @@ namespace OpenRA
 	public interface IGraphicsContext : IDisposable
 	{
 		IVertexBuffer<Vertex> CreateVertexBuffer(int size);
+		IIndexBuffer CreateIndexBuffer(uint[] indices);
 		Vertex[] CreateVertices(int size);
 		ITexture CreateTexture();
 		IFrameBuffer CreateFrameBuffer(Size s);
@@ -112,6 +113,11 @@ namespace OpenRA
 		/// </summary>
 		void SetData(ref T[] vertices, int length);
 		void SetData(T[] vertices, int offset, int start, int length);
+	}
+
+	public interface IIndexBuffer : IDisposable
+	{
+		void Bind();
 	}
 
 	public interface IShader

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -94,6 +94,7 @@ namespace OpenRA
 		void DisableScissor();
 		void Present();
 		void DrawPrimitives(PrimitiveType pt, int firstVertex, int numVertices);
+		void DrawElements(int numIndices, int offset);
 		void Clear();
 		void EnableDepthBuffer();
 		void DisableDepthBuffer();

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -26,7 +26,7 @@ namespace OpenRA
 
 	public interface IPlatform
 	{
-		IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int batchSize, int videoDisplay, GLProfile profile, bool enableLegacyGL);
+		IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int vertexBatchSize, int indexBatchSize, int videoDisplay, GLProfile profile, bool enableLegacyGL);
 		ISoundEngine CreateSound(string device);
 		IFont CreateFont(byte[] data);
 	}

--- a/OpenRA.Game/Graphics/RgbaColorRenderer.cs
+++ b/OpenRA.Game/Graphics/RgbaColorRenderer.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Graphics
 		static readonly float3 Offset = new(0.5f, 0.5f, 0f);
 
 		readonly SpriteRenderer parent;
-		readonly Vertex[] vertices = new Vertex[6];
+		readonly Vertex[] vertices = new Vertex[4];
 
 		public RgbaColorRenderer(SpriteRenderer parent)
 		{
@@ -48,11 +48,9 @@ namespace OpenRA.Graphics
 			vertices[0] = new Vertex(start - corner + Offset, sr, sg, sb, sa, 0, 0);
 			vertices[1] = new Vertex(start + corner + Offset, sr, sg, sb, sa, 0, 0);
 			vertices[2] = new Vertex(end + corner + Offset, er, eg, eb, ea, 0, 0);
-			vertices[3] = new Vertex(end + corner + Offset, er, eg, eb, ea, 0, 0);
-			vertices[4] = new Vertex(end - corner + Offset, er, eg, eb, ea, 0, 0);
-			vertices[5] = new Vertex(start - corner + Offset, sr, sg, sb, sa, 0, 0);
+			vertices[3] = new Vertex(end - corner + Offset, er, eg, eb, ea, 0, 0);
 
-			parent.DrawRGBAVertices(vertices, blendMode);
+			parent.DrawRGBAQuad(vertices, blendMode);
 		}
 
 		public void DrawLine(in float3 start, in float3 end, float width, Color color, BlendMode blendMode = BlendMode.Alpha)
@@ -69,10 +67,8 @@ namespace OpenRA.Graphics
 			vertices[0] = new Vertex(start - corner + Offset, r, g, b, a, 0, 0);
 			vertices[1] = new Vertex(start + corner + Offset, r, g, b, a, 0, 0);
 			vertices[2] = new Vertex(end + corner + Offset, r, g, b, a, 0, 0);
-			vertices[3] = new Vertex(end + corner + Offset, r, g, b, a, 0, 0);
-			vertices[4] = new Vertex(end - corner + Offset, r, g, b, a, 0, 0);
-			vertices[5] = new Vertex(start - corner + Offset, r, g, b, a, 0, 0);
-			parent.DrawRGBAVertices(vertices, blendMode);
+			vertices[3] = new Vertex(end - corner + Offset, r, g, b, a, 0, 0);
+			parent.DrawRGBAQuad(vertices, blendMode);
 		}
 
 		/// <summary>
@@ -160,10 +156,8 @@ namespace OpenRA.Graphics
 				vertices[0] = new Vertex(ca + Offset, r, g, b, a, 0, 0);
 				vertices[1] = new Vertex(cb + Offset, r, g, b, a, 0, 0);
 				vertices[2] = new Vertex(cc + Offset, r, g, b, a, 0, 0);
-				vertices[3] = new Vertex(cc + Offset, r, g, b, a, 0, 0);
-				vertices[4] = new Vertex(cd + Offset, r, g, b, a, 0, 0);
-				vertices[5] = new Vertex(ca + Offset, r, g, b, a, 0, 0);
-				parent.DrawRGBAVertices(vertices, blendMode);
+				vertices[3] = new Vertex(cd + Offset, r, g, b, a, 0, 0);
+				parent.DrawRGBAQuad(vertices, blendMode);
 
 				// Advance line segment
 				end = next;
@@ -200,20 +194,6 @@ namespace OpenRA.Graphics
 			DrawPolygon(new[] { tl, tr, br, bl }, width, color, blendMode);
 		}
 
-		public void FillTriangle(in float3 a, in float3 b, in float3 c, Color color, BlendMode blendMode = BlendMode.Alpha)
-		{
-			color = Util.PremultiplyAlpha(color);
-			var cr = color.R / 255.0f;
-			var cg = color.G / 255.0f;
-			var cb = color.B / 255.0f;
-			var ca = color.A / 255.0f;
-
-			vertices[0] = new Vertex(a + Offset, cr, cg, cb, ca, 0, 0);
-			vertices[1] = new Vertex(b + Offset, cr, cg, cb, ca, 0, 0);
-			vertices[2] = new Vertex(c + Offset, cr, cg, cb, ca, 0, 0);
-			parent.DrawRGBAVertices(vertices, blendMode);
-		}
-
 		public void FillRect(in float3 tl, in float3 br, Color color, BlendMode blendMode = BlendMode.Alpha)
 		{
 			var tr = new float3(br.X, tl.Y, tl.Z);
@@ -232,10 +212,8 @@ namespace OpenRA.Graphics
 			vertices[0] = new Vertex(a + Offset, cr, cg, cb, ca, 0, 0);
 			vertices[1] = new Vertex(b + Offset, cr, cg, cb, ca, 0, 0);
 			vertices[2] = new Vertex(c + Offset, cr, cg, cb, ca, 0, 0);
-			vertices[3] = new Vertex(c + Offset, cr, cg, cb, ca, 0, 0);
-			vertices[4] = new Vertex(d + Offset, cr, cg, cb, ca, 0, 0);
-			vertices[5] = new Vertex(a + Offset, cr, cg, cb, ca, 0, 0);
-			parent.DrawRGBAVertices(vertices, blendMode);
+			vertices[3] = new Vertex(d + Offset, cr, cg, cb, ca, 0, 0);
+			parent.DrawRGBAQuad(vertices, blendMode);
 		}
 
 		public void FillRect(in float3 a, in float3 b, in float3 c, in float3 d, Color topLeftColor, Color topRightColor, Color bottomRightColor, Color bottomLeftColor, BlendMode blendMode = BlendMode.Alpha)
@@ -243,11 +221,9 @@ namespace OpenRA.Graphics
 			vertices[0] = VertexWithColor(a + Offset, topLeftColor);
 			vertices[1] = VertexWithColor(b + Offset, topRightColor);
 			vertices[2] = VertexWithColor(c + Offset, bottomRightColor);
-			vertices[3] = VertexWithColor(c + Offset, bottomRightColor);
-			vertices[4] = VertexWithColor(d + Offset, bottomLeftColor);
-			vertices[5] = VertexWithColor(a + Offset, topLeftColor);
+			vertices[3] = VertexWithColor(d + Offset, bottomLeftColor);
 
-			parent.DrawRGBAVertices(vertices, blendMode);
+			parent.DrawRGBAQuad(vertices, blendMode);
 		}
 
 		static Vertex VertexWithColor(in float3 xyz, Color color)

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Graphics
 		{
 			this.renderer = renderer;
 			this.shader = shader;
-			vertices = renderer.Context.CreateVertices(renderer.TempBufferSize);
+			vertices = renderer.Context.CreateVertices(renderer.TempVertexBufferSize);
 		}
 
 		public void Flush()
@@ -65,7 +65,7 @@ namespace OpenRA.Graphics
 		{
 			renderer.CurrentBatchRenderer = this;
 
-			if (s.BlendMode != currentBlend || nv + 6 > renderer.TempBufferSize)
+			if (s.BlendMode != currentBlend || nv + 6 > renderer.TempVertexBufferSize)
 				Flush();
 
 			currentBlend = s.BlendMode;
@@ -202,7 +202,7 @@ namespace OpenRA.Graphics
 		{
 			renderer.CurrentBatchRenderer = this;
 
-			if (currentBlend != blendMode || nv + v.Length > renderer.TempBufferSize)
+			if (currentBlend != blendMode || nv + v.Length > renderer.TempVertexBufferSize)
 				Flush();
 
 			currentBlend = blendMode;

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -29,8 +29,8 @@ namespace OpenRA.Graphics
 		readonly Sheet[] sheets = new Sheet[SheetCount];
 
 		BlendMode currentBlend = BlendMode.Alpha;
-		int nv = 0;
-		int ns = 0;
+		int vertexCount = 0;
+		int sheetCount = 0;
 
 		public SpriteRenderer(Renderer renderer, IShader shader)
 		{
@@ -41,9 +41,9 @@ namespace OpenRA.Graphics
 
 		public void Flush()
 		{
-			if (nv > 0)
+			if (vertexCount > 0)
 			{
-				for (var i = 0; i < ns; i++)
+				for (var i = 0; i < sheetCount; i++)
 				{
 					shader.SetTexture(SheetIndexToTextureName[i], sheets[i].GetTexture());
 					sheets[i] = null;
@@ -52,12 +52,11 @@ namespace OpenRA.Graphics
 				renderer.Context.SetBlendMode(currentBlend);
 				shader.PrepareRender();
 
-				// PERF: The renderer may choose to replace vertices with a different temporary buffer.
-				renderer.DrawBatch(ref vertices, nv, PrimitiveType.TriangleList);
+				renderer.DrawQuadBatch(ref vertices, vertexCount);
 				renderer.Context.SetBlendMode(BlendMode.None);
 
-				nv = 0;
-				ns = 0;
+				vertexCount = 0;
+				sheetCount = 0;
 			}
 		}
 
@@ -65,7 +64,7 @@ namespace OpenRA.Graphics
 		{
 			renderer.CurrentBatchRenderer = this;
 
-			if (s.BlendMode != currentBlend || nv + 6 > renderer.TempVertexBufferSize)
+			if (s.BlendMode != currentBlend || vertexCount + 4 > renderer.TempVertexBufferSize)
 				Flush();
 
 			currentBlend = s.BlendMode;
@@ -73,7 +72,7 @@ namespace OpenRA.Graphics
 			// Check if the sheet (or secondary data sheet) have already been mapped
 			var sheet = s.Sheet;
 			var sheetIndex = 0;
-			for (; sheetIndex < ns; sheetIndex++)
+			for (; sheetIndex < sheetCount; sheetIndex++)
 				if (sheets[sheetIndex] == sheet)
 					break;
 
@@ -82,7 +81,7 @@ namespace OpenRA.Graphics
 			if (ss != null)
 			{
 				var secondarySheet = ss.SecondarySheet;
-				for (; secondarySheetIndex < ns; secondarySheetIndex++)
+				for (; secondarySheetIndex < sheetCount; secondarySheetIndex++)
 					if (sheets[secondarySheetIndex] == secondarySheet)
 						break;
 
@@ -101,16 +100,16 @@ namespace OpenRA.Graphics
 				secondarySheetIndex = ss != null && ss.SecondarySheet != sheet ? 1 : 0;
 			}
 
-			if (sheetIndex >= ns)
+			if (sheetIndex >= sheetCount)
 			{
 				sheets[sheetIndex] = sheet;
-				ns++;
+				sheetCount++;
 			}
 
-			if (secondarySheetIndex >= ns && ss != null)
+			if (secondarySheetIndex >= sheetCount && ss != null)
 			{
 				sheets[secondarySheetIndex] = ss.SecondarySheet;
-				ns++;
+				sheetCount++;
 			}
 
 			return new int2(sheetIndex, secondarySheetIndex);
@@ -133,17 +132,17 @@ namespace OpenRA.Graphics
 		internal void DrawSprite(Sprite s, float paletteTextureIndex, in float3 location, in float3 scale, float rotation = 0f)
 		{
 			var samplers = SetRenderStateForSprite(s);
-			Util.FastCreateQuad(vertices, location + scale * s.Offset, s, samplers, paletteTextureIndex, nv, scale * s.Size, float3.Ones,
+			Util.FastCreateQuad(vertices, location + scale * s.Offset, s, samplers, paletteTextureIndex, vertexCount, scale * s.Size, float3.Ones,
 								1f, rotation);
-			nv += 6;
+			vertexCount += 4;
 		}
 
 		internal void DrawSprite(Sprite s, float paletteTextureIndex, in float3 location, float scale, float rotation = 0f)
 		{
 			var samplers = SetRenderStateForSprite(s);
-			Util.FastCreateQuad(vertices, location + scale * s.Offset, s, samplers, paletteTextureIndex, nv, scale * s.Size, float3.Ones,
+			Util.FastCreateQuad(vertices, location + scale * s.Offset, s, samplers, paletteTextureIndex, vertexCount, scale * s.Size, float3.Ones,
 								1f, rotation);
-			nv += 6;
+			vertexCount += 4;
 		}
 
 		public void DrawSprite(Sprite s, PaletteReference pal, in float3 location, float scale = 1f, float rotation = 0f)
@@ -155,9 +154,9 @@ namespace OpenRA.Graphics
 			float rotation = 0f)
 		{
 			var samplers = SetRenderStateForSprite(s);
-			Util.FastCreateQuad(vertices, location + scale * s.Offset, s, samplers, paletteTextureIndex, nv, scale * s.Size, tint, alpha,
+			Util.FastCreateQuad(vertices, location + scale * s.Offset, s, samplers, paletteTextureIndex, vertexCount, scale * s.Size, tint, alpha,
 								rotation);
-			nv += 6;
+			vertexCount += 4;
 		}
 
 		public void DrawSprite(Sprite s, PaletteReference pal, in float3 location, float scale, in float3 tint, float alpha,
@@ -169,8 +168,8 @@ namespace OpenRA.Graphics
 		internal void DrawSprite(Sprite s, float paletteTextureIndex, in float3 a, in float3 b, in float3 c, in float3 d, in float3 tint, float alpha)
 		{
 			var samplers = SetRenderStateForSprite(s);
-			Util.FastCreateQuad(vertices, a, b, c, d, s, samplers, paletteTextureIndex, tint, alpha, nv);
-			nv += 6;
+			Util.FastCreateQuad(vertices, a, b, c, d, s, samplers, paletteTextureIndex, tint, alpha, vertexCount);
+			vertexCount += 4;
 		}
 
 		public void DrawVertexBuffer(IVertexBuffer<Vertex> buffer, IIndexBuffer indices, int start, int length, IEnumerable<Sheet> sheets, BlendMode blendMode)
@@ -187,7 +186,7 @@ namespace OpenRA.Graphics
 
 			renderer.Context.SetBlendMode(blendMode);
 			shader.PrepareRender();
-			renderer.DrawBatch(buffer, indices, length, UintSize * start);
+			renderer.DrawQuadBatch(buffer, indices, length, UintSize * start);
 			renderer.Context.SetBlendMode(BlendMode.None);
 		}
 
@@ -198,16 +197,17 @@ namespace OpenRA.Graphics
 		}
 
 		// For RGBAColorRenderer
-		internal void DrawRGBAVertices(Vertex[] v, BlendMode blendMode)
+		internal void DrawRGBAQuad(Vertex[] v, BlendMode blendMode)
 		{
 			renderer.CurrentBatchRenderer = this;
 
-			if (currentBlend != blendMode || nv + v.Length > renderer.TempVertexBufferSize)
+			if (currentBlend != blendMode || vertexCount + 4 > renderer.TempVertexBufferSize)
 				Flush();
 
 			currentBlend = blendMode;
-			Array.Copy(v, 0, vertices, nv, v.Length);
-			nv += v.Length;
+
+			Array.Copy(v, 0, vertices, vertexCount, v.Length);
+			vertexCount += 4;
 		}
 
 		public void SetPalette(ITexture palette, ITexture colorShifts)

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using OpenRA.Primitives;
 
 namespace OpenRA.Graphics
@@ -19,6 +20,7 @@ namespace OpenRA.Graphics
 	{
 		public const int SheetCount = 8;
 		static readonly string[] SheetIndexToTextureName = Exts.MakeArray(SheetCount, i => $"Texture{i}");
+		static readonly int UintSize = Marshal.SizeOf(typeof(uint));
 
 		readonly Renderer renderer;
 		readonly IShader shader;
@@ -171,7 +173,7 @@ namespace OpenRA.Graphics
 			nv += 6;
 		}
 
-		public void DrawVertexBuffer(IVertexBuffer<Vertex> buffer, int start, int length, PrimitiveType type, IEnumerable<Sheet> sheets, BlendMode blendMode)
+		public void DrawVertexBuffer(IVertexBuffer<Vertex> buffer, IIndexBuffer indices, int start, int length, IEnumerable<Sheet> sheets, BlendMode blendMode)
 		{
 			var i = 0;
 			foreach (var s in sheets)
@@ -185,7 +187,7 @@ namespace OpenRA.Graphics
 
 			renderer.Context.SetBlendMode(blendMode);
 			shader.PrepareRender();
-			renderer.DrawBatch(buffer, start, length, type);
+			renderer.DrawBatch(buffer, indices, length, UintSize * start);
 			renderer.Context.SetBlendMode(BlendMode.None);
 		}
 

--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -20,6 +20,16 @@ namespace OpenRA.Graphics
 		// yes, our channel order is nuts.
 		static readonly int[] ChannelMasks = { 2, 1, 0, 3 };
 
+		public static uint[] CreateQuadIndices(int quads)
+		{
+			var indices = new uint[quads * 6];
+			ReadOnlySpan<uint> cornerVertexMap = stackalloc uint[] { 0, 1, 2, 2, 3, 0 };
+			for (var i = 0; i < indices.Length; i++)
+				indices[i] = cornerVertexMap[i % 6] + (uint)(4 * (i / 6));
+
+			return indices;
+		}
+
 		public static void FastCreateQuad(Vertex[] vertices, in float3 o, Sprite r, int2 samplers, float paletteTextureIndex, int nv,
 			in float3 size, in float3 tint, float alpha, float rotation = 0f)
 		{

--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -98,9 +98,7 @@ namespace OpenRA.Graphics
 			vertices[nv] = new Vertex(a, r.Left, r.Top, sl, st, paletteTextureIndex, fAttribC, tint, alpha);
 			vertices[nv + 1] = new Vertex(b, r.Right, r.Top, sr, st, paletteTextureIndex, fAttribC, tint, alpha);
 			vertices[nv + 2] = new Vertex(c, r.Right, r.Bottom, sr, sb, paletteTextureIndex, fAttribC, tint, alpha);
-			vertices[nv + 3] = new Vertex(c, r.Right, r.Bottom, sr, sb, paletteTextureIndex, fAttribC, tint, alpha);
-			vertices[nv + 4] = new Vertex(d, r.Left, r.Bottom, sl, sb, paletteTextureIndex, fAttribC, tint, alpha);
-			vertices[nv + 5] = new Vertex(a, r.Left, r.Top, sl, st, paletteTextureIndex, fAttribC, tint, alpha);
+			vertices[nv + 3] = new Vertex(d, r.Left, r.Bottom, sl, sb, paletteTextureIndex, fAttribC, tint, alpha);
 		}
 
 		public static void FastCopyIntoChannel(Sprite dest, byte[] src, SpriteFrameType srcType)

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -347,6 +347,15 @@ namespace OpenRA
 			PerfHistory.Increment("batches", 1);
 		}
 
+		public void DrawBatch<T>(IVertexBuffer<T> vertices, IIndexBuffer indices, int numIndices, int start)
+			where T : struct
+		{
+			vertices.Bind();
+			indices.Bind();
+			Context.DrawElements(numIndices, start);
+			PerfHistory.Increment("batches", 1);
+		}
+
 		public void Flush()
 		{
 			CurrentBatchRenderer = null;

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -97,7 +97,7 @@ namespace OpenRA
 			RgbaColorRenderer = new RgbaColorRenderer(SpriteRenderer);
 
 			tempVertexBuffer = Context.CreateVertexBuffer(TempVertexBufferSize);
-			quadIndexBuffer = Context.CreateQuadIndexBuffer(TempIndexBufferSize);
+			quadIndexBuffer = Context.CreateIndexBuffer(Util.CreateQuadIndices(TempIndexBufferSize / 6));
 		}
 
 		static Size GetResolution(GraphicSettings graphicsSettings)
@@ -331,18 +331,6 @@ namespace OpenRA
 			renderType = RenderType.None;
 		}
 
-		public void DrawBatch(Vertex[] vertices, int numVertices, PrimitiveType type)
-		{
-			tempBuffer.SetData(vertices, numVertices);
-			DrawBatch(tempBuffer, 0, numVertices, type);
-		}
-
-		public void DrawBatch(ref Vertex[] vertices, int numVertices, PrimitiveType type)
-		{
-			tempBuffer.SetData(ref vertices, numVertices);
-			DrawBatch(tempBuffer, 0, numVertices, type);
-		}
-
 		public void DrawBatch<T>(IVertexBuffer<T> vertices,
 			int firstVertex, int numVertices, PrimitiveType type)
 			where T : struct
@@ -352,7 +340,13 @@ namespace OpenRA
 			PerfHistory.Increment("batches", 1);
 		}
 
-		public void DrawBatch<T>(IVertexBuffer<T> vertices, IIndexBuffer indices, int numIndices, int start)
+		public void DrawQuadBatch(ref Vertex[] vertices, int numVertices)
+		{
+			tempVertexBuffer.SetData(ref vertices, numVertices);
+			DrawQuadBatch(tempVertexBuffer, quadIndexBuffer, numVertices / 4 * 6, 0);
+		}
+
+		public void DrawQuadBatch<T>(IVertexBuffer<T> vertices, IIndexBuffer indices, int numIndices, int start)
 			where T : struct
 		{
 			vertices.Bind();

--- a/OpenRA.Platforms.Default/DefaultPlatform.cs
+++ b/OpenRA.Platforms.Default/DefaultPlatform.cs
@@ -16,9 +16,9 @@ namespace OpenRA.Platforms.Default
 {
 	public class DefaultPlatform : IPlatform
 	{
-		public IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int batchSize, int videoDisplay, GLProfile profile, bool enableLegacyGL)
+		public IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int vertexBatchSize, int indexBatchSize, int videoDisplay, GLProfile profile, bool enableLegacyGL)
 		{
-			return new Sdl2PlatformWindow(size, windowMode, scaleModifier, batchSize, videoDisplay, profile, enableLegacyGL);
+			return new Sdl2PlatformWindow(size, windowMode, scaleModifier, vertexBatchSize, indexBatchSize, videoDisplay, profile, enableLegacyGL);
 		}
 
 		public ISoundEngine CreateSound(string device)

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -131,6 +131,8 @@ namespace OpenRA.Platforms.Default
 		public const int GL_TEXTURE_MAX_LEVEL = 0x813D;
 
 		public const int GL_ARRAY_BUFFER = 0x8892;
+		public const int GL_ELEMENT_ARRAY_BUFFER = 0x8893;
+		public const int GL_STATIC_DRAW = 0x88E4;
 		public const int GL_DYNAMIC_DRAW = 0x88E8;
 
 		public const int GL_TEXTURE0 = 0x84C0;

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -50,6 +50,7 @@ namespace OpenRA.Platforms.Default
 
 		// Data types
 		public const int GL_UNSIGNED_BYTE = 0x1401;
+		public const int GL_UNSIGNED_INT = 0x1405;
 		public const int GL_FLOAT = 0x1406;
 
 		// Errors
@@ -394,6 +395,9 @@ namespace OpenRA.Platforms.Default
 		public delegate void DrawArrays(int mode, int first, int count);
 		public static DrawArrays glDrawArrays { get; private set; }
 
+		public delegate void DrawElements(int mode, int count, int type, IntPtr indices);
+		public static DrawElements glDrawElements { get; private set; }
+
 		public delegate void Enable(int cap);
 		public static Enable glEnable { get; private set; }
 
@@ -590,6 +594,7 @@ namespace OpenRA.Platforms.Default
 				glEnableVertexAttribArray = Bind<EnableVertexAttribArray>("glEnableVertexAttribArray");
 				glDisableVertexAttribArray = Bind<DisableVertexAttribArray>("glDisableVertexAttribArray");
 				glDrawArrays = Bind<DrawArrays>("glDrawArrays");
+				glDrawElements = Bind<DrawElements>("glDrawElements");
 				glBlendEquation = Bind<BlendEquation>("glBlendEquation");
 				glBlendEquationSeparate = Bind<BlendEquationSeparate>("glBlendEquationSeparate");
 				glBlendFunc = Bind<BlendFunc>("glBlendFunc");

--- a/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
@@ -68,6 +68,12 @@ namespace OpenRA.Platforms.Default
 			return new VertexBuffer<Vertex>(size);
 		}
 
+		public IIndexBuffer CreateIndexBuffer(uint[] indices)
+		{
+			VerifyThreadAffinity();
+			return new StaticIndexBuffer(indices);
+		}
+
 		public Vertex[] CreateVertices(int size)
 		{
 			VerifyThreadAffinity();

--- a/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
@@ -170,6 +170,13 @@ namespace OpenRA.Platforms.Default
 			OpenGL.CheckGLError();
 		}
 
+		public void DrawElements(int numIndices, int offset)
+		{
+			VerifyThreadAffinity();
+			OpenGL.glDrawElements(OpenGL.GL_TRIANGLES, numIndices, OpenGL.GL_UNSIGNED_INT, new IntPtr(offset));
+			OpenGL.CheckGLError();
+		}
+
 		public void Clear()
 		{
 			VerifyThreadAffinity();

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -133,7 +133,7 @@ namespace OpenRA.Platforms.Default
 		static extern IntPtr XFlush(IntPtr display);
 
 		public Sdl2PlatformWindow(Size requestEffectiveWindowSize, WindowMode windowMode,
-			float scaleModifier, int batchSize, int videoDisplay, GLProfile requestProfile, bool enableLegacyGL)
+			float scaleModifier, int vertexBatchSize, int indexBatchSize, int videoDisplay, GLProfile requestProfile, bool enableLegacyGL)
 		{
 			// Lock the Window/Surface properties until initialization is complete
 			lock (syncObject)
@@ -348,7 +348,7 @@ namespace OpenRA.Platforms.Default
 				Context = ctx;
 			}
 			else
-				Context = new ThreadedGraphicsContext(new Sdl2GraphicsContext(this), batchSize);
+				Context = new ThreadedGraphicsContext(new Sdl2GraphicsContext(this), vertexBatchSize, indexBatchSize);
 
 			Context.SetVSyncEnabled(Game.Settings.Graphics.VSync);
 

--- a/OpenRA.Platforms.Default/StaticIndexBuffer.cs
+++ b/OpenRA.Platforms.Default/StaticIndexBuffer.cs
@@ -1,0 +1,62 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace OpenRA.Platforms.Default
+{
+	sealed class StaticIndexBuffer : ThreadAffine, IDisposable, IIndexBuffer
+	{
+		const int UintSize = 4;
+		uint buffer;
+		bool disposed;
+
+		public StaticIndexBuffer(uint[] indices)
+		{
+			OpenGL.glGenBuffers(1, out buffer);
+			OpenGL.CheckGLError();
+			Bind();
+
+			var ptr = GCHandle.Alloc(indices, GCHandleType.Pinned);
+			try
+			{
+				OpenGL.glBufferData(OpenGL.GL_ELEMENT_ARRAY_BUFFER,
+					new IntPtr(UintSize * indices.Length),
+					ptr.AddrOfPinnedObject(),
+					OpenGL.GL_STATIC_DRAW);
+			}
+			finally
+			{
+				ptr.Free();
+			}
+
+			OpenGL.CheckGLError();
+		}
+
+		public void Bind()
+		{
+			VerifyThreadAffinity();
+			OpenGL.glBindBuffer(OpenGL.GL_ELEMENT_ARRAY_BUFFER, buffer);
+			OpenGL.CheckGLError();
+		}
+
+		public void Dispose()
+		{
+			if (disposed)
+				return;
+
+			disposed = true;
+			OpenGL.glDeleteBuffers(1, ref buffer);
+			OpenGL.CheckGLError();
+		}
+	}
+}

--- a/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
+++ b/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
@@ -48,6 +48,7 @@ namespace OpenRA.Platforms.Default
 		Func<object, IVertexBuffer<Vertex>> getCreateVertexBuffer;
 		Func<object, IIndexBuffer> getCreateIndexBuffer;
 		Action<object> doDrawPrimitives;
+		Action<object> doDrawElements;
 		Action<object> doEnableScissor;
 		Action<object> doSetBlendMode;
 		Action<object> doSetVSync;
@@ -101,6 +102,12 @@ namespace OpenRA.Platforms.Default
 						{
 							var t = ((PrimitiveType, int, int))tuple;
 							context.DrawPrimitives(t.Item1, t.Item2, t.Item3);
+						};
+					doDrawElements =
+						tuple =>
+						{
+							var t = ((int, int))tuple;
+							context.DrawElements(t.Item1, t.Item2);
 						};
 					doEnableScissor =
 						tuple =>
@@ -429,6 +436,11 @@ namespace OpenRA.Platforms.Default
 		public void DrawPrimitives(PrimitiveType type, int firstVertex, int numVertices)
 		{
 			Post(doDrawPrimitives, (type, firstVertex, numVertices));
+		}
+
+		public void DrawElements(int numIndices, int offset)
+		{
+			Post(doDrawElements, (numIndices, offset));
 		}
 
 		public void EnableDepthBuffer()

--- a/OpenRA.Platforms.Default/VertexBuffer.cs
+++ b/OpenRA.Platforms.Default/VertexBuffer.cs
@@ -14,7 +14,7 @@ using System.Runtime.InteropServices;
 
 namespace OpenRA.Platforms.Default
 {
-	sealed class VertexBuffer<T> : ThreadAffine, IVertexBuffer<T>
+	sealed class VertexBuffer<T> : ThreadAffine, IDisposable, IVertexBuffer<T>
 			where T : struct
 	{
 		static readonly int VertexSize = Marshal.SizeOf(typeof(T));


### PR DESCRIPTION
Its standard practice to use IndexBuffers in all rendering API's, not just in OpenGL. The documentation shows that the new method of rendering `glDrawElements` exists in OpenGL 1.1. (fyi this is considered the earliest proper OpenGL version)

Why index buffers are important? To draw a rectangle we need 2 triangles, to draw each triangle we need 3 vertices. Meaning we need 6 vertices for a square, but when we think of a square it's really just drawn from 4 points. 2 of the 6 vertices are just holding duplicated data, and do mind that a single vertex holds quite a lot of data

The solution are IndexBuffers, they allow you to reuse vertices or change their order. By using them we reduce the RAM usage on Both the GPU and CPU, as well as data they need to pass around. In `TerrainSpriteLayer` specific case it also significantly reduces the amount of calculations on the CPU side

I had observed the FPS timer on the RA shellmap, on bleed saw `~202`, on this PR `~226` FPS
I also checked out the TS shell map bleed: `~186` PR:  `~202`