### PR TITLE
Add SinglePerActor trait tag to prevent conflicting traits

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Traits
 	/// </summary>
 	public sealed class DamageType { DamageType() { } }
 
-	public interface IHealthInfo : ITraitInfoInterface
+	public interface IHealthInfo : SinglePerActor
 	{
 		int MaxHP { get; }
 	}
@@ -199,6 +199,8 @@ namespace OpenRA.Traits
 		int RemoveResource(string resourceType, int value);
 	}
 
+	public interface IEffectiveOwnerInfo : SinglePerActor { }
+
 	public interface IEffectiveOwner
 	{
 		bool Disguised { get; }
@@ -304,7 +306,7 @@ namespace OpenRA.Traits
 		void PopulateMapPreviewSignatureCells(Map map, ActorInfo ai, ActorReference s, List<(MPos Uv, Color Color)> destinationBuffer);
 	}
 
-	public interface IOccupySpaceInfo : ITraitInfoInterface
+	public interface IOccupySpaceInfo : SinglePerActor
 	{
 		IReadOnlyDictionary<CPos, SubCell> OccupiedCells(ActorInfo info, CPos location, SubCell subCell = SubCell.Any);
 		bool SharesCell { get; }
@@ -335,7 +337,7 @@ namespace OpenRA.Traits
 		WRot Orientation { get; }
 	}
 
-	public interface IFacingInfo : ITraitInfoInterface { WAngle GetInitialFacing(); }
+	public interface IFacingInfo : SinglePerActor { WAngle GetInitialFacing(); }
 
 	public interface ITraitInfoInterface { }
 
@@ -360,6 +362,9 @@ namespace OpenRA.Traits
 
 	[SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Not a real interface, but more like a tag.")]
 	public interface NotBefore<T> where T : class, ITraitInfoInterface { }
+
+	[SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Not a real interface, but more like a tag.")]
+	public interface SinglePerActor : ITraitInfoInterface { }
 
 	public interface IActivityInterface { }
 
@@ -546,7 +551,7 @@ namespace OpenRA.Traits
 		IEnumerable<WPos> TargetablePositions(Actor self);
 	}
 
-	public interface IMoveInfo : ITraitInfoInterface
+	public interface IMoveInfo : SinglePerActor
 	{
 		Color GetTargetLineColor();
 	}

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	}
 
 	[Desc("Provides access to the disguise command, which makes the actor appear to be another player's actor.")]
-	sealed class DisguiseInfo : TraitInfo
+	sealed class DisguiseInfo : TraitInfo, IEffectiveOwnerInfo
 	{
 		[VoiceReference]
 		public readonly string Voice = "Action";

--- a/OpenRA.Mods.Common/Traits/Air/FallsToEarth.cs
+++ b/OpenRA.Mods.Common/Traits/Air/FallsToEarth.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Causes aircraft husks that are spawned in the air to crash to the ground.")]
-	public class FallsToEarthInfo : TraitInfo, IRulesetLoaded, Requires<AircraftInfo>
+	public class FallsToEarthInfo : TraitInfo, IEffectiveOwnerInfo, IRulesetLoaded, Requires<AircraftInfo>
 	{
 		[WeaponReference]
 		[Desc("Explosion weapon that triggers when hitting ground.")]

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Spawns remains of a husk actor with the correct facing.")]
-	public class HuskInfo : TraitInfo, IPositionableInfo, IFacingInfo, IActorPreviewInitInfo, IRulesetLoaded
+	public class HuskInfo : TraitInfo, IPositionableInfo, IFacingInfo, IEffectiveOwnerInfo, IActorPreviewInitInfo, IRulesetLoaded
 	{
 		public readonly HashSet<string> AllowedTerrain = new();
 

--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -58,6 +58,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				// bind some nonfatal error handling into FieldLoader, so we don't just *explode*.
 				ObjectCreator.MissingTypeAction = s => EmitError($"Missing Type: {s}.");
 				FieldLoader.UnknownFieldAction = (s, f) => EmitError($"FieldLoader: Missing field `{s}` on `{f.Name}`.");
+				ActorInfo.OnConflictingTraitsAction = (s) => EmitError(s);
 
 				var maps = new List<(IReadWritePackage Package, string Map)>();
 				if (args.Length < 2)


### PR DESCRIPTION
The code adds a tag interface for marking traits as single per actor. Trait info classes and interfaces that directly inherit `OpenRA.Traits.SinglePerActor` are considered the base types and having multiple traits sub-classing or implementing them produces an error or clear message during linting with the actor type, conflict base, and MiniYaml keys of the conflicting traits.

For example, when these lines are added to `E1` in mods/ra/rules/infantry.yaml:
```MiniYaml
	Health@SPECIAL:
		HP: 5000
	Mobile@PRIMARY:
		Speed: 68
		AlwaysTurnInPlace: true
		Locomotor: foot
	Mobile@SECONDARY:
		Speed: 58
		AlwaysTurnInPlace: true
		Locomotor: foot
	Disguise@PRIMARY:
	Disguise@SECONDARY:
	FallsToEarth:
	TDGunboat:
	Immobile:
	Aircraft:
	Building:
	Crate:
	Husk:
```
... the result in `make test` or `./utility.sh ra --check-yaml` is:
```
OpenRA.Utility(1,1): Error: Actor type `e1` has conflicting traits of type `IHealth`: Health, Health@SPECIAL.
OpenRA.Utility(1,1): Error: Actor type `e1` has conflicting traits of type `IMove`: Aircraft, Mobile, Mobile@PRIMARY, Mobile@SECONDARY, TDGunboat.
OpenRA.Utility(1,1): Error: Actor type `e1` has conflicting traits of type `IOccupySpace`: Aircraft, Building, Crate, Husk, Immobile, Mobile, Mobile@PRIMARY, Mobile@SECONDARY, TDGunboat.
OpenRA.Utility(1,1): Error: Actor type `e1` has conflicting traits of type `IFacing`: Aircraft, Husk, Mobile, Mobile@PRIMARY, Mobile@SECONDARY, TDGunboat.
OpenRA.Utility(1,1): Error: Actor type `e1` has conflicting traits of type `IEffectiveOwner`: Disguise@PRIMARY, Disguise@SECONDARY, FallsToEarth, Husk.
OpenRA.Utility(1,1): Error: Actor type `e1r1` has conflicting traits of type `IHealth`: Health, Health@SPECIAL.
OpenRA.Utility(1,1): Error: Actor type `e1r1` has conflicting traits of type `IMove`: Aircraft, Mobile, Mobile@PRIMARY, Mobile@SECONDARY, TDGunboat.
OpenRA.Utility(1,1): Error: Actor type `e1r1` has conflicting traits of type `IOccupySpace`: Aircraft, Building, Crate, Husk, Immobile, Mobile, Mobile@PRIMARY, Mobile@SECONDARY, TDGunboat.
OpenRA.Utility(1,1): Error: Actor type `e1r1` has conflicting traits of type `IFacing`: Aircraft, Husk, Mobile, Mobile@PRIMARY, Mobile@SECONDARY, TDGunboat.
OpenRA.Utility(1,1): Error: Actor type `e1r1` has conflicting traits of type `IEffectiveOwner`: Disguise@PRIMARY, Disguise@SECONDARY, FallsToEarth, Husk.
```
Note: `e1r1` inherits from `e1`.

The normal error messages still appear:
```
OpenRA.Utility(1,1): Error: TypeDictionary contains multiple instances of type `OpenRA.Traits.IOccupySpaceInfo` (Actor type `e1`).
OpenRA.Utility(1,1): Error: TypeDictionary contains multiple instances of type `OpenRA.Traits.IOccupySpaceInfo` (Actor type `e1r1`).
OpenRA.Utility(1,1): Error: TypeDictionary contains multiple instances of type `OpenRA.Traits.IHealthInfo` (Actor type `e1`).
OpenRA.Utility(1,1): Error: TypeDictionary contains multiple instances of type `OpenRA.Traits.IHealthInfo` (Actor type `e1r1`).
```
However, I have code that exposes the cached traits in `Actor` as currently set with the following code:
```c#
		{ if (trait is IOccupySpace t) OccupiesSpace = t; }
		{ if (trait is IEffectiveOwner t) EffectiveOwner = t; }
		{ if (trait is IFacing t) facing = t; }
		{ if (trait is IHealth t) health = t; }
		{ if (trait is IResolveOrder t) resolveOrdersList.Add(t); }
		{ if (trait is IRenderModifier t) renderModifiersList.Add(t); }
		{ if (trait is IRender t) rendersList.Add(t); }
		{ if (trait is IMouseBounds t) mouseBoundsList.Add(t); }
		{ if (trait is IVisibilityModifier t) visibilityModifiersList.Add(t); }
		{ if (trait is IDefaultVisibility t) defaultVisibility = t; }
		{ if (trait is INotifyBecomingIdle t) becomingIdlesList.Add(t); }
		{ if (trait is INotifyIdle t) tickIdlesList.Add(t); }
		{ if (trait is ITargetable t) targetablesList.Add(t); }
		{ if (trait is ITargetablePositions t) targetablePositionsList.Add(t); }
		{ if (trait is ISync t) syncHashesList.Add(new SyncHash(t)); }
		{ if (trait is ICrushable t) crushablesList.Add(t); }
```
The above code simply allows conflicting traits to overwrite each other. Unlike `Actor.Trait<T>()` and `Actor.TraitOrDefault<T>()`, using the cached traits will not report a conflict.

I plan on marking the other single per actor traits in a future PR. On that subject, I am wondering if `SinglePerActor` should be renamed `ISinglePerActorTraitInfo` with the addition of `ISinglePerActorTrait`. `Actor.Trait<T>()` and `Actor.TraitOrDefault<T>()` can be restricted with `where T: ISinglePerActorTrait`; that would catch trait usage that would cause a runtime error to become a compile-time error and force dependent mods to mark their traits accordingly. Of course, enforcement would require a linting pass that makes sure that the trait and corresponding info types are correctly matched.