### PR TITLE
Update links to HTTPS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-; Top-most http://editorconfig.org/ file
+; Top-most https://editorconfig.org/ file
 root = true
 charset=utf-8
 

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+patreon: orahosting

--- a/AUTHORS
+++ b/AUTHORS
@@ -216,7 +216,7 @@ Using Linguini by the Space Station 14 team
 licensed under Apache and MIT terms.
 
 This site or product includes IP2Location LITE data
-available from http://www.ip2location.com.
+available from https://www.ip2location.com.
 
 Finally, special thanks goes to the original teams
 at Westwood Studios and EA for creating the classic

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -70,7 +70,7 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+available at [https://contributor-covenant.org/version/1/4][version]
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Help us keep OpenRA open and inclusive. Please read and follow our [Code of Cond
 
 * [Coding standard](https://github.com/OpenRA/OpenRA/wiki/Coding-Standard)
 * [Branches and Releases](https://github.com/OpenRA/OpenRA/wiki/Branches-and-Releases)
-* [Licensing](http://www.gnu.org/licenses/quick-guide-gplv3.html)
+* [Licensing](https://www.gnu.org/licenses/quick-guide-gplv3.html)
 
 Please `git rebase` to the latest revision of the bleed branch.
 

--- a/COPYING
+++ b/COPYING
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -645,7 +645,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -664,11 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@ Windows
 =======
 
 Compiling OpenRA requires the following dependencies:
-* [Windows PowerShell >= 4.0](http://microsoft.com/powershell) (included by default in recent Windows 10 versions)
+* [Windows PowerShell >= 4.0](https://microsoft.com/powershell) (included by default in recent Windows 10 versions)
 * [.NET 6 SDK](https://dotnet.microsoft.com/download/dotnet/6.0) (or via Visual Studio)
 
 To compile OpenRA, open the `OpenRA.sln` solution in the main folder, build it from the command-line with `dotnet` or use the Makefile analogue command `make all` scripted in PowerShell syntax.
@@ -25,7 +25,7 @@ To compile OpenRA, run `make` from the command line (or `make RUNTIME=mono` if u
 
 The default behaviour on the x86_64 architecture is to download several pre-compiled native libraries using the Nuget packaging manager. If you prefer to use system libraries, compile instead using `make TARGETPLATFORM=unix-generic`.
 
-If you choose to use system libraries, or your system is not x86_64, you will need to install [SDL 2](https://www.libsdl.org/download-2.0.php), [FreeType](http://gnuwin32.sourceforge.net/packages/freetype.htm), [OpenAL](https://openal-soft.org/), and [liblua 5.1](http://luabinaries.sourceforge.net/download.html) before compiling OpenRA.
+If you choose to use system libraries, or your system is not x86_64, you will need to install [SDL 2](https://www.libsdl.org/download-2.0.php), [FreeType](https://gnuwin32.sourceforge.net/packages/freetype.htm), [OpenAL](https://openal-soft.org/), and [liblua 5.1](https://luabinaries.sourceforge.net/download.html) before compiling OpenRA.
 
 These can be installed using your package manager on various distros:
 

--- a/OpenRA.Game/Primitives/Color.cs
+++ b/OpenRA.Game/Primitives/Color.cs
@@ -77,13 +77,13 @@ namespace OpenRA.Primitives
 
 		static float SrgbToLinear(float c)
 		{
-			// Standard gamma conversion equation: see e.g. http://entropymine.com/imageworsener/srgbformula/
+			// Standard gamma conversion equation: see e.g. https://entropymine.com/imageworsener/srgbformula/
 			return c <= 0.04045f ? c / 12.92f : (float)Math.Pow((c + 0.055f) / 1.055f, 2.4f);
 		}
 
 		static float LinearToSrgb(float c)
 		{
-			// Standard gamma conversion equation: see e.g. http://entropymine.com/imageworsener/srgbformula/
+			// Standard gamma conversion equation: see e.g. https://entropymine.com/imageworsener/srgbformula/
 			return c <= 0.0031308f ? c * 12.92f : 1.055f * (float)Math.Pow(c, 1.0f / 2.4f) - 0.055f;
 		}
 

--- a/OpenRA.Mods.Cnc/FileFormats/LZOCompression.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/LZOCompression.cs
@@ -11,7 +11,7 @@
 #region Additional Copyright & License Information
 /*
  * C# port of the crude minilzo source version 2.06 by Frank Razenberg
- * The full LZO package can be found at http://www.oberhumer.com/opensource/lzo/
+ * The full LZO package can be found at https://www.oberhumer.com/opensource/lzo/
  *
  * Beware, you should never want to see C# code like this. You were warned.
  * I simply ran the MSVC preprocessor on the original source, changed the datatypes
@@ -61,7 +61,7 @@
  *
  * Markus F.X.J. Oberhumer
  * <markus@oberhumer.com>
- * http://www.oberhumer.com/opensource/lzo/
+ * https://www.oberhumer.com/opensource/lzo/
  */
 #endregion
 

--- a/OpenRA.Mods.Cnc/Traits/World/VoxelNormalsPalette.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/VoxelNormalsPalette.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			wr.AddPalette(info.Name, new ImmutablePalette(data));
 		}
 
-		// Normal vector tables from http://www.sleipnirstuff.com/forum/viewtopic.php?t=8048
+		// Normal vector tables from https://web.archive.org/web/20041022134721/https://www.sleipnirstuff.com/forum/viewtopic.php?t=8048
 		static readonly float[] TSNormals =
 		{
 			0.671214f,  0.198492f, -0.714194f,

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 		/// <summary>
 		/// Default: Diagonal distance heuristic. More information:
-		/// http://theory.stanford.edu/~amitp/GameProgramming/Heuristics.html
+		/// https://theory.stanford.edu/~amitp/GameProgramming/Heuristics.html
 		/// Layers are ignored and incur no additional cost.
 		/// </summary>
 		/// <param name="locomotor">Locomotor used to provide terrain costs.</param>
@@ -137,7 +137,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 		/// <summary>
 		/// Default: Diagonal distance heuristic. More information:
-		/// http://theory.stanford.edu/~amitp/GameProgramming/Heuristics.html
+		/// https://theory.stanford.edu/~amitp/GameProgramming/Heuristics.html
 		/// Layers are ignored and incur no additional cost.
 		/// </summary>
 		/// <param name="locomotor">Locomotor used to provide terrain costs.</param>

--- a/OpenRA.Mods.Common/UtilityCommands/CreateManPage.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CreateManPage.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			Console.WriteLine(".SH FILES");
 			Console.WriteLine("Settings are stored in the ~/.openra user folder.");
 			Console.WriteLine(".SH BUGS");
-			Console.WriteLine("Known issues are tracked at http://bugs.openra.net");
+			Console.WriteLine("Known issues are tracked at https://bugs.openra.net");
 			Console.WriteLine(".SH COPYRIGHT");
 			Console.WriteLine("Copyright (c) The OpenRA Developers and Contributors");
 			Console.WriteLine("This manual is part of OpenRA, which is free software. It is GNU GPL v3 licensed. See COPYING for details.");

--- a/configure-system-libraries.sh
+++ b/configure-system-libraries.sh
@@ -3,7 +3,7 @@
 
 ####
 # This file must stay /bin/sh and POSIX compliant for macOS and BSD portability.
-# Copy-paste the entire script into http://shellcheck.net to check.
+# Copy-paste the entire script into https://shellcheck.net to check.
 ####
 
 set -o errexit || exit $?

--- a/fetch-geoip.sh
+++ b/fetch-geoip.sh
@@ -3,7 +3,7 @@
 
 ####
 # This file must stay /bin/sh and POSIX compliant for macOS and BSD portability.
-# Copy-paste the entire script into http://shellcheck.net to check.
+# Copy-paste the entire script into https://shellcheck.net to check.
 ####
 
 set -o errexit || exit $?

--- a/glsl/combined.frag
+++ b/glsl/combined.frag
@@ -51,7 +51,7 @@ vec3 hsv2rgb(vec3 c)
 
 float srgb2linear(float c)
 {
-	// Standard gamma conversion equation: see e.g. http://entropymine.com/imageworsener/srgbformula/
+	// Standard gamma conversion equation: see e.g. https://entropymine.com/imageworsener/srgbformula/
 	return c <= 0.04045f ? c / 12.92f : pow((c + 0.055f) / 1.055f, 2.4f);
 }
 
@@ -63,7 +63,7 @@ vec4 srgb2linear(vec4 c)
 
 float linear2srgb(float c)
 {
-	// Standard gamma conversion equation: see e.g. http://entropymine.com/imageworsener/srgbformula/
+	// Standard gamma conversion equation: see e.g. https://entropymine.com/imageworsener/srgbformula/
 	return c <= 0.0031308 ? c * 12.92f : 1.055f * pow(c, 1.0f / 2.4f) - 0.055f;
 }
 

--- a/launch-game.sh
+++ b/launch-game.sh
@@ -50,7 +50,7 @@ if [ "${rc}" != 0 ] && [ "${rc}" != 1 ]; then
 	if [ -d Support/Logs ]; then
 		LOGS="${PWD}/Support/Logs"
 	fi
-	ERROR_MESSAGE=$(printf "%s has encountered a fatal error.\nPlease refer to the crash logs and FAQ for more information.\n\nLog files are located in %s\nThe FAQ is available at http://wiki.openra.net/FAQ" "OpenRA" "${LOGS}")
+	ERROR_MESSAGE=$(printf "%s has encountered a fatal error.\nPlease refer to the crash logs and FAQ for more information.\n\nLog files are located in %s\nThe FAQ is available at https://wiki.openra.net/FAQ" "OpenRA" "${LOGS}")
 	if command -v zenity > /dev/null; then
 		zenity --no-wrap --error --title "OpenRA" --no-markup --text "${ERROR_MESSAGE}" 2> /dev/null || :
 	elif command -v kdialog > /dev/null; then

--- a/mods/cnc/installer/downloads.yaml
+++ b/mods/cnc/installer/downloads.yaml
@@ -1,7 +1,7 @@
 basefiles: Base Freeware Content
 	Type: ZipFile
 	SHA1: 72f337464963fa37d3688eb03e80eefd33669a3d
-	MirrorList: http://www.openra.net/packages/cnc-mirrors.txt
+	MirrorList: https://www.openra.net/packages/cnc-mirrors.txt
 	Extract:
 		^SupportDir|Content/cnc/conquer.mix: conquer.mix
 		^SupportDir|Content/cnc/desert.mix: desert.mix

--- a/mods/d2k/installer/downloads.yaml
+++ b/mods/d2k/installer/downloads.yaml
@@ -1,7 +1,7 @@
 quickinstall: Quick Install Package
 	Type: ZipFile
 	SHA1: 7bcaa55408a5e6995b43a0d02862c4e8574cf861
-	MirrorList: http://www.openra.net/packages/d2k-quickinstall-v3-mirrors.txt
+	MirrorList: https://www.openra.net/packages/d2k-quickinstall-v3-mirrors.txt
 	Extract:
 		^SupportDir|Content/d2k/v3/BLOXBASE.R16: v3/BLOXBASE.R16
 		^SupportDir|Content/d2k/v3/BLOXBAT.R16: v3/BLOXBAT.R16
@@ -269,7 +269,7 @@ quickinstall: Quick Install Package
 basefiles: Base Content
 	Type: ZipFile
 	SHA1: 399b9a6d5293298204d15ebe61145db155ed963c
-	MirrorList: http://www.openra.net/packages/d2k-base-v3-mirrors.txt
+	MirrorList: https://www.openra.net/packages/d2k-base-v3-mirrors.txt
 	Extract:
 		^SupportDir|Content/d2k/v3/BLOXBASE.R16: v3/BLOXBASE.R16
 		^SupportDir|Content/d2k/v3/BLOXBAT.R16: v3/BLOXBAT.R16
@@ -535,7 +535,7 @@ basefiles: Base Content
 patch106: Patch 1.06 Content
 	Type: ZipFile
 	SHA1: 86f3e468bdea6775d5744737ba5f375e5296e47c
-	MirrorList: http://www.openra.net/packages/d2k-patch106-v3-mirrors.txt
+	MirrorList: https://www.openra.net/packages/d2k-patch106-v3-mirrors.txt
 	Extract:
 		^SupportDir|Content/d2k/v3/BLOXXMAS.R8: v3/BLOXXMAS.R8
 		^SupportDir|Content/d2k/v3/DATA.R16: v3/DATA.R16

--- a/mods/ra/installer/downloads.yaml
+++ b/mods/ra/installer/downloads.yaml
@@ -1,7 +1,7 @@
 quickinstall: Quick Install Package
 	Type: ZipFile
 	SHA1: 44241f68e69db9511db82cf83c174737ccda300b
-	MirrorList: http://www.openra.net/packages/ra-quickinstall-mirrors.txt
+	MirrorList: https://www.openra.net/packages/ra-quickinstall-mirrors.txt
 	Extract:
 		^SupportDir|Content/ra/v2/allies.mix: allies.mix
 		^SupportDir|Content/ra/v2/conquer.mix: conquer.mix
@@ -46,7 +46,7 @@ quickinstall: Quick Install Package
 basefiles: Base Freeware Content
 	Type: ZipFile
 	SHA1: aa022b208a3b45b4a45c00fdae22ccf3c6de3e5c
-	MirrorList: http://www.openra.net/packages/ra-base-mirrors.txt
+	MirrorList: https://www.openra.net/packages/ra-base-mirrors.txt
 	Extract:
 		^SupportDir|Content/ra/v2/allies.mix: allies.mix
 		^SupportDir|Content/ra/v2/conquer.mix: conquer.mix
@@ -63,7 +63,7 @@ basefiles: Base Freeware Content
 aftermath: Aftermath Expansion Files
 	Type: ZipFile
 	SHA1: d511d4363b485e11c63eecf96d4365d42ec4ef5e
-	MirrorList: http://www.openra.net/packages/ra-aftermath-mirrors.txt
+	MirrorList: https://www.openra.net/packages/ra-aftermath-mirrors.txt
 	Extract:
 		^SupportDir|Content/ra/v2/expand/chrotnk1.aud: expand/chrotnk1.aud
 		^SupportDir|Content/ra/v2/expand/expand2.mix: expand/expand2.mix
@@ -96,6 +96,6 @@ aftermath: Aftermath Expansion Files
 cncdesert: C&C Desert Tileset
 	Type: ZipFile
 	SHA1: 039849f16e39e4722e8c838a393c8a0d6529fd59
-	MirrorList: http://www.openra.net/packages/ra-cncdesert-mirrors.txt
+	MirrorList: https://www.openra.net/packages/ra-cncdesert-mirrors.txt
 	Extract:
 		^SupportDir|Content/ra/v2/cnc/desert.mix: cnc/desert.mix

--- a/mods/ts/installer/downloads.yaml
+++ b/mods/ts/installer/downloads.yaml
@@ -1,7 +1,7 @@
 basefiles: Base Freeware Content
 	Type: ZipFile
 	SHA1: 824df30de0004ad13fac29cf16450caafee9fb1b
-	MirrorList: http://www.openra.net/packages/ts-mirrors.txt
+	MirrorList: https://www.openra.net/packages/ts-mirrors.txt
 	Extract:
 		^SupportDir|Content/ts/cache.mix: cache.mix
 		^SupportDir|Content/ts/conquer.mix: conquer.mix
@@ -21,7 +21,7 @@ basefiles: Base Freeware Content
 fstorm: Expansion Freeware Content
 	Type: ZipFile
 	SHA1: 8bff90870a9348b72cbe91314aec7d3a50311aa9
-	MirrorList: http://www.openra.net/packages/fs-mirrors.txt
+	MirrorList: https://www.openra.net/packages/fs-mirrors.txt
 	Extract:
 		^SupportDir|Content/ts/firestorm/c_kodiak.shp: firestorm/c_kodiak.shp
 		^SupportDir|Content/ts/firestorm/coremk.shp: firestorm/coremk.shp
@@ -205,7 +205,7 @@ fstorm: Expansion Freeware Content
 quickinstall: Quick Install Package
 	Type: ZipFile
 	SHA1: d9339e7b6ecf624ac6ca91d25c58b88fb88a49d2
-	MirrorList: http://www.openra.net/packages/ts-quickinstall-mirrors.txt
+	MirrorList: https://www.openra.net/packages/ts-quickinstall-mirrors.txt
 	Extract:
 		^SupportDir|Content/ts/cache.mix: cache.mix
 		^SupportDir|Content/ts/conquer.mix: conquer.mix

--- a/packaging/functions.sh
+++ b/packaging/functions.sh
@@ -3,7 +3,7 @@
 
 ####
 # This file must stay /bin/sh and POSIX compliant for macOS and BSD portability.
-# Copy-paste the entire script into http://shellcheck.net to check.
+# Copy-paste the entire script into https://shellcheck.net to check.
 ####
 
 # Compile and publish the core engine and specified mod assemblies to the target directory

--- a/packaging/linux/openra-mimeinfo.xml.discord.in
+++ b/packaging/linux/openra-mimeinfo.xml.discord.in
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+<mime-info xmlns='https://www.freedesktop.org/standards/shared-mime-info'>
   <mime-type type="x-scheme-handler/openra-{MODID}-{TAG}">
     <icon name="openra-{MODID}" />
     <generic-icon name="applications-games"/>

--- a/packaging/linux/openra-mimeinfo.xml.in
+++ b/packaging/linux/openra-mimeinfo.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+<mime-info xmlns='https://www.freedesktop.org/standards/shared-mime-info'>
   <mime-type type="x-scheme-handler/openra-{MODID}-{TAG}">
     <icon name="openra-{MODID}" />
     <generic-icon name="applications-games"/>

--- a/packaging/linux/openra.appimage.in
+++ b/packaging/linux/openra.appimage.in
@@ -58,7 +58,7 @@ if [ "${rc}" != 0 ] && [ "${rc}" != 1 ]; then
 	if [ -d Support/Logs ]; then
 		LOGS="${PWD}/Support/Logs"
 	fi
-	ERROR_MESSAGE=$(printf "%s has encountered a fatal error.\nPlease refer to the crash logs and FAQ for more information.\n\nLog files are located in %s\nThe FAQ is available at http://wiki.openra.net/FAQ" "{MODNAME}" "${LOGS}")
+	ERROR_MESSAGE=$(printf "%s has encountered a fatal error.\nPlease refer to the crash logs and FAQ for more information.\n\nLog files are located in %s\nThe FAQ is available at https://wiki.openra.net/FAQ" "{MODNAME}" "${LOGS}")
 	if command -v zenity > /dev/null; then
 		zenity --no-wrap --error --title "{MODNAME}" --no-markup --text "${ERROR_MESSAGE}" 2> /dev/null || :
 	elif command -v kdialog > /dev/null; then

--- a/packaging/linux/openra.in
+++ b/packaging/linux/openra.in
@@ -29,7 +29,7 @@ if [ "${rc}" != 0 ] && [ "${rc}" != 1 ]; then
 	if [ -d Support/Logs ]; then
 		LOGS="${PWD}/Support/Logs"
 	fi
-	ERROR_MESSAGE=$(printf "%s has encountered a fatal error.\nPlease refer to the crash logs and FAQ for more information.\n\nLog files are located in %s\nThe FAQ is available at http://wiki.openra.net/FAQ" "{MODNAME}" "${LOGS}")
+	ERROR_MESSAGE=$(printf "%s has encountered a fatal error.\nPlease refer to the crash logs and FAQ for more information.\n\nLog files are located in %s\nThe FAQ is available at https://wiki.openra.net/FAQ" "{MODNAME}" "${LOGS}")
 	if command -v zenity > /dev/null; then
 		zenity --no-wrap --error --title "{MODNAME}" --no-markup --text "${ERROR_MESSAGE}" 2> /dev/null || :
 	elif command -v kdialog > /dev/null; then

--- a/packaging/linux/openra.metainfo.xml.in
+++ b/packaging/linux/openra.metainfo.xml.in
@@ -45,6 +45,7 @@
   </screenshots>
   <url type="homepage">https://www.openra.net</url>
   <url type="bugtracker">https://github.com/OpenRA/OpenRA/issues</url>
+  <url type="donation">https://www.patreon.com/orahosting</url>
   <update_contact>paul_at_chote.net</update_contact>
   <developer_name>The OpenRA Developers</developer_name>
   <developer id="net.openra">

--- a/packaging/macos/Info.plist.in
+++ b/packaging/macos/Info.plist.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/packaging/macos/buildpackage.sh
+++ b/packaging/macos/buildpackage.sh
@@ -121,7 +121,7 @@ mkdir -p "${TEMPLATE_DIR}/Contents/MacOS/arm64"
 echo "APPL????" > "${TEMPLATE_DIR}/Contents/PkgInfo"
 cp Info.plist.in "${TEMPLATE_DIR}/Contents/Info.plist"
 modify_plist "{DEV_VERSION}" "${TAG}" "${TEMPLATE_DIR}/Contents/Info.plist"
-modify_plist "{FAQ_URL}" "http://wiki.openra.net/FAQ" "${TEMPLATE_DIR}/Contents/Info.plist"
+modify_plist "{FAQ_URL}" "https://wiki.openra.net/FAQ" "${TEMPLATE_DIR}/Contents/Info.plist"
 modify_plist "{MINIMUM_SYSTEM_VERSION}" "10.11" "${TEMPLATE_DIR}/Contents/Info.plist"
 
 # Compile universal (x86_64 + arm64) arch-specific apphosts

--- a/packaging/macos/entitlements.plist
+++ b/packaging/macos/entitlements.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 <key>com.apple.security.cs.allow-jit</key>

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -12,7 +12,7 @@
 ;  GNU General Public License for more details.
 ;
 ;  You should have received a copy of the GNU General Public License
-;  along with OpenRA.  If not, see <http://www.gnu.org/licenses/>.
+;  along with OpenRA.  If not, see <https://www.gnu.org/licenses/>.
 
 !include "MUI2.nsh"
 !include "FileFunc.nsh"
@@ -193,7 +193,7 @@ Section "-Uninstaller"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenRA${SUFFIX}" "InstallLocation" "$INSTDIR"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenRA${SUFFIX}" "DisplayIcon" "$INSTDIR\ra.ico"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenRA${SUFFIX}" "Publisher" "OpenRA developers"
-	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenRA${SUFFIX}" "URLInfoAbout" "http://openra.net"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenRA${SUFFIX}" "URLInfoAbout" "https://openra.net"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenRA${SUFFIX}" "DisplayVersion" "${TAG}"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenRA${SUFFIX}" "NoModify" "1"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenRA${SUFFIX}" "NoRepair" "1"


### PR DESCRIPTION
I went through all links and checked checked wether they worked

only these require HTTP:
- http://lolengine.net/blog/2013/07/27/rgb-to-hsv-in-glsl
- http://lolengine.net/blog/2013/01/13/fast-rgb-to-hsv
- http://lua-users.org/wiki/SandBoxes

Does it make sense to keep links with json responses be HTTP? For speed?