### PR TITLE
Bumped Eluant NuGet version

### DIFF
--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Linguini.Bundle" Version="0.5.0" />
-    <PackageReference Include="OpenRA-Eluant" Version="1.0.21" />
+    <PackageReference Include="OpenRA-Eluant" Version="1.0.22" />
     <PackageReference Include="Mono.NAT" Version="3.0.4" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="System.Threading.Channels" Version="6.0.0" />


### PR DESCRIPTION
The new version fixes the windows 32-bit build not working.

Fixes #21033.