### PR TITLE
Fix force rally point not setting building as primary

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -184,7 +184,7 @@ namespace OpenRA.Mods.Common.Traits
 					{
 						var closest = self.World.Selection.Actors
 							.Where(a => a.TraitOrDefault<RallyPoint>()?.Info.ForceSetType == info.ForceSetType)
-							.ClosestToWithPathTo(self.World, target.CenterPosition);
+							.ClosestToIgnoringPath(target.CenterPosition);
 
 						ForceSet = closest == self;
 					}


### PR DESCRIPTION
Closes #21312
Regression from #20227

buildings can't move so the search failed