### PR TITLE
Don't spam the master server if the initial ping fails.

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Server
 			// Update the master server and LAN clients if something has changed
 			// Note that isBusy is set while the master server ping is running on a
 			// background thread, and limits LAN pings as well as master server pings for simplicity.
-			if (!isBusy && ((lastChanged > lastPing && Game.RunTime - lastPing > RateLimitInterval) || isInitialPing))
+			if (!isBusy && lastChanged >= lastPing && Game.RunTime - lastPing > RateLimitInterval)
 			{
 				var gs = new GameServer(server);
 				if (server.Settings.AdvertiseOnline)


### PR DESCRIPTION
MasterServerPinger has rate limiting built-in. However this rate limiting is skipped when isInitialPing is true. This is an issue if the ping fails and we never set isInitialPing to false - we will spam requests continuously.

Fix this by not allowing the initial ping to skip the rate limiting. Tweaking the rate limit condition to `lastChanged >= lastPing` allows the first tick to ping right away without delay.

Fixes #21597