### PR TITLE
Stream Cleanup

### DIFF
--- a/OpenRA.Game/CryptoUtil.cs
+++ b/OpenRA.Game/CryptoUtil.cs
@@ -53,33 +53,33 @@ namespace OpenRA
 				using (var s = new MemoryStream(data))
 				{
 					// SEQUENCE
-					s.ReadByte();
+					s.ReadUInt8();
 					ReadTLVLength(s);
 
 					// SEQUENCE -> fixed header junk
-					s.ReadByte();
+					s.ReadUInt8();
 					var headerLength = ReadTLVLength(s);
 					s.Position += headerLength;
 
 					// SEQUENCE -> BIT_STRING
-					s.ReadByte();
+					s.ReadUInt8();
 					ReadTLVLength(s);
-					s.ReadByte();
+					s.ReadUInt8();
 
 					// SEQUENCE -> BIT_STRING -> SEQUENCE
-					s.ReadByte();
+					s.ReadUInt8();
 					ReadTLVLength(s);
 
 					// SEQUENCE -> BIT_STRING -> SEQUENCE -> INTEGER (modulus)
-					s.ReadByte();
+					s.ReadUInt8();
 					var modulusLength = ReadTLVLength(s);
-					s.ReadByte();
+					s.ReadUInt8();
 					var modulus = s.ReadBytes(modulusLength - 1);
 
 					// SEQUENCE -> BIT_STRING -> SEQUENCE -> INTEGER (exponent)
-					s.ReadByte();
+					s.ReadUInt8();
 					var exponentLength = ReadTLVLength(s);
-					s.ReadByte();
+					s.ReadUInt8();
 					var exponent = s.ReadBytes(exponentLength - 1);
 
 					return new RSAParameters
@@ -158,7 +158,7 @@ namespace OpenRA
 
 		static int ReadTLVLength(Stream s)
 		{
-			var length = s.ReadByte();
+			var length = s.ReadUInt8();
 			if (length < 0x80)
 				return length;
 

--- a/OpenRA.Game/Network/Connection.cs
+++ b/OpenRA.Game/Network/Connection.cs
@@ -260,14 +260,14 @@ namespace OpenRA.Network
 			try
 			{
 				var ms = new MemoryStream();
-				ms.WriteArray(BitConverter.GetBytes(packet.Length));
+				ms.Write(packet.Length);
 				ms.WriteArray(packet);
 
 				foreach (var s in queuedSyncPackets)
 				{
 					var q = OrderIO.SerializeSync(s);
 
-					ms.WriteArray(BitConverter.GetBytes(q.Length));
+					ms.Write(q.Length);
 					ms.WriteArray(q);
 
 					sentSync.Enqueue(s);

--- a/OpenRA.Game/Network/GameSave.cs
+++ b/OpenRA.Game/Network/GameSave.cs
@@ -226,9 +226,9 @@ namespace OpenRA.Network
 				clientSlot = firstBotSlotIndex;
 			}
 
-			ordersStream.WriteArray(BitConverter.GetBytes(data.Length + 8));
-			ordersStream.WriteArray(BitConverter.GetBytes(frame));
-			ordersStream.WriteArray(BitConverter.GetBytes(clientSlot));
+			ordersStream.Write(data.Length + 8);
+			ordersStream.Write(frame);
+			ordersStream.Write(clientSlot);
 			ordersStream.WriteArray(data);
 			LastOrdersFrame = frame;
 		}
@@ -288,9 +288,9 @@ namespace OpenRA.Network
 			{
 				ordersStream.Seek(0, SeekOrigin.Begin);
 				ordersStream.CopyTo(file);
-				file.Write(BitConverter.GetBytes(MetadataMarker), 0, 4);
-				file.Write(BitConverter.GetBytes(LastOrdersFrame), 0, 4);
-				file.Write(BitConverter.GetBytes(LastSyncFrame), 0, 4);
+				file.Write(MetadataMarker);
+				file.Write(LastOrdersFrame);
+				file.Write(LastSyncFrame);
 				file.Write(lastSyncPacket, 0, Order.SyncHashOrderLength);
 
 				var globalSettingsNodes = new List<MiniYamlNode>() { GlobalSettings.Serialize() };
@@ -307,16 +307,16 @@ namespace OpenRA.Network
 				file.WriteString(Encoding.UTF8, slotClientNodes.WriteToString());
 
 				var traitDataOffset = file.Length;
-				file.Write(BitConverter.GetBytes(TraitDataMarker), 0, 4);
+				file.Write(TraitDataMarker);
 
 				var traitDataNodes = TraitData
 					.Select(kv => new MiniYamlNode(kv.Key.ToStringInvariant(), kv.Value))
 					.ToList();
 				file.WriteString(Encoding.UTF8, traitDataNodes.WriteToString());
 
-				file.Write(BitConverter.GetBytes(ordersStream.Length), 0, 4);
-				file.Write(BitConverter.GetBytes(traitDataOffset), 0, 4);
-				file.Write(BitConverter.GetBytes(EOFMarker), 0, 4);
+				file.Write((int)ordersStream.Length);
+				file.Write((int)traitDataOffset);
+				file.Write(EOFMarker);
 			}
 		}
 	}

--- a/OpenRA.Game/Network/OrderIO.cs
+++ b/OpenRA.Game/Network/OrderIO.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Network
 		public byte[] Serialize(int frame)
 		{
 			var ms = new MemoryStream((int)data.Length + 4);
-			ms.WriteArray(BitConverter.GetBytes(frame));
+			ms.Write(frame);
 
 			data.Position = 0;
 			data.CopyTo(ms);
@@ -83,9 +83,9 @@ namespace OpenRA.Network
 		public static byte[] SerializeSync((int Frame, int SyncHash, ulong DefeatState) data)
 		{
 			var ms = new MemoryStream(4 + Order.SyncHashOrderLength);
-			ms.WriteArray(BitConverter.GetBytes(data.Frame));
+			ms.Write(data.Frame);
 			ms.WriteByte((byte)OrderType.SyncHash);
-			ms.WriteArray(BitConverter.GetBytes(data.SyncHash));
+			ms.Write(data.SyncHash);
 			ms.WriteArray(BitConverter.GetBytes(data.DefeatState));
 			return ms.GetBuffer();
 		}
@@ -93,7 +93,7 @@ namespace OpenRA.Network
 		public static byte[] SerializePingResponse(long timestamp, byte queueLength)
 		{
 			var ms = new MemoryStream(14);
-			ms.WriteArray(BitConverter.GetBytes(0));
+			ms.Write(0);
 			ms.WriteByte((byte)OrderType.Ping);
 			ms.WriteArray(BitConverter.GetBytes(timestamp));
 			ms.WriteByte(queueLength);

--- a/OpenRA.Game/Network/ReplayRecorder.cs
+++ b/OpenRA.Game/Network/ReplayRecorder.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Network
 		public void ReceiveFrame(int clientID, int frame, byte[] data)
 		{
 			var ms = new MemoryStream(4 + data.Length);
-			ms.WriteArray(BitConverter.GetBytes(frame));
+			ms.Write(frame);
 			ms.WriteArray(data);
 			Receive(clientID, ms.GetBuffer());
 		}

--- a/OpenRA.Game/Server/Connection.cs
+++ b/OpenRA.Game/Server/Connection.cs
@@ -60,9 +60,9 @@ namespace OpenRA.Server
 		static byte[] CreatePingFrame()
 		{
 			var ms = new MemoryStream(21);
-			ms.WriteArray(BitConverter.GetBytes(13));
-			ms.WriteArray(BitConverter.GetBytes(0));
-			ms.WriteArray(BitConverter.GetBytes(0));
+			ms.Write(13);
+			ms.Write(0);
+			ms.Write(0);
 			ms.WriteByte((byte)OrderType.Ping);
 			ms.WriteArray(BitConverter.GetBytes(Game.RunTime));
 			return ms.GetBuffer();

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -436,8 +436,8 @@ namespace OpenRA.Server
 			{
 				// Send handshake and client index.
 				var ms = new MemoryStream(8);
-				ms.WriteArray(BitConverter.GetBytes(ProtocolVersion.Handshake));
-				ms.WriteArray(BitConverter.GetBytes(newConn.PlayerIndex));
+				ms.Write(ProtocolVersion.Handshake);
+				ms.Write(newConn.PlayerIndex);
 				newConn.TrySendData(ms.ToArray());
 
 				// Dispatch a handshake order
@@ -704,9 +704,9 @@ namespace OpenRA.Server
 		static byte[] CreateFrame(int client, int frame, byte[] data)
 		{
 			var ms = new MemoryStream(data.Length + 12);
-			ms.WriteArray(BitConverter.GetBytes(data.Length + 4));
-			ms.WriteArray(BitConverter.GetBytes(client));
-			ms.WriteArray(BitConverter.GetBytes(frame));
+			ms.Write(data.Length + 4);
+			ms.Write(client);
+			ms.Write(frame);
 			ms.WriteArray(data);
 			return ms.GetBuffer();
 		}
@@ -714,9 +714,9 @@ namespace OpenRA.Server
 		static byte[] CreateAckFrame(int frame, byte count)
 		{
 			var ms = new MemoryStream(14);
-			ms.WriteArray(BitConverter.GetBytes(6));
-			ms.WriteArray(BitConverter.GetBytes(0));
-			ms.WriteArray(BitConverter.GetBytes(frame));
+			ms.Write(6);
+			ms.Write(0);
+			ms.Write(frame);
 			ms.WriteByte((byte)OrderType.Ack);
 			ms.WriteByte(count);
 			return ms.GetBuffer();
@@ -725,9 +725,9 @@ namespace OpenRA.Server
 		static byte[] CreateTickScaleFrame(float scale)
 		{
 			var ms = new MemoryStream(17);
-			ms.WriteArray(BitConverter.GetBytes(9));
-			ms.WriteArray(BitConverter.GetBytes(0));
-			ms.WriteArray(BitConverter.GetBytes(0));
+			ms.Write(9);
+			ms.Write(0);
+			ms.Write(0);
 			ms.WriteByte((byte)OrderType.TickScale);
 			ms.Write(scale);
 			return ms.GetBuffer();

--- a/OpenRA.Mods.Cnc/AudioLoaders/VocLoader.cs
+++ b/OpenRA.Mods.Cnc/AudioLoaders/VocLoader.cs
@@ -150,7 +150,7 @@ namespace OpenRA.Mods.Cnc.AudioLoaders
 				var block = default(VocBlock);
 				try
 				{
-					block.Code = stream.ReadByte();
+					block.Code = stream.ReadUInt8();
 					block.Length = 0;
 				}
 				catch (EndOfStreamException)
@@ -162,9 +162,9 @@ namespace OpenRA.Mods.Cnc.AudioLoaders
 				if (block.Code == 0 || block.Code > 9)
 					break;
 
-				block.Length = stream.ReadByte();
-				block.Length |= stream.ReadByte() << 8;
-				block.Length |= stream.ReadByte() << 16;
+				block.Length = stream.ReadUInt8();
+				block.Length |= stream.ReadUInt8() << 8;
+				block.Length |= stream.ReadUInt8() << 16;
 
 				var skip = 0;
 				switch (block.Code)
@@ -174,9 +174,9 @@ namespace OpenRA.Mods.Cnc.AudioLoaders
 						{
 							if (block.Length < 2)
 								throw new InvalidDataException("Invalid sound data block length in voc file");
-							var freqDiv = stream.ReadByte();
+							var freqDiv = stream.ReadUInt8();
 							block.SampleBlock.Rate = GetSampleRateFromVocRate(freqDiv);
-							var codec = stream.ReadByte();
+							var codec = stream.ReadUInt8();
 							if (codec != 0)
 								throw new InvalidDataException("Unhandled codec used in voc file");
 							skip = block.Length - 2;
@@ -205,7 +205,7 @@ namespace OpenRA.Mods.Cnc.AudioLoaders
 								throw new InvalidDataException("Invalid silence block length in voc file");
 							block.SampleBlock.Offset = 0;
 							block.SampleBlock.Samples = stream.ReadUInt16() + 1;
-							var freqDiv = stream.ReadByte();
+							var freqDiv = stream.ReadUInt8();
 							block.SampleBlock.Rate = GetSampleRateFromVocRate(freqDiv);
 							break;
 						}
@@ -231,10 +231,10 @@ namespace OpenRA.Mods.Cnc.AudioLoaders
 							int freqDiv = stream.ReadUInt16();
 							if (freqDiv == 65536)
 								throw new InvalidDataException("Invalid frequency divisor 65536 in voc file");
-							var codec = stream.ReadByte();
+							var codec = stream.ReadUInt8();
 							if (codec != 0)
 								throw new InvalidDataException("Unhandled codec used in voc file");
-							var channels = stream.ReadByte() + 1;
+							var channels = stream.ReadUInt8() + 1;
 							if (channels != 1)
 								throw new InvalidDataException("Unhandled number of channels in voc file");
 							block.SampleBlock.Offset = 0;

--- a/OpenRA.Mods.Cnc/FileFormats/AudReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/AudReader.cs
@@ -18,13 +18,13 @@ using OpenRA.Primitives;
 namespace OpenRA.Mods.Cnc.FileFormats
 {
 	[Flags]
-	enum SoundFlags
+	enum SoundFlags : byte
 	{
 		Stereo = 0x1,
 		_16Bit = 0x2,
 	}
 
-	enum SoundFormat
+	enum SoundFormat : byte
 	{
 		WestwoodCompressed = 1,
 		ImaAdpcm = 99,
@@ -59,12 +59,12 @@ namespace OpenRA.Mods.Cnc.FileFormats
 				sampleRate = s.ReadUInt16();
 				var dataSize = s.ReadInt32();
 				var outputSize = s.ReadInt32();
-				var audioFlags = (SoundFlags)s.ReadByte();
+				var audioFlags = (SoundFlags)s.ReadUInt8();
 				sampleBits = (audioFlags & SoundFlags._16Bit) == 0 ? 8 : 16;
 				channels = (audioFlags & SoundFlags.Stereo) == 0 ? 1 : 2;
 				lengthInSeconds = (float)(outputSize * 8) / (channels * sampleBits * sampleRate);
 
-				var readFormat = s.ReadByte();
+				var readFormat = s.ReadUInt8();
 				if (!Enum.IsDefined(typeof(SoundFormat), readFormat))
 					return false;
 

--- a/OpenRA.Mods.Cnc/FileFormats/VqaVideo.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/VqaVideo.cs
@@ -93,8 +93,8 @@ namespace OpenRA.Mods.Cnc.FileFormats
 
 			// Audio
 			SampleRate = stream.ReadUInt16();
-			AudioChannels = stream.ReadByte();
-			SampleBits = stream.ReadByte();
+			AudioChannels = stream.ReadUInt8();
+			SampleBits = stream.ReadUInt8();
 
 			/*var unknown3 =*/stream.ReadUInt32();
 			/*var unknown4 =*/stream.ReadUInt16();
@@ -221,7 +221,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 					}
 
 					// Chunks are aligned on even bytes; advance by a byte if the next one is null
-					if (stream.Peek() == 0) stream.ReadByte();
+					if (stream.Peek() == 0) stream.ReadUInt8();
 				}
 			}
 
@@ -300,7 +300,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 						DecodeVQFR(stream);
 						break;
 					case "\0VQF":
-						stream.ReadByte();
+						stream.ReadUInt8();
 						DecodeVQFR(stream);
 						break;
 					case "VQFL":
@@ -313,7 +313,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 				}
 
 				// Chunks are aligned on even bytes; advance by a byte if the next one is null
-				if (stream.Peek() == 0) stream.ReadByte();
+				if (stream.Peek() == 0) stream.ReadUInt8();
 			}
 
 			// Now that the frame data has been loaded (in the relevant private fields), decode it into CurrentFrameData.
@@ -340,7 +340,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 			while (true)
 			{
 				// Chunks are aligned on even bytes; may be padded with a single null
-				if (s.Peek() == 0) s.ReadByte();
+				if (s.Peek() == 0) s.ReadUInt8();
 				var type = s.ReadASCII(4);
 				var subchunkLength = (int)int2.Swap(s.ReadUInt32());
 

--- a/OpenRA.Mods.Cnc/FileFormats/VxlReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/VxlReader.cs
@@ -15,7 +15,7 @@ using System.IO;
 
 namespace OpenRA.Mods.Cnc.FileFormats
 {
-	public enum NormalType { TiberianSun = 2, RedAlert2 = 4 }
+	public enum NormalType : byte { TiberianSun = 2, RedAlert2 = 4 }
 	public readonly struct VxlElement
 	{
 		public readonly byte Color;
@@ -148,7 +148,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 				for (var j = 0; j < 6; j++)
 					Limbs[i].Bounds[j] = s.ReadFloat();
 				Limbs[i].Size = s.ReadBytes(3);
-				Limbs[i].Type = (NormalType)s.ReadByte();
+				Limbs[i].Type = (NormalType)s.ReadUInt8();
 			}
 
 			for (var i = 0; i < LimbCount; i++)

--- a/OpenRA.Mods.Cnc/FileFormats/WsaVideo.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/WsaVideo.cs
@@ -63,9 +63,9 @@ namespace OpenRA.Mods.Cnc.FileFormats
 				paletteBytes = new byte[1024];
 				for (var i = 0; i < paletteBytes.Length;)
 				{
-					var r = (byte)(stream.ReadByte() << 2);
-					var g = (byte)(stream.ReadByte() << 2);
-					var b = (byte)(stream.ReadByte() << 2);
+					var r = (byte)(stream.ReadUInt8() << 2);
+					var g = (byte)(stream.ReadUInt8() << 2);
+					var b = (byte)(stream.ReadUInt8() << 2);
 
 					// Replicate high bits into the (currently zero) low bits.
 					r |= (byte)(r >> 6);

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpD2Loader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpD2Loader.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 	public class ShpD2Loader : ISpriteLoader
 	{
 		[Flags]
-		enum FormatFlags : int
+		enum FormatFlags : ushort
 		{
 			PaletteTable = 1,
 			NotLCWCompressed = 2,

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpTDLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpTDLoader.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 
 	public class ShpTDSprite
 	{
-		enum Format { XORPrev = 0x20, XORLCW = 0x40, LCW = 0x80 }
+		enum Format : ushort { XORPrev = 0x20, XORLCW = 0x40, LCW = 0x80 }
 
 		sealed class ImageHeader : ISpriteFrame
 		{

--- a/OpenRA.Mods.Common/FileFormats/WavReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/WavReader.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.FileFormats
 {
 	public static class WavReader
 	{
-		enum WaveType { Pcm = 0x1, MsAdpcm = 0x2, ImaAdpcm = 0x11 }
+		enum WaveType : short { Pcm = 0x1, MsAdpcm = 0x2, ImaAdpcm = 0x11 }
 
 		public static bool LoadSound(Stream s, out Func<Stream> result, out short channels, out int sampleBits, out int sampleRate, out float lengthInSeconds)
 		{
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.FileFormats
 			while (s.Position < s.Length)
 			{
 				if ((s.Position & 1) == 1)
-					s.ReadByte(); // Alignment
+					s.ReadUInt8(); // Alignment
 
 				if (s.Position == s.Length)
 					break; // Break if we aligned with end of stream

--- a/OpenRA.Mods.Common/FileSystem/InstallShieldPackage.cs
+++ b/OpenRA.Mods.Common/FileSystem/InstallShieldPackage.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.FileSystem
 				s.Position += 12;
 				var chunkSize = s.ReadUInt16();
 				s.Position += 4;
-				var nameLength = s.ReadByte();
+				var nameLength = s.ReadUInt8();
 				var fileName = dirName + "\\" + s.ReadASCII(nameLength);
 
 				// Use index syntax to overwrite any duplicate entries with the last value


### PR DESCRIPTION
- Use Stream.Write(int) extension method where possible.
- Prefer ReadUInt8 over ReadByte. The former will throw when the end of the stream is reached, rather than requiring the caller to check for -1.