### PR TITLE
Rename `*_RIGHT` to `*_WIDTH` and `*_BOTTOM` to `*_HEIGHT` in integer expressions for widgets

### DIFF
--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -290,10 +290,10 @@ namespace OpenRA.Widgets
 				new Dictionary<string, int>((Dictionary<string, int>)subs) :
 				new Dictionary<string, int>();
 
-			substitutions.Add("WINDOW_RIGHT", Game.Renderer.Resolution.Width);
-			substitutions.Add("WINDOW_BOTTOM", Game.Renderer.Resolution.Height);
-			substitutions.Add("PARENT_RIGHT", parentBounds.Width);
-			substitutions.Add("PARENT_BOTTOM", parentBounds.Height);
+			substitutions.Add("WINDOW_WIDTH", Game.Renderer.Resolution.Width);
+			substitutions.Add("WINDOW_HEIGHT", Game.Renderer.Resolution.Height);
+			substitutions.Add("PARENT_WIDTH", parentBounds.Width);
+			substitutions.Add("PARENT_HEIGHT", parentBounds.Height);
 
 			var readOnlySubstitutions = new ReadOnlyDictionary<string, int>(substitutions);
 			var width = Width?.Evaluate(readOnlySubstitutions) ?? 0;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20231010/RenameWidgetSubstitutions.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20231010/RenameWidgetSubstitutions.cs
@@ -1,0 +1,45 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RenameWidgetSubstitutions : UpdateRule
+	{
+		public override string Name => "Rename *_RIGHT to *_WIDTH and *_BOTTOM to *_HEIGHT in integer expressions for widgets.";
+
+		public override string Description =>
+			"PARENT_RIGHT -> PARENT_WIDTH, PARENT_BOTTOM -> PARENT_HEIGHT, " +
+			"WINDOW_RIGHT -> WINDOW_WIDTH, WINDOW_BOTTOM -> WINDOW_HEIGHT " +
+			"in integer expressions for width, height and position.";
+
+		public override IEnumerable<string> UpdateChromeNode(ModData modData, MiniYamlNodeBuilder chromeNode)
+		{
+			var dimensionFields =
+				chromeNode.ChildrenMatching("Width")
+				.Concat(chromeNode.ChildrenMatching("Height"))
+				.Concat(chromeNode.ChildrenMatching("X"))
+				.Concat(chromeNode.ChildrenMatching("Y")).ToArray();
+
+			foreach (var field in dimensionFields)
+			{
+				field.ReplaceValue(field.Value.Value.Replace("PARENT_RIGHT", "PARENT_WIDTH"));
+				field.ReplaceValue(field.Value.Value.Replace("PARENT_BOTTOM", "PARENT_HEIGHT"));
+				field.ReplaceValue(field.Value.Value.Replace("WINDOW_RIGHT", "WINDOW_WIDTH"));
+				field.ReplaceValue(field.Value.Value.Replace("WINDOW_BOTTOM", "WINDOW_HEIGHT"));
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -91,6 +91,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new MovePreviewFacing(),
 				new RenameOnDeath(),
 				new RemoveParentTopParentLeftSubstitutions(),
+				new RenameWidgetSubstitutions(),
 
 				// Execute these rules last to avoid premature yaml merge crashes.
 				new ReplaceCloakPalette(),

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -243,7 +243,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				// HACK: MULTIPLAYER_FILTER_PANEL doesn't follow our normal procedure for dropdown creation
 				// but we still need to be able to set the dropdown width based on the parent
-				// The yaml should use PARENT_RIGHT instead of DROPDOWN_WIDTH
+				// The yaml should use PARENT_WIDTH instead of DROPDOWN_WIDTH
 				var filtersPanel = Ui.LoadWidget("MULTIPLAYER_FILTER_PANEL", filtersButton, new WidgetArgs());
 				filtersButton.Children.Remove(filtersPanel);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -517,10 +517,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var substitutions = new Dictionary<string, int>
 			{
-				{ "WINDOW_RIGHT", Game.Renderer.Resolution.Width },
-				{ "WINDOW_BOTTOM", Game.Renderer.Resolution.Height },
-				{ "PARENT_RIGHT", parentBounds.Width },
-				{ "PARENT_BOTTOM", parentBounds.Height }
+				{ "WINDOW_WIDTH", Game.Renderer.Resolution.Width },
+				{ "WINDOW_HEIGHT", Game.Renderer.Resolution.Height },
+				{ "PARENT_WIDTH", parentBounds.Width },
+				{ "PARENT_HEIGHT", parentBounds.Height }
 			};
 
 			var readOnlySubstitutions = new ReadOnlyDictionary<string, int>(substitutions);

--- a/mods/cnc/chrome/assetbrowser.yaml
+++ b/mods/cnc/chrome/assetbrowser.yaml
@@ -1,13 +1,13 @@
 Container@ASSETBROWSER_PANEL:
 	Logic: AssetBrowserLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 900
 	Height: 540
 	Children:
 		LogicTicker@ANIMATION_TICKER:
 		Label@ASSETBROWSER_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Font: BigBold
@@ -15,8 +15,8 @@ Container@ASSETBROWSER_PANEL:
 			Align: Center
 			Text: label-assetbrowser-panel-title
 		Background@bg:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				Label@SOURCE_SELECTOR_DESC:
@@ -59,11 +59,11 @@ Container@ASSETBROWSER_PANEL:
 					X: 15
 					Y: 155
 					Width: 195
-					Height: PARENT_BOTTOM - 205
+					Height: PARENT_HEIGHT - 205
 					CollapseHiddenChildren: True
 					Children:
 						ScrollItem@ASSET_TEMPLATE:
-							Width: PARENT_RIGHT - 27
+							Width: PARENT_WIDTH - 27
 							Height: 25
 							X: 2
 							Visible: false
@@ -71,12 +71,12 @@ Container@ASSETBROWSER_PANEL:
 							Children:
 								LabelWithTooltip@TITLE:
 									X: 10
-									Width: PARENT_RIGHT - 15
+									Width: PARENT_WIDTH - 15
 									Height: 25
 									TooltipContainer: TOOLTIP_CONTAINER
 									TooltipTemplate: SIMPLE_TOOLTIP
 				Label@SPRITE_SCALE:
-					X: PARENT_RIGHT - WIDTH - 440
+					X: PARENT_WIDTH - WIDTH - 440
 					Y: 31
 					Width: 50
 					Height: 25
@@ -84,14 +84,14 @@ Container@ASSETBROWSER_PANEL:
 					Align: Left
 					Text: label-bg-sprite-scale
 				Slider@SPRITE_SCALE_SLIDER:
-					X: PARENT_RIGHT - WIDTH - 330
+					X: PARENT_WIDTH - WIDTH - 330
 					Y: 35
 					Width: 100
 					Height: 20
 					MinimumValue: 0.5
 					MaximumValue: 4
 				Label@PALETTE_DESC:
-					X: PARENT_RIGHT - WIDTH - 270
+					X: PARENT_WIDTH - WIDTH - 270
 					Y: 31
 					Width: 150
 					Height: 25
@@ -99,13 +99,13 @@ Container@ASSETBROWSER_PANEL:
 					Align: Right
 					Text: label-bg-palette-desc
 				DropDownButton@PALETTE_SELECTOR:
-					X: PARENT_RIGHT - WIDTH - 110
+					X: PARENT_WIDTH - WIDTH - 110
 					Y: 30
 					Width: 150
 					Height: 25
 					Font: Bold
 				DropDownButton@COLOR:
-					X: PARENT_RIGHT - WIDTH - 15
+					X: PARENT_WIDTH - WIDTH - 15
 					Y: 30
 					Width: 80
 					Height: 25
@@ -113,32 +113,32 @@ Container@ASSETBROWSER_PANEL:
 						ColorBlock@COLORBLOCK:
 							X: 5
 							Y: 6
-							Width: PARENT_RIGHT - 35
-							Height: PARENT_BOTTOM - 12
+							Width: PARENT_WIDTH - 35
+							Height: PARENT_HEIGHT - 12
 				Background@SPRITE_BG:
 					X: 225
 					Y: 65
-					Width: PARENT_RIGHT - 195 - 45
-					Height: PARENT_BOTTOM - 115
+					Width: PARENT_WIDTH - 195 - 45
+					Height: PARENT_HEIGHT - 115
 					Background: scrollpanel-bg
 					Children:
 						Sprite@SPRITE:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 						VideoPlayer@PLAYER:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							AspectRatio: 1
 						Label@ERROR:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Align: Center
 							Visible: false
 							Text: label-sprite-bg-error
 				Container@FRAME_SELECTOR:
 					X: 225
-					Y: PARENT_BOTTOM - 40
-					Width: PARENT_RIGHT - 225
+					Y: PARENT_HEIGHT - 40
+					Width: PARENT_WIDTH - 225
 					Children:
 						Button@BUTTON_PREV:
 							Width: 26
@@ -208,11 +208,11 @@ Container@ASSETBROWSER_PANEL:
 						Slider@FRAME_SLIDER:
 							X: 140
 							Y: 3
-							Width: PARENT_RIGHT - 140 - 85
+							Width: PARENT_WIDTH - 140 - 85
 							Height: 20
 							MinimumValue: 0
 						Label@FRAME_COUNT:
-							X: PARENT_RIGHT - WIDTH + 5
+							X: PARENT_WIDTH - WIDTH + 5
 							Y: 0
 							Width: 80
 							Height: 25
@@ -220,7 +220,7 @@ Container@ASSETBROWSER_PANEL:
 							Align: Left
 		Button@CLOSE_BUTTON:
 			Key: escape
-			Y: PARENT_BOTTOM - 1
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-back
@@ -235,5 +235,5 @@ ScrollPanel@ASSET_TYPES_PANEL:
 		Checkbox@ASSET_TYPE_TEMPLATE:
 			X: 5
 			Y: 5
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20

--- a/mods/cnc/chrome/color-picker.yaml
+++ b/mods/cnc/chrome/color-picker.yaml
@@ -29,14 +29,14 @@ Background@COLOR_CHOOSER:
 			Animate: true
 		Button@MIXER_TAB_BUTTON:
 			X: 5
-			Y: PARENT_BOTTOM - 30
+			Y: PARENT_HEIGHT - 30
 			Height: 25
 			Width: 80
 			Text: button-color-chooser-mixer-tab
 			Font: Bold
 		Button@PALETTE_TAB_BUTTON:
 			X: 90
-			Y: PARENT_BOTTOM - 30
+			Y: PARENT_HEIGHT - 30
 			Height: 25
 			Width: 80
 			Text: button-color-chooser-palette-tab
@@ -44,63 +44,63 @@ Background@COLOR_CHOOSER:
 		Container@MIXER_TAB:
 			X: 5
 			Y: 5
-			Width: PARENT_RIGHT - 91
-			Height: PARENT_BOTTOM - 34
+			Width: PARENT_WIDTH - 91
+			Height: PARENT_HEIGHT - 34
 			Children:
 				Background@HUEBG:
 					Background: panel-black
 					X: 0
 					Y: 0
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 17
 					Children:
 						HueSlider@HUE_SLIDER:
 							X: 2
 							Y: 2
-							Width: PARENT_RIGHT - 4
-							Height: PARENT_BOTTOM - 4
+							Width: PARENT_WIDTH - 4
+							Height: PARENT_HEIGHT - 4
 							Ticks: 5
 				Background@MIXERBG:
 					Background: panel-black
 					X: 0
 					Y: 21
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM - 21
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT - 21
 					Children:
 						ColorMixer@MIXER:
 							X: 2
 							Y: 2
-							Width: PARENT_RIGHT - 4
-							Height: PARENT_BOTTOM - 4
+							Width: PARENT_WIDTH - 4
+							Height: PARENT_HEIGHT - 4
 		Background@PALETTE_TAB:
 			Background: panel-black
 			X: 5
 			Y: 5
-			Width: PARENT_RIGHT - 91
-			Height: PARENT_BOTTOM - 34
+			Width: PARENT_WIDTH - 91
+			Height: PARENT_HEIGHT - 34
 			Visible: false
 			Children:
 				Container@PALETTE_TAB_PANEL:
 					X: 0
 					Y: 0
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						Background@PRESET_HEADER:
 							Background: panel-black
-							Width: PARENT_RIGHT - 4
+							Width: PARENT_WIDTH - 4
 							Height: 13
 							X: 2
 							Y: 2
 							Children:
 								Label@LABEL:
 									Font: TinyBold
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 13
 									Align: Center
 									Text: label-preset-header
 						Container@PRESET_AREA:
-							Width: PARENT_RIGHT - 4
+							Width: PARENT_WIDTH - 4
 							Height: 58
 							X: 2
 							Y: 16
@@ -114,19 +114,19 @@ Background@COLOR_CHOOSER:
 									ClickSound: ClickSound
 						Background@CUSTOM_HEADER:
 							Background: panel-black
-							Width: PARENT_RIGHT - 4
+							Width: PARENT_WIDTH - 4
 							Height: 13
 							X: 2
 							Y: 71
 							Children:
 								Label@LABEL:
 									Font: TinyBold
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 13
 									Align: Center
 									Text: label-custom-header
 						Container@CUSTOM_AREA:
-							Width: PARENT_RIGHT - 4
+							Width: PARENT_WIDTH - 4
 							Height: 31
 							X: 2
 							Y: 85

--- a/mods/cnc/chrome/connection.yaml
+++ b/mods/cnc/chrome/connection.yaml
@@ -1,12 +1,12 @@
 Container@CONNECTING_PANEL:
 	Logic: ConnectionLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - 90) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - 90) / 2
 	Width: 370
 	Height: 125
 	Children:
 		Label@CONNECTING_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Font: BigBold
@@ -19,8 +19,8 @@ Container@CONNECTING_PANEL:
 			Background: panel-black
 			Children:
 				Label@CONNECTING_DESC:
-					Y: (PARENT_BOTTOM - HEIGHT) / 2
-					Width: PARENT_RIGHT
+					Y: (PARENT_HEIGHT - HEIGHT) / 2
+					Width: PARENT_WIDTH
 					Height: 25
 					Text: label-bg-connecting-desc
 					Font: Bold
@@ -34,14 +34,14 @@ Container@CONNECTING_PANEL:
 
 Container@CONNECTIONFAILED_PANEL:
 	Logic: ConnectionFailedLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - 90) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - 90) / 2
 	Width: 370
 	Height: 129
 	Children:
 		LogicTicker@CONNECTION_FAILED_TICKER:
 		Label@TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Font: BigBold
@@ -54,14 +54,14 @@ Container@CONNECTIONFAILED_PANEL:
 			Children:
 				Label@CONNECTING_DESC:
 					Y: 16
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Text: label-connection-background-connecting-desc
 					Font: Bold
 					Align: Center
 				Label@CONNECTION_ERROR:
 					Y: 41
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 					Font: Bold
@@ -101,13 +101,13 @@ Container@CONNECTIONFAILED_PANEL:
 
 Container@CONNECTION_SWITCHMOD_PANEL:
 	Logic: ConnectionSwitchModLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - 90) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - 90) / 2
 	Width: 370
 	Height: 134
 	Children:
 		Label@TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Font: BigBold
@@ -121,7 +121,7 @@ Container@CONNECTION_SWITCHMOD_PANEL:
 			Children:
 				Label@DESC:
 					Y: 16
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Text: label-connection-background-desc
 					Font: Bold
@@ -129,7 +129,7 @@ Container@CONNECTION_SWITCHMOD_PANEL:
 				Container@MOD_CONTAINER:
 					X: 0
 					Y: 42
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Children:
 						RGBASprite@MOD_ICON:
 							Y: 4
@@ -138,20 +138,20 @@ Container@CONNECTION_SWITCHMOD_PANEL:
 						Label@MOD_TITLE:
 							X: 37
 							Y: 1
-							Width: PARENT_RIGHT - 37
+							Width: PARENT_WIDTH - 37
 							Height: 25
 							Font: Bold
 							Align: Left
 						Label@MOD_VERSION:
 							X: 37
 							Y: 16
-							Width: PARENT_RIGHT - 37
+							Width: PARENT_WIDTH - 37
 							Height: 25
 							Font: Tiny
 							Align: Left
 				Label@DESC2:
 					Y: 81
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Text: label-connection-background-desc2
 					Font: Bold

--- a/mods/cnc/chrome/credits.yaml
+++ b/mods/cnc/chrome/credits.yaml
@@ -1,12 +1,12 @@
 Container@CREDITS_PANEL:
 	Logic: CreditsLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 410
 	Height: 435
 	Children:
 		Label@CREDITS_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Font: BigBold
@@ -14,15 +14,15 @@ Container@CREDITS_PANEL:
 			Align: Center
 			Text: label-credits-title
 		Background@bg:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				Container@TAB_CONTAINER:
 					Visible: False
 					X: 15
 					Y: 15
-					Width: PARENT_RIGHT - 30
+					Width: PARENT_WIDTH - 30
 					Height: 34
 					Children:
 						Button@MOD_TAB:
@@ -36,18 +36,18 @@ Container@CREDITS_PANEL:
 				ScrollPanel@CREDITS_DISPLAY:
 					X: 15
 					Y: 15
-					Width: PARENT_RIGHT - 30
-					Height: PARENT_BOTTOM - 30
+					Width: PARENT_WIDTH - 30
+					Height: PARENT_HEIGHT - 30
 					TopBottomSpacing: 8
 					Children:
 						Label@CREDITS_TEMPLATE:
 							X: 8
-							Width: PARENT_RIGHT - 24 - 2 * 8
+							Width: PARENT_WIDTH - 24 - 2 * 8
 							Height: 16
 							VAlign: Top
 							WordWrap: true
 		Button@BACK_BUTTON:
-			Y: PARENT_BOTTOM - 1
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-back

--- a/mods/cnc/chrome/dialogs.yaml
+++ b/mods/cnc/chrome/dialogs.yaml
@@ -4,7 +4,7 @@ ScrollPanel@LABEL_DROPDOWN_TEMPLATE:
 	Children:
 		ScrollItem@HEADER:
 			Background: scrollheader
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 13
 			X: 2
 			Y: 0
@@ -12,11 +12,11 @@ ScrollPanel@LABEL_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					Font: TinyBold
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 13
 					Align: Center
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -24,7 +24,7 @@ ScrollPanel@LABEL_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					X: 10
-					Width: PARENT_RIGHT - 20
+					Width: PARENT_WIDTH - 20
 					Height: 25
 
 ScrollPanel@PLAYERACTION_DROPDOWN_TEMPLATE:
@@ -32,7 +32,7 @@ ScrollPanel@PLAYERACTION_DROPDOWN_TEMPLATE:
 	Background: panel-black
 	Children:
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -40,7 +40,7 @@ ScrollPanel@PLAYERACTION_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					X: 10
-					Width: PARENT_RIGHT - 20
+					Width: PARENT_WIDTH - 20
 					Height: 25
 					Align: Left
 
@@ -50,7 +50,7 @@ ScrollPanel@FACTION_DROPDOWN_TEMPLATE:
 	Children:
 		ScrollItem@HEADER:
 			Background: scrollheader
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 13
 			X: 2
 			Y: 0
@@ -58,11 +58,11 @@ ScrollPanel@FACTION_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					Font: TinyBold
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 13
 					Align: Center
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -84,7 +84,7 @@ ScrollPanel@TEAM_DROPDOWN_TEMPLATE:
 	Background: panel-black
 	Children:
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -92,7 +92,7 @@ ScrollPanel@TEAM_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					X: 0
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 
@@ -101,7 +101,7 @@ ScrollPanel@SPAWN_DROPDOWN_TEMPLATE:
 	Background: panel-black
 	Children:
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -109,7 +109,7 @@ ScrollPanel@SPAWN_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					X: 0
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 
@@ -119,7 +119,7 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 	Children:
 		ScrollItem@HEADER:
 			Background: scrollheader
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 13
 			X: 2
 			Y: 0
@@ -127,11 +127,11 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					Font: TinyBold
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 13
 					Align: Center
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -144,24 +144,24 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 					Height: 16
 				Label@LABEL:
 					X: 40
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Shadow: True
 				Label@NOFLAG_LABEL:
 					X: 5
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Shadow: True
 
 Background@THREEBUTTON_PROMPT:
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - 90) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - 90) / 2
 	Width: 500
 	Height: 41
 	Background: panel-black
 	Children:
 		Label@PROMPT_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Font: BigBold
@@ -169,7 +169,7 @@ Background@THREEBUTTON_PROMPT:
 			Align: Center
 		Label@PROMPT_TEXT:
 			Y: 22
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 20
 			Font: Bold
 			Align: Center
@@ -198,14 +198,14 @@ Background@THREEBUTTON_PROMPT:
 			Visible: false
 
 Background@TWOBUTTON_PROMPT:
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - 90) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - 90) / 2
 	Width: 370
 	Height: 31
 	Background: panel-black
 	Children:
 		Label@PROMPT_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Font: BigBold
@@ -213,7 +213,7 @@ Background@TWOBUTTON_PROMPT:
 			Align: Center
 		Label@PROMPT_TEXT:
 			Y: 17
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 20
 			Font: Bold
 			Align: Center
@@ -234,38 +234,38 @@ Background@TWOBUTTON_PROMPT:
 			Visible: false
 
 Container@TEXT_INPUT_PROMPT:
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 370
 	Height: 80
 	Children:
 		Label@PROMPT_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center
 		Background@bg:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 80
 			Background: panel-black
 			Children:
 				Label@PROMPT_TEXT:
 					X: 20
 					Y: 12
-					Width: PARENT_RIGHT - 40
+					Width: PARENT_WIDTH - 40
 					Height: 25
 					Font: Bold
 					Align: Center
 				TextField@INPUT_TEXT:
 					X: 20
 					Y: 40
-					Width: PARENT_RIGHT - 40
+					Width: PARENT_WIDTH - 40
 					Height: 25
 		Button@ACCEPT_BUTTON:
-			X: PARENT_RIGHT - 160
-			Y: PARENT_BOTTOM - 1
+			X: PARENT_WIDTH - 160
+			Y: PARENT_HEIGHT - 1
 			Width: 160
 			Height: 34
 			Text: button-text-input-prompt-accept
@@ -273,7 +273,7 @@ Container@TEXT_INPUT_PROMPT:
 			Key: return
 		Button@CANCEL_BUTTON:
 			X: 0
-			Y: PARENT_BOTTOM - 1
+			Y: PARENT_HEIGHT - 1
 			Width: 160
 			Height: 35
 			Text: button-cancel
@@ -290,28 +290,28 @@ ScrollPanel@NEWS_PANEL:
 		Container@NEWS_ITEM_TEMPLATE:
 			X: 10
 			Y: 5
-			Width: PARENT_RIGHT - 40
+			Width: PARENT_WIDTH - 40
 			Height: 45
 			Children:
 				Label@TITLE:
 					Y: 1
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 					Font: Bold
 				Label@AUTHOR_DATETIME:
 					Y: 26
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 15
 					Align: Center
 					Font: TinyBold
 				Label@CONTENT:
 					Y: 46
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 		Label@NEWS_STATUS:
 			X: 80
 			Y: 1
-			Width: PARENT_RIGHT - 80 - 80 - 24
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH - 80 - 80 - 24
+			Height: PARENT_HEIGHT
 			Align: Center
 			VAlign: Middle

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -1,21 +1,21 @@
 Container@NEW_MAP_BG:
 	Logic: NewMapLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 300
 	Height: 95
 	Children:
 		Label@TITLE:
 			Text: label-new-map-bg-title
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center
 		Background@bg:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				Label@TILESET_LABEL:
@@ -61,15 +61,15 @@ Container@NEW_MAP_BG:
 					Text: 128
 					Type: Integer
 		Button@CANCEL_BUTTON:
-			Y: PARENT_BOTTOM - 1
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-cancel
 			Font: Bold
 			Key: escape
 		Button@CREATE_BUTTON:
-			X: PARENT_RIGHT - WIDTH
-			Y: PARENT_BOTTOM - 1
+			X: PARENT_WIDTH - WIDTH
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-new-map-bg-create
@@ -78,22 +78,22 @@ Container@NEW_MAP_BG:
 
 Container@SAVE_MAP_PANEL:
 	Logic: SaveMapLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 345
 	Height: 195
 	Children:
 		Label@LABEL_TITLE:
 			Text: label-save-map-panel-title
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center
 		Background@SAVE_MAP_BACKGROUND:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				Label@TITLE_LABEL:
@@ -169,15 +169,15 @@ Container@SAVE_MAP_PANEL:
 					Height: 25
 					Font: Regular
 		Button@BACK_BUTTON:
-			Y: PARENT_BOTTOM - 1
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-cancel
 			Font: Bold
 			Key: escape
 		Button@SAVE_BUTTON:
-			X: PARENT_RIGHT - 140
-			Y: PARENT_BOTTOM - 1
+			X: PARENT_WIDTH - 140
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-save-map-panel
@@ -191,7 +191,7 @@ ScrollPanel@MAP_SAVE_VISIBILITY_PANEL:
 	Children:
 		Checkbox@VISIBILITY_TEMPLATE:
 			X: 5
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Font: Regular
 
@@ -223,13 +223,13 @@ Container@EDITOR_WORLD_ROOT:
 		LogicKeyListener@OVERLAY_KEYHANDLER:
 		Container@PERF_ROOT:
 		EditorViewportController@MAP_EDITOR:
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
+			Width: WINDOW_WIDTH
+			Height: WINDOW_HEIGHT
 			TooltipContainer: TOOLTIP_CONTAINER
 			TooltipTemplate: SIMPLE_TOOLTIP
 		ViewportController:
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
+			Width: WINDOW_WIDTH
+			Height: WINDOW_HEIGHT
 			IgnoreMouseOver: True
 			ZoomInKey: ZoomIn
 			ZoomOutKey: ZoomOut
@@ -245,7 +245,7 @@ Container@EDITOR_WORLD_ROOT:
 			BookmarkRestoreKeyPrefix: MapBookmarkRestore
 			BookmarkKeyCount: 4
 		Background@RADAR_BG:
-			X: WINDOW_RIGHT - 295
+			X: WINDOW_WIDTH - 295
 			Y: 5
 			Width: 290
 			Height: 290
@@ -254,12 +254,12 @@ Container@EDITOR_WORLD_ROOT:
 				Radar@INGAME_RADAR:
 					X: 1
 					Y: 1
-					Width: PARENT_RIGHT - 2
-					Height: PARENT_BOTTOM - 2
+					Width: PARENT_WIDTH - 2
+					Height: PARENT_HEIGHT - 2
 		MenuButton@OPTIONS_BUTTON:
 			Logic: MenuButtonsChromeLogic
 			Key: escape
-			X: WINDOW_RIGHT - 294 - WIDTH
+			X: WINDOW_WIDTH - 294 - WIDTH
 			Y: 5
 			Width: 30
 			Height: 25
@@ -272,20 +272,20 @@ Container@EDITOR_WORLD_ROOT:
 					ImageCollection: order-icons
 					ImageName: options
 		Background@TOOLS_BG:
-			X: WINDOW_RIGHT - 295
+			X: WINDOW_WIDTH - 295
 			Y: 330
 			Width: 290
-			Height: WINDOW_BOTTOM - 422
+			Height: WINDOW_HEIGHT - 422
 		Container@TILE_WIDGETS:
-			X: WINDOW_RIGHT - 295
+			X: WINDOW_WIDTH - 295
 			Y: 318
 			Width: 290
-			Height: WINDOW_BOTTOM - 410
+			Height: WINDOW_HEIGHT - 410
 			Logic: TileSelectorLogic
 			Children:
 				Container@TILES_BG:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						Background:
 							Width: 61
@@ -294,54 +294,54 @@ Container@EDITOR_WORLD_ROOT:
 							Children:
 								Label@SEARCH_LABEL:
 									Y: 1
-									Width: PARENT_RIGHT - 5
+									Width: PARENT_WIDTH - 5
 									Height: 25
 									Text: label-tiles-bg-search
 									Align: Right
 									Font: TinyBold
 								Label@CATEGORIES_LABEL:
 									Y: 25
-									Width: PARENT_RIGHT - 5
+									Width: PARENT_WIDTH - 5
 									Height: 25
 									Text: label-bg-filter
 									Align: Right
 									Font: TinyBold
 						TextField@SEARCH_TEXTFIELD:
 							X: 60
-							Width: PARENT_RIGHT - 60
+							Width: PARENT_WIDTH - 60
 							Height: 25
 						DropDownButton@CATEGORIES_DROPDOWN:
 							X: 60
 							Y: 24
-							Width: PARENT_RIGHT - 60
+							Width: PARENT_WIDTH - 60
 							Height: 25
 							Font: Bold
 						ScrollPanel@TILETEMPLATE_LIST:
 							Y: 48
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM - 48
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT - 48
 							TopBottomSpacing: 4
 							ItemSpacing: 4
 							Children:
 								ScrollItem@TILEPREVIEW_TEMPLATE:
 									Visible: false
-									Width: PARENT_RIGHT - 35
+									Width: PARENT_WIDTH - 35
 									TooltipContainer: TOOLTIP_CONTAINER
 									Children:
 										TerrainTemplatePreview@TILE_PREVIEW:
 											X: 4
 											Y: 4
 		Container@LAYER_WIDGETS:
-			X: WINDOW_RIGHT - 295
+			X: WINDOW_WIDTH - 295
 			Y: 318
 			Width: 290
-			Height: WINDOW_BOTTOM - 410
+			Height: WINDOW_HEIGHT - 410
 			Visible: false
 			Logic: LayerSelectorLogic
 			Children:
 				ScrollPanel@LAYERTEMPLATE_LIST:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					TopBottomSpacing: 4
 					ItemSpacing: 4
 					Children:
@@ -355,15 +355,15 @@ Container@EDITOR_WORLD_ROOT:
 									Y: 4
 									Visible: false
 		Container@ACTOR_WIDGETS:
-			X: WINDOW_RIGHT - 295
+			X: WINDOW_WIDTH - 295
 			Y: 318
 			Width: 290
-			Height: WINDOW_BOTTOM - 410
+			Height: WINDOW_HEIGHT - 410
 			Visible: false
 			Logic: ActorSelectorLogic
 			Children:
 				Background@ACTORS_BG:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 83
 					Background: panel-black
 					Children:
@@ -376,7 +376,7 @@ Container@EDITOR_WORLD_ROOT:
 							Font: TinyBold
 						TextField@SEARCH_TEXTFIELD:
 							X: 60
-							Width: PARENT_RIGHT - 60
+							Width: PARENT_WIDTH - 60
 							Height: 25
 						Label@CATEGORIES_LABEL:
 							Y: 25
@@ -388,7 +388,7 @@ Container@EDITOR_WORLD_ROOT:
 						DropDownButton@CATEGORIES_DROPDOWN:
 							X: 60
 							Y: 24
-							Width: PARENT_RIGHT - 60
+							Width: PARENT_WIDTH - 60
 							Height: 25
 							Font: Bold
 						Label@OWNERS_LABEL:
@@ -401,19 +401,19 @@ Container@EDITOR_WORLD_ROOT:
 						DropDownButton@OWNERS_DROPDOWN:
 							X: 60
 							Y: 48
-							Width: PARENT_RIGHT - 60
+							Width: PARENT_WIDTH - 60
 							Height: 25
 							Font: Bold
 				ScrollPanel@ACTORTEMPLATE_LIST:
 					Y: 72
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM - 72
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT - 72
 					TopBottomSpacing: 4
 					ItemSpacing: 4
 					Children:
 						ScrollItem@ACTORPREVIEW_TEMPLATE:
 							Visible: false
-							Width: PARENT_RIGHT - 35
+							Width: PARENT_WIDTH - 35
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 							IgnoreChildMouseOver: true
@@ -423,15 +423,15 @@ Container@EDITOR_WORLD_ROOT:
 									Y: 4
 									Visible: true
 		Container@TOOLS_WIDGETS:
-			X: WINDOW_RIGHT - 295
+			X: WINDOW_WIDTH - 295
 			Y: 318
 			Width: 290
-			Height: WINDOW_BOTTOM - 410
+			Height: WINDOW_HEIGHT - 410
 			Visible: false
 			Logic: MapToolsLogic
 			Children:
 				Background@TOOLS_EDIT_PANEL:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Background: panel-black
 					Children:
@@ -444,20 +444,20 @@ Container@EDITOR_WORLD_ROOT:
 							Font: TinyBold
 						DropDownButton@TOOLS_DROPDOWN:
 							X: 60
-							Width: PARENT_RIGHT - 60
+							Width: PARENT_WIDTH - 60
 							Height: 25
 							Font: Bold
 				Background@MARKER_TOOL_PANEL:
 					Y: 25
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM - 25
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT - 25
 					Background: scrollpanel-bg
 					Logic: MapMarkerTilesLogic
 					Children:
 						ScrollPanel@TILE_COLOR_PANEL:
 							X: 6
 							Y: 6
-							Width: PARENT_RIGHT - 19
+							Width: PARENT_WIDTH - 19
 							Height: 31
 							TopBottomSpacing: 1
 							ItemSpacing: 1
@@ -580,16 +580,16 @@ Container@EDITOR_WORLD_ROOT:
 							Align: Left
 							Visible: false
 		Container@HISTORY_WIDGETS:
-			X: WINDOW_RIGHT - 295
+			X: WINDOW_WIDTH - 295
 			Y: 318
 			Width: 290
-			Height: WINDOW_BOTTOM - 410
+			Height: WINDOW_HEIGHT - 410
 			Logic: HistoryLogLogic
 			Visible: false
 			Children:
 				ScrollPanel@HISTORY_LIST:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					CollapseHiddenChildren: True
 					TopBottomSpacing: 4
 					ItemSpacing: 4
@@ -597,7 +597,7 @@ Container@EDITOR_WORLD_ROOT:
 						ScrollItem@HISTORY_TEMPLATE:
 							X: 4
 							Visible: false
-							Width: PARENT_RIGHT - 31
+							Width: PARENT_WIDTH - 31
 							Height: 25
 							IgnoreChildMouseOver: true
 							TextColor: ffffff
@@ -605,24 +605,24 @@ Container@EDITOR_WORLD_ROOT:
 							Children:
 								Label@TITLE:
 									X: 5
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Align: Left
 		Container@SELECT_WIDGETS:
-			X: WINDOW_RIGHT - 295
+			X: WINDOW_WIDTH - 295
 			Y: 318
 			Width: 290
-			Height: WINDOW_BOTTOM - 410
+			Height: WINDOW_HEIGHT - 410
 			Visible: false
 			Children:
 				Background@AREA_EDIT_PANEL:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Background: scrollpanel-bg
 					Children:
 						Label@AREA_EDIT_TITLE:
 							Y: 16
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 24
 							Align: Center
 							Font: Bold
@@ -638,24 +638,24 @@ Container@EDITOR_WORLD_ROOT:
 						Checkbox@COPY_FILTER_TERRAIN_CHECKBOX:
 							X: 7
 							Y: 70
-							Width: PARENT_RIGHT - 29
+							Width: PARENT_WIDTH - 29
 							Height: 20
 							Text: label-filter-terrain
 						Checkbox@COPY_FILTER_RESOURCES_CHECKBOX:
 							X: 7
 							Y: 95
-							Width: PARENT_RIGHT - 29
+							Width: PARENT_WIDTH - 29
 							Height: 20
 							Text: label-filter-resources
 						Checkbox@COPY_FILTER_ACTORS_CHECKBOX:
 							X: 7
 							Y: 120
-							Width: PARENT_RIGHT - 29
+							Width: PARENT_WIDTH - 29
 							Height: 20
 							Text: label-filter-actors
 						Label@AREA_INFO_TITLE:
 							Y: 139
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 24
 							Align: Center
 							Font: Bold
@@ -696,13 +696,13 @@ Container@EDITOR_WORLD_ROOT:
 							Text: button-cancel
 							Font: Bold
 				Background@ACTOR_EDIT_PANEL:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Background: scrollpanel-bg
 					Children:
 						Label@ACTOR_TYPE_LABEL:
 							Y: 6
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 24
 							Align: Center
 							Font: Bold
@@ -726,19 +726,19 @@ Container@EDITOR_WORLD_ROOT:
 							TextColor: FF0000
 						Container@ACTOR_INIT_CONTAINER:
 							Y: 63
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Children:
 								Container@CHECKBOX_OPTION_TEMPLATE:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 22
 									Children:
 										Checkbox@OPTION:
 											X: 60
 											Y: 1
-											Width: PARENT_RIGHT - 100
+											Width: PARENT_WIDTH - 100
 											Height: 20
 								Container@SLIDER_OPTION_TEMPLATE:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 22
 									Children:
 										Label@LABEL:
@@ -758,7 +758,7 @@ Container@EDITOR_WORLD_ROOT:
 											Height: 20
 											Type: Integer
 								Container@DROPDOWN_OPTION_TEMPLATE:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 27
 									Children:
 										Label@LABEL:
@@ -795,7 +795,7 @@ Container@EDITOR_WORLD_ROOT:
 									Font: Bold
 		Container@MAP_EDITOR_TAB_CONTAINER:
 			Logic: MapEditorTabsLogic
-			X: WINDOW_RIGHT - 295
+			X: WINDOW_WIDTH - 295
 			Y: 294
 			Width: 290
 			Height: 25
@@ -884,7 +884,7 @@ Container@EDITOR_WORLD_ROOT:
 							ImageCollection: editor
 							ImageName: history
 		Button@UNDO_BUTTON:
-			X: WINDOW_RIGHT - 764
+			X: WINDOW_WIDTH - 764
 			Y: 5
 			Height: 25
 			Width: 100
@@ -895,7 +895,7 @@ Container@EDITOR_WORLD_ROOT:
 			TooltipText: button-editor-world-root-undo.tooltip
 			TooltipContainer: TOOLTIP_CONTAINER
 		Button@REDO_BUTTON:
-			X: WINDOW_RIGHT - 654
+			X: WINDOW_WIDTH - 654
 			Y: 5
 			Height: 25
 			Width: 100
@@ -906,7 +906,7 @@ Container@EDITOR_WORLD_ROOT:
 			TooltipText: button-editor-world-root-redo.tooltip
 			TooltipContainer: TOOLTIP_CONTAINER
 		Button@COPY_BUTTON:
-			X: WINDOW_RIGHT - 544
+			X: WINDOW_WIDTH - 544
 			Y: 5
 			Height: 25
 			Width: 100
@@ -917,7 +917,7 @@ Container@EDITOR_WORLD_ROOT:
 			TooltipText: button-editor-world-root-copy.tooltip
 			TooltipContainer: TOOLTIP_CONTAINER
 		Button@PASTE_BUTTON:
-			X: WINDOW_RIGHT - 434
+			X: WINDOW_WIDTH - 434
 			Y: 5
 			Height: 25
 			Width: 100
@@ -928,7 +928,7 @@ Container@EDITOR_WORLD_ROOT:
 			TooltipText: button-editor-world-root-paste.tooltip
 			TooltipContainer: TOOLTIP_CONTAINER
 		DropDownButton@OVERLAY_BUTTON:
-			X: WINDOW_RIGHT - 914
+			X: WINDOW_WIDTH - 914
 			Y: 5
 			Width: 140
 			Height: 25
@@ -955,7 +955,7 @@ ScrollPanel@CATEGORY_FILTER_PANEL:
 	ItemSpacing: 5
 	Children:
 		Container@SELECT_CATEGORIES_BUTTONS:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Children:
 				Button@SELECT_ALL:
@@ -974,7 +974,7 @@ ScrollPanel@CATEGORY_FILTER_PANEL:
 					Font: Bold
 		Checkbox@CATEGORY_TEMPLATE:
 			X: 5
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Visible: false
 
@@ -987,6 +987,6 @@ ScrollPanel@OVERLAY_PANEL:
 		Checkbox@CATEGORY_TEMPLATE:
 			X: 5
 			Y: 5
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Visible: false

--- a/mods/cnc/chrome/encyclopedia.yaml
+++ b/mods/cnc/chrome/encyclopedia.yaml
@@ -1,18 +1,18 @@
 Background@ENCYCLOPEDIA_PANEL:
 	Logic: EncyclopediaLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 900
 	Height: 600
 	Children:
 		Container@ENCYCLOPEDIA_CONTENT:
-			Width: PARENT_RIGHT - 40
-			Height: PARENT_BOTTOM - 80
+			Width: PARENT_WIDTH - 40
+			Height: PARENT_HEIGHT - 80
 			X: 20
 			Y: 20
 			Children:
 				Label@ENCYCLOPEDIA_TITLE:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Text: label-encyclopedia-title
 					Align: Center
@@ -20,37 +20,37 @@ Background@ENCYCLOPEDIA_PANEL:
 				ScrollPanel@ACTOR_LIST:
 					Y: 30
 					Width: 190
-					Height: PARENT_BOTTOM - 25
+					Height: PARENT_HEIGHT - 25
 					Children:
 						ScrollItem@HEADER:
 							Background: scrollheader
-							Width: PARENT_RIGHT - 27
+							Width: PARENT_WIDTH - 27
 							Height: 13
 							X: 2
 							Visible: false
 							Children:
 								Label@LABEL:
 									Font: TinyBold
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 13
 									Align: Center
 						ScrollItem@TEMPLATE:
-							Width: PARENT_RIGHT - 27
+							Width: PARENT_WIDTH - 27
 							Height: 25
 							X: 2
 							EnableChildMouseOver: True
 							Children:
 								LabelWithTooltip@TITLE:
 									X: 10
-									Width: PARENT_RIGHT - 20
+									Width: PARENT_WIDTH - 20
 									Height: 25
 									TooltipContainer: TOOLTIP_CONTAINER
 									TooltipTemplate: SIMPLE_TOOLTIP
 				Container@ACTOR_INFO:
-					X: PARENT_RIGHT - WIDTH
+					X: PARENT_WIDTH - WIDTH
 					Y: 30
-					Width: PARENT_RIGHT - 190 - 10
-					Height: PARENT_BOTTOM - 25
+					Width: PARENT_WIDTH - 190 - 10
+					Height: PARENT_HEIGHT - 25
 					Children:
 						Background@ACTOR_BG:
 							Width: 150
@@ -60,23 +60,23 @@ Background@ENCYCLOPEDIA_PANEL:
 								ActorPreview@ACTOR_PREVIEW:
 									X: 1
 									Y: 1
-									Width: PARENT_RIGHT - 2
-									Height: PARENT_BOTTOM - 2
+									Width: PARENT_WIDTH - 2
+									Height: PARENT_HEIGHT - 2
 						ScrollPanel@ACTOR_DESCRIPTION_PANEL:
 							X: 150 + 10
-							Width: PARENT_RIGHT - 150 - 10
+							Width: PARENT_WIDTH - 150 - 10
 							Height: 170
 							TopBottomSpacing: 8
 							Children:
 								Label@ACTOR_DESCRIPTION:
 									X: 8
 									Y: 8
-									Width: PARENT_RIGHT - 40
+									Width: PARENT_WIDTH - 40
 									VAlign: Top
 									Font: Regular
 		Button@BACK_BUTTON:
-			X: PARENT_RIGHT - 180
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 180
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-back

--- a/mods/cnc/chrome/gamesave-browser.yaml
+++ b/mods/cnc/chrome/gamesave-browser.yaml
@@ -1,12 +1,12 @@
 Container@GAMESAVE_BROWSER_PANEL:
 	Logic: GameSaveBrowserLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 716
 	Height: 435
 	Children:
 		Label@LOAD_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Font: BigBold
@@ -15,7 +15,7 @@ Container@GAMESAVE_BROWSER_PANEL:
 			Text: label-gamesave-browser-panel-load-title
 			Visible: False
 		Label@SAVE_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Font: BigBold
@@ -24,29 +24,29 @@ Container@GAMESAVE_BROWSER_PANEL:
 			Text: label-gamesave-browser-panel-save-title
 			Visible: False
 		Background@bg:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				ScrollPanel@GAME_LIST:
 					X: 15
 					Y: 15
-					Width: PARENT_RIGHT - 30
-					Height: PARENT_BOTTOM - 30
+					Width: PARENT_WIDTH - 30
+					Height: PARENT_HEIGHT - 30
 					Children:
 						ScrollItem@NEW_TEMPLATE:
-							Width: PARENT_RIGHT - 27
+							Width: PARENT_WIDTH - 27
 							Height: 25
 							X: 2
 							Visible: false
 							Children:
 								Label@TITLE:
-									Width: PARENT_RIGHT
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
 									Align: Center
 									Text: label-bg-title
 						ScrollItem@GAME_TEMPLATE:
-							Width: PARENT_RIGHT - 27
+							Width: PARENT_WIDTH - 27
 							Height: 25
 							X: 2
 							Visible: false
@@ -54,65 +54,65 @@ Container@GAMESAVE_BROWSER_PANEL:
 							Children:
 								LabelWithTooltip@TITLE:
 									X: 10
-									Width: PARENT_RIGHT - 200 - 10
+									Width: PARENT_WIDTH - 200 - 10
 									Height: 25
 									TooltipContainer: GAMESAVE_TOOLTIP_CONTAINER
 									TooltipTemplate: SIMPLE_TOOLTIP
 								Label@DATE:
-									X: PARENT_RIGHT - WIDTH - 10
+									X: PARENT_WIDTH - WIDTH - 10
 									Width: 200
 									Height: 25
 									Align: Right
 				Container@SAVE_WIDGETS:
 					X: 15
-					Y: PARENT_BOTTOM - 40
-					Width: PARENT_RIGHT - 30
+					Y: PARENT_HEIGHT - 40
+					Width: PARENT_WIDTH - 30
 					Height: 30
 					Visible: False
 					Children:
 						TextField@SAVE_TEXTFIELD:
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 25
 							Type: Filename
 				Button@CANCEL_BUTTON:
 					Key: escape
 					X: 0
-					Y: PARENT_BOTTOM - 1
+					Y: PARENT_HEIGHT - 1
 					Width: 140
 					Height: 35
 					Text: button-back
 				Button@DELETE_ALL_BUTTON:
-					X: PARENT_RIGHT - 370 - WIDTH
-					Y: PARENT_BOTTOM - 1
+					X: PARENT_WIDTH - 370 - WIDTH
+					Y: PARENT_HEIGHT - 1
 					Width: 100
 					Height: 35
 					Text: button-bg-delete-all
 				Button@DELETE_BUTTON:
-					X: PARENT_RIGHT - 260 - WIDTH
-					Y: PARENT_BOTTOM - 1
+					X: PARENT_WIDTH - 260 - WIDTH
+					Y: PARENT_HEIGHT - 1
 					Width: 100
 					Height: 35
 					Text: button-bg-delete
 					Key: Delete
 				Button@RENAME_BUTTON:
-					X: PARENT_RIGHT - 150 - WIDTH
-					Y: PARENT_BOTTOM - 1
+					X: PARENT_WIDTH - 150 - WIDTH
+					Y: PARENT_HEIGHT - 1
 					Width: 100
 					Height: 35
 					Text: button-bg-rename
 					Key: F2
 				Button@LOAD_BUTTON:
 					Key: return
-					X: PARENT_RIGHT - WIDTH
-					Y: PARENT_BOTTOM - 1
+					X: PARENT_WIDTH - WIDTH
+					Y: PARENT_HEIGHT - 1
 					Width: 140
 					Height: 35
 					Text: button-bg-load
 					Visible: False
 				Button@SAVE_BUTTON:
 					Key: return
-					X: PARENT_RIGHT - WIDTH
-					Y: PARENT_BOTTOM - 1
+					X: PARENT_WIDTH - WIDTH
+					Y: PARENT_HEIGHT - 1
 					Width: 140
 					Height: 35
 					Text: button-bg-save

--- a/mods/cnc/chrome/gamesave-loading.yaml
+++ b/mods/cnc/chrome/gamesave-loading.yaml
@@ -1,21 +1,21 @@
 Container@GAMESAVE_LOADING_SCREEN:
 	Logic: GameSaveLoadingLogic
-	Width: WINDOW_RIGHT
-	Height: WINDOW_BOTTOM
+	Width: WINDOW_WIDTH
+	Height: WINDOW_HEIGHT
 	Children:
 		LogicKeyListener@CANCEL_HANDLER:
 		Image@NOD:
-			X: WINDOW_RIGHT / 2 - 384
-			Y: (WINDOW_BOTTOM - 256) / 2
+			X: WINDOW_WIDTH / 2 - 384
+			Y: (WINDOW_HEIGHT - 256) / 2
 			ImageCollection: logos
 			ImageName: nod-load
 		Image@GDI:
-			X: WINDOW_RIGHT / 2 + 128
-			Y: (WINDOW_BOTTOM - 256) / 2
+			X: WINDOW_WIDTH / 2 + 128
+			Y: (WINDOW_HEIGHT - 256) / 2
 			ImageCollection: logos
 			ImageName: gdi-load
 		Image@EVA:
-			X: WINDOW_RIGHT - 128 - 43
+			X: WINDOW_WIDTH - 128 - 43
 			Y: 43
 			Width: 128
 			Height: 64
@@ -23,30 +23,30 @@ Container@GAMESAVE_LOADING_SCREEN:
 			ImageName: eva
 		Label@VERSION_LABEL:
 			Logic: VersionLabelLogic
-			X: WINDOW_RIGHT - 128 - 43
+			X: WINDOW_WIDTH - 128 - 43
 			Y: 116
 			Width: 128
 			Align: Center
 			Shadow: true
 		Background@BORDER:
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
+			Width: WINDOW_WIDTH
+			Height: WINDOW_HEIGHT
 			Background: shellmapborder
 		Label@TITLE:
-			Width: WINDOW_RIGHT
-			Y: 3 * WINDOW_BOTTOM / 4 - 29
+			Width: WINDOW_WIDTH
+			Y: 3 * WINDOW_HEIGHT / 4 - 29
 			Height: 25
 			Font: Bold
 			Align: Center
 			Text: label-gamesave-loading-screen-title
 		ProgressBar@PROGRESS:
-			X: (WINDOW_RIGHT - 500) / 2
-			Y: 3 * WINDOW_BOTTOM / 4
+			X: (WINDOW_WIDTH - 500) / 2
+			Y: 3 * WINDOW_HEIGHT / 4
 			Width: 500
 			Height: 20
 		Label@DESC:
-			Width: WINDOW_RIGHT
-			Y: 3 * WINDOW_BOTTOM / 4 + 19
+			Width: WINDOW_WIDTH
+			Y: 3 * WINDOW_HEIGHT / 4 + 19
 			Height: 25
 			Font: Regular
 			Align: Center

--- a/mods/cnc/chrome/ingame-chat.yaml
+++ b/mods/cnc/chrome/ingame-chat.yaml
@@ -1,6 +1,6 @@
 Container@CHAT_PANEL:
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: WINDOW_BOTTOM - HEIGHT - 56
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: WINDOW_HEIGHT - HEIGHT - 56
 	Width: 550
 	Height: 194
 	Logic: IngameChatLogic
@@ -13,22 +13,22 @@ Container@CHAT_PANEL:
 	Children:
 		LogicKeyListener@OPEN_CHAT_KEY_LISTENER:
 		Container@CHAT_OVERLAY:
-			Width: PARENT_RIGHT - 24
-			Height: PARENT_BOTTOM - 30
+			Width: PARENT_WIDTH - 24
+			Height: PARENT_HEIGHT - 30
 			Visible: false
 			Children:
 				TextNotificationsDisplay@CHAT_DISPLAY:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					DisplayDurationMs: 10000
 					BottomSpacing: 3
 		Container@CHAT_CHROME:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				WorldButton@CHAT_MODE:
 					Logic: AddFactionSuffixLogic
-					Y: PARENT_BOTTOM - HEIGHT
+					Y: PARENT_HEIGHT - HEIGHT
 					Width: 50
 					Height: 25
 					Text: button-chat-chrome-mode.label
@@ -40,13 +40,13 @@ Container@CHAT_PANEL:
 				TextField@CHAT_TEXTFIELD:
 					Logic: AddFactionSuffixLogic
 					X: 55
-					Y: PARENT_BOTTOM - HEIGHT
+					Y: PARENT_HEIGHT - HEIGHT
 					Width: 466
 					Height: 25
 				Button@CHAT_CLOSE:
 					Logic: AddFactionSuffixLogic
 					X: 526
-					Y: PARENT_BOTTOM - HEIGHT
+					Y: PARENT_HEIGHT - HEIGHT
 					Width: 24
 					Height: 25
 					Children:
@@ -58,7 +58,7 @@ Container@CHAT_PANEL:
 				LogicKeyListener@KEY_LISTENER:
 				ScrollPanel@CHAT_SCROLLPANEL:
 					Logic: AddFactionSuffixLogic
-					Y: PARENT_BOTTOM - HEIGHT - 30
+					Y: PARENT_HEIGHT - HEIGHT - 30
 					Width: 550
 					Height: 164
 					TopBottomSpacing: 3

--- a/mods/cnc/chrome/ingame-debug.yaml
+++ b/mods/cnc/chrome/ingame-debug.yaml
@@ -1,14 +1,14 @@
 Container@DEBUG_PANEL:
 	Logic: DebugMenuLogic
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		Label@TITLE:
 			Y: 16
 			Font: Bold
 			Text: label-debug-panel-title
 			Align: Center
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 20
 		Checkbox@INSTANT_BUILD:
 			X: 45
@@ -81,7 +81,7 @@ Container@DEBUG_PANEL:
 			Font: Bold
 			Text: label-debug-panel-visualizations-title
 			Align: Center
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 20
 		Checkbox@SHOW_UNIT_PATHS:
 			X: 45

--- a/mods/cnc/chrome/ingame-debuginfo.yaml
+++ b/mods/cnc/chrome/ingame-debuginfo.yaml
@@ -1,13 +1,13 @@
 Container@DEBUG_WIDGETS:
 	Logic: DebugLogic
-	X: WINDOW_RIGHT / 2 - WIDTH
+	X: WINDOW_WIDTH / 2 - WIDTH
 	Y: 60
 	Width: 100
 	Height: 55
 	Children:
 		Label@DEBUG_TEXT:
 			Y: 35
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 15
 			Align: Center
 			Font: Bold

--- a/mods/cnc/chrome/ingame-info-lobby-options.yaml
+++ b/mods/cnc/chrome/ingame-info-lobby-options.yaml
@@ -1,64 +1,64 @@
 Container@LOBBY_OPTIONS_PANEL:
-	Height: PARENT_BOTTOM
-	Width: PARENT_RIGHT
+	Height: PARENT_HEIGHT
+	Width: PARENT_WIDTH
 	Children:
 		ScrollPanel:
 			Logic: LobbyOptionsLogic
 			X: 15
 			Y: 15
-			Width: PARENT_RIGHT - 30
-			Height: PARENT_BOTTOM - 30
+			Width: PARENT_WIDTH - 30
+			Height: PARENT_HEIGHT - 30
 			Children:
 				Container@LOBBY_OPTIONS:
 					Y: 10
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Children:
 						Container@CHECKBOX_ROW_TEMPLATE:
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 30
 							Children:
 								Checkbox@A:
 									X: 10
-									Width: PARENT_RIGHT / 2 - 20
+									Width: PARENT_WIDTH / 2 - 20
 									Height: 20
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								Checkbox@B:
-									X: PARENT_RIGHT / 2 + 10
-									Width: PARENT_RIGHT / 2 - 20
+									X: PARENT_WIDTH / 2 + 10
+									Width: PARENT_WIDTH / 2 - 20
 									Height: 20
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 						Container@DROPDOWN_ROW_TEMPLATE:
 							Height: 60
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Children:
 								LabelForInput@A_DESC:
 									X: 10
-									Width: PARENT_RIGHT / 2 - 20
+									Width: PARENT_WIDTH / 2 - 20
 									Height: 20
 									Visible: False
 									For: A
 								DropDownButton@A:
 									X: 10
 									Y: 25
-									Width: PARENT_RIGHT / 2 - 20
+									Width: PARENT_WIDTH / 2 - 20
 									Height: 25
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								LabelForInput@B_DESC:
-									X: PARENT_RIGHT / 2 + 10
-									Width: PARENT_RIGHT / 2 - 20
+									X: PARENT_WIDTH / 2 + 10
+									Width: PARENT_WIDTH / 2 - 20
 									Height: 20
 									Visible: False
 									For: B
 								DropDownButton@B:
-									X: PARENT_RIGHT / 2 + 10
+									X: PARENT_WIDTH / 2 + 10
 									Y: 25
-									Width: PARENT_RIGHT / 2 - 20
+									Width: PARENT_WIDTH / 2 - 20
 									Height: 25
 									Font: Regular
 									Visible: False

--- a/mods/cnc/chrome/ingame-info.yaml
+++ b/mods/cnc/chrome/ingame-info.yaml
@@ -1,13 +1,13 @@
 Container@GAME_INFO_PANEL:
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 570
 	Height: 435
 	Logic: GameInfoLogic
 	Visible: False
 	Children:
 		Label@TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Text: label-game-info-panel-title
@@ -83,25 +83,25 @@ Container@GAME_INFO_PANEL:
 					Width: 140
 					Height: 35
 		Background@BACKGROUND:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				Container@STATS_PANEL:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 				Container@MAP_PANEL:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 				Container@OBJECTIVES_PANEL:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 				Container@DEBUG_PANEL:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 				Container@CHAT_PANEL:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 				Container@LOBBY_OPTIONS_PANEL:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT

--- a/mods/cnc/chrome/ingame-infobriefing.yaml
+++ b/mods/cnc/chrome/ingame-infobriefing.yaml
@@ -1,10 +1,10 @@
 Container@MAP_PANEL:
-	Height: PARENT_BOTTOM
-	Width: PARENT_RIGHT
+	Height: PARENT_HEIGHT
+	Width: PARENT_WIDTH
 	Logic: GameInfoBriefingLogic
 	Children:
 		Background@PREVIEW_BG:
-			X: (PARENT_RIGHT - WIDTH) / 2
+			X: (PARENT_WIDTH - WIDTH) / 2
 			Y: 15
 			Width: 362
 			Height: 202
@@ -21,10 +21,10 @@ Container@MAP_PANEL:
 		ScrollPanel@MAP_DESCRIPTION_PANEL:
 			X: 15
 			Y: 228
-			Width: PARENT_RIGHT - 30
-			Height: PARENT_BOTTOM - 228 - 15
+			Width: PARENT_WIDTH - 30
+			Height: PARENT_HEIGHT - 228 - 15
 			Children:
 				Label@MAP_DESCRIPTION:
 					X: 4
 					Y: 2
-					Width: PARENT_RIGHT - 32
+					Width: PARENT_WIDTH - 32

--- a/mods/cnc/chrome/ingame-infochat.yaml
+++ b/mods/cnc/chrome/ingame-infochat.yaml
@@ -1,8 +1,8 @@
 Container@CHAT_CONTAINER:
 	X: 15
 	Y: 15
-	Width: PARENT_RIGHT - 30
-	Height: PARENT_BOTTOM - 30
+	Width: PARENT_WIDTH - 30
+	Height: PARENT_HEIGHT - 30
 	Logic: IngameChatLogic
 		Templates:
 			Chat: CHAT_LINE_TEMPLATE
@@ -10,11 +10,11 @@ Container@CHAT_CONTAINER:
 			Mission: CHAT_LINE_TEMPLATE
 	Children:
 		Container@CHAT_CHROME:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Button@CHAT_MODE:
-					Y: PARENT_BOTTOM - HEIGHT
+					Y: PARENT_HEIGHT - HEIGHT
 					Width: 50
 					Height: 25
 					Text: button-chat-chrome-mode.label
@@ -24,11 +24,11 @@ Container@CHAT_CONTAINER:
 					TooltipContainer: TOOLTIP_CONTAINER
 				TextField@CHAT_TEXTFIELD:
 					X: 55
-					Y: PARENT_BOTTOM - HEIGHT
-					Width: PARENT_RIGHT - 55
+					Y: PARENT_HEIGHT - HEIGHT
+					Width: PARENT_WIDTH - 55
 					Height: 25
 				ScrollPanel@CHAT_SCROLLPANEL:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM - 30
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT - 30
 					TopBottomSpacing: 3
 					ItemSpacing: 2

--- a/mods/cnc/chrome/ingame-infoobjectives.yaml
+++ b/mods/cnc/chrome/ingame-infoobjectives.yaml
@@ -1,6 +1,6 @@
 Container@MISSION_OBJECTIVES:
-	Height: PARENT_BOTTOM
-	Width: PARENT_RIGHT
+	Height: PARENT_HEIGHT
+	Width: PARENT_WIDTH
 	Logic: GameInfoObjectivesLogic
 	Children:
 		Label@MISSION:
@@ -13,31 +13,31 @@ Container@MISSION_OBJECTIVES:
 		Label@MISSION_STATUS:
 			X: 95
 			Y: 17
-			Width: PARENT_RIGHT - 110
+			Width: PARENT_WIDTH - 110
 			Height: 20
 			Font: MediumBold
 		ScrollPanel@OBJECTIVES_PANEL:
 			X: 15
 			Y: 50
-			Width: PARENT_RIGHT - 30
-			Height: PARENT_BOTTOM - 65
+			Width: PARENT_WIDTH - 30
+			Height: PARENT_HEIGHT - 65
 			TopBottomSpacing: 15
 			ItemSpacing: 15
 			Children:
 				Container@OBJECTIVE_TEMPLATE:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 20
 					Children:
 						Label@OBJECTIVE_TYPE:
 							X: 10
 							Y: 1
 							Width: 70
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Align: Center
 						Checkbox@OBJECTIVE_STATUS:
 							X: 90
 							Y: 0
-							Width: PARENT_RIGHT - 100
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH - 100
+							Height: PARENT_HEIGHT
 							Disabled: True
 							TextColorDisabled: FFFFFF

--- a/mods/cnc/chrome/ingame-infostats.yaml
+++ b/mods/cnc/chrome/ingame-infostats.yaml
@@ -1,6 +1,6 @@
 Container@SKIRMISH_STATS:
-	Height: PARENT_BOTTOM
-	Width: PARENT_RIGHT
+	Height: PARENT_HEIGHT
+	Width: PARENT_WIDTH
 	Logic: GameInfoStatsLogic
 	Children:
 		Container@OBJECTIVE:
@@ -16,7 +16,7 @@ Container@SKIRMISH_STATS:
 				Label@STATS_STATUS:
 					X: 95
 					Y: 17
-					Width: PARENT_RIGHT - 110
+					Width: PARENT_WIDTH - 110
 					Height: 20
 					Font: MediumBold
 				Checkbox@STATS_CHECKBOX:
@@ -31,7 +31,7 @@ Container@SKIRMISH_STATS:
 		Container@STATS_HEADERS:
 			X: 17
 			Y: 80
-			Width: PARENT_RIGHT - 34
+			Width: PARENT_WIDTH - 34
 			Children:
 				Label@NAME:
 					X: 10
@@ -63,13 +63,13 @@ Container@SKIRMISH_STATS:
 		ScrollPanel@PLAYER_LIST:
 			X: 15
 			Y: 105
-			Width: PARENT_RIGHT - 30
-			Height: PARENT_BOTTOM - 120
+			Width: PARENT_WIDTH - 30
+			Height: PARENT_HEIGHT - 120
 			ItemSpacing: 5
 			Children:
 				ScrollItem@TEAM_TEMPLATE:
 					Background: scrollheader
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 20
 					X: 2
 					Visible: false
@@ -87,7 +87,7 @@ Container@SKIRMISH_STATS:
 							Height: 20
 							Font: Bold
 				Container@PLAYER_TEMPLATE:
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 25
 					X: 2
 					Children:
@@ -146,7 +146,7 @@ Container@SKIRMISH_STATS:
 									X: 7
 									Y: 7
 				Container@SPECTATOR_TEMPLATE:
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 25
 					X: 2
 					Children:

--- a/mods/cnc/chrome/ingame-menu.yaml
+++ b/mods/cnc/chrome/ingame-menu.yaml
@@ -1,12 +1,12 @@
 Container@INGAME_MENU:
-	Width: WINDOW_RIGHT
-	Height: WINDOW_BOTTOM
+	Width: WINDOW_WIDTH
+	Height: WINDOW_HEIGHT
 	Logic: IngameMenuLogic
 		Buttons: EXIT_EDITOR, PLAY_MAP, SAVE_MAP, ABORT_MISSION, BACK_TO_EDITOR, SURRENDER, RESTART, LOAD_GAME, SAVE_GAME, MUSIC, SETTINGS, RESUME
 		ButtonStride: 130, 0
 	Children:
 		Image@EVA:
-			X: WINDOW_RIGHT - 128 - 43
+			X: WINDOW_WIDTH - 128 - 43
 			Y: 43
 			Width: 128
 			Height: 64
@@ -14,19 +14,19 @@ Container@INGAME_MENU:
 			ImageName: eva
 		Label@VERSION_LABEL:
 			Logic: VersionLabelLogic
-			X: WINDOW_RIGHT - 128 - 43
+			X: WINDOW_WIDTH - 128 - 43
 			Y: 116
 			Width: 128
 			Align: Center
 			Contrast: true
 		Background@BORDER:
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
+			Width: WINDOW_WIDTH
+			Height: WINDOW_HEIGHT
 			Background: shellmapborder
 		Container@PANEL_ROOT:
 		Container@MENU_BUTTONS:
-			X: (WINDOW_RIGHT - WIDTH) / 2
-			Y: WINDOW_BOTTOM - 33 - HEIGHT - 10
+			X: (WINDOW_WIDTH - WIDTH) / 2
+			Y: WINDOW_HEIGHT - 33 - HEIGHT - 10
 			Width: 120
 			Height: 35
 			Children:

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -27,7 +27,7 @@ Container@INGAME_ROOT:
 				LogicTicker@DISCONNECT_WATCHER:
 					Logic: DisconnectWatcherLogic
 				Label@MISSION_TEXT:
-					X: WINDOW_RIGHT / 2 - 256
+					X: WINDOW_WIDTH / 2 - 256
 					Y: 22
 					Width: 512
 					Height: 25
@@ -35,11 +35,11 @@ Container@INGAME_ROOT:
 					Align: Center
 					Contrast: true
 				StrategicProgress@STRATEGIC_PROGRESS:
-					X: WINDOW_RIGHT / 2
+					X: WINDOW_WIDTH / 2
 					Y: 40
 				WorldInteractionController@INTERACTION_CONTROLLER:
-					Width: WINDOW_RIGHT
-					Height: WINDOW_BOTTOM
+					Width: WINDOW_WIDTH
+					Height: WINDOW_HEIGHT
 				Container@PLAYER_ROOT:
 		Container@MENU_ROOT:
 		TooltipContainer@TOOLTIP_CONTAINER:
@@ -49,8 +49,8 @@ Container@PERF_WIDGETS:
 	Logic: PerfDebugLogic
 	Children:
 		Label@PERF_TEXT:
-			X: WINDOW_RIGHT - 200
-			Y: WINDOW_BOTTOM - 90
+			X: WINDOW_WIDTH - 200
+			Y: WINDOW_HEIGHT - 90
 			Width: 170
 			Height: 40
 			Contrast: true
@@ -58,7 +58,7 @@ Container@PERF_WIDGETS:
 		Background@GRAPH_BG:
 			Logic: AddFactionSuffixLogic
 			X: 5
-			Y: WINDOW_BOTTOM - HEIGHT - 156
+			Y: WINDOW_HEIGHT - HEIGHT - 156
 			Width: 220
 			Height: 220
 			Background: panel-black
@@ -76,12 +76,12 @@ Container@OBSERVER_WIDGETS:
 		Container@PERF_ROOT:
 		Container@HPF_ROOT:
 			Logic: LoadIngameHierarchicalPathFinderOverlayLogic
-			X: WINDOW_RIGHT - WIDTH - 270
+			X: WINDOW_WIDTH - WIDTH - 270
 			Y: 40
 			Width: 175
 		ViewportController:
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
+			Width: WINDOW_WIDTH
+			Height: WINDOW_HEIGHT
 			TooltipContainer: TOOLTIP_CONTAINER
 			ZoomInKey: ZoomIn
 			ZoomOutKey: ZoomOut
@@ -98,12 +98,12 @@ Container@OBSERVER_WIDGETS:
 			BookmarkKeyCount: 4
 		Container@GAME_TIMER_BLOCK:
 			Logic: GameTimerLogic
-			X: WINDOW_RIGHT / 2 - WIDTH
+			X: WINDOW_WIDTH / 2 - WIDTH
 			Width: 100
 			Height: 55
 			Children:
 				LabelWithTooltip@GAME_TIMER:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 30
 					Align: Center
 					Font: Title
@@ -112,27 +112,27 @@ Container@OBSERVER_WIDGETS:
 					TooltipTemplate: SIMPLE_TOOLTIP
 				Label@GAME_TIMER_STATUS:
 					Y: 35
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 15
 					Align: Center
 					Font: Bold
 					Contrast: true
 		Container@MUTE_INDICATOR:
 			Logic: MuteIndicatorLogic
-			X: WINDOW_RIGHT - WIDTH - 295
+			X: WINDOW_WIDTH - WIDTH - 295
 			Y: 5
 			Width: 200
 			Height: 25
 			Children:
 				Image@ICON:
-					X: PARENT_RIGHT - WIDTH
+					X: PARENT_WIDTH - WIDTH
 					Y: 1
 					Width: 24
 					Height: 24
 					ImageCollection: sidebar-bits
 					ImageName: indicator-muted
 				Label@LABEL:
-					Width: PARENT_RIGHT - 30
+					Width: PARENT_WIDTH - 30
 					Height: 25
 					Align: Right
 					Text: label-mute-indicator
@@ -140,7 +140,7 @@ Container@OBSERVER_WIDGETS:
 		LogicKeyListener@OBSERVER_KEY_LISTENER:
 		MenuButton@OPTIONS_BUTTON:
 			Key: escape
-			X: WINDOW_RIGHT - 260 - WIDTH
+			X: WINDOW_WIDTH - 260 - WIDTH
 			Y: 5
 			Width: 30
 			Height: 25
@@ -154,7 +154,7 @@ Container@OBSERVER_WIDGETS:
 					ImageCollection: order-icons
 					ImageName: options
 		Background@RADAR:
-			X: WINDOW_RIGHT - WIDTH - 5
+			X: WINDOW_WIDTH - WIDTH - 5
 			Y: 5
 			Width: 256
 			Height: 256
@@ -163,17 +163,17 @@ Container@OBSERVER_WIDGETS:
 				Radar:
 					X: 1
 					Y: 1
-					Width: PARENT_RIGHT - 2
-					Height: PARENT_BOTTOM - 2
+					Width: PARENT_WIDTH - 2
+					Height: PARENT_HEIGHT - 2
 				VideoPlayer@PLAYER:
 					X: 1
 					Y: 1
-					Width: PARENT_RIGHT - 2
-					Height: PARENT_BOTTOM - 2
+					Width: PARENT_WIDTH - 2
+					Height: PARENT_HEIGHT - 2
 					Skippable: false
 		Background@REPLAY_PLAYER:
 			Logic: ReplayControlBarLogic
-			X: WINDOW_RIGHT - WIDTH - 5
+			X: WINDOW_WIDTH - WIDTH - 5
 			Y: 283
 			Width: 256
 			Height: 46
@@ -262,7 +262,7 @@ Container@OBSERVER_WIDGETS:
 			Logic: ObserverShroudSelectorLogic
 				CombinedViewKey: ObserverCombinedView
 				WorldViewKey: ObserverWorldView
-			X: WINDOW_RIGHT - WIDTH - 5
+			X: WINDOW_WIDTH - WIDTH - 5
 			Y: 260
 			Width: 256
 			Height: 25
@@ -276,12 +276,12 @@ Container@OBSERVER_WIDGETS:
 					Height: 16
 				Label@LABEL:
 					X: 40
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Shadow: True
 				Label@NOFLAG_LABEL:
 					X: 5
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Shadow: True
 		Container@INGAME_OBSERVERSTATS_BG:
@@ -311,33 +311,33 @@ Container@OBSERVER_WIDGETS:
 				Container@GRAPH_BG:
 					Y: 30
 					X: 0
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 24
 					Children:
 						Container@BASIC_STATS_HEADERS:
 							X: 0
 							Y: 0
 							Width: 705
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-player-header
 									Align: Left
@@ -346,7 +346,7 @@ Container@OBSERVER_WIDGETS:
 									X: 160
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-cash-header
 									Align: Right
@@ -355,7 +355,7 @@ Container@OBSERVER_WIDGETS:
 									X: 240
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-power-header
 									Align: Center
@@ -364,7 +364,7 @@ Container@OBSERVER_WIDGETS:
 									X: 320
 									Y: 0
 									Width: 40
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-kills-header
 									Align: Right
@@ -373,7 +373,7 @@ Container@OBSERVER_WIDGETS:
 									X: 360
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-deaths-header
 									Align: Right
@@ -382,7 +382,7 @@ Container@OBSERVER_WIDGETS:
 									X: 420
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-assets-destroyed-header
 									Align: Right
@@ -391,7 +391,7 @@ Container@OBSERVER_WIDGETS:
 									X: 500
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-assets-lost-header
 									Align: Right
@@ -400,7 +400,7 @@ Container@OBSERVER_WIDGETS:
 									X: 580
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-experience-header
 									Align: Right
@@ -409,7 +409,7 @@ Container@OBSERVER_WIDGETS:
 									X: 640
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-actions-min-header
 									Align: Right
@@ -418,32 +418,32 @@ Container@OBSERVER_WIDGETS:
 							X: 0
 							Y: 0
 							Width: 735
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 40
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-player-header
 									Shadow: True
 								Label@CASH_HEADER:
 									X: 160
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-cash-header
 									Align: Right
@@ -451,7 +451,7 @@ Container@OBSERVER_WIDGETS:
 								Label@INCOME_HEADER:
 									X: 240
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-income-header
 									Align: Right
@@ -459,7 +459,7 @@ Container@OBSERVER_WIDGETS:
 								Label@ASSETS_HEADER:
 									X: 320
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-assets-header
 									Align: Right
@@ -467,7 +467,7 @@ Container@OBSERVER_WIDGETS:
 								Label@EARNED_HEADER:
 									X: 400
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-earned-header
 									Align: Right
@@ -475,7 +475,7 @@ Container@OBSERVER_WIDGETS:
 								Label@SPENT_HEADER:
 									X: 480
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-spent-header
 									Align: Right
@@ -483,7 +483,7 @@ Container@OBSERVER_WIDGETS:
 								Label@HARVESTERS_HEADER:
 									X: 560
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-harvesters-header
 									Align: Right
@@ -491,7 +491,7 @@ Container@OBSERVER_WIDGETS:
 								Label@DERRICKS_HEADER:
 									X: 650
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-derricks-header
 									Align: Right
@@ -500,26 +500,26 @@ Container@OBSERVER_WIDGETS:
 							X: 0
 							Y: 0
 							Width: 400
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-production-stats-player-header
 									Align: Left
@@ -528,7 +528,7 @@ Container@OBSERVER_WIDGETS:
 									X: 160
 									Y: 0
 									Width: 100
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-production-stats-header
 									Shadow: True
@@ -536,26 +536,26 @@ Container@OBSERVER_WIDGETS:
 							X: 0
 							Y: 0
 							Width: 400
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-support-powers-player-header
 									Align: Left
@@ -564,7 +564,7 @@ Container@OBSERVER_WIDGETS:
 									X: 160
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-support-powers-header
 									Shadow: True
@@ -572,26 +572,26 @@ Container@OBSERVER_WIDGETS:
 							X: 0
 							Y: 0
 							Width: 400
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-army-player-header
 									Align: Left
@@ -600,7 +600,7 @@ Container@OBSERVER_WIDGETS:
 									X: 160
 									Y: 0
 									Width: 100
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-army-header
 									Shadow: True
@@ -608,26 +608,26 @@ Container@OBSERVER_WIDGETS:
 							X: 0
 							Y: 0
 							Width: 760
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-player-header
 									Align: Left
@@ -636,7 +636,7 @@ Container@OBSERVER_WIDGETS:
 									X: 160
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-assets-destroyed-header
 									Align: Right
@@ -645,7 +645,7 @@ Container@OBSERVER_WIDGETS:
 									X: 235
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-assets-lost-header
 									Align: Right
@@ -654,7 +654,7 @@ Container@OBSERVER_WIDGETS:
 									X: 310
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-units-killed-header
 									Align: Right
@@ -663,7 +663,7 @@ Container@OBSERVER_WIDGETS:
 									X: 385
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-units-dead-header
 									Align: Right
@@ -672,7 +672,7 @@ Container@OBSERVER_WIDGETS:
 									X: 460
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-buildings-killed-header
 									Align: Right
@@ -681,7 +681,7 @@ Container@OBSERVER_WIDGETS:
 									X: 535
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-buildings-dead-header
 									Align: Right
@@ -690,7 +690,7 @@ Container@OBSERVER_WIDGETS:
 									X: 610
 									Y: 0
 									Width: 90
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-army-value-header
 									Align: Right
@@ -699,7 +699,7 @@ Container@OBSERVER_WIDGETS:
 									X: 700
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-vision-header
 									Align: Right
@@ -707,7 +707,7 @@ Container@OBSERVER_WIDGETS:
 				ScrollPanel@PLAYER_STATS_PANEL:
 					X: 0
 					Y: 54
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 240
 					TopBottomSpacing: 0
 					BorderWidth: 0
@@ -718,27 +718,27 @@ Container@OBSERVER_WIDGETS:
 						ScrollItem@TEAM_TEMPLATE:
 							X: 0
 							Y: 0
-							Width: 650 #PARENT_RIGHT - 35
+							Width: 650 #PARENT_WIDTH - 35
 							Height: 24
 							Children:
 								ColorBlock@TEAM_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@TEAM_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@TEAM:
 									X: 10
 									Y: 0
-									Width: PARENT_RIGHT
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 						ScrollItem@BASIC_PLAYER_TEMPLATE:
@@ -751,81 +751,81 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 5
 									Y: 4
 									Width: 35
-									Height: PARENT_BOTTOM - 4
+									Height: PARENT_HEIGHT - 4
 									ImageName: random
 									ImageCollection: flags
 								Label@PLAYER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								Label@CASH:
 									X: 160
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@POWER:
 									X: 240
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Center
 									Shadow: True
 								Label@KILLS:
 									X: 320
 									Y: 0
 									Width: 40
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@DEATHS:
 									X: 360
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ASSETS_DESTROYED:
 									X: 420
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ASSETS_LOST:
 									X: 500
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@EXPERIENCE:
 									X: 580
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ACTIONS_MIN:
 									X: 640
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 						ScrollItem@ECONOMY_PLAYER_TEMPLATE:
@@ -838,74 +838,74 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 5
 									Y: 4
 									Width: 35
-									Height: PARENT_BOTTOM - 4
+									Height: PARENT_HEIGHT - 4
 									ImageName: random
 									ImageCollection: flags
 								Label@PLAYER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								Label@CASH:
 									X: 160
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@INCOME:
 									X: 240
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ASSETS:
 									X: 320
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@EARNED:
 									X: 400
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@SPENT:
 									X: 480
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@HARVESTERS:
 									X: 560
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@DERRICKS:
 									X: 650
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 						ScrollItem@PRODUCTION_PLAYER_TEMPLATE:
@@ -918,32 +918,32 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 5
 									Y: 4
 									Width: 35
-									Height: PARENT_BOTTOM - 4
+									Height: PARENT_HEIGHT - 4
 									ImageName: random
 									ImageCollection: flags
 								Label@PLAYER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								ObserverProductionIcons@PRODUCTION_ICONS:
 									X: 160
 									Y: 0
 									Width: 0
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									TooltipContainer: TOOLTIP_CONTAINER
 						ScrollItem@SUPPORT_POWERS_PLAYER_TEMPLATE:
 							X: 0
@@ -955,32 +955,32 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 5
 									Y: 4
 									Width: 35
-									Height: PARENT_BOTTOM - 4
+									Height: PARENT_HEIGHT - 4
 									ImageName: random
 									ImageCollection: flags
 								Label@PLAYER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								ObserverSupportPowerIcons@SUPPORT_POWER_ICONS:
 									X: 160
 									Y: 0
 									Width: 0
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									TooltipContainer: TOOLTIP_CONTAINER
 						ScrollItem@ARMY_PLAYER_TEMPLATE:
 							X: 0
@@ -992,32 +992,32 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 5
 									Y: 4
 									Width: 35
-									Height: PARENT_BOTTOM - 4
+									Height: PARENT_HEIGHT - 4
 									ImageName: random
 									ImageCollection: flags
 								Label@PLAYER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								ObserverArmyIcons@ARMY_ICONS:
 									X: 160
 									Y: 0
 									Width: 0
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									TooltipContainer: TOOLTIP_CONTAINER
 						ScrollItem@COMBAT_PLAYER_TEMPLATE:
 							X: 0
@@ -1029,101 +1029,101 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 5
 									Y: 4
 									Width: 35
-									Height: PARENT_BOTTOM - 4
+									Height: PARENT_HEIGHT - 4
 									ImageName: random
 									ImageCollection: flags
 								Label@PLAYER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								Label@ASSETS_DESTROYED:
 									X: 160
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ASSETS_LOST:
 									X: 235
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@UNITS_KILLED:
 									X: 310
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@UNITS_DEAD:
 									X: 385
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_KILLED:
 									X: 460
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_DEAD:
 									X: 535
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ARMY_VALUE:
 									X: 610
 									Y: 0
 									Width: 90
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@VISION:
 									X: 700
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 				Container@INCOME_GRAPH_CONTAINER:
 					X: 0
 					Y: 30
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Visible: False
 					Children:
 						ColorBlock@GRAPH_BACKGROUND:
 							X: 0
 							Y: 0
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Color: 00000090
 						LineGraph@INCOME_GRAPH:
 							X: 0
 							Y: 0
-							Width: PARENT_RIGHT - 5
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH - 5
+							Height: PARENT_HEIGHT
 							ValueFormat: ${0}
 							YAxisValueFormat: ${0:F0}
 							XAxisSize: 40
@@ -1135,21 +1135,21 @@ Container@OBSERVER_WIDGETS:
 				Container@ARMY_VALUE_GRAPH_CONTAINER:
 					X: 0
 					Y: 30
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Visible: False
 					Children:
 						ColorBlock@GRAPH_BACKGROUND:
 							X: 0
 							Y: 0
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Color: 00000090
 						LineGraph@ARMY_VALUE_GRAPH:
 							X: 0
 							Y: 0
-							Width: PARENT_RIGHT - 5
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH - 5
+							Height: PARENT_HEIGHT
 							ValueFormat: ${0}
 							YAxisValueFormat: ${0:F0}
 							XAxisSize: 40
@@ -1166,12 +1166,12 @@ Container@PLAYER_WIDGETS:
 		Container@PERF_ROOT:
 		Container@HPF_ROOT:
 			Logic: LoadIngameHierarchicalPathFinderOverlayLogic
-			X: WINDOW_RIGHT - WIDTH - 240
+			X: WINDOW_WIDTH - WIDTH - 240
 			Y: 40
 			Width: 175
 		ViewportController:
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
+			Width: WINDOW_WIDTH
+			Height: WINDOW_HEIGHT
 			TooltipTemplate: WORLD_TOOLTIP_FACTIONSUFFIX
 			TooltipContainer: TOOLTIP_CONTAINER
 			ZoomInKey: ZoomIn
@@ -1222,7 +1222,7 @@ Container@PLAYER_WIDGETS:
 					HotkeyCount: 6
 		Image@COMMAND_BAR_BACKGROUND:
 			X: 5
-			Y: WINDOW_BOTTOM - HEIGHT - 5
+			Y: WINDOW_HEIGHT - HEIGHT - 5
 			Width: 494
 			Height: 44
 			ImageCollection: sidebar
@@ -1232,7 +1232,7 @@ Container@PLAYER_WIDGETS:
 			Logic: CommandBarLogic
 				HighlightOnButtonPress: True
 			X: 14
-			Y: WINDOW_BOTTOM - HEIGHT - 14
+			Y: WINDOW_HEIGHT - HEIGHT - 14
 			Width: 311
 			Height: 26
 			Children:
@@ -1434,7 +1434,7 @@ Container@PLAYER_WIDGETS:
 		Container@STANCE_BAR:
 			Logic: StanceSelectorLogic
 			X: 335
-			Y: WINDOW_BOTTOM - HEIGHT - 14
+			Y: WINDOW_HEIGHT - HEIGHT - 14
 			Width: 155
 			Height: 26
 			Children:
@@ -1538,26 +1538,26 @@ Container@PLAYER_WIDGETS:
 							ImageName: hold-fire
 		Container@MUTE_INDICATOR:
 			Logic: MuteIndicatorLogic
-			X: WINDOW_RIGHT - WIDTH - 240
+			X: WINDOW_WIDTH - WIDTH - 240
 			Y: 5
 			Width: 200
 			Height: 25
 			Children:
 				Image@ICON:
-					X: PARENT_RIGHT - WIDTH
+					X: PARENT_WIDTH - WIDTH
 					Y: 1
 					Width: 24
 					Height: 24
 					ImageCollection: sidebar-bits
 					ImageName: indicator-muted
 				Label@LABEL:
-					Width: PARENT_RIGHT - 30
+					Width: PARENT_WIDTH - 30
 					Height: 25
 					Align: Right
 					Text: label-mute-indicator
 					Contrast: true
 		Image@SIDEBAR_BACKGROUND:
-			X: WINDOW_RIGHT - WIDTH - 5
+			X: WINDOW_WIDTH - WIDTH - 5
 			Y: 5
 			Width: 230
 			Height: 314
@@ -1682,7 +1682,7 @@ Container@PLAYER_WIDGETS:
 					Children:
 						ResourceBar@POWERBAR:
 							Width: 9
-							Height: PARENT_BOTTOM - 2
+							Height: PARENT_HEIGHT - 2
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP_FACTIONSUFFIX
 							IndicatorImage: indicator-left
@@ -1699,7 +1699,7 @@ Container@PLAYER_WIDGETS:
 						ResourceBar@SILOBAR:
 							X: 1
 							Width: 9
-							Height: PARENT_BOTTOM - 2
+							Height: PARENT_HEIGHT - 2
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP_FACTIONSUFFIX
 							IndicatorImage: indicator-right
@@ -1710,7 +1710,7 @@ Container@PLAYER_WIDGETS:
 					Logic: GameTimerLogic
 					X: 0
 					Y: 234
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 22
 					Align: Center
 					Font: TinyBold
@@ -1731,7 +1731,7 @@ Container@PLAYER_WIDGETS:
 							ImageName: power-normal
 				WorldLabelWithTooltip@CASH:
 					Logic: IngameCashCounterLogic
-					X: PARENT_RIGHT - WIDTH - 35
+					X: PARENT_WIDTH - WIDTH - 35
 					Y: 234
 					Width: 50
 					Height: 22
@@ -1741,7 +1741,7 @@ Container@PLAYER_WIDGETS:
 					TooltipTemplate: SIMPLE_TOOLTIP_FACTIONSUFFIX
 					Children:
 						Image@CASH_ICON:
-							X: PARENT_RIGHT
+							X: PARENT_WIDTH
 							Y: 3
 							ImageCollection: cash-icons
 							ImageName: cash-normal
@@ -1855,7 +1855,7 @@ Container@PLAYER_WIDGETS:
 									Y: 5
 									ImageCollection: production-icons
 		Container@PRODUCTION_BACKGROUND:
-			X: WINDOW_RIGHT - 5 - 18 - 194
+			X: WINDOW_WIDTH - 5 - 18 - 194
 			Y: 319
 			Children:
 				Background@ICON_TEMPLATE:
@@ -1865,7 +1865,7 @@ Container@PLAYER_WIDGETS:
 					Background: panel-black
 		ProductionPalette@PRODUCTION_PALETTE:
 			IconSize: 64, 48
-			X: WINDOW_RIGHT - 5 - 17 - 194
+			X: WINDOW_WIDTH - 5 - 17 - 194
 			Y: 320
 			Width: 192
 			TooltipContainer: TOOLTIP_CONTAINER
@@ -1882,18 +1882,18 @@ Container@PLAYER_WIDGETS:
 			BackgroundContainer: PRODUCTION_BACKGROUND
 			PreviousProductionTabKey: PreviousProductionTab
 			NextProductionTabKey: NextProductionTab
-			X: WINDOW_RIGHT - 5 - 18 - 194
+			X: WINDOW_WIDTH - 5 - 18 - 194
 			Y: 299
 			Width: 194
 			Height: 20
 
 Background@FMVPLAYER:
-	Width: WINDOW_RIGHT
-	Height: WINDOW_BOTTOM
+	Width: WINDOW_WIDTH
+	Height: WINDOW_HEIGHT
 	Background: panel-allblack
 	Children:
 		VideoPlayer@PLAYER:
 			X: 0
 			Y: 0
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
+			Width: WINDOW_WIDTH
+			Height: WINDOW_HEIGHT

--- a/mods/cnc/chrome/lobby-kickdialogs.yaml
+++ b/mods/cnc/chrome/lobby-kickdialogs.yaml
@@ -1,45 +1,45 @@
 Background@KICK_CLIENT_DIALOG:
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Logic: KickClientLogic
 	Background: scrollpanel-bg
 	Children:
 		Label@TITLE:
 			Y: 41
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Bold
 			Align: Center
 		Label@TEXTA:
 			Y: 68
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Regular
 			Align: Center
 			Text: label-kick-client-dialog-texta
 		Label@TEXTB:
 			Y: 86
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Regular
 			Align: Center
 			Text: label-kick-client-dialog-textb
 		Checkbox@PREVENT_REJOINING_CHECKBOX:
-			X: (PARENT_RIGHT - WIDTH) / 2
+			X: (PARENT_WIDTH - WIDTH) / 2
 			Y: 120
 			Width: 150
 			Height: 20
 			Font: Regular
 			Text: checkbox-kick-client-dialog-prevent-rejoining
 		Button@OK_BUTTON:
-			X: (PARENT_RIGHT - WIDTH) / 2 + 75
+			X: (PARENT_WIDTH - WIDTH) / 2 + 75
 			Y: 155
 			Width: 120
 			Height: 25
 			Text: button-kick-client-dialog
 			Font: Bold
 		Button@CANCEL_BUTTON:
-			X: (PARENT_RIGHT - WIDTH) / 2 - 75
+			X: (PARENT_WIDTH - WIDTH) / 2 - 75
 			Y: 155
 			Width: 120
 			Height: 25
@@ -47,33 +47,33 @@ Background@KICK_CLIENT_DIALOG:
 			Font: Bold
 
 Background@KICK_SPECTATORS_DIALOG:
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Logic: KickSpectatorsLogic
 	Background: scrollpanel-bg
 	Children:
 		Label@TITLE:
 			Y: 41
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Bold
 			Align: Center
 			Text: label-kick-spectators-dialog-title
 		Label@TEXT:
 			Y: 86
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Regular
 			Align: Center
 		Button@OK_BUTTON:
-			X: (PARENT_RIGHT - WIDTH) / 2 + 75
+			X: (PARENT_WIDTH - WIDTH) / 2 + 75
 			Y: 155
 			Width: 120
 			Height: 25
 			Text: button-kick-spectators-dialog-ok
 			Font: Bold
 		Button@CANCEL_BUTTON:
-			X: (PARENT_RIGHT - WIDTH) / 2 - 75
+			X: (PARENT_WIDTH - WIDTH) / 2 - 75
 			Y: 155
 			Width: 120
 			Height: 25
@@ -81,38 +81,38 @@ Background@KICK_SPECTATORS_DIALOG:
 			Font: Bold
 
 Background@FORCE_START_DIALOG:
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Background: scrollpanel-bg
 	Children:
 		Label@TITLE:
 			Y: 41
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Bold
 			Align: Center
 			Text: label-force-start-dialog-title
 		Label@TEXTA:
 			Y: 68
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Regular
 			Align: Center
 			Text: label-force-start-dialog-texta
 		Label@TEXTB:
 			Y: 86
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Regular
 			Align: Center
 			Text: label-force-start-dialog-textb
 		Container@KICK_WARNING:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Children:
 				Label@KICK_WARNING_A:
 					X: 0
 					Y: 107
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Bold
 					Align: Center
@@ -120,20 +120,20 @@ Background@FORCE_START_DIALOG:
 				Label@KICK_WARNING_B:
 					X: 0
 					Y: 124
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Bold
 					Align: Center
 					Text: label-kick-warning-b
 		Button@OK_BUTTON:
-			X: (PARENT_RIGHT - WIDTH) / 2 + 75
+			X: (PARENT_WIDTH - WIDTH) / 2 + 75
 			Y: 155
 			Width: 120
 			Height: 25
 			Text: button-force-start-dialog-start
 			Font: Bold
 		Button@CANCEL_BUTTON:
-			X: (PARENT_RIGHT - WIDTH) / 2 - 75
+			X: (PARENT_WIDTH - WIDTH) / 2 - 75
 			Y: 155
 			Width: 120
 			Height: 25

--- a/mods/cnc/chrome/lobby-mappreview.yaml
+++ b/mods/cnc/chrome/lobby-mappreview.yaml
@@ -1,78 +1,78 @@
 Container@MAP_PREVIEW:
 	Logic: MapPreviewLogic
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		Container@MAP_LARGE:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Background@MAP_BG:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 174
 					Background: panel-gray
 					Children:
 						MapPreview@MAP_PREVIEW:
 							X: 1
 							Y: 1
-							Width: PARENT_RIGHT - 2
-							Height: PARENT_BOTTOM - 2
+							Width: PARENT_WIDTH - 2
+							Height: PARENT_HEIGHT - 2
 							TooltipContainer: TOOLTIP_CONTAINER
 				LabelWithTooltip@MAP_TITLE:
 					Y: 173
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Bold
 					Align: Center
 					TooltipContainer: TOOLTIP_CONTAINER
 					TooltipTemplate: SIMPLE_TOOLTIP
 		Container@MAP_SMALL:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Background@MAP_BG:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 142
 					Background: panel-gray
 					Children:
 						MapPreview@MAP_PREVIEW:
 							X: 1
 							Y: 1
-							Width: PARENT_RIGHT - 2
-							Height: PARENT_BOTTOM - 2
+							Width: PARENT_WIDTH - 2
+							Height: PARENT_HEIGHT - 2
 							TooltipContainer: TOOLTIP_CONTAINER
 				LabelWithTooltip@MAP_TITLE:
 					Y: 143
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Bold
 					Align: Center
 					TooltipContainer: TOOLTIP_CONTAINER
 					TooltipTemplate: SIMPLE_TOOLTIP
 		Container@MAP_AVAILABLE:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Label@MAP_TYPE:
 					Y: 188
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: TinyBold
 					Align: Center
 					IgnoreMouseOver: true
 				Label@MAP_AUTHOR:
 					Y: 201
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
 		Container@MAP_INCOMPATIBLE:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Label@MAP_STATUS_A:
 					Y: 188
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
@@ -80,18 +80,18 @@ Container@MAP_PREVIEW:
 					IgnoreMouseOver: true
 				Label@MAP_STATUS_B:
 					Y: 201
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
 					Text: label-map-incompatible-status-b
 		Container@MAP_VALIDATING:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Label@MAP_STATUS_VALIDATING:
 					Y: 174
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
@@ -99,109 +99,109 @@ Container@MAP_PREVIEW:
 					IgnoreMouseOver: true
 				ProgressBar@MAP_VALIDATING_BAR:
 					Y: 194
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Indeterminate: True
 		Container@MAP_DOWNLOAD_AVAILABLE:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Label@MAP_TYPE:
 					Y: 158
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: TinyBold
 					Align: Center
 					IgnoreMouseOver: true
 				Label@MAP_AUTHOR:
 					Y: 171
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
 				Button@MAP_INSTALL:
 					Y: 194
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Text: button-map-download-available-install
 		Button@MAP_UPDATE:
 			Y: 195
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Text: button-map-preview-update
 		Container@MAP_UPDATE_DOWNLOAD_AVAILABLE:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Button@MAP_INSTALL:
 					Y: 166
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Text: button-map-update-download-available-install
 		Label@MAP_SEARCHING:
 			Y: 158
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Tiny
 			Align: Center
 			Text: label-map-preview-searching
 			IgnoreMouseOver: true
 		Container@MAP_UNAVAILABLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Children:
 				Label@a:
 					Y: 158
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
 					Text: label-map-unavailable-a
 				Label@b:
 					Y: 171
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
 					Text: label-map-unavailable-b
 		Label@MAP_ERROR:
 			Y: 158
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Tiny
 			Align: Center
 			Text: label-map-preview-error
 		Container@MAP_DOWNLOADING:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Label@MAP_STATUS_DOWNLOADING:
 					Y: 158
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
 				ProgressBar@MAP_PROGRESSBAR:
 					Y: 194
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Indeterminate: True
 		Button@MAP_RETRY:
 			Y: 194
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 		Container@MAP_UPDATE_AVAILABLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Children:
 				Label@a:
 					Y: 158
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
 					Text: label-map-update-available-a
 				Label@b:
 					Y: 171
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center

--- a/mods/cnc/chrome/lobby-music.yaml
+++ b/mods/cnc/chrome/lobby-music.yaml
@@ -1,12 +1,12 @@
 Container@LOBBY_MUSIC_BIN:
 	Logic: MusicPlayerLogic
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		LogicTicker@SONG_WATCHER:
 		Container@LABEL_CONTAINER:
 			Y: 0 - 23
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Children:
 				Label@MUSIC:
 					Width: 308
@@ -21,7 +21,7 @@ Container@LOBBY_MUSIC_BIN:
 					Text: label-container-title
 					Font: Bold
 				Label@LENGTH:
-					X: PARENT_RIGHT - 80
+					X: PARENT_WIDTH - 80
 					Height: 25
 					Width: 50
 					Text: label-music-controls-length
@@ -30,7 +30,7 @@ Container@LOBBY_MUSIC_BIN:
 		Background@CONTROLS:
 			Background: panel-transparent
 			Width: 308
-			Height: PARENT_BOTTOM
+			Height: PARENT_HEIGHT
 			Children:
 				Label@MUTE_LABEL:
 					X: 60
@@ -40,17 +40,17 @@ Container@LOBBY_MUSIC_BIN:
 					Font: Small
 				Label@TITLE_LABEL:
 					Y: 45
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 					Font: Bold
 				Label@TIME_LABEL:
 					Y: 65
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 				Container@BUTTONS:
-					X: (PARENT_RIGHT - WIDTH) / 2
+					X: (PARENT_WIDTH - WIDTH) / 2
 					Y: 100
 					Width: 131
 					Children:
@@ -127,7 +127,7 @@ Container@LOBBY_MUSIC_BIN:
 					Font: Regular
 					Text: checkbox-music-controls-shuffle
 				Checkbox@REPEAT:
-					X: PARENT_RIGHT - 15 - WIDTH
+					X: PARENT_WIDTH - 15 - WIDTH
 					Y: 150
 					Width: 70
 					Height: 20
@@ -142,16 +142,16 @@ Container@LOBBY_MUSIC_BIN:
 				ExponentialSlider@MUSIC_SLIDER:
 					X: 70
 					Y: 186
-					Width: PARENT_RIGHT - 80
+					Width: PARENT_WIDTH - 80
 					Height: 20
 					Ticks: 7
 		ScrollPanel@MUSIC_LIST:
 			X: 307
-			Width: PARENT_RIGHT - 307
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH - 307
+			Height: PARENT_HEIGHT
 			Children:
 				ScrollItem@MUSIC_TEMPLATE:
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 25
 					X: 2
 					Visible: false
@@ -159,36 +159,36 @@ Container@LOBBY_MUSIC_BIN:
 					Children:
 						LabelWithTooltip@TITLE:
 							X: 10
-							Width: PARENT_RIGHT - 50
+							Width: PARENT_WIDTH - 50
 							Height: 25
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 						Label@LENGTH:
-							X: PARENT_RIGHT - 60
+							X: PARENT_WIDTH - 60
 							Width: 50
 							Height: 25
 							Align: Right
 		Container@NO_MUSIC_LABEL:
 			X: 307
-			Width: PARENT_RIGHT - 307
+			Width: PARENT_WIDTH - 307
 			Visible: false
 			Children:
 				Label@TITLE:
 					Y: 75
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 25
 					Font: Bold
 					Align: Center
 					Text: label-no-music-title
 				Label@DESCA:
 					Y: 95
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 25
 					Align: Center
 					Text: label-no-music-desc-a
 				Label@DESCB:
 					Y: 115
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 25
 					Align: Center
 					Text: label-no-music-desc-b

--- a/mods/cnc/chrome/lobby-options.yaml
+++ b/mods/cnc/chrome/lobby-options.yaml
@@ -1,89 +1,89 @@
 Container@LOBBY_OPTIONS_BIN:
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		Label@TITLE:
 			Y: 0 - 24
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Bold
 			Align: Center
 			Text: label-lobby-options-bin-title
 		ScrollPanel:
 			Logic: LobbyOptionsLogic
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Container@LOBBY_OPTIONS:
 					Y: 10
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Children:
 						Container@CHECKBOX_ROW_TEMPLATE:
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 30
 							Children:
 								Checkbox@A:
 									X: 10
-									Width: PARENT_RIGHT / 3 - 20
+									Width: PARENT_WIDTH / 3 - 20
 									Height: 20
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								Checkbox@B:
-									X: PARENT_RIGHT / 3 + 10
-									Width: PARENT_RIGHT / 3 - 20
+									X: PARENT_WIDTH / 3 + 10
+									Width: PARENT_WIDTH / 3 - 20
 									Height: 20
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								Checkbox@C:
-									X: (PARENT_RIGHT / 3) * 2 + 10
-									Width: PARENT_RIGHT / 3 - 20
+									X: (PARENT_WIDTH / 3) * 2 + 10
+									Width: PARENT_WIDTH / 3 - 20
 									Height: 20
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 						Container@DROPDOWN_ROW_TEMPLATE:
 							Height: 60
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Children:
 								LabelForInput@A_DESC:
 									X: 10
-									Width: PARENT_RIGHT / 3 - 20
+									Width: PARENT_WIDTH / 3 - 20
 									Height: 20
 									Visible: False
 									For: A
 								DropDownButton@A:
 									X: 10
-									Width: PARENT_RIGHT / 3 - 20
+									Width: PARENT_WIDTH / 3 - 20
 									Y: 25
 									Height: 25
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								LabelForInput@B_DESC:
-									X: PARENT_RIGHT / 3 + 10
-									Width: PARENT_RIGHT / 3 - 20
+									X: PARENT_WIDTH / 3 + 10
+									Width: PARENT_WIDTH / 3 - 20
 									Height: 20
 									Visible: False
 									For: B
 								DropDownButton@B:
-									X: PARENT_RIGHT / 3 + 10
-									Width: PARENT_RIGHT / 3 - 20
+									X: PARENT_WIDTH / 3 + 10
+									Width: PARENT_WIDTH / 3 - 20
 									Y: 25
 									Height: 25
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								LabelForInput@C_DESC:
-									X: (PARENT_RIGHT / 3) * 2 + 10
-									Width: PARENT_RIGHT / 3 - 20
+									X: (PARENT_WIDTH / 3) * 2 + 10
+									Width: PARENT_WIDTH / 3 - 20
 									Height: 20
 									Visible: False
 									For: C
 								DropDownButton@C:
-									X: (PARENT_RIGHT / 3) * 2 + 10
-									Width: PARENT_RIGHT / 3 - 20
+									X: (PARENT_WIDTH / 3) * 2 + 10
+									Width: PARENT_WIDTH / 3 - 20
 									Y: 25
 									Height: 25
 									Font: Regular

--- a/mods/cnc/chrome/lobby-players.yaml
+++ b/mods/cnc/chrome/lobby-players.yaml
@@ -1,12 +1,12 @@
 Container@LOBBY_PLAYER_BIN:
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		Container@LABEL_CONTAINER:
 			X: 5
 			Y: 0 - 24
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Label@LABEL_LOBBY_NAME:
 					Width: 200
@@ -57,8 +57,8 @@ Container@LOBBY_PLAYER_BIN:
 					Align: Left
 					Font: Bold
 		ScrollPanel@LOBBY_PLAYERS:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			TopBottomSpacing: 5
 			ItemSpacing: 5
 			Children:
@@ -78,8 +78,8 @@ Container@LOBBY_PLAYER_BIN:
 								ColorBlock@LATENCY_COLOR:
 									X: 2
 									Y: 2
-									Width: PARENT_RIGHT - 4
-									Height: PARENT_BOTTOM - 4
+									Width: PARENT_WIDTH - 4
+									Height: PARENT_HEIGHT - 4
 						ClientTooltipRegion@LATENCY_REGION:
 							Width: 11
 							Height: 25
@@ -123,8 +123,8 @@ Container@LOBBY_PLAYER_BIN:
 								ColorBlock@COLORBLOCK:
 									X: 5
 									Y: 6
-									Width: PARENT_RIGHT - 35
-									Height: PARENT_BOTTOM - 12
+									Width: PARENT_WIDTH - 35
+									Height: PARENT_HEIGHT - 12
 						DropDownButton@FACTION:
 							X: 309
 							Width: 120
@@ -191,8 +191,8 @@ Container@LOBBY_PLAYER_BIN:
 								ColorBlock@LATENCY_COLOR:
 									X: 2
 									Y: 2
-									Width: PARENT_RIGHT - 4
-									Height: PARENT_BOTTOM - 4
+									Width: PARENT_WIDTH - 4
+									Height: PARENT_HEIGHT - 4
 						ClientTooltipRegion@LATENCY_REGION:
 							Width: 11
 							Height: 25
@@ -337,8 +337,8 @@ Container@LOBBY_PLAYER_BIN:
 								ColorBlock@LATENCY_COLOR:
 									X: 2
 									Y: 2
-									Width: PARENT_RIGHT - 4
-									Height: PARENT_BOTTOM - 4
+									Width: PARENT_WIDTH - 4
+									Height: PARENT_HEIGHT - 4
 						ClientTooltipRegion@LATENCY_REGION:
 							Width: 11
 							Height: 25
@@ -401,8 +401,8 @@ Container@LOBBY_PLAYER_BIN:
 								ColorBlock@LATENCY_COLOR:
 									X: 2
 									Y: 2
-									Width: PARENT_RIGHT - 4
-									Height: PARENT_BOTTOM - 4
+									Width: PARENT_WIDTH - 4
+									Height: PARENT_HEIGHT - 4
 						ClientTooltipRegion@LATENCY_REGION:
 							Width: 11
 							Height: 25

--- a/mods/cnc/chrome/lobby-servers.yaml
+++ b/mods/cnc/chrome/lobby-servers.yaml
@@ -1,11 +1,11 @@
 Container@LOBBY_SERVERS_BIN:
 	Logic: ServerListLogic
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		Container@LABEL_CONTAINER:
 			Y: 0 - 24
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Children:
 				Label@NAME:
 					X: 5
@@ -34,42 +34,42 @@ Container@LOBBY_SERVERS_BIN:
 					Font: Bold
 		LogicTicker@NOTICE_WATCHER:
 		Container@NOTICE_CONTAINER:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 19
 			Children:
 				Background@bg:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 20
 					Background: panel-black
 					Children:
 						Label@OUTDATED_VERSION_LABEL:
 							X: 5
-							Width: PARENT_RIGHT - 10
+							Width: PARENT_WIDTH - 10
 							Height: 18
 							Align: Center
 							Text: label-bg-outdated-version
 							Font: TinyBold
 						Label@UNKNOWN_VERSION_LABEL:
 							X: 5
-							Width: PARENT_RIGHT - 10
+							Width: PARENT_WIDTH - 10
 							Height: 18
 							Align: Center
 							Text: label-bg-unknown-version
 							Font: TinyBold
 						Label@PLAYTEST_AVAILABLE_LABEL:
 							X: 5
-							Width: PARENT_RIGHT - 10
+							Width: PARENT_WIDTH - 10
 							Height: 18
 							Align: Center
 							Text: label-bg-playtest-available
 							Font: TinyBold
 		ScrollPanel@SERVER_LIST:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				ScrollItem@HEADER_TEMPLATE:
 					Background: scrollheader
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 20
 					X: 2
 					Visible: false
@@ -77,11 +77,11 @@ Container@LOBBY_SERVERS_BIN:
 						Label@LABEL:
 							Y: 0 - 1
 							Font: TinyBold
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 20
 							Align: Center
 				ScrollItem@SERVER_TEMPLATE:
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 25
 					X: 2
 					EnableChildMouseOver: True
@@ -125,21 +125,21 @@ Container@LOBBY_SERVERS_BIN:
 							Width: 50
 							Height: 25
 		Label@PROGRESS_LABEL:
-			Y: (PARENT_BOTTOM - HEIGHT) / 2
-			Width: PARENT_RIGHT
+			Y: (PARENT_HEIGHT - HEIGHT) / 2
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Bold
 			Align: Center
 			Visible: false
 		DropDownButton@FILTERS_DROPDOWNBUTTON:
-			Y: PARENT_BOTTOM + 5
+			Y: PARENT_HEIGHT + 5
 			Width: 180
 			Height: 25
 			Text: dropdownbutton-lobby-servers-bin-filters
 			Font: Bold
 		Button@RELOAD_BUTTON:
 			X: 185
-			Y: PARENT_BOTTOM + 5
+			Y: PARENT_HEIGHT + 5
 			Width: 26
 			Height: 25
 			Children:
@@ -154,24 +154,24 @@ Container@LOBBY_SERVERS_BIN:
 					Children:
 						LogicTicker@ANIMATION:
 		Container@SELECTED_SERVER:
-			X: PARENT_RIGHT + 14
+			X: PARENT_WIDTH + 14
 			Width: 174
 			Height: 280
 			Children:
 				Background@MAP_BG:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 174
 					Background: panel-gray
 					Children:
 						MapPreview@SELECTED_MAP_PREVIEW:
 							X: 1
 							Y: 1
-							Width: PARENT_RIGHT - 2
-							Height: PARENT_BOTTOM - 2
+							Width: PARENT_WIDTH - 2
+							Height: PARENT_HEIGHT - 2
 							TooltipContainer: TOOLTIP_CONTAINER
 				LabelWithTooltip@SELECTED_MAP:
 					Y: 172
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Bold
 					Align: Center
@@ -179,25 +179,25 @@ Container@LOBBY_SERVERS_BIN:
 					TooltipTemplate: SIMPLE_TOOLTIP
 				Label@SELECTED_IP:
 					Y: 187
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
 				Label@SELECTED_STATUS:
 					Y: 203
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: TinyBold
 					Align: Center
 				Label@SELECTED_MOD_VERSION:
 					Y: 216
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
 				Label@SELECTED_PLAYERS:
 					Y: 229
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: TinyBold
 					Align: Center

--- a/mods/cnc/chrome/lobby.yaml
+++ b/mods/cnc/chrome/lobby.yaml
@@ -7,25 +7,25 @@ Container@SERVER_LOBBY:
 			System: SYSTEM_LINE_TEMPLATE
 			Mission: CHAT_LINE_TEMPLATE
 			Feedback: TRANSIENT_LINE_TEMPLATE
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 900
 	Height: 540
 	Children:
 		Label@SERVER_NAME:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center
 		Background@bg:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				Container@MAP_PREVIEW_ROOT:
-					X: PARENT_RIGHT - 15 - WIDTH
+					X: PARENT_WIDTH - 15 - WIDTH
 					Y: 30
 					Width: 174
 					Height: 250
@@ -92,7 +92,7 @@ Container@SERVER_LOBBY:
 							Height: 31
 							Text: button-multiplayer-tabs-servers-tab
 				Button@CHANGEMAP_BUTTON:
-					X: PARENT_RIGHT - WIDTH - 15
+					X: PARENT_WIDTH - WIDTH - 15
 					Y: 254
 					Width: 174
 					Height: 25
@@ -105,16 +105,16 @@ Container@SERVER_LOBBY:
 				Container@LOBBYCHAT:
 					X: 15
 					Y: 285
-					Width: PARENT_RIGHT - 30
-					Height: PARENT_BOTTOM - 300
+					Width: PARENT_WIDTH - 30
+					Height: PARENT_HEIGHT - 300
 					Children:
 						ScrollPanel@CHAT_DISPLAY:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM - 30
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT - 30
 							TopBottomSpacing: 3
 							ItemSpacing: 2
 						Button@CHAT_MODE:
-							Y: PARENT_BOTTOM - HEIGHT
+							Y: PARENT_HEIGHT - HEIGHT
 							Width: 50
 							Height: 25
 							Text: button-lobbychat-chat-mode.label
@@ -124,17 +124,17 @@ Container@SERVER_LOBBY:
 							TooltipContainer: TOOLTIP_CONTAINER
 						TextField@CHAT_TEXTFIELD:
 							X: 55
-							Y: PARENT_BOTTOM - HEIGHT
-							Width: PARENT_RIGHT - 55
+							Y: PARENT_HEIGHT - HEIGHT
+							Width: PARENT_WIDTH - 55
 							Height: 25
 		Button@DISCONNECT_BUTTON:
-			Y: PARENT_BOTTOM - 1
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-server-lobby-disconnect
 		Button@START_GAME_BUTTON:
-			X: PARENT_RIGHT - WIDTH
-			Y: PARENT_BOTTOM - 1
+			X: PARENT_WIDTH - WIDTH
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-server-lobby-start-game

--- a/mods/cnc/chrome/mainmenu-prompts.yaml
+++ b/mods/cnc/chrome/mainmenu-prompts.yaml
@@ -1,12 +1,12 @@
 Container@MAINMENU_INTRODUCTION_PROMPT:
 	Logic: IntroductionPromptLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 700
 	Height: 445
 	Children:
 		Label@PROMPT_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 37
 			Font: BigBold
@@ -14,19 +14,19 @@ Container@MAINMENU_INTRODUCTION_PROMPT:
 			Align: Center
 			Text: label-mainmenu-introduction-prompt-title
 		Background@bg:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				Label@DESC_A:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Y: 15
 					Height: 16
 					Font: Regular
 					Align: Center
 					Text: label-bg-desc-a
 				Label@DESC_B:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Y: 33
 					Height: 16
 					Font: Regular
@@ -35,8 +35,8 @@ Container@MAINMENU_INTRODUCTION_PROMPT:
 				ScrollPanel@SETTINGS_SCROLLPANEL:
 					X: 15
 					Y: 60
-					Width: PARENT_RIGHT - 30
-					Height: PARENT_BOTTOM - 75
+					Width: PARENT_WIDTH - 30
+					Height: PARENT_HEIGHT - 75
 					CollapseHiddenChildren: True
 					TopBottomSpacing: 5
 					ItemSpacing: 10
@@ -44,41 +44,41 @@ Container@MAINMENU_INTRODUCTION_PROMPT:
 					Children:
 						Background@PROFILE_SECTION_HEADER:
 							X: 5
-							Width: PARENT_RIGHT - 10
+							Width: PARENT_WIDTH - 10
 							Height: 13
 							Background: separator
 							ClickThrough: True
 							Children:
 								Label@LABEL:
-									Width: PARENT_RIGHT
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
 									Font: TinyBold
 									Align: Center
 									Text: label-profile-section-header
 						Container@ROW:
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 50
 							Children:
 								Container@PLAYER_CONTAINER:
 									X: 10
-									Width: PARENT_RIGHT / 2 - 20
+									Width: PARENT_WIDTH / 2 - 20
 									Children:
 										Label@PLAYER:
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 20
 											Text: label-player-container
 										TextField@PLAYERNAME:
 											Y: 25
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 25
 											MaxLength: 16
 											Text: Name
 								Container@PLAYERCOLOR_CONTAINER:
-									X: PARENT_RIGHT / 2 + 10
-									Width: PARENT_RIGHT / 2 - 20
+									X: PARENT_WIDTH / 2 + 10
+									Width: PARENT_WIDTH / 2 - 20
 									Children:
 										Label@COLOR:
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 20
 											Text: label-playercolor-container-color
 										DropDownButton@PLAYERCOLOR:
@@ -91,166 +91,166 @@ Container@MAINMENU_INTRODUCTION_PROMPT:
 												ColorBlock@COLORBLOCK:
 													X: 5
 													Y: 6
-													Width: PARENT_RIGHT - 35
-													Height: PARENT_BOTTOM - 12
+													Width: PARENT_WIDTH - 35
+													Height: PARENT_HEIGHT - 12
 						Container@SPACER:
 						Background@INPUT_SECTION_HEADER:
 							X: 5
-							Width: PARENT_RIGHT - 10
+							Width: PARENT_WIDTH - 10
 							Height: 13
 							Background: separator
 							ClickThrough: True
 							Children:
 								Label@LABEL:
-									Width: PARENT_RIGHT
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
 									Font: TinyBold
 									Align: Center
 									Text: label-input-section-header
 						Container@ROW:
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 50
 							Children:
 								Container@MOUSE_CONTROL_CONTAINER:
 									X: 10
-									Width: PARENT_RIGHT / 2 - 20
+									Width: PARENT_WIDTH / 2 - 20
 									Children:
 										Label@MOUSE_CONTROL_LABEL:
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 20
 											Font: Regular
 											Text: label-mouse-control-container
 										DropDownButton@MOUSE_CONTROL_DROPDOWN:
 											Y: 25
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 25
 											Font: Regular
 								Container@MOUSE_CONTROL_DESC_CLASSIC:
-									X: PARENT_RIGHT / 2 + 10
-									Width: PARENT_RIGHT / 2 - 20
+									X: PARENT_WIDTH / 2 + 10
+									Width: PARENT_WIDTH / 2 - 20
 									Children:
 										LabelWithHighlight@DESC_SELECTION:
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-classic-selection
 										LabelWithHighlight@DESC_COMMANDS:
 											Y: 17
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-classic-commands
 										LabelWithHighlight@DESC_BUILDINGS:
 											Y: 34
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-classic-buildings
 										LabelWithHighlight@DESC_SUPPORT:
 											Y: 51
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-classic-support
 										LabelWithHighlight@DESC_ZOOM:
 											Y: 68
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-classic-zoom
 										LabelWithHighlight@DESC_ZOOM_MODIFIER:
 											Y: 68
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-classic-zoom-modifier
 										LabelWithHighlight@DESC_SCROLL_RIGHT:
 											Y: 85
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-classic-scroll-right
 										LabelWithHighlight@DESC_SCROLL_MIDDLE:
 											Y: 85
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-classic-scroll-middle
 										Label@DESC_EDGESCROLL:
 											X: 9
 											Y: 102
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-classic-edgescroll
 								Container@MOUSE_CONTROL_DESC_MODERN:
-									X: PARENT_RIGHT / 2 + 10
-									Width: PARENT_RIGHT / 2 - 20
+									X: PARENT_WIDTH / 2 + 10
+									Width: PARENT_WIDTH / 2 - 20
 									Children:
 										LabelWithHighlight@DESC_SELECTION:
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-modern-selection
 										LabelWithHighlight@DESC_COMMANDS:
 											Y: 17
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-modern-commands
 										LabelWithHighlight@DESC_BUILDINGS:
 											Y: 34
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-modern-buildings
 										LabelWithHighlight@DESC_SUPPORT:
 											Y: 51
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-modern-support
 										LabelWithHighlight@DESC_ZOOM:
 											Y: 68
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-modern-zoom
 										LabelWithHighlight@DESC_ZOOM_MODIFIER:
 											Y: 68
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-modern-zoom-modifier
 										LabelWithHighlight@DESC_SCROLL_RIGHT:
 											Y: 85
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-modern-scroll-right
 										LabelWithHighlight@DESC_SCROLL_MIDDLE:
 											Y: 85
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-modern-scroll-middle
 										Label@DESC_EDGESCROLL:
 											X: 9
 											Y: 102
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 16
 											Font: Small
 											Text: label-mouse-control-desc-modern-edgescroll
 						Container@ROW:
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 20
 							Children:
 								Container@EDGESCROLL_CHECKBOX_CONTAINER:
 									X: 10
-									Width: PARENT_RIGHT / 2 - 20
+									Width: PARENT_WIDTH / 2 - 20
 									Children:
 										Checkbox@EDGESCROLL_CHECKBOX:
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 20
 											Font: Regular
 											Text: checkbox-edgescroll-container
@@ -258,63 +258,63 @@ Container@MAINMENU_INTRODUCTION_PROMPT:
 							Height: 30
 						Background@DISPLAY_SECTION_HEADER:
 							X: 5
-							Width: PARENT_RIGHT - 10
+							Width: PARENT_WIDTH - 10
 							Height: 13
 							Background: separator
 							ClickThrough: True
 							Children:
 								Label@LABEL:
-									Width: PARENT_RIGHT
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
 									Font: TinyBold
 									Align: Center
 									Text: label-display-section-header
 						Container@ROW:
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 50
 							Children:
 								Container@BATTLEFIELD_CAMERA_DROPDOWN_CONTAINER:
 									X: 10
-									Width: PARENT_RIGHT / 2 - 20
+									Width: PARENT_WIDTH / 2 - 20
 									Children:
 										Label@BATTLEFIELD_CAMERA:
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 20
 											Text: label-battlefield-camera-dropdown
 										DropDownButton@BATTLEFIELD_CAMERA_DROPDOWN:
 											Y: 25
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 25
 											Font: Regular
 								Container@UI_SCALE_DROPDOWN_CONTAINER:
-									X: PARENT_RIGHT / 2 + 10
-									Width: PARENT_RIGHT / 2 - 20
+									X: PARENT_WIDTH / 2 + 10
+									Width: PARENT_WIDTH / 2 - 20
 									Children:
 										Label@UI_SCALE:
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 20
 											Text: label-ui-scale-dropdown
 										DropDownButton@UI_SCALE_DROPDOWN:
 											Y: 25
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 25
 											Font: Regular
 						Container@ROW:
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 20
 							Children:
 								Container@CURSORDOUBLE_CHECKBOX_CONTAINER:
-									X: PARENT_RIGHT / 2 + 10
-									Width: PARENT_RIGHT / 2 - 20
+									X: PARENT_WIDTH / 2 + 10
+									Width: PARENT_WIDTH / 2 - 20
 									Children:
 										Checkbox@CURSORDOUBLE_CHECKBOX:
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 20
 											Font: Regular
 											Text: checkbox-cursordouble-container
 		Button@CONTINUE_BUTTON:
-			X: PARENT_RIGHT - WIDTH
-			Y: PARENT_BOTTOM - 1
+			X: PARENT_WIDTH - WIDTH
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-continue
@@ -323,13 +323,13 @@ Container@MAINMENU_INTRODUCTION_PROMPT:
 
 Container@MAINMENU_SYSTEM_INFO_PROMPT:
 	Logic: SystemInfoPromptLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 600
 	Height: 350
 	Children:
 		Label@PROMPT_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 37
 			Font: BigBold
@@ -337,28 +337,28 @@ Container@MAINMENU_SYSTEM_INFO_PROMPT:
 			Align: Center
 			Text: label-mainmenu-system-info-prompt-title
 		Background@bg:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				Label@PROMPT_TEXT_A:
 					X: 15
 					Y: 15
-					Width: PARENT_RIGHT - 30
+					Width: PARENT_WIDTH - 30
 					Height: 16
 					Align: Center
 					Text: label-bg-prompt-text-a
 				Label@PROMPT_TEXT_B:
 					X: 15
 					Y: 33
-					Width: PARENT_RIGHT - 30
+					Width: PARENT_WIDTH - 30
 					Height: 16
 					Align: Center
 					Text: label-bg-prompt-text-b
 				ScrollPanel@SYSINFO_DATA:
 					X: 15
 					Y: 63
-					Width: PARENT_RIGHT - 30
+					Width: PARENT_WIDTH - 30
 					TopBottomSpacing: 4
 					ItemSpacing: 4
 					Height: 240
@@ -376,8 +376,8 @@ Container@MAINMENU_SYSTEM_INFO_PROMPT:
 					Font: Regular
 					Text: checkbox-bg-sysinfo
 		Button@CONTINUE_BUTTON:
-			X: PARENT_RIGHT - WIDTH
-			Y: PARENT_BOTTOM - 1
+			X: PARENT_WIDTH - WIDTH
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-continue

--- a/mods/cnc/chrome/mainmenu.yaml
+++ b/mods/cnc/chrome/mainmenu.yaml
@@ -1,6 +1,6 @@
 Container@MENU_BACKGROUND:
-	Width: WINDOW_RIGHT
-	Height: WINDOW_BOTTOM
+	Width: WINDOW_WIDTH
+	Height: WINDOW_HEIGHT
 	Logic: MainMenuLogic
 	Children:
 		LogicKeyListener@GLOBAL_KEYHANDLER:
@@ -14,17 +14,17 @@ Container@MENU_BACKGROUND:
 		Container@SHELLMAP_DECORATIONS:
 			Children:
 				Image@NOD:
-					X: WINDOW_RIGHT / 2 - 384
-					Y: (WINDOW_BOTTOM - 256) / 2
+					X: WINDOW_WIDTH / 2 - 384
+					Y: (WINDOW_HEIGHT - 256) / 2
 					ImageCollection: logos
 					ImageName: nod-load
 				Image@GDI:
-					X: WINDOW_RIGHT / 2 + 128
-					Y: (WINDOW_BOTTOM - 256) / 2
+					X: WINDOW_WIDTH / 2 + 128
+					Y: (WINDOW_HEIGHT - 256) / 2
 					ImageCollection: logos
 					ImageName: gdi-load
 		Image@EVA:
-			X: WINDOW_RIGHT - 128 - 43
+			X: WINDOW_WIDTH - 128 - 43
 			Y: 43
 			Width: 128
 			Height: 64
@@ -32,28 +32,28 @@ Container@MENU_BACKGROUND:
 			ImageName: eva
 		Label@VERSION_LABEL:
 			Logic: VersionLabelLogic
-			X: WINDOW_RIGHT - 128 - 43
+			X: WINDOW_WIDTH - 128 - 43
 			Y: 116
 			Width: 128
 			Align: Center
 			Shadow: true
 		Background@BORDER:
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
+			Width: WINDOW_WIDTH
+			Height: WINDOW_HEIGHT
 			Background: shellmapborder
 		Container@MENUS:
-			X: (WINDOW_RIGHT - WIDTH) / 2
-			Y: WINDOW_BOTTOM - 33 - HEIGHT - 10
+			X: (WINDOW_WIDTH - WIDTH) / 2
+			Y: WINDOW_HEIGHT - 33 - HEIGHT - 10
 			Width: 890
 			Height: 35
 			Children:
 				Container@MAIN_MENU:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Children:
 						Label@MAINMENU_LABEL_TITLE:
 							X: 0
 							Y: 0 - 28
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 20
 							Text: label-main-menu-mainmenu-title
 							Align: Center
@@ -96,13 +96,13 @@ Container@MENU_BACKGROUND:
 							Height: 35
 							Text: button-quit
 				Container@SINGLEPLAYER_MENU:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Visible: False
 					Children:
 						Label@SINGLEPLAYER_MENU_TITLE:
 							X: 0
 							Y: 0 - 28
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 20
 							Text: label-singleplayer-title
 							Align: Center
@@ -140,13 +140,13 @@ Container@MENU_BACKGROUND:
 							Height: 35
 							Text: button-back
 				Container@EXTRAS_MENU:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Visible: False
 					Children:
 						Label@EXTRAS_MENU_TITLE:
 							X: 0
 							Y: 0 - 28
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 20
 							Text: button-extras-title
 							Align: Center
@@ -191,13 +191,13 @@ Container@MENU_BACKGROUND:
 							Height: 35
 							Text: button-back
 				Container@MAP_EDITOR_MENU:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Visible: False
 					Children:
 						Label@MAP_EDITOR_MENU_TITLE:
 							X: 0
 							Y: 0 - 28
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 20
 							Text: label-map-editor-title
 							Align: Center
@@ -228,26 +228,26 @@ Container@MENU_BACKGROUND:
 		Container@NEWS_BG:
 			Children:
 				DropDownButton@NEWS_BUTTON:
-					X: (WINDOW_RIGHT - WIDTH) / 2
+					X: (WINDOW_WIDTH - WIDTH) / 2
 					Y: 50
 					Width: 400
 					Height: 25
 					Text: dropdownbutton-news-bg-button
 					Font: Bold
 		Container@UPDATE_NOTICE:
-			X: (WINDOW_RIGHT - WIDTH) / 2
+			X: (WINDOW_WIDTH - WIDTH) / 2
 			Y: 75
 			Width: 128
 			Children:
 				Label@A:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 					Shadow: true
 					Text: label-update-notice-a
 				Label@B:
 					Y: 20
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 					Shadow: true
@@ -256,13 +256,13 @@ Container@MENU_BACKGROUND:
 			Logic: PerfDebugLogic
 			Children:
 				Label@PERF_TEXT:
-					X: WINDOW_RIGHT - WIDTH - 25
-					Y: WINDOW_BOTTOM - HEIGHT - 100
+					X: WINDOW_WIDTH - WIDTH - 25
+					Y: WINDOW_HEIGHT - HEIGHT - 100
 					Width: 170
 					Contrast: true
 					VAlign: Top
 				Background@GRAPH_BG:
-					X: WINDOW_RIGHT - WIDTH - 31
+					X: WINDOW_WIDTH - WIDTH - 31
 					Y: 31
 					Width: 220
 					Height: 220

--- a/mods/cnc/chrome/mapchooser.yaml
+++ b/mods/cnc/chrome/mapchooser.yaml
@@ -1,12 +1,12 @@
 Container@MAPCHOOSER_PANEL:
 	Logic: MapChooserLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 900
 	Height: 540
 	Children:
 		Label@TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Font: BigBold
@@ -14,8 +14,8 @@ Container@MAPCHOOSER_PANEL:
 			Align: Center
 			Text: label-mapchooser-panel-title
 		Background@bg:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				Button@SYSTEM_MAPS_TAB_BUTTON:
@@ -37,34 +37,34 @@ Container@MAPCHOOSER_PANEL:
 					Width: 135
 					Text: button-bg-user-maps-tab
 				Container@MAP_TAB_PANES:
-					Width: PARENT_RIGHT - 30
-					Height: PARENT_BOTTOM - 90
+					Width: PARENT_WIDTH - 30
+					Height: PARENT_HEIGHT - 90
 					X: 15
 					Y: 45
 					Children:
 						Container@SYSTEM_MAPS_TAB:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Children:
 								ScrollPanel@MAP_LIST:
-									Width: PARENT_RIGHT
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
 									ItemSpacing: 1
 						Container@REMOTE_MAPS_TAB:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Children:
 								ScrollPanel@MAP_LIST:
-									Width: PARENT_RIGHT
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
 									ItemSpacing: 1
 						Container@USER_MAPS_TAB:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Children:
 								ScrollPanel@MAP_LIST:
-									Width: PARENT_RIGHT
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
 									ItemSpacing: 1
 				ScrollItem@MAP_TEMPLATE:
 					Width: 210
@@ -74,7 +74,7 @@ Container@MAPCHOOSER_PANEL:
 					EnableChildMouseOver: True
 					Children:
 						MapPreview@PREVIEW:
-							X: (PARENT_RIGHT - WIDTH) / 2
+							X: (PARENT_WIDTH - WIDTH) / 2
 							Y: 3
 							Width: 204
 							Height: 204
@@ -82,40 +82,40 @@ Container@MAPCHOOSER_PANEL:
 							IgnoreMouseInput: true
 						LabelWithTooltip@TITLE:
 							X: 4
-							Y: PARENT_BOTTOM - HEIGHT - 33
-							Width: PARENT_RIGHT - 8
+							Y: PARENT_HEIGHT - HEIGHT - 33
+							Width: PARENT_WIDTH - 8
 							Height: 24
 							Align: Center
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 						Label@DETAILS:
-							Width: PARENT_RIGHT - 8
+							Width: PARENT_WIDTH - 8
 							Height: 12
 							X: 4
-							Y: PARENT_BOTTOM - HEIGHT - 26
+							Y: PARENT_HEIGHT - HEIGHT - 26
 							Align: Center
 							Font: Tiny
 						LabelWithTooltip@AUTHOR:
-							Width: PARENT_RIGHT - 8
+							Width: PARENT_WIDTH - 8
 							Height: 12
 							X: 4
-							Y: PARENT_BOTTOM - HEIGHT - 14
+							Y: PARENT_HEIGHT - HEIGHT - 14
 							Align: Center
 							Font: Tiny
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 						Label@SIZE:
-							Width: PARENT_RIGHT - 8
+							Width: PARENT_WIDTH - 8
 							Height: 12
 							X: 4
-							Y: PARENT_BOTTOM - HEIGHT - 2
+							Y: PARENT_HEIGHT - HEIGHT - 2
 							Align: Center
 							Font: Tiny
 				Container@FILTER_ORDER_CONTROLS:
 					X: 15
-					Y: PARENT_BOTTOM - 40
-					Width: PARENT_RIGHT - 30
-					Height: PARENT_BOTTOM
+					Y: PARENT_HEIGHT - 40
+					Width: PARENT_WIDTH - 30
+					Height: PARENT_HEIGHT
 					Children:
 						Label@FILTER_DESC:
 							Width: 40
@@ -139,52 +139,52 @@ Container@MAPCHOOSER_PANEL:
 							Width: 200
 							Height: 25
 						Label@ORDERBY_LABEL:
-							X: PARENT_RIGHT - WIDTH - 200 - 5
+							X: PARENT_WIDTH - WIDTH - 200 - 5
 							Width: 100
 							Height: 24
 							Font: Bold
 							Align: Right
 							Text: label-filter-order-controls-orderby
 						DropDownButton@ORDERBY:
-							X: PARENT_RIGHT - WIDTH
+							X: PARENT_WIDTH - WIDTH
 							Width: 200
 							Height: 25
 				Label@REMOTE_MAP_LABEL:
 					X: 140
 					Y: 539
-					Width: PARENT_RIGHT - 430
+					Width: PARENT_WIDTH - 430
 					Height: 35
 					Align: Center
 					Font: Bold
 				Button@BUTTON_CANCEL:
 					Key: escape
-					Y: PARENT_BOTTOM - 1
+					Y: PARENT_HEIGHT - 1
 					Width: 140
 					Height: 35
 					Text: button-back
 				Button@RANDOMMAP_BUTTON:
 					Key: space
-					X: PARENT_RIGHT - 150 - WIDTH
-					Y: PARENT_BOTTOM - 1
+					X: PARENT_WIDTH - 150 - WIDTH
+					Y: PARENT_HEIGHT - 1
 					Width: 140
 					Height: 35
 					Text: button-bg-randommap
 				Button@DELETE_MAP_BUTTON:
-					X: PARENT_RIGHT - 300 - WIDTH
-					Y: PARENT_BOTTOM - 1
+					X: PARENT_WIDTH - 300 - WIDTH
+					Y: PARENT_HEIGHT - 1
 					Width: 140
 					Height: 35
 					Text: button-bg-delete-map
 				Button@DELETE_ALL_MAPS_BUTTON:
-					X: PARENT_RIGHT - 450 - WIDTH
-					Y: PARENT_BOTTOM - 1
+					X: PARENT_WIDTH - 450 - WIDTH
+					Y: PARENT_HEIGHT - 1
 					Width: 140
 					Height: 35
 					Text: button-bg-delete-all-maps
 				Button@BUTTON_OK:
 					Key: return
-					X: PARENT_RIGHT - WIDTH
-					Y: PARENT_BOTTOM - 1
+					X: PARENT_WIDTH - WIDTH
+					Y: PARENT_HEIGHT - 1
 					Width: 140
 					Height: 35
 					Text: button-bg-ok

--- a/mods/cnc/chrome/missionbrowser.yaml
+++ b/mods/cnc/chrome/missionbrowser.yaml
@@ -1,43 +1,43 @@
 Container@MISSIONBROWSER_PANEL:
 	Logic: MissionBrowserLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 716
 	Height: 435
 	Children:
 		Label@MISSIONBROWSER_TITLE:
 			Y: 0 - 34
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Text: label-missions-title
 			Align: Center
 			Contrast: true
 			Font: BigBold
 		Background@BG:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				ScrollPanel@MISSION_LIST:
 					X: 15
 					Y: 15
 					Width: 313
-					Height: PARENT_BOTTOM - 30
+					Height: PARENT_HEIGHT - 30
 					Children:
 						ScrollItem@HEADER:
 							Background: scrollheader
-							Width: PARENT_RIGHT - 27
+							Width: PARENT_WIDTH - 27
 							Height: 13
 							X: 2
 							Visible: false
 							Children:
 								Label@LABEL:
 									Font: TinyBold
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 13
 									Align: Center
 						ScrollItem@TEMPLATE:
-							Width: PARENT_RIGHT - 27
+							Width: PARENT_WIDTH - 27
 							Height: 25
 							X: 2
 							Visible: False
@@ -45,7 +45,7 @@ Container@MISSIONBROWSER_PANEL:
 							Children:
 								LabelWithTooltip@TITLE:
 									X: 10
-									Width: PARENT_RIGHT - 20
+									Width: PARENT_WIDTH - 20
 									Height: 25
 									TooltipContainer: TOOLTIP_CONTAINER
 									TooltipTemplate: SIMPLE_TOOLTIP
@@ -53,24 +53,24 @@ Container@MISSIONBROWSER_PANEL:
 					X: 339
 					Y: 15
 					Width: 362
-					Height: PARENT_BOTTOM - 30
+					Height: PARENT_HEIGHT - 30
 					Children:
 						Background@MISSION_BG:
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 202
 							Background: panel-black
 							Children:
 								MapPreview@MISSION_PREVIEW:
 									X: 1
 									Y: 1
-									Width: PARENT_RIGHT - 2
-									Height: PARENT_BOTTOM - 2
+									Width: PARENT_WIDTH - 2
+									Height: PARENT_HEIGHT - 2
 									IgnoreMouseOver: True
 									IgnoreMouseInput: True
 									ShowSpawnPoints: False
 						Container@MISSION_TABS:
-							Width: PARENT_RIGHT
-							Y: PARENT_BOTTOM - 31
+							Width: PARENT_WIDTH
+							Y: PARENT_HEIGHT - 31
 							Children:
 								Button@MISSIONINFO_TAB:
 									Width: 178
@@ -85,110 +85,110 @@ Container@MISSIONBROWSER_PANEL:
 									Text: button-missionbrowser-panel-mission-options
 						Container@MISSION_DETAIL:
 							Y: 213
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM - 213 - 30
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT - 213 - 30
 							Children:
 								ScrollPanel@MISSION_DESCRIPTION_PANEL:
-									Height: PARENT_BOTTOM
-									Width: PARENT_RIGHT
+									Height: PARENT_HEIGHT
+									Width: PARENT_WIDTH
 									TopBottomSpacing: 5
 									Children:
 										Label@MISSION_DESCRIPTION:
 											X: 4
-											Width: PARENT_RIGHT - 32
+											Width: PARENT_WIDTH - 32
 											VAlign: Top
 											Font: Small
 								ScrollPanel@MISSION_OPTIONS:
-									Height: PARENT_BOTTOM
-									Width: PARENT_RIGHT
+									Height: PARENT_HEIGHT
+									Width: PARENT_WIDTH
 									TopBottomSpacing: 5
 									Children:
 										Container@CHECKBOX_ROW_TEMPLATE:
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 30
 											Children:
 												Checkbox@A:
 													X: 10
-													Width: PARENT_RIGHT / 2 - 25
+													Width: PARENT_WIDTH / 2 - 25
 													Height: 20
 													Visible: False
 													TooltipContainer: TOOLTIP_CONTAINER
 												Checkbox@B:
-													X: PARENT_RIGHT / 2 + 5
-													Width: PARENT_RIGHT / 2 - 25
+													X: PARENT_WIDTH / 2 + 5
+													Width: PARENT_WIDTH / 2 - 25
 													Height: 20
 													Visible: False
 													TooltipContainer: TOOLTIP_CONTAINER
 										Container@DROPDOWN_ROW_TEMPLATE:
 											Height: 60
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Children:
 												LabelForInput@A_DESC:
 													X: 10
-													Width: PARENT_RIGHT / 2 - 35
+													Width: PARENT_WIDTH / 2 - 35
 													Height: 20
 													Visible: False
 													For: A
 												DropDownButton@A:
 													X: 10
-													Width: PARENT_RIGHT / 2 - 35
+													Width: PARENT_WIDTH / 2 - 35
 													Y: 25
 													Height: 25
 													Visible: False
 													PanelRoot: MISSION_DROPDOWN_PANEL_ROOT
 													TooltipContainer: TOOLTIP_CONTAINER
 												LabelForInput@B_DESC:
-													X: PARENT_RIGHT / 2 + 5
-													Width: PARENT_RIGHT / 2 - 35
+													X: PARENT_WIDTH / 2 + 5
+													Width: PARENT_WIDTH / 2 - 35
 													Height: 20
 													Visible: False
 													For: B
 												DropDownButton@B:
-													X: PARENT_RIGHT / 2 + 5
-													Width: PARENT_RIGHT / 2 - 35
+													X: PARENT_WIDTH / 2 + 5
+													Width: PARENT_WIDTH / 2 - 35
 													Y: 25
 													Height: 25
 													Visible: False
 													PanelRoot: MISSION_DROPDOWN_PANEL_ROOT
 													TooltipContainer: TOOLTIP_CONTAINER
 		Button@BACK_BUTTON:
-			Y: PARENT_BOTTOM - 1
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-back
 			Font: Bold
 			Key: escape
 		Button@START_BRIEFING_VIDEO_BUTTON:
-			X: PARENT_RIGHT - 290
-			Y: PARENT_BOTTOM - 1
+			X: PARENT_WIDTH - 290
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-missionbrowser-panel-start-briefing-video
 			Font: Bold
 		Button@STOP_BRIEFING_VIDEO_BUTTON:
-			X: PARENT_RIGHT - 290
-			Y: PARENT_BOTTOM - 1
+			X: PARENT_WIDTH - 290
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-missionbrowser-panel-stop-briefing-video
 			Font: Bold
 		Button@START_INFO_VIDEO_BUTTON:
-			X: PARENT_RIGHT - 440
-			Y: PARENT_BOTTOM - 1
+			X: PARENT_WIDTH - 440
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-missionbrowser-panel-start-info-video
 			Font: Bold
 		Button@STOP_INFO_VIDEO_BUTTON:
-			X: PARENT_RIGHT - 440
-			Y: PARENT_BOTTOM - 1
+			X: PARENT_WIDTH - 440
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-missionbrowser-panel-stop-info-video
 			Font: Bold
 		Button@STARTGAME_BUTTON:
-			X: PARENT_RIGHT - 140
-			Y: PARENT_BOTTOM - 1
+			X: PARENT_WIDTH - 140
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-missionbrowser-panel-play
@@ -209,13 +209,13 @@ Container@MISSIONBROWSER_PANEL:
 		TooltipContainer@TOOLTIP_CONTAINER:
 
 Background@FULLSCREEN_PLAYER:
-	Width: WINDOW_RIGHT
-	Height: WINDOW_BOTTOM
+	Width: WINDOW_WIDTH
+	Height: WINDOW_HEIGHT
 	Background: panel-allblack
 	Visible: False
 	Children:
 		VideoPlayer@PLAYER:
 			X: 0
 			Y: 0
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
+			Width: WINDOW_WIDTH
+			Height: WINDOW_HEIGHT

--- a/mods/cnc/chrome/multiplayer-browser.yaml
+++ b/mods/cnc/chrome/multiplayer-browser.yaml
@@ -1,28 +1,28 @@
 Container@MULTIPLAYER_PANEL:
 	Logic: MultiplayerLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 900
 	Height: 540
 	Children:
 		Label@TITLE:
 			Text: label-multiplayer-title
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Font: BigBold
 			Contrast: true
 			Align: Center
 		Background@bg:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				Container@LABEL_CONTAINER:
 					X: 15
 					Y: 6
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						Label@NAME:
 							X: 5
@@ -57,27 +57,27 @@ Container@MULTIPLAYER_PANEL:
 					Height: 19
 					Children:
 						Background@bg:
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 20
 							Background: panel-black
 							Children:
 								Label@OUTDATED_VERSION_LABEL:
 									X: 5
-									Width: PARENT_RIGHT - 10
+									Width: PARENT_WIDTH - 10
 									Height: 20
 									Align: Center
 									Text: label-bg-outdated-version
 									Font: TinyBold
 								Label@UNKNOWN_VERSION_LABEL:
 									X: 5
-									Width: PARENT_RIGHT - 10
+									Width: PARENT_WIDTH - 10
 									Height: 20
 									Align: Center
 									Text: label-bg-unknown-version
 									Font: TinyBold
 								Label@PLAYTEST_AVAILABLE_LABEL:
 									X: 5
-									Width: PARENT_RIGHT - 10
+									Width: PARENT_WIDTH - 10
 									Height: 20
 									Align: Center
 									Text: label-bg-playtest-available
@@ -86,23 +86,23 @@ Container@MULTIPLAYER_PANEL:
 					X: 15
 					Y: 30
 					Width: 682
-					Height: PARENT_BOTTOM - 75
+					Height: PARENT_HEIGHT - 75
 					TopBottomSpacing: 2
 					Children:
 						ScrollItem@HEADER_TEMPLATE:
 							Background: scrollheader
-							Width: PARENT_RIGHT - 27
+							Width: PARENT_WIDTH - 27
 							Height: 20
 							X: 2
 							Visible: false
 							Children:
 								Label@LABEL:
 									Font: TinyBold
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Align: Center
 						ScrollItem@SERVER_TEMPLATE:
-							Width: PARENT_RIGHT - 27
+							Width: PARENT_WIDTH - 27
 							Height: 25
 							X: 2
 							EnableChildMouseOver: True
@@ -147,32 +147,32 @@ Container@MULTIPLAYER_PANEL:
 									Height: 25
 				Label@PROGRESS_LABEL:
 					X: 15
-					Y: 31 + (PARENT_BOTTOM - 75 - HEIGHT) / 2
+					Y: 31 + (PARENT_HEIGHT - 75 - HEIGHT) / 2
 					Width: 682
 					Height: 25
 					Font: Bold
 					Align: Center
 					Visible: false
 				Container@SELECTED_SERVER:
-					X: PARENT_RIGHT - WIDTH - 15
+					X: PARENT_WIDTH - WIDTH - 15
 					Y: 30
 					Width: 174
 					Height: 280
 					Children:
 						Background@MAP_BG:
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 174
 							Background: panel-gray
 							Children:
 								MapPreview@SELECTED_MAP_PREVIEW:
 									X: 1
 									Y: 1
-									Width: PARENT_RIGHT - 2
-									Height: PARENT_BOTTOM - 2
+									Width: PARENT_WIDTH - 2
+									Height: PARENT_HEIGHT - 2
 									TooltipContainer: TOOLTIP_CONTAINER
 						LabelWithTooltip@SELECTED_MAP:
 							Y: 173
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 25
 							Font: Bold
 							Align: Center
@@ -180,47 +180,47 @@ Container@MULTIPLAYER_PANEL:
 							TooltipTemplate: SIMPLE_TOOLTIP
 						Label@SELECTED_IP:
 							Y: 188
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 25
 							Font: Tiny
 							Align: Center
 						Label@SELECTED_STATUS:
 							Y: 204
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 25
 							Font: TinyBold
 							Align: Center
 						Label@SELECTED_MOD_VERSION:
 							Y: 217
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 25
 							Font: Tiny
 							Align: Center
 						Label@SELECTED_PLAYERS:
 							Y: 230
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 25
 							Font: TinyBold
 							Align: Center
 						Container@CLIENT_LIST_CONTAINER:
 							Y: 240
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 230
 						Button@JOIN_BUTTON:
 							Key: return
 							Y: 255
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 25
 							Text: button-selected-server-join
 				DropDownButton@FILTERS_DROPDOWNBUTTON:
 					X: 15
-					Y: PARENT_BOTTOM - 40
+					Y: PARENT_HEIGHT - 40
 					Width: 152
 					Height: 25
 					Text: dropdownbutton-bg-filters
 				Button@RELOAD_BUTTON:
 					X: 172
-					Y: PARENT_BOTTOM - 40
+					Y: PARENT_HEIGHT - 40
 					Width: 26
 					Height: 25
 					Children:
@@ -236,27 +236,27 @@ Container@MULTIPLAYER_PANEL:
 								LogicTicker@ANIMATION:
 				Label@PLAYER_COUNT:
 					X: 248
-					Y: PARENT_BOTTOM - 40
+					Y: PARENT_HEIGHT - 40
 					Width: 189
 					Height: 25
 					Align: Center
 					Font: Bold
 				Button@DIRECTCONNECT_BUTTON:
 					X: 487
-					Y: PARENT_BOTTOM - 40
+					Y: PARENT_HEIGHT - 40
 					Width: 100
 					Height: 25
 					Text: button-bg-directconnect
 				Button@CREATE_BUTTON:
 					X: 592
-					Y: PARENT_BOTTOM - 40
+					Y: PARENT_HEIGHT - 40
 					Width: 105
 					Height: 25
 					Text: button-bg-create
 		Button@BACK_BUTTON:
 			Key: escape
 			X: 0
-			Y: PARENT_BOTTOM - 1
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-back

--- a/mods/cnc/chrome/multiplayer-browserpanels.yaml
+++ b/mods/cnc/chrome/multiplayer-browserpanels.yaml
@@ -1,11 +1,11 @@
 ScrollPanel@MULTIPLAYER_CLIENT_LIST:
-	Width: PARENT_RIGHT
+	Width: PARENT_WIDTH
 	Height: 225
 	IgnoreChildMouseOver: true
 	Children:
 		ScrollItem@HEADER:
 			Background: scrollheader
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 13
 			X: 2
 			Y: 0
@@ -13,11 +13,11 @@ ScrollPanel@MULTIPLAYER_CLIENT_LIST:
 			Children:
 				Label@LABEL:
 					Font: TinyBold
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 13
 					Align: Center
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -31,24 +31,24 @@ ScrollPanel@MULTIPLAYER_CLIENT_LIST:
 					Visible: False
 				Label@LABEL:
 					X: 40
-					Width: PARENT_RIGHT - 50
+					Width: PARENT_WIDTH - 50
 					Height: 25
 					Shadow: True
 				Label@NOFLAG_LABEL:
 					X: 5
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Shadow: True
 
 ScrollPanel@MULTIPLAYER_FILTER_PANEL:
-	Width: PARENT_RIGHT
+	Width: PARENT_WIDTH
 	Height: 130
 	Background: panel-black
 	Children:
 		Checkbox@WAITING_FOR_PLAYERS:
 			X: 5
 			Y: 5
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Text: checkbox-multiplayer-filter-panel-waiting-for-players
 			TextColor: 32CD32
@@ -56,14 +56,14 @@ ScrollPanel@MULTIPLAYER_FILTER_PANEL:
 		Checkbox@EMPTY:
 			X: 5
 			Y: 30
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Text: checkbox-multiplayer-filter-panel-empty
 			Font: Regular
 		Checkbox@PASSWORD_PROTECTED:
 			X: 5
 			Y: 55
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Text: checkbox-multiplayer-filter-panel-password-protected
 			TextColor: FF0000
@@ -71,7 +71,7 @@ ScrollPanel@MULTIPLAYER_FILTER_PANEL:
 		Checkbox@ALREADY_STARTED:
 			X: 5
 			Y: 80
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Text: checkbox-multiplayer-filter-panel-already-started
 			TextColor: FFA500
@@ -79,7 +79,7 @@ ScrollPanel@MULTIPLAYER_FILTER_PANEL:
 		Checkbox@INCOMPATIBLE_VERSION:
 			X: 5
 			Y: 105
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Text: checkbox-multiplayer-filter-panel-incompatible-version
 			TextColor: BEBEBE

--- a/mods/cnc/chrome/multiplayer-createserver.yaml
+++ b/mods/cnc/chrome/multiplayer-createserver.yaml
@@ -1,12 +1,12 @@
 Container@MULTIPLAYER_CREATESERVER_PANEL:
 	Logic: ServerCreationLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT - 15) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT - 15) / 2
 	Width: 530
 	Height: 275
 	Children:
 		Label@TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Font: BigBold
@@ -14,8 +14,8 @@ Container@MULTIPLAYER_CREATESERVER_PANEL:
 			Align: Center
 			Text: label-multiplayer-createserver-panel-title
 		Background@bg:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				Label@SERVER_NAME_LABEL:
@@ -92,8 +92,8 @@ Container@MULTIPLAYER_CREATESERVER_PANEL:
 				Container@NOTICES_LAN:
 					X: 20
 					Y: 145
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						Label@ADVERTISING:
 							Width: 305
@@ -126,8 +126,8 @@ Container@MULTIPLAYER_CREATESERVER_PANEL:
 				Container@NOTICES_NO_UPNP:
 					X: 20
 					Y: 145
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						Label@ADVERTISING:
 							Width: 305
@@ -175,8 +175,8 @@ Container@MULTIPLAYER_CREATESERVER_PANEL:
 				Container@NOTICES_UPNP:
 					X: 20
 					Y: 145
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						Label@ADVERTISING:
 							Width: 305
@@ -206,26 +206,26 @@ Container@MULTIPLAYER_CREATESERVER_PANEL:
 							Align: Left
 							Text: label-notices-upnp-settings-a
 				Container@MAP_PREVIEW_ROOT:
-					X: PARENT_RIGHT - 189
+					X: PARENT_WIDTH - 189
 					Y: 15
 					Width: 174
 					Height: 250
 		Button@BACK_BUTTON:
 			Key: return
-			Y: PARENT_BOTTOM - 1
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-back
 		Button@MAP_BUTTON:
-			X: PARENT_RIGHT - WIDTH - 150
-			Y: PARENT_BOTTOM - 1
+			X: PARENT_WIDTH - WIDTH - 150
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-multiplayer-createserver-panel-change-map
 		Button@CREATE_BUTTON:
 			Key: return
-			X: PARENT_RIGHT - WIDTH
-			Y: PARENT_BOTTOM - 1
+			X: PARENT_WIDTH - WIDTH
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-multiplayer-createserver-panel-create

--- a/mods/cnc/chrome/multiplayer-directconnect.yaml
+++ b/mods/cnc/chrome/multiplayer-directconnect.yaml
@@ -1,12 +1,12 @@
 Container@DIRECTCONNECT_PANEL:
 	Logic: DirectConnectLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - 90) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - 90) / 2
 	Width: 370
 	Height: 125
 	Children:
 		Label@DIRECTCONNECT_LABEL_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Font: BigBold

--- a/mods/cnc/chrome/music.yaml
+++ b/mods/cnc/chrome/music.yaml
@@ -1,13 +1,13 @@
 Container@MUSIC_PANEL:
 	Logic: MusicPlayerLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 410
 	Height: 435
 	Children:
 		LogicTicker@SONG_WATCHER:
 		Label@TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Font: BigBold
@@ -15,18 +15,18 @@ Container@MUSIC_PANEL:
 			Align: Center
 			Text: label-music-title-panel-title
 		Background@bg:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				ScrollPanel@MUSIC_LIST:
 					X: 15
 					Y: 30
-					Width: PARENT_RIGHT - 30
-					Height: PARENT_BOTTOM - 125
+					Width: PARENT_WIDTH - 30
+					Height: PARENT_HEIGHT - 125
 					Children:
 						ScrollItem@MUSIC_TEMPLATE:
-							Width: PARENT_RIGHT - 27
+							Width: PARENT_WIDTH - 27
 							Height: 25
 							X: 2
 							Y: 0
@@ -35,19 +35,19 @@ Container@MUSIC_PANEL:
 							Children:
 								LabelWithTooltip@TITLE:
 									X: 10
-									Width: PARENT_RIGHT - 50
+									Width: PARENT_WIDTH - 50
 									Height: 25
 									TooltipContainer: TOOLTIP_CONTAINER
 									TooltipTemplate: SIMPLE_TOOLTIP
 								Label@LENGTH:
 									Width: 50
-									X: PARENT_RIGHT - 60
+									X: PARENT_WIDTH - 60
 									Align: Right
 									Height: 25
 				Container@LABEL_CONTAINER:
 					X: 25
 					Y: 4
-					Width: PARENT_RIGHT - 30
+					Width: PARENT_WIDTH - 30
 					Children:
 						Label@TITLE:
 							Width: 100
@@ -56,7 +56,7 @@ Container@MUSIC_PANEL:
 							Align: Center
 							Font: Bold
 						Label@TYPE:
-							X: PARENT_RIGHT - 85
+							X: PARENT_WIDTH - 85
 							Height: 25
 							Width: 50
 							Text: label-music-controls-length
@@ -64,8 +64,8 @@ Container@MUSIC_PANEL:
 							Font: Bold
 				Container@BUTTONS:
 					X: 15
-					Y: PARENT_BOTTOM - HEIGHT - 40
-					Width: PARENT_RIGHT - 30
+					Y: PARENT_HEIGHT - HEIGHT - 40
+					Width: PARENT_WIDTH - 30
 					Children:
 						Button@BUTTON_PREV:
 							Width: 26
@@ -133,66 +133,66 @@ Container@MUSIC_PANEL:
 									ImageCollection: music
 									ImageName: next
 						ExponentialSlider@MUSIC_SLIDER:
-							X: PARENT_RIGHT - WIDTH
+							X: PARENT_WIDTH - WIDTH
 							Y: 3
-							Width: PARENT_RIGHT - 145
+							Width: PARENT_WIDTH - 145
 							Height: 20
 							Ticks: 7
 				Label@TIME_LABEL:
-					X: (PARENT_RIGHT - WIDTH) / 2
-					Y: PARENT_BOTTOM - HEIGHT - 60 - 3
+					X: (PARENT_WIDTH - WIDTH) / 2
+					Y: PARENT_HEIGHT - HEIGHT - 60 - 3
 					Width: 140
 					Height: 25
 					Align: Center
 				Checkbox@SHUFFLE:
 					X: 15
-					Y: PARENT_BOTTOM - HEIGHT - 60
+					Y: PARENT_HEIGHT - HEIGHT - 60
 					Width: 85
 					Height: 20
 					Font: Regular
 					Text: checkbox-music-controls-shuffle
 				Checkbox@REPEAT:
-					X: PARENT_RIGHT - 15 - WIDTH
-					Y: PARENT_BOTTOM - HEIGHT - 60
+					X: PARENT_WIDTH - 15 - WIDTH
+					Y: PARENT_HEIGHT - HEIGHT - 60
 					Width: 70
 					Height: 20
 					Font: Regular
 					Text: checkbox-music-controls-loop
 				Container@NO_MUSIC_LABEL:
 					X: 15
-					Y: (PARENT_BOTTOM - HEIGHT - 60) / 2
-					Width: PARENT_RIGHT - 30
+					Y: (PARENT_HEIGHT - HEIGHT - 60) / 2
+					Width: PARENT_WIDTH - 30
 					Height: 75
 					Visible: false
 					Children:
 						Label@TITLE:
-							Width: PARENT_RIGHT - 24
+							Width: PARENT_WIDTH - 24
 							Height: 25
 							Font: Bold
 							Align: Center
 							Text: label-no-music-title
 						Label@DESCA:
 							Y: 20
-							Width: PARENT_RIGHT - 24
+							Width: PARENT_WIDTH - 24
 							Height: 25
 							Align: Center
 							Text: label-no-music-desc-a
 						Label@DESCB:
 							Y: 40
-							Width: PARENT_RIGHT - 24
+							Width: PARENT_WIDTH - 24
 							Height: 25
 							Align: Center
 							Text: label-no-music-desc-b
 		Button@BACK_BUTTON:
 			Key: escape
 			X: 0
-			Y: PARENT_BOTTOM - 1
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-back
 		Label@MUTE_LABEL:
 			X: 100
-			Y: PARENT_BOTTOM - 60 - 3
+			Y: PARENT_HEIGHT - 60 - 3
 			Width: 300
 			Height: 20
 			Font: Small

--- a/mods/cnc/chrome/playerprofile.yaml
+++ b/mods/cnc/chrome/playerprofile.yaml
@@ -4,114 +4,114 @@ Container@LOCAL_PROFILE_PANEL:
 	Height: 100
 	Children:
 		Background@PROFILE_HEADER:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 50
 			Background: panel-black
 			Children:
 				Label@PROFILE_NAME:
 					X: 10
 					Y: 5
-					Width: PARENT_RIGHT - 20
+					Width: PARENT_WIDTH - 20
 					Height: 25
 					Font: MediumBold
 				Label@PROFILE_RANK:
 					X: 10
 					Y: 24
-					Width: PARENT_RIGHT - 20
+					Width: PARENT_WIDTH - 20
 					Height: 25
 					Font: TinyBold
 				Button@DESTROY_KEY:
-					X: PARENT_RIGHT - 70
+					X: PARENT_WIDTH - 70
 					Y: 15
 					Width: 60
 					Height: 20
 					Font: TinyBold
 					Text: button-profile-header-logout
 		Background@BADGES_CONTAINER:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Y: 48
 			Visible: false
 			Background: panel-black
 		Background@GENERATE_KEYS:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				Label@DESC_A:
 					Y: 6
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-generate-keys-desc-a
 				Label@DESC_B:
 					Y: 22
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-generate-keys-desc-b
 				Label@DESC_C:
 					Y: 38
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-generate-keys-desc-c
 				Button@GENERATE_KEY:
-					X: (PARENT_RIGHT - WIDTH) / 2
+					X: (PARENT_WIDTH - WIDTH) / 2
 					Y: 70
 					Width: 240
 					Height: 20
 					Font: TinyBold
 					Text: button-generate-keys-key
 		Background@GENERATING_KEYS:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				Label@DESC_A:
 					Y: 14
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-generating-keys-desc-a
 				Label@DESC_B:
 					Y: 30
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-generating-keys-desc-b
 				ProgressBar:
-					X: (PARENT_RIGHT - WIDTH) / 2
+					X: (PARENT_WIDTH - WIDTH) / 2
 					Y: 70
 					Width: 240
 					Height: 20
 					Indeterminate: true
 		Background@REGISTER_FINGERPRINT:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				Label@DESC_A:
 					Y: 3
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-register-fingerprint-desc-a
 				Label@DESC_B:
 					Y: 19
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-register-fingerprint-desc-b
 				Label@DESC_C:
 					Y: 35
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
@@ -131,45 +131,45 @@ Container@LOCAL_PROFILE_PANEL:
 					Font: TinyBold
 					Text: button-continue
 		Background@CHECKING_FINGERPRINT:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				Label@DESC_A:
 					Y: 14
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-checking-fingerprint-desc-a
 				Label@DESC_B:
 					Y: 30
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-checking-fingerprint-desc-b
 				ProgressBar:
-					X: (PARENT_RIGHT - WIDTH) / 2
+					X: (PARENT_WIDTH - WIDTH) / 2
 					Y: 70
 					Width: 240
 					Height: 20
 					Indeterminate: true
 		Background@FINGERPRINT_NOT_FOUND:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				Label@DESC_A:
 					Y: 14
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-fingerprint-not-found-desc-a
 				Label@DESC_B:
 					Y: 30
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
@@ -182,20 +182,20 @@ Container@LOCAL_PROFILE_PANEL:
 					Font: TinyBold
 					Text: button-back
 		Background@CONNECTION_ERROR:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				Label@DESC_A:
 					Y: 14
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-connection-error-desc-a
 				Label@DESC_B:
 					Y: 30
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
@@ -210,10 +210,10 @@ Container@LOCAL_PROFILE_PANEL:
 
 Container@PLAYER_PROFILE_BADGES_INSERT:
 	Logic: PlayerProfileBadgesLogic
-	Width: PARENT_RIGHT
+	Width: PARENT_WIDTH
 	Children:
 		Container@BADGE_TEMPLATE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Children:
 				Badge@ICON:
@@ -224,6 +224,6 @@ Container@PLAYER_PROFILE_BADGES_INSERT:
 				Label@LABEL:
 					X: 36
 					Y: 2
-					Width: PARENT_RIGHT - 60
+					Width: PARENT_WIDTH - 60
 					Height: 24
 					Font: Bold

--- a/mods/cnc/chrome/replaybrowser.yaml
+++ b/mods/cnc/chrome/replaybrowser.yaml
@@ -1,12 +1,12 @@
 Container@REPLAYBROWSER_PANEL:
 	Logic: ReplayBrowserLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 900
 	Height: 540
 	Children:
 		Label@TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Font: BigBold
@@ -14,24 +14,24 @@ Container@REPLAYBROWSER_PANEL:
 			Align: Center
 			Text: label-replaybrowser-panel-title
 		Background@bg:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				Container@FILTER_AND_MANAGE_CONTAINER:
 					X: 15
 					Y: 15
 					Width: 285
-					Height: PARENT_BOTTOM
+					Height: PARENT_HEIGHT
 					Children:
 						Container@FILTERS:
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 320
 							Children:
 								Label@FILTERS_TITLE:
 									X: 85
 									Y: 0 - 9
-									Width: PARENT_RIGHT - 85
+									Width: PARENT_WIDTH - 85
 									Height: 25
 									Font: Bold
 									Align: Center
@@ -46,7 +46,7 @@ Container@REPLAYBROWSER_PANEL:
 								DropDownButton@FLT_GAMETYPE_DROPDOWNBUTTON:
 									X: 85
 									Y: 15
-									Width: PARENT_RIGHT - 85
+									Width: PARENT_WIDTH - 85
 									Height: 25
 									Text: dropdownbutton-filters-any
 								Label@FLT_DATE_DESC:
@@ -59,7 +59,7 @@ Container@REPLAYBROWSER_PANEL:
 								DropDownButton@FLT_DATE_DROPDOWNBUTTON:
 									X: 85
 									Y: 45
-									Width: PARENT_RIGHT - 85
+									Width: PARENT_WIDTH - 85
 									Height: 25
 									Text: dropdownbutton-filters-any
 								Label@FLT_DURATION_DESC:
@@ -72,7 +72,7 @@ Container@REPLAYBROWSER_PANEL:
 								DropDownButton@FLT_DURATION_DROPDOWNBUTTON:
 									X: 85
 									Y: 75
-									Width: PARENT_RIGHT - 85
+									Width: PARENT_WIDTH - 85
 									Height: 25
 									Text: dropdownbutton-filters-any
 								Label@FLT_MAPNAME_DESC:
@@ -85,7 +85,7 @@ Container@REPLAYBROWSER_PANEL:
 								DropDownButton@FLT_MAPNAME_DROPDOWNBUTTON:
 									X: 85
 									Y: 105
-									Width: PARENT_RIGHT - 85
+									Width: PARENT_WIDTH - 85
 									Height: 25
 									Text: dropdownbutton-filters-any
 								Label@FLT_PLAYER_DESC:
@@ -98,7 +98,7 @@ Container@REPLAYBROWSER_PANEL:
 								DropDownButton@FLT_PLAYER_DROPDOWNBUTTON:
 									X: 85
 									Y: 135
-									Width: PARENT_RIGHT - 85
+									Width: PARENT_WIDTH - 85
 									Height: 25
 									Text: dropdownbutton-filters-flt-player
 								Label@FLT_OUTCOME_DESC:
@@ -111,7 +111,7 @@ Container@REPLAYBROWSER_PANEL:
 								DropDownButton@FLT_OUTCOME_DROPDOWNBUTTON:
 									X: 85
 									Y: 165
-									Width: PARENT_RIGHT - 85
+									Width: PARENT_WIDTH - 85
 									Height: 25
 									Text: dropdownbutton-filters-any
 								Label@FLT_FACTION_DESC:
@@ -124,45 +124,45 @@ Container@REPLAYBROWSER_PANEL:
 								DropDownButton@FLT_FACTION_DROPDOWNBUTTON:
 									X: 85
 									Y: 195
-									Width: PARENT_RIGHT - 85
+									Width: PARENT_WIDTH - 85
 									Height: 25
 									Text: dropdownbutton-filters-any
 								Button@FLT_RESET_BUTTON:
 									X: 85
 									Y: 235
-									Width: PARENT_RIGHT - 85
+									Width: PARENT_WIDTH - 85
 									Height: 25
 									Text: button-filters-flt-reset
 									Font: Bold
 						Container@MANAGEMENT:
 							X: 85
 							Y: 395
-							Width: PARENT_RIGHT - 85
+							Width: PARENT_WIDTH - 85
 							Children:
 								Label@MANAGE_TITLE:
 									Y: 1
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Bold
 									Align: Center
 									Text: label-management-manage-title
 								Button@MNG_RENSEL_BUTTON:
 									Y: 30
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Text: button-management-mng-rensel
 									Font: Bold
 									Key: F2
 								Button@MNG_DELSEL_BUTTON:
 									Y: 60
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Text: button-management-mng-delsel
 									Font: Bold
 									Key: Delete
 								Button@MNG_DELALL_BUTTON:
 									Y: 90
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Text: button-management-mng-delall
 									Font: Bold
@@ -170,11 +170,11 @@ Container@REPLAYBROWSER_PANEL:
 					X: 314
 					Y: 15
 					Width: 383
-					Height: PARENT_BOTTOM - 45
+					Height: PARENT_HEIGHT - 45
 					Children:
 						Label@REPLAYBROWSER_LABEL_TITLE:
 							Y: 0 - 9
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 25
 							Text: label-replay-list-container-replaybrowser-title
 							Align: Center
@@ -182,12 +182,12 @@ Container@REPLAYBROWSER_PANEL:
 						ScrollPanel@REPLAY_LIST:
 							X: 0
 							Y: 15
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							CollapseHiddenChildren: True
 							Children:
 								ScrollItem@REPLAY_TEMPLATE:
-									Width: PARENT_RIGHT - 27
+									Width: PARENT_WIDTH - 27
 									Height: 25
 									X: 2
 									Visible: false
@@ -195,36 +195,36 @@ Container@REPLAYBROWSER_PANEL:
 									Children:
 										LabelWithTooltip@TITLE:
 											X: 10
-											Width: PARENT_RIGHT - 20
+											Width: PARENT_WIDTH - 20
 											Height: 25
 											TooltipContainer: TOOLTIP_CONTAINER
 											TooltipTemplate: SIMPLE_TOOLTIP
 				Container@MAP_PREVIEW_ROOT:
-					X: PARENT_RIGHT - WIDTH - 15
+					X: PARENT_WIDTH - WIDTH - 15
 					Y: 30
 					Width: 174
 					Height: 250
 				Container@REPLAY_INFO:
-					X: PARENT_RIGHT - WIDTH - 15
+					X: PARENT_WIDTH - WIDTH - 15
 					Y: 230
 					Width: 174
-					Height: PARENT_BOTTOM - 240
+					Height: PARENT_HEIGHT - 240
 					Children:
 						Label@DURATION:
 							Y: 21
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 15
 							Font: Tiny
 							Align: Center
 						ScrollPanel@PLAYER_LIST:
 							Y: 40
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM - 45
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT - 45
 							IgnoreChildMouseOver: true
 							Children:
 								ScrollItem@HEADER:
 									Background: scrollheader
-									Width: PARENT_RIGHT - 27
+									Width: PARENT_WIDTH - 27
 									Height: 13
 									X: 2
 									Y: 0
@@ -232,11 +232,11 @@ Container@REPLAYBROWSER_PANEL:
 									Children:
 										Label@LABEL:
 											Font: TinyBold
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 13
 											Align: Center
 								ScrollItem@TEMPLATE:
-									Width: PARENT_RIGHT - 27
+									Width: PARENT_WIDTH - 27
 									Height: 25
 									X: 2
 									Y: 0
@@ -249,24 +249,24 @@ Container@REPLAYBROWSER_PANEL:
 											Height: 16
 										Label@LABEL:
 											X: 40
-											Width: PARENT_RIGHT - 50
+											Width: PARENT_WIDTH - 50
 											Height: 25
 											Shadow: True
 										Label@NOFLAG_LABEL:
 											X: 5
-											Width: PARENT_RIGHT
+											Width: PARENT_WIDTH
 											Height: 25
 		Button@CANCEL_BUTTON:
 			Key: escape
 			X: 0
-			Y: PARENT_BOTTOM - 1
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-back
 		Button@WATCH_BUTTON:
 			Key: return
-			X: PARENT_RIGHT - 140
-			Y: PARENT_BOTTOM - 1
+			X: PARENT_WIDTH - 140
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-replaybrowser-panel-watch

--- a/mods/cnc/chrome/settings-advanced.yaml
+++ b/mods/cnc/chrome/settings-advanced.yaml
@@ -1,97 +1,97 @@
 Container@ADVANCED_PANEL:
 	Logic: AdvancedSettingsLogic
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		ScrollPanel@SETTINGS_SCROLLPANEL:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			CollapseHiddenChildren: True
 			TopBottomSpacing: 5
 			ItemSpacing: 10
 			Children:
 				Background@NETWORK_SECTION_HEADER:
 					X: 5
-					Width: PARENT_RIGHT - 24 - 10
+					Width: PARENT_WIDTH - 24 - 10
 					Height: 13
 					Background: separator
 					ClickThrough: True
 					Children:
 						Label@LABEL:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Font: TinyBold
 							Align: Center
 							Text: label-network-section-header
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@NAT_DISCOVERY_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@NAT_DISCOVERY:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-nat-discovery-container
 						Container@FETCH_NEWS_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@FETCH_NEWS_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-fetch-news-container
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@PERFGRAPH_CHECKBOX_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@PERFGRAPH_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-perfgraph-container
 						Container@CHECK_VERSION_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@CHECK_VERSION_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-check-version-container
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@PERFTEXT_CHECKBOX_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@PERFTEXT_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-perftext-container
 						Container@SENDSYSINFO_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@SENDSYSINFO_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-sendsysinfo-container
 								Label@SENDSYSINFO_DESC:
 									Y: 15
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 30
 									Font: Tiny
 									WordWrap: True
@@ -99,99 +99,99 @@ Container@ADVANCED_PANEL:
 				Container@SPACER:
 				Background@DEBUG_SECTION_HEADER:
 					X: 5
-					Width: PARENT_RIGHT - 24 - 10
+					Width: PARENT_WIDTH - 24 - 10
 					Height: 13
 					Background: separator
 					ClickThrough: True
 					Children:
 						Label@LABEL:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Font: TinyBold
 							Align: Center
 							Text: label-debug-section-header
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 40
 					Children:
 						Container@DEBUG_HIDDEN_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT - 10
+							Width: PARENT_WIDTH - 10
 							Children:
 								Label@A:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-debug-hidden-container-a
 									Align: Center
 								Label@B:
 									Y: 20
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-debug-hidden-container-b
 									Align: Center
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@BOTDEBUG_CHECKBOX_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@BOTDEBUG_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-botdebug-container
 						Container@CHECKBOTSYNC_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@CHECKBOTSYNC_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-checkbotsync-container
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@LUADEBUG_CHECKBOX_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@LUADEBUG_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-luadebug-container
 						Container@CHECKUNSYNCED_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@CHECKUNSYNCED_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-checkunsynced-container
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@REPLAY_COMMANDS_CHECKBOX_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@REPLAY_COMMANDS_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-replay-commands-container
 						Container@PERFLOGGING_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@PERFLOGGING_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-perflogging-container

--- a/mods/cnc/chrome/settings-audio.yaml
+++ b/mods/cnc/chrome/settings-audio.yaml
@@ -1,144 +1,144 @@
 Container@AUDIO_PANEL:
 	Logic: AudioSettingsLogic
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		ScrollPanel@SETTINGS_SCROLLPANEL:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			CollapseHiddenChildren: True
 			TopBottomSpacing: 5
 			ItemSpacing: 10
 			Children:
 				Background@AUDIO_SECTION_HEADER:
 					X: 5
-					Width: PARENT_RIGHT - 24 - 10
+					Width: PARENT_WIDTH - 24 - 10
 					Height: 13
 					Background: separator
 					ClickThrough: True
 					Children:
 						Label@LABEL:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Font: TinyBold
 							Align: Center
 							Text: label-audio-section-header
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@NO_AUDIO_DEVICE_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT - 10
+							Width: PARENT_WIDTH - 10
 							Children:
 								Label@NO_AUDIO_DEVICE:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Align: Center
 									Text: label-no-audio-device-container
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@CASH_TICKS_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@CASH_TICKS:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-cash-ticks-container
 						Container@MUTE_SOUND_CONTAINER:
 							X: 10
 							Y: 30
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@MUTE_SOUND:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-mute-sound-container
 						Container@SOUND_VOLUME_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@SOUND_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-sound-volume-container
 								ExponentialSlider@SOUND_VOLUME:
 									Y: 30
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Ticks: 7
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@MUTE_BACKGROUND_MUSIC_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@MUTE_BACKGROUND_MUSIC:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-mute-background-music-container.label
 									TooltipText: checkbox-mute-background-music-container.tooltip
 									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 						Container@MUSIC_VOLUME_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@MUSIC_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-music-title-volume-container
 								ExponentialSlider@MUSIC_VOLUME:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Ticks: 7
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@AUDIO_DEVICE_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@AUDIO_DEVICE_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-audio-device-container
 								DropDownButton@AUDIO_DEVICE:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 						Container@VIDEO_VOLUME_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@VIDEO_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-video-volume-container
 								ExponentialSlider@VIDEO_VOLUME:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Ticks: 7
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@RESTART_REQUIRED_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT - 10
+							Width: PARENT_WIDTH - 10
 							Children:
 								Label@AUDIO_RESTART_REQUIRED_DESC:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Tiny
 									Align: Center

--- a/mods/cnc/chrome/settings-display.yaml
+++ b/mods/cnc/chrome/settings-display.yaml
@@ -1,53 +1,53 @@
 Container@DISPLAY_PANEL:
 	Logic: DisplaySettingsLogic
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		ScrollPanel@SETTINGS_SCROLLPANEL:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			CollapseHiddenChildren: True
 			TopBottomSpacing: 5
 			ItemSpacing: 10
 			Children:
 				Background@PROFILE_SECTION_HEADER:
 					X: 5
-					Width: PARENT_RIGHT - 24 - 10
+					Width: PARENT_WIDTH - 24 - 10
 					Height: 13
 					Background: separator
 					ClickThrough: True
 					Children:
 						Label@LABEL:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Font: TinyBold
 							Align: Center
 							Text: label-profile-section-header
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@PLAYER_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								LabelForInput@PLAYER:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-player-container
 									For: PLAYERNAME
 								TextField@PLAYERNAME:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									MaxLength: 16
 									Text: Name
 						Container@PLAYERCOLOR_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								LabelForInput@COLOR:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-playercolor-container-color
 									For: PLAYERCOLOR
@@ -61,184 +61,184 @@ Container@DISPLAY_PANEL:
 										ColorBlock@COLORBLOCK:
 											X: 5
 											Y: 6
-											Width: PARENT_RIGHT - 35
-											Height: PARENT_BOTTOM - 12
+											Width: PARENT_WIDTH - 35
+											Height: PARENT_HEIGHT - 12
 				Container@SPACER:
 				Background@DISPLAY_SECTION_HEADER:
 					X: 5
-					Width: PARENT_RIGHT - 24 - 10
+					Width: PARENT_WIDTH - 24 - 10
 					Height: 13
 					Background: separator
 					ClickThrough: True
 					Children:
 						Label@LABEL:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Font: TinyBold
 							Align: Center
 							Text: label-display-section-header
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@BATTLEFIELD_CAMERA_DROPDOWN_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@BATTLEFIELD_CAMERA:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-battlefield-camera-dropdown
 								DropDownButton@BATTLEFIELD_CAMERA_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 						Container@TARGET_LINES_DROPDOWN_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@TARGET_LINES:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-target-lines-dropdown-container
 								DropDownButton@TARGET_LINES_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@UI_SCALE_DROPDOWN_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								LabelForInput@UI_SCALE:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-ui-scale-dropdown
 									For: UI_SCALE_DROPDOWN
 								DropDownButton@UI_SCALE_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 						Container@STATUS_BAR_DROPDOWN_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@STATUS_BARS:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-status-bar-dropdown-container-bars
 								DropDownButton@STATUS_BAR_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@CURSORDOUBLE_CHECKBOX_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@CURSORDOUBLE_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-cursordouble-container
 						Container@PLAYER_STANCE_COLORS_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@PLAYER_STANCE_COLORS_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-player-stance-colors-container.label
 									TooltipText: checkbox-player-stance-colors-container.tooltip
 									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@UI_FEEDBACK_CHECKBOX_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 10
+							Width: PARENT_WIDTH / 2 - 10
 							Children:
 								Checkbox@UI_FEEDBACK_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-ui-feedback-container.label
 									TooltipText: checkbox-ui-feedback-container.tooltip
 									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 						Container@TRANSIENTS_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@TRANSIENTS_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-transients-container.label
 									TooltipText: checkbox-transients-container.tooltip
 									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@HIDE_REPLAY_CHAT_CHECKBOX_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 10
+							Width: PARENT_WIDTH / 2 - 10
 							Children:
 								Checkbox@HIDE_REPLAY_CHAT_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-hide-replay-chat-container
 				Container@SPACER:
 				Background@VIDEO_SECTION_HEADER:
 					X: 5
-					Width: PARENT_RIGHT - 24 - 10
+					Width: PARENT_WIDTH - 24 - 10
 					Height: 13
 					Background: separator
 					ClickThrough: True
 					Children:
 						Label@LABEL:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Font: TinyBold
 							Align: Center
 							Text: label-video-section-header
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@VIDEO_MODE_DROPDOWN_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@VIDEO_MODE:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-video-mode-dropdown-container
 								DropDownButton@MODE_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 									Text: dropdownbutton-video-mode-dropdown-container
 						Container@WINDOW_RESOLUTION_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@WINDOW_SIZE:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-window-resolution-container-size
 								TextField@WINDOW_WIDTH:
@@ -263,88 +263,88 @@ Container@DISPLAY_PANEL:
 									MaxLength: 5
 									Type: Integer
 						Container@DISPLAY_SELECTION_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@DISPLAY_SELECTION_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-display-selection-container
 								DropDownButton@DISPLAY_SELECTION_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 									Text: dropdownbutton-display-selection-container-dropdown
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@FRAME_LIMIT_CHECKBOX_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@FRAME_LIMIT_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 						Container@FRAME_LIMIT_SLIDER_CONTAINER:
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Slider@FRAME_LIMIT_SLIDER:
 									X: 20
 									Y: 25
-									Width: PARENT_RIGHT - 20
+									Width: PARENT_WIDTH - 20
 									Height: 20
 									Ticks: 20
 									MinimumValue: 50
 									MaximumValue: 240
 						Container@VSYNC_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@VSYNC_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-vsync-container
 						Container@FRAME_LIMIT_GAMESPEED_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
+							X: PARENT_WIDTH / 2 + 10
 							Y: 25
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@FRAME_LIMIT_GAMESPEED_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-frame-limit-gamespeed-container
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@GL_PROFILE_DROPDOWN_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@GL_PROFILE:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-gl-profile-dropdown-container
 								DropDownButton@GL_PROFILE_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 30
 					Children:
 						Container@RESTART_REQUIRED_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT - 20
+							Width: PARENT_WIDTH - 20
 							Children:
 								Label@VIDEO_RESTART_REQUIRED_DESC:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Tiny
 									Text: label-restart-required-container-video-desc

--- a/mods/cnc/chrome/settings-hotkeys.yaml
+++ b/mods/cnc/chrome/settings-hotkeys.yaml
@@ -23,8 +23,8 @@ Container@HOTKEYS_PANEL:
 				Types: ControlGroups
 			Editor Commands:
 				Types: Editor
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		Label@FILTER_INPUT_LABEL:
 			Width: 103
@@ -36,72 +36,72 @@ Container@HOTKEYS_PANEL:
 			Width: 180
 			Height: 25
 		Label@CONTEXT_DROPDOWN_LABEL:
-			X: PARENT_RIGHT - WIDTH - 195 - 5
+			X: PARENT_WIDTH - WIDTH - 195 - 5
 			Width: 100
 			Height: 25
 			Font: Bold
 			Text: label-hotkeys-panel-context-dropdown
 			Align: Right
 		DropDownButton@CONTEXT_DROPDOWN:
-			X: PARENT_RIGHT - WIDTH
+			X: PARENT_WIDTH - WIDTH
 			Width: 195
 			Height: 25
 			Font: Bold
 		ScrollPanel@HOTKEY_LIST:
 			Y: 35
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM - 65 - 35
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT - 65 - 35
 			TopBottomSpacing: 5
 			ItemSpacing: 5
 			Children:
 				Container@HEADER:
-					Width: PARENT_RIGHT - 24 - 10
+					Width: PARENT_WIDTH - 24 - 10
 					Height: 18
 					Children:
 						Background@BACKGROUND:
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 13
 							Background: separator
 							ClickThrough: True
 						Label@LABEL:
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 13
 							Font: TinyBold
 							Align: Center
 				Container@TEMPLATE:
-					Width: (PARENT_RIGHT - 24) / 2 - 10
+					Width: (PARENT_WIDTH - 24) / 2 - 10
 					Height: 30
 					Visible: false
 					Children:
 						Label@FUNCTION:
 							Y: 0 - 1
-							Width: PARENT_RIGHT - 90 - 5
+							Width: PARENT_WIDTH - 90 - 5
 							Height: 25
 							Align: Right
 						Button@HOTKEY:
-							X: PARENT_RIGHT - WIDTH
+							X: PARENT_WIDTH - WIDTH
 							Width: 90
 							Height: 25
 							TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 		Container@HOTKEY_EMPTY_LIST:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Visible: false
 			Children:
 				Label@HOTKEY_EMPTY_LIST_MESSAGE:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Align: Center
 					Text: label-hotkey-empty-list-message
 		Background@HOTKEY_REMAP_BGND:
-			Y: PARENT_BOTTOM - HEIGHT - 1
-			Width: PARENT_RIGHT
+			Y: PARENT_HEIGHT - HEIGHT - 1
+			Width: PARENT_WIDTH
 			Height: 65 + 1
 			Background: panel-gray
 			Children:
 				Container@HOTKEY_REMAP_DIALOG:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						Label@HOTKEY_LABEL:
 							X: 15
@@ -122,27 +122,27 @@ Container@HOTKEYS_PANEL:
 							Height: 25
 							Children:
 								Label@ORIGINAL_NOTICE:
-									Width: PARENT_RIGHT
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
 									Font: Tiny
 								Label@DUPLICATE_NOTICE:
-									Width: PARENT_RIGHT
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
 									Font: Tiny
 								Label@READONLY_NOTICE:
-									Width: PARENT_RIGHT
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
 									Font: Tiny
 									Text: label-notices-readonly-notice
 						Button@OVERRIDE_HOTKEY_BUTTON:
-							X: PARENT_RIGHT - 3 * WIDTH - 30
+							X: PARENT_WIDTH - 3 * WIDTH - 30
 							Y: 20
 							Width: 70
 							Height: 25
 							Text: button-hotkey-remap-dialog-override
 							Font: Bold
 						Button@CLEAR_HOTKEY_BUTTON:
-							X: PARENT_RIGHT - 2 * WIDTH - 30
+							X: PARENT_WIDTH - 2 * WIDTH - 30
 							Y: 20
 							Width: 65
 							Height: 25
@@ -152,7 +152,7 @@ Container@HOTKEYS_PANEL:
 							TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 						Button@RESET_HOTKEY_BUTTON:
-							X: PARENT_RIGHT - WIDTH - 20
+							X: PARENT_WIDTH - WIDTH - 20
 							Y: 20
 							Width: 65
 							Height: 25

--- a/mods/cnc/chrome/settings-input.yaml
+++ b/mods/cnc/chrome/settings-input.yaml
@@ -1,286 +1,286 @@
 Container@INPUT_PANEL:
 	Logic: InputSettingsLogic
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		ScrollPanel@SETTINGS_SCROLLPANEL:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			CollapseHiddenChildren: True
 			TopBottomSpacing: 5
 			ItemSpacing: 10
 			Children:
 				Background@INPUT_SECTION_HEADER:
 					X: 5
-					Width: PARENT_RIGHT - 24 - 10
+					Width: PARENT_WIDTH - 24 - 10
 					Height: 13
 					Background: separator
 					ClickThrough: True
 					Children:
 						Label@LABEL:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Font: TinyBold
 							Align: Center
 							Text: label-input-section-header
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@MOUSE_CONTROL_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@MOUSE_CONTROL_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: label-mouse-control-container
 								DropDownButton@MOUSE_CONTROL_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 						Container@ZOOM_MODIFIER_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@ZOOM_MODIFIER_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: label-zoom-modifier-container
 								DropDownButton@ZOOM_MODIFIER:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 						Container@MOUSE_CONTROL_DESC_CLASSIC:
 							X: 10
 							Y: 55
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Children:
 								LabelWithHighlight@DESC_SELECTION:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-selection
 								LabelWithHighlight@DESC_COMMANDS:
 									Y: 17
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-commands
 								LabelWithHighlight@DESC_BUILDINGS:
 									Y: 34
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-buildings
 								LabelWithHighlight@DESC_SUPPORT:
 									Y: 51
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-support
 								LabelWithHighlight@DESC_ZOOM:
 									Y: 68
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-zoom
 								LabelWithHighlight@DESC_ZOOM_MODIFIER:
 									Y: 68
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-zoom-modifier
 								LabelWithHighlight@DESC_SCROLL_RIGHT:
 									Y: 85
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-scroll-right
 								LabelWithHighlight@DESC_SCROLL_MIDDLE:
 									Y: 85
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-scroll-middle
 								Label@DESC_EDGESCROLL:
 									X: 9
 									Y: 102
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-edgescroll
 						Container@MOUSE_CONTROL_DESC_MODERN:
 							X: 10
 							Y: 55
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								LabelWithHighlight@DESC_SELECTION:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-selection
 								LabelWithHighlight@DESC_COMMANDS:
 									Y: 17
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-commands
 								LabelWithHighlight@DESC_BUILDINGS:
 									Y: 34
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-buildings
 								LabelWithHighlight@DESC_SUPPORT:
 									Y: 51
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-support
 								LabelWithHighlight@DESC_ZOOM:
 									Y: 68
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-zoom
 								LabelWithHighlight@DESC_ZOOM_MODIFIER:
 									Y: 68
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-zoom-modifier
 								LabelWithHighlight@DESC_SCROLL_RIGHT:
 									Y: 85
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-scroll-right
 								LabelWithHighlight@DESC_SCROLL_MIDDLE:
 									Y: 85
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-scroll-middle
 								Label@DESC_EDGESCROLL:
 									X: 9
 									Y: 102
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-edgescroll
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@EDGESCROLL_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@EDGESCROLL_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-edgescroll-container
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@ALTERNATE_SCROLL_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@ALTERNATE_SCROLL_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-alternate-scroll-container
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@LOCKMOUSE_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@LOCKMOUSE_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-lockmouse-container
 				Container@SPACER:
 					Height: 30
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@MOUSE_SCROLL_TYPE_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@MOUSE_SCROLL_TYPE_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: label-mouse-scroll-type-container
 								DropDownButton@MOUSE_SCROLL_TYPE_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 						Container@SCROLLSPEED_SLIDER_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@SCROLL_SPEED_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-scrollspeed-slider-container-scroll-speed
 								Slider@SCROLLSPEED_SLIDER:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Ticks: 7
 									MinimumValue: 10
 									MaximumValue: 50
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@ZOOMSPEED_SLIDER_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@ZOOM_SPEED_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-zoomspeed-slider-container-zoom-speed
 								ExponentialSlider@ZOOMSPEED_SLIDER:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Ticks: 7
 									MinimumValue: 0.01
 									MaximumValue: 0.4
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@UI_SCROLLSPEED_SLIDER_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@UI_SCROLL_SPEED_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-ui-scrollspeed-slider-container-scroll-speed
 								Slider@UI_SCROLLSPEED_SLIDER:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Ticks: 7
 									MinimumValue: 1

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -7,13 +7,13 @@ Container@SETTINGS_PANEL:
 			INPUT_PANEL: Input
 			HOTKEYS_PANEL: Hotkeys
 			ADVANCED_PANEL: Advanced
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 640
 	Height: 435
 	Children:
 		Label@SETTINGS_LABEL_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Y: 0 - 34
 			Font: BigBold
@@ -22,13 +22,13 @@ Container@SETTINGS_PANEL:
 			Text: button-settings-title
 		Button@BACK_BUTTON:
 			Key: escape
-			Y: PARENT_BOTTOM - 1
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-back
 		Button@RESET_BUTTON:
 			X: 150
-			Y: PARENT_BOTTOM - 1
+			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-settings-panel-reset
@@ -39,13 +39,13 @@ Container@SETTINGS_PANEL:
 					Width: 140
 					Height: 35
 		Background@PANEL_CONTAINER:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-black
 			Children:
 				Container@PANEL_TEMPLATE:
 					X: 15
 					Y: 15
-					Width: PARENT_RIGHT - 30
-					Height: PARENT_BOTTOM - 30
+					Width: PARENT_WIDTH - 30
+					Height: PARENT_HEIGHT - 30
 		TooltipContainer@SETTINGS_TOOLTIP_CONTAINER:

--- a/mods/cnc/chrome/tooltips.yaml
+++ b/mods/cnc/chrome/tooltips.yaml
@@ -477,29 +477,29 @@ Container@REGISTERED_PLAYER_TOOLTIP:
 	Height: 137
 	Children:
 		Background@HEADER:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Background: panel-black
 			Children:
 				Container@PROFILE_HEADER:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 42
 					Children:
 						Label@PROFILE_NAME:
 							X: 5
 							Y: 2
-							Width: PARENT_RIGHT - 20
+							Width: PARENT_WIDTH - 20
 							Height: 23
 							Font: MediumBold
 						Label@PROFILE_RANK:
 							X: 5
 							Y: 24
-							Width: PARENT_RIGHT - 20
+							Width: PARENT_WIDTH - 20
 							Height: 12
 							Font: TinyBold
 						Container@GAME_ADMIN:
 							X: 5
 							Y: 36
-							Width: PARENT_RIGHT - 20
+							Width: PARENT_WIDTH - 20
 							Height: 12
 							Visible: False
 							Children:
@@ -519,16 +519,16 @@ Container@REGISTERED_PLAYER_TOOLTIP:
 									Font: TinyBold
 				Container@MESSAGE_HEADER:
 					Height: 26
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Children:
 						Label@MESSAGE:
 							Y: 1
 							X: 5
-							Width: PARENT_RIGHT - 20
+							Width: PARENT_WIDTH - 20
 							Height: 23
 							Font: Bold
 		Background@BADGES_CONTAINER:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Y: -1
 			Visible: false
 			Background: panel-black

--- a/mods/common/chrome/assetbrowser.yaml
+++ b/mods/common/chrome/assetbrowser.yaml
@@ -1,14 +1,14 @@
 Background@ASSETBROWSER_PANEL:
 	Logic: AssetBrowserLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 900
 	Height: 600
 	Children:
 		LogicTicker@ANIMATION_TICKER:
 		Label@ASSETBROWSER_TITLE:
 			Y: 16
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Bold
 			Align: Center
@@ -53,11 +53,11 @@ Background@ASSETBROWSER_PANEL:
 			X: 20
 			Y: 170
 			Width: 195
-			Height: PARENT_BOTTOM - 250
+			Height: PARENT_HEIGHT - 250
 			CollapseHiddenChildren: True
 			Children:
 				ScrollItem@ASSET_TEMPLATE:
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 25
 					X: 2
 					Visible: false
@@ -65,12 +65,12 @@ Background@ASSETBROWSER_PANEL:
 					Children:
 						LabelWithTooltip@TITLE:
 							X: 10
-							Width: PARENT_RIGHT - 20
+							Width: PARENT_WIDTH - 20
 							Height: 25
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 		Label@SPRITE_SCALE:
-			X: PARENT_RIGHT - WIDTH - 440
+			X: PARENT_WIDTH - WIDTH - 440
 			Y: 60
 			Width: 50
 			Height: 25
@@ -78,14 +78,14 @@ Background@ASSETBROWSER_PANEL:
 			Align: Left
 			Text: label-assetbrowser-sprite-scale
 		Slider@SPRITE_SCALE_SLIDER:
-			X: PARENT_RIGHT - WIDTH - 330
+			X: PARENT_WIDTH - WIDTH - 330
 			Y: 62
 			Width: 100
 			Height: 20
 			MinimumValue: 0.5
 			MaximumValue: 4
 		Label@PALETTE_DESC:
-			X: PARENT_RIGHT - WIDTH - 270
+			X: PARENT_WIDTH - WIDTH - 270
 			Y: 60
 			Width: 150
 			Height: 25
@@ -93,13 +93,13 @@ Background@ASSETBROWSER_PANEL:
 			Align: Right
 			Text: label-assetbrowser-palette-desc
 		DropDownButton@PALETTE_SELECTOR:
-			X: PARENT_RIGHT - WIDTH - 110
+			X: PARENT_WIDTH - WIDTH - 110
 			Y: 60
 			Width: 150
 			Height: 25
 			Font: Bold
 		DropDownButton@COLOR:
-			X: PARENT_RIGHT - WIDTH - 20
+			X: PARENT_WIDTH - WIDTH - 20
 			Y: 60
 			Width: 80
 			Height: 25
@@ -107,32 +107,32 @@ Background@ASSETBROWSER_PANEL:
 				ColorBlock@COLORBLOCK:
 					X: 5
 					Y: 6
-					Width: PARENT_RIGHT - 35
-					Height: PARENT_BOTTOM - 12
+					Width: PARENT_WIDTH - 35
+					Height: PARENT_HEIGHT - 12
 		Background@SPRITE_BG:
 			X: 226
 			Y: 90
-			Width: PARENT_RIGHT - 226 - 20
-			Height: PARENT_BOTTOM - 170
+			Width: PARENT_WIDTH - 226 - 20
+			Height: PARENT_HEIGHT - 170
 			Background: dialog3
 			Children:
 				Sprite@SPRITE:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 				VideoPlayer@PLAYER:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					AspectRatio: 1
 				Label@ERROR:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Align: Center
 					Visible: false
 					Text: label-assetbrowser-sprite-bg-error
 		Container@FRAME_SELECTOR:
 			X: 226
-			Y: PARENT_BOTTOM - 75
-			Width: PARENT_RIGHT - 226
+			Y: PARENT_HEIGHT - 75
+			Width: PARENT_WIDTH - 226
 			Children:
 				Button@BUTTON_PREV:
 					Width: 26
@@ -192,11 +192,11 @@ Background@ASSETBROWSER_PANEL:
 				Slider@FRAME_SLIDER:
 					X: 140
 					Y: 3
-					Width: PARENT_RIGHT - 140 - 85
+					Width: PARENT_WIDTH - 140 - 85
 					Height: 20
 					MinimumValue: 0
 				Label@FRAME_COUNT:
-					X: PARENT_RIGHT - WIDTH + 5
+					X: PARENT_WIDTH - WIDTH + 5
 					Y: 0
 					Width: 85
 					Height: 25
@@ -204,8 +204,8 @@ Background@ASSETBROWSER_PANEL:
 					Align: Left
 		Button@CLOSE_BUTTON:
 			Key: escape
-			X: PARENT_RIGHT - 180
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 180
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Font: Bold
@@ -221,5 +221,5 @@ ScrollPanel@ASSET_TYPES_PANEL:
 		Checkbox@ASSET_TYPE_TEMPLATE:
 			X: 5
 			Y: 5
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20

--- a/mods/common/chrome/color-picker.yaml
+++ b/mods/common/chrome/color-picker.yaml
@@ -29,14 +29,14 @@ Background@COLOR_CHOOSER:
 			Height: 73
 		Button@MIXER_TAB_BUTTON:
 			X: 5
-			Y: PARENT_BOTTOM - 30
+			Y: PARENT_HEIGHT - 30
 			Height: 25
 			Width: 80
 			Text: button-color-chooser-mixer-tab
 			Font: Bold
 		Button@PALETTE_TAB_BUTTON:
 			X: 85
-			Y: PARENT_BOTTOM - 30
+			Y: PARENT_HEIGHT - 30
 			Height: 25
 			Width: 80
 			Text: button-color-chooser-palette-tab
@@ -44,63 +44,63 @@ Background@COLOR_CHOOSER:
 		Container@MIXER_TAB:
 			X: 5
 			Y: 5
-			Width: PARENT_RIGHT - 90
-			Height: PARENT_BOTTOM - 34
+			Width: PARENT_WIDTH - 90
+			Height: PARENT_HEIGHT - 34
 			Children:
 				Background@HUEBG:
 					Background: dialog3
 					X: 0
 					Y: 0
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 17
 					Children:
 						HueSlider@HUE_SLIDER:
 							X: 2
 							Y: 2
-							Width: PARENT_RIGHT - 4
-							Height: PARENT_BOTTOM - 4
+							Width: PARENT_WIDTH - 4
+							Height: PARENT_HEIGHT - 4
 							Ticks: 5
 				Background@MIXERBG:
 					Background: dialog3
 					X: 0
 					Y: 22
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM - 22
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT - 22
 					Children:
 						ColorMixer@MIXER:
 							X: 2
 							Y: 2
-							Width: PARENT_RIGHT - 4
-							Height: PARENT_BOTTOM - 4
+							Width: PARENT_WIDTH - 4
+							Height: PARENT_HEIGHT - 4
 		Background@PALETTE_TAB:
 			Background: dialog3
 			X: 5
 			Y: 5
-			Width: PARENT_RIGHT - 90
-			Height: PARENT_BOTTOM - 34
+			Width: PARENT_WIDTH - 90
+			Height: PARENT_HEIGHT - 34
 			Visible: false
 			Children:
 				Container@PALETTE_TAB_PANEL:
 					X: 0
 					Y: 0
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						Background@PRESET_HEADER:
 							Background: dialog2
-							Width: PARENT_RIGHT - 4
+							Width: PARENT_WIDTH - 4
 							Height: 13
 							X: 2
 							Y: 2
 							Children:
 								Label@LABEL:
 									Font: TinyBold
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 13
 									Align: Center
 									Text: label-preset-header
 						Container@PRESET_AREA:
-							Width: PARENT_RIGHT - 4
+							Width: PARENT_WIDTH - 4
 							Height: 58
 							X: 2
 							Y: 16
@@ -114,19 +114,19 @@ Background@COLOR_CHOOSER:
 									ClickSound: ClickSound
 						Background@CUSTOM_HEADER:
 							Background: dialog2
-							Width: PARENT_RIGHT - 4
+							Width: PARENT_WIDTH - 4
 							Height: 13
 							X: 2
 							Y: 75
 							Children:
 								Label@LABEL:
 									Font: TinyBold
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 13
 									Align: Center
 									Text: label-custom-header
 						Container@CUSTOM_AREA:
-							Width: PARENT_RIGHT - 4
+							Width: PARENT_WIDTH - 4
 							Height: 31
 							X: 2
 							Y: 89

--- a/mods/common/chrome/confirmation-dialogs.yaml
+++ b/mods/common/chrome/confirmation-dialogs.yaml
@@ -1,11 +1,11 @@
 Background@THREEBUTTON_PROMPT:
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - 90) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - 90) / 2
 	Width: 600
 	Height: 110
 	Children:
 		Label@PROMPT_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Y: 21
 			Height: 25
 			Font: Bold
@@ -13,12 +13,12 @@ Background@THREEBUTTON_PROMPT:
 		Label@PROMPT_TEXT:
 			X: 15
 			Y: 51
-			Width: PARENT_RIGHT - 30
+			Width: PARENT_WIDTH - 30
 			Height: 20
 			Align: Center
 		Button@CONFIRM_BUTTON:
 			X: 20
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-prompt-confirm
@@ -26,16 +26,16 @@ Background@THREEBUTTON_PROMPT:
 			Key: return
 			Visible: false
 		Button@OTHER_BUTTON:
-			X: PARENT_RIGHT - 380
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 380
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-prompt-other
 			Font: Bold
 			Visible: false
 		Button@CANCEL_BUTTON:
-			X: PARENT_RIGHT - 180
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 180
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-cancel
@@ -44,13 +44,13 @@ Background@THREEBUTTON_PROMPT:
 			Visible: false
 
 Background@TWOBUTTON_PROMPT:
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - 90) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - 90) / 2
 	Width: 370
 	Height: 110
 	Children:
 		Label@PROMPT_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Y: 21
 			Height: 25
 			Font: Bold
@@ -58,12 +58,12 @@ Background@TWOBUTTON_PROMPT:
 		Label@PROMPT_TEXT:
 			X: 15
 			Y: 51
-			Width: PARENT_RIGHT - 30
+			Width: PARENT_WIDTH - 30
 			Height: 20
 			Align: Center
 		Button@CONFIRM_BUTTON:
 			X: 20
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-prompt-confirm
@@ -71,8 +71,8 @@ Background@TWOBUTTON_PROMPT:
 			Key: return
 			Visible: false
 		Button@CANCEL_BUTTON:
-			X: PARENT_RIGHT - 180
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 180
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-cancel
@@ -81,13 +81,13 @@ Background@TWOBUTTON_PROMPT:
 			Visible: false
 
 Background@TEXT_INPUT_PROMPT:
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 370
 	Height: 175
 	Children:
 		Label@PROMPT_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Y: 21
 			Height: 25
 			Font: Bold
@@ -95,25 +95,25 @@ Background@TEXT_INPUT_PROMPT:
 		Label@PROMPT_TEXT:
 			X: 20
 			Y: 51
-			Width: PARENT_RIGHT - 40
+			Width: PARENT_WIDTH - 40
 			Height: 25
 			Align: Center
 		TextField@INPUT_TEXT:
 			X: 20
 			Y: 80
-			Width: PARENT_RIGHT - 40
+			Width: PARENT_WIDTH - 40
 			Height: 25
 		Button@ACCEPT_BUTTON:
 			X: 20
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-text-input-prompt-accept
 			Font: Bold
 			Key: return
 		Button@CANCEL_BUTTON:
-			X: PARENT_RIGHT - 180
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 180
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-cancel

--- a/mods/common/chrome/connection.yaml
+++ b/mods/common/chrome/connection.yaml
@@ -1,7 +1,7 @@
 Background@CONNECTIONFAILED_PANEL:
 	Logic: ConnectionFailedLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 450
 	Height: 160
 	Children:
@@ -16,48 +16,48 @@ Background@CONNECTIONFAILED_PANEL:
 		Label@CONNECTING_DESC:
 			X: 0
 			Y: 46
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Align: Center
 		Label@CONNECTION_ERROR:
 			X: 0
 			Y: 76
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Align: Center
 			Font: Bold
 		Label@PASSWORD_LABEL:
-			X: PARENT_RIGHT - 360
+			X: PARENT_WIDTH - 360
 			Y: 111
 			Width: 95
 			Height: 25
 			Text: label-connectionfailed-panel-password
 			Font: Bold
 		PasswordField@PASSWORD:
-			X: PARENT_RIGHT - 285
+			X: PARENT_WIDTH - 285
 			Y: 111
 			Width: 190
 			MaxLength: 20
 			Height: 25
 		Button@RETRY_BUTTON:
-			X: PARENT_RIGHT - 430
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 430
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-retry
 			Font: Bold
 			Key: return
 		Button@ABORT_BUTTON:
-			X: PARENT_RIGHT - 180
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 180
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-connectionfailed-panel-abort
 			Font: Bold
 			Key: escape
 		Button@QUIT_BUTTON:
-			X: PARENT_RIGHT - 180
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 180
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-quit
@@ -66,8 +66,8 @@ Background@CONNECTIONFAILED_PANEL:
 
 Background@CONNECTING_PANEL:
 	Logic: ConnectionLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 450
 	Height: 160
 	Children:
@@ -82,12 +82,12 @@ Background@CONNECTING_PANEL:
 		Label@CONNECTING_DESC:
 			X: 0
 			Y: 61
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Align: Center
 		Button@ABORT_BUTTON:
-			X: PARENT_RIGHT - 180
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 180
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-connecting-panel-abort
@@ -96,8 +96,8 @@ Background@CONNECTING_PANEL:
 
 Background@CONNECTION_SWITCHMOD_PANEL:
 	Logic: ConnectionSwitchModLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 450
 	Height: 191
 	Children:
@@ -111,7 +111,7 @@ Background@CONNECTION_SWITCHMOD_PANEL:
 			Text: label-connection-switchmod-panel-title
 		Label@DESC:
 			Y: 46
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Text: label-connection-switchmod-panel-desc
 			Font: Bold
@@ -119,7 +119,7 @@ Background@CONNECTION_SWITCHMOD_PANEL:
 		Container@MOD_CONTAINER:
 			X: 0
 			Y: 72
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Children:
 				RGBASprite@MOD_ICON:
 					Y: 4
@@ -128,35 +128,35 @@ Background@CONNECTION_SWITCHMOD_PANEL:
 				Label@MOD_TITLE:
 					X: 37
 					Y: 1
-					Width: PARENT_RIGHT - 37
+					Width: PARENT_WIDTH - 37
 					Height: 25
 					Font: Bold
 					Align: Left
 				Label@MOD_VERSION:
 					X: 37
 					Y: 16
-					Width: PARENT_RIGHT - 37
+					Width: PARENT_WIDTH - 37
 					Height: 25
 					Font: Tiny
 					Align: Left
 		Label@DESC2:
 			Y: 111
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Text: label-connection-switchmod-panel-desc2
 			Font: Bold
 			Align: Center
 		Button@SWITCH_BUTTON:
-			X: PARENT_RIGHT - 430
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 430
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-connection-switchmod-panel-switch
 			Font: Bold
 			Key: return
 		Button@ABORT_BUTTON:
-			X: PARENT_RIGHT - 180
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 180
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-connection-switchmod-panel-abort

--- a/mods/common/chrome/credits.yaml
+++ b/mods/common/chrome/credits.yaml
@@ -1,12 +1,12 @@
 Background@CREDITS_PANEL:
 	Logic: CreditsLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 410
 	Height: 500
 	Children:
 		Label@CREDITS_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Y: 21
 			Height: 25
 			Font: Bold
@@ -16,7 +16,7 @@ Background@CREDITS_PANEL:
 			Visible: False
 			X: 20
 			Y: 50
-			Width: PARENT_RIGHT - 40
+			Width: PARENT_WIDTH - 40
 			Height: 30
 			Children:
 				Button@MOD_TAB:
@@ -32,19 +32,19 @@ Background@CREDITS_PANEL:
 		ScrollPanel@CREDITS_DISPLAY:
 			X: 20
 			Y: 50
-			Width: PARENT_RIGHT - 40
+			Width: PARENT_WIDTH - 40
 			Height: 395
 			TopBottomSpacing: 8
 			Children:
 				Label@CREDITS_TEMPLATE:
 					X: 8
-					Width: PARENT_RIGHT - 24 - 2 * 8
+					Width: PARENT_WIDTH - 24 - 2 * 8
 					Height: 16
 					VAlign: Top
 					WordWrap: true
 		Button@BACK_BUTTON:
-			X: PARENT_RIGHT - 180
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 180
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-back

--- a/mods/common/chrome/dropdowns.yaml
+++ b/mods/common/chrome/dropdowns.yaml
@@ -3,7 +3,7 @@ ScrollPanel@LABEL_DROPDOWN_TEMPLATE:
 	Children:
 		ScrollItem@HEADER:
 			Background: scrollheader
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 13
 			X: 2
 			Y: 0
@@ -11,11 +11,11 @@ ScrollPanel@LABEL_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					Font: TinyBold
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 13
 					Align: Center
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -23,14 +23,14 @@ ScrollPanel@LABEL_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					X: 10
-					Width: PARENT_RIGHT - 20
+					Width: PARENT_WIDTH - 20
 					Height: 25
 
 ScrollPanel@PLAYERACTION_DROPDOWN_TEMPLATE:
 	Width: DROPDOWN_WIDTH
 	Children:
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -38,7 +38,7 @@ ScrollPanel@PLAYERACTION_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					X: 10
-					Width: PARENT_RIGHT - 20
+					Width: PARENT_WIDTH - 20
 					Height: 25
 					Align: Left
 
@@ -46,7 +46,7 @@ ScrollPanel@TEAM_DROPDOWN_TEMPLATE:
 	Width: DROPDOWN_WIDTH
 	Children:
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -54,7 +54,7 @@ ScrollPanel@TEAM_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					X: 0
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 
@@ -62,7 +62,7 @@ ScrollPanel@SPAWN_DROPDOWN_TEMPLATE:
 	Width: DROPDOWN_WIDTH
 	Children:
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -70,7 +70,7 @@ ScrollPanel@SPAWN_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					X: 0
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 
@@ -82,7 +82,7 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 	Children:
 		ScrollItem@HEADER:
 			Background: observer-scrollheader
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 13
 			X: 2
 			Y: 0
@@ -90,12 +90,12 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					Font: TinyBold
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 10
 					Align: Center
 		ScrollItem@TEMPLATE:
 			Background: observer-scrollitem
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -108,12 +108,12 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 					Height: 16
 				Label@LABEL:
 					X: 40
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Shadow: True
 				Label@NOFLAG_LABEL:
 					X: 5
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Shadow: True
 
@@ -125,7 +125,7 @@ ScrollPanel@SPECTATOR_LABEL_DROPDOWN_TEMPLATE:
 	Children:
 		ScrollItem@HEADER:
 			Background: observer-scrollitem
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 13
 			X: 2
 			Y: 0
@@ -133,12 +133,12 @@ ScrollPanel@SPECTATOR_LABEL_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					Font: TinyBold
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 10
 					Align: Center
 		ScrollItem@TEMPLATE:
 			Background: observer-scrollitem
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -146,7 +146,7 @@ ScrollPanel@SPECTATOR_LABEL_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					X: 10
-					Width: PARENT_RIGHT - 20
+					Width: PARENT_WIDTH - 20
 					Height: 25
 
 ScrollPanel@NEWS_PANEL:
@@ -158,27 +158,27 @@ ScrollPanel@NEWS_PANEL:
 		Container@NEWS_ITEM_TEMPLATE:
 			X: 10
 			Y: 5
-			Width: PARENT_RIGHT - 40
+			Width: PARENT_WIDTH - 40
 			Height: 45
 			Children:
 				Label@TITLE:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 					Font: Bold
 				Label@AUTHOR_DATETIME:
 					Y: 25
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 15
 					Align: Center
 					Font: TinyBold
 				Label@CONTENT:
 					Y: 45
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 		Label@NEWS_STATUS:
 			X: 80
 			Y: 0
-			Width: PARENT_RIGHT - 80 - 80 - 24
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH - 80 - 80 - 24
+			Height: PARENT_HEIGHT
 			Align: Center
 			VAlign: Middle

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -1,7 +1,7 @@
 Background@NEW_MAP_BG:
 	Logic: NewMapLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 300
 	Height: 185
 	Children:
@@ -57,7 +57,7 @@ Background@NEW_MAP_BG:
 			Type: Integer
 		Button@CREATE_BUTTON:
 			X: 30
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 120
 			Height: 25
 			Text: button-new-map-bg-create
@@ -65,7 +65,7 @@ Background@NEW_MAP_BG:
 			Key: return
 		Button@CANCEL_BUTTON:
 			X: 160
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 120
 			Height: 25
 			Text: button-cancel
@@ -74,13 +74,13 @@ Background@NEW_MAP_BG:
 
 Background@SAVE_MAP_PANEL:
 	Logic: SaveMapLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 350
 	Height: 300
 	Children:
 		Label@LABEL_TITLE:
-			X: (PARENT_RIGHT - WIDTH) / 2
+			X: (PARENT_WIDTH - WIDTH) / 2
 			Y: 21
 			Width: 250
 			Height: 25
@@ -158,14 +158,14 @@ Background@SAVE_MAP_PANEL:
 			Height: 25
 		Button@SAVE_BUTTON:
 			X: 80
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 120
 			Height: 25
 			Text: button-save-map-panel
 			Font: Bold
 		Button@BACK_BUTTON:
 			X: 210
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 120
 			Height: 25
 			Text: button-cancel
@@ -180,7 +180,7 @@ ScrollPanel@MAP_SAVE_VISIBILITY_PANEL:
 	Children:
 		Checkbox@VISIBILITY_TEMPLATE:
 			X: 5
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Font: Regular
 
@@ -212,13 +212,13 @@ Container@EDITOR_WORLD_ROOT:
 		LogicKeyListener@OVERLAY_KEYHANDLER:
 		Container@PERF_ROOT:
 		EditorViewportController@MAP_EDITOR:
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
+			Width: WINDOW_WIDTH
+			Height: WINDOW_HEIGHT
 			TooltipContainer: TOOLTIP_CONTAINER
 			TooltipTemplate: SIMPLE_TOOLTIP
 		ViewportController:
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
+			Width: WINDOW_WIDTH
+			Height: WINDOW_HEIGHT
 			IgnoreMouseOver: True
 			ZoomInKey: ZoomIn
 			ZoomOutKey: ZoomOut
@@ -234,7 +234,7 @@ Container@EDITOR_WORLD_ROOT:
 			BookmarkRestoreKeyPrefix: MapBookmarkRestore
 			BookmarkKeyCount: 4
 		Background@RADAR_BG:
-			X: WINDOW_RIGHT - 325
+			X: WINDOW_WIDTH - 325
 			Y: 5
 			Width: 320
 			Height: 320
@@ -242,18 +242,18 @@ Container@EDITOR_WORLD_ROOT:
 				Radar@INGAME_RADAR:
 					X: 10
 					Y: 10
-					Width: PARENT_RIGHT - 19
-					Height: PARENT_BOTTOM - 19
+					Width: PARENT_WIDTH - 19
+					Height: PARENT_HEIGHT - 19
 		Background@TOOLS_BG:
-			X: WINDOW_RIGHT - 320
+			X: WINDOW_WIDTH - 320
 			Y: 330
 			Width: 310
-			Height: WINDOW_BOTTOM - 422
+			Height: WINDOW_HEIGHT - 422
 		Container@TILE_WIDGETS:
-			X: WINDOW_RIGHT - 320
+			X: WINDOW_WIDTH - 320
 			Y: 354
 			Width: 310
-			Height: WINDOW_BOTTOM - 458
+			Height: WINDOW_HEIGHT - 458
 			Logic: TileSelectorLogic
 			Children:
 				Label@SEARCH_LABEL:
@@ -266,7 +266,7 @@ Container@EDITOR_WORLD_ROOT:
 				TextField@SEARCH_TEXTFIELD:
 					X: 60
 					Y: 10
-					Width: PARENT_RIGHT - 70
+					Width: PARENT_WIDTH - 70
 					Height: 25
 				Label@CATEGORIES_LABEL:
 					Y: 36
@@ -278,38 +278,38 @@ Container@EDITOR_WORLD_ROOT:
 				DropDownButton@CATEGORIES_DROPDOWN:
 					X: 60
 					Y: 34
-					Width: PARENT_RIGHT - 70
+					Width: PARENT_WIDTH - 70
 					Height: 25
 					Font: Bold
 				ScrollPanel@TILETEMPLATE_LIST:
 					X: 10
 					Y: 58
-					Width: PARENT_RIGHT - 20
-					Height: PARENT_BOTTOM - 55
+					Width: PARENT_WIDTH - 20
+					Height: PARENT_HEIGHT - 55
 					TopBottomSpacing: 4
 					ItemSpacing: 4
 					Children:
 						ScrollItem@TILEPREVIEW_TEMPLATE:
 							Visible: false
-							Width: PARENT_RIGHT - 35
+							Width: PARENT_WIDTH - 35
 							TooltipContainer: TOOLTIP_CONTAINER
 							Children:
 								TerrainTemplatePreview@TILE_PREVIEW:
 									X: 4
 									Y: 4
 		Container@LAYER_WIDGETS:
-			X: WINDOW_RIGHT - 320
+			X: WINDOW_WIDTH - 320
 			Y: 354
 			Width: 310
-			Height: WINDOW_BOTTOM - 458
+			Height: WINDOW_HEIGHT - 458
 			Visible: false
 			Logic: LayerSelectorLogic
 			Children:
 				ScrollPanel@LAYERTEMPLATE_LIST:
 					X: 10
 					Y: 10
-					Width: PARENT_RIGHT - 20
-					Height: PARENT_BOTTOM - 7
+					Width: PARENT_WIDTH - 20
+					Height: PARENT_HEIGHT - 7
 					TopBottomSpacing: 4
 					ItemSpacing: 4
 					Children:
@@ -323,10 +323,10 @@ Container@EDITOR_WORLD_ROOT:
 									Y: 4
 									Visible: false
 		Container@ACTOR_WIDGETS:
-			X: WINDOW_RIGHT - 320
+			X: WINDOW_WIDTH - 320
 			Y: 354
 			Width: 310
-			Height: WINDOW_BOTTOM - 458
+			Height: WINDOW_HEIGHT - 458
 			Visible: false
 			Logic: ActorSelectorLogic
 			Children:
@@ -340,7 +340,7 @@ Container@EDITOR_WORLD_ROOT:
 				TextField@SEARCH_TEXTFIELD:
 					X: 60
 					Y: 10
-					Width: PARENT_RIGHT - 70
+					Width: PARENT_WIDTH - 70
 					Height: 25
 				Label@CATEGORIES_LABEL:
 					Y: 36
@@ -352,7 +352,7 @@ Container@EDITOR_WORLD_ROOT:
 				DropDownButton@CATEGORIES_DROPDOWN:
 					X: 60
 					Y: 34
-					Width: PARENT_RIGHT - 70
+					Width: PARENT_WIDTH - 70
 					Height: 25
 					Font: Bold
 				Label@OWNERS_LABEL:
@@ -365,20 +365,20 @@ Container@EDITOR_WORLD_ROOT:
 				DropDownButton@OWNERS_DROPDOWN:
 					X: 60
 					Y: 58
-					Width: PARENT_RIGHT - 70
+					Width: PARENT_WIDTH - 70
 					Height: 25
 					Font: Bold
 				ScrollPanel@ACTORTEMPLATE_LIST:
 					X: 10
 					Y: 82
-					Width: PARENT_RIGHT - 20
-					Height: PARENT_BOTTOM - 79
+					Width: PARENT_WIDTH - 20
+					Height: PARENT_HEIGHT - 79
 					TopBottomSpacing: 4
 					ItemSpacing: 4
 					Children:
 						ScrollItem@ACTORPREVIEW_TEMPLATE:
 							Visible: false
-							Width: PARENT_RIGHT - 35
+							Width: PARENT_WIDTH - 35
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 							IgnoreChildMouseOver: true
@@ -388,10 +388,10 @@ Container@EDITOR_WORLD_ROOT:
 									Y: 4
 									Visible: true
 		Container@TOOLS_WIDGETS:
-			X: WINDOW_RIGHT - 320
+			X: WINDOW_WIDTH - 320
 			Y: 354
 			Width: 310
-			Height: WINDOW_BOTTOM - 458
+			Height: WINDOW_HEIGHT - 458
 			Visible: false
 			Logic: MapToolsLogic
 			Children:
@@ -405,21 +405,21 @@ Container@EDITOR_WORLD_ROOT:
 				DropDownButton@TOOLS_DROPDOWN:
 					X: 60
 					Y: 10
-					Width: PARENT_RIGHT - 70
+					Width: PARENT_WIDTH - 70
 					Height: 25
 					Font: Bold
 				Background@MARKER_TOOL_PANEL:
 					X: 10
 					Y: 35
-					Width: PARENT_RIGHT - 20
-					Height: WINDOW_BOTTOM - 490
+					Width: PARENT_WIDTH - 20
+					Height: WINDOW_HEIGHT - 490
 					Background: scrollpanel-bg
 					Logic: MapMarkerTilesLogic
 					Children:
 						ScrollPanel@TILE_COLOR_PANEL:
 							X: 6
 							Y: 6
-							Width: PARENT_RIGHT - 19
+							Width: PARENT_WIDTH - 19
 							Height: 31
 							TopBottomSpacing: 1
 							ItemSpacing: 1
@@ -542,18 +542,18 @@ Container@EDITOR_WORLD_ROOT:
 							Align: Left
 							Visible: false
 		Container@HISTORY_WIDGETS:
-			X: WINDOW_RIGHT - 320
+			X: WINDOW_WIDTH - 320
 			Y: 354
 			Width: 310
-			Height: WINDOW_BOTTOM - 458
+			Height: WINDOW_HEIGHT - 458
 			Logic: HistoryLogLogic
 			Visible: false
 			Children:
 				ScrollPanel@HISTORY_LIST:
 					X: 10
 					Y: 10
-					Width: PARENT_RIGHT - 20
-					Height: PARENT_BOTTOM - 7
+					Width: PARENT_WIDTH - 20
+					Height: PARENT_HEIGHT - 7
 					CollapseHiddenChildren: True
 					TopBottomSpacing: 4
 					ItemSpacing: 4
@@ -561,7 +561,7 @@ Container@EDITOR_WORLD_ROOT:
 						ScrollItem@HISTORY_TEMPLATE:
 							X: 4
 							Visible: false
-							Width: PARENT_RIGHT - 31
+							Width: PARENT_WIDTH - 31
 							Height: 25
 							IgnoreChildMouseOver: true
 							TextColor: ffffff
@@ -569,26 +569,26 @@ Container@EDITOR_WORLD_ROOT:
 							Children:
 								Label@TITLE:
 									X: 5
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Align: Left
 		Container@SELECT_WIDGETS:
-			X: WINDOW_RIGHT - 320
+			X: WINDOW_WIDTH - 320
 			Y: 354
 			Width: 310
-			Height: WINDOW_BOTTOM - 458
+			Height: WINDOW_HEIGHT - 458
 			Visible: false
 			Children:
 				Background@AREA_EDIT_PANEL:
 					X: 10
 					Y: 10
-					Width: PARENT_RIGHT - 20
-					Height: PARENT_BOTTOM - 7
+					Width: PARENT_WIDTH - 20
+					Height: PARENT_HEIGHT - 7
 					Background: scrollpanel-bg
 					Children:
 						Label@AREA_EDIT_TITLE:
 							Y: 16
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 24
 							Align: Center
 							Font: Bold
@@ -604,24 +604,24 @@ Container@EDITOR_WORLD_ROOT:
 						Checkbox@COPY_FILTER_TERRAIN_CHECKBOX:
 							X: 5
 							Y: 70
-							Width: PARENT_RIGHT - 29
+							Width: PARENT_WIDTH - 29
 							Height: 20
 							Text: label-filter-terrain
 						Checkbox@COPY_FILTER_RESOURCES_CHECKBOX:
 							X: 5
 							Y: 95
-							Width: PARENT_RIGHT - 29
+							Width: PARENT_WIDTH - 29
 							Height: 20
 							Text: label-filter-resources
 						Checkbox@COPY_FILTER_ACTORS_CHECKBOX:
 							X: 5
 							Y: 120
-							Width: PARENT_RIGHT - 29
+							Width: PARENT_WIDTH - 29
 							Height: 20
 							Text: label-filter-actors
 						Label@AREA_INFO_TITLE:
 							Y: 139
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 24
 							Align: Center
 							Font: Bold
@@ -664,13 +664,13 @@ Container@EDITOR_WORLD_ROOT:
 				Background@ACTOR_EDIT_PANEL:
 					X: 10
 					Y: 10
-					Width: PARENT_RIGHT - 20
-					Height: PARENT_BOTTOM - 7
+					Width: PARENT_WIDTH - 20
+					Height: PARENT_HEIGHT - 7
 					Background: scrollpanel-bg
 					Children:
 						Label@ACTOR_TYPE_LABEL:
 							Y: 16
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 24
 							Align: Center
 							Font: Bold
@@ -694,19 +694,19 @@ Container@EDITOR_WORLD_ROOT:
 							TextColor: FF0000
 						Container@ACTOR_INIT_CONTAINER:
 							Y: 73
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Children:
 								Container@CHECKBOX_OPTION_TEMPLATE:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 22
 									Children:
 										Checkbox@OPTION:
 											X: 60
 											Y: 1
-											Width: PARENT_RIGHT - 100
+											Width: PARENT_WIDTH - 100
 											Height: 20
 								Container@SLIDER_OPTION_TEMPLATE:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 22
 									Children:
 										Label@LABEL:
@@ -726,7 +726,7 @@ Container@EDITOR_WORLD_ROOT:
 											Height: 20
 											Type: Integer
 								Container@DROPDOWN_OPTION_TEMPLATE:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 27
 									Children:
 										Label@LABEL:
@@ -763,7 +763,7 @@ Container@EDITOR_WORLD_ROOT:
 									Font: Bold
 		Container@MAP_EDITOR_TAB_CONTAINER:
 			Logic: MapEditorTabsLogic
-			X: WINDOW_RIGHT - 311
+			X: WINDOW_WIDTH - 311
 			Y: 339
 			Width: 292
 			Height: 25
@@ -931,7 +931,7 @@ ScrollPanel@CATEGORY_FILTER_PANEL:
 	ItemSpacing: 5
 	Children:
 		Container@SELECT_CATEGORIES_BUTTONS:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Children:
 				Button@SELECT_ALL:
@@ -950,7 +950,7 @@ ScrollPanel@CATEGORY_FILTER_PANEL:
 					Font: Bold
 		Checkbox@CATEGORY_TEMPLATE:
 			X: 5
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Visible: false
 
@@ -963,6 +963,6 @@ ScrollPanel@OVERLAY_PANEL:
 		Checkbox@CATEGORY_TEMPLATE:
 			X: 5
 			Y: 5
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Visible: false

--- a/mods/common/chrome/gamesave-browser.yaml
+++ b/mods/common/chrome/gamesave-browser.yaml
@@ -1,12 +1,12 @@
 Background@GAMESAVE_BROWSER_PANEL:
 	Logic: GameSaveBrowserLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 700
 	Height: 500
 	Children:
 		Label@LOAD_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Y: 16
 			Height: 25
 			Font: Bold
@@ -14,7 +14,7 @@ Background@GAMESAVE_BROWSER_PANEL:
 			Text: label-gamesave-browser-panel-load-title
 			Visible: False
 		Label@SAVE_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Y: 16
 			Height: 25
 			Font: Bold
@@ -24,22 +24,22 @@ Background@GAMESAVE_BROWSER_PANEL:
 		ScrollPanel@GAME_LIST:
 			X: 20
 			Y: 45
-			Width: PARENT_RIGHT - 40
-			Height: PARENT_BOTTOM - 97
+			Width: PARENT_WIDTH - 40
+			Height: PARENT_HEIGHT - 97
 			Children:
 				ScrollItem@NEW_TEMPLATE:
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 25
 					X: 2
 					Visible: false
 					Children:
 						Label@TITLE:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Align: Center
 							Text: label-gamesave-browser-panel-title
 				ScrollItem@GAME_TEMPLATE:
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 25
 					X: 2
 					Visible: false
@@ -47,52 +47,52 @@ Background@GAMESAVE_BROWSER_PANEL:
 					Children:
 						LabelWithTooltip@TITLE:
 							X: 10
-							Width: PARENT_RIGHT - 200 - 10
+							Width: PARENT_WIDTH - 200 - 10
 							Height: 25
 							TooltipContainer: GAMESAVE_TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 						Label@DATE:
-							X: PARENT_RIGHT - WIDTH - 10
+							X: PARENT_WIDTH - WIDTH - 10
 							Width: 200
 							Height: 25
 							Align: Right
 		Container@SAVE_WIDGETS:
 			X: 20
-			Y: PARENT_BOTTOM - 77
-			Width: PARENT_RIGHT - 40
+			Y: PARENT_HEIGHT - 77
+			Width: PARENT_WIDTH - 40
 			Height: 32
 			Visible: False
 			Children:
 				TextField@SAVE_TEXTFIELD:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Type: Filename
 		Button@CANCEL_BUTTON:
 			Key: escape
 			X: 20
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 100
 			Height: 25
 			Text: button-back
 			Font: Bold
 		Button@DELETE_ALL_BUTTON:
-			X: PARENT_RIGHT - 350 - WIDTH
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 350 - WIDTH
+			Y: PARENT_HEIGHT - 45
 			Width: 100
 			Height: 25
 			Text: button-gamesave-browser-panel-delete-all
 			Font: Bold
 		Button@DELETE_BUTTON:
-			X: PARENT_RIGHT - 240 - WIDTH
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 240 - WIDTH
+			Y: PARENT_HEIGHT - 45
 			Width: 100
 			Height: 25
 			Text: button-gamesave-browser-panel-delete
 			Font: Bold
 			Key: Delete
 		Button@RENAME_BUTTON:
-			X: PARENT_RIGHT - 130 - WIDTH
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 130 - WIDTH
+			Y: PARENT_HEIGHT - 45
 			Width: 100
 			Height: 25
 			Text: button-gamesave-browser-panel-rename
@@ -100,8 +100,8 @@ Background@GAMESAVE_BROWSER_PANEL:
 			Key: F2
 		Button@LOAD_BUTTON:
 			Key: return
-			X: PARENT_RIGHT - WIDTH - 20
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - WIDTH - 20
+			Y: PARENT_HEIGHT - 45
 			Width: 100
 			Height: 25
 			Text: button-gamesave-browser-panel-load
@@ -109,8 +109,8 @@ Background@GAMESAVE_BROWSER_PANEL:
 			Visible: False
 		Button@SAVE_BUTTON:
 			Key: return
-			X: PARENT_RIGHT - WIDTH - 20
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - WIDTH - 20
+			Y: PARENT_HEIGHT - 45
 			Width: 100
 			Height: 25
 			Text: button-gamesave-browser-panel-save

--- a/mods/common/chrome/gamesave-loading.yaml
+++ b/mods/common/chrome/gamesave-loading.yaml
@@ -1,34 +1,34 @@
 Container@GAMESAVE_LOADING_SCREEN:
 	Logic: GameSaveLoadingLogic
-	Width: WINDOW_RIGHT
-	Height: WINDOW_BOTTOM
+	Width: WINDOW_WIDTH
+	Height: WINDOW_HEIGHT
 	Children:
 		LogicKeyListener@CANCEL_HANDLER:
 		Background@STRIPE:
-			Y: (WINDOW_BOTTOM - HEIGHT) / 2
-			Width: WINDOW_RIGHT
+			Y: (WINDOW_HEIGHT - HEIGHT) / 2
+			Width: WINDOW_WIDTH
 			Height: 256
 			Background: loadscreen-stripe
 		Image@LOGO:
-			X: (WINDOW_RIGHT - 256) / 2
-			Y: (WINDOW_BOTTOM - 256) / 2
+			X: (WINDOW_WIDTH - 256) / 2
+			Y: (WINDOW_HEIGHT - 256) / 2
 			ImageCollection: logos
 			ImageName: logo
 		Label@TITLE:
-			Width: WINDOW_RIGHT
-			Y: 3 * WINDOW_BOTTOM / 4 - 29
+			Width: WINDOW_WIDTH
+			Y: 3 * WINDOW_HEIGHT / 4 - 29
 			Height: 25
 			Font: Bold
 			Align: Center
 			Text: label-gamesave-loading-screen-title
 		ProgressBar@PROGRESS:
-			X: (WINDOW_RIGHT - 500) / 2
-			Y: 3 * WINDOW_BOTTOM / 4
+			X: (WINDOW_WIDTH - 500) / 2
+			Y: 3 * WINDOW_HEIGHT / 4
 			Width: 500
 			Height: 20
 		Label@DESC:
-			Width: WINDOW_RIGHT
-			Y: 3 * WINDOW_BOTTOM / 4 + 19
+			Width: WINDOW_WIDTH
+			Y: 3 * WINDOW_HEIGHT / 4 + 19
 			Height: 25
 			Font: Regular
 			Align: Center

--- a/mods/common/chrome/ingame-chat.yaml
+++ b/mods/common/chrome/ingame-chat.yaml
@@ -1,6 +1,6 @@
 Container@CHAT_PANEL:
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: WINDOW_BOTTOM - HEIGHT - 56
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: WINDOW_HEIGHT - HEIGHT - 56
 	Width: 550
 	Height: 194
 	Logic: IngameChatLogic
@@ -13,21 +13,21 @@ Container@CHAT_PANEL:
 	Children:
 		LogicKeyListener@OPEN_CHAT_KEY_LISTENER:
 		Container@CHAT_OVERLAY:
-			Width: PARENT_RIGHT - 24
-			Height: PARENT_BOTTOM - 30
+			Width: PARENT_WIDTH - 24
+			Height: PARENT_HEIGHT - 30
 			Visible: false
 			Children:
 				TextNotificationsDisplay@CHAT_DISPLAY:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					DisplayDurationMs: 10000
 					BottomSpacing: 3
 		Container@CHAT_CHROME:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Button@CHAT_MODE:
-					Y: PARENT_BOTTOM - HEIGHT
+					Y: PARENT_HEIGHT - HEIGHT
 					Width: 50
 					Height: 25
 					Text: button-chat-chrome-mode.label
@@ -37,12 +37,12 @@ Container@CHAT_PANEL:
 					TooltipContainer: TOOLTIP_CONTAINER
 				TextField@CHAT_TEXTFIELD:
 					X: 55
-					Y: PARENT_BOTTOM - HEIGHT
+					Y: PARENT_HEIGHT - HEIGHT
 					Width: 466
 					Height: 25
 				Button@CHAT_CLOSE:
 					X: 526
-					Y: PARENT_BOTTOM - HEIGHT
+					Y: PARENT_HEIGHT - HEIGHT
 					Width: 24
 					Height: 25
 					Children:
@@ -53,7 +53,7 @@ Container@CHAT_PANEL:
 							Y: 8
 				LogicKeyListener@KEY_LISTENER:
 				ScrollPanel@CHAT_SCROLLPANEL:
-					Y: PARENT_BOTTOM - HEIGHT - 30
+					Y: PARENT_HEIGHT - HEIGHT - 30
 					Width: 550
 					Height: 164
 					TopBottomSpacing: 3

--- a/mods/common/chrome/ingame-debug-hpf.yaml
+++ b/mods/common/chrome/ingame-debug-hpf.yaml
@@ -1,16 +1,16 @@
 Container@HPF_OVERLAY:
 	Logic: HierarchicalPathFinderOverlayLogic
-	Width: PARENT_RIGHT
+	Width: PARENT_WIDTH
 	Height: 60
 	Children:
 		DropDownButton@HPF_OVERLAY_LOCOMOTOR:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Text: dropdownbutton-hpf-overlay-locomotor
 			Font: Regular
 		DropDownButton@HPF_OVERLAY_CHECK:
 			Y: 35
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Text: dropdownbutton-hpf-overlay-check
 			Font: Regular

--- a/mods/common/chrome/ingame-debug.yaml
+++ b/mods/common/chrome/ingame-debug.yaml
@@ -1,15 +1,15 @@
 Container@DEBUG_PANEL:
 	Logic: DebugMenuLogic
 	Y: 10
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		Label@TITLE:
 			Y: 16
 			Font: Bold
 			Text: label-debug-panel-title
 			Align: Center
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 20
 		Checkbox@INSTANT_BUILD:
 			X: 45
@@ -86,7 +86,7 @@ Container@DEBUG_PANEL:
 			Font: Bold
 			Text: label-debug-panel-visualizations-title
 			Align: Center
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 20
 		Checkbox@SHOW_UNIT_PATHS:
 			X: 45

--- a/mods/common/chrome/ingame-debuginfo.yaml
+++ b/mods/common/chrome/ingame-debuginfo.yaml
@@ -1,13 +1,13 @@
 Container@DEBUG_WIDGETS:
 	Logic: DebugLogic
-	X: WINDOW_RIGHT / 2 - WIDTH
+	X: WINDOW_WIDTH / 2 - WIDTH
 	Y: 60
 	Width: 100
 	Height: 55
 	Children:
 		Label@DEBUG_TEXT:
 			Y: 35
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 15
 			Align: Center
 			Font: Bold

--- a/mods/common/chrome/ingame-fmvplayer.yaml
+++ b/mods/common/chrome/ingame-fmvplayer.yaml
@@ -1,10 +1,10 @@
 Background@FMVPLAYER:
-	Width: WINDOW_RIGHT
-	Height: WINDOW_BOTTOM
+	Width: WINDOW_WIDTH
+	Height: WINDOW_HEIGHT
 	Background: dialog5
 	Children:
 		VideoPlayer@PLAYER:
 			X: 0
 			Y: 0
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
+			Width: WINDOW_WIDTH
+			Height: WINDOW_HEIGHT

--- a/mods/common/chrome/ingame-info-lobby-options.yaml
+++ b/mods/common/chrome/ingame-info-lobby-options.yaml
@@ -1,62 +1,62 @@
 Container@LOBBY_OPTIONS_PANEL:
-	Height: PARENT_BOTTOM
-	Width: PARENT_RIGHT
+	Height: PARENT_HEIGHT
+	Width: PARENT_WIDTH
 	Children:
 		ScrollPanel:
 			Logic: LobbyOptionsLogic
 			X: 20
 			Y: 20
-			Width: PARENT_RIGHT - 40
+			Width: PARENT_WIDTH - 40
 			Height: 365
 			Children:
 				Container@LOBBY_OPTIONS:
 					Y: 10
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Children:
 						Container@CHECKBOX_ROW_TEMPLATE:
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 30
 							Children:
 								Checkbox@A:
 									X: 10
-									Width: PARENT_RIGHT / 2 - 20
+									Width: PARENT_WIDTH / 2 - 20
 									Height: 20
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								Checkbox@B:
-									X: PARENT_RIGHT / 2 + 10
-									Width: PARENT_RIGHT / 2 - 20
+									X: PARENT_WIDTH / 2 + 10
+									Width: PARENT_WIDTH / 2 - 20
 									Height: 20
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 						Container@DROPDOWN_ROW_TEMPLATE:
 							Height: 60
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Children:
 								LabelForInput@A_DESC:
 									X: 10
-									Width: PARENT_RIGHT / 2 - 20
+									Width: PARENT_WIDTH / 2 - 20
 									Height: 20
 									Visible: False
 									For: A
 								DropDownButton@A:
 									X: 10
 									Y: 25
-									Width: PARENT_RIGHT / 2 - 20
+									Width: PARENT_WIDTH / 2 - 20
 									Height: 25
 									Font: Regular
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								LabelForInput@B_DESC:
-									X: PARENT_RIGHT / 2 + 10
-									Width: PARENT_RIGHT / 2 - 20
+									X: PARENT_WIDTH / 2 + 10
+									Width: PARENT_WIDTH / 2 - 20
 									Height: 20
 									Visible: False
 									For: B
 								DropDownButton@B:
-									X: PARENT_RIGHT / 2 + 10
+									X: PARENT_WIDTH / 2 + 10
 									Y: 25
-									Width: PARENT_RIGHT / 2 - 20
+									Width: PARENT_WIDTH / 2 - 20
 									Height: 25
 									Font: Regular
 									Visible: False

--- a/mods/common/chrome/ingame-info.yaml
+++ b/mods/common/chrome/ingame-info.yaml
@@ -1,22 +1,22 @@
 Container@GAME_INFO_PANEL:
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 580
 	Height: 500
 	Logic: GameInfoLogic
 	Visible: False
 	Children:
 		Background@BACKGROUND:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 		Label@TITLE:
 			Y: 21
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Align: Center
 			Font: Bold
 		Container@TAB_CONTAINER_2:
-			X: (PARENT_RIGHT - WIDTH) / 2
+			X: (PARENT_WIDTH - WIDTH) / 2
 			Width: 280
 			Height: 25
 			Visible: False
@@ -33,7 +33,7 @@ Container@GAME_INFO_PANEL:
 					Height: 25
 					Font: Bold
 		Container@TAB_CONTAINER_3:
-			X: (PARENT_RIGHT - WIDTH) / 2
+			X: (PARENT_WIDTH - WIDTH) / 2
 			Width: 360
 			Height: 25
 			Visible: False
@@ -56,7 +56,7 @@ Container@GAME_INFO_PANEL:
 					Height: 25
 					Font: Bold
 		Container@TAB_CONTAINER_4:
-			X: (PARENT_RIGHT - WIDTH) / 2
+			X: (PARENT_WIDTH - WIDTH) / 2
 			Width: 480
 			Height: 25
 			Visible: False
@@ -85,7 +85,7 @@ Container@GAME_INFO_PANEL:
 					Height: 25
 					Font: Bold
 		Container@TAB_CONTAINER_5:
-			X: (PARENT_RIGHT - WIDTH) / 2
+			X: (PARENT_WIDTH - WIDTH) / 2
 			Width: 480
 			Height: 25
 			Visible: False
@@ -123,20 +123,20 @@ Container@GAME_INFO_PANEL:
 			Y: 65
 		Container@MAP_PANEL:
 			Y: 65
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 		Container@OBJECTIVES_PANEL:
 			Y: 65
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 		Container@DEBUG_PANEL:
 			Y: 65
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 		Container@CHAT_PANEL:
 			Y: 65
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 		Container@LOBBY_OPTIONS_PANEL:
 			Y: 65
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT

--- a/mods/common/chrome/ingame-infobriefing.yaml
+++ b/mods/common/chrome/ingame-infobriefing.yaml
@@ -1,10 +1,10 @@
 Container@MAP_PANEL:
-	Height: PARENT_BOTTOM
-	Width: PARENT_RIGHT
+	Height: PARENT_HEIGHT
+	Width: PARENT_WIDTH
 	Logic: GameInfoBriefingLogic
 	Children:
 		Background@PREVIEW_BG:
-			X: (PARENT_RIGHT - WIDTH) / 2
+			X: (PARENT_WIDTH - WIDTH) / 2
 			Y: 20
 			Width: 362
 			Height: 202
@@ -13,18 +13,18 @@ Container@MAP_PANEL:
 				MapPreview@MAP_PREVIEW:
 					X: 1
 					Y: 1
-					Width: PARENT_RIGHT - 2
-					Height: PARENT_BOTTOM - 2
+					Width: PARENT_WIDTH - 2
+					Height: PARENT_HEIGHT - 2
 					IgnoreMouseOver: True
 					IgnoreMouseInput: True
 					ShowSpawnPoints: False
 		ScrollPanel@MAP_DESCRIPTION_PANEL:
 			X: 20
 			Y: 232
-			Width: PARENT_RIGHT - 40
+			Width: PARENT_WIDTH - 40
 			Height: 153
 			Children:
 				Label@MAP_DESCRIPTION:
 					X: 4
 					Y: 2
-					Width: PARENT_RIGHT - 32
+					Width: PARENT_WIDTH - 32

--- a/mods/common/chrome/ingame-infochat.yaml
+++ b/mods/common/chrome/ingame-infochat.yaml
@@ -1,7 +1,7 @@
 Container@CHAT_CONTAINER:
 	Y: 20
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM - 105
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT - 105
 	Logic: IngameChatLogic
 		Templates:
 			Chat: CHAT_LINE_TEMPLATE
@@ -10,11 +10,11 @@ Container@CHAT_CONTAINER:
 	Children:
 		Container@CHAT_CHROME:
 			X: 20
-			Width: PARENT_RIGHT - 40
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH - 40
+			Height: PARENT_HEIGHT
 			Children:
 				Button@CHAT_MODE:
-					Y: PARENT_BOTTOM - HEIGHT
+					Y: PARENT_HEIGHT - HEIGHT
 					Width: 50
 					Height: 25
 					Text: button-chat-chrome-mode.label
@@ -24,11 +24,11 @@ Container@CHAT_CONTAINER:
 					TooltipContainer: TOOLTIP_CONTAINER
 				TextField@CHAT_TEXTFIELD:
 					X: 55
-					Y: PARENT_BOTTOM - HEIGHT
-					Width: PARENT_RIGHT - 55
+					Y: PARENT_HEIGHT - HEIGHT
+					Width: PARENT_WIDTH - 55
 					Height: 25
 				ScrollPanel@CHAT_SCROLLPANEL:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM - 30
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT - 30
 					TopBottomSpacing: 3
 					ItemSpacing: 2

--- a/mods/common/chrome/ingame-infoobjectives.yaml
+++ b/mods/common/chrome/ingame-infoobjectives.yaml
@@ -1,6 +1,6 @@
 Container@MISSION_OBJECTIVES:
-	Height: PARENT_BOTTOM
-	Width: PARENT_RIGHT
+	Height: PARENT_HEIGHT
+	Width: PARENT_WIDTH
 	Logic: GameInfoObjectivesLogic
 	Children:
 		Label@MISSION:
@@ -13,7 +13,7 @@ Container@MISSION_OBJECTIVES:
 		Label@MISSION_STATUS:
 			X: 100
 			Y: 21
-			Width: PARENT_RIGHT - 120
+			Width: PARENT_WIDTH - 120
 			Height: 25
 			Font: MediumBold
 		ScrollPanel@OBJECTIVES_PANEL:
@@ -25,19 +25,19 @@ Container@MISSION_OBJECTIVES:
 			ItemSpacing: 15
 			Children:
 				Container@OBJECTIVE_TEMPLATE:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 20
 					Children:
 						Label@OBJECTIVE_TYPE:
 							X: 10
 							Y: 1
 							Width: 70
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Align: Center
 						Checkbox@OBJECTIVE_STATUS:
 							X: 90
 							Y: 0
-							Width: PARENT_RIGHT - 100
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH - 100
+							Height: PARENT_HEIGHT
 							Disabled: True
 							TextColorDisabled: FFFFFF

--- a/mods/common/chrome/ingame-infoscripterror.yaml
+++ b/mods/common/chrome/ingame-infoscripterror.yaml
@@ -1,12 +1,12 @@
 Container@SCRIPT_ERROR_PANEL:
-	Height: PARENT_BOTTOM
-	Width: PARENT_RIGHT
+	Height: PARENT_HEIGHT
+	Width: PARENT_WIDTH
 	Logic: ScriptErrorLogic
 	Children:
 		Label@DESCA:
 			X: 15
 			Y: 16
-			Width: PARENT_RIGHT - 30
+			Width: PARENT_WIDTH - 30
 			Height: 20
 			Font: Bold
 			Align: Center
@@ -14,7 +14,7 @@ Container@SCRIPT_ERROR_PANEL:
 		Label@DESCB:
 			X: 15
 			Y: 46
-			Width: PARENT_RIGHT - 30
+			Width: PARENT_WIDTH - 30
 			Height: 20
 			Font: Regular
 			Align: Center
@@ -22,7 +22,7 @@ Container@SCRIPT_ERROR_PANEL:
 		Label@DESCC:
 			X: 15
 			Y: 66
-			Width: PARENT_RIGHT - 30
+			Width: PARENT_WIDTH - 30
 			Height: 20
 			Font: Regular
 			Align: Center
@@ -30,10 +30,10 @@ Container@SCRIPT_ERROR_PANEL:
 		ScrollPanel@SCRIPT_ERROR_MESSAGE_PANEL:
 			X: 20
 			Y: 96
-			Width: PARENT_RIGHT - 40
+			Width: PARENT_WIDTH - 40
 			Height: 300
 			Children:
 				Label@SCRIPT_ERROR_MESSAGE:
 					X: 4
 					Y: 2
-					Width: PARENT_RIGHT - 32
+					Width: PARENT_WIDTH - 32

--- a/mods/common/chrome/ingame-infostats.yaml
+++ b/mods/common/chrome/ingame-infostats.yaml
@@ -1,6 +1,6 @@
 Container@SKIRMISH_STATS:
-	Height: PARENT_BOTTOM
-	Width: PARENT_RIGHT
+	Height: PARENT_HEIGHT
+	Width: PARENT_WIDTH
 	Logic: GameInfoStatsLogic
 	Children:
 		Container@OBJECTIVE:
@@ -16,7 +16,7 @@ Container@SKIRMISH_STATS:
 				Label@STATS_STATUS:
 					X: 100
 					Y: 22
-					Width: PARENT_RIGHT - 10
+					Width: PARENT_WIDTH - 10
 					Height: 25
 					Font: MediumBold
 				Checkbox@STATS_CHECKBOX:
@@ -31,7 +31,7 @@ Container@SKIRMISH_STATS:
 		Container@STATS_HEADERS:
 			X: 22
 			Y: 81
-			Width: PARENT_RIGHT - 44
+			Width: PARENT_WIDTH - 44
 			Children:
 				Label@NAME:
 					X: 10
@@ -60,13 +60,13 @@ Container@SKIRMISH_STATS:
 		ScrollPanel@PLAYER_LIST:
 			X: 20
 			Y: 105
-			Width: PARENT_RIGHT - 40
+			Width: PARENT_WIDTH - 40
 			Height: 280
 			ItemSpacing: 5
 			Children:
 				ScrollItem@TEAM_TEMPLATE:
 					Background: scrollheader
-					Width: PARENT_RIGHT - 26
+					Width: PARENT_WIDTH - 26
 					Height: 20
 					X: 2
 					Visible: false
@@ -84,7 +84,7 @@ Container@SKIRMISH_STATS:
 							Height: 20
 							Font: Bold
 				Container@PLAYER_TEMPLATE:
-					Width: PARENT_RIGHT - 26
+					Width: PARENT_WIDTH - 26
 					Height: 25
 					X: 2
 					Children:
@@ -143,7 +143,7 @@ Container@SKIRMISH_STATS:
 									X: 7
 									Y: 7
 				Container@SPECTATOR_TEMPLATE:
-					Width: PARENT_RIGHT - 26
+					Width: PARENT_WIDTH - 26
 					Height: 25
 					X: 2
 					Children:

--- a/mods/common/chrome/ingame-menu.yaml
+++ b/mods/common/chrome/ingame-menu.yaml
@@ -1,6 +1,6 @@
 Container@INGAME_MENU:
-	Width: WINDOW_RIGHT
-	Height: WINDOW_BOTTOM
+	Width: WINDOW_WIDTH
+	Height: WINDOW_HEIGHT
 	Logic: IngameMenuLogic
 		Buttons: RESUME, LOAD_GAME, SAVE_GAME, SETTINGS, MUSIC, SURRENDER, RESTART, BACK_TO_EDITOR, ABORT_MISSION, SAVE_MAP, PLAY_MAP, EXIT_EDITOR
 		ButtonStride: 0, 40
@@ -8,17 +8,17 @@ Container@INGAME_MENU:
 		Background@BORDER:
 			X: 0 - 15
 			Y: 0 - 15
-			Width: WINDOW_RIGHT + 30
-			Height: WINDOW_BOTTOM + 30
+			Width: WINDOW_WIDTH + 30
+			Height: WINDOW_HEIGHT + 30
 			Background: mainmenu-border
 		Image@LOGO:
-			X: WINDOW_RIGHT - 296
+			X: WINDOW_WIDTH - 296
 			Y: 30
 			ImageCollection: logos
 			ImageName: logo
 		Label@VERSION_LABEL:
 			Logic: VersionLabelLogic
-			X: WINDOW_RIGHT - 296
+			X: WINDOW_WIDTH - 296
 			Y: 296 - 19
 			Width: 296 - 20
 			Height: 25
@@ -27,13 +27,13 @@ Container@INGAME_MENU:
 			Contrast: True
 		Container@PANEL_ROOT:
 		Background@MENU_BUTTONS:
-			X: 13 + (WINDOW_RIGHT - 522) / 4 - WIDTH / 2
-			Y: (WINDOW_BOTTOM - HEIGHT) / 2
+			X: 13 + (WINDOW_WIDTH - 522) / 4 - WIDTH / 2
+			Y: (WINDOW_HEIGHT - HEIGHT) / 2
 			Width: 200
 			Height: 120
 			Children:
 				Label@LABEL_TITLE:
-					X: (PARENT_RIGHT - WIDTH) / 2
+					X: (PARENT_WIDTH - WIDTH) / 2
 					Y: 20
 					Width: 200
 					Height: 30
@@ -41,7 +41,7 @@ Container@INGAME_MENU:
 					Align: Center
 					Font: Bold
 				Button@BUTTON_TEMPLATE:
-					X: (PARENT_RIGHT - WIDTH) / 2
+					X: (PARENT_WIDTH - WIDTH) / 2
 					Y: 60
 					Width: 140
 					Height: 30

--- a/mods/common/chrome/ingame-perf.yaml
+++ b/mods/common/chrome/ingame-perf.yaml
@@ -2,8 +2,8 @@ Container@PERF_WIDGETS:
 	Logic: PerfDebugLogic
 	Children:
 		Label@PERF_TEXT:
-			X: WINDOW_RIGHT - 200
-			Y: WINDOW_BOTTOM - 69
+			X: WINDOW_WIDTH - 200
+			Y: WINDOW_HEIGHT - 69
 			Width: 170
 			Height: 40
 			Contrast: true
@@ -11,7 +11,7 @@ Container@PERF_WIDGETS:
 			ClickThrough: true
 			Background: dialog4
 			X: 10
-			Y: WINDOW_BOTTOM - HEIGHT - 156
+			Y: WINDOW_HEIGHT - HEIGHT - 156
 			Width: 210
 			Height: 210
 			Children:

--- a/mods/common/chrome/ingame-transients.yaml
+++ b/mods/common/chrome/ingame-transients.yaml
@@ -1,13 +1,13 @@
 Container@TRANSIENTS_PANEL:
 	X: 5
-	Y: WINDOW_BOTTOM - HEIGHT - 55
+	Y: WINDOW_HEIGHT - HEIGHT - 55
 	Width: 550
 	Height: 80
 	Logic: IngameTransientNotificationsLogic
 	Children:
 		TextNotificationsDisplay@TRANSIENTS_DISPLAY:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			DisplayDurationMs: 4000
 			LogLength: 5
 			HideOverflow: False

--- a/mods/common/chrome/ingame.yaml
+++ b/mods/common/chrome/ingame.yaml
@@ -28,7 +28,7 @@ Container@INGAME_ROOT:
 				LogicTicker@DISCONNECT_WATCHER:
 					Logic: DisconnectWatcherLogic
 				Label@MISSION_TEXT:
-					X: WINDOW_RIGHT / 2 - 256
+					X: WINDOW_WIDTH / 2 - 256
 					Y: 23
 					Width: 512
 					Height: 25
@@ -36,11 +36,11 @@ Container@INGAME_ROOT:
 					Align: Center
 					Contrast: true
 				WorldInteractionController@INTERACTION_CONTROLLER:
-					Width: WINDOW_RIGHT
-					Height: WINDOW_BOTTOM
+					Width: WINDOW_WIDTH
+					Height: WINDOW_HEIGHT
 				ViewportController:
-					Width: WINDOW_RIGHT
-					Height: WINDOW_BOTTOM
+					Width: WINDOW_WIDTH
+					Height: WINDOW_HEIGHT
 					TooltipContainer: TOOLTIP_CONTAINER
 					ZoomInKey: ZoomIn
 					ZoomOutKey: ZoomOut
@@ -56,7 +56,7 @@ Container@INGAME_ROOT:
 					BookmarkRestoreKeyPrefix: MapBookmarkRestore
 					BookmarkKeyCount: 4
 				StrategicProgress@STRATEGIC_PROGRESS:
-					X: WINDOW_RIGHT / 2
+					X: WINDOW_WIDTH / 2
 					Y: 40
 				Container@PLAYER_ROOT:
 				Container@PERF_ROOT:

--- a/mods/common/chrome/lobby-kickdialogs.yaml
+++ b/mods/common/chrome/lobby-kickdialogs.yaml
@@ -1,44 +1,44 @@
 Background@KICK_CLIENT_DIALOG:
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Logic: KickClientLogic
 	Background: dialog3
 	Children:
 		Label@TITLE:
 			Y: 41
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Bold
 			Align: Center
 		Label@TEXTA:
 			Y: 68
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Regular
 			Align: Center
 			Text: label-kick-client-dialog-texta
 		Label@TEXTB:
 			Y: 86
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Regular
 			Align: Center
 			Text: label-kick-client-dialog-textb
 		Checkbox@PREVENT_REJOINING_CHECKBOX:
-			X: (PARENT_RIGHT - WIDTH) / 2
+			X: (PARENT_WIDTH - WIDTH) / 2
 			Y: 120
 			Width: 150
 			Height: 20
 			Text: checkbox-kick-client-dialog-prevent-rejoining
 		Button@OK_BUTTON:
-			X: (PARENT_RIGHT - WIDTH) / 2 + 75
+			X: (PARENT_WIDTH - WIDTH) / 2 + 75
 			Y: 155
 			Width: 120
 			Height: 25
 			Text: button-kick-client-dialog
 			Font: Bold
 		Button@CANCEL_BUTTON:
-			X: (PARENT_RIGHT - WIDTH) / 2 - 75
+			X: (PARENT_WIDTH - WIDTH) / 2 - 75
 			Y: 155
 			Width: 120
 			Height: 25
@@ -46,33 +46,33 @@ Background@KICK_CLIENT_DIALOG:
 			Font: Bold
 
 Background@KICK_SPECTATORS_DIALOG:
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Logic: KickSpectatorsLogic
 	Background: dialog3
 	Children:
 		Label@TITLE:
 			Y: 41
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Bold
 			Align: Center
 			Text: label-kick-spectators-dialog-title
 		Label@TEXT:
 			Y: 86
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Regular
 			Align: Center
 		Button@OK_BUTTON:
-			X: (PARENT_RIGHT - WIDTH) / 2 + 75
+			X: (PARENT_WIDTH - WIDTH) / 2 + 75
 			Y: 155
 			Width: 120
 			Height: 25
 			Text: button-kick-spectators-dialog-ok
 			Font: Bold
 		Button@CANCEL_BUTTON:
-			X: (PARENT_RIGHT - WIDTH) / 2 - 75
+			X: (PARENT_WIDTH - WIDTH) / 2 - 75
 			Y: 155
 			Width: 120
 			Height: 25
@@ -80,38 +80,38 @@ Background@KICK_SPECTATORS_DIALOG:
 			Font: Bold
 
 Background@FORCE_START_DIALOG:
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Background: dialog3
 	Children:
 		Label@TITLE:
 			Y: 41
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Bold
 			Align: Center
 			Text: label-force-start-dialog-title
 		Label@TEXTA:
 			Y: 68
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Regular
 			Align: Center
 			Text: label-force-start-dialog-texta
 		Label@TEXTB:
 			Y: 86
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Regular
 			Align: Center
 			Text: label-force-start-dialog-textb
 		Container@KICK_WARNING:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Children:
 				Label@KICK_WARNING_A:
 					X: 0
 					Y: 107
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Bold
 					Align: Center
@@ -119,20 +119,20 @@ Background@FORCE_START_DIALOG:
 				Label@KICK_WARNING_B:
 					X: 0
 					Y: 124
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Bold
 					Align: Center
 					Text: label-kick-warning-b
 		Button@OK_BUTTON:
-			X: (PARENT_RIGHT - WIDTH) / 2 + 75
+			X: (PARENT_WIDTH - WIDTH) / 2 + 75
 			Y: 155
 			Width: 120
 			Height: 25
 			Text: button-force-start-dialog-start
 			Font: Bold
 		Button@CANCEL_BUTTON:
-			X: (PARENT_RIGHT - WIDTH) / 2 - 75
+			X: (PARENT_WIDTH - WIDTH) / 2 - 75
 			Y: 155
 			Width: 120
 			Height: 25

--- a/mods/common/chrome/lobby-mappreview.yaml
+++ b/mods/common/chrome/lobby-mappreview.yaml
@@ -1,78 +1,78 @@
 Container@MAP_PREVIEW:
 	Logic: MapPreviewLogic
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		Container@MAP_LARGE:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Background@MAP_BG:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 174
 					Background: dialog3
 					Children:
 						MapPreview@MAP_PREVIEW:
 							X: 1
 							Y: 1
-							Width: PARENT_RIGHT - 2
-							Height: PARENT_BOTTOM - 2
+							Width: PARENT_WIDTH - 2
+							Height: PARENT_HEIGHT - 2
 							TooltipContainer: TOOLTIP_CONTAINER
 				LabelWithTooltip@MAP_TITLE:
 					Y: 173
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Bold
 					Align: Center
 					TooltipContainer: TOOLTIP_CONTAINER
 					TooltipTemplate: SIMPLE_TOOLTIP
 		Container@MAP_SMALL:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Background@MAP_BG:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 142
 					Background: dialog3
 					Children:
 						MapPreview@MAP_PREVIEW:
 							X: 1
 							Y: 1
-							Width: PARENT_RIGHT - 2
-							Height: PARENT_BOTTOM - 2
+							Width: PARENT_WIDTH - 2
+							Height: PARENT_HEIGHT - 2
 							TooltipContainer: TOOLTIP_CONTAINER
 				LabelWithTooltip@MAP_TITLE:
 					Y: 143
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Bold
 					Align: Center
 					TooltipContainer: TOOLTIP_CONTAINER
 					TooltipTemplate: SIMPLE_TOOLTIP
 		Container@MAP_AVAILABLE:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Label@MAP_TYPE:
 					Y: 188
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: TinyBold
 					Align: Center
 					IgnoreMouseOver: true
 				Label@MAP_AUTHOR:
 					Y: 201
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
 		Container@MAP_INCOMPATIBLE:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Label@MAP_STATUS_A:
 					Y: 188
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
@@ -80,18 +80,18 @@ Container@MAP_PREVIEW:
 					IgnoreMouseOver: true
 				Label@MAP_STATUS_B:
 					Y: 201
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
 					Text: label-map-incompatible-status-b
 		Container@MAP_VALIDATING:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Label@MAP_STATUS_VALIDATING:
 					Y: 174
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
@@ -99,113 +99,113 @@ Container@MAP_PREVIEW:
 					IgnoreMouseOver: true
 				ProgressBar@MAP_VALIDATING_BAR:
 					Y: 194
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Indeterminate: True
 		Container@MAP_DOWNLOAD_AVAILABLE:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Label@MAP_TYPE:
 					Y: 158
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: TinyBold
 					Align: Center
 					IgnoreMouseOver: true
 				Label@MAP_AUTHOR:
 					Y: 171
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
 				Button@MAP_INSTALL:
 					Y: 194
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Bold
 					Text: button-map-download-available-install
 		Button@MAP_UPDATE:
 			Y: 195
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Bold
 			Text: button-map-preview-update
 		Container@MAP_UPDATE_DOWNLOAD_AVAILABLE:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Button@MAP_INSTALL:
 					Y: 166
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Bold
 					Text: button-map-update-download-available-install
 		Label@MAP_SEARCHING:
 			Y: 158
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Tiny
 			Align: Center
 			Text: label-map-preview-searching
 			IgnoreMouseOver: true
 		Container@MAP_UNAVAILABLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Children:
 				Label@a:
 					Y: 158
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
 					Text: label-map-unavailable-a
 				Label@b:
 					Y: 171
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
 					Text: label-map-unavailable-b
 		Label@MAP_ERROR:
 			Y: 158
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Tiny
 			Align: Center
 			Text: label-map-preview-error
 		Container@MAP_DOWNLOADING:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Label@MAP_STATUS_DOWNLOADING:
 					Y: 158
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
 				ProgressBar@MAP_PROGRESSBAR:
 					Y: 194
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Indeterminate: True
 		Button@MAP_RETRY:
 			Y: 194
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Bold
 		Container@MAP_UPDATE_AVAILABLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Children:
 				Label@a:
 					Y: 158
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
 					Text: label-map-update-available-a
 				Label@b:
 					Y: 171
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center

--- a/mods/common/chrome/lobby-music.yaml
+++ b/mods/common/chrome/lobby-music.yaml
@@ -1,12 +1,12 @@
 Container@LOBBY_MUSIC_BIN:
 	Logic: MusicPlayerLogic
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		LogicTicker@SONG_WATCHER:
 		Container@LABEL_CONTAINER:
 			Y: 0 - 24
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Children:
 				Label@MUSIC:
 					Width: 268
@@ -21,7 +21,7 @@ Container@LOBBY_MUSIC_BIN:
 					Text: label-container-title
 					Font: Bold
 				Label@LENGTH:
-					X: PARENT_RIGHT - 80
+					X: PARENT_WIDTH - 80
 					Height: 25
 					Width: 50
 					Text: label-music-controls-length
@@ -30,7 +30,7 @@ Container@LOBBY_MUSIC_BIN:
 		Background@CONTROLS:
 			Background: dialog3
 			Width: 268
-			Height: PARENT_BOTTOM
+			Height: PARENT_HEIGHT
 			Children:
 				Label@MUTE_LABEL:
 					X: 45
@@ -40,17 +40,17 @@ Container@LOBBY_MUSIC_BIN:
 					Font: Small
 				Label@TITLE_LABEL:
 					Y: 46
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 					Font: Bold
 				Label@TIME_LABEL:
 					Y: 66
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 				Container@BUTTONS:
-					X: (PARENT_RIGHT - WIDTH) / 2
+					X: (PARENT_WIDTH - WIDTH) / 2
 					Y: 100
 					Width: 131
 					Children:
@@ -117,7 +117,7 @@ Container@LOBBY_MUSIC_BIN:
 					Font: Regular
 					Text: checkbox-music-controls-shuffle
 				Checkbox@REPEAT:
-					X: PARENT_RIGHT - 15 - WIDTH
+					X: PARENT_WIDTH - 15 - WIDTH
 					Y: 150
 					Width: 70
 					Height: 20
@@ -132,16 +132,16 @@ Container@LOBBY_MUSIC_BIN:
 				ExponentialSlider@MUSIC_SLIDER:
 					X: 70
 					Y: 186
-					Width: PARENT_RIGHT - 80
+					Width: PARENT_WIDTH - 80
 					Height: 20
 					Ticks: 7
 		ScrollPanel@MUSIC_LIST:
 			X: 268
-			Width: PARENT_RIGHT - 268
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH - 268
+			Height: PARENT_HEIGHT
 			Children:
 				ScrollItem@MUSIC_TEMPLATE:
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 25
 					X: 2
 					Visible: false
@@ -149,36 +149,36 @@ Container@LOBBY_MUSIC_BIN:
 					Children:
 						LabelWithTooltip@TITLE:
 							X: 10
-							Width: PARENT_RIGHT - 50
+							Width: PARENT_WIDTH - 50
 							Height: 25
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 						Label@LENGTH:
-							X: PARENT_RIGHT - 60
+							X: PARENT_WIDTH - 60
 							Width: 50
 							Height: 25
 							Align: Right
 		Container@NO_MUSIC_LABEL:
 			X: 268
-			Width: PARENT_RIGHT - 268
+			Width: PARENT_WIDTH - 268
 			Visible: false
 			Children:
 				Label@TITLE:
 					Y: 76
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 25
 					Font: Bold
 					Align: Center
 					Text: label-no-music-title
 				Label@DESCA:
 					Y: 96
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 25
 					Align: Center
 					Text: label-no-music-desc-a
 				Label@DESCB:
 					Y: 116
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 25
 					Align: Center
 					Text: label-no-music-desc-b

--- a/mods/common/chrome/lobby-options.yaml
+++ b/mods/common/chrome/lobby-options.yaml
@@ -1,84 +1,84 @@
 Container@LOBBY_OPTIONS_BIN:
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		Label@TITLE:
 			Y: 0 - 24
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Bold
 			Align: Center
 			Text: label-lobby-options-bin-title
 		ScrollPanel:
 			Logic: LobbyOptionsLogic
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Container@LOBBY_OPTIONS:
 					Y: 10
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Children:
 						Container@CHECKBOX_ROW_TEMPLATE:
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 30
 							Children:
 								Checkbox@A:
 									X: 10
-									Width: PARENT_RIGHT / 3 - 20
+									Width: PARENT_WIDTH / 3 - 20
 									Height: 20
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								Checkbox@B:
-									X: PARENT_RIGHT / 3 + 10
-									Width: PARENT_RIGHT / 3 - 20
+									X: PARENT_WIDTH / 3 + 10
+									Width: PARENT_WIDTH / 3 - 20
 									Height: 20
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								Checkbox@C:
-									X: (PARENT_RIGHT / 3) * 2 + 10
-									Width: PARENT_RIGHT / 3 - 20
+									X: (PARENT_WIDTH / 3) * 2 + 10
+									Width: PARENT_WIDTH / 3 - 20
 									Height: 20
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 						Container@DROPDOWN_ROW_TEMPLATE:
 							Height: 60
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Children:
 								LabelForInput@A_DESC:
 									X: 10
-									Width: PARENT_RIGHT / 3 - 20
+									Width: PARENT_WIDTH / 3 - 20
 									Height: 20
 									Visible: False
 									For: A
 								DropDownButton@A:
 									X: 10
-									Width: PARENT_RIGHT / 3 - 20
+									Width: PARENT_WIDTH / 3 - 20
 									Y: 25
 									Height: 25
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								LabelForInput@B_DESC:
-									X: PARENT_RIGHT / 3 + 10
-									Width: PARENT_RIGHT / 3 - 20
+									X: PARENT_WIDTH / 3 + 10
+									Width: PARENT_WIDTH / 3 - 20
 									Height: 20
 									Visible: False
 									For: B
 								DropDownButton@B:
-									X: PARENT_RIGHT / 3 + 10
-									Width: PARENT_RIGHT / 3 - 20
+									X: PARENT_WIDTH / 3 + 10
+									Width: PARENT_WIDTH / 3 - 20
 									Y: 25
 									Height: 25
 									Visible: False
 									TooltipContainer: TOOLTIP_CONTAINER
 								LabelForInput@C_DESC:
-									X: (PARENT_RIGHT / 3) * 2 + 10
-									Width: PARENT_RIGHT / 3 - 20
+									X: (PARENT_WIDTH / 3) * 2 + 10
+									Width: PARENT_WIDTH / 3 - 20
 									Height: 20
 									Visible: False
 									For: C
 								DropDownButton@C:
-									X: (PARENT_RIGHT / 3) * 2 + 10
-									Width: PARENT_RIGHT / 3 - 20
+									X: (PARENT_WIDTH / 3) * 2 + 10
+									Width: PARENT_WIDTH / 3 - 20
 									Y: 25
 									Height: 25
 									Visible: False

--- a/mods/common/chrome/lobby-players.yaml
+++ b/mods/common/chrome/lobby-players.yaml
@@ -1,12 +1,12 @@
 Container@LOBBY_PLAYER_BIN:
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		Container@LABEL_CONTAINER:
 			X: 5
 			Y: 0 - 24
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Label@LABEL_LOBBY_NAME:
 					Width: 180
@@ -57,8 +57,8 @@ Container@LOBBY_PLAYER_BIN:
 					Align: Left
 					Font: Bold
 		ScrollPanel@LOBBY_PLAYERS:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			TopBottomSpacing: 5
 			ItemSpacing: 5
 			Children:
@@ -77,8 +77,8 @@ Container@LOBBY_PLAYER_BIN:
 								ColorBlock@LATENCY_COLOR:
 									X: 2
 									Y: 2
-									Width: PARENT_RIGHT - 4
-									Height: PARENT_BOTTOM - 4
+									Width: PARENT_WIDTH - 4
+									Height: PARENT_HEIGHT - 4
 						ClientTooltipRegion@LATENCY_REGION:
 							Width: 11
 							Height: 25
@@ -121,8 +121,8 @@ Container@LOBBY_PLAYER_BIN:
 								ColorBlock@COLORBLOCK:
 									X: 5
 									Y: 6
-									Width: PARENT_RIGHT - 35
-									Height: PARENT_BOTTOM - 12
+									Width: PARENT_WIDTH - 35
+									Height: PARENT_HEIGHT - 12
 						DropDownButton@FACTION:
 							X: 270
 							Width: 140
@@ -186,8 +186,8 @@ Container@LOBBY_PLAYER_BIN:
 								ColorBlock@LATENCY_COLOR:
 									X: 2
 									Y: 2
-									Width: PARENT_RIGHT - 4
-									Height: PARENT_BOTTOM - 4
+									Width: PARENT_WIDTH - 4
+									Height: PARENT_HEIGHT - 4
 						ClientTooltipRegion@LATENCY_REGION:
 							Width: 11
 							Height: 25
@@ -328,8 +328,8 @@ Container@LOBBY_PLAYER_BIN:
 								ColorBlock@LATENCY_COLOR:
 									X: 2
 									Y: 2
-									Width: PARENT_RIGHT - 4
-									Height: PARENT_BOTTOM - 4
+									Width: PARENT_WIDTH - 4
+									Height: PARENT_HEIGHT - 4
 						ClientTooltipRegion@LATENCY_REGION:
 							Width: 11
 							Height: 25
@@ -391,8 +391,8 @@ Container@LOBBY_PLAYER_BIN:
 								ColorBlock@LATENCY_COLOR:
 									X: 2
 									Y: 2
-									Width: PARENT_RIGHT - 4
-									Height: PARENT_BOTTOM - 4
+									Width: PARENT_WIDTH - 4
+									Height: PARENT_HEIGHT - 4
 						ClientTooltipRegion@LATENCY_REGION:
 							Width: 11
 							Height: 25
@@ -475,7 +475,7 @@ ScrollPanel@FACTION_DROPDOWN_TEMPLATE:
 	Children:
 		ScrollItem@HEADER:
 			Background: scrollheader
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 13
 			X: 2
 			Y: 0
@@ -483,11 +483,11 @@ ScrollPanel@FACTION_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					Font: TinyBold
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 10
 					Align: Center
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0

--- a/mods/common/chrome/lobby-servers.yaml
+++ b/mods/common/chrome/lobby-servers.yaml
@@ -1,11 +1,11 @@
 Container@LOBBY_SERVERS_BIN:
 	Logic: ServerListLogic
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		Container@LABEL_CONTAINER:
 			Y: 0 - 24
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Children:
 				Label@NAME:
 					X: 5
@@ -34,50 +34,50 @@ Container@LOBBY_SERVERS_BIN:
 					Font: Bold
 		LogicTicker@NOTICE_WATCHER:
 		Background@NOTICE_CONTAINER:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 20
 			Background: dialog2
 			Children:
 				Label@OUTDATED_VERSION_LABEL:
 					X: 5
-					Width: PARENT_RIGHT - 10
+					Width: PARENT_WIDTH - 10
 					Height: 20
 					Align: Center
 					Text: label-notice-container-outdated-version
 					Font: TinyBold
 				Label@UNKNOWN_VERSION_LABEL:
 					X: 5
-					Width: PARENT_RIGHT - 10
+					Width: PARENT_WIDTH - 10
 					Height: 20
 					Align: Center
 					Text: label-notice-container-unknown-version
 					Font: TinyBold
 				Label@PLAYTEST_AVAILABLE_LABEL:
 					X: 5
-					Width: PARENT_RIGHT - 10
+					Width: PARENT_WIDTH - 10
 					Height: 20
 					Align: Center
 					Text: label-notice-container-playtest-available
 					Font: TinyBold
 		ScrollPanel@SERVER_LIST:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				ScrollItem@HEADER_TEMPLATE:
 					X: 2
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 20
 					Background: scrollheader
 					Visible: false
 					Children:
 						Label@LABEL:
 							Font: TinyBold
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 20
 							Align: Center
 				ScrollItem@SERVER_TEMPLATE:
 					X: 2
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 25
 					EnableChildMouseOver: True
 					Children:
@@ -120,21 +120,21 @@ Container@LOBBY_SERVERS_BIN:
 							Width: 50
 							Height: 25
 		Label@PROGRESS_LABEL:
-			Y: (PARENT_BOTTOM - HEIGHT) / 2
-			Width: PARENT_RIGHT
+			Y: (PARENT_HEIGHT - HEIGHT) / 2
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Bold
 			Align: Center
 			Visible: false
 		DropDownButton@FILTERS_DROPDOWNBUTTON:
-			Y: PARENT_BOTTOM + 5
+			Y: PARENT_HEIGHT + 5
 			Width: 154
 			Height: 25
 			Text: dropdownbutton-lobby-servers-bin-filters
 			Font: Bold
 		Button@RELOAD_BUTTON:
 			X: 159
-			Y: PARENT_BOTTOM + 5
+			Y: PARENT_HEIGHT + 5
 			Width: 26
 			Height: 25
 			Children:
@@ -149,24 +149,24 @@ Container@LOBBY_SERVERS_BIN:
 					Children:
 						LogicTicker@ANIMATION:
 		Container@SELECTED_SERVER:
-			X: PARENT_RIGHT + 11
+			X: PARENT_WIDTH + 11
 			Width: 174
 			Height: 280
 			Children:
 				Background@MAP_BG:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 174
 					Background: dialog3
 					Children:
 						MapPreview@SELECTED_MAP_PREVIEW:
 							X: 1
 							Y: 1
-							Width: PARENT_RIGHT - 2
-							Height: PARENT_BOTTOM - 2
+							Width: PARENT_WIDTH - 2
+							Height: PARENT_HEIGHT - 2
 							TooltipContainer: TOOLTIP_CONTAINER
 				LabelWithTooltip@SELECTED_MAP:
 					Y: 173
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Bold
 					Align: Center
@@ -174,25 +174,25 @@ Container@LOBBY_SERVERS_BIN:
 					TooltipTemplate: SIMPLE_TOOLTIP
 				Label@SELECTED_IP:
 					Y: 188
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
 				Label@SELECTED_STATUS:
 					Y: 204
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: TinyBold
 					Align: Center
 				Label@SELECTED_MOD_VERSION:
 					Y: 217
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
 				Label@SELECTED_PLAYERS:
 					Y: 230
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: TinyBold
 					Align: Center

--- a/mods/common/chrome/lobby.yaml
+++ b/mods/common/chrome/lobby.yaml
@@ -7,19 +7,19 @@ Background@SERVER_LOBBY:
 			System: SYSTEM_LINE_TEMPLATE
 			Mission: CHAT_LINE_TEMPLATE
 			Feedback: TRANSIENT_LINE_TEMPLATE
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 900
 	Height: 600
 	Children:
 		Label@SERVER_NAME:
 			Y: 16
 			Align: Center
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Bold
 		Container@MAP_PREVIEW_ROOT:
-			X: PARENT_RIGHT - 20 - WIDTH
+			X: PARENT_WIDTH - 20 - WIDTH
 			Y: 67
 			Width: 174
 			Height: 250
@@ -100,7 +100,7 @@ Background@SERVER_LOBBY:
 			Width: 675
 			Height: 219
 		Button@CHANGEMAP_BUTTON:
-			X: PARENT_RIGHT - WIDTH - 20
+			X: PARENT_WIDTH - WIDTH - 20
 			Y: 291
 			Width: 174
 			Height: 25
@@ -108,17 +108,17 @@ Background@SERVER_LOBBY:
 			Font: Bold
 		Container@LOBBYCHAT:
 			X: 20
-			Y: PARENT_BOTTOM - HEIGHT - 20
-			Width: PARENT_RIGHT - 40
+			Y: PARENT_HEIGHT - HEIGHT - 20
+			Width: PARENT_WIDTH - 40
 			Height: 259
 			Children:
 				ScrollPanel@CHAT_DISPLAY:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM - 30
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT - 30
 					TopBottomSpacing: 2
 					ItemSpacing: 2
 				Button@CHAT_MODE:
-					Y: PARENT_BOTTOM - HEIGHT
+					Y: PARENT_HEIGHT - HEIGHT
 					Width: 50
 					Height: 25
 					Text: button-lobbychat-chat-mode.label
@@ -128,19 +128,19 @@ Background@SERVER_LOBBY:
 					TooltipContainer: TOOLTIP_CONTAINER
 				TextField@CHAT_TEXTFIELD:
 					X: 55
-					Y: PARENT_BOTTOM - HEIGHT
-					Width: PARENT_RIGHT - 260 - 55
+					Y: PARENT_HEIGHT - HEIGHT
+					Width: PARENT_WIDTH - 260 - 55
 					Height: 25
 		Button@START_GAME_BUTTON:
-			X: PARENT_RIGHT - WIDTH - 150
-			Y: PARENT_BOTTOM - HEIGHT - 20
+			X: PARENT_WIDTH - WIDTH - 150
+			Y: PARENT_HEIGHT - HEIGHT - 20
 			Width: 120
 			Height: 25
 			Text: button-server-lobby-start-game
 			Font: Bold
 		Button@DISCONNECT_BUTTON:
-			X: PARENT_RIGHT - WIDTH - 20
-			Y: PARENT_BOTTOM - HEIGHT - 20
+			X: PARENT_WIDTH - WIDTH - 20
+			Y: PARENT_HEIGHT - HEIGHT - 20
 			Width: 120
 			Height: 25
 			Text: button-server-lobby-disconnect

--- a/mods/common/chrome/mainmenu-prompts.yaml
+++ b/mods/common/chrome/mainmenu-prompts.yaml
@@ -1,26 +1,26 @@
 Background@MAINMENU_INTRODUCTION_PROMPT:
 	Logic: IntroductionPromptLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 700
 	Height: 525
 	Children:
 		Label@PROMPT_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Y: 20
 			Height: 25
 			Font: Bold
 			Align: Center
 			Text: label-mainmenu-introduction-prompt-title
 		Label@DESC_A:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Y: 50
 			Height: 16
 			Font: Regular
 			Align: Center
 			Text: label-mainmenu-introduction-prompt-desc-a
 		Label@DESC_B:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Y: 68
 			Height: 16
 			Font: Regular
@@ -29,8 +29,8 @@ Background@MAINMENU_INTRODUCTION_PROMPT:
 		ScrollPanel@SETTINGS_SCROLLPANEL:
 			X: 20
 			Y: 100
-			Width: PARENT_RIGHT - 40
-			Height: PARENT_BOTTOM - 155
+			Width: PARENT_WIDTH - 40
+			Height: PARENT_HEIGHT - 155
 			CollapseHiddenChildren: True
 			TopBottomSpacing: 5
 			ItemSpacing: 10
@@ -38,41 +38,41 @@ Background@MAINMENU_INTRODUCTION_PROMPT:
 			Children:
 				Background@PROFILE_SECTION_HEADER:
 					X: 5
-					Width: PARENT_RIGHT - 10
+					Width: PARENT_WIDTH - 10
 					Height: 13
 					Background: separator
 					ClickThrough: True
 					Children:
 						Label@LABEL:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Font: TinyBold
 							Align: Center
 							Text: label-profile-section-header
 				Container@ROW:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 50
 					Children:
 						Container@PLAYER_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@PLAYER:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-player-container
 								TextField@PLAYERNAME:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									MaxLength: 16
 									Text: Name
 						Container@PLAYERCOLOR_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@COLOR:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-playercolor-container-color
 								DropDownButton@PLAYERCOLOR:
@@ -85,166 +85,166 @@ Background@MAINMENU_INTRODUCTION_PROMPT:
 										ColorBlock@COLORBLOCK:
 											X: 5
 											Y: 6
-											Width: PARENT_RIGHT - 35
-											Height: PARENT_BOTTOM - 12
+											Width: PARENT_WIDTH - 35
+											Height: PARENT_HEIGHT - 12
 				Container@SPACER:
 				Background@INPUT_SECTION_HEADER:
 					X: 5
-					Width: PARENT_RIGHT - 10
+					Width: PARENT_WIDTH - 10
 					Height: 13
 					Background: separator
 					ClickThrough: True
 					Children:
 						Label@LABEL:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Font: TinyBold
 							Align: Center
 							Text: label-input-section-header
 				Container@ROW:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 50
 					Children:
 						Container@MOUSE_CONTROL_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@MOUSE_CONTROL_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: label-mouse-control-container
 								DropDownButton@MOUSE_CONTROL_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 						Container@MOUSE_CONTROL_DESC_CLASSIC:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								LabelWithHighlight@DESC_SELECTION:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-selection
 								LabelWithHighlight@DESC_COMMANDS:
 									Y: 17
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-commands
 								LabelWithHighlight@DESC_BUILDINGS:
 									Y: 34
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-buildings
 								LabelWithHighlight@DESC_SUPPORT:
 									Y: 51
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-support
 								LabelWithHighlight@DESC_ZOOM:
 									Y: 68
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-zoom
 								LabelWithHighlight@DESC_ZOOM_MODIFIER:
 									Y: 68
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-zoom-modifier
 								LabelWithHighlight@DESC_SCROLL_RIGHT:
 									Y: 85
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-scroll-right
 								LabelWithHighlight@DESC_SCROLL_MIDDLE:
 									Y: 85
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-scroll-middle
 								Label@DESC_EDGESCROLL:
 									X: 9
 									Y: 102
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-edgescroll
 						Container@MOUSE_CONTROL_DESC_MODERN:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								LabelWithHighlight@DESC_SELECTION:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-selection
 								LabelWithHighlight@DESC_COMMANDS:
 									Y: 17
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-commands
 								LabelWithHighlight@DESC_BUILDINGS:
 									Y: 34
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-buildings
 								LabelWithHighlight@DESC_SUPPORT:
 									Y: 51
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-support
 								LabelWithHighlight@DESC_ZOOM:
 									Y: 68
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-zoom
 								LabelWithHighlight@DESC_ZOOM_MODIFIER:
 									Y: 68
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-zoom-modifier
 								LabelWithHighlight@DESC_SCROLL_RIGHT:
 									Y: 85
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-scroll-right
 								LabelWithHighlight@DESC_SCROLL_MIDDLE:
 									Y: 85
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-scroll-middle
 								Label@DESC_EDGESCROLL:
 									X: 9
 									Y: 102
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-edgescroll
 				Container@ROW:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 20
 					Children:
 						Container@EDGESCROLL_CHECKBOX_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@EDGESCROLL_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-edgescroll-container
@@ -252,63 +252,63 @@ Background@MAINMENU_INTRODUCTION_PROMPT:
 					Height: 30
 				Background@DISPLAY_SECTION_HEADER:
 					X: 5
-					Width: PARENT_RIGHT - 10
+					Width: PARENT_WIDTH - 10
 					Height: 13
 					Background: separator
 					ClickThrough: True
 					Children:
 						Label@LABEL:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Font: TinyBold
 							Align: Center
 							Text: label-display-section-header
 				Container@ROW:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 50
 					Children:
 						Container@BATTLEFIELD_CAMERA_DROPDOWN_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@BATTLEFIELD_CAMERA:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-battlefield-camera-dropdown
 								DropDownButton@BATTLEFIELD_CAMERA_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 						Container@UI_SCALE_DROPDOWN_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@UI_SCALE:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-ui-scale-dropdown
 								DropDownButton@UI_SCALE_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 				Container@ROW:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 20
 					Children:
 						Container@CURSORDOUBLE_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@CURSORDOUBLE_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-cursordouble-container
 		Button@CONTINUE_BUTTON:
-			X: PARENT_RIGHT - 180
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 180
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-continue
@@ -317,13 +317,13 @@ Background@MAINMENU_INTRODUCTION_PROMPT:
 
 Background@MAINMENU_SYSTEM_INFO_PROMPT:
 	Logic: SystemInfoPromptLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 600
 	Height: 430
 	Children:
 		Label@PROMPT_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Y: 20
 			Height: 25
 			Font: Bold
@@ -332,21 +332,21 @@ Background@MAINMENU_SYSTEM_INFO_PROMPT:
 		Label@PROMPT_TEXT_A:
 			X: 15
 			Y: 50
-			Width: PARENT_RIGHT - 30
+			Width: PARENT_WIDTH - 30
 			Height: 16
 			Align: Center
 			Text: label-mainmenu-system-info-prompt-text-a
 		Label@PROMPT_TEXT_B:
 			X: 15
 			Y: 68
-			Width: PARENT_RIGHT - 30
+			Width: PARENT_WIDTH - 30
 			Height: 16
 			Align: Center
 			Text: label-mainmenu-system-info-prompt-text-b
 		ScrollPanel@SYSINFO_DATA:
 			X: 20
 			Y: 98
-			Width: PARENT_RIGHT - 40
+			Width: PARENT_WIDTH - 40
 			Height: 355 - 98 - 10
 			TopBottomSpacing: 4
 			ItemSpacing: 4
@@ -364,8 +364,8 @@ Background@MAINMENU_SYSTEM_INFO_PROMPT:
 			Font: Regular
 			Text: checkbox-mainmenu-system-info-prompt-sysinfo
 		Button@CONTINUE_BUTTON:
-			X: PARENT_RIGHT - WIDTH - 20
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - WIDTH - 20
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-continue

--- a/mods/common/chrome/mainmenu.yaml
+++ b/mods/common/chrome/mainmenu.yaml
@@ -13,16 +13,16 @@ Container@MAINMENU:
 			Background: mainmenu-border
 			X: 0 - 15
 			Y: 0 - 15
-			Width: WINDOW_RIGHT + 30
-			Height: WINDOW_BOTTOM + 30
+			Width: WINDOW_WIDTH + 30
+			Height: WINDOW_HEIGHT + 30
 		Image@LOGO:
-			X: WINDOW_RIGHT - 296
+			X: WINDOW_WIDTH - 296
 			Y: 30
 			ImageCollection: logos
 			ImageName: logo
 		Label@VERSION_LABEL:
 			Logic: VersionLabelLogic
-			X: WINDOW_RIGHT - 296
+			X: WINDOW_WIDTH - 296
 			Y: 296 - 20
 			Width: 296 - 20
 			Height: 25
@@ -30,14 +30,14 @@ Container@MAINMENU:
 			Font: Regular
 			Shadow: true
 		Container@MENUS:
-			X: 13 + (WINDOW_RIGHT - 522) / 4 - WIDTH / 2
-			Y: WINDOW_BOTTOM / 2 - HEIGHT / 2
+			X: 13 + (WINDOW_WIDTH - 522) / 4 - WIDTH / 2
+			Y: WINDOW_HEIGHT / 2 - HEIGHT / 2
 			Width: 200
 			Height: 320
 			Children:
 				Background@MAIN_MENU:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						Label@MAINMENU_LABEL_TITLE:
 							X: 0
@@ -48,50 +48,50 @@ Container@MAINMENU:
 							Align: Center
 							Font: Bold
 						Button@SINGLEPLAYER_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 60
 							Width: 140
 							Height: 30
 							Text: label-singleplayer-title
 							Font: Bold
 						Button@MULTIPLAYER_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 100
 							Width: 140
 							Height: 30
 							Text: label-multiplayer-title
 							Font: Bold
 						Button@SETTINGS_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 140
 							Width: 140
 							Height: 30
 							Text: button-settings-title
 							Font: Bold
 						Button@EXTRAS_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 180
 							Width: 140
 							Height: 30
 							Text: button-extras-title
 							Font: Bold
 						Button@CONTENT_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 220
 							Width: 140
 							Height: 30
 							Text: button-main-menu-content
 							Font: Bold
 						Button@QUIT_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 260
 							Width: 140
 							Height: 30
 							Text: button-quit
 							Font: Bold
 				Background@SINGLEPLAYER_MENU:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						Label@SINGLEPLAYER_MENU_TITLE:
 							X: 0
@@ -102,28 +102,28 @@ Container@MAINMENU:
 							Align: Center
 							Font: Bold
 						Button@SKIRMISH_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 60
 							Width: 140
 							Height: 30
 							Text: button-singleplayer-menu-skirmish
 							Font: Bold
 						Button@MISSIONS_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 100
 							Width: 140
 							Height: 30
 							Text: label-missions-title
 							Font: Bold
 						Button@LOAD_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 140
 							Width: 140
 							Height: 30
 							Text: button-singleplayer-menu-load
 							Font: Bold
 						Button@BACK_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Key: escape
 							Y: 260
 							Width: 140
@@ -131,8 +131,8 @@ Container@MAINMENU:
 							Text: button-back
 							Font: Bold
 				Background@EXTRAS_MENU:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						Label@EXTRAS_MENU_TITLE:
 							X: 0
@@ -143,42 +143,42 @@ Container@MAINMENU:
 							Align: Center
 							Font: Bold
 						Button@REPLAYS_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 60
 							Width: 140
 							Height: 30
 							Text: button-extras-menu-replays
 							Font: Bold
 						Button@MUSIC_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 100
 							Width: 140
 							Height: 30
 							Text: label-music-title
 							Font: Bold
 						Button@MAP_EDITOR_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 140
 							Width: 140
 							Height: 30
 							Text: label-map-editor-title
 							Font: Bold
 						Button@ASSETBROWSER_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 180
 							Width: 140
 							Height: 30
 							Text: button-extras-menu-assetbrowser
 							Font: Bold
 						Button@CREDITS_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 220
 							Width: 140
 							Height: 30
 							Text: label-credits-title
 							Font: Bold
 						Button@BACK_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Key: escape
 							Y: 260
 							Width: 140
@@ -186,8 +186,8 @@ Container@MAINMENU:
 							Text: button-back
 							Font: Bold
 				Background@MAP_EDITOR_MENU:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						Label@MAP_EDITOR_MENU_TITLE:
 							X: 0
@@ -198,21 +198,21 @@ Container@MAINMENU:
 							Align: Center
 							Font: Bold
 						Button@NEW_MAP_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 60
 							Width: 140
 							Height: 30
 							Text: button-map-editor-new-map
 							Font: Bold
 						Button@LOAD_MAP_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 100
 							Width: 140
 							Height: 30
 							Text: button-map-editor-load-map
 							Font: Bold
 						Button@BACK_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Key: escape
 							Y: 260
 							Width: 140
@@ -224,15 +224,15 @@ Container@MAINMENU:
 			Children:
 				Label@PERF_TEXT:
 					X: 30
-					Y: WINDOW_BOTTOM - 70
+					Y: WINDOW_HEIGHT - 70
 					Width: 170
 					Height: 40
 					Contrast: true
 				Background@GRAPH_BG:
 					ClickThrough: true
 					Background: dialog4
-					X: WINDOW_RIGHT - 240
-					Y: WINDOW_BOTTOM - 240
+					X: WINDOW_WIDTH - 240
+					Y: WINDOW_HEIGHT - 240
 					Width: 210
 					Height: 210
 					Children:
@@ -242,7 +242,7 @@ Container@MAINMENU:
 							Width: 200
 							Height: 200
 		Background@NEWS_BG:
-			X: (WINDOW_RIGHT - WIDTH) / 2
+			X: (WINDOW_WIDTH - WIDTH) / 2
 			Y: 35
 			Width: 430
 			Height: 55
@@ -256,19 +256,19 @@ Container@MAINMENU:
 					Text: dropdownbutton-news-bg-button
 					Font: Bold
 		Container@UPDATE_NOTICE:
-			X: (WINDOW_RIGHT - WIDTH) / 2
+			X: (WINDOW_WIDTH - WIDTH) / 2
 			Y: 95
 			Width: 128
 			Children:
 				Label@A:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 					Shadow: true
 					Text: label-update-notice-a
 				Label@B:
 					Y: 20
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 					Shadow: true

--- a/mods/common/chrome/map-chooser.yaml
+++ b/mods/common/chrome/map-chooser.yaml
@@ -1,6 +1,6 @@
 Background@MAPCHOOSER_PANEL:
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Logic: MapChooserLogic
 	Width: 900
 	Height: 600
@@ -8,7 +8,7 @@ Background@MAPCHOOSER_PANEL:
 		Label@MAPCHOOSER_TITLE:
 			Y: 17
 			Align: Center
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 20
 			Text: label-mapchooser-panel-title
 			Font: Bold
@@ -34,32 +34,32 @@ Background@MAPCHOOSER_PANEL:
 			Text: button-mapchooser-panel-user-maps-tab
 			Font: Bold
 		Container@MAP_TAB_PANES:
-			Width: PARENT_RIGHT - 40
+			Width: PARENT_WIDTH - 40
 			Height: 438
 			X: 20
 			Y: 77
 			Children:
 				Container@SYSTEM_MAPS_TAB:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						ScrollPanel@MAP_LIST:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 				Container@REMOTE_MAPS_TAB:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						ScrollPanel@MAP_LIST:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 				Container@USER_MAPS_TAB:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						ScrollPanel@MAP_LIST:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 		ScrollItem@MAP_TEMPLATE:
 			Width: 208
 			Height: 266
@@ -68,7 +68,7 @@ Background@MAPCHOOSER_PANEL:
 			EnableChildMouseOver: True
 			Children:
 				MapPreview@PREVIEW:
-					X: (PARENT_RIGHT - WIDTH) / 2
+					X: (PARENT_WIDTH - WIDTH) / 2
 					Y: 3
 					Width: 202
 					Height: 202
@@ -76,40 +76,40 @@ Background@MAPCHOOSER_PANEL:
 					IgnoreMouseInput: true
 				LabelWithTooltip@TITLE:
 					X: 4
-					Y: PARENT_BOTTOM - HEIGHT - 39
-					Width: PARENT_RIGHT - 8
+					Y: PARENT_HEIGHT - HEIGHT - 39
+					Width: PARENT_WIDTH - 8
 					Height: 24
 					Align: Center
 					TooltipContainer: TOOLTIP_CONTAINER
 					TooltipTemplate: SIMPLE_TOOLTIP
 				Label@DETAILS:
-					Width: PARENT_RIGHT - 8
+					Width: PARENT_WIDTH - 8
 					Height: 12
 					X: 4
-					Y: PARENT_BOTTOM - HEIGHT - 30
+					Y: PARENT_HEIGHT - HEIGHT - 30
 					Align: Center
 					Font: Tiny
 				LabelWithTooltip@AUTHOR:
-					Width: PARENT_RIGHT - 8
+					Width: PARENT_WIDTH - 8
 					Height: 12
 					X: 4
-					Y: PARENT_BOTTOM - HEIGHT - 18
+					Y: PARENT_HEIGHT - HEIGHT - 18
 					Align: Center
 					Font: Tiny
 					TooltipContainer: TOOLTIP_CONTAINER
 					TooltipTemplate: SIMPLE_TOOLTIP
 				Label@SIZE:
-					Width: PARENT_RIGHT - 8
+					Width: PARENT_WIDTH - 8
 					Height: 12
 					X: 4
-					Y: PARENT_BOTTOM - HEIGHT - 6
+					Y: PARENT_HEIGHT - HEIGHT - 6
 					Align: Center
 					Font: Tiny
 		Container@FILTER_ORDER_CONTROLS:
 			X: 20
-			Y: PARENT_BOTTOM - 80
-			Width: PARENT_RIGHT - 40
-			Height: PARENT_BOTTOM
+			Y: PARENT_HEIGHT - 80
+			Width: PARENT_WIDTH - 40
+			Height: PARENT_HEIGHT
 			Children:
 				Label@FILTER_DESC:
 					Width: 40
@@ -133,55 +133,55 @@ Background@MAPCHOOSER_PANEL:
 					Width: 200
 					Height: 25
 				Label@ORDERBY_LABEL:
-					X: PARENT_RIGHT - WIDTH - 200 - 5
+					X: PARENT_WIDTH - WIDTH - 200 - 5
 					Width: 100
 					Height: 24
 					Font: Bold
 					Align: Right
 					Text: label-filter-order-controls-orderby
 				DropDownButton@ORDERBY:
-					X: PARENT_RIGHT - WIDTH
+					X: PARENT_WIDTH - WIDTH
 					Width: 200
 					Height: 25
 		Button@RANDOMMAP_BUTTON:
 			X: 20
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 120
 			Height: 25
 			Text: button-mapchooser-panel-randommap
 			Font: Bold
 		Button@DELETE_MAP_BUTTON:
 			X: 160
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 120
 			Height: 25
 			Text: button-mapchooser-panel-delete-map
 			Font: Bold
 		Button@DELETE_ALL_MAPS_BUTTON:
 			X: 300
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 120
 			Height: 25
 			Text: button-mapchooser-panel-delete-all-maps
 			Font: Bold
 		Label@REMOTE_MAP_LABEL:
 			X: 140
-			Y: PARENT_BOTTOM - HEIGHT - 20
-			Width: PARENT_RIGHT - 410
+			Y: PARENT_HEIGHT - HEIGHT - 20
+			Width: PARENT_WIDTH - 410
 			Height: 25
 			Align: Center
 			Font: Bold
 		Button@BUTTON_OK:
-			X: PARENT_RIGHT - 270
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 270
+			Y: PARENT_HEIGHT - 45
 			Width: 120
 			Height: 25
 			Text: button-mapchooser-panel-ok
 			Font: Bold
 			Key: return
 		Button@BUTTON_CANCEL:
-			X: PARENT_RIGHT - 140
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 140
+			Y: PARENT_HEIGHT - 45
 			Width: 120
 			Height: 25
 			Text: button-back

--- a/mods/common/chrome/missionbrowser.yaml
+++ b/mods/common/chrome/missionbrowser.yaml
@@ -1,13 +1,13 @@
 Background@MISSIONBROWSER_PANEL:
 	Logic: MissionBrowserLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 700
 	Height: 500
 	Children:
 		Label@MISSIONBROWSER_TITLE:
 			Y: 21
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Text: label-missions-title
 			Align: Center
@@ -16,29 +16,29 @@ Background@MISSIONBROWSER_PANEL:
 			X: 20
 			Y: 50
 			Width: 288
-			Height: PARENT_BOTTOM - 110
+			Height: PARENT_HEIGHT - 110
 			Children:
 				ScrollItem@HEADER:
 					Background: scrollheader
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 13
 					X: 2
 					Visible: false
 					Children:
 						Label@LABEL:
 							Font: TinyBold
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 13
 							Align: Center
 				ScrollItem@TEMPLATE:
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 25
 					X: 2
 					EnableChildMouseOver: True
 					Children:
 						LabelWithTooltip@TITLE:
 							X: 10
-							Width: PARENT_RIGHT - 20
+							Width: PARENT_WIDTH - 20
 							Height: 25
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
@@ -46,99 +46,99 @@ Background@MISSIONBROWSER_PANEL:
 			X: 318
 			Y: 50
 			Width: 362
-			Height: PARENT_BOTTOM - 110
+			Height: PARENT_HEIGHT - 110
 			Children:
 				Background@MISSION_BG:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 202
 					Background: dialog3
 					Children:
 						MapPreview@MISSION_PREVIEW:
 							X: 1
 							Y: 1
-							Width: PARENT_RIGHT - 2
-							Height: PARENT_BOTTOM - 2
+							Width: PARENT_WIDTH - 2
+							Height: PARENT_HEIGHT - 2
 							IgnoreMouseOver: True
 							IgnoreMouseInput: True
 							ShowSpawnPoints: False
 				Container@MISSION_TABS:
-					Width: PARENT_RIGHT
-					Y: PARENT_BOTTOM - 31
+					Width: PARENT_WIDTH
+					Y: PARENT_HEIGHT - 31
 					Children:
 						Button@MISSIONINFO_TAB:
-							Width: PARENT_RIGHT / 2
+							Width: PARENT_WIDTH / 2
 							Height: 31
 							Font: Bold
 							Text: button-missionbrowser-panel-mission-info
 						Button@OPTIONS_TAB:
-							X: PARENT_RIGHT / 2
-							Width: PARENT_RIGHT / 2
+							X: PARENT_WIDTH / 2
+							Width: PARENT_WIDTH / 2
 							Height: 31
 							Font: Bold
 							Text: button-missionbrowser-panel-mission-options
 				Container@MISSION_DETAIL:
 					Y: 212
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM - 212
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT - 212
 					Children:
 						ScrollPanel@MISSION_DESCRIPTION_PANEL:
-							Height: PARENT_BOTTOM - 30
-							Width: PARENT_RIGHT
+							Height: PARENT_HEIGHT - 30
+							Width: PARENT_WIDTH
 							TopBottomSpacing: 5
 							Children:
 								Label@MISSION_DESCRIPTION:
 									X: 4
-									Width: PARENT_RIGHT - 32
+									Width: PARENT_WIDTH - 32
 									VAlign: Top
 									Font: Small
 						ScrollPanel@MISSION_OPTIONS:
-							Height: PARENT_BOTTOM - 30
-							Width: PARENT_RIGHT
+							Height: PARENT_HEIGHT - 30
+							Width: PARENT_WIDTH
 							TopBottomSpacing: 5
 							Children:
 								Container@CHECKBOX_ROW_TEMPLATE:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 30
 									Children:
 										Checkbox@A:
 											X: 10
-											Width: PARENT_RIGHT / 2 - 25
+											Width: PARENT_WIDTH / 2 - 25
 											Height: 20
 											Visible: False
 											TooltipContainer: TOOLTIP_CONTAINER
 										Checkbox@B:
-											X: PARENT_RIGHT / 2 + 5
-											Width: PARENT_RIGHT / 2 - 25
+											X: PARENT_WIDTH / 2 + 5
+											Width: PARENT_WIDTH / 2 - 25
 											Height: 20
 											Visible: False
 											TooltipContainer: TOOLTIP_CONTAINER
 								Container@DROPDOWN_ROW_TEMPLATE:
 									Height: 60
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Children:
 										LabelForInput@A_DESC:
 											X: 10
-											Width: PARENT_RIGHT / 2 - 35
+											Width: PARENT_WIDTH / 2 - 35
 											Height: 20
 											Visible: False
 											For: A
 										DropDownButton@A:
 											X: 10
-											Width: PARENT_RIGHT / 2 - 35
+											Width: PARENT_WIDTH / 2 - 35
 											Y: 25
 											Height: 25
 											Visible: False
 											PanelRoot: MISSION_DROPDOWN_PANEL_ROOT
 											TooltipContainer: TOOLTIP_CONTAINER
 										LabelForInput@B_DESC:
-											X: PARENT_RIGHT / 2 + 5
-											Width: PARENT_RIGHT / 2 - 35
+											X: PARENT_WIDTH / 2 + 5
+											Width: PARENT_WIDTH / 2 - 35
 											Height: 20
 											Visible: False
 											For: B
 										DropDownButton@B:
-											X: PARENT_RIGHT / 2 + 5
-											Width: PARENT_RIGHT / 2 - 35
+											X: PARENT_WIDTH / 2 + 5
+											Width: PARENT_WIDTH / 2 - 35
 											Y: 25
 											Height: 25
 											Visible: False
@@ -146,42 +146,42 @@ Background@MISSIONBROWSER_PANEL:
 											TooltipContainer: TOOLTIP_CONTAINER
 		Button@START_BRIEFING_VIDEO_BUTTON:
 			X: 20
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 130
 			Height: 25
 			Text: button-missionbrowser-panel-start-briefing-video
 			Font: Bold
 		Button@STOP_BRIEFING_VIDEO_BUTTON:
 			X: 20
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 130
 			Height: 25
 			Text: button-missionbrowser-panel-stop-briefing-video
 			Font: Bold
 		Button@START_INFO_VIDEO_BUTTON:
 			X: 160
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 130
 			Height: 25
 			Text: button-missionbrowser-panel-start-info-video
 			Font: Bold
 		Button@STOP_INFO_VIDEO_BUTTON:
 			X: 160
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 130
 			Height: 25
 			Text: button-missionbrowser-panel-stop-info-video
 			Font: Bold
 		Button@STARTGAME_BUTTON:
-			X: PARENT_RIGHT - 140 - 130
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 140 - 130
+			Y: PARENT_HEIGHT - 45
 			Width: 120
 			Height: 25
 			Text: button-missionbrowser-panel-play
 			Font: Bold
 		Button@BACK_BUTTON:
-			X: PARENT_RIGHT - 140
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 140
+			Y: PARENT_HEIGHT - 45
 			Width: 120
 			Height: 25
 			Text: button-back
@@ -190,26 +190,26 @@ Background@MISSIONBROWSER_PANEL:
 		Background@MISSION_BIN:
 			X: 20
 			Y: 50
-			Width: PARENT_RIGHT - 40
-			Height: PARENT_BOTTOM - 110
+			Width: PARENT_WIDTH - 40
+			Height: PARENT_HEIGHT - 110
 			Background: dialog3
 			Children:
 				VideoPlayer@MISSION_VIDEO:
 					X: 1
 					Y: 1
-					Width: PARENT_RIGHT - 2
-					Height: PARENT_BOTTOM - 2
+					Width: PARENT_WIDTH - 2
+					Height: PARENT_HEIGHT - 2
 		Container@MISSION_DROPDOWN_PANEL_ROOT:
 		TooltipContainer@TOOLTIP_CONTAINER:
 
 Background@FULLSCREEN_PLAYER:
-	Width: WINDOW_RIGHT
-	Height: WINDOW_BOTTOM
+	Width: WINDOW_WIDTH
+	Height: WINDOW_HEIGHT
 	Background: dialog5
 	Visible: False
 	Children:
 		VideoPlayer@PLAYER:
 			X: 0
 			Y: 0
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
+			Width: WINDOW_WIDTH
+			Height: WINDOW_HEIGHT

--- a/mods/common/chrome/multiplayer-browser.yaml
+++ b/mods/common/chrome/multiplayer-browser.yaml
@@ -1,13 +1,13 @@
 Background@MULTIPLAYER_PANEL:
 	Logic: MultiplayerLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 900
 	Height: 600
 	Children:
 		Label@TITLE:
 			Y: 16
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Text: label-multiplayer-title
 			Align: Center
@@ -15,8 +15,8 @@ Background@MULTIPLAYER_PANEL:
 		Container@LABEL_CONTAINER:
 			X: 20
 			Y: 43
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Label@NAME:
 					X: 5
@@ -53,21 +53,21 @@ Background@MULTIPLAYER_PANEL:
 			Children:
 				Label@OUTDATED_VERSION_LABEL:
 					X: 5
-					Width: PARENT_RIGHT - 10
+					Width: PARENT_WIDTH - 10
 					Height: 20
 					Align: Center
 					Text: label-notice-container-outdated-version
 					Font: TinyBold
 				Label@UNKNOWN_VERSION_LABEL:
 					X: 5
-					Width: PARENT_RIGHT - 10
+					Width: PARENT_WIDTH - 10
 					Height: 20
 					Align: Center
 					Text: label-notice-container-unknown-version
 					Font: TinyBold
 				Label@PLAYTEST_AVAILABLE_LABEL:
 					X: 5
-					Width: PARENT_RIGHT - 10
+					Width: PARENT_WIDTH - 10
 					Height: 20
 					Align: Center
 					Text: label-notice-container-playtest-available
@@ -76,24 +76,24 @@ Background@MULTIPLAYER_PANEL:
 			X: 20
 			Y: 67
 			Width: 675
-			Height: PARENT_BOTTOM - 122
+			Height: PARENT_HEIGHT - 122
 			TopBottomSpacing: 2
 			Children:
 				ScrollItem@HEADER_TEMPLATE:
 					X: 2
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 20
 					Background: scrollheader
 					Visible: false
 					Children:
 						Label@LABEL:
 							Font: TinyBold
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 20
 							Align: Center
 				ScrollItem@SERVER_TEMPLATE:
 					X: 2
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 25
 					EnableChildMouseOver: True
 					Children:
@@ -137,32 +137,32 @@ Background@MULTIPLAYER_PANEL:
 							Height: 25
 		Label@PROGRESS_LABEL:
 			X: 20
-			Y: 67 + (PARENT_BOTTOM - 119 - HEIGHT) / 2
+			Y: 67 + (PARENT_HEIGHT - 119 - HEIGHT) / 2
 			Width: 675
 			Height: 25
 			Font: Bold
 			Align: Center
 			Visible: false
 		Container@SELECTED_SERVER:
-			X: PARENT_RIGHT - WIDTH - 20
+			X: PARENT_WIDTH - WIDTH - 20
 			Y: 67
 			Width: 174
 			Height: 280
 			Children:
 				Background@MAP_BG:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 174
 					Background: dialog3
 					Children:
 						MapPreview@SELECTED_MAP_PREVIEW:
 							X: 1
 							Y: 1
-							Width: PARENT_RIGHT - 2
-							Height: PARENT_BOTTOM - 2
+							Width: PARENT_WIDTH - 2
+							Height: PARENT_HEIGHT - 2
 							TooltipContainer: TOOLTIP_CONTAINER
 				LabelWithTooltip@SELECTED_MAP:
 					Y: 173
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Bold
 					Align: Center
@@ -170,49 +170,49 @@ Background@MULTIPLAYER_PANEL:
 					TooltipTemplate: SIMPLE_TOOLTIP
 				Label@SELECTED_IP:
 					Y: 188
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
 				Label@SELECTED_STATUS:
 					Y: 204
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: TinyBold
 					Align: Center
 				Label@SELECTED_MOD_VERSION:
 					Y: 217
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Tiny
 					Align: Center
 				Label@SELECTED_PLAYERS:
 					Y: 230
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: TinyBold
 					Align: Center
 				Container@CLIENT_LIST_CONTAINER:
 					Y: 240
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 166
 				Button@JOIN_BUTTON:
 					Key: return
 					Y: 255
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Text: button-selected-server-join
 					Font: Bold
 		DropDownButton@FILTERS_DROPDOWNBUTTON:
 			X: 20
-			Y: PARENT_BOTTOM - HEIGHT - 20
+			Y: PARENT_HEIGHT - HEIGHT - 20
 			Width: 158
 			Height: 25
 			Text: dropdownbutton-multiplayer-panel-filters
 			Font: Bold
 		Button@RELOAD_BUTTON:
 			X: 182
-			Y: PARENT_BOTTOM - HEIGHT - 20
+			Y: PARENT_HEIGHT - HEIGHT - 20
 			Width: 26
 			Height: 25
 			Children:
@@ -228,29 +228,29 @@ Background@MULTIPLAYER_PANEL:
 						LogicTicker@ANIMATION:
 		Label@PLAYER_COUNT:
 			X: 254
-			Y: PARENT_BOTTOM - HEIGHT - 20
+			Y: PARENT_HEIGHT - HEIGHT - 20
 			Width: 190
 			Height: 25
 			Align: Center
 			Font: Bold
 		Button@DIRECTCONNECT_BUTTON:
 			X: 490
-			Y: PARENT_BOTTOM - HEIGHT - 20
+			Y: PARENT_HEIGHT - HEIGHT - 20
 			Width: 100
 			Height: 25
 			Text: button-multiplayer-panel-directconnect
 			Font: Bold
 		Button@CREATE_BUTTON:
 			X: 595
-			Y: PARENT_BOTTOM - HEIGHT - 20
+			Y: PARENT_HEIGHT - HEIGHT - 20
 			Width: 100
 			Height: 25
 			Text: button-multiplayer-panel-create
 			Font: Bold
 		Button@BACK_BUTTON:
 			Key: escape
-			X: PARENT_RIGHT - WIDTH - 20
-			Y: PARENT_BOTTOM - HEIGHT - 20
+			X: PARENT_WIDTH - WIDTH - 20
+			Y: PARENT_HEIGHT - HEIGHT - 20
 			Width: 174
 			Height: 25
 			Text: button-back

--- a/mods/common/chrome/multiplayer-browserpanels.yaml
+++ b/mods/common/chrome/multiplayer-browserpanels.yaml
@@ -1,11 +1,11 @@
 ScrollPanel@MULTIPLAYER_CLIENT_LIST:
-	Width: PARENT_RIGHT
+	Width: PARENT_WIDTH
 	Height: 159
 	IgnoreChildMouseOver: true
 	Children:
 		ScrollItem@HEADER:
 			Background: scrollheader
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 13
 			X: 2
 			Y: 0
@@ -13,11 +13,11 @@ ScrollPanel@MULTIPLAYER_CLIENT_LIST:
 			Children:
 				Label@LABEL:
 					Font: TinyBold
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 13
 					Align: Center
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -31,23 +31,23 @@ ScrollPanel@MULTIPLAYER_CLIENT_LIST:
 					Visible: False
 				Label@LABEL:
 					X: 40
-					Width: PARENT_RIGHT - 50
+					Width: PARENT_WIDTH - 50
 					Height: 25
 					Shadow: True
 				Label@NOFLAG_LABEL:
 					X: 5
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Shadow: True
 
 ScrollPanel@MULTIPLAYER_FILTER_PANEL:
-	Width: PARENT_RIGHT
+	Width: PARENT_WIDTH
 	Height: 130
 	Children:
 		Checkbox@WAITING_FOR_PLAYERS:
 			X: 5
 			Y: 5
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Text: checkbox-multiplayer-filter-panel-waiting-for-players
 			TextColor: 32CD32
@@ -55,14 +55,14 @@ ScrollPanel@MULTIPLAYER_FILTER_PANEL:
 		Checkbox@EMPTY:
 			X: 5
 			Y: 30
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Text: checkbox-multiplayer-filter-panel-empty
 			Font: Regular
 		Checkbox@PASSWORD_PROTECTED:
 			X: 5
 			Y: 55
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Text: checkbox-multiplayer-filter-panel-password-protected
 			TextColor: FF0000
@@ -70,7 +70,7 @@ ScrollPanel@MULTIPLAYER_FILTER_PANEL:
 		Checkbox@ALREADY_STARTED:
 			X: 5
 			Y: 80
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Text: checkbox-multiplayer-filter-panel-already-started
 			TextColor: FFA500
@@ -78,7 +78,7 @@ ScrollPanel@MULTIPLAYER_FILTER_PANEL:
 		Checkbox@INCOMPATIBLE_VERSION:
 			X: 5
 			Y: 105
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Text: checkbox-multiplayer-filter-panel-incompatible-version
 			TextColor: BEBEBE

--- a/mods/common/chrome/multiplayer-createserver.yaml
+++ b/mods/common/chrome/multiplayer-createserver.yaml
@@ -1,13 +1,13 @@
 Background@MULTIPLAYER_CREATESERVER_PANEL:
 	Logic: ServerCreationLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 530
 	Height: 315
 	Children:
 		Label@TITLE:
 			Y: 16
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Text: label-multiplayer-createserver-panel-title
 			Align: Center
@@ -86,8 +86,8 @@ Background@MULTIPLAYER_CREATESERVER_PANEL:
 		Container@NOTICES_LAN:
 			X: 25
 			Y: 176
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Label@ADVERTISING:
 					Width: 305
@@ -120,8 +120,8 @@ Background@MULTIPLAYER_CREATESERVER_PANEL:
 		Container@NOTICES_NO_UPNP:
 			X: 25
 			Y: 176
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Label@ADVERTISING:
 					Width: 305
@@ -169,8 +169,8 @@ Background@MULTIPLAYER_CREATESERVER_PANEL:
 		Container@NOTICES_UPNP:
 			X: 25
 			Y: 176
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Label@ADVERTISING:
 					Width: 305
@@ -200,20 +200,20 @@ Background@MULTIPLAYER_CREATESERVER_PANEL:
 					Align: Left
 					Text: label-notices-upnp-settings-a
 		Container@MAP_PREVIEW_ROOT:
-			X: PARENT_RIGHT - 194
+			X: PARENT_WIDTH - 194
 			Y: 45
 			Width: 174
 			Height: 250
 		Button@MAP_BUTTON:
 			X: 20
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 120
 			Height: 25
 			Text: button-multiplayer-createserver-panel-change-map
 			Font: Bold
 		Button@BACK_BUTTON:
-			X: PARENT_RIGHT - WIDTH - 20
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - WIDTH - 20
+			Y: PARENT_HEIGHT - 45
 			Width: 120
 			Height: 25
 			Text: button-back
@@ -221,8 +221,8 @@ Background@MULTIPLAYER_CREATESERVER_PANEL:
 			Key: escape
 		Button@CREATE_BUTTON:
 			Key: return
-			X: PARENT_RIGHT - 2 * WIDTH - 30
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 2 * WIDTH - 30
+			Y: PARENT_HEIGHT - 45
 			Width: 120
 			Height: 25
 			Text: button-multiplayer-createserver-panel-create

--- a/mods/common/chrome/multiplayer-directconnect.yaml
+++ b/mods/common/chrome/multiplayer-directconnect.yaml
@@ -1,7 +1,7 @@
 Background@DIRECTCONNECT_PANEL:
 	Logic: DirectConnectLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 450
 	Height: 160
 	Children:
@@ -41,16 +41,16 @@ Background@DIRECTCONNECT_PANEL:
 			Height: 25
 			Type: Integer
 		Button@JOIN_BUTTON:
-			X: PARENT_RIGHT - 430
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 430
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-directconnect-panel-join
 			Font: Bold
 			Key: return
 		Button@BACK_BUTTON:
-			X: PARENT_RIGHT - 180
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 180
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-cancel

--- a/mods/common/chrome/musicplayer.yaml
+++ b/mods/common/chrome/musicplayer.yaml
@@ -1,7 +1,7 @@
 Background@MUSIC_PANEL:
 	Logic: MusicPlayerLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 410
 	Height: 500
 	Children:
@@ -9,11 +9,11 @@ Background@MUSIC_PANEL:
 		ScrollPanel@MUSIC_LIST:
 			X: 20
 			Y: 45
-			Width: PARENT_RIGHT - 40
-			Height: PARENT_BOTTOM - 175
+			Width: PARENT_WIDTH - 40
+			Height: PARENT_HEIGHT - 175
 			Children:
 				ScrollItem@MUSIC_TEMPLATE:
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 25
 					X: 2
 					Y: 0
@@ -22,19 +22,19 @@ Background@MUSIC_PANEL:
 					Children:
 						LabelWithTooltip@TITLE:
 							X: 10
-							Width: PARENT_RIGHT - 50
+							Width: PARENT_WIDTH - 50
 							Height: 25
 							TooltipContainer: MUSIC_TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 						Label@LENGTH:
 							Width: 50
-							X: PARENT_RIGHT - 60
+							X: PARENT_WIDTH - 60
 							Align: Right
 							Height: 25
 		Container@LABEL_CONTAINER:
 			X: 20
 			Y: 16
-			Width: PARENT_RIGHT - 40
+			Width: PARENT_WIDTH - 40
 			Children:
 				Label@TITLE:
 					Width: 100
@@ -43,7 +43,7 @@ Background@MUSIC_PANEL:
 					Align: Center
 					Font: Bold
 				Label@TYPE:
-					X: PARENT_RIGHT - WIDTH
+					X: PARENT_WIDTH - WIDTH
 					Height: 25
 					Width: 95
 					Text: label-music-controls-length
@@ -51,8 +51,8 @@ Background@MUSIC_PANEL:
 					Font: Bold
 		Container@BUTTONS:
 			X: 20
-			Y: PARENT_BOTTOM - HEIGHT - 85
-			Width: PARENT_RIGHT - 40
+			Y: PARENT_HEIGHT - HEIGHT - 85
+			Width: PARENT_WIDTH - 40
 			Children:
 				Button@BUTTON_PREV:
 					Width: 26
@@ -110,58 +110,58 @@ Background@MUSIC_PANEL:
 							ImageCollection: music
 							ImageName: next
 				ExponentialSlider@MUSIC_SLIDER:
-					X: PARENT_RIGHT - WIDTH
+					X: PARENT_WIDTH - WIDTH
 					Y: 3
-					Width: PARENT_RIGHT - 145
+					Width: PARENT_WIDTH - 145
 					Height: 20
 					Ticks: 7
 		Label@TIME_LABEL:
-			X: (PARENT_RIGHT - WIDTH) / 2
-			Y: PARENT_BOTTOM - HEIGHT - 95 - 3
+			X: (PARENT_WIDTH - WIDTH) / 2
+			Y: PARENT_HEIGHT - HEIGHT - 95 - 3
 			Width: 140
 			Height: 25
 			Align: Center
 			Font: Bold
 		Checkbox@SHUFFLE:
 			X: 20
-			Y: PARENT_BOTTOM - HEIGHT - 95
+			Y: PARENT_HEIGHT - HEIGHT - 95
 			Width: 85
 			Height: 20
 			Text: checkbox-music-controls-shuffle
 		Checkbox@REPEAT:
-			X: PARENT_RIGHT - 15 - WIDTH
-			Y: PARENT_BOTTOM - HEIGHT - 95
+			X: PARENT_WIDTH - 15 - WIDTH
+			Y: PARENT_HEIGHT - HEIGHT - 95
 			Width: 70
 			Height: 20
 			Text: checkbox-music-controls-loop
 		Container@NO_MUSIC_LABEL:
 			X: 20
-			Y: (PARENT_BOTTOM - HEIGHT - 95) / 2
-			Width: PARENT_RIGHT - 40
+			Y: (PARENT_HEIGHT - HEIGHT - 95) / 2
+			Width: PARENT_WIDTH - 40
 			Height: 75
 			Visible: false
 			Children:
 				Label@TITLE:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 25
 					Font: Bold
 					Align: Center
 					Text: label-no-music-title
 				Label@DESCA:
 					Y: 20
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 25
 					Align: Center
 					Text: label-no-music-desc-a
 				Label@DESCB:
 					Y: 40
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 25
 					Align: Center
 					Text: label-no-music-desc-b
 		Button@BACK_BUTTON:
-			X: PARENT_RIGHT - WIDTH - 20
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - WIDTH - 20
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-back
@@ -169,7 +169,7 @@ Background@MUSIC_PANEL:
 			Key: escape
 		Label@MUTE_LABEL:
 			X: 25
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 300
 			Height: 20
 			Font: Small

--- a/mods/common/chrome/playerprofile.yaml
+++ b/mods/common/chrome/playerprofile.yaml
@@ -4,114 +4,114 @@ Container@LOCAL_PROFILE_PANEL:
 	Height: 100
 	Children:
 		Background@PROFILE_HEADER:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 50
 			Background: dialog2
 			Children:
 				Label@PROFILE_NAME:
 					X: 10
 					Y: 5
-					Width: PARENT_RIGHT - 20
+					Width: PARENT_WIDTH - 20
 					Height: 25
 					Font: MediumBold
 				Label@PROFILE_RANK:
 					X: 10
 					Y: 24
-					Width: PARENT_RIGHT - 20
+					Width: PARENT_WIDTH - 20
 					Height: 25
 					Font: TinyBold
 				Button@DESTROY_KEY:
-					X: PARENT_RIGHT - 70
+					X: PARENT_WIDTH - 70
 					Y: 15
 					Width: 60
 					Height: 20
 					Font: TinyBold
 					Text: button-profile-header-logout
 		Background@BADGES_CONTAINER:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Y: 48
 			Visible: false
 			Background: dialog3
 		Background@GENERATE_KEYS:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: dialog2
 			Children:
 				Label@DESC_A:
 					Y: 5
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-generate-keys-desc-a
 				Label@DESC_B:
 					Y: 21
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-generate-keys-desc-b
 				Label@DESC_C:
 					Y: 37
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-generate-keys-desc-c
 				Button@GENERATE_KEY:
-					X: (PARENT_RIGHT - WIDTH) / 2
+					X: (PARENT_WIDTH - WIDTH) / 2
 					Y: 70
 					Width: 240
 					Height: 20
 					Font: TinyBold
 					Text: button-generate-keys-key
 		Background@GENERATING_KEYS:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: dialog2
 			Children:
 				Label@DESC_A:
 					Y: 13
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-generating-keys-desc-a
 				Label@DESC_B:
 					Y: 29
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-generating-keys-desc-b
 				ProgressBar:
-					X: (PARENT_RIGHT - WIDTH) / 2
+					X: (PARENT_WIDTH - WIDTH) / 2
 					Y: 70
 					Width: 240
 					Height: 20
 					Indeterminate: true
 		Background@REGISTER_FINGERPRINT:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: dialog2
 			Children:
 				Label@DESC_A:
 					Y: 2
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-register-fingerprint-desc-a
 				Label@DESC_B:
 					Y: 18
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-register-fingerprint-desc-b
 				Label@DESC_C:
 					Y: 34
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
@@ -131,45 +131,45 @@ Container@LOCAL_PROFILE_PANEL:
 					Font: TinyBold
 					Text: button-continue
 		Background@CHECKING_FINGERPRINT:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: dialog2
 			Children:
 				Label@DESC_A:
 					Y: 13
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-checking-fingerprint-desc-a
 				Label@DESC_B:
 					Y: 29
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-checking-fingerprint-desc-b
 				ProgressBar:
-					X: (PARENT_RIGHT - WIDTH) / 2
+					X: (PARENT_WIDTH - WIDTH) / 2
 					Y: 70
 					Width: 240
 					Height: 20
 					Indeterminate: true
 		Background@FINGERPRINT_NOT_FOUND:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: dialog2
 			Children:
 				Label@DESC_A:
 					Y: 13
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-fingerprint-not-found-desc-a
 				Label@DESC_B:
 					Y: 29
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
@@ -182,20 +182,20 @@ Container@LOCAL_PROFILE_PANEL:
 					Font: TinyBold
 					Text: button-back
 		Background@CONNECTION_ERROR:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: dialog2
 			Children:
 				Label@DESC_A:
 					Y: 13
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
 					Text: label-connection-error-desc-a
 				Label@DESC_B:
 					Y: 29
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Font: Small
 					Align: Center
@@ -210,11 +210,11 @@ Container@LOCAL_PROFILE_PANEL:
 
 Container@PLAYER_PROFILE_BADGES_INSERT:
 	Logic: PlayerProfileBadgesLogic
-	Width: PARENT_RIGHT
+	Width: PARENT_WIDTH
 	Height: 110
 	Children:
 		Container@BADGE_TEMPLATE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Children:
 				Badge@ICON:
@@ -225,6 +225,6 @@ Container@PLAYER_PROFILE_BADGES_INSERT:
 				Label@LABEL:
 					X: 36
 					Y: 2
-					Width: PARENT_RIGHT - 60
+					Width: PARENT_WIDTH - 60
 					Height: 24
 					Font: Bold

--- a/mods/common/chrome/replaybrowser.yaml
+++ b/mods/common/chrome/replaybrowser.yaml
@@ -1,13 +1,13 @@
 Background@REPLAYBROWSER_PANEL:
 	Logic: ReplayBrowserLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 900
 	Height: 600
 	Children:
 		Label@TITLE:
 			Y: 16
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Text: label-replaybrowser-panel-title
 			Align: Center
@@ -16,7 +16,7 @@ Background@REPLAYBROWSER_PANEL:
 			X: 20
 			Y: 37
 			Width: 280
-			Height: PARENT_BOTTOM - 75
+			Height: PARENT_HEIGHT - 75
 			Children:
 				Container@FILTERS:
 					Width: 280
@@ -25,7 +25,7 @@ Background@REPLAYBROWSER_PANEL:
 						Label@FILTERS_TITLE:
 							X: 85
 							Y: 6
-							Width: PARENT_RIGHT - 85
+							Width: PARENT_WIDTH - 85
 							Height: 25
 							Font: Bold
 							Align: Center
@@ -40,7 +40,7 @@ Background@REPLAYBROWSER_PANEL:
 						DropDownButton@FLT_GAMETYPE_DROPDOWNBUTTON:
 							X: 85
 							Y: 30
-							Width: PARENT_RIGHT - 85
+							Width: PARENT_WIDTH - 85
 							Height: 25
 							Text: dropdownbutton-filters-any
 						Label@FLT_DATE_DESC:
@@ -53,7 +53,7 @@ Background@REPLAYBROWSER_PANEL:
 						DropDownButton@FLT_DATE_DROPDOWNBUTTON:
 							X: 85
 							Y: 60
-							Width: PARENT_RIGHT - 85
+							Width: PARENT_WIDTH - 85
 							Height: 25
 							Text: dropdownbutton-filters-any
 						Label@FLT_DURATION_DESC:
@@ -66,7 +66,7 @@ Background@REPLAYBROWSER_PANEL:
 						DropDownButton@FLT_DURATION_DROPDOWNBUTTON:
 							X: 85
 							Y: 90
-							Width: PARENT_RIGHT - 85
+							Width: PARENT_WIDTH - 85
 							Height: 25
 							Text: dropdownbutton-filters-any
 						Label@FLT_MAPNAME_DESC:
@@ -79,7 +79,7 @@ Background@REPLAYBROWSER_PANEL:
 						DropDownButton@FLT_MAPNAME_DROPDOWNBUTTON:
 							X: 85
 							Y: 120
-							Width: PARENT_RIGHT - 85
+							Width: PARENT_WIDTH - 85
 							Height: 25
 							Text: dropdownbutton-filters-any
 						Label@FLT_PLAYER_DESC:
@@ -92,7 +92,7 @@ Background@REPLAYBROWSER_PANEL:
 						DropDownButton@FLT_PLAYER_DROPDOWNBUTTON:
 							X: 85
 							Y: 150
-							Width: PARENT_RIGHT - 85
+							Width: PARENT_WIDTH - 85
 							Height: 25
 							Text: dropdownbutton-filters-flt-player
 						Label@FLT_OUTCOME_DESC:
@@ -105,7 +105,7 @@ Background@REPLAYBROWSER_PANEL:
 						DropDownButton@FLT_OUTCOME_DROPDOWNBUTTON:
 							X: 85
 							Y: 180
-							Width: PARENT_RIGHT - 85
+							Width: PARENT_WIDTH - 85
 							Height: 25
 							Text: dropdownbutton-filters-any
 						Label@FLT_FACTION_DESC:
@@ -118,45 +118,45 @@ Background@REPLAYBROWSER_PANEL:
 						DropDownButton@FLT_FACTION_DROPDOWNBUTTON:
 							X: 85
 							Y: 210
-							Width: PARENT_RIGHT - 85
+							Width: PARENT_WIDTH - 85
 							Height: 25
 							Text: dropdownbutton-filters-any
 						Button@FLT_RESET_BUTTON:
 							X: 85
 							Y: 250
-							Width: PARENT_RIGHT - 85
+							Width: PARENT_WIDTH - 85
 							Height: 25
 							Text: button-filters-flt-reset
 							Font: Bold
 				Container@MANAGEMENT:
 					X: 85
 					Y: 395
-					Width: PARENT_RIGHT - 85
+					Width: PARENT_WIDTH - 85
 					Children:
 						Label@MANAGE_TITLE:
 							Y: 1
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 25
 							Font: Bold
 							Align: Center
 							Text: label-management-manage-title
 						Button@MNG_RENSEL_BUTTON:
 							Y: 30
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 25
 							Text: button-management-mng-rensel
 							Font: Bold
 							Key: F2
 						Button@MNG_DELSEL_BUTTON:
 							Y: 60
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 25
 							Text: button-management-mng-delsel
 							Font: Bold
 							Key: Delete
 						Button@MNG_DELALL_BUTTON:
 							Y: 90
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 25
 							Text: button-management-mng-delall
 							Font: Bold
@@ -164,11 +164,11 @@ Background@REPLAYBROWSER_PANEL:
 			X: 311
 			Y: 37
 			Width: 384
-			Height: PARENT_BOTTOM - 37 - 55
+			Height: PARENT_HEIGHT - 37 - 55
 			Children:
 				Label@REPLAYBROWSER_LABEL_TITLE:
 					Y: 6
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Text: label-replay-list-container-replaybrowser-title
 					Align: Center
@@ -176,12 +176,12 @@ Background@REPLAYBROWSER_PANEL:
 				ScrollPanel@REPLAY_LIST:
 					X: 0
 					Y: 30
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM - 30
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT - 30
 					CollapseHiddenChildren: True
 					Children:
 						ScrollItem@REPLAY_TEMPLATE:
-							Width: PARENT_RIGHT - 27
+							Width: PARENT_WIDTH - 27
 							Height: 25
 							X: 2
 							Visible: false
@@ -189,36 +189,36 @@ Background@REPLAYBROWSER_PANEL:
 							Children:
 								LabelWithTooltip@TITLE:
 									X: 10
-									Width: PARENT_RIGHT - 20
+									Width: PARENT_WIDTH - 20
 									Height: 25
 									TooltipContainer: TOOLTIP_CONTAINER
 									TooltipTemplate: SIMPLE_TOOLTIP
 		Container@MAP_PREVIEW_ROOT:
-			X: PARENT_RIGHT - WIDTH - 20
+			X: PARENT_WIDTH - WIDTH - 20
 			Y: 67
 			Width: 174
 			Height: 250
 		Container@REPLAY_INFO:
-			X: PARENT_RIGHT - WIDTH - 20
+			X: PARENT_WIDTH - WIDTH - 20
 			Y: 267
 			Width: 174
-			Height: PARENT_BOTTOM - 267 - 45
+			Height: PARENT_HEIGHT - 267 - 45
 			Children:
 				Label@DURATION:
 					Y: 19
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 15
 					Font: Tiny
 					Align: Center
 				ScrollPanel@PLAYER_LIST:
 					Y: 40
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM - 50
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT - 50
 					IgnoreChildMouseOver: true
 					Children:
 						ScrollItem@HEADER:
 							Background: scrollheader
-							Width: PARENT_RIGHT - 27
+							Width: PARENT_WIDTH - 27
 							Height: 13
 							X: 2
 							Y: 0
@@ -226,11 +226,11 @@ Background@REPLAYBROWSER_PANEL:
 							Children:
 								Label@LABEL:
 									Font: TinyBold
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 13
 									Align: Center
 						ScrollItem@TEMPLATE:
-							Width: PARENT_RIGHT - 27
+							Width: PARENT_WIDTH - 27
 							Height: 25
 							X: 2
 							Y: 0
@@ -243,24 +243,24 @@ Background@REPLAYBROWSER_PANEL:
 									Height: 16
 								Label@LABEL:
 									X: 40
-									Width: PARENT_RIGHT - 50
+									Width: PARENT_WIDTH - 50
 									Height: 25
 									Shadow: True
 								Label@NOFLAG_LABEL:
 									X: 5
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 		Button@WATCH_BUTTON:
-			X: PARENT_RIGHT - 140 - 130
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 140 - 130
+			Y: PARENT_HEIGHT - 45
 			Width: 120
 			Height: 25
 			Text: button-replaybrowser-panel-watch
 			Font: Bold
 			Key: return
 		Button@CANCEL_BUTTON:
-			X: PARENT_RIGHT - 140
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 140
+			Y: PARENT_HEIGHT - 45
 			Width: 120
 			Height: 25
 			Text: button-back

--- a/mods/common/chrome/settings-advanced.yaml
+++ b/mods/common/chrome/settings-advanced.yaml
@@ -1,97 +1,97 @@
 Container@ADVANCED_PANEL:
 	Logic: AdvancedSettingsLogic
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		ScrollPanel@SETTINGS_SCROLLPANEL:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			CollapseHiddenChildren: True
 			TopBottomSpacing: 5
 			ItemSpacing: 10
 			Children:
 				Background@NETWORK_SECTION_HEADER:
 					X: 5
-					Width: PARENT_RIGHT - 24 - 10
+					Width: PARENT_WIDTH - 24 - 10
 					Height: 13
 					Background: separator
 					ClickThrough: True
 					Children:
 						Label@LABEL:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Font: TinyBold
 							Align: Center
 							Text: label-network-section-header
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@NAT_DISCOVERY_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@NAT_DISCOVERY:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-nat-discovery-container
 						Container@FETCH_NEWS_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@FETCH_NEWS_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-fetch-news-container
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@PERFGRAPH_CHECKBOX_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@PERFGRAPH_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-perfgraph-container
 						Container@CHECK_VERSION_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@CHECK_VERSION_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-check-version-container
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@PERFTEXT_CHECKBOX_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@PERFTEXT_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-perftext-container
 						Container@SENDSYSINFO_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@SENDSYSINFO_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-sendsysinfo-container
 								Label@SENDSYSINFO_DESC:
 									Y: 15
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 30
 									Font: Tiny
 									WordWrap: True
@@ -99,99 +99,99 @@ Container@ADVANCED_PANEL:
 				Container@SPACER:
 				Background@DEBUG_SECTION_HEADER:
 					X: 5
-					Width: PARENT_RIGHT - 24 - 10
+					Width: PARENT_WIDTH - 24 - 10
 					Height: 13
 					Background: separator
 					ClickThrough: True
 					Children:
 						Label@LABEL:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Font: TinyBold
 							Align: Center
 							Text: label-debug-section-header
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 40
 					Children:
 						Container@DEBUG_HIDDEN_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT - 10
+							Width: PARENT_WIDTH - 10
 							Children:
 								Label@A:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-debug-hidden-container-a
 									Align: Center
 								Label@B:
 									Y: 20
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-debug-hidden-container-b
 									Align: Center
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@BOTDEBUG_CHECKBOX_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@BOTDEBUG_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-botdebug-container
 						Container@CHECKBOTSYNC_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@CHECKBOTSYNC_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-checkbotsync-container
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@LUADEBUG_CHECKBOX_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@LUADEBUG_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-luadebug-container
 						Container@CHECKUNSYNCED_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@CHECKUNSYNCED_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-checkunsynced-container
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@REPLAY_COMMANDS_CHECKBOX_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@REPLAY_COMMANDS_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-replay-commands-container
 						Container@PERFLOGGING_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@PERFLOGGING_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-perflogging-container

--- a/mods/common/chrome/settings-audio.yaml
+++ b/mods/common/chrome/settings-audio.yaml
@@ -1,144 +1,144 @@
 Container@AUDIO_PANEL:
 	Logic: AudioSettingsLogic
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		ScrollPanel@SETTINGS_SCROLLPANEL:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			CollapseHiddenChildren: True
 			TopBottomSpacing: 5
 			ItemSpacing: 10
 			Children:
 				Background@AUDIO_SECTION_HEADER:
 					X: 5
-					Width: PARENT_RIGHT - 24 - 10
+					Width: PARENT_WIDTH - 24 - 10
 					Height: 13
 					Background: separator
 					ClickThrough: True
 					Children:
 						Label@LABEL:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Font: TinyBold
 							Align: Center
 							Text: label-audio-section-header
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@NO_AUDIO_DEVICE_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT - 10
+							Width: PARENT_WIDTH - 10
 							Children:
 								Label@NO_AUDIO_DEVICE:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Align: Center
 									Text: label-no-audio-device-container
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@CASH_TICKS_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@CASH_TICKS:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-cash-ticks-container
 						Container@MUTE_SOUND_CONTAINER:
 							X: 10
 							Y: 30
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@MUTE_SOUND:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-mute-sound-container
 						Container@SOUND_VOLUME_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@SOUND_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-sound-volume-container
 								ExponentialSlider@SOUND_VOLUME:
 									Y: 30
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Ticks: 7
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@MUTE_BACKGROUND_MUSIC_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@MUTE_BACKGROUND_MUSIC:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-mute-background-music-container.label
 									TooltipText: checkbox-mute-background-music-container.tooltip
 									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 						Container@MUSIC_VOLUME_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@MUSIC_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-music-title-volume-container
 								ExponentialSlider@MUSIC_VOLUME:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Ticks: 7
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@AUDIO_DEVICE_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@AUDIO_DEVICE_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-audio-device-container
 								DropDownButton@AUDIO_DEVICE:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 						Container@VIDEO_VOLUME_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@VIDEO_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-video-volume-container
 								ExponentialSlider@VIDEO_VOLUME:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Ticks: 7
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@RESTART_REQUIRED_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT - 10
+							Width: PARENT_WIDTH - 10
 							Children:
 								Label@AUDIO_RESTART_REQUIRED_DESC:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Tiny
 									Align: Center

--- a/mods/common/chrome/settings-display.yaml
+++ b/mods/common/chrome/settings-display.yaml
@@ -1,53 +1,53 @@
 Container@DISPLAY_PANEL:
 	Logic: DisplaySettingsLogic
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		ScrollPanel@SETTINGS_SCROLLPANEL:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			CollapseHiddenChildren: True
 			TopBottomSpacing: 5
 			ItemSpacing: 10
 			Children:
 				Background@PROFILE_SECTION_HEADER:
 					X: 5
-					Width: PARENT_RIGHT - 24 - 10
+					Width: PARENT_WIDTH - 24 - 10
 					Height: 13
 					Background: separator
 					ClickThrough: True
 					Children:
 						Label@LABEL:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Font: TinyBold
 							Align: Center
 							Text: label-profile-section-header
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@PLAYER_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								LabelForInput@PLAYER:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-player-container
 									For: PLAYERNAME
 								TextField@PLAYERNAME:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									MaxLength: 16
 									Text: Name
 						Container@PLAYERCOLOR_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								LabelForInput@COLOR:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-playercolor-container-color
 									For: PLAYERCOLOR
@@ -61,193 +61,193 @@ Container@DISPLAY_PANEL:
 										ColorBlock@COLORBLOCK:
 											X: 5
 											Y: 6
-											Width: PARENT_RIGHT - 35
-											Height: PARENT_BOTTOM - 12
+											Width: PARENT_WIDTH - 35
+											Height: PARENT_HEIGHT - 12
 				Container@SPACER:
 				Background@DISPLAY_SECTION_HEADER:
 					X: 5
-					Width: PARENT_RIGHT - 24 - 10
+					Width: PARENT_WIDTH - 24 - 10
 					Height: 13
 					Background: separator
 					ClickThrough: True
 					Children:
 						Label@LABEL:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Font: TinyBold
 							Align: Center
 							Text: label-display-section-header
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@BATTLEFIELD_CAMERA_DROPDOWN_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@BATTLEFIELD_CAMERA:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-battlefield-camera-dropdown
 								DropDownButton@BATTLEFIELD_CAMERA_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 						Container@TARGET_LINES_DROPDOWN_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@TARGET_LINES:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-target-lines-dropdown-container
 								DropDownButton@TARGET_LINES_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@UI_SCALE_DROPDOWN_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								LabelForInput@UI_SCALE:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-ui-scale-dropdown
 									For: UI_SCALE_DROPDOWN
 								DropDownButton@UI_SCALE_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 						Container@STATUS_BAR_DROPDOWN_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@STATUS_BARS:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-status-bar-dropdown-container-bars
 								DropDownButton@STATUS_BAR_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@CURSORDOUBLE_CHECKBOX_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@CURSORDOUBLE_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-cursordouble-container
 						Container@PLAYER_STANCE_COLORS_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@PLAYER_STANCE_COLORS_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-player-stance-colors-container.label
 									TooltipText: checkbox-player-stance-colors-container.tooltip
 									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@UI_FEEDBACK_CHECKBOX_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 10
+							Width: PARENT_WIDTH / 2 - 10
 							Children:
 								Checkbox@UI_FEEDBACK_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-ui-feedback-container.label
 									TooltipText: checkbox-ui-feedback-container.tooltip
 									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 						Container@TRANSIENTS_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@TRANSIENTS_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-transients-container.label
 									TooltipText: checkbox-transients-container.tooltip
 									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@PAUSE_SHELLMAP_CHECKBOX_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 10
+							Width: PARENT_WIDTH / 2 - 10
 							Children:
 								Checkbox@PAUSE_SHELLMAP_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-pause-shellmap-container
 						Container@HIDE_REPLAY_CHAT_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 10
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 10
 							Children:
 								Checkbox@HIDE_REPLAY_CHAT_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-hide-replay-chat-container
 				Container@SPACER:
 				Background@VIDEO_SECTION_HEADER:
 					X: 5
-					Width: PARENT_RIGHT - 24 - 10
+					Width: PARENT_WIDTH - 24 - 10
 					Height: 13
 					Background: separator
 					ClickThrough: True
 					Children:
 						Label@LABEL:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Font: TinyBold
 							Align: Center
 							Text: label-video-section-header
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@VIDEO_MODE_DROPDOWN_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@VIDEO_MODE:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-video-mode-dropdown-container
 								DropDownButton@MODE_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 									Text: dropdownbutton-video-mode-dropdown-container
 						Container@WINDOW_RESOLUTION_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@WINDOW_SIZE:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-window-resolution-container-size
 								TextField@WINDOW_WIDTH:
@@ -272,88 +272,88 @@ Container@DISPLAY_PANEL:
 									MaxLength: 5
 									Type: Integer
 						Container@DISPLAY_SELECTION_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@DISPLAY_SELECTION_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-display-selection-container
 								DropDownButton@DISPLAY_SELECTION_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 									Text: dropdownbutton-display-selection-container-dropdown
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@FRAME_LIMIT_CHECKBOX_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@FRAME_LIMIT_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 						Container@FRAME_LIMIT_SLIDER_CONTAINER:
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Slider@FRAME_LIMIT_SLIDER:
 									X: 20
 									Y: 25
-									Width: PARENT_RIGHT - 20
+									Width: PARENT_WIDTH - 20
 									Height: 20
 									Ticks: 20
 									MinimumValue: 50
 									MaximumValue: 240
 						Container@VSYNC_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@VSYNC_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-vsync-container
 						Container@FRAME_LIMIT_GAMESPEED_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
+							X: PARENT_WIDTH / 2 + 10
 							Y: 25
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@FRAME_LIMIT_GAMESPEED_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-frame-limit-gamespeed-container
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@GL_PROFILE_DROPDOWN_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@GL_PROFILE:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-gl-profile-dropdown-container
 								DropDownButton@GL_PROFILE_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 30
 					Children:
 						Container@RESTART_REQUIRED_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT - 20
+							Width: PARENT_WIDTH - 20
 							Children:
 								Label@VIDEO_RESTART_REQUIRED_DESC:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Tiny
 									Text: label-restart-required-container-video-desc

--- a/mods/common/chrome/settings-hotkeys.yaml
+++ b/mods/common/chrome/settings-hotkeys.yaml
@@ -23,8 +23,8 @@ Container@HOTKEYS_PANEL:
 				Types: ControlGroups
 			Editor Commands:
 				Types: Editor
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		Label@FILTER_INPUT_LABEL:
 			Width: 103
@@ -36,72 +36,72 @@ Container@HOTKEYS_PANEL:
 			Width: 180
 			Height: 25
 		Label@CONTEXT_DROPDOWN_LABEL:
-			X: PARENT_RIGHT - WIDTH - 195 - 5
+			X: PARENT_WIDTH - WIDTH - 195 - 5
 			Width: 100
 			Height: 25
 			Font: Bold
 			Text: label-hotkeys-panel-context-dropdown
 			Align: Right
 		DropDownButton@CONTEXT_DROPDOWN:
-			X: PARENT_RIGHT - WIDTH
+			X: PARENT_WIDTH - WIDTH
 			Width: 195
 			Height: 25
 			Font: Bold
 		ScrollPanel@HOTKEY_LIST:
 			Y: 35
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM - 65 - 35
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT - 65 - 35
 			TopBottomSpacing: 5
 			ItemSpacing: 5
 			Children:
 				Container@HEADER:
-					Width: PARENT_RIGHT - 24 - 10
+					Width: PARENT_WIDTH - 24 - 10
 					Height: 18
 					Children:
 						Background@BACKGROUND:
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 13
 							Background: separator
 							ClickThrough: True
 						Label@LABEL:
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 13
 							Font: TinyBold
 							Align: Center
 				Container@TEMPLATE:
-					Width: (PARENT_RIGHT - 24) / 2 - 10
+					Width: (PARENT_WIDTH - 24) / 2 - 10
 					Height: 30
 					Visible: false
 					Children:
 						Label@FUNCTION:
 							Y: 0 - 1
-							Width: PARENT_RIGHT - 120 - 5
+							Width: PARENT_WIDTH - 120 - 5
 							Height: 25
 							Align: Right
 						Button@HOTKEY:
-							X: PARENT_RIGHT - WIDTH
+							X: PARENT_WIDTH - WIDTH
 							Width: 120
 							Height: 25
 							TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 		Container@HOTKEY_EMPTY_LIST:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Visible: false
 			Children:
 				Label@HOTKEY_EMPTY_LIST_MESSAGE:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Align: Center
 					Text: label-hotkey-empty-list-message
 		Background@HOTKEY_REMAP_BGND:
-			Y: PARENT_BOTTOM - HEIGHT
-			Width: PARENT_RIGHT
+			Y: PARENT_HEIGHT - HEIGHT
+			Width: PARENT_WIDTH
 			Height: 65
 			Background: dialog3
 			Children:
 				Container@HOTKEY_REMAP_DIALOG:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						Label@HOTKEY_LABEL:
 							X: 15
@@ -122,27 +122,27 @@ Container@HOTKEYS_PANEL:
 							Height: 25
 							Children:
 								Label@ORIGINAL_NOTICE:
-									Width: PARENT_RIGHT
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
 									Font: Tiny
 								Label@DUPLICATE_NOTICE:
-									Width: PARENT_RIGHT
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
 									Font: Tiny
 								Label@READONLY_NOTICE:
-									Width: PARENT_RIGHT
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
 									Font: Tiny
 									Text: label-notices-readonly-notice
 						Button@OVERRIDE_HOTKEY_BUTTON:
-							X: PARENT_RIGHT - 3 * WIDTH - 30
+							X: PARENT_WIDTH - 3 * WIDTH - 30
 							Y: 20
 							Width: 70
 							Height: 25
 							Text: button-hotkey-remap-dialog-override
 							Font: Bold
 						Button@CLEAR_HOTKEY_BUTTON:
-							X: PARENT_RIGHT - 2 * WIDTH - 30
+							X: PARENT_WIDTH - 2 * WIDTH - 30
 							Y: 20
 							Width: 65
 							Height: 25
@@ -152,7 +152,7 @@ Container@HOTKEYS_PANEL:
 							TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 						Button@RESET_HOTKEY_BUTTON:
-							X: PARENT_RIGHT - WIDTH - 20
+							X: PARENT_WIDTH - WIDTH - 20
 							Y: 20
 							Width: 65
 							Height: 25

--- a/mods/common/chrome/settings-input.yaml
+++ b/mods/common/chrome/settings-input.yaml
@@ -1,286 +1,286 @@
 Container@INPUT_PANEL:
 	Logic: InputSettingsLogic
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		ScrollPanel@SETTINGS_SCROLLPANEL:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			CollapseHiddenChildren: True
 			TopBottomSpacing: 5
 			ItemSpacing: 10
 			Children:
 				Background@INPUT_SECTION_HEADER:
 					X: 5
-					Width: PARENT_RIGHT - 24 - 10
+					Width: PARENT_WIDTH - 24 - 10
 					Height: 13
 					Background: separator
 					ClickThrough: True
 					Children:
 						Label@LABEL:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Font: TinyBold
 							Align: Center
 							Text: label-input-section-header
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@MOUSE_CONTROL_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@MOUSE_CONTROL_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: label-mouse-control-container
 								DropDownButton@MOUSE_CONTROL_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 						Container@ZOOM_MODIFIER_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@ZOOM_MODIFIER_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: label-zoom-modifier-container
 								DropDownButton@ZOOM_MODIFIER:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 						Container@MOUSE_CONTROL_DESC_CLASSIC:
 							X: 10
 							Y: 55
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Children:
 								LabelWithHighlight@DESC_SELECTION:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-selection
 								LabelWithHighlight@DESC_COMMANDS:
 									Y: 17
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-commands
 								LabelWithHighlight@DESC_BUILDINGS:
 									Y: 34
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-buildings
 								LabelWithHighlight@DESC_SUPPORT:
 									Y: 51
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-support
 								LabelWithHighlight@DESC_ZOOM:
 									Y: 68
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-zoom
 								LabelWithHighlight@DESC_ZOOM_MODIFIER:
 									Y: 68
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-zoom-modifier
 								LabelWithHighlight@DESC_SCROLL_RIGHT:
 									Y: 85
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-scroll-right
 								LabelWithHighlight@DESC_SCROLL_MIDDLE:
 									Y: 85
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-scroll-middle
 								Label@DESC_EDGESCROLL:
 									X: 9
 									Y: 102
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-classic-edgescroll
 						Container@MOUSE_CONTROL_DESC_MODERN:
 							X: 10
 							Y: 55
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								LabelWithHighlight@DESC_SELECTION:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-selection
 								LabelWithHighlight@DESC_COMMANDS:
 									Y: 17
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-commands
 								LabelWithHighlight@DESC_BUILDINGS:
 									Y: 34
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-buildings
 								LabelWithHighlight@DESC_SUPPORT:
 									Y: 51
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-support
 								LabelWithHighlight@DESC_ZOOM:
 									Y: 68
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-zoom
 								LabelWithHighlight@DESC_ZOOM_MODIFIER:
 									Y: 68
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-zoom-modifier
 								LabelWithHighlight@DESC_SCROLL_RIGHT:
 									Y: 85
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-scroll-right
 								LabelWithHighlight@DESC_SCROLL_MIDDLE:
 									Y: 85
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-scroll-middle
 								Label@DESC_EDGESCROLL:
 									X: 9
 									Y: 102
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 16
 									Font: Small
 									Text: label-mouse-control-desc-modern-edgescroll
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@EDGESCROLL_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@EDGESCROLL_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-edgescroll-container
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@ALTERNATE_SCROLL_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@ALTERNATE_SCROLL_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-alternate-scroll-container
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@LOCKMOUSE_CHECKBOX_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Checkbox@LOCKMOUSE_CHECKBOX:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: checkbox-lockmouse-container
 				Container@SPACER:
 					Height: 30
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@MOUSE_SCROLL_TYPE_CONTAINER:
 							X: 10
-							Width: PARENT_RIGHT / 2 - 20
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@MOUSE_SCROLL_TYPE_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
 									Text: label-mouse-scroll-type-container
 								DropDownButton@MOUSE_SCROLL_TYPE_DROPDOWN:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 25
 									Font: Regular
 						Container@SCROLLSPEED_SLIDER_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@SCROLL_SPEED_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-scrollspeed-slider-container-scroll-speed
 								Slider@SCROLLSPEED_SLIDER:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Ticks: 7
 									MinimumValue: 10
 									MaximumValue: 50
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@ZOOMSPEED_SLIDER_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@ZOOM_SPEED_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-zoomspeed-slider-container-zoom-speed
 								ExponentialSlider@ZOOMSPEED_SLIDER:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Ticks: 7
 									MinimumValue: 0.01
 									MaximumValue: 0.4
 				Container@ROW:
-					Width: PARENT_RIGHT - 24
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@UI_SCROLLSPEED_SLIDER_CONTAINER:
-							X: PARENT_RIGHT / 2 + 10
-							Width: PARENT_RIGHT / 2 - 20
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
 							Children:
 								Label@UI_SCROLL_SPEED_LABEL:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Text: label-ui-scrollspeed-slider-container-scroll-speed
 								Slider@UI_SCROLLSPEED_SLIDER:
 									Y: 25
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 20
 									Ticks: 7
 									MinimumValue: 1

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -7,29 +7,29 @@ Background@SETTINGS_PANEL:
 			INPUT_PANEL: Input
 			HOTKEYS_PANEL: Hotkeys
 			ADVANCED_PANEL: Advanced
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM -  HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT -  HEIGHT) / 2
 	Width: 900
 	Height: 600
 	Children:
 		Label@SETTINGS_LABEL_TITLE:
 			Y: 20
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Text: button-settings-title
 			Align: Center
 			Font: Bold
 		Button@RESET_BUTTON:
 			X: 20 + 10 + WIDTH
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-settings-panel-reset
 			Font: Bold
 		Button@BACK_BUTTON:
 			Key: escape
-			X: PARENT_RIGHT - 180
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 180
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-back
@@ -37,7 +37,7 @@ Background@SETTINGS_PANEL:
 		Container@SETTINGS_TAB_CONTAINER:
 			X: 20
 			Y: 50
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Children:
 				Button@BUTTON_TEMPLATE:
@@ -45,12 +45,12 @@ Background@SETTINGS_PANEL:
 					Height: 25
 					Font: Bold
 		Container@PANEL_CONTAINER:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Container@PANEL_TEMPLATE:
 					X: 190
 					Y: 50
-					Width: PARENT_RIGHT - 190 - 20
-					Height: PARENT_BOTTOM - 105
+					Width: PARENT_WIDTH - 190 - 20
+					Height: PARENT_HEIGHT - 105
 		TooltipContainer@SETTINGS_TOOLTIP_CONTAINER:

--- a/mods/common/chrome/text-notifications.yaml
+++ b/mods/common/chrome/text-notifications.yaml
@@ -1,5 +1,5 @@
 Container@CHAT_LINE_TEMPLATE:
-	Width: PARENT_RIGHT
+	Width: PARENT_WIDTH
 	Height: 16
 	Children:
 		Label@TIME:
@@ -18,7 +18,7 @@ Container@CHAT_LINE_TEMPLATE:
 			Shadow: True
 
 Container@SYSTEM_LINE_TEMPLATE:
-	Width: PARENT_RIGHT
+	Width: PARENT_WIDTH
 	Height: 16
 	Children:
 		Label@TIME:
@@ -39,7 +39,7 @@ Container@SYSTEM_LINE_TEMPLATE:
 			TextColor: FFFF00
 
 Container@TRANSIENT_LINE_TEMPLATE:
-	Width: PARENT_RIGHT
+	Width: PARENT_WIDTH
 	Height: 16
 	Children:
 		Label@TIME:

--- a/mods/common/chrome/tooltips.yaml
+++ b/mods/common/chrome/tooltips.yaml
@@ -195,7 +195,7 @@ Background@REGISTERED_PLAYER_TOOLTIP:
 	Background: dialog4
 	Children:
 		Container@HEADER:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Children:
 				Container@PROFILE_HEADER:
 					Height: 43
@@ -203,19 +203,19 @@ Background@REGISTERED_PLAYER_TOOLTIP:
 						Label@PROFILE_NAME:
 							X: 7
 							Y: 2
-							Width: PARENT_RIGHT - 20
+							Width: PARENT_WIDTH - 20
 							Height: 24
 							Font: MediumBold
 						Label@PROFILE_RANK:
 							X: 7
 							Y: 24
-							Width: PARENT_RIGHT - 20
+							Width: PARENT_WIDTH - 20
 							Height: 12
 							Font: TinyBold
 						Container@GAME_ADMIN:
 							X: 7
 							Y: 36
-							Width: PARENT_RIGHT - 20
+							Width: PARENT_WIDTH - 20
 							Height: 12
 							Visible: False
 							Children:
@@ -234,15 +234,15 @@ Background@REGISTERED_PLAYER_TOOLTIP:
 									Font: TinyBold
 				Container@MESSAGE_HEADER:
 					Height: 26
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Children:
 						Label@MESSAGE:
 							X: 7
-							Width: PARENT_RIGHT - 14
+							Width: PARENT_WIDTH - 14
 							Height: 23
 							Font: Bold
 		Container@BADGES_CONTAINER:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Visible: false
 			Children:
 				Background@SEPARATOR:

--- a/mods/d2k/chrome/dropdowns.yaml
+++ b/mods/d2k/chrome/dropdowns.yaml
@@ -3,7 +3,7 @@ ScrollPanel@LABEL_DROPDOWN_TEMPLATE:
 	Children:
 		ScrollItem@HEADER:
 			Background: scrollheader
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 13
 			X: 2
 			Y: 0
@@ -11,11 +11,11 @@ ScrollPanel@LABEL_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					Font: TinyBold
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 13
 					Align: Center
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -23,14 +23,14 @@ ScrollPanel@LABEL_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					X: 10
-					Width: PARENT_RIGHT - 20
+					Width: PARENT_WIDTH - 20
 					Height: 25
 
 ScrollPanel@PLAYERACTION_DROPDOWN_TEMPLATE:
 	Width: DROPDOWN_WIDTH
 	Children:
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -38,7 +38,7 @@ ScrollPanel@PLAYERACTION_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					X: 10
-					Width: PARENT_RIGHT - 20
+					Width: PARENT_WIDTH - 20
 					Height: 25
 					Align: Left
 
@@ -46,7 +46,7 @@ ScrollPanel@TEAM_DROPDOWN_TEMPLATE:
 	Width: DROPDOWN_WIDTH
 	Children:
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -54,7 +54,7 @@ ScrollPanel@TEAM_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					X: 0
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 
@@ -62,7 +62,7 @@ ScrollPanel@SPAWN_DROPDOWN_TEMPLATE:
 	Width: DROPDOWN_WIDTH
 	Children:
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -70,7 +70,7 @@ ScrollPanel@SPAWN_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					X: 0
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 
@@ -79,7 +79,7 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 	Children:
 		ScrollItem@HEADER:
 			Background: scrollheader
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 13
 			X: 2
 			Y: 0
@@ -87,11 +87,11 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					Font: TinyBold
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 10
 					Align: Center
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -104,12 +104,12 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 					Y: 2
 				Label@LABEL:
 					X: 34
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Shadow: True
 				Label@NOFLAG_LABEL:
 					X: 5
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Shadow: True
 
@@ -122,27 +122,27 @@ ScrollPanel@NEWS_PANEL:
 		Container@NEWS_ITEM_TEMPLATE:
 			X: 10
 			Y: 5
-			Width: PARENT_RIGHT - 40
+			Width: PARENT_WIDTH - 40
 			Height: 45
 			Children:
 				Label@TITLE:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 					Font: Bold
 				Label@AUTHOR_DATETIME:
 					Y: 25
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 15
 					Align: Center
 					Font: TinyBold
 				Label@CONTENT:
 					Y: 45
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 		Label@NEWS_STATUS:
 			X: 80
 			Y: 0
-			Width: PARENT_RIGHT - 80 - 80 - 24
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH - 80 - 80 - 24
+			Height: PARENT_HEIGHT
 			Align: Center
 			VAlign: Middle

--- a/mods/d2k/chrome/encyclopedia.yaml
+++ b/mods/d2k/chrome/encyclopedia.yaml
@@ -1,18 +1,18 @@
 Background@ENCYCLOPEDIA_PANEL:
 	Logic: EncyclopediaLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 900
 	Height: 600
 	Children:
 		Container@ENCYCLOPEDIA_CONTENT:
-			Width: PARENT_RIGHT - 40
-			Height: PARENT_BOTTOM - 80
+			Width: PARENT_WIDTH - 40
+			Height: PARENT_HEIGHT - 80
 			X: 20
 			Y: 20
 			Children:
 				Label@ENCYCLOPEDIA_TITLE:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Text: label-mentat-title
 					Align: Center
@@ -20,37 +20,37 @@ Background@ENCYCLOPEDIA_PANEL:
 				ScrollPanel@ACTOR_LIST:
 					Y: 30
 					Width: 190
-					Height: PARENT_BOTTOM - 25
+					Height: PARENT_HEIGHT - 25
 					Children:
 						ScrollItem@HEADER:
 							Background: scrollheader
-							Width: PARENT_RIGHT - 27
+							Width: PARENT_WIDTH - 27
 							Height: 13
 							X: 2
 							Visible: false
 							Children:
 								Label@LABEL:
 									Font: TinyBold
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 13
 									Align: Center
 						ScrollItem@TEMPLATE:
-							Width: PARENT_RIGHT - 27
+							Width: PARENT_WIDTH - 27
 							Height: 25
 							X: 2
 							EnableChildMouseOver: True
 							Children:
 								LabelWithTooltip@TITLE:
 									X: 10
-									Width: PARENT_RIGHT - 20
+									Width: PARENT_WIDTH - 20
 									Height: 25
 									TooltipContainer: TOOLTIP_CONTAINER
 									TooltipTemplate: SIMPLE_TOOLTIP
 				Container@ACTOR_INFO:
-					X: PARENT_RIGHT - WIDTH
+					X: PARENT_WIDTH - WIDTH
 					Y: 30
-					Width: PARENT_RIGHT - 190 - 10
-					Height: PARENT_BOTTOM - 25
+					Width: PARENT_WIDTH - 190 - 10
+					Height: PARENT_HEIGHT - 25
 					Children:
 						Background@ACTOR_BG:
 							Width: 150
@@ -60,23 +60,23 @@ Background@ENCYCLOPEDIA_PANEL:
 								ActorPreview@ACTOR_PREVIEW:
 									X: 1
 									Y: 1
-									Width: PARENT_RIGHT - 2
-									Height: PARENT_BOTTOM - 2
+									Width: PARENT_WIDTH - 2
+									Height: PARENT_HEIGHT - 2
 						ScrollPanel@ACTOR_DESCRIPTION_PANEL:
 							X: 150 + 10
-							Width: PARENT_RIGHT - 150 - 10
+							Width: PARENT_WIDTH - 150 - 10
 							Height: 170
 							TopBottomSpacing: 8
 							Children:
 								Label@ACTOR_DESCRIPTION:
 									X: 8
 									Y: 8
-									Width: PARENT_RIGHT - 40
+									Width: PARENT_WIDTH - 40
 									VAlign: Top
 									Font: Regular
 		Button@BACK_BUTTON:
-			X: PARENT_RIGHT - 180
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 180
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Text: button-back

--- a/mods/d2k/chrome/ingame-infostats.yaml
+++ b/mods/d2k/chrome/ingame-infostats.yaml
@@ -1,6 +1,6 @@
 Container@SKIRMISH_STATS:
-	Height: PARENT_BOTTOM
-	Width: PARENT_RIGHT
+	Height: PARENT_HEIGHT
+	Width: PARENT_WIDTH
 	Logic: GameInfoStatsLogic
 	Children:
 		Container@OBJECTIVE:
@@ -16,7 +16,7 @@ Container@SKIRMISH_STATS:
 				Label@STATS_STATUS:
 					X: 100
 					Y: 22
-					Width: PARENT_RIGHT - 10
+					Width: PARENT_WIDTH - 10
 					Height: 25
 					Font: MediumBold
 				Checkbox@STATS_CHECKBOX:
@@ -31,7 +31,7 @@ Container@SKIRMISH_STATS:
 		Container@STATS_HEADERS:
 			X: 22
 			Y: 81
-			Width: PARENT_RIGHT - 44
+			Width: PARENT_WIDTH - 44
 			Children:
 				Label@NAME:
 					X: 10
@@ -64,13 +64,13 @@ Container@SKIRMISH_STATS:
 		ScrollPanel@PLAYER_LIST:
 			X: 20
 			Y: 105
-			Width: PARENT_RIGHT - 40
+			Width: PARENT_WIDTH - 40
 			Height: 265
 			ItemSpacing: 5
 			Children:
 				ScrollItem@TEAM_TEMPLATE:
 					Background: scrollheader
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 20
 					X: 2
 					Visible: false
@@ -86,7 +86,7 @@ Container@SKIRMISH_STATS:
 							Height: 20
 							Font: Bold
 				Container@PLAYER_TEMPLATE:
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 25
 					X: 2
 					Children:
@@ -145,7 +145,7 @@ Container@SKIRMISH_STATS:
 									X: 7
 									Y: 7
 				Container@SPECTATOR_TEMPLATE:
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 25
 					X: 2
 					Children:

--- a/mods/d2k/chrome/ingame-menu.yaml
+++ b/mods/d2k/chrome/ingame-menu.yaml
@@ -1,26 +1,26 @@
 Container@INGAME_MENU:
-	Width: WINDOW_RIGHT
-	Height: WINDOW_BOTTOM
+	Width: WINDOW_WIDTH
+	Height: WINDOW_HEIGHT
 	Logic: IngameMenuLogic
 		Buttons: RESUME, LOAD_GAME, SAVE_GAME, SETTINGS, MUSIC, SURRENDER, RESTART, BACK_TO_EDITOR, ABORT_MISSION, SAVE_MAP, PLAY_MAP, EXIT_EDITOR
 		ButtonStride: 0, 40
 	Children:
 		Label@VERSION_LABEL:
 			Logic: VersionLabelLogic
-			X: WINDOW_RIGHT - 10
-			Y: WINDOW_BOTTOM - 19
+			X: WINDOW_WIDTH - 10
+			Y: WINDOW_HEIGHT - 19
 			Align: Right
 			Font: Regular
 			Contrast: True
 		Container@PANEL_ROOT:
 		Background@MENU_BUTTONS:
-			X: 13 + (WINDOW_RIGHT - 522) / 4 - WIDTH / 2
-			Y: (WINDOW_BOTTOM - HEIGHT) / 2
+			X: 13 + (WINDOW_WIDTH - 522) / 4 - WIDTH / 2
+			Y: (WINDOW_HEIGHT - HEIGHT) / 2
 			Width: 200
 			Height: 120
 			Children:
 				Label@LABEL_TITLE:
-					X: (PARENT_RIGHT - WIDTH) / 2
+					X: (PARENT_WIDTH - WIDTH) / 2
 					Y: 21
 					Width: 200
 					Height: 30
@@ -28,7 +28,7 @@ Container@INGAME_MENU:
 					Align: Center
 					Font: Bold
 				Button@BUTTON_TEMPLATE:
-					X: (PARENT_RIGHT - WIDTH) / 2
+					X: (PARENT_WIDTH - WIDTH) / 2
 					Y: 60
 					Width: 140
 					Height: 30

--- a/mods/d2k/chrome/ingame-observer.yaml
+++ b/mods/d2k/chrome/ingame-observer.yaml
@@ -5,20 +5,20 @@ Container@OBSERVER_WIDGETS:
 		LogicKeyListener@OBSERVER_KEY_LISTENER:
 		Container@MUTE_INDICATOR:
 			Logic: MuteIndicatorLogic
-			X: WINDOW_RIGHT - WIDTH - 260
+			X: WINDOW_WIDTH - WIDTH - 260
 			Y: 5
 			Width: 200
 			Height: 25
 			Children:
 				Image@ICON:
-					X: PARENT_RIGHT - WIDTH
+					X: PARENT_WIDTH - WIDTH
 					Y: 1
 					Width: 24
 					Height: 24
 					ImageCollection: sidebar-bits
 					ImageName: indicator-muted
 				Label@LABEL:
-					Width: PARENT_RIGHT - 30
+					Width: PARENT_WIDTH - 30
 					Height: 25
 					Align: Right
 					Text: label-mute-indicator
@@ -34,12 +34,12 @@ Container@OBSERVER_WIDGETS:
 			DisableWorldSounds: true
 		Container@GAME_TIMER_BLOCK:
 			Logic: GameTimerLogic
-			X: (WINDOW_RIGHT - WIDTH) / 2
+			X: (WINDOW_WIDTH - WIDTH) / 2
 			Width: 100
 			Height: 55
 			Children:
 				LabelWithTooltip@GAME_TIMER:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 30
 					Align: Center
 					Font: Title
@@ -48,13 +48,13 @@ Container@OBSERVER_WIDGETS:
 					TooltipTemplate: SIMPLE_TOOLTIP
 				Label@GAME_TIMER_STATUS:
 					Y: 32
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 15
 					Align: Center
 					Font: Bold
 					Contrast: true
 		Background@RADAR_BG:
-			X: WINDOW_RIGHT - 255
+			X: WINDOW_WIDTH - 255
 			Y: 5
 			Width: 250
 			Height: 250
@@ -62,17 +62,17 @@ Container@OBSERVER_WIDGETS:
 				Radar@INGAME_RADAR:
 					X: 10
 					Y: 10
-					Width: PARENT_RIGHT - 19
-					Height: PARENT_BOTTOM - 19
+					Width: PARENT_WIDTH - 19
+					Height: PARENT_HEIGHT - 19
 					WorldInteractionController: INTERACTION_CONTROLLER
 				VideoPlayer@PLAYER:
 					X: 10
 					Y: 10
-					Width: PARENT_RIGHT - 20
-					Height: PARENT_BOTTOM - 20
+					Width: PARENT_WIDTH - 20
+					Height: PARENT_HEIGHT - 20
 					Skippable: false
 		Background@OBSERVER_CONTROL_BG:
-			X: WINDOW_RIGHT - 255
+			X: WINDOW_WIDTH - 255
 			Y: 260
 			Width: 250
 			Height: 55
@@ -95,12 +95,12 @@ Container@OBSERVER_WIDGETS:
 							Y: 2
 						Label@LABEL:
 							X: 34
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 25
 							Shadow: True
 						Label@NOFLAG_LABEL:
 							X: 5
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 25
 							Shadow: True
 				Container@REPLAY_PLAYER:
@@ -207,33 +207,33 @@ Container@OBSERVER_WIDGETS:
 				Container@GRAPH_BG:
 					Y: 30
 					X: 0
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Children:
 						Container@BASIC_STATS_HEADERS:
 							X: 0
 							Y: 0
 							Width: 700
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 35
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-player-header
 									Align: Left
@@ -242,7 +242,7 @@ Container@OBSERVER_WIDGETS:
 									X: 155
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-cash-header
 									Align: Right
@@ -251,7 +251,7 @@ Container@OBSERVER_WIDGETS:
 									X: 235
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-power-header
 									Align: Center
@@ -260,7 +260,7 @@ Container@OBSERVER_WIDGETS:
 									X: 315
 									Y: 0
 									Width: 40
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-kills-header
 									Align: Right
@@ -269,7 +269,7 @@ Container@OBSERVER_WIDGETS:
 									X: 355
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-deaths-header
 									Align: Right
@@ -278,7 +278,7 @@ Container@OBSERVER_WIDGETS:
 									X: 415
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-assets-destroyed-header
 									Align: Right
@@ -287,7 +287,7 @@ Container@OBSERVER_WIDGETS:
 									X: 495
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-assets-lost-header
 									Align: Right
@@ -296,7 +296,7 @@ Container@OBSERVER_WIDGETS:
 									X: 575
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-experience-header
 									Align: Right
@@ -305,7 +305,7 @@ Container@OBSERVER_WIDGETS:
 									X: 635
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-actions-min-header
 									Align: Right
@@ -314,32 +314,32 @@ Container@OBSERVER_WIDGETS:
 							X: 0
 							Y: 0
 							Width: 720
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 35
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-player-header
 									Shadow: True
 								Label@CASH_HEADER:
 									X: 155
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-cash-header
 									Align: Right
@@ -347,7 +347,7 @@ Container@OBSERVER_WIDGETS:
 								Label@INCOME_HEADER:
 									X: 235
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-income-header
 									Align: Right
@@ -355,7 +355,7 @@ Container@OBSERVER_WIDGETS:
 								Label@ASSETS_HEADER:
 									X: 315
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-assets-header
 									Align: Right
@@ -363,7 +363,7 @@ Container@OBSERVER_WIDGETS:
 								Label@EARNED_HEADER:
 									X: 395
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-earned-header
 									Align: Right
@@ -371,7 +371,7 @@ Container@OBSERVER_WIDGETS:
 								Label@SPENT_HEADER:
 									X: 475
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-spent-header
 									Align: Right
@@ -379,7 +379,7 @@ Container@OBSERVER_WIDGETS:
 								Label@HARVESTERS_HEADER:
 									X: 555
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-harvesters-header
 									Align: Right
@@ -387,7 +387,7 @@ Container@OBSERVER_WIDGETS:
 								Label@CARRYALLS_HEADER:
 									X: 635
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-carryalls-header
 									Align: Right
@@ -396,26 +396,26 @@ Container@OBSERVER_WIDGETS:
 							X: 0
 							Y: 0
 							Width: 400
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 35
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-production-stats-player-header
 									Align: Left
@@ -424,7 +424,7 @@ Container@OBSERVER_WIDGETS:
 									X: 155
 									Y: 0
 									Width: 100
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-production-stats-header
 									Shadow: True
@@ -432,26 +432,26 @@ Container@OBSERVER_WIDGETS:
 							X: 0
 							Y: 0
 							Width: 400
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 35
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-support-powers-player-header
 									Align: Left
@@ -460,7 +460,7 @@ Container@OBSERVER_WIDGETS:
 									X: 155
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-support-powers-header
 									Shadow: True
@@ -468,26 +468,26 @@ Container@OBSERVER_WIDGETS:
 							X: 0
 							Y: 0
 							Width: 400
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 35
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-army-player-header
 									Align: Left
@@ -496,7 +496,7 @@ Container@OBSERVER_WIDGETS:
 									X: 155
 									Y: 0
 									Width: 100
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-army-header
 									Shadow: True
@@ -504,26 +504,26 @@ Container@OBSERVER_WIDGETS:
 							X: 0
 							Y: 0
 							Width: 755
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 35
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-player-header
 									Align: Left
@@ -532,7 +532,7 @@ Container@OBSERVER_WIDGETS:
 									X: 155
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-assets-destroyed-header
 									Align: Right
@@ -541,7 +541,7 @@ Container@OBSERVER_WIDGETS:
 									X: 230
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-assets-lost-header
 									Align: Right
@@ -550,7 +550,7 @@ Container@OBSERVER_WIDGETS:
 									X: 305
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-units-killed-header
 									Align: Right
@@ -559,7 +559,7 @@ Container@OBSERVER_WIDGETS:
 									X: 380
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-units-dead-header
 									Align: Right
@@ -568,7 +568,7 @@ Container@OBSERVER_WIDGETS:
 									X: 455
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-buildings-killed-header
 									Align: Right
@@ -577,7 +577,7 @@ Container@OBSERVER_WIDGETS:
 									X: 530
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-buildings-dead-header
 									Align: Right
@@ -586,7 +586,7 @@ Container@OBSERVER_WIDGETS:
 									X: 605
 									Y: 0
 									Width: 90
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-army-value-header
 									Align: Right
@@ -595,7 +595,7 @@ Container@OBSERVER_WIDGETS:
 									X: 695
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-vision-header
 									Align: Right
@@ -603,7 +603,7 @@ Container@OBSERVER_WIDGETS:
 				ScrollPanel@PLAYER_STATS_PANEL:
 					X: 0
 					Y: 55
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 250
 					TopBottomSpacing: 0
 					BorderWidth: 0
@@ -614,27 +614,27 @@ Container@OBSERVER_WIDGETS:
 						ScrollItem@TEAM_TEMPLATE:
 							X: 0
 							Y: 0
-							Width: 650 #PARENT_RIGHT - 35
+							Width: 650 #PARENT_WIDTH - 35
 							Height: 25
 							Children:
 								ColorBlock@TEAM_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@TEAM_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@TEAM:
 									X: 10
 									Y: 0
-									Width: PARENT_RIGHT
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 						ScrollItem@BASIC_PLAYER_TEMPLATE:
@@ -647,13 +647,13 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 2
 									Y: 2
@@ -663,63 +663,63 @@ Container@OBSERVER_WIDGETS:
 									X: 35
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								Label@CASH:
 									X: 155
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@POWER:
 									X: 235
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Center
 									Shadow: True
 								Label@KILLS:
 									X: 315
 									Y: 0
 									Width: 40
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@DEATHS:
 									X: 355
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ASSETS_DESTROYED:
 									X: 415
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ASSETS_LOST:
 									X: 495
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@EXPERIENCE:
 									X: 575
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ACTIONS_MIN:
 									X: 635
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 						ScrollItem@ECONOMY_PLAYER_TEMPLATE:
@@ -732,13 +732,13 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 2
 									Y: 2
@@ -748,56 +748,56 @@ Container@OBSERVER_WIDGETS:
 									X: 35
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								Label@CASH:
 									X: 155
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@INCOME:
 									X: 235
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ASSETS:
 									X: 315
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@EARNED:
 									X: 395
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@SPENT:
 									X: 475
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@HARVESTERS:
 									X: 555
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@CARRYALLS:
 									X: 635
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 						ScrollItem@PRODUCTION_PLAYER_TEMPLATE:
@@ -810,13 +810,13 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 2
 									Y: 2
@@ -826,7 +826,7 @@ Container@OBSERVER_WIDGETS:
 									X: 35
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								ObserverProductionIcons@PRODUCTION_ICONS:
@@ -834,7 +834,7 @@ Container@OBSERVER_WIDGETS:
 									Y: 1
 									Width: 0
 									IconWidth: 30
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									TooltipContainer: TOOLTIP_CONTAINER
 						ScrollItem@SUPPORT_POWERS_PLAYER_TEMPLATE:
 							X: 0
@@ -846,13 +846,13 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 2
 									Y: 2
@@ -862,14 +862,14 @@ Container@OBSERVER_WIDGETS:
 									X: 35
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								ObserverSupportPowerIcons@SUPPORT_POWER_ICONS:
 									X: 155
 									Y: 1
 									Width: 0
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									IconWidth: 30
 									TooltipContainer: TOOLTIP_CONTAINER
 						ScrollItem@ARMY_PLAYER_TEMPLATE:
@@ -882,32 +882,32 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 2
 									Y: 2
 									Width: 35
-									Height: PARENT_BOTTOM - 4
+									Height: PARENT_HEIGHT - 4
 									ImageName: random
 									ImageCollection: flags
 								Label@PLAYER:
 									X: 35
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								ObserverArmyIcons@ARMY_ICONS:
 									X: 155
 									Y: 1
 									Width: 0
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									IconWidth: 30
 									TooltipContainer: TOOLTIP_CONTAINER
 						ScrollItem@COMBAT_PLAYER_TEMPLATE:
@@ -920,13 +920,13 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 2
 									Y: 2
@@ -936,83 +936,83 @@ Container@OBSERVER_WIDGETS:
 									X: 35
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								Label@ASSETS_DESTROYED:
 									X: 155
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ASSETS_LOST:
 									X: 230
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@UNITS_KILLED:
 									X: 305
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@UNITS_DEAD:
 									X: 380
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_KILLED:
 									X: 455
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_DEAD:
 									X: 530
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ARMY_VALUE:
 									X: 605
 									Y: 0
 									Width: 90
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@VISION:
 									X: 695
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 				Container@INCOME_GRAPH_CONTAINER:
 					X: 0
 					Y: 30
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Visible: False
 					Children:
 						ColorBlock@GRAPH_BACKGROUND:
 							X: 0
 							Y: 0
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Color: 00000090
 						LineGraph@INCOME_GRAPH:
 							X: 0
 							Y: 0
-							Width: PARENT_RIGHT - 5
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH - 5
+							Height: PARENT_HEIGHT
 							ValueFormat: ${0}
 							YAxisValueFormat: ${0:F0}
 							XAxisSize: 40
@@ -1024,21 +1024,21 @@ Container@OBSERVER_WIDGETS:
 				Container@ARMY_VALUE_GRAPH_CONTAINER:
 					X: 0
 					Y: 30
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Visible: False
 					Children:
 						ColorBlock@GRAPH_BACKGROUND:
 							X: 0
 							Y: 0
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Color: 00000090
 						LineGraph@ARMY_VALUE_GRAPH:
 							X: 0
 							Y: 0
-							Width: PARENT_RIGHT - 5
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH - 5
+							Height: PARENT_HEIGHT
 							ValueFormat: ${0}
 							YAxisValueFormat: ${0:F0}
 							XAxisSize: 40
@@ -1049,6 +1049,6 @@ Container@OBSERVER_WIDGETS:
 							AxisFont: TinyBold
 		Container@HPF_ROOT:
 			Logic: LoadIngameHierarchicalPathFinderOverlayLogic
-			X: WINDOW_RIGHT - WIDTH - 260
+			X: WINDOW_WIDTH - WIDTH - 260
 			Y: 40
 			Width: 175

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -27,7 +27,7 @@ Container@PLAYER_WIDGETS:
 					HotkeyCount: 6
 		Image@COMMAND_BAR_BACKGROUND:
 			X: 0
-			Y: WINDOW_BOTTOM - HEIGHT
+			Y: WINDOW_HEIGHT - HEIGHT
 			Width: 451
 			Height: 43
 			ImageCollection: commandbar
@@ -36,7 +36,7 @@ Container@PLAYER_WIDGETS:
 		Container@COMMAND_BAR:
 			Logic: CommandBarLogic
 			X: 24
-			Y: WINDOW_BOTTOM - HEIGHT - 9
+			Y: WINDOW_HEIGHT - HEIGHT - 9
 			Width: 275
 			Height: 41
 			Children:
@@ -183,7 +183,7 @@ Container@PLAYER_WIDGETS:
 		Container@STANCE_BAR:
 			Logic: StanceSelectorLogic
 			X: 316
-			Y: WINDOW_BOTTOM - HEIGHT - 11
+			Y: WINDOW_HEIGHT - HEIGHT - 11
 			Width: 138
 			Height: 26
 			Children:
@@ -260,26 +260,26 @@ Container@PLAYER_WIDGETS:
 							ImageName: hold-fire
 		Container@MUTE_INDICATOR:
 			Logic: MuteIndicatorLogic
-			X: WINDOW_RIGHT - WIDTH - 231
+			X: WINDOW_WIDTH - WIDTH - 231
 			Y: 5
 			Width: 200
 			Height: 25
 			Children:
 				Image@ICON:
-					X: PARENT_RIGHT - WIDTH
+					X: PARENT_WIDTH - WIDTH
 					Y: 1
 					Width: 24
 					Height: 24
 					ImageCollection: sidebar-bits
 					ImageName: indicator-muted
 				Label@LABEL:
-					Width: PARENT_RIGHT - 30
+					Width: PARENT_WIDTH - 30
 					Height: 25
 					Align: Right
 					Text: label-mute-indicator
 					Contrast: true
 		Image@SIDEBAR_BACKGROUND_TOP:
-			X: WINDOW_RIGHT - 226
+			X: WINDOW_WIDTH - 226
 			Y: 0
 			Width: 226
 			Height: 295
@@ -436,7 +436,7 @@ Container@PLAYER_WIDGETS:
 					Logic: GameTimerLogic
 					X: 10
 					Y: 4
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 22
 					Align: Center
 					Font: TinyBold
@@ -451,7 +451,7 @@ Container@PLAYER_WIDGETS:
 					TooltipTemplate: SIMPLE_TOOLTIP
 				LabelWithTooltip@POWER:
 					Logic: IngamePowerCounterLogic
-					X: PARENT_RIGHT - WIDTH - 30
+					X: PARENT_WIDTH - WIDTH - 30
 					Y: 4
 					Width: 50
 					Height: 22
@@ -461,13 +461,13 @@ Container@PLAYER_WIDGETS:
 					TooltipTemplate: SIMPLE_TOOLTIP
 					Children:
 						Image@POWER_ICON:
-							X: PARENT_RIGHT + 0
+							X: PARENT_WIDTH + 0
 							Y: 3
 							ImageCollection: power-icons
 							ImageName: power-normal
 		Container@SIDEBAR_PRODUCTION:
 			Logic: ClassicProductionLogic
-			X: WINDOW_RIGHT - 226
+			X: WINDOW_WIDTH - 226
 			Y: 279
 			Width: 226
 			Height: 250
@@ -642,6 +642,6 @@ Container@PLAYER_WIDGETS:
 									ImageName: down
 		Container@HPF_ROOT:
 			Logic: LoadIngameHierarchicalPathFinderOverlayLogic
-			X: WINDOW_RIGHT - WIDTH - 231
+			X: WINDOW_WIDTH - WIDTH - 231
 			Y: 40
 			Width: 175

--- a/mods/d2k/chrome/lobby-players.yaml
+++ b/mods/d2k/chrome/lobby-players.yaml
@@ -1,12 +1,12 @@
 Container@LOBBY_PLAYER_BIN:
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		Container@LABEL_CONTAINER:
 			X: 5
 			Y: 0 - 26
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Children:
 				Label@LABEL_LOBBY_NAME:
 					Width: 180
@@ -57,8 +57,8 @@ Container@LOBBY_PLAYER_BIN:
 					Align: Left
 					Font: Bold
 		ScrollPanel@LOBBY_PLAYERS:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			TopBottomSpacing: 5
 			ItemSpacing: 5
 			Children:
@@ -77,8 +77,8 @@ Container@LOBBY_PLAYER_BIN:
 								ColorBlock@LATENCY_COLOR:
 									X: 2
 									Y: 2
-									Width: PARENT_RIGHT - 4
-									Height: PARENT_BOTTOM - 4
+									Width: PARENT_WIDTH - 4
+									Height: PARENT_HEIGHT - 4
 						ClientTooltipRegion@LATENCY_REGION:
 							Width: 11
 							Height: 25
@@ -121,8 +121,8 @@ Container@LOBBY_PLAYER_BIN:
 								ColorBlock@COLORBLOCK:
 									X: 5
 									Y: 6
-									Width: PARENT_RIGHT - 35
-									Height: PARENT_BOTTOM - 12
+									Width: PARENT_WIDTH - 35
+									Height: PARENT_HEIGHT - 12
 						DropDownButton@FACTION:
 							X: 270
 							Width: 140
@@ -186,8 +186,8 @@ Container@LOBBY_PLAYER_BIN:
 								ColorBlock@LATENCY_COLOR:
 									X: 2
 									Y: 2
-									Width: PARENT_RIGHT - 4
-									Height: PARENT_BOTTOM - 4
+									Width: PARENT_WIDTH - 4
+									Height: PARENT_HEIGHT - 4
 						ClientTooltipRegion@LATENCY_REGION:
 							Width: 11
 							Height: 25
@@ -328,8 +328,8 @@ Container@LOBBY_PLAYER_BIN:
 								ColorBlock@LATENCY_COLOR:
 									X: 2
 									Y: 2
-									Width: PARENT_RIGHT - 4
-									Height: PARENT_BOTTOM - 4
+									Width: PARENT_WIDTH - 4
+									Height: PARENT_HEIGHT - 4
 						ClientTooltipRegion@LATENCY_REGION:
 							Width: 11
 							Height: 25
@@ -391,8 +391,8 @@ Container@LOBBY_PLAYER_BIN:
 								ColorBlock@LATENCY_COLOR:
 									X: 2
 									Y: 2
-									Width: PARENT_RIGHT - 4
-									Height: PARENT_BOTTOM - 4
+									Width: PARENT_WIDTH - 4
+									Height: PARENT_HEIGHT - 4
 						ClientTooltipRegion@LATENCY_REGION:
 							Width: 11
 							Height: 25
@@ -475,7 +475,7 @@ ScrollPanel@FACTION_DROPDOWN_TEMPLATE:
 	Children:
 		ScrollItem@HEADER:
 			Background: scrollheader
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 13
 			X: 2
 			Y: 0
@@ -483,11 +483,11 @@ ScrollPanel@FACTION_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					Font: TinyBold
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 13
 					Align: Center
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0

--- a/mods/d2k/chrome/mainmenu.yaml
+++ b/mods/d2k/chrome/mainmenu.yaml
@@ -11,20 +11,20 @@ Container@MAINMENU:
 				MuteAudioKey: ToggleMute
 		Label@VERSION_LABEL:
 			Logic: VersionLabelLogic
-			X: WINDOW_RIGHT - 10
-			Y: WINDOW_BOTTOM - 19
+			X: WINDOW_WIDTH - 10
+			Y: WINDOW_HEIGHT - 19
 			Align: Right
 			Font: Regular
 			Shadow: True
 		Container@MENUS:
-			X: 13 + (WINDOW_RIGHT - 522) / 4 - WIDTH / 2
-			Y: WINDOW_BOTTOM / 2 - HEIGHT / 2
+			X: 13 + (WINDOW_WIDTH - 522) / 4 - WIDTH / 2
+			Y: WINDOW_HEIGHT / 2 - HEIGHT / 2
 			Width: 200
 			Height: 320
 			Children:
 				Background@MAIN_MENU:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						Label@MAINMENU_LABEL_TITLE:
 							X: 0
@@ -35,50 +35,50 @@ Container@MAINMENU:
 							Align: Center
 							Font: Bold
 						Button@SINGLEPLAYER_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 60
 							Width: 140
 							Height: 30
 							Text: label-singleplayer-title
 							Font: Bold
 						Button@MULTIPLAYER_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 100
 							Width: 140
 							Height: 30
 							Text: label-multiplayer-title
 							Font: Bold
 						Button@SETTINGS_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 140
 							Width: 140
 							Height: 30
 							Text: button-settings-title
 							Font: Bold
 						Button@EXTRAS_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 180
 							Width: 140
 							Height: 30
 							Text: button-extras-title
 							Font: Bold
 						Button@CONTENT_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 220
 							Width: 140
 							Height: 30
 							Text: button-main-menu-content
 							Font: Bold
 						Button@QUIT_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 260
 							Width: 140
 							Height: 30
 							Text: button-quit
 							Font: Bold
 				Background@SINGLEPLAYER_MENU:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						Label@SINGLEPLAYER_MENU_TITLE:
 							X: 0
@@ -89,35 +89,35 @@ Container@MAINMENU:
 							Align: Center
 							Font: Bold
 						Button@SKIRMISH_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 60
 							Width: 140
 							Height: 30
 							Text: button-singleplayer-menu-skirmish
 							Font: Bold
 						Button@MISSIONS_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 100
 							Width: 140
 							Height: 30
 							Text: label-missions-title
 							Font: Bold
 						Button@LOAD_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 140
 							Width: 140
 							Height: 30
 							Text: button-singleplayer-menu-load
 							Font: Bold
 						Button@ENCYCLOPEDIA_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 180
 							Width: 140
 							Height: 30
 							Text: label-mentat-title
 							Font: Bold
 						Button@BACK_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Key: escape
 							Y: 260
 							Width: 140
@@ -125,8 +125,8 @@ Container@MAINMENU:
 							Text: button-back
 							Font: Bold
 				Background@EXTRAS_MENU:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						Label@EXTRAS_MENU_TITLE:
 							X: 0
@@ -137,42 +137,42 @@ Container@MAINMENU:
 							Align: Center
 							Font: Bold
 						Button@REPLAYS_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 60
 							Width: 140
 							Height: 30
 							Text: button-extras-menu-replays
 							Font: Bold
 						Button@MUSIC_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 100
 							Width: 140
 							Height: 30
 							Text: label-music-title
 							Font: Bold
 						Button@MAP_EDITOR_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 140
 							Width: 140
 							Height: 30
 							Text: label-map-editor-title
 							Font: Bold
 						Button@ASSETBROWSER_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 180
 							Width: 140
 							Height: 30
 							Text: button-extras-menu-assetbrowser
 							Font: Bold
 						Button@CREDITS_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 220
 							Width: 140
 							Height: 30
 							Text: label-credits-title
 							Font: Bold
 						Button@BACK_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Key: escape
 							Y: 260
 							Width: 140
@@ -180,8 +180,8 @@ Container@MAINMENU:
 							Text: button-back
 							Font: Bold
 				Background@MAP_EDITOR_MENU:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						Label@MAP_EDITOR_MENU_TITLE:
 							X: 0
@@ -192,21 +192,21 @@ Container@MAINMENU:
 							Align: Center
 							Font: Bold
 						Button@NEW_MAP_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 60
 							Width: 140
 							Height: 30
 							Text: button-map-editor-new-map
 							Font: Bold
 						Button@LOAD_MAP_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 100
 							Width: 140
 							Height: 30
 							Text: button-map-editor-load-map
 							Font: Bold
 						Button@BACK_BUTTON:
-							X: PARENT_RIGHT / 2 - WIDTH / 2
+							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Key: escape
 							Y: 260
 							Width: 140
@@ -214,7 +214,7 @@ Container@MAINMENU:
 							Text: button-back
 							Font: Bold
 		Background@NEWS_BG:
-			X: (WINDOW_RIGHT - WIDTH) / 2
+			X: (WINDOW_WIDTH - WIDTH) / 2
 			Y: 35
 			Width: 430
 			Height: 55
@@ -227,19 +227,19 @@ Container@MAINMENU:
 					Text: dropdownbutton-news-bg-button
 					Font: Bold
 		Container@UPDATE_NOTICE:
-			X: (WINDOW_RIGHT - WIDTH) / 2
+			X: (WINDOW_WIDTH - WIDTH) / 2
 			Y: 96
 			Width: 128
 			Children:
 				Label@A:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 					Shadow: true
 					Text: label-update-notice-a
 				Label@B:
 					Y: 20
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 					Shadow: true
@@ -249,15 +249,15 @@ Container@MAINMENU:
 			Children:
 				Label@PERF_TEXT:
 					X: 30
-					Y: WINDOW_BOTTOM - 69
+					Y: WINDOW_HEIGHT - 69
 					Width: 170
 					Height: 40
 					Contrast: true
 				Background@GRAPH_BG:
 					ClickThrough: true
 					Background: dialog4
-					X: WINDOW_RIGHT - 240
-					Y: WINDOW_BOTTOM - 240
+					X: WINDOW_WIDTH - 240
+					Y: WINDOW_HEIGHT - 240
 					Width: 210
 					Height: 210
 					Children:

--- a/mods/d2k/chrome/missionbrowser.yaml
+++ b/mods/d2k/chrome/missionbrowser.yaml
@@ -1,13 +1,13 @@
 Background@MISSIONBROWSER_PANEL:
 	Logic: MissionBrowserLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 682
 	Height: 591
 	Children:
 		Label@MISSIONBROWSER_TITLE:
 			Y: 20
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Text: label-missions-title
 			Align: Center
@@ -20,125 +20,125 @@ Background@MISSIONBROWSER_PANEL:
 			Children:
 				ScrollItem@HEADER:
 					Background: scrollheader
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 13
 					X: 2
 					Visible: false
 					Children:
 						Label@LABEL:
 							Font: TinyBold
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 13
 							Align: Center
 				ScrollItem@TEMPLATE:
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 25
 					X: 2
 					EnableChildMouseOver: True
 					Children:
 						LabelWithTooltip@TITLE:
 							X: 10
-							Width: PARENT_RIGHT - 20
+							Width: PARENT_WIDTH - 20
 							Height: 25
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 		Container@MISSION_INFO:
 			X: 220
 			Y: 50
-			Width: PARENT_RIGHT - 240
+			Width: PARENT_WIDTH - 240
 			Height: 483
 			Children:
 				Background@MISSION_BG:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 225
 					Background: dialog3
 					Children:
 						MapPreview@MISSION_PREVIEW:
 							X: 1
 							Y: 1
-							Width: PARENT_RIGHT - 2
-							Height: PARENT_BOTTOM - 2
+							Width: PARENT_WIDTH - 2
+							Height: PARENT_HEIGHT - 2
 							IgnoreMouseOver: True
 							IgnoreMouseInput: True
 							ShowSpawnPoints: False
 				Container@MISSION_TABS:
-					Width: PARENT_RIGHT
-					Y: PARENT_BOTTOM - 31
+					Width: PARENT_WIDTH
+					Y: PARENT_HEIGHT - 31
 					Children:
 						Button@MISSIONINFO_TAB:
-							Width: PARENT_RIGHT / 2
+							Width: PARENT_WIDTH / 2
 							Height: 31
 							Font: Bold
 							Text: button-missionbrowser-panel-mission-info
 						Button@OPTIONS_TAB:
-							X: PARENT_RIGHT / 2
-							Width: PARENT_RIGHT / 2
+							X: PARENT_WIDTH / 2
+							Width: PARENT_WIDTH / 2
 							Height: 31
 							Font: Bold
 							Text: button-missionbrowser-panel-mission-options
 				Container@MISSION_DETAIL:
 					Y: 235
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM - 235
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT - 235
 					Children:
 						ScrollPanel@MISSION_DESCRIPTION_PANEL:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM - 30
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT - 30
 							TopBottomSpacing: 5
 							Children:
 								Label@MISSION_DESCRIPTION:
 									X: 4
-									Width: PARENT_RIGHT - 32
+									Width: PARENT_WIDTH - 32
 									VAlign: Top
 									Font: Small
 						ScrollPanel@MISSION_OPTIONS:
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM - 30
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT - 30
 							TopBottomSpacing: 5
 							Children:
 								Container@CHECKBOX_ROW_TEMPLATE:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 30
 									Children:
 										Checkbox@A:
 											X: 10
-											Width: PARENT_RIGHT / 2 - 25
+											Width: PARENT_WIDTH / 2 - 25
 											Height: 20
 											Visible: False
 											TooltipContainer: TOOLTIP_CONTAINER
 										Checkbox@B:
-											X: PARENT_RIGHT / 2 + 5
-											Width: PARENT_RIGHT / 2 - 25
+											X: PARENT_WIDTH / 2 + 5
+											Width: PARENT_WIDTH / 2 - 25
 											Height: 20
 											Visible: False
 											TooltipContainer: TOOLTIP_CONTAINER
 								Container@DROPDOWN_ROW_TEMPLATE:
 									Height: 60
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Children:
 										LabelForInput@A_DESC:
 											X: 10
-											Width: PARENT_RIGHT / 2 - 35
+											Width: PARENT_WIDTH / 2 - 35
 											Height: 20
 											Visible: False
 											For: A
 										DropDownButton@A:
 											X: 10
-											Width: PARENT_RIGHT / 2 - 35
+											Width: PARENT_WIDTH / 2 - 35
 											Y: 25
 											Height: 25
 											Visible: False
 											PanelRoot: MISSION_DROPDOWN_PANEL_ROOT
 											TooltipContainer: TOOLTIP_CONTAINER
 										LabelForInput@B_DESC:
-											X: PARENT_RIGHT / 2 + 5
-											Width: PARENT_RIGHT / 2 - 35
+											X: PARENT_WIDTH / 2 + 5
+											Width: PARENT_WIDTH / 2 - 35
 											Height: 20
 											Visible: False
 											For: B
 										DropDownButton@B:
-											X: PARENT_RIGHT / 2 + 5
-											Width: PARENT_RIGHT / 2 - 35
+											X: PARENT_WIDTH / 2 + 5
+											Width: PARENT_WIDTH / 2 - 35
 											Y: 25
 											Height: 25
 											Visible: False
@@ -146,42 +146,42 @@ Background@MISSIONBROWSER_PANEL:
 											TooltipContainer: TOOLTIP_CONTAINER
 		Button@START_BRIEFING_VIDEO_BUTTON:
 			X: 20
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 130
 			Height: 25
 			Text: button-missionbrowser-panel-start-briefing-video
 			Font: Bold
 		Button@STOP_BRIEFING_VIDEO_BUTTON:
 			X: 20
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 130
 			Height: 25
 			Text: button-missionbrowser-panel-stop-briefing-video
 			Font: Bold
 		Button@START_INFO_VIDEO_BUTTON:
 			X: 160
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 130
 			Height: 25
 			Text: button-missionbrowser-panel-start-info-video
 			Font: Bold
 		Button@STOP_INFO_VIDEO_BUTTON:
 			X: 160
-			Y: PARENT_BOTTOM - 45
+			Y: PARENT_HEIGHT - 45
 			Width: 130
 			Height: 25
 			Text: button-missionbrowser-panel-stop-info-video
 			Font: Bold
 		Button@STARTGAME_BUTTON:
-			X: PARENT_RIGHT - 140 - 130
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 140 - 130
+			Y: PARENT_HEIGHT - 45
 			Width: 120
 			Height: 25
 			Text: button-missionbrowser-panel-play
 			Font: Bold
 		Button@BACK_BUTTON:
-			X: PARENT_RIGHT - 140
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 140
+			Y: PARENT_HEIGHT - 45
 			Width: 120
 			Height: 25
 			Text: button-back
@@ -205,13 +205,13 @@ Background@MISSIONBROWSER_PANEL:
 		TooltipContainer@TOOLTIP_CONTAINER:
 
 Background@FULLSCREEN_PLAYER:
-	Width: WINDOW_RIGHT
-	Height: WINDOW_BOTTOM
+	Width: WINDOW_WIDTH
+	Height: WINDOW_HEIGHT
 	Background: dialog5
 	Visible: False
 	Children:
 		VideoPlayer@PLAYER:
 			X: 0
 			Y: 0
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
+			Width: WINDOW_WIDTH
+			Height: WINDOW_HEIGHT

--- a/mods/d2k/chrome/multiplayer-browserpanels.yaml
+++ b/mods/d2k/chrome/multiplayer-browserpanels.yaml
@@ -1,11 +1,11 @@
 ScrollPanel@MULTIPLAYER_CLIENT_LIST:
-	Width: PARENT_RIGHT
+	Width: PARENT_WIDTH
 	Height: 159
 	IgnoreChildMouseOver: true
 	Children:
 		ScrollItem@HEADER:
 			Background: scrollheader
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 13
 			X: 2
 			Y: 0
@@ -13,11 +13,11 @@ ScrollPanel@MULTIPLAYER_CLIENT_LIST:
 			Children:
 				Label@LABEL:
 					Font: TinyBold
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 13
 					Align: Center
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -31,12 +31,12 @@ ScrollPanel@MULTIPLAYER_CLIENT_LIST:
 					Visible: False
 				Label@LABEL:
 					X: 35
-					Width: PARENT_RIGHT - 45
+					Width: PARENT_WIDTH - 45
 					Height: 25
 					Shadow: True
 				Label@NOFLAG_LABEL:
 					X: 5
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 
 ScrollPanel@MULTIPLAYER_FILTER_PANEL:
@@ -46,7 +46,7 @@ ScrollPanel@MULTIPLAYER_FILTER_PANEL:
 		Checkbox@WAITING_FOR_PLAYERS:
 			X: 5
 			Y: 5
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Text: checkbox-multiplayer-filter-panel-waiting-for-players
 			TextColor: 32CD32
@@ -54,14 +54,14 @@ ScrollPanel@MULTIPLAYER_FILTER_PANEL:
 		Checkbox@EMPTY:
 			X: 5
 			Y: 30
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Text: checkbox-multiplayer-filter-panel-empty
 			Font: Regular
 		Checkbox@PASSWORD_PROTECTED:
 			X: 5
 			Y: 55
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Text: checkbox-multiplayer-filter-panel-password-protected
 			TextColor: FF0000
@@ -69,7 +69,7 @@ ScrollPanel@MULTIPLAYER_FILTER_PANEL:
 		Checkbox@ALREADY_STARTED:
 			X: 5
 			Y: 80
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Text: checkbox-multiplayer-filter-panel-already-started
 			TextColor: FFA500
@@ -77,7 +77,7 @@ ScrollPanel@MULTIPLAYER_FILTER_PANEL:
 		Checkbox@INCOMPATIBLE_VERSION:
 			X: 5
 			Y: 105
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20
 			Text: checkbox-multiplayer-filter-panel-incompatible-version
 			TextColor: BEBEBE

--- a/mods/d2k/chrome/tooltips.yaml
+++ b/mods/d2k/chrome/tooltips.yaml
@@ -196,7 +196,7 @@ Background@REGISTERED_PLAYER_TOOLTIP:
 	Width: 270
 	Children:
 		Container@HEADER:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Children:
 				Container@PROFILE_HEADER:
 					Height: 45
@@ -204,19 +204,19 @@ Background@REGISTERED_PLAYER_TOOLTIP:
 						Label@PROFILE_NAME:
 							X: 7
 							Y: 3
-							Width: PARENT_RIGHT - 20
+							Width: PARENT_WIDTH - 20
 							Height: 24
 							Font: MediumBold
 						Label@PROFILE_RANK:
 							X: 7
 							Y: 25
-							Width: PARENT_RIGHT - 20
+							Width: PARENT_WIDTH - 20
 							Height: 12
 							Font: TinyBold
 						Container@GAME_ADMIN:
 							X: 7
 							Y: 37
-							Width: PARENT_RIGHT - 20
+							Width: PARENT_WIDTH - 20
 							Height: 12
 							Visible: False
 							Children:
@@ -235,16 +235,16 @@ Background@REGISTERED_PLAYER_TOOLTIP:
 									Font: TinyBold
 				Container@MESSAGE_HEADER:
 					Height: 31
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Children:
 						Label@MESSAGE:
 							X: 7
 							Y: 4
-							Width: PARENT_RIGHT - 14
+							Width: PARENT_WIDTH - 14
 							Height: 23
 							Font: Bold
 		Container@BADGES_CONTAINER:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Visible: false
 			Children:
 				Background@SEPARATOR:

--- a/mods/modcontent/content.yaml
+++ b/mods/modcontent/content.yaml
@@ -1,7 +1,7 @@
 Background@CONTENT_PANEL:
 	Logic: ModContentLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 500
 	Height: 290
 	Background: panel-bg
@@ -15,7 +15,7 @@ Background@CONTENT_PANEL:
 		Label@TITLE:
 			X: 0
 			Y: 14
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Text: Manage Content
 			Align: Center
@@ -23,14 +23,14 @@ Background@CONTENT_PANEL:
 		Label@HEADER_TEMPLATE:
 			X: 30
 			Y: 66
-			Width: PARENT_RIGHT - 60
+			Width: PARENT_WIDTH - 60
 			Height: 16
 			Align: Center
 			WordWrap: true
 		ScrollPanel@PACKAGES:
 			X: 30
 			Y: 84
-			Width: PARENT_RIGHT - 60
+			Width: PARENT_WIDTH - 60
 			Height: 137
 			TopBottomSpacing: 4
 			ItemSpacing: 2
@@ -38,7 +38,7 @@ Background@CONTENT_PANEL:
 			Children:
 				Container@PACKAGE_TEMPLATE:
 					X: 6
-					Width: PARENT_RIGHT - 16
+					Width: PARENT_WIDTH - 16
 					Height: 23
 					Children:
 						Label@TITLE:
@@ -86,15 +86,15 @@ Background@CONTENT_PANEL:
 							Text: Requires Disc
 		Button@CHECK_SOURCE_BUTTON:
 			X: 30
-			Y: PARENT_BOTTOM - 52
+			Y: PARENT_HEIGHT - 52
 			Background: button-highlighted
 			Width: 200
 			Height: 32
 			Text: Detect Disc or Installation
 			Font: Bold
 		Button@BACK_BUTTON:
-			X: PARENT_RIGHT - 140
-			Y: PARENT_BOTTOM - 52
+			X: PARENT_WIDTH - 140
+			Y: PARENT_HEIGHT - 52
 			Background: button-highlighted
 			Width: 110
 			Height: 32
@@ -115,7 +115,7 @@ Background@SOURCE_TOOLTIP:
 			Text: Content available from:
 		Container@SOURCES:
 			Y: 15
-			Width: PARENT_RIGHT - 10
+			Width: PARENT_WIDTH - 10
 			Height: 7 # used as bottom margin
 			Children:
 				Label@SOURCE_TEMPLATE:
@@ -138,14 +138,14 @@ Background@INFO_TOOLTIP:
 
 Container@PACKAGE_DOWNLOAD_PANEL:
 	Logic: DownloadPackageLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 500
 	Height: 177
 	Children:
 		Background:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Background: panel-bg
 		Background@RULE:
 			X: 30
@@ -156,25 +156,25 @@ Container@PACKAGE_DOWNLOAD_PANEL:
 		Label@TITLE:
 			X: 0
 			Y: 12
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Align: Center
 			Font: MediumBold
 		ProgressBar@PROGRESS_BAR:
 			X: 30
 			Y: 64
-			Width: PARENT_RIGHT - 60
+			Width: PARENT_WIDTH - 60
 			Height: 16
 			BarMargin: 0, 0
 		Label@STATUS_LABEL:
 			X: 30
 			Y: 85
-			Width: PARENT_RIGHT - 60
+			Width: PARENT_WIDTH - 60
 			Height: 25
 			Align: Left
 		Button@RETRY_BUTTON:
 			X: 30
-			Y: PARENT_BOTTOM - 52
+			Y: PARENT_HEIGHT - 52
 			Background: button-highlighted
 			Width: 120
 			Height: 32
@@ -183,8 +183,8 @@ Container@PACKAGE_DOWNLOAD_PANEL:
 			Font: Bold
 			Key: return
 		Button@CANCEL_BUTTON:
-			X: PARENT_RIGHT - 30 - WIDTH
-			Y: PARENT_BOTTOM - 52
+			X: PARENT_WIDTH - 30 - WIDTH
+			Y: PARENT_HEIGHT - 52
 			Background: button-highlighted
 			Width: 110
 			Height: 32
@@ -194,8 +194,8 @@ Container@PACKAGE_DOWNLOAD_PANEL:
 
 Background@SOURCE_INSTALL_PANEL:
 	Logic: InstallFromSourceLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 500
 	Height: 177
 	Background: panel-bg
@@ -208,52 +208,52 @@ Background@SOURCE_INSTALL_PANEL:
 			Background: panel-rule
 		Label@TITLE:
 			Y: 12
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Align: Center
 			Font: MediumBold
 		Container@PROGRESS:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Visible: false
 			Children:
 				ProgressBar@PROGRESS_BAR:
 					X: 30
 					Y: 60
-					Width: PARENT_RIGHT - 60
+					Width: PARENT_WIDTH - 60
 					Height: 16
 					BarMargin: 0, 0
 				Label@PROGRESS_MESSAGE:
 					X: 30
 					Y: 80
-					Width: PARENT_RIGHT - 60
+					Width: PARENT_WIDTH - 60
 					Height: 25
 					Align: Left
 		Container@MESSAGE:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Height: 157
 			Visible: false
 			Children:
 				Label@MESSAGE_MESSAGE:
 					Y: 65
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 		Container@LIST:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 338
 			Visible: false
 			Children:
 				Label@LIST_MESSAGE:
 					Y: 65
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 16
 					Align: Center
 				ScrollPanel@LIST_PANEL:
 					X: 30
 					Y: 99
-					Width: PARENT_RIGHT - 60
+					Width: PARENT_WIDTH - 60
 					Height: 170
 					TopBottomSpacing: 4
 					ItemSpacing: 2
@@ -261,36 +261,36 @@ Background@SOURCE_INSTALL_PANEL:
 					Children:
 						Container@LIST_HEADER_TEMPLATE:
 							X: 6
-							Width: PARENT_RIGHT - 12 - 24
+							Width: PARENT_WIDTH - 12 - 24
 							Height: 14
 							Children:
 								Background@TOP_RULE:
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 1
 									Background: panel-rule
 								Label@LABEL:
 									Y: 3
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 10
 									Font: TinyBold
 									Align: Center
 								Background@BOTTOM_RULE:
 									Y: 16
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 1
 									Background: panel-rule
 						Label@LABEL_LIST_TEMPLATE:
 							X: 6
-							Width: PARENT_RIGHT - 16
+							Width: PARENT_WIDTH - 16
 							Height: 23
 						Container@CHECKBOX_LIST_TEMPLATE:
 							X: 6
-							Width: PARENT_RIGHT - 16
+							Width: PARENT_WIDTH - 16
 							Height: 23
 							Children:
 								Checkbox@PACKAGE_CHECKBOX:
 									X: 6
-									Width: PARENT_RIGHT - 16
+									Width: PARENT_WIDTH - 16
 									Height: 23
 									Children:
 								Image@PACKAGE_INFO:
@@ -305,15 +305,15 @@ Background@SOURCE_INSTALL_PANEL:
 									TooltipTemplate: INFO_TOOLTIP
 		Button@PRIMARY_BUTTON:
 			X: 30
-			Y: PARENT_BOTTOM - 52
+			Y: PARENT_HEIGHT - 52
 			Background: button-highlighted
 			Width: 110
 			Height: 32
 			Font: Bold
 			Key: return
 		Button@SECONDARY_BUTTON:
-			X: PARENT_RIGHT - 140
-			Y: PARENT_BOTTOM - 52
+			X: PARENT_WIDTH - 140
+			Y: PARENT_HEIGHT - 52
 			Background: button-highlighted
 			Width: 110
 			Height: 32
@@ -323,8 +323,8 @@ Background@SOURCE_INSTALL_PANEL:
 
 Background@CONTENT_PROMPT_PANEL:
 	Logic: ModContentPromptLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 500
 	Height: 140
 	Background: panel-bg
@@ -338,7 +338,7 @@ Background@CONTENT_PROMPT_PANEL:
 		Label@TITLE:
 			X: 0
 			Y: 12
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Text: Install Content
 			Align: Center
@@ -346,13 +346,13 @@ Background@CONTENT_PROMPT_PANEL:
 		Label@HEADER_TEMPLATE:
 			X: 30
 			Y: 65
-			Width: PARENT_RIGHT - 60
+			Width: PARENT_WIDTH - 60
 			Height: 16
 			Align: Center
 			WordWrap: true
 		Button@ADVANCED_BUTTON:
 			X: 30
-			Y: PARENT_BOTTOM - 52
+			Y: PARENT_HEIGHT - 52
 			Background: button-highlighted
 			Width: 140
 			Height: 32
@@ -360,15 +360,15 @@ Background@CONTENT_PROMPT_PANEL:
 			Font: Bold
 		Button@QUICK_BUTTON:
 			X: 185
-			Y: PARENT_BOTTOM - 52
+			Y: PARENT_HEIGHT - 52
 			Background: button-highlighted
 			Width: 110
 			Height: 32
 			Text: Quick Install
 			Font: Bold
 		Button@QUIT_BUTTON:
-			X: PARENT_RIGHT - WIDTH - 30
-			Y: PARENT_BOTTOM - 52
+			X: PARENT_WIDTH - WIDTH - 30
+			Y: PARENT_HEIGHT - 52
 			Background: button-highlighted
 			Width: 110
 			Height: 32
@@ -378,8 +378,8 @@ Background@CONTENT_PROMPT_PANEL:
 
 Background@MODCONTENT_BACKGROUND:
 	Background: background
-	Width: WINDOW_RIGHT
-	Height: WINDOW_BOTTOM
+	Width: WINDOW_WIDTH
+	Height: WINDOW_HEIGHT
 
 Background@BUTTON_TOOLTIP:
 	Logic: ButtonTooltipLogic

--- a/mods/ra/chrome/gamesave-loading.yaml
+++ b/mods/ra/chrome/gamesave-loading.yaml
@@ -1,36 +1,36 @@
 Container@GAMESAVE_LOADING_SCREEN:
 	Logic: GameSaveLoadingLogic
-	Width: WINDOW_RIGHT
-	Height: WINDOW_BOTTOM
+	Width: WINDOW_WIDTH
+	Height: WINDOW_HEIGHT
 	Children:
 		LogicKeyListener@CANCEL_HANDLER:
 		Background@STRIPE:
-			Y: (WINDOW_BOTTOM - HEIGHT) / 2
-			Width: WINDOW_RIGHT
+			Y: (WINDOW_HEIGHT - HEIGHT) / 2
+			Width: WINDOW_WIDTH
 			Height: 256
 			Background: loadscreen-stripe
 		Image@LOGO:
-			X: (WINDOW_RIGHT - 256) / 2
-			Y: (WINDOW_BOTTOM - 256) / 2
+			X: (WINDOW_WIDTH - 256) / 2
+			Y: (WINDOW_HEIGHT - 256) / 2
 			ImageCollection: logos
 			ImageName: logo
 		Label@TITLE:
-			Width: WINDOW_RIGHT
-			Y: 3 * WINDOW_BOTTOM / 4 - 29
+			Width: WINDOW_WIDTH
+			Y: 3 * WINDOW_HEIGHT / 4 - 29
 			Height: 25
 			Font: Bold
 			Align: Center
 			Text: label-gamesave-loading-screen-title
 		ProgressBar@PROGRESS:
-			X: (WINDOW_RIGHT - 500) / 2
-			Y: 3 * WINDOW_BOTTOM / 4
+			X: (WINDOW_WIDTH - 500) / 2
+			Y: 3 * WINDOW_HEIGHT / 4
 			Width: 500
 			Height: 20
 			Background: observer-scrollpanel-button-pressed
 			Bar: observer-scrollpanel-button
 		Label@DESC:
-			Width: WINDOW_RIGHT
-			Y: 3 * WINDOW_BOTTOM / 4 + 19
+			Width: WINDOW_WIDTH
+			Y: 3 * WINDOW_HEIGHT / 4 + 19
 			Height: 25
 			Font: Regular
 			Align: Center

--- a/mods/ra/chrome/ingame-observer.yaml
+++ b/mods/ra/chrome/ingame-observer.yaml
@@ -4,26 +4,26 @@ Container@OBSERVER_WIDGETS:
 		Container@CHAT_ROOT:
 		Container@MUTE_INDICATOR:
 			Logic: MuteIndicatorLogic
-			X: WINDOW_RIGHT - WIDTH - 260
+			X: WINDOW_WIDTH - WIDTH - 260
 			Y: 10
 			Width: 200
 			Height: 25
 			Children:
 				Image@ICON:
-					X: PARENT_RIGHT - WIDTH
+					X: PARENT_WIDTH - WIDTH
 					Y: 1
 					Width: 24
 					Height: 24
 					ImageCollection: sidebar-bits
 					ImageName: indicator-muted
 				Label@LABEL:
-					Width: PARENT_RIGHT - 30
+					Width: PARENT_WIDTH - 30
 					Height: 25
 					Align: Right
 					Text: label-mute-indicator
 					Contrast: true
 		Image@SIDEBAR_BACKGROUND_TOP:
-			X: WINDOW_RIGHT - 250
+			X: WINDOW_WIDTH - 250
 			Y: 10
 			Width: 238
 			Height: 287
@@ -41,8 +41,8 @@ Container@OBSERVER_WIDGETS:
 					Children:
 						LabelWithTooltip@GAME_TIMER:
 							Y: 0 - 1
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Align: Center
 							Font: TinyBold
 							TooltipContainer: TOOLTIP_CONTAINER
@@ -110,16 +110,16 @@ Container@OBSERVER_WIDGETS:
 							Height: 16
 						Label@LABEL:
 							X: 40
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 25
 							Shadow: True
 						Label@NOFLAG_LABEL:
 							X: 5
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 25
 							Shadow: True
 		Image@SIDEBAR_BACKGROUND_BOTTOM:
-			X: WINDOW_RIGHT - 250
+			X: WINDOW_WIDTH - 250
 			Y: 297
 			Width: 238
 			Height: 8
@@ -127,7 +127,7 @@ Container@OBSERVER_WIDGETS:
 			ImageName: observer-bottom
 		Image@REPLAY_PLAYER:
 			Logic: ReplayControlBarLogic
-			X: WINDOW_RIGHT - 250
+			X: WINDOW_WIDTH - 250
 			Y: 297
 			Width: 238
 			Height: 40
@@ -247,33 +247,33 @@ Container@OBSERVER_WIDGETS:
 				Container@GRAPH_BG:
 					Y: 30
 					X: 0
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 24
 					Children:
 						Container@BASIC_STATS_HEADERS:
 							X: 0
 							Y: 0
 							Width: 705
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-player-header
 									Align: Left
@@ -282,7 +282,7 @@ Container@OBSERVER_WIDGETS:
 									X: 160
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-cash-header
 									Align: Right
@@ -291,7 +291,7 @@ Container@OBSERVER_WIDGETS:
 									X: 240
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-power-header
 									Align: Center
@@ -300,7 +300,7 @@ Container@OBSERVER_WIDGETS:
 									X: 320
 									Y: 0
 									Width: 40
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-kills-header
 									Align: Right
@@ -309,7 +309,7 @@ Container@OBSERVER_WIDGETS:
 									X: 360
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-deaths-header
 									Align: Right
@@ -318,7 +318,7 @@ Container@OBSERVER_WIDGETS:
 									X: 420
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-assets-destroyed-header
 									Align: Right
@@ -327,7 +327,7 @@ Container@OBSERVER_WIDGETS:
 									X: 500
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-assets-lost-header
 									Align: Right
@@ -336,7 +336,7 @@ Container@OBSERVER_WIDGETS:
 									X: 580
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-experience-header
 									Align: Right
@@ -345,7 +345,7 @@ Container@OBSERVER_WIDGETS:
 									X: 640
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-actions-min-header
 									Align: Right
@@ -354,32 +354,32 @@ Container@OBSERVER_WIDGETS:
 							X: 0
 							Y: 0
 							Width: 735
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 40
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-player-header
 									Shadow: True
 								Label@CASH_HEADER:
 									X: 160
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-cash-header
 									Align: Right
@@ -387,7 +387,7 @@ Container@OBSERVER_WIDGETS:
 								Label@INCOME_HEADER:
 									X: 240
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-income-header
 									Align: Right
@@ -395,7 +395,7 @@ Container@OBSERVER_WIDGETS:
 								Label@ASSETS_HEADER:
 									X: 320
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-assets-header
 									Align: Right
@@ -403,7 +403,7 @@ Container@OBSERVER_WIDGETS:
 								Label@EARNED_HEADER:
 									X: 400
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-earned-header
 									Align: Right
@@ -411,7 +411,7 @@ Container@OBSERVER_WIDGETS:
 								Label@SPENT_HEADER:
 									X: 480
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-spent-header
 									Align: Right
@@ -419,7 +419,7 @@ Container@OBSERVER_WIDGETS:
 								Label@HARVESTERS_HEADER:
 									X: 560
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-harvesters-header
 									Align: Right
@@ -427,7 +427,7 @@ Container@OBSERVER_WIDGETS:
 								Label@DERRICKS_HEADER:
 									X: 650
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-derricks-header
 									Align: Right
@@ -436,26 +436,26 @@ Container@OBSERVER_WIDGETS:
 							X: 0
 							Y: 0
 							Width: 400
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-production-stats-player-header
 									Align: Left
@@ -464,7 +464,7 @@ Container@OBSERVER_WIDGETS:
 									X: 160
 									Y: 0
 									Width: 100
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-production-stats-header
 									Shadow: True
@@ -472,26 +472,26 @@ Container@OBSERVER_WIDGETS:
 							X: 0
 							Y: 0
 							Width: 400
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-support-powers-player-header
 									Align: Left
@@ -500,7 +500,7 @@ Container@OBSERVER_WIDGETS:
 									X: 160
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-support-powers-header
 									Shadow: True
@@ -508,26 +508,26 @@ Container@OBSERVER_WIDGETS:
 							X: 0
 							Y: 0
 							Width: 400
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-army-player-header
 									Align: Left
@@ -536,7 +536,7 @@ Container@OBSERVER_WIDGETS:
 									X: 160
 									Y: 0
 									Width: 100
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-army-header
 									Shadow: True
@@ -544,26 +544,26 @@ Container@OBSERVER_WIDGETS:
 							X: 0
 							Y: 0
 							Width: 760
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-player-header
 									Align: Left
@@ -572,7 +572,7 @@ Container@OBSERVER_WIDGETS:
 									X: 160
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-assets-destroyed-header
 									Align: Right
@@ -581,7 +581,7 @@ Container@OBSERVER_WIDGETS:
 									X: 235
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-assets-lost-header
 									Align: Right
@@ -590,7 +590,7 @@ Container@OBSERVER_WIDGETS:
 									X: 310
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-units-killed-header
 									Align: Right
@@ -599,7 +599,7 @@ Container@OBSERVER_WIDGETS:
 									X: 385
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-units-dead-header
 									Align: Right
@@ -608,7 +608,7 @@ Container@OBSERVER_WIDGETS:
 									X: 460
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-buildings-killed-header
 									Align: Right
@@ -617,7 +617,7 @@ Container@OBSERVER_WIDGETS:
 									X: 535
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-buildings-dead-header
 									Align: Right
@@ -626,7 +626,7 @@ Container@OBSERVER_WIDGETS:
 									X: 610
 									Y: 0
 									Width: 90
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-army-value-header
 									Align: Right
@@ -635,7 +635,7 @@ Container@OBSERVER_WIDGETS:
 									X: 700
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-vision-header
 									Align: Right
@@ -643,7 +643,7 @@ Container@OBSERVER_WIDGETS:
 				ScrollPanel@PLAYER_STATS_PANEL:
 					X: 0
 					Y: 54
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 240
 					TopBottomSpacing: 0
 					BorderWidth: 0
@@ -663,20 +663,20 @@ Container@OBSERVER_WIDGETS:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@TEAM_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@TEAM:
 									X: 10
 									Y: 0
-									Width: PARENT_RIGHT
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 						ScrollItem@BASIC_PLAYER_TEMPLATE:
@@ -689,81 +689,81 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 5
 									Y: 4
 									Width: 35
-									Height: PARENT_BOTTOM - 4
+									Height: PARENT_HEIGHT - 4
 									ImageName: random
 									ImageCollection: flags
 								Label@PLAYER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								Label@CASH:
 									X: 160
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@POWER:
 									X: 240
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Center
 									Shadow: True
 								Label@KILLS:
 									X: 320
 									Y: 0
 									Width: 40
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@DEATHS:
 									X: 360
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ASSETS_DESTROYED:
 									X: 420
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ASSETS_LOST:
 									X: 500
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@EXPERIENCE:
 									X: 580
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ACTIONS_MIN:
 									X: 640
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 						ScrollItem@ECONOMY_PLAYER_TEMPLATE:
@@ -776,74 +776,74 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 5
 									Y: 4
 									Width: 35
-									Height: PARENT_BOTTOM - 4
+									Height: PARENT_HEIGHT - 4
 									ImageName: random
 									ImageCollection: flags
 								Label@PLAYER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								Label@CASH:
 									X: 160
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@INCOME:
 									X: 240
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ASSETS:
 									X: 320
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@EARNED:
 									X: 400
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@SPENT:
 									X: 480
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@HARVESTERS:
 									X: 560
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@DERRICKS:
 									X: 650
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 						ScrollItem@PRODUCTION_PLAYER_TEMPLATE:
@@ -856,32 +856,32 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 5
 									Y: 4
 									Width: 35
-									Height: PARENT_BOTTOM - 4
+									Height: PARENT_HEIGHT - 4
 									ImageName: random
 									ImageCollection: flags
 								Label@PLAYER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								ObserverProductionIcons@PRODUCTION_ICONS:
 									X: 160
 									Y: 0
 									Width: 0
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									TooltipContainer: TOOLTIP_CONTAINER
 						ScrollItem@SUPPORT_POWERS_PLAYER_TEMPLATE:
 							X: 0
@@ -893,32 +893,32 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 5
 									Y: 4
 									Width: 35
-									Height: PARENT_BOTTOM - 4
+									Height: PARENT_HEIGHT - 4
 									ImageName: random
 									ImageCollection: flags
 								Label@PLAYER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								ObserverSupportPowerIcons@SUPPORT_POWER_ICONS:
 									X: 160
 									Y: 0
 									Width: 0
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									TooltipContainer: TOOLTIP_CONTAINER
 						ScrollItem@ARMY_PLAYER_TEMPLATE:
 							X: 0
@@ -930,32 +930,32 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 5
 									Y: 4
 									Width: 35
-									Height: PARENT_BOTTOM - 4
+									Height: PARENT_HEIGHT - 4
 									ImageName: random
 									ImageCollection: flags
 								Label@PLAYER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								ObserverArmyIcons@ARMY_ICONS:
 									X: 160
 									Y: 0
 									Width: 0
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									TooltipContainer: TOOLTIP_CONTAINER
 						ScrollItem@COMBAT_PLAYER_TEMPLATE:
 							X: 0
@@ -967,101 +967,101 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 5
 									Y: 4
 									Width: 35
-									Height: PARENT_BOTTOM - 4
+									Height: PARENT_HEIGHT - 4
 									ImageName: random
 									ImageCollection: flags
 								Label@PLAYER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								Label@ASSETS_DESTROYED:
 									X: 160
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ASSETS_LOST:
 									X: 235
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@UNITS_KILLED:
 									X: 310
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@UNITS_DEAD:
 									X: 385
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_KILLED:
 									X: 460
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_DEAD:
 									X: 535
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ARMY_VALUE:
 									X: 610
 									Y: 0
 									Width: 90
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@VISION:
 									X: 700
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 				Container@INCOME_GRAPH_CONTAINER:
 					X: 0
 					Y: 30
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Visible: False
 					Children:
 						ColorBlock@GRAPH_BACKGROUND:
 							X: 0
 							Y: 0
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Color: 00000090
 						LineGraph@INCOME_GRAPH:
 							X: 0
 							Y: 0
-							Width: PARENT_RIGHT - 5
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH - 5
+							Height: PARENT_HEIGHT
 							ValueFormat: ${0}
 							YAxisValueFormat: ${0:F0}
 							XAxisSize: 40
@@ -1073,21 +1073,21 @@ Container@OBSERVER_WIDGETS:
 				Container@ARMY_VALUE_GRAPH_CONTAINER:
 					X: 0
 					Y: 30
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Visible: False
 					Children:
 						ColorBlock@GRAPH_BACKGROUND:
 							X: 0
 							Y: 0
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Color: 00000090
 						LineGraph@ARMY_VALUE_GRAPH:
 							X: 0
 							Y: 0
-							Width: PARENT_RIGHT - 5
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH - 5
+							Height: PARENT_HEIGHT
 							ValueFormat: ${0}
 							YAxisValueFormat: ${0:F0}
 							XAxisSize: 40
@@ -1098,6 +1098,6 @@ Container@OBSERVER_WIDGETS:
 							AxisFont: TinyBold
 		Container@HPF_ROOT:
 			Logic: LoadIngameHierarchicalPathFinderOverlayLogic
-			X: WINDOW_RIGHT - WIDTH - 255
+			X: WINDOW_WIDTH - WIDTH - 255
 			Y: 40
 			Width: 175

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -42,7 +42,7 @@ Container@PLAYER_WIDGETS:
 			Order: Descending
 		Image@COMMAND_BAR_BACKGROUND:
 			X: 5
-			Y: WINDOW_BOTTOM - HEIGHT - 5
+			Y: WINDOW_HEIGHT - HEIGHT - 5
 			Width: 434
 			Height: 44
 			ImageCollection: commandbar
@@ -51,7 +51,7 @@ Container@PLAYER_WIDGETS:
 		Container@COMMAND_BAR:
 			Logic: CommandBarLogic
 			X: 14
-			Y: WINDOW_BOTTOM - HEIGHT - 14
+			Y: WINDOW_HEIGHT - HEIGHT - 14
 			Width: 275
 			Height: 26
 			Children:
@@ -206,7 +206,7 @@ Container@PLAYER_WIDGETS:
 		Container@STANCE_BAR:
 			Logic: StanceSelectorLogic
 			X: 294
-			Y: WINDOW_BOTTOM - HEIGHT - 14
+			Y: WINDOW_HEIGHT - HEIGHT - 14
 			Width: 138
 			Height: 26
 			Children:
@@ -287,27 +287,27 @@ Container@PLAYER_WIDGETS:
 							ImageName: hold-fire
 		Container@MUTE_INDICATOR:
 			Logic: MuteIndicatorLogic
-			X: WINDOW_RIGHT - WIDTH - 260
+			X: WINDOW_WIDTH - WIDTH - 260
 			Y: 10
 			Width: 200
 			Height: 25
 			Children:
 				Image@ICON:
-					X: PARENT_RIGHT - WIDTH
+					X: PARENT_WIDTH - WIDTH
 					Y: 1
 					Width: 24
 					Height: 24
 					ImageCollection: sidebar-bits
 					ImageName: indicator-muted
 				Label@LABEL:
-					Width: PARENT_RIGHT - 30
+					Width: PARENT_WIDTH - 30
 					Height: 25
 					Align: Right
 					Text: label-mute-indicator
 					Contrast: true
 		Image@SIDEBAR_BACKGROUND_TOP:
 			Logic: AddFactionSuffixLogic
-			X: WINDOW_RIGHT - 250
+			X: WINDOW_WIDTH - 250
 			Y: 10
 			Width: 238
 			Height: 262
@@ -424,7 +424,7 @@ Container@PLAYER_WIDGETS:
 							Skippable: false
 		Container@SIDEBAR_PRODUCTION:
 			Logic: ClassicProductionLogic
-			X: WINDOW_RIGHT - 250
+			X: WINDOW_WIDTH - 250
 			Y: 300
 			Width: 238
 			Height: 250
@@ -605,7 +605,7 @@ Container@PLAYER_WIDGETS:
 									ImageName: down
 		Image@SIDEBAR_MONEYBIN:
 			Logic: AddFactionSuffixLogic
-			X: WINDOW_RIGHT - 250
+			X: WINDOW_WIDTH - 250
 			Y: 272
 			Width: 238
 			Height: 28
@@ -617,7 +617,7 @@ Container@PLAYER_WIDGETS:
 					Logic: GameTimerLogic
 					X: 3
 					Y: 3
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 23
 					Align: Center
 					Font: TinyBold
@@ -638,7 +638,7 @@ Container@PLAYER_WIDGETS:
 							ImageName: cash-normal
 				LabelWithTooltip@POWER:
 					Logic: IngamePowerCounterLogic
-					X: PARENT_RIGHT - WIDTH - 30
+					X: PARENT_WIDTH - WIDTH - 30
 					Y: 2
 					Width: 50
 					Height: 23
@@ -648,12 +648,12 @@ Container@PLAYER_WIDGETS:
 					TooltipTemplate: SIMPLE_TOOLTIP
 					Children:
 						Image@POWER_ICON:
-							X: PARENT_RIGHT + 4
+							X: PARENT_WIDTH + 4
 							Y: 4
 							ImageCollection: power-icons
 							ImageName: power-normal
 		Container@HPF_ROOT:
 			Logic: LoadIngameHierarchicalPathFinderOverlayLogic
-			X: WINDOW_RIGHT - WIDTH - 260
+			X: WINDOW_WIDTH - WIDTH - 260
 			Y: 40
 			Width: 175

--- a/mods/ts/chrome/assetbrowser.yaml
+++ b/mods/ts/chrome/assetbrowser.yaml
@@ -1,14 +1,14 @@
 Background@ASSETBROWSER_PANEL:
 	Logic: AssetBrowserLogic
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 900
 	Height: 600
 	Children:
 		LogicTicker@ANIMATION_TICKER:
 		Label@ASSETBROWSER_TITLE:
 			Y: 16
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 25
 			Font: Bold
 			Align: Center
@@ -53,11 +53,11 @@ Background@ASSETBROWSER_PANEL:
 			X: 20
 			Y: 170
 			Width: 195
-			Height: PARENT_BOTTOM - 250
+			Height: PARENT_HEIGHT - 250
 			CollapseHiddenChildren: True
 			Children:
 				ScrollItem@ASSET_TEMPLATE:
-					Width: PARENT_RIGHT - 27
+					Width: PARENT_WIDTH - 27
 					Height: 25
 					X: 2
 					Visible: false
@@ -65,12 +65,12 @@ Background@ASSETBROWSER_PANEL:
 					Children:
 						LabelWithTooltip@TITLE:
 							X: 10
-							Width: PARENT_RIGHT - 20
+							Width: PARENT_WIDTH - 20
 							Height: 25
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 		Label@SPRITE_SCALE:
-			X: PARENT_RIGHT - WIDTH - 440
+			X: PARENT_WIDTH - WIDTH - 440
 			Y: 60
 			Width: 50
 			Height: 25
@@ -78,14 +78,14 @@ Background@ASSETBROWSER_PANEL:
 			Align: Left
 			Text: label-assetbrowser-sprite-scale
 		Slider@SPRITE_SCALE_SLIDER:
-			X: PARENT_RIGHT - WIDTH - 330
+			X: PARENT_WIDTH - WIDTH - 330
 			Y: 62
 			Width: 100
 			Height: 20
 			MinimumValue: 0.5
 			MaximumValue: 4
 		Label@MODEL_SCALE:
-			X: PARENT_RIGHT - WIDTH - 440
+			X: PARENT_WIDTH - WIDTH - 440
 			Y: 60
 			Width: 50
 			Height: 25
@@ -93,14 +93,14 @@ Background@ASSETBROWSER_PANEL:
 			Align: Left
 			Text: label-assetbrowser-model-scale
 		Slider@MODEL_SCALE_SLIDER:
-			X: PARENT_RIGHT - WIDTH - 330
+			X: PARENT_WIDTH - WIDTH - 330
 			Y: 62
 			Width: 100
 			Height: 20
 			MinimumValue: 10
 			MaximumValue: 64
 		Label@PALETTE_DESC:
-			X: PARENT_RIGHT - WIDTH - 270
+			X: PARENT_WIDTH - WIDTH - 270
 			Y: 60
 			Width: 150
 			Height: 25
@@ -108,13 +108,13 @@ Background@ASSETBROWSER_PANEL:
 			Align: Right
 			Text: label-assetbrowser-palette-desc
 		DropDownButton@PALETTE_SELECTOR:
-			X: PARENT_RIGHT - WIDTH - 110
+			X: PARENT_WIDTH - WIDTH - 110
 			Y: 60
 			Width: 150
 			Height: 25
 			Font: Bold
 		DropDownButton@COLOR:
-			X: PARENT_RIGHT - WIDTH - 20
+			X: PARENT_WIDTH - WIDTH - 20
 			Y: 60
 			Width: 80
 			Height: 25
@@ -122,39 +122,39 @@ Background@ASSETBROWSER_PANEL:
 				ColorBlock@COLORBLOCK:
 					X: 5
 					Y: 6
-					Width: PARENT_RIGHT - 35
-					Height: PARENT_BOTTOM - 12
+					Width: PARENT_WIDTH - 35
+					Height: PARENT_HEIGHT - 12
 		Background@SPRITE_BG:
 			X: 226
 			Y: 90
-			Width: PARENT_RIGHT - 226 - 20
-			Height: PARENT_BOTTOM - 170
+			Width: PARENT_WIDTH - 226 - 20
+			Height: PARENT_HEIGHT - 170
 			Background: dialog3
 			Children:
 				Sprite@SPRITE:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 				VideoPlayer@PLAYER:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					AspectRatio: 1
 				Model@VOXEL:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Palette: colorpicker
 					PlayerPalette: colorpicker
 					LightPitch: 256
 					LightYaw: 0
 				Label@ERROR:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Align: Center
 					Visible: false
 					Text: label-assetbrowser-sprite-bg-error
 		Container@FRAME_SELECTOR:
 			X: 226
-			Y: PARENT_BOTTOM - 75
-			Width: PARENT_RIGHT - 226
+			Y: PARENT_HEIGHT - 75
+			Width: PARENT_WIDTH - 226
 			Children:
 				Button@BUTTON_PREV:
 					Width: 26
@@ -214,11 +214,11 @@ Background@ASSETBROWSER_PANEL:
 				Slider@FRAME_SLIDER:
 					X: 140
 					Y: 3
-					Width: PARENT_RIGHT - 140 - 85
+					Width: PARENT_WIDTH - 140 - 85
 					Height: 20
 					MinimumValue: 0
 				Label@FRAME_COUNT:
-					X: PARENT_RIGHT - WIDTH + 5
+					X: PARENT_WIDTH - WIDTH + 5
 					Y: 0
 					Width: 85
 					Height: 25
@@ -226,7 +226,7 @@ Background@ASSETBROWSER_PANEL:
 					Align: Left
 		Container@VOXEL_SELECTOR:
 			X: 226
-			Y: PARENT_BOTTOM - 75
+			Y: PARENT_HEIGHT - 75
 			Children:
 				Label@ROLL:
 					Y: 1
@@ -274,8 +274,8 @@ Background@ASSETBROWSER_PANEL:
 					MaximumValue: 1023
 		Button@CLOSE_BUTTON:
 			Key: escape
-			X: PARENT_RIGHT - 180
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - 180
+			Y: PARENT_HEIGHT - 45
 			Width: 160
 			Height: 25
 			Font: Bold
@@ -291,5 +291,5 @@ ScrollPanel@ASSET_TYPES_PANEL:
 		Checkbox@ASSET_TYPE_TEMPLATE:
 			X: 5
 			Y: 5
-			Width: PARENT_RIGHT - 29
+			Width: PARENT_WIDTH - 29
 			Height: 20

--- a/mods/ts/chrome/color-picker.yaml
+++ b/mods/ts/chrome/color-picker.yaml
@@ -23,21 +23,21 @@ Background@COLOR_CHOOSER:
 			Text: button-color-chooser-store
 			Font: Bold
 		ActorPreview@PREVIEW:
-			X: PARENT_RIGHT - 94
+			X: PARENT_WIDTH - 94
 			Y: 10
 			Width: 90
 			Height: 90
 			Animate: true
 		Button@MIXER_TAB_BUTTON:
 			X: 5
-			Y: PARENT_BOTTOM - 30
+			Y: PARENT_HEIGHT - 30
 			Height: 25
 			Width: 80
 			Text: button-color-chooser-mixer-tab
 			Font: Bold
 		Button@PALETTE_TAB_BUTTON:
 			X: 85
-			Y: PARENT_BOTTOM - 30
+			Y: PARENT_HEIGHT - 30
 			Height: 25
 			Width: 80
 			Text: button-color-chooser-palette-tab
@@ -45,63 +45,63 @@ Background@COLOR_CHOOSER:
 		Container@MIXER_TAB:
 			X: 5
 			Y: 5
-			Width: PARENT_RIGHT - 94
-			Height: PARENT_BOTTOM - 34
+			Width: PARENT_WIDTH - 94
+			Height: PARENT_HEIGHT - 34
 			Children:
 				Background@HUEBG:
 					Background: dialog3
 					X: 0
 					Y: 0
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 17
 					Children:
 						HueSlider@HUE_SLIDER:
 							X: 2
 							Y: 2
-							Width: PARENT_RIGHT - 4
-							Height: PARENT_BOTTOM - 4
+							Width: PARENT_WIDTH - 4
+							Height: PARENT_HEIGHT - 4
 							Ticks: 5
 				Background@MIXERBG:
 					Background: dialog3
 					X: 0
 					Y: 22
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM - 22
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT - 22
 					Children:
 						ColorMixer@MIXER:
 							X: 2
 							Y: 2
-							Width: PARENT_RIGHT - 4
-							Height: PARENT_BOTTOM - 4
+							Width: PARENT_WIDTH - 4
+							Height: PARENT_HEIGHT - 4
 		Background@PALETTE_TAB:
 			Background: dialog3
 			X: 5
 			Y: 5
-			Width: PARENT_RIGHT - 94
-			Height: PARENT_BOTTOM - 34
+			Width: PARENT_WIDTH - 94
+			Height: PARENT_HEIGHT - 34
 			Visible: false
 			Children:
 				Container@PALETTE_TAB_PANEL:
 					X: 0
 					Y: 0
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						Background@PRESET_HEADER:
 							Background: dialog2
-							Width: PARENT_RIGHT - 4
+							Width: PARENT_WIDTH - 4
 							Height: 13
 							X: 2
 							Y: 2
 							Children:
 								Label@LABEL:
 									Font: TinyBold
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 13
 									Align: Center
 									Text: label-preset-header
 						Container@PRESET_AREA:
-							Width: PARENT_RIGHT - 4
+							Width: PARENT_WIDTH - 4
 							Height: 58
 							X: 2
 							Y: 16
@@ -115,19 +115,19 @@ Background@COLOR_CHOOSER:
 									ClickSound: ClickSound
 						Background@CUSTOM_HEADER:
 							Background: dialog2
-							Width: PARENT_RIGHT - 4
+							Width: PARENT_WIDTH - 4
 							Height: 13
 							X: 2
 							Y: 75
 							Children:
 								Label@LABEL:
 									Font: TinyBold
-									Width: PARENT_RIGHT
+									Width: PARENT_WIDTH
 									Height: 13
 									Align: Center
 									Text: label-custom-header
 						Container@CUSTOM_AREA:
-							Width: PARENT_RIGHT - 4
+							Width: PARENT_WIDTH - 4
 							Height: 31
 							X: 2
 							Y: 89

--- a/mods/ts/chrome/dropdowns.yaml
+++ b/mods/ts/chrome/dropdowns.yaml
@@ -3,7 +3,7 @@ ScrollPanel@LABEL_DROPDOWN_TEMPLATE:
 	Children:
 		ScrollItem@HEADER:
 			Background: scrollheader
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 13
 			X: 2
 			Y: 0
@@ -11,11 +11,11 @@ ScrollPanel@LABEL_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					Font: TinyBold
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 13
 					Align: Center
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -23,14 +23,14 @@ ScrollPanel@LABEL_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					X: 10
-					Width: PARENT_RIGHT - 20
+					Width: PARENT_WIDTH - 20
 					Height: 25
 
 ScrollPanel@TEAM_DROPDOWN_TEMPLATE:
 	Width: DROPDOWN_WIDTH
 	Children:
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -38,7 +38,7 @@ ScrollPanel@TEAM_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					X: 0
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 
@@ -46,7 +46,7 @@ ScrollPanel@SPAWN_DROPDOWN_TEMPLATE:
 	Width: DROPDOWN_WIDTH
 	Children:
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -54,7 +54,7 @@ ScrollPanel@SPAWN_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					X: 0
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 
@@ -62,7 +62,7 @@ ScrollPanel@PLAYERACTION_DROPDOWN_TEMPLATE:
 	Width: DROPDOWN_WIDTH
 	Children:
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -70,7 +70,7 @@ ScrollPanel@PLAYERACTION_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					X: 10
-					Width: PARENT_RIGHT - 20
+					Width: PARENT_WIDTH - 20
 					Height: 25
 					Align: Left
 
@@ -79,7 +79,7 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 	Children:
 		ScrollItem@HEADER:
 			Background: scrollheader
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 13
 			X: 2
 			Y: 0
@@ -87,11 +87,11 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 			Children:
 				Label@LABEL:
 					Font: TinyBold
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 13
 					Align: Center
 		ScrollItem@TEMPLATE:
-			Width: PARENT_RIGHT - 27
+			Width: PARENT_WIDTH - 27
 			Height: 25
 			X: 2
 			Y: 0
@@ -104,12 +104,12 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 					Height: 16
 				Label@LABEL:
 					X: 40
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Shadow: True
 				Label@NOFLAG_LABEL:
 					X: 5
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Shadow: True
 
@@ -122,27 +122,27 @@ ScrollPanel@NEWS_PANEL:
 		Container@NEWS_ITEM_TEMPLATE:
 			X: 10
 			Y: 6
-			Width: PARENT_RIGHT - 40
+			Width: PARENT_WIDTH - 40
 			Height: 45
 			Children:
 				Label@TITLE:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 25
 					Align: Center
 					Font: Bold
 				Label@AUTHOR_DATETIME:
 					Y: 25
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 15
 					Align: Center
 					Font: TinyBold
 				Label@CONTENT:
 					Y: 45
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 		Label@NEWS_STATUS:
 			X: 80
 			Y: 1
-			Width: PARENT_RIGHT - 80 - 80 - 24
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH - 80 - 80 - 24
+			Height: PARENT_HEIGHT
 			Align: Center
 			VAlign: Middle

--- a/mods/ts/chrome/ingame-debug.yaml
+++ b/mods/ts/chrome/ingame-debug.yaml
@@ -1,15 +1,15 @@
 Container@DEBUG_PANEL:
 	Logic: DebugMenuLogic
 	Y: 10
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		Label@TITLE:
 			Y: 16
 			Font: Bold
 			Text: label-debug-panel-title
 			Align: Center
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 20
 		Checkbox@INSTANT_BUILD:
 			X: 45
@@ -86,7 +86,7 @@ Container@DEBUG_PANEL:
 			Font: Bold
 			Text: label-debug-panel-visualizations-title
 			Align: Center
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Height: 20
 		Checkbox@SHOW_UNIT_PATHS:
 			X: 45

--- a/mods/ts/chrome/ingame-observer.yaml
+++ b/mods/ts/chrome/ingame-observer.yaml
@@ -5,20 +5,20 @@ Container@OBSERVER_WIDGETS:
 		LogicKeyListener@OBSERVER_KEY_LISTENER:
 		Container@MUTE_INDICATOR:
 			Logic: MuteIndicatorLogic
-			X: WINDOW_RIGHT - WIDTH - 260
+			X: WINDOW_WIDTH - WIDTH - 260
 			Y: 5
 			Width: 200
 			Height: 25
 			Children:
 				Image@ICON:
-					X: PARENT_RIGHT - WIDTH
+					X: PARENT_WIDTH - WIDTH
 					Y: 1
 					Width: 24
 					Height: 24
 					ImageCollection: sidebar-bits
 					ImageName: indicator-muted
 				Label@LABEL:
-					Width: PARENT_RIGHT - 30
+					Width: PARENT_WIDTH - 30
 					Height: 25
 					Align: Right
 					Text: label-mute-indicator
@@ -34,12 +34,12 @@ Container@OBSERVER_WIDGETS:
 			DisableWorldSounds: true
 		Container@GAME_TIMER_BLOCK:
 			Logic: GameTimerLogic
-			X: (WINDOW_RIGHT - WIDTH) / 2
+			X: (WINDOW_WIDTH - WIDTH) / 2
 			Width: 100
 			Height: 55
 			Children:
 				LabelWithTooltip@GAME_TIMER:
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 30
 					Align: Center
 					Font: Title
@@ -48,13 +48,13 @@ Container@OBSERVER_WIDGETS:
 					TooltipTemplate: SIMPLE_TOOLTIP
 				Label@GAME_TIMER_STATUS:
 					Y: 32
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 15
 					Align: Center
 					Font: Bold
 					Contrast: true
 		Background@RADAR_BG:
-			X: WINDOW_RIGHT - 255
+			X: WINDOW_WIDTH - 255
 			Y: 5
 			Width: 250
 			Height: 250
@@ -62,17 +62,17 @@ Container@OBSERVER_WIDGETS:
 				Radar@INGAME_RADAR:
 					X: 10
 					Y: 10
-					Width: PARENT_RIGHT - 19
-					Height: PARENT_BOTTOM - 19
+					Width: PARENT_WIDTH - 19
+					Height: PARENT_HEIGHT - 19
 					WorldInteractionController: INTERACTION_CONTROLLER
 				VideoPlayer@PLAYER:
 					X: 10
 					Y: 10
-					Width: PARENT_RIGHT - 20
-					Height: PARENT_BOTTOM - 20
+					Width: PARENT_WIDTH - 20
+					Height: PARENT_HEIGHT - 20
 					Skippable: false
 		Background@OBSERVER_CONTROL_BG:
-			X: WINDOW_RIGHT - 255
+			X: WINDOW_WIDTH - 255
 			Y: 260
 			Width: 250
 			Height: 55
@@ -95,12 +95,12 @@ Container@OBSERVER_WIDGETS:
 							Y: 5
 						Label@LABEL:
 							X: 34
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 25
 							Shadow: True
 						Label@NOFLAG_LABEL:
 							X: 5
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 25
 							Shadow: True
 				Container@REPLAY_PLAYER:
@@ -207,33 +207,33 @@ Container@OBSERVER_WIDGETS:
 				Container@GRAPH_BG:
 					Y: 30
 					X: 0
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 24
 					Children:
 						Container@BASIC_STATS_HEADERS:
 							X: 0
 							Y: 0
 							Width: 705
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-player-header
 									Align: Left
@@ -242,7 +242,7 @@ Container@OBSERVER_WIDGETS:
 									X: 160
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-cash-header
 									Align: Right
@@ -251,7 +251,7 @@ Container@OBSERVER_WIDGETS:
 									X: 240
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-power-header
 									Align: Center
@@ -260,7 +260,7 @@ Container@OBSERVER_WIDGETS:
 									X: 320
 									Y: 0
 									Width: 40
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-kills-header
 									Align: Right
@@ -269,7 +269,7 @@ Container@OBSERVER_WIDGETS:
 									X: 360
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-deaths-header
 									Align: Right
@@ -278,7 +278,7 @@ Container@OBSERVER_WIDGETS:
 									X: 420
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-assets-destroyed-header
 									Align: Right
@@ -287,7 +287,7 @@ Container@OBSERVER_WIDGETS:
 									X: 500
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-assets-lost-header
 									Align: Right
@@ -296,7 +296,7 @@ Container@OBSERVER_WIDGETS:
 									X: 580
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-experience-header
 									Align: Right
@@ -305,7 +305,7 @@ Container@OBSERVER_WIDGETS:
 									X: 640
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-basic-stats-actions-min-header
 									Align: Right
@@ -314,32 +314,32 @@ Container@OBSERVER_WIDGETS:
 							X: 0
 							Y: 0
 							Width: 645
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 40
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-player-header
 									Shadow: True
 								Label@CASH_HEADER:
 									X: 160
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-cash-header
 									Align: Right
@@ -347,7 +347,7 @@ Container@OBSERVER_WIDGETS:
 								Label@INCOME_HEADER:
 									X: 240
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-income-header
 									Align: Right
@@ -355,7 +355,7 @@ Container@OBSERVER_WIDGETS:
 								Label@ASSETS_HEADER:
 									X: 320
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-assets-header
 									Align: Right
@@ -363,7 +363,7 @@ Container@OBSERVER_WIDGETS:
 								Label@EARNED_HEADER:
 									X: 400
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-earned-header
 									Align: Right
@@ -371,7 +371,7 @@ Container@OBSERVER_WIDGETS:
 								Label@SPENT_HEADER:
 									X: 480
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-spent-header
 									Align: Right
@@ -379,7 +379,7 @@ Container@OBSERVER_WIDGETS:
 								Label@HARVESTERS_HEADER:
 									X: 560
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-economy-stats-harvesters-header
 									Align: Right
@@ -388,26 +388,26 @@ Container@OBSERVER_WIDGETS:
 							X: 0
 							Y: 0
 							Width: 400
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-production-stats-player-header
 									Align: Left
@@ -416,7 +416,7 @@ Container@OBSERVER_WIDGETS:
 									X: 160
 									Y: 0
 									Width: 100
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-production-stats-header
 									Shadow: True
@@ -424,26 +424,26 @@ Container@OBSERVER_WIDGETS:
 							X: 0
 							Y: 0
 							Width: 400
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-support-powers-player-header
 									Align: Left
@@ -452,7 +452,7 @@ Container@OBSERVER_WIDGETS:
 									X: 160
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-support-powers-header
 									Shadow: True
@@ -460,26 +460,26 @@ Container@OBSERVER_WIDGETS:
 							X: 0
 							Y: 0
 							Width: 400
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-army-player-header
 									Align: Left
@@ -488,7 +488,7 @@ Container@OBSERVER_WIDGETS:
 									X: 160
 									Y: 0
 									Width: 100
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-army-header
 									Shadow: True
@@ -496,26 +496,26 @@ Container@OBSERVER_WIDGETS:
 							X: 0
 							Y: 0
 							Width: 760
-							Height: PARENT_BOTTOM
+							Height: PARENT_HEIGHT
 							Children:
 								ColorBlock@HEADER_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@HEADER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@PLAYER_HEADER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-player-header
 									Align: Left
@@ -524,7 +524,7 @@ Container@OBSERVER_WIDGETS:
 									X: 160
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-assets-destroyed-header
 									Align: Right
@@ -533,7 +533,7 @@ Container@OBSERVER_WIDGETS:
 									X: 235
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-assets-lost-header
 									Align: Right
@@ -542,7 +542,7 @@ Container@OBSERVER_WIDGETS:
 									X: 310
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-units-killed-header
 									Align: Right
@@ -551,7 +551,7 @@ Container@OBSERVER_WIDGETS:
 									X: 385
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-units-dead-header
 									Align: Right
@@ -560,7 +560,7 @@ Container@OBSERVER_WIDGETS:
 									X: 460
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-buildings-killed-header
 									Align: Right
@@ -569,7 +569,7 @@ Container@OBSERVER_WIDGETS:
 									X: 535
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-buildings-dead-header
 									Align: Right
@@ -578,7 +578,7 @@ Container@OBSERVER_WIDGETS:
 									X: 610
 									Y: 0
 									Width: 90
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-army-value-header
 									Align: Right
@@ -587,7 +587,7 @@ Container@OBSERVER_WIDGETS:
 									X: 700
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Text: label-combat-stats-vision-header
 									Align: Right
@@ -595,7 +595,7 @@ Container@OBSERVER_WIDGETS:
 				ScrollPanel@PLAYER_STATS_PANEL:
 					X: 0
 					Y: 54
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 240
 					TopBottomSpacing: 0
 					BorderWidth: 0
@@ -606,27 +606,27 @@ Container@OBSERVER_WIDGETS:
 						ScrollItem@TEAM_TEMPLATE:
 							X: 0
 							Y: 0
-							Width: 650 #PARENT_RIGHT - 35
+							Width: 650 #PARENT_WIDTH - 35
 							Height: 24
 							Children:
 								ColorBlock@TEAM_COLOR:
 									X: 0
 									Y: 0
 									Color: 00000090
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@TEAM_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									TopLeftColor: 00000090
 									BottomLeftColor: 00000090
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Label@TEAM:
 									X: 10
 									Y: 0
-									Width: PARENT_RIGHT
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 						ScrollItem@BASIC_PLAYER_TEMPLATE:
@@ -639,81 +639,81 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 5
 									Y: 4
 									Width: 35
-									Height: PARENT_BOTTOM - 4
+									Height: PARENT_HEIGHT - 4
 									ImageName: random
 									ImageCollection: flags
 								Label@PLAYER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								Label@CASH:
 									X: 160
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@POWER:
 									X: 240
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Center
 									Shadow: True
 								Label@KILLS:
 									X: 320
 									Y: 0
 									Width: 40
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@DEATHS:
 									X: 360
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ASSETS_DESTROYED:
 									X: 420
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ASSETS_LOST:
 									X: 500
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@EXPERIENCE:
 									X: 580
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ACTIONS_MIN:
 									X: 640
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 						ScrollItem@ECONOMY_PLAYER_TEMPLATE:
@@ -726,67 +726,67 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 5
 									Y: 4
 									Width: 35
-									Height: PARENT_BOTTOM - 4
+									Height: PARENT_HEIGHT - 4
 									ImageName: random
 									ImageCollection: flags
 								Label@PLAYER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								Label@CASH:
 									X: 160
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@INCOME:
 									X: 240
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ASSETS:
 									X: 320
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@EARNED:
 									X: 400
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@SPENT:
 									X: 480
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@HARVESTERS:
 									X: 560
 									Y: 0
 									Width: 80
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 						ScrollItem@PRODUCTION_PLAYER_TEMPLATE:
@@ -799,32 +799,32 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 5
 									Y: 4
 									Width: 35
-									Height: PARENT_BOTTOM - 4
+									Height: PARENT_HEIGHT - 4
 									ImageName: random
 									ImageCollection: flags
 								Label@PLAYER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								ObserverProductionIcons@PRODUCTION_ICONS:
 									X: 160
 									Y: 0
 									Width: 0
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									TooltipContainer: TOOLTIP_CONTAINER
 									ClockPalette: iconclock
 						ScrollItem@SUPPORT_POWERS_PLAYER_TEMPLATE:
@@ -837,32 +837,32 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 5
 									Y: 4
 									Width: 35
-									Height: PARENT_BOTTOM - 4
+									Height: PARENT_HEIGHT - 4
 									ImageName: random
 									ImageCollection: flags
 								Label@PLAYER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								ObserverSupportPowerIcons@SUPPORT_POWER_ICONS:
 									X: 160
 									Y: 0
 									Width: 0
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									ClockPalette: iconclock
 									TooltipContainer: TOOLTIP_CONTAINER
 						ScrollItem@ARMY_PLAYER_TEMPLATE:
@@ -875,32 +875,32 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 5
 									Y: 4
 									Width: 35
-									Height: PARENT_BOTTOM - 4
+									Height: PARENT_HEIGHT - 4
 									ImageName: random
 									ImageCollection: flags
 								Label@PLAYER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								ObserverArmyIcons@ARMY_ICONS:
 									X: 160
 									Y: 0
 									Width: 0
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									TooltipContainer: TOOLTIP_CONTAINER
 						ScrollItem@COMBAT_PLAYER_TEMPLATE:
 							X: 0
@@ -912,101 +912,101 @@ Container@OBSERVER_WIDGETS:
 								ColorBlock@PLAYER_COLOR:
 									X: 0
 									Y: 0
-									Width: PARENT_RIGHT - 200
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
 								GradientColorBlock@PLAYER_GRADIENT:
-									X: PARENT_RIGHT - 200
+									X: PARENT_WIDTH - 200
 									Y: 0
 									Width: 200
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 								Image@FLAG:
 									X: 5
 									Y: 4
 									Width: 35
-									Height: PARENT_BOTTOM - 4
+									Height: PARENT_HEIGHT - 4
 									ImageName: random
 									ImageCollection: flags
 								Label@PLAYER:
 									X: 40
 									Y: 0
 									Width: 120
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Font: Bold
 									Shadow: True
 								Label@ASSETS_DESTROYED:
 									X: 160
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ASSETS_LOST:
 									X: 235
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@UNITS_KILLED:
 									X: 310
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@UNITS_DEAD:
 									X: 385
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_KILLED:
 									X: 460
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@BUILDINGS_DEAD:
 									X: 535
 									Y: 0
 									Width: 75
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@ARMY_VALUE:
 									X: 610
 									Y: 0
 									Width: 90
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 								Label@VISION:
 									X: 700
 									Y: 0
 									Width: 60
-									Height: PARENT_BOTTOM
+									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
 				Container@INCOME_GRAPH_CONTAINER:
 					X: 0
 					Y: 30
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Visible: False
 					Children:
 						ColorBlock@GRAPH_BACKGROUND:
 							X: 0
 							Y: 0
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Color: 00000090
 						LineGraph@INCOME_GRAPH:
 							X: 0
 							Y: 0
-							Width: PARENT_RIGHT - 5
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH - 5
+							Height: PARENT_HEIGHT
 							ValueFormat: ${0}
 							YAxisValueFormat: ${0:F0}
 							XAxisSize: 40
@@ -1018,21 +1018,21 @@ Container@OBSERVER_WIDGETS:
 				Container@ARMY_VALUE_GRAPH_CONTAINER:
 					X: 0
 					Y: 30
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Visible: False
 					Children:
 						ColorBlock@GRAPH_BACKGROUND:
 							X: 0
 							Y: 0
-							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
 							Color: 00000090
 						LineGraph@ARMY_VALUE_GRAPH:
 							X: 0
 							Y: 0
-							Width: PARENT_RIGHT - 5
-							Height: PARENT_BOTTOM
+							Width: PARENT_WIDTH - 5
+							Height: PARENT_HEIGHT
 							ValueFormat: ${0}
 							YAxisValueFormat: ${0:F0}
 							XAxisSize: 40
@@ -1043,6 +1043,6 @@ Container@OBSERVER_WIDGETS:
 							AxisFont: TinyBold
 		Container@HPF_ROOT:
 			Logic: LoadIngameHierarchicalPathFinderOverlayLogic
-			X: WINDOW_RIGHT - WIDTH - 260
+			X: WINDOW_WIDTH - WIDTH - 260
 			Y: 40
 			Width: 175

--- a/mods/ts/chrome/ingame-player.yaml
+++ b/mods/ts/chrome/ingame-player.yaml
@@ -36,7 +36,7 @@ Container@PLAYER_WIDGETS:
 		Image@COMMAND_BAR_BACKGROUND:
 			Logic: AddFactionSuffixLogic
 			X: 5
-			Y: WINDOW_BOTTOM - HEIGHT - 5
+			Y: WINDOW_HEIGHT - HEIGHT - 5
 			Width: 449
 			Height: 51
 			ImageCollection: sidebar
@@ -46,7 +46,7 @@ Container@PLAYER_WIDGETS:
 			Logic: CommandBarLogic
 				HighlightOnButtonPress: True
 			X: 19
-			Y: WINDOW_BOTTOM - HEIGHT - 20
+			Y: WINDOW_HEIGHT - HEIGHT - 20
 			Width: 275
 			Height: 26
 			Children:
@@ -201,7 +201,7 @@ Container@PLAYER_WIDGETS:
 		Container@STANCE_BAR:
 			Logic: StanceSelectorLogic
 			X: 306
-			Y: WINDOW_BOTTOM - HEIGHT - 20
+			Y: WINDOW_HEIGHT - HEIGHT - 20
 			Width: 138
 			Height: 26
 			Children:
@@ -282,27 +282,27 @@ Container@PLAYER_WIDGETS:
 							ImageName: hold-fire
 		Container@MUTE_INDICATOR:
 			Logic: MuteIndicatorLogic
-			X: WINDOW_RIGHT - WIDTH - 245
+			X: WINDOW_WIDTH - WIDTH - 245
 			Y: 5
 			Width: 200
 			Height: 25
 			Children:
 				Image@ICON:
-					X: PARENT_RIGHT - WIDTH
+					X: PARENT_WIDTH - WIDTH
 					Y: 1
 					Width: 24
 					Height: 24
 					ImageCollection: sidebar-bits
 					ImageName: indicator-muted
 				Label@LABEL:
-					Width: PARENT_RIGHT - 30
+					Width: PARENT_WIDTH - 30
 					Height: 25
 					Align: Right
 					Text: label-mute-indicator
 					Contrast: true
 		Image@SIDEBAR_BACKGROUND_TOP:
 			Logic: AddFactionSuffixLogic
-			X: WINDOW_RIGHT - 235
+			X: WINDOW_WIDTH - 235
 			Y: 0
 			Width: 235
 			Height: 260
@@ -430,7 +430,7 @@ Container@PLAYER_WIDGETS:
 					Logic: GameTimerLogic
 					X: 10
 					Y: 1
-					Width: PARENT_RIGHT
+					Width: PARENT_WIDTH
 					Height: 22
 					Align: Center
 					Font: TinyBold
@@ -451,7 +451,7 @@ Container@PLAYER_WIDGETS:
 							ImageName: cash-normal
 				LabelWithTooltip@POWER:
 					Logic: IngamePowerCounterLogic
-					X: PARENT_RIGHT - WIDTH - 30
+					X: PARENT_WIDTH - WIDTH - 30
 					Y: 0
 					Width: 50
 					Height: 22
@@ -461,13 +461,13 @@ Container@PLAYER_WIDGETS:
 					TooltipTemplate: SIMPLE_TOOLTIP
 					Children:
 						Image@POWER_ICON:
-							X: PARENT_RIGHT + 0
+							X: PARENT_WIDTH + 0
 							Y: 3
 							ImageCollection: power-icons
 							ImageName: power-normal
 		Container@SIDEBAR_PRODUCTION:
 			Logic: ClassicProductionLogic
-			X: WINDOW_RIGHT - 235
+			X: WINDOW_WIDTH - 235
 			Y: 260
 			Width: 235
 			Height: 250
@@ -600,7 +600,7 @@ Container@PLAYER_WIDGETS:
 						Button@SCROLL_UP_BUTTON:
 							Logic: AddFactionSuffixLogic
 							X: 74
-							Y: PARENT_BOTTOM + 36
+							Y: PARENT_HEIGHT + 36
 							Width: 34
 							Height: 27
 							VisualHeight: 0
@@ -610,7 +610,7 @@ Container@PLAYER_WIDGETS:
 						Button@SCROLL_DOWN_BUTTON:
 							Logic: AddFactionSuffixLogic
 							X: 141
-							Y: PARENT_BOTTOM + 36
+							Y: PARENT_HEIGHT + 36
 							Width: 34
 							Height: 27
 							VisualHeight: 0
@@ -619,6 +619,6 @@ Container@PLAYER_WIDGETS:
 							TooltipContainer: TOOLTIP_CONTAINER
 		Container@HPF_ROOT:
 			Logic: LoadIngameHierarchicalPathFinderOverlayLogic
-			X: WINDOW_RIGHT - WIDTH - 245
+			X: WINDOW_WIDTH - WIDTH - 245
 			Y: 40
 			Width: 175

--- a/mods/ts/chrome/ingame-transients.yaml
+++ b/mods/ts/chrome/ingame-transients.yaml
@@ -1,13 +1,13 @@
 Container@TRANSIENTS_PANEL:
 	X: 5
-	Y: WINDOW_BOTTOM - HEIGHT - 65
+	Y: WINDOW_HEIGHT - HEIGHT - 65
 	Width: 550
 	Height: 80
 	Logic: IngameTransientNotificationsLogic
 	Children:
 		TextNotificationsDisplay@TRANSIENTS_DISPLAY:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			DisplayDurationMs: 4000
 			LogLength: 5
 			HideOverflow: False

--- a/mods/ts/chrome/mainmenu-prerelease-notification.yaml
+++ b/mods/ts/chrome/mainmenu-prerelease-notification.yaml
@@ -1,12 +1,12 @@
 Background@MAINMENU_PRERELEASE_NOTIFICATION:
 	Logic: PreReleaseWarningPrompt
-	X: (WINDOW_RIGHT - WIDTH) / 2
-	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 520
 	Height: 195
 	Children:
 		Label@PROMPT_TITLE:
-			Width: PARENT_RIGHT
+			Width: PARENT_WIDTH
 			Y: 20
 			Height: 25
 			Font: Bold
@@ -15,40 +15,40 @@ Background@MAINMENU_PRERELEASE_NOTIFICATION:
 		Label@PROMPT_TEXT_A:
 			X: 15
 			Y: 50
-			Width: PARENT_RIGHT - 30
+			Width: PARENT_WIDTH - 30
 			Height: 16
 			Align: Center
 			Text: label-mainmenu-prerelease-notification-prompt-text-a
 		Label@PROMPT_TEXT_B:
 			X: 15
 			Y: 68
-			Width: PARENT_RIGHT - 30
+			Width: PARENT_WIDTH - 30
 			Height: 16
 			Align: Center
 			Text: label-mainmenu-prerelease-notification-prompt-text-b
 		Label@PROMPT_TEXT_C:
 			X: 15
 			Y: 104
-			Width: PARENT_RIGHT - 30
+			Width: PARENT_WIDTH - 30
 			Height: 16
 			Align: Center
 			Text: label-mainmenu-prerelease-notification-prompt-text-c
 		Label@PROMPT_TEXT_D:
 			X: 15
 			Y: 122
-			Width: PARENT_RIGHT - 30
+			Width: PARENT_WIDTH - 30
 			Height: 16
 			Align: Center
 			Text: label-mainmenu-prerelease-notification-prompt-text-d
 		Label@PROMPT_TEXT_E:
 			X: 15
 			Y: 140
-			Width: PARENT_RIGHT - 30
+			Width: PARENT_WIDTH - 30
 			Height: 16
 			Align: Center
 		Button@CONTINUE_BUTTON:
-			X: PARENT_RIGHT - WIDTH - 20
-			Y: PARENT_BOTTOM - 45
+			X: PARENT_WIDTH - WIDTH - 20
+			Y: PARENT_HEIGHT - 45
 			Width: 120
 			Height: 25
 			Text: button-mainmenu-prerelease-notification-continue

--- a/mods/ts/chrome/settings-hotkeys.yaml
+++ b/mods/ts/chrome/settings-hotkeys.yaml
@@ -25,8 +25,8 @@ Container@HOTKEYS_PANEL:
 				Types: Editor
 			Depth Preview Debug:
 				Types: DepthDebug
-	Width: PARENT_RIGHT
-	Height: PARENT_BOTTOM
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
 	Children:
 		Label@FILTER_INPUT_LABEL:
 			Width: 103
@@ -38,72 +38,72 @@ Container@HOTKEYS_PANEL:
 			Width: 180
 			Height: 25
 		Label@CONTEXT_DROPDOWN_LABEL:
-			X: PARENT_RIGHT - WIDTH - 195 - 5
+			X: PARENT_WIDTH - WIDTH - 195 - 5
 			Width: 100
 			Height: 25
 			Font: Bold
 			Text: label-hotkeys-panel-context-dropdown
 			Align: Right
 		DropDownButton@CONTEXT_DROPDOWN:
-			X: PARENT_RIGHT - WIDTH
+			X: PARENT_WIDTH - WIDTH
 			Width: 195
 			Height: 25
 			Font: Bold
 		ScrollPanel@HOTKEY_LIST:
 			Y: 35
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM - 65 - 35
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT - 65 - 35
 			TopBottomSpacing: 5
 			ItemSpacing: 5
 			Children:
 				Container@HEADER:
-					Width: PARENT_RIGHT - 24 - 10
+					Width: PARENT_WIDTH - 24 - 10
 					Height: 18
 					Children:
 						Background@BACKGROUND:
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 13
 							Background: separator
 							ClickThrough: True
 						Label@LABEL:
-							Width: PARENT_RIGHT
+							Width: PARENT_WIDTH
 							Height: 13
 							Font: TinyBold
 							Align: Center
 				Container@TEMPLATE:
-					Width: (PARENT_RIGHT - 24) / 2 - 10
+					Width: (PARENT_WIDTH - 24) / 2 - 10
 					Height: 30
 					Visible: false
 					Children:
 						Label@FUNCTION:
 							Y: 0 - 1
-							Width: PARENT_RIGHT - 120 - 5
+							Width: PARENT_WIDTH - 120 - 5
 							Height: 25
 							Align: Right
 						Button@HOTKEY:
-							X: PARENT_RIGHT - WIDTH
+							X: PARENT_WIDTH - WIDTH
 							Width: 120
 							Height: 25
 							TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 		Container@HOTKEY_EMPTY_LIST:
-			Width: PARENT_RIGHT
-			Height: PARENT_BOTTOM
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
 			Visible: false
 			Children:
 				Label@HOTKEY_EMPTY_LIST_MESSAGE:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Align: Center
 					Text: label-hotkey-empty-list-message
 		Background@HOTKEY_REMAP_BGND:
-			Y: PARENT_BOTTOM - HEIGHT
-			Width: PARENT_RIGHT
+			Y: PARENT_HEIGHT - HEIGHT
+			Width: PARENT_WIDTH
 			Height: 65
 			Background: dialog3
 			Children:
 				Container@HOTKEY_REMAP_DIALOG:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 					Children:
 						Label@HOTKEY_LABEL:
 							X: 15
@@ -124,27 +124,27 @@ Container@HOTKEYS_PANEL:
 							Height: 25
 							Children:
 								Label@ORIGINAL_NOTICE:
-									Width: PARENT_RIGHT
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
 									Font: Tiny
 								Label@DUPLICATE_NOTICE:
-									Width: PARENT_RIGHT
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
 									Font: Tiny
 								Label@READONLY_NOTICE:
-									Width: PARENT_RIGHT
-									Height: PARENT_BOTTOM
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
 									Font: Tiny
 									Text: label-notices-readonly-notice
 						Button@OVERRIDE_HOTKEY_BUTTON:
-							X: PARENT_RIGHT - 3 * WIDTH - 30
+							X: PARENT_WIDTH - 3 * WIDTH - 30
 							Y: 20
 							Width: 70
 							Height: 25
 							Text: button-hotkey-remap-dialog-override
 							Font: Bold
 						Button@CLEAR_HOTKEY_BUTTON:
-							X: PARENT_RIGHT - 2 * WIDTH - 30
+							X: PARENT_WIDTH - 2 * WIDTH - 30
 							Y: 20
 							Width: 65
 							Height: 25
@@ -154,7 +154,7 @@ Container@HOTKEYS_PANEL:
 							TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 						Button@RESET_HOTKEY_BUTTON:
-							X: PARENT_RIGHT - WIDTH - 20
+							X: PARENT_WIDTH - WIDTH - 20
 							Y: 20
 							Width: 65
 							Height: 25


### PR DESCRIPTION
The terms "width" and "height" are clearer and they match what the values actually represent (window or parent width/height). The YAML changes are generated with the update rule.