### PR TITLE
Make Color use uint for ARGB.

### DIFF
--- a/OpenRA.Game/Graphics/Palette.cs
+++ b/OpenRA.Game/Graphics/Palette.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Graphics
 
 		public static Color GetColor(this IPalette palette, int index)
 		{
-			return Color.FromArgb((int)palette[index]);
+			return Color.FromArgb(palette[index]);
 		}
 
 		public static IPalette AsReadOnly(this IPalette palette)
@@ -103,7 +103,7 @@ namespace OpenRA.Graphics
 			: this(p)
 		{
 			for (var i = 0; i < Palette.Size; i++)
-				colors[i] = (uint)r.GetRemappedColor(this.GetColor(i), i).ToArgb();
+				colors[i] = r.GetRemappedColor(this.GetColor(i), i).ToArgb();
 		}
 
 		public ImmutablePalette(IPalette p)
@@ -142,7 +142,7 @@ namespace OpenRA.Graphics
 
 		public void SetColor(int index, Color color)
 		{
-			colors[index] = (uint)color.ToArgb();
+			colors[index] = color.ToArgb();
 		}
 
 		public void SetFromPalette(IPalette p)
@@ -153,7 +153,7 @@ namespace OpenRA.Graphics
 		public void ApplyRemap(IPaletteRemap r)
 		{
 			for (var i = 0; i < Palette.Size; i++)
-				colors[i] = (uint)r.GetRemappedColor(this.GetColor(i), i).ToArgb();
+				colors[i] = r.GetRemappedColor(this.GetColor(i), i).ToArgb();
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Graphics
 					// Cast the data to an int array so we can copy the src data directly
 					fixed (byte* bd = &destData[0])
 					{
-						var data = (int*)bd;
+						var data = (uint*)bd;
 						var x = dest.Bounds.Left;
 						var y = dest.Bounds.Top;
 
@@ -195,7 +195,7 @@ namespace OpenRA.Graphics
 				// Cast the data to an int array so we can copy the src data directly
 				fixed (byte* bd = &destData[0])
 				{
-					var data = (int*)bd;
+					var data = (uint*)bd;
 					var x = dest.Bounds.Left;
 					var y = dest.Bounds.Top;
 

--- a/OpenRA.Game/Primitives/Color.cs
+++ b/OpenRA.Game/Primitives/Color.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Primitives
 {
 	public readonly struct Color : IEquatable<Color>, IScriptBindable
 	{
-		readonly long argb;
+		readonly uint argb;
 
 		public static Color FromArgb(int red, int green, int blue)
 		{
@@ -26,7 +26,7 @@ namespace OpenRA.Primitives
 
 		public static Color FromArgb(int alpha, int red, int green, int blue)
 		{
-			return new Color(((byte)alpha << 24) + ((byte)red << 16) + ((byte)green << 8) + (byte)blue);
+			return new Color((uint)(((byte)alpha << 24) + ((byte)red << 16) + ((byte)green << 8) + (byte)blue));
 		}
 
 		public static Color FromAhsl(int alpha, float h, float s, float l)
@@ -55,14 +55,14 @@ namespace OpenRA.Primitives
 			return (A, h, s, v);
 		}
 
-		Color(long argb)
+		Color(uint argb)
 		{
 			this.argb = argb;
 		}
 
-		public int ToArgb()
+		public uint ToArgb()
 		{
-			return (int)argb;
+			return argb;
 		}
 
 		public static Color FromArgb(int alpha, Color baseColor)
@@ -70,14 +70,9 @@ namespace OpenRA.Primitives
 			return FromArgb(alpha, baseColor.R, baseColor.G, baseColor.B);
 		}
 
-		public static Color FromArgb(int argb)
-		{
-			return FromArgb((byte)(argb >> 24), (byte)(argb >> 16), (byte)(argb >> 8), (byte)argb);
-		}
-
 		public static Color FromArgb(uint argb)
 		{
-			return FromArgb((byte)(argb >> 24), (byte)(argb >> 16), (byte)(argb >> 8), (byte)argb);
+			return new Color(argb);
 		}
 
 		static float SrgbToLinear(float c)

--- a/OpenRA.Mods.Cnc/Traits/World/ShroudPalette.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/ShroudPalette.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public void LoadPalettes(WorldRenderer wr)
 		{
 			var c = info.Fog ? Fog : Shroud;
-			wr.AddPalette(info.Name, new ImmutablePalette(Enumerable.Range(0, Palette.Size).Select(i => (uint)c[i % 8].ToArgb())));
+			wr.AddPalette(info.Name, new ImmutablePalette(Enumerable.Range(0, Palette.Size).Select(i => c[i % 8].ToArgb())));
 		}
 
 		static readonly Color[] Fog = new[]

--- a/OpenRA.Mods.Cnc/UtilityCommands/RemapShpCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/RemapShpCommand.cs
@@ -77,8 +77,8 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 
 		static int ColorDistance(uint a, uint b)
 		{
-			var ca = Color.FromArgb((int)a);
-			var cb = Color.FromArgb((int)b);
+			var ca = Color.FromArgb(a);
+			var cb = Color.FromArgb(b);
 
 			return Math.Abs(ca.R - cb.R) +
 				Math.Abs(ca.G - cb.G) +

--- a/OpenRA.Mods.Common/SpriteLoaders/PngSheetLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/PngSheetLoader.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 			};
 
 			if (png.Palette != null)
-				metadata.Add(new EmbeddedSpritePalette(png.Palette.Select(x => (uint)x.ToArgb()).ToArray()));
+				metadata.Add(new EmbeddedSpritePalette(png.Palette.Select(x => x.ToArgb()).ToArray()));
 
 			return true;
 		}

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromGimpOrJascFile.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromGimpOrJascFile.cs
@@ -95,11 +95,11 @@ namespace OpenRA.Mods.Common.Traits
 						if (i == TransparentIndex)
 							colors[i] = 0;
 						else if (noAlpha)
-							colors[i] = (uint)Color.FromArgb(r, g, b).ToArgb();
+							colors[i] = Color.FromArgb(r, g, b).ToArgb();
 						else if (Premultiply)
-							colors[i] = (uint)Color.FromArgb(a, r * a / 255, g * a / 255, b * a / 255).ToArgb();
+							colors[i] = Color.FromArgb(a, r * a / 255, g * a / 255, b * a / 255).ToArgb();
 						else
-							colors[i] = (uint)Color.FromArgb(a, r, g, b).ToArgb();
+							colors[i] = Color.FromArgb(a, r, g, b).ToArgb();
 
 						i++;
 					}

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromGrayscale.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromGrayscale.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.Tileset != null && !string.Equals(info.Tileset, world.Map.Tileset, StringComparison.InvariantCultureIgnoreCase))
 				return;
 
-			wr.AddPalette(info.Name, new ImmutablePalette(Enumerable.Range(0, Palette.Size).Select(i => (i == info.TransparentIndex) ? 0 : (uint)Color.FromArgb(255, i, i, i).ToArgb())), info.AllowModifiers);
+			wr.AddPalette(info.Name, new ImmutablePalette(Enumerable.Range(0, Palette.Size).Select(i => (i == info.TransparentIndex) ? 0 : Color.FromArgb(255, i, i, i).ToArgb())), info.AllowModifiers);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromPng.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromPng.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 			var colors = new uint[Palette.Size];
 
 			for (var i = 0; i < png.Palette.Length; i++)
-				colors[i] = (uint)png.Palette[i].ToArgb();
+				colors[i] = png.Palette[i].ToArgb();
 
 			return new ImmutablePalette(colors);
 		}

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromRGBA.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromRGBA.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Traits
 			var r = (int)(a * info.R + 0.5f).Clamp(0, 255);
 			var g = (int)(a * info.G + 0.5f).Clamp(0, 255);
 			var b = (int)(a * info.B + 0.5f).Clamp(0, 255);
-			var c = (uint)Color.FromArgb(info.A, r, g, b).ToArgb();
+			var c = Color.FromArgb(info.A, r, g, b).ToArgb();
 			wr.AddPalette(info.Name, new ImmutablePalette(Enumerable.Range(0, Palette.Size).Select(i => (i == info.TransparentIndex) ? 0 : c)), info.AllowModifiers);
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Player/PlayerRadarTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerRadarTerrain.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		readonly World world;
 		IRadarTerrainLayer[] radarTerrainLayers;
-		CellLayer<(int, int)> terrainColor;
+		CellLayer<(uint, uint)> terrainColor;
 		readonly Shroud shroud;
 
 		public event Action<MPos> CellTerrainColorChanged = null;
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void WorldLoaded(World w, WorldRenderer wr)
 		{
 			radarTerrainLayers = w.WorldActor.TraitsImplementing<IRadarTerrainLayer>().ToArray();
-			terrainColor = new CellLayer<(int, int)>(w.Map);
+			terrainColor = new CellLayer<(uint, uint)>(w.Map);
 
 			w.AddFrameEndTask(_ =>
 			{
@@ -82,9 +82,9 @@ namespace OpenRA.Mods.Common.Traits
 			});
 		}
 
-		public (int Left, int Right) this[MPos uv] => terrainColor[uv];
+		public (uint Left, uint Right) this[MPos uv] => terrainColor[uv];
 
-		public static (int Left, int Right) GetColor(Map map, IRadarTerrainLayer[] radarTerrainLayers, MPos uv)
+		public static (uint Left, uint Right) GetColor(Map map, IRadarTerrainLayer[] radarTerrainLayers, MPos uv)
 		{
 			foreach (var rtl in radarTerrainLayers)
 				if (rtl.TryGetTerrainColorPair(uv, out var c))

--- a/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Widgets
 				// Generate palette in HSV
 				fixed (byte* cc = &buffer[0])
 				{
-					var c = (int*)cc;
+					var c = (uint*)cc;
 					for (var v = 0; v < 256; v++)
 					{
 						for (var s = 0; s < 256; s++)

--- a/OpenRA.Mods.Common/Widgets/HueSliderWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/HueSliderWidget.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				fixed (byte* cc = &buffer[0])
 				{
-					var c = (int*)cc;
+					var c = (uint*)cc;
 					for (var h = 0; h < 256; h++)
 					{
 						*(c + 0 * 256 + h) = Color.FromAhsv(h / 255f, 1, 1).ToArgb();

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -22,8 +22,8 @@ namespace OpenRA.Mods.Common.Widgets
 {
 	public sealed class RadarWidget : Widget, IDisposable
 	{
-		public readonly int ColorFog = Color.FromArgb(128, Color.Black).ToArgb();
-		public readonly int ColorShroud = Color.Black.ToArgb();
+		public readonly uint ColorFog = Color.FromArgb(128, Color.Black).ToArgb();
+		public readonly uint ColorShroud = Color.Black.ToArgb();
 
 		public string WorldInteractionController = null;
 		public int AnimationLength = 5;
@@ -230,7 +230,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				fixed (byte* colorBytes = &radarData[0])
 				{
-					var colors = (int*)colorBytes;
+					var colors = (uint*)colorBytes;
 					if (isRectangularIsometric)
 					{
 						// Odd rows are shifted right by 1px
@@ -249,7 +249,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		void UpdateShroudCell(PPos puv)
 		{
-			var color = 0;
+			var color = 0u;
 			var cv = currentPlayer.Shroud.GetVisibility(puv);
 			if (!cv.HasFlag(Shroud.CellVisibility.Explored))
 				color = ColorShroud;
@@ -261,7 +261,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				fixed (byte* colorBytes = &radarData[0])
 				{
-					var colors = (int*)colorBytes;
+					var colors = (uint*)colorBytes;
 					foreach (var iuv in world.Map.Unproject(puv))
 					{
 						if (isRectangularIsometric)
@@ -407,7 +407,7 @@ namespace OpenRA.Mods.Common.Widgets
 				{
 					fixed (byte* colorBytes = &radarData[0])
 					{
-						var colors = (int*)colorBytes;
+						var colors = (uint*)colorBytes;
 
 						foreach (var t in world.ActorsWithTrait<IRadarSignature>())
 						{

--- a/OpenRA.Mods.D2k/SpriteLoaders/R8Loader.cs
+++ b/OpenRA.Mods.D2k/SpriteLoaders/R8Loader.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.D2k.SpriteLoaders
 						{
 							var r = new PlayerColorRemap(Enumerable.Range(240, 16).ToArray(), remap);
 							for (var i = 240; i < 256; i++)
-								palette[i] = (uint)r.GetRemappedColor(Color.FromArgb(palette[i]), i).ToArgb();
+								palette[i] = r.GetRemappedColor(Color.FromArgb(palette[i]), i).ToArgb();
 						}
 
 						unsafe


### PR DESCRIPTION
This is a more natural representation than int that allows removal of casts in many places that require uint. Additionally, we can change the internal representation from long to uint, making the Color struct smaller. Since arrays of colors are common, this can save on memory.