### PR TITLE
ActorMoveBrush for Editor

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/EditorCursorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorCursorLayer.cs
@@ -189,6 +189,22 @@ namespace OpenRA.Mods.Common.Traits
 			return ++CurrentToken;
 		}
 
+		public void MoveActor(EditorActorPreview preview, CPos location)
+		{
+			editorLayer.Remove(preview);
+			preview.ReplaceInit(new LocationInit(location));
+			var ios = preview.Info.TraitInfoOrDefault<IOccupySpaceInfo>();
+			if (ios != null && ios.SharesCell)
+			{
+				var actorSubCell = editorLayer.FreeSubCellAt(location);
+				if (actorSubCell != SubCell.Invalid)
+					preview.ReplaceInit(new SubCellInit(actorSubCell));
+			}
+
+			preview.UpdateFromMove();
+			editorLayer.Add(preview);
+		}
+
 		public int SetTerrainTemplate(WorldRenderer wr, TerrainTemplateInfo template)
 		{
 			terrainOrResourceCell = wr.Viewport.ViewToWorld(wr.Viewport.WorldToViewPx(Viewport.LastMousePos));

--- a/mods/common/languages/en.ftl
+++ b/mods/common/languages/en.ftl
@@ -810,6 +810,7 @@ notification-selected-actor = Selected actor { $id }
 notification-cleared-selection = Cleared selection
 notification-removed-actor = Removed { $name } ({ $id })
 notification-removed-resource = Removed { $type }
+notification-moved-actor = Moved { $id } from { $x1 },{ $y1 } to { $x2 },{ $y2 }
 
 ## EditorResourceBrush
 notification-added-resource =


### PR DESCRIPTION
This PR adds a new brush that can move singular actors by drag and drop. It includes _Ctrl + M_ hotkey as well as translation strings. It is expected to wait for #20226 to be merged first and this adjusted to changes, currently my goal is to get feedback whether this is the right approach. Example of tool in action:

Fixes #5241 



https://github.com/OpenRA/OpenRA/assets/25931859/cfe3eb57-d8b2-4164-9a6c-8926715aa04e

