### PR TITLE
Introduce integer vertex attributes

### DIFF
--- a/OpenRA.Game/Graphics/ModelVertex.cs
+++ b/OpenRA.Game/Graphics/ModelVertex.cs
@@ -45,9 +45,9 @@ namespace OpenRA.Graphics
 
 		public override ShaderVertexAttribute[] Attributes { get; }	= new[]
 		{
-			new ShaderVertexAttribute("aVertexPosition", 3, 0),
-			new ShaderVertexAttribute("aVertexTexCoord", 4, 12),
-			new ShaderVertexAttribute("aVertexTexMetadata", 2, 28),
+			new ShaderVertexAttribute("aVertexPosition", ShaderVertexAttributeType.Float, 3, 0),
+			new ShaderVertexAttribute("aVertexTexCoord", ShaderVertexAttributeType.Float, 4, 12),
+			new ShaderVertexAttribute("aVertexTexMetadata", ShaderVertexAttributeType.Float, 2, 28),
 		};
 	}
 }

--- a/OpenRA.Game/Graphics/PaletteReference.cs
+++ b/OpenRA.Game/Graphics/PaletteReference.cs
@@ -13,19 +13,17 @@ namespace OpenRA.Graphics
 {
 	public sealed class PaletteReference
 	{
-		readonly float index;
 		readonly HardwarePalette hardwarePalette;
 
 		public readonly string Name;
 		public IPalette Palette { get; internal set; }
-		public float TextureIndex => index / hardwarePalette.Height;
-		public float TextureMidIndex => (index + 0.5f) / hardwarePalette.Height;
+		public int TextureIndex { get; }
 
 		public PaletteReference(string name, int index, IPalette palette, HardwarePalette hardwarePalette)
 		{
 			Name = name;
 			Palette = palette;
-			this.index = index;
+			TextureIndex = index;
 			this.hardwarePalette = hardwarePalette;
 		}
 

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -107,7 +107,7 @@ namespace OpenRA
 	{
 		void BeginFrame();
 		void EndFrame();
-		void SetPalette(ITexture palette);
+		void SetPalette(HardwarePalette palette);
 	}
 
 	public interface IVertexBuffer<T> : IDisposable where T : struct

--- a/OpenRA.Game/Graphics/RenderPostProcessPassVertex.cs
+++ b/OpenRA.Game/Graphics/RenderPostProcessPassVertex.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Graphics
 
 		public override ShaderVertexAttribute[] Attributes { get; } = new[]
 		{
-			new ShaderVertexAttribute("aVertexPosition", 2, 0)
+			new ShaderVertexAttribute("aVertexPosition", ShaderVertexAttributeType.Float, 2, 0)
 		};
 	}
 }

--- a/OpenRA.Game/Graphics/RgbaColorRenderer.cs
+++ b/OpenRA.Game/Graphics/RgbaColorRenderer.cs
@@ -45,10 +45,10 @@ namespace OpenRA.Graphics
 			var eb = endColor.B / 255.0f;
 			var ea = endColor.A / 255.0f;
 
-			vertices[0] = new Vertex(start - corner + Offset, sr, sg, sb, sa, 0, 0);
-			vertices[1] = new Vertex(start + corner + Offset, sr, sg, sb, sa, 0, 0);
-			vertices[2] = new Vertex(end + corner + Offset, er, eg, eb, ea, 0, 0);
-			vertices[3] = new Vertex(end - corner + Offset, er, eg, eb, ea, 0, 0);
+			vertices[0] = new Vertex(start - corner + Offset, sr, sg, sb, sa, 0);
+			vertices[1] = new Vertex(start + corner + Offset, sr, sg, sb, sa, 0);
+			vertices[2] = new Vertex(end + corner + Offset, er, eg, eb, ea, 0);
+			vertices[3] = new Vertex(end - corner + Offset, er, eg, eb, ea, 0);
 
 			parent.DrawRGBAQuad(vertices, blendMode);
 		}
@@ -64,10 +64,10 @@ namespace OpenRA.Graphics
 			var b = color.B / 255.0f;
 			var a = color.A / 255.0f;
 
-			vertices[0] = new Vertex(start - corner + Offset, r, g, b, a, 0, 0);
-			vertices[1] = new Vertex(start + corner + Offset, r, g, b, a, 0, 0);
-			vertices[2] = new Vertex(end + corner + Offset, r, g, b, a, 0, 0);
-			vertices[3] = new Vertex(end - corner + Offset, r, g, b, a, 0, 0);
+			vertices[0] = new Vertex(start - corner + Offset, r, g, b, a, 0);
+			vertices[1] = new Vertex(start + corner + Offset, r, g, b, a, 0);
+			vertices[2] = new Vertex(end + corner + Offset, r, g, b, a, 0);
+			vertices[3] = new Vertex(end - corner + Offset, r, g, b, a, 0);
 			parent.DrawRGBAQuad(vertices, blendMode);
 		}
 
@@ -153,10 +153,10 @@ namespace OpenRA.Graphics
 				var cd = closed || i < limit - 1 ? IntersectionOf(end - corner, dir, end - nextCorner, nextDir) : end - corner;
 
 				// Fill segment
-				vertices[0] = new Vertex(ca + Offset, r, g, b, a, 0, 0);
-				vertices[1] = new Vertex(cb + Offset, r, g, b, a, 0, 0);
-				vertices[2] = new Vertex(cc + Offset, r, g, b, a, 0, 0);
-				vertices[3] = new Vertex(cd + Offset, r, g, b, a, 0, 0);
+				vertices[0] = new Vertex(ca + Offset, r, g, b, a, 0);
+				vertices[1] = new Vertex(cb + Offset, r, g, b, a, 0);
+				vertices[2] = new Vertex(cc + Offset, r, g, b, a, 0);
+				vertices[3] = new Vertex(cd + Offset, r, g, b, a, 0);
 				parent.DrawRGBAQuad(vertices, blendMode);
 
 				// Advance line segment
@@ -209,10 +209,10 @@ namespace OpenRA.Graphics
 			var cb = color.B / 255.0f;
 			var ca = color.A / 255.0f;
 
-			vertices[0] = new Vertex(a + Offset, cr, cg, cb, ca, 0, 0);
-			vertices[1] = new Vertex(b + Offset, cr, cg, cb, ca, 0, 0);
-			vertices[2] = new Vertex(c + Offset, cr, cg, cb, ca, 0, 0);
-			vertices[3] = new Vertex(d + Offset, cr, cg, cb, ca, 0, 0);
+			vertices[0] = new Vertex(a + Offset, cr, cg, cb, ca, 0);
+			vertices[1] = new Vertex(b + Offset, cr, cg, cb, ca, 0);
+			vertices[2] = new Vertex(c + Offset, cr, cg, cb, ca, 0);
+			vertices[3] = new Vertex(d + Offset, cr, cg, cb, ca, 0);
 			parent.DrawRGBAQuad(vertices, blendMode);
 		}
 
@@ -234,7 +234,7 @@ namespace OpenRA.Graphics
 			var cb = color.B / 255.0f;
 			var ca = color.A / 255.0f;
 
-			return new Vertex(xyz, cr, cg, cb, ca, 0, 0);
+			return new Vertex(xyz, cr, cg, cb, ca, 0);
 		}
 
 		public void FillEllipse(in float3 tl, in float3 br, Color color, BlendMode blendMode = BlendMode.Alpha)

--- a/OpenRA.Game/Graphics/ShaderBindings.cs
+++ b/OpenRA.Game/Graphics/ShaderBindings.cs
@@ -14,15 +14,26 @@ using System.Linq;
 
 namespace OpenRA.Graphics
 {
+	public enum ShaderVertexAttributeType
+	{
+		// Assign the underlying OpenGL type values
+		// to simplify enum use in the shader
+		Float = 0x1406, // GL_FLOAT
+		Int = 0x1404, // GL_INT
+		UInt = 0x1405 // GL_UNSIGNED_INT
+	}
+
 	public readonly struct ShaderVertexAttribute
 	{
 		public readonly string Name;
+		public readonly ShaderVertexAttributeType Type;
 		public readonly int Components;
 		public readonly int Offset;
 
-		public ShaderVertexAttribute(string name, int components, int offset)
+		public ShaderVertexAttribute(string name, ShaderVertexAttributeType type, int components, int offset)
 		{
 			Name = name;
+			Type = type;
 			Components = components;
 			Offset = offset;
 		}

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Graphics
 			return new int2(sheetIndex, secondarySheetIndex);
 		}
 
-		static float ResolveTextureIndex(Sprite s, PaletteReference pal)
+		static int ResolveTextureIndex(Sprite s, PaletteReference pal)
 		{
 			if (pal == null)
 				return 0;
@@ -129,7 +129,7 @@ namespace OpenRA.Graphics
 			return pal.TextureIndex;
 		}
 
-		internal void DrawSprite(Sprite s, float paletteTextureIndex, in float3 location, in float3 scale, float rotation = 0f)
+		internal void DrawSprite(Sprite s, int paletteTextureIndex, in float3 location, in float3 scale, float rotation = 0f)
 		{
 			var samplers = SetRenderStateForSprite(s);
 			Util.FastCreateQuad(vertices, location + scale * s.Offset, s, samplers, paletteTextureIndex, vertexCount, scale * s.Size, float3.Ones,
@@ -137,7 +137,7 @@ namespace OpenRA.Graphics
 			vertexCount += 4;
 		}
 
-		internal void DrawSprite(Sprite s, float paletteTextureIndex, in float3 location, float scale, float rotation = 0f)
+		internal void DrawSprite(Sprite s, int paletteTextureIndex, in float3 location, float scale, float rotation = 0f)
 		{
 			var samplers = SetRenderStateForSprite(s);
 			Util.FastCreateQuad(vertices, location + scale * s.Offset, s, samplers, paletteTextureIndex, vertexCount, scale * s.Size, float3.Ones,
@@ -150,7 +150,7 @@ namespace OpenRA.Graphics
 			DrawSprite(s, ResolveTextureIndex(s, pal), location, scale, rotation);
 		}
 
-		internal void DrawSprite(Sprite s, float paletteTextureIndex, in float3 location, float scale, in float3 tint, float alpha,
+		internal void DrawSprite(Sprite s, int paletteTextureIndex, in float3 location, float scale, in float3 tint, float alpha,
 			float rotation = 0f)
 		{
 			var samplers = SetRenderStateForSprite(s);
@@ -165,7 +165,7 @@ namespace OpenRA.Graphics
 			DrawSprite(s, ResolveTextureIndex(s, pal), location, scale, tint, alpha, rotation);
 		}
 
-		internal void DrawSprite(Sprite s, float paletteTextureIndex, in float3 a, in float3 b, in float3 c, in float3 d, in float3 tint, float alpha)
+		internal void DrawSprite(Sprite s, int paletteTextureIndex, in float3 a, in float3 b, in float3 c, in float3 d, in float3 tint, float alpha)
 		{
 			var samplers = SetRenderStateForSprite(s);
 			Util.FastCreateQuad(vertices, a, b, c, d, s, samplers, paletteTextureIndex, tint, alpha, vertexCount);
@@ -210,10 +210,11 @@ namespace OpenRA.Graphics
 			vertexCount += 4;
 		}
 
-		public void SetPalette(ITexture palette, ITexture colorShifts)
+		public void SetPalette(HardwarePalette palette)
 		{
-			shader.SetTexture("Palette", palette);
-			shader.SetTexture("ColorShifts", colorShifts);
+			shader.SetTexture("Palette", palette.Texture);
+			shader.SetTexture("ColorShifts", palette.ColorShifts);
+			shader.SetVec("PaletteRows", palette.Height);
 		}
 
 		public void SetViewportParams(Size sheetSize, int downscale, float depthMargin, int2 scroll)

--- a/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
+++ b/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
@@ -76,7 +76,8 @@ namespace OpenRA.Graphics
 			{
 				var v = vertices[i];
 				var p = palettes[i / 4]?.TextureIndex ?? 0;
-				vertices[i] = new Vertex(v.X, v.Y, v.Z, v.S, v.T, v.U, v.V, p, v.C, v.R, v.G, v.B, v.A);
+				var c = (uint)((p & 0xFFFF) << 16) | (v.C & 0xFFFF);
+				vertices[i] = new Vertex(v.X, v.Y, v.Z, v.S, v.T, v.U, v.V, c, v.R, v.G, v.B, v.A);
 			}
 
 			for (var row = 0; row < map.MapSize.Y; row++)
@@ -113,7 +114,7 @@ namespace OpenRA.Graphics
 				for (var i = 0; i < 4; i++)
 				{
 					var v = vertices[offset + i];
-					vertices[offset + i] = new Vertex(v.X, v.Y, v.Z, v.S, v.T, v.U, v.V, v.P, v.C, v.A * float3.Ones, v.A);
+					vertices[offset + i] = new Vertex(v.X, v.Y, v.Z, v.S, v.T, v.U, v.V, v.C, v.A * float3.Ones, v.A);
 				}
 
 				return;
@@ -138,7 +139,7 @@ namespace OpenRA.Graphics
 			for (var i = 0; i < 4; i++)
 			{
 				var v = vertices[offset + i];
-				vertices[offset + i] = new Vertex(v.X, v.Y, v.Z, v.S, v.T, v.U, v.V, v.P, v.C, v.A * weights[i], v.A);
+				vertices[offset + i] = new Vertex(v.X, v.Y, v.Z, v.S, v.T, v.U, v.V, v.C, v.A * weights[i], v.A);
 			}
 
 			dirtyRows.Add(uv.V);

--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -94,11 +94,13 @@ namespace OpenRA.Graphics
 				attribC |= samplers.Y << 9;
 			}
 
-			var fAttribC = (float)attribC;
-			vertices[nv] = new Vertex(a, r.Left, r.Top, sl, st, paletteTextureIndex, fAttribC, tint, alpha);
-			vertices[nv + 1] = new Vertex(b, r.Right, r.Top, sr, st, paletteTextureIndex, fAttribC, tint, alpha);
-			vertices[nv + 2] = new Vertex(c, r.Right, r.Bottom, sr, sb, paletteTextureIndex, fAttribC, tint, alpha);
-			vertices[nv + 3] = new Vertex(d, r.Left, r.Bottom, sl, sb, paletteTextureIndex, fAttribC, tint, alpha);
+			attribC |= (paletteTextureIndex & 0xFFFF) << 16;
+
+			var uAttribC = (uint)attribC;
+			vertices[nv] = new Vertex(a, r.Left, r.Top, sl, st, uAttribC, tint, alpha);
+			vertices[nv + 1] = new Vertex(b, r.Right, r.Top, sr, st, uAttribC, tint, alpha);
+			vertices[nv + 2] = new Vertex(c, r.Right, r.Bottom, sr, sb, uAttribC, tint, alpha);
+			vertices[nv + 3] = new Vertex(d, r.Left, r.Bottom, sl, sb, uAttribC, tint, alpha);
 		}
 
 		public static void FastCopyIntoChannel(Sprite dest, byte[] src, SpriteFrameType srcType)

--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Graphics
 			return indices;
 		}
 
-		public static void FastCreateQuad(Vertex[] vertices, in float3 o, Sprite r, int2 samplers, float paletteTextureIndex, int nv,
+		public static void FastCreateQuad(Vertex[] vertices, in float3 o, Sprite r, int2 samplers, int paletteTextureIndex, int nv,
 			in float3 size, in float3 tint, float alpha, float rotation = 0f)
 		{
 			float3 a, b, c, d;
@@ -72,7 +72,7 @@ namespace OpenRA.Graphics
 
 		public static void FastCreateQuad(Vertex[] vertices,
 			in float3 a, in float3 b, in float3 c, in float3 d,
-			Sprite r, int2 samplers, float paletteTextureIndex,
+			Sprite r, int2 samplers, int paletteTextureIndex,
 			in float3 tint, float alpha, int nv)
 		{
 			float sl = 0;

--- a/OpenRA.Game/Graphics/Vertex.cs
+++ b/OpenRA.Game/Graphics/Vertex.cs
@@ -23,26 +23,26 @@ namespace OpenRA.Graphics
 		public readonly float S, T, U, V;
 
 		// Palette and channel flags
-		public readonly float P, C;
+		public readonly uint C;
 
 		// Color tint
 		public readonly float R, G, B, A;
 
-		public Vertex(in float3 xyz, float s, float t, float u, float v, float p, float c)
-			: this(xyz.X, xyz.Y, xyz.Z, s, t, u, v, p, c, float3.Ones, 1f) { }
+		public Vertex(in float3 xyz, float s, float t, float u, float v, uint c)
+			: this(xyz.X, xyz.Y, xyz.Z, s, t, u, v, c, float3.Ones, 1f) { }
 
-		public Vertex(in float3 xyz, float s, float t, float u, float v, float p, float c, in float3 tint, float a)
-			: this(xyz.X, xyz.Y, xyz.Z, s, t, u, v, p, c, tint.X, tint.Y, tint.Z, a) { }
+		public Vertex(in float3 xyz, float s, float t, float u, float v, uint c, in float3 tint, float a)
+			: this(xyz.X, xyz.Y, xyz.Z, s, t, u, v, c, tint.X, tint.Y, tint.Z, a) { }
 
-		public Vertex(float x, float y, float z, float s, float t, float u, float v, float p, float c, in float3 tint, float a)
-			: this(x, y, z, s, t, u, v, p, c, tint.X, tint.Y, tint.Z, a) { }
+		public Vertex(float x, float y, float z, float s, float t, float u, float v, uint c, in float3 tint, float a)
+			: this(x, y, z, s, t, u, v, c, tint.X, tint.Y, tint.Z, a) { }
 
-		public Vertex(float x, float y, float z, float s, float t, float u, float v, float p, float c, float r, float g, float b, float a)
+		public Vertex(float x, float y, float z, float s, float t, float u, float v, uint c, float r, float g, float b, float a)
 		{
 			X = x; Y = y; Z = z;
 			S = s; T = t;
 			U = u; V = v;
-			P = p; C = c;
+			C = c;
 			R = r; G = g; B = b; A = a;
 		}
 	}
@@ -57,8 +57,8 @@ namespace OpenRA.Graphics
 		{
 			new ShaderVertexAttribute("aVertexPosition", ShaderVertexAttributeType.Float, 3, 0),
 			new ShaderVertexAttribute("aVertexTexCoord", ShaderVertexAttributeType.Float, 4, 12),
-			new ShaderVertexAttribute("aVertexTexMetadata", ShaderVertexAttributeType.Float, 2, 28),
-			new ShaderVertexAttribute("aVertexTint", ShaderVertexAttributeType.Float, 4, 36)
+			new ShaderVertexAttribute("aVertexAttributes", ShaderVertexAttributeType.UInt, 1, 28),
+			new ShaderVertexAttribute("aVertexTint", ShaderVertexAttributeType.Float, 4, 32)
 		};
 	}
 }

--- a/OpenRA.Game/Graphics/Vertex.cs
+++ b/OpenRA.Game/Graphics/Vertex.cs
@@ -55,10 +55,10 @@ namespace OpenRA.Graphics
 
 		public override ShaderVertexAttribute[] Attributes { get; }	= new[]
 		{
-			new ShaderVertexAttribute("aVertexPosition", 3, 0),
-			new ShaderVertexAttribute("aVertexTexCoord", 4, 12),
-			new ShaderVertexAttribute("aVertexTexMetadata", 2, 28),
-			new ShaderVertexAttribute("aVertexTint", 4, 36)
+			new ShaderVertexAttribute("aVertexPosition", ShaderVertexAttributeType.Float, 3, 0),
+			new ShaderVertexAttribute("aVertexTexCoord", ShaderVertexAttributeType.Float, 4, 12),
+			new ShaderVertexAttribute("aVertexTexMetadata", ShaderVertexAttributeType.Float, 2, 28),
+			new ShaderVertexAttribute("aVertexTint", ShaderVertexAttributeType.Float, 4, 36)
 		};
 	}
 }

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -333,6 +333,7 @@ namespace OpenRA.Graphics
 				// Make a copy of the world texture to avoid reading and writing on the same buffer
 				Game.Renderer.Flush();
 				postProcessTexture.SetDataFromReadBuffer(rect);
+				Game.Renderer.Flush();
 				pass.Draw(this, postProcessTexture);
 			}
 		}

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -303,11 +303,11 @@ namespace OpenRA
 			Flush();
 			currentPaletteTexture = palette.Texture;
 
-			SpriteRenderer.SetPalette(currentPaletteTexture, palette.ColorShifts);
-			WorldSpriteRenderer.SetPalette(currentPaletteTexture, palette.ColorShifts);
+			SpriteRenderer.SetPalette(palette);
+			WorldSpriteRenderer.SetPalette(palette);
 
 			foreach (var r in WorldRenderers)
-				r.SetPalette(currentPaletteTexture);
+				r.SetPalette(palette);
 		}
 
 		public void EndFrame(IInputHandler inputHandler)

--- a/OpenRA.Mods.Cnc/Traits/World/ModelRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/ModelRenderer.cs
@@ -65,9 +65,10 @@ namespace OpenRA.Mods.Cnc.Traits
 		SheetBuilder sheetBuilderForFrame;
 		bool isInFrame;
 
-		public void SetPalette(ITexture palette)
+		public void SetPalette(HardwarePalette palette)
 		{
-			shader.SetTexture("Palette", palette);
+			shader.SetTexture("Palette", palette.Texture);
+			shader.SetVec("PaletteRows", palette.Height);
 		}
 
 		public ModelRenderer(ModelRendererInfo info, Actor self)
@@ -226,12 +227,12 @@ namespace OpenRA.Mods.Cnc.Traits
 						var lightDirection = ExtractRotationVector(Util.MatrixMultiply(it, lightTransform));
 
 						Render(rd, ModelCache, Util.MatrixMultiply(transform, t), lightDirection,
-							lightAmbientColor, lightDiffuseColor, color.TextureMidIndex, normals.TextureMidIndex);
+							lightAmbientColor, lightDiffuseColor, color.TextureIndex, normals.TextureIndex);
 
 						// Disable shadow normals by forcing zero diffuse and identity ambient light
 						if (m.ShowShadow)
 							Render(rd, ModelCache, Util.MatrixMultiply(shadow, t), lightDirection,
-								ShadowAmbient, ShadowDiffuse, shadowPalette.TextureMidIndex, normals.TextureMidIndex);
+								ShadowAmbient, ShadowDiffuse, shadowPalette.TextureIndex, normals.TextureIndex);
 					}
 				}
 			}));
@@ -279,10 +280,10 @@ namespace OpenRA.Mods.Cnc.Traits
 			IModelCache cache,
 			float[] t, float[] lightDirection,
 			float[] ambientLight, float[] diffuseLight,
-			float colorPaletteTextureMidIndex, float normalsPaletteTextureMidIndex)
+			float colorPaletteTextureIndex, float normalsPaletteTextureIndex)
 		{
 			shader.SetTexture("DiffuseTexture", renderData.Sheet.GetTexture());
-			shader.SetVec("PaletteRows", colorPaletteTextureMidIndex, normalsPaletteTextureMidIndex);
+			shader.SetVec("Palettes", colorPaletteTextureIndex, normalsPaletteTextureIndex);
 			shader.SetMatrix("TransformMatrix", t);
 			shader.SetVec("LightDirection", lightDirection, 4);
 			shader.SetVec("AmbientLight", ambientLight, 3);

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -386,6 +386,10 @@ namespace OpenRA.Platforms.Default
 			int stride, IntPtr pointer);
 		public static VertexAttribPointer glVertexAttribPointer { get; private set; }
 
+		public delegate void VertexAttribIPointer(int index, int size, int type,
+			int stride, IntPtr pointer);
+		public static VertexAttribIPointer glVertexAttribIPointer { get; private set; }
+
 		public delegate void EnableVertexAttribArray(int index);
 		public static EnableVertexAttribArray glEnableVertexAttribArray { get; private set; }
 
@@ -595,6 +599,7 @@ namespace OpenRA.Platforms.Default
 				glDeleteBuffers = Bind<DeleteBuffers>("glDeleteBuffers");
 				glBindAttribLocation = Bind<BindAttribLocation>("glBindAttribLocation");
 				glVertexAttribPointer = Bind<VertexAttribPointer>("glVertexAttribPointer");
+				glVertexAttribIPointer = Bind<VertexAttribIPointer>("glVertexAttribIPointer");
 				glEnableVertexAttribArray = Bind<EnableVertexAttribArray>("glEnableVertexAttribArray");
 				glDisableVertexAttribArray = Bind<DisableVertexAttribArray>("glDisableVertexAttribArray");
 				glDrawArrays = Bind<DrawArrays>("glDrawArrays");

--- a/OpenRA.Platforms.Default/Shader.cs
+++ b/OpenRA.Platforms.Default/Shader.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using OpenRA.Graphics;
 
 namespace OpenRA.Platforms.Default
 {
@@ -135,7 +136,10 @@ namespace OpenRA.Platforms.Default
 			for (ushort i = 0; i < bindings.Attributes.Length; i++)
 			{
 				var attribute = bindings.Attributes[i];
-				OpenGL.glVertexAttribPointer(i, attribute.Components, OpenGL.GL_FLOAT, false, bindings.Stride, new IntPtr(attribute.Offset));
+				if (attribute.Type == ShaderVertexAttributeType.Float)
+					OpenGL.glVertexAttribPointer(i, attribute.Components, OpenGL.GL_FLOAT, false, bindings.Stride, new IntPtr(attribute.Offset));
+				else
+					OpenGL.glVertexAttribIPointer(i, attribute.Components, (int)attribute.Type, bindings.Stride, new IntPtr(attribute.Offset));
 				OpenGL.CheckGLError();
 			}
 		}

--- a/glsl/combined.frag
+++ b/glsl/combined.frag
@@ -22,7 +22,7 @@ uniform float AntialiasPixelsPerTexel;
 in vec4 vColor;
 
 in vec4 vTexCoord;
-in vec2 vTexMetadata;
+in float vTexPalette;
 in vec4 vChannelMask;
 in vec4 vDepthMask;
 in vec2 vTexSampler;
@@ -129,10 +129,10 @@ vec4 SamplePalettedBilinear(float samplerIndex, vec2 coords, vec2 textureSize)
 	vec4 x3 = Sample(samplerIndex, tl + vec2(0., px.y));
 	vec4 x4 = Sample(samplerIndex, tl + px);
 
-	vec4 c1 = texture(Palette, vec2(dot(x1, vChannelMask), vTexMetadata.s));
-	vec4 c2 = texture(Palette, vec2(dot(x2, vChannelMask), vTexMetadata.s));
-	vec4 c3 = texture(Palette, vec2(dot(x3, vChannelMask), vTexMetadata.s));
-	vec4 c4 = texture(Palette, vec2(dot(x4, vChannelMask), vTexMetadata.s));
+	vec4 c1 = texture(Palette, vec2(dot(x1, vChannelMask), vTexPalette));
+	vec4 c2 = texture(Palette, vec2(dot(x2, vChannelMask), vTexPalette));
+	vec4 c3 = texture(Palette, vec2(dot(x3, vChannelMask), vTexPalette));
+	vec4 c4 = texture(Palette, vec2(dot(x4, vChannelMask), vTexPalette));
 
 	return mix(mix(c1, c2, interp.x), mix(c3, c4, interp.x), interp.y);
 }
@@ -174,7 +174,7 @@ void main()
 	if (!(AntialiasPixelsPerTexel > 0.0 && vPalettedFraction.x > 0.0))
 	{
 		vec4 x = Sample(vTexSampler.s, coords);
-		vec2 p = vec2(dot(x, vChannelMask), vTexMetadata.s);
+		vec2 p = vec2(dot(x, vChannelMask), vTexPalette);
 		c = vPalettedFraction * texture(Palette, p) + vRGBAFraction * x + vColorFraction * vTexCoord;
 	}
 
@@ -182,8 +182,8 @@ void main()
 	if (c.a == 0.0)
 		discard;
 
-	if (vRGBAFraction.r > 0.0 && vTexMetadata.s > 0.0)
-		c = ColorShift(c, vTexMetadata.s);
+	if (vRGBAFraction.r > 0.0 && vTexPalette > 0.0)
+		c = ColorShift(c, vTexPalette);
 
 	float depth = gl_FragCoord.z;
 	if (length(vDepthMask) > 0.0)

--- a/glsl/combined.vert
+++ b/glsl/combined.vert
@@ -2,6 +2,7 @@
 
 uniform vec3 Scroll;
 uniform vec3 p1, p2;
+uniform float PaletteRows;
 
 in vec3 aVertexPosition;
 in vec4 aVertexTexCoord;
@@ -9,7 +10,7 @@ in vec2 aVertexTexMetadata;
 in vec4 aVertexTint;
 
 out vec4 vTexCoord;
-out vec2 vTexMetadata;
+out float vTexPalette;
 out vec4 vChannelMask;
 out vec4 vDepthMask;
 out vec2 vTexSampler;
@@ -100,7 +101,7 @@ void main()
 {
 	gl_Position = vec4((aVertexPosition - Scroll) * p1 + p2, 1);
 	vTexCoord = aVertexTexCoord;
-	vTexMetadata = aVertexTexMetadata;
+	vTexPalette = aVertexTexMetadata.s / PaletteRows;
 
 	vec4 attrib = UnpackChannelAttributes(aVertexTexMetadata.t);
 	vChannelMask = SelectChannelMask(attrib.s);

--- a/glsl/model.frag
+++ b/glsl/model.frag
@@ -4,7 +4,8 @@ precision mediump float;
 #endif
 
 uniform sampler2D Palette, DiffuseTexture;
-uniform vec2 PaletteRows;
+uniform vec2 Palettes;
+uniform float PaletteRows;
 
 uniform vec4 LightDirection;
 uniform vec3 AmbientLight, DiffuseLight;
@@ -17,12 +18,12 @@ out vec4 fragColor;
 void main()
 {
 	vec4 x = texture(DiffuseTexture, vTexCoord.st);
-	vec4 color = texture(Palette, vec2(dot(x, vChannelMask), PaletteRows.x));
+	vec4 color = texture(Palette, vec2(dot(x, vChannelMask), (Palettes.x + 0.5) / PaletteRows));
 	if (color.a < 0.01)
 		discard;
 
 	vec4 y = texture(DiffuseTexture, vTexCoord.pq);
-	vec4 normal = (2.0 * texture(Palette, vec2(dot(y, vNormalsMask), PaletteRows.y)) - 1.0);
+	vec4 normal = (2.0 * texture(Palette, vec2(dot(y, vNormalsMask), (Palettes.y + 0.5) / PaletteRows)) - 1.0);
 	vec3 intensity = AmbientLight + DiffuseLight * max(dot(normal, LightDirection), 0.0);
 	fragColor = vec4(intensity * color.rgb, color.a);
 }

--- a/glsl/postprocess_chronoshift.frag
+++ b/glsl/postprocess_chronoshift.frag
@@ -9,7 +9,7 @@ out vec4 fragColor;
 
 void main()
 {
-	vec4 c = texture(WorldTexture, gl_FragCoord.xy / textureSize(WorldTexture, 0));
+	vec4 c = texelFetch(WorldTexture, ivec2(gl_FragCoord.xy), 0);
 	float lum = 0.5 * (min(c.r, min(c.g, c.b)) + max(c.r, max(c.g, c.b)));
-	fragColor = vec4(lum, lum, lum, c.a) * Blend + c * (1.0 - Blend);
+	fragColor = mix(c, vec4(lum, lum, lum, c.a), Blend);
 }

--- a/glsl/postprocess_flash.frag
+++ b/glsl/postprocess_flash.frag
@@ -10,6 +10,6 @@ out vec4 fragColor;
 
 void main()
 {
-	vec4 c = texture(WorldTexture, gl_FragCoord.xy / textureSize(WorldTexture, 0));
-	fragColor = vec4(Color, c.a) * Blend + c * (1.0 - Blend);
+	vec4 c = texelFetch(WorldTexture, ivec2(gl_FragCoord.xy), 0);
+	fragColor = mix(c, vec4(Color, c.a), Blend);
 }

--- a/glsl/postprocess_menufade.frag
+++ b/glsl/postprocess_menufade.frag
@@ -27,6 +27,6 @@ vec4 ColorForEffect(float effect, vec4 c)
 
 void main()
 {
-	vec4 c = texture(WorldTexture, gl_FragCoord.xy / vec2(textureSize(WorldTexture, 0)));
-	fragColor = ColorForEffect(From, c) * Blend + ColorForEffect(To, c) * (1.0 - Blend);
+	vec4 c = texelFetch(WorldTexture, ivec2(gl_FragCoord.xy), 0);
+	fragColor = mix(ColorForEffect(To, c), ColorForEffect(From, c), Blend);
 }

--- a/glsl/postprocess_tint.frag
+++ b/glsl/postprocess_tint.frag
@@ -9,6 +9,6 @@ out vec4 fragColor;
 
 void main()
 {
-	vec4 c = texture(WorldTexture, gl_FragCoord.xy / textureSize(WorldTexture, 0));
-	fragColor = vec4(min(c.r * Tint.r, 1.0), min(c.g * Tint.g, 1.0), min(c.b * Tint.b, 1.0), c.a);
+	vec4 c = texelFetch(WorldTexture, ivec2(gl_FragCoord.xy), 0);
+	fragColor = vec4(Tint, c.a) * c;
 }


### PR DESCRIPTION
With GL 2.1 out of the picture, we are finally able to use integers and bitwise operations in shaders. This PR replaces the legacy workaround simulating a bitfield with a float to a real bitfield. This allows us to use the full 32 bits of storage, which I use to pack the palette row (as a 16 bit int) to shave 4 bytes off the vertex size.

I expect this should give a minor performance boost, but the focus is on shader readability and maintability.