### PR TITLE
Fix D2k objectives, alerts in Ha2, Or4, At5

### DIFF
--- a/mods/d2k/maps/atreides-05/atreides05.lua
+++ b/mods/d2k/maps/atreides-05/atreides05.lua
@@ -251,7 +251,7 @@ Tick = function()
 	end
 
 	if LastHarkonnenArrived and not Atreides.IsObjectiveCompleted(KillHarkonnen) and Harkonnen.HasNoRequiredUnits() then
-		Media.DisplayMessage(UserInterface.Translate("atreides-05"), Mentat)
+		Media.DisplayMessage(UserInterface.Translate("harkonnen-annihilated"), Mentat)
 		Atreides.MarkCompletedObjective(KillHarkonnen)
 	end
 
@@ -330,8 +330,8 @@ WorldLoaded = function()
 			Atreides.MarkFailedObjective(DefendStarport)
 		end
 	end)
-	Trigger.OnDamaged(Starport, function()
-		if Starport.Owner ~= Smuggler then
+	Trigger.OnDamaged(Starport, function(_, attacker)
+		if Starport.Owner ~= Smuggler or attacker.IsDead or attacker.Owner ~= Atreides then
 			return
 		end
 

--- a/mods/d2k/maps/harkonnen-02a/harkonnen02a.lua
+++ b/mods/d2k/maps/harkonnen-02a/harkonnen02a.lua
@@ -81,7 +81,7 @@ WorldLoaded = function()
 
 	InitObjectives(Harkonnen)
 	KillHarkonnen = AddPrimaryObjective(Atreides, "")
-	KillAtreides = AddSecondaryObjective(Harkonnen, "destroy-atreides-forces")
+	KillAtreides = AddPrimaryObjective(Harkonnen, "destroy-atreides-forces")
 
 	Camera.Position = HConyard.CenterPosition
 

--- a/mods/d2k/maps/harkonnen-02b/harkonnen02b.lua
+++ b/mods/d2k/maps/harkonnen-02b/harkonnen02b.lua
@@ -81,7 +81,7 @@ WorldLoaded = function()
 
 	InitObjectives(Harkonnen)
 	KillHarkonnen = AddPrimaryObjective(Atreides, "")
-	KillAtreides = AddSecondaryObjective(Harkonnen, "destroy-atreides-forces")
+	KillAtreides = AddPrimaryObjective(Harkonnen, "destroy-atreides-forces")
 
 	Camera.Position = HConyard.CenterPosition
 

--- a/mods/d2k/maps/ordos-04/map.yaml
+++ b/mods/d2k/maps/ordos-04/map.yaml
@@ -318,16 +318,16 @@ Actors:
 	Actor92: spicebloom.spawnpoint
 		Location: 23,24
 		Owner: Neutral
-	HGunTurret3: wind_trap
+	HPower3: wind_trap
 		Location: 44,24
 		Owner: Harkonnen
-	HPower3: wind_trap
+	HPower4: wind_trap
 		Location: 46,24
 		Owner: Harkonnen
 	Actor95: wall
 		Location: 46,29
 		Owner: Harkonnen
-	HGunTurret4: medium_gun_turret
+	HGunTurret3: medium_gun_turret
 		Location: 47,29
 		Owner: Harkonnen
 	Actor97: wall
@@ -345,7 +345,7 @@ Actors:
 	Actor101: wall
 		Location: 10,32
 		Owner: Harkonnen
-	HGunTurret5: medium_gun_turret
+	HGunTurret4: medium_gun_turret
 		Location: 11,32
 		Owner: Harkonnen
 	Actor103: light_inf

--- a/mods/d2k/maps/ordos-04/ordos04.lua
+++ b/mods/d2k/maps/ordos-04/ordos04.lua
@@ -9,7 +9,7 @@
 
 Base =
 {
-	Harkonnen = { HConyard, HRefinery, HHeavyFactory, HLightFactory, HGunTurret1, HGunTurret2, HGunTurret3, HGunTurret4, HGunTurret5, HBarracks, HPower1, HPower2, HPower3, HPower4 },
+	Harkonnen = { HConyard, HRefinery, HHeavyFactory, HLightFactory, HGunTurret1, HGunTurret2, HGunTurret3, HGunTurret4, HBarracks, HPower1, HPower2, HPower3, HPower4 },
 	Smugglers = { SOutpost, SHeavyFactory, SLightFactory, SGunTurret1, SGunTurret2, SGunTurret3, SGunTurret4, SBarracks, SPower1, SPower2, SPower3 }
 }
 
@@ -139,8 +139,8 @@ WorldLoaded = function()
 			Smuggler.MarkFailedObjective(DefendOutpost)
 		end)
 	end)
-	Trigger.OnDamaged(SOutpost, function()
-		if SOutpost.Owner ~= Smuggler then
+	Trigger.OnDamaged(SOutpost, function(_, attacker)
+		if SOutpost.Owner ~= Smuggler or attacker.IsDead or attacker.Owner ~= Ordos then
 			return
 		end
 


### PR DESCRIPTION
Some changes to objectives or alerts that seemed worthwhile, if a bit light for separate PRs.

**Harkonnen 2a & 2b**
The only player objective is now a primary one, so victory will actually trigger.

**Ordos 4**

To avoid warnings about flying debris (which are almost guaranteed from nearby walls), the Outpost to be captured will now check if attackers are alive and owned by the player.

![Ordos04_Outpost](https://github.com/OpenRA/OpenRA/assets/4985264/0c5c2540-83ef-4150-abad-67c519474338)

The editor pointed out a (harmless) name mismatch, so I threw in a correction for that.

![Ordos04_WindTurret](https://github.com/OpenRA/OpenRA/assets/4985264/c4c070e7-c6cf-44f8-b912-83c2469aea48)

**Atreides 5**
Like the Ordos 4 Outpost, the Starport now only gives a warning when attacked by the player, just in case the nearby Wind Traps are blown apart first.
- The Barracks to be captured already limits its own warning.

Text for finishing the Harkonnen has been fixed.

![Atreides05_Text](https://github.com/OpenRA/OpenRA/assets/4985264/b8919121-9f15-4fe6-a9a1-fbb64f0fbfdd)