### PR TITLE
Don't create an unnecessary HPF layer

### DIFF
--- a/mods/ra/maps/allies-03b/rules.yaml
+++ b/mods/ra/maps/allies-03b/rules.yaml
@@ -15,6 +15,9 @@ World:
 			normal: options-difficulty.normal
 			hard: options-difficulty.hard
 		Default: normal
+	Locomotor@IMMOBILE:
+		Name: immobile
+		TerrainSpeeds:
 
 powerproxy.paratroopers:
 	ParatroopersPower:

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -88,9 +88,6 @@
 		TerrainSpeeds:
 			Water: 100
 			Beach: 70
-	Locomotor@IMMOBILE:
-		Name: immobile
-		TerrainSpeeds:
 	TerrainRenderer:
 	ChronoVortexRenderer:
 	ShroudRenderer:


### PR DESCRIPTION
As each locomotor has HPF layers loaded for it, we shouldn't have mission specific ones in base world