### PR TITLE
Don't dispose of sequences when unnecessary

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -150,7 +150,7 @@ namespace OpenRA
 		}
 	}
 
-	public sealed class Map : IReadOnlyFileSystem, IDisposable
+	public sealed class Map : IReadOnlyFileSystem
 	{
 		public const int SupportedMapFormat = 11;
 		public const int CurrentMapFormat = 12;
@@ -452,7 +452,7 @@ namespace OpenRA
 				Rules = Ruleset.LoadDefaultsForTileSet(modData, Tileset);
 			}
 
-			Sequences = new SequenceSet(this, modData, Tileset, SequenceDefinitions);
+			Sequences = modData.GetSequences(this, Tileset, SequenceDefinitions);
 
 			var tl = new MPos(0, 0).ToCPos(this);
 			var br = new MPos(MapSize.X - 1, MapSize.Y - 1).ToCPos(this);
@@ -1434,11 +1434,6 @@ namespace OpenRA
 				return modData.DefaultFileSystem.IsExternalFile(filename);
 
 			return false;
-		}
-
-		public void Dispose()
-		{
-			Sequences.Dispose();
 		}
 	}
 }

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -119,6 +119,24 @@ namespace OpenRA
 		public readonly string Value;
 		public readonly ImmutableArray<MiniYamlNode> Nodes;
 
+		public bool Matches(MiniYaml other)
+		{
+			if (other == null || Nodes.Length != other.Nodes.Length
+				|| !Value.Equals(other.Value, StringComparison.InvariantCulture))
+				return false;
+
+			for (var i = 0; i < Nodes.Length; i++)
+			{
+				var n = Nodes[i];
+				var on = other.Nodes[i];
+				if (!n.Key.Equals(on.Key, StringComparison.InvariantCulture)
+					|| !n.Value.Matches(on.Value))
+					return false;
+			}
+
+			return true;
+		}
+
 		public MiniYaml WithValue(string value)
 		{
 			if (Value == value)

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -622,8 +622,6 @@ namespace OpenRA
 			if (Type == WorldType.Shellmap)
 				OrderManager.Dispose();
 
-			Map.Dispose();
-
 			Game.FinishBenchmark();
 		}
 

--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -100,8 +100,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					if (package == null)
 						continue;
 
-					using (var testMap = new Map(modData, package))
-						TestMap(testMap, modData);
+					TestMap(new Map(modData, package), modData);
 				}
 
 				if (errors > 0)

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -71,7 +71,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				Action<string> afterSave = uid =>
 				{
-					map.Dispose();
 					Game.LoadEditor(uid);
 
 					Ui.CloseWindow();


### PR DESCRIPTION
#20597 got rid of defaultSequences as to not keep multiple copies of assets floating around. This freed up on RAM but now on every game start all sequences need to be reloaded, which in games with larger asset files is a massive problem.

This PR delays the disposal of loaded assets until we can check whether they can be reused. This is a fairly simple fix

A possible future optimisation would be to load tileset specific assets into a separate SequenceSet, so that in a common scenario where sequences match and tileset doesn't, we could avoid reloading everything

Impact
- mission load times
- skirmish load times
- game save load times
- replay load times