### PR TITLE
Add smart deploy

### DIFF
--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -135,6 +135,7 @@ thumper:
 		UndeployOnMove: true
 		Facing: 512
 		AllowedTerrainTypes: Sand, Spice, Dune, SpiceSand
+		SmartDeploy: true
 	Encyclopedia:
 		Description: actor-thumper.encyclopedia
 		Order: 40

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -371,6 +371,7 @@ JUGG:
 		DeploySounds: place2.aud
 		UndeploySounds: clicky1.aud
 		Voice: Move
+		SmartDeploy: true
 	EntersTunnels:
 		RequireForceMoveCondition: !undeployed
 	Repairable:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -140,6 +140,7 @@ TTNK:
 		DeploySounds: place2.aud
 		UndeploySounds: clicky1.aud
 		Voice: Move
+		SmartDeploy: true
 	EntersTunnels:
 		RequireForceMoveCondition: !undeployed
 	Repairable:
@@ -252,6 +253,7 @@ ART2:
 		DeploySounds: place2.aud
 		UndeploySounds: clicky1.aud
 		Voice: Move
+		SmartDeploy: true
 	EntersTunnels:
 		RequireForceMoveCondition: !undeployed
 	Repairable:
@@ -605,6 +607,7 @@ SGEN:
 		DeploySounds: place2.aud
 		UndeploySounds: clicky1.aud
 		Voice: Move
+		SmartDeploy: true
 	EntersTunnels:
 		RequireForceMoveCondition: !undeployed
 	Repairable:

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -169,6 +169,7 @@ LPST:
 		DeploySounds: place2.aud
 		UndeploySounds: clicky1.aud
 		Voice: Move
+		SmartDeploy: true
 	EntersTunnels:
 		RequireForceMoveCondition: !undeployed
 	Repairable:


### PR DESCRIPTION
New Behaviour: Units refuse to undeploy while there are undeployed units in selection. It can be seen as the deploy action having priority over undeploy.

The opposite behaviour can already be achieved with force move, where only deployed units undeploy.

Used in Shattered Paradise and Romanov's Vengeance. It's a critical feature for wielding a lot of deployable units

Note: As this check happens at order issuing time, it means the game state is lagging behind; thus, spamming the order may not give the intended results.