### PR TITLE
Repulse in Aircraft can be turn off from outside. FerryUnit turn off repulse when transporting.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -288,6 +288,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly int creationActivityDelay;
 
 		bool notify = true;
+		bool repulseEnabled = true;
 
 		public static WPos GroundPosition(Actor self)
 		{
@@ -451,8 +452,12 @@ namespace OpenRA.Mods.Common.Traits
 					Pitch = Util.TickFacing(Pitch, WAngle.Zero, Info.PitchSpeed);
 			}
 
-			Repulse();
+			if (repulseEnabled)
+				Repulse();
 		}
+
+		public void EnableRepulse() { repulseEnabled = true; }
+		public void DisableRepulse() { repulseEnabled = false; }
 
 		public void Repulse()
 		{

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -63,6 +63,7 @@ carryall:
 		Category: Units
 	Aircraft:
 		MinAirborneAltitude: 400
+		Repulsable: True
 	RevealsShroud@lifting_low:
 		Range: 2c512
 		Type: GroundPosition


### PR DESCRIPTION
It is a very common way to turn off actor's collision when doing some automatic activity for RTS to avoid actor stuck, especially aircraft (for example, General's chinook when harvesting)