### PR TITLE
Add base failure, Nod defense to gdi05b & gdi05c

### DIFF
--- a/mods/cnc/maps/gdi05b/map.yaml
+++ b/mods/cnc/maps/gdi05b/map.yaml
@@ -567,7 +567,7 @@ Actors:
 	Fact1: fact
 		Location: 51,17
 		Owner: Nod
-	GdiNuke1: nuke
+	GdiNuke2: nuke
 		Location: 33,51
 		Owner: AbandonedBase
 		Health: 46
@@ -576,15 +576,11 @@ Actors:
 		Owner: AbandonedBase
 		Health: 48
 		FreeActor: False
-	GdiHarv: harv
-		Location: 27,55
-		Owner: AbandonedBase
-		Facing: 256
 	GdiWeap1: weap
 		Location: 35,52
 		Owner: AbandonedBase
 		Health: 41
-	GdiNuke2: nuke
+	GdiNuke1: nuke
 		Location: 31,51
 		Owner: AbandonedBase
 		Health: 39
@@ -611,6 +607,9 @@ Actors:
 	Sam4: sam
 		Location: 26,37
 		Owner: Nod
+	GDIBaseCenter: waypoint
+		Owner: Neutral
+		Location: 32,53
 
 Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml
 

--- a/mods/cnc/maps/gdi05c/gdi05c.lua
+++ b/mods/cnc/maps/gdi05c/gdi05c.lua
@@ -18,10 +18,10 @@ ActorRemovals =
 
 AllToHuntTrigger = { Silo1, Proc1, Silo2, Radar1, Afld1, Hand1, Nuke1, Nuke2, Nuke3, Fact1 }
 
-AtkRoute1 = { waypoint0, waypoint1, waypoint2, waypoint3, waypoint4 }
-AtkRoute2 = { waypoint0, waypoint8, waypoint4 }
-AtkRoute3 = { waypoint0, waypoint1, waypoint2, waypoint5, waypoint6, waypoint7 }
-AtkRoute4 = { waypoint0, waypoint8, waypoint9, waypoint10, waypoint11 }
+AtkRoute1 = { waypoint0, waypoint1, waypoint2, waypoint3, waypoint4, GDIBaseCenter }
+AtkRoute2 = { waypoint0, waypoint8, waypoint4, GDIBaseCenter }
+AtkRoute3 = { waypoint0, waypoint1, waypoint2, waypoint5, waypoint6, waypoint7, GDIBaseCenter }
+AtkRoute4 = { waypoint0, waypoint8, waypoint9, waypoint10, waypoint11, GDIBaseCenter }
 
 AutoCreateTeams =
 {
@@ -46,17 +46,32 @@ GDIBase = { GdiNuke1, GdiProc1, GdiWeap1, GdiNuke2, GdiNuke3, GdiPyle1, GdiSilo1
 GDIUnits = { "e2", "e2", "e2", "e2", "e1", "e1", "e1", "e1", "mtnk", "mtnk", "jeep", "apc", "apc" }
 GDIHarvester = { "harv" }
 NodSams = { Sam1, Sam2, Sam3 }
+NodAttackers = { }
+EarlyAttackTimer = 0
+
+SendAttackers = function(actors, path)
+	Utils.Do(actors, function(actor)
+		local id = #NodAttackers + 1
+		NodAttackers[id] = actor
+
+		Trigger.OnKilled(actor, function()
+			NodAttackers[id] = nil
+		end)
+	end)
+
+	MoveAndHunt(actors, path)
+end
 
 AutoCreateTeam = function()
 	local team = Utils.Random(AutoCreateTeams)
 	for type, count in pairs(team.types) do
-		MoveAndHunt(Utils.Take(count, Nod.GetActorsByType(type)), team.route)
+		SendAttackers(Utils.Take(count, Nod.GetActorsByType(type)), team.route)
 	end
 
 	Trigger.AfterDelay(Utils.RandomInteger(AutoAtkMinDelay[Difficulty], AutoAtkMaxDelay[Difficulty]), AutoCreateTeam)
 end
 
-DiscoverGDIBase = function(actor, discoverer)
+DiscoverGDIBase = function(_, discoverer)
 	if BaseDiscovered or not discoverer == GDI then
 		return
 	end
@@ -76,27 +91,100 @@ DiscoverGDIBase = function(actor, discoverer)
 	GDI.MarkCompletedObjective(FindBase)
 end
 
+LoseGDIBase = function(location)
+	if BaseDiscovered then
+		return
+	end
+
+	GDI.MarkFailedObjective(FindBase)
+	Actor.Create("camera", true, { Owner = GDI, Location = location })
+	Camera.Position = Map.CenterOfCell(location)
+end
+
 Atk1TriggerFunction = function()
-	MoveAndHunt(Utils.Take(2, Nod.GetActorsByType('e1')), AtkRoute1)
-	MoveAndHunt(Utils.Take(2, Nod.GetActorsByType('e3')), AtkRoute1)
+	SendAttackers(Utils.Take(2, Nod.GetActorsByType('e1')), AtkRoute1)
+	SendAttackers(Utils.Take(2, Nod.GetActorsByType('e3')), AtkRoute1)
 end
 
 Atk2TriggerFunction = function()
-	MoveAndHunt(Utils.Take(4, Nod.GetActorsByType('e3')), AtkRoute2)
+	SendAttackers(Utils.Take(4, Nod.GetActorsByType('e3')), AtkRoute2)
 end
 
 Atk3TriggerFunction = function()
-	MoveAndHunt(Utils.Take(1, Nod.GetActorsByType('bggy')), AtkRoute2)
+	SendAttackers(Utils.Take(1, Nod.GetActorsByType('bggy')), AtkRoute2)
 end
 
 Atk4TriggerFunction = function()
-	MoveAndHunt(Utils.Take(2, Nod.GetActorsByType('e1')), AtkRoute1)
-	MoveAndHunt(Utils.Take(1, Nod.GetActorsByType('ltnk')), AtkRoute1)
+	SendAttackers(Utils.Take(2, Nod.GetActorsByType('e1')), AtkRoute1)
+	SendAttackers(Utils.Take(1, Nod.GetActorsByType('ltnk')), AtkRoute1)
 end
 
 InsertGDIUnits = function()
 	Media.PlaySpeechNotification(GDI, "Reinforce")
 	Reinforcements.Reinforce(GDI, GDIUnits, { UnitsEntry.Location, UnitsRally.Location }, 15)
+end
+
+ScheduleNodAttacks = function()
+	Trigger.AfterDelay(Atk1Delay[Difficulty], Atk1TriggerFunction)
+	Trigger.AfterDelay(Atk2Delay[Difficulty], Atk2TriggerFunction)
+	Trigger.AfterDelay(Atk3Delay[Difficulty], Atk3TriggerFunction)
+	Trigger.AfterDelay(Atk4Delay[Difficulty], Atk4TriggerFunction)
+
+	Trigger.AfterDelay(AutoAtkStartDelay[Difficulty], AutoCreateTeam)
+
+	Trigger.OnAllKilledOrCaptured(AllToHuntTrigger, function()
+		Utils.Do(Nod.GetGroundAttackers(), IdleHunt)
+	end)
+
+	Trigger.AfterDelay(DateTime.Seconds(40), function()
+		local delay = function() return DateTime.Seconds(30) end
+		local toBuild = function() return { "e1" } end
+		ProduceUnits(Nod, Hand1, delay, toBuild)
+	end)
+
+	local baseDefenses = Nod.GetActorsByTypes({ "sam", "gun" })
+	local pullBuildings = Utils.Concat(AllToHuntTrigger, baseDefenses)
+
+	Utils.Do(pullBuildings, function(building)
+		Trigger.OnDamaged(building, OnNodBaseDamaged)
+	end)
+end
+
+OnNodBaseDamaged = function(building, attacker)
+	if BaseDiscovered then
+		Trigger.Clear(building, "OnDamaged")
+		return
+	end
+
+	if EarlyAttackTimer > 0 or attacker.Owner ~= GDI then
+		return
+	end
+
+	EarlyAttackTimer = DateTime.Seconds(10)
+
+	if attacker.IsDead then
+		PullAttackers(building.Location)
+		return
+	end
+
+	PullAttackers(attacker.Location)
+end
+
+PullAttackers = function(location)
+	Utils.Do(NodAttackers, function(attacker)
+		if attacker.IsDead or attacker.Stance == "Defend" then
+			return
+		end
+
+		-- Ignore structures.
+		attacker.Stance = "Defend"
+		attacker.Stop()
+		attacker.AttackMove(location, 2)
+		attacker.CallFunc(function()
+			-- No targets nearby. Reset stance for IdleHunt.
+			attacker.Stance = "AttackAnything"
+		end)
+	end)
 end
 
 WorldLoaded = function()
@@ -116,24 +204,12 @@ WorldLoaded = function()
 		unit.Destroy()
 	end)
 
-	Trigger.AfterDelay(Atk1Delay[Difficulty], Atk1TriggerFunction)
-	Trigger.AfterDelay(Atk2Delay[Difficulty], Atk2TriggerFunction)
-	Trigger.AfterDelay(Atk3Delay[Difficulty], Atk3TriggerFunction)
-	Trigger.AfterDelay(Atk4Delay[Difficulty], Atk4TriggerFunction)
-
-	Trigger.AfterDelay(AutoAtkStartDelay[Difficulty], AutoCreateTeam)
-
-	Trigger.OnAllKilledOrCaptured(AllToHuntTrigger, function()
-		Utils.Do(Nod.GetGroundAttackers(), IdleHunt)
-	end)
-
-	Trigger.AfterDelay(DateTime.Seconds(40), function()
-		local delay = function() return DateTime.Seconds(30) end
-		local toBuild = function() return { "e1" } end
-		ProduceUnits(Nod, Hand1, delay, toBuild)
-	end)
-
 	Trigger.OnPlayerDiscovered(AbandonedBase, DiscoverGDIBase)
+
+	local revealCell = GdiRadar1.Location + CVec.New(0, 5)
+	Trigger.OnAllKilled(GDIBase, function()
+		LoseGDIBase(revealCell)
+	end)
 
 	Trigger.OnAllKilled(NodSams, function()
 		GDI.MarkCompletedObjective(DestroySAMs)
@@ -143,6 +219,7 @@ WorldLoaded = function()
 	Camera.Position = UnitsRally.CenterPosition
 
 	InsertGDIUnits()
+	ScheduleNodAttacks()
 end
 
 Tick = function()
@@ -150,7 +227,12 @@ Tick = function()
 		Nod.MarkCompletedObjective(NodObjective)
 	end
 
-	if BaseDiscovered and Nod.HasNoRequiredUnits() then
+	if not BaseDiscovered then
+		EarlyAttackTimer = EarlyAttackTimer - 1
+		return
+	end
+
+	if Nod.HasNoRequiredUnits() then
 		GDI.MarkCompletedObjective(EliminateNod)
 	end
 end

--- a/mods/cnc/maps/gdi05c/map.yaml
+++ b/mods/cnc/maps/gdi05c/map.yaml
@@ -764,6 +764,9 @@ Actors:
 	UnitsRally: waypoint
 		Location: 51,42
 		Owner: Neutral
+	GDIBaseCenter: waypoint
+		Owner: Neutral
+		Location: 29,6
 
 Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml
 


### PR DESCRIPTION
In 05b/05c, GDI now fails if the GDI base is destroyed before its discovery.
- If this happens, the location is revealed as a courtesy.

In 05b/05c, GDI can now draw Nod attackers from the GDI base by going after Nod's own base.
- This is skipped if the GDI base has been discovered.
- Extra simple to do on 05b because of the terrain.

Nod attack routes in 05b/05c are now more direct.

Like 05c, 05b now delays the appearance of GDI's harvester until the base is discovered.

----

Some changes to GDI 05 prompted by a bug report from **Zsombi**. It's possible to skip recovering the GDI base and destroy Nod with only starting units. If Nod first destroys all the GDI structures, completing the "Find the GDI base" objective becomes impossible and the mission is locked.

**Zsombi** expected victory since Nod got wiped off the map. This seems at odds with at least the _video_ briefing and how the original triggers are set up.

![BaseTrigger2](https://github.com/OpenRA/OpenRA/assets/4985264/ba80b84d-584d-4f94-a964-e31765c33af7)

For the sake of fun, I've tried for a middle ground that happens to be possible in the original mission: losing the base before discovery still causes defeat but if the Nod base is attacked, their forces at the GDI base can get pulled back to defend.

Attack routes in 05b/05c have an added waypoint inside the GDI base to sidestep an issue. It's possible for the attack functions with Utils.Take to affect the same units and queue orders. The result is attackers that path toward one entrance of the GDI base, finish that attack route, circle back to the Nod base to begin another route, and then attack a different entrance.

https://github.com/OpenRA/OpenRA/assets/4985264/9b805d33-a4ac-4776-85bd-6f13a8e23755

05a was left untouched because Nod is not scripted to attack until the base is discovered.