### PR TITLE
Allow maps to override the player viewport size.

### DIFF
--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -69,6 +69,8 @@ namespace OpenRA.Graphics
 		bool unlockMinZoom;
 		float unlockedMinZoomScale;
 		float unlockedMinZoom = 1f;
+		float defaultScale;
+		bool overrideUserScale;
 
 		public float Zoom
 		{
@@ -85,6 +87,13 @@ namespace OpenRA.Graphics
 
 		public float MinZoom { get; private set; } = 1f;
 		public float MaxZoom { get; private set; } = 2f;
+
+		public void OverrideDefaultHeight(float height)
+		{
+			defaultScale = viewportSizes.DefaultScale * Game.Renderer.NativeResolution.Height / height;
+			overrideUserScale = true;
+			UpdateViewportZooms(false);
+		}
 
 		public void AdjustZoom(float dz)
 		{
@@ -140,6 +149,7 @@ namespace OpenRA.Graphics
 			var grid = Game.ModData.Manifest.Get<MapGrid>();
 			viewportSizes = Game.ModData.Manifest.Get<WorldViewportSizes>();
 			graphicSettings = Game.Settings.Graphics;
+			defaultScale = viewportSizes.DefaultScale;
 
 			// Calculate map bounds in world-px
 			if (wr.World.Type == WorldType.Editor)
@@ -207,17 +217,17 @@ namespace OpenRA.Graphics
 			lastViewportDistance = graphicSettings.ViewportDistance;
 
 			var vd = graphicSettings.ViewportDistance;
-			if (viewportSizes.AllowNativeZoom && vd == WorldViewport.Native)
-				MinZoom = viewportSizes.DefaultScale;
+			if (overrideUserScale || (viewportSizes.AllowNativeZoom && vd == WorldViewport.Native))
+				MinZoom = defaultScale;
 			else
 			{
 				var range = viewportSizes.GetSizeRange(vd);
-				MinZoom = CalculateMinimumZoom(range.X, range.Y) * viewportSizes.DefaultScale;
+				MinZoom = CalculateMinimumZoom(range.X, range.Y) * defaultScale;
 			}
 
 			MaxZoom = Math.Min(
 				MinZoom * viewportSizes.MaxZoomScale,
-				Game.Renderer.NativeResolution.Height * viewportSizes.DefaultScale / viewportSizes.MaxZoomWindowHeight);
+				Game.Renderer.NativeResolution.Height * defaultScale / viewportSizes.MaxZoomWindowHeight);
 
 			if (unlockMinZoom)
 			{

--- a/OpenRA.Mods.Common/Traits/World/MapOptions.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapOptions.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Graphics;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -79,6 +80,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Display order for the game speed option in the lobby.")]
 		public readonly int GameSpeedDropdownDisplayOrder = 0;
 
+		[Desc("If defined, overrides the viewport height for all players to this many world units.")]
+		public readonly WDist? ViewportHeight = null;
+
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{
 			yield return new LobbyBooleanOption(map, "shortgame",
@@ -113,7 +117,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new MapOptions(this); }
 	}
 
-	public class MapOptions : INotifyCreated
+	public class MapOptions : INotifyCreated, IWorldLoaded
 	{
 		readonly MapOptionsInfo info;
 
@@ -132,6 +136,16 @@ namespace OpenRA.Mods.Common.Traits
 
 			TechLevel = self.World.LobbyInfo.GlobalSettings
 				.OptionOrDefault("techlevel", info.TechLevel);
+		}
+
+		void IWorldLoaded.WorldLoaded(World w, WorldRenderer wr)
+		{
+			if (info.ViewportHeight.HasValue)
+			{
+				// WPos to world pixels
+				var height = info.ViewportHeight.Value.Length * w.Map.Grid.TileSize.Height / w.Map.Grid.TileScale;
+				wr.Viewport.OverrideDefaultHeight(height);
+			}
 		}
 	}
 }


### PR DESCRIPTION
There has been ongoing interest from the multiplayer community in being able to force a specific viewport size on all players during tournaments etc. The plumbing to support this has existed for a while now (starting with the arbitrary zoom support, extended by remaster viewport scaling support) so I don't see why we can't expose this as an optional feature for custom maps / minigames.

The feature is demonstrated on Fort Lonestar as a testcase.