### PR TITLE
Fix aircraft that don't rearm stalling over invalid targets

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -119,10 +119,14 @@ namespace OpenRA.Mods.Common.Activities
 			if (useLastVisibleTarget && !lastVisibleTarget.IsValidFor(self))
 				return true;
 
-			// If all valid weapons have depleted their ammo and Rearmable trait exists, return to RearmActor to reload
-			// and resume the activity after reloading if AbortOnResupply is set to 'false'
-			if (rearmable != null && !useLastVisibleTarget && attackAircraft.Armaments.All(x => x.IsTraitPaused || !x.Weapon.IsValidAgainst(target, self.World, self)))
+			// If all weapons are invalid against the target
+			if (!useLastVisibleTarget && attackAircraft.Armaments.All(x => x.IsTraitPaused || !x.Weapon.IsValidAgainst(target, self.World, self)))
 			{
+				// If Rearmable trait exists, return to RearmActor to reload and resume the activity after
+				// reloading if AbortOnResupply is set to 'false'.
+				if (rearmable == null)
+					return true;
+
 				// Attack moves never resupply
 				if (source == AttackSource.AttackMove)
 					return true;


### PR DESCRIPTION
The check for if an aircraft's weapons were invalid was only triggered if it was rearmable, so mods where it wasn't had the issue of stalling over targets when they became untargetable from conditions. The check for resupply is moved within the if-block, if not present the aircraft will just complete the flyattack activity.