### PR TITLE
RA balance update

### DIFF
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -439,7 +439,7 @@
 	EdibleByLeap:
 	DetectCloaked:
 		DetectionTypes: Cloak
-		Range: 1c0
+		Range: 1c512
 
 ^Soldier:
 	Inherits: ^Infantry

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -131,7 +131,7 @@ E2:
 		Prerequisites: ~barr, ~techlevel.infonly
 		Description: actor-e2.description
 	Valued:
-		Cost: 160
+		Cost: 150
 	Tooltip:
 		Name: actor-e2.name
 	UpdatesPlayerStatistics:
@@ -407,7 +407,7 @@ E7:
 		BuildLimit: 1
 		Description: actor-e7.description
 	Valued:
-		Cost: 1500
+		Cost: 1800
 	Tooltip:
 		Name: actor-e7.name
 	UpdatesPlayerStatistics:
@@ -633,7 +633,7 @@ THF:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 5000
+		HP: 8000
 	RevealsShroud:
 		Range: 5c0
 	Passenger:
@@ -670,7 +670,7 @@ THF:
 		ValidDamageStates: Critical
 	Mobile:
 		Voice: Move
-		Speed: 68
+		Speed: 72
 	-AttackFrontal:
 
 SHOK:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -226,18 +226,18 @@ LST:
 		Prerequisites: ~techlevel.low
 		Description: actor-lst.description
 	Valued:
-		Cost: 700
+		Cost: 500
 	Tooltip:
 		Name: actor-lst.name
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 35000
+		HP: 40000
 	Armor:
 		Type: Heavy
 	Mobile:
 		Locomotor: lcraft
-		Speed: 128
+		Speed: 115
 		PauseOnCondition: notmobile
 	RevealsShroud:
 		MinRange: 5c0

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -224,7 +224,7 @@ SPEN:
 	ProductionBar:
 		ProductionType: Ship
 	Power:
-		Amount: -30
+		Amount: -20
 	DetectCloaked:
 		DetectionTypes: Underwater
 		Range: 10c0
@@ -344,7 +344,7 @@ SYRD:
 	ProductionBar:
 		ProductionType: Ship
 	Power:
-		Amount: -30
+		Amount: -20
 	DetectCloaked:
 		DetectionTypes: Underwater
 		Range: 10c0
@@ -404,7 +404,7 @@ IRON:
 		BuildLimit: 1
 		Description: actor-iron.description
 	Valued:
-		Cost: 1500
+		Cost: 2000
 	Tooltip:
 		Name: actor-iron.name
 	Building:
@@ -598,7 +598,7 @@ TSLA:
 		MaxCharges: 3
 		ReloadDelay: 120
 	Power:
-		Amount: -100
+		Amount: -80
 	DetectCloaked:
 		Range: 6c0
 		RequiresCondition: !disabled
@@ -917,7 +917,7 @@ FTUR:
 	Power:
 		Amount: -20
 	DetectCloaked:
-		Range: 6c0
+		Range: 5c0
 	ProvidesPrerequisite@buildingname:
 	Explodes:
 		Weapon: BuildingExplode

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -68,7 +68,7 @@ V2RL:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 26000
+		HP: 23000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -166,7 +166,7 @@ V2RL:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 60
+		Speed: 64
 	RevealsShroud:
 		MinRange: 4c0
 		Range: 6c0
@@ -609,7 +609,7 @@ MGG:
 	RevealsShroud@GAPGEN:
 		Range: 4c0
 	CreatesShroud:
-		Range: 6c0
+		Range: 7c0
 	RenderShroudCircle:
 	SpawnActorOnDeath:
 		Actor: MGG.Husk

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -283,7 +283,7 @@ MiniNuke:
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: GroundActor, Trees, WaterActor, Underwater, AirborneActor
 		Versus:
-			Wood: 25
+			Wood: 40
 			Concrete: 25
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
@@ -300,7 +300,7 @@ MiniNuke:
 		Delay: 5
 		ValidTargets: GroundActor, Trees, WaterActor, Underwater, AirborneActor
 		Versus:
-			Wood: 50
+			Wood: 55
 			Concrete: 25
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -164,6 +164,7 @@ RedEye:
 		Inaccuracy: 0
 		HorizontalRateOfTurn: 80
 		Speed: 298
+		RangeLimit: 9c0
 	Warhead@1Dam: SpreadDamage
 		Damage: 2400
 
@@ -317,7 +318,7 @@ SubMissileAA:
 
 SCUD:
 	Inherits: ^AntiGroundMissile
-	ReloadDelay: 240
+	ReloadDelay: 215
 	Range: 10c0
 	MinRange: 4c0
 	Report: missile1.aud

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -227,7 +227,7 @@ ChainGun.Yak:
 	BurstDelays: 0
 	ReloadDelay: 3
 	Range: 5c0
-	MinRange: 3c0
+	MinRange: 2c512
 	Projectile: InstantHit
 		Blockable: false
 	Warhead@1Dam: SpreadDamage


### PR DESCRIPTION
The main repo for changes https://github.com/tttppp/ora-balance-iteration/blob/master/CHANGELOG.md

Not everything is being merged as there are serious conceptual concerns with some of the changes. These changes have built up over many months.

- Thief
   - health 8000 (up from 5000)
   - speed 72 (up from 68)
- Grenadier
   - cost 150 (down from 160)
- Tanya
   - cost 1800 (up from 1500)
- Iron Curtain
   - cost 2000 (up from 1500)
- Tesla coil
   - power consumption 80 (down from 100)
- Ranger
   - health 18000 (up from 15000)
- Light tank
   - health 23000 (down from 26000)
- Heavy tank
   - speed 64 (up from 60)
- Demo truck
   - wood damage 40 then 55 (up from 25 then 50)
- Mobile Gap Generator
   - creates shroud 7c0 (up from 6c0)
- V2 Rocket Launcher
   - reload delay 215 (down from 240)

## Detection
- Infantry
   - detection 1c512 (up from 1c0)
- Flame Tower
   - detects cloak 5 cells (down from 6)

## Interaction changes
- Rocket soldier
   - anti-air tracking 9c0 (down from 11c0)
- Yak
   - min range 2c512 (down from 3c0)

# Naval
- Sub Pen
   - power 20 (down from 30)
- Shipyard
   - power 20 (down from 30)
- Naval transport
   - cost 500 (down from 700)
   - speed 115 (down from 128)
   - health 40000 (up from 35000)