### PR TITLE
Fix NREs in DiscordService.

### DIFF
--- a/OpenRA.Mods.Common/DiscordService.cs
+++ b/OpenRA.Mods.Common/DiscordService.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common
 	{
 		public readonly string ApplicationId = null;
 		public readonly string Tooltip = "Open Source real-time strategy game engine for early Westwood titles.";
-		DiscordRpcClient client;
+		readonly DiscordRpcClient client;
 		DiscordState currentState;
 
 		static DiscordService instance;
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common
 			if (currentState == state)
 				return;
 
-			if (instance == null)
+			if (client == null)
 				return;
 
 			string stateText;
@@ -192,6 +192,9 @@ namespace OpenRA.Mods.Common
 
 		void UpdateParty(int players, int slots)
 		{
+			if (client == null)
+				return;
+
 			if (client.CurrentPresence.Party != null)
 			{
 				client.UpdatePartySize(players, slots);
@@ -206,14 +209,18 @@ namespace OpenRA.Mods.Common
 			});
 		}
 
+		void SetDetails(string details)
+		{
+			if (client == null)
+				return;
+
+			client.UpdateDetails(details);
+		}
+
 		public void Dispose()
 		{
-			if (client != null)
-			{
-				client.Dispose();
-				client = null;
-				instance = null;
-			}
+			client?.Dispose();
+			instance = null;
 		}
 
 		public static void UpdateStatus(DiscordState state, string details = null, string secret = null, int? players = null, int? slots = null)
@@ -228,7 +235,7 @@ namespace OpenRA.Mods.Common
 
 		public static void UpdateDetails(string details)
 		{
-			Service?.client.UpdateDetails(details);
+			Service?.SetDetails(details);
 		}
 	}
 }


### PR DESCRIPTION
Handle the client being null. Previously, a service could be created with a null client. This would leads to NREs when invoking the static Update methods. Now we provide a static helper to get the instance created for the mod. This avoids two instances of the DiscordService being created (a static one, and an instance created in the mod manifest).

Fixes #21275