### PR TITLE
Fix subcells imported from Gen1 maps

### DIFF
--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportGen1MapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportGen1MapCommand.cs
@@ -443,7 +443,19 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 						actor.Add(new FacingInit(new WAngle(1024 - 4 * facing)));
 
 					if (section == "INFANTRY")
-						actor.Add(new SubCellInit((SubCell)Exts.ParseByteInvariant(parts[4])));
+					{
+						var subcell = 0;
+						switch (Exts.ParseByteInvariant(parts[4]))
+						{
+							case 1: subcell = 1; break;
+							case 2: subcell = 2; break;
+							case 3: subcell = 4; break;
+							case 4: subcell = 5; break;
+						}
+
+						if (subcell != 0)
+							actor.Add(new SubCellInit((SubCell)subcell));
+					}
 
 					if (!map.Rules.Actors.ContainsKey(parts[1].ToLowerInvariant()))
 						Console.WriteLine($"Ignoring unknown actor type: `{parts[1].ToLowerInvariant()}`");


### PR DESCRIPTION
This should correct a minor issue with RA/CnC imports of infantry. The subcell number is copied as-is, though ORA's assignment for them is different. https://github.com/OpenRA/OpenRA/blob/7b82d85b27427f8f3eefa614dc2795c06798fd82/OpenRA.Game/Map/MapGrid.cs#L119-L124

Below, each number is the original subcell index. The SW corner becomes the center and a possible duplicate, while the SE corner replaces the SW one.
```
 Gen 1      Bleed Import

1     2      1       2
   0            0+3
3     4      4       _
```

The Gen2 importer has its own adjustments. https://github.com/OpenRA/OpenRA/blob/4fca85f63d9f661b102f777f562089f368b80436/OpenRA.Mods.Cnc/UtilityCommands/ImportGen2MapCommand.cs#L286-L295

----

I had seen odd subcells on occasion but hadn't dug into it until I noticed Soviets in `allies-03` were less likely to be hidden by trees. That is something the enemy does fairly often in Tiberian Dawn as well.

![allies-03-ra96](https://github.com/OpenRA/OpenRA/assets/4985264/419a4475-c87f-42f8-a528-4d82099f7ae8)