### PR TITLE
Callback in Passenger during UnloadCargo before re-adding it to the world

### DIFF
--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -119,11 +119,12 @@ namespace OpenRA.Mods.Common.Activities
 
 					var move = actor.Trait<IMove>();
 					var pos = actor.Trait<IPositionable>();
+					var passenger = actor.Trait<Passenger>();
 
 					pos.SetPosition(actor, exitSubCell.Value.Cell, exitSubCell.Value.SubCell);
 					pos.SetCenterPosition(actor, spawn);
 
-					actor.CancelActivity();
+					passenger.OnBeforeAddedToWorld(actor);
 					w.Add(actor);
 				});
 			}

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -428,8 +428,7 @@ namespace OpenRA.Mods.Common.Traits
 							foreach (var nbm in nbms)
 								nbm.OnNotifyBlockingMove(passenger, passenger);
 
-							// For show.
-							passenger.QueueActivity(new Nudge(passenger));
+							passenger.Trait<Passenger>().OnEjectedFromKilledCargo(passenger);
 						}
 						else
 							passenger.Kill(e.Attacker);

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -207,6 +207,19 @@ namespace OpenRA.Mods.Common.Traits
 			ReservedCargo = null;
 		}
 
+		public virtual void OnBeforeAddedToWorld(Actor actor)
+		{
+			actor.CancelActivity();
+		}
+
+		public virtual void OnEjectedFromKilledCargo(Actor self)
+		{
+			// Cancel all other activities to keep consistent behavior with the one in UnloadCargo.
+			self.CurrentActivity?.Cancel(self);
+
+			self.QueueActivity(new Nudge(self));
+		}
+
 		void INotifyKilled.Killed(Actor self, AttackInfo e)
 		{
 			if (Transport == null)


### PR DESCRIPTION
This PR adds extension point in `Passenger`, which is used by`UnloadCargo`. The callback is called *just before* adding the Passenger actor back to the world and by default cancels actor's activities (which keeps the original behavior intact).

On the other hand by preserving actor's queued activities, new useful scenarios such as "ride and capture" attacks open up:
- queue loading engineers (or other capture-capable actors) onto a transporter (`Cargo` actor)
- also queue the capture order for the engineers of the target building (or other capturable actor)
- queue moving the transporter next to target building and queue deploy order

Example usage in OpenE2140 mod (here, any infantry actor can capture buildings):

![opene2140_ride_and_capture](https://github.com/OpenRA/OpenRA/assets/119738087/2156fb35-6412-41f5-a664-78884fbfa369)

This PR *also fixes* bug, when passenger actor's activities were not canceled, when it was ejected after the `Cargo` actor was destroyed.

The PR supersedes #21079.