### PR TITLE
Add polish to Intervention

### DIFF
--- a/mods/ra/maps/intervention/map.yaml
+++ b/mods/ra/maps/intervention/map.yaml
@@ -2130,10 +2130,10 @@ Actors:
 	GroundAttackWpt1: waypoint
 		Location: 29,64
 		Owner: Soviets
-	MCVInsertLocation: waypoint
+	MCVEntry: waypoint
 		Location: 71,143
 		Owner: Allies
-	MCVDeployLocation: waypoint
+	MCVRally: waypoint
 		Location: 73,133
 		Owner: Allies
 	AlliedAreaTopLeft: waypoint
@@ -2199,6 +2199,9 @@ Actors:
 	BaseRearAttackWpt3: waypoint
 		Location: 129,57
 		Owner: Soviets
+	BeachheadFlare: waypoint
+		Owner: Neutral
+		Location: 130,89
 
 Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, ra|rules/campaign-palettes.yaml, rules.yaml
 

--- a/mods/ra/maps/intervention/rules.yaml
+++ b/mods/ra/maps/intervention/rules.yaml
@@ -1,6 +1,6 @@
 Player:
 	PlayerResources:
-		DefaultCash: 2000
+		DefaultCash: 2400
 
 World:
 	LuaScript:
@@ -12,6 +12,7 @@ World:
 		Label: dropdown-difficulty.label
 		Description: dropdown-difficulty.description
 		Values:
+			easy: options-difficulty.easy
 			normal: options-difficulty.normal
 			hard: options-difficulty.hard
 		Default: normal
@@ -19,6 +20,15 @@ World:
 CAMERA:
 	RevealsShroud:
 		Range: 18c0
+
+CAMERA.hq:
+	Inherits: CAMERA
+	RevealsShroud:
+		Range: 8c0
+
+FLARE:
+	RevealsShroud:
+		Range: 5c0
 
 MISS:
 	Tooltip:
@@ -73,6 +83,7 @@ MIG.SCRIPTED:
 		Ammo: 2
 	Aircraft:
 		IdleBehavior: LeaveMapAtClosestEdge
+		NumberOfTicksToVerifyAvailableAirport: 25
 
 HELI:
 	Buildable:


### PR DESCRIPTION
I split a lot of the beachhead-triggered stuff into its own function, so the diff looks messier than it should be. Please pardon that.

----

- Added a persistent death check for the MCV so its loss can trigger defeat if the beachhead is not yet reached. This includes its sale as a Construction Yard or its death as an LST passenger.
  - Fixes #8294

- Added a basic Easy difficulty. On Easy, the Air Force HQ is revealed (but left in fog), and a flare marks the beachhead after a Naval Yard is built. This flare is coupled with a speech notification.

- Added speech notifications for completing/failing the beachhead objective.

- Changed the player's starting cash to 2400 (from 2000). This should trim 20-30 seconds from the slow start, because 2 ore hauls are needed for the Naval Yard and LST instead of 3.

- Added some bad luck insurance to the village objective. In the unlikely event that the last house is destroyed after the Air Force HQ is captured, the player is still granted victory.

- Changed Soviet aircraft to linger for less time before flying away for disposal (25 ticks from 150).

- Swapped a Map.ActorsInWorld check for an Allies.Actors() check because that seems more sane.