### PR TITLE
Introduce MoveCooldownHelper to prevent lag spikes from failed pathfinding

### DIFF
--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -24,6 +24,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly HarvesterInfo harvInfo;
 		readonly Mobile mobile;
 		readonly ResourceClaimLayer claimLayer;
+		readonly MoveCooldownHelper moveCooldownHelper;
 		CPos? orderLocation;
 		CPos? lastHarvestedCell;
 		bool hasDeliveredLoad;
@@ -38,6 +39,7 @@ namespace OpenRA.Mods.Common.Activities
 			harvInfo = self.Info.TraitInfo<HarvesterInfo>();
 			mobile = self.Trait<Mobile>();
 			claimLayer = self.World.WorldActor.Trait<ResourceClaimLayer>();
+			moveCooldownHelper = new MoveCooldownHelper(self.World, mobile) { RetryIfDestinationBlocked = true };
 			if (orderLocation.HasValue)
 				this.orderLocation = orderLocation.Value;
 		}
@@ -112,6 +114,10 @@ namespace OpenRA.Mods.Common.Activities
 			else
 				LastSearchFailed = false;
 
+			var result = moveCooldownHelper.Tick(false);
+			if (result != null)
+				return result.Value;
+
 			// If no harvestable position could be found and we are at the refinery, get out of the way
 			// of the refinery entrance.
 			if (LastSearchFailed)
@@ -124,6 +130,7 @@ namespace OpenRA.Mods.Common.Activities
 					{
 						var unblockCell = deliveryLoc + harv.Info.UnblockCell;
 						var moveTo = mobile.NearestMoveableCell(unblockCell, 1, 5);
+						moveCooldownHelper.NotifyMoveQueued();
 						QueueChild(mobile.MoveTo(moveTo, 1));
 					}
 				}
@@ -132,6 +139,7 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			// If we get here, our search for resources was successful. Commence harvesting.
+			moveCooldownHelper.NotifyMoveQueued();
 			QueueChild(new HarvestResource(self, closestHarvestableCell.Value));
 			lastHarvestedCell = closestHarvestableCell.Value;
 			hasHarvestedCell = true;

--- a/OpenRA.Mods.Common/Activities/HarvestResource.cs
+++ b/OpenRA.Mods.Common/Activities/HarvestResource.cs
@@ -28,6 +28,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly IMove move;
 		readonly CPos targetCell;
 		readonly INotifyHarvestAction[] notifyHarvestActions;
+		readonly MoveCooldownHelper moveCooldownHelper;
 
 		public HarvestResource(Actor self, CPos targetCell)
 		{
@@ -40,6 +41,7 @@ namespace OpenRA.Mods.Common.Activities
 			resourceLayer = self.World.WorldActor.Trait<IResourceLayer>();
 			this.targetCell = targetCell;
 			notifyHarvestActions = self.TraitsImplementing<INotifyHarvestAction>().ToArray();
+			moveCooldownHelper = new MoveCooldownHelper(self.World, move as Mobile);
 		}
 
 		protected override void OnFirstRun(Actor self)
@@ -58,12 +60,17 @@ namespace OpenRA.Mods.Common.Activities
 			if (IsCanceling || harv.IsFull)
 				return true;
 
+			var result = moveCooldownHelper.Tick(false);
+			if (result != null)
+				return result.Value;
+
 			// Move towards the target cell
 			if (self.Location != targetCell)
 			{
 				foreach (var n in notifyHarvestActions)
 					n.MovingToResources(self, targetCell);
 
+				moveCooldownHelper.NotifyMoveQueued();
 				QueueChild(move.MoveTo(targetCell, 0));
 				return false;
 			}

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -42,6 +42,7 @@ namespace OpenRA.Mods.Common.Activities
 		List<CPos> path;
 		CPos? destination;
 		int startTicks;
+		bool hadNoPath;
 
 		// For dealing with blockers
 		bool hasWaited;
@@ -113,6 +114,7 @@ namespace OpenRA.Mods.Common.Activities
 		protected override void OnFirstRun(Actor self)
 		{
 			startTicks = self.World.WorldTick;
+			mobile.MoveResult = MoveResult.InProgress;
 
 			if (evaluateNearestMovableCell && destination.HasValue)
 			{
@@ -137,6 +139,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				path?.Clear();
 
+				mobile.MoveResult = MoveResult.CompleteCanceled;
 				return true;
 			}
 
@@ -144,19 +147,35 @@ namespace OpenRA.Mods.Common.Activities
 				return false;
 
 			if (destination == mobile.ToCell)
+			{
+				if (hadNoPath)
+					mobile.MoveResult = MoveResult.CompleteDestinationBlocked;
+				else
+					mobile.MoveResult = MoveResult.CompleteDestinationReached;
+
 				return true;
+			}
 
 			if (path.Count == 0)
 			{
+				hadNoPath = true;
 				destination = mobile.ToCell;
 				return false;
 			}
 
 			destination = path[0];
 
-			var nextCell = PopPath(self);
+			var (nextCell, shouldTryAgain) = PopPath(self);
 			if (nextCell == null)
+			{
+				if (!shouldTryAgain)
+				{
+					mobile.MoveResult = MoveResult.CompleteDestinationBlocked;
+					return true;
+				}
+
 				return false;
+			}
 
 			var firstFacing = self.World.Map.FacingBetween(mobile.FromCell, nextCell.Value.Cell, mobile.Facing);
 
@@ -200,10 +219,10 @@ namespace OpenRA.Mods.Common.Activities
 			return false;
 		}
 
-		(CPos Cell, SubCell SubCell)? PopPath(Actor self)
+		((CPos Cell, SubCell SubCell)? Next, bool ShouldTryAgain) PopPath(Actor self)
 		{
 			if (path.Count == 0)
-				return null;
+				return (null, false);
 
 			var nextCell = path[^1];
 
@@ -211,7 +230,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (!Util.AreAdjacentCells(mobile.ToCell, nextCell))
 			{
 				path = EvalPath(BlockedByActor.Immovable);
-				return null;
+				return (null, false);
 			}
 
 			var containsTemporaryBlocker = self.World.ContainsTemporaryBlocker(nextCell, self);
@@ -230,7 +249,7 @@ namespace OpenRA.Mods.Common.Activities
 					if (path.Count < 2)
 					{
 						path.Clear();
-						return null;
+						return (null, false);
 					}
 
 					// We can reasonably assume that the blocker is friendly and has a similar locomotor type.
@@ -244,7 +263,7 @@ namespace OpenRA.Mods.Common.Activities
 					if (!nudgeOrRepath)
 					{
 						path.Clear();
-						return null;
+						return (null, false);
 					}
 				}
 
@@ -252,7 +271,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (!mobile.CanEnterCell(nextCell, ignoreActor, BlockedByActor.Immovable))
 				{
 					path = EvalPath(BlockedByActor.Immovable);
-					return null;
+					return (null, false);
 				}
 
 				// See if they will move
@@ -263,17 +282,17 @@ namespace OpenRA.Mods.Common.Activities
 				{
 					waitTicksRemaining = mobile.Info.LocomotorInfo.WaitAverage;
 					hasWaited = true;
-					return null;
+					return (null, true);
 				}
 
 				if (--waitTicksRemaining >= 0)
-					return null;
+					return (null, true);
 
 				hasWaited = false;
 
 				// If the blocking actors are already leaving, wait a little longer instead of repathing
 				if (CellIsEvacuating(self, nextCell))
-					return null;
+					return (null, true);
 
 				// Calculate a new path
 				mobile.RemoveInfluence();
@@ -286,7 +305,7 @@ namespace OpenRA.Mods.Common.Activities
 					var newCell = path[^1];
 					path.RemoveAt(path.Count - 1);
 
-					return (newCell, mobile.GetAvailableSubCell(nextCell, mobile.FromSubCell, ignoreActor));
+					return ((newCell, mobile.GetAvailableSubCell(nextCell, mobile.FromSubCell, ignoreActor)), true);
 				}
 				else if (mobile.IsBlocking)
 				{
@@ -297,17 +316,17 @@ namespace OpenRA.Mods.Common.Activities
 						if ((nextCell - newCell).Value.LengthSquared > 2)
 							path.Add(mobile.ToCell);
 
-						return (newCell.Value, mobile.GetAvailableSubCell(newCell.Value, mobile.FromSubCell, ignoreActor));
+						return ((newCell.Value, mobile.GetAvailableSubCell(newCell.Value, mobile.FromSubCell, ignoreActor)), true);
 					}
 				}
 
-				return null;
+				return (null, false);
 			}
 
 			hasWaited = false;
 			path.RemoveAt(path.Count - 1);
 
-			return (nextCell, mobile.GetAvailableSubCell(nextCell, mobile.FromSubCell, ignoreActor));
+			return ((nextCell, mobile.GetAvailableSubCell(nextCell, mobile.FromSubCell, ignoreActor)), true);
 		}
 
 		protected override void OnLastRun(Actor self)
@@ -518,7 +537,7 @@ namespace OpenRA.Mods.Common.Activities
 				var fromSubcellOffset = map.Grid.OffsetOfSubCell(mobile.FromSubCell);
 				var toSubcellOffset = map.Grid.OffsetOfSubCell(mobile.ToSubCell);
 
-				var nextCell = parent.PopPath(self);
+				var (nextCell, _) = parent.PopPath(self);
 				if (nextCell != null)
 				{
 					if (!mobile.IsTraitPaused && !mobile.IsTraitDisabled && IsTurn(self, mobile, nextCell.Value.Cell, map))

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -99,9 +99,17 @@ namespace OpenRA.Mods.Common.Activities
 				QueueChild(Mobile.MoveTo(check => CalculatePathToTarget(self, check)));
 			}
 
-			// The last queued childactivity is guaranteed to be the inner move, so if the childactivity
-			// queue is empty it means we have reached our destination.
-			return TickChild(self);
+			// The last queued child activity is guaranteed to be the inner move,
+			// so if the child activity queue is empty it means the move completed.
+			if (!TickChild(self))
+				return false;
+
+			if (Mobile.MoveResult == MoveResult.CompleteDestinationReached)
+				return true;
+
+			// The move completed but we didn't reach the destination, so Cancel.
+			Cancel(self);
+			return true;
 		}
 
 		protected readonly List<CPos> SearchCells = new();

--- a/OpenRA.Mods.Common/Activities/Move/MoveCooldownHelper.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveCooldownHelper.cs
@@ -1,0 +1,100 @@
+﻿using OpenRA.Activities;
+using OpenRA.Mods.Common.Traits;
+
+namespace OpenRA.Mods.Common.Activities
+{
+	/// <summary>
+	/// Activities that queue move activities via <see cref="IMove"/> can use this helper to decide
+	/// when moves with blocked destinations should be retried and to apply a cooldown between repeated moves.
+	/// </summary>
+	public sealed class MoveCooldownHelper
+	{
+		/// <summary>
+		/// If a move failed because the destination was blocked, indicates if we should try again.
+		/// When true, <see cref="Tick"/> will return null when the destination is blocked, after the cooldown has been applied.
+		/// When false, <see cref="Tick"/> will return true to indicate the activity should give up and complete.
+		/// Defaults to false.
+		/// </summary>
+		public bool RetryIfDestinationBlocked { get; set; }
+
+		/// <summary>
+		/// The cooldown delay in ticks. After a move with a blocked destination, the cooldown will be started.
+		/// Whilst the cooldown is in effect, <see cref="Tick"/> will return false.
+		/// After the cooldown finishes, <see cref="Tick"/> will return null to allow activity logic to resume.
+		/// This cooldown is important to avoid lag spikes caused by pathfinding every tick because the destination is unreachable.
+		/// Defaults to (20, 31).
+		/// </summary>
+		public (int MinTicksInclusive, int MaxTicksExclusive) Cooldown { get; set; } = (20, 31);
+
+		readonly World world;
+		readonly Mobile mobile;
+		bool wasMoving;
+		bool hasRunCooldown;
+		int cooldownTicks;
+
+		public MoveCooldownHelper(World world, Mobile mobile)
+		{
+			this.world = world;
+			this.mobile = mobile;
+		}
+
+		/// <summary>
+		/// Call this when queuing a move activity.
+		/// </summary>
+		public void NotifyMoveQueued()
+		{
+			wasMoving = true;
+		}
+
+		/// <summary>
+		/// Call this method within the <see cref="Activity.Tick(Actor)"/> method. It will return a tick result.
+		/// </summary>
+		/// <param name="targetIsHiddenActor">If the target is a hidden actor, forces the result to be true, once the move has completed.</param>
+		/// <returns>A result that should be returned from the calling Tick method.
+		/// A non-null result should be returned immediately.
+		/// On a null result, the method should continue with it's usual logic and perform any desired moves.</returns>
+		public bool? Tick(bool targetIsHiddenActor)
+		{
+			// We haven't moved yet, or we did move and we've finished the cooldown, allow the caller to resume with their logic.
+			if (!wasMoving)
+				return null;
+
+			if (!hasRunCooldown)
+			{
+				// The target is hidden, don't continue tracking it.
+				if (targetIsHiddenActor)
+					return true;
+
+				// Movement was cancelled, or we reached our destination, return immediately to allow the caller to perform their next steps.
+				if (mobile == null || mobile.MoveResult == MoveResult.CompleteCanceled || mobile.MoveResult == MoveResult.CompleteDestinationReached)
+				{
+					wasMoving = false;
+					return null;
+				}
+
+				// We couldn't reach the destination, don't try and keep going after the actor.
+				if (!RetryIfDestinationBlocked && mobile.MoveResult == MoveResult.CompleteDestinationBlocked)
+					return true;
+
+				// To avoid excessive pathfinding when the destination is blocked, wait for the cooldown before trying to move again.
+				// Applying some jitter to the wait time helps avoid multiple units repathing on the same tick and creating a lag spike.
+				hasRunCooldown = true;
+				cooldownTicks = world.SharedRandom.Next(Cooldown.MinTicksInclusive, Cooldown.MaxTicksExclusive);
+				return false;
+			}
+			else
+			{
+				if (cooldownTicks > 0)
+					cooldownTicks--;
+
+				if (cooldownTicks <= 0)
+				{
+					hasRunCooldown = false;
+					wasMoving = false;
+				}
+
+				return false;
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -38,6 +38,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly bool wasRepaired;
 		readonly PlayerResources playerResources;
 		readonly int unitCost;
+		readonly MoveCooldownHelper moveCooldownHelper;
 
 		int remainingTicks;
 		bool played;
@@ -62,6 +63,7 @@ namespace OpenRA.Mods.Common.Activities
 			aircraft = move as Aircraft;
 			moveInfo = self.Info.TraitInfo<IMoveInfo>();
 			playerResources = self.Owner.PlayerActor.Trait<PlayerResources>();
+			moveCooldownHelper = new MoveCooldownHelper(self.World, move as Mobile) { RetryIfDestinationBlocked = true };
 
 			var valued = self.Info.TraitInfoOrDefault<ValuedInfo>();
 			unitCost = valued != null ? valued.Cost : 0;
@@ -129,12 +131,18 @@ namespace OpenRA.Mods.Common.Activities
 
 				return true;
 			}
-			else if (activeResupplyTypes != 0 && aircraft == null && !isCloseEnough)
+
+			var result = moveCooldownHelper.Tick(false);
+			if (result != null)
+				return result.Value;
+
+			if (activeResupplyTypes != 0 && aircraft == null && !isCloseEnough)
 			{
 				var targetCell = self.World.Map.CellContaining(host.Actor.CenterPosition);
 
 				// HACK: Repairable needs the actor to move to host center.
 				// TODO: Get rid of this or at least replace it with something less hacky.
+				moveCooldownHelper.NotifyMoveQueued();
 				if (repairableNear == null)
 					QueueChild(move.MoveOntoTarget(self, host, WVec.Zero, null, moveInfo.GetTargetLineColor()));
 				else
@@ -217,8 +225,11 @@ namespace OpenRA.Mods.Common.Activities
 				if (wasRepaired || isHostInvalid || (!stayOnResupplier && aircraft.Info.TakeOffOnResupply))
 				{
 					if (self.CurrentActivity.NextActivity == null && rp != null && rp.Path.Count > 0)
+					{
+						moveCooldownHelper.NotifyMoveQueued();
 						foreach (var cell in rp.Path)
 							QueueChild(new AttackMoveActivity(self, () => move.MoveTo(cell, 1, ignoreActor: repairableNear != null ? null : host.Actor, targetLineColor: aircraft.Info.TargetLineColor)));
+					}
 					else
 						QueueChild(new TakeOff(self));
 
@@ -235,6 +246,7 @@ namespace OpenRA.Mods.Common.Activities
 				// If there's no next activity, move to rallypoint if available, else just leave host if Repairable.
 				// Do nothing if RepairableNear (RepairableNear actors don't enter their host and will likely remain within closeEnough).
 				// If there's a next activity and we're not RepairableNear, first leave host if the next activity is not a Move.
+				moveCooldownHelper.NotifyMoveQueued();
 				if (self.CurrentActivity.NextActivity == null)
 				{
 					if (rp != null && rp.Path.Count > 0)

--- a/OpenRA.Mods.Common/Traits/DockHost.cs
+++ b/OpenRA.Mods.Common/Traits/DockHost.cs
@@ -132,7 +132,7 @@ namespace OpenRA.Mods.Common.Traits
 				OnDockCompleted(self, dockedClientActor, dockedClient);
 		}
 
-		public virtual bool QueueMoveActivity(Activity moveToDockActivity, Actor self, Actor clientActor, DockClientManager client)
+		public virtual bool QueueMoveActivity(Activity moveToDockActivity, Actor self, Actor clientActor, DockClientManager client, MoveCooldownHelper moveCooldownHelper)
 		{
 			var move = clientActor.Trait<IMove>();
 
@@ -141,6 +141,7 @@ namespace OpenRA.Mods.Common.Traits
 			if ((move is Mobile ? clientActor.Location != clientActor.World.Map.CellContaining(DockPosition) : clientActor.CenterPosition != DockPosition)
 				|| move is not IFacing facing || facing.Facing != DockAngle)
 			{
+				moveCooldownHelper.NotifyMoveQueued();
 				moveToDockActivity.QueueChild(move.MoveOntoTarget(clientActor, Target.FromActor(self), DockPosition - self.CenterPosition, DockAngle));
 				return true;
 			}

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -217,6 +217,7 @@ namespace OpenRA.Mods.Common.Traits
 		public bool IsBlocking { get; private set; }
 
 		public bool IsMovingBetweenCells => FromCell != ToCell;
+		public MoveResult MoveResult { get; set; }
 
 		#region IFacing
 

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Common.Terrain;
 using OpenRA.Mods.Common.Widgets;
@@ -262,7 +263,7 @@ namespace OpenRA.Mods.Common.Traits
 		void OnDockCompleted(Actor self, Actor clientActor, DockClientManager client);
 
 		/// <summary>If <paramref name="client"/> is not in range of <see cref="IDockHost"/> queues a child move activity and returns true. If in range returns false.</summary>
-		bool QueueMoveActivity(Activity moveToDockActivity, Actor self, Actor clientActor, DockClientManager client);
+		bool QueueMoveActivity(Activity moveToDockActivity, Actor self, Actor clientActor, DockClientManager client, MoveCooldownHelper moveCooldownHelper);
 
 		/// <summary>Should be called when in range of <see cref="IDockHost"/>.</summary>
 		void QueueDockActivity(Activity moveToDockActivity, Actor self, Actor clientActor, DockClientManager client);
@@ -726,6 +727,14 @@ namespace OpenRA.Mods.Common.Traits
 		Horizontal = 1,
 		Vertical = 2,
 		Turn = 4
+	}
+
+	public enum MoveResult
+	{
+		InProgress,
+		CompleteCanceled,
+		CompleteDestinationReached,
+		CompleteDestinationBlocked,
 	}
 
 	[RequireExplicitImplementation]


### PR DESCRIPTION
Several activities that queue child Move activities can get into a bad scenario where the actor is pathfinding and then gets stuck because the destination is unreachable. When the Move activity then completes, then parent activity sees it has yet to reach the destination and tries to move again. However, the actor is still blocked in the same spot as before and thus the movment finishes immediately. This causes a performance death spiral where the actor attempts to pathfind every tick. The pathfinding attempt can also be very expensive if it must exhaustively check the whole map to determine no route is possible.

In order to prevent blocked actors from running into this scenario, we introduce MoveCooldownHelper. In its default setup it allows the parent activity to bail out if the actor was blocked during a pathfinding attempt. This means the activity will be dropped rather than trying to move endlessly. It also has an option to allow retrying if pathfinding was blocked, but applies a cooldown to avoid the performance penalty. For activities such as Enter, this means the actors will still try and enter their target if it is unreachable, but will only attempt once a second now rather than every tick.

MoveAdjacentTo will now cancel if it fails to reach the destination. This fixes MoveOntoAndTurn to skip the Turn if the move didn't reach the intended destination. Any other derived classes will similarly benefit from skipping follow-up actions.

----

Based on and supersedes #20954. Fixes #20948. Fixes #21187. Fixes #21203. Fixes #21301.

#21164 means that the test case from #21187 no longer has easily visible impact. The repeated pathfinding attempts every tick are there, but they're very cheap now.

I recommend the test case from #21203 instead. This doesn't benefit from the changes in #21164 and the performance impact is very obvious.

Bleed:
Attack moving with units trapped in by a laser fence causes the game to slow to a crawl for a long time.

PR:
Attack moving with units trapped in by a laser fence causes an initial lag spike, but after that the performance is reasonable.