### PR TITLE
Fix IRenderPostProcessPass texture unit binding.

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/RenderPostProcessPassBase.cs
+++ b/OpenRA.Mods.Common/Traits/World/RenderPostProcessPassBase.cs
@@ -44,9 +44,9 @@ namespace OpenRA.Mods.Common.Traits
 		bool IRenderPostProcessPass.Enabled => Enabled;
 		void IRenderPostProcessPass.Draw(WorldRenderer wr, ITexture worldTexture)
 		{
-			shader.PrepareRender();
 			shader.SetTexture("WorldTexture", worldTexture);
 			PrepareRender(wr, shader);
+			shader.PrepareRender();
 			renderer.DrawBatch(buffer, shader, 0, 6, PrimitiveType.TriangleList);
 		}
 


### PR DESCRIPTION
`shader.SetTexture()` caches state that is then submitted by `shader.PrepareRender()`. Calling them in the correct order ensures that we aren't copying pixels from the wrong texture (e.g. unit sprite sheets...)