### PR TITLE
Hovers: remove dependency on IMove trait

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/Hovers.cs
+++ b/OpenRA.Mods.Common/Traits/Render/Hovers.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Changes the visual Z position periodically.")]
-	public class HoversInfo : ConditionalTraitInfo, Requires<IMoveInfo>
+	public class HoversInfo : ConditionalTraitInfo
 	{
 		[Desc("Maximum visual Z axis distance relative to actual position + InitialHeight.")]
 		public readonly WDist BobDistance = new(-43);


### PR DESCRIPTION
This change was requested on Discord (so the `Hovers` trait could be used on a building).

`Hovers` trait does not use `IMove(Info)`, so the dependency is unnecessary.

![openra_hovers_no_imoveinfo](https://github.com/OpenRA/OpenRA/assets/119738087/62d31c6c-958c-45a2-a8de-36fca613bd0c)
