### PR TITLE
Add support for custom smudge smoke offset and add flame spawns to RA/TD - continued

### DIFF
--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -167,8 +167,8 @@ World:
 		Type: Scorch
 		Sequence: scorches
 		SmokeChance: 50
-		SmokeImage: smoke_m
-		SmokeSequences: idle
+		SmokeImage: scorch_flames
+		SmokeSequences: large_flame, medium_flame, small_flame
 		MaxSmokeOffsetDistance: 341
 	SmudgeLayer@CRATER:
 		Type: Crater

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -169,12 +169,14 @@ World:
 		SmokeChance: 50
 		SmokeImage: smoke_m
 		SmokeSequences: idle
+		MaxSmokeOffsetDistance: 341
 	SmudgeLayer@CRATER:
 		Type: Crater
 		Sequence: craters
 		SmokeChance: 25
 		SmokeImage: smoke_m
 		SmokeSequences: idle
+		MaxSmokeOffsetDistance: 213
 	ResourceLayer:
 		RecalculateResourceDensity: true
 		ResourceTypes:

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -83,6 +83,218 @@ smoke_m:
 		Offset: 2, -5
 		ZOffset: 512
 
+scorch_flames:
+	large_flame:
+		Length: *
+		Combine:
+			0:
+				Filename: fire1.shp
+				Length: *
+				Offset: 0,-3
+			1:
+				Filename: fire1.shp
+				Length: *
+				Offset: 0,-3
+			2:
+				Filename: fire1.shp
+				Length: *
+				Offset: 0,-3
+			3:
+				Filename: fire1.shp
+				Length: *
+				Offset: 0,-3
+			4:
+				Filename: fire2.shp
+				Length: *
+				Offset: 0,-3
+			5:
+				Filename: fire2.shp
+				Length: *
+				Offset: 0,-3
+			6:
+				Filename: fire2.shp
+				Length: *
+				Offset: 0,-3
+			7:
+				Filename: smoke_m.shp
+				Length: *
+				Offset: 2, -5
+			8:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+			9:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.75
+			10:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.5
+			11:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.25
+	medium_flame:
+		Length: *
+		Combine:
+			0:
+				Filename: fire2.shp
+				Length: *
+				Offset: 0,-3
+			1:
+				Filename: fire2.shp
+				Length: *
+				Offset: 0,-3
+			2:
+				Filename: fire2.shp
+				Length: *
+				Offset: 0,-3
+			3:
+				Filename: fire2.shp
+				Length: *
+				Offset: 0,-3
+			4:
+				Filename: fire2.shp
+				Length: *
+				Offset: 0,-3
+			5:
+				Filename: smoke_m.shp
+				Length: *
+				Offset: 2, -5
+			6:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.75
+			7:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.5
+			8:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.25
+	small_flame:
+		Combine:
+			0:
+				Filename: fire3.shp
+				Length: *
+				Offset: 0,-3
+			1:
+				Filename: fire3.shp
+				Length: *
+				Offset: 0,-3
+			2:
+				Filename: fire3.shp
+				Length: *
+				Offset: 0,-3
+			3:
+				Filename: fire3.shp
+				Length: *
+				Offset: 0,-3
+			4:
+				Filename: fire3.shp
+				Length: *
+				Offset: 0,-3
+			5:
+				Filename: smoke_m.shp
+				Length: *
+				Offset: 2, -5
+				Scale: 0.75
+			6:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.5
+			7:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.25
+		Length: *
+		Offset: 0,-3
+	tiny_flame:
+		Combine:
+			0:
+				Filename: fire4.shp
+				Length: *
+				Offset: 0,-3
+			1:
+				Filename: fire4.shp
+				Length: *
+				Offset: 0,-3
+			2:
+				Filename: fire4.shp
+				Length: *
+				Offset: 0,-3
+			3:
+				Filename: fire4.shp
+				Length: *
+				Offset: 0,-3
+			4:
+				Filename: smoke_m.shp
+				Length: *
+				Offset: 2, -5
+				Scale: 0.3
+			5:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.2
+		Length: *
+		Offset: 0,-3
+	smoke:
+		Combine:
+			0:
+				Filename: smoke_m.shp
+				Length: *
+				Offset: 2, -5
+			1:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+			2:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.8
+			3:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.6
+			4:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.4
+			5:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.2
+
 laserfire:
 	idle:
 		Filename: veh-hit3.shp

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -192,12 +192,14 @@ World:
 		SmokeChance: 50
 		SmokeImage: smoke_m
 		SmokeSequences: idle
+		MaxSmokeOffsetDistance: 341
 	SmudgeLayer@CRATER:
 		Type: Crater
 		Sequence: craters
 		SmokeChance: 25
 		SmokeImage: smoke_m
 		SmokeSequences: idle
+		MaxSmokeOffsetDistance: 213
 	ResourceLayer:
 		RecalculateResourceDensity: true
 		ResourceTypes:

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -190,8 +190,8 @@ World:
 		Type: Scorch
 		Sequence: scorches
 		SmokeChance: 50
-		SmokeImage: smoke_m
-		SmokeSequences: idle
+		SmokeImage: scorch_flames
+		SmokeSequences: large_flame, medium_flame, small_flame
 		MaxSmokeOffsetDistance: 341
 	SmudgeLayer@CRATER:
 		Type: Crater

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -236,6 +236,218 @@ smoke_m:
 		Offset: 2, -5
 		ZOffset: 512
 
+scorch_flames:
+	large_flame:
+		Length: *
+		Combine:
+			0:
+				Filename: fire1.shp
+				Length: *
+				Offset: 0,-3
+			1:
+				Filename: fire1.shp
+				Length: *
+				Offset: 0,-3
+			2:
+				Filename: fire1.shp
+				Length: *
+				Offset: 0,-3
+			3:
+				Filename: fire1.shp
+				Length: *
+				Offset: 0,-3
+			4:
+				Filename: fire2.shp
+				Length: *
+				Offset: 0,-3
+			5:
+				Filename: fire2.shp
+				Length: *
+				Offset: 0,-3
+			6:
+				Filename: fire2.shp
+				Length: *
+				Offset: 0,-3
+			7:
+				Filename: smoke_m.shp
+				Length: *
+				Offset: 2, -5
+			8:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+			9:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.75
+			10:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.5
+			11:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.25
+	medium_flame:
+		Length: *
+		Combine:
+			0:
+				Filename: fire2.shp
+				Length: *
+				Offset: 0,-3
+			1:
+				Filename: fire2.shp
+				Length: *
+				Offset: 0,-3
+			2:
+				Filename: fire2.shp
+				Length: *
+				Offset: 0,-3
+			3:
+				Filename: fire2.shp
+				Length: *
+				Offset: 0,-3
+			4:
+				Filename: fire2.shp
+				Length: *
+				Offset: 0,-3
+			5:
+				Filename: smoke_m.shp
+				Length: *
+				Offset: 2, -5
+			6:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.75
+			7:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.5
+			8:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.25
+	small_flame:
+		Combine:
+			0:
+				Filename: fire3.shp
+				Length: *
+				Offset: 0,-3
+			1:
+				Filename: fire3.shp
+				Length: *
+				Offset: 0,-3
+			2:
+				Filename: fire3.shp
+				Length: *
+				Offset: 0,-3
+			3:
+				Filename: fire3.shp
+				Length: *
+				Offset: 0,-3
+			4:
+				Filename: fire3.shp
+				Length: *
+				Offset: 0,-3
+			5:
+				Filename: smoke_m.shp
+				Length: *
+				Offset: 2, -5
+				Scale: 0.75
+			6:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.5
+			7:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.25
+		Length: *
+		Offset: 0,-3
+	tiny_flame:
+		Combine:
+			0:
+				Filename: fire4.shp
+				Length: *
+				Offset: 0,-3
+			1:
+				Filename: fire4.shp
+				Length: *
+				Offset: 0,-3
+			2:
+				Filename: fire4.shp
+				Length: *
+				Offset: 0,-3
+			3:
+				Filename: fire4.shp
+				Length: *
+				Offset: 0,-3
+			4:
+				Filename: smoke_m.shp
+				Length: *
+				Offset: 2, -5
+				Scale: 0.3
+			5:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.2
+		Length: *
+		Offset: 0,-3
+	smoke:
+		Combine:
+			0:
+				Filename: smoke_m.shp
+				Length: *
+				Offset: 2, -5
+			1:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+			2:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.8
+			3:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.6
+			4:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.4
+			5:
+				Filename: smoke_m.shp
+				Start: 49
+				Length: 42
+				Offset: 2, -5
+				Scale: 0.2
+
 dragon:
 	idle:
 		Filename: dragon.shp

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -55,6 +55,8 @@ Flamer:
 			Light: 40
 			Heavy: 20
 			Concrete: 10
+	Warhead@2Smu: LeaveSmudge
+		Chance: 15
 	Warhead@3Eff: CreateEffect
 		Explosions: small_napalm
 

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -250,18 +250,21 @@ World:
 		SmokeImage: smallfire
 		SmokeSequences: idle
 		SmokeChance: 50
+		MaxSmokeOffsetDistance: 256
 	SmudgeLayer@MEDIUMSCORCH:
 		Type: MediumScorch
 		Sequence: mediumscorches
 		SmokeImage: mediumfire
 		SmokeSequences: idle
 		SmokeChance: 75
+		MaxSmokeOffsetDistance: 192
 	SmudgeLayer@LARGESCORCH:
 		Type: LargeScorch
 		Sequence: largescorches
 		SmokeImage: largefire
 		SmokeSequences: idle
 		SmokeChance: 100
+		MaxSmokeOffsetDistance: 128
 	SmudgeLayer@SMALLCRATER:
 		Type: SmallCrater
 		Sequence: smallcraters


### PR DESCRIPTION
Supersedes #19238 

Tested on both mods, seems to work fine, lowered flamer smudge chance by a lot as multiple projectiles cluttered the effect.