### PR TITLE
Style fixes (.NET 9 SDK)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -913,6 +913,9 @@ dotnet_diagnostic.CA1858.severity = warning
 # Avoid using 'Enumerable.Any()' extension method.
 dotnet_diagnostic.CA1860.severity = warning
 
+# Use the 'StringComparison' method overloads to perform case-insensitive string comparisons.
+dotnet_diagnostic.CA1862.severity = warning
+
 # Use 'CompositeFormat'.
 dotnet_diagnostic.CA1863.severity = suggestion # TODO: Change to warning once using .NET 7 or later.
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1049,6 +1049,9 @@ dotnet_diagnostic.CA2263.severity = none # TODO: Change to warning once mono is 
 # Do not pass a non-nullable value to 'ArgumentNullException.ThrowIfNull'.
 dotnet_diagnostic.CA2264.severity = warning
 
+# Do not compare 'Span<T>' to 'null' or 'default'.
+dotnet_diagnostic.CA2265.severity = warning
+
 ### Roslynator.Analyzers
 ### https://josefpihrt.github.io/docs/roslynator/analyzers
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1043,6 +1043,9 @@ dotnet_diagnostic.CA2251.severity = warning
 # Ensure ThreadStatic is only used with static fields.
 dotnet_diagnostic.CA2259.severity = suggestion # TODO: Change to warning once using .NET 7 or later.
 
+# Prefer generic overload when type is known.
+dotnet_diagnostic.CA2263.severity = none # TODO: Change to warning once mono is dropped.
+
 # Do not pass a non-nullable value to 'ArgumentNullException.ThrowIfNull'.
 dotnet_diagnostic.CA2264.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -74,6 +74,10 @@ dotnet_diagnostic.IDE0211.severity = warning
 #csharp_style_prefer_primary_constructors = true
 dotnet_diagnostic.IDE0200.severity = silent # Requires C# 12
 
+# IDE0330 Prefer 'System.Threading.Lock'
+#csharp_prefer_system_threading_lock = true
+dotnet_diagnostic.IDE0330.severity = silent # Requires C# 13
+
 ## Expression-bodied members
 
 # IDE0021 Use expression body for constructors
@@ -298,6 +302,34 @@ dotnet_diagnostic.IDE0240.severity = warning
 # No options
 dotnet_diagnostic.IDE0241.severity = warning
 
+# This option applies to the collection expression rules below
+# .NET 8 defaults to true/when_types_exactly_match, .NET 9+ defaults to when_types_loosely_match
+#dotnet_style_prefer_collection_expression = true
+
+# IDE0300 Use collection expression for array
+# From above, uses dotnet_style_prefer_collection_expression
+dotnet_diagnostic.IDE0300.severity = silent # Requires C# 12
+
+# IDE0301 Use collection expression for empty
+# From above, uses dotnet_style_prefer_collection_expression
+dotnet_diagnostic.IDE0301.severity = silent # Requires C# 12
+
+# IDE0302 Use collection expression for stackalloc
+# From above, uses dotnet_style_prefer_collection_expression
+dotnet_diagnostic.IDE0302.severity = silent # Requires C# 12
+
+# IDE0303 Use collection expression for 'Create()'
+# From above, uses dotnet_style_prefer_collection_expression
+dotnet_diagnostic.IDE0303.severity = silent # Requires C# 12
+
+# IDE0304 Use collection expression for builder
+# From above, uses dotnet_style_prefer_collection_expression
+dotnet_diagnostic.IDE0304.severity = silent # Requires C# 12
+
+# IDE0305 Use collection expression for fluent
+# From above, uses dotnet_style_prefer_collection_expression
+dotnet_diagnostic.IDE0305.severity = silent # Requires C# 12
+
 ## Field preferences
 
 # IDE0044 Add readonly modifier
@@ -336,6 +368,10 @@ dotnet_diagnostic.IDE0250.severity = warning
 # IDE0251 Member can be made 'readonly'
 #csharp_style_prefer_readonly_struct_member = true
 dotnet_diagnostic.IDE0251.severity = warning
+
+# IDE0320 Make anonymous function static
+#csharp_prefer_static_anonymous_function = true
+dotnet_diagnostic.IDE0320.severity = warning
 
 ## Null-checking preferences
 
@@ -726,6 +762,18 @@ dotnet_diagnostic.CA1417.severity = warning
 # Use 'nameof' in place of string.
 dotnet_diagnostic.CA1507.severity = warning
 
+# Use ArgumentNullException throw helper.
+dotnet_diagnostic.CA1510.severity = suggestion # TODO: Change to warning once using .NET 7 or later.
+
+# Use ArgumentException throw helper.
+dotnet_diagnostic.CA1511.severity = suggestion # TODO: Change to warning once using .NET 7 or later.
+
+# Use ArgumentOutOfRangeException throw helper.
+dotnet_diagnostic.CA1512.severity = suggestion # TODO: Change to warning once using .NET 8 or later.
+
+# Use ObjectDisposedException throw helper.
+dotnet_diagnostic.CA1513.severity = suggestion # TODO: Change to warning once using .NET 7 or later.
+
 # Avoid redundant length argument.
 dotnet_diagnostic.CA1514.severity = suggestion # TODO: Change to warning once using .NET 8 or later.
 
@@ -853,11 +901,20 @@ dotnet_diagnostic.CA1854.severity = suggestion # TODO: Change to warning once us
 # Use Span<T>.Clear() instead of Span<T>.Fill().
 dotnet_diagnostic.CA1855.severity = suggestion # TODO: Change to warning once using .NET 7 or later.
 
+# Incorrect usage of ConstantExpected attribute.
+dotnet_diagnostic.CA1856.severity = suggestion # TODO: Change to warning once using .NET 7 or later.
+
+# The parameter expects a constant for optimal performance.
+dotnet_diagnostic.CA1857.severity = suggestion # TODO: Change to warning once using .NET 7 or later.
+
 # Use StartsWith instead of IndexOf.
 dotnet_diagnostic.CA1858.severity = warning
 
 # Avoid using 'Enumerable.Any()' extension method.
 dotnet_diagnostic.CA1860.severity = warning
+
+# Use 'CompositeFormat'.
+dotnet_diagnostic.CA1863.severity = suggestion # TODO: Change to warning once using .NET 7 or later.
 
 # Prefer the 'IDictionary.TryAdd(TKey, TValue)' method.
 dotnet_diagnostic.CA1864.severity = suggestion # TODO: Change to warning once using .NET 8 or later.
@@ -875,6 +932,12 @@ dotnet_diagnostic.CA1869.severity = suggestion # TODO: Change to warning once us
 
 # Use a cached 'SearchValues' instance.
 dotnet_diagnostic.CA1870.severity = suggestion # TODO: Change to warning once using .NET 8 or later.
+
+# Do not pass a nullable struct to 'ArgumentNullException.ThrowIfNull'.
+dotnet_diagnostic.CA1871.severity = warning
+
+# Prefer 'Convert.ToHexString' and 'Convert.ToHexStringLower' over call chains based on 'BitConverter.ToString'.
+dotnet_diagnostic.CA1872.severity = warning
 
 ### Reliability Rules
 ### https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/reliability-warnings
@@ -899,6 +962,12 @@ dotnet_diagnostic.CA2018.severity = warning
 
 # ThreadStatic fields should not use inline initialization.
 dotnet_diagnostic.CA2019.severity = suggestion # TODO: Change to warning once using .NET 7 or later.
+
+# Don't call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types.
+dotnet_diagnostic.CA2021.severity = warning
+
+# Avoid inexact read with Stream.Read.
+dotnet_diagnostic.CA2022.severity = warning
 
 ### Security Rules
 ### https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/security-warnings
@@ -970,6 +1039,9 @@ dotnet_diagnostic.CA2251.severity = warning
 
 # Ensure ThreadStatic is only used with static fields.
 dotnet_diagnostic.CA2259.severity = suggestion # TODO: Change to warning once using .NET 7 or later.
+
+# Do not pass a non-nullable value to 'ArgumentNullException.ThrowIfNull'.
+dotnet_diagnostic.CA2264.severity = warning
 
 ### Roslynator.Analyzers
 ### https://josefpihrt.github.io/docs/roslynator/analyzers

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Graphics
 	{
 		public const int SheetCount = 8;
 		static readonly string[] SheetIndexToTextureName = Exts.MakeArray(SheetCount, i => $"Texture{i}");
-		static readonly int UintSize = Marshal.SizeOf(typeof(uint));
+		static readonly int UintSize = Marshal.SizeOf<uint>();
 
 		readonly Renderer renderer;
 		readonly IShader shader;

--- a/OpenRA.Game/Map/ActorInitializer.cs
+++ b/OpenRA.Game/Map/ActorInitializer.cs
@@ -154,7 +154,7 @@ namespace OpenRA
 
 		public virtual void Initialize(MiniYaml yaml)
 		{
-			Initialize((T)FieldLoader.GetValue(nameof(value), typeof(T), yaml.Value));
+			Initialize(FieldLoader.GetValue<T>(nameof(value), yaml.Value));
 		}
 
 		public virtual void Initialize(T value)

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -333,7 +333,7 @@ namespace OpenRA
 
 					// Note: We need to support empty comments here to ensure that empty comments
 					// (i.e. a lone # at the end of a line) can be correctly re-serialized
-					var commentString = comment == default ? null : comment.ToString();
+					var commentString = comment == ReadOnlySpan<char>.Empty ? null : comment.ToString();
 
 					keyString = keyString == null ? null : stringPool.GetOrAdd(keyString);
 					valueString = valueString == null ? null : stringPool.GetOrAdd(valueString);

--- a/OpenRA.Game/Scripting/ScriptMemberWrapper.cs
+++ b/OpenRA.Game/Scripting/ScriptMemberWrapper.cs
@@ -149,7 +149,7 @@ namespace OpenRA.Scripting
 
 			// Remove the namespace and the trailing "Info"
 			return types.SelectMany(i => i.GetGenericArguments())
-				.Select(g => g.Name.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries).LastOrDefault())
+				.Select(g => g.Name.Split('.', StringSplitOptions.RemoveEmptyEntries).LastOrDefault())
 				.Select(s => s.EndsWith("Info", StringComparison.Ordinal) ? s.Remove(s.Length - 4, 4) : s)
 				.ToArray();
 		}

--- a/OpenRA.Mods.Cnc/Traits/World/VoxelCache.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/VoxelCache.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			var hva = unit;
 			if (info.Value != null)
 			{
-				var fields = info.Value.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+				var fields = info.Value.Split(',', StringSplitOptions.RemoveEmptyEntries);
 				if (fields.Length >= 1)
 					vxl = hva = fields[0].Trim();
 

--- a/OpenRA.Mods.Cnc/UtilityCommands/LegacyRulesImporter.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/LegacyRulesImporter.cs
@@ -130,7 +130,8 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 					Console.WriteLine("\t\tIntoActor: " + undeploysInto);
 				}
 
-				if (artIni.Sections.Any(s => s.Name == building.ToLowerInvariant()))
+				var buildingLower = building.ToLowerInvariant();
+				if (artIni.Sections.Any(s => s.Name == buildingLower))
 				{
 					var artSection = artIni.GetSection(building);
 

--- a/OpenRA.Mods.Cnc/UtilityCommands/LegacySequenceImporter.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/LegacySequenceImporter.cs
@@ -138,7 +138,8 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 				Console.WriteLine("\t\tUseTilesetCode: false");
 			}
 
-			if (file.Sections.Any(s => s.Name == sequence.ToLowerInvariant()))
+			var sequenceLower = sequence.ToLowerInvariant();
+			if (file.Sections.Any(s => s.Name == sequenceLower))
 			{
 				var sequenceSection = file.GetSection(sequence);
 				var guard = sequenceSection.GetValue("Guard", string.Empty);

--- a/OpenRA.Mods.Common/Activities/LayMines.cs
+++ b/OpenRA.Mods.Common/Activities/LayMines.cs
@@ -150,7 +150,9 @@ namespace OpenRA.Mods.Common.Activities
 				var positionable = (IPositionable)movement;
 				var mobile = positionable as Mobile;
 				minefield.RemoveAll(c => self.World.ActorMap.GetActorsAt(c)
-					.Any(a => a.Info.Name == minelayer.Info.Mine.ToLowerInvariant() && a.CanBeViewedByPlayer(self.Owner)) ||
+					.Any(a =>
+						string.Equals(a.Info.Name, minelayer.Info.Mine, System.StringComparison.OrdinalIgnoreCase)
+						&& a.CanBeViewedByPlayer(self.Owner)) ||
 						((!positionable.CanEnterCell(c, null, BlockedByActor.Immovable) || (mobile != null && !mobile.CanStayInCell(c)))
 						&& self.Owner.Shroud.IsVisible(c)));
 			}

--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -55,8 +55,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			return cargo.CurrentAdjacentCells()
 				.Shuffle(self.World.SharedRandom)
-				.Select(c => (c, pos.GetAvailableSubCell(c)))
-				.Cast<(CPos, SubCell SubCell)?>()
+				.Select(c => ((CPos Cell, SubCell SubCell)?)(c, pos.GetAvailableSubCell(c)))
 				.FirstOrDefault(s => s.Value.SubCell != SubCell.Invalid);
 		}
 

--- a/OpenRA.Mods.Common/ActorInitializer.cs
+++ b/OpenRA.Mods.Common/ActorInitializer.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common
 
 		public void Initialize(MiniYaml yaml)
 		{
-			Initialize((int)FieldLoader.GetValue(nameof(value), typeof(int), yaml.Value));
+			Initialize(FieldLoader.GetValue<int>(nameof(value), yaml.Value));
 		}
 
 		public void Initialize(int value)

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -267,10 +267,6 @@ namespace OpenRA.Mods.Common.Traits
 		INotifyAddedToWorld, INotifyRemovedFromWorld
 	{
 		public readonly BuildingInfo Info;
-
-		[Sync]
-		readonly CPos topLeft;
-
 		readonly Actor self;
 		readonly BuildingInfluence influence;
 
@@ -278,13 +274,14 @@ namespace OpenRA.Mods.Common.Traits
 		readonly (CPos, SubCell)[] targetableCells;
 		readonly CPos[] transitOnlyCells;
 
-		public CPos TopLeft => topLeft;
+		[Sync]
+		public CPos TopLeft { get; }
 		public WPos CenterPosition { get; }
 
 		public Building(ActorInitializer init, BuildingInfo info)
 		{
 			self = init.Self;
-			topLeft = init.GetValue<LocationInit, CPos>();
+			TopLeft = init.GetValue<LocationInit, CPos>();
 			Info = info;
 			influence = self.World.WorldActor.Trait<BuildingInfluence>();
 
@@ -296,7 +293,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			transitOnlyCells = Info.TransitOnlyTiles(TopLeft).ToArray();
 
-			CenterPosition = init.World.Map.CenterOfCell(topLeft) + Info.CenterOffset(init.World);
+			CenterPosition = init.World.Map.CenterOfCell(TopLeft) + Info.CenterOffset(init.World);
 		}
 
 		public (CPos, SubCell)[] OccupiedCells() { return occupiedCells; }

--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -60,47 +60,45 @@ namespace OpenRA.Mods.Common.Traits
 		INotifyKilled[] notifyKilled;
 		INotifyKilled[] notifyKilledPlayer;
 
-		[Sync]
-		int hp;
-
 		public int DisplayHP { get; private set; }
 
 		public Health(ActorInitializer init, HealthInfo info)
 		{
 			Info = info;
-			MaxHP = hp = info.HP > 0 ? info.HP : 1;
+			MaxHP = HP = info.HP > 0 ? info.HP : 1;
 
 			// Cast to long to avoid overflow when multiplying by the health
 			var healthInit = init.GetOrDefault<HealthInit>();
 			if (healthInit != null)
-				hp = (int)(healthInit.Value * (long)MaxHP / 100);
+				HP = (int)(healthInit.Value * (long)MaxHP / 100);
 
-			DisplayHP = hp;
+			DisplayHP = HP;
 		}
 
-		public int HP => hp;
+		[Sync]
+		public int HP { get; private set; }
 		public int MaxHP { get; }
 
-		public bool IsDead => hp <= 0;
+		public bool IsDead => HP <= 0;
 		public bool RemoveOnDeath = true;
 
 		public DamageState DamageState
 		{
 			get
 			{
-				if (hp == MaxHP)
+				if (HP == MaxHP)
 					return DamageState.Undamaged;
 
-				if (hp <= 0)
+				if (HP <= 0)
 					return DamageState.Dead;
 
-				if (hp * 100L < MaxHP * 25L)
+				if (HP * 100L < MaxHP * 25L)
 					return DamageState.Critical;
 
-				if (hp * 100L < MaxHP * 50L)
+				if (HP * 100L < MaxHP * 50L)
 					return DamageState.Heavy;
 
-				if (hp * 100L < MaxHP * 75L)
+				if (HP * 100L < MaxHP * 75L)
 					return DamageState.Medium;
 
 				return DamageState.Light;
@@ -130,7 +128,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!IsDead)
 				return;
 
-			hp = MaxHP;
+			HP = MaxHP;
 
 			var ai = new AttackInfo
 			{
@@ -188,7 +186,7 @@ namespace OpenRA.Mods.Common.Traits
 				damage = new Damage((int)appliedDamage, damage.DamageTypes);
 			}
 
-			hp = (hp - damage.Value).Clamp(0, MaxHP);
+			HP = (HP - damage.Value).Clamp(0, MaxHP);
 
 			var ai = new AttackInfo
 			{
@@ -215,7 +213,7 @@ namespace OpenRA.Mods.Common.Traits
 					nd.AppliedDamage(attacker, self, ai);
 			}
 
-			if (hp == 0)
+			if (HP == 0)
 			{
 				foreach (var nd in notifyKilled)
 					nd.Killed(self, ai);
@@ -234,10 +232,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ITick.Tick(Actor self)
 		{
-			if (hp >= DisplayHP)
-				DisplayHP = hp;
+			if (HP >= DisplayHP)
+				DisplayHP = HP;
 			else
-				DisplayHP = (2 * DisplayHP + hp) / 3;
+				DisplayHP = (2 * DisplayHP + HP) / 3;
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Immobile.cs
+++ b/OpenRA.Mods.Common/Traits/Immobile.cs
@@ -31,18 +31,12 @@ namespace OpenRA.Mods.Common.Traits
 
 	sealed class Immobile : IOccupySpace, ISync, INotifyAddedToWorld, INotifyRemovedFromWorld
 	{
-		[Sync]
-		readonly CPos location;
-
-		[Sync]
-		readonly WPos position;
-
 		readonly (CPos, SubCell)[] occupied;
 
 		public Immobile(ActorInitializer init, ImmobileInfo info)
 		{
-			location = init.GetValue<LocationInit, CPos>();
-			position = init.World.Map.CenterOfCell(location);
+			TopLeft = init.GetValue<LocationInit, CPos>();
+			CenterPosition = init.World.Map.CenterOfCell(TopLeft);
 
 			if (info.OccupiesSpace)
 				occupied = new[] { (TopLeft, SubCell.FullCell) };
@@ -50,8 +44,10 @@ namespace OpenRA.Mods.Common.Traits
 				occupied = Array.Empty<(CPos, SubCell)>();
 		}
 
-		public CPos TopLeft => location;
-		public WPos CenterPosition => position;
+		[Sync]
+		public CPos TopLeft { get; }
+		[Sync]
+		public WPos CenterPosition { get; }
 		public (CPos, SubCell)[] OccupiedCells() { return occupied; }
 
 		void INotifyAddedToWorld.AddedToWorld(Actor self)

--- a/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
@@ -42,16 +42,12 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Dictionary<Actor, int> powerDrain = new();
 
 		[Sync]
-		int totalProvided;
-
-		public int PowerProvided => totalProvided;
+		public int PowerProvided { get; private set; }
 
 		[Sync]
-		int totalDrained;
+		public int PowerDrained { get; private set; }
 
-		public int PowerDrained => totalDrained;
-
-		public int ExcessPower => totalProvided - totalDrained;
+		public int ExcessPower => PowerProvided - PowerDrained;
 
 		public int PowerOutageRemainingTicks { get; private set; }
 		public int PowerOutageTotalTicks { get; private set; }
@@ -96,14 +92,14 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			if (old > 0)
-				totalProvided -= old;
+				PowerProvided -= old;
 			else if (old < 0)
-				totalDrained += old;
+				PowerDrained += old;
 
 			if (amount > 0)
-				totalProvided += amount;
+				PowerProvided += amount;
 			else if (amount < 0)
-				totalDrained -= amount;
+				PowerDrained -= amount;
 
 			UpdatePowerState();
 		}
@@ -122,9 +118,9 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			if (amount > 0)
-				totalProvided -= amount;
+				PowerProvided -= amount;
 			else if (amount < 0)
-				totalDrained += amount;
+				PowerDrained += amount;
 
 			UpdatePowerState();
 		}
@@ -147,17 +143,17 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (wasHackEnabled != devMode.UnlimitedPower)
 			{
-				totalProvided = 0;
-				totalDrained = 0;
+				PowerProvided = 0;
+				PowerDrained = 0;
 
 				if (!devMode.UnlimitedPower)
 				{
 					foreach (var kv in powerDrain)
 					{
 						if (kv.Value > 0)
-							totalProvided += kv.Value;
+							PowerProvided += kv.Value;
 						else if (kv.Value < 0)
-							totalDrained -= kv.Value;
+							PowerDrained -= kv.Value;
 					}
 				}
 

--- a/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
@@ -336,7 +336,9 @@ namespace OpenRA.Mods.Common.UpdateRules
 
 		public static bool IsAlreadyExtracted(string key)
 		{
+#pragma warning disable CA1862 // Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
 			if (key == key.ToLowerInvariant() && key.Any(c => c == '-') && key.All(c => c != ' '))
+#pragma warning restore CA1862
 			{
 				Console.WriteLine($"Skipping {key} because it is already extracted.");
 				return true;

--- a/OpenRA.Mods.Common/UtilityCommands/Rgba2Hex.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/Rgba2Hex.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 	{
 		string IUtilityCommand.Name => "--rgba2hex";
 
-		static readonly char[] Comma = new char[] { ',' };
+		const char Comma = ',';
 
 		bool IUtilityCommand.ValidateArguments(string[] args)
 		{
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 	{
 		string IUtilityCommand.Name => "--argb2hex";
 
-		static readonly char[] Comma = new char[] { ',' };
+		const char Comma = ',';
 
 		bool IUtilityCommand.ValidateArguments(string[] args)
 		{

--- a/OpenRA.Mods.Common/Widgets/LabelWithHighlightWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LabelWithHighlightWidget.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Widgets
 		(string, bool)[] MakeComponents(string text)
 		{
 			var components = new List<(string, bool)>();
-			foreach (var l in text.Split(new[] { "\\n" }, StringSplitOptions.None))
+			foreach (var l in text.Split("\\n", StringSplitOptions.None))
 			{
 				var line = l;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipLogic.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var descFont = Game.Renderer.Fonts[descTemplate.Font];
 				var descWidth = 0;
 				var descOffset = descTemplate.Bounds.Y;
-				foreach (var line in desc.Split(new[] { "\n" }, StringSplitOptions.None))
+				foreach (var line in desc.Split('\n', StringSplitOptions.None))
 				{
 					descWidth = Math.Max(descWidth, descFont.Measure(line).X);
 					var lineLabel = (LabelWidget)descTemplate.Clone();

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
@@ -304,7 +304,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						var httpResponseMessage = await client.GetAsync(download.MirrorList);
 						var result = await httpResponseMessage.Content.ReadAsStringAsync();
 
-						var mirrorList = result.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+						var mirrorList = result.Split('\n', StringSplitOptions.RemoveEmptyEntries);
 						DownloadUrl(mirrorList.Random(new MersenneTwister()));
 					}
 					catch (Exception e)

--- a/OpenRA.Platforms.Default/Sdl2HardwareCursor.cs
+++ b/OpenRA.Platforms.Default/Sdl2HardwareCursor.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Platforms.Default
 				if (surface == IntPtr.Zero)
 					throw new InvalidDataException($"Failed to create surface: {SDL.SDL_GetError()}");
 
-				var sur = (SDL.SDL_Surface)Marshal.PtrToStructure(surface, typeof(SDL.SDL_Surface));
+				var sur = Marshal.PtrToStructure<SDL.SDL_Surface>(surface);
 				Marshal.Copy(data, 0, sur.pixels, data.Length);
 
 				// This call very occasionally fails on Windows, but often works when retried.

--- a/OpenRA.Platforms.Default/VertexBuffer.cs
+++ b/OpenRA.Platforms.Default/VertexBuffer.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Platforms.Default
 	sealed class VertexBuffer<T> : ThreadAffine, IDisposable, IVertexBuffer<T>
 			where T : struct
 	{
-		static readonly int VertexSize = Marshal.SizeOf(typeof(T));
+		static readonly int VertexSize = Marshal.SizeOf<T>();
 		uint buffer;
 		bool disposed;
 


### PR DESCRIPTION
If you're using the .NET 9 SDK that came out yesterday (or e.g. updated Visual Studio which ships it) then some of the style rules have been updated and trigger additional warnings locally. We can also except them to be flagged by CI if the runners move to .NET 9, even if we continue to specify .NET 6 or .NET 8 as the build target.

Fix these issues to improve the local dev experience for anybody using this SDK:

```
> dotnet --version
9.0.100
```

See also #21211

