### PR TITLE
Use spans to improve performance in StreamExts.

### DIFF
--- a/OpenRA.Game/CryptoUtil.cs
+++ b/OpenRA.Game/CryptoUtil.cs
@@ -165,9 +165,9 @@ namespace OpenRA
 			if (length < 0x80)
 				return length;
 
-			var data = new byte[4];
-			s.ReadBytes(data, 0, Math.Min(length & 0x7F, 4));
-			return BitConverter.ToInt32(data.ToArray(), 0);
+			Span<byte> data = stackalloc byte[4];
+			s.ReadBytes(data[..Math.Min(length & 0x7F, 4)]);
+			return BitConverter.ToInt32(data);
 		}
 
 		static int TripletFullLength(int dataLength)

--- a/OpenRA.Game/FileFormats/Png.cs
+++ b/OpenRA.Game/FileFormats/Png.cs
@@ -48,7 +48,7 @@ namespace OpenRA.FileFormats
 			while (true)
 			{
 				var length = IPAddress.NetworkToHostOrder(s.ReadInt32());
-				var type = Encoding.UTF8.GetString(s.ReadBytes(4));
+				var type = s.ReadASCII(4);
 				var content = s.ReadBytes(length);
 				/*var crc = */s.ReadInt32();
 
@@ -287,10 +287,10 @@ namespace OpenRA.FileFormats
 
 			var typeBytes = Encoding.ASCII.GetBytes(type);
 			output.Write(IPAddress.HostToNetworkOrder((int)input.Length));
-			output.WriteArray(typeBytes);
+			output.Write(typeBytes);
 
 			var data = input.ReadAllBytes();
-			output.WriteArray(data);
+			output.Write(data);
 
 			var crc32 = new Crc32();
 			crc32.Update(typeBytes);
@@ -302,7 +302,7 @@ namespace OpenRA.FileFormats
 		{
 			using (var output = new MemoryStream())
 			{
-				output.WriteArray(Signature);
+				output.Write(Signature);
 				using (var header = new MemoryStream())
 				{
 					header.Write(IPAddress.HostToNetworkOrder(Width));
@@ -371,7 +371,7 @@ namespace OpenRA.FileFormats
 				{
 					using (var text = new MemoryStream())
 					{
-						text.WriteArray(Encoding.ASCII.GetBytes(kv.Key + (char)0 + kv.Value));
+						text.Write(Encoding.ASCII.GetBytes(kv.Key + (char)0 + kv.Value));
 						WritePngChunk(output, "tEXt", text);
 					}
 				}

--- a/OpenRA.Game/FileFormats/ReplayMetadata.cs
+++ b/OpenRA.Game/FileFormats/ReplayMetadata.cs
@@ -47,7 +47,7 @@ namespace OpenRA.FileFormats
 				throw new NotSupportedException($"Metadata version {version} is not supported");
 
 			// Read game info (max 100K limit as a safeguard against corrupted files)
-			var data = fs.ReadString(Encoding.UTF8, 1024 * 100);
+			var data = fs.ReadLengthPrefixedString(Encoding.UTF8, 1024 * 100);
 			GameInfo = GameInformation.Deserialize(data);
 		}
 
@@ -62,7 +62,7 @@ namespace OpenRA.FileFormats
 			{
 				// Write lobby info data
 				writer.Flush();
-				dataLength += writer.BaseStream.WriteString(Encoding.UTF8, GameInfo.Serialize());
+				dataLength += writer.BaseStream.WriteLengthPrefixedString(Encoding.UTF8, GameInfo.Serialize());
 			}
 
 			// Write total length & end marker

--- a/OpenRA.Game/FileSystem/ZipFile.cs
+++ b/OpenRA.Game/FileSystem/ZipFile.cs
@@ -117,10 +117,7 @@ namespace OpenRA.FileSystem
 
 			void Commit()
 			{
-				var pos = pkgStream.Position;
-				pkgStream.Position = 0;
-				File.WriteAllBytes(Name, pkgStream.ReadBytes((int)pkgStream.Length));
-				pkgStream.Position = pos;
+				File.WriteAllBytes(Name, pkgStream.ToArray());
 			}
 
 			public void Update(string filename, byte[] contents)

--- a/OpenRA.Game/Network/Connection.cs
+++ b/OpenRA.Game/Network/Connection.cs
@@ -261,14 +261,14 @@ namespace OpenRA.Network
 			{
 				var ms = new MemoryStream();
 				ms.Write(packet.Length);
-				ms.WriteArray(packet);
+				ms.Write(packet);
 
 				foreach (var s in queuedSyncPackets)
 				{
 					var q = OrderIO.SerializeSync(s);
 
 					ms.Write(q.Length);
-					ms.WriteArray(q);
+					ms.Write(q);
 
 					sentSync.Enqueue(s);
 				}

--- a/OpenRA.Game/Network/OrderIO.cs
+++ b/OpenRA.Game/Network/OrderIO.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Network
 			// the Order objects directly on the local client.
 			data = new MemoryStream();
 			foreach (var o in orders)
-				data.WriteArray(o.Serialize());
+				data.Write(o.Serialize());
 		}
 
 		public OrderPacket(MemoryStream data)
@@ -86,7 +86,7 @@ namespace OpenRA.Network
 			ms.Write(data.Frame);
 			ms.WriteByte((byte)OrderType.SyncHash);
 			ms.Write(data.SyncHash);
-			ms.WriteArray(BitConverter.GetBytes(data.DefeatState));
+			ms.Write(data.DefeatState);
 			return ms.GetBuffer();
 		}
 
@@ -95,7 +95,7 @@ namespace OpenRA.Network
 			var ms = new MemoryStream(14);
 			ms.Write(0);
 			ms.WriteByte((byte)OrderType.Ping);
-			ms.WriteArray(BitConverter.GetBytes(timestamp));
+			ms.Write(timestamp);
 			ms.WriteByte(queueLength);
 			return ms.GetBuffer();
 		}

--- a/OpenRA.Game/Network/ReplayRecorder.cs
+++ b/OpenRA.Game/Network/ReplayRecorder.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Network
 				}
 			}
 
-			file.WriteArray(initialContent);
+			file.Write(initialContent);
 			writer = new BinaryWriter(file);
 		}
 
@@ -93,7 +93,7 @@ namespace OpenRA.Network
 		{
 			var ms = new MemoryStream(4 + data.Length);
 			ms.Write(frame);
-			ms.WriteArray(data);
+			ms.Write(data);
 			Receive(clientID, ms.GetBuffer());
 		}
 

--- a/OpenRA.Game/Server/Connection.cs
+++ b/OpenRA.Game/Server/Connection.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Server
 			ms.Write(0);
 			ms.Write(0);
 			ms.WriteByte((byte)OrderType.Ping);
-			ms.WriteArray(BitConverter.GetBytes(Game.RunTime));
+			ms.Write(Game.RunTime);
 			return ms.GetBuffer();
 		}
 

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -707,7 +707,7 @@ namespace OpenRA.Server
 			ms.Write(data.Length + 4);
 			ms.Write(client);
 			ms.Write(frame);
-			ms.WriteArray(data);
+			ms.Write(data);
 			return ms.GetBuffer();
 		}
 

--- a/OpenRA.Mods.Cnc/FileFormats/HvaReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/HvaReader.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 					Transforms[c + 15] = 1;
 
 					for (var k = 0; k < 12; k++)
-						Transforms[c + ids[k]] = s.ReadFloat();
+						Transforms[c + ids[k]] = s.ReadSingle();
 
 					Array.Copy(Transforms, 16 * (LimbCount * j + i), testMatrix, 0, 16);
 					if (Util.MatrixInverse(testMatrix) == null)

--- a/OpenRA.Mods.Cnc/FileFormats/VqaVideo.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/VqaVideo.cs
@@ -199,16 +199,16 @@ namespace OpenRA.Mods.Cnc.FileFormats
 							else if (AudioChannels == 1)
 							{
 								var rawAudio = stream.ReadBytes((int)length);
-								audio1.WriteArray(rawAudio);
+								audio1.Write(rawAudio);
 							}
 							else
 							{
 								var rawAudio = stream.ReadBytes((int)length / 2);
-								audio1.WriteArray(rawAudio);
+								audio1.Write(rawAudio);
 								rawAudio = stream.ReadBytes((int)length / 2);
-								audio2.WriteArray(rawAudio);
+								audio2.Write(rawAudio);
 								if (length % 2 != 0)
-									stream.ReadBytes(2);
+									stream.Position += 2;
 							}
 
 							compressed = type == "SND2";
@@ -216,7 +216,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 						default:
 							if (length + stream.Position > stream.Length)
 								throw new NotSupportedException($"Vqa uses unknown Subtype: {type}");
-							stream.ReadBytes((int)length);
+							stream.Position += length;
 							break;
 					}
 
@@ -308,7 +308,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 						break;
 					default:
 						// Don't parse sound here.
-						stream.ReadBytes((int)length);
+						stream.Position += length;
 						break;
 				}
 
@@ -382,8 +382,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 					// frame-modifier chunk
 					case "CBP0":
 					case "CBPZ":
-						var bytes = s.ReadBytes(subchunkLength);
-						bytes.CopyTo(cbp, chunkBufferOffset);
+						s.ReadBytes(cbp, chunkBufferOffset, subchunkLength);
 						chunkBufferOffset += subchunkLength;
 						currentChunkBuffer++;
 						cbpIsCompressed = type == "CBPZ";

--- a/OpenRA.Mods.Cnc/FileFormats/VxlReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/VxlReader.cs
@@ -141,12 +141,12 @@ namespace OpenRA.Mods.Cnc.FileFormats
 			{
 				limbDataOffset[i] = s.ReadUInt32();
 				s.Seek(8, SeekOrigin.Current);
-				Limbs[i].Scale = s.ReadFloat();
+				Limbs[i].Scale = s.ReadSingle();
 				s.Seek(48, SeekOrigin.Current);
 
 				Limbs[i].Bounds = new float[6];
 				for (var j = 0; j < 6; j++)
-					Limbs[i].Bounds[j] = s.ReadFloat();
+					Limbs[i].Bounds[j] = s.ReadSingle();
 				Limbs[i].Size = s.ReadBytes(3);
 				Limbs[i].Type = (NormalType)s.ReadUInt8();
 			}

--- a/OpenRA.Mods.Common/FileFormats/ImaAdpcmReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/ImaAdpcmReader.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.IO;
+using System;
 
 namespace OpenRA.Mods.Common.FileFormats
 {
@@ -56,15 +56,14 @@ namespace OpenRA.Mods.Common.FileFormats
 			return (short)current;
 		}
 
-		public static byte[] LoadImaAdpcmSound(byte[] raw, ref int index)
+		public static byte[] LoadImaAdpcmSound(ReadOnlySpan<byte> raw, ref int index)
 		{
 			var currentSample = 0;
 			return LoadImaAdpcmSound(raw, ref index, ref currentSample);
 		}
 
-		public static byte[] LoadImaAdpcmSound(byte[] raw, ref int index, ref int currentSample)
+		public static byte[] LoadImaAdpcmSound(ReadOnlySpan<byte> raw, ref int index, ref int currentSample)
 		{
-			var s = new MemoryStream(raw);
 			var dataSize = raw.Length;
 			var outputSize = raw.Length * 4;
 
@@ -73,7 +72,7 @@ namespace OpenRA.Mods.Common.FileFormats
 
 			while (dataSize-- > 0)
 			{
-				var b = s.ReadUInt8();
+				var b = raw[offset / 4];
 
 				var t = DecodeImaAdpcmSample(b, ref index, ref currentSample);
 				output[offset++] = (byte)t;

--- a/OpenRA.Mods.Common/FileFormats/WestwoodCompressedReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/WestwoodCompressedReader.cs
@@ -20,11 +20,11 @@ namespace OpenRA.Mods.Common.FileFormats
 		static readonly int[] AudWsStepTable2 = { -2, -1, 0, 1 };
 		static readonly int[] AudWsStepTable4 = { -9, -8, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 8 };
 
-		public static void DecodeWestwoodCompressedSample(byte[] input, byte[] output)
+		public static void DecodeWestwoodCompressedSample(ReadOnlySpan<byte> input, Span<byte> output)
 		{
 			if (input.Length == output.Length)
 			{
-				Array.Copy(input, output, output.Length);
+				input.CopyTo(output);
 
 				return;
 			}

--- a/OpenRA.Mods.Common/FileSystem/InstallShieldPackage.cs
+++ b/OpenRA.Mods.Common/FileSystem/InstallShieldPackage.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.FileSystem
 						var dirName = s.ReadASCII(nameLength);
 
 						// Skip to the end of the chunk
-						s.ReadBytes(chunkSize - nameLength - 6);
+						s.Position += chunkSize - nameLength - 6;
 						directories.Add(dirName, fileCount);
 					}
 


### PR DESCRIPTION
Also avoid ReadBytes calls that allocate a buffer by either updating the stream position (if not interested in the bytes), by reusing an input buffer (if interested in the bytes), or using a stackalloc buffer to avoid the allocation (for small reads).

----

This isn't motivated by any specific performance benchmark, but rather just on the basis that moving towards using more span features in something that affects a large chunk of the codebase such as streams will provide some incremental gains.