### PR TITLE
Replace Cloak palette effects with vertex effects

### DIFF
--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -227,7 +227,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!(firstTick && Info.InitialDelay == 0) && (otherCloaks == null || !otherCloaks.Any(a => a.Cloaked)))
 				{
 					var pos = self.CenterPosition;
-					Game.Sound.Play(SoundType.World, Info.CloakSound, pos);
+					Game.Sound.Play(SoundType.World, Info.UncloakSound, pos);
 
 					Func<WPos> posfunc = () => self.CenterPosition + Info.EffectOffset;
 					if (!Info.EffectTracksActor)

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20231010/ReplaceCloakPalette.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20231010/ReplaceCloakPalette.cs
@@ -1,0 +1,49 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class ReplaceCloakPalette : UpdateRule
+	{
+		public override string Name => "Change default Cloak style from Palette to Alpha.";
+
+		public override string Description =>
+			"Cloak has gained several new rendering modes\n" +
+			"and its default behaviour has changed from using a palette to native alpha.";
+
+		readonly List<string> locations = new();
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (locations.Count > 0)
+				yield return "Cloak no longer defaults to replacing the actor's palette.\n" +
+					"If you wish to keep the previous behavior you wish to change the\n" +
+					"Cloak definitions on the following actor definitions:\n" +
+					UpdateUtils.FormatMessageList(locations);
+
+			locations.Clear();
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
+		{
+			foreach (var cloak in actorNode.ChildrenMatching("Cloak"))
+			{
+				cloak.RemoveNodes("Palette");
+				cloak.RemoveNodes("IsPlayerPalette");
+				locations.Add($"{actorNode.Key} ({actorNode.Location.Filename})");
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -85,9 +85,9 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new ExtractResourceStorageFromHarvester(),
 				new ReplacePaletteModifiers(),
 				new RemoveConyardChronoReturnAnimation(),
-				new ReplaceCloakPalette(),
 
 				// Execute these rules last to avoid premature yaml merge crashes.
+				new ReplaceCloakPalette(),
 				new AbstractDocking(),
 			}),
 		};

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -85,6 +85,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new ExtractResourceStorageFromHarvester(),
 				new ReplacePaletteModifiers(),
 				new RemoveConyardChronoReturnAnimation(),
+				new ReplaceCloakPalette(),
 
 				// Execute these rules last to avoid premature yaml merge crashes.
 				new AbstractDocking(),

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -208,6 +208,8 @@ C17:
 	Cloak:
 		InitialDelay: 0
 		CloakDelay: 0
+		CloakStyle: Palette
+		CloakedPalette: cloak
 		DetectionTypes: C17
 		RequiresCondition: global-C17-stealth
 	Contrail@1:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -199,6 +199,8 @@
 		CloakDelay: 90
 		CloakSound: trans1.aud
 		UncloakSound: trans1.aud
+		CloakStyle: Palette
+		CloakedPalette: cloak
 		PauseOnCondition: cloak-force-disabled
 		RequiresCondition: cloak-crate-collected
 	ExternalCondition@CLOAK:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -708,6 +708,8 @@ STNK:
 		CloakDelay: 85
 		CloakSound: trans1.aud
 		UncloakSound: trans1.aud
+		CloakStyle: Palette
+		CloakedPalette: cloak
 		UncloakOn: Attack, Unload, Dock, Damage, Heal
 		PauseOnCondition: cloak-force-disabled
 	GrantConditionOnDamageState@UNCLOAK:

--- a/mods/d2k/rules/campaign-palettes.yaml
+++ b/mods/d2k/rules/campaign-palettes.yaml
@@ -1,6 +1,5 @@
 ^Palettes:
 	-PlayerColorPalette:
-	-PaletteFromPlayerPaletteWithAlpha@cloak:
 	IndexedPlayerPalette:
 		BasePalette: d2k
 		BaseName: player
@@ -15,7 +14,3 @@
 			Mercenaries: 239, 238, 237, 236, 235, 234, 233, 232, 231, 230, 229, 228, 227, 226, 225, 224
 			Neutral: 255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240
 			Creeps: 255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240
-	PaletteFromPlayerPaletteWithAlpha@Cloak:
-		BaseName: cloak
-		BasePalette: player
-		Alpha: 0.55

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -186,7 +186,6 @@ fremen:
 		InitialDelay: 85
 		CloakDelay: 85
 		UncloakOn: Attack, Unload, Infiltrate, Demolish, Dock, Damage, Heal
-		IsPlayerPalette: true
 		PauseOnCondition: cloak-force-disabled
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
@@ -328,7 +327,6 @@ saboteur:
 		CloakDelay: 25
 		CloakSound: STEALTH1.WAV
 		UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage, Heal
-		IsPlayerPalette: true
 		PauseOnCondition: cloak-force-disabled
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled

--- a/mods/d2k/rules/palettes.yaml
+++ b/mods/d2k/rules/palettes.yaml
@@ -44,7 +44,3 @@
 		RemapIndex: 255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240
 	MenuPostProcessEffect:
 	FlashPostProcessEffect:
-	PaletteFromPlayerPaletteWithAlpha@cloak:
-		BaseName: cloak
-		BasePalette: player
-		Alpha: 0.55

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -498,7 +498,6 @@ stealth_raider:
 		InitialDelay: 45
 		CloakDelay: 90
 		UncloakOn: Attack, Unload, Infiltrate, Demolish, Dock, Damage, Heal
-		IsPlayerPalette: true
 		PauseOnCondition: cloak-force-disabled
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -316,7 +316,6 @@ SNIPER:
 		CloakSound:
 		UncloakSound:
 		UncloakOn: Attack, Unload, Infiltrate, Demolish, Move
-		IsPlayerPalette: true
 		PauseOnCondition: cloak-force-disabled
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled

--- a/mods/ra/rules/campaign-palettes.yaml
+++ b/mods/ra/rules/campaign-palettes.yaml
@@ -1,7 +1,6 @@
 ^Palettes:
 	-PlayerColorPalette:
 	-PlayerColorPalette@NOSHADOW:
-	-PaletteFromPlayerPaletteWithAlpha@cloak:
 	IndexedPlayerPalette:
 		BasePalette: player
 		BaseName: player
@@ -40,7 +39,3 @@
 			Creeps: 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143
 			GoodGuy: 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175
 			BadGuy: 229, 230, 231, 232, 233, 234, 235, 8, 236, 237, 238, 239, 221, 222, 223, 223
-	PaletteFromPlayerPaletteWithAlpha@Cloak:
-		BaseName: cloak
-		BasePalette: player
-		Alpha: 0.55

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -559,10 +559,10 @@
 		DetectionTypes: Underwater
 		InitialDelay: 0
 		CloakDelay: 50
+		CloakStyle: Color
 		CloakSound: subshow1.aud
 		UncloakSound: subshow1.aud
 		CloakedCondition: underwater
-		Palette: submerged
 		PauseOnCondition: cloak-force-disabled
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
@@ -1230,7 +1230,7 @@
 	Cloak:
 		CloakSound:
 		UncloakSound:
-		Palette:
+		CloakStyle: None
 		DetectionTypes: Mine
 		InitialDelay: 0
 	Tooltip:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -664,7 +664,6 @@ THF:
 		CloakDelay: 120
 		UncloakOn: Attack, Unload, Infiltrate, Demolish, Move
 		DetectionTypes: Cloak
-		IsPlayerPalette: true
 		PauseOnCondition: cloak-force-disabled
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled

--- a/mods/ra/rules/palettes.yaml
+++ b/mods/ra/rules/palettes.yaml
@@ -56,12 +56,6 @@
 		G: 0
 		B: 0
 		A: 140
-	PaletteFromRGBA@submerged:
-		Name: submerged
-		R: 0
-		G: 0
-		B: 0
-		A: 140
 	PaletteFromRGBA@moveflash:
 		Name: moveflash
 		R: 255
@@ -80,10 +74,6 @@
 		BaseName: player-noshadow
 		BasePalette: player-noshadow
 		RemapIndex: 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95
-	PaletteFromPlayerPaletteWithAlpha@cloak:
-		BaseName: cloak
-		BasePalette: player
-		Alpha: 0.55
 	MenuPostProcessEffect:
 	RotationPaletteEffect@defaultwater:
 		Palettes: terrain

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -795,7 +795,6 @@ HBOX:
 	Cloak:
 		InitialDelay: 125
 		CloakDelay: 60
-		IsPlayerPalette: true
 		PauseOnCondition: cloak-force-disabled
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -919,7 +919,6 @@ STNK:
 		CloakDelay: 175
 		CloakSound: appear1.aud
 		UncloakSound: appear1.aud
-		IsPlayerPalette: true
 		PauseOnCondition: cloak-force-disabled
 		UncloakOn: Attack, Load, Unload, Heal, Dock
 	GrantConditionOnDamageState@UNCLOAK:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -129,7 +129,6 @@
 		RequiresCondition: cloakgenerator || crate-cloak
 		InitialDelay: 0
 		CloakDelay: 90
-		IsPlayerPalette: true
 		CloakSound: cloak5.aud
 		UncloakSound: cloak5.aud
 		UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage, Heal, SupportPower

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -526,7 +526,6 @@ STNK:
 		CloakDelay: 90
 		CloakSound: cloak5.aud
 		UncloakSound: cloak5.aud
-		IsPlayerPalette: true
 		UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage, Heal
 		PauseOnCondition: cloak-force-disabled || empdisable
 		CloakType: nod-stealth

--- a/mods/ts/rules/palettes.yaml
+++ b/mods/ts/rules/palettes.yaml
@@ -152,10 +152,6 @@
 		BaseName: player-nobright
 		BasePalette: player-nobright
 		RemapIndex: 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
-	PaletteFromPlayerPaletteWithAlpha@cloak:
-		BaseName: cloak
-		BasePalette: player
-		Alpha: 0.55
 	PaletteFromPaletteWithAlpha@terrainalpha:
 		BasePalette: terraindecoration
 		Name: terrainalpha


### PR DESCRIPTION
This PR replaces the palette effects used by RA/D2k/TS with visually equivalent vertex effects, and changes TD to use the same translucency as the other mods. This also implements a smooth fading to/from cloak.

https://github.com/OpenRA/OpenRA/assets/167819/95ad8aad-38b3-4828-82c5-82395d9c231a

These new effects are compatible with 32-bit sprites, needed for TDHD and D2kHDR.

Closes #19263.