### PR TITLE
Fix Scroll bug when chat is opened (the same issue was for menu)

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -195,6 +195,9 @@ namespace OpenRA.Mods.Common.Widgets
 				if (Game.Settings.Game.ViewportEdgeScroll && Game.Renderer.WindowHasInputFocus)
 					edgeDirections = CheckForDirections();
 
+				if (Ui.KeyboardFocusWidget != null)
+					keyboardDirections = ScrollDirection.None;
+
 				if (keyboardDirections != ScrollDirection.None || edgeDirections != ScrollDirection.None)
 				{
 					var scroll = float2.Zero;


### PR DESCRIPTION
Fixes #21344 

Added conditions to halt scrolling when chat is opened 

The same issue was for opening and closing the menu:
while holding any arrow key, open the menu, release the key, close the menu
the camera keeps moving

Best regards,
Raushan Sakhibzadin