### PR TITLE
Fix a crash caused by invalid target in FlyAttack

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -141,9 +141,6 @@ namespace OpenRA.Mods.Common.Activities
 
 			var minimumRange = attackAircraft.Info.AttackType == AirAttackType.Strafe ? WDist.Zero : attackAircraft.GetMinimumRangeVersusTarget(target);
 
-			if (checkTarget.IsInRange(pos, lastVisibleMaximumRange) && !checkTarget.IsInRange(pos, minimumRange) && useLastVisibleTarget)
-				return true;
-
 			if (lastVisibleMaximumRange == WDist.Zero || lastVisibleMaximumRange < minimumRange)
 				return true;
 
@@ -153,8 +150,12 @@ namespace OpenRA.Mods.Common.Activities
 			QueueChild(new TakeOff(self));
 
 			// Move into range of the target.
-			if (!target.IsInRange(pos, lastVisibleMaximumRange) || target.IsInRange(pos, minimumRange))
-				QueueChild(aircraft.MoveWithinRange(target, minimumRange, lastVisibleMaximumRange, target.CenterPosition, Color.Red));
+			if (!checkTarget.IsInRange(pos, lastVisibleMaximumRange) || checkTarget.IsInRange(pos, minimumRange))
+				QueueChild(aircraft.MoveWithinRange(target, minimumRange, lastVisibleMaximumRange, checkTarget.CenterPosition, Color.Red));
+
+			// We've reached the assumed position but it is not there - give up
+			else if (useLastVisibleTarget)
+				return true;
 
 			// The aircraft must keep moving forward even if it is already in an ideal position.
 			else if (attackAircraft.Info.AttackType == AirAttackType.Strafe)


### PR DESCRIPTION
By moving to checkTarget's position this makes FlyAttack's MoveWithinRange consistent with its counterpart in AttackFollow as has been the approach in #21455.