### PR TITLE
Teach CheckTranslationReference about translations in Lua scripts

### DIFF
--- a/mods/common/scripts/utils.lua
+++ b/mods/common/scripts/utils.lua
@@ -7,26 +7,6 @@
    information, see COPYING.
 ]]
 
----Adds a new mandatory objective, translates it and announces it via in-game chat message.
----@param player player recipient of the objective
----@param description string key of the translation string
----@return number id used to query for the objective later
-AddPrimaryObjective = function(player, description)
-	local translation = UserInterface.Translate(description)
-	Media.DisplayMessageToPlayer(player, translation, UserInterface.Translate("new-primary-objective"))
-	return player.AddObjective(translation, UserInterface.Translate("primary"), true)
-end
-
----Adds a new optional objective, translates it and announces it via in-game chat message.
----@param player player recipient of the objective
----@param description string key of the translation string
----@return number id used to query for the objective later
-AddSecondaryObjective = function(player, description)
-	local translation = UserInterface.Translate(description)
-	Media.DisplayMessageToPlayer(player, translation, UserInterface.Translate("new-secondary-objective"))
-	return player.AddObjective(translation, UserInterface.Translate("secondary"), false)
-end
-
 IdleHunt = function(actor)
 	if actor.HasProperty("Hunt") and not actor.IsDead then
 		Trigger.OnIdle(actor, actor.Hunt)
@@ -39,7 +19,6 @@ end
 ---@return number id used to query for the objective later
 AddPrimaryObjective = function(player, description)
 	local translation = UserInterface.Translate(description)
-
 	Media.DisplayMessageToPlayer(player, translation, UserInterface.Translate("new-primary-objective"))
 	return player.AddObjective(translation, UserInterface.Translate("primary"), true)
 end
@@ -50,7 +29,6 @@ end
 ---@return number id used to query for the objective later
 AddSecondaryObjective = function(player, description)
 	local translation = UserInterface.Translate(description)
-
 	Media.DisplayMessageToPlayer(player, translation, UserInterface.Translate("new-secondary-objective"))
 	return player.AddObjective(translation, UserInterface.Translate("secondary"), false)
 end

--- a/mods/d2k/maps/atreides-01a/atreides01a.lua
+++ b/mods/d2k/maps/atreides-01a/atreides01a.lua
@@ -87,8 +87,8 @@ Tick = function()
 	end
 
 	if Atreides.Resources ~= CachedResources then
-		local parameters = { ["harvested"] = Atreides.Resources, ["goal"] = SpiceToHarvest }
-		local harvestedResources = UserInterface.Translate("harvested-resources", parameters)
+		local harvestedResources = UserInterface.Translate("harvested-resources",
+			{ ["harvested"] = Atreides.Resources, ["goal"] = SpiceToHarvest })
 		UserInterface.SetMissionText(harvestedResources)
 		CachedResources = Atreides.Resources
 	end

--- a/mods/d2k/maps/atreides-01b/atreides01b.lua
+++ b/mods/d2k/maps/atreides-01b/atreides01b.lua
@@ -87,8 +87,8 @@ Tick = function()
 	end
 
 	if Atreides.Resources ~= CachedResources then
-		local parameters = { ["harvested"] = Atreides.Resources, ["goal"] = SpiceToHarvest }
-		local harvestedResources = UserInterface.Translate("harvested-resources", parameters)
+		local harvestedResources = UserInterface.Translate("harvested-resources",
+			{ ["harvested"] = Atreides.Resources, ["goal"] = SpiceToHarvest })
 		UserInterface.SetMissionText(harvestedResources)
 		CachedResources = Atreides.Resources
 	end

--- a/mods/d2k/maps/atreides-03a/atreides03a.lua
+++ b/mods/d2k/maps/atreides-03a/atreides03a.lua
@@ -110,8 +110,8 @@ Tick = function()
 	end
 
 	if Atreides.Resources ~= CachedResources then
-		local parameters = { ["harvested"] = Atreides.Resources, ["goal"] = SpiceToHarvest }
-		local harvestedResources = UserInterface.Translate("harvested-resources", parameters)
+		local harvestedResources = UserInterface.Translate("harvested-resources",
+			{ ["harvested"] = Atreides.Resources, ["goal"] = SpiceToHarvest })
 		UserInterface.SetMissionText(harvestedResources)
 		CachedResources = Atreides.Resources
 	end

--- a/mods/d2k/maps/atreides-03b/atreides03b.lua
+++ b/mods/d2k/maps/atreides-03b/atreides03b.lua
@@ -110,8 +110,8 @@ Tick = function()
 	end
 
 	if Atreides.Resources ~= CachedResources then
-		local parameters = { ["harvested"] = Atreides.Resources, ["goal"] = SpiceToHarvest }
-		local harvestedResources = UserInterface.Translate("harvested-resources", parameters)
+		local harvestedResources = UserInterface.Translate("harvested-resources",
+			{ ["harvested"] = Atreides.Resources, ["goal"] = SpiceToHarvest })
 		UserInterface.SetMissionText(harvestedResources)
 		CachedResources = Atreides.Resources
 	end

--- a/mods/d2k/maps/atreides-05/atreides05.lua
+++ b/mods/d2k/maps/atreides-05/atreides05.lua
@@ -305,8 +305,8 @@ WorldLoaded = function()
 
 	Trigger.AfterDelay(DateTime.Seconds(2), function()
 		TimerTicks = ContrabandTimes[Difficulty]
-		local time = { ["time"] = Utils.FormatTime(TimerTicks) }
-		local contrabandApproaching = UserInterface.Translate("contraband-approaching-starport-north-in", time)
+		local time = Utils.FormatTime(TimerTicks)
+		local contrabandApproaching = UserInterface.Translate("contraband-approaching-starport-north-in", { ["time"] = time })
 		Media.DisplayMessage(contrabandApproaching, Mentat)
 	end)
 

--- a/mods/d2k/maps/harkonnen-01a/harkonnen01a.lua
+++ b/mods/d2k/maps/harkonnen-01a/harkonnen01a.lua
@@ -87,8 +87,8 @@ Tick = function()
 	end
 
 	if Harkonnen.Resources ~= CachedResources then
-		local parameters = { ["harvested"] = Harkonnen.Resources, ["goal"] = SpiceToHarvest }
-		local harvestedResources = UserInterface.Translate("harvested-resources", parameters)
+		local harvestedResources = UserInterface.Translate("harvested-resources",
+			{ ["harvested"] = Harkonnen.Resources, ["goal"] = SpiceToHarvest })
 		UserInterface.SetMissionText(harvestedResources)
 		CachedResources = Harkonnen.Resources
 	end

--- a/mods/d2k/maps/harkonnen-01b/harkonnen01b.lua
+++ b/mods/d2k/maps/harkonnen-01b/harkonnen01b.lua
@@ -87,8 +87,8 @@ Tick = function()
 	end
 
 	if Harkonnen.Resources ~= CachedResources then
-		local parameters = { ["harvested"] = Harkonnen.Resources, ["goal"] = SpiceToHarvest }
-		local harvestedResources = UserInterface.Translate("harvested-resources", parameters)
+		local harvestedResources = UserInterface.Translate("harvested-resources",
+			{ ["harvested"] = Harkonnen.Resources, ["goal"] = SpiceToHarvest })
 		UserInterface.SetMissionText(harvestedResources)
 		CachedResources = Harkonnen.Resources
 	end

--- a/mods/d2k/maps/ordos-01a/ordos01a.lua
+++ b/mods/d2k/maps/ordos-01a/ordos01a.lua
@@ -87,8 +87,8 @@ Tick = function()
 	end
 
 	if Ordos.Resources ~= CachedResources then
-		local parameters = { ["harvested"] = Ordos.Resources, ["goal"] = SpiceToHarvest }
-		local harvestedResources = UserInterface.Translate("harvested-resources", parameters)
+		local harvestedResources = UserInterface.Translate("harvested-resources",
+			{ ["harvested"] = Ordos.Resources, ["goal"] = SpiceToHarvest })
 		UserInterface.SetMissionText(harvestedResources)
 		CachedResources = Ordos.Resources
 	end

--- a/mods/d2k/maps/ordos-01b/ordos01b.lua
+++ b/mods/d2k/maps/ordos-01b/ordos01b.lua
@@ -87,8 +87,8 @@ Tick = function()
 	end
 
 	if Ordos.Resources ~= CachedResources then
-		local parameters = { ["harvested"] = Ordos.Resources, ["goal"] = SpiceToHarvest }
-		local harvestedResources = UserInterface.Translate("harvested-resources", parameters)
+		local harvestedResources = UserInterface.Translate("harvested-resources",
+			{ ["harvested"] = Ordos.Resources, ["goal"] = SpiceToHarvest })
 		UserInterface.SetMissionText(harvestedResources)
 		CachedResources = Ordos.Resources
 	end

--- a/mods/d2k/maps/ordos-05/ordos05.lua
+++ b/mods/d2k/maps/ordos-05/ordos05.lua
@@ -132,8 +132,8 @@ Tick = function()
 
 	if Ordos.IsObjectiveCompleted(CaptureStarport) then
 		if Ordos.Resources ~= CachedResources then
-			local parameters = { ["harvested"] = Ordos.Resources, ["goal"] = SpiceToHarvest }
-			local harvestedResources = UserInterface.Translate("harvested-resources", parameters)
+			local harvestedResources = UserInterface.Translate("harvested-resources",
+				{ ["harvested"] = Ordos.Resources, ["goal"] = SpiceToHarvest })
 			UserInterface.SetMissionText(harvestedResources)
 			CachedResources = Ordos.Resources
 		end

--- a/mods/d2k/maps/ordos-06a/ordos06a.lua
+++ b/mods/d2k/maps/ordos-06a/ordos06a.lua
@@ -211,10 +211,10 @@ Tick = function()
 			FirstIxiansArrived = true
 			SendContraband()
 		elseif (TimerTicks % DateTime.Seconds(1)) == 0 then
-			local time = { ["time"] = Utils.FormatTime(TimerTicks) }
-			local reinforcementsText = UserInterface.Translate("initial-reinforcements-arrive-in", time)
+			local time = Utils.FormatTime(TimerTicks)
+			local reinforcementsText = UserInterface.Translate("initial-reinforcements-arrive-in", { ["time"] = time })
 			if FirstIxiansArrived then
-				reinforcementsText = UserInterface.Translate("additional-reinforcements-arrive-in", time)
+				reinforcementsText = UserInterface.Translate("additional-reinforcements-arrive-in", { ["time"] = time })
 			end
 
 			UserInterface.SetMissionText(reinforcementsText, Ordos.Color)
@@ -244,8 +244,8 @@ WorldLoaded = function()
 
 	Trigger.AfterDelay(DateTime.Seconds(2), function()
 		TimerTicks = InitialContrabandTimes[Difficulty]
-		local time = { ["time"] = Utils.FormatTime(TimerTicks) }
-		Media.DisplayMessage(UserInterface.Translate("ixian-reinforcements-in", time), Mentat)
+		local time = Utils.FormatTime(TimerTicks)
+		Media.DisplayMessage(UserInterface.Translate("ixian-reinforcements-in", { ["time"] = time }), Mentat)
 	end)
 
 	Hunt(Atreides)

--- a/mods/ra/maps/exodus/exodus.lua
+++ b/mods/ra/maps/exodus/exodus.lua
@@ -90,7 +90,7 @@ ReinforcementsTicks2 = DateTime.Minutes(10)
 Reinforcements2 =
 {
 	"mgg", "2tnk", "2tnk", "2tnk", "2tnk", "truk", "truk", "truk",
-	"truk",	"truk", "truk", "1tnk", "1tnk", "jeep", "jeep"
+	"truk", "truk", "truk", "1tnk", "1tnk", "jeep", "jeep"
 }
 
 SovietUnits1 =
@@ -230,8 +230,8 @@ ManageSovietAircraft = function()
 end
 
 SetEvacuateMissionText = function()
-	local attributes = { ["evacuated"] = UnitsEvacuated, ["threshold"] = UnitsEvacuatedThreshold[Difficulty] }
-	local unitsEvacuated = UserInterface.Translate("units-evacuated", attributes)
+	local unitsEvacuated = UserInterface.Translate("units-evacuated",
+		{ ["evacuated"] = UnitsEvacuated, ["threshold"] = UnitsEvacuatedThreshold[Difficulty] })
 	UserInterface.SetMissionText(unitsEvacuated, TextColor)
 end
 

--- a/mods/ra/maps/fall-of-greece-2-evacuation/evacuation.lua
+++ b/mods/ra/maps/fall-of-greece-2-evacuation/evacuation.lua
@@ -178,8 +178,8 @@ VillageSetup = function()
 end
 
 SetCivilianEvacuatedText = function()
-	local attributes = { ["evacuated"] = CiviliansEvacuated, ["threshold"] = CiviliansEvacuatedThreshold }
-	local civiliansEvacuated = UserInterface.Translate("civilians-evacuated", attributes)
+	local civiliansEvacuated = UserInterface.Translate("civilians-evacuated",
+		{ ["evacuated"] = CiviliansEvacuated, ["threshold"] = CiviliansEvacuatedThreshold })
 	UserInterface.SetMissionText(civiliansEvacuated, TextColor)
 end
 


### PR DESCRIPTION
Using the glory of regex, we can scrape any Lua script files that a map includes and locate calls to the UserInterface.Translate method. We can then treat them in the same way as C# fields marked with a TranslationReferenceAttribute. This allows the lint check to validate the translation invoked in the .lua script has a matching entry in the translation .ftl files, with all the required arguments (if any).

We can also locate any calls to AddPrimaryObjective or AddSecondaryObjective defined by the utils.lua script, which also accept translation keys.

The are a couple of restrictions:
- When linting the map, we don't check for keys in the ftl file that are unused. This is because the linter doesn't load all the keys when checking maps.
- In order to validate translation arguments with the regex, we require the Lua script to pass the table of arguments inline at the callsite. If it does not, we raise a warning so the user can adjust the code.

----

Example by modifying allies-01:

https://github.com/OpenRA/OpenRA/blob/5ddc7b1177d28ec9f867677d074b2d64392b854a/mods/ra/maps/allies-01/allies01.lua#L28

to be:

```lua
Media.DisplayMessage(UserInterface.Translate("tanya-rules-of-engagement-2"), UserInterface.Translate("tanya", { ["some-arg"] = 1 }))
local argsFromAVariable = { ["some-arg"] = 1 }
UserInterface.Translate("tanya", argsFromAVariable)
```

Run the utility with `ra --check-yaml`

gives the following logs:

```
Testing map: 01:   In the Thick of It
OpenRA.Utility(1,1): Warning: Script allies01.lua:30 calls UserInterface.Translate with key `tanya` and translate args passed as `argsFromAVariable`. Inline the args at the callsite for lint analysis.
OpenRA.Utility(1,1): Error: Missing variable `some-arg` for key `tanya` in ra|languages/lua/en.ftl
OpenRA.Utility(1,1): Warning: Missing key `tanya-rules-of-engagement-2` in `en` language in map translation files required by Script allies01.lua:28
```

~~We could look to later extend this to other Lua calls where a translation-key should be passed, but this seems like a nice starting point.~~

Recommend viewing the diff with whitespace changes hidden.

Assists with #10475