### PR TITLE
Fix tiles 69, 79 in D2k tileset

### DIFF
--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -1388,7 +1388,7 @@ Templates:
 		Tiles:
 			0: Cliff
 			1: Cliff
-			2: Rock
+			2: Transition
 			3: Rock
 	Template@190:
 		Id: 190
@@ -1437,7 +1437,7 @@ Templates:
 			0: Cliff
 			1: Cliff
 			2: Cliff
-			3: Rock
+			3: Cliff
 	Template@194:
 		Id: 194
 		Images: BLOXBASE.R16
@@ -1571,9 +1571,9 @@ Templates:
 		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
-			1: Rock
+			1: Cliff
 			2: Cliff
-			3: Rock
+			3: Cliff
 	Template@206:
 		Id: 206
 		Images: BLOXBASE.R16
@@ -6730,3 +6730,35 @@ Templates:
 		Categories: Bridge
 		Tiles:
 			0: Rock
+	Template@1227
+		Id: 1227
+		Images: BLOXBASE.R16
+		Frames: 318
+		Size: 1,1
+		Categories: Rock-Sand-Smooth
+		Tiles:
+			0: Transition
+	Template@1228
+		Id: 1228
+		Images: BLOXBASE.R16
+		Frames: 296
+		Size: 1,1
+		Categories: Rock-Sand-Smooth
+		Tiles:
+			0: Transition
+	Template@1229
+		Id: 1229
+		Images: BLOXBASE.R16
+		Frames: 317
+		Size: 1,1
+		Categories: Rock-Sand-Smooth
+		Tiles:
+			0: Transition
+	Template@1230
+		Id: 1230
+		Images: BLOXBASE.R16
+		Frames: 295
+		Size: 1,1
+		Categories: Rock-Sand-Smooth
+		Tiles:
+			0: Transition


### PR DESCRIPTION
Tiles 69 and 79 should be as 1x1 tile because they are corners. For compatibility reasons I leave 69, 79 intact and add corners as new tiles.
Also fixed wrong tile type for tiles: 189, 181, 205

P.s. If you wonder why  ID start on 1227 its because of dependency #21308 . 
before:

![d2k-2024-04-05T080130515Z](https://github.com/OpenRA/OpenRA/assets/100044015/f2505290-e7b2-4cef-9dda-85a471f99284)

After:
![d2k-2024-04-05T082331306Z](https://github.com/OpenRA/OpenRA/assets/100044015/f5bfe43e-092c-4f38-8f61-a8d345b43dd2)
