### PR TITLE
Fix Survival01 mission objective text

### DIFF
--- a/mods/ra/maps/survival01/survival01.lua
+++ b/mods/ra/maps/survival01/survival01.lua
@@ -272,7 +272,7 @@ TimerExpired = function()
 	Reinforcements.Reinforce(Allies, FrenchReinforcements, { SovietEntryPoint7.Location, Alliesbase.Location })
 
 	if DestroyObj then
-		KillObj = AddPrimaryObjective(Allies, "control-reinforcements-kill-remaining-soviet-forces")
+		KillObj = AddPrimaryObjective(Allies, "takeover-reinforcements-kill-remaining-soviet-forces")
 	else
 		DestroyObj = AddPrimaryObjective(Allies, "takeover-reinforcements-dismantle-soviet-base")
 	end


### PR DESCRIPTION
One of the final objectives in the Survival01 mission was missing translation.
(the 3rd item in the screenshot - `control-reinforcements-kill-remaining-soviet-forces`)
![Screenshot_20240713_010054](https://github.com/user-attachments/assets/119cbe6f-1713-481b-98de-33053885b12b)

Upon further inspection, it turned out that `takeover-reinforcements-kill-remaining-soviet-forces` is present in 
https://github.com/OpenRA/OpenRA/blob/bleed/mods/ra/languages/lua/en.ftl#L388-L391 and not in use (`git grep -A 2 takeover-` will show this message and the one that is 2 lines below from my change (`takeover-reinforcements-dismantle-soviet-base`).