### PR TITLE
Fix untranslated factions in GameInfoStats

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -260,7 +260,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							: TranslationProvider.GetString(pp.Faction.Name);
 					}
 					else
+					{
 						flag.GetImageName = () => pp.DisplayFaction.InternalName;
+						factionName = TranslationProvider.GetString(factionName);
+					}
 
 					WidgetUtils.TruncateLabelToTooltip(item.Get<LabelWithTooltipWidget>("FACTION"), factionName);
 


### PR DESCRIPTION
![Before](https://github.com/user-attachments/assets/85c64d62-fe15-4406-9d33-1864355f96fa)
![After](https://github.com/user-attachments/assets/a813821f-5433-4382-9fd7-2ff3fd84e7f8)
This is intended to fix untranslated faction names for unallied players. I'm well outside my comfort zone when tinkering with the C# side, so corrections are extra welcome.