### PR TITLE
Allow sheet buffers to be reused in SheetBuilder.

### DIFF
--- a/OpenRA.Game/Graphics/CursorManager.cs
+++ b/OpenRA.Game/Graphics/CursorManager.cs
@@ -91,10 +91,6 @@ namespace OpenRA.Graphics
 			}
 
 			CreateOrUpdateHardwareCursors();
-
-			foreach (var s in sheetBuilder.AllSheets)
-				s.ReleaseBuffer();
-
 			Update();
 		}
 
@@ -127,6 +123,8 @@ namespace OpenRA.Graphics
 					}
 				}
 			}
+
+			sheetBuilder.Current.ReleaseBuffer();
 
 			hardwareCursorsDoubled = graphicSettings.CursorDouble;
 		}

--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -132,12 +132,32 @@ namespace OpenRA.Graphics
 		{
 			if (!Buffered)
 				return;
+
 			dirty = true;
 			releaseBufferOnCommit = true;
 
 			// Commit data from the buffer to the texture, allowing the buffer to be released and reclaimed by GC.
 			if (Game.Renderer != null)
 				GetTexture();
+		}
+
+		public bool ReleaseBufferAndTryTransferTo(Sheet destination)
+		{
+			if (Size != destination.Size)
+				throw new ArgumentException("Destination sheet does not have the same size", nameof(destination));
+
+			var buffer = data;
+			ReleaseBuffer();
+
+			// Only transfer if the destination has no data that would be lost by overwriting.
+			if (buffer != null && destination.data == null && destination.texture == null)
+			{
+				Array.Clear(buffer, 0, buffer.Length);
+				destination.data = buffer;
+				return true;
+			}
+
+			return false;
 		}
 
 		public void Dispose()

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -130,8 +130,13 @@ namespace OpenRA.Graphics
 				var next = NextChannel(CurrentChannel);
 				if (next == null)
 				{
-					Current.ReleaseBuffer();
+					var previous = Current;
 					Current = allocateSheet();
+
+					// Reuse the backing buffer between sheets where possible.
+					// This avoids allocating additional buffers which the GC must clean up.
+					previous.ReleaseBufferAndTryTransferTo(Current);
+
 					sheets.Add(Current);
 					CurrentChannel = Type == SheetType.Indexed ? TextureChannel.Red : TextureChannel.RGBA;
 				}

--- a/OpenRA.Game/Graphics/SpriteCache.cs
+++ b/OpenRA.Game/Graphics/SpriteCache.cs
@@ -80,9 +80,6 @@ namespace OpenRA.Graphics
 
 		public void LoadReservations(ModData modData)
 		{
-			foreach (var sb in SheetBuilders.Values)
-				sb.Current.CreateBuffer();
-
 			var pendingResolve = new List<(
 				string Filename,
 				int FrameIndex,

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -97,7 +97,6 @@ namespace OpenRA.Mods.Common.Widgets
 
 			// The four layers are stored in a 2x2 grid within a single texture
 			radarSheet = new Sheet(SheetType.BGRA, new Size(2 * previewWidth, 2 * previewHeight).NextPowerOf2());
-			radarSheet.CreateBuffer();
 			radarData = radarSheet.GetData();
 
 			MapBoundsChanged();


### PR DESCRIPTION
Sheets can be buffered - where a copy of their data is kept in RAM. This allows for modifications to the sheet to be batched in the RAM buffer, before later being committed to VRAM in a single operation. The SheetBuilder class allows for sprites to be allocated onto one or more sheets. Each time a sheet is filled, it will allocate a new sheet. Sheets allocated by the sheet builder will typically use the buffering mechanism.

Previously each time the builder allocated a new sheet, the buffer would get thrown away, and the next sheet would allocate a fresh buffer. These buffers can be large and may accumulate before the GC cleans them up. So although only one buffer will be live at a time, they can cause a spike in memory used by the process during loading.

We can avoid this issue by allowing the buffer from the previous sheet to be reused by the next sheet. This is possible because the sheet builder only has one live sheet for modifications at a time, and they are all the same type and size. By allocating only one buffer per builder instead of one per sheet, we reduce the peak memory required during loading.

Separately, remove some unrequired Sheet.CreateBuffer or Sheet.ReleaseBuffer calls.

----

The TDHD mod uses large 8192x8192 sheets for the high-definition assets. With this change applied, the peak memory usage during loading of the main menu is reduced from 4.0GB to 3.1GB.