### PR TITLE
Add backup `ExplicitSequenceFilenames` to update rules

### DIFF
--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230225/ExplicitSequenceFilenames.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230225/ExplicitSequenceFilenames.cs
@@ -92,19 +92,73 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 					defaultSpriteExtension = defaultSpriteExtensionNode.Value.Value;
 				}
 
-				var tilesetExtensionsNode = spriteSequenceFormatNode.LastChildMatching("TilesetExtensions");
+				var fromBackup = false;
+
+				var tilesetExtensionsNode = spriteSequenceFormatNode.LastChildMatching("TilesetExtensions")?.Value?.Nodes;
+				if (tilesetExtensionsNode == null)
+				{
+					switch (modData.Manifest.Id)
+					{
+						case "cnc":
+							fromBackup = true;
+							tilesetExtensionsNode = new List<MiniYamlNodeBuilder>()
+							{
+								new MiniYamlNodeBuilder("TEMPERAT", ".tem"),
+								new MiniYamlNodeBuilder("SNOW", ".sno"),
+								new MiniYamlNodeBuilder("INTERIOR", ".int"),
+								new MiniYamlNodeBuilder("DESERT", ".des"),
+								new MiniYamlNodeBuilder("JUNGLE", ".jun"),
+							};
+							break;
+						case "ra":
+							fromBackup = true;
+							tilesetExtensionsNode = new List<MiniYamlNodeBuilder>()
+							{
+								new MiniYamlNodeBuilder("TEMPERAT", ".tem"),
+								new MiniYamlNodeBuilder("SNOW", ".sno"),
+								new MiniYamlNodeBuilder("INTERIOR", ".int"),
+								new MiniYamlNodeBuilder("DESERT", ".des"),
+							};
+							break;
+						case "ts":
+							fromBackup = true;
+							tilesetExtensionsNode = new List<MiniYamlNodeBuilder>()
+							{
+								new MiniYamlNodeBuilder("TEMPERATE", ".tem"),
+								new MiniYamlNodeBuilder("SNOW", ".sno"),
+							};
+							break;
+					}
+				}
+
 				if (tilesetExtensionsNode != null)
 				{
-					reportModYamlChanges = true;
-					foreach (var n in tilesetExtensionsNode.Value.Nodes)
+					if (!fromBackup)
+						reportModYamlChanges = true;
+
+					foreach (var n in tilesetExtensionsNode)
 						tilesetExtensions[n.Key] = n.Value.Value;
 				}
 
-				var tilesetCodesNode = spriteSequenceFormatNode.LastChildMatching("TilesetCodes");
+				fromBackup = false;
+
+				var tilesetCodesNode = spriteSequenceFormatNode.LastChildMatching("TilesetCodes")?.Value?.Nodes;
+				if (tilesetCodesNode == null && modData.Manifest.Id == "ts")
+				{
+					fromBackup = true;
+					tilesetCodesNode = new List<MiniYamlNodeBuilder>()
+					{
+						new MiniYamlNodeBuilder("TEMPERATE", "t"),
+						new MiniYamlNodeBuilder("SNOW", "a"),
+					};
+				}
+
 				if (tilesetCodesNode != null)
 				{
-					reportModYamlChanges = true;
-					foreach (var n in tilesetCodesNode.Value.Nodes)
+					if (!fromBackup)
+						reportModYamlChanges = true;
+
+					foreach (var n in tilesetCodesNode)
 						tilesetCodes[n.Key] = n.Value.Value;
 				}
 			}


### PR DESCRIPTION
Adds https://github.com/OpenRA/OpenRA/pull/20580/commits/6c09805c656f57f8399ee274d9d5963287f69154 to update rules

Adresses https://github.com/OpenRA/OpenRA/pull/20580#issuecomment-1365073895

Due to the miniyaml refactor this will have issues when being merged into prep