### PR TITLE
Provide buffer size in ShpRemasteredSprite.

### DIFF
--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpRemasteredLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpRemasteredLoader.cs
@@ -97,14 +97,21 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 					var metaStream = metaEntry != null ? container.GetInputStream(metaEntry) : null;
 					if (metaStream != null)
 					{
-						var meta = MetaRegex.Match(metaStream.ReadAllText());
+						string metaText;
+#if NET5_0_OR_GREATER
+						using (metaStream)
+						using (var metaReader = new StreamReader(metaStream, bufferSize: 64))
+							metaText = metaReader.ReadToEnd();
+#else
+						metaText = metaStream.ReadAllText();
+#endif
+						var meta = MetaRegex.Match(metaText);
 						var crop = Rectangle.FromLTRB(
 							ParseGroup(meta, "left"), ParseGroup(meta, "top"),
 							ParseGroup(meta, "right"), ParseGroup(meta, "bottom"));
 
 						var frameSize = new Size(ParseGroup(meta, "width"), ParseGroup(meta, "height"));
 						frames[i] = new TgaSprite.TgaFrame(tgaStream, frameSize, crop);
-						metaStream.Dispose();
 					}
 					else
 						frames[i] = new TgaSprite.TgaFrame(tgaStream);


### PR DESCRIPTION
As the expected size is quite small here, providing an explicit buffer size helps as otherwise default buffers for 1024 characters are allocated by the StreamReader which must be cleaned up by the GC afterwards. These smaller buffers still need cleanup but waste less memory.

----

Small PR aiming to assist the TDHD mod.