### PR TITLE
Remove drag support from `BackgroundWidget`

### DIFF
--- a/OpenRA.Mods.Common/Widgets/BackgroundWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/BackgroundWidget.cs
@@ -16,7 +16,6 @@ namespace OpenRA.Mods.Common.Widgets
 	public class BackgroundWidget : Widget
 	{
 		public readonly bool ClickThrough = false;
-		public readonly bool Draggable = false;
 		public string Background = "dialog";
 
 		public override void Draw()
@@ -26,36 +25,10 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public BackgroundWidget() { }
 
-		bool moving;
-		int2? prevMouseLocation;
-
 		public override bool HandleMouseInput(MouseInput mi)
 		{
 			if (ClickThrough || !RenderBounds.Contains(mi.Location))
 				return false;
-
-			if (!Draggable || (moving && (!TakeMouseFocus(mi) || mi.Button != MouseButton.Left)))
-				return true;
-
-			if (prevMouseLocation == null)
-				prevMouseLocation = mi.Location;
-			var vec = mi.Location - (int2)prevMouseLocation;
-			prevMouseLocation = mi.Location;
-			switch (mi.Event)
-			{
-				case MouseInputEvent.Up:
-					moving = false;
-					YieldMouseFocus(mi);
-					break;
-				case MouseInputEvent.Down:
-					moving = true;
-					Bounds = new WidgetBounds(Bounds.X + vec.X, Bounds.Y + vec.Y, Bounds.Width, Bounds.Height);
-					break;
-				case MouseInputEvent.Move:
-					if (moving)
-						Bounds = new WidgetBounds(Bounds.X + vec.X, Bounds.Y + vec.Y, Bounds.Width, Bounds.Height);
-					break;
-			}
 
 			return true;
 		}
@@ -65,7 +38,6 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			Background = other.Background;
 			ClickThrough = other.ClickThrough;
-			Draggable = other.Draggable;
 		}
 
 		public override Widget Clone() { return new BackgroundWidget(this); }

--- a/OpenRA.Mods.Common/Widgets/BackgroundWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/BackgroundWidget.cs
@@ -27,10 +27,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override bool HandleMouseInput(MouseInput mi)
 		{
-			if (ClickThrough || !RenderBounds.Contains(mi.Location))
-				return false;
-
-			return true;
+			return !ClickThrough && EventBounds.Contains(mi.Location);
 		}
 
 		protected BackgroundWidget(BackgroundWidget other)


### PR DESCRIPTION
This was not used anywhere, was somewhat buggy and could be implemented in a better way when needed.