### PR TITLE
Update Production's Faction when its owner changes

### DIFF
--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -23,14 +23,17 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("e.g. Infantry, Vehicles, Aircraft, Buildings")]
 		public readonly string[] Produces = Array.Empty<string>();
 
+		[Desc("When owner is changed, should the Faction be updated to the new owner's faction?")]
+		public readonly bool UpdateFactionOnOwnerChange = false;
+
 		public override object Create(ActorInitializer init) { return new Production(init, this); }
 	}
 
-	public class Production : PausableConditionalTrait<ProductionInfo>
+	public class Production : PausableConditionalTrait<ProductionInfo>, INotifyOwnerChanged
 	{
 		RallyPoint rp;
 
-		public string Faction { get; }
+		public string Faction { get; private set; }
 
 		public Production(ActorInitializer init, ProductionInfo info)
 			: base(info)
@@ -137,6 +140,12 @@ namespace OpenRA.Mods.Common.Traits
 
 			return mobileInfo == null ||
 				mobileInfo.CanEnterCell(self.World, self, self.Location + s.ExitCell, ignoreActor: self);
+		}
+
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		{
+			if (Info.UpdateFactionOnOwnerChange)
+				Faction = self.Owner.Faction.InternalName;
 		}
 	}
 


### PR DESCRIPTION
This PR makes it possible to optionally change `Production.Faction` (i.e. custom property on `Production` trait, not faction of `Player`) when the actor's owner changes. It fixes the discrepancy between faction stored in `Production` trait and the faction of the actual owner of the actor.

This behavior is however disabled by default to keep backward compatibility. Each mod should decide, which actors are going to get `Production` trait that behaves like this.

Related to #21162 and #20705.