### PR TITLE
Enable more Roslynator rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -980,6 +980,9 @@ dotnet_diagnostic.RCS1058.severity = warning
 # Avoid locking on publicly accessible instance.
 dotnet_diagnostic.RCS1059.severity = warning
 
+# Merge 'if' with nested 'if'.
+dotnet_diagnostic.RCS1061.severity = warning
+
 # Remove empty 'finally' clause.
 dotnet_diagnostic.RCS1066.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1061,6 +1061,9 @@ dotnet_diagnostic.RCS1159.severity = warning
 # Unused type parameter.
 dotnet_diagnostic.RCS1164.severity = warning
 
+# Use read-only auto-implemented property.
+dotnet_diagnostic.RCS1170.severity = warning
+
 # Use 'is' operator instead of 'as' operator.
 dotnet_diagnostic.RCS1172.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1097,6 +1097,9 @@ dotnet_diagnostic.RCS1199.severity = warning
 # Use EventArgs.Empty.
 dotnet_diagnostic.RCS1204.severity = warning
 
+# Order named arguments according to the order of parameters.
+dotnet_diagnostic.RCS1205.severity = warning
+
 # Order type parameter constraints.
 dotnet_diagnostic.RCS1209.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1004,6 +1004,9 @@ dotnet_diagnostic.RCS1080.severity = warning
 # Use coalesce expression instead of conditional expression.
 dotnet_diagnostic.RCS1084.severity = warning
 
+# Use --/++ operator instead of assignment.
+dotnet_diagnostic.RCS1089.severity = warning
+
 # Remove empty region.
 dotnet_diagnostic.RCS1091.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1028,6 +1028,9 @@ dotnet_diagnostic.RCS1112.severity = warning
 # Use 'string.IsNullOrEmpty' method.
 dotnet_diagnostic.RCS1113.severity = warning
 
+# Mark local variable as const.
+dotnet_diagnostic.RCS1118.severity = warning
+
 # Bitwise operation on enum without Flags attribute.
 dotnet_diagnostic.RCS1130.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1136,5 +1136,9 @@ dotnet_diagnostic.RCS1233.severity = warning
 # Optimize method call.
 dotnet_diagnostic.RCS1235.severity = warning
 
+# Use exception filter.
+dotnet_diagnostic.RCS1236.severity = warning
+
 # Use 'for' statement instead of 'while' statement.
 dotnet_diagnostic.RCS1239.severity = warning
+

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -71,7 +71,7 @@ namespace OpenRA
 		public IEffectiveOwner EffectiveOwner { get; }
 		public IOccupySpace OccupiesSpace { get; }
 		public ITargetable[] Targetables { get; }
-		public IEnumerable<ITargetablePositions> EnabledTargetablePositions { get; private set; }
+		public IEnumerable<ITargetablePositions> EnabledTargetablePositions { get; }
 
 		public bool IsIdle => CurrentActivity == null;
 		public bool IsDead => Disposed || (health != null && health.IsDead);

--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -302,9 +302,9 @@ namespace OpenRA
 
 			// Adjust for other rounding modes
 			if (round == ISqrtRoundMode.Nearest && remainder > root)
-				root += 1;
+				root++;
 			else if (round == ISqrtRoundMode.Ceiling && root * root < number)
-				root += 1;
+				root++;
 
 			return root;
 		}
@@ -343,9 +343,9 @@ namespace OpenRA
 
 			// Adjust for other rounding modes
 			if (round == ISqrtRoundMode.Nearest && remainder > root)
-				root += 1;
+				root++;
 			else if (round == ISqrtRoundMode.Ceiling && root * root < number)
-				root += 1;
+				root++;
 
 			return root;
 		}

--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -195,11 +195,11 @@ namespace OpenRA
 			if (value != null)
 			{
 				var parts = value.Split(SplitComma);
-				if (parts.Length == 3)
-				{
-					if (WDist.TryParse(parts[0], out var rx) && WDist.TryParse(parts[1], out var ry) && WDist.TryParse(parts[2], out var rz))
-						return new WVec(rx, ry, rz);
-				}
+				if (parts.Length == 3
+					&& WDist.TryParse(parts[0], out var rx)
+					&& WDist.TryParse(parts[1], out var ry)
+					&& WDist.TryParse(parts[2], out var rz))
+					return new WVec(rx, ry, rz);
 			}
 
 			return InvalidValueAction(value, fieldType, fieldName);
@@ -219,8 +219,8 @@ namespace OpenRA
 				for (var i = 0; i < vecs.Length; ++i)
 				{
 					if (WDist.TryParse(parts[3 * i], out var rx)
-							&& WDist.TryParse(parts[3 * i + 1], out var ry)
-							&& WDist.TryParse(parts[3 * i + 2], out var rz))
+						&& WDist.TryParse(parts[3 * i + 1], out var ry)
+						&& WDist.TryParse(parts[3 * i + 2], out var rz))
 						vecs[i] = new WVec(rx, ry, rz);
 				}
 
@@ -235,13 +235,11 @@ namespace OpenRA
 			if (value != null)
 			{
 				var parts = value.Split(SplitComma);
-				if (parts.Length == 3)
-				{
-					if (WDist.TryParse(parts[0], out var rx)
-						&& WDist.TryParse(parts[1], out var ry)
-						&& WDist.TryParse(parts[2], out var rz))
-						return new WPos(rx, ry, rz);
-				}
+				if (parts.Length == 3
+					&& WDist.TryParse(parts[0], out var rx)
+					&& WDist.TryParse(parts[1], out var ry)
+					&& WDist.TryParse(parts[2], out var rz))
+					return new WPos(rx, ry, rz);
 			}
 
 			return InvalidValueAction(value, fieldType, fieldName);
@@ -259,13 +257,11 @@ namespace OpenRA
 			if (value != null)
 			{
 				var parts = value.Split(SplitComma);
-				if (parts.Length == 3)
-				{
-					if (Exts.TryParseInt32Invariant(parts[0], out var rr)
-							&& Exts.TryParseInt32Invariant(parts[1], out var rp)
-							&& Exts.TryParseInt32Invariant(parts[2], out var ry))
-						return new WRot(new WAngle(rr), new WAngle(rp), new WAngle(ry));
-				}
+				if (parts.Length == 3
+					&& Exts.TryParseInt32Invariant(parts[0], out var rr)
+					&& Exts.TryParseInt32Invariant(parts[1], out var rp)
+					&& Exts.TryParseInt32Invariant(parts[2], out var ry))
+					return new WRot(new WAngle(rr), new WAngle(rp), new WAngle(ry));
 			}
 
 			return InvalidValueAction(value, fieldType, fieldName);

--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -109,10 +109,8 @@ namespace OpenRA.FileSystem
 
 				Mount(package, explicitName);
 			}
-			catch
+			catch when (optional)
 			{
-				if (!optional)
-					throw;
 			}
 		}
 

--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -226,14 +226,11 @@ namespace OpenRA.FileSystem
 		public bool TryOpen(string filename, out Stream s)
 		{
 			var explicitSplit = filename.IndexOf('|');
-			if (explicitSplit > 0)
+			if (explicitSplit > 0 && explicitMounts.TryGetValue(filename[..explicitSplit], out var explicitPackage))
 			{
-				if (explicitMounts.TryGetValue(filename[..explicitSplit], out var explicitPackage))
-				{
-					s = explicitPackage.GetStream(filename[(explicitSplit + 1)..]);
-					if (s != null)
-						return true;
-				}
+				s = explicitPackage.GetStream(filename[(explicitSplit + 1)..]);
+				if (s != null)
+					return true;
 			}
 
 			s = GetFromCache(filename);
@@ -262,10 +259,10 @@ namespace OpenRA.FileSystem
 		public bool Exists(string filename)
 		{
 			var explicitSplit = filename.IndexOf('|');
-			if (explicitSplit > 0)
-				if (explicitMounts.TryGetValue(filename[..explicitSplit], out var explicitPackage))
-					if (explicitPackage.Contains(filename[(explicitSplit + 1)..]))
-						return true;
+			if (explicitSplit > 0 &&
+				explicitMounts.TryGetValue(filename[..explicitSplit], out var explicitPackage) &&
+				explicitPackage.Contains(filename[(explicitSplit + 1)..]))
+				return true;
 
 			return fileIndex.ContainsKey(filename);
 		}

--- a/OpenRA.Game/Graphics/Sprite.cs
+++ b/OpenRA.Game/Graphics/Sprite.cs
@@ -42,11 +42,11 @@ namespace OpenRA.Graphics
 			// in rendering a line of texels that sample outside the sprite rectangle.
 			// Insetting the texture coordinates by a small fraction of a pixel avoids this
 			// with negligible impact on the 1:1 rendering case.
-			var inset = 1 / 128f;
-			Left = (Math.Min(bounds.Left, bounds.Right) + inset) / sheet.Size.Width;
-			Top = (Math.Min(bounds.Top, bounds.Bottom) + inset) / sheet.Size.Height;
-			Right = (Math.Max(bounds.Left, bounds.Right) - inset) / sheet.Size.Width;
-			Bottom = (Math.Max(bounds.Top, bounds.Bottom) - inset) / sheet.Size.Height;
+			const float Inset = 1 / 128f;
+			Left = (Math.Min(bounds.Left, bounds.Right) + Inset) / sheet.Size.Width;
+			Top = (Math.Min(bounds.Top, bounds.Bottom) + Inset) / sheet.Size.Height;
+			Right = (Math.Max(bounds.Left, bounds.Right) - Inset) / sheet.Size.Width;
+			Bottom = (Math.Max(bounds.Top, bounds.Bottom) - Inset) / sheet.Size.Height;
 		}
 	}
 

--- a/OpenRA.Game/Map/CellRegion.cs
+++ b/OpenRA.Game/Map/CellRegion.cs
@@ -135,12 +135,12 @@ namespace OpenRA
 
 			public bool MoveNext()
 			{
-				u += 1;
+				u++;
 
 				// Check for column overflow
 				if (u > r.mapBottomRight.U)
 				{
-					v += 1;
+					v++;
 					u = r.mapTopLeft.U;
 
 					// Check for row overflow

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -685,16 +685,16 @@ namespace OpenRA
 				writer.Write((ushort)MapSize.Y);
 
 				// Data offsets
-				var tilesOffset = 17;
+				const int TilesOffset = 17;
 				var heightsOffset = Grid.MaximumTerrainHeight > 0 ? 3 * MapSize.X * MapSize.Y + 17 : 0;
 				var resourcesOffset = (Grid.MaximumTerrainHeight > 0 ? 4 : 3) * MapSize.X * MapSize.Y + 17;
 
-				writer.Write((uint)tilesOffset);
+				writer.Write((uint)TilesOffset);
 				writer.Write((uint)heightsOffset);
 				writer.Write((uint)resourcesOffset);
 
 				// Tile data
-				if (tilesOffset != 0)
+				if (TilesOffset != 0)
 				{
 					for (var i = 0; i < MapSize.X; i++)
 					{
@@ -805,7 +805,7 @@ namespace OpenRA
 				bitmapWidth = 2 * bitmapWidth - 1;
 
 			var stride = bitmapWidth * 4;
-			var pxStride = 4;
+			const int PxStride = 4;
 			var minimapData = new byte[stride * height];
 			(Color Left, Color Right) terrainColor = default;
 
@@ -827,10 +827,10 @@ namespace OpenRA
 					{
 						// Odd rows are shifted right by 1px
 						var dx = uv.V & 1;
-						var xOffset = pxStride * (2 * x + dx);
+						var xOffset = PxStride * (2 * x + dx);
 						if (x + dx > 0)
 						{
-							var z = y * stride + xOffset - pxStride;
+							var z = y * stride + xOffset - PxStride;
 							var c = actorColor.A == 0 ? terrainColor.Left : actorColor;
 							minimapData[z++] = c.R;
 							minimapData[z++] = c.G;
@@ -850,7 +850,7 @@ namespace OpenRA
 					}
 					else
 					{
-						var z = y * stride + pxStride * x;
+						var z = y * stride + PxStride * x;
 						var c = actorColor.A == 0 ? terrainColor.Left : actorColor;
 						minimapData[z++] = c.R;
 						minimapData[z++] = c.G;

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -611,7 +611,7 @@ namespace OpenRA
 
 			// Odd-height ramps get bumped up a level to the next even height layer
 			if ((height & 1) == 1 && Ramp[uv] != 0)
-				height += 1;
+				height++;
 
 			var candidates = new List<PPos>();
 

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -282,11 +282,11 @@ namespace OpenRA
 			Log.Write("debug", "MapCache.LoadAsyncInternal started");
 
 			// Milliseconds to wait on one loop when nothing to do
-			var emptyDelay = 50;
+			const int EmptyDelay = 50;
 
 			// Keep the thread alive for at least 5 seconds after the last minimap generation
-			var maxKeepAlive = 5000 / emptyDelay;
-			var keepAlive = maxKeepAlive;
+			const int MaxKeepAlive = 5000 / EmptyDelay;
+			var keepAlive = MaxKeepAlive;
 
 			while (true)
 			{
@@ -306,11 +306,11 @@ namespace OpenRA
 
 				if (todo.Count == 0)
 				{
-					Thread.Sleep(emptyDelay);
+					Thread.Sleep(EmptyDelay);
 					continue;
 				}
 				else
-					keepAlive = maxKeepAlive;
+					keepAlive = MaxKeepAlive;
 
 				// Render the minimap into the shared sheet
 				foreach (var p in todo)

--- a/OpenRA.Game/Map/MapCoordsRegion.cs
+++ b/OpenRA.Game/Map/MapCoordsRegion.cs
@@ -35,7 +35,7 @@ namespace OpenRA
 				// Check for column overflow
 				if (u > r.BottomRight.U)
 				{
-					v += 1;
+					v++;
 					u = r.TopLeft.U;
 
 					// Check for row overflow

--- a/OpenRA.Game/Map/ProjectedCellRegion.cs
+++ b/OpenRA.Game/Map/ProjectedCellRegion.cs
@@ -93,12 +93,12 @@ namespace OpenRA
 
 			public bool MoveNext()
 			{
-				u += 1;
+				u++;
 
 				// Check for column overflow
 				if (u > r.BottomRight.U)
 				{
-					v += 1;
+					v++;
 					u = r.TopLeft.U;
 
 					// Check for row overflow

--- a/OpenRA.Game/Network/GameServer.cs
+++ b/OpenRA.Game/Network/GameServer.cs
@@ -169,9 +169,8 @@ namespace OpenRA.Network
 			}
 
 			// Games advertised using the old API calculated the play time locally
-			if (State == 2 && PlayTime < 0)
-				if (DateTime.TryParse(Started, out var startTime))
-					PlayTime = (int)(DateTime.UtcNow - startTime).TotalSeconds;
+			if (State == 2 && PlayTime < 0 && DateTime.TryParse(Started, out var startTime))
+				PlayTime = (int)(DateTime.UtcNow - startTime).TotalSeconds;
 
 			var externalKey = ExternalMod.MakeKey(Mod, Version);
 			if (Game.ExternalMods.TryGetValue(externalKey, out var external) && external.Version == Version)

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -133,8 +133,8 @@ namespace OpenRA
 
 		public ConstructorInfo GetCtor(Type type)
 		{
-			var flags = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance;
-			var ctors = type.GetConstructors(flags).Where(x => x.HasAttribute<UseCtorAttribute>()).ToList();
+			const BindingFlags Flags = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance;
+			var ctors = type.GetConstructors(Flags).Where(x => x.HasAttribute<UseCtorAttribute>()).ToList();
 			if (ctors.Count > 1)
 				throw new InvalidOperationException("ObjectCreator: UseCtor on multiple constructors; invalid.");
 			return ctors.FirstOrDefault();

--- a/OpenRA.Game/Primitives/Color.cs
+++ b/OpenRA.Game/Primitives/Color.cs
@@ -154,7 +154,7 @@ namespace OpenRA.Primitives
 
 			// Wrap negative values into [0-1)
 			if (h < 0)
-				h += 1;
+				h++;
 
 			var s = delta / rgbMax;
 			return (h, s, v);

--- a/OpenRA.Game/Scripting/ScriptMemberWrapper.cs
+++ b/OpenRA.Game/Scripting/ScriptMemberWrapper.cs
@@ -125,8 +125,8 @@ namespace OpenRA.Scripting
 		public static IEnumerable<MemberInfo> WrappableMembers(Type t)
 		{
 			// Only expose defined public non-static methods that were explicitly declared by the author
-			var flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly;
-			foreach (var mi in t.GetMembers(flags))
+			const BindingFlags Flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly;
+			foreach (var mi in t.GetMembers(Flags))
 			{
 				// Properties are always wrappable
 				if (mi is PropertyInfo)

--- a/OpenRA.Game/Scripting/ScriptTypes.cs
+++ b/OpenRA.Game/Scripting/ScriptTypes.cs
@@ -40,13 +40,10 @@ namespace OpenRA.Scripting
 				t = nullable;
 
 			// Value wraps a CLR object
-			if (value.TryGetClrObject(out var temp))
+			if (value.TryGetClrObject(out var temp) && temp.GetType() == t)
 			{
-				if (temp.GetType() == t)
-				{
-					clrObject = temp;
-					return true;
-				}
+				clrObject = temp;
+				return true;
 			}
 
 			if (value is LuaNil && !t.IsValueType)

--- a/OpenRA.Game/Server/Connection.cs
+++ b/OpenRA.Game/Server/Connection.cs
@@ -153,9 +153,8 @@ namespace OpenRA.Server
 						return;
 
 					// Regularly check player ping
-					if (lastPingSent.ElapsedMilliseconds > 1000)
-						if (TrySendData(CreatePingFrame()))
-							lastPingSent.Restart();
+					if (lastPingSent.ElapsedMilliseconds > 1000 && TrySendData(CreatePingFrame()))
+						lastPingSent.Restart();
 
 					// Send all data immediately, we will block again on read
 					while (sendQueue.TryTake(out var data, 0))

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -248,12 +248,9 @@ namespace OpenRA.Server
 					{
 						listener.Server.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, 1);
 					}
-					catch (Exception ex)
+					catch (Exception ex) when (ex is SocketException || ex is ArgumentException)
 					{
-						if (ex is SocketException || ex is ArgumentException)
-							Log.Write("server", $"Failed to set socket option on {endpoint}: {ex.Message}");
-						else
-							throw;
+						Log.Write("server", $"Failed to set socket option on {endpoint}: {ex.Message}");
 					}
 
 					listener.Start();

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -876,13 +876,13 @@ namespace OpenRA.Server
 
 		public void DispatchServerOrdersToClients(byte[] data, int frame = 0)
 		{
-			var from = 0;
-			var frameData = CreateFrame(from, frame, data);
+			const int From = 0;
+			var frameData = CreateFrame(From, frame, data);
 			foreach (var c in Conns.ToList())
 				if (c.Validated)
-					DispatchFrameToClient(c, from, frameData);
+					DispatchFrameToClient(c, From, frameData);
 
-			RecordOrder(frame, data, from);
+			RecordOrder(frame, data, From);
 		}
 
 		public void ReceiveOrders(Connection conn, int frame, byte[] data)

--- a/OpenRA.Game/Support/VariableExpression.cs
+++ b/OpenRA.Game/Support/VariableExpression.cs
@@ -750,13 +750,11 @@ namespace OpenRA.Support
 			public void Push(Expression expression, ExpressionType type)
 			{
 				expressions.Add(expression);
-				if (type == ExpressionType.Int)
-					if (expression.Type != typeof(int))
-						throw new InvalidOperationException($"Expected System.Int type instead of {expression.Type} for {expression}");
+				if (type == ExpressionType.Int && expression.Type != typeof(int))
+					throw new InvalidOperationException($"Expected System.Int type instead of {expression.Type} for {expression}");
 
-				if (type == ExpressionType.Bool)
-					if (expression.Type != typeof(bool))
-						throw new InvalidOperationException($"Expected System.Boolean type instead of {expression.Type} for {expression}");
+				if (type == ExpressionType.Bool && expression.Type != typeof(bool))
+					throw new InvalidOperationException($"Expected System.Boolean type instead of {expression.Type} for {expression}");
 				types.Add(type);
 			}
 

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -312,9 +312,8 @@ namespace OpenRA.Widgets
 				return true;
 
 			foreach (var child in Children)
-				if (child.IsVisible())
-					if (child.EventBoundsContains(location))
-						return true;
+				if (child.IsVisible() && child.EventBoundsContains(location))
+					return true;
 
 			return false;
 		}

--- a/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
@@ -378,11 +378,8 @@ namespace OpenRA.Mods.Cnc.FileFormats
 							if (tmp > 0)
 							{
 								MulBignumWord(esi, globOne, tmp, 2 * len);
-								if ((*edi & 0x8000) == 0)
-								{
-									if (SubBigNum((uint*)esi, (uint*)esi, g1, 0, (int)len) != 0)
-										(*edi)--;
-								}
+								if ((*edi & 0x8000) == 0 && SubBigNum((uint*)esi, (uint*)esi, g1, 0, (int)len) != 0)
+									(*edi)--;
 							}
 						}
 

--- a/OpenRA.Mods.Cnc/FileSystem/MixFile.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/MixFile.cs
@@ -235,10 +235,9 @@ namespace OpenRA.Mods.Cnc.FileSystem
 			}
 
 			// Load the global mix database
-			if (globalFilenames == null)
-				if (context.TryOpen("global mix database.dat", out var mixDatabase))
-					using (var db = new XccGlobalDatabase(mixDatabase))
-						globalFilenames = db.Entries.ToHashSet().ToArray();
+			if (globalFilenames == null && context.TryOpen("global mix database.dat", out var mixDatabase))
+				using (var db = new XccGlobalDatabase(mixDatabase))
+					globalFilenames = db.Entries.ToHashSet().ToArray();
 
 			package = new MixFile(s, filename, globalFilenames ?? Array.Empty<string>());
 			return true;

--- a/OpenRA.Mods.Cnc/Graphics/ClassicTilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ClassicTilesetSpecificSpriteSequence.cs
@@ -60,14 +60,11 @@ namespace OpenRA.Mods.Cnc.Graphics
 				var tilesetNode = node.Value.NodeWithKeyOrDefault(tileset);
 				if (tilesetNode != null)
 				{
-					if (frames == null)
+					if (frames == null && LoadField<string>("Length", null, data) != "*")
 					{
-						if (LoadField<string>("Length", null, data) != "*")
-						{
-							var subStart = LoadField("Start", 0, data);
-							var subLength = LoadField("Length", 1, data);
-							frames = Exts.MakeArray(subLength, i => subStart + i);
-						}
+						var subStart = LoadField("Start", 0, data);
+						var subLength = LoadField("Length", 1, data);
+						frames = Exts.MakeArray(subLength, i => subStart + i);
 					}
 
 					return new[] { new ReservationInfo(tilesetNode.Value.Value, frames, frames, tilesetNode.Location) };

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpD2Loader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpD2Loader.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			public ShpD2Frame(Stream s)
 			{
 				var flags = (FormatFlags)s.ReadUInt16();
-				s.Position += 1;
+				s.Position++;
 				var width = s.ReadUInt16();
 				var height = s.ReadUInt8();
 				Size = new Size(width, height);

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -203,13 +203,10 @@ namespace OpenRA.Mods.Cnc.Traits
 					mad.initiated = true;
 				}
 
-				if (++ticks % mad.info.ThumpInterval == 0)
+				if (++ticks % mad.info.ThumpInterval == 0 && mad.info.ThumpDamageWeapon != null)
 				{
-					if (mad.info.ThumpDamageWeapon != null)
-					{
-						// Use .FromPos since this weapon needs to affect more than just the MadTank actor
-						mad.info.ThumpDamageWeaponInfo.Impact(Target.FromPos(self.CenterPosition), self);
-					}
+					// Use .FromPos since this weapon needs to affect more than just the MadTank actor
+					mad.info.ThumpDamageWeaponInfo.Impact(Target.FromPos(self.CenterPosition), self);
 				}
 
 				if (ticks == mad.info.ChargeDelay)

--- a/OpenRA.Mods.Cnc/Traits/World/ModelRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/ModelRenderer.cs
@@ -250,9 +250,9 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			// Width and height must be even to avoid rendering glitches
 			if ((width & 1) == 1)
-				width += 1;
+				width++;
 			if ((height & 1) == 1)
-				height += 1;
+				height++;
 
 			size = new Size(width, height);
 		}

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportGen2MapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportGen2MapCommand.cs
@@ -441,14 +441,12 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 				// Only import the top-left cell of multi-celled overlays
 				// Returning true here means this is a part of a bigger overlay that has already been handled.
 				var aboveType = overlayPack[overlayIndex[cell - new CVec(1, 0)]];
-				if (shape.Width > 1 && aboveType != 0xFF)
-					if (OverlayToActor.TryGetValue(aboveType, out var a) && a == actorType)
-						return true;
+				if (shape.Width > 1 && aboveType != 0xFF && OverlayToActor.TryGetValue(aboveType, out var a) && a == actorType)
+					return true;
 
 				var leftType = overlayPack[overlayIndex[cell - new CVec(0, 1)]];
-				if (shape.Height > 1 && leftType != 0xFF)
-					if (OverlayToActor.TryGetValue(leftType, out var a) && a == actorType)
-						return true;
+				if (shape.Height > 1 && leftType != 0xFF && OverlayToActor.TryGetValue(leftType, out var l) && l == actorType)
+					return true;
 			}
 
 			actorReference = new ActorReference(actorType)

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianSunMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianSunMapCommand.cs
@@ -282,14 +282,12 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 				// Only import the top-left cell of multi-celled overlays
 				// Returning true here means this is a part of a bigger overlay that has already been handled.
 				var aboveType = overlayPack[overlayIndex[cell - new CVec(1, 0)]];
-				if (shape.Width > 1 && aboveType != 0xFF)
-					if (OverlayToActor.TryGetValue(aboveType, out var a) && a == actorType)
-						return true;
+				if (shape.Width > 1 && aboveType != 0xFF && OverlayToActor.TryGetValue(aboveType, out var a) && a == actorType)
+					return true;
 
 				var leftType = overlayPack[overlayIndex[cell - new CVec(0, 1)]];
-				if (shape.Height > 1 && leftType != 0xFF)
-					if (OverlayToActor.TryGetValue(leftType, out var a) && a == actorType)
-						return true;
+				if (shape.Height > 1 && leftType != 0xFF && OverlayToActor.TryGetValue(leftType, out var l) && l == actorType)
+					return true;
 			}
 
 			// Fix position of vein hole actors.

--- a/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
@@ -58,14 +58,11 @@ namespace OpenRA.Mods.Common.Graphics
 				var tilesetNode = node.Value.NodeWithKeyOrDefault(tileset);
 				if (tilesetNode != null)
 				{
-					if (frames == null)
+					if (frames == null && LoadField<string>("Length", null, data) != "*")
 					{
-						if (LoadField<string>("Length", null, data) != "*")
-						{
-							var subStart = LoadField("Start", 0, data);
-							var subLength = LoadField("Length", 1, data);
-							frames = Exts.MakeArray(subLength, i => subStart + i);
-						}
+						var subStart = LoadField("Start", 0, data);
+						var subLength = LoadField("Length", 1, data);
+						frames = Exts.MakeArray(subLength, i => subStart + i);
 					}
 
 					return new[] { new ReservationInfo(tilesetNode.Value.Value, frames, frames, tilesetNode.Location) };

--- a/OpenRA.Mods.Common/Lint/CheckChromeHotkeys.cs
+++ b/OpenRA.Mods.Common/Lint/CheckChromeHotkeys.cs
@@ -109,9 +109,10 @@ namespace OpenRA.Mods.Common.Lint
 					}
 
 					foreach (var n in node.Value.Nodes)
-						if (checkArgKeys.Contains(n.Key))
-							if (!namedKeys.Contains(n.Value.Value) && !Hotkey.TryParse(n.Value.Value, out var unused))
-								emitError($"{filename} {node.Value.Value}:{n.Key} refers to a Key named `{n.Value.Value}` that does not exist.");
+						if (checkArgKeys.Contains(n.Key) &&
+							!namedKeys.Contains(n.Value.Value) &&
+							!Hotkey.TryParse(n.Value.Value, out var unused))
+							emitError($"{filename} {node.Value.Value}:{n.Key} refers to a Key named `{n.Value.Value}` that does not exist.");
 				}
 
 				if (node.Value.Nodes != null)

--- a/OpenRA.Mods.Common/Lint/CheckOwners.cs
+++ b/OpenRA.Mods.Common/Lint/CheckOwners.cs
@@ -40,9 +40,8 @@ namespace OpenRA.Mods.Common.Lint
 					if (!playerNames.Contains(ownerName))
 						emitError($"Actor `{kv.Key}` is owned by unknown player `{ownerName}`.");
 
-					if (actorsWithRequiredOwner.TryGetValue(kv.Value.Value, out var info))
-						if (!info.ValidOwnerNames.Contains(ownerName))
-							emitError($"Actor `{kv.Key}` owner `{ownerName}` is not one of ValidOwnerNames: {info.ValidOwnerNames.JoinWith(", ")}");
+					if (actorsWithRequiredOwner.TryGetValue(kv.Value.Value, out var info) && !info.ValidOwnerNames.Contains(ownerName))
+						emitError($"Actor `{kv.Key}` owner `{ownerName}` is not one of ValidOwnerNames: {info.ValidOwnerNames.JoinWith(", ")}");
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
@@ -70,40 +70,40 @@ namespace OpenRA.Mods.Common.Lint
 				return;
 
 			// TODO: Check all available languages.
-			var language = "en";
-			var modTranslation = new Translation(language, modData.Manifest.Translations, modData.DefaultFileSystem, _ => { });
-			var mapTranslation = new Translation(language, FieldLoader.GetValue<string[]>("value", map.TranslationDefinitions.Value), map, error => emitError(error.ToString()));
+			const string Language = "en";
+			var modTranslation = new Translation(Language, modData.Manifest.Translations, modData.DefaultFileSystem, _ => { });
+			var mapTranslation = new Translation(Language, FieldLoader.GetValue<string[]>("value", map.TranslationDefinitions.Value), map, error => emitError(error.ToString()));
 
 			TestTraits(map.Rules, emitError, key =>
 			{
 				if (modTranslation.HasMessage(key))
 				{
 					if (mapTranslation.HasMessage(key))
-						emitWarning($"Map translation key `{key}` already exists in `{language}` mod translations and will not be used.");
+						emitWarning($"Map translation key `{key}` already exists in `{Language}` mod translations and will not be used.");
 				}
 				else if (!mapTranslation.HasMessage(key))
-					emitWarning($"`{key}` is not present in `{language}` translation.");
+					emitWarning($"`{key}` is not present in `{Language}` translation.");
 			});
 		}
 
 		void ILintPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData)
 		{
 			// TODO: Check all available languages.
-			var language = "en";
-			Console.WriteLine($"Testing translation: {language}");
-			var translation = new Translation(language, modData.Manifest.Translations, modData.DefaultFileSystem, error => emitError(error.ToString()));
+			const string Language = "en";
+			Console.WriteLine($"Testing translation: {Language}");
+			var translation = new Translation(Language, modData.Manifest.Translations, modData.DefaultFileSystem, error => emitError(error.ToString()));
 
 			TestTraits(modData.DefaultRules, emitError, key =>
 			{
 				if (!translation.HasMessage(key))
-					emitWarning($"`{key}` is not present in `{language}` translation.");
+					emitWarning($"`{key}` is not present in `{Language}` translation.");
 			});
 
 			var gameSpeeds = modData.Manifest.Get<GameSpeeds>();
 			foreach (var speed in gameSpeeds.Speeds.Values)
 			{
 				if (!translation.HasMessage(speed.Name))
-					emitWarning($"`{speed.Name}` is not present in `{language}` translation.");
+					emitWarning($"`{speed.Name}` is not present in `{Language}` translation.");
 
 				referencedKeys.Add(speed.Name);
 			}
@@ -126,7 +126,7 @@ namespace OpenRA.Mods.Common.Lint
 						continue;
 
 					if (!translation.HasMessage(key))
-						emitWarning($"`{key}` is not present in `{language}` translation.");
+						emitWarning($"`{key}` is not present in `{Language}` translation.");
 
 					var translationReference = Utility.GetCustomAttributes<TranslationReferenceAttribute>(fieldInfo, true)[0];
 					if (translationReference.RequiredVariableNames != null && translationReference.RequiredVariableNames.Length > 0)
@@ -150,7 +150,7 @@ namespace OpenRA.Mods.Common.Lint
 			{
 				var nodes = MiniYaml.FromStream(modData.DefaultFileSystem.Open(filename));
 				foreach (var node in nodes)
-					CheckChrome(node, translation, language, emitError, emitWarning, translatableFields);
+					CheckChrome(node, translation, Language, emitError, emitWarning, translatableFields);
 			}
 
 			foreach (var file in modData.Manifest.Translations)

--- a/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
@@ -256,9 +256,9 @@ namespace OpenRA.Mods.Common.Lint
 				if (element is Placeable placeable)
 				{
 					var expression = placeable.Expression;
-					if (expression is IInlineExpression inlineExpression)
-						if (inlineExpression is VariableReference variableReference)
-							CheckVariableReference(variableReference.Id.Name.ToString(), key, attribute, emitWarning, file);
+					if (expression is IInlineExpression inlineExpression &&
+						inlineExpression is VariableReference variableReference)
+						CheckVariableReference(variableReference.Id.Name.ToString(), key, attribute, emitWarning, file);
 
 					if (expression is SelectExpression selectExpression)
 					{
@@ -269,9 +269,9 @@ namespace OpenRA.Mods.Common.Lint
 								if (variantElement is Placeable variantPlaceable)
 								{
 									var variantExpression = variantPlaceable.Expression;
-									if (variantExpression is IInlineExpression variantInlineExpression)
-										if (variantInlineExpression is VariableReference variantVariableReference)
-											CheckVariableReference(variantVariableReference.Id.Name.ToString(), key, attribute, emitWarning, file);
+									if (variantExpression is IInlineExpression variantInlineExpression &&
+										variantInlineExpression is VariableReference variantVariableReference)
+										CheckVariableReference(variantVariableReference.Id.Name.ToString(), key, attribute, emitWarning, file);
 								}
 							}
 						}

--- a/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
+++ b/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
@@ -936,8 +936,8 @@ namespace OpenRA.Mods.Common.Pathfinder
 					using (var fromDest = GetLocalPathSearch(
 						self, new[] { target }, source, customCost, ignoreActor, check, laneBias, null, heuristicWeightPercentage,
 						heuristic: Heuristic(forwardAbstractSearch, estimatedSearchSize, null, null),
-						recorder: pathFinderOverlay?.RecordLocalEdges(self),
-						inReverse: true))
+						inReverse: true,
+						recorder: pathFinderOverlay?.RecordLocalEdges(self)))
 						return PathSearch.FindBidiPath(fromDest, fromSrc);
 				}
 			}

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -377,9 +377,8 @@ namespace OpenRA.Mods.Common.Projectiles
 				// If the impact position is within any actor's HitShape, we have a direct hit
 				// PERF: Avoid using TraitsImplementing<HitShape> that needs to find the actor in the trait dictionary.
 				foreach (var targetPos in victim.EnabledTargetablePositions)
-					if (targetPos is HitShape h)
-						if (h.DistanceFromEdge(victim, pos).Length <= 0)
-							return true;
+					if (targetPos is HitShape h && h.DistanceFromEdge(victim, pos).Length <= 0)
+						return true;
 			}
 
 			return false;

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -496,8 +496,8 @@ namespace OpenRA.Mods.Common.Projectiles
 			lastHt = 0; // Height just before the last height change
 
 			// NOTE: Might be desired to unhardcode the lookahead step size
-			var stepSize = 32;
-			var step = new WVec(0, -stepSize, 0)
+			const int StepSize = 32;
+			var step = new WVec(0, -StepSize, 0)
 				.Rotate(new WRot(WAngle.Zero, WAngle.Zero, WAngle.FromFacing(hFacing))); // Step vector of length 128
 
 			// Probe terrain ahead of the missile
@@ -505,7 +505,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			var maxLookaheadDistance = loopRadius * 4;
 			var posProbe = pos;
 			var curDist = 0;
-			var tickLimit = System.Math.Min(maxLookaheadDistance, distCheck) / stepSize;
+			var tickLimit = System.Math.Min(maxLookaheadDistance, distCheck) / StepSize;
 			var prevHt = 0;
 
 			// TODO: Make sure cell on map!!!
@@ -517,7 +517,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 				var ht = world.Map.Height[world.Map.CellContaining(posProbe)] * 512;
 
-				curDist += stepSize;
+				curDist += StepSize;
 				if (ht > predClfHgt)
 				{
 					predClfHgt = ht;

--- a/OpenRA.Mods.Common/Projectiles/Railgun.cs
+++ b/OpenRA.Mods.Common/Projectiles/Railgun.cs
@@ -179,7 +179,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			CycleCount = SourceToTarget.Length / info.HelixPitch.Length;
 			if (SourceToTarget.Length % info.HelixPitch.Length != 0)
-				CycleCount += 1; // math.ceil, int version.
+				CycleCount++; // math.ceil, int version.
 
 			// Using ForwardStep * CycleCount, the helix and the main beam gets "out of sync"
 			// if drawn from source to target. Instead, the main beam is drawn from source to end point of helix.

--- a/OpenRA.Mods.Common/SpriteLoaders/ShpTSLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/ShpTSLoader.cs
@@ -41,10 +41,10 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 				var dataWidth = width;
 				var dataHeight = height;
 				if (dataWidth % 2 == 1)
-					dataWidth += 1;
+					dataWidth++;
 
 				if (dataHeight % 2 == 1)
-					dataHeight += 1;
+					dataHeight++;
 
 				Offset = new int2(x + (dataWidth - frameSize.Width) / 2, y + (dataHeight - frameSize.Height) / 2);
 				Size = new Size(dataWidth, dataHeight);

--- a/OpenRA.Mods.Common/SpriteLoaders/TgaLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/TgaLoader.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 			try
 			{
 				// Require true-color images
-				s.Position += 1;
+				s.Position++;
 				var colorMapType = s.ReadUInt8();
 				if (colorMapType != 0)
 					return false;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -94,9 +94,10 @@ namespace OpenRA.Mods.Common.Traits
 			var pos = self.CenterPosition;
 			var armaments = ChooseArmamentsForTarget(target, forceAttack);
 			foreach (var a in armaments)
-				if (target.IsInRange(pos, a.MaxRange()) && (a.Weapon.MinRange == WDist.Zero || !target.IsInRange(pos, a.Weapon.MinRange)))
-					if (TargetInFiringArc(self, target, Info.FacingTolerance))
-						return true;
+				if (target.IsInRange(pos, a.MaxRange()) &&
+					(a.Weapon.MinRange == WDist.Zero || !target.IsInRange(pos, a.Weapon.MinRange)) &&
+					TargetInFiringArc(self, target, Info.FacingTolerance))
+					return true;
 
 			return false;
 		}

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -247,13 +247,11 @@ namespace OpenRA.Mods.Common.Traits
 				a => a.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(p => p.Amount));
 
 			// First priority is to get out of a low power situation
-			if (playerPower != null && playerPower.ExcessPower < minimumExcessPower)
+			if (playerPower != null && playerPower.ExcessPower < minimumExcessPower &&
+				power != null && power.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(p => p.Amount) > 0)
 			{
-				if (power != null && power.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(p => p.Amount) > 0)
-				{
-					AIUtils.BotDebug("{0} decided to build {1}: Priority override (low power)", queue.Actor.Owner, power.Name);
-					return power;
-				}
+				AIUtils.BotDebug("{0} decided to build {1}: Priority override (low power)", queue.Actor.Owner, power.Name);
+				return power;
 			}
 
 			// Next is to build up a strong economy

--- a/OpenRA.Mods.Common/Traits/BotModules/BuildingRepairBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BuildingRepairBotModule.cs
@@ -34,14 +34,11 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			var rb = self.TraitOrDefault<RepairableBuilding>();
-			if (rb != null)
+			if (rb != null && e.DamageState > DamageState.Light && e.PreviousDamageState <= DamageState.Light && !rb.RepairActive)
 			{
-				if (e.DamageState > DamageState.Light && e.PreviousDamageState <= DamageState.Light && !rb.RepairActive)
-				{
-					AIUtils.BotDebug("{0} noticed damage {1} {2}->{3}, repairing.",
-						self.Owner, self, e.PreviousDamageState, e.DamageState);
-					bot.QueueOrder(new Order("RepairBuilding", self.Owner.PlayerActor, Target.FromActor(self), false));
-				}
+				AIUtils.BotDebug("{0} noticed damage {1} {2}->{3}, repairing.",
+					self.Owner, self, e.PreviousDamageState, e.DamageState);
+				bot.QueueOrder(new Order("RepairBuilding", self.Owner.PlayerActor, Target.FromActor(self), false));
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/CaptureManager.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureManager.cs
@@ -197,7 +197,7 @@ namespace OpenRA.Mods.Common.Traits
 				currentTargetDelay = 0;
 			}
 			else
-				currentTargetDelay += 1;
+				currentTargetDelay++;
 
 			if (capturingToken == Actor.InvalidConditionToken)
 				capturingToken = self.GrantCondition(info.CapturingCondition);

--- a/OpenRA.Mods.Common/Traits/Conditions/ExternalCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ExternalCondition.cs
@@ -75,11 +75,13 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Timed tokens do not count towards the source cap: the condition with the shortest
 			// remaining duration can always be revoked to make room.
-			if (Info.SourceCap > 0)
-				if (permanentTokens.TryGetValue(source, out var permanentTokensForSource) && permanentTokensForSource.Count >= Info.SourceCap)
-					return false;
+			if (Info.SourceCap > 0 &&
+				permanentTokens.TryGetValue(source, out var permanentTokensForSource) &&
+				permanentTokensForSource.Count >= Info.SourceCap)
+				return false;
 
-			if (Info.TotalCap > 0 && permanentTokens.Values.Sum(t => t.Count) >= Info.TotalCap)
+			if (Info.TotalCap > 0 &&
+				permanentTokens.Values.Sum(t => t.Count) >= Info.TotalCap)
 				return false;
 
 			return true;

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnAttack.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnAttack.cs
@@ -93,29 +93,34 @@ namespace OpenRA.Mods.Common.Traits
 		static bool TargetChanged(in Target lastTarget, in Target target)
 		{
 			// Invalidate reveal changing the target.
-			if (lastTarget.Type == TargetType.FrozenActor && target.Type == TargetType.Actor)
-				if (lastTarget.FrozenActor.Actor == target.Actor)
-					return false;
+			if (lastTarget.Type == TargetType.FrozenActor &&
+				target.Type == TargetType.Actor &&
+				lastTarget.FrozenActor.Actor == target.Actor)
+				return false;
 
-			if (lastTarget.Type == TargetType.Actor && target.Type == TargetType.FrozenActor)
-				if (target.FrozenActor.Actor == lastTarget.Actor)
-					return false;
+			if (lastTarget.Type == TargetType.Actor &&
+				target.Type == TargetType.FrozenActor &&
+				target.FrozenActor.Actor == lastTarget.Actor)
+				return false;
 
 			if (lastTarget.Type != target.Type)
 				return true;
 
 			// Invalidate attacking different targets with shared target types.
-			if (lastTarget.Type == TargetType.Actor && target.Type == TargetType.Actor)
-				if (lastTarget.Actor != target.Actor)
-					return true;
+			if (lastTarget.Type == TargetType.Actor &&
+				target.Type == TargetType.Actor &&
+				lastTarget.Actor != target.Actor)
+				return true;
 
-			if (lastTarget.Type == TargetType.FrozenActor && target.Type == TargetType.FrozenActor)
-				if (lastTarget.FrozenActor != target.FrozenActor)
-					return true;
+			if (lastTarget.Type == TargetType.FrozenActor &&
+				target.Type == TargetType.FrozenActor &&
+				lastTarget.FrozenActor != target.FrozenActor)
+				return true;
 
-			if (lastTarget.Type == TargetType.Terrain && target.Type == TargetType.Terrain)
-				if (lastTarget.CenterPosition != target.CenterPosition)
-					return true;
+			if (lastTarget.Type == TargetType.Terrain &&
+				target.Type == TargetType.Terrain &&
+				lastTarget.CenterPosition != target.CenterPosition)
+				return true;
 
 			return false;
 		}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnClientDock.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnClientDock.cs
@@ -48,17 +48,16 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyDockClient.Docked(Actor self, Actor host)
 		{
-			if (info.Condition != null && (info.DockHostNames == null || info.DockHostNames.Contains(host.Info.Name)))
+			if (info.Condition != null &&
+				(info.DockHostNames == null || info.DockHostNames.Contains(host.Info.Name)) &&
+				token == Actor.InvalidConditionToken)
 			{
-				if (token == Actor.InvalidConditionToken)
+				if (delayedtoken == Actor.InvalidConditionToken)
+					token = self.GrantCondition(info.Condition);
+				else
 				{
-					if (delayedtoken == Actor.InvalidConditionToken)
-						token = self.GrantCondition(info.Condition);
-					else
-					{
-						token = delayedtoken;
-						delayedtoken = Actor.InvalidConditionToken;
-					}
+					token = delayedtoken;
+					delayedtoken = Actor.InvalidConditionToken;
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnHostDock.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnHostDock.cs
@@ -48,17 +48,16 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyDockHost.Docked(Actor self, Actor client)
 		{
-			if (info.Condition != null && (info.DockClientNames == null || info.DockClientNames.Contains(client.Info.Name)))
+			if (info.Condition != null &&
+				(info.DockClientNames == null || info.DockClientNames.Contains(client.Info.Name)) &&
+				token == Actor.InvalidConditionToken)
 			{
-				if (token == Actor.InvalidConditionToken)
+				if (delayedtoken == Actor.InvalidConditionToken)
+					token = self.GrantCondition(info.Condition);
+				else
 				{
-					if (delayedtoken == Actor.InvalidConditionToken)
-						token = self.GrantCondition(info.Condition);
-					else
-					{
-						token = delayedtoken;
-						delayedtoken = Actor.InvalidConditionToken;
-					}
+					token = delayedtoken;
+					delayedtoken = Actor.InvalidConditionToken;
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -714,7 +714,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			RemainingCost -= costThisFrame;
-			RemainingTime -= 1;
+			RemainingTime--;
 			if (RemainingTime > 0)
 				return;
 

--- a/OpenRA.Mods.Common/Traits/World/Selection.cs
+++ b/OpenRA.Mods.Common/Traits/World/Selection.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Not a real hash, but things checking this only care about checking when the selection has changed
 			// For this purpose, having a false positive (forcing a refresh when nothing changed) is much better
 			// than a false negative (selection state mismatch)
-			Hash += 1;
+			Hash++;
 		}
 
 		public virtual void Add(Actor a)

--- a/OpenRA.Mods.Common/Widgets/ConfirmationDialogs.cs
+++ b/OpenRA.Mods.Common/Widgets/ConfirmationDialogs.cs
@@ -24,10 +24,10 @@ namespace OpenRA.Mods.Common.Widgets
 			Dictionary<string, object> titleArguments = null,
 			Dictionary<string, object> textArguments = null,
 			Action onConfirm = null,
-			Action onCancel = null,
-			Action onOther = null,
 			string confirmText = null,
+			Action onCancel = null,
 			string cancelText = null,
+			Action onOther = null,
 			string otherText = null)
 		{
 			var promptName = onOther != null ? "THREEBUTTON_PROMPT" : "TWOBUTTON_PROMPT";

--- a/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
@@ -97,15 +97,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var palettePresetRows = 2;
 			var paletteCustomRows = 1;
 
-			if (logicArgs.TryGetValue("PaletteColumns", out var yaml))
-				if (!int.TryParse(yaml.Value, out paletteCols))
-					throw new YamlException($"Invalid value for PaletteColumns: {yaml.Value}");
-			if (logicArgs.TryGetValue("PalettePresetRows", out yaml))
-				if (!int.TryParse(yaml.Value, out palettePresetRows))
-					throw new YamlException($"Invalid value for PalettePresetRows: {yaml.Value}");
-			if (logicArgs.TryGetValue("PaletteCustomRows", out yaml))
-				if (!int.TryParse(yaml.Value, out paletteCustomRows))
-					throw new YamlException($"Invalid value for PaletteCustomRows: {yaml.Value}");
+			if (logicArgs.TryGetValue("PaletteColumns", out var yaml) && !int.TryParse(yaml.Value, out paletteCols))
+				throw new YamlException($"Invalid value for PaletteColumns: {yaml.Value}");
+			if (logicArgs.TryGetValue("PalettePresetRows", out yaml) && !int.TryParse(yaml.Value, out palettePresetRows))
+				throw new YamlException($"Invalid value for PalettePresetRows: {yaml.Value}");
+			if (logicArgs.TryGetValue("PaletteCustomRows", out yaml) && !int.TryParse(yaml.Value, out paletteCustomRows))
+				throw new YamlException($"Invalid value for PaletteCustomRows: {yaml.Value}");
 
 			var presetColors = colorManager.PresetColors;
 			for (var j = 0; j < palettePresetRows; j++)

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -140,15 +140,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				}
 
 				// Check for duplicate actor ID
-				if (!CurrentActor.ID.Equals(actorId, StringComparison.OrdinalIgnoreCase))
+				if (!CurrentActor.ID.Equals(actorId, StringComparison.OrdinalIgnoreCase) && editorActorLayer[actorId] != null)
 				{
-					if (editorActorLayer[actorId] != null)
-					{
-						nextActorIDStatus = ActorIDStatus.Duplicate;
-						actorIDErrorLabel.Text = TranslationProvider.GetString(DuplicateActorId);
-						actorIDErrorLabel.Visible = true;
-						return;
-					}
+					nextActorIDStatus = ActorIDStatus.Duplicate;
+					actorIDErrorLabel.Text = TranslationProvider.GetString(DuplicateActorId);
+					actorIDErrorLabel.Visible = true;
+					return;
 				}
 
 				SetActorID(actorId);

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -250,13 +250,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					ConfirmationDialogs.ButtonPrompt(modData,
 						title: OverwriteMapFailedTitle,
 						text: OverwriteMapFailedPrompt,
-						confirmText: OverwriteMapFailedConfirm,
 						onConfirm: () =>
 						{
 							saveMap(combinedPath);
 							if (actionManager != null)
 								actionManager.SaveFailed = false;
 						},
+						confirmText: OverwriteMapFailedConfirm,
 						onCancel: () =>
 						{
 							if (actionManager != null)
@@ -278,13 +278,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					ConfirmationDialogs.ButtonPrompt(modData,
 						title: OverwriteMapOutsideEditTitle,
 						text: OverwriteMapOutsideEditPrompt,
-						confirmText: SaveMapMapOutsideConfirm,
 						onConfirm: () =>
 						{
 							saveMap(combinedPath);
 							if (actionManager != null)
 								actionManager.SaveFailed = false;
 						},
+						confirmText: SaveMapMapOutsideConfirm,
 						onCancel: () =>
 						{
 							if (actionManager != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -158,8 +158,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						ConfirmationDialogs.ButtonPrompt(modData,
 							title: VoteKickTitle,
-							titleArguments: Translation.Arguments("player", client.Name),
 							text: botsCount > 0 ? VoteKickPromptBreakBots : VoteKickPrompt,
+							titleArguments: Translation.Arguments("player", client.Name),
 							textArguments: Translation.Arguments("bots", botsCount),
 							onConfirm: () =>
 							{
@@ -174,8 +174,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					ConfirmationDialogs.ButtonPrompt(modData,
 						title: VoteKickTitle,
-						titleArguments: Translation.Arguments("player", client.Name),
 						text: botsCount > 0 ? VoteKickPromptBreakBots : VoteKickPrompt,
+						titleArguments: Translation.Arguments("player", client.Name),
 						textArguments: Translation.Arguments("bots", botsCount),
 						onConfirm: () =>
 						{
@@ -184,6 +184,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							closeMenu();
 						},
 						confirmText: VoteKickVoteFor,
+						onCancel: () => hideMenu(false),
+						cancelText: VoteKickVoteCancel,
 						onOther: () =>
 						{
 							Ui.CloseWindow();
@@ -191,16 +193,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							hideMenu(false);
 							closeMenu();
 						},
-						otherText: VoteKickVoteAgainst,
-						onCancel: () => hideMenu(false),
-						cancelText: VoteKickVoteCancel);
+						otherText: VoteKickVoteAgainst);
 				}
 				else
 				{
 					ConfirmationDialogs.ButtonPrompt(modData,
 						title: KickTitle,
-						titleArguments: Translation.Arguments("player", client.Name),
 						text: KickPrompt,
+						titleArguments: Translation.Arguments("player", client.Name),
 						onConfirm: () =>
 						{
 							orderManager.IssueOrder(Order.Command($"kick {client.Index} {false}"));

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -322,8 +322,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					title: LeaveMissionTitle,
 					text: LeaveMissionPrompt,
 					onConfirm: () => { OnQuit(world); leaving = true; },
-					onCancel: ShowMenu,
 					confirmText: LeaveMissionAccept,
+					onCancel: ShowMenu,
 					cancelText: LeaveMissionCancel);
 			};
 		}
@@ -358,8 +358,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					title: RestartMissionTitle,
 					text: RestartMissionPrompt,
 					onConfirm: OnRestart,
-					onCancel: ShowMenu,
 					confirmText: RestartMissionAccept,
+					onCancel: ShowMenu,
 					cancelText: RestartMissionCancel);
 			};
 		}
@@ -384,8 +384,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					title: SurrenderTitle,
 					text: SurrenderPrompt,
 					onConfirm: OnSurrender,
-					onCancel: ShowMenu,
 					confirmText: SurrenderAccept,
+					onCancel: ShowMenu,
 					cancelText: SurrenderCancel);
 			};
 		}
@@ -591,8 +591,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						title: ExitToMapEditorTitle,
 						text: ExitToMapEditorPrompt,
 						onConfirm: OnConfirm,
-						onCancel: ShowMenu,
 						confirmText: ExitToMapEditorConfirm,
+						onCancel: ShowMenu,
 						cancelText: ExitToMapEditorCancel);
 				};
 		}
@@ -617,8 +617,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ConfirmationDialogs.ButtonPrompt(modData,
 					title: ExitMapEditorTitle,
 					text: deletedOrUnavailable ? ExitMapEditorPromptDeleted : ExitMapEditorPromptUnsaved,
-					confirmText: deletedOrUnavailable ? ExitMapEditorAnywayConfirm : ExitMapEditorConfirm,
 					onConfirm: () => { onSuccess(); leaving = true; },
+					confirmText: deletedOrUnavailable ? ExitMapEditorAnywayConfirm : ExitMapEditorConfirm,
 					onCancel: ShowMenu);
 			}
 			else

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -438,8 +438,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ConfirmationDialogs.ButtonPrompt(modData,
 					title: NoVideoTitle,
 					text: NoVideoPrompt,
-					cancelText: NoVideoCancel,
-					onCancel: () => { });
+					onCancel: () => { },
+					cancelText: NoVideoCancel);
 			}
 			else
 			{
@@ -455,8 +455,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					ConfirmationDialogs.ButtonPrompt(modData,
 						title: CantPlayTitle,
 						text: CantPlayPrompt,
-						cancelText: CantPlayCancel,
-						onCancel: () => { });
+						onCancel: () => { },
+						cancelText: CantPlayCancel);
 				}
 				else
 				{

--- a/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
@@ -100,27 +100,24 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				badgesVisible = false;
 
-				if (localProfile.State == LocalPlayerProfile.LinkState.Linked)
+				if (localProfile.State == LocalPlayerProfile.LinkState.Linked && localProfile.ProfileData.Badges.Count > 0)
 				{
-					if (localProfile.ProfileData.Badges.Count > 0)
-					{
-						Func<int, int> negotiateWidth = _ => widget.Get("PROFILE_HEADER").Bounds.Width;
+					Func<int, int> negotiateWidth = _ => widget.Get("PROFILE_HEADER").Bounds.Width;
 
-						// Remove any stale badges that may be left over from a previous session
-						badgeContainer.RemoveChildren();
+					// Remove any stale badges that may be left over from a previous session
+					badgeContainer.RemoveChildren();
 
-						var badges = Ui.LoadWidget("PLAYER_PROFILE_BADGES_INSERT", badgeContainer, new WidgetArgs()
+					var badges = Ui.LoadWidget("PLAYER_PROFILE_BADGES_INSERT", badgeContainer, new WidgetArgs()
 						{
 							{ "worldRenderer", worldRenderer },
 							{ "profile", localProfile.ProfileData },
 							{ "negotiateWidth", negotiateWidth }
 						});
 
-						if (badges.Bounds.Height > 0)
-						{
-							badgeContainer.Bounds.Height = badges.Bounds.Height;
-							badgesVisible = true;
-						}
+					if (badges.Bounds.Height > 0)
+					{
+						badgeContainer.Bounds.Height = badges.Bounds.Height;
+						badgesVisible = true;
 					}
 				}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
@@ -124,8 +124,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						title: RestartTitle,
 						text: RestartPrompt,
 						onConfirm: () => Game.SwitchToExternalMod(external, null, NoRestart),
-						onCancel: CloseAndExit,
 						confirmText: RestartAccept,
+						onCancel: CloseAndExit,
 						cancelText: RestartCancel);
 				}
 				else
@@ -142,11 +142,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				ConfirmationDialogs.ButtonPrompt(modData,
 					title: ResetTitle,
-					titleArguments: Translation.Arguments("panel", panels[activePanel]),
 					text: ResetPrompt,
+					titleArguments: Translation.Arguments("panel", panels[activePanel]),
 					onConfirm: Reset,
-					onCancel: () => { },
 					confirmText: ResetAccept,
+					onCancel: () => { },
 					cancelText: ResetCancel);
 			};
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/SingleHotkeyBaseLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SingleHotkeyBaseLogic.cs
@@ -25,9 +25,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var keyhandler = widget.Get<LogicKeyListenerWidget>(parentName);
 			keyhandler.AddHandler(e =>
 			{
-				if (e.Event == KeyInputEvent.Down)
-					if (namedKey.IsActivatedBy(e))
-						return OnHotkeyActivated(e);
+				if (e.Event == KeyInputEvent.Down && namedKey.IsActivatedBy(e))
+					return OnHotkeyActivated(e);
 
 				return false;
 			});

--- a/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
@@ -156,7 +156,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			// Odd rows are shifted right by 1px
 			if ((point.V & 1) == 1)
-				dx += 1;
+				dx++;
 
 			return new int2(mapRect.X + dx, mapRect.Y + dy);
 		}

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -474,7 +474,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			// Odd rows are shifted right by 1px
 			if (isRectangularIsometric && (uv.V & 1) == 1)
-				dx += 1;
+				dx++;
 
 			return new int2(mapRect.X + dx, mapRect.Y + dy);
 		}

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -29,6 +29,8 @@ namespace OpenRA.Mods.Common.Widgets
 		public int AnimationLength = 5;
 		public string RadarOnlineSound = null;
 		public string RadarOfflineSound = null;
+		public string SoundUp;
+		public string SoundDown;
 		public Func<bool> IsEnabled = () => true;
 		public Action AfterOpen = () => { };
 		public Action AfterClose = () => { };
@@ -62,9 +64,6 @@ namespace OpenRA.Mods.Common.Widgets
 		Shroud shroud;
 		PlayerRadarTerrain playerRadarTerrain;
 		Player currentPlayer;
-
-		public string SoundUp { get; private set; }
-		public string SoundDown { get; private set; }
 
 		[ObjectCreator.UseCtor]
 		public RadarWidget(World world, WorldRenderer worldRenderer)

--- a/OpenRA.Mods.Common/Widgets/ResourcePreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ResourcePreviewWidget.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 		}
 
-		public Size IdealPreviewSize { get; private set; }
+		public Size IdealPreviewSize { get; }
 
 		[ObjectCreator.UseCtor]
 		public ResourcePreviewWidget(ModData modData, WorldRenderer worldRenderer, World world)

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -107,16 +107,15 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Up)
 			{
-				if (useClassicMouseStyle && HasMouseFocus)
+				if (useClassicMouseStyle && HasMouseFocus &&
+					!IsValidDragbox && World.Selection.Actors.Count != 0 &&
+					!multiClick && uog.InputOverridesSelection(World, mousePos, mi))
 				{
-					if (!IsValidDragbox && World.Selection.Actors.Count != 0 && !multiClick && uog.InputOverridesSelection(World, mousePos, mi))
-					{
-						// Order units instead of selecting
-						ApplyOrders(World, mi);
-						isDragging = false;
-						YieldMouseFocus(mi);
-						return true;
-					}
+					// Order units instead of selecting
+					ApplyOrders(World, mi);
+					isDragging = false;
+					YieldMouseFocus(mi);
+					return true;
 				}
 
 				if (multiClick)

--- a/OpenRA.Platforms.Default/FreeTypeFont.cs
+++ b/OpenRA.Platforms.Default/FreeTypeFont.cs
@@ -131,15 +131,12 @@ namespace OpenRA.Platforms.Default
 
 		public void Dispose()
 		{
-			if (!disposed)
+			if (!disposed && faceHandle.IsAllocated)
 			{
-				if (faceHandle.IsAllocated)
-				{
-					FreeType.FT_Done_Face(face);
+				FreeType.FT_Done_Face(face);
 
-					faceHandle.Free();
-					disposed = true;
-				}
+				faceHandle.Free();
+				disposed = true;
 			}
 		}
 	}

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -224,14 +224,14 @@ namespace OpenRA.Platforms.Default
 
 				Console.WriteLine($"Using resolution: {windowSize.Width}x{windowSize.Height}");
 
-				var windowFlags = SDL.SDL_WindowFlags.SDL_WINDOW_OPENGL | SDL.SDL_WindowFlags.SDL_WINDOW_ALLOW_HIGHDPI;
+				const SDL.SDL_WindowFlags WindowFlags = SDL.SDL_WindowFlags.SDL_WINDOW_OPENGL | SDL.SDL_WindowFlags.SDL_WINDOW_ALLOW_HIGHDPI;
 
 				// HiDPI doesn't work properly on OSX with (legacy) fullscreen mode
 				if (Platform.CurrentPlatform == PlatformType.OSX && windowMode == WindowMode.Fullscreen)
 					SDL.SDL_SetHint(SDL.SDL_HINT_VIDEO_HIGHDPI_DISABLED, "1");
 
 				window = SDL.SDL_CreateWindow("OpenRA", SDL.SDL_WINDOWPOS_CENTERED_DISPLAY(videoDisplay), SDL.SDL_WINDOWPOS_CENTERED_DISPLAY(videoDisplay),
-					windowSize.Width, windowSize.Height, windowFlags);
+					windowSize.Width, windowSize.Height, WindowFlags);
 
 				if (Platform.CurrentPlatform == PlatformType.Linux)
 				{
@@ -551,8 +551,8 @@ namespace OpenRA.Platforms.Default
 
 			SetSDLAttributes(profile);
 
-			var flags = SDL.SDL_WindowFlags.SDL_WINDOW_HIDDEN | SDL.SDL_WindowFlags.SDL_WINDOW_OPENGL;
-			var window = SDL.SDL_CreateWindow("", 0, 0, 1, 1, flags);
+			const SDL.SDL_WindowFlags Flags = SDL.SDL_WindowFlags.SDL_WINDOW_HIDDEN | SDL.SDL_WindowFlags.SDL_WINDOW_OPENGL;
+			var window = SDL.SDL_CreateWindow("", 0, 0, 1, 1, Flags);
 			if (window == IntPtr.Zero || !string.IsNullOrEmpty(SDL.SDL_GetError()))
 			{
 				errorLog.Add($"{profile}: SDL window creation failed: {SDL.SDL_GetError()}");

--- a/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
+++ b/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Test
 		[TestCase(TestName = "Parse tree roundtrips")]
 		public void TestParseRoundtrip()
 		{
-			var yaml =
+			const string Yaml =
 @"1:
 2: Test
 3: # Test
@@ -44,15 +44,15 @@ namespace OpenRA.Test
 	9.1.2: Test
 	9.1.3: # Test
 ";
-			var serialized = MiniYaml.FromString(yaml, discardCommentsAndWhitespace: false).WriteToString();
+			var serialized = MiniYaml.FromString(Yaml, discardCommentsAndWhitespace: false).WriteToString();
 			Console.WriteLine();
-			Assert.That(serialized, Is.EqualTo(yaml));
+			Assert.That(serialized, Is.EqualTo(Yaml));
 		}
 
 		[TestCase(TestName = "Parse tree can handle empty lines")]
 		public void TestParseEmptyLines()
 		{
-			var yaml =
+			const string Yaml =
 @"1:
 
 2: Test
@@ -97,7 +97,7 @@ namespace OpenRA.Test
 
 ";
 
-			var expectedYaml =
+			const string ExpectedYaml =
 @"1:
 2: Test
 3:
@@ -120,14 +120,14 @@ namespace OpenRA.Test
 	9.1.2: Test
 	9.1.3:
 ";
-			var serialized = MiniYaml.FromString(yaml).WriteToString();
-			Assert.That(serialized, Is.EqualTo(expectedYaml));
+			var serialized = MiniYaml.FromString(Yaml).WriteToString();
+			Assert.That(serialized, Is.EqualTo(ExpectedYaml));
 		}
 
 		[TestCase(TestName = "Mixed tabs & spaces indents")]
 		public void TestIndents()
 		{
-			var yamlTabStyle = @"
+			const string YamlTabStyle = @"
 Root1:
 	Child1:
 		Attribute1: Test
@@ -140,7 +140,7 @@ Root2:
 		Attribute1: Test
 ";
 
-			var yamlMixedStyle = @"
+			const string YamlMixedStyle = @"
 Root1:
     Child1:
         Attribute1: Test
@@ -152,9 +152,9 @@ Root2:
     Child1:
 		Attribute1: Test
 ";
-			var tabs = MiniYaml.FromString(yamlTabStyle, "yamlTabStyle").WriteToString();
+			var tabs = MiniYaml.FromString(YamlTabStyle, "yamlTabStyle").WriteToString();
 			Console.WriteLine(tabs);
-			var mixed = MiniYaml.FromString(yamlMixedStyle, "yamlMixedStyle").WriteToString();
+			var mixed = MiniYaml.FromString(YamlMixedStyle, "yamlMixedStyle").WriteToString();
 			Console.WriteLine(mixed);
 			Assert.That(tabs, Is.EqualTo(mixed));
 		}
@@ -162,25 +162,25 @@ Root2:
 		[TestCase(TestName = "Inheritance and removal can be composed")]
 		public void InheritanceAndRemovalCanBeComposed()
 		{
-			var baseYaml = @"
+			const string BaseYaml = @"
 ^BaseA:
 	MockA2:
 ^BaseB:
 	Inherits@a: ^BaseA
 	MockB2:
 ";
-			var extendedYaml = @"
+			const string ExtendedYaml = @"
 Test:
 	Inherits@b: ^BaseB
 	-MockA2:
 ";
-			var mapYaml = @"
+			const string MapYaml = @"
 ^BaseC:
 	MockC2:
 Test:
 	Inherits@c: ^BaseC
 ";
-			var result = MiniYaml.Merge(new[] { baseYaml, extendedYaml, mapYaml }.Select(s => MiniYaml.FromString(s, "")))
+			var result = MiniYaml.Merge(new[] { BaseYaml, ExtendedYaml, MapYaml }.Select(s => MiniYaml.FromString(s, "")))
 				.First(n => n.Key == "Test").Value.Nodes;
 
 			Assert.IsFalse(result.Any(n => n.Key == "MockA2"), "Node should not have the MockA2 child, but does.");
@@ -191,19 +191,19 @@ Test:
 		[TestCase(TestName = "Child can be removed after multiple inheritance")]
 		public void ChildCanBeRemovedAfterMultipleInheritance()
 		{
-			var baseYaml = @"
+			const string BaseYaml = @"
 ^BaseA:
 	MockA2:
 Test:
 	Inherits: ^BaseA
 	MockA2:
 ";
-			var overrideYaml = @"
+			const string OverrideYaml = @"
 Test:
 	-MockA2
 ";
 
-			var result = MiniYaml.Merge(new[] { baseYaml, overrideYaml }.Select(s => MiniYaml.FromString(s, "")))
+			var result = MiniYaml.Merge(new[] { BaseYaml, OverrideYaml }.Select(s => MiniYaml.FromString(s, "")))
 				.First(n => n.Key == "Test").Value.Nodes;
 
 			Assert.IsFalse(result.Any(n => n.Key == "MockA2"), "Node should not have the MockA2 child, but does.");
@@ -212,7 +212,7 @@ Test:
 		[TestCase(TestName = "Child can be immediately removed")]
 		public void ChildCanBeImmediatelyRemoved()
 		{
-			var baseYaml = @"
+			const string BaseYaml = @"
 ^BaseA:
     MockString:
         AString: Base
@@ -223,7 +223,7 @@ Test:
     -MockString:
 ";
 
-			var result = MiniYaml.Merge(new[] { baseYaml }.Select(s => MiniYaml.FromString(s, "")))
+			var result = MiniYaml.Merge(new[] { BaseYaml }.Select(s => MiniYaml.FromString(s, "")))
 				 .First(n => n.Key == "Test").Value.Nodes;
 
 			Assert.IsFalse(result.Any(n => n.Key == "MockString"), "Node should not have the MockString child, but does.");
@@ -232,7 +232,7 @@ Test:
 		[TestCase(TestName = "Child can be removed and immediately overridden")]
 		public void ChildCanBeRemovedAndImmediatelyOverridden()
 		{
-			var baseYaml = @"
+			const string BaseYaml = @"
 ^BaseA:
     MockString:
         AString: Base
@@ -243,7 +243,7 @@ Test:
         AString: Override
 ";
 
-			var result = MiniYaml.Merge(new[] { baseYaml }.Select(s => MiniYaml.FromString(s, "")))
+			var result = MiniYaml.Merge(new[] { BaseYaml }.Select(s => MiniYaml.FromString(s, "")))
 				 .First(n => n.Key == "Test").Value.Nodes;
 
 			Assert.IsTrue(result.Any(n => n.Key == "MockString"), "Node should have the MockString child, but does not.");
@@ -254,7 +254,7 @@ Test:
 		[TestCase(TestName = "Child can be removed and later overridden")]
 		public void ChildCanBeRemovedAndLaterOverridden()
 		{
-			var baseYaml = @"
+			const string BaseYaml = @"
 ^BaseA:
     MockString:
         AString: Base
@@ -262,13 +262,13 @@ Test:
     Inherits: ^BaseA
     -MockString:
 ";
-			var overrideYaml = @"
+			const string OverrideYaml = @"
 Test:
     MockString:
         AString: Override
 ";
 
-			var result = MiniYaml.Merge(new[] { baseYaml, overrideYaml }.Select(s => MiniYaml.FromString(s, "")))
+			var result = MiniYaml.Merge(new[] { BaseYaml, OverrideYaml }.Select(s => MiniYaml.FromString(s, "")))
 				.First(n => n.Key == "Test").Value.Nodes;
 
 			Assert.IsTrue(result.Any(n => n.Key == "MockString"), "Node should have the MockString child, but does not.");
@@ -279,7 +279,7 @@ Test:
 		[TestCase(TestName = "Child can be removed from intermediate parent")]
 		public void ChildCanBeOverriddenThenRemoved()
 		{
-			var baseYaml = @"
+			const string BaseYaml = @"
 ^BaseA:
     MockString:
         AString: Base
@@ -288,14 +288,14 @@ Test:
     MockString:
         AString: Override
 ";
-			var overrideYaml = @"
+			const string OverrideYaml = @"
 Test:
     Inherits: ^BaseB
     MockString:
     	-AString:
 ";
 
-			var result = MiniYaml.Merge(new[] { baseYaml, overrideYaml }.Select(s => MiniYaml.FromString(s, "")))
+			var result = MiniYaml.Merge(new[] { BaseYaml, OverrideYaml }.Select(s => MiniYaml.FromString(s, "")))
 				.First(n => n.Key == "Test").Value.Nodes;
 			Assert.IsTrue(result.Any(n => n.Key == "MockString"), "Node should have the MockString child, but does not.");
 			Assert.IsFalse(result.First(n => n.Key == "MockString").Value.Nodes.Any(n => n.Key == "AString"),
@@ -305,7 +305,7 @@ Test:
 		[TestCase(TestName = "Child subnode can be removed and immediately overridden")]
 		public void ChildSubNodeCanBeRemovedAndImmediatelyOverridden()
 		{
-			var baseYaml = @"
+			const string BaseYaml = @"
 ^BaseA:
 	MockString:
 		CollectionOfStrings:
@@ -319,7 +319,7 @@ Test:
 			StringC: C
 ";
 
-			var merged = MiniYaml.Merge(new[] { baseYaml }.Select(s => MiniYaml.FromString(s, "")))
+			var merged = MiniYaml.Merge(new[] { BaseYaml }.Select(s => MiniYaml.FromString(s, "")))
 				.First(n => n.Key == "Test");
 
 			var traitNode = merged.Value.Nodes.Single();
@@ -334,7 +334,7 @@ Test:
 		[TestCase(TestName = "Child subnode can be removed and later overridden")]
 		public void ChildSubNodeCanBeRemovedAndLaterOverridden()
 		{
-			var baseYaml = @"
+			const string BaseYaml = @"
 ^BaseA:
 	MockString:
 		CollectionOfStrings:
@@ -346,14 +346,14 @@ Test:
 		-CollectionOfStrings:
 ";
 
-			var overrideYaml = @"
+			const string OverrideYaml = @"
 Test:
     MockString:
 		CollectionOfStrings:
 			StringC: C
 ";
 
-			var merged = MiniYaml.Merge(new[] { baseYaml, overrideYaml }.Select(s => MiniYaml.FromString(s, "")))
+			var merged = MiniYaml.Merge(new[] { BaseYaml, OverrideYaml }.Select(s => MiniYaml.FromString(s, "")))
 				.First(n => n.Key == "Test");
 
 			var traitNode = merged.Value.Nodes.Single();
@@ -368,7 +368,7 @@ Test:
 		[TestCase(TestName = "Empty lines should count toward line numbers")]
 		public void EmptyLinesShouldCountTowardLineNumbers()
 		{
-			var yaml = @"
+			const string Yaml = @"
 TestA:
 	Nothing:
 
@@ -376,14 +376,14 @@ TestB:
 	Nothing:
 ";
 
-			var result = MiniYaml.FromString(yaml).First(n => n.Key == "TestB");
+			var result = MiniYaml.FromString(Yaml).First(n => n.Key == "TestB");
 			Assert.AreEqual(5, result.Location.Line);
 		}
 
 		[TestCase(TestName = "Duplicated nodes are correctly merged")]
 		public void TestSelfMerging()
 		{
-			var baseYaml = @"
+			const string BaseYaml = @"
 Test:
 	Merge: original
 		Child: original
@@ -394,7 +394,7 @@ Test:
 	Override:
 ";
 
-			var result = MiniYaml.Merge(new[] { baseYaml }.Select(s => MiniYaml.FromString(s, "")));
+			var result = MiniYaml.Merge(new[] { BaseYaml }.Select(s => MiniYaml.FromString(s, "")));
 			Assert.That(result.Count(n => n.Key == "Test"), Is.EqualTo(1), "Result should have exactly one Test node.");
 
 			var testNodes = result.First(n => n.Key == "Test").Value.Nodes;
@@ -408,13 +408,13 @@ Test:
 		[TestCase(TestName = "Duplicated nodes across multiple sources are correctly merged")]
 		public void TestSelfMergingMultiSource()
 		{
-			var firstYaml = @"
+			const string FirstYaml = @"
 Test:
 	Merge: original
 		Child: original
 	Original:
 ";
-			var secondYaml = @"
+			const string SecondYaml = @"
 Test:
 	Merge: original
 		Child: original
@@ -425,7 +425,7 @@ Test:
 	Override:
 ";
 
-			var result = MiniYaml.Merge(new[] { firstYaml, secondYaml }.Select(s => MiniYaml.FromString(s, "")));
+			var result = MiniYaml.Merge(new[] { FirstYaml, SecondYaml }.Select(s => MiniYaml.FromString(s, "")));
 			Assert.That(result.Count(n => n.Key == "Test"), Is.EqualTo(1), "Result should have exactly one Test node.");
 
 			var testNodes = result.First(n => n.Key == "Test").Value.Nodes;
@@ -439,14 +439,14 @@ Test:
 		[TestCase(TestName = "Duplicated child nodes do not throw if parent does not require merging")]
 		public void TestMergeConflictsNoMerge()
 		{
-			var baseYaml = @"
+			const string BaseYaml = @"
 Test:
 	Merge:
 		Child:
 		Child:
 ";
 
-			var result = MiniYaml.Merge(new[] { baseYaml }.Select(s => MiniYaml.FromString(s, "")));
+			var result = MiniYaml.Merge(new[] { BaseYaml }.Select(s => MiniYaml.FromString(s, "")));
 			var testNodes = result.First(n => n.Key == "Test").Value.Nodes;
 			var mergeNode = testNodes.First(n => n.Key == "Merge").Value;
 			Assert.That(mergeNode.Nodes.Count, Is.EqualTo(2));
@@ -455,7 +455,7 @@ Test:
 		[TestCase(TestName = "Duplicated child nodes throw merge error if first parent requires merging")]
 		public void TestMergeConflictsFirstParent()
 		{
-			var baseYaml = @"
+			const string BaseYaml = @"
 Test:
 	Merge:
 		Child1:
@@ -463,7 +463,8 @@ Test:
 	Merge:
 ";
 
-			void Merge() => MiniYaml.Merge(new[] { baseYaml }.Select(s => MiniYaml.FromString(s, "test-filename")));
+			static void Merge() => MiniYaml.Merge(new[] { BaseYaml }.Select(s => MiniYaml.FromString(s, "test-filename")));
+
 			Assert.That(Merge, Throws.Exception.TypeOf<ArgumentException>().And.Message.EqualTo(
 				"MiniYaml.Merge, duplicate values found for the following keys: Child1: [Child1 (at test-filename:4),Child1 (at test-filename:5)]"));
 		}
@@ -471,14 +472,16 @@ Test:
 		[TestCase(TestName = "Duplicated child nodes throw merge error if second parent requires merging")]
 		public void TestMergeConflictsSecondParent()
 		{
-			var baseYaml = @"
+			const string BaseYaml = @"
 Test:
 	Merge:
 	Merge:
 		Child2:
 		Child2:
 ";
-			void Merge() => MiniYaml.Merge(new[] { baseYaml }.Select(s => MiniYaml.FromString(s, "test-filename")));
+
+			static void Merge() => MiniYaml.Merge(new[] { BaseYaml }.Select(s => MiniYaml.FromString(s, "test-filename")));
+
 			Assert.That(Merge, Throws.Exception.TypeOf<ArgumentException>().And.Message.EqualTo(
 				"MiniYaml.Merge, duplicate values found for the following keys: Child2: [Child2 (at test-filename:5),Child2 (at test-filename:6)]"));
 		}
@@ -486,18 +489,18 @@ Test:
 		[TestCase(TestName = "Duplicated child nodes across multiple sources do not throw")]
 		public void TestMergeConflictsMultiSourceMerge()
 		{
-			var firstYaml = @"
+			const string FirstYaml = @"
 Test:
 	Merge:
 		Child:
 ";
-			var secondYaml = @"
+			const string SecondYaml = @"
 Test:
 	Merge:
 		Child:
 ";
 
-			var result = MiniYaml.Merge(new[] { firstYaml, secondYaml }.Select(s => MiniYaml.FromString(s, "")));
+			var result = MiniYaml.Merge(new[] { FirstYaml, SecondYaml }.Select(s => MiniYaml.FromString(s, "")));
 			var testNodes = result.First(n => n.Key == "Test").Value.Nodes;
 			var mergeNode = testNodes.First(n => n.Key == "Merge").Value;
 			Assert.That(mergeNode.Nodes.Count, Is.EqualTo(1));
@@ -506,18 +509,19 @@ Test:
 		[TestCase(TestName = "Duplicated child nodes across multiple sources throw merge error if first parent requires merging")]
 		public void TestMergeConflictsMultiSourceFirstParent()
 		{
-			var firstYaml = @"
+			const string FirstYaml = @"
 Test:
 	Merge:
 		Child1:
 		Child1:
 ";
-			var secondYaml = @"
+			const string SecondYaml = @"
 Test:
 	Merge:
 ";
 
-			void Merge() => MiniYaml.Merge(new[] { firstYaml, secondYaml }.Select(s => MiniYaml.FromString(s, "test-filename")));
+			static void Merge() => MiniYaml.Merge(new[] { FirstYaml, SecondYaml }.Select(s => MiniYaml.FromString(s, "test-filename")));
+
 			Assert.That(Merge, Throws.Exception.TypeOf<ArgumentException>().And.Message.EqualTo(
 				"MiniYaml.Merge, duplicate values found for the following keys: Child1: [Child1 (at test-filename:4),Child1 (at test-filename:5)]"));
 		}
@@ -525,18 +529,19 @@ Test:
 		[TestCase(TestName = "Duplicated child nodes across multiple sources throw merge error if second parent requires merging")]
 		public void TestMergeConflictsMultiSourceSecondParent()
 		{
-			var firstYaml = @"
+			const string FirstYaml = @"
 Test:
 	Merge:
 ";
-			var secondYaml = @"
+			const string SecondYaml = @"
 Test:
 	Merge:
 		Child2:
 		Child2:
 ";
 
-			void Merge() => MiniYaml.Merge(new[] { firstYaml, secondYaml }.Select(s => MiniYaml.FromString(s, "test-filename")));
+			static void Merge() => MiniYaml.Merge(new[] { FirstYaml, SecondYaml }.Select(s => MiniYaml.FromString(s, "test-filename")));
+
 			Assert.That(Merge, Throws.Exception.TypeOf<ArgumentException>().And.Message.EqualTo(
 				"MiniYaml.Merge, duplicate values found for the following keys: Child2: [Child2 (at test-filename:4),Child2 (at test-filename:5)]"));
 		}
@@ -573,15 +578,15 @@ Test:
 		[TestCase(TestName = "Leading and trailing whitespace can be guarded using a backslash")]
 		public void TestGuardedWhitespace()
 		{
-			var testYaml = @"key:   \      test value    \   ";
-			var nodes = MiniYaml.FromString(testYaml, "testYaml");
+			const string TestYaml = @"key:   \      test value    \   ";
+			var nodes = MiniYaml.FromString(TestYaml, "testYaml");
 			Assert.AreEqual("      test value    ", nodes[0].Value.Value);
 		}
 
 		[TestCase(TestName = "Comments should count toward line numbers")]
 		public void CommentsShouldCountTowardLineNumbers()
 		{
-			var yaml = @"
+			const string Yaml = @"
 TestA:
 	Nothing:
 
@@ -589,12 +594,12 @@ TestA:
 TestB:
 	Nothing:
 ";
-			var resultDiscard = MiniYaml.FromString(yaml);
+			var resultDiscard = MiniYaml.FromString(Yaml);
 			var resultDiscardLine = resultDiscard.First(n => n.Key == "TestB").Location.Line;
 			Assert.That(resultDiscardLine, Is.EqualTo(6), "Node TestB should report its location as line 6, but is not (discarding comments)");
 			Assert.That(resultDiscard[1].Key, Is.EqualTo("TestB"), "Node TestB should be the second child of the root node, but is not (discarding comments)");
 
-			var resultKeep = MiniYaml.FromString(yaml, discardCommentsAndWhitespace: false);
+			var resultKeep = MiniYaml.FromString(Yaml, discardCommentsAndWhitespace: false);
 			var resultKeepLine = resultKeep.First(n => n.Key == "TestB").Location.Line;
 			Assert.That(resultKeepLine, Is.EqualTo(6), "Node TestB should report its location as line 6, but is not (parsing comments)");
 			Assert.That(resultKeep[4].Key, Is.EqualTo("TestB"), "Node TestB should be the fifth child of the root node, but is not (parsing comments)");
@@ -621,7 +626,7 @@ Parent: # comment without value
 		[TestCase(TestName = "Comments should be removed when discardCommentsAndWhitespace is false")]
 		public void CommentsShouldntSurviveRoundTrip()
 		{
-			var yaml = @"
+			const string Yaml = @"
 # Top level comment node
 Parent: # comment without value
 	# Indented comment node
@@ -634,7 +639,7 @@ Parent: # comment without value
 	Second: value
 ".Replace("\r\n", "\n");
 
-			var result = MiniYaml.FromString(yaml).WriteToString();
+			var result = MiniYaml.FromString(Yaml).WriteToString();
 			Assert.AreEqual(strippedYaml, result);
 		}
 	}


### PR DESCRIPTION
Following on from #21176.

Enforces 6 Roslynator rules across the project.

I have batched together a PR for these rules as they are hopefully uncontroversial. However fixes are arranged per commit so we can easily bikeshed over rules as desired.

See https://josefpihrt.github.io/docs/roslynator/analyzers for explanation of each rule.