### PR TITLE
Fix graphical error when adding multiplayer spawn points in the map editor

### DIFF
--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -79,6 +79,7 @@ namespace OpenRA
 
 		Rectangle lastWorldViewport = Rectangle.Empty;
 		ITexture currentPaletteTexture;
+		int currentPaletteHeight = 0;
 		IBatchRenderer currentBatchRenderer;
 		RenderType renderType = RenderType.None;
 
@@ -309,11 +310,13 @@ namespace OpenRA
 		{
 			// Note: palette.Texture and palette.ColorShifts are updated at the same time
 			// so we only need to check one of the two to know whether we must update the textures
-			if (palette.Texture == currentPaletteTexture)
+			// also compare heights in case new palettes have been added
+			if (palette.Texture == currentPaletteTexture && palette.Height == currentPaletteHeight)
 				return;
 
 			Flush();
 			currentPaletteTexture = palette.Texture;
+			currentPaletteHeight = palette.Height;
 
 			SpriteRenderer.SetPalette(palette);
 			WorldSpriteRenderer.SetPalette(palette);


### PR DESCRIPTION
Adding multiplayer spawn points in the map editor adds a new palette for each player, which can in turn lead to the palette texture's height being increased. Since the actual texture remains unchanged after the height change, refreshing the palette was exited early leading to the graphical error. With this fix refreshing the palette will also work if only the height has changed.

All four mods are affected; this fix leads to correct behaviour in all mods.

Fixes #21313.