### PR TITLE
Don't show cash trickler when cloaked

### DIFF
--- a/OpenRA.Mods.Common/Traits/CashTrickler.cs
+++ b/OpenRA.Mods.Common/Traits/CashTrickler.cs
@@ -91,13 +91,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		void AddCashTick(Actor self, int amount)
-		{
-			self.World.AddFrameEndTask(w => w.Add(
-				new FloatingText(self.CenterPosition, self.OwnerColor(), FloatingText.FormatCashTick(amount), info.DisplayDuration)));
-		}
-
-		void ModifyCash(Actor self, int amount)
+		public virtual void ModifyCash(Actor self, int amount)
 		{
 			if (info.UseResourceStorage)
 			{
@@ -112,7 +106,8 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			if (info.ShowTicks && amount != 0)
-				AddCashTick(self, amount);
+				self.World.AddFrameEndTask(w =>
+					w.Add(new FloatingText(self.CenterPosition, self.OwnerColor(), FloatingText.FormatCashTick(amount), info.DisplayDuration)));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/CashTrickler.cs
+++ b/OpenRA.Mods.Common/Traits/CashTrickler.cs
@@ -49,6 +49,8 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly CashTricklerInfo info;
 		PlayerResources resources;
+		Cloak[] cloaks;
+
 		[Sync]
 		public int Ticks { get; private set; }
 
@@ -62,6 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 		protected override void Created(Actor self)
 		{
 			resources = self.Owner.PlayerActor.Trait<PlayerResources>();
+			cloaks = self.TraitsImplementing<Cloak>().ToArray();
 
 			base.Created(self);
 		}
@@ -104,6 +107,9 @@ namespace OpenRA.Mods.Common.Traits
 			}
 			else
 				amount = resources.ChangeCash(amount);
+
+			if (cloaks.Length != 0 && !cloaks.Any(c => c.IsVisible(self, self.World.RenderPlayer)))
+				return;
 
 			if (info.ShowTicks && amount != 0)
 				AddCashTick(self, amount);


### PR DESCRIPTION
Also add a flag for fake tricklers

Used In Shattered Paradise 