### PR TITLE
Teach ConvertSpriteToPngCommand to handle frames that extend outside FrameSize.

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
@@ -71,11 +71,14 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				var pngData = frame.Data;
 				if (frameSize != frame.Size)
 				{
+					var width = Math.Min(frame.Size.Width, frameSize.Width - offset.X);
+					var height = Math.Min(frame.Size.Height, frameSize.Height - offset.Y);
 					pngData = new byte[frameSize.Width * frameSize.Height];
-					for (var i = 0; i < frame.Size.Height; i++)
-						Buffer.BlockCopy(frame.Data, i * frame.Size.Width,
-							pngData, (i + offset.Y) * frameSize.Width + offset.X,
-							frame.Size.Width);
+					for (var h = 0; h < height; h++)
+						Array.Copy(
+							frame.Data, h * frame.Size.Width,
+							pngData, (h + offset.Y) * frameSize.Width + offset.X,
+							width);
 				}
 
 				var png = new Png(pngData, SpriteFrameType.Indexed8, frameSize.Width, frameSize.Height, palColors);


### PR DESCRIPTION
The rectangle defined by a frames's Offset+Size usually fits within the rectangle given by FrameSize. However it can sometimes extend outside this region due to padding added by the engine. This causes an array-out-of-bounds crash as we only allocate space to cover the FrameSize region.

Now, we teach the copying process to only copy the portion of the data that lies within the FrameSize region. If any data extends outside the region, it won't be copied.

Fixes #21536