### PR TITLE
Chronoshift Trait Fixes

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -320,7 +320,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					{
 						var targetCell = unit.Location + (xy - sourceLocation);
 						var canEnter = manager.Self.Owner.Shroud.IsExplored(targetCell) &&
-							unit.Trait<Chronoshiftable>().CanChronoshiftTo(unit, targetCell);
+							unit.TraitsImplementing<Chronoshiftable>().Any(c => !c.IsTraitDisabled && c.CanChronoshiftTo(unit, targetCell));
 						var tile = canEnter ? validTile : invalidTile;
 						var alpha = canEnter ? validAlpha : invalidAlpha;
 						yield return new SpriteRenderable(tile, wr.World.Map.CenterOfCell(targetCell), WVec.Zero, -511, palette, 1f, alpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
@@ -364,7 +364,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				{
 					anyUnitsInRange = true;
 					var targetCell = unit.Location + (xy - sourceLocation);
-					if (manager.Self.Owner.Shroud.IsExplored(targetCell) && unit.Trait<Chronoshiftable>().CanChronoshiftTo(unit, targetCell))
+					if (manager.Self.Owner.Shroud.IsExplored(targetCell) && unit.TraitsImplementing<Chronoshiftable>().Any(c => !c.IsTraitDisabled && c.CanChronoshiftTo(unit, targetCell)))
 					{
 						canTeleport = true;
 						break;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20231010/ChronoshiftableSplitPausable.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20231010/ChronoshiftableSplitPausable.cs
@@ -1,0 +1,58 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class ChronoshiftableSplitPausable : UpdateRule
+	{
+		public override string Name => "Chronoshiftable is now pausable.";
+
+		public override string Description => "PauseOnCondition is now used to pause the return of Chronoshiftable units.";
+
+		readonly List<string> locations = new();
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
+		{
+			foreach (var node in actorNode.ChildrenMatching("Chronoshiftable"))
+				foreach (var subNode in node.ChildrenMatching("RequiresCondition").ToArray())
+					if (!string.IsNullOrEmpty(subNode.Value.Value))
+					{
+						var value = subNode.Value.Value;
+						var startsWithNotPrefix = value.StartsWith('!');
+						var withoutNotPrefix = startsWithNotPrefix ? value[1..].TrimStart() : value;
+						var complex = withoutNotPrefix.ToCharArray().Any(c => " ~!%^&*()+=[]{}|:;'\"<>?,/".Contains(c));
+						if (complex)
+							value = "!(" + value + ")";
+						else if (startsWithNotPrefix)
+							value = withoutNotPrefix;
+						else
+							value = "!" + value;
+						node.AddNode("PauseOnCondition", value);
+						locations.Add($"{actorNode.Key}: {node.Key} ({actorNode.Location.Name})");
+					}
+
+			yield break;
+		}
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (locations.Count > 0)
+				yield return
+					"You must check the PauseOnCondition and RequiresCondition for the following traits :\n" +
+					UpdateUtils.FormatMessageList(locations);
+
+			locations.Clear();
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -86,6 +86,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new ReplacePaletteModifiers(),
 				new RemoveConyardChronoReturnAnimation(),
 				new RemoveEditorSelectionLayerProperties(),
+				new ChronoshiftableSplitPausable(),
 
 				// Execute these rules last to avoid premature yaml merge crashes.
 				new ReplaceCloakPalette(),


### PR DESCRIPTION
This corrects `ChronoshiftPower` to support multiple  `Chronoshiftable`s (rather than crash by calling `Actor.Trait<Chronoshiftable>()`) as well as separating the return-to-origin timer by making `Chronoshiftable` a `PausableConditionalTrait` with `PauseOnCondition` controlling the timer. The indicator bar will not show until the timer has started running. Having `RequiresCondition` control both eligible `Chronoshiftable` for `ChronoshiftPower` and the return-to-origin timer can cause conflict when the actor is not supposed to be chronoshiftable but should automatically return to origin.

#### Example Test:

This test requires being within 25 cells to try teleporting and within 12 cells to not explode; the teleportation range also pauses the return-to-origin timer. This patch also includes a `testing` `SOURCE` for `--update-mod`. Running `--update-mod` in this patch will create extra `PauseOnCondition`  since that is a new field for `Chronoshiftable`.

Apply the follwing patch which is also committed to [https://github.com/atlimit8/OpenRA/tree/fix-multiple-Chronoshiftables-testing](https://github.com/atlimit8/OpenRA/tree/fix-multiple-Chronoshiftables-testing):
```diff
diff --git a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
index 4c5d139da7..3ad438407f 100644
--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -92,6 +92,11 @@ public sealed class UpdatePath
 				new ReplaceCloakPalette(),
 				new AbstractDocking(),
 			}),
+
+			new("testing", new UpdateRule[]
+			{
+				new ChronoshiftableSplitPausable(),
+			}),
 		};
 
 		public static IReadOnlyCollection<UpdateRule> FromSource(ObjectCreator objectCreator, string source, bool chain = true)
diff --git a/mods/ra/maps/bomber-john/rules.yaml b/mods/ra/maps/bomber-john/rules.yaml
index a4c0f6942f..3d03b96dda 100644
--- a/mods/ra/maps/bomber-john/rules.yaml
+++ b/mods/ra/maps/bomber-john/rules.yaml
@@ -147,7 +147,7 @@ MNLYR:
 		Amount: 20
 	RenderSprites:
 		Image: MNLY
-	Chronoshiftable:
+	Chronoshiftable@SAFE_CHRONOSHIFTABLE:
 		ReturnToOrigin: false
 	HitShape:
 
diff --git a/mods/ra/maps/mousetrap/rules.yaml b/mods/ra/maps/mousetrap/rules.yaml
index d9ecca38e2..1a2a8f0a32 100644
--- a/mods/ra/maps/mousetrap/rules.yaml
+++ b/mods/ra/maps/mousetrap/rules.yaml
@@ -26,7 +26,9 @@ World:
 
 # Used in ChronoEffect.
 1TNK:
-	Chronoshiftable:
+	Chronoshiftable@CHRONOSHIFTABLE:
+		ChronoshiftSound:
+	Chronoshiftable@SAFE_CHRONOSHIFTABLE:
 		ChronoshiftSound:
 
 ^Soldier:
diff --git a/mods/ra/rules/defaults.yaml b/mods/ra/rules/defaults.yaml
index 6236a13865..f0cbfa3eb0 100644
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -262,7 +262,16 @@
 		ValidDamageStates: Light, Medium, Heavy, Critical
 	Repairable:
 		RepairActors: fix
-	Chronoshiftable:
+	Chronoshiftable@CHRONOSHIFTABLE:
+		RequiresCondition: chronoshiftable && !safe-chronoshiftable
+		ExplodeInstead: true
+	Chronoshiftable@SAFE_CHRONOSHIFTABLE:
+		RequiresCondition: safe-chronoshiftable
+		PauseOnCondition: chronoshiftable
+	ExternalCondition@CHRONOSHIFTABLE:
+		Condition: chronoshiftable
+	ExternalCondition@SAFE_CHRONOSHIFTABLE:
+		Condition: safe-chronoshiftable
 	Passenger:
 		CargoType: Vehicle
 	AttackMove:
@@ -525,7 +534,16 @@
 		TextNotification: notification-naval-unit-lost
 	ProximityCaptor:
 		Types: Ship
-	Chronoshiftable:
+	Chronoshiftable@CHRONOSHIFTABLE:
+		RequiresCondition: chronoshiftable && !safe-chronoshiftable
+		ExplodeInstead: true
+	Chronoshiftable@SAFE_CHRONOSHIFTABLE:
+		RequiresCondition: safe-chronoshiftable
+		PauseOnCondition: chronoshiftable
+	ExternalCondition@CHRONOSHIFTABLE:
+		Condition: chronoshiftable
+	ExternalCondition@SAFE_CHRONOSHIFTABLE:
+		Condition: safe-chronoshiftable
 	RepairableNear:
 		RepairActors: spen, syrd
 	GpsDot:
@@ -1075,7 +1093,16 @@
 	Targetable:
 		TargetTypes: GroundActor, Husk, NoAutoTarget
 		RequiresForceFire: true
-	Chronoshiftable:
+	Chronoshiftable@CHRONOSHIFTABLE:
+		RequiresCondition: chronoshiftable && !safe-chronoshiftable
+		ExplodeInstead: true
+	Chronoshiftable@SAFE_CHRONOSHIFTABLE:
+		RequiresCondition: safe-chronoshiftable
+		PauseOnCondition: chronoshiftable
+	ExternalCondition@CHRONOSHIFTABLE:
+		Condition: chronoshiftable
+	ExternalCondition@SAFE_CHRONOSHIFTABLE:
+		Condition: safe-chronoshiftable
 	Tooltip:
 		GenericName: meta-husk-generic-name
 
diff --git a/mods/ra/rules/ships.yaml b/mods/ra/rules/ships.yaml
index 5d61740ca9..43279d70cd 100644
--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -252,7 +252,10 @@ LST:
 		MaxWeight: 5
 		PassengerFacing: 0
 		LoadingCondition: notmobile
-	-Chronoshiftable:
+	-Chronoshiftable@CHRONOSHIFTABLE:
+	-Chronoshiftable@SAFE_CHRONOSHIFTABLE:
+	-ExternalCondition@CHRONOSHIFTABLE:
+	-ExternalCondition@SAFE_CHRONOSHIFTABLE:
 	Selectable:
 		DecorationBounds: 1536, 1536
 
diff --git a/mods/ra/rules/structures.yaml b/mods/ra/rules/structures.yaml
index cab716e8ab..eb6265df61 100644
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -547,6 +547,22 @@ PDOX:
 		SupportPowerPaletteOrder: 30
 		Dimensions: 5, 5
 		Footprint: __x__ _xxx_ xxxxx _xxx_ __x__
+	ProximityExternalCondition@CHRONOSHIFTABLE:
+		RequiresCondition: !disabled
+		Condition: chronoshiftable
+		Range: 25c0
+	WithRangeCircle@CHRONOSHIFTABLE:
+		Range: 25c0
+		Type: cloakgenerator
+		Color: FF510080
+	ProximityExternalCondition@SAFE_CHRONOSHIFTABLE:
+		RequiresCondition: !disabled
+		Condition: safe-chronoshiftable
+		Range: 12c0
+	WithRangeCircle@SAFE_CHRONOSHIFTABLE:
+		Range: 12c0
+		Type: safe-cloakgenerator
+		Color: 40FF0080
 	SupportPowerChargeBar:
 	InfiltrateForSupportPowerReset:
 		Types: SpyInfiltrate
diff --git a/mods/ra/rules/vehicles.yaml b/mods/ra/rules/vehicles.yaml
index 800b3ee334..69212737f4 100644
--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -782,7 +782,7 @@ DTRK:
 	-DamageMultiplier@IRONCURTAIN:
 	KillsSelf:
 		RequiresCondition: invulnerability || triggered
-	Chronoshiftable:
+	Chronoshiftable@SAFE_CHRONOSHIFTABLE:
 		ExplodeInstead: true
 
 CTNK:
@@ -852,8 +852,8 @@ QTNK:
 		RequiresCondition: !deployed
 		PauseOnCondition: being-captured
 		Speed: 46
-	Chronoshiftable:
-		RequiresCondition: !deployed && !being-captured
+	Chronoshiftable@SAFE_CHRONOSHIFTABLE:
+		RequiresCondition: !deployed && !being-captured && safe-chronoshiftable
 	RevealsShroud:
 		MinRange: 4c0
 		Range: 6c0
```
