### PR TITLE
Fix margins of TD ingame menu panels.

### DIFF
--- a/mods/cnc/chrome/ingame-info-lobby-options.yaml
+++ b/mods/cnc/chrome/ingame-info-lobby-options.yaml
@@ -7,7 +7,7 @@ Container@LOBBY_OPTIONS_PANEL:
 			X: 15
 			Y: 15
 			Width: PARENT_RIGHT - 30
-			Height: 375
+			Height: PARENT_BOTTOM - 30
 			Children:
 				Container@LOBBY_OPTIONS:
 					Y: 10

--- a/mods/cnc/chrome/ingame-info.yaml
+++ b/mods/cnc/chrome/ingame-info.yaml
@@ -87,11 +87,14 @@ Container@GAME_INFO_PANEL:
 			Background: panel-black
 			Children:
 				Container@STATS_PANEL:
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
 				Container@MAP_PANEL:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM
 				Container@OBJECTIVES_PANEL:
 					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
 				Container@DEBUG_PANEL:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM

--- a/mods/cnc/chrome/ingame-infobriefing.yaml
+++ b/mods/cnc/chrome/ingame-infobriefing.yaml
@@ -21,8 +21,8 @@ Container@MAP_PANEL:
 		ScrollPanel@MAP_DESCRIPTION_PANEL:
 			X: 15
 			Y: 228
-			Width: 482
-			Height: 162
+			Width: PARENT_RIGHT - 30
+			Height: PARENT_BOTTOM - 228 - 15
 			Children:
 				Label@MAP_DESCRIPTION:
 					X: 4

--- a/mods/cnc/chrome/ingame-infoobjectives.yaml
+++ b/mods/cnc/chrome/ingame-infoobjectives.yaml
@@ -19,8 +19,8 @@ Container@MISSION_OBJECTIVES:
 		ScrollPanel@OBJECTIVES_PANEL:
 			X: 15
 			Y: 50
-			Width: 482
-			Height: 340
+			Width: PARENT_RIGHT - 30
+			Height: PARENT_BOTTOM - 65
 			TopBottomSpacing: 15
 			ItemSpacing: 15
 			Children:

--- a/mods/cnc/chrome/ingame-infostats.yaml
+++ b/mods/cnc/chrome/ingame-infostats.yaml
@@ -64,7 +64,7 @@ Container@SKIRMISH_STATS:
 			X: 15
 			Y: 105
 			Width: PARENT_RIGHT - 30
-			Height: 285
+			Height: PARENT_BOTTOM - 120
 			ItemSpacing: 5
 			Children:
 				ScrollItem@TEAM_TEMPLATE:


### PR DESCRIPTION
Before (and similar for the other panels):
<img width="779" alt="Screenshot 2023-10-29 at 11 04 06" src="https://github.com/OpenRA/OpenRA/assets/167819/ce3fd50f-f27d-464a-85b5-b4582145297d">

After:
<img width="789" alt="Screenshot 2023-10-29 at 11 03 30" src="https://github.com/OpenRA/OpenRA/assets/167819/91ebbe88-75c4-450c-b4f1-25b70685c631">
