### PR TITLE
Lock starting units in Fort Lonestar & Oil Spill

### DIFF
--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -33,6 +33,7 @@ World:
 		BuildRadiusCheckboxVisible: False
 	SpawnStartingUnits:
 		DropdownVisible: False
+		DropdownLocked: True
 	MapOptions:
 		TechLevelDropdownLocked: True
 		TechLevel: unrestricted

--- a/mods/ra/maps/oil-spill/rules.yaml
+++ b/mods/ra/maps/oil-spill/rules.yaml
@@ -3,6 +3,7 @@ World:
 		Scripts: oil-spill.lua
 	SpawnStartingUnits:
 		DropdownVisible: False
+		DropdownLocked: True
 	StartingUnits@mcvonly:
 		BaseActor: fcom
 


### PR DESCRIPTION
![ra-2024-08-11T101109876Z_indexed](https://github.com/user-attachments/assets/af145be4-7ccb-4358-b6b1-e0c81d4cdfc4)
The Fort Lonestar and Oil Spill missions assume the default "MCV Only" option and make the dropdown invisible to ensure it. That is no longer a guarantee because settings from another map can be saved, so this PR locks in the default.