### PR TITLE
Enable paying up front in Production queue

### DIFF
--- a/OpenRA.Mods.Common/Traits/ProductionQueueFromSelection.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionQueueFromSelection.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 					.FirstOrDefault(q => q.Enabled && types.Contains(q.Info.Type));
 			}
 
-			if (queue == null || !queue.BuildableItems().Any())
+			if (queue == null || !queue.AnyItemsToBuild())
 				return;
 
 			if (tabsWidget.Value != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ClassicProductionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ClassicProductionLogic.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				palette.PickUpCompletedBuilding();
 			}
 
-			button.IsDisabled = () => !queues.Any(q => q.BuildableItems().Any());
+			button.IsDisabled = () => !queues.Any(q => q.AnyItemsToBuild());
 			button.OnMouseUp = mi => SelectTab(mi.Modifiers.HasModifier(Modifiers.Shift));
 			button.OnKeyPress = e => SelectTab(e.Modifiers.HasModifier(Modifiers.Shift));
 			button.OnClick = () => SelectTab(false);

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -338,8 +338,11 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (buildable != null)
 			{
-				// Queue a new item
+				if (CurrentQueue.Info.PayUpFront && currentQueue.GetProductionCost(buildable) > CurrentQueue.Actor.Owner.PlayerActor.Trait<PlayerResources>().GetCashAndResources())
+					return false;
 				Game.Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Sounds", ClickSound, null);
+
+				// Queue a new item
 				var canQueue = CurrentQueue.CanQueue(buildable, out var notification, out var textNotification);
 
 				if (!CurrentQueue.AllQueued().Any())
@@ -366,7 +369,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			Game.Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Sounds", ClickSound, null);
 
-			if (CurrentQueue.Info.DisallowPaused || item.Paused || item.Done || item.TotalCost == item.RemainingCost)
+			if (CurrentQueue.Info.DisallowPaused || item.Paused || item.Done || item.TotalCost == item.RemainingCost || !item.Started)
 			{
 				// Instantly cancel items that haven't started, have finished, or if the queue doesn't support pausing
 				Game.Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.CancelledAudio, World.LocalPlayer.Faction.InternalName);


### PR DESCRIPTION
This PR implements some features thats D2k Starport will need.
In OG D2k Starport tab behaves like this;
- you must pay full Unit Price up front.
- Unit Icon is enabled only if you have enough money at the moment. If you dont unit icon is disabled.
- When you reach max capacity all unit icons become disabled and you can click only on Purchase Icon.

This PR implements first two steps. It adds MoneyUpFront options into the ProductionQueue.

Example how its work on ClassicProductionQueues:

https://github.com/OpenRA/OpenRA/assets/100044015/35db0cb5-f832-4bc2-9c32-4e9d287b5c78

Example how its work with my LUA Starport implementation:

https://github.com/OpenRA/OpenRA/assets/100044015/4bea2e8d-0cfd-41e6-bf6f-d6720f3f748b


Im not sure if this is the right way to code this, so feal free for suggestions.
