### PR TITLE
Make cancellation of Passenger's activity on unload from Cargo optional

### DIFF
--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -119,11 +119,13 @@ namespace OpenRA.Mods.Common.Activities
 
 					var move = actor.Trait<IMove>();
 					var pos = actor.Trait<IPositionable>();
+					var passenger = actor.Trait<Passenger>();
 
 					pos.SetPosition(actor, exitSubCell.Value.Cell, exitSubCell.Value.SubCell);
 					pos.SetCenterPosition(actor, spawn);
 
-					actor.CancelActivity();
+					if (passenger.Info.CancelActivitiesOnExit)
+						actor.CancelActivity();
 					w.Add(actor);
 				});
 			}

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -429,7 +429,7 @@ namespace OpenRA.Mods.Common.Traits
 								nbm.OnNotifyBlockingMove(passenger, passenger);
 
 							// For show.
-							passenger.QueueActivity(new Nudge(passenger));
+							passenger.CurrentActivity.QueueChild(new Nudge(passenger));
 						}
 						else
 							passenger.Kill(e.Attacker);

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -58,6 +58,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Cursor to display when unable to enter target actor.")]
 		public readonly string EnterBlockedCursor = "enter-blocked";
 
+		[Desc("When unloading, cancel all other activies.")]
+		public readonly bool CancelActivitiesOnExit = true;
+
 		public override object Create(ActorInitializer init) { return new Passenger(this); }
 	}
 


### PR DESCRIPTION
The PR makes it possible to keep passenger's next activity (after `RideTransport`). This is useful for "ride and capture" attacks:
- queue loading engineers (or other capture-capable actors) onto a transporter (`Cargo` actor)
- also queue the capture order for the engineers of the target building (or other capturable actor)
- queue moving the transporter next to target building and queue deploy order

Example usage in OpenE2140 mod (here, any infantry actor can capture buildings):

![opene2140_ride_and_capture](https://github.com/OpenRA/OpenRA/assets/119738087/2156fb35-6412-41f5-a664-78884fbfa369)
