### PR TITLE
Fixed wrong support folder when using .NET 8 on other Unix variants

### DIFF
--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -204,7 +204,7 @@ namespace OpenRA
 				default:
 				{
 					modernUserSupportPath = legacyUserSupportPath =
-						Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".openra") + Path.DirectorySeparatorChar;
+						Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".openra") + Path.DirectorySeparatorChar;
 					systemSupportPath = "/var/games/openra/";
 					break;
 				}


### PR DESCRIPTION
Followup to https://github.com/OpenRA/OpenRA/pull/21583#issuecomment-2355241634