### PR TITLE
Change ActorIndex to work in terms of TraitInfo, instead of Trait.

### DIFF
--- a/OpenRA.Mods.Common/AIUtils.cs
+++ b/OpenRA.Mods.Common/AIUtils.cs
@@ -47,7 +47,8 @@ namespace OpenRA.Mods.Common
 			return owner.World.ActorsHavingTrait<T>().Count(a => a.Owner == owner && a.Info.Name == actorName);
 		}
 
-		public static int CountActorByCommonName<T>(ActorIndex.OwnerAndNamesAndTrait<T> actorIndex)
+		public static int CountActorByCommonName<TTraitInfo>(
+			ActorIndex.OwnerAndNamesAndTrait<TTraitInfo> actorIndex) where TTraitInfo : ITraitInfoInterface
 		{
 			return actorIndex.Actors.Count(a => !a.IsDead);
 		}

--- a/OpenRA.Mods.Common/ActorIndex.cs
+++ b/OpenRA.Mods.Common/ActorIndex.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common
 {
@@ -97,9 +98,9 @@ namespace OpenRA.Mods.Common
 		/// <summary>
 		/// Maintains an index of actors in the world that
 		/// have one of the given <see cref="ActorInfo.Name"/>
-		/// and have the trait of type <typeparamref name="T"/>.
+		/// and have the trait with info of type <typeparamref name="TTraitInfo"/>.
 		/// </summary>
-		public sealed class NamesAndTrait<T> : ActorIndex
+		public sealed class NamesAndTrait<TTraitInfo> : ActorIndex where TTraitInfo : ITraitInfoInterface
 		{
 			readonly HashSet<string> names;
 
@@ -111,12 +112,12 @@ namespace OpenRA.Mods.Common
 
 			static IEnumerable<Actor> ActorsToIndex(World world, HashSet<string> names)
 			{
-				return world.ActorsHavingTrait<T>().Where(a => names.Contains(a.Info.Name));
+				return world.Actors.Where(a => names.Contains(a.Info.Name) && a.Info.HasTraitInfo<TTraitInfo>());
 			}
 
 			protected override bool ShouldIndexActor(Actor actor)
 			{
-				return names.Contains(actor.Info.Name) && actor.TraitsImplementing<T>().Any();
+				return names.Contains(actor.Info.Name) && actor.Info.HasTraitInfo<TTraitInfo>();
 			}
 		}
 
@@ -124,9 +125,9 @@ namespace OpenRA.Mods.Common
 		/// Maintains an index of actors in the world that
 		/// are owned by a given <see cref="Player"/>,
 		/// have one of the given <see cref="ActorInfo.Name"/>
-		/// and have the trait of type <typeparamref name="T"/>.
+		/// and have the trait with info of type <typeparamref name="TTraitInfo"/>.
 		/// </summary>
-		public sealed class OwnerAndNamesAndTrait<T> : ActorIndex
+		public sealed class OwnerAndNamesAndTrait<TTraitInfo> : ActorIndex where TTraitInfo : ITraitInfoInterface
 		{
 			readonly HashSet<string> names;
 			readonly Player owner;
@@ -140,12 +141,12 @@ namespace OpenRA.Mods.Common
 
 			static IEnumerable<Actor> ActorsToIndex(World world, HashSet<string> names, Player owner)
 			{
-				return world.ActorsHavingTrait<T>().Where(a => a.Owner == owner && names.Contains(a.Info.Name));
+				return world.Actors.Where(a => a.Owner == owner && names.Contains(a.Info.Name) && a.Info.HasTraitInfo<TTraitInfo>());
 			}
 
 			protected override bool ShouldIndexActor(Actor actor)
 			{
-				return actor.Owner == owner && names.Contains(actor.Info.Name) && actor.TraitsImplementing<T>().Any();
+				return actor.Owner == owner && names.Contains(actor.Info.Name) && actor.Info.HasTraitInfo<TTraitInfo>();
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -173,10 +173,10 @@ namespace OpenRA.Mods.Common.Traits
 		readonly BaseBuilderQueueManager[] builders;
 		int currentBuilderIndex = 0;
 
-		readonly ActorIndex.OwnerAndNamesAndTrait<Building> refineryBuildings;
-		readonly ActorIndex.OwnerAndNamesAndTrait<Building> powerBuildings;
-		readonly ActorIndex.OwnerAndNamesAndTrait<Building> constructionYardBuildings;
-		readonly ActorIndex.OwnerAndNamesAndTrait<Building> barracksBuildings;
+		readonly ActorIndex.OwnerAndNamesAndTrait<BuildingInfo> refineryBuildings;
+		readonly ActorIndex.OwnerAndNamesAndTrait<BuildingInfo> powerBuildings;
+		readonly ActorIndex.OwnerAndNamesAndTrait<BuildingInfo> constructionYardBuildings;
+		readonly ActorIndex.OwnerAndNamesAndTrait<BuildingInfo> barracksBuildings;
 
 		public BaseBuilderBotModule(Actor self, BaseBuilderBotModuleInfo info)
 			: base(info)
@@ -184,10 +184,10 @@ namespace OpenRA.Mods.Common.Traits
 			world = self.World;
 			player = self.Owner;
 			builders = new BaseBuilderQueueManager[info.BuildingQueues.Count + info.DefenseQueues.Count];
-			refineryBuildings = new ActorIndex.OwnerAndNamesAndTrait<Building>(world, info.RefineryTypes, player);
-			powerBuildings = new ActorIndex.OwnerAndNamesAndTrait<Building>(world, info.PowerTypes, player);
-			constructionYardBuildings = new ActorIndex.OwnerAndNamesAndTrait<Building>(world, info.ConstructionYardTypes, player);
-			barracksBuildings = new ActorIndex.OwnerAndNamesAndTrait<Building>(world, info.BarracksTypes, player);
+			refineryBuildings = new ActorIndex.OwnerAndNamesAndTrait<BuildingInfo>(world, info.RefineryTypes, player);
+			powerBuildings = new ActorIndex.OwnerAndNamesAndTrait<BuildingInfo>(world, info.PowerTypes, player);
+			constructionYardBuildings = new ActorIndex.OwnerAndNamesAndTrait<BuildingInfo>(world, info.ConstructionYardTypes, player);
+			barracksBuildings = new ActorIndex.OwnerAndNamesAndTrait<BuildingInfo>(world, info.BarracksTypes, player);
 		}
 
 		protected override void Created(Actor self)

--- a/OpenRA.Mods.Common/Traits/BotModules/CaptureManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/CaptureManagerBotModule.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 		// Units that the bot already knows about and has given a capture order. Any unit not on this list needs to be given a new order.
 		readonly List<Actor> activeCapturers = new();
 
-		readonly ActorIndex.OwnerAndNamesAndTrait<Captures> capturingActors;
+		readonly ActorIndex.OwnerAndNamesAndTrait<CapturesInfo> capturingActors;
 
 		public CaptureManagerBotModule(Actor self, CaptureManagerBotModuleInfo info)
 			: base(info)
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			maximumCaptureTargetOptions = Math.Max(1, Info.MaximumCaptureTargetOptions);
 
-			capturingActors = new ActorIndex.OwnerAndNamesAndTrait<Captures>(world, Info.CapturingActorTypes, player);
+			capturingActors = new ActorIndex.OwnerAndNamesAndTrait<CapturesInfo>(world, Info.CapturingActorTypes, player);
 		}
 
 		protected override void TraitEnabled(Actor self)

--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -70,8 +70,8 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Func<Actor, bool> unitCannotBeOrdered;
 		readonly Dictionary<Actor, HarvesterTraitWrapper> harvesters = new();
 		readonly Stack<HarvesterTraitWrapper> harvestersNeedingOrders = new();
-		readonly ActorIndex.OwnerAndNamesAndTrait<Building> refineries;
-		readonly ActorIndex.OwnerAndNamesAndTrait<Harvester> harvestersIndex;
+		readonly ActorIndex.OwnerAndNamesAndTrait<BuildingInfo> refineries;
+		readonly ActorIndex.OwnerAndNamesAndTrait<HarvesterInfo> harvestersIndex;
 		readonly Dictionary<CPos, string> resourceTypesByCell = new();
 
 		IResourceLayer resourceLayer;
@@ -85,8 +85,8 @@ namespace OpenRA.Mods.Common.Traits
 			world = self.World;
 			player = self.Owner;
 			unitCannotBeOrdered = a => a.Owner != self.Owner || a.IsDead || !a.IsInWorld;
-			refineries = new ActorIndex.OwnerAndNamesAndTrait<Building>(world, info.RefineryTypes, player);
-			harvestersIndex = new ActorIndex.OwnerAndNamesAndTrait<Harvester>(world, info.HarvesterTypes, player);
+			refineries = new ActorIndex.OwnerAndNamesAndTrait<BuildingInfo>(world, info.RefineryTypes, player);
+			harvestersIndex = new ActorIndex.OwnerAndNamesAndTrait<HarvesterInfo>(world, info.HarvesterTypes, player);
 		}
 
 		protected override void Created(Actor self)

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -60,9 +60,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		readonly World world;
 		readonly Player player;
-		readonly ActorIndex.OwnerAndNamesAndTrait<Transforms> mcvs;
-		readonly ActorIndex.OwnerAndNamesAndTrait<Building> constructionYards;
-		readonly ActorIndex.OwnerAndNamesAndTrait<Building> mcvFactories;
+		readonly ActorIndex.OwnerAndNamesAndTrait<TransformsInfo> mcvs;
+		readonly ActorIndex.OwnerAndNamesAndTrait<BuildingInfo> constructionYards;
+		readonly ActorIndex.OwnerAndNamesAndTrait<BuildingInfo> mcvFactories;
 
 		IBotPositionsUpdated[] notifyPositionsUpdated;
 		IBotRequestUnitProduction[] requestUnitProduction;
@@ -76,9 +76,9 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			world = self.World;
 			player = self.Owner;
-			mcvs = new ActorIndex.OwnerAndNamesAndTrait<Transforms>(world, info.McvTypes, player);
-			constructionYards = new ActorIndex.OwnerAndNamesAndTrait<Building>(world, info.ConstructionYardTypes, player);
-			mcvFactories = new ActorIndex.OwnerAndNamesAndTrait<Building>(world, info.McvFactoryTypes, player);
+			mcvs = new ActorIndex.OwnerAndNamesAndTrait<TransformsInfo>(world, info.McvTypes, player);
+			constructionYards = new ActorIndex.OwnerAndNamesAndTrait<BuildingInfo>(world, info.ConstructionYardTypes, player);
+			mcvFactories = new ActorIndex.OwnerAndNamesAndTrait<BuildingInfo>(world, info.McvFactoryTypes, player);
 		}
 
 		protected override void Created(Actor self)

--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -126,7 +126,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public List<Squad> Squads = new();
 		readonly Stack<Squad> squadsPendingUpdate = new();
-		readonly ActorIndex.NamesAndTrait<Building> constructionYardBuildings;
+		readonly ActorIndex.NamesAndTrait<BuildingInfo> constructionYardBuildings;
 
 		IBot bot;
 		IBotPositionsUpdated[] notifyPositionsUpdated;
@@ -146,7 +146,7 @@ namespace OpenRA.Mods.Common.Traits
 			Player = self.Owner;
 
 			unitCannotBeOrdered = a => a == null || a.Owner != Player || a.IsDead || !a.IsInWorld;
-			constructionYardBuildings = new ActorIndex.NamesAndTrait<Building>(World, info.ConstructionYardTypes);
+			constructionYardBuildings = new ActorIndex.NamesAndTrait<BuildingInfo>(World, info.ConstructionYardTypes);
 		}
 
 		// Use for proactive targeting.


### PR DESCRIPTION
This allows actor.Info.HasTraitInfo to be used when checking if an actor needs to be added to the index, which is a cheaper call than actor.TraitsImplementing.

Closes #21485