### PR TITLE
Fix ProductionTabsWidget not detecting ProductionQueue getting enabled/disabled during its lifetime

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public void Update(IEnumerable<ProductionQueue> allQueues)
 		{
-			var queues = allQueues.Where(q => q.Info.Group == Group).ToList();
+			var queues = allQueues.Where(q => q.Enabled && q.Info.Group == Group).ToList();
 			var tabs = new List<ProductionTab>();
 			var largestUsedName = 0;
 
@@ -104,6 +104,8 @@ namespace OpenRA.Mods.Common.Widgets
 		Rectangle rightButtonRect;
 		readonly Lazy<ProductionPaletteWidget> paletteWidget;
 		string queueGroup;
+
+		readonly List<(ProductionQueue Queue, bool Enabled)> cachedProductionQueueEnabledStates = new();
 
 		[ObjectCreator.UseCtor]
 		public ProductionTabsWidget(World world)
@@ -239,12 +241,16 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			if (a.Info.HasTraitInfo<ProductionQueueInfo>())
 			{
-				var allQueues = a.World.ActorsWithTrait<ProductionQueue>()
-					.Where(p => p.Actor.Owner == p.Actor.World.LocalPlayer && p.Actor.IsInWorld && p.Trait.Enabled)
-					.Select(p => p.Trait).ToList();
+				var queues = a.World.ActorsWithTrait<ProductionQueue>()
+					.Where(p => p.Actor.Owner == p.Actor.World.LocalPlayer && p.Actor.IsInWorld)
+					.Select(p => p.Trait);
+
+				cachedProductionQueueEnabledStates.Clear();
+				foreach (var queue in queues)
+					cachedProductionQueueEnabledStates.Add((queue, queue.Enabled));
 
 				foreach (var g in Groups.Values)
-					g.Update(allQueues);
+					g.Update(cachedProductionQueueEnabledStates.Select(t => t.Queue));
 
 				if (queueGroup == null)
 					return;
@@ -264,6 +270,22 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			if (leftPressed) Scroll(1);
 			if (rightPressed) Scroll(-1);
+
+			// It is possible that production queues get enabled/disabled during their lifetime.
+			// This makes sure every enabled production queue always has its tab associated with it.
+			var shouldUpdateQueues = false;
+			foreach (var (queue, enabled) in cachedProductionQueueEnabledStates)
+			{
+				if (queue.Enabled != enabled)
+				{
+					shouldUpdateQueues = true;
+					break;
+				}
+			}
+
+			if (shouldUpdateQueues)
+				foreach (var g in Groups.Values)
+					g.Update(cachedProductionQueueEnabledStates.Select(t => t.Queue));
 		}
 
 		public override bool YieldMouseFocus(MouseInput mi)


### PR DESCRIPTION
This is a fix for `ProductionTabsWidget` not picking up production queues' being enabled/disabled during their lifetime.

`ProductionQueue` is enabled in its <a href="https://github.com/OpenRA/OpenRA/blob/3d9ac5a85e45a6a31d67d36edb2a5129a4034e77/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs#L329C2-L329C2">`Tick()` method</a> based on whether there's at least one `Production` trait enabled (if not, the queue is disabled). This value (`ProductionQueue.Enabled`) is used in several places, in this PRs case it's in `ProductionTabsWidget`, when actor with `ProductionQueue` is <a href="https://github.com/OpenRA/OpenRA/blob/3d9ac5a85e45a6a31d67d36edb2a5129a4034e77/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs#L238">added/removed from `World`</a>.

The issue (this PR fixes) is mainly visible, when `ProductionQueue` is disabled immediately, when the production actor is created. Example would be OpenE2140 mod, where buildings are always constructed from MCV-like vehicles (called MCUs). In case of OpenE2140, the building *should not* be usable while its being constructed. This is implemented by putting condition on `Production` trait. The issue is triggered, when one MCU is transformed to building while another one is already being constructed. In this case, the `ProductionQueue` for the second building has `Enabled == false`, so when the actor for the new building is created, `ProductionTabsWidget` wrongly assumes the ProductionQueue for the second building (the one being constructed) is not available and thus does not create tab for it (i.e. `ProductionTab` object).

This is how the bug looks like in OpenE2140:

![GIF](https://github.com/OpenE2140/OpenE2140/assets/119738087/0c59511f-b5d9-4b22-80ae-472aaeaffd10)

(GIF is intentionally slowed down, to make it easier to follow changes in the `ProductionTabsWidget`)
