### PR TITLE
Fix trike muzzle sequence

### DIFF
--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -150,10 +150,10 @@ trike:
 	WithMuzzleOverlay:
 	Armament@damage:
 		Weapon: HMG
-		LocalOffset: 180,0,110
+		LocalOffset: 50,0,0
 	Armament@muzzle:
 		Weapon: HMG_muzzle
-		LocalOffset: -544,0,0
+		LocalOffset: 50,0,0
 		MuzzleSequence: muzzle
 	AttackFrontal:
 		FacingTolerance: 0
@@ -467,10 +467,10 @@ raider:
 	WithMuzzleOverlay:
 	Armament@damage:
 		Weapon: HMGo
-		LocalOffset: 170,0,0
+		LocalOffset: 100,0,0
 	Armament@muzzle:
 		Weapon: HMGo_muzzle
-		LocalOffset: 170,0,0
+		LocalOffset: 100,0,0
 		MuzzleSequence: muzzle
 	AttackFrontal:
 		FacingTolerance: 0

--- a/mods/d2k/sequences/vehicles.yaml
+++ b/mods/d2k/sequences/vehicles.yaml
@@ -61,7 +61,7 @@ trike:
 		Remap: 54F94B
 	muzzle:
 		Filename: DATA.R16
-		Start: 4092
+		Start: 3996
 		Tick: 50
 		Facings: -32
 		BlendMode: Additive


### PR DESCRIPTION
While digging in #21266 I realize that trike use wrong muzzle sequence compared to OG.

https://github.com/OpenRA/OpenRA/assets/100044015/49c39d32-ff26-41f7-8b86-155872a89f74

