### PR TITLE
Introduce Renderer.SwapWorldBuffer and Renderer.CloneWorldBuffer.

### DIFF
--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -46,7 +46,6 @@ namespace OpenRA.Graphics
 		readonly List<IRenderable> renderablesBuffer = new();
 		readonly IRenderer[] renderers;
 		readonly IRenderPostProcessPass[] postProcessPasses;
-		readonly ITexture postProcessTexture;
 
 		internal WorldRenderer(ModData modData, World world)
 		{
@@ -75,8 +74,6 @@ namespace OpenRA.Graphics
 			debugVis = Exts.Lazy(() => world.WorldActor.TraitOrDefault<DebugVisualizations>());
 
 			postProcessPasses = world.WorldActor.TraitsImplementing<IRenderPostProcessPass>().ToArray();
-			if (postProcessPasses.Length > 0)
-				postProcessTexture = Game.Renderer.Context.CreateTexture();
 		}
 
 		public void BeginFrame()
@@ -323,18 +320,13 @@ namespace OpenRA.Graphics
 
 		void ApplyPostProcessing(PostProcessPassType type)
 		{
-			var size = Game.Renderer.WorldFrameBufferSize;
-			var rect = new Rectangle(0, 0, size.Width, size.Height);
 			foreach (var pass in postProcessPasses)
 			{
 				if (pass.Type != type || !pass.Enabled)
 					continue;
 
-				// Make a copy of the world texture to avoid reading and writing on the same buffer
 				Game.Renderer.Flush();
-				postProcessTexture.SetDataFromReadBuffer(rect);
-				Game.Renderer.Flush();
-				pass.Draw(this, postProcessTexture);
+				pass.Draw(this);
 			}
 		}
 

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -47,6 +47,7 @@ namespace OpenRA
 		readonly IVertexBuffer<Vertex> tempVertexBuffer;
 		readonly IIndexBuffer quadIndexBuffer;
 		readonly Stack<Rectangle> scissorState = new();
+		readonly ITexture worldBufferSnapshot;
 
 		IFrameBuffer screenBuffer;
 		Sprite screenSprite;
@@ -59,6 +60,15 @@ namespace OpenRA
 
 		public Size WorldFrameBufferSize => worldSheet.Size;
 		public int WorldDownscaleFactor { get; private set; } = 1;
+
+		/// <summary>
+		/// Copies and returns the currently rendered world state as a temporary texture.
+		/// </summary>
+		public ITexture WorldBufferSnapshot()
+		{
+			worldBufferSnapshot.SetDataFromReadBuffer(new Rectangle(int2.Zero, worldSheet.Size));
+			return worldBufferSnapshot;
+		}
 
 		SheetBuilder fontSheetBuilder;
 		readonly IPlatform platform;
@@ -98,6 +108,7 @@ namespace OpenRA
 
 			tempVertexBuffer = Context.CreateVertexBuffer<Vertex>(TempVertexBufferSize);
 			quadIndexBuffer = Context.CreateIndexBuffer(Util.CreateQuadIndices(TempIndexBufferSize / 6));
+			worldBufferSnapshot = Context.CreateTexture();
 		}
 
 		static Size GetResolution(GraphicSettings graphicsSettings)
@@ -525,6 +536,7 @@ namespace OpenRA
 		{
 			worldBuffer.Dispose();
 			screenBuffer.Dispose();
+			worldBufferSnapshot.Dispose();
 			tempVertexBuffer.Dispose();
 			quadIndexBuffer.Dispose();
 			fontSheetBuilder?.Dispose();

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -523,6 +523,8 @@ namespace OpenRA
 
 		public void Dispose()
 		{
+			worldBuffer.Dispose();
+			screenBuffer.Dispose();
 			tempVertexBuffer.Dispose();
 			quadIndexBuffer.Dispose();
 			fontSheetBuilder?.Dispose();

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -467,7 +467,7 @@ namespace OpenRA.Traits
 	{
 		PostProcessPassType Type { get; }
 		bool Enabled { get; }
-		void Draw(WorldRenderer wr, ITexture worldTexture);
+		void Draw(WorldRenderer wr);
 	}
 
 	[Flags]

--- a/OpenRA.Mods.Cnc/Traits/World/ChronoVortexRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/ChronoVortexRenderer.cs
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		PostProcessPassType IRenderPostProcessPass.Type => PostProcessPassType.AfterWorld;
 		bool IRenderPostProcessPass.Enabled => vortices.Count > 0;
 
-		void IRenderPostProcessPass.Draw(WorldRenderer wr, ITexture worldTexture)
+		void IRenderPostProcessPass.Draw(WorldRenderer wr)
 		{
 			var scroll = wr.Viewport.TopLeft;
 			var size = renderer.WorldFrameBufferSize;
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			shader.SetVec("Scroll", scroll.X, scroll.Y);
 			shader.SetVec("p1", width, height);
 			shader.SetVec("p2", -1, -1);
-			shader.SetTexture("WorldTexture", worldTexture);
+			shader.SetTexture("WorldTexture", Game.Renderer.WorldBufferSnapshot());
 			shader.SetTexture("VortexTexture", vortexSheet.GetTexture());
 			shader.PrepareRender();
 			foreach (var (pos, frame) in vortices)

--- a/OpenRA.Mods.Common/Traits/World/RenderPostProcessPassBase.cs
+++ b/OpenRA.Mods.Common/Traits/World/RenderPostProcessPassBase.cs
@@ -42,9 +42,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		PostProcessPassType IRenderPostProcessPass.Type => type;
 		bool IRenderPostProcessPass.Enabled => Enabled;
-		void IRenderPostProcessPass.Draw(WorldRenderer wr, ITexture worldTexture)
+		void IRenderPostProcessPass.Draw(WorldRenderer wr)
 		{
-			shader.SetTexture("WorldTexture", worldTexture);
+			shader.SetTexture("WorldTexture", Game.Renderer.WorldBufferSnapshot());
 			PrepareRender(wr, shader);
 			shader.PrepareRender();
 			renderer.DrawBatch(buffer, shader, 0, 6, PrimitiveType.TriangleList);


### PR DESCRIPTION
The current post processing plumbing isn't suitable for in-world distortion effects (e.g. disruptor/sonic tank beams), which need to be able to access the already-rendered state at arbitrary points during rendering so that they can be occluded by foreground objects.

The main feature of this pr is the new `Renderer.CloneWorldBuffer` method, which serves that use case. ~~At the same time, we are able to avoid unnecessary texture copies in the common case of full-screen effects by implementing `Renderer.SwapWorldBuffer` which behaves similarly but destroys the current rendered state - not an issue when we're re-rendering all of the pixels anyway.~~

~~The first commit is necessary to work avoid the limitations of Sprite and Sheet not being able to change the texture that their texture coordinates refer to.~~