### PR TITLE
Fix terrain positions for targets not being serialized for Orders

### DIFF
--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -157,8 +157,8 @@ namespace OpenRA
 									{
 										var pos = new WPos(r.ReadInt32(), r.ReadInt32(), r.ReadInt32());
 
-										var numberOfTerrainPositions = r.ReadByte();
-										if (numberOfTerrainPositions == 0)
+										var numberOfTerrainPositions = r.ReadInt16();
+										if (numberOfTerrainPositions == -1)
 											target = Target.FromPos(pos);
 										else
 										{
@@ -403,10 +403,10 @@ namespace OpenRA
 									// Don't send extra data over the network that will be restored by the Target ctor
 									var terrainPositions = targetState.TerrainPositions.Length;
 									if (terrainPositions == 1 && targetState.TerrainPositions[0] == targetState.Pos)
-										w.Write((byte)0);
+										w.Write((short)-1);
 									else
 									{
-										w.Write((byte)terrainPositions);
+										w.Write((short)terrainPositions);
 										foreach (var position in targetState.TerrainPositions)
 										{
 											w.Write(position.X);

--- a/OpenRA.Game/Server/ProtocolVersion.cs
+++ b/OpenRA.Game/Server/ProtocolVersion.cs
@@ -77,6 +77,6 @@ namespace OpenRA.Server
 		// The protocol for server and world orders
 		// This applies after the handshake has completed, and is provided to support
 		// alternative server implementations that wish to support multiple versions in parallel
-		public const int Orders = 20;
+		public const int Orders = 21;
 	}
 }

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -288,7 +288,8 @@ namespace OpenRA.Traits
 
 		// Expose internal state for serialization by the orders code *only*
 		internal static Target FromSerializedActor(Actor a, int generation) { return a != null ? new Target(a, generation) : Invalid; }
-		internal (TargetType Type, Actor Actor, int Generation, CPos? Cell, SubCell? SubCell, WPos Pos) SerializableState =>
-			(type, Actor, generation, cell, subCell, terrainCenterPosition);
+		internal static Target FromSerializedTerrainPosition(WPos centerPosition, WPos[] terrainPositions) { return new Target(centerPosition, terrainPositions); }
+		internal (TargetType Type, Actor Actor, int Generation, CPos? Cell, SubCell? SubCell, WPos Pos, WPos[] TerrainPositions) SerializableState =>
+			(type, Actor, generation, cell, subCell, terrainCenterPosition, terrainPositions);
 	}
 }


### PR DESCRIPTION
Takeover of #20216, see for more details.

Ensure we serialize terrain positions for a target correctly. Resolves my comment from original PR by using -1 as a magic number rather than 0 which conflicts with a 0-length array.