### PR TITLE
Fix ProductionBar visually glitching for units without value

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/ProductionBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/ProductionBar.cs
@@ -77,7 +77,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 				return;
 
 			var current = queue.AllQueued().Where(i => i.Started).MinByOrDefault(i => i.RemainingTime);
-			value = current != null ? 1 - (float)current.RemainingCost / current.TotalCost : 0;
+			if (current == null)
+				value = 0;
+			else if (current.TotalCost <= 0)
+				value = 1;
+			else
+				value = 1 - (float)current.RemainingCost / current.TotalCost;
 		}
 
 		float ISelectionBar.GetValue()


### PR DESCRIPTION
I made a unit buildable for testing purposes without giving them a cost/value. (The default for `Valued.Cost` even is zero.) That caused the production bar in TS to glitch to the bottom left for a brief second. Setting the value to one displays the bar correctly as full for the split second the unit is build.