### PR TITLE
Fix RA+CnC map import of BARB/FENC

### DIFF
--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertMapCommand.cs
@@ -40,11 +40,11 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 		// Mapping from RA95 overlay index to type string
 		static readonly string[] RedAlertOverlayNames =
 		{
-			"sbag", "cycl", "brik", "fenc", "wood",
+			"sbag", "cycl", "brik", "barb", "wood",
 			"gold01", "gold02", "gold03", "gold04",
 			"gem01", "gem02", "gem03", "gem04",
 			"v12", "v13", "v14", "v15", "v16", "v17", "v18",
-			"fpls", "wcrate", "scrate", "barb", "sbag",
+			"fpls", "wcrate", "scrate", "fenc", "sbag",
 		};
 
 		static readonly Dictionary<string, (byte Type, byte Index)> OverlayResourceMapping = new()
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 		static readonly string[] OverlayActors = new string[]
 		{
 			// Fences
-			"sbag", "cycl", "brik", "fenc", "wood",
+			"sbag", "cycl", "brik", "barb", "wood", "fenc",
 
 			// Fields
 			"v12", "v13", "v14", "v15", "v16", "v17", "v18",

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianDawnMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianDawnMapCommand.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 		static readonly string[] OverlayActors = new string[]
 		{
 			// Fences
-			"sbag", "cycl", "brik", "fenc", "wood",
+			"sbag", "cycl", "brik", "barb", "wood",
 
 			// Fields
 			"v12", "v13", "v14", "v15", "v16", "v17", "v18",


### PR DESCRIPTION
Small potatoes but this should fix an issue with imported overlays. In Red Alert, [the newer FENC should have an index of 23 instead of BARB's 3](https://github.com/electronicarts/CnC_Remastered_Collection/blob/7d496e8a633a8bbf8a14b65f490b4d21fa32ca03/REDALERT/DEFINES.H#L1547). On bleed, FENC is not imported at all and BARB is replaced by FENC.

I ran into the BARB -> FENC swap when putting together Mousetrap, clocked it only as a curiosity at the time, and just placed back the BARB. It seems that other people working on the campaign did a similar thing, with some exceptions like `soviet-01` or `allies-06a`/`allies-06b` where wire is missing around Soviet bases.

Tiberian Dawn's importer likewise has BARB swapped for FENC, which doesn't exist in that mod.

----

A test map in Mobius:
![InEditorTrimmed](https://github.com/OpenRA/OpenRA/assets/4985264/226c6569-9855-4ce8-ad21-f06af2d5079e)

That map imported on bleed:
![InBleedTrim](https://github.com/OpenRA/OpenRA/assets/4985264/962d6688-945f-4f34-9c08-d5a5c60a8502)

The same map imported with these changes:
![InPRTrimmed](https://github.com/OpenRA/OpenRA/assets/4985264/3c6a8a0b-d4a2-41e9-84ed-b873d56b9970)