### PR TITLE
Editor: ActorEditLogic: support for dynamic generation of items in dropdown

### DIFF
--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -115,8 +115,8 @@ namespace OpenRA.Mods.Common.Traits
 				{ "attackanything", "Attack Anything" },
 			};
 
-			yield return new EditorActorDropdown("Stance", EditorStanceDisplayOrder, labels,
-				actor =>
+			yield return new EditorActorDropdown("Stance", EditorStanceDisplayOrder, _ => labels,
+				(actor, _) =>
 				{
 					var init = actor.GetInitOrDefault<StanceInit>(this);
 					var stance = init?.Value ?? InitialStance;

--- a/OpenRA.Mods.Common/Traits/Pluggable.cs
+++ b/OpenRA.Mods.Common/Traits/Pluggable.cs
@@ -59,8 +59,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Make sure the no-plug option is always available
 			EditorOptions[""] = EmptyOption;
-			yield return new EditorActorDropdown("Plug", EditorDisplayOrder, EditorOptions,
-				actor =>
+			yield return new EditorActorDropdown("Plug", EditorDisplayOrder, _ => EditorOptions,
+				(actor, _) =>
 				{
 					var init = actor.GetInitOrDefault<PlugInit>(this);
 					return init?.Value ?? "";

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -692,17 +692,20 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class EditorActorDropdown : EditorActorOption
 	{
-		public readonly Dictionary<string, string> Labels;
-		public readonly Func<EditorActorPreview, string> GetValue;
+		public readonly Func<EditorActorPreview, Dictionary<string, string>> GetLabels;
+		public readonly Func<EditorActorPreview, Dictionary<string, string>, string> GetValue;
 		public readonly Action<EditorActorPreview, string> OnChange;
 
+		/// <summary>
+		/// Creates dropdown for editing actor's metadata with dynamically created items.
+		/// </summary>
 		public EditorActorDropdown(string name, int displayOrder,
-			Dictionary<string, string> labels,
-			Func<EditorActorPreview, string> getValue,
+			Func<EditorActorPreview, Dictionary<string, string>> getLabels,
+			Func<EditorActorPreview, Dictionary<string, string>, string> getValue,
 			Action<EditorActorPreview, string> onChange)
 			: base(name, displayOrder)
 		{
-			Labels = labels;
+			GetLabels = getLabels;
 			GetValue = getValue;
 			OnChange = onChange;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -294,14 +294,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						initContainer.Bounds.Height += dropdownContainer.Bounds.Height;
 						dropdownContainer.Get<LabelWidget>("LABEL").GetText = () => ddo.Name;
 
-						var editorActionHandle = new EditorActorOptionActionHandle<string>(ddo.OnChange, ddo.GetValue(SelectedActor));
+						var labels = ddo.GetLabels(SelectedActor);
+
+						var editorActionHandle = new EditorActorOptionActionHandle<string>(ddo.OnChange, ddo.GetValue(SelectedActor, labels));
 						editActorPreview.Add(editorActionHandle);
 
 						var dropdown = dropdownContainer.Get<DropDownButtonWidget>("OPTION");
 						ScrollItemWidget DropdownSetup(KeyValuePair<string, string> option, ScrollItemWidget template)
 						{
 							var item = ScrollItemWidget.Setup(template,
-								() => ddo.GetValue(SelectedActor) == option.Key,
+								() => ddo.GetValue(SelectedActor, labels) == option.Key,
 								() =>
 								{
 									ddo.OnChange(SelectedActor, option.Key);
@@ -312,8 +314,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							return item;
 						}
 
-						dropdown.GetText = () => ddo.Labels[ddo.GetValue(SelectedActor)];
-						dropdown.OnClick = () => dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 270, ddo.Labels, DropdownSetup);
+						dropdown.GetText = () => labels[ddo.GetValue(SelectedActor, labels)];
+						dropdown.OnClick = () => dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 270, labels, DropdownSetup);
 
 						initContainer.AddChild(dropdownContainer);
 					}


### PR DESCRIPTION
This PR makes it possible for `EditorActorDropdown` to dynamically generate items for particular actor.

This requires second constructor for `EditorActorDropdown` to keep backward-compatibility with existing traits (which will still use old callbacks `GetLabels` and `GetValue`).