### PR TITLE
Remove legacy OpenGL support.

### DIFF
--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -20,13 +20,12 @@ namespace OpenRA
 		Automatic,
 		ANGLE,
 		Modern,
-		Embedded,
-		Legacy
+		Embedded
 	}
 
 	public interface IPlatform
 	{
-		IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int vertexBatchSize, int indexBatchSize, int videoDisplay, GLProfile profile, bool enableLegacyGL);
+		IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int vertexBatchSize, int indexBatchSize, int videoDisplay, GLProfile profile);
 		ISoundEngine CreateSound(string device);
 		IFont CreateFont(byte[] data);
 	}

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -82,7 +82,7 @@ namespace OpenRA
 
 			Window = platform.CreateWindow(new Size(resolution.Width, resolution.Height),
 				graphicSettings.Mode, graphicSettings.UIScale, TempVertexBufferSize, TempIndexBufferSize,
-				graphicSettings.VideoDisplay, graphicSettings.GLProfile, !graphicSettings.DisableLegacyGL);
+				graphicSettings.VideoDisplay, graphicSettings.GLProfile);
 
 			Context = Window.Context;
 

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -210,9 +210,6 @@ namespace OpenRA
 		[Desc("Disable operating-system provided cursor rendering.")]
 		public bool DisableHardwareCursors = false;
 
-		[Desc("Disable legacy OpenGL 2.1 support.")]
-		public bool DisableLegacyGL = true;
-
 		[Desc("Display index to use in a multi-monitor fullscreen setup.")]
 		public int VideoDisplay = 0;
 

--- a/OpenRA.Platforms.Default/DefaultPlatform.cs
+++ b/OpenRA.Platforms.Default/DefaultPlatform.cs
@@ -16,9 +16,9 @@ namespace OpenRA.Platforms.Default
 {
 	public class DefaultPlatform : IPlatform
 	{
-		public IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int vertexBatchSize, int indexBatchSize, int videoDisplay, GLProfile profile, bool enableLegacyGL)
+		public IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int vertexBatchSize, int indexBatchSize, int videoDisplay, GLProfile profile)
 		{
-			return new Sdl2PlatformWindow(size, windowMode, scaleModifier, vertexBatchSize, indexBatchSize, videoDisplay, profile, enableLegacyGL);
+			return new Sdl2PlatformWindow(size, windowMode, scaleModifier, vertexBatchSize, indexBatchSize, videoDisplay, profile);
 		}
 
 		public ISoundEngine CreateSound(string device)

--- a/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
@@ -40,16 +40,13 @@ namespace OpenRA.Platforms.Default
 			if (SDL.SDL_GL_MakeCurrent(window.Window, context) < 0)
 				throw new InvalidOperationException($"Can not bind OpenGL context. (Error: {SDL.SDL_GetError()})");
 
-			OpenGL.Initialize(window.GLProfile == GLProfile.Legacy);
+			OpenGL.Initialize();
 			OpenGL.CheckGLError();
 
-			if (OpenGL.Profile != GLProfile.Legacy)
-			{
-				OpenGL.glGenVertexArrays(1, out var vao);
-				OpenGL.CheckGLError();
-				OpenGL.glBindVertexArray(vao);
-				OpenGL.CheckGLError();
-			}
+			OpenGL.glGenVertexArrays(1, out var vao);
+			OpenGL.CheckGLError();
+			OpenGL.glBindVertexArray(vao);
+			OpenGL.CheckGLError();
 		}
 
 		public IVertexBuffer<T> CreateVertexBuffer<T>(int size) where T : struct

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -133,7 +133,7 @@ namespace OpenRA.Platforms.Default
 		static extern IntPtr XFlush(IntPtr display);
 
 		public Sdl2PlatformWindow(Size requestEffectiveWindowSize, WindowMode windowMode,
-			float scaleModifier, int vertexBatchSize, int indexBatchSize, int videoDisplay, GLProfile requestProfile, bool enableLegacyGL)
+			float scaleModifier, int vertexBatchSize, int indexBatchSize, int videoDisplay, GLProfile requestProfile)
 		{
 			// Lock the Window/Surface properties until initialization is complete
 			lock (syncObject)
@@ -147,9 +147,6 @@ namespace OpenRA.Platforms.Default
 				// Decide which OpenGL profile to use.
 				// Prefer standard GL over GLES provided by the native driver
 				var testProfiles = new List<GLProfile> { GLProfile.ANGLE, GLProfile.Modern, GLProfile.Embedded };
-				if (enableLegacyGL)
-					testProfiles.Add(GLProfile.Legacy);
-
 				var errorLog = new List<string>();
 				supportedProfiles = testProfiles
 					.Where(profile => CanCreateGLWindow(profile, errorLog))
@@ -536,10 +533,6 @@ namespace OpenRA.Platforms.Default
 					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_MAJOR_VERSION, 3);
 					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_MINOR_VERSION, 0);
 					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_PROFILE_MASK, (int)SDL.SDL_GLprofile.SDL_GL_CONTEXT_PROFILE_ES);
-					break;
-				case GLProfile.Legacy:
-					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_MAJOR_VERSION, 2);
-					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_MINOR_VERSION, 1);
 					break;
 			}
 		}

--- a/glsl/combined.frag
+++ b/glsl/combined.frag
@@ -19,27 +19,6 @@ uniform vec2 DepthPreviewParams;
 uniform float DepthTextureScale;
 uniform float AntialiasPixelsPerTexel;
 
-#if __VERSION__ == 120
-varying vec4 vTexCoord;
-varying vec2 vTexMetadata;
-varying vec4 vChannelMask;
-varying vec4 vDepthMask;
-varying vec2 vTexSampler;
-
-varying vec4 vColorFraction;
-varying vec4 vRGBAFraction;
-varying vec4 vPalettedFraction;
-varying vec4 vTint;
-
-uniform vec2 Texture0Size;
-uniform vec2 Texture1Size;
-uniform vec2 Texture2Size;
-uniform vec2 Texture3Size;
-uniform vec2 Texture4Size;
-uniform vec2 Texture5Size;
-uniform vec2 Texture6Size;
-uniform vec2 Texture7Size;
-#else
 in vec4 vColor;
 
 in vec4 vTexCoord;
@@ -54,7 +33,6 @@ in vec4 vPalettedFraction;
 in vec4 vTint;
 
 out vec4 fragColor;
-#endif
 
 vec3 rgb2hsv(vec3 c)
 {
@@ -99,47 +77,6 @@ vec4 linear2srgb(vec4 c)
 	return c.a * vec4(linear2srgb(c.r / c.a), linear2srgb(c.g / c.a), linear2srgb(c.b / c.a), 1.0f);
 }
 
-#if __VERSION__ == 120
-vec2 Size(float samplerIndex)
-{
-	if (samplerIndex < 0.5)
-		return Texture0Size;
-	else if (samplerIndex < 1.5)
-		return Texture1Size;
-	else if (samplerIndex < 2.5)
-		return Texture2Size;
-	else if (samplerIndex < 3.5)
-		return Texture3Size;
-	else if (samplerIndex < 4.5)
-		return Texture4Size;
-	else if (samplerIndex < 5.5)
-		return Texture5Size;
-	else if (samplerIndex < 6.5)
-		return Texture6Size;
-
-	return Texture7Size;
-}
-
-vec4 Sample(float samplerIndex, vec2 pos)
-{
-	if (samplerIndex < 0.5)
-		return texture2D(Texture0, pos);
-	else if (samplerIndex < 1.5)
-		return texture2D(Texture1, pos);
-	else if (samplerIndex < 2.5)
-		return texture2D(Texture2, pos);
-	else if (samplerIndex < 3.5)
-		return texture2D(Texture3, pos);
-	else if (samplerIndex < 4.5)
-		return texture2D(Texture4, pos);
-	else if (samplerIndex < 5.5)
-		return texture2D(Texture5, pos);
-	else if (samplerIndex < 6.5)
-		return texture2D(Texture6, pos);
-
-	return texture2D(Texture7, pos);
-}
-#else
 ivec2 Size(float samplerIndex)
 {
 	if (samplerIndex < 0.5)
@@ -179,7 +116,6 @@ vec4 Sample(float samplerIndex, vec2 pos)
 
 	return texture(Texture7, pos);
 }
-#endif
 
 vec4 SamplePalettedBilinear(float samplerIndex, vec2 coords, vec2 textureSize)
 {
@@ -193,30 +129,18 @@ vec4 SamplePalettedBilinear(float samplerIndex, vec2 coords, vec2 textureSize)
 	vec4 x3 = Sample(samplerIndex, tl + vec2(0., px.y));
 	vec4 x4 = Sample(samplerIndex, tl + px);
 
-	#if __VERSION__ == 120
-	vec4 c1 = texture2D(Palette, vec2(dot(x1, vChannelMask), vTexMetadata.s));
-	vec4 c2 = texture2D(Palette, vec2(dot(x2, vChannelMask), vTexMetadata.s));
-	vec4 c3 = texture2D(Palette, vec2(dot(x3, vChannelMask), vTexMetadata.s));
-	vec4 c4 = texture2D(Palette, vec2(dot(x4, vChannelMask), vTexMetadata.s));
-	#else
 	vec4 c1 = texture(Palette, vec2(dot(x1, vChannelMask), vTexMetadata.s));
 	vec4 c2 = texture(Palette, vec2(dot(x2, vChannelMask), vTexMetadata.s));
 	vec4 c3 = texture(Palette, vec2(dot(x3, vChannelMask), vTexMetadata.s));
 	vec4 c4 = texture(Palette, vec2(dot(x4, vChannelMask), vTexMetadata.s));
-	#endif
 
 	return mix(mix(c1, c2, interp.x), mix(c3, c4, interp.x), interp.y);
 }
 
 vec4 ColorShift(vec4 c, float p)
 {
-	#if __VERSION__ == 120
-	vec4 range = texture2D(ColorShifts, vec2(0.25, p));
- 	vec4 shift = texture2D(ColorShifts, vec2(0.75, p));
-	#else
 	vec4 range = texture(ColorShifts, vec2(0.25, p));
  	vec4 shift = texture(ColorShifts, vec2(0.75, p));
-	#endif
 
 	vec3 hsv = rgb2hsv(srgb2linear(c).rgb);
 	if (hsv.r > range.r && range.g >= hsv.r)
@@ -251,11 +175,7 @@ void main()
 	{
 		vec4 x = Sample(vTexSampler.s, coords);
 		vec2 p = vec2(dot(x, vChannelMask), vTexMetadata.s);
-		#if __VERSION__ == 120
-		c = vPalettedFraction * texture2D(Palette, p) + vRGBAFraction * x + vColorFraction * vTexCoord;
-		#else
 		c = vPalettedFraction * texture(Palette, p) + vRGBAFraction * x + vColorFraction * vTexCoord;
-		#endif
 	}
 
 	// Discard any transparent fragments (both color and depth)
@@ -277,12 +197,7 @@ void main()
 	if (EnableDepthPreview)
 	{
 		float intensity = 1.0 - clamp(DepthPreviewParams.x * depth - 0.5 * DepthPreviewParams.x - DepthPreviewParams.y + 0.5, 0.0, 1.0);
-
-		#if __VERSION__ == 120
-		gl_FragColor = vec4(vec3(intensity), 1.0);
-		#else
 		fragColor = vec4(vec3(intensity), 1.0);
-		#endif
 	}
 	else
 	{
@@ -292,10 +207,6 @@ void main()
 		else
 			c *= vTint;
 
-		#if __VERSION__ == 120
-		gl_FragColor = c;
-		#else
 		fragColor = c;
-		#endif
 	}
 }

--- a/glsl/combined.vert
+++ b/glsl/combined.vert
@@ -3,23 +3,6 @@
 uniform vec3 Scroll;
 uniform vec3 p1, p2;
 
-#if __VERSION__ == 120
-attribute vec3 aVertexPosition;
-attribute vec4 aVertexTexCoord;
-attribute vec2 aVertexTexMetadata;
-attribute vec4 aVertexTint;
-
-varying vec4 vTexCoord;
-varying vec2 vTexMetadata;
-varying vec4 vChannelMask;
-varying vec4 vDepthMask;
-varying vec2 vTexSampler;
-
-varying vec4 vColorFraction;
-varying vec4 vRGBAFraction;
-varying vec4 vPalettedFraction;
-varying vec4 vTint;
-#else
 in vec3 aVertexPosition;
 in vec4 aVertexTexCoord;
 in vec2 aVertexTexMetadata;
@@ -35,7 +18,6 @@ out vec4 vColorFraction;
 out vec4 vRGBAFraction;
 out vec4 vPalettedFraction;
 out vec4 vTint;
-#endif
 
 vec4 UnpackChannelAttributes(float x)
 {

--- a/glsl/model.frag
+++ b/glsl/model.frag
@@ -9,30 +9,13 @@ uniform vec2 PaletteRows;
 uniform vec4 LightDirection;
 uniform vec3 AmbientLight, DiffuseLight;
 
-#if __VERSION__ == 120
-varying vec4 vTexCoord;
-varying vec4 vChannelMask;
-varying vec4 vNormalsMask;
-#else
 in vec4 vTexCoord;
 in vec4 vChannelMask;
 in vec4 vNormalsMask;
 out vec4 fragColor;
-#endif
 
 void main()
 {
-	#if __VERSION__ == 120
-	vec4 x = texture2D(DiffuseTexture, vTexCoord.st);
-	vec4 color = texture2D(Palette, vec2(dot(x, vChannelMask), PaletteRows.x));
-	if (color.a < 0.01)
-		discard;
-
-	vec4 y = texture2D(DiffuseTexture, vTexCoord.pq);
-	vec4 normal = (2.0 * texture2D(Palette, vec2(dot(y, vNormalsMask), PaletteRows.y)) - 1.0);
-	vec3 intensity = AmbientLight + DiffuseLight * max(dot(normal, LightDirection), 0.0);
-	gl_FragColor = vec4(intensity * color.rgb, color.a);
-	#else
 	vec4 x = texture(DiffuseTexture, vTexCoord.st);
 	vec4 color = texture(Palette, vec2(dot(x, vChannelMask), PaletteRows.x));
 	if (color.a < 0.01)
@@ -42,5 +25,4 @@ void main()
 	vec4 normal = (2.0 * texture(Palette, vec2(dot(y, vNormalsMask), PaletteRows.y)) - 1.0);
 	vec3 intensity = AmbientLight + DiffuseLight * max(dot(normal, LightDirection), 0.0);
 	fragColor = vec4(intensity * color.rgb, color.a);
-	#endif
 }

--- a/glsl/model.vert
+++ b/glsl/model.vert
@@ -3,21 +3,12 @@
 uniform mat4 View;
 uniform mat4 TransformMatrix;
 
-#if __VERSION__ == 120
-attribute vec4 aVertexPosition;
-attribute vec4 aVertexTexCoord;
-attribute vec2 aVertexTexMetadata;
-varying vec4 vTexCoord;
-varying vec4 vChannelMask;
-varying vec4 vNormalsMask;
-#else
 in vec4 aVertexPosition;
 in vec4 aVertexTexCoord;
 in vec2 aVertexTexMetadata;
 out vec4 vTexCoord;
 out vec4 vChannelMask;
 out vec4 vNormalsMask;
-#endif
 
 vec4 DecodeMask(float x)
 {

--- a/glsl/postprocess.vert
+++ b/glsl/postprocess.vert
@@ -1,10 +1,6 @@
 #version {VERSION}
 
-#if __VERSION__ == 120
-attribute vec2 aVertexPosition;
-#else
 in vec2 aVertexPosition;
-#endif
 
 void main()
 {

--- a/glsl/postprocess_chronoshift.frag
+++ b/glsl/postprocess_chronoshift.frag
@@ -5,27 +5,11 @@ precision mediump float;
 
 uniform float Blend;
 uniform sampler2D WorldTexture;
-
-#if __VERSION__ == 120
-uniform vec2 WorldTextureSize;
-#else
 out vec4 fragColor;
-#endif
 
 void main()
 {
-#if __VERSION__ == 120
-	vec4 c = texture2D(WorldTexture, gl_FragCoord.xy / WorldTextureSize);
-#else
 	vec4 c = texture(WorldTexture, gl_FragCoord.xy / textureSize(WorldTexture, 0));
-#endif
-
 	float lum = 0.5 * (min(c.r, min(c.g, c.b)) + max(c.r, max(c.g, c.b)));
-	c = vec4(lum, lum, lum, c.a) * Blend + c * (1.0 - Blend);
-
-	#if __VERSION__ == 120
-	gl_FragColor = c;
-	#else
-	fragColor = c;
-	#endif
+	fragColor = vec4(lum, lum, lum, c.a) * Blend + c * (1.0 - Blend);
 }

--- a/glsl/postprocess_flash.frag
+++ b/glsl/postprocess_flash.frag
@@ -6,26 +6,10 @@ precision mediump float;
 uniform float Blend;
 uniform vec3 Color;
 uniform sampler2D WorldTexture;
-
-#if __VERSION__ == 120
-uniform vec2 WorldTextureSize;
-#else
 out vec4 fragColor;
-#endif
 
 void main()
 {
-#if __VERSION__ == 120
-	vec4 c = texture2D(WorldTexture, gl_FragCoord.xy / WorldTextureSize);
-#else
 	vec4 c = texture(WorldTexture, gl_FragCoord.xy / textureSize(WorldTexture, 0));
-#endif
-
-	c = vec4(Color, c.a) * Blend + c * (1.0 - Blend);
-
-	#if __VERSION__ == 120
-	gl_FragColor = c;
-	#else
-	fragColor = c;
-	#endif
+	fragColor = vec4(Color, c.a) * Blend + c * (1.0 - Blend);
 }

--- a/glsl/postprocess_menufade.frag
+++ b/glsl/postprocess_menufade.frag
@@ -7,12 +7,7 @@ uniform float From;
 uniform float To;
 uniform float Blend;
 uniform sampler2D WorldTexture;
-
-#if __VERSION__ == 120
-uniform vec2 WorldTextureSize;
-#else
 out vec4 fragColor;
-#endif
 
 vec4 ColorForEffect(float effect, vec4 c)
 {
@@ -32,16 +27,6 @@ vec4 ColorForEffect(float effect, vec4 c)
 
 void main()
 {
-#if __VERSION__ == 120
-	vec4 c = texture2D(WorldTexture, gl_FragCoord.xy / WorldTextureSize);
-#else
 	vec4 c = texture(WorldTexture, gl_FragCoord.xy / textureSize(WorldTexture, 0));
-#endif
-	c = ColorForEffect(From, c) * Blend + ColorForEffect(To, c) * (1.0 - Blend);
-
-	#if __VERSION__ == 120
-	gl_FragColor = c;
-	#else
-	fragColor = c;
-	#endif
+	fragColor = ColorForEffect(From, c) * Blend + ColorForEffect(To, c) * (1.0 - Blend);
 }

--- a/glsl/postprocess_tint.frag
+++ b/glsl/postprocess_tint.frag
@@ -5,26 +5,10 @@ precision mediump float;
 
 uniform vec3 Tint;
 uniform sampler2D WorldTexture;
-
-#if __VERSION__ == 120
-uniform vec2 WorldTextureSize;
-#else
 out vec4 fragColor;
-#endif
 
 void main()
 {
-#if __VERSION__ == 120
-	vec4 c = texture2D(WorldTexture, gl_FragCoord.xy / WorldTextureSize);
-#else
 	vec4 c = texture(WorldTexture, gl_FragCoord.xy / textureSize(WorldTexture, 0));
-#endif
-
-	c = vec4(min(c.r * Tint.r, 1.0), min(c.g * Tint.g, 1.0), min(c.b * Tint.b, 1.0), c.a);
-
-	#if __VERSION__ == 120
-	gl_FragColor = c;
-	#else
-	fragColor = c;
-	#endif
+	fragColor = vec4(min(c.r * Tint.r, 1.0), min(c.g * Tint.g, 1.0), min(c.b * Tint.b, 1.0), c.a);
 }


### PR DESCRIPTION
With #21142 and its future followups adding many new shaders, support for the legacy GLSL version is becoming increasingly awkward to maintain.

The sysinfo database (downloaded before `release-20231010` was released) showed that only 29 out of the 45302 sysinfo entries (0.06%) on `release-20230225` were using this fallback, so this feels like a good time to make the jump.