### PR TITLE
Order help commands by name

### DIFF
--- a/OpenRA.Mods.Common/Commands/ChatCommands.cs
+++ b/OpenRA.Mods.Common/Commands/ChatCommands.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -37,10 +36,9 @@ namespace OpenRA.Mods.Common.Commands
 			if (message.StartsWith('/'))
 			{
 				var name = message[1..].Split(' ')[0].ToLowerInvariant();
-				var command = Commands.FirstOrDefault(x => x.Key == name);
 
-				if (command.Value != null)
-					command.Value.InvokeCommand(name.ToLowerInvariant(), message[(1 + name.Length)..].Trim());
+				if (Commands.TryGetValue(name, out var command))
+					command.InvokeCommand(name, message[(1 + name.Length)..].Trim());
 				else
 					TextNotificationsManager.Debug(TranslationProvider.GetString(InvalidCommand, Translation.Arguments("name", name)));
 

--- a/OpenRA.Mods.Common/Commands/HelpCommand.cs
+++ b/OpenRA.Mods.Common/Commands/HelpCommand.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Traits;
 
@@ -53,7 +54,7 @@ namespace OpenRA.Mods.Common.Commands
 		{
 			TextNotificationsManager.Debug(TranslationProvider.GetString(AvailableCommands));
 
-			foreach (var key in console.Commands.Keys)
+			foreach (var key in console.Commands.Keys.OrderBy(k => k))
 			{
 				if (!helpDescriptions.TryGetValue(key, out var description))
 					description = TranslationProvider.GetString(NoDescription);


### PR DESCRIPTION
A small usability improvement when uisng the `/help` text command.