### PR TITLE
FPS counter adjustments

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -180,6 +180,7 @@ namespace OpenRA
 		}
 
 		public static event Action BeforeGameStart = () => { };
+		public static event Action AfterGameStart = () => { };
 		internal static void StartGame(string mapUID, WorldType type)
 		{
 			// Dispose of the old world before creating a new one.
@@ -227,6 +228,8 @@ namespace OpenRA
 			// PostLoadComplete is designed for anything that should trigger at the very end of loading.
 			// e.g. audio notifications that the game is starting.
 			OrderManager.World.PostLoadComplete(worldRenderer);
+
+			AfterGameStart();
 		}
 
 		public static void RestartGame()

--- a/OpenRA.Mods.Common/Widgets/Logic/PerfDebugLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PerfDebugLogic.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			perfText.IsVisible = () => Game.Settings.Debug.PerfText;
 
 			var fpsTimer = Stopwatch.StartNew();
-			var fpsReferenceFrame = 0;
+			var fpsReferenceFrame = Game.RenderFrame;
 			var fps = 0;
 			perfText.GetText = () =>
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/PerfDebugLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PerfDebugLogic.cs
@@ -9,6 +9,8 @@
  */
 #endregion
 
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using OpenRA.Graphics;
 using OpenRA.Support;
@@ -28,22 +30,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			perfText.IsVisible = () => Game.Settings.Debug.PerfText;
 
 			var fpsTimer = Stopwatch.StartNew();
-			var fpsReferenceFrame = Game.RenderFrame;
-			var fps = 0;
+			var frameTimings = new List<(int Frame, TimeSpan Time)>(32) { (Game.RenderFrame, TimeSpan.Zero) };
 			perfText.GetText = () =>
 			{
-				var elapsed = fpsTimer.ElapsedMilliseconds;
-				if (elapsed > 1000)
-				{
-					// Round to closest integer
-					fps = (int)(1000.0f * (Game.RenderFrame - fpsReferenceFrame) / fpsTimer.ElapsedMilliseconds + 0.5f);
-					fpsTimer.Restart();
-					fpsReferenceFrame = Game.RenderFrame;
-				}
+				// Calculate FPS as a rolling average over the last ~1 second of frames.
+				frameTimings.Add((Game.RenderFrame, fpsTimer.Elapsed));
+				var cutoffTime = frameTimings[^1].Time - TimeSpan.FromSeconds(1);
+				var firstIndexPastCutoff = frameTimings.FindIndex(ft => ft.Time >= cutoffTime);
+				if (frameTimings.Count - firstIndexPastCutoff >= 2) // Keep at least 2 items for comparing.
+					frameTimings.RemoveRange(0, firstIndexPastCutoff);
+				var (oldestFrame, oldestTime) = frameTimings[0];
+				var (newestFrame, newestTime) = frameTimings[^1];
+				var fps = (newestFrame - oldestFrame) / (newestTime - oldestTime).TotalSeconds;
 
 				var wfbSize = Game.Renderer.WorldFrameBufferSize;
 				var viewportSize = worldRenderer.Viewport.Rectangle.Size;
-				return $"FPS: {fps}\nTick {Game.LocalTick} @ {PerfHistory.Items["tick_time"].Average(Game.Settings.Debug.Samples):F1} ms\n" +
+				return $"FPS: {fps:0}\nTick {Game.LocalTick} @ {PerfHistory.Items["tick_time"].Average(Game.Settings.Debug.Samples):F1} ms\n" +
 					$"Render {Game.RenderFrame} @ {PerfHistory.Items["render"].Average(Game.Settings.Debug.Samples):F1} ms\n" +
 					$"Batches: {PerfHistory.Items["batches"].LastValue}\n" +
 					$"Viewport Size: {viewportSize.Width} x {viewportSize.Height} / {Game.Renderer.WorldDownscaleFactor}\n" +


### PR DESCRIPTION
First commit fixes #17445.

Second commit switches to a rolling average of frames over the last second, rather than the current once-a-second snapshot of frames in the prior second. Let me know if this is worth keeping.

----

Fix FPS counter showing initial high figure.

When the widget is created, use the current frame as reference rather than always using zero. That avoids the first FPS reading from a new widget calculating as if all frames rendered since the game started occurred in the first second.

----

Change FPS counter behaviour.

Calculate a rolling average of FPS over the last second. This allows the FPS counter to be updated every frame - and in particular means it can display a rough figure immediately rather than needing to wait one second to collect information at the start of a game.