### PR TITLE
Increase sound source pool size to the maximum

### DIFF
--- a/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
+++ b/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
@@ -49,7 +49,10 @@ namespace OpenRA.Platforms.Default
 		const int MaxInstancesPerFrame = 3;
 		const int GroupDistance = 2730;
 		const int GroupDistanceSqr = GroupDistance * GroupDistance;
-		const int PoolSize = 32;
+
+		// https://github.com/kcat/openal-soft/issues/580
+		// https://github.com/kcat/openal-soft/blob/b6aa73b26004afe63d83097f2f91ecda9bc25cb9/alc/alc.cpp#L3191-L3203
+		const int PoolSize = 256;
 
 		readonly Dictionary<uint, PoolSlot> sourcePool = new(PoolSize);
 		float volume = 1f;


### PR DESCRIPTION
Closes #19724

https://github.com/kcat/openal-soft/issues/580
https://github.com/kcat/openal-soft/blob/b6aa73b26004afe63d83097f2f91ecda9bc25cb9/alc/alc.cpp#L1468-L1485
https://github.com/kcat/openal-soft/blob/b6aa73b26004afe63d83097f2f91ecda9bc25cb9/alc/alc.cpp#L3191-L3203

If I try to create a 257th source it errors with
> [ALSOFT] (WW) Error generated on context 0x7fd37b9509d0, code 0xa005, "Exceeding 256 source limit (256 + 1)"

with the AL error being
> Out of Memory