### PR TITLE
Fix(TS): Fixed QuantizeFacing divide error in Tiberian Sun

### DIFF
--- a/OpenRA.Mods.Common/Traits/BodyOrientation.cs
+++ b/OpenRA.Mods.Common/Traits/BodyOrientation.cs
@@ -52,6 +52,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual WAngle QuantizeFacing(WAngle facing, int facings)
 		{
+            if (facings <= 0)
+            {
+                return facing;
+            }
 			return Util.QuantizeFacing(facing, facings);
 		}
 

--- a/OpenRA.Mods.Common/Traits/BodyOrientation.cs
+++ b/OpenRA.Mods.Common/Traits/BodyOrientation.cs
@@ -52,10 +52,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual WAngle QuantizeFacing(WAngle facing, int facings)
 		{
+			// Quantization disabled
             if (facings <= 0)
-            {
                 return facing;
-            }
+
 			return Util.QuantizeFacing(facing, facings);
 		}
 


### PR DESCRIPTION
[2024-12-05T23:07:39] Game started.
Exception of type `System.DivideByZeroException`: Attempted to divide by zero.
   at OpenRA.Mods.Common.Traits.BodyOrientationInfo.QuantizeFacing(WAngle facing, Int32 facings) in D:\OpenRA\OpenRA.Mods.Common\Traits\BodyOrientation.cs:line 55
   at OpenRA.Mods.Common.Traits.BodyOrientation.QuantizeFacing(WAngle facing) in D:\OpenRA\OpenRA.Mods.Common\Traits\BodyOrientation.cs:line 111
   at OpenRA.Mods.Common.Traits.Render.WithIdleOverlay.<>c__DisplayClass1_1.<.ctor>b__6() in D:\OpenRA\OpenRA.Mods.Common\Traits\Render\WithIdleOverlay.cs:line 99
   at OpenRA.Graphics.Animation.Render(WPos pos, WVec& offset, Int32 zOffset, PaletteReference palette) in D:\OpenRA\OpenRA.Game\Graphics\Animation.cs:line 79
   at OpenRA.Graphics.AnimationWithOffset.Render(Actor self, PaletteReference pal) in D:\OpenRA\OpenRA.Game\Graphics\AnimationWithOffset.cs:line 44
   at OpenRA.Mods.Common.Traits.Render.RenderSprites.Render(Actor self, WorldRenderer wr)+MoveNext() in D:\OpenRA\OpenRA.Mods.Common\Traits\Render\RenderSprites.cs:line 192
   at OpenRA.Actor.Renderables(WorldRenderer wr)+MoveNext() in D:\OpenRA\OpenRA.Game\Actor.cs:line 307
   at System.Linq.Enumerable.SelectEnumerableIterator`2.ToList()
   at OpenRA.Mods.Common.Traits.Render.WithShadow.OpenRA.Traits.IRenderModifier.ModifyRender(Actor self, WorldRenderer wr, IEnumerable`1 r) in D:\OpenRA\OpenRA.Mods.Common\Traits\Render\WithShadow.cs:line 54
   at OpenRA.Actor.Render(WorldRenderer wr) in D:\OpenRA\OpenRA.Game\Actor.cs:line 293
   at OpenRA.Graphics.WorldRenderer.GenerateRenderables() in D:\OpenRA\OpenRA.Game\Graphics\WorldRenderer.cs:line 141
   at OpenRA.Graphics.WorldRenderer.PrepareRenderables() in D:\OpenRA\OpenRA.Game\Graphics\WorldRenderer.cs:line 263
   at OpenRA.Game.RenderTick() in D:\OpenRA\OpenRA.Game\Game.cs:line 748
   at OpenRA.Game.Loop() in D:\OpenRA\OpenRA.Game\Game.cs:line 856
   at OpenRA.Game.Run() in D:\OpenRA\OpenRA.Game\Game.cs:line 888
   at OpenRA.Game.InitializeAndRun(String[] args) in D:\OpenRA\OpenRA.Game\Game.cs:line 313
   at OpenRA.Launcher.Program.Main(String[] args) in D:\OpenRA\OpenRA.Launcher\Program.cs:line 46

terminate called without an active exception

This application has requested the Runtime to terminate it in an unusual way.
Please contact the application's support team for more information.
----------------------------------------
OpenRA has encountered a fatal error.
  * Log Files are available in C:\Users\AoMe\AppData\Roaming\OpenRA\Logs
  * FAQ is available at https://github.com/OpenRA/OpenRA/wiki/FAQ
----------------------------------------