### PR TITLE
Remove key handling from `ContainerWidget`

### DIFF
--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -632,8 +632,6 @@ namespace OpenRA.Widgets
 
 		public override string GetCursor(int2 pos) { return null; }
 		public override Widget Clone() { return new ContainerWidget(this); }
-		public Func<KeyInput, bool> OnKeyPress = _ => false;
-		public override bool HandleKeyPress(KeyInput e) { return OnKeyPress(e); }
 
 		public override bool HandleMouseInput(MouseInput mi)
 		{

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -209,7 +209,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var chatClose = chatChrome.Get<ButtonWidget>("CHAT_CLOSE");
 				chatClose.OnClick += CloseChat;
 
-				chatPanel.OnKeyPress = e =>
+				var openChatKeyListener = chatPanel.Get<LogicKeyListenerWidget>("OPEN_CHAT_KEY_LISTENER");
+
+				openChatKeyListener.AddHandler(e =>
 				{
 					if (e.Event == KeyInputEvent.Up)
 						return false;
@@ -223,7 +225,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					}
 
 					return false;
-				};
+				});
 			}
 
 			chatScrollPanel = chatChrome.Get<ScrollPanelWidget>("CHAT_SCROLLPANEL");

--- a/mods/cnc/chrome/ingame-chat.yaml
+++ b/mods/cnc/chrome/ingame-chat.yaml
@@ -11,6 +11,7 @@ Container@CHAT_PANEL:
 			System: SYSTEM_LINE_TEMPLATE
 			Mission: CHAT_LINE_TEMPLATE
 	Children:
+		LogicKeyListener@OPEN_CHAT_KEY_LISTENER:
 		Container@CHAT_OVERLAY:
 			Width: PARENT_RIGHT - 24
 			Height: PARENT_BOTTOM - 30

--- a/mods/common/chrome/ingame-chat.yaml
+++ b/mods/common/chrome/ingame-chat.yaml
@@ -11,6 +11,7 @@ Container@CHAT_PANEL:
 			System: SYSTEM_LINE_TEMPLATE
 			Mission: CHAT_LINE_TEMPLATE
 	Children:
+		LogicKeyListener@OPEN_CHAT_KEY_LISTENER:
 		Container@CHAT_OVERLAY:
 			Width: PARENT_RIGHT - 24
 			Height: PARENT_BOTTOM - 30


### PR DESCRIPTION
It has no business handling key input. This was used only for opening the ingame chat and replacing it with a `LogicKeyListener` was trivial.

~~Depends on #21599~~