### PR TITLE
Fix parallel queues not pausing production for more than one of same item queued

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ClassicParallelProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicParallelProductionQueue.cs
@@ -192,6 +192,12 @@ namespace OpenRA.Mods.Common.Traits
 			base.BeginProduction(item, false);
 		}
 
+		protected override void PauseProduction(string itemName, bool paused)
+		{
+			foreach (var item in Queue.Where(a => a.Item == itemName))
+				item.Pause(paused);
+		}
+
 		public override int GetBuildTime(ActorInfo unit, BuildableInfo bi)
 		{
 			if (developerMode.FastBuild)

--- a/OpenRA.Mods.Common/Traits/Player/ParallelProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ParallelProductionQueue.cs
@@ -56,6 +56,12 @@ namespace OpenRA.Mods.Common.Traits
 			base.BeginProduction(item, false);
 		}
 
+		protected override void PauseProduction(string itemName, bool paused)
+		{
+			foreach (var item in Queue.Where(a => a.Item == itemName))
+				item.Pause(paused);
+		}
+
 		public override int RemainingTimeActual(ProductionItem item)
 		{
 			var parallelBuilds = Queue.FindAll(i => !i.Paused && !i.Done)


### PR DESCRIPTION
Parallel production queues did not pause production if more than one of the paused item was queued, because not all instances queued were paused and it simply moved on to producing the next one that was in the queue. This PR fixes it by pausing all instances of the paused item in the queue