### PR TITLE
Fix moves being reported as blocked when already at the destination.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -116,7 +116,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected int searchCellsTick = -1;
 
-		protected virtual List<CPos> CalculatePathToTarget(Actor self, BlockedByActor check)
+		protected virtual (bool AlreadyAtDestination, List<CPos> Path) CalculatePathToTarget(Actor self, BlockedByActor check)
 		{
 			// PERF: Assume that candidate cells don't change within a tick to avoid repeated queries
 			// when Move enumerates different BlockedByActor values.
@@ -125,14 +125,21 @@ namespace OpenRA.Mods.Common.Activities
 				SearchCells.Clear();
 				searchCellsTick = self.World.WorldTick;
 				foreach (var cell in Util.AdjacentCells(self.World, Target))
+				{
 					if (Mobile.CanStayInCell(cell) && Mobile.CanEnterCell(cell))
+					{
+						if (cell == self.Location)
+							return (true, PathFinder.NoPath);
+
 						SearchCells.Add(cell);
+					}
+				}
 			}
 
 			if (SearchCells.Count == 0)
-				return PathFinder.NoPath;
+				return (false, PathFinder.NoPath);
 
-			return Mobile.PathFinder.FindPathToTargetCells(self, self.Location, SearchCells, check);
+			return (false, Mobile.PathFinder.FindPathToTargetCells(self, self.Location, SearchCells, check));
 		}
 
 		public override IEnumerable<Target> GetTargets(Actor self)

--- a/OpenRA.Mods.Common/Activities/Move/MoveOnto.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveOnto.cs
@@ -38,11 +38,14 @@ namespace OpenRA.Mods.Common.Activities
 			return Target.Type == TargetType.Terrain;
 		}
 
-		protected override List<CPos> CalculatePathToTarget(Actor self, BlockedByActor check)
+		protected override (bool AlreadyAtDestination, List<CPos> Path) CalculatePathToTarget(Actor self, BlockedByActor check)
 		{
+			if (lastVisibleTargetLocation == self.Location)
+				return (true, PathFinder.NoPath);
+
 			// If we are close to the target but can't enter, we wait.
 			if (!Mobile.CanEnterCell(lastVisibleTargetLocation) && Util.AreAdjacentCells(lastVisibleTargetLocation, self.Location))
-				return PathFinder.NoPath;
+				return (false, PathFinder.NoPath);
 
 			// PERF: Don't create a new list every run.
 			// PERF: Also reuse the already created list in the base class.
@@ -51,7 +54,7 @@ namespace OpenRA.Mods.Common.Activities
 			else if (SearchCells[0] != lastVisibleTargetLocation)
 				SearchCells[0] = lastVisibleTargetLocation;
 
-			return Mobile.PathFinder.FindPathToTargetCells(self, self.Location, SearchCells, check);
+			return (false, Mobile.PathFinder.FindPathToTargetCells(self, self.Location, SearchCells, check));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs
@@ -48,8 +48,11 @@ namespace OpenRA.Mods.Common.Activities
 				|| !Mobile.CanInteractWithGroundLayer(self) || !Mobile.CanStayInCell(self.Location));
 		}
 
-		protected override List<CPos> CalculatePathToTarget(Actor self, BlockedByActor check)
+		protected override (bool AlreadyAtDestination, List<CPos> Path) CalculatePathToTarget(Actor self, BlockedByActor check)
 		{
+			if (lastVisibleTargetLocation == self.Location)
+				return (true, PathFinder.NoPath);
+
 			// PERF: Assume that candidate cells don't change within a tick to avoid repeated queries
 			// when Move enumerates different BlockedByActor values.
 			if (searchCellsTick != self.World.WorldTick)
@@ -62,9 +65,9 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			if (SearchCells.Count == 0)
-				return PathFinder.NoPath;
+				return (false, PathFinder.NoPath);
 
-			return Mobile.PathFinder.FindPathToTargetCells(self, self.Location, SearchCells, check);
+			return (false, Mobile.PathFinder.FindPathToTargetCells(self, self.Location, SearchCells, check));
 		}
 
 		bool AtCorrectRange(WPos origin)

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -798,7 +798,7 @@ namespace OpenRA.Mods.Common.Traits
 			CrushAction(self, (notifyCrushed) => notifyCrushed.WarnCrush);
 		}
 
-		public Activity MoveTo(Func<BlockedByActor, List<CPos>> pathFunc) { return new Move(self, pathFunc); }
+		public Activity MoveTo(Func<BlockedByActor, (bool AlreadyAtDestination, List<CPos> Path)> pathFunc) { return new Move(self, pathFunc); }
 
 		Activity LocalMove(Actor self, WPos fromPos, WPos toPos, CPos cell)
 		{


### PR DESCRIPTION
When a move is made where the source and target locations are the same and no actual moving is required, a path of length 0 is returned. When a move cannot be made as there is no valid route, a path of length 0 is also returned. This means Move is unable to tell the difference between no movement required, and no path is possible. Currently it will hit the `hadNoPath` case and report CompleteDestinationBlocked.

To fix the scenario where the source and target location match, track a alreadyAtDestination field. When this scenario triggers, report CompleteDestinationReached instead.

This fixes activities that were using this result to inform their next actions. e.g. MoveOntoAndTurn would previously cancel the Turn portion of the activity, believing that the destination could not be reached. Now, it knows the destination was reached (since we are already there!) and will perform the turn.

----

This fixes the following replay from @michaeldgg2 recorded against da8eb68d9d37361f0a8b1e1479f1302a839f6f67.
[moveonto_dockhost_bug.zip](https://github.com/user-attachments/files/16630139/moveonto_dockhost_bug.zip)

This also matches the approach from @dnqbob in #20954: [Move.cs](https://github.com/OpenRA/OpenRA/pull/20954/files#diff-8e7de1308cf60447f10db1c1b42d1bccc2f98f1598b0e63dae108a78f9851cad) with `DestinationIsStartpoint`. Sadly I did not copy this into #21391 when I superseded it. dnqbob had done a better job at understanding the change than me, and it was a mistake not to copy it!