### PR TITLE
Adds tilting on slopes to suitable actor previews

### DIFF
--- a/OpenRA.Mods.Common/ActorInitializer.cs
+++ b/OpenRA.Mods.Common/ActorInitializer.cs
@@ -23,6 +23,12 @@ namespace OpenRA.Mods.Common
 			: base(value) { }
 	}
 
+	public class TerrainOrientationInit : ValueActorInit<WRot>, ISingleInstanceInit
+	{
+		public TerrainOrientationInit(WRot value)
+			: base(value) { }
+	}
+
 	public class CreationActivityDelayInit : ValueActorInit<int>, ISingleInstanceInit
 	{
 		public CreationActivityDelayInit(int value)

--- a/OpenRA.Mods.Common/Graphics/ActorPreview.cs
+++ b/OpenRA.Mods.Common/Graphics/ActorPreview.cs
@@ -67,20 +67,32 @@ namespace OpenRA.Mods.Common.Graphics
 			if (facingInfo == null)
 				return () => WRot.None;
 
+			WAngle facing;
+
 			// Dynamic facing takes priority
 			var dynamicInit = reference.GetOrDefault<DynamicFacingInit>();
 			if (dynamicInit != null)
 			{
-				// TODO: Account for terrain slope
 				var getFacing = dynamicInit.Value;
-				return () => WRot.FromYaw(getFacing());
+				facing = getFacing();
+			}
+			else
+			{
+				// Fall back to initial actor facing if an Init isn't available
+				var facingInit = reference.GetOrDefault<FacingInit>();
+				facing = facingInit != null ? facingInit.Value : facingInfo.GetInitialFacing();
 			}
 
-			// Fall back to initial actor facing if an Init isn't available
-			var facingInit = reference.GetOrDefault<FacingInit>();
-			var facing = facingInit != null ? facingInit.Value : facingInfo.GetInitialFacing();
-			var orientation = WRot.FromYaw(facing);
-			return () => orientation;
+			var mobileInfo = Actor.TraitInfoOrDefault<MobileInfo>();
+			var location = reference.GetOrDefault<LocationInit>();
+			if (location == null || mobileInfo == null || mobileInfo.TerrainOrientationAdjustmentMargin.Length < 0)
+				return () => WRot.FromYaw(facing);
+
+			var orientationInit = reference.GetOrDefault<TerrainOrientationInit>();
+			var terrainOrientation = orientationInit != null ? orientationInit.Value : World.Map.TerrainOrientation(location.Value);
+			var terrainAdjustedFacing = new WRot(new WVec(0, 0, 1024).Rotate(terrainOrientation), facing);
+
+			return () => terrainOrientation + terrainAdjustedFacing;
 		}
 
 		public Func<WAngle> GetFacing()


### PR DESCRIPTION
Adds more functionality to _ActorPreview.cs_. _GetOrientation_ now checks for _MobileInfo_, and whether the actor has TerrainOrientationAdjustmentMargin defined. If so it gets orientation of the slope the actor is upon and applies facing rotation onto it. Otherwise the functionality remains unchanged. Tested new functionality on TS mod and saw no regressions on TD/RA end.

https://github.com/OpenRA/OpenRA/assets/25931859/dac3c492-1ecf-4874-9f92-b2e35d674859

