### PR TITLE
Put PlaceBeacon cursor in reference attribute

### DIFF
--- a/OpenRA.Mods.Common/Orders/BeaconOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/BeaconOrderGenerator.cs
@@ -17,6 +17,8 @@ namespace OpenRA.Mods.Common.Orders
 {
 	public class BeaconOrderGenerator : OrderGenerator
 	{
+		public string BeaconCursor;
+
 		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			world.CancelInputMode();
@@ -30,7 +32,8 @@ namespace OpenRA.Mods.Common.Orders
 		protected override IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world) { yield break; }
 		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
-			return "ability"; // TODO: [CursorReference]
+			// Always return the beacon cursor as the command cannot be blocked.
+			return BeaconCursor;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
@@ -41,6 +41,9 @@ namespace OpenRA.Mods.Common.Traits
 		[SequenceReference(nameof(BeaconImage))]
 		public readonly string CircleSequence = "circles";
 
+		[CursorReference]
+		public readonly string BeaconCursor = "ability";
+
 		public override object Create(ActorInitializer init) { return new PlaceBeacon(init.Self, this); }
 	}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/OrderButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/OrderButtonsChromeLogic.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System;
 using OpenRA.Mods.Common.Orders;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Orders;
 using OpenRA.Widgets;
 
@@ -47,20 +49,24 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 	public class BeaconOrderButtonLogic : ChromeLogic
 	{
+		static string beaconCursor;
+
 		[ObjectCreator.UseCtor]
 		public BeaconOrderButtonLogic(Widget widget, World world)
 		{
+			beaconCursor ??= world.LocalPlayer.PlayerActor.Info.TraitInfo<PlaceBeaconInfo>().BeaconCursor;
+
 			if (widget is ButtonWidget beacon)
-				OrderButtonsChromeUtils.BindOrderButton<BeaconOrderGenerator>(world, beacon, "beacon");
+				OrderButtonsChromeUtils.BindOrderButton<BeaconOrderGenerator>(world, beacon, "beacon", og => og.BeaconCursor = beaconCursor);
 		}
 	}
 
 	public static class OrderButtonsChromeUtils
 	{
-		public static void BindOrderButton<T>(World world, ButtonWidget w, string icon)
+		public static void BindOrderButton<T>(World world, ButtonWidget w, string icon, Action<T> initializeOrderGenerator = null)
 			where T : IOrderGenerator, new()
 		{
-			w.OnClick = () => world.ToggleInputMode<T>();
+			w.OnClick = () => { world.ToggleInputMode<T>(); if (world.OrderGenerator is T t) initializeOrderGenerator?.Invoke(t); };
 			w.IsHighlighted = () => world.OrderGenerator is T;
 
 			w.Get<ImageWidget>("ICON").GetImageName =


### PR DESCRIPTION
Put the default "ability" into the CursorReference of `PlaceBeaconInfo`. This way other mods can override it with their own cursor by changing the player.yaml. There is only a single cursor reference necessary as the order cannot be blocked.

Closes #20850.