### PR TITLE
Don't allow actors to disguise themselves as themselves

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -171,19 +171,39 @@ namespace OpenRA.Mods.Cnc.Traits
 				var targetDisguise = target.TraitOrDefault<Disguise>();
 				if (targetDisguise != null && targetDisguise.Disguised)
 				{
-					AsPlayer = targetDisguise.AsPlayer;
-					AsActor = targetDisguise.AsActor;
-					AsTooltipInfo = targetDisguise.AsTooltipInfo;
+					// Don't disguise as yourself
+					if (targetDisguise.AsActor.Name == self.Info.Name && targetDisguise.AsPlayer == self.Owner)
+					{
+						AsTooltipInfo = null;
+						AsPlayer = null;
+						AsActor = self.Info;
+					}
+					else
+					{
+						AsPlayer = targetDisguise.AsPlayer;
+						AsActor = targetDisguise.AsActor;
+						AsTooltipInfo = targetDisguise.AsTooltipInfo;
+					}
 				}
 				else
 				{
-					var tooltip = target.TraitsImplementing<ITooltip>().FirstEnabledTraitOrDefault();
-					if (tooltip == null)
-						throw new ArgumentException("Missing tooltip or invalid target.", nameof(target));
+					// Don't disguise as yourself
+					if (target.Info.Name == self.Info.Name && target.Owner == self.Owner)
+					{
+						AsTooltipInfo = null;
+						AsPlayer = null;
+						AsActor = self.Info;
+					}
+					else
+					{
+						var tooltip = target.TraitsImplementing<ITooltip>().FirstEnabledTraitOrDefault();
+						if (tooltip == null)
+							throw new ArgumentException("Missing tooltip or invalid target.", nameof(target));
 
-					AsPlayer = tooltip.Owner;
-					AsActor = target.Info;
-					AsTooltipInfo = tooltip.TooltipInfo;
+						AsPlayer = tooltip.Owner;
+						AsActor = target.Info;
+						AsTooltipInfo = tooltip.TooltipInfo;
+					}
 				}
 			}
 			else


### PR DESCRIPTION
Follow-up to #21277.

Testcases:
- Disguise an own spy as an own spy (undisguised): Spy tag is not visible
- Disguise an own spy as an own spy (disguised): Spy tag and disguise is visible
- Disguise an own spy as an enemy spy: Spy tag and disguise (if enemy spy disguised) visible
- Disguise an own spy as an enemy spy disguised as an own spy: Spy tag is not visible