### PR TITLE
Enforce a line length limit.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -982,7 +982,7 @@ dotnet_analyzer_diagnostic.category-roslynator.severity = none
 
 # A line is too long.
 dotnet_diagnostic.RCS0056.severity = warning
-roslynator_max_line_length = 180 #140
+roslynator_max_line_length = 160 #140
 #roslynator_tab_length = 4
 
 # Remove redundant 'sealed' modifier.

--- a/.editorconfig
+++ b/.editorconfig
@@ -976,7 +976,14 @@ dotnet_diagnostic.CA2259.severity = suggestion # TODO: Change to warning once us
 
 # We disable the rule category by setting severity to none.
 # Below we enable specific rules by setting severity to warning.
+# Rules are listed below with any options available.
+# Options are commented out if they match the defaults.
 dotnet_analyzer_diagnostic.category-roslynator.severity = none
+
+# A line is too long.
+dotnet_diagnostic.RCS0056.severity = warning
+roslynator_max_line_length = 180 #140
+#roslynator_tab_length = 4
 
 # Remove redundant 'sealed' modifier.
 dotnet_diagnostic.RCS1034.severity = warning

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -56,5 +56,6 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="All" />
     <!-- Roslynator analyzers fail to run under Mono (AD0001) -->
     <PackageReference Include="Roslynator.Analyzers" Version="4.2.0" PrivateAssets="All" Condition="'$(MSBuildRuntimeType)'!='Mono'" />
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.2.0" PrivateAssets="All" Condition="'$(MSBuildRuntimeType)'!='Mono'" />
   </ItemGroup>
 </Project>

--- a/OpenRA.Game/CVec.cs
+++ b/OpenRA.Game/CVec.cs
@@ -17,7 +17,8 @@ using OpenRA.Scripting;
 
 namespace OpenRA
 {
-	public readonly struct CVec : IScriptBindable, ILuaAdditionBinding, ILuaSubtractionBinding, ILuaUnaryMinusBinding, ILuaEqualityBinding, ILuaTableBinding, IEquatable<CVec>
+	public readonly struct CVec : IScriptBindable,
+		ILuaAdditionBinding, ILuaSubtractionBinding, ILuaUnaryMinusBinding, ILuaEqualityBinding, ILuaTableBinding, IEquatable<CVec>
 	{
 		public readonly int X, Y;
 

--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -324,7 +324,8 @@ namespace OpenRA.FileSystem
 				if (name == ".")
 					continue;
 
-				resolved = Directory.GetFileSystemEntries(resolved).FirstOrDefault(e => e.Equals(Path.Combine(resolved, name), StringComparison.InvariantCultureIgnoreCase));
+				resolved = Directory.GetFileSystemEntries(resolved)
+					.FirstOrDefault(e => e.Equals(Path.Combine(resolved, name), StringComparison.InvariantCultureIgnoreCase));
 
 				if (resolved == null)
 					return null;

--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -58,13 +58,16 @@ namespace OpenRA.Graphics
 			var tintModifiers = CurrentSequence.IgnoreWorldTint ? TintModifiers.IgnoreWorldTint : TintModifiers.None;
 			var alpha = CurrentSequence.GetAlpha(CurrentFrame);
 			var (image, rotation) = CurrentSequence.GetSpriteWithRotation(CurrentFrame, facingFunc());
-			var imageRenderable = new SpriteRenderable(image, pos, offset, CurrentSequence.ZOffset + zOffset, palette, CurrentSequence.Scale, alpha, float3.Ones, tintModifiers, IsDecoration,
-				rotation);
+			var imageRenderable = new SpriteRenderable(
+				image, pos, offset, CurrentSequence.ZOffset + zOffset, palette,
+				CurrentSequence.Scale, alpha, float3.Ones, tintModifiers, IsDecoration, rotation);
 
 			var shadow = CurrentSequence.GetShadow(CurrentFrame, facingFunc());
 			if (shadow != null)
 			{
-				var shadowRenderable = new SpriteRenderable(shadow, pos, offset, CurrentSequence.ShadowZOffset + zOffset, palette, CurrentSequence.Scale, 1f, float3.Ones, tintModifiers,
+				var shadowRenderable = new SpriteRenderable(
+					shadow, pos, offset, CurrentSequence.ShadowZOffset + zOffset, palette,
+					CurrentSequence.Scale, 1f, float3.Ones, tintModifiers,
 					true, rotation);
 				return new IRenderable[] { shadowRenderable, imageRenderable };
 			}

--- a/OpenRA.Game/Graphics/ChromeProvider.cs
+++ b/OpenRA.Game/Graphics/ChromeProvider.cs
@@ -228,7 +228,11 @@ namespace OpenRA.Graphics
 					(PanelSides.Bottom | PanelSides.Right, new Rectangle(pr[0] + pr[2] + pr[4], pr[1] + pr[3] + pr[5], pr[6], pr[7]))
 				};
 
-				sprites = sides.Select(x => ps.HasSide(x.PanelSides) ? new Sprite(sheetDensity.Sheet, sheetDensity.Density * x.Bounds, TextureChannel.RGBA, 1f / sheetDensity.Density) : null)
+				sprites = sides
+					.Select(x =>
+						ps.HasSide(x.PanelSides)
+							? new Sprite(sheetDensity.Sheet, sheetDensity.Density * x.Bounds, TextureChannel.RGBA, 1f / sheetDensity.Density)
+							: null)
 					.ToArray();
 			}
 			else

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -25,7 +25,8 @@ namespace OpenRA
 
 	public interface IPlatform
 	{
-		IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int vertexBatchSize, int indexBatchSize, int videoDisplay, GLProfile profile);
+		IPlatformWindow CreateWindow(
+			Size size, WindowMode windowMode, float scaleModifier, int vertexBatchSize, int indexBatchSize, int videoDisplay, GLProfile profile);
 		ISoundEngine CreateSound(string device);
 		IFont CreateFont(byte[] data);
 	}

--- a/OpenRA.Game/Graphics/RgbaColorRenderer.cs
+++ b/OpenRA.Game/Graphics/RgbaColorRenderer.cs
@@ -216,7 +216,8 @@ namespace OpenRA.Graphics
 			parent.DrawRGBAQuad(vertices, blendMode);
 		}
 
-		public void FillRect(in float3 a, in float3 b, in float3 c, in float3 d, Color topLeftColor, Color topRightColor, Color bottomRightColor, Color bottomLeftColor, BlendMode blendMode = BlendMode.Alpha)
+		public void FillRect(in float3 a, in float3 b, in float3 c, in float3 d,
+			Color topLeftColor, Color topRightColor, Color bottomRightColor, Color bottomLeftColor, BlendMode blendMode = BlendMode.Alpha)
 		{
 			vertices[0] = VertexWithColor(a + Offset, topLeftColor);
 			vertices[1] = VertexWithColor(b + Offset, topRightColor);

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -142,7 +142,9 @@ namespace OpenRA.Graphics
 				p = int2.Zero;
 			}
 
-			var rect = new Sprite(Current, new Rectangle(p.X + margin, p.Y + margin, imageSize.Width, imageSize.Height), zRamp, spriteOffset, CurrentChannel, BlendMode.Alpha, scale);
+			var rect = new Sprite(
+				Current, new Rectangle(p.X + margin, p.Y + margin, imageSize.Width, imageSize.Height),
+				zRamp, spriteOffset, CurrentChannel, BlendMode.Alpha, scale);
 			p += new int2(imageSize.Width + margin, 0);
 
 			return rect;

--- a/OpenRA.Game/Graphics/SpriteCache.cs
+++ b/OpenRA.Game/Graphics/SpriteCache.cs
@@ -45,7 +45,8 @@ namespace OpenRA.Graphics
 			this.loaders = loaders;
 		}
 
-		public int ReserveSprites(string filename, IEnumerable<int> frames, MiniYamlNode.SourceLocation location, Func<ISpriteFrame, ISpriteFrame> adjustFrame = null, bool premultiplied = false)
+		public int ReserveSprites(string filename, IEnumerable<int> frames, MiniYamlNode.SourceLocation location,
+			Func<ISpriteFrame, ISpriteFrame> adjustFrame = null, bool premultiplied = false)
 		{
 			var token = nextReservationToken++;
 			spriteReservations[token] = (frames?.ToArray(), location, adjustFrame, premultiplied);

--- a/OpenRA.Game/Graphics/SpriteCache.cs
+++ b/OpenRA.Game/Graphics/SpriteCache.cs
@@ -24,7 +24,9 @@ namespace OpenRA.Graphics
 		readonly ISpriteLoader[] loaders;
 		readonly IReadOnlyFileSystem fileSystem;
 
-		readonly Dictionary<int, (int[] Frames, MiniYamlNode.SourceLocation Location, Func<ISpriteFrame, ISpriteFrame> AdjustFrame, bool Premultiplied)> spriteReservations = new();
+		readonly Dictionary<
+			int,
+			(int[] Frames, MiniYamlNode.SourceLocation Location, Func<ISpriteFrame, ISpriteFrame> AdjustFrame, bool Premultiplied)> spriteReservations = new();
 		readonly Dictionary<string, List<int>> reservationsByFilename = new();
 
 		readonly Dictionary<int, Sprite[]> resolvedSprites = new();
@@ -33,7 +35,8 @@ namespace OpenRA.Graphics
 
 		int nextReservationToken = 1;
 
-		public SpriteCache(IReadOnlyFileSystem fileSystem, ISpriteLoader[] loaders, int bgraSheetSize, int indexedSheetSize, int bgraSheetMargin = 1, int indexedSheetMargin = 1)
+		public SpriteCache(
+			IReadOnlyFileSystem fileSystem, ISpriteLoader[] loaders, int bgraSheetSize, int indexedSheetSize, int bgraSheetMargin = 1, int indexedSheetMargin = 1)
 		{
 			SheetBuilders = new Dictionary<SheetType, SheetBuilder>
 			{

--- a/OpenRA.Game/Graphics/UISpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/UISpriteRenderable.cs
@@ -21,7 +21,8 @@ namespace OpenRA.Graphics
 		readonly float alpha;
 		readonly float rotation = 0f;
 
-		public UISpriteRenderable(Sprite sprite, WPos effectiveWorldPos, int2 screenPos, int zOffset, PaletteReference palette, float scale = 1f, float alpha = 1f, float rotation = 0f)
+		public UISpriteRenderable(Sprite sprite, WPos effectiveWorldPos, int2 screenPos, int zOffset, PaletteReference palette,
+			float scale = 1f, float alpha = 1f, float rotation = 0f)
 		{
 			this.sprite = sprite;
 			Pos = effectiveWorldPos;
@@ -47,7 +48,8 @@ namespace OpenRA.Graphics
 		public PaletteReference Palette { get; }
 		public int ZOffset { get; }
 
-		public IPalettedRenderable WithPalette(PaletteReference newPalette) { return new UISpriteRenderable(sprite, Pos, screenPos, ZOffset, newPalette, scale, alpha, rotation); }
+		public IPalettedRenderable WithPalette(PaletteReference newPalette) =>
+			new UISpriteRenderable(sprite, Pos, screenPos, ZOffset, newPalette, scale, alpha, rotation);
 		public IRenderable WithZOffset(int newOffset) { return this; }
 		public IRenderable OffsetBy(in WVec vec) { return this; }
 		public IRenderable AsDecoration() { return this; }

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -215,7 +215,9 @@ namespace OpenRA.Graphics
 				MinZoom = CalculateMinimumZoom(range.X, range.Y) * viewportSizes.DefaultScale;
 			}
 
-			MaxZoom = Math.Min(MinZoom * viewportSizes.MaxZoomScale, Game.Renderer.NativeResolution.Height * viewportSizes.DefaultScale / viewportSizes.MaxZoomWindowHeight);
+			MaxZoom = Math.Min(
+				MinZoom * viewportSizes.MaxZoomScale,
+				Game.Renderer.NativeResolution.Height * viewportSizes.DefaultScale / viewportSizes.MaxZoomWindowHeight);
 
 			if (unlockMinZoom)
 			{

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -410,10 +410,16 @@ namespace OpenRA
 		{
 			UpdateMaps();
 			var map = string.IsNullOrEmpty(initialUid) ? null : previews[initialUid];
-			if (map == null || map.Status != MapStatus.Available || !map.Visibility.HasFlag(MapVisibility.Lobby) || (map.Class != MapClassification.System && map.Class != MapClassification.User))
+			if (map == null ||
+				map.Status != MapStatus.Available ||
+				!map.Visibility.HasFlag(MapVisibility.Lobby) ||
+				(map.Class != MapClassification.System && map.Class != MapClassification.User))
 			{
 				var selected = previews.Values.Where(IsSuitableInitialMap).RandomOrDefault(random) ??
-					previews.Values.FirstOrDefault(m => m.Status == MapStatus.Available && m.Visibility.HasFlag(MapVisibility.Lobby) && (m.Class == MapClassification.System || m.Class == MapClassification.User));
+					previews.Values.FirstOrDefault(m =>
+					m.Status == MapStatus.Available &&
+					m.Visibility.HasFlag(MapVisibility.Lobby) &&
+					(m.Class == MapClassification.System || m.Class == MapClassification.User));
 				return selected == null ? string.Empty : selected.Uid;
 			}
 

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -140,7 +140,8 @@ namespace OpenRA
 			LoadMapInternal(map, package, classification, mapGrid, oldMap, null);
 		}
 
-		void LoadMapInternal(string map, IReadOnlyPackage package, MapClassification classification, MapGrid mapGrid, string oldMap, IEnumerable<List<MiniYamlNode>> modDataRules)
+		void LoadMapInternal(string map, IReadOnlyPackage package, MapClassification classification, MapGrid mapGrid, string oldMap,
+			IEnumerable<List<MiniYamlNode>> modDataRules)
 		{
 			IReadOnlyPackage mapPackage = null;
 			try
@@ -226,7 +227,8 @@ namespace OpenRA
 						yield return mapPackage;
 		}
 
-		public void QueryRemoteMapDetails(string repositoryUrl, IEnumerable<string> uids, Action<MapPreview> mapDetailsReceived = null, Action<MapPreview> mapQueryFailed = null)
+		public void QueryRemoteMapDetails(string repositoryUrl, IEnumerable<string> uids,
+			Action<MapPreview> mapDetailsReceived = null, Action<MapPreview> mapQueryFailed = null)
 		{
 			var queryUids = uids.Distinct()
 				.Where(uid => uid != null)

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -339,7 +339,8 @@ namespace OpenRA
 			}, null);
 		}
 
-		public void UpdateFromMap(IReadOnlyPackage p, IReadOnlyPackage parent, MapClassification classification, string[] mapCompatibility, MapGridType gridType, IEnumerable<List<MiniYamlNode>> modDataRules)
+		public void UpdateFromMap(IReadOnlyPackage p, IReadOnlyPackage parent, MapClassification classification,
+			string[] mapCompatibility, MapGridType gridType, IEnumerable<List<MiniYamlNode>> modDataRules)
 		{
 			Dictionary<string, MiniYaml> yaml;
 			using (var yamlStream = p.GetStream("map.yaml"))

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -148,8 +148,14 @@ namespace OpenRA
 							sources = sources.Append(RuleDefinitions.Nodes.Where(IsLoadableRuleDefinition).ToList());
 
 						var yamlNodes = MiniYaml.Merge(sources);
-						WorldActorInfo = new ActorInfo(modData.ObjectCreator, "world", yamlNodes.First(n => string.Equals(n.Key, "world", StringComparison.InvariantCultureIgnoreCase)).Value);
-						PlayerActorInfo = new ActorInfo(modData.ObjectCreator, "player", yamlNodes.First(n => string.Equals(n.Key, "player", StringComparison.InvariantCultureIgnoreCase)).Value);
+						WorldActorInfo = new ActorInfo(
+							modData.ObjectCreator,
+							"world",
+							yamlNodes.First(n => string.Equals(n.Key, "world", StringComparison.InvariantCultureIgnoreCase)).Value);
+						PlayerActorInfo = new ActorInfo(
+							modData.ObjectCreator,
+							"player",
+							yamlNodes.First(n => string.Equals(n.Key, "player", StringComparison.InvariantCultureIgnoreCase)).Value);
 						return;
 					}
 				}

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -444,7 +444,8 @@ namespace OpenRA
 				existingNodes.Add(overrideNode.WithValue(value));
 		}
 
-		static List<MiniYamlNode> ResolveInherits(MiniYaml node, Dictionary<string, MiniYaml> tree, ImmutableDictionary<string, MiniYamlNode.SourceLocation> inherited)
+		static List<MiniYamlNode> ResolveInherits(
+			MiniYaml node, Dictionary<string, MiniYaml> tree, ImmutableDictionary<string, MiniYamlNode.SourceLocation> inherited)
 		{
 			var resolved = new List<MiniYamlNode>(node.Nodes.Length);
 			var resolvedKeys = new HashSet<string>(node.Nodes.Length);

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -463,7 +463,8 @@ namespace OpenRA
 					}
 					catch (ArgumentException)
 					{
-						throw new YamlException($"{n.Location}: Parent type `{n.Value.Value}` was already inherited by this yaml tree at {inherited[n.Value.Value]} (note: may be from a derived tree)");
+						throw new YamlException(
+							$"{n.Location}: Parent type `{n.Value.Value}` was already inherited by this yaml tree at {inherited[n.Value.Value]} (note: may be from a derived tree)");
 					}
 
 					foreach (var r in ResolveInherits(parent, tree, inherited))

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -271,7 +271,15 @@ namespace OpenRA
 
 		public static Order FromGroupedOrder(Order grouped, Actor subject)
 		{
-			return new Order(grouped.OrderString, subject, grouped.Target, grouped.TargetString, grouped.Queued, grouped.ExtraActors, grouped.ExtraLocation, grouped.ExtraData);
+			return new Order(
+				grouped.OrderString,
+				subject,
+				grouped.Target,
+				grouped.TargetString,
+				grouped.Queued,
+				grouped.ExtraActors,
+				grouped.ExtraLocation,
+				grouped.ExtraData);
 		}
 
 		public static Order Command(string text)

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -78,7 +78,8 @@ namespace OpenRA
 		readonly Target target;
 		readonly Target visualFeedbackTarget;
 
-		Order(string orderString, Actor subject, in Target target, string targetString, bool queued, Actor[] extraActors, CPos extraLocation, uint extraData, Actor[] groupedActors = null)
+		Order(string orderString, Actor subject, in Target target, string targetString, bool queued,
+			Actor[] extraActors, CPos extraLocation, uint extraData, Actor[] groupedActors = null)
 		{
 			OrderString = orderString ?? "";
 			Subject = subject;

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -203,7 +203,8 @@ namespace OpenRA
 
 				default:
 				{
-					modernUserSupportPath = legacyUserSupportPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".openra") + Path.DirectorySeparatorChar;
+					modernUserSupportPath = legacyUserSupportPath =
+						Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".openra") + Path.DirectorySeparatorChar;
 					systemSupportPath = "/var/games/openra/";
 					break;
 				}

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -97,7 +97,8 @@ namespace OpenRA
 			}
 		}
 
-		public static FactionInfo ResolveFaction(string factionName, IEnumerable<FactionInfo> factionInfos, MersenneTwister playerRandom, bool requireSelectable = true)
+		public static FactionInfo ResolveFaction(
+			string factionName, IEnumerable<FactionInfo> factionInfos, MersenneTwister playerRandom, bool requireSelectable = true)
 		{
 			var selectableFactions = factionInfos
 				.Where(f => !requireSelectable || f.Selectable)

--- a/OpenRA.Game/Primitives/Polygon.cs
+++ b/OpenRA.Game/Primitives/Polygon.cs
@@ -66,7 +66,9 @@ namespace OpenRA.Primitives
 
 		public bool IntersectsWith(Rectangle rect)
 		{
-			var intersectsBoundingRect = BoundingRect.Left < rect.Right && BoundingRect.Right > rect.Left && BoundingRect.Top < rect.Bottom && BoundingRect.Bottom > rect.Top;
+			var intersectsBoundingRect =
+				BoundingRect.Left < rect.Right && BoundingRect.Right > rect.Left &&
+				BoundingRect.Top < rect.Bottom && BoundingRect.Bottom > rect.Top;
 			if (isRectangle)
 				return intersectsBoundingRect;
 
@@ -75,11 +77,13 @@ namespace OpenRA.Primitives
 				return false;
 
 			// Easy case 2: Rect and bounding box intersect in a cross shape
-			if ((rect.Left <= BoundingRect.Left && rect.Right >= BoundingRect.Right) || (rect.Top <= BoundingRect.Top && rect.Bottom >= BoundingRect.Bottom))
+			if ((rect.Left <= BoundingRect.Left && rect.Right >= BoundingRect.Right) ||
+				(rect.Top <= BoundingRect.Top && rect.Bottom >= BoundingRect.Bottom))
 				return true;
 
 			// Easy case 3: Corner of rect is inside the polygon
-			if (Vertices.PolygonContains(rect.TopLeft) || Vertices.PolygonContains(rect.TopRight) || Vertices.PolygonContains(rect.BottomLeft) || Vertices.PolygonContains(rect.BottomRight))
+			if (Vertices.PolygonContains(rect.TopLeft) || Vertices.PolygonContains(rect.TopRight) ||
+				Vertices.PolygonContains(rect.BottomLeft) || Vertices.PolygonContains(rect.BottomRight))
 				return true;
 
 			// Easy case 4: Polygon vertex is inside rect

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -337,7 +337,8 @@ namespace OpenRA
 			// Render the compositor buffers to the screen
 			// HACK / PERF: Fudge the coordinates to cover the actual window while keeping the buffer viewport parameters
 			// This saves us two redundant (and expensive) SetViewportParams each frame
-			RgbaSpriteRenderer.DrawSprite(screenSprite, new float3(0, lastBufferSize.Height, 0), new float3(lastBufferSize.Width / screenSprite.Size.X, -lastBufferSize.Height / screenSprite.Size.Y, 1f));
+			RgbaSpriteRenderer.DrawSprite(screenSprite, new float3(0, lastBufferSize.Height, 0),
+				new float3(lastBufferSize.Width / screenSprite.Size.X, -lastBufferSize.Height / screenSprite.Size.Y, 1f));
 			Flush();
 
 			Window.PumpInput(inputHandler);

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -289,7 +289,10 @@ namespace OpenRA
 				screenBuffer.Bind();
 
 				var scale = Window.EffectiveWindowScale;
-				var bufferScale = new float3((int)(screenSprite.Bounds.Width / scale) / worldSprite.Size.X, (int)(-screenSprite.Bounds.Height / scale) / worldSprite.Size.Y, 1f);
+				var bufferScale = new float3(
+					(int)(screenSprite.Bounds.Width / scale) / worldSprite.Size.X,
+					(int)(-screenSprite.Bounds.Height / scale) / worldSprite.Size.Y,
+					1f);
 
 				SpriteRenderer.SetAntialiasingPixelsPerTexel(Window.SurfaceSize.Height * 1f / worldSprite.Bounds.Height);
 				RgbaSpriteRenderer.DrawSprite(worldSprite, float3.Zero, bufferScale);

--- a/OpenRA.Game/Scripting/ScriptPlayerInterface.cs
+++ b/OpenRA.Game/Scripting/ScriptPlayerInterface.cs
@@ -15,8 +15,10 @@ namespace OpenRA.Scripting
 	{
 		readonly Player player;
 
-		protected override string DuplicateKeyError(string memberName) { return $"Player '{player.PlayerName}' defines the command '{memberName}' on multiple traits"; }
-		protected override string MemberNotFoundError(string memberName) { return $"Player '{player.PlayerName}' does not define a property '{memberName}'"; }
+		protected override string DuplicateKeyError(string memberName) =>
+			$"Player '{player.PlayerName}' defines the command '{memberName}' on multiple traits";
+		protected override string MemberNotFoundError(string memberName) =>
+			$"Player '{player.PlayerName}' does not define a property '{memberName}'";
 
 		public ScriptPlayerInterface(ScriptContext context, Player player)
 			: base(context)

--- a/OpenRA.Game/Server/PlayerMessageTracker.cs
+++ b/OpenRA.Game/Server/PlayerMessageTracker.cs
@@ -24,7 +24,10 @@ namespace OpenRA.Server
 		readonly Action<Connection, int, int, byte[]> dispatchOrdersToClient;
 		readonly Action<Connection, string, Dictionary<string, object>> sendLocalizedMessageTo;
 
-		public PlayerMessageTracker(Server server, Action<Connection, int, int, byte[]> dispatchOrdersToClient, Action<Connection, string, Dictionary<string, object>> sendLocalizedMessageTo)
+		public PlayerMessageTracker(
+			Server server,
+			Action<Connection, int, int, byte[]> dispatchOrdersToClient,
+			Action<Connection, string, Dictionary<string, object>> sendLocalizedMessageTo)
 		{
 			this.server = server;
 			this.dispatchOrdersToClient = dispatchOrdersToClient;

--- a/OpenRA.Game/Support/ExceptionHandler.cs
+++ b/OpenRA.Game/Support/ExceptionHandler.cs
@@ -44,7 +44,11 @@ namespace OpenRA
 			Log.Write("exception", $"Date: {DateTime.UtcNow:u}");
 			Log.Write("exception", $"Operating System: {Platform.CurrentPlatform} ({Platform.CurrentArchitecture}, {Environment.OSVersion})");
 			Log.Write("exception", $"Runtime Version: {Platform.RuntimeVersion}");
-			Log.Write("exception", $"Installed Language: {CultureInfo.InstalledUICulture.TwoLetterISOLanguageName} (Installed) {CultureInfo.CurrentCulture.TwoLetterISOLanguageName} (Current) {CultureInfo.CurrentUICulture.TwoLetterISOLanguageName} (Current UI)");
+			Log.Write("exception",
+				"Installed Language: " +
+				$"{CultureInfo.InstalledUICulture.TwoLetterISOLanguageName} (Installed) " +
+				$"{CultureInfo.CurrentCulture.TwoLetterISOLanguageName} (Current) " +
+				$"{CultureInfo.CurrentUICulture.TwoLetterISOLanguageName} (Current UI)");
 
 			var rpt = BuildExceptionReport(ex).ToString();
 			Log.Write("exception", rpt);

--- a/OpenRA.Game/Support/VariableExpression.cs
+++ b/OpenRA.Game/Support/VariableExpression.cs
@@ -629,7 +629,8 @@ namespace OpenRA.Support
 					if (lastToken.RightOperand == token.LeftOperand)
 					{
 						if (lastToken.RightOperand)
-							throw new InvalidDataException($"Missing value or sub-expression or there is an extra operator `{lastToken.Symbol}` at index {lastToken.Index} or `{token.Symbol}` at index {token.Index}");
+							throw new InvalidDataException(
+								$"Missing value or sub-expression or there is an extra operator `{lastToken.Symbol}` at index {lastToken.Index} or `{token.Symbol}` at index {token.Index}");
 						throw new InvalidDataException($"Missing binary operation before `{token.Symbol}` at index {token.Index}");
 					}
 				}
@@ -736,7 +737,10 @@ namespace OpenRA.Support
 						return IfThenElse(expression, One, Zero);
 				}
 
-				throw new InvalidProgramException($"Unable to convert ExpressionType.{Enum<ExpressionType>.GetValues()[(int)fromType]} to ExpressionType.{Enum<ExpressionType>.GetValues()[(int)toType]}");
+				throw new InvalidProgramException(
+					"Unable to convert " +
+					$"ExpressionType.{Enum<ExpressionType>.GetValues()[(int)fromType]} to " +
+					$"ExpressionType.{Enum<ExpressionType>.GetValues()[(int)toType]}");
 			}
 
 			public Expression Pop(ExpressionType type)

--- a/OpenRA.Game/Support/VariableExpression.cs
+++ b/OpenRA.Game/Support/VariableExpression.cs
@@ -629,8 +629,8 @@ namespace OpenRA.Support
 					if (lastToken.RightOperand == token.LeftOperand)
 					{
 						if (lastToken.RightOperand)
-							throw new InvalidDataException(
-								$"Missing value or sub-expression or there is an extra operator `{lastToken.Symbol}` at index {lastToken.Index} or `{token.Symbol}` at index {token.Index}");
+							throw new InvalidDataException("Missing value or sub-expression or there is an extra operator " +
+								$"`{lastToken.Symbol}` at index {lastToken.Index} or `{token.Symbol}` at index {token.Index}");
 						throw new InvalidDataException($"Missing binary operation before `{token.Symbol}` at index {token.Index}");
 					}
 				}
@@ -937,7 +937,9 @@ namespace OpenRA.Support
 						}
 
 						default:
-							throw new InvalidProgramException($"ConditionExpression.Compiler.Compile() is missing an expression builder for TokenType.{Enum<TokenType>.GetValues()[(int)t.Type]}");
+							throw new InvalidProgramException(
+								"ConditionExpression.Compiler.Compile() is missing an expression builder for " +
+								$"TokenType.{Enum<TokenType>.GetValues()[(int)t.Type]}");
 					}
 				}
 

--- a/OpenRA.Game/WAngle.cs
+++ b/OpenRA.Game/WAngle.cs
@@ -222,23 +222,31 @@ namespace OpenRA
 		public LuaValue Add(LuaRuntime runtime, LuaValue left, LuaValue right)
 		{
 			if (!left.TryGetClrValue(out WAngle a))
-				throw new LuaException($"Attempted to call WAngle.Add(WAngle, WAngle) with invalid arguments ({left.WrappedClrType().Name}, {right.WrappedClrType().Name})");
+				throw new LuaException(
+					"Attempted to call WAngle.Add(WAngle, WAngle) with invalid arguments " +
+					$"({left.WrappedClrType().Name}, {right.WrappedClrType().Name})");
 
 			if (right.TryGetClrValue(out WAngle b))
 				return new LuaCustomClrObject(a + b);
 
-			throw new LuaException($"Attempted to call WAngle.Add(WAngle, WAngle) with invalid arguments ({left.WrappedClrType().Name}, {right.WrappedClrType().Name})");
+			throw new LuaException(
+				"Attempted to call WAngle.Add(WAngle, WAngle) with invalid arguments " +
+				$"({left.WrappedClrType().Name}, {right.WrappedClrType().Name})");
 		}
 
 		public LuaValue Subtract(LuaRuntime runtime, LuaValue left, LuaValue right)
 		{
 			if (!left.TryGetClrValue(out WAngle a))
-				throw new LuaException($"Attempted to call WAngle.Subtract(WAngle, WAngle) with invalid arguments ({left.WrappedClrType().Name}, {right.WrappedClrType().Name})");
+				throw new LuaException(
+					"Attempted to call WAngle.Subtract(WAngle, WAngle) with invalid arguments " +
+					$"({left.WrappedClrType().Name}, {right.WrappedClrType().Name})");
 
 			if (right.TryGetClrValue(out WAngle b))
 				return new LuaCustomClrObject(a - b);
 
-			throw new LuaException($"Attempted to call WAngle.Subtract(WAngle, WAngle) with invalid arguments ({left.WrappedClrType().Name}, {right.WrappedClrType().Name})");
+			throw new LuaException(
+				"Attempted to call WAngle.Subtract(WAngle, WAngle) with invalid arguments " +
+				$"({left.WrappedClrType().Name}, {right.WrappedClrType().Name})");
 		}
 
 		public LuaValue Equals(LuaRuntime runtime, LuaValue left, LuaValue right)

--- a/OpenRA.Game/WDist.cs
+++ b/OpenRA.Game/WDist.cs
@@ -21,7 +21,8 @@ namespace OpenRA
 	/// <summary>
 	/// 1d world distance - 1024 units = 1 cell.
 	/// </summary>
-	public readonly struct WDist : IComparable, IComparable<WDist>, IEquatable<WDist>, IScriptBindable, ILuaAdditionBinding, ILuaSubtractionBinding, ILuaEqualityBinding, ILuaTableBinding
+	public readonly struct WDist : IComparable, IComparable<WDist>, IEquatable<WDist>,
+		IScriptBindable, ILuaAdditionBinding, ILuaSubtractionBinding, ILuaEqualityBinding, ILuaTableBinding
 	{
 		public readonly int Length;
 		public long LengthSquared => (long)Length * Length;

--- a/OpenRA.Game/WVec.cs
+++ b/OpenRA.Game/WVec.cs
@@ -17,7 +17,8 @@ using OpenRA.Support;
 
 namespace OpenRA
 {
-	public readonly struct WVec : IScriptBindable, ILuaAdditionBinding, ILuaSubtractionBinding, ILuaUnaryMinusBinding, ILuaEqualityBinding, ILuaTableBinding, IEquatable<WVec>
+	public readonly struct WVec : IScriptBindable,
+		ILuaAdditionBinding, ILuaSubtractionBinding, ILuaUnaryMinusBinding, ILuaEqualityBinding, ILuaTableBinding, IEquatable<WVec>
 	{
 		public readonly int X, Y, Z;
 

--- a/OpenRA.Mods.Cnc/Graphics/ClassicSpriteSequence.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ClassicSpriteSequence.cs
@@ -20,7 +20,8 @@ namespace OpenRA.Mods.Cnc.Graphics
 		public ClassicSpriteSequenceLoader(ModData modData)
 			: base(modData) { }
 
-		public override ISpriteSequence CreateSequence(ModData modData, string tileset, SpriteCache cache, string image, string sequence, MiniYaml data, MiniYaml defaults)
+		public override ISpriteSequence CreateSequence(
+			ModData modData, string tileset, SpriteCache cache, string image, string sequence, MiniYaml data, MiniYaml defaults)
 		{
 			return new ClassicSpriteSequence(cache, this, image, sequence, data, defaults);
 		}

--- a/OpenRA.Mods.Cnc/Graphics/ClassicTilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ClassicTilesetSpecificSpriteSequence.cs
@@ -21,7 +21,8 @@ namespace OpenRA.Mods.Cnc.Graphics
 		public ClassicTilesetSpecificSpriteSequenceLoader(ModData modData)
 			: base(modData) { }
 
-		public override ISpriteSequence CreateSequence(ModData modData, string tileset, SpriteCache cache, string image, string sequence, MiniYaml data, MiniYaml defaults)
+		public override ISpriteSequence CreateSequence(
+			ModData modData, string tileset, SpriteCache cache, string image, string sequence, MiniYaml data, MiniYaml defaults)
 		{
 			return new ClassicTilesetSpecificSpriteSequence(cache, this, image, sequence, data, defaults);
 		}

--- a/OpenRA.Mods.Cnc/Graphics/TeslaZapRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/TeslaZapRenderable.cs
@@ -41,7 +41,11 @@ namespace OpenRA.Mods.Cnc.Graphics
 		readonly WVec cachedLength;
 		IEnumerable<IFinalizedRenderable> cache;
 
-		public TeslaZapRenderable(WPos pos, int zOffset, in WVec length, string image, string brightSequence, int brightZaps, string dimSequence, int dimZaps, string palette)
+		public TeslaZapRenderable(
+			WPos pos, int zOffset, in WVec length, string image,
+			string brightSequence, int brightZaps,
+			string dimSequence, int dimZaps,
+			string palette)
 		{
 			Pos = pos;
 			ZOffset = zOffset;
@@ -68,8 +72,10 @@ namespace OpenRA.Mods.Cnc.Graphics
 			return new TeslaZapRenderable(Pos, ZOffset, length, image, brightSequence, brightZaps, dimSequence, dimZaps, palette);
 		}
 
-		public IRenderable WithZOffset(int newOffset) { return new TeslaZapRenderable(Pos, ZOffset, length, image, brightSequence, brightZaps, dimSequence, dimZaps, palette); }
-		public IRenderable OffsetBy(in WVec vec) { return new TeslaZapRenderable(Pos + vec, ZOffset, length, image, brightSequence, brightZaps, dimSequence, dimZaps, palette); }
+		public IRenderable WithZOffset(int newOffset) =>
+			new TeslaZapRenderable(Pos, ZOffset, length, image, brightSequence, brightZaps, dimSequence, dimZaps, palette);
+		public IRenderable OffsetBy(in WVec vec) =>
+			new TeslaZapRenderable(Pos + vec, ZOffset, length, image, brightSequence, brightZaps, dimSequence, dimZaps, palette);
 		public IRenderable AsDecoration() { return this; }
 
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }

--- a/OpenRA.Mods.Cnc/Installer/ExtractMixSourceAction.cs
+++ b/OpenRA.Mods.Cnc/Installer/ExtractMixSourceAction.cs
@@ -25,7 +25,9 @@ namespace OpenRA.Mods.Cnc.Installer
 		public void RunActionOnSource(MiniYaml actionYaml, string path, ModData modData, List<string> extracted, Action<string> updateMessage)
 		{
 			// Yaml path may be specified relative to a named directory (e.g. ^SupportDir) or the detected source path
-			var sourcePath = actionYaml.Value.StartsWith('^') ? Platform.ResolvePath(actionYaml.Value) : FS.ResolveCaseInsensitivePath(Path.Combine(path, actionYaml.Value));
+			var sourcePath = actionYaml.Value.StartsWith('^')
+				? Platform.ResolvePath(actionYaml.Value)
+				: FS.ResolveCaseInsensitivePath(Path.Combine(path, actionYaml.Value));
 
 			using (var source = File.OpenRead(sourcePath))
 			{

--- a/OpenRA.Mods.Cnc/Installer/ExtractMixSourceAction.cs
+++ b/OpenRA.Mods.Cnc/Installer/ExtractMixSourceAction.cs
@@ -49,9 +49,13 @@ namespace OpenRA.Mods.Cnc.Installer
 
 						Action<long> onProgress = null;
 						if (stream.Length < InstallFromSourceLogic.ShowPercentageThreshold)
-							updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.Extracing, Translation.Arguments("filename", displayFilename)));
+							updateMessage(TranslationProvider.GetString(
+								InstallFromSourceLogic.Extracing,
+								Translation.Arguments("filename", displayFilename)));
 						else
-							onProgress = b => updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", 100 * b / stream.Length)));
+							onProgress = b => updateMessage(TranslationProvider.GetString(
+								InstallFromSourceLogic.ExtractingProgress,
+								Translation.Arguments("filename", displayFilename, "progress", 100 * b / stream.Length)));
 
 						using (var target = File.OpenWrite(targetPath))
 						{

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
@@ -78,7 +78,8 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel) { }
 
-		public override Activity GetAttackActivity(Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
+		public override Activity GetAttackActivity(
+			Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 		{
 			return new ChargeAttack(this, newTarget, forceAttack, targetLineColor);
 		}

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -102,7 +102,9 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			get
 			{
-				yield return new TargetTypeOrderTargeter(new BitSet<TargetableType>("DetonateAttack"), "DetonateAttack", 5, info.AttackCursor, true, false) { ForceAttack = false };
+				yield return
+					new TargetTypeOrderTargeter(new BitSet<TargetableType>("DetonateAttack"), "DetonateAttack", 5, info.AttackCursor, true, false)
+					{ ForceAttack = false };
 
 				if (!initiated)
 					yield return new DeployOrderTargeter("Detonate", 5, () => info.DeployCursor);

--- a/OpenRA.Mods.Cnc/Traits/Render/WithVoxelBarrel.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithVoxelBarrel.cs
@@ -19,7 +19,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits.Render
 {
-	public class WithVoxelBarrelInfo : ConditionalTraitInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>, Requires<ArmamentInfo>, Requires<TurretedInfo>
+	public class WithVoxelBarrelInfo : ConditionalTraitInfo,
+		IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>, Requires<ArmamentInfo>, Requires<TurretedInfo>
 	{
 		[Desc("Voxel sequence name to use")]
 		public readonly string Sequence = "barrel";

--- a/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
@@ -19,7 +19,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits.Render
 {
-	public class WithVoxelWalkerBodyInfo : PausableConditionalTraitInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>, Requires<IMoveInfo>, Requires<IFacingInfo>
+	public class WithVoxelWalkerBodyInfo : PausableConditionalTraitInfo,
+		IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>, Requires<IMoveInfo>, Requires<IFacingInfo>
 	{
 		public readonly string Sequence = "idle";
 

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -209,7 +209,8 @@ namespace OpenRA.Mods.Cnc.Traits
 				var tiles = power.CellsMatching(xy, footprint, dimensions);
 				var palette = wr.Palette(((ChronoshiftPowerInfo)power.Info).TargetOverlayPalette);
 				foreach (var t in tiles)
-					yield return new SpriteRenderable(tile, wr.World.Map.CenterOfCell(t), WVec.Zero, -511, palette, 1f, alpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
+					yield return new SpriteRenderable(
+						tile, wr.World.Map.CenterOfCell(t), WVec.Zero, -511, palette, 1f, alpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
 			}
 
 			protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
@@ -310,7 +311,8 @@ namespace OpenRA.Mods.Cnc.Traits
 					var isValid = manager.Self.Owner.Shroud.IsExplored(t + delta);
 					var tile = isValid ? validTile : invalidTile;
 					var alpha = isValid ? validAlpha : invalidAlpha;
-					yield return new SpriteRenderable(tile, wr.World.Map.CenterOfCell(t + delta), WVec.Zero, -511, palette, 1f, alpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
+					yield return new SpriteRenderable(
+						tile, wr.World.Map.CenterOfCell(t + delta), WVec.Zero, -511, palette, 1f, alpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
 				}
 
 				// Unit previews
@@ -323,7 +325,8 @@ namespace OpenRA.Mods.Cnc.Traits
 							unit.Trait<Chronoshiftable>().CanChronoshiftTo(unit, targetCell);
 						var tile = canEnter ? validTile : invalidTile;
 						var alpha = canEnter ? validAlpha : invalidAlpha;
-						yield return new SpriteRenderable(tile, wr.World.Map.CenterOfCell(targetCell), WVec.Zero, -511, palette, 1f, alpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
+						yield return new SpriteRenderable(
+							tile, wr.World.Map.CenterOfCell(targetCell), WVec.Zero, -511, palette, 1f, alpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
 					}
 
 					var offset = world.Map.CenterOfCell(xy) - world.Map.CenterOfCell(sourceLocation);
@@ -353,7 +356,8 @@ namespace OpenRA.Mods.Cnc.Traits
 
 				// Source tiles
 				foreach (var t in power.CellsMatching(sourceLocation, footprint, dimensions))
-					yield return new SpriteRenderable(sourceTile, wr.World.Map.CenterOfCell(t), WVec.Zero, -511, palette, 1f, sourceAlpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
+					yield return new SpriteRenderable(
+						sourceTile, wr.World.Map.CenterOfCell(t), WVec.Zero, -511, palette, 1f, sourceAlpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
 			}
 
 			bool IsValidTarget(CPos xy)

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -47,7 +47,8 @@ namespace OpenRA.Mods.Cnc.Traits
 		bool IOccupySpaceInfo.SharesCell => false;
 
 		// Used to determine if actor can spawn
-		public bool CanEnterCell(World world, Actor self, CPos cell, SubCell subCell = SubCell.FullCell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
+		public bool CanEnterCell(World world, Actor self, CPos cell,
+			SubCell subCell = SubCell.FullCell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
 		{
 			return world.Map.Contains(cell);
 		}

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportGen2MapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportGen2MapCommand.cs
@@ -447,7 +447,8 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			}
 		}
 
-		protected virtual bool TryHandleOverlayToActorInner(CPos cell, byte[] overlayPack, CellLayer<int> overlayIndex, byte overlayType, out ActorReference actorReference)
+		protected virtual bool TryHandleOverlayToActorInner(
+			CPos cell, byte[] overlayPack, CellLayer<int> overlayIndex, byte overlayType, out ActorReference actorReference)
 		{
 			actorReference = null;
 			if (!OverlayToActor.TryGetValue(overlayType, out var actorType))

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianSunMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianSunMapCommand.cs
@@ -267,7 +267,8 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 
 		#region Method overrides
 
-		protected override bool TryHandleOverlayToActorInner(CPos cell, byte[] overlayPack, CellLayer<int> overlayIndex, byte overlayType, out ActorReference actorReference)
+		protected override bool TryHandleOverlayToActorInner(
+			CPos cell, byte[] overlayPack, CellLayer<int> overlayIndex, byte overlayType, out ActorReference actorReference)
 		{
 			actorReference = null;
 			if (!OverlayToActor.TryGetValue(overlayType, out var actorType))

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -204,7 +204,9 @@ namespace OpenRA.Mods.Common.Activities
 
 			// HACK: Consider ourselves blocked if we have moved by less than 64 WDist in the last five ticks
 			// Stop if we are blocked and close enough
-			if (previousPositions.Count == previousPositions.Capacity && (previousPositions.First() - previousPositions.Last()).LengthSquared < 4096 && delta.HorizontalLengthSquared <= nearEnough.LengthSquared)
+			if (previousPositions.Count == previousPositions.Capacity &&
+				(previousPositions.First() - previousPositions.Last()).LengthSquared < 4096 &&
+				delta.HorizontalLengthSquared <= nearEnough.LengthSquared)
 				return true;
 
 			// The next move would overshoot, so consider it close enough or set final position if we CanSlide

--- a/OpenRA.Mods.Common/Activities/InstantRepair.cs
+++ b/OpenRA.Mods.Common/Activities/InstantRepair.cs
@@ -38,7 +38,9 @@ namespace OpenRA.Mods.Common.Activities
 			// Make sure we can still repair the target before entering
 			// (but not before, because this may stop the actor in the middle of nowhere)
 			var stance = self.Owner.RelationshipWith(enterActor.Owner);
-			if (enterHealth == null || enterHealth.DamageState == DamageState.Undamaged || enterInstantlyRepariable == null || enterInstantlyRepariable.IsTraitDisabled || !info.ValidRelationships.HasRelationship(stance))
+			if (enterHealth == null || enterHealth.DamageState == DamageState.Undamaged ||
+				enterInstantlyRepariable == null || enterInstantlyRepariable.IsTraitDisabled ||
+				!info.ValidRelationships.HasRelationship(stance))
 			{
 				Cancel(self, true);
 				return false;

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -516,9 +516,13 @@ namespace OpenRA.Mods.Common.Activities
 
 		sealed class MoveFirstHalf : MovePart
 		{
-			public MoveFirstHalf(Move move, WPos from, WPos to, WAngle fromFacing, WAngle toFacing,
+			public MoveFirstHalf(
+				Move move, WPos from, WPos to, WAngle fromFacing, WAngle toFacing,
 				WRot? fromTerrainOrientation, WRot? toTerrainOrientation, int terrainOrientationMargin, int carryoverProgress, bool shouldArc, bool movingOnGroundLayer)
-				: base(move, from, to, fromFacing, toFacing, fromTerrainOrientation, toTerrainOrientation, terrainOrientationMargin, carryoverProgress, shouldArc, movingOnGroundLayer) { }
+				: base(
+					  move, from, to, fromFacing, toFacing,
+					  fromTerrainOrientation, toTerrainOrientation, terrainOrientationMargin, carryoverProgress, shouldArc, movingOnGroundLayer)
+			{ }
 
 			bool IsTurn(Actor self, Mobile mobile, CPos nextCell, Map map)
 			{
@@ -599,9 +603,13 @@ namespace OpenRA.Mods.Common.Activities
 
 		sealed class MoveSecondHalf : MovePart
 		{
-			public MoveSecondHalf(Move move, WPos from, WPos to, WAngle fromFacing, WAngle toFacing,
+			public MoveSecondHalf(
+				Move move, WPos from, WPos to, WAngle fromFacing, WAngle toFacing,
 				WRot? fromTerrainOrientation, WRot? toTerrainOrientation, int terrainOrientationMargin, int carryoverProgress, bool shouldArc, bool movingOnGroundLayer)
-				: base(move, from, to, fromFacing, toFacing, fromTerrainOrientation, toTerrainOrientation, terrainOrientationMargin, carryoverProgress, shouldArc, movingOnGroundLayer) { }
+				: base(
+					  move, from, to, fromFacing, toFacing,
+					  fromTerrainOrientation, toTerrainOrientation, terrainOrientationMargin, carryoverProgress, shouldArc, movingOnGroundLayer)
+			{ }
 
 			protected override MovePart OnComplete(Actor self, Mobile mobile, Move parent)
 			{

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -228,7 +228,11 @@ namespace OpenRA.Mods.Common.Activities
 					{
 						moveCooldownHelper.NotifyMoveQueued();
 						foreach (var cell in rp.Path)
-							QueueChild(new AttackMoveActivity(self, () => move.MoveTo(cell, 1, ignoreActor: repairableNear != null ? null : host.Actor, targetLineColor: aircraft.Info.TargetLineColor)));
+							QueueChild(new AttackMoveActivity(self, () => move.MoveTo(
+								cell,
+								1,
+								ignoreActor: repairableNear != null ? null : host.Actor,
+								targetLineColor: aircraft.Info.TargetLineColor)));
 					}
 					else
 						QueueChild(new TakeOff(self));

--- a/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
@@ -38,14 +38,15 @@ namespace OpenRA.Mods.Common.Commands
 		[TranslationReference]
 		const string ActorTagsOverlayDescripition = "description-actor-tags-overlay";
 
-		readonly IDictionary<string, (string Description, Action<DebugVisualizations, DeveloperMode> Handler)> commandHandlers = new Dictionary<string, (string Description, Action<DebugVisualizations, DeveloperMode> Handler)>
-		{
-			{ "combat-geometry", (CombatGeometryDescription, CombatGeometry) },
-			{ "render-geometry", (RenderGeometryDescription, RenderGeometry) },
-			{ "screen-map", (ScreenMapOverlayDescription, ScreenMap) },
-			{ "depth-buffer", (DepthBufferDescription, DepthBuffer) },
-			{ "actor-tags", (ActorTagsOverlayDescripition, ActorTags) },
-		};
+		readonly IDictionary<string, (string Description, Action<DebugVisualizations, DeveloperMode> Handler)> commandHandlers =
+			new Dictionary<string, (string Description, Action<DebugVisualizations, DeveloperMode> Handler)>
+			{
+				{ "combat-geometry", (CombatGeometryDescription, CombatGeometry) },
+				{ "render-geometry", (RenderGeometryDescription, RenderGeometry) },
+				{ "screen-map", (ScreenMapOverlayDescription, ScreenMap) },
+				{ "depth-buffer", (DepthBufferDescription, DepthBuffer) },
+				{ "actor-tags", (ActorTagsOverlayDescripition, ActorTags) },
+			};
 
 		DebugVisualizations debugVis;
 		DeveloperMode devMode;

--- a/OpenRA.Mods.Common/FileFormats/WavReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/WavReader.cs
@@ -253,7 +253,14 @@ namespace OpenRA.Mods.Common.FileFormats
 					WriteSample(DecodeNibble((short)((bytecode >> 4) & 0x0F), bpred[0], ref chanIdelta[0], ref s1[0], ref s2[0]), data);
 
 					// Decode the second nibble, for stereo this will be the right channel
-					WriteSample(DecodeNibble((short)(bytecode & 0x0F), bpred[channelNumber], ref chanIdelta[channelNumber], ref s1[channelNumber], ref s2[channelNumber]), data);
+					WriteSample(
+						DecodeNibble(
+							(short)(bytecode & 0x0F),
+							bpred[channelNumber],
+							ref chanIdelta[channelNumber],
+							ref s1[channelNumber],
+							ref s2[channelNumber]),
+						data);
 				}
 
 				return ++currentBlock >= numBlocks;

--- a/OpenRA.Mods.Common/Graphics/ContrailRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/ContrailRenderable.cs
@@ -36,10 +36,15 @@ namespace OpenRA.Mods.Common.Graphics
 		int length;
 		readonly int skip;
 
-		public ContrailRenderable(World world, Actor owner, Color startcolor, bool usePlayerStartColor, Color endcolor, bool usePlayerEndColor, WDist startWidth, WDist endWidth, int length, int skip, int zOffset)
-			: this(world, owner, new WPos[length], startWidth, endWidth, 0, 0, skip, startcolor, usePlayerStartColor, endcolor, usePlayerEndColor, zOffset) { }
+		public ContrailRenderable(
+			World world, Actor owner, Color startcolor, bool usePlayerStartColor, Color endcolor, bool usePlayerEndColor,
+			WDist startWidth, WDist endWidth, int length, int skip, int zOffset)
+			: this(world, owner, new WPos[length], startWidth, endWidth, 0, 0, skip,
+				  startcolor, usePlayerStartColor, endcolor, usePlayerEndColor, zOffset)
+		{ }
 
-		ContrailRenderable(World world, Actor owner, WPos[] trail, WDist startWidth, WDist endWidth, int next, int length, int skip, Color startColor, bool usePlayerStartColor, Color endColor, bool usePlayerEndColor, int zOffset)
+		ContrailRenderable(World world, Actor owner, WPos[] trail, WDist startWidth, WDist endWidth,
+			int next, int length, int skip, Color startColor, bool usePlayerStartColor, Color endColor, bool usePlayerEndColor, int zOffset)
 		{
 			this.world = world;
 			this.owner = owner;
@@ -60,12 +65,17 @@ namespace OpenRA.Mods.Common.Graphics
 		public int ZOffset { get; }
 		public bool IsDecoration => true;
 
-		public IRenderable WithZOffset(int newOffset) { return new ContrailRenderable(world, owner, (WPos[])trail.Clone(), startWidth, endWidth, next, length, skip, startColor, usePlayerStartColor, endColor, usePlayerEndColor, newOffset); }
+		public IRenderable WithZOffset(int newOffset) =>
+			new ContrailRenderable(
+				world, owner, (WPos[])trail.Clone(), startWidth, endWidth, next,
+				length, skip, startColor, usePlayerStartColor, endColor, usePlayerEndColor, newOffset);
 		public IRenderable OffsetBy(in WVec vec)
 		{
 			// Lambdas can't use 'in' variables, so capture a copy for later
 			var offset = vec;
-			return new ContrailRenderable(world, owner, trail.Select(pos => pos + offset).ToArray(), startWidth, endWidth, next, length, skip, startColor, usePlayerStartColor, endColor, usePlayerEndColor, ZOffset);
+			return new ContrailRenderable(
+				world, owner, trail.Select(pos => pos + offset).ToArray(), startWidth, endWidth, next,
+				length, skip, startColor, usePlayerStartColor, endColor, usePlayerEndColor, ZOffset);
 		}
 
 		public IRenderable AsDecoration() { return this; }

--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -36,7 +36,8 @@ namespace OpenRA.Mods.Common.Graphics
 				IndexedSheetSize = FieldLoader.GetValue<int>("IndexedSheetSize", yaml.Value);
 		}
 
-		public virtual ISpriteSequence CreateSequence(ModData modData, string tileset, SpriteCache cache, string image, string sequence, MiniYaml data, MiniYaml defaults)
+		public virtual ISpriteSequence CreateSequence(
+			ModData modData, string tileset, SpriteCache cache, string image, string sequence, MiniYaml data, MiniYaml defaults)
 		{
 			return new DefaultSpriteSequence(cache, this, image, sequence, data, defaults);
 		}
@@ -44,7 +45,8 @@ namespace OpenRA.Mods.Common.Graphics
 		int ISpriteSequenceLoader.BgraSheetSize => BgraSheetSize;
 		int ISpriteSequenceLoader.IndexedSheetSize => IndexedSheetSize;
 
-		IReadOnlyDictionary<string, ISpriteSequence> ISpriteSequenceLoader.ParseSequences(ModData modData, string tileset, SpriteCache cache, MiniYamlNode imageNode)
+		IReadOnlyDictionary<string, ISpriteSequence> ISpriteSequenceLoader.ParseSequences(
+			ModData modData, string tileset, SpriteCache cache, MiniYamlNode imageNode)
 		{
 			var sequences = new Dictionary<string, ISpriteSequence>();
 			var node = imageNode.Value.NodeWithKeyOrDefault("Defaults");
@@ -135,7 +137,9 @@ namespace OpenRA.Mods.Common.Graphics
 		[Desc("The number of facings that are provided by sprite frames. Use negative values to rotate counter-clockwise.")]
 		protected static readonly SpriteSequenceField<int> Facings = new(nameof(Facings), 1);
 
-		[Desc("The total number of facings for the sequence. If >Facings, the closest facing sprite will be rotated to match. Use negative values to rotate counter-clockwise.")]
+		[Desc("The total number of facings for the sequence. " +
+			"If >Facings, the closest facing sprite will be rotated to match. " +
+			"Use negative values to rotate counter-clockwise.")]
 		protected static readonly SpriteSequenceField<int?> InterpolatedFacings = new(nameof(InterpolatedFacings), null);
 
 		[Desc("Time (in milliseconds at default game speed) to wait until playing the next frame in the animation.")]
@@ -302,7 +306,8 @@ namespace OpenRA.Mods.Common.Graphics
 			return Rectangle.FromLTRB(left, top, right, bottom);
 		}
 
-		protected static List<int> CalculateFrameIndices(int start, int? length, int stride, int facings, int[] frames, bool transpose, bool reverseFacings, int shadowStart)
+		protected static List<int> CalculateFrameIndices(
+			int start, int? length, int stride, int facings, int[] frames, bool transpose, bool reverseFacings, int shadowStart)
 		{
 			// Request all frames
 			if (length == null)
@@ -411,10 +416,17 @@ namespace OpenRA.Mods.Common.Graphics
 			// Facings must be an integer factor of 1024 (i.e. 1024 / facings is an integer) to allow the frames to be
 			// mapped uniformly over the full rotation range. This implies that it is a power of 2.
 			if (facings == 0 || facings > 1024 || !Exts.IsPowerOf2(facings))
-				throw new YamlException($"{facingsLocation}: {Facings.Key} must be within the (positive or negative) range of 1 to 1024, and a power of 2.");
+				throw new YamlException(
+					$"{facingsLocation}: {Facings.Key} must be within the (positive or negative) range of 1 to 1024, and a power of 2.");
 
-			if (interpolatedFacings != null && (interpolatedFacings < 2 || interpolatedFacings <= facings || interpolatedFacings > 1024 || !Exts.IsPowerOf2(interpolatedFacings.Value)))
-				throw new YamlException($"{interpolatedFacingsLocation}: {InterpolatedFacings.Key} must be greater than {Facings.Key}, within the range of 2 to 1024, and a power of 2.");
+			if (interpolatedFacings != null &&
+				(interpolatedFacings < 2 ||
+				interpolatedFacings <= facings ||
+				interpolatedFacings > 1024 ||
+				!Exts.IsPowerOf2(interpolatedFacings.Value)))
+				throw new YamlException(
+					$"{interpolatedFacingsLocation}: {InterpolatedFacings.Key} must be greater than {Facings.Key}, " +
+					"within the range of 2 to 1024, and a power of 2.");
 
 			if (length != null && length <= 0)
 				throw new YamlException($"{lengthLocation}: {Length.Key} must be positive.");

--- a/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
@@ -20,7 +20,8 @@ namespace OpenRA.Mods.Common.Graphics
 		public TilesetSpecificSpriteSequenceLoader(ModData modData)
 			: base(modData) { }
 
-		public override ISpriteSequence CreateSequence(ModData modData, string tileSet, SpriteCache cache, string image, string sequence, MiniYaml data, MiniYaml defaults)
+		public override ISpriteSequence CreateSequence(
+			ModData modData, string tileSet, SpriteCache cache, string image, string sequence, MiniYaml data, MiniYaml defaults)
 		{
 			return new TilesetSpecificSpriteSequence(cache, this, image, sequence, data, defaults);
 		}

--- a/OpenRA.Mods.Common/Installer/SourceActions/CopySourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/CopySourceAction.cs
@@ -44,9 +44,13 @@ namespace OpenRA.Mods.Common.Installer
 
 					Action<long> onProgress = null;
 					if (length < InstallFromSourceLogic.ShowPercentageThreshold)
-						updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.CopyingFilename, Translation.Arguments("filename", displayFilename)));
+						updateMessage(TranslationProvider.GetString(
+							InstallFromSourceLogic.CopyingFilename,
+							Translation.Arguments("filename", displayFilename)));
 					else
-						onProgress = b => updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.CopyingFilenameProgress, Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
+						onProgress = b => updateMessage(
+							TranslationProvider.GetString(InstallFromSourceLogic.CopyingFilenameProgress,
+							Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
 
 					InstallerUtils.CopyStream(source, target, length, onProgress);
 				}

--- a/OpenRA.Mods.Common/Installer/SourceActions/CopySourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/CopySourceAction.cs
@@ -48,8 +48,8 @@ namespace OpenRA.Mods.Common.Installer
 							InstallFromSourceLogic.CopyingFilename,
 							Translation.Arguments("filename", displayFilename)));
 					else
-						onProgress = b => updateMessage(
-							TranslationProvider.GetString(InstallFromSourceLogic.CopyingFilenameProgress,
+						onProgress = b => updateMessage(TranslationProvider.GetString(
+							InstallFromSourceLogic.CopyingFilenameProgress,
 							Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
 
 					InstallerUtils.CopyStream(source, target, length, onProgress);

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractBlastSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractBlastSourceAction.cs
@@ -23,7 +23,9 @@ namespace OpenRA.Mods.Common.Installer
 		public void RunActionOnSource(MiniYaml actionYaml, string path, ModData modData, List<string> extracted, Action<string> updateMessage)
 		{
 			// Yaml path may be specified relative to a named directory (e.g. ^SupportDir) or the detected source path
-			var sourcePath = actionYaml.Value.StartsWith('^') ? Platform.ResolvePath(actionYaml.Value) : FS.ResolveCaseInsensitivePath(Path.Combine(path, actionYaml.Value));
+			var sourcePath = actionYaml.Value.StartsWith('^')
+				? Platform.ResolvePath(actionYaml.Value)
+				: FS.ResolveCaseInsensitivePath(Path.Combine(path, actionYaml.Value));
 
 			using (var source = File.OpenRead(sourcePath))
 			{

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractBlastSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractBlastSourceAction.cs
@@ -66,9 +66,13 @@ namespace OpenRA.Mods.Common.Installer
 
 					Action<long> onProgress = null;
 					if (length < InstallFromSourceLogic.ShowPercentageThreshold)
-						updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.Extracing, Translation.Arguments("filename", displayFilename)));
+						updateMessage(TranslationProvider.GetString(
+							InstallFromSourceLogic.Extracing,
+							Translation.Arguments("filename", displayFilename)));
 					else
-						onProgress = b => updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
+						onProgress = b => updateMessage(TranslationProvider.GetString(
+							InstallFromSourceLogic.ExtractingProgress,
+							Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
 
 					using (var target = File.OpenWrite(targetPath))
 					{

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractIscabSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractIscabSourceAction.cs
@@ -62,7 +62,9 @@ namespace OpenRA.Mods.Common.Installer
 						{
 							Log.Write("install", $"Extracting {sourcePath} -> {targetPath}");
 							var displayFilename = Path.GetFileName(Path.GetFileName(targetPath));
-							void OnProgress(int percent) => updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", percent)));
+							void OnProgress(int percent) => updateMessage(TranslationProvider.GetString(
+								InstallFromSourceLogic.ExtractingProgress,
+								Translation.Arguments("filename", displayFilename, "progress", percent)));
 							reader.ExtractFile(node.Value.Value, target, OnProgress);
 						}
 					}

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractIscabSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractIscabSourceAction.cs
@@ -23,7 +23,9 @@ namespace OpenRA.Mods.Common.Installer
 		public void RunActionOnSource(MiniYaml actionYaml, string path, ModData modData, List<string> extracted, Action<string> updateMessage)
 		{
 			// Yaml path may be specified relative to a named directory (e.g. ^SupportDir) or the detected source path
-			var sourcePath = actionYaml.Value.StartsWith('^') ? Platform.ResolvePath(actionYaml.Value) : FS.ResolveCaseInsensitivePath(Path.Combine(path, actionYaml.Value));
+			var sourcePath = actionYaml.Value.StartsWith('^')
+				? Platform.ResolvePath(actionYaml.Value)
+				: FS.ResolveCaseInsensitivePath(Path.Combine(path, actionYaml.Value));
 
 			var volumeNode = actionYaml.NodeWithKeyOrDefault("Volumes");
 			if (volumeNode == null)

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractMscabSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractMscabSourceAction.cs
@@ -23,7 +23,9 @@ namespace OpenRA.Mods.Common.Installer
 		public void RunActionOnSource(MiniYaml actionYaml, string path, ModData modData, List<string> extracted, Action<string> updateMessage)
 		{
 			// Yaml path may be specified relative to a named directory (e.g. ^SupportDir) or the detected source path
-			var sourcePath = actionYaml.Value.StartsWith('^') ? Platform.ResolvePath(actionYaml.Value) : FS.ResolveCaseInsensitivePath(Path.Combine(path, actionYaml.Value));
+			var sourcePath = actionYaml.Value.StartsWith('^')
+				? Platform.ResolvePath(actionYaml.Value)
+				: FS.ResolveCaseInsensitivePath(Path.Combine(path, actionYaml.Value));
 
 			using (var source = File.OpenRead(sourcePath))
 			{

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractMscabSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractMscabSourceAction.cs
@@ -44,7 +44,9 @@ namespace OpenRA.Mods.Common.Installer
 					{
 						Log.Write("install", $"Extracting {sourcePath} -> {targetPath}");
 						var displayFilename = Path.GetFileName(Path.GetFileName(targetPath));
-						void OnProgress(int percent) => updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", percent)));
+						void OnProgress(int percent) => updateMessage(TranslationProvider.GetString(
+							InstallFromSourceLogic.ExtractingProgress,
+							Translation.Arguments("filename", displayFilename, "progress", percent)));
 						reader.ExtractFile(node.Value.Value, target, OnProgress);
 					}
 				}

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractRawSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractRawSourceAction.cs
@@ -22,7 +22,9 @@ namespace OpenRA.Mods.Common.Installer
 		public void RunActionOnSource(MiniYaml actionYaml, string path, ModData modData, List<string> extracted, Action<string> updateMessage)
 		{
 			// Yaml path may be specified relative to a named directory (e.g. ^SupportDir) or the detected source path
-			var sourcePath = actionYaml.Value.StartsWith('^') ? Platform.ResolvePath(actionYaml.Value) : FS.ResolveCaseInsensitivePath(Path.Combine(path, actionYaml.Value));
+			var sourcePath = actionYaml.Value.StartsWith('^')
+				? Platform.ResolvePath(actionYaml.Value)
+				: FS.ResolveCaseInsensitivePath(Path.Combine(path, actionYaml.Value));
 
 			using (var source = File.OpenRead(sourcePath))
 			{

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractRawSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractRawSourceAction.cs
@@ -61,7 +61,9 @@ namespace OpenRA.Mods.Common.Installer
 					if (length < InstallFromSourceLogic.ShowPercentageThreshold)
 						updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.Extracing, Translation.Arguments("filename", displayFilename)));
 					else
-						onProgress = b => updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
+						onProgress = b => updateMessage(TranslationProvider.GetString(
+							InstallFromSourceLogic.ExtractingProgress,
+							Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
 
 					using (var target = File.OpenWrite(targetPath))
 					{

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractZipSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractZipSourceAction.cs
@@ -49,7 +49,9 @@ namespace OpenRA.Mods.Common.Installer
 					using (var targetStream = File.OpenWrite(targetPath))
 						sourceStream.CopyTo(targetStream);
 
-					updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.ExtractingProgress, Translation.Arguments("filename", displayFilename, "progress", 100)));
+					updateMessage(TranslationProvider.GetString(
+						InstallFromSourceLogic.ExtractingProgress,
+						Translation.Arguments("filename", displayFilename, "progress", 100)));
 
 					extracted.Add(targetPath);
 				}

--- a/OpenRA.Mods.Common/Installer/SourceResolvers/SteamSourceResolver.cs
+++ b/OpenRA.Mods.Common/Installer/SourceResolvers/SteamSourceResolver.cs
@@ -85,16 +85,29 @@ namespace OpenRA.Mods.Common.Installer
 				}
 
 				case PlatformType.OSX:
-					candidatePaths.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support", "Steam"));
+					candidatePaths.Add(Path.Combine(
+						Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+						"Library",
+						"Application Support",
+						"Steam"));
 
 					break;
 
 				case PlatformType.Linux:
 					// Direct distro install
-					candidatePaths.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".steam", "root"));
+					candidatePaths.Add(Path.Combine(
+						Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+						".steam",
+						"root"));
 
 					// Flatpak installed via Flathub
-					candidatePaths.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".var", "app", "com.valvesoftware.Steam", ".steam", "root"));
+					candidatePaths.Add(Path.Combine(
+						Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+						".var",
+						"app",
+						"com.valvesoftware.Steam",
+						".steam",
+						"root"));
 
 					break;
 			}

--- a/OpenRA.Mods.Common/Lint/CheckActors.cs
+++ b/OpenRA.Mods.Common/Lint/CheckActors.cs
@@ -19,7 +19,9 @@ namespace OpenRA.Mods.Common.Lint
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
 		{
-			var scriptBindings = Game.ModData.ObjectCreator.GetTypesImplementing<ScriptGlobal>().Select(t => Utility.GetCustomAttributes<ScriptGlobalAttribute>(t, true)[0].Name).ToHashSet();
+			var scriptBindings = Game.ModData.ObjectCreator.GetTypesImplementing<ScriptGlobal>()
+				.Select(t => Utility.GetCustomAttributes<ScriptGlobalAttribute>(t, true)[0].Name)
+				.ToHashSet();
 			foreach (var actor in map.ActorDefinitions)
 			{
 				var name = actor.Value.Value;

--- a/OpenRA.Mods.Common/Lint/CheckChromeHotkeys.cs
+++ b/OpenRA.Mods.Common/Lint/CheckChromeHotkeys.cs
@@ -64,8 +64,15 @@ namespace OpenRA.Mods.Common.Lint
 			}
 		}
 
-		static void CheckInner(ModData modData, string[] namedKeys, (string Widget, string Field)[] checkWidgetFields, Dictionary<string, List<string>> customLintMethods,
-			IEnumerable<MiniYamlNode> nodes, string filename, MiniYamlNode parent, Action<string> emitError)
+		static void CheckInner(
+			ModData modData,
+			string[] namedKeys,
+			(string Widget, string Field)[] checkWidgetFields,
+			Dictionary<string, List<string>> customLintMethods,
+			IEnumerable<MiniYamlNode> nodes,
+			string filename,
+			MiniYamlNode parent,
+			Action<string> emitError)
 		{
 			foreach (var node in nodes)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
+++ b/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
@@ -42,7 +42,9 @@ namespace OpenRA.Mods.Common.Lint
 					if (count == 0)
 						emitError($"Actor type `{actorInfo.Key}` does not define a default visibility type.");
 					else if (count > 1)
-						emitError($"Actor type `{actorInfo.Key}` defines multiple default visibility types: {string.Join(", ", visibilityTypes.Select(vis => vis.GetType().Name))}.");
+						emitError(
+							$"Actor type `{actorInfo.Key}` defines multiple default visibility types: " +
+							$"{string.Join(", ", visibilityTypes.Select(vis => vis.GetType().Name))}.");
 					else
 					{
 						var vis = actorInfo.Value.TraitInfoOrDefault<HiddenUnderShroudInfo>();
@@ -50,9 +52,13 @@ namespace OpenRA.Mods.Common.Lint
 						{
 							var ios = actorInfo.Value.TraitInfoOrDefault<IOccupySpaceInfo>();
 							if (ios == null)
-								emitError($"Actor type `{actorInfo.Key}` defines VisibilityType.Footprint in `{vis.GetType().Name}` but has no IOccupySpace traits.");
+								emitError(
+									$"Actor type `{actorInfo.Key}` defines VisibilityType.Footprint in `{vis.GetType().Name}` " +
+									"but has no IOccupySpace traits.");
 							else if (ios.OccupiedCells(actorInfo.Value, CPos.Zero).Count == 0)
-								emitError($"Actor type `{actorInfo.Key}` defines VisibilityType.Footprint in `{vis.GetType().Name}` but does not have any footprint cells.");
+								emitError(
+									$"Actor type `{actorInfo.Key}` defines VisibilityType.Footprint in `{vis.GetType().Name}` " +
+									"but does not have any footprint cells.");
 						}
 					}
 				}

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -38,7 +38,8 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, emitWarning, map.Players, map.Visibility, map.WorldActorInfo, map.SpawnPoints);
 		}
 
-		static void Run(Action<string> emitError, Action<string> emitWarning, MapPlayers players, MapVisibility visibility, ActorInfo worldActorInfo, CPos[] spawnPoints)
+		static void Run(Action<string> emitError, Action<string> emitWarning,
+			MapPlayers players, MapVisibility visibility, ActorInfo worldActorInfo, CPos[] spawnPoints)
 		{
 			if (players.Players.Count > 64)
 				emitError("Defining more than 64 players is not allowed.");

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -97,10 +97,13 @@ namespace OpenRA.Mods.Common.Lint
 										// TODO: Remove prefixed sequence references and instead use explicit lists of lintable references.
 										if (!sequences.Sequences(i).Any(s => s.StartsWith(sequence, StringComparison.Ordinal)))
 											emitWarning(
-												$"Actor type `{actorInfo.Value.Name}` trait `{traitName}` field `{field.Name}` defines a prefix `{sequence}` that does not match any sequences on image `{i}`.");
+												$"Actor type `{actorInfo.Value.Name}` trait `{traitName}` field `{field.Name}` " +
+												$"defines a prefix `{sequence}` that does not match any sequences on image `{i}`.");
 									}
 									else if (!sequences.HasSequence(i, sequence))
-										emitError($"Actor type `{actorInfo.Value.Name}` trait `{traitName}` field `{field.Name}` references an undefined sequence `{sequence}` on image `{i}`.");
+										emitError(
+											$"Actor type `{actorInfo.Value.Name}` trait `{traitName}` field `{field.Name}` " +
+											$"references an undefined sequence `{sequence}` on image `{i}`.");
 								}
 							}
 						}
@@ -145,10 +148,14 @@ namespace OpenRA.Mods.Common.Lint
 						{
 							// TODO: Remove prefixed sequence references and instead use explicit lists of lintable references.
 							if (!sequences.Sequences(image).Any(s => s.StartsWith(sequence, StringComparison.Ordinal)))
-								emitWarning($"Weapon type `{weaponInfo.Key}` projectile field `{field.Name}` defines a prefix `{sequence}` that does not match any sequences on image `{image}`.");
+								emitWarning(
+									$"Weapon type `{weaponInfo.Key}` projectile field `{field.Name}` " +
+									$"defines a prefix `{sequence}` that does not match any sequences on image `{image}`.");
 						}
 						else if (!sequences.HasSequence(image, sequence))
-							emitError($"Weapon type `{weaponInfo.Key}` projectile field `{field.Name}` references an undefined sequence `{sequence}` on image `{image}`.");
+							emitError(
+								$"Weapon type `{weaponInfo.Key}` projectile field `{field.Name}` " +
+								$"references an undefined sequence `{sequence}` on image `{image}`.");
 					}
 				}
 			}

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -96,7 +96,8 @@ namespace OpenRA.Mods.Common.Lint
 									{
 										// TODO: Remove prefixed sequence references and instead use explicit lists of lintable references.
 										if (!sequences.Sequences(i).Any(s => s.StartsWith(sequence, StringComparison.Ordinal)))
-											emitWarning($"Actor type `{actorInfo.Value.Name}` trait `{traitName}` field `{field.Name}` defines a prefix `{sequence}` that does not match any sequences on image `{i}`.");
+											emitWarning(
+												$"Actor type `{actorInfo.Value.Name}` trait `{traitName}` field `{field.Name}` defines a prefix `{sequence}` that does not match any sequences on image `{i}`.");
 									}
 									else if (!sequences.HasSequence(i, sequence))
 										emitError($"Actor type `{actorInfo.Value.Name}` trait `{traitName}` field `{field.Name}` references an undefined sequence `{sequence}` on image `{i}`.");

--- a/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
@@ -209,7 +209,9 @@ namespace OpenRA.Mods.Common.Lint
 							{
 								var userInterface = typeof(UserInterfaceGlobal).GetCustomAttribute<ScriptGlobalAttribute>().Name;
 								const string Translate = nameof(UserInterfaceGlobal.Translate);
-								emitWarning($"{context} calls {userInterface}.{Translate} with key `{key}` and translate args passed as `{variable}`. Inline the args at the callsite for lint analysis.");
+								emitWarning(
+									$"{context} calls {userInterface}.{Translate} with key `{key}` and translate args passed as `{variable}`." +
+									"Inline the args at the callsite for lint analysis.");
 							}
 						}
 					}

--- a/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTranslationReference.cs
@@ -245,7 +245,10 @@ namespace OpenRA.Mods.Common.Lint
 					var resourceTypeTranslationReference = Utility.GetCustomAttributes<TranslationReferenceAttribute>(resourceTypeNameField, true)[0];
 					testedFields.Add(resourceTypeNameField);
 					foreach (var resourceTypes in info.ResourceTypes)
-						usedKeys.Add(resourceTypes.Value.Name, resourceTypeTranslationReference, $"`{nameof(ResourceRendererInfo.ResourceTypeInfo)}.{nameof(ResourceRendererInfo.ResourceTypeInfo.Name)}`");
+						usedKeys.Add(
+							resourceTypes.Value.Name,
+							resourceTypeTranslationReference,
+							$"`{nameof(ResourceRendererInfo.ResourceTypeInfo)}.{nameof(ResourceRendererInfo.ResourceTypeInfo.Name)}`");
 				}
 			}
 

--- a/OpenRA.Mods.Common/Lint/LintExts.cs
+++ b/OpenRA.Mods.Common/Lint/LintExts.cs
@@ -63,7 +63,9 @@ namespace OpenRA.Mods.Common.Lint
 				"BooleanExpression", "IntegerExpression"
 			};
 
-			throw new InvalidOperationException($"Bad type for reference on `{ruleInfo.GetType().Name}.{fieldInfo.Name}`. Supported types: {supportedTypes.JoinWith(", ")}.");
+			throw new InvalidOperationException(
+				$"Bad type for reference on `{ruleInfo.GetType().Name}.{fieldInfo.Name}`. " +
+				$"Supported types: {supportedTypes.JoinWith(", ")}.");
 		}
 
 		public static IEnumerable<string> GetPropertyValues(object ruleInfo, PropertyInfo propertyInfo,
@@ -108,7 +110,9 @@ namespace OpenRA.Mods.Common.Lint
 				"BooleanExpression", "IntegerExpression"
 			};
 
-			throw new InvalidOperationException($"Bad type for reference on `{ruleInfo.GetType().Name}.{propertyInfo.Name}`. Supported types: {supportedTypes.JoinWith(", ")}.");
+			throw new InvalidOperationException(
+				$"Bad type for reference on `{ruleInfo.GetType().Name}.{propertyInfo.Name}`." +
+				$"Supported types: {supportedTypes.JoinWith(", ")}.");
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -294,7 +294,12 @@ namespace OpenRA.Mods.Common.Orders
 			{
 				var isCloseEnough = buildingInfo.IsCloseEnoughToBase(world, world.LocalPlayer, actorInfo, topLeft);
 				foreach (var t in buildingInfo.Tiles(topLeft))
-					footprint.Add(t, MakeCellType(isCloseEnough && world.IsCellBuildable(t, actorInfo, buildingInfo) && (resourceLayer == null || resourceLayer.GetResource(t).Type == null)));
+					footprint.Add(
+						t,
+						MakeCellType(
+							isCloseEnough &&
+							world.IsCellBuildable(t, actorInfo, buildingInfo) &&
+							(resourceLayer == null || resourceLayer.GetResource(t).Type == null)));
 			}
 
 			return preview?.Render(wr, topLeft, footprint) ?? Enumerable.Empty<IRenderable>();

--- a/OpenRA.Mods.Common/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/UnitOrderGenerator.cs
@@ -99,7 +99,10 @@ namespace OpenRA.Mods.Common.Orders
 		public virtual bool InputOverridesSelection(World world, int2 xy, MouseInput mi)
 		{
 			var actor = world.ScreenMap.ActorsAtMouse(xy)
-				.Where(a => !a.Actor.IsDead && a.Actor.Info.HasTraitInfo<ISelectableInfo>() && (a.Actor.Owner.IsAlliedWith(world.RenderPlayer) || !world.FogObscures(a.Actor)))
+				.Where(a =>
+					!a.Actor.IsDead &&
+					a.Actor.Info.HasTraitInfo<ISelectableInfo>() &&
+					(a.Actor.Owner.IsAlliedWith(world.RenderPlayer) || !world.FogObscures(a.Actor)))
 				.WithHighestSelectionPriority(xy, mi.Modifiers);
 
 			if (actor == null)

--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -54,7 +54,10 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("The maximum/constant/incremental inaccuracy used in conjunction with the InaccuracyType property.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
 
-		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' - scale from 0 to max with range, 'PerCellIncrement' - scale from 0 with range and 'Absolute' - use set value regardless of range.")]
+		[Desc("Controls the way inaccuracy is calculated. Possible values are " +
+			"'Maximum' - scale from 0 to max with range, " +
+			"'PerCellIncrement' - scale from 0 with range, " +
+			"'Absolute' - use set value regardless of range.")]
 		public readonly InaccuracyType InaccuracyType = InaccuracyType.Maximum;
 
 		[Desc("Can this projectile be blocked when hitting actors with an IBlocksProjectiles trait.")]

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -30,7 +30,10 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("The maximum/constant/incremental inaccuracy used in conjunction with the InaccuracyType property.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
 
-		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' - scale from 0 to max with range, 'PerCellIncrement' - scale from 0 with range and 'Absolute' - use set value regardless of range.")]
+		[Desc("Controls the way inaccuracy is calculated. Possible values are " +
+			"'Maximum' - scale from 0 to max with range, " +
+			"'PerCellIncrement' - scale from 0 with range, " +
+			"'Absolute' - use set value regardless of range.")]
 		public readonly InaccuracyType InaccuracyType = InaccuracyType.Maximum;
 
 		[Desc("Image to display.")]

--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -75,7 +75,8 @@ namespace OpenRA.Mods.Common.Projectiles
 				target = Target.FromPos(args.PassiveTarget);
 
 			// Check for blocking actors
-			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, args.SourceActor.Owner, args.Source, target.CenterPosition, info.Width, out var blockedPos))
+			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(
+				world, args.SourceActor.Owner, args.Source, target.CenterPosition, info.Width, out var blockedPos))
 				target = Target.FromPos(blockedPos);
 
 			var warheadArgs = new WarheadArgs(args)

--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -24,7 +24,10 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("The maximum/constant/incremental inaccuracy used in conjunction with the InaccuracyType property.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
 
-		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' - scale from 0 to max with range, 'PerCellIncrement' - scale from 0 with range and 'Absolute' - use set value regardless of range.")]
+		[Desc("Controls the way inaccuracy is calculated. Possible values are " +
+			"'Maximum' - scale from 0 to max with range, " +
+			"'PerCellIncrement' - scale from 0 with range, " +
+			"'Absolute' - use set value regardless of range.")]
 		public readonly InaccuracyType InaccuracyType = InaccuracyType.Maximum;
 
 		[Desc("Projectile can be blocked.")]

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -52,7 +52,10 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("The maximum/constant/incremental inaccuracy used in conjunction with the InaccuracyType property.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
 
-		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' - scale from 0 to max with range, 'PerCellIncrement' - scale from 0 with range and 'Absolute' - use set value regardless of range.")]
+		[Desc("Controls the way inaccuracy is calculated. Possible values are " +
+			"'Maximum' - scale from 0 to max with range, " +
+			"'PerCellIncrement' - scale from 0 with range, " +
+			"'Absolute' - use set value regardless of range.")]
 		public readonly InaccuracyType InaccuracyType = InaccuracyType.Maximum;
 
 		[Desc("Beam can be blocked.")]

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -77,7 +77,10 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("The maximum/constant/incremental inaccuracy used in conjunction with the InaccuracyType property.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
 
-		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' - scale from 0 to max with range, 'PerCellIncrement' - scale from 0 with range and 'Absolute' - use set value regardless of range.")]
+		[Desc("Controls the way inaccuracy is calculated. Possible values are " +
+			"'Maximum' - scale from 0 to max with range, " +
+			"'PerCellIncrement' - scale from 0 with range, " +
+			"'Absolute' - use set value regardless of range.")]
 		public readonly InaccuracyType InaccuracyType = InaccuracyType.Absolute;
 
 		[Desc("Inaccuracy override when successfully locked onto target. Defaults to Inaccuracy if negative.")]

--- a/OpenRA.Mods.Common/Projectiles/Railgun.cs
+++ b/OpenRA.Mods.Common/Projectiles/Railgun.cs
@@ -28,7 +28,10 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("The maximum/constant/incremental inaccuracy used in conjunction with the InaccuracyType property.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
 
-		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' - scale from 0 to max with range, 'PerCellIncrement' - scale from 0 with range and 'Absolute' - use set value regardless of range.")]
+		[Desc("Controls the way inaccuracy is calculated. Possible values are " +
+			"'Maximum' - scale from 0 to max with range, " +
+			"'PerCellIncrement' - scale from 0 with range, " +
+			"'Absolute' - use set value regardless of range.")]
 		public readonly InaccuracyType InaccuracyType = InaccuracyType.Maximum;
 
 		[Desc("Can this projectile be blocked when hitting actors with an IBlocksProjectiles trait.")]

--- a/OpenRA.Mods.Common/Scripting/Global/UserInterfaceGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/UserInterfaceGlobal.cs
@@ -45,7 +45,9 @@ namespace OpenRA.Mods.Common.Scripting.Global
 					using (kv.Value)
 					{
 						if (!kv.Key.TryGetClrValue<string>(out var variable) || !kv.Value.TryGetClrValue<object>(out var value))
-							throw new LuaException($"Translation arguments requires a table of [\"string\"]=value pairs. Received {kv.Key.WrappedClrType().Name},{kv.Value.WrappedClrType().Name}");
+							throw new LuaException(
+								"Translation arguments requires a table of [\"string\"]=value pairs. " +
+								$"Received {kv.Key.WrappedClrType().Name},{kv.Value.WrappedClrType().Name}");
 
 						argumentDictionary.Add(variable, value);
 					}

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -165,33 +165,34 @@ namespace OpenRA.Mods.Common.Server
 		[TranslationReference]
 		const string VoteKickDisabled = "notification-vote-kick-disabled";
 
-		readonly IDictionary<string, Func<S, Connection, Session.Client, string, bool>> commandHandlers = new Dictionary<string, Func<S, Connection, Session.Client, string, bool>>
-		{
-			{ "state", State },
-			{ "startgame", StartGame },
-			{ "slot", Slot },
-			{ "allow_spectators", AllowSpectators },
-			{ "spectate", Specate },
-			{ "slot_close", SlotClose },
-			{ "slot_open", SlotOpen },
-			{ "slot_bot", SlotBot },
-			{ "map", Map },
-			{ "option", Option },
-			{ "reset_options", ResetOptions },
-			{ "assignteams", AssignTeams },
-			{ "kick", Kick },
-			{ "vote_kick", VoteKick },
-			{ "make_admin", MakeAdmin },
-			{ "make_spectator", MakeSpectator },
-			{ "name", Name },
-			{ "faction", Faction },
-			{ "team", Team },
-			{ "handicap", Handicap },
-			{ "spawn", Spawn },
-			{ "clear_spawn", ClearPlayerSpawn },
-			{ "color", PlayerColor },
-			{ "sync_lobby", SyncLobby }
-		};
+		readonly IDictionary<string, Func<S, Connection, Session.Client, string, bool>> commandHandlers =
+			new Dictionary<string, Func<S, Connection, Session.Client, string, bool>>
+			{
+				{ "state", State },
+				{ "startgame", StartGame },
+				{ "slot", Slot },
+				{ "allow_spectators", AllowSpectators },
+				{ "spectate", Specate },
+				{ "slot_close", SlotClose },
+				{ "slot_open", SlotOpen },
+				{ "slot_bot", SlotBot },
+				{ "map", Map },
+				{ "option", Option },
+				{ "reset_options", ResetOptions },
+				{ "assignteams", AssignTeams },
+				{ "kick", Kick },
+				{ "vote_kick", VoteKick },
+				{ "make_admin", MakeAdmin },
+				{ "make_spectator", MakeSpectator },
+				{ "name", Name },
+				{ "faction", Faction },
+				{ "team", Team },
+				{ "handicap", Handicap },
+				{ "spawn", Spawn },
+				{ "clear_spawn", ClearPlayerSpawn },
+				{ "color", PlayerColor },
+				{ "sync_lobby", SyncLobby }
+			};
 
 		static bool ValidateSlotCommand(S server, Connection conn, Session.Client client, string arg, bool requiresHost)
 		{

--- a/OpenRA.Mods.Common/Terrain/TerrainInfo.cs
+++ b/OpenRA.Mods.Common/Terrain/TerrainInfo.cs
@@ -50,7 +50,8 @@ namespace OpenRA.Mods.Common.Terrain
 
 					if (key < 0 || key >= tileInfo.Length)
 						throw new YamlException(
-							$"Tileset `{terrainInfo.Id}` template `{Id}` references frame {key}, but only [0..{tileInfo.Length - 1}] are valid for a {Size.X}x{Size.Y} Size template.");
+							$"Tileset `{terrainInfo.Id}` template `{Id}` references frame {key}, " +
+							$"but only [0..{tileInfo.Length - 1}] are valid for a {Size.X}x{Size.Y} Size template.");
 
 					tileInfo[key] = LoadTileInfo(terrainInfo, node.Value);
 				}

--- a/OpenRA.Mods.Common/Terrain/TerrainInfo.cs
+++ b/OpenRA.Mods.Common/Terrain/TerrainInfo.cs
@@ -45,10 +45,12 @@ namespace OpenRA.Mods.Common.Terrain
 				foreach (var node in nodes)
 				{
 					if (!int.TryParse(node.Key, out var key))
-						throw new YamlException($"Tileset `{terrainInfo.Id}` template `{Id}` defines a frame `{node.Key}` that is not a valid integer.");
+						throw new YamlException(
+							$"Tileset `{terrainInfo.Id}` template `{Id}` defines a frame `{node.Key}` that is not a valid integer.");
 
 					if (key < 0 || key >= tileInfo.Length)
-						throw new YamlException($"Tileset `{terrainInfo.Id}` template `{Id}` references frame {key}, but only [0..{tileInfo.Length - 1}] are valid for a {Size.X}x{Size.Y} Size template.");
+						throw new YamlException(
+							$"Tileset `{terrainInfo.Id}` template `{Id}` references frame {key}, but only [0..{tileInfo.Length - 1}] are valid for a {Size.X}x{Size.Y} Size template.");
 
 					tileInfo[key] = LoadTileInfo(terrainInfo, node.Value);
 				}

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -190,12 +190,14 @@ namespace OpenRA.Mods.Common.Traits
 			yield return new FacingInit(PreviewFacing);
 		}
 
-		public IReadOnlyDictionary<CPos, SubCell> OccupiedCells(ActorInfo info, CPos location, SubCell subCell = SubCell.Any) { return new Dictionary<CPos, SubCell>(); }
+		public IReadOnlyDictionary<CPos, SubCell> OccupiedCells(ActorInfo info, CPos location, SubCell subCell = SubCell.Any) =>
+			new Dictionary<CPos, SubCell>();
 
 		bool IOccupySpaceInfo.SharesCell => false;
 
 		// Used to determine if an aircraft can spawn landed
-		public bool CanEnterCell(World world, Actor self, CPos cell, SubCell subCell = SubCell.FullCell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
+		public bool CanEnterCell(World world, Actor self, CPos cell,
+			SubCell subCell = SubCell.FullCell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
 		{
 			if (!world.Map.Contains(cell))
 				return false;

--- a/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
@@ -27,7 +27,9 @@ namespace OpenRA.Mods.Common.Traits
 			"Strafe: Perform a fixed-length attack run on the target.")]
 		public readonly AirAttackType AttackType = AirAttackType.Default;
 
-		[Desc("Distance the strafing aircraft makes to a target before turning for another pass. When set to WDist.Zero this defaults to the maximum armament range.")]
+		[Desc(
+			"Distance the strafing aircraft makes to a target before turning for another pass. " +
+			"When set to WDist.Zero this defaults to the maximum armament range.")]
 		public readonly WDist StrafeRunLength = WDist.Zero;
 
 		public override object Create(ActorInitializer init) { return new AttackAircraft(init.Self, this); }
@@ -45,7 +47,8 @@ namespace OpenRA.Mods.Common.Traits
 			aircraftInfo = self.Info.TraitInfo<AircraftInfo>();
 		}
 
-		public override Activity GetAttackActivity(Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
+		public override Activity GetAttackActivity(
+			Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 		{
 			return new FlyAttack(self, source, newTarget, forceAttack, targetLineColor);
 		}

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -380,7 +380,10 @@ namespace OpenRA.Mods.Common.Traits
 				Burst = Weapon.Burst;
 
 				if (Weapon.AfterFireSound != null && Weapon.AfterFireSound.Length > 0)
-					ScheduleDelayedAction(Weapon.AfterFireSoundDelay, Burst, (burst) => Game.Sound.Play(SoundType.World, Weapon.AfterFireSound, self.World, self.CenterPosition));
+					ScheduleDelayedAction(
+						Weapon.AfterFireSoundDelay,
+						Burst,
+						burst => Game.Sound.Play(SoundType.World, Weapon.AfterFireSound, self.World, self.CenterPosition));
 
 				foreach (var nbc in notifyBurstComplete)
 					nbc.FiredBurst(self, target, this);

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -226,7 +226,8 @@ namespace OpenRA.Mods.Common.Traits
 			return order.OrderString == attackOrderName || order.OrderString == forceAttackOrderName ? Info.Voice : null;
 		}
 
-		public abstract Activity GetAttackActivity(Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null);
+		public abstract Activity GetAttackActivity(
+			Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null);
 
 		public bool HasAnyValidWeapons(in Target t, bool checkForCenterTargetingWeapons = false, bool reloadingIsInvalid = false)
 		{

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -159,7 +159,8 @@ namespace OpenRA.Mods.Common.Traits
 			base.Tick(self);
 		}
 
-		public override Activity GetAttackActivity(Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
+		public override Activity GetAttackActivity(
+			Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 		{
 			// HACK: Manually set force attacking if we persisted an opportunity target that required force attacking
 			if (opportunityTargetIsPersistentTarget && opportunityForceAttack && newTarget == OpportunityTarget)

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
@@ -39,7 +39,8 @@ namespace OpenRA.Mods.Common.Traits
 			return TargetInFiringArc(self, target, Info.FacingTolerance);
 		}
 
-		public override Activity GetAttackActivity(Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
+		public override Activity GetAttackActivity(
+			Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 		{
 			return new Activities.Attack(self, newTarget, allowMove, forceAttack, targetLineColor);
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
@@ -26,7 +26,8 @@ namespace OpenRA.Mods.Common.Traits
 		public AttackOmni(Actor self, AttackOmniInfo info)
 			: base(self, info) { }
 
-		public override Activity GetAttackActivity(Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
+		public override Activity GetAttackActivity(
+			Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 		{
 			return new SetTarget(this, newTarget, allowMove, forceAttack, targetLineColor);
 		}

--- a/OpenRA.Mods.Common/Traits/AutoCarryable.cs
+++ b/OpenRA.Mods.Common/Traits/AutoCarryable.cs
@@ -68,7 +68,9 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Inform all idle carriers
 			var carriers = self.World.ActorsWithTrait<AutoCarryall>()
-				.Where(c => c.Trait.State == Carryall.CarryallState.Idle && !c.Trait.IsTraitDisabled && c.Trait.EnableAutoCarry && !c.Actor.IsDead && c.Actor.Owner == self.Owner && c.Actor.IsInWorld)
+				.Where(c =>
+					c.Trait.State == Carryall.CarryallState.Idle && !c.Trait.IsTraitDisabled &&
+					c.Trait.EnableAutoCarry && !c.Actor.IsDead && c.Actor.Owner == self.Owner && c.Actor.IsInWorld)
 				.OrderBy(p => (self.Location - p.Actor.Location).LengthSquared);
 
 			// Enumerate idle carriers to find the first that is able to transport us

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -100,8 +100,12 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			playerBuildings = world.ActorsHavingTrait<Building>().Where(a => a.Owner == player).ToArray();
-			var excessPowerBonus = baseBuilder.Info.ExcessPowerIncrement * (playerBuildings.Length / baseBuilder.Info.ExcessPowerIncreaseThreshold.Clamp(1, int.MaxValue));
-			minimumExcessPower = (baseBuilder.Info.MinimumExcessPower + excessPowerBonus).Clamp(baseBuilder.Info.MinimumExcessPower, baseBuilder.Info.MaximumExcessPower);
+			var excessPowerBonus =
+				baseBuilder.Info.ExcessPowerIncrement *
+				(playerBuildings.Length / baseBuilder.Info.ExcessPowerIncreaseThreshold.Clamp(1, int.MaxValue));
+			minimumExcessPower =
+				(baseBuilder.Info.MinimumExcessPower + excessPowerBonus)
+					.Clamp(baseBuilder.Info.MinimumExcessPower, baseBuilder.Info.MaximumExcessPower);
 
 			// PERF: Queue only one actor at a time per category
 			itemQueuedThisTick = false;
@@ -344,7 +348,9 @@ namespace OpenRA.Mods.Common.Traits
 				var buildingVariantInfo = actorInfo.TraitInfoOrDefault<PlaceBuildingVariantsInfo>();
 				var variants = buildingVariantInfo?.Actors ?? Array.Empty<string>();
 
-				var count = playerBuildings.Count(a => a.Info.Name == name || variants.Contains(a.Info.Name)) + (baseBuilder.BuildingsBeingProduced.TryGetValue(name, out var num) ? num : 0);
+				var count = playerBuildings.Count(a =>
+					a.Info.Name == name || variants.Contains(a.Info.Name)) +
+					(baseBuilder.BuildingsBeingProduced.TryGetValue(name, out var num) ? num : 0);
 
 				// Do we want to build this structure?
 				if (count * 100 > frac.Value * playerBuildings.Length)

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/MinelayerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/MinelayerBotModule.cs
@@ -225,8 +225,21 @@ namespace OpenRA.Mods.Common.Traits
 					}
 
 					var vec = new CVec(Info.MineFieldRadius, Info.MineFieldRadius);
-					bot.QueueOrder(new Order("PlaceMinefield", null, Target.FromCell(world, minelayingPosition + vec), false, groupedActors: orderedActors.ToArray()) { ExtraLocation = minelayingPosition - vec });
-					bot.QueueOrder(new Order("Move", null, Target.FromCell(world, orderedActors[0].Location), true, groupedActors: orderedActors.ToArray()));
+					bot.QueueOrder(
+						new Order(
+							"PlaceMinefield",
+							null,
+							Target.FromCell(world, minelayingPosition + vec),
+							false,
+							groupedActors: orderedActors.ToArray())
+						{ ExtraLocation = minelayingPosition - vec });
+					bot.QueueOrder(
+						new Order(
+							"Move",
+							null,
+							Target.FromCell(world, orderedActors[0].Location),
+							true,
+							groupedActors: orderedActors.ToArray()));
 				}
 				else
 				{

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/MinelayerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/MinelayerBotModule.cs
@@ -148,7 +148,8 @@ namespace OpenRA.Mods.Common.Traits
 
 						foreach (var minelayer in minelayers)
 						{
-							var cells = pathFinder.FindPathToTargetCell(minelayer.Actor, new[] { minelayer.Actor.Location }, enemy.Location, BlockedByActor.Immovable, laneBias: false);
+							var cells = pathFinder.FindPathToTargetCell(
+								minelayer.Actor, new[] { minelayer.Actor.Location }, enemy.Location, BlockedByActor.Immovable, laneBias: false);
 							if (cells != null && cells.Count != 0)
 							{
 								AIUtils.BotDebug($"{player}: try find a location to lay mine.");
@@ -192,7 +193,8 @@ namespace OpenRA.Mods.Common.Traits
 
 				foreach (var minelayer in minelayers)
 				{
-					var cells = pathFinder.FindPathToTargetCell(minelayer.Actor, new[] { minelayer.Actor.Location }, minelayingPosition, BlockedByActor.Immovable, laneBias: false);
+					var cells = pathFinder.FindPathToTargetCell(
+						minelayer.Actor, new[] { minelayer.Actor.Location }, minelayingPosition, BlockedByActor.Immovable, laneBias: false);
 					if (cells != null && cells.Count != 0)
 					{
 						orderedActors.Add(minelayer.Actor);

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs
@@ -24,10 +24,16 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("What support power does this decision apply to?")]
 		public readonly string OrderName = "AirstrikePowerInfoOrder";
 
-		[Desc("What is the coarse scan radius of this power?", "For finding the general target area, before doing a detail scan", "Should be 10 or more to avoid lag")]
+		[Desc(
+			"What is the coarse scan radius of this power?",
+			"For finding the general target area, before doing a detail scan",
+			"Should be 10 or more to avoid lag")]
 		public readonly int CoarseScanRadius = 20;
 
-		[Desc("What is the fine scan radius of this power?", "For doing a detailed scan in the general target area.", "Minimum is 1")]
+		[Desc(
+			"What is the fine scan radius of this power?",
+			"For doing a detailed scan in the general target area.",
+			"Minimum is 1")]
 		public readonly int FineScanRadius = 2;
 
 		[FieldLoader.LoadUsing(nameof(LoadConsiderations))]

--- a/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
@@ -111,7 +111,9 @@ namespace OpenRA.Mods.Common.Traits
 					waitingPowers[sp] += 10;
 
 					// Note: SelectDirectionalTarget uses uint.MaxValue in ExtraData to indicate that the player did not pick a direction.
-					bot.QueueOrder(new Order(sp.Key, supportPowerManager.Self, Target.FromCell(world, attackLocation.Value), false) { SuppressVisualFeedback = true, ExtraData = uint.MaxValue });
+					bot.QueueOrder(
+						new Order(sp.Key, supportPowerManager.Self, Target.FromCell(world, attackLocation.Value), false)
+						{ SuppressVisualFeedback = true, ExtraData = uint.MaxValue });
 				}
 			}
 

--- a/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
@@ -23,7 +23,8 @@ namespace OpenRA.Mods.Common.Traits
 		// Reason: If this is less than SquadSize, the bot might get stuck between not producing more units due to this,
 		// but also not creating squads since there aren't enough idle units.
 		[Desc("If > 0, only produce units as long as there are less than this amount of units idling inside the base.",
-			"Beware: if it is less than squad size, e.g. the `SquadSize` from `SquadManagerBotModule`, the bot might get stuck as there aren't enough idle units to create squad.")]
+			"Beware: if it is less than squad size, e.g. the `SquadSize` from `SquadManagerBotModule`, " +
+			"the bot might get stuck as there aren't enough idle units to create squad.")]
 		public readonly int IdleBaseUnitsMaximum = -1;
 
 		[Desc("Production queues AI uses for producing units.")]

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoDockClientManager.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoDockClientManager.cs
@@ -140,7 +140,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (Info.RequiresForceMove && !forceEnter)
 				return false;
 
-			return !IsTraitDisabled && target.TraitsImplementing<DockHost>().Any(host => dockClients.Any(client => client.IsDockingPossible(host.GetDockType)));
+			return !IsTraitDisabled && target.TraitsImplementing<DockHost>().Any(
+				host => dockClients.Any(client => client.IsDockingPossible(host.GetDockType)));
 		}
 
 		/// <summary>Clone of <see cref="DockClientManager.DockingPossible(Actor, TargetModifiers)"/>.</summary>
@@ -150,7 +151,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (Info.RequiresForceMove && !forceEnter)
 				return false;
 
-			return !IsTraitDisabled && target.TraitsImplementing<DockHost>().Any(host => dockClients.Any(client => client.IsDockingPossible(host.GetDockType, forceEnter)));
+			return !IsTraitDisabled && target.TraitsImplementing<DockHost>().Any(
+				host => dockClients.Any(client => client.IsDockingPossible(host.GetDockType, forceEnter)));
 		}
 
 		/// <summary>Clone of <see cref="DockClientManager.CanDockAt(Actor, bool, bool)"/>.</summary>
@@ -159,7 +161,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!(self.CurrentActivity is Transform || transforms.Any(t => !t.IsTraitDisabled && !t.IsTraitPaused)))
 				return false;
 
-			return !IsTraitDisabled && target.TraitsImplementing<DockHost>().Any(host => dockClients.Any(client => client.CanDockAt(target, host, forceEnter, true)));
+			return !IsTraitDisabled && target.TraitsImplementing<DockHost>().Any(
+				host => dockClients.Any(client => client.CanDockAt(target, host, forceEnter, true)));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -411,7 +411,9 @@ namespace OpenRA.Mods.Common.Traits
 		void INotifyKilled.Killed(Actor self, AttackInfo e)
 		{
 			// IsAtGroundLevel contains Map.Contains(self.Location) check.
-			if (Info.EjectOnDeath && self.IsAtGroundLevel() && (!checkTerrainType || Info.UnloadTerrainTypes.Contains(self.World.Map.GetTerrainInfo(self.Location).Type)))
+			if (Info.EjectOnDeath &&
+				self.IsAtGroundLevel() &&
+				(!checkTerrainType || Info.UnloadTerrainTypes.Contains(self.World.Map.GetTerrainInfo(self.Location).Type)))
 			{
 				while (!IsEmpty())
 				{

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -50,7 +50,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Measured in game ticks.")]
 		public readonly int CloakDelay = 30;
 
-		[Desc("Events leading to the actor getting uncloaked. Possible values are: Attack, Move, Unload, Infiltrate, Demolish, Dock, Damage, Heal, SelfHeal and SupportPower.",
+		[Desc(
+			"Events leading to the actor getting uncloaked. " +
+			"Possible values are: Attack, Move, Unload, Infiltrate, Demolish, Dock, Damage, Heal, SelfHeal and SupportPower.",
 			"'Dock' is triggered when docking to a refinery or resupplying.",
 			"'SupportPower' is triggered when using a support power.")]
 		public readonly UncloakType UncloakOn = UncloakType.Attack
@@ -108,7 +110,8 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Cloak(this); }
 	}
 
-	public class Cloak : PausableConditionalTrait<CloakInfo>, IRenderModifier, INotifyDamage, INotifyUnloadCargo, INotifyLoadCargo, INotifyDemolition, INotifyInfiltration,
+	public class Cloak : PausableConditionalTrait<CloakInfo>,
+		IRenderModifier, INotifyDamage, INotifyUnloadCargo, INotifyLoadCargo, INotifyDemolition, INotifyInfiltration,
 		INotifyAttack, ITick, IVisibilityModifier, IRadarColorModifier, INotifyDockClient, INotifySupportPower
 	{
 		readonly float3 cloakedColor;

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeployWithCharge.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeployWithCharge.cs
@@ -35,7 +35,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Cooldown (in ticks) to reach full charge.")]
 		public readonly int ChargeDuration = 500;
 
-		[Desc("The ammount of charge that needs to be present for deploy to be issued. If set to -1, threshold is set to full charge. If activated without full charge " + nameof(ConditionDuration) + " is percentally smaller.")]
+		[Desc("The amount of charge that needs to be present for deploy to be issued. " +
+			"If set to -1, threshold is set to full charge. " +
+			"If activated without full charge " + nameof(ConditionDuration) + " is percentally smaller.")]
 		public readonly int ChargeThreshhold = -1;
 
 		[Desc("How long (in ticks) should the condition stay active?")]
@@ -78,7 +80,8 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class GrantConditionOnDeployWithCharge : PausableConditionalTrait<GrantConditionOnDeployWithChargeInfo>, IIssueOrder, IResolveOrder, ITick, ISelectionBar, IOrderVoice, ISync, IIssueDeployOrder
+	public class GrantConditionOnDeployWithCharge : PausableConditionalTrait<GrantConditionOnDeployWithChargeInfo>,
+		IIssueOrder, IResolveOrder, ITick, ISelectionBar, IOrderVoice, ISync, IIssueDeployOrder
 	{
 		[Sync]
 		int chargeTick = 0;

--- a/OpenRA.Mods.Common/Traits/Conditions/ProximityExternalCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ProximityExternalCondition.cs
@@ -42,7 +42,8 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new ProximityExternalCondition(init.Self, this); }
 	}
 
-	public class ProximityExternalCondition : ConditionalTrait<ProximityExternalConditionInfo>, ITick, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyOtherProduction, INotifyProximityOwnerChanged
+	public class ProximityExternalCondition : ConditionalTrait<ProximityExternalConditionInfo>,
+		ITick, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyOtherProduction, INotifyProximityOwnerChanged
 	{
 		readonly Actor self;
 

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -39,7 +39,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool IOccupySpaceInfo.SharesCell => false;
 
-		public bool CanEnterCell(World world, Actor self, CPos cell, SubCell subCell = SubCell.FullCell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
+		public bool CanEnterCell(World world, Actor self, CPos cell,
+			SubCell subCell = SubCell.FullCell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
 		{
 			// Since crates don't share cells and GetAvailableSubCell only returns SubCell.Full or SubCell.Invalid, we ignore the subCell parameter
 			return GetAvailableSubCell(world, cell, ignoreActor, check) != SubCell.Invalid;

--- a/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
@@ -45,7 +45,9 @@ namespace OpenRA.Mods.Common.Traits
 			this.self = self;
 			this.info = info;
 			if (info.Units.Length == 0)
-				throw new YamlException("A GiveUnitCrateAction does not specify any units to give. This might be because the yaml is referring to 'Unit' rather than 'Units'.");
+				throw new YamlException(
+					"A GiveUnitCrateAction does not specify any units to give. " +
+					"This might be because the yaml is referring to 'Unit' rather than 'Units'.");
 		}
 
 		public bool CanGiveTo(Actor collector)

--- a/OpenRA.Mods.Common/Traits/DeliversExperience.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversExperience.cs
@@ -17,7 +17,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	[Desc("This actor can grant experience levels equal to it's own current level via entering to other actors with the `" + nameof(AcceptsDeliveredExperience) + "` trait.")]
+	[Desc("This actor can grant experience levels equal to it's own current level " +
+		"via entering to other actors with the `" + nameof(AcceptsDeliveredExperience) + "` trait.")]
 	sealed class DeliversExperienceInfo : TraitInfo, Requires<GainsExperienceInfo>
 	{
 		[Desc("The amount of experience the donating player receives.")]

--- a/OpenRA.Mods.Common/Traits/DockClientBase.cs
+++ b/OpenRA.Mods.Common/Traits/DockClientBase.cs
@@ -42,7 +42,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual bool CanDockAt(Actor hostActor, IDockHost host, bool forceEnter = false, bool ignoreOccupancy = false)
 		{
-			return (forceEnter || self.Owner.IsAlliedWith(hostActor.Owner)) && IsDockingPossible(host.GetDockType, forceEnter) && host.IsDockingPossible(self, this, ignoreOccupancy);
+			return (forceEnter || self.Owner.IsAlliedWith(hostActor.Owner)) &&
+				IsDockingPossible(host.GetDockType, forceEnter) &&
+				host.IsDockingPossible(self, this, ignoreOccupancy);
 		}
 
 		public virtual void OnDockStarted(Actor self, Actor hostActor, IDockHost host) { }

--- a/OpenRA.Mods.Common/Traits/DockClientManager.cs
+++ b/OpenRA.Mods.Common/Traits/DockClientManager.cs
@@ -240,26 +240,30 @@ namespace OpenRA.Mods.Common.Traits
 		/// <summary>Does this <paramref name="target"/> contain at least one enabled <see cref="IDockHost"/> with maching <see cref="DockType"/>.</summary>
 		public bool DockingPossible(Actor target)
 		{
-			return !IsTraitDisabled && target.TraitsImplementing<IDockHost>().Any(host => dockClients.Any(client => client.IsDockingPossible(host.GetDockType)));
+			return !IsTraitDisabled && target.TraitsImplementing<IDockHost>().Any(
+				host => dockClients.Any(client => client.IsDockingPossible(host.GetDockType)));
 		}
 
 		/// <summary>Does this <paramref name="target"/> contain at least one enabled <see cref="IDockHost"/> with maching <see cref="DockType"/>.</summary>
 		public bool DockingPossible(Actor target, TargetModifiers modifiers)
 		{
 			var forceEnter = modifiers.HasModifier(TargetModifiers.ForceMove);
-			return !IsTraitDisabled && target.TraitsImplementing<IDockHost>().Any(host => dockClients.Any(client => client.IsDockingPossible(host.GetDockType, forceEnter)));
+			return !IsTraitDisabled && target.TraitsImplementing<IDockHost>().Any(
+				host => dockClients.Any(client => client.IsDockingPossible(host.GetDockType, forceEnter)));
 		}
 
 		/// <summary>Can we dock to this <paramref name="host"/>.</summary>
 		public bool CanDockAt(Actor hostActor, IDockHost host, bool forceEnter = false, bool ignoreOccupancy = false)
 		{
-			return !IsTraitDisabled && dockClients.Any(client => client.CanDockAt(hostActor, host, forceEnter, ignoreOccupancy));
+			return !IsTraitDisabled && dockClients.Any(
+				client => client.CanDockAt(hostActor, host, forceEnter, ignoreOccupancy));
 		}
 
 		/// <summary>Can we dock to this <paramref name="target"/>.</summary>
 		public bool CanDockAt(Actor target, bool forceEnter = false, bool ignoreOccupancy = false)
 		{
-			return !IsTraitDisabled && target.TraitsImplementing<IDockHost>().Any(host => dockClients.Any(client => client.CanDockAt(target, host, forceEnter, ignoreOccupancy)));
+			return !IsTraitDisabled && target.TraitsImplementing<IDockHost>().Any(
+				host => dockClients.Any(client => client.CanDockAt(target, host, forceEnter, ignoreOccupancy)));
 		}
 
 		/// <summary>Find the closest viable <see cref="IDockHost"/>.</summary>
@@ -268,7 +272,9 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var clients = type.IsEmpty ? dockClients : AvailableDockClients(type);
 			return self.World.ActorsWithTrait<IDockHost>()
-				.Where(host => host.Trait != ignore && clients.Any(client => client.CanDockAt(host.Actor, host.Trait, forceEnter, ignoreOccupancy)))
+				.Where(host =>
+					host.Trait != ignore &&
+					clients.Any(client => client.CanDockAt(host.Actor, host.Trait, forceEnter, ignoreOccupancy)))
 				.ClosestDock(self, this);
 		}
 

--- a/OpenRA.Mods.Common/Traits/DockClientManager.cs
+++ b/OpenRA.Mods.Common/Traits/DockClientManager.cs
@@ -322,7 +322,9 @@ namespace OpenRA.Mods.Common.Traits
 			else
 			{
 				return docks
-					.OrderBy(dock => (clientActor.Location - clientActor.World.Map.CellContaining(dock.Trait.DockPosition)).LengthSquared + dock.Trait.ReservationCount * client.OccupancyCostModifier)
+					.OrderBy(dock =>
+						(clientActor.Location - clientActor.World.Map.CellContaining(dock.Trait.DockPosition)).LengthSquared +
+						dock.Trait.ReservationCount * client.OccupancyCostModifier)
 					.FirstOrDefault();
 			}
 

--- a/OpenRA.Mods.Common/Traits/DockHost.cs
+++ b/OpenRA.Mods.Common/Traits/DockHost.cs
@@ -133,7 +133,8 @@ namespace OpenRA.Mods.Common.Traits
 				OnDockCompleted(self, dockedClientActor, dockedClient);
 		}
 
-		public virtual bool QueueMoveActivity(Activity moveToDockActivity, Actor self, Actor clientActor, DockClientManager client, MoveCooldownHelper moveCooldownHelper)
+		public virtual bool QueueMoveActivity(
+			Activity moveToDockActivity, Actor self, Actor clientActor, DockClientManager client, MoveCooldownHelper moveCooldownHelper)
 		{
 			var move = clientActor.Trait<IMove>();
 

--- a/OpenRA.Mods.Common/Traits/DockHost.cs
+++ b/OpenRA.Mods.Common/Traits/DockHost.cs
@@ -48,7 +48,8 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new DockHost(init.Self, this); }
 	}
 
-	public class DockHost : ConditionalTrait<DockHostInfo>, IDockHost, IDockHostDrag, ITick, INotifySold, INotifyCapture, INotifyOwnerChanged, ISync, INotifyKilled, INotifyActorDisposing
+	public class DockHost : ConditionalTrait<DockHostInfo>,
+		IDockHost, IDockHostDrag, ITick, INotifySold, INotifyCapture, INotifyOwnerChanged, ISync, INotifyKilled, INotifyActorDisposing
 	{
 		readonly Actor self;
 

--- a/OpenRA.Mods.Common/Traits/GivesBounty.cs
+++ b/OpenRA.Mods.Common/Traits/GivesBounty.cs
@@ -72,7 +72,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			var displayedBounty = GetDisplayedBountyValue(self);
 			if (Info.ShowBounty && self.IsInWorld && displayedBounty != 0 && e.Attacker.Owner.IsAlliedWith(self.World.RenderPlayer))
-				e.Attacker.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, e.Attacker.OwnerColor(), FloatingText.FormatCashTick(displayedBounty), 30)));
+				e.Attacker.World.AddFrameEndTask(
+					w => w.Add(new FloatingText(self.CenterPosition, e.Attacker.OwnerColor(), FloatingText.FormatCashTick(displayedBounty), 30)));
 
 			e.Attacker.Owner.PlayerActor.Trait<PlayerResources>().ChangeCash(GetBountyValue(self));
 		}

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -47,7 +47,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool IOccupySpaceInfo.SharesCell => false;
 
-		public bool CanEnterCell(World world, Actor self, CPos cell, SubCell subCell = SubCell.FullCell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
+		public bool CanEnterCell(World world, Actor self, CPos cell,
+			SubCell subCell = SubCell.FullCell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
 		{
 			// IPositionable*Info*.CanEnterCell is only ever used for things like exiting production facilities,
 			// all places relevant for husks check IPositionable.CanEnterCell instead, so we can safely set this to true.

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -127,7 +127,8 @@ namespace OpenRA.Mods.Common.Traits
 		/// <summary>
 		/// Note: If the target <paramref name="cell"/> has any free subcell, the value of <paramref name="subCell"/> is ignored.
 		/// </summary>
-		public bool CanEnterCell(World world, Actor self, CPos cell, SubCell subCell = SubCell.FullCell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
+		public bool CanEnterCell(World world, Actor self, CPos cell,
+			SubCell subCell = SubCell.FullCell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
 		{
 			// PERF: Avoid repeated trait queries on the hot path
 			locomotor ??= world.WorldActor.TraitsImplementing<Locomotor>()

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -26,7 +26,8 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new FrozenUnderFog(init, this); }
 	}
 
-	public class FrozenUnderFog : ICreatesFrozenActors, IRenderModifier, IDefaultVisibility, ITickRender, ISync, INotifyCreated, INotifyOwnerChanged, INotifyActorDisposing
+	public class FrozenUnderFog : ICreatesFrozenActors, IRenderModifier, IDefaultVisibility,
+		ITickRender, ISync, INotifyCreated, INotifyOwnerChanged, INotifyActorDisposing
 	{
 		[Sync]
 		public int VisibilityHash;

--- a/OpenRA.Mods.Common/Traits/Palettes/IndexedPlayerPalette.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/IndexedPlayerPalette.cs
@@ -63,7 +63,9 @@ namespace OpenRA.Mods.Common.Traits
 			ImmutablePalette pal;
 
 			if (info.PlayerIndex.TryGetValue(playerName, out var remap))
-				pal = new ImmutablePalette(basePalette, new IndexedColorRemap(basePalette, info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToArray() : info.RemapIndex, remap));
+				pal = new ImmutablePalette(
+					basePalette,
+					new IndexedColorRemap(basePalette, info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToArray() : info.RemapIndex, remap));
 			else
 				pal = new ImmutablePalette(basePalette);
 

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromGrayscale.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromGrayscale.cs
@@ -55,7 +55,9 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.Tileset != null && !string.Equals(info.Tileset, world.Map.Tileset, StringComparison.InvariantCultureIgnoreCase))
 				return;
 
-			wr.AddPalette(info.Name, new ImmutablePalette(Enumerable.Range(0, Palette.Size).Select(i => (i == info.TransparentIndex) ? 0 : Color.FromArgb(255, i, i, i).ToArgb())), info.AllowModifiers);
+			wr.AddPalette(info.Name, new ImmutablePalette(
+				Enumerable.Range(0, Palette.Size).Select(i => (i == info.TransparentIndex) ? 0 : Color.FromArgb(255, i, i, i).ToArgb())),
+				info.AllowModifiers);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -61,7 +61,8 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Passenger(this); }
 	}
 
-	public class Passenger : IIssueOrder, IResolveOrder, IOrderVoice, INotifyRemovedFromWorld, INotifyEnteredCargo, INotifyExitedCargo, INotifyKilled, IObservesVariables
+	public class Passenger : IIssueOrder, IResolveOrder, IOrderVoice,
+		INotifyRemovedFromWorld, INotifyEnteredCargo, INotifyExitedCargo, INotifyKilled, IObservesVariables
 	{
 		public readonly PassengerInfo Info;
 		public Actor Transport;

--- a/OpenRA.Mods.Common/Traits/Player/ClassicParallelProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicParallelProductionQueue.cs
@@ -219,7 +219,9 @@ namespace OpenRA.Mods.Common.Traits
 				.GroupBy(i => i.Item)
 				.ToList()
 				.Count;
-			return item.RemainingTimeActual * parallelBuilds * info.ParallelPenaltyBuildTimeMultipliers[Math.Min(parallelBuilds - 1, info.ParallelPenaltyBuildTimeMultipliers.Length - 1)] / 100;
+			return item.RemainingTimeActual *
+				parallelBuilds *
+				info.ParallelPenaltyBuildTimeMultipliers[Math.Min(parallelBuilds - 1, info.ParallelPenaltyBuildTimeMultipliers.Length - 1)] / 100;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
@@ -66,7 +66,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
-			yield return new LobbyBooleanOption(map, "cheats", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
+			yield return new LobbyBooleanOption(map, "cheats",
+				CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
 		}
 
 		public override object Create(ActorInitializer init) { return new DeveloperMode(this); }

--- a/OpenRA.Mods.Common/Traits/Player/ModularBot.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ModularBot.cs
@@ -28,7 +28,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Human-readable name this bot uses.")]
 		public readonly string Name = "Unnamed Bot";
 
-		[Desc("Minimum portion of pending orders to issue each tick (e.g. 5 issues at least 1/5th of all pending orders). Excess orders remain queued for subsequent ticks.")]
+		[Desc("Minimum portion of pending orders to issue each tick (e.g. 5 issues at least 1/5th of all pending orders). " +
+			"Excess orders remain queued for subsequent ticks.")]
 		public readonly int MinOrderQuotientPerTick = 5;
 
 		string IBotInfo.Type => Type;

--- a/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
@@ -66,7 +66,8 @@ namespace OpenRA.Mods.Common.Traits
 			var startingCash = SelectableCash.ToDictionary(c => c.ToStringInvariant(), c => "$" + c.ToString(NumberFormatInfo.CurrentInfo));
 
 			if (startingCash.Count > 0)
-				yield return new LobbyOption(map, "startingcash", DefaultCashDropdownLabel, DefaultCashDropdownDescription, DefaultCashDropdownVisible, DefaultCashDropdownDisplayOrder,
+				yield return new LobbyOption(map, "startingcash",
+					DefaultCashDropdownLabel, DefaultCashDropdownDescription, DefaultCashDropdownVisible, DefaultCashDropdownDisplayOrder,
 					startingCash, DefaultCash.ToStringInvariant(), DefaultCashDropdownLocked);
 		}
 

--- a/OpenRA.Mods.Common/Traits/ProximityCapturableBase.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCapturableBase.cs
@@ -41,7 +41,8 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var pci = rules.Actors[SystemActors.Player].TraitInfoOrDefault<ProximityCaptorInfo>();
 			if (pci == null)
-				throw new YamlException(nameof(ProximityCapturableBase) + " requires the `" + nameof(Player) + "` actor to have the " + nameof(ProximityCaptor) + " trait.");
+				throw new YamlException(
+					nameof(ProximityCapturableBase) + " requires the `" + nameof(Player) + "` actor to have the " + nameof(ProximityCaptor) + " trait.");
 		}
 
 		public abstract override object Create(ActorInitializer init);

--- a/OpenRA.Mods.Common/Traits/Render/WithAttackOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAttackOverlay.cs
@@ -60,7 +60,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var body = init.Self.TraitOrDefault<BodyOrientation>();
 			var facing = init.Self.TraitOrDefault<IFacing>();
 
-			overlay = new Animation(init.World, renderSprites.GetImage(init.Self), facing == null ? () => WAngle.Zero : (body == null ? () => facing.Facing : () => body.QuantizeFacing(facing.Facing)))
+			overlay = new Animation(init.World, renderSprites.GetImage(init.Self),
+				facing == null ? () => WAngle.Zero : (body == null ? () => facing.Facing : () => body.QuantizeFacing(facing.Facing)))
 			{
 				IsDecoration = info.IsDecoration
 			};

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -95,7 +95,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var facing = self.TraitOrDefault<IFacing>();
 
 			var image = info.Image ?? rs.GetImage(self);
-			overlay = new Animation(self.World, image, facing == null ? () => WAngle.Zero : (body == null ? () => facing.Facing : () => body.QuantizeFacing(facing.Facing)), () => IsTraitPaused)
+			overlay = new Animation(self.World, image,
+				facing == null ? () => WAngle.Zero : (body == null ? () => facing.Facing : () => body.QuantizeFacing(facing.Facing)),
+				() => IsTraitPaused)
 			{
 				IsDecoration = info.IsDecoration
 			};

--- a/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
@@ -182,7 +182,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var palette = wr.Palette(info.Palette);
 			var alpha = shadow.CurrentSequence.GetAlpha(shadow.CurrentFrame);
 			var tintModifiers = shadow.CurrentSequence.IgnoreWorldTint ? TintModifiers.ReplaceColor | TintModifiers.IgnoreWorldTint : TintModifiers.ReplaceColor;
-			return new IRenderable[] { new SpriteRenderable(shadow.Image, pos, info.ShadowOffset, info.ShadowZOffset, palette, 1, shadowAlpha * alpha, shadowColor, tintModifiers, true) };
+			return new IRenderable[]
+			{
+				new SpriteRenderable(shadow.Image, pos, info.ShadowOffset, info.ShadowZOffset, palette, 1, shadowAlpha * alpha, shadowColor, tintModifiers, true)
+			};
 		}
 
 		IEnumerable<Rectangle> IRender.ScreenBounds(Actor self, WorldRenderer wr)

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
@@ -18,7 +18,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Play an animation when a unit exits or blocks the exit after production finished.")]
-	sealed class WithProductionDoorOverlayInfo : ConditionalTraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>, Requires<BuildingInfo>
+	sealed class WithProductionDoorOverlayInfo : ConditionalTraitInfo,
+		IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>, Requires<BuildingInfo>
 	{
 		[SequenceReference]
 		public readonly string Sequence = "build-door";

--- a/OpenRA.Mods.Common/Traits/Render/WithSwitchableOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSwitchableOverlay.cs
@@ -137,7 +137,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			var anim = new AnimationWithOffset(overlay,
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self.Orientation))),
-				() => IsTraitDisabled || (Info.SwitchingSequence == null && chargeSpeed != 0) || (Info.EnabledSequence == null && switchingLevel > Info.SwitchingLevel) || (Info.DisabledSequence == null && switchingLevel < 0),
+				() =>
+					IsTraitDisabled ||
+					(Info.SwitchingSequence == null && chargeSpeed != 0) ||
+					(Info.EnabledSequence == null && switchingLevel > Info.SwitchingLevel) ||
+					(Info.DisabledSequence == null && switchingLevel < 0),
 				p => RenderUtils.ZOffsetFromCenter(self, p, 1));
 
 			rs.Add(anim, info.Palette, info.IsPlayerPalette);

--- a/OpenRA.Mods.Common/Traits/Render/WithSwitchableOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSwitchableOverlay.cs
@@ -18,7 +18,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Renders a decorative animation on units and buildings. Overlay switching controlled by " + nameof(PauseOnCondition) + ".")]
-	public class WithSwitchableOverlayInfo : PausableConditionalTraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
+	public class WithSwitchableOverlayInfo : PausableConditionalTraitInfo,
+		IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
 		[Desc("Image used for this decoration. Defaults to the actor's type.")]
 		public readonly string Image = null;
@@ -123,7 +124,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var facing = self.TraitOrDefault<IFacing>();
 
 			var image = info.Image ?? rs.GetImage(self);
-			overlay = new Animation(self.World, image, facing == null ? () => WAngle.Zero : (body == null ? () => facing.Facing : () => body.QuantizeFacing(facing.Facing)), () => false)
+			overlay = new Animation(
+				self.World,
+				image,
+				facing == null ? () => WAngle.Zero : (body == null ? () => facing.Facing : () => body.QuantizeFacing(facing.Facing)),
+				() => false)
 			{
 				IsDecoration = info.IsDecoration
 			};

--- a/OpenRA.Mods.Common/Traits/RepairsBridges.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsBridges.cs
@@ -111,7 +111,9 @@ namespace OpenRA.Mods.Common.Traits
 				else
 					return;
 
-				self.QueueActivity(order.Queued, new RepairBridge(self, order.Target, info.EnterBehaviour, info.RepairNotification, info.RepairTextNotification, info.TargetLineColor));
+				self.QueueActivity(
+					order.Queued,
+					new RepairBridge(self, order.Target, info.EnterBehaviour, info.RepairNotification, info.RepairTextNotification, info.TargetLineColor));
 				self.ShowTargetLines();
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/World/ColorPickerManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/ColorPickerManager.cs
@@ -82,7 +82,8 @@ namespace OpenRA.Mods.Common.Traits
 			return false;
 		}
 
-		Color MakeValid(float hue, float sat, float val, MersenneTwister random, IReadOnlyCollection<Color> terrainColors, IReadOnlyCollection<Color> playerColors, Action<string> onError)
+		Color MakeValid(float hue, float sat, float val, MersenneTwister random,
+			IReadOnlyCollection<Color> terrainColors, IReadOnlyCollection<Color> playerColors, Action<string> onError)
 		{
 			// Clamp saturation without triggering a warning
 			// This can only happen due to rounding errors (common) or modified clients (rare)
@@ -132,7 +133,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		Color[] IColorPickerManagerInfo.PresetColors => PresetColors;
 
-		Color IColorPickerManagerInfo.RandomPresetColor(MersenneTwister random, IReadOnlyCollection<Color> terrainColors, IReadOnlyCollection<Color> playerColors)
+		Color IColorPickerManagerInfo.RandomPresetColor(
+			MersenneTwister random,
+			IReadOnlyCollection<Color> terrainColors,
+			IReadOnlyCollection<Color> playerColors)
 		{
 			foreach (var color in PresetColors.Shuffle(random))
 			{
@@ -148,13 +152,21 @@ namespace OpenRA.Mods.Common.Traits
 			return MakeValid(randomHue, randomSat, randomVal, random, terrainColors, playerColors, null);
 		}
 
-		Color IColorPickerManagerInfo.MakeValid(Color color, MersenneTwister random, IReadOnlyCollection<Color> terrainColors, IReadOnlyCollection<Color> playerColors, Action<string> onError)
+		Color IColorPickerManagerInfo.MakeValid(
+			Color color,
+			MersenneTwister random,
+			IReadOnlyCollection<Color> terrainColors,
+			IReadOnlyCollection<Color> playerColors,
+			Action<string> onError)
 		{
 			var (_, h, s, v) = color.ToAhsv();
 			return MakeValid(h, s, v, random, terrainColors, playerColors, onError);
 		}
 
-		Color IColorPickerManagerInfo.RandomValidColor(MersenneTwister random, IReadOnlyCollection<Color> terrainColors, IReadOnlyCollection<Color> playerColors)
+		Color IColorPickerManagerInfo.RandomValidColor(
+			MersenneTwister random,
+			IReadOnlyCollection<Color> terrainColors,
+			IReadOnlyCollection<Color> playerColors)
 		{
 			var h = random.NextFloat();
 			var s = float2.Lerp(HsvSaturationRange[0], HsvSaturationRange[1], random.NextFloat());
@@ -162,7 +174,12 @@ namespace OpenRA.Mods.Common.Traits
 			return MakeValid(h, s, v, random, terrainColors, playerColors, null);
 		}
 
-		void IColorPickerManagerInfo.ShowColorDropDown(DropDownButtonWidget dropdownButton, Color initialColor, string initialFaction, WorldRenderer worldRenderer, Action<Color> onExit)
+		void IColorPickerManagerInfo.ShowColorDropDown(
+			DropDownButtonWidget dropdownButton,
+			Color initialColor,
+			string initialFaction,
+			WorldRenderer worldRenderer,
+			Action<Color> onExit)
 		{
 			dropdownButton.RemovePanel();
 
@@ -177,7 +194,9 @@ namespace OpenRA.Mods.Common.Traits
 				if (initialFaction == null || !FactionPreviewActors.TryGetValue(initialFaction, out var actorType))
 				{
 					if (PreviewActor == null)
-						throw new YamlException($"{nameof(ColorPickerManager)} does not define a preview actor" + (initialFaction == null ? "." : $"for faction {initialFaction}."));
+						throw new YamlException(
+							$"{nameof(ColorPickerManager)} does not define a preview actor" +
+							(initialFaction == null ? "." : $" for faction {initialFaction}."));
 
 					actorType = PreviewActor;
 				}

--- a/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
@@ -81,7 +81,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
-			yield return new LobbyBooleanOption(map, "crates", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
+			yield return new LobbyBooleanOption(map, "crates",
+				CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
 		}
 
 		public override object Create(ActorInitializer init) { return new CrateSpawner(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -206,7 +206,8 @@ namespace OpenRA.Mods.Common.Traits
 			return terrainInfos[index].Speed;
 		}
 
-		public short MovementCostToEnterCell(Actor actor, CPos destNode, BlockedByActor check, Actor ignoreActor, bool ignoreSelf = false, SubCell subCell = SubCell.FullCell)
+		public short MovementCostToEnterCell(
+			Actor actor, CPos destNode, BlockedByActor check, Actor ignoreActor, bool ignoreSelf = false, SubCell subCell = SubCell.FullCell)
 		{
 			var cellCost = MovementCostForCell(destNode);
 
@@ -217,7 +218,8 @@ namespace OpenRA.Mods.Common.Traits
 			return cellCost;
 		}
 
-		public short MovementCostToEnterCell(Actor actor, CPos srcNode, CPos destNode, BlockedByActor check, Actor ignoreActor, bool ignoreSelf = false)
+		public short MovementCostToEnterCell(
+			Actor actor, CPos srcNode, CPos destNode, BlockedByActor check, Actor ignoreActor, bool ignoreSelf = false)
 		{
 			var cellCost = MovementCostForCell(destNode, srcNode);
 

--- a/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
@@ -40,7 +40,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
-			yield return new LobbyBooleanOption(map, "creeps", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
+			yield return new LobbyBooleanOption(map, "creeps",
+				CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
 		}
 
 		public override object Create(ActorInitializer init) { return new MapCreeps(this); }

--- a/OpenRA.Mods.Common/Traits/World/MapOptions.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapOptions.cs
@@ -81,14 +81,16 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
-			yield return new LobbyBooleanOption(map, "shortgame", ShortGameCheckboxLabel, ShortGameCheckboxDescription,
+			yield return new LobbyBooleanOption(map, "shortgame",
+				ShortGameCheckboxLabel, ShortGameCheckboxDescription,
 				ShortGameCheckboxVisible, ShortGameCheckboxDisplayOrder, ShortGameCheckboxEnabled, ShortGameCheckboxLocked);
 
 			var techLevels = map.PlayerActorInfo.TraitInfos<ProvidesTechPrerequisiteInfo>()
 				.ToDictionary(t => t.Id, t => map.GetLocalisedString(t.Name));
 
 			if (techLevels.Count > 0)
-				yield return new LobbyOption(map, "techlevel", TechLevelDropdownLabel, TechLevelDropdownDescription, TechLevelDropdownVisible, TechLevelDropdownDisplayOrder,
+				yield return new LobbyOption(map, "techlevel",
+					TechLevelDropdownLabel, TechLevelDropdownDescription, TechLevelDropdownVisible, TechLevelDropdownDisplayOrder,
 					techLevels, TechLevel, TechLevelDropdownLocked);
 
 			var gameSpeeds = Game.ModData.Manifest.Get<GameSpeeds>();

--- a/OpenRA.Mods.Common/Traits/World/OrderEffects.cs
+++ b/OpenRA.Mods.Common/Traits/World/OrderEffects.cs
@@ -95,7 +95,8 @@ namespace OpenRA.Mods.Common.Traits
 
 				case TargetType.Terrain:
 				{
-					world.AddFrameEndTask(w => w.Add(new SpriteAnnotation(target.CenterPosition, world, info.TerrainFlashImage, info.TerrainFlashSequence, info.TerrainFlashPalette)));
+					world.AddFrameEndTask(w => w.Add(new SpriteAnnotation(
+						target.CenterPosition, world, info.TerrainFlashImage, info.TerrainFlashSequence, info.TerrainFlashPalette)));
 					return true;
 				}
 

--- a/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
@@ -19,7 +19,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World)]
-	[Desc("Spawn base actor at the spawnpoint and support units in an annulus around the base actor. Both are defined at MPStartUnits. Attach this to the world actor.")]
+	[Desc("Spawn base actor at the spawnpoint and support units in an annulus around the base actor. " +
+		"Both are defined at MPStartUnits. Attach this to the world actor.")]
 	public class SpawnStartingUnitsInfo : TraitInfo, Requires<StartingUnitsInfo>, NotBefore<LocomotorInfo>, ILobbyOptions
 	{
 		public readonly string StartingUnitsClass = "none";

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -377,7 +377,8 @@ namespace OpenRA.Mods.Common.Traits
 		Color[] PresetColors { get; }
 		Color RandomPresetColor(MersenneTwister random, IReadOnlyCollection<Color> terrainColors, IReadOnlyCollection<Color> playerColors);
 		Color RandomValidColor(MersenneTwister random, IReadOnlyCollection<Color> terrainColors, IReadOnlyCollection<Color> playerColors);
-		Color MakeValid(Color color, MersenneTwister random, IReadOnlyCollection<Color> terrainColors, IReadOnlyCollection<Color> playerColors, Action<string> onError = null);
+		Color MakeValid(
+			Color color, MersenneTwister random, IReadOnlyCollection<Color> terrainColors, IReadOnlyCollection<Color> playerColors, Action<string> onError = null);
 		void ShowColorDropDown(DropDownButtonWidget dropdownButton, Color initialColor, string initialFaction, WorldRenderer worldRenderer, Action<Color> onExit);
 	}
 
@@ -876,7 +877,8 @@ namespace OpenRA.Mods.Common.Traits
 
 	public interface IPositionableInfo : IOccupySpaceInfo
 	{
-		bool CanEnterCell(World world, Actor self, CPos cell, SubCell subCell = SubCell.FullCell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All);
+		bool CanEnterCell(World world, Actor self, CPos cell,
+			SubCell subCell = SubCell.FullCell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All);
 	}
 
 	public interface IPositionable : IOccupySpace
@@ -885,7 +887,8 @@ namespace OpenRA.Mods.Common.Traits
 		bool IsLeavingCell(CPos location, SubCell subCell = SubCell.Any);
 		bool CanEnterCell(CPos location, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All);
 		SubCell GetValidSubCell(SubCell preferred = SubCell.Any);
-		SubCell GetAvailableSubCell(CPos location, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All);
+		SubCell GetAvailableSubCell(CPos location,
+			SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All);
 		void SetPosition(Actor self, CPos cell, SubCell subCell = SubCell.Any);
 		void SetPosition(Actor self, WPos pos);
 		void SetCenterPosition(Actor self, WPos pos);

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/AttackFrontalFacingTolerance.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/AttackFrontalFacingTolerance.cs
@@ -17,7 +17,9 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 	{
 		public override string Name => "Adds the old default value for AttackFrontal's FacingTolerance.";
 
-		public override string Description => "The tolerance for the attack angle was defined twice on AttackFrontal. This override has to be defined in the rules now.";
+		public override string Description =>
+			"The tolerance for the attack angle was defined twice on AttackFrontal. " +
+			"This override has to be defined in the rules now.";
 
 		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RenameContrailProperties.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/RenameContrailProperties.cs
@@ -18,7 +18,9 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 	{
 		public override string Name => "Rename contrail color properties";
 
-		public override string Description => "Rename contrail color properties `Color` to `StartColor` and `UsePlayerColor` to `StartColorUsePlayerColor` in traits and weapons to account for added `EndColor` functionality";
+		public override string Description =>
+			"Rename contrail color properties `Color` to `StartColor` and `UsePlayerColor` to `StartColorUsePlayerColor` " +
+			"in traits and weapons to account for added `EndColor` functionality";
 
 		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
 		{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/ReplaceResourceValueModifiers.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/ReplaceResourceValueModifiers.cs
@@ -17,7 +17,9 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 	{
 		public override string Name => "HarvesterResourceMultiplier and RefineryResourceMultiplier replaced with ResourceValueMultiplier.";
 
-		public override string Description => "The HarvesterResourceMultiplier trait has been removed, and the RefineryResourceMultiplier trait renamed to ResourceValueMultiplier.";
+		public override string Description =>
+			"The HarvesterResourceMultiplier trait has been removed, " +
+			"and the RefineryResourceMultiplier trait renamed to ResourceValueMultiplier.";
 
 		bool notified;
 		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UnhardcodeBaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UnhardcodeBaseBuilderBotModule.cs
@@ -19,7 +19,20 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 		MiniYamlNodeBuilder defences;
 
 		// Excludes AttackBomber and AttackTDGunboatTurreted as actors with these AttackBase traits aren't supposed to be controlled.
-		readonly string[] attackBase = { "AttackLeap", "AttackPopupTurreted", "AttackAircraft", "AttackTesla", "AttackCharges", "AttackFollow", "AttackTurreted", "AttackFrontal", "AttackGarrisoned", "AttackOmni", "AttackSwallow" };
+		readonly string[] attackBase =
+		{
+			"AttackLeap",
+			"AttackPopupTurreted",
+			"AttackAircraft",
+			"AttackTesla",
+			"AttackCharges",
+			"AttackFollow",
+			"AttackTurreted",
+			"AttackFrontal",
+			"AttackGarrisoned",
+			"AttackOmni",
+			"AttackSwallow"
+		};
 		readonly string[] buildings = { "Building", "EnergyWall", "D2kBuilding" };
 
 		bool anyAdded;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UnhardcodeSquadManager.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20210321/UnhardcodeSquadManager.cs
@@ -19,7 +19,20 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 		readonly List<MiniYamlNodeBuilder> addNodes = new();
 
 		// Excludes AttackBomber and AttackTDGunboatTurreted as actors with these AttackBase traits aren't supposed to be controlled.
-		readonly string[] attackBase = { "AttackLeap", "AttackPopupTurreted", "AttackAircraft", "AttackTesla", "AttackCharges", "AttackFollow", "AttackTurreted", "AttackFrontal", "AttackGarrisoned", "AttackOmni", "AttackSwallow" };
+		readonly string[] attackBase =
+		{
+			"AttackLeap",
+			"AttackPopupTurreted",
+			"AttackAircraft",
+			"AttackTesla",
+			"AttackCharges",
+			"AttackFollow",
+			"AttackTurreted",
+			"AttackFrontal",
+			"AttackGarrisoned",
+			"AttackOmni",
+			"AttackSwallow"
+		};
 		readonly string[] vipsNames = { "Harvester", "BaseBuilding" };
 		readonly string[] buildings = { "Building", "EnergyWall", "D2kBuilding" };
 		readonly string[] excludedBuildings = { "LineBuild", "Plug" };

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230225/RemoveExperienceFromInfiltrates.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230225/RemoveExperienceFromInfiltrates.cs
@@ -17,7 +17,9 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 	{
 		public override string Name => "Removes PlayerExperience property from Infiltrates.";
 
-		public override string Description => "Infiltrates property PlayerExperience was removed, it was replaced by adding PlayerExperience to all InfiltrateFor* Traits.";
+		public override string Description =>
+			"Infiltrates property PlayerExperience was removed, " +
+			"it was replaced by adding PlayerExperience to all InfiltrateFor* Traits.";
 
 		readonly List<string> locations = new();
 

--- a/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
@@ -35,7 +35,12 @@ namespace OpenRA.Mods.Common.UpdateRules
 					continue;
 				}
 
-				yaml.Add(((IReadWritePackage)package, name, MiniYaml.FromStream(package.GetStream(name), $"{package.Name}:{name}", false).ConvertAll(n => new MiniYamlNodeBuilder(n))));
+				yaml.Add(
+					((IReadWritePackage)package,
+					name,
+					MiniYaml
+						.FromStream(package.GetStream(name), $"{package.Name}:{name}", false)
+						.ConvertAll(n => new MiniYamlNodeBuilder(n))));
 			}
 
 			return yaml;
@@ -68,7 +73,12 @@ namespace OpenRA.Mods.Common.UpdateRules
 			{
 				// Ignore any files that aren't in the map bundle
 				if (!filename.Contains('|') && mapPackage.Contains(filename))
-					fileSet.Add((mapPackage, filename, MiniYaml.FromStream(mapPackage.GetStream(filename), $"{mapPackage.Name}:{filename}", false).ConvertAll(n => new MiniYamlNodeBuilder(n))));
+					fileSet.Add((
+						mapPackage,
+						filename,
+						MiniYaml
+							.FromStream(mapPackage.GetStream(filename), $"{mapPackage.Name}:{filename}", false)
+							.ConvertAll(n => new MiniYamlNodeBuilder(n))));
 				else if (modData.ModFiles.Exists(filename))
 					externalFilenames.Add(filename);
 			}
@@ -159,7 +169,8 @@ namespace OpenRA.Mods.Common.UpdateRules
 			return manualSteps;
 		}
 
-		public static List<MiniYamlNodeBuilder> LoadMapYaml(IReadOnlyFileSystem fileSystem, IReadOnlyPackage mapPackage, IEnumerable<string> files, MiniYamlBuilder mapNode)
+		public static List<MiniYamlNodeBuilder> LoadMapYaml(
+			IReadOnlyFileSystem fileSystem, IReadOnlyPackage mapPackage, IEnumerable<string> files, MiniYamlBuilder mapNode)
 		{
 			var yaml = files.Select(s => MiniYaml.FromStream(fileSystem.Open(s), s)).ToList();
 
@@ -357,7 +368,8 @@ namespace OpenRA.Mods.Common.UpdateRules
 		}
 
 		/// <summary>Renames a yaml key preserving any @suffix.</summary>
-		public static void RenameKey(this MiniYamlNodeBuilder node, string newKey, bool preserveSuffix = true, bool includeRemovals = true)
+		public static void RenameKey(
+			this MiniYamlNodeBuilder node, string newKey, bool preserveSuffix = true, bool includeRemovals = true)
 		{
 			var prefix = includeRemovals && node.IsRemoval() ? "-" : "";
 			var split = node.Key.IndexOf('@');
@@ -398,7 +410,8 @@ namespace OpenRA.Mods.Common.UpdateRules
 			fromNode.Value.Nodes.Remove(node);
 		}
 
-		public static void MoveAndRenameNode(this MiniYamlNodeBuilder node,
+		public static void MoveAndRenameNode(
+			this MiniYamlNodeBuilder node,
 			MiniYamlNodeBuilder fromNode, MiniYamlNodeBuilder toNode, string newKey, bool preserveSuffix = true, bool includeRemovals = true)
 		{
 			node.RenameKey(newKey, preserveSuffix, includeRemovals);
@@ -406,13 +419,15 @@ namespace OpenRA.Mods.Common.UpdateRules
 		}
 
 		/// <summary>Removes children with keys equal to [match] or [match]@[arbitrary suffix].</summary>
-		public static int RemoveNodes(this MiniYamlNodeBuilder node, string match, bool ignoreSuffix = true, bool includeRemovals = true)
+		public static int RemoveNodes(
+			this MiniYamlNodeBuilder node, string match, bool ignoreSuffix = true, bool includeRemovals = true)
 		{
 			return node.Value.Nodes.RemoveAll(n => n.KeyMatches(match, ignoreSuffix, includeRemovals));
 		}
 
 		/// <summary>Returns true if the node is of the form [match] or [match]@[arbitrary suffix].</summary>
-		public static bool KeyMatches(this MiniYamlNodeBuilder node, string match, bool ignoreSuffix = true, bool includeRemovals = true)
+		public static bool KeyMatches(
+			this MiniYamlNodeBuilder node, string match, bool ignoreSuffix = true, bool includeRemovals = true)
 		{
 			if (node.Key == null)
 				return false;
@@ -430,7 +445,8 @@ namespace OpenRA.Mods.Common.UpdateRules
 		}
 
 		/// <summary>Returns true if the node is of the form [match], [match]@[arbitrary suffix] or [arbitrary suffix]@[match].</summary>
-		public static bool KeyContains(this MiniYamlNodeBuilder node, string match, bool ignoreSuffix = true, bool includeRemovals = true)
+		public static bool KeyContains(
+			this MiniYamlNodeBuilder node, string match, bool ignoreSuffix = true, bool includeRemovals = true)
 		{
 			if (node.Key == null)
 				return false;
@@ -445,23 +461,27 @@ namespace OpenRA.Mods.Common.UpdateRules
 		}
 
 		/// <summary>Returns children with keys equal to [match] or [match]@[arbitrary suffix].</summary>
-		public static IEnumerable<MiniYamlNodeBuilder> ChildrenMatching(this MiniYamlNodeBuilder node, string match, bool ignoreSuffix = true, bool includeRemovals = true)
+		public static IEnumerable<MiniYamlNodeBuilder> ChildrenMatching(
+			this MiniYamlNodeBuilder node, string match, bool ignoreSuffix = true, bool includeRemovals = true)
 		{
 			return node.Value.Nodes.Where(n => n.KeyMatches(match, ignoreSuffix, includeRemovals));
 		}
 
 		/// <summary>Returns children whose keys contain 'match' (optionally in the suffix).</summary>
-		public static IEnumerable<MiniYamlNodeBuilder> ChildrenContaining(this MiniYamlNodeBuilder node, string match, bool ignoreSuffix = true, bool includeRemovals = true)
+		public static IEnumerable<MiniYamlNodeBuilder> ChildrenContaining(
+			this MiniYamlNodeBuilder node, string match, bool ignoreSuffix = true, bool includeRemovals = true)
 		{
 			return node.Value.Nodes.Where(n => n.KeyContains(match, ignoreSuffix, includeRemovals));
 		}
 
-		public static MiniYamlNodeBuilder LastChildMatching(this MiniYamlNodeBuilder node, string match, bool includeRemovals = true)
+		public static MiniYamlNodeBuilder LastChildMatching(
+			this MiniYamlNodeBuilder node, string match, bool includeRemovals = true)
 		{
 			return node.ChildrenMatching(match, includeRemovals: includeRemovals).LastOrDefault();
 		}
 
-		public static void RenameChildrenMatching(this MiniYamlNodeBuilder node, string match, string newKey, bool preserveSuffix = true, bool includeRemovals = true)
+		public static void RenameChildrenMatching(
+			this MiniYamlNodeBuilder node, string match, string newKey, bool preserveSuffix = true, bool includeRemovals = true)
 		{
 			var matching = node.ChildrenMatching(match);
 			foreach (var m in matching)

--- a/OpenRA.Mods.Common/UtilityCommands/CheckConditionalTraitInterfaceOverrides.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckConditionalTraitInterfaceOverrides.cs
@@ -52,7 +52,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				if (!IsConditionalTrait(t))
 					continue;
 
-				var overridesCreated = t.GetMethod($"{interfaceType.FullName}.{methodName}", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly) != null;
+				var overridesCreated = t.GetMethod(
+					$"{interfaceType.FullName}.{methodName}",
+					BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly) != null;
 				if (overridesCreated)
 				{
 					Console.WriteLine("{0} must override ConditionalTrait's {1} method instead of implementing {2} directly", t.Name, methodName, interfaceType.Name);

--- a/OpenRA.Mods.Common/UtilityCommands/DebugChromeRegions.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/DebugChromeRegions.cs
@@ -74,7 +74,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				}
 			}
 
-			var output = HtmlTemplate.JoinWith("\n").FormatInvariant(zoom, Convert.ToBase64String(modData.ModFiles.Open(image).ReadAllBytes()), "[" + regions.JoinWith(",") + "]");
+			var output = HtmlTemplate.JoinWith("\n").FormatInvariant(
+				zoom,
+				Convert.ToBase64String(modData.ModFiles.Open(image).ReadAllBytes()),
+				"[" + regions.JoinWith(",") + "]");
 			var outputPath = Path.ChangeExtension(image, ".html");
 			File.WriteAllLines(outputPath, new[] { output });
 			Console.WriteLine("Saved {0}", outputPath);

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractChromeStrings.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractChromeStrings.cs
@@ -244,7 +244,8 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				.ToLowerInvariant();
 		}
 
-		static void FromChromeLayout(MiniYamlNodeBuilder node, Dictionary<string, string[]> translatables, string container, ref List<TranslationCandidate> translations)
+		static void FromChromeLayout(
+			MiniYamlNodeBuilder node, Dictionary<string, string[]> translatables, string container, ref List<TranslationCandidate> translations)
 		{
 			var nodeSplit = node.Key.Split('@');
 			var nodeType = nodeSplit[0];

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractChromeStrings.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractChromeStrings.cs
@@ -314,8 +314,16 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		public static void FindUntranslatedStringFields(ModData modData)
 		{
 			var types = modData.ObjectCreator.GetTypes();
-			foreach (var (type, fields) in types.Where(t => t.Name.EndsWith("Widget", StringComparison.InvariantCulture) && t.IsSubclassOf(typeof(Widget))).ToDictionary(t => t.Name[..^6],
-				t => t.GetFields().Where(f => f.Name != "Id" && f.IsPublic && f.FieldType == typeof(string) && !f.HasAttribute<TranslationReferenceAttribute>()).Distinct().Select(f => f.Name).ToList()))
+			foreach (var (type, fields) in types
+				.Where(t => t.Name.EndsWith("Widget", StringComparison.InvariantCulture) && t.IsSubclassOf(typeof(Widget)))
+				.ToDictionary(
+					t => t.Name[..^6],
+					t => t
+						.GetFields()
+						.Where(f => f.Name != "Id" && f.IsPublic && f.FieldType == typeof(string) && !f.HasAttribute<TranslationReferenceAttribute>())
+						.Distinct()
+						.Select(f => f.Name)
+						.ToList()))
 				if (fields.Count > 0)
 					Console.WriteLine($"{type}Widget:\n  {string.Join("\n  ", fields)}");
 		}

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractEmmyLuaAPI.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractEmmyLuaAPI.cs
@@ -68,7 +68,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 		static void WriteDiagnosticsDisabling()
 		{
-			Console.WriteLine("--- This file only lists function \"signatures\", causing Lua Diagnostics errors: \"Annotations specify that a return value is required here.\"");
+			Console.WriteLine(
+				"--- This file only lists function \"signatures\", causing Lua Diagnostics errors: " +
+				"\"Annotations specify that a return value is required here.\"");
 			Console.WriteLine("--- and Lua Diagnostics warnings \"Unused local\" for the functions' parameters.");
 			Console.WriteLine("--- Disable those specific errors for the entire file.");
 			Console.WriteLine("---@diagnostic disable: missing-return");
@@ -341,7 +343,8 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 				if (requiredTraits.Length != 0)
 					Console.WriteLine(
-						$"{new string(' ', indentation * 4)}--- **Requires {(requiredTraits.Length == 1 ? "Trait" : "Traits")}:** {requiredTraits.Select(GetDocumentationUrl).JoinWith(", ")}");
+						$"{new string(' ', indentation * 4)}--- **Requires {(requiredTraits.Length == 1 ? "Trait" : "Traits")}:** " +
+						$"{requiredTraits.Select(GetDocumentationUrl).JoinWith(", ")}");
 			}
 		}
 

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractEmmyLuaAPI.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractEmmyLuaAPI.cs
@@ -336,10 +336,12 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				}
 
 				if (isActivity)
-					Console.WriteLine($"{new string(' ', indentation * 4)}--- *Queued Activity*");
+					Console.WriteLine(
+						$"{new string(' ', indentation * 4)}--- *Queued Activity*");
 
 				if (requiredTraits.Length != 0)
-					Console.WriteLine($"{new string(' ', indentation * 4)}--- **Requires {(requiredTraits.Length == 1 ? "Trait" : "Traits")}:** {requiredTraits.Select(GetDocumentationUrl).JoinWith(", ")}");
+					Console.WriteLine(
+						$"{new string(' ', indentation * 4)}--- **Requires {(requiredTraits.Length == 1 ? "Trait" : "Traits")}:** {requiredTraits.Select(GetDocumentationUrl).JoinWith(", ")}");
 			}
 		}
 

--- a/OpenRA.Mods.Common/Warheads/Warhead.cs
+++ b/OpenRA.Mods.Common/Warheads/Warhead.cs
@@ -38,7 +38,10 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("Can this warhead affect the actor that fired it.")]
 		public readonly bool AffectsParent = false;
 
-		[Desc("If impact is above this altitude, warheads that would affect terrain ignore terrain target types (and either do nothing or perform their own checks).")]
+		[Desc(
+			"If impact is above this altitude, " +
+			"warheads that would affect terrain ignore terrain target types " +
+			"(and either do nothing or perform their own checks).")]
 		public readonly WDist AirThreshold = new(128);
 
 		[Desc("Delay in ticks before applying the warhead effect.", "0 = instant (old model).")]

--- a/OpenRA.Mods.Common/Widgets/CheckboxWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/CheckboxWidget.cs
@@ -78,7 +78,11 @@ namespace OpenRA.Mods.Common.Widgets
 			var checkmarkImage = getCheckmarkImageCache
 				.Update((GetCheckmark(), IsChecked()))
 				.Update((disabled, Depressed, hover, false, IsHighlighted()));
-			WidgetUtils.DrawSprite(checkmarkImage, new float2(rect.Right - (int)((rect.Height + checkmarkImage.Size.X) / 2), rect.Top + (int)((rect.Height - checkmarkImage.Size.Y) / 2)));
+			WidgetUtils.DrawSprite(
+				checkmarkImage,
+				new float2(
+					rect.Right - (int)((rect.Height + checkmarkImage.Size.X) / 2),
+					rect.Top + (int)((rect.Height - checkmarkImage.Size.Y) / 2)));
 		}
 
 		public override Widget Clone() { return new CheckboxWidget(this); }

--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -58,13 +58,20 @@ namespace OpenRA.Mods.Common.Widgets
 			getMarkerImage ??= WidgetUtils.GetCachedStatefulImage(Decorations, DecorationMarker);
 
 			var arrowImage = getMarkerImage.Update((isDisabled, Depressed, isHover, false, IsHighlighted()));
-			WidgetUtils.DrawSprite(arrowImage, stateOffset + new float2(rb.Right - (int)((rb.Height + arrowImage.Size.X) / 2), rb.Top + (int)((rb.Height - arrowImage.Size.Y) / 2)));
+			WidgetUtils.DrawSprite(
+				arrowImage,
+				stateOffset + new float2(
+					rb.Right - (int)((rb.Height + arrowImage.Size.X) / 2),
+					rb.Top + (int)((rb.Height - arrowImage.Size.Y) / 2)));
 
 			getSeparatorImage ??= WidgetUtils.GetCachedStatefulImage(Separators, SeparatorImage);
 
 			var separatorImage = getSeparatorImage.Update((isDisabled, Depressed, isHover, false, IsHighlighted()));
 			if (separatorImage != null)
-				WidgetUtils.DrawSprite(separatorImage, stateOffset + new float2(-3, 0) + new float2(rb.Right - rb.Height + 4, rb.Top + (int)((rb.Height - separatorImage.Size.Y) / 2)));
+				WidgetUtils.DrawSprite(
+					separatorImage,
+					stateOffset + new float2(-3, 0) + new float2(rb.Right - rb.Height + 4,
+					rb.Top + (int)((rb.Height - separatorImage.Size.Y) / 2)));
 		}
 
 		public override Widget Clone() { return new DropDownButtonWidget(this); }
@@ -138,7 +145,8 @@ namespace OpenRA.Mods.Common.Widgets
 			(panel as ScrollPanelWidget)?.ScrollToSelectedItem();
 		}
 
-		public void ShowDropDown<T>(string panelTemplate, int maxHeight, IEnumerable<T> options, Func<T, ScrollItemWidget, ScrollItemWidget> setupItem)
+		public void ShowDropDown<T>(
+			string panelTemplate, int maxHeight, IEnumerable<T> options, Func<T, ScrollItemWidget, ScrollItemWidget> setupItem)
 		{
 			var substitutions = new Dictionary<string, int>() { { "DROPDOWN_WIDTH", Bounds.Width } };
 			var panel = (ScrollPanelWidget)Ui.LoadWidget(panelTemplate, null, new WidgetArgs() { { "substitutions", substitutions } });
@@ -160,7 +168,8 @@ namespace OpenRA.Mods.Common.Widgets
 			AttachPanel(panel);
 		}
 
-		public void ShowDropDown<T>(string panelTemplate, int height, Dictionary<string, IEnumerable<T>> groups, Func<T, ScrollItemWidget, ScrollItemWidget> setupItem)
+		public void ShowDropDown<T>(
+			string panelTemplate, int height, Dictionary<string, IEnumerable<T>> groups, Func<T, ScrollItemWidget, ScrollItemWidget> setupItem)
 		{
 			var substitutions = new Dictionary<string, int>() { { "DROPDOWN_WIDTH", Bounds.Width } };
 			var panel = (ScrollPanelWidget)Ui.LoadWidget(panelTemplate, null, new WidgetArgs() { { "substitutions", substitutions } });

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -471,11 +471,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			item.IsVisible = () =>
 			{
-				var allowed = (assetTypesToDisplay.HasFlag(AssetType.Sprite) && allowedSpriteExtensions.Any(ext => filepath.EndsWith(ext, true, CultureInfo.InvariantCulture)))
-					|| (assetTypesToDisplay.HasFlag(AssetType.Model) && allowedModelExtensions.Any(ext => filepath.EndsWith(ext, true, CultureInfo.InvariantCulture)))
-					|| (assetTypesToDisplay.HasFlag(AssetType.Audio) && allowedAudioExtensions.Any(ext => filepath.EndsWith(ext, true, CultureInfo.InvariantCulture)))
-					|| (assetTypesToDisplay.HasFlag(AssetType.Video) && allowedVideoExtensions.Any(ext => filepath.EndsWith(ext, true, CultureInfo.InvariantCulture)))
-					|| (assetTypesToDisplay.HasFlag(AssetType.Unknown) && !allowedExtensions.Any(ext => filepath.EndsWith(ext, true, CultureInfo.InvariantCulture)));
+				var allowed =
+					(assetTypesToDisplay.HasFlag(AssetType.Sprite)
+						&& allowedSpriteExtensions.Any(ext => filepath.EndsWith(ext, true, CultureInfo.InvariantCulture)))
+					|| (assetTypesToDisplay.HasFlag(AssetType.Model)
+						&& allowedModelExtensions.Any(ext => filepath.EndsWith(ext, true, CultureInfo.InvariantCulture)))
+					|| (assetTypesToDisplay.HasFlag(AssetType.Audio)
+						&& allowedAudioExtensions.Any(ext => filepath.EndsWith(ext, true, CultureInfo.InvariantCulture)))
+					|| (assetTypesToDisplay.HasFlag(AssetType.Video)
+						&& allowedVideoExtensions.Any(ext => filepath.EndsWith(ext, true, CultureInfo.InvariantCulture)))
+					|| (assetTypesToDisplay.HasFlag(AssetType.Unknown)
+						&& !allowedExtensions.Any(ext => filepath.EndsWith(ext, true, CultureInfo.InvariantCulture)));
 
 				if (assetVisByName.TryGetValue(filepath, out var visible))
 					return visible && allowed;

--- a/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
@@ -103,7 +103,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		bool passwordOffsetAdjusted;
 
 		[ObjectCreator.UseCtor]
-		public ConnectionFailedLogic(Widget widget, ModData modData, OrderManager orderManager, NetworkConnection connection, string password, Action onAbort, Action onQuit, Action<string> onRetry)
+		public ConnectionFailedLogic(Widget widget, ModData modData, OrderManager orderManager,
+			NetworkConnection connection, string password, Action onAbort, Action onQuit, Action<string> onRetry)
 		{
 			var panel = widget;
 			var abortButton = panel.Get<ButtonWidget>("ABORT_BUTTON");
@@ -133,7 +134,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			widget.Get<LabelWidget>("CONNECTING_DESC").GetText = () => connectingDescText;
 
 			var connectionError = widget.Get<LabelWidget>("CONNECTION_ERROR");
-			var connectionErrorText = orderManager.ServerError != null ? TranslationProvider.GetString(orderManager.ServerError) : connection.ErrorMessage ?? TranslationProvider.GetString(UnknownError);
+			var connectionErrorText = orderManager.ServerError != null
+				? TranslationProvider.GetString(orderManager.ServerError)
+				: connection.ErrorMessage ?? TranslationProvider.GetString(UnknownError);
 			connectionError.GetText = () => connectionErrorText;
 
 			var panelTitle = widget.Get<LabelWidget>("TITLE");

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorSelectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorSelectionLogic.cs
@@ -156,7 +156,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var diagonalLength = Math.Round(Math.Sqrt(Math.Pow(selectionSize.X, 2) + Math.Pow(selectionSize.Y, 2)), 3);
 			var resourceValueInRegion = editorResourceLayer.CalculateRegionValue(selectedRegion);
 
-			var areaSelectionLabel = $"{TranslationProvider.GetString(AreaSelection)} ({DimensionsAsString(selectionSize)}) {PositionAsString(selectedRegion.TopLeft)} : {PositionAsString(selectedRegion.BottomRight)}";
+			var areaSelectionLabel =
+				$"{TranslationProvider.GetString(AreaSelection)} ({DimensionsAsString(selectionSize)}) " +
+				$"{PositionAsString(selectedRegion.TopLeft)} : {PositionAsString(selectedRegion.BottomRight)}";
 
 			AreaEditTitle.GetText = () => areaSelectionLabel;
 			DiagonalLabel.GetText = () => $"{diagonalLength}";

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/AddFactionSuffixLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/AddFactionSuffixLogic.cs
@@ -51,7 +51,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ptw.Background += suffix;
 			}
 			else
-				throw new InvalidOperationException("AddFactionSuffixLogic only supports ButtonWidget, ImageWidget, BackgroundWidget, TextFieldWidget, ScrollPanelWidget and ProductionTabsWidget");
+				throw new InvalidOperationException(
+					"AddFactionSuffixLogic only supports ButtonWidget, ImageWidget, BackgroundWidget, TextFieldWidget, ScrollPanelWidget and ProductionTabsWidget");
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -87,7 +87,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		const string VoteKickVoteCancel = "dialog-vote-kick.vote-cancel";
 
 		[ObjectCreator.UseCtor]
-		public GameInfoStatsLogic(Widget widget, ModData modData, World world, OrderManager orderManager, WorldRenderer worldRenderer, Action<bool> hideMenu, Action closeMenu)
+		public GameInfoStatsLogic(Widget widget, ModData modData, World world,
+			OrderManager orderManager, WorldRenderer worldRenderer, Action<bool> hideMenu, Action closeMenu)
 		{
 			var player = world.LocalPlayer;
 			var playerPanel = widget.Get<ScrollPanelWidget>("PLAYER_LIST");

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -24,7 +24,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public enum ObserverStatsPanel { None, Basic, Economy, Production, SupportPowers, Combat, Army, Graph, ArmyGraph }
 
-	[ChromeLogicArgsHotkeys("StatisticsBasicKey", "StatisticsEconomyKey", "StatisticsProductionKey", "StatisticsSupportPowersKey", "StatisticsCombatKey", "StatisticsArmyKey", "StatisticsGraphKey",
+	[ChromeLogicArgsHotkeys(
+		"StatisticsBasicKey",
+		"StatisticsEconomyKey",
+		"StatisticsProductionKey",
+		"StatisticsSupportPowersKey",
+		"StatisticsCombatKey",
+		"StatisticsArmyKey",
+		"StatisticsGraphKey",
 		"StatisticsArmyGraphKey")]
 	public class ObserverStatsLogic : ChromeLogic
 	{
@@ -450,15 +457,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			template.Get<LabelWidget>("ASSETS").GetText = () => assetsText.Update(stats.AssetsValue);
 
 			var harvesters = template.Get<LabelWidget>("HARVESTERS");
-			harvesters.GetText = () => world.ActorsWithTrait<Harvester>().Count(a => a.Actor.Owner == player && !a.Actor.IsDead && !a.Trait.IsTraitDisabled).ToString(NumberFormatInfo.CurrentInfo);
+			harvesters.GetText = () => world.ActorsWithTrait<Harvester>()
+				.Count(a => a.Actor.Owner == player && !a.Actor.IsDead && !a.Trait.IsTraitDisabled).ToString(NumberFormatInfo.CurrentInfo);
 
 			var carryalls = template.GetOrNull<LabelWidget>("CARRYALLS");
 			if (carryalls != null)
-				carryalls.GetText = () => world.ActorsWithTrait<AutoCarryall>().Count(a => a.Actor.Owner == player && !a.Actor.IsDead).ToString(NumberFormatInfo.CurrentInfo);
+				carryalls.GetText = () => world.ActorsWithTrait<AutoCarryall>()
+					.Count(a => a.Actor.Owner == player && !a.Actor.IsDead).ToString(NumberFormatInfo.CurrentInfo);
 
 			var derricks = template.GetOrNull<LabelWidget>("DERRICKS");
 			if (derricks != null)
-				derricks.GetText = () => world.ActorsHavingTrait<UpdatesDerrickCount>().Count(a => a.Owner == player && !a.IsDead).ToString(NumberFormatInfo.CurrentInfo);
+				derricks.GetText = () => world.ActorsHavingTrait<UpdatesDerrickCount>()
+					.Count(a => a.Owner == player && !a.IsDead).ToString(NumberFormatInfo.CurrentInfo);
 
 			return template;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -135,7 +135,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				var timeText = formatBuildTime.Update(buildTime * timeModifier / 100);
 				timeLabel.GetText = () => timeText;
-				timeLabel.TextColor = (pm != null && pm.PowerState != PowerState.Normal && tooltipIcon.ProductionQueue.Info.LowPowerModifier > 100) ? Color.Red : Color.White;
+				timeLabel.TextColor =
+					(pm != null && pm.PowerState != PowerState.Normal && tooltipIcon.ProductionQueue.Info.LowPowerModifier > 100)
+						? Color.Red
+						: Color.White;
 				var timeSize = font.Measure(timeText);
 
 				var costText = cost.ToString(NumberFormatInfo.CurrentInfo);

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
@@ -19,7 +19,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class SupportPowerTooltipLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
-		public SupportPowerTooltipLogic(Widget widget, TooltipContainerWidget tooltipContainer, Func<SupportPowersWidget.SupportPowerIcon> getTooltipIcon, World world)
+		public SupportPowerTooltipLogic(Widget widget, TooltipContainerWidget tooltipContainer,
+			Func<SupportPowersWidget.SupportPowerIcon> getTooltipIcon, World world)
 		{
 			widget.IsVisible = () => getTooltipIcon() != null && getTooltipIcon().Power.Info != null;
 			var nameLabel = widget.Get<LabelWidget>("NAME");

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentPromptLogic.cs
@@ -40,7 +40,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var panel = widget.Get("CONTENT_PROMPT_PANEL");
 			var headerTemplate = panel.Get<LabelWidget>("HEADER_TEMPLATE");
-			var headerLines = !string.IsNullOrEmpty(content.InstallPromptMessage) ? content.InstallPromptMessage.Replace("\\n", "\n").Split('\n') : Array.Empty<string>();
+			var headerLines =
+				!string.IsNullOrEmpty(content.InstallPromptMessage)
+					? content.InstallPromptMessage.Replace("\\n", "\n").Split('\n')
+					: Array.Empty<string>();
 			var headerHeight = 0;
 			foreach (var l in headerLines)
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -592,7 +592,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				panel = PanelType.Players;
 
 			var chatWasEnabled = chatEnabled;
-			chatEnabled = worldRenderer.World.IsReplay || (Game.RunTime >= TextNotificationsManager.ChatDisabledUntil && TextNotificationsManager.ChatDisabledUntil != uint.MaxValue);
+			chatEnabled =
+				worldRenderer.World.IsReplay ||
+				(Game.RunTime >= TextNotificationsManager.ChatDisabledUntil && TextNotificationsManager.ChatDisabledUntil != uint.MaxValue);
 
 			if (chatEnabled && !chatWasEnabled)
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -521,7 +521,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 		}
 
-		public static void SetupEditableColorWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, WorldRenderer worldRenderer, IColorPickerManagerInfo colorManager)
+		public static void SetupEditableColorWidget(Widget parent, Session.Slot s, Session.Client c,
+			OrderManager orderManager, WorldRenderer worldRenderer, IColorPickerManagerInfo colorManager)
 		{
 			var colorDropdown = parent.Get<DropDownButtonWidget>("COLOR");
 			colorDropdown.IsDisabled = () => (s != null && s.LockColor) || orderManager.LocalClient.IsReady;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -284,7 +284,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		static void SetSpawnPoint(OrderManager orderManager, Session.Client playerToMove, int selectedSpawnPoint)
 		{
-			var owned = orderManager.LobbyInfo.Clients.Any(c => c.SpawnPoint == selectedSpawnPoint) || orderManager.LobbyInfo.DisabledSpawnPoints.Contains(selectedSpawnPoint);
+			var owned =
+				orderManager.LobbyInfo.Clients.Any(c => c.SpawnPoint == selectedSpawnPoint) ||
+				orderManager.LobbyInfo.DisabledSpawnPoints.Contains(selectedSpawnPoint);
 			if (selectedSpawnPoint == 0 || !owned)
 				orderManager.IssueOrder(Order.Command($"spawn {(playerToMove ?? orderManager.LocalClient).Index} {selectedSpawnPoint}"));
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
@@ -205,17 +205,28 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var previewSmall = SetupMapPreview(widget.Get("MAP_SMALL"));
 
 			// Widgets to be made visible.
-			previewWidgets[PreviewStatus.Unknown] = new Widget[] { previewLarge };
-			previewWidgets[PreviewStatus.Playable] = new Widget[] { previewLarge, SetupAuthorAndMapType(widget.Get("MAP_AVAILABLE")) };
-			previewWidgets[PreviewStatus.Incompatible] = new Widget[] { previewLarge, widget.Get("MAP_INCOMPATIBLE") };
-			previewWidgets[PreviewStatus.Validating] = new Widget[] { previewSmall, widget.Get("MAP_VALIDATING") };
-			previewWidgets[PreviewStatus.UpdateAvailable] = new Widget[] { previewSmall, widget.Get("MAP_UPDATE_AVAILABLE"), updateButton };
-			previewWidgets[PreviewStatus.DownloadAvailable] = new Widget[] { previewSmall, SetUpInstallButton(SetupAuthorAndMapType(widget.Get("MAP_DOWNLOAD_AVAILABLE"))) };
-			previewWidgets[PreviewStatus.UpdateDownloadAvailable] = new Widget[] { previewSmall, SetUpInstallButton(widget.Get("MAP_UPDATE_DOWNLOAD_AVAILABLE")), updateButton };
-			previewWidgets[PreviewStatus.Searching] = new Widget[] { previewSmall, widget.Get("MAP_SEARCHING") };
-			previewWidgets[PreviewStatus.Downloading] = new Widget[] { previewSmall, SetUpDownloadProgress(widget.Get("MAP_DOWNLOADING")) };
-			previewWidgets[PreviewStatus.Unavailable] = new Widget[] { previewSmall, widget.Get("MAP_UNAVAILABLE"), retryButton };
-			previewWidgets[PreviewStatus.DownloadError] = new Widget[] { previewSmall, widget.Get("MAP_ERROR"), retryButton };
+			previewWidgets[PreviewStatus.Unknown] =
+				new Widget[] { previewLarge };
+			previewWidgets[PreviewStatus.Playable] =
+				new Widget[] { previewLarge, SetupAuthorAndMapType(widget.Get("MAP_AVAILABLE")) };
+			previewWidgets[PreviewStatus.Incompatible] =
+				new Widget[] { previewLarge, widget.Get("MAP_INCOMPATIBLE") };
+			previewWidgets[PreviewStatus.Validating] =
+				new Widget[] { previewSmall, widget.Get("MAP_VALIDATING") };
+			previewWidgets[PreviewStatus.UpdateAvailable] =
+				new Widget[] { previewSmall, widget.Get("MAP_UPDATE_AVAILABLE"), updateButton };
+			previewWidgets[PreviewStatus.DownloadAvailable] =
+				new Widget[] { previewSmall, SetUpInstallButton(SetupAuthorAndMapType(widget.Get("MAP_DOWNLOAD_AVAILABLE"))) };
+			previewWidgets[PreviewStatus.UpdateDownloadAvailable] =
+				new Widget[] { previewSmall, SetUpInstallButton(widget.Get("MAP_UPDATE_DOWNLOAD_AVAILABLE")), updateButton };
+			previewWidgets[PreviewStatus.Searching] =
+				new Widget[] { previewSmall, widget.Get("MAP_SEARCHING") };
+			previewWidgets[PreviewStatus.Downloading] =
+				new Widget[] { previewSmall, SetUpDownloadProgress(widget.Get("MAP_DOWNLOADING")) };
+			previewWidgets[PreviewStatus.Unavailable] =
+				new Widget[] { previewSmall, widget.Get("MAP_UNAVAILABLE"), retryButton };
+			previewWidgets[PreviewStatus.DownloadError] =
+				new Widget[] { previewSmall, widget.Get("MAP_ERROR"), retryButton };
 
 			// Hide all widgets.
 			foreach (var preview in previewWidgets)

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
@@ -41,7 +41,21 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly Dictionary<PreviewStatus, Widget[]> previewWidgets = new();
 		readonly Func<(MapPreview Map, Session.MapStatus Status)> getMap;
 
-		enum PreviewStatus { Unknown, Playable, Incompatible, Validating, DownloadAvailable, Searching, Downloading, DownloadError, Unavailable, UpdateAvailable, UpdateDownloadAvailable }
+		enum PreviewStatus
+		{
+			Unknown,
+			Playable,
+			Incompatible,
+			Validating,
+			DownloadAvailable,
+			Searching,
+			Downloading,
+			DownloadError,
+			Unavailable,
+			UpdateAvailable,
+			UpdateDownloadAvailable,
+		}
+
 		PreviewStatus currentStatus;
 		bool blink;
 		int blinkTick;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/SpawnSelectorTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/SpawnSelectorTooltipLogic.cs
@@ -29,7 +29,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly CachedTransform<int, string> teamMessage;
 
 		[ObjectCreator.UseCtor]
-		public SpawnSelectorTooltipLogic(Widget widget, ModData modData, TooltipContainerWidget tooltipContainer, MapPreviewWidget preview, bool showUnoccupiedSpawnpoints)
+		public SpawnSelectorTooltipLogic(Widget widget, ModData modData,
+			TooltipContainerWidget tooltipContainer, MapPreviewWidget preview, bool showUnoccupiedSpawnpoints)
 		{
 			var showTooltip = true;
 			widget.IsVisible = () => preview.TooltipSpawnIndex != -1 && showTooltip;

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
@@ -72,7 +72,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		static bool IncompatibleReplayDialog(string text, Dictionary<string, object> textArguments, ModData modData, Action onCancel)
 		{
-			ConfirmationDialogs.ButtonPrompt(modData, IncompatibleReplayTitle, text, textArguments: textArguments, onCancel: onCancel, cancelText: IncompatibleReplayAccept);
+			ConfirmationDialogs.ButtonPrompt(
+				modData, IncompatibleReplayTitle, text, textArguments: textArguments, onCancel: onCancel, cancelText: IncompatibleReplayAccept);
 			return false;
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -70,7 +70,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var settings = Game.Settings;
 
-			map = modData.MapCache[modData.MapCache.ChooseInitialMap(modData.MapCache.PickLastModifiedMap(MapVisibility.Lobby) ?? Game.Settings.Server.Map, Game.CosmeticRandom)];
+			map = modData.MapCache[
+				modData.MapCache.ChooseInitialMap(
+					modData.MapCache.PickLastModifiedMap(MapVisibility.Lobby) ?? Game.Settings.Server.Map,
+					Game.CosmeticRandom)];
 
 			Ui.LoadWidget("MAP_PREVIEW", panel.Get("MAP_PREVIEW_ROOT"), new WidgetArgs
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/AudioSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/AudioSettingsLogic.cs
@@ -32,7 +32,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 
 		[ObjectCreator.UseCtor]
-		public AudioSettingsLogic(Action<string, string, Func<Widget, Func<bool>>, Func<Widget, Action>> registerPanel, string panelID, string label, WorldRenderer worldRenderer)
+		public AudioSettingsLogic(
+			Action<string, string, Func<Widget, Func<bool>>, Func<Widget, Action>> registerPanel,
+			string panelID,
+			string label,
+			WorldRenderer worldRenderer)
 		{
 			this.worldRenderer = worldRenderer;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -97,7 +97,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 
 		[ObjectCreator.UseCtor]
-		public DisplaySettingsLogic(Action<string, string, Func<Widget, Func<bool>>, Func<Widget, Action>> registerPanel, string panelID, string label, ModData modData, WorldRenderer worldRenderer)
+		public DisplaySettingsLogic(
+			Action<string, string, Func<Widget, Func<bool>>, Func<Widget, Action>> registerPanel,
+			string panelID, string label, ModData modData, WorldRenderer worldRenderer)
 		{
 			this.worldRenderer = worldRenderer;
 			this.modData = modData;

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
@@ -50,7 +50,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		static HotkeysSettingsLogic() { }
 
 		[ObjectCreator.UseCtor]
-		public HotkeysSettingsLogic(Action<string, string, Func<Widget, Func<bool>>, Func<Widget, Action>> registerPanel, string panelID, string label, ModData modData, Dictionary<string, MiniYaml> logicArgs)
+		public HotkeysSettingsLogic(
+			Action<string, string, Func<Widget, Func<bool>>, Func<Widget, Action>> registerPanel,
+			string panelID, string label, ModData modData, Dictionary<string, MiniYaml> logicArgs)
 		{
 			this.modData = modData;
 			this.logicArgs = logicArgs;

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
@@ -276,7 +276,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			duplicateHotkeyDefinition = modData.Hotkeys.GetFirstDuplicate(selectedHotkeyDefinition, hotkeyEntryWidget.Key);
 			isHotkeyValid = duplicateHotkeyDefinition == null || selectedHotkeyDefinition.Readonly;
-			isHotkeyDefault = hotkeyEntryWidget.Key == selectedHotkeyDefinition.Default || (!hotkeyEntryWidget.Key.IsValid() && !selectedHotkeyDefinition.Default.IsValid());
+			isHotkeyDefault =
+				hotkeyEntryWidget.Key == selectedHotkeyDefinition.Default ||
+				(!hotkeyEntryWidget.Key.IsValid() && !selectedHotkeyDefinition.Default.IsValid());
 
 			if (isHotkeyValid)
 			{

--- a/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
@@ -212,7 +212,13 @@ namespace OpenRA.Mods.Common.Widgets
 					}
 
 					if (occupied)
-						WidgetUtils.FillEllipseWithColor(new Rectangle(pos.X - offset.X + 1, pos.Y - offset.Y + 1, (int)sprite.Size.X - 2, (int)sprite.Size.Y - 2), occupant.Color);
+						WidgetUtils.FillEllipseWithColor(
+							new Rectangle(
+								pos.X - offset.X + 1,
+								pos.Y - offset.Y + 1,
+								(int)sprite.Size.X - 2,
+								(int)sprite.Size.Y - 2),
+							occupant.Color);
 
 					WidgetUtils.DrawSprite(sprite, pos - offset);
 

--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -269,7 +269,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 				lastIconIdx = i;
 				TooltipIcon = productionIcons[i];
-				currentTooltipToken = tooltipContainer.Value.SetTooltip(TooltipTemplate, new WidgetArgs { { "player", GetPlayer() }, { "getTooltipIcon", GetTooltipIcon } });
+				currentTooltipToken = tooltipContainer.Value.SetTooltip(
+					TooltipTemplate,
+					new WidgetArgs { { "player", GetPlayer() }, { "getTooltipIcon", GetTooltipIcon } });
 				return;
 			}
 

--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -256,7 +256,10 @@ namespace OpenRA.Mods.Common.Widgets
 				return;
 			}
 
-			if (TooltipIcon != null && productionIconsBounds.Count > lastIconIdx && productionIcons[lastIconIdx].Actor == TooltipIcon.Actor && productionIconsBounds[lastIconIdx].Contains(Viewport.LastMousePos))
+			if (TooltipIcon != null &&
+				productionIconsBounds.Count > lastIconIdx &&
+				productionIcons[lastIconIdx].Actor == TooltipIcon.Actor &&
+				productionIconsBounds[lastIconIdx].Contains(Viewport.LastMousePos))
 				return;
 
 			for (var i = 0; i < productionIconsBounds.Count; i++)

--- a/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
@@ -175,7 +175,10 @@ namespace OpenRA.Mods.Common.Widgets
 				return;
 			}
 
-			if (TooltipIcon != null && lastIconIdx < supportPowerIconsBounds.Count && supportPowerIconsIcons[lastIconIdx].Power == TooltipIcon.Power && supportPowerIconsBounds[lastIconIdx].Contains(Viewport.LastMousePos))
+			if (TooltipIcon != null &&
+				lastIconIdx < supportPowerIconsBounds.Count &&
+				supportPowerIconsIcons[lastIconIdx].Power == TooltipIcon.Power &&
+				supportPowerIconsBounds[lastIconIdx].Contains(Viewport.LastMousePos))
 				return;
 
 			for (var i = 0; i < supportPowerIconsBounds.Count; i++)

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -336,7 +336,8 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (buildable != null)
 			{
-				if (CurrentQueue.Info.PayUpFront && currentQueue.GetProductionCost(buildable) > CurrentQueue.Actor.Owner.PlayerActor.Trait<PlayerResources>().GetCashAndResources())
+				if (CurrentQueue.Info.PayUpFront &&
+					currentQueue.GetProductionCost(buildable) > CurrentQueue.Actor.Owner.PlayerActor.Trait<PlayerResources>().GetCashAndResources())
 					return false;
 				Game.Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Sounds", ClickSound, null);
 

--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -201,11 +201,15 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var leftArrowImage = getLeftArrowImage.Update((leftDisabled, leftPressed, leftHover, false, false));
 			WidgetUtils.DrawSprite(leftArrowImage,
-				new float2(leftButtonRect.Left + (int)((leftButtonRect.Width - leftArrowImage.Size.X) / 2), leftButtonRect.Top + (int)((leftButtonRect.Height - leftArrowImage.Size.Y) / 2)));
+				new float2(
+					leftButtonRect.Left + (int)((leftButtonRect.Width - leftArrowImage.Size.X) / 2),
+					leftButtonRect.Top + (int)((leftButtonRect.Height - leftArrowImage.Size.Y) / 2)));
 
 			var rightArrowImage = getRightArrowImage.Update((rightDisabled, rightPressed, rightHover, false, false));
 			WidgetUtils.DrawSprite(rightArrowImage,
-				new float2(rightButtonRect.Left + (int)((rightButtonRect.Width - rightArrowImage.Size.X) / 2), rightButtonRect.Top + (int)((rightButtonRect.Height - rightArrowImage.Size.Y) / 2)));
+				new float2(
+					rightButtonRect.Left + (int)((rightButtonRect.Width - rightArrowImage.Size.X) / 2),
+					rightButtonRect.Top + (int)((rightButtonRect.Height - rightArrowImage.Size.Y) / 2)));
 
 			// Draw tab buttons
 			Game.Renderer.EnableScissor(new Rectangle(leftButtonRect.Right, rb.Y + 1, rightButtonRect.Left - leftButtonRect.Right - 1, rb.Height));

--- a/OpenRA.Mods.Common/Widgets/SelectionUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/SelectionUtils.cs
@@ -20,18 +20,21 @@ namespace OpenRA.Mods.Common.Widgets
 {
 	public static class SelectionUtils
 	{
-		public static IEnumerable<Actor> SelectActorsOnScreen(World world, WorldRenderer wr, IEnumerable<string> selectionClasses, IEnumerable<Player> players)
+		public static IEnumerable<Actor> SelectActorsOnScreen(
+			World world, WorldRenderer wr, IEnumerable<string> selectionClasses, IEnumerable<Player> players)
 		{
 			var actors = world.ScreenMap.ActorsInMouseBox(wr.Viewport.TopLeft, wr.Viewport.BottomRight).Select(a => a.Actor);
 			return SelectActorsByOwnerAndSelectionClass(actors, players, selectionClasses);
 		}
 
-		public static IEnumerable<Actor> SelectActorsInWorld(World world, IEnumerable<string> selectionClasses, IEnumerable<Player> players)
+		public static IEnumerable<Actor> SelectActorsInWorld(
+			World world, IEnumerable<string> selectionClasses, IEnumerable<Player> players)
 		{
 			return SelectActorsByOwnerAndSelectionClass(world.Actors.Where(a => a.IsInWorld), players, selectionClasses);
 		}
 
-		public static IEnumerable<Actor> SelectActorsByOwnerAndSelectionClass(IEnumerable<Actor> actors, IEnumerable<Player> owners, IEnumerable<string> selectionClasses)
+		public static IEnumerable<Actor> SelectActorsByOwnerAndSelectionClass(
+			IEnumerable<Actor> actors, IEnumerable<Player> owners, IEnumerable<string> selectionClasses)
 		{
 			return actors.Where(a =>
 			{

--- a/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
@@ -20,7 +20,8 @@ namespace OpenRA.Mods.Common.Widgets
 {
 	public static class WidgetUtils
 	{
-		public static string GetStatefulImageName(string baseName, bool disabled = false, bool pressed = false, bool hover = false, bool focused = false)
+		public static string GetStatefulImageName(
+			string baseName, bool disabled = false, bool pressed = false, bool hover = false, bool focused = false)
 		{
 			var suffix = disabled ? "-disabled" :
 				focused ? "-focused" :
@@ -31,7 +32,8 @@ namespace OpenRA.Mods.Common.Widgets
 			return baseName + suffix;
 		}
 
-		public static CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted), Sprite> GetCachedStatefulImage(string collection, string imageName)
+		public static CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted), Sprite>
+			GetCachedStatefulImage(string collection, string imageName)
 		{
 			return new CachedTransform<(bool, bool, bool, bool, bool), Sprite>(
 				((bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted) args) =>
@@ -43,7 +45,8 @@ namespace OpenRA.Mods.Common.Widgets
 		}
 
 		// TODO: refactor buttons and related UI to use this function
-		public static CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted), Sprite[]> GetCachedStatefulPanelImages(string collection)
+		public static CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted), Sprite[]>
+			GetCachedStatefulPanelImages(string collection)
 		{
 			return new CachedTransform<(bool, bool, bool, bool, bool), Sprite[]>(
 				((bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted) args) =>

--- a/OpenRA.Mods.Common/WorldExtensions.cs
+++ b/OpenRA.Mods.Common/WorldExtensions.cs
@@ -25,7 +25,8 @@ namespace OpenRA.Mods.Common
 		/// <paramref name="targetOffsets"/> is used to define locations around each actor in <paramref name="actors"/>
 		/// of which one must be reachable.
 		/// </summary>
-		public static IEnumerable<(Actor Actor, WVec[] ReachableOffsets)> WithPathFrom(this IEnumerable<Actor> actors, Actor sourceActor, Func<Actor, WVec[]> targetOffsets)
+		public static IEnumerable<(Actor Actor, WVec[] ReachableOffsets)> WithPathFrom(
+			this IEnumerable<Actor> actors, Actor sourceActor, Func<Actor, WVec[]> targetOffsets)
 		{
 			if (sourceActor.Info.HasTraitInfo<AircraftInfo>())
 				return actors.Select<Actor, (Actor Actor, WVec[] ReachableOffsets)>(a => (a, targetOffsets(a)));
@@ -66,7 +67,8 @@ namespace OpenRA.Mods.Common
 		/// <paramref name="targetOffsets"/> is used to define locations around each actor in <paramref name="actors"/>
 		/// of which one must be reachable.
 		/// </summary>
-		public static Actor ClosestToWithPathFrom(this IEnumerable<Actor> actors, Actor sourceActor, Func<Actor, WVec[]> targetOffsets = null)
+		public static Actor ClosestToWithPathFrom(
+			this IEnumerable<Actor> actors, Actor sourceActor, Func<Actor, WVec[]> targetOffsets = null)
 		{
 			return actors
 				.WithPathFrom(sourceActor, targetOffsets ?? (_ => new[] { WVec.Zero }))
@@ -178,7 +180,8 @@ namespace OpenRA.Mods.Common
 		/// target of a path from the actor, returns the nearest by comparing the <see cref="Actor.CenterPosition"/>.
 		/// Only terrain is taken into account, i.e. as if <see cref="BlockedByActor.None"/> was given.
 		/// </summary>
-		public static Actor ClosestToWithPathToAny(this IEnumerable<Actor> actors, World world, Func<Actor, WPos[]> targetPositions)
+		public static Actor ClosestToWithPathToAny(
+			this IEnumerable<Actor> actors, World world, Func<Actor, WPos[]> targetPositions)
 		{
 			return actors
 				.WithPathToAny(world, targetPositions)
@@ -206,7 +209,8 @@ namespace OpenRA.Mods.Common
 		/// <param name="onlyBlockers">If set, only considers the size of actors that have an <see cref="IBlocksProjectiles"/>
 		/// trait which may improve search performance. However does NOT filter the returned actors on this trait.</param>
 		/// <returns>A list of all the actors intersected by the line.</returns>
-		public static IEnumerable<Actor> FindActorsOnLine(this World world, WPos lineStart, WPos lineEnd, WDist lineWidth, bool onlyBlockers = false)
+		public static IEnumerable<Actor> FindActorsOnLine(
+			this World world, WPos lineStart, WPos lineEnd, WDist lineWidth, bool onlyBlockers = false)
 		{
 			// This line intersection check is done by first just finding all actors within a square that starts at the source, and ends at the target.
 			// Then we iterate over this list, and find all actors for which their health radius is at least within lineWidth of the line.

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -80,7 +80,8 @@ namespace OpenRA.Mods.D2k.Activities
 			Game.Sound.Play(SoundType.World, swallow.Info.WormAttackSound, self.CenterPosition);
 
 			foreach (var player in affectedPlayers)
-				self.World.AddFrameEndTask(w => w.Add(new MapNotificationEffect(player, "Speech", swallow.Info.WormAttackNotification, 25, true, attackPosition, Color.Red)));
+				self.World.AddFrameEndTask(w => w.Add(
+					new MapNotificationEffect(player, "Speech", swallow.Info.WormAttackNotification, 25, true, attackPosition, Color.Red)));
 
 			if (affectedPlayers.Contains(self.World.LocalPlayer))
 				TextNotificationsManager.AddTransientLine(self.World.LocalPlayer, swallow.Info.WormAttackTextNotification);

--- a/OpenRA.Mods.D2k/Graphics/D2kSpriteSequence.cs
+++ b/OpenRA.Mods.D2k/Graphics/D2kSpriteSequence.cs
@@ -23,7 +23,8 @@ namespace OpenRA.Mods.Cnc.Graphics
 		public D2kSpriteSequenceLoader(ModData modData)
 			: base(modData) { }
 
-		public override ISpriteSequence CreateSequence(ModData modData, string tileset, SpriteCache cache, string image, string sequence, MiniYaml data, MiniYaml defaults)
+		public override ISpriteSequence CreateSequence(
+			ModData modData, string tileset, SpriteCache cache, string image, string sequence, MiniYaml data, MiniYaml defaults)
 		{
 			return new D2kSpriteSequence(cache, this, image, sequence, data, defaults);
 		}

--- a/OpenRA.Mods.D2k/Traits/Buildings/D2kActorPreviewPlaceBuildingPreview.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/D2kActorPreviewPlaceBuildingPreview.cs
@@ -105,7 +105,12 @@ namespace OpenRA.Mods.D2k.Traits
 				if ((c.Value & filter) == 0)
 					continue;
 
-				var isUnsafe = checkUnsafeTiles && wr.World.Map.Contains(c.Key) && candidateSafeTiles.Contains(c.Key) && info.UnsafeTerrainTypes.Contains(wr.World.Map.GetTerrainInfo(c.Key).Type);
+				var isUnsafe =
+					checkUnsafeTiles &&
+					wr.World.Map.Contains(c.Key) &&
+					candidateSafeTiles.Contains(c.Key) &&
+					info.UnsafeTerrainTypes.Contains(wr.World.Map.GetTerrainInfo(c.Key).Type);
+
 				var tile = (c.Value & PlaceBuildingCellType.Invalid) != 0 ? blockedTile : isUnsafe ? unsafeTile : validTile;
 				var sequenceAlpha = (c.Value & PlaceBuildingCellType.Invalid) != 0 ? blockedAlpha : isUnsafe ? unsafeAlpha : validAlpha;
 

--- a/OpenRA.Platforms.Default/DefaultPlatform.cs
+++ b/OpenRA.Platforms.Default/DefaultPlatform.cs
@@ -16,7 +16,8 @@ namespace OpenRA.Platforms.Default
 {
 	public class DefaultPlatform : IPlatform
 	{
-		public IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int vertexBatchSize, int indexBatchSize, int videoDisplay, GLProfile profile)
+		public IPlatformWindow CreateWindow(
+			Size size, WindowMode windowMode, float scaleModifier, int vertexBatchSize, int indexBatchSize, int videoDisplay, GLProfile profile)
 		{
 			return new Sdl2PlatformWindow(size, windowMode, scaleModifier, vertexBatchSize, indexBatchSize, videoDisplay, profile);
 		}


### PR DESCRIPTION
Adds Roslynator.Formatting.Analyzers and enforces [RCS0056](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0056).

I have commits with the line length set to 180 and 160 to choose from. Getting to 140 requires another 600 violations resolved which my motivation does not currently extend to. We can always adjust the setting later if we're happy to take something to start with.

We used to enforce a line length limit, but it got lost in the transition from StyleCop to Analyzers. #7649