### PR TITLE
Use a smaller sheet in CursorManager.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -496,7 +496,7 @@ namespace OpenRA
 			Renderer.InitializeDepthBuffer(grid);
 
 			Cursor?.Dispose();
-			Cursor = new CursorManager(ModData.CursorProvider);
+			Cursor = new CursorManager(ModData.CursorProvider, ModData.Manifest.CursorSheetSize);
 
 			var metadata = ModData.Manifest.Metadata;
 			if (!string.IsNullOrEmpty(metadata.WindowTitle))

--- a/OpenRA.Game/Graphics/CursorManager.cs
+++ b/OpenRA.Game/Graphics/CursorManager.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Primitives;
 
 namespace OpenRA.Graphics
@@ -43,8 +44,11 @@ namespace OpenRA.Graphics
 			hardwareCursorsDisabled = Game.Settings.Graphics.DisableHardwareCursors;
 
 			graphicSettings = Game.Settings.Graphics;
-			sheetBuilder = new SheetBuilder(SheetType.BGRA);
-			foreach (var kv in cursorProvider.Cursors)
+			sheetBuilder = new SheetBuilder(SheetType.BGRA, 512);
+
+			// Sort the cursors for better packing onto the sheet.
+			foreach (var kv in cursorProvider.Cursors
+				.OrderBy(kvp => kvp.Value.Frames.Max(f => f.Size.Height)))
 			{
 				var frames = kv.Value.Frames;
 				var palette = !string.IsNullOrEmpty(kv.Value.Palette) ? cursorProvider.Palettes[kv.Value.Palette] : null;

--- a/OpenRA.Game/Graphics/CursorManager.cs
+++ b/OpenRA.Game/Graphics/CursorManager.cs
@@ -39,12 +39,12 @@ namespace OpenRA.Graphics
 		readonly bool hardwareCursorsDisabled = false;
 		bool hardwareCursorsDoubled = false;
 
-		public CursorManager(CursorProvider cursorProvider)
+		public CursorManager(CursorProvider cursorProvider, int cursorSheetSize)
 		{
 			hardwareCursorsDisabled = Game.Settings.Graphics.DisableHardwareCursors;
 
 			graphicSettings = Game.Settings.Graphics;
-			sheetBuilder = new SheetBuilder(SheetType.BGRA, 512);
+			sheetBuilder = new SheetBuilder(SheetType.BGRA, cursorSheetSize);
 
 			// Sort the cursors for better packing onto the sheet.
 			foreach (var kv in cursorProvider.Cursors

--- a/OpenRA.Game/Graphics/CursorManager.cs
+++ b/OpenRA.Game/Graphics/CursorManager.cs
@@ -16,7 +16,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Graphics
 {
-	public sealed class CursorManager
+	public sealed class CursorManager : IDisposable
 	{
 		sealed class Cursor
 		{

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -74,7 +74,9 @@ namespace OpenRA
 		public readonly string[] SpriteFormats = Array.Empty<string>();
 		public readonly string[] PackageFormats = Array.Empty<string>();
 		public readonly string[] VideoFormats = Array.Empty<string>();
-		public bool AllowUnusedTranslationsInExternalPackages = true;
+		public readonly bool AllowUnusedTranslationsInExternalPackages = true;
+		public readonly int FontSheetSize = 512;
+		public readonly int CursorSheetSize = 512;
 
 		readonly string[] reservedModuleNames =
 		{
@@ -82,7 +84,7 @@ namespace OpenRA
 			"Sequences", "ModelSequences", "Cursors", "Chrome", "Assemblies", "ChromeLayout", "Weapons",
 			"Voices", "Notifications", "Music", "Translations", "TileSets", "ChromeMetrics", "Missions", "Hotkeys",
 			"ServerTraits", "LoadScreen", "DefaultOrderGenerator", "SupportsMapsFrom", "SoundFormats", "SpriteFormats", "VideoFormats",
-			"RequiresMods", "PackageFormats", "AllowUnusedTranslationsInExternalPackages"
+			"RequiresMods", "PackageFormats", "AllowUnusedTranslationsInExternalPackages", "FontSheetSize", "CursorSheetSize"
 		};
 
 		readonly TypeDictionary modules = new();
@@ -171,6 +173,12 @@ namespace OpenRA
 			if (yaml.TryGetValue("AllowUnusedTranslationsInExternalPackages", out entry))
 				AllowUnusedTranslationsInExternalPackages =
 					FieldLoader.GetValue<bool>("AllowUnusedTranslationsInExternalPackages", entry.Value);
+
+			if (yaml.TryGetValue("FontSheetSize", out entry))
+				FontSheetSize = FieldLoader.GetValue<int>("FontSheetSize", entry.Value);
+
+			if (yaml.TryGetValue("CursorSheetSize", out entry))
+				CursorSheetSize = FieldLoader.GetValue<int>("CursorSheetSize", entry.Value);
 		}
 
 		public void LoadCustomData(ObjectCreator oc)

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -133,7 +133,7 @@ namespace OpenRA
 			using (new PerfTimer("SpriteFonts"))
 			{
 				fontSheetBuilder?.Dispose();
-				fontSheetBuilder = new SheetBuilder(SheetType.BGRA, 512);
+				fontSheetBuilder = new SheetBuilder(SheetType.BGRA, modData.Manifest.FontSheetSize);
 				Fonts = modData.Manifest.Get<Fonts>().FontList.ToDictionary(x => x.Key,
 					x => new SpriteFont(
 						platform, x.Value.Font, modData.DefaultFileSystem.Open(x.Value.Font).ReadAllBytes(),


### PR DESCRIPTION
Provide an explicit size of 512, smaller than the default 2048. The cursors for all mods still pack onto this single sheet, so we avoid wasting memory on larger sheets.

Sorting the cursors also helps pack them onto the sheets more efficiently.