### PR TITLE
Make MiniYaml inherits and removal more flexible

### DIFF
--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -425,19 +425,23 @@ namespace OpenRA
 		static void MergeIntoResolved(MiniYamlNode overrideNode, List<MiniYamlNode> existingNodes, HashSet<string> existingNodeKeys,
 			Dictionary<string, MiniYaml> tree, ImmutableDictionary<string, MiniYamlNode.SourceLocation> inherited)
 		{
-			if (existingNodeKeys.Add(overrideNode.Key))
+			var existingNodeIndex = -1;
+			MiniYamlNode existingNode = null;
+			if (!existingNodeKeys.Add(overrideNode.Key))
 			{
-				existingNodes.Add(overrideNode);
-				return;
+				existingNodeIndex = IndexOfKey(existingNodes, overrideNode.Key);
+				existingNode = existingNodes[existingNodeIndex];
 			}
 
-			var existingNodeIndex = IndexOfKey(existingNodes, overrideNode.Key);
-			var existingNode = existingNodes[existingNodeIndex];
-			var value = MergePartial(existingNode.Value, overrideNode.Value);
+			var value = MergePartial(existingNode?.Value, overrideNode.Value);
 			var nodes = ResolveInherits(value, tree, inherited);
 			if (!value.Nodes.SequenceEqual(nodes))
 				value = value.WithNodes(nodes);
-			existingNodes[existingNodeIndex] = existingNode.WithValue(value);
+
+			if (existingNode != null)
+				existingNodes[existingNodeIndex] = existingNode.WithValue(value);
+			else
+				existingNodes.Add(overrideNode.WithValue(value));
 		}
 
 		static List<MiniYamlNode> ResolveInherits(MiniYaml node, Dictionary<string, MiniYaml> tree, ImmutableDictionary<string, MiniYamlNode.SourceLocation> inherited)

--- a/mods/d2k/sequences/infantry.yaml
+++ b/mods/d2k/sequences/infantry.yaml
@@ -83,6 +83,7 @@ light_inf:
 		Filename: DATA.R16
 		Start: 4272
 		Offset: -30,-24
+		Remap: 00000000
 
 trooper:
 	Defaults:
@@ -168,6 +169,7 @@ trooper:
 		Filename: DATA.R16
 		Start: 4273
 		Offset: -30,-24
+		Remap: 00000000
 
 engineer:
 	Defaults:
@@ -242,6 +244,7 @@ engineer:
 		Filename: DATA.R16
 		Start: 4274
 		Offset: -30,-24
+		Remap: 00000000
 
 thumper:
 	Defaults:
@@ -301,6 +304,7 @@ thumper:
 		Length: 5
 		Tick: 480
 		BlendMode: Multiply
+		Remap: 00000000
 	die1:
 		Filename: DATA.R16
 		Frames: 1543, 1550, 1557, 1564, 1571, 1578, 1585, 1592, 1599, 1600, 1601, 1602
@@ -331,6 +335,7 @@ thumper:
 		Filename: DATA.R16
 		Start: 4275
 		Offset: -30,-24
+		Remap: 00000000
 
 fremen:
 	Defaults:
@@ -417,6 +422,7 @@ fremen:
 		Filename: DATA.R16
 		Start: 4293
 		Offset: -30,-24
+		Remap: 00000000
 
 saboteur:
 	Defaults:
@@ -491,6 +497,7 @@ saboteur:
 		Filename: DATA.R16
 		Start: 4295
 		Offset: -30,-24
+		Remap: 00000000
 
 sardaukar:
 	Defaults:
@@ -579,6 +586,7 @@ sardaukar:
 		Filename: DATA.R16
 		Start: 4276
 		Offset: -30,-24
+		Remap: 00000000
 
 grenadier:
 	Defaults:
@@ -654,6 +662,7 @@ grenadier:
 		Filename: DATA.R16
 		Start: 4297
 		Offset: -30,-24
+		Remap: 00000000
 
 sandworm:
 	mouth:

--- a/mods/d2k/sequences/infantry.yaml
+++ b/mods/d2k/sequences/infantry.yaml
@@ -83,7 +83,6 @@ light_inf:
 		Filename: DATA.R16
 		Start: 4272
 		Offset: -30,-24
-		-Remap:
 
 trooper:
 	Defaults:
@@ -169,7 +168,6 @@ trooper:
 		Filename: DATA.R16
 		Start: 4273
 		Offset: -30,-24
-		-Remap:
 
 engineer:
 	Defaults:
@@ -244,7 +242,6 @@ engineer:
 		Filename: DATA.R16
 		Start: 4274
 		Offset: -30,-24
-		-Remap:
 
 thumper:
 	Defaults:
@@ -304,7 +301,6 @@ thumper:
 		Length: 5
 		Tick: 480
 		BlendMode: Multiply
-		-Remap:
 	die1:
 		Filename: DATA.R16
 		Frames: 1543, 1550, 1557, 1564, 1571, 1578, 1585, 1592, 1599, 1600, 1601, 1602
@@ -335,7 +331,6 @@ thumper:
 		Filename: DATA.R16
 		Start: 4275
 		Offset: -30,-24
-		-Remap:
 
 fremen:
 	Defaults:
@@ -422,7 +417,6 @@ fremen:
 		Filename: DATA.R16
 		Start: 4293
 		Offset: -30,-24
-		-Remap:
 
 saboteur:
 	Defaults:
@@ -497,7 +491,6 @@ saboteur:
 		Filename: DATA.R16
 		Start: 4295
 		Offset: -30,-24
-		-Remap:
 
 sardaukar:
 	Defaults:
@@ -586,7 +579,6 @@ sardaukar:
 		Filename: DATA.R16
 		Start: 4276
 		Offset: -30,-24
-		-Remap:
 
 grenadier:
 	Defaults:
@@ -662,7 +654,6 @@ grenadier:
 		Filename: DATA.R16
 		Start: 4297
 		Offset: -30,-24
-		-Remap:
 
 sandworm:
 	mouth:


### PR DESCRIPTION
- Previously the Inherits syntax was only resolved when used for top-level nodes. Now it is also resolved for nested nodes as well.
- Previously the MiniYAML Merge feature supported the ability to remove nodes, but this only worked within the context of inherited nodes. Now, we allow node removal to work outside of the inheritance context.
- Fix the sprite issues in d2k, as the old `-Remap` syntax is now considered invalid (before it was valid, but was a no-op and not working as intended)

Fixes #19580 Fixes #16278 Fixes #21444