### PR TITLE
New SendUnitToAttackBotModule and related

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/BotModules/BotModuleLogic/UnitAttackOptions.cs
+++ b/OpenRA.Mods.Cnc/Traits/BotModules/BotModuleLogic/UnitAttackOptions.cs
@@ -1,0 +1,54 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+
+namespace OpenRA.Mods.Cnc.Traits
+{
+	[Flags]
+	public enum AttackRequires
+	{
+		None = 0,
+		CargoLoaded = 1,
+		Disguised = 2,
+	}
+
+	[Desc("Adds metadata for the " + nameof(SendUnitToAttackBotModule) + ".")]
+	public sealed class UnitAttackOptions
+	{
+		[Desc("Base desire provided for attack desire for each of this unit.",
+			"When desire reach 100, AI will send them to attack")]
+		public readonly int AttackDesireOfEach = 20;
+
+		[Desc("Order used for closing in the target before attack. Left empty for attack directly.")]
+		public readonly string MoveToOrderName = null;
+
+		[Desc("Attack order name. Used for actor to attack target.")]
+		public readonly string AttackOrderName = "Attack";
+
+		[Desc("Order used for moving the unit back to where it was after attack. Left empty for no return.")]
+		public readonly string MoveBackOrderName = null;
+
+		[Desc("Disguise before attack, if possible.")]
+		public readonly bool TryDisguise = false;
+
+		[Desc("Repaired before attack, if possible.")]
+		public readonly bool TryGetHealed = true;
+
+		[Desc("Filters units don't meet the requirements. Possible values are None, CargoLoaded, MustDisguised.")]
+		public readonly AttackRequires AttackRequires = AttackRequires.None;
+
+		public UnitAttackOptions(MiniYaml yaml)
+		{
+			FieldLoader.Load(this, yaml);
+		}
+	}
+}

--- a/OpenRA.Mods.Cnc/Traits/BotModules/SendUnitToAttackBotModule.cs
+++ b/OpenRA.Mods.Cnc/Traits/BotModules/SendUnitToAttackBotModule.cs
@@ -1,0 +1,376 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Cnc.Traits
+{
+	[Flags]
+	public enum TargetDistance
+	{
+		Closest = 0,
+		Furthest = 1,
+		Random = 2
+	}
+
+	[TraitLocation(SystemActors.Player)]
+	[Desc("Bot logic for units that should not be sent with a regular squad, like suicide or subterranean units.")]
+	public sealed class SendUnitToAttackBotModuleInfo : ConditionalTraitInfo
+	{
+		[Desc("Actors used for attack, and their options on attacking.")]
+		[FieldLoader.LoadUsing(nameof(LoadOptions))]
+		public readonly FrozenDictionary<string, UnitAttackOptions> ActorTypesAndAttackOptions = default;
+
+		[Desc("Target types that can be targeted.")]
+		public readonly BitSet<TargetableType> ValidTargets = new("Structure");
+
+		[Desc("Target types that can't be targeted.")]
+		public readonly BitSet<TargetableType> InvalidTargets;
+
+		[Desc("Player relationships that will be targeted.")]
+		public readonly PlayerRelationship ValidRelationships = PlayerRelationship.Enemy;
+
+		[Desc("Should attack the furthest or closest target. Possible values are Closest, Furthest, Random",
+			"Multiple values mean the distance randomizes between them")]
+		public readonly TargetDistance[] TargetDistances = [TargetDistance.Closest];
+
+		[Desc("Prepare unit, disguise unit and try attack target in this interval.")]
+		public readonly int ScanTick = 463;
+
+		[Desc("The total attack desire increases by this amount per scan",
+			"Note: When there is no attack unit, the total attack desire will return to 0.")]
+		public readonly int AttackDesireIncreasedPerScan = 10;
+
+		static object LoadOptions(MiniYaml yaml)
+		{
+			var ret = new Dictionary<string, UnitAttackOptions>();
+			var options = yaml.Nodes.FirstOrDefault(n => n.Key == "ActorTypesAndAttackOptions");
+			if (options != null)
+				foreach (var d in options.Value.Nodes)
+				{
+					ret.Add(d.Key, new UnitAttackOptions(d.Value));
+				}
+
+			return ret.ToFrozenDictionary();
+		}
+
+		public override object Create(ActorInitializer init) { return new SendUnitToAttackBotModule(init.Self, this); }
+	}
+
+	public class SendUnitToAttackBotModule : ConditionalTrait<SendUnitToAttackBotModuleInfo>, IBotTick
+	{
+		const PlayerRelationship ValidDisguiseRelationship = PlayerRelationship.Ally | PlayerRelationship.Neutral;
+
+		readonly World world;
+		readonly Player player;
+		PathFinder pathfinder;
+
+		readonly Predicate<Actor> unitCannotBeOrdered;
+		readonly Predicate<Actor> unitCannotBeOrderedOrIsBusy;
+		readonly Predicate<Actor> isInvalidActor;
+
+		readonly List<TraitPair<Disguise>> disguisePairs = [];
+		BitSet<TargetableType> disguiseTypes;
+		List<Actor> attackActors = [];
+
+		int prepareAttackTicks;
+		int disguiseDelayTicks;
+		int assignAttackTicks;
+
+		Player targetPlayer;
+		int desireIncreased;
+
+		public SendUnitToAttackBotModule(Actor self, SendUnitToAttackBotModuleInfo info)
+		: base(info)
+		{
+			world = self.World;
+			player = self.Owner;
+			isInvalidActor = a => a == null || a.IsDead || !a.IsInWorld;
+			unitCannotBeOrdered = a => isInvalidActor(a) || a.Owner != player;
+			unitCannotBeOrderedOrIsBusy = a => unitCannotBeOrdered(a) || !(a.IsIdle || a.CurrentActivity is FlyIdle);
+			desireIncreased = 0;
+		}
+
+		protected override void Created(Actor self)
+		{
+			// Special case handling is required for the Player actor.
+			// Created is called before Player.PlayerActor is assigned,
+			// so we must query player traits from self, which refers
+			// for bot modules always to the Player actor.
+			pathfinder = world.WorldActor.Trait<PathFinder>();
+		}
+
+		protected override void TraitEnabled(Actor self)
+		{
+			// Avoid all AIs reevaluating assignments on the same tick, randomize their initial evaluation delay.
+			// and we divide preparing stage, disguising stage and attacking stage for PERF.
+			prepareAttackTicks = world.LocalRandom.Next(0, Info.ScanTick);
+			disguiseDelayTicks = prepareAttackTicks + Info.ScanTick / 3;
+			assignAttackTicks = disguiseDelayTicks + Info.ScanTick / 3;
+		}
+
+		void IBotTick.BotTick(IBot bot)
+		{
+			if (--prepareAttackTicks <= 0)
+			{
+				prepareAttackTicks = Info.ScanTick;
+				PrepareAttackTick(bot);
+			}
+
+			if (--disguiseDelayTicks < 0)
+			{
+				disguiseDelayTicks = Info.ScanTick;
+				if (targetPlayer.WinState != WinState.Lost)
+					DisguiseTicks(bot);
+			}
+
+			if (--assignAttackTicks <= 0)
+			{
+				assignAttackTicks = Info.ScanTick;
+				if (targetPlayer.WinState != WinState.Lost)
+					AttackTicks(bot);
+			}
+		}
+
+		void PrepareAttackTick(IBot bot)
+		{
+			// Randomly choose target player to attack
+			var targetPlayers = world.Players.Where(p => p.WinState != WinState.Lost && Info.ValidRelationships.HasRelationship(p.RelationshipWith(player))).ToList();
+			if (targetPlayers.Count == 0)
+				return;
+			targetPlayer = targetPlayers.Random(world.LocalRandom);
+
+			attackActors = world.ActorsHavingTrait<IPositionable>().Where(a =>
+			{
+				if (!unitCannotBeOrderedOrIsBusy(a) && Info.ActorTypesAndAttackOptions.TryGetValue(a.Info.Name, out var option))
+				{
+					if (option.TryGetHealed && TryGetHeal(bot, a))
+						return false;
+
+					if (option.AttackRequires.HasFlag(AttackRequires.CargoLoaded) && a.TraitsImplementing<Cargo>().FirstOrDefault(t => !t.IsTraitDisabled) is Cargo cargo
+						&& cargo.IsEmpty())
+						return false;
+
+					if (option.TryDisguise && a.TraitOrDefault<Disguise>() is Disguise disguise && !disguise.Disguised)
+					{
+						disguisePairs.Add(new TraitPair<Disguise>(a, disguise));
+						disguiseTypes = disguiseTypes.Union(disguise.Info.TargetTypes);
+						if (option.AttackRequires.HasFlag(AttackRequires.Disguised))
+							return false;
+					}
+
+					return true;
+				}
+
+				return false;
+			}).ToList();
+		}
+
+		void DisguiseTicks(IBot bot)
+		{
+			var invalidActors = new HashSet<Actor>();
+			foreach (var p in disguisePairs)
+			{
+				if (isInvalidActor(p.Actor))
+					invalidActors.Add(p.Actor);
+			}
+
+			disguisePairs.RemoveAll(p => invalidActors.Contains(p.Actor));
+
+			if (disguisePairs.Count <= 0)
+				return;
+
+			var targets = world.Actors.Where(a =>
+			{
+				if (isInvalidActor(a) || !ValidDisguiseRelationship.HasRelationship(a.Owner.RelationshipWith(targetPlayer)) || a.Info.HasTraitInfo<DisguiseInfo>())
+					return false;
+
+				var t = a.GetEnabledTargetTypes();
+
+				if (!disguiseTypes.Overlaps(t))
+					return false;
+
+				var hasModifier = false;
+				var visModifiers = a.TraitsImplementing<IVisibilityModifier>();
+				foreach (var v in visModifiers)
+				{
+					if (v.IsVisible(a, player))
+						return true;
+
+					hasModifier = true;
+				}
+
+				return !hasModifier;
+			});
+
+			foreach (var t in targets)
+			{
+				invalidActors.Clear();
+				foreach (var p in disguisePairs)
+				{
+					if (!p.Trait.Info.TargetTypes.Overlaps(t.GetEnabledTargetTypes()))
+						continue;
+
+					bot.QueueOrder(new Order("Disguise", p.Actor, Target.FromActor(t), true));
+					invalidActors.Add(p.Actor);
+					attackActors.Add(p.Actor);
+				}
+
+				disguisePairs.RemoveAll(p => invalidActors.Contains(p.Actor));
+				if (disguisePairs.Count == 0)
+					break;
+			}
+
+			disguisePairs.Clear();
+		}
+
+		void AttackTicks(IBot bot)
+		{
+			var attackdesire = 0;
+
+			var invalidActors = new HashSet<Actor>();
+			foreach (var a in attackActors)
+			{
+				if (unitCannotBeOrderedOrIsBusy(a))
+					invalidActors.Add(a);
+				else
+					attackdesire += Info.ActorTypesAndAttackOptions[a.Info.Name].AttackDesireOfEach;
+			}
+
+			attackActors.RemoveAll(invalidActors.Contains);
+			invalidActors.Clear();
+
+			if (attackActors.Count == 0)
+			{
+				desireIncreased = 0;
+				return;
+			}
+
+			desireIncreased += Info.AttackDesireIncreasedPerScan;
+			if (desireIncreased + attackdesire < 100)
+				return;
+
+			var targets = world.Actors.Where(a =>
+			{
+				if (isInvalidActor(a) || a.Owner != targetPlayer)
+					return false;
+
+				var t = a.GetEnabledTargetTypes();
+
+				if (!Info.ValidTargets.Overlaps(t) || Info.InvalidTargets.Overlaps(t))
+					return false;
+
+				var hasModifier = false;
+				var visModifiers = a.TraitsImplementing<IVisibilityModifier>();
+				foreach (var v in visModifiers)
+				{
+					if (v.IsVisible(a, player))
+						return true;
+
+					hasModifier = true;
+				}
+
+				return !hasModifier;
+			});
+
+			var targetDistance = Info.TargetDistances.Random(world.LocalRandom);
+			switch (targetDistance)
+			{
+				case TargetDistance.Closest:
+					targets = targets.OrderBy(a => (a.CenterPosition - attackActors[0].CenterPosition).HorizontalLengthSquared);
+					break;
+				case TargetDistance.Furthest:
+					targets = targets.OrderByDescending(a => (a.CenterPosition - attackActors[0].CenterPosition).HorizontalLengthSquared);
+					break;
+				case TargetDistance.Random:
+					targets = targets.Shuffle(world.LocalRandom);
+					break;
+			}
+
+			foreach (var t in targets)
+			{
+				foreach (var a in attackActors)
+				{
+					if (!a.Info.HasTraitInfo<IMoveInfo>())
+						continue;
+
+					var mobile = a.TraitOrDefault<Mobile>();
+					if (mobile != null && !pathfinder.PathMightExistForLocomotorBlockedByImmovable(mobile.Locomotor, a.Location, t.Location))
+						continue;
+
+					AssignAttackOrders(bot, a, t);
+					invalidActors.Add(a);
+				}
+
+				attackActors.RemoveAll(invalidActors.Contains);
+				invalidActors.Clear();
+
+				if (attackActors.Count == 0)
+					break;
+			}
+
+			attackActors.Clear();
+		}
+
+		void AssignAttackOrders(IBot bot, Actor attacker, Actor victim)
+		{
+			var option = Info.ActorTypesAndAttackOptions[attacker.Info.Name];
+			if (option.MoveToOrderName != null)
+				bot.QueueOrder(new Order(option.MoveToOrderName, attacker, Target.FromCell(world, victim.Location), true));
+
+			bot.QueueOrder(new Order(option.AttackOrderName, attacker, Target.FromActor(victim), true));
+
+			if (option.MoveBackOrderName != null)
+				bot.QueueOrder(new Order(option.MoveBackOrderName, attacker, Target.FromCell(world, attacker.Location), true));
+		}
+
+		protected static bool TryGetHeal(IBot bot, Actor unit)
+		{
+			var health = unit.TraitOrDefault<IHealth>();
+
+			if (health != null && health.DamageState > DamageState.Undamaged)
+			{
+				Actor repairBuilding = null;
+				var orderId = "Repair";
+				var repairable = unit.TraitOrDefault<Repairable>();
+				if (repairable != null)
+					repairBuilding = repairable.FindRepairBuilding(unit);
+				else
+				{
+					var repairableNear = unit.TraitOrDefault<RepairableNear>();
+					if (repairableNear != null)
+					{
+						orderId = "RepairNear";
+						repairBuilding = repairableNear.FindRepairBuilding(unit);
+					}
+				}
+
+				if (repairBuilding != null)
+				{
+					bot.QueueOrder(new Order(orderId, unit, Target.FromActor(repairBuilding), true));
+					return true;
+				}
+
+				return false;
+			}
+			else
+				return false;
+		}
+	}
+}

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -110,8 +110,8 @@ namespace OpenRA.Mods.Cnc.Traits
 		public bool Disguised => AsPlayer != null;
 		public Player Owner => AsPlayer;
 
+		public readonly DisguiseInfo Info;
 		readonly Actor self;
-		readonly DisguiseInfo info;
 
 		int disguisedToken = Actor.InvalidConditionToken;
 		int disguisedAsToken = Actor.InvalidConditionToken;
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public Disguise(Actor self, DisguiseInfo info)
 		{
 			this.self = self;
-			this.info = info;
+			Info = info;
 
 			AsActor = self.Info;
 		}
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			get
 			{
-				yield return new DisguiseOrderTargeter(info);
+				yield return new DisguiseOrderTargeter(Info);
 			}
 		}
 
@@ -156,7 +156,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		string IOrderVoice.VoicePhraseForOrder(Actor self, Order order)
 		{
-			return order.OrderString == "Disguise" ? info.Voice : null;
+			return order.OrderString == "Disguise" ? Info.Voice : null;
 		}
 
 		public void DisguiseAs(Actor target)
@@ -238,7 +238,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (Disguised != oldDisguiseSetting)
 			{
 				if (Disguised && disguisedToken == Actor.InvalidConditionToken)
-					disguisedToken = self.GrantCondition(info.DisguisedCondition);
+					disguisedToken = self.GrantCondition(Info.DisguisedCondition);
 				else if (!Disguised && disguisedToken != Actor.InvalidConditionToken)
 					disguisedToken = self.RevokeCondition(disguisedToken);
 			}
@@ -248,7 +248,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				if (disguisedAsToken != Actor.InvalidConditionToken)
 					disguisedAsToken = self.RevokeCondition(disguisedAsToken);
 
-				if (info.DisguisedAsConditions.TryGetValue(AsActor.Name, out var disguisedAsCondition))
+				if (Info.DisguisedAsConditions.TryGetValue(AsActor.Name, out var disguisedAsCondition))
 					disguisedAsToken = self.GrantCondition(disguisedAsCondition);
 			}
 		}
@@ -257,43 +257,43 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
-			if (info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Attack))
+			if (Info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Attack))
 				DisguiseAs(null);
 		}
 
 		void INotifyDamage.Damaged(Actor self, AttackInfo e)
 		{
-			if (info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Damaged) && e.Damage.Value > 0)
+			if (Info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Damaged) && e.Damage.Value > 0)
 				DisguiseAs(null);
 		}
 
 		void INotifyLoadCargo.Loading(Actor self)
 		{
-			if (info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Load))
+			if (Info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Load))
 				DisguiseAs(null);
 		}
 
 		void INotifyUnloadCargo.Unloading(Actor self)
 		{
-			if (info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Unload))
+			if (Info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Unload))
 				DisguiseAs(null);
 		}
 
 		void INotifyDemolition.Demolishing(Actor self)
 		{
-			if (info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Demolish))
+			if (Info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Demolish))
 				DisguiseAs(null);
 		}
 
 		void INotifyInfiltration.Infiltrating(Actor self)
 		{
-			if (info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Infiltrate))
+			if (Info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Infiltrate))
 				DisguiseAs(null);
 		}
 
 		void ITick.Tick(Actor self)
 		{
-			if (info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Move) && lastPos != null && lastPos.Value != self.Location)
+			if (Info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Move) && lastPos != null && lastPos.Value != self.Location)
 				DisguiseAs(null);
 
 			lastPos = self.Location;

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -336,7 +336,7 @@ Player:
 		RequiresCondition: enable-rush-ai
 		SquadSize: 20
 		NavalUnitsTypes: ss, msub, dd, ca, lst, pt
-		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2
+		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2, dtrk, qtnk, spy, spy.england
 		ConstructionYardTypes: fact
 		AirUnitsTypes: mig, yak, heli, hind, mh60
 		AircraftTargetType: AirborneActor
@@ -378,6 +378,8 @@ Player:
 			e7: 1
 			dog: 15
 			shok: 15
+			spy: 2
+			spy.england: 2
 			harv: 10
 			apc: 30
 			jeep: 20
@@ -390,16 +392,20 @@ Player:
 			4tnk: 25
 			ttnk: 25
 			stnk: 5
+			dtrk: 1
+			qtnk: 1
 		UnitLimits:
 			dog: 4
 			harv: 8
 			jeep: 4
 			ftrk: 4
+			dtrk: 1
+			qtnk: 1
 	SquadManagerBotModule@normal:
 		RequiresCondition: enable-normal-ai
 		SquadSize: 40
 		NavalUnitsTypes: ss, msub, dd, ca, lst, pt
-		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2
+		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2, dtrk, qtnk, spy, spy.england
 		ConstructionYardTypes: fact
 		NavalProductionTypes: spen, syrd
 		AirUnitsTypes: mig, yak, heli, hind, mh60
@@ -419,6 +425,8 @@ Player:
 			dog: 15
 			shok: 15
 			harv: 15
+			spy: 2
+			spy.england: 2
 			apc: 30
 			jeep: 20
 			arty: 15
@@ -439,16 +447,20 @@ Player:
 			dd: 10
 			ca: 10
 			pt: 10
+			dtrk: 1
+			qtnk: 1
 		UnitLimits:
 			dog: 4
 			harv: 8
 			jeep: 4
 			ftrk: 4
+			dtrk: 1
+			qtnk: 1
 	SquadManagerBotModule@turtle:
 		RequiresCondition: enable-turtle-ai
 		SquadSize: 10
 		NavalUnitsTypes: ss, msub, dd, ca, lst, pt
-		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2, mnly
+		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2, mnly, dtrk, qtnk, spy, spy.england
 		ConstructionYardTypes: fact
 		NavalProductionTypes: spen, syrd
 		AirUnitsTypes: mig, yak, heli, hind, mh60
@@ -469,6 +481,8 @@ Player:
 			e7: 1
 			dog: 15
 			shok: 15
+			spy: 2
+			spy.england: 2
 			harv: 15
 			apc: 30
 			jeep: 20
@@ -491,12 +505,16 @@ Player:
 			ca: 10
 			pt: 10
 			mnly: 2
+			dtrk: 1
+			qtnk: 1
 		UnitLimits:
 			dog: 3
 			harv: 8
 			jeep: 2
 			ftrk: 4
 			mnly: 2
+			dtrk: 1
+			qtnk: 1
 	MinelayerBotModule@turtle:
 		RequiresCondition: enable-turtle-ai
 		MinelayingActorTypes: mnly
@@ -507,7 +525,7 @@ Player:
 	SquadManagerBotModule@naval:
 		RequiresCondition: enable-naval-ai
 		SquadSize: 1
-		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2
+		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2, dtrk, qtnk, spy, spy.england
 		NavalUnitsTypes: ss, msub, dd, ca, lst, pt
 		ConstructionYardTypes: fact
 		NavalProductionTypes: spen, syrd
@@ -518,6 +536,8 @@ Player:
 	UnitBuilderBotModule@naval:
 		RequiresCondition: enable-naval-ai
 		UnitsToBuild:
+			spy: 2
+			spy.england: 2
 			harv: 1
 			ftrk: 40
 			arty: 40
@@ -540,3 +560,34 @@ Player:
 			jeep: 1
 		UnitDelays:
 			harv: 10000
+	SendUnitToAttackBotModule@Mad:
+		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
+		ActorTypesAndAttackOptions:
+			dtrk:
+				AttackDesireOfEach: 100
+				MoveToOrderName: AssaultMove
+				MoveBackOrderName: AssaultMove
+			qtnk:
+				AttackDesireOfEach: 100
+				AttackOrderName: DetonateAttack
+				MoveBackOrderName: Detonate
+		ValidTargets: Structure
+		InvalidTargets: WaterActor
+	SendUnitToAttackBotModule@SendSpy:
+		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
+		ActorTypesAndAttackOptions:
+			spy:
+				AttackDesireOfEach: 100
+				TryDisguise: True
+				TryGetHealed: False
+				AttackRequires: Disguised
+				AttackOrderName: Infiltrate
+			spy.england:
+				AttackDesireOfEach: 100
+				TryDisguise: True
+				TryGetHealed: False
+				AttackRequires: Disguised
+				AttackOrderName: Infiltrate
+		ValidTargets: SpyInfiltrate
+		InvalidTargets: WaterActor
+		TargetDistances: Random

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -81,7 +81,7 @@ Player:
 	SquadManagerBotModule@test:
 		RequiresCondition: enable-test-ai
 		SquadSize: 20
-		ExcludeFromSquadsTypes: harv, mcv, dpod, hunter
+		ExcludeFromSquadsTypes: harv, mcv, dpod, hunter, subtank
 		ConstructionYardTypes: gacnst
 		AirUnitsTypes: orca, orcab, scrin, apache, jumpjet
 		ProtectionTypes: gapowr, gapile, gaweap, gahpad, gadept, garadr, gatech, gaplug, gagate_a, gagate_b, gactwr, napowr, naapwr, nahand, naweap, nahpad, naradr, natech, nastlh, natmpl, namisl, nawast, nagate_a, nagate_b, nalasr, naobel, nasam, weed, gacnst, proc, gasilo, napuls, mcv, harv
@@ -121,3 +121,13 @@ Player:
 		ConstructionYardTypes: gacnst
 		McvFactoryTypes: gaweap, naweap
 		MinimumConstructionYardCount: 2
+	SendUnitToAttackBotModule@test:
+		RequiresCondition: enable-test-ai
+		ActorTypesAndAttackOptions:
+			subtank:
+				AttackDesireOfEach: 10
+				MoveToOrderName: Move
+				MoveBackOrderName: Move
+		ValidTargets: Building
+		InvalidTargets: Defense
+		TargetDistances: Furthest, Random


### PR DESCRIPTION
Supersedes #21010, with more complex options and acceptable perf.

There are more:
-- You can set order to move close to target. (Hack: don't have to be Move order)
-- You can set order to move back to base after attack. (Hack: don't have to be Move order)
-- Disguise is more accurate accroding to the exact player the unit target.
-- Allow set to repair the actor first before attack.
-- Distance can be more randomlize in `TargetDistances`, which can approximately immitate something like:
> It should be more like a random with weight, as in there's a higher change to target units farther in the back, but not at the very back

Weight can be the the number of the same distance in the array, such as `{Closest, Random, Random}`.