### PR TITLE
Fix InitialActor in Carryall not initialized correctly

### DIFF
--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -166,7 +166,7 @@ namespace OpenRA.Mods.Common.Activities
 				self.World.AddFrameEndTask(w =>
 				{
 					cargo.World.Remove(cargo);
-					carryable.Attached(cargo);
+					carryable.Attached(cargo, self);
 					carryall.AttachCarryable(self, cargo);
 				});
 			}

--- a/OpenRA.Mods.Common/Traits/Carryable.cs
+++ b/OpenRA.Mods.Common/Traits/Carryable.cs
@@ -69,12 +69,13 @@ namespace OpenRA.Mods.Common.Traits
 			base.Created(self);
 		}
 
-		public virtual void Attached(Actor self)
+		public virtual void Attached(Actor self, Actor carrier)
 		{
 			if (attached)
 				return;
 
 			attached = true;
+			Carrier = carrier;
 
 			if (carriedToken == Actor.InvalidConditionToken)
 				carriedToken = self.GrantCondition(Info.CarriedCondition);

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -128,14 +128,14 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (!string.IsNullOrEmpty(info.InitialActor))
 			{
-				var unit = self.World.CreateActor(false, info.InitialActor.ToLowerInvariant(), new TypeDictionary
+				var cargo = self.World.CreateActor(false, info.InitialActor.ToLowerInvariant(), new TypeDictionary
 				{
 					new ParentActorInit(self),
 					new OwnerInit(self.Owner)
 				});
 
-				unit.Trait<Carryable>().Attached(unit);
-				AttachCarryable(self, unit);
+				cargo.Trait<Carryable>().Attached(cargo, self);
+				AttachCarryable(self, cargo);
 			}
 		}
 


### PR DESCRIPTION
`Carrier` field in `Carryable` is missing when `Carryall` initializing a carried actor by using option `InitialActor`.