### PR TITLE
Pass order name to OrderEffects

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/OrderEffects.cs
+++ b/OpenRA.Mods.Common/Traits/World/OrderEffects.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 		}
 
-		bool INotifyOrderIssued.OrderIssued(World world, Target target)
+		bool INotifyOrderIssued.OrderIssued(World world, string orderString, Target target)
 		{
 			switch (target.Type)
 			{

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 	[RequireExplicitImplementation]
 	public interface INotifyOrderIssued
 	{
-		bool OrderIssued(World world, Target target);
+		bool OrderIssued(World world, string orderString, Target target);
 	}
 
 	[RequireExplicitImplementation]

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -197,7 +197,7 @@ namespace OpenRA.Mods.Common.Widgets
 					var visualTarget = o.VisualFeedbackTarget.Type != TargetType.Invalid ? o.VisualFeedbackTarget : o.Target;
 
 					foreach (var notifyOrderIssued in world.WorldActor.TraitsImplementing<INotifyOrderIssued>())
-						flashed = notifyOrderIssued.OrderIssued(world, visualTarget);
+						flashed = notifyOrderIssued.OrderIssued(world, o.OrderString, visualTarget);
 				}
 
 				world.IssueOrder(o);


### PR DESCRIPTION
Pass the order name to OrderEffects (until now, only the target was passed) to allow mods to scope their custom order effects to specific orders.

Required by OpenE2140 for the attack flash animation.