### PR TITLE
Support loading sprites with pre-multiplied alpha.

### DIFF
--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -82,16 +82,16 @@ namespace OpenRA.Graphics
 			this.margin = margin;
 		}
 
-		public Sprite Add(ISpriteFrame frame) { return Add(frame.Data, frame.Type, frame.Size, 0, frame.Offset); }
-		public Sprite Add(byte[] src, SpriteFrameType type, Size size) { return Add(src, type, size, 0, float3.Zero); }
-		public Sprite Add(byte[] src, SpriteFrameType type, Size size, float zRamp, in float3 spriteOffset)
+		public Sprite Add(ISpriteFrame frame, bool premultiplied = false) { return Add(frame.Data, frame.Type, frame.Size, 0, frame.Offset, premultiplied); }
+		public Sprite Add(byte[] src, SpriteFrameType type, Size size, bool premultiplied = false) { return Add(src, type, size, 0, float3.Zero, premultiplied); }
+		public Sprite Add(byte[] src, SpriteFrameType type, Size size, float zRamp, in float3 spriteOffset, bool premultiplied = false)
 		{
 			// Don't bother allocating empty sprites
 			if (size.Width == 0 || size.Height == 0)
 				return new Sprite(Current, Rectangle.Empty, 0, spriteOffset, CurrentChannel, BlendMode.Alpha);
 
 			var rect = Allocate(size, zRamp, spriteOffset);
-			Util.FastCopyIntoChannel(rect, src, type);
+			Util.FastCopyIntoChannel(rect, src, type, premultiplied);
 			Current.CommitBufferedData();
 			return rect;
 		}

--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -103,7 +103,7 @@ namespace OpenRA.Graphics
 			vertices[nv + 3] = new Vertex(d, r.Left, r.Bottom, sl, sb, uAttribC, tint, alpha);
 		}
 
-		public static void FastCopyIntoChannel(Sprite dest, byte[] src, SpriteFrameType srcType)
+		public static void FastCopyIntoChannel(Sprite dest, byte[] src, SpriteFrameType srcType, bool premultiplied = false)
 		{
 			var destData = dest.Sheet.GetData();
 			var width = dest.Bounds.Width;
@@ -154,7 +154,10 @@ namespace OpenRA.Graphics
 								}
 
 								var cc = Color.FromArgb(a, r, g, b);
-								data[(y + j) * destStride + x + i] = PremultiplyAlpha(cc).ToArgb();
+								if (premultiplied)
+									data[(y + j) * destStride + x + i] = cc.ToArgb();
+								else
+									data[(y + j) * destStride + x + i] = PremultiplyAlpha(cc).ToArgb();
 							}
 						}
 					}


### PR DESCRIPTION
This PR adds engine support for `ISpriteSequence` implementations to opt-out of automatic alpha premultiplication. This is important for assets that are already natively premultiplied and otherwise render incorrectly.

Used by https://github.com/OpenRA/TiberianDawnHD/commit/ce297b52cbfdf5d5d7f684405f490caeb79ab07c to fix https://github.com/OpenRA/TiberianDawnHD/issues/28.