### PR TITLE
McvManagerBotModule: Add ability to build additional MCVs

### DIFF
--- a/OpenRA.Mods.Common/UpdateRules/Rules/20231010/RemoveMinimumConYardCount.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20231010/RemoveMinimumConYardCount.cs
@@ -1,0 +1,31 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class MinimumConstructionYardCountProperties : UpdateRule
+	{
+		public override string Name => "Remove defunct properties from McvManagerBotModule.";
+
+		public override string Description =>
+			"AI Basebuilding was changed and MinimumConstructionYardCount of McvManagerBotModule was replaced by MaxAllowedMCVs.";
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
+		{
+			foreach (var t in actorNode.ChildrenMatching("McvManagerBotModule"))
+				t.RemoveNodes("MinimumConstructionYardCount");
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -86,6 +86,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new ReplacePaletteModifiers(),
 				new RemoveConyardChronoReturnAnimation(),
 				new RemoveEditorSelectionLayerProperties(),
+				new MinimumConstructionYardCountProperties(),
 
 				// Execute these rules last to avoid premature yaml merge crashes.
 				new ReplaceCloakPalette(),


### PR DESCRIPTION
This commit gives the bot the ability to build additional MCVs and send them out to random selected resource fields. Otherwise it deploys the MCV in/near the current base. The bot builds currently only 2 MCVs atm.

This PR picks "the Multible MCV logic" from #12186
superseeds #12186 and #17649

Testcase:
A Bot should send out MCVs nearby resource fields and deploy it (there).
Setting "MaxAllowedMCVs" to "1" will disable this additional functionality.

Steps:
[x] Add ability to build additional MCVs.
[X] Set the new deployed MCV as base center
[ ] Increase the building limit by the amount of Construction Yards 
