### PR TITLE
Enable more Roslynator rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1103,6 +1103,9 @@ dotnet_diagnostic.RCS1218.severity = warning
 # Use pattern matching instead of combination of 'is' operator and cast operator.
 dotnet_diagnostic.RCS1220.severity = warning
 
+# Make class sealed.
+dotnet_diagnostic.RCS1225.severity = warning
+
 # Unnecessary explicit use of enumerator.
 dotnet_diagnostic.RCS1230.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1031,6 +1031,9 @@ dotnet_diagnostic.RCS1132.severity = warning
 # Remove redundant Dispose/Close call.
 dotnet_diagnostic.RCS1133.severity = warning
 
+# Remove redundant statement.
+dotnet_diagnostic.RCS1134.severity = warning
+
 # Merge switch sections with equivalent content.
 dotnet_diagnostic.RCS1136.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1088,6 +1088,9 @@ dotnet_diagnostic.RCS1204.severity = warning
 # Order type parameter constraints.
 dotnet_diagnostic.RCS1209.severity = warning
 
+# Unnecessary interpolated string.
+dotnet_diagnostic.RCS1214.severity = warning
+
 # Expression is always equal to 'true'.
 dotnet_diagnostic.RCS1215.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -998,6 +998,9 @@ dotnet_diagnostic.RCS1074.severity = warning
 # Use 'Count' property instead of 'Any' method.
 dotnet_diagnostic.RCS1080.severity = warning
 
+# Use coalesce expression instead of conditional expression.
+dotnet_diagnostic.RCS1084.severity = warning
+
 # Remove empty region.
 dotnet_diagnostic.RCS1091.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -986,6 +986,9 @@ dotnet_diagnostic.RCS1066.severity = warning
 # Simplify logical negation.
 dotnet_diagnostic.RCS1068.severity = warning
 
+# Remove redundant base constructor call.
+dotnet_diagnostic.RCS1071.severity = warning
+
 # Remove empty namespace declaration.
 dotnet_diagnostic.RCS1072.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -971,6 +971,9 @@ dotnet_diagnostic.RCS1043.severity = warning
 # Use lambda expression instead of anonymous method.
 dotnet_diagnostic.RCS1048.severity = warning
 
+# Simplify boolean comparison.
+dotnet_diagnostic.RCS1049.severity = warning
+
 # Avoid locking on publicly accessible instance.
 dotnet_diagnostic.RCS1059.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1097,6 +1097,9 @@ dotnet_diagnostic.RCS1215.severity = warning
 # Unnecessary unsafe context.
 dotnet_diagnostic.RCS1216.severity = warning
 
+# Simplify code branching.
+dotnet_diagnostic.RCS1218.severity = warning
+
 # Use pattern matching instead of combination of 'is' operator and cast operator.
 dotnet_diagnostic.RCS1220.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1094,6 +1094,9 @@ dotnet_diagnostic.RCS1214.severity = warning
 # Expression is always equal to 'true'.
 dotnet_diagnostic.RCS1215.severity = warning
 
+# Unnecessary unsafe context.
+dotnet_diagnostic.RCS1216.severity = warning
+
 # Use pattern matching instead of combination of 'is' operator and cast operator.
 dotnet_diagnostic.RCS1220.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -983,6 +983,9 @@ dotnet_diagnostic.RCS1059.severity = warning
 # Remove empty 'finally' clause.
 dotnet_diagnostic.RCS1066.severity = warning
 
+# Simplify logical negation.
+dotnet_diagnostic.RCS1068.severity = warning
+
 # Remove empty namespace declaration.
 dotnet_diagnostic.RCS1072.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1109,6 +1109,9 @@ dotnet_diagnostic.RCS1225.severity = warning
 # Add paragraph to documentation comment.
 dotnet_diagnostic.RCS1226.severity = warning
 
+# Validate arguments correctly.
+dotnet_diagnostic.RCS1227.severity = warning
+
 # Unnecessary explicit use of enumerator.
 dotnet_diagnostic.RCS1230.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1025,6 +1025,9 @@ dotnet_diagnostic.RCS1113.severity = warning
 # Bitwise operation on enum without Flags attribute.
 dotnet_diagnostic.RCS1130.severity = warning
 
+# Remove redundant overriding member.
+dotnet_diagnostic.RCS1132.severity = warning
+
 # Remove redundant Dispose/Close call.
 dotnet_diagnostic.RCS1133.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1106,6 +1106,9 @@ dotnet_diagnostic.RCS1220.severity = warning
 # Make class sealed.
 dotnet_diagnostic.RCS1225.severity = warning
 
+# Add paragraph to documentation comment.
+dotnet_diagnostic.RCS1226.severity = warning
+
 # Unnecessary explicit use of enumerator.
 dotnet_diagnostic.RCS1230.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -995,6 +995,9 @@ dotnet_diagnostic.RCS1072.severity = warning
 # Remove redundant constructor.
 dotnet_diagnostic.RCS1074.severity = warning
 
+# Use 'Count' property instead of 'Any' method.
+dotnet_diagnostic.RCS1080.severity = warning
+
 # Remove empty region.
 dotnet_diagnostic.RCS1091.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1070,6 +1070,9 @@ dotnet_diagnostic.RCS1190.severity = warning
 # Declare enum value as combination of names.
 dotnet_diagnostic.RCS1191.severity = warning
 
+# Unnecessary usage of verbatim string literal.
+dotnet_diagnostic.RCS1192.severity = warning
+
 # Overriding member should not change 'params' modifier.
 dotnet_diagnostic.RCS1193.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1064,6 +1064,9 @@ dotnet_diagnostic.RCS1179.severity = warning
 # Use constant instead of field.
 dotnet_diagnostic.RCS1187.severity = warning
 
+# Join string expressions.
+dotnet_diagnostic.RCS1190.severity = warning
+
 # Overriding member should not change 'params' modifier.
 dotnet_diagnostic.RCS1193.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -974,6 +974,9 @@ dotnet_diagnostic.RCS1048.severity = warning
 # Simplify boolean comparison.
 dotnet_diagnostic.RCS1049.severity = warning
 
+# Use compound assignment.
+dotnet_diagnostic.RCS1058.severity = warning
+
 # Avoid locking on publicly accessible instance.
 dotnet_diagnostic.RCS1059.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1120,3 +1120,6 @@ dotnet_diagnostic.RCS1233.severity = warning
 
 # Optimize method call.
 dotnet_diagnostic.RCS1235.severity = warning
+
+# Use 'for' statement instead of 'while' statement.
+dotnet_diagnostic.RCS1239.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -1016,6 +1016,9 @@ dotnet_diagnostic.RCS1107.severity = warning
 # Add 'static' modifier to all partial class declarations.
 dotnet_diagnostic.RCS1108.severity = warning
 
+# Combine 'Enumerable.Where' method chain.
+dotnet_diagnostic.RCS1112.severity = warning
+
 # Use 'string.IsNullOrEmpty' method.
 dotnet_diagnostic.RCS1113.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -992,6 +992,9 @@ dotnet_diagnostic.RCS1071.severity = warning
 # Remove empty namespace declaration.
 dotnet_diagnostic.RCS1072.severity = warning
 
+# Remove redundant constructor.
+dotnet_diagnostic.RCS1074.severity = warning
+
 # Remove empty region.
 dotnet_diagnostic.RCS1091.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1004,6 +1004,9 @@ dotnet_diagnostic.RCS1084.severity = warning
 # Remove empty region.
 dotnet_diagnostic.RCS1091.severity = warning
 
+# Default label should be the last label in a switch section.
+dotnet_diagnostic.RCS1099.severity = warning
+
 # Unnecessary interpolation.
 dotnet_diagnostic.RCS1105.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -959,6 +959,9 @@ dotnet_diagnostic.RCS1034.severity = warning
 # Remove argument list from attribute.
 dotnet_diagnostic.RCS1039.severity = warning
 
+# Remove empty initializer.
+dotnet_diagnostic.RCS1041.severity = warning
+
 # Remove enum default underlying type.
 dotnet_diagnostic.RCS1042.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1058,6 +1058,9 @@ dotnet_diagnostic.RCS1172.severity = warning
 # Unused 'this' parameter.
 dotnet_diagnostic.RCS1175.severity = warning
 
+# Unnecessary assignment.
+dotnet_diagnostic.RCS1179.severity = warning
+
 # Use constant instead of field.
 dotnet_diagnostic.RCS1187.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1067,6 +1067,9 @@ dotnet_diagnostic.RCS1187.severity = warning
 # Join string expressions.
 dotnet_diagnostic.RCS1190.severity = warning
 
+# Declare enum value as combination of names.
+dotnet_diagnostic.RCS1191.severity = warning
+
 # Overriding member should not change 'params' modifier.
 dotnet_diagnostic.RCS1193.severity = warning
 

--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -146,18 +146,22 @@ namespace OpenRA.Activities
 		}
 
 		/// <summary>
+		/// <para>
 		/// Called every tick to run activity logic. Returns false if the activity should
 		/// remain active, or true if it is complete. Cancelled activities must ensure they
 		/// return the actor to a consistent state before returning true.
-		///
+		/// </para>
+		/// <para>
 		/// Child activities can be queued using QueueChild, and these will be ticked
 		/// instead of the parent while they are active. Activities that need to run logic
 		/// in parallel with child activities should set ChildHasPriority to false and
 		/// manually call TickChildren.
-		///
+		/// </para>
+		/// <para>
 		/// Queuing one or more child activities and returning true is valid, and causes
 		/// the activity to be completed immediately (without ticking again) once the
 		/// children have completed.
+		/// </para>
 		/// </summary>
 		public virtual bool Tick(Actor self)
 		{
@@ -222,10 +226,11 @@ namespace OpenRA.Activities
 		}
 
 		/// <summary>
-		/// Prints the activity tree, starting from the top or optionally from a given origin.
-		///
+		/// <para>Prints the activity tree, starting from the top or optionally from a given origin.</para>
+		/// <para>
 		/// Call this method from any place that's called during a tick, such as the Tick() method itself or
 		/// the Before(First|Last)Run() methods. The origin activity will be marked in the output.
+		/// </para>
 		/// </summary>
 		/// <param name="self">The actor performing this activity.</param>
 		/// <param name="origin">Activity from which to start traversing, and which to mark. If null, mark the calling activity, and start traversal from the top.</param>

--- a/OpenRA.Game/Map/ActorInitializer.cs
+++ b/OpenRA.Game/Map/ActorInitializer.cs
@@ -175,8 +175,7 @@ namespace OpenRA
 		protected CompositeActorInit(TraitInfo info)
 			: base(info.InstanceName) { }
 
-		protected CompositeActorInit()
-			: base() { }
+		protected CompositeActorInit() { }
 
 		public virtual void Initialize(MiniYaml yaml)
 		{

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -1353,13 +1353,18 @@ namespace OpenRA
 				throw new ArgumentOutOfRangeException(nameof(maxRange),
 					$"The requested range ({maxRange}) cannot exceed the value of MaximumTileSearchRange ({Grid.MaximumTileSearchRange})");
 
-			for (var i = minRange; i <= maxRange; i++)
+			return FindTilesInAnnulus();
+
+			IEnumerable<CPos> FindTilesInAnnulus()
 			{
-				foreach (var offset in Grid.TilesByDistance[i])
+				for (var i = minRange; i <= maxRange; i++)
 				{
-					var t = offset + center;
-					if (allowOutsideBounds ? Tiles.Contains(t) : Contains(t))
-						yield return t;
+					foreach (var offset in Grid.TilesByDistance[i])
+					{
+						var t = offset + center;
+						if (allowOutsideBounds ? Tiles.Contains(t) : Contains(t))
+							yield return t;
+					}
 				}
 			}
 		}

--- a/OpenRA.Game/Primitives/BitSet.cs
+++ b/OpenRA.Game/Primitives/BitSet.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Primitives
 
 		public static BitSet<T> FromStringsNoAlloc(string[] values)
 		{
-			return new BitSet<T>(BitSetAllocator<T>.GetBitsNoAlloc(values)) { };
+			return new BitSet<T>(BitSetAllocator<T>.GetBitsNoAlloc(values));
 		}
 
 		public override string ToString()

--- a/OpenRA.Game/Primitives/LongBitSet.cs
+++ b/OpenRA.Game/Primitives/LongBitSet.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Primitives
 
 		public static LongBitSet<T> FromStringsNoAlloc(string[] values)
 		{
-			return new LongBitSet<T>(LongBitSetAllocator<T>.GetBitsNoAlloc(values)) { };
+			return new LongBitSet<T>(LongBitSetAllocator<T>.GetBitsNoAlloc(values));
 		}
 
 		public static void Reset()

--- a/OpenRA.Game/Scripting/ScriptContext.cs
+++ b/OpenRA.Game/Scripting/ScriptContext.cs
@@ -74,14 +74,17 @@ namespace OpenRA.Scripting
 	/// Provides global bindings in Lua code.
 	/// </summary>
 	/// <remarks>
+	/// <para>
 	/// Instance methods and properties declared in derived classes will be made available in Lua. Use
 	/// <see cref="ScriptGlobalAttribute"/> on your derived class to specify the name exposed in Lua. It is recommended
 	/// to apply <see cref="DescAttribute"/> against each method or property to provide a description of what it does.
-	///
+	/// </para>
+	/// <para>
 	/// Any parameters to your method that are <see cref="LuaValue"/>s will be disposed automatically when your method
 	/// completes. If you need to return any of these values, or need them to live longer than your method, you must
 	/// use <see cref="LuaValue.CopyReference"/> to get your own copy of the value. Any copied values you return will
 	/// be disposed automatically, but you assume responsibility for disposing any other copies.
+	/// </para>
 	/// </remarks>
 	public abstract class ScriptGlobal : ScriptObjectWrapper
 	{

--- a/OpenRA.Game/Support/LaunchArguments.cs
+++ b/OpenRA.Game/Support/LaunchArguments.cs
@@ -37,8 +37,8 @@ namespace OpenRA
 				return;
 
 			foreach (var f in GetType().GetFields())
-				if (args.Contains("Launch" + "." + f.Name))
-					FieldLoader.LoadField(this, f.Name, args.GetValue("Launch" + "." + f.Name, ""));
+				if (args.Contains("Launch." + f.Name))
+					FieldLoader.LoadField(this, f.Name, args.GetValue("Launch." + f.Name, ""));
 		}
 
 		public ConnectionTarget GetConnectEndPoint()

--- a/OpenRA.Game/Support/MersenneTwister.cs
+++ b/OpenRA.Game/Support/MersenneTwister.cs
@@ -79,7 +79,7 @@ namespace OpenRA.Support
 					var y = (mt[i] & 0x80000000) | (mt[(i + 1) % 624] & 0x7fffffff);
 					mt[i] = mt[(i + 397u) % 624u] ^ (y >> 1);
 					if ((y & 1) == 1)
-						mt[i] = mt[i] ^ 2567483615;
+						mt[i] ^= 2567483615;
 				}
 			}
 		}

--- a/OpenRA.Game/Support/VariableExpression.cs
+++ b/OpenRA.Game/Support/VariableExpression.cs
@@ -676,7 +676,7 @@ namespace OpenRA.Support
 				else if (t.Closes != Grouping.None)
 				{
 					Token temp;
-					while (!((temp = s.Pop()).Opens != Grouping.None))
+					while ((temp = s.Pop()).Opens == Grouping.None)
 						yield return temp;
 				}
 				else if (t.OperandSides == Sides.None)

--- a/OpenRA.Game/Sync.cs
+++ b/OpenRA.Game/Sync.cs
@@ -151,8 +151,8 @@ namespace OpenRA
 				case TargetType.Terrain:
 					return HashUsingHashCode(t.CenterPosition);
 
-				default:
 				case TargetType.Invalid:
+				default:
 					return 0;
 			}
 		}

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -120,8 +120,8 @@ namespace OpenRA.Traits
 					return FrozenActor.IsValid && FrozenActor.Visible && !FrozenActor.Hidden;
 				case TargetType.Invalid:
 					return false;
-				default:
 				case TargetType.Terrain:
+				default:
 					return true;
 			}
 		}
@@ -164,8 +164,8 @@ namespace OpenRA.Traits
 						return FrozenActor.CenterPosition;
 					case TargetType.Terrain:
 						return terrainCenterPosition;
-					default:
 					case TargetType.Invalid:
+					default:
 						throw new InvalidOperationException("Attempting to query the position of an invalid Target");
 				}
 			}
@@ -186,8 +186,8 @@ namespace OpenRA.Traits
 						return FrozenActor.TargetablePositions ?? NoPositions;
 					case TargetType.Terrain:
 						return terrainPositions;
-					default:
 					case TargetType.Invalid:
+					default:
 						return NoPositions;
 				}
 			}
@@ -215,8 +215,8 @@ namespace OpenRA.Traits
 				case TargetType.Terrain:
 					return terrainCenterPosition.ToString();
 
-				default:
 				case TargetType.Invalid:
+				default:
 					return "Invalid";
 			}
 		}
@@ -239,8 +239,8 @@ namespace OpenRA.Traits
 				case TargetType.FrozenActor:
 					return me.FrozenActor == other.FrozenActor;
 
-				default:
 				case TargetType.Invalid:
+				default:
 					return false;
 			}
 		}
@@ -270,8 +270,8 @@ namespace OpenRA.Traits
 				case TargetType.FrozenActor:
 					return FrozenActor.GetHashCode();
 
-				default:
 				case TargetType.Invalid:
+				default:
 					return 0;
 			}
 		}

--- a/OpenRA.Game/UtilityCommands/ExtractChromeStrings.cs
+++ b/OpenRA.Game/UtilityCommands/ExtractChromeStrings.cs
@@ -38,7 +38,7 @@ namespace OpenRA.UtilityCommands
 				.ToDictionary(
 					t => t.Name[..^6],
 					t => t.GetFields().Where(f => f.HasAttribute<TranslationReferenceAttribute>()).Select(f => f.Name).ToArray())
-				.Where(t => t.Value.Any())
+				.Where(t => t.Value.Length > 0)
 				.ToDictionary(t => t.Key, t => t.Value);
 
 			var chromeLayouts = modData.Manifest.ChromeLayout.GroupBy(c => c.Split('/')[0].Split('|')[0], c => c);

--- a/OpenRA.Mods.Cnc/Activities/Teleport.cs
+++ b/OpenRA.Mods.Cnc/Activities/Teleport.cs
@@ -128,7 +128,7 @@ namespace OpenRA.Mods.Cnc.Activities
 			if (pos.CanEnterCell(destination) && teleporter.Owner.Shroud.IsExplored(destination))
 				return destination;
 
-			var max = maximumDistance != null ? maximumDistance.Value : teleporter.World.Map.Grid.MaximumTileSearchRange;
+			var max = maximumDistance ?? teleporter.World.Map.Grid.MaximumTileSearchRange;
 			foreach (var tile in self.World.Map.FindTilesInCircle(destination, max))
 			{
 				if (teleporter.Owner.Shroud.IsExplored(tile)

--- a/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
@@ -149,7 +149,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 
 			if (bits == 0) return;
 			for (i = 0; i < len - 1; i++) n[i] = (n[i] >> bits) | (n[i + 1] << (32 - bits));
-			n[i] = n[i] >> bits;
+			n[i] >>= bits;
 		}
 
 		static void ShlBigNum(uint[] n, int bits, int len)

--- a/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
@@ -284,24 +284,21 @@ namespace OpenRA.Mods.Cnc.FileFormats
 		static unsafe void MulBignumWord(ushort* pn1, uint[] n2, uint mul, uint len)
 		{
 			uint i, tmp;
-			unsafe
+			fixed (uint* tempPn2 = &n2[0])
 			{
-				fixed (uint* tempPn2 = &n2[0])
+				var pn2 = (ushort*)tempPn2;
+
+				tmp = 0;
+				for (i = 0; i < len; i++)
 				{
-					var pn2 = (ushort*)tempPn2;
-
-					tmp = 0;
-					for (i = 0; i < len; i++)
-					{
-						tmp = mul * *pn2 + *pn1 + tmp;
-						*pn1 = (ushort)tmp;
-						pn1++;
-						pn2++;
-						tmp >>= 16;
-					}
-
-					*pn1 += (ushort)tmp;
+					tmp = mul * *pn2 + *pn1 + tmp;
+					*pn1 = (ushort)tmp;
+					pn1++;
+					pn2++;
+					tmp >>= 16;
 				}
+
+				*pn1 += (ushort)tmp;
 			}
 		}
 

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpTDLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpTDLoader.cs
@@ -232,7 +232,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 				var eof = new ImageHeader { FileOffset = (uint)dataOffset };
 				eof.WriteTo(bw);
 
-				var allZeroes = new ImageHeader { };
+				var allZeroes = new ImageHeader();
 				allZeroes.WriteTo(bw);
 
 				foreach (var f in compressedFrames)

--- a/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
@@ -204,8 +204,6 @@ namespace OpenRA.Mods.Cnc.Traits
 					cursor = targetCursor;
 					return true;
 				}
-
-				return false;
 			}
 
 			return false;
@@ -252,7 +250,6 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (portableChrono.IsTraitDisabled || portableChrono.IsTraitPaused)
 			{
 				world.CancelInputMode();
-				return;
 			}
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/World/TSEditorResourceLayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSEditorResourceLayer.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		[ActorReference]
 		[Desc("Actor types that should be treated as veins for adjacency.")]
-		public readonly HashSet<string> VeinholeActors = new() { };
+		public readonly HashSet<string> VeinholeActors = new();
 
 		public override object Create(ActorInitializer init) { return new TSEditorResourceLayer(init.Self, this); }
 	}

--- a/OpenRA.Mods.Cnc/Traits/World/TSResourceLayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSResourceLayer.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		[ActorReference]
 		[Desc("Actor types that should be treated as veins for adjacency.")]
-		public readonly HashSet<string> VeinholeActors = new() { };
+		public readonly HashSet<string> VeinholeActors = new();
 
 		public override object Create(ActorInitializer init) { return new TSResourceLayer(init.Self, this); }
 	}

--- a/OpenRA.Mods.Cnc/Traits/World/TSVeinsRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSVeinsRenderer.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		[ActorReference]
 		[Desc("Actor types that should be treated as veins for adjacency.")]
-		public readonly HashSet<string> VeinholeActors = new() { };
+		public readonly HashSet<string> VeinholeActors = new();
 
 		void IMapPreviewSignatureInfo.PopulateMapPreviewSignatureCells(Map map, ActorInfo ai, ActorReference s, List<(MPos Uv, Color Color)> destinationBuffer)
 		{

--- a/OpenRA.Mods.Cnc/UtilityCommands/Glob.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/Glob.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			if (parts.Count == 0
 				|| (parts[0][0] != Path.DirectorySeparatorChar
 				&& parts[0][0] != Path.AltDirectorySeparatorChar
-				&& parts[0].Contains(':') == false
+				&& !parts[0].Contains(':')
 				&& parts[0] != "." + Path.DirectorySeparatorChar
 				&& parts[0] != "." + Path.AltDirectorySeparatorChar
 				&& parts[0] != ".." + Path.DirectorySeparatorChar

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertMapCommand.cs
@@ -34,10 +34,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 		public override void ValidateMapFormat(int format)
 		{
 			if (format < 2)
-			{
 				Console.WriteLine($"ERROR: Detected NewINIFormat {format}. Are you trying to import a Tiberian Dawn map?");
-				return;
-			}
 		}
 
 		// Mapping from RA95 overlay index to type string
@@ -146,46 +143,46 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			string faction;
 			switch (section)
 			{
-			case "Spain":
-				color = "gold";
-				faction = "allies";
-				break;
-			case "England":
-				color = "green";
-				faction = "allies";
-				break;
-			case "Ukraine":
-				color = "orange";
-				faction = "soviet";
-				break;
-			case "Germany":
-				color = "black";
-				faction = "allies";
-				break;
-			case "France":
-				color = "teal";
-				faction = "allies";
-				break;
-			case "Turkey":
-				color = "salmon";
-				faction = "allies";
-				break;
-			case "Greece":
-			case "GoodGuy":
-				color = "blue";
-				faction = "allies";
-				break;
-			case "USSR":
-			case "BadGuy":
-				color = "red";
-				faction = "soviet";
-				break;
-			case "Special":
-			case "Neutral":
-			default:
-				color = "neutral";
-				faction = "allies";
-				break;
+				case "Spain":
+					color = "gold";
+					faction = "allies";
+					break;
+				case "England":
+					color = "green";
+					faction = "allies";
+					break;
+				case "Ukraine":
+					color = "orange";
+					faction = "soviet";
+					break;
+				case "Germany":
+					color = "black";
+					faction = "allies";
+					break;
+				case "France":
+					color = "teal";
+					faction = "allies";
+					break;
+				case "Turkey":
+					color = "salmon";
+					faction = "allies";
+					break;
+				case "Greece":
+				case "GoodGuy":
+					color = "blue";
+					faction = "allies";
+					break;
+				case "USSR":
+				case "BadGuy":
+					color = "red";
+					faction = "soviet";
+					break;
+				case "Special":
+				case "Neutral":
+				default:
+					color = "neutral";
+					faction = "allies";
+					break;
 			}
 
 			SetMapPlayers(section, faction, color, file, Players, MapPlayers);

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianDawnMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianDawnMapCommand.cs
@@ -32,10 +32,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 		public override void ValidateMapFormat(int format)
 		{
 			if (format > 1)
-			{
 				Console.WriteLine($"ERROR: Detected NewINIFormat {format}. Are you trying to import a Red Alert map?");
-				return;
-			}
 		}
 
 		static readonly Dictionary<string, (byte Type, byte Index)> OverlayResourceMapping = new()
@@ -145,20 +142,20 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			string faction;
 			switch (section)
 			{
-			case "GoodGuy":
-				color = "gold";
-				faction = "gdi";
-				break;
-			case "BadGuy":
-				color = "red";
-				faction = "nod";
-				break;
-			case "Special":
-			case "Neutral":
-			default:
-				color = "neutral";
-				faction = "gdi";
-				break;
+				case "GoodGuy":
+					color = "gold";
+					faction = "gdi";
+					break;
+				case "BadGuy":
+					color = "red";
+					faction = "nod";
+					break;
+				case "Special":
+				case "Neutral":
+				default:
+					color = "neutral";
+					faction = "gdi";
+					break;
 			}
 
 			SetMapPlayers(section, faction, color, file, Players, MapPlayers);

--- a/OpenRA.Mods.Common/Activities/DeployForGrantedCondition.cs
+++ b/OpenRA.Mods.Common/Activities/DeployForGrantedCondition.cs
@@ -50,8 +50,6 @@ namespace OpenRA.Mods.Common.Activities
 			if (NextActivity != null)
 				foreach (var n in NextActivity.TargetLineNodes(self))
 					yield return n;
-
-			yield break;
 		}
 	}
 

--- a/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
+++ b/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
@@ -103,8 +103,6 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			foreach (var n in getMove().TargetLineNodes(self))
 				yield return n;
-
-			yield break;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Move/Nudge.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Nudge.cs
@@ -59,8 +59,6 @@ namespace OpenRA.Mods.Common.Traits
 			if (ChildActivity != null)
 				foreach (var n in ChildActivity.TargetLineNodes(self))
 					yield return n;
-
-			yield break;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Effects
 		readonly Animation flag;
 		readonly Animation circles;
 
-		readonly List<WPos> targetLineNodes = new() { };
+		readonly List<WPos> targetLineNodes = new();
 		List<CPos> cachedLocations;
 
 		public RallyPointIndicator(Actor building, RallyPoint rp)

--- a/OpenRA.Mods.Common/FileFormats/Blast.cs
+++ b/OpenRA.Mods.Common/FileFormats/Blast.cs
@@ -214,8 +214,7 @@ namespace OpenRA.Mods.Common.FileFormats
 		public int ReadBits(int count)
 		{
 			var ret = 0;
-			var filled = 0;
-			while (filled < count)
+			for (var filled = 0; filled < count; filled++)
 			{
 				if (bitCount == 0)
 				{
@@ -226,7 +225,6 @@ namespace OpenRA.Mods.Common.FileFormats
 				ret |= (bitBuffer & 1) << filled;
 				bitBuffer >>= 1;
 				bitCount--;
-				filled++;
 			}
 
 			return ret;

--- a/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
+++ b/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
@@ -632,17 +632,20 @@ namespace OpenRA.Mods.Common.Pathfinder
 		}
 
 		/// <summary>
+		/// <para>
 		/// <see cref="BlockedByActor.Immovable"/> defines immovability based on the mobile trait. The blocking rules
 		/// in <see cref="Locomotor.CanMoveFreelyInto(Actor, CPos, SubCell, BlockedByActor, Actor, bool)"/> allow units
 		/// to pass these immovable actors if they are temporary blockers (e.g. gates) or crushable by the locomotor.
 		/// Since our abstract graph must work for any actor, we have to be conservative and can only consider a subset
 		/// of the immovable actors in the graph - ones we know cannot be passed by some actors due to these rules.
 		/// Both this and <see cref="ActorCellIsBlocking"/> must be true for a cell to be blocked.
-		///
+		/// </para>
+		/// <para>
 		/// This method is dependant on the logic in
 		/// <see cref="Locomotor.CanMoveFreelyInto(Actor, CPos, SubCell, BlockedByActor, Actor, bool)"/> and
 		/// <see cref="Locomotor.UpdateCellBlocking"/>. This method must be kept in sync with changes in the locomotor
 		/// rules.
+		/// </para>
 		/// </summary>
 		bool ActorIsBlocking(Actor actor)
 		{

--- a/OpenRA.Mods.Common/Scripting/CallLuaFunc.cs
+++ b/OpenRA.Mods.Common/Scripting/CallLuaFunc.cs
@@ -46,7 +46,6 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			base.Cancel(self, keepQueue);
 			Dispose();
-			return;
 		}
 
 		public void Dispose()

--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -159,11 +159,10 @@ namespace OpenRA.Mods.Common.Scripting
 
 		Action WrapOnPlayComplete(LuaFunction onPlayComplete)
 		{
-			Action onComplete;
 			if (onPlayComplete != null)
 			{
 				var f = (LuaFunction)onPlayComplete.CopyReference();
-				onComplete = () =>
+				return () =>
 				{
 					try
 					{
@@ -177,9 +176,7 @@ namespace OpenRA.Mods.Common.Scripting
 				};
 			}
 			else
-				onComplete = () => { };
-
-			return onComplete;
+				return () => { };
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/AcceptsDeliveredExperience.cs
+++ b/OpenRA.Mods.Common/Traits/AcceptsDeliveredExperience.cs
@@ -26,8 +26,5 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new AcceptsDeliveredExperience(); }
 	}
 
-	public class AcceptsDeliveredExperience
-	{
-		public AcceptsDeliveredExperience() { }
-	}
+	public class AcceptsDeliveredExperience { }
 }

--- a/OpenRA.Mods.Common/Traits/ActorSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/ActorSpawner.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class ActorSpawnerInfo : ConditionalTraitInfo
 	{
 		[Desc("Type of ActorSpawner with which it connects.")]
-		public readonly HashSet<string> Types = new() { };
+		public readonly HashSet<string> Types = new();
 
 		public override object Create(ActorInitializer init) { return new ActorSpawner(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/MinelayerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/MinelayerBotModule.cs
@@ -149,7 +149,7 @@ namespace OpenRA.Mods.Common.Traits
 						foreach (var minelayer in minelayers)
 						{
 							var cells = pathFinder.FindPathToTargetCell(minelayer.Actor, new[] { minelayer.Actor.Location }, enemy.Location, BlockedByActor.Immovable, laneBias: false);
-							if (cells != null && !(cells.Count == 0))
+							if (cells != null && cells.Count != 0)
 							{
 								AIUtils.BotDebug($"{player}: try find a location to lay mine.");
 								EnqueueConflictPosition(cells[cells.Count / 2]);
@@ -193,7 +193,7 @@ namespace OpenRA.Mods.Common.Traits
 				foreach (var minelayer in minelayers)
 				{
 					var cells = pathFinder.FindPathToTargetCell(minelayer.Actor, new[] { minelayer.Actor.Location }, minelayingPosition, BlockedByActor.Immovable, laneBias: false);
-					if (cells != null && !(cells.Count == 0))
+					if (cells != null && cells.Count != 0)
 					{
 						orderedActors.Add(minelayer.Actor);
 

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[ActorReference]
 		[FieldLoader.Require]
-		public readonly HashSet<string> DockActors = new() { };
+		public readonly HashSet<string> DockActors = new();
 
 		[VoiceReference]
 		public readonly string Voice = "Action";

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoRepairable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoRepairable.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[ActorReference]
 		[FieldLoader.Require]
-		public readonly HashSet<string> RepairActors = new() { };
+		public readonly HashSet<string> RepairActors = new();
 
 		[VoiceReference]
 		public readonly string Voice = "Action";

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -313,7 +313,7 @@ namespace OpenRA.Mods.Common.Traits
 				Uncloak();
 		}
 
-		void INotifySupportPower.Charged(Actor self) { return; }
+		void INotifySupportPower.Charged(Actor self) { }
 
 		void INotifySupportPower.Activated(Actor self)
 		{

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeployWithCharge.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeployWithCharge.cs
@@ -256,8 +256,6 @@ namespace OpenRA.Mods.Common.Traits
 			if (NextActivity != null)
 				foreach (var n in NextActivity.TargetLineNodes(self))
 					yield return n;
-
-			yield break;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Player/ClassicParallelProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicParallelProductionQueue.cs
@@ -181,10 +181,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			if (!anyProducers)
-			{
 				CancelProduction(unit.Name, 1);
-				return false;
-			}
 
 			return false;
 		}

--- a/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
@@ -131,10 +131,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			if (!anyProducers)
-			{
 				CancelProduction(unit.Name, 1);
-				return false;
-			}
 
 			return false;
 		}

--- a/OpenRA.Mods.Common/Traits/Player/TechTree.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TechTree.cs
@@ -171,7 +171,7 @@ namespace OpenRA.Mods.Common.Traits
 				var nowHasPrerequisites = !hasReachedLimit && HasPrerequisites(ownedPrerequisites);
 				var nowHidden = IsHidden(ownedPrerequisites);
 
-				if (initialized == false)
+				if (!initialized)
 				{
 					initialized = true;
 					hasPrerequisites = !nowHasPrerequisites;

--- a/OpenRA.Mods.Common/Traits/Rearmable.cs
+++ b/OpenRA.Mods.Common/Traits/Rearmable.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 		[ActorReference]
 		[FieldLoader.Require]
 		[Desc("Actors that this actor can dock to and get rearmed by.")]
-		public readonly HashSet<string> RearmActors = new() { };
+		public readonly HashSet<string> RearmActors = new();
 
 		[Desc("Name(s) of AmmoPool(s) that use this trait to rearm.")]
 		public readonly HashSet<string> AmmoPools = new() { "primary" };

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
@@ -76,16 +76,18 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			// Per-actor production
 			queues = self.TraitsImplementing<ProductionQueue>()
-				.Where(q => productionInfos.Any(p => p.Produces.Contains(q.Info.Type)))
-				.Where(q => Info.Queues.Count == 0 || Info.Queues.Contains(q.Info.Type))
+				.Where(q =>
+					productionInfos.Any(p => p.Produces.Contains(q.Info.Type)) &&
+					(Info.Queues.Count == 0 || Info.Queues.Contains(q.Info.Type)))
 				.ToArray();
 
 			if (queues.Length == 0)
 			{
 				// Player-wide production
 				queues = self.Owner.PlayerActor.TraitsImplementing<ProductionQueue>()
-					.Where(q => productionInfos.Any(p => p.Produces.Contains(q.Info.Type)))
-					.Where(q => Info.Queues.Count == 0 || Info.Queues.Contains(q.Info.Type))
+					.Where(q =>
+						productionInfos.Any(p => p.Produces.Contains(q.Info.Type)) &&
+						(Info.Queues.Count == 0 || Info.Queues.Contains(q.Info.Type)))
 					.ToArray();
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[ActorReference]
 		[FieldLoader.Require]
-		public readonly HashSet<string> RepairActors = new() { };
+		public readonly HashSet<string> RepairActors = new();
 
 		[VoiceReference]
 		public readonly string Voice = "Action";

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[ActorReference]
 		[FieldLoader.Require]
-		public readonly HashSet<string> RepairActors = new() { };
+		public readonly HashSet<string> RepairActors = new();
 
 		public readonly WDist CloseEnough = WDist.FromCells(4);
 

--- a/OpenRA.Mods.Common/Traits/World/ActorSpawnManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorSpawnManager.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Owner = "Creeps";
 
 		[Desc("Type of ActorSpawner with which it connects.")]
-		public readonly HashSet<string> Types = new() { };
+		public readonly HashSet<string> Types = new();
 
 		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RemoveLaysTerrain.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/RemoveLaysTerrain.cs
@@ -23,8 +23,6 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 		{
 			if (actorNode.RemoveNodes("LaysTerrain") > 0)
 				yield return $"'LaysTerrain' was removed from {actorNode.Key} ({actorNode.Location.Filename}) without replacement.\n";
-
-			yield break;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230801/ExtractResourceStorageFromHarvester.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230801/ExtractResourceStorageFromHarvester.cs
@@ -42,8 +42,6 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				storesResources.AddNode(resources);
 
 			actorNode.AddNode(storesResources);
-
-			yield break;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230801/RemoveValidRelationsFromCapturable.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230801/RemoveValidRelationsFromCapturable.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {
@@ -24,7 +23,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override IEnumerable<string> AfterUpdate(ModData modData)
 		{
-			if (locations.Any())
+			if (locations.Count > 0)
 				yield return Description + "\n" +
 					"ValidRelations have been removed from:\n" +
 					UpdateUtils.FormatMessageList(locations);

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -15,7 +15,7 @@ using OpenRA.Mods.Common.UpdateRules.Rules;
 
 namespace OpenRA.Mods.Common.UpdateRules
 {
-	public class UpdatePath
+	public sealed class UpdatePath
 	{
 		// Define known update paths from stable tags to the current bleed tip
 		//

--- a/OpenRA.Mods.Common/Widgets/ExponentialSliderWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ExponentialSliderWidget.cs
@@ -19,8 +19,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public double ExpA = 1.0e-3;
 		public double ExpB = 6.908;
 
-		public ExponentialSliderWidget()
-			: base() { }
+		public ExponentialSliderWidget() { }
 
 		public ExponentialSliderWidget(ExponentialSliderWidget other)
 			: base(other) { }

--- a/OpenRA.Mods.Common/Widgets/HotkeyEntryWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/HotkeyEntryWidget.cs
@@ -44,11 +44,6 @@ namespace OpenRA.Mods.Common.Widgets
 			VisualHeight = widget.VisualHeight;
 		}
 
-		public override bool TakeKeyboardFocus()
-		{
-			return base.TakeKeyboardFocus();
-		}
-
 		public override bool YieldKeyboardFocus()
 		{
 			OnLoseFocus();

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -225,7 +225,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					Log.Write("debug", $"Map editor ignoring actor {actor.Name}, "
 						+ $"because of missing sprites for tileset {World.Map.Rules.TerrainInfo.Id}.");
-					continue;
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -326,7 +326,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		static void SaveMapFailed(Exception e, ModData modData, World world)
 		{
-			Log.Write("debug", $"Failed to save map.");
+			Log.Write("debug", "Failed to save map.");
 			Log.Write("debug", e);
 
 			var actionManager = world.WorldActor.TraitOrDefault<EditorActionManager>();

--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -105,13 +105,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				defaultSaveFilename = world.Map.Title;
 				var filenameAttempt = 0;
-				while (true)
-				{
-					if (!File.Exists(Path.Combine(baseSavePath, defaultSaveFilename + ".orasav")))
-						break;
-
+				while (File.Exists(Path.Combine(baseSavePath, defaultSaveFilename + ".orasav")))
 					defaultSaveFilename = world.Map.Title + $" ({++filenameAttempt})";
-				}
 
 				var saveButton = panel.Get<ButtonWidget>("SAVE_BUTTON");
 				saveButton.IsDisabled = () => string.IsNullOrWhiteSpace(saveTextField.Text);

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -323,11 +323,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				playerCountFilter = -1;
 
 			var maps = tabMaps[tab]
-				.Where(m => category == null || m.Categories.Contains(category))
-				.Where(m => mapFilter == null ||
+				.Where(m => (category == null || m.Categories.Contains(category)) &&
+					(mapFilter == null ||
 					(m.Title != null && m.Title.Contains(mapFilter, StringComparison.CurrentCultureIgnoreCase)) ||
 					(m.Author != null && m.Author.Contains(mapFilter, StringComparison.CurrentCultureIgnoreCase)) ||
-					m.PlayerCount == playerCountFilter);
+					m.PlayerCount == playerCountFilter));
 
 			if (orderByFunc == null)
 				maps = maps.OrderBy(m => m.Title);

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -688,7 +688,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			foreach (var replay in replays)
 				replayState[replay].Visible = EvaluateReplayVisibility(replay);
 
-			if (selectedReplay == null || replayState[selectedReplay].Visible == false)
+			if (selectedReplay == null || !replayState[selectedReplay].Visible)
 				SelectFirstVisibleReplay();
 
 			replayList.Layout.AdjustChildren();

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -570,7 +570,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			catch (Exception ex)
 			{
 				Log.Write("debug", ex.ToString());
-				return;
 			}
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -235,7 +235,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (e.ErrorCode == 10048)
 					message += "\n" + TranslationProvider.GetString(ServerCreationFailedPortUsed);
 				else
-					message += $"\n" + TranslationProvider.GetString(ServerCreationFailedError,
+					message += "\n" + TranslationProvider.GetString(ServerCreationFailedError,
 						Translation.Arguments("message", e.Message, "code", e.ErrorCode));
 
 				ConfirmationDialogs.ButtonPrompt(modData, ServerCreationFailedTitle, message,

--- a/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.D2k.Traits
 			if (world.ActorMap.GetActorsAt(cell).Any(a => a.TraitOrDefault<Building>() != null))
 				return;
 
-			strength[cell] = strength[cell] - damage;
+			strength[cell] -= damage;
 			if (strength[cell] < 1)
 				RemoveTile(cell);
 		}

--- a/OpenRA.Mods.D2k/Traits/World/D2kResourceRenderer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/D2kResourceRenderer.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.D2k.Traits
 			BottomLeft = 0x40,
 			BottomRight = 0x80,
 
-			All = 0xFF
+			All = Left | Top | Right | Bottom | TopLeft | TopRight | BottomLeft | BottomRight
 		}
 
 		public static readonly Dictionary<ClearSides, int> SpriteMap = new()

--- a/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
@@ -18,7 +18,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Mods.D2k.UtilityCommands
 {
-	public class D2kMapImporter
+	public sealed class D2kMapImporter
 	{
 		const int MapCordonWidth = 2;
 

--- a/OpenRA.Platforms.Default/DummySoundEngine.cs
+++ b/OpenRA.Platforms.Default/DummySoundEngine.cs
@@ -27,8 +27,6 @@ namespace OpenRA.Platforms.Default
 			return defaultDevices;
 		}
 
-		public DummySoundEngine() { }
-
 		public ISoundSource AddSoundSourceFromMemory(byte[] data, int channels, int sampleBits, int sampleRate)
 		{
 			return new NullSoundSource();

--- a/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
+++ b/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Platforms.Default
 			var buffer = new List<byte>();
 			var offset = 0;
 
-			while (true)
+			do
 			{
 				var b = Marshal.ReadByte(devicesPtr, offset++);
 				if (b != 0)
@@ -85,11 +85,8 @@ namespace OpenRA.Platforms.Default
 				// A null indicates termination of that string, so add that to our list.
 				devices.Add(Encoding.UTF8.GetString(buffer.ToArray()));
 				buffer.Clear();
-
-				// Two successive nulls indicates the end of the list.
-				if (Marshal.ReadByte(devicesPtr, offset) == 0)
-					break;
 			}
+			while (Marshal.ReadByte(devicesPtr, offset) != 0); // Two successive nulls indicates the end of the list.
 
 			return devices.ToArray();
 		}

--- a/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
+++ b/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
@@ -544,11 +544,11 @@ Test:
 		[TestCase(TestName = "Comments are correctly separated from values")]
 		public void TestEscapedHashInValues()
 		{
-			var trailingWhitespace = MiniYaml.FromString(@"key: value # comment", "trailingWhitespace", discardCommentsAndWhitespace: false)[0];
+			var trailingWhitespace = MiniYaml.FromString("key: value # comment", "trailingWhitespace", discardCommentsAndWhitespace: false)[0];
 			Assert.AreEqual("value", trailingWhitespace.Value.Value);
 			Assert.AreEqual(" comment", trailingWhitespace.Comment);
 
-			var noWhitespace = MiniYaml.FromString(@"key:value# comment", "noWhitespace", discardCommentsAndWhitespace: false)[0];
+			var noWhitespace = MiniYaml.FromString("key:value# comment", "noWhitespace", discardCommentsAndWhitespace: false)[0];
 			Assert.AreEqual("value", noWhitespace.Value.Value);
 			Assert.AreEqual(" comment", noWhitespace.Comment);
 
@@ -556,15 +556,15 @@ Test:
 			Assert.AreEqual("before # after", escapedHashInValue.Value.Value);
 			Assert.AreEqual(" comment", escapedHashInValue.Comment);
 
-			var emptyValueAndComment = MiniYaml.FromString(@"key:#", "emptyValueAndComment", discardCommentsAndWhitespace: false)[0];
+			var emptyValueAndComment = MiniYaml.FromString("key:#", "emptyValueAndComment", discardCommentsAndWhitespace: false)[0];
 			Assert.AreEqual(null, emptyValueAndComment.Value.Value);
 			Assert.AreEqual("", emptyValueAndComment.Comment);
 
-			var noValue = MiniYaml.FromString(@"key:", "noValue", discardCommentsAndWhitespace: false)[0];
+			var noValue = MiniYaml.FromString("key:", "noValue", discardCommentsAndWhitespace: false)[0];
 			Assert.AreEqual(null, noValue.Value.Value);
 			Assert.AreEqual(null, noValue.Comment);
 
-			var emptyKey = MiniYaml.FromString(@" : value", "emptyKey", discardCommentsAndWhitespace: false)[0];
+			var emptyKey = MiniYaml.FromString(" : value", "emptyKey", discardCommentsAndWhitespace: false)[0];
 			Assert.AreEqual(null, emptyKey.Key);
 			Assert.AreEqual("value", emptyKey.Value.Value);
 			Assert.AreEqual(null, emptyKey.Comment);


### PR DESCRIPTION
Following on from #21013.

Enforces 23 Roslynator rules across the project.

I have batched together a PR for these rules as they each had limited existing violations and are hopefully uncontroversial. However fixes are arranged per commit so we can easily bikeshed over rules as desired.

Reviewing with Ignore Whitespace will make the diff in a couple of files less cumbersome.

See https://josefpihrt.github.io/docs/roslynator/analyzers for explanation of each rule.