### PR TITLE
Minelayer: remove unnecessary requirement on Rearmable

### DIFF
--- a/OpenRA.Mods.Common/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Common/Traits/Minelayer.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class MinelayerInfo : TraitInfo, Requires<RearmableInfo>
+	public class MinelayerInfo : TraitInfo
 	{
 		[ActorReference]
 		public readonly string Mine = "minv";


### PR DESCRIPTION
`Minelayer` requires `Rearmable`, but `Minelayer` does not use it. `LayMines` activity uses `Rearmable`, but it [can work](https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Activities/LayMines.cs#L86) without it:

```
if ((minefield == null || minefield.Contains(self.Location)) && CanLayMine(self, self.Location))
{
    if (rearmableInfo != null && ammoPools.Any(p => p.Info.Name == minelayer.Info.AmmoPoolName && !p.HasAmmo))
    {
    // ...
```

This PR simply removes the mandatory dependency on `Rearmable`, making it possible to remove `Rearmable` trait on actors, which don't need to use it.