### PR TITLE
Add Turtle condition to RA bots' mine laying

### DIFF
--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -421,6 +421,7 @@ Player:
 			ftrk: 4
 			mnly: 2
 	MinelayerBotModule@turtle:
+		RequiresCondition: enable-turtle-ai
 		MinelayingActorTypes: mnly
 		IgnoredEnemyTargetTypes: Structure, Defense, AirborneActor
 		UseEnemyLocationTargetTypes: Structure, Defense, AirborneActor


### PR DESCRIPTION
This restricts MinelayerBotModule's use to Turtle bots, which seemed like the intent. While the other skirmish bots don't build Minelayers and don't see much effect from this being active, this also affects the campaign bots (like on `soviet-05`).