### PR TITLE
Fix Linux MIME namespace

### DIFF
--- a/packaging/linux/openra-mimeinfo.xml.discord.in
+++ b/packaging/linux/openra-mimeinfo.xml.discord.in
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<mime-info xmlns='https://www.freedesktop.org/standards/shared-mime-info'>
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
   <mime-type type="x-scheme-handler/openra-{MODID}-{TAG}">
     <icon name="openra-{MODID}" />
     <generic-icon name="applications-games"/>

--- a/packaging/linux/openra-mimeinfo.xml.in
+++ b/packaging/linux/openra-mimeinfo.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<mime-info xmlns='https://www.freedesktop.org/standards/shared-mime-info'>
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
   <mime-type type="x-scheme-handler/openra-{MODID}-{TAG}">
     <icon name="openra-{MODID}" />
     <generic-icon name="applications-games"/>


### PR DESCRIPTION
Partly reverts https://github.com/OpenRA/OpenRA/pull/21427 which mistakenly handled this like a URL and causes error messages.