### PR TITLE
Fix actorSpawnManager use only one spawnpoint for all actors.

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/ActorSpawnManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorSpawnManager.cs
@@ -114,6 +114,9 @@ namespace OpenRA.Mods.Common.Traits
 				// Always spawn at least one actor, plus
 				// however many needed to reach the minimum.
 				SpawnActor(self, spawnPoint);
+
+				// choose new random SpawnPoint for each actor
+				spawnPoint = GetRandomSpawnPoint(self.World, self.World.SharedRandom);
 			}
 			while (actorsPresent < info.Minimum);
 		}


### PR DESCRIPTION
You want multiple worms on multiple places, not one.
Testcase: oasis-conquest map