### PR TITLE
Fix autotarget not checking all attack traits for targets

### DIFF
--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -303,7 +303,9 @@ namespace OpenRA.Mods.Common.Traits
 					if (attackStances != PlayerRelationship.None)
 					{
 						var range = Info.ScanRadius > 0 ? WDist.FromCells(Info.ScanRadius) : ab.GetMaximumRange();
-						return ChooseTarget(self, ab, attackStances, range, allowMove, allowTurn);
+						var target = ChooseTarget(self, ab, attackStances, range, allowMove, allowTurn);
+						if (target.Type != TargetType.Invalid)
+							return target;
 					}
 				}
 			}


### PR DESCRIPTION
Mods where an actor had multiple attack traits using weapons with mutually exclusive target types found only one able to autotarget, as the first element in the attack trait collection always returned even if the target was invalid. The attack trait's target search now returns only if the target is valid, otherwise it iterates on until one is found and so all attack traits will be searched properly.