### PR TITLE
Add custom map pool support for dedicated servers

### DIFF
--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -233,7 +233,7 @@ namespace OpenRA
 				.ToList();
 
 			foreach (var uid in queryUids)
-				previews[uid].UpdateRemoteSearch(MapStatus.Searching, null);
+				previews[uid].UpdateRemoteSearch(MapStatus.Searching, null, null);
 
 			Task.Run(async () =>
 			{
@@ -251,13 +251,13 @@ namespace OpenRA
 
 						var yaml = MiniYaml.FromStream(result);
 						foreach (var kv in yaml)
-							previews[kv.Key].UpdateRemoteSearch(MapStatus.DownloadAvailable, kv.Value, mapDetailsReceived);
+							previews[kv.Key].UpdateRemoteSearch(MapStatus.DownloadAvailable, kv.Value, modData.Manifest.MapCompatibility, mapDetailsReceived);
 
 						foreach (var uid in batchUids)
 						{
 							var p = previews[uid];
 							if (p.Status != MapStatus.DownloadAvailable)
-								p.UpdateRemoteSearch(MapStatus.Unavailable, null);
+								p.UpdateRemoteSearch(MapStatus.Unavailable, null, null);
 						}
 					}
 					catch (Exception e)
@@ -269,7 +269,7 @@ namespace OpenRA
 						foreach (var uid in batchUids)
 						{
 							var p = previews[uid];
-							p.UpdateRemoteSearch(MapStatus.Unavailable, null);
+							p.UpdateRemoteSearch(MapStatus.Unavailable, null, null);
 							mapQueryFailed?.Invoke(p);
 						}
 					}

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -59,6 +59,7 @@ namespace OpenRA
 		public readonly string rules;
 		public readonly string players_block;
 		public readonly int mapformat;
+		public readonly string game_mod;
 	}
 
 	public sealed class MapPreview : IDisposable, IReadOnlyFileSystem
@@ -427,7 +428,7 @@ namespace OpenRA
 			innerData = newData;
 		}
 
-		public void UpdateRemoteSearch(MapStatus status, MiniYaml yaml, Action<MapPreview> parseMetadata = null)
+		public void UpdateRemoteSearch(MapStatus status, MiniYaml yaml, string[] mapCompatibility, Action<MapPreview> parseMetadata = null)
 		{
 			var newData = innerData.Clone();
 			newData.Status = status;
@@ -479,6 +480,12 @@ namespace OpenRA
 					var rulesString = Encoding.UTF8.GetString(Convert.FromBase64String(r.rules));
 					var rulesYaml = new MiniYaml("", MiniYaml.FromString(rulesString)).ToDictionary();
 					newData.SetCustomRules(modData, this, rulesYaml, null);
+
+					// Map is for a different mod: update its information so it can be displayed
+					// in the cross-mod server browser UI, but mark it as unavailable so it can't
+					// be selected in a server for the current mod.
+					if (!mapCompatibility.Contains(r.game_mod))
+						newData.Status = MapStatus.Unavailable;
 				}
 				catch (Exception e)
 				{

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -39,6 +39,9 @@ namespace OpenRA.Network
 		public string ServerError = null;
 		public bool AuthenticationFailed = false;
 
+		// The default null means "no map restriction" while an empty set means "all maps restricted"
+		public HashSet<string> ServerMapPool = null;
+
 		public int NetFrameNumber { get; private set; }
 		public int LocalFrameNumber;
 

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -383,6 +383,12 @@ namespace OpenRA.Network
 						break;
 					}
 
+				case "SyncMapPool":
+					{
+						orderManager.ServerMapPool = FieldLoader.GetValue<HashSet<string>>("SyncMapPool", order.TargetString);
+						break;
+					}
+
 				default:
 					{
 						if (world == null)

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -102,6 +102,9 @@ namespace OpenRA
 		[Desc("For dedicated servers only, treat maps that fail the lint checks as invalid.")]
 		public bool EnableLintChecks = true;
 
+		[Desc("For dedicated servers only, a comma separated list of map uids that are allowed to be used.")]
+		public string[] MapPool = Array.Empty<string>();
+
 		[Desc("Delay in milliseconds before newly joined players can send chat messages.")]
 		public int FloodLimitJoinCooldown = 5000;
 

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -11,12 +11,15 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Widgets.Logic;
 using OpenRA.Network;
 using OpenRA.Primitives;
 using OpenRA.Server;
+using OpenRA.Support;
 using OpenRA.Traits;
 using S = OpenRA.Server.Server;
 
@@ -570,6 +573,12 @@ namespace OpenRA.Mods.Common.Server
 					return true;
 				}
 
+				if (server.MapPool != null && !server.MapPool.Contains(s))
+				{
+					QueryFailed();
+					return true;
+				}
+
 				var lastMap = server.LobbyInfo.GlobalSettings.Map;
 				void SelectMap(MapPreview map)
 				{
@@ -659,8 +668,6 @@ namespace OpenRA.Mods.Common.Server
 					}
 				}
 
-				void QueryFailed() => server.SendLocalizedMessageTo(conn, UnknownMap);
-
 				var m = server.ModData.MapCache[s];
 				if (m.Status == MapStatus.Available || m.Status == MapStatus.DownloadAvailable)
 					SelectMap(m);
@@ -682,6 +689,8 @@ namespace OpenRA.Mods.Common.Server
 
 				return true;
 			}
+
+			void QueryFailed() => server.SendLocalizedMessageTo(conn, UnknownMap);
 		}
 
 		static bool Option(S server, Connection conn, Session.Client client, string s)
@@ -1227,16 +1236,68 @@ namespace OpenRA.Mods.Common.Server
 			}
 		}
 
+		static void InitializeMapPool(S server)
+		{
+			if (server.Type != ServerType.Dedicated)
+				return;
+
+			var mapCache = server.ModData.MapCache;
+			if (server.Settings.MapPool.Length > 0)
+				server.MapPool = server.Settings.MapPool.ToHashSet();
+			else if (!server.Settings.QueryMapRepository)
+				server.MapPool = mapCache
+					.Where(p => p.Status == MapStatus.Available && p.Visibility.HasFlag(MapVisibility.Lobby))
+					.Select(p => p.Uid)
+					.ToHashSet();
+			else
+				return;
+
+			var unknownMaps = server.MapPool.Where(server.MapIsUnknown);
+			if (server.Settings.QueryMapRepository && unknownMaps.Any())
+			{
+				Log.Write("server", $"Querying Resource Center for information on {unknownMaps.Count()} maps...");
+
+				// Query any missing maps and wait up to 10 seconds for a response
+				// Maps that have not resolved will not be valid for the initial map choice
+				var mapRepository = server.ModData.Manifest.Get<WebServices>().MapRepository;
+				mapCache.QueryRemoteMapDetails(mapRepository, unknownMaps);
+
+				var searchingMaps = server.MapPool.Where(uid => mapCache[uid].Status == MapStatus.Searching);
+				var stopwatch = Stopwatch.StartNew();
+				while (searchingMaps.Any() && stopwatch.ElapsedMilliseconds < 10000)
+					Thread.Sleep(100);
+			}
+
+			if (unknownMaps.Any())
+				Log.Write("server", "Failed to resolve maps: " + unknownMaps.JoinWith(", "));
+		}
+
+		static string ChooseInitialMap(S server)
+		{
+			if (server.MapIsKnown(server.Settings.Map))
+				return server.Settings.Map;
+
+			if (server.MapPool == null)
+				return server.ModData.MapCache.ChooseInitialMap(server.Settings.Map, new MersenneTwister());
+
+			return server.MapPool
+				.Where(server.MapIsKnown)
+				.RandomOrDefault(new MersenneTwister());
+		}
+
 		public void ServerStarted(S server)
 		{
 			lock (server.LobbyInfo)
 			{
-				// Remote maps are not supported for the initial map
-				var uid = server.LobbyInfo.GlobalSettings.Map;
-				server.Map = server.ModData.MapCache[uid];
-				if (server.Map.Status != MapStatus.Available)
-					throw new InvalidOperationException($"Map {uid} not found");
+				InitializeMapPool(server);
 
+				var uid = ChooseInitialMap(server);
+				if (string.IsNullOrEmpty(uid))
+					throw new InvalidOperationException("Unable to resolve a valid initial map");
+
+				server.LobbyInfo.GlobalSettings.Map = server.Settings.Map = uid;
+				server.Map = server.ModData.MapCache[uid];
+				server.LobbyInfo.GlobalSettings.MapStatus = server.MapStatusCache[server.Map];
 				server.LobbyInfo.Slots = server.Map.Players.Players
 					.Select(p => MakeSlotFromPlayerReference(p.Value))
 					.Where(s => s != null)

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -1396,6 +1396,9 @@ namespace OpenRA.Mods.Common.Server
 		{
 			lock (server.LobbyInfo)
 			{
+				if (server.MapPool != null)
+					server.SendOrderTo(conn, "SyncMapPool", FieldSaver.FormatValue(server.MapPool));
+
 				var client = server.GetClient(conn);
 
 				// Validate whether color is allowed and get an alternative if it isn't

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -236,7 +236,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var onSelect = new Action<string>(uid =>
 					{
 						// Don't select the same map again, and handle map becoming unavailable
-						if (uid == map.Uid || modData.MapCache[uid].Status != MapStatus.Available)
+						var status = modData.MapCache[uid].Status;
+						if (uid == map.Uid || (status != MapStatus.Available && status != MapStatus.DownloadAvailable))
 							return;
 
 						orderManager.IssueOrder(Order.Command("map " + uid));
@@ -250,6 +251,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					Ui.OpenWindow("MAPCHOOSER_PANEL", new WidgetArgs()
 					{
 						{ "initialMap", modData.MapCache.PickLastModifiedMap(MapVisibility.Lobby) ?? map.Uid },
+						{ "remoteMapPool", orderManager.ServerMapPool },
 						{ "initialTab", MapClassification.System },
 						{ "onExit", modData.MapCache.UpdateMaps },
 						{ "onSelect", Game.IsHost ? onSelect : null },

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -204,6 +204,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Game.OpenWindow("MAPCHOOSER_PANEL", new WidgetArgs()
 				{
 					{ "initialMap", null },
+					{ "remoteMapPool", null },
 					{ "initialTab", MapClassification.User },
 					{ "onExit", () => SwitchMenu(MenuType.MapEditor) },
 					{ "onSelect", onSelect },

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -95,6 +95,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					Ui.OpenWindow("MAPCHOOSER_PANEL", new WidgetArgs()
 					{
 						{ "initialMap", map.Uid },
+						{ "remoteMapPool", null },
 						{ "initialTab", MapClassification.System },
 						{ "onExit", () => modData.MapCache.UpdateMaps() },
 						{ "onSelect", (Action<string>)(uid => map = modData.MapCache[uid]) },

--- a/OpenRA.Server/Program.cs
+++ b/OpenRA.Server/Program.cs
@@ -16,7 +16,6 @@ using System.IO;
 using System.Net;
 using System.Threading;
 using OpenRA.Network;
-using OpenRA.Support;
 
 namespace OpenRA.Server
 {
@@ -89,8 +88,6 @@ namespace OpenRA.Server
 
 				// HACK: Related to the above one, initialize the translations so we can load maps with their (translated) lobby options.
 				TranslationProvider.Initialize(modData, modData.DefaultFileSystem);
-
-				settings.Map = modData.MapCache.ChooseInitialMap(settings.Map, new MersenneTwister());
 
 				var endpoints = new List<IPEndPoint> { new IPEndPoint(IPAddress.IPv6Any, settings.ListenPort), new IPEndPoint(IPAddress.Any, settings.ListenPort) };
 				var server = new Server(endpoints, settings, modData, ServerType.Dedicated);

--- a/mods/cnc/chrome/mapchooser.yaml
+++ b/mods/cnc/chrome/mapchooser.yaml
@@ -23,6 +23,12 @@ Container@MAPCHOOSER_PANEL:
 					Height: 31
 					Width: 135
 					Text: button-bg-system-maps-tab
+				Button@REMOTE_MAPS_TAB_BUTTON:
+					X: 15
+					Y: 15
+					Height: 31
+					Width: 135
+					Text: button-bg-remote-maps-tab
 				Button@USER_MAPS_TAB_BUTTON:
 					X: 155
 					Y: 15
@@ -36,6 +42,14 @@ Container@MAPCHOOSER_PANEL:
 					Y: 45
 					Children:
 						Container@SYSTEM_MAPS_TAB:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Children:
+								ScrollPanel@MAP_LIST:
+									Width: PARENT_RIGHT
+									Height: PARENT_BOTTOM
+									ItemSpacing: 1
+						Container@REMOTE_MAPS_TAB:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							Children:
@@ -134,6 +148,13 @@ Container@MAPCHOOSER_PANEL:
 							X: PARENT_RIGHT - WIDTH
 							Width: 200
 							Height: 25
+				Label@REMOTE_MAP_LABEL:
+					X: 140
+					Y: 539
+					Width: PARENT_RIGHT - 430
+					Height: 35
+					Align: Center
+					Font: Bold
 				Button@BUTTON_CANCEL:
 					Key: escape
 					Y: PARENT_BOTTOM - 1

--- a/mods/cnc/languages/chrome/en.ftl
+++ b/mods/cnc/languages/chrome/en.ftl
@@ -499,6 +499,7 @@ label-update-notice-b = Download the latest version from www.openra.net
 ## mapchooser.yaml
 label-mapchooser-panel-title = Select Map
 button-bg-system-maps-tab = Official Maps
+button-bg-remote-maps-tab = Server Maps
 button-bg-user-maps-tab = Custom Maps
 label-filter-order-controls-desc = Filter:
 label-filter-order-controls-desc-joiner = in

--- a/mods/common/chrome/map-chooser.yaml
+++ b/mods/common/chrome/map-chooser.yaml
@@ -19,6 +19,13 @@ Background@MAPCHOOSER_PANEL:
 			Width: 140
 			Text: button-mapchooser-panel-system-maps-tab
 			Font: Bold
+		Button@REMOTE_MAPS_TAB_BUTTON:
+			X: 20
+			Y: 48
+			Height: 31
+			Width: 140
+			Text: button-mapchooser-panel-remote-maps-tab
+			Font: Bold
 		Button@USER_MAPS_TAB_BUTTON:
 			X: 160
 			Y: 48
@@ -33,6 +40,13 @@ Background@MAPCHOOSER_PANEL:
 			Y: 77
 			Children:
 				Container@SYSTEM_MAPS_TAB:
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
+					Children:
+						ScrollPanel@MAP_LIST:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+				Container@REMOTE_MAPS_TAB:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM
 					Children:
@@ -149,6 +163,13 @@ Background@MAPCHOOSER_PANEL:
 			Width: 120
 			Height: 25
 			Text: button-mapchooser-panel-delete-all-maps
+			Font: Bold
+		Label@REMOTE_MAP_LABEL:
+			X: 140
+			Y: PARENT_BOTTOM - HEIGHT - 20
+			Width: PARENT_RIGHT - 410
+			Height: 25
+			Align: Center
 			Font: Bold
 		Button@BUTTON_OK:
 			X: PARENT_RIGHT - 270

--- a/mods/common/languages/chrome/en.ftl
+++ b/mods/common/languages/chrome/en.ftl
@@ -350,6 +350,7 @@ label-update-notice-b = Download the latest version from www.openra.net
 ## map-chooser.yaml
 label-mapchooser-panel-title = Choose Map
 button-mapchooser-panel-system-maps-tab = Official Maps
+button-mapchooser-panel-remote-maps-tab = Server Maps
 button-mapchooser-panel-user-maps-tab = Custom Maps
 label-filter-order-controls-desc = Filter:
 label-filter-order-controls-desc-joiner = in

--- a/mods/common/languages/en.ftl
+++ b/mods/common/languages/en.ftl
@@ -500,6 +500,16 @@ label-map-size-huge = (Huge)
 label-map-size-large = (Large)
 label-map-size-medium = (Medium)
 label-map-size-small = (Small)
+label-map-searching-count =
+    { $count ->
+        [one] Searching the OpenRA Resource Center for { $count } map...
+       *[other] Searching the OpenRA Resource Center for { $count } maps...
+    }
+label-map-unavailable-count =
+    { $count ->
+        [one] { $count } map was not found on the OpenRA Resource Center
+       *[other] { $count } maps were not found on the OpenRA Resource Center
+    }
 
 notification-map-deletion-failed = Failed to delete map '{ $map }'. See the debug.log file for details.
 


### PR DESCRIPTION
#19323 resurrected and updated for translations etc:

> This PR implements two big usability improvements for the ladder and similarly focused servers.
> 
> The first (for server hosts) is a new `Server.MapPool` setting to limit the maps that are allowed to be used on the server without resorting to modifying the local files and disabling RC queries. This setting takes a comma separated list of map UIDs, which may either be local maps or queried from the RC.
> 
> The second (for players) is that the map browser on these servers will now show the map pool, including maps that aren't installed (again, queried from the RC). This removes any confusion about "Map was not found on server" errors, and allows players to install maps directly ingame instead of having to deal with manually installing map packs.
> 
> I think that with this PR we now also implement enough to close #3357. There are too many UI issues around searching and filtering the RC content to realistically support a full ingame browser, so relying on server hosts to curate map packs that players are able to download ingame strikes a good compromise.

