### PR TITLE
Reduce the size of battlefield news when messages are short

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -43,6 +43,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		protected MenuType menuType = MenuType.Main;
 		readonly Widget rootMenu;
 		readonly ScrollPanelWidget newsPanel;
+		readonly int maxNewsHeight;
 		readonly Widget newsTemplate;
 		readonly LabelWidget newsStatus;
 		readonly ModData modData;
@@ -230,6 +231,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				newsPanel = Ui.LoadWidget<ScrollPanelWidget>("NEWS_PANEL", null, new WidgetArgs());
 				newsTemplate = newsPanel.Get("NEWS_ITEM_TEMPLATE");
 				newsPanel.RemoveChild(newsTemplate);
+				maxNewsHeight = newsPanel.Bounds.Height;
 
 				newsStatus = newsPanel.Get<LabelWidget>("NEWS_STATUS");
 				SetNewsStatus(FluentProvider.GetMessage(LoadingNews));
@@ -416,10 +418,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			newsPanel.RemoveChildren();
 			SetNewsStatus("");
 
-			foreach (var i in newsItems)
+			foreach (var item in newsItems)
 			{
-				var item = i;
-
 				var newsItem = newsTemplate.Clone();
 
 				var titleLabel = newsItem.Get<LabelWidget>("TITLE");
@@ -441,6 +441,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				newsPanel.AddChild(newsItem);
 				newsPanel.Layout.AdjustChildren();
+				newsPanel.Bounds.Height = Math.Min(newsPanel.ContentHeight, maxNewsHeight);
 			}
 		}
 

--- a/mods/cnc/chrome/dialogs.yaml
+++ b/mods/cnc/chrome/dialogs.yaml
@@ -284,29 +284,27 @@ ScrollPanel@NEWS_PANEL:
 	Width: 400
 	Height: 265
 	Background: panel-black
-	TopBottomSpacing: 5
+	TopBottomSpacing: 10
 	ItemSpacing: 5
 	Children:
 		Container@NEWS_ITEM_TEMPLATE:
 			X: 10
-			Y: 5
 			Width: PARENT_WIDTH - 40
-			Height: 45
+			Height: 40
 			Children:
 				Label@TITLE:
-					Y: 1
 					Width: PARENT_WIDTH
-					Height: 25
+					Height: 20
 					Align: Center
 					Font: Bold
 				Label@AUTHOR_DATETIME:
-					Y: 26
+					Y: 21
 					Width: PARENT_WIDTH
 					Height: 15
 					Align: Center
 					Font: TinyBold
 				Label@CONTENT:
-					Y: 46
+					Y: 40
 					Width: PARENT_WIDTH
 		Label@NEWS_STATUS:
 			X: 80

--- a/mods/common/chrome/dropdowns.yaml
+++ b/mods/common/chrome/dropdowns.yaml
@@ -152,32 +152,30 @@ ScrollPanel@SPECTATOR_LABEL_DROPDOWN_TEMPLATE:
 ScrollPanel@NEWS_PANEL:
 	Width: 400
 	Height: 265
-	TopBottomSpacing: 5
+	TopBottomSpacing: 15
 	ItemSpacing: 5
 	Children:
 		Container@NEWS_ITEM_TEMPLATE:
 			X: 10
-			Y: 5
 			Width: PARENT_WIDTH - 40
-			Height: 45
+			Height: 40
 			Children:
 				Label@TITLE:
 					Width: PARENT_WIDTH
-					Height: 25
+					Height: 15
 					Align: Center
 					Font: Bold
 				Label@AUTHOR_DATETIME:
-					Y: 25
+					Y: 20
 					Width: PARENT_WIDTH
 					Height: 15
 					Align: Center
 					Font: TinyBold
 				Label@CONTENT:
-					Y: 45
+					Y: 40
 					Width: PARENT_WIDTH
 		Label@NEWS_STATUS:
 			X: 80
-			Y: 0
 			Width: PARENT_WIDTH - 80 - 80 - 24
 			Height: PARENT_HEIGHT
 			Align: Center

--- a/mods/d2k/chrome/dropdowns.yaml
+++ b/mods/d2k/chrome/dropdowns.yaml
@@ -116,32 +116,30 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 ScrollPanel@NEWS_PANEL:
 	Width: 400
 	Height: 265
-	TopBottomSpacing: 5
+	TopBottomSpacing: 15
 	ItemSpacing: 5
 	Children:
 		Container@NEWS_ITEM_TEMPLATE:
 			X: 10
-			Y: 5
 			Width: PARENT_WIDTH - 40
-			Height: 45
+			Height: 40
 			Children:
 				Label@TITLE:
 					Width: PARENT_WIDTH
-					Height: 25
+					Height: 15
 					Align: Center
 					Font: Bold
 				Label@AUTHOR_DATETIME:
-					Y: 25
+					Y: 20
 					Width: PARENT_WIDTH
 					Height: 15
 					Align: Center
 					Font: TinyBold
 				Label@CONTENT:
-					Y: 45
+					Y: 40
 					Width: PARENT_WIDTH
 		Label@NEWS_STATUS:
 			X: 80
-			Y: 0
 			Width: PARENT_WIDTH - 80 - 80 - 24
 			Height: PARENT_HEIGHT
 			Align: Center

--- a/mods/ts/chrome/dropdowns.yaml
+++ b/mods/ts/chrome/dropdowns.yaml
@@ -116,32 +116,30 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 ScrollPanel@NEWS_PANEL:
 	Width: 400
 	Height: 265
-	TopBottomSpacing: 5
+	TopBottomSpacing: 15
 	ItemSpacing: 5
 	Children:
 		Container@NEWS_ITEM_TEMPLATE:
 			X: 10
-			Y: 6
 			Width: PARENT_WIDTH - 40
-			Height: 45
+			Height: 40
 			Children:
 				Label@TITLE:
 					Width: PARENT_WIDTH
-					Height: 25
+					Height: 15
 					Align: Center
 					Font: Bold
 				Label@AUTHOR_DATETIME:
-					Y: 25
+					Y: 20
 					Width: PARENT_WIDTH
 					Height: 15
 					Align: Center
 					Font: TinyBold
 				Label@CONTENT:
-					Y: 45
+					Y: 40
 					Width: PARENT_WIDTH
 		Label@NEWS_STATUS:
 			X: 80
-			Y: 1
 			Width: PARENT_WIDTH - 80 - 80 - 24
 			Height: PARENT_HEIGHT
 			Align: Center


### PR DESCRIPTION
# Bleed

<img width="483" alt="Screenshot 2024-12-10 at 23 43 33" src="https://github.com/user-attachments/assets/f3e4214a-c1a4-4dd7-9bf3-3476b37c9b1a">

<img width="445" alt="Screenshot 2024-12-10 at 22 52 44" src="https://github.com/user-attachments/assets/b70f64e8-c3f7-4f19-9eb5-fa0c5a5d5245">

# Suggested

<img width="451" alt="Screenshot 2024-12-10 at 23 39 25" src="https://github.com/user-attachments/assets/44b4b918-628d-4891-ba65-56c00e076a4e">
<img width="426" alt="Screenshot 2024-12-10 at 23 36 37" src="https://github.com/user-attachments/assets/00e080a6-089f-4dd3-9f06-26a9c568c3c9">
<img width="470" alt="Screenshot 2024-12-10 at 23 42 09" src="https://github.com/user-attachments/assets/5759628e-cd2f-4482-a049-bf8fc112f829">
<img width="471" alt="Screenshot 2024-12-10 at 23 42 50" src="https://github.com/user-attachments/assets/b32568a7-0ef1-491c-9c79-56eb48d155ac">
