### PR TITLE
Use HTTPS for screenshot URLs in AppStream metainfo

### DIFF
--- a/packaging/linux/openra.metainfo.xml.in
+++ b/packaging/linux/openra.metainfo.xml.in
@@ -27,19 +27,19 @@
   <launchable type="desktop-id">openra-{MODID}.desktop</launchable>
   <screenshots>
     <screenshot{SCREENSHOT_RA}>
-      <image>http://www.openra.net/images/appdata/ingame-ra.png</image>
+      <image>https://www.openra.net/images/appdata/ingame-ra.png</image>
       <caption>Red Alert mod</caption>
     </screenshot>
     <screenshot{SCREENSHOT_CNC}>
-      <image>http://www.openra.net/images/appdata/ingame-cnc.png</image>
+      <image>https://www.openra.net/images/appdata/ingame-cnc.png</image>
       <caption>Tiberian Dawn mod</caption>
     </screenshot>
     <screenshot{SCREENSHOT_D2K}>
-      <image>http://www.openra.net/images/appdata/ingame-d2k.png</image>
+      <image>https://www.openra.net/images/appdata/ingame-d2k.png</image>
       <caption>Dune 2000 Mod</caption>
     </screenshot>
     <screenshot>
-      <image>http://www.openra.net/images/appdata/multiplayer.png</image>
+      <image>https://www.openra.net/images/appdata/multiplayer.png</image>
       <caption>Multiplayer lobby in the Tiberian Dawn mod</caption>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
Resolves some non-controversial pickups by `appstreamcli validate`:

```
I: openra-ra.desktop:30: screenshot-media-url-not-secure
     http://www.openra.net/images/appdata/ingame-ra.png
I: openra-ra.desktop:34: screenshot-media-url-not-secure
     http://www.openra.net/images/appdata/ingame-cnc.png
I: openra-ra.desktop:38: screenshot-media-url-not-secure
     http://www.openra.net/images/appdata/ingame-d2k.png
I: openra-ra.desktop:42: screenshot-media-url-not-secure
     http://www.openra.net/images/appdata/multiplayer.png
```