### PR TITLE
Remove IRON offset from RA1 map imports

### DIFF
--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertMapCommand.cs
@@ -131,7 +131,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			var newLoc = new CPos(loc % MapSize, loc / MapSize);
 			var vectorDown = new CVec(0, 1);
 
-			if (input == "tsla" || input == "agun" || input == "gap" || input == "apwr" || input == "iron")
+			if (input == "tsla" || input == "agun" || input == "gap" || input == "apwr")
 				newLoc += vectorDown;
 
 			return newLoc;


### PR DESCRIPTION
![Static1](https://github.com/user-attachments/assets/e23b81c9-c157-4009-b34a-90b5cc9c7f5b)
![Static2](https://github.com/user-attachments/assets/0f75d15f-02c5-4d45-8b18-3b62c3a46897)
The anchor cell of the Iron Curtain structure now matches the original 2x2 after https://github.com/OpenRA/OpenRA/pull/20832, and the offset is no longer necessary.