### PR TITLE
In MoveAdjacentTo, don't discard child activities when self-cancelling.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -28,6 +28,7 @@ namespace OpenRA.Mods.Common.Activities
 		protected Target lastVisibleTarget;
 		protected CPos lastVisibleTargetLocation;
 		bool useLastVisibleTarget;
+		bool keepQueue;
 
 		public MoveAdjacentTo(Actor self, in Target target, WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
@@ -91,7 +92,10 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Cancel the current path if the activity asks to stop.
 			if (ShouldStop(self) || noTarget)
+			{
 				Cancel(self, true);
+				keepQueue = true;
+			}
 			else if (!IsCanceling && targetIsValid && ShouldRepath(self, oldTargetLocation))
 			{
 				// Target has moved, but is still valid.
@@ -104,10 +108,11 @@ namespace OpenRA.Mods.Common.Activities
 			if (!TickChild(self))
 				return false;
 
-			if (Mobile.MoveResult == MoveResult.CompleteDestinationReached)
+			// The move reached the destination, or was canceled intentionally and we want to keep the activity queue.
+			if (Mobile.MoveResult == MoveResult.CompleteDestinationReached || keepQueue)
 				return true;
 
-			// The move completed but we didn't reach the destination, so Cancel.
+			// The move completed but we didn't reach the destination, so Cancel and discard the queue.
 			Cancel(self);
 			return true;
 		}


### PR DESCRIPTION
In 2ed0656d1b36d99d5a1e814ce66c6a6d084fb891, MoveAdjacentTo was changed to cancel and discard child activities if the move destination was not reached. This changed the behaviour of MoveOntoAndTurn to skip the turn step if the move didn't reach the destination, e.g. a harvester moving to a refinery was blocked by a wall.

However it regresses the MoveWithinRange activity. This overrides ShouldStop to stop once within range. It cancels the activty but preserves the queue. However the later tick realizes the move was cancelled before reaching the destination, and throws away the queue. This regresses the behaviour of this activity where the queued actions were desired to be kept and executed once the actor had moved within range.

Now, we note if we cancelled and wanted to keep the child activity queue, so that we don't throw it away later. This fixes the regression in the MoveWithinRange activity so that the follow-up activities will now run. But it also preserves the behaviour change where if the destination was not reached and it wasn't due to us intentionally cancelling ourselves, we'll still discard the queue.

Fixes #21466.