### PR TITLE
Restore threaded renderer on Windows in windowed mode.

### DIFF
--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -337,15 +337,7 @@ namespace OpenRA.Platforms.Default
 			// Run graphics rendering on a dedicated thread.
 			// The calling thread will then have more time to process other tasks, since rendering happens in parallel.
 			// If the calling thread is the main game thread, this means it can run more logic and render ticks.
-			// This is disabled when running in windowed mode on Windows because it breaks the ability to minimize/restore the window.
-			if (Platform.CurrentPlatform == PlatformType.Windows && windowMode == WindowMode.Windowed)
-			{
-				var ctx = new Sdl2GraphicsContext(this);
-				ctx.InitializeOpenGL();
-				Context = ctx;
-			}
-			else
-				Context = new ThreadedGraphicsContext(new Sdl2GraphicsContext(this), vertexBatchSize, indexBatchSize);
+			Context = new ThreadedGraphicsContext(new Sdl2GraphicsContext(this), vertexBatchSize, indexBatchSize);
 
 			Context.SetVSyncEnabled(Game.Settings.Graphics.VSync);
 


### PR DESCRIPTION
Previously, when running in windowed-mode on Windows, the threaded renderer would cause the minimize/restore behaviour to become unreliable. It was disabled under this configuration to avoid the problem.

This no longer occurs (perhaps fixed by an intervening SDL update?), so we can remove the workaround and always use the threaded renderer for a performance improvement.