### PR TITLE
Disable flak truck in Soviet-13, others

### DIFF
--- a/mods/ra/maps/allies-06a/rules.yaml
+++ b/mods/ra/maps/allies-06a/rules.yaml
@@ -39,6 +39,10 @@ ARTY:
 	Buildable:
 		Prerequisites: ~disabled
 
+FTRK:
+	Buildable:
+		Prerequisites: ~disabled
+
 MCV:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/allies-06b/rules.yaml
+++ b/mods/ra/maps/allies-06b/rules.yaml
@@ -35,6 +35,10 @@ ARTY:
 	Buildable:
 		Prerequisites: ~disabled
 
+FTRK:
+	Buildable:
+		Prerequisites: ~disabled
+
 MCV:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/allies-07/rules.yaml
+++ b/mods/ra/maps/allies-07/rules.yaml
@@ -33,6 +33,10 @@ powerproxy.paratroopers:
 	ParatroopersPower:
 		DropItems: E1,E1,E1,E2,E2
 
+FTRK:
+	Buildable:
+		Prerequisites: ~disabled
+
 MCV:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/allies-09a/rules.yaml
+++ b/mods/ra/maps/allies-09a/rules.yaml
@@ -41,6 +41,10 @@ powerproxy.paratroopers:
 	ParatroopersPower:
 		DropItems: E1,E1,E1,E2,E2
 
+FTRK:
+	Buildable:
+		Prerequisites: ~disabled
+
 MCV:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/allies-10a/rules.yaml
+++ b/mods/ra/maps/allies-10a/rules.yaml
@@ -42,6 +42,10 @@ MSLO:
 	Capturable:
 		Types: ~disabled
 
+FTRK:
+	Buildable:
+		Prerequisites: ~disabled
+
 MCV:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/fall-of-greece-2-evacuation/rules.yaml
+++ b/mods/ra/maps/fall-of-greece-2-evacuation/rules.yaml
@@ -75,6 +75,10 @@ MSLO:
 	Buildable:
 		Prerequisites: ~disabled
 
+FTRK:
+	Buildable:
+		Prerequisites: ~disabled
+
 MCV:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/monster-tank-madness/rules.yaml
+++ b/mods/ra/maps/monster-tank-madness/rules.yaml
@@ -282,6 +282,10 @@ STEK:
 	Buildable:
 		Prerequisites: ~disabled
 
+FTRK:
+	Buildable:
+		Prerequisites: ~disabled
+
 MCV:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/soviet-13a/rules.yaml
+++ b/mods/ra/maps/soviet-13a/rules.yaml
@@ -42,6 +42,10 @@ MSLO:
 	Buildable:
 		Prerequisites: ~disabled
 
+FTRK:
+	Buildable:
+		Prerequisites: ~disabled
+
 MCV:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/soviet-13b/rules.yaml
+++ b/mods/ra/maps/soviet-13b/rules.yaml
@@ -42,6 +42,10 @@ MSLO:
 	Buildable:
 		Prerequisites: ~disabled
 
+FTRK:
+	Buildable:
+		Prerequisites: ~disabled
+
 MCV:
 	Buildable:
 		Prerequisites: ~disabled


### PR DESCRIPTION
Prompted by a message from Yara on the discord. Removes the flak truck's build option on Soviet-13a & Soviet-13b to match the rest of the Soviet campaign.

Some other missions where it's possible to build flak trucks from a captured factory are also included. Allies-03a, Allies-05 a/b/c, Allies-08 a/b, and some other Allied missions already have it disabled, so I figured this wouldn't be contentious.