### PR TITLE
Improve performance of AIUtils.FindQueues

### DIFF
--- a/OpenRA.Mods.Common/AIUtils.cs
+++ b/OpenRA.Mods.Common/AIUtils.cs
@@ -34,11 +34,12 @@ namespace OpenRA.Mods.Common
 							.Any(availableCells => availableCells > 0);
 		}
 
-		public static IEnumerable<ProductionQueue> FindQueues(Player player, string category)
+		public static ILookup<string, ProductionQueue> FindQueuesByCategory(Player player)
 		{
 			return player.World.ActorsWithTrait<ProductionQueue>()
-				.Where(a => a.Actor.Owner == player && a.Trait.Info.Type == category && a.Trait.Enabled)
-				.Select(a => a.Trait);
+				.Where(a => a.Actor.Owner == player && a.Trait.Enabled)
+				.Select(a => a.Trait)
+				.ToLookup(pq => pq.Info.Type);
 		}
 
 		public static int CountActorsWithNameAndTrait<T>(string actorName, Player owner)

--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -220,6 +220,7 @@ namespace OpenRA.Mods.Common.Traits
 			// PERF: We tick only one type of valid queue at a time
 			// if AI gets enough cash, it can fill all of its queues with enough ticks
 			var findQueue = false;
+			var queuesByCategory = AIUtils.FindQueuesByCategory(player);
 			for (int i = 0, builderIndex = currentBuilderIndex; i < builders.Length; i++)
 			{
 				if (++builderIndex >= builders.Length)
@@ -227,7 +228,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				--builders[builderIndex].WaitTicks;
 
-				var queues = AIUtils.FindQueues(player, builders[builderIndex].Category).ToArray();
+				var queues = queuesByCategory[builders[builderIndex].Category].ToArray();
 				if (queues.Length != 0)
 				{
 					if (!findQueue)
@@ -254,7 +255,7 @@ namespace OpenRA.Mods.Common.Traits
 				}
 			}
 
-			builders[currentBuilderIndex].Tick(bot);
+			builders[currentBuilderIndex].Tick(bot, queuesByCategory);
 		}
 
 		void IBotRespondToAttack.RespondToAttack(IBot bot, Actor self, AttackInfo e)

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 				waterState = WaterCheck.DontCheck;
 		}
 
-		public void Tick(IBot bot)
+		public void Tick(IBot bot, ILookup<string, ProductionQueue> queuesByCategory)
 		{
 			// If failed to place something N consecutive times, wait M ticks until resuming building production
 			if (failCount >= baseBuilder.Info.MaximumFailedPlacementAttempts && --failRetryTicks <= 0)
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Common.Traits
 			// PERF: Queue only one actor at a time per category
 			itemQueuedThisTick = false;
 			var active = false;
-			foreach (var queue in AIUtils.FindQueues(player, Category))
+			foreach (var queue in queuesByCategory[Category])
 			{
 				if (TickQueue(bot, queue))
 					active = true;


### PR DESCRIPTION
The AI would often invoke this method inside of loops, searching for a different category of queue each time. This would result in multiple searches against the trait dictionary to locate matching queues. Now we alter the method to create a lookup of all the queues keyed by category. This allows a single trait search to be performed.

UnitBuilderBotModule and BaseBuilderBotModule are updated to fetch this lookup once when required, and pass the results along to avoid calling the method more times than necessary. This improves their performance.