### PR TITLE
GrantConditionOnDeployWithCharge requires no IMove

### DIFF
--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeployWithCharge.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeployWithCharge.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Allow deploying on specified charge to grant a condition for a specified duration.")]
-	public class GrantConditionOnDeployWithChargeInfo : PausableConditionalTraitInfo, Requires<IMoveInfo>, IRulesetLoaded
+	public class GrantConditionOnDeployWithChargeInfo : PausableConditionalTraitInfo, IRulesetLoaded
 	{
 		[FieldLoader.Require]
 		[GrantedConditionReference]


### PR DESCRIPTION
@PunkPun idk if it is by design or just an oversight, but I think it should go if we actually don't have to use it in trait.