### PR TITLE
Replace hardcoded mod.yaml Packages list with a mod-defined filesystem loader

### DIFF
--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -181,12 +181,8 @@ namespace OpenRA.FileSystem
 			fileIndex = new Cache<string, List<IReadOnlyPackage>>(_ => new List<IReadOnlyPackage>());
 		}
 
-		public void LoadFromManifest(Manifest manifest)
+		public void TrimExcess()
 		{
-			UnmountAll();
-			foreach (var kv in manifest.Packages)
-				Mount(kv.Key, kv.Value);
-
 			mountedPackages.TrimExcess();
 			explicitMounts.TrimExcess();
 			modPackages.TrimExcess();

--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -277,40 +277,6 @@ namespace OpenRA.FileSystem
 			return !filename.StartsWith($"{modID}|", StringComparison.Ordinal);
 		}
 
-		/// <summary>
-		/// Resolves a filesystem for an assembly, accounting for explicit and mod mounts.
-		/// Assemblies must exist in the native OS file system (not inside an OpenRA-defined package).
-		/// </summary>
-		public static string ResolveAssemblyPath(string path, Manifest manifest, InstalledMods installedMods)
-		{
-			var explicitSplit = path.IndexOf('|');
-			if (explicitSplit > 0 && !path.StartsWith('^'))
-			{
-				var parent = path[..explicitSplit];
-				var filename = path[(explicitSplit + 1)..];
-
-				var parentPath = manifest.Packages.FirstOrDefault(kv => kv.Value == parent).Key;
-				if (parentPath == null)
-					return null;
-
-				if (parentPath.StartsWith('$'))
-				{
-					if (!installedMods.TryGetValue(parentPath[1..], out var mod))
-						return null;
-
-					if (mod.Package is not Folder)
-						return null;
-
-					path = Path.Combine(mod.Package.Name, filename);
-				}
-				else
-					path = Path.Combine(parentPath, filename);
-			}
-
-			var resolvedPath = Platform.ResolvePath(path);
-			return File.Exists(resolvedPath) ? resolvedPath : null;
-		}
-
 		public static string ResolveCaseInsensitivePath(string path)
 		{
 			var resolved = Path.GetPathRoot(path);

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -65,8 +65,8 @@ namespace OpenRA
 			Weapons, Voices, Notifications, Music, Translations, TileSets,
 			ChromeMetrics, MapCompatibility, Missions, Hotkeys;
 
-		public readonly IReadOnlyDictionary<string, string> Packages;
 		public readonly IReadOnlyDictionary<string, string> MapFolders;
+		public readonly MiniYaml FileSystem;
 		public readonly MiniYaml LoadScreen;
 		public readonly string DefaultOrderGenerator;
 
@@ -81,7 +81,7 @@ namespace OpenRA
 
 		readonly string[] reservedModuleNames =
 		{
-			"Include", "Metadata", "Folders", "MapFolders", "Packages", "Rules",
+			"Include", "Metadata", "FileSystem", "MapFolders", "Rules",
 			"Sequences", "ModelSequences", "Cursors", "Chrome", "Assemblies", "ChromeLayout", "Weapons",
 			"Voices", "Notifications", "Music", "Translations", "TileSets", "ChromeMetrics", "Missions", "Hotkeys",
 			"ServerTraits", "LoadScreen", "DefaultOrderGenerator", "SupportsMapsFrom", "SoundFormats", "SpriteFormats", "VideoFormats",
@@ -123,8 +123,8 @@ namespace OpenRA
 			// TODO: Use fieldloader
 			MapFolders = YamlDictionary(yaml, "MapFolders");
 
-			if (yaml.TryGetValue("Packages", out var packages))
-				Packages = packages.ToDictionary(x => x.Value);
+			if (!yaml.TryGetValue("FileSystem", out FileSystem))
+				throw new InvalidDataException("`FileSystem` section is not defined.");
 
 			Rules = YamlList(yaml, "Rules");
 			Sequences = YamlList(yaml, "Sequences");

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -61,7 +61,7 @@ namespace OpenRA
 		public readonly ModMetadata Metadata;
 		public readonly string[]
 			Rules, ServerTraits,
-			Sequences, ModelSequences, Cursors, Chrome, Assemblies, ChromeLayout,
+			Sequences, ModelSequences, Cursors, Chrome, ChromeLayout,
 			Weapons, Voices, Notifications, Music, Translations, TileSets,
 			ChromeMetrics, MapCompatibility, Missions, Hotkeys;
 
@@ -70,6 +70,7 @@ namespace OpenRA
 		public readonly MiniYaml LoadScreen;
 		public readonly string DefaultOrderGenerator;
 
+		public readonly string[] Assemblies = Array.Empty<string>();
 		public readonly string[] SoundFormats = Array.Empty<string>();
 		public readonly string[] SpriteFormats = Array.Empty<string>();
 		public readonly string[] PackageFormats = Array.Empty<string>();
@@ -130,7 +131,6 @@ namespace OpenRA
 			ModelSequences = YamlList(yaml, "ModelSequences");
 			Cursors = YamlList(yaml, "Cursors");
 			Chrome = YamlList(yaml, "Chrome");
-			Assemblies = YamlList(yaml, "Assemblies");
 			ChromeLayout = YamlList(yaml, "ChromeLayout");
 			Weapons = YamlList(yaml, "Weapons");
 			Voices = YamlList(yaml, "Voices");
@@ -157,6 +157,9 @@ namespace OpenRA
 
 			if (yaml.TryGetValue("DefaultOrderGenerator", out entry))
 				DefaultOrderGenerator = entry.Value;
+
+			if (yaml.TryGetValue("Assemblies", out entry))
+				Assemblies = FieldLoader.GetValue<string[]>("Assemblies", entry.Value);
 
 			if (yaml.TryGetValue("PackageFormats", out entry))
 				PackageFormats = FieldLoader.GetValue<string[]>("PackageFormats", entry.Value);

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -35,6 +35,8 @@ namespace OpenRA
 		public readonly ISpriteSequenceLoader SpriteSequenceLoader;
 		public readonly IVideoLoader[] VideoLoaders;
 		public readonly HotkeyManager Hotkeys;
+		public readonly IFileSystemLoader FileSystemLoader;
+
 		public ILoadScreen LoadScreen { get; }
 		public CursorProvider CursorProvider { get; private set; }
 		public FS ModFiles;
@@ -54,9 +56,13 @@ namespace OpenRA
 			Manifest = new Manifest(mod.Id, mod.Package);
 			ObjectCreator = new ObjectCreator(Manifest, mods);
 			PackageLoaders = ObjectCreator.GetLoaders<IPackageLoader>(Manifest.PackageFormats, "package");
-
 			ModFiles = new FS(mod.Id, mods, PackageLoaders);
-			ModFiles.LoadFromManifest(Manifest);
+
+			FileSystemLoader = ObjectCreator.GetLoader<IFileSystemLoader>(Manifest.FileSystem.Value, "filesystem");
+			FieldLoader.Load(FileSystemLoader, Manifest.FileSystem);
+			FileSystemLoader.Mount(ModFiles, ObjectCreator);
+			ModFiles.TrimExcess();
+
 			Manifest.LoadCustomData(ObjectCreator);
 
 			if (useLoadScreen)
@@ -189,5 +195,10 @@ namespace OpenRA
 
 		/// <summary>Called when the engine expects to connect to a server/replay or load the shellmap.</summary>
 		void StartGame(Arguments args);
+	}
+
+	public interface IFileSystemLoader
+	{
+		void Mount(FS fileSystem, ObjectCreator objectCreator);
 	}
 }

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -165,17 +165,20 @@ namespace OpenRA
 				.SelectMany(ma => ma.GetTypes());
 		}
 
+		public TLoader GetLoader<TLoader>(string format, string name)
+		{
+			var loader = FindType(format + "Loader");
+			if (loader == null || !loader.GetInterfaces().Contains(typeof(TLoader)))
+				throw new InvalidOperationException($"Unable to find a {name} loader for type '{format}'.");
+
+			return (TLoader)CreateBasic(loader);
+		}
+
 		public TLoader[] GetLoaders<TLoader>(IEnumerable<string> formats, string name)
 		{
 			var loaders = new List<TLoader>();
 			foreach (var format in formats)
-			{
-				var loader = FindType(format + "Loader");
-				if (loader == null || !loader.GetInterfaces().Contains(typeof(TLoader)))
-					throw new InvalidOperationException($"Unable to find a {name} loader for type '{format}'.");
-
-				loaders.Add((TLoader)CreateBasic(loader));
-			}
+				loaders.Add(GetLoader<TLoader>(format, name));
 
 			return loaders.ToArray();
 		}

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -34,16 +34,10 @@ namespace OpenRA
 			ctorCache = new Cache<Type, ConstructorInfo>(GetCtor);
 
 			// Allow mods to load types from the core Game assembly, and any additional assemblies they specify.
-			// Assemblies can only be loaded from directories to avoid circular dependencies on package loaders.
+			// Assemblies must exist in the game binary directory next to the main game executable.
 			var assemblyList = new List<Assembly>() { typeof(Game).Assembly };
-			foreach (var path in manifest.Assemblies)
-			{
-				var resolvedPath = FileSystem.FileSystem.ResolveAssemblyPath(path, manifest, mods);
-				if (resolvedPath == null)
-					throw new FileNotFoundException($"Assembly `{path}` not found.");
-
-				LoadAssembly(assemblyList, resolvedPath);
-			}
+			foreach (var filename in manifest.Assemblies)
+				LoadAssembly(assemblyList, Path.Combine(Platform.BinDir, filename));
 
 			AppDomain.CurrentDomain.AssemblyResolve += ResolveAssembly;
 			assemblies = assemblyList.SelectMany(asm => asm.GetNamespaces().Select(ns => (asm, ns))).ToArray();

--- a/OpenRA.Mods.Common/FileSystem/DefaultFileSystemLoader.cs
+++ b/OpenRA.Mods.Common/FileSystem/DefaultFileSystemLoader.cs
@@ -1,0 +1,27 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.FileSystem
+{
+	public class DefaultFileSystemLoader : IFileSystemLoader
+	{
+		public readonly Dictionary<string, string> Packages = null;
+
+		public void Mount(OpenRA.FileSystem.FileSystem fileSystem, ObjectCreator objectCreator)
+		{
+			if (Packages != null)
+				foreach (var kv in Packages)
+					fileSystem.Mount(kv.Key, kv.Value);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
@@ -12,8 +12,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using OpenRA.FileFormats;
+using OpenRA.Mods.Common.FileSystem;
 using OpenRA.Mods.Common.Widgets.Logic;
 using OpenRA.Widgets;
 
@@ -126,21 +126,10 @@ namespace OpenRA.Mods.Common.LoadScreens
 			if (graphicSettings.GLProfile != GLProfile.Automatic && graphicSettings.GLProfile != Game.Renderer.GLProfile)
 				graphicSettings.GLProfile = GLProfile.Automatic;
 
-			// If a ModContent section is defined then we need to make sure that the
-			// required content is installed or switch to the defined content installer.
-			if (!ModData.Manifest.Contains<ModContent>())
+			if (ModData.FileSystemLoader is not IFileSystemExternalContent content)
 				return true;
 
-			var content = ModData.Manifest.Get<ModContent>();
-			var contentInstalled = content.Packages
-				.Where(p => p.Value.Required)
-				.All(p => p.Value.TestFiles.All(f => File.Exists(Platform.ResolvePath(f))));
-
-			if (contentInstalled)
-				return true;
-
-			Game.InitializeMod(content.ContentInstallerMod, new Arguments(new[] { "Content.Mod=" + ModData.Manifest.Id }));
-			return false;
+			return !content.InstallContentIfRequired(ModData);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
@@ -42,7 +42,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var modObjectCreator = new ObjectCreator(mod, Game.Mods);
 			var modPackageLoaders = modObjectCreator.GetLoaders<IPackageLoader>(mod.PackageFormats, "package");
 			var modFileSystem = new FS(mod.Id, Game.Mods, modPackageLoaders);
-			modFileSystem.LoadFromManifest(mod);
+
+			var modFileSystemLoader = modObjectCreator.GetLoader<IFileSystemLoader>(mod.FileSystem.Value, "filesystem");
+			FieldLoader.Load(modFileSystemLoader, mod.FileSystem);
+			modFileSystemLoader.Mount(modFileSystem, modObjectCreator);
+			modFileSystem.TrimExcess();
 
 			var sourceYaml = MiniYaml.Load(modFileSystem, content.Sources, null);
 			foreach (var s in sourceYaml)

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentPromptLogic.cs
@@ -78,7 +78,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var modObjectCreator = new ObjectCreator(mod, Game.Mods);
 				var modPackageLoaders = modObjectCreator.GetLoaders<IPackageLoader>(mod.PackageFormats, "package");
 				var modFileSystem = new FS(mod.Id, Game.Mods, modPackageLoaders);
-				modFileSystem.LoadFromManifest(mod);
+
+				var modFileSystemLoader = modObjectCreator.GetLoader<IFileSystemLoader>(mod.FileSystem.Value, "filesystem");
+				FieldLoader.Load(modFileSystemLoader, mod.FileSystem);
+				modFileSystemLoader.Mount(modFileSystem, modObjectCreator);
+				modFileSystem.TrimExcess();
 
 				var downloadYaml = MiniYaml.Load(modFileSystem, content.Downloads, null);
 				modFileSystem.UnmountAll();

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -80,16 +80,25 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			mainMenu.Get<ButtonWidget>("MULTIPLAYER_BUTTON").OnClick = OpenMultiplayerPanel;
 
-			mainMenu.Get<ButtonWidget>("CONTENT_BUTTON").OnClick = () =>
+			var contentButton = mainMenu.GetOrNull<ButtonWidget>("CONTENT_BUTTON");
+			if (contentButton != null)
 			{
-				// Switching mods changes the world state (by disposing it),
-				// so we can't do this inside the input handler.
-				Game.RunAfterTick(() =>
+				var hasContent = modData.Manifest.Contains<ModContent>();
+				contentButton.Disabled = !hasContent;
+				contentButton.OnClick = () =>
 				{
-					var content = modData.Manifest.Get<ModContent>();
-					Game.InitializeMod(content.ContentInstallerMod, new Arguments(new[] { "Content.Mod=" + modData.Manifest.Id }));
-				});
-			};
+					// Switching mods changes the world state (by disposing it),
+					// so we can't do this inside the input handler.
+					Game.RunAfterTick(() =>
+					{
+						if (!hasContent)
+							return;
+
+						var content = modData.Manifest.Get<ModContent>();
+						Game.InitializeMod(content.ContentInstallerMod, new Arguments(new[] { "Content.Mod=" + modData.Manifest.Id }));
+					});
+				};
+			}
 
 			mainMenu.Get<ButtonWidget>("SETTINGS_BUTTON").OnClick = () =>
 			{

--- a/mods/all/mod.yaml
+++ b/mods/all/mod.yaml
@@ -3,8 +3,9 @@ Metadata:
 	Version: {DEV_VERSION}
 	Hidden: true
 
-Packages:
-	^EngineDir
+FileSystem: DefaultFileSystem
+    Packages:
+		^EngineDir
 
 Cursors:
 

--- a/mods/all/mod.yaml
+++ b/mods/all/mod.yaml
@@ -10,10 +10,7 @@ Cursors:
 
 Chrome:
 
-Assemblies:
-	^BinDir|OpenRA.Mods.Common.dll
-	^BinDir|OpenRA.Mods.Cnc.dll
-	^BinDir|OpenRA.Mods.D2k.dll
+Assemblies: OpenRA.Mods.Common.dll, OpenRA.Mods.Cnc.dll, OpenRA.Mods.D2k.dll
 
 ChromeLayout:
 

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -89,9 +89,7 @@ Cursors:
 Chrome:
 	cnc|chrome.yaml
 
-Assemblies:
-	^BinDir|OpenRA.Mods.Common.dll
-	^BinDir|OpenRA.Mods.Cnc.dll
+Assemblies: OpenRA.Mods.Common.dll, OpenRA.Mods.Cnc.dll
 
 ChromeLayout:
 	cnc|chrome/mainmenu.yaml

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -7,33 +7,34 @@ Metadata:
 
 PackageFormats: Mix
 
-Packages:
-	~^SupportDir|Content/cnc
-	~^SupportDir|Content/cnc/movies
-	^EngineDir
-	$cnc: cnc
-	^EngineDir|mods/common: common
-	~speech.mix
-	~conquer.mix
-	~sounds.mix
-	~tempicnh.mix
-	~temperat.mix
-	~winter.mix
-	~desert.mix
-	~movies.mix
-	~scores.mix
-	~scores2.mix
-	~scores-covertops.mix
-	~transit.mix
-	~general.mix
-	cnc|bits/snow.mix
-	cnc|bits
-	cnc|bits/jungle
-	cnc|bits/desert
-	cnc|bits/ss
-	cnc|scripts
-	common|scripts
-	cnc|uibits
+FileSystem: DefaultFileSystem
+    Packages:
+		~^SupportDir|Content/cnc
+		~^SupportDir|Content/cnc/movies
+		^EngineDir
+		$cnc: cnc
+		^EngineDir|mods/common: common
+		~speech.mix
+		~conquer.mix
+		~sounds.mix
+		~tempicnh.mix
+		~temperat.mix
+		~winter.mix
+		~desert.mix
+		~movies.mix
+		~scores.mix
+		~scores2.mix
+		~scores-covertops.mix
+		~transit.mix
+		~general.mix
+		cnc|bits/snow.mix
+		cnc|bits
+		cnc|bits/jungle
+		cnc|bits/desert
+		cnc|bits/ss
+		cnc|scripts
+		common|scripts
+		cnc|uibits
 
 MapFolders:
 	cnc|maps: System

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -7,20 +7,20 @@ Metadata:
 
 PackageFormats: D2kSoundResources
 
-Packages:
-	~^SupportDir|Content/d2k/v3/
-	~^SupportDir|Content/d2k/v3/GAMESFX
-	~^SupportDir|Content/d2k/v3/Movies
-	~^SupportDir|Content/d2k/v3/Music
-	^EngineDir
-	$d2k: d2k
-	^EngineDir|mods/common: common
-
-	~SOUND.RS
-	d2k|bits
-	d2k|scripts
-	common|scripts
-	d2k|uibits
+FileSystem: DefaultFileSystem
+    Packages:
+		~^SupportDir|Content/d2k/v3/
+		~^SupportDir|Content/d2k/v3/GAMESFX
+		~^SupportDir|Content/d2k/v3/Movies
+		~^SupportDir|Content/d2k/v3/Music
+		^EngineDir
+		$d2k: d2k
+		^EngineDir|mods/common: common
+		~SOUND.RS
+		d2k|bits
+		d2k|scripts
+		common|scripts
+		d2k|uibits
 
 MapFolders:
 	d2k|maps: System

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -62,10 +62,7 @@ Cursors:
 Chrome:
 	d2k|chrome.yaml
 
-Assemblies:
-	^BinDir|OpenRA.Mods.Common.dll
-	^BinDir|OpenRA.Mods.Cnc.dll
-	^BinDir|OpenRA.Mods.D2k.dll
+Assemblies: OpenRA.Mods.Common.dll, OpenRA.Mods.Cnc.dll, OpenRA.Mods.D2k.dll
 
 ChromeLayout:
 	common|chrome/ingame.yaml

--- a/mods/modcontent/mod.yaml
+++ b/mods/modcontent/mod.yaml
@@ -3,10 +3,11 @@ Metadata:
 	Version: {DEV_VERSION}
 	Hidden: true
 
-Packages:
-	^EngineDir
-	^EngineDir|mods/modcontent: modcontent
-	^EngineDir|mods/common: common
+FileSystem: DefaultFileSystem
+    Packages:
+		^EngineDir
+		^EngineDir|mods/modcontent: modcontent
+		^EngineDir|mods/common: common
 
 Rules:
 	modcontent|rules.yaml

--- a/mods/modcontent/mod.yaml
+++ b/mods/modcontent/mod.yaml
@@ -17,8 +17,7 @@ Cursors:
 Chrome:
 	modcontent|chrome.yaml
 
-Assemblies:
-	^BinDir|OpenRA.Mods.Common.dll
+Assemblies: OpenRA.Mods.Common.dll
 
 ChromeLayout:
 	modcontent|content.yaml

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -7,36 +7,37 @@ Metadata:
 
 PackageFormats: Mix
 
-Packages:
-	~^SupportDir|Content/ra/v2/
-	~^SupportDir|Content/ra/v2/expand
-	~^SupportDir|Content/ra/v2/cnc
-	~^SupportDir|Content/ra/v2/movies
-	^EngineDir
-	$ra: ra
-	^EngineDir|mods/common: common
-	~main.mix
-	~conquer.mix
-	~lores.mix: lores
-	~hires.mix
-	~local.mix
-	~sounds.mix
-	~speech.mix
-	~allies.mix
-	~russian.mix
-	~temperat.mix
-	~snow.mix
-	~interior.mix
-	~scores.mix
-	~expand2.mix
-	~hires1.mix
-	~desert.mix
-	~general.mix
-	ra|bits
-	ra|bits/desert
-	ra|scripts
-	common|scripts
-	ra|uibits
+FileSystem: DefaultFileSystem
+    Packages:
+		~^SupportDir|Content/ra/v2/
+		~^SupportDir|Content/ra/v2/expand
+		~^SupportDir|Content/ra/v2/cnc
+		~^SupportDir|Content/ra/v2/movies
+		^EngineDir
+		$ra: ra
+		^EngineDir|mods/common: common
+		~main.mix
+		~conquer.mix
+		~lores.mix: lores
+		~hires.mix
+		~local.mix
+		~sounds.mix
+		~speech.mix
+		~allies.mix
+		~russian.mix
+		~temperat.mix
+		~snow.mix
+		~interior.mix
+		~scores.mix
+		~expand2.mix
+		~hires1.mix
+		~desert.mix
+		~general.mix
+		ra|bits
+		ra|bits/desert
+		ra|scripts
+		common|scripts
+		ra|uibits
 
 MapFolders:
 	ra|maps: System

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -80,9 +80,7 @@ Cursors:
 Chrome:
 	ra|chrome.yaml
 
-Assemblies:
-	^BinDir|OpenRA.Mods.Common.dll
-	^BinDir|OpenRA.Mods.Cnc.dll
+Assemblies: OpenRA.Mods.Common.dll, OpenRA.Mods.Cnc.dll
 
 ChromeLayout:
 	common|chrome/ingame.yaml

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -7,48 +7,49 @@ Metadata:
 
 PackageFormats: Mix
 
-Packages:
-	~^SupportDir|Content/ts
-	~^SupportDir|Content/ts/firestorm
-	^EngineDir
-	$ts: ts
-	^EngineDir|mods/common: common
+FileSystem: DefaultFileSystem
+    Packages:
+		~^SupportDir|Content/ts
+		~^SupportDir|Content/ts/firestorm
+		^EngineDir
+		$ts: ts
+		^EngineDir|mods/common: common
 
-	# Tiberian Sun
-	~scores.mix
-	~sidenc01.mix
-	~sidenc02.mix
-	~e01scd01.mix
-	~e01scd02.mix
-	~movies01.mix
-	~movies02.mix
-	~sidecd01.mix
-	~sidecd02.mix
-	~cache.mix
-	~conquer.mix
-	~isosnow.mix
-	~isotemp.mix
-	~local.mix
-	~sidec01.mix: sidebar-gdi
-	~sidec02.mix: sidebar-nod
-	~sno.mix
-	~snow.mix
-	~sounds.mix
-	~speech01.mix: speech-gdi
-	~speech02.mix: speech-nod
-	~tem.mix
-	~temperat.mix
-	# Firestorm
-	~scores01.mix
-	~expand01.mix
-	~sounds01.mix
-	~e01sc01.mix
-	~e01sc02.mix
-	~e01vox01.mix
-	~e01vox02.mix
-	~ecache01.mix
-	ts|bits
-	ts|uibits
+		# Tiberian Sun
+		~scores.mix
+		~sidenc01.mix
+		~sidenc02.mix
+		~e01scd01.mix
+		~e01scd02.mix
+		~movies01.mix
+		~movies02.mix
+		~sidecd01.mix
+		~sidecd02.mix
+		~cache.mix
+		~conquer.mix
+		~isosnow.mix
+		~isotemp.mix
+		~local.mix
+		~sidec01.mix: sidebar-gdi
+		~sidec02.mix: sidebar-nod
+		~sno.mix
+		~snow.mix
+		~sounds.mix
+		~speech01.mix: speech-gdi
+		~speech02.mix: speech-nod
+		~tem.mix
+		~temperat.mix
+		# Firestorm
+		~scores01.mix
+		~expand01.mix
+		~sounds01.mix
+		~e01sc01.mix
+		~e01sc02.mix
+		~e01vox01.mix
+		~e01vox02.mix
+		~ecache01.mix
+		ts|bits
+		ts|uibits
 
 MapFolders:
 	ts|maps: System

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -124,9 +124,7 @@ Cursors:
 Chrome:
 	ts|chrome.yaml
 
-Assemblies:
-	^BinDir|OpenRA.Mods.Common.dll
-	^BinDir|OpenRA.Mods.Cnc.dll
+Assemblies: OpenRA.Mods.Common.dll, OpenRA.Mods.Cnc.dll
 
 ChromeLayout:
 	common|chrome/ingame.yaml


### PR DESCRIPTION
This PR allows mod code to customize the way that the filesystem is mounted. This makes it possible for mods to find and mount content dynamically without relying on load screen hacks and duplicated utility commands.

Corresponding TDHD commit showing the benefits of this PR: https://github.com/OpenRA/TiberianDawnHD/commit/9645e001e2031d61a87594cdd68f011ac2292a77