### PR TITLE
Improve BotModule performance.

### DIFF
--- a/OpenRA.Mods.Common/AIUtils.cs
+++ b/OpenRA.Mods.Common/AIUtils.cs
@@ -41,31 +41,14 @@ namespace OpenRA.Mods.Common
 				.Select(a => a.Trait);
 		}
 
-		public static IEnumerable<Actor> GetActorsWithTrait<T>(World world)
+		public static int CountActorsWithNameAndTrait<T>(string actorName, Player owner)
 		{
-			return world.ActorsHavingTrait<T>();
+			return owner.World.ActorsHavingTrait<T>().Count(a => a.Owner == owner && a.Info.Name == actorName);
 		}
 
-		public static int CountActorsWithTrait<T>(string actorName, Player owner)
+		public static int CountActorByCommonName<T>(ActorIndex.OwnerAndNamesAndTrait<T> actorIndex)
 		{
-			return GetActorsWithTrait<T>(owner.World).Count(a => a.Owner == owner && a.Info.Name == actorName);
-		}
-
-		public static int CountActorByCommonName(HashSet<string> commonNames, Player owner)
-		{
-			return owner.World.Actors.Count(a => !a.IsDead && a.Owner == owner &&
-				commonNames.Contains(a.Info.Name));
-		}
-
-		public static int CountBuildingByCommonName(HashSet<string> buildings, Player owner)
-		{
-			return GetActorsWithTrait<Building>(owner.World)
-				.Count(a => a.Owner == owner && buildings.Contains(a.Info.Name));
-		}
-
-		public static ActorInfo GetInfoByCommonName(HashSet<string> names, Player owner)
-		{
-			return owner.World.Map.Rules.Actors.Where(k => names.Contains(k.Key)).Random(owner.World.LocalRandom).Value;
+			return actorIndex.Actors.Count(a => !a.IsDead);
 		}
 
 		public static void BotDebug(string format, params object[] args)

--- a/OpenRA.Mods.Common/ActorIndex.cs
+++ b/OpenRA.Mods.Common/ActorIndex.cs
@@ -1,0 +1,152 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common
+{
+	/// <summary>
+	/// Maintains an index of actors in the world.
+	/// </summary>
+	public abstract class ActorIndex : IDisposable
+	{
+		readonly World world;
+		readonly HashSet<Actor> actors = new();
+
+		public IReadOnlyCollection<Actor> Actors => actors;
+
+		ActorIndex(World world, IEnumerable<Actor> initialActorsToIndex)
+		{
+			this.world = world;
+			world.ActorAdded += AddActor;
+			world.ActorRemoved += RemoveActor;
+
+			actors.UnionWith(initialActorsToIndex);
+		}
+
+		protected abstract bool ShouldIndexActor(Actor actor);
+
+		void AddActor(Actor actor)
+		{
+			if (ShouldIndexActor(actor))
+				actors.Add(actor);
+		}
+
+		void RemoveActor(Actor actor)
+		{
+			actors.Remove(actor);
+		}
+
+		public void Dispose()
+		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		protected virtual void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				world.ActorAdded -= AddActor;
+				world.ActorRemoved -= RemoveActor;
+			}
+		}
+
+		// No OwnerAndTrait class is provided. As the world can provide actors by trait anyway,
+		// an additional filter on owner isn't sufficiently selective to justify the overhead of manging the index.
+		// Whereas a filter with actor names is much more selective, so OwnerAndNames is worthwhile.
+
+		/// <summary>
+		/// Maintains an index of actors in the world that
+		/// are owned by a given <see cref="Player"/>
+		/// and have one of the given <see cref="ActorInfo.Name"/>.
+		/// </summary>
+		public sealed class OwnerAndNames : ActorIndex
+		{
+			readonly HashSet<string> names;
+			readonly Player owner;
+
+			public OwnerAndNames(World world, IReadOnlyCollection<string> names, Player owner)
+				: base(world, ActorsToIndex(world, names.ToHashSet(), owner))
+			{
+				this.names = names.ToHashSet();
+				this.owner = owner;
+			}
+
+			static IEnumerable<Actor> ActorsToIndex(World world, HashSet<string> names, Player owner)
+			{
+				return world.Actors.Where(a => a.Owner == owner && names.Contains(a.Info.Name));
+			}
+
+			protected override bool ShouldIndexActor(Actor actor)
+			{
+				return actor.Owner == owner && names.Contains(actor.Info.Name);
+			}
+		}
+
+		/// <summary>
+		/// Maintains an index of actors in the world that
+		/// have one of the given <see cref="ActorInfo.Name"/>
+		/// and have the trait of type <typeparamref name="T"/>.
+		/// </summary>
+		public sealed class NamesAndTrait<T> : ActorIndex
+		{
+			readonly HashSet<string> names;
+
+			public NamesAndTrait(World world, IReadOnlyCollection<string> names)
+				: base(world, ActorsToIndex(world, names.ToHashSet()))
+			{
+				this.names = names.ToHashSet();
+			}
+
+			static IEnumerable<Actor> ActorsToIndex(World world, HashSet<string> names)
+			{
+				return world.ActorsHavingTrait<T>().Where(a => names.Contains(a.Info.Name));
+			}
+
+			protected override bool ShouldIndexActor(Actor actor)
+			{
+				return names.Contains(actor.Info.Name) && actor.TraitOrDefault<T>() != null;
+			}
+		}
+
+		/// <summary>
+		/// Maintains an index of actors in the world that
+		/// are owned by a given <see cref="Player"/>,
+		/// have one of the given <see cref="ActorInfo.Name"/>
+		/// and have the trait of type <typeparamref name="T"/>.
+		/// </summary>
+		public sealed class OwnerAndNamesAndTrait<T> : ActorIndex
+		{
+			readonly HashSet<string> names;
+			readonly Player owner;
+
+			public OwnerAndNamesAndTrait(World world, IReadOnlyCollection<string> names, Player owner)
+				: base(world, ActorsToIndex(world, names.ToHashSet(), owner))
+			{
+				this.names = names.ToHashSet();
+				this.owner = owner;
+			}
+
+			static IEnumerable<Actor> ActorsToIndex(World world, HashSet<string> names, Player owner)
+			{
+				return world.ActorsHavingTrait<T>().Where(a => a.Owner == owner && names.Contains(a.Info.Name));
+			}
+
+			protected override bool ShouldIndexActor(Actor actor)
+			{
+				return actor.Owner == owner && names.Contains(actor.Info.Name) && actor.TraitOrDefault<T>() != null;
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -255,7 +255,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// Next is to build up a strong economy
-			if (!baseBuilder.HasAdequateRefineryCount)
+			if (!baseBuilder.HasAdequateRefineryCount())
 			{
 				var refinery = GetProducibleBuilding(baseBuilder.Info.RefineryTypes, buildableThings);
 				if (refinery != null && HasSufficientPowerForActor(refinery))

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -47,12 +47,12 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new McvManagerBotModule(init.Self, this); }
 	}
 
-	public class McvManagerBotModule : ConditionalTrait<McvManagerBotModuleInfo>, IBotTick, IBotPositionsUpdated, IGameSaveTraitData
+	public class McvManagerBotModule : ConditionalTrait<McvManagerBotModuleInfo>,
+		IBotTick, IBotPositionsUpdated, IGameSaveTraitData, INotifyActorDisposing
 	{
 		public CPos GetRandomBaseCenter()
 		{
-			var randomConstructionYard = world.Actors.Where(a => a.Owner == player &&
-				Info.ConstructionYardTypes.Contains(a.Info.Name))
+			var randomConstructionYard = constructionYards.Actors
 				.RandomOrDefault(world.LocalRandom);
 
 			return randomConstructionYard?.Location ?? initialBaseCenter;
@@ -60,6 +60,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		readonly World world;
 		readonly Player player;
+		readonly ActorIndex.OwnerAndNamesAndTrait<Transforms> mcvs;
+		readonly ActorIndex.OwnerAndNamesAndTrait<Building> constructionYards;
+		readonly ActorIndex.OwnerAndNamesAndTrait<Building> mcvFactories;
 
 		IBotPositionsUpdated[] notifyPositionsUpdated;
 		IBotRequestUnitProduction[] requestUnitProduction;
@@ -73,6 +76,9 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			world = self.World;
 			player = self.Owner;
+			mcvs = new ActorIndex.OwnerAndNamesAndTrait<Transforms>(world, info.McvTypes, player);
+			constructionYards = new ActorIndex.OwnerAndNamesAndTrait<Building>(world, info.ConstructionYardTypes, player);
+			mcvFactories = new ActorIndex.OwnerAndNamesAndTrait<Building>(world, info.McvFactoryTypes, player);
 		}
 
 		protected override void Created(Actor self)
@@ -108,15 +114,12 @@ namespace OpenRA.Mods.Common.Traits
 				DeployMcvs(bot, true);
 
 				// No construction yards - Build a new MCV
-				if (ShouldBuildMCV())
+				var unitBuilder = requestUnitProduction.FirstEnabledTraitOrDefault();
+				if (unitBuilder != null && Info.McvTypes.Count > 0 && ShouldBuildMCV())
 				{
-					var unitBuilder = requestUnitProduction.FirstEnabledTraitOrDefault();
-					if (unitBuilder != null)
-					{
-						var mcvInfo = AIUtils.GetInfoByCommonName(Info.McvTypes, player);
-						if (unitBuilder.RequestedProductionCount(bot, mcvInfo.Name) == 0)
-							unitBuilder.RequestUnitProduction(bot, mcvInfo.Name);
-					}
+					var mcvType = Info.McvTypes.Random(world.LocalRandom);
+					if (unitBuilder.RequestedProductionCount(bot, mcvType) == 0)
+						unitBuilder.RequestUnitProduction(bot, mcvType);
 				}
 			}
 		}
@@ -124,19 +127,19 @@ namespace OpenRA.Mods.Common.Traits
 		bool ShouldBuildMCV()
 		{
 			// Only build MCV if we don't already have one in the field.
-			var allowedToBuildMCV = AIUtils.CountActorByCommonName(Info.McvTypes, player) == 0;
+			var allowedToBuildMCV = AIUtils.CountActorByCommonName(mcvs) == 0;
 			if (!allowedToBuildMCV)
 				return false;
 
 			// Build MCV if we don't have the desired number of construction yards, unless we have no factory (can't build it).
-			return AIUtils.CountBuildingByCommonName(Info.ConstructionYardTypes, player) < Info.MinimumConstructionYardCount &&
-				AIUtils.CountBuildingByCommonName(Info.McvFactoryTypes, player) > 0;
+			return AIUtils.CountActorByCommonName(constructionYards) < Info.MinimumConstructionYardCount &&
+				AIUtils.CountActorByCommonName(mcvFactories) > 0;
 		}
 
 		void DeployMcvs(IBot bot, bool chooseLocation)
 		{
-			var newMCVs = world.ActorsHavingTrait<Transforms>()
-				.Where(a => a.Owner == player && a.IsIdle && Info.McvTypes.Contains(a.Info.Name));
+			var newMCVs = mcvs.Actors
+				.Where(a => a.IsIdle);
 
 			foreach (var mcv in newMCVs)
 				DeployMcv(bot, mcv, chooseLocation);
@@ -148,7 +151,9 @@ namespace OpenRA.Mods.Common.Traits
 			if (move)
 			{
 				// If we lack a base, we need to make sure we don't restrict deployment of the MCV to the base!
-				var restrictToBase = Info.RestrictMCVDeploymentFallbackToBase && AIUtils.CountBuildingByCommonName(Info.ConstructionYardTypes, player) > 0;
+				var restrictToBase =
+					Info.RestrictMCVDeploymentFallbackToBase &&
+					AIUtils.CountActorByCommonName(constructionYards) > 0;
 
 				var transformsInfo = mcv.Info.TraitInfo<TransformsInfo>();
 				var desiredLocation = ChooseMcvDeployLocation(transformsInfo.IntoActor, transformsInfo.Offset, restrictToBase);
@@ -220,6 +225,13 @@ namespace OpenRA.Mods.Common.Traits
 			var initialBaseCenterNode = data.NodeWithKeyOrDefault("InitialBaseCenter");
 			if (initialBaseCenterNode != null)
 				initialBaseCenter = FieldLoader.GetValue<CPos>("InitialBaseCenter", initialBaseCenterNode.Value.Value);
+		}
+
+		void INotifyActorDisposing.Disposing(Actor self)
+		{
+			mcvs.Dispose();
+			constructionYards.Dispose();
+			mcvFactories.Dispose();
 		}
 	}
 }


### PR DESCRIPTION
Several parts of bot module logic, often through the AIUtils helper class, will query or count over all actors in the world. This is not a fast operation and the AI tends to repeat it often.

Introduce some ActorIndex classes that can maintain an index of actors in the world that match a query based on a mix of actor name, owner or trait. These indexes introduce some overhead to maintain, but allow the queries or counts that bot modules needs to perform to be greatly sped up, as the index means there is a much smaller starting set of actors to consider. This is beneficial to the bot logic as the TraitDictionary index maintained by the world works only in terms of traits and doesn't allow the bot logic to perform a sufficiently selective lookup. This is because the bot logic is usually defined in terms of actor names rather than traits.