### PR TITLE
Flush logs when crashing.

### DIFF
--- a/OpenRA.Server/Program.cs
+++ b/OpenRA.Server/Program.cs
@@ -27,6 +27,13 @@ namespace OpenRA.Server
 			{
 				Run(args);
 			}
+			catch
+			{
+				// Flush logs before rethrowing, i.e. allowing the exception to go unhandled.
+				// try-finally won't work - an unhandled exception kills our process without running the finally block!
+				Log.Dispose();
+				throw;
+			}
 			finally
 			{
 				Log.Dispose();

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -44,6 +44,13 @@ namespace OpenRA
 			{
 				Run(args);
 			}
+			catch
+			{
+				// Flush logs before rethrowing, i.e. allowing the exception to go unhandled.
+				// try-finally won't work - an unhandled exception kills our process without running the finally block!
+				Log.Dispose();
+				throw;
+			}
 			finally
 			{
 				Log.Dispose();
@@ -133,6 +140,7 @@ namespace OpenRA
 				if (e is NoSuchCommandException)
 				{
 					Console.WriteLine(e.Message);
+					Log.Dispose(); // Flush logs before we terminate the process.
 					Environment.Exit(1);
 				}
 				else

--- a/OpenRA.WindowsLauncher/Program.cs
+++ b/OpenRA.WindowsLauncher/Program.cs
@@ -80,6 +80,7 @@ namespace OpenRA.WindowsLauncher
 			}
 			finally
 			{
+				// Flushing logs in finally block is okay here, as the catch block handles the exception.
 				Log.Dispose();
 			}
 		}


### PR DESCRIPTION
When the process is running, we use a finally block to call Log.Dispose and flush any outstanding logs to disk before the process exits. This works when we handle any exception in a matching catch block.

When the exception is unhandled, then the finally block will not run and instead the process will just exit. To fix this, flush the logs inside a catch block instead before rethrowing the error. This ensures we get logs even when crashing.

Fixes #20733