### PR TITLE
Installers: Fix Steam library manifest parsing.

### DIFF
--- a/OpenRA.Mods.Common/Installer/SourceResolvers/SteamSourceResolver.cs
+++ b/OpenRA.Mods.Common/Installer/SourceResolvers/SteamSourceResolver.cs
@@ -109,8 +109,13 @@ namespace OpenRA.Mods.Common.Installer
 					continue;
 
 				foreach (var e in ParseLibraryManifest(libraryFoldersPath).Where(e => e.Item1 == "path"))
-					yield return e.Item2;
+					yield return Unescape(e.Item2);
 			}
+		}
+
+		static string Unescape(string path)
+		{
+			return path.Replace(@"\\", @"\");
 		}
 
 		static Dictionary<string, string> ParseGameManifest(string path)


### PR DESCRIPTION
Fixes #21129.
Steam library paths stored in manifest files have escaped backslashes on Windows and need to be unescaped. This either never worked on Windows or regressed since it was implemented.
