### PR TITLE
AI uses better rally point placement

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -258,6 +258,25 @@ namespace OpenRA.Mods.Common.Traits
 			return hierarchicalPathFindersBlockedByNoneByLocomotor[locomotor].PathExists(source, target);
 		}
 
+		/// <summary>
+		/// Determines if a path exists between source and target.
+		/// Terrain and a *subset* of immovable actors are taken into account,
+		/// i.e. as if a subset of <see cref="BlockedByActor.Immovable"/> was given.
+		/// This would apply for any actor using the given <see cref="Locomotor"/>.
+		/// </summary>
+		/// <remarks>
+		/// It is allowed for an actor to occupy an inaccessible space and move out of it if another adjacent cell is
+		/// accessible, but it is not allowed to move into an inaccessible target space. Therefore it is vitally
+		/// important to not mix up the source and target locations. A path can exist from an inaccessible source space
+		/// to an accessible target space, but if those parameters as swapped then no path can exist.
+		/// As only a subset of immovable actors are taken into account,
+		/// this method can return false positives, indicating a path might exist where none is possible.
+		/// </remarks>
+		public bool PathMightExistForLocomotorBlockedByImmovable(Locomotor locomotor, CPos source, CPos target)
+		{
+			return hierarchicalPathFindersBlockedByImmovableByLocomotor[locomotor].PathExists(source, target);
+		}
+
 		static Locomotor GetActorLocomotor(Actor self)
 		{
 			// PERF: This PathFinder trait requires the use of Mobile, so we can be sure that is in use.

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -940,5 +940,19 @@ namespace OpenRA.Mods.Common.Traits
 		/// <remarks>Path searches are not guaranteed to by symmetric,
 		/// the source and target locations cannot be swapped.</remarks>
 		bool PathExistsForLocomotor(Locomotor locomotor, CPos source, CPos target);
+
+		/// <summary>
+		/// Determines if a path exists between source and target.
+		/// Terrain and immovable actors are taken into account,
+		/// i.e. as if <see cref="BlockedByActor.Immovable"/> was given.
+		/// Implementations are permitted to only account for a subset of actors, for performance.
+		/// This would apply for any actor using the given <see cref="Locomotor"/>.
+		/// </summary>
+		/// <remarks>Path searches are not guaranteed to by symmetric,
+		/// the source and target locations cannot be swapped.
+		/// If this method returns false, there is guaranteed to be no path.
+		/// If it returns true, there *might* be a path.
+		/// </remarks>
+		bool PathMightExistForLocomotorBlockedByImmovable(Locomotor locomotor, CPos source, CPos target);
 	}
 }


### PR DESCRIPTION
- ~~AI places rally points at pathable locations. This replaces the previous logic which required the location to be buildable. This doesn't make much sense, as soon as the first unit arrives at the rally point, the location became unbuildable and the AI would move the rally point! A pathable location isn't strictly required, but avoids the AI setting rally points at seemingly dumb locations.~~
- AI places rally points at pathable locations. A pathable location isn't strictly required, but avoids the AI setting rally points at seemingly dumb locations. This is an addtional check on top of the existing buildability check.

- AI now evaluates rally points every AssignRallyPointsInterval (default 100 ticks). Invalid rally points aren't that harmful, so no need to check them every tick. Additionally we do a rolling update so rally points for multiple locations are spread across multiple ticks to reduce any potential lag spikes.

Fixes #11938 Fixes #13289 