### PR TITLE
Extend translation linting to check translation text fits within widget bounds

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -143,33 +143,27 @@ namespace OpenRA
 			OnRemoteDirectConnect(endpoint);
 		}
 
-		// Hacky workaround for orderManager visibility
-		public static Widget OpenWindow(World world, string widget)
+		/// <summary>
+		/// Creates the widget given by <paramref name="id"/> and attaches it to the <paramref name="parent"/>.
+		/// Prefer to call <see cref="ChromeLogic.DynamicWidgets.LoadWidget"/>.
+		/// </summary>
+		public static Widget LoadWidgetUnchecked(string id, Widget parent, WidgetArgs args)
 		{
-			return Ui.OpenWindow(widget, new WidgetArgs() { { "world", world }, { "orderManager", OrderManager }, { "worldRenderer", worldRenderer } });
+			return ModData.WidgetLoader.LoadWidget(ExtendWidgetArgs(args), parent, id);
 		}
 
-		// Who came up with the great idea of making these things
-		// impossible for the things that want them to access them directly?
-		public static Widget OpenWindow(string widget, WidgetArgs args)
+		/// <summary>
+		/// Returns a new widget args based on <paramref name="args"/>
+		/// and extended with values for 'orderManager', 'world' and 'worldRenderer'.
+		/// </summary>
+		public static WidgetArgs ExtendWidgetArgs(WidgetArgs args)
 		{
-			return Ui.OpenWindow(widget, new WidgetArgs(args)
+			return new WidgetArgs(args)
 			{
-				{ "world", worldRenderer.World },
+				{ "world", worldRenderer?.World },
 				{ "orderManager", OrderManager },
 				{ "worldRenderer", worldRenderer },
-			});
-		}
-
-		// Load a widget with world, orderManager, worldRenderer args, without adding it to the widget tree
-		public static Widget LoadWidget(World world, string id, Widget parent, WidgetArgs args)
-		{
-			return ModData.WidgetLoader.LoadWidget(new WidgetArgs(args)
-			{
-				{ "world", world },
-				{ "orderManager", OrderManager },
-				{ "worldRenderer", worldRenderer },
-			}, parent, id);
+			};
 		}
 
 		public static event Action LobbyInfoChanged = () => { };

--- a/OpenRA.Mods.Cnc/Widgets/Logic/PreReleaseWarningPrompt.cs
+++ b/OpenRA.Mods.Cnc/Widgets/Logic/PreReleaseWarningPrompt.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Mods.Common.Widgets;
 using OpenRA.Widgets;
 
@@ -18,20 +19,33 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 	{
 		static bool promptAccepted;
 
-		[ObjectCreator.UseCtor]
-		public PreReleaseWarningPrompt(Widget widget, World world, ModData modData)
+		public class PreReleaseWarningPromptDynamicWidgets : DynamicWidgets
 		{
-			if (!promptAccepted && modData.Manifest.Metadata.Version != "{DEV_VERSION}")
-				widget.Get<ButtonWidget>("CONTINUE_BUTTON").OnClick = () => ShowMainMenu(world);
-			else
-				ShowMainMenu(world);
+			public override ISet<string> WindowWidgetIds { get; } = EmptySet;
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } = EmptyDictionary;
+			public override IReadOnlyDictionary<string, string> OutOfTreeParentWidgetIdForChildWidgetId =>
+				new Dictionary<string, string>
+				{
+					{ "MAINMENU", "" },
+				};
 		}
 
-		static void ShowMainMenu(World world)
+		readonly PreReleaseWarningPromptDynamicWidgets dynamicWidgets = new();
+
+		[ObjectCreator.UseCtor]
+		public PreReleaseWarningPrompt(Widget widget, ModData modData)
+		{
+			if (!promptAccepted && modData.Manifest.Metadata.Version != "{DEV_VERSION}")
+				widget.Get<ButtonWidget>("CONTINUE_BUTTON").OnClick = ShowMainMenu;
+			else
+				ShowMainMenu();
+		}
+
+		void ShowMainMenu()
 		{
 			promptAccepted = true;
 			Ui.ResetAll();
-			Game.LoadWidget(world, "MAINMENU", Ui.Root, new WidgetArgs());
+			dynamicWidgets.LoadWidgetOutOfTree(Ui.Root, "MAINMENU", new WidgetArgs());
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
@@ -17,11 +17,15 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using Linguini.Syntax.Ast;
 using Linguini.Syntax.Parser;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.LoadScreens;
 using OpenRA.Mods.Common.Scripting;
 using OpenRA.Mods.Common.Scripting.Global;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Warheads;
+using OpenRA.Mods.Common.Widgets;
 using OpenRA.Scripting;
+using OpenRA.Support;
 using OpenRA.Traits;
 using OpenRA.Widgets;
 
@@ -82,7 +86,7 @@ namespace OpenRA.Mods.Common.Lint
 			{
 				Console.WriteLine($"Testing translation: {language}");
 				var translation = new Translation(language, modData.Manifest.Translations, modData.DefaultFileSystem, error => emitError(error.Message));
-				CheckModWidgets(modData, usedKeys, testedFields);
+				CheckModWidgets(modData, usedKeys, testedFields, translation, language, emitError, emitWarning);
 
 				// With the fully populated keys, check keys and variables are not missing and not unused across all language files.
 				var keyWithAttrs = CheckKeys(
@@ -295,9 +299,11 @@ namespace OpenRA.Mods.Common.Lint
 			return (usedKeys, testedFields);
 		}
 
-		static void CheckModWidgets(ModData modData, TranslationKeys usedKeys, List<FieldInfo> testedFields)
+		static void CheckModWidgets(
+			ModData modData, TranslationKeys usedKeys, List<FieldInfo> testedFields,
+			Translation translation, string language, Action<string> emitError, Action<string> emitWarning)
 		{
-			var chromeLayoutNodes = BuildChromeTree(modData);
+			var (minEffectiveResolution, chromeLayoutNodes, rootsByNodeId) = BuildChromeTree(modData);
 
 			var widgetTypes = modData.ObjectCreator.GetTypes()
 				.Where(t => t.Name.EndsWith("Widget", StringComparison.InvariantCulture) && t.IsSubclassOf(typeof(Widget)))
@@ -320,25 +326,347 @@ namespace OpenRA.Mods.Common.Lint
 			testedFields.AddRange(widgetTypes.SelectMany(
 				t => Utility.GetFields(t).Where(Utility.HasAttribute<TranslationReferenceAttribute>)));
 
+			// Set up data we need to check the translation text fits on the widgets.
+			var platform = Game.CreatePlatform("Default");
+			var fontSheetBuilder = new SheetBuilder(SheetType.BGRA, 512);
+			var fonts = modData.Manifest.Get<Fonts>().FontList.ToDictionary(x => x.Key,
+				x => new SpriteFont(
+					platform, x.Value.Font, modData.DefaultFileSystem.Open(x.Value.Font).ReadAllBytes(),
+					x.Value.Size, x.Value.Ascender, 1f, fontSheetBuilder));
+			ChromeMetrics.Initialize(modData);
+
+			// Check that translations fit onto the widget.
+			var uncheckedNodes = new List<MiniYamlNode>();
 			foreach (var node in chromeLayoutNodes)
-				CheckChrome(node, translationReferencesByWidgetField, usedKeys);
+			{
+				var nodeId = node.Key.Split('@')[1];
+				if (rootsByNodeId.TryGetValue(nodeId, out var rootContext))
+				{
+					var allBounds = rootContext.Entries.Select(e => e.Bounds).ToArray();
+					CheckChrome(
+						node, translation, language, emitError, emitWarning, translationReferencesByWidgetField,
+						allBounds, usedKeys, minEffectiveResolution, fonts);
+				}
+				else
+					uncheckedNodes.Add(node);
+			}
+
+			// For any nodes where we couldn't work out what their parent should be, we don't know the available size of the parent widget.
+			// Instead, check them assuming they have the full window size available.
+			foreach (var node in uncheckedNodes)
+			{
+				emitWarning($"Widget `{node.Key}` in {node.Location} does not have a known parent in the widget hierarchy, validation performed assuming window bounds.");
+				var windowBounds = new WidgetBounds(0, 0, minEffectiveResolution.X, minEffectiveResolution.Y);
+				CheckChrome(
+					node, translation, language, emitError, emitWarning, translationReferencesByWidgetField,
+					new[] { windowBounds }, usedKeys, minEffectiveResolution, fonts);
+			}
 		}
 
-		static MiniYamlNode[] BuildChromeTree(ModData modData)
+		static WidgetBounds GetWidgetBounds(MiniYamlNode node, WidgetBounds parentBounds, int2 minEffectiveResolution)
 		{
+			// See Widget.Initialize & DropDownButtonWidget.ShowDropDown for reference.
+			var substitutions = new Dictionary<string, int>
+			{
+				{ "WINDOW_RIGHT", minEffectiveResolution.X },
+				{ "WINDOW_BOTTOM", minEffectiveResolution.Y },
+				{ "PARENT_RIGHT", parentBounds.Right },
+				{ "PARENT_BOTTOM", parentBounds.Bottom },
+				{ "DROPDOWN_WIDTH", parentBounds.Width },
+			};
+			var xExpr = new IntegerExpression(node.Value.NodeWithKeyOrDefault("X")?.Value.Value ?? "0");
+			var yExpr = new IntegerExpression(node.Value.NodeWithKeyOrDefault("Y")?.Value.Value ?? "0");
+			var widthExpr = new IntegerExpression(node.Value.NodeWithKeyOrDefault("Width")?.Value.Value ?? "0");
+			var heightExpr = new IntegerExpression(node.Value.NodeWithKeyOrDefault("Height")?.Value.Value ?? "0");
+			var x = xExpr.Evaluate(substitutions);
+			var y = yExpr.Evaluate(substitutions);
+			var width = widthExpr.Evaluate(substitutions);
+			var height = heightExpr.Evaluate(substitutions);
+			return new WidgetBounds(x, y, width, height);
+		}
+
+		static (
+			int2 MinEffectiveResolution,
+			MiniYamlNode[] ChromeLayoutNodes,
+			Dictionary<string, RootContext> RootsByNodeId) BuildChromeTree(ModData modData)
+		{
+			// MinEffectiveResolution is the minimum resolution we design the UI around.
+			// This means we can check the translations fit for our minimum supported size.
+			var minEffectiveResolution = new int2(modData.Manifest.Get<WorldViewportSizes>().MinEffectiveResolution);
+			var windowBounds = new WidgetBounds(0, 0, minEffectiveResolution.X, minEffectiveResolution.Y);
+
+			// Initial roots for possible widgets trees are given by LoadWidgetAtGameStartInfo.
+			// Also handle windows created by ModContentLoadScreen.
+			var rootsByNodeId = new Dictionary<string, RootContext>();
+			var loadWidgetAtGameStartInfo = modData.DefaultRules.Actors[SystemActors.World].TraitInfo<LoadWidgetAtGameStartInfo>();
+			rootsByNodeId[loadWidgetAtGameStartInfo.ShellmapRoot] = RootContext.CreateInitial(windowBounds);
+			rootsByNodeId[loadWidgetAtGameStartInfo.IngameRoot] = RootContext.CreateInitial(windowBounds);
+			rootsByNodeId[loadWidgetAtGameStartInfo.EditorRoot] = RootContext.CreateInitial(windowBounds);
+			rootsByNodeId[loadWidgetAtGameStartInfo.GameSaveLoadingRoot] = RootContext.CreateInitial(windowBounds);
+			rootsByNodeId[ModContentLoadScreen.ContentPromptPanelWidgetId] = RootContext.CreateInitial(windowBounds);
+			rootsByNodeId[ModContentLoadScreen.ContentPanelWidgetId] = RootContext.CreateInitial(windowBounds);
+			rootsByNodeId[ModContentLoadScreen.ModContentBackgroundWidgetId] = RootContext.CreateInitial(windowBounds);
+
 			// Gather all the nodes together for evaluation.
 			var chromeLayoutNodes = modData.Manifest.ChromeLayout
 				.SelectMany(filename => MiniYaml.FromStream(modData.DefaultFileSystem.Open(filename), filename))
 				.ToArray();
 
-			return chromeLayoutNodes;
+			// Stitch parent-> child widget relations together, until we have built the whole widget tree.
+			// We loop multiple times, as each time we resolve a parent->child that allows
+			// on the next pass for the children of those children to be resolved.
+			// rootsByNodeId stores the state at the time the widget tree reached that location.
+			// As child widgets might be parented to multiple places in the tree, multiple entrypoints are possible.
+			// e.g. the same widget is used on two different screens. We track the bounds across all branches.
+			var nodesLeftToBuild = chromeLayoutNodes.ToList();
+			while (nodesLeftToBuild.Count > 0)
+			{
+				var builtNodes = new HashSet<MiniYamlNode>();
+				foreach (var node in nodesLeftToBuild)
+				{
+					var nodeId = node.Key.Split('@')[1];
+					if (rootsByNodeId.TryGetValue(nodeId, out var rootContext))
+					{
+						builtNodes.Add(node);
+
+						// Snapshot Entries as it can be mutated.
+						foreach (var entrypoint in rootContext.Entries.ToArray())
+						{
+							var outOfTreeParentChildWidgetIds = new Dictionary<string, HashSet<string>>();
+							BuildChromeTreeBranch(
+								modData, minEffectiveResolution, rootsByNodeId, outOfTreeParentChildWidgetIds,
+								node, entrypoint.Bounds, new Stack<LogicCall>(entrypoint.Calls));
+							BuildChromeTreeBranchForOutOfTree(
+								minEffectiveResolution, rootsByNodeId, outOfTreeParentChildWidgetIds,
+								node, entrypoint.Bounds, new Stack<LogicCall>(entrypoint.Calls));
+						}
+					}
+				}
+
+				if (builtNodes.Count == 0)
+					break;
+
+				nodesLeftToBuild.RemoveAll(builtNodes.Contains);
+			}
+
+			return (minEffectiveResolution, chromeLayoutNodes, rootsByNodeId);
+		}
+
+		static void WalkChromeTree(
+			int2 minEffectiveResolution, MiniYamlNode node, WidgetBounds parentBounds, Stack<LogicCall> logicCallStack,
+			Action<string, string, MiniYamlNode, WidgetBounds> nodeAction)
+		{
+			LogicCall logicCall = null;
+			var logicNode = node.Value.NodeWithKeyOrDefault("Logic");
+			if (logicNode != null)
+			{
+				var logics = logicNode.Value.Value.Split(",").Select(x => x.Trim()).ToArray();
+				var logicArgs = logicNode.Value.ToDictionary();
+				logicCallStack.Push(logicCall = new LogicCall(logics, logicArgs));
+			}
+
+			var bounds = GetWidgetBounds(node, parentBounds, minEffectiveResolution);
+
+			var split = node.Key.Split('@');
+			var nodeType = split[0];
+			var nodeId = split.ElementAtOrDefault(1);
+			nodeAction(nodeType, nodeId, node, bounds);
+
+			foreach (var childNode in node.Value.Nodes)
+				if (childNode.Key == "Children")
+					foreach (var n in childNode.Value.Nodes)
+						WalkChromeTree(minEffectiveResolution, n, bounds, logicCallStack, nodeAction);
+
+			if (logicCall != null)
+				logicCallStack.Pop();
+		}
+
+		static void BuildChromeTreeBranch(
+			ModData modData, int2 minEffectiveResolution,
+			Dictionary<string, RootContext> rootsByNodeId, Dictionary<string, HashSet<string>> outOfTreeParentChildWidgetIds,
+			MiniYamlNode rootNode, WidgetBounds parentBounds, Stack<LogicCall> logicCallStack)
+		{
+			WalkChromeTree(minEffectiveResolution, rootNode, parentBounds, logicCallStack, (nodeType, nodeId, node, bounds) =>
+			{
+				if (nodeId == null)
+					return;
+
+				var windowBounds = new WidgetBounds(0, 0, minEffectiveResolution.X, minEffectiveResolution.Y);
+
+				// Determine parent->child widget links that are created dynamically at runtime.
+				// We can get a static reference of such relationships via derived classes of DynamicWidgets.
+				var parentChildWidgetIds = GetParentChildWidgetIds(
+					modData, logicCallStack, dw => dw.ParentWidgetIdForChildWidgetId, true);
+				var dropdownParentChildWidgetIds = GetMultiParentChildWidgetIds(
+					modData, logicCallStack, dw => dw.ParentDropdownWidgetIdsFromPanelWidgetId, true);
+				var allParentChildWidgetIds = parentChildWidgetIds.Concat(dropdownParentChildWidgetIds)
+					.GroupBy(x => x.Key)
+					.ToDictionary(g => g.Key, g => g.SelectMany(kvp => kvp.Value).ToArray());
+
+				// Determine out-of-tree links. This is where the logic grabs a widget outside the widget it has been given to manage.
+				// e.g. it goes to Ui.Root and finds a widget from there.
+				// This means the logic might be manging something outside its call stack.
+				var localOutOfTreeParentChildWidgetIds = GetParentChildWidgetIds(
+					modData, logicCallStack, dw => dw.OutOfTreeParentWidgetIdForChildWidgetId, false);
+				foreach (var kvp in localOutOfTreeParentChildWidgetIds)
+				{
+					var parentWidgetId = kvp.Key.ParentWidgetId;
+					if (parentWidgetId == "")
+					{
+						// A blank parent indicates the parent is Ui.Root. Add it with the window area.
+						foreach (var childWidgetId in kvp.Value)
+							rootsByNodeId.TryAdd(childWidgetId, RootContext.CreateInitial(windowBounds));
+					}
+					else
+					{
+						// Save this link for later, we'll walk the tree again and link up out-of-tree elements.
+						var entries = outOfTreeParentChildWidgetIds.GetOrAdd(parentWidgetId, _ => new HashSet<string>());
+						entries.UnionWith(kvp.Value);
+					}
+				}
+
+				// Add any windows the logic can open.
+				var windowWidgetIds = GetLogicWidgets(modData, logicCallStack, true)
+					.SelectMany(x => x.DynamicWidgets.WindowWidgetIds);
+				foreach (var windowWidgetId in windowWidgetIds)
+					rootsByNodeId.TryAdd(windowWidgetId, RootContext.CreateInitial(windowBounds));
+
+				// If we've resolved the parent, set up the child bounds for the next pass.
+				// For every logic that is if effect in this call stack we'll
+				// add bounds for every child widget it links up dynamically.
+				foreach (var logic in logicCallStack.SelectMany(c => c.Logics).Distinct())
+					if (allParentChildWidgetIds.TryGetValue((logic, nodeId), out var childOfParentNodeIds))
+						foreach (var childOfParentNodeId in childOfParentNodeIds)
+							rootsByNodeId.GetOrAdd(childOfParentNodeId, _ => RootContext.CreateEmpty()).Add(bounds, logicCallStack);
+			});
+
+			static Dictionary<(string Logic, string ParentWidgetId), string[]> GetParentChildWidgetIds(
+				ModData modData, Stack<LogicCall> logicCallStack,
+				Func<ChromeLogic.DynamicWidgets, IReadOnlyDictionary<string, string>> parentWidgetIdForChildWidgetId,
+				bool logicMustBeOnCallStack)
+			{
+				return GetLogicWidgets(modData, logicCallStack, logicMustBeOnCallStack)
+					.SelectMany(x =>
+						parentWidgetIdForChildWidgetId(x.DynamicWidgets)
+							.GroupBy(kvp => kvp.Value)
+							.Select(g => (x.Logic, ParentWidgetId: g.Key, ChildWidgetIds: g.Select(kvp => kvp.Key).ToArray())))
+					.GroupBy(x => (x.Logic, x.ParentWidgetId))
+					.ToDictionary(g => g.Key, g => g.SelectMany(x => x.ChildWidgetIds).ToArray());
+			}
+
+			static Dictionary<(string Logic, string ParentWidgetId), string[]> GetMultiParentChildWidgetIds(
+				ModData modData, Stack<LogicCall> logicCallStack,
+				Func<ChromeLogic.DynamicWidgets, IReadOnlyDictionary<string, IReadOnlyCollection<string>>> parentWidgetIdsForChildWidgetId,
+				bool logicMustBeOnCallStack)
+			{
+				return GetLogicWidgets(modData, logicCallStack, logicMustBeOnCallStack)
+					.SelectMany(x =>
+						parentWidgetIdsForChildWidgetId(x.DynamicWidgets)
+							.SelectMany(kvp => kvp.Value.Select(v => (ChildWidgetId: kvp.Key, ParentWidgetId: v)))
+							.GroupBy(x => x.ParentWidgetId)
+							.Select(g => (x.Logic, ParentWidgetId: g.Key, ChildWidgetIds: g.Select(x => x.ChildWidgetId).ToArray())))
+					.GroupBy(x => (x.Logic, x.ParentWidgetId))
+					.ToDictionary(g => g.Key, g => g.SelectMany(x => x.ChildWidgetIds).ToArray());
+			}
+
+			static IEnumerable<(string Logic, ChromeLogic.DynamicWidgets DynamicWidgets)> GetLogicWidgets(
+				ModData modData, Stack<LogicCall> logicCallStack, bool logicMustBeOnCallStack)
+			{
+				return modData.ObjectCreator.GetTypes()
+					.Where(t =>
+						t.IsSubclassOf(typeof(ChromeLogic.DynamicWidgets)) &&
+						typeof(ChromeLogic).IsAssignableFrom(t.ReflectedType))
+					.SelectMany(t =>
+					{
+						var reflectedTypeName = t.ReflectedType.Name;
+						return logicCallStack
+							.Where(c => !logicMustBeOnCallStack || c.Logics.Contains(reflectedTypeName))
+							.Select(c =>
+								modData.ObjectCreator.CreateObject<ChromeLogic.DynamicWidgets>(
+									$"{reflectedTypeName}+{t.Name}",
+									new Dictionary<string, object> { { "logicArgs", c.LogicArgs } }))
+							.Select(dw => (Logic: reflectedTypeName, DynamicWidgets: dw));
+					});
+			}
+		}
+
+		static void BuildChromeTreeBranchForOutOfTree(
+			int2 minEffectiveResolution,
+			Dictionary<string, RootContext> rootsByNodeId, Dictionary<string, HashSet<string>> outOfTreeParentChildWidgetIds,
+			MiniYamlNode rootNode, WidgetBounds parentBounds, Stack<LogicCall> logicCallStack)
+		{
+			WalkChromeTree(minEffectiveResolution, rootNode, parentBounds, logicCallStack, (nodeType, nodeId, node, bounds) =>
+			{
+				// Tooltips operate out-of-tree, as the widget tree has a single container widget for all tooltips.
+				var tooltipContainer = node.Value.NodeWithKeyOrDefault("TooltipContainer");
+				var tooltipTemplate = node.Value.NodeWithKeyOrDefault("TooltipTemplate");
+				if (tooltipContainer != null || tooltipTemplate != null)
+				{
+					var container = tooltipContainer?.Value.Value;
+					var template = tooltipTemplate?.Value.Value;
+
+					// HACK: Hardcode the default values for nodes that have a default in code and don't force a value in YAML.
+					container ??= "TOOLTIP_CONTAINER"; // Fallback, if a new type ever gets added that doesn't require this to be set in YAML.
+					template ??= nodeType switch
+					{
+						"ClientTooltipRegion" =>
+							node.Value.NodeWithKey("Template").Value.Value, // Breaks the usual convention of 'TooltipTemplate'.
+						"Button" or "DropDownButton" or "Checkbox" or "MenuButton" or "WorldButton" or "ProductionTypeButton" or "ScrollItem" =>
+							"BUTTON_TOOLTIP",
+						"ObserverProductionIcons" or "ProductionPalette" =>
+							"PRODUCTION_TOOLTIP",
+						"ObserverSupportPowerIcons" or "SupportPowers" =>
+							"SUPPORT_POWER_TOOLTIP",
+						"ObserverArmyIcons" =>
+							"ARMY_TOOLTIP",
+						"MapPreview" =>
+							"SPAWN_TOOLTIP",
+						"ViewportController" =>
+							"WORLD_TOOLTIP",
+						_ => "SIMPLE_TOOLTIP", // Fallback, for any type we haven't got the correct hardcoded value for.
+					};
+
+					// Add discovered tooltips. Tooltips determine their own size so the bounds are irrelevant.
+					// However adding them to the roots list allows us to mark them as widgets with known parents.
+					foreach (var logic in logicCallStack.SelectMany(c => c.Logics).Distinct())
+						rootsByNodeId.GetOrAdd(template, _ => RootContext.CreateEmpty()).Add(new WidgetBounds(0, 0, 0, 0), logicCallStack);
+				}
+
+				if (nodeId == null)
+					return;
+
+				// For out-of-tree widgets, assume the full window bounds is available to them.
+				// As out-of-tree widgets might be managed by a logic outside their call stack,
+				// we ignore the callstack when making checks here.
+				var windowBounds = new WidgetBounds(0, 0, minEffectiveResolution.X, minEffectiveResolution.Y);
+				if (outOfTreeParentChildWidgetIds.TryGetValue(nodeId, out var childOfParentNodeIds))
+					foreach (var childOfParentNodeId in childOfParentNodeIds)
+						rootsByNodeId.GetOrAdd(childOfParentNodeId, _ => RootContext.CreateEmpty()).Add(windowBounds, logicCallStack);
+			});
 		}
 
 		static void CheckChrome(
-			MiniYamlNode rootNode,
+			MiniYamlNode rootNode, Translation translation, string language,
+			Action<string> emitError, Action<string> emitWarning,
 			Dictionary<(string WidgetName, string FieldName), TranslationReferenceAttribute> translationReferencesByWidgetField,
-			TranslationKeys usedKeys)
+			IReadOnlyCollection<WidgetBounds> allParentBounds,
+			TranslationKeys usedKeys,
+			int2 minEffectiveResolution,
+			Dictionary<string, SpriteFont> fonts)
 		{
+			var allWidgetBounds = allParentBounds.Select(parentBounds => GetWidgetBounds(rootNode, parentBounds, minEffectiveResolution));
+
+			// HACK: Some widgets that display icons don't bother with bounds, but instead use a icon size.
+			// So we need to check if text fits on the icon, rather than within the bounds.
+			var iconSize = rootNode.Value.NodeWithKeyOrDefault("IconSize")?.Value.Value;
+			if (iconSize != null)
+			{
+				var iconSizeValues = iconSize.Split(",").Select(int.Parse).ToArray();
+				allWidgetBounds = allWidgetBounds.Select(wb => new WidgetBounds(wb.X, wb.Y, iconSizeValues[0], iconSizeValues[1]));
+			}
+
+			var allWidgetBoundsArray = allWidgetBounds.ToArray();
+
 			var nodeType = rootNode.Key.Split('@')[0];
 			foreach (var childNode in rootNode.Value.Nodes)
 			{
@@ -348,12 +676,61 @@ namespace OpenRA.Mods.Common.Lint
 
 				var key = childNode.Value.Value;
 				usedKeys.Add(key, translationReference, $"Widget `{rootNode.Key}` field `{childType}` in {rootNode.Location}");
+
+				if (key == null)
+					continue;
+
+				// HACK: Tooltips don't display on the widget directly, don't validate their sizes.
+				if (childType == "TooltipText" || childType == "TooltipDesc")
+					continue;
+
+				// HACK: Hardcode how each widget determines available fonts.
+				var fontName = nodeType switch
+				{
+					"Button" or "DropDownButton" or "Checkbox" or "MenuButton" or "WorldButton" =>
+						rootNode.Value.NodeWithKeyOrDefault("Font")?.Value.Value ?? ChromeMetrics.Get<string>("ButtonFont"),
+					"Label" or "LabelWithHighlight" or "LabelForInput" =>
+						rootNode.Value.NodeWithKeyOrDefault("Font")?.Value.Value ?? ChromeMetrics.Get<string>("TextFont"),
+					"SupportPowers" =>
+						rootNode.Value.NodeWithKeyOrDefault("OverlayFont")?.Value.Value ?? "TinyBold",
+					"ProductionPalette" =>
+						rootNode.Value.NodeWithKeyOrDefault("OverlayFont")?.Value.Value ?? "TinyBold",
+					_ => null,
+				};
+				if (fontName == null)
+				{
+					emitWarning(
+						$"`{key}` defined by `{rootNode.Key}` in field `{childType}` in {rootNode.Location} " +
+						"is not a widget type whose font is recognised, validation performed using TextFont from ChromeMetrics.");
+					fontName = ChromeMetrics.Get<string>("TextFont");
+				}
+
+				var font = fonts[fontName];
+				var text = translation.GetString(key);
+				foreach (var widgetBounds in allWidgetBoundsArray)
+				{
+					var widgetSize = new int2(widgetBounds.Width, widgetBounds.Height);
+
+					// HACK: Apply the WordWrap that labels can apply.
+					if ((nodeType == "Label" || nodeType == "LabelWithHighlight") &&
+						bool.Parse(rootNode.Value.NodeWithKeyOrDefault("WordWrap")?.Value.Value ?? bool.FalseString))
+						text = WidgetUtils.WrapText(text, widgetSize.X, font);
+
+					var textSize = font.Measure(text);
+					if (textSize.X > widgetSize.X || textSize.Y > widgetSize.Y)
+						emitWarning(
+							$"`{key}` defined by `{rootNode.Key}` in field `{childType}` in {rootNode.Location} " +
+							$"has value `{text}` in `{language}` translation. Text is too large for widget. " +
+							$"Text is {textSize}. Widget is {widgetSize}.");
+				}
 			}
 
 			foreach (var childNode in rootNode.Value.Nodes)
 				if (childNode.Key == "Children")
 					foreach (var n in childNode.Value.Nodes)
-						CheckChrome(n, translationReferencesByWidgetField, usedKeys);
+						CheckChrome(
+							n, translation, language, emitError, emitWarning, translationReferencesByWidgetField,
+							allWidgetBoundsArray, usedKeys, minEffectiveResolution, fonts);
 		}
 
 		static HashSet<string> CheckKeys(
@@ -502,6 +879,53 @@ namespace OpenRA.Mods.Common.Lint
 			public ILookup<string, string> KeysWithContext => keysWithContext.OrderBy(x => x.Key).ToLookup(x => x.Key, x => x.Context);
 
 			public IEnumerable<string> EmptyKeyContexts => contextForEmptyKeys;
+		}
+
+		class LogicCall
+		{
+			public string[] Logics { get; }
+
+			public Dictionary<string, MiniYaml> LogicArgs { get; }
+
+			public LogicCall(string[] logics, Dictionary<string, MiniYaml> logicArgs)
+			{
+				Logics = logics;
+				LogicArgs = logicArgs;
+			}
+		}
+
+		class RootContext
+		{
+			public sealed class Entry
+			{
+				public WidgetBounds Bounds { get; }
+				public LogicCall[] Calls { get; }
+
+				public Entry(WidgetBounds bounds, LogicCall[] calls)
+				{
+					Bounds = bounds;
+					Calls = calls;
+				}
+			}
+
+			public List<Entry> Entries { get; }
+
+			RootContext(List<Entry> entries) { Entries = entries; }
+
+			public static RootContext CreateEmpty()
+			{
+				return new RootContext(new List<Entry>());
+			}
+
+			public static RootContext CreateInitial(WidgetBounds bounds)
+			{
+				return new RootContext(new List<Entry>() { new(bounds, Array.Empty<LogicCall>()) });
+			}
+
+			public void Add(WidgetBounds bounds, IEnumerable<LogicCall> calls)
+			{
+				Entries.Add(new Entry(bounds, calls.ToArray()));
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.LoadScreens
 				}
 				catch { }
 
-				if (ReplayUtils.PromptConfirmReplayCompatibility(replayMeta, Game.ModData, Game.LoadShellMap))
+				if (ReplayUtils.PromptConfirmReplayCompatibility(new ReplayBrowserLogic.ReplayBrowserLogicDynamicWidgets(), replayMeta, Game.ModData, Game.LoadShellMap))
 					Game.JoinReplay(Launch.Replay);
 
 				if (replayMeta != null)

--- a/OpenRA.Mods.Common/LoadScreens/ModContentLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/ModContentLoadScreen.cs
@@ -21,6 +21,10 @@ namespace OpenRA.Mods.Common.LoadScreens
 {
 	public sealed class ModContentLoadScreen : SheetLoadScreen
 	{
+		public const string ContentPromptPanelWidgetId = "CONTENT_PROMPT_PANEL";
+		public const string ContentPanelWidgetId = "CONTENT_PANEL";
+		public const string ModContentBackgroundWidgetId = "MODCONTENT_BACKGROUND";
+
 		Sprite sprite;
 		Rectangle bounds;
 
@@ -54,7 +58,7 @@ namespace OpenRA.Mods.Common.LoadScreens
 
 			var content = selectedMod.Get<ModContent>(Game.ModData.ObjectCreator);
 
-			Ui.LoadWidget("MODCONTENT_BACKGROUND", Ui.Root, new WidgetArgs());
+			Ui.LoadWidgetUnchecked(ModContentBackgroundWidgetId, Ui.Root, new WidgetArgs());
 
 			if (!IsModInstalled(content))
 			{
@@ -65,7 +69,7 @@ namespace OpenRA.Mods.Common.LoadScreens
 					{ "content", content },
 				};
 
-				Ui.OpenWindow("CONTENT_PROMPT_PANEL", widgetArgs);
+				Ui.OpenWindowUnchecked(ContentPromptPanelWidgetId, widgetArgs);
 			}
 			else
 			{
@@ -76,7 +80,7 @@ namespace OpenRA.Mods.Common.LoadScreens
 					{ "onCancel", () => Game.RunAfterTick(() => Game.InitializeMod(modId, new Arguments())) }
 				};
 
-				Ui.OpenWindow("CONTENT_PANEL", widgetArgs);
+				Ui.OpenWindowUnchecked(ContentPanelWidgetId, widgetArgs);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.Scripting
 		public void PlayMovieFullscreen(string videoFileName, [ScriptEmmyTypeOverride("fun()")] LuaFunction onPlayComplete = null)
 		{
 			var onComplete = WrapOnPlayComplete(onPlayComplete);
-			Media.PlayFMVFullscreen(world, videoFileName, onComplete);
+			Media.PlayFMVFullscreen(null, world, videoFileName, onComplete);
 		}
 
 		[Desc("Play a video in the radar window. File name has to include the file extension.")]

--- a/OpenRA.Mods.Common/Scripting/Media.cs
+++ b/OpenRA.Mods.Common/Scripting/Media.cs
@@ -18,9 +18,11 @@ namespace OpenRA.Mods.Common.Scripting
 {
 	public static class Media
 	{
-		public static void PlayFMVFullscreen(World w, string videoFileName, Action onComplete)
+		public static void PlayFMVFullscreen(ChromeLogic.DynamicWidgets dynamicWidgets, World w, string videoFileName, Action onComplete)
 		{
-			var playerRoot = Game.OpenWindow(w, "FMVPLAYER");
+			var playerRoot = dynamicWidgets == null
+				? Ui.OpenWindowUnchecked("FMVPLAYER", new WidgetArgs())
+				: dynamicWidgets.OpenWindow("FMVPLAYER", new WidgetArgs());
 			var player = playerRoot.Get<VideoPlayerWidget>("PLAYER");
 
 			try

--- a/OpenRA.Mods.Common/Traits/World/ColorPickerManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/ColorPickerManager.cs
@@ -175,11 +175,9 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		void IColorPickerManagerInfo.ShowColorDropDown(
-			DropDownButtonWidget dropdownButton,
-			Color initialColor,
-			string initialFaction,
-			WorldRenderer worldRenderer,
-			Action<Color> onExit)
+			ChromeLogic.DynamicWidgets dynamicWidgets, DropDownButtonWidget dropdownButton,
+			Color initialColor, string initialFaction,
+			WorldRenderer worldRenderer, Action<Color> onExit)
 		{
 			dropdownButton.RemovePanel();
 
@@ -217,14 +215,14 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			var finalColor = initialColor;
-			var colorChooser = Game.LoadWidget(worldRenderer.World, "COLOR_CHOOSER", null, new WidgetArgs()
+			var colorChooser = dynamicWidgets.LoadWidgetAsDropdownPanel("COLOR_CHOOSER", new WidgetArgs()
 			{
 				{ "onChange", (Action<Color>)(c => { finalColor = c; OnColorPickerColorUpdate(c); }) },
 				{ "initialColor", initialColor },
 				{ "extraLogic", (Action<Widget>)AddActorPreview },
 			});
 
-			dropdownButton.AttachPanel(colorChooser, () => onExit(finalColor));
+			dynamicWidgets.AttachPanel(dropdownButton, colorChooser, () => onExit(finalColor));
 		}
 
 		#endregion

--- a/OpenRA.Mods.Common/Traits/World/LoadWidgetAtGameStart.cs
+++ b/OpenRA.Mods.Common/Traits/World/LoadWidgetAtGameStart.cs
@@ -53,10 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.ClearRoot)
 				Ui.ResetAll();
 
-			Ui.OpenWindow(info.GameSaveLoadingRoot, new WidgetArgs()
-			{
-				{ "world", world }
-			});
+			Ui.OpenWindowUnchecked(info.GameSaveLoadingRoot, Game.ExtendWidgetArgs(new WidgetArgs()));
 		}
 
 		void IWorldLoaded.WorldLoaded(World world, WorldRenderer wr)
@@ -67,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 			var widget = world.Type == WorldType.Shellmap ? info.ShellmapRoot :
 				world.Type == WorldType.Editor ? info.EditorRoot : info.IngameRoot;
 
-			root = Game.LoadWidget(world, widget, Ui.Root, new WidgetArgs());
+			root = Game.LoadWidgetUnchecked(widget, Ui.Root, new WidgetArgs());
 
 			// The Lua API requires the UI to available, so hide it instead
 			if (world.IsLoadingGameSave)

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -20,6 +20,7 @@ using OpenRA.Mods.Common.Widgets;
 using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Traits;
+using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Traits
 {
@@ -379,7 +380,9 @@ namespace OpenRA.Mods.Common.Traits
 		Color RandomValidColor(MersenneTwister random, IReadOnlyCollection<Color> terrainColors, IReadOnlyCollection<Color> playerColors);
 		Color MakeValid(
 			Color color, MersenneTwister random, IReadOnlyCollection<Color> terrainColors, IReadOnlyCollection<Color> playerColors, Action<string> onError = null);
-		void ShowColorDropDown(DropDownButtonWidget dropdownButton, Color initialColor, string initialFaction, WorldRenderer worldRenderer, Action<Color> onExit);
+		void ShowColorDropDown(
+			ChromeLogic.DynamicWidgets dynamicWidgets,
+			DropDownButtonWidget dropdownButton, Color initialColor, string initialFaction, WorldRenderer worldRenderer, Action<Color> onExit);
 	}
 
 	public interface ICallForTransport

--- a/OpenRA.Mods.Common/Widgets/ClientTooltipRegionWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ClientTooltipRegionWidget.cs
@@ -59,8 +59,6 @@ namespace OpenRA.Mods.Common.Widgets
 
 			tooltipContainer.Value.SetTooltip(Template, new WidgetArgs()
 			{
-				{ "orderManager", orderManager },
-				{ "worldRenderer", worldRenderer },
 				{ "client", client }
 			});
 		}

--- a/OpenRA.Mods.Common/Widgets/ConfirmationDialogs.cs
+++ b/OpenRA.Mods.Common/Widgets/ConfirmationDialogs.cs
@@ -18,6 +18,7 @@ namespace OpenRA.Mods.Common.Widgets
 	public static class ConfirmationDialogs
 	{
 		public static void ButtonPrompt(
+			ChromeLogic.DynamicWidgets dynamicWidgets,
 			ModData modData,
 			string title,
 			string text,
@@ -31,7 +32,7 @@ namespace OpenRA.Mods.Common.Widgets
 			string otherText = null)
 		{
 			var promptName = onOther != null ? "THREEBUTTON_PROMPT" : "TWOBUTTON_PROMPT";
-			var prompt = Ui.OpenWindow(promptName);
+			var prompt = dynamicWidgets.OpenWindow(promptName, new WidgetArgs());
 			var confirmButton = prompt.GetOrNull<ButtonWidget>("CONFIRM_BUTTON");
 			var cancelButton = prompt.GetOrNull<ButtonWidget>("CANCEL_BUTTON");
 			var otherButton = prompt.GetOrNull<ButtonWidget>("OTHER_BUTTON");
@@ -104,13 +105,15 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 		}
 
-		public static void TextInputPrompt(ModData modData,
+		public static void TextInputPrompt(
+			ChromeLogic.DynamicWidgets dynamicWidgets,
+			ModData modData,
 			string title, string prompt, string initialText,
 			Action<string> onAccept, Action onCancel = null,
 			string acceptText = null, string cancelText = null,
 			Func<string, bool> inputValidator = null)
 		{
-			var panel = Ui.OpenWindow("TEXT_INPUT_PROMPT");
+			var panel = dynamicWidgets.OpenWindow("TEXT_INPUT_PROMPT", new WidgetArgs());
 			Func<bool> doValidate = null;
 			ButtonWidget acceptButton = null, cancelButton = null;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/DirectConnectLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/DirectConnectLogic.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using OpenRA.Network;
 using OpenRA.Widgets;
@@ -19,6 +20,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class DirectConnectLogic : ChromeLogic
 	{
 		static readonly Action DoNothing = () => { };
+
+		public class DirectConnectLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } =
+				new HashSet<string>
+				{
+					"CONNECTING_PANEL",
+				};
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } = EmptyDictionary;
+		}
+
+		readonly DirectConnectLogicDynamicWidgets dynamicWidgets = new();
 
 		[ObjectCreator.UseCtor]
 		public DirectConnectLogic(Widget widget, Action onExit, Action openLobby, ConnectionTarget directConnectEndPoint)
@@ -52,7 +65,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Game.Settings.Player.LastServer = $"{ipField.Text}:{port}";
 				Game.Settings.Save();
 
-				ConnectionLogic.Connect(new ConnectionTarget(ipField.Text, port), "", () => { Ui.CloseWindow(); openLobby(); }, DoNothing);
+				ConnectionLogic.Connect(dynamicWidgets, new ConnectionTarget(ipField.Text, port), "", () => { Ui.CloseWindow(); openLobby(); }, DoNothing);
 			};
 
 			panel.Get<ButtonWidget>("BACK_BUTTON").OnClick = () => { Ui.CloseWindow(); onExit(); };
@@ -64,7 +77,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				widget.Visible = false;
 				Game.RunAfterTick(() =>
 				{
-					ConnectionLogic.Connect(directConnectEndPoint, "", () => { Ui.CloseWindow(); openLobby(); }, DoNothing);
+					ConnectionLogic.Connect(dynamicWidgets, directConnectEndPoint, "", () => { Ui.CloseWindow(); openLobby(); }, DoNothing);
 					widget.Visible = true;
 				});
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/DisconnectWatcherLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/DisconnectWatcherLogic.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Network;
 using OpenRA.Widgets;
 
@@ -16,6 +17,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class DisconnectWatcherLogic : ChromeLogic
 	{
+		public class DisconnectWatcherLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = new HashSet<string>
+			{
+				"CONNECTIONFAILED_PANEL",
+			};
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } = EmptyDictionary;
+		}
+
+		readonly DisconnectWatcherLogicDynamicWidgets dynamicWidgets = new();
+
 		[ObjectCreator.UseCtor]
 		public DisconnectWatcherLogic(Widget widget, World world, OrderManager orderManager)
 		{
@@ -28,9 +40,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (disconnected || connection.ConnectionState != ConnectionState.NotConnected)
 					return;
 
-				Game.RunAfterTick(() => Ui.OpenWindow("CONNECTIONFAILED_PANEL", new WidgetArgs
+				Game.RunAfterTick(() => dynamicWidgets.OpenWindow("CONNECTIONFAILED_PANEL", new WidgetArgs
 				{
-					{ "orderManager", orderManager },
 					{ "password", CurrentServerSettings.Password },
 					{ "connection", connection },
 					{ "onAbort", null },

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -34,6 +34,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[Flags]
 		enum ActorIDStatus { Normal = 0, Duplicate = 1, Empty = 3 }
 
+		public class ActorEditLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = EmptySet;
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } = EmptyDictionary;
+			public override IReadOnlyDictionary<string, IReadOnlyCollection<string>> ParentDropdownWidgetIdsFromPanelWidgetId { get; } =
+				new Dictionary<string, IReadOnlyCollection<string>>
+				{
+					{ "LABEL_DROPDOWN_TEMPLATE", new[] { "OPTION" } },
+				};
+		}
+
+		readonly ActorEditLogicDynamicWidgets dynamicWidgets = new();
 		readonly WorldRenderer worldRenderer;
 		readonly EditorActorLayer editorActorLayer;
 		readonly EditorActionManager editorActionManager;
@@ -213,7 +225,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ownerDropdown.OnClick = () =>
 				{
 					var owners = editorActorLayer.Players.Players.Values.OrderBy(p => p.Name);
-					ownerDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 270, owners, SetupItem);
+					dynamicWidgets.ShowDropDown(ownerDropdown, "LABEL_DROPDOWN_TEMPLATE", 270, owners, SetupItem);
 				};
 
 				initContainer.Bounds.Height += ownerContainer.Bounds.Height;
@@ -315,7 +327,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						}
 
 						dropdown.GetText = () => labels[ddo.GetValue(SelectedActor, labels)];
-						dropdown.OnClick = () => dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 270, labels, DropdownSetup);
+						dropdown.OnClick = () => dynamicWidgets.ShowDropDown(dropdown, "LABEL_DROPDOWN_TEMPLATE", 270, labels, DropdownSetup);
 
 						initContainer.AddChild(dropdownContainer);
 					}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -40,6 +40,20 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 		}
 
+		public class ActorSelectorLogicDynamicWidgets : CommonSelectorLogicDynamicWidgets
+		{
+			public override IReadOnlyDictionary<string, IReadOnlyCollection<string>> ParentDropdownWidgetIdsFromPanelWidgetId { get; }
+			public ActorSelectorLogicDynamicWidgets()
+			{
+				var parentDropdownWidgetIdsFromPanelWidgetId =
+					new Dictionary<string, IReadOnlyCollection<string>>(base.ParentDropdownWidgetIdsFromPanelWidgetId);
+				var existing = parentDropdownWidgetIdsFromPanelWidgetId.GetOrAdd("LABEL_DROPDOWN_TEMPLATE", Array.Empty<string>());
+				parentDropdownWidgetIdsFromPanelWidgetId["LABEL_DROPDOWN_TEMPLATE"] = existing.Append("OWNERS_DROPDOWN").ToArray();
+				ParentDropdownWidgetIdsFromPanelWidgetId = parentDropdownWidgetIdsFromPanelWidgetId;
+			}
+		}
+
+		readonly ActorSelectorLogicDynamicWidgets dynamicWidgets = new();
 		readonly DropDownButtonWidget ownersDropDown;
 		readonly Ruleset mapRules;
 		readonly ActorSelectorActor[] allActors;
@@ -77,7 +91,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			ownersDropDown.OnClick = () =>
 			{
 				var owners = editorLayer.Players.Players.Values.OrderBy(p => p.Name);
-				ownersDropDown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 270, owners, SetupItem);
+				dynamicWidgets.ShowDropDown(ownersDropDown, "LABEL_DROPDOWN_TEMPLATE", 270, owners, SetupItem);
 			};
 
 			var selectedOwnerName = selectedOwner.Name;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/CommonSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/CommonSelectorLogic.cs
@@ -31,6 +31,19 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference]
 		const string Multiple = "options-common-selector.multiple";
 
+		public class CommonSelectorLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = EmptySet;
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } = EmptyDictionary;
+			public override IReadOnlyDictionary<string, IReadOnlyCollection<string>> ParentDropdownWidgetIdsFromPanelWidgetId =>
+				new Dictionary<string, IReadOnlyCollection<string>>
+				{
+					{ "CATEGORY_FILTER_PANEL", new[] { "CATEGORIES_DROPDOWN" } },
+				};
+		}
+
+		readonly CommonSelectorLogicDynamicWidgets dynamicWidgets = new();
+
 		protected readonly Widget Widget;
 		protected readonly ModData ModData;
 		protected readonly TextFieldWidget SearchTextField;
@@ -101,7 +114,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				SearchTextField?.YieldKeyboardFocus();
 
 				categorySelector.RemovePanel();
-				categorySelector.AttachPanel(CreateCategoriesPanel(Panel));
+				var panel = CreateCategoriesPanel(dynamicWidgets, Panel);
+				dynamicWidgets.AttachPanel(categorySelector, panel);
 			};
 		}
 
@@ -117,9 +131,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SearchTextField.YieldKeyboardFocus();
 		}
 
-		protected Widget CreateCategoriesPanel(ScrollPanelWidget panel)
+		protected Widget CreateCategoriesPanel(
+			CommonSelectorLogicDynamicWidgets dynamicWidgets,
+			ScrollPanelWidget panel)
 		{
-			var categoriesPanel = Ui.LoadWidget("CATEGORY_FILTER_PANEL", null, new WidgetArgs());
+			var categoriesPanel = dynamicWidgets.LoadWidgetAsDropdownPanel("CATEGORY_FILTER_PANEL", new WidgetArgs());
 			var categoryTemplate = categoriesPanel.Get<CheckboxWidget>("CATEGORY_TEMPLATE");
 
 			var selectButtons = categoriesPanel.Get<ContainerWidget>("SELECT_CATEGORIES_BUTTONS");

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapMarkerTilesLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapMarkerTilesLogic.cs
@@ -31,6 +31,20 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference]
 		const string MarkerMirrorModeRotateTranslation = "mirror-mode.rotate";
 
+		public class MapMarkerTilesLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = EmptySet;
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } = EmptyDictionary;
+
+			public override IReadOnlyDictionary<string, IReadOnlyCollection<string>> ParentDropdownWidgetIdsFromPanelWidgetId { get; } =
+				new Dictionary<string, IReadOnlyCollection<string>>
+				{
+					{ "LABEL_DROPDOWN_TEMPLATE", new[] { "MODE_DROPDOWN", "FLIP_NUM_SIDES_DROPDOWN" } },
+				};
+		}
+
+		readonly MapMarkerTilesLogicDynamicWidgets dynamicWidgets = new();
+
 		readonly EditorActionManager editorActionManager;
 		readonly MarkerLayerOverlay markerLayerTrait;
 		readonly ScrollPanelWidget tileColorPanel;
@@ -235,7 +249,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var options = new[] { MarkerTileMirrorMode.None, MarkerTileMirrorMode.Flip, MarkerTileMirrorMode.Rotate };
-			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 150, options, SetupItem);
+			dynamicWidgets.ShowDropDown(dropdown, "LABEL_DROPDOWN_TEMPLATE", 150, options, SetupItem);
 		}
 
 		void ShowFlipNumSidesDropDown(DropDownButtonWidget dropdown)
@@ -251,7 +265,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var options = new[] { 2, 4 };
-			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 150, options, SetupItem);
+			dynamicWidgets.ShowDropDown(dropdown, "LABEL_DROPDOWN_TEMPLATE", 150, options, SetupItem);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapOverlaysLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapOverlaysLogic.cs
@@ -30,6 +30,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Marker = 4,
 		}
 
+		public class MapOverlaysLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = EmptySet;
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } =
+				new Dictionary<string, string>
+				{
+					{ "TOOLS_WIDGETS", "OVERLAY_BUTTON" },
+				};
+			public override IReadOnlyDictionary<string, IReadOnlyCollection<string>> ParentDropdownWidgetIdsFromPanelWidgetId { get; } =
+				new Dictionary<string, IReadOnlyCollection<string>>
+				{
+					{ "OVERLAY_PANEL", new[] { "OVERLAY_BUTTON" } },
+				};
+		}
+
+		readonly MapOverlaysLogicDynamicWidgets dynamicWidgets = new();
 		readonly TerrainGeometryOverlay terrainGeometryTrait;
 		readonly BuildableTerrainOverlay buildableTerrainTrait;
 		readonly MarkerLayerOverlay markerLayerTrait;
@@ -88,14 +104,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				overlayDropdown.OnMouseDown = _ =>
 				{
 					overlayDropdown.RemovePanel();
-					overlayDropdown.AttachPanel(overlayPanel);
+					dynamicWidgets.AttachPanel(overlayDropdown, overlayPanel);
 				};
 			}
 		}
 
 		Widget CreateOverlaysPanel()
 		{
-			var categoriesPanel = Ui.LoadWidget("OVERLAY_PANEL", null, new WidgetArgs());
+			var categoriesPanel = dynamicWidgets.LoadWidgetAsDropdownPanel("OVERLAY_PANEL", new WidgetArgs());
 			var categoryTemplate = categoriesPanel.Get<CheckboxWidget>("CATEGORY_TEMPLATE");
 
 			MapOverlays[] allCategories = { MapOverlays.Grid, MapOverlays.Buildable, MapOverlays.Marker };

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapToolsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapToolsLogic.cs
@@ -20,11 +20,24 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference]
 		const string MarkerTiles = "label-tool-marker-tiles";
 
+		public class MapToolsLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = EmptySet;
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } = EmptyDictionary;
+
+			public override IReadOnlyDictionary<string, IReadOnlyCollection<string>> ParentDropdownWidgetIdsFromPanelWidgetId { get; } =
+				new Dictionary<string, IReadOnlyCollection<string>>
+				{
+					{ "LABEL_DROPDOWN_TEMPLATE", new[] { "TOOLS_DROPDOWN" } },
+				};
+		}
+
 		enum MapTool
 		{
 			MarkerTiles
 		}
 
+		readonly MapToolsLogicDynamicWidgets dynamicWidgets = new();
 		readonly DropDownButtonWidget toolsDropdown;
 		readonly Dictionary<MapTool, string> toolNames = new()
 		{
@@ -62,7 +75,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var options = new[] { MapTool.MarkerTiles };
-			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 150, options, SetupItem);
+			dynamicWidgets.ShowDropDown(dropdown, "LABEL_DROPDOWN_TEMPLATE", 150, options, SetupItem);
 		}
 
 		void SelectTool(MapTool tool)

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Terrain;
 using OpenRA.Widgets;
@@ -18,6 +19,21 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class NewMapLogic : ChromeLogic
 	{
+		public class NewMapLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = new HashSet<string>
+			{
+				"SAVE_MAP_PANEL",
+			};
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } = EmptyDictionary;
+			public override IReadOnlyDictionary<string, IReadOnlyCollection<string>> ParentDropdownWidgetIdsFromPanelWidgetId { get; } =
+				new Dictionary<string, IReadOnlyCollection<string>>
+				{
+					{ "LABEL_DROPDOWN_TEMPLATE", new[] { "TILESET" } },
+				};
+		}
+
+		readonly NewMapLogicDynamicWidgets dynamicWidgets = new();
 		readonly Widget panel;
 
 		[ObjectCreator.UseCtor]
@@ -41,7 +57,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var firstTileset = tilesets.First();
 			tilesetDropDown.GetText = () => firstTileset;
 			tilesetDropDown.OnClick = () =>
-				tilesetDropDown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 210, tilesets, SetupItem);
+				dynamicWidgets.ShowDropDown(tilesetDropDown, "LABEL_DROPDOWN_TEMPLATE", 210, tilesets, SetupItem);
 
 			var widthTextField = panel.Get<TextFieldWidget>("WIDTH");
 			var heightTextField = panel.Get<TextFieldWidget>("HEIGHT");
@@ -78,12 +94,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					onSelect(uid);
 				};
 
-				Ui.OpenWindow("SAVE_MAP_PANEL", new WidgetArgs()
+				dynamicWidgets.OpenWindow("SAVE_MAP_PANEL", new WidgetArgs()
 				{
 					{ "onSave", afterSave },
 					{ "onExit", () => { Ui.CloseWindow(); onExit(); } },
 					{ "map", map },
-					{ "world", world },
 					{ "playerDefinitions", map.PlayerDefinitions },
 					{ "actorDefinitions", map.ActorDefinitions }
 				});

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
@@ -21,6 +21,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class TileSelectorLogic : CommonSelectorLogic
 	{
+		// Required so the linter can detect we use the same DynamicWidgets as our base class.
+		public class TileSelectorLogicDynamicWidgets : CommonSelectorLogicDynamicWidgets { }
+
 		sealed class TileSelectorTemplate
 		{
 			public readonly TerrainTemplateInfo Template;

--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -60,6 +60,19 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference]
 		const string OverwriteSaveAccpet = "dialog-overwrite-save.confirm";
 
+		public class GameSaveBrowserLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } =
+				new HashSet<string>
+				{
+					"TEXT_INPUT_PROMPT",
+					"TWOBUTTON_PROMPT",
+					"THREEBUTTON_PROMPT",
+				};
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } = EmptyDictionary;
+		}
+
+		readonly GameSaveBrowserLogicDynamicWidgets dynamicWidgets = new();
 		readonly Widget panel;
 		readonly ScrollPanelWidget gameList;
 		readonly TextFieldWidget saveTextField;
@@ -140,7 +153,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var initialName = Path.GetFileNameWithoutExtension(selectedSave);
 				var invalidChars = Path.GetInvalidFileNameChars();
 
-				ConfirmationDialogs.TextInputPrompt(modData,
+				ConfirmationDialogs.TextInputPrompt(
+					dynamicWidgets,
+					modData,
 					RenameSaveTitle,
 					RenameSavePrompt,
 					initialName,
@@ -170,7 +185,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			deleteButton.IsDisabled = () => selectedSave == null;
 			deleteButton.OnClick = () =>
 			{
-				ConfirmationDialogs.ButtonPrompt(modData,
+				ConfirmationDialogs.ButtonPrompt(
+					dynamicWidgets,
+					modData,
 					title: DeleteSaveTitle,
 					text: DeleteSavePrompt,
 					textArguments: Translation.Arguments("save", Path.GetFileNameWithoutExtension(selectedSave)),
@@ -194,7 +211,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			deleteAllButton.IsDisabled = () => games.Count == 0;
 			deleteAllButton.OnClick = () =>
 			{
-				ConfirmationDialogs.ButtonPrompt(modData,
+				ConfirmationDialogs.ButtonPrompt(
+					dynamicWidgets,
+					modData,
 					title: DeleteAllSavesTitle,
 					text: DeleteAllSavesPrompt,
 					textArguments: Translation.Arguments("count", games.Count),
@@ -370,7 +389,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			if (File.Exists(testPath))
 			{
-				ConfirmationDialogs.ButtonPrompt(modData,
+				ConfirmationDialogs.ButtonPrompt(
+					dynamicWidgets,
+					modData,
 					title: OverwriteSaveTitle,
 					text: OverwriteSavePrompt,
 					textArguments: Translation.Arguments("file", saveTextField.Text),

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -37,6 +37,23 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference]
 		const string Chat = "menu-game-info.chat";
 
+		public class GameInfoLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = EmptySet;
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } =
+				new Dictionary<string, string>
+				{
+					{ "SCRIPT_ERROR_PANEL", "OBJECTIVES_PANEL" },
+					{ "MISSION_OBJECTIVES", "OBJECTIVES_PANEL" },
+					{ "SKIRMISH_STATS", "OBJECTIVES_PANEL" },
+					{ "MAP_PANEL", "MAP_PANEL" },
+					{ "LOBBY_OPTIONS_PANEL", "LOBBY_OPTIONS_PANEL" },
+					{ "DEBUG_PANEL", "DEBUG_PANEL" },
+					{ "CHAT_CONTAINER", "CHAT_PANEL" },
+				};
+		}
+
+		readonly GameInfoLogicDynamicWidgets dynamicWidgets = new();
 		readonly World world;
 		readonly ModData modData;
 		readonly Action<bool> hideMenu;
@@ -141,7 +158,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void SetupObjectivesPanel(ButtonWidget objectivesTabButton, Widget objectivesPanelContainer)
 		{
 			var panel = hasError ? "SCRIPT_ERROR_PANEL" : iop.PanelName;
-			Game.LoadWidget(world, panel, objectivesPanelContainer, new WidgetArgs()
+			dynamicWidgets.LoadWidget(objectivesPanelContainer, panel, new WidgetArgs()
 			{
 				{ "hideMenu", hideMenu },
 				{ "closeMenu", closeMenu },
@@ -150,12 +167,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void SetupMapPanel(ButtonWidget mapTabButton, Widget mapPanelContainer)
 		{
-			Game.LoadWidget(world, "MAP_PANEL", mapPanelContainer, new WidgetArgs());
+			dynamicWidgets.LoadWidget(mapPanelContainer, "MAP_PANEL", new WidgetArgs());
 		}
 
 		void SetupLobbyOptionsPanel(ButtonWidget mapTabButton, Widget optionsPanelContainer)
 		{
-			Game.LoadWidget(world, "LOBBY_OPTIONS_PANEL", optionsPanelContainer, new WidgetArgs()
+			dynamicWidgets.LoadWidget(optionsPanelContainer, "LOBBY_OPTIONS_PANEL", new WidgetArgs()
 			{
 				{ "getMap", (Func<MapPreview>)(() => modData.MapCache[world.Map.Uid]) },
 				{ "configurationDisabled", (Func<bool>)(() => true) }
@@ -167,7 +184,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (debugTabButton != null)
 				debugTabButton.IsDisabled = () => world.IsGameOver;
 
-			Game.LoadWidget(world, "DEBUG_PANEL", debugPanelContainer, new WidgetArgs());
+			dynamicWidgets.LoadWidget(debugPanelContainer, "DEBUG_PANEL", new WidgetArgs());
 
 			if (activePanel == IngameInfoPanel.AutoSelect)
 				activePanel = IngameInfoPanel.Debug;
@@ -185,7 +202,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				};
 			}
 
-			Game.LoadWidget(world, "CHAT_CONTAINER", chatPanelContainer, new WidgetArgs() { { "isMenuChat", true } });
+			dynamicWidgets.LoadWidget(chatPanelContainer, "CHAT_CONTAINER", new WidgetArgs() { { "isMenuChat", true } });
 		}
 
 		static void LeaveChatPanel(Widget chatPanelContainer)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using OpenRA.Graphics;
@@ -86,6 +87,26 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference]
 		const string VoteKickVoteCancel = "dialog-vote-kick.vote-cancel";
 
+		public class GameInfoStatsLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } =
+				new HashSet<string>
+				{
+					"TWOBUTTON_PROMPT",
+					"THREEBUTTON_PROMPT",
+				};
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } =
+				new Dictionary<string, string>();
+			public override IReadOnlyDictionary<string, string> OutOfTreeParentWidgetIdForChildWidgetId { get; } =
+				new Dictionary<string, string>
+				{
+					{ "REGISTERED_PLAYER_TOOLTIP", "PROFILE_TOOLTIP" },
+					{ "BOT_TOOLTIP", "PROFILE_TOOLTIP" },
+				};
+		}
+
+		readonly GameInfoStatsLogicDynamicWidgets dynamicWidgets = new();
+
 		[ObjectCreator.UseCtor]
 		public GameInfoStatsLogic(Widget widget, ModData modData, World world,
 			OrderManager orderManager, WorldRenderer worldRenderer, Action<bool> hideMenu, Action closeMenu)
@@ -157,7 +178,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					if (UnitOrders.KickVoteTarget == null)
 					{
-						ConfirmationDialogs.ButtonPrompt(modData,
+						ConfirmationDialogs.ButtonPrompt(
+							dynamicWidgets,
+							modData,
 							title: VoteKickTitle,
 							text: botsCount > 0 ? VoteKickPromptBreakBots : VoteKickPrompt,
 							titleArguments: Translation.Arguments("player", client.Name),
@@ -173,7 +196,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						return;
 					}
 
-					ConfirmationDialogs.ButtonPrompt(modData,
+					ConfirmationDialogs.ButtonPrompt(
+						dynamicWidgets,
+						modData,
 						title: VoteKickTitle,
 						text: botsCount > 0 ? VoteKickPromptBreakBots : VoteKickPrompt,
 						titleArguments: Translation.Arguments("player", client.Name),
@@ -198,7 +223,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				}
 				else
 				{
-					ConfirmationDialogs.ButtonPrompt(modData,
+					ConfirmationDialogs.ButtonPrompt(
+						dynamicWidgets,
+						modData,
 						title: KickTitle,
 						text: KickPrompt,
 						titleArguments: Translation.Arguments("player", client.Name),
@@ -243,7 +270,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var pp = p.Player;
 					var client = world.LobbyInfo.ClientWithIndex(pp.ClientIndex);
 					var item = playerTemplate.Clone();
-					LobbyUtils.SetupProfileWidget(item, client, orderManager, worldRenderer);
+					LobbyUtils.SetupProfileWidget(dynamicWidgets, item, client, orderManager, worldRenderer);
 
 					var nameLabel = item.Get<LabelWidget>("NAME");
 					WidgetUtils.BindPlayerNameAndStatus(nameLabel, pp);
@@ -299,7 +326,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				foreach (var client in spectators)
 				{
 					var item = spectatorTemplate.Clone();
-					LobbyUtils.SetupProfileWidget(item, client, orderManager, worldRenderer);
+					LobbyUtils.SetupProfileWidget(dynamicWidgets, item, client, orderManager, worldRenderer);
 
 					var nameLabel = item.Get<LabelWidget>("NAME");
 					var nameFont = Game.Renderer.Fonts[nameLabel.Font];

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/HierarchicalPathFinderOverlayLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/HierarchicalPathFinderOverlayLogic.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Widgets;
@@ -17,6 +18,19 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class HierarchicalPathFinderOverlayLogic : ChromeLogic
 	{
+		public class HierarchicalPathFinderOverlayLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = EmptySet;
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } = EmptyDictionary;
+			public override IReadOnlyDictionary<string, IReadOnlyCollection<string>> ParentDropdownWidgetIdsFromPanelWidgetId { get; } =
+				new Dictionary<string, IReadOnlyCollection<string>>
+				{
+					{ "LABEL_DROPDOWN_TEMPLATE", new[] { "HPF_OVERLAY_LOCOMOTOR", "HPF_OVERLAY_CHECK" } },
+				};
+		}
+
+		readonly HierarchicalPathFinderOverlayLogicDynamicWidgets dynamicWidgets = new();
+
 		[ObjectCreator.UseCtor]
 		public HierarchicalPathFinderOverlayLogic(Widget widget, World world)
 		{
@@ -39,7 +53,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return item;
 				}
 
-				locomotorSelector.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", locomotors.Length * 30, locomotors, SetupItem);
+				dynamicWidgets.ShowDropDown(locomotorSelector, "LABEL_DROPDOWN_TEMPLATE", locomotors.Length * 30, locomotors, SetupItem);
 			};
 
 			var checks = new[] { BlockedByActor.None, BlockedByActor.Immovable };
@@ -56,7 +70,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return item;
 				}
 
-				checkSelector.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", checks.Length * 30, checks, SetupItem);
+				dynamicWidgets.ShowDropDown(checkSelector, "LABEL_DROPDOWN_TEMPLATE", checks.Length * 30, checks, SetupItem);
 			};
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngameChatLogic.cs
@@ -9,17 +9,29 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class LoadIngameChatLogic : ChromeLogic
 	{
+		public class LoadIngameChatLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = EmptySet;
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } =
+				new Dictionary<string, string>
+				{
+					{ "CHAT_PANEL", "CHAT_ROOT" },
+				};
+		}
+
+		readonly LoadIngameChatLogicDynamicWidgets dynamicWidgets = new();
+
 		[ObjectCreator.UseCtor]
 		public LoadIngameChatLogic(Widget widget, World world)
 		{
-			var root = widget.Get("CHAT_ROOT");
-			Game.LoadWidget(world, "CHAT_PANEL", root, new WidgetArgs() { { "isMenuChat", false } });
+			dynamicWidgets.LoadWidget(widget, "CHAT_PANEL", new WidgetArgs() { { "isMenuChat", false } });
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngameHierarchicalPathFinderOverlayLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngameHierarchicalPathFinderOverlayLogic.cs
@@ -9,16 +9,29 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class LoadIngameHierarchicalPathFinderOverlayLogic : ChromeLogic
 	{
+		public class LoadIngameHierarchicalPathFinderOverlayLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = EmptySet;
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } =
+				new Dictionary<string, string>
+				{
+					{ "HPF_OVERLAY", "HPF_ROOT" },
+				};
+		}
+
+		readonly LoadIngameHierarchicalPathFinderOverlayLogicDynamicWidgets dynamicWidgets = new();
+
 		[ObjectCreator.UseCtor]
 		public LoadIngameHierarchicalPathFinderOverlayLogic(Widget widget, World world)
 		{
-			Game.LoadWidget(world, "HPF_OVERLAY", widget, new WidgetArgs());
+			dynamicWidgets.LoadWidget(widget, "HPF_OVERLAY", new WidgetArgs());
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePerfLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePerfLogic.cs
@@ -9,17 +9,29 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class LoadIngamePerfLogic : ChromeLogic
 	{
+		public class LoadIngamePerfLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = EmptySet;
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } =
+				new Dictionary<string, string>
+				{
+					{ "PERF_WIDGETS", "PERF_ROOT" },
+				};
+		}
+
+		readonly LoadIngamePerfLogicDynamicWidgets dynamicWidgets = new();
+
 		[ObjectCreator.UseCtor]
 		public LoadIngamePerfLogic(Widget widget, World world)
 		{
-			var perfRoot = widget.Get("PERF_ROOT");
-			Game.LoadWidget(world, "PERF_WIDGETS", perfRoot, new WidgetArgs());
+			dynamicWidgets.LoadWidget(widget, "PERF_WIDGETS", new WidgetArgs());
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadMapEditorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadMapEditorLogic.cs
@@ -9,18 +9,31 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class LoadMapEditorLogic : ChromeLogic
 	{
+		public class LoadMapEditorLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = EmptySet;
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } =
+				new Dictionary<string, string>
+				{
+					{ "EDITOR_WORLD_ROOT", "WORLD_ROOT" },
+					{ "TRANSIENTS_PANEL", "WORLD_ROOT" },
+				};
+		}
+
+		readonly LoadMapEditorLogicDynamicWidgets dynamicWidgets = new();
+
 		[ObjectCreator.UseCtor]
 		public LoadMapEditorLogic(Widget widget, World world)
 		{
-			var editorRoot = widget.Get("WORLD_ROOT");
-			Game.LoadWidget(world, "EDITOR_WORLD_ROOT", editorRoot, new WidgetArgs());
-			Game.LoadWidget(world, "TRANSIENTS_PANEL", editorRoot, new WidgetArgs());
+			dynamicWidgets.LoadWidget(widget, "EDITOR_WORLD_ROOT", new WidgetArgs());
+			dynamicWidgets.LoadWidget(widget, "TRANSIENTS_PANEL", new WidgetArgs());
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
@@ -41,6 +41,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference]
 		const string NoTeam = "label-no-team";
 
+		public class ObserverShroudSelectorLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = EmptySet;
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } = EmptyDictionary;
+			public override IReadOnlyDictionary<string, IReadOnlyCollection<string>> ParentDropdownWidgetIdsFromPanelWidgetId { get; } =
+				new Dictionary<string, IReadOnlyCollection<string>>
+				{
+					{ "SPECTATOR_DROPDOWN_TEMPLATE", new[] { "SHROUD_SELECTOR" } },
+				};
+		}
+
+		readonly ObserverShroudSelectorLogicDynamicWidgets dynamicWidgets = new();
 		readonly CameraOption combined, disableShroud;
 		readonly IGrouping<int, CameraOption>[] teams;
 		readonly bool limitViews;
@@ -159,7 +171,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return item;
 				}
 
-				shroudSelector.ShowDropDown("SPECTATOR_DROPDOWN_TEMPLATE", 400, groups, SetupItem);
+				dynamicWidgets.ShowDropDown(shroudSelector, "SPECTATOR_DROPDOWN_TEMPLATE", 400, groups, SetupItem);
 			};
 
 			shroudLabel = shroudSelector.Get<LabelWidget>("LABEL");

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
@@ -23,6 +23,19 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference]
 		const string ManualInstall = "button-manual-install";
 
+		public class ModContentLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } =
+				new HashSet<string>
+				{
+					"SOURCE_INSTALL_PANEL",
+					"PACKAGE_DOWNLOAD_PANEL",
+				};
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } = EmptyDictionary;
+		}
+
+		readonly ModContentLogicDynamicWidgets dynamicWidgets = new();
+
 		readonly ModContent content;
 		readonly ScrollPanelWidget scrollPanel;
 		readonly Widget template;
@@ -82,7 +95,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			sourceButton.Bounds.Y += headerHeight;
 			sourceButton.IsVisible = () => sourceAvailable;
 
-			sourceButton.OnClick = () => Ui.OpenWindow("SOURCE_INSTALL_PANEL", new WidgetArgs
+			sourceButton.OnClick = () => dynamicWidgets.OpenWindow("SOURCE_INSTALL_PANEL", new WidgetArgs
 			{
 				{ "sources", sources },
 				{ "content", content }
@@ -134,7 +147,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						{ "onSuccess", () => { } }
 					};
 
-					downloadButton.OnClick = () => Ui.OpenWindow("PACKAGE_DOWNLOAD_PANEL", widgetArgs);
+					downloadButton.OnClick = () => dynamicWidgets.OpenWindow("PACKAGE_DOWNLOAD_PANEL", widgetArgs);
 				}
 
 				var installedWidget = container.Get<LabelWidget>("INSTALLED");

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentPromptLogic.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using OpenRA.FileSystem;
@@ -25,6 +26,19 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		[TranslationReference]
 		const string Quit = "button-quit";
+
+		public class ModContentPromptLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } =
+				new HashSet<string>
+				{
+					"CONTENT_PANEL",
+					"PACKAGE_DOWNLOAD_PANEL",
+				};
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } = EmptyDictionary;
+		}
+
+		readonly ModContentPromptLogicDynamicWidgets dynamicWidgets = new();
 
 		readonly ModContent content;
 		bool requiredContentInstalled;
@@ -62,7 +76,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			advancedButton.Bounds.Y += headerHeight;
 			advancedButton.OnClick = () =>
 			{
-				Ui.OpenWindow("CONTENT_PANEL", new WidgetArgs
+				dynamicWidgets.OpenWindow("CONTENT_PANEL", new WidgetArgs
 				{
 					{ "mod", mod },
 					{ "content", content },
@@ -91,7 +105,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (download == null)
 					throw new InvalidOperationException($"Mod QuickDownload `{content.QuickDownload}` definition not found.");
 
-				Ui.OpenWindow("PACKAGE_DOWNLOAD_PANEL", new WidgetArgs
+				dynamicWidgets.OpenWindow("PACKAGE_DOWNLOAD_PANEL", new WidgetArgs
 				{
 					{ "download", new ModContent.ModDownload(download.Value, modObjectCreator) },
 					{ "onSuccess", continueLoading }

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
@@ -24,6 +24,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference]
 		const string NotAvailable = "label-not-available";
 
+		public class LobbyOptionsLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = EmptySet;
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } = EmptyDictionary;
+			public override IReadOnlyDictionary<string, IReadOnlyCollection<string>> ParentDropdownWidgetIdsFromPanelWidgetId { get; } =
+				new Dictionary<string, IReadOnlyCollection<string>>
+				{
+					{ "LABEL_DROPDOWN_TEMPLATE", new[] { "A", "B", "C" } },
+				};
+		}
+
+		readonly LobbyOptionsLogicDynamicWidgets dynamicWidgets = new();
 		readonly ScrollPanelWidget panel;
 		readonly Widget optionsContainer;
 		readonly Widget checkboxRowTemplate;
@@ -175,7 +187,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						return item;
 					}
 
-					dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", option.Values.Count * 30, option.Values, SetupItem);
+					dynamicWidgets.ShowDropDown(dropdown, "LABEL_DROPDOWN_TEMPLATE", option.Values.Count * 30, option.Values, SetupItem);
 				};
 
 				var label = row.GetOrNull<LabelWidget>(dropdown.Id + "_DESC");

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -53,7 +53,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 		}
 
-		public static void ShowSlotDropDown(DropDownButtonWidget dropdown, Session.Slot slot,
+		public static void ShowSlotDropDown(
+			LobbyLogic.LobbyLogicDynamicWidgets dynamicWidgets,
+			DropDownButtonWidget dropdown, Session.Slot slot,
 			Session.Client client, OrderManager orderManager, MapPreview map, ModData modData)
 		{
 			var open = TranslationProvider.GetString(Open);
@@ -92,10 +94,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return item;
 			}
 
-			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 180, options, SetupItem);
+			dynamicWidgets.ShowDropDown(dropdown, "LABEL_DROPDOWN_TEMPLATE", 180, options, SetupItem);
 		}
 
-		public static void ShowPlayerActionDropDown(DropDownButtonWidget dropdown,
+		public static void ShowPlayerActionDropDown(
+			LobbyLogic.LobbyLogicDynamicWidgets dynamicWidgets,
+			DropDownButtonWidget dropdown,
 			Session.Client c, OrderManager orderManager, Widget lobby, Action before, Action after)
 		{
 			Action<bool> okPressed = tempBan => { orderManager.IssueOrder(Order.Command($"kick {c.Index} {tempBan}")); after(); };
@@ -103,7 +107,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				before();
 
-				Game.LoadWidget(null, "KICK_CLIENT_DIALOG", lobby.Get("TOP_PANELS_ROOT"), new WidgetArgs
+				dynamicWidgets.LoadWidget(lobby, "KICK_CLIENT_DIALOG", new WidgetArgs
 				{
 					{ "clientName", c.Name },
 					{ "okPressed", okPressed },
@@ -146,10 +150,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return item;
 			}
 
-			dropdown.ShowDropDown("PLAYERACTION_DROPDOWN_TEMPLATE", 167, options, SetupItem);
+			dynamicWidgets.ShowDropDown(dropdown, "PLAYERACTION_DROPDOWN_TEMPLATE", 167, options, SetupItem);
 		}
 
-		public static void ShowTeamDropDown(DropDownButtonWidget dropdown, Session.Client client,
+		public static void ShowTeamDropDown(
+			LobbyLogic.LobbyLogicDynamicWidgets dynamicWidgets,
+			DropDownButtonWidget dropdown, Session.Client client,
 			OrderManager orderManager, int teamCount)
 		{
 			ScrollItemWidget SetupItem(int ii, ScrollItemWidget itemTemplate)
@@ -162,10 +168,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var options = Enumerable.Range(0, teamCount + 1);
-			dropdown.ShowDropDown("TEAM_DROPDOWN_TEMPLATE", 150, options, SetupItem);
+			dynamicWidgets.ShowDropDown(dropdown, "TEAM_DROPDOWN_TEMPLATE", 150, options, SetupItem);
 		}
 
-		public static void ShowHandicapDropDown(DropDownButtonWidget dropdown, Session.Client client,
+		public static void ShowHandicapDropDown(
+			LobbyLogic.LobbyLogicDynamicWidgets dynamicWidgets,
+			DropDownButtonWidget dropdown, Session.Client client,
 			OrderManager orderManager)
 		{
 			ScrollItemWidget SetupItem(int ii, ScrollItemWidget itemTemplate)
@@ -181,10 +189,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			// Handicaps may be set between 0 - 95% in steps of 5%
 			var options = Enumerable.Range(0, 20).Select(i => 5 * i);
-			dropdown.ShowDropDown("TEAM_DROPDOWN_TEMPLATE", 150, options, SetupItem);
+			dynamicWidgets.ShowDropDown(dropdown, "TEAM_DROPDOWN_TEMPLATE", 150, options, SetupItem);
 		}
 
-		public static void ShowSpawnDropDown(DropDownButtonWidget dropdown, Session.Client client,
+		public static void ShowSpawnDropDown(
+			LobbyLogic.LobbyLogicDynamicWidgets dynamicWidgets,
+			DropDownButtonWidget dropdown, Session.Client client,
 			OrderManager orderManager, IEnumerable<int> spawnPoints)
 		{
 			ScrollItemWidget SetupItem(int ii, ScrollItemWidget itemTemplate)
@@ -196,7 +206,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return item;
 			}
 
-			dropdown.ShowDropDown("SPAWN_DROPDOWN_TEMPLATE", 150, spawnPoints, SetupItem);
+			dynamicWidgets.ShowDropDown(dropdown, "SPAWN_DROPDOWN_TEMPLATE", 150, spawnPoints, SetupItem);
 		}
 
 		/// <summary>Splits a string into two parts on the first instance of a given token.</summary>
@@ -211,7 +221,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			return (first, second);
 		}
 
-		public static void ShowFactionDropDown(DropDownButtonWidget dropdown, Session.Client client,
+		public static void ShowFactionDropDown(
+			LobbyLogic.LobbyLogicDynamicWidgets dynamicWidgets,
+			DropDownButtonWidget dropdown, Session.Client client,
 			OrderManager orderManager, Dictionary<string, LobbyFaction> factions)
 		{
 			ScrollItemWidget SetupItem(string factionId, ScrollItemWidget itemTemplate)
@@ -240,7 +252,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var options = factions.Where(f => f.Value.Selectable).GroupBy(f => f.Value.Side)
 				.ToDictionary(g => g.Key != null ? TranslationProvider.GetString(g.Key) : "", g => g.Select(f => TranslationProvider.GetString(f.Key)));
 
-			dropdown.ShowDropDown("FACTION_DROPDOWN_TEMPLATE", 154, options, SetupItem);
+			dynamicWidgets.ShowDropDown(dropdown, "FACTION_DROPDOWN_TEMPLATE", 154, options, SetupItem);
 		}
 
 		public static void SelectSpawnPoint(OrderManager orderManager, MapPreviewWidget mapPreview, MapPreview preview, MouseInput mi)
@@ -352,7 +364,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				tooltip.Bind(orderManager, null, c);
 		}
 
-		public static void SetupProfileWidget(Widget parent, Session.Client c, OrderManager orderManager, WorldRenderer worldRenderer)
+		public static void SetupProfileWidget(
+			ChromeLogic.DynamicWidgets dynamicWidgets,
+			Widget parent, Session.Client c, OrderManager orderManager, WorldRenderer worldRenderer)
 		{
 			var profile = parent.GetOrNull<ImageWidget>("PROFILE");
 			if (profile != null)
@@ -372,10 +386,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (profileTooltip != null)
 			{
 				if (c.Fingerprint != null)
+				{
+					dynamicWidgets.ValidateWidgetOutOfTree(profileTooltip, "REGISTERED_PLAYER_TOOLTIP");
 					profileTooltip.Template = "REGISTERED_PLAYER_TOOLTIP";
+				}
 
 				if (c.IsBot)
+				{
+					dynamicWidgets.ValidateWidgetOutOfTree(profileTooltip, "BOT_TOOLTIP");
 					profileTooltip.Template = "BOT_TOOLTIP";
+				}
 
 				profileTooltip.Bind(orderManager, worldRenderer, c);
 
@@ -383,7 +403,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 		}
 
-		public static void SetupEditableNameWidget(Widget parent, Session.Client c, OrderManager orderManager, WorldRenderer worldRenderer)
+		public static void SetupEditableNameWidget(
+			LobbyLogic.LobbyLogicDynamicWidgets dynamicWidgets,
+			Widget parent, Session.Client c, OrderManager orderManager, WorldRenderer worldRenderer)
 		{
 			var name = parent.Get<TextFieldWidget>("NAME");
 			name.IsVisible = () => true;
@@ -420,12 +442,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return true;
 			};
 
-			SetupProfileWidget(name, c, orderManager, worldRenderer);
+			SetupProfileWidget(dynamicWidgets, name, c, orderManager, worldRenderer);
 
 			HideChildWidget(parent, "SLOT_OPTIONS");
 		}
 
-		public static void SetupNameWidget(Widget parent, Session.Client c, OrderManager orderManager, WorldRenderer worldRenderer)
+		public static void SetupNameWidget(
+			LobbyLogic.LobbyLogicDynamicWidgets dynamicWidgets,
+			Widget parent, Session.Client c, OrderManager orderManager, WorldRenderer worldRenderer)
 		{
 			var label = parent.Get<LabelWidget>("NAME");
 			label.IsVisible = () => true;
@@ -434,10 +458,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var text = WidgetUtils.TruncateText(name, label.Bounds.Width, font);
 			label.GetText = () => text;
 
-			SetupProfileWidget(parent, c, orderManager, worldRenderer);
+			SetupProfileWidget(dynamicWidgets, parent, c, orderManager, worldRenderer);
 		}
 
-		public static void SetupEditableSlotWidget(Widget parent, Session.Slot s, Session.Client c,
+		public static void SetupEditableSlotWidget(
+			LobbyLogic.LobbyLogicDynamicWidgets dynamicWidgets,
+			Widget parent, Session.Slot s, Session.Client c,
 			OrderManager orderManager, MapPreview map, ModData modData)
 		{
 			var slot = parent.Get<DropDownButtonWidget>("SLOT_OPTIONS");
@@ -454,7 +480,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				c.IsBot ? TranslationProvider.GetString(c.Name) : c.Name
 					: s.Closed ? closed : open);
 
-			slot.OnMouseDown = _ => ShowSlotDropDown(slot, s, c, orderManager, map, modData);
+			slot.OnMouseDown = _ => ShowSlotDropDown(dynamicWidgets, slot, s, c, orderManager, map, modData);
 
 			// Ensure Name selector (if present) is hidden
 			HideChildWidget(parent, "NAME");
@@ -472,7 +498,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			HideChildWidget(parent, "SLOT_OPTIONS");
 		}
 
-		public static void SetupPlayerActionWidget(Widget parent, Session.Client c, OrderManager orderManager,
+		public static void SetupPlayerActionWidget(
+			LobbyLogic.LobbyLogicDynamicWidgets dynamicWidgets,
+			Widget parent, Session.Client c, OrderManager orderManager,
 			WorldRenderer worldRenderer, Widget lobby, Action before, Action after)
 		{
 			var slot = parent.Get<DropDownButtonWidget>("PLAYER_ACTION");
@@ -484,15 +512,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Game.Renderer.Fonts[slot.Font]));
 
 			slot.GetText = () => truncated.Update(c != null ? c.Name : string.Empty);
-			slot.OnMouseDown = _ => ShowPlayerActionDropDown(slot, c, orderManager, lobby, before, after);
+			slot.OnMouseDown = _ => ShowPlayerActionDropDown(dynamicWidgets, slot, c, orderManager, lobby, before, after);
 
-			SetupProfileWidget(slot, c, orderManager, worldRenderer);
+			SetupProfileWidget(dynamicWidgets, slot, c, orderManager, worldRenderer);
 
 			// Ensure Name selector (if present) is hidden
 			HideChildWidget(parent, "NAME");
 		}
 
-		public static void SetupKickSpectatorsWidget(Widget parent, OrderManager orderManager, Widget lobby, Action before, Action after, bool skirmishMode)
+		public static void SetupKickSpectatorsWidget(
+			LobbyLogic.LobbyLogicDynamicWidgets dynamicWidgets,
+			Widget parent, OrderManager orderManager, Widget lobby, Action before, Action after, bool skirmishMode)
 		{
 			var checkBox = parent.Get<CheckboxWidget>("TOGGLE_SPECTATORS");
 			checkBox.IsChecked = () => orderManager.LobbyInfo.GlobalSettings.AllowSpectators;
@@ -517,7 +547,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var spectatorCount = orderManager.LobbyInfo.Clients.Count(c => c.IsObserver);
 				if (spectatorCount > 0)
 				{
-					Game.LoadWidget(null, "KICK_SPECTATORS_DIALOG", lobby.Get("TOP_PANELS_ROOT"), new WidgetArgs
+					dynamicWidgets.LoadWidget(lobby, "KICK_SPECTATORS_DIALOG", new WidgetArgs
 					{
 						{ "clientCount", spectatorCount },
 						{ "okPressed", OkPressed },
@@ -532,12 +562,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 		}
 
-		public static void SetupEditableColorWidget(Widget parent, Session.Slot s, Session.Client c,
-			OrderManager orderManager, WorldRenderer worldRenderer, IColorPickerManagerInfo colorManager)
+		public static void SetupEditableColorWidget(
+			LobbyLogic.LobbyLogicDynamicWidgets dynamicWidgets,
+			Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, WorldRenderer worldRenderer, IColorPickerManagerInfo colorManager)
 		{
 			var colorDropdown = parent.Get<DropDownButtonWidget>("COLOR");
 			colorDropdown.IsDisabled = () => (s != null && s.LockColor) || orderManager.LocalClient.IsReady;
-			colorDropdown.OnMouseDown = _ => colorManager.ShowColorDropDown(colorDropdown, c.Color, c.Faction, worldRenderer, color =>
+			colorDropdown.OnMouseDown = _ => colorManager.ShowColorDropDown(
+				dynamicWidgets, colorDropdown, c.Color, c.Faction, worldRenderer, color =>
 			{
 				if (c == orderManager.LocalClient)
 				{
@@ -557,12 +589,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			color.GetColor = () => c.Color;
 		}
 
-		public static void SetupEditableFactionWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager,
+		public static void SetupEditableFactionWidget(
+			LobbyLogic.LobbyLogicDynamicWidgets dynamicWidgets,
+			Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager,
 			Dictionary<string, LobbyFaction> factions)
 		{
 			var dropdown = parent.Get<DropDownButtonWidget>("FACTION");
 			dropdown.IsDisabled = () => s.LockFaction || orderManager.LocalClient.IsReady;
-			dropdown.OnMouseDown = _ => ShowFactionDropDown(dropdown, c, orderManager, factions);
+			dropdown.OnMouseDown = _ => ShowFactionDropDown(dynamicWidgets, dropdown, c, orderManager, factions);
 
 			var description = factions[c.Faction].Description != null ? TranslationProvider.GetString(factions[c.Faction].Description) : null;
 			var (text, desc) = SplitOnFirstToken(description);
@@ -585,12 +619,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			factionFlag.GetImageCollection = () => "flags";
 		}
 
-		public static void SetupEditableTeamWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, MapPreview map)
+		public static void SetupEditableTeamWidget(
+			LobbyLogic.LobbyLogicDynamicWidgets dynamicWidgets,
+			Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, MapPreview map)
 		{
 			var dropdown = parent.Get<DropDownButtonWidget>("TEAM_DROPDOWN");
 			dropdown.IsVisible = () => true;
 			dropdown.IsDisabled = () => s.LockTeam || orderManager.LocalClient.IsReady;
-			dropdown.OnMouseDown = _ => ShowTeamDropDown(dropdown, c, orderManager, map.PlayerCount);
+			dropdown.OnMouseDown = _ => ShowTeamDropDown(dynamicWidgets, dropdown, c, orderManager, map.PlayerCount);
 			dropdown.GetText = () => (c.Team == 0) ? "-" : c.Team.ToString(NumberFormatInfo.CurrentInfo);
 
 			HideChildWidget(parent, "TEAM");
@@ -604,12 +640,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			HideChildWidget(parent, "TEAM_DROPDOWN");
 		}
 
-		public static void SetupEditableHandicapWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager)
+		public static void SetupEditableHandicapWidget(
+			LobbyLogic.LobbyLogicDynamicWidgets dynamicWidgets,
+			Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager)
 		{
 			var dropdown = parent.Get<DropDownButtonWidget>("HANDICAP_DROPDOWN");
 			dropdown.IsVisible = () => true;
 			dropdown.IsDisabled = () => s.LockHandicap || orderManager.LocalClient.IsReady;
-			dropdown.OnMouseDown = _ => ShowHandicapDropDown(dropdown, c, orderManager);
+			dropdown.OnMouseDown = _ => ShowHandicapDropDown(dynamicWidgets, dropdown, c, orderManager);
 
 			var handicapLabel = new CachedTransform<int, string>(h => $"{h}%");
 			dropdown.GetText = () => handicapLabel.Update(c.Handicap);
@@ -627,7 +665,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			HideChildWidget(parent, "HANDICAP_DROPDOWN");
 		}
 
-		public static void SetupEditableSpawnWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, MapPreview map)
+		public static void SetupEditableSpawnWidget(
+			LobbyLogic.LobbyLogicDynamicWidgets dynamicWidgets,
+			Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, MapPreview map)
 		{
 			var dropdown = parent.Get<DropDownButtonWidget>("SPAWN_DROPDOWN");
 			dropdown.IsVisible = () => true;
@@ -638,7 +678,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					orderManager.LobbyInfo.Clients.Where(
 					client => client != c && client.SpawnPoint != 0).Select(client => client.SpawnPoint))
 					.Except(orderManager.LobbyInfo.DisabledSpawnPoints);
-				ShowSpawnDropDown(dropdown, c, orderManager, spawnPoints);
+				ShowSpawnDropDown(dynamicWidgets, dropdown, c, orderManager, spawnPoints);
 			};
 			dropdown.GetText = () => (c.SpawnPoint == 0) ? "-" : Convert.ToChar('A' - 1 + c.SpawnPoint).ToString();
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -39,6 +39,41 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		protected enum MenuPanel { None, Missions, Skirmish, Multiplayer, MapEditor, Replays, GameSaves }
 
+		public class MainMenuLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } =
+				new HashSet<string>
+				{
+					"CONNECTING_PANEL",
+					"MUSIC_PANEL",
+					"CREDITS_PANEL",
+					"MAINMENU_SYSTEM_INFO_PROMPT",
+					"MULTIPLAYER_PANEL",
+					"REPLAYBROWSER_PANEL",
+					"GAMESAVE_BROWSER_PANEL",
+					"SETTINGS_PANEL",
+					"ASSETBROWSER_PANEL",
+					"NEW_MAP_BG",
+					"MAPCHOOSER_PANEL",
+					"MAINMENU_INTRODUCTION_PROMPT",
+					"MISSIONBROWSER_PANEL",
+					"ENCYCLOPEDIA_PANEL",
+					"SERVER_LOBBY",
+				};
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } =
+				new Dictionary<string, string>
+				{
+					{ "LOCAL_PROFILE_PANEL", "PLAYER_PROFILE_CONTAINER" },
+				};
+			public override IReadOnlyDictionary<string, IReadOnlyCollection<string>> ParentDropdownWidgetIdsFromPanelWidgetId { get; } =
+				new Dictionary<string, IReadOnlyCollection<string>>
+				{
+					{ "NEWS_PANEL", new[] { "NEWS_BUTTON" } },
+				};
+		}
+
+		readonly MainMenuLogicDynamicWidgets dynamicWidgets = new();
+
 		protected MenuType menuType = MenuType.Main;
 		readonly Widget rootMenu;
 		readonly ScrollPanelWidget newsPanel;
@@ -101,7 +136,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			mainMenu.Get<ButtonWidget>("SETTINGS_BUTTON").OnClick = () =>
 			{
 				SwitchMenu(MenuType.None);
-				Game.OpenWindow("SETTINGS_PANEL", new WidgetArgs
+				dynamicWidgets.OpenWindow("SETTINGS_PANEL", new WidgetArgs
 				{
 					{ "onExit", () => SwitchMenu(MenuType.Main) }
 				});
@@ -148,10 +183,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			extrasMenu.Get<ButtonWidget>("MUSIC_BUTTON").OnClick = () =>
 			{
 				SwitchMenu(MenuType.None);
-				Ui.OpenWindow("MUSIC_PANEL", new WidgetArgs
+				dynamicWidgets.OpenWindow("MUSIC_PANEL", new WidgetArgs
 				{
 					{ "onExit", () => SwitchMenu(MenuType.Extras) },
-					{ "world", world }
 				});
 			};
 
@@ -162,7 +196,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				assetBrowserButton.OnClick = () =>
 				{
 					SwitchMenu(MenuType.None);
-					Game.OpenWindow("ASSETBROWSER_PANEL", new WidgetArgs
+					dynamicWidgets.OpenWindow("ASSETBROWSER_PANEL", new WidgetArgs
 					{
 						{ "onExit", () => SwitchMenu(MenuType.Extras) },
 					});
@@ -171,7 +205,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			extrasMenu.Get<ButtonWidget>("CREDITS_BUTTON").OnClick = () =>
 			{
 				SwitchMenu(MenuType.None);
-				Ui.OpenWindow("CREDITS_PANEL", new WidgetArgs
+				dynamicWidgets.OpenWindow("CREDITS_PANEL", new WidgetArgs
 				{
 					{ "onExit", () => SwitchMenu(MenuType.Extras) },
 				});
@@ -198,7 +232,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			newMapButton.OnClick = () =>
 			{
 				SwitchMenu(MenuType.None);
-				Game.OpenWindow("NEW_MAP_BG", new WidgetArgs()
+				dynamicWidgets.OpenWindow("NEW_MAP_BG", new WidgetArgs()
 				{
 					{ "onSelect", onSelect },
 					{ "onExit", () => SwitchMenu(MenuType.MapEditor) }
@@ -209,7 +243,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			loadMapButton.OnClick = () =>
 			{
 				SwitchMenu(MenuType.None);
-				Game.OpenWindow("MAPCHOOSER_PANEL", new WidgetArgs()
+				dynamicWidgets.OpenWindow("MAPCHOOSER_PANEL", new WidgetArgs()
 				{
 					{ "initialMap", null },
 					{ "remoteMapPool", null },
@@ -229,7 +263,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				newsBG.IsVisible = () => Game.Settings.Game.FetchNews && menuType != MenuType.None && menuType != MenuType.StartupPrompts;
 
-				newsPanel = Ui.LoadWidget<ScrollPanelWidget>("NEWS_PANEL", null, new WidgetArgs());
+				newsPanel = (ScrollPanelWidget)dynamicWidgets.LoadWidgetAsDropdownPanel("NEWS_PANEL", new WidgetArgs());
 				newsTemplate = newsPanel.Get("NEWS_ITEM_TEMPLATE");
 				newsPanel.RemoveChild(newsTemplate);
 
@@ -254,7 +288,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (playerProfile != null)
 			{
 				Func<bool> minimalProfile = () => Ui.CurrentWindow() != null;
-				Game.LoadWidget(world, "LOCAL_PROFILE_PANEL", playerProfile, new WidgetArgs()
+				dynamicWidgets.LoadWidget(playerProfile, "LOCAL_PROFILE_PANEL", new WidgetArgs()
 				{
 					{ "minimalProfile", minimalProfile }
 				});
@@ -272,7 +306,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				if (SystemInfoPromptLogic.ShouldShowPrompt())
 				{
-					Ui.OpenWindow("MAINMENU_SYSTEM_INFO_PROMPT", new WidgetArgs
+					dynamicWidgets.OpenWindow("MAINMENU_SYSTEM_INFO_PROMPT", new WidgetArgs
 					{
 						{ "onComplete", OnSysInfoComplete }
 					});
@@ -283,7 +317,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			if (IntroductionPromptLogic.ShouldShowPrompt())
 			{
-				Game.OpenWindow("MAINMENU_INTRODUCTION_PROMPT", new WidgetArgs
+				dynamicWidgets.OpenWindow("MAINMENU_INTRODUCTION_PROMPT", new WidgetArgs
 				{
 					{ "onComplete", OnIntroductionComplete }
 				});
@@ -359,13 +393,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void OpenNewsPanel(DropDownButtonWidget button)
 		{
 			newsOpen = true;
-			button.AttachPanel(newsPanel, () => newsOpen = false);
+			dynamicWidgets.AttachPanel(button, newsPanel, () => newsOpen = false);
 		}
 
 		void OnRemoteDirectConnect(ConnectionTarget endpoint)
 		{
 			SwitchMenu(MenuType.None);
-			Ui.OpenWindow("MULTIPLAYER_PANEL", new WidgetArgs
+			dynamicWidgets.OpenWindow("MULTIPLAYER_PANEL", new WidgetArgs
 			{
 				{ "onStart", RemoveShellmapUI },
 				{ "onExit", () => SwitchMenu(MenuType.Main) },
@@ -469,7 +503,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Game.Settings.Server.Map = map;
 			Game.Settings.Save();
 
-			ConnectionLogic.Connect(Game.CreateLocalServer(map, isSkirmish: true),
+			ConnectionLogic.Connect(dynamicWidgets, Game.CreateLocalServer(map, isSkirmish: true),
 				"",
 				OpenSkirmishLobbyPanel,
 				() => { Game.CloseServer(); SwitchMenu(MenuType.Main); });
@@ -478,7 +512,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void OpenMissionBrowserPanel(string map)
 		{
 			SwitchMenu(MenuType.None);
-			Game.OpenWindow("MISSIONBROWSER_PANEL", new WidgetArgs
+			dynamicWidgets.OpenWindow("MISSIONBROWSER_PANEL", new WidgetArgs
 			{
 				{ "onExit", () => { Game.Disconnect(); SwitchMenu(MenuType.Singleplayer); } },
 				{ "onStart", () => { RemoveShellmapUI(); lastGameState = MenuPanel.Missions; } },
@@ -489,7 +523,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void OpenEncyclopediaPanel()
 		{
 			SwitchMenu(MenuType.None);
-			Game.OpenWindow("ENCYCLOPEDIA_PANEL", new WidgetArgs
+			dynamicWidgets.OpenWindow("ENCYCLOPEDIA_PANEL", new WidgetArgs
 			{
 				{ "onExit", () => SwitchMenu(MenuType.Singleplayer) }
 			});
@@ -498,7 +532,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void OpenSkirmishLobbyPanel()
 		{
 			SwitchMenu(MenuType.None);
-			Game.OpenWindow("SERVER_LOBBY", new WidgetArgs
+			dynamicWidgets.OpenWindow("SERVER_LOBBY", new WidgetArgs
 			{
 				{ "onExit", () => { Game.Disconnect(); SwitchMenu(MenuType.Singleplayer); } },
 				{ "onStart", () => { RemoveShellmapUI(); lastGameState = MenuPanel.Skirmish; } },
@@ -509,7 +543,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void OpenMultiplayerPanel()
 		{
 			SwitchMenu(MenuType.None);
-			Ui.OpenWindow("MULTIPLAYER_PANEL", new WidgetArgs
+			dynamicWidgets.OpenWindow("MULTIPLAYER_PANEL", new WidgetArgs
 			{
 				{ "onStart", () => { RemoveShellmapUI(); lastGameState = MenuPanel.Multiplayer; } },
 				{ "onExit", () => SwitchMenu(MenuType.Main) },
@@ -520,7 +554,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void OpenReplayBrowserPanel()
 		{
 			SwitchMenu(MenuType.None);
-			Ui.OpenWindow("REPLAYBROWSER_PANEL", new WidgetArgs
+			dynamicWidgets.OpenWindow("REPLAYBROWSER_PANEL", new WidgetArgs
 			{
 				{ "onExit", () => SwitchMenu(MenuType.Extras) },
 				{ "onStart", () => { RemoveShellmapUI(); lastGameState = MenuPanel.Replays; } }
@@ -530,12 +564,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void OpenGameSaveBrowserPanel()
 		{
 			SwitchMenu(MenuType.None);
-			Ui.OpenWindow("GAMESAVE_BROWSER_PANEL", new WidgetArgs
+			dynamicWidgets.OpenWindow("GAMESAVE_BROWSER_PANEL", new WidgetArgs
 			{
 				{ "onExit", () => SwitchMenu(MenuType.Singleplayer) },
 				{ "onStart", () => { RemoveShellmapUI(); lastGameState = MenuPanel.GameSaves; } },
 				{ "isSavePanel", false },
-				{ "world", null }
 			});
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -82,6 +82,23 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference]
 		const string OrderMapsBySize = "options-order-maps.size";
 
+		public class MapChooserLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } =
+				new HashSet<string>
+				{
+					"TWOBUTTON_PROMPT",
+					"THREEBUTTON_PROMPT",
+				};
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } = EmptyDictionary;
+			public override IReadOnlyDictionary<string, IReadOnlyCollection<string>> ParentDropdownWidgetIdsFromPanelWidgetId { get; } =
+				new Dictionary<string, IReadOnlyCollection<string>>
+				{
+					{ "LABEL_DROPDOWN_TEMPLATE", new[] { "GAMEMODE_FILTER", "ORDERBY" } },
+				};
+		}
+
+		readonly MapChooserLogicDynamicWidgets dynamicWidgets = new();
 		readonly string allMaps;
 
 		readonly Widget widget;
@@ -353,7 +370,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				}
 
 				gameModeDropdown.OnClick = () =>
-					gameModeDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 210, categories, SetupItem);
+					dynamicWidgets.ShowDropDown(gameModeDropdown, "LABEL_DROPDOWN_TEMPLATE", 210, categories, SetupItem);
 
 				gameModeDropdown.GetText = () =>
 				{
@@ -395,7 +412,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			orderByDropdown.OnClick = () =>
-				orderByDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, orderByDict.Keys, SetupItem);
+				dynamicWidgets.ShowDropDown(orderByDropdown, "LABEL_DROPDOWN_TEMPLATE", 500, orderByDict.Keys, SetupItem);
 
 			orderByDropdown.GetText = () =>
 				orderByDict.FirstOrDefault(m => m.Value == orderByFunc).Key;
@@ -511,7 +528,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void DeleteOneMap(string map, Action<string> after)
 		{
-			ConfirmationDialogs.ButtonPrompt(modData,
+			ConfirmationDialogs.ButtonPrompt(
+				dynamicWidgets,
+				modData,
 				title: DeleteMapTitle,
 				text: DeleteMapPrompt,
 				textArguments: Translation.Arguments("title", modData.MapCache[map].Title),
@@ -526,7 +545,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void DeleteAllMaps(string[] maps, Action<string> after)
 		{
-			ConfirmationDialogs.ButtonPrompt(modData,
+			ConfirmationDialogs.ButtonPrompt(
+				dynamicWidgets,
+				modData,
 				title: DeleteAllMapsTitle,
 				text: DeleteAllMapsPrompt,
 				onConfirm: () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using OpenRA.Graphics;
@@ -21,7 +22,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class LocalProfileLogic : ChromeLogic
 	{
-		readonly WorldRenderer worldRenderer;
+		public class LocalProfileLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = EmptySet;
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } =
+				new Dictionary<string, string>
+				{
+					{ "PLAYER_PROFILE_BADGES_INSERT", "BADGES_CONTAINER" },
+				};
+		}
+
+		readonly LocalProfileLogicDynamicWidgets dynamicWidgets = new();
+
 		readonly LocalPlayerProfile localProfile;
 		readonly Widget badgeContainer;
 		readonly Widget widget;
@@ -29,9 +41,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		bool badgesVisible;
 
 		[ObjectCreator.UseCtor]
-		public LocalProfileLogic(Widget widget, WorldRenderer worldRenderer, Func<bool> minimalProfile)
+		public LocalProfileLogic(Widget widget, Func<bool> minimalProfile)
 		{
-			this.worldRenderer = worldRenderer;
 			this.widget = widget;
 			localProfile = Game.LocalPlayerProfile;
 
@@ -107,9 +118,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					// Remove any stale badges that may be left over from a previous session
 					badgeContainer.RemoveChildren();
 
-					var badges = Ui.LoadWidget("PLAYER_PROFILE_BADGES_INSERT", badgeContainer, new WidgetArgs()
+					var badges = dynamicWidgets.LoadWidget(badgeContainer, "PLAYER_PROFILE_BADGES_INSERT", new WidgetArgs()
 						{
-							{ "worldRenderer", worldRenderer },
 							{ "profile", localProfile.ProfileData },
 							{ "negotiateWidth", negotiateWidth }
 						});
@@ -134,6 +144,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference]
 		const string LoadingPlayerProfileFailed = "label-loading-player-profile-failed";
 
+		public class RegisteredProfileTooltipLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = EmptySet;
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } =
+				new Dictionary<string, string>
+				{
+					{ "PLAYER_PROFILE_BADGES_INSERT", "BADGES_CONTAINER" },
+				};
+		}
+
+		readonly RegisteredProfileTooltipLogicDynamicWidgets dynamicWidgets = new();
 		readonly PlayerDatabase playerDatabase;
 		PlayerProfile profile;
 		bool profileLoaded;
@@ -213,7 +234,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 							if (profile.Badges.Count > 0)
 							{
-								var badges = Ui.LoadWidget("PLAYER_PROFILE_BADGES_INSERT", badgeContainer, new WidgetArgs()
+								var badges = dynamicWidgets.LoadWidget(badgeContainer, "PLAYER_PROFILE_BADGES_INSERT", new WidgetArgs()
 								{
 									{ nameof(worldRenderer), worldRenderer },
 									{ nameof(profile), profile },

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -106,6 +106,41 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		static Filter filter = new();
 
+		public class ReplayBrowserLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } =
+				new HashSet<string>
+				{
+					"TEXT_INPUT_PROMPT",
+					"TWOBUTTON_PROMPT",
+					"THREEBUTTON_PROMPT",
+				};
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } =
+				new Dictionary<string, string>
+				{
+					{ "MAP_PREVIEW", "MAP_PREVIEW_ROOT" },
+				};
+			public override IReadOnlyDictionary<string, IReadOnlyCollection<string>> ParentDropdownWidgetIdsFromPanelWidgetId { get; } =
+				new Dictionary<string, IReadOnlyCollection<string>>
+				{
+					{
+						"LABEL_DROPDOWN_TEMPLATE",
+						new[]
+						{
+							"FLT_GAMETYPE_DROPDOWNBUTTON",
+							"FLT_DATE_DROPDOWNBUTTON",
+							"FLT_DURATION_DROPDOWNBUTTON",
+							"FLT_OUTCOME_DROPDOWNBUTTON",
+							"FLT_MAPNAME_DROPDOWNBUTTON",
+							"FLT_PLAYER_DROPDOWNBUTTON",
+							"FLT_FACTION_DROPDOWNBUTTON",
+						}
+					},
+				};
+		}
+
+		readonly ReplayBrowserLogicDynamicWidgets dynamicWidgets = new();
+
 		readonly Widget panel;
 		readonly ScrollPanelWidget replayList, playerList;
 		readonly ScrollItemWidget playerTemplate, playerHeader;
@@ -169,9 +204,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var noSpawns = new HashSet<int>();
 			var disabledSpawnPoints = new CachedTransform<ReplayMetadata, HashSet<int>>(r => r.GameInfo.DisabledSpawnPoints ?? noSpawns);
 
-			Ui.LoadWidget("MAP_PREVIEW", mapPreviewRoot, new WidgetArgs
+			dynamicWidgets.LoadWidget(mapPreviewRoot, "MAP_PREVIEW", new WidgetArgs
 			{
-				{ "orderManager", null },
 				{ "getMap", (Func<(MapPreview, Session.MapStatus)>)(() => (map, Session.MapStatus.Playable)) },
 				{ "onMouseDown", null },
 				{ "getSpawnOccupants", (Func<Dictionary<int, SpawnOccupant>>)(() => spawnOccupants.Update(selectedReplay)) },
@@ -253,7 +287,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							return item;
 						}
 
-						ddb.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 330, options, SetupItem);
+						dynamicWidgets.ShowDropDown(ddb, "LABEL_DROPDOWN_TEMPLATE", 330, options, SetupItem);
 					};
 				}
 			}
@@ -289,7 +323,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							return item;
 						}
 
-						ddb.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 330, options, SetupItem);
+						dynamicWidgets.ShowDropDown(ddb, "LABEL_DROPDOWN_TEMPLATE", 330, options, SetupItem);
 					};
 				}
 			}
@@ -324,7 +358,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							return item;
 						}
 
-						ddb.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 330, options, SetupItem);
+						dynamicWidgets.ShowDropDown(ddb, "LABEL_DROPDOWN_TEMPLATE", 330, options, SetupItem);
 					};
 				}
 			}
@@ -359,7 +393,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							return item;
 						}
 
-						ddb.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 330, options, SetupItem);
+						dynamicWidgets.ShowDropDown(ddb, "LABEL_DROPDOWN_TEMPLATE", 330, options, SetupItem);
 					};
 				}
 			}
@@ -397,7 +431,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							return item;
 						}
 
-						ddb.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 330, options, SetupItem);
+						dynamicWidgets.ShowDropDown(ddb, "LABEL_DROPDOWN_TEMPLATE", 330, options, SetupItem);
 					};
 				}
 			}
@@ -427,7 +461,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							return item;
 						}
 
-						ddb.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 330, options, SetupItem);
+						dynamicWidgets.ShowDropDown(ddb, "LABEL_DROPDOWN_TEMPLATE", 330, options, SetupItem);
 					};
 				}
 			}
@@ -459,7 +493,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							return item;
 						}
 
-						ddb.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 330, options, SetupItem);
+						dynamicWidgets.ShowDropDown(ddb, "LABEL_DROPDOWN_TEMPLATE", 330, options, SetupItem);
 					};
 				}
 			}
@@ -476,7 +510,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var directoryName = Path.GetDirectoryName(r.FilePath);
 				var invalidChars = Path.GetInvalidFileNameChars();
 
-				ConfirmationDialogs.TextInputPrompt(modData,
+				ConfirmationDialogs.TextInputPrompt(
+					dynamicWidgets,
+					modData,
 					RenameReplayTitle,
 					RenameReplayPrompt,
 					initialName,
@@ -504,7 +540,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			void OnDeleteReplay(ReplayMetadata r, Action after)
 			{
-				ConfirmationDialogs.ButtonPrompt(modData,
+				ConfirmationDialogs.ButtonPrompt(
+					dynamicWidgets,
+					modData,
 					title: DeleteReplayTitle,
 					text: DeleteReplayPrompt,
 					textArguments: Translation.Arguments("replay", Path.GetFileNameWithoutExtension(r.FilePath)),
@@ -542,7 +580,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return;
 				}
 
-				ConfirmationDialogs.ButtonPrompt(modData,
+				ConfirmationDialogs.ButtonPrompt(
+					dynamicWidgets,
+					modData,
 					title: DeleteAllReplaysTitle,
 					text: DeleteAllReplaysPrompt,
 					textArguments: Translation.Arguments("count", list.Count),
@@ -776,7 +816,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void WatchReplay()
 		{
-			if (selectedReplay != null && ReplayUtils.PromptConfirmReplayCompatibility(selectedReplay, modData))
+			if (selectedReplay != null && ReplayUtils.PromptConfirmReplayCompatibility(dynamicWidgets, selectedReplay, modData))
 			{
 				cancelLoadingReplays = true;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using OpenRA.FileFormats;
+using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
@@ -39,41 +40,43 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		const string IncompatibleVersion = "dialog-incompatible-replay.prompt-incompatible-version";
 
 		[TranslationReference("map")]
-		const string UnvailableMap = "dialog-incompatible-replay.prompt-unavailable-map";
+		const string UnavailableMap = "dialog-incompatible-replay.prompt-unavailable-map";
 
 		static readonly Action DoNothing = () => { };
 
-		public static bool PromptConfirmReplayCompatibility(ReplayMetadata replayMeta, ModData modData, Action onCancel = null)
+		public static bool PromptConfirmReplayCompatibility(
+			ChromeLogic.DynamicWidgets dynamicWidgets, ReplayMetadata replayMeta, ModData modData, Action onCancel = null)
 		{
 			onCancel ??= DoNothing;
 
 			if (replayMeta == null)
-				return IncompatibleReplayDialog(IncompatibleReplayPrompt, null, modData, onCancel);
+				return IncompatibleReplayDialog(dynamicWidgets, IncompatibleReplayPrompt, null, modData, onCancel);
 
 			var version = replayMeta.GameInfo.Version;
 			if (version == null)
-				return IncompatibleReplayDialog(UnknownVersion, null, modData, onCancel);
+				return IncompatibleReplayDialog(dynamicWidgets, UnknownVersion, null, modData, onCancel);
 
 			var mod = replayMeta.GameInfo.Mod;
 			if (mod == null)
-				return IncompatibleReplayDialog(UnknownMod, null, modData, onCancel);
+				return IncompatibleReplayDialog(dynamicWidgets, UnknownMod, null, modData, onCancel);
 
 			if (!Game.Mods.ContainsKey(mod))
-				return IncompatibleReplayDialog(UnvailableMod, Translation.Arguments("mod", mod), modData, onCancel);
+				return IncompatibleReplayDialog(dynamicWidgets, UnvailableMod, Translation.Arguments("mod", mod), modData, onCancel);
 
 			if (Game.Mods[mod].Metadata.Version != version)
-				return IncompatibleReplayDialog(IncompatibleVersion, Translation.Arguments("version", version), modData, onCancel);
+				return IncompatibleReplayDialog(dynamicWidgets, IncompatibleVersion, Translation.Arguments("version", version), modData, onCancel);
 
 			if (replayMeta.GameInfo.MapPreview.Status != MapStatus.Available)
-				return IncompatibleReplayDialog(UnvailableMap, Translation.Arguments("map", replayMeta.GameInfo.MapUid), modData, onCancel);
+				return IncompatibleReplayDialog(dynamicWidgets, UnavailableMap, Translation.Arguments("map", replayMeta.GameInfo.MapUid), modData, onCancel);
 
 			return true;
 		}
 
-		static bool IncompatibleReplayDialog(string text, Dictionary<string, object> textArguments, ModData modData, Action onCancel)
+		static bool IncompatibleReplayDialog(
+			ChromeLogic.DynamicWidgets dynamicWidgets, string text, Dictionary<string, object> textArguments, ModData modData, Action onCancel)
 		{
 			ConfirmationDialogs.ButtonPrompt(
-				modData, IncompatibleReplayTitle, text, textArguments: textArguments, onCancel: onCancel, cancelText: IncompatibleReplayAccept);
+				dynamicWidgets, modData, IncompatibleReplayTitle, text, textArguments: textArguments, onCancel: onCancel, cancelText: IncompatibleReplayAccept);
 			return false;
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -88,6 +88,23 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference]
 		const string UnknownServerState = "label-unknown-server-state";
 
+		public class ServerListLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = EmptySet;
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } =
+				new Dictionary<string, string>
+				{
+					{ "MULTIPLAYER_CLIENT_LIST", "CLIENT_LIST_CONTAINER" },
+					{ "MULTIPLAYER_FILTER_PANEL", "FILTERS_DROPDOWNBUTTON" },
+				};
+			public override IReadOnlyDictionary<string, IReadOnlyCollection<string>> ParentDropdownWidgetIdsFromPanelWidgetId =>
+				new Dictionary<string, IReadOnlyCollection<string>>
+				{
+					{ "MULTIPLAYER_FILTER_PANEL", new[] { "FILTERS_DROPDOWNBUTTON" } },
+				};
+		}
+
+		readonly ServerListLogicDynamicWidgets dynamicWidgets = new();
 		readonly string noServerSelected;
 		readonly string mapStatusSearching;
 		readonly string mapClassificationUnknown;
@@ -244,7 +261,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				// HACK: MULTIPLAYER_FILTER_PANEL doesn't follow our normal procedure for dropdown creation
 				// but we still need to be able to set the dropdown width based on the parent
 				// The yaml should use PARENT_RIGHT instead of DROPDOWN_WIDTH
-				var filtersPanel = Ui.LoadWidget("MULTIPLAYER_FILTER_PANEL", filtersButton, new WidgetArgs());
+				var filtersPanel = dynamicWidgets.LoadWidget(filtersButton, "MULTIPLAYER_FILTER_PANEL", new WidgetArgs());
 				filtersButton.Children.Remove(filtersPanel);
 
 				var showWaitingCheckbox = filtersPanel.GetOrNull<CheckboxWidget>("WAITING_FOR_PLAYERS");
@@ -286,7 +303,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				filtersButton.OnMouseDown = _ =>
 				{
 					filtersButton.RemovePanel();
-					filtersButton.AttachPanel(filtersPanel);
+					dynamicWidgets.AttachPanel(filtersButton, filtersPanel);
 				};
 			}
 
@@ -394,7 +411,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			clientContainer = widget.GetOrNull("CLIENT_LIST_CONTAINER");
 			if (clientContainer != null)
 			{
-				clientList = Ui.LoadWidget("MULTIPLAYER_CLIENT_LIST", clientContainer, new WidgetArgs()) as ScrollPanelWidget;
+				clientList = dynamicWidgets.LoadWidget(clientContainer, "MULTIPLAYER_CLIENT_LIST", new WidgetArgs()) as ScrollPanelWidget;
 				clientList.IsVisible = () => currentServer != null && currentServer.Clients.Length > 0;
 				clientHeader = clientList.Get<ScrollItemWidget>("HEADER");
 				clientTemplate = clientList.Get<ScrollItemWidget>("TEMPLATE");

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/AudioSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/AudioSettingsLogic.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
@@ -22,6 +23,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	{
 		static readonly string OriginalSoundDevice;
 
+		public class AudioSettingsLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = EmptySet;
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } = EmptyDictionary;
+			public override IReadOnlyDictionary<string, IReadOnlyCollection<string>> ParentDropdownWidgetIdsFromPanelWidgetId { get; } =
+				new Dictionary<string, IReadOnlyCollection<string>>
+				{
+					{ "LABEL_DROPDOWN_TEMPLATE", new[] { "AUDIO_DEVICE" } },
+				};
+		}
+
+		readonly AudioSettingsLogicDynamicWidgets dynamicWidgets = new();
 		readonly WorldRenderer worldRenderer;
 
 		SoundDevice soundDevice;
@@ -178,7 +191,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return item;
 			}
 
-			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, SetupItem);
+			dynamicWidgets.ShowDropDown(dropdown, "LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, SetupItem);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
@@ -25,6 +25,19 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference("key", "context")]
 		const string DuplicateNotice = "label-duplicate-notice";
 
+		public class HotkeysSettingsLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = EmptySet;
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } = EmptyDictionary;
+			public override IReadOnlyDictionary<string, IReadOnlyCollection<string>> ParentDropdownWidgetIdsFromPanelWidgetId { get; } =
+				new Dictionary<string, IReadOnlyCollection<string>>
+				{
+					{ "LABEL_DROPDOWN_TEMPLATE", new[] { "CONTEXT_DROPDOWN" } },
+				};
+		}
+
+		readonly HotkeysSettingsLogicDynamicWidgets dynamicWidgets = new();
+
 		readonly ModData modData;
 		readonly Dictionary<string, MiniYaml> logicArgs;
 
@@ -46,8 +59,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		Widget template;
 		Widget emptyListMessage;
 		Widget remapDialog;
-
-		static HotkeysSettingsLogic() { }
 
 		[ObjectCreator.UseCtor]
 		public HotkeysSettingsLogic(
@@ -349,7 +360,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return item;
 			}
 
-			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 280, contexts, SetupItem);
+			dynamicWidgets.ShowDropDown(dropdown, "LABEL_DROPDOWN_TEMPLATE", 280, contexts, SetupItem);
 
 			return true;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/InputSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/InputSettingsLogic.cs
@@ -51,8 +51,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[TranslationReference]
 		const string None = "options-zoom-modifier.none";
 
-		static InputSettingsLogic() { }
+		public class InputSettingsLogicDynamicWidgets : DynamicWidgets
+		{
+			public override ISet<string> WindowWidgetIds { get; } = EmptySet;
+			public override IReadOnlyDictionary<string, string> ParentWidgetIdForChildWidgetId { get; } = EmptyDictionary;
+			public override IReadOnlyDictionary<string, IReadOnlyCollection<string>> ParentDropdownWidgetIdsFromPanelWidgetId { get; } =
+				new Dictionary<string, IReadOnlyCollection<string>>
+				{
+					{ "LABEL_DROPDOWN_TEMPLATE", new[] { "MOUSE_CONTROL_DROPDOWN", "MOUSE_SCROLL_TYPE_DROPDOWN", "ZOOM_MODIFIER" } },
+				};
+		}
 
+		readonly InputSettingsLogicDynamicWidgets dynamicWidgets = new();
 		readonly string classic;
 		readonly string modern;
 
@@ -78,11 +88,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SettingsUtils.BindSliderPref(panel, "UI_SCROLLSPEED_SLIDER", gs, "UIScrollSpeed");
 
 			var mouseControlDropdown = panel.Get<DropDownButtonWidget>("MOUSE_CONTROL_DROPDOWN");
-			mouseControlDropdown.OnMouseDown = _ => ShowMouseControlDropdown(mouseControlDropdown, gs);
+			mouseControlDropdown.OnMouseDown = _ => ShowMouseControlDropdown(dynamicWidgets, mouseControlDropdown, gs);
 			mouseControlDropdown.GetText = () => gs.UseClassicMouseStyle ? classic : modern;
 
 			var mouseScrollDropdown = panel.Get<DropDownButtonWidget>("MOUSE_SCROLL_TYPE_DROPDOWN");
-			mouseScrollDropdown.OnMouseDown = _ => ShowMouseScrollDropdown(mouseScrollDropdown, gs);
+			mouseScrollDropdown.OnMouseDown = _ => ShowMouseScrollDropdown(dynamicWidgets, mouseScrollDropdown, gs);
 			mouseScrollDropdown.GetText = () => gs.MouseScroll.ToString();
 
 			var mouseControlDescClassic = panel.Get("MOUSE_CONTROL_DESC_CLASSIC");
@@ -127,7 +137,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			var zoomModifierDropdown = panel.Get<DropDownButtonWidget>("ZOOM_MODIFIER");
-			zoomModifierDropdown.OnMouseDown = _ => ShowZoomModifierDropdown(zoomModifierDropdown, gs);
+			zoomModifierDropdown.OnMouseDown = _ => ShowZoomModifierDropdown(dynamicWidgets, zoomModifierDropdown, gs);
 			zoomModifierDropdown.GetText = () => gs.ZoomModifier.ToString();
 
 			SettingsUtils.AdjustSettingsScrollPanelLayout(scrollPanel);
@@ -159,7 +169,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 		}
 
-		public static void ShowMouseControlDropdown(DropDownButtonWidget dropdown, GameSettings s)
+		public static void ShowMouseControlDropdown(
+			DynamicWidgets dynamicWidgets,
+			DropDownButtonWidget dropdown, GameSettings s)
 		{
 			var options = new Dictionary<string, bool>()
 			{
@@ -176,10 +188,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return item;
 			}
 
-			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, SetupItem);
+			dynamicWidgets.ShowDropDown(dropdown, "LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, SetupItem);
 		}
 
-		static void ShowMouseScrollDropdown(DropDownButtonWidget dropdown, GameSettings s)
+		static void ShowMouseScrollDropdown(
+			InputSettingsLogicDynamicWidgets dynamicWidgets,
+			DropDownButtonWidget dropdown, GameSettings s)
 		{
 			var options = new Dictionary<string, MouseScrollType>()
 			{
@@ -198,10 +212,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return item;
 			}
 
-			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, SetupItem);
+			dynamicWidgets.ShowDropDown(dropdown, "LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, SetupItem);
 		}
 
-		static void ShowZoomModifierDropdown(DropDownButtonWidget dropdown, GameSettings s)
+		static void ShowZoomModifierDropdown(
+			InputSettingsLogicDynamicWidgets dynamicWidgets,
+			DropDownButtonWidget dropdown, GameSettings s)
 		{
 			var options = new Dictionary<string, Modifiers>()
 			{
@@ -221,7 +237,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return item;
 			}
 
-			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, SetupItem);
+			dynamicWidgets.ShowDropDown(dropdown, "LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, SetupItem);
 		}
 
 		static void MakeMouseFocusSettingsLive()

--- a/OpenRA.Mods.Common/Widgets/MenuButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MenuButtonWidget.cs
@@ -13,7 +13,6 @@ namespace OpenRA.Mods.Common.Widgets
 {
 	public class MenuButtonWidget : WorldButtonWidget
 	{
-		public readonly string MenuContainer = "INGAME_MENU";
 		public readonly bool Pause = true;
 		public readonly bool HideIngameUI = true;
 		public readonly bool DisableWorldSounds = false;
@@ -25,7 +24,6 @@ namespace OpenRA.Mods.Common.Widgets
 		protected MenuButtonWidget(MenuButtonWidget other)
 			: base(other)
 		{
-			MenuContainer = other.MenuContainer;
 			Pause = other.Pause;
 			HideIngameUI = other.HideIngameUI;
 		}

--- a/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
@@ -189,7 +189,7 @@ namespace OpenRA.Mods.Common.Widgets
 				lastIconIdx = i;
 				TooltipIcon = supportPowerIconsIcons[i];
 				currentTooltipToken = tooltipContainer.Value.SetTooltip(TooltipTemplate,
-					new WidgetArgs() { { "world", worldRenderer.World }, { "player", GetPlayer() }, { "getTooltipIcon", GetTooltipIcon } });
+					new WidgetArgs() { { "player", GetPlayer() }, { "getTooltipIcon", GetTooltipIcon } });
 				return;
 			}
 

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -249,7 +249,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			if (TooltipContainer != null)
 				tooltipContainer.Value.SetTooltip(TooltipTemplate,
-					new WidgetArgs() { { "player", World.LocalPlayer }, { "getTooltipIcon", GetTooltipIcon }, { "world", World } });
+					new WidgetArgs() { { "player", World.LocalPlayer }, { "getTooltipIcon", GetTooltipIcon } });
 		}
 
 		public override void MouseExited()

--- a/OpenRA.Mods.Common/Widgets/ResourceBarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ResourceBarWidget.cs
@@ -33,13 +33,11 @@ namespace OpenRA.Mods.Common.Widgets
 		public Func<Color> GetBarColor = () => Color.White;
 		readonly EWMA providedLerp = new(0.3f);
 		readonly EWMA usedLerp = new(0.3f);
-		readonly World world;
 		Sprite indicator;
 
 		[ObjectCreator.UseCtor]
-		public ResourceBarWidget(World world)
+		public ResourceBarWidget()
 		{
-			this.world = world;
 			tooltipContainer = Exts.Lazy(() =>
 				Ui.Root.Get<TooltipContainerWidget>(TooltipContainer));
 		}
@@ -57,7 +55,7 @@ namespace OpenRA.Mods.Common.Widgets
 				return;
 
 			Func<string> getText = () => TooltipTextCached.Update((GetUsed(), GetProvided()));
-			tooltipContainer.Value.SetTooltip(TooltipTemplate, new WidgetArgs() { { "getText", getText }, { "world", world } });
+			tooltipContainer.Value.SetTooltip(TooltipTemplate, new WidgetArgs() { { "getText", getText } });
 		}
 
 		public override void MouseExited()

--- a/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
@@ -261,7 +261,7 @@ namespace OpenRA.Mods.Common.Widgets
 				return;
 
 			tooltipContainer.Value.SetTooltip(TooltipTemplate,
-				new WidgetArgs() { { "world", worldRenderer.World }, { "player", spm.Self.Owner }, { "getTooltipIcon", GetTooltipIcon } });
+				new WidgetArgs() { { "player", spm.Self.Owner }, { "getTooltipIcon", GetTooltipIcon } });
 		}
 
 		public override void MouseExited()

--- a/OpenRA.Mods.Common/Widgets/TextNotificationsDisplayWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TextNotificationsDisplayWidget.cs
@@ -40,11 +40,11 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			base.Initialize(args);
 
-			templates.Add(TextNotificationPool.Chat, Ui.LoadWidget(ChatTemplate, null, new WidgetArgs()));
-			templates.Add(TextNotificationPool.System, Ui.LoadWidget(SystemTemplate, null, new WidgetArgs()));
-			templates.Add(TextNotificationPool.Mission, Ui.LoadWidget(MissionTemplate, null, new WidgetArgs()));
-			templates.Add(TextNotificationPool.Feedback, Ui.LoadWidget(FeedbackTemplate, null, new WidgetArgs()));
-			templates.Add(TextNotificationPool.Transients, Ui.LoadWidget(TransientsTemplate, null, new WidgetArgs()));
+			templates.Add(TextNotificationPool.Chat, Ui.LoadWidgetUnchecked(ChatTemplate, null, new WidgetArgs()));
+			templates.Add(TextNotificationPool.System, Ui.LoadWidgetUnchecked(SystemTemplate, null, new WidgetArgs()));
+			templates.Add(TextNotificationPool.Mission, Ui.LoadWidgetUnchecked(MissionTemplate, null, new WidgetArgs()));
+			templates.Add(TextNotificationPool.Feedback, Ui.LoadWidgetUnchecked(FeedbackTemplate, null, new WidgetArgs()));
+			templates.Add(TextNotificationPool.Transients, Ui.LoadWidgetUnchecked(TransientsTemplate, null, new WidgetArgs()));
 
 			// HACK: Assume that all templates use the same font
 			var lineHeight = Game.Renderer.Fonts[templates[TextNotificationPool.Chat].Get<LabelWidget>("TEXT").Font].Measure("").Y;

--- a/OpenRA.Mods.Common/Widgets/TooltipContainerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TooltipContainerWidget.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (id == null || tooltip != null)
 				return;
 
-			tooltip = Ui.LoadWidget(id, this, new WidgetArgs(widgetArgs) { { "tooltipContainer", this } });
+			tooltip = Ui.LoadWidgetUnchecked(id, this, Game.ExtendWidgetArgs(new WidgetArgs(widgetArgs) { { "tooltipContainer", this } }));
 		}
 
 		public int SetTooltip(string id, WidgetArgs args)

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -167,7 +167,7 @@ namespace OpenRA.Mods.Common.Widgets
 				return;
 
 			tooltipContainer.Value.SetTooltip(TooltipTemplate,
-				new WidgetArgs() { { "world", world }, { "viewport", this } });
+				new WidgetArgs() { { "viewport", this } });
 		}
 
 		public override void MouseExited()

--- a/OpenRA.Mods.Common/Widgets/WorldButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldButtonWidget.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Widgets
 				return;
 
 			tooltipContainer.Value.SetTooltip(TooltipTemplate,
-				new WidgetArgs { { "button", this }, { "getText", GetTooltipText }, { "getDesc", GetTooltipDesc }, { "world", world } });
+				new WidgetArgs { { "button", this }, { "getText", GetTooltipText }, { "getDesc", GetTooltipDesc } });
 		}
 
 		public override Widget Clone() { return new WorldButtonWidget(this); }

--- a/OpenRA.Mods.Common/Widgets/WorldLabelWithTooltipWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldLabelWithTooltipWidget.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Widgets
 				return;
 
 			if (GetTooltipText != null)
-				tooltipContainer.Value.SetTooltip(TooltipTemplate, new WidgetArgs() { { "getText", GetTooltipText }, { "world", world } });
+				tooltipContainer.Value.SetTooltip(TooltipTemplate, new WidgetArgs() { { "getText", GetTooltipText } });
 		}
 	}
 }

--- a/mods/cnc/chrome/tooltips.yaml
+++ b/mods/cnc/chrome/tooltips.yaml
@@ -72,29 +72,6 @@ Background@BUTTON_TOOLTIP_FACTIONSUFFIX:
 			Font: TinyBold
 			VAlign: Top
 
-Background@BUTTON_WITH_DESC_HIGHLIGHT_TOOLTIP:
-	Logic: ButtonTooltipLogic
-	Background: panel-black
-	Height: 26
-	Children:
-		Label@LABEL:
-			X: 5
-			Y: 1
-			Height: 23
-			Font: Bold
-		Label@HOTKEY:
-			Y: 1
-			Visible: false
-			TextColor: FFFF00
-			Height: 23
-			Font: Bold
-		LabelWithHighlight@DESC:
-			X: 5
-			Y: 26
-			Height: 12
-			Font: TinyBold
-			VAlign: Top
-
 Background@BUTTON_WITH_DESC_HIGHLIGHT_TOOLTIP_FACTIONSUFFIX:
 	Logic: ButtonTooltipLogic, AddFactionSuffixLogic
 	Background: panel-black

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -854,7 +854,7 @@ Container@EDITOR_WORLD_ROOT:
 							ImageName: history
 		MenuButton@OPTIONS_BUTTON:
 			Logic: MenuButtonsChromeLogic
-			MenuContainer: INGAME_MENU
+				MenuContainer: INGAME_MENU
 			HideIngameUI: true
 			Pause: true
 			Width: 60


### PR DESCRIPTION
We teach the CheckTranslationReference lint pass to determine the widget bounds of all possible widget trees, and then check the translation text fits within the bounds where it is going to be rendered. This allows translation text that is too long to be flagged, so that either the translation text can be revised or the UI adjusted to ensure the text fits.

As the lint pass is doing a static analysis, results won't be perfect as for example it won't replicate logic that resizes widgets dynamically at runtime. It also hardcodes a lot of knowledge about the function of widgets and logic classes in order to provide a sufficient model for determining widget bounds so we can check sizes.

Existing issues flagged by this pass often look okay in the UI, as we allow text to be rendered outside of the available widget bounds. So the text can appear to be fine even though it's outside the defined area. By fixing the existing sizes in YAML, we now have an English translation that pass the lint. Future translations will now be able to quickly identify issues as we know the English version passes. (This is also useful to help avoid issues where the bounds do matter, e.g. the scroll widget uses the bounds to decide what is in view and needs rendering, so inaccurate bounds can cause items to fail to render when required) Fixes detected by this lint pass were merged in #21309.

To try this lint pass, run the Utility with `ra --check-yaml`, `cnc --check-yaml`, `d2k --check-yaml` or `ts --check-yaml` to validate that mod.

----

Assists with #10475.

Example by setting `button-main-menu-singleplayer = SingleplayerButTheTextIsTooLong`:
https://github.com/OpenRA/OpenRA/blob/0741439dd6face978a46bf3b0e7a3e4f363280b2/mods/common/languages/chrome/en.ftl#L325

Ingame:
![image](https://github.com/OpenRA/OpenRA/assets/3399086/dd088324-25fe-4aa7-bb0c-023853226c37)

Utility output of `ra --check-yaml`:
> Testing translation: en
OpenRA.Utility(1,1): Warning: `button-main-menu-singleplayer` defined by `Button@SINGLEPLAYER_BUTTON` in field `Text` in common|chrome/mainmenu.yaml:49 has value `SingleplayerButTheTextIsTooLong` in `en` translation. Text is too large for widget. Text is 240,14. Widget is 140,30.