### PR TITLE
Determine pixel-to-texel ratio for each sprite individually.

### DIFF
--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -253,9 +253,9 @@ namespace OpenRA.Graphics
 			shader.SetVec("DepthPreviewParams", contrast, offset);
 		}
 
-		public void SetAntialiasingPixelsPerTexel(float pxPerTx)
+		public void EnablePixelArtScaling(bool enabled)
 		{
-			shader.SetVec("AntialiasPixelsPerTexel", pxPerTx);
+			shader.SetBool("EnablePixelArtScaling", enabled);
 		}
 	}
 }

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -294,10 +294,10 @@ namespace OpenRA
 					(int)(-screenSprite.Bounds.Height / scale) / worldSprite.Size.Y,
 					1f);
 
-				SpriteRenderer.SetAntialiasingPixelsPerTexel(Window.SurfaceSize.Height * 1f / worldSprite.Bounds.Height);
+				SpriteRenderer.EnablePixelArtScaling(true);
 				RgbaSpriteRenderer.DrawSprite(worldSprite, float3.Zero, bufferScale);
 				Flush();
-				SpriteRenderer.SetAntialiasingPixelsPerTexel(0);
+				SpriteRenderer.EnablePixelArtScaling(false);
 			}
 			else
 			{
@@ -499,7 +499,7 @@ namespace OpenRA
 				throw new InvalidOperationException($"EndFrame called with renderType = {renderType}, expected RenderType.UI.");
 
 			Flush();
-			SpriteRenderer.SetAntialiasingPixelsPerTexel(Window.EffectiveWindowScale);
+			SpriteRenderer.EnablePixelArtScaling(true);
 		}
 
 		public void DisableAntialiasingFilter()
@@ -508,7 +508,7 @@ namespace OpenRA
 				throw new InvalidOperationException($"EndFrame called with renderType = {renderType}, expected RenderType.UI.");
 
 			Flush();
-			SpriteRenderer.SetAntialiasingPixelsPerTexel(0);
+			SpriteRenderer.EnablePixelArtScaling(false);
 		}
 
 		public void GrabWindowMouseFocus()

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -674,9 +674,10 @@ namespace OpenRA.Platforms.Default
 						break;
 				}
 
-				// Core features are defined as the shared feature set of GL 3.2 and (GLES 3 + BGRA extension)
+				// Core features are defined as the shared feature set of GL 3.2 and (GLES 3 + derivatives, BGRA extensions)
 				var hasBGRA = SDL.SDL_GL_ExtensionSupported("GL_EXT_texture_format_BGRA8888") == SDL.SDL_bool.SDL_TRUE;
-				if (Version.Contains(" ES") && hasBGRA && major >= 3)
+				var hasDerivatives = SDL.SDL_GL_ExtensionSupported("GL_OES_standard_derivatives") == SDL.SDL_bool.SDL_TRUE;
+				if (Version.Contains(" ES") && hasBGRA && hasDerivatives && major >= 3)
 				{
 					hasValidConfiguration = true;
 					Profile = GLProfile.Embedded;

--- a/glsl/combined.frag
+++ b/glsl/combined.frag
@@ -17,7 +17,7 @@ uniform sampler2D ColorShifts;
 uniform bool EnableDepthPreview;
 uniform vec2 DepthPreviewParams;
 uniform float DepthTextureScale;
-uniform float AntialiasPixelsPerTexel;
+uniform bool EnablePixelArtScaling;
 
 in vec4 vTexCoord;
 flat in float vTexPalette;
@@ -158,24 +158,26 @@ void main()
 	bool isColor = vChannelType == 0u;
 
 	vec4 c;
-	if (AntialiasPixelsPerTexel > 0.0)
+	if (EnablePixelArtScaling)
 	{
 		vec2 textureSize = vec2(Size(vChannelSampler));
-		vec2 offset = fract(coords.st * textureSize);
+		vec2 vUv = coords.st * textureSize;
+		vec2 offset = fract(vUv);
+		vec2 pixelsPerTexel = vec2(1.0 / dFdx(vUv.x), 1.0 / dFdy(vUv.y));
 
 		// Offset the sampling point to simulate bilinear intepolation in window coordinates instead of texture coordinates
 		// https://csantosbh.wordpress.com/2014/01/25/manual-texture-filtering-for-pixelated-games-in-webgl/
 		// https://csantosbh.wordpress.com/2014/02/05/automatically-detecting-the-texture-filter-threshold-for-pixelated-magnifications/
 		// ik is defined as 1/k from the articles, set to 1/0.7 because it looks good
 		float ik = 1.43;
-		vec2 interp = clamp(offset * ik * AntialiasPixelsPerTexel, 0.0, .5) + clamp((offset - 1.0) * ik * AntialiasPixelsPerTexel + .5, 0.0, .5);
+		vec2 interp = clamp(offset * ik * pixelsPerTexel, 0.0, .5) + clamp((offset - 1.0) * ik * pixelsPerTexel + .5, 0.0, .5);
 		coords = (floor(coords.st * textureSize) + interp) / textureSize;
 
 		if (isPaletted)
 			c = SamplePalettedBilinear(vChannelSampler, coords, textureSize);
 	}
 
-	if (!(AntialiasPixelsPerTexel > 0.0 && isPaletted))
+	if (!(EnablePixelArtScaling && isPaletted))
 	{
 		vec4 x = Sample(vChannelSampler, coords);
 		vec2 p = vec2(dot(x, vChannelMask), vTexPalette);


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/OpenRA/OpenRA/pull/21631#discussion_r1818530400. See https://github.com/OpenRA/OpenRA/pull/17424#discussion_r355189553 for the original discussion - my version of the fix is correct for sprites rendered at 1:1 scale, but fails when we want to render them at a large magnification. We now have a mechanism to require GLES extensions which is now used also for the derivatives.

Testcase: Change `ActorPreviewWidget`'s `GetScale` method to return `10f` and check the lobby colour picker.

Before:
![Screenshot 2024-10-29 at 21 33 10](https://github.com/user-attachments/assets/67787850-40b1-47ce-9556-87d367814999)

After:
<img width="1234" alt="Screenshot 2024-10-29 at 21 53 13" src="https://github.com/user-attachments/assets/33dcabc9-5d21-4c0d-8576-172d9e515b1e">

