### PR TITLE
Remove unused RenderSprite trait fields

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Render/WithGunboatBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithGunboatBody.cs
@@ -42,7 +42,6 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 	{
 		readonly WithGunboatBodyInfo info;
 		readonly Animation wake;
-		readonly RenderSprites rs;
 		readonly IFacing facing;
 		readonly Turreted turret;
 
@@ -57,7 +56,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 			: base(init, info, MakeTurretFacingFunc(init.Self))
 		{
 			this.info = info;
-			rs = init.Self.Trait<RenderSprites>();
+			var rs = init.Self.Trait<RenderSprites>();
 			facing = init.Self.Trait<IFacing>();
 			var name = rs.GetImage(init.Self);
 			turret = init.Self.TraitsImplementing<Turreted>()

--- a/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeOverlay.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeOverlay.cs
@@ -36,7 +36,6 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 	public class WithTeslaChargeOverlay : INotifyTeslaCharging, INotifyDamageStateChanged, INotifySold
 	{
 		readonly Animation overlay;
-		readonly RenderSprites renderSprites;
 		readonly WithTeslaChargeOverlayInfo info;
 
 		bool charging;
@@ -45,7 +44,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		{
 			this.info = info;
 
-			renderSprites = init.Self.Trait<RenderSprites>();
+			var renderSprites = init.Self.Trait<RenderSprites>();
 
 			overlay = new Animation(init.World, renderSprites.GetImage(init.Self));
 

--- a/OpenRA.Mods.Common/Traits/Render/WithResourceLevelOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResourceLevelOverlay.cs
@@ -34,7 +34,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 	sealed class WithResourceLevelOverlay : ConditionalTrait<WithResourceLevelOverlayInfo>, INotifyOwnerChanged, INotifyDamageStateChanged
 	{
 		readonly AnimationWithOffset anim;
-		readonly RenderSprites rs;
 		readonly WithSpriteBody wsb;
 
 		PlayerResources playerResources;
@@ -42,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public WithResourceLevelOverlay(Actor self, WithResourceLevelOverlayInfo info)
 			: base(info)
 		{
-			rs = self.Trait<RenderSprites>();
+			var rs = self.Trait<RenderSprites>();
 			wsb = self.Trait<WithSpriteBody>();
 			playerResources = self.Owner.PlayerActor.Trait<PlayerResources>();
 

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
@@ -64,7 +64,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 	public class WithSpriteBarrel : ConditionalTrait<WithSpriteBarrelInfo>
 	{
 		public readonly Animation DefaultAnimation;
-		readonly RenderSprites rs;
 		readonly Actor self;
 		readonly Armament armament;
 		readonly Turreted turreted;
@@ -80,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			turreted = self.TraitsImplementing<Turreted>()
 				.First(tt => tt.Name == armament.Info.Turret);
 
-			rs = self.Trait<RenderSprites>();
+			var rs = self.Trait<RenderSprites>();
 			DefaultAnimation = new Animation(self.World, rs.GetImage(self), () => turreted.WorldOrientation.Yaw);
 			DefaultAnimation.PlayRepeating(NormalizeSequence(self, Info.Sequence));
 			rs.Add(new AnimationWithOffset(

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -64,7 +64,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 	public class WithSpriteBody : PausableConditionalTrait<WithSpriteBodyInfo>, INotifyDamageStateChanged, IAutoMouseBounds
 	{
 		public readonly Animation DefaultAnimation;
-		readonly RenderSprites rs;
 		readonly Animation boundsAnimation;
 
 		public WithSpriteBody(ActorInitializer init, WithSpriteBodyInfo info)
@@ -73,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		protected WithSpriteBody(ActorInitializer init, WithSpriteBodyInfo info, Func<WAngle> baseFacing)
 			: base(info)
 		{
-			rs = init.Self.Trait<RenderSprites>();
+			var rs = init.Self.Trait<RenderSprites>();
 
 			bool Paused() => IsTraitPaused &&
 				DefaultAnimation.CurrentSequence.Name == NormalizeSequence(init.Self, Info.Sequence);

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -75,7 +75,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 	public class WithSpriteTurret : ConditionalTrait<WithSpriteTurretInfo>, INotifyDamageStateChanged
 	{
 		public readonly Animation DefaultAnimation;
-		readonly RenderSprites rs;
 		readonly BodyOrientation body;
 		readonly Turreted t;
 		readonly Armament[] arms;
@@ -83,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public WithSpriteTurret(Actor self, WithSpriteTurretInfo info)
 			: base(info)
 		{
-			rs = self.Trait<RenderSprites>();
+			var rs = self.Trait<RenderSprites>();
 			body = self.Trait<BodyOrientation>();
 			t = self.TraitsImplementing<Turreted>()
 				.First(tt => tt.Name == info.Turret);


### PR DESCRIPTION
I noticed that there are traits that store `init.Self.Trait<RenderSprites>()` without using it beyond the constructor. This should remove a little of memory wasting.