### PR TITLE
AI load&unload and micro management on unit.

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/ExternalBotOrdersManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/ExternalBotOrdersManager.cs
@@ -1,0 +1,150 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Allows the player to issue the orders from actors with " + nameof(IssueOrderToBot) + ". etc")]
+	public class ExternalBotOrdersManagerInfo : ConditionalTraitInfo
+	{
+		public override object Create(ActorInitializer init) { return new ExternalBotOrdersManager(init.Self, this); }
+	}
+
+	public class ExternalBotOrdersManager : ConditionalTrait<ExternalBotOrdersManagerInfo>, IBotTick
+	{
+		readonly Dictionary<Actor, (Order Order, int Chance)> directEntries = [];
+		readonly Dictionary<Actor, IssueOrderToBotInfo> issueOrderToBotEntries = [];
+		readonly World world;
+		readonly Player player;
+
+		public bool ManagerRunning { get; private set; }
+
+		public ExternalBotOrdersManager(Actor self, ExternalBotOrdersManagerInfo info)
+			: base(info)
+		{
+			world = self.World;
+			player = self.Owner;
+			ManagerRunning = false;
+		}
+
+		// Use for proactive targeting.
+		public bool IsPreferredTarget(Actor self, Actor a,
+			PlayerRelationship validRelationships, BitSet<TargetableType> validTargets, BitSet<TargetableType> invalidTargets)
+		{
+			if (a == self || a == null || a.IsDead || !a.IsInWorld || !validRelationships.HasRelationship(self.Owner.RelationshipWith(a.Owner)))
+				return false;
+
+			var targetTypes = a.GetEnabledTargetTypes();
+			return !targetTypes.IsEmpty && validTargets.Overlaps(targetTypes) && !invalidTargets.Overlaps(targetTypes);
+		}
+
+		public bool IsNotHiddenUnit(Actor self, Actor a)
+		{
+			var hasModifier = false;
+			var visModifiers = a.TraitsImplementing<IVisibilityModifier>();
+			foreach (var v in visModifiers)
+			{
+				if (v.IsVisible(a, self.Owner))
+					return true;
+
+				hasModifier = true;
+			}
+
+			return !hasModifier;
+		}
+
+		public void AddEntry(Actor issuer, Order order, int chance)
+		{
+			directEntries[issuer] = (order, chance);
+		}
+
+		public void AddEntryFromIssueOrderToBot(Actor issuer, IssueOrderToBotInfo info)
+		{
+			issueOrderToBotEntries[issuer] = info;
+		}
+
+		public Order PhraseEntryFromIssueOrderToBot(Actor issuer, IssueOrderToBotInfo info)
+		{
+			if (issuer.IsDead || !issuer.IsInWorld || issuer.Owner != player || world.LocalRandom.Next(100) > info.OrderChance)
+				return null;
+
+			var subject = info.IsIssuerOwner ? issuer.Owner.PlayerActor : issuer;
+			Order order = null;
+
+			if (info.TargetRangeInCell > 0)
+			{
+				var validActors = world.FindActorsInCircle(issuer.CenterPosition, WDist.FromCells(info.TargetRangeInCell))
+					.Where(a => IsPreferredTarget(issuer, a, info.ValidRelationships, info.ValidTargets, info.InvalidTargets) && IsNotHiddenUnit(issuer, a));
+
+				Actor validActor = null;
+
+				switch (info.TargetDistance)
+				{
+					case TargetDistance.Closest:
+						validActor = validActors.ClosestToIgnoringPath(issuer);
+						break;
+					case TargetDistance.Furthest:
+						validActor = validActors.OrderByDescending(a => (a.Location - issuer.Location).LengthSquared).FirstOrDefault();
+						break;
+					case TargetDistance.Random:
+						validActor = validActors.RandomOrDefault(world.LocalRandom);
+						break;
+				}
+
+				if (validActor == null)
+					return null;
+
+				var target = Target.Invalid;
+				if (info.UseTargetLocation)
+					order = new Order(info.OrderName, subject, Target.FromCell(world, validActor.Location), false);
+				else
+					order = new Order(info.OrderName, subject, Target.FromActor(validActor), false);
+			}
+
+			return order ??= new Order(info.OrderName, subject, false);
+		}
+
+		void IBotTick.BotTick(IBot bot)
+		{
+			// "ManagerRunning = true" means IBotTick is running, and the game is
+			// 1. not a replay
+			// 2. not saved game still loading
+			// 3. the game running on the host where AI is enabled
+			ManagerRunning = true;
+
+			foreach (var entry in directEntries)
+			{
+				if (entry.Key.IsDead || !entry.Key.IsInWorld || entry.Key.Owner != player)
+					continue;
+
+				if (world.LocalRandom.Next(100) > entry.Value.Chance)
+					continue;
+
+				bot.QueueOrder(entry.Value.Order);
+			}
+
+			directEntries.Clear();
+
+			foreach (var entry in issueOrderToBotEntries)
+			{
+				var order = PhraseEntryFromIssueOrderToBot(entry.Key, entry.Value);
+				if (order != null)
+					bot.QueueOrder(order);
+			}
+
+			issueOrderToBotEntries.Clear();
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/BotModules/LoadCargoBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/LoadCargoBotModule.cs
@@ -1,0 +1,157 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Flags]
+	public enum LoadRequirement
+	{
+		All = 0,
+		IdleUnit = 1,
+	}
+
+	[Flags]
+	public enum TransportOwner
+	{
+		Self = 0,
+		AlliedBot = 1,
+		Allies = 2
+	}
+
+	[TraitLocation(SystemActors.Player)]
+	[Desc("Manages AI load unit related with " + nameof(Cargo) + " and " + nameof(Passenger) + " traits.")]
+	public class LoadCargoBotModuleInfo : ConditionalTraitInfo
+	{
+		[Desc("Actor types that can be targeted for load, must have " + nameof(Cargo) + ".",
+			"The flag represents if this transport only requires idle unit. Possible values are: All, IdleUnit")]
+		public readonly FrozenDictionary<string, LoadRequirement> TransportTypesAndLoadRequirement = default;
+
+		[Desc("Actor types that used for loading, must have " + nameof(Passenger) + ".")]
+		public readonly FrozenSet<string> PassengerTypes = default;
+
+		[Desc("The type of relationship that can be targeted for load. Possible values are: Self, AlliedBot and Allies",
+			"AlliedBot means AI will load transport for another allied bot player.")]
+		public readonly TransportOwner ValidTransportOwner = TransportOwner.Self;
+
+		[Desc("Scan suitable actors and target in this interval.")]
+		public readonly int ScanTick = 317;
+
+		[Desc("Don't load passengers to this actor if damage state is worse than this.")]
+		public readonly DamageState ValidDamageState = DamageState.Heavy;
+
+		[Desc("Don't load passengers that are further than this distance to this actor.")]
+		public readonly WDist MaxDistance = WDist.FromCells(20);
+
+		public override object Create(ActorInitializer init) { return new LoadCargoBotModule(init.Self, this); }
+	}
+
+	public class LoadCargoBotModule : ConditionalTrait<LoadCargoBotModuleInfo>, IBotTick
+	{
+		readonly World world;
+		readonly Player player;
+		readonly Predicate<Actor> unitCannotBeOrdered;
+		readonly Predicate<Actor> unitCannotBeOrderedOrIsBusy;
+		readonly Predicate<Actor> invalidTransport;
+
+		int minAssignRoleDelayTicks;
+
+		public LoadCargoBotModule(Actor self, LoadCargoBotModuleInfo info)
+			: base(info)
+		{
+			world = self.World;
+			player = self.Owner;
+
+			switch (info.ValidTransportOwner)
+			{
+				case TransportOwner.Self:
+					invalidTransport = a => a == null || a.IsDead || !a.IsInWorld || a.Owner != player;
+					break;
+				case TransportOwner.AlliedBot:
+					invalidTransport = a => a == null || a.IsDead || !a.IsInWorld || !a.Owner.IsBot || a.Owner.RelationshipWith(player) != PlayerRelationship.Ally;
+					break;
+				case TransportOwner.Allies:
+					invalidTransport = a => a == null || a.IsDead || !a.IsInWorld || a.Owner.RelationshipWith(player) != PlayerRelationship.Ally;
+					break;
+			}
+
+			unitCannotBeOrdered = a => a == null || a.IsDead || !a.IsInWorld || a.Owner != player;
+			unitCannotBeOrderedOrIsBusy = a => unitCannotBeOrdered(a) || (!a.IsIdle && a.CurrentActivity is not FlyIdle);
+		}
+
+		protected override void TraitEnabled(Actor self)
+		{
+			// Avoid all AIs reevaluating assignments on the same tick, randomize their initial evaluation delay.
+			minAssignRoleDelayTicks = world.LocalRandom.Next(0, Info.ScanTick);
+		}
+
+		void IBotTick.BotTick(IBot bot)
+		{
+			if (--minAssignRoleDelayTicks <= 0)
+			{
+				minAssignRoleDelayTicks = Info.ScanTick;
+
+				var transporters = world.ActorsWithTrait<Cargo>().Where(at =>
+				{
+					var health = at.Actor.TraitOrDefault<IHealth>()?.DamageState;
+					return Info.TransportTypesAndLoadRequirement.ContainsKey(at.Actor.Info.Name) && !invalidTransport(at.Actor)
+					&& !at.Trait.IsTraitDisabled && at.Trait.HasSpace(1) && (health == null || health < Info.ValidDamageState);
+				}).ToArray();
+
+				if (transporters.Length == 0)
+					return;
+
+				var transporter = transporters.Random(world.LocalRandom);
+				var cargo = transporter.Trait;
+				var transport = transporter.Actor;
+				var spaceTaken = 0;
+
+				Predicate<Actor> invalidPassenger;
+				if (Info.TransportTypesAndLoadRequirement[transport.Info.Name] == LoadRequirement.IdleUnit)
+					invalidPassenger = unitCannotBeOrderedOrIsBusy;
+				else
+					invalidPassenger = unitCannotBeOrdered;
+
+				var passengers = world.ActorsWithTrait<Passenger>().Where(at => Info.PassengerTypes.Contains(at.Actor.Info.Name) && !invalidPassenger(at.Actor)
+					&& cargo.HasSpace(at.Trait.Info.Weight)
+					&& (at.Actor.CenterPosition - transport.CenterPosition).HorizontalLengthSquared <= Info.MaxDistance.LengthSquared)
+					.OrderBy(at => (at.Actor.CenterPosition - transport.CenterPosition).HorizontalLengthSquared);
+
+				var orderedActors = new List<Actor>();
+
+				foreach (var p in passengers)
+				{
+					var mobile = p.Actor.TraitOrDefault<Mobile>();
+					if (mobile == null || !mobile.PathFinder.PathExistsForLocomotor(mobile.Locomotor, p.Actor.Location, transport.Location))
+						continue;
+
+					if (cargo.HasSpace(spaceTaken + p.Trait.Info.Weight))
+					{
+						spaceTaken += p.Trait.Info.Weight;
+						orderedActors.Add(p.Actor);
+					}
+
+					if (!cargo.HasSpace(spaceTaken + 1))
+						break;
+				}
+
+				if (orderedActors.Count > 0)
+					bot.QueueOrder(new Order("EnterTransport", null, Target.FromActor(transport), false, groupedActors: orderedActors.ToArray()));
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits.BotModules.Squads;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -151,7 +152,7 @@ namespace OpenRA.Mods.Common.Traits
 			World = self.World;
 			Player = self.Owner;
 
-			unitCannotBeOrdered = a => a == null || a.Owner != Player || a.IsDead || !a.IsInWorld;
+			unitCannotBeOrdered = a => a == null || a.Owner != Player || a.IsDead || !a.IsInWorld || a.CurrentActivity is Enter;
 			constructionYardBuildings = new ActorIndex.NamesAndTrait<BuildingInfo>(World, info.ConstructionYardTypes);
 		}
 

--- a/OpenRA.Mods.Common/Traits/IssueOrderToBot.cs
+++ b/OpenRA.Mods.Common/Traits/IssueOrderToBot.cs
@@ -1,0 +1,147 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Flags]
+	public enum TargetDistance
+	{
+		Closest = 0,
+		Furthest = 1,
+		Random = 2
+	}
+
+	[Flags]
+	public enum OrderTriggers
+	{
+		None = 0,
+		Attack = 1,
+		Damage = 2,
+		Heal = 4,
+		Periodically = 8,
+		BecomingIdle = 16
+	}
+
+	[Desc("Allow this actor to automatically issue orders to bot player and processed by " + nameof(ExternalBotOrdersManager))]
+	public class IssueOrderToBotInfo : ConditionalTraitInfo
+	{
+		[Desc("Events leading to the actor issue order. Possible values are: None, Attack, Damage, Heal, Periodically, BecomingIdle.")]
+		public readonly OrderTriggers OrderTrigger = OrderTriggers.Attack | OrderTriggers.Damage;
+
+		[FieldLoader.Require]
+		[Desc("Order name to issue.")]
+		public readonly string OrderName = null;
+
+		[Desc("Chance of the order take effect.")]
+		public readonly int OrderChance = 50;
+
+		[Desc("Order's target range. <0 means disable targeting.")]
+		public readonly int TargetRangeInCell = -1;
+
+		[Desc("Should the player be the subject of the order. It is the actor by default.", "Can use this to issue support power order.")]
+		public readonly bool IsIssuerOwner = false;
+
+		[Desc("What player relationships are affected.")]
+		public readonly PlayerRelationship ValidRelationships = PlayerRelationship.Enemy;
+
+		[Desc("What types of targets are affected.")]
+		public readonly BitSet<TargetableType> ValidTargets;
+
+		[Desc("What types of targets are unaffected.", "Overrules ValidTargets.")]
+		public readonly BitSet<TargetableType> InvalidTargets;
+
+		[Desc("Use Target's Location.")]
+		public readonly bool UseTargetLocation = true;
+
+		[Desc("Delay between two successful issued orders.")]
+		public readonly int OrderInterval = 2500;
+
+		[Desc("Should attack the furthest or closest target. Possible values are Closest, Furthest, Random",
+			"Multiple values mean the distance randomizes between them")]
+		public readonly TargetDistance TargetDistance = TargetDistance.Closest;
+
+		public override object Create(ActorInitializer init) { return new IssueOrderToBot(this); }
+	}
+
+	public class IssueOrderToBot : ConditionalTrait<IssueOrderToBotInfo>, INotifyAttack, ITick, INotifyDamage,
+		INotifyCreated, INotifyOwnerChanged, INotifyBecomingIdle
+	{
+		int orderTicks;
+		ExternalBotOrdersManager orderManager;
+
+		public IssueOrderToBot(IssueOrderToBotInfo info)
+			: base(info) { }
+
+		protected override void Created(Actor self)
+		{
+			orderManager = self.Owner.PlayerActor.Trait<ExternalBotOrdersManager>();
+		}
+
+		void TryIssueOrder(Actor self)
+		{
+			if (!orderManager.ManagerRunning || orderTicks > 0 || orderManager.IsTraitDisabled)
+				return;
+
+			orderManager.AddEntryFromIssueOrderToBot(self, Info);
+			orderTicks = Info.OrderInterval;
+		}
+
+		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
+		{
+			if (!orderManager.ManagerRunning || IsTraitDisabled || orderManager.IsTraitDisabled)
+				return;
+
+			if (Info.OrderTrigger.HasFlag(OrderTriggers.Attack))
+				TryIssueOrder(self);
+		}
+
+		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel) { }
+
+		void ITick.Tick(Actor self)
+		{
+			if (!orderManager.ManagerRunning || IsTraitDisabled || orderManager.IsTraitDisabled)
+				return;
+
+			if (--orderTicks < 0 && Info.OrderTrigger.HasFlag(OrderTriggers.Periodically))
+				TryIssueOrder(self);
+		}
+
+		void INotifyDamage.Damaged(Actor self, AttackInfo e)
+		{
+			if (!orderManager.ManagerRunning || IsTraitDisabled || orderManager.IsTraitDisabled)
+				return;
+
+			if (e.Damage.Value > 0 && Info.OrderTrigger.HasFlag(OrderTriggers.Damage))
+				TryIssueOrder(self);
+
+			if (e.Damage.Value < 0 && Info.OrderTrigger.HasFlag(OrderTriggers.Heal))
+				TryIssueOrder(self);
+		}
+
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		{
+			orderManager = newOwner.PlayerActor.Trait<ExternalBotOrdersManager>();
+		}
+
+		void INotifyBecomingIdle.OnBecomingIdle(Actor self)
+		{
+			if (!orderManager.ManagerRunning || IsTraitDisabled || orderManager.IsTraitDisabled)
+				return;
+
+			if (Info.OrderTrigger.HasFlag(OrderTriggers.BecomingIdle))
+				TryIssueOrder(self);
+		}
+	}
+}

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -17,6 +17,8 @@ Player:
 	GrantConditionOnBotOwner@hal9001:
 		Condition: enable-hal9001-ai
 		Bots: hal9001
+	ExternalBotOrdersManager:
+		RequiresCondition: enable-cabal-ai || enable-watson-ai || enable-hal9001-ai
 	SupportPowerBotModule:
 		RequiresCondition: enable-cabal-ai || enable-watson-ai || enable-hal9001-ai
 		Decisions:
@@ -279,6 +281,7 @@ Player:
 			e3: 40
 			e4: 15
 			e5: 15
+			rmbo: 1
 			harv: 10
 			bggy: 5
 			bike: 40
@@ -297,6 +300,8 @@ Player:
 		UnitLimits:
 			harv: 8
 			mlrs: 3
+		UnitDelays:
+			bike: 2000
 	McvExpansionManagerBotModule@cabal:
 		RequiresCondition: enable-cabal-ai
 		McvTypes: mcv
@@ -327,6 +332,7 @@ Player:
 			e3: 40
 			e4: 30
 			e5: 30
+			rmbo: 1
 			harv: 10
 			bggy: 10
 			ftnk: 10
@@ -344,6 +350,8 @@ Player:
 		UnitLimits:
 			harv: 8
 			mlrs: 2
+		UnitDelays:
+			bike: 2000
 	SquadManagerBotModule@hal9001:
 		RequiresCondition: enable-hal9001-ai
 		SquadSize: 15
@@ -363,6 +371,7 @@ Player:
 			e3: 40
 			e4: 50
 			e5: 50
+			rmbo: 1
 			harv: 16
 			bggy: 10
 			bike: 10
@@ -381,3 +390,5 @@ Player:
 		UnitLimits:
 			harv: 8
 			mlrs: 3
+		UnitDelays:
+			bike: 2000

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -304,6 +304,26 @@ RMBO:
 	AnnounceOnKill:
 	Voiced:
 		VoiceSet: CommandoVoice
+	IssueOrderToBot@AI: ## retreat to safty
+		OrderName: AttackMove
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 70
+		TargetRangeInCell: 9
+		ValidTargets: Ground
+		ValidRelationships: Ally
+		TargetDistance: Furthest
+	IssueOrderToBot@AI2: ## c4
+		OrderName: C4
+		OrderTrigger: Periodically
+		OrderChance: 100
+		OrderInterval: 100
+		UseTargetLocation: False
+		TargetRangeInCell: 4
+		ValidTargets: C4
+		InvalidTargets: Water
+		ValidRelationships: Enemy
+		TargetDistance: Closest
 
 PVICE:
 	Inherits: ^Viceroid

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -354,6 +354,15 @@ BGGY:
 		Actor: BGGY.Husk
 		OwnerType: InternalName
 		EffectiveOwnerFromOwner: true
+	IssueOrderToBot@AI: ## hit and run
+		OrderName: Move
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 80
+		TargetRangeInCell: 9
+		ValidTargets: Ground
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 BIKE:
 	Inherits: ^Vehicle
@@ -402,6 +411,15 @@ BIKE:
 		Actor: BIKE.Husk
 		OwnerType: InternalName
 		EffectiveOwnerFromOwner: true
+	IssueOrderToBot@AI: ## hit and run
+		OrderName: Move
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 80
+		TargetRangeInCell: 9
+		ValidTargets: Ground
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 JEEP:
 	Inherits: ^Vehicle
@@ -453,6 +471,15 @@ JEEP:
 		Actor: JEEP.Husk
 		OwnerType: InternalName
 		EffectiveOwnerFromOwner: true
+	IssueOrderToBot@AI: ## hit and run
+		OrderName: Move
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 80
+		TargetRangeInCell: 9
+		ValidTargets: Ground
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 LTNK:
 	Inherits: ^Tank
@@ -816,7 +843,6 @@ STNK:
 		Voice: Attack
 	AutoTarget:
 		InitialStance: HoldFire
-		InitialStanceAI: ReturnFire
 	FireWarheadsOnDeath:
 		Weapon: UnitExplodeStealthTank
 		EmptyWeapon: UnitExplodeStealthTank
@@ -825,6 +851,15 @@ STNK:
 		OwnerType: InternalName
 		EffectiveOwnerFromOwner: true
 	-MustBeDestroyed:
+	IssueOrderToBot@AI: ## hit and run
+		OrderName: Move
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 80
+		TargetRangeInCell: 9
+		ValidTargets: Ground
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 MHQ:
 	Inherits: ^Vehicle

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -23,6 +23,18 @@ Player:
 	GrantConditionOnBotOwner@naval:
 		Condition: enable-naval-ai
 		Bots: naval
+	ExternalBotOrdersManager:
+		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
+	LoadCargoBotModule:
+		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
+		TransportTypesAndLoadRequirement:
+			jeep: IdleUnit
+			apc: IdleUnit
+			stnk: IdleUnit
+			hbox: All
+			pbox: All
+		ValidTransportOwner: AlliedBot
+		PassengerTypes: e1, e1r1, e2, e3, e3r1, e4, e7, shok
 	ResourceMapBotModule:
 		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai
 		ResourceCreatorTypes: mine, gmine

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -388,6 +388,8 @@ Player:
 			e3: 30
 			e4: 15
 			e7: 1
+			medi: 1
+			mech: 1
 			dog: 15
 			shok: 15
 			harv: 10
@@ -403,11 +405,13 @@ Player:
 			ttnk: 25
 			stnk: 5
 			ctnk: 3
+			mrj: 1
 		UnitLimits:
 			dog: 4
 			harv: 8
 			jeep: 4
 			ftrk: 4
+			mrj: 1
 	SquadManagerBotModule@normal:
 		RequiresCondition: enable-normal-ai
 		SquadSize: 40
@@ -429,6 +433,8 @@ Player:
 			e3: 30
 			e4: 15
 			e7: 1
+			medi: 2
+			mech: 2
 			dog: 15
 			shok: 15
 			harv: 15
@@ -453,11 +459,15 @@ Player:
 			ca: 10
 			pt: 10
 			ctnk: 3
+			mrj: 1
 		UnitLimits:
 			dog: 4
+			medi: 3
+			mech: 3
 			harv: 8
 			jeep: 4
 			ftrk: 4
+			mrj: 1
 	SquadManagerBotModule@turtle:
 		RequiresCondition: enable-turtle-ai
 		SquadSize: 10
@@ -481,6 +491,8 @@ Player:
 			e3: 30
 			e4: 15
 			e7: 1
+			medi: 3
+			mech: 3
 			dog: 15
 			shok: 15
 			harv: 15
@@ -506,12 +518,16 @@ Player:
 			pt: 10
 			mnly: 2
 			ctnk: 3
+			mrj: 1
 		UnitLimits:
 			dog: 3
+			medi: 3
+			mech: 3
 			harv: 8
 			jeep: 2
 			ftrk: 4
 			mnly: 2
+			mrj: 2
 	MinelayerBotModule@turtle:
 		RequiresCondition: enable-turtle-ai
 		MinelayingActorTypes: mnly
@@ -548,11 +564,13 @@ Player:
 			ca: 20
 			pt: 10
 			ctnk: 3
+			mrj: 1
 		UnitLimits:
 			harv: 4
 			ftrk: 3
 			arty: 1
 			v2rl: 1
 			jeep: 1
+			mrj: 1
 		UnitDelays:
 			harv: 10000

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -402,6 +402,7 @@ Player:
 			4tnk: 25
 			ttnk: 25
 			stnk: 5
+			ctnk: 3
 		UnitLimits:
 			dog: 4
 			harv: 8
@@ -451,6 +452,7 @@ Player:
 			dd: 10
 			ca: 10
 			pt: 10
+			ctnk: 3
 		UnitLimits:
 			dog: 4
 			harv: 8
@@ -503,6 +505,7 @@ Player:
 			ca: 10
 			pt: 10
 			mnly: 2
+			ctnk: 3
 		UnitLimits:
 			dog: 3
 			harv: 8
@@ -544,6 +547,7 @@ Player:
 			dd: 30
 			ca: 20
 			pt: 10
+			ctnk: 3
 		UnitLimits:
 			harv: 4
 			ftrk: 3

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -456,6 +456,26 @@ E7:
 	WithProductionIconOverlay:
 		Types: Veterancy
 		Prerequisites: barracks.upgraded
+	IssueOrderToBot@AI: ## retreat to safty
+		OrderName: AttackMove
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 70
+		TargetRangeInCell: 9
+		ValidTargets: GroundActor
+		ValidRelationships: Ally
+		TargetDistance: Furthest
+	IssueOrderToBot@AI2: ## c4
+		OrderName: C4
+		OrderTrigger: Periodically
+		OrderChance: 100
+		OrderInterval: 100
+		UseTargetLocation: False
+		TargetRangeInCell: 4
+		ValidTargets: C4
+		InvalidTargets: WaterActor
+		ValidRelationships: Enemy
+		TargetDistance: Closest
 
 MEDI:
 	Inherits: ^Soldier
@@ -499,6 +519,15 @@ MEDI:
 	AutoTarget:
 	AutoTargetPriority@DEFAULT:
 		ValidTargets: Infantry
+	IssueOrderToBot@AI: ## retreat to safty
+		OrderName: AttackMove
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 70
+		TargetRangeInCell: 9
+		ValidTargets: GroundActor, AirActor, WaterActor
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 MECH:
 	Inherits: ^Soldier
@@ -555,6 +584,26 @@ MECH:
 	AutoTarget:
 	AutoTargetPriority@DEFAULT:
 		ValidTargets: Vehicle, Ship
+	IssueOrderToBot@AI: ## retreat to safty
+		OrderName: AttackMove
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 70
+		TargetRangeInCell: 9
+		ValidTargets: GroundActor
+		ValidRelationships: Ally
+		TargetDistance: Furthest
+	IssueOrderToBot@AI2: ## capture husk
+		OrderName: CaptureActor
+		OrderTrigger: Periodically
+		OrderChance: 100
+		OrderInterval: 100
+		UseTargetLocation: False
+		TargetRangeInCell: 7
+		ValidTargets: Husk
+		InvalidTargets: AirActor, WaterActor
+		ValidRelationships: Ally, Enemy, Neutral
+		TargetDistance: Closest
 
 EINSTEIN:
 	Inherits: ^CivInfantry

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -749,6 +749,7 @@ PBOX:
 		Types: Infantry
 		MaxWeight: 1
 		InitialUnits: e1
+		LoadedCondition: loaded
 		PassengerConditions:
 			e3: RocketSoldier
 	WithRangeCircle@ROCKETSOLDIER:
@@ -768,6 +769,15 @@ PBOX:
 		Amount: -20
 	DetectCloaked:
 		Range: 6c0
+	GrantConditionOnDamageState@CriticalDamaged:
+		Condition: CriticalDamaged
+		ValidDamageStates: Critical
+	IssueOrderToBot:
+		RequiresCondition: loaded && CriticalDamaged
+		OrderName: Unload
+		OrderChance: 100
+		OrderTrigger: Periodically
+		OrderInterval: 20
 
 HBOX:
 	Inherits: ^Defense
@@ -816,6 +826,7 @@ HBOX:
 		Types: Infantry
 		MaxWeight: 1
 		InitialUnits: e1
+		LoadedCondition: loaded
 	-SpawnActorsOnSell:
 	DetectCloaked:
 		Range: 6c0
@@ -829,6 +840,12 @@ HBOX:
 		PortCones: 88, 88, 88, 88, 88, 88
 	Power:
 		Amount: -20
+	IssueOrderToBot:
+		RequiresCondition: loaded && cloak-force-disabled
+		OrderName: Unload
+		OrderChance: 100
+		OrderTrigger: Periodically
+		OrderInterval: 20
 	-MustBeDestroyed:
 
 GUN:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -842,6 +842,15 @@ CTNK:
 	WithProductionIconOverlay:
 		Types: Veterancy
 		Prerequisites: vehicles.upgraded
+	IssueOrderToBot@AI:
+		OrderName: PortableChronoTeleport
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 265
+		TargetRangeInCell: 12
+		ValidTargets: GroundActor, AirActor, WaterActor
+		ValidRelationships: Ally, Neutral
+		TargetDistance: Furthest
 
 QTNK:
 	Inherits: ^TrackedVehicle

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -663,6 +663,15 @@ MRJ:
 		Range: 5c0
 		DeflectionRelationships: Neutral, Enemy
 	RenderJammerCircle:
+	IssueOrderToBot@AI: ## retreat To safety
+		OrderName: Move
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 80
+		TargetRangeInCell: 7
+		ValidTargets: GroundActor, AirActor, WaterActor
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 TTNK:
 	Inherits: ^TrackedVehicle
@@ -706,6 +715,15 @@ TTNK:
 	WithProductionIconOverlay:
 		Types: Veterancy
 		Prerequisites: vehicles.upgraded
+	IssueOrderToBot@AI: ## hit and run
+		OrderName: Move
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 80
+		TargetRangeInCell: 7
+		ValidTargets: GroundActor, AirActor, WaterActor
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 FTRK:
 	Inherits: ^Vehicle
@@ -758,6 +776,15 @@ FTRK:
 	WithProductionIconOverlay:
 		Types: Veterancy
 		Prerequisites: vehicles.upgraded
+	IssueOrderToBot@AI: ## hit and run
+		OrderName: Move
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 80
+		TargetRangeInCell: 9
+		ValidTargets: GroundActor, AirActor, WaterActor
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 DTRK:
 	Inherits: ^Vehicle
@@ -924,7 +951,6 @@ STNK:
 		Range: 4c0
 	AutoTarget:
 		InitialStance: HoldFire
-		InitialStanceAI: ReturnFire
 	Armament:
 		Weapon: APTusk.stnk
 		LocalOffset: 192,0,176
@@ -955,6 +981,16 @@ STNK:
 		Prerequisites: vehicles.upgraded
 	IssueOrderToBot@AI:
 		RequiresCondition: loaded
+		OrderTrigger: Attack
 		OrderName: Unload
 		OrderChance: 100
 		OrderInterval: 45
+	IssueOrderToBot@AI2: ## hit and run
+		OrderName: Move
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 80
+		TargetRangeInCell: 9
+		ValidTargets: GroundActor, AirActor, WaterActor
+		ValidRelationships: Ally
+		TargetDistance: Furthest

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -451,11 +451,17 @@ JEEP:
 		Types: Infantry
 		MaxWeight: 1
 		LoadingCondition: notmobile
+		LoadedCondition: loaded
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 	WithProductionIconOverlay:
 		Types: Veterancy
 		Prerequisites: vehicles.upgraded
+	IssueOrderToBot@AI:
+		RequiresCondition: loaded
+		OrderName: Unload
+		OrderChance: 100
+		OrderInterval: 45
 
 APC:
 	Inherits: ^TrackedVehicle
@@ -497,11 +503,17 @@ APC:
 		Types: Infantry
 		MaxWeight: 5
 		LoadingCondition: notmobile
+		LoadedCondition: loaded
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 	WithProductionIconOverlay:
 		Types: Veterancy
 		Prerequisites: vehicles.upgraded
+	IssueOrderToBot:
+		RequiresCondition: loaded
+		OrderName: Unload
+		OrderChance: 100
+		OrderInterval: 45
 
 MNLY:
 	Inherits: ^TrackedVehicle
@@ -915,6 +927,7 @@ STNK:
 		Types: Infantry
 		MaxWeight: 5
 		LoadingCondition: notmobile
+		LoadedCondition: loaded
 	Cloak:
 		InitialDelay: 125
 		CloakDelay: 175
@@ -931,3 +944,8 @@ STNK:
 	WithProductionIconOverlay:
 		Types: Veterancy
 		Prerequisites: vehicles.upgraded
+	IssueOrderToBot@AI:
+		RequiresCondition: loaded
+		OrderName: Unload
+		OrderChance: 100
+		OrderInterval: 45

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -5,6 +5,8 @@ Player:
 	GrantConditionOnBotOwner@test:
 		Condition: enable-test-ai
 		Bots: test
+	ExternalBotOrdersManager:
+		RequiresCondition: enable-test-ai
 	HarvesterBotModule:
 		RequiresCondition: enable-test-ai
 		HarvesterTypes: harv

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -83,7 +83,7 @@ Player:
 	SquadManagerBotModule@test:
 		RequiresCondition: enable-test-ai
 		SquadSize: 20
-		ExcludeFromSquadsTypes: harv, mcv, dpod, hunter
+		ExcludeFromSquadsTypes: harv, mcv, dpod, hunter, lpst
 		ConstructionYardTypes: gacnst
 		AirUnitsTypes: orca, orcab, scrin, apache, jumpjet
 		ProtectionTypes: gapowr, gapile, gaweap, gahpad, gadept, garadr, gatech, gaplug, gagate_a, gagate_b, gactwr, napowr, naapwr, nahand, naweap, nahpad, naradr, natech, nastlh, natmpl, namisl, nawast, nagate_a, nagate_b, nalasr, naobel, nasam, weed, gacnst, proc, gasilo, napuls, mcv, harv
@@ -109,6 +109,9 @@ Player:
 			subtank: 10
 			sonic: 10
 			stnk: 8
+			art2: 5
+			jugg: 5
+			lpst: 5
 			orca: 5
 			orcab: 4
 			apache: 5
@@ -117,6 +120,7 @@ Player:
 			harv: 12
 			medic: 3
 			repair: 3
+			lpst: 1
 	McvExpansionManagerBotModule@test:
 		RequiresCondition: enable-test-ai
 		McvTypes: mcv

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -13,7 +13,7 @@ Player:
 		RefineryTypes: proc
 	PowerDownBotModule:
 		RequiresCondition: enable-test-ai
-		PowerDownTypes: garadr, naradr, gavulc,garock,gacsam,gactwr,naobel,nalasr,nasam
+		PowerDownTypes: garadr, naradr, gavulc,garock,gacsam,gactwr,naobel,nalasr,nasam,napuls
 	ResourceMapBotModule:
 		RequiresCondition: enable-test-ai
 		ResourceCreatorTypes: tibtre01, tibtre02, tibtre03, bigblue, bigblue3
@@ -28,12 +28,14 @@ Player:
 		ExcessPowerIncrement: 30
 		ExcessPowerIncreaseThreshold: 4
 		ConstructionYardTypes: gacnst
+		BuildingQueues: Building
+		DefenseQueues: Support
 		RefineryTypes: proc
 		PowerTypes: gapowr, gapowrup, napowr, naapwr
 		ProductionTypes: gapile, nahand, gaweap, naweap, gahpad, nahpad
 		TechTypes: garadr, naradr, gahpad, nahpad, gatech, natech
 		SiloTypes: gasilo
-		DefenseTypes: gavulc,garock,gacsam,gactwr,naobel,nalasr,nasam
+		DefenseTypes: gavulc,garock,gacsam,gactwr,naobel,nalasr,nasam,napuls
 		SellRefineryNoResourceDistance: 18
 		BuildingLimits:
 			proc: 4
@@ -58,6 +60,7 @@ Player:
 			naobel: 2
 			nalasr: 8
 			nasam: 4
+			napuls: 1
 		BuildingFractions:
 			proc: 30
 			gapile: 1
@@ -78,6 +81,7 @@ Player:
 			gactwr: 18
 			nasam: 6
 			naobel: 3
+			napuls: 1
 	BuildingRepairBotModule:
 		RequiresCondition: enable-test-ai
 	SquadManagerBotModule@test:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -85,6 +85,11 @@
 		BlinkPatterns:
 			hospitalheal: On, Off
 
+^BotOwner:
+	GrantConditionOnBotOwner@BotOwner:
+		Condition: bot-owner
+		Bots: test
+
 ^CrateStatModifiers:
 	FirepowerMultiplier@CRATES:
 		RequiresCondition: crate-firepower

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -318,6 +318,7 @@ JUGG:
 	Inherits@SPRITES: ^SpriteActor
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	Inherits@BOT: ^BotOwner
 	Valued:
 		Cost: 950
 	Tooltip:
@@ -342,7 +343,7 @@ JUGG:
 		TurnSpeed: 20
 		AlwaysTurnInPlace: true
 		ImmovableCondition: !undeployed
-		RequireForceMoveCondition: !undeployed
+		RequireForceMoveCondition: !undeployed && !bot-owner
 		TerrainOrientationAdjustmentMargin: -1
 	RevealsShroud:
 		RequiresCondition: !inside-tunnel
@@ -421,6 +422,15 @@ JUGG:
 		ArmamentNames: deployed
 	Selectable:
 		DecorationBounds: 1448, 2413, 0, -482
+	IssueOrderToBot@AI:
+		RequiresCondition: undeployed
+		OrderName: GrantConditionOnDeploy
+		OrderTrigger: Periodically
+		OrderChance: 100
+		OrderInterval: 45
+		TargetRangeInCell: 17
+		ValidTargets: Ground, Water
+		ValidRelationships: Enemy
 
 MOBILEMP:
 	Inherits: ^Tank

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -86,6 +86,7 @@ TTNK:
 	Inherits@VOXELS: ^VoxelActor
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	Inherits@BOT: ^BotOwner
 	Valued:
 		Cost: 800
 	Tooltip:
@@ -105,7 +106,7 @@ TTNK:
 		TurnSpeed: 20
 		Speed: 85
 		ImmovableCondition: !undeployed
-		RequireForceMoveCondition: !undeployed
+		RequireForceMoveCondition: !undeployed && !bot-owner
 	Health:
 		HP: 35000
 	Armor:
@@ -203,6 +204,12 @@ TTNK:
 		ArmamentNames: primary, deployed
 	RenderVoxels:
 		Scale: 11.5
+	IssueOrderToBot@AI:
+		RequiresCondition: undeployed
+		OrderName: GrantConditionOnDeploy
+		OrderChance: 100
+		OrderTrigger: Attack
+		OrderInterval: 35
 
 ART2:
 	Inherits: ^Tank

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -216,6 +216,7 @@ ART2:
 	Inherits@VOXELS: ^VoxelActor
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	Inherits@BOT: ^BotOwner
 	Valued:
 		Cost: 975
 	Tooltip:
@@ -239,7 +240,7 @@ ART2:
 		Speed: 71
 		TurnSpeed: 8
 		ImmovableCondition: !undeployed
-		RequireForceMoveCondition: !undeployed
+		RequireForceMoveCondition: !undeployed && !bot-owner
 	RevealsShroud:
 		RequiresCondition: !inside-tunnel
 		Range: 9c0
@@ -306,6 +307,15 @@ ART2:
 	WithMuzzleOverlay:
 	RevealOnFire:
 		ArmamentNames: deployed
+	IssueOrderToBot@AI:
+		RequiresCondition: undeployed
+		OrderName: GrantConditionOnDeploy
+		OrderTrigger: Periodically
+		OrderChance: 100
+		OrderInterval: 45
+		TargetRangeInCell: 17
+		ValidTargets: Ground, Water
+		ValidRelationships: Enemy
 
 REPAIR:
 	Inherits: ^Tank

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -50,9 +50,22 @@ NAPULS:
 		Cursor: emp
 		Icon: emp
 		ChargeInterval: 3375
+		OrderName: EmpCannonAttack
 		Name: actor-napuls.attackorderpower-name
 		Description: actor-napuls.attackorderpower-description
 		EndChargeSpeechNotification: EmPulseCannonReady
 		SelectTargetSpeechNotification: SelectTarget
 		EndChargeTextNotification: notification-emp-cannon-ready
 		SelectTargetTextNotification: notification-select-target
+	IssueOrderToBot@AI:
+		RequiresCondition: !empdisable && !disabled
+		OrderName: EmpCannonAttack
+		OrderTrigger: Periodically
+		OrderChance: 100
+		OrderInterval: 675
+		IsIssuerOwner: True
+		TargetRangeInCell: 38
+		ValidTargets: Vehicle
+		InvalidTargets: Air
+		ValidRelationships: Enemy
+		TargetDistance: Random

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -118,6 +118,7 @@ LPST:
 	Inherits: ^Tank
 	Inherits@VOXELS: ^VoxelActor
 	Inherits@selection: ^SelectableSupportUnit
+	Inherits@BOT: ^BotOwner
 	-AppearsOnRadar:
 	Buildable:
 		Queue: Vehicle
@@ -140,7 +141,7 @@ LPST:
 		Speed: 85
 		TurnSpeed: 20
 		ImmovableCondition: !undeployed
-		RequireForceMoveCondition: !undeployed
+		RequireForceMoveCondition: !undeployed && !bot-owner
 	RevealsShroud:
 		RequiresCondition: !inside-tunnel && undeployed
 		Range: 10c0
@@ -196,3 +197,9 @@ LPST:
 		TrailCount: 3
 	RenderVoxels:
 		Scale: 11.5
+	IssueOrderToBot@AI:
+		OrderTrigger: BecomingIdle, Periodically
+		OrderName: GrantConditionOnDeploy
+		OrderChance: 100
+		OrderInterval: 40
+		RequiresCondition: undeployed


### PR DESCRIPTION
## About IssueOrderToBot and ExternalBotOrdersManager:

The idea is: 

1. When actors with `IssueOrderToBot` have certain condition, it can use `IssueOrderToBot` to **request bot player to give it an order**. (it is not the actors issue the orders, it is always the AI issue the orders)
2. `ExternalBotOrdersManager` recieve the request and give it an order by using `bot.QueueOrder`.

It is a cheap way (compared to search the actors of different traits in world and give orders) to perform control in detail and very flexible.

![AI_chrono](https://github.com/user-attachments/assets/2c7e8b1d-51ff-4fe3-a4e1-e4376639d4ed)

In doing so, on the macro scale we use `SquadManagerBotModule` to form squad and attack, on the micro scale units with `IssueOrderToBot` send order request to `ExternalBotOrdersManager` in order to be micro-managed. 