### PR TITLE
Fix crash when a sequences defines both Alpha and Reverses.

### DIFF
--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -544,6 +544,8 @@ namespace OpenRA.Mods.Common.Graphics
 			if (reverses)
 			{
 				index.AddRange(index.Skip(1).Take(length.Value - 2).Reverse());
+				alpha = alpha?.Concat(alpha.Skip(1).Take(length.Value - 2).Reverse()).ToArray();
+
 				length = 2 * length - 2;
 			}
 


### PR DESCRIPTION
Fixes a crash reported by Charlyko on Discord.

Testcase: Add `Alpha: 0.5` to e.g. `garadr.idle-dish` in ts.