### PR TITLE
Add NotBefore<SpawnStartingUnitsInfo> to LuaScriptInfo

### DIFF
--- a/OpenRA.Mods.Common/Scripting/LuaScript.cs
+++ b/OpenRA.Mods.Common/Scripting/LuaScript.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Scripting
 {
 	[TraitLocation(SystemActors.World)]
 	[Desc("Part of the new Lua API.")]
-	public class LuaScriptInfo : TraitInfo, Requires<SpawnMapActorsInfo>
+	public class LuaScriptInfo : TraitInfo, Requires<SpawnMapActorsInfo>, NotBefore<SpawnStartingUnitsInfo>
 	{
 		[Desc("File names with location relative to the map.")]
 		public readonly HashSet<string> Scripts = new();


### PR DESCRIPTION
Closes #21091.

`LuaScriptInfo` already requires `SpawnMapActorsInfo`, so it seems reasonable to wait for the starting units to spawn as well. Then all actors can be queried from the `WorldLoaded` Lua function.