### PR TITLE
Add a button to reset lobby options to default.

### DIFF
--- a/mods/cnc/chrome/lobby.yaml
+++ b/mods/cnc/chrome/lobby.yaml
@@ -34,6 +34,12 @@ Container@SERVER_LOBBY:
 					Width: 211
 					Height: 25
 					Text: dropdownbutton-bg-slots
+				Button@RESET_OPTIONS_BUTTON:
+					X: 15
+					Y: 254
+					Width: 211
+					Height: 25
+					Text: button-bg-reset-options
 				Container@SKIRMISH_TABS:
 					X: 697 - WIDTH
 					Width: 465

--- a/mods/cnc/languages/chrome/en.ftl
+++ b/mods/cnc/languages/chrome/en.ftl
@@ -409,6 +409,7 @@ dropdownbutton-lobby-servers-bin-filters = Filter Games
 
 ## lobby.yaml
 dropdownbutton-bg-slots = Slot Admin
+button-bg-reset-options = Reset Defaults
 button-skirmish-tabs-players-tab = Players
 button-skirmish-tabs-options-tab = Options
 button-skirmish-tabs-music-tab = Music

--- a/mods/common/chrome/lobby.yaml
+++ b/mods/common/chrome/lobby.yaml
@@ -30,6 +30,13 @@ Background@SERVER_LOBBY:
 			Height: 25
 			Font: Bold
 			Text: dropdownbutton-server-lobby-slots
+		Button@RESET_OPTIONS_BUTTON:
+			X: 20
+			Y: 291
+			Width: 185
+			Height: 25
+			Font: Bold
+			Text: button-server-lobby-reset-options
 		Container@SKIRMISH_TABS:
 			X: 695 - WIDTH
 			Width: 486

--- a/mods/common/languages/chrome/en.ftl
+++ b/mods/common/languages/chrome/en.ftl
@@ -260,6 +260,7 @@ label-notice-container-playtest-available = A preview of the next OpenRA release
 
 ## lobby.yaml
 dropdownbutton-server-lobby-slots = Slot Admin
+button-server-lobby-reset-options = Reset Defaults
 button-skirmish-tabs-players-tab = Players
 button-skirmish-tabs-options-tab = Options
 button-skirmish-tabs-music-tab = Music


### PR DESCRIPTION
This makes it easier to restore the options to the map-author's intended state, and provides a quick way for the game admin to know if anything has been changed.