### PR TITLE
Make UnitOrderGenerator more extensible by giving inherited classes access to some methods

### DIFF
--- a/OpenRA.Mods.Common/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/UnitOrderGenerator.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Orders
 		readonly string worldSelectCursor = ChromeMetrics.Get<string>("WorldSelectCursor");
 		readonly string worldDefaultCursor = ChromeMetrics.Get<string>("WorldDefaultCursor");
 
-		static Target TargetForInput(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		protected static Target TargetForInput(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			var actor = world.ScreenMap.ActorsAtMouse(mi)
 				.Where(a => !a.Actor.IsDead && a.Actor.Info.HasTraitInfo<ITargetableInfo>() && !world.FogObscures(a.Actor))
@@ -134,7 +134,7 @@ namespace OpenRA.Mods.Common.Orders
 		/// First priority is given to orders that interact with the given actors.
 		/// Second priority is given to actors in the given cell.
 		/// </summary>
-		static UnitOrderResult OrderForUnit(Actor self, Target target, CPos xy, MouseInput mi)
+		protected static UnitOrderResult OrderForUnit(Actor self, Target target, CPos xy, MouseInput mi)
 		{
 			if (mi.Button != Game.Settings.Game.MouseButtonPreference.Action)
 				return null;
@@ -194,7 +194,7 @@ namespace OpenRA.Mods.Common.Orders
 			return order;
 		}
 
-		sealed class UnitOrderResult
+		protected sealed class UnitOrderResult
 		{
 			public readonly Actor Actor;
 			public readonly IOrderTargeter Order;


### PR DESCRIPTION
`UnitOrderGenerator` is already pretty extensible, but lack of (at least protected) access to some methods make it difficult to extend it with features that depend on determining current `Target` or even `Order` itself.

This PR makes methods `TargetForInput` and `OrderForUnit` and also `UnitOrderResult` nested class protected, so custom `OrderGenerators` can use their logic without copying it or invoking it via reflection.

Example usage in OpenE2140: OpenE2140/OpenE2140#538

https://github.com/OpenE2140/OpenE2140/blob/4009286db2aeae651d299489328e8a1e33298589/OpenRA.Mods.OpenE2140/Orders/ExtendedUnitOrderGenerator.cs