### PR TITLE
Allow changing ZOffset of renderables in ActorPreviewPlaceBuildingPreview

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/ActorPreviewPlaceBuildingPreview.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ActorPreviewPlaceBuildingPreview.cs
@@ -33,6 +33,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Footprint types to draw above the actor preview.")]
 		public readonly PlaceBuildingCellType FootprintOverPreview = PlaceBuildingCellType.Invalid;
 
+		[Desc("Custom ZOffset of the rendered building preview.")]
+		public readonly int ZOffset = 0;
+
 		protected override IPlaceBuildingPreview CreatePreview(WorldRenderer wr, ActorInfo ai, TypeDictionary init)
 		{
 			return new ActorPreviewPlaceBuildingPreviewPreview(wr, ai, this, init);
@@ -82,10 +85,14 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var r in previewRenderables.OrderBy(WorldRenderer.RenderableZPositionComparisonKey))
 			{
+				var renderable = r;
 				if (info.PreviewAlpha < 1f && r is IModifyableRenderable mr)
-					yield return mr.WithAlpha(mr.Alpha * info.PreviewAlpha);
-				else
-					yield return r;
+					renderable = mr.WithAlpha(mr.Alpha * info.PreviewAlpha);
+
+				if (info.ZOffset != 0)
+					renderable = renderable.WithZOffset(info.ZOffset);
+
+				yield return renderable;
 			}
 
 			if (info.FootprintOverPreview != PlaceBuildingCellType.None)


### PR DESCRIPTION
PR enables modifying ZOffset at which actor preview renderables are rendered in `ActorPreviewPlaceBuildingPreview` trait.

Example usage in OpenE2140/OpenE2140#519.