### PR TITLE
Use Array.IndexOf to speed up Shroud.Tick.

### DIFF
--- a/OpenRA.Game/Map/ProjectedCellLayer.cs
+++ b/OpenRA.Game/Map/ProjectedCellLayer.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using OpenRA.Primitives;
 
 namespace OpenRA
@@ -52,6 +53,16 @@ namespace OpenRA
 		public bool Contains(PPos uv)
 		{
 			return Bounds.Contains(uv.U, uv.V);
+		}
+
+		public int IndexOf(T value, int startIndex)
+		{
+			return Array.IndexOf(Entries, value, startIndex);
+		}
+
+		public void SetAll(T value)
+		{
+			Array.Fill(Entries, value);
 		}
 	}
 }

--- a/OpenRA.Game/Traits/Player/Shroud.cs
+++ b/OpenRA.Game/Traits/Player/Shroud.cs
@@ -274,10 +274,8 @@ namespace OpenRA.Traits
 
 		public void AddSource(object key, SourceType type, PPos[] projectedCells)
 		{
-			if (sources.ContainsKey(key))
+			if (!sources.TryAdd(key, new ShroudSource(type, projectedCells)))
 				throw new InvalidOperationException("Attempting to add duplicate shroud source");
-
-			sources[key] = new ShroudSource(type, projectedCells);
 
 			foreach (var puv in projectedCells)
 			{
@@ -309,7 +307,7 @@ namespace OpenRA.Traits
 
 		public void RemoveSource(object key)
 		{
-			if (!sources.TryGetValue(key, out var state))
+			if (!sources.Remove(key, out var state))
 				return;
 
 			foreach (var puv in state.ProjectedCells)
@@ -334,8 +332,6 @@ namespace OpenRA.Traits
 					}
 				}
 			}
-
-			sources.Remove(key);
 		}
 
 		public void ExploreProjectedCells(IEnumerable<PPos> cells)

--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
@@ -143,13 +143,9 @@ namespace OpenRA.Mods.Common.Traits
 
 					if (enableAll)
 					{
-						self.Owner.Shroud.ExploreAll();
-
 						var amount = order.ExtraData != 0 ? (int)order.ExtraData : info.Cash;
 						self.Trait<PlayerResources>().ChangeCash(amount);
 					}
-					else
-						self.Owner.Shroud.ResetExploration();
 
 					self.Owner.Shroud.Disabled = DisableShroud;
 					if (self.World.LocalPlayer == self.Owner)


### PR DESCRIPTION
As the `touched` cell layer uses Boolean values, Array.IndexOf is able to use a fast vectorised search. Most values in the array are false, so the search is able to significantly improve the performance of finding the next true value in the array.

----

Review with ignore whitespace for a cleaner diff.

Running this replay at max speed on commit https://github.com/OpenRA/OpenRA/commit/5157bc375d554e275b142e650fec27356a8bd63b gives the following performance improvement. [ra-2023-11-04T105726Z.zip](https://github.com/OpenRA/OpenRA/files/13256599/ra-2023-11-04T105726Z.zip)

Before
- Shroud.Tick 14.3%
  - OnShroudChanged 2.5%

After
- Shroud.Tick 6.5%
  - UpdateCell 4.0%
      - OnShroudChanged 2.9%
  - IndexOf 1.8%