### PR TITLE
Fix uses of LabelWidget.Text and ButtonWidget.Text to use GetText instead.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -113,8 +113,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			actorIDErrorLabel = actorEditPanel.Get<LabelWidget>("ACTOR_ID_ERROR_LABEL");
 			actorIDErrorLabel.IsVisible = () => actorIDStatus != ActorIDStatus.Normal;
-			actorIDErrorLabel.GetText = () => actorIDStatus == ActorIDStatus.Duplicate ?
-				TranslationProvider.GetString(DuplicateActorId)
+			actorIDErrorLabel.GetText = () =>
+				actorIDStatus == ActorIDStatus.Duplicate || nextActorIDStatus == ActorIDStatus.Duplicate
+					? TranslationProvider.GetString(DuplicateActorId)
 					: TranslationProvider.GetString(EnterActorId);
 
 			if (logicArgs.TryGetValue("EditPanelPadding", out var yaml))
@@ -143,7 +144,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (!CurrentActor.ID.Equals(actorId, StringComparison.OrdinalIgnoreCase) && editorActorLayer[actorId] != null)
 				{
 					nextActorIDStatus = ActorIDStatus.Duplicate;
-					actorIDErrorLabel.Text = TranslationProvider.GetString(DuplicateActorId);
 					actorIDErrorLabel.Visible = true;
 					return;
 				}
@@ -214,7 +214,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					var font = Game.Renderer.Fonts[typeLabel.Font];
 					var truncatedType = WidgetUtils.TruncateText(actor.DescriptiveName, typeLabel.Bounds.Width, font);
-					typeLabel.Text = truncatedType;
+					typeLabel.GetText = () => truncatedType;
 
 					actorIDField.CursorPosition = actor.ID.Length;
 					nextActorIDStatus = ActorIDStatus.Normal;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -80,7 +80,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ownersDropDown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 270, owners, SetupItem);
 			};
 
-			ownersDropDown.Text = selectedOwner.Name;
+			var selectedOwnerName = selectedOwner.Name;
+			ownersDropDown.GetText = () => selectedOwnerName;
 			ownersDropDown.TextColor = selectedOwner.Color;
 
 			var tileSetId = world.Map.Rules.TerrainInfo.Id;
@@ -161,7 +162,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void SelectOwner(PlayerReference option)
 		{
 			selectedOwner = option;
-			ownersDropDown.Text = option.Name;
+			var optionName = option.Name;
+			ownersDropDown.GetText = () => optionName;
 			ownersDropDown.TextColor = option.Color;
 			InitializePreviews();
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -32,13 +32,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			ScrollItemWidget SetupItem(string option, ScrollItemWidget template)
 			{
 				var item = ScrollItemWidget.Setup(template,
-					() => tilesetDropDown.Text == option,
-					() => tilesetDropDown.Text = option);
+					() => tilesetDropDown.GetText() == option,
+					() => tilesetDropDown.GetText = () => option);
 				item.Get<LabelWidget>("LABEL").GetText = () => option;
 				return item;
 			}
 
-			tilesetDropDown.Text = tilesets.First();
+			var firstTileset = tilesets.First();
+			tilesetDropDown.GetText = () => firstTileset;
 			tilesetDropDown.OnClick = () =>
 				tilesetDropDown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 210, tilesets, SetupItem);
 
@@ -56,7 +57,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				height = Math.Max(2, height);
 
 				var maxTerrainHeight = world.Map.Grid.MaximumTerrainHeight;
-				var tileset = modData.DefaultTerrainInfo[tilesetDropDown.Text];
+				var tileset = modData.DefaultTerrainInfo[tilesetDropDown.GetText()];
 				var map = new Map(Game.ModData, tileset, width + 2, height + maxTerrainHeight + 2);
 
 				var tl = new PPos(1, 1 + maxTerrainHeight);

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -179,12 +179,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					var item = ScrollItemWidget.Setup(template,
 						() => fileType == option.Key,
-						() => { typeDropdown.Text = option.Value.UiLabel; fileType = option.Key; });
+						() => { var label = option.Value.UiLabel; typeDropdown.GetText = () => label; fileType = option.Key; });
 					item.Get<LabelWidget>("LABEL").GetText = () => option.Value.UiLabel;
 					return item;
 				}
 
-				typeDropdown.Text = fileTypes[fileType].UiLabel;
+				var label = fileTypes[fileType].UiLabel;
+				typeDropdown.GetText = () => label;
 
 				typeDropdown.OnClick = () =>
 					typeDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 210, fileTypes, SetupItem);

--- a/OpenRA.Mods.Common/Widgets/Logic/EncyclopediaLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/EncyclopediaLogic.cs
@@ -162,7 +162,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				text += WidgetUtils.WrapText(TranslationProvider.GetString(info.Description) + "\n\n", descriptionLabel.Bounds.Width, descriptionFont);
 
 			var height = descriptionFont.Measure(text).Y;
-			descriptionLabel.Text = text;
+			descriptionLabel.GetText = () => text;
 			descriptionLabel.Bounds.Height = height;
 			descriptionPanel.Layout.AdjustChildren();
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ArmyTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ArmyTooltipLogic.cs
@@ -41,12 +41,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var name = tooltip != null ? TranslationProvider.GetString(tooltip.Name) : armyUnit.ActorInfo.Name;
 				var buildable = armyUnit.BuildableInfo;
 
-				nameLabel.Text = name;
-
+				nameLabel.GetText = () => name;
 				var nameSize = font.Measure(name);
 
 				var desc = string.IsNullOrEmpty(buildable.Description) ? "" : TranslationProvider.GetString(buildable.Description);
-				descLabel.Text = desc;
+				descLabel.GetText = () => desc;
 				var descSize = descFont.Measure(desc);
 				descLabel.Bounds.Width = descSize.X;
 				descLabel.Bounds.Height = descSize.Y + descLabelPadding;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoBriefingLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoBriefingLogic.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (missionData != null)
 			{
 				var text = WidgetUtils.WrapText(missionData.Briefing?.Replace("\\n", "\n"), mapDescription.Bounds.Width, mapFont);
-				mapDescription.Text = text;
+				mapDescription.GetText = () => text;
 				mapDescription.Bounds.Height = mapFont.Measure(text).Y;
 				mapDescriptionPanel.ScrollToTop();
 				mapDescriptionPanel.Layout.AdjustChildren();

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -108,7 +108,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				if (tabButton != null)
 				{
-					tabButton.Text = TranslationProvider.GetString(label);
+					var tabButtonText = TranslationProvider.GetString(label);
+					tabButton.GetText = () => tabButtonText;
 					tabButton.OnClick = () =>
 					{
 						if (activePanel == IngameInfoPanel.Chat)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameSaveLoadingLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameSaveLoadingLogic.cs
@@ -22,7 +22,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var versionLabel = widget.GetOrNull<LabelWidget>("VERSION_LABEL");
 			if (versionLabel != null)
-				versionLabel.Text = modData.Manifest.Metadata.Version;
+			{
+				var versionText = modData.Manifest.Metadata.Version;
+				versionLabel.GetText = () => versionText;
+			}
 
 			var keyhandler = widget.Get<LogicKeyListenerWidget>("CANCEL_HANDLER");
 			keyhandler.AddHandler(e =>

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
@@ -78,7 +78,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			siloUsageTooltip = siloUsageTooltipCache.Update((playerResources.Resources, playerResources.ResourceCapacity));
-			cashLabel.Text = displayResources.ToString(CultureInfo.CurrentCulture);
+			var displayResourcesText = displayResources.ToString(CultureInfo.CurrentCulture);
+			cashLabel.GetText = () => displayResourcesText;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -187,7 +187,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			mpe = world.WorldActor.TraitOrDefault<MenuPostProcessEffect>();
 			mpe?.Fade(mpe.Info.MenuEffect);
 
-			menu.Get<LabelWidget>("VERSION_LABEL").Text = modData.Manifest.Metadata.Version;
+			var versionText = modData.Manifest.Metadata.Version;
+			menu.Get<LabelWidget>("VERSION_LABEL").GetText = () => versionText;
 
 			buttonContainer = menu.Get("MENU_BUTTONS");
 			buttonTemplate = buttonContainer.Get<ButtonWidget>("BUTTON_TEMPLATE");

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						cost = valued.Cost;
 				}
 
-				nameLabel.Text = name;
+				nameLabel.GetText = () => name;
 
 				var nameSize = font.Measure(name);
 				var hotkeyWidth = 0;
@@ -93,18 +93,21 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var hotkeyText = $"({hotkey.DisplayString()})";
 
 					hotkeyWidth = font.Measure(hotkeyText).X + 2 * nameLabel.Bounds.X;
-					hotkeyLabel.Text = hotkeyText;
+					hotkeyLabel.GetText = () => hotkeyText;
 					hotkeyLabel.Bounds.X = nameSize.X + 2 * nameLabel.Bounds.X;
 				}
 
-				var prereqs = buildable.Prerequisites.Select(a => ActorName(mapRules, a))
-					.Where(s => !s.StartsWith('~') && !s.StartsWith('!'));
+				var prereqs = buildable.Prerequisites
+					.Select(a => ActorName(mapRules, a))
+					.Where(s => !s.StartsWith('~') && !s.StartsWith('!'))
+					.ToList();
 
 				var requiresSize = int2.Zero;
-				if (prereqs.Any())
+				if (prereqs.Count > 0)
 				{
-					requiresLabel.Text = TranslationProvider.GetString(Requires, Translation.Arguments("prequisites", prereqs.JoinWith(", ")));
-					requiresSize = requiresFont.Measure(requiresLabel.Text);
+					var requiresText = TranslationProvider.GetString(Requires, Translation.Arguments("prequisites", prereqs.JoinWith(", ")));
+					requiresLabel.GetText = () => requiresText;
+					requiresSize = requiresFont.Measure(requiresText);
 					requiresLabel.Visible = true;
 					descLabel.Bounds.Y = descLabelY + requiresLabel.Bounds.Height;
 				}
@@ -118,27 +121,30 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (pm != null)
 				{
 					var power = actor.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(i => i.Amount);
-					powerLabel.Text = power.ToString(NumberFormatInfo.CurrentInfo);
+					var powerText = power.ToString(NumberFormatInfo.CurrentInfo);
+					powerLabel.GetText = () => powerText;
 					powerLabel.GetColor = () => (pm.PowerProvided - pm.PowerDrained >= -power || power > 0)
 						? Color.White : Color.Red;
 					powerLabel.Visible = power != 0;
 					powerIcon.Visible = power != 0;
-					powerSize = font.Measure(powerLabel.Text);
+					powerSize = font.Measure(powerText);
 				}
 
 				var buildTime = tooltipIcon.ProductionQueue?.GetBuildTime(actor, buildable) ?? 0;
 				var timeModifier = pm != null && pm.PowerState != PowerState.Normal ? tooltipIcon.ProductionQueue.Info.LowPowerModifier : 100;
 
-				timeLabel.Text = formatBuildTime.Update(buildTime * timeModifier / 100);
+				var timeText = formatBuildTime.Update(buildTime * timeModifier / 100);
+				timeLabel.GetText = () => timeText;
 				timeLabel.TextColor = (pm != null && pm.PowerState != PowerState.Normal && tooltipIcon.ProductionQueue.Info.LowPowerModifier > 100) ? Color.Red : Color.White;
-				var timeSize = font.Measure(timeLabel.Text);
+				var timeSize = font.Measure(timeText);
 
-				costLabel.Text = cost.ToString(NumberFormatInfo.CurrentInfo);
+				var costText = cost.ToString(NumberFormatInfo.CurrentInfo);
+				costLabel.GetText = () => costText;
 				costLabel.GetColor = () => pr.GetCashAndResources() >= cost ? Color.White : Color.Red;
-				var costSize = font.Measure(costLabel.Text);
+				var costSize = font.Measure(costText);
 
 				var desc = string.IsNullOrEmpty(buildable.Description) ? "" : TranslationProvider.GetString(buildable.Description);
-				descLabel.Text = desc;
+				descLabel.GetText = () => desc;
 				var descSize = descFont.Measure(desc);
 				descLabel.Bounds.Width = descSize.X;
 				descLabel.Bounds.Height = descSize.Y + descLabelPadding;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ScriptErrorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ScriptErrorLogic.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var errorMessage = luaScript.Context.ErrorMessage.Replace("\r\n", "\n");
 
 				var text = WidgetUtils.WrapText(errorMessage, label.Bounds.Width, font);
-				label.Text = text;
+				label.GetText = () => text;
 				label.Bounds.Height = font.Measure(text).Y;
 				panel.ScrollToTop();
 				panel.Layout.AdjustChildren();

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
@@ -53,23 +53,24 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (sp == lastPower && hotkey == lastHotkey && lastRemainingSeconds == remainingSeconds)
 					return;
 
-				nameLabel.Text = sp.Info.Name;
-				var nameSize = nameFont.Measure(nameLabel.Text);
+				var nameText = sp.Info.Name;
+				nameLabel.GetText = () => nameText;
+				var nameSize = nameFont.Measure(nameText);
 
-				descLabel.Text = sp.Info.Description.Replace("\\n", "\n");
-				var descSize = descFont.Measure(descLabel.Text);
+				var descText = sp.Info.Description.Replace("\\n", "\n");
+				descLabel.GetText = () => descText;
+				var descSize = descFont.Measure(descText);
 
-				var customLabel = sp.TooltipTimeTextOverride();
-				if (customLabel == null)
+				var timeText = sp.TooltipTimeTextOverride();
+				if (timeText == null)
 				{
 					var remaining = WidgetUtils.FormatTime(sp.RemainingTicks, world.Timestep);
 					var total = WidgetUtils.FormatTime(sp.Info.ChargeInterval, world.Timestep);
-					timeLabel.Text = $"{remaining} / {total}";
+					timeText = $"{remaining} / {total}";
 				}
-				else
-					timeLabel.Text = customLabel;
 
-				var timeSize = timeFont.Measure(timeLabel.Text);
+				timeLabel.GetText = () => timeText;
+				var timeSize = timeFont.Measure(timeText);
 				var hotkeyWidth = 0;
 				hotkeyLabel.Visible = hotkey.IsValid();
 				if (hotkeyLabel.Visible)
@@ -77,7 +78,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var hotkeyText = $"({hotkey.DisplayString()})";
 
 					hotkeyWidth = hotkeyFont.Measure(hotkeyText).X + 2 * nameLabel.Bounds.X;
-					hotkeyLabel.Text = hotkeyText;
+					hotkeyLabel.GetText = () => hotkeyText;
 					hotkeyLabel.Bounds.X = nameSize.X + 2 * nameLabel.Bounds.X;
 				}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			statusLabel.GetText = () => status.Update(getStatusText());
 
 			var text = TranslationProvider.GetString(Downloading, Translation.Arguments("title", download.Title));
-			panel.Get<LabelWidget>("TITLE").Text = text;
+			panel.Get<LabelWidget>("TITLE").GetText = () => text;
 
 			ShowDownloadDialog();
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromSourceLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromSourceLogic.cs
@@ -296,8 +296,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void ShowMessage(string title, string message)
 		{
 			visible = Mode.Message;
-			titleLabel.Text = title;
-			messageLabel.Text = message;
+			titleLabel.GetText = () => title;
+			messageLabel.GetText = () => message;
 
 			primaryButton.Bounds.Y += messageContainer.Bounds.Height - panel.Bounds.Height;
 			secondaryButton.Bounds.Y += messageContainer.Bounds.Height - panel.Bounds.Height;
@@ -308,7 +308,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void ShowProgressbar(string title, Func<string> getMessage)
 		{
 			visible = Mode.Progress;
-			titleLabel.Text = title;
+			titleLabel.GetText = () => title;
 			progressBar.IsIndeterminate = () => true;
 
 			var font = Game.Renderer.Fonts[progressLabel.Font];
@@ -324,8 +324,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void ShowList(ModContent.ModSource source, string message)
 		{
 			visible = Mode.List;
-			titleLabel.Text = source.Title;
-			listLabel.Text = message;
+			var titleText = source.Title;
+			titleLabel.GetText = () => titleText;
+			listLabel.GetText = () => message;
 
 			listPanel.RemoveChildren();
 			foreach (var package in availablePackages)
@@ -357,8 +358,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void ShowList(string title, string message, Dictionary<string, IEnumerable<string>> groups)
 		{
 			visible = Mode.List;
-			titleLabel.Text = title;
-			listLabel.Text = message;
+			titleLabel.GetText = () => title;
+			listLabel.GetText = () => message;
 
 			listPanel.RemoveChildren();
 
@@ -391,11 +392,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void ShowContinueCancel(Action continueAction)
 		{
 			primaryButton.OnClick = continueAction;
-			primaryButton.Text = TranslationProvider.GetString(Continue);
+			var primaryButtonText = TranslationProvider.GetString(Continue);
+			primaryButton.GetText = () => primaryButtonText;
 			primaryButton.Visible = true;
 
 			secondaryButton.OnClick = Ui.CloseWindow;
-			secondaryButton.Text = TranslationProvider.GetString(Cancel);
+			var secondaryButtonText = TranslationProvider.GetString(Cancel);
+			secondaryButton.GetText = () => secondaryButtonText;
 			secondaryButton.Visible = true;
 			secondaryButton.Disabled = false;
 			Game.RunAfterTick(Ui.ResetTooltips);
@@ -404,11 +407,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void ShowBackRetry(Action retryAction)
 		{
 			primaryButton.OnClick = retryAction;
-			primaryButton.Text = TranslationProvider.GetString(Retry);
+			var primaryButtonText = TranslationProvider.GetString(Retry);
+			primaryButton.GetText = () => primaryButtonText;
 			primaryButton.Visible = true;
 
 			secondaryButton.OnClick = Ui.CloseWindow;
-			secondaryButton.Text = TranslationProvider.GetString(Back);
+			var secondaryButtonText = TranslationProvider.GetString(Back);
+			secondaryButton.GetText = () => secondaryButtonText;
 			secondaryButton.Visible = true;
 			secondaryButton.Disabled = false;
 			Game.RunAfterTick(Ui.ResetTooltips);

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentSourceTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentSourceTooltipLogic.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var font = Game.Renderer.Fonts[template.Font];
 			var sourceTitles = getText().Split('\n');
 
-			var maxWidth = Game.Renderer.Fonts[desc.Font].Measure(desc.Text).X;
+			var maxWidth = Game.Renderer.Fonts[desc.Font].Measure(desc.GetText()).X;
 			var sideMargin = desc.Bounds.X;
 			var bottomMargin = sources.Bounds.Height;
 			foreach (var source in sourceTitles)

--- a/OpenRA.Mods.Common/Widgets/Logic/IntroductionPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/IntroductionPromptLogic.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var zoomDescModifier = container.Get<LabelWidget>("DESC_ZOOM_MODIFIER");
 				zoomDescModifier.IsVisible = () => gs.ZoomModifier != Modifiers.None;
 
-				var zoomDescModifierTemplate = zoomDescModifier.Text;
+				var zoomDescModifierTemplate = zoomDescModifier.GetText();
 				var zoomDescModifierLabel = new CachedTransform<Modifiers, string>(
 					mod => zoomDescModifierTemplate.Replace("MODIFIER", mod.ToString()));
 				zoomDescModifier.GetText = () => zoomDescModifierLabel.Update(gs.ZoomModifier);

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LatencyTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LatencyTooltipLogic.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var latencyFont = Game.Renderer.Fonts[latency.Font];
 			var rightMargin = widget.Bounds.Width;
 
-			latency.Bounds.X = latencyPrefix.Bounds.X + latencyPrefixFont.Measure(latencyPrefix.Text + " ").X;
+			latency.Bounds.X = latencyPrefix.Bounds.X + latencyPrefixFont.Measure(latencyPrefix.GetText() + " ").X;
 
 			widget.IsVisible = () => client != null;
 			tooltipContainer.BeforeRender = () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -481,7 +481,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			if (skirmishMode)
-				disconnectButton.Text = TranslationProvider.GetString(Back);
+			{
+				var disconnectButtonText = TranslationProvider.GetString(Back);
+				disconnectButton.GetText = () => disconnectButtonText;
+			}
 
 			if (logicArgs.TryGetValue("ChatTemplates", out var templateIds))
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -69,7 +69,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.modData = modData;
 
 			rootMenu = widget;
-			rootMenu.Get<LabelWidget>("VERSION_LABEL").Text = modData.Manifest.Metadata.Version;
+			var versionText = modData.Manifest.Metadata.Version;
+			rootMenu.Get<LabelWidget>("VERSION_LABEL").GetText = () => versionText;
 
 			// Menu buttons
 			var mainMenu = widget.Get("MAIN_MENU");

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -85,8 +85,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var title = widget.GetOrNull<LabelWidget>("MISSIONBROWSER_TITLE");
 			if (title != null)
 			{
-				var label = TranslationProvider.GetString(title.Text);
-				title.GetText = () => playingVideo != PlayingVideo.None ? selectedMap.Title : label;
+				var titleText = title.GetText();
+				title.GetText = () => playingVideo != PlayingVideo.None ? selectedMap.Title : titleText;
 			}
 
 			widget.Get("MISSION_INFO").IsVisible = () => selectedMap != null;
@@ -284,7 +284,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						if (preview == selectedMap)
 						{
-							description.Text = briefing;
+							description.GetText = () => briefing;
 							description.Bounds.Height = height;
 							descriptionPanel.Layout.AdjustChildren();
 						}

--- a/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
@@ -196,7 +196,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							badgeContainer.Bounds.Y += header.Bounds.Height;
 							if (client.IsAdmin)
 							{
-								profileWidth = Math.Max(profileWidth, adminFont.Measure(adminLabel.Text).X + 2 * adminLabel.Bounds.Left);
+								profileWidth = Math.Max(profileWidth, adminFont.Measure(adminLabel.GetText()).X + 2 * adminLabel.Bounds.Left);
 
 								adminContainer.IsVisible = () => true;
 								profileHeader.Bounds.Height += adminLabel.Bounds.Height;
@@ -318,7 +318,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var nameLabel = widget.Get<LabelWidget>("NAME");
 			var nameFont = Game.Renderer.Fonts[nameLabel.Font];
-			widget.Bounds.Width = nameFont.Measure(nameLabel.Text).X + 2 * nameLabel.Bounds.Left;
+			widget.Bounds.Width = nameFont.Measure(nameLabel.GetText()).X + 2 * nameLabel.Bounds.Left;
 
 			var locationLabel = widget.Get<LabelWidget>("LOCATION");
 			var ipLabel = widget.Get<LabelWidget>("IP");

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -562,10 +562,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				var item = replayState[replay].Item;
 				replay.RenameFile(newFilenameWithoutExtension);
-				item.Text = newFilenameWithoutExtension;
+				item.GetText = () => newFilenameWithoutExtension;
 
 				var label = item.Get<LabelWithTooltipWidget>("TITLE");
-				WidgetUtils.TruncateLabelToTooltip(label, item.Text);
+				WidgetUtils.TruncateLabelToTooltip(label, item.GetText());
 			}
 			catch (Exception ex)
 			{
@@ -798,9 +798,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Visible = true
 			};
 
-			item.Text = Path.GetFileNameWithoutExtension(replay.FilePath);
+			var itemText = Path.GetFileNameWithoutExtension(replay.FilePath);
+			item.GetText = () => itemText;
 			var label = item.Get<LabelWithTooltipWidget>("TITLE");
-			WidgetUtils.TruncateLabelToTooltip(label, item.Text);
+			WidgetUtils.TruncateLabelToTooltip(label, itemText);
 
 			item.IsVisible = () => replayState[replay].Visible;
 			replayList.AddChild(item);

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -167,30 +167,36 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			if (advertiseOnline)
 			{
-				noticesLabelA.Text = TranslationProvider.GetString(InternetServerNatA) + " ";
-				var aWidth = Game.Renderer.Fonts[noticesLabelA.Font].Measure(noticesLabelA.Text).X;
+				var noticesLabelAText = TranslationProvider.GetString(InternetServerNatA) + " ";
+				noticesLabelA.GetText = () => noticesLabelAText;
+				var aWidth = Game.Renderer.Fonts[noticesLabelA.Font].Measure(noticesLabelAText).X;
 				noticesLabelA.Bounds.Width = aWidth;
 
-				noticesLabelB.Text = Nat.Status == NatStatus.Enabled ? TranslationProvider.GetString(InternetServerNatBenabled) :
-					Nat.Status == NatStatus.NotSupported ? TranslationProvider.GetString(InternetServerNatBnotSupported)
-						: TranslationProvider.GetString(InternetServerNatBdisabled);
+				var noticesLabelBText =
+					Nat.Status == NatStatus.Enabled ? TranslationProvider.GetString(InternetServerNatBenabled) :
+					Nat.Status == NatStatus.NotSupported ? TranslationProvider.GetString(InternetServerNatBnotSupported) :
+					TranslationProvider.GetString(InternetServerNatBdisabled);
+				noticesLabelB.GetText = () => noticesLabelBText;
 
-				noticesLabelB.TextColor = Nat.Status == NatStatus.Enabled ? ChromeMetrics.Get<Color>("NoticeSuccessColor") :
+				noticesLabelB.TextColor =
+					Nat.Status == NatStatus.Enabled ? ChromeMetrics.Get<Color>("NoticeSuccessColor") :
 					Nat.Status == NatStatus.NotSupported ? ChromeMetrics.Get<Color>("NoticeErrorColor") :
 					ChromeMetrics.Get<Color>("NoticeInfoColor");
 
-				var bWidth = Game.Renderer.Fonts[noticesLabelB.Font].Measure(noticesLabelB.Text).X;
+				var bWidth = Game.Renderer.Fonts[noticesLabelB.Font].Measure(noticesLabelBText).X;
 				noticesLabelB.Bounds.X = noticesLabelA.Bounds.Right;
 				noticesLabelB.Bounds.Width = bWidth;
 				noticesLabelB.Visible = true;
 
-				noticesLabelC.Text = TranslationProvider.GetString(InternetServerNatC);
+				var noticesLabelCText = TranslationProvider.GetString(InternetServerNatC);
+				noticesLabelC.GetText = () => noticesLabelCText;
 				noticesLabelC.Bounds.X = noticesLabelB.Bounds.Right;
 				noticesLabelC.Visible = true;
 			}
 			else
 			{
-				noticesLabelA.Text = TranslationProvider.GetString(LocalServer);
+				var noticesLabelAText = TranslationProvider.GetString(LocalServer);
+				noticesLabelA.GetText = () => noticesLabelAText;
 				noticesLabelB.Visible = false;
 				noticesLabelC.Visible = false;
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -229,7 +229,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var frameLimitGamespeedCheckbox = panel.Get<CheckboxWidget>("FRAME_LIMIT_GAMESPEED_CHECKBOX");
 			var frameLimitCheckbox = panel.Get<CheckboxWidget>("FRAME_LIMIT_CHECKBOX");
-			var frameLimitOrigLabel = frameLimitCheckbox.Text;
 			var frameLimitLabel = new CachedTransform<int, string>(fps => TranslationProvider.GetString(FrameLimiter, Translation.Arguments("fps", fps)));
 			frameLimitCheckbox.GetText = () => frameLimitLabel.Update(ds.MaxFramerate);
 			frameLimitCheckbox.IsDisabled = () => ds.CapFramerateToGameFps;

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/InputSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/InputSettingsLogic.cs
@@ -104,7 +104,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var zoomDescModifier = container.Get<LabelWidget>("DESC_ZOOM_MODIFIER");
 				zoomDescModifier.IsVisible = () => gs.ZoomModifier != Modifiers.None;
 
-				var zoomDescModifierTemplate = zoomDescModifier.Text;
+				var zoomDescModifierTemplate = zoomDescModifier.GetText();
 				var zoomDescModifierLabel = new CachedTransform<Modifiers, string>(
 					mod => zoomDescModifierTemplate.Replace("MODIFIER", mod.ToString()));
 				zoomDescModifier.GetText = () => zoomDescModifierLabel.Update(gs.ZoomModifier);


### PR DESCRIPTION
The Text element of these widgets was changed from display text to a translation key as part of adding translation support. Functions interested in the display text need to invoke GetText instead. Lots of functions have not been updated, resulting in symptoms such as measuring the font size of the translation key rather than the display text and resizing a widget to the wrong size.

Update all callers to use GetText when getting or setting display text. This ensure their existing functionality that was intended to work in terms of the display text and not the translation key works as expected.

----

Before:
![image](https://github.com/OpenRA/OpenRA/assets/3399086/8ee67673-58e0-4383-b7ca-f6919a43d6c8)
![image](https://github.com/OpenRA/OpenRA/assets/3399086/90184fe1-3683-4a68-96e6-8141b1028689)

After:
![image](https://github.com/OpenRA/OpenRA/assets/3399086/f95e8760-97cb-4787-b0c6-1594c2ea0a36)
![image](https://github.com/OpenRA/OpenRA/assets/3399086/5c3997e0-df4a-413c-a19a-4f5f28a77549)