### PR TITLE
WithDockingAnimation: remove unnecessary dependency on Harvester trait

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithDockingAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDockingAnimation.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
 {
-	public class WithDockingAnimationInfo : TraitInfo, Requires<WithSpriteBodyInfo>, Requires<HarvesterInfo>
+	public class WithDockingAnimationInfo : TraitInfo, Requires<WithSpriteBodyInfo>
 	{
 		[SequenceReference]
 		[Desc("Displayed when docking to refinery.")]


### PR DESCRIPTION
As the title says. Probably left-over from the docking refactoring.

I tested it in RA mod, Harvester behaves and looks the same as before the change.