### PR TITLE
Add [FieldLoader.Require] to TooltipInfoBase.Name 

### DIFF
--- a/OpenRA.Mods.Common/Traits/Tooltip.cs
+++ b/OpenRA.Mods.Common/Traits/Tooltip.cs
@@ -15,6 +15,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public abstract class TooltipInfoBase : ConditionalTraitInfo, Requires<IMouseBoundsInfo>
 	{
+		[FieldLoader.Require]
 		[TranslationReference]
 		public readonly string Name;
 	}


### PR DESCRIPTION
Edited:

This PR adds now [FieldLoader.Require] to TooltipInfoBase.Name and requires a tooltip name to be set.
Testcase (without PR):

use (repack with 7zip)) and update the map ww3 dry 3.0.7 and build an IFV, (https://resource.openra.net/maps/55822/)