### PR TITLE
Add a more helpful crash on missing frames

### DIFF
--- a/OpenRA.Game/Graphics/SpriteCache.cs
+++ b/OpenRA.Game/Graphics/SpriteCache.cs
@@ -97,9 +97,11 @@ namespace OpenRA.Graphics
 						{
 							var resolved = new Sprite[loadedFrames.Length];
 							resolvedSprites[token] = resolved;
-							var frames = rs.Frames ?? Enumerable.Range(0, loadedFrames.Length);
+							if (rs.Frames != null && rs.Frames.Any(i => i >= loadedFrames.Length))
+								throw new InvalidOperationException($"{rs.Location}: {filename} does not contain frames: " +
+									string.Join(',', rs.Frames.Where(f => f >= loadedFrames.Length)));
 
-							foreach (var i in frames)
+							foreach (var i in rs.Frames ?? Enumerable.Range(0, loadedFrames.Length))
 							{
 								var frame = loadedFrames[i];
 								if (rs.AdjustFrame != null)


### PR DESCRIPTION
Currently it crashes with: exception of type `System.IndexOutOfRangeException`: Index was outside the bounds of the array.

With no hint to where the issue resides
This is hot code though it runs only once on game / map start