### PR TITLE
Don't attempt moves when blocked by immovable actors.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -33,7 +33,6 @@ namespace OpenRA.Mods.Common.Activities
 			BlockedByActor.All,
 			BlockedByActor.Stationary,
 			BlockedByActor.Immovable,
-			BlockedByActor.None
 		];
 
 		int carryoverProgress;


### PR DESCRIPTION
The PathSearchOrder in Move defines a fallback mechanism. If a path cannot be found when accounting for all blocking actors, e.g. BlockedByActor.All, then the next fallback will be tried, and some actors will be ignored.

This fallback exists to help prevent actors getting blocked if the blocker might not be there forever. e.g. harvesters will want to return to the refinery to drop off resources. Without a fallback they will be blocked if another harvester is already at the refinery and dropping off. With the fallbacks, we'll ignore the other harvester and path anyway. For harvesters this works well, we know the harvester dropping off will likely have moved by the time we get there anyway. (introduced in #16408)

These fallbacks go all the way to BlockedByActor.None, meaning all actors on the map are ignored and only terrain is taken into account. This can result is paths being attempted to some seemingly "impossible" locations.

We remove BlockedByActor.None as a fallback option. If a path is blocked by an immovable actors such as trees or walls, the path will not be attempted. Previously a path would only be attempted if no route over the terrain was possible, e.g. when trying to path between two islands.

----

Closes #20246
Reopens #3671

Consider the following test suite, when moving the ranger from south to north:
![image](https://github.com/user-attachments/assets/e0e93c38-4146-46dd-a43c-769ef2185496)

Bleed:
1: Path not attempted, destroyed bridge counts as a gap in the terrain
2: Path attempted, blocked by tree
3: Path attempted, blocked by wall
4: Path succeeds, other ranger moves aside

PR:
1: Path not attempted
2: Path not attempted
3: Path not attempted
4: Path succeeds

This also highlights some that the notion of whether it is possible to complete the path isn't a cut and dry concept.

- In 1, the bridge counts as terrain, so when destroyed no path is possible. But if we repair the bridge this lays new terrain, and now a path is possible. Indeed any mechanism that modifies the terrain can fundamentally change the map layout and what path might be possible.
- In 2, the tree is an actor, but it can never be destroyed. No path is ever possible.
- In 3, the wall is an actor, but the wall *can* be destroyed. A path is possible if it is destroyed.

Conceptually this PR is therefore putting blocking actors like trees and walls into the same bucket as the bridge: It's *unlikely* but not impossible a path will be possible by the time we get to the blockage point, so don't try and path in the first place.

This also reintroduces the issue that information can be leaked through the fog of war. If you try to path into the fog when this should succeed and your unit doesn't move, you know the path has been blocked off by walls or something that you don't have vision over.