### PR TITLE
Improve performance of copy-paste in map editor.

### DIFF
--- a/OpenRA.Game/Map/CellCoordsRegion.cs
+++ b/OpenRA.Game/Map/CellCoordsRegion.cs
@@ -64,6 +64,11 @@ namespace OpenRA
 			BottomRight = bottomRight;
 		}
 
+		public bool Contains(CPos cell)
+		{
+			return cell.X >= TopLeft.X && cell.X <= BottomRight.X && cell.Y >= TopLeft.Y && cell.Y <= BottomRight.Y;
+		}
+
 		public override string ToString()
 		{
 			return $"{TopLeft}->{BottomRight}";

--- a/OpenRA.Mods.Cnc/Traits/World/TSEditorResourceLayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSEditorResourceLayer.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				return false;
 
 			// Cell is automatically valid if it contains a veinhole actor
-			if (actorLayer.PreviewsAt(neighbour).Any(a => info.VeinholeActors.Contains(a.Info.Name)))
+			if (actorLayer.PreviewsAtCell(neighbour).Any(a => info.VeinholeActors.Contains(a.Info.Name)))
 				return true;
 
 			// Neighbour must be flat or a cardinal slope, unless the resource cell itself is a slope

--- a/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
@@ -165,7 +165,7 @@ namespace OpenRA.Mods.Common.Widgets
 				tiles.Add(cell, new ClipboardTile(mapTiles[cell], mapResources[cell], resourceLayerContents, mapHeight[cell]));
 
 				if (copyFilters.HasFlag(MapCopyFilters.Actors))
-					foreach (var preview in selection.CellCoords.SelectMany(editorActorLayer.PreviewsAt).Distinct())
+					foreach (var preview in editorActorLayer.PreviewsInCellRegion(selection.CellCoords))
 						previews.TryAdd(preview.ID, preview);
 			}
 
@@ -187,7 +187,7 @@ namespace OpenRA.Mods.Common.Widgets
 				// Clear any existing actors in the paste cells.
 				var selectionSize = clipboard.CellRegion.BottomRight - clipboard.CellRegion.TopLeft;
 				var pasteRegion = new CellRegion(map.Grid.Type, pastePosition, pastePosition + selectionSize);
-				foreach (var regionActor in pasteRegion.CellCoords.SelectMany(editorActorLayer.PreviewsAt).ToHashSet())
+				foreach (var regionActor in editorActorLayer.PreviewsInCellRegion(pasteRegion.CellCoords).ToList())
 					editorActorLayer.Remove(regionActor);
 			}
 
@@ -244,7 +244,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (copyFilters.HasFlag(MapCopyFilters.Actors))
 			{
 				// Clear existing actors.
-				foreach (var regionActor in undoClipboard.CellRegion.CellCoords.SelectMany(editorActorLayer.PreviewsAt).Distinct().ToList())
+				foreach (var regionActor in editorActorLayer.PreviewsInCellRegion(undoClipboard.CellRegion.CellCoords).ToList())
 					editorActorLayer.Remove(regionActor);
 			}
 

--- a/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Common.Widgets
 			worldPixel = worldRenderer.Viewport.ViewToWorldPx(mi.Location);
 			var cell = worldRenderer.Viewport.ViewToWorld(mi.Location);
 
-			var underCursor = editorLayer.PreviewsAt(worldPixel).MinByOrDefault(CalculateActorSelectionPriority);
+			var underCursor = editorLayer.PreviewsAtWorldPixel(worldPixel).MinByOrDefault(CalculateActorSelectionPriority);
 			var resourceUnderCursor = resourceLayer?.GetResource(cell).Type;
 
 			if (underCursor != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorSelectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorSelectionLogic.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.EditorBrushes;
 using OpenRA.Mods.Common.Traits;
@@ -123,7 +122,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				tiles.Add(cell, new ClipboardTile(mapTiles[cell], mapResources[cell], resourceLayer?.GetResource(cell), mapHeight[cell]));
 
 				if (copyFilters.HasFlag(MapCopyFilters.Actors))
-					foreach (var preview in selection.CellCoords.SelectMany(editorActorLayer.PreviewsAt).Distinct())
+					foreach (var preview in editorActorLayer.PreviewsInCellRegion(selection.CellCoords))
 						previews.TryAdd(preview.ID, preview);
 			}
 


### PR DESCRIPTION
- EditorActorLayer now tracks previews on map with a SpatiallyPartitioned instead of a Dictionary. This allows the copy-paste logic to call an efficient PreviewsInCellRegion method, instead of asking for previews cell-by-cell.
- EditorActorPreview subscribes to the CellEntryChanged methods on the map. Previously the preview was refreshed regardless of which cell changed. Now the preview only regenerates if the preview's footprint has been affected.

Fixes #21434. Depends on #21446.