### PR TITLE
Speed up Util.FastCopyIntoChannel

### DIFF
--- a/OpenRA.Game/Graphics/SpriteLoader.cs
+++ b/OpenRA.Game/Graphics/SpriteLoader.cs
@@ -22,20 +22,30 @@ namespace OpenRA.Graphics
 	/// </summary>
 	public enum SpriteFrameType
 	{
-		// 8 bit index into an external palette
+		/// <summary>
+		/// 8 bit index into an external palette.
+		/// </summary>
 		Indexed8,
 
-		// 32 bit color such as returned by Color.ToArgb() or the bmp file format
-		// (remember that little-endian systems place the little bits in the first byte!)
+		/// <summary>
+		/// 32 bit color such as returned by Color.ToArgb() or the bmp file format
+		/// (remember that little-endian systems place the little bits in the first byte).
+		/// </summary>
 		Bgra32,
 
-		// Like BGRA, but without an alpha channel
+		/// <summary>
+		/// Like BGRA, but without an alpha channel.
+		/// </summary>
 		Bgr24,
 
-		// 32 bit color in big-endian format, like png
+		/// <summary>
+		/// 32 bit color in big-endian format, like png.
+		/// </summary>
 		Rgba32,
 
-		// Like RGBA, but without an alpha channel
+		/// <summary>
+		/// Like RGBA, but without an alpha channel.
+		/// </summary>
 		Rgb24
 	}
 


### PR DESCRIPTION
Depends on #21358

The assets for the Tiberian Dawn HD mod are much larger than assets for the default mods, causing a lot of load time to be spent in Util.FastCopyIntoChannel.

We can provide a special case for the SpriteFrameType.Bgra32 format, which is the same format as the destination buffer. In this scenario we can just perform memory copies between the source and destination. Additionally, whilst the default mods require all their assets to get their alpha premultiplied, many of the Tiberian Dawn assets are already premultiplied. Being able to skip this step for these assets saves us having to interpret the bytes into colors and back again.

For the default mods, there isn't a noticeable timing difference. For Tiberian Dawn HD or other mods with modern assets sizes, a large speedup is achieved.

Timings for TD HD on my machine, split by assets for which `premultiplied` was true or false. When true, a bigger speedup is seen as the method doesn't have to do the premultiplication step.
| Already premultipled? | Before | After |
| -- | -- | -- |
| true | 740ms | 220ms |
| false | 340ms | 210ms |
| total | 1080ms | 430ms |