### PR TITLE
Fix click through for disabled command bar buttons

### DIFF
--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -32,6 +32,7 @@ Container@PLAYER_WIDGETS:
 			Height: 43
 			ImageCollection: commandbar
 			ImageName: background
+			ClickThrough: False
 		Container@COMMAND_BAR:
 			Logic: CommandBarLogic
 			X: 24

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -47,6 +47,7 @@ Container@PLAYER_WIDGETS:
 			Height: 44
 			ImageCollection: commandbar
 			ImageName: background
+			ClickThrough: False
 		Container@COMMAND_BAR:
 			Logic: CommandBarLogic
 			X: 14


### PR DESCRIPTION
It is already set in `cnc` and `ts`. It inhibits clicking on actors through disabled command bar buttons.