### PR TITLE
Don't allocate empty sheets

### DIFF
--- a/OpenRA.Game/Graphics/CursorManager.cs
+++ b/OpenRA.Game/Graphics/CursorManager.cs
@@ -128,7 +128,7 @@ namespace OpenRA.Graphics
 				}
 			}
 
-			sheetBuilder.Current.ReleaseBuffer();
+			sheetBuilder.Current?.ReleaseBuffer();
 
 			hardwareCursorsDoubled = graphicSettings.CursorDouble;
 		}

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -75,8 +75,6 @@ namespace OpenRA.Graphics
 		{
 			CurrentChannel = t == SheetType.Indexed ? TextureChannel.Red : TextureChannel.RGBA;
 			Type = t;
-			Current = allocateSheet();
-			sheets.Add(Current);
 			this.allocateSheet = allocateSheet;
 			this.margin = margin;
 		}
@@ -85,6 +83,12 @@ namespace OpenRA.Graphics
 		public Sprite Add(byte[] src, SpriteFrameType type, Size size, bool premultiplied = false) { return Add(src, type, size, 0, float3.Zero, premultiplied); }
 		public Sprite Add(byte[] src, SpriteFrameType type, Size size, float zRamp, in float3 spriteOffset, bool premultiplied = false)
 		{
+			if (Current == null)
+			{
+				Current = allocateSheet();
+				sheets.Add(Current);
+			}
+
 			// Don't bother allocating empty sprites
 			if (size.Width == 0 || size.Height == 0)
 				return new Sprite(Current, Rectangle.Empty, 0, spriteOffset, CurrentChannel, BlendMode.Alpha);
@@ -115,6 +119,12 @@ namespace OpenRA.Graphics
 		public Sprite Allocate(Size imageSize, float scale = 1f) { return Allocate(imageSize, 0, float3.Zero, scale); }
 		public Sprite Allocate(Size imageSize, float zRamp, in float3 spriteOffset, float scale = 1f)
 		{
+			if (Current == null)
+			{
+				Current = allocateSheet();
+				sheets.Add(Current);
+			}
+
 			if (imageSize.Width + p.X + margin > Current.Size.Width)
 			{
 				p = new int2(0, p.Y + rowHeight + margin);

--- a/OpenRA.Game/Graphics/SpriteCache.cs
+++ b/OpenRA.Game/Graphics/SpriteCache.cs
@@ -155,7 +155,7 @@ namespace OpenRA.Graphics
 			}
 
 			foreach (var sb in SheetBuilders.Values)
-				sb.Current.ReleaseBuffer();
+				sb.Current?.ReleaseBuffer();
 		}
 
 		public Sprite[] ResolveSprites(int token)

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -363,7 +363,9 @@ namespace OpenRA
 			}
 
 			// Release the buffer by forcing changes to be written out to the texture, allowing the buffer to be reclaimed by GC.
-			Game.RunAfterTick(sheetBuilder.Current.ReleaseBuffer);
+			if (sheetBuilder.Current != null)
+				Game.RunAfterTick(sheetBuilder.Current.ReleaseBuffer);
+
 			Log.Write("debug", "MapCache.LoadAsyncInternal ended");
 		}
 

--- a/OpenRA.Mods.Cnc/Graphics/VoxelLoader.cs
+++ b/OpenRA.Mods.Cnc/Graphics/VoxelLoader.cs
@@ -229,7 +229,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 
 		public void Finish()
 		{
-			sheetBuilder.Current.ReleaseBuffer();
+			sheetBuilder.Current?.ReleaseBuffer();
 		}
 
 		public void Dispose()

--- a/OpenRA.Mods.Common/Terrain/DefaultTileCache.cs
+++ b/OpenRA.Mods.Common/Terrain/DefaultTileCache.cs
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.Common.Terrain
 
 			MissingTile = sheetBuilders[missingSheetType].Add(new byte[missingDataLength], missingFrameType, new Size(1, 1));
 			foreach (var sb in sheetBuilders.Values)
-				sb.Current.ReleaseBuffer();
+				sb.Current?.ReleaseBuffer();
 		}
 
 		public bool HasTileSprite(TerrainTile r, int? variant = null)


### PR DESCRIPTION
Currently sheet builder allocates empty BGRA sheets for RA, TD and TS