### PR TITLE
Change bombers, remove Hard from Evacuation

### DIFF
--- a/mods/ra/languages/lua/en.ftl
+++ b/mods/ra/languages/lua/en.ftl
@@ -126,7 +126,7 @@ keep-einstein-alive-at-all-costs = Keep Einstein alive at all costs.
 find-einstein-crashed-helicopter = Find Einstein's crashed helicopter.
 destroy-sam-sites = Destroy the SAM sites.
 hold-position-protect-base = Hold your position and protect the base.
-keep-civilians-alive = Do not lose more than { $units } units.
+do-not-lose-more-than = Do not lose more than { $units } units.
 take-out-the-soviet-power-grid = Take out the Soviet power grid.
 
 ## exodus

--- a/mods/ra/maps/evacuation/evacuation.lua
+++ b/mods/ra/maps/evacuation/evacuation.lua
@@ -107,8 +107,7 @@ end
 
 SendParabombs = function()
 	local proxy = Actor.Create("powerproxy.parabombs", false, { Owner = Soviets })
-	proxy.TargetAirstrike(ParabombPoint1.CenterPosition, (BadgerEntryPoint2.CenterPosition - ParabombPoint1.CenterPosition).Facing)
-	proxy.TargetAirstrike(ParabombPoint2.CenterPosition, (Map.CenterOfCell(BadgerEntryPoint2.Location + CVec.New(0, 3)) - ParabombPoint2.CenterPosition).Facing)
+	proxy.TargetAirstrike(ParabombPoint1.CenterPosition, (ParabombPoint1.CenterPosition - BadgerEntryPoint2.CenterPosition).Facing)
 	proxy.Destroy()
 end
 
@@ -296,7 +295,7 @@ SpawnTanya = function()
 
 	if Difficulty ~= "easy" and Allies1.IsLocalPlayer then
 		Trigger.AfterDelay(DateTime.Seconds(2), function()
-			Media.DisplayMessage(UserInterface.Translate("tanya-rules-of-engagement"), UserInterface.Translate("tanya"))
+			Media.DisplayMessageToPlayer(Allies1, UserInterface.Translate("tanya-rules-of-engagement"), UserInterface.Translate("tanya"))
 		end)
 	end
 end
@@ -348,7 +347,7 @@ WorldLoaded = function()
 	DestroySamSitesObjective = AddPrimaryObjective(Allies1, "destroy-sam-sites")
 
 	HoldPositionObjective = AddPrimaryObjective(Allies2, "hold-position-protect-base")
-	local dontLoseMoreThan = UserInterface.Translate("keep-civilians-alive", { ["units"] = DeathThreshold[Difficulty] })
+	local dontLoseMoreThan = UserInterface.Translate("do-not-lose-more-than", { ["units"] = DeathThreshold[Difficulty] })
 	LimitLossesObjective = AddSecondaryObjective(Allies2, dontLoseMoreThan)
 	CutSovietPowerObjective = AddSecondaryObjective(Allies2, "take-out-the-soviet-power-grid")
 

--- a/mods/ra/maps/evacuation/map.yaml
+++ b/mods/ra/maps/evacuation/map.yaml
@@ -1600,7 +1600,7 @@ Actors:
 		Location: 26,100
 		Owner: Neutral
 	ParabombPoint1: waypoint
-		Location: 39,105
+		Location: 42,106
 		Owner: Neutral
 	ParabombPoint2: waypoint
 		Location: 39,108

--- a/mods/ra/maps/evacuation/rules.yaml
+++ b/mods/ra/maps/evacuation/rules.yaml
@@ -16,7 +16,6 @@ World:
 		Values:
 			easy: options-difficulty.easy
 			normal: options-difficulty.normal
-			hard: options-difficulty.hard
 		Default: normal
 	TimeLimitManager:
 		TimeLimitLocked: True


### PR DESCRIPTION
On bleed, Soviet bombers will destroy both of the Allies' power plants and put unintended pressure on that player.

https://github.com/OpenRA/OpenRA/assets/4985264/9c8695ee-ed0b-464a-abf7-06e0db21e285

The bomber damage used to be enough to knock out power while leaving the plants intact (https://youtu.be/pw-c71Tzt1M?t=28). One bomber is now removed and the other's target waypoint is moved to roughly match the previous damage.

https://github.com/OpenRA/OpenRA/assets/4985264/ea5ca5e9-a9a5-49a0-9f70-19581e3c3904

The bomber will now come from `BadgerEntryPoint2` to the east, as in the original script: https://github.com/OpenRA/OpenRA/blob/be56f1ebeb891b777b72018180f7fce8945f85c6/OpenRA.Mods.RA/Missions/Allies02Script.cs#L163-L167

This isn't the case on bleed because the bombers' facing math is inverted (start position - target position) when compared to the paratrooper planes (target position - start position).

----

The Hard difficulty is removed. The map script doesn't use it and its selection will cause a crash.
- There are some other maps with an unused (but harmless) Hard difficulty. I know of `allies-03a`, `allies-03b`, and `production-disruption`. There's also `funpark01` from Tiberian Dawn.

Changed the "Do not lose more than X units" objective text's label from "keep-civilians-alive" to "do-not-lose-more-than".
- I'd guess this got mixed up with TD's "keep-civilians-alive" label for `gdi08b`.

Tanya now announces her rules only to her commander, to match how objectives and notifications are already split between the two human players.