### PR TITLE
Fix TD helicopters losing target when out of ammo

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 
 			// If all weapons are invalid against the target
-			if (!useLastVisibleTarget && attackAircraft.Armaments.All(x => x.IsTraitPaused || !x.Weapon.IsValidAgainst(target, self.World, self)))
+			if (!(attackAircraft.Info.AttackType == AirAttackType.Hover || aircraft.Info.CanHover) && !useLastVisibleTarget && attackAircraft.Armaments.All(x => x.IsTraitPaused || !x.Weapon.IsValidAgainst(target, self.World, self)))
 			{
 				// If Rearmable trait exists, return to RearmActor to reload and resume the activity after
 				// reloading if AbortOnResupply is set to 'false'.


### PR DESCRIPTION
#21451 introduced a regression that helicopters in TD lost their targets when out of ammo. Since stalling is only an issue if the aircraft does not hover, a check for that is introduced.