### PR TITLE
Render Cloak Traits

### DIFF
--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -39,9 +39,10 @@ namespace OpenRA.Mods.Common.Traits
 	// Type tag for DetectionTypes
 	public class DetectionType { }
 
-	public enum CloakStyle { None, Alpha, Color, Palette }
-
-	[Desc("This unit can cloak and uncloak in specific situations.")]
+	[Desc("This unit can cloak and uncloak in specific situations.",
+		"To render the actor differently when cloaked, use a RenderCloak* trait.",
+		"While more than 1 RenderCloak* trait can be used, more than 3 RenderCloak* traits may affect performance since they are called during rendering even when disabled.",
+		"Note that the actor will not be rendered if the actor is cloaked and the actor is not visible to the player.")]
 	public class CloakInfo : PausableConditionalTraitInfo
 	{
 		[Desc("Measured in game ticks.")]
@@ -67,22 +68,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("The type of cloak. Same type of cloaks won't trigger cloaking and uncloaking sound and effect.")]
 		public readonly string CloakType = null;
-
-		[Desc("Render effect to use when cloaked.")]
-		public readonly CloakStyle CloakStyle = CloakStyle.Alpha;
-
-		[Desc("The alpha level to use when cloaked when using Alpha CloakStyle.")]
-		public readonly float CloakedAlpha = 0.55f;
-
-		[Desc("The color to use when cloaked when using Color CloakStyle.")]
-		public readonly Color CloakedColor = Color.FromArgb(140, 0, 0, 0);
-
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("The palette to use when cloaked when using Palette CloakStyle.")]
-		public readonly string CloakedPalette = null;
-
-		[Desc("Indicates that CloakedPalette is a player palette when using Palette CloakStyle.")]
-		public readonly bool IsPlayerPalette = false;
 
 		[Desc("Which image to use for the effect played when cloaking or uncloaking.")]
 		public readonly string EffectImage = null;
@@ -111,14 +96,12 @@ namespace OpenRA.Mods.Common.Traits
 	public class Cloak : PausableConditionalTrait<CloakInfo>, IRenderModifier, INotifyDamage, INotifyUnloadCargo, INotifyLoadCargo, INotifyDemolition, INotifyInfiltration,
 		INotifyAttack, ITick, IVisibilityModifier, IRadarColorModifier, INotifyDockClient, INotifySupportPower
 	{
-		readonly float3 cloakedColor;
-		readonly float cloakedColorAlpha;
-
 		[Sync]
 		int remainingTime;
 
 		bool isDocking;
 		Cloak[] otherCloaks;
+		IRenderCloaked[] renderCloakedTraits;
 
 		CPos? lastPos;
 		bool wasCloaked = false;
@@ -129,8 +112,6 @@ namespace OpenRA.Mods.Common.Traits
 			: base(info)
 		{
 			remainingTime = info.InitialDelay;
-			cloakedColor = new float3(info.CloakedColor.R, info.CloakedColor.G, info.CloakedColor.B) / 255f;
-			cloakedColorAlpha = info.CloakedColor.A / 255f;
 		}
 
 		protected override void Created(Actor self)
@@ -142,6 +123,7 @@ namespace OpenRA.Mods.Common.Traits
 					.ToArray();
 			}
 
+			renderCloakedTraits = self.TraitsImplementing<IRenderCloaked>().Where(n => n.IsValidCloakType(Info.CloakType)).ToArray();
 			if (Cloaked)
 			{
 				wasCloaked = true;
@@ -181,23 +163,26 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (Cloaked && IsVisible(self, self.World.RenderPlayer))
 			{
-				switch (Info.CloakStyle)
+				// PERF: Try to keep the cost of this as low since it affects rendering.
+				switch (renderCloakedTraits.Length)
 				{
-					case CloakStyle.Alpha:
-						return r.Select(a => !a.IsDecoration && a is IModifyableRenderable mr ? mr.WithAlpha(Info.CloakedAlpha) : a);
-
-					case CloakStyle.Color:
-						return r.Select(a => !a.IsDecoration && a is IModifyableRenderable mr ?
-							mr.WithTint(cloakedColor, mr.TintModifiers | TintModifiers.ReplaceColor).WithAlpha(cloakedColorAlpha) :
-							a);
-
-					case CloakStyle.Palette:
-					{
-						var palette = wr.Palette(Info.IsPlayerPalette ? Info.CloakedPalette + self.Owner.InternalName : Info.CloakedPalette);
-						return r.Select(a => !a.IsDecoration && a is IPalettedRenderable pr ? pr.WithPalette(palette) : a);
-					}
-
+					case 0:
+						return r;
+					case 1:
+						return renderCloakedTraits[0].ModifyRender(self, wr, r);
+					case 2:
+						return renderCloakedTraits[1].ModifyRender(self, wr, renderCloakedTraits[0].ModifyRender(self, wr, r));
+					case 3:
+						return renderCloakedTraits[2].ModifyRender(self, wr, renderCloakedTraits[1].ModifyRender(self, wr, renderCloakedTraits[0].ModifyRender(self, wr, r)));
 					default:
+						for (var i = 0; i < renderCloakedTraits.Length; i++)
+						{
+							// Unless some IRenderCloaked trait does not process in order, this should be a false positive
+#pragma warning disable CA1851 // Possible multiple enumerations of 'IEnumerable' collection
+							r = renderCloakedTraits[i].ModifyRender(self, wr, r);
+#pragma warning restore CA1851 // Possible multiple enumerations of 'IEnumerable' collection
+						}
+
 						return r;
 				}
 			}
@@ -249,6 +234,14 @@ namespace OpenRA.Mods.Common.Traits
 						self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(
 							posfunc, () => WAngle.Zero, w, Info.EffectImage, Info.CloakEffectSequence, palette)));
 					}
+
+					foreach (var renderCloaked in renderCloakedTraits)
+						renderCloaked.OnCloaked(self, Info, false);
+				}
+				else
+				{
+					foreach (var renderCloaked in renderCloakedTraits)
+						renderCloaked.OnCloaked(self, Info, true);
 				}
 			}
 			else if (!isCloaked && wasCloaked)
@@ -274,6 +267,14 @@ namespace OpenRA.Mods.Common.Traits
 						self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(
 							posfunc, () => WAngle.Zero, w, Info.EffectImage, Info.UncloakEffectSequence, palette)));
 					}
+
+					foreach (var renderCloaked in renderCloakedTraits)
+						renderCloaked.OnUncloaked(self, Info, false);
+				}
+				else
+				{
+					foreach (var renderCloaked in renderCloakedTraits)
+						renderCloaked.OnUncloaked(self, Info, true);
 				}
 			}
 

--- a/OpenRA.Mods.Common/Traits/Render/RenderCloakAsAlpha.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderCloakAsAlpha.cs
@@ -1,0 +1,37 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+
+namespace OpenRA.Mods.Common.Traits.Render
+{
+	[Desc("Render the actor with alpha when cloaked.")]
+	public class RenderCloakAsAlphaInfo : RenderCloakAsBaseInfo
+	{
+		[Desc("The alpha level to use when cloaked when using Alpha CloakStyle.")]
+		public readonly float Alpha = 0.55f;
+
+		public override object Create(ActorInitializer init) { return new RenderCloakAsAlpha(init, this); }
+	}
+
+	public class RenderCloakAsAlpha : RenderCloakAsBase<RenderCloakAsAlphaInfo>
+	{
+		public RenderCloakAsAlpha(ActorInitializer init, RenderCloakAsAlphaInfo info)
+			: base(info) { }
+
+		protected override IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
+		{
+			return r.Select(a => !a.IsDecoration && a is IModifyableRenderable mr ? mr.WithAlpha(Info.Alpha) : a);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Render/RenderCloakAsBase.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderCloakAsBase.cs
@@ -1,0 +1,56 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Graphics;
+
+namespace OpenRA.Mods.Common.Traits.Render
+{
+	public abstract class RenderCloakAsBaseInfo : ConditionalTraitInfo
+	{
+		[Desc("Cloak types that should be rendered as invisible. If empty, all cloak types are rendered as invisible.")]
+		public readonly HashSet<string> CloakTypes = new();
+	}
+
+	public abstract class RenderCloakAsBase<InfoType> : ConditionalTrait<InfoType>, IRenderCloaked where InfoType : RenderCloakAsBaseInfo
+	{
+		protected RenderCloakAsBase(InfoType info)
+			: base(info) { }
+
+		bool IRenderCloaked.IsValidCloakType(string cloakType)
+		{
+			return Info.CloakTypes.Count == 0 || Info.CloakTypes.Contains(cloakType);
+		}
+
+		protected abstract IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r);
+
+		IEnumerable<IRenderable> IRenderCloaked.ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
+		{
+			if (IsTraitDisabled)
+				return r;
+			return ModifyRender(self, wr, r);
+		}
+
+		protected virtual void OnCloaked(Actor self, CloakInfo cloakInfo, bool isInitial) { }
+
+		void IRenderCloaked.OnCloaked(Actor self, CloakInfo cloakInfo, bool isInitial)
+		{
+			OnCloaked(self, cloakInfo, isInitial);
+		}
+
+		protected virtual void OnUncloaked(Actor self, CloakInfo cloakInfo, bool isInitial) { }
+
+		void IRenderCloaked.OnUncloaked(Actor self, CloakInfo cloakInfo, bool isInitial)
+		{
+			OnUncloaked(self, cloakInfo, isInitial);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Render/RenderCloakAsColor.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderCloakAsColor.cs
@@ -1,0 +1,47 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Primitives;
+
+namespace OpenRA.Mods.Common.Traits.Render
+{
+	[Desc("Render the actor with a given color when cloaked.")]
+	public class RenderCloakAsColorInfo : RenderCloakAsBaseInfo
+	{
+		[Desc("The color to use when cloaked when using Color CloakStyle.")]
+		public readonly Color Color = Color.FromArgb(140, 0, 0, 0);
+
+		public override object Create(ActorInitializer init) { return new RenderCloakAsColor(init, this); }
+	}
+
+	public class RenderCloakAsColor : RenderCloakAsBase<RenderCloakAsColorInfo>
+	{
+		readonly float3 color;
+		readonly float colorAlpha;
+
+		public RenderCloakAsColor(ActorInitializer init, RenderCloakAsColorInfo info)
+			: base(info)
+		{
+			color = new float3(info.Color.R, info.Color.G, info.Color.B) / 255f;
+			colorAlpha = info.Color.A / 255f;
+		}
+
+		protected override IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
+		{
+			return r.Select(a => !a.IsDecoration && a is IModifyableRenderable mr ?
+				mr.WithTint(color, mr.TintModifiers | TintModifiers.ReplaceColor).WithAlpha(colorAlpha) :
+				a);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Render/RenderCloakAsInvisible.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderCloakAsInvisible.cs
@@ -1,0 +1,33 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Graphics;
+
+namespace OpenRA.Mods.Common.Traits.Render
+{
+	[Desc("Render the actor as invisible when cloaked.")]
+	public class RenderCloakAsInvisibleInfo : RenderCloakAsBaseInfo
+	{
+		public override object Create(ActorInitializer init) { return new RenderCloakAsInvisible(init, this); }
+	}
+
+	public class RenderCloakAsInvisible : RenderCloakAsBase<RenderCloakAsInvisibleInfo>
+	{
+		public RenderCloakAsInvisible(ActorInitializer init, RenderCloakAsInvisibleInfo info)
+			: base(info) { }
+
+		protected override IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
+		{
+			return SpriteRenderable.None;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Render/RenderCloakAsShiftingAlpha.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderCloakAsShiftingAlpha.cs
@@ -1,0 +1,99 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits.Render
+{
+	[Desc("Render the actor with alpha when cloaked.")]
+	public class RenderCloakAsShiftingAlphaInfo : RenderCloakAsBaseInfo, IRulesetLoaded
+	{
+		[Desc("The minimum alpha level to use.")]
+		public readonly float MinAlpha = 0.4f;
+
+		[Desc("The maximum alpha level to use.")]
+		public readonly float MaxAlpha = 0.7f;
+
+		[FieldLoader.Require]
+		[Desc("Time to to change from maximum alpha level to minimum alpha level.")]
+		public readonly int ChangeInterval = 0;
+
+		[Desc("Starting percentage from the minimum level to the maximum alpha level.",
+			"0 means the minimum alpha level, 100 means the maximum alpha level, and empty means random.")]
+		public readonly int? StartingPercent = null;
+
+		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
+		{
+			base.RulesetLoaded(rules, ai);
+			if (MinAlpha < 0 || MinAlpha > 1)
+				throw new YamlException("RenderCloakAsShiftingAlpha.MinAlpha must be between 0 and 1.");
+			if (MaxAlpha < 0 || MaxAlpha > 1)
+				throw new YamlException("RenderCloakAsShiftingAlpha.MaxAlpha must be between 0 and 1.");
+			if (ChangeInterval < 1)
+				throw new YamlException("RenderCloakAsShiftingAlpha.AlphaChangeInterval must be greater than 0.");
+			if (StartingPercent.HasValue && (StartingPercent.Value < 0 || StartingPercent.Value > 100))
+				throw new YamlException("RenderCloakAsShiftingAlpha.StartingPercent must be between 0 and 100.");
+		}
+
+		public override object Create(ActorInitializer init) { return new RenderCloakAsShiftingAlpha(init, this); }
+	}
+
+	public class RenderCloakAsShiftingAlpha : RenderCloakAsBase<RenderCloakAsShiftingAlphaInfo>, ITick
+	{
+		float currentAlpha;
+		float alphaChange;
+		bool cloaked = false;
+		public RenderCloakAsShiftingAlpha(ActorInitializer init, RenderCloakAsShiftingAlphaInfo info)
+			: base(info)
+		{
+			alphaChange = (Info.MaxAlpha - Info.MinAlpha) / Info.ChangeInterval;
+			currentAlpha = Info.MinAlpha + alphaChange * (Info.StartingPercent.HasValue
+				? Info.ChangeInterval * Info.StartingPercent.Value / 100
+				: Game.CosmeticRandom.Next(Info.ChangeInterval));
+		}
+
+		protected override IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
+		{
+			return r.Select(a => !a.IsDecoration && a is IModifyableRenderable mr ? mr.WithAlpha(currentAlpha) : a);
+		}
+
+		protected override void OnCloaked(Actor self, CloakInfo cloakInfo, bool isInitial)
+		{
+			cloaked = true;
+		}
+
+		protected override void OnUncloaked(Actor self, CloakInfo cloakInfo, bool isInitial)
+		{
+			cloaked = false;
+		}
+
+		void ITick.Tick(Actor self)
+		{
+			if (!cloaked)
+				return;
+
+			currentAlpha += alphaChange;
+			if (alphaChange > 0 && currentAlpha > Info.MaxAlpha)
+			{
+				alphaChange = -alphaChange;
+				currentAlpha = Info.MaxAlpha;
+			}
+			else if (alphaChange < 0 && currentAlpha < Info.MinAlpha)
+			{
+				alphaChange = -alphaChange;
+				currentAlpha = Info.MinAlpha;
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Render/RenderCloakWithPalette.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderCloakWithPalette.cs
@@ -1,0 +1,49 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits.Render
+{
+	[Desc("Render the actor with a given color when cloaked.")]
+	public class RenderCloakWithPaletteInfo : RenderCloakAsBaseInfo
+	{
+		[PaletteReference(nameof(IsPlayerPalette))]
+		[Desc("The palette to use when cloaked when using Palette CloakStyle.")]
+		public readonly string Palette = "cloak";
+
+		[Desc("Indicates that CloakedPalette is a player palette when using Palette CloakStyle.")]
+		public readonly bool IsPlayerPalette = false;
+
+		public override object Create(ActorInitializer init) { return new RenderCloakWithPalette(init, this); }
+	}
+
+	public class RenderCloakWithPalette : RenderCloakAsBase<RenderCloakWithPaletteInfo>, INotifyOwnerChanged
+	{
+		PaletteReference palette = null;
+		public RenderCloakWithPalette(ActorInitializer init, RenderCloakWithPaletteInfo info)
+			: base(info) { }
+
+		protected override IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
+		{
+			palette ??= wr.Palette(Info.IsPlayerPalette ? Info.Palette + self.Owner.InternalName : Info.Palette);
+			return r.Select(a => !a.IsDecoration && a is IPalettedRenderable pr ? pr.WithPalette(palette) : a);
+		}
+
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		{
+			palette = null;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -482,6 +482,16 @@ namespace OpenRA.Mods.Common.Traits
 	public interface IDetectCloakedModifier { int GetDetectCloakedModifier(); }
 
 	[RequireExplicitImplementation]
+	public interface IRenderCloaked
+	{
+		// Used by Cloak to filter renders for cloak type
+		bool IsValidCloakType(string cloakType);
+		IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r);
+		void OnCloaked(Actor self, CloakInfo cloakInfo, bool isInitial);
+		void OnUncloaked(Actor self, CloakInfo cloakInfo, bool isInitial);
+	}
+
+	[RequireExplicitImplementation]
 	public interface IResourceValueModifier { int GetResourceValueModifier(); }
 
 	[RequireExplicitImplementation]

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -208,10 +208,9 @@ C17:
 	Cloak:
 		InitialDelay: 0
 		CloakDelay: 0
-		CloakStyle: Palette
-		CloakedPalette: cloak
 		DetectionTypes: C17
 		RequiresCondition: global-C17-stealth
+	RenderCloakWithPalette:
 	Contrail@1:
 		Offset: -261,-650,0
 		TrailLength: 15

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -199,10 +199,9 @@
 		CloakDelay: 90
 		CloakSound: trans1.aud
 		UncloakSound: trans1.aud
-		CloakStyle: Palette
-		CloakedPalette: cloak
 		PauseOnCondition: cloak-force-disabled
 		RequiresCondition: cloak-crate-collected
+	RenderCloakWithPalette:
 	ExternalCondition@CLOAK:
 		Condition: cloak-crate-collected
 	GrantConditionOnDamageState@UNCLOAK:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -708,10 +708,9 @@ STNK:
 		CloakDelay: 85
 		CloakSound: trans1.aud
 		UncloakSound: trans1.aud
-		CloakStyle: Palette
-		CloakedPalette: cloak
 		UncloakOn: Attack, Unload, Dock, Damage, Heal
 		PauseOnCondition: cloak-force-disabled
+	RenderCloakWithPalette:
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -187,6 +187,7 @@ fremen:
 		CloakDelay: 85
 		UncloakOn: Attack, Unload, Infiltrate, Demolish, Dock, Damage, Heal
 		PauseOnCondition: cloak-force-disabled
+	RenderCloakAsAlpha:
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical
@@ -334,6 +335,7 @@ saboteur:
 	Voiced:
 		VoiceSet: SaboteurVoice
 	-AttackFrontal:
+	RenderCloakAsAlpha:
 
 nsfremen:
 	Inherits: fremen

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -499,6 +499,7 @@ stealth_raider:
 		CloakDelay: 90
 		UncloakOn: Attack, Unload, Infiltrate, Demolish, Dock, Damage, Heal
 		PauseOnCondition: cloak-force-disabled
+	RenderCloakAsAlpha:
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -317,6 +317,7 @@ SNIPER:
 		UncloakSound:
 		UncloakOn: Attack, Unload, Infiltrate, Demolish, Move
 		PauseOnCondition: cloak-force-disabled
+	RenderCloakAsAlpha:
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -559,11 +559,11 @@
 		DetectionTypes: Underwater
 		InitialDelay: 0
 		CloakDelay: 50
-		CloakStyle: Color
 		CloakSound: subshow1.aud
 		UncloakSound: subshow1.aud
 		CloakedCondition: underwater
 		PauseOnCondition: cloak-force-disabled
+	RenderCloakAsColor:
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical
@@ -1230,7 +1230,6 @@
 	Cloak:
 		CloakSound:
 		UncloakSound:
-		CloakStyle: None
 		DetectionTypes: Mine
 		InitialDelay: 0
 	Tooltip:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -665,6 +665,7 @@ THF:
 		UncloakOn: Attack, Unload, Infiltrate, Demolish, Move
 		DetectionTypes: Cloak
 		PauseOnCondition: cloak-force-disabled
+	RenderCloakAsAlpha:
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -796,6 +796,7 @@ HBOX:
 		InitialDelay: 125
 		CloakDelay: 60
 		PauseOnCondition: cloak-force-disabled
+	RenderCloakAsAlpha:
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -921,6 +921,7 @@ STNK:
 		UncloakSound: appear1.aud
 		PauseOnCondition: cloak-force-disabled
 		UncloakOn: Attack, Load, Unload, Heal, Dock
+	RenderCloakAsAlpha:
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -133,6 +133,8 @@
 		UncloakSound: cloak5.aud
 		UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage, Heal, SupportPower
 		CloakType: nod-stealth
+	RenderCloakAsAlpha@EXTERNALCLOAK:
+		CloakTypes: nod-stealth
 	ExternalCondition@CLOAKGENERATOR:
 		Condition: cloakgenerator
 	ExternalCondition@CRATE-CLOAK:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -529,6 +529,8 @@ STNK:
 		UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage, Heal
 		PauseOnCondition: cloak-force-disabled || empdisable
 		CloakType: nod-stealth
+	RenderCloakAsAlpha:
+		CloakTypes: nod-stealth
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical


### PR DESCRIPTION
This PR adds plumbing for separating cloak rendering from the `Cloak` trait itself and includes cloak rendering traits as well as upgrade rule updates. It is designed to address the architectural mentioned in the discussion for #21294. The second commit ports [dnqbob](https://github.com/dnqbob)'s additions in #21294 to a new trait called `RenderCloakShiftingAlpha`. As such, this PR should supersede #21294.