### PR TITLE
Add crash fix, minor polish to volkov-n-chitzkoi

### DIFF
--- a/mods/ra/languages/lua/en.ftl
+++ b/mods/ra/languages/lua/en.ftl
@@ -366,7 +366,7 @@ keep-chitzkoi-alive = Keep Chitzkoi Alive.
 destroy-alloy-facility = Destroy the alloy facility.
 heavy-turret-control-destroyed = Excellent! The heavy turret control center is destroyed
     and now we can deal with the alloy facility.
-rebuild-chitzkoy = We can rebuild Chitzkoi. We have the technology.
+rebuild-chitzkoi = We can rebuild Chitzkoi. We have the technology.
 
 ## survival01
 french-reinforcements-arrive-in = French reinforcements arrive in { $time }

--- a/mods/ra/maps/soviet-soldier-volkov-n-chitzkoi/rules.yaml
+++ b/mods/ra/maps/soviet-soldier-volkov-n-chitzkoi/rules.yaml
@@ -25,6 +25,10 @@ E7:
 	Buildable:
 		Prerequisites: ~vehicles.allies, ~techlevel.medium
 
+CA:
+	Buildable:
+		Prerequisites: ~syrd
+
 C2:
 	Inherits@2: ^ArmedCivilian
 

--- a/mods/ra/maps/soviet-soldier-volkov-n-chitzkoi/soviet-soldier-volkov-n-chitzkoi-AI.lua
+++ b/mods/ra/maps/soviet-soldier-volkov-n-chitzkoi/soviet-soldier-volkov-n-chitzkoi-AI.lua
@@ -82,8 +82,14 @@ ProduceArmor = function()
 
 	local delay = Utils.RandomInteger(DateTime.Seconds(7), DateTime.Seconds(10))
 	local toBuild = { Utils.Random(AlliedArmorTypes) }
-	local Rally = Utils.Random(AlliedWarFactRally)
-	Utils.Do(AlliedWarFact, function(fact) fact.RallyPoint = Rally.Location end)
+	local rally = Utils.Random(AlliedWarFactRally)
+
+	Utils.Do(AlliedWarFact, function(fact)
+		if not fact.IsDead then
+			fact.RallyPoint = rally.Location
+		end
+	end)
+
 	Greece.Build(toBuild, function(unit)
 		ArmorAttack[#ArmorAttack + 1] = unit[1]
 
@@ -105,8 +111,6 @@ ProduceNavyGuard = function()
 	end
 	NavalYard01.RallyPoint = waypoint26.Location
 	Greece.Build(AlliedNavyGuard, function(nvgrd)
-		Utils.Do(nvgrd, function(unit)
-			Trigger.OnKilled(unit, ProduceNavyGuard)
-		end)
+		Trigger.OnAllKilled(nvgrd, ProduceNavyGuard)
 	end)
 end

--- a/mods/ra/maps/soviet-soldier-volkov-n-chitzkoi/soviet-soldier-volkov-n-chitzkoi.lua
+++ b/mods/ra/maps/soviet-soldier-volkov-n-chitzkoi/soviet-soldier-volkov-n-chitzkoi.lua
@@ -131,24 +131,25 @@ WorldLoaded = function()
 		if unit.Owner == USSR then
 			Trigger.RemoveFootprintTrigger(id)
 			Trigger.AfterDelay(DateTime.Seconds(2), function()
+				Utils.Do(InitialHuntTeam, IdleHunt)
+
+				if Barrel.IsDead then
+					return
+				end
+
 				if not BarrelsShooter[1].IsDead then
 					BarrelsShooter[1].Attack(Barrel, true, true)
 				elseif not BarrelsShooter[2].IsDead then
 					BarrelsShooter[2].Attack(Barrel, true, true)
 				end
-				Utils.Do(InitialHuntTeam, function(actor)
-					if not actor.IsDead then
-						Trigger.OnIdle(actor, actor.Hunt)
-					end
-				end)
 			end)
 		end
 	end)
 
 --Guards Squads Setup -- I used proximity triggers to make them hunt you down in order to mimic their behavior from the original mission
-	Trigger.OnEnteredProximityTrigger(RangerGuard01.CenterPosition, WDist.New(70 * 70), function(unit, id)
-		if not RangerGuard01.IsDead and unit.Owner == USSR then
-			Trigger.OnIdle(RangerGuard01, RangerGuard01.Hunt)
+	Trigger.OnEnteredProximityTrigger(RangerGuard01.CenterPosition, WDist.FromCells(7), function(unit, id)
+		if unit.Owner == USSR and (unit.Type == "volk" or unit.Type == "zkoi") then
+			IdleHunt(RangerGuard01)
 			Trigger.RemoveProximityTrigger(id)
 		end
 	end)
@@ -199,8 +200,8 @@ WorldLoaded = function()
 	end)
 
 	Trigger.OnEnteredProximityTrigger(LightTankGuard02.CenterPosition, WDist.FromCells(8), function(unit, id)
-		if not LightTankGuard02.IsDead and unit.Owner == USSR and (unit.Type == "volk" or unit.Type == "zkoi") then
-			Trigger.OnIdle(LightTankGuard02, LightTankGuard02.Hunt)
+		if unit.Owner == USSR and (unit.Type == "volk" or unit.Type == "zkoi") then
+			IdleHunt(LightTankGuard02)
 			Trigger.RemoveProximityTrigger(id)
 		end
 	end)
@@ -244,6 +245,7 @@ WorldLoaded = function()
 				local civ01 = Reinforcements.Reinforce(Spain, CivTeam01, { civteam01spawn.Location }, 0)
 				Utils.Do(civ01, function(actor)
 					if not actor.IsDead then
+						actor.Scatter()
 						Trigger.OnIdle(actor, actor.Hunt)
 					end
 				end)
@@ -258,6 +260,7 @@ WorldLoaded = function()
 				local civ02 = Reinforcements.Reinforce(Spain, CivTeam02, { civteam02spawn.Location }, 0)
 				Utils.Do(civ02, function(actor)
 					if not actor.IsDead then
+						actor.Scatter()
 						Trigger.OnIdle(actor, actor.Hunt)
 					end
 				end)
@@ -349,7 +352,7 @@ end
 ChitzkoiIsDead = function(a)
 	Trigger.OnKilled(a, function()
 		USSR.MarkFailedObjective(KeepChitzkoiAlive)
-		Media.DisplayMessage(UserInterface.Translate("rebuild-chitzkoy"))
+		Media.DisplayMessage(UserInterface.Translate("rebuild-chitzkoi"))
 		Trigger.AfterDelay(DateTime.Seconds(1), function()
 			Media.PlaySpeechNotification(USSR, "ObjectiveNotMet")
 		end)

--- a/mods/ra/maps/soviet-soldier-volkov-n-chitzkoi/weapons.yaml
+++ b/mods/ra/maps/soviet-soldier-volkov-n-chitzkoi/weapons.yaml
@@ -20,7 +20,7 @@ VolkovWeapon:
 			Light: 60
 			Heavy: 25
 			Concrete: 50
-		ValidTargets: Barrel, Infantry, Vehicle, Mine
+		ValidTargets: Barrel, Infantry, Ship, Vehicle, Mine
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater


### PR DESCRIPTION
This fixes a crash reported by **DMTM**. Some other light touches are added as well.

----

- Fixed rally points being set for dead War Factories.
- Fixed the Ranger at the start guarding its territory from downed aircraft, rather than just infantry.
- Changed two proximity hunt triggers so they can't linger if that hunter is dead.
- Added a death check for a barrel targeted by soldiers, just in case.
- Fixed Volkov's hand cannon dealing no damage to Cruisers, despite them being targetable.
- Fixed prerequisites blocking Cruisers from being built.
- Fixed each Cruiser's death queuing two replacements on Hard difficulty.
- Fixed a tiny translation typo.

----

Civilian reinforcements in the village will now scatter before hunting. This avoids some visual weirdness.

https://github.com/OpenRA/OpenRA/assets/4985264/ebd0d7f1-8e53-48b7-ad27-922cdf1e4d97

https://github.com/OpenRA/OpenRA/assets/4985264/0420659f-6ed1-4350-b007-321e21bc974a