### PR TITLE
Damaged buildings VFX for D2k + WithDamageOverlay refactor

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
@@ -62,6 +62,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			if (Offset != WVec.Zero && !info.HasTraitInfo<BodyOrientationInfo>())
 				throw new YamlException("Specifying WithDamageOverlay.Offset requires the BodyOrientation trait on the actor.");
+			base.RulesetLoaded(rules, info);
 		}
 	}
 
@@ -89,6 +90,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			WVec AnimationOffset() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self.Orientation)));
 			rs.Add(new AnimationWithOffset(anim, info.Offset == WVec.Zero || body == null ? null : AnimationOffset, () => !isPlayingAnimation));
+			base.Created(self);
 		}
 
 		void INotifyDamage.Damaged(Actor self, AttackInfo e)

--- a/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		[Desc("How many times should " + nameof(LoopSequence),
 			" be played? A range can be provided to be randomly chosen from.")]
-		public readonly int[] LoopCount = [2];
+		public readonly int[] LoopCount = [1, 3];
 
 		[Desc("Initial delay before animation is enabled",
 			"Two values indicate a random delay range.")]

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20231010/AbstractDocking.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20231010/AbstractDocking.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 					harvesters[actorNode.Key] = harvesterNode.ChildrenMatching("DeliveryBuildings", includeRemovals: false)
 						.FirstOrDefault()?.NodeValue<HashSet<string>>() ?? [];
 
-				if (actorNode.ChildrenMatching("Refinery", includeRemovals: false).Any())
+				if (actorNode.HasChild("Refinery"))
 					refineries.Add(actorNode.Key.ToLowerInvariant());
 			}
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20231010/ReplaceCloakPalette.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20231010/ReplaceCloakPalette.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 		{
 			foreach (var actor in resolvedActors)
 				foreach (var cloak in actor.ChildrenMatching("Cloak"))
-					if (cloak.LastChildMatching("Palette", false) == null)
+					if (cloak.HasChild("Palette"))
 						actorsWithDefault.Add((actor.Key, cloak.Key));
 
 			yield break;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20250330/WithDamageOverlayPropertyRename.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20250330/WithDamageOverlayPropertyRename.cs
@@ -1,0 +1,64 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class WithDamageOverlayPropertyRename : UpdateRule, IBeforeUpdateActors
+	{
+		public override string Name => "Renamed `WithDamageOverlay`'s `IdleSequence` to `StartSequence`.";
+
+		public override string Description => "WithDamageOverlay's property `IdleSequence` was renamed to `StartSequence`"
+			+ " and functionality of WithDamageOverlay changed.";
+
+		readonly List<(string, string)> hasIdleDefault = [];
+		readonly List<(string, string)> hasEndDefault = [];
+
+		public IEnumerable<string> BeforeUpdateActors(ModData modData, List<MiniYamlNodeBuilder> resolvedActors)
+		{
+			foreach (var actorNode in resolvedActors)
+				foreach (var damage in actorNode.ChildrenMatching("WithDamageOverlay"))
+					if (damage.HasChild("IdleSequence") || damage.HasChild("StartSequence"))
+						hasIdleDefault.Add((actorNode.Key, damage.Key));
+
+			foreach (var actorNode in resolvedActors)
+				foreach (var damage in actorNode.ChildrenMatching("WithDamageOverlay"))
+					if (damage.HasChild("EndSequence"))
+						hasEndDefault.Add((actorNode.Key, damage.Key));
+
+			yield break;
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
+		{
+			foreach (var damage in actorNode.ChildrenMatching("WithDamageOverlay"))
+			{
+				var renamed = false;
+				foreach (var start in damage.ChildrenMatching("IdleSequence"))
+				{
+					start.RenameKey("StartSequence");
+					renamed = true;
+				}
+
+				if (!renamed && !hasIdleDefault.Contains((actorNode.Key, damage.Key)))
+					damage.AddNode("StartSequence", "idle");
+
+				damage.AddNode("LoopCount", 1);
+
+				if (!hasEndDefault.Contains((actorNode.Key, damage.Key)))
+					damage.AddNode("EndSequence", "end");
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -48,7 +48,8 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveNegativeSequenceLength(),
 			]),
 
-			new("release-20231010", "release-20250303", [
+			new("release-20231010", "release-20250303",
+			[
 				new RemoveValidRelationsFromCapturable(),
 				new ExtractResourceStorageFromHarvester(),
 				new ReplacePaletteModifiers(),
@@ -73,6 +74,9 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveBuildingInfoAllowPlacementOnResources(),
 				new EditorMarkerTileLabels(),
 				new RemoveBarracksTypesAndVehiclesTypesInBaseBuilderBotModule(),
+
+				// Execute these rules last to avoid premature yaml merge crashes.
+				new WithDamageOverlayPropertyRename(),
 			]),
 		];
 

--- a/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
@@ -471,6 +471,13 @@ namespace OpenRA.Mods.Common.UpdateRules
 			return node.Value.Nodes.Where(n => n.KeyMatches(match, ignoreSuffix, includeRemovals));
 		}
 
+		/// <summary>Returns true if node exists and is not being removed.</summary>
+		public static bool HasChild(
+			this MiniYamlNodeBuilder node, string match, bool ignoreSuffix = true)
+		{
+			return ChildrenMatching(node, match, ignoreSuffix).LastOrDefault()?.IsRemoval() == false;
+		}
+
 		/// <summary>Returns children whose keys contain 'match' (optionally in the suffix).</summary>
 		public static IEnumerable<MiniYamlNodeBuilder> ChildrenContaining(
 			this MiniYamlNodeBuilder node, string match, bool ignoreSuffix = true, bool includeRemovals = true)

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -252,6 +252,7 @@
 	HiddenUnderFog:
 	AttackMove:
 	WithDamageOverlay:
+		StartSequence: idle
 	WithFacingSpriteBody:
 	FireWarheadsOnDeath:
 		Weapon: UnitExplodeSmall
@@ -670,6 +671,7 @@
 		TextNotification: notification-unit-lost
 	AttackMove:
 	WithDamageOverlay:
+		StartSequence: idle
 	FireWarheadsOnDeath:
 		Weapon: UnitExplodeShip
 		EmptyWeapon: UnitExplodeShip
@@ -974,16 +976,28 @@
 		Image: burn-s
 		MinimumDamageState: Light
 		MaximumDamageState: Medium
+		StartSequence: start
+		LoopCount: 1, 7
+		InitialDelay: 0, 25
+		EndSequence: end
 	WithDamageOverlay@MediumBurn:
 		DamageTypes: Incendiary
 		Image: burn-m
 		MinimumDamageState: Medium
 		MaximumDamageState: Heavy
+		StartSequence: start
+		LoopCount: 1, 7
+		InitialDelay: 0, 25
+		EndSequence: end
 	WithDamageOverlay@LargeBurn:
 		DamageTypes: Incendiary
 		Image: burn-l
 		MinimumDamageState: Heavy
 		MaximumDamageState: Dead
+		StartSequence: start
+		LoopCount: 1, 7
+		InitialDelay: 0, 25
+		EndSequence: end
 	HiddenUnderShroud:
 	HitShape:
 	MapEditorData:

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -19,8 +19,8 @@ fire:
 burn-l:
 	Defaults:
 		Filename: burn-l.shp
-	idle:
-		Length: *
+	start:
+		Length: 16
 		ZOffset: 512
 	loop:
 		Start: 16
@@ -34,8 +34,8 @@ burn-l:
 burn-m:
 	Defaults:
 		Filename: burn-m.shp
-	idle:
-		Length: *
+	start:
+		Length: 16
 		ZOffset: 512
 	loop:
 		Start: 16
@@ -49,8 +49,8 @@ burn-m:
 burn-s:
 	Defaults:
 		Filename: burn-s.shp
-	idle:
-		Length: *
+	start:
+		Length: 12
 		ZOffset: 512
 	loop:
 		Start: 12
@@ -73,13 +73,13 @@ smoke_m:
 		Length: *
 		Offset: 2, -5
 		ZOffset: 512
+	start:
+		Length: 49
+		Offset: 2, -5
+		ZOffset: 512
 	loop:
 		Start: 49
 		Length: 42
-		Offset: 2, -5
-		ZOffset: 512
-	end:
-		Frames: 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0
 		Offset: 2, -5
 		ZOffset: 512
 

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -779,3 +779,118 @@
 		RequiresForceFire: true
 	MapEditorData:
 		Categories: Destroyed Tiles
+
+^DamagedBuildingEffects :
+	GrantConditionOnFaction@atreidesVFX:
+		Condition: atreidesVFX
+		Factions: atreides, fremen
+	GrantConditionOnFaction@harkonnenVFX:
+		Condition: harkonnenVFX
+		Factions: harkonnen, corrino
+	GrantConditionOnFaction@ordosVFX:
+		Condition: ordosVFX
+		Factions: ordos, mercenary, smuggler
+	GrantConditionOnDamageState@heavyDamage:
+		Condition: heavy-damage
+	FloatingSpriteEmitter@SmokeHugeAtreides:
+		RequiresCondition: heavy-damage && atreidesVFX
+		Image: smoke3
+		Lifetime: 15, 20
+		Speed: 5
+		Gravity: 60
+		SpawnFrequency: 2, 5
+		RandomFacing: true
+		RandomRate: 4
+		TurnRate: 3
+		Duration: 1300
+	FloatingSpriteEmitter@SmokeSmallAtreides:
+		RequiresCondition: heavy-damage && atreidesVFX
+		Image: smoke3
+		Lifetime: 15, 20
+		Speed: 3
+		Gravity: 50
+		SpawnFrequency: 4, 15
+		RandomFacing: true
+		RandomRate: 4
+		TurnRate: 3
+		Duration: 900
+	WithDamageOverlay@Fire1_Atreides:
+		RequiresCondition: atreidesVFX
+		Image: fire
+		LoopSequence: 1
+		LoopCount: 20, 30
+		InitialDelay: 0, 25
+	WithDamageOverlay@Fire2_atreides:
+		RequiresCondition: atreidesVFX
+		Image: fire
+		LoopSequence: 2
+		LoopCount: 20, 30
+		InitialDelay: 0, 25
+	FloatingSpriteEmitter@SmokeHugeHarkonnen:
+		RequiresCondition: heavy-damage && harkonnenVFX
+		Image: smoke3
+		Lifetime: 20,25
+		Speed: 5
+		Gravity: 60
+		SpawnFrequency: 3, 7
+		RandomFacing: true
+		RandomRate: 4
+		TurnRate: 3
+		Duration: 1300
+	FloatingSpriteEmitter@SmokeSmallHarkonnen:
+		RequiresCondition: heavy-damage && harkonnenVFX
+		Image: smoke3
+		Lifetime: 15, 20
+		Speed: 3
+		Gravity: 50
+		SpawnFrequency: 4, 15
+		RandomFacing: true
+		RandomRate: 4
+		TurnRate: 3
+		Duration: 900
+	WithDamageOverlay@Fire1Harkonnen:
+		RequiresCondition: harkonnenVFX
+		Image: fire
+		LoopSequence: 1
+		LoopCount: 10
+		InitialDelay: 0, 25
+	WithDamageOverlay@Fire2Harkonnen:
+		RequiresCondition: harkonnenVFX
+		Image: fire
+		LoopSequence: 2
+		LoopCount: 20, 30
+		InitialDelay: 0, 25
+	FloatingSpriteEmitter@SmokeHugeOrdos:
+		RequiresCondition: heavy-damage && ordosVFX
+		Image: smoke3
+		Lifetime: 20,25
+		Speed: 7
+		Gravity: 60
+		SpawnFrequency: 3, 8
+		RandomFacing: true
+		RandomRate: 4
+		TurnRate: 3
+		Duration: 1300
+	FloatingSpriteEmitter@SmokeSmallOrdos:
+		RequiresCondition: heavy-damage && ordosVFX
+		Image: smoke3
+		Lifetime: 15, 20
+		Speed: 3
+		Gravity: 50
+		SpawnFrequency: 4, 15
+		RandomFacing: true
+		RandomRate: 4
+		TurnRate: 3
+		Duration: 900
+	WithDamageOverlay@Fire1Ordos:
+		RequiresCondition: ordosVFX
+		Image: fire
+		LoopSequence: 1
+		LoopCount: 20, 30
+		InitialDelay: 0, 25
+	WithDamageOverlay@Fire2Ordos:
+		RequiresCondition: ordosVFX
+		Image: fire
+		LoopSequence: 2
+		LoopCount: 20, 30
+		InitialDelay: 0, 25

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -58,6 +58,7 @@ construction_yard:
 	Inherits: ^Building
 	Inherits@PRIMARY: ^PrimaryBuilding
 	Inherits@UPGRADEABLE: ^Upgradeable
+	Inherits@BUILDINGVFX: ^DamagedBuildingEffects
 	Buildable:
 		Description: actor-construction-yard.description
 	D2kBuilding:
@@ -115,9 +116,48 @@ construction_yard:
 		Prerequisites: upgrade.conyard
 	RevealOnDeath:
 		Radius: 5c768
+	FloatingSpriteEmitter@SmokeHugeAtreides:
+		Offset: 600, -500, 0
+		Gravity: 70
+	FloatingSpriteEmitter@SmokeSmallAtreides:
+		Offset: -300, -1200, 0
+		SpawnFrequency: 3, 13
+	FloatingSpriteEmitter@SmokeSmallConyard:
+		RequiresCondition: heavy-damage && atreidesVFX
+		Offset: -1024, -500, 0
+		SpawnFrequency: 5, 20
+		Image: smoke3
+		Lifetime: 15, 20
+		Speed: 3
+		Gravity: 50
+		Duration: 800
+	WithDamageOverlay@Fire1_Atreides:
+		Offset: 300, 500, 0
+	WithDamageOverlay@Fire2_atreides:
+		Offset: 2024, -350, 0
+	FloatingSpriteEmitter@SmokeHugeHarkonnen:
+		Offset: -100,300,0
+	FloatingSpriteEmitter@SmokeSmallHarkonnen:
+		Offset: 800,-200,0
+		Speed: 10
+	WithDamageOverlay@Fire1Harkonnen:
+		Offset: -700, -200,0
+	WithDamageOverlay@Fire2Harkonnen:
+		Offset: 500, 900,0
+	FloatingSpriteEmitter@SmokeHugeOrdos:
+		Offset: 500, -1000, 0
+		Gravity: 70
+	FloatingSpriteEmitter@SmokeSmallOrdos:
+		Offset: -300, -1200, 0
+		SpawnFrequency: 3, 13
+	WithDamageOverlay@Fire1Ordos:
+		Offset: 300, 500, 0
+	WithDamageOverlay@Fire2Ordos:
+		Offset: 1124, -350, 0
 
 wind_trap:
 	Inherits: ^Building
+	Inherits@BUILDINGVFX: ^DamagedBuildingEffects
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 120
@@ -165,11 +205,33 @@ wind_trap:
 	ProvidesPrerequisite@buildingname:
 	RevealOnDeath:
 		Radius: 3c768
+	FloatingSpriteEmitter@SmokeHugeAtreides:
+		Offset: 100, -1024, 0
+	FloatingSpriteEmitter@SmokeSmallAtreides:
+		Offset: -580, -400, 0
+	WithDamageOverlay@Fire1_Atreides:
+		Offset: 1124, 0, 0
+	FloatingSpriteEmitter@SmokeHugeHarkonnen:
+		Offset: 100, -1024, 0
+	FloatingSpriteEmitter@SmokeSmallHarkonnen:
+		Offset: -500, -400, 0
+	WithDamageOverlay@Fire1Harkonnen:
+		Offset: 300, -500, 0
+	FloatingSpriteEmitter@SmokeSmallOrdos:
+		Offset: -500, -900, 0
+		SpawnFrequency: 3, 13
+	WithDamageOverlay@Fire1Ordos:
+		Offset: 500, -700, 0
+	-WithDamageOverlay@Fire2Harkonnen:
+	-FloatingSpriteEmitter@SmokeHugeOrdos:
+	-WithDamageOverlay@Fire2Ordos:
+	-WithDamageOverlay@Fire2_atreides:
 
 barracks:
 	Inherits: ^Building
 	Inherits@PRIMARY: ^PrimaryBuilding
 	Inherits@UPGRADEABLE: ^Upgradeable
+	Inherits@BUILDINGVFX: ^DamagedBuildingEffects
 	Buildable:
 		Prerequisites: wind_trap
 		Queue: Building
@@ -241,9 +303,28 @@ barracks:
 		Prerequisites: upgrade.barracks
 	RevealOnDeath:
 		Radius: 3c768
+	WithDamageOverlay@Fire1_Atreides:
+		Offset: 500, 500, 0
+	FloatingSpriteEmitter@SmokeSmallAtreides:
+		Offset: 600, -500, 0
+	FloatingSpriteEmitter@SmokeSmallHarkonnen:
+		Offset: 0,0,0
+	WithDamageOverlay@Fire2Harkonnen:
+		Offset: 0,0,0
+	FloatingSpriteEmitter@SmokeHugeOrdos:
+		Offset: 300, -800, 0
+	WithDamageOverlay@Fire1Ordos:
+		Offset: 600, 300, 0
+	-WithDamageOverlay@Fire2_atreides:
+	-WithDamageOverlay@Fire1Harkonnen:
+	-WithDamageOverlay@Fire2Ordos:
+	-FloatingSpriteEmitter@SmokeHugeHarkonnen:
+	-FloatingSpriteEmitter@SmokeSmallOrdos:
+	-FloatingSpriteEmitter@SmokeHugeAtreides:
 
 refinery:
 	Inherits: ^Building
+	Inherits@BUILDINGVFX: ^DamagedBuildingEffects
 	Buildable:
 		Prerequisites: wind_trap
 		Queue: Building
@@ -316,6 +397,34 @@ refinery:
 		Margin: 1, 4
 		RequiresSelection: true
 		PipCount: 10
+	FloatingSpriteEmitter@SmokeSmallAtreides:
+		Offset: -900, 0, 0
+	FloatingSpriteEmitter@SmokeHugeAtreides:
+		Offset: 700,-612,0
+	WithDamageOverlay@Fire1_Atreides:
+		Offset: 950, 600,0
+	WithDamageOverlay@Fire2_atreides:
+		Offset: 700, -800, 0
+		LoopSequence: 4
+	FloatingSpriteEmitter@SmokeHugeHarkonnen:
+		Offset: 1100,-800,0
+	FloatingSpriteEmitter@SmokeSmallHarkonnen:
+		Offset: -1024, 0,0
+	WithDamageOverlay@Fire1Harkonnen:
+		Offset: 1200, 1000,0
+	WithDamageOverlay@Fire2Harkonnen:
+		Offset: 0, -1024, 0
+		LoopSequence: 4
+	FloatingSpriteEmitter@SmokeHugeOrdos:
+		Offset: -100, -1050, 0
+		Gravity: 70
+	FloatingSpriteEmitter@SmokeSmallOrdos:
+		Offset: -250, 250, 0
+		SpawnFrequency: 3, 13
+	WithDamageOverlay@Fire1Ordos:
+		Offset: 1200, -200, 0
+	WithDamageOverlay@Fire2Ordos:
+		Offset: 0, -200, 0
 
 silo:
 	Inherits: ^Building
@@ -373,11 +482,26 @@ silo:
 		Margin: 1, 4
 		RequiresSelection: true
 		PipCount: 5
+	GrantConditionOnDamageState@heavyDamage:
+		Condition: heavy-damage
+	FloatingSpriteEmitter@SmokeSmall:
+		Offset: 0, -300, 0
+		RequiresCondition: heavy-damage
+		Image: smoke3
+		Lifetime: 15, 20
+		Speed: 3
+		Gravity: 50
+		SpawnFrequency: 4, 15
+		RandomFacing: true
+		RandomRate: 4
+		TurnRate: 3
+		Duration: 1024
 
 light_factory:
 	Inherits: ^Building
 	Inherits@PRIMARY: ^PrimaryBuilding
 	Inherits@UPGRADEABLE: ^Upgradeable
+	Inherits@BUILDINGVFX: ^DamagedBuildingEffects
 	Buildable:
 		Prerequisites: refinery
 		Queue: Building
@@ -458,11 +582,39 @@ light_factory:
 		Amount: -100
 	GrantConditionOnPrerequisite@UPGRADEABLE:
 		Prerequisites: upgrade.light
+	FloatingSpriteEmitter@SmokeSmallAtreides:
+		Offset: -400, -500, 0
+	FloatingSpriteEmitter@SmokeHugeAtreides:
+		Offset: 400,-612,0
+	WithDamageOverlay@Fire1_Atreides:
+		Offset: 1024, 300,0
+	WithDamageOverlay@Fire2_atreides:
+		Offset: 1024, -500, 0
+	FloatingSpriteEmitter@SmokeHugeHarkonnen:
+		Offset: -100,300,0
+		Speed: 7
+	FloatingSpriteEmitter@SmokeSmallHarkonnen:
+		Offset: -900,-500,0
+		Speed: 10
+	WithDamageOverlay@Fire1Harkonnen:
+		Offset: -0,-950,0
+	WithDamageOverlay@Fire2Harkonnen:
+	FloatingSpriteEmitter@SmokeHugeOrdos:
+		Offset: -900, 0, 0
+		Gravity: 70
+	FloatingSpriteEmitter@SmokeSmallOrdos:
+		Offset: 300, -200, 0
+		SpawnFrequency: 3, 13
+	WithDamageOverlay@Fire1Ordos:
+		Offset: -600, -1000, 0
+	WithDamageOverlay@Fire2Ordos:
+		Offset: 700, 200, 0
 
 heavy_factory:
 	Inherits: ^Building
 	Inherits@PRIMARY: ^PrimaryBuilding
 	Inherits@UPGRADEABLE: ^Upgradeable
+	Inherits@BUILDINGVFX: ^DamagedBuildingEffects
 	Buildable:
 		Prerequisites: refinery
 		Queue: Building
@@ -554,10 +706,36 @@ heavy_factory:
 	ProvidesPrerequisite@buildingname:
 	GrantConditionOnPrerequisite@UPGRADEABLE:
 		Prerequisites: upgrade.heavy
+	FloatingSpriteEmitter@SmokeHugeAtreides:
+		Offset: 512, 0, 0
+	FloatingSpriteEmitter@SmokeSmallAtreides:
+		Offset: -300, -1000, 0
+	WithDamageOverlay@Fire1_Atreides:
+		Offset: -200, 300, 0
+	WithDamageOverlay@Fire2_atreides:
+		Offset: 1550, -400, 0
+	FloatingSpriteEmitter@SmokeHugeHarkonnen:
+		Offset: -600,-200,0
+	FloatingSpriteEmitter@SmokeSmallHarkonnen:
+		Offset: 0, -660,0
+	WithDamageOverlay@Fire1Harkonnen:
+		Offset: 500, -600,0
+	WithDamageOverlay@Fire2Harkonnen:
+		Offset: 1800, 50,0
+	FloatingSpriteEmitter@SmokeHugeOrdos:
+		Offset: -700, 100,0
+	FloatingSpriteEmitter@SmokeSmallOrdos:
+		Offset: -400, -1000,0
+	WithDamageOverlay@Fire1Ordos:
+		Offset: 1300, -500,0
+	WithDamageOverlay@Fire2Ordos:
+		Offset: 100, -600,0
+		LoopSequence: 4
 
 outpost:
 	Inherits: ^Building
 	Inherits@IDISABLE: ^DisableOnLowPowerOrPowerDown
+	Inherits@BUILDINGVFX: ^DamagedBuildingEffects
 	Buildable:
 		Prerequisites: barracks, ~techlevel.medium
 		Queue: Building
@@ -615,10 +793,35 @@ outpost:
 	Power:
 		Amount: -75
 	ProvidesPrerequisite@buildingname:
+	FloatingSpriteEmitter@SmokeSmallAtreides:
+		Offset: -400, -500, 0
+	FloatingSpriteEmitter@SmokeHugeAtreides:
+		Offset: 300,0,0
+	WithDamageOverlay@Fire1_Atreides:
+		Offset: -150, 300, 0
+	WithDamageOverlay@Fire2_atreides:
+		Offset: 1024, -400, 0
+	FloatingSpriteEmitter@SmokeHugeHarkonnen:
+		Offset: -550, -500, 0
+	FloatingSpriteEmitter@SmokeSmallHarkonnen:
+		Offset: 400, 0, 0
+	WithDamageOverlay@Fire1Harkonnen:
+		Offset: 600,-600,0
+	-WithDamageOverlay@Fire2Harkonnen:
+	FloatingSpriteEmitter@SmokeHugeOrdos:
+		Offset: -600, -300, 0
+		Gravity: 70
+	FloatingSpriteEmitter@SmokeSmallOrdos:
+		Offset: 350, 0, 0
+		SpawnFrequency: 3, 13
+	WithDamageOverlay@Fire1Ordos:
+		Offset: 350, -600, 0
+	-WithDamageOverlay@Fire2Ordos:
 
 starport:
 	Inherits: ^Building
 	Inherits@PRIMARY: ^PrimaryBuilding
+	Inherits@BUILDINGVFX: ^DamagedBuildingEffects
 	Tooltip:
 		Name: actor-starport.name
 	Buildable:
@@ -703,6 +906,32 @@ starport:
 	Power:
 		Amount: -150
 	ProvidesPrerequisite@buildingname:
+	FloatingSpriteEmitter@SmokeHugeAtreides:
+		Offset: 900, -1400, 0
+		Gravity: 40
+		Speed: 5
+	FloatingSpriteEmitter@SmokeSmallAtreides:
+		Offset: -1224, -1312, 0
+		SpawnFrequency: 3, 13
+	WithDamageOverlay@Fire1_Atreides:
+		Offset: 1424, -1390, 0
+	-WithDamageOverlay@Fire2_atreides:
+	FloatingSpriteEmitter@SmokeHugeHarkonnen:
+		Offset: -1100,-1000,0
+	FloatingSpriteEmitter@SmokeSmallHarkonnen:
+		Offset: 700,-900,0
+		Speed: 10
+	-WithDamageOverlay@Fire1Harkonnen:
+	WithDamageOverlay@Fire2Harkonnen:
+		Offset: 1800, 780,0
+	FloatingSpriteEmitter@SmokeHugeOrdos:
+		Offset: -1100,-1000,0
+	FloatingSpriteEmitter@SmokeSmallOrdos:
+		Offset: 700,-900,0
+		Speed: 10
+	-WithDamageOverlay@Fire1Ordos:
+	WithDamageOverlay@Fire2Ordos:
+		Offset: 1800, 780,0
 
 wall:
 	Inherits@1: ^SpriteActor
@@ -821,6 +1050,20 @@ medium_gun_turret:
 		Amount: -50
 	Replacement:
 		ReplaceableTypes: Tower
+	GrantConditionOnDamageState@heavyDamage:
+		Condition: heavy-damage
+	FloatingSpriteEmitter@smoke2_small:
+		Offset: 0, -700, 0
+		RequiresCondition: heavy-damage
+		Image: smoke3
+		Lifetime: 15, 20
+		Speed: 3
+		Gravity: 50
+		SpawnFrequency: 4, 15
+		RandomFacing: true
+		RandomRate: 4
+		TurnRate: 3
+		Duration: 1024
 
 large_gun_turret:
 	Inherits: ^Defense
@@ -867,6 +1110,20 @@ large_gun_turret:
 		Amount: -60
 	Replacement:
 		ReplaceableTypes: Tower
+	GrantConditionOnDamageState@heavyDamage:
+		Condition: heavy-damage
+	FloatingSpriteEmitter@smokeSmall:
+		Offset: 0, -700, 0
+		RequiresCondition: heavy-damage
+		Image: smoke3
+		Lifetime: 15, 20
+		Speed: 3
+		Gravity: 50
+		SpawnFrequency: 4, 15
+		RandomFacing: true
+		RandomRate: 4
+		TurnRate: 3
+		Duration: 1024
 
 repair_pad:
 	Inherits: ^Building
@@ -929,11 +1186,38 @@ repair_pad:
 	Power:
 		Amount: -50
 	ProvidesPrerequisite@buildingname:
+	GrantConditionOnDamageState@heavyDamage:
+		Condition: heavy-damage
+	FloatingSpriteEmitter@smokeSmall:
+		Offset: 100, -1400, 0
+		Gravity: 40
+		RequiresCondition: heavy-damage
+		Image: smoke3
+		Lifetime: 15, 20
+		Speed: 3
+		SpawnFrequency: 4, 15
+		RandomFacing: true
+		RandomRate: 4
+		TurnRate: 3
+		Duration: 1024
+	FloatingSpriteEmitter@smokeHuge:
+		Offset: 800,200,0
+		SpawnFrequency: 4,10
+		RequiresCondition: heavy-damage
+		Image: smoke3
+		Lifetime: 15, 20
+		Speed: 7
+		Gravity: 60
+		RandomFacing: true
+		RandomRate: 4
+		TurnRate: 3
+		Duration: 1224
 
 high_tech_factory:
 	Inherits: ^Building
 	Inherits@PRIMARY: ^PrimaryBuilding
 	Inherits@UPGRADEABLE: ^Upgradeable
+	Inherits@BUILDINGVFX: ^DamagedBuildingEffects
 	Buildable:
 		Prerequisites: outpost, ~techlevel.medium
 		Queue: Building
@@ -1019,6 +1303,25 @@ high_tech_factory:
 		Amount: -75
 	GrantConditionOnPrerequisite@UPGRADEABLE:
 		Prerequisites: upgrade.hightech
+	FloatingSpriteEmitter@SmokeHugeAtreides:
+		Offset: 500, -800, 0
+	WithDamageOverlay@Fire1_Atreides:
+		Offset: 1100, 500, 0
+	FloatingSpriteEmitter@SmokeHugeHarkonnen:
+		Offset: 400,-150,0
+	-FloatingSpriteEmitter@SmokeSmallHarkonnen:
+	WithDamageOverlay@Fire1Harkonnen:
+		Offset: -100, 350,0
+	-WithDamageOverlay@Fire2Harkonnen:
+	FloatingSpriteEmitter@SmokeHugeOrdos:
+		Offset: 500, -200, 0
+		Gravity: 70
+	FloatingSpriteEmitter@SmokeSmallOrdos:
+		Offset: 0, -800, 0
+		SpawnFrequency: 3, 13
+	WithDamageOverlay@Fire1Ordos:
+		Offset: 0, 450, 0
+	-WithDamageOverlay@Fire2Ordos:
 
 research_centre:
 	Inherits: ^Building
@@ -1073,11 +1376,44 @@ research_centre:
 	Power:
 		Amount: -175
 	ProvidesPrerequisite@buildingname:
+	GrantConditionOnDamageState@heavyDamage:
+		Condition: heavy-damage
+	FloatingSpriteEmitter@SmokeHugeAtreides:
+		Offset: 512, 0, 0
+		Speed: 10
+		SpawnFrequency: 3,6
+		RequiresCondition: heavy-damage
+		Image: smoke3
+		Lifetime: 15, 20
+		Gravity: 60
+		RandomFacing: true
+		RandomRate: 4
+		TurnRate: 3
+		Duration: 1224
+	FloatingSpriteEmitter@SmokeSmallAtreides:
+		Offset: 300, -1500, 0
+		RequiresCondition: heavy-damage
+		Image: smoke3
+		Lifetime: 15, 20
+		Speed: 3
+		Gravity: 50
+		SpawnFrequency: 4, 15
+		RandomFacing: true
+		RandomRate: 4
+		TurnRate: 3
+		Duration: 1024
+	WithDamageOverlay@Fire1_Atreides:
+		Offset: -300, 500, 0
+		RequiresCondition: heavy-damage
+		Image: fire
+		LoopSequence: 1
+		LoopCount: 30
 
 palace:
 	Inherits: ^Building
 	Inherits@PRIMARY: ^PrimaryBuilding
 	Inherits@IDISABLE: ^DisableOnLowPowerOrPowerDown
+	Inherits@BUILDINGVFX: ^DamagedBuildingEffects
 	Buildable:
 		Prerequisites: research_centre, ~techlevel.high
 		Queue: Building
@@ -1244,6 +1580,34 @@ palace:
 	SupportPowerChargeBar:
 		RequiresCondition: atreides || harkonnen || ordos
 	ProvidesPrerequisite@buildingname:
+	FloatingSpriteEmitter@SmokeHugeAtreides:
+		Offset: 1000, -600, 0
+		Gravity: 70
+	FloatingSpriteEmitter@SmokeSmallAtreides:
+		Offset: -300, -2000, 0
+		SpawnFrequency: 2,6
+		Speed: 10
+	WithDamageOverlay@Fire1_Atreides:
+		Offset: -200, 800, 0
+	WithDamageOverlay@Fire2_atreides:
+		Offset: 3048, -350, 0
+		LoopSequence: 4
+	FloatingSpriteEmitter@SmokeHugeHarkonnen:
+		Offset: 600,-200,0
+	FloatingSpriteEmitter@SmokeSmallHarkonnen:
+		Offset: -100, -660,0
+	WithDamageOverlay@Fire1Harkonnen:
+		Offset: -300, 512,0
+	WithDamageOverlay@Fire2Harkonnen:
+		Offset: 1700, -100,0
+	FloatingSpriteEmitter@SmokeHugeOrdos:
+		Offset: 800,0,0
+	FloatingSpriteEmitter@SmokeSmallOrdos:
+		Offset: -150, -1200,0
+	WithDamageOverlay@Fire1Ordos:
+		Offset: -500, 750,0
+	WithDamageOverlay@Fire2Ordos:
+		Offset: 2450, -200,0
 
 conyard.atreides:
 	Inherits: construction_yard

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -352,7 +352,7 @@ fire:
 		Start: 3965
 		Length: 10
 		Offset: 4,-17
-		ZOffset: 1023
+		ZOffset: 3023
 		Tick: 100
 		BlendMode: Additive
 	2:
@@ -360,7 +360,7 @@ fire:
 		Start: 3976
 		Length: 11
 		Offset: 0,-3
-		ZOffset: 1023
+		ZOffset: 3023
 		Tick: 100
 		BlendMode: Additive
 	3:
@@ -403,7 +403,7 @@ smoke3:
 		ZOffset: 511
 		Start: 3747
 		Length: 7
-		Tick: 120
+		Tick: 140
 		BlendMode: Subtractive
 
 bombs:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -274,6 +274,7 @@
 	GpsDot:
 		String: Vehicle
 	WithDamageOverlay:
+		StartSequence: start
 	Guard:
 	Guardable:
 	Tooltip:
@@ -536,6 +537,7 @@
 	GpsDot:
 		String: Ship
 	WithDamageOverlay:
+		StartSequence: start
 	FireWarheadsOnDeath:
 		Weapon: UnitExplodeShip
 		EmptyWeapon: UnitExplodeShip
@@ -575,6 +577,7 @@
 	-MustBeDestroyed:
 	WithDamageOverlay:
 		MinimumDamageState: Critical
+		StartSequence: start
 
 ^NeutralPlane:
 	Inherits@1: ^ExistsInWorld
@@ -984,18 +987,30 @@
 		Palette: effect
 		MinimumDamageState: Light
 		MaximumDamageState: Medium
+		StartSequence: start
+		LoopCount: 1, 5
+		InitialDelay: 0, 25
+		EndSequence: end
 	WithDamageOverlay@MediumBurn:
 		DamageTypes: Incendiary
 		Image: burn-m
 		Palette: effect
 		MinimumDamageState: Medium
 		MaximumDamageState: Heavy
+		StartSequence: start
+		LoopCount: 1, 5
+		InitialDelay: 0, 25
+		EndSequence: end
 	WithDamageOverlay@LargeBurn:
 		DamageTypes: Incendiary
 		Image: burn-l
 		Palette: effect
 		MinimumDamageState: Heavy
 		MaximumDamageState: Dead
+		StartSequence: start
+		LoopCount: 1, 5
+		InitialDelay: 0, 25
+		EndSequence: end
 	HiddenUnderShroud:
 	MapEditorData:
 		ExcludeTilesets: INTERIOR

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -83,8 +83,8 @@ explosion:
 burn-l:
 	Defaults:
 		Filename: burn-l.shp
-	idle:
-		Length: *
+	start:
+		Length: 16
 		ZOffset: 512
 	loop:
 		Start: 16
@@ -98,8 +98,8 @@ burn-l:
 burn-m:
 	Defaults:
 		Filename: burn-m.shp
-	idle:
-		Length: *
+	start:
+		Length: 16
 		ZOffset: 512
 	loop:
 		Start: 16
@@ -113,8 +113,8 @@ burn-m:
 burn-s:
 	Defaults:
 		Filename: burn-s.shp
-	idle:
-		Length: *
+	start:
+		Length: 12
 		ZOffset: 512
 	loop:
 		Start: 12
@@ -226,13 +226,13 @@ smoke_m:
 		Length: *
 		Offset: 2, -5
 		ZOffset: 512
+	start:
+		Length: 49
+		Offset: 2, -5
+		ZOffset: 512
 	loop:
 		Start: 49
 		Length: 42
-		Offset: 2, -5
-		ZOffset: 512
-	end:
-		Frames: 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0
 		Offset: 2, -5
 		ZOffset: 512
 


### PR DESCRIPTION
Take over: #20769
 
OG behaviour:

- VFX started on heavy damage state.
- Smoke starts after condition is granted, Fire starts after some delay
- Fire stops first, smoke continue for some time
- Both start again when new damage is taken.
- position is static for each building/faction

Differences:
- According D2kEditor Fire sequences use same animation but with ??? different numbers of frames???. That looks weird in ORA. I decide to go with separate animations for both WithDamageOverlay.

Other changes:
- Make trees burn a random duration
- Rename IdleSequence to StartSequence
- Allow WithDamageOverlay to loop multiple times.
- unhardcode StartSequence and EndSequence
- add initialDelay for WithDamageOverlay
- make WithDamageOverlay conditional
- add ResetOnDamaged to FloatEmitter

RA and CNC have different logic for damaged buildings. Will be addressed in follow up PRs. This is already big enough.