### PR TITLE
Fix map editor copy-paste for isometric maps.

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
@@ -185,7 +185,7 @@ namespace OpenRA.Mods.Common.Traits
 		public int CalculateRegionValue(CellRegion sourceRegion)
 		{
 			var resourceValueInRegion = 0;
-			foreach (var cell in sourceRegion)
+			foreach (var cell in sourceRegion.CellCoords)
 			{
 				var mcell = cell.ToMPos(Map);
 				if (Map.Resources.Contains(mcell) && Map.Resources[mcell].Type != 0)

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorSelectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorSelectionLogic.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				tiles.Add(cell, new ClipboardTile(mapTiles[cell], mapResources[cell], resourceLayer?.GetResource(cell), mapHeight[cell]));
 
 				if (copyFilters.HasFlag(MapCopyFilters.Actors))
-					foreach (var preview in selection.SelectMany(editorActorLayer.PreviewsAt).Distinct())
+					foreach (var preview in selection.CellCoords.SelectMany(editorActorLayer.PreviewsAt).Distinct())
 						previews.TryAdd(preview.ID, preview);
 			}
 


### PR DESCRIPTION
When dealing with isometric maps, the copy paste region needs to copy the CellCoords area covered by the CellRegion. This is equivalent to the selected rectangle on screen. Using the cell region itself invokes cell->map->cell conversion that doesn't roundtrip and thus some of the selected cells don't get copied.

Also when pasting terrain + actors, we need to fix the sequencing to clear actors on the current terrain, before adjusting the height and pasting in new actors. The current sequencing means we are clearing actors after having adjusted the terrain height, and affects the wrong area.

Fixes #21433.

----

Before - notice the wall on the left of the selection is not copied.

![image](https://github.com/OpenRA/OpenRA/assets/3399086/8e92deb0-edf9-4ca2-b203-2690549172d4)

After - the wall is now included in the copy, as expected.

![image](https://github.com/OpenRA/OpenRA/assets/3399086/f14c3c85-bd78-4804-a30c-b02e7750703a)