### PR TITLE
Update ExtractEmmyLuaAPI command

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/ExtractEmmyLuaAPI.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractEmmyLuaAPI.cs
@@ -149,7 +149,13 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						.Distinct());
 
 				if (!string.IsNullOrEmpty(parameterString))
+				{
+					// OwnerInit is special as it is the only "required" init. All others are optional.
+					if (init.Name != nameof(OwnerInit))
+						parameterString += '?';
+
 					Console.WriteLine($"---@field {name} {parameterString}");
+				}
 			}
 
 			usedEnums = localEnums.Distinct();

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractEmmyLuaAPI.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractEmmyLuaAPI.cs
@@ -69,8 +69,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		static void WriteDiagnosticsDisabling()
 		{
 			Console.WriteLine("--- This file only lists function \"signatures\", causing Lua Diagnostics errors: \"Annotations specify that a return value is required here.\"");
-			Console.WriteLine("--- Disable that specific error for the entire file.");
+			Console.WriteLine("--- and Lua Diagnostics warnings \"Unused local\" for the functions' parameters.");
+			Console.WriteLine("--- Disable those specific errors for the entire file.");
 			Console.WriteLine("---@diagnostic disable: missing-return");
+			Console.WriteLine("---@diagnostic disable: unused-local");
 		}
 
 		static void WriteManual()


### PR DESCRIPTION
Fixes https://github.com/OpenRA/vscode-openra-lua/issues/13, fixes https://github.com/OpenRA/vscode-openra-lua/issues/14 by:
1. Changing how Actor and Player properties are represented in the generated Lua API file - switching from table entries annotated with `@type` to just `@field` annotations on the class (table).
**BONUS:** Makes a distinction between readonly and "normal" properties now!
<img width="320" alt="image" src="https://github.com/OpenRA/OpenRA/assets/7137365/0f2afcd5-6c78-4993-94b7-c5c11e6dca8d">

2. Marks all actor inits as nullable/optional members of the InitTable type. (All except `OwnerInit`).

*Also disabled warnings inside the generated file about unused method parameters, because of course they are unused there.*

You can see a diff in the generated file in https://github.com/OpenRA/vscode-openra-lua/pull/15.