### PR TITLE
Remove unused previous state in AI StateMachine

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/Squad.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/Squad.cs
@@ -58,13 +58,13 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				case SquadType.Assault:
 				case SquadType.Rush:
 				case SquadType.Naval:
-					FuzzyStateMachine.ChangeState(this, new GroundUnitsIdleState(), true);
+					FuzzyStateMachine.ChangeState(this, new GroundUnitsIdleState());
 					break;
 				case SquadType.Air:
-					FuzzyStateMachine.ChangeState(this, new AirIdleState(), true);
+					FuzzyStateMachine.ChangeState(this, new AirIdleState());
 					break;
 				case SquadType.Protection:
-					FuzzyStateMachine.ChangeState(this, new UnitsForProtectionIdleState(), true);
+					FuzzyStateMachine.ChangeState(this, new UnitsForProtectionIdleState());
 					break;
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/StateMachine.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/StateMachine.cs
@@ -14,29 +14,20 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 	sealed class StateMachine
 	{
 		IState currentState;
-		IState previousState;
 
 		public void Update(Squad squad)
 		{
 			currentState?.Tick(squad);
 		}
 
-		public void ChangeState(Squad squad, IState newState, bool rememberPrevious)
+		public void ChangeState(Squad squad, IState newState)
 		{
-			if (rememberPrevious)
-				previousState = currentState;
-
 			currentState?.Deactivate(squad);
 
 			if (newState != null)
 				currentState = newState;
 
 			currentState?.Activate(squad);
-		}
-
-		public void RevertToPreviousState(Squad squad, bool saveCurrentState)
-		{
-			ChangeState(squad, previousState, saveCurrentState);
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 
 			if (ShouldFlee(owner))
 			{
-				owner.FuzzyStateMachine.ChangeState(owner, new AirFleeState(), true);
+				owner.FuzzyStateMachine.ChangeState(owner, new AirFleeState());
 				return;
 			}
 
@@ -132,7 +132,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				return;
 
 			owner.SetActorToTarget((e, WVec.Zero));
-			owner.FuzzyStateMachine.ChangeState(owner, new AirAttackState(), true);
+			owner.FuzzyStateMachine.ChangeState(owner, new AirAttackState());
 		}
 
 		public void Deactivate(Squad owner) { }
@@ -154,14 +154,14 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				owner.SetActorToTarget(closestEnemy);
 				if (closestEnemy.Actor == null)
 				{
-					owner.FuzzyStateMachine.ChangeState(owner, new AirFleeState(), true);
+					owner.FuzzyStateMachine.ChangeState(owner, new AirFleeState());
 					return;
 				}
 			}
 
 			if (!NearToPosSafely(owner, owner.Target.CenterPosition))
 			{
-				owner.FuzzyStateMachine.ChangeState(owner, new AirFleeState(), true);
+				owner.FuzzyStateMachine.ChangeState(owner, new AirFleeState());
 				return;
 			}
 
@@ -215,7 +215,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				owner.Bot.QueueOrder(new Order("Move", a, Target.FromCell(owner.World, RandomBuildingLocation(owner)), false));
 			}
 
-			owner.FuzzyStateMachine.ChangeState(owner, new AirIdleState(), true);
+			owner.FuzzyStateMachine.ChangeState(owner, new AirIdleState());
 		}
 
 		public void Deactivate(Squad owner) { }

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
@@ -109,10 +109,10 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				owner.Bot.QueueOrder(new Order("AttackMove", null, owner.Target, false, groupedActors: owner.Units.ToArray()));
 
 				// We have gathered sufficient units. Attack the nearest enemy unit.
-				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsAttackMoveState(), true);
+				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsAttackMoveState());
 			}
 			else
-				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsFleeState(), true);
+				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsFleeState());
 		}
 
 		public void Deactivate(Squad owner) { }
@@ -137,7 +137,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				owner.SetActorToTarget(closestEnemy);
 				if (closestEnemy.Actor == null)
 				{
-					owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsFleeState(), true);
+					owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsFleeState());
 					return;
 				}
 			}
@@ -160,7 +160,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			// that they cannot path to, generating expensive pathfinding calls each tick.
 			if (owner.World.WorldTick > lastUpdatedTick + 63)
 			{
-				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsIdleState(), true);
+				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsIdleState());
 				return;
 			}
 
@@ -182,14 +182,14 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				if (target.Actor != null)
 				{
 					owner.SetActorToTarget(target);
-					owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsAttackState(), true);
+					owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsAttackState());
 				}
 				else
 					owner.Bot.QueueOrder(new Order("AttackMove", null, owner.Target, false, groupedActors: owner.Units.ToArray()));
 			}
 
 			if (ShouldFlee(owner))
-				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsFleeState(), true);
+				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsFleeState());
 		}
 
 		public void Deactivate(Squad owner) { }
@@ -214,7 +214,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				owner.SetActorToTarget(closestEnemy);
 				if (closestEnemy.Actor == null)
 				{
-					owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsFleeState(), true);
+					owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsFleeState());
 					return;
 				}
 			}
@@ -237,7 +237,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			// that they cannot path to, generating expensive pathfinding calls each tick.
 			if (owner.World.WorldTick > lastUpdatedTick + 63)
 			{
-				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsIdleState(), true);
+				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsIdleState());
 				return;
 			}
 
@@ -246,7 +246,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 					owner.Bot.QueueOrder(new Order("AttackMove", a, owner.Target, false));
 
 			if (ShouldFlee(owner))
-				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsFleeState(), true);
+				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsFleeState());
 		}
 
 		public void Deactivate(Squad owner) { }
@@ -262,7 +262,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				return;
 
 			GoToRandomOwnBuilding(owner);
-			owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsIdleState(), true);
+			owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsIdleState());
 		}
 
 		public void Deactivate(Squad owner) { owner.SquadManager.UnregisterSquad(owner); }

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/ProtectionStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/ProtectionStates.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 	sealed class UnitsForProtectionIdleState : GroundStateBase, IState
 	{
 		public void Activate(Squad owner) { }
-		public void Tick(Squad owner) { owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionAttackState(), true); }
+		public void Tick(Squad owner) { owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionAttackState()); }
 		public void Deactivate(Squad owner) { }
 	}
 
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				owner.SetActorToTarget(target);
 				if (target.Actor == null)
 				{
-					owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionFleeState(), true);
+					owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionFleeState());
 					return;
 				}
 			}
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			{
 				if (Backoff < 0)
 				{
-					owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionFleeState(), true);
+					owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionFleeState());
 					Backoff = BackoffTicks;
 					return;
 				}
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				return;
 
 			GoToRandomOwnBuilding(owner);
-			owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionIdleState(), true);
+			owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionIdleState());
 		}
 
 		public void Deactivate(Squad owner) { owner.SquadManager.UnregisterSquad(owner); }


### PR DESCRIPTION
The StateMachine offered a feature to remember the previous state and allow reverting to it. However this feature is unused. Remove it to allow the previous states to be reclaimed by the GC earlier.

Fixes #18818