### PR TITLE
Let Map and CellLayer use ReadOnlyRectangle as Bounds.

### DIFF
--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -99,6 +99,7 @@ namespace OpenRA
 				{ typeof(float2), ParseFloat2 },
 				{ typeof(float3), ParseFloat3 },
 				{ typeof(Rectangle), ParseRectangle },
+				{ typeof(ReadOnlyRectangle), ParseReadOnlyRectangle },
 				{ typeof(DateTime), ParseDateTime }
 			};
 
@@ -460,6 +461,21 @@ namespace OpenRA
 			{
 				var parts = value.Split(SplitComma, StringSplitOptions.RemoveEmptyEntries);
 				return new Rectangle(
+					Exts.ParseInt32Invariant(parts[0]),
+					Exts.ParseInt32Invariant(parts[1]),
+					Exts.ParseInt32Invariant(parts[2]),
+					Exts.ParseInt32Invariant(parts[3]));
+			}
+
+			return InvalidValueAction(value, fieldType, fieldName);
+		}
+
+		static object ParseReadOnlyRectangle(string fieldName, Type fieldType, string value, MemberInfo field)
+		{
+			if (value != null)
+			{
+				var parts = value.Split(SplitComma, StringSplitOptions.RemoveEmptyEntries);
+				return new ReadOnlyRectangle(
 					Exts.ParseInt32Invariant(parts[0]),
 					Exts.ParseInt32Invariant(parts[1]),
 					Exts.ParseInt32Invariant(parts[2]),

--- a/OpenRA.Game/MPos.cs
+++ b/OpenRA.Game/MPos.cs
@@ -29,7 +29,7 @@ namespace OpenRA
 		public bool Equals(MPos other) { return other == this; }
 		public override bool Equals(object obj) { return obj is MPos uv && Equals(uv); }
 
-		public MPos Clamp(Rectangle r)
+		public MPos Clamp(ReadOnlyRectangle r)
 		{
 			return new MPos(Math.Min(r.Right, Math.Max(U, r.Left)),
 							Math.Min(r.Bottom, Math.Max(V, r.Top)));

--- a/OpenRA.Game/Map/CellLayer.cs
+++ b/OpenRA.Game/Map/CellLayer.cs
@@ -143,7 +143,7 @@ namespace OpenRA
 
 		public MPos Clamp(MPos uv)
 		{
-			return uv.Clamp(new Rectangle(0, 0, Size.Width - 1, Size.Height - 1));
+			return uv.Clamp(new ReadOnlyRectangle(0, 0, Size.Width - 1, Size.Height - 1));
 		}
 	}
 

--- a/OpenRA.Game/Map/CellLayerBase.cs
+++ b/OpenRA.Game/Map/CellLayerBase.cs
@@ -22,7 +22,7 @@ namespace OpenRA
 		public readonly MapGridType GridType;
 
 		protected readonly T[] Entries;
-		protected readonly Rectangle Bounds;
+		protected readonly ReadOnlyRectangle Bounds;
 
 		protected CellLayerBase(Map map)
 			: this(map.Grid.Type, new Size(map.MapSize.X, map.MapSize.Y)) { }
@@ -30,7 +30,7 @@ namespace OpenRA
 		protected CellLayerBase(MapGridType gridType, Size size)
 		{
 			Size = size;
-			Bounds = new Rectangle(0, 0, Size.Width, Size.Height);
+			Bounds = new ReadOnlyRectangle(0, 0, Size.Width, Size.Height);
 			GridType = gridType;
 			Entries = new T[size.Width * size.Height];
 		}

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -191,7 +191,7 @@ namespace OpenRA
 		public string Author;
 		public string Tileset;
 		public bool LockPreview;
-		public Rectangle Bounds;
+		public ReadOnlyRectangle Bounds;
 		public MapVisibility Visibility = MapVisibility.Lobby;
 		public string[] Categories = { "Conquest" };
 
@@ -255,7 +255,7 @@ namespace OpenRA
 		CellLayer<PPos[]> cellProjection;
 		CellLayer<List<MPos>> inverseCellProjection;
 		CellLayer<byte> projectedHeight;
-		Rectangle projectionSafeBounds;
+		ReadOnlyRectangle projectionSafeBounds;
 
 		public static string ComputeUID(IReadOnlyPackage package)
 		{
@@ -1091,7 +1091,7 @@ namespace OpenRA
 		{
 			// The tl and br coordinates are inclusive, but the Rectangle
 			// is exclusive.  Pad the right and bottom edges to match.
-			Bounds = Rectangle.FromLTRB(tl.U, tl.V, br.U + 1, br.V + 1);
+			Bounds = ReadOnlyRectangle.FromLTRB(tl.U, tl.V, br.U + 1, br.V + 1);
 
 			// See ProjectCellInner to see how any given position may be projected.
 			// U: May gain or lose 1, so bring in the left and right edge by 1.
@@ -1103,7 +1103,7 @@ namespace OpenRA
 			var maxHeight = Grid.MaximumTerrainHeight;
 			if ((maxHeight & 1) == 1)
 				maxHeight += 2;
-			projectionSafeBounds = Rectangle.FromLTRB(
+			projectionSafeBounds = ReadOnlyRectangle.FromLTRB(
 				Bounds.Left + 1,
 				Bounds.Top + maxHeight,
 				Bounds.Right - 1,

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -50,7 +50,7 @@ namespace OpenRA
 		public readonly string author;
 		public readonly string[] categories;
 		public readonly int players;
-		public readonly Rectangle bounds;
+		public readonly ReadOnlyRectangle bounds;
 		public readonly short[] spawnpoints = Array.Empty<short>();
 		public readonly MapGridType map_grid_type;
 		public readonly string minimap;
@@ -75,7 +75,7 @@ namespace OpenRA
 			public int PlayerCount;
 			public CPos[] SpawnPoints;
 			public MapGridType GridType;
-			public Rectangle Bounds;
+			public ReadOnlyRectangle Bounds;
 			public Png Preview;
 			public MapStatus Status;
 			public MapClassification Class;
@@ -186,7 +186,7 @@ namespace OpenRA
 		public int PlayerCount => innerData.PlayerCount;
 		public CPos[] SpawnPoints => innerData.SpawnPoints;
 		public MapGridType GridType => innerData.GridType;
-		public Rectangle Bounds => innerData.Bounds;
+		public ReadOnlyRectangle Bounds => innerData.Bounds;
 		public Png Preview => innerData.Preview;
 		public MapStatus Status => innerData.Status;
 		public MapClassification Class => innerData.Class;
@@ -269,7 +269,7 @@ namespace OpenRA
 				PlayerCount = 0,
 				SpawnPoints = NoSpawns,
 				GridType = gridType,
-				Bounds = Rectangle.Empty,
+				Bounds = ReadOnlyRectangle.Empty,
 				Preview = null,
 				Status = MapStatus.Unavailable,
 				Class = MapClassification.Unknown,
@@ -363,7 +363,7 @@ namespace OpenRA
 				newData.Author = temp.Value;
 
 			if (yaml.TryGetValue("Bounds", out temp))
-				newData.Bounds = FieldLoader.GetValue<Rectangle>("Bounds", temp.Value);
+				newData.Bounds = FieldLoader.GetValue<ReadOnlyRectangle>("Bounds", temp.Value);
 
 			if (yaml.TryGetValue("Visibility", out temp))
 				newData.Visibility = FieldLoader.GetValue<MapVisibility>("Visibility", temp.Value);

--- a/OpenRA.Game/Primitives/ReadOnlyRectangle.cs
+++ b/OpenRA.Game/Primitives/ReadOnlyRectangle.cs
@@ -1,0 +1,133 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+
+namespace OpenRA.Primitives
+{
+	public readonly struct ReadOnlyRectangle : IEquatable<ReadOnlyRectangle>
+	{
+		public readonly int2 TopLeft;
+		public readonly int2 BottomRight;
+		public static readonly ReadOnlyRectangle Empty;
+
+		public static ReadOnlyRectangle FromLTRB(int left, int top, int right, int bottom)
+		{
+			return new ReadOnlyRectangle(left, top, right - left, bottom - top);
+		}
+
+		public static ReadOnlyRectangle Union(ReadOnlyRectangle a, ReadOnlyRectangle b)
+		{
+			return FromLTRB(Math.Min(a.Left, b.Left), Math.Min(a.Top, b.Top), Math.Max(a.Right, b.Right), Math.Max(a.Bottom, b.Bottom));
+		}
+
+		public static bool operator ==(ReadOnlyRectangle left, ReadOnlyRectangle right)
+		{
+			return left.TopLeft == right.TopLeft && left.BottomRight == right.BottomRight;
+		}
+
+		public static bool operator !=(ReadOnlyRectangle left, ReadOnlyRectangle right)
+		{
+			return !(left == right);
+		}
+
+		public ReadOnlyRectangle(Rectangle r)
+		{
+			TopLeft = r.TopLeft;
+			BottomRight = r.BottomRight;
+		}
+
+		public ReadOnlyRectangle(int x, int y, int width, int height)
+		{
+			TopLeft = new(x, y);
+			BottomRight = new(x + width, y + height);
+		}
+
+		public ReadOnlyRectangle(int2 location, Size size)
+		{
+			TopLeft = new(location.X, location.Y);
+			BottomRight = new(location.X + size.Width, location.Y + size.Height);
+		}
+
+		public readonly int Left => TopLeft.X;
+		public readonly int Right => BottomRight.X;
+		public readonly int Top => TopLeft.Y;
+		public readonly int Bottom => BottomRight.Y;
+		public readonly bool IsEmpty => TopLeft.X == 0 && TopLeft.Y == 0 && BottomRight.X == 0 && BottomRight.Y == 0;
+		public readonly int2 Location => TopLeft;
+		public readonly Size Size => new(BottomRight.X - TopLeft.X, BottomRight.Y - TopLeft.Y);
+
+		public readonly int X => TopLeft.X;
+		public readonly int Y => TopLeft.Y;
+		public readonly int Width => BottomRight.X - TopLeft.X;
+		public readonly int Height => BottomRight.Y - TopLeft.Y;
+		public readonly int2 TopRight => new(BottomRight.X, TopLeft.Y);
+		public readonly int2 BottomLeft => new(TopLeft.X, BottomRight.Y);
+
+		public readonly bool Contains(int x, int y)
+		{
+			return x >= TopLeft.X && x < BottomRight.X && y >= TopLeft.Y && y < BottomRight.Y;
+		}
+
+		public readonly bool Contains(int2 pt)
+		{
+			return Contains(pt.X, pt.Y);
+		}
+
+		public readonly bool Equals(ReadOnlyRectangle other)
+		{
+			return this == other;
+		}
+
+		public override readonly bool Equals(object obj)
+		{
+			if (obj is not ReadOnlyRectangle)
+				return false;
+
+			return this == (ReadOnlyRectangle)obj;
+		}
+
+		public override readonly int GetHashCode()
+		{
+			return Height + Width ^ X + Y;
+		}
+
+		public readonly bool IntersectsWith(ReadOnlyRectangle rect)
+		{
+			return Left < rect.Right && Right > rect.Left && Top < rect.Bottom && Bottom > rect.Top;
+		}
+
+		readonly bool IntersectsWithInclusive(ReadOnlyRectangle r)
+		{
+			return Left <= r.Right && Right >= r.Left && Top <= r.Bottom && Bottom >= r.Top;
+		}
+
+		public static ReadOnlyRectangle Intersect(ReadOnlyRectangle a, ReadOnlyRectangle b)
+		{
+			if (!a.IntersectsWithInclusive(b))
+				return Empty;
+
+			return FromLTRB(Math.Max(a.Left, b.Left), Math.Max(a.Top, b.Top), Math.Min(a.Right, b.Right), Math.Min(a.Bottom, b.Bottom));
+		}
+
+		public readonly bool Contains(ReadOnlyRectangle rect)
+		{
+			return rect == Intersect(this, rect);
+		}
+
+		public static ReadOnlyRectangle operator *(int a, ReadOnlyRectangle b) { return new ReadOnlyRectangle(a * b.X, a * b.Y, a * b.Width, a * b.Height); }
+
+		public override readonly string ToString()
+		{
+			return $"{X},{Y},{Width},{Height}";
+		}
+	}
+}

--- a/OpenRA.Game/Primitives/Rectangle.cs
+++ b/OpenRA.Game/Primitives/Rectangle.cs
@@ -15,7 +15,7 @@ namespace OpenRA.Primitives
 {
 	public struct Rectangle : IEquatable<Rectangle>
 	{
-		// TODO: Make these readonly: this will require a lot of changes to the UI logic
+		// TODO: Replace all usage of this struct with ReadOnlyRectangle. This will require a lot of changes to the UI logic
 		public int X;
 		public int Y;
 		public int Width;


### PR DESCRIPTION

Replace the use of `Rectangle` with `ReadOnlyRectangle` in `Map` and `CellLayerBase`.

Why:

`Map.Bounds.Contains` and `CellLayerBase.Bounds.Contains` are some of the most often executed functions to validate if positions lie within the bounds of the map. Using readonly struct members may/should allow for better optmization.

The location of `BottomRight` is stored - rather than `Width` and `Height` to avoid having to calculate the position each time.

Op purpose not done for all Render and Widget classes as it would become an impossibly huge commit. 

This will allow for a step wise migration to `ReadOnlyRectangle` over time after which it can be renamed to `Rectangle`.

The types are not auto convertable on purpose. To be able to distinguise the use and encourage the use of either.

