### PR TITLE
Adjust widget sizes to ensure they accommodate the English translation text

### DIFF
--- a/mods/cnc/chrome/assetbrowser.yaml
+++ b/mods/cnc/chrome/assetbrowser.yaml
@@ -8,7 +8,8 @@ Container@ASSETBROWSER_PANEL:
 		LogicTicker@ANIMATION_TICKER:
 		Label@ASSETBROWSER_TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center
@@ -77,7 +78,7 @@ Container@ASSETBROWSER_PANEL:
 				Label@SPRITE_SCALE:
 					X: PARENT_RIGHT - WIDTH - 440
 					Y: 31
-					Width: 40
+					Width: 50
 					Height: 25
 					Font: Bold
 					Align: Left

--- a/mods/cnc/chrome/connection.yaml
+++ b/mods/cnc/chrome/connection.yaml
@@ -7,7 +7,8 @@ Container@CONNECTING_PANEL:
 	Children:
 		Label@CONNECTING_TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center
@@ -41,7 +42,8 @@ Container@CONNECTIONFAILED_PANEL:
 		LogicTicker@CONNECTION_FAILED_TICKER:
 		Label@TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center
@@ -106,7 +108,8 @@ Container@CONNECTION_SWITCHMOD_PANEL:
 	Children:
 		Label@TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center

--- a/mods/cnc/chrome/credits.yaml
+++ b/mods/cnc/chrome/credits.yaml
@@ -7,7 +7,8 @@ Container@CREDITS_PANEL:
 	Children:
 		Label@CREDITS_TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center

--- a/mods/cnc/chrome/dialogs.yaml
+++ b/mods/cnc/chrome/dialogs.yaml
@@ -162,7 +162,8 @@ Background@THREEBUTTON_PROMPT:
 	Children:
 		Label@PROMPT_TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center
@@ -205,7 +206,8 @@ Background@TWOBUTTON_PROMPT:
 	Children:
 		Label@PROMPT_TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center
@@ -239,7 +241,8 @@ Container@TEXT_INPUT_PROMPT:
 	Children:
 		Label@PROMPT_TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -8,7 +8,8 @@ Container@NEW_MAP_BG:
 		Label@TITLE:
 			Text: label-new-map-bg-title
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center
@@ -85,7 +86,8 @@ Container@SAVE_MAP_PANEL:
 		Label@LABEL_TITLE:
 			Text: label-save-map-panel-title
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center

--- a/mods/cnc/chrome/gamesave-browser.yaml
+++ b/mods/cnc/chrome/gamesave-browser.yaml
@@ -7,7 +7,8 @@ Container@GAMESAVE_BROWSER_PANEL:
 	Children:
 		Label@LOAD_TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center
@@ -15,7 +16,8 @@ Container@GAMESAVE_BROWSER_PANEL:
 			Visible: False
 		Label@SAVE_TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center

--- a/mods/cnc/chrome/ingame-debug.yaml
+++ b/mods/cnc/chrome/ingame-debug.yaml
@@ -4,11 +4,12 @@ Container@DEBUG_PANEL:
 	Height: PARENT_BOTTOM
 	Children:
 		Label@TITLE:
-			Y: 26
+			Y: 16
 			Font: Bold
 			Text: label-debug-panel-title
 			Align: Center
 			Width: PARENT_RIGHT
+			Height: 20
 		Checkbox@INSTANT_BUILD:
 			X: 45
 			Y: 45
@@ -76,11 +77,12 @@ Container@DEBUG_PANEL:
 			Height: 35
 			Text: button-debug-panel-reset-exploration
 		Label@VISUALIZATIONS_TITLE:
-			Y: 256
+			Y: 246
 			Font: Bold
 			Text: label-debug-panel-visualizations-title
 			Align: Center
 			Width: PARENT_RIGHT
+			Height: 20
 		Checkbox@SHOW_UNIT_PATHS:
 			X: 45
 			Y: 275

--- a/mods/cnc/chrome/ingame-info.yaml
+++ b/mods/cnc/chrome/ingame-info.yaml
@@ -8,7 +8,8 @@ Container@GAME_INFO_PANEL:
 	Children:
 		Label@TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Text: label-game-info-panel-title
 			Align: Center
 			Font: BigBold

--- a/mods/cnc/chrome/ingame-infostats.yaml
+++ b/mods/cnc/chrome/ingame-infostats.yaml
@@ -56,7 +56,7 @@ Container@SKIRMISH_STATS:
 					Font: Bold
 				Label@ACTIONS:
 					X: 457
-					Width: 20
+					Width: 80
 					Height: 25
 					Text: label-stats-actions
 					Font: Bold

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -417,7 +417,7 @@ Container@OBSERVER_WIDGETS:
 						Container@ECONOMY_STATS_HEADERS:
 							X: 0
 							Y: 0
-							Width: 730
+							Width: 735
 							Height: PARENT_BOTTOM
 							Children:
 								ColorBlock@HEADER_COLOR:
@@ -490,7 +490,7 @@ Container@OBSERVER_WIDGETS:
 									Shadow: True
 								Label@DERRICKS_HEADER:
 									X: 650
-									Width: 75
+									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
 									Text: label-economy-stats-derricks-header
@@ -563,7 +563,7 @@ Container@OBSERVER_WIDGETS:
 								Label@SUPPORT_POWERS_HEADER:
 									X: 160
 									Y: 0
-									Width: 100
+									Width: 200
 									Height: PARENT_BOTTOM
 									Font: Bold
 									Text: label-support-powers-header
@@ -1211,6 +1211,7 @@ Container@PLAYER_WIDGETS:
 							ClickThrough: false
 							Background: panel-black
 				SupportPowers@SUPPORT_PALETTE:
+					IconSize: 64, 48
 					X: 1
 					Y: 1
 					TooltipContainer: TOOLTIP_CONTAINER
@@ -1863,6 +1864,7 @@ Container@PLAYER_WIDGETS:
 					Height: 50
 					Background: panel-black
 		ProductionPalette@PRODUCTION_PALETTE:
+			IconSize: 64, 48
 			X: WINDOW_RIGHT - 5 - 17 - 194
 			Y: 320
 			Width: 192

--- a/mods/cnc/chrome/lobby-players.yaml
+++ b/mods/cnc/chrome/lobby-players.yaml
@@ -51,7 +51,7 @@ Container@LOBBY_PLAYER_BIN:
 					Font: Bold
 				Label@LABEL_LOBBY_STATUS:
 					X: 627
-					Width: 20
+					Width: 20 + 24
 					Height: 25
 					Text: label-container-lobby-status
 					Align: Left
@@ -257,7 +257,7 @@ Container@LOBBY_PLAYER_BIN:
 									Text: label-faction-factionname
 						Label@TEAM:
 							X: 435
-							Width: 25
+							Width: 44
 							Height: 25
 							Align: Center
 						DropDownButton@TEAM_DROPDOWN:

--- a/mods/cnc/chrome/lobby.yaml
+++ b/mods/cnc/chrome/lobby.yaml
@@ -14,7 +14,8 @@ Container@SERVER_LOBBY:
 	Children:
 		Label@SERVER_NAME:
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center

--- a/mods/cnc/chrome/mainmenu-prompts.yaml
+++ b/mods/cnc/chrome/mainmenu-prompts.yaml
@@ -7,7 +7,8 @@ Container@MAINMENU_INTRODUCTION_PROMPT:
 	Children:
 		Label@PROMPT_TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 25
+			Height: 25
+			Y: 0 - 37
 			Font: BigBold
 			Contrast: true
 			Align: Center
@@ -129,47 +130,56 @@ Container@MAINMENU_INTRODUCTION_PROMPT:
 									Width: PARENT_RIGHT / 2 - 20
 									Children:
 										LabelWithHighlight@DESC_SELECTION:
+											Width: PARENT_RIGHT
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-classic-selection
 										LabelWithHighlight@DESC_COMMANDS:
 											Y: 17
+											Width: PARENT_RIGHT
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-classic-commands
 										LabelWithHighlight@DESC_BUILDIGS:
 											Y: 34
+											Width: PARENT_RIGHT
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-classic-buildigs
 										LabelWithHighlight@DESC_SUPPORT:
 											Y: 51
+											Width: PARENT_RIGHT
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-classic-support
 										LabelWithHighlight@DESC_ZOOM:
 											Y: 68
+											Width: PARENT_RIGHT
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-classic-zoom
 										LabelWithHighlight@DESC_ZOOM_MODIFIER:
 											Y: 68
+											Width: PARENT_RIGHT
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-classic-zoom-modifier
 										LabelWithHighlight@DESC_SCROLL_RIGHT:
 											Y: 85
+											Width: PARENT_RIGHT
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-classic-scroll-right
 										LabelWithHighlight@DESC_SCROLL_MIDDLE:
 											Y: 85
+											Width: PARENT_RIGHT
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-classic-scroll-middle
 										Label@DESC_EDGESCROLL:
 											X: 9
 											Y: 102
+											Width: PARENT_RIGHT
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-classic-edgescroll
@@ -178,47 +188,56 @@ Container@MAINMENU_INTRODUCTION_PROMPT:
 									Width: PARENT_RIGHT / 2 - 20
 									Children:
 										LabelWithHighlight@DESC_SELECTION:
+											Width: PARENT_RIGHT
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-modern-selection
 										LabelWithHighlight@DESC_COMMANDS:
 											Y: 17
+											Width: PARENT_RIGHT
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-modern-commands
 										LabelWithHighlight@DESC_BUILDIGS:
 											Y: 34
+											Width: PARENT_RIGHT
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-modern-buildigs
 										LabelWithHighlight@DESC_SUPPORT:
 											Y: 51
+											Width: PARENT_RIGHT
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-modern-support
 										LabelWithHighlight@DESC_ZOOM:
 											Y: 68
+											Width: PARENT_RIGHT
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-modern-zoom
 										LabelWithHighlight@DESC_ZOOM_MODIFIER:
 											Y: 68
+											Width: PARENT_RIGHT
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-modern-zoom-modifier
 										LabelWithHighlight@DESC_SCROLL_RIGHT:
 											Y: 85
+											Width: PARENT_RIGHT
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-modern-scroll-right
 										LabelWithHighlight@DESC_SCROLL_MIDDLE:
 											Y: 85
+											Width: PARENT_RIGHT
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-modern-scroll-middle
 										Label@DESC_EDGESCROLL:
 											X: 9
 											Y: 102
+											Width: PARENT_RIGHT
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-modern-edgescroll
@@ -311,7 +330,8 @@ Container@MAINMENU_SYSTEM_INFO_PROMPT:
 	Children:
 		Label@PROMPT_TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 25
+			Height: 25
+			Y: 0 - 37
 			Font: BigBold
 			Contrast: true
 			Align: Center

--- a/mods/cnc/chrome/mapchooser.yaml
+++ b/mods/cnc/chrome/mapchooser.yaml
@@ -7,7 +7,8 @@ Container@MAPCHOOSER_PANEL:
 	Children:
 		Label@TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center

--- a/mods/cnc/chrome/missionbrowser.yaml
+++ b/mods/cnc/chrome/missionbrowser.yaml
@@ -6,8 +6,9 @@ Container@MISSIONBROWSER_PANEL:
 	Height: 435
 	Children:
 		Label@MISSIONBROWSER_TITLE:
-			Y: 0 - 22
+			Y: 0 - 34
 			Width: PARENT_RIGHT
+			Height: 25
 			Text: label-missionbrowser-panel-title
 			Align: Center
 			Contrast: true

--- a/mods/cnc/chrome/multiplayer-browser.yaml
+++ b/mods/cnc/chrome/multiplayer-browser.yaml
@@ -8,7 +8,8 @@ Container@MULTIPLAYER_PANEL:
 		Label@TITLE:
 			Text: label-multiplayer-panel-title
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center

--- a/mods/cnc/chrome/multiplayer-createserver.yaml
+++ b/mods/cnc/chrome/multiplayer-createserver.yaml
@@ -7,7 +7,8 @@ Container@MULTIPLAYER_CREATESERVER_PANEL:
 	Children:
 		Label@TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center

--- a/mods/cnc/chrome/multiplayer-directconnect.yaml
+++ b/mods/cnc/chrome/multiplayer-directconnect.yaml
@@ -7,7 +7,8 @@ Container@DIRECTCONNECT_PANEL:
 	Children:
 		Label@DIRECTCONNECT_LABEL_TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center
@@ -18,9 +19,9 @@ Container@DIRECTCONNECT_PANEL:
 			Background: panel-black
 			Children:
 				Label@ADDRESS_LABEL:
-					X: 50
+					X: 20
 					Y: 14
-					Width: 95
+					Width: 125
 					Height: 25
 					Align: Right
 					Text: label-bg-address

--- a/mods/cnc/chrome/music.yaml
+++ b/mods/cnc/chrome/music.yaml
@@ -8,7 +8,8 @@ Container@MUSIC_PANEL:
 		LogicTicker@SONG_WATCHER:
 		Label@TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center

--- a/mods/cnc/chrome/replaybrowser.yaml
+++ b/mods/cnc/chrome/replaybrowser.yaml
@@ -7,7 +7,8 @@ Container@REPLAYBROWSER_PANEL:
 	Children:
 		Label@TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center

--- a/mods/cnc/chrome/settings-hotkeys.yaml
+++ b/mods/cnc/chrome/settings-hotkeys.yaml
@@ -27,7 +27,7 @@ Container@HOTKEYS_PANEL:
 	Height: PARENT_BOTTOM
 	Children:
 		Label@FILTER_INPUT_LABEL:
-			Width: 100
+			Width: 103
 			Height: 25
 			Font: Bold
 			Text: label-hotkeys-panel-filter-input

--- a/mods/cnc/chrome/settings-input.yaml
+++ b/mods/cnc/chrome/settings-input.yaml
@@ -61,47 +61,56 @@ Container@INPUT_PANEL:
 							Width: PARENT_RIGHT
 							Children:
 								LabelWithHighlight@DESC_SELECTION:
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-selection
 								LabelWithHighlight@DESC_COMMANDS:
 									Y: 17
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-commands
 								LabelWithHighlight@DESC_BUILDIGS:
 									Y: 34
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-buildigs
 								LabelWithHighlight@DESC_SUPPORT:
 									Y: 51
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-support
 								LabelWithHighlight@DESC_ZOOM:
 									Y: 68
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-zoom
 								LabelWithHighlight@DESC_ZOOM_MODIFIER:
 									Y: 68
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-zoom-modifier
 								LabelWithHighlight@DESC_SCROLL_RIGHT:
 									Y: 85
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-scroll-right
 								LabelWithHighlight@DESC_SCROLL_MIDDLE:
 									Y: 85
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-scroll-middle
 								Label@DESC_EDGESCROLL:
 									X: 9
 									Y: 102
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-edgescroll
@@ -111,47 +120,56 @@ Container@INPUT_PANEL:
 							Width: PARENT_RIGHT / 2 - 20
 							Children:
 								LabelWithHighlight@DESC_SELECTION:
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-selection
 								LabelWithHighlight@DESC_COMMANDS:
 									Y: 17
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-commands
 								LabelWithHighlight@DESC_BUILDIGS:
 									Y: 34
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-buildigs
 								LabelWithHighlight@DESC_SUPPORT:
 									Y: 51
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-support
 								LabelWithHighlight@DESC_ZOOM:
 									Y: 68
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-zoom
 								LabelWithHighlight@DESC_ZOOM_MODIFIER:
 									Y: 68
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-zoom-modifier
 								LabelWithHighlight@DESC_SCROLL_RIGHT:
 									Y: 85
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-scroll-right
 								LabelWithHighlight@DESC_SCROLL_MIDDLE:
 									Y: 85
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-scroll-middle
 								Label@DESC_EDGESCROLL:
 									X: 9
 									Y: 102
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-edgescroll

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -14,7 +14,8 @@ Container@SETTINGS_PANEL:
 	Children:
 		Label@SETTINGS_LABEL_TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 22
+			Height: 25
+			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center

--- a/mods/cnc/chrome/tooltips.yaml
+++ b/mods/cnc/chrome/tooltips.yaml
@@ -403,6 +403,7 @@ Background@LATENCY_TOOLTIP:
 		Label@LATENCY_PREFIX:
 			X: 5
 			Y: 1
+			Width: 200
 			Height: 23
 			Font: Bold
 			Text: label-latency-tooltip-prefix
@@ -415,12 +416,13 @@ Background@ANONYMOUS_PLAYER_TOOLTIP:
 	Logic: AnonymousProfileTooltipLogic
 	Background: panel-black
 	Height: 30
-	Width: 200
+	Width: 300
 	Children:
 		Label@NAME:
 			X: 5
 			Y: 2
 			Text: label-anonymous-player-tooltip-name
+			Width: 290
 			Height: 23
 			Font: MediumBold
 		Label@LOCATION:
@@ -450,6 +452,7 @@ Background@ANONYMOUS_PLAYER_TOOLTIP:
 					ImageName: admin
 				Label@LABEL:
 					X: 10
+					Width: 200
 					Height: 12
 					Text: label-game-admin
 					Font: TinyBold
@@ -496,6 +499,7 @@ Container@REGISTERED_PLAYER_TOOLTIP:
 								Label@LABEL:
 									X: 10
 									Y: 1
+									Width: 200
 									Height: 12
 									Text: label-game-admin
 									Font: TinyBold

--- a/mods/common/chrome/assetbrowser.yaml
+++ b/mods/common/chrome/assetbrowser.yaml
@@ -72,7 +72,7 @@ Background@ASSETBROWSER_PANEL:
 		Label@SPRITE_SCALE:
 			X: PARENT_RIGHT - WIDTH - 440
 			Y: 60
-			Width: 40
+			Width: 50
 			Height: 25
 			Font: Bold
 			Align: Left

--- a/mods/common/chrome/ingame-debug.yaml
+++ b/mods/common/chrome/ingame-debug.yaml
@@ -5,11 +5,12 @@ Container@DEBUG_PANEL:
 	Height: PARENT_BOTTOM
 	Children:
 		Label@TITLE:
-			Y: 26
+			Y: 16
 			Font: Bold
 			Text: label-debug-panel-title
 			Align: Center
 			Width: PARENT_RIGHT
+			Height: 20
 		Checkbox@INSTANT_BUILD:
 			X: 45
 			Y: 45
@@ -81,11 +82,12 @@ Container@DEBUG_PANEL:
 			Font: Bold
 			Text: button-debug-panel-reset-exploration
 		Label@VISUALIZATIONS_TITLE:
-			Y: 256
+			Y: 246
 			Font: Bold
 			Text: label-debug-panel-visualizations-title
 			Align: Center
 			Width: PARENT_RIGHT
+			Height: 20
 		Checkbox@SHOW_UNIT_PATHS:
 			X: 45
 			Y: 275

--- a/mods/common/chrome/ingame-infostats.yaml
+++ b/mods/common/chrome/ingame-infostats.yaml
@@ -53,7 +53,7 @@ Container@SKIRMISH_STATS:
 					Font: Bold
 				Label@ACTIONS:
 					X: 457
-					Width: 20
+					Width: 80
 					Height: 25
 					Text: label-stats-actions
 					Font: Bold

--- a/mods/common/chrome/lobby-players.yaml
+++ b/mods/common/chrome/lobby-players.yaml
@@ -51,7 +51,7 @@ Container@LOBBY_PLAYER_BIN:
 					Font: Bold
 				Label@LABEL_LOBBY_STATUS:
 					X: 617
-					Width: 20
+					Width: 20 + 24
 					Height: 25
 					Text: label-container-lobby-status
 					Align: Left
@@ -253,7 +253,7 @@ Container@LOBBY_PLAYER_BIN:
 									Text: label-faction-factionname
 						Label@TEAM:
 							X: 420
-							Width: 23
+							Width: 42
 							Height: 25
 							Text: label-template-noneditable-player-team
 							Align: Center

--- a/mods/common/chrome/mainmenu-prompts.yaml
+++ b/mods/common/chrome/mainmenu-prompts.yaml
@@ -124,47 +124,56 @@ Background@MAINMENU_INTRODUCTION_PROMPT:
 							Width: PARENT_RIGHT / 2 - 20
 							Children:
 								LabelWithHighlight@DESC_SELECTION:
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-selection
 								LabelWithHighlight@DESC_COMMANDS:
 									Y: 17
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-commands
 								LabelWithHighlight@DESC_BUILDIGS:
 									Y: 34
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-buildigs
 								LabelWithHighlight@DESC_SUPPORT:
 									Y: 51
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-support
 								LabelWithHighlight@DESC_ZOOM:
 									Y: 68
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-zoom
 								LabelWithHighlight@DESC_ZOOM_MODIFIER:
 									Y: 68
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-zoom-modifier
 								LabelWithHighlight@DESC_SCROLL_RIGHT:
 									Y: 85
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-scroll-right
 								LabelWithHighlight@DESC_SCROLL_MIDDLE:
 									Y: 85
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-scroll-middle
 								Label@DESC_EDGESCROLL:
 									X: 9
 									Y: 102
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-edgescroll
@@ -173,47 +182,56 @@ Background@MAINMENU_INTRODUCTION_PROMPT:
 							Width: PARENT_RIGHT / 2 - 20
 							Children:
 								LabelWithHighlight@DESC_SELECTION:
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-selection
 								LabelWithHighlight@DESC_COMMANDS:
 									Y: 17
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-commands
 								LabelWithHighlight@DESC_BUILDIGS:
 									Y: 34
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-buildigs
 								LabelWithHighlight@DESC_SUPPORT:
 									Y: 51
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-support
 								LabelWithHighlight@DESC_ZOOM:
 									Y: 68
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-zoom
 								LabelWithHighlight@DESC_ZOOM_MODIFIER:
 									Y: 68
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-zoom-modifier
 								LabelWithHighlight@DESC_SCROLL_RIGHT:
 									Y: 85
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-scroll-right
 								LabelWithHighlight@DESC_SCROLL_MIDDLE:
 									Y: 85
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-scroll-middle
 								Label@DESC_EDGESCROLL:
 									X: 9
 									Y: 102
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-edgescroll

--- a/mods/common/chrome/multiplayer-directconnect.yaml
+++ b/mods/common/chrome/multiplayer-directconnect.yaml
@@ -14,9 +14,9 @@ Background@DIRECTCONNECT_PANEL:
 			Align: Center
 			Font: Bold
 		Label@ADDRESS_LABEL:
-			X: 50
+			X: 20
 			Y: 60
-			Width: 95
+			Width: 125
 			Height: 25
 			Align: Right
 			Text: label-directconnect-panel-address

--- a/mods/common/chrome/settings-hotkeys.yaml
+++ b/mods/common/chrome/settings-hotkeys.yaml
@@ -27,7 +27,7 @@ Container@HOTKEYS_PANEL:
 	Height: PARENT_BOTTOM
 	Children:
 		Label@FILTER_INPUT_LABEL:
-			Width: 100
+			Width: 103
 			Height: 25
 			Font: Bold
 			Text: label-hotkeys-panel-filter-input

--- a/mods/common/chrome/settings-input.yaml
+++ b/mods/common/chrome/settings-input.yaml
@@ -61,47 +61,56 @@ Container@INPUT_PANEL:
 							Width: PARENT_RIGHT
 							Children:
 								LabelWithHighlight@DESC_SELECTION:
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-selection
 								LabelWithHighlight@DESC_COMMANDS:
 									Y: 17
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-commands
 								LabelWithHighlight@DESC_BUILDIGS:
 									Y: 34
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-buildigs
 								LabelWithHighlight@DESC_SUPPORT:
 									Y: 51
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-support
 								LabelWithHighlight@DESC_ZOOM:
 									Y: 68
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-zoom
 								LabelWithHighlight@DESC_ZOOM_MODIFIER:
 									Y: 68
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-zoom-modifier
 								LabelWithHighlight@DESC_SCROLL_RIGHT:
 									Y: 85
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-scroll-right
 								LabelWithHighlight@DESC_SCROLL_MIDDLE:
 									Y: 85
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-scroll-middle
 								Label@DESC_EDGESCROLL:
 									X: 9
 									Y: 102
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-edgescroll
@@ -111,47 +120,56 @@ Container@INPUT_PANEL:
 							Width: PARENT_RIGHT / 2 - 20
 							Children:
 								LabelWithHighlight@DESC_SELECTION:
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-selection
 								LabelWithHighlight@DESC_COMMANDS:
 									Y: 17
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-commands
 								LabelWithHighlight@DESC_BUILDIGS:
 									Y: 34
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-buildigs
 								LabelWithHighlight@DESC_SUPPORT:
 									Y: 51
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-support
 								LabelWithHighlight@DESC_ZOOM:
 									Y: 68
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-zoom
 								LabelWithHighlight@DESC_ZOOM_MODIFIER:
 									Y: 68
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-zoom-modifier
 								LabelWithHighlight@DESC_SCROLL_RIGHT:
 									Y: 85
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-scroll-right
 								LabelWithHighlight@DESC_SCROLL_MIDDLE:
 									Y: 85
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-scroll-middle
 								Label@DESC_EDGESCROLL:
 									X: 9
 									Y: 102
+									Width: PARENT_RIGHT
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-edgescroll

--- a/mods/common/chrome/tooltips.yaml
+++ b/mods/common/chrome/tooltips.yaml
@@ -121,6 +121,7 @@ Background@LATENCY_TOOLTIP:
 		Label@LATENCY_PREFIX:
 			X: 7
 			Y: 3
+			Width: 200
 			Height: 26
 			Font: Bold
 			Text: label-latency-tooltip-prefix
@@ -133,12 +134,13 @@ Background@ANONYMOUS_PLAYER_TOOLTIP:
 	Logic: AnonymousProfileTooltipLogic
 	Background: dialog4
 	Height: 30
-	Width: 200
+	Width: 300
 	Children:
 		Label@NAME:
 			X: 7
 			Y: 2
 			Text: label-anonymous-player-tooltip-name
+			Width: 290
 			Height: 24
 			Font: MediumBold
 		Label@LOCATION:
@@ -168,6 +170,7 @@ Background@ANONYMOUS_PLAYER_TOOLTIP:
 					ImageName: admin
 				Label@LABEL:
 					X: 10
+					Width: 200
 					Height: 12
 					Text: label-game-admin
 					Font: TinyBold
@@ -211,6 +214,7 @@ Background@REGISTERED_PLAYER_TOOLTIP:
 								Label@LABEL:
 									X: 10
 									Y: 1
+									Width: 200
 									Height: 12
 									Text: label-game-admin
 									Font: TinyBold

--- a/mods/d2k/chrome/ingame-infostats.yaml
+++ b/mods/d2k/chrome/ingame-infostats.yaml
@@ -57,7 +57,7 @@ Container@SKIRMISH_STATS:
 				Label@ACTIONS:
 					X: 457
 					Y: 1
-					Width: 20
+					Width: 80
 					Height: 25
 					Text: label-stats-actions
 					Font: Bold

--- a/mods/d2k/chrome/ingame-observer.yaml
+++ b/mods/d2k/chrome/ingame-observer.yaml
@@ -459,7 +459,7 @@ Container@OBSERVER_WIDGETS:
 								Label@SUPPORT_POWERS_HEADER:
 									X: 155
 									Y: 0
-									Width: 100
+									Width: 200
 									Height: PARENT_BOTTOM
 									Font: Bold
 									Text: label-support-powers-header

--- a/mods/d2k/chrome/lobby-players.yaml
+++ b/mods/d2k/chrome/lobby-players.yaml
@@ -51,7 +51,7 @@ Container@LOBBY_PLAYER_BIN:
 					Font: Bold
 				Label@LABEL_LOBBY_STATUS:
 					X: 617
-					Width: 20
+					Width: 20 + 24
 					Height: 25
 					Text: label-container-lobby-status
 					Align: Left
@@ -253,7 +253,7 @@ Container@LOBBY_PLAYER_BIN:
 									Text: label-faction-factionname
 						Label@TEAM:
 							X: 420
-							Width: 23
+							Width: 42
 							Height: 25
 							Align: Center
 							Text: label-template-noneditable-player-team

--- a/mods/d2k/chrome/tooltips.yaml
+++ b/mods/d2k/chrome/tooltips.yaml
@@ -122,6 +122,7 @@ Background@LATENCY_TOOLTIP:
 		Label@LATENCY_PREFIX:
 			X: 7
 			Y: 4
+			Width: 200
 			Height: 23
 			Font: Bold
 			Text: label-latency-tooltip-prefix
@@ -134,12 +135,13 @@ Background@ANONYMOUS_PLAYER_TOOLTIP:
 	Logic: AnonymousProfileTooltipLogic
 	Background: dialog3
 	Height: 32
-	Width: 200
+	Width: 300
 	Children:
 		Label@NAME:
 			X: 7
 			Y: 3
 			Text: label-anonymous-player-tooltip-name
+			Width: 290
 			Height: 24
 			Font: MediumBold
 		Label@LOCATION:
@@ -169,6 +171,7 @@ Background@ANONYMOUS_PLAYER_TOOLTIP:
 					ImageName: admin
 				Label@LABEL:
 					X: 10
+					Width: 200
 					Height: 12
 					Text: label-game-admin
 					Font: TinyBold
@@ -212,6 +215,7 @@ Background@REGISTERED_PLAYER_TOOLTIP:
 								Label@LABEL:
 									X: 10
 									Y: 1
+									Width: 200
 									Height: 12
 									Text: label-game-admin
 									Font: TinyBold

--- a/mods/ra/chrome/ingame-observer.yaml
+++ b/mods/ra/chrome/ingame-observer.yaml
@@ -499,7 +499,7 @@ Container@OBSERVER_WIDGETS:
 								Label@SUPPORT_POWERS_HEADER:
 									X: 160
 									Y: 0
-									Width: 100
+									Width: 200
 									Height: PARENT_BOTTOM
 									Font: Bold
 									Text: label-support-powers-header

--- a/mods/ts/chrome/assetbrowser.yaml
+++ b/mods/ts/chrome/assetbrowser.yaml
@@ -72,7 +72,7 @@ Background@ASSETBROWSER_PANEL:
 		Label@SPRITE_SCALE:
 			X: PARENT_RIGHT - WIDTH - 440
 			Y: 60
-			Width: 40
+			Width: 50
 			Height: 25
 			Font: Bold
 			Align: Left
@@ -87,7 +87,7 @@ Background@ASSETBROWSER_PANEL:
 		Label@MODEL_SCALE:
 			X: PARENT_RIGHT - WIDTH - 440
 			Y: 60
-			Width: 40
+			Width: 50
 			Height: 25
 			Font: Bold
 			Align: Left

--- a/mods/ts/chrome/ingame-debug.yaml
+++ b/mods/ts/chrome/ingame-debug.yaml
@@ -5,11 +5,12 @@ Container@DEBUG_PANEL:
 	Height: PARENT_BOTTOM
 	Children:
 		Label@TITLE:
-			Y: 26
+			Y: 16
 			Font: Bold
 			Text: label-debug-panel-title
 			Align: Center
 			Width: PARENT_RIGHT
+			Height: 20
 		Checkbox@INSTANT_BUILD:
 			X: 45
 			Y: 45
@@ -81,11 +82,12 @@ Container@DEBUG_PANEL:
 			Font: Bold
 			Text: button-debug-panel-reset-exploration
 		Label@VISUALIZATIONS_TITLE:
-			Y: 255
+			Y: 245
 			Font: Bold
 			Text: label-debug-panel-visualizations-title
 			Align: Center
 			Width: PARENT_RIGHT
+			Height: 20
 		Checkbox@SHOW_UNIT_PATHS:
 			X: 45
 			Y: 275

--- a/mods/ts/chrome/ingame-observer.yaml
+++ b/mods/ts/chrome/ingame-observer.yaml
@@ -451,7 +451,7 @@ Container@OBSERVER_WIDGETS:
 								Label@SUPPORT_POWERS_HEADER:
 									X: 160
 									Y: 0
-									Width: 100
+									Width: 200
 									Height: PARENT_BOTTOM
 									Font: Bold
 									Text: label-support-powers-header

--- a/mods/ts/chrome/settings-hotkeys.yaml
+++ b/mods/ts/chrome/settings-hotkeys.yaml
@@ -29,7 +29,7 @@ Container@HOTKEYS_PANEL:
 	Height: PARENT_BOTTOM
 	Children:
 		Label@FILTER_INPUT_LABEL:
-			Width: 100
+			Width: 103
 			Height: 25
 			Font: Bold
 			Text: label-hotkeys-panel-filter-input


### PR DESCRIPTION
Some existing widget are too small to accommodate their text. Adjust their sizes to fit. Text can be rendered outside the widget bounds so visually this often has no impact, but adjusting this now will help in the future for checking translation text for other languages fit in their widgets.

----

Split from #21293, with fixes detected but the lint pass but exlcuding the lint pass itself.