### PR TITLE
Fix TFD asset installation.

### DIFF
--- a/mods/cnc/installer/firstdecade.yaml
+++ b/mods/cnc/installer/firstdecade.yaml
@@ -5,22 +5,23 @@ tfd: C&C The First Decade (English)
 		data1.cab: 12ad6113a6890a1b4d5651a75378c963eaf513b9
 	Install:
 		BeforeInstall:
-			# This one step sets up the 1 required package and the two optional video packages.
-			ExtractIscab: data1.hdr
-				Volumes:
-					2: data2.cab
-					3: data3.cab
-				Extract:
-					^SupportDir|Content/cnc/conquer.mix: CnC\\CONQUER.MIX
-					^SupportDir|Content/cnc/desert.mix: CnC\\DESERT.MIX
-					^SupportDir|Content/cnc/general.mix: CnC\\GENERAL.MIX
-					^SupportDir|Content/cnc/sounds.mix: CnC\\SOUNDS.MIX
-					^SupportDir|Content/cnc/temperat.mix: CnC\\TEMPERAT.MIX
-					^SupportDir|Content/cnc/winter.mix: CnC\\WINTER.MIX
-					^SupportDir|Content/cnc/speech.mix: CnC\\SPEECH.MIX
-					^SupportDir|Content/cnc/tempicnh.mix: CnC\\TEMPICNH.MIX
-					^SupportDir|Content/cnc/transit.mix: CnC\\TRANSIT.MIX
-					^SupportDir|Content/cnc/movies.mix: CnC\\MOVIES.MIX
+			Actions:
+				# This one step sets up the 1 required package and the two optional video packages.
+				ExtractIscab: data1.hdr
+					Volumes:
+						2: data2.cab
+						3: data3.cab
+					Extract:
+						^SupportDir|Content/cnc/conquer.mix: CnC\\CONQUER.MIX
+						^SupportDir|Content/cnc/desert.mix: CnC\\DESERT.MIX
+						^SupportDir|Content/cnc/general.mix: CnC\\GENERAL.MIX
+						^SupportDir|Content/cnc/sounds.mix: CnC\\SOUNDS.MIX
+						^SupportDir|Content/cnc/temperat.mix: CnC\\TEMPERAT.MIX
+						^SupportDir|Content/cnc/winter.mix: CnC\\WINTER.MIX
+						^SupportDir|Content/cnc/speech.mix: CnC\\SPEECH.MIX
+						^SupportDir|Content/cnc/tempicnh.mix: CnC\\TEMPICNH.MIX
+						^SupportDir|Content/cnc/transit.mix: CnC\\TRANSIT.MIX
+						^SupportDir|Content/cnc/movies.mix: CnC\\MOVIES.MIX
 		# GDI campaign briefings (optional):
 		ContentPackage@movies-gdi:
 			Name: movies-gdi
@@ -178,4 +179,5 @@ tfd: C&C The First Decade (English)
 					Extract:
 						^SupportDir|Content/cnc/scores-covertops.mix: CnC\covert\SCORES.MIX
 		AfterInstall:
-			Delete: ^SupportDir|Content/cnc/movies.mix
+			Actions:
+				Delete: ^SupportDir|Content/cnc/movies.mix

--- a/mods/ra/installer/firstdecade.yaml
+++ b/mods/ra/installer/firstdecade.yaml
@@ -7,20 +7,21 @@ tfd: C&C The First Decade (English)
 	# Unless a patch is installed, but we probably don't want to deal with whether or not it is.
 	Install:
 		BeforeInstall:
-			# This one step handles 3 packages - base (partially), aftermathbase (partially) and cncdesert.
-			ExtractIscab: data1.hdr
-				Volumes:
-					2: data2.cab
-					3: data3.cab
-					4: data4.cab
-					5: data5.cab
-				Extract:
-					^SupportDir|Content/ra/v2/main.mix: Red Alert\\MAIN.MIX
-					^SupportDir|Content/ra/v2/redalert.mix: Red Alert\\REDALERT.MIX
-					^SupportDir|Content/ra/v2/expand/hires1.mix: Red Alert\\HIRES1.MIX
-					^SupportDir|Content/ra/v2/expand/lores1.mix: Red Alert\\LORES1.MIX
-					^SupportDir|Content/ra/v2/expand/expand2.mix: Red Alert\\EXPAND2.MIX
-					^SupportDir|Content/ra/v2/cnc/desert.mix: CnC\\DESERT.MIX
+			Actions:
+				# This one step handles 3 packages - base (partially), aftermathbase (partially) and cncdesert.
+				ExtractIscab: data1.hdr
+					Volumes:
+						2: data2.cab
+						3: data3.cab
+						4: data4.cab
+						5: data5.cab
+					Extract:
+						^SupportDir|Content/ra/v2/main.mix: Red Alert\\MAIN.MIX
+						^SupportDir|Content/ra/v2/redalert.mix: Red Alert\\REDALERT.MIX
+						^SupportDir|Content/ra/v2/expand/hires1.mix: Red Alert\\HIRES1.MIX
+						^SupportDir|Content/ra/v2/expand/lores1.mix: Red Alert\\LORES1.MIX
+						^SupportDir|Content/ra/v2/expand/expand2.mix: Red Alert\\EXPAND2.MIX
+						^SupportDir|Content/ra/v2/cnc/desert.mix: CnC\\DESERT.MIX
 		# Base game files:
 		ContentPackage@base:
 			Name: base
@@ -197,4 +198,5 @@ tfd: C&C The First Decade (English)
 					^SupportDir|Content/ra/v2/expand/myeehaw1.aud: myeehaw1.aud
 					^SupportDir|Content/ra/v2/expand/myes1.aud: myes1.aud
 		AfterInstall:
-			Delete: ^SupportDir|Content/ra/v2/main.mix
+			Actions:
+				Delete: ^SupportDir|Content/ra/v2/main.mix

--- a/mods/ts/installer/firstdecade.yaml
+++ b/mods/ts/installer/firstdecade.yaml
@@ -5,14 +5,15 @@ tfd: C&C The First Decade (English)
 		data1.cab: 12ad6113a6890a1b4d5651a75378c963eaf513b9
 	Install:
 		BeforeInstall:
-			# This one step sets up both required packages - tibsun and fstorm.
-			ExtractIscab: data1.hdr
-				Volumes:
-					6: data6.cab
-					7: data7.cab
-				Extract:
-					^SupportDir|Content/ts/tibsun.mix: Tiberian Sun\SUN\TIBSUN.MIX
-					^SupportDir|Content/ts/expand01.mix: Tiberian Sun\SUN\expand01.mix
+			Actions:
+				# This one step sets up both required packages - tibsun and fstorm.
+				ExtractIscab: data1.hdr
+					Volumes:
+						6: data6.cab
+						7: data7.cab
+					Extract:
+						^SupportDir|Content/ts/tibsun.mix: Tiberian Sun\SUN\TIBSUN.MIX
+						^SupportDir|Content/ts/expand01.mix: Tiberian Sun\SUN\expand01.mix
 		# Base game files:
 		ContentPackage@tibsun:
 			Name: tibsun


### PR DESCRIPTION
Fixes #21289. #20688 missed the intermediate `Actions` node when defining `BeforeInstall` and `AfterInstall` for TFD.