### PR TITLE
Fix untranslated speakers

### DIFF
--- a/mods/d2k/languages/lua/en.ftl
+++ b/mods/d2k/languages/lua/en.ftl
@@ -45,10 +45,12 @@ eliminate-ordos-units-reinforcements = Eliminate all Ordos units and reinforceme
 destroy-harkonnen = Destroy the Harkonnen.
 
 ## atreides-04
+fremen-leader = Fremen Leader
 sietch-integrity = Sietch structural integrity: { $integrity }%
 protect-fremen-sietch = Protect the Fremen Sietch.
 keep-sietch-intact = Keep the Sietch { $integrity }% intact!
 fremen-sietch-southeast = Fremen Sietch detected to the southeast.
+harkonnen-units-approaching = Harkonnen units approaching!
 sietch-destroyed = Sietch destroyed!
 fremen-sietch-under-attack = The Fremen Sietch is under attack!
 

--- a/mods/d2k/maps/atreides-04/atreides04-AI.lua
+++ b/mods/d2k/maps/atreides-04/atreides04-AI.lua
@@ -36,7 +36,7 @@ SendAttack = function(owner, size)
 	Utils.Do(units, IdleHunt)
 
 	if #units > 0 then
-		Media.DisplayMessage("Harkonnen units approaching!", "Fremen Leader")
+		Media.DisplayMessage(UserInterface.Translate("harkonnen-units-approaching"), UserInterface.Translate("fremen-leader"))
 	end
 
 	Trigger.OnAllRemovedFromWorld(units, function()

--- a/mods/ra/languages/lua/en.ftl
+++ b/mods/ra/languages/lua/en.ftl
@@ -164,6 +164,7 @@ clear-enemy-submarines = Clear the area of enemy submarine activity.
 ## fort-lonestar
 no-more-waves = You almost survived the onslaught! No more waves incoming.
 defend-fort-lonestar = Defend Fort Lonestar at all costs!
+lonestar-ai-sold-its-walls = Lonestar AI { $id } sold its walls for a better combat experience.
 
 ## in-the-nick-of-time
 friendlies-coming-out = Friendlies coming out!

--- a/mods/ra/maps/allies-05a/allies05a.lua
+++ b/mods/ra/maps/allies-05a/allies05a.lua
@@ -220,7 +220,7 @@ SendSpy = function()
 	end
 
 	Trigger.AfterDelay(DateTime.Seconds(3), function()
-		Media.DisplayMessage(UserInterface.Translate("disguise-spy"), "Spy")
+		Media.DisplayMessage(UserInterface.Translate("disguise-spy"), UserInterface.Translate("spy"))
 	end)
 end
 

--- a/mods/ra/maps/allies-05b/allies05b.lua
+++ b/mods/ra/maps/allies-05b/allies05b.lua
@@ -50,7 +50,7 @@ SendSpy = function()
 	Trigger.OnKilled(Spy, function() USSR.MarkCompletedObjective(USSRObj) end)
 
 	Trigger.AfterDelay(DateTime.Seconds(3), function()
-		Media.DisplayMessage(UserInterface.Translate("disguise-spy"), "Spy")
+		Media.DisplayMessage(UserInterface.Translate("disguise-spy"), UserInterface.Translate("spy"))
 		if SpecialCameras then
 			SpyCameraA = Actor.Create("camera", true, { Owner = Greece, Location = SpyCamera1.Location })
 			SpyCameraB = Actor.Create("camera", true, { Owner = Greece, Location = SpyCamera2.Location })

--- a/mods/ra/maps/allies-05c/allies05c.lua
+++ b/mods/ra/maps/allies-05c/allies05c.lua
@@ -184,7 +184,7 @@ FreeTanya = function()
 
 	if TanyaType == "e7.noautotarget" then
 		Trigger.AfterDelay(DateTime.Seconds(1), function()
-			Media.DisplayMessage(UserInterface.Translate("tanya-rules-of-engagement"), "Tanya")
+			Media.DisplayMessage(UserInterface.Translate("tanya-rules-of-engagement"), UserInterface.Translate("tanya"))
 		end)
 	end
 

--- a/mods/ra/maps/fort-lonestar/fort-lonestar-AI.lua
+++ b/mods/ra/maps/fort-lonestar/fort-lonestar-AI.lua
@@ -154,7 +154,7 @@ RepairBarracks = function(id)
 end
 
 SellWalls = function(id)
-	Media.DisplayMessage("Lonestar AI " .. id .. " sold its walls for better combat experience.")
+	Media.DisplayMessage(UserInterface.Translate("lonestar-ai-sold-its-walls", { ["id"] = id }))
 
 	local walls = AIPlayers[id].GetActorsByType("brik")
 	Utils.Do(walls, function(wall)

--- a/mods/ra/maps/situation-critical/situation-critical.lua
+++ b/mods/ra/maps/situation-critical/situation-critical.lua
@@ -90,7 +90,7 @@ SetupTriggers = function()
 	end)
 
 	Trigger.OnInfiltrated(BioLab, function()
-		Media.DisplayMessage("plans-stolen-erase-data", "scientist")
+		Media.DisplayMessage(UserInterface.Translate("plans-stolen-erase-data"), UserInterface.Translate("scientist"))
 		Trigger.AfterDelay(DateTime.Seconds(5), function()
 			USSR.MarkCompletedObjective(InfiltrateLab)
 			LabInfiltrated = true


### PR DESCRIPTION
There are messages in Tanya's Tale where the text is fine but the translation for a speaker goes unused.

I didn't find a mismatch like this in other scripts. ![SpeakerMismatchCheck](https://github.com/user-attachments/assets/308c7c69-9b5c-4cac-bcce-26878385bf8a)

A similar search turned up untranslated messages in RA's Situation Critical and D2k's `atreides-04`, so I've tossed in a fix for those.