### PR TITLE
Spawn aircraft occupying land or at cruise altitude

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				actorReference.Add(new SkipMakeAnimsInit());
-				actorReference.Add(new SpawnedByMapInit(kv.Key));
+				actorReference.Add(new SpawnedByMapInit());
 
 				if (PreventMapSpawn(world, actorReference, preventMapSpawns))
 					continue;
@@ -66,9 +66,13 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public class SkipMakeAnimsInit : RuntimeFlagInit { }
-	public class SpawnedByMapInit : ValueActorInit<string>, ISuppressInitExport, ISingleInstanceInit
+	public class SpawnedByMapInit : ActorInit, ISuppressInitExport, ISingleInstanceInit
 	{
-		public SpawnedByMapInit(string value)
-			: base(value) { }
+		protected SpawnedByMapInit(string instanceName)
+			: base(instanceName) { }
+
+		public SpawnedByMapInit() { }
+
+		public override MiniYaml Save() => null;
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
@@ -94,6 +94,7 @@ namespace OpenRA.Mods.Common.Traits
 					new OwnerInit(p),
 					new SkipMakeAnimsInit(),
 					new FacingInit(facing),
+					new SpawnedByMapInit(),
 				});
 			}
 
@@ -123,6 +124,7 @@ namespace OpenRA.Mods.Common.Traits
 					new LocationInit(validCell),
 					new SubCellInit(subCell),
 					new FacingInit(facing),
+					new SpawnedByMapInit(),
 				});
 			}
 		}

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -18,6 +18,7 @@ carryall.reinforce:
 		LandableTerrainTypes: Sand, Rock, Transition, Spice, SpiceSand, Dune, Concrete
 		Repulsable: False
 		AirborneCondition: airborne
+		CanForceLand: false
 		CanSlide: True
 		VTOL: true
 		IdleTurnSpeed: 4


### PR DESCRIPTION
Followup on #21076

Fixes #21305
Fixes #21339
Fixes #21384

Aircraft spawned by map and spawned by starting unit now have new behaviour. They always either occupy and an airpad, are occupying ground or are spawned at cruise altitude 

or testing see cnc - TwistOfFate. Helicopters are parked on airfields, or download d2k testcase from to see that carryalls are spawned airborne #21305