### PR TITLE
Missile projectile improvements

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -68,6 +68,9 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Is the missile blocked by actors with BlocksProjectiles: trait.")]
 		public readonly bool Blockable = true;
 
+		[Desc("Ignore actor, who fired the projectile, when detecting blocking actors?")]
+		public readonly bool BlockingIgnoreSourceActor = false;
+
 		[Desc("Is the missile aware of terrain height levels. Only needed for mods with real, non-visual height levels.")]
 		public readonly bool TerrainHeightAware = false;
 
@@ -881,7 +884,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			// Check for walls or other blocking obstacles
 			var shouldExplode = false;
-			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, args.SourceActor.Owner, lastPos, pos, info.Width, out var blockedPos))
+			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, args.SourceActor.Owner, lastPos, pos, info.Width, out var blockedPos, info.BlockingIgnoreSourceActor ? args.SourceActor : null))
 			{
 				pos = blockedPos;
 				shouldExplode = true;

--- a/OpenRA.Mods.Common/Traits/BlocksProjectiles.cs
+++ b/OpenRA.Mods.Common/Traits/BlocksProjectiles.cs
@@ -44,13 +44,16 @@ namespace OpenRA.Mods.Common.Traits
 					.Any(Exts.IsTraitEnabled));
 		}
 
-		public static bool AnyBlockingActorsBetween(World world, Player owner, WPos start, WPos end, WDist width, out WPos hit)
+		public static bool AnyBlockingActorsBetween(World world, Player owner, WPos start, WPos end, WDist width, out WPos hit, Actor ignoreActor = null)
 		{
 			var actors = world.FindBlockingActorsOnLine(start, end, width);
 			var length = (end - start).Length;
 
 			foreach (var a in actors)
 			{
+				if (a == ignoreActor)
+					continue;
+
 				var blockers = a.TraitsImplementing<IBlocksProjectiles>()
 					.Where(Exts.IsTraitEnabled).Where(t => t.ValidRelationships.HasRelationship(a.Owner.RelationshipWith(owner)))
 					.ToList();


### PR DESCRIPTION
### Description

This PR makes three changes to `Missile` projectile:
- optionally ignore source actor when determining, if the missile got blocked
  - this makes it possible for the source actor to be a blocker (for other blockable projectiles), while still not block its own missiles
- allow inherited classes changing moment, when the missile explodes
- and finally allow overriding `MissileInfo.Create()`

### Example usage in OpenE2140 mod

OpenE2140/OpenE2140#540

Submarine fires torpedo, which does not explode at target position, but continues traveling:

![torpedo](https://github.com/OpenRA/OpenRA/assets/119738087/bbb011ab-a00a-4187-8da5-3dfbcc07a0a1)


Relevant files:
- `Torpedo` class:
  - https://github.com/OpenE2140/OpenE2140/blob/ba9a87703aa985a87c371d3cd2806b5747129cc5/OpenRA.Mods.OpenE2140/Projectiles/Torpedo.cs
- Torpedo weapon of a ship:
  - https://github.com/OpenE2140/OpenE2140/blob/ba9a87703aa985a87c371d3cd2806b5747129cc5/mods/e2140/content/ed/ships/shark/weapons.yaml
- Torpedo weapon of a submarine:
   - https://github.com/OpenE2140/OpenE2140/blob/ba9a87703aa985a87c371d3cd2806b5747129cc5/mods/e2140/content/ucs/ships/russ3/weapons.yaml