### PR TITLE
Adjust difficulty, add speeches to allies-06a

### DIFF
--- a/mods/ra/languages/lua/en.ftl
+++ b/mods/ra/languages/lua/en.ftl
@@ -65,6 +65,8 @@ destroy-soviet-buildings-units = Destroy all Soviet buildings and units in the a
 dont-capture-tech-centers = Do not capture the tech centers! Infiltrate one with a spy.
 infiltrate-tech-center-spy = Infiltrate one of the Soviet tech centers with a spy.
 capture-radar-shore = Capture the Radar Dome at the shore.
+build-naval-yard-redeploy-mcv = Secure a foothold and build a Naval Yard.
+    If needed, the MCV can be redeployed.
 
 # allies-07
 enemy-approaching = Enemy approaching.

--- a/mods/ra/maps/allies-06a/map.yaml
+++ b/mods/ra/maps/allies-06a/map.yaml
@@ -38,14 +38,14 @@ Players:
 		LockFaction: True
 		Faction: allies
 		LockColor: True
-		Color: E2E6F6
+		Color: ABB7E4
 		LockSpawn: True
 		LockTeam: True
 		Enemies: USSR
 
 Actors:
-	Actor176: camera
-		Owner: USSR
+	YakCamera: camera
+		Owner: Neutral
 		Location: 19,66
 	Actor0: sbag
 		Location: 22,81
@@ -242,10 +242,10 @@ Actors:
 	Actor74: kenn
 		Location: 77,101
 		Owner: USSR
-	Actor75: ftur
+	MiniBaseTower1: ftur
 		Location: 16,82
 		Owner: USSR
-	Actor76: ftur
+	MiniBaseTower2: ftur
 		Location: 19,82
 		Owner: USSR
 	Actor77: tsla
@@ -300,7 +300,7 @@ Actors:
 		Location: 23,82
 		Owner: USSR
 		Facing: 124
-		SubCell: 3
+		SubCell: 4
 	Actor111: e1
 		Location: 20,64
 		Owner: Greece
@@ -324,7 +324,7 @@ Actors:
 		Location: 13,85
 		Owner: USSR
 		Facing: 252
-		SubCell: 3
+		SubCell: 4
 	Actor117: dog
 		Location: 79,100
 		Owner: USSR
@@ -333,11 +333,11 @@ Actors:
 	Actor126: ss
 		Location: 59,102
 		Owner: USSR
-		Facing: 380
+		Facing: 384
 	Actor130: ss
 		Location: 74,113
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 	Actor177: mine
 		Owner: Neutral
 		Location: 56,94
@@ -350,7 +350,7 @@ Actors:
 	SovietConyard: fact
 		Location: 69,96
 		Owner: USSR
-	dome2: dome
+	EastRadarDome: dome
 		Location: 90,109
 		Owner: USSR
 	harv: harv
@@ -397,22 +397,22 @@ Actors:
 	SubPatrol3_3: waypoint
 		Location: 79,71
 		Owner: Neutral
-	Patrol3Sub1: ss
+	Patrol3Sub: ss
 		Location: 46,105
 		Owner: USSR
-		Facing: 252
-	Patrol3Sub2: ss
+		Facing: 256
+	ScoutSub: ss
 		Location: 77,71
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 	Patrol1Sub: ss
 		Location: 46,71
 		Owner: USSR
-		Facing: 508
+		Facing: 512
 	Patrol2Sub: ss
 		Location: 52,85
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 	SubPatrol1_1: waypoint
 		Location: 42,71
 		Owner: Neutral
@@ -502,7 +502,7 @@ Actors:
 	BadGuy1: e1
 		Location: 20,69
 		Owner: USSR
-		SubCell: 3
+		SubCell: 4
 	BadGuy2: e1
 		Location: 19,70
 		Owner: USSR
@@ -511,11 +511,11 @@ Actors:
 		Location: 24,67
 		Owner: USSR
 		Facing: 252
-		SubCell: 3
+		SubCell: 4
 	Patrol_1_e1: e1
 		Location: 71,84
 		Owner: USSR
-		SubCell: 4
+		SubCell: 5
 	Patrol_1_dog: dog
 		Location: 72,84
 		Owner: USSR
@@ -529,7 +529,7 @@ Actors:
 		Location: 89,93
 		Owner: USSR
 		Facing: 380
-		SubCell: 4
+		SubCell: 5
 	Patrol_3_e1: e1
 		Location: 92,108
 		Owner: USSR
@@ -537,16 +537,16 @@ Actors:
 	Patrol_3_dog: dog
 		Location: 92,108
 		Owner: USSR
-		SubCell: 3
+		SubCell: 4
 	Patrol_4_e1: e1
 		Location: 76,102
 		Owner: USSR
-		SubCell: 4
+		SubCell: 5
 	Patrol_4_dog: dog
 		Location: 77,102
 		Owner: USSR
 		Facing: 380
-		SubCell: 4
+		SubCell: 5
 	WaterUnloadEntry1: waypoint
 		Location: 22,114
 		Owner: Neutral
@@ -628,6 +628,201 @@ Actors:
 	WeaponMeetPoint: waypoint
 		Owner: Neutral
 		Location: 73,90
+	Actor179: fenc
+		Location: 14,81
+		Owner: USSR
+	Actor181: fenc
+		Location: 16,81
+		Owner: USSR
+	Actor182: fenc
+		Location: 19,81
+		Owner: USSR
+	Actor183: fenc
+		Location: 20,81
+		Owner: USSR
+	Actor184: fenc
+		Location: 21,81
+		Owner: USSR
+	Actor185: fenc
+		Location: 79,81
+		Owner: USSR
+	Actor186: fenc
+		Location: 80,81
+		Owner: USSR
+	Actor187: fenc
+		Location: 14,82
+		Owner: USSR
+	Actor188: fenc
+		Location: 67,82
+		Owner: USSR
+	Actor189: fenc
+		Location: 73,82
+		Owner: USSR
+	Actor190: fenc
+		Location: 14,83
+		Owner: USSR
+	Actor191: fenc
+		Location: 73,83
+		Owner: USSR
+	Actor192: fenc
+		Location: 22,84
+		Owner: USSR
+	Actor193: fenc
+		Location: 22,85
+		Owner: USSR
+	Actor194: fenc
+		Location: 73,85
+		Owner: USSR
+	Actor195: fenc
+		Location: 74,85
+		Owner: USSR
+	Actor196: fenc
+		Location: 75,85
+		Owner: USSR
+	Actor197: fenc
+		Location: 76,85
+		Owner: USSR
+	Actor198: fenc
+		Location: 73,86
+		Owner: USSR
+	Actor199: fenc
+		Location: 77,86
+		Owner: USSR
+	Actor200: fenc
+		Location: 14,87
+		Owner: USSR
+	Actor201: fenc
+		Location: 77,87
+		Owner: USSR
+	Actor202: fenc
+		Location: 14,88
+		Owner: USSR
+	Actor203: fenc
+		Location: 77,88
+		Owner: USSR
+	Actor204: fenc
+		Location: 80,89
+		Owner: USSR
+	Actor205: fenc
+		Location: 81,89
+		Owner: USSR
+	Actor206: fenc
+		Location: 82,89
+		Owner: USSR
+	Actor207: fenc
+		Location: 83,89
+		Owner: USSR
+	Actor208: fenc
+		Location: 84,89
+		Owner: USSR
+	Actor209: fenc
+		Location: 84,90
+		Owner: USSR
+	Actor210: fenc
+		Location: 84,91
+		Owner: USSR
+	Actor211: fenc
+		Location: 85,91
+		Owner: USSR
+	Actor212: fenc
+		Location: 62,95
+		Owner: USSR
+	Actor213: fenc
+		Location: 63,95
+		Owner: USSR
+	Actor214: fenc
+		Location: 64,95
+		Owner: USSR
+	Actor215: fenc
+		Location: 65,95
+		Owner: USSR
+	Actor216: fenc
+		Location: 66,95
+		Owner: USSR
+	Actor217: fenc
+		Location: 67,95
+		Owner: USSR
+	Actor218: fenc
+		Location: 62,96
+		Owner: USSR
+	Actor219: fenc
+		Location: 67,96
+		Owner: USSR
+	Actor220: fenc
+		Location: 68,96
+		Owner: USSR
+	Actor221: fenc
+		Location: 85,98
+		Owner: USSR
+	Actor222: fenc
+		Location: 86,98
+		Owner: USSR
+	Actor223: fenc
+		Location: 87,98
+		Owner: USSR
+	Actor224: fenc
+		Location: 88,98
+		Owner: USSR
+	Actor225: fenc
+		Location: 89,98
+		Owner: USSR
+	Actor226: fenc
+		Location: 90,98
+		Owner: USSR
+	Actor227: fenc
+		Location: 93,98
+		Owner: USSR
+	Actor228: fenc
+		Location: 84,99
+		Owner: USSR
+	Actor229: fenc
+		Location: 85,99
+		Owner: USSR
+	Actor230: fenc
+		Location: 77,100
+		Owner: USSR
+	Actor231: fenc
+		Location: 78,100
+		Owner: USSR
+	Actor232: fenc
+		Location: 80,100
+		Owner: USSR
+	Actor233: fenc
+		Location: 81,100
+		Owner: USSR
+	Actor234: fenc
+		Location: 78,101
+		Owner: USSR
+	Actor235: fenc
+		Location: 79,101
+		Owner: USSR
+	Actor236: fenc
+		Location: 80,101
+		Owner: USSR
+	Actor237: fenc
+		Location: 92,103
+		Owner: USSR
+	Actor238: fenc
+		Location: 93,103
+		Owner: USSR
+	Actor239: fenc
+		Location: 94,103
+		Owner: USSR
+	Actor240: fenc
+		Location: 95,103
+		Owner: USSR
+	Actor241: fenc
+		Location: 96,103
+		Owner: USSR
+	Actor242: fenc
+		Location: 96,104
+		Owner: USSR
+	Actor243: fenc
+		Location: 96,105
+		Owner: USSR
+	Actor244: fenc
+		Location: 15,81
+		Owner: USSR
 
 Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, ra|rules/campaign-palettes.yaml, rules.yaml
 

--- a/mods/ra/maps/allies-06a/rules.yaml
+++ b/mods/ra/maps/allies-06a/rules.yaml
@@ -1,6 +1,6 @@
 Player:
 	PlayerResources:
-		DefaultCash: 5000
+		DefaultCash: 8500
 
 World:
 	LuaScript:


### PR DESCRIPTION
These are some tweaks intended to smooth out this mission's Hard difficulty (without committing to bigger changes), fix some oddities, and add some polish.

If and when this is considered golden, it _should_ be simple to give B a similar treatment.

Fixes https://github.com/OpenRA/OpenRA/issues/20045

----

### LSTs

On bleed, the mission starts with a repeating timer for Soviet LSTs that unload one of two random teams. These are the teams on Hard:
  - x3 Heavy Tank, x2 V2 Rocket Launcher
  - X1 Heavy Tank, x2 V2 Rocket Launcher, x2 Flamethrower

One of these every minute seems harsh. The interval for LST teams on Hard is now 140s (from 60s; Normal is 180s).
  - Besides the obvious effect, this lets the smaller Soviet base use their tanks in attacks beforehand. On bleed, one of those attacks can coincide with the first LST team for extra pain.

<details><summary>The original timeline for LSTs is less straightforward if you are REALLY interested.</summary>

**Greece approaches the western Soviet base (`OP1-`/`OP1X` trigger):**

Reinforce the `lst1` team.
  - 4 Rifle Infantry are carried from Waypoint 22 to 43 (at the beach southeast of this base). They simply hunt.

----

**Greece touches the `LST3` zone at the northeastern gem island:**

Reinforce the `lst2` team:
  - 3 Heavy Tanks are carried from Waypoint 22 to 43.
  - They attack defenses, vehicles, and any other targets.

----

**Greece kills/captures the Barracks or nearby Radar Dome:**

`LST4`: After ~03:06, reinforce the `lst4` team.
  - 1 Heavy Tank, 3 Grenadiers are carried from Waypoint 22 to 43.
  - They attack vehicles, defenses, and power plants before hunting.

`LST5`: After ~07:33, reinforce the `lst5` team.
  - 1 V2 Rocket Launcher, 4 Flamethrowers are carried from Waypoint22 to 68 (by the beach in the southwest corner).
  - They will attack harvesters, defenses, & factories before a hunt.

----

**Greece kills one of USSR's starting Submarines:**

A Submarine will investigate when Greece builds a Naval Yard, and the teams below will be scheduled after its death. (`SEA7`, `SEA3`) If USSR later loses their Sub Pen, the teams can be skipped. (`SEA6`)

`SEA4`: After ~01:36, reinforce the `sea1` team.
  - 2 Heavy Tanks and 1 V2 Rocket Launcher are carried from Waypoint 34 to 43.
  - They attack vehicles, defenses, and structures.

`LST2`: After ~05:24, reinforce the `lst3` team.
  - 1 Heavy Tank, 2 V2 Rocket Launchers, and 2 Flamethrowers are carried from Waypoint 22 to 68.
  - They attack defenses or structures before hunting.

`LST1`: After ~09:12, reinforce the `lst2` team.
 - 3 Heavy Tanks are carried from Waypoint 22 to 43.
 - They attack defenses, vehicles, and any other targets.

`LST7`: After ~18:36, reinforce the `lst4` and `lst5` teams.
 - `lst4`: 1 Heavy Tank, 3 Grenadiers are carried from Waypoint 22 to 43.
   - They attack vehicles, defenses, and power plants before hunting.

 - `lst5`: 1 V2 Rocket Launcher and 4 Flamethrowers are carried from Waypoint 22 to 68.
   - They attack harvesters, defenses, and factories before hunting.

`LST8`: After ~25:00, reinforce the `lst5` team again.
</details>

----

### Yaks

Limited USSR production to one Yak for their one Airfield. (That part of the script seemed to be from `allies-04` where two are expected.)

Changed Yak production so the first has different delays for each difficulty. On Hard, this is 90s (from 70s). On Normal, this is 120s (from 70s) so production roughly matches the RA '96 timer (reinforcement at ~150s).

<details><summary>Like the LST one, the original aircraft timeline is a rabbit hole.</summary>

**Greece acquires a Construction Yard:**

Trigger `AIR9`: Every 50 moments, reinforce team `air2`.
  - 1 Yak targets power plants, structures, vehicles, and infantry.

`AIR4`: The `air2` team has died.
  - Set global {8} and prompt `AIR7`.

`AIR7`: Every 40 moments while global {8} is set, reinforce team `air3`.
  - 2 Yaks target power plants, structures, vehicles, and infantry.
  - Remove the previous `AIR9` trigger.
  - These planes start near the northwest corner at waypoint 52. This is the only team with a particular spawn point, and the last air team reinforced until the eastern base is attacked.

`AIR5`: The `air3` team has died.
  - Clear global {8} and call `DES1` ( -> `DES2` -> `DES3`).
    - Remove the previous `AIR9`, `AIR4`, and `AIR7` triggers.

----

**Greece kills a USSR starting submarine:**

`LST6`: After 265 moments, reinforce team `air5`.
  - A Badger drops 3 Rifle Infantry and 2 Flamethrowers at Waypoint 73.

`LST8`: After 500 moments, reinforce team `air6`.
  - A Badger drops 2 Rifle Infantry and 3 Grenadiers at Waypoint 72.

----

**Greece attacks certain units/structures at the eastern base:**

`REAC`: Set global {4}. The rest of the events below can be skipped if the Airfield is destroyed (`AIR2`).

`AIR1`: Every 40 moments while global {4} is set, reinforce team `air1`.
  - 3 Yak planes target factories, structures, vehicles, and infantry.

`AIR8`: The `air1` team has died.
  - Set global {11} and prompt `AIR0`.
  - Clear the previous `AIR1` trigger.

`AIR0`: Every 52 moments while global {11} is set, reinforce team `air4`.
  - 2 Yak planes target vehicles and infantry.

`AI10`: The `air4` team has died.
  - Clear global {11} and call `DES4`.

`AIR2`/`AI10`/`DES4`: Clear globals {4} and {11}, along with the `AIR1` trigger.
</details>

----

### Navy Stuff

Changed the Soviet navy production so a Submarine cluster is less likely to force Greece out of the water and maintain that with more production.
  - Per the original, Submarines won't start production until a starting Submarine is killed. One of the starters will scout the coast near the Soviet Barracks after a Naval Yard is built.
  - Production is delayed whenever Greece is later found to lack any Naval Yard.

Added an objective for building a Naval Yard, with text that mentions redeployable MCVs. That knowledge has unusual importance for this map, where the build area in common start locations may not reach the water.
  - I'm [partly going off remarks](https://forum.openra.net/viewtopic.php?f=82&t=21566) from **rossboylan** and **Carrillo**.
  - The infiltration objective's appearance is normally delayed until this one is completed.

----

Added a 30s grace period before Soviet infantry production, reinforcement timers, and so on are started. This grace period ends when Greece deploys (or loses) their MCV, but it should help with early pressure.
  - There is a 10s delay to these events on bleed, though this is about the time it takes for the MCV to reinforce and move to its rally point (8.2s).
  - This is closer to original behavior anyway, where USSR starts creating infantry teams at ~30s or once Greece has "built" a Construction Yard (which itself triggers more things).

Changed Greece's starting cash to its original 8500 (from 5000).

Changed Greece's death check so they can be defeated if they're somehow wiped out after the spy objective is done.

Added an alert bleep to the tech capture message.

Added "objective met" notifications, with some delays so speech should not overlap.

Added back the Soviet bases' wire fencing. (See https://github.com/OpenRA/OpenRA/pull/21373)

Added another Soviet infantry team based on `inf2`: 2 Grenadiers, 1 Rifle Infantry.

Changed dog patrols to stop waiting on dead team members.

Changed Soviet paratrooopers to hunt when idle.

Fixed some infantry subcells. (See https://github.com/OpenRA/OpenRA/pull/21397)