### PR TITLE
Trim empty space around edges of Shp(TD) frames

### DIFF
--- a/OpenRA.Game/Graphics/CursorManager.cs
+++ b/OpenRA.Game/Graphics/CursorManager.cs
@@ -229,6 +229,10 @@ namespace OpenRA.Graphics
 
 			var width = frame.Size.Width;
 			var height = frame.Size.Height;
+
+			if (width == 0 || height == 0)
+				return Array.Empty<byte>();
+
 			var data = new byte[4 * width * height];
 			unsafe
 			{


### PR DESCRIPTION
Revives #15148. It appears the original issues were fixed along the years. I suspect the addition of anti-aliasing had an effect on it.

https://github.com/OpenRA/OpenRA/issues/15184#issuecomment-393969769 is still present but we can't do anything about it. The 2nd option was chosen back then and we can choose it again. Auto bounds is correct much more often than its not anyhow.