### PR TITLE
Add ExludeDamageTypes to HarvesterAttackNotifier

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
@@ -27,6 +27,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Length of time (in ticks) to display a location ping in the minimap.")]
 		public readonly int RadarPingDuration = 250;
 
+		[Desc("Exclude damage types (defined on the warheads) that trigger Notification.")]
+		public readonly BitSet<DamageType> ExludeDamageTypes = default;
+
 		[NotificationReference("Speech")]
 		[Desc("Speech notification type to play.")]
 		public readonly string Notification = "HarvesterAttack";
@@ -54,6 +57,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyDamage.Damaged(Actor self, AttackInfo e)
 		{
+			if (!info.ExludeDamageTypes.IsEmpty && e.Damage.DamageTypes.Overlaps(info.ExludeDamageTypes))
+				return;
+
 			// Don't track self-damage
 			if (e.Attacker != null && e.Attacker.Owner == self.Owner)
 				return;

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -133,6 +133,7 @@ Player:
 		Prerequisites: global-auto-concrete
 	FrozenActorLayer:
 	HarvesterAttackNotifier:
+		ExludeDamageTypes: SpiceExplosion
 		TextNotification: notification-harvester-under-attack
 	PlayerStatistics:
 	PlaceBeacon:

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -305,7 +305,7 @@ SpiceExplosion:
 			invulnerable: 0
 			cy: 20
 			harvester: 25
-		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+		DamageTypes: Prone50Percent, TriggerProne, SpiceExplosion
 		DamageCalculationType: ClosestTargetablePosition
 		AffectsParent: true
 	Warhead@2Res: CreateResource
@@ -333,7 +333,7 @@ BloomExplosion:
 			invulnerable: 0
 			cy: 20
 			harvester: 25
-		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath, SpiceExplosion
 		DamageCalculationType: ClosestTargetablePosition
 		AffectsParent: true
 


### PR DESCRIPTION
PR fix problem in d2k were SpiceBlooms and spiceExplosions always trigger false positive warnings.