### PR TITLE
Small FireWarheads tweaks

### DIFF
--- a/OpenRA.Mods.Common/Traits/FireWarheads.cs
+++ b/OpenRA.Mods.Common/Traits/FireWarheads.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Detonate defined warheads at the current location at a set interval.")]
-	public class FireWarheadsInfo : PausableConditionalTraitInfo, Requires<IMoveInfo>, IRulesetLoaded
+	public class FireWarheadsInfo : PausableConditionalTraitInfo, Requires<IOccupySpaceInfo>, IRulesetLoaded
 	{
 		[WeaponReference]
 		[FieldLoader.Require]

--- a/OpenRA.Mods.Common/Traits/FireWarheads.cs
+++ b/OpenRA.Mods.Common/Traits/FireWarheads.cs
@@ -72,11 +72,8 @@ namespace OpenRA.Mods.Common.Traits
 				foreach (var wep in Info.WeaponInfos)
 				{
 					wep.Impact(Target.FromPos(self.CenterPosition), self);
-					self.World.AddFrameEndTask(world =>
-					{
-						if (wep.Report != null && wep.Report.Length > 0)
-							Game.Sound.Play(SoundType.World, wep.Report, world, self.CenterPosition);
-					});
+					if (wep.Report != null && wep.Report.Length > 0)
+						Game.Sound.Play(SoundType.World, wep.Report, self.World, self.CenterPosition);
 				}
 			}
 		}


### PR DESCRIPTION
Small tweaks for `FireWarheads` trait:
- `FireWarheads` unnecessarily depends on `IMove` making it difficult to use for non-Mobile/Aircraft actors
- playing weapon's report sound in `FrameEndTask` is not necessary