### PR TITLE
Use covariant return types.

### DIFF
--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -629,7 +629,7 @@ namespace OpenRA.Widgets
 			: base(other) { IgnoreMouseOver = true; }
 
 		public override string GetCursor(int2 pos) { return null; }
-		public override Widget Clone() { return new ContainerWidget(this); }
+		public override ContainerWidget Clone() { return new ContainerWidget(this); }
 		public Func<KeyInput, bool> OnKeyPress = _ => false;
 		public override bool HandleKeyPress(KeyInput e) { return OnKeyPress(e); }
 
@@ -655,7 +655,7 @@ namespace OpenRA.Widgets
 			IsDisabled = () => other.Disabled;
 		}
 
-		public override Widget Clone() { return new InputWidget(this); }
+		public override InputWidget Clone() { return new InputWidget(this); }
 	}
 
 	public class WidgetArgs : Dictionary<string, object>

--- a/OpenRA.Mods.Cnc/Graphics/ClassicSpriteSequence.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ClassicSpriteSequence.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 		public ClassicSpriteSequenceLoader(ModData modData)
 			: base(modData) { }
 
-		public override ISpriteSequence CreateSequence(
+		public override ClassicSpriteSequence CreateSequence(
 			ModData modData, string tileset, SpriteCache cache, string image, string sequence, MiniYaml data, MiniYaml defaults)
 		{
 			return new ClassicSpriteSequence(cache, this, image, sequence, data, defaults);

--- a/OpenRA.Mods.Cnc/Graphics/ClassicTilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ClassicTilesetSpecificSpriteSequence.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 		public ClassicTilesetSpecificSpriteSequenceLoader(ModData modData)
 			: base(modData) { }
 
-		public override ISpriteSequence CreateSequence(
+		public override ClassicTilesetSpecificSpriteSequence CreateSequence(
 			ModData modData, string tileset, SpriteCache cache, string image, string sequence, MiniYaml data, MiniYaml defaults)
 		{
 			return new ClassicTilesetSpecificSpriteSequence(cache, this, image, sequence, data, defaults);

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/GrantPrerequisiteChargeDrainPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/GrantPrerequisiteChargeDrainPower.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			active = false;
 		}
 
-		public override SupportPowerInstance CreateInstance(string key, SupportPowerManager manager)
+		public override DischargeableSupportPowerInstance CreateInstance(string key, SupportPowerManager manager)
 		{
 			return new DischargeableSupportPowerInstance(key, info, manager);
 		}

--- a/OpenRA.Mods.Cnc/Widgets/ModelWidget.cs
+++ b/OpenRA.Mods.Cnc/Widgets/ModelWidget.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Cnc.Widgets
 			GetRotation = getRotation;
 		}
 
-		public override Widget Clone()
+		public override ModelWidget Clone()
 		{
 			return new ModelWidget(this);
 		}

--- a/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Graphics
 		public TilesetSpecificSpriteSequenceLoader(ModData modData)
 			: base(modData) { }
 
-		public override ISpriteSequence CreateSequence(
+		public override TilesetSpecificSpriteSequence CreateSequence(
 			ModData modData, string tileSet, SpriteCache cache, string image, string sequence, MiniYaml data, MiniYaml defaults)
 		{
 			return new TilesetSpecificSpriteSequence(cache, this, image, sequence, data, defaults);

--- a/OpenRA.Mods.Common/Terrain/DefaultTerrain.cs
+++ b/OpenRA.Mods.Common/Terrain/DefaultTerrain.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Terrain
 		public DefaultTerrainTemplateInfo(ITerrainInfo terrainInfo, MiniYaml my)
 			: base(terrainInfo, my) { }
 
-		protected override TerrainTileInfo LoadTileInfo(ITerrainInfo terrainInfo, MiniYaml my)
+		protected override DefaultTerrainTileInfo LoadTileInfo(ITerrainInfo terrainInfo, MiniYaml my)
 		{
 			var tile = new DefaultTerrainTileInfo();
 			FieldLoader.Load(tile, my);

--- a/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Widgets
 			viewportSizes = other.viewportSizes;
 		}
 
-		public override Widget Clone() { return new ActorPreviewWidget(this); }
+		public override ActorPreviewWidget Clone() { return new ActorPreviewWidget(this); }
 
 		public void SetPreview(ActorInfo actor, TypeDictionary td)
 		{

--- a/OpenRA.Mods.Common/Widgets/BackgroundWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/BackgroundWidget.cs
@@ -68,6 +68,6 @@ namespace OpenRA.Mods.Common.Widgets
 			Draggable = other.Draggable;
 		}
 
-		public override Widget Clone() { return new BackgroundWidget(this); }
+		public override BackgroundWidget Clone() { return new BackgroundWidget(this); }
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/BadgeWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/BadgeWidget.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Widgets
 			playerDatabase = other.playerDatabase;
 		}
 
-		public override Widget Clone() { return new BadgeWidget(this); }
+		public override BadgeWidget Clone() { return new BadgeWidget(this); }
 
 		public override void Draw()
 		{

--- a/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
@@ -276,7 +276,7 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 		}
 
-		public override Widget Clone() { return new ButtonWidget(this); }
+		public override ButtonWidget Clone() { return new ButtonWidget(this); }
 		public virtual int UsableWidth => Bounds.Width;
 
 		public virtual void DrawBackground(Rectangle rect, bool disabled, bool pressed, bool hover, bool highlighted)

--- a/OpenRA.Mods.Common/Widgets/CheckboxWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/CheckboxWidget.cs
@@ -85,6 +85,6 @@ namespace OpenRA.Mods.Common.Widgets
 					rect.Top + (int)((rect.Height - checkmarkImage.Size.Y) / 2)));
 		}
 
-		public override Widget Clone() { return new CheckboxWidget(this); }
+		public override CheckboxWidget Clone() { return new CheckboxWidget(this); }
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/ClientTooltipRegionWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ClientTooltipRegionWidget.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Widgets
 			client = other.client;
 		}
 
-		public override Widget Clone() { return new ClientTooltipRegionWidget(this); }
+		public override ClientTooltipRegionWidget Clone() { return new ClientTooltipRegionWidget(this); }
 
 		public void Bind(OrderManager orderManager, WorldRenderer worldRenderer, Session.Client client)
 		{

--- a/OpenRA.Mods.Common/Widgets/ColorBlockWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ColorBlockWidget.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Widgets
 			ClickSound = widget.ClickSound;
 		}
 
-		public override Widget Clone()
+		public override ColorBlockWidget Clone()
 		{
 			return new ColorBlockWidget(this);
 		}

--- a/OpenRA.Mods.Common/Widgets/ConfirmationDialogs.cs
+++ b/OpenRA.Mods.Common/Widgets/ConfirmationDialogs.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var headerHeight = 0;
 			foreach (var l in headerLines)
 			{
-				var line = (LabelWidget)headerTemplate.Clone();
+				var line = headerTemplate.Clone();
 				line.GetText = () => l;
 				line.Bounds.Y += headerHeight;
 				prompt.AddChild(line);

--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Widgets
 					rb.Top + (int)((rb.Height - separatorImage.Size.Y) / 2)));
 		}
 
-		public override Widget Clone() { return new DropDownButtonWidget(this); }
+		public override DropDownButtonWidget Clone() { return new DropDownButtonWidget(this); }
 
 		// This is crap
 		public override int UsableWidth => Bounds.Width - Bounds.Height; /* space for button */
@@ -228,6 +228,6 @@ namespace OpenRA.Mods.Common.Widgets
 		}
 
 		public override string GetCursor(int2 pos) { return null; }
-		public override Widget Clone() { return new MaskWidget(this); }
+		public override MaskWidget Clone() { return new MaskWidget(this); }
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/GradientColorBlockWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/GradientColorBlockWidget.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Widgets
 			GetBottomLeftColor = widget.GetBottomLeftColor;
 		}
 
-		public override Widget Clone()
+		public override GradientColorBlockWidget Clone()
 		{
 			return new GradientColorBlockWidget(this);
 		}

--- a/OpenRA.Mods.Common/Widgets/HotkeyEntryWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/HotkeyEntryWidget.cs
@@ -157,6 +157,6 @@ namespace OpenRA.Mods.Common.Widgets
 				Game.Renderer.DisableScissor();
 		}
 
-		public override Widget Clone() { return new HotkeyEntryWidget(this); }
+		public override HotkeyEntryWidget Clone() { return new HotkeyEntryWidget(this); }
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/ImageWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ImageWidget.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Widgets
 			GetSprite = () => getImageCache.Update((GetImageCollection(), GetImageName()));
 		}
 
-		public override Widget Clone() { return new ImageWidget(this); }
+		public override ImageWidget Clone() { return new ImageWidget(this); }
 
 		public override void Draw()
 		{

--- a/OpenRA.Mods.Common/Widgets/LabelForInputWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LabelForInputWidget.cs
@@ -43,6 +43,6 @@ namespace OpenRA.Mods.Common.Widgets
 			font.DrawText(text, position, textColor.Update(inputWidget.Value.IsDisabled()));
 		}
 
-		public override Widget Clone() { return new LabelForInputWidget(this); }
+		public override LabelForInputWidget Clone() { return new LabelForInputWidget(this); }
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/LabelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LabelWidget.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.Widgets
 				font.DrawText(text, position, color);
 		}
 
-		public override Widget Clone() { return new LabelWidget(this); }
+		public override LabelWidget Clone() { return new LabelWidget(this); }
 
 		public override string GetCursor(int2 pos) { return null; }
 	}

--- a/OpenRA.Mods.Common/Widgets/LabelWithHighlightWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LabelWithHighlightWidget.cs
@@ -81,6 +81,6 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 		}
 
-		public override Widget Clone() { return new LabelWithHighlightWidget(this); }
+		public override LabelWithHighlightWidget Clone() { return new LabelWithHighlightWidget(this); }
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/LabelWithTooltipWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LabelWithTooltipWidget.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Widgets
 			GetTooltipText = other.GetTooltipText;
 		}
 
-		public override Widget Clone() { return new LabelWithTooltipWidget(this); }
+		public override LabelWithTooltipWidget Clone() { return new LabelWithTooltipWidget(this); }
 
 		public override void MouseEntered()
 		{

--- a/OpenRA.Mods.Common/Widgets/LineGraphWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LineGraphWidget.cs
@@ -224,7 +224,7 @@ namespace OpenRA.Mods.Common.Widgets
 			cr.DrawLine(graphOrigin, graphOrigin + new float2(0, -height), 1, Color.White);
 		}
 
-		public override Widget Clone()
+		public override LineGraphWidget Clone()
 		{
 			return new LineGraphWidget(this);
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -744,7 +744,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var allAssetTypes = new[] { AssetType.Sprite, AssetType.Model, AssetType.Audio, AssetType.Video, AssetType.Unknown };
 			foreach (var type in allAssetTypes)
 			{
-				var assetType = (CheckboxWidget)assetTypeTemplate.Clone();
+				var assetType = assetTypeTemplate.Clone();
 				var text = type.ToString();
 				assetType.GetText = () => text;
 				assetType.IsChecked = () => assetTypesToDisplay.HasFlag(type);

--- a/OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipLogic.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				foreach (var line in desc.Split(new[] { "\n" }, StringSplitOptions.None))
 				{
 					descWidth = Math.Max(descWidth, descFont.Measure(line).X);
-					var lineLabel = (LabelWidget)descTemplate.Clone();
+					var lineLabel = descTemplate.Clone();
 					lineLabel.GetText = () => line;
 					lineLabel.Bounds.Y = descOffset;
 					widget.AddChild(lineLabel);

--- a/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					var color = presetColors[colorIndex];
 
-					var newSwatch = (ColorBlockWidget)presetColorTemplate.Clone();
+					var newSwatch = presetColorTemplate.Clone();
 					newSwatch.GetColor = () => color;
 					newSwatch.IsVisible = () => true;
 					newSwatch.Bounds.X = i * newSwatch.Bounds.Width;
@@ -136,7 +136,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					var colorIndex = j * paletteCols + i;
 
-					var newSwatch = (ColorBlockWidget)customColorTemplate.Clone();
+					var newSwatch = customColorTemplate.Clone();
 					var getColor = new CachedTransform<Color, Color>(c => colorManager.MakeValid(c, world.LocalRandom, Array.Empty<Color>(), Array.Empty<Color>()));
 
 					newSwatch.GetColor = () => getColor.Update(Game.Settings.Player.CustomColors[colorIndex]);

--- a/OpenRA.Mods.Common/Widgets/Logic/CreditsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/CreditsLogic.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var font = Game.Renderer.Fonts[template.Font];
 			foreach (var line in modCredits ? modLines : engineLines)
 			{
-				var label = (LabelWidget)template.Clone();
+				var label = template.Clone();
 				label.GetText = () => line;
 				var wrappedLine = line;
 				if (label.WordWrap)

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/CommonSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/CommonSelectorLogic.cs
@@ -145,7 +145,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var categoryHeight = 5 + selectButtons.Bounds.Height;
 			foreach (var cat in FilteredCategories)
 			{
-				var category = (CheckboxWidget)categoryTemplate.Clone();
+				var category = categoryTemplate.Clone();
 				category.GetText = () => cat;
 				category.IsChecked = () => SelectedCategories.Contains(cat);
 				category.IsVisible = () => true;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapOverlaysLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapOverlaysLogic.cs
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			MapOverlays[] allCategories = { MapOverlays.Grid, MapOverlays.Buildable, MapOverlays.Marker };
 			foreach (var cat in allCategories)
 			{
-				var category = (CheckboxWidget)categoryTemplate.Clone();
+				var category = categoryTemplate.Clone();
 				category.GetText = () => cat.ToString();
 				category.IsVisible = () => true;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (visibilityOption == MapVisibility.Shellmap && !map.Visibility.HasFlag(visibilityOption))
 					continue;
 
-				var checkbox = (CheckboxWidget)visOptionTemplate.Clone();
+				var checkbox = visOptionTemplate.Clone();
 				checkbox.GetText = () => visibilityOption.ToString();
 				checkbox.IsChecked = () => map.Visibility.HasFlag(visibilityOption);
 				checkbox.OnClick = () => map.Visibility ^= visibilityOption;

--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -235,7 +235,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				// Create the item manually so the click handlers can refer to itself
 				// This simplifies the rename handling (only needs to update ItemKey)
-				var item = gameTemplate.Clone() as ScrollItemWidget;
+				var item = gameTemplate.Clone();
 				item.ItemKey = savePath;
 				item.IsVisible = () => true;
 				item.IsSelected = () => selectedSave == item.ItemKey;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -298,7 +298,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		ButtonWidget AddButton(string id, string text)
 		{
-			var button = buttonTemplate.Clone() as ButtonWidget;
+			var button = buttonTemplate.Clone();
 			var lastButton = buttons.LastOrDefault();
 			if (lastButton != null)
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromSourceLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromSourceLogic.cs
@@ -337,7 +337,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			listPanel.RemoveChildren();
 			foreach (var package in availablePackages)
 			{
-				var containerWidget = (ContainerWidget)checkboxListTemplate.Clone();
+				var containerWidget = checkboxListTemplate.Clone();
 				var checkboxWidget = containerWidget.Get<CheckboxWidget>("PACKAGE_CHECKBOX");
 				checkboxWidget.GetText = () => package.Title;
 				checkboxWidget.IsDisabled = () => package.Required;
@@ -383,7 +383,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				foreach (var i in kv.Value)
 				{
 					var item = i;
-					var labelWidget = (LabelWidget)labelListTemplate.Clone();
+					var labelWidget = labelListTemplate.Clone();
 					labelWidget.GetText = () => item;
 					listPanel.AddChild(labelWidget);
 				}

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var headerHeight = 0;
 			foreach (var l in headerLines)
 			{
-				var line = (LabelWidget)headerTemplate.Clone();
+				var line = headerTemplate.Clone();
 				line.GetText = () => l;
 				line.Bounds.Y += headerHeight;
 				panel.AddChild(line);

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentPromptLogic.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var headerHeight = 0;
 			foreach (var l in headerLines)
 			{
-				var line = (LabelWidget)headerTemplate.Clone();
+				var line = headerTemplate.Clone();
 				line.GetText = () => l;
 				line.Bounds.Y += headerHeight;
 				panel.AddChild(line);

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentSourceTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentSourceTooltipLogic.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var bottomMargin = sources.Bounds.Height;
 			foreach (var source in sourceTitles)
 			{
-				var label = (LabelWidget)template.Clone();
+				var label = template.Clone();
 				var title = source;
 				label.GetText = () => title;
 				label.Bounds.Y = sources.Bounds.Height;

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				foreach (var panel in panels)
 				{
-					var container = panelTemplate.Clone() as ContainerWidget;
+					var container = panelTemplate.Clone();
 					container.Id = panel.Key;
 					panelContainer.AddChild(container);
 
@@ -167,7 +167,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		ButtonWidget AddSettingsTab(string id, string label)
 		{
-			var tab = tabTemplate.Clone() as ButtonWidget;
+			var tab = tabTemplate.Clone();
 			var lastButton = buttons.LastOrDefault();
 			if (lastButton != null)
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/SimpleTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SimpleTooltipLogic.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var bottom = 0;
 				for (var i = 0; i < lines.Length; i++)
 				{
-					var line = (LabelWidget)label.Clone();
+					var line = label.Clone();
 					var lineText = lines[i];
 					line.Bounds.Y += spacing.Bounds.Y + i * spacing.Bounds.Height;
 					line.Bounds.Width = textWidth;

--- a/OpenRA.Mods.Common/Widgets/Logic/SystemInfoPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SystemInfoPromptLogic.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			foreach (var (name, value) in GetSystemInformation().Values)
 			{
-				var label = template.Clone() as LabelWidget;
+				var label = template.Clone();
 				var text = name + ": " + value;
 				label.GetText = () => text;
 				sysInfoData.AddChild(label);

--- a/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
@@ -116,7 +116,7 @@ namespace OpenRA.Mods.Common.Widgets
 			spawnLabelOffset = ChromeMetrics.Get<int2>("SpawnLabelOffset");
 		}
 
-		public override Widget Clone() { return new MapPreviewWidget(this); }
+		public override MapPreviewWidget Clone() { return new MapPreviewWidget(this); }
 
 		public override bool HandleMouseInput(MouseInput mi)
 		{

--- a/OpenRA.Mods.Common/Widgets/ObserverArmyIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverArmyIconsWidget.cs
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.Common.Widgets
 			Parent.Parent.Bounds.Width = Math.Max(25 + widestChildWidth, Bounds.Left + MinWidth);
 		}
 
-		public override Widget Clone()
+		public override ObserverArmyIconsWidget Clone()
 		{
 			return new ObserverArmyIconsWidget(this);
 		}

--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -234,7 +234,7 @@ namespace OpenRA.Mods.Common.Widgets
 			return WidgetUtils.FormatTime(item.Queue.RemainingTimeActual(item), timestep);
 		}
 
-		public override Widget Clone()
+		public override ObserverProductionIconsWidget Clone()
 		{
 			return new ObserverProductionIconsWidget(this);
 		}

--- a/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
@@ -153,7 +153,7 @@ namespace OpenRA.Mods.Common.Widgets
 			return WidgetUtils.FormatTime(item.RemainingTicks, timestep);
 		}
 
-		public override Widget Clone()
+		public override ObserverSupportPowerIconsWidget Clone()
 		{
 			return new ObserverSupportPowerIconsWidget(this);
 		}

--- a/OpenRA.Mods.Common/Widgets/PasswordFieldWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/PasswordFieldWidget.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using OpenRA.Widgets;
-
 namespace OpenRA.Mods.Common.Widgets
 {
 	public class PasswordFieldWidget : TextFieldWidget
@@ -20,6 +18,6 @@ namespace OpenRA.Mods.Common.Widgets
 			: base(widget) { }
 
 		protected override string GetApparentText() { return new string('*', Text.Length); }
-		public override Widget Clone() { return new PasswordFieldWidget(this); }
+		public override PasswordFieldWidget Clone() { return new PasswordFieldWidget(this); }
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/ProgressBarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProgressBarWidget.cs
@@ -80,6 +80,6 @@ namespace OpenRA.Mods.Common.Widgets
 			wasIndeterminate = indeterminate;
 		}
 
-		public override Widget Clone() { return new ProgressBarWidget(this); }
+		public override ProgressBarWidget Clone() { return new ProgressBarWidget(this); }
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/RGBASpriteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RGBASpriteWidget.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Widgets
 			GetSprite = other.GetSprite;
 		}
 
-		public override Widget Clone() { return new RGBASpriteWidget(this); }
+		public override RGBASpriteWidget Clone() { return new RGBASpriteWidget(this); }
 
 		public override void Draw()
 		{

--- a/OpenRA.Mods.Common/Widgets/ResourcePreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ResourcePreviewWidget.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Widgets
 			IdealPreviewSize = other.IdealPreviewSize;
 		}
 
-		public override Widget Clone() { return new ResourcePreviewWidget(this); }
+		public override ResourcePreviewWidget Clone() { return new ResourcePreviewWidget(this); }
 
 		public override void Draw()
 		{

--- a/OpenRA.Mods.Common/Widgets/ScrollItemWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollItemWidget.cs
@@ -68,11 +68,11 @@ namespace OpenRA.Mods.Common.Widgets
 			WidgetUtils.DrawPanel(RenderBounds, getPanelCache.Update((IsDisabled(), Depressed, hover, false, IsSelected() || IsHighlighted())));
 		}
 
-		public override Widget Clone() { return new ScrollItemWidget(this); }
+		public override ScrollItemWidget Clone() { return new ScrollItemWidget(this); }
 
 		public static ScrollItemWidget Setup(ScrollItemWidget template, Func<bool> isSelected, Action onClick)
 		{
-			var w = template.Clone() as ScrollItemWidget;
+			var w = template.Clone();
 			w.IsVisible = () => true;
 			w.IsSelected = isSelected;
 			w.OnClick = onClick;

--- a/OpenRA.Mods.Common/Widgets/SliderWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SliderWidget.cs
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Common.Widgets
 			return (int)(0.5f * RenderBounds.Height + (RenderBounds.Width - RenderBounds.Height) * (x - MinimumValue) / (MaximumValue - MinimumValue));
 		}
 
-		public override Widget Clone() { return new SliderWidget(this); }
+		public override SliderWidget Clone() { return new SliderWidget(this); }
 
 		Rectangle ThumbRect
 		{

--- a/OpenRA.Mods.Common/Widgets/SpriteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SpriteWidget.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Widgets
 			WorldRenderer = other.WorldRenderer;
 		}
 
-		public override Widget Clone() { return new SpriteWidget(this); }
+		public override SpriteWidget Clone() { return new SpriteWidget(this); }
 
 		Sprite cachedSprite = null;
 		string cachedPalette = null;

--- a/OpenRA.Mods.Common/Widgets/TerrainTemplatePreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TerrainTemplatePreviewWidget.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Widgets
 			GetScale = other.GetScale;
 		}
 
-		public override Widget Clone() { return new TerrainTemplatePreviewWidget(this); }
+		public override TerrainTemplatePreviewWidget Clone() { return new TerrainTemplatePreviewWidget(this); }
 
 		public void SetTemplate(TerrainTemplateInfo template)
 		{

--- a/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
@@ -600,6 +600,6 @@ namespace OpenRA.Mods.Common.Widgets
 				Game.Renderer.DisableScissor();
 		}
 
-		public override Widget Clone() { return new TextFieldWidget(this); }
+		public override TextFieldWidget Clone() { return new TextFieldWidget(this); }
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/WorldButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldButtonWidget.cs
@@ -39,6 +39,6 @@ namespace OpenRA.Mods.Common.Widgets
 				new WidgetArgs { { "button", this }, { "getText", GetTooltipText }, { "getDesc", GetTooltipDesc }, { "world", world } });
 		}
 
-		public override Widget Clone() { return new WorldButtonWidget(this); }
+		public override WorldButtonWidget Clone() { return new WorldButtonWidget(this); }
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/WorldLabelWithTooltipWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldLabelWithTooltipWidget.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Widgets
 			world = other.world;
 		}
 
-		public override Widget Clone() { return new WorldLabelWithTooltipWidget(this); }
+		public override WorldLabelWithTooltipWidget Clone() { return new WorldLabelWithTooltipWidget(this); }
 
 		public override void MouseEntered()
 		{

--- a/OpenRA.Mods.D2k/Graphics/D2kSpriteSequence.cs
+++ b/OpenRA.Mods.D2k/Graphics/D2kSpriteSequence.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.D2k.Graphics
 		public D2kSpriteSequenceLoader(ModData modData)
 			: base(modData) { }
 
-		public override ISpriteSequence CreateSequence(
+		public override D2kSpriteSequence CreateSequence(
 			ModData modData, string tileset, SpriteCache cache, string image, string sequence, MiniYaml data, MiniYaml defaults)
 		{
 			return new D2kSpriteSequence(cache, this, image, sequence, data, defaults);


### PR DESCRIPTION
Use the covariant return type feature of C# 9 to allow method overrides to be more specific about their return type. By exposing this information, e.g. for Widget.Clone(), callers will have more information. This allows various casts to be removed as the information is now available within the type system.