### PR TITLE
Bytes -> Hex conversion update

### DIFF
--- a/OpenRA.Game/Primitives/Color.cs
+++ b/OpenRA.Game/Primitives/Color.cs
@@ -224,9 +224,9 @@ namespace OpenRA.Primitives
 		public override string ToString()
 		{
 			if (A == 255)
-				return R.ToStringInvariant("X2") + G.ToStringInvariant("X2") + B.ToStringInvariant("X2");
+				return CryptoUtil.ToHex(stackalloc byte[3] { R, G, B });
 
-			return R.ToStringInvariant("X2") + G.ToStringInvariant("X2") + B.ToStringInvariant("X2") + A.ToStringInvariant("X2");
+			return CryptoUtil.ToHex(stackalloc byte[4] { R, G, B, A });
 		}
 
 		public static Color Transparent => FromArgb(0x00FFFFFF);

--- a/OpenRA.Test/OpenRA.Game/Sha1Tests.cs
+++ b/OpenRA.Test/OpenRA.Game/Sha1Tests.cs
@@ -1,0 +1,35 @@
+﻿using NUnit.Framework;
+using OpenRA.Primitives;
+
+namespace OpenRA.Test
+{
+	[TestFixture]
+	sealed class Sha1Tests
+	{
+		/// <summary>
+		/// https://en.wikipedia.org/wiki/SHA-1#Examples_and_pseudocode.
+		/// </summary>
+		/// <param name="input">The input string.</param>
+		/// <param name="expected">The expected hex string of the SHA1.</param>
+		[TestCase("The quick brown fox jumps over the lazy dog", "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12")]
+		[TestCase("The quick brown fox jumps over the lazy cog", "de9f2c7fd25e1b3afad3e85a0bd17d9b100db4b3")]
+		[TestCase("", "da39a3ee5e6b4b0d3255bfef95601890afd80709")]
+		public void Sha1HexConvert(string input, string expected)
+		{
+			var actual = CryptoUtil.SHA1Hash(input);
+
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestCase(0xFF0000FF, "0000FF")]
+		[TestCase(0xFF00FFFF, "00FFFF")]
+		[TestCase(0xFFFF00FF, "FF00FF")]
+		[TestCase(0xAAFF00FF, "FF00FFAA")]
+		public void ColorsToHex(uint value, string expected)
+		{
+			var color = Color.FromArgb(value);
+			var actual = color.ToString();
+			Assert.AreEqual(expected, actual);
+		}
+	}
+}


### PR DESCRIPTION
# Bytes -> Hex conversion update

Hi!

I've updated the functionality which converts a byte array to a lower case hex string.

The performance is improved while still being compatible with the previous version.
For good measure I've added a few unit tests for SHA-1 hashing which uses the wiki examples.

## Changes

- Added new byte-to-hex compute functionality
- Added sha-1 unit tests which computes hashes from wiki hash examples

## Affects

Anything that computes a SHA1 hash through CryptoUtil.

## Benchmarks

To get an idea of the scaling, I cooked up a little benchmark to test the changes when hashing with SHA-1.

Runs with data sizes of 32 and 128 data sizes.

~~~text
BenchmarkDotNet v0.13.8, Windows 11 (10.0.22621.2283/22H2/2022Update/SunValley2)
Intel Core i7-8086K CPU 4.00GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK 7.0.401
  [Host]     : .NET 6.0.22 (6.0.2223.42425), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.22 (6.0.2223.42425), X64 RyuJIT AVX2

| Method       | source    | Mean       | Error    | StdDev   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|------------- |---------- |-----------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
| New          | Byte[32]  |   572.1 ns |  3.98 ns |  3.53 ns |  1.00 |    0.00 | 0.0515 |     328 B |        1.00 |
| Mono         | Byte[32]  |   584.4 ns |  6.29 ns |  5.89 ns |  1.02 |    0.01 | 0.0687 |     432 B |        1.32 |
| Convert      | Byte[32]  |   584.6 ns |  7.32 ns |  6.49 ns |  1.02 |    0.01 | 0.0687 |     432 B |        1.32 |
| New          | Byte[128] |   763.4 ns |  6.32 ns |  5.60 ns |  1.33 |    0.01 | 0.0515 |     328 B |        1.00 |
| Convert      | Byte[128] |   779.6 ns |  6.37 ns |  5.65 ns |  1.36 |    0.01 | 0.0687 |     432 B |        1.32 |
| Mono         | Byte[128] |   788.1 ns |  7.79 ns |  7.29 ns |  1.38 |    0.01 | 0.0687 |     432 B |        1.32 |
| BitConverter | Byte[32]  |   952.5 ns |  6.68 ns |  5.92 ns |  1.66 |    0.02 | 0.0916 |     576 B |        1.76 |
| BitConverter | Byte[128] | 1,154.8 ns |  3.34 ns |  2.79 ns |  2.02 |    0.01 | 0.0916 |     576 B |        1.76 |
| Old          | Byte[32]  | 1,979.5 ns | 20.45 ns | 17.07 ns |  3.46 |    0.03 | 0.3357 |    2120 B |        6.46 |
| Old          | Byte[128] | 2,167.2 ns | 15.33 ns | 14.34 ns |  3.79 |    0.04 | 0.3357 |    2120 B |        6.46 |
~~~
