### PR TITLE
RallyPoint improvements

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -264,7 +264,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public class Building : IOccupySpace, ITargetableCells, INotifySold, INotifyTransform, ISync,
-		INotifyAddedToWorld, INotifyRemovedFromWorld
+		INotifyAddedToWorld, INotifyRemovedFromWorld, IRallyPointValidator
 	{
 		public readonly BuildingInfo Info;
 
@@ -352,6 +352,16 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var smudgeLayer in smudgeLayers)
 				foreach (var footprintTile in Info.Tiles(self.Location))
 					smudgeLayer.RemoveSmudge(footprintTile);
+		}
+
+		bool IRallyPointValidator.CanPlaceRallyPoint(Actor self, in Target target)
+		{
+			if (target.Type == TargetType.Actor && target.Actor != null)
+				return false;
+			if (target.Type == TargetType.Terrain)
+				return !self.World.ActorMap.GetActorsAt(self.World.Map.CellContaining(target.CenterPosition)).Any();
+
+			return true;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Effects;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
 
@@ -68,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public RallyPointInfo Info;
 		public string PaletteName { get; private set; }
-		RallyPointIndicator effect;
+		IEffect effect;
 
 		public void ResetPath(Actor self)
 		{
@@ -84,7 +85,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyCreated.Created(Actor self)
 		{
-			effect = new RallyPointIndicator(self, this);
+			effect = CreateRallyPointIndicator(self);
+		}
+
+		protected virtual IEffect CreateRallyPointIndicator(Actor self)
+		{
+			return new RallyPointIndicator(self, this);
 		}
 
 		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -18,6 +18,12 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[RequireExplicitImplementation]
+	public interface IRallyPointValidator
+	{
+		bool CanPlaceRallyPoint(Actor self, in Target target);
+	}
+
 	[Desc("Used to waypoint units after production or repair is finished.")]
 	public class RallyPointInfo : TraitInfo
 	{
@@ -71,6 +77,8 @@ namespace OpenRA.Mods.Common.Traits
 		public string PaletteName { get; private set; }
 		IEffect effect;
 
+		IRallyPointValidator validator;
+
 		public void ResetPath(Actor self)
 		{
 			Path = Info.Path.Select(p => self.Location + p).ToList();
@@ -86,6 +94,7 @@ namespace OpenRA.Mods.Common.Traits
 		void INotifyCreated.Created(Actor self)
 		{
 			effect = CreateRallyPointIndicator(self);
+			validator = self.TraitOrDefault<IRallyPointValidator>();
 		}
 
 		protected virtual IEffect CreateRallyPointIndicator(Actor self)
@@ -134,7 +143,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (order.OrderString != OrderID)
 				return;
 
-			if (!order.Target.IsValidFor(self))
+			if (!order.Target.IsValidFor(self) || validator?.CanPlaceRallyPoint(self, order.Target) == false)
 				return;
 
 			if (!order.Queued)


### PR DESCRIPTION
This PR adds two extension points into `RallyPoint` trait, which enable customized versions of the trait to:
- override indicator effect (i.e. custom `RallyPointIndicator` effect)
- validate new point before the point is added to the path (and possibly suppress it)

As for the custom indicator, it's possible to create `IRallyPointIndicator` interface, but I don't see any benefits from doing it (at least not now), since `RallyPoint` does not interact with `RallyPointIndicator` apart from adding/removing it to/from world.

Example use cases:
- (1) custom indicator, which can change how the indicator looks like
- (2) forbid placing new point in specific places