### PR TITLE
Fix tooltips in the Encyclopedia.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/EncyclopediaLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/EncyclopediaLogic.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					() => SelectActor(actor));
 
 				var label = item.Get<LabelWithTooltipWidget>("TITLE");
-				var name = actor.TraitInfoOrDefault<TooltipInfo>()?.Name;
+				var name = actor.TraitInfos<TooltipInfo>().FirstOrDefault(info => info.EnabledByDefault)?.Name;
 				if (!string.IsNullOrEmpty(name))
 					WidgetUtils.TruncateLabelToTooltip(label, TranslationProvider.GetString(name));
 


### PR DESCRIPTION
If multiple tooltips are defined with conditionals attached, the Encyclopedia could not handle this. Now, it selects the tooltip EnabledByDefault to match usage across the rest of the code.

Fixes #21530