### PR TITLE
Recalculate shroud changes less often.

### DIFF
--- a/OpenRA.Mods.Common/Traits/AffectsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/AffectsShroud.cs
@@ -25,31 +25,28 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("If >= 0, prevent cells that are this much higher than the actor from being revealed.")]
 		public readonly int MaxHeightDelta = -1;
 
-		[Desc("If > 0, force visibility to be recalculated if the unit moves within a cell by more than this distance.")]
-		public readonly WDist MoveRecalculationThreshold = new(256);
+		[Desc("If > 0, force visibility to be recalculated when a unit moves by more than this distance. " +
+			"Applies to " + nameof(VisibilityType.CenterPosition) + " and " + nameof(VisibilityType.GroundPosition) + " types.")]
+		public readonly WDist MoveRecalculationThreshold = new(512);
 
-		[Desc("Possible values are CenterPosition (measure range from the center) and ",
-			"Footprint (measure range from the footprint)")]
+		[Desc("Possible values are " +
+			nameof(VisibilityType.CenterPosition) + " (measure range from the center)," +
+			nameof(VisibilityType.GroundPosition) + " (measure range from the ground level under center) and " +
+			nameof(VisibilityType.Footprint) + " (measure range from the footprint)")]
 		public readonly VisibilityType Type = VisibilityType.Footprint;
 	}
 
 	public abstract class AffectsShroud : ConditionalTrait<AffectsShroudInfo>, ISync, INotifyAddedToWorld,
-		INotifyRemovedFromWorld, INotifyMoving, INotifyCenterPositionChanged, ITick
+		INotifyRemovedFromWorld, INotifyCenterPositionChanged, ITick
 	{
 		static readonly PPos[] NoCells = Array.Empty<PPos>();
 
 		readonly HashSet<PPos> footprint;
 
 		[Sync]
-		CPos cachedLocation;
-
-		[Sync]
 		WDist cachedRange;
 
-		[Sync]
-		protected bool CachedTraitDisabled { get; private set; }
-
-		WPos cachedPos;
+		InputPositions cachedInput;
 
 		protected abstract void AddCellsToPlayerShroud(Actor self, Player player, PPos[] uv);
 		protected abstract void RemoveCellsFromPlayerShroud(Actor self, Player player);
@@ -61,7 +58,33 @@ namespace OpenRA.Mods.Common.Traits
 				footprint = new HashSet<PPos>();
 		}
 
-		PPos[] ProjectedCells(Actor self)
+		InputPositions ProjectedCellsInput(Actor self)
+		{
+			(CPos Cell, SubCell SubCell)[] cells = null;
+			WPos position = default;
+
+			if (Info.Type == VisibilityType.Footprint)
+			{
+				cells = self.OccupiesSpace.OccupiedCells();
+			}
+			else
+			{
+				position = self.CenterPosition;
+
+				// Don't recalculate shroud for every tiny position change. Quantize the position.
+				// Avoids us updating the shroud too much - until the position has changed a sufficient amount.
+				var l = Info.MoveRecalculationThreshold.Length;
+				if (l > 0)
+				{
+					var l2 = l / 2; // Put us in the middle of the region, half way along.
+					position = new WPos(position.X / l * l + l2, position.Y / l * l + l2, position.Z / l * l + l2);
+				}
+			}
+
+			return new InputPositions(cells, position);
+		}
+
+		PPos[] ProjectedCells(Actor self, InputPositions input)
 		{
 			var map = self.World.Map;
 			var minRange = Info.MinRange;
@@ -71,19 +94,27 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (Info.Type == VisibilityType.Footprint)
 			{
+				if (input.FootprintOccupiedCells.Length == 1)
+				{
+					var cellPosition = map.CenterOfCell(input.FootprintOccupiedCells[0].Cell);
+					return Shroud.ProjectedCellsInRange(map, cellPosition, minRange, maxRange, Info.MaxHeightDelta)
+						.ToArray();
+				}
+
+				// With multiple footprint cells we will produce overlapping shrouds, so we must de-duplicate the cells.
 				// PERF: Reuse collection to avoid allocations.
-				footprint.UnionWith(self.OccupiesSpace.OccupiedCells()
+				footprint.UnionWith(input.FootprintOccupiedCells
 					.SelectMany(kv => Shroud.ProjectedCellsInRange(map, map.CenterOfCell(kv.Cell), minRange, maxRange, Info.MaxHeightDelta)));
 				var cells = footprint.ToArray();
 				footprint.Clear();
 				return cells;
 			}
 
-			var pos = self.CenterPosition;
+			var position = input.CenterPosition;
 			if (Info.Type == VisibilityType.GroundPosition)
-				pos -= new WVec(WDist.Zero, WDist.Zero, self.World.Map.DistanceAboveTerrain(pos));
+				position -= new WVec(WDist.Zero, WDist.Zero, self.World.Map.DistanceAboveTerrain(position));
 
-			return Shroud.ProjectedCellsInRange(map, pos, minRange, maxRange, Info.MaxHeightDelta)
+			return Shroud.ProjectedCellsInRange(map, position, minRange, maxRange, Info.MaxHeightDelta)
 				.ToArray();
 		}
 
@@ -92,19 +123,14 @@ namespace OpenRA.Mods.Common.Traits
 			if (!self.IsInWorld)
 				return;
 
-			var centerPosition = self.CenterPosition;
-			var projectedPos = centerPosition - new WVec(0, centerPosition.Z, centerPosition.Z);
-			var projectedLocation = self.World.Map.CellContaining(projectedPos);
-			var pos = self.CenterPosition;
+			var input = ProjectedCellsInput(self);
 
-			var dirty = Info.MoveRecalculationThreshold.Length > 0 && (pos - cachedPos).LengthSquared > Info.MoveRecalculationThreshold.LengthSquared;
-			if (!dirty && cachedLocation == projectedLocation)
+			if (input == cachedInput)
 				return;
 
-			cachedLocation = projectedLocation;
-			cachedPos = pos;
+			cachedInput = input;
 
-			UpdateShroudCells(self);
+			UpdateShroudCells(self, input);
 		}
 
 		void ITick.Tick(Actor self)
@@ -112,21 +138,20 @@ namespace OpenRA.Mods.Common.Traits
 			if (!self.IsInWorld)
 				return;
 
-			var traitDisabled = IsTraitDisabled;
 			var range = Range;
 
-			if (cachedRange == range && traitDisabled == CachedTraitDisabled)
+			if (cachedRange == range)
 				return;
 
 			cachedRange = range;
-			CachedTraitDisabled = traitDisabled;
 
-			UpdateShroudCells(self);
+			var input = ProjectedCellsInput(self);
+			UpdateShroudCells(self, input);
 		}
 
-		void UpdateShroudCells(Actor self)
+		void UpdateShroudCells(Actor self, InputPositions input)
 		{
-			var cells = ProjectedCells(self);
+			var cells = ProjectedCells(self, input);
 			foreach (var p in self.World.Players)
 			{
 				RemoveCellsFromPlayerShroud(self, p);
@@ -136,12 +161,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
-			var centerPosition = self.CenterPosition;
-			var projectedPos = centerPosition - new WVec(0, centerPosition.Z, centerPosition.Z);
-			cachedLocation = self.World.Map.CellContaining(projectedPos);
-			cachedPos = centerPosition;
-			CachedTraitDisabled = IsTraitDisabled;
-			var cells = ProjectedCells(self);
+			var input = ProjectedCellsInput(self);
+			var cells = ProjectedCells(self, input);
 
 			foreach (var p in self.World.Players)
 				AddCellsToPlayerShroud(self, p, cells);
@@ -153,23 +174,33 @@ namespace OpenRA.Mods.Common.Traits
 				RemoveCellsFromPlayerShroud(self, p);
 		}
 
-		public virtual WDist Range => CachedTraitDisabled ? WDist.Zero : Info.Range;
+		public virtual WDist Range => IsTraitDisabled ? WDist.Zero : Info.Range;
 
-		void INotifyMoving.MovementTypeChanged(Actor self, MovementType type)
+		readonly struct InputPositions : IEquatable<InputPositions>
 		{
-			// Recalculate the visibility at our final stop position
-			if (type == MovementType.None && self.IsInWorld)
+			public readonly (CPos Cell, SubCell SubCell)[] FootprintOccupiedCells { get; }
+			public readonly WPos CenterPosition { get; }
+
+			public InputPositions((CPos Cell, SubCell SubCell)[] footprintOccupiedCells, WPos centerPosition)
 			{
-				var centerPosition = self.CenterPosition;
-				var projectedPos = centerPosition - new WVec(0, centerPosition.Z, centerPosition.Z);
-				var projectedLocation = self.World.Map.CellContaining(projectedPos);
-				var pos = self.CenterPosition;
-
-				cachedLocation = projectedLocation;
-				cachedPos = pos;
-
-				UpdateShroudCells(self);
+				FootprintOccupiedCells = footprintOccupiedCells;
+				CenterPosition = centerPosition;
 			}
+
+			public bool Equals(InputPositions other)
+			{
+				if (CenterPosition != other.CenterPosition) return false;
+				if (FootprintOccupiedCells == null ^ other.FootprintOccupiedCells == null) return false;
+				if (FootprintOccupiedCells == null && other.FootprintOccupiedCells == null) return true;
+				return FootprintOccupiedCells.SequenceEqual(other.FootprintOccupiedCells);
+			}
+
+			public override int GetHashCode() =>
+				HashCode.Combine(CenterPosition, FootprintOccupiedCells?.FirstOrDefault());
+
+			public override bool Equals(object obj) => obj is InputPositions input && Equals(input);
+			public static bool operator ==(InputPositions left, InputPositions right) => left.Equals(right);
+			public static bool operator !=(InputPositions left, InputPositions right) => !(left == right);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/CreatesShroud.cs
+++ b/OpenRA.Mods.Common/Traits/CreatesShroud.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				if (CachedTraitDisabled)
+				if (IsTraitDisabled)
 					return WDist.Zero;
 
 				var range = Util.ApplyPercentageModifiers(Info.Range.Length, rangeModifiers);

--- a/OpenRA.Mods.Common/Traits/RevealsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/RevealsShroud.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				if (CachedTraitDisabled)
+				if (IsTraitDisabled)
 					return WDist.Zero;
 
 				var range = Util.ApplyPercentageModifiers(Info.Range.Length, rangeModifiers);


### PR DESCRIPTION
AffectsShroudInfo.MoveRecalculationThreshold is used to force a shroud recalculation as units move. The current setting means it is calculated 4 times through each cell, and again finally when the unit stops moving. Calculating the affected region and updating the shroud is quite an expensive operation.

The previous method used for MoveRecalculationThreshold would capture an accurate shroud boundary at the unit's current location, and then after moving this threshold recalculate it again. This means the accuracy would sawtooth between 0 world units and 256 world units behind the unit's current location. i.e. on average it is 128 world units behind.

We wish to increase the threshold in order to recalculate less often, but also avoid increasing the lag effect that comes from the above approach which means increasing the threshold increases the average distance the shroud trails behind.

We change the technique to instead quantize the current location. This means when the shroud is refreshed we pretend instead that the unit is in the middle of the cell. The accuracy now sawtooths between 512 world units *ahead* and 512 world units behind the unit's current location. This averages to 0!

Since this approach balances the inaccuracy between both ahead and behind, we can set the default threshold to 1 cell. However options both smaller and larger than this will work.

We also don't update once we stop moving - when the shroud was always behind, this meant it would always catch up to the current location. Now that it can be ahead, we don't want it to "snap back" when it becomes accurate, if our inaccurate boundary during movement meant we could see ahead of our actual location. Instead, we accept the inaccurate boundary.

----

Some years ago, we cached the shroud once per cell, at the unit's current location. This lead to issues such as #16952 and #16334 where the shroud "lagged behind".

#16953 fixed this by updating the shroud 4x per cell when moving, and again once movement stopped. This reduces the amount by which the shroud can lag behind at a 4x performance cost from updating the shroud so much. The performance impact was severe #17377, and #17383 introduced other shroud optimizations to offset it.

In this PR I take an adjusted approach to the original solve for the "shroud lag" issues that avoids the need for this performance hit whilst (hopefully) still producing an acceptable result.