### PR TITLE
Renderer: Dispose worldBuffer only when it was initialized.

### DIFF
--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -534,7 +534,7 @@ namespace OpenRA
 
 		public void Dispose()
 		{
-			worldBuffer.Dispose();
+			worldBuffer?.Dispose();
 			screenBuffer.Dispose();
 			worldBufferSnapshot.Dispose();
 			tempVertexBuffer.Dispose();


### PR DESCRIPTION
This PR prevents a crash when exiting OpenRA in bleed!

1. Rebuild OpenRa on bleed branch and start the Engine with mod "TS"!
2. Start OpenRA **without** existing support folder! **(clean install)**
3. on the menu where you choose between "Quick install" or "Advanced Install" click Quit!
4. crash...
5. 
![ooopsss](https://github.com/OpenRA/OpenRA/assets/2057932/2de49627-5759-46d0-97e9-18a11747315c)
