### PR TITLE
Fix harvesters refusing to allow queuing up docking orders when invalid

### DIFF
--- a/OpenRA.Mods.Common/Traits/DockClientBase.cs
+++ b/OpenRA.Mods.Common/Traits/DockClientBase.cs
@@ -37,9 +37,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual bool CanDockAt(Actor hostActor, IDockHost host, bool forceEnter = false, bool ignoreOccupancy = false)
 		{
-			return (forceEnter || self.Owner.IsAlliedWith(hostActor.Owner)) &&
-				CanDock(host.GetDockType, forceEnter) &&
-				host.IsDockingPossible(self, this, ignoreOccupancy);
+			return CanDock(host.GetDockType, forceEnter)
+				&& host.IsDockingPossible(self, this, ignoreOccupancy);
+		}
+
+		public virtual bool CanQueueDockAt(Actor hostActor, IDockHost host, bool forceEnter, bool isQueued)
+		{
+			return CanDock(host.GetDockType, true)
+				&& host.IsDockingPossible(self, this, true);
 		}
 
 		public virtual void OnDockStarted(Actor self, Actor hostActor, IDockHost host) { }

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -137,6 +137,12 @@ namespace OpenRA.Mods.Common.Traits
 				&& (self.Owner == hostActor.Owner || (ignoreOccupancy && self.Owner.IsAlliedWith(hostActor.Owner)));
 		}
 
+		public override bool CanQueueDockAt(Actor hostActor, IDockHost host, bool forceEnter, bool isQueued)
+		{
+			return base.CanQueueDockAt(hostActor, host, forceEnter, isQueued)
+				&& self.Owner.IsAlliedWith(hostActor.Owner);
+		}
+
 		void UpdateCondition(Actor self)
 		{
 			if (string.IsNullOrEmpty(Info.EmptyCondition))

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -220,19 +220,26 @@ namespace OpenRA.Mods.Common.Traits
 		bool OnDockTick(Actor self, Actor hostActor, IDockHost dock);
 		void OnDockCompleted(Actor self, Actor hostActor, IDockHost host);
 
-		/// <summary>Is this client allowed to dock.</summary>
+		/// <summary>Are we allowed to dock.</summary>
 		/// <remarks>
 		/// Does not check if <see cref="Traits.DockClientManager"/> is enabled.
 		/// Function should only be called from within <see cref="IDockClient"/> or <see cref="Traits.DockClientManager"/>.
 		/// </remarks>
 		bool CanDock(BitSet<DockType> type, bool forceEnter = false);
 
-		/// <summary>Is this client allowed to dock to <paramref name="host"/>.</summary>
+		/// <summary>Are we allowed to dock to this <paramref name="host"/>.</summary>
 		/// <remarks>
 		/// Does not check if <see cref="Traits.DockClientManager"/> is enabled.
 		/// Function should only be called from within <see cref="IDockClient"/> or <see cref="Traits.DockClientManager"/>.
 		/// </remarks>
 		bool CanDockAt(Actor hostActor, IDockHost host, bool forceEnter = false, bool ignoreOccupancy = false);
+
+		/// <summary>Are we allowed to give a docking order for this <paramref name="host"/>.</summary>
+		/// <remarks>
+		/// Does not check if <see cref="Traits.DockClientManager"/> is enabled.
+		/// Function should only be called from within <see cref="IDockClient"/> or <see cref="Traits.DockClientManager"/>.
+		/// </remarks>
+		bool CanQueueDockAt(Actor hostActor, IDockHost host, bool forceEnter, bool isQueued);
 	}
 
 	public interface IDockHostInfo : ITraitInfoInterface { }


### PR DESCRIPTION
It's a bug as by the time the queued dock order could be played as an activity, it might have become valid

Reported on discord