### PR TITLE
configure-system-libraries.sh: Skip 32bit libraries during lookup on x64 Linux. #21353

### DIFF
--- a/configure-system-libraries.sh
+++ b/configure-system-libraries.sh
@@ -5,7 +5,6 @@
 # This file must stay /bin/sh and POSIX compliant for macOS and BSD portability.
 # Copy-paste the entire script into http://shellcheck.net to check.
 ####
-
 set -o errexit || exit $?
 
 patch_config()
@@ -37,11 +36,18 @@ patch_config()
 		if [ -L "bin/${REPLACE}" ]; then
 			return 0
 		fi
-
+		KERNEL="$(uname -s)"
+		ARCH="$(arch)"
 		printf "Searching for %s... " "${LABEL}"
 		for DIR in ${SEARCHDIRS} ; do
 			for LIB in ${SEARCH}; do
 				if [ -f "${DIR}/${LIB}" ]; then
+					# x86-64 Linux might have 32-bit libraries present, link against the 64 bit libraries since there is no 32-bit Linux release of dotnet
+					if [ "${KERNEL}" = "Linux" ] && [ "${ARCH}" = "x86_64" ];  then
+						if [ "$(LANG=C file -L -b "${DIR}/${LIB}" | cut -d" " -f2)" != "64-bit" ]; then
+							continue
+						fi
+					fi
 					echo "${LIB}"
 					ln -s "${DIR}/${LIB}" "bin/${REPLACE}"
 					return 0


### PR DESCRIPTION
Fixes #21353
When looking up system libraries on x64 Linux,  there might be 32bit libraries present higher on the path priority list than 64bit libraries. These should be skipped, since there is no official 32bit build of .NET 6 for Linux.

Tested on OpenSuse Tumbleweed.