### PR TITLE
ParallelProductionQueue: pause production, when all Production traits are paused

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ParallelProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ParallelProductionQueue.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 			CancelUnbuildableItems();
 
 			var item = Queue.FirstOrDefault(i => !i.Paused);
-			if (item == null)
+			if (item == null || allProductionPaused)
 				return;
 
 			var before = item.RemainingTime;


### PR DESCRIPTION
As per discussion on Discord, this PR makes `ParallelProductionQueue` support paused `Production` traits (i.e. the production is actually paused).