### PR TITLE
Polish the Mentat encyclopedia UI.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Encyclopedia.cs
+++ b/OpenRA.Mods.Common/Traits/Encyclopedia.cs
@@ -24,6 +24,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Group under this heading.")]
 		public readonly string Category;
 
+		[Desc("Scale the actor preview.")]
+		public readonly float Scale = 1f;
+
 		public override object Create(ActorInitializer init) { return Encyclopedia.Instance; }
 	}
 

--- a/mods/d2k/chrome/encyclopedia.yaml
+++ b/mods/d2k/chrome/encyclopedia.yaml
@@ -2,8 +2,8 @@ Background@ENCYCLOPEDIA_PANEL:
 	Logic: EncyclopediaLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
-	Width: 900
-	Height: 600
+	Width: 682
+	Height: 591
 	Children:
 		Container@ENCYCLOPEDIA_CONTENT:
 			Width: PARENT_RIGHT - 40
@@ -49,31 +49,35 @@ Background@ENCYCLOPEDIA_PANEL:
 				Container@ACTOR_INFO:
 					X: PARENT_RIGHT - WIDTH
 					Y: 30
-					Width: PARENT_RIGHT - 190 - 10
+					Width: PARENT_RIGHT - 190
 					Height: PARENT_BOTTOM - 25
 					Children:
-						Background@ACTOR_BG:
-							Width: 150
-							Height: 170
-							Background: dialog3
-							Children:
-								ActorPreview@ACTOR_PREVIEW:
-									X: 1
-									Y: 1
-									Width: PARENT_RIGHT - 2
-									Height: PARENT_BOTTOM - 2
 						ScrollPanel@ACTOR_DESCRIPTION_PANEL:
-							X: 150 + 10
-							Width: PARENT_RIGHT - 150 - 10
-							Height: 170
+							X: 10
+							Width: PARENT_RIGHT - 10
+							Height: PARENT_BOTTOM
 							TopBottomSpacing: 8
 							Children:
-								Label@ACTOR_DESCRIPTION:
+								Label@ACTOR_TITLE:
 									X: 8
 									Y: 8
 									Width: PARENT_RIGHT - 40
+									Height: 25
+									VAlign: Top
+									Align: Center
+									Font: Bold
+								Label@ACTOR_DESCRIPTION:
+									X: 148
+									Y: 20
+									Width: PARENT_RIGHT - 180
 									VAlign: Top
 									Font: Regular
+						ActorPreview@ACTOR_PREVIEW:
+							X: 14
+							Y: 16
+							Width: 140
+							Height: 140
+							Animate: true
 		Button@BACK_BUTTON:
 			X: PARENT_RIGHT - 180
 			Y: PARENT_BOTTOM - 45
@@ -82,5 +86,6 @@ Background@ENCYCLOPEDIA_PANEL:
 			Text: button-encyclopedia-panel-back
 			Font: Bold
 			Key: escape
+		Container@FACTION_DROPDOWN_PANEL_ROOT:
 		TooltipContainer@TOOLTIP_CONTAINER:
 

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -113,6 +113,7 @@ ornithopter:
 		Description: The fastest aircraft on Dune, the Ornithopther is lightly armored and capable of dropping 500lb bombs. This unit is most effective against infantry and lightly armored targets, but also damages armored targets.
 		Order: 240
 		Category: Units
+		Scale: 2
 	Aircraft:
 		Speed: 224
 		TurnSpeed: 8

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -23,6 +23,7 @@ light_inf:
 		Description: Light Infantry are lightly armored foot soldiers, equipped with 9mm RP assault rifles. Light Infantry are effective against other infantry and lightly armored vehicles.\n\nLight Infantry are resistant to missiles and large-caliber guns, but very vulnerable to high-explosives, fire and bullet weapons.
 		Order: 0
 		Category: Units
+		Scale: 2
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
 
@@ -56,6 +57,7 @@ engineer:
 		Description: Engineers can be used to capture enemy buildings.\n\nEngineers are resistant to anti-tank weaponry but very vulnerable to high-explosives, fire and bullet weapons.
 		Order: 30
 		Category: Units
+		Scale: 2
 	-RevealOnFire:
 	Voiced:
 		VoiceSet: EngineerVoice
@@ -90,6 +92,7 @@ trooper:
 		Description: Armed with missile launchers, Troopers fire wire guided armor-piercing warheads. These units are particularly effective against vehicles (especially armored ones) and buildings. However, this unit is largely useless against infantry.\n\nTroopers are resistant to anti-tank weaponry but very vulnerable to high-explosives, fire and bullet weapons.
 		Order: 10
 		Category: Units
+		Scale: 2
 	TakeCover:
 		ProneOffset: 324,0,-204
 	WithInfantryBody:
@@ -128,6 +131,7 @@ thumper:
 		Description: Deploys a noisy hammering device which will attract sand worms to this area.
 		Order: 40
 		Category: Units
+		Scale: 2
 	WithInfantryBody:
 		RequiresCondition: undeployed
 	WithSpriteBody@DEPLOYED:
@@ -180,6 +184,7 @@ fremen:
 		Description: Fremen are the native desert warriors of Dune. Fremen ground units carry 10mm Assault Rifles and Rockets. Their firepower is equally effective against infantry and vehicles.\n\nFremen units are very vulnerable to high-explosive and bullet weapons.
 		Order: 70
 		Category: Units
+		Scale: 2
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
 	Cloak:
@@ -223,6 +228,7 @@ grenadier:
 		Description: Grenadiers are an infantry artillery unit which are strong against buildings. They have a chance to explode on death, so don't group them together.
 		Order: 50
 		Category: Units
+		Scale: 2
 	TakeCover:
 		ProneOffset: 96,100,-64
 	WithInfantryBody:
@@ -263,6 +269,7 @@ sardaukar:
 		Description: These powerful heavy troopers have a machine gun that's effective against infantry, and a rocket launcher for vehicles.
 		Order: 60
 		Category: Units
+		Scale: 2
 	Voiced:
 		VoiceSet: GenericVoice
 	Explodes:
@@ -309,6 +316,7 @@ saboteur:
 		Description: The Saboteur is a special military unit acquired by House Ordos. A single Saboteur can destroy any enemy building once he moves into it, though also destroys himself! A Saboteur can be stealthed by deploying itself.\n\nThe Saboteur is resistant to anti-tank weaponry, but very vulnerable to high-explosives, fire, and bullet weapons.
 		Order: 80
 		Category: Units
+		Scale: 2
 	Mobile:
 		Speed: 43
 	Demolition:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -13,6 +13,7 @@
 		Name: Concrete
 		GenericName: Structure
 	RenderSprites:
+		Palette: terrain
 	KillsSelf:
 		RemoveInstead: true
 	Buildable:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -23,6 +23,7 @@ mcv:
 		Description: The Mobile Construction Vehicle must be driven to a suitable deployment area. After locating an appropriate area of rock, the MCV can be transformed into a Construction Yard.\n\nMCVs are resistant to bullets and light-explosives. They are vulnerable to missiles and high-caliber guns.
 		Order: 180
 		Category: Units
+		Scale: 2
 	Mobile:
 		Speed: 31
 	RevealsShroud:
@@ -88,6 +89,7 @@ harvester:
 		Description: Harvesters are resistant to bullets, and to some degree, high-explosives. These units are vulnerable to missiles and high-caliber guns.\n\nA Harvester is included with a Refinery.
 		Order: 130
 		Category: Units
+		Scale: 2
 	Mobile:
 		Speed: 43
 	RevealsShroud:
@@ -143,6 +145,7 @@ trike:
 		Description: Trikes are lightly armored, three-wheeled vehicles equipped with heavy machine guns, effective against infantry and lightly armored vehicles.\n\nTrikes are vulnerable to most weapons, though high-caliber guns are slightly less effective against them.
 		Order: 90
 		Category: Units
+		Scale: 2
 	Mobile:
 		TurnSpeed: 40
 		Speed: 128
@@ -197,6 +200,7 @@ quad:
 		Description: Stronger than the Trike in both armor and firepower, the Quad is a four-wheeled vehicle firing armor-piercing rockets. The Quad is effective against most vehicles.\n\nQuads are resistant to bullets and explosives, to a lesser degree. However, Quads are vulnerable to missiles and high-caliber guns.
 		Order: 110
 		Category: Units
+		Scale: 2
 	AttackFrontal:
 		FacingTolerance: 0
 	Explodes:
@@ -232,6 +236,7 @@ siege_tank:
 		Description: Siege Tanks are very effective against infantry and lightly armored vehicles - but very weak against heavily armored targets. They fire over a long range.\n\nSiege Tanks are resistant to bullets, and to some degree, explosives. These units are vulnerable to missiles and high-caliber guns.
 		Order: 170
 		Category: Units
+		Scale: 2
 	Mobile:
 		Speed: 43
 		TurnSpeed: 12
@@ -292,6 +297,7 @@ missile_tank:
 		Description: The Missile Tank is anti-aircraft capable and effective against most targets, except infantry units.\n\nMissile Tanks are vulnerable to most weapons, though high-caliber guns are slightly less effective.
 		Order: 190
 		Category: Units
+		Scale: 2
 	RevealsShroud:
 		Range: 6c768
 	Armament:
@@ -346,6 +352,7 @@ sonic_tank:
 		Description: The Sonic Tank is most effective against infantry and lightly armored vehicles - but weaker against armored targets.\n\nThe Sonic Tank will damage all units in its firing path.\n\nThey are very resistant to bullets and small-explosives, but vulnerable to missiles and high-caliber guns.
 		Order: 200
 		Category: Units
+		Scale: 2
 	AttackFrontal:
 		FacingTolerance: 0
 	Explodes:
@@ -397,6 +404,7 @@ devastator:
 		Description: The Devastator is the most powerful tank on Dune - powerfully effective against most units, but slow - and slow to fire. Nuclear powered, the Devastator fires dual plasma charges and may be ordered to self-destruct, damaging surrounding units and structures.\n\nThe Devastator is very resistant to bullet and high-explosives, but vulnerable to missiles and high-caliber guns.
 		Order: 220
 		Category: Units
+		Scale: 2
 	AttackFrontal:
 		FacingTolerance: 0
 	WithMuzzleOverlay:
@@ -454,6 +462,7 @@ raider:
 		Description: Raiders are similar to Trikes, but the Ordos have refined their fire power, speed and armor to create a powerful and maneuverable scout. With dual 20mm cannons, Raiders are most effective against infantry and lightly armored vehicles.\n\nRaiders are vulnerable to most types of weaponry, though high-caliber guns are slightly less effective.
 		Order: 100
 		Category: Units
+		Scale: 2
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -508,6 +517,7 @@ stealth_raider:
 		Description: A cloaked version of the raider, good for stealth attacks. Will uncloak when firing its machine guns.
 		Order: 120
 		Category: Units
+		Scale: 2
 	AutoTarget:
 		InitialStance: HoldFire
 		InitialStanceAI: ReturnFire
@@ -541,6 +551,7 @@ deviator:
 		Description: The Deviator's missiles discharge a silicon cloud that interferes with vehicle controls - temporarily changing the allegiance of the targeted unit. Personnel are not seriously effected by the cloud.\n\nThe Deviator is vulnerable to most types of weapon, though high-caliber guns are slightly less effective.
 		Order: 210
 		Category: Units
+		Scale: 2
 	RevealsShroud:
 		Range: 4c768
 	Armament:
@@ -616,6 +627,7 @@ combat_tank_a:
 		Description: The Combat Tank is effective against most vehicles, less so against lightly armored vehicles.\n\nAtreides Combat Tanks are very resistant to bullet and heavy-explosives, but vulnerable to missiles and high-caliber guns.
 		Order: 140
 		Category: Units
+		Scale: 2
 	Buildable:
 		Prerequisites: ~heavy.atreides_combat
 	Armament:
@@ -631,6 +643,7 @@ combat_tank_h:
 		Description: The Combat Tank is effective against most vehicles, less so against lightly armored vehicles.\n\nThe Harkonnen Combat Tank is stronger than its counterparts, but also slower.
 		Order: 160
 		Category: Units
+		Scale: 2
 	Buildable:
 		Prerequisites: ~heavy.harkonnen_combat
 	Armament:
@@ -654,6 +667,7 @@ combat_tank_o:
 		Description: The Combat Tank is effective against most vehicles, less so against lightly armored vehicles.\n\nThe Ordos Combat Tank is the fastest variant of the Combat Tank, but it is also the weakest.
 		Order: 150
 		Category: Units
+		Scale: 2
 	Armament:
 		Weapon: 80mm_O
 	Mobile:


### PR DESCRIPTION
Before:
<img width="949" alt="Screenshot 2023-10-29 at 15 55 40" src="https://github.com/OpenRA/OpenRA/assets/167819/fa76f1e0-5533-4035-9be0-1fed8bfaf33e">

After:
<img width="735" alt="Screenshot 2023-10-29 at 17 03 48" src="https://github.com/OpenRA/OpenRA/assets/167819/781e893d-b731-4846-966c-004a6b738024">

The new panel width is set to match the mission browser from #21169.