### PR TITLE
Fix a compiler warning in MapCommand.cs

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/MapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/MapCommand.cs
@@ -76,13 +76,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 									map.Save(new Folder(z.Name.Replace(".oramap", "")));
 								break;
 							case "repack":
-								if (mapPackage is Folder f)
+								if (mapPackage is Folder f && File.Exists(f.Name + ".oramap"))
 								{
-									if (File.Exists(f.Name + ".oramap"))
-									{
-										map.Save(ZipFileLoader.Create(f.Name + ".oramap"));
-										Directory.Delete(f.Name, true);
-									}
+									map.Save(ZipFileLoader.Create(f.Name + ".oramap"));
+									Directory.Delete(f.Name, true);
 								}
 
 								break;


### PR DESCRIPTION
Current bleed [fails the CI](https://github.com/OpenRA/OpenRA/actions/runs/6990000491/job/19019070817) with `Error: /home/runner/work/OpenRA/OpenRA/OpenRA.Mods.Common/UtilityCommands/MapCommand.cs(79,9): error RCS1061: Merge 'if' with nested 'if'. (http://pihrt.net/roslynator/analyzer?id=RCS1061) [/home/runner/work/OpenRA/OpenRA/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj]` which was added in #21138.