### PR TITLE
Add navy orders, fixes to Soviet 06b

### DIFF
--- a/mods/ra/maps/soviet-06a/soviet06a.lua
+++ b/mods/ra/maps/soviet-06a/soviet06a.lua
@@ -140,7 +140,7 @@ WorldLoaded = function()
 	AlliedObjective = AddPrimaryObjective(Greece, "")
 	SovietObjective = AddPrimaryObjective(USSR, "escort-convoy")
 	SovietObjective2 = AddSecondaryObjective(USSR, "destroy-capture-radar-dome-reinforcements")
-	SaveAllTrucks = AddSecondaryObjective(USSR, "Keep all trucks alive.")
+	SaveAllTrucks = AddSecondaryObjective(USSR, "keep-trucks-alive")
 end
 
 Tick = function()

--- a/mods/ra/maps/soviet-06b/map.yaml
+++ b/mods/ra/maps/soviet-06b/map.yaml
@@ -288,94 +288,98 @@ Actors:
 		Location: 57,46
 		Owner: Greece
 		Facing: 640
+		TurretFacing: 768
 	Actor93: gun
 		Location: 61,48
 		Owner: Greece
 		Facing: 640
+		TurretFacing: 768
 	Actor103: 2tnk
 		Location: 76,30
 		Owner: Greece
-		Facing: 640
+		Facing: 384
 	Actor104: 2tnk
 		Location: 76,29
 		Owner: Greece
-		Facing: 640
+		Facing: 384
 	Actor106: arty
-		Location: 63,47
+		Location: 64,46
 		Owner: Greece
-		Facing: 640
+		Facing: 384
+		Stance: Defend
 	Actor107: arty
 		Location: 58,44
 		Owner: Greece
-		Facing: 640
+		Facing: 384
+		Stance: Defend
 	Actor110: 3tnk
 		Location: 43,63
 		Owner: USSR
-		Facing: 128
+		Facing: 896
 	Actor111: 3tnk
 		Location: 44,62
 		Owner: USSR
-		Facing: 128
+		Facing: 896
 	Actor112: v2rl
 		Location: 41,64
 		Owner: USSR
-		Facing: 128
+		Facing: 896
 	Actor113: v2rl
 		Location: 43,64
 		Owner: USSR
-		Facing: 128
+		Facing: 896
 	Actor115: 2tnk
 		Location: 75,30
 		Owner: Greece
-		Facing: 640
+		Facing: 384
 	Actor116: 2tnk
 		Location: 75,31
 		Owner: Greece
-		Facing: 640
+		Facing: 384
 	Actor117: 2tnk
-		Location: 83,20
+		Location: 83,19
 		Owner: Greece
-		Facing: 640
+		Facing: 384
 	Actor118: 2tnk
 		Location: 88,21
 		Owner: Greece
-		Facing: 640
+		Facing: 384
 	Actor119: 2tnk
 		Location: 62,44
 		Owner: Greece
-		Facing: 640
+		Facing: 384
 	Actor120: 1tnk
 		Location: 59,44
 		Owner: Greece
-		Facing: 640
+		Facing: 384
 	Actor121: 1tnk
 		Location: 63,46
 		Owner: Greece
-		Facing: 640
-	Actor123: ca
+		Facing: 384
+	BridgeBreaker: ca
 		Location: 87,29
 		Owner: Greece
-		Facing: 896
-	Actor124: ca
+		Facing: 128
+	BridgeBreaker2: ca
 		Location: 87,31
 		Owner: Greece
-		Facing: 640
-	Actor125: ca
+		Facing: 384
+	ResponseCruiser: ca
 		Location: 75,25
 		Owner: Greece
-		Facing: 896
+		Facing: 128
 	Actor126: pt
 		Location: 71,16
 		Owner: Greece
-		Facing: 896
+		Facing: 128
 	Actor127: pt
 		Location: 65,20
 		Owner: Greece
-		Facing: 896
+		Facing: 128
 	Actor128: dd
 		Location: 70,20
 		Owner: Greece
-		Facing: 896
+		Facing: 128
 	Actor129: waypoint
 		Location: 46,60
 		Owner: Neutral
@@ -437,7 +441,7 @@ Actors:
 	AttackWaypoint2: waypoint
 		Owner: Neutral
 		Location: 41,55
-	Barr: tent
+	Tent: tent
 		Location: 67,45
 		Owner: Greece
 	CameraStart: camera
@@ -470,20 +474,20 @@ Actors:
 	IntroEnemy1: 1tnk
 		Location: 55,49
 		Owner: Greece
-		Facing: 640
+		Facing: 384
 	IntroEnemy2: 2tnk
 		Location: 56,50
 		Owner: Greece
-		Facing: 640
+		Facing: 384
 	IntroEnemy3: 1tnk
 		Location: 58,50
 		Owner: Greece
-		Facing: 640
+		Facing: 384
 	Mcv: mcv
 		Location: 51,55
 		Owner: USSR
 		Health: 82
-		Facing: 640
+		Facing: 384
 	McvWaypoint: waypoint
 		Location: 39,67
 		Owner: Neutral
@@ -494,11 +498,11 @@ Actors:
 	Truck1: truk
 		Location: 42,66
 		Owner: USSR
-		Facing: 128
+		Facing: 896
 	Truck2: truk
 		Location: 39,65
 		Owner: USSR
-		Facing: 128
+		Facing: 896
 	Weap: weap
 		Location: 67,41
 		Owner: Greece

--- a/mods/ra/maps/soviet-06b/soviet06b-AI.lua
+++ b/mods/ra/maps/soviet-06b/soviet06b-AI.lua
@@ -6,29 +6,117 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
-IdlingUnits = function()
-	local lazyUnits = Greece.GetGroundAttackers()
+InfAttack = { }
+ArmorAttack = { }
+AttackPaths = { { AttackWaypoint1.Location }, { AttackWaypoint2.Location } }
 
-	Utils.Do(lazyUnits, function(unit)
-		Trigger.OnDamaged(unit, function()
-			Trigger.ClearAll(unit)
-			Trigger.AfterDelay(0, function() IdleHunt(unit) end)
-		end)
+AlliedInfantryTypes = { "e1", "e1", "e3" }
+AlliedArmorTypes = { "jeep", "jeep", "1tnk", "1tnk", "2tnk", "2tnk", "arty" }
+
+ProduceInfantry = function(barracks)
+	if barracks.IsDead or barracks.Owner ~= Greece then
+		return
+	elseif GreeceMoney() <= 299 and IsHarvesterMissing() then
+		return
+	end
+
+	local delay = Utils.RandomInteger(DateTime.Seconds(3), DateTime.Seconds(9))
+	local toBuild = { Utils.Random(AlliedInfantryTypes) }
+	local path = Utils.Random(AttackPaths)
+	Greece.Build(toBuild, function(unit)
+		InfAttack[#InfAttack + 1] = unit[1]
+
+		if #InfAttack >= 10 then
+			SendUnits(InfAttack, path)
+			InfAttack = { }
+			Trigger.AfterDelay(DateTime.Minutes(2), function()
+				ProduceInfantry(barracks)
+			end)
+		else
+			Trigger.AfterDelay(delay, function()
+				ProduceInfantry(barracks)
+			end)
+		end
 	end)
 end
 
-BaseApwr =  { type = "apwr", pos = CVec.New(5, -9), cost = 500, exists = true }
-BaseTent =  { type = "tent", pos = CVec.New(-4, -4), cost = 400, exists = true }
-BaseProc =  { type = "proc", pos = CVec.New(0, -8), cost = 1400, exists = true }
-BaseWeap =  { type = "weap", pos = CVec.New(-4, -8), cost = 2000, exists = true }
-BaseApwr2 = { type = "apwr", pos = CVec.New(6, -5), cost = 500, exists = true }
+ProduceArmor = function(factory)
+	if factory.IsDead or factory.Owner ~= Greece then
+		return
+	elseif IsHarvesterMissing() then
+		ProduceHarvester(factory)
+		return
+	end
 
-BaseBuildings = { BaseApwr, BaseTent, BaseProc, BaseWeap, BaseApwr2 }
+	local delay = Utils.RandomInteger(DateTime.Seconds(12), DateTime.Seconds(17))
+	local toBuild = { Utils.Random(AlliedArmorTypes) }
+	local path = Utils.Random(AttackPaths)
+	Greece.Build(toBuild, function(unit)
+		ArmorAttack[#ArmorAttack + 1] = unit[1]
 
+		if #ArmorAttack >= 6 then
+			SendUnits(ArmorAttack, path)
+			ArmorAttack = { }
+			Trigger.AfterDelay(DateTime.Minutes(3), function()
+				ProduceArmor(factory)
+			end)
+		else
+			Trigger.AfterDelay(delay, function()
+				ProduceArmor(factory)
+			end)
+		end
+	end)
+end
+
+ProduceHarvester = function(factory)
+	if GreeceMoney() < Actor.Cost("harv") then
+		return
+	end
+
+	local toBuild = { "harv" }
+	Greece.Build(toBuild, function(unit)
+		unit.FindResources()
+		ProduceArmor(factory)
+	end)
+end
+
+SendUnits = function(units, path)
+	Utils.Do(units, function(unit)
+		if unit.IsDead then
+			return
+		end
+
+		unit.Patrol(path, false)
+		IdleHunt(unit)
+	end)
+end
+
+IsHarvesterMissing = function()
+	return #Greece.GetActorsByType("harv") == 0
+end
+
+GreeceMoney = function()
+	return Greece.Cash + Greece.Resources
+end
+
+BaseBlueprints =
+{
+	{ type = "apwr", actor = Apwr, cost = 500, shape = { 3, 3 }, location = CPos.New(76, 41) },
+	{ type = "tent", actor = Tent, cost = 400, shape = { 2, 3 }, location = CPos.New(67, 45), onBuilt = ProduceInfantry },
+	{ type = "proc", actor = Proc, cost = 1400, shape = { 3, 4 }, location = CPos.New(71, 41) },
+	{ type = "weap", actor = Weap, cost = 2000, shape = { 3, 3 }, location = CPos.New(67, 41), onBuilt = ProduceArmor },
+	{ type = "apwr", actor = Apwr2, cost = 500, shape = { 3, 3 }, location = CPos.New(77, 45) }
+}
+
+--[[
+	Similar to the original CnC/RA [BASE] and [STRUCTURES] .INI sections.
+	Check a list every so often and (re)build structures missing from
+	that list, in order, if circumstances allow for it.
+]]
 BuildBase = function()
-	for i,v in ipairs(BaseBuildings) do
-		if not v.exists then
-			BuildBuilding(v)
+	for _, blueprint in pairs(BaseBlueprints) do
+		if not blueprint.actor then
+			BuildBlueprint(blueprint)
 			return
 		end
 	end
@@ -36,82 +124,103 @@ BuildBase = function()
 	Trigger.AfterDelay(DateTime.Seconds(10), BuildBase)
 end
 
-BuildBuilding = function(building)
-	Trigger.AfterDelay(Actor.BuildTime(building.type), function()
+BuildBlueprint = function(blueprint)
+	Trigger.AfterDelay(Actor.BuildTime(blueprint.type), function()
 		if CYard.IsDead or CYard.Owner ~= Greece then
 			return
-		elseif Harvester.IsDead and Greece.Resources <= 299 then
+		elseif GreeceMoney() <= 299 and IsHarvesterMissing() then
 			return
 		end
 
-		local actor = Actor.Create(building.type, true, { Owner = Greece, Location = CYardLocation.Location + building.pos })
-		Greece.Cash = Greece.Cash - building.cost
+		if IsBuildAreaBlocked(Greece, blueprint) then
+			Trigger.AfterDelay(DateTime.Seconds(5), function()
+				BuildBlueprint(blueprint)
+			end)
+			return
+		end
 
-		building.exists = true
-		Trigger.OnKilled(actor, function() building.exists = false end)
-		Trigger.OnDamaged(actor, function(building)
-			if building.Owner == Greece and building.Health < building.MaxHealth * 3/4 then
-				building.StartBuildingRepairs()
-			end
-		end)
+		local actor = Actor.Create(blueprint.type, true, { Owner = Greece, Location = blueprint.location })
+		OnBlueprintBuilt(actor, blueprint)
 
 		Trigger.AfterDelay(DateTime.Seconds(10), BuildBase)
 	end)
 end
 
-ProduceInfantry = function()
-	if not BaseTent.exists then
-		return
-	elseif Harvester.IsDead and Greece.Resources <= 299 then
-		return
+OnBlueprintBuilt = function(actor, blueprint)
+	Greece.Cash = Greece.Cash - blueprint.cost
+	blueprint.actor = actor
+	MaintainBuilding(actor, blueprint, 0.75)
+
+	if blueprint.onBuilt then
+		-- Build() will not work properly on producers if immediately called.
+		Trigger.AfterDelay(1, function()
+			blueprint.onBuilt(actor)
+		end)
+	end
+end
+
+IsBuildAreaBlocked = function(player, blueprint)
+	local nw, se = blueprint.northwestEdge, blueprint.southeastEdge
+	local blockers = Map.ActorsInBox(nw, se, function(actor)
+		-- Neutral check is for ignoring trees near the refinery.
+		return actor.Owner ~= Neutral and actor.CenterPosition.Z == 0 and actor.HasProperty("Health")
+	end)
+
+	if #blockers == 0 then
+		return false
 	end
 
-	local delay = Utils.RandomInteger(DateTime.Seconds(3), DateTime.Seconds(9))
-	local toBuild = { Utils.Random(AlliedInfantryTypes) }
-	local Path = Utils.Random(AttackPaths)
-	Greece.Build(toBuild, function(unit)
-		InfAttack[#InfAttack + 1] = unit[1]
+	ScatterBlockers(player, blockers)
+	return true
+end
 
-		if #InfAttack >= 10 then
-			SendUnits(InfAttack, Path)
-			InfAttack = { }
-			Trigger.AfterDelay(DateTime.Minutes(2), ProduceInfantry)
-		else
-			Trigger.AfterDelay(delay, ProduceInfantry)
+ScatterBlockers = function(player, actors)
+	Utils.Do(actors, function(actor)
+		if actor.IsIdle and actor.Owner == player and actor.HasProperty("Scatter") then
+			actor.Scatter()
 		end
 	end)
 end
 
-ProduceArmor = function()
-	if not BaseWeap.exists then
-		return
-	elseif Harvester.IsDead and Greece.Resources <= 599 then
-		return
-	end
+BeginBaseMaintenance = function()
+	Utils.Do(BaseBlueprints, function(blueprint)
+		MaintainBuilding(blueprint.actor, blueprint)
+	end)
 
-	local delay = Utils.RandomInteger(DateTime.Seconds(12), DateTime.Seconds(17))
-	local toBuild = { Utils.Random(AlliedArmorTypes) }
-	local Path = Utils.Random(AttackPaths)
-	Greece.Build(toBuild, function(unit)
-		ArmorAttack[#ArmorAttack + 1] = unit[1]
-
-		if #ArmorAttack >= 6 then
-			SendUnits(ArmorAttack, Path)
-			ArmorAttack = { }
-			Trigger.AfterDelay(DateTime.Minutes(3), ProduceArmor)
-		else
-			Trigger.AfterDelay(delay, ProduceArmor)
+	Utils.Do(Greece.GetActors(), function(actor)
+		if actor.HasProperty("StartBuildingRepairs") then
+			MaintainBuilding(actor, nil, 0.75)
 		end
 	end)
 end
 
-SendUnits = function(units, waypoints)
-	Utils.Do(units, function(unit)
-		if not unit.IsDead then
-			Utils.Do(waypoints, function(waypoint)
-				unit.AttackMove(waypoint.Location)
-			end)
-			IdleHunt(unit)
+MaintainBuilding = function(actor, blueprint, repairThreshold)
+	if blueprint then
+		Trigger.OnKilled(actor, function() blueprint.actor = nil end)
+		Trigger.OnSold(actor, function() blueprint.actor = nil end)
+		if not blueprint.northwestEdge then
+			PrepareBlueprintEdges(blueprint)
 		end
-	end)
+	end
+
+	if repairThreshold then
+		local original = actor.Owner
+
+		Trigger.OnDamaged(actor, function()
+			if actor.Owner ~= original or actor.Health > actor.MaxHealth * repairThreshold then
+				return
+			end
+
+			actor.StartBuildingRepairs()
+		end)
+	end
+end
+
+PrepareBlueprintEdges = function(blueprint)
+	local shapeX, shapeY = blueprint.shape[1], blueprint.shape[2]
+	local northwestEdge = Map.CenterOfCell(blueprint.location) + WVec.New(-512, -512, 0)
+	local southeastEdge = northwestEdge + WVec.New(shapeX * 1024, shapeY * 1024, 0)
+
+	blueprint.northwestEdge = northwestEdge
+	blueprint.southeastEdge = southeastEdge
 end

--- a/mods/ra/maps/soviet-06b/soviet06b-reinforcements_teams.lua
+++ b/mods/ra/maps/soviet-06b/soviet06b-reinforcements_teams.lua
@@ -44,8 +44,11 @@ EnemyPaths =
 }
 
 Wave = 0
-SendEnemies = function()
+SendReinforcements = function()
 	Trigger.AfterDelay(EnemyAttackDelay[Difficulty], function()
+		if Dome.IsDead or Dome.Owner ~= Greece then
+			return
+		end
 
 		Wave = Wave + 1
 		if Wave > 3 then
@@ -60,8 +63,6 @@ SendEnemies = function()
 			Utils.Do(units, IdleHunt)
 		end
 
-		if not Dome.IsDead then
-			SendEnemies()
-		end
+		SendReinforcements()
 	end)
 end

--- a/mods/ra/maps/soviet-06b/soviet06b.lua
+++ b/mods/ra/maps/soviet-06b/soviet06b.lua
@@ -6,110 +6,211 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
-IntroAttackers = { IntroEnemy1, IntroEnemy2, IntroEnemy3 }
-Trucks = { Truck1, Truck2 }
-InfAttack = { }
-ArmorAttack = { }
-AttackPaths = { { AttackWaypoint1 }, { AttackWaypoint2 } }
 
-AlliedInfantryTypes = { "e1", "e1", "e3" }
-AlliedArmorTypes = { "jeep", "jeep", "1tnk", "1tnk", "2tnk", "2tnk", "arty" }
-
-SovietReinforcements1 = { "e6", "e6", "e6", "e6", "e6" }
-SovietReinforcements2 = { "e4", "e4", "e2", "e2", "e2" }
-SovietReinforcements1Waypoints = { McvWaypoint.Location, APCWaypoint1.Location }
-SovietReinforcements2Waypoints = { McvWaypoint.Location, APCWaypoint2.Location }
-
-TruckGoalTrigger = { CPos.New(85, 10), CPos.New(85, 11), CPos.New(85, 12), CPos.New(86, 13), CPos.New(87, 13), CPos.New(88, 13), CPos.New(88, 14), CPos.New(89, 14), CPos.New(90, 14), CPos.New(90, 15), CPos.New(91, 15), CPos.New(91, 16), CPos.New(91, 17), CPos.New(92, 17), CPos.New(93, 17), CPos.New(94, 17), CPos.New(94, 18), CPos.New(95, 18), CPos.New(96, 18), CPos.New(96, 19), CPos.New(97, 19), CPos.New(98, 19)}
-
-Trigger.OnEnteredFootprint(TruckGoalTrigger, function(a, id)
-	if not TruckGoalTriggered and a.Owner == USSR and a.Type == "truk" then
-		TruckGoalTriggered = true
-		USSR.MarkCompletedObjective(SovietObjective)
-		USSR.MarkCompletedObjective(SaveAllTrucks)
+Trigger.OnRemovedFromWorld(Mcv, function()
+	if McvDeployed or Mcv.IsDead then
+		return
 	end
-end)
 
-Trigger.OnAllKilled(Trucks, function()
-	Greece.MarkCompletedObjective(AlliedObjective)
-end)
+	McvDeployed = true
+	BuildBase()
+	SendReinforcements()
 
-Trigger.OnAnyKilled(Trucks, function()
-	USSR.MarkFailedObjective(SaveAllTrucks)
-end)
+	Trigger.AfterDelay(DateTime.Minutes(1), function()
+		ProduceInfantry(Tent)
+	end)
 
-Trigger.OnKilled(Apwr, function()
-	BaseApwr.exists = false
-end)
-
-Trigger.OnKilled(Barr, function()
-	BaseTent.exists = false
-end)
-
-Trigger.OnKilled(Proc, function()
-	BaseProc.exists = false
-end)
-
-Trigger.OnKilled(Weap, function()
-	BaseWeap.exists = false
-end)
-
-Trigger.OnKilled(Apwr2, function()
-	BaseApwr2.exists = false
-end)
-
-Trigger.OnKilledOrCaptured(Dome, function()
-	Trigger.AfterDelay(DateTime.Seconds(2), function()
-		USSR.MarkCompletedObjective(SovietObjective2)
-		Media.PlaySpeechNotification(USSR, "ObjectiveMet")
+	Trigger.AfterDelay(DateTime.Minutes(2), function()
+		ProduceArmor(Weap)
 	end)
 end)
 
-Trigger.OnRemovedFromWorld(Mcv, function()
-	if not McvDeployed then
-		McvDeployed = true
-		BuildBase()
-		SendEnemies()
-		Trigger.AfterDelay(DateTime.Minutes(1), ProduceInfantry)
-		Trigger.AfterDelay(DateTime.Minutes(2), ProduceArmor)
+PrepareResponseCruiser = function()
+	local responseBuildings = { Apwr, Tent, Weap }
+	local responseOrdered = false
+
+	Utils.Do(responseBuildings, function(building)
+		Trigger.OnDamaged(building, function()
+			if responseOrdered or USSR.IsObjectiveCompleted(DisruptDome) then
+				return
+			end
+
+			responseOrdered = true
+			OrderResponseCruiser()
+		end)
+	end)
+end
+
+OrderResponseCruiser = function()
+	if ResponseCruiser.IsDead then
+		return
 	end
-end)
+
+	ResponseCruiser.AttackMove(waypoint94.Location, 2)
+	ResponseCruiser.Wait(DateTime.Seconds(90))
+
+	Trigger.OnIdle(ResponseCruiser, function()
+		ResponseCruiser.AttackMove(waypoint69.Location, 2)
+	end)
+
+	Trigger.OnDamaged(ResponseCruiser, function(_, attacker)
+		if attacker.IsDead or not ResponseCruiser.CanTarget(attacker) then
+			return
+		end
+
+		ResponseCruiser.Attack(attacker)
+		ResponseCruiser.Scatter()
+	end)
+end
+
+PrepareBridgeBreakers = function()
+	local target = Map.ActorsInCircle(waypoint78.CenterPosition, WDist.New(1536), function(actor)
+		return actor.Type == "br3"
+	end)[1]
+
+	if not target then
+		Media.Debug("No bridge segment found.")
+		return
+	end
+
+	local orderSent = false
+	Trigger.AfterDelay(DateTime.Seconds(30), function()
+		orderSent = true
+		OrderBridgeBreakers(target)
+	end)
+
+	local bridgeEntryCells = { CPos.New(75, 30), CPos.New(76, 30), CPos.New(77, 30) }
+	Trigger.OnEnteredFootprint(bridgeEntryCells, function(a, id)
+		if a.Owner ~= USSR then
+			return
+		end
+
+		Trigger.RemoveFootprintTrigger(id)
+
+		if not orderSent then
+			OrderBridgeBreakers(target, "with bridge reveal")
+		end
+	end)
+end
+
+OrderBridgeBreakers = function(target, reveal)
+	if target.IsDead then
+		return
+	end
+
+	local breakers = { BridgeBreaker, BridgeBreaker2 }
+	Utils.Do(breakers, function(breaker)
+		if breaker.IsDead then
+			return
+		end
+
+		breaker.Stop()
+		breaker.Attack(target, true, true)
+	end)
+
+	if not reveal then
+		return
+	end
+
+	local camera = Actor.Create("camera", true, { Owner = USSR, Location = target.Location })
+	Trigger.OnKilled(target, function()
+		Trigger.AfterDelay(DateTime.Seconds(2), camera.Destroy)
+	end)
+end
+
+PrepareObjectives = function()
+	InitObjectives(USSR)
+	KillTrucks = AddPrimaryObjective(Greece, "")
+	EscortConvoy = AddPrimaryObjective(USSR, "escort-convoy")
+	DisruptDome = AddSecondaryObjective(USSR, "destroy-capture-radar-dome-reinforcements")
+	SaveAllTrucks = AddSecondaryObjective(USSR, "keep-trucks-alive")
+
+	Trigger.OnKilledOrCaptured(Dome, function()
+		-- Let the capture notification play first.
+		Trigger.AfterDelay(DateTime.Seconds(2), function()
+			USSR.MarkCompletedObjective(DisruptDome)
+			Media.PlaySpeechNotification(USSR, "ObjectiveMet")
+		end)
+	end)
+end
+
+PrepareTrucks = function()
+	local trucks = { Truck1, Truck2 }
+	local goalCells = { CPos.New(85, 10), CPos.New(85, 11), CPos.New(85, 12), CPos.New(86, 13), CPos.New(87, 13), CPos.New(88, 13), CPos.New(88, 14), CPos.New(89, 14), CPos.New(90, 14), CPos.New(90, 15), CPos.New(91, 15), CPos.New(91, 16), CPos.New(91, 17), CPos.New(92, 17), CPos.New(93, 17), CPos.New(94, 17), CPos.New(94, 18), CPos.New(95, 18), CPos.New(96, 18), CPos.New(96, 19), CPos.New(97, 19), CPos.New(98, 19)}
+
+	local goalTriggered = false
+	Trigger.OnEnteredFootprint(goalCells, function(a)
+		if not goalTriggered and a.Owner == USSR and a.Type == "truk" then
+			goalTriggered = true
+			USSR.MarkCompletedObjective(EscortConvoy)
+			USSR.MarkCompletedObjective(SaveAllTrucks)
+		end
+	end)
+
+	Trigger.OnAllKilled(trucks, function()
+		Greece.MarkCompletedObjective(KillTrucks)
+	end)
+
+	Trigger.OnAnyKilled(trucks, function()
+		USSR.MarkFailedObjective(SaveAllTrucks)
+	end)
+end
+
+BeginIntro = function()
+	local introAttackers = { IntroEnemy1, IntroEnemy2, IntroEnemy3 }
+	local sovietReinforcements1 = { "e6", "e6", "e6", "e6", "e6" }
+	local sovietReinforcements2 = { "e4", "e4", "e2", "e2", "e2" }
+	local sovietReinforcements1Path = { McvWaypoint.Location, APCWaypoint1.Location }
+	local sovietReinforcements2Path = { McvWaypoint.Location, APCWaypoint2.Location }
+
+	Mcv.Move(McvWaypoint.Location)
+	Utils.Do(introAttackers, IdleHunt)
+	Reinforcements.ReinforceWithTransport(USSR, "apc", sovietReinforcements1, sovietReinforcements1Path)
+	Reinforcements.ReinforceWithTransport(USSR, "apc", sovietReinforcements2, sovietReinforcements2Path)
+end
+
+PrepareIdleGuards = function()
+	local lazyUnits = Utils.Where(Greece.GetGroundAttackers(), function(unit)
+		return unit.Type ~= "ca" and unit.Type ~= "arty"
+	end)
+
+	Utils.Do(lazyUnits, function(unit)
+		local triggered = false
+
+		Trigger.OnDamaged(unit, function()
+			if triggered then
+				return
+			end
+
+			triggered = true
+			IdleHunt(unit)
+		end)
+	end)
+end
 
 WorldLoaded = function()
 	USSR = Player.GetPlayer("USSR")
 	Greece = Player.GetPlayer("Greece")
+	Neutral = Player.GetPlayer("Neutral")
 
+	PrepareObjectives()
 	Camera.Position = CameraStart.CenterPosition
-
-	Mcv.Move(McvWaypoint.Location)
 	Harvester.FindResources()
-	Utils.Do(IntroAttackers, function(actor)
-		IdleHunt(actor)
-	end)
+	BeginBaseMaintenance()
 
-	Reinforcements.ReinforceWithTransport(USSR, "apc", SovietReinforcements1, SovietReinforcements1Waypoints)
-	Reinforcements.ReinforceWithTransport(USSR, "apc", SovietReinforcements2, SovietReinforcements2Waypoints)
+	if Difficulty ~= "easy" then
+		PrepareResponseCruiser()
+		Trigger.AfterDelay(1, PrepareBridgeBreakers)
+	end
 
-	Utils.Do(Map.NamedActors, function(actor)
-		if actor.Owner == Greece and actor.HasProperty("StartBuildingRepairs") then
-			Trigger.OnDamaged(actor, function(building)
-				if building.Owner == Greece and building.Health < 3/4 * building.MaxHealth then
-					building.StartBuildingRepairs()
-				end
-			end)
-		end
-	end)
-
-	InitObjectives(USSR)
-	AlliedObjective = AddPrimaryObjective(Greece, "")
-	SovietObjective = AddPrimaryObjective(USSR, "escort-convoy")
-	SovietObjective2 = AddSecondaryObjective(USSR, "destroy-capture-radar-dome-reinforcements")
-	SaveAllTrucks = AddSecondaryObjective(USSR, "Keep all trucks alive.")
+	PrepareTrucks()
+	BeginIntro()
+	PrepareIdleGuards()
 end
 
 Tick = function()
 	if USSR.HasNoRequiredUnits() then
-		Greece.MarkCompletedObjective(AlliedObjective)
+		Greece.MarkCompletedObjective(KillTrucks)
 	end
 
 	if Greece.Resources >= Greece.ResourceCapacity * 0.75 then
@@ -117,3 +218,4 @@ Tick = function()
 		Greece.Resources = Greece.ResourceCapacity * 0.25
 	end
 end
+


### PR DESCRIPTION
This changes Over the Bridge VizchGoi to add missing events, tweak how base rebuilds work, fix some oddities, and hopefully make the script a bit more straightforward to read.

----

The Allied navy has some "new" behavior that was in the original mission.

When the bridge is approached **or** 30 seconds pass, two Cruisers will shell part of the bridge until it breaks.
  - If approached first, there is also a camera reveal.
  - The bridge shelling is skipped on Easy difficulty.

https://github.com/OpenRA/OpenRA/assets/4985264/846a07dd-e9da-44f5-9641-2abfc6294192

![Bridge_Triggers](https://github.com/OpenRA/OpenRA/assets/4985264/2efb7d5c-5eb7-4bda-bf35-09b47adebe2b)

If certain Allied buildings are attacked before the Radar Dome is captured or destroyed, a Cruiser moves toward the Soviet base to retaliate.
- This response is skipped on Easy difficulty.
- For better or worse, this is less effective without the original's obvious vision cheating.

![RSPD_Triggers](https://github.com/OpenRA/OpenRA/assets/4985264/6028719d-07c3-4d3f-812f-65b8d9d8ad9c)

----

The truck objective text correctly uses its translation.
- A fix for the same issue in Soviet 06a is included.

The Radar Dome's capture correctly stops Allied reinforcements.
- The Radar Dome is also checked before a wave is sent, rather than before the next wave is scheduled.

The Allies' rebuild logic has gone through some changes.
- When building, the area is first checked for obstructions.
  - If not clear, another attempt is scheduled.
  - If the obstruction is an idle Allied unit, they will be scattered.
- Buildings that are captured and sold can now be rebuilt (as a step toward https://github.com/OpenRA/OpenRA/issues/15356).
- ProduceArmor/ProduceInfantry restart when the War Factory/Allied Barracks is rebuilt.
  - Similar to https://github.com/OpenRA/OpenRA/issues/10617, whether the rebuilt structure will actually build units is down to luck at the moment. If the structure died in the middle of a Build, you can expect that queue to stay frozen.
- The rebuilding information and the rebuildable structure list are merged as a list of "blueprints".
  - Each blueprint location is now a plain CPos instead of a CVec added to a waypoint's CPos.

The Allies' unit production is slightly changed.
- ProduceArmor/ProduceInfantry is halted by a captured War Factory/Allied Barracks, instead of only a destroyed one.
- If the Allies' harvester dies, a replacement can be built.

Some unit facings that were mismatched from the original are fixed. This may be most noticeable on the main stretch of road where, on bleed, everything is pointed off to the side.

![Facings](https://github.com/OpenRA/OpenRA/assets/4985264/a2f34d77-db93-4540-89be-4b56bbdf35f6)

A tank and Artillery are nudged so they don't start on impassable terrain.

The Allies' starting artillery use Defend stance to mimic their original "sticky" orders.

The pre-placed "lazy" Allied units will start hunting when damaged. This seemed intended but the function for this was never called. Cruisers and artillery are skipped by this.