### PR TITLE
In RemoveCellsFromPlayerShroud, don't call RemoveSource unless required.

### DIFF
--- a/OpenRA.Mods.Common/Effects/RevealShroudEffect.cs
+++ b/OpenRA.Mods.Common/Effects/RevealShroudEffect.cs
@@ -44,11 +44,19 @@ namespace OpenRA.Mods.Common.Effects
 
 		void AddCellsToPlayerShroud(Player p, PPos[] uv)
 		{
-			if (validStances.HasRelationship(player.RelationshipWith(p)))
-				p.Shroud.AddSource(this, sourceType, uv);
+			if (!validStances.HasRelationship(player.RelationshipWith(p)))
+				return;
+
+			p.Shroud.AddSource(this, sourceType, uv);
 		}
 
-		void RemoveCellsFromPlayerShroud(Player p) { p.Shroud.RemoveSource(this); }
+		void RemoveCellsFromPlayerShroud(Player p)
+		{
+			if (!validStances.HasRelationship(player.RelationshipWith(p)))
+				return;
+
+			p.Shroud.RemoveSource(this);
+		}
 
 		PPos[] ProjectedCells(World world)
 		{

--- a/OpenRA.Mods.Common/Traits/CreatesShroud.cs
+++ b/OpenRA.Mods.Common/Traits/CreatesShroud.cs
@@ -49,7 +49,13 @@ namespace OpenRA.Mods.Common.Traits
 			p.Shroud.AddSource(this, Shroud.SourceType.Shroud, uv);
 		}
 
-		protected override void RemoveCellsFromPlayerShroud(Actor self, Player p) { p.Shroud.RemoveSource(this); }
+		protected override void RemoveCellsFromPlayerShroud(Actor self, Player p)
+		{
+			if (!info.ValidRelationships.HasRelationship(self.Owner.RelationshipWith(p)))
+				return;
+
+			p.Shroud.RemoveSource(this);
+		}
 
 		public override WDist Range
 		{

--- a/OpenRA.Mods.Common/Traits/RevealsMap.cs
+++ b/OpenRA.Mods.Common/Traits/RevealsMap.cs
@@ -44,7 +44,13 @@ namespace OpenRA.Mods.Common.Traits
 			p.Shroud.AddSource(this, type, uv);
 		}
 
-		protected void RemoveCellsFromPlayerShroud(Player p) { p.Shroud.RemoveSource(this); }
+		protected void RemoveCellsFromPlayerShroud(Actor self, Player p)
+		{
+			if (!Info.ValidRelationships.HasRelationship(self.Owner.RelationshipWith(p)))
+				return;
+
+			p.Shroud.RemoveSource(this);
+		}
 
 		protected PPos[] ProjectedCells(Actor self)
 		{
@@ -58,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 				var cells = ProjectedCells(self);
 				foreach (var player in self.World.Players)
 				{
-					RemoveCellsFromPlayerShroud(player);
+					RemoveCellsFromPlayerShroud(self, player);
 					AddCellsToPlayerShroud(self, player, cells);
 				}
 			}
@@ -67,13 +73,13 @@ namespace OpenRA.Mods.Common.Traits
 		void INotifyActorDisposing.Disposing(Actor self)
 		{
 			foreach (var player in self.World.Players)
-				RemoveCellsFromPlayerShroud(player);
+				RemoveCellsFromPlayerShroud(self, player);
 		}
 
 		void INotifyKilled.Killed(Actor self, AttackInfo e)
 		{
 			foreach (var player in self.World.Players)
-				RemoveCellsFromPlayerShroud(player);
+				RemoveCellsFromPlayerShroud(self, player);
 		}
 
 		protected override void TraitEnabled(Actor self)
@@ -86,7 +92,7 @@ namespace OpenRA.Mods.Common.Traits
 		protected override void TraitDisabled(Actor self)
 		{
 			foreach (var player in self.World.Players)
-				RemoveCellsFromPlayerShroud(player);
+				RemoveCellsFromPlayerShroud(self, player);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/RevealsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/RevealsShroud.cs
@@ -55,7 +55,13 @@ namespace OpenRA.Mods.Common.Traits
 			p.Shroud.AddSource(this, type, uv);
 		}
 
-		protected override void RemoveCellsFromPlayerShroud(Actor self, Player p) { p.Shroud.RemoveSource(this); }
+		protected override void RemoveCellsFromPlayerShroud(Actor self, Player p)
+		{
+			if (!info.ValidRelationships.HasRelationship(self.Owner.RelationshipWith(p)))
+				return;
+
+			p.Shroud.RemoveSource(this);
+		}
 
 		public override WDist Range
 		{


### PR DESCRIPTION
Since AddCellsToPlayerShroud only adds for players with a valid relationship, we can skip a dictionary lookup in RemoveSource by only attempting the remove if the relationship check passes as well.

Closes #21595