### PR TITLE
Improve NAT logging

### DIFF
--- a/OpenRA.Game/Network/Nat.cs
+++ b/OpenRA.Game/Network/Nat.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Network
 			}
 			catch (Exception e)
 			{
-				Console.WriteLine("Port forwarding failed: {0}", e.Message);
+				Log.Write("nat", $"Port forwarding failed: {e.Message}");
 				Log.Write("nat", e.StackTrace);
 				return false;
 			}
@@ -90,7 +90,7 @@ namespace OpenRA.Network
 			}
 			catch (Exception e)
 			{
-				Console.WriteLine("Port removal failed: {0}", e.Message);
+				Log.Write("nat", $"Port removal failed: {e.Message}");
 				Log.Write("nat", e.StackTrace);
 				return false;
 			}

--- a/OpenRA.Game/Network/Nat.cs
+++ b/OpenRA.Game/Network/Nat.cs
@@ -71,8 +71,8 @@ namespace OpenRA.Network
 			}
 			catch (Exception e)
 			{
-				Log.Write("nat", $"Port forwarding failed: {e.Message}");
-				Log.Write("nat", e.StackTrace);
+				Log.Write("nat", "Port forwarding failed.");
+				Log.Write("nat", e);
 				return false;
 			}
 
@@ -90,8 +90,8 @@ namespace OpenRA.Network
 			}
 			catch (Exception e)
 			{
-				Log.Write("nat", $"Port removal failed: {e.Message}");
-				Log.Write("nat", e.StackTrace);
+				Log.Write("nat", "Port removal failed.");
+				Log.Write("nat", e);
 				return false;
 			}
 


### PR DESCRIPTION
Ordinary people usually do not run game from terminal. If an NAT error occurs, user does not see the root cause from logs. Unfortunately, stack traces do not report the issue of failure.

If change is worthy of mentioning, I would add following ChangeLog entry under General improvements:
  * Improve NAT troubleshooting log messages

Log before change:
```
Device found: 192.168.1.1:2828
Type: Upnp
   at Mono.Nat.Upnp.ResponseMessage.Decode(UpnpNatDevice device, String message)
   at Mono.Nat.Upnp.UpnpNatDevice.DecodeMessageFromResponse(Stream s, Int32 length)
   at Mono.Nat.Upnp.UpnpNatDevice.SendMessageAsync(RequestMessage message)
   at Mono.Nat.Upnp.UpnpNatDevice.CreatePortMapAsync(Mapping mapping)
   at Mono.Nat.NatDeviceExtensions.CreatePortMap(INatDevice device, Mapping mapping)
   at OpenRA.Network.Nat.TryForwardPort(Int32 listen, Int32 external) in /home/mastermind/Apps/OpenRA/OpenRA.Game/Network/Nat.cs:line 70
   at Mono.Nat.Upnp.ResponseMessage.Decode(UpnpNatDevice device, String message)
   at Mono.Nat.Upnp.UpnpNatDevice.DecodeMessageFromResponse(Stream s, Int32 length)
   at Mono.Nat.Upnp.UpnpNatDevice.SendMessageAsync(RequestMessage message)
   at Mono.Nat.Upnp.UpnpNatDevice.DeletePortMapAsync(Mapping mapping)
   at Mono.Nat.NatDeviceExtensions.DeletePortMap(INatDevice device, Mapping mapping)
   at OpenRA.Network.Nat.TryRemovePortForward() in /home/mastermind/Apps/OpenRA/OpenRA.Game/Network/Nat.cs:line 89
```

Log after change:
```
Device found: 192.168.1.1:2828
Type: Upnp
Port forwarding failed: Error 725: OnlyPermanentLeasesSupported
   at Mono.Nat.Upnp.ResponseMessage.Decode(UpnpNatDevice device, String message)
   at Mono.Nat.Upnp.UpnpNatDevice.DecodeMessageFromResponse(Stream s, Int32 length)
   at Mono.Nat.Upnp.UpnpNatDevice.SendMessageAsync(RequestMessage message)
   at Mono.Nat.Upnp.UpnpNatDevice.CreatePortMapAsync(Mapping mapping)
   at Mono.Nat.NatDeviceExtensions.CreatePortMap(INatDevice device, Mapping mapping)
   at OpenRA.Network.Nat.TryForwardPort(Int32 listen, Int32 external) in /home/mastermind/Apps/OpenRA/OpenRA.Game/Network/Nat.cs:line 70
Port removal failed: Error 714: NoSuchEntryInArray
   at Mono.Nat.Upnp.ResponseMessage.Decode(UpnpNatDevice device, String message)
   at Mono.Nat.Upnp.UpnpNatDevice.DecodeMessageFromResponse(Stream s, Int32 length)
   at Mono.Nat.Upnp.UpnpNatDevice.SendMessageAsync(RequestMessage message)
   at Mono.Nat.Upnp.UpnpNatDevice.DeletePortMapAsync(Mapping mapping)
   at Mono.Nat.NatDeviceExtensions.DeletePortMap(INatDevice device, Mapping mapping)
   at OpenRA.Network.Nat.TryRemovePortForward() in /home/mastermind/Apps/OpenRA/OpenRA.Game/Network/Nat.cs:line 89
```

