### PR TITLE
Interactable: allow specifying arbitrary 2D polygon for mouse interaction

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/RenderMouseBounds.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderMouseBounds.cs
@@ -1,0 +1,67 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Graphics;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits.Render
+{
+	[Desc("Renders polygon for mouse bounds (usually defined by " + nameof(Interactable) + " or " + nameof(Selectable) + ").",
+		"Put on actor for which the polygon should be rendered.")]
+	public class RenderMouseBoundsInfo : TraitInfo, Requires<InteractableInfo>
+	{
+		[Desc("Color to use for the polygon lines.")]
+		public readonly Color PolygonLineColor = Color.Green;
+
+		public override object Create(ActorInitializer init) { return new RenderMouseBounds(init.Self, this); }
+	}
+
+	public class RenderMouseBounds : IRenderAnnotations
+	{
+		readonly IMouseBounds mouseBounds;
+		readonly RenderMouseBoundsInfo info;
+
+		public RenderMouseBounds(Actor self, RenderMouseBoundsInfo info)
+		{
+			mouseBounds = self.Trait<IMouseBounds>();
+			this.info = info;
+		}
+
+		bool IRenderAnnotations.SpatiallyPartitionable => true;
+
+		IEnumerable<IRenderable> IRenderAnnotations.RenderAnnotations(Actor self, WorldRenderer wr)
+		{
+			if (self.World.FogObscures(self))
+				return Enumerable.Empty<IRenderable>();
+
+			return DrawDecorations(self, wr);
+		}
+
+		IEnumerable<IRenderable> DrawDecorations(Actor self, WorldRenderer wr)
+		{
+			var polygon = mouseBounds.MouseoverBounds(self, wr);
+			var vertices = new WPos[polygon.Vertices.Length];
+
+			for (var i = 0; i < polygon.Vertices.Length; i++)
+			{
+				var screenVertex = polygon.Vertices[i];
+
+				vertices[i] = wr.ProjectedPosition(screenVertex);
+			}
+
+			yield return new PolygonAnnotationRenderable(vertices, vertices[0], 1, info.PolygonLineColor);
+		}
+	}
+}


### PR DESCRIPTION
### Background

`Interactable` trait does not allow specifying non-rectangular region as mouse bounds...

```
[Desc("Used to enable mouse interaction on actors that are not Selectable.")]
public class InteractableInfo : TraitInfo, IMouseBoundsInfo
{
	[Desc("Defines a custom rectangle for mouse interaction with the actor.",
		"If null, the engine will guess an appropriate size based on the With*Body trait.",
		"The first two numbers define the width and height of the rectangle as a world distance.",
		"The (optional) second two numbers define an x and y offset from the actor center.")]
	public readonly WDist[] Bounds = null;

	// ...
```

... despite `MouseoverBounds()` method in `IMouseBounds` interface returning `Polygon`:

```
public interface IMouseBounds { Polygon MouseoverBounds(Actor self, WorldRenderer wr); }
```

### PR description

This PR allows specifying arbitrary 2D polygon for mouse interaction that will be used instead of `Bounds` (or bounds generated using `IAutoMouseBounds` trait):

```
[Desc("Defines a custom 2D polygon for mouse interaction with the actor.",
	"If null, Bounds will be used instead",
	"Each vertex has two components (so two numbers), which define an x and y offset from the actor center.")]
public readonly int2[] Polygon = null;
```
### Example in RA

This is how a (bit contrived) test case could look like in RA:

![openra_nonrectangular_mousebounds](https://github.com/user-attachments/assets/53287112-7579-4997-8675-77b7bb7f2d06)
(here only Refinery has polygon mouse bounds, the rest of the buildings use normal rectangle)

```
Selectable:
	# Bounds: 3072, 2133, 0, 170
	DecorationBounds: 3072, 2986, 0, -85
	Polygon: 0,1194, 938,170, 3072,170, 3072,1621, 2560,1621, 1066,2303, 0,2303
```

I also added a debug trait `RenderMouseBounds` for use by modders in order to tweak the polygon, since the mouse bounds are not visible unlike the selection box. It's not essential for the PR, so I can remove it, if required.

### More background (and a real use case)

In OpenE2140 we have a small issue with the mouse bounds for Refinery and Mine buildings. Both have conveyor belt on one entire tile, which "sticks" out of the main part of each building. The problem is that it's not possible to target the cell right below the conveyor belt:

![opene2140_refinery_rectangular_mouse_bounds](https://github.com/user-attachments/assets/d8c95cac-c6ee-4fbd-a0c3-b8860098ca6d)

With `Interactable` allowing to define polygon (in addition to normal rectangle), we can solve this issue very elegantly:

![opene2140_refinery_non_rectangular_mouse_bounds](https://github.com/user-attachments/assets/ae482930-3a86-456a-ac30-2d19916dd368)


Actually this is how the mouse interaction works in the original Earth 2140:

![e2140_mine_mousebounds](https://github.com/user-attachments/assets/fecc4367-c0db-4a15-98aa-6fa5232accdd)
