### PR TITLE
Fix Animation shadow to account for height.

### DIFF
--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -22,6 +22,7 @@ namespace OpenRA.Graphics
 		public string Name { get; private set; }
 		public bool IsDecoration { get; set; }
 
+		readonly Map map;
 		readonly SequenceSet sequences;
 		readonly Func<WAngle> facingFunc;
 		readonly Func<bool> paused;
@@ -43,6 +44,7 @@ namespace OpenRA.Graphics
 
 		public Animation(World world, string name, Func<WAngle> facingFunc, Func<bool> paused)
 		{
+			map = world.Map;
 			sequences = world.Map.Sequences;
 			Name = name.ToLowerInvariant();
 			this.facingFunc = facingFunc;
@@ -65,8 +67,10 @@ namespace OpenRA.Graphics
 			var shadow = CurrentSequence.GetShadow(CurrentFrame, facingFunc());
 			if (shadow != null)
 			{
+				var height = map.DistanceAboveTerrain(pos).Length;
+
 				var shadowRenderable = new SpriteRenderable(
-					shadow, pos, offset, CurrentSequence.ShadowZOffset + zOffset, palette,
+					shadow, pos, offset - new WVec(0, 0, height), CurrentSequence.ShadowZOffset + zOffset + height, palette,
 					CurrentSequence.Scale, 1f, float3.Ones, tintModifiers,
 					true, rotation);
 				return new IRenderable[] { shadowRenderable, imageRenderable };


### PR DESCRIPTION
If a unit is above the terrain, the shadow shouldn't display directly underneath the unit, it should take the height into account and display further down. This fix uses the same adjustment as applied by the WithShadow trait.

Supersedes #21378

Tescase: Carryall carrying a Juggernaut in TS.

Bleed:
![image](https://github.com/user-attachments/assets/64368e03-1486-4015-90a6-492819fedf7c)

PR:
![image](https://github.com/user-attachments/assets/9948e60c-e8a2-4cba-b5a8-b1025bcaa3e8)
