### PR TITLE
adds Hovers WorldVisualOffset to muzzle calculations

### DIFF
--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.GameRules;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -113,6 +114,8 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly WeaponInfo Weapon;
 		public readonly Barrel[] Barrels;
 		Turreted turret;
+		Hovers hovers;
+
 		BodyOrientation coords;
 		INotifyBurstComplete[] notifyBurstComplete;
 		INotifyAttack[] notifyAttacks;
@@ -168,6 +171,7 @@ namespace OpenRA.Mods.Common.Traits
 		protected override void Created(Actor self)
 		{
 			turret = self.TraitsImplementing<Turreted>().FirstOrDefault(t => t.Name == Info.Turret);
+			hovers = self.TraitOrDefault<Hovers>();
 			coords = self.Trait<BodyOrientation>();
 			notifyBurstComplete = self.TraitsImplementing<INotifyBurstComplete>().ToArray();
 			notifyAttacks = self.TraitsImplementing<INotifyAttack>().ToArray();
@@ -388,6 +392,9 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// Weapon offset in turret coordinates
 			var localOffset = b.Offset + new WVec(-Recoil, WDist.Zero, WDist.Zero);
+
+			if (hovers != null)
+				localOffset += hovers.WorldVisualOffset;
 
 			// Turret coordinates to body coordinates
 			var bodyOrientation = coords.QuantizeOrientation(self.Orientation);

--- a/OpenRA.Mods.Common/Traits/Render/Hovers.cs
+++ b/OpenRA.Mods.Common/Traits/Render/Hovers.cs
@@ -69,7 +69,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 		readonly int fallTickHeight;
 
 		int ticks;
-		WVec worldVisualOffset;
+
+		[Sync]
+		public WVec WorldVisualOffset { get; private set; }
 
 		public Hovers(HoversInfo info)
 			: base(info)
@@ -85,11 +87,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			if (IsTraitDisabled)
 			{
-				if (worldVisualOffset.Z < 0)
+				if (WorldVisualOffset.Z < 0)
 					return;
 
-				var fallTicks = worldVisualOffset.Z / fallTickHeight - 1;
-				worldVisualOffset = new WVec(0, 0, fallTickHeight * fallTicks);
+				var fallTicks = WorldVisualOffset.Z / fallTickHeight - 1;
+				WorldVisualOffset = new WVec(0, 0, fallTickHeight * fallTicks);
 			}
 			else
 				ticks++;
@@ -104,13 +106,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 				var currentHeight = info.BobDistance.Length * visualOffset / 1024 + info.InitialHeight.Length;
 
 				// This part rises the actor up from disabled state
-				if (worldVisualOffset.Z < currentHeight)
-					currentHeight = Math.Min(worldVisualOffset.Z + info.InitialHeight.Length / info.RiseTicks, currentHeight);
+				if (WorldVisualOffset.Z < currentHeight)
+					currentHeight = Math.Min(WorldVisualOffset.Z + info.InitialHeight.Length / info.RiseTicks, currentHeight);
 
-				worldVisualOffset = new WVec(0, 0, currentHeight);
+				WorldVisualOffset = new WVec(0, 0, currentHeight);
 			}
 
-			return r.Select(a => a.OffsetBy(worldVisualOffset));
+			return r.Select(a => a.OffsetBy(WorldVisualOffset));
 		}
 
 		IEnumerable<Rectangle> IRenderModifier.ModifyScreenBounds(Actor self, WorldRenderer wr, IEnumerable<Rectangle> bounds)


### PR DESCRIPTION
This is a simple change that makes muzzle take in current world offset from hovers trait, if one is present. This way units such as hover MRLS have accurate offset positions.