### PR TITLE
CheckTranslationReference lint pass learns additional checks

### DIFF
--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Graphics
 
 		float deviceScale;
 
-		public SpriteFont(string name, byte[] data, int size, int ascender, float scale, SheetBuilder builder)
+		public SpriteFont(IPlatform platform, string name, byte[] data, int size, int ascender, float scale, SheetBuilder builder)
 		{
 			if (builder.Type != SheetType.BGRA)
 				throw new ArgumentException("The sheet builder must create BGRA sheets.", nameof(builder));
@@ -36,7 +36,7 @@ namespace OpenRA.Graphics
 			this.size = size;
 			this.builder = builder;
 
-			font = Game.Renderer.CreateFont(data);
+			font = platform.CreateFont(data);
 			glyphs = new Cache<char, GlyphInfo>(CreateGlyph);
 			contrastGlyphs = new Cache<(char, int), Sprite>(CreateContrastGlyph);
 			dilationElements = new Cache<int, float[]>(CreateCircularWeightMap);

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -134,8 +134,9 @@ namespace OpenRA
 				fontSheetBuilder?.Dispose();
 				fontSheetBuilder = new SheetBuilder(SheetType.BGRA, 512);
 				Fonts = modData.Manifest.Get<Fonts>().FontList.ToDictionary(x => x.Key,
-					x => new SpriteFont(x.Value.Font, modData.DefaultFileSystem.Open(x.Value.Font).ReadAllBytes(),
-										x.Value.Size, x.Value.Ascender, Window.EffectiveWindowScale, fontSheetBuilder));
+					x => new SpriteFont(
+						platform, x.Value.Font, modData.DefaultFileSystem.Open(x.Value.Font).ReadAllBytes(),
+						x.Value.Size, x.Value.Ascender, Window.EffectiveWindowScale, fontSheetBuilder));
 			}
 
 			Window.OnWindowScaleChanged += (oldNative, oldEffective, newNative, newEffective) =>
@@ -562,11 +563,6 @@ namespace OpenRA
 		}
 
 		public string GLVersion => Context.GLVersion;
-
-		public IFont CreateFont(byte[] data)
-		{
-			return platform.CreateFont(data);
-		}
 
 		public int DisplayCount => Window.DisplayCount;
 

--- a/OpenRA.Game/Translation.cs
+++ b/OpenRA.Game/Translation.cs
@@ -54,7 +54,7 @@ namespace OpenRA
 		readonly FluentBundle bundle;
 
 		public Translation(string language, string[] translations, IReadOnlyFileSystem fileSystem)
-			: this(language, translations, fileSystem, error => Log.Write("debug", error.ToString())) { }
+			: this(language, translations, fileSystem, error => Log.Write("debug", error.Message)) { }
 
 		public Translation(string language, string[] translations, IReadOnlyFileSystem fileSystem, Action<ParseError> onError)
 		{
@@ -92,12 +92,12 @@ namespace OpenRA
 		{
 			// Always load english strings to provide a fallback for missing translations.
 			// It is important to load the english files first so the chosen language's files can override them.
-			var paths = translations.Where(t => t.EndsWith("en.ftl", StringComparison.Ordinal)).ToHashSet();
+			var paths = translations.Where(t => t.EndsWith("en.ftl", StringComparison.Ordinal)).ToList();
 			foreach (var t in translations)
 				if (t.EndsWith($"{language}.ftl", StringComparison.Ordinal))
 					paths.Add(t);
 
-			foreach (var path in paths)
+			foreach (var path in paths.Distinct())
 			{
 				var stream = fileSystem.Open(path);
 				using (var reader = new StreamReader(stream))

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -526,7 +526,6 @@ Container@EDITOR_WORLD_ROOT:
 							Width: 30
 							Height: 25
 							Align: Left
-							Text: 85
 						Label@MODE_LABEL:
 							X: 6
 							Y: 102
@@ -558,7 +557,6 @@ Container@EDITOR_WORLD_ROOT:
 							Width: 30
 							Height: 25
 							Align: Left
-							Text: 2
 							Visible: false
 						DropDownButton@FLIP_NUM_SIDES_DROPDOWN:
 							X: 129
@@ -585,7 +583,6 @@ Container@EDITOR_WORLD_ROOT:
 							Width: 30
 							Height: 25
 							Align: Left
-							Text: 0
 							Visible: false
 		Container@HISTORY_WIDGETS:
 			Logic: HistoryLogLogic
@@ -651,7 +648,7 @@ Container@EDITOR_WORLD_ROOT:
 						Label@AREA_FILTERS_LABEL:
 							X: 6
 							Y: 36
-							Width: 55
+							Width: 150
 							Height: 25
 							Font: Bold
 							Align: Left
@@ -685,7 +682,7 @@ Container@EDITOR_WORLD_ROOT:
 						Label@DIAGONAL_LABEL:
 							X: 6
 							Y: 171
-							Width: 55
+							Width: 120
 							Height: 20
 							Font: Bold
 							Align: Left
@@ -693,7 +690,7 @@ Container@EDITOR_WORLD_ROOT:
 						Label@RESOURCE_LABEL:
 							X: 6
 							Y: 193
-							Width: 55
+							Width: 120
 							Height: 25
 							Font: Bold
 							Align: Left
@@ -1001,19 +998,6 @@ ScrollPanel@CATEGORY_FILTER_PANEL:
 					Text: button-select-categories-buttons-none
 		Checkbox@CATEGORY_TEMPLATE:
 			X: 5
-			Width: PARENT_RIGHT - 29
-			Height: 20
-			Visible: false
-
-ScrollPanel@OVERLAY_PANEL:
-	Width: 140
-	Height: 80
-	ItemSpacing: 5
-	TopBottomSpacing: 0
-	Children:
-		Checkbox@CATEGORY_TEMPLATE:
-			X: 5
-			Y: 5
 			Width: PARENT_RIGHT - 29
 			Height: 20
 			Visible: false

--- a/mods/cnc/chrome/tooltips.yaml
+++ b/mods/cnc/chrome/tooltips.yaml
@@ -72,29 +72,6 @@ Background@BUTTON_TOOLTIP_FACTIONSUFFIX:
 			Font: TinyBold
 			VAlign: Top
 
-Background@BUTTON_WITH_DESC_HIGHLIGHT_TOOLTIP:
-	Logic: ButtonTooltipLogic
-	Background: panel-black
-	Height: 26
-	Children:
-		Label@LABEL:
-			X: 5
-			Y: 1
-			Height: 23
-			Font: Bold
-		Label@HOTKEY:
-			Y: 1
-			Visible: false
-			TextColor: FFFF00
-			Height: 23
-			Font: Bold
-		LabelWithHighlight@DESC:
-			X: 5
-			Y: 26
-			Height: 12
-			Font: TinyBold
-			VAlign: Top
-
 Background@BUTTON_WITH_DESC_HIGHLIGHT_TOOLTIP_FACTIONSUFFIX:
 	Logic: ButtonTooltipLogic, AddFactionSuffixLogic
 	Background: panel-black

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -485,7 +485,6 @@ Container@EDITOR_WORLD_ROOT:
 							Width: 30
 							Height: 25
 							Align: Left
-							Text: 85
 						Label@MODE_LABEL:
 							X: 6
 							Y: 102
@@ -517,7 +516,6 @@ Container@EDITOR_WORLD_ROOT:
 							Width: 30
 							Height: 25
 							Align: Left
-							Text: 2
 							Visible: false
 						DropDownButton@FLIP_NUM_SIDES_DROPDOWN:
 							X: 129
@@ -544,7 +542,6 @@ Container@EDITOR_WORLD_ROOT:
 							Width: 30
 							Height: 25
 							Align: Left
-							Text: 0
 							Visible: false
 		Container@HISTORY_WIDGETS:
 			X: WINDOW_RIGHT - 320
@@ -599,7 +596,7 @@ Container@EDITOR_WORLD_ROOT:
 						Label@AREA_FILTERS_LABEL:
 							X: 15
 							Y: 45
-							Width: 55
+							Width: 150
 							Height: 25
 							Font: Bold
 							Align: Left
@@ -633,7 +630,7 @@ Container@EDITOR_WORLD_ROOT:
 						Label@DIAGONAL_LABEL:
 							X: 15
 							Y: 171
-							Width: 55
+							Width: 120
 							Height: 20
 							Font: Bold
 							Align: Left
@@ -641,7 +638,7 @@ Container@EDITOR_WORLD_ROOT:
 						Label@RESOURCE_LABEL:
 							X: 15
 							Y: 193
-							Width: 55
+							Width: 120
 							Height: 25
 							Font: Bold
 							Align: Left

--- a/mods/common/chrome/multiplayer-directconnect.yaml
+++ b/mods/common/chrome/multiplayer-directconnect.yaml
@@ -32,7 +32,7 @@ Background@DIRECTCONNECT_PANEL:
 			Width: 10
 			Height: 25
 			Align: Center
-			Text: :
+			Text: label-directconnect-panel-port
 		TextField@PORT:
 			X: 370
 			Y: 60

--- a/mods/common/languages/chrome/en.ftl
+++ b/mods/common/languages/chrome/en.ftl
@@ -386,6 +386,7 @@ button-multiplayer-createserver-panel-create = Create
 ## multiplayer-directconnect.yaml
 label-directconnect-panel-title = Connect to Server
 label-directconnect-panel-address = Server Address:
+label-directconnect-panel-port = :
 button-directconnect-panel-join = Join
 
 ## playerprofile.yaml


### PR DESCRIPTION
- Test all translation languages, not just English.
- Report any fields marked with TranslationReferenceAttribute that the lint pass lacked the knowledge to check.
- Improve context provided by lint messages.
- Restructure code for readability.

Additionally:
- Fix some bugs in Translation.
- Tweak some UI Yaml files.
- Inject platform dependency in SpriteFont.

Assists with #10475. Split from #21293