### PR TITLE
Ensure starting units or units granted by a crate are not isolated.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
@@ -58,10 +58,12 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.ValidFactions.Count > 0 && !info.ValidFactions.Contains(collector.Owner.Faction.InternalName))
 				return false;
 
+			var pathFinder = collector.World.WorldActor.TraitOrDefault<IPathFinder>();
+			var locomotorsByName = collector.World.WorldActor.TraitsImplementing<Locomotor>().ToDictionary(l => l.Info.Name);
 			foreach (var unit in info.Units)
 			{
 				// avoid dumping tanks in the sea, and ships on dry land.
-				if (!GetSuitableCells(collector.Location, unit).Any())
+				if (!GetSuitableCells(collector.Location, unit, pathFinder, locomotorsByName).Any())
 					return false;
 			}
 
@@ -80,9 +82,11 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			collector.World.AddFrameEndTask(w =>
 			{
+				var pathFinder = w.WorldActor.TraitOrDefault<IPathFinder>();
+				var locomotorsByName = w.WorldActor.TraitsImplementing<Locomotor>().ToDictionary(l => l.Info.Name);
 				foreach (var unit in info.Units)
 				{
-					var location = ChooseEmptyCellNear(collector, unit);
+					var location = ChooseEmptyCellNear(collector, unit, pathFinder, locomotorsByName);
 					if (location != null)
 					{
 						var actor = w.CreateActor(unit, new TypeDictionary
@@ -101,19 +105,33 @@ namespace OpenRA.Mods.Common.Traits
 			base.Activate(collector);
 		}
 
-		IEnumerable<CPos> GetSuitableCells(CPos near, string unitName)
+		IEnumerable<CPos> GetSuitableCells(CPos near, string unitName, IPathFinder pathFinder, Dictionary<string, Locomotor> locomotorsByName)
 		{
-			var ip = self.World.Map.Rules.Actors[unitName].TraitInfo<IPositionableInfo>();
+			var actorRules = self.World.Map.Rules.Actors[unitName];
 
-			for (var i = -1; i < 2; i++)
-				for (var j = -1; j < 2; j++)
-					if (ip.CanEnterCell(self.World, self, near + new CVec(i, j)))
+			Locomotor locomotor = null;
+			if (pathFinder != null)
+			{
+				var locomotorName = actorRules.TraitInfoOrDefault<MobileInfo>()?.Locomotor;
+				locomotor = locomotorName != null ? locomotorsByName[locomotorName] : null;
+			}
+
+			var ip = actorRules.TraitInfo<IPositionableInfo>();
+			for (var i = -1; i <= 1; i++)
+			{
+				for (var j = -1; j <= 1; j++)
+				{
+					var cell = near + new CVec(i, j);
+					if (ip.CanEnterCell(self.World, self, cell) &&
+						(locomotor == null || pathFinder.PathMightExistForLocomotorBlockedByImmovable(locomotor, cell, near)))
 						yield return near + new CVec(i, j);
+				}
+			}
 		}
 
-		CPos? ChooseEmptyCellNear(Actor a, string unit)
+		CPos? ChooseEmptyCellNear(Actor a, string unit, IPathFinder pathFinder, Dictionary<string, Locomotor> locomotorsByName)
 		{
-			return GetSuitableCells(a.Location, unit)
+			return GetSuitableCells(a.Location, unit, pathFinder, locomotorsByName)
 				.Cast<CPos?>()
 				.RandomOrDefault(self.World.SharedRandom);
 		}


### PR DESCRIPTION
When spawning starting units, or spawning units when collecting a crate, nearby locations will be used. If a nearby location cannot be reached, e.g. it is on top of a cliff or blocked in by trees, then any unit spawned there will be isolated which is not ideal.

Use the PathMightExistForLocomotorBlockedByImmovable method to filter nearby locations to those where the spawned unit can path back to the original location. This ensures the spawned unit is not isolated.

Fixes #12057 Fixes #6515

----

The following test map can be used to check that units do not spawn in the area blocked off by the cacti, both at start and when collecting crates.

[spawntest.oramap.zip](https://github.com/user-attachments/files/16482674/spawntest.oramap.zip)

![image](https://github.com/user-attachments/assets/7c5c2d75-2fde-44ac-8e43-a0f446b03979)