### PR TITLE
Update Pfim to 0.11.3.

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="NVorbis" Version="0.10.5" />
     <PackageReference Include="TagLibSharp" Version="2.3.0" />
     <PackageReference Include="rix0rrr.BeaconLib" Version="1.0.2" />
-    <PackageReference Include="Pfim" Version="0.11.2" />
+    <PackageReference Include="Pfim" Version="0.11.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This version reduces memory allocation necessary to decode images. See https://github.com/nickbabcock/Pfim/pull/118 for details.