### PR TITLE
Automate documentation website updates

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,6 +2,7 @@ name: Deploy Documentation
 
 on:
   push:
+    branches: [ bleed ]
     tags: [ 'release-*', 'playtest-*' ]
   workflow_dispatch:
     inputs:
@@ -73,9 +74,14 @@ jobs:
       - name: Prepare environment variables
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
-            VERSION=`echo "${GITHUB_REF#refs/tags/}" | cut -d"-" -f1`
-            echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-            echo "VERSION=$VERSION" >> $GITHUB_ENV
+            if [ "${{ github.ref_type }}" = "tag" ]; then
+              VERSION=`echo "${GITHUB_REF#refs/tags/}" | cut -d"-" -f1`
+              echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+              echo "VERSION=$VERSION" >> $GITHUB_ENV
+            else
+              echo "GIT_TAG=bleed" >> $GITHUB_ENV
+              echo "VERSION=bleed" >> $GITHUB_ENV
+            fi
           else
             VERSION=`echo "${{ github.event.inputs.tag }}" | cut -d"-" -f1`
             echo "GIT_TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
@@ -96,7 +102,7 @@ jobs:
         run: |
           make all
 
-      # VERSION is release/playtest - the name of the target branch.
+      # VERSION is release/playtest/bleed - the name of the target branch.
       - name: Clone docs.openra.net
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,6 +1,8 @@
 name: Deploy Documentation
 
 on:
+  push:
+    tags: [ 'release-*', 'playtest-*' ]
   workflow_dispatch:
     inputs:
       tag:
@@ -70,9 +72,15 @@ jobs:
     steps:
       - name: Prepare environment variables
         run: |
-          VERSION=`echo "${{ github.event.inputs.tag }}" | cut -d"-" -f1`
-          echo "GIT_TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          if [ "${{ github.event_name }}" = "push" ]; then
+            VERSION=`echo "${GITHUB_REF#refs/tags/}" | cut -d"-" -f1`
+            echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+            echo "VERSION=$VERSION" >> $GITHUB_ENV
+          else
+            VERSION=`echo "${{ github.event.inputs.tag }}" | cut -d"-" -f1`
+            echo "GIT_TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
+            echo "VERSION=$VERSION" >> $GITHUB_ENV
+          fi
 
       - name: Clone Repository
         uses: actions/checkout@v3

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -68,10 +68,16 @@ jobs:
     if: github.repository == 'openra/openra'
     runs-on: ubuntu-22.04
     steps:
+      - name: Prepare environment variables
+        run: |
+          VERSION=`echo "${{ github.event.inputs.tag }}" | cut -d"-" -f1`
+          echo "GIT_TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
       - name: Clone Repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.inputs.tag }}
+          ref: ${{ env.GIT_TAG }}
 
       - name: Install .NET 6
         uses: actions/setup-dotnet@v3
@@ -82,62 +88,27 @@ jobs:
         run: |
           make all
 
-      - name: Clone docs.openra.net (Playtest)
-        if: startsWith(github.event.inputs.tag, 'playtest-')
+      # VERSION is release/playtest - the name of the target branch.
+      - name: Clone docs.openra.net
         uses: actions/checkout@v3
         with:
           repository: openra/docs
           token: ${{ secrets.DOCS_TOKEN }}
           path: docs
-          ref: playtest
+          ref: ${{ env.VERSION }}
 
-      - name: Clone docs.openra.net (Release)
-        if: startsWith(github.event.inputs.tag, 'release-')
-        uses: actions/checkout@v3
-        with:
-          repository: openra/docs
-          token: ${{ secrets.DOCS_TOKEN }}
-          path: docs
-          ref: release
-
-      - name: Update docs.openra.net (Playtest)
-        if: startsWith(github.event.inputs.tag, 'playtest-')
-        env:
-          GIT_TAG: ${{ github.event.inputs.tag }}
+      - name: Generate docs files
         run: |
-          ./utility.sh all --docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/traits.md"
-          ./utility.sh all --weapon-docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/weapons.md"
-          ./utility.sh all --sprite-sequence-docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/sprite-sequences.md"
-          ./utility.sh all --lua-docs "${GIT_TAG}" > "docs/api/lua.md"
+          ./utility.sh all --docs "${{ env.GIT_TAG }}" | python3 ./packaging/format-docs.py > "docs/api/traits.md"
+          ./utility.sh all --weapon-docs "${{ env.GIT_TAG }}" | python3 ./packaging/format-docs.py > "docs/api/weapons.md"
+          ./utility.sh all --sprite-sequence-docs "${{ env.GIT_TAG }}" | python3 ./packaging/format-docs.py > "docs/api/sprite-sequences.md"
+          ./utility.sh all --lua-docs "${{ env.GIT_TAG }}" > "docs/api/lua.md"
 
-      - name: Update docs.openra.net (Release)
-        if: startsWith(github.event.inputs.tag, 'release-')
-        env:
-          GIT_TAG: ${{ github.event.inputs.tag }}
-        run: |
-          ./utility.sh all --docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/traits.md"
-          ./utility.sh all --weapon-docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/weapons.md"
-          ./utility.sh all --sprite-sequence-docs "${GIT_TAG}" | python3 ./packaging/format-docs.py > "docs/api/sprite-sequences.md"
-          ./utility.sh all --lua-docs "${GIT_TAG}" > "docs/api/lua.md"
-
-      - name: Commit docs.openra.net
-        env:
-          GIT_TAG: ${{ github.event.inputs.tag }}
+      - name: Update docs.openra.net
         run: |
           cd docs
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"
           git add api/*.md
-          git commit -m "Update auto-generated documentation for ${GIT_TAG}"
-
-      - name: Push docs.openra.net (Release)
-        if: startsWith(github.event.inputs.tag, 'release-')
-        run: |
-          cd docs
-          git push origin release
-
-      - name: Push docs.openra.net (Playtest)
-        if: startsWith(github.event.inputs.tag, 'playtest-')
-        run: |
-          cd docs
-          git push origin playtest
+          git commit -m "Update auto-generated documentation for ${{ env.GIT_TAG }}"
+          git push origin ${{ env.VERSION }}


### PR DESCRIPTION
So far, the documentation website relies on manually running the workflow to update it and inputting the correct version. This is now automated on tagging a release or playtest.
The other thing here is that now merges to the `bleed` branch will trigger the workflow, which will try to update the dev version of the documentation website to always keep it up-to-date.