### PR TITLE
DetectCloaked: actor should be in world

### DIFF
--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -261,8 +261,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!Cloaked || self.Owner.IsAlliedWith(viewer))
 				return true;
 
-			return self.World.ActorsWithTrait<DetectCloaked>().Any(a => a.Actor.Owner.IsAlliedWith(viewer)
-				&& Info.DetectionTypes.Overlaps(a.Trait.Info.DetectionTypes)
+			return self.World.ActorsWithTrait<DetectCloaked>().Any(a => a.Actor.IsInWorld
+				&& a.Actor.Owner.IsAlliedWith(viewer) && Info.DetectionTypes.Overlaps(a.Trait.Info.DetectionTypes)
 				&& (self.CenterPosition - a.Actor.CenterPosition).LengthSquared <= a.Trait.Range.LengthSquared);
 		}
 


### PR DESCRIPTION
Otherwise, detecting unit will leave the detection circle at where it gets on the transport.