### PR TITLE
Fix being able to click through some areas of the chrome

### DIFF
--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -626,7 +626,11 @@ namespace OpenRA.Widgets
 
 		public ContainerWidget() { IgnoreMouseOver = true; }
 		public ContainerWidget(ContainerWidget other)
-			: base(other) { IgnoreMouseOver = true; }
+			: base(other)
+		{
+			ClickThrough = other.ClickThrough;
+			IgnoreMouseOver = true;
+		}
 
 		public override string GetCursor(int2 pos) { return null; }
 		public override Widget Clone() { return new ContainerWidget(this); }

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -28,7 +28,7 @@ Container@PLAYER_WIDGETS:
 		Image@COMMAND_BAR_BACKGROUND:
 			X: 0
 			Y: WINDOW_BOTTOM - HEIGHT
-			Width: 416
+			Width: 451
 			Height: 43
 			ImageCollection: commandbar
 			ImageName: background

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -431,14 +431,18 @@ Container@PLAYER_WIDGETS:
 			Children:
 				Container@PALETTE_BACKGROUND:
 					Children:
-						Image@ROW_TEMPLATE:
-							Logic: AddFactionSuffixLogic
-							X: 40
-							Width: 190
+						Container@ROW_TEMPLATE:
+							Width: 238
 							Height: 47
 							ClickThrough: false
-							ImageCollection: sidebar
-							ImageName: background-iconbg
+							Children:
+								Image@ROW_BGND:
+									Logic: AddFactionSuffixLogic
+									X: 40
+									Width: 190
+									Height: 47
+									ImageCollection: sidebar
+									ImageName: background-iconbg
 						Image@BOTTOM_CAP:
 							Logic: AddFactionSuffixLogic
 							Width: 238

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -43,7 +43,7 @@ Container@PLAYER_WIDGETS:
 		Image@COMMAND_BAR_BACKGROUND:
 			X: 5
 			Y: WINDOW_BOTTOM - HEIGHT - 5
-			Width: 416
+			Width: 434
 			Height: 44
 			ImageCollection: commandbar
 			ImageName: background


### PR DESCRIPTION
The production palette in RA is assembled from a foreground and a background. The foreground provides most of the visible graphics (such as the metallic chrome) but it has to let clicks go through to the production icons. The background is the one that has to stop the clicks then but it was not wide enough (because the art is only for the background behind production icons and not the whole chrome). Trying to fix that by wrapping the image in wider container that has `ClickThrough` set to `false` revealed that there is a bug with the cloning logic for `ContainerWidget`. It simply did not copy the `ClickThrough` field and it was always `true` for cloned widgets. So the value in YAML was lost when the template was cloned.

Before:
![image](https://github.com/user-attachments/assets/bbe1cf3b-dfd7-4190-88fd-d59d7ddf181c)
![image](https://github.com/user-attachments/assets/cec46672-c373-4d11-84c0-0c441d7694fd)
![image](https://github.com/user-attachments/assets/ef19e552-6826-415a-bfef-68eede3d6c40)

After:
![image](https://github.com/user-attachments/assets/05932ea5-54c4-46df-8415-b03e30dec60d)
![image](https://github.com/user-attachments/assets/ed2b0366-64e9-4327-b142-1b257df25da1)
![image](https://github.com/user-attachments/assets/09c069d2-3093-4671-9476-8cdae657ce2b)



