### PR TITLE
Fix crashing when transports are loaded via lua and related regressions

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -1221,7 +1221,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		Activity ICreationActivity.GetCreationActivity()
 		{
-			return new AssociateWithAirfieldActivity(self, creationActivityDelay, creationRallyPoint);
+			if (creationRallyPoint != null || creationActivityDelay > 0)
+				return new AssociateWithAirfieldActivity(self, creationActivityDelay, creationRallyPoint);
+
+			return null;
 		}
 
 		sealed class AssociateWithAirfieldActivity : Activity

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -1236,7 +1236,6 @@ namespace OpenRA.Mods.Common.Traits
 			public AssociateWithAirfieldActivity(Actor self, int delay, CPos[] rallyPoint)
 			{
 				aircraft = self.Trait<Aircraft>();
-				IsInterruptible = false;
 				this.delay = delay;
 				this.rallyPoint = rallyPoint;
 			}
@@ -1245,7 +1244,12 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				var host = aircraft.GetActorBelow();
 				if (host != null)
+				{
 					aircraft.MakeReservation(host);
+
+					// Freshly created aircraft shouldn't block the exit, so we allow them to yield their reservation.
+					aircraft.AllowYieldingReservation();
+				}
 
 				if (delay > 0)
 					QueueChild(new Wait(delay));
@@ -1253,17 +1257,13 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override bool Tick(Actor self)
 			{
-				if (!aircraft.Info.TakeOffOnCreation)
-				{
-					// Freshly created aircraft shouldn't block the exit, so we allow them to yield their reservation
-					aircraft.AllowYieldingReservation();
+				if (!aircraft.Info.TakeOffOnCreation || IsCanceling)
 					return true;
-				}
 
-				if (rallyPoint != null && aircraft.Info.TakeOffOnCreation)
+				if (rallyPoint != null && rallyPoint.Length > 0)
 				{
 					foreach (var cell in rallyPoint)
-						self.QueueActivity(new AttackMoveActivity(self, () => aircraft.MoveTo(cell, 1, evaluateNearestMovableCell: true, targetLineColor: Color.OrangeRed)));
+						QueueChild(new AttackMoveActivity(self, () => aircraft.MoveTo(cell, 1, evaluateNearestMovableCell: true, targetLineColor: Color.OrangeRed)));
 				}
 				else if (self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition).Length <= aircraft.LandAltitude.Length)
 					QueueChild(new TakeOff(self));

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -114,9 +114,8 @@ namespace OpenRA.Mods.Common.Traits
 			mobile = self.TraitOrDefault<Mobile>();
 			UpdateCondition(self);
 
-			// Note: This is queued in a FrameEndTask because otherwise the activity is dropped/overridden while moving out of a factory.
 			if (Info.SearchOnCreation && mobile != null)
-				self.World.AddFrameEndTask(w => self.QueueActivity(new FindAndDeliverResources(self)));
+				self.QueueActivity(new FindAndDeliverResources(self));
 
 			base.Created(self);
 		}

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -979,7 +979,6 @@ namespace OpenRA.Mods.Common.Traits
 			public LeaveProductionActivity(Actor self, int delay, CPos[] rallyPoint, ReturnToCellActivity returnToCell)
 			{
 				mobile = self.Trait<Mobile>();
-				IsInterruptible = false;
 				this.delay = delay;
 				this.rallyPoint = rallyPoint;
 				this.returnToCell = returnToCell;
@@ -987,14 +986,15 @@ namespace OpenRA.Mods.Common.Traits
 
 			protected override void OnFirstRun(Actor self)
 			{
+				// It is vital that ReturnToCell is queued first as it needs the power to intercept a possible cancellation of this activity.
 				if (returnToCell != null)
-					self.QueueActivity(returnToCell);
+					QueueChild(returnToCell);
 				else if (delay > 0)
-					self.QueueActivity(new Wait(delay));
+					QueueChild(new Wait(delay));
 
 				if (rallyPoint != null)
 					foreach (var cell in rallyPoint)
-						self.QueueActivity(new AttackMoveActivity(self, () => mobile.MoveTo(cell, 1, evaluateNearestMovableCell: true, targetLineColor: Color.OrangeRed)));
+						QueueChild(new AttackMoveActivity(self, () => mobile.MoveTo(cell, 1, evaluateNearestMovableCell: true, targetLineColor: Color.OrangeRed)));
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -1000,7 +1000,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		Activity ICreationActivity.GetCreationActivity()
 		{
-			return new LeaveProductionActivity(self, creationActivityDelay, creationRallypoint, returnToCellOnCreation ? new ReturnToCellActivity(self, creationActivityDelay, returnToCellOnCreationRecalculateSubCell) : null);
+			if (returnToCellOnCreation || creationRallypoint != null || creationActivityDelay > 0)
+				return new LeaveProductionActivity(self, creationActivityDelay, creationRallypoint,
+					returnToCellOnCreation ? new ReturnToCellActivity(self, creationActivityDelay, returnToCellOnCreationRecalculateSubCell) : null);
+
+			return null;
 		}
 
 		sealed class MoveOrderTargeter : IOrderTargeter

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Traits;
@@ -61,7 +62,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (exitingActor == null)
 				return;
 
-			if (!exitingActor.IsInWorld || exitingActor.Location != openExit || exitingActor.CurrentActivity is not Mobile.ReturnToCellActivity)
+			if (!exitingActor.IsInWorld || exitingActor.Location != openExit
+				|| (!exitingActor.CurrentActivity?.ActivitiesImplementing<Mobile.ReturnToCellActivity>().Any() ?? true))
 			{
 				desiredFrame = 0;
 				exitingActor = null;

--- a/mods/d2k/maps/shellmap/d2k-shellmap.lua
+++ b/mods/d2k/maps/shellmap/d2k-shellmap.lua
@@ -158,6 +158,10 @@ WorldLoaded = function()
 	Corrino = Player.GetPlayer("Corrino")
 	Smugglers = Player.GetPlayer("Smugglers")
 
+	Reinforcements.Reinforce(Atreides, { "carryall" }, { atr_carry_1.Location })
+	Reinforcements.Reinforce(Atreides, { "carryall" }, { atr_carry_2.Location })
+	Reinforcements.Reinforce(Atreides, { "carryall" }, { atr_carry_3.Location })
+
 	ViewportOrigin = Camera.Position
 
 	Utils.Do(Utils.Take(4, Upgrades), function(upgrade)

--- a/mods/d2k/maps/shellmap/map.yaml
+++ b/mods/d2k/maps/shellmap/map.yaml
@@ -676,18 +676,6 @@ Actors:
 		Owner: Atreides
 		Location: 71,86
 		Facing: 384
-	atr_carry1: carryall
-		Owner: Atreides
-		Location: 94,86
-		Facing: 0
-	atr_carry2: carryall
-		Owner: Atreides
-		Location: 94,88
-		Facing: 0
-	atr_carry3: carryall
-		Owner: Atreides
-		Location: 94,90
-		Facing: 0
 	atr_trike: trike
 		Owner: Atreides
 		Location: 92,82
@@ -976,5 +964,14 @@ Actors:
 	Actor267: spicebloom.spawnpoint
 		Owner: Neutral
 		Location: 50,65
+	atr_carry_3: waypoint
+		Owner: Atreides
+		Location: 96,90
+	atr_carry_2: waypoint
+		Owner: Atreides
+		Location: 88,98
+	atr_carry_1: waypoint
+		Owner: Atreides
+		Location: 80,98
 
 Rules: d2k|rules/campaign-palettes.yaml, rules.yaml


### PR DESCRIPTION
Fixes #21078
Fixes #21119
Fixes #21156
Fixes #21229
Fixes #21213
Supersedes #21208

Regression from #20825

Crash:
> Eluant.LuaException: LoadPassenger requires the passenger to be idle.

This PR entails that aircraft will no longer automatically take-off when placed on the map, restoring the legacy behaviour

An alternative solution would be to never call GetCreationActivity if actor is not to be added to world. Or perhaps instead pass that info down to the GetCreationActivity activity. It would make crashes possibly easier to debug.