### PR TITLE
Fixed empty `ScriptLobbyDropdown` description crashing the game despite being optional

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -550,7 +550,7 @@ namespace OpenRA.Traits
 		{
 			Id = id;
 			Name = map.GetLocalisedString(name);
-			Description = map.GetLocalisedString(description);
+			Description = description != null ? map.GetLocalisedString(description) : null;
 			IsVisible = visible;
 			DisplayOrder = displayorder;
 			Values = values.ToDictionary(v => v.Key, v => map.GetLocalisedString(v.Value));

--- a/OpenRA.Mods.Common/Traits/World/ScriptLobbyDropdown.cs
+++ b/OpenRA.Mods.Common/Traits/World/ScriptLobbyDropdown.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[FieldLoader.Require]
 		[TranslationReference(dictionaryReference: LintDictionaryReference.Values)]
-		[Desc("Difficulty levels supported by the map.")]
+		[Desc("Options to choose from.")]
 		public readonly Dictionary<string, string> Values = null;
 
 		[Desc("Prevent the option from being changed from its default value.")]


### PR DESCRIPTION
Closes https://github.com/OpenRA/OpenRA/issues/21025