### PR TITLE
implements flashing on healing units

### DIFF
--- a/OpenRA.Mods.Common/Warheads/FlashTargetsInRadiusWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/FlashTargetsInRadiusWarhead.cs
@@ -1,0 +1,60 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.GameRules;
+using OpenRA.Mods.Common.Effects;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Warheads
+{
+	[Desc("Trigger a flash effect on the targeted actor, or actors within a circle.")]
+	public class FlashTargetsInRadiusWarhead : Warhead
+	{
+		[Desc("The overlay color to display when ActorFlashType is Overlay.")]
+		public readonly Color ActorFlashOverlayColor = Color.White;
+
+		[Desc("The overlay transparency to display when ActorFlashType is Overlay.")]
+		public readonly float ActorFlashOverlayAlpha = 0.5f;
+
+		[Desc("The tint to apply when ActorFlashType is Tint.")]
+		public readonly float3 ActorFlashTint = new(1.4f, 1.4f, 1.4f);
+
+		[Desc("Number of times to flash actors.")]
+		public readonly int ActorFlashCount = 2;
+
+		[Desc("Number of ticks between actor flashes.")]
+		public readonly int ActorFlashInterval = 2;
+
+		[Desc("Radius of an area at which effect will be applied. If left default effect applies only to target actor.")]
+		public readonly WDist Radius = new(0);
+
+		[Desc("Controls the way damage is calculated. Possible values are 'HitShape', 'ClosestTargetablePosition' and 'CenterPosition'.")]
+		public readonly DamageCalculationType DamageCalculationType = DamageCalculationType.HitShape;
+
+		public override void DoImpact(in Target target, WarheadArgs args)
+		{
+			var targetActor = target.Actor;
+			var firedBy = args.SourceActor;
+			var victims = Radius == WDist.Zero && targetActor != null ? new Actor[] { targetActor } : firedBy.World.FindActorsInCircle(target.CenterPosition, Radius);
+
+			foreach (var victim in victims)
+			{
+				if (!IsValidAgainst(victim, firedBy))
+					continue;
+
+				victim.World.AddFrameEndTask(w => w.Add(new FlashTarget(
+									victim, ActorFlashOverlayColor, ActorFlashOverlayAlpha,
+									ActorFlashCount, ActorFlashInterval)));
+			}
+		}
+	}
+}

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -128,7 +128,11 @@ Heal:
 	ValidTargets: Heal
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead@1Dam: SpreadDamage
+	Warhead@1Eff: FlashTargetsInRadius
+		Radius: 1065
+		ValidRelationships: Ally
+		ValidTargets: Heal
+	Warhead@2Dam: SpreadDamage
 		Spread: 213
 		Damage: -5000
 		ValidRelationships: Ally
@@ -139,7 +143,9 @@ Repair:
 	Inherits: Heal
 	Report: fixit1.aud
 	ValidTargets: Repair
-	Warhead@1Dam: SpreadDamage
+	Warhead@1Eff: FlashTargetsInRadius
+		ValidTargets: Repair
+	Warhead@2Dam: SpreadDamage
 		Damage: -2000
 		ValidTargets: Repair
 

--- a/mods/ts/weapons/healweapons.yaml
+++ b/mods/ts/weapons/healweapons.yaml
@@ -5,10 +5,14 @@
 	ValidTargets: Heal
 	TargetActorCenter: true
 	Projectile: InstantHit
-	Warhead@1Dam: TargetDamage
+	Warhead@1Eff: FlashTargetsInRadius
+		ValidTargets: Heal
+		ValidRelationships: Ally
+	Warhead@2Dam: TargetDamage
 		DebugOverlayColor: 00FF00
 		Damage: -5000
 		ValidTargets: Heal
+		ValidRelationships: Ally
 
 Heal:
 	Inherits: ^HealWeapon
@@ -18,5 +22,7 @@ Repair:
 	Range: 1c819
 	Report: repair11.aud
 	ValidTargets: Repair
-	Warhead@1Dam: TargetDamage
+	Warhead@1Eff: FlashTargetsInRadius
+		ValidTargets: Repair
+	Warhead@2Dam: TargetDamage
 		ValidTargets: Repair


### PR DESCRIPTION
Implements warhead that applies flashing effect to units in given area or target depending on properties. My only concern is that I was not sure which approach for area is correct and consistent with the project. It could very well be 2 different warheads with a lot of overlap (_FlashesTargetsInRadius_ / _FlashesTarget_ ) or this odd approach with radius that may be confusing for users.

Fixes #21068