### PR TITLE
Fix movement on ramps when moving to a subcell

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -451,7 +451,13 @@ namespace OpenRA.Mods.Common.Activities
 
 				if (progress >= Distance)
 				{
-					mobile.SetCenterPosition(self, To);
+					var toPos = To;
+
+					// apply ramp offset to ground units
+					if (MovingOnGroundLayer)
+						toPos -= new WVec(WDist.Zero, WDist.Zero, self.World.Map.DistanceAboveTerrain(toPos));
+					mobile.SetCenterPosition(self, toPos);
+
 					mobile.Facing = TurnsWhileMoving
 						? Util.TickFacing(mobile.Facing, ToFacing, mobile.TurnSpeed)
 						: ToFacing;

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -471,8 +471,10 @@ namespace OpenRA.Mods.Common.Traits
 			var position = cell.Layer == 0 ? self.World.Map.CenterOfCell(cell) :
 				self.World.GetCustomMovementLayers()[cell.Layer].CenterOfCell(cell);
 
-			var subcellOffset = self.World.Map.Grid.OffsetOfSubCell(subCell);
-			SetCenterPosition(self, position + subcellOffset);
+			position += self.World.Map.Grid.OffsetOfSubCell(subCell);
+			position -= new WVec(0, 0, self.World.Map.DistanceAboveTerrain(position).Length);
+
+			SetCenterPosition(self, position);
 			FinishedMoving(self);
 		}
 


### PR DESCRIPTION
When infantry moves on ramps their position's Z value got reset to the cell center's height despite them moving to a subcell that is off-center. Also when ending their movement there was some adjusting to the X and Y position that left the Z value unchanged. As a result infantry on a ramp would always end up with a non-zero distance above ground.

This fix keeps ground units at the correct height for the ramp they are on even if they don't end their movement at the cell's center.

Fixes #21375