### PR TITLE
Fixed wrong support folder when using .NET 8 on Unix

### DIFF
--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -180,7 +180,7 @@ namespace OpenRA
 				case PlatformType.OSX:
 				{
 					modernUserSupportPath = legacyUserSupportPath = Path.Combine(
-						Environment.GetFolderPath(Environment.SpecialFolder.Personal),
+						Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
 						"Library", "Application Support", "OpenRA") + Path.DirectorySeparatorChar;
 
 					systemSupportPath = "/Library/Application Support/OpenRA/";
@@ -189,11 +189,11 @@ namespace OpenRA
 
 				case PlatformType.Linux:
 				{
-					legacyUserSupportPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".openra") + Path.DirectorySeparatorChar;
+					legacyUserSupportPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".openra") + Path.DirectorySeparatorChar;
 
 					var xdgConfigHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
 					if (string.IsNullOrEmpty(xdgConfigHome))
-						xdgConfigHome = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".config") + Path.DirectorySeparatorChar;
+						xdgConfigHome = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config") + Path.DirectorySeparatorChar;
 
 					modernUserSupportPath = Path.Combine(xdgConfigHome, "openra") + Path.DirectorySeparatorChar;
 					systemSupportPath = "/var/games/openra/";


### PR DESCRIPTION
It saves into `~/Documents/.config/openra/` instead of `~/.config/openra/` on Linux. https://learn.microsoft.com/dotnet/core/compatibility/core-libraries/8.0/getfolderpath-unix Discovered during https://github.com/OpenRA/OpenRA/pull/21577. Also effects https://launchpad.net/~xtradeb/+archive/ubuntu/play/+build/28130160 which is already on .NET 8.