### PR TITLE
HierarchicalPathFinder: Fix NRE in ActorIsBlocking

### DIFF
--- a/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
+++ b/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
@@ -657,6 +657,10 @@ namespace OpenRA.Mods.Common.Pathfinder
 			if (isTemporaryBlocker)
 				return false;
 
+			var crushableActors = actor.Crushables;
+			if (crushableActors == null)
+				return false;
+
 			foreach (var crushable in actor.Crushables)
 				if (world.NoPlayersMask != crushable.CrushableBy(actor, locomotor.Info.Crushes))
 					return false;


### PR DESCRIPTION
 HierarchicalPathFinder: Fix NRE in ActorIsBlocking when actor.Crushables is null.
fixes #21330
