### PR TITLE
Add FilenamePattern support to sequences.

### DIFF
--- a/OpenRA.Mods.Cnc/Graphics/ClassicTilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ClassicTilesetSpecificSpriteSequence.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
 
@@ -33,11 +34,28 @@ namespace OpenRA.Mods.Cnc.Graphics
 		[Desc("Dictionary of <tileset name>: filename to override the Filename key.")]
 		static readonly SpriteSequenceField<Dictionary<string, string>> TilesetFilenames = new(nameof(TilesetFilenames), null);
 
+		[Desc("Dictionary of <tileset name>: <filename pattern> to override the FilenamePattern key.")]
+		static readonly SpriteSequenceField<Dictionary<string, string>> TilesetFilenamesPattern = new(nameof(TilesetFilenamesPattern), null);
+
 		public ClassicTilesetSpecificSpriteSequence(SpriteCache cache, ISpriteSequenceLoader loader, string image, string sequence, MiniYaml data, MiniYaml defaults)
 			: base(cache, loader, image, sequence, data, defaults) { }
 
 		protected override IEnumerable<ReservationInfo> ParseFilenames(ModData modData, string tileset, int[] frames, MiniYaml data, MiniYaml defaults)
 		{
+			var tilesetFilenamesPatternNode = data.NodeWithKeyOrDefault(TilesetFilenamesPattern.Key) ?? defaults.NodeWithKeyOrDefault(TilesetFilenamesPattern.Key);
+			if (tilesetFilenamesPatternNode != null)
+			{
+				var tilesetNode = tilesetFilenamesPatternNode.Value.NodeWithKeyOrDefault(tileset);
+				if (tilesetNode != null)
+				{
+					var patternStart = LoadField("Start", 0, tilesetNode.Value);
+					var patternCount = LoadField("Count", 1, tilesetNode.Value);
+
+					return Enumerable.Range(patternStart, patternCount).Select(i =>
+						new ReservationInfo(tilesetNode.Value.Value.FormatInvariant(i), FirstFrame, FirstFrame, tilesetNode.Location));
+				}
+			}
+
 			var node = data.NodeWithKeyOrDefault(TilesetFilenames.Key) ?? defaults.NodeWithKeyOrDefault(TilesetFilenames.Key);
 			if (node != null)
 			{


### PR DESCRIPTION
Backported from TDHD, this gives modders/mappers a simpler solution for multi-frame pngs.