### PR TITLE
Fix unrelated CVE warnings

### DIFF
--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -3,7 +3,7 @@
     <RootNamespace>OpenRA</RootNamespace>
   </PropertyGroup>
   <ItemGroup Condition="'$(MSBuildRuntimeType)'!='Mono'">
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.2" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(MSBuildRuntimeType)'=='Mono'">


### PR DESCRIPTION
that happen because .NET changed `<NuGetAuditMode>` to `all`. See https://github.com/OpenHV/OpenHV/actions/runs/11987849692/job/33422489150 for example.