### PR TITLE
Chore/minimal devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,38 @@
+# FROM mcr.microsoft.com/devcontainers/dotnet:0-6.0
+FROM mcr.microsoft.com/devcontainers/base:debian-11
+
+# Add backports.
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main" > /etc/apt/sources.list.d/backports.list
+
+# Install dependencies.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  file \
+  nsis \
+  imagemagick \
+  wine64 \
+  shellcheck
+
+# Install dotnet SDK and PowerShell.
+RUN curl -SOL https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb \
+  && dpkg -i packages-microsoft-prod.deb \
+  && rm packages-microsoft-prod.deb \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+  dotnet-sdk-6.0 \
+  powershell
+
+# Install updated packages from backports.
+RUN apt-get update && sudo apt-get install -y --no-install-recommends \
+  curl/bullseye-backports \
+  wine64/bullseye-backports
+
+# Install AppImageTool.
+RUN curl -SLO https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage \
+  && install appimagetool-x86_64.AppImage /usr/local/bin \
+  && rm appimagetool-x86_64.AppImage
+
+
+# Download rcdedit.
+USER vscode
+RUN curl -SLo /home/vscode/rcedit-x64.exe https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe
+ENV PATH=/usr/lib/wine/:$PATH

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,13 +26,20 @@ RUN apt-get update && sudo apt-get install -y --no-install-recommends \
   curl/bullseye-backports \
   wine64/bullseye-backports
 
-# Install AppImageTool.
-RUN curl -SLO https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage \
-  && install appimagetool-x86_64.AppImage /usr/local/bin \
-  && rm appimagetool-x86_64.AppImage
-
-
-# Download rcdedit.
+# Add wine to $PATH.
 USER vscode
-RUN curl -SLo /home/vscode/rcedit-x64.exe https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe
 ENV PATH=/usr/lib/wine/:$PATH
+
+# The following obviate the need to download binaries during the build process.
+# # Install AppImageTool.
+# RUN curl -SLO https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage \
+#   && install appimagetool-x86_64.AppImage $HOME/.local/bin/ \
+#   && rm appimagetool-x86_64.AppImage
+
+# # Download rcdedit.
+# RUN curl -SLo /home/vscode/rcedit-x64.exe https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe
+
+# Add an entrypoint to permit package-all to be run directly.
+# Build with `docker build -t builder .devcontainer`.
+# Run with `docker run -v $(pwd):/workspaces/OpenRA builder`.
+ENTRYPOINT [ "/workspaces/OpenRA/packaging/package-all.sh" ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+	"name": "C# (.NET)",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"EditorConfig.EditorConfig",
+				"foxundermoon.shell-format",
+				"GitHub.vscode-github-actions",
+				"idleberg.nsis",
+				"macabeus.vscode-fluent",
+				"ms-dotnettools.csdevkit",
+				"ms-dotnettools.csharp",
+				"ms-python.python",
+				"ms-vscode.cpptools-extension-pack",
+				"ms-vscode.makefile-tools",
+				"ms-vscode.powershell",
+				"nico-castell.linux-desktop-file",
+				"openra.oraide-vscode",
+				"openra.vscode-openra-lua",
+				"tamasfe.even-better-toml",
+				"timonwong.shellcheck"
+			]
+		}
+	},
+	"features": {},
+	"postAttachCommand": {
+		"safe-dir": "git config --global --add safe.directory ${containerWorkspaceFolder}"
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ update.log
 
 # IntelliJ files
 .idea
+
+# Default output directory
+build/

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ endif
 # dotnet clean and msbuild -t:Clean leave files that cause problems when switching between mono/dotnet
 # Deleting the intermediate / output directories ensures the build directory is actually clean
 clean:
-	@-$(RM_RF) ./bin ./*/obj
+	@-$(RM_RF) ./bin ./*/obj ./build
 	@-$(RM_F) IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP
 
 check:

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -53,7 +53,7 @@ else
 	wget -cq -O $HOME/appimagetool-x86_64.AppImage https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
 fi
 
-chmod a+x appimagetool-x86_64.AppImage
+chmod a+x $HOME/appimagetool-x86_64.AppImage
 
 echo "Building AppImages"
 

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -13,7 +13,7 @@ HERE=$(dirname "$0")
 cd "${HERE}"
 . ../functions.sh
 
-TAG="${1:-HEAD}"
+TAG="${1:-devtest-19700101}"
 
 if [ -z ${2:-} ]; then
 OUTPUTDIR=$(pwd)/../../build/linux

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -8,18 +8,20 @@ command -v curl >/dev/null 2>&1 || command -v wget > /dev/null 2>&1 || { echo >&
 
 DEPENDENCIES_TAG="20201222"
 
-if [ $# -eq "0" ]; then
-	echo "Usage: $(basename "$0") version [outputdir]"
-	exit 1
-fi
-
 # Set the working dir to the location of this script
 HERE=$(dirname "$0")
 cd "${HERE}"
 . ../functions.sh
 
-TAG="$1"
-OUTPUTDIR="$2"
+TAG="${1:-HEAD}"
+
+if [ -z ${2:-} ]; then
+OUTPUTDIR=$(pwd)/../../build/linux
+mkdir -p $OUTPUTDIR
+else
+OUTPUTDIR="${2}"
+fi
+
 SRCDIR="$(pwd)/../.."
 ARTWORK_DIR="$(pwd)/../artwork/"
 
@@ -112,10 +114,10 @@ build_appimage() {
 
 	# Embed update metadata if (and only if) compiled on GitHub Actions
 	if [ -n "${GITHUB_REPOSITORY}" ]; then
-		ARCH=x86_64 ./appimagetool-x86_64.AppImage --no-appstream -u "zsync|https://master.openra.net/appimagecheck.zsync?mod=${MOD_ID}&channel=${UPDATE_CHANNEL}" "${APPDIR}" "${OUTPUTDIR}/${APPIMAGE}"
+		ARCH=x86_64 ./appimagetool-x86_64.AppImage --appimage-extract-and-run --no-appstream -u "zsync|https://master.openra.net/appimagecheck.zsync?mod=${MOD_ID}&channel=${UPDATE_CHANNEL}" "${APPDIR}" "${OUTPUTDIR}/${APPIMAGE}"
 		zsyncmake -u "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${APPIMAGE}" -o "${OUTPUTDIR}/${APPIMAGE}.zsync" "${OUTPUTDIR}/${APPIMAGE}"
 	else
-		ARCH=x86_64 ./appimagetool-x86_64.AppImage --no-appstream "${APPDIR}" "${OUTPUTDIR}/${APPIMAGE}"
+		ARCH=x86_64 ./appimagetool-x86_64.AppImage --appimage-extract-and-run --no-appstream "${APPDIR}" "${OUTPUTDIR}/${APPIMAGE}"
 	fi
 
 	rm -rf "${APPDIR}"

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -48,9 +48,9 @@ fi
 # Add native libraries
 echo "Downloading appimagetool"
 if command -v curl >/dev/null 2>&1; then
-	curl -s -L -O https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+	curl -s -L -o $HOME/appimagetool-x86_64.AppImage https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
 else
-	wget -cq https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+	wget -cq -O $HOME/appimagetool-x86_64.AppImage https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
 fi
 
 chmod a+x appimagetool-x86_64.AppImage
@@ -114,10 +114,10 @@ build_appimage() {
 
 	# Embed update metadata if (and only if) compiled on GitHub Actions
 	if [ -n "${GITHUB_REPOSITORY}" ]; then
-		ARCH=x86_64 ./appimagetool-x86_64.AppImage --appimage-extract-and-run --no-appstream -u "zsync|https://master.openra.net/appimagecheck.zsync?mod=${MOD_ID}&channel=${UPDATE_CHANNEL}" "${APPDIR}" "${OUTPUTDIR}/${APPIMAGE}"
+		ARCH=x86_64 $HOME/appimagetool-x86_64.AppImage --appimage-extract-and-run --no-appstream -u "zsync|https://master.openra.net/appimagecheck.zsync?mod=${MOD_ID}&channel=${UPDATE_CHANNEL}" "${APPDIR}" "${OUTPUTDIR}/${APPIMAGE}"
 		zsyncmake -u "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${APPIMAGE}" -o "${OUTPUTDIR}/${APPIMAGE}.zsync" "${OUTPUTDIR}/${APPIMAGE}"
 	else
-		ARCH=x86_64 ./appimagetool-x86_64.AppImage --appimage-extract-and-run --no-appstream "${APPDIR}" "${OUTPUTDIR}/${APPIMAGE}"
+		ARCH=x86_64 $HOME/appimagetool-x86_64.AppImage --appimage-extract-and-run --no-appstream "${APPDIR}" "${OUTPUTDIR}/${APPIMAGE}"
 	fi
 
 	rm -rf "${APPDIR}"
@@ -128,4 +128,4 @@ build_appimage "cnc" "Tiberian Dawn" "699223250181292033"
 build_appimage "d2k" "Dune 2000" "712711732770111550"
 
 # Clean up
-rm -rf appimagetool-x86_64.AppImage "${BUILTDIR}"
+rm -rf $HOME/appimagetool-x86_64.AppImage "${BUILTDIR}"

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -3,13 +3,8 @@
 
 set -o errexit -o pipefail || exit $?
 
-if [ $# -ne "2" ]; then
-	echo "Usage: $(basename "$0") version outputdir."
-	exit 1
-fi
-
-export GIT_TAG="$1"
-export BUILD_OUTPUT_DIR="$2"
+export GIT_TAG="${1:-}"
+export BUILD_OUTPUT_DIR="${2:-}"
 
 # Set the working dir to the location of this script
 HERE=$(dirname "$0")

--- a/packaging/source/buildpackage.sh
+++ b/packaging/source/buildpackage.sh
@@ -26,7 +26,7 @@ make version VERSION="${TAG}"
 # Use the amend flag (r) to prevent each call erasing the output from earlier calls.
 rm "${OUTPUTDIR}/OpenRA-${TAG}-source.tar" || :
 git ls-tree HEAD --name-only -r -z | xargs -0 tar vrf "${OUTPUTDIR}/OpenRA-${TAG}-source.tar"
-bzip2 "${OUTPUTDIR}/OpenRA-${TAG}-source.tar"
+bzip2 -f "${OUTPUTDIR}/OpenRA-${TAG}-source.tar"
 
 make version VERSION='{DEV_VERSION}'
 

--- a/packaging/source/buildpackage.sh
+++ b/packaging/source/buildpackage.sh
@@ -3,17 +3,19 @@
 
 set -o errexit -o pipefail || exit $?
 
-if [ $# -ne "2" ]; then
-	echo "Usage: $(basename "$0") tag outputdir"
-	exit 1
-fi
-
 # Set the working dir to the location of this script
 HERE=$(dirname "$0")
 cd "${HERE}"
 
-TAG="$1"
-OUTPUTDIR="$2"
+TAG="${1:-devtest-19700101}"
+
+if [ -z ${2:-} ]; then
+OUTPUTDIR=$(pwd)/../../build/source
+mkdir -p $OUTPUTDIR
+else
+OUTPUTDIR="${2}"
+fi
+
 SRCDIR="$(pwd)/../.."
 
 pushd "${SRCDIR}" > /dev/null
@@ -25,5 +27,7 @@ make version VERSION="${TAG}"
 rm "${OUTPUTDIR}/OpenRA-${TAG}-source.tar" || :
 git ls-tree HEAD --name-only -r -z | xargs -0 tar vrf "${OUTPUTDIR}/OpenRA-${TAG}-source.tar"
 bzip2 "${OUTPUTDIR}/OpenRA-${TAG}-source.tar"
+
+make version VERSION='{DEV_VERSION}'
 
 popd > /dev/null

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -37,9 +37,9 @@ elif [[ ${TAG} == playtest* ]]; then
 fi
 
 if command -v curl >/dev/null 2>&1; then
-	curl -s -L -O https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe
+	curl -s -L -o $HOME/rcedit-x64.exe https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe
 else
-	wget -cq https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe
+	wget -cq -O $HOME/rcedit-x64.exe https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe
 fi
 
 function makelauncher()
@@ -58,12 +58,12 @@ function makelauncher()
 
 	# Use rcedit to patch the generated EXE with missing assembly/PortableExecutable information because .NET 6 ignores that when building on Linux.
 	# Using a backwards version tag because rcedit is unable to set versions starting with a letter.
-	wine64 rcedit-x64.exe "${BUILTDIR}/${LAUNCHER_NAME}.exe" --set-product-version "${BACKWARDS_TAG}"
-	wine64 rcedit-x64.exe "${BUILTDIR}/${LAUNCHER_NAME}.exe" --set-version-string "ProductName" "OpenRA"
-	wine64 rcedit-x64.exe "${BUILTDIR}/${LAUNCHER_NAME}.exe" --set-version-string "CompanyName" "The OpenRA team"
-	wine64 rcedit-x64.exe "${BUILTDIR}/${LAUNCHER_NAME}.exe" --set-version-string "FileDescription" "${LAUNCHER_NAME} mod for OpenRA"
-	wine64 rcedit-x64.exe "${BUILTDIR}/${LAUNCHER_NAME}.exe" --set-version-string "LegalCopyright" "Copyright (c) The OpenRA Developers and Contributors"
-	wine64 rcedit-x64.exe "${BUILTDIR}/${LAUNCHER_NAME}.exe" --set-icon "${BUILTDIR}/${MOD_ID}.ico"
+	wine64 $HOME/rcedit-x64.exe "${BUILTDIR}/${LAUNCHER_NAME}.exe" --set-product-version "${BACKWARDS_TAG}"
+	wine64 $HOME/rcedit-x64.exe "${BUILTDIR}/${LAUNCHER_NAME}.exe" --set-version-string "ProductName" "OpenRA"
+	wine64 $HOME/rcedit-x64.exe "${BUILTDIR}/${LAUNCHER_NAME}.exe" --set-version-string "CompanyName" "The OpenRA team"
+	wine64 $HOME/rcedit-x64.exe "${BUILTDIR}/${LAUNCHER_NAME}.exe" --set-version-string "FileDescription" "${LAUNCHER_NAME} mod for OpenRA"
+	wine64 $HOME/rcedit-x64.exe "${BUILTDIR}/${LAUNCHER_NAME}.exe" --set-version-string "LegalCopyright" "Copyright (c) The OpenRA Developers and Contributors"
+	wine64 $HOME/rcedit-x64.exe "${BUILTDIR}/${LAUNCHER_NAME}.exe" --set-icon "${BUILTDIR}/${MOD_ID}.ico"
 }
 
 function build_platform()
@@ -101,4 +101,4 @@ function build_platform()
 
 build_platform "x86"
 build_platform "x64"
-rm rcedit-x64.exe
+rm $HOME/rcedit-x64.exe

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -9,18 +9,20 @@ command -v convert >/dev/null 2>&1 || { echo >&2 "Windows packaging requires Ima
 command -v python3 >/dev/null 2>&1 || { echo >&2 "Windows packaging requires python 3."; exit 1; }
 command -v wine64 >/dev/null 2>&1 || { echo >&2 "Windows packaging requires wine64."; exit 1; }
 
-if [ $# -ne "2" ]; then
-	echo "Usage: $(basename "$0") tag outputdir"
-	exit 1
-fi
-
 # Set the working dir to the location of this script
 HERE=$(dirname "$0")
 cd "${HERE}"
 . ../functions.sh
 
-TAG="$1"
-OUTPUTDIR="$2"
+TAG="${1:-devtest-19700101}"
+
+if [ -z ${2:-} ]; then
+OUTPUTDIR=$(pwd)/../../build/windows
+mkdir -p $OUTPUTDIR
+else
+OUTPUTDIR="${2}"
+fi
+
 SRCDIR="$(pwd)/../.."
 BUILTDIR="$(pwd)/build"
 ARTWORK_DIR="$(pwd)/../artwork/"


### PR DESCRIPTION
This is a followup / replacement to #21085 which added a Windows Dockerfile to permit for the project to be built without local dependencies. This time, it uses the [devcontainer](https://containers.dev) system to provide not only a full Docker-based build workflow but also full integration with Visual Studio Code, IntelliJ and other compatible IDEs. Just open the repository and (if you have container-based workflows enabled) you should be prompted to re-open in the container. This includes all of the relevant extensions for working on the code.

I've confirmed that a full build of Windows, Linux and source releases works on both Windows and Linux hosts. A few tweaks were made either to resolve breakages in the above or to make the build slightly cleaner. Full list follows.

- Addition of a Dockerfile which contains all necessary project dependencies for Windows and Linux builds. This can either be run standalone (instructions in the comments in the file) or using the devcontainer workflow.
- Set sensible defaults for the packaging scripts: use a default build directory if unspecified (also included in gitignore), and use a tag set to the epoch if no tag name is set per best practice for reproducible builds.
- Download binaries used in the build to a location outside of the source tree. Not only does this ensure they aren't accidentally left behind if the build aborts, but it also resolved an issue with a wine segfault (difficult to reproduce, only happens in docker, but doesn't happen if the file is out of tree).
- After the source packaging script has finished creating archives, reset the tags in the tree so that running the packaging script doesn't cause changed files in Git.

Note that this change should not result in any changes to the output - it is purely about making it easier and more foolproof to build the project.