### PR TITLE
FreeActor should not spawn actor on parent actor dead

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
@@ -72,6 +72,9 @@ namespace OpenRA.Mods.Common.Traits
 
 			self.World.AddFrameEndTask(w =>
 			{
+				if (self.IsDead)
+					return;
+
 				w.CreateActor(Info.Actor, new TypeDictionary
 				{
 					new ParentActorInit(self),


### PR DESCRIPTION
Generally, any actor can die at frame end, so we need a `IsDead` check here to prevent spawn actor when parent actor dead.