### PR TITLE
TS: Implement Hunter-Seeker Attempt 2 #12918 

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -181,7 +181,7 @@ namespace OpenRA.GameRules
 		/// <summary>Checks if the weapon is valid against (can target) the target.</summary>
 		public bool IsValidAgainst(in Target target, World world, Actor firedBy)
 		{
-			if (target.Type == TargetType.Actor)
+			if (target.Type == TargetType.Actor || target.Type == TargetType.ActorIgnoreVisibility)
 				return IsValidAgainst(target.Actor, firedBy);
 
 			if (target.Type == TargetType.FrozenActor)

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -116,6 +116,7 @@ namespace OpenRA
 						{
 							switch ((TargetType)r.ReadByte())
 							{
+								case TargetType.ActorIgnoreVisibility:
 								case TargetType.Actor:
 								{
 									var actorID = r.ReadUInt32();
@@ -380,6 +381,7 @@ namespace OpenRA
 						w.Write((byte)targetState.Type);
 						switch (targetState.Type)
 						{
+							case TargetType.ActorIgnoreVisibility:
 							case TargetType.Actor:
 								w.Write(UIntFromActor(targetState.Actor));
 								w.Write(targetState.Generation);

--- a/OpenRA.Game/Sync.cs
+++ b/OpenRA.Game/Sync.cs
@@ -138,6 +138,7 @@ namespace OpenRA
 		{
 			switch (t.Type)
 			{
+				case TargetType.ActorIgnoreVisibility:
 				case TargetType.Actor:
 					return (int)(t.Actor.ActorID << 16) * 0x567;
 

--- a/OpenRA.Mods.Cnc/Traits/HunterSeeker.cs
+++ b/OpenRA.Mods.Cnc/Traits/HunterSeeker.cs
@@ -1,0 +1,70 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Cnc.Traits
+{
+	sealed class HunterSeekerInfo : TraitInfo
+	{
+		[Desc("Valid target relationships.")]
+		public readonly PlayerRelationship TargetRelationships = PlayerRelationship.Enemy;
+		public override object Create(ActorInitializer init) { return new HunterSeeker(this); }
+	}
+
+	sealed class HunterSeeker : INotifyAddedToWorld, INotifyBecomingIdle, ITick
+	{
+		Actor target;
+		readonly HunterSeekerInfo info;
+
+		public HunterSeeker(HunterSeekerInfo info)
+		{
+			this.info = info;
+		}
+
+		void INotifyAddedToWorld.AddedToWorld(Actor self)
+		{
+			SelectNewTarget(self);
+		}
+
+		void INotifyBecomingIdle.OnBecomingIdle(Actor self)
+		{
+			if (target == null)
+				return;
+
+			if (TargetIsInvalid())
+				SelectNewTarget(self);
+		}
+
+		bool TargetIsInvalid()
+		{
+			return target.Disposed || target.IsDead || !target.IsInWorld;
+		}
+
+		void SelectNewTarget(Actor self)
+		{
+			target = self.World.Actors.Where(x => info.TargetRelationships.HasFlag(self.Owner.RelationshipWith(x.Owner)) && x.IsTargetableBy(self)).RandomOrDefault(self.World.SharedRandom);
+			if (target != null)
+				self.QueueActivity(false, new FlyAttack(self, Common.Traits.AttackSource.AutoTarget, Target.FromTrackedActor(target), forceAttack: false, null));
+		}
+
+		void ITick.Tick(Actor self)
+		{
+			if (self.IsDead)
+				return;
+
+			if (target == null || TargetIsInvalid())
+				SelectNewTarget(self);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -53,12 +53,12 @@ namespace OpenRA.Mods.Common.Activities
 			// The target may become hidden between the initial order request and the first tick (e.g. if queued)
 			// Moving to any position (even if quite stale) is still better than immediately giving up
 			if ((target.Type == TargetType.Actor && target.Actor.CanBeViewedByPlayer(self.Owner))
-				|| target.Type == TargetType.FrozenActor || target.Type == TargetType.Terrain)
+				|| target.Type == TargetType.FrozenActor || target.Type == TargetType.Terrain || target.Type == TargetType.ActorIgnoreVisibility)
 			{
 				lastVisibleTarget = Target.FromPos(target.CenterPosition);
 				lastVisibleMaximumRange = attackAircraft.GetMaximumRangeVersusTarget(target);
 
-				if (target.Type == TargetType.Actor)
+				if (target.Type == TargetType.Actor || target.Type == TargetType.ActorIgnoreVisibility)
 				{
 					lastVisibleOwner = target.Actor.Owner;
 					lastVisibleTargetTypes = target.Actor.GetEnabledTargetTypes();
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.Common.Activities
 			attackAircraft.SetRequestedTarget(target, forceAttack);
 			hasTicked = true;
 
-			if (!targetIsHiddenActor && target.Type == TargetType.Actor)
+			if (target.Type == TargetType.ActorIgnoreVisibility || (!targetIsHiddenActor && (target.Type == TargetType.Actor)))
 			{
 				lastVisibleTarget = Target.FromTargetPositions(target);
 				lastVisibleMaximumRange = attackAircraft.GetMaximumRangeVersusTarget(target);

--- a/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Warheads
 			var firedBy = args.SourceActor;
 
 			// Used by traits or warheads that damage a single actor, rather than a position
-			if (target.Type == TargetType.Actor)
+			if (target.Type == TargetType.Actor || target.Type == TargetType.ActorIgnoreVisibility)
 			{
 				var victim = target.Actor;
 

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -508,6 +508,8 @@ HUNTER:
 		CruiseAltitude: 3c128
 		CruisingCondition: cruising
 		MoveIntoShroud: true
+		CanHover: true
+		CanSlide: true
 	AttackAircraft:
 		FacingTolerance: 512
 		AttackType: Hover
@@ -533,5 +535,6 @@ HUNTER:
 		UseLocation: true
 	Interactable:
 	HitShape:
+	HunterSeeker:
 	MapEditorData:
 		Categories: System


### PR DESCRIPTION
Implements https://github.com/OpenRA/OpenRA/issues/12918
Implements random hunter seeker behavior by adding a trait thats issues a FlyAttack command on spawn, if there is a valid target. The new TargetType was added so that we can ignore the shroud while doing target validity checks and so that we do not have to reimplement a whole new attack activity for this.