### PR TITLE
Don't bind bogus Location or Facing lua properties for actors without Location or Facing

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
@@ -96,7 +96,6 @@ namespace OpenRA.Mods.Common.Scripting
 	[ScriptPropertyGroup("General")]
 	public class GeneralProperties : ScriptActorProperties
 	{
-		readonly IFacing facing;
 		readonly AutoTarget autotarget;
 		readonly ScriptTags scriptTags;
 		readonly Tooltip[] tooltips;
@@ -104,22 +103,9 @@ namespace OpenRA.Mods.Common.Scripting
 		public GeneralProperties(ScriptContext context, Actor self)
 			: base(context, self)
 		{
-			facing = self.TraitOrDefault<IFacing>();
 			autotarget = self.TraitOrDefault<AutoTarget>();
 			scriptTags = self.TraitOrDefault<ScriptTags>();
 			tooltips = self.TraitsImplementing<Tooltip>().ToArray();
-		}
-
-		[Desc("The direction that the actor is facing.")]
-		public WAngle Facing
-		{
-			get
-			{
-				if (facing == null)
-					throw new LuaException($"Actor '{Self}' doesn't define a facing");
-
-				return facing.Facing;
-			}
 		}
 
 		[ScriptActorPropertyActivity]
@@ -219,5 +205,20 @@ namespace OpenRA.Mods.Common.Scripting
 
 		[Desc("The actor position in world coordinates.")]
 		public WPos CenterPosition => Self.CenterPosition;
+	}
+
+	[ScriptPropertyGroup("General")]
+	public class FacingProperties : ScriptActorProperties, Requires<IFacingInfo>
+	{
+		readonly IFacing facing;
+
+		public FacingProperties(ScriptContext context, Actor self)
+			: base(context, self)
+		{
+			facing = self.Trait<IFacing>();
+		}
+
+		[Desc("The direction that the actor is facing.")]
+		public WAngle Facing => facing.Facing;
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
@@ -110,12 +110,6 @@ namespace OpenRA.Mods.Common.Scripting
 			tooltips = self.TraitsImplementing<Tooltip>().ToArray();
 		}
 
-		[Desc("The actor position in cell coordinates.")]
-		public CPos Location => Self.Location;
-
-		[Desc("The actor position in world coordinates.")]
-		public WPos CenterPosition => Self.CenterPosition;
-
 		[Desc("The direction that the actor is facing.")]
 		public WAngle Facing
 		{
@@ -212,5 +206,18 @@ namespace OpenRA.Mods.Common.Scripting
 		{
 			return IsTaggable && scriptTags.HasTag(tag);
 		}
+	}
+
+	[ScriptPropertyGroup("General")]
+	public class LocationProperties : ScriptActorProperties, Requires<IOccupySpaceInfo>
+	{
+		public LocationProperties(ScriptContext context, Actor self)
+			: base(context, self) { }
+
+		[Desc("The actor position in cell coordinates.")]
+		public CPos Location => Self.Location;
+
+		[Desc("The actor position in world coordinates.")]
+		public WPos CenterPosition => Self.CenterPosition;
 	}
 }


### PR DESCRIPTION
Fixes an issue brought up on Discord where `HasProperty` returns true but the script crashes when they are used on e.g. the player actor.

Testcase: add the following to the bottom of the RA shellmap's `WorldLoaded` function:
```
Utils.Do(Allies.GetActors(), function(f) if f.HasProperty("Location") then print(f.Location.X) end end)
```

Note: Similar changes really should be done for the other methods/properties in `GeneralProperties`, but those would be breaking API changes, so I don't want to deal with them here.