### PR TITLE
Land activity: fix bug which causes crash in Aircraft.AddInflunce()

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -131,6 +131,9 @@ namespace OpenRA.Mods.Common.Activities
 					target = Target.FromCell(self.World, newLocation.Value);
 					targetPosition = target.CenterPosition + offset;
 					landingCell = self.World.Map.CellContaining(targetPosition);
+
+					if ((targetPosition - pos).LengthSquared == 0)
+						return true;
 				}
 			}
 


### PR DESCRIPTION
This PR fixes #21302 by adding additional check in `Land.Tick()` for skipping landing mechanism, if the aircraft is already on the ground at target location.

## More details

`Land` activity has an [early check](https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Activities/Air/Land.cs#L114), if the aircraft is at the landing location:

    var pos = aircraft.GetPosition();

    // Reevaluate target position in case the target has moved.
    targetPosition = target.CenterPosition + offset;
    landingCell = self.World.Map.CellContaining(targetPosition);

    // We are already at the landing location.
    if ((targetPosition - pos).LengthSquared == 0)
        return true;

However, this can change, since the desired landing location can be occupied:

    var newLocation = aircraft.FindLandingLocation(landingCell, landRange);

    // ...

    if (newLocation.Value != landingCell)
    {
        target = Target.FromCell(self.World, newLocation.Value);
        targetPosition = target.CenterPosition + offset;
        landingCell = self.World.Map.CellContaining(targetPosition);
    }

After new landing location is picked, the check isn't performed again and `Aircraft.AddInfluence()` can be called without calling `Aircraft.RemoveInfluence()` first.

This can happen, if the aircraft is on the ground and force land order is issued to the adjacent cell, which is occupied (doesn't matter what kind of actor is on that cell). Since the aircraft does not take off first, when forcing the landing, but immediately attempts to land on the adjacent cell, it does not do the check mentioned above.

It is possible that an older issue #20459 is caused by the same bug as the crash described in #21302.
