### PR TITLE
Correct landing craft passenger subcells

### DIFF
--- a/mods/cnc/scripts/campaign.lua
+++ b/mods/cnc/scripts/campaign.lua
@@ -31,7 +31,12 @@ end
 
 ReinforceWithLandingCraft = function(player, units, transportStart, transportUnload, rallypoint)
 	local transport = Actor.Create("lst", true, { Owner = player, Facing = Angle.North, Location = transportStart })
-	local subcell = 0
+	local subcell = 1
+
+	if #units == 1 then
+		subcell = 0
+	end
+
 	Utils.Do(units, function(a)
 		transport.LoadPassenger(Actor.Create(a, false, { Owner = transport.Owner, Facing = transport.Facing, Location = transportUnload, SubCell = subcell }))
 		subcell = subcell + 1


### PR DESCRIPTION
This is a tiny PR for a tiny issue that is difficult to spot because most Tiberian Dawn LSTs reinforce solo units or a mix of infantry that look alike, such as Minigunners and Grenadiers. This may be more obvious with the remastered assets.

Multiple passengers should each have their own subcell, beginning with the northwest and going NW -> NE -> Center -> SW -> SE. On bleed, the script begins with 0, [the "full cell" subcell](https://github.com/OpenRA/OpenRA/blob/7b82d85b27427f8f3eefa614dc2795c06798fd82/OpenRA.Game/Map/MapGrid.cs#L117) that is fine for solo passengers. If more are loaded, they'll have mismatched subcells like the group shown on the left:

https://github.com/OpenRA/OpenRA/assets/4985264/d258e25e-f246-48ca-bef2-27c9e44c09c8

The start of `gdi-07` works as a quick test case with Alt + P to pause. Note where the Grenadier on each boat begins. Once the boat stops on bleed, each passenger will swap to another position because their subcells are 0 -> 1 -> 2 (Full Cell/Center -> NW -> NE) instead of 1 -> 2 -> 3 (NW -> NE -> Center). The first Funpark mission also kinda works, though it's an oddball for loading Recon Bikes alongside infantry. As a 4th passenger, bikes will swap to subcell 3 at the center.