### PR TITLE
Added current datetime properties to the Lua API

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Global/DateTimeGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/DateTimeGlobal.cs
@@ -43,6 +43,13 @@ namespace OpenRA.Mods.Common.Scripting
 			return seconds * ticksPerSecond;
 		}
 
+		public int CurrentYear => DateTime.Now.Year;
+		public int CurrentMonth => DateTime.Now.Month;
+		public int CurrentDay => DateTime.Now.Day;
+		public int CurrentHour => DateTime.Now.Hour;
+		public int CurrentMinute => DateTime.Now.Minute;
+		public int CurrentSecond => DateTime.Now.Second;
+
 		[Desc("Converts the number of minutes into game time (ticks).")]
 		public int Minutes(int minutes)
 		{

--- a/OpenRA.Mods.Common/Scripting/Global/DateTimeGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/DateTimeGlobal.cs
@@ -32,6 +32,7 @@ namespace OpenRA.Mods.Common.Scripting
 		}
 
 		[Desc("True on the 31st of October.")]
+		[Obsolete("Use CurrentMonth and CurrentDay instead.")]
 		public bool IsHalloween => DateTime.Today.Month == 10 && DateTime.Today.Day == 31;
 
 		[Desc("Get the current game time (in ticks).")]

--- a/mods/ra/maps/desert-shellmap/desert-shellmap.lua
+++ b/mods/ra/maps/desert-shellmap/desert-shellmap.lua
@@ -6,7 +6,9 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
-if DateTime.IsHalloween then
+
+-- Halloween easter egg
+if DateTime.CurrentMonth == 10 and DateTime.CurrentDay == 31 then
 	UnitTypes = { "ant", "ant", "ant" }
 	BeachUnitTypes = { "ant", "ant" }
 	ProxyType = "powerproxy.parazombies"


### PR DESCRIPTION
A spiritual successor to #20541.

Test case:
```lua
if DateTime.GameTime % DateTime.Seconds(4) == 0 then
	Media.DisplayMessage(DateTime.CurrentYear .. "." .. DateTime.CurrentMonth .. "." .. DateTime.CurrentDay .. " - " .. DateTime.CurrentHour .. ":" .. DateTime.CurrentMinute .. ":" .. DateTime.CurrentSecond, Mentat)
end
```
![image](https://github.com/OpenRA/OpenRA/assets/7137365/f84f95b7-be80-4232-966e-977bc6d61f19)
