### PR TITLE
Enforce stricter checks on sequence Facings.

### DIFF
--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -392,6 +392,11 @@ namespace OpenRA.Mods.Common.Graphics
 				facings = -facings;
 			}
 
+			// Facings must be an integer factor of 1024 (i.e. 1024 / facings is an integer) to allow the frames to be
+			// mapped uniformly over the full rotation range. This implies that it is a power of 2.
+			if (facings == 0 || facings > 1024 || !Exts.IsPowerOf2(facings))
+				throw new YamlException($"{facingsLocation}: {Facings.Key} must be within the (positive or negative) range of 1 to 1024, and a power of 2.");
+
 			if (interpolatedFacings != null && (interpolatedFacings < 2 || interpolatedFacings <= facings || interpolatedFacings > 1024 || !Exts.IsPowerOf2(interpolatedFacings.Value)))
 				throw new YamlException($"{interpolatedFacingsLocation}: {InterpolatedFacings.Key} must be greater than {Facings.Key}, within the range of 2 to 1024, and a power of 2.");
 


### PR DESCRIPTION
This prevents modders from setting Facings values that can cause the game to crash with an unhelpful `IndexOutOfRangeException`.

Consider `Facings: 5`. 1024 / 5 = 204.8 WAngle units for each sprite. The frame selection code rounds this down to 204 per frame, which then leaves angles 204 * 5 = 1020 through 1023 without associated artwork, causing a crash when something asks for that.

An alternative solution would be to non-uniformly map the facings to the angle range (4 of the 5 frames have 205 units, 1 with 204, or 5 with 204 and 1 with 208), but this would add a lot of complexity and probably a measurable performance hit. The responsibility is on modders to not pick silly frame values, but this does rely on the game telling them when they do it wrong.
