### PR TITLE
Fix editor crash from added mission fencing

### DIFF
--- a/mods/ra/maps/allies-05b/map.yaml
+++ b/mods/ra/maps/allies-05b/map.yaml
@@ -1242,31 +1242,31 @@ Actors:
 	Actor375: fenc
 		Location: 88,58
 		Owner: USSR
-	Actor375: fenc
+	Actor376: fenc
 		Location: 93,58
 		Owner: USSR
-	Actor376: fenc
+	Actor377: fenc
 		Location: 98,58
 		Owner: USSR
-	Actor377: fenc
+	Actor378: fenc
 		Location: 102,58
 		Owner: USSR
-	Actor378: fenc
+	Actor379: fenc
 		Location: 103,58
 		Owner: USSR
-	Actor379: fenc
+	Actor380: fenc
 		Location: 87,59
 		Owner: USSR
-	Actor380: fenc
+	Actor381: fenc
 		Location: 92,59
 		Owner: USSR
-	Actor381: fenc
+	Actor382: fenc
 		Location: 93,59
 		Owner: USSR
-	Actor382: fenc
+	Actor383: fenc
 		Location: 98,59
 		Owner: USSR
-	Actor383: fenc
+	Actor384: fenc
 		Location: 99,59
 		Owner: USSR
 

--- a/mods/ra/maps/fall-of-greece-1-personal-war/map.yaml
+++ b/mods/ra/maps/fall-of-greece-1-personal-war/map.yaml
@@ -533,7 +533,7 @@ Actors:
 	Actor156: t16
 		Location: 61,84
 		Owner: Neutral
-	Actor391: flare
+	NorthBridgeFlare: flare
 		Location: 81,41
 		Owner: England
 	Actor157: apwr

--- a/mods/ra/maps/soviet-09/map.yaml
+++ b/mods/ra/maps/soviet-09/map.yaml
@@ -1476,7 +1476,7 @@ Actors:
 	TruckEscape1: waypoint
 		Owner: Neutral
 		Location: 72,36
-	TruckEcsape2: waypoint
+	TruckEscape2: waypoint
 		Owner: Neutral
 		Location: 33,35
 	TruckEscape3: waypoint
@@ -1578,22 +1578,22 @@ Actors:
 	Actor471: fenc
 		Location: 93,38
 		Owner: Greece
-	Actor471: fenc
+	Actor472: fenc
 		Location: 94,38
 		Owner: Greece
-	Actor472: fenc
+	Actor473: fenc
 		Location: 95,38
 		Owner: Greece
-	Actor473: fenc
+	Actor474: fenc
 		Location: 102,38
 		Owner: Greece
-	Actor474: fenc
+	Actor475: fenc
 		Location: 103,38
 		Owner: Greece
-	Actor475: fenc
+	Actor476: fenc
 		Location: 104,38
 		Owner: Greece
-	Actor476: fenc
+	Actor477: fenc
 		Location: 105,38
 		Owner: Greece
 


### PR DESCRIPTION
https://github.com/OpenRA/OpenRA/pull/21482 has some errors despite my testing. All the missions play without issue, but three have duplicate actor keys that crash them in the editor.