### PR TITLE
Add new code style rules (.NET 8)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -861,6 +861,9 @@ dotnet_diagnostic.CA1858.severity = warning
 # Avoid using 'Enumerable.Any()' extension method.
 dotnet_diagnostic.CA1860.severity = warning
 
+# Prefer the 'IDictionary.TryAdd(TKey, TValue)' method.
+dotnet_diagnostic.CA1864.severity = suggestion # TODO: Change to warning once using .NET 8 or later.
+
 # Cache and reuse 'JsonSerializerOptions' instances.
 dotnet_diagnostic.CA1869.severity = suggestion # TODO: Change to warning once using .NET 8 or later.
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -869,6 +869,9 @@ dotnet_diagnostic.CA1865.severity = suggestion # TODO: Change to warning once us
 dotnet_diagnostic.CA1866.severity = suggestion # TODO: Change to warning once using .NET 8 or later.
 dotnet_diagnostic.CA1867.severity = suggestion # TODO: Change to warning once using .NET 8 or later.
 
+# Unnecessary call to 'Contains' for sets.
+dotnet_diagnostic.CA1868.severity = suggestion # TODO: Change to warning once using .NET 8 or later.
+
 # Cache and reuse 'JsonSerializerOptions' instances.
 dotnet_diagnostic.CA1869.severity = suggestion # TODO: Change to warning once using .NET 8 or later.
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -864,6 +864,11 @@ dotnet_diagnostic.CA1860.severity = warning
 # Prefer the 'IDictionary.TryAdd(TKey, TValue)' method.
 dotnet_diagnostic.CA1864.severity = suggestion # TODO: Change to warning once using .NET 8 or later.
 
+# Use 'string.Method(char)' instead of 'string.Method(string)' for string with single char.
+dotnet_diagnostic.CA1865.severity = suggestion # TODO: Change to warning once using .NET 8 or later.
+dotnet_diagnostic.CA1866.severity = suggestion # TODO: Change to warning once using .NET 8 or later.
+dotnet_diagnostic.CA1867.severity = suggestion # TODO: Change to warning once using .NET 8 or later.
+
 # Cache and reuse 'JsonSerializerOptions' instances.
 dotnet_diagnostic.CA1869.severity = suggestion # TODO: Change to warning once using .NET 8 or later.
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -70,6 +70,10 @@ csharp_style_prefer_top_level_statements = false
 dotnet_diagnostic.IDE0210.severity = warning
 dotnet_diagnostic.IDE0211.severity = warning
 
+# IDE0290 Use primary constructor
+#csharp_style_prefer_primary_constructors = true
+dotnet_diagnostic.IDE0200.severity = silent # Requires C# 12
+
 ## Expression-bodied members
 
 # IDE0021 Use expression body for constructors
@@ -724,6 +728,9 @@ dotnet_diagnostic.CA1417.severity = warning
 # Use 'nameof' in place of string.
 dotnet_diagnostic.CA1507.severity = warning
 
+# Avoid redundant length argument.
+dotnet_diagnostic.CA1514.severity = suggestion # TODO: Change to warning once using .NET 8 or later.
+
 ### Naming Rules
 ### https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/naming-warnings
 
@@ -853,6 +860,12 @@ dotnet_diagnostic.CA1858.severity = warning
 
 # Avoid using 'Enumerable.Any()' extension method.
 dotnet_diagnostic.CA1860.severity = warning
+
+# Cache and reuse 'JsonSerializerOptions' instances.
+dotnet_diagnostic.CA1869.severity = suggestion # TODO: Change to warning once using .NET 8 or later.
+
+# Use a cached 'SearchValues' instance.
+dotnet_diagnostic.CA1870.severity = suggestion # TODO: Change to warning once using .NET 8 or later.
 
 ### Reliability Rules
 ### https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/reliability-warnings

--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -159,9 +159,7 @@ namespace OpenRA.FileSystem
 					explicitMounts.Remove(key);
 
 				// Mod packages aren't owned by us, so we shouldn't dispose them
-				if (modPackages.Contains(package))
-					modPackages.Remove(package);
-				else
+				if (!modPackages.Remove(package))
 					package.Dispose();
 			}
 			else

--- a/OpenRA.Game/FileSystem/ZipFile.cs
+++ b/OpenRA.Game/FileSystem/ZipFile.cs
@@ -144,7 +144,7 @@ namespace OpenRA.FileSystem
 
 			public ZipFolder(ReadOnlyZipFile parent, string path)
 			{
-				if (path.EndsWith("/", StringComparison.Ordinal))
+				if (path.EndsWith('/'))
 					path = path[..^1];
 
 				Name = path;

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -200,18 +200,18 @@ namespace OpenRA
 
 		static string[] YamlList(Dictionary<string, MiniYaml> yaml, string key)
 		{
-			if (!yaml.ContainsKey(key))
+			if (!yaml.TryGetValue(key, out var value))
 				return Array.Empty<string>();
 
-			return yaml[key].Nodes.Select(n => n.Key).ToArray();
+			return value.Nodes.Select(n => n.Key).ToArray();
 		}
 
 		static IReadOnlyDictionary<string, string> YamlDictionary(Dictionary<string, MiniYaml> yaml, string key)
 		{
-			if (!yaml.ContainsKey(key))
+			if (!yaml.TryGetValue(key, out var value))
 				return new Dictionary<string, string>();
 
-			return yaml[key].ToDictionary(my => my.Value);
+			return value.ToDictionary(my => my.Value);
 		}
 
 		public bool Contains<T>() where T : IGlobalModData

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -348,8 +348,8 @@ namespace OpenRA
 
 			while (this[uid].Status != MapStatus.Available)
 			{
-				if (mapUpdates.ContainsKey(uid))
-					uid = mapUpdates[uid];
+				if (mapUpdates.TryGetValue(uid, out var newUid))
+					uid = newUid;
 				else
 					return null;
 			}

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -533,7 +533,7 @@ namespace OpenRA
 			{
 				// Append Removal nodes to the result.
 				// Therefore: we know the remainder of the method deals with a plain node.
-				if (node.Key.StartsWith("-", StringComparison.Ordinal))
+				if (node.Key.StartsWith('-'))
 				{
 					ret.Add(node);
 					return;

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -152,8 +152,8 @@ namespace OpenRA
 			for (var i = 0; i < p.Length; i++)
 			{
 				var key = p[i].Name;
-				if (!args.ContainsKey(key)) throw new InvalidOperationException($"ObjectCreator: key `{key}' not found");
-				a[i] = args[key];
+				if (!args.TryGetValue(key, out var arg)) throw new InvalidOperationException($"ObjectCreator: key `{key}' not found");
+				a[i] = arg;
 			}
 
 			return ctor.Invoke(a);

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -380,17 +380,17 @@ namespace OpenRA
 
 			if (voicedActor != null)
 			{
-				if (!rules.VoicePools.Value.ContainsKey(definition))
+				if (!rules.VoicePools.Value.TryGetValue(definition, out var p))
 					throw new InvalidOperationException($"Can't find {definition} in voice pool.");
 
-				pool = rules.VoicePools.Value[definition];
+				pool = p;
 			}
 			else
 			{
-				if (!rules.NotificationsPools.Value.ContainsKey(definition))
+				if (!rules.NotificationsPools.Value.TryGetValue(definition, out var p))
 					throw new InvalidOperationException($"Can't find {definition} in notification pool.");
 
-				pool = rules.NotificationsPools.Value[definition];
+				pool = p;
 			}
 
 			var clip = pool.GetNext();

--- a/OpenRA.Game/Traits/World/ScreenMap.cs
+++ b/OpenRA.Game/Traits/World/ScreenMap.cs
@@ -85,8 +85,7 @@ namespace OpenRA.Traits
 
 		public void AddOrUpdate(Player viewer, FrozenActor fa)
 		{
-			if (removeFrozenActors[viewer].Contains(fa))
-				removeFrozenActors[viewer].Remove(fa);
+			removeFrozenActors[viewer].Remove(fa);
 
 			addOrUpdateFrozenActors[viewer].Add(fa);
 		}
@@ -98,8 +97,7 @@ namespace OpenRA.Traits
 
 		public void AddOrUpdate(Actor a)
 		{
-			if (removeActors.Contains(a))
-				removeActors.Remove(a);
+			removeActors.Remove(a);
 
 			addOrUpdateActors.Add(a);
 		}

--- a/OpenRA.Game/UtilityCommands/ExtractChromeStrings.cs
+++ b/OpenRA.Game/UtilityCommands/ExtractChromeStrings.cs
@@ -257,10 +257,10 @@ namespace OpenRA.UtilityCommands
 			var validChildTypes = new List<(MiniYamlNodeBuilder Node, string Type, string Value)>();
 			foreach (var childNode in node.Value.Nodes)
 			{
-				if (translatables.ContainsKey(nodeType))
+				if (translatables.TryGetValue(nodeType, out var fieldName))
 				{
 					var childType = childNode.Key.Split('@')[0];
-					if (translatables[nodeType].Contains(childType)
+					if (fieldName.Contains(childType)
 						&& !string.IsNullOrEmpty(childNode.Value.Value)
 						&& !IsAlreadyTranslated(childNode.Value.Value)
 						&& childNode.Value.Value.Any(char.IsLetterOrDigit))

--- a/OpenRA.Mods.Cnc/Traits/World/VoxelCache.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/VoxelCache.cs
@@ -96,11 +96,11 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public bool HasModelSequence(string model, string sequence)
 		{
-			if (!models.ContainsKey(model))
+			if (!models.TryGetValue(model, out var sequences))
 				throw new InvalidOperationException(
 					$"Model `{model}` does not have any sequences defined.");
 
-			return models[model].ContainsKey(sequence);
+			return sequences.ContainsKey(sequence);
 		}
 
 		public IVertexBuffer<ModelVertex> VertexBuffer => loader.VertexBuffer;

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportGen2MapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportGen2MapCommand.cs
@@ -262,9 +262,9 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 
 				var name = entries[1].ToLowerInvariant();
 
-				if (DeployableActors.ContainsKey(name))
+				if (DeployableActors.TryGetValue(name, out var n))
 				{
-					name = DeployableActors[name];
+					name = n;
 					isDeployed = true;
 				}
 

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianDawnMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianDawnMapCommand.cs
@@ -91,8 +91,8 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 
 				var res = (Type: (byte)0, Index: (byte)0);
 				var type = kv.Value.ToLowerInvariant();
-				if (OverlayResourceMapping.ContainsKey(type))
-					res = OverlayResourceMapping[type];
+				if (OverlayResourceMapping.TryGetValue(type, out var r))
+					res = r;
 
 				Map.Resources[cell] = new ResourceTile(res.Type, res.Index);
 				if (OverlayActors.Contains(type))

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractBlastSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractBlastSourceAction.cs
@@ -43,8 +43,7 @@ namespace OpenRA.Mods.Common.Installer
 					source.Position += 13;
 
 					// This does not apply on game relevant data.
-					if (!entries.ContainsKey(key))
-						entries.Add(key, entry);
+					entries.TryAdd(key, entry);
 				}
 
 				foreach (var node in actionYaml.Nodes)

--- a/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
@@ -285,10 +285,10 @@ namespace OpenRA.Mods.Common.Lint
 			var isAttribute = !string.IsNullOrEmpty(attribute);
 			var keyWithAtrr = isAttribute ? $"{key}.{attribute}" : key;
 
-			if (!referencedVariablesPerKey.ContainsKey(keyWithAtrr))
+			if (!referencedVariablesPerKey.TryGetValue(keyWithAtrr, out var referencedVariables))
 				return;
 
-			foreach (var referencedVariable in referencedVariablesPerKey[keyWithAtrr])
+			foreach (var referencedVariable in referencedVariables)
 				if (!variableReferences.Contains(referencedVariable))
 					emitError(isAttribute ?
 						$"Missing variable `{referencedVariable}` for attribute `{attribute}` of key `{key}` in {file}." :
@@ -302,7 +302,7 @@ namespace OpenRA.Mods.Common.Lint
 
 			variableReferences.Add(varName);
 
-			if (!referencedVariablesPerKey.ContainsKey(keyWithAtrr) || !referencedVariablesPerKey[keyWithAtrr].Contains(varName))
+			if (!referencedVariablesPerKey.TryGetValue(keyWithAtrr, out var referencedVariables) || !referencedVariables.Contains(varName))
 				emitWarning(isAttribute ?
 					$"Unused variable `{varName}` for attribute `{attribute}` of key `{key}` in {file}." :
 					$"Unused variable `{varName}` for key `{key}` in {file}.");

--- a/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
@@ -292,10 +292,10 @@ namespace OpenRA.Mods.Common.Scripting
 		{
 			var queue = GetBuildableInfo(actorType).Queue.First();
 
-			if (!queues.ContainsKey(queue))
+			if (!queues.TryGetValue(queue, out var cpq))
 				return true;
 
-			return productionHandlers.ContainsKey(queue) || queues[queue].AllQueued().Any();
+			return productionHandlers.ContainsKey(queue) || cpq.AllQueued().Any();
 		}
 
 		BuildableInfo GetBuildableInfo(string actorType)

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -1163,9 +1163,7 @@ namespace OpenRA.Mods.Common.Server
 
 			// Clearing an empty spawn point prevents it from being selected
 			// Clearing a disabled spawn restores it for use
-			if (!server.LobbyInfo.DisabledSpawnPoints.Contains(spawnPoint))
-				server.LobbyInfo.DisabledSpawnPoints.Add(spawnPoint);
-			else
+			if (!server.LobbyInfo.DisabledSpawnPoints.Add(spawnPoint))
 				server.LobbyInfo.DisabledSpawnPoints.Remove(spawnPoint);
 
 			server.SyncLobbyInfo();

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -361,13 +361,11 @@ namespace OpenRA.Mods.Common.Server
 		{
 			lock (server.LobbyInfo)
 			{
-				if (!server.LobbyInfo.Slots.ContainsKey(s))
+				if (!server.LobbyInfo.Slots.TryGetValue(s, out var slot))
 				{
 					Log.Write("server", $"Invalid slot: {s}");
 					return false;
 				}
-
-				var slot = server.LobbyInfo.Slots[s];
 
 				if (slot.Closed || server.LobbyInfo.ClientInSlot(s) != null)
 					return false;

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -220,10 +220,10 @@ namespace OpenRA.Mods.Common.Traits
 				if (!actors.Contains(actor.Name))
 					return false;
 
-				if (!baseBuilder.Info.BuildingLimits.ContainsKey(actor.Name))
+				if (!baseBuilder.Info.BuildingLimits.TryGetValue(actor.Name, out var limit))
 					return true;
 
-				return playerBuildings.Count(a => a.Info.Name == actor.Name) < baseBuilder.Info.BuildingLimits[actor.Name];
+				return playerBuildings.Count(a => a.Info.Name == actor.Name) < limit;
 			});
 
 			if (orderBy != null)

--- a/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
@@ -72,8 +72,7 @@ namespace OpenRA.Mods.Common.Traits
 					continue;
 
 				// Add power to dictionary if not in delay dictionary yet
-				if (!waitingPowers.ContainsKey(sp))
-					waitingPowers.Add(sp, 0);
+				waitingPowers.TryAdd(sp, 0);
 
 				if (waitingPowers[sp] > 0)
 					waitingPowers[sp]--;

--- a/OpenRA.Mods.Common/Traits/DockClientManager.cs
+++ b/OpenRA.Mods.Common/Traits/DockClientManager.cs
@@ -308,10 +308,8 @@ namespace OpenRA.Mods.Common.Traits
 					clientActor, lookup.Keys, clientActor.Location, BlockedByActor.None,
 					location =>
 					{
-						if (!lookup.ContainsKey(location))
+						if (!lookup.TryGetValue(location, out var dock))
 							return 0;
-
-						var dock = lookup[location];
 
 						// Prefer docks with less occupancy (multiplier is to offset distance cost):
 						// TODO: add custom wieghts. E.g. owner vs allied.

--- a/OpenRA.Mods.Common/Traits/DockHost.cs
+++ b/OpenRA.Mods.Common/Traits/DockHost.cs
@@ -104,11 +104,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual void Unreserve(DockClientManager client)
 		{
-			if (ReservedDockClients.Contains(client))
-			{
-				ReservedDockClients.Remove(client);
+			if (ReservedDockClients.Remove(client))
 				client.UnreserveHost();
-			}
 		}
 
 		public virtual void OnDockStarted(Actor self, Actor clientActor, DockClientManager client)

--- a/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
@@ -51,10 +51,10 @@ namespace OpenRA.Mods.Common.Traits
 			var pos = map.CellContaining(self.CenterPosition);
 			var terrainType = map.GetTerrainInfo(pos).Type;
 
-			if (!Info.TerrainModifier.ContainsKey(terrainType))
+			if (!Info.TerrainModifier.TryGetValue(terrainType, out var modifiedDamage))
 				return FullDamage;
 
-			return Info.TerrainModifier[terrainType];
+			return modifiedDamage;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Player/GrantConditionOnPrerequisiteManager.cs
+++ b/OpenRA.Mods.Common/Traits/Player/GrantConditionOnPrerequisiteManager.cs
@@ -42,13 +42,13 @@ namespace OpenRA.Mods.Common.Traits
 		public void Register(Actor actor, GrantConditionOnPrerequisite u, string[] prerequisites)
 		{
 			var key = MakeKey(prerequisites);
-			if (!upgradables.ContainsKey(key))
+			if (!upgradables.TryGetValue(key, out var list))
 			{
-				upgradables.Add(key, new List<(Actor, GrantConditionOnPrerequisite)>());
+				upgradables.Add(key, list = new List<(Actor, GrantConditionOnPrerequisite)>());
 				techTree.Add(key, prerequisites, 0, this);
 			}
 
-			upgradables[key].Add((actor, u));
+			list.Add((actor, u));
 
 			// Notify the current state
 			u.PrerequisitesUpdated(actor, techTree.HasPrerequisites(prerequisites));

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -59,9 +59,9 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				var key = MakeKey(t);
 
-				if (!Powers.ContainsKey(key))
+				if (!Powers.TryGetValue(key, out var spi))
 				{
-					Powers.Add(key, t.CreateInstance(key, this));
+					Powers.Add(key, spi = t.CreateInstance(key, this));
 
 					if (t.Info.Prerequisites.Length > 0)
 					{
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 					}
 				}
 
-				Powers[key].Instances.Add(t);
+				spi.Instances.Add(t);
 			}
 		}
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20231010/AbstractDocking.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20231010/AbstractDocking.cs
@@ -80,10 +80,10 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				var dockNode = new MiniYamlNodeBuilder("DockHost", "");
 
 				var lowActorName = actorNode.Key.ToLowerInvariant();
-				if (!refineryNodes.ContainsKey(lowActorName) || !refineryNodes[lowActorName].Any(n => n.Key == "Type"))
+				if (!refineryNodes.TryGetValue(lowActorName, out var nodes) || !nodes.Any(n => n.Key == "Type"))
 					dockNode.AddNode("Type", "Unload");
 				else
-					dockNode.AddNode(refineryNodes[lowActorName].First(n => n.Key == "Type"));
+					dockNode.AddNode(nodes.First(n => n.Key == "Type"));
 
 				foreach (var value in moveRefineyValues)
 				{

--- a/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
@@ -349,7 +349,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 		public static void RenameKey(this MiniYamlNodeBuilder node, string newKey, bool preserveSuffix = true, bool includeRemovals = true)
 		{
 			var prefix = includeRemovals && node.IsRemoval() ? "-" : "";
-			var split = node.Key.IndexOf("@", StringComparison.Ordinal);
+			var split = node.Key.IndexOf('@');
 			if (preserveSuffix && split > -1)
 				node.Key = prefix + newKey + node.Key[split..];
 			else

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -622,10 +622,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					foreach (var content in mountedPackage.Contents)
 					{
-						if (!files.ContainsKey(content))
+						if (!files.TryGetValue(content, out var list))
 							files.Add(content, new List<IReadOnlyPackage> { mountedPackage });
 						else
-							files[content].Add(mountedPackage);
+							list.Add(mountedPackage);
 					}
 				}
 			}

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -107,11 +107,11 @@ namespace OpenRA
 			try
 			{
 				var command = args[0];
-				if (!actions.ContainsKey(command))
+				if (!actions.TryGetValue(command, out var kvp))
 					throw new NoSuchCommandException(command);
 
-				var action = actions[command].Key;
-				var validateActionArgs = actions[command].Value;
+				var action = kvp.Key;
+				var validateActionArgs = kvp.Value;
 
 				if (validateActionArgs.Invoke(args))
 				{


### PR DESCRIPTION
Add new code style rules from .NET 8. We don't enforce them yet since we support a .NET 6 target, but we can still get them into the config and fix them up. Also take the chance to fix violations for some .NET 7 rules, again without enforcing the rule as yet. (See #21011)