### PR TITLE
Fix mod content installers.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromSourceLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromSourceLogic.cs
@@ -252,7 +252,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 						foreach (var sourceActionNode in sourceActionListYaml.Value.Nodes)
 						{
-							var sourceAction = modSource.ObjectCreator.CreateObject<ISourceAction>($"{sourceActionNode.Key}SourceAction");
+							var key = sourceActionNode.Key;
+							var split = key.IndexOf('@');
+							if (split != -1)
+								key = key[..split];
+							var sourceAction = modSource.ObjectCreator.CreateObject<ISourceAction>($"{key}SourceAction");
 							sourceAction.RunActionOnSource(sourceActionNode.Value, path, modData, extracted, m => message = m);
 						}
 					}
@@ -261,7 +265,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					if (beforeInstall != null)
 						RunSourceActions(beforeInstall);
 
-					foreach (var packageInstallationNode in modSource.Install.Where(x => x.Key == "ContentPackage"))
+					foreach (var packageInstallationNode in modSource.Install.Where(
+						x => x.Key == "ContentPackage" || x.Key.StartsWith("ContentPackage@", StringComparison.Ordinal)))
 					{
 						var packageName = packageInstallationNode.Value.NodeWithKeyOrDefault("Name")?.Value.Value;
 						if (!string.IsNullOrEmpty(packageName) && selectedPackages.TryGetValue(packageName, out var required) && required)

--- a/mods/cnc/installer/covertops.yaml
+++ b/mods/cnc/installer/covertops.yaml
@@ -5,7 +5,7 @@ covertops: Covert Operations Expansion (English)
 		CONQUER.MIX: 713b53fa4c188ca9619c6bbeadbfc86513704266
 	Install:
 		# Covert Operations music (optional):
-		ContentPackage:
+		ContentPackage@music-covertops:
 			Name: music-covertops
 			Actions:
 				Copy: .

--- a/mods/cnc/installer/firstdecade.yaml
+++ b/mods/cnc/installer/firstdecade.yaml
@@ -22,7 +22,7 @@ tfd: C&C The First Decade (English)
 					^SupportDir|Content/cnc/transit.mix: CnC\\TRANSIT.MIX
 					^SupportDir|Content/cnc/movies.mix: CnC\\MOVIES.MIX
 		# GDI campaign briefings (optional):
-		ContentPackage:
+		ContentPackage@movies-gdi:
 			Name: movies-gdi
 			Actions:
 				ExtractMix: ^SupportDir|Content/cnc/movies.mix
@@ -92,7 +92,7 @@ tfd: C&C The First Decade (English)
 					^SupportDir|Content/cnc/movies/bcanyon.vqa: bcanyon.vqa
 					^SupportDir|Content/cnc/movies/banner.vqa: banner.vqa
 		# Nod campaign briefings (optional):
-		ContentPackage:
+		ContentPackage@movies-nod:
 			Name: movies-nod
 			Actions:
 				ExtractMix: ^SupportDir|Content/cnc/movies.mix
@@ -158,7 +158,7 @@ tfd: C&C The First Decade (English)
 					^SupportDir|Content/cnc/movies/akira.vqa: akira.vqa
 					^SupportDir|Content/cnc/movies/airstrk.vqa: airstrk.vqa
 		# Base game music (optional):
-		ContentPackage:
+		ContentPackage@music:
 			Name: music
 			Actions:
 				ExtractIscab: data1.hdr
@@ -168,7 +168,7 @@ tfd: C&C The First Decade (English)
 					Extract:
 						^SupportDir|Content/cnc/scores.mix: CnC\\SCORES.MIX
 		# Covert Operations music (optional):
-		ContentPackage:
+		ContentPackage@music-covertops:
 			Name: music-covertops
 			Actions:
 				ExtractIscab: data1.hdr

--- a/mods/cnc/installer/gdi95.yaml
+++ b/mods/cnc/installer/gdi95.yaml
@@ -5,7 +5,7 @@ gdi95: C&C Gold (GDI Disc, English)
 		CONQUER.MIX: 833e02a09aae694659eb312d3838367f681d1b30
 	Install:
 		# Base game files:
-		ContentPackage:
+		ContentPackage@base:
 			Name: base
 			Actions:
 				Copy: .
@@ -20,13 +20,13 @@ gdi95: C&C Gold (GDI Disc, English)
 					^SupportDir|Content/cnc/tempicnh.mix: TEMPICNH.MIX
 					^SupportDir|Content/cnc/transit.mix: TRANSIT.MIX
 		# Base game music (optional):
-		ContentPackage:
+		ContentPackage@music:
 			Name: music
 			Actions:
 				Copy: .
 					^SupportDir|Content/cnc/scores.mix: SCORES.MIX
 		# GDI campaign briefings (optional):
-		ContentPackage:
+		ContentPackage@movies-gdi:
 			Name: movies-gdi
 			Actions:
 				ExtractMix: MOVIES.MIX

--- a/mods/cnc/installer/nod95.yaml
+++ b/mods/cnc/installer/nod95.yaml
@@ -5,7 +5,7 @@ nod95: C&C Gold (Nod Disc, English)
 		CONQUER.MIX: 833e02a09aae694659eb312d3838367f681d1b30
 	Install:
 		# Base game files:
-		ContentPackage:
+		ContentPackage@base:
 			Name: base
 			Actions:
 				Copy: .
@@ -20,13 +20,13 @@ nod95: C&C Gold (Nod Disc, English)
 					^SupportDir|Content/cnc/tempicnh.mix: TEMPICNH.MIX
 					^SupportDir|Content/cnc/transit.mix: TRANSIT.MIX
 		# Base game music (optional):
-		ContentPackage:
+		ContentPackage@music:
 			Name: music
 			Actions:
 				Copy: .
 					^SupportDir|Content/cnc/scores.mix: SCORES.MIX
 		# Nod campaign briefings (optional):
-		ContentPackage:
+		ContentPackage@movies-nod:
 			Name: movies-nod
 			Actions:
 				ExtractMix: MOVIES.MIX

--- a/mods/cnc/installer/origin.yaml
+++ b/mods/cnc/installer/origin.yaml
@@ -7,7 +7,7 @@ tuc-origin: C&C The Ultimate Collection (Origin version, English)
 		CONQUER.MIX: 833e02a09aae694659eb312d3838367f681d1b30
 	Install:
 		# Base game files:
-		ContentPackage:
+		ContentPackage@base:
 			Name: base
 			Actions:
 				Copy: .
@@ -21,19 +21,19 @@ tuc-origin: C&C The Ultimate Collection (Origin version, English)
 					^SupportDir|Content/cnc/tempicnh.mix: TEMPICNH.MIX
 					^SupportDir|Content/cnc/transit.mix: TRANSIT.MIX
 		# Base game music (optional):
-		ContentPackage:
+		ContentPackage@music:
 			Name: music
 			Actions:
 				Copy: .
 					^SupportDir|Content/cnc/scores.mix: SCORES.MIX
 		# Covert Operations music (optional):
-		ContentPackage:
+		ContentPackage@music-covertops:
 			Name: music-covertops
 			Actions:
 				Copy: .
 					^SupportDir|Content/cnc/scores-covertops.mix: covert/SCORES.MIX
 		# GDI campaign briefings (optional):
-		ContentPackage:
+		ContentPackage@movies-gdi:
 			Name: movies-gdi
 			Actions:
 				ExtractMix: movies.mix
@@ -103,7 +103,7 @@ tuc-origin: C&C The Ultimate Collection (Origin version, English)
 					^SupportDir|Content/cnc/movies/bcanyon.vqa: bcanyon.vqa
 					^SupportDir|Content/cnc/movies/banner.vqa: banner.vqa
 		# Nod campaign briefings (optional):
-		ContentPackage:
+		ContentPackage@movies-nod:
 			Name: movies-nod
 			Actions:
 				ExtractMix: movies.mix
@@ -179,7 +179,7 @@ cncr-origin: C&C Remastered Collection (Origin version, English)
 		Data/CNCDATA/TIBERIAN_DAWN/CD1/CONQUER.MIX: 3f891c8dc0864f654e1710430ea4ff34c3715e97
 	Install:
 		# Base game files:
-		ContentPackage:
+		ContentPackage@base:
 			Name: base
 			Actions:
 				Copy: Data/CNCDATA/TIBERIAN_DAWN/CD1
@@ -193,20 +193,20 @@ cncr-origin: C&C Remastered Collection (Origin version, English)
 					^SupportDir|Content/cnc/transit.mix: TRANSIT.MIX
 					^SupportDir|Content/cnc/winter.mix: WINTER.MIX
 		# Base game music (optional):
-		ContentPackage:
+		ContentPackage@music:
 			Name: music
 			Actions:
 				Copy: Data/CNCDATA/TIBERIAN_DAWN/CD1
 					^SupportDir|Content/cnc/scores.mix: SCORES.MIX
 		# Covert Operations music (optional):
-		ContentPackage:
+		ContentPackage@music-covertops:
 			Name: music-covertops
 			Actions:
 				Copy: Data/CNCDATA/TIBERIAN_DAWN/CD3
 					^SupportDir|Content/cnc/scores-covertops.mix: SCORES.MIX
 		# GDI campaign briefings (optional):
 		# The Remastered Collection doesn't include trailer.vqa.
-		ContentPackage:
+		ContentPackage@movies-gdi:
 			Name: movies-gdi
 			TooltipText: The Remastered Collection doesn't include trailer.vqa.
 			Actions:
@@ -277,7 +277,7 @@ cncr-origin: C&C Remastered Collection (Origin version, English)
 					^SupportDir|Content/cnc/movies/banner.vqa: banner.vqa
 		# Nod campaign briefings (optional):
 		# The Remastered Collection doesn't include trailer.vqa.
-		ContentPackage:
+		ContentPackage@movies-nod:
 			Name: movies-nod
 			TooltipText: The Remastered Collection doesn't include trailer.vqa.
 			Actions:

--- a/mods/cnc/installer/steam.yaml
+++ b/mods/cnc/installer/steam.yaml
@@ -5,7 +5,7 @@ tuc-steam: C&C The Ultimate Collection (Steam version, English)
 		CONQUER.MIX: 713b53fa4c188ca9619c6bbeadbfc86513704266
 	Install:
 		# Base game files:
-		ContentPackage:
+		ContentPackage@base:
 			Name: base
 			Actions:
 				Copy: .
@@ -19,19 +19,19 @@ tuc-steam: C&C The Ultimate Collection (Steam version, English)
 					^SupportDir|Content/cnc/tempicnh.mix: TEMPICNH.MIX
 					^SupportDir|Content/cnc/transit.mix: TRANSIT.MIX
 		# Base game music (optional):
-		ContentPackage:
+		ContentPackage@music:
 			Name: music
 			Actions:
 				Copy: .
 					^SupportDir|Content/cnc/scores.mix: SCORES.MIX
 		# Covert Operations music (optional):
-		ContentPackage:
+		ContentPackage@music-covertops:
 			Name: music-covertops
 			Actions:
 				Copy: .
 					^SupportDir|Content/cnc/scores-covertops.mix: SCORES.MIX
 		# GDI campaign briefings (optional):
-		ContentPackage:
+		ContentPackage@movies-gdi:
 			Name: movies-gdi
 			Actions:
 				ExtractMix: movies.mix
@@ -101,7 +101,7 @@ tuc-steam: C&C The Ultimate Collection (Steam version, English)
 					^SupportDir|Content/cnc/movies/bcanyon.vqa: bcanyon.vqa
 					^SupportDir|Content/cnc/movies/banner.vqa: banner.vqa
 		# Nod campaign briefings (optional):
-		ContentPackage:
+		ContentPackage@movies-nod:
 			Name: movies-nod
 			Actions:
 				ExtractMix: movies.mix
@@ -174,7 +174,7 @@ cncr-steam: C&C Remastered Collection (Steam version, English)
 		Data/CNCDATA/TIBERIAN_DAWN/CD1/CONQUER.MIX: 3f891c8dc0864f654e1710430ea4ff34c3715e97
 	Install:
 		# Base game files:
-		ContentPackage:
+		ContentPackage@base:
 			Name: base
 			Actions:
 				Copy: Data/CNCDATA/TIBERIAN_DAWN/CD1
@@ -188,20 +188,20 @@ cncr-steam: C&C Remastered Collection (Steam version, English)
 					^SupportDir|Content/cnc/transit.mix: TRANSIT.MIX
 					^SupportDir|Content/cnc/winter.mix: WINTER.MIX
 		# Base game music (optional):
-		ContentPackage:
+		ContentPackage@music:
 			Name: music
 			Actions:
 				Copy: Data/CNCDATA/TIBERIAN_DAWN/CD1
 					^SupportDir|Content/cnc/scores.mix: SCORES.MIX
 		# Covert Operations music (optional):
-		ContentPackage:
+		ContentPackage@music-covertops:
 			Name: music-covertops
 			Actions:
 				Copy: Data/CNCDATA/TIBERIAN_DAWN/CD3
 					^SupportDir|Content/cnc/scores-covertops.mix: SCORES.MIX
 		# GDI campaign briefings (optional):
 		# The Remastered Collection doesn't include trailer.vqa.
-		ContentPackage:
+		ContentPackage@movies-gdi:
 			Name: movies-gdi
 			TooltipText: The Remastered Collection doesn't include trailer.vqa.
 			Actions:
@@ -272,7 +272,7 @@ cncr-steam: C&C Remastered Collection (Steam version, English)
 					^SupportDir|Content/cnc/movies/banner.vqa: banner.vqa
 		# Nod campaign briefings (optional):
 		# The Remastered Collection doesn't include trailer.vqa.
-		ContentPackage:
+		ContentPackage@movies-nod:
 			Name: movies-nod
 			TooltipText: The Remastered Collection doesn't include trailer.vqa.
 			Actions:

--- a/mods/d2k/installer/d2k.yaml
+++ b/mods/d2k/installer/d2k.yaml
@@ -4,7 +4,7 @@ d2k: Dune 2000 (English)
 		MUSIC/AMBUSH.AUD: bd5926a56a83bc0e49f96037e1f909014ac0772a
 	Install:
 		# Campaign briefings (optional):
-		ContentPackage:
+		ContentPackage@movies:
 			Name: movies
 			Actions:
 				Copy: MOVIES
@@ -51,7 +51,7 @@ d2k: Dune 2000 (English)
 					^SupportDir|Content/d2k/v3/Movies/G_PLNT_E.VQA: G_PLNT_E.VQA
 					^SupportDir|Content/d2k/v3/Movies/T_TITL_E.VQA: T_TITL_E.VQA
 		# Game music (optional):
-		ContentPackage:
+		ContentPackage@music:
 			Name: music
 			Actions:
 				Copy: MUSIC
@@ -73,7 +73,7 @@ d2k: Dune 2000 (English)
 					^SupportDir|Content/d2k/v3/Music/UNDERCON.AUD: UNDERCON.AUD
 					^SupportDir|Content/d2k/v3/Music/WAITGAME.AUD: WAITGAME.AUD
 		# Base game files:
-		ContentPackage:
+		ContentPackage@base:
 			Name: base
 			Actions:
 				ExtractBlast: SETUP/SETUP.Z

--- a/mods/d2k/installer/gruntmods.yaml
+++ b/mods/d2k/installer/gruntmods.yaml
@@ -7,7 +7,7 @@ gruntmods: Dune 2000: GruntMods Edition
 		Dune 2000/data/DATA.R16: 2471ef70e2ce5ab3514db14b9611a09f188127fa
 	Install:
 		# Game music (optional):
-		ContentPackage:
+		ContentPackage@music:
 			Name: music
 			Actions:
 				Copy: Dune 2000/data/Music
@@ -30,10 +30,10 @@ gruntmods: Dune 2000: GruntMods Edition
 					^SupportDir|Content/d2k/v3/Music/WAITGAME.AUD: WAITGAME.AUD
 		# TODO: DOES THIS NEED TO BE SEPARATED INTO TWO PACKAGES?
 		# Base game files + 1.06 Patch Content:
-		ContentPackage:
+		ContentPackage@patch:
 			Name: patch
 			Actions:
-				Copy: Dune 2000/data
+				Copy@1: Dune 2000/data
 					^SupportDir|Content/d2k/v3/BLOXBAT.R16: BLOXBAT.R16
 					^SupportDir|Content/d2k/v3/BLOXBASE.R16: BLOXBASE.R16
 					^SupportDir|Content/d2k/v3/BLOXBGBS.R16: BLOXBGBS.R16
@@ -43,9 +43,9 @@ gruntmods: Dune 2000: GruntMods Edition
 					^SupportDir|Content/d2k/v3/BLOXXMAS.R8: BLOXXMAS.R8
 					^SupportDir|Content/d2k/v3/DATA.R16: DATA.R16
 					^SupportDir|Content/d2k/v3/MOUSE.R16: MOUSE.R16
-				Copy: Dune 2000/data/bin
+				Copy@2: Dune 2000/data/bin
 					^SupportDir|Content/d2k/v3/PALETTE.BIN: PALETTE.BIN
-				Copy: Dune 2000/data/GAMESFX
+				Copy@3: Dune 2000/data/GAMESFX
 					^SupportDir|Content/d2k/v3/GAMESFX/A_ECONF2.AUD: A_ECONF2.AUD
 					^SupportDir|Content/d2k/v3/GAMESFX/A_ECONF1.AUD: A_ECONF1.AUD
 					^SupportDir|Content/d2k/v3/GAMESFX/A_ECONF3.AUD: A_ECONF3.AUD

--- a/mods/ra/installer/aftermath.yaml
+++ b/mods/ra/installer/aftermath.yaml
@@ -5,7 +5,7 @@ aftermath: Aftermath Expansion Disc (English)
 		SETUP/INSTALL/PATCH.RTP: 5bce93f834f9322ddaa7233242e5b6c7fea0bf17
 	Install:
 		# Aftermath expansion files:
-		ContentPackage:
+		ContentPackage@aftermathbase:
 			Name: aftermathbase
 			Actions:
 				ExtractRaw: SETUP/INSTALL/PATCH.RTP
@@ -18,9 +18,9 @@ aftermath: Aftermath Expansion Disc (English)
 					^SupportDir|Content/ra/v2/expand/lores1.mix:
 						Offset: 5273320
 						Length: 57076
-				ExtractMix: MAIN.MIX
+				ExtractMix@1: MAIN.MIX
 					^SupportDir|Content/ra/v2/expand/sounds.mix: sounds.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/expand/sounds.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/expand/sounds.mix
 					^SupportDir|Content/ra/v2/expand/chrotnk1.aud: chrotnk1.aud
 					^SupportDir|Content/ra/v2/expand/fixit1.aud: fixit1.aud
 					^SupportDir|Content/ra/v2/expand/jburn1.aud: jburn1.aud
@@ -47,12 +47,12 @@ aftermath: Aftermath Expansion Disc (English)
 					^SupportDir|Content/ra/v2/expand/myes1.aud: myes1.aud
 				Delete: ^SupportDir|Content/ra/v2/expand/sounds.mix
 		# Aftermath music (optional):
-		ContentPackage:
+		ContentPackage@music-aftermath:
 			Name: music-aftermath
 			Actions:
-				ExtractMix: MAIN.MIX
+				ExtractMix@1: MAIN.MIX
 					^SupportDir|Content/ra/v2/expand/scores.mix: scores.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/expand/scores.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/expand/scores.mix
 					^SupportDir|Content/ra/v2/expand/await.aud: await.aud
 					^SupportDir|Content/ra/v2/expand/bog.aud: bog.aud
 					^SupportDir|Content/ra/v2/expand/float_v2.aud: float_v2.aud

--- a/mods/ra/installer/allies95.yaml
+++ b/mods/ra/installer/allies95.yaml
@@ -6,15 +6,15 @@ allied: Red Alert 95 (Allied Disc, English)
 		INSTALL/REDALERT.MIX: 0e58f4b54f44f6cd29fecf8cf379d33cf2d4caef
 	Install:
 		# Base game files:
-		ContentPackage:
+		ContentPackage@base:
 			Name: base
 			Actions:
-				ExtractMix: INSTALL/REDALERT.MIX
+				ExtractMix@1: INSTALL/REDALERT.MIX
 					^SupportDir|Content/ra/v2/hires.mix: hires.mix
 					^SupportDir|Content/ra/v2/local.mix: local.mix
 					^SupportDir|Content/ra/v2/lores.mix: lores.mix
 					^SupportDir|Content/ra/v2/speech.mix: speech.mix
-				ExtractMix: MAIN.MIX
+				ExtractMix@2: MAIN.MIX
 					^SupportDir|Content/ra/v2/conquer.mix: conquer.mix
 					^SupportDir|Content/ra/v2/general.mix: general.mix # Is this one used? The FirstDecade and TUC installers are missing this!
 					^SupportDir|Content/ra/v2/interior.mix: interior.mix
@@ -24,18 +24,18 @@ allied: Red Alert 95 (Allied Disc, English)
 					^SupportDir|Content/ra/v2/allies.mix: allies.mix
 					^SupportDir|Content/ra/v2/temperat.mix: temperat.mix
 		# Base game music (optional):
-		ContentPackage:
+		ContentPackage@music:
 			Name: music
 			Actions:
 				ExtractMix: MAIN.MIX
 					^SupportDir|Content/ra/v2/scores.mix: scores.mix
 		# Allied campaign briefings (optional):
-		ContentPackage:
+		ContentPackage@movies-allied:
 			Name: movies-allied
 			Actions:
-				ExtractMix: MAIN.MIX
+				ExtractMix@1: MAIN.MIX
 					^SupportDir|Content/ra/v2/movies1.mix: movies1.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/movies1.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/movies1.mix
 					^SupportDir|Content/ra/v2/movies/aagun.vqa: aagun.vqa
 					^SupportDir|Content/ra/v2/movies/aftrmath.vqa: aftrmath.vqa
 					^SupportDir|Content/ra/v2/movies/ally1.vqa: ally1.vqa

--- a/mods/ra/installer/cnc95.yaml
+++ b/mods/ra/installer/cnc95.yaml
@@ -4,7 +4,7 @@ cnc95: C&C Gold (GDI or Nod Disc, English)
 		CONQUER.MIX: 833e02a09aae694659eb312d3838367f681d1b30
 	Install:
 		# C&C Desert Tileset:
-		ContentPackage:
+		ContentPackage@cncdesert:
 			Name: cncdesert
 			Actions:
 				Copy: .

--- a/mods/ra/installer/counterstrike.yaml
+++ b/mods/ra/installer/counterstrike.yaml
@@ -5,12 +5,12 @@ counterstrike: Counterstrike Expansion Disc (English)
 		SETUP/INSTALL/CSTRIKE.RTP: fae8ba82db71574f6ecd8fb4ff4026fcb65d2adc
 	Install:
 		# Counterstrike music (optional):
-		ContentPackage:
+		ContentPackage@music-counterstrike:
 			Name: music-counterstrike
 			Actions:
-				ExtractMix: MAIN.MIX
+				ExtractMix@1: MAIN.MIX
 					^SupportDir|Content/ra/v2/expand/scores.mix: scores.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/expand/scores.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/expand/scores.mix
 					^SupportDir|Content/ra/v2/expand/2nd_hand.aud: 2nd_hand.aud
 					^SupportDir|Content/ra/v2/expand/araziod.aud: araziod.aud
 					^SupportDir|Content/ra/v2/expand/backstab.aud: backstab.aud

--- a/mods/ra/installer/firstdecade.yaml
+++ b/mods/ra/installer/firstdecade.yaml
@@ -22,16 +22,16 @@ tfd: C&C The First Decade (English)
 					^SupportDir|Content/ra/v2/expand/expand2.mix: Red Alert\\EXPAND2.MIX
 					^SupportDir|Content/ra/v2/cnc/desert.mix: CnC\\DESERT.MIX
 		# Base game files:
-		ContentPackage:
+		ContentPackage@base:
 			Name: base
 			Actions:
-				ExtractMix: ^SupportDir|Content/ra/v2/redalert.mix
+				ExtractMix@1: ^SupportDir|Content/ra/v2/redalert.mix
 					^SupportDir|Content/ra/v2/hires.mix: hires.mix
 					^SupportDir|Content/ra/v2/local.mix: local.mix
 					^SupportDir|Content/ra/v2/lores.mix: lores.mix
 					^SupportDir|Content/ra/v2/speech.mix: speech.mix
 				Delete: ^SupportDir|Content/ra/v2/redalert.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/main.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/main.mix
 					^SupportDir|Content/ra/v2/interior.mix: interior.mix
 					^SupportDir|Content/ra/v2/conquer.mix: conquer.mix
 					^SupportDir|Content/ra/v2/allies.mix: allies.mix
@@ -40,18 +40,18 @@ tfd: C&C The First Decade (English)
 					^SupportDir|Content/ra/v2/snow.mix: snow.mix
 					^SupportDir|Content/ra/v2/russian.mix: russian.mix
 		# Base game music (optional):
-		ContentPackage:
+		ContentPackage@music:
 			Name: music
 			Actions:
 				ExtractMix: ^SupportDir|Content/ra/v2/main.mix
 					^SupportDir|Content/ra/v2/scores.mix: scores.mix
 		# Allied campaign briefings (optional):
-		ContentPackage:
+		ContentPackage@movies-allied:
 			Name: movies-allied
 			Actions:
-				ExtractMix: ^SupportDir|Content/ra/v2/main.mix
+				ExtractMix@1: ^SupportDir|Content/ra/v2/main.mix
 					^SupportDir|Content/ra/v2/movies1.mix: movies1.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/movies1.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/movies1.mix
 					^SupportDir|Content/ra/v2/movies/aagun.vqa: aagun.vqa
 					^SupportDir|Content/ra/v2/movies/aftrmath.vqa: aftrmath.vqa
 					^SupportDir|Content/ra/v2/movies/ally12.vqa: ally12.vqa
@@ -105,12 +105,12 @@ tfd: C&C The First Decade (English)
 					^SupportDir|Content/ra/v2/movies/ally11.vqa: ally11.vqa
 				Delete: ^SupportDir|Content/ra/v2/movies1.mix
 		# Soviet campaign briefings (optional):
-		ContentPackage:
+		ContentPackage@movies-soviet:
 			Name: movies-soviet
 			Actions:
-				ExtractMix: ^SupportDir|Content/ra/v2/main.mix
+				ExtractMix@1: ^SupportDir|Content/ra/v2/main.mix
 					^SupportDir|Content/ra/v2/movies2.mix: movies2.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/movies2.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/movies2.mix
 					^SupportDir|Content/ra/v2/movies/double.vqa: double.vqa
 					^SupportDir|Content/ra/v2/movies/dpthchrg.vqa: dpthchrg.vqa
 					^SupportDir|Content/ra/v2/movies/execute.vqa: execute.vqa
@@ -168,7 +168,7 @@ tfd: C&C The First Decade (English)
 					^SupportDir|Content/ra/v2/movies/cronfail.vqa: cronfail.vqa
 				Delete: ^SupportDir|Content/ra/v2/movies2.mix
 		# Aftermath expansion files:
-		ContentPackage:
+		ContentPackage@aftermathbase:
 			Name: aftermathbase
 			Actions:
 				ExtractMix: ^SupportDir|Content/ra/v2/sounds.mix

--- a/mods/ra/installer/origin.yaml
+++ b/mods/ra/installer/origin.yaml
@@ -7,15 +7,15 @@ ra-origin: C&C The Ultimate Collection (Origin version, English)
 		REDALERT.MIX: 0e58f4b54f44f6cd29fecf8cf379d33cf2d4caef
 	Install:
 		# Base game files:
-		ContentPackage:
+		ContentPackage@base:
 			Name: base
 			Actions:
-				ExtractMix: REDALERT.MIX
+				ExtractMix@1: REDALERT.MIX
 					^SupportDir|Content/ra/v2/hires.mix: hires.mix
 					^SupportDir|Content/ra/v2/local.mix: local.mix
 					^SupportDir|Content/ra/v2/lores.mix: lores.mix
 					^SupportDir|Content/ra/v2/speech.mix: speech.mix
-				ExtractMix: MAIN.MIX
+				ExtractMix@2: MAIN.MIX
 					^SupportDir|Content/ra/v2/interior.mix: interior.mix
 					^SupportDir|Content/ra/v2/conquer.mix: conquer.mix
 					^SupportDir|Content/ra/v2/allies.mix: allies.mix
@@ -24,13 +24,13 @@ ra-origin: C&C The Ultimate Collection (Origin version, English)
 					^SupportDir|Content/ra/v2/snow.mix: snow.mix
 					^SupportDir|Content/ra/v2/russian.mix: russian.mix
 		# Base game music (optional):
-		ContentPackage:
+		ContentPackage@music:
 			Name: music
 			Actions:
 				ExtractMix: MAIN.MIX
 					^SupportDir|Content/ra/v2/scores.mix: scores.mix
 		# Aftermath expansion files:
-		ContentPackage:
+		ContentPackage@aftermathbase:
 			Name: aftermathbase
 			Actions:
 				Copy: .
@@ -63,7 +63,7 @@ ra-origin: C&C The Ultimate Collection (Origin version, English)
 					^SupportDir|Content/ra/v2/expand/myeehaw1.aud: myeehaw1.aud
 					^SupportDir|Content/ra/v2/expand/myes1.aud: myes1.aud
 		# Aftermath music (optional):
-		ContentPackage:
+		ContentPackage@music-aftermath:
 			Name: music-aftermath
 			Actions:
 				Copy: .
@@ -77,7 +77,7 @@ ra-origin: C&C The Ultimate Collection (Origin version, English)
 					^SupportDir|Content/ra/v2/expand/traction.aud: traction.aud
 					^SupportDir|Content/ra/v2/expand/wastelnd.aud: wastelnd.aud
 		# Counterstrike music (optional):
-		ContentPackage:
+		ContentPackage@music-counterstrike:
 			Name: music-counterstrike
 			Actions:
 				Copy: .
@@ -90,12 +90,12 @@ ra-origin: C&C The Ultimate Collection (Origin version, English)
 					^SupportDir|Content/ra/v2/expand/under3.aud: under3.aud
 					^SupportDir|Content/ra/v2/expand/vr2.aud: vr2.aud
 		# Allied campaign briefings (optional):
-		ContentPackage:
+		ContentPackage@movies-allied:
 			Name: movies-allied
 			Actions:
-				ExtractMix: MAIN.MIX
+				ExtractMix@1: MAIN.MIX
 					^SupportDir|Content/ra/v2/movies1.mix: movies1.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/movies1.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/movies1.mix
 					^SupportDir|Content/ra/v2/movies/aagun.vqa: aagun.vqa
 					^SupportDir|Content/ra/v2/movies/aftrmath.vqa: aftrmath.vqa
 					^SupportDir|Content/ra/v2/movies/ally12.vqa: ally12.vqa
@@ -149,12 +149,12 @@ ra-origin: C&C The Ultimate Collection (Origin version, English)
 					^SupportDir|Content/ra/v2/movies/ally11.vqa: ally11.vqa
 				Delete: ^SupportDir|Content/ra/v2/movies1.mix
 		# Soviet campaign briefings (optional):
-		ContentPackage:
+		ContentPackage@movies-soviet:
 			Name: movies-soviet
 			Actions:
-				ExtractMix: MAIN.MIX
+				ExtractMix@1: MAIN.MIX
 					^SupportDir|Content/ra/v2/movies2.mix: movies2.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/movies2.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/movies2.mix
 					^SupportDir|Content/ra/v2/movies/double.vqa: double.vqa
 					^SupportDir|Content/ra/v2/movies/dpthchrg.vqa: dpthchrg.vqa
 					^SupportDir|Content/ra/v2/movies/execute.vqa: execute.vqa
@@ -221,7 +221,7 @@ cnc-origin: Command & Conquer (Origin version, English)
 		CONQUER.MIX: 833e02a09aae694659eb312d3838367f681d1b30
 	Install:
 		# C&C Desert Tileset:
-		ContentPackage:
+		ContentPackage@cncdesert:
 			Name: cncdesert
 			Actions:
 				Copy: .
@@ -237,15 +237,15 @@ cncr-origin: C&C Remastered Collection (Origin version, English)
 	# The Remastered Collection doesn't include the RA Soviet CD unfortunately, so we can't install Soviet campaign briefings.
 	Install:
 		# Base game files:
-		ContentPackage:
+		ContentPackage@base:
 			Name: base
 			Actions:
-				ExtractMix: Data/CNCDATA/RED_ALERT/CD1/REDALERT.MIX
+				ExtractMix@1: Data/CNCDATA/RED_ALERT/CD1/REDALERT.MIX
 					^SupportDir|Content/ra/v2/hires.mix: hires.mix
 					^SupportDir|Content/ra/v2/local.mix: local.mix
 					^SupportDir|Content/ra/v2/lores.mix: lores.mix
 					^SupportDir|Content/ra/v2/speech.mix: speech.mix
-				ExtractMix: Data/CNCDATA/RED_ALERT/CD1/MAIN.MIX
+				ExtractMix@2: Data/CNCDATA/RED_ALERT/CD1/MAIN.MIX
 					^SupportDir|Content/ra/v2/conquer.mix: conquer.mix
 					^SupportDir|Content/ra/v2/general.mix: general.mix
 					^SupportDir|Content/ra/v2/interior.mix: interior.mix
@@ -255,18 +255,18 @@ cncr-origin: C&C Remastered Collection (Origin version, English)
 					^SupportDir|Content/ra/v2/allies.mix: allies.mix
 					^SupportDir|Content/ra/v2/temperat.mix: temperat.mix
 		# Base game music (optional):
-		ContentPackage:
+		ContentPackage@music:
 			Name: music
 			Actions:
 				ExtractMix: Data/CNCDATA/RED_ALERT/CD1/MAIN.MIX
 					^SupportDir|Content/ra/v2/scores.mix: scores.mix
 		# Allied campaign briefings (optional):
-		ContentPackage:
+		ContentPackage@movies-allied:
 			Name: movies-allied
 			Actions:
-				ExtractMix: Data/CNCDATA/RED_ALERT/CD1/MAIN.MIX
+				ExtractMix@1: Data/CNCDATA/RED_ALERT/CD1/MAIN.MIX
 					^SupportDir|Content/ra/v2/movies1.mix: movies1.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/movies1.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/movies1.mix
 					^SupportDir|Content/ra/v2/movies/aagun.vqa: aagun.vqa
 					^SupportDir|Content/ra/v2/movies/aftrmath.vqa: aftrmath.vqa
 					^SupportDir|Content/ra/v2/movies/ally1.vqa: ally1.vqa
@@ -320,12 +320,12 @@ cncr-origin: C&C Remastered Collection (Origin version, English)
 					^SupportDir|Content/ra/v2/movies/trinity.vqa: trinity.vqa
 				Delete: ^SupportDir|Content/ra/v2/movies1.mix
 		# Counterstrike music (optional):
-		ContentPackage:
+		ContentPackage@music-counterstrike:
 			Name: music-counterstrike
 			Actions:
-				ExtractMix: Data/CNCDATA/RED_ALERT/COUNTERSTRIKE/MAIN.MIX
+				ExtractMix@1: Data/CNCDATA/RED_ALERT/COUNTERSTRIKE/MAIN.MIX
 					^SupportDir|Content/ra/v2/expand/scores.mix: scores.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/expand/scores.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/expand/scores.mix
 					^SupportDir|Content/ra/v2/expand/2nd_hand.aud: 2nd_hand.aud
 					^SupportDir|Content/ra/v2/expand/araziod.aud: araziod.aud
 					^SupportDir|Content/ra/v2/expand/backstab.aud: backstab.aud
@@ -336,16 +336,16 @@ cncr-origin: C&C Remastered Collection (Origin version, English)
 					^SupportDir|Content/ra/v2/expand/vr2.aud: vr2.aud
 				Delete: ^SupportDir|Content/ra/v2/expand/scores.mix
 		# Aftermath expansion files:
-		ContentPackage:
+		ContentPackage@aftermathbase:
 			Name: aftermathbase
 			Actions:
 				Copy: Data/CNCDATA/RED_ALERT/AFTERMATH
 					^SupportDir|Content/ra/v2/expand/expand2.mix: expand2.mix
 					^SupportDir|Content/ra/v2/expand/hires1.mix: hires1.mix
 					^SupportDir|Content/ra/v2/expand/lores1.mix: lores1.mix
-				ExtractMix: Data/CNCDATA/RED_ALERT/AFTERMATH/MAIN.MIX
+				ExtractMix@1: Data/CNCDATA/RED_ALERT/AFTERMATH/MAIN.MIX
 					^SupportDir|Content/ra/v2/expand/sounds.mix: sounds.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/expand/sounds.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/expand/sounds.mix
 					^SupportDir|Content/ra/v2/expand/chrotnk1.aud: chrotnk1.aud
 					^SupportDir|Content/ra/v2/expand/fixit1.aud: fixit1.aud
 					^SupportDir|Content/ra/v2/expand/jburn1.aud: jburn1.aud
@@ -372,12 +372,12 @@ cncr-origin: C&C Remastered Collection (Origin version, English)
 					^SupportDir|Content/ra/v2/expand/myes1.aud: myes1.aud
 				Delete: ^SupportDir|Content/ra/v2/expand/sounds.mix
 		# Aftermath music (optional):
-		ContentPackage:
+		ContentPackage@music-aftermath:
 			Name: music-aftermath
 			Actions:
-				ExtractMix: Data/CNCDATA/RED_ALERT/AFTERMATH/MAIN.MIX
+				ExtractMix@1: Data/CNCDATA/RED_ALERT/AFTERMATH/MAIN.MIX
 					^SupportDir|Content/ra/v2/expand/scores.mix: scores.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/expand/scores.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/expand/scores.mix
 					^SupportDir|Content/ra/v2/expand/await.aud: await.aud
 					^SupportDir|Content/ra/v2/expand/bog.aud: bog.aud
 					^SupportDir|Content/ra/v2/expand/float_v2.aud: float_v2.aud
@@ -389,7 +389,7 @@ cncr-origin: C&C Remastered Collection (Origin version, English)
 					^SupportDir|Content/ra/v2/expand/wastelnd.aud: wastelnd.aud
 				Delete: ^SupportDir|Content/ra/v2/expand/scores.mix
 		# C&C Desert Tileset:
-		ContentPackage:
+		ContentPackage@cncdesert:
 			Name: cncdesert
 			Actions:
 				Copy: Data/CNCDATA/TIBERIAN_DAWN/CD1

--- a/mods/ra/installer/soviet95.yaml
+++ b/mods/ra/installer/soviet95.yaml
@@ -6,15 +6,15 @@ soviet: Red Alert 95 (Soviet Disc, English)
 		INSTALL/REDALERT.MIX: 0e58f4b54f44f6cd29fecf8cf379d33cf2d4caef
 	Install:
 		# Base game files:
-		ContentPackage:
+		ContentPackage@base:
 			Name: base
 			Actions:
-				ExtractMix: INSTALL/REDALERT.MIX
+				ExtractMix@1: INSTALL/REDALERT.MIX
 					^SupportDir|Content/ra/v2/hires.mix: hires.mix
 					^SupportDir|Content/ra/v2/local.mix: local.mix
 					^SupportDir|Content/ra/v2/lores.mix: lores.mix
 					^SupportDir|Content/ra/v2/speech.mix: speech.mix
-				ExtractMix: MAIN.MIX
+				ExtractMix@2: MAIN.MIX
 					^SupportDir|Content/ra/v2/conquer.mix: conquer.mix
 					^SupportDir|Content/ra/v2/general.mix: general.mix # Is this one used? The FirstDecade and TUC installers are missing this!
 					^SupportDir|Content/ra/v2/interior.mix: interior.mix
@@ -24,18 +24,18 @@ soviet: Red Alert 95 (Soviet Disc, English)
 					^SupportDir|Content/ra/v2/sounds.mix: sounds.mix
 					^SupportDir|Content/ra/v2/temperat.mix: temperat.mix
 		# Base game music (optional):
-		ContentPackage:
+		ContentPackage@music:
 			Name: music
 			Actions:
 				ExtractMix: MAIN.MIX
 					^SupportDir|Content/ra/v2/scores.mix: scores.mix
 		# Soviet campaign briefings (optional):
-		ContentPackage:
+		ContentPackage@movies-soviet:
 			Name: movies-soviet
 			Actions:
-				ExtractMix: MAIN.MIX
+				ExtractMix@1: MAIN.MIX
 					^SupportDir|Content/ra/v2/movies2.mix: movies2.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/movies2.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/movies2.mix
 					^SupportDir|Content/ra/v2/movies/aagun.vqa: aagun.vqa
 					^SupportDir|Content/ra/v2/movies/cronfail.vqa: cronfail.vqa
 					^SupportDir|Content/ra/v2/movies/airfield.vqa: airfield.vqa

--- a/mods/ra/installer/steam.yaml
+++ b/mods/ra/installer/steam.yaml
@@ -5,15 +5,15 @@ ra-steam: C&C The Ultimate Collection (Steam version, English)
 		REDALERT.MIX: 0e58f4b54f44f6cd29fecf8cf379d33cf2d4caef
 	Install:
 		# Base game files:
-		ContentPackage:
+		ContentPackage@base:
 			Name: base
 			Actions:
-				ExtractMix: REDALERT.MIX
+				ExtractMix@1: REDALERT.MIX
 					^SupportDir|Content/ra/v2/hires.mix: hires.mix
 					^SupportDir|Content/ra/v2/local.mix: local.mix
 					^SupportDir|Content/ra/v2/lores.mix: lores.mix
 					^SupportDir|Content/ra/v2/speech.mix: speech.mix
-				ExtractMix: MAIN1.MIX
+				ExtractMix@2: MAIN1.MIX
 					^SupportDir|Content/ra/v2/interior.mix: interior.mix
 					^SupportDir|Content/ra/v2/conquer.mix: conquer.mix
 					^SupportDir|Content/ra/v2/allies.mix: allies.mix
@@ -22,22 +22,22 @@ ra-steam: C&C The Ultimate Collection (Steam version, English)
 					^SupportDir|Content/ra/v2/snow.mix: snow.mix
 					^SupportDir|Content/ra/v2/russian.mix: russian.mix
 		# Base game music (optional):
-		ContentPackage:
+		ContentPackage@music:
 			Name: music
 			Actions:
 				ExtractMix: MAIN1.MIX
 					^SupportDir|Content/ra/v2/scores.mix: scores.mix
 		# Aftermath expansion files:
-		ContentPackage:
+		ContentPackage@aftermathbase:
 			Name: aftermathbase
 			Actions:
 				Copy: .
 					^SupportDir|Content/ra/v2/expand/expand2.mix: EXPAND2.MIX
 					^SupportDir|Content/ra/v2/expand/hires1.mix: HIRES1.MIX
 					^SupportDir|Content/ra/v2/expand/lores1.mix: LORES1.MIX
-				ExtractMix: MAIN4.MIX
+				ExtractMix@1: MAIN4.MIX
 					^SupportDir|Content/ra/v2/expand/sounds-aftermath.mix: sounds.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/expand/sounds-aftermath.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/expand/sounds-aftermath.mix
 					^SupportDir|Content/ra/v2/expand/chrotnk1.aud: chrotnk1.aud
 					^SupportDir|Content/ra/v2/expand/fixit1.aud: fixit1.aud
 					^SupportDir|Content/ra/v2/expand/jburn1.aud: jburn1.aud
@@ -64,12 +64,12 @@ ra-steam: C&C The Ultimate Collection (Steam version, English)
 					^SupportDir|Content/ra/v2/expand/myes1.aud: myes1.aud
 				Delete: ^SupportDir|Content/ra/v2/expand/sounds-aftermath.mix
 		# Aftermath music (optional):
-		ContentPackage:
+		ContentPackage@music-aftermath:
 			Name: music-aftermath
 			Actions:
-				ExtractMix: MAIN4.MIX
+				ExtractMix@1: MAIN4.MIX
 					^SupportDir|Content/ra/v2/expand/scores-aftermath.mix: scores.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/expand/scores-aftermath.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/expand/scores-aftermath.mix
 					^SupportDir|Content/ra/v2/expand/await.aud: await.aud
 					^SupportDir|Content/ra/v2/expand/bog.aud: bog.aud
 					^SupportDir|Content/ra/v2/expand/float_v2.aud: float_v2.aud
@@ -81,12 +81,12 @@ ra-steam: C&C The Ultimate Collection (Steam version, English)
 					^SupportDir|Content/ra/v2/expand/wastelnd.aud: wastelnd.aud
 				Delete: ^SupportDir|Content/ra/v2/expand/scores-aftermath.mix
 		# Counterstrike music (optional):
-		ContentPackage:
+		ContentPackage@music-counterstrike:
 			Name: music-counterstrike
 			Actions:
-				ExtractMix: MAIN3.MIX
+				ExtractMix@1: MAIN3.MIX
 					^SupportDir|Content/ra/v2/expand/scores-counterstrike.mix: scores.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/expand/scores-counterstrike.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/expand/scores-counterstrike.mix
 					^SupportDir|Content/ra/v2/expand/2nd_hand.aud: 2nd_hand.aud
 					^SupportDir|Content/ra/v2/expand/araziod.aud: araziod.aud
 					^SupportDir|Content/ra/v2/expand/backstab.aud: backstab.aud
@@ -97,12 +97,12 @@ ra-steam: C&C The Ultimate Collection (Steam version, English)
 					^SupportDir|Content/ra/v2/expand/vr2.aud: vr2.aud
 				Delete: ^SupportDir|Content/ra/v2/expand/scores-counterstrike.mix
 		# Allied campaign briefings (optional):
-		ContentPackage:
+		ContentPackage@movies-allied:
 			Name: movies-allied
 			Actions:
-				ExtractMix: MAIN1.MIX
+				ExtractMix@1: MAIN1.MIX
 					^SupportDir|Content/ra/v2/movies1.mix: movies1.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/movies1.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/movies1.mix
 					^SupportDir|Content/ra/v2/movies/aagun.vqa: aagun.vqa
 					^SupportDir|Content/ra/v2/movies/aftrmath.vqa: aftrmath.vqa
 					^SupportDir|Content/ra/v2/movies/ally12.vqa: ally12.vqa
@@ -156,12 +156,12 @@ ra-steam: C&C The Ultimate Collection (Steam version, English)
 					^SupportDir|Content/ra/v2/movies/ally11.vqa: ally11.vqa
 				Delete: ^SupportDir|Content/ra/v2/movies1.mix
 		# Soviet campaign briefings (optional):
-		ContentPackage:
+		ContentPackage@movies-soviet:
 			Name: movies-soviet
 			Actions:
-				ExtractMix: MAIN2.MIX
+				ExtractMix@1: MAIN2.MIX
 					^SupportDir|Content/ra/v2/movies2.mix: movies2.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/movies2.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/movies2.mix
 					^SupportDir|Content/ra/v2/movies/double.vqa: double.vqa
 					^SupportDir|Content/ra/v2/movies/dpthchrg.vqa: dpthchrg.vqa
 					^SupportDir|Content/ra/v2/movies/execute.vqa: execute.vqa
@@ -226,7 +226,7 @@ cnc-steam: Command & Conquer (Steam version, English)
 		CONQUER.MIX: 713b53fa4c188ca9619c6bbeadbfc86513704266
 	Install:
 		# C&C Desert Tileset:
-		ContentPackage:
+		ContentPackage@cncdesert:
 			Name: cncdesert
 			Actions:
 				Copy: .
@@ -240,15 +240,15 @@ cncr-steam: C&C Remastered Collection (Steam version, English)
 	# The Remastered Collection doesn't include the RA Soviet CD unfortunately, so we can't install Soviet campaign briefings.
 	Install:
 		# Base game files:
-		ContentPackage:
+		ContentPackage@base:
 			Name: base
 			Actions:
-				ExtractMix: Data/CNCDATA/RED_ALERT/CD1/REDALERT.MIX
+				ExtractMix@1: Data/CNCDATA/RED_ALERT/CD1/REDALERT.MIX
 					^SupportDir|Content/ra/v2/hires.mix: hires.mix
 					^SupportDir|Content/ra/v2/local.mix: local.mix
 					^SupportDir|Content/ra/v2/lores.mix: lores.mix
 					^SupportDir|Content/ra/v2/speech.mix: speech.mix
-				ExtractMix: Data/CNCDATA/RED_ALERT/CD1/MAIN.MIX
+				ExtractMix@2: Data/CNCDATA/RED_ALERT/CD1/MAIN.MIX
 					^SupportDir|Content/ra/v2/conquer.mix: conquer.mix
 					^SupportDir|Content/ra/v2/general.mix: general.mix # Is this one used? The FirstDecade and TUC installers are missing this!
 					^SupportDir|Content/ra/v2/interior.mix: interior.mix
@@ -258,18 +258,18 @@ cncr-steam: C&C Remastered Collection (Steam version, English)
 					^SupportDir|Content/ra/v2/allies.mix: allies.mix
 					^SupportDir|Content/ra/v2/temperat.mix: temperat.mix
 		# Base game music (optional):
-		ContentPackage:
+		ContentPackage@music:
 			Name: music
 			Actions:
 				ExtractMix: Data/CNCDATA/RED_ALERT/CD1/MAIN.MIX
 					^SupportDir|Content/ra/v2/scores.mix: scores.mix
 		# Allied campaign briefings (optional):
-		ContentPackage:
+		ContentPackage@movies-allied:
 			Name: movies-allied
 			Actions:
-				ExtractMix: Data/CNCDATA/RED_ALERT/CD1/MAIN.MIX
+				ExtractMix@1: Data/CNCDATA/RED_ALERT/CD1/MAIN.MIX
 					^SupportDir|Content/ra/v2/movies1.mix: movies1.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/movies1.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/movies1.mix
 					^SupportDir|Content/ra/v2/movies/aagun.vqa: aagun.vqa
 					^SupportDir|Content/ra/v2/movies/aftrmath.vqa: aftrmath.vqa
 					^SupportDir|Content/ra/v2/movies/ally1.vqa: ally1.vqa
@@ -323,12 +323,12 @@ cncr-steam: C&C Remastered Collection (Steam version, English)
 					^SupportDir|Content/ra/v2/movies/trinity.vqa: trinity.vqa
 				Delete: ^SupportDir|Content/ra/v2/movies1.mix
 		# Counterstrike music (optional):
-		ContentPackage:
+		ContentPackage@music-counterstrike:
 			Name: music-counterstrike
 			Actions:
-				ExtractMix: Data/CNCDATA/RED_ALERT/COUNTERSTRIKE/MAIN.MIX
+				ExtractMix@1: Data/CNCDATA/RED_ALERT/COUNTERSTRIKE/MAIN.MIX
 					^SupportDir|Content/ra/v2/expand/scores.mix: scores.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/expand/scores.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/expand/scores.mix
 					^SupportDir|Content/ra/v2/expand/2nd_hand.aud: 2nd_hand.aud
 					^SupportDir|Content/ra/v2/expand/araziod.aud: araziod.aud
 					^SupportDir|Content/ra/v2/expand/backstab.aud: backstab.aud
@@ -339,16 +339,16 @@ cncr-steam: C&C Remastered Collection (Steam version, English)
 					^SupportDir|Content/ra/v2/expand/vr2.aud: vr2.aud
 				Delete: ^SupportDir|Content/ra/v2/expand/scores.mix
 		# Aftermath expansion files:
-		ContentPackage:
+		ContentPackage@aftermathbase:
 			Name: aftermathbase
 			Actions:
 				Copy: Data/CNCDATA/RED_ALERT/AFTERMATH
 					^SupportDir|Content/ra/v2/expand/expand2.mix: expand2.mix
 					^SupportDir|Content/ra/v2/expand/hires1.mix: hires1.mix
 					^SupportDir|Content/ra/v2/expand/lores1.mix: lores1.mix
-				ExtractMix: Data/CNCDATA/RED_ALERT/AFTERMATH/MAIN.MIX
+				ExtractMix@1: Data/CNCDATA/RED_ALERT/AFTERMATH/MAIN.MIX
 					^SupportDir|Content/ra/v2/expand/sounds.mix: sounds.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/expand/sounds.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/expand/sounds.mix
 					^SupportDir|Content/ra/v2/expand/chrotnk1.aud: chrotnk1.aud
 					^SupportDir|Content/ra/v2/expand/fixit1.aud: fixit1.aud
 					^SupportDir|Content/ra/v2/expand/jburn1.aud: jburn1.aud
@@ -375,12 +375,12 @@ cncr-steam: C&C Remastered Collection (Steam version, English)
 					^SupportDir|Content/ra/v2/expand/myes1.aud: myes1.aud
 				Delete: ^SupportDir|Content/ra/v2/expand/sounds.mix
 		# Aftermath music (optional):
-		ContentPackage:
+		ContentPackage@music-aftermath:
 			Name: music-aftermath
 			Actions:
-				ExtractMix: Data/CNCDATA/RED_ALERT/AFTERMATH/MAIN.MIX
+				ExtractMix@1: Data/CNCDATA/RED_ALERT/AFTERMATH/MAIN.MIX
 					^SupportDir|Content/ra/v2/expand/scores.mix: scores.mix
-				ExtractMix: ^SupportDir|Content/ra/v2/expand/scores.mix
+				ExtractMix@2: ^SupportDir|Content/ra/v2/expand/scores.mix
 					^SupportDir|Content/ra/v2/expand/await.aud: await.aud
 					^SupportDir|Content/ra/v2/expand/bog.aud: bog.aud
 					^SupportDir|Content/ra/v2/expand/float_v2.aud: float_v2.aud
@@ -392,7 +392,7 @@ cncr-steam: C&C Remastered Collection (Steam version, English)
 					^SupportDir|Content/ra/v2/expand/wastelnd.aud: wastelnd.aud
 				Delete: ^SupportDir|Content/ra/v2/expand/scores.mix
 		# C&C Desert Tileset:
-		ContentPackage:
+		ContentPackage@cncdesert:
 			Name: cncdesert
 			Actions:
 				Copy: Data/CNCDATA/TIBERIAN_DAWN/CD1

--- a/mods/ts/installer/firestorm.yaml
+++ b/mods/ts/installer/firestorm.yaml
@@ -5,10 +5,10 @@ fstorm: Firestorm Expansion Disc (English)
 		Install/Language.dll: 4df87c1a2289da57dd14d0a7299546f37357fcca
 	Install:
 		# Firestorm expansion files:
-		ContentPackage:
+		ContentPackage@fstorm:
 			Name: fstorm
 			Actions:
-				ExtractMix: Install/expand01.mix
+				ExtractMix@1: Install/expand01.mix
 					^SupportDir|Content/ts/firestorm/m_emp.vxl: m_emp.vxl
 					^SupportDir|Content/ts/firestorm/mwar_nod.vxl: mwar_nod.vxl
 					^SupportDir|Content/ts/firestorm/djuggbar.vxl: djuggbar.vxl
@@ -32,7 +32,7 @@ fstorm: Firestorm Expansion Disc (English)
 					^SupportDir|Content/ts/firestorm/sounds01.mix: sounds01.mix
 					^SupportDir|Content/ts/firestorm/isotemp.mix: isotemp.mix
 					^SupportDir|Content/ts/firestorm/temperat.mix: temperat.mix
-				ExtractMix: ^SupportDir|Content/ts/firestorm/isotemp.mix
+				ExtractMix@2: ^SupportDir|Content/ts/firestorm/isotemp.mix
 					^SupportDir|Content/ts/firestorm/blat01.tem: blat01.tem
 					^SupportDir|Content/ts/firestorm/blat01a.tem: blat01a.tem
 					^SupportDir|Content/ts/firestorm/blat02.tem: blat02.tem
@@ -174,8 +174,8 @@ fstorm: Firestorm Expansion Disc (English)
 					^SupportDir|Content/ts/firestorm/swamp07.tem: swamp07.tem
 					^SupportDir|Content/ts/firestorm/swamp08.tem: swamp08.tem
 					^SupportDir|Content/ts/firestorm/swamp09.tem: swamp09.tem
-				Delete: ^SupportDir|Content/ts/firestorm/isotemp.mix
-				ExtractMix: ^SupportDir|Content/ts/firestorm/temperat.mix
+				Delete@3: ^SupportDir|Content/ts/firestorm/isotemp.mix
+				ExtractMix@4: ^SupportDir|Content/ts/firestorm/temperat.mix
 					^SupportDir|Content/ts/firestorm/fona01.tem: fona01.tem
 					^SupportDir|Content/ts/firestorm/fona02.tem: fona02.tem
 					^SupportDir|Content/ts/firestorm/fona03.tem: fona03.tem
@@ -192,9 +192,9 @@ fstorm: Firestorm Expansion Disc (English)
 					^SupportDir|Content/ts/firestorm/fona14.tem: fona14.tem
 					^SupportDir|Content/ts/firestorm/fona15.tem: fona15.tem
 					^SupportDir|Content/ts/firestorm/bigblue3.tem: bigblue3.tem
-				Delete: ^SupportDir|Content/ts/firestorm/temperat.mix
+				Delete@5: ^SupportDir|Content/ts/firestorm/temperat.mix
 		# Firestorm expansion music (optional):
-		ContentPackage:
+		ContentPackage@fstorm-music:
 			Name: fstorm-music
 			Actions:
 				Copy: .

--- a/mods/ts/installer/firstdecade.yaml
+++ b/mods/ts/installer/firstdecade.yaml
@@ -14,7 +14,7 @@ tfd: C&C The First Decade (English)
 					^SupportDir|Content/ts/tibsun.mix: Tiberian Sun\SUN\TIBSUN.MIX
 					^SupportDir|Content/ts/expand01.mix: Tiberian Sun\SUN\expand01.mix
 		# Base game files:
-		ContentPackage:
+		ContentPackage@tibsun:
 			Name: tibsun
 			Actions:
 				ExtractMix: ^SupportDir|Content/ts/tibsun.mix
@@ -34,10 +34,10 @@ tfd: C&C The First Decade (English)
 					^SupportDir|Content/ts/temperat.mix: temperat.mix
 				Delete: ^SupportDir|Content/ts/tibsun.mix
 		# Firestorm expansion files:
-		ContentPackage:
+		ContentPackage@fstorm:
 			Name: fstorm
 			Actions:
-				ExtractMix: ^SupportDir|Content/ts/expand01.mix
+				ExtractMix@1: ^SupportDir|Content/ts/expand01.mix
 					^SupportDir|Content/ts/firestorm/m_emp.vxl: m_emp.vxl
 					^SupportDir|Content/ts/firestorm/mwar_nod.vxl: mwar_nod.vxl
 					^SupportDir|Content/ts/firestorm/djuggbar.vxl: djuggbar.vxl
@@ -61,8 +61,8 @@ tfd: C&C The First Decade (English)
 					^SupportDir|Content/ts/firestorm/sounds01.mix: sounds01.mix
 					^SupportDir|Content/ts/firestorm/isotemp.mix: isotemp.mix
 					^SupportDir|Content/ts/firestorm/temperat.mix: temperat.mix
-				Delete: ^SupportDir|Content/ts/expand01.mix
-				ExtractMix: ^SupportDir|Content/ts/firestorm/isotemp.mix
+				Delete@2: ^SupportDir|Content/ts/expand01.mix
+				ExtractMix@3: ^SupportDir|Content/ts/firestorm/isotemp.mix
 					^SupportDir|Content/ts/firestorm/blat01.tem: blat01.tem
 					^SupportDir|Content/ts/firestorm/blat01a.tem: blat01a.tem
 					^SupportDir|Content/ts/firestorm/blat02.tem: blat02.tem
@@ -204,8 +204,8 @@ tfd: C&C The First Decade (English)
 					^SupportDir|Content/ts/firestorm/swamp07.tem: swamp07.tem
 					^SupportDir|Content/ts/firestorm/swamp08.tem: swamp08.tem
 					^SupportDir|Content/ts/firestorm/swamp09.tem: swamp09.tem
-				Delete: ^SupportDir|Content/ts/firestorm/isotemp.mix
-				ExtractMix: ^SupportDir|Content/ts/firestorm/temperat.mix
+				Delete@4: ^SupportDir|Content/ts/firestorm/isotemp.mix
+				ExtractMix@5: ^SupportDir|Content/ts/firestorm/temperat.mix
 					^SupportDir|Content/ts/firestorm/fona01.tem: fona01.tem
 					^SupportDir|Content/ts/firestorm/fona02.tem: fona02.tem
 					^SupportDir|Content/ts/firestorm/fona03.tem: fona03.tem
@@ -222,24 +222,24 @@ tfd: C&C The First Decade (English)
 					^SupportDir|Content/ts/firestorm/fona14.tem: fona14.tem
 					^SupportDir|Content/ts/firestorm/fona15.tem: fona15.tem
 					^SupportDir|Content/ts/firestorm/bigblue3.tem: bigblue3.tem
-				Delete: ^SupportDir|Content/ts/firestorm/temperat.mix
+				Delete@6: ^SupportDir|Content/ts/firestorm/temperat.mix
 		# Base game music (optional):
-		ContentPackage:
+		ContentPackage@tibsun-music:
 			Name: tibsun-music
 			Actions:
-			ExtractIscab: data1.hdr
-				Volumes:
-					6: data6.cab
-					7: data7.cab
-				Extract:
-					^SupportDir|Content/ts/scores.mix: Tiberian Sun\SUN\SCORES.MIX
+				ExtractIscab: data1.hdr
+					Volumes:
+						6: data6.cab
+						7: data7.cab
+					Extract:
+						^SupportDir|Content/ts/scores.mix: Tiberian Sun\SUN\SCORES.MIX
 		# Firestorm expansion music (optional):
-		ContentPackage:
+		ContentPackage@fstorm-music:
 			Name: fstorm-music
 			Actions:
-			ExtractIscab: data1.hdr
-				Volumes:
-					6: data6.cab
-					7: data7.cab
-				Extract:
-					^SupportDir|Content/ts/firestorm/scores01.mix: Tiberian Sun\SUN\scores01.mix
+				ExtractIscab: data1.hdr
+					Volumes:
+						6: data6.cab
+						7: data7.cab
+					Extract:
+						^SupportDir|Content/ts/firestorm/scores01.mix: Tiberian Sun\SUN\scores01.mix

--- a/mods/ts/installer/origin.yaml
+++ b/mods/ts/installer/origin.yaml
@@ -7,7 +7,7 @@ origin: C&C The Ultimate Collection (Origin version, English)
 		GDFBinary_en_US.dll: 4bb56a449bd0003e7ae67625d90a11ae169319d6
 	Install:
 		# Base game files:
-		ContentPackage:
+		ContentPackage@tibsun:
 			Name: tibsun
 			Actions:
 				ExtractMix: TIBSUN.MIX
@@ -26,10 +26,10 @@ origin: C&C The Ultimate Collection (Origin version, English)
 					^SupportDir|Content/ts/tem.mix: tem.mix
 					^SupportDir|Content/ts/temperat.mix: temperat.mix
 		# Firestorm expansion files:
-		ContentPackage:
+		ContentPackage@fstorm:
 			Name: fstorm
 			Actions:
-				ExtractMix: expand01.mix
+				ExtractMix@1: expand01.mix
 					^SupportDir|Content/ts/firestorm/m_emp.vxl: m_emp.vxl
 					^SupportDir|Content/ts/firestorm/mwar_nod.vxl: mwar_nod.vxl
 					^SupportDir|Content/ts/firestorm/djuggbar.vxl: djuggbar.vxl
@@ -53,7 +53,7 @@ origin: C&C The Ultimate Collection (Origin version, English)
 					^SupportDir|Content/ts/firestorm/sounds01.mix: sounds01.mix
 					^SupportDir|Content/ts/firestorm/isotemp.mix: isotemp.mix
 					^SupportDir|Content/ts/firestorm/temperat.mix: temperat.mix
-				ExtractMix: ^SupportDir|Content/ts/firestorm/isotemp.mix
+				ExtractMix@2: ^SupportDir|Content/ts/firestorm/isotemp.mix
 					^SupportDir|Content/ts/firestorm/blat01.tem: blat01.tem
 					^SupportDir|Content/ts/firestorm/blat01a.tem: blat01a.tem
 					^SupportDir|Content/ts/firestorm/blat02.tem: blat02.tem
@@ -195,8 +195,8 @@ origin: C&C The Ultimate Collection (Origin version, English)
 					^SupportDir|Content/ts/firestorm/swamp07.tem: swamp07.tem
 					^SupportDir|Content/ts/firestorm/swamp08.tem: swamp08.tem
 					^SupportDir|Content/ts/firestorm/swamp09.tem: swamp09.tem
-				Delete: ^SupportDir|Content/ts/firestorm/isotemp.mix
-				ExtractMix: ^SupportDir|Content/ts/firestorm/temperat.mix
+				Delete@3: ^SupportDir|Content/ts/firestorm/isotemp.mix
+				ExtractMix@4: ^SupportDir|Content/ts/firestorm/temperat.mix
 					^SupportDir|Content/ts/firestorm/fona01.tem: fona01.tem
 					^SupportDir|Content/ts/firestorm/fona02.tem: fona02.tem
 					^SupportDir|Content/ts/firestorm/fona03.tem: fona03.tem
@@ -213,15 +213,15 @@ origin: C&C The Ultimate Collection (Origin version, English)
 					^SupportDir|Content/ts/firestorm/fona14.tem: fona14.tem
 					^SupportDir|Content/ts/firestorm/fona15.tem: fona15.tem
 					^SupportDir|Content/ts/firestorm/bigblue3.tem: bigblue3.tem
-				Delete: ^SupportDir|Content/ts/firestorm/temperat.mix
+				Delete@5: ^SupportDir|Content/ts/firestorm/temperat.mix
 		# Base game music (optional):
-		ContentPackage:
+		ContentPackage@tibsun-music:
 			Name: tibsun-music
 			Actions:
 				Copy: .
 					^SupportDir|Content/ts/scores.mix: SCORES.MIX
 		# Firestorm expansion music (optional):
-		ContentPackage:
+		ContentPackage@fstorm-music:
 			Name: fstorm-music
 			Actions:
 				Copy: .

--- a/mods/ts/installer/steam.yaml
+++ b/mods/ts/installer/steam.yaml
@@ -5,7 +5,7 @@ steam: C&C The Ultimate Collection (Steam version, English)
 		TIBSUN.MIX: fd298ff16983f226c58136a5345b7d9bf2b5f2e9
 	Install:
 		# Base game files:
-		ContentPackage:
+		ContentPackage@tibsun:
 			Name: tibsun
 			Actions:
 				ExtractMix: TIBSUN.MIX
@@ -24,10 +24,10 @@ steam: C&C The Ultimate Collection (Steam version, English)
 					^SupportDir|Content/ts/tem.mix: tem.mix
 					^SupportDir|Content/ts/temperat.mix: temperat.mix
 		# Firestorm expansion files:
-		ContentPackage:
+		ContentPackage@fstorm:
 			Name: fstorm
 			Actions:
-				ExtractMix: expand01.mix
+				ExtractMix@1: expand01.mix
 					^SupportDir|Content/ts/firestorm/m_emp.vxl: m_emp.vxl
 					^SupportDir|Content/ts/firestorm/mwar_nod.vxl: mwar_nod.vxl
 					^SupportDir|Content/ts/firestorm/djuggbar.vxl: djuggbar.vxl
@@ -51,7 +51,7 @@ steam: C&C The Ultimate Collection (Steam version, English)
 					^SupportDir|Content/ts/firestorm/sounds01.mix: sounds01.mix
 					^SupportDir|Content/ts/firestorm/isotemp.mix: isotemp.mix
 					^SupportDir|Content/ts/firestorm/temperat.mix: temperat.mix
-				ExtractMix: ^SupportDir|Content/ts/firestorm/isotemp.mix
+				ExtractMix@2: ^SupportDir|Content/ts/firestorm/isotemp.mix
 					^SupportDir|Content/ts/firestorm/blat01.tem: blat01.tem
 					^SupportDir|Content/ts/firestorm/blat01a.tem: blat01a.tem
 					^SupportDir|Content/ts/firestorm/blat02.tem: blat02.tem
@@ -193,8 +193,8 @@ steam: C&C The Ultimate Collection (Steam version, English)
 					^SupportDir|Content/ts/firestorm/swamp07.tem: swamp07.tem
 					^SupportDir|Content/ts/firestorm/swamp08.tem: swamp08.tem
 					^SupportDir|Content/ts/firestorm/swamp09.tem: swamp09.tem
-				Delete: ^SupportDir|Content/ts/firestorm/isotemp.mix
-				ExtractMix: ^SupportDir|Content/ts/firestorm/temperat.mix
+				Delete@3: ^SupportDir|Content/ts/firestorm/isotemp.mix
+				ExtractMix@4: ^SupportDir|Content/ts/firestorm/temperat.mix
 					^SupportDir|Content/ts/firestorm/fona01.tem: fona01.tem
 					^SupportDir|Content/ts/firestorm/fona02.tem: fona02.tem
 					^SupportDir|Content/ts/firestorm/fona03.tem: fona03.tem
@@ -211,15 +211,15 @@ steam: C&C The Ultimate Collection (Steam version, English)
 					^SupportDir|Content/ts/firestorm/fona14.tem: fona14.tem
 					^SupportDir|Content/ts/firestorm/fona15.tem: fona15.tem
 					^SupportDir|Content/ts/firestorm/bigblue3.tem: bigblue3.tem
-				Delete: ^SupportDir|Content/ts/firestorm/temperat.mix
+				Delete@5: ^SupportDir|Content/ts/firestorm/temperat.mix
 		# Base game music (optional):
-		ContentPackage:
+		ContentPackage@tibsun-music:
 			Name: tibsun-music
 			Actions:
 				Copy: .
 					^SupportDir|Content/ts/scores.mix: SCORES.MIX
 		# Firestorm expansion music (optional):
-		ContentPackage:
+		ContentPackage@fstorm-music:
 			Name: fstorm-music
 			Actions:
 				Copy: .

--- a/mods/ts/installer/tibsun.yaml
+++ b/mods/ts/installer/tibsun.yaml
@@ -5,7 +5,7 @@ tibsun: Tiberian Sun (GDI or Nod Disc, English)
 		AUTOPLAY.WAV: 2dfce5d00f98b641849c29942b651f4e98d30e30
 	Install:
 		# Base game files:
-		ContentPackage:
+		ContentPackage@tibsun:
 			Name: tibsun
 			Actions:
 				ExtractMix: INSTALL/TIBSUN.MIX
@@ -24,7 +24,7 @@ tibsun: Tiberian Sun (GDI or Nod Disc, English)
 					^SupportDir|Content/ts/tem.mix: tem.mix
 					^SupportDir|Content/ts/temperat.mix: temperat.mix
 		# Base game music (optional):
-		ContentPackage:
+		ContentPackage@tibsun-music:
 			Name: tibsun-music
 			Actions:
 				Copy: .


### PR DESCRIPTION
In #21462 MiniYaml merging was adjusted. One effect of this change was that duplicate keys in files that did not previously require merging was previously allowed, but was now an error. (Test case `TestMergeConflictsNoMerge`)

The installer files were relying on the previous behaviour to allow multiple `ContentPackage` keys. The above change caused a regression where attempting to manage mod content would crash due to now erroring on the duplicate keys.

We fix the issue by applying a unique ID suffix, as is a common pattern elsewhere in our yaml files, and teach InstallFromSourceLogic to recognise and strip it.

Fixes #21505