### PR TITLE
Improve delay between load complete and game starting

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -223,6 +223,10 @@ namespace OpenRA
 			//   Much better to clean up now then to drop frames during gameplay for GC pauses.
 			GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
 			GC.Collect();
+
+			// PostLoadComplete is designed for anything that should trigger at the very end of loading.
+			// e.g. audio notifications that the game is starting.
+			OrderManager.World.PostLoadComplete(worldRenderer);
 		}
 
 		public static void RestartGame()

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -602,7 +602,10 @@ namespace OpenRA
 
 			if (orderManager.LastTickTime.ShouldAdvance(tick))
 			{
-				using (new PerfSample("tick_time"))
+				if (orderManager.GameStarted && orderManager.LocalFrameNumber == 0)
+					PerfHistory.Reset(); // Remove history that occurred whilst the new game was loading.
+
+				using (var sample = new PerfSample("tick_time"))
 				{
 					orderManager.LastTickTime.AdvanceTickTime(tick);
 
@@ -611,7 +614,11 @@ namespace OpenRA
 					Sync.RunUnsynced(world, orderManager.TickImmediate);
 
 					if (world == null)
+					{
+						if (orderManager.GameStarted)
+							PerfHistory.Reset(); // Remove old history when a new game starts.
 						return;
+					}
 
 					if (orderManager.TryTick())
 					{

--- a/OpenRA.Game/Support/PerfHistory.cs
+++ b/OpenRA.Game/Support/PerfHistory.cs
@@ -47,5 +47,11 @@ namespace OpenRA.Support
 				if (item.HasNormalTick)
 					item.Tick();
 		}
+
+		public static void Reset()
+		{
+			foreach (var item in Items.Values)
+				item.ResetSamples();
+		}
 	}
 }

--- a/OpenRA.Game/Support/PerfItem.cs
+++ b/OpenRA.Game/Support/PerfItem.cs
@@ -72,5 +72,12 @@ namespace OpenRA.Support
 				return samples[n];
 			}
 		}
+
+		public void ResetSamples()
+		{
+			head = 1;
+			tail = 0;
+			Val = 0.0;
+		}
 	}
 }

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -366,6 +366,7 @@ namespace OpenRA.Traits
 	public interface INotifySelection { void SelectionChanged(); }
 
 	public interface IWorldLoaded { void WorldLoaded(World w, WorldRenderer wr); }
+	public interface IPostWorldLoaded { void PostWorldLoaded(World w, WorldRenderer wr); }
 	public interface INotifyGameLoading { void GameLoading(World w); }
 	public interface INotifyGameLoaded { void GameLoaded(World w); }
 	public interface INotifyGameSaved { void GameSaved(World w); }

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -296,14 +296,27 @@ namespace OpenRA
 					using (new PerfTimer(iwl.GetType().Name + ".WorldLoaded"))
 						iwl.WorldLoaded(this, wr);
 
-			gameInfo.StartTimeUtc = DateTime.UtcNow;
 			foreach (var player in Players)
 				gameInfo.AddPlayer(player, OrderManager.LobbyInfo);
 
 			gameInfo.DisabledSpawnPoints = OrderManager.LobbyInfo.DisabledSpawnPoints;
 
+			gameInfo.StartTimeUtc = DateTime.UtcNow;
+
 			if (OrderManager.Connection is NetworkConnection nc && nc.Recorder != null)
 				nc.Recorder.Metadata = new ReplayMetadata(gameInfo);
+		}
+
+		public void PostLoadComplete(WorldRenderer wr)
+		{
+			foreach (var iwl in WorldActor.TraitsImplementing<IPostWorldLoaded>())
+				using (new PerfTimer(iwl.GetType().Name + ".PostWorldLoaded"))
+					iwl.PostWorldLoaded(this, wr);
+
+			foreach (var p in Players)
+				foreach (var iwl in p.PlayerActor.TraitsImplementing<IPostWorldLoaded>())
+					using (new PerfTimer(iwl.GetType().Name + ".PostWorldLoaded"))
+						iwl.PostWorldLoaded(this, wr);
 		}
 
 		public void SetWorldOwner(Player p)

--- a/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
+++ b/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new MusicPlaylist(init.World, this); }
 	}
 
-	public class MusicPlaylist : INotifyActorDisposing, IGameOver, IWorldLoaded, INotifyGameLoaded
+	public class MusicPlaylist : INotifyActorDisposing, IGameOver, IPostWorldLoaded, INotifyGameLoaded
 	{
 		readonly MusicPlaylistInfo info;
 		readonly World world;
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		void IWorldLoaded.WorldLoaded(World world, WorldRenderer wr)
+		void IPostWorldLoaded.PostWorldLoaded(World world, WorldRenderer wr)
 		{
 			// Reset any bogus pre-existing state
 			Game.Sound.DisableWorldSounds = info.DisableWorldSounds;

--- a/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
+++ b/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new StartGameNotification(this); }
 	}
 
-	sealed class StartGameNotification : IWorldLoaded, INotifyGameLoaded, INotifyGameSaved
+	sealed class StartGameNotification : IPostWorldLoaded, INotifyGameLoaded, INotifyGameSaved
 	{
 		readonly StartGameNotificationInfo info;
 		public StartGameNotification(StartGameNotificationInfo info)
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 		}
 
-		void IWorldLoaded.WorldLoaded(World world, WorldRenderer wr)
+		void IPostWorldLoaded.PostWorldLoaded(World world, WorldRenderer wr)
 		{
 			if (!world.IsLoadingGameSave)
 			{


### PR DESCRIPTION
Improve the delay from load screen disappearing to gaining control when starting a new game.

----

Ensure PerfHistory is reset when starting a new game.

Ensure stale perf history data, to ensure the data is useful and the perf graph widget displays useful information.
- Remove stale data from the previous game when starting a new game. This avoids the graph showing values from the previous game when a new game starts.
- Remove data that was collected during loading. This avoids displaying data points that were collected whilst the loading screen was visible. Data collected whilst loading is not relevant to the in-game performance graph.

The performance graph when starting a new game will now display accurate information from the first tick of the game, whereas previously it displayed some stale information as well.

----

Play game started audio notifications just as the game starts.

Previously the StartGameNotification and MusicPlaylist traits used the IWorldLoaded interface to play an audio notification and begin music when the game started. However this interface is used by many traits to perform initial loading whilst the load screen was visible, and this loading can take time. Since the traits could run in any order, then audio notification might fire before another trait with a long loading time. This is not ideal as we want the time between the audio notification occurring and the player being able to interact to be as short and reliable as possible.

Now, we introduce a new IPostWorldLoaded which runs after all other loading activity, and we switch StartGameNotification and MusicPlaylist to use it. This allows timing sensitive traits that want to run right at the end of loading to fire reliably and with minimal delay. The player perception of hearing the notification and being able to interact is now much snappier.
