### PR TITLE
Fix map editor not removing an actor properly.

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public string Type => reference.Type;
 
-		public string ID { get; set; }
+		public string ID { get; }
 		public PlayerReference Owner { get; set; }
 		public WPos CenterPosition { get; set; }
 		public IReadOnlyDictionary<CPos, SubCell> Footprint { get; private set; }
@@ -81,6 +81,11 @@ namespace OpenRA.Mods.Common.Traits
 
 			// TODO: updating all actors on the map is not very efficient.
 			onCellEntryChanged = _ => UpdateFromCellChange();
+		}
+
+		public EditorActorPreview WithId(string id)
+		{
+			return new EditorActorPreview(worldRenderer, id, reference.Clone(), Owner);
 		}
 
 		void UpdateFromCellChange()

--- a/mods/common/languages/en.ftl
+++ b/mods/common/languages/en.ftl
@@ -848,6 +848,7 @@ mirror-mode =
 
 ## ActorEditLogic
 notification-edited-actor = Edited { $name } ({ $id })
+notification-edited-actor-id = Edited { $name } ({ $old-id }->{ $new-id })
 
 ## ConquestVictoryConditions, StrategicVictoryConditions
 notification-player-is-victorious = { $player } is victorious.


### PR DESCRIPTION
If you edit an actor name, then delete the actor - it fails to be removed from the map in the editor. This is because the actor previews are keyed by ID. Editing their name edits their ID and breaks the stability of their hash code. This unstable hash code means the preview will now fail to be removed from collections, even though it's the "same" object.

Fix this by making the ID immutable to ensure hash stability - this means that a preview can be added and removed from collections successfully. Now when we edit the ID in the UI, we can't update the ID in place on the preview. Instead we must generate a new preview with the correct ID and swap it with the preview currently in use.

Fixes #19287