### PR TITLE
Fix support power name not really being optional

### DIFF
--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -157,6 +157,8 @@ namespace OpenRA.Mods.Common.Traits
 			oneShotFired;
 
 		public SupportPowerInfo Info { get { return Instances.Select(i => i.Info).FirstOrDefault(); } }
+		public readonly string Name;
+		public readonly string Description;
 		public bool Ready => Active && RemainingTicks == 0;
 
 		bool instancesEnabled;
@@ -175,6 +177,8 @@ namespace OpenRA.Mods.Common.Traits
 			Key = key;
 			TotalTicks = info.ChargeInterval;
 			remainingSubTicks = info.StartFullyCharged ? 0 : TotalTicks * 100;
+			Name = info.Name == null ? string.Empty : TranslationProvider.GetString(info.Name);
+			Description = info.Description == null ? string.Empty : TranslationProvider.GetString(info.Description);
 
 			Manager = manager;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
@@ -53,13 +53,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (sp == lastPower && hotkey == lastHotkey && lastRemainingSeconds == remainingSeconds)
 					return;
 
-				var nameText = TranslationProvider.GetString(sp.Info.Name);
-				nameLabel.GetText = () => nameText;
-				var nameSize = nameFont.Measure(nameText);
+				nameLabel.GetText = () => sp.Name;
+				var nameSize = nameFont.Measure(sp.Name);
 
-				var descText = TranslationProvider.GetString(sp.Info.Description);
-				descLabel.GetText = () => descText;
-				var descSize = descFont.Measure(descText);
+				descLabel.GetText = () => sp.Description;
+				var descSize = descFont.Measure(sp.Description);
 
 				var timeText = sp.TooltipTimeTextOverride();
 				if (timeText == null)

--- a/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
@@ -59,8 +59,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				var self = p.Instances[0].Self;
 				var time = WidgetUtils.FormatTime(p.RemainingTicks, false, self.World.Timestep);
-				var supportPowerName = TranslationProvider.GetString(p.Info.Name);
-				var text = TranslationProvider.GetString(Format, Translation.Arguments("player", self.Owner.PlayerName, "support-power", supportPowerName, "time", time));
+				var text = TranslationProvider.GetString(Format, Translation.Arguments("player", self.Owner.PlayerName, "support-power", p.Name, "time", time));
 
 				var playerColor = self.Owner.Color;
 


### PR DESCRIPTION
Follow up on #21385

In missions we don't define names for support powers that are meant to be only used via scripting, but just because this edge case exists it doesn't mean we shouldn't handle it crashing for player support powers

This also fixes the translation query spam