### PR TITLE
Restore allies-05 prison self-targeting

### DIFF
--- a/mods/ra/maps/allies-05a/weapons.yaml
+++ b/mods/ra/maps/allies-05a/weapons.yaml
@@ -1,4 +1,5 @@
 PrisonColt:
+	CanTargetSelf: true
 	ValidTargets: Ground, GroundActor
 	ReloadDelay: 7
 	Report: gun5.aud

--- a/mods/ra/maps/allies-05b/weapons.yaml
+++ b/mods/ra/maps/allies-05b/weapons.yaml
@@ -1,4 +1,5 @@
 PrisonColt:
+	CanTargetSelf: true
 	ValidTargets: Ground, GroundActor
 	ReloadDelay: 7
 	Report: gun5.aud

--- a/mods/ra/maps/allies-05c/weapons.yaml
+++ b/mods/ra/maps/allies-05c/weapons.yaml
@@ -1,6 +1,7 @@
 PrisonColt:
+	CanTargetSelf: true
 	ValidTargets: Ground, GroundActor
-	ReloadDelay: 5
+	ReloadDelay: 7
 	Report: gun5.aud
 	Projectile: InstantHit
 	Warhead@1Dam: SpreadDamage


### PR DESCRIPTION
This fixes a minor mission bug from https://github.com/OpenRA/OpenRA/pull/20369, which adds a toggle for self-targeting that is off by default. The prison in Tanya's Tale should fire upon itself before it self-destructs, and that no longer happens on stable/bleed.

I don't think my words convey the issue well, so here's a before/after **with sound**:

https://github.com/OpenRA/OpenRA/assets/4985264/2e9cff95-86ec-4705-a75a-b7be216ebf99

https://github.com/OpenRA/OpenRA/assets/4985264/0bf54a39-5340-45f7-859b-3243bd017891