### PR TITLE
Fix ActorIndex when dealing with multiple trait instances.

### DIFF
--- a/OpenRA.Mods.Common/ActorIndex.cs
+++ b/OpenRA.Mods.Common/ActorIndex.cs
@@ -116,7 +116,7 @@ namespace OpenRA.Mods.Common
 
 			protected override bool ShouldIndexActor(Actor actor)
 			{
-				return names.Contains(actor.Info.Name) && actor.TraitOrDefault<T>() != null;
+				return names.Contains(actor.Info.Name) && actor.TraitsImplementing<T>().Any();
 			}
 		}
 
@@ -145,7 +145,7 @@ namespace OpenRA.Mods.Common
 
 			protected override bool ShouldIndexActor(Actor actor)
 			{
-				return actor.Owner == owner && names.Contains(actor.Info.Name) && actor.TraitOrDefault<T>() != null;
+				return actor.Owner == owner && names.Contains(actor.Info.Name) && actor.TraitsImplementing<T>().Any();
 			}
 		}
 	}


### PR DESCRIPTION
The intended check was "has any trait", but TraitOrDefault throws if there is more than one. Adjust this check so it doesn't throw in the face of multiple trait instances.

Resolves a regression introduced in #21360.
