### PR TITLE
Remove syncing from Hovers.WorldVisualOffset

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/Hovers.cs
+++ b/OpenRA.Mods.Common/Traits/Render/Hovers.cs
@@ -70,7 +70,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		int ticks;
 
-		[Sync]
 		public WVec WorldVisualOffset { get; private set; }
 
 		public Hovers(HoversInfo info)


### PR DESCRIPTION
This is a visual offset so shouldn't need to be synced.