### PR TITLE
Fix documentation workflow always trying to commit #2

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -87,6 +87,7 @@ jobs:
           cd wiki
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"
+          git status
           git diff-index --quiet HEAD || \
           (
             git add --all && \
@@ -140,6 +141,7 @@ jobs:
           cd docs
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"
+          git status
           git diff-index --quiet HEAD || \
           (
             git add api/*.md && \


### PR DESCRIPTION
A continuation of #21232.
Will hopefully fix https://github.com/OpenRA/OpenRA/actions/runs/7187570268

I know adding `git status` makes no sense, but a bunch of experimenting with @tinix0 on Discord and my fork showed this magically makes it work, so 🤷‍♂️ 
with nothing to commit: https://github.com/penev92/OpenRA/actions/runs/7200288884
with something to commit: https://github.com/penev92/OpenRA/actions/runs/7200308019