### PR TITLE
Remove PARENT_TOP and PARENT_LEFT from integer expressions for widgets

### DIFF
--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -293,8 +293,6 @@ namespace OpenRA.Widgets
 			substitutions.Add("WINDOW_RIGHT", Game.Renderer.Resolution.Width);
 			substitutions.Add("WINDOW_BOTTOM", Game.Renderer.Resolution.Height);
 			substitutions.Add("PARENT_RIGHT", parentBounds.Width);
-			substitutions.Add("PARENT_LEFT", parentBounds.Left);
-			substitutions.Add("PARENT_TOP", parentBounds.Top);
 			substitutions.Add("PARENT_BOTTOM", parentBounds.Height);
 
 			var readOnlySubstitutions = new ReadOnlyDictionary<string, int>(substitutions);

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20231010/RemoveParentTopParentLeftSubstitutions.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20231010/RemoveParentTopParentLeftSubstitutions.cs
@@ -1,0 +1,51 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RemoveParentTopParentLeftSubstitutions : UpdateRule
+	{
+		public override string Name => "Remove PARENT_TOP and PARENT_LEFT from integer expressions for widgets.";
+
+		public override string Description =>
+			"PARENT_TOP is replaced with 0 and PARENT_LEFT is replaced with 0 in integer expressions for width, hegiht and position.";
+
+		public override IEnumerable<string> UpdateChromeNode(ModData modData, MiniYamlNodeBuilder chromeNode)
+		{
+			var dimensionFields =
+				chromeNode.ChildrenMatching("Width")
+				.Concat(chromeNode.ChildrenMatching("Height"))
+				.Concat(chromeNode.ChildrenMatching("X"))
+				.Concat(chromeNode.ChildrenMatching("Y")).ToArray();
+
+			foreach (var field in dimensionFields)
+			{
+				if (field.Value.Value == "PARENT_TOP" || field.Value.Value == "PARENT_LEFT")
+				{
+					chromeNode.RemoveNode(field);
+				}
+				else if (field.Value.Value.Contains("PARENT_TOP"))
+				{
+					field.ReplaceValue(field.Value.Value.Replace("PARENT_TOP", "0"));
+				}
+				else if (field.Value.Value.Contains("PARENT_LEFT"))
+				{
+					field.ReplaceValue(field.Value.Value.Replace("PARENT_LEFT", "0"));
+				}
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -90,6 +90,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new AddSupportPowerBlockedCursor(),
 				new MovePreviewFacing(),
 				new RenameOnDeath(),
+				new RemoveParentTopParentLeftSubstitutions(),
 
 				// Execute these rules last to avoid premature yaml merge crashes.
 				new ReplaceCloakPalette(),

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -520,8 +520,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{ "WINDOW_RIGHT", Game.Renderer.Resolution.Width },
 				{ "WINDOW_BOTTOM", Game.Renderer.Resolution.Height },
 				{ "PARENT_RIGHT", parentBounds.Width },
-				{ "PARENT_LEFT", parentBounds.Left },
-				{ "PARENT_TOP", parentBounds.Top },
 				{ "PARENT_BOTTOM", parentBounds.Height }
 			};
 

--- a/mods/common/chrome/ingame-debug-hpf.yaml
+++ b/mods/common/chrome/ingame-debug-hpf.yaml
@@ -4,13 +4,12 @@ Container@HPF_OVERLAY:
 	Height: 60
 	Children:
 		DropDownButton@HPF_OVERLAY_LOCOMOTOR:
-			Y: PARENT_TOP
 			Width: PARENT_RIGHT
 			Height: 25
 			Text: dropdownbutton-hpf-overlay-locomotor
 			Font: Regular
 		DropDownButton@HPF_OVERLAY_CHECK:
-			Y: PARENT_TOP + 35
+			Y: 35
 			Width: PARENT_RIGHT
 			Height: 25
 			Text: dropdownbutton-hpf-overlay-check


### PR DESCRIPTION
`PARENT_TOP` and `PARENT_LEFT` should be `0` so they are not very useful substitutions. They are replaced with `0` or removed if that was the whole value for a field.