### PR TITLE
Remove an outdated comment from AutoCrusher.cs

### DIFF
--- a/OpenRA.Mods.Common/Traits/AutoCrusher.cs
+++ b/OpenRA.Mods.Common/Traits/AutoCrusher.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 					self.Location != a.Location && a.IsAtGroundLevel() &&
 					Info.TargetRelationships.HasRelationship(self.Owner.RelationshipWith(a.Owner)) &&
 					a.TraitsImplementing<ICrushable>().Any(c => c.CrushableBy(a, self, Info.CrushClasses)))
-				.ClosestToWithPathFrom(self); // TODO: Make it use shortest pathfinding distance instead
+				.ClosestToWithPathFrom(self);
 
 			if (crushableActor == null)
 				return;


### PR DESCRIPTION
This was fixed in https://github.com/OpenRA/OpenRA/commit/23f3f8d90c3e1186d4bb9af2f2707cc607cba488