### PR TITLE
Rename Fluent-related code to be more precise.

### DIFF
--- a/OpenRA.Game/FluentExts.cs
+++ b/OpenRA.Game/FluentExts.cs
@@ -13,7 +13,7 @@ using Linguini.Shared.Types.Bundle;
 
 namespace OpenRA
 {
-	public static class TranslationExts
+	public static class FluentExts
 	{
 		public static IFluentType ToFluentType(this object value)
 		{

--- a/OpenRA.Game/FluentProvider.cs
+++ b/OpenRA.Game/FluentProvider.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using OpenRA.FileSystem;
 
 namespace OpenRA
@@ -32,7 +31,7 @@ namespace OpenRA
 			}
 		}
 
-		public static string GetString(string key, IDictionary<string, object> args = null)
+		public static string GetString(string key, params object[] args)
 		{
 			lock (SyncObject)
 			{
@@ -48,7 +47,7 @@ namespace OpenRA
 			}
 		}
 
-		public static bool TryGetString(string key, out string message, IDictionary<string, object> args = null)
+		public static bool TryGetString(string key, out string message, params object[] args)
 		{
 			lock (SyncObject)
 			{
@@ -65,7 +64,7 @@ namespace OpenRA
 		}
 
 		/// <summary>Should only be used by <see cref="MapPreview"/>.</summary>
-		internal static bool TryGetModString(string key, out string message, IDictionary<string, object> args = null)
+		internal static bool TryGetModString(string key, out string message, params object[] args)
 		{
 			lock (SyncObject)
 			{

--- a/OpenRA.Game/FluentProvider.cs
+++ b/OpenRA.Game/FluentProvider.cs
@@ -14,20 +14,20 @@ using OpenRA.FileSystem;
 
 namespace OpenRA
 {
-	public static class TranslationProvider
+	public static class FluentProvider
 	{
 		// Ensure thread-safety.
 		static readonly object SyncObject = new();
-		static Translation modTranslation;
-		static Translation mapTranslation;
+		static FluentBundle modFluentBundle;
+		static FluentBundle mapFluentBundle;
 
 		public static void Initialize(ModData modData, IReadOnlyFileSystem fileSystem)
 		{
 			lock (SyncObject)
 			{
-				modTranslation = new Translation(Game.Settings.Player.Language, modData.Manifest.Translations, fileSystem);
-				mapTranslation = fileSystem is Map map && map.TranslationDefinitions != null
-					? new Translation(Game.Settings.Player.Language, FieldLoader.GetValue<string[]>("value", map.TranslationDefinitions.Value), fileSystem)
+				modFluentBundle = new FluentBundle(Game.Settings.Player.Language, modData.Manifest.Translations, fileSystem);
+				mapFluentBundle = fileSystem is Map map && map.TranslationDefinitions != null
+					? new FluentBundle(Game.Settings.Player.Language, FieldLoader.GetValue<string[]>("value", map.TranslationDefinitions.Value), fileSystem)
 					: null;
 			}
 		}
@@ -36,13 +36,13 @@ namespace OpenRA
 		{
 			lock (SyncObject)
 			{
-				// By prioritizing mod-level translations we prevent maps from overwriting translation keys. We do not want to
+				// By prioritizing mod-level fluent bundles we prevent maps from overwriting string keys. We do not want to
 				// allow maps to change the UI nor any other strings not exposed to the map.
-				if (modTranslation.TryGetString(key, out var message, args))
+				if (modFluentBundle.TryGetString(key, out var message, args))
 					return message;
 
-				if (mapTranslation != null)
-					return mapTranslation.GetString(key, args);
+				if (mapFluentBundle != null)
+					return mapFluentBundle.GetString(key, args);
 
 				return key;
 			}
@@ -52,12 +52,12 @@ namespace OpenRA
 		{
 			lock (SyncObject)
 			{
-				// By prioritizing mod-level translations we prevent maps from overwriting translation keys. We do not want to
+				// By prioritizing mod-level bundle we prevent maps from overwriting string keys. We do not want to
 				// allow maps to change the UI nor any other strings not exposed to the map.
-				if (modTranslation.TryGetString(key, out message, args))
+				if (modFluentBundle.TryGetString(key, out message, args))
 					return true;
 
-				if (mapTranslation != null && mapTranslation.TryGetString(key, out message, args))
+				if (mapFluentBundle != null && mapFluentBundle.TryGetString(key, out message, args))
 					return true;
 
 				return false;
@@ -69,7 +69,7 @@ namespace OpenRA
 		{
 			lock (SyncObject)
 			{
-				return modTranslation.TryGetString(key, out message, args);
+				return modFluentBundle.TryGetString(key, out message, args);
 			}
 		}
 	}

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -29,7 +29,7 @@ namespace OpenRA
 {
 	public static class Game
 	{
-		[TranslationReference("filename")]
+		[FluentReference("filename")]
 		const string SavedScreenshot = "notification-saved-screenshot";
 
 		public const int TimestepJankThreshold = 250; // Don't catch up for delays larger than 250ms
@@ -595,7 +595,7 @@ namespace OpenRA
 				Log.Write("debug", "Taking screenshot " + path);
 
 				Renderer.SaveScreenshot(path);
-				TextNotificationsManager.Debug(TranslationProvider.GetString(SavedScreenshot, Translation.Arguments("filename", filename)));
+				TextNotificationsManager.Debug(FluentProvider.GetString(SavedScreenshot, FluentBundle.Arguments("filename", filename)));
 			}
 		}
 

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -595,7 +595,7 @@ namespace OpenRA
 				Log.Write("debug", "Taking screenshot " + path);
 
 				Renderer.SaveScreenshot(path);
-				TextNotificationsManager.Debug(FluentProvider.GetString(SavedScreenshot, FluentBundle.Arguments("filename", filename)));
+				TextNotificationsManager.Debug(FluentProvider.GetString(SavedScreenshot, "filename", filename));
 			}
 		}
 

--- a/OpenRA.Game/GameInformation.cs
+++ b/OpenRA.Game/GameInformation.cs
@@ -19,7 +19,7 @@ namespace OpenRA
 {
 	public class GameInformation
 	{
-		[TranslationReference("name", "number")]
+		[FluentReference("name", "number")]
 		const string EnumeratedBotName = "enumerated-bot-name";
 
 		public string Mod;
@@ -152,9 +152,9 @@ namespace OpenRA
 			if (player.IsBot)
 			{
 				var number = Players.Where(p => p.BotType == player.BotType).ToList().IndexOf(player) + 1;
-				return TranslationProvider.GetString(EnumeratedBotName,
-					Translation.Arguments(
-						"name", TranslationProvider.GetString(player.Name),
+				return FluentProvider.GetString(EnumeratedBotName,
+					FluentBundle.Arguments(
+						"name", FluentProvider.GetString(player.Name),
 						"number", number));
 			}
 

--- a/OpenRA.Game/GameInformation.cs
+++ b/OpenRA.Game/GameInformation.cs
@@ -153,9 +153,8 @@ namespace OpenRA
 			{
 				var number = Players.Where(p => p.BotType == player.BotType).ToList().IndexOf(player) + 1;
 				return FluentProvider.GetString(EnumeratedBotName,
-					FluentBundle.Arguments(
 						"name", FluentProvider.GetString(player.Name),
-						"number", number));
+						"number", number);
 			}
 
 			return player.Name;

--- a/OpenRA.Game/GameSpeed.cs
+++ b/OpenRA.Game/GameSpeed.cs
@@ -15,7 +15,7 @@ namespace OpenRA
 {
 	public class GameSpeed
 	{
-		[TranslationReference]
+		[FluentReference]
 		[FieldLoader.Require]
 		public readonly string Name;
 

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -227,7 +227,7 @@ namespace OpenRA
 		/// Functionality mirrors <see cref="FluentProvider.GetString"/>, except instead of using
 		/// loaded <see cref="Map"/>'s fluent bundle as backup, we use this <see cref="MapPreview"/>'s.
 		/// </summary>
-		public string GetLocalisedString(string key, object[] args = null)
+		public string GetString(string key, object[] args = null)
 		{
 			// PERF: instead of loading mod level strings per each MapPreview, reuse the already loaded one in FluentProvider.
 			if (FluentProvider.TryGetModString(key, out var message, args))

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -227,7 +227,7 @@ namespace OpenRA
 		/// Functionality mirrors <see cref="FluentProvider.GetString"/>, except instead of using
 		/// loaded <see cref="Map"/>'s fluent bundle as backup, we use this <see cref="MapPreview"/>'s.
 		/// </summary>
-		public string GetLocalisedString(string key, IDictionary<string, object> args = null)
+		public string GetLocalisedString(string key, object[] args = null)
 		{
 			// PERF: instead of loading mod level strings per each MapPreview, reuse the already loaded one in FluentProvider.
 			if (FluentProvider.TryGetModString(key, out var message, args))

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -91,7 +91,7 @@ namespace OpenRA
 			public MiniYaml SequenceDefinitions;
 			public MiniYaml ModelSequenceDefinitions;
 
-			public Translation Translation { get; private set; }
+			public FluentBundle FluentBundle { get; private set; }
 			public ActorInfo WorldActorInfo { get; private set; }
 			public ActorInfo PlayerActorInfo { get; private set; }
 
@@ -122,8 +122,8 @@ namespace OpenRA
 				SequenceDefinitions = LoadRuleSection(yaml, "Sequences");
 				ModelSequenceDefinitions = LoadRuleSection(yaml, "ModelSequences");
 
-				Translation = yaml.TryGetValue("Translations", out var node) && node != null
-					? new Translation(Game.Settings.Player.Language, FieldLoader.GetValue<string[]>("value", node.Value), fileSystem)
+				FluentBundle = yaml.TryGetValue("Translations", out var node) && node != null
+					? new FluentBundle(Game.Settings.Player.Language, FieldLoader.GetValue<string[]>("value", node.Value), fileSystem)
 					: null;
 
 				try
@@ -224,16 +224,16 @@ namespace OpenRA
 		public int DownloadPercentage { get; private set; }
 
 		/// <summary>
-		/// Functionality mirrors <see cref="TranslationProvider.GetString"/>, except instead of using
-		/// loaded <see cref="Map"/>'s translations as backup, we use this <see cref="MapPreview"/>'s.
+		/// Functionality mirrors <see cref="FluentProvider.GetString"/>, except instead of using
+		/// loaded <see cref="Map"/>'s fluent bundle as backup, we use this <see cref="MapPreview"/>'s.
 		/// </summary>
 		public string GetLocalisedString(string key, IDictionary<string, object> args = null)
 		{
-			// PERF: instead of loading mod level Translation per each MapPreview, reuse the already loaded one in TranslationProvider.
-			if (TranslationProvider.TryGetModString(key, out var message, args))
+			// PERF: instead of loading mod level strings per each MapPreview, reuse the already loaded one in FluentProvider.
+			if (FluentProvider.TryGetModString(key, out var message, args))
 				return message;
 
-			return innerData.Translation?.GetString(key, args) ?? key;
+			return innerData.FluentBundle?.GetString(key, args) ?? key;
 		}
 
 		Sprite minimap;

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -124,7 +124,7 @@ namespace OpenRA
 			// horribly when you use ModData in unexpected ways.
 			ChromeMetrics.Initialize(this);
 			ChromeProvider.Initialize(this);
-			TranslationProvider.Initialize(this, fileSystem);
+			FluentProvider.Initialize(this, fileSystem);
 
 			Game.Sound.Initialize(SoundLoaders, fileSystem);
 

--- a/OpenRA.Game/Network/FluentMessage.cs
+++ b/OpenRA.Game/Network/FluentMessage.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Network
 		}
 	}
 
-	public class LocalizedMessage
+	public class FluentMessage
 	{
 		public const int ProtocolVersion = 1;
 
@@ -81,7 +81,7 @@ namespace OpenRA.Network
 			return arguments;
 		}
 
-		public LocalizedMessage(MiniYaml yaml)
+		public FluentMessage(MiniYaml yaml)
 		{
 			// Let the FieldLoader do the dirty work of loading the public fields.
 			FieldLoader.Load(this, yaml);
@@ -105,7 +105,7 @@ namespace OpenRA.Network
 			}
 
 			return new MiniYaml("", root)
-				.ToLines("LocalizedMessage")
+				.ToLines("FluentMessage")
 				.JoinWith("\n");
 		}
 	}

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -91,7 +91,7 @@ namespace OpenRA.Network
 			World.OutOfSync();
 			IsOutOfSync = true;
 
-			TextNotificationsManager.AddSystemLine(DesyncCompareLogs, FluentBundle.Arguments("frame", frame));
+			TextNotificationsManager.AddSystemLine(DesyncCompareLogs, "frame", frame);
 		}
 
 		public void StartGame()

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Network
 	{
 		const OrderPacket ClientDisconnected = null;
 
-		[TranslationReference("frame")]
+		[FluentReference("frame")]
 		const string DesyncCompareLogs = "notification-desync-compare-logs";
 
 		readonly SyncReport syncReport;
@@ -91,7 +91,7 @@ namespace OpenRA.Network
 			World.OutOfSync();
 			IsOutOfSync = true;
 
-			TextNotificationsManager.AddSystemLine(DesyncCompareLogs, Translation.Arguments("frame", frame));
+			TextNotificationsManager.AddSystemLine(DesyncCompareLogs, FluentBundle.Arguments("frame", frame));
 		}
 
 		public void StartGame()

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -20,22 +20,22 @@ namespace OpenRA.Network
 	{
 		public const int ChatMessageMaxLength = 2500;
 
-		[TranslationReference("player")]
+		[FluentReference("player")]
 		const string Joined = "notification-joined";
 
-		[TranslationReference("player")]
+		[FluentReference("player")]
 		const string Left = "notification-lobby-disconnected";
 
-		[TranslationReference]
+		[FluentReference]
 		const string GameStarted = "notification-game-has-started";
 
-		[TranslationReference]
+		[FluentReference]
 		const string GameSaved = "notification-game-saved";
 
-		[TranslationReference("player")]
+		[FluentReference("player")]
 		const string GamePaused = "notification-game-paused";
 
-		[TranslationReference("player")]
+		[FluentReference("player")]
 		const string GameUnpaused = "notification-game-unpaused";
 
 		public static int? KickVoteTarget { get; internal set; }
@@ -56,8 +56,8 @@ namespace OpenRA.Network
 					TextNotificationsManager.AddSystemLine(order.TargetString);
 					break;
 
-				// Client side translated server message
-				case "LocalizedMessage":
+				// Client side resolved server message
+				case "FluentMessage":
 				{
 					if (string.IsNullOrEmpty(order.TargetString))
 						break;
@@ -65,7 +65,7 @@ namespace OpenRA.Network
 					var yaml = MiniYaml.FromString(order.TargetString, order.OrderString);
 					foreach (var node in yaml)
 					{
-						var localizedMessage = new LocalizedMessage(node.Value);
+						var localizedMessage = new FluentMessage(node.Value);
 						if (localizedMessage.Key == Joined)
 							TextNotificationsManager.AddPlayerJoinedLine(localizedMessage.Key, localizedMessage.Arguments);
 						else if (localizedMessage.Key == Left)
@@ -231,7 +231,7 @@ namespace OpenRA.Network
 							break;
 
 						if (orderManager.World.Paused != pause && world != null && world.LobbyInfo.NonBotClients.Count() > 1)
-							TextNotificationsManager.AddSystemLine(pause ? GamePaused : GameUnpaused, Translation.Arguments("player", client.Name));
+							TextNotificationsManager.AddSystemLine(pause ? GamePaused : GameUnpaused, FluentBundle.Arguments("player", client.Name));
 
 						orderManager.World.Paused = pause;
 						orderManager.World.PredictedPaused = pause;

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -65,13 +65,13 @@ namespace OpenRA.Network
 					var yaml = MiniYaml.FromString(order.TargetString, order.OrderString);
 					foreach (var node in yaml)
 					{
-						var localizedMessage = new FluentMessage(node.Value);
-						if (localizedMessage.Key == Joined)
-							TextNotificationsManager.AddPlayerJoinedLine(localizedMessage.Key, localizedMessage.Arguments);
-						else if (localizedMessage.Key == Left)
-							TextNotificationsManager.AddPlayerLeftLine(localizedMessage.Key, localizedMessage.Arguments);
+						var message = new FluentMessage(node.Value);
+						if (message.Key == Joined)
+							TextNotificationsManager.AddPlayerJoinedLine(message.Key, message.Arguments);
+						else if (message.Key == Left)
+							TextNotificationsManager.AddPlayerLeftLine(message.Key, message.Arguments);
 						else
-							TextNotificationsManager.AddSystemLine(localizedMessage.Key, localizedMessage.Arguments);
+							TextNotificationsManager.AddSystemLine(message.Key, message.Arguments);
 					}
 
 					break;

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -231,7 +231,7 @@ namespace OpenRA.Network
 							break;
 
 						if (orderManager.World.Paused != pause && world != null && world.LobbyInfo.NonBotClients.Count() > 1)
-							TextNotificationsManager.AddSystemLine(pause ? GamePaused : GameUnpaused, FluentBundle.Arguments("player", client.Name));
+							TextNotificationsManager.AddSystemLine(pause ? GamePaused : GameUnpaused, "player", client.Name);
 
 						orderManager.World.Paused = pause;
 						orderManager.World.PredictedPaused = pause;

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -38,7 +38,7 @@ namespace OpenRA
 
 	public class Player : IScriptBindable, IScriptNotifyBind, ILuaTableBinding, ILuaEqualityBinding, ILuaToStringBinding
 	{
-		[TranslationReference("name", "number")]
+		[FluentReference("name", "number")]
 		const string EnumeratedBotName = "enumerated-bot-name";
 
 		public readonly Actor PlayerActor;
@@ -238,8 +238,8 @@ namespace OpenRA
 			{
 				var botInfo = botInfos.First(b => b.Type == BotType);
 				var botsOfSameType = World.Players.Where(c => c.BotType == BotType).ToArray();
-				return TranslationProvider.GetString(EnumeratedBotName,
-					Translation.Arguments("name", TranslationProvider.GetString(botInfo.Name),
+				return FluentProvider.GetString(EnumeratedBotName,
+					FluentBundle.Arguments("name", FluentProvider.GetString(botInfo.Name),
 						"number", botsOfSameType.IndexOf(this) + 1));
 			}
 

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -239,8 +239,8 @@ namespace OpenRA
 				var botInfo = botInfos.First(b => b.Type == BotType);
 				var botsOfSameType = World.Players.Where(c => c.BotType == BotType).ToArray();
 				return FluentProvider.GetString(EnumeratedBotName,
-					FluentBundle.Arguments("name", FluentProvider.GetString(botInfo.Name),
-						"number", botsOfSameType.IndexOf(this) + 1));
+					"name", FluentProvider.GetString(botInfo.Name),
+					"number", botsOfSameType.IndexOf(this) + 1);
 			}
 
 			return PlayerName;

--- a/OpenRA.Game/Server/PlayerMessageTracker.cs
+++ b/OpenRA.Game/Server/PlayerMessageTracker.cs
@@ -22,16 +22,16 @@ namespace OpenRA.Server
 		readonly Dictionary<int, List<long>> messageTracker = new();
 		readonly Server server;
 		readonly Action<Connection, int, int, byte[]> dispatchOrdersToClient;
-		readonly Action<Connection, string, object[]> sendLocalizedMessageTo;
+		readonly Action<Connection, string, object[]> sendFluentMessageTo;
 
 		public PlayerMessageTracker(
 			Server server,
 			Action<Connection, int, int, byte[]> dispatchOrdersToClient,
-			Action<Connection, string, object[]> sendLocalizedMessageTo)
+			Action<Connection, string, object[]> sendFluentMessageTo)
 		{
 			this.server = server;
 			this.dispatchOrdersToClient = dispatchOrdersToClient;
-			this.sendLocalizedMessageTo = sendLocalizedMessageTo;
+			this.sendFluentMessageTo = sendFluentMessageTo;
 		}
 
 		public void DisableChatUI(Connection conn, int time)
@@ -56,7 +56,7 @@ namespace OpenRA.Server
 			if (!isAdmin && time < settings.FloodLimitJoinCooldown)
 			{
 				var remaining = CalculateRemaining(settings.FloodLimitJoinCooldown);
-				sendLocalizedMessageTo(conn, ChatTemporaryDisabled, new object[] { "remaining", remaining });
+				sendFluentMessageTo(conn, ChatTemporaryDisabled, new object[] { "remaining", remaining });
 				return true;
 			}
 
@@ -64,7 +64,7 @@ namespace OpenRA.Server
 			if (tracker.Count >= settings.FloodLimitMessageCount)
 			{
 				var remaining = CalculateRemaining(tracker[0] + settings.FloodLimitInterval);
-				sendLocalizedMessageTo(conn, ChatTemporaryDisabled, new object[] { "remaining", remaining });
+				sendFluentMessageTo(conn, ChatTemporaryDisabled, new object[] { "remaining", remaining });
 				return true;
 			}
 

--- a/OpenRA.Game/Server/PlayerMessageTracker.cs
+++ b/OpenRA.Game/Server/PlayerMessageTracker.cs
@@ -22,12 +22,12 @@ namespace OpenRA.Server
 		readonly Dictionary<int, List<long>> messageTracker = new();
 		readonly Server server;
 		readonly Action<Connection, int, int, byte[]> dispatchOrdersToClient;
-		readonly Action<Connection, string, Dictionary<string, object>> sendLocalizedMessageTo;
+		readonly Action<Connection, string, object[]> sendLocalizedMessageTo;
 
 		public PlayerMessageTracker(
 			Server server,
 			Action<Connection, int, int, byte[]> dispatchOrdersToClient,
-			Action<Connection, string, Dictionary<string, object>> sendLocalizedMessageTo)
+			Action<Connection, string, object[]> sendLocalizedMessageTo)
 		{
 			this.server = server;
 			this.dispatchOrdersToClient = dispatchOrdersToClient;
@@ -56,7 +56,7 @@ namespace OpenRA.Server
 			if (!isAdmin && time < settings.FloodLimitJoinCooldown)
 			{
 				var remaining = CalculateRemaining(settings.FloodLimitJoinCooldown);
-				sendLocalizedMessageTo(conn, ChatTemporaryDisabled, FluentBundle.Arguments("remaining", remaining));
+				sendLocalizedMessageTo(conn, ChatTemporaryDisabled, new object[] { "remaining", remaining });
 				return true;
 			}
 
@@ -64,7 +64,7 @@ namespace OpenRA.Server
 			if (tracker.Count >= settings.FloodLimitMessageCount)
 			{
 				var remaining = CalculateRemaining(tracker[0] + settings.FloodLimitInterval);
-				sendLocalizedMessageTo(conn, ChatTemporaryDisabled, FluentBundle.Arguments("remaining", remaining));
+				sendLocalizedMessageTo(conn, ChatTemporaryDisabled, new object[] { "remaining", remaining });
 				return true;
 			}
 

--- a/OpenRA.Game/Server/PlayerMessageTracker.cs
+++ b/OpenRA.Game/Server/PlayerMessageTracker.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Server
 {
 	sealed class PlayerMessageTracker
 	{
-		[TranslationReference("remaining")]
+		[FluentReference("remaining")]
 		const string ChatTemporaryDisabled = "notification-chat-temp-disabled";
 
 		readonly Dictionary<int, List<long>> messageTracker = new();
@@ -56,7 +56,7 @@ namespace OpenRA.Server
 			if (!isAdmin && time < settings.FloodLimitJoinCooldown)
 			{
 				var remaining = CalculateRemaining(settings.FloodLimitJoinCooldown);
-				sendLocalizedMessageTo(conn, ChatTemporaryDisabled, Translation.Arguments("remaining", remaining));
+				sendLocalizedMessageTo(conn, ChatTemporaryDisabled, FluentBundle.Arguments("remaining", remaining));
 				return true;
 			}
 
@@ -64,7 +64,7 @@ namespace OpenRA.Server
 			if (tracker.Count >= settings.FloodLimitMessageCount)
 			{
 				var remaining = CalculateRemaining(tracker[0] + settings.FloodLimitInterval);
-				sendLocalizedMessageTo(conn, ChatTemporaryDisabled, Translation.Arguments("remaining", remaining));
+				sendLocalizedMessageTo(conn, ChatTemporaryDisabled, FluentBundle.Arguments("remaining", remaining));
 				return true;
 			}
 

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -319,7 +319,7 @@ namespace OpenRA.Server
 
 			MapStatusCache = new MapStatusCache(modData, MapStatusChanged, type == ServerType.Dedicated && settings.EnableLintChecks);
 
-			playerMessageTracker = new PlayerMessageTracker(this, DispatchOrdersToClient, SendLocalizedMessageTo);
+			playerMessageTracker = new PlayerMessageTracker(this, DispatchOrdersToClient, SendFluentMessageTo);
 			VoteKickTracker = new VoteKickTracker(this);
 
 			LobbyInfo = new Session
@@ -580,7 +580,7 @@ namespace OpenRA.Server
 
 						Log.Write("server", $"{client.Name} ({newConn.EndPoint}) has joined the game.");
 
-						SendLocalizedMessage(Joined, "player", client.Name);
+						SendFluentMessage(Joined, "player", client.Name);
 
 						if (Type == ServerType.Dedicated)
 						{
@@ -594,12 +594,12 @@ namespace OpenRA.Server
 						}
 
 						if ((LobbyInfo.GlobalSettings.MapStatus & Session.MapStatus.UnsafeCustomRules) != 0)
-							SendLocalizedMessageTo(newConn, CustomRules);
+							SendFluentMessageTo(newConn, CustomRules);
 
 						if (!LobbyInfo.GlobalSettings.EnableSingleplayer)
-							SendLocalizedMessageTo(newConn, TwoHumansRequired);
+							SendFluentMessageTo(newConn, TwoHumansRequired);
 						else if (Map.Players.Players.Where(p => p.Value.Playable).All(p => !p.Value.AllowBots))
-							SendLocalizedMessageTo(newConn, BotsDisabled);
+							SendFluentMessageTo(newConn, BotsDisabled);
 					}
 				}
 
@@ -952,7 +952,7 @@ namespace OpenRA.Server
 				WriteLineWithTimeStamp(text);
 		}
 
-		public void SendLocalizedMessage(string key, params object[] args)
+		public void SendFluentMessage(string key, params object[] args)
 		{
 			var text = FluentMessage.Serialize(key, args);
 			DispatchServerOrdersToClients(Order.FromTargetString("FluentMessage", text, true));
@@ -961,7 +961,7 @@ namespace OpenRA.Server
 				WriteLineWithTimeStamp(FluentProvider.GetString(key, args));
 		}
 
-		public void SendLocalizedMessageTo(Connection conn, string key, object[] args = null)
+		public void SendFluentMessageTo(Connection conn, string key, object[] args = null)
 		{
 			var text = FluentMessage.Serialize(key, args);
 			DispatchOrdersToClient(conn, 0, 0, Order.FromTargetString("FluentMessage", text, true).Serialize());
@@ -998,7 +998,7 @@ namespace OpenRA.Server
 						if (!InterpretCommand(o.TargetString, conn))
 						{
 							Log.Write("server", $"Unknown server command: {o.TargetString}");
-							SendLocalizedMessageTo(conn, UnknownServerCommand, new object[] { "command", o.TargetString });
+							SendFluentMessageTo(conn, UnknownServerCommand, new object[] { "command", o.TargetString });
 						}
 
 						break;
@@ -1180,14 +1180,14 @@ namespace OpenRA.Server
 				if (State == ServerState.GameStarted)
 				{
 					if (dropClient.IsObserver)
-						SendLocalizedMessage(ObserverDisconnected, "player", dropClient.Name);
+						SendFluentMessage(ObserverDisconnected, "player", dropClient.Name);
 					else if (dropClient.Team > 0)
-						SendLocalizedMessage(PlayerTeamDisconnected, "player", dropClient.Name, "team", dropClient.Team);
+						SendFluentMessage(PlayerTeamDisconnected, "player", dropClient.Name, "team", dropClient.Team);
 					else
-						SendLocalizedMessage(PlayerDisconnected, "player", dropClient.Name);
+						SendFluentMessage(PlayerDisconnected, "player", dropClient.Name);
 				}
 				else
-					SendLocalizedMessage(LobbyDisconnected, "player", dropClient.Name);
+					SendFluentMessage(LobbyDisconnected, "player", dropClient.Name);
 
 				LobbyInfo.Clients.RemoveAll(c => c.Index == toDrop.PlayerIndex);
 
@@ -1204,7 +1204,7 @@ namespace OpenRA.Server
 					if (nextAdmin != null)
 					{
 						nextAdmin.IsAdmin = true;
-						SendLocalizedMessage(NewAdmin, "player", nextAdmin.Name);
+						SendFluentMessage(NewAdmin, "player", nextAdmin.Name);
 					}
 				}
 

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -580,7 +580,7 @@ namespace OpenRA.Server
 
 						Log.Write("server", $"{client.Name} ({newConn.EndPoint}) has joined the game.");
 
-						SendLocalizedMessage(Joined, FluentBundle.Arguments("player", client.Name));
+						SendLocalizedMessage(Joined, "player", client.Name);
 
 						if (Type == ServerType.Dedicated)
 						{
@@ -952,18 +952,18 @@ namespace OpenRA.Server
 				WriteLineWithTimeStamp(text);
 		}
 
-		public void SendLocalizedMessage(string key, Dictionary<string, object> arguments = null)
+		public void SendLocalizedMessage(string key, params object[] args)
 		{
-			var text = FluentMessage.Serialize(key, arguments);
+			var text = FluentMessage.Serialize(key, args);
 			DispatchServerOrdersToClients(Order.FromTargetString("FluentMessage", text, true));
 
 			if (Type == ServerType.Dedicated)
-				WriteLineWithTimeStamp(FluentProvider.GetString(key, arguments));
+				WriteLineWithTimeStamp(FluentProvider.GetString(key, args));
 		}
 
-		public void SendLocalizedMessageTo(Connection conn, string key, Dictionary<string, object> arguments = null)
+		public void SendLocalizedMessageTo(Connection conn, string key, object[] args = null)
 		{
-			var text = FluentMessage.Serialize(key, arguments);
+			var text = FluentMessage.Serialize(key, args);
 			DispatchOrdersToClient(conn, 0, 0, Order.FromTargetString("FluentMessage", text, true).Serialize());
 		}
 
@@ -998,7 +998,7 @@ namespace OpenRA.Server
 						if (!InterpretCommand(o.TargetString, conn))
 						{
 							Log.Write("server", $"Unknown server command: {o.TargetString}");
-							SendLocalizedMessageTo(conn, UnknownServerCommand, FluentBundle.Arguments("command", o.TargetString));
+							SendLocalizedMessageTo(conn, UnknownServerCommand, new object[] { "command", o.TargetString });
 						}
 
 						break;
@@ -1180,14 +1180,14 @@ namespace OpenRA.Server
 				if (State == ServerState.GameStarted)
 				{
 					if (dropClient.IsObserver)
-						SendLocalizedMessage(ObserverDisconnected, FluentBundle.Arguments("player", dropClient.Name));
+						SendLocalizedMessage(ObserverDisconnected, "player", dropClient.Name);
 					else if (dropClient.Team > 0)
-						SendLocalizedMessage(PlayerTeamDisconnected, FluentBundle.Arguments("player", dropClient.Name, "team", dropClient.Team));
+						SendLocalizedMessage(PlayerTeamDisconnected, "player", dropClient.Name, "team", dropClient.Team);
 					else
-						SendLocalizedMessage(PlayerDisconnected, FluentBundle.Arguments("player", dropClient.Name));
+						SendLocalizedMessage(PlayerDisconnected, "player", dropClient.Name);
 				}
 				else
-					SendLocalizedMessage(LobbyDisconnected, FluentBundle.Arguments("player", dropClient.Name));
+					SendLocalizedMessage(LobbyDisconnected, "player", dropClient.Name);
 
 				LobbyInfo.Clients.RemoveAll(c => c.Index == toDrop.PlayerIndex);
 
@@ -1204,7 +1204,7 @@ namespace OpenRA.Server
 					if (nextAdmin != null)
 					{
 						nextAdmin.IsAdmin = true;
-						SendLocalizedMessage(NewAdmin, FluentBundle.Arguments("player", nextAdmin.Name));
+						SendLocalizedMessage(NewAdmin, "player", nextAdmin.Name);
 					}
 				}
 

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -47,73 +47,73 @@ namespace OpenRA.Server
 
 	public sealed class Server
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string CustomRules = "notification-custom-rules";
 
-		[TranslationReference]
+		[FluentReference]
 		const string BotsDisabled = "notification-map-bots-disabled";
 
-		[TranslationReference]
+		[FluentReference]
 		const string TwoHumansRequired = "notification-two-humans-required";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ErrorGameStarted = "notification-error-game-started";
 
-		[TranslationReference]
+		[FluentReference]
 		const string RequiresPassword = "notification-requires-password";
 
-		[TranslationReference]
+		[FluentReference]
 		const string IncorrectPassword = "notification-incorrect-password";
 
-		[TranslationReference]
+		[FluentReference]
 		const string IncompatibleMod = "notification-incompatible-mod";
 
-		[TranslationReference]
+		[FluentReference]
 		const string IncompatibleVersion = "notification-incompatible-version";
 
-		[TranslationReference]
+		[FluentReference]
 		const string IncompatibleProtocol = "notification-incompatible-protocol";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Banned = "notification-you-were-banned";
 
-		[TranslationReference]
+		[FluentReference]
 		const string TempBanned = "notification-you-were-temp-banned";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Full = "notification-game-full";
 
-		[TranslationReference("player")]
+		[FluentReference("player")]
 		const string Joined = "notification-joined";
 
-		[TranslationReference]
+		[FluentReference]
 		const string RequiresAuthentication = "notification-requires-authentication";
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoPermission = "notification-no-permission-to-join";
 
-		[TranslationReference("command")]
+		[FluentReference("command")]
 		const string UnknownServerCommand = "notification-unknown-server-command";
 
-		[TranslationReference("player")]
+		[FluentReference("player")]
 		const string LobbyDisconnected = "notification-lobby-disconnected";
 
-		[TranslationReference("player")]
+		[FluentReference("player")]
 		const string PlayerDisconnected = "notification-player-disconnected";
 
-		[TranslationReference("player", "team")]
+		[FluentReference("player", "team")]
 		const string PlayerTeamDisconnected = "notification-team-player-disconnected";
 
-		[TranslationReference("player")]
+		[FluentReference("player")]
 		const string ObserverDisconnected = "notification-observer-disconnected";
 
-		[TranslationReference("player")]
+		[FluentReference("player")]
 		const string NewAdmin = "notification-new-admin";
 
-		[TranslationReference]
+		[FluentReference]
 		const string YouWereKicked = "notification-you-were-kicked";
 
-		[TranslationReference]
+		[FluentReference]
 		const string GameStarted = "notification-game-started";
 
 		public readonly MersenneTwister Random = new();
@@ -580,7 +580,7 @@ namespace OpenRA.Server
 
 						Log.Write("server", $"{client.Name} ({newConn.EndPoint}) has joined the game.");
 
-						SendLocalizedMessage(Joined, Translation.Arguments("player", client.Name));
+						SendLocalizedMessage(Joined, FluentBundle.Arguments("player", client.Name));
 
 						if (Type == ServerType.Dedicated)
 						{
@@ -954,17 +954,17 @@ namespace OpenRA.Server
 
 		public void SendLocalizedMessage(string key, Dictionary<string, object> arguments = null)
 		{
-			var text = LocalizedMessage.Serialize(key, arguments);
-			DispatchServerOrdersToClients(Order.FromTargetString("LocalizedMessage", text, true));
+			var text = FluentMessage.Serialize(key, arguments);
+			DispatchServerOrdersToClients(Order.FromTargetString("FluentMessage", text, true));
 
 			if (Type == ServerType.Dedicated)
-				WriteLineWithTimeStamp(TranslationProvider.GetString(key, arguments));
+				WriteLineWithTimeStamp(FluentProvider.GetString(key, arguments));
 		}
 
 		public void SendLocalizedMessageTo(Connection conn, string key, Dictionary<string, object> arguments = null)
 		{
-			var text = LocalizedMessage.Serialize(key, arguments);
-			DispatchOrdersToClient(conn, 0, 0, Order.FromTargetString("LocalizedMessage", text, true).Serialize());
+			var text = FluentMessage.Serialize(key, arguments);
+			DispatchOrdersToClient(conn, 0, 0, Order.FromTargetString("FluentMessage", text, true).Serialize());
 		}
 
 		void WriteLineWithTimeStamp(string line)
@@ -998,7 +998,7 @@ namespace OpenRA.Server
 						if (!InterpretCommand(o.TargetString, conn))
 						{
 							Log.Write("server", $"Unknown server command: {o.TargetString}");
-							SendLocalizedMessageTo(conn, UnknownServerCommand, Translation.Arguments("command", o.TargetString));
+							SendLocalizedMessageTo(conn, UnknownServerCommand, FluentBundle.Arguments("command", o.TargetString));
 						}
 
 						break;
@@ -1180,14 +1180,14 @@ namespace OpenRA.Server
 				if (State == ServerState.GameStarted)
 				{
 					if (dropClient.IsObserver)
-						SendLocalizedMessage(ObserverDisconnected, Translation.Arguments("player", dropClient.Name));
+						SendLocalizedMessage(ObserverDisconnected, FluentBundle.Arguments("player", dropClient.Name));
 					else if (dropClient.Team > 0)
-						SendLocalizedMessage(PlayerTeamDisconnected, Translation.Arguments("player", dropClient.Name, "team", dropClient.Team));
+						SendLocalizedMessage(PlayerTeamDisconnected, FluentBundle.Arguments("player", dropClient.Name, "team", dropClient.Team));
 					else
-						SendLocalizedMessage(PlayerDisconnected, Translation.Arguments("player", dropClient.Name));
+						SendLocalizedMessage(PlayerDisconnected, FluentBundle.Arguments("player", dropClient.Name));
 				}
 				else
-					SendLocalizedMessage(LobbyDisconnected, Translation.Arguments("player", dropClient.Name));
+					SendLocalizedMessage(LobbyDisconnected, FluentBundle.Arguments("player", dropClient.Name));
 
 				LobbyInfo.Clients.RemoveAll(c => c.Index == toDrop.PlayerIndex);
 
@@ -1204,7 +1204,7 @@ namespace OpenRA.Server
 					if (nextAdmin != null)
 					{
 						nextAdmin.IsAdmin = true;
-						SendLocalizedMessage(NewAdmin, Translation.Arguments("player", nextAdmin.Name));
+						SendLocalizedMessage(NewAdmin, FluentBundle.Arguments("player", nextAdmin.Name));
 					}
 				}
 
@@ -1302,7 +1302,7 @@ namespace OpenRA.Server
 		{
 			lock (LobbyInfo)
 			{
-				WriteLineWithTimeStamp(TranslationProvider.GetString(GameStarted));
+				WriteLineWithTimeStamp(FluentProvider.GetString(GameStarted));
 
 				// Drop any players who are not ready
 				foreach (var c in Conns.Where(c => !c.Validated || GetClient(c).IsInvalid).ToArray())

--- a/OpenRA.Game/Server/VoteKickTracker.cs
+++ b/OpenRA.Game/Server/VoteKickTracker.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Server
 				|| (voteInProgress && this.kickee.Client != kickee) // Disallow starting new votes when one is already ongoing.
 				|| !ClientHasPower(kicker))
 			{
-				server.SendLocalizedMessageTo(conn, UnableToStartAVote);
+				server.SendFluentMessageTo(conn, UnableToStartAVote);
 				return false;
 			}
 
@@ -107,7 +107,7 @@ namespace OpenRA.Server
 				if (!kickee.IsObserver && !server.HasClientWonOrLost(kickee))
 				{
 					// Vote kick cannot be the sole deciding factor for a game.
-					server.SendLocalizedMessageTo(conn, InsufficientVotes, new object[] { "kickee", kickee.Name });
+					server.SendFluentMessageTo(conn, InsufficientVotes, new object[] { "kickee", kickee.Name });
 					EndKickVote();
 					return false;
 				}
@@ -126,7 +126,7 @@ namespace OpenRA.Server
 				{
 					if (time + server.Settings.VoteKickerCooldown > kickeeConn.ConnectionTimer.ElapsedMilliseconds)
 					{
-						server.SendLocalizedMessageTo(conn, UnableToStartAVote);
+						server.SendFluentMessageTo(conn, UnableToStartAVote);
 						return false;
 					}
 					else
@@ -135,7 +135,7 @@ namespace OpenRA.Server
 
 				Log.Write("server", $"Vote kick started on {kickeeID}.");
 				voteKickTimer = Stopwatch.StartNew();
-				server.SendLocalizedMessage(VoteKickStarted, "kicker", kicker.Name, "kickee", kickee.Name);
+				server.SendFluentMessage(VoteKickStarted, "kicker", kicker.Name, "kickee", kickee.Name);
 				server.DispatchServerOrdersToClients(new Order("StartKickVote", null, false) { ExtraData = (uint)kickeeID }.Serialize());
 				this.kickee = (kickee, kickeeConn);
 				voteKickerStarter = (kicker, conn);
@@ -145,7 +145,7 @@ namespace OpenRA.Server
 				voteTracker[conn.PlayerIndex] = vote;
 			else
 			{
-				server.SendLocalizedMessageTo(conn, AlreadyVoted);
+				server.SendFluentMessageTo(conn, AlreadyVoted);
 				return false;
 			}
 
@@ -168,7 +168,7 @@ namespace OpenRA.Server
 			}
 
 			var votesNeeded = eligiblePlayers / 2 + 1;
-			server.SendLocalizedMessage(VoteKickProgress,
+			server.SendFluentMessage(VoteKickProgress,
 				"kickee", kickee.Name,
 				"percentage", votesFor * 100 / eligiblePlayers);
 
@@ -210,7 +210,7 @@ namespace OpenRA.Server
 				return;
 
 			if (sendMessage)
-				server.SendLocalizedMessage(VoteKickEnded, "kickee", kickee.Client.Name);
+				server.SendFluentMessage(VoteKickEnded, "kickee", kickee.Client.Name);
 
 			server.DispatchServerOrdersToClients(new Order("EndKickVote", null, false) { ExtraData = (uint)kickee.Client.Index }.Serialize());
 

--- a/OpenRA.Game/Server/VoteKickTracker.cs
+++ b/OpenRA.Game/Server/VoteKickTracker.cs
@@ -17,22 +17,22 @@ namespace OpenRA.Server
 {
 	public sealed class VoteKickTracker
 	{
-		[TranslationReference("kickee")]
+		[FluentReference("kickee")]
 		const string InsufficientVotes = "notification-insufficient-votes-to-kick";
 
-		[TranslationReference]
+		[FluentReference]
 		const string AlreadyVoted = "notification-kick-already-voted";
 
-		[TranslationReference("kicker", "kickee")]
+		[FluentReference("kicker", "kickee")]
 		const string VoteKickStarted = "notification-vote-kick-started";
 
-		[TranslationReference]
+		[FluentReference]
 		const string UnableToStartAVote = "notification-unable-to-start-a-vote";
 
-		[TranslationReference("kickee", "percentage")]
+		[FluentReference("kickee", "percentage")]
 		const string VoteKickProgress = "notification-vote-kick-in-progress";
 
-		[TranslationReference("kickee")]
+		[FluentReference("kickee")]
 		const string VoteKickEnded = "notification-vote-kick-ended";
 
 		readonly Dictionary<int, bool> voteTracker = new();
@@ -107,7 +107,7 @@ namespace OpenRA.Server
 				if (!kickee.IsObserver && !server.HasClientWonOrLost(kickee))
 				{
 					// Vote kick cannot be the sole deciding factor for a game.
-					server.SendLocalizedMessageTo(conn, InsufficientVotes, Translation.Arguments("kickee", kickee.Name));
+					server.SendLocalizedMessageTo(conn, InsufficientVotes, FluentBundle.Arguments("kickee", kickee.Name));
 					EndKickVote();
 					return false;
 				}
@@ -135,7 +135,7 @@ namespace OpenRA.Server
 
 				Log.Write("server", $"Vote kick started on {kickeeID}.");
 				voteKickTimer = Stopwatch.StartNew();
-				server.SendLocalizedMessage(VoteKickStarted, Translation.Arguments("kicker", kicker.Name, "kickee", kickee.Name));
+				server.SendLocalizedMessage(VoteKickStarted, FluentBundle.Arguments("kicker", kicker.Name, "kickee", kickee.Name));
 				server.DispatchServerOrdersToClients(new Order("StartKickVote", null, false) { ExtraData = (uint)kickeeID }.Serialize());
 				this.kickee = (kickee, kickeeConn);
 				voteKickerStarter = (kicker, conn);
@@ -168,7 +168,7 @@ namespace OpenRA.Server
 			}
 
 			var votesNeeded = eligiblePlayers / 2 + 1;
-			server.SendLocalizedMessage(VoteKickProgress, Translation.Arguments(
+			server.SendLocalizedMessage(VoteKickProgress, FluentBundle.Arguments(
 				"kickee", kickee.Name,
 				"percentage", votesFor * 100 / eligiblePlayers));
 
@@ -210,7 +210,7 @@ namespace OpenRA.Server
 				return;
 
 			if (sendMessage)
-				server.SendLocalizedMessage(VoteKickEnded, Translation.Arguments("kickee", kickee.Client.Name));
+				server.SendLocalizedMessage(VoteKickEnded, FluentBundle.Arguments("kickee", kickee.Client.Name));
 
 			server.DispatchServerOrdersToClients(new Order("EndKickVote", null, false) { ExtraData = (uint)kickee.Client.Index }.Serialize());
 

--- a/OpenRA.Game/Server/VoteKickTracker.cs
+++ b/OpenRA.Game/Server/VoteKickTracker.cs
@@ -107,7 +107,7 @@ namespace OpenRA.Server
 				if (!kickee.IsObserver && !server.HasClientWonOrLost(kickee))
 				{
 					// Vote kick cannot be the sole deciding factor for a game.
-					server.SendLocalizedMessageTo(conn, InsufficientVotes, FluentBundle.Arguments("kickee", kickee.Name));
+					server.SendLocalizedMessageTo(conn, InsufficientVotes, new object[] { "kickee", kickee.Name });
 					EndKickVote();
 					return false;
 				}
@@ -135,7 +135,7 @@ namespace OpenRA.Server
 
 				Log.Write("server", $"Vote kick started on {kickeeID}.");
 				voteKickTimer = Stopwatch.StartNew();
-				server.SendLocalizedMessage(VoteKickStarted, FluentBundle.Arguments("kicker", kicker.Name, "kickee", kickee.Name));
+				server.SendLocalizedMessage(VoteKickStarted, "kicker", kicker.Name, "kickee", kickee.Name);
 				server.DispatchServerOrdersToClients(new Order("StartKickVote", null, false) { ExtraData = (uint)kickeeID }.Serialize());
 				this.kickee = (kickee, kickeeConn);
 				voteKickerStarter = (kicker, conn);
@@ -145,7 +145,7 @@ namespace OpenRA.Server
 				voteTracker[conn.PlayerIndex] = vote;
 			else
 			{
-				server.SendLocalizedMessageTo(conn, AlreadyVoted, null);
+				server.SendLocalizedMessageTo(conn, AlreadyVoted);
 				return false;
 			}
 
@@ -168,9 +168,9 @@ namespace OpenRA.Server
 			}
 
 			var votesNeeded = eligiblePlayers / 2 + 1;
-			server.SendLocalizedMessage(VoteKickProgress, FluentBundle.Arguments(
+			server.SendLocalizedMessage(VoteKickProgress,
 				"kickee", kickee.Name,
-				"percentage", votesFor * 100 / eligiblePlayers));
+				"percentage", votesFor * 100 / eligiblePlayers);
 
 			// If a player or players during a vote lose or disconnect, it is possible that a downvote will
 			// kick a client. Guard against that situation.
@@ -210,7 +210,7 @@ namespace OpenRA.Server
 				return;
 
 			if (sendMessage)
-				server.SendLocalizedMessage(VoteKickEnded, FluentBundle.Arguments("kickee", kickee.Client.Name));
+				server.SendLocalizedMessage(VoteKickEnded, "kickee", kickee.Client.Name);
 
 			server.DispatchServerOrdersToClients(new Order("EndKickVote", null, false) { ExtraData = (uint)kickee.Client.Index }.Serialize());
 

--- a/OpenRA.Game/TextNotificationsManager.cs
+++ b/OpenRA.Game/TextNotificationsManager.cs
@@ -38,12 +38,12 @@ namespace OpenRA
 				return;
 
 			if (player == null || player == player.World.LocalPlayer)
-				AddTextNotification(TextNotificationPool.Transients, SystemClientId, SystemMessageLabel, TranslationProvider.GetString(text));
+				AddTextNotification(TextNotificationPool.Transients, SystemClientId, SystemMessageLabel, FluentProvider.GetString(text));
 		}
 
 		public static void AddFeedbackLine(string text, Dictionary<string, object> arguments = null)
 		{
-			AddTextNotification(TextNotificationPool.Feedback, SystemClientId, SystemMessageLabel, TranslationProvider.GetString(text, arguments));
+			AddTextNotification(TextNotificationPool.Feedback, SystemClientId, SystemMessageLabel, FluentProvider.GetString(text, arguments));
 		}
 
 		public static void AddMissionLine(string prefix, string text, Color? prefixColor = null)
@@ -53,17 +53,17 @@ namespace OpenRA
 
 		public static void AddPlayerJoinedLine(string text, Dictionary<string, object> arguments = null)
 		{
-			AddTextNotification(TextNotificationPool.Join, SystemClientId, SystemMessageLabel, TranslationProvider.GetString(text, arguments));
+			AddTextNotification(TextNotificationPool.Join, SystemClientId, SystemMessageLabel, FluentProvider.GetString(text, arguments));
 		}
 
 		public static void AddPlayerLeftLine(string text, Dictionary<string, object> arguments = null)
 		{
-			AddTextNotification(TextNotificationPool.Leave, SystemClientId, SystemMessageLabel, TranslationProvider.GetString(text, arguments));
+			AddTextNotification(TextNotificationPool.Leave, SystemClientId, SystemMessageLabel, FluentProvider.GetString(text, arguments));
 		}
 
 		public static void AddSystemLine(string text, Dictionary<string, object> arguments = null)
 		{
-			AddSystemLine(SystemMessageLabel, TranslationProvider.GetString(text, arguments));
+			AddSystemLine(SystemMessageLabel, FluentProvider.GetString(text, arguments));
 		}
 
 		public static void AddSystemLine(string prefix, string text)

--- a/OpenRA.Game/TextNotificationsManager.cs
+++ b/OpenRA.Game/TextNotificationsManager.cs
@@ -41,9 +41,9 @@ namespace OpenRA
 				AddTextNotification(TextNotificationPool.Transients, SystemClientId, SystemMessageLabel, FluentProvider.GetString(text));
 		}
 
-		public static void AddFeedbackLine(string text, Dictionary<string, object> arguments = null)
+		public static void AddFeedbackLine(string text, params object[] args)
 		{
-			AddTextNotification(TextNotificationPool.Feedback, SystemClientId, SystemMessageLabel, FluentProvider.GetString(text, arguments));
+			AddTextNotification(TextNotificationPool.Feedback, SystemClientId, SystemMessageLabel, FluentProvider.GetString(text, args));
 		}
 
 		public static void AddMissionLine(string prefix, string text, Color? prefixColor = null)
@@ -51,19 +51,19 @@ namespace OpenRA
 			AddTextNotification(TextNotificationPool.Mission, SystemClientId, prefix, text, prefixColor);
 		}
 
-		public static void AddPlayerJoinedLine(string text, Dictionary<string, object> arguments = null)
+		public static void AddPlayerJoinedLine(string text, params object[] args)
 		{
-			AddTextNotification(TextNotificationPool.Join, SystemClientId, SystemMessageLabel, FluentProvider.GetString(text, arguments));
+			AddTextNotification(TextNotificationPool.Join, SystemClientId, SystemMessageLabel, FluentProvider.GetString(text, args));
 		}
 
-		public static void AddPlayerLeftLine(string text, Dictionary<string, object> arguments = null)
+		public static void AddPlayerLeftLine(string text, params object[] args)
 		{
-			AddTextNotification(TextNotificationPool.Leave, SystemClientId, SystemMessageLabel, FluentProvider.GetString(text, arguments));
+			AddTextNotification(TextNotificationPool.Leave, SystemClientId, SystemMessageLabel, FluentProvider.GetString(text, args));
 		}
 
-		public static void AddSystemLine(string text, Dictionary<string, object> arguments = null)
+		public static void AddSystemLine(string text, params object[] args)
 		{
-			AddSystemLine(SystemMessageLabel, FluentProvider.GetString(text, arguments));
+			AddSystemLine(SystemMessageLabel, FluentProvider.GetString(text, args));
 		}
 
 		public static void AddSystemLine(string prefix, string text)

--- a/OpenRA.Game/Traits/Player/Shroud.cs
+++ b/OpenRA.Game/Traits/Player/Shroud.cs
@@ -18,11 +18,11 @@ namespace OpenRA.Traits
 	[Desc("Required for shroud and fog visibility checks. Add this to the player actor.")]
 	public class ShroudInfo : TraitInfo, ILobbyOptions
 	{
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Descriptive label for the fog checkbox in the lobby.")]
 		public readonly string FogCheckboxLabel = "checkbox-fog-of-war.label";
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Tooltip description for the fog checkbox in the lobby.")]
 		public readonly string FogCheckboxDescription = "checkbox-fog-of-war.description";
 
@@ -38,11 +38,11 @@ namespace OpenRA.Traits
 		[Desc("Display order for the fog checkbox in the lobby.")]
 		public readonly int FogCheckboxDisplayOrder = 0;
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Descriptive label for the explored map checkbox in the lobby.")]
 		public readonly string ExploredMapCheckboxLabel = "checkbox-explored-map.label";
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Tooltip description for the explored map checkbox in the lobby.")]
 		public readonly string ExploredMapCheckboxDescription = "checkbox-explored-map.description";
 

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -586,11 +586,11 @@ namespace OpenRA.Traits
 			IReadOnlyDictionary<string, string> values, string defaultValue, bool locked)
 		{
 			Id = id;
-			Name = map.GetLocalisedString(name);
-			Description = description != null ? map.GetLocalisedString(description).Replace(@"\n", "\n") : null;
+			Name = map.GetString(name);
+			Description = description != null ? map.GetString(description).Replace(@"\n", "\n") : null;
 			IsVisible = visible;
 			DisplayOrder = displayorder;
-			Values = values.ToDictionary(v => v.Key, v => map.GetLocalisedString(v.Value));
+			Values = values.ToDictionary(v => v.Key, v => map.GetString(v.Value));
 			DefaultValue = defaultValue;
 			IsLocked = locked;
 		}

--- a/OpenRA.Game/Traits/World/Faction.cs
+++ b/OpenRA.Game/Traits/World/Faction.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Traits
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	public class FactionInfo : TraitInfo<Faction>
 	{
-		[TranslationReference]
+		[FluentReference]
 		[Desc("This is the name exposed to the players.")]
 		public readonly string Name = null;
 
@@ -30,7 +30,7 @@ namespace OpenRA.Traits
 		[Desc("The side that the faction belongs to. For example, England belongs to the 'Allies' side.")]
 		public readonly string Side = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("This is shown in the lobby as a tooltip.")]
 		public readonly string Description = null;
 

--- a/OpenRA.Mods.Cnc/Installer/ExtractMixSourceAction.cs
+++ b/OpenRA.Mods.Cnc/Installer/ExtractMixSourceAction.cs
@@ -51,13 +51,13 @@ namespace OpenRA.Mods.Cnc.Installer
 
 						Action<long> onProgress = null;
 						if (stream.Length < InstallFromSourceLogic.ShowPercentageThreshold)
-							updateMessage(TranslationProvider.GetString(
+							updateMessage(FluentProvider.GetString(
 								InstallFromSourceLogic.Extracing,
-								Translation.Arguments("filename", displayFilename)));
+								FluentBundle.Arguments("filename", displayFilename)));
 						else
-							onProgress = b => updateMessage(TranslationProvider.GetString(
+							onProgress = b => updateMessage(FluentProvider.GetString(
 								InstallFromSourceLogic.ExtractingProgress,
-								Translation.Arguments("filename", displayFilename, "progress", 100 * b / stream.Length)));
+								FluentBundle.Arguments("filename", displayFilename, "progress", 100 * b / stream.Length)));
 
 						using (var target = File.OpenWrite(targetPath))
 						{

--- a/OpenRA.Mods.Cnc/Installer/ExtractMixSourceAction.cs
+++ b/OpenRA.Mods.Cnc/Installer/ExtractMixSourceAction.cs
@@ -51,13 +51,11 @@ namespace OpenRA.Mods.Cnc.Installer
 
 						Action<long> onProgress = null;
 						if (stream.Length < InstallFromSourceLogic.ShowPercentageThreshold)
-							updateMessage(FluentProvider.GetString(
-								InstallFromSourceLogic.Extracing,
-								FluentBundle.Arguments("filename", displayFilename)));
+							updateMessage(FluentProvider.GetString(InstallFromSourceLogic.Extracting, "filename", displayFilename));
 						else
-							onProgress = b => updateMessage(FluentProvider.GetString(
-								InstallFromSourceLogic.ExtractingProgress,
-								FluentBundle.Arguments("filename", displayFilename, "progress", 100 * b / stream.Length)));
+							onProgress = b => updateMessage(FluentProvider.GetString(InstallFromSourceLogic.ExtractingProgress,
+								"filename", displayFilename,
+								"progress", 100 * b / stream.Length));
 
 						using (var target = File.OpenWrite(targetPath))
 						{

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForCash.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForCash.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sound the victim will hear when they get robbed.")]
 		public readonly string InfiltratedNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification the victim will see when they get robbed.")]
 		public readonly string InfiltratedTextNotification = null;
 
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sound the perpetrator will hear after successful infiltration.")]
 		public readonly string InfiltrationNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification the perpetrator will see after successful infiltration.")]
 		public readonly string InfiltrationTextNotification = null;
 

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForExploration.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForExploration.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sound the victim will hear when they get sabotaged.")]
 		public readonly string InfiltratedNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification the victim will see when they get sabotaged.")]
 		public readonly string InfiltratedTextNotification = null;
 
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sound the perpetrator will hear after successful infiltration.")]
 		public readonly string InfiltrationNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification the perpetrator will see after successful infiltration.")]
 		public readonly string InfiltrationTextNotification = null;
 

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForPowerOutage.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForPowerOutage.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sound the victim will hear when they get sabotaged.")]
 		public readonly string InfiltratedNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification the victim will see when they get sabotaged.")]
 		public readonly string InfiltratedTextNotification = null;
 
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sound the perpetrator will hear after successful infiltration.")]
 		public readonly string InfiltrationNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification the perpetrator will see after successful infiltration.")]
 		public readonly string InfiltrationTextNotification = null;
 

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPower.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sound the victim will hear when technology gets stolen.")]
 		public readonly string InfiltratedNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification the victim will see when technology gets stolen.")]
 		public readonly string InfiltratedTextNotification = null;
 
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sound the perpetrator will hear after successful infiltration.")]
 		public readonly string InfiltrationNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification the perpetrator will see after successful infiltration.")]
 		public readonly string InfiltrationTextNotification = null;
 

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPowerReset.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPowerReset.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Experience to grant to the infiltrating player.")]
 		public readonly int PlayerExperience = 0;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification the victim will see when they get sabotaged.")]
 		public readonly string InfiltratedTextNotification = null;
 
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sound the perpetrator will hear after successful infiltration.")]
 		public readonly string InfiltrationNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification the perpetrator will see after successful infiltration.")]
 		public readonly string InfiltrationTextNotification = null;
 

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Notification to play when a target is infiltrated.")]
 		public readonly string Notification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification to display when a target is infiltrated.")]
 		public readonly string TextNotification = null;
 

--- a/OpenRA.Mods.Cnc/Traits/World/TSVeinsRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSVeinsRenderer.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public readonly string Palette = TileSet.TerrainPaletteInternalName;
 
 		[FieldLoader.Require]
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Resource name used by tooltips.")]
 		public readonly string Name = null;
 
@@ -371,7 +371,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		string IResourceRenderer.GetRenderedResourceTooltip(CPos cell)
 		{
 			if (renderIndices[cell] != null || borders[cell] != Adjacency.None)
-				return TranslationProvider.GetString(info.Name);
+				return FluentProvider.GetString(info.Name);
 
 			return null;
 		}

--- a/OpenRA.Mods.Common/Commands/ChatCommands.cs
+++ b/OpenRA.Mods.Common/Commands/ChatCommands.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Commands
 
 	public class ChatCommands : INotifyChat
 	{
-		[TranslationReference("name")]
+		[FluentReference("name")]
 		const string InvalidCommand = "notification-invalid-command";
 
 		public Dictionary<string, IChatCommand> Commands { get; }
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Commands
 				if (Commands.TryGetValue(name, out var command))
 					command.InvokeCommand(name, message[(1 + name.Length)..].Trim());
 				else
-					TextNotificationsManager.Debug(TranslationProvider.GetString(InvalidCommand, Translation.Arguments("name", name)));
+					TextNotificationsManager.Debug(FluentProvider.GetString(InvalidCommand, FluentBundle.Arguments("name", name)));
 
 				return false;
 			}

--- a/OpenRA.Mods.Common/Commands/ChatCommands.cs
+++ b/OpenRA.Mods.Common/Commands/ChatCommands.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Commands
 				if (Commands.TryGetValue(name, out var command))
 					command.InvokeCommand(name, message[(1 + name.Length)..].Trim());
 				else
-					TextNotificationsManager.Debug(FluentProvider.GetString(InvalidCommand, FluentBundle.Arguments("name", name)));
+					TextNotificationsManager.Debug(FluentProvider.GetString(InvalidCommand, "name", name));
 
 				return false;
 			}

--- a/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
@@ -23,19 +23,19 @@ namespace OpenRA.Mods.Common.Commands
 
 	public class DebugVisualizationCommands : IChatCommand, IWorldLoaded
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string CombatGeometryDescription = "description-combat-geometry";
 
-		[TranslationReference]
+		[FluentReference]
 		const string RenderGeometryDescription = "description-render-geometry";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ScreenMapOverlayDescription = "description-screen-map-overlay";
 
-		[TranslationReference]
+		[FluentReference]
 		const string DepthBufferDescription = "description-depth-buffer";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ActorTagsOverlayDescripition = "description-actor-tags-overlay";
 
 		readonly IDictionary<string, (string Description, Action<DebugVisualizations, DeveloperMode> Handler)> commandHandlers =

--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -24,55 +24,55 @@ namespace OpenRA.Mods.Common.Commands
 
 	public class DevCommands : IChatCommand, IWorldLoaded
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string CheatsDisabled = "notification-cheats-disabled";
 
-		[TranslationReference]
+		[FluentReference]
 		const string InvalidCashAmount = "notification-invalid-cash-amount";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ToggleVisiblityDescription = "description-toggle-visibility";
 
-		[TranslationReference]
+		[FluentReference]
 		const string GiveCashDescription = "description-give-cash";
 
-		[TranslationReference]
+		[FluentReference]
 		const string GiveCashAllDescription = "description-give-cash-all";
 
-		[TranslationReference]
+		[FluentReference]
 		const string InstantBuildingDescription = "description-instant-building";
 
-		[TranslationReference]
+		[FluentReference]
 		const string BuildAnywhereDescription = "description-build-anywhere";
 
-		[TranslationReference]
+		[FluentReference]
 		const string UnlimitedPowerDescription = "description-unlimited-power";
 
-		[TranslationReference]
+		[FluentReference]
 		const string EnableTechDescription = "description-enable-tech";
 
-		[TranslationReference]
+		[FluentReference]
 		const string FastChargeDescription = "description-fast-charge";
 
-		[TranslationReference]
+		[FluentReference]
 		const string DevCheatAllDescription = "description-dev-cheat-all";
 
-		[TranslationReference]
+		[FluentReference]
 		const string DevCrashDescription = "description-dev-crash";
 
-		[TranslationReference]
+		[FluentReference]
 		const string LevelUpActorDescription = "description-levelup-actor";
 
-		[TranslationReference]
+		[FluentReference]
 		const string PlayerExperienceDescription = "description-player-experience";
 
-		[TranslationReference]
+		[FluentReference]
 		const string PowerOutageDescription = "description-power-outage";
 
-		[TranslationReference]
+		[FluentReference]
 		const string KillSelectedActorsDescription = "description-kill-selected-actors";
 
-		[TranslationReference]
+		[FluentReference]
 		const string DisposeSelectedActorsDescription = "description-dispose-selected-actors";
 
 		readonly IDictionary<string, (string Description, Action<string, World> Handler)> commandHandlers = new Dictionary<string, (string, Action<string, World>)>
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.Common.Commands
 
 			if (!developerMode.Enabled)
 			{
-				TextNotificationsManager.Debug(TranslationProvider.GetString(CheatsDisabled));
+				TextNotificationsManager.Debug(FluentProvider.GetString(CheatsDisabled));
 				return;
 			}
 
@@ -149,7 +149,7 @@ namespace OpenRA.Mods.Common.Commands
 				giveCashOrder.ExtraData = (uint)cash;
 			else
 			{
-				TextNotificationsManager.Debug(TranslationProvider.GetString(InvalidCashAmount));
+				TextNotificationsManager.Debug(FluentProvider.GetString(InvalidCashAmount));
 				return;
 			}
 

--- a/OpenRA.Mods.Common/Commands/HelpCommand.cs
+++ b/OpenRA.Mods.Common/Commands/HelpCommand.cs
@@ -22,13 +22,13 @@ namespace OpenRA.Mods.Common.Commands
 
 	public class HelpCommand : IChatCommand, IWorldLoaded
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string AvailableCommands = "notification-available-commands";
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoDescription = "description-no-description";
 
-		[TranslationReference]
+		[FluentReference]
 		const string HelpDescription = "description-help-description";
 
 		readonly Dictionary<string, string> helpDescriptions;
@@ -52,12 +52,12 @@ namespace OpenRA.Mods.Common.Commands
 
 		public void InvokeCommand(string name, string arg)
 		{
-			TextNotificationsManager.Debug(TranslationProvider.GetString(AvailableCommands));
+			TextNotificationsManager.Debug(FluentProvider.GetString(AvailableCommands));
 
 			foreach (var key in console.Commands.Keys.OrderBy(k => k))
 			{
 				if (!helpDescriptions.TryGetValue(key, out var description))
-					description = TranslationProvider.GetString(NoDescription);
+					description = FluentProvider.GetString(NoDescription);
 
 				TextNotificationsManager.Debug($"{key}: {description}");
 			}
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Commands
 
 		public void RegisterHelp(string name, string description)
 		{
-			helpDescriptions[name] = TranslationProvider.GetString(description);
+			helpDescriptions[name] = FluentProvider.GetString(description);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Commands/PlayerCommands.cs
+++ b/OpenRA.Mods.Common/Commands/PlayerCommands.cs
@@ -20,10 +20,10 @@ namespace OpenRA.Mods.Common.Commands
 
 	public class PlayerCommands : IChatCommand, IWorldLoaded
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string PauseDescription = "description-pause-description";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SurrenderDescription = "description-surrender-description";
 
 		World world;

--- a/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Common.Widgets
 	{
 		public string Text { get; private set; }
 
-		[TranslationReference("name", "id")]
+		[FluentReference("name", "id")]
 		const string AddedActor = "notification-added-actor";
 
 		readonly EditorActorLayer editorLayer;
@@ -167,8 +167,8 @@ namespace OpenRA.Mods.Common.Widgets
 		public void Do()
 		{
 			editorActorPreview = editorLayer.Add(actor);
-			Text = TranslationProvider.GetString(AddedActor,
-				Translation.Arguments("name", editorActorPreview.Info.Name, "id", editorActorPreview.ID));
+			Text = FluentProvider.GetString(AddedActor,
+				FluentBundle.Arguments("name", editorActorPreview.Info.Name, "id", editorActorPreview.ID));
 		}
 
 		public void Undo()

--- a/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
@@ -168,7 +168,8 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			editorActorPreview = editorLayer.Add(actor);
 			Text = FluentProvider.GetString(AddedActor,
-				FluentBundle.Arguments("name", editorActorPreview.Info.Name, "id", editorActorPreview.ID));
+				"name", editorActorPreview.Info.Name,
+				"id", editorActorPreview.ID);
 		}
 
 		public void Undo()

--- a/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
@@ -116,7 +116,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 	sealed class CopyPasteEditorAction : IEditorAction
 	{
-		[TranslationReference("amount")]
+		[FluentReference("amount")]
 		const string CopiedTiles = "notification-copied-tiles";
 
 		public string Text { get; }
@@ -146,7 +146,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			undoClipboard = CopySelectionContents();
 
-			Text = TranslationProvider.GetString(CopiedTiles, Translation.Arguments("amount", clipboard.Tiles.Count));
+			Text = FluentProvider.GetString(CopiedTiles, FluentBundle.Arguments("amount", clipboard.Tiles.Count));
 		}
 
 		/// <summary>

--- a/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
@@ -146,7 +146,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			undoClipboard = CopySelectionContents();
 
-			Text = FluentProvider.GetString(CopiedTiles, FluentBundle.Arguments("amount", clipboard.Tiles.Count));
+			Text = FluentProvider.GetString(CopiedTiles, "amount", clipboard.Tiles.Count);
 		}
 
 		/// <summary>

--- a/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
@@ -279,13 +279,13 @@ namespace OpenRA.Mods.Common.Widgets
 
 	sealed class ChangeSelectionAction : IEditorAction
 	{
-		[TranslationReference("x", "y", "width", "height")]
+		[FluentReference("x", "y", "width", "height")]
 		const string SelectedArea = "notification-selected-area";
 
-		[TranslationReference("id")]
+		[FluentReference("id")]
 		const string SelectedActor = "notification-selected-actor";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ClearedSelection = "notification-cleared-selection";
 
 		public string Text { get; }
@@ -308,15 +308,15 @@ namespace OpenRA.Mods.Common.Widgets
 			};
 
 			if (selection.Area != null)
-				Text = TranslationProvider.GetString(SelectedArea, Translation.Arguments(
+				Text = FluentProvider.GetString(SelectedArea, FluentBundle.Arguments(
 						"x", selection.Area.TopLeft.X,
 						"y", selection.Area.TopLeft.Y,
 						"width", selection.Area.BottomRight.X - selection.Area.TopLeft.X,
 						"height", selection.Area.BottomRight.Y - selection.Area.TopLeft.Y));
 			else if (selection.Actor != null)
-				Text = TranslationProvider.GetString(SelectedActor, Translation.Arguments("id", selection.Actor.ID));
+				Text = FluentProvider.GetString(SelectedActor, FluentBundle.Arguments("id", selection.Actor.ID));
 			else
-				Text = TranslationProvider.GetString(ClearedSelection);
+				Text = FluentProvider.GetString(ClearedSelection);
 		}
 
 		public void Execute()
@@ -337,7 +337,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 	sealed class RemoveSelectedActorAction : IEditorAction
 	{
-		[TranslationReference("name", "id")]
+		[FluentReference("name", "id")]
 		const string RemovedActor = "notification-removed-actor";
 
 		public string Text { get; }
@@ -360,8 +360,8 @@ namespace OpenRA.Mods.Common.Widgets
 				Actor = defaultBrush.Selection.Actor
 			};
 
-			Text = TranslationProvider.GetString(RemovedActor,
-				Translation.Arguments("name", actor.Info.Name, "id", actor.ID));
+			Text = FluentProvider.GetString(RemovedActor,
+				FluentBundle.Arguments("name", actor.Info.Name, "id", actor.ID));
 		}
 
 		public void Execute()
@@ -384,7 +384,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 	sealed class RemoveActorAction : IEditorAction
 	{
-		[TranslationReference("name", "id")]
+		[FluentReference("name", "id")]
 		const string RemovedActor = "notification-removed-actor";
 
 		public string Text { get; }
@@ -397,8 +397,8 @@ namespace OpenRA.Mods.Common.Widgets
 			this.editorActorLayer = editorActorLayer;
 			this.actor = actor;
 
-			Text = TranslationProvider.GetString(RemovedActor,
-				Translation.Arguments("name", actor.Info.Name, "id", actor.ID));
+			Text = FluentProvider.GetString(RemovedActor,
+				FluentBundle.Arguments("name", actor.Info.Name, "id", actor.ID));
 		}
 
 		public void Execute()
@@ -419,7 +419,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 	sealed class MoveActorAction : IEditorAction
 	{
-		[TranslationReference("id", "x1", "y1", "x2", "y2")]
+		[FluentReference("id", "x1", "y1", "x2", "y2")]
 		const string MovedActor = "notification-moved-actor";
 
 		public string Text { get; private set; }
@@ -466,13 +466,13 @@ namespace OpenRA.Mods.Common.Widgets
 			to = worldRenderer.Viewport.ViewToWorld(pixelTo + pixelOffset) + cellOffset;
 			layer.MoveActor(actor, to);
 
-			Text = TranslationProvider.GetString(MovedActor, Translation.Arguments("id", actor.ID, "x1", from.X, "y1", from.Y, "x2", to.X, "y2", to.Y));
+			Text = FluentProvider.GetString(MovedActor, FluentBundle.Arguments("id", actor.ID, "x1", from.X, "y1", from.Y, "x2", to.X, "y2", to.Y));
 		}
 	}
 
 	sealed class RemoveResourceAction : IEditorAction
 	{
-		[TranslationReference("type")]
+		[FluentReference("type")]
 		const string RemovedResource = "notification-removed-resource";
 
 		public string Text { get; }
@@ -487,7 +487,7 @@ namespace OpenRA.Mods.Common.Widgets
 			this.resourceLayer = resourceLayer;
 			this.cell = cell;
 
-			Text = TranslationProvider.GetString(RemovedResource, Translation.Arguments("type", resourceType));
+			Text = FluentProvider.GetString(RemovedResource, FluentBundle.Arguments("type", resourceType));
 		}
 
 		public void Execute()

--- a/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
@@ -308,13 +308,13 @@ namespace OpenRA.Mods.Common.Widgets
 			};
 
 			if (selection.Area != null)
-				Text = FluentProvider.GetString(SelectedArea, FluentBundle.Arguments(
-						"x", selection.Area.TopLeft.X,
-						"y", selection.Area.TopLeft.Y,
-						"width", selection.Area.BottomRight.X - selection.Area.TopLeft.X,
-						"height", selection.Area.BottomRight.Y - selection.Area.TopLeft.Y));
+				Text = FluentProvider.GetString(SelectedArea,
+					"x", selection.Area.TopLeft.X,
+					"y", selection.Area.TopLeft.Y,
+					"width", selection.Area.BottomRight.X - selection.Area.TopLeft.X,
+					"height", selection.Area.BottomRight.Y - selection.Area.TopLeft.Y);
 			else if (selection.Actor != null)
-				Text = FluentProvider.GetString(SelectedActor, FluentBundle.Arguments("id", selection.Actor.ID));
+				Text = FluentProvider.GetString(SelectedActor, "id", selection.Actor.ID);
 			else
 				Text = FluentProvider.GetString(ClearedSelection);
 		}
@@ -360,8 +360,7 @@ namespace OpenRA.Mods.Common.Widgets
 				Actor = defaultBrush.Selection.Actor
 			};
 
-			Text = FluentProvider.GetString(RemovedActor,
-				FluentBundle.Arguments("name", actor.Info.Name, "id", actor.ID));
+			Text = FluentProvider.GetString(RemovedActor, "name", actor.Info.Name, "id", actor.ID);
 		}
 
 		public void Execute()
@@ -397,8 +396,7 @@ namespace OpenRA.Mods.Common.Widgets
 			this.editorActorLayer = editorActorLayer;
 			this.actor = actor;
 
-			Text = FluentProvider.GetString(RemovedActor,
-				FluentBundle.Arguments("name", actor.Info.Name, "id", actor.ID));
+			Text = FluentProvider.GetString(RemovedActor, "name", actor.Info.Name, "id", actor.ID);
 		}
 
 		public void Execute()
@@ -466,7 +464,7 @@ namespace OpenRA.Mods.Common.Widgets
 			to = worldRenderer.Viewport.ViewToWorld(pixelTo + pixelOffset) + cellOffset;
 			layer.MoveActor(actor, to);
 
-			Text = FluentProvider.GetString(MovedActor, FluentBundle.Arguments("id", actor.ID, "x1", from.X, "y1", from.Y, "x2", to.X, "y2", to.Y));
+			Text = FluentProvider.GetString(MovedActor, "id", actor.ID, "x1", from.X, "y1", from.Y, "x2", to.X, "y2", to.Y);
 		}
 	}
 
@@ -487,7 +485,7 @@ namespace OpenRA.Mods.Common.Widgets
 			this.resourceLayer = resourceLayer;
 			this.cell = cell;
 
-			Text = FluentProvider.GetString(RemovedResource, FluentBundle.Arguments("type", resourceType));
+			Text = FluentProvider.GetString(RemovedResource, "type", resourceType);
 		}
 
 		public void Execute()

--- a/OpenRA.Mods.Common/EditorBrushes/EditorMarkerLayerBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorMarkerLayerBrush.cs
@@ -150,9 +150,9 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 
 			if (type != null)
-				Text = FluentProvider.GetString(AddedMarkerTiles, FluentBundle.Arguments("amount", paintTiles.Count, "type", type));
+				Text = FluentProvider.GetString(AddedMarkerTiles, "amount", paintTiles.Count, "type", type);
 			else
-				Text = FluentProvider.GetString(RemovedMarkerTiles, FluentBundle.Arguments("amount", paintTiles.Count));
+				Text = FluentProvider.GetString(RemovedMarkerTiles, "amount", paintTiles.Count);
 		}
 	}
 
@@ -176,7 +176,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			tiles = new HashSet<CPos>(markerLayerOverlay.Tiles[tile]);
 
-			Text = FluentProvider.GetString(ClearedSelectedMarkerTiles, FluentBundle.Arguments("amount", tiles.Count, "type", tile));
+			Text = FluentProvider.GetString(ClearedSelectedMarkerTiles, "amount", tiles.Count, "type", tile);
 		}
 
 		public void Execute()
@@ -213,7 +213,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var allTilesCount = tiles.Values.Select(x => x.Count).Sum();
 
-			Text = FluentProvider.GetString(ClearedAllMarkerTiles, FluentBundle.Arguments("amount", allTilesCount));
+			Text = FluentProvider.GetString(ClearedAllMarkerTiles, "amount", allTilesCount);
 		}
 
 		public void Execute()

--- a/OpenRA.Mods.Common/EditorBrushes/EditorMarkerLayerBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorMarkerLayerBrush.cs
@@ -98,10 +98,10 @@ namespace OpenRA.Mods.Common.Widgets
 
 	class PaintMarkerTileEditorAction : IEditorAction
 	{
-		[TranslationReference("amount", "type")]
+		[FluentReference("amount", "type")]
 		const string AddedMarkerTiles = "notification-added-marker-tiles";
 
-		[TranslationReference("amount")]
+		[FluentReference("amount")]
 		const string RemovedMarkerTiles = "notification-removed-marker-tiles";
 
 		public string Text { get; private set; }
@@ -150,15 +150,15 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 
 			if (type != null)
-				Text = TranslationProvider.GetString(AddedMarkerTiles, Translation.Arguments("amount", paintTiles.Count, "type", type));
+				Text = FluentProvider.GetString(AddedMarkerTiles, FluentBundle.Arguments("amount", paintTiles.Count, "type", type));
 			else
-				Text = TranslationProvider.GetString(RemovedMarkerTiles, Translation.Arguments("amount", paintTiles.Count));
+				Text = FluentProvider.GetString(RemovedMarkerTiles, FluentBundle.Arguments("amount", paintTiles.Count));
 		}
 	}
 
 	class ClearSelectedMarkerTilesEditorAction : IEditorAction
 	{
-		[TranslationReference("amount", "type")]
+		[FluentReference("amount", "type")]
 		const string ClearedSelectedMarkerTiles = "notification-cleared-selected-marker-tiles";
 
 		public string Text { get; }
@@ -176,7 +176,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			tiles = new HashSet<CPos>(markerLayerOverlay.Tiles[tile]);
 
-			Text = TranslationProvider.GetString(ClearedSelectedMarkerTiles, Translation.Arguments("amount", tiles.Count, "type", tile));
+			Text = FluentProvider.GetString(ClearedSelectedMarkerTiles, FluentBundle.Arguments("amount", tiles.Count, "type", tile));
 		}
 
 		public void Execute()
@@ -197,7 +197,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 	class ClearAllMarkerTilesEditorAction : IEditorAction
 	{
-		[TranslationReference("amount")]
+		[FluentReference("amount")]
 		const string ClearedAllMarkerTiles = "notification-cleared-all-marker-tiles";
 
 		public string Text { get; }
@@ -213,7 +213,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var allTilesCount = tiles.Values.Select(x => x.Count).Sum();
 
-			Text = TranslationProvider.GetString(ClearedAllMarkerTiles, Translation.Arguments("amount", allTilesCount));
+			Text = FluentProvider.GetString(ClearedAllMarkerTiles, FluentBundle.Arguments("amount", allTilesCount));
 		}
 
 		public void Execute()

--- a/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
@@ -168,7 +168,7 @@ namespace OpenRA.Mods.Common.Widgets
 			resourceLayer.ClearResources(resourceCell.Cell);
 			resourceLayer.AddResource(resourceCell.NewResourceType, resourceCell.Cell, resourceLayer.GetMaxDensity(resourceCell.NewResourceType));
 			cellResources.Add(resourceCell);
-			Text = FluentProvider.GetString(AddedResource, FluentBundle.Arguments("amount", cellResources.Count, "type", resourceType));
+			Text = FluentProvider.GetString(AddedResource, "amount", cellResources.Count, "type", resourceType);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
@@ -125,7 +125,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 	sealed class AddResourcesEditorAction : IEditorAction
 	{
-		[TranslationReference("amount", "type")]
+		[FluentReference("amount", "type")]
 		const string AddedResource = "notification-added-resource";
 
 		public string Text { get; private set; }
@@ -168,7 +168,7 @@ namespace OpenRA.Mods.Common.Widgets
 			resourceLayer.ClearResources(resourceCell.Cell);
 			resourceLayer.AddResource(resourceCell.NewResourceType, resourceCell.Cell, resourceLayer.GetMaxDensity(resourceCell.NewResourceType));
 			cellResources.Add(resourceCell);
-			Text = TranslationProvider.GetString(AddedResource, Translation.Arguments("amount", cellResources.Count, "type", resourceType));
+			Text = FluentProvider.GetString(AddedResource, FluentBundle.Arguments("amount", cellResources.Count, "type", resourceType));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
@@ -192,7 +192,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var terrainInfo = (ITemplatedTerrainInfo)map.Rules.TerrainInfo;
 			terrainTemplate = terrainInfo.Templates[template];
-			Text = FluentProvider.GetString(AddedTile, FluentBundle.Arguments("id", terrainTemplate.Id));
+			Text = FluentProvider.GetString(AddedTile, "id", terrainTemplate.Id);
 		}
 
 		public void Execute()
@@ -264,7 +264,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var terrainInfo = (ITemplatedTerrainInfo)map.Rules.TerrainInfo;
 			terrainTemplate = terrainInfo.Templates[template];
-			Text = FluentProvider.GetString(FilledTile, FluentBundle.Arguments("id", terrainTemplate.Id));
+			Text = FluentProvider.GetString(FilledTile, "id", terrainTemplate.Id);
 		}
 
 		public void Execute()

--- a/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
@@ -172,7 +172,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 	sealed class PaintTileEditorAction : IEditorAction
 	{
-		[TranslationReference("id")]
+		[FluentReference("id")]
 		const string AddedTile = "notification-added-tile";
 
 		public string Text { get; }
@@ -192,7 +192,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var terrainInfo = (ITemplatedTerrainInfo)map.Rules.TerrainInfo;
 			terrainTemplate = terrainInfo.Templates[template];
-			Text = TranslationProvider.GetString(AddedTile, Translation.Arguments("id", terrainTemplate.Id));
+			Text = FluentProvider.GetString(AddedTile, FluentBundle.Arguments("id", terrainTemplate.Id));
 		}
 
 		public void Execute()
@@ -244,7 +244,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 	sealed class FloodFillEditorAction : IEditorAction
 	{
-		[TranslationReference("id")]
+		[FluentReference("id")]
 		const string FilledTile = "notification-filled-tile";
 
 		public string Text { get; }
@@ -264,7 +264,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var terrainInfo = (ITemplatedTerrainInfo)map.Rules.TerrainInfo;
 			terrainTemplate = terrainInfo.Templates[template];
-			Text = TranslationProvider.GetString(FilledTile, Translation.Arguments("id", terrainTemplate.Id));
+			Text = FluentProvider.GetString(FilledTile, FluentBundle.Arguments("id", terrainTemplate.Id));
 		}
 
 		public void Execute()

--- a/OpenRA.Mods.Common/Installer/SourceActions/CopySourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/CopySourceAction.cs
@@ -44,13 +44,13 @@ namespace OpenRA.Mods.Common.Installer
 
 					Action<long> onProgress = null;
 					if (length < InstallFromSourceLogic.ShowPercentageThreshold)
-						updateMessage(TranslationProvider.GetString(
+						updateMessage(FluentProvider.GetString(
 							InstallFromSourceLogic.CopyingFilename,
-							Translation.Arguments("filename", displayFilename)));
+							FluentBundle.Arguments("filename", displayFilename)));
 					else
-						onProgress = b => updateMessage(TranslationProvider.GetString(
+						onProgress = b => updateMessage(FluentProvider.GetString(
 							InstallFromSourceLogic.CopyingFilenameProgress,
-							Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
+							FluentBundle.Arguments("filename", displayFilename, "progress", 100 * b / length)));
 
 					InstallerUtils.CopyStream(source, target, length, onProgress);
 				}

--- a/OpenRA.Mods.Common/Installer/SourceActions/CopySourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/CopySourceAction.cs
@@ -44,13 +44,12 @@ namespace OpenRA.Mods.Common.Installer
 
 					Action<long> onProgress = null;
 					if (length < InstallFromSourceLogic.ShowPercentageThreshold)
-						updateMessage(FluentProvider.GetString(
-							InstallFromSourceLogic.CopyingFilename,
-							FluentBundle.Arguments("filename", displayFilename)));
+						updateMessage(FluentProvider.GetString(InstallFromSourceLogic.CopyingFilename,
+							"filename", displayFilename));
 					else
-						onProgress = b => updateMessage(FluentProvider.GetString(
-							InstallFromSourceLogic.CopyingFilenameProgress,
-							FluentBundle.Arguments("filename", displayFilename, "progress", 100 * b / length)));
+						onProgress = b => updateMessage(FluentProvider.GetString(InstallFromSourceLogic.CopyingFilenameProgress,
+							"filename", displayFilename,
+							"progress", 100 * b / length));
 
 					InstallerUtils.CopyStream(source, target, length, onProgress);
 				}

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractBlastSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractBlastSourceAction.cs
@@ -68,13 +68,13 @@ namespace OpenRA.Mods.Common.Installer
 
 					Action<long> onProgress = null;
 					if (length < InstallFromSourceLogic.ShowPercentageThreshold)
-						updateMessage(TranslationProvider.GetString(
+						updateMessage(FluentProvider.GetString(
 							InstallFromSourceLogic.Extracing,
-							Translation.Arguments("filename", displayFilename)));
+							FluentBundle.Arguments("filename", displayFilename)));
 					else
-						onProgress = b => updateMessage(TranslationProvider.GetString(
+						onProgress = b => updateMessage(FluentProvider.GetString(
 							InstallFromSourceLogic.ExtractingProgress,
-							Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
+							FluentBundle.Arguments("filename", displayFilename, "progress", 100 * b / length)));
 
 					using (var target = File.OpenWrite(targetPath))
 					{

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractBlastSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractBlastSourceAction.cs
@@ -68,13 +68,12 @@ namespace OpenRA.Mods.Common.Installer
 
 					Action<long> onProgress = null;
 					if (length < InstallFromSourceLogic.ShowPercentageThreshold)
-						updateMessage(FluentProvider.GetString(
-							InstallFromSourceLogic.Extracing,
-							FluentBundle.Arguments("filename", displayFilename)));
+						updateMessage(FluentProvider.GetString(InstallFromSourceLogic.Extracting,
+							"filename", displayFilename));
 					else
-						onProgress = b => updateMessage(FluentProvider.GetString(
-							InstallFromSourceLogic.ExtractingProgress,
-							FluentBundle.Arguments("filename", displayFilename, "progress", 100 * b / length)));
+						onProgress = b => updateMessage(FluentProvider.GetString(InstallFromSourceLogic.ExtractingProgress,
+							"filename", displayFilename,
+							"progress", 100 * b / length));
 
 					using (var target = File.OpenWrite(targetPath))
 					{

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractIscabSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractIscabSourceAction.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Installer
 							var displayFilename = Path.GetFileName(Path.GetFileName(targetPath));
 							void OnProgress(int percent) => updateMessage(FluentProvider.GetString(
 								InstallFromSourceLogic.ExtractingProgress,
-								FluentBundle.Arguments("filename", displayFilename, "progress", percent)));
+								"filename", displayFilename, "progress", percent));
 							reader.ExtractFile(node.Value.Value, target, OnProgress);
 						}
 					}

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractIscabSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractIscabSourceAction.cs
@@ -64,9 +64,9 @@ namespace OpenRA.Mods.Common.Installer
 						{
 							Log.Write("install", $"Extracting {sourcePath} -> {targetPath}");
 							var displayFilename = Path.GetFileName(Path.GetFileName(targetPath));
-							void OnProgress(int percent) => updateMessage(TranslationProvider.GetString(
+							void OnProgress(int percent) => updateMessage(FluentProvider.GetString(
 								InstallFromSourceLogic.ExtractingProgress,
-								Translation.Arguments("filename", displayFilename, "progress", percent)));
+								FluentBundle.Arguments("filename", displayFilename, "progress", percent)));
 							reader.ExtractFile(node.Value.Value, target, OnProgress);
 						}
 					}

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractMscabSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractMscabSourceAction.cs
@@ -46,9 +46,9 @@ namespace OpenRA.Mods.Common.Installer
 					{
 						Log.Write("install", $"Extracting {sourcePath} -> {targetPath}");
 						var displayFilename = Path.GetFileName(Path.GetFileName(targetPath));
-						void OnProgress(int percent) => updateMessage(TranslationProvider.GetString(
+						void OnProgress(int percent) => updateMessage(FluentProvider.GetString(
 							InstallFromSourceLogic.ExtractingProgress,
-							Translation.Arguments("filename", displayFilename, "progress", percent)));
+							FluentBundle.Arguments("filename", displayFilename, "progress", percent)));
 						reader.ExtractFile(node.Value.Value, target, OnProgress);
 					}
 				}

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractMscabSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractMscabSourceAction.cs
@@ -46,9 +46,9 @@ namespace OpenRA.Mods.Common.Installer
 					{
 						Log.Write("install", $"Extracting {sourcePath} -> {targetPath}");
 						var displayFilename = Path.GetFileName(Path.GetFileName(targetPath));
-						void OnProgress(int percent) => updateMessage(FluentProvider.GetString(
-							InstallFromSourceLogic.ExtractingProgress,
-							FluentBundle.Arguments("filename", displayFilename, "progress", percent)));
+						void OnProgress(int percent) => updateMessage(FluentProvider.GetString(InstallFromSourceLogic.ExtractingProgress,
+							"filename", displayFilename,
+							"progress", percent));
 						reader.ExtractFile(node.Value.Value, target, OnProgress);
 					}
 				}

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractRawSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractRawSourceAction.cs
@@ -61,11 +61,12 @@ namespace OpenRA.Mods.Common.Installer
 
 					Action<long> onProgress = null;
 					if (length < InstallFromSourceLogic.ShowPercentageThreshold)
-						updateMessage(FluentProvider.GetString(InstallFromSourceLogic.Extracing, FluentBundle.Arguments("filename", displayFilename)));
+						updateMessage(FluentProvider.GetString(InstallFromSourceLogic.Extracting,
+							"filename", displayFilename));
 					else
-						onProgress = b => updateMessage(FluentProvider.GetString(
-							InstallFromSourceLogic.ExtractingProgress,
-							FluentBundle.Arguments("filename", displayFilename, "progress", 100 * b / length)));
+						onProgress = b => updateMessage(FluentProvider.GetString(InstallFromSourceLogic.ExtractingProgress,
+							"filename", displayFilename,
+							"progress", 100 * b / length));
 
 					using (var target = File.OpenWrite(targetPath))
 					{

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractRawSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractRawSourceAction.cs
@@ -61,11 +61,11 @@ namespace OpenRA.Mods.Common.Installer
 
 					Action<long> onProgress = null;
 					if (length < InstallFromSourceLogic.ShowPercentageThreshold)
-						updateMessage(TranslationProvider.GetString(InstallFromSourceLogic.Extracing, Translation.Arguments("filename", displayFilename)));
+						updateMessage(FluentProvider.GetString(InstallFromSourceLogic.Extracing, FluentBundle.Arguments("filename", displayFilename)));
 					else
-						onProgress = b => updateMessage(TranslationProvider.GetString(
+						onProgress = b => updateMessage(FluentProvider.GetString(
 							InstallFromSourceLogic.ExtractingProgress,
-							Translation.Arguments("filename", displayFilename, "progress", 100 * b / length)));
+							FluentBundle.Arguments("filename", displayFilename, "progress", 100 * b / length)));
 
 					using (var target = File.OpenWrite(targetPath))
 					{

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractZipSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractZipSourceAction.cs
@@ -49,9 +49,9 @@ namespace OpenRA.Mods.Common.Installer
 					using (var targetStream = File.OpenWrite(targetPath))
 						sourceStream.CopyTo(targetStream);
 
-					updateMessage(FluentProvider.GetString(
-						InstallFromSourceLogic.ExtractingProgress,
-						FluentBundle.Arguments("filename", displayFilename, "progress", 100)));
+					updateMessage(FluentProvider.GetString(InstallFromSourceLogic.ExtractingProgress,
+						"filename", displayFilename,
+						"progress", 100));
 
 					extracted.Add(targetPath);
 				}

--- a/OpenRA.Mods.Common/Installer/SourceActions/ExtractZipSourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/ExtractZipSourceAction.cs
@@ -49,9 +49,9 @@ namespace OpenRA.Mods.Common.Installer
 					using (var targetStream = File.OpenWrite(targetPath))
 						sourceStream.CopyTo(targetStream);
 
-					updateMessage(TranslationProvider.GetString(
+					updateMessage(FluentProvider.GetString(
 						InstallFromSourceLogic.ExtractingProgress,
-						Translation.Arguments("filename", displayFilename, "progress", 100)));
+						FluentBundle.Arguments("filename", displayFilename, "progress", 100)));
 
 					extracted.Add(targetPath);
 				}

--- a/OpenRA.Mods.Common/Lint/CheckFluentReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckFluentReferences.cs
@@ -27,23 +27,23 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	sealed class CheckTranslationReference : ILintPass, ILintMapPass
+	sealed class CheckFluentReferences : ILintPass, ILintMapPass
 	{
-		static readonly Regex TranslationFilenameRegex = new(@"(?<language>[^\/\\]+)\.ftl$");
+		static readonly Regex FilenameRegex = new(@"(?<language>[^\/\\]+)\.ftl$");
 
 		void ILintMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
 		{
 			if (map.TranslationDefinitions == null)
 				return;
 
-			var usedKeys = GetUsedTranslationKeysInMap(map, emitWarning);
+			var usedKeys = GetUsedFluentKeysInMap(map, emitWarning);
 
 			foreach (var context in usedKeys.EmptyKeyContexts)
-				emitWarning($"Empty key in map translation files required by {context}");
+				emitWarning($"Empty key in map ftl files required by {context}");
 
 			var mapTranslations = FieldLoader.GetValue<string[]>("value", map.TranslationDefinitions.Value);
 
-			foreach (var language in GetTranslationLanguages(modData))
+			foreach (var language in GetModLanguages(modData))
 			{
 				// Check keys and variables are not missing across all language files.
 				// But for maps we don't warn on unused keys. They might be unused on *this* map,
@@ -52,20 +52,20 @@ namespace OpenRA.Mods.Common.Lint
 					modData.Manifest.Translations.Concat(mapTranslations), map.Open, usedKeys,
 					language, _ => false, emitError, emitWarning);
 
-				var modTranslation = new Translation(language, modData.Manifest.Translations, modData.DefaultFileSystem, _ => { });
-				var mapTranslation = new Translation(language, mapTranslations, map, error => emitError(error.Message));
+				var modFluentBundle = new FluentBundle(language, modData.Manifest.Translations, modData.DefaultFileSystem, _ => { });
+				var mapFluentBundle = new FluentBundle(language, mapTranslations, map, error => emitError(error.Message));
 
 				foreach (var group in usedKeys.KeysWithContext)
 				{
-					if (modTranslation.HasMessage(group.Key))
+					if (modFluentBundle.HasMessage(group.Key))
 					{
-						if (mapTranslation.HasMessage(group.Key))
-							emitWarning($"Key `{group.Key}` in `{language}` language in map translation files already exists in mod translations and will not be used.");
+						if (mapFluentBundle.HasMessage(group.Key))
+							emitWarning($"Key `{group.Key}` in `{language}` language in map ftl files already exists in mod translations and will not be used.");
 					}
-					else if (!mapTranslation.HasMessage(group.Key))
+					else if (!mapFluentBundle.HasMessage(group.Key))
 					{
 						foreach (var context in group)
-							emitWarning($"Missing key `{group.Key}` in `{language}` language in map translation files required by {context}");
+							emitWarning($"Missing key `{group.Key}` in `{language}` language in map ftl files required by {context}");
 					}
 				}
 			}
@@ -73,15 +73,14 @@ namespace OpenRA.Mods.Common.Lint
 
 		void ILintPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData)
 		{
-			var (usedKeys, testedFields) = GetUsedTranslationKeysInMod(modData);
+			var (usedKeys, testedFields) = GetUsedFluentKeysInMod(modData);
 
 			foreach (var context in usedKeys.EmptyKeyContexts)
 				emitWarning($"Empty key in mod translation files required by {context}");
 
-			foreach (var language in GetTranslationLanguages(modData))
+			foreach (var language in GetModLanguages(modData))
 			{
-				Console.WriteLine($"Testing translation: {language}");
-				var translation = new Translation(language, modData.Manifest.Translations, modData.DefaultFileSystem, error => emitError(error.Message));
+				Console.WriteLine($"Testing language: {language}");
 				CheckModWidgets(modData, usedKeys, testedFields);
 
 				// With the fully populated keys, check keys and variables are not missing and not unused across all language files.
@@ -99,32 +98,32 @@ namespace OpenRA.Mods.Common.Lint
 						continue;
 
 					foreach (var context in group)
-						emitWarning($"Missing key `{group.Key}` in `{language}` language in mod translation files required by {context}");
+						emitWarning($"Missing key `{group.Key}` in `{language}` language in mod ftl files required by {context}");
 				}
 			}
 
 			// Check if we couldn't test any fields.
 			const BindingFlags Binding = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
-			var allTranslatableFields = modData.ObjectCreator.GetTypes().SelectMany(t =>
-				t.GetFields(Binding).Where(m => Utility.HasAttribute<TranslationReferenceAttribute>(m))).ToArray();
-			var untestedFields = allTranslatableFields.Except(testedFields);
+			var allFluentFields = modData.ObjectCreator.GetTypes().SelectMany(t =>
+				t.GetFields(Binding).Where(m => Utility.HasAttribute<FluentReferenceAttribute>(m))).ToArray();
+			var untestedFields = allFluentFields.Except(testedFields);
 			foreach (var field in untestedFields)
 				emitError(
-					$"Lint pass ({nameof(CheckTranslationReference)}) lacks the know-how to test translatable field " +
+					$"Lint pass ({nameof(CheckFluentReferences)}) lacks the know-how to test translatable field " +
 					$"`{field.ReflectedType.Name}.{field.Name}` - previous warnings may be incorrect");
 		}
 
-		static IEnumerable<string> GetTranslationLanguages(ModData modData)
+		static IEnumerable<string> GetModLanguages(ModData modData)
 		{
 			return modData.Manifest.Translations
-				.Select(filename => TranslationFilenameRegex.Match(filename).Groups["language"].Value)
+				.Select(filename => FilenameRegex.Match(filename).Groups["language"].Value)
 				.Distinct()
 				.OrderBy(l => l);
 		}
 
-		static TranslationKeys GetUsedTranslationKeysInRuleset(Ruleset rules)
+		static Keys GetUsedFluentKeysInRuleset(Ruleset rules)
 		{
-			var usedKeys = new TranslationKeys();
+			var usedKeys = new Keys();
 			foreach (var actorInfo in rules.Actors)
 			{
 				foreach (var traitInfo in actorInfo.Value.TraitInfos<TraitInfo>())
@@ -132,12 +131,12 @@ namespace OpenRA.Mods.Common.Lint
 					var traitType = traitInfo.GetType();
 					foreach (var field in Utility.GetFields(traitType))
 					{
-						var translationReference = Utility.GetCustomAttributes<TranslationReferenceAttribute>(field, true).SingleOrDefault();
-						if (translationReference == null)
+						var fluentReference = Utility.GetCustomAttributes<FluentReferenceAttribute>(field, true).SingleOrDefault();
+						if (fluentReference == null)
 							continue;
 
-						foreach (var key in LintExts.GetFieldValues(traitInfo, field, translationReference.DictionaryReference))
-							usedKeys.Add(key, translationReference, $"Actor `{actorInfo.Key}` trait `{traitType.Name[..^4]}.{field.Name}`");
+						foreach (var key in LintExts.GetFieldValues(traitInfo, field, fluentReference.DictionaryReference))
+							usedKeys.Add(key, fluentReference, $"Actor `{actorInfo.Key}` trait `{traitType.Name[..^4]}.{field.Name}`");
 					}
 				}
 			}
@@ -149,12 +148,12 @@ namespace OpenRA.Mods.Common.Lint
 					var warheadType = warhead.GetType();
 					foreach (var field in Utility.GetFields(warheadType))
 					{
-						var translationReference = Utility.GetCustomAttributes<TranslationReferenceAttribute>(field, true).SingleOrDefault();
-						if (translationReference == null)
+						var fluentReference = Utility.GetCustomAttributes<FluentReferenceAttribute>(field, true).SingleOrDefault();
+						if (fluentReference == null)
 							continue;
 
-						foreach (var key in LintExts.GetFieldValues(warhead, field, translationReference.DictionaryReference))
-							usedKeys.Add(key, translationReference, $"Weapon `{weapon.Key}` warhead `{warheadType.Name[..^7]}.{field.Name}`");
+						foreach (var key in LintExts.GetFieldValues(warhead, field, fluentReference.DictionaryReference))
+							usedKeys.Add(key, fluentReference, $"Weapon `{weapon.Key}` warhead `{warheadType.Name[..^7]}.{field.Name}`");
 					}
 				}
 			}
@@ -162,40 +161,40 @@ namespace OpenRA.Mods.Common.Lint
 			return usedKeys;
 		}
 
-		static TranslationKeys GetUsedTranslationKeysInMap(Map map, Action<string> emitWarning)
+		static Keys GetUsedFluentKeysInMap(Map map, Action<string> emitWarning)
 		{
-			var usedKeys = GetUsedTranslationKeysInRuleset(map.Rules);
+			var usedKeys = GetUsedFluentKeysInRuleset(map.Rules);
 
 			var luaScriptInfo = map.Rules.Actors[SystemActors.World].TraitInfoOrDefault<LuaScriptInfo>();
 			if (luaScriptInfo != null)
 			{
 				// Matches expressions such as:
-				// UserInterface.Translate("translation-key")
-				// UserInterface.Translate("translation-key\"with-escape")
-				// UserInterface.Translate("translation-key", { ["attribute"] = foo })
-				// UserInterface.Translate("translation-key", { ["attribute\"-with-escape"] = foo })
-				// UserInterface.Translate("translation-key", { ["attribute1"] = foo, ["attribute2"] = bar })
-				// UserInterface.Translate("translation-key", tableVariable)
+				// UserInterface.Translate("fluent-key")
+				// UserInterface.Translate("fluent-key\"with-escape")
+				// UserInterface.Translate("fluent-key", { ["attribute"] = foo })
+				// UserInterface.Translate("fluent-key", { ["attribute\"-with-escape"] = foo })
+				// UserInterface.Translate("fluent-key", { ["attribute1"] = foo, ["attribute2"] = bar })
+				// UserInterface.Translate("fluent-key", tableVariable)
 				// Extracts groups for the 'key' and each 'attr'.
 				// If the table isn't inline like in the last example, extracts it as 'variable'.
 				const string UserInterfaceTranslatePattern =
 					@"UserInterface\s*\.\s*Translate\s*\(" + // UserInterface.Translate(
-					@"\s*""(?<key>(?:[^""\\]|\\.)+?)""\s*" + // "translation-key"
+					@"\s*""(?<key>(?:[^""\\]|\\.)+?)""\s*" + // "fluent-key"
 					@"(,\s*({\s*\[\s*""(?<attr>(?:[^""\\]|\\.)*?)""\s*\]\s*=\s*.*?" + // { ["attribute1"] = foo
 					@"(\s*,\s*\[\s*""(?<attr>(?:[^""\\]|\\.)*?)""\s*\]\s*=\s*.*?)*\s*}\s*)" + // , ["attribute2"] = bar }
 					"|\\s*,\\s*(?<variable>.*?))?" + // tableVariable
 					@"\)"; // )
 				var translateRegex = new Regex(UserInterfaceTranslatePattern);
 
-				// The script in mods/common/scripts/utils.lua defines some helpers which accept a translation key
+				// The script in mods/common/scripts/utils.lua defines some helpers which accept a fluent key
 				// Matches expressions such as:
-				// AddPrimaryObjective(Player, "translation-key")
-				// AddSecondaryObjective(Player, "translation-key")
-				// AddPrimaryObjective(Player, "translation-key\"with-escape")
+				// AddPrimaryObjective(Player, "fluent-key")
+				// AddSecondaryObjective(Player, "fluent-key")
+				// AddPrimaryObjective(Player, "fluent-key\"with-escape")
 				// Extracts groups for the 'key'.
 				const string AddObjectivePattern =
 					@"(AddPrimaryObjective|AddSecondaryObjective)\s*\(" + // AddPrimaryObjective(
-					@".*?\s*,\s*""(?<key>(?:[^""\\]|\\.)+?)""\s*" + // Player, "translation-key"
+					@".*?\s*,\s*""(?<key>(?:[^""\\]|\\.)+?)""\s*" + // Player, "fluent-key"
 					@"\)"; // )
 				var objectiveRegex = new Regex(AddObjectivePattern);
 
@@ -210,7 +209,8 @@ namespace OpenRA.Mods.Common.Lint
 						IEnumerable<Match> matches = translateRegex.Matches(scriptText);
 						if (luaScriptInfo.Scripts.Contains("utils.lua"))
 							matches = matches.Concat(objectiveRegex.Matches(scriptText));
-						var scriptTranslations = matches.Select(m =>
+
+						var references = matches.Select(m =>
 						{
 							var key = m.Groups["key"].Value.Replace(@"\""", @"""");
 							var attrs = m.Groups["attr"].Captures.Select(c => c.Value.Replace(@"\""", @"""")).ToArray();
@@ -218,10 +218,11 @@ namespace OpenRA.Mods.Common.Lint
 							var line = scriptText.Take(m.Index).Count(x => x == '\n') + 1;
 							return (Key: key, Attrs: attrs, Variable: variable, Line: line);
 						}).ToArray();
-						foreach (var (key, attrs, variable, line) in scriptTranslations)
+
+						foreach (var (key, attrs, variable, line) in references)
 						{
 							var context = $"Script {script}:{line}";
-							usedKeys.Add(key, new TranslationReferenceAttribute(attrs), context);
+							usedKeys.Add(key, new FluentReferenceAttribute(attrs), context);
 
 							if (variable != "")
 							{
@@ -239,22 +240,22 @@ namespace OpenRA.Mods.Common.Lint
 			return usedKeys;
 		}
 
-		static (TranslationKeys UsedKeys, List<FieldInfo> TestedFields) GetUsedTranslationKeysInMod(ModData modData)
+		static (Keys UsedKeys, List<FieldInfo> TestedFields) GetUsedFluentKeysInMod(ModData modData)
 		{
-			var usedKeys = GetUsedTranslationKeysInRuleset(modData.DefaultRules);
+			var usedKeys = GetUsedFluentKeysInRuleset(modData.DefaultRules);
 			var testedFields = new List<FieldInfo>();
 			testedFields.AddRange(
 				modData.ObjectCreator.GetTypes()
 				.Where(t => t.IsSubclassOf(typeof(TraitInfo)) || t.IsSubclassOf(typeof(Warhead)))
-				.SelectMany(t => t.GetFields().Where(f => f.HasAttribute<TranslationReferenceAttribute>())));
+				.SelectMany(t => t.GetFields().Where(f => f.HasAttribute<FluentReferenceAttribute>())));
 
 			// HACK: Need to hardcode the custom loader for GameSpeeds.
 			var gameSpeeds = modData.Manifest.Get<GameSpeeds>();
 			var gameSpeedNameField = typeof(GameSpeed).GetField(nameof(GameSpeed.Name));
-			var gameSpeedTranslationReference = Utility.GetCustomAttributes<TranslationReferenceAttribute>(gameSpeedNameField, true)[0];
+			var gameSpeedFluentReference = Utility.GetCustomAttributes<FluentReferenceAttribute>(gameSpeedNameField, true)[0];
 			testedFields.Add(gameSpeedNameField);
 			foreach (var speed in gameSpeeds.Speeds.Values)
-				usedKeys.Add(speed.Name, gameSpeedTranslationReference, $"`{nameof(GameSpeed)}.{nameof(GameSpeed.Name)}`");
+				usedKeys.Add(speed.Name, gameSpeedFluentReference, $"`{nameof(GameSpeed)}.{nameof(GameSpeed.Name)}`");
 
 			// TODO: linter does not work with LoadUsing
 			foreach (var actorInfo in modData.DefaultRules.Actors)
@@ -262,12 +263,12 @@ namespace OpenRA.Mods.Common.Lint
 				foreach (var info in actorInfo.Value.TraitInfos<ResourceRendererInfo>())
 				{
 					var resourceTypeNameField = typeof(ResourceRendererInfo.ResourceTypeInfo).GetField(nameof(ResourceRendererInfo.ResourceTypeInfo.Name));
-					var resourceTypeTranslationReference = Utility.GetCustomAttributes<TranslationReferenceAttribute>(resourceTypeNameField, true)[0];
+					var resourceTypeFluentReference = Utility.GetCustomAttributes<FluentReferenceAttribute>(resourceTypeNameField, true)[0];
 					testedFields.Add(resourceTypeNameField);
 					foreach (var resourceTypes in info.ResourceTypes)
 						usedKeys.Add(
 							resourceTypes.Value.Name,
-							resourceTypeTranslationReference,
+							resourceTypeFluentReference,
 							$"`{nameof(ResourceRendererInfo.ResourceTypeInfo)}.{nameof(ResourceRendererInfo.ResourceTypeInfo.Name)}`");
 				}
 			}
@@ -281,47 +282,48 @@ namespace OpenRA.Mods.Common.Lint
 					if (!field.IsLiteral)
 						continue;
 
-					var translationReference = Utility.GetCustomAttributes<TranslationReferenceAttribute>(field, true).SingleOrDefault();
-					if (translationReference == null)
+					var fluentReference = Utility.GetCustomAttributes<FluentReferenceAttribute>(field, true).SingleOrDefault();
+					if (fluentReference == null)
 						continue;
 
 					testedFields.Add(field);
-					var keys = LintExts.GetFieldValues(null, field, translationReference.DictionaryReference);
+					var keys = LintExts.GetFieldValues(null, field, fluentReference.DictionaryReference);
 					foreach (var key in keys)
-						usedKeys.Add(key, translationReference, $"`{field.ReflectedType.Name}.{field.Name}`");
+						usedKeys.Add(key, fluentReference, $"`{field.ReflectedType.Name}.{field.Name}`");
 				}
 			}
 
 			return (usedKeys, testedFields);
 		}
 
-		static void CheckModWidgets(ModData modData, TranslationKeys usedKeys, List<FieldInfo> testedFields)
+		static void CheckModWidgets(ModData modData, Keys usedKeys, List<FieldInfo> testedFields)
 		{
 			var chromeLayoutNodes = BuildChromeTree(modData);
 
 			var widgetTypes = modData.ObjectCreator.GetTypes()
 				.Where(t => t.Name.EndsWith("Widget", StringComparison.InvariantCulture) && t.IsSubclassOf(typeof(Widget)))
 				.ToList();
-			var translationReferencesByWidgetField = widgetTypes.SelectMany(t =>
+
+			var fluentReferencesByWidgetField = widgetTypes.SelectMany(t =>
 				{
 					var widgetName = t.Name[..^6];
 					return Utility.GetFields(t)
 						.Select(f =>
 						{
-							var attribute = Utility.GetCustomAttributes<TranslationReferenceAttribute>(f, true).SingleOrDefault();
-							return (WidgetName: widgetName, FieldName: f.Name, TranslationReference: attribute);
+							var attribute = Utility.GetCustomAttributes<FluentReferenceAttribute>(f, true).SingleOrDefault();
+							return (WidgetName: widgetName, FieldName: f.Name, FluentReference: attribute);
 						})
-						.Where(x => x.TranslationReference != null);
+						.Where(x => x.FluentReference != null);
 				})
 				.ToDictionary(
 					x => (x.WidgetName, x.FieldName),
-					x => x.TranslationReference);
+					x => x.FluentReference);
 
 			testedFields.AddRange(widgetTypes.SelectMany(
-				t => Utility.GetFields(t).Where(Utility.HasAttribute<TranslationReferenceAttribute>)));
+				t => Utility.GetFields(t).Where(Utility.HasAttribute<FluentReferenceAttribute>)));
 
 			foreach (var node in chromeLayoutNodes)
-				CheckChrome(node, translationReferencesByWidgetField, usedKeys);
+				CheckChrome(node, fluentReferencesByWidgetField, usedKeys);
 		}
 
 		static MiniYamlNode[] BuildChromeTree(ModData modData)
@@ -336,38 +338,38 @@ namespace OpenRA.Mods.Common.Lint
 
 		static void CheckChrome(
 			MiniYamlNode rootNode,
-			Dictionary<(string WidgetName, string FieldName), TranslationReferenceAttribute> translationReferencesByWidgetField,
-			TranslationKeys usedKeys)
+			Dictionary<(string WidgetName, string FieldName), FluentReferenceAttribute> fluentReferencesByWidgetField,
+			Keys usedKeys)
 		{
 			var nodeType = rootNode.Key.Split('@')[0];
 			foreach (var childNode in rootNode.Value.Nodes)
 			{
 				var childType = childNode.Key.Split('@')[0];
-				if (!translationReferencesByWidgetField.TryGetValue((nodeType, childType), out var translationReference))
+				if (!fluentReferencesByWidgetField.TryGetValue((nodeType, childType), out var reference))
 					continue;
 
 				var key = childNode.Value.Value;
-				usedKeys.Add(key, translationReference, $"Widget `{rootNode.Key}` field `{childType}` in {rootNode.Location}");
+				usedKeys.Add(key, reference, $"Widget `{rootNode.Key}` field `{childType}` in {rootNode.Location}");
 			}
 
 			foreach (var childNode in rootNode.Value.Nodes)
 				if (childNode.Key == "Children")
 					foreach (var n in childNode.Value.Nodes)
-						CheckChrome(n, translationReferencesByWidgetField, usedKeys);
+						CheckChrome(n, fluentReferencesByWidgetField, usedKeys);
 		}
 
 		static HashSet<string> CheckKeys(
-			IEnumerable<string> translationFiles, Func<string, Stream> openFile, TranslationKeys usedKeys,
+			IEnumerable<string> paths, Func<string, Stream> openFile, Keys usedKeys,
 			string language, Func<string, bool> checkUnusedKeysForFile,
 			Action<string> emitError, Action<string> emitWarning)
 		{
 			var keyWithAttrs = new HashSet<string>();
-			foreach (var file in translationFiles)
+			foreach (var path in paths)
 			{
-				if (!file.EndsWith($"{language}.ftl", StringComparison.Ordinal))
+				if (!path.EndsWith($"{language}.ftl", StringComparison.Ordinal))
 					continue;
 
-				var stream = openFile(file);
+				var stream = openFile(path);
 				using (var reader = new StreamReader(stream))
 				{
 					var parser = new LinguiniParser(reader);
@@ -388,9 +390,9 @@ namespace OpenRA.Mods.Common.Lint
 						foreach (var (node, attributeName) in nodeAndAttributeNames)
 						{
 							keyWithAttrs.Add(attributeName == null ? key : $"{key}.{attributeName}");
-							if (checkUnusedKeysForFile(file))
-								CheckUnusedKey(key, attributeName, file, usedKeys, emitWarning);
-							CheckVariables(node, key, attributeName, file, usedKeys, emitError, emitWarning);
+							if (checkUnusedKeysForFile(path))
+								CheckUnusedKey(key, attributeName, path, usedKeys, emitWarning);
+							CheckVariables(node, key, attributeName, path, usedKeys, emitError, emitWarning);
 						}
 					}
 				}
@@ -398,7 +400,7 @@ namespace OpenRA.Mods.Common.Lint
 
 			return keyWithAttrs;
 
-			static void CheckUnusedKey(string key, string attribute, string file, TranslationKeys usedKeys, Action<string> emitWarning)
+			static void CheckUnusedKey(string key, string attribute, string file, Keys usedKeys, Action<string> emitWarning)
 			{
 				var isAttribute = !string.IsNullOrEmpty(attribute);
 				var keyWithAtrr = isAttribute ? $"{key}.{attribute}" : key;
@@ -410,7 +412,7 @@ namespace OpenRA.Mods.Common.Lint
 			}
 
 			static void CheckVariables(
-				Pattern node, string key, string attribute, string file, TranslationKeys usedKeys,
+				Pattern node, string key, string attribute, string file, Keys usedKeys,
 				Action<string> emitError, Action<string> emitWarning)
 			{
 				var isAttribute = !string.IsNullOrEmpty(attribute);
@@ -456,26 +458,26 @@ namespace OpenRA.Mods.Common.Lint
 			}
 		}
 
-		class TranslationKeys
+		class Keys
 		{
 			readonly HashSet<string> keys = new();
 			readonly List<(string Key, string Context)> keysWithContext = new();
 			readonly Dictionary<string, HashSet<string>> requiredVariablesByKey = new();
 			readonly List<string> contextForEmptyKeys = new();
 
-			public void Add(string key, TranslationReferenceAttribute translationReference, string context)
+			public void Add(string key, FluentReferenceAttribute fluentReference, string context)
 			{
 				if (key == null)
 				{
-					if (!translationReference.Optional)
+					if (!fluentReference.Optional)
 						contextForEmptyKeys.Add(context);
 					return;
 				}
 
-				if (translationReference.RequiredVariableNames != null && translationReference.RequiredVariableNames.Length > 0)
+				if (fluentReference.RequiredVariableNames != null && fluentReference.RequiredVariableNames.Length > 0)
 				{
 					var rv = requiredVariablesByKey.GetOrAdd(key, _ => new HashSet<string>());
-					rv.UnionWith(translationReference.RequiredVariableNames);
+					rv.UnionWith(fluentReference.RequiredVariableNames);
 				}
 
 				keys.Add(key);

--- a/OpenRA.Mods.Common/Lint/CheckFluentSyntax.cs
+++ b/OpenRA.Mods.Common/Lint/CheckFluentSyntax.cs
@@ -18,7 +18,7 @@ using OpenRA.FileSystem;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	sealed class CheckTranslationSyntax : ILintPass, ILintMapPass
+	sealed class CheckFluentSyntax : ILintPass, ILintMapPass
 	{
 		void ILintMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
 		{
@@ -33,11 +33,11 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, emitWarning, modData.DefaultFileSystem, modData.Manifest.Translations);
 		}
 
-		static void Run(Action<string> emitError, Action<string> emitWarning, IReadOnlyFileSystem fileSystem, string[] translations)
+		static void Run(Action<string> emitError, Action<string> emitWarning, IReadOnlyFileSystem fileSystem, string[] paths)
 		{
-			foreach (var file in translations)
+			foreach (var path in paths)
 			{
-				var stream = fileSystem.Open(file);
+				var stream = fileSystem.Open(path);
 				using (var reader = new StreamReader(stream))
 				{
 					var ids = new List<string>();
@@ -46,12 +46,12 @@ namespace OpenRA.Mods.Common.Lint
 					foreach (var entry in resource.Entries)
 					{
 						if (entry is Junk junk)
-							emitError($"{junk.GetId()}: {junk.AsStr()} in {file} {junk.Content}.");
+							emitError($"{junk.GetId()}: {junk.AsStr()} in {path} {junk.Content}.");
 
 						if (entry is AstMessage message)
 						{
 							if (ids.Contains(message.Id.Name.ToString()))
-								emitWarning($"Duplicate ID `{message.Id.Name}` in {file}.");
+								emitWarning($"Duplicate ID `{message.Id.Name}` in {path}.");
 
 							ids.Add(message.Id.Name.ToString());
 						}

--- a/OpenRA.Mods.Common/Scripting/Global/UserInterfaceGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/UserInterfaceGlobal.cs
@@ -34,9 +34,9 @@ namespace OpenRA.Mods.Common.Scripting.Global
 			luaLabel.GetColor = () => c;
 		}
 
-		[Desc("Translates text into the users language. The translation key must be added to the language files (*.ftl). " +
+		[Desc("Formats a language string for a given string key defined in the language files (*.ftl). " +
 			"Args can be passed to be substituted into the resulting message.")]
-		public string Translate(string translationKey, [ScriptEmmyTypeOverride("{ string: any }")] LuaTable args = null)
+		public string Translate(string key, [ScriptEmmyTypeOverride("{ string: any }")] LuaTable args = null)
 		{
 			if (args != null)
 			{
@@ -48,17 +48,17 @@ namespace OpenRA.Mods.Common.Scripting.Global
 					{
 						if (!kv.Key.TryGetClrValue<string>(out var variable) || !kv.Value.TryGetClrValue<object>(out var value))
 							throw new LuaException(
-								"Translation arguments requires a table of [\"string\"]=value pairs. " +
+								"String arguments requires a table of [\"string\"]=value pairs. " +
 								$"Received {kv.Key.WrappedClrType().Name},{kv.Value.WrappedClrType().Name}");
 
 						argumentDictionary.Add(variable, value);
 					}
 				}
 
-				return TranslationProvider.GetString(translationKey, argumentDictionary);
+				return FluentProvider.GetString(key, argumentDictionary);
 			}
 
-			return TranslationProvider.GetString(translationKey);
+			return FluentProvider.GetString(key);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
@@ -188,7 +188,7 @@ namespace OpenRA.Mods.Common.Scripting
 				if (tooltip == null)
 					return null;
 
-				return TranslationProvider.GetString(tooltip.Info.Name);
+				return FluentProvider.GetString(tooltip.Info.Name);
 			}
 		}
 

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -224,7 +224,7 @@ namespace OpenRA.Mods.Common.Server
 
 				if (server.State == ServerState.GameStarted)
 				{
-					server.SendLocalizedMessageTo(conn, StateUnchangedGameStarted, FluentBundle.Arguments("command", command));
+					server.SendLocalizedMessageTo(conn, StateUnchangedGameStarted, new object[] { "command", command });
 					return false;
 				}
 				else if (client.State == Session.ClientState.Ready && !(command.StartsWith("state", StringComparison.Ordinal) || command == "startgame"))
@@ -303,7 +303,7 @@ namespace OpenRA.Mods.Common.Server
 			{
 				if (!Enum<Session.ClientState>.TryParse(s, false, out var state))
 				{
-					server.SendLocalizedMessageTo(conn, MalformedCommand, FluentBundle.Arguments("command", "state"));
+					server.SendLocalizedMessageTo(conn, MalformedCommand, new object[] { "command", "state" });
 
 					return true;
 				}
@@ -399,7 +399,7 @@ namespace OpenRA.Mods.Common.Server
 					return true;
 				}
 
-				server.SendLocalizedMessageTo(conn, MalformedCommand, FluentBundle.Arguments("command", "allow_spectate"));
+				server.SendLocalizedMessageTo(conn, MalformedCommand, new object[] { "command", "allow_spectate" });
 
 				return true;
 			}
@@ -488,7 +488,7 @@ namespace OpenRA.Mods.Common.Server
 				var parts = s.Split(' ');
 				if (parts.Length < 3)
 				{
-					server.SendLocalizedMessageTo(conn, MalformedCommand, FluentBundle.Arguments("command", "slot_bot"));
+					server.SendLocalizedMessageTo(conn, MalformedCommand, new object[] { "command", "slot_bot" });
 					return true;
 				}
 
@@ -652,7 +652,7 @@ namespace OpenRA.Mods.Common.Server
 
 						server.SyncLobbyInfo();
 
-						server.SendLocalizedMessage(ChangedMap, FluentBundle.Arguments("player", client.Name, "map", server.Map.Title));
+						server.SendLocalizedMessage(ChangedMap, "player", client.Name, "map", server.Map.Title);
 
 						if ((server.LobbyInfo.GlobalSettings.MapStatus & Session.MapStatus.UnsafeCustomRules) != 0)
 							server.SendLocalizedMessage(CustomRules);
@@ -722,7 +722,7 @@ namespace OpenRA.Mods.Common.Server
 
 				if (option.IsLocked)
 				{
-					server.SendLocalizedMessageTo(conn, OptionLocked, FluentBundle.Arguments("option", option.Name));
+					server.SendLocalizedMessageTo(conn, OptionLocked, new object[] { "option", option.Name });
 					return true;
 				}
 
@@ -739,7 +739,7 @@ namespace OpenRA.Mods.Common.Server
 				oo.Value = oo.PreferredValue = split[1];
 
 				server.SyncLobbyGlobalSettings();
-				server.SendLocalizedMessage(ValueChanged, FluentBundle.Arguments("player", client.Name, "name", option.Name, "value", option.Label(split[1])));
+				server.SendLocalizedMessage(ValueChanged, "player", client.Name, "name", option.Name, "value", option.Label(split[1]));
 
 				foreach (var c in server.LobbyInfo.Clients)
 					c.State = Session.ClientState.NotReady;
@@ -768,10 +768,10 @@ namespace OpenRA.Mods.Common.Server
 				foreach (var o in allOptions)
 				{
 					if (o.DefaultValue != server.LobbyInfo.GlobalSettings.LobbyOptions[o.Id].Value)
-						server.SendLocalizedMessage(ValueChanged, FluentBundle.Arguments(
+						server.SendLocalizedMessage(ValueChanged,
 							"player", client.Name,
 							"name", o.Name,
-							"value", o.Label(o.DefaultValue)));
+							"value", o.Label(o.DefaultValue));
 
 					options[o.Id] = new Session.LobbyOptionState
 					{
@@ -805,7 +805,7 @@ namespace OpenRA.Mods.Common.Server
 
 				if (!Exts.TryParseInt32Invariant(raw, out var teamCount))
 				{
-					server.SendLocalizedMessageTo(conn, NumberTeams, FluentBundle.Arguments("raw", raw));
+					server.SendLocalizedMessageTo(conn, NumberTeams, new object[] { "raw", raw });
 					return true;
 				}
 
@@ -850,7 +850,7 @@ namespace OpenRA.Mods.Common.Server
 				var split = s.Split(' ');
 				if (split.Length < 2)
 				{
-					server.SendLocalizedMessageTo(conn, MalformedCommand, FluentBundle.Arguments("command", "kick"));
+					server.SendLocalizedMessageTo(conn, MalformedCommand, new object[] { "command", "kick" });
 					return true;
 				}
 
@@ -877,14 +877,14 @@ namespace OpenRA.Mods.Common.Server
 				}
 
 				Log.Write("server", $"Kicking client {kickClientID}.");
-				server.SendLocalizedMessage(AdminKicked, FluentBundle.Arguments("admin", client.Name, "player", kickClient.Name));
+				server.SendLocalizedMessage(AdminKicked, "admin", client.Name, "player", kickClient.Name);
 				server.SendOrderTo(kickConn, "ServerError", YouWereKicked);
 				server.DropClient(kickConn);
 
 				if (bool.TryParse(split[1], out var tempBan) && tempBan)
 				{
 					Log.Write("server", $"Temporarily banning client {kickClientID} ({kickClient.IPAddress}).");
-					server.SendLocalizedMessage(TempBan, FluentBundle.Arguments("admin", client.Name, "player", kickClient.Name));
+					server.SendLocalizedMessage(TempBan, "admin", client.Name, "player", kickClient.Name);
 					server.TempBans.Add(kickClient.IPAddress);
 				}
 
@@ -902,7 +902,7 @@ namespace OpenRA.Mods.Common.Server
 				var split = s.Split(' ');
 				if (split.Length != 2)
 				{
-					server.SendLocalizedMessageTo(conn, MalformedCommand, FluentBundle.Arguments("command", "vote_kick"));
+					server.SendLocalizedMessageTo(conn, MalformedCommand, new object[] { "command", "vote_kick" });
 					return true;
 				}
 
@@ -930,14 +930,14 @@ namespace OpenRA.Mods.Common.Server
 
 				if (!bool.TryParse(split[1], out var vote))
 				{
-					server.SendLocalizedMessageTo(conn, MalformedCommand, FluentBundle.Arguments("command", "vote_kick"));
+					server.SendLocalizedMessageTo(conn, MalformedCommand, new object[] { "command", "vote_kick" });
 					return true;
 				}
 
 				if (server.VoteKickTracker.VoteKick(conn, client, kickConn, kickClient, kickClientID, vote))
 				{
 					Log.Write("server", $"Kicking client {kickClientID}.");
-					server.SendLocalizedMessage(Kicked, FluentBundle.Arguments("player", kickClient.Name));
+					server.SendLocalizedMessage(Kicked, "player", kickClient.Name);
 					server.SendOrderTo(kickConn, "ServerError", YouWereKicked);
 					server.DropClient(kickConn);
 
@@ -980,7 +980,7 @@ namespace OpenRA.Mods.Common.Server
 				foreach (var b in bots)
 					b.BotControllerClientIndex = newAdminId;
 
-				server.SendLocalizedMessage(NewAdmin, FluentBundle.Arguments("player", newAdminClient.Name));
+				server.SendLocalizedMessage(NewAdmin, "player", newAdminClient.Name);
 				Log.Write("server", $"{newAdminClient.Name} is now the admin.");
 				server.SyncLobbyClients();
 
@@ -1014,7 +1014,7 @@ namespace OpenRA.Mods.Common.Server
 				targetClient.Handicap = 0;
 				targetClient.Color = Color.White;
 				targetClient.State = Session.ClientState.NotReady;
-				server.SendLocalizedMessage(MoveSpectators, FluentBundle.Arguments("admin", client.Name, "player", targetClient.Name));
+				server.SendLocalizedMessage(MoveSpectators, "admin", client.Name, "player", targetClient.Name);
 				Log.Write("server", $"{client.Name} moved {targetClient.Name} to spectators.");
 				server.SyncLobbyClients();
 				CheckAutoStart(server);
@@ -1032,7 +1032,7 @@ namespace OpenRA.Mods.Common.Server
 					return true;
 
 				Log.Write("server", $"Player@{conn.EndPoint} is now known as {sanitizedName}.");
-				server.SendLocalizedMessage(Nick, FluentBundle.Arguments("player", client.Name, "name", sanitizedName));
+				server.SendLocalizedMessage(Nick, "player", client.Name, "name", sanitizedName);
 				client.Name = sanitizedName;
 				server.SyncLobbyClients();
 
@@ -1062,8 +1062,8 @@ namespace OpenRA.Mods.Common.Server
 				var faction = parts[1];
 				if (!factions.Contains(faction))
 				{
-					server.SendLocalizedMessageTo(conn, InvalidFactionSelected, FluentBundle.Arguments("faction", faction));
-					server.SendLocalizedMessageTo(conn, SupportedFactions, FluentBundle.Arguments("factions", factions.JoinWith(", ")));
+					server.SendLocalizedMessageTo(conn, InvalidFactionSelected, new object[] { "faction", faction });
+					server.SendLocalizedMessageTo(conn, SupportedFactions, new object[] { "factions", factions.JoinWith(", ") });
 					return true;
 				}
 

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -206,7 +206,7 @@ namespace OpenRA.Mods.Common.Server
 
 				if (requiresHost && !client.IsAdmin)
 				{
-					server.SendLocalizedMessageTo(conn, RequiresHost);
+					server.SendFluentMessageTo(conn, RequiresHost);
 					return false;
 				}
 
@@ -224,12 +224,12 @@ namespace OpenRA.Mods.Common.Server
 
 				if (server.State == ServerState.GameStarted)
 				{
-					server.SendLocalizedMessageTo(conn, StateUnchangedGameStarted, new object[] { "command", command });
+					server.SendFluentMessageTo(conn, StateUnchangedGameStarted, new object[] { "command", command });
 					return false;
 				}
 				else if (client.State == Session.ClientState.Ready && !(command.StartsWith("state", StringComparison.Ordinal) || command == "startgame"))
 				{
-					server.SendLocalizedMessageTo(conn, StateUnchangedReady);
+					server.SendFluentMessageTo(conn, StateUnchangedReady);
 					return false;
 				}
 
@@ -303,7 +303,7 @@ namespace OpenRA.Mods.Common.Server
 			{
 				if (!Enum<Session.ClientState>.TryParse(s, false, out var state))
 				{
-					server.SendLocalizedMessageTo(conn, MalformedCommand, new object[] { "command", "state" });
+					server.SendFluentMessageTo(conn, MalformedCommand, new object[] { "command", "state" });
 
 					return true;
 				}
@@ -324,13 +324,13 @@ namespace OpenRA.Mods.Common.Server
 			{
 				if (!client.IsAdmin)
 				{
-					server.SendLocalizedMessageTo(conn, OnlyHostStartGame);
+					server.SendFluentMessageTo(conn, OnlyHostStartGame);
 					return true;
 				}
 
 				if (server.LobbyInfo.Slots.Any(sl => sl.Value.Required && server.LobbyInfo.ClientInSlot(sl.Key) == null))
 				{
-					server.SendLocalizedMessageTo(conn, NoStartUntilRequiredSlotsFull);
+					server.SendFluentMessageTo(conn, NoStartUntilRequiredSlotsFull);
 					return true;
 				}
 
@@ -342,13 +342,13 @@ namespace OpenRA.Mods.Common.Server
 
 				if (!server.LobbyInfo.GlobalSettings.EnableSingleplayer && server.LobbyInfo.NonBotPlayers.Count() < 2)
 				{
-					server.SendLocalizedMessageTo(conn, TwoHumansRequired);
+					server.SendFluentMessageTo(conn, TwoHumansRequired);
 					return true;
 				}
 
 				if (LobbyUtils.InsufficientEnabledSpawnPoints(server.Map, server.LobbyInfo))
 				{
-					server.SendLocalizedMessageTo(conn, InsufficientEnabledSpawnPoints);
+					server.SendFluentMessageTo(conn, InsufficientEnabledSpawnPoints);
 					return true;
 				}
 
@@ -399,7 +399,7 @@ namespace OpenRA.Mods.Common.Server
 					return true;
 				}
 
-				server.SendLocalizedMessageTo(conn, MalformedCommand, new object[] { "command", "allow_spectate" });
+				server.SendFluentMessageTo(conn, MalformedCommand, new object[] { "command", "allow_spectate" });
 
 				return true;
 			}
@@ -488,7 +488,7 @@ namespace OpenRA.Mods.Common.Server
 				var parts = s.Split(' ');
 				if (parts.Length < 3)
 				{
-					server.SendLocalizedMessageTo(conn, MalformedCommand, new object[] { "command", "slot_bot" });
+					server.SendFluentMessageTo(conn, MalformedCommand, new object[] { "command", "slot_bot" });
 					return true;
 				}
 
@@ -506,7 +506,7 @@ namespace OpenRA.Mods.Common.Server
 				// Invalid slot
 				if (bot != null && bot.Bot == null)
 				{
-					server.SendLocalizedMessageTo(conn, InvalidBotSlot);
+					server.SendFluentMessageTo(conn, InvalidBotSlot);
 					return true;
 				}
 
@@ -516,7 +516,7 @@ namespace OpenRA.Mods.Common.Server
 
 				if (botInfo == null)
 				{
-					server.SendLocalizedMessageTo(conn, InvalidBotType);
+					server.SendFluentMessageTo(conn, InvalidBotType);
 					return true;
 				}
 
@@ -569,7 +569,7 @@ namespace OpenRA.Mods.Common.Server
 			{
 				if (!client.IsAdmin)
 				{
-					server.SendLocalizedMessageTo(conn, HostChangeMap);
+					server.SendFluentMessageTo(conn, HostChangeMap);
 					return true;
 				}
 
@@ -652,15 +652,15 @@ namespace OpenRA.Mods.Common.Server
 
 						server.SyncLobbyInfo();
 
-						server.SendLocalizedMessage(ChangedMap, "player", client.Name, "map", server.Map.Title);
+						server.SendFluentMessage(ChangedMap, "player", client.Name, "map", server.Map.Title);
 
 						if ((server.LobbyInfo.GlobalSettings.MapStatus & Session.MapStatus.UnsafeCustomRules) != 0)
-							server.SendLocalizedMessage(CustomRules);
+							server.SendFluentMessage(CustomRules);
 
 						if (!server.LobbyInfo.GlobalSettings.EnableSingleplayer)
-							server.SendLocalizedMessage(TwoHumansRequired);
+							server.SendFluentMessage(TwoHumansRequired);
 						else if (server.Map.Players.Players.Where(p => p.Value.Playable).All(p => !p.Value.AllowBots))
-							server.SendLocalizedMessage(MapBotsDisabled);
+							server.SendFluentMessage(MapBotsDisabled);
 
 						var briefing = MissionBriefingOrDefault(server);
 						if (briefing != null)
@@ -673,7 +673,7 @@ namespace OpenRA.Mods.Common.Server
 					SelectMap(m);
 				else if (server.Settings.QueryMapRepository)
 				{
-					server.SendLocalizedMessageTo(conn, SearchingMap);
+					server.SendFluentMessageTo(conn, SearchingMap);
 					var mapRepository = server.ModData.Manifest.Get<WebServices>().MapRepository;
 					var reported = false;
 					server.ModData.MapCache.QueryRemoteMapDetails(mapRepository, new[] { s }, SelectMap, _ =>
@@ -690,7 +690,7 @@ namespace OpenRA.Mods.Common.Server
 				return true;
 			}
 
-			void QueryFailed() => server.SendLocalizedMessageTo(conn, UnknownMap);
+			void QueryFailed() => server.SendFluentMessageTo(conn, UnknownMap);
 		}
 
 		static bool Option(S server, Connection conn, Session.Client client, string s)
@@ -699,7 +699,7 @@ namespace OpenRA.Mods.Common.Server
 			{
 				if (!client.IsAdmin)
 				{
-					server.SendLocalizedMessageTo(conn, NotAdmin);
+					server.SendFluentMessageTo(conn, NotAdmin);
 					return true;
 				}
 
@@ -716,13 +716,13 @@ namespace OpenRA.Mods.Common.Server
 				if (split.Length < 2 || !options.TryGetValue(split[0], out var option) ||
 					!option.Values.ContainsKey(split[1]))
 				{
-					server.SendLocalizedMessageTo(conn, InvalidConfigurationCommand);
+					server.SendFluentMessageTo(conn, InvalidConfigurationCommand);
 					return true;
 				}
 
 				if (option.IsLocked)
 				{
-					server.SendLocalizedMessageTo(conn, OptionLocked, new object[] { "option", option.Name });
+					server.SendFluentMessageTo(conn, OptionLocked, new object[] { "option", option.Name });
 					return true;
 				}
 
@@ -732,14 +732,14 @@ namespace OpenRA.Mods.Common.Server
 
 				if (!option.Values.ContainsKey(split[1]))
 				{
-					server.SendLocalizedMessageTo(conn, InvalidConfigurationCommand);
+					server.SendFluentMessageTo(conn, InvalidConfigurationCommand);
 					return true;
 				}
 
 				oo.Value = oo.PreferredValue = split[1];
 
 				server.SyncLobbyGlobalSettings();
-				server.SendLocalizedMessage(ValueChanged, "player", client.Name, "name", option.Name, "value", option.Label(split[1]));
+				server.SendFluentMessage(ValueChanged, "player", client.Name, "name", option.Name, "value", option.Label(split[1]));
 
 				foreach (var c in server.LobbyInfo.Clients)
 					c.State = Session.ClientState.NotReady;
@@ -756,7 +756,7 @@ namespace OpenRA.Mods.Common.Server
 			{
 				if (!client.IsAdmin)
 				{
-					server.SendLocalizedMessageTo(conn, NotAdmin);
+					server.SendFluentMessageTo(conn, NotAdmin);
 					return true;
 				}
 
@@ -768,7 +768,7 @@ namespace OpenRA.Mods.Common.Server
 				foreach (var o in allOptions)
 				{
 					if (o.DefaultValue != server.LobbyInfo.GlobalSettings.LobbyOptions[o.Id].Value)
-						server.SendLocalizedMessage(ValueChanged,
+						server.SendFluentMessage(ValueChanged,
 							"player", client.Name,
 							"name", o.Name,
 							"value", o.Label(o.DefaultValue));
@@ -799,13 +799,13 @@ namespace OpenRA.Mods.Common.Server
 			{
 				if (!client.IsAdmin)
 				{
-					server.SendLocalizedMessageTo(conn, AdminOption);
+					server.SendFluentMessageTo(conn, AdminOption);
 					return true;
 				}
 
 				if (!Exts.TryParseInt32Invariant(raw, out var teamCount))
 				{
-					server.SendLocalizedMessageTo(conn, NumberTeams, new object[] { "raw", raw });
+					server.SendFluentMessageTo(conn, NumberTeams, new object[] { "raw", raw });
 					return true;
 				}
 
@@ -843,14 +843,14 @@ namespace OpenRA.Mods.Common.Server
 			{
 				if (!client.IsAdmin)
 				{
-					server.SendLocalizedMessageTo(conn, AdminKick);
+					server.SendFluentMessageTo(conn, AdminKick);
 					return true;
 				}
 
 				var split = s.Split(' ');
 				if (split.Length < 2)
 				{
-					server.SendLocalizedMessageTo(conn, MalformedCommand, new object[] { "command", "kick" });
+					server.SendFluentMessageTo(conn, MalformedCommand, new object[] { "command", "kick" });
 					return true;
 				}
 
@@ -859,32 +859,32 @@ namespace OpenRA.Mods.Common.Server
 
 				if (kickConn == null)
 				{
-					server.SendLocalizedMessageTo(conn, KickNone);
+					server.SendFluentMessageTo(conn, KickNone);
 					return true;
 				}
 
 				var kickClient = server.GetClient(kickConn);
 				if (client == kickClient)
 				{
-					server.SendLocalizedMessageTo(conn, NoKickSelf);
+					server.SendFluentMessageTo(conn, NoKickSelf);
 					return true;
 				}
 
 				if (server.State == ServerState.GameStarted && !kickClient.IsObserver && !server.HasClientWonOrLost(kickClient))
 				{
-					server.SendLocalizedMessageTo(conn, NoKickGameStarted);
+					server.SendFluentMessageTo(conn, NoKickGameStarted);
 					return true;
 				}
 
 				Log.Write("server", $"Kicking client {kickClientID}.");
-				server.SendLocalizedMessage(AdminKicked, "admin", client.Name, "player", kickClient.Name);
+				server.SendFluentMessage(AdminKicked, "admin", client.Name, "player", kickClient.Name);
 				server.SendOrderTo(kickConn, "ServerError", YouWereKicked);
 				server.DropClient(kickConn);
 
 				if (bool.TryParse(split[1], out var tempBan) && tempBan)
 				{
 					Log.Write("server", $"Temporarily banning client {kickClientID} ({kickClient.IPAddress}).");
-					server.SendLocalizedMessage(TempBan, "admin", client.Name, "player", kickClient.Name);
+					server.SendFluentMessage(TempBan, "admin", client.Name, "player", kickClient.Name);
 					server.TempBans.Add(kickClient.IPAddress);
 				}
 
@@ -902,13 +902,13 @@ namespace OpenRA.Mods.Common.Server
 				var split = s.Split(' ');
 				if (split.Length != 2)
 				{
-					server.SendLocalizedMessageTo(conn, MalformedCommand, new object[] { "command", "vote_kick" });
+					server.SendFluentMessageTo(conn, MalformedCommand, new object[] { "command", "vote_kick" });
 					return true;
 				}
 
 				if (!server.Settings.EnableVoteKick)
 				{
-					server.SendLocalizedMessageTo(conn, VoteKickDisabled);
+					server.SendFluentMessageTo(conn, VoteKickDisabled);
 					return true;
 				}
 
@@ -917,27 +917,27 @@ namespace OpenRA.Mods.Common.Server
 
 				if (kickConn == null)
 				{
-					server.SendLocalizedMessageTo(conn, KickNone);
+					server.SendFluentMessageTo(conn, KickNone);
 					return true;
 				}
 
 				var kickClient = server.GetClient(kickConn);
 				if (client == kickClient)
 				{
-					server.SendLocalizedMessageTo(conn, NoKickSelf);
+					server.SendFluentMessageTo(conn, NoKickSelf);
 					return true;
 				}
 
 				if (!bool.TryParse(split[1], out var vote))
 				{
-					server.SendLocalizedMessageTo(conn, MalformedCommand, new object[] { "command", "vote_kick" });
+					server.SendFluentMessageTo(conn, MalformedCommand, new object[] { "command", "vote_kick" });
 					return true;
 				}
 
 				if (server.VoteKickTracker.VoteKick(conn, client, kickConn, kickClient, kickClientID, vote))
 				{
 					Log.Write("server", $"Kicking client {kickClientID}.");
-					server.SendLocalizedMessage(Kicked, "player", kickClient.Name);
+					server.SendFluentMessage(Kicked, "player", kickClient.Name);
 					server.SendOrderTo(kickConn, "ServerError", YouWereKicked);
 					server.DropClient(kickConn);
 
@@ -957,7 +957,7 @@ namespace OpenRA.Mods.Common.Server
 			{
 				if (!client.IsAdmin)
 				{
-					server.SendLocalizedMessageTo(conn, NoTransferAdmin);
+					server.SendFluentMessageTo(conn, NoTransferAdmin);
 					return true;
 				}
 
@@ -966,7 +966,7 @@ namespace OpenRA.Mods.Common.Server
 
 				if (newAdminConn == null)
 				{
-					server.SendLocalizedMessageTo(conn, EmptySlot);
+					server.SendFluentMessageTo(conn, EmptySlot);
 					return true;
 				}
 
@@ -980,7 +980,7 @@ namespace OpenRA.Mods.Common.Server
 				foreach (var b in bots)
 					b.BotControllerClientIndex = newAdminId;
 
-				server.SendLocalizedMessage(NewAdmin, "player", newAdminClient.Name);
+				server.SendFluentMessage(NewAdmin, "player", newAdminClient.Name);
 				Log.Write("server", $"{newAdminClient.Name} is now the admin.");
 				server.SyncLobbyClients();
 
@@ -994,7 +994,7 @@ namespace OpenRA.Mods.Common.Server
 			{
 				if (!client.IsAdmin)
 				{
-					server.SendLocalizedMessageTo(conn, NoMoveSpectators);
+					server.SendFluentMessageTo(conn, NoMoveSpectators);
 					return true;
 				}
 
@@ -1003,7 +1003,7 @@ namespace OpenRA.Mods.Common.Server
 
 				if (targetConn == null)
 				{
-					server.SendLocalizedMessageTo(conn, EmptySlot);
+					server.SendFluentMessageTo(conn, EmptySlot);
 					return true;
 				}
 
@@ -1014,7 +1014,7 @@ namespace OpenRA.Mods.Common.Server
 				targetClient.Handicap = 0;
 				targetClient.Color = Color.White;
 				targetClient.State = Session.ClientState.NotReady;
-				server.SendLocalizedMessage(MoveSpectators, "admin", client.Name, "player", targetClient.Name);
+				server.SendFluentMessage(MoveSpectators, "admin", client.Name, "player", targetClient.Name);
 				Log.Write("server", $"{client.Name} moved {targetClient.Name} to spectators.");
 				server.SyncLobbyClients();
 				CheckAutoStart(server);
@@ -1032,7 +1032,7 @@ namespace OpenRA.Mods.Common.Server
 					return true;
 
 				Log.Write("server", $"Player@{conn.EndPoint} is now known as {sanitizedName}.");
-				server.SendLocalizedMessage(Nick, "player", client.Name, "name", sanitizedName);
+				server.SendFluentMessage(Nick, "player", client.Name, "name", sanitizedName);
 				client.Name = sanitizedName;
 				server.SyncLobbyClients();
 
@@ -1062,8 +1062,8 @@ namespace OpenRA.Mods.Common.Server
 				var faction = parts[1];
 				if (!factions.Contains(faction))
 				{
-					server.SendLocalizedMessageTo(conn, InvalidFactionSelected, new object[] { "faction", faction });
-					server.SendLocalizedMessageTo(conn, SupportedFactions, new object[] { "factions", factions.JoinWith(", ") });
+					server.SendFluentMessageTo(conn, InvalidFactionSelected, new object[] { "faction", faction });
+					server.SendFluentMessageTo(conn, SupportedFactions, new object[] { "factions", factions.JoinWith(", ") });
 					return true;
 				}
 
@@ -1147,7 +1147,7 @@ namespace OpenRA.Mods.Common.Server
 			var existingClient = server.LobbyInfo.Clients.FirstOrDefault(cc => cc.SpawnPoint == spawnPoint);
 			if (client != existingClient && !client.IsAdmin)
 			{
-				server.SendLocalizedMessageTo(conn, AdminClearSpawn);
+				server.SendFluentMessageTo(conn, AdminClearSpawn);
 				return true;
 			}
 
@@ -1203,7 +1203,7 @@ namespace OpenRA.Mods.Common.Server
 
 				if (server.LobbyInfo.Clients.Any(cc => cc != client && (cc.SpawnPoint == spawnPoint) && (cc.SpawnPoint != 0)))
 				{
-					server.SendLocalizedMessageTo(conn, SpawnOccupied);
+					server.SendFluentMessageTo(conn, SpawnOccupied);
 					return true;
 				}
 
@@ -1218,7 +1218,7 @@ namespace OpenRA.Mods.Common.Server
 
 					if (spawnLockedByAnotherSlot)
 					{
-						server.SendLocalizedMessageTo(conn, SpawnLocked);
+						server.SendFluentMessageTo(conn, SpawnLocked);
 						return true;
 					}
 				}
@@ -1265,7 +1265,7 @@ namespace OpenRA.Mods.Common.Server
 			{
 				if (!client.IsAdmin)
 				{
-					server.SendLocalizedMessageTo(conn, AdminLobbyInfo);
+					server.SendFluentMessageTo(conn, AdminLobbyInfo);
 					return true;
 				}
 
@@ -1276,7 +1276,7 @@ namespace OpenRA.Mods.Common.Server
 				}
 				catch (Exception)
 				{
-					server.SendLocalizedMessageTo(conn, InvalidLobbyInfo);
+					server.SendFluentMessageTo(conn, InvalidLobbyInfo);
 				}
 
 				return true;
@@ -1427,7 +1427,7 @@ namespace OpenRA.Mods.Common.Server
 				void OnError(string message)
 				{
 					if (connectionToEcho != null && message != null)
-						server.SendLocalizedMessageTo(connectionToEcho, message);
+						server.SendFluentMessageTo(connectionToEcho, message);
 				}
 
 				var terrainColors = server.ModData.DefaultTerrainInfo[server.Map.TileSet].RestrictedPlayerColors.ToList();

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -27,142 +27,142 @@ namespace OpenRA.Mods.Common.Server
 {
 	public class LobbyCommands : ServerTrait, IInterpretCommand, INotifyServerStart, INotifyServerEmpty, IClientJoined, OpenRA.Server.ITick
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string CustomRules = "notification-custom-rules";
 
-		[TranslationReference]
+		[FluentReference]
 		const string OnlyHostStartGame = "notification-admin-start-game";
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoStartUntilRequiredSlotsFull = "notification-no-start-until-required-slots-full";
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoStartWithoutPlayers = "notification-no-start-without-players";
 
-		[TranslationReference]
+		[FluentReference]
 		const string TwoHumansRequired = "notification-two-humans-required";
 
-		[TranslationReference]
+		[FluentReference]
 		const string InsufficientEnabledSpawnPoints = "notification-insufficient-enabled-spawn-points";
 
-		[TranslationReference("command")]
+		[FluentReference("command")]
 		const string MalformedCommand = "notification-malformed-command";
 
-		[TranslationReference]
+		[FluentReference]
 		const string KickNone = "notification-kick-none";
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoKickSelf = "notification-kick-self";
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoKickGameStarted = "notification-no-kick-game-started";
 
-		[TranslationReference("admin", "player")]
+		[FluentReference("admin", "player")]
 		const string AdminKicked = "notification-admin-kicked";
 
-		[TranslationReference("player")]
+		[FluentReference("player")]
 		const string Kicked = "notification-kicked";
 
-		[TranslationReference("admin", "player")]
+		[FluentReference("admin", "player")]
 		const string TempBan = "notification-temp-ban";
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoTransferAdmin = "notification-admin-transfer-admin";
 
-		[TranslationReference]
+		[FluentReference]
 		const string EmptySlot = "notification-empty-slot";
 
-		[TranslationReference("admin", "player")]
+		[FluentReference("admin", "player")]
 		const string MoveSpectators = "notification-move-spectators";
 
-		[TranslationReference("player", "name")]
+		[FluentReference("player", "name")]
 		const string Nick = "notification-nick-changed";
 
-		[TranslationReference]
+		[FluentReference]
 		const string StateUnchangedReady = "notification-state-unchanged-ready";
 
-		[TranslationReference("command")]
+		[FluentReference("command")]
 		const string StateUnchangedGameStarted = "notification-state-unchanged-game-started";
 
-		[TranslationReference("faction")]
+		[FluentReference("faction")]
 		const string InvalidFactionSelected = "notification-invalid-faction-selected";
 
-		[TranslationReference("factions")]
+		[FluentReference("factions")]
 		const string SupportedFactions = "notification-supported-factions";
 
-		[TranslationReference]
+		[FluentReference]
 		const string RequiresHost = "notification-requires-host";
 
-		[TranslationReference]
+		[FluentReference]
 		const string InvalidBotSlot = "notification-invalid-bot-slot";
 
-		[TranslationReference]
+		[FluentReference]
 		const string InvalidBotType = "notification-invalid-bot-type";
 
-		[TranslationReference]
+		[FluentReference]
 		const string HostChangeMap = "notification-admin-change-map";
 
-		[TranslationReference]
+		[FluentReference]
 		const string UnknownMap = "notification-unknown-map";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SearchingMap = "notification-searching-map";
 
-		[TranslationReference]
+		[FluentReference]
 		const string NotAdmin = "notification-admin-change-configuration";
 
-		[TranslationReference]
+		[FluentReference]
 		const string InvalidConfigurationCommand = "notification-invalid-configuration-command";
 
-		[TranslationReference("option")]
+		[FluentReference("option")]
 		const string OptionLocked = "notification-option-locked";
 
-		[TranslationReference("player", "map")]
+		[FluentReference("player", "map")]
 		const string ChangedMap = "notification-changed-map";
 
-		[TranslationReference]
+		[FluentReference]
 		const string MapBotsDisabled = "notification-map-bots-disabled";
 
-		[TranslationReference("player", "name", "value")]
+		[FluentReference("player", "name", "value")]
 		const string ValueChanged = "notification-option-changed";
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoMoveSpectators = "notification-admin-move-spectators";
 
-		[TranslationReference]
+		[FluentReference]
 		const string AdminOption = "notification-admin-option";
 
-		[TranslationReference("raw")]
+		[FluentReference("raw")]
 		const string NumberTeams = "notification-error-number-teams";
 
-		[TranslationReference]
+		[FluentReference]
 		const string AdminClearSpawn = "notification-admin-clear-spawn";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SpawnOccupied = "notification-spawn-occupied";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SpawnLocked = "notification-spawn-locked";
 
-		[TranslationReference]
+		[FluentReference]
 		const string AdminLobbyInfo = "notification-admin-lobby-info";
 
-		[TranslationReference]
+		[FluentReference]
 		const string InvalidLobbyInfo = "notification-invalid-lobby-info";
 
-		[TranslationReference]
+		[FluentReference]
 		const string AdminKick = "notification-admin-kick";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SlotClosed = "notification-slot-closed";
 
-		[TranslationReference("player")]
+		[FluentReference("player")]
 		const string NewAdmin = "notification-new-admin";
 
-		[TranslationReference]
+		[FluentReference]
 		const string YouWereKicked = "notification-you-were-kicked";
 
-		[TranslationReference]
+		[FluentReference]
 		const string VoteKickDisabled = "notification-vote-kick-disabled";
 
 		readonly IDictionary<string, Func<S, Connection, Session.Client, string, bool>> commandHandlers =
@@ -224,7 +224,7 @@ namespace OpenRA.Mods.Common.Server
 
 				if (server.State == ServerState.GameStarted)
 				{
-					server.SendLocalizedMessageTo(conn, StateUnchangedGameStarted, Translation.Arguments("command", command));
+					server.SendLocalizedMessageTo(conn, StateUnchangedGameStarted, FluentBundle.Arguments("command", command));
 					return false;
 				}
 				else if (client.State == Session.ClientState.Ready && !(command.StartsWith("state", StringComparison.Ordinal) || command == "startgame"))
@@ -303,7 +303,7 @@ namespace OpenRA.Mods.Common.Server
 			{
 				if (!Enum<Session.ClientState>.TryParse(s, false, out var state))
 				{
-					server.SendLocalizedMessageTo(conn, MalformedCommand, Translation.Arguments("command", "state"));
+					server.SendLocalizedMessageTo(conn, MalformedCommand, FluentBundle.Arguments("command", "state"));
 
 					return true;
 				}
@@ -399,7 +399,7 @@ namespace OpenRA.Mods.Common.Server
 					return true;
 				}
 
-				server.SendLocalizedMessageTo(conn, MalformedCommand, Translation.Arguments("command", "allow_spectate"));
+				server.SendLocalizedMessageTo(conn, MalformedCommand, FluentBundle.Arguments("command", "allow_spectate"));
 
 				return true;
 			}
@@ -488,7 +488,7 @@ namespace OpenRA.Mods.Common.Server
 				var parts = s.Split(' ');
 				if (parts.Length < 3)
 				{
-					server.SendLocalizedMessageTo(conn, MalformedCommand, Translation.Arguments("command", "slot_bot"));
+					server.SendLocalizedMessageTo(conn, MalformedCommand, FluentBundle.Arguments("command", "slot_bot"));
 					return true;
 				}
 
@@ -652,7 +652,7 @@ namespace OpenRA.Mods.Common.Server
 
 						server.SyncLobbyInfo();
 
-						server.SendLocalizedMessage(ChangedMap, Translation.Arguments("player", client.Name, "map", server.Map.Title));
+						server.SendLocalizedMessage(ChangedMap, FluentBundle.Arguments("player", client.Name, "map", server.Map.Title));
 
 						if ((server.LobbyInfo.GlobalSettings.MapStatus & Session.MapStatus.UnsafeCustomRules) != 0)
 							server.SendLocalizedMessage(CustomRules);
@@ -722,7 +722,7 @@ namespace OpenRA.Mods.Common.Server
 
 				if (option.IsLocked)
 				{
-					server.SendLocalizedMessageTo(conn, OptionLocked, Translation.Arguments("option", option.Name));
+					server.SendLocalizedMessageTo(conn, OptionLocked, FluentBundle.Arguments("option", option.Name));
 					return true;
 				}
 
@@ -739,7 +739,7 @@ namespace OpenRA.Mods.Common.Server
 				oo.Value = oo.PreferredValue = split[1];
 
 				server.SyncLobbyGlobalSettings();
-				server.SendLocalizedMessage(ValueChanged, Translation.Arguments("player", client.Name, "name", option.Name, "value", option.Label(split[1])));
+				server.SendLocalizedMessage(ValueChanged, FluentBundle.Arguments("player", client.Name, "name", option.Name, "value", option.Label(split[1])));
 
 				foreach (var c in server.LobbyInfo.Clients)
 					c.State = Session.ClientState.NotReady;
@@ -768,7 +768,7 @@ namespace OpenRA.Mods.Common.Server
 				foreach (var o in allOptions)
 				{
 					if (o.DefaultValue != server.LobbyInfo.GlobalSettings.LobbyOptions[o.Id].Value)
-						server.SendLocalizedMessage(ValueChanged, Translation.Arguments(
+						server.SendLocalizedMessage(ValueChanged, FluentBundle.Arguments(
 							"player", client.Name,
 							"name", o.Name,
 							"value", o.Label(o.DefaultValue)));
@@ -805,7 +805,7 @@ namespace OpenRA.Mods.Common.Server
 
 				if (!Exts.TryParseInt32Invariant(raw, out var teamCount))
 				{
-					server.SendLocalizedMessageTo(conn, NumberTeams, Translation.Arguments("raw", raw));
+					server.SendLocalizedMessageTo(conn, NumberTeams, FluentBundle.Arguments("raw", raw));
 					return true;
 				}
 
@@ -850,7 +850,7 @@ namespace OpenRA.Mods.Common.Server
 				var split = s.Split(' ');
 				if (split.Length < 2)
 				{
-					server.SendLocalizedMessageTo(conn, MalformedCommand, Translation.Arguments("command", "kick"));
+					server.SendLocalizedMessageTo(conn, MalformedCommand, FluentBundle.Arguments("command", "kick"));
 					return true;
 				}
 
@@ -877,14 +877,14 @@ namespace OpenRA.Mods.Common.Server
 				}
 
 				Log.Write("server", $"Kicking client {kickClientID}.");
-				server.SendLocalizedMessage(AdminKicked, Translation.Arguments("admin", client.Name, "player", kickClient.Name));
+				server.SendLocalizedMessage(AdminKicked, FluentBundle.Arguments("admin", client.Name, "player", kickClient.Name));
 				server.SendOrderTo(kickConn, "ServerError", YouWereKicked);
 				server.DropClient(kickConn);
 
 				if (bool.TryParse(split[1], out var tempBan) && tempBan)
 				{
 					Log.Write("server", $"Temporarily banning client {kickClientID} ({kickClient.IPAddress}).");
-					server.SendLocalizedMessage(TempBan, Translation.Arguments("admin", client.Name, "player", kickClient.Name));
+					server.SendLocalizedMessage(TempBan, FluentBundle.Arguments("admin", client.Name, "player", kickClient.Name));
 					server.TempBans.Add(kickClient.IPAddress);
 				}
 
@@ -902,7 +902,7 @@ namespace OpenRA.Mods.Common.Server
 				var split = s.Split(' ');
 				if (split.Length != 2)
 				{
-					server.SendLocalizedMessageTo(conn, MalformedCommand, Translation.Arguments("command", "vote_kick"));
+					server.SendLocalizedMessageTo(conn, MalformedCommand, FluentBundle.Arguments("command", "vote_kick"));
 					return true;
 				}
 
@@ -930,14 +930,14 @@ namespace OpenRA.Mods.Common.Server
 
 				if (!bool.TryParse(split[1], out var vote))
 				{
-					server.SendLocalizedMessageTo(conn, MalformedCommand, Translation.Arguments("command", "vote_kick"));
+					server.SendLocalizedMessageTo(conn, MalformedCommand, FluentBundle.Arguments("command", "vote_kick"));
 					return true;
 				}
 
 				if (server.VoteKickTracker.VoteKick(conn, client, kickConn, kickClient, kickClientID, vote))
 				{
 					Log.Write("server", $"Kicking client {kickClientID}.");
-					server.SendLocalizedMessage(Kicked, Translation.Arguments("player", kickClient.Name));
+					server.SendLocalizedMessage(Kicked, FluentBundle.Arguments("player", kickClient.Name));
 					server.SendOrderTo(kickConn, "ServerError", YouWereKicked);
 					server.DropClient(kickConn);
 
@@ -980,7 +980,7 @@ namespace OpenRA.Mods.Common.Server
 				foreach (var b in bots)
 					b.BotControllerClientIndex = newAdminId;
 
-				server.SendLocalizedMessage(NewAdmin, Translation.Arguments("player", newAdminClient.Name));
+				server.SendLocalizedMessage(NewAdmin, FluentBundle.Arguments("player", newAdminClient.Name));
 				Log.Write("server", $"{newAdminClient.Name} is now the admin.");
 				server.SyncLobbyClients();
 
@@ -1014,7 +1014,7 @@ namespace OpenRA.Mods.Common.Server
 				targetClient.Handicap = 0;
 				targetClient.Color = Color.White;
 				targetClient.State = Session.ClientState.NotReady;
-				server.SendLocalizedMessage(MoveSpectators, Translation.Arguments("admin", client.Name, "player", targetClient.Name));
+				server.SendLocalizedMessage(MoveSpectators, FluentBundle.Arguments("admin", client.Name, "player", targetClient.Name));
 				Log.Write("server", $"{client.Name} moved {targetClient.Name} to spectators.");
 				server.SyncLobbyClients();
 				CheckAutoStart(server);
@@ -1032,7 +1032,7 @@ namespace OpenRA.Mods.Common.Server
 					return true;
 
 				Log.Write("server", $"Player@{conn.EndPoint} is now known as {sanitizedName}.");
-				server.SendLocalizedMessage(Nick, Translation.Arguments("player", client.Name, "name", sanitizedName));
+				server.SendLocalizedMessage(Nick, FluentBundle.Arguments("player", client.Name, "name", sanitizedName));
 				client.Name = sanitizedName;
 				server.SyncLobbyClients();
 
@@ -1062,8 +1062,8 @@ namespace OpenRA.Mods.Common.Server
 				var faction = parts[1];
 				if (!factions.Contains(faction))
 				{
-					server.SendLocalizedMessageTo(conn, InvalidFactionSelected, Translation.Arguments("faction", faction));
-					server.SendLocalizedMessageTo(conn, SupportedFactions, Translation.Arguments("factions", factions.JoinWith(", ")));
+					server.SendLocalizedMessageTo(conn, InvalidFactionSelected, FluentBundle.Arguments("faction", faction));
+					server.SendLocalizedMessageTo(conn, SupportedFactions, FluentBundle.Arguments("factions", factions.JoinWith(", ")));
 					return true;
 				}
 

--- a/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.Server
 
 			lock (masterServerMessages)
 				while (masterServerMessages.Count > 0)
-					server.SendLocalizedMessage(masterServerMessages.Dequeue());
+					server.SendFluentMessage(masterServerMessages.Dequeue());
 		}
 
 		void INotifyServerStart.ServerStarted(S server)

--- a/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
@@ -30,22 +30,22 @@ namespace OpenRA.Mods.Common.Server
 		// 1 second (in milliseconds) minimum delay between pings
 		const int RateLimitInterval = 1000;
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoPortForward = "notification-no-port-forward";
 
-		[TranslationReference]
+		[FluentReference]
 		const string BlacklistedTitle = "notification-blacklisted-server-name";
 
-		[TranslationReference]
+		[FluentReference]
 		const string InvalidErrorCode = "notification-invalid-error-code";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Connected = "notification-master-server-connected";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Error = "notification-master-server-error";
 
-		[TranslationReference]
+		[FluentReference]
 		const string GameOffline = "notification-game-offline";
 
 		static readonly Beacon LanGameBeacon;

--- a/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
@@ -18,16 +18,16 @@ namespace OpenRA.Mods.Common.Server
 {
 	public class PlayerPinger : ServerTrait, ITick
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string PlayerDropped = "notification-player-dropped";
 
-		[TranslationReference("player")]
+		[FluentReference("player")]
 		const string ConnectionProblems = "notification-connection-problems";
 
-		[TranslationReference("player")]
+		[FluentReference("player")]
 		const string Timeout = "notification-timeout-dropped";
 
-		[TranslationReference("player", "timeout")]
+		[FluentReference("player", "timeout")]
 		const string TimeoutIn = "notification-timeout-dropped-in";
 
 		const int PingInterval = 5000; // Ping every 5 seconds
@@ -69,13 +69,13 @@ namespace OpenRA.Mods.Common.Server
 						{
 							if (!c.TimeoutMessageShown && c.TimeSinceLastResponse > PingInterval * 2)
 							{
-								server.SendLocalizedMessage(ConnectionProblems, Translation.Arguments("player", client.Name));
+								server.SendLocalizedMessage(ConnectionProblems, FluentBundle.Arguments("player", client.Name));
 								c.TimeoutMessageShown = true;
 							}
 						}
 						else
 						{
-							server.SendLocalizedMessage(Timeout, Translation.Arguments("player", client.Name));
+							server.SendLocalizedMessage(Timeout, FluentBundle.Arguments("player", client.Name));
 							server.DropClient(c);
 						}
 					}

--- a/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Server
 						if (client == null)
 						{
 							server.DropClient(c);
-							server.SendLocalizedMessage(PlayerDropped);
+							server.SendFluentMessage(PlayerDropped);
 							continue;
 						}
 
@@ -68,13 +68,13 @@ namespace OpenRA.Mods.Common.Server
 						{
 							if (!c.TimeoutMessageShown && c.TimeSinceLastResponse > PingInterval * 2)
 							{
-								server.SendLocalizedMessage(ConnectionProblems, "player", client.Name);
+								server.SendFluentMessage(ConnectionProblems, "player", client.Name);
 								c.TimeoutMessageShown = true;
 							}
 						}
 						else
 						{
-							server.SendLocalizedMessage(Timeout, "player", client.Name);
+							server.SendFluentMessage(Timeout, "player", client.Name);
 							server.DropClient(c);
 						}
 					}
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Server
 							if (client != null)
 							{
 								var timeout = (ConnTimeout - c.TimeSinceLastResponse) / 1000;
-								server.SendLocalizedMessage(TimeoutIn, "player", client.Name, "timeout", timeout);
+								server.SendFluentMessage(TimeoutIn, "player", client.Name, "timeout", timeout);
 							}
 						}
 					}

--- a/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Server;
 using S = OpenRA.Server.Server;
@@ -69,13 +68,13 @@ namespace OpenRA.Mods.Common.Server
 						{
 							if (!c.TimeoutMessageShown && c.TimeSinceLastResponse > PingInterval * 2)
 							{
-								server.SendLocalizedMessage(ConnectionProblems, FluentBundle.Arguments("player", client.Name));
+								server.SendLocalizedMessage(ConnectionProblems, "player", client.Name);
 								c.TimeoutMessageShown = true;
 							}
 						}
 						else
 						{
-							server.SendLocalizedMessage(Timeout, FluentBundle.Arguments("player", client.Name));
+							server.SendLocalizedMessage(Timeout, "player", client.Name);
 							server.DropClient(c);
 						}
 					}
@@ -94,11 +93,7 @@ namespace OpenRA.Mods.Common.Server
 							if (client != null)
 							{
 								var timeout = (ConnTimeout - c.TimeSinceLastResponse) / 1000;
-								server.SendLocalizedMessage(TimeoutIn, new Dictionary<string, object>()
-								{
-									{ "player", client.Name },
-									{ "timeout", timeout }
-								});
+								server.SendLocalizedMessage(TimeoutIn, "player", client.Name, "timeout", timeout);
 							}
 						}
 					}

--- a/OpenRA.Mods.Common/Traits/Buildable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildable.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int BuildPaletteOrder = 9999;
 
 		[Desc("Text shown in the production tooltip.")]
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string Description;
 
 		public static string GetInitialFaction(ActorInfo ai, string defaultFaction)

--- a/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech notification to play when selecting a primary building.")]
 		public readonly string SelectionNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification to display when selecting a primary building.")]
 		public readonly string SelectionTextNotification = null;
 

--- a/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech notification to play when a unit is delivered.")]
 		public readonly string ReadyAudio = "Reinforce";
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification to display when a unit is delivered.")]
 		public readonly string ReadyTextNotification = null;
 

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech notification to play when setting a new rallypoint.")]
 		public readonly string Notification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification to display when setting a new rallypoint.")]
 		public readonly string TextNotification = null;
 

--- a/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Voice line to play when repairs are started.")]
 		public readonly string RepairingNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Transient text message to display when repairs are started.")]
 		public readonly string RepairingTextNotification = null;
 

--- a/OpenRA.Mods.Common/Traits/Conditions/ToggleConditionOnOrder.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ToggleConditionOnOrder.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Speech")]
 		public readonly string EnabledSpeech = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string EnabledTextNotification = null;
 
 		[NotificationReference("Sounds")]
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Speech")]
 		public readonly string DisabledSpeech = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string DisabledTextNotification = null;
 
 		public override object Create(ActorInitializer init) { return new ToggleConditionOnOrder(this); }

--- a/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech notification to play when the crate is collected.")]
 		public readonly string Notification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification to display when the crate is collected.")]
 		public readonly string TextNotification = null;
 

--- a/OpenRA.Mods.Common/Traits/Encyclopedia.cs
+++ b/OpenRA.Mods.Common/Traits/Encyclopedia.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class EncyclopediaInfo : TraitInfo
 	{
 		[Desc("Explains the purpose in the in-game encyclopedia.")]
-		[TranslationReference]
+		[FluentReference]
 		public readonly string Description;
 
 		[Desc("Number for ordering the list.")]

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Sounds")]
 		public readonly string LevelUpNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string LevelUpTextNotification = null;
 
 		public override object Create(ActorInitializer init) { return new GainsExperience(init, this); }

--- a/OpenRA.Mods.Common/Traits/Player/BaseAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/BaseAttackNotifier.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech notification type to play.")]
 		public readonly string Notification = "BaseAttack";
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification to display.")]
 		public readonly string TextNotification = null;
 
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 			"Won't play a notification to allies if this is null.")]
 		public readonly string AllyNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification to display to allies when under attack.")]
 		public readonly string AllyTextNotification = null;
 

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -32,10 +32,10 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class ConquestVictoryConditions : ITick, INotifyWinStateChanged, INotifyTimeLimit
 	{
-		[TranslationReference("player")]
+		[FluentReference("player")]
 		const string PlayerIsVictorious = "notification-player-is-victorious";
 
-		[TranslationReference("player")]
+		[FluentReference("player")]
 		const string PlayerIsDefeated = "notification-player-is-defeated";
 
 		readonly ConquestVictoryConditionsInfo info;
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.SuppressNotifications)
 				return;
 
-			TextNotificationsManager.AddSystemLine(PlayerIsDefeated, Translation.Arguments("player", player.ResolvedPlayerName));
+			TextNotificationsManager.AddSystemLine(PlayerIsDefeated, FluentBundle.Arguments("player", player.ResolvedPlayerName));
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.SuppressNotifications)
 				return;
 
-			TextNotificationsManager.AddSystemLine(PlayerIsVictorious, Translation.Arguments("player", player.ResolvedPlayerName));
+			TextNotificationsManager.AddSystemLine(PlayerIsVictorious, FluentBundle.Arguments("player", player.ResolvedPlayerName));
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.SuppressNotifications)
 				return;
 
-			TextNotificationsManager.AddSystemLine(PlayerIsDefeated, FluentBundle.Arguments("player", player.ResolvedPlayerName));
+			TextNotificationsManager.AddSystemLine(PlayerIsDefeated, "player", player.ResolvedPlayerName);
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.SuppressNotifications)
 				return;
 
-			TextNotificationsManager.AddSystemLine(PlayerIsVictorious, FluentBundle.Arguments("player", player.ResolvedPlayerName));
+			TextNotificationsManager.AddSystemLine(PlayerIsVictorious, "player", player.ResolvedPlayerName);
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)

--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
@@ -275,8 +275,10 @@ namespace OpenRA.Mods.Common.Traits
 					return;
 			}
 
-			var arguments = FluentBundle.Arguments("cheat", order.OrderString, "player", self.Owner.ResolvedPlayerName, "suffix", debugSuffix);
-			TextNotificationsManager.Debug(FluentProvider.GetString(CheatUsed, arguments));
+			TextNotificationsManager.Debug(FluentProvider.GetString(CheatUsed,
+				"cheat", order.OrderString,
+				"player", self.Owner.ResolvedPlayerName,
+				"suffix", debugSuffix));
 		}
 
 		bool IUnlocksRenderPlayer.RenderPlayerUnlocked => Enabled;

--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
@@ -20,11 +20,11 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Attach this to the player actor.")]
 	public class DeveloperModeInfo : TraitInfo, ILobbyOptions
 	{
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Descriptive label for the developer mode checkbox in the lobby.")]
 		public readonly string CheckboxLabel = "checkbox-debug-menu.label";
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Tooltip description for the developer mode checkbox in the lobby.")]
 		public readonly string CheckboxDescription = "checkbox-debug-menu.description";
 
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class DeveloperMode : IResolveOrder, ISync, INotifyCreated, IUnlocksRenderPlayer
 	{
-		[TranslationReference("cheat", "player", "suffix")]
+		[FluentReference("cheat", "player", "suffix")]
 		const string CheatUsed = "notification-cheat-used";
 
 		readonly DeveloperModeInfo info;
@@ -275,8 +275,8 @@ namespace OpenRA.Mods.Common.Traits
 					return;
 			}
 
-			var arguments = Translation.Arguments("cheat", order.OrderString, "player", self.Owner.ResolvedPlayerName, "suffix", debugSuffix);
-			TextNotificationsManager.Debug(TranslationProvider.GetString(CheatUsed, arguments));
+			var arguments = FluentBundle.Arguments("cheat", order.OrderString, "player", self.Owner.ResolvedPlayerName, "suffix", debugSuffix);
+			TextNotificationsManager.Debug(FluentProvider.GetString(CheatUsed, arguments));
 		}
 
 		bool IUnlocksRenderPlayer.RenderPlayerUnlocked => Enabled;

--- a/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech notification type to play.")]
 		public readonly string Notification = "HarvesterAttack";
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification to display.")]
 		public readonly string TextNotification = null;
 

--- a/OpenRA.Mods.Common/Traits/Player/LobbyPrerequisiteCheckbox.cs
+++ b/OpenRA.Mods.Common/Traits/Player/LobbyPrerequisiteCheckbox.cs
@@ -22,12 +22,12 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Internal id for this checkbox.")]
 		public readonly string ID = null;
 
-		[TranslationReference]
+		[FluentReference]
 		[FieldLoader.Require]
 		[Desc("Display name for this checkbox.")]
 		public readonly string Label = null;
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Description name for this checkbox.")]
 		public readonly string Description = null;
 

--- a/OpenRA.Mods.Common/Traits/Player/MissionObjectives.cs
+++ b/OpenRA.Mods.Common/Traits/Player/MissionObjectives.cs
@@ -54,19 +54,19 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Speech")]
 		public readonly string WinNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string WinTextNotification = null;
 
 		[NotificationReference("Speech")]
 		public readonly string LoseNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string LoseTextNotification = null;
 
 		[NotificationReference("Speech")]
 		public readonly string LeaveNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string LeaveTextNotification = null;
 
 		public override object Create(ActorInitializer init) { return new MissionObjectives(init.Self.Owner, this); }

--- a/OpenRA.Mods.Common/Traits/Player/ModularBot.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ModularBot.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Internal id for this bot.")]
 		public readonly string Type = null;
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Human-readable name this bot uses.")]
 		public readonly string Name = null;
 

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech notification to play after building placement if new construction options are available.")]
 		public readonly string NewOptionsNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification to display after building placement if new construction options are available.")]
 		public readonly string NewOptionsTextNotification = null;
 
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech notification to play if building placement is not possible.")]
 		public readonly string CannotPlaceNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification to display if building placement is not possible.")]
 		public readonly string CannotPlaceTextNotification = null;
 

--- a/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech notification to play when the player does not have any funds.")]
 		public readonly string InsufficientFundsNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification to display when the player does not have any funds.")]
 		public readonly string InsufficientFundsTextNotification = null;
 

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 			"The filename of the audio is defined per faction in notifications.yaml.")]
 		public readonly string ReadyAudio = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Notification displayed when production is complete.")]
 		public readonly string ReadyTextNotification = null;
 
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Traits
 			"The filename of the audio is defined per faction in notifications.yaml.")]
 		public readonly string BlockedAudio = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Notification displayed when you can't train another actor",
 			"when the build limit exceeded or the exit is jammed.")]
 		public readonly string BlockedTextNotification = null;
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Traits
 			"The filename of the audio is defined per faction in notifications.yaml.")]
 		public readonly string LimitedAudio = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Notification displayed when you can't queue another actor",
 			"when the queue length limit is exceeded.")]
 		public readonly string LimitedTextNotification = null;
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.Common.Traits
 			"The filename of the audio is defined per faction in notifications.yaml.")]
 		public readonly string QueuedAudio = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Notification displayed when user clicks on the build palette icon.")]
 		public readonly string QueuedTextNotification = null;
 
@@ -110,7 +110,7 @@ namespace OpenRA.Mods.Common.Traits
 			"The filename of the audio is defined per faction in notifications.yaml.")]
 		public readonly string OnHoldAudio = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Notification displayed when player right-clicks on the build palette icon.")]
 		public readonly string OnHoldTextNotification = null;
 
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Traits
 			"The filename of the audio is defined per faction in notifications.yaml.")]
 		public readonly string CancelledAudio = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Notification displayed when player right-clicks on a build palette icon that is already on hold.")]
 		public readonly string CancelledTextNotification = null;
 

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Internal id for this tech level.")]
 		public readonly string Id;
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Name shown in the lobby options.")]
 		public readonly string Name;
 

--- a/OpenRA.Mods.Common/Traits/Player/ResourceStorageWarning.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ResourceStorageWarning.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech to play for the warning.")]
 		public readonly string Notification = "SilosNeeded";
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text to display for the warning.")]
 		public readonly string TextNotification = null;
 

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -46,10 +46,10 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class StrategicVictoryConditions : ITick, ISync, INotifyWinStateChanged, INotifyTimeLimit
 	{
-		[TranslationReference("player")]
+		[FluentReference("player")]
 		const string PlayerIsVictorious = "notification-player-is-victorious";
 
-		[TranslationReference("player")]
+		[FluentReference("player")]
 		const string PlayerIsDefeated = "notification-player-is-defeated";
 
 		readonly StrategicVictoryConditionsInfo info;
@@ -151,7 +151,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.SuppressNotifications)
 				return;
 
-			TextNotificationsManager.AddSystemLine(PlayerIsDefeated, Translation.Arguments("player", player.ResolvedPlayerName));
+			TextNotificationsManager.AddSystemLine(PlayerIsDefeated, FluentBundle.Arguments("player", player.ResolvedPlayerName));
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)
@@ -167,7 +167,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.SuppressNotifications)
 				return;
 
-			TextNotificationsManager.AddSystemLine(PlayerIsVictorious, Translation.Arguments("player", player.ResolvedPlayerName));
+			TextNotificationsManager.AddSystemLine(PlayerIsVictorious, FluentBundle.Arguments("player", player.ResolvedPlayerName));
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -151,7 +151,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.SuppressNotifications)
 				return;
 
-			TextNotificationsManager.AddSystemLine(PlayerIsDefeated, FluentBundle.Arguments("player", player.ResolvedPlayerName));
+			TextNotificationsManager.AddSystemLine(PlayerIsDefeated, "player", player.ResolvedPlayerName);
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)
@@ -167,7 +167,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.SuppressNotifications)
 				return;
 
-			TextNotificationsManager.AddSystemLine(PlayerIsVictorious, FluentBundle.Arguments("player", player.ResolvedPlayerName));
+			TextNotificationsManager.AddSystemLine(PlayerIsVictorious, "player", player.ResolvedPlayerName);
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)

--- a/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string SpeechNotification = null;
 
 		[Desc("The text notification to display when the player is low power.")]
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string TextNotification = null;
 
 		public override object Create(ActorInitializer init) { return new PowerManager(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech notification to play when dropping the unit.")]
 		public readonly string ReadyAudio = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification to display when dropping the unit.")]
 		public readonly string ReadyTextNotification = null;
 

--- a/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		const string CommandName = "custom-terrain";
 
-		[TranslationReference]
+		[FluentReference]
 		const string CommandDescription = "description-custom-terrain-debug-overlay";
 
 		public bool Enabled;

--- a/OpenRA.Mods.Common/Traits/RepairsBridges.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsBridges.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech notification to play when a bridge is repaired.")]
 		public readonly string RepairNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification to display when a bridge is repaired.")]
 		public readonly string RepairTextNotification = null;
 

--- a/OpenRA.Mods.Common/Traits/RepairsUnits.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsUnits.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech notification played when starting to repair a unit.")]
 		public readonly string StartRepairingNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification displayed when starting to repair a unit.")]
 		public readonly string StartRepairingTextNotification = null;
 
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech notification played when repairing a unit is done.")]
 		public readonly string FinishRepairingNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification displayed when repairing a unit is done.")]
 		public readonly string FinishRepairingTextNotification = null;
 

--- a/OpenRA.Mods.Common/Traits/Sellable.cs
+++ b/OpenRA.Mods.Common/Traits/Sellable.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech notification to play.")]
 		public readonly string Notification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification to display.")]
 		public readonly string TextNotification = null;
 

--- a/OpenRA.Mods.Common/Traits/Sound/ActorLostNotification.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/ActorLostNotification.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		public readonly string Notification = "UnitLost";
 
 		[Desc("Text notification to display.")]
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string TextNotification = null;
 
 		public readonly bool NotifyAll = false;

--- a/OpenRA.Mods.Common/Traits/Sound/AnnounceOnSeen.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AnnounceOnSeen.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		[Desc("Speech notification to play.")]
 		public readonly string Notification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification to display.")]
 		public readonly string TextNotification = null;
 

--- a/OpenRA.Mods.Common/Traits/Sound/CaptureNotification.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/CaptureNotification.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		[Desc("Speech notification to play to the new owner.")]
 		public readonly string Notification = "BuildingCaptured";
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification to display to the new owner.")]
 		public readonly string TextNotification = null;
 
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		[Desc("Speech notification to play to the old owner.")]
 		public readonly string LoseNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification to display to the old owner.")]
 		public readonly string LoseTextNotification = null;
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/ParatroopersPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/ParatroopersPower.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech notification to play when entering the drop zone.")]
 		public readonly string ReinforcementsArrivedSpeechNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification to display when entering the drop zone.")]
 		public readonly string ReinforcementsArrivedTextNotification = null;
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 			"The filename of the audio is defined per faction in notifications.yaml.")]
 		public readonly string ReadyAudio = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification displayed when production is activated.")]
 		public readonly string ReadyTextNotification = null;
 
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 			"The filename of the audio is defined per faction in notifications.yaml.")]
 		public readonly string BlockedAudio = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification displayed when the exit is jammed.")]
 		public readonly string BlockedTextNotification = null;
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
@@ -30,10 +30,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Palette used for the icon.")]
 		public readonly string IconPalette = "chrome";
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string Name = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string Description = null;
 
 		[Desc("Allow multiple instances of the same support power.")]
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Speech")]
 		public readonly string DetectedSpeechNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string DetectedTextNotification = null;
 
 		public readonly string BeginChargeSound = null;
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Speech")]
 		public readonly string BeginChargeSpeechNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string BeginChargeTextNotification = null;
 
 		public readonly string EndChargeSound = null;
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Speech")]
 		public readonly string EndChargeSpeechNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string EndChargeTextNotification = null;
 
 		public readonly string SelectTargetSound = null;
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Speech")]
 		public readonly string SelectTargetSpeechNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string SelectTargetTextNotification = null;
 
 		public readonly string InsufficientPowerSound = null;
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Speech")]
 		public readonly string InsufficientPowerSpeechNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string InsufficientPowerTextNotification = null;
 
 		public readonly string LaunchSound = null;
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Speech")]
 		public readonly string LaunchSpeechNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string LaunchTextNotification = null;
 
 		public readonly string IncomingSound = null;
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Speech")]
 		public readonly string IncomingSpeechNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string IncomingTextNotification = null;
 
 		[Desc("Defines to which players the timer is shown.")]

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -177,8 +177,8 @@ namespace OpenRA.Mods.Common.Traits
 			Key = key;
 			TotalTicks = info.ChargeInterval;
 			remainingSubTicks = info.StartFullyCharged ? 0 : TotalTicks * 100;
-			Name = info.Name == null ? string.Empty : TranslationProvider.GetString(info.Name);
-			Description = info.Description == null ? string.Empty : TranslationProvider.GetString(info.Description);
+			Name = info.Name == null ? string.Empty : FluentProvider.GetString(info.Name);
+			Description = info.Description == null ? string.Empty : FluentProvider.GetString(info.Description);
 
 			Manager = manager;
 		}

--- a/OpenRA.Mods.Common/Traits/Tooltip.cs
+++ b/OpenRA.Mods.Common/Traits/Tooltip.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.Traits
 	public abstract class TooltipInfoBase : ConditionalTraitInfo, Requires<IMouseBoundsInfo>
 	{
 		[FieldLoader.Require]
-		[TranslationReference]
+		[FluentReference]
 		public readonly string Name;
 	}
 
@@ -31,22 +31,22 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[Desc("An optional generic name (i.e. \"Soldier\" or \"Structure\")" +
 			"to be shown to chosen players.")]
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string GenericName;
 
 		[Desc("Prefix generic tooltip name with 'Ally/Neutral/EnemyPrefix'.")]
 		public readonly bool GenericStancePrefix = true;
 
 		[Desc("Prefix to display in the tooltip for allied units.")]
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string AllyPrefix = "label-tooltip-prefix.ally";
 
 		[Desc("Prefix to display in the tooltip for neutral units.")]
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string NeutralPrefix;
 
 		[Desc("Prefix to display in the tooltip for enemy units.")]
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string EnemyPrefix = "label-tooltip-prefix.enemy";
 
 		[Desc("Player stances that the generic name should be shown to.")]
@@ -60,19 +60,19 @@ namespace OpenRA.Mods.Common.Traits
 		public string TooltipForPlayerStance(PlayerRelationship relationship)
 		{
 			if (relationship == PlayerRelationship.None || !GenericVisibility.HasRelationship(relationship))
-				return TranslationProvider.GetString(Name);
+				return FluentProvider.GetString(Name);
 
-			var genericName = string.IsNullOrEmpty(GenericName) ? "" : TranslationProvider.GetString(GenericName);
+			var genericName = string.IsNullOrEmpty(GenericName) ? "" : FluentProvider.GetString(GenericName);
 			if (GenericStancePrefix)
 			{
 				if (!string.IsNullOrEmpty(AllyPrefix) && relationship == PlayerRelationship.Ally)
-					return TranslationProvider.GetString(AllyPrefix) + " " + genericName;
+					return FluentProvider.GetString(AllyPrefix) + " " + genericName;
 
 				if (!string.IsNullOrEmpty(NeutralPrefix) && relationship == PlayerRelationship.Neutral)
-					return TranslationProvider.GetString(NeutralPrefix) + " " + genericName;
+					return FluentProvider.GetString(NeutralPrefix) + " " + genericName;
 
 				if (!string.IsNullOrEmpty(EnemyPrefix) && relationship == PlayerRelationship.Enemy)
-					return TranslationProvider.GetString(EnemyPrefix) + " " + genericName;
+					return FluentProvider.GetString(EnemyPrefix) + " " + genericName;
 			}
 
 			return genericName;

--- a/OpenRA.Mods.Common/Traits/TooltipDescription.cs
+++ b/OpenRA.Mods.Common/Traits/TooltipDescription.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class TooltipDescriptionInfo : ConditionalTraitInfo
 	{
 		[FieldLoader.Require]
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Text shown in tooltip.")]
 		public readonly string Description;
 
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 			: base(info)
 		{
 			this.self = self;
-			TooltipText = TranslationProvider.GetString(info.Description);
+			TooltipText = FluentProvider.GetString(info.Description);
 		}
 
 		public bool IsTooltipVisible(Player forPlayer)

--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech notification to play when transforming.")]
 		public readonly string TransformNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification to display when transforming.")]
 		public readonly string TransformTextNotification = null;
 
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech notification to play when the transformation is blocked.")]
 		public readonly string NoTransformNotification = null;
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		[Desc("Text notification to display when the transformation is blocked.")]
 		public readonly string NoTransformTextNotification = null;
 

--- a/OpenRA.Mods.Common/Traits/World/CellTriggerOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/CellTriggerOverlay.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		const string CommandName = "triggers";
 
-		[TranslationReference]
+		[FluentReference]
 		const string CommandDescription = "description-cell-triggers-overlay";
 
 		bool enabled;

--- a/OpenRA.Mods.Common/Traits/World/ColorPickerManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/ColorPickerManager.cs
@@ -24,13 +24,13 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Configuration options for the lobby player color picker. Attach this to the world actor.")]
 	public class ColorPickerManagerInfo : TraitInfo<ColorPickerManager>, IColorPickerManagerInfo
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string PlayerColorTerrain = "notification-player-color-terrain";
 
-		[TranslationReference]
+		[FluentReference]
 		const string PlayerColorPlayer = "notification-player-color-player";
 
-		[TranslationReference]
+		[FluentReference]
 		const string InvalidPlayerColor = "notification-invalid-player-color";
 
 		[Desc("Minimum and maximum saturation levels that are valid for use.")]

--- a/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
@@ -21,11 +21,11 @@ namespace OpenRA.Mods.Common.Traits
 	[TraitLocation(SystemActors.World)]
 	public class CrateSpawnerInfo : TraitInfo, ILobbyOptions
 	{
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Descriptive label for the crates checkbox in the lobby.")]
 		public readonly string CheckboxLabel = "checkbox-crates.label";
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Tooltip description for the crates checkbox in the lobby.")]
 		public readonly string CheckboxDescription = "checkbox-crates.description";
 

--- a/OpenRA.Mods.Common/Traits/World/EditorActionManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActionManager.cs
@@ -146,12 +146,12 @@ namespace OpenRA.Mods.Common.Traits
 
 	sealed class OpenMapAction : IEditorAction
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string Opened = "notification-opened";
 
 		public OpenMapAction()
 		{
-			Text = TranslationProvider.GetString(Opened);
+			Text = FluentProvider.GetString(Opened);
 		}
 
 		public void Execute()

--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly ActorInfo Info;
 
 		public string Tooltip =>
-			(tooltip == null ? " < " + Info.Name + " >" : TranslationProvider.GetString(tooltip.Name)) + "\n" + Owner.Name + " (" + Owner.Faction + ")"
+			(tooltip == null ? " < " + Info.Name + " >" : FluentProvider.GetString(tooltip.Name)) + "\n" + Owner.Name + " (" + Owner.Faction + ")"
 			+ "\nID: " + ID + "\nType: " + Info.Name;
 
 		public string Type => reference.Type;

--- a/OpenRA.Mods.Common/Traits/World/ExitsDebugOverlayManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/ExitsDebugOverlayManager.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		const string CommandName = "exits-overlay";
 
-		[TranslationReference]
+		[FluentReference]
 		const string CommandDescription = "description-exits-overlay";
 
 		public readonly SpriteFont Font;

--- a/OpenRA.Mods.Common/Traits/World/HierarchicalPathFinderOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/HierarchicalPathFinderOverlay.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		const string CommandName = "hpf";
 
-		[TranslationReference]
+		[FluentReference]
 		const string CommandDescription = "description-hpf-debug-overlay";
 
 		readonly HierarchicalPathFinderOverlayInfo info;

--- a/OpenRA.Mods.Common/Traits/World/MapBuildRadius.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapBuildRadius.cs
@@ -18,11 +18,11 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Controls the build radius checkboxes in the lobby options.")]
 	public class MapBuildRadiusInfo : TraitInfo, ILobbyOptions
 	{
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Descriptive label for the ally build radius checkbox in the lobby.")]
 		public readonly string AllyBuildRadiusCheckboxLabel = "checkbox-ally-build-radius.label";
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Tooltip description for the ally build radius checkbox in the lobby.")]
 		public readonly string AllyBuildRadiusCheckboxDescription = "checkbox-ally-build-radius.description";
 
@@ -38,11 +38,11 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Display order for the ally build radius checkbox in the lobby.")]
 		public readonly int AllyBuildRadiusCheckboxDisplayOrder = 0;
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Tooltip description for the build radius checkbox in the lobby.")]
 		public readonly string BuildRadiusCheckboxLabel = "checkbox-build-radius.label";
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Tooltip description for the build radius checkbox in the lobby.")]
 		public readonly string BuildRadiusCheckboxDescription = "checkbox-build-radius.description";
 

--- a/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
@@ -18,11 +18,11 @@ namespace OpenRA.Mods.Common.Traits
 	[TraitLocation(SystemActors.World)]
 	public class MapCreepsInfo : TraitInfo, ILobbyOptions
 	{
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Descriptive label for the creeps checkbox in the lobby.")]
 		public readonly string CheckboxLabel = "dropdown-map-creeps.label";
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Tooltip description for the creeps checkbox in the lobby.")]
 		public readonly string CheckboxDescription = "dropdown-map-creeps.description";
 

--- a/OpenRA.Mods.Common/Traits/World/MapOptions.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapOptions.cs
@@ -19,11 +19,11 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Controls the game speed, tech level, and short game lobby options.")]
 	public class MapOptionsInfo : TraitInfo, ILobbyOptions, IRulesetLoaded
 	{
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Descriptive label for the short game checkbox in the lobby.")]
 		public readonly string ShortGameCheckboxLabel = "checkbox-short-game.label";
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Tooltip description for the short game checkbox in the lobby.")]
 		public readonly string ShortGameCheckboxDescription = "checkbox-short-game.description";
 
@@ -39,11 +39,11 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Display order for the short game checkbox in the lobby.")]
 		public readonly int ShortGameCheckboxDisplayOrder = 0;
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Descriptive label for the tech level option in the lobby.")]
 		public readonly string TechLevelDropdownLabel = "dropdown-tech-level.label";
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Tooltip description for the tech level option in the lobby.")]
 		public readonly string TechLevelDropdownDescription = "dropdown-tech-level.description";
 
@@ -59,11 +59,11 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Display order for the tech level option in the lobby.")]
 		public readonly int TechLevelDropdownDisplayOrder = 0;
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Tooltip description for the game speed option in the lobby.")]
 		public readonly string GameSpeedDropdownLabel = "dropdown-game-speed.label";
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Description of the game speed option in the lobby.")]
 		public readonly string GameSpeedDropdownDescription = "dropdown-game-speed.description";
 
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.Common.Traits
 					techLevels, TechLevel, TechLevelDropdownLocked);
 
 			var gameSpeeds = Game.ModData.Manifest.Get<GameSpeeds>();
-			var speeds = gameSpeeds.Speeds.ToDictionary(s => s.Key, s => TranslationProvider.GetString(s.Value.Name));
+			var speeds = gameSpeeds.Speeds.ToDictionary(s => s.Key, s => FluentProvider.GetString(s.Value.Name));
 
 			// NOTE: This is just exposing the UI, the backend logic for this option is hardcoded in World.
 			yield return new LobbyOption(map, "gamespeed",

--- a/OpenRA.Mods.Common/Traits/World/MapOptions.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapOptions.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Traits
 				ShortGameCheckboxVisible, ShortGameCheckboxDisplayOrder, ShortGameCheckboxEnabled, ShortGameCheckboxLocked);
 
 			var techLevels = map.PlayerActorInfo.TraitInfos<ProvidesTechPrerequisiteInfo>()
-				.ToDictionary(t => t.Id, t => map.GetLocalisedString(t.Name));
+				.ToDictionary(t => t.Id, t => map.GetString(t.Name));
 
 			if (techLevels.Count > 0)
 				yield return new LobbyOption(map, "techlevel",

--- a/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
@@ -25,11 +25,11 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public readonly WDist InitialExploreRange = WDist.FromCells(5);
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Descriptive label for the spawn positions checkbox in the lobby.")]
 		public readonly string SeparateTeamSpawnsCheckboxLabel = "checkbox-separate-team-spawns.label";
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Tooltip description for the spawn positions checkbox in the lobby.")]
 		public readonly string SeparateTeamSpawnsCheckboxDescription = "checkbox-separate-team-spawns.description";
 

--- a/OpenRA.Mods.Common/Traits/World/MapStartingUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapStartingUnits.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Internal class ID.")]
 		public readonly string Class = "none";
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Exposed via the UI to the player.")]
 		public readonly string ClassName = "Unlabeled";
 

--- a/OpenRA.Mods.Common/Traits/World/PathFinderOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinderOverlay.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		const string CommandName = "path-debug";
 
-		[TranslationReference]
+		[FluentReference]
 		const string CommandDescription = "description-path-debug-overlay";
 
 		sealed class Record : PathSearch.IRecorder, IEnumerable<(CPos Source, CPos Destination, int CostSoFar, int EstimatedRemainingCost)>

--- a/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			[FieldLoader.Require]
 			[Desc("Resource name used by tooltips.")]
-			[TranslationReference]
+			[FluentReference]
 			public readonly string Name = null;
 
 			public ResourceTypeInfo(MiniYaml yaml)
@@ -273,7 +273,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (info == null)
 				return null;
 
-			return TranslationProvider.GetString(info.Name);
+			return FluentProvider.GetString(info.Name);
 		}
 
 		IEnumerable<string> IResourceRenderer.ResourceTypes => Info.ResourceTypes.Keys;

--- a/OpenRA.Mods.Common/Traits/World/ScriptLobbyDropdown.cs
+++ b/OpenRA.Mods.Common/Traits/World/ScriptLobbyDropdown.cs
@@ -23,11 +23,11 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string ID = null;
 
 		[FieldLoader.Require]
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Descriptive label for this option.")]
 		public readonly string Label = null;
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Tooltip description for this option.")]
 		public readonly string Description = null;
 
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Default = null;
 
 		[FieldLoader.Require]
-		[TranslationReference(dictionaryReference: LintDictionaryReference.Values)]
+		[FluentReference(dictionaryReference: LintDictionaryReference.Values)]
 		[Desc("Options to choose from.")]
 		public readonly Dictionary<string, string> Values = null;
 

--- a/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
@@ -25,11 +25,11 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public readonly string StartingUnitsClass = "none";
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Descriptive label for the starting units option in the lobby.")]
 		public readonly string DropdownLabel = "dropdown-starting-units.label";
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Tooltip description for the starting units option in the lobby.")]
 		public readonly string DropdownDescription = "dropdown-starting-units.description";
 

--- a/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Duplicate classes are defined for different race variants
 			foreach (var t in map.WorldActorInfo.TraitInfos<StartingUnitsInfo>())
-				startingUnits[t.Class] = map.GetLocalisedString(t.ClassName);
+				startingUnits[t.Class] = map.GetString(t.ClassName);
 
 			if (startingUnits.Count > 0)
 				yield return new LobbyOption(map, "startingunits", DropdownLabel, DropdownDescription, DropdownVisible, DropdownDisplayOrder,

--- a/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
+++ b/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
@@ -20,19 +20,19 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Speech")]
 		public readonly string Notification = "StartGame";
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string TextNotification = null;
 
 		[NotificationReference("Speech")]
 		public readonly string LoadedNotification = "GameLoaded";
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string LoadedTextNotification = null;
 
 		[NotificationReference("Speech")]
 		public readonly string SavedNotification = "GameSaved";
 
-		[TranslationReference(optional: true)]
+		[FluentReference(optional: true)]
 		public readonly string SavedTextNotification = null;
 
 		public override object Create(ActorInitializer init) { return new StartGameNotification(this); }

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		const string CommandName = "terrain-geometry";
 
-		[TranslationReference]
+		[FluentReference]
 		const string CommandDescription = "description-terrain-geometry-overlay";
 
 		public bool Enabled;

--- a/OpenRA.Mods.Common/Traits/World/TimeLimitManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/TimeLimitManager.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (m == 0)
 					return FluentProvider.GetString(NoTimeLimit);
 				else
-					return FluentProvider.GetString(TimeLimitOption, FluentBundle.Arguments("minutes", m));
+					return FluentProvider.GetString(TimeLimitOption, "minutes", m);
 			});
 
 			yield return new LobbyOption(map, "timelimit", TimeLimitLabel, TimeLimitDescription, TimeLimitDropdownVisible, TimeLimitDisplayOrder,

--- a/OpenRA.Mods.Common/Traits/World/TimeLimitManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/TimeLimitManager.cs
@@ -22,11 +22,11 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("This trait allows setting a time limit on matches. Attach this to the World actor.")]
 	public class TimeLimitManagerInfo : TraitInfo, ILobbyOptions, IRulesetLoaded
 	{
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Label that will be shown for the time limit option in the lobby.")]
 		public readonly string TimeLimitLabel = "dropdown-time-limit.label";
 
-		[TranslationReference]
+		[FluentReference]
 		[Desc("Tooltip description that will be shown for the time limit option in the lobby.")]
 		public readonly string TimeLimitDescription = "dropdown-time-limit.description";
 
@@ -77,10 +77,10 @@ namespace OpenRA.Mods.Common.Traits
 				throw new YamlException("TimeLimitDefault must be a value from TimeLimitOptions");
 		}
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoTimeLimit = "options-time-limit.no-limit";
 
-		[TranslationReference("minutes")]
+		[FluentReference("minutes")]
 		const string TimeLimitOption = "options-time-limit.options";
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
@@ -88,9 +88,9 @@ namespace OpenRA.Mods.Common.Traits
 			var timelimits = TimeLimitOptions.ToDictionary(m => m.ToStringInvariant(), m =>
 			{
 				if (m == 0)
-					return TranslationProvider.GetString(NoTimeLimit);
+					return FluentProvider.GetString(NoTimeLimit);
 				else
-					return TranslationProvider.GetString(TimeLimitOption, Translation.Arguments("minutes", m));
+					return FluentProvider.GetString(TimeLimitOption, FluentBundle.Arguments("minutes", m));
 			});
 
 			yield return new LobbyOption(map, "timelimit", TimeLimitLabel, TimeLimitDescription, TimeLimitDropdownVisible, TimeLimitDisplayOrder,
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class TimeLimitManager : INotifyTimeLimit, ITick, IWorldLoaded
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string TimeLimitExpired = "notification-time-limit-expired";
 
 		readonly TimeLimitManagerInfo info;
@@ -182,7 +182,7 @@ namespace OpenRA.Mods.Common.Traits
 				countdownLabel.GetText = () => null;
 
 			if (!info.SkipTimerExpiredNotification)
-				TextNotificationsManager.AddSystemLine(TranslationProvider.GetString(TimeLimitExpired));
+				TextNotificationsManager.AddSystemLine(FluentProvider.GetString(TimeLimitExpired));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
@@ -334,11 +334,11 @@ namespace OpenRA.Mods.Common.UpdateRules
 			return string.Join("\n", messages.Select(m => prefix + $" {separator} {m.Replace("\n", "\n   " + prefix)}"));
 		}
 
-		public static bool IsAlreadyTranslated(string translation)
+		public static bool IsAlreadyExtracted(string key)
 		{
-			if (translation == translation.ToLowerInvariant() && translation.Any(c => c == '-') && translation.All(c => c != ' '))
+			if (key == key.ToLowerInvariant() && key.Any(c => c == '-') && key.All(c => c != ' '))
 			{
-				Console.WriteLine($"Skipping {translation} because it is already translated.");
+				Console.WriteLine($"Skipping {key} because it is already extracted.");
 				return true;
 			}
 

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractChromeStrings.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractChromeStrings.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using OpenRA.FileSystem;
@@ -37,11 +36,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			// HACK: The engine code assumes that Game.modData is set.
 			var modData = Game.ModData = utility.ModData;
 
-			var translatableFields = modData.ObjectCreator.GetTypes()
+			var widgetInfos = modData.ObjectCreator.GetTypes()
 				.Where(t => t.Name.EndsWith("Widget", StringComparison.InvariantCulture) && t.IsSubclassOf(typeof(Widget)))
 				.ToDictionary(
 					t => t.Name[..^6],
-					t => t.GetFields().Where(f => f.HasAttribute<TranslationReferenceAttribute>()).Select(f => f.Name).ToArray())
+					t => t.GetFields().Where(f => f.HasAttribute<FluentReferenceAttribute>()).Select(f => f.Name).ToArray())
 				.Where(t => t.Value.Length > 0)
 				.ToDictionary(t => t.Key, t => t.Value);
 
@@ -53,12 +52,12 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				var fluentPackage = modData.ModFiles.OpenPackage(fluentFolder);
 				var fluentPath = Path.Combine(fluentPackage.Name, "chrome/en.ftl");
 
-				var unsortedCandidates = new List<TranslationCandidate>();
-				var groupedCandidates = new Dictionary<HashSet<string>, List<TranslationCandidate>>();
+				var unsortedCandidates = new List<ExtractionCandidate>();
+				var groupedCandidates = new Dictionary<HashSet<string>, List<ExtractionCandidate>>();
 
 				var yamlSet = new YamlFileSet();
 
-				// Get all translations.
+				// Get all string candidates.
 				foreach (var chrome in layout)
 				{
 					modData.ModFiles.TryGetPackageContaining(chrome, out var chromePackage, out var chromeName);
@@ -67,40 +66,40 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					var yaml = MiniYaml.FromFile(chromePath, false).ConvertAll(n => new MiniYamlNodeBuilder(n));
 					yamlSet.Add(((IReadWritePackage)chromePackage, chromeName, yaml));
 
-					var translationCandidates = new List<TranslationCandidate>();
+					var extractionCandidates = new List<ExtractionCandidate>();
 					foreach (var node in yaml)
 					{
 						if (node.Key != null)
 						{
 							var nodeSplit = node.Key.Split('@');
 							var nodeId = nodeSplit.Length > 1 ? ClearContainersAndToLower(nodeSplit[1]) : null;
-							FromChromeLayout(node, translatableFields, nodeId, ref translationCandidates);
+							FromChromeLayout(node, widgetInfos, nodeId, ref extractionCandidates);
 						}
 					}
 
-					if (translationCandidates.Count > 0)
+					if (extractionCandidates.Count > 0)
 					{
 						var chromeFilename = chrome.Split('/').Last();
-						groupedCandidates[new HashSet<string>() { chromeFilename }] = new List<TranslationCandidate>();
-						for (var i = 0; i < translationCandidates.Count; i++)
+						groupedCandidates[new HashSet<string>() { chromeFilename }] = new List<ExtractionCandidate>();
+						for (var i = 0; i < extractionCandidates.Count; i++)
 						{
-							var candidate = translationCandidates[i];
+							var candidate = extractionCandidates[i];
 							candidate.Chrome = chromeFilename;
 							unsortedCandidates.Add(candidate);
 						}
 					}
 				}
 
-				// Join matching translations.
+				// Join matching candidates.
 				foreach (var candidate in unsortedCandidates)
 				{
 					HashSet<string> foundHash = null;
-					TranslationCandidate found = default;
-					foreach (var (hash, translation) in groupedCandidates)
+					ExtractionCandidate found = default;
+					foreach (var (hash, candidates) in groupedCandidates)
 					{
-						foreach (var c in translation)
+						foreach (var c in candidates)
 						{
-							if (c.Key == candidate.Key && c.Type == candidate.Type && c.Translation == candidate.Translation)
+							if (c.Key == candidate.Key && c.Type == candidate.Type && c.Value == candidate.Value)
 							{
 								foundHash = hash;
 								found = c;
@@ -127,7 +126,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					if (nHash.Key != null)
 						groupedCandidates[nHash.Key].Add(candidate);
 					else
-						groupedCandidates[newHash] = new List<TranslationCandidate>() { candidate };
+						groupedCandidates[newHash] = new List<ExtractionCandidate>() { candidate };
 				}
 
 				var startWithNewline = File.Exists(fluentPath);
@@ -136,7 +135,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				if (!startWithNewline)
 					Directory.CreateDirectory(Path.GetDirectoryName(fluentPath));
 
-				// Write to translation files.
+				// Write output .ftl files.
 				using (var fluentWriter = new StreamWriter(fluentPath, append: true))
 				{
 					foreach (var (chromeFilename, candidates) in groupedCandidates.OrderBy(t => string.Join(',', t.Key)))
@@ -151,30 +150,28 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 						fluentWriter.WriteLine("## " + string.Join(", ", chromeFilename));
 
-						// Pushing blocks of translations to string first allows for fancier formatting.
+						// Pushing blocks to string first allows for fancier formatting.
 						var build = "";
 						foreach (var grouping in candidates.GroupBy(t => t.Key))
 						{
 							if (grouping.Count() == 1)
 							{
 								var candidate = grouping.First();
-								var translationKey = candidate.Key;
-								if (candidate.Type == "text")
-									translationKey = $"{translationKey}";
-								else
-									translationKey = $"{translationKey}-" + candidate.Type.Replace("text", "");
+								var key = candidate.Key;
+								if (candidate.Type != "text")
+									key = $"{key}-" + candidate.Type.Replace("text", "");
 
-								build += $"{translationKey} = {candidate.Translation}\n";
+								build += $"{key} = {candidate.Value}\n";
 								foreach (var node in candidate.Nodes)
-									node.Value.Value = translationKey;
+									node.Value.Value = key;
 							}
 							else
 							{
 								if (build.Length > 1 && build.Substring(build.Length - 2, 2) != "\n\n")
 									build += "\n";
 
-								var translationKey = grouping.Key;
-								build += $"{translationKey} =\n";
+								var key = grouping.Key;
+								build += $"{key} =\n";
 								foreach (var candidate in grouping)
 								{
 									var type = candidate.Type;
@@ -186,9 +183,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 											type = type.Replace("text", "");
 									}
 
-									build += $"   .{type} = {candidate.Translation}\n";
+									build += $"   .{type} = {candidate.Value}\n";
 									foreach (var node in candidate.Nodes)
-										node.Value.Value = $"{translationKey}.{type}";
+										node.Value.Value = $"{key}.{type}";
 								}
 
 								build += "\n";
@@ -203,20 +200,20 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			}
 		}
 
-		struct TranslationCandidate
+		struct ExtractionCandidate
 		{
 			public string Chrome;
 			public readonly string Key;
 			public readonly string Type;
-			public readonly string Translation;
+			public readonly string Value;
 			public readonly List<MiniYamlNodeBuilder> Nodes;
 
-			public TranslationCandidate(string key, string type, string translation, MiniYamlNodeBuilder node)
+			public ExtractionCandidate(string key, string type, string value, MiniYamlNodeBuilder node)
 			{
 				Chrome = null;
 				Key = key;
 				Type = type;
-				Translation = translation;
+				Value = value;
 				Nodes = new List<MiniYamlNodeBuilder>() { node };
 			}
 		}
@@ -245,88 +242,69 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		}
 
 		static void FromChromeLayout(
-			MiniYamlNodeBuilder node, Dictionary<string, string[]> translatables, string container, ref List<TranslationCandidate> translations)
+			MiniYamlNodeBuilder node, Dictionary<string, string[]> widgetInfos, string container, ref List<ExtractionCandidate> candidates)
 		{
 			var nodeSplit = node.Key.Split('@');
-			var nodeType = nodeSplit[0];
+			var widgetType = nodeSplit[0];
 			var nodeId = nodeSplit.Length > 1 ? ClearContainersAndToLower(nodeSplit[1]) : null;
 
-			if ((nodeType == "Background" || nodeType == "Container") && nodeId != null)
+			if ((widgetType == "Background" || widgetType == "Container") && nodeId != null)
 				container = nodeId;
 
-			// Get translatable types.
 			var validChildTypes = new List<(MiniYamlNodeBuilder Node, string Type, string Value)>();
 			foreach (var childNode in node.Value.Nodes)
 			{
-				if (translatables.TryGetValue(nodeType, out var fieldName))
+				if (widgetInfos.TryGetValue(widgetType, out var fieldName))
 				{
 					var childType = childNode.Key.Split('@')[0];
 					if (fieldName.Contains(childType)
 						&& !string.IsNullOrEmpty(childNode.Value.Value)
-						&& !UpdateUtils.IsAlreadyTranslated(childNode.Value.Value)
+						&& !UpdateUtils.IsAlreadyExtracted(childNode.Value.Value)
 						&& childNode.Value.Value.Any(char.IsLetterOrDigit))
 					{
-						var translationValue = childNode.Value.Value
+						var value = childNode.Value.Value
 							.Replace("\\n", "\n    ")
 							.Replace("{", "<")
 							.Replace("}", ">")
 							.Trim().Trim('\n');
 
-						validChildTypes.Add((childNode, childType.ToLowerInvariant(), translationValue));
+						validChildTypes.Add((childNode, childType.ToLowerInvariant(), value));
 					}
 				}
 			}
 
-			// Generate translation key.
+			// Generate string key.
 			if (validChildTypes.Count > 0)
 			{
-				nodeType = ClearTypesAndToLower(nodeType);
+				widgetType = ClearTypesAndToLower(widgetType);
 
-				var translationKey = nodeType;
+				var key = widgetType;
 				if (!string.IsNullOrEmpty(container))
 				{
-					var containerType = string.Join('-', container.Split('_').Exclude(nodeType).Where(s => !string.IsNullOrEmpty(s)));
+					var containerType = string.Join('-', container.Split('_').Exclude(widgetType).Where(s => !string.IsNullOrEmpty(s)));
 					if (!string.IsNullOrEmpty(containerType))
-						translationKey = $"{translationKey}-{containerType}";
+						key = $"{key}-{containerType}";
 				}
 
 				if (!string.IsNullOrEmpty(nodeId))
 				{
 					nodeId = string.Join('-', nodeId.Split('_')
-						.Except(string.IsNullOrEmpty(container) ? new string[] { nodeType } : container.Split('_').Append(nodeType))
+						.Except(string.IsNullOrEmpty(container) ? new string[] { widgetType } : container.Split('_').Append(widgetType))
 						.Where(s => !string.IsNullOrEmpty(s)));
 
 					if (!string.IsNullOrEmpty(nodeId))
-						translationKey = $"{translationKey}-{nodeId}";
+						key = $"{key}-{nodeId}";
 				}
 
-				foreach (var (childNode, childType, translationValue) in validChildTypes)
-					translations.Add(new TranslationCandidate(translationKey, childType, translationValue.Trim().Trim('\n'), childNode));
+				foreach (var (childNode, childType, childValue) in validChildTypes)
+					candidates.Add(new ExtractionCandidate(key, childType, childValue.Trim().Trim('\n'), childNode));
 			}
 
 			// Recursive.
 			foreach (var childNode in node.Value.Nodes)
 				if (childNode.Key == "Children")
 					foreach (var n in childNode.Value.Nodes)
-						FromChromeLayout(n, translatables, container, ref translations);
-		}
-
-		/// <summary>This is a helper method to find untranslated strings in chrome layouts.</summary>
-		public static void FindUntranslatedStringFields(ModData modData)
-		{
-			var types = modData.ObjectCreator.GetTypes();
-			foreach (var (type, fields) in types
-				.Where(t => t.Name.EndsWith("Widget", StringComparison.InvariantCulture) && t.IsSubclassOf(typeof(Widget)))
-				.ToDictionary(
-					t => t.Name[..^6],
-					t => t
-						.GetFields()
-						.Where(f => f.Name != "Id" && f.IsPublic && f.FieldType == typeof(string) && !f.HasAttribute<TranslationReferenceAttribute>())
-						.Distinct()
-						.Select(f => f.Name)
-						.ToList()))
-				if (fields.Count > 0)
-					Console.WriteLine($"{type}Widget:\n  {string.Join("\n  ", fields)}");
+						FromChromeLayout(n, widgetInfos, container, ref candidates);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public bool DisableKeyRepeat = false;
 		public bool DisableKeySound = false;
 
-		[TranslationReference]
+		[FluentReference]
 		public string Text = "";
 		public TextAlign Align = TextAlign.Center;
 		public int LeftMargin = 5;
@@ -55,11 +55,11 @@ namespace OpenRA.Mods.Common.Widgets
 
 		protected Lazy<TooltipContainerWidget> tooltipContainer;
 
-		[TranslationReference]
+		[FluentReference]
 		public string TooltipText;
 		public Func<string> GetTooltipText;
 
-		[TranslationReference]
+		[FluentReference]
 		public string TooltipDesc;
 		public Func<string> GetTooltipDesc;
 
@@ -77,9 +77,9 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			ModRules = modData.DefaultRules;
 
-			var textCache = new CachedTransform<string, string>(s => !string.IsNullOrEmpty(s) ? TranslationProvider.GetString(s) : "");
-			var tooltipTextCache = new CachedTransform<string, string>(s => !string.IsNullOrEmpty(s) ? TranslationProvider.GetString(s) : "");
-			var tooltipDescCache = new CachedTransform<string, string>(s => !string.IsNullOrEmpty(s) ? TranslationProvider.GetString(s) : "");
+			var textCache = new CachedTransform<string, string>(s => !string.IsNullOrEmpty(s) ? FluentProvider.GetString(s) : "");
+			var tooltipTextCache = new CachedTransform<string, string>(s => !string.IsNullOrEmpty(s) ? FluentProvider.GetString(s) : "");
+			var tooltipDescCache = new CachedTransform<string, string>(s => !string.IsNullOrEmpty(s) ? FluentProvider.GetString(s) : "");
 
 			GetText = () => textCache.Update(Text);
 			GetColor = () => TextColor;

--- a/OpenRA.Mods.Common/Widgets/ConfirmationDialogs.cs
+++ b/OpenRA.Mods.Common/Widgets/ConfirmationDialogs.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets
@@ -21,8 +20,8 @@ namespace OpenRA.Mods.Common.Widgets
 			ModData modData,
 			string title,
 			string text,
-			Dictionary<string, object> titleArguments = null,
-			Dictionary<string, object> textArguments = null,
+			object[] titleArguments = null,
+			object[] textArguments = null,
 			Action onConfirm = null,
 			string confirmText = null,
 			Action onCancel = null,

--- a/OpenRA.Mods.Common/Widgets/ConfirmationDialogs.cs
+++ b/OpenRA.Mods.Common/Widgets/ConfirmationDialogs.cs
@@ -36,11 +36,11 @@ namespace OpenRA.Mods.Common.Widgets
 			var cancelButton = prompt.GetOrNull<ButtonWidget>("CANCEL_BUTTON");
 			var otherButton = prompt.GetOrNull<ButtonWidget>("OTHER_BUTTON");
 
-			var titleMessage = TranslationProvider.GetString(title, titleArguments);
+			var titleMessage = FluentProvider.GetString(title, titleArguments);
 			prompt.Get<LabelWidget>("PROMPT_TITLE").GetText = () => titleMessage;
 
 			var headerTemplate = prompt.Get<LabelWidget>("PROMPT_TEXT");
-			var textMessage = TranslationProvider.GetString(text, textArguments);
+			var textMessage = FluentProvider.GetString(text, textArguments);
 			var headerLines = textMessage.Split('\n');
 			var headerHeight = 0;
 			foreach (var l in headerLines)
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 				if (!string.IsNullOrEmpty(confirmText))
 				{
-					var confirmTextMessage = TranslationProvider.GetString(confirmText);
+					var confirmTextMessage = FluentProvider.GetString(confirmText);
 					confirmButton.GetText = () => confirmTextMessage;
 				}
 			}
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 				if (!string.IsNullOrEmpty(cancelText))
 				{
-					var cancelTextMessage = TranslationProvider.GetString(cancelText);
+					var cancelTextMessage = FluentProvider.GetString(cancelText);
 					cancelButton.GetText = () => cancelTextMessage;
 				}
 			}
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 				if (!string.IsNullOrEmpty(otherText))
 				{
-					var otherTextMessage = TranslationProvider.GetString(otherText);
+					var otherTextMessage = FluentProvider.GetString(otherText);
 					otherButton.GetText = () => otherTextMessage;
 				}
 			}
@@ -114,10 +114,10 @@ namespace OpenRA.Mods.Common.Widgets
 			Func<bool> doValidate = null;
 			ButtonWidget acceptButton = null, cancelButton = null;
 
-			var titleMessage = TranslationProvider.GetString(title);
+			var titleMessage = FluentProvider.GetString(title);
 			panel.Get<LabelWidget>("PROMPT_TITLE").GetText = () => titleMessage;
 
-			var promptMessage = TranslationProvider.GetString(prompt);
+			var promptMessage = FluentProvider.GetString(prompt);
 			panel.Get<LabelWidget>("PROMPT_TEXT").GetText = () => promptMessage;
 
 			var input = panel.Get<TextFieldWidget>("INPUT_TEXT");
@@ -147,7 +147,7 @@ namespace OpenRA.Mods.Common.Widgets
 			acceptButton = panel.Get<ButtonWidget>("ACCEPT_BUTTON");
 			if (!string.IsNullOrEmpty(acceptText))
 			{
-				var acceptTextMessage = TranslationProvider.GetString(acceptText);
+				var acceptTextMessage = FluentProvider.GetString(acceptText);
 				acceptButton.GetText = () => acceptTextMessage;
 			}
 
@@ -163,7 +163,7 @@ namespace OpenRA.Mods.Common.Widgets
 			cancelButton = panel.Get<ButtonWidget>("CANCEL_BUTTON");
 			if (!string.IsNullOrEmpty(cancelText))
 			{
-				var cancelTextMessage = TranslationProvider.GetString(cancelText);
+				var cancelTextMessage = FluentProvider.GetString(cancelText);
 				cancelButton.GetText = () => cancelTextMessage;
 			}
 

--- a/OpenRA.Mods.Common/Widgets/ImageWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ImageWidget.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public Func<string> GetImageCollection;
 		public Func<Sprite> GetSprite;
 
-		[TranslationReference]
+		[FluentReference]
 		public string TooltipText;
 
 		readonly Lazy<TooltipContainerWidget> tooltipContainer;
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			GetImageName = () => ImageName;
 			GetImageCollection = () => ImageCollection;
-			var tooltipCache = new CachedTransform<string, string>(s => !string.IsNullOrEmpty(s) ? TranslationProvider.GetString(s) : "");
+			var tooltipCache = new CachedTransform<string, string>(s => !string.IsNullOrEmpty(s) ? FluentProvider.GetString(s) : "");
 			GetTooltipText = () => tooltipCache.Update(TooltipText);
 			tooltipContainer = Exts.Lazy(() =>
 				Ui.Root.Get<TooltipContainerWidget>(TooltipContainer));

--- a/OpenRA.Mods.Common/Widgets/LabelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LabelWidget.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 	public class LabelWidget : Widget
 	{
-		[TranslationReference]
+		[FluentReference]
 		public string Text = null;
 		public TextAlign Align = TextAlign.Left;
 		public TextVAlign VAlign = TextVAlign.Middle;
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Widgets
 		[ObjectCreator.UseCtor]
 		public LabelWidget(ModData modData)
 		{
-			var textCache = new CachedTransform<string, string>(s => !string.IsNullOrEmpty(s) ? TranslationProvider.GetString(s) : "");
+			var textCache = new CachedTransform<string, string>(s => !string.IsNullOrEmpty(s) ? FluentProvider.GetString(s) : "");
 			GetText = () => textCache.Update(Text);
 			GetColor = () => TextColor;
 			GetContrastColorDark = () => ContrastColorDark;

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -238,7 +238,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (frameText != null)
 			{
 				var soundLength = new CachedTransform<double, string>(p =>
-					FluentProvider.GetString(LengthInSeconds, FluentBundle.Arguments("length", Math.Round(p, 3))));
+					FluentProvider.GetString(LengthInSeconds, "length", Math.Round(p, 3)));
 
 				frameText.GetText = () =>
 				{

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -35,10 +35,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Unknown = 16
 		}
 
-		[TranslationReference("length")]
+		[FluentReference("length")]
 		const string LengthInSeconds = "label-length-in-seconds";
 
-		[TranslationReference]
+		[FluentReference]
 		const string AllPackages = "label-all-packages";
 
 		readonly string[] allowedExtensions;
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.modData = modData;
 			panel = widget;
 
-			allPackages = TranslationProvider.GetString(AllPackages);
+			allPackages = FluentProvider.GetString(AllPackages);
 
 			var colorPickerPalettes = world.WorldActor.TraitsImplementing<IProvidesAssetBrowserColorPickerPalettes>()
 				.SelectMany(p => p.ColorPickerPaletteNames)
@@ -238,7 +238,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (frameText != null)
 			{
 				var soundLength = new CachedTransform<double, string>(p =>
-					TranslationProvider.GetString(LengthInSeconds, Translation.Arguments("length", Math.Round(p, 3))));
+					FluentProvider.GetString(LengthInSeconds, FluentBundle.Arguments("length", Math.Round(p, 3))));
 
 				frameText.GetText = () =>
 				{

--- a/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var panel = widget;
 			panel.Get<ButtonWidget>("ABORT_BUTTON").OnClick = () => { CloseWindow(); onAbort(); };
 
-			var connectingDesc = FluentProvider.GetString(ConnectingToEndpoint, FluentBundle.Arguments("endpoint", endpoint));
+			var connectingDesc = FluentProvider.GetString(ConnectingToEndpoint, "endpoint", endpoint);
 			widget.Get<LabelWidget>("CONNECTING_DESC").GetText = () => connectingDesc;
 		}
 
@@ -130,7 +130,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				onRetry(pass);
 			};
 
-			var connectingDescText = FluentProvider.GetString(CouldNotConnectToTarget, FluentBundle.Arguments("target", connection.Target));
+			var connectingDescText = FluentProvider.GetString(CouldNotConnectToTarget, "target", connection.Target);
 			widget.Get<LabelWidget>("CONNECTING_DESC").GetText = () => connectingDescText;
 
 			var connectionError = widget.Get<LabelWidget>("CONNECTION_ERROR");

--- a/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class ConnectionLogic : ChromeLogic
 	{
-		[TranslationReference("endpoint")]
+		[FluentReference("endpoint")]
 		const string ConnectingToEndpoint = "label-connecting-to-endpoint";
 
 		readonly Action onConnect;
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var panel = widget;
 			panel.Get<ButtonWidget>("ABORT_BUTTON").OnClick = () => { CloseWindow(); onAbort(); };
 
-			var connectingDesc = TranslationProvider.GetString(ConnectingToEndpoint, Translation.Arguments("endpoint", endpoint));
+			var connectingDesc = FluentProvider.GetString(ConnectingToEndpoint, FluentBundle.Arguments("endpoint", endpoint));
 			widget.Get<LabelWidget>("CONNECTING_DESC").GetText = () => connectingDesc;
 		}
 
@@ -87,16 +87,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 	public class ConnectionFailedLogic : ChromeLogic
 	{
-		[TranslationReference("target")]
+		[FluentReference("target")]
 		const string CouldNotConnectToTarget = "label-could-not-connect-to-target";
 
-		[TranslationReference]
+		[FluentReference]
 		const string UnknownError = "label-unknown-error";
 
-		[TranslationReference]
+		[FluentReference]
 		const string PasswordRequired = "label-password-required";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ConnectionFailed = "label-connection-failed";
 
 		readonly PasswordFieldWidget passwordField;
@@ -130,17 +130,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				onRetry(pass);
 			};
 
-			var connectingDescText = TranslationProvider.GetString(CouldNotConnectToTarget, Translation.Arguments("target", connection.Target));
+			var connectingDescText = FluentProvider.GetString(CouldNotConnectToTarget, FluentBundle.Arguments("target", connection.Target));
 			widget.Get<LabelWidget>("CONNECTING_DESC").GetText = () => connectingDescText;
 
 			var connectionError = widget.Get<LabelWidget>("CONNECTION_ERROR");
 			var connectionErrorText = orderManager.ServerError != null
-				? TranslationProvider.GetString(orderManager.ServerError)
-				: connection.ErrorMessage ?? TranslationProvider.GetString(UnknownError);
+				? FluentProvider.GetString(orderManager.ServerError)
+				: connection.ErrorMessage ?? FluentProvider.GetString(UnknownError);
 			connectionError.GetText = () => connectionErrorText;
 
 			var panelTitle = widget.Get<LabelWidget>("TITLE");
-			var panelTitleText = orderManager.AuthenticationFailed ? TranslationProvider.GetString(PasswordRequired) : TranslationProvider.GetString(ConnectionFailed);
+			var panelTitleText = orderManager.AuthenticationFailed ? FluentProvider.GetString(PasswordRequired) : FluentProvider.GetString(ConnectionFailed);
 			panelTitle.GetText = () => panelTitleText;
 
 			passwordField = panel.GetOrNull<PasswordFieldWidget>("PASSWORD");
@@ -182,7 +182,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 	public class ConnectionSwitchModLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string ModSwitchFailed = "notification-mod-switch-failed";
 
 		[ObjectCreator.UseCtor]

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -21,13 +21,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class ActorEditLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string DuplicateActorId = "label-duplicate-actor-id";
 
-		[TranslationReference]
+		[FluentReference]
 		const string EnterActorId = "label-actor-id";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Owner = "label-actor-owner";
 
 		// Error states define overlapping bits to simplify panel reflow logic
@@ -94,8 +94,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			actorIDErrorLabel.IsVisible = () => actorIDStatus != ActorIDStatus.Normal;
 			actorIDErrorLabel.GetText = () =>
 				actorIDStatus == ActorIDStatus.Duplicate || nextActorIDStatus == ActorIDStatus.Duplicate
-					? TranslationProvider.GetString(DuplicateActorId)
-					: TranslationProvider.GetString(EnterActorId);
+					? FluentProvider.GetString(DuplicateActorId)
+					: FluentProvider.GetString(EnterActorId);
 
 			okButton.IsDisabled = () => !IsValid() || editActorPreview == null || !editActorPreview.IsDirty;
 			okButton.OnClick = Save;
@@ -167,7 +167,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				initialActorID = actorIDField.Text = SelectedActor.ID;
 
 				var font = Game.Renderer.Fonts[typeLabel.Font];
-				var truncatedType = WidgetUtils.TruncateText(TranslationProvider.GetString(SelectedActor.DescriptiveName), typeLabel.Bounds.Width, font);
+				var truncatedType = WidgetUtils.TruncateText(FluentProvider.GetString(SelectedActor.DescriptiveName), typeLabel.Bounds.Width, font);
 				typeLabel.GetText = () => truncatedType;
 
 				actorIDField.CursorPosition = SelectedActor.ID.Length;
@@ -180,7 +180,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				// Add owner dropdown
 				var ownerContainer = dropdownOptionTemplate.Clone();
-				var owner = TranslationProvider.GetString(Owner);
+				var owner = FluentProvider.GetString(Owner);
 				ownerContainer.Get<LabelWidget>("LABEL").GetText = () => owner;
 				var ownerDropdown = ownerContainer.Get<DropDownButtonWidget>("OPTION");
 				var selectedOwner = SelectedActor.Owner;
@@ -439,10 +439,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 	sealed class EditActorEditorAction : IEditorAction
 	{
-		[TranslationReference("name", "id")]
+		[FluentReference("name", "id")]
 		const string EditedActor = "notification-edited-actor";
 
-		[TranslationReference("name", "old-id", "new-id")]
+		[FluentReference("name", "old-id", "new-id")]
 		const string EditedActorId = "notification-edited-actor-id";
 
 		public string Text { get; private set; }
@@ -454,7 +454,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			Actor = actor;
 			this.handles = handles;
-			Text = TranslationProvider.GetString(EditedActor, Translation.Arguments("name", actor.Info.Name, "id", actor.ID));
+			Text = FluentProvider.GetString(EditedActor, FluentBundle.Arguments("name", actor.Info.Name, "id", actor.ID));
 		}
 
 		public void Execute()
@@ -466,7 +466,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var after = Actor;
 			if (before != after)
-				Text = TranslationProvider.GetString(EditedActorId, Translation.Arguments("name", after.Info.Name, "old-id", before.ID, "new-id", after.ID));
+				Text = FluentProvider.GetString(EditedActorId, FluentBundle.Arguments("name", after.Info.Name, "old-id", before.ID, "new-id", after.ID));
 		}
 
 		public void Do()

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -454,7 +454,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			Actor = actor;
 			this.handles = handles;
-			Text = FluentProvider.GetString(EditedActor, FluentBundle.Arguments("name", actor.Info.Name, "id", actor.ID));
+			Text = FluentProvider.GetString(EditedActor, "name", actor.Info.Name, "id", actor.ID);
 		}
 
 		public void Execute()
@@ -466,7 +466,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var after = Actor;
 			if (before != after)
-				Text = FluentProvider.GetString(EditedActorId, FluentBundle.Arguments("name", after.Info.Name, "old-id", before.ID, "new-id", after.ID));
+				Text = FluentProvider.GetString(EditedActorId, "name", after.Info.Name, "old-id", before.ID, "new-id", after.ID);
 		}
 
 		public void Do()

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var tooltip = a.TraitInfos<EditorOnlyTooltipInfo>().FirstOrDefault(ti => ti.EnabledByDefault) as TooltipInfoBase
 					?? a.TraitInfos<TooltipInfo>().FirstOrDefault(ti => ti.EnabledByDefault);
 
-				var actorType = FluentProvider.GetString(ActorTypeTooltip, FluentBundle.Arguments("actorType", a.Name));
+				var actorType = FluentProvider.GetString(ActorTypeTooltip, "actorType", a.Name);
 
 				var searchTerms = new List<string>() { a.Name };
 				if (tooltip != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class ActorSelectorLogic : CommonSelectorLogic
 	{
-		[TranslationReference("actorType")]
+		[FluentReference("actorType")]
 		const string ActorTypeTooltip = "label-actor-type";
 
 		sealed class ActorSelectorActor
@@ -112,12 +112,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var tooltip = a.TraitInfos<EditorOnlyTooltipInfo>().FirstOrDefault(ti => ti.EnabledByDefault) as TooltipInfoBase
 					?? a.TraitInfos<TooltipInfo>().FirstOrDefault(ti => ti.EnabledByDefault);
 
-				var actorType = TranslationProvider.GetString(ActorTypeTooltip, Translation.Arguments("actorType", a.Name));
+				var actorType = FluentProvider.GetString(ActorTypeTooltip, FluentBundle.Arguments("actorType", a.Name));
 
 				var searchTerms = new List<string>() { a.Name };
 				if (tooltip != null)
 				{
-					var actorName = TranslationProvider.GetString(tooltip.Name);
+					var actorName = FluentProvider.GetString(tooltip.Name);
 					searchTerms.Add(actorName);
 					allActorsTemp.Add(new ActorSelectorActor(a, editorData.Categories, searchTerms.ToArray(), actorName + $"\n{actorType}"));
 				}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/CommonSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/CommonSelectorLogic.cs
@@ -19,16 +19,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public abstract class CommonSelectorLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string None = "options-common-selector.none";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SearchResults = "options-common-selector.search-results";
 
-		[TranslationReference]
+		[FluentReference]
 		const string All = "options-common-selector.all";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Multiple = "options-common-selector.multiple";
 
 		protected readonly Widget Widget;
@@ -73,10 +73,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			Editor.DefaultBrush.SelectionChanged += HandleSelectionChanged;
 
-			var none = TranslationProvider.GetString(None);
-			var searchResults = TranslationProvider.GetString(SearchResults);
-			var all = TranslationProvider.GetString(All);
-			var multiple = TranslationProvider.GetString(Multiple);
+			var none = FluentProvider.GetString(None);
+			var searchResults = FluentProvider.GetString(SearchResults);
+			var all = FluentProvider.GetString(All);
+			var multiple = FluentProvider.GetString(Multiple);
 
 			var categorySelector = widget.Get<DropDownButtonWidget>("CATEGORIES_DROPDOWN");
 			categorySelector.GetText = () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorSelectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorSelectionLogic.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class MapEditorSelectionLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string AreaSelection = "label-area-selection";
 
 		readonly EditorViewportControllerWidget editor;
@@ -151,7 +151,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var resourceValueInRegion = editorResourceLayer.CalculateRegionValue(selectedRegion);
 
 			var areaSelectionLabel =
-				$"{TranslationProvider.GetString(AreaSelection)} ({DimensionsAsString(selectionSize)}) " +
+				$"{FluentProvider.GetString(AreaSelection)} ({DimensionsAsString(selectionSize)}) " +
 				$"{PositionAsString(selectedRegion.TopLeft)} : {PositionAsString(selectedRegion.BottomRight)}";
 
 			AreaEditTitle.GetText = () => areaSelectionLabel;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapMarkerTilesLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapMarkerTilesLogic.cs
@@ -22,14 +22,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class MapMarkerTilesLogic : ChromeLogic
 	{
-		[TranslationReference]
-		const string MarkerMirrorModeNoneTranslation = "mirror-mode.none";
+		[FluentReference]
+		const string MarkerMirrorModeNone = "mirror-mode.none";
 
-		[TranslationReference]
-		const string MarkerMirrorModeFlipTranslation = "mirror-mode.flip";
+		[FluentReference]
+		const string MarkerMirrorModeFlip = "mirror-mode.flip";
 
-		[TranslationReference]
-		const string MarkerMirrorModeRotateTranslation = "mirror-mode.rotate";
+		[FluentReference]
+		const string MarkerMirrorModeRotate = "mirror-mode.rotate";
 
 		readonly EditorActionManager editorActionManager;
 		readonly MarkerLayerOverlay markerLayerTrait;
@@ -130,13 +130,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				switch (markerLayerTrait.MirrorMode)
 				{
 					case MarkerTileMirrorMode.None:
-						return TranslationProvider.GetString(MarkerMirrorModeNoneTranslation);
+						return FluentProvider.GetString(MarkerMirrorModeNone);
 					case MarkerTileMirrorMode.Flip:
-						return TranslationProvider.GetString(MarkerMirrorModeFlipTranslation);
+						return FluentProvider.GetString(MarkerMirrorModeFlip);
 					case MarkerTileMirrorMode.Rotate:
-						return TranslationProvider.GetString(MarkerMirrorModeRotateTranslation);
+						return FluentProvider.GetString(MarkerMirrorModeRotate);
 					default:
-						throw new ArgumentException($"Couldn't find translation for marker tile mirror mode '{markerLayerTrait.MirrorMode}'");
+						throw new ArgumentException($"Couldn't find fluent string for marker tile mirror mode '{markerLayerTrait.MirrorMode}'");
 				}
 			};
 
@@ -221,13 +221,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					switch (mode)
 					{
 						case MarkerTileMirrorMode.None:
-							return TranslationProvider.GetString(MarkerMirrorModeNoneTranslation);
+							return FluentProvider.GetString(MarkerMirrorModeNone);
 						case MarkerTileMirrorMode.Flip:
-							return TranslationProvider.GetString(MarkerMirrorModeFlipTranslation);
+							return FluentProvider.GetString(MarkerMirrorModeFlip);
 						case MarkerTileMirrorMode.Rotate:
-							return TranslationProvider.GetString(MarkerMirrorModeRotateTranslation);
+							return FluentProvider.GetString(MarkerMirrorModeRotate);
 						default:
-							throw new ArgumentException($"Couldn't find translation for marker tile mirror mode '{mode}'");
+							throw new ArgumentException($"Couldn't find fluent string for marker tile mirror mode '{mode}'");
 					}
 				};
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapToolsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapToolsLogic.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class MapToolsLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string MarkerTiles = "label-tool-marker-tiles";
 
 		enum MapTool
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			toolPanels.Add(MapTool.MarkerTiles, markerToolPanel);
 
 			toolsDropdown.OnMouseDown = _ => ShowToolsDropDown(toolsDropdown);
-			toolsDropdown.GetText = () => TranslationProvider.GetString(toolNames[selectedTool]);
+			toolsDropdown.GetText = () => FluentProvider.GetString(toolNames[selectedTool]);
 			toolsDropdown.Disabled = true; // TODO: Enable if new tools are added
 		}
 
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					() => selectedTool == tool,
 					() => SelectTool(tool));
 
-				item.Get<LabelWidget>("LABEL").GetText = () => TranslationProvider.GetString(toolNames[tool]);
+				item.Get<LabelWidget>("LABEL").GetText = () => FluentProvider.GetString(toolNames[tool]);
 
 				return item;
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -44,37 +44,37 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 		}
 
-		[TranslationReference]
+		[FluentReference]
 		const string SaveMapFailedTitle = "dialog-save-map-failed.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SaveMapFailedPrompt = "dialog-save-map-failed.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SaveMapFailedConfirm = "dialog-save-map-failed.confirm";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Unpacked = "label-unpacked-map";
 
-		[TranslationReference]
+		[FluentReference]
 		const string OverwriteMapFailedTitle = "dialog-overwrite-map-failed.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string OverwriteMapFailedPrompt = "dialog-overwrite-map-failed.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string OverwriteMapFailedConfirm = "dialog-overwrite-map-failed.confirm";
 
-		[TranslationReference]
+		[FluentReference]
 		const string OverwriteMapOutsideEditTitle = "dialog-overwrite-map-outside-edit.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string OverwriteMapOutsideEditPrompt = "dialog-overwrite-map-outside-edit.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SaveMapMapOutsideConfirm = "dialog-overwrite-map-outside-edit.confirm";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SaveCurrentMap = "notification-save-current-map";
 
 		[ObjectCreator.UseCtor]
@@ -171,7 +171,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var fileTypes = new Dictionary<MapFileType, MapFileTypeInfo>()
 			{
 				{ MapFileType.OraMap, new MapFileTypeInfo { Extension = ".oramap", UiLabel = ".oramap" } },
-				{ MapFileType.Unpacked, new MapFileTypeInfo { Extension = "", UiLabel = $"({TranslationProvider.GetString(Unpacked)})" } }
+				{ MapFileType.Unpacked, new MapFileTypeInfo { Extension = "", UiLabel = $"({FluentProvider.GetString(Unpacked)})" } }
 			};
 
 			var typeDropdown = widget.Get<DropDownButtonWidget>("TYPE_DROPDOWN");

--- a/OpenRA.Mods.Common/Widgets/Logic/EncyclopediaLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/EncyclopediaLogic.cs
@@ -116,7 +116,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var label = item.Get<LabelWithTooltipWidget>("TITLE");
 				var name = actor.TraitInfos<TooltipInfo>().FirstOrDefault(info => info.EnabledByDefault)?.Name;
 				if (!string.IsNullOrEmpty(name))
-					WidgetUtils.TruncateLabelToTooltip(label, TranslationProvider.GetString(name));
+					WidgetUtils.TruncateLabelToTooltip(label, FluentProvider.GetString(name));
 
 				if (firstItem == null)
 				{
@@ -159,7 +159,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var info = actor.TraitInfoOrDefault<EncyclopediaInfo>();
 			if (info != null && !string.IsNullOrEmpty(info.Description))
-				text += WidgetUtils.WrapText(TranslationProvider.GetString(info.Description) + "\n\n", descriptionLabel.Bounds.Width, descriptionFont);
+				text += WidgetUtils.WrapText(FluentProvider.GetString(info.Description) + "\n\n", descriptionLabel.Bounds.Width, descriptionFont);
 
 			var height = descriptionFont.Measure(text).Y;
 			descriptionLabel.GetText = () => text;
@@ -175,7 +175,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				var actorTooltip = actor.TraitInfos<TooltipInfo>().FirstOrDefault(info => info.EnabledByDefault);
 				if (actorTooltip != null)
-					return TranslationProvider.GetString(actorTooltip.Name);
+					return FluentProvider.GetString(actorTooltip.Name);
 			}
 
 			return name;

--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		const string OverwriteSavePrompt = "dialog-overwrite-save.prompt";
 
 		[FluentReference]
-		const string OverwriteSaveAccpet = "dialog-overwrite-save.confirm";
+		const string OverwriteSaveAccept = "dialog-overwrite-save.confirm";
 
 		readonly Widget panel;
 		readonly ScrollPanelWidget gameList;
@@ -173,7 +173,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ConfirmationDialogs.ButtonPrompt(modData,
 					title: DeleteSaveTitle,
 					text: DeleteSavePrompt,
-					textArguments: FluentBundle.Arguments("save", Path.GetFileNameWithoutExtension(selectedSave)),
+					textArguments: new object[] { "save", Path.GetFileNameWithoutExtension(selectedSave) },
 					onConfirm: () =>
 					{
 						Delete(selectedSave);
@@ -197,7 +197,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ConfirmationDialogs.ButtonPrompt(modData,
 					title: DeleteAllSavesTitle,
 					text: DeleteAllSavesPrompt,
-					textArguments: FluentBundle.Arguments("count", games.Count),
+					textArguments: new object[] { "count", games.Count },
 					onConfirm: () =>
 					{
 						foreach (var s in games.ToList())
@@ -293,7 +293,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 			catch (Exception ex)
 			{
-				TextNotificationsManager.Debug(FluentProvider.GetString(SaveDeletionFailed, FluentBundle.Arguments("savePath", savePath)));
+				TextNotificationsManager.Debug(FluentProvider.GetString(SaveDeletionFailed, "savePath", savePath));
 				Log.Write("debug", ex.ToString());
 				return;
 			}
@@ -373,9 +373,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ConfirmationDialogs.ButtonPrompt(modData,
 					title: OverwriteSaveTitle,
 					text: OverwriteSavePrompt,
-					textArguments: FluentBundle.Arguments("file", saveTextField.Text),
+					textArguments: new object[] { "file", saveTextField.Text },
 					onConfirm: Inner,
-					confirmText: OverwriteSaveAccpet,
+					confirmText: OverwriteSaveAccept,
 					onCancel: () => { });
 			}
 			else

--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -21,43 +21,43 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class GameSaveBrowserLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string RenameSaveTitle = "dialog-rename-save.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string RenameSavePrompt = "dialog-rename-save.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string RenameSaveAccept = "dialog-rename-save.confirm";
 
-		[TranslationReference]
+		[FluentReference]
 		const string DeleteSaveTitle = "dialog-delete-save.title";
 
-		[TranslationReference("save")]
+		[FluentReference("save")]
 		const string DeleteSavePrompt = "dialog-delete-save.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string DeleteSaveAccept = "dialog-delete-save.confirm";
 
-		[TranslationReference]
+		[FluentReference]
 		const string DeleteAllSavesTitle = "dialog-delete-all-saves.title";
 
-		[TranslationReference("count")]
+		[FluentReference("count")]
 		const string DeleteAllSavesPrompt = "dialog-delete-all-saves.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string DeleteAllSavesAccept = "dialog-delete-all-saves.confirm";
 
-		[TranslationReference("savePath")]
+		[FluentReference("savePath")]
 		const string SaveDeletionFailed = "notification-save-deletion-failed";
 
-		[TranslationReference]
+		[FluentReference]
 		const string OverwriteSaveTitle = "dialog-overwrite-save.title";
 
-		[TranslationReference("file")]
+		[FluentReference("file")]
 		const string OverwriteSavePrompt = "dialog-overwrite-save.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string OverwriteSaveAccpet = "dialog-overwrite-save.confirm";
 
 		readonly Widget panel;
@@ -173,7 +173,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ConfirmationDialogs.ButtonPrompt(modData,
 					title: DeleteSaveTitle,
 					text: DeleteSavePrompt,
-					textArguments: Translation.Arguments("save", Path.GetFileNameWithoutExtension(selectedSave)),
+					textArguments: FluentBundle.Arguments("save", Path.GetFileNameWithoutExtension(selectedSave)),
 					onConfirm: () =>
 					{
 						Delete(selectedSave);
@@ -197,7 +197,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ConfirmationDialogs.ButtonPrompt(modData,
 					title: DeleteAllSavesTitle,
 					text: DeleteAllSavesPrompt,
-					textArguments: Translation.Arguments("count", games.Count),
+					textArguments: FluentBundle.Arguments("count", games.Count),
 					onConfirm: () =>
 					{
 						foreach (var s in games.ToList())
@@ -293,7 +293,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 			catch (Exception ex)
 			{
-				TextNotificationsManager.Debug(TranslationProvider.GetString(SaveDeletionFailed, Translation.Arguments("savePath", savePath)));
+				TextNotificationsManager.Debug(FluentProvider.GetString(SaveDeletionFailed, FluentBundle.Arguments("savePath", savePath)));
 				Log.Write("debug", ex.ToString());
 				return;
 			}
@@ -373,7 +373,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ConfirmationDialogs.ButtonPrompt(modData,
 					title: OverwriteSaveTitle,
 					text: OverwriteSavePrompt,
-					textArguments: Translation.Arguments("file", saveTextField.Text),
+					textArguments: FluentBundle.Arguments("file", saveTextField.Text),
 					onConfirm: Inner,
 					confirmText: OverwriteSaveAccpet,
 					onCancel: () => { });

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ArmyTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ArmyTooltipLogic.cs
@@ -38,13 +38,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return;
 
 				var tooltip = armyUnit.TooltipInfo;
-				var name = tooltip != null ? TranslationProvider.GetString(tooltip.Name) : armyUnit.ActorInfo.Name;
+				var name = tooltip != null ? FluentProvider.GetString(tooltip.Name) : armyUnit.ActorInfo.Name;
 				var buildable = armyUnit.BuildableInfo;
 
 				nameLabel.GetText = () => name;
 				var nameSize = font.Measure(name);
 
-				var desc = string.IsNullOrEmpty(buildable.Description) ? "" : TranslationProvider.GetString(buildable.Description);
+				var desc = string.IsNullOrEmpty(buildable.Description) ? "" : FluentProvider.GetString(buildable.Description);
 				descLabel.GetText = () => desc;
 				var descSize = descFont.Measure(desc);
 				descLabel.Bounds.Width = descSize.X;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -22,19 +22,19 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 	sealed class GameInfoLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string Objectives = "menu-game-info.objectives";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Briefing = "menu-game-info.briefing";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Options = "menu-game-info.options";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Debug = "menu-game-info.debug";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Chat = "menu-game-info.chat";
 
 		readonly World world;
@@ -108,7 +108,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				if (tabButton != null)
 				{
-					var tabButtonText = TranslationProvider.GetString(label);
+					var tabButtonText = FluentProvider.GetString(label);
 					tabButton.GetText = () => tabButtonText;
 					tabButton.OnClick = () =>
 					{

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoObjectivesLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoObjectivesLogic.cs
@@ -18,13 +18,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	sealed class GameInfoObjectivesLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string InProgress = "label-mission-in-progress";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Accomplished = "label-mission-accomplished";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Failed = "label-mission-failed";
 
 		readonly ContainerWidget template;
@@ -51,9 +51,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var missionStatus = widget.Get<LabelWidget>("MISSION_STATUS");
-			var inProgress = TranslationProvider.GetString(InProgress);
-			var accomplished = TranslationProvider.GetString(Accomplished);
-			var failed = TranslationProvider.GetString(Failed);
+			var inProgress = FluentProvider.GetString(InProgress);
+			var accomplished = FluentProvider.GetString(Accomplished);
+			var failed = FluentProvider.GetString(Failed);
 			missionStatus.GetText = () => player.WinState == WinState.Undefined ? inProgress :
 				player.WinState == WinState.Won ? accomplished : failed;
 			missionStatus.GetColor = () => player.WinState == WinState.Undefined ? Color.White :

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -160,8 +160,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						ConfirmationDialogs.ButtonPrompt(modData,
 							title: VoteKickTitle,
 							text: botsCount > 0 ? VoteKickPromptBreakBots : VoteKickPrompt,
-							titleArguments: FluentBundle.Arguments("player", client.Name),
-							textArguments: FluentBundle.Arguments("bots", botsCount),
+							titleArguments: new object[] { "player", client.Name },
+							textArguments: new object[] { "bots", botsCount },
 							onConfirm: () =>
 							{
 								orderManager.IssueOrder(Order.Command($"vote_kick {client.Index} {true}"));
@@ -176,8 +176,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					ConfirmationDialogs.ButtonPrompt(modData,
 						title: VoteKickTitle,
 						text: botsCount > 0 ? VoteKickPromptBreakBots : VoteKickPrompt,
-						titleArguments: FluentBundle.Arguments("player", client.Name),
-						textArguments: FluentBundle.Arguments("bots", botsCount),
+						titleArguments: new object[] { "player", client.Name },
+						textArguments: new object[] { "bots", botsCount },
 						onConfirm: () =>
 						{
 							orderManager.IssueOrder(Order.Command($"vote_kick {client.Index} {true}"));
@@ -201,7 +201,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					ConfirmationDialogs.ButtonPrompt(modData,
 						title: KickTitle,
 						text: KickPrompt,
-						titleArguments: FluentBundle.Arguments("player", client.Name),
+						titleArguments: new object[] { "player", client.Name },
 						onConfirm: () =>
 						{
 							orderManager.IssueOrder(Order.Command($"kick {client.Index} {false}"));
@@ -227,7 +227,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					var teamHeader = ScrollItemWidget.Setup(teamTemplate, () => false, () => { });
 					var team = t.Key > 0
-						? FluentProvider.GetString(TeamNumber, FluentBundle.Arguments("team", t.Key))
+						? FluentProvider.GetString(TeamNumber, "team", t.Key)
 						: FluentProvider.GetString(NoTeam);
 					teamHeader.Get<LabelWidget>("TEAM").GetText = () => team;
 					var teamRating = teamHeader.Get<LabelWidget>("TEAM_SCORE");

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -23,67 +23,67 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	sealed class GameInfoStatsLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string Unmute = "label-unmute-player";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Mute = "label-mute-player";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Accomplished = "label-mission-accomplished";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Failed = "label-mission-failed";
 
-		[TranslationReference]
+		[FluentReference]
 		const string InProgress = "label-mission-in-progress";
 
-		[TranslationReference("team")]
+		[FluentReference("team")]
 		const string TeamNumber = "label-team-name";
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoTeam = "label-no-team";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Spectators = "label-spectators";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Gone = "label-client-state-disconnected";
 
-		[TranslationReference]
+		[FluentReference]
 		const string KickTooltip = "button-kick-player";
 
-		[TranslationReference("player")]
+		[FluentReference("player")]
 		const string KickTitle = "dialog-kick.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string KickPrompt = "dialog-kick.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string KickAccept = "dialog-kick.confirm";
 
-		[TranslationReference]
+		[FluentReference]
 		const string KickVoteTooltip = "button-vote-kick-player";
 
-		[TranslationReference("player")]
+		[FluentReference("player")]
 		const string VoteKickTitle = "dialog-vote-kick.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string VoteKickPrompt = "dialog-vote-kick.prompt";
 
-		[TranslationReference("bots")]
+		[FluentReference("bots")]
 		const string VoteKickPromptBreakBots = "dialog-vote-kick.prompt-break-bots";
 
-		[TranslationReference]
+		[FluentReference]
 		const string VoteKickVoteStart = "dialog-vote-kick.vote-start";
 
-		[TranslationReference]
+		[FluentReference]
 		const string VoteKickVoteFor = "dialog-vote-kick.vote-for";
 
-		[TranslationReference]
+		[FluentReference]
 		const string VoteKickVoteAgainst = "dialog-vote-kick.vote-against";
 
-		[TranslationReference]
+		[FluentReference]
 		const string VoteKickVoteCancel = "dialog-vote-kick.vote-cancel";
 
 		[ObjectCreator.UseCtor]
@@ -108,9 +108,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					checkbox.GetText = () => mo.Objectives[0].Description;
 				}
 
-				var failed = TranslationProvider.GetString(Failed);
-				var inProgress = TranslationProvider.GetString(InProgress);
-				var accomplished = TranslationProvider.GetString(Accomplished);
+				var failed = FluentProvider.GetString(Failed);
+				var inProgress = FluentProvider.GetString(InProgress);
+				var accomplished = FluentProvider.GetString(Accomplished);
 				statusLabel.GetText = () => player.WinState == WinState.Won ? accomplished :
 					player.WinState == WinState.Lost ? failed : inProgress;
 				statusLabel.GetColor = () => player.WinState == WinState.Won ? Color.LimeGreen :
@@ -133,10 +133,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var teamTemplate = playerPanel.Get<ScrollItemWidget>("TEAM_TEMPLATE");
 			var playerTemplate = playerPanel.Get("PLAYER_TEMPLATE");
 			var spectatorTemplate = playerPanel.Get("SPECTATOR_TEMPLATE");
-			var unmuteTooltip = TranslationProvider.GetString(Unmute);
-			var muteTooltip = TranslationProvider.GetString(Mute);
-			var kickTooltip = TranslationProvider.GetString(KickTooltip);
-			var voteKickTooltip = TranslationProvider.GetString(KickVoteTooltip);
+			var unmuteTooltip = FluentProvider.GetString(Unmute);
+			var muteTooltip = FluentProvider.GetString(Mute);
+			var kickTooltip = FluentProvider.GetString(KickTooltip);
+			var voteKickTooltip = FluentProvider.GetString(KickVoteTooltip);
 			playerPanel.RemoveChildren();
 
 			var teams = world.Players.Where(p => !p.NonCombatant && p.Playable)
@@ -160,8 +160,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						ConfirmationDialogs.ButtonPrompt(modData,
 							title: VoteKickTitle,
 							text: botsCount > 0 ? VoteKickPromptBreakBots : VoteKickPrompt,
-							titleArguments: Translation.Arguments("player", client.Name),
-							textArguments: Translation.Arguments("bots", botsCount),
+							titleArguments: FluentBundle.Arguments("player", client.Name),
+							textArguments: FluentBundle.Arguments("bots", botsCount),
 							onConfirm: () =>
 							{
 								orderManager.IssueOrder(Order.Command($"vote_kick {client.Index} {true}"));
@@ -176,8 +176,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					ConfirmationDialogs.ButtonPrompt(modData,
 						title: VoteKickTitle,
 						text: botsCount > 0 ? VoteKickPromptBreakBots : VoteKickPrompt,
-						titleArguments: Translation.Arguments("player", client.Name),
-						textArguments: Translation.Arguments("bots", botsCount),
+						titleArguments: FluentBundle.Arguments("player", client.Name),
+						textArguments: FluentBundle.Arguments("bots", botsCount),
 						onConfirm: () =>
 						{
 							orderManager.IssueOrder(Order.Command($"vote_kick {client.Index} {true}"));
@@ -201,7 +201,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					ConfirmationDialogs.ButtonPrompt(modData,
 						title: KickTitle,
 						text: KickPrompt,
-						titleArguments: Translation.Arguments("player", client.Name),
+						titleArguments: FluentBundle.Arguments("player", client.Name),
 						onConfirm: () =>
 						{
 							orderManager.IssueOrder(Order.Command($"kick {client.Index} {false}"));
@@ -227,8 +227,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					var teamHeader = ScrollItemWidget.Setup(teamTemplate, () => false, () => { });
 					var team = t.Key > 0
-						? TranslationProvider.GetString(TeamNumber, Translation.Arguments("team", t.Key))
-						: TranslationProvider.GetString(NoTeam);
+						? FluentProvider.GetString(TeamNumber, FluentBundle.Arguments("team", t.Key))
+						: FluentProvider.GetString(NoTeam);
 					teamHeader.Get<LabelWidget>("TEAM").GetText = () => team;
 					var teamRating = teamHeader.Get<LabelWidget>("TEAM_SCORE");
 					var scoreCache = new CachedTransform<int, string>(s => s.ToString(NumberFormatInfo.CurrentInfo));
@@ -257,13 +257,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						flag.GetImageName = () => pp.Faction.InternalName;
 						factionName = pp.Faction.Name != factionName
-							? $"{TranslationProvider.GetString(factionName)} ({TranslationProvider.GetString(pp.Faction.Name)})"
-							: TranslationProvider.GetString(pp.Faction.Name);
+							? $"{FluentProvider.GetString(factionName)} ({FluentProvider.GetString(pp.Faction.Name)})"
+							: FluentProvider.GetString(pp.Faction.Name);
 					}
 					else
 					{
 						flag.GetImageName = () => pp.DisplayFaction.InternalName;
-						factionName = TranslationProvider.GetString(factionName);
+						factionName = FluentProvider.GetString(factionName);
 					}
 
 					WidgetUtils.TruncateLabelToTooltip(item.Get<LabelWithTooltipWidget>("FACTION"), factionName);
@@ -291,7 +291,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (spectators.Count > 0)
 			{
 				var spectatorHeader = ScrollItemWidget.Setup(teamTemplate, () => false, () => { });
-				var spectatorTeam = TranslationProvider.GetString(Spectators);
+				var spectatorTeam = FluentProvider.GetString(Spectators);
 				spectatorHeader.Get<LabelWidget>("TEAM").GetText = () => spectatorTeam;
 
 				playerPanel.AddChild(spectatorHeader);
@@ -310,7 +310,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					nameLabel.GetText = () =>
 					{
-						var suffix = client.State == Session.ClientState.Disconnected ? $" ({TranslationProvider.GetString(Gone)})" : "";
+						var suffix = client.State == Session.ClientState.Disconnected ? $" ({FluentProvider.GetString(Gone)})" : "";
 						return name.Update((client.Name, suffix));
 					};
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameTimerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameTimerLogic.cs
@@ -19,16 +19,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class GameTimerLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string Paused = "label-paused";
 
-		[TranslationReference]
+		[FluentReference]
 		const string MaxSpeed = "label-max-speed";
 
-		[TranslationReference("percentage")]
+		[FluentReference("percentage")]
 		const string Speed = "label-replay-speed";
 
-		[TranslationReference("percentage")]
+		[FluentReference("percentage")]
 		const string Complete = "label-replay-complete";
 
 		[ObjectCreator.UseCtor]
@@ -44,10 +44,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			bool Paused() => world.Paused || world.ReplayTimestep == 0;
 
-			var pausedText = TranslationProvider.GetString(GameTimerLogic.Paused);
-			var maxSpeedText = TranslationProvider.GetString(MaxSpeed);
+			var pausedText = FluentProvider.GetString(GameTimerLogic.Paused);
+			var maxSpeedText = FluentProvider.GetString(MaxSpeed);
 			var speedText = new CachedTransform<int, string>(p =>
-					TranslationProvider.GetString(Speed, Translation.Arguments("percentage", p)));
+					FluentProvider.GetString(Speed, FluentBundle.Arguments("percentage", p)));
 
 			if (timer != null)
 			{
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var timerText = new CachedTransform<int, string>(p =>
-				TranslationProvider.GetString(Complete, Translation.Arguments("percentage", p)));
+				FluentProvider.GetString(Complete, FluentBundle.Arguments("percentage", p)));
 			if (timer is LabelWithTooltipWidget timerTooltip)
 			{
 				var connection = orderManager.Connection as ReplayConnection;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameTimerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameTimerLogic.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var pausedText = FluentProvider.GetString(GameTimerLogic.Paused);
 			var maxSpeedText = FluentProvider.GetString(MaxSpeed);
 			var speedText = new CachedTransform<int, string>(p =>
-					FluentProvider.GetString(Speed, FluentBundle.Arguments("percentage", p)));
+					FluentProvider.GetString(Speed, "percentage", p));
 
 			if (timer != null)
 			{
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var timerText = new CachedTransform<int, string>(p =>
-				FluentProvider.GetString(Complete, FluentBundle.Arguments("percentage", p)));
+				FluentProvider.GetString(Complete, "percentage", p));
 			if (timer is LabelWithTooltipWidget timerTooltip)
 			{
 				var connection = orderManager.Connection as ReplayConnection;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/SelectAllUnitsHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/SelectAllUnitsHotkeyLogic.cs
@@ -27,10 +27,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 
 		public readonly string ClickSound = ChromeMetrics.Get<string>("ClickSound");
 
-		[TranslationReference("units")]
+		[FluentReference("units")]
 		const string SelectedUnitsAcrossScreen = "selected-units-across-screen";
 
-		[TranslationReference("units")]
+		[FluentReference("units")]
 		const string SelectedUnitsAcrossMap = "selected-units-across-map";
 
 		[ObjectCreator.UseCtor]
@@ -54,12 +54,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 
 			// Check if selecting actors on the screen has selected new units
 			if (newSelection.Count > selection.Actors.Count)
-				TextNotificationsManager.AddFeedbackLine(SelectedUnitsAcrossScreen, Translation.Arguments("units", newSelection.Count));
+				TextNotificationsManager.AddFeedbackLine(SelectedUnitsAcrossScreen, FluentBundle.Arguments("units", newSelection.Count));
 			else
 			{
 				// Select actors in the world that have highest selection priority
 				newSelection = SelectionUtils.SelectActorsInWorld(world, null, eligiblePlayers).SubsetWithHighestSelectionPriority(e.Modifiers).ToList();
-				TextNotificationsManager.AddFeedbackLine(SelectedUnitsAcrossMap, Translation.Arguments("units", newSelection.Count));
+				TextNotificationsManager.AddFeedbackLine(SelectedUnitsAcrossMap, FluentBundle.Arguments("units", newSelection.Count));
 			}
 
 			selection.Combine(world, newSelection, false, false);

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/SelectAllUnitsHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/SelectAllUnitsHotkeyLogic.cs
@@ -54,12 +54,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 
 			// Check if selecting actors on the screen has selected new units
 			if (newSelection.Count > selection.Actors.Count)
-				TextNotificationsManager.AddFeedbackLine(SelectedUnitsAcrossScreen, FluentBundle.Arguments("units", newSelection.Count));
+				TextNotificationsManager.AddFeedbackLine(SelectedUnitsAcrossScreen, "units", newSelection.Count);
 			else
 			{
 				// Select actors in the world that have highest selection priority
 				newSelection = SelectionUtils.SelectActorsInWorld(world, null, eligiblePlayers).SubsetWithHighestSelectionPriority(e.Modifiers).ToList();
-				TextNotificationsManager.AddFeedbackLine(SelectedUnitsAcrossMap, FluentBundle.Arguments("units", newSelection.Count));
+				TextNotificationsManager.AddFeedbackLine(SelectedUnitsAcrossMap, "units", newSelection.Count);
 			}
 
 			selection.Combine(world, newSelection, false, false);

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/SelectUnitsByTypeHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/SelectUnitsByTypeHotkeyLogic.cs
@@ -79,12 +79,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 
 			// Check if selecting actors on the screen has selected new units
 			if (newSelection.Count > selection.Actors.Count)
-				TextNotificationsManager.AddFeedbackLine(SelectedUnitsAcrossScreen, FluentBundle.Arguments("units", newSelection.Count));
+				TextNotificationsManager.AddFeedbackLine(SelectedUnitsAcrossScreen, "units", newSelection.Count);
 			else
 			{
 				// Select actors in the world that have the same selection class as one of the already selected actors
 				newSelection = SelectionUtils.SelectActorsInWorld(world, selectedClasses, eligiblePlayers).ToList();
-				TextNotificationsManager.AddFeedbackLine(SelectedUnitsAcrossMap, FluentBundle.Arguments("units", newSelection.Count));
+				TextNotificationsManager.AddFeedbackLine(SelectedUnitsAcrossMap, "units", newSelection.Count);
 			}
 
 			selection.Combine(world, newSelection, true, false);

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/SelectUnitsByTypeHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/SelectUnitsByTypeHotkeyLogic.cs
@@ -29,13 +29,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 		public readonly string ClickSound = ChromeMetrics.Get<string>("ClickSound");
 		public readonly string ClickDisabledSound = ChromeMetrics.Get<string>("ClickDisabledSound");
 
-		[TranslationReference]
+		[FluentReference]
 		const string NothingSelected = "nothing-selected";
 
-		[TranslationReference("units")]
+		[FluentReference("units")]
 		const string SelectedUnitsAcrossScreen = "selected-units-across-screen";
 
-		[TranslationReference("units")]
+		[FluentReference("units")]
 		const string SelectedUnitsAcrossMap = "selected-units-across-map";
 
 		[ObjectCreator.UseCtor]
@@ -79,12 +79,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 
 			// Check if selecting actors on the screen has selected new units
 			if (newSelection.Count > selection.Actors.Count)
-				TextNotificationsManager.AddFeedbackLine(SelectedUnitsAcrossScreen, Translation.Arguments("units", newSelection.Count));
+				TextNotificationsManager.AddFeedbackLine(SelectedUnitsAcrossScreen, FluentBundle.Arguments("units", newSelection.Count));
 			else
 			{
 				// Select actors in the world that have the same selection class as one of the already selected actors
 				newSelection = SelectionUtils.SelectActorsInWorld(world, selectedClasses, eligiblePlayers).ToList();
-				TextNotificationsManager.AddFeedbackLine(SelectedUnitsAcrossMap, Translation.Arguments("units", newSelection.Count));
+				TextNotificationsManager.AddFeedbackLine(SelectedUnitsAcrossMap, FluentBundle.Arguments("units", newSelection.Count));
 			}
 
 			selection.Combine(world, newSelection, true, false);

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class IngameCashCounterLogic : ChromeLogic
 	{
-		[TranslationReference("usage", "capacity")]
+		[FluentReference("usage", "capacity")]
 		const string SiloUsage = "label-silo-usage";
 
 		const float DisplayFracPerFrame = .07f;
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			displayResources = playerResources.GetCashAndResources();
 
 			siloUsageTooltipCache = new CachedTransform<(int Resources, int Capacity), string>(x =>
-				TranslationProvider.GetString(SiloUsage, Translation.Arguments("usage", x.Resources, "capacity", x.Capacity)));
+				FluentProvider.GetString(SiloUsage, FluentBundle.Arguments("usage", x.Resources, "capacity", x.Capacity)));
 			cashLabel = widget.Get<LabelWithTooltipWidget>("CASH");
 			cashLabel.GetTooltipText = () => siloUsageTooltip;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			displayResources = playerResources.GetCashAndResources();
 
 			siloUsageTooltipCache = new CachedTransform<(int Resources, int Capacity), string>(x =>
-				FluentProvider.GetString(SiloUsage, FluentBundle.Arguments("usage", x.Resources, "capacity", x.Capacity)));
+				FluentProvider.GetString(SiloUsage, "usage", x.Resources, "capacity", x.Capacity));
 			cashLabel = widget.Get<LabelWithTooltipWidget>("CASH");
 			cashLabel.GetTooltipText = () => siloUsageTooltip;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -194,7 +194,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return true;
 			};
 
-			chatAvailableIn = new CachedTransform<int, string>(x => FluentProvider.GetString(ChatAvailability, FluentBundle.Arguments("seconds", x)));
+			chatAvailableIn = new CachedTransform<int, string>(x => FluentProvider.GetString(ChatAvailability, "seconds", x));
 
 			if (!isMenuChat)
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -23,16 +23,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	[ChromeLogicArgsHotkeys("OpenTeamChat", "OpenGeneralChat")]
 	public class IngameChatLogic : ChromeLogic, INotificationHandler<TextNotification>
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string TeamChat = "button-team-chat";
 
-		[TranslationReference]
+		[FluentReference]
 		const string GeneralChat = "button-general-chat";
 
-		[TranslationReference("seconds")]
+		[FluentReference("seconds")]
 		const string ChatAvailability = "label-chat-availability";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ChatDisabled = "label-chat-disabled";
 
 		readonly Ruleset modRules;
@@ -70,10 +70,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var disableTeamChat = alwaysDisabled || (world.LocalPlayer != null && !players.Any(p => p.IsAlliedWith(world.LocalPlayer)));
 			var teamChat = !disableTeamChat;
 
-			var teamMessage = TranslationProvider.GetString(TeamChat);
-			var allMessage = TranslationProvider.GetString(GeneralChat);
+			var teamMessage = FluentProvider.GetString(TeamChat);
+			var allMessage = FluentProvider.GetString(GeneralChat);
 
-			chatDisabled = TranslationProvider.GetString(ChatDisabled);
+			chatDisabled = FluentProvider.GetString(ChatDisabled);
 
 			// Only execute this once, the first time this widget is loaded
 			if (TextNotificationsManager.MutedPlayers.Count == 0)
@@ -194,7 +194,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return true;
 			};
 
-			chatAvailableIn = new CachedTransform<int, string>(x => TranslationProvider.GetString(ChatAvailability, Translation.Arguments("seconds", x)));
+			chatAvailableIn = new CachedTransform<int, string>(x => FluentProvider.GetString(ChatAvailability, FluentBundle.Arguments("seconds", x)));
 
 			if (!isMenuChat)
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -497,7 +497,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					ConfirmationDialogs.ButtonPrompt(modData,
 						title: ErrorMaxPlayerTitle,
 						text: ErrorMaxPlayerPrompt,
-						textArguments: FluentBundle.Arguments("players", playerCount, "max", MapPlayers.MaximumPlayerCount),
+						textArguments: new object[] { "players", playerCount, "max", MapPlayers.MaximumPlayerCount },
 						onConfirm: ShowMenu,
 						confirmText: ErrorMaxPlayerAccept);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -21,121 +21,121 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class IngameMenuLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string Leave = "menu-ingame.leave";
 
-		[TranslationReference]
+		[FluentReference]
 		const string AbortMission = "menu-ingame.abort";
 
-		[TranslationReference]
+		[FluentReference]
 		const string LeaveMissionTitle = "dialog-leave-mission.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string LeaveMissionPrompt = "dialog-leave-mission.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string LeaveMissionAccept = "dialog-leave-mission.confirm";
 
-		[TranslationReference]
+		[FluentReference]
 		const string LeaveMissionCancel = "dialog-leave-mission.cancel";
 
-		[TranslationReference]
+		[FluentReference]
 		const string RestartButton = "menu-ingame.restart";
 
-		[TranslationReference]
+		[FluentReference]
 		const string RestartMissionTitle = "dialog-restart-mission.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string RestartMissionPrompt = "dialog-restart-mission.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string RestartMissionAccept = "dialog-restart-mission.confirm";
 
-		[TranslationReference]
+		[FluentReference]
 		const string RestartMissionCancel = "dialog-restart-mission.cancel";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SurrenderButton = "menu-ingame.surrender";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SurrenderTitle = "dialog-surrender.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SurrenderPrompt = "dialog-surrender.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SurrenderAccept = "dialog-surrender.confirm";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SurrenderCancel = "dialog-surrender.cancel";
 
-		[TranslationReference]
+		[FluentReference]
 		const string LoadGameButton = "menu-ingame.load-game";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SaveGameButton = "menu-ingame.save-game";
 
-		[TranslationReference]
+		[FluentReference]
 		const string MusicButton = "menu-ingame.music";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SettingsButton = "menu-ingame.settings";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ReturnToMap = "menu-ingame.return-to-map";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Resume = "menu-ingame.resume";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SaveMapButton = "menu-ingame.save-map";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ErrorMaxPlayerTitle = "dialog-error-max-player.title";
 
-		[TranslationReference("players", "max")]
+		[FluentReference("players", "max")]
 		const string ErrorMaxPlayerPrompt = "dialog-error-max-player.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ErrorMaxPlayerAccept = "dialog-error-max-player.confirm";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ExitMapButton = "menu-ingame.exit-map";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ExitMapEditorTitle = "dialog-exit-map-editor.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ExitMapEditorPromptUnsaved = "dialog-exit-map-editor.prompt-unsaved";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ExitMapEditorPromptDeleted = "dialog-exit-map-editor.prompt-deleted";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ExitMapEditorAnywayConfirm = "dialog-exit-map-editor.confirm-anyway";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ExitMapEditorConfirm = "dialog-exit-map-editor.confirm";
 
-		[TranslationReference]
+		[FluentReference]
 		const string PlayMapWarningTitle = "dialog-play-map-warning.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string PlayMapWarningPrompt = "dialog-play-map-warning.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string PlayMapWarningCancel = "dialog-play-map-warning.cancel";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ExitToMapEditorTitle = "dialog-exit-to-map-editor.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ExitToMapEditorPrompt = "dialog-exit-to-map-editor.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ExitToMapEditorConfirm = "dialog-exit-to-map-editor.confirm";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ExitToMapEditorCancel = "dialog-exit-to-map-editor.cancel";
 
 		readonly Widget menu;
@@ -296,7 +296,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Ui.ResetTooltips();
 		}
 
-		ButtonWidget AddButton(string id, string text)
+		ButtonWidget AddButton(string id, string label)
 		{
 			var button = buttonTemplate.Clone() as ButtonWidget;
 			var lastButton = buttons.LastOrDefault();
@@ -308,8 +308,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			button.Id = id;
 			button.IsDisabled = () => leaving;
-			var translation = TranslationProvider.GetString(text);
-			button.GetText = () => translation;
+			var text = FluentProvider.GetString(label);
+			button.GetText = () => text;
 			buttonContainer.AddChild(button);
 			buttons.Add(button);
 
@@ -322,8 +322,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return;
 
 			var button = AddButton("ABORT_MISSION", world.IsGameOver
-				? TranslationProvider.GetString(Leave)
-				: TranslationProvider.GetString(AbortMission));
+				? FluentProvider.GetString(Leave)
+				: FluentProvider.GetString(AbortMission));
 
 			button.OnClick = () =>
 			{
@@ -497,7 +497,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					ConfirmationDialogs.ButtonPrompt(modData,
 						title: ErrorMaxPlayerTitle,
 						text: ErrorMaxPlayerPrompt,
-						textArguments: Translation.Arguments("players", playerCount, "max", MapPlayers.MaximumPlayerCount),
+						textArguments: FluentBundle.Arguments("players", playerCount, "max", MapPlayers.MaximumPlayerCount),
 						onConfirm: ShowMenu,
 						confirmText: ErrorMaxPlayerAccept);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerBarLogic.cs
@@ -18,10 +18,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class IngamePowerBarLogic : ChromeLogic
 	{
-		[TranslationReference("usage", "capacity")]
+		[FluentReference("usage", "capacity")]
 		const string PowerUsage = "label-power-usage";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Infinite = "label-infinite-power";
 
 		[ObjectCreator.UseCtor]
@@ -36,12 +36,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			powerBar.TooltipTextCached = new CachedTransform<(float Current, float Capacity), string>(usage =>
 			{
 				var capacity = developerMode.UnlimitedPower ?
-					TranslationProvider.GetString(Infinite) :
+					FluentProvider.GetString(Infinite) :
 					powerManager.PowerProvided.ToString(NumberFormatInfo.CurrentInfo);
 
-				return TranslationProvider.GetString(
+				return FluentProvider.GetString(
 					PowerUsage,
-					Translation.Arguments("usage", usage.Current, "capacity", capacity));
+					FluentBundle.Arguments("usage", usage.Current, "capacity", capacity));
 			});
 
 			powerBar.GetBarColor = () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerBarLogic.cs
@@ -39,9 +39,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					FluentProvider.GetString(Infinite) :
 					powerManager.PowerProvided.ToString(NumberFormatInfo.CurrentInfo);
 
-				return FluentProvider.GetString(
-					PowerUsage,
-					FluentBundle.Arguments("usage", usage.Current, "capacity", capacity));
+				return FluentProvider.GetString(PowerUsage, "usage", usage.Current, "capacity", capacity);
 			});
 
 			powerBar.GetBarColor = () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerCounterLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerCounterLogic.cs
@@ -18,10 +18,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class IngamePowerCounterLogic : ChromeLogic
 	{
-		[TranslationReference("usage", "capacity")]
+		[FluentReference("usage", "capacity")]
 		const string PowerUsage = "label-power-usage";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Infinite = "label-infinite-power";
 
 		[ObjectCreator.UseCtor]
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var powerManager = world.LocalPlayer.PlayerActor.Trait<PowerManager>();
 			var power = widget.Get<LabelWithTooltipWidget>("POWER");
 			var powerIcon = widget.Get<ImageWidget>("POWER_ICON");
-			var unlimitedCapacity = TranslationProvider.GetString(Infinite);
+			var unlimitedCapacity = FluentProvider.GetString(Infinite);
 
 			powerIcon.GetImageName = () => powerManager.ExcessPower < 0 ? "power-critical" : "power-normal";
 			power.GetColor = () => powerManager.ExcessPower < 0 ? Color.Red : Color.White;
@@ -41,9 +41,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var tooltipTextCached = new CachedTransform<(int, int?), string>(((int Usage, int? Capacity) args) =>
 			{
 				var capacity = args.Capacity == null ? unlimitedCapacity : args.Capacity.Value.ToString(NumberFormatInfo.CurrentInfo);
-				return TranslationProvider.GetString(
+				return FluentProvider.GetString(
 					PowerUsage,
-					Translation.Arguments(
+					FluentBundle.Arguments(
 						"usage", args.Usage.ToString(NumberFormatInfo.CurrentInfo),
 						"capacity", capacity));
 			});

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerCounterLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerCounterLogic.cs
@@ -41,11 +41,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var tooltipTextCached = new CachedTransform<(int, int?), string>(((int Usage, int? Capacity) args) =>
 			{
 				var capacity = args.Capacity == null ? unlimitedCapacity : args.Capacity.Value.ToString(NumberFormatInfo.CurrentInfo);
-				return FluentProvider.GetString(
-					PowerUsage,
-					FluentBundle.Arguments(
-						"usage", args.Usage.ToString(NumberFormatInfo.CurrentInfo),
-						"capacity", capacity));
+				return FluentProvider.GetString(PowerUsage,
+					"usage", args.Usage.ToString(NumberFormatInfo.CurrentInfo),
+					"capacity", capacity);
 			});
 
 			power.GetTooltipText = () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameSiloBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameSiloBarLogic.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class IngameSiloBarLogic : ChromeLogic
 	{
-		[TranslationReference("usage", "capacity")]
+		[FluentReference("usage", "capacity")]
 		const string SiloUsage = "label-silo-usage";
 
 		[ObjectCreator.UseCtor]
@@ -30,9 +30,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			siloBar.GetUsed = () => playerResources.Resources;
 			siloBar.TooltipTextCached = new CachedTransform<(float Current, float Capacity), string>(usage =>
 			{
-				return TranslationProvider.GetString(
+				return FluentProvider.GetString(
 					SiloUsage,
-					Translation.Arguments("usage", usage.Current, "capacity", usage.Capacity));
+					FluentBundle.Arguments("usage", usage.Current, "capacity", usage.Capacity));
 			});
 			siloBar.GetBarColor = () =>
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameSiloBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameSiloBarLogic.cs
@@ -28,12 +28,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			siloBar.GetProvided = () => playerResources.ResourceCapacity;
 			siloBar.GetUsed = () => playerResources.Resources;
-			siloBar.TooltipTextCached = new CachedTransform<(float Current, float Capacity), string>(usage =>
-			{
-				return FluentProvider.GetString(
-					SiloUsage,
-					FluentBundle.Arguments("usage", usage.Current, "capacity", usage.Capacity));
-			});
+			siloBar.TooltipTextCached = new CachedTransform<(float Current, float Capacity), string>(
+				usage => FluentProvider.GetString(SiloUsage, "usage", usage.Current, "capacity", usage.Capacity));
 			siloBar.GetBarColor = () =>
 			{
 				if (playerResources.Resources == playerResources.ResourceCapacity)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				totalPlayers += t.Count();
 				var label = noTeams ? FluentProvider.GetString(Players) : t.Key > 0
-					? FluentProvider.GetString(TeamNumber, FluentBundle.Arguments("team", t.Key))
+					? FluentProvider.GetString(TeamNumber, "team", t.Key)
 					: FluentProvider.GetString(NoTeam);
 
 				groups.Add(label, t);

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
@@ -23,22 +23,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	[ChromeLogicArgsHotkeys("CombinedViewKey", "WorldViewKey")]
 	public class ObserverShroudSelectorLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string CameraOptionAllPlayers = "options-shroud-selector.all-players";
 
-		[TranslationReference]
+		[FluentReference]
 		const string CameraOptionDisableShroud = "options-shroud-selector.disable-shroud";
 
-		[TranslationReference]
+		[FluentReference]
 		const string CameraOptionOther = "options-shroud-selector.other";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Players = "label-players";
 
-		[TranslationReference("team")]
+		[FluentReference("team")]
 		const string TeamNumber = "label-team-name";
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoTeam = "label-no-team";
 
 		readonly CameraOption combined, disableShroud;
@@ -104,10 +104,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var groups = new Dictionary<string, IEnumerable<CameraOption>>();
 
-			combined = new CameraOption(this, world, TranslationProvider.GetString(CameraOptionAllPlayers), world.Players.First(p => p.InternalName == "Everyone"));
-			disableShroud = new CameraOption(this, world, TranslationProvider.GetString(CameraOptionDisableShroud), null);
+			combined = new CameraOption(this, world, FluentProvider.GetString(CameraOptionAllPlayers), world.Players.First(p => p.InternalName == "Everyone"));
+			disableShroud = new CameraOption(this, world, FluentProvider.GetString(CameraOptionDisableShroud), null);
 			if (!limitViews)
-				groups.Add(TranslationProvider.GetString(CameraOptionOther), new List<CameraOption>() { combined, disableShroud });
+				groups.Add(FluentProvider.GetString(CameraOptionOther), new List<CameraOption>() { combined, disableShroud });
 
 			teams = world.Players.Where(p => !p.NonCombatant && p.Playable)
 				.Select(p => new CameraOption(this, p))
@@ -120,9 +120,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			foreach (var t in teams)
 			{
 				totalPlayers += t.Count();
-				var label = noTeams ? TranslationProvider.GetString(Players) : t.Key > 0
-					? TranslationProvider.GetString(TeamNumber, Translation.Arguments("team", t.Key))
-					: TranslationProvider.GetString(NoTeam);
+				var label = noTeams ? FluentProvider.GetString(Players) : t.Key > 0
+					? FluentProvider.GetString(TeamNumber, FluentBundle.Arguments("team", t.Key))
+					: FluentProvider.GetString(NoTeam);
 
 				groups.Add(label, t);
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -35,37 +35,37 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		"StatisticsArmyGraphKey")]
 	public class ObserverStatsLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string InformationNone = "options-observer-stats.none";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Basic = "options-observer-stats.basic";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Economy = "options-observer-stats.economy";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Production = "options-observer-stats.production";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SupportPowers = "options-observer-stats.support-powers";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Combat = "options-observer-stats.combat";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Army = "options-observer-stats.army";
 
-		[TranslationReference]
+		[FluentReference]
 		const string EarningsGraph = "options-observer-stats.earnings-graph";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ArmyGraph = "options-observer-stats.army-graph";
 
-		[TranslationReference("team")]
+		[FluentReference("team")]
 		const string TeamNumber = "label-team-name";
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoTeam = "label-no-team";
 
 		readonly ContainerWidget basicStatsHeaders;
@@ -155,10 +155,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var statsDropDown = widget.Get<DropDownButtonWidget>("STATS_DROPDOWN");
 			StatsDropDownOption CreateStatsOption(string title, ObserverStatsPanel panel, ScrollItemWidget template, Action a)
 			{
-				title = TranslationProvider.GetString(title);
+				title = FluentProvider.GetString(title);
 				return new StatsDropDownOption
 				{
-					Title = TranslationProvider.GetString(title),
+					Title = FluentProvider.GetString(title),
 					IsSelected = () => activePanel == panel,
 					OnClick = () =>
 					{
@@ -179,11 +179,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				new()
 				{
-					Title = TranslationProvider.GetString(InformationNone),
+					Title = FluentProvider.GetString(InformationNone),
 					IsSelected = () => activePanel == ObserverStatsPanel.None,
 					OnClick = () =>
 					{
-						var informationNone = TranslationProvider.GetString(InformationNone);
+						var informationNone = FluentProvider.GetString(InformationNone);
 						statsDropDown.GetText = () => informationNone;
 						playerStatsPanel.Visible = false;
 						ClearStats();
@@ -286,8 +286,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					tt.IgnoreMouseOver = true;
 
 					var teamLabel = tt.Get<LabelWidget>("TEAM");
-					var teamText = team.Key > 0 ? TranslationProvider.GetString(TeamNumber, Translation.Arguments("team", team.Key))
-						: TranslationProvider.GetString(NoTeam);
+					var teamText = team.Key > 0 ? FluentProvider.GetString(TeamNumber, FluentBundle.Arguments("team", team.Key))
+						: FluentProvider.GetString(NoTeam);
 					teamLabel.GetText = () => teamText;
 					tt.Bounds.Width = teamLabel.Bounds.Width = Game.Renderer.Fonts[tt.Font].Measure(teamText).X;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -286,7 +286,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					tt.IgnoreMouseOver = true;
 
 					var teamLabel = tt.Get<LabelWidget>("TEAM");
-					var teamText = team.Key > 0 ? FluentProvider.GetString(TeamNumber, FluentBundle.Arguments("team", team.Key))
+					var teamText = team.Key > 0 ? FluentProvider.GetString(TeamNumber, "team", team.Key)
 						: FluentProvider.GetString(NoTeam);
 					teamLabel.GetText = () => teamText;
 					tt.Bounds.Width = teamLabel.Bounds.Width = Game.Renderer.Fonts[tt.Font].Measure(teamText).X;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var requiresSize = int2.Zero;
 				if (prereqs.Count > 0)
 				{
-					var requiresText = FluentProvider.GetString(Requires, FluentBundle.Arguments("prequisites", prereqs.JoinWith(", ")));
+					var requiresText = FluentProvider.GetString(Requires, "prequisites", prereqs.JoinWith(", "));
 					requiresLabel.GetText = () => requiresText;
 					requiresSize = requiresFont.Measure(requiresText);
 					requiresLabel.Visible = true;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class ProductionTooltipLogic : ChromeLogic
 	{
-		[TranslationReference("prequisites")]
+		[FluentReference("prequisites")]
 		const string Requires = "label-requires";
 
 		[ObjectCreator.UseCtor]
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return;
 
 				var tooltip = actor.TraitInfos<TooltipInfo>().FirstOrDefault(info => info.EnabledByDefault);
-				var name = tooltip != null ? TranslationProvider.GetString(tooltip.Name) : actor.Name;
+				var name = tooltip != null ? FluentProvider.GetString(tooltip.Name) : actor.Name;
 				var buildable = actor.TraitInfo<BuildableInfo>();
 
 				var cost = 0;
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var requiresSize = int2.Zero;
 				if (prereqs.Count > 0)
 				{
-					var requiresText = TranslationProvider.GetString(Requires, Translation.Arguments("prequisites", prereqs.JoinWith(", ")));
+					var requiresText = FluentProvider.GetString(Requires, FluentBundle.Arguments("prequisites", prereqs.JoinWith(", ")));
 					requiresLabel.GetText = () => requiresText;
 					requiresSize = requiresFont.Measure(requiresText);
 					requiresLabel.Visible = true;
@@ -146,7 +146,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				costLabel.GetColor = () => pr.GetCashAndResources() >= cost ? Color.White : Color.Red;
 				var costSize = font.Measure(costText);
 
-				var desc = string.IsNullOrEmpty(buildable.Description) ? "" : TranslationProvider.GetString(buildable.Description);
+				var desc = string.IsNullOrEmpty(buildable.Description) ? "" : FluentProvider.GetString(buildable.Description);
 				descLabel.GetText = () => desc;
 				var descSize = descFont.Measure(desc);
 				descLabel.Bounds.Width = descSize.X;
@@ -180,7 +180,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				var actorTooltip = ai.TraitInfos<TooltipInfo>().FirstOrDefault(info => info.EnabledByDefault);
 				if (actorTooltip != null)
-					return TranslationProvider.GetString(actorTooltip.Name);
+					return FluentProvider.GetString(actorTooltip.Name);
 			}
 
 			return a;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class WorldTooltipLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string UnrevealedTerrain = "label-unrevealed-terrain";
 
 		[ObjectCreator.UseCtor]
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var extraHeightOnDouble = extras.Bounds.Y;
 			var extraHeightOnSingle = extraHeightOnDouble - (doubleHeight - singleHeight);
 
-			var unrevealedTerrain = TranslationProvider.GetString(UnrevealedTerrain);
+			var unrevealedTerrain = FluentProvider.GetString(UnrevealedTerrain);
 
 			tooltipContainer.BeforeRender = () =>
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
@@ -24,37 +24,37 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class DownloadPackageLogic : ChromeLogic
 	{
-		[TranslationReference("title")]
+		[FluentReference("title")]
 		const string Downloading = "label-downloading";
 
-		[TranslationReference]
+		[FluentReference]
 		const string FetchingMirrorList = "label-fetching-mirror-list";
 
-		[TranslationReference]
+		[FluentReference]
 		const string UnknownHost = "label-unknown-host";
 
-		[TranslationReference("host", "received", "suffix")]
+		[FluentReference("host", "received", "suffix")]
 		const string DownloadingFrom = "label-downloading-from";
 
-		[TranslationReference("host", "received", "total", "suffix", "progress")]
+		[FluentReference("host", "received", "total", "suffix", "progress")]
 		const string DownloadingFromProgress = "label-downloading-from-progress";
 
-		[TranslationReference]
+		[FluentReference]
 		const string VerifyingArchive = "label-verifying-archive";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ArchiveValidationFailed = "label-archive-validation-failed";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Extracting = "label-extracting-archive";
 
-		[TranslationReference("entry")]
+		[FluentReference("entry")]
 		const string ExtractingEntry = "label-extracting-archive-entry";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ArchiveExtractionFailed = "label-archive-extraction-failed";
 
-		[TranslationReference]
+		[FluentReference]
 		const string MirrorSelectionFailed = "label-mirror-selection-failed";
 
 		static readonly string[] SizeSuffixes = { "bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" };
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var status = new CachedTransform<string, string>(s => WidgetUtils.TruncateText(s, statusLabel.Bounds.Width, statusFont));
 			statusLabel.GetText = () => status.Update(getStatusText());
 
-			var text = TranslationProvider.GetString(Downloading, Translation.Arguments("title", download.Title));
+			var text = FluentProvider.GetString(Downloading, FluentBundle.Arguments("title", download.Title));
 			panel.Get<LabelWidget>("TITLE").GetText = () => text;
 
 			ShowDownloadDialog();
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void ShowDownloadDialog()
 		{
-			getStatusText = () => TranslationProvider.GetString(FetchingMirrorList);
+			getStatusText = () => FluentProvider.GetString(FetchingMirrorList);
 			progressBar.Indeterminate = true;
 
 			var retryButton = panel.Get<ButtonWidget>("RETRY_BUTTON");
@@ -108,7 +108,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var dataTotal = 0.0f;
 				var mag = 0;
 				var dataSuffix = "";
-				var host = downloadHost ?? TranslationProvider.GetString(UnknownHost);
+				var host = downloadHost ?? FluentProvider.GetString(UnknownHost);
 
 				if (total < 0)
 				{
@@ -116,8 +116,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					dataReceived = read / (float)(1L << (mag * 10));
 					dataSuffix = SizeSuffixes[mag];
 
-					getStatusText = () => TranslationProvider.GetString(DownloadingFrom,
-						Translation.Arguments("host", host, "received", $"{dataReceived:0.00}", "suffix", dataSuffix));
+					getStatusText = () => FluentProvider.GetString(DownloadingFrom,
+						FluentBundle.Arguments("host", host, "received", $"{dataReceived:0.00}", "suffix", dataSuffix));
 					progressBar.Indeterminate = true;
 				}
 				else
@@ -127,8 +127,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					dataReceived = read / (float)(1L << (mag * 10));
 					dataSuffix = SizeSuffixes[mag];
 
-					getStatusText = () => TranslationProvider.GetString(DownloadingFromProgress,
-						Translation.Arguments("host", host, "received", $"{dataReceived:0.00}", "total", $"{dataTotal:0.00}",
+					getStatusText = () => FluentProvider.GetString(DownloadingFromProgress,
+						FluentBundle.Arguments("host", host, "received", $"{dataReceived:0.00}", "total", $"{dataTotal:0.00}",
 							"suffix", dataSuffix, "progress", progressPercentage));
 					progressBar.Indeterminate = false;
 				}
@@ -140,7 +140,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			void OnError(string s) => Game.RunAfterTick(() =>
 			{
-				var host = downloadHost ?? TranslationProvider.GetString(UnknownHost);
+				var host = downloadHost ?? FluentProvider.GetString(UnknownHost);
 				Log.Write("install", $"Download from {host} failed: " + s);
 
 				progressBar.Indeterminate = false;
@@ -184,7 +184,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						// Validate integrity
 						if (!string.IsNullOrEmpty(download.SHA1))
 						{
-							getStatusText = () => TranslationProvider.GetString(VerifyingArchive);
+							getStatusText = () => FluentProvider.GetString(VerifyingArchive);
 							progressBar.Indeterminate = true;
 
 							var archiveValid = false;
@@ -206,13 +206,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 							if (!archiveValid)
 							{
-								OnError(TranslationProvider.GetString(ArchiveValidationFailed));
+								OnError(FluentProvider.GetString(ArchiveValidationFailed));
 								return;
 							}
 						}
 
 						// Automatically extract
-						getStatusText = () => TranslationProvider.GetString(Extracting);
+						getStatusText = () => FluentProvider.GetString(Extracting);
 						progressBar.Indeterminate = true;
 
 						var extracted = new List<string>();
@@ -232,7 +232,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 											continue;
 										}
 
-										OnExtractProgress(TranslationProvider.GetString(ExtractingEntry, Translation.Arguments("entry", kv.Value)));
+										OnExtractProgress(FluentProvider.GetString(ExtractingEntry, FluentBundle.Arguments("entry", kv.Value)));
 										Log.Write("install", "Extracting " + kv.Value);
 										var targetPath = Platform.ResolvePath(kv.Key);
 										Directory.CreateDirectory(Path.GetDirectoryName(targetPath));
@@ -263,7 +263,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 								File.Delete(f);
 							}
 
-							OnError(TranslationProvider.GetString(ArchiveExtractionFailed));
+							OnError(FluentProvider.GetString(ArchiveExtractionFailed));
 						}
 					}
 					catch (Exception e)
@@ -296,7 +296,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						Log.Write("install", "Mirror selection failed with error:");
 						Log.Write("install", e.ToString());
-						OnError(TranslationProvider.GetString(MirrorSelectionFailed));
+						OnError(FluentProvider.GetString(MirrorSelectionFailed));
 					}
 				});
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var status = new CachedTransform<string, string>(s => WidgetUtils.TruncateText(s, statusLabel.Bounds.Width, statusFont));
 			statusLabel.GetText = () => status.Update(getStatusText());
 
-			var text = FluentProvider.GetString(Downloading, FluentBundle.Arguments("title", download.Title));
+			var text = FluentProvider.GetString(Downloading, "title", download.Title);
 			panel.Get<LabelWidget>("TITLE").GetText = () => text;
 
 			ShowDownloadDialog();
@@ -117,7 +117,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					dataSuffix = SizeSuffixes[mag];
 
 					getStatusText = () => FluentProvider.GetString(DownloadingFrom,
-						FluentBundle.Arguments("host", host, "received", $"{dataReceived:0.00}", "suffix", dataSuffix));
+						"host", host,
+						"received", $"{dataReceived:0.00}",
+						"suffix", dataSuffix);
 					progressBar.Indeterminate = true;
 				}
 				else
@@ -128,8 +130,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					dataSuffix = SizeSuffixes[mag];
 
 					getStatusText = () => FluentProvider.GetString(DownloadingFromProgress,
-						FluentBundle.Arguments("host", host, "received", $"{dataReceived:0.00}", "total", $"{dataTotal:0.00}",
-							"suffix", dataSuffix, "progress", progressPercentage));
+						"host", host,
+						"received", $"{dataReceived:0.00}",
+						"total", $"{dataTotal:0.00}",
+						"suffix", dataSuffix,
+						"progress", progressPercentage);
 					progressBar.Indeterminate = false;
 				}
 
@@ -232,7 +237,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 											continue;
 										}
 
-										OnExtractProgress(FluentProvider.GetString(ExtractingEntry, FluentBundle.Arguments("entry", kv.Value)));
+										OnExtractProgress(FluentProvider.GetString(ExtractingEntry, "entry", kv.Value));
 										Log.Write("install", "Extracting " + kv.Value);
 										var targetPath = Platform.ResolvePath(kv.Key);
 										Directory.CreateDirectory(Path.GetDirectoryName(targetPath));

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromSourceLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromSourceLogic.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		const string CheckInstallLog = "label-check-install-log";
 
 		[FluentReference("filename")]
-		public const string Extracing = "label-extracting-filename";
+		public const string Extracting = "label-extracting-filename";
 
 		[FluentReference("filename", "progress")]
 		public const string ExtractingProgress = "label-extracting-filename-progress";
@@ -168,7 +168,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				foreach (var kv in sources)
 				{
-					message = FluentProvider.GetString(SearchingSourceFor, FluentBundle.Arguments("title", kv.Value.Title));
+					message = FluentProvider.GetString(SearchingSourceFor, "title", kv.Value.Title);
 
 					var sourceResolver = kv.Value.ObjectCreator.CreateObject<ISourceResolver>($"{kv.Value.Type.Value}SourceResolver");
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromSourceLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromSourceLogic.cs
@@ -22,61 +22,61 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class InstallFromSourceLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string DetectingSources = "label-detecting-sources";
 
-		[TranslationReference]
+		[FluentReference]
 		const string CheckingSources = "label-checking-sources";
 
-		[TranslationReference("title")]
+		[FluentReference("title")]
 		const string SearchingSourceFor = "label-searching-source-for";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ContentPackageInstallation = "label-content-package-installation";
 
-		[TranslationReference]
+		[FluentReference]
 		const string GameSources = "label-game-sources";
 
-		[TranslationReference]
+		[FluentReference]
 		const string DigitalInstalls = "label-digital-installs";
 
-		[TranslationReference]
+		[FluentReference]
 		const string GameContentNotFound = "label-game-content-not-found";
 
-		[TranslationReference]
+		[FluentReference]
 		const string AlternativeContentSources = "label-alternative-content-sources";
 
-		[TranslationReference]
+		[FluentReference]
 		const string InstallingContent = "label-installing-content";
 
-		[TranslationReference("filename")]
+		[FluentReference("filename")]
 		public const string CopyingFilename = "label-copying-filename";
 
-		[TranslationReference("filename", "progress")]
+		[FluentReference("filename", "progress")]
 		public const string CopyingFilenameProgress = "label-copying-filename-progress";
 
-		[TranslationReference]
+		[FluentReference]
 		const string InstallationFailed = "label-installation-failed";
 
-		[TranslationReference]
+		[FluentReference]
 		const string CheckInstallLog = "label-check-install-log";
 
-		[TranslationReference("filename")]
+		[FluentReference("filename")]
 		public const string Extracing = "label-extracting-filename";
 
-		[TranslationReference("filename", "progress")]
+		[FluentReference("filename", "progress")]
 		public const string ExtractingProgress = "label-extracting-filename-progress";
 
-		[TranslationReference]
+		[FluentReference]
 		public const string Continue = "button-continue";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Cancel = "button-cancel";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Retry = "button-retry";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Back = "button-back";
 
 		// Hide percentage indicators for files smaller than 25 MB
@@ -160,15 +160,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void DetectContentSources()
 		{
-			var message = TranslationProvider.GetString(DetectingSources);
-			ShowProgressbar(TranslationProvider.GetString(CheckingSources), () => message);
+			var message = FluentProvider.GetString(DetectingSources);
+			ShowProgressbar(FluentProvider.GetString(CheckingSources), () => message);
 			ShowBackRetry(DetectContentSources);
 
 			new Task(() =>
 			{
 				foreach (var kv in sources)
 				{
-					message = TranslationProvider.GetString(SearchingSourceFor, Translation.Arguments("title", kv.Value.Title));
+					message = FluentProvider.GetString(SearchingSourceFor, FluentBundle.Arguments("title", kv.Value.Title));
 
 					var sourceResolver = kv.Value.ObjectCreator.CreateObject<ISourceResolver>($"{kv.Value.Type.Value}SourceResolver");
 
@@ -188,7 +188,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						{
 							Game.RunAfterTick(() =>
 							{
-								ShowList(kv.Value, TranslationProvider.GetString(ContentPackageInstallation));
+								ShowList(kv.Value, FluentProvider.GetString(ContentPackageInstallation));
 								ShowContinueCancel(() => InstallFromSource(path, kv.Value));
 							});
 
@@ -220,14 +220,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var options = new Dictionary<string, IEnumerable<string>>();
 
 				if (gameSources.Count != 0)
-					options.Add(TranslationProvider.GetString(GameSources), gameSources);
+					options.Add(FluentProvider.GetString(GameSources), gameSources);
 
 				if (digitalInstalls.Count != 0)
-					options.Add(TranslationProvider.GetString(DigitalInstalls), digitalInstalls);
+					options.Add(FluentProvider.GetString(DigitalInstalls), digitalInstalls);
 
 				Game.RunAfterTick(() =>
 				{
-					ShowList(TranslationProvider.GetString(GameContentNotFound), TranslationProvider.GetString(AlternativeContentSources), options);
+					ShowList(FluentProvider.GetString(GameContentNotFound), FluentProvider.GetString(AlternativeContentSources), options);
 					ShowBackRetry(DetectContentSources);
 				});
 			}).Start();
@@ -236,7 +236,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void InstallFromSource(string path, ModContent.ModSource modSource)
 		{
 			var message = "";
-			ShowProgressbar(TranslationProvider.GetString(InstallingContent), () => message);
+			ShowProgressbar(FluentProvider.GetString(InstallingContent), () => message);
 			ShowDisabledCancel();
 
 			new Task(() =>
@@ -292,7 +292,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					Game.RunAfterTick(() =>
 					{
-						ShowMessage(TranslationProvider.GetString(InstallationFailed), TranslationProvider.GetString(CheckInstallLog));
+						ShowMessage(FluentProvider.GetString(InstallationFailed), FluentProvider.GetString(CheckInstallLog));
 						ShowBackRetry(() => InstallFromSource(path, modSource));
 					});
 				}
@@ -398,12 +398,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void ShowContinueCancel(Action continueAction)
 		{
 			primaryButton.OnClick = continueAction;
-			var primaryButtonText = TranslationProvider.GetString(Continue);
+			var primaryButtonText = FluentProvider.GetString(Continue);
 			primaryButton.GetText = () => primaryButtonText;
 			primaryButton.Visible = true;
 
 			secondaryButton.OnClick = Ui.CloseWindow;
-			var secondaryButtonText = TranslationProvider.GetString(Cancel);
+			var secondaryButtonText = FluentProvider.GetString(Cancel);
 			secondaryButton.GetText = () => secondaryButtonText;
 			secondaryButton.Visible = true;
 			secondaryButton.Disabled = false;
@@ -413,12 +413,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void ShowBackRetry(Action retryAction)
 		{
 			primaryButton.OnClick = retryAction;
-			var primaryButtonText = TranslationProvider.GetString(Retry);
+			var primaryButtonText = FluentProvider.GetString(Retry);
 			primaryButton.GetText = () => primaryButtonText;
 			primaryButton.Visible = true;
 
 			secondaryButton.OnClick = Ui.CloseWindow;
-			var secondaryButtonText = TranslationProvider.GetString(Back);
+			var secondaryButtonText = FluentProvider.GetString(Back);
 			secondaryButton.GetText = () => secondaryButtonText;
 			secondaryButton.Visible = true;
 			secondaryButton.Disabled = false;

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class ModContentLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string ManualInstall = "button-manual-install";
 
 		readonly ModContent content;
@@ -140,7 +140,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				requiresSourceWidget.IsVisible = () => !installed && !downloadEnabled;
 				if (!isSourceAvailable)
 				{
-					var manualInstall = TranslationProvider.GetString(ManualInstall);
+					var manualInstall = FluentProvider.GetString(ManualInstall);
 					requiresSourceWidget.GetText = () => manualInstall;
 				}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentPromptLogic.cs
@@ -20,10 +20,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class ModContentPromptLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string Continue = "button-continue";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Quit = "button-quit";
 
 		readonly ModContent content;
@@ -35,8 +35,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.content = content;
 			CheckRequiredContentInstalled();
 
-			var continueMessage = TranslationProvider.GetString(Continue);
-			var quitMessage = TranslationProvider.GetString(Quit);
+			var continueMessage = FluentProvider.GetString(Continue);
+			var quitMessage = FluentProvider.GetString(Quit);
 
 			var panel = widget.Get("CONTENT_PROMPT_PANEL");
 			var headerTemplate = panel.Get<LabelWidget>("HEADER_TEMPLATE");

--- a/OpenRA.Mods.Common/Widgets/Logic/IntroductionPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/IntroductionPromptLogic.cs
@@ -22,10 +22,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		// Increment the version number when adding new stats
 		const int IntroductionVersion = 1;
 
-		[TranslationReference]
+		[FluentReference]
 		const string Classic = "options-control-scheme.classic";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Modern = "options-control-scheme.modern";
 
 		readonly string classic;
@@ -43,8 +43,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var ds = Game.Settings.Graphics;
 			var gs = Game.Settings.Game;
 
-			classic = TranslationProvider.GetString(Classic);
-			modern = TranslationProvider.GetString(Modern);
+			classic = FluentProvider.GetString(Classic);
+			modern = FluentProvider.GetString(Modern);
 
 			var escPressed = false;
 			var nameTextfield = widget.Get<TextFieldWidget>("PLAYERNAME");

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickClientLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickClientLogic.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[ObjectCreator.UseCtor]
 		public KickClientLogic(Widget widget, string clientName, Action<bool> okPressed, Action cancelPressed)
 		{
-			var kickMessage = FluentProvider.GetString(KickClient, FluentBundle.Arguments("player", clientName));
+			var kickMessage = FluentProvider.GetString(KickClient, "player", clientName);
 			widget.Get<LabelWidget>("TITLE").GetText = () => kickMessage;
 
 			var tempBan = false;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickClientLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickClientLogic.cs
@@ -16,13 +16,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	sealed class KickClientLogic : ChromeLogic
 	{
-		[TranslationReference("player")]
+		[FluentReference("player")]
 		const string KickClient = "dialog-kick-client.prompt";
 
 		[ObjectCreator.UseCtor]
 		public KickClientLogic(Widget widget, string clientName, Action<bool> okPressed, Action cancelPressed)
 		{
-			var kickMessage = TranslationProvider.GetString(KickClient, Translation.Arguments("player", clientName));
+			var kickMessage = FluentProvider.GetString(KickClient, FluentBundle.Arguments("player", clientName));
 			widget.Get<LabelWidget>("TITLE").GetText = () => kickMessage;
 
 			var tempBan = false;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickSpectatorsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickSpectatorsLogic.cs
@@ -16,13 +16,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	sealed class KickSpectatorsLogic : ChromeLogic
 	{
-		[TranslationReference("count")]
+		[FluentReference("count")]
 		const string KickSpectators = "dialog-kick-spectators.prompt";
 
 		[ObjectCreator.UseCtor]
 		public KickSpectatorsLogic(Widget widget, int clientCount, Action okPressed, Action cancelPressed)
 		{
-			var kickMessage = TranslationProvider.GetString(KickSpectators, Translation.Arguments("count", clientCount));
+			var kickMessage = FluentProvider.GetString(KickSpectators, FluentBundle.Arguments("count", clientCount));
 			widget.Get<LabelWidget>("TEXT").GetText = () => kickMessage;
 
 			widget.Get<ButtonWidget>("OK_BUTTON").OnClick = () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickSpectatorsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickSpectatorsLogic.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[ObjectCreator.UseCtor]
 		public KickSpectatorsLogic(Widget widget, int clientCount, Action okPressed, Action cancelPressed)
 		{
-			var kickMessage = FluentProvider.GetString(KickSpectators, FluentBundle.Arguments("count", clientCount));
+			var kickMessage = FluentProvider.GetString(KickSpectators, "count", clientCount);
 			widget.Get<LabelWidget>("TEXT").GetText = () => kickMessage;
 
 			widget.Get<ButtonWidget>("OK_BUTTON").OnClick = () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -23,40 +23,40 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class LobbyLogic : ChromeLogic, INotificationHandler<TextNotification>
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string Add = "options-slot-admin.add-bots";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Remove = "options-slot-admin.remove-bots";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ConfigureBots = "options-slot-admin.configure-bots";
 
-		[TranslationReference("count")]
+		[FluentReference("count")]
 		const string NumberTeams = "options-slot-admin.teams-count";
 
-		[TranslationReference]
+		[FluentReference]
 		const string HumanVsBots = "options-slot-admin.humans-vs-bots";
 
-		[TranslationReference]
+		[FluentReference]
 		const string FreeForAll = "options-slot-admin.free-for-all";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ConfigureTeams = "options-slot-admin.configure-teams";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Back = "button-back";
 
-		[TranslationReference]
+		[FluentReference]
 		const string TeamChat = "button-team-chat";
 
-		[TranslationReference]
+		[FluentReference]
 		const string GeneralChat = "button-general-chat";
 
-		[TranslationReference("seconds")]
+		[FluentReference("seconds")]
 		const string ChatAvailability = "label-chat-availability";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ChatDisabled = "label-chat-disabled";
 
 		static readonly Action DoNothing = () => { };
@@ -282,7 +282,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						{
 							new()
 							{
-								Title = TranslationProvider.GetString(Add),
+								Title = FluentProvider.GetString(Add),
 								IsSelected = () => false,
 								OnClick = () =>
 								{
@@ -301,7 +301,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						{
 							botOptions.Add(new DropDownOption()
 							{
-								Title = TranslationProvider.GetString(Remove),
+								Title = FluentProvider.GetString(Remove),
 								IsSelected = () => false,
 								OnClick = () =>
 								{
@@ -315,7 +315,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							});
 						}
 
-						options.Add(TranslationProvider.GetString(ConfigureBots), botOptions);
+						options.Add(FluentProvider.GetString(ConfigureBots), botOptions);
 					}
 
 					var teamCount = (orderManager.LobbyInfo.Slots.Count(s => !s.Value.LockTeam && orderManager.LobbyInfo.ClientInSlot(s.Key) != null) + 1) / 2;
@@ -323,7 +323,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						var teamOptions = Enumerable.Range(2, teamCount - 1).Reverse().Select(d => new DropDownOption
 						{
-							Title = TranslationProvider.GetString(NumberTeams, Translation.Arguments("count", d)),
+							Title = FluentProvider.GetString(NumberTeams, FluentBundle.Arguments("count", d)),
 							IsSelected = () => false,
 							OnClick = () => orderManager.IssueOrder(Order.Command($"assignteams {d}"))
 						}).ToList();
@@ -332,7 +332,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						{
 							teamOptions.Add(new DropDownOption
 							{
-								Title = TranslationProvider.GetString(HumanVsBots),
+								Title = FluentProvider.GetString(HumanVsBots),
 								IsSelected = () => false,
 								OnClick = () => orderManager.IssueOrder(Order.Command("assignteams 1"))
 							});
@@ -340,12 +340,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 						teamOptions.Add(new DropDownOption
 						{
-							Title = TranslationProvider.GetString(FreeForAll),
+							Title = FluentProvider.GetString(FreeForAll),
 							IsSelected = () => false,
 							OnClick = () => orderManager.IssueOrder(Order.Command("assignteams 0"))
 						});
 
-						options.Add(TranslationProvider.GetString(ConfigureTeams), teamOptions);
+						options.Add(FluentProvider.GetString(ConfigureTeams), teamOptions);
 					}
 
 					ScrollItemWidget SetupItem(DropDownOption option, ScrollItemWidget template)
@@ -483,7 +483,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			if (skirmishMode)
 			{
-				var disconnectButtonText = TranslationProvider.GetString(Back);
+				var disconnectButtonText = FluentProvider.GetString(Back);
 				disconnectButton.GetText = () => disconnectButtonText;
 			}
 
@@ -497,8 +497,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var chatMode = lobby.Get<ButtonWidget>("CHAT_MODE");
-			var team = TranslationProvider.GetString(TeamChat);
-			var all = TranslationProvider.GetString(GeneralChat);
+			var team = FluentProvider.GetString(TeamChat);
+			var all = FluentProvider.GetString(GeneralChat);
 			chatMode.GetText = () => teamChat ? team : all;
 			chatMode.OnClick = () => teamChat ^= true;
 			chatMode.IsDisabled = () => disableTeamChat || !chatEnabled;
@@ -539,8 +539,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			chatTextField.OnEscKey = _ => chatTextField.YieldKeyboardFocus();
 
-			chatAvailableIn = new CachedTransform<int, string>(x => TranslationProvider.GetString(ChatAvailability, Translation.Arguments("seconds", x)));
-			chatDisabled = TranslationProvider.GetString(ChatDisabled);
+			chatAvailableIn = new CachedTransform<int, string>(x => FluentProvider.GetString(ChatAvailability, FluentBundle.Arguments("seconds", x)));
+			chatDisabled = FluentProvider.GetString(ChatDisabled);
 
 			lobbyChatPanel = lobby.Get<ScrollPanelWidget>("CHAT_DISPLAY");
 			lobbyChatPanel.RemoveChildren();

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -323,7 +323,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						var teamOptions = Enumerable.Range(2, teamCount - 1).Reverse().Select(d => new DropDownOption
 						{
-							Title = FluentProvider.GetString(NumberTeams, FluentBundle.Arguments("count", d)),
+							Title = FluentProvider.GetString(NumberTeams, "count", d),
 							IsSelected = () => false,
 							OnClick = () => orderManager.IssueOrder(Order.Command($"assignteams {d}"))
 						}).ToList();
@@ -539,7 +539,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			chatTextField.OnEscKey = _ => chatTextField.YieldKeyboardFocus();
 
-			chatAvailableIn = new CachedTransform<int, string>(x => FluentProvider.GetString(ChatAvailability, FluentBundle.Arguments("seconds", x)));
+			chatAvailableIn = new CachedTransform<int, string>(x => FluentProvider.GetString(ChatAvailability, "seconds", x));
 			chatDisabled = FluentProvider.GetString(ChatDisabled);
 
 			lobbyChatPanel = lobby.Get<ScrollPanelWidget>("CHAT_DISPLAY");

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class LobbyOptionsLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string NotAvailable = "label-not-available";
 
 		readonly ScrollPanelWidget panel;
@@ -146,7 +146,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var getOptionLabel = new CachedTransform<string, string>(id =>
 				{
 					if (id == null || !option.Values.TryGetValue(id, out var value))
-						return TranslationProvider.GetString(NotAvailable);
+						return FluentProvider.GetString(NotAvailable);
 
 					return value;
 				});

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -24,19 +24,19 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public static class LobbyUtils
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string Open = "options-lobby-slot.open";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Closed = "options-lobby-slot.closed";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Bots = "options-lobby-slot.bots";
 
-		[TranslationReference]
+		[FluentReference]
 		const string BotsDisabled = "options-lobby-slot.bots-disabled";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Slot = "options-lobby-slot.slot";
 
 		sealed class SlotDropDownOption
@@ -56,12 +56,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		public static void ShowSlotDropDown(DropDownButtonWidget dropdown, Session.Slot slot,
 			Session.Client client, OrderManager orderManager, MapPreview map, ModData modData)
 		{
-			var open = TranslationProvider.GetString(Open);
-			var closed = TranslationProvider.GetString(Closed);
+			var open = FluentProvider.GetString(Open);
+			var closed = FluentProvider.GetString(Closed);
 			var options = new Dictionary<string, IEnumerable<SlotDropDownOption>>
 			{
 				{
-					TranslationProvider.GetString(Slot), new List<SlotDropDownOption>
+					FluentProvider.GetString(Slot), new List<SlotDropDownOption>
 					{
 						new(open, "slot_open " + slot.PlayerReference, () => !slot.Closed && client == null),
 						new(closed, "slot_close " + slot.PlayerReference, () => slot.Closed)
@@ -75,13 +75,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				foreach (var b in map.PlayerActorInfo.TraitInfos<IBotInfo>())
 				{
 					var botController = orderManager.LobbyInfo.Clients.FirstOrDefault(c => c.IsAdmin);
-					bots.Add(new SlotDropDownOption(TranslationProvider.GetString(b.Name),
+					bots.Add(new SlotDropDownOption(FluentProvider.GetString(b.Name),
 						$"slot_bot {slot.PlayerReference} {botController.Index} {b.Type}",
 						() => client != null && client.Bot == b.Type));
 				}
 			}
 
-			options.Add(bots.Count > 0 ? TranslationProvider.GetString(Bots) : TranslationProvider.GetString(BotsDisabled), bots);
+			options.Add(bots.Count > 0 ? FluentProvider.GetString(Bots) : FluentProvider.GetString(BotsDisabled), bots);
 
 			ScrollItemWidget SetupItem(SlotDropDownOption o, ScrollItemWidget itemTemplate)
 			{
@@ -222,14 +222,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var faction = factions[factionId];
 
 				var label = item.Get<LabelWidget>("LABEL");
-				var labelText = WidgetUtils.TruncateText(TranslationProvider.GetString(faction.Name), label.Bounds.Width, Game.Renderer.Fonts[label.Font]);
+				var labelText = WidgetUtils.TruncateText(FluentProvider.GetString(faction.Name), label.Bounds.Width, Game.Renderer.Fonts[label.Font]);
 				label.GetText = () => labelText;
 
 				var flag = item.Get<ImageWidget>("FLAG");
 				flag.GetImageCollection = () => "flags";
 				flag.GetImageName = () => factionId;
 
-				var description = faction.Description != null ? TranslationProvider.GetString(faction.Description) : null;
+				var description = faction.Description != null ? FluentProvider.GetString(faction.Description) : null;
 				var (text, desc) = SplitOnFirstToken(description);
 				item.GetTooltipText = () => text;
 				item.GetTooltipDesc = () => desc;
@@ -238,7 +238,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var options = factions.Where(f => f.Value.Selectable).GroupBy(f => f.Value.Side)
-				.ToDictionary(g => g.Key != null ? TranslationProvider.GetString(g.Key) : "", g => g.Select(f => TranslationProvider.GetString(f.Key)));
+				.ToDictionary(g => g.Key != null ? FluentProvider.GetString(g.Key) : "", g => g.Select(f => FluentProvider.GetString(f.Key)));
 
 			dropdown.ShowDropDown("FACTION_DROPDOWN_TEMPLATE", 154, options, SetupItem);
 		}
@@ -430,7 +430,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var label = parent.Get<LabelWidget>("NAME");
 			label.IsVisible = () => true;
 			var font = Game.Renderer.Fonts[label.Font];
-			var name = c.IsBot ? TranslationProvider.GetString(c.Name) : c.Name;
+			var name = c.IsBot ? FluentProvider.GetString(c.Name) : c.Name;
 			var text = WidgetUtils.TruncateText(name, label.Bounds.Width, font);
 			label.GetText = () => text;
 
@@ -448,10 +448,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				WidgetUtils.TruncateText(name, slot.Bounds.Width - slot.Bounds.Height - slot.LeftMargin - slot.RightMargin,
 				Game.Renderer.Fonts[slot.Font]));
 
-			var closed = TranslationProvider.GetString(Closed);
-			var open = TranslationProvider.GetString(Open);
+			var closed = FluentProvider.GetString(Closed);
+			var open = FluentProvider.GetString(Open);
 			slot.GetText = () => truncated.Update(c != null ?
-				c.IsBot ? TranslationProvider.GetString(c.Name) : c.Name
+				c.IsBot ? FluentProvider.GetString(c.Name) : c.Name
 					: s.Closed ? closed : open);
 
 			slot.OnMouseDown = _ => ShowSlotDropDown(slot, s, c, orderManager, map, modData);
@@ -465,8 +465,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var name = parent.Get<LabelWidget>("NAME");
 			name.IsVisible = () => true;
 			name.GetText = () => c != null ? c.Name : s.Closed
-				? TranslationProvider.GetString(Closed)
-				: TranslationProvider.GetString(Open);
+				? FluentProvider.GetString(Closed)
+				: FluentProvider.GetString(Open);
 
 			// Ensure Slot selector (if present) is hidden
 			HideChildWidget(parent, "SLOT_OPTIONS");
@@ -564,7 +564,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			dropdown.IsDisabled = () => s.LockFaction || orderManager.LocalClient.IsReady;
 			dropdown.OnMouseDown = _ => ShowFactionDropDown(dropdown, c, orderManager, factions);
 
-			var description = factions[c.Faction].Description != null ? TranslationProvider.GetString(factions[c.Faction].Description) : null;
+			var description = factions[c.Faction].Description != null ? FluentProvider.GetString(factions[c.Faction].Description) : null;
 			var (text, desc) = SplitOnFirstToken(description);
 			dropdown.GetTooltipText = () => text;
 			dropdown.GetTooltipDesc = () => desc;
@@ -577,7 +577,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var factionName = parent.Get<LabelWidget>("FACTIONNAME");
 			var font = Game.Renderer.Fonts[factionName.Font];
 			var truncated = new CachedTransform<string, string>(clientFaction =>
-				WidgetUtils.TruncateText(TranslationProvider.GetString(factions[clientFaction].Name), factionName.Bounds.Width, font));
+				WidgetUtils.TruncateText(FluentProvider.GetString(factions[clientFaction].Name), factionName.Bounds.Width, font));
 			factionName.GetText = () => truncated.Update(c.Faction);
 
 			var factionFlag = parent.Get<ImageWidget>("FACTIONFLAG");

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
@@ -20,22 +20,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class MapPreviewLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string Connecting = "label-connecting";
 
-		[TranslationReference("size")]
+		[FluentReference("size")]
 		const string Downloading = "label-downloading-map";
 
-		[TranslationReference("size", "progress")]
+		[FluentReference("size", "progress")]
 		const string DownloadingPercentage = "label-downloading-map-progress";
 
-		[TranslationReference]
+		[FluentReference]
 		const string RetryInstall = "button-retry-install";
 
-		[TranslationReference]
+		[FluentReference]
 		const string RetrySearch = "button-retry-search";
 
-		[TranslationReference("author")]
+		[FluentReference("author")]
 		const string CreatedBy = "label-created-by";
 
 		readonly int blinkTickLength = 10;
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var authorCache = new CachedTransform<string, string>(
-				text => TranslationProvider.GetString(CreatedBy, Translation.Arguments("author", text)));
+				text => FluentProvider.GetString(CreatedBy, FluentBundle.Arguments("author", text)));
 
 			Widget SetupAuthorAndMapType(Widget parent)
 			{
@@ -165,13 +165,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					var (map, _) = getMap();
 					if (map.DownloadBytes == 0)
-						return TranslationProvider.GetString(Connecting);
+						return FluentProvider.GetString(Connecting);
 
 					// Server does not provide the total file length.
 					if (map.DownloadPercentage == 0)
-						return TranslationProvider.GetString(Downloading, Translation.Arguments("size", map.DownloadBytes / 1024));
+						return FluentProvider.GetString(Downloading, FluentBundle.Arguments("size", map.DownloadBytes / 1024));
 
-					return TranslationProvider.GetString(DownloadingPercentage, Translation.Arguments("size", map.DownloadBytes / 1024, "progress", map.DownloadPercentage));
+					return FluentProvider.GetString(DownloadingPercentage, FluentBundle.Arguments("size", map.DownloadBytes / 1024, "progress", map.DownloadPercentage));
 				};
 
 				return parent;
@@ -198,8 +198,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					modData.MapCache.QueryRemoteMapDetails(mapRepository, new[] { map.Uid });
 			};
 
-			var retryInstall = TranslationProvider.GetString(RetryInstall);
-			var retrySearch = TranslationProvider.GetString(RetrySearch);
+			var retryInstall = FluentProvider.GetString(RetryInstall);
+			var retrySearch = FluentProvider.GetString(RetrySearch);
 			retryButton.GetText = () => getMap().Map.Status == MapStatus.DownloadError ? retryInstall : retrySearch;
 
 			var previewLarge = SetupMapPreview(widget.Get("MAP_LARGE"));

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var authorCache = new CachedTransform<string, string>(
-				text => FluentProvider.GetString(CreatedBy, FluentBundle.Arguments("author", text)));
+				text => FluentProvider.GetString(CreatedBy, "author", text));
 
 			Widget SetupAuthorAndMapType(Widget parent)
 			{
@@ -169,9 +169,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					// Server does not provide the total file length.
 					if (map.DownloadPercentage == 0)
-						return FluentProvider.GetString(Downloading, FluentBundle.Arguments("size", map.DownloadBytes / 1024));
+						return FluentProvider.GetString(Downloading, "size", map.DownloadBytes / 1024);
 
-					return FluentProvider.GetString(DownloadingPercentage, FluentBundle.Arguments("size", map.DownloadBytes / 1024, "progress", map.DownloadPercentage));
+					return FluentProvider.GetString(DownloadingPercentage, "size", map.DownloadBytes / 1024, "progress", map.DownloadPercentage);
 				};
 
 				return parent;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/SpawnSelectorTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/SpawnSelectorTooltipLogic.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var labelText = "";
 			string playerFaction = null;
 			var playerTeam = -1;
-			teamMessage = new CachedTransform<int, string>(t => FluentProvider.GetString(TeamNumber, FluentBundle.Arguments("team", t)));
+			teamMessage = new CachedTransform<int, string>(t => FluentProvider.GetString(TeamNumber, "team", t));
 			var disabledSpawn = FluentProvider.GetString(DisabledSpawn);
 			var availableSpawn = FluentProvider.GetString(AvailableSpawn);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/SpawnSelectorTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/SpawnSelectorTooltipLogic.cs
@@ -18,13 +18,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class SpawnSelectorTooltipLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string DisabledSpawn = "label-disabled-spawn";
 
-		[TranslationReference]
+		[FluentReference]
 		const string AvailableSpawn = "label-available-spawn";
 
-		[TranslationReference("team")]
+		[FluentReference("team")]
 		const string TeamNumber = "label-team-name";
 
 		readonly CachedTransform<int, string> teamMessage;
@@ -49,9 +49,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var labelText = "";
 			string playerFaction = null;
 			var playerTeam = -1;
-			teamMessage = new CachedTransform<int, string>(t => TranslationProvider.GetString(TeamNumber, Translation.Arguments("team", t)));
-			var disabledSpawn = TranslationProvider.GetString(DisabledSpawn);
-			var availableSpawn = TranslationProvider.GetString(AvailableSpawn);
+			teamMessage = new CachedTransform<int, string>(t => FluentProvider.GetString(TeamNumber, FluentBundle.Arguments("team", t)));
+			var disabledSpawn = FluentProvider.GetString(DisabledSpawn);
+			var availableSpawn = FluentProvider.GetString(AvailableSpawn);
 
 			tooltipContainer.BeforeRender = () =>
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -23,16 +23,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class MainMenuLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string LoadingNews = "label-loading-news";
 
-		[TranslationReference("message")]
+		[FluentReference("message")]
 		const string NewsRetrivalFailed = "label-news-retrieval-failed";
 
-		[TranslationReference("message")]
+		[FluentReference("message")]
 		const string NewsParsingFailed = "label-news-parsing-failed";
 
-		[TranslationReference("author", "datetime")]
+		[FluentReference("author", "datetime")]
 		const string AuthorDateTime = "label-author-datetime";
 
 		protected enum MenuType { Main, Singleplayer, Extras, MapEditor, StartupPrompts, None }
@@ -227,7 +227,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				newsPanel.RemoveChild(newsTemplate);
 
 				newsStatus = newsPanel.Get<LabelWidget>("NEWS_STATUS");
-				SetNewsStatus(TranslationProvider.GetString(LoadingNews));
+				SetNewsStatus(FluentProvider.GetString(LoadingNews));
 			}
 
 			Game.OnRemoteDirectConnect += OnRemoteDirectConnect;
@@ -339,7 +339,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							catch (Exception e)
 							{
 								Game.RunAfterTick(() => // run on the main thread
-									SetNewsStatus(TranslationProvider.GetString(NewsRetrivalFailed, Translation.Arguments("message", e.Message))));
+									SetNewsStatus(FluentProvider.GetString(NewsRetrivalFailed, FluentBundle.Arguments("message", e.Message))));
 							}
 						});
 					}
@@ -410,7 +410,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 			catch (Exception ex)
 			{
-				SetNewsStatus(TranslationProvider.GetString(NewsParsingFailed, Translation.Arguments("message", ex.Message)));
+				SetNewsStatus(FluentProvider.GetString(NewsParsingFailed, FluentBundle.Arguments("message", ex.Message)));
 			}
 
 			return null;
@@ -431,7 +431,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				titleLabel.GetText = () => item.Title;
 
 				var authorDateTimeLabel = newsItem.Get<LabelWidget>("AUTHOR_DATETIME");
-				var authorDateTime = TranslationProvider.GetString(AuthorDateTime, Translation.Arguments(
+				var authorDateTime = FluentProvider.GetString(AuthorDateTime, FluentBundle.Arguments(
 					"author", item.Author,
 					"datetime", item.DateTime.ToLocalTime().ToString(CultureInfo.CurrentCulture)));
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -339,7 +339,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							catch (Exception e)
 							{
 								Game.RunAfterTick(() => // run on the main thread
-									SetNewsStatus(FluentProvider.GetString(NewsRetrivalFailed, FluentBundle.Arguments("message", e.Message))));
+									SetNewsStatus(FluentProvider.GetString(NewsRetrivalFailed, "message", e.Message)));
 							}
 						});
 					}
@@ -410,7 +410,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 			catch (Exception ex)
 			{
-				SetNewsStatus(FluentProvider.GetString(NewsParsingFailed, FluentBundle.Arguments("message", ex.Message)));
+				SetNewsStatus(FluentProvider.GetString(NewsParsingFailed, "message", ex.Message));
 			}
 
 			return null;
@@ -431,9 +431,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				titleLabel.GetText = () => item.Title;
 
 				var authorDateTimeLabel = newsItem.Get<LabelWidget>("AUTHOR_DATETIME");
-				var authorDateTime = FluentProvider.GetString(AuthorDateTime, FluentBundle.Arguments(
+				var authorDateTime = FluentProvider.GetString(AuthorDateTime,
 					"author", item.Author,
-					"datetime", item.DateTime.ToLocalTime().ToString(CultureInfo.CurrentCulture)));
+					"datetime", item.DateTime.ToLocalTime().ToString(CultureInfo.CurrentCulture));
 
 				authorDateTimeLabel.GetText = () => authorDateTime;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -205,9 +205,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var remoteMapText = new CachedTransform<(int Searching, int Unavailable), string>(counts =>
 			{
 				if (counts.Searching > 0)
-					return FluentProvider.GetString(MapSearchingCount, FluentBundle.Arguments("count", counts.Searching));
+					return FluentProvider.GetString(MapSearchingCount, "count", counts.Searching);
 
-				return FluentProvider.GetString(MapUnavailableCount, FluentBundle.Arguments("count", counts.Unavailable));
+				return FluentProvider.GetString(MapUnavailableCount, "count", counts.Unavailable);
 			});
 
 			remoteMapLabel.IsVisible = () => remoteMapPool != null && (remoteSearching > 0 || remoteUnavailable > 0);
@@ -458,13 +458,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					if (type != null)
 						details = type + " ";
 
-					details += FluentProvider.GetString(Players, FluentBundle.Arguments("players", preview.PlayerCount));
+					details += FluentProvider.GetString(Players, "players", preview.PlayerCount);
 					detailsWidget.GetText = () => details;
 				}
 
 				var authorWidget = item.GetOrNull<LabelWithTooltipWidget>("AUTHOR");
 				if (authorWidget != null && !string.IsNullOrEmpty(preview.Author))
-					WidgetUtils.TruncateLabelToTooltip(authorWidget, FluentProvider.GetString(CreatedBy, FluentBundle.Arguments("author", preview.Author)));
+					WidgetUtils.TruncateLabelToTooltip(authorWidget, FluentProvider.GetString(CreatedBy, "author", preview.Author));
 
 				var sizeWidget = item.GetOrNull<LabelWidget>("SIZE");
 				if (sizeWidget != null)
@@ -502,7 +502,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 			catch (Exception ex)
 			{
-				TextNotificationsManager.Debug(FluentProvider.GetString(MapDeletionFailed, FluentBundle.Arguments("map", map)));
+				TextNotificationsManager.Debug(FluentProvider.GetString(MapDeletionFailed, "map", map));
 				Log.Write("debug", ex.ToString());
 			}
 
@@ -514,7 +514,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			ConfirmationDialogs.ButtonPrompt(modData,
 				title: DeleteMapTitle,
 				text: DeleteMapPrompt,
-				textArguments: FluentBundle.Arguments("title", modData.MapCache[map].Title),
+				textArguments: new object[] { "title", modData.MapCache[map].Title },
 				onConfirm: () =>
 				{
 					var newUid = DeleteMap(map);

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -19,67 +19,67 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class MapChooserLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string AllMaps = "label-all-maps";
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoMatches = "label-no-matches";
 
-		[TranslationReference("players")]
+		[FluentReference("players")]
 		const string Players = "label-player-count";
 
-		[TranslationReference("author")]
+		[FluentReference("author")]
 		const string CreatedBy = "label-created-by";
 
-		[TranslationReference]
+		[FluentReference]
 		const string MapSizeHuge = "label-map-size-huge";
 
-		[TranslationReference]
+		[FluentReference]
 		const string MapSizeLarge = "label-map-size-large";
 
-		[TranslationReference]
+		[FluentReference]
 		const string MapSizeMedium = "label-map-size-medium";
 
-		[TranslationReference]
+		[FluentReference]
 		const string MapSizeSmall = "label-map-size-small";
 
-		[TranslationReference("count")]
+		[FluentReference("count")]
 		const string MapSearchingCount = "label-map-searching-count";
 
-		[TranslationReference("count")]
+		[FluentReference("count")]
 		const string MapUnavailableCount = "label-map-unavailable-count";
 
-		[TranslationReference("map")]
+		[FluentReference("map")]
 		const string MapDeletionFailed = "notification-map-deletion-failed";
 
-		[TranslationReference]
+		[FluentReference]
 		const string DeleteMapTitle = "dialog-delete-map.title";
 
-		[TranslationReference("title")]
+		[FluentReference("title")]
 		const string DeleteMapPrompt = "dialog-delete-map.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string DeleteMapAccept = "dialog-delete-map.confirm";
 
-		[TranslationReference]
+		[FluentReference]
 		const string DeleteAllMapsTitle = "dialog-delete-all-maps.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string DeleteAllMapsPrompt = "dialog-delete-all-maps.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string DeleteAllMapsAccept = "dialog-delete-all-maps.confirm";
 
-		[TranslationReference]
+		[FluentReference]
 		const string OrderMapsByPlayers = "options-order-maps.player-count";
 
-		[TranslationReference]
+		[FluentReference]
 		const string OrderMapsByTitle = "options-order-maps.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string OrderMapsByDate = "options-order-maps.date";
 
-		[TranslationReference]
+		[FluentReference]
 		const string OrderMapsBySize = "options-order-maps.size";
 
 		readonly string allMaps;
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.onSelect = onSelect;
 			this.remoteMapPool = remoteMapPool;
 
-			allMaps = TranslationProvider.GetString(AllMaps);
+			allMaps = FluentProvider.GetString(AllMaps);
 
 			var approving = new Action(() =>
 			{
@@ -205,9 +205,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var remoteMapText = new CachedTransform<(int Searching, int Unavailable), string>(counts =>
 			{
 				if (counts.Searching > 0)
-					return TranslationProvider.GetString(MapSearchingCount, Translation.Arguments("count", counts.Searching));
+					return FluentProvider.GetString(MapSearchingCount, FluentBundle.Arguments("count", counts.Searching));
 
-				return TranslationProvider.GetString(MapUnavailableCount, Translation.Arguments("count", counts.Unavailable));
+				return FluentProvider.GetString(MapUnavailableCount, FluentBundle.Arguments("count", counts.Unavailable));
 			});
 
 			remoteMapLabel.IsVisible = () => remoteMapPool != null && (remoteSearching > 0 || remoteUnavailable > 0);
@@ -359,7 +359,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					var item = categories.FirstOrDefault(m => m.Category == category);
 					if (item == default((string, int)))
-						item.Category = TranslationProvider.GetString(NoMatches);
+						item.Category = FluentProvider.GetString(NoMatches);
 
 					return ShowItem(item);
 				};
@@ -372,14 +372,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (orderByDropdown == null)
 				return;
 
-			var orderByPlayer = TranslationProvider.GetString(OrderMapsByPlayers);
+			var orderByPlayer = FluentProvider.GetString(OrderMapsByPlayers);
 
 			var orderByDict = new Dictionary<string, Func<MapPreview, long>>()
 			{
 				{ orderByPlayer, m => m.PlayerCount },
-				{ TranslationProvider.GetString(OrderMapsByTitle), null },
-				{ TranslationProvider.GetString(OrderMapsByDate), m => -m.ModifiedDate.Ticks },
-				{ TranslationProvider.GetString(OrderMapsBySize), m => m.Bounds.Width * m.Bounds.Height },
+				{ FluentProvider.GetString(OrderMapsByTitle), null },
+				{ FluentProvider.GetString(OrderMapsByDate), m => -m.ModifiedDate.Ticks },
+				{ FluentProvider.GetString(OrderMapsBySize), m => m.Bounds.Width * m.Bounds.Height },
 			};
 
 			orderByFunc = orderByDict[orderByPlayer];
@@ -458,23 +458,23 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					if (type != null)
 						details = type + " ";
 
-					details += TranslationProvider.GetString(Players, Translation.Arguments("players", preview.PlayerCount));
+					details += FluentProvider.GetString(Players, FluentBundle.Arguments("players", preview.PlayerCount));
 					detailsWidget.GetText = () => details;
 				}
 
 				var authorWidget = item.GetOrNull<LabelWithTooltipWidget>("AUTHOR");
 				if (authorWidget != null && !string.IsNullOrEmpty(preview.Author))
-					WidgetUtils.TruncateLabelToTooltip(authorWidget, TranslationProvider.GetString(CreatedBy, Translation.Arguments("author", preview.Author)));
+					WidgetUtils.TruncateLabelToTooltip(authorWidget, FluentProvider.GetString(CreatedBy, FluentBundle.Arguments("author", preview.Author)));
 
 				var sizeWidget = item.GetOrNull<LabelWidget>("SIZE");
 				if (sizeWidget != null)
 				{
 					var size = preview.Bounds.Width + "x" + preview.Bounds.Height;
 					var numberPlayableCells = preview.Bounds.Width * preview.Bounds.Height;
-					if (numberPlayableCells >= 120 * 120) size += " " + TranslationProvider.GetString(MapSizeHuge);
-					else if (numberPlayableCells >= 90 * 90) size += " " + TranslationProvider.GetString(MapSizeLarge);
-					else if (numberPlayableCells >= 60 * 60) size += " " + TranslationProvider.GetString(MapSizeMedium);
-					else size += " " + TranslationProvider.GetString(MapSizeSmall);
+					if (numberPlayableCells >= 120 * 120) size += " " + FluentProvider.GetString(MapSizeHuge);
+					else if (numberPlayableCells >= 90 * 90) size += " " + FluentProvider.GetString(MapSizeLarge);
+					else if (numberPlayableCells >= 60 * 60) size += " " + FluentProvider.GetString(MapSizeMedium);
+					else size += " " + FluentProvider.GetString(MapSizeSmall);
 					sizeWidget.GetText = () => size;
 				}
 
@@ -502,7 +502,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 			catch (Exception ex)
 			{
-				TextNotificationsManager.Debug(TranslationProvider.GetString(MapDeletionFailed, Translation.Arguments("map", map)));
+				TextNotificationsManager.Debug(FluentProvider.GetString(MapDeletionFailed, FluentBundle.Arguments("map", map)));
 				Log.Write("debug", ex.ToString());
 			}
 
@@ -514,7 +514,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			ConfirmationDialogs.ButtonPrompt(modData,
 				title: DeleteMapTitle,
 				text: DeleteMapPrompt,
-				textArguments: Translation.Arguments("title", modData.MapCache[map].Title),
+				textArguments: FluentBundle.Arguments("title", modData.MapCache[map].Title),
 				onConfirm: () =>
 				{
 					var newUid = DeleteMap(map);

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -27,25 +27,25 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		enum PlayingVideo { None, Info, Briefing, GameStart }
 		enum PanelType { MissionInfo, Options }
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoVideoTitle = "dialog-no-video.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoVideoPrompt = "dialog-no-video.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoVideoCancel = "dialog-no-video.cancel";
 
-		[TranslationReference]
+		[FluentReference]
 		const string CantPlayTitle = "dialog-cant-play-video.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string CantPlayPrompt = "dialog-cant-play-video.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string CantPlayCancel = "dialog-cant-play-video.cancel";
 
-		[TranslationReference]
+		[FluentReference]
 		const string NotAvailable = "label-not-available";
 
 		readonly ModData modData;
@@ -386,7 +386,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					if (option.Values.TryGetValue(missionOptions[option.Id], out var value))
 						return value;
 
-					return TranslationProvider.GetString(NotAvailable);
+					return FluentProvider.GetString(NotAvailable);
 				};
 
 				if (option.Description != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
@@ -18,10 +18,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class MusicPlayerLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string SoundMuted = "label-sound-muted";
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoSongPlaying = "label-no-song-playing";
 
 		readonly ScrollPanelWidget musicList;
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				panel.Get<LabelWidget>("MUTE_LABEL").GetText = () =>
 				{
 					if (Game.Settings.Sound.Mute)
-						return TranslationProvider.GetString(SoundMuted);
+						return FluentProvider.GetString(SoundMuted);
 
 					return "";
 				};
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return $"{minutes:D2}:{seconds:D2} / {totalMinutes:D2}:{totalSeconds:D2}";
 			};
 
-			var noSongPlaying = TranslationProvider.GetString(NoSongPlaying);
+			var noSongPlaying = FluentProvider.GetString(NoSongPlaying);
 			var musicTitle = panel.GetOrNull<LabelWidget>("TITLE_LABEL");
 			if (musicTitle != null)
 				musicTitle.GetText = () => currentSong != null ? currentSong.Title : noSongPlaying;

--- a/OpenRA.Mods.Common/Widgets/Logic/MuteHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MuteHotkeyLogic.cs
@@ -18,10 +18,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	[ChromeLogicArgsHotkeys("MuteAudioKey")]
 	public class MuteHotkeyLogic : SingleHotkeyBaseLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string AudioMuted = "label-audio-muted";
 
-		[TranslationReference]
+		[FluentReference]
 		const string AudioUnmuted = "label-audio-unmuted";
 
 		[ObjectCreator.UseCtor]
@@ -35,12 +35,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (Game.Settings.Sound.Mute)
 			{
 				Game.Sound.MuteAudio();
-				TextNotificationsManager.AddFeedbackLine(TranslationProvider.GetString(AudioMuted));
+				TextNotificationsManager.AddFeedbackLine(FluentProvider.GetString(AudioMuted));
 			}
 			else
 			{
 				Game.Sound.UnmuteAudio();
-				TextNotificationsManager.AddFeedbackLine(TranslationProvider.GetString(AudioUnmuted));
+				TextNotificationsManager.AddFeedbackLine(FluentProvider.GetString(AudioUnmuted));
 			}
 
 			return true;

--- a/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
@@ -128,10 +128,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 	public class RegisteredProfileTooltipLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string LoadingPlayerProfile = "label-loading-player-profile";
 
-		[TranslationReference]
+		[FluentReference]
 		const string LoadingPlayerProfileFailed = "label-loading-player-profile-failed";
 
 		readonly PlayerDatabase playerDatabase;
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var profileWidth = 0;
 			var maxProfileWidth = widget.Bounds.Width;
-			var messageText = TranslationProvider.GetString(LoadingPlayerProfile);
+			var messageText = FluentProvider.GetString(LoadingPlayerProfile);
 			var messageWidth = messageFont.Measure(messageText).X + 2 * message.Bounds.Left;
 
 			Task.Run(async () =>
@@ -247,7 +247,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					if (profile == null)
 					{
-						messageText = TranslationProvider.GetString(LoadingPlayerProfileFailed);
+						messageText = FluentProvider.GetString(LoadingPlayerProfileFailed);
 						messageWidth = messageFont.Measure(messageText).X + 2 * message.Bounds.Left;
 						header.Bounds.Width = widget.Bounds.Width = messageWidth;
 					}
@@ -355,7 +355,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 	public class BotTooltipLogic : ChromeLogic
 	{
-		[TranslationReference("name")]
+		[FluentReference("name")]
 		const string BotManagedBy = "label-bot-managed-by-tooltip";
 
 		[ObjectCreator.UseCtor]
@@ -365,7 +365,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var nameFont = Game.Renderer.Fonts[nameLabel.Font];
 			var controller = orderManager.LobbyInfo.Clients.FirstOrDefault(c => c.Index == client.BotControllerClientIndex);
 			if (controller != null)
-				nameLabel.GetText = () => TranslationProvider.GetString(BotManagedBy, Translation.Arguments("name", controller.Name));
+				nameLabel.GetText = () => FluentProvider.GetString(BotManagedBy, FluentBundle.Arguments("name", controller.Name));
 
 			widget.Bounds.Width = nameFont.Measure(nameLabel.GetText()).X + 2 * nameLabel.Bounds.Left;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
@@ -365,7 +365,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var nameFont = Game.Renderer.Fonts[nameLabel.Font];
 			var controller = orderManager.LobbyInfo.Clients.FirstOrDefault(c => c.Index == client.BotControllerClientIndex);
 			if (controller != null)
-				nameLabel.GetText = () => FluentProvider.GetString(BotManagedBy, FluentBundle.Arguments("name", controller.Name));
+				nameLabel.GetText = () => FluentProvider.GetString(BotManagedBy, "name", controller.Name);
 
 			widget.Bounds.Width = nameFont.Measure(nameLabel.GetText()).X + 2 * nameLabel.Bounds.Left;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -26,82 +26,82 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class ReplayBrowserLogic : ChromeLogic
 	{
-		[TranslationReference("time")]
+		[FluentReference("time")]
 		const string Duration = "label-duration";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Singleplayer = "options-replay-type.singleplayer";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Multiplayer = "options-replay-type.multiplayer";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Today = "options-replay-date.today";
 
-		[TranslationReference]
+		[FluentReference]
 		const string LastWeek = "options-replay-date.last-week";
 
-		[TranslationReference]
+		[FluentReference]
 		const string LastFortnight = "options-replay-date.last-fortnight";
 
-		[TranslationReference]
+		[FluentReference]
 		const string LastMonth = "options-replay-date.last-month";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ReplayDurationVeryShort = "options-replay-duration.very-short";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ReplayDurationShort = "options-replay-duration.short";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ReplayDurationMedium = "options-replay-duration.medium";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ReplayDurationLong = "options-replay-duration.long";
 
-		[TranslationReference]
+		[FluentReference]
 		const string RenameReplayTitle = "dialog-rename-replay.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string RenameReplayPrompt = "dialog-rename-replay.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string RenameReplayAccept = "dialog-rename-replay.confirm";
 
-		[TranslationReference]
+		[FluentReference]
 		const string DeleteReplayTitle = "dialog-delete-replay.title";
 
-		[TranslationReference("replay")]
+		[FluentReference("replay")]
 		const string DeleteReplayPrompt = "dialog-delete-replay.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string DeleteReplayAccept = "dialog-delete-replay.confirm";
 
-		[TranslationReference]
+		[FluentReference]
 		const string DeleteAllReplaysTitle = "dialog-delete-all-replays.title";
 
-		[TranslationReference("count")]
+		[FluentReference("count")]
 		const string DeleteAllReplaysPrompt = "dialog-delete-all-replays.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string DeleteAllReplaysAccept = "dialog-delete-all-replays.confirm";
 
-		[TranslationReference("file")]
+		[FluentReference("file")]
 		const string ReplayDeletionFailed = "notification-replay-deletion-failed";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Players = "label-players";
 
-		[TranslationReference("team")]
+		[FluentReference("team")]
 		const string TeamNumber = "label-team-name";
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoTeam = "label-no-team";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Victory = "options-winstate.victory";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Defeat = "options-winstate.defeat";
 
 		static Filter filter = new();
@@ -182,7 +182,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			});
 
 			var replayDuration = new CachedTransform<ReplayMetadata, string>(r =>
-				TranslationProvider.GetString(Duration, Translation.Arguments("time", WidgetUtils.FormatTimeSeconds((int)selectedReplay.GameInfo.Duration.TotalSeconds))));
+				FluentProvider.GetString(Duration, FluentBundle.Arguments("time", WidgetUtils.FormatTimeSeconds((int)selectedReplay.GameInfo.Duration.TotalSeconds))));
 			panel.Get<LabelWidget>("DURATION").GetText = () => replayDuration.Update(selectedReplay);
 
 			SetupFilters();
@@ -234,8 +234,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var options = new List<(GameType GameType, string Text)>
 					{
 						(GameType.Any, ddb.GetText()),
-						(GameType.Singleplayer, TranslationProvider.GetString(Singleplayer)),
-						(GameType.Multiplayer, TranslationProvider.GetString(Multiplayer))
+						(GameType.Singleplayer, FluentProvider.GetString(Singleplayer)),
+						(GameType.Multiplayer, FluentProvider.GetString(Multiplayer))
 					};
 
 					var lookup = options.ToDictionary(kvp => kvp.GameType, kvp => kvp.Text);
@@ -267,10 +267,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var options = new List<(DateType DateType, string Text)>
 					{
 						(DateType.Any, ddb.GetText()),
-						(DateType.Today, TranslationProvider.GetString(Today)),
-						(DateType.LastWeek, TranslationProvider.GetString(LastWeek)),
-						(DateType.LastFortnight, TranslationProvider.GetString(LastFortnight)),
-						(DateType.LastMonth, TranslationProvider.GetString(LastMonth))
+						(DateType.Today, FluentProvider.GetString(Today)),
+						(DateType.LastWeek, FluentProvider.GetString(LastWeek)),
+						(DateType.LastFortnight, FluentProvider.GetString(LastFortnight)),
+						(DateType.LastMonth, FluentProvider.GetString(LastMonth))
 					};
 
 					var lookup = options.ToDictionary(kvp => kvp.DateType, kvp => kvp.Text);
@@ -303,10 +303,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var options = new List<(DurationType DurationType, string Text)>
 					{
 						(DurationType.Any, ddb.GetText()),
-						(DurationType.VeryShort, TranslationProvider.GetString(ReplayDurationVeryShort)),
-						(DurationType.Short, TranslationProvider.GetString(ReplayDurationShort)),
-						(DurationType.Medium, TranslationProvider.GetString(ReplayDurationMedium)),
-						(DurationType.Long, TranslationProvider.GetString(ReplayDurationLong))
+						(DurationType.VeryShort, FluentProvider.GetString(ReplayDurationVeryShort)),
+						(DurationType.Short, FluentProvider.GetString(ReplayDurationShort)),
+						(DurationType.Medium, FluentProvider.GetString(ReplayDurationMedium)),
+						(DurationType.Long, FluentProvider.GetString(ReplayDurationLong))
 					};
 
 					var lookup = options.ToDictionary(kvp => kvp.DurationType, kvp => kvp.Text);
@@ -340,8 +340,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var options = new List<(WinState WinState, string Text)>
 					{
 						(WinState.Undefined, ddb.GetText()),
-						(WinState.Lost, TranslationProvider.GetString(Defeat)),
-						(WinState.Won, TranslationProvider.GetString(Victory))
+						(WinState.Lost, FluentProvider.GetString(Defeat)),
+						(WinState.Won, FluentProvider.GetString(Victory))
 					};
 
 					var lookup = options.ToDictionary(kvp => kvp.WinState, kvp => kvp.Text);
@@ -446,7 +446,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					options.Insert(0, null); // no filter
 
 					var anyText = ddb.GetText();
-					ddb.GetText = () => string.IsNullOrEmpty(filter.Faction) ? anyText : TranslationProvider.GetString(filter.Faction);
+					ddb.GetText = () => string.IsNullOrEmpty(filter.Faction) ? anyText : FluentProvider.GetString(filter.Faction);
 					ddb.OnMouseDown = _ =>
 					{
 						ScrollItemWidget SetupItem(string option, ScrollItemWidget tpl)
@@ -455,7 +455,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 								tpl,
 								() => string.Equals(filter.Faction, option, StringComparison.CurrentCultureIgnoreCase),
 								() => { filter.Faction = option; ApplyFilter(); });
-							item.Get<LabelWidget>("LABEL").GetText = () => option != null ? TranslationProvider.GetString(option) : anyText;
+							item.Get<LabelWidget>("LABEL").GetText = () => option != null ? FluentProvider.GetString(option) : anyText;
 							return item;
 						}
 
@@ -507,7 +507,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ConfirmationDialogs.ButtonPrompt(modData,
 					title: DeleteReplayTitle,
 					text: DeleteReplayPrompt,
-					textArguments: Translation.Arguments("replay", Path.GetFileNameWithoutExtension(r.FilePath)),
+					textArguments: FluentBundle.Arguments("replay", Path.GetFileNameWithoutExtension(r.FilePath)),
 					onConfirm: () =>
 					{
 						DeleteReplay(r);
@@ -545,7 +545,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ConfirmationDialogs.ButtonPrompt(modData,
 					title: DeleteAllReplaysTitle,
 					text: DeleteAllReplaysPrompt,
-					textArguments: Translation.Arguments("count", list.Count),
+					textArguments: FluentBundle.Arguments("count", list.Count),
 					onConfirm: () =>
 					{
 						foreach (var replayMetadata in list)
@@ -584,7 +584,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 			catch (Exception ex)
 			{
-				TextNotificationsManager.Debug(TranslationProvider.GetString(ReplayDeletionFailed, Translation.Arguments("file", replay.FilePath)));
+				TextNotificationsManager.Debug(FluentProvider.GetString(ReplayDeletionFailed, FluentBundle.Arguments("file", replay.FilePath)));
 				Log.Write("debug", ex.ToString());
 				return;
 			}
@@ -724,9 +724,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var noTeams = players.Count == 1;
 				foreach (var p in players)
 				{
-					var label = noTeams ? TranslationProvider.GetString(Players) : p.Key > 0
-						? TranslationProvider.GetString(TeamNumber, Translation.Arguments("team", p.Key))
-						: TranslationProvider.GetString(NoTeam);
+					var label = noTeams ? FluentProvider.GetString(Players) : p.Key > 0
+						? FluentProvider.GetString(TeamNumber, FluentBundle.Arguments("team", p.Key))
+						: FluentProvider.GetString(NoTeam);
 
 					teams.Add(label, p);
 				}

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -182,7 +182,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			});
 
 			var replayDuration = new CachedTransform<ReplayMetadata, string>(r =>
-				FluentProvider.GetString(Duration, FluentBundle.Arguments("time", WidgetUtils.FormatTimeSeconds((int)selectedReplay.GameInfo.Duration.TotalSeconds))));
+				FluentProvider.GetString(Duration, "time", WidgetUtils.FormatTimeSeconds((int)selectedReplay.GameInfo.Duration.TotalSeconds)));
 			panel.Get<LabelWidget>("DURATION").GetText = () => replayDuration.Update(selectedReplay);
 
 			SetupFilters();
@@ -507,7 +507,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ConfirmationDialogs.ButtonPrompt(modData,
 					title: DeleteReplayTitle,
 					text: DeleteReplayPrompt,
-					textArguments: FluentBundle.Arguments("replay", Path.GetFileNameWithoutExtension(r.FilePath)),
+					textArguments: new object[] { "replay", Path.GetFileNameWithoutExtension(r.FilePath) },
 					onConfirm: () =>
 					{
 						DeleteReplay(r);
@@ -545,7 +545,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ConfirmationDialogs.ButtonPrompt(modData,
 					title: DeleteAllReplaysTitle,
 					text: DeleteAllReplaysPrompt,
-					textArguments: FluentBundle.Arguments("count", list.Count),
+					textArguments: new object[] { "count", list.Count },
 					onConfirm: () =>
 					{
 						foreach (var replayMetadata in list)
@@ -584,7 +584,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 			catch (Exception ex)
 			{
-				TextNotificationsManager.Debug(FluentProvider.GetString(ReplayDeletionFailed, FluentBundle.Arguments("file", replay.FilePath)));
+				TextNotificationsManager.Debug(FluentProvider.GetString(ReplayDeletionFailed, "file", replay.FilePath));
 				Log.Write("debug", ex.ToString());
 				return;
 			}
@@ -725,7 +725,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				foreach (var p in players)
 				{
 					var label = noTeams ? FluentProvider.GetString(Players) : p.Key > 0
-						? FluentProvider.GetString(TeamNumber, FluentBundle.Arguments("team", p.Key))
+						? FluentProvider.GetString(TeamNumber, "team", p.Key)
 						: FluentProvider.GetString(NoTeam);
 
 					teams.Add(label, p);

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using OpenRA.FileFormats;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
@@ -48,32 +47,32 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			onCancel ??= DoNothing;
 
 			if (replayMeta == null)
-				return IncompatibleReplayDialog(IncompatibleReplayPrompt, null, modData, onCancel);
+				return IncompatibleReplayDialog(modData, onCancel, IncompatibleReplayPrompt);
 
 			var version = replayMeta.GameInfo.Version;
 			if (version == null)
-				return IncompatibleReplayDialog(UnknownVersion, null, modData, onCancel);
+				return IncompatibleReplayDialog(modData, onCancel, UnknownVersion);
 
 			var mod = replayMeta.GameInfo.Mod;
 			if (mod == null)
-				return IncompatibleReplayDialog(UnknownMod, null, modData, onCancel);
+				return IncompatibleReplayDialog(modData, onCancel, UnknownMod);
 
 			if (!Game.Mods.ContainsKey(mod))
-				return IncompatibleReplayDialog(UnvailableMod, FluentBundle.Arguments("mod", mod), modData, onCancel);
+				return IncompatibleReplayDialog(modData, onCancel, UnvailableMod, "mod", mod);
 
 			if (Game.Mods[mod].Metadata.Version != version)
-				return IncompatibleReplayDialog(IncompatibleVersion, FluentBundle.Arguments("version", version), modData, onCancel);
+				return IncompatibleReplayDialog(modData, onCancel, IncompatibleVersion, "version", version);
 
 			if (replayMeta.GameInfo.MapPreview.Status != MapStatus.Available)
-				return IncompatibleReplayDialog(UnvailableMap, FluentBundle.Arguments("map", replayMeta.GameInfo.MapUid), modData, onCancel);
+				return IncompatibleReplayDialog(modData, onCancel, UnvailableMap, "map", replayMeta.GameInfo.MapUid);
 
 			return true;
 		}
 
-		static bool IncompatibleReplayDialog(string text, Dictionary<string, object> textArguments, ModData modData, Action onCancel)
+		static bool IncompatibleReplayDialog(ModData modData, Action onCancel, string text, params object[] args)
 		{
 			ConfirmationDialogs.ButtonPrompt(
-				modData, IncompatibleReplayTitle, text, textArguments: textArguments, onCancel: onCancel, cancelText: IncompatibleReplayAccept);
+				modData, IncompatibleReplayTitle, text, textArguments: args, onCancel: onCancel, cancelText: IncompatibleReplayAccept);
 			return false;
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
@@ -17,28 +17,28 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public static class ReplayUtils
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string IncompatibleReplayTitle = "dialog-incompatible-replay.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string IncompatibleReplayPrompt = "dialog-incompatible-replay.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string IncompatibleReplayAccept = "dialog-incompatible-replay.confirm";
 
-		[TranslationReference]
+		[FluentReference]
 		const string UnknownVersion = "dialog-incompatible-replay.prompt-unknown-version";
 
-		[TranslationReference]
+		[FluentReference]
 		const string UnknownMod = "dialog-incompatible-replay.prompt-unknown-mod";
 
-		[TranslationReference("mod")]
+		[FluentReference("mod")]
 		const string UnvailableMod = "dialog-incompatible-replay.prompt-unavailable-mod";
 
-		[TranslationReference("version")]
+		[FluentReference("version")]
 		const string IncompatibleVersion = "dialog-incompatible-replay.prompt-incompatible-version";
 
-		[TranslationReference("map")]
+		[FluentReference("map")]
 		const string UnvailableMap = "dialog-incompatible-replay.prompt-unavailable-map";
 
 		static readonly Action DoNothing = () => { };
@@ -59,13 +59,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return IncompatibleReplayDialog(UnknownMod, null, modData, onCancel);
 
 			if (!Game.Mods.ContainsKey(mod))
-				return IncompatibleReplayDialog(UnvailableMod, Translation.Arguments("mod", mod), modData, onCancel);
+				return IncompatibleReplayDialog(UnvailableMod, FluentBundle.Arguments("mod", mod), modData, onCancel);
 
 			if (Game.Mods[mod].Metadata.Version != version)
-				return IncompatibleReplayDialog(IncompatibleVersion, Translation.Arguments("version", version), modData, onCancel);
+				return IncompatibleReplayDialog(IncompatibleVersion, FluentBundle.Arguments("version", version), modData, onCancel);
 
 			if (replayMeta.GameInfo.MapPreview.Status != MapStatus.Available)
-				return IncompatibleReplayDialog(UnvailableMap, Translation.Arguments("map", replayMeta.GameInfo.MapUid), modData, onCancel);
+				return IncompatibleReplayDialog(UnvailableMap, FluentBundle.Arguments("map", replayMeta.GameInfo.MapUid), modData, onCancel);
 
 			return true;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -19,37 +19,37 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class ServerCreationLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string InternetServerNatA = "label-internet-server-nat-A";
 
-		[TranslationReference]
+		[FluentReference]
 		const string InternetServerNatBenabled = "label-internet-server-nat-B-enabled";
 
-		[TranslationReference]
+		[FluentReference]
 		const string InternetServerNatBnotSupported = "label-internet-server-nat-B-not-supported";
 
-		[TranslationReference]
+		[FluentReference]
 		const string InternetServerNatBdisabled = "label-internet-server-nat-B-disabled";
 
-		[TranslationReference]
+		[FluentReference]
 		const string InternetServerNatC = "label-internet-server-nat-C";
 
-		[TranslationReference]
+		[FluentReference]
 		const string LocalServer = "label-local-server";
 
-		[TranslationReference("port")]
+		[FluentReference("port")]
 		const string ServerCreationFailedPrompt = "dialog-server-creation-failed.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ServerCreationFailedPortUsed = "dialog-server-creation-failed.prompt-port-used";
 
-		[TranslationReference("message", "code")]
+		[FluentReference("message", "code")]
 		const string ServerCreationFailedError = "dialog-server-creation-failed.prompt-error";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ServerCreationFailedTitle = "dialog-server-creation-failed.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ServerCreationFailedCancel = "dialog-server-creation-failed.cancel";
 
 		readonly Widget panel;
@@ -170,15 +170,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			if (advertiseOnline)
 			{
-				var noticesLabelAText = TranslationProvider.GetString(InternetServerNatA) + " ";
+				var noticesLabelAText = FluentProvider.GetString(InternetServerNatA) + " ";
 				noticesLabelA.GetText = () => noticesLabelAText;
 				var aWidth = Game.Renderer.Fonts[noticesLabelA.Font].Measure(noticesLabelAText).X;
 				noticesLabelA.Bounds.Width = aWidth;
 
 				var noticesLabelBText =
-					Nat.Status == NatStatus.Enabled ? TranslationProvider.GetString(InternetServerNatBenabled) :
-					Nat.Status == NatStatus.NotSupported ? TranslationProvider.GetString(InternetServerNatBnotSupported) :
-					TranslationProvider.GetString(InternetServerNatBdisabled);
+					Nat.Status == NatStatus.Enabled ? FluentProvider.GetString(InternetServerNatBenabled) :
+					Nat.Status == NatStatus.NotSupported ? FluentProvider.GetString(InternetServerNatBnotSupported) :
+					FluentProvider.GetString(InternetServerNatBdisabled);
 				noticesLabelB.GetText = () => noticesLabelBText;
 
 				noticesLabelB.TextColor =
@@ -191,14 +191,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				noticesLabelB.Bounds.Width = bWidth;
 				noticesLabelB.Visible = true;
 
-				var noticesLabelCText = TranslationProvider.GetString(InternetServerNatC);
+				var noticesLabelCText = FluentProvider.GetString(InternetServerNatC);
 				noticesLabelC.GetText = () => noticesLabelCText;
 				noticesLabelC.Bounds.X = noticesLabelB.Bounds.Right;
 				noticesLabelC.Visible = true;
 			}
 			else
 			{
-				var noticesLabelAText = TranslationProvider.GetString(LocalServer);
+				var noticesLabelAText = FluentProvider.GetString(LocalServer);
 				noticesLabelA.GetText = () => noticesLabelAText;
 				noticesLabelB.Visible = false;
 				noticesLabelC.Visible = false;
@@ -239,14 +239,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 			catch (System.Net.Sockets.SocketException e)
 			{
-				var message = TranslationProvider.GetString(ServerCreationFailedPrompt, Translation.Arguments("port", Game.Settings.Server.ListenPort));
+				var message = FluentProvider.GetString(ServerCreationFailedPrompt, FluentBundle.Arguments("port", Game.Settings.Server.ListenPort));
 
 				// AddressAlreadyInUse (WSAEADDRINUSE)
 				if (e.ErrorCode == 10048)
-					message += "\n" + TranslationProvider.GetString(ServerCreationFailedPortUsed);
+					message += "\n" + FluentProvider.GetString(ServerCreationFailedPortUsed);
 				else
-					message += "\n" + TranslationProvider.GetString(ServerCreationFailedError,
-						Translation.Arguments("message", e.Message, "code", e.ErrorCode));
+					message += "\n" + FluentProvider.GetString(ServerCreationFailedError,
+						FluentBundle.Arguments("message", e.Message, "code", e.ErrorCode));
 
 				ConfirmationDialogs.ButtonPrompt(modData, ServerCreationFailedTitle, message,
 					onCancel: () => { }, cancelText: ServerCreationFailedCancel);

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -239,14 +239,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 			catch (System.Net.Sockets.SocketException e)
 			{
-				var message = FluentProvider.GetString(ServerCreationFailedPrompt, FluentBundle.Arguments("port", Game.Settings.Server.ListenPort));
+				var message = FluentProvider.GetString(ServerCreationFailedPrompt, "port", Game.Settings.Server.ListenPort);
 
 				// AddressAlreadyInUse (WSAEADDRINUSE)
 				if (e.ErrorCode == 10048)
 					message += "\n" + FluentProvider.GetString(ServerCreationFailedPortUsed);
 				else
-					message += "\n" + FluentProvider.GetString(ServerCreationFailedError,
-						FluentBundle.Arguments("message", e.Message, "code", e.ErrorCode));
+					message += "\n" + FluentProvider.GetString(ServerCreationFailedError, "message", e.Message, "code", e.ErrorCode);
 
 				ConfirmationDialogs.ButtonPrompt(modData, ServerCreationFailedTitle, message,
 					onCancel: () => { }, cancelText: ServerCreationFailedCancel);

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -164,11 +164,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			mapStatusSearching = FluentProvider.GetString(MapStatusSearching);
 			mapClassificationUnknown = FluentProvider.GetString(MapClassificationUnknown);
 
-			players = new CachedTransform<int, string>(i => FluentProvider.GetString(PlayersLabel, FluentBundle.Arguments("players", i)));
-			bots = new CachedTransform<int, string>(i => FluentProvider.GetString(BotsLabel, FluentBundle.Arguments("bots", i)));
-			spectators = new CachedTransform<int, string>(i => FluentProvider.GetString(SpectatorsLabel, FluentBundle.Arguments("spectators", i)));
+			players = new CachedTransform<int, string>(i => FluentProvider.GetString(PlayersLabel, "players", i));
+			bots = new CachedTransform<int, string>(i => FluentProvider.GetString(BotsLabel, "bots", i));
+			spectators = new CachedTransform<int, string>(i => FluentProvider.GetString(SpectatorsLabel, "spectators", i));
 
-			minutes = new CachedTransform<double, string>(i => FluentProvider.GetString(InProgress, FluentBundle.Arguments("minutes", i)));
+			minutes = new CachedTransform<double, string>(i => FluentProvider.GetString(InProgress, "minutes", i));
 			passwordProtected = FluentProvider.GetString(PasswordProtected);
 			waitingForPlayers = FluentProvider.GetString(WaitingForPlayers);
 			serverShuttingDown = FluentProvider.GetString(ServerShuttingDown);
@@ -318,7 +318,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var playersLabel = widget.GetOrNull<LabelWidget>("PLAYER_COUNT");
 			if (playersLabel != null)
 			{
-				var playersText = new CachedTransform<int, string>(p => FluentProvider.GetString(PlayersOnline, FluentBundle.Arguments("players", p)));
+				var playersText = new CachedTransform<int, string>(p => FluentProvider.GetString(PlayersOnline, "players", p));
 				playersLabel.IsVisible = () => playerCount != 0;
 				playersLabel.GetText = () => playersText.Update(playerCount);
 			}
@@ -582,7 +582,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			foreach (var p in players)
 			{
 				var label = noTeams ? FluentProvider.GetString(Players) : p.Key > 0
-					? FluentProvider.GetString(TeamNumber, FluentBundle.Arguments("team", p.Key))
+					? FluentProvider.GetString(TeamNumber, "team", p.Key)
 					: FluentProvider.GetString(NoTeam);
 				teams.Add(label, p);
 			}
@@ -765,7 +765,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 								if (game.Clients.Length > 10)
 									displayClients = displayClients
 										.Take(9)
-										.Append(FluentProvider.GetString(OtherPlayers, FluentBundle.Arguments("players", game.Clients.Length - 9)));
+										.Append(FluentProvider.GetString(OtherPlayers, "players", game.Clients.Length - 9));
 
 								var tooltip = displayClients.JoinWith("\n");
 								players.GetTooltipText = () => tooltip;

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -25,67 +25,67 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class ServerListLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string SearchStatusFailed = "label-search-status-failed";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SearchStatusNoGames = "label-search-status-no-games";
 
-		[TranslationReference("players")]
+		[FluentReference("players")]
 		const string PlayersOnline = "label-players-online-count";
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoServerSelected = "label-no-server-selected";
 
-		[TranslationReference]
+		[FluentReference]
 		const string MapStatusSearching = "label-map-status-searching";
 
-		[TranslationReference]
+		[FluentReference]
 		const string MapClassificationUnknown = "label-map-classification-unknown";
 
-		[TranslationReference("players")]
+		[FluentReference("players")]
 		const string PlayersLabel = "label-players-count";
 
-		[TranslationReference("bots")]
+		[FluentReference("bots")]
 		const string BotsLabel = "label-bots-count";
 
-		[TranslationReference("spectators")]
+		[FluentReference("spectators")]
 		const string SpectatorsLabel = "label-spectators-count";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Players = "label-players";
 
-		[TranslationReference("team")]
+		[FluentReference("team")]
 		const string TeamNumber = "label-team-name";
 
-		[TranslationReference]
+		[FluentReference]
 		const string NoTeam = "label-no-team";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Spectators = "label-spectators";
 
-		[TranslationReference("players")]
+		[FluentReference("players")]
 		const string OtherPlayers = "label-other-players-count";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Playing = "label-playing";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Waiting = "label-waiting";
 
-		[TranslationReference("minutes")]
+		[FluentReference("minutes")]
 		const string InProgress = "label-in-progress-for";
 
-		[TranslationReference]
+		[FluentReference]
 		const string PasswordProtected = "label-password-protected";
 
-		[TranslationReference]
+		[FluentReference]
 		const string WaitingForPlayers = "label-waiting-for-players";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ServerShuttingDown = "label-server-shutting-down";
 
-		[TranslationReference]
+		[FluentReference]
 		const string UnknownServerState = "label-unknown-server-state";
 
 		readonly string noServerSelected;
@@ -145,8 +145,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			switch (searchStatus)
 			{
-				case SearchStatus.Failed: return TranslationProvider.GetString(SearchStatusFailed);
-				case SearchStatus.NoGames: return TranslationProvider.GetString(SearchStatusNoGames);
+				case SearchStatus.Failed: return FluentProvider.GetString(SearchStatusFailed);
+				case SearchStatus.NoGames: return FluentProvider.GetString(SearchStatusNoGames);
 				default: return "";
 			}
 		}
@@ -157,22 +157,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.modData = modData;
 			this.onJoin = onJoin;
 
-			playing = TranslationProvider.GetString(Playing);
-			waiting = TranslationProvider.GetString(Waiting);
+			playing = FluentProvider.GetString(Playing);
+			waiting = FluentProvider.GetString(Waiting);
 
-			noServerSelected = TranslationProvider.GetString(NoServerSelected);
-			mapStatusSearching = TranslationProvider.GetString(MapStatusSearching);
-			mapClassificationUnknown = TranslationProvider.GetString(MapClassificationUnknown);
+			noServerSelected = FluentProvider.GetString(NoServerSelected);
+			mapStatusSearching = FluentProvider.GetString(MapStatusSearching);
+			mapClassificationUnknown = FluentProvider.GetString(MapClassificationUnknown);
 
-			players = new CachedTransform<int, string>(i => TranslationProvider.GetString(PlayersLabel, Translation.Arguments("players", i)));
-			bots = new CachedTransform<int, string>(i => TranslationProvider.GetString(BotsLabel, Translation.Arguments("bots", i)));
-			spectators = new CachedTransform<int, string>(i => TranslationProvider.GetString(SpectatorsLabel, Translation.Arguments("spectators", i)));
+			players = new CachedTransform<int, string>(i => FluentProvider.GetString(PlayersLabel, FluentBundle.Arguments("players", i)));
+			bots = new CachedTransform<int, string>(i => FluentProvider.GetString(BotsLabel, FluentBundle.Arguments("bots", i)));
+			spectators = new CachedTransform<int, string>(i => FluentProvider.GetString(SpectatorsLabel, FluentBundle.Arguments("spectators", i)));
 
-			minutes = new CachedTransform<double, string>(i => TranslationProvider.GetString(InProgress, Translation.Arguments("minutes", i)));
-			passwordProtected = TranslationProvider.GetString(PasswordProtected);
-			waitingForPlayers = TranslationProvider.GetString(WaitingForPlayers);
-			serverShuttingDown = TranslationProvider.GetString(ServerShuttingDown);
-			unknownServerState = TranslationProvider.GetString(UnknownServerState);
+			minutes = new CachedTransform<double, string>(i => FluentProvider.GetString(InProgress, FluentBundle.Arguments("minutes", i)));
+			passwordProtected = FluentProvider.GetString(PasswordProtected);
+			waitingForPlayers = FluentProvider.GetString(WaitingForPlayers);
+			serverShuttingDown = FluentProvider.GetString(ServerShuttingDown);
+			unknownServerState = FluentProvider.GetString(UnknownServerState);
 
 			services = modData.Manifest.Get<WebServices>();
 
@@ -318,7 +318,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var playersLabel = widget.GetOrNull<LabelWidget>("PLAYER_COUNT");
 			if (playersLabel != null)
 			{
-				var playersText = new CachedTransform<int, string>(p => TranslationProvider.GetString(PlayersOnline, Translation.Arguments("players", p)));
+				var playersText = new CachedTransform<int, string>(p => FluentProvider.GetString(PlayersOnline, FluentBundle.Arguments("players", p)));
 				playersLabel.IsVisible = () => playerCount != 0;
 				playersLabel.GetText = () => playersText.Update(playerCount);
 			}
@@ -581,14 +581,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var noTeams = players.Count == 1;
 			foreach (var p in players)
 			{
-				var label = noTeams ? TranslationProvider.GetString(Players) : p.Key > 0
-					? TranslationProvider.GetString(TeamNumber, Translation.Arguments("team", p.Key))
-					: TranslationProvider.GetString(NoTeam);
+				var label = noTeams ? FluentProvider.GetString(Players) : p.Key > 0
+					? FluentProvider.GetString(TeamNumber, FluentBundle.Arguments("team", p.Key))
+					: FluentProvider.GetString(NoTeam);
 				teams.Add(label, p);
 			}
 
 			if (server.Clients.Any(c => c.IsSpectator))
-				teams.Add(TranslationProvider.GetString(Spectators), server.Clients.Where(c => c.IsSpectator));
+				teams.Add(FluentProvider.GetString(Spectators), server.Clients.Where(c => c.IsSpectator));
 
 			var factionInfo = modData.DefaultRules.Actors[SystemActors.World].TraitInfos<FactionInfo>();
 			foreach (var kv in teams)
@@ -765,7 +765,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 								if (game.Clients.Length > 10)
 									displayClients = displayClients
 										.Take(9)
-										.Append(TranslationProvider.GetString(OtherPlayers, Translation.Arguments("players", game.Clients.Length - 9)));
+										.Append(FluentProvider.GetString(OtherPlayers, FluentBundle.Arguments("players", game.Clients.Length - 9)));
 
 								var tooltip = displayClients.JoinWith("\n");
 								players.GetTooltipText = () => tooltip;

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -23,49 +23,49 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class DisplaySettingsLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string Close = "options-camera.close";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Medium = "options-camera.medium";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Far = "options-camera.far";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Furthest = "options-camera.furthest";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Windowed = "options-display-mode.windowed";
 
-		[TranslationReference]
+		[FluentReference]
 		const string LegacyFullscreen = "options-display-mode.legacy-fullscreen";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Fullscreen = "options-display-mode.fullscreen";
 
-		[TranslationReference("number")]
+		[FluentReference("number")]
 		const string Display = "label-video-display-index";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Standard = "options-status-bars.standard";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ShowOnDamage = "options-status-bars.show-on-damage";
 
-		[TranslationReference]
+		[FluentReference]
 		const string AlwaysShow = "options-status-bars.always-show";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Automatic = "options-target-lines.automatic";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Manual = "options-target-lines.manual";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Disabled = "options-target-lines.disabled";
 
-		[TranslationReference("fps")]
+		[FluentReference("fps")]
 		const string FrameLimiter = "checkbox-frame-limiter";
 		static readonly int OriginalVideoDisplay;
 		static readonly WindowMode OriginalGraphicsMode;
@@ -106,17 +106,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.modData = modData;
 			viewportSizes = modData.Manifest.Get<WorldViewportSizes>();
 
-			legacyFullscreen = TranslationProvider.GetString(LegacyFullscreen);
-			fullscreen = TranslationProvider.GetString(Fullscreen);
+			legacyFullscreen = FluentProvider.GetString(LegacyFullscreen);
+			fullscreen = FluentProvider.GetString(Fullscreen);
 
 			registerPanel(panelID, label, InitPanel, ResetPanel);
 
-			showOnDamage = TranslationProvider.GetString(ShowOnDamage);
-			alwaysShow = TranslationProvider.GetString(AlwaysShow);
+			showOnDamage = FluentProvider.GetString(ShowOnDamage);
+			alwaysShow = FluentProvider.GetString(AlwaysShow);
 
-			automatic = TranslationProvider.GetString(Automatic);
-			manual = TranslationProvider.GetString(Manual);
-			disabled = TranslationProvider.GetString(Disabled);
+			automatic = FluentProvider.GetString(Automatic);
+			manual = FluentProvider.GetString(Manual);
+			disabled = FluentProvider.GetString(Disabled);
 		}
 
 		public static string GetViewportSizeName(ModData modData, WorldViewport worldViewport)
@@ -124,13 +124,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			switch (worldViewport)
 			{
 				case WorldViewport.Close:
-					return TranslationProvider.GetString(Close);
+					return FluentProvider.GetString(Close);
 				case WorldViewport.Medium:
-					return TranslationProvider.GetString(Medium);
+					return FluentProvider.GetString(Medium);
 				case WorldViewport.Far:
-					return TranslationProvider.GetString(Far);
+					return FluentProvider.GetString(Far);
 				case WorldViewport.Native:
-					return TranslationProvider.GetString(Furthest);
+					return FluentProvider.GetString(Furthest);
 				default:
 					return "";
 			}
@@ -166,12 +166,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var windowModeDropdown = panel.Get<DropDownButtonWidget>("MODE_DROPDOWN");
 			windowModeDropdown.OnMouseDown = _ => ShowWindowModeDropdown(windowModeDropdown, ds, scrollPanel);
 			windowModeDropdown.GetText = () => ds.Mode == WindowMode.Windowed
-				? TranslationProvider.GetString(Windowed)
+				? FluentProvider.GetString(Windowed)
 				: ds.Mode == WindowMode.Fullscreen ? legacyFullscreen : fullscreen;
 
 			var displaySelectionDropDown = panel.Get<DropDownButtonWidget>("DISPLAY_SELECTION_DROPDOWN");
 			displaySelectionDropDown.OnMouseDown = _ => ShowDisplaySelectionDropdown(displaySelectionDropDown, ds);
-			var displaySelectionLabel = new CachedTransform<int, string>(i => TranslationProvider.GetString(Display, Translation.Arguments("number", i + 1)));
+			var displaySelectionLabel = new CachedTransform<int, string>(i => FluentProvider.GetString(Display, FluentBundle.Arguments("number", i + 1)));
 			displaySelectionDropDown.GetText = () => displaySelectionLabel.Update(ds.VideoDisplay);
 			displaySelectionDropDown.IsDisabled = () => Game.Renderer.DisplayCount < 2;
 
@@ -185,7 +185,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var statusBarsDropDown = panel.Get<DropDownButtonWidget>("STATUS_BAR_DROPDOWN");
 			statusBarsDropDown.OnMouseDown = _ => ShowStatusBarsDropdown(statusBarsDropDown, gs);
 			statusBarsDropDown.GetText = () => gs.StatusBars == StatusBarsType.Standard
-				? TranslationProvider.GetString(Standard)
+				? FluentProvider.GetString(Standard)
 				: gs.StatusBars == StatusBarsType.DamageShow
 					? showOnDamage
 					: alwaysShow;
@@ -242,7 +242,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var frameLimitGamespeedCheckbox = panel.Get<CheckboxWidget>("FRAME_LIMIT_GAMESPEED_CHECKBOX");
 			var frameLimitCheckbox = panel.Get<CheckboxWidget>("FRAME_LIMIT_CHECKBOX");
-			var frameLimitLabel = new CachedTransform<int, string>(fps => TranslationProvider.GetString(FrameLimiter, Translation.Arguments("fps", fps)));
+			var frameLimitLabel = new CachedTransform<int, string>(fps => FluentProvider.GetString(FrameLimiter, FluentBundle.Arguments("fps", fps)));
 			frameLimitCheckbox.GetText = () => frameLimitLabel.Update(ds.MaxFramerate);
 			frameLimitCheckbox.IsDisabled = () => ds.CapFramerateToGameFps;
 
@@ -350,9 +350,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var options = new Dictionary<string, WindowMode>()
 			{
-				{ TranslationProvider.GetString(Fullscreen), WindowMode.PseudoFullscreen },
-				{ TranslationProvider.GetString(LegacyFullscreen), WindowMode.Fullscreen },
-				{ TranslationProvider.GetString(Windowed), WindowMode.Windowed },
+				{ FluentProvider.GetString(Fullscreen), WindowMode.PseudoFullscreen },
+				{ FluentProvider.GetString(LegacyFullscreen), WindowMode.Fullscreen },
+				{ FluentProvider.GetString(Windowed), WindowMode.Windowed },
 			};
 
 			ScrollItemWidget SetupItem(string o, ScrollItemWidget itemTemplate)
@@ -399,9 +399,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var options = new Dictionary<string, StatusBarsType>()
 			{
-				{ TranslationProvider.GetString(Standard), StatusBarsType.Standard },
-				{ TranslationProvider.GetString(ShowOnDamage), StatusBarsType.DamageShow },
-				{ TranslationProvider.GetString(AlwaysShow), StatusBarsType.AlwaysShow },
+				{ FluentProvider.GetString(Standard), StatusBarsType.Standard },
+				{ FluentProvider.GetString(ShowOnDamage), StatusBarsType.DamageShow },
+				{ FluentProvider.GetString(AlwaysShow), StatusBarsType.AlwaysShow },
 			};
 
 			ScrollItemWidget SetupItem(string o, ScrollItemWidget itemTemplate)
@@ -454,9 +454,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var options = new Dictionary<string, TargetLinesType>()
 			{
-				{ TranslationProvider.GetString(Automatic), TargetLinesType.Automatic },
-				{ TranslationProvider.GetString(Manual), TargetLinesType.Manual },
-				{ TranslationProvider.GetString(Disabled), TargetLinesType.Disabled },
+				{ FluentProvider.GetString(Automatic), TargetLinesType.Automatic },
+				{ FluentProvider.GetString(Manual), TargetLinesType.Manual },
+				{ FluentProvider.GetString(Disabled), TargetLinesType.Disabled },
 			};
 
 			ScrollItemWidget SetupItem(string o, ScrollItemWidget itemTemplate)

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -171,7 +171,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var displaySelectionDropDown = panel.Get<DropDownButtonWidget>("DISPLAY_SELECTION_DROPDOWN");
 			displaySelectionDropDown.OnMouseDown = _ => ShowDisplaySelectionDropdown(displaySelectionDropDown, ds);
-			var displaySelectionLabel = new CachedTransform<int, string>(i => FluentProvider.GetString(Display, FluentBundle.Arguments("number", i + 1)));
+			var displaySelectionLabel = new CachedTransform<int, string>(i => FluentProvider.GetString(Display, "number", i + 1));
 			displaySelectionDropDown.GetText = () => displaySelectionLabel.Update(ds.VideoDisplay);
 			displaySelectionDropDown.IsDisabled = () => Game.Renderer.DisplayCount < 2;
 
@@ -242,7 +242,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var frameLimitGamespeedCheckbox = panel.Get<CheckboxWidget>("FRAME_LIMIT_GAMESPEED_CHECKBOX");
 			var frameLimitCheckbox = panel.Get<CheckboxWidget>("FRAME_LIMIT_CHECKBOX");
-			var frameLimitLabel = new CachedTransform<int, string>(fps => FluentProvider.GetString(FrameLimiter, FluentBundle.Arguments("fps", fps)));
+			var frameLimitLabel = new CachedTransform<int, string>(fps => FluentProvider.GetString(FrameLimiter, "fps", fps));
 			frameLimitCheckbox.GetText = () => frameLimitLabel.Update(ds.MaxFramerate);
 			frameLimitCheckbox.IsDisabled = () => ds.CapFramerateToGameFps;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
@@ -19,10 +19,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class HotkeysSettingsLogic : ChromeLogic
 	{
-		[TranslationReference("key")]
+		[FluentReference("key")]
 		const string OriginalNotice = "label-original-notice";
 
-		[TranslationReference("key", "context")]
+		[FluentReference("key", "context")]
 		const string DuplicateNotice = "label-duplicate-notice";
 
 		readonly ModData modData;
@@ -229,7 +229,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			duplicateNotice.IsVisible = () => !isHotkeyValid;
 			var duplicateNoticeText = new CachedTransform<HotkeyDefinition, string>(hd =>
 				hd != null ?
-				TranslationProvider.GetString(DuplicateNotice, Translation.Arguments("key", hd.Description,
+				FluentProvider.GetString(DuplicateNotice, FluentBundle.Arguments("key", hd.Description,
 					"context", hd.Contexts.First(c => selectedHotkeyDefinition.Contexts.Contains(c)))) :
 				"");
 			duplicateNotice.GetText = () => duplicateNoticeText.Update(duplicateHotkeyDefinition);
@@ -238,7 +238,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			originalNotice.TextColor = ChromeMetrics.Get<Color>("NoticeInfoColor");
 			originalNotice.IsVisible = () => isHotkeyValid && !isHotkeyDefault;
 			var originalNoticeText = new CachedTransform<HotkeyDefinition, string>(hd =>
-				TranslationProvider.GetString(OriginalNotice, Translation.Arguments("key", hd?.Default.DisplayString())));
+				FluentProvider.GetString(OriginalNotice, FluentBundle.Arguments("key", hd?.Default.DisplayString())));
 			originalNotice.GetText = () => originalNoticeText.Update(selectedHotkeyDefinition);
 
 			var readonlyNotice = panel.Get<LabelWidget>("READONLY_NOTICE");

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
@@ -229,16 +229,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			duplicateNotice.IsVisible = () => !isHotkeyValid;
 			var duplicateNoticeText = new CachedTransform<HotkeyDefinition, string>(hd =>
 				hd != null ?
-				FluentProvider.GetString(DuplicateNotice, FluentBundle.Arguments("key", hd.Description,
-					"context", hd.Contexts.First(c => selectedHotkeyDefinition.Contexts.Contains(c)))) :
-				"");
+				FluentProvider.GetString(DuplicateNotice,
+					"key", hd.Description,
+					"context", hd.Contexts.First(c => selectedHotkeyDefinition.Contexts.Contains(c))) : "");
 			duplicateNotice.GetText = () => duplicateNoticeText.Update(duplicateHotkeyDefinition);
 
 			var originalNotice = panel.Get<LabelWidget>("ORIGINAL_NOTICE");
 			originalNotice.TextColor = ChromeMetrics.Get<Color>("NoticeInfoColor");
 			originalNotice.IsVisible = () => isHotkeyValid && !isHotkeyDefault;
 			var originalNoticeText = new CachedTransform<HotkeyDefinition, string>(hd =>
-				FluentProvider.GetString(OriginalNotice, FluentBundle.Arguments("key", hd?.Default.DisplayString())));
+				FluentProvider.GetString(OriginalNotice, "key", hd?.Default.DisplayString()));
 			originalNotice.GetText = () => originalNoticeText.Update(selectedHotkeyDefinition);
 
 			var readonlyNotice = panel.Get<LabelWidget>("READONLY_NOTICE");

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/InputSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/InputSettingsLogic.cs
@@ -18,37 +18,37 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class InputSettingsLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string Classic = "options-control-scheme.classic";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Modern = "options-control-scheme.modern";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Disabled = "options-mouse-scroll-type.disabled";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Standard = "options-mouse-scroll-type.standard";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Inverted = "options-mouse-scroll-type.inverted";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Joystick = "options-mouse-scroll-type.joystick";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Alt = "options-zoom-modifier.alt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Ctrl = "options-zoom-modifier.ctrl";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Meta = "options-zoom-modifier.meta";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Shift = "options-zoom-modifier.shift";
 
-		[TranslationReference]
+		[FluentReference]
 		const string None = "options-zoom-modifier.none";
 
 		static InputSettingsLogic() { }
@@ -59,8 +59,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[ObjectCreator.UseCtor]
 		public InputSettingsLogic(Action<string, string, Func<Widget, Func<bool>>, Func<Widget, Action>> registerPanel, string panelID, string label)
 		{
-			classic = TranslationProvider.GetString(Classic);
-			modern = TranslationProvider.GetString(Modern);
+			classic = FluentProvider.GetString(Classic);
+			modern = FluentProvider.GetString(Modern);
 
 			registerPanel(panelID, label, InitPanel, ResetPanel);
 		}
@@ -163,8 +163,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var options = new Dictionary<string, bool>()
 			{
-				{ TranslationProvider.GetString(Classic), true },
-				{ TranslationProvider.GetString(Modern), false },
+				{ FluentProvider.GetString(Classic), true },
+				{ FluentProvider.GetString(Modern), false },
 			};
 
 			ScrollItemWidget SetupItem(string o, ScrollItemWidget itemTemplate)
@@ -183,10 +183,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var options = new Dictionary<string, MouseScrollType>()
 			{
-				{ TranslationProvider.GetString(Disabled), MouseScrollType.Disabled },
-				{ TranslationProvider.GetString(Standard), MouseScrollType.Standard },
-				{ TranslationProvider.GetString(Inverted), MouseScrollType.Inverted },
-				{ TranslationProvider.GetString(Joystick), MouseScrollType.Joystick },
+				{ FluentProvider.GetString(Disabled), MouseScrollType.Disabled },
+				{ FluentProvider.GetString(Standard), MouseScrollType.Standard },
+				{ FluentProvider.GetString(Inverted), MouseScrollType.Inverted },
+				{ FluentProvider.GetString(Joystick), MouseScrollType.Joystick },
 			};
 
 			ScrollItemWidget SetupItem(string o, ScrollItemWidget itemTemplate)
@@ -205,11 +205,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var options = new Dictionary<string, Modifiers>()
 			{
-				{ TranslationProvider.GetString(Alt), Modifiers.Alt },
-				{ TranslationProvider.GetString(Ctrl), Modifiers.Ctrl },
-				{ TranslationProvider.GetString(Meta), Modifiers.Meta },
-				{ TranslationProvider.GetString(Shift), Modifiers.Shift },
-				{ TranslationProvider.GetString(None), Modifiers.None }
+				{ FluentProvider.GetString(Alt), Modifiers.Alt },
+				{ FluentProvider.GetString(Ctrl), Modifiers.Ctrl },
+				{ FluentProvider.GetString(Meta), Modifiers.Meta },
+				{ FluentProvider.GetString(Shift), Modifiers.Shift },
+				{ FluentProvider.GetString(None), Modifiers.None }
 			};
 
 			ScrollItemWidget SetupItem(string o, ScrollItemWidget itemTemplate)

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
@@ -19,37 +19,37 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class SettingsLogic : ChromeLogic
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string SettingsSaveTitle = "dialog-settings-save.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SettingsSavePrompt = "dialog-settings-save.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string SettingsSaveCancel = "dialog-settings-save.cancel";
 
-		[TranslationReference]
+		[FluentReference]
 		const string RestartTitle = "dialog-settings-restart.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string RestartPrompt = "dialog-settings-restart.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string RestartAccept = "dialog-settings-restart.confirm";
 
-		[TranslationReference]
+		[FluentReference]
 		const string RestartCancel = "dialog-settings-restart.cancel";
 
-		[TranslationReference("panel")]
+		[FluentReference("panel")]
 		const string ResetTitle = "dialog-settings-reset.title";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ResetPrompt = "dialog-settings-reset.prompt";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ResetAccept = "dialog-settings-reset.confirm";
 
-		[TranslationReference]
+		[FluentReference]
 		const string ResetCancel = "dialog-settings-reset.cancel";
 
 		readonly Dictionary<string, Func<bool>> leavePanelActions = new();
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ConfirmationDialogs.ButtonPrompt(modData,
 					title: ResetTitle,
 					text: ResetPrompt,
-					titleArguments: Translation.Arguments("panel", panels[activePanel]),
+					titleArguments: FluentBundle.Arguments("panel", panels[activePanel]),
 					onConfirm: Reset,
 					confirmText: ResetAccept,
 					onCancel: () => { },

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ConfirmationDialogs.ButtonPrompt(modData,
 					title: ResetTitle,
 					text: ResetPrompt,
-					titleArguments: FluentBundle.Arguments("panel", panels[activePanel]),
+					titleArguments: new object[] { "panel", panels[activePanel] },
 					onConfirm: Reset,
 					confirmText: ResetAccept,
 					onCancel: () => { },

--- a/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public SpawnOccupant(Session.Client client)
 		{
 			Color = client.Color;
-			PlayerName = client.IsBot ? TranslationProvider.GetString(client.Name) : client.Name;
+			PlayerName = client.IsBot ? FluentProvider.GetString(client.Name) : client.Name;
 			Team = client.Team;
 			Faction = client.Faction;
 			SpawnPoint = client.SpawnPoint;
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public SpawnOccupant(GameInformation.Player player)
 		{
 			Color = player.Color;
-			PlayerName = player.IsBot ? TranslationProvider.GetString(player.Name) : player.Name;
+			PlayerName = player.IsBot ? FluentProvider.GetString(player.Name) : player.Name;
 			Team = player.Team;
 			Faction = player.FactionId;
 			SpawnPoint = player.SpawnPoint;
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public SpawnOccupant(GameClient player, bool suppressFaction)
 		{
 			Color = player.Color;
-			PlayerName = player.IsBot ? TranslationProvider.GetString(player.Name) : player.Name;
+			PlayerName = player.IsBot ? FluentProvider.GetString(player.Name) : player.Name;
 			Team = player.Team;
 			Faction = !suppressFaction ? player.Faction : null;
 			SpawnPoint = player.SpawnPoint;

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -75,10 +75,10 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public readonly bool DrawTime = true;
 
-		[TranslationReference]
+		[FluentReference]
 		public string ReadyText = "";
 
-		[TranslationReference]
+		[FluentReference]
 		public string HoldText = "";
 
 		public readonly string InfiniteSymbol = "\u221E";
@@ -178,9 +178,9 @@ namespace OpenRA.Mods.Common.Widgets
 			Game.Renderer.Fonts.TryGetValue(SymbolsFont, out symbolFont);
 
 			iconOffset = 0.5f * IconSize.ToFloat2() + IconSpriteOffset;
-			HoldText = TranslationProvider.GetString(HoldText);
+			HoldText = FluentProvider.GetString(HoldText);
 			holdOffset = iconOffset - overlayFont.Measure(HoldText) / 2;
-			ReadyText = TranslationProvider.GetString(ReadyText);
+			ReadyText = FluentProvider.GetString(ReadyText);
 			readyOffset = iconOffset - overlayFont.Measure(ReadyText) / 2;
 
 			if (ChromeMetrics.TryGet("InfiniteOffset", out infiniteOffset))

--- a/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
@@ -59,7 +59,10 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				var self = p.Instances[0].Self;
 				var time = WidgetUtils.FormatTime(p.RemainingTicks, false, self.World.Timestep);
-				var text = FluentProvider.GetString(Format, FluentBundle.Arguments("player", self.Owner.ResolvedPlayerName, "support-power", p.Name, "time", time));
+				var text = FluentProvider.GetString(Format,
+					"player", self.Owner.ResolvedPlayerName,
+					"support-power", p.Name,
+					"time", time);
 
 				var color = !p.Ready || Game.LocalTick % 50 < 25 ? self.OwnerColor() : Color.White;
 

--- a/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Widgets
 {
 	public class SupportPowerTimerWidget : Widget
 	{
-		[TranslationReference("player", "support-power", "time")]
+		[FluentReference("player", "support-power", "time")]
 		const string Format = "support-power-timer";
 
 		public readonly string Font = "Bold";
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				var self = p.Instances[0].Self;
 				var time = WidgetUtils.FormatTime(p.RemainingTicks, false, self.World.Timestep);
-				var text = TranslationProvider.GetString(Format, Translation.Arguments("player", self.Owner.ResolvedPlayerName, "support-power", p.Name, "time", time));
+				var text = FluentProvider.GetString(Format, FluentBundle.Arguments("player", self.Owner.ResolvedPlayerName, "support-power", p.Name, "time", time));
 
 				var color = !p.Ready || Game.LocalTick % 50 < 25 ? self.OwnerColor() : Color.White;
 

--- a/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
@@ -22,10 +22,10 @@ namespace OpenRA.Mods.Common.Widgets
 {
 	public class SupportPowersWidget : Widget
 	{
-		[TranslationReference]
+		[FluentReference]
 		public string ReadyText = "";
 
-		[TranslationReference]
+		[FluentReference]
 		public string HoldText = "";
 
 		public readonly string OverlayFont = "TinyBold";
@@ -112,9 +112,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 			iconOffset = 0.5f * IconSize.ToFloat2() + IconSpriteOffset;
 
-			HoldText = TranslationProvider.GetString(HoldText);
+			HoldText = FluentProvider.GetString(HoldText);
 			holdOffset = iconOffset - overlayFont.Measure(HoldText) / 2;
-			ReadyText = TranslationProvider.GetString(ReadyText);
+			ReadyText = FluentProvider.GetString(ReadyText);
 			readyOffset = iconOffset - overlayFont.Measure(ReadyText) / 2;
 
 			clock = new Animation(worldRenderer.World, ClockAnimation);

--- a/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
@@ -20,13 +20,13 @@ namespace OpenRA.Mods.Common.Widgets
 {
 	public static class WidgetUtils
 	{
-		[TranslationReference]
+		[FluentReference]
 		const string Gone = "label-client-state-disconnected";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Won = "label-win-state-won";
 
-		[TranslationReference]
+		[FluentReference]
 		const string Lost = "label-win-state-lost";
 
 		public static string GetStatefulImageName(
@@ -339,12 +339,12 @@ namespace OpenRA.Mods.Common.Widgets
 
 				var suffix = "";
 				if (c.WinState == WinState.Won)
-					suffix = $" ({TranslationProvider.GetString(Won)})";
+					suffix = $" ({FluentProvider.GetString(Won)})";
 				else if (c.WinState == WinState.Lost)
-					suffix = $" ({TranslationProvider.GetString(Lost)})";
+					suffix = $" ({FluentProvider.GetString(Lost)})";
 
 				if (client.State == Session.ClientState.Disconnected)
-					suffix = $" ({TranslationProvider.GetString(Gone)})";
+					suffix = $" ({FluentProvider.GetString(Gone)})";
 
 				text += suffix;
 

--- a/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
+++ b/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.D2k.Traits
 		[NotificationReference("Speech")]
 		public readonly string WormAttackNotification = "WormAttack";
 
-		[TranslationReference]
+		[FluentReference]
 		public readonly string WormAttackTextNotification = "notification-worm-attack";
 
 		public override object Create(ActorInitializer init) { return new AttackSwallow(init.Self, this); }

--- a/OpenRA.Server/Program.cs
+++ b/OpenRA.Server/Program.cs
@@ -93,8 +93,8 @@ namespace OpenRA.Server
 				modData.MapCache.LoadPreviewImages = false; // PERF: Server doesn't need previews, save memory by not loading them.
 				modData.MapCache.LoadMaps();
 
-				// HACK: Related to the above one, initialize the translations so we can load maps with their (translated) lobby options.
-				TranslationProvider.Initialize(modData, modData.DefaultFileSystem);
+				// HACK: Related to the above one, initialize fluent so we can resolve lobby option ids to strings.
+				FluentProvider.Initialize(modData, modData.DefaultFileSystem);
 
 				var endpoints = new List<IPEndPoint> { new(IPAddress.IPv6Any, settings.ListenPort), new(IPAddress.Any, settings.ListenPort) };
 				var server = new Server(endpoints, settings, modData, ServerType.Dedicated);

--- a/OpenRA.Test/OpenRA.Game/FluentTest.cs
+++ b/OpenRA.Test/OpenRA.Game/FluentTest.cs
@@ -27,10 +27,10 @@ label-players = {$player ->
 		[TestCase(TestName = "Fluent Plural Terms")]
 		public void TestOne()
 		{
-			var translation = new Translation("en", pluralForms, e => Console.WriteLine(e.Message));
-			var label = translation.GetString("label-players", Translation.Arguments("player", 1));
+			var bundle = new FluentBundle("en", pluralForms, e => Console.WriteLine(e.Message));
+			var label = bundle.GetString("label-players", FluentBundle.Arguments("player", 1));
 			Assert.That("One player", Is.EqualTo(label));
-			label = translation.GetString("label-players", Translation.Arguments("player", 2));
+			label = bundle.GetString("label-players", FluentBundle.Arguments("player", 2));
 			Assert.That("2 players", Is.EqualTo(label));
 		}
 	}

--- a/OpenRA.Test/OpenRA.Game/FluentTest.cs
+++ b/OpenRA.Test/OpenRA.Game/FluentTest.cs
@@ -28,9 +28,9 @@ label-players = {$player ->
 		public void TestOne()
 		{
 			var bundle = new FluentBundle("en", pluralForms, e => Console.WriteLine(e.Message));
-			var label = bundle.GetString("label-players", FluentBundle.Arguments("player", 1));
+			var label = bundle.GetString("label-players", new object[] { "player", 1 });
 			Assert.That("One player", Is.EqualTo(label));
-			label = bundle.GetString("label-players", FluentBundle.Arguments("player", 2));
+			label = bundle.GetString("label-players", new object[] { "player", 2 });
 			Assert.That("2 players", Is.EqualTo(label));
 		}
 	}


### PR DESCRIPTION
A spin off from active discussions on Discord: The term "translation" is used without restraint throughout the code and yaml to refer to many distinct concepts - many of which may be *language* related, but are not *translation* (i.e the ability to select between different languages) related.

This PR applies a brute-force rename in an attempt to define more precise terminology for language- and (specifically) fluent-related concepts/code to free up "translation" for the actual (future) translation implementation details.

This intentionally avoids changing the external API exposed to yaml and lua, these are left to followup PRs as they will contain logic changes in addition to just renaming.