### PR TITLE
Rename the Radar Dome in Soviets08a to avoid a crash

### DIFF
--- a/mods/ra/maps/soviet-08a/map.yaml
+++ b/mods/ra/maps/soviet-08a/map.yaml
@@ -578,7 +578,7 @@ Actors:
 	Actor174: gun
 		Location: 51,41
 		Owner: Greece
-	Radar: dome
+	GreeceRadar: dome
 		Location: 34,37
 		Owner: Greece
 	Actor176: agun


### PR DESCRIPTION
Closes #21250. The issue is that the name `Radar` conflicts with the https://github.com/OpenRA/OpenRA/blob/dd7441e0b4194457276dc2eb1ef07fc919aa5ec5/OpenRA.Mods.Common/Scripting/Global/RadarGlobal.cs#L18 binding. We should add a lint rule to catch this and throw a better exception.