### PR TITLE
R16 support for Dune 2000

### DIFF
--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -216,7 +216,7 @@ SupportsMapsFrom: d2k
 
 SoundFormats: Aud, Wav
 
-SpriteFormats: R8, ShpTD, TmpRA
+SpriteFormats: R816, ShpTD, TmpRA
 
 VideoFormats: Vqa
 
@@ -225,7 +225,7 @@ TerrainFormat: DefaultTerrain
 SpriteSequenceFormat: DefaultSpriteSequence
 
 AssetBrowser:
-	SpriteExtensions: .shp, .r8, .tmp
+	SpriteExtensions: .shp, .r8, .r16, .tmp
 	AudioExtensions: .aud, .wav
 	VideoExtensions: .vqa
 


### PR DESCRIPTION
While the Tileset R16 files include 16bpp sprites only, Data.R16 and Mouse.R16 include 8bpp files too. So viewing them in the asset browser still requires the right palette to be selected.