### PR TITLE
Add line dragging to the map editor

### DIFF
--- a/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
@@ -100,6 +100,8 @@ namespace OpenRA.Mods.Common.Widgets
 			return true;
 		}
 
+		public bool HandleKeyboardInput(KeyInput ki) => false;
+
 		void IEditorBrush.TickRender(WorldRenderer wr, Actor self)
 		{
 			// Offset mouse position by the center offset (in world pixels)

--- a/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
@@ -10,37 +10,55 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Widgets
 {
 	public sealed class EditorActorBrush : IEditorBrush
 	{
-		public EditorActorPreview Preview;
+		public List<EditorActorPreview> Previews = [];
 
-		readonly World world;
+		readonly WorldRenderer worldRenderer;
 		readonly EditorActorLayer editorLayer;
 		readonly EditorActionManager editorActionManager;
 		readonly EditorViewportControllerWidget editorWidget;
 		readonly WVec centerOffset;
 		readonly bool sharesCell;
 
+		readonly BuildingInfo buildingInfo;
+		readonly int2 dimentions;
+		readonly LineBuildNodeInfo lineBuildInfo;
+
 		CPos cell;
 		SubCell subcell = SubCell.Invalid;
+
+		bool shiftHeldDown;
+		bool dragging;
+		CPos startCell;
 
 		public EditorActorBrush(EditorViewportControllerWidget editorWidget, ActorInfo actor, PlayerReference owner, WorldRenderer wr)
 		{
 			this.editorWidget = editorWidget;
-			world = wr.World;
+			var world = wr.World;
+			worldRenderer = wr;
 			editorLayer = world.WorldActor.Trait<EditorActorLayer>();
 			editorActionManager = world.WorldActor.Trait<EditorActionManager>();
 
 			var ios = actor.TraitInfoOrDefault<IOccupySpaceInfo>();
-			centerOffset = (ios as BuildingInfo)?.CenterOffset(world) ?? WVec.Zero;
+			buildingInfo = ios as BuildingInfo;
+			centerOffset = buildingInfo?.CenterOffset(world) ?? WVec.Zero;
+
+			dimentions = buildingInfo != null
+				? new int2(buildingInfo.Dimensions.X, buildingInfo.Dimensions.Y)
+				: new int2(1, 1);
+
 			sharesCell = ios != null && ios.SharesCell;
+			lineBuildInfo = actor.TraitInfoOrDefault<LineBuildNodeInfo>();
 
 			// Enforce first entry of ValidOwnerNames as owner if the actor has RequiresSpecificOwners.
 			var ownerName = owner.Name;
@@ -67,11 +85,27 @@ namespace OpenRA.Mods.Common.Widgets
 			if (actor.HasTraitInfo<IFacingInfo>())
 				reference.Add(new FacingInit(editorLayer.Info.DefaultActorFacing));
 
-			Preview = new EditorActorPreview(wr, null, reference, owner);
+			Previews.Add(new EditorActorPreview(wr, null, reference, owner));
 		}
 
 		public bool HandleMouseInput(MouseInput mi)
 		{
+			if (mi.Event == MouseInputEvent.Move)
+			{
+				// Offset mouse position by the center offset (in world pixels)
+				var worldPx = worldRenderer.Viewport.ViewToWorldPx(Viewport.LastMousePos) - worldRenderer.ScreenPxOffset(centerOffset);
+				var currentCell = worldRenderer.Viewport.ViewToWorld(worldRenderer.Viewport.WorldToViewPx(worldPx));
+				var currentSubcell = sharesCell ? editorLayer.FreeSubCellAt(currentCell) : SubCell.Invalid;
+				if (cell != currentCell || subcell != currentSubcell)
+				{
+					cell = currentCell;
+					if (sharesCell)
+						subcell = editorLayer.FreeSubCellAt(cell);
+
+					UpdateLine();
+				}
+			}
+
 			// Exclusively uses left and right mouse buttons, but nothing else.
 			if (mi.Button != MouseButton.Left && mi.Button != MouseButton.Right)
 				return false;
@@ -87,53 +121,152 @@ namespace OpenRA.Mods.Common.Widgets
 				return false;
 			}
 
-			if (mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Down)
-			{
-				// Check the actor is inside the map
-				if (!Preview.Footprint.All(c => world.Map.Tiles.Contains(c.Key)))
-					return true;
+			if (mi.Button != MouseButton.Left)
+				return true;
 
-				var action = new AddActorAction(editorLayer, Preview.Export());
-				editorActionManager.Add(action);
+			if (mi.Event == MouseInputEvent.Down)
+			{
+				startCell = cell;
+				dragging = true;
+				UpdateLine();
+			}
+
+			if (mi.Event == MouseInputEvent.Up)
+			{
+				UpdateLine(true);
+
+				var actors = Previews
+					.Where(p => p.Footprint.All(c => worldRenderer.World.Map.Tiles.Contains(c.Key)))
+					.Select(p => p.Export())
+					.ToImmutableArray();
+
+				if (actors.Length != 0)
+					editorActionManager.Add(new AddActorsAction(editorLayer, actors));
+
+				dragging = false;
+				UpdateLine();
 			}
 
 			return true;
 		}
 
-		public bool HandleKeyboardInput(KeyInput ki) => false;
-
-		void IEditorBrush.TickRender(WorldRenderer wr, Actor self)
+		public bool HandleKeyboardInput(KeyInput ki)
 		{
-			// Offset mouse position by the center offset (in world pixels)
-			var worldPx = wr.Viewport.ViewToWorldPx(Viewport.LastMousePos) - wr.ScreenPxOffset(centerOffset);
-			var currentCell = wr.Viewport.ViewToWorld(wr.Viewport.WorldToViewPx(worldPx));
-			var currentSubcell = sharesCell ? editorLayer.FreeSubCellAt(currentCell) : SubCell.Invalid;
-			if (cell != currentCell || subcell != currentSubcell)
+			if (ki.Key == Keycode.LSHIFT || ki.Key == Keycode.RSHIFT)
 			{
-				cell = currentCell;
-				Preview.ReplaceInit(new LocationInit(cell));
+				shiftHeldDown = ki.Event == KeyInputEvent.Down;
+				UpdateLine();
+			}
 
+			return false;
+		}
+
+		public void UpdatePreviewsOwner(PlayerReference owner)
+		{
+			foreach (var preview in Previews)
+			{
+				preview.Owner = owner;
+				preview.ReplaceInit(new OwnerInit(owner.Name));
+				preview.ReplaceInit(new FactionInit(owner.Faction));
+			}
+		}
+
+		// PERF: reduce allocations by reusing the list.
+		readonly List<CPos> cells = [];
+		void UpdateLine(bool commiting = false)
+		{
+			cells.Clear();
+			if (dragging && shiftHeldDown)
+				cells.AddRange(Util.GetCurvedLine(startCell, cell, dimentions));
+			else if (dragging)
+			{
+				cells.Add(startCell);
+
+				// If the user placed an actor, we want it to feel responsive.
+				if (!commiting && cell != startCell)
+					cells.Add(cell);
+			}
+			else
+				cells.Add(cell);
+
+			var basePreview = Previews[0];
+			var currentPreviews = Previews.Count;
+			var needToUpdate = cells.Count;
+			if (cells.Count > currentPreviews)
+			{
+				for (var i = currentPreviews; i < cells.Count; i++)
+				{
+					var cell = cells[i];
+					var reference = basePreview.Export();
+					reference.Replace(new LocationInit(cell));
+					if (sharesCell)
+					{
+						subcell = editorLayer.FreeSubCellAt(cell);
+						if (subcell == SubCell.Invalid)
+							reference.RemoveAll<SubCellInit>();
+						else
+							reference.Replace(new SubCellInit(subcell));
+					}
+
+					Previews.Add(new EditorActorPreview(worldRenderer, null, reference, basePreview.Owner));
+				}
+
+				needToUpdate = currentPreviews;
+			}
+			else if (cells.Count < currentPreviews)
+				for (var i = currentPreviews - 1; i >= cells.Count; i--)
+					Previews.RemoveAt(i);
+
+			for (var i = 0; i < needToUpdate; i++)
+			{
+				var cell = cells[i];
+				var preview = Previews[i];
+				preview.ReplaceInit(new LocationInit(cell));
 				if (sharesCell)
 				{
 					subcell = editorLayer.FreeSubCellAt(cell);
 					if (subcell == SubCell.Invalid)
-						Preview.RemoveInit<SubCellInit>();
+						preview.RemoveInit<SubCellInit>();
 					else
-						Preview.ReplaceInit(new SubCellInit(subcell));
+						preview.ReplaceInit(new SubCellInit(subcell));
 				}
 
-				Preview.UpdateFromMove();
+				preview.UpdateFromMove();
+			}
+
+			if (lineBuildInfo == null)
+				return;
+
+			// It's nicer when previews can connect.
+			for (var i = 0; i < Previews.Count; i++)
+			{
+				var dict = new Dictionary<CPos, string[]>();
+				if (i != 0)
+				{
+					var neighbour = Previews[i - 1];
+					dict[neighbour.Location] = [neighbour.Info.Name];
+				}
+
+				if (i != Previews.Count - 1)
+				{
+					var neighbour = Previews[i + 1];
+					dict[neighbour.Location] = [neighbour.Info.Name];
+				}
+
+				Previews[i].ReplaceInit(new RuntimeNeighbourInit(dict));
 			}
 		}
 
+		void IEditorBrush.TickRender(WorldRenderer wr, Actor self) { }
+
 		IEnumerable<IRenderable> IEditorBrush.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
-			return Preview.Render().OrderBy(WorldRenderer.RenderableZPositionComparisonKey);
+			return Previews.SelectMany(p => p.Render()).OrderBy(WorldRenderer.RenderableZPositionComparisonKey);
 		}
 
 		IEnumerable<IRenderable> IEditorBrush.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
-			return Preview.RenderAnnotations();
+			return Previews.SelectMany(p => p.RenderAnnotations()).OrderBy(WorldRenderer.RenderableZPositionComparisonKey);
 		}
 
 		public void Tick() { }
@@ -141,24 +274,22 @@ namespace OpenRA.Mods.Common.Widgets
 		public void Dispose() { }
 	}
 
-	sealed class AddActorAction : IEditorAction
+	sealed class AddActorsAction : IEditorAction
 	{
 		public string Text { get; private set; }
 
-		[FluentReference("name", "id")]
-		const string AddedActor = "notification-added-actor";
+		[FluentReference("name", "id", "count")]
+		const string AddedActors = "notification-added-actors";
 
 		readonly EditorActorLayer editorLayer;
-		readonly ActorReference actor;
+		readonly ImmutableArray<ActorReference> actor;
 
-		EditorActorPreview editorActorPreview;
+		ImmutableArray<EditorActorPreview> editorActorPreviews;
 
-		public AddActorAction(EditorActorLayer editorLayer, ActorReference actor)
+		public AddActorsAction(EditorActorLayer editorLayer, ImmutableArray<ActorReference> actor)
 		{
 			this.editorLayer = editorLayer;
-
-			// Take an immutable copy of the reference.
-			this.actor = actor.Clone();
+			this.actor = actor;
 		}
 
 		public void Execute()
@@ -168,15 +299,16 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public void Do()
 		{
-			editorActorPreview = editorLayer.Add(actor);
-			Text = FluentProvider.GetMessage(AddedActor,
-				"name", editorActorPreview.Info.Name,
-				"id", editorActorPreview.ID);
+			editorActorPreviews = editorLayer.AddRange(actor.AsSpan()).ToImmutableArray();
+			Text = FluentProvider.GetMessage(AddedActors,
+				"name", editorActorPreviews[0].Info.Name,
+				"id", editorActorPreviews[0].ID,
+				"count", editorActorPreviews.Length);
 		}
 
 		public void Undo()
 		{
-			editorLayer.Remove(editorActorPreview);
+			editorLayer.RemoveRange(editorActorPreviews.AsSpan());
 		}
 	}
 }

--- a/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
@@ -87,6 +87,8 @@ namespace OpenRA.Mods.Common.Widgets
 			return false;
 		}
 
+		public bool HandleKeyboardInput(KeyInput ki) => false;
+
 		void IEditorBrush.TickRender(WorldRenderer wr, Actor self) { }
 		IEnumerable<IRenderable> IEditorBrush.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{

--- a/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
@@ -24,6 +24,7 @@ namespace OpenRA.Mods.Common.Widgets
 	public interface IEditorBrush : IDisposable
 	{
 		bool HandleMouseInput(MouseInput mi);
+		bool HandleKeyboardInput(KeyInput ki);
 		void Tick();
 
 		void TickRender(WorldRenderer wr, Actor self);
@@ -274,6 +275,8 @@ namespace OpenRA.Mods.Common.Widgets
 
 			return true;
 		}
+
+		public bool HandleKeyboardInput(KeyInput ki) => false;
 
 		void IEditorBrush.TickRender(WorldRenderer wr, Actor self) { }
 		IEnumerable<IRenderable> IEditorBrush.RenderAboveShroud(Actor self, WorldRenderer wr) { yield break; }

--- a/OpenRA.Mods.Common/EditorBrushes/EditorMarkerLayerBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorMarkerLayerBrush.cs
@@ -28,9 +28,10 @@ namespace OpenRA.Mods.Common.Widgets
 		readonly MarkerLayerOverlay markerLayerOverlay;
 		readonly EditorViewportControllerWidget editorWidget;
 
-		readonly List<PaintMarkerTile> paintTiles = [];
+		readonly Dictionary<CPos, int?> paintTiles = [];
+		readonly List<CPos> cells = [];
 		bool painting;
-		CPos cell;
+		bool shiftHeldDown;
 
 		public EditorMarkerLayerBrush(EditorViewportControllerWidget editorWidget, int? id, WorldRenderer wr)
 		{
@@ -64,58 +65,86 @@ namespace OpenRA.Mods.Common.Widgets
 			if (mi.Button != MouseButton.Left)
 				return true;
 
-			if (mi.Event == MouseInputEvent.Up)
+			UpdatePreview();
+			if (mi.Event == MouseInputEvent.Down)
+			{
+				painting = true;
+
+				UpdatePreview();
+			}
+			else if (mi.Event == MouseInputEvent.Up)
 			{
 				UpdatePreview();
 				if (paintTiles.Count != 0)
 				{
-					editorActionManager.Add(new PaintMarkerTileEditorAction(Template, paintTiles.ToImmutableArray(), markerLayerOverlay));
+					var tiles = paintTiles.Select(t => new PaintMarkerTile(t.Key, t.Value)).ToImmutableArray();
+					editorActionManager.Add(new PaintMarkerTileEditorAction(Template, tiles, markerLayerOverlay));
 					paintTiles.Clear();
-					UpdatePreview(true);
 				}
 
 				painting = false;
+				UpdatePreview(true);
 			}
 			else
-			{
-				painting = true;
 				UpdatePreview();
-			}
 
 			return true;
+		}
+
+		public bool HandleKeyboardInput(KeyInput ki)
+		{
+			if (ki.Key == Keycode.LSHIFT || ki.Key == Keycode.RSHIFT)
+			{
+				shiftHeldDown = ki.Event == KeyInputEvent.Down;
+				UpdatePreview(true);
+			}
+
+			return false;
 		}
 
 		void UpdatePreview(bool forceRefresh = false)
 		{
 			var currentCell = worldRenderer.Viewport.ViewToWorld(Viewport.LastMousePos);
-			if (!forceRefresh && cell == currentCell)
+			if (!forceRefresh && cells.Contains(currentCell))
 				return;
 
-			cell = currentCell;
-
-			if (!painting)
+			if (!painting || shiftHeldDown)
 			{
 				foreach (var paintTile in paintTiles)
-					markerLayerOverlay.SetTile(paintTile.Cell, paintTile.Previous);
+					markerLayerOverlay.SetTile(paintTile.Key, paintTile.Value);
 
 				paintTiles.Clear();
 			}
 
-			foreach (var cell in markerLayerOverlay.CalculateMirrorPositions(cell))
+			if (!painting)
+				cells.Clear();
+
+			cells.Add(currentCell);
+			IEnumerable<CPos> cellsToPaint;
+			if (shiftHeldDown)
+				cellsToPaint = Util.GetCurvedLine(cells[0], cells[^1], new int2(1, 1));
+			else
+				cellsToPaint = cells;
+
+			foreach (var c in cellsToPaint)
 			{
-				if (paintTiles.Any(t => t.Cell == cell))
-					continue;
+				foreach (var cell in markerLayerOverlay.CalculateMirrorPositions(c))
+				{
+					if (!world.Map.Contains(c))
+						continue;
 
-				var existing = markerLayerOverlay.CellLayer[cell];
-				if (existing == Template)
-					continue;
+					if (paintTiles.ContainsKey(cell))
+						continue;
 
-				paintTiles.Add(new PaintMarkerTile(cell, existing));
-				markerLayerOverlay.SetTile(cell, Template);
+					var existing = markerLayerOverlay.CellLayer[cell];
+					if (existing == Template)
+						continue;
+
+					paintTiles[cell] = existing;
+					markerLayerOverlay.SetTile(cell, Template);
+				}
 			}
 		}
-
-		public bool HandleKeyboardInput(KeyInput ki) => false;
 
 		void IEditorBrush.TickRender(WorldRenderer wr, Actor self) { UpdatePreview(); }
 		IEnumerable<IRenderable> IEditorBrush.RenderAboveShroud(Actor self, WorldRenderer wr) { yield break; }
@@ -126,7 +155,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public void Dispose()
 		{
 			foreach (var paintTile in paintTiles)
-				markerLayerOverlay.SetTile(paintTile.Cell, paintTile.Previous);
+				markerLayerOverlay.SetTile(paintTile.Key, paintTile.Value);
 		}
 	}
 

--- a/OpenRA.Mods.Common/EditorBrushes/EditorMarkerLayerBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorMarkerLayerBrush.cs
@@ -115,6 +115,8 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 		}
 
+		public bool HandleKeyboardInput(KeyInput ki) => false;
+
 		void IEditorBrush.TickRender(WorldRenderer wr, Actor self) { UpdatePreview(); }
 		IEnumerable<IRenderable> IEditorBrush.RenderAboveShroud(Actor self, WorldRenderer wr) { yield break; }
 		IEnumerable<IRenderable> IEditorBrush.RenderAnnotations(Actor self, WorldRenderer wr) { yield break; }

--- a/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
@@ -82,6 +82,8 @@ namespace OpenRA.Mods.Common.Widgets
 			return true;
 		}
 
+		public bool HandleKeyboardInput(KeyInput ki) => false;
+
 		void UpdatePreview()
 		{
 			var pos = world.Map.CenterOfCell(cell);

--- a/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
@@ -25,13 +25,17 @@ namespace OpenRA.Mods.Common.Widgets
 		readonly EditorViewportControllerWidget editorWidget;
 		readonly EditorActionManager editorActionManager;
 		readonly IResourceLayer resourceLayer;
+		readonly IResourceRenderer[] resourceRenderers;
+
+		readonly HashSet<CPos> cells = [];
+		readonly List<IRenderable> preview = [];
 
 		AddResourcesEditorAction action;
-		bool resourceAdded;
+
+		bool linePainting;
+		CPos lineStart;
 
 		CPos cell;
-		readonly List<IRenderable> preview = [];
-		readonly IResourceRenderer[] resourceRenderers;
 
 		public EditorResourceBrush(EditorViewportControllerWidget editorWidget, string resourceType, WorldRenderer wr)
 		{
@@ -41,8 +45,10 @@ namespace OpenRA.Mods.Common.Widgets
 			world = wr.World;
 			editorActionManager = world.WorldActor.Trait<EditorActionManager>();
 			resourceLayer = world.WorldActor.Trait<IResourceLayer>();
-
 			resourceRenderers = world.WorldActor.TraitsImplementing<IResourceRenderer>().ToArray();
+
+			ResourceType = resourceType;
+
 			cell = wr.Viewport.ViewToWorld(wr.Viewport.WorldToViewPx(Viewport.LastMousePos));
 			UpdatePreview();
 		}
@@ -64,19 +70,32 @@ namespace OpenRA.Mods.Common.Widgets
 				return false;
 			}
 
-			var cell = worldRenderer.Viewport.ViewToWorld(mi.Location);
+			if (mi.Button != MouseButton.Left)
+				return true;
 
-			if (mi.Button == MouseButton.Left && mi.Event != MouseInputEvent.Up && resourceLayer.CanAddResource(ResourceType, cell))
+			if (mi.Event == MouseInputEvent.Down && mi.Modifiers.HasModifier(Modifiers.Shift))
 			{
-				action ??= new AddResourcesEditorAction(ResourceType, resourceLayer);
-				action.Add(new CellResource(cell, resourceLayer.GetResource(cell)));
-				resourceAdded = true;
+				linePainting = true;
+				lineStart = worldRenderer.Viewport.ViewToWorld(mi.Location);
 			}
-			else if (resourceAdded && mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Up)
+			else if (mi.Event == MouseInputEvent.Up)
 			{
-				editorActionManager.Add(action);
-				action = null;
-				resourceAdded = false;
+				if (action != null)
+				{
+					editorActionManager.Add(action);
+					action = null;
+				}
+
+				linePainting = false;
+				cells.Clear();
+				UpdatePreview();
+			}
+			else
+			{
+				UpdatePreview();
+				action ??= new AddResourcesEditorAction(ResourceType, resourceLayer);
+
+				action.Replace(cells);
 			}
 
 			return true;
@@ -86,20 +105,36 @@ namespace OpenRA.Mods.Common.Widgets
 
 		void UpdatePreview()
 		{
-			var pos = world.Map.CenterOfCell(cell);
+			var currentCell = worldRenderer.Viewport.ViewToWorld(Viewport.LastMousePos);
+			if (cell == currentCell && cells.Count > 0)
+				return;
+
+			cell = currentCell;
+
+			if (linePainting)
+			{
+				cells.Clear();
+				foreach (var cell in Util.GetCurvedLine(lineStart, currentCell, new int2(1, 1)))
+					if (world.Map.Contains(cell))
+						cells.Add(cell);
+			}
+			else
+			{
+				if (action == null)
+					cells.Clear();
+
+				if (world.Map.Contains(currentCell))
+					cells.Add(currentCell);
+			}
 
 			preview.Clear();
-			preview.AddRange(resourceRenderers.SelectMany(r => r.RenderPreview(worldRenderer, ResourceType, pos)));
+			preview.AddRange(resourceRenderers
+				.SelectMany(r => r.RenderPreview(worldRenderer, ResourceType, world.Map.CenterOfCell(cell))));
 		}
 
 		void IEditorBrush.TickRender(WorldRenderer wr, Actor self)
 		{
-			var currentCell = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
-			if (cell != currentCell)
-			{
-				cell = currentCell;
-				UpdatePreview();
-			}
+			UpdatePreview();
 		}
 
 		IEnumerable<IRenderable> IEditorBrush.RenderAboveShroud(Actor self, WorldRenderer wr) { return action == null ? preview : null; }
@@ -153,10 +188,16 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 		}
 
-		public void Add(CellResource resourceCell)
+		public void Replace(HashSet<CPos> resources)
 		{
-			resourceLayer.AddResource(resourceType, resourceCell.Cell, resourceLayer.GetMaxDensity(resourceType));
-			cellResources.Add(resourceCell);
+			Undo();
+			cellResources.Clear();
+			cellResources.AddRange(resources
+				.Where(c => resourceLayer.CanAddResource(resourceType, c))
+				.Select(c => new CellResource(c, resourceLayer.GetResource(c))));
+
+			Do();
+
 			Text = FluentProvider.GetMessage(AddedResource, "count", cellResources.Count, "type", resourceType);
 		}
 	}

--- a/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
@@ -98,6 +98,8 @@ namespace OpenRA.Mods.Common.Widgets
 			return true;
 		}
 
+		public bool HandleKeyboardInput(KeyInput ki) => false;
+
 		void PaintCell(CPos cell, bool isMoving)
 		{
 			var template = terrainInfo.Templates[Template];

--- a/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
@@ -9,8 +9,11 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Terrain;
 using OpenRA.Mods.Common.Traits;
@@ -28,9 +31,12 @@ namespace OpenRA.Mods.Common.Widgets
 		readonly EditorViewportControllerWidget editorWidget;
 		readonly EditorActionManager editorActionManager;
 
-		bool painting;
+		bool linePainting;
+		CPos lineStart;
 
 		readonly ITiledTerrainRenderer terrainRenderer;
+
+		PaintTileEditorAction action;
 
 		CPos cell;
 		readonly List<IRenderable> preview = [];
@@ -70,44 +76,56 @@ namespace OpenRA.Mods.Common.Widgets
 				return false;
 			}
 
-			if (mi.Button == MouseButton.Left)
-			{
-				if (mi.Event == MouseInputEvent.Down)
-					painting = true;
-				else if (mi.Event == MouseInputEvent.Up)
-					painting = false;
-			}
-
-			if (!painting)
-				return true;
-
-			if (mi.Event != MouseInputEvent.Down && mi.Event != MouseInputEvent.Move)
-				return true;
-
 			var cell = worldRenderer.Viewport.ViewToWorld(mi.Location);
-			var isMoving = mi.Event == MouseInputEvent.Move;
 
-			if (mi.Modifiers.HasModifier(Modifiers.Shift))
+			if (mi.Button != MouseButton.Left)
+				return true;
+
+			if (mi.Event == MouseInputEvent.Down && mi.Modifiers.HasModifier(Modifiers.Shift))
+			{
+				linePainting = true;
+				lineStart = cell;
+			}
+			else if (mi.Event == MouseInputEvent.Down && mi.Modifiers.HasModifier(Modifiers.Alt))
 			{
 				FloodFillWithBrush(cell);
-				painting = false;
 			}
-			else
-				PaintCell(cell, isMoving);
+			else if (mi.Event == MouseInputEvent.Up)
+			{
+				if (linePainting)
+				{
+					var cells = Util.GetCurvedLine(lineStart, cell, TerrainTemplate.Size)
+						.Where(c => world.Map.Contains(c) && !PlacementOverlapsSameTemplate(TerrainTemplate, c)).ToList();
+
+					if (cells.Count > 0)
+					{
+						var action = new PaintTileEditorAction(Template, world.Map);
+						action.Add(CollectionsMarshal.AsSpan(cells));
+						editorActionManager.Add(action);
+					}
+
+					linePainting = false;
+					UpdatePreview(true);
+				}
+				else if (action != null)
+				{
+					editorActionManager.Add(action);
+					action = null;
+				}
+			}
+			else if (!linePainting)
+			{
+				if (!PlacementOverlapsSameTemplate(TerrainTemplate, cell))
+				{
+					action ??= new PaintTileEditorAction(Template, world.Map);
+					action.Add([cell]);
+				}
+			}
 
 			return true;
 		}
 
 		public bool HandleKeyboardInput(KeyInput ki) => false;
-
-		void PaintCell(CPos cell, bool isMoving)
-		{
-			var template = terrainInfo.Templates[Template];
-			if (isMoving && PlacementOverlapsSameTemplate(template, cell))
-				return;
-
-			editorActionManager.Add(new PaintTileEditorAction(Template, world.Map, cell));
-		}
 
 		void FloodFillWithBrush(CPos cell)
 		{
@@ -145,25 +163,35 @@ namespace OpenRA.Mods.Common.Widgets
 			return false;
 		}
 
-		void UpdatePreview()
+		void UpdatePreview(bool forceRefresh = false)
 		{
-			var pos = world.Map.CenterOfCell(cell);
+			var currentCell = worldRenderer.Viewport.ViewToWorld(Viewport.LastMousePos);
+			if (!forceRefresh && cell == currentCell)
+				return;
+
+			cell = currentCell;
 
 			preview.Clear();
-			preview.AddRange(terrainRenderer.RenderPreview(worldRenderer, TerrainTemplate, pos));
-		}
 
-		void IEditorBrush.TickRender(WorldRenderer wr, Actor self)
-		{
-			var currentCell = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
-			if (cell != currentCell)
+			if (linePainting)
 			{
-				cell = currentCell;
-				UpdatePreview();
+				foreach (var c in Util.GetCurvedLine(lineStart, cell, TerrainTemplate.Size))
+				{
+					var p = world.Map.CenterOfCell(c);
+					preview.AddRange(terrainRenderer.RenderPreview(worldRenderer, TerrainTemplate, p));
+				}
+			}
+			else
+			{
+				var pos = world.Map.CenterOfCell(cell);
+				preview.AddRange(terrainRenderer.RenderPreview(worldRenderer, TerrainTemplate, pos));
 			}
 		}
 
+		void IEditorBrush.TickRender(WorldRenderer wr, Actor self) { UpdatePreview(); }
+
 		IEnumerable<IRenderable> IEditorBrush.RenderAboveShroud(Actor self, WorldRenderer wr) { return preview; }
+
 		IEnumerable<IRenderable> IEditorBrush.RenderAnnotations(Actor self, WorldRenderer wr) { yield break; }
 
 		public void Tick() { }
@@ -173,59 +201,31 @@ namespace OpenRA.Mods.Common.Widgets
 
 	sealed class PaintTileEditorAction : IEditorAction
 	{
-		[FluentReference("id")]
+		[FluentReference("id", "count")]
 		const string AddedTile = "notification-added-tile";
 
-		public string Text { get; }
+		public string Text { get; private set; }
 
 		readonly ushort template;
 		readonly Map map;
-		readonly CPos cell;
+		readonly List<CPos> cells = [];
 
-		readonly Queue<UndoTile> undoTiles = [];
-		readonly TerrainTemplateInfo terrainTemplate;
+		readonly Queue<UndoTile> undoTiles = new();
 
-		public PaintTileEditorAction(ushort template, Map map, CPos cell)
+		public PaintTileEditorAction(ushort template, Map map)
 		{
 			this.template = template;
 			this.map = map;
-			this.cell = cell;
-
-			var terrainInfo = (ITemplatedTerrainInfo)map.Rules.TerrainInfo;
-			terrainTemplate = terrainInfo.Templates[template];
-			Text = FluentProvider.GetMessage(AddedTile, "id", terrainTemplate.Id);
 		}
 
 		public void Execute()
 		{
-			Do();
+			cells.TrimExcess();
 		}
 
 		public void Do()
 		{
-			var mapTiles = map.Tiles;
-			var mapHeight = map.Height;
-			var baseHeight = mapHeight.Contains(cell) ? mapHeight[cell] : (byte)0;
-
-			var i = 0;
-			for (var y = 0; y < terrainTemplate.Size.Y; y++)
-			{
-				for (var x = 0; x < terrainTemplate.Size.X; x++, i++)
-				{
-					if (terrainTemplate.Contains(i) && terrainTemplate[i] != null)
-					{
-						var index = terrainTemplate.PickAny ? (byte)Game.CosmeticRandom.Next(0, terrainTemplate.TilesCount) : (byte)i;
-						var c = cell + new CVec(x, y);
-						if (!mapTiles.Contains(c))
-							continue;
-
-						undoTiles.Enqueue(new UndoTile(c, mapTiles[c], mapHeight[c]));
-
-						mapTiles[c] = new TerrainTile(template, index);
-						mapHeight[c] = (byte)(baseHeight + terrainTemplate[index].Height).Clamp(0, map.Grid.MaximumTerrainHeight);
-					}
-				}
-			}
+			UpdateCells(CollectionsMarshal.AsSpan(cells));
 		}
 
 		public void Undo()
@@ -240,6 +240,46 @@ namespace OpenRA.Mods.Common.Widgets
 				mapTiles[undoTile.Cell] = undoTile.MapTile;
 				mapHeight[undoTile.Cell] = undoTile.Height;
 			}
+		}
+
+		public void Add(ReadOnlySpan<CPos> additionalCells)
+		{
+			cells.AddRange(additionalCells);
+			UpdateCells(additionalCells);
+		}
+
+		void UpdateCells(ReadOnlySpan<CPos> additionalCells)
+		{
+			var mapTiles = map.Tiles;
+			var mapHeight = map.Height;
+			var terrainInfo = (ITemplatedTerrainInfo)map.Rules.TerrainInfo;
+			var terrainTemplate = terrainInfo.Templates[template];
+
+			foreach (var cell in additionalCells)
+			{
+				var baseHeight = mapHeight.Contains(cell) ? mapHeight[cell] : (byte)0;
+				var i = 0;
+				for (var y = 0; y < terrainTemplate.Size.Y; y++)
+				{
+					for (var x = 0; x < terrainTemplate.Size.X; x++, i++)
+					{
+						if (terrainTemplate.Contains(i) && terrainTemplate[i] != null)
+						{
+							var index = terrainTemplate.PickAny ? (byte)Game.CosmeticRandom.Next(0, terrainTemplate.TilesCount) : (byte)i;
+							var c = cell + new CVec(x, y);
+							if (!mapTiles.Contains(c))
+								continue;
+
+							undoTiles.Enqueue(new UndoTile(c, mapTiles[c], mapHeight[c]));
+
+							mapTiles[c] = new TerrainTile(template, index);
+							mapHeight[c] = (byte)(baseHeight + terrainTemplate[index].Height).Clamp(0, map.Grid.MaximumTerrainHeight);
+						}
+					}
+				}
+			}
+
+			Text = FluentProvider.GetMessage(AddedTile, "id", terrainTemplate.Id, "count", cells.Count);
 		}
 	}
 

--- a/OpenRA.Mods.Common/EditorBrushes/EditorTilingPathBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorTilingPathBrush.cs
@@ -197,6 +197,8 @@ namespace OpenRA.Mods.Common.Widgets
 			return true;
 		}
 
+		public bool HandleKeyboardInput(KeyInput ki) => false;
+
 		void IEditorBrush.TickRender(WorldRenderer wr, Actor self) { }
 		IEnumerable<IRenderable> IEditorBrush.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -162,7 +162,7 @@ namespace OpenRA.Mods.Common.Traits
 			return preview;
 		}
 
-		public void AddRange(ReadOnlySpan<ActorReference> references, ReadOnlySpan<string> names)
+		public ReadOnlySpan<EditorActorPreview> AddRange(ReadOnlySpan<ActorReference> references, ReadOnlySpan<string> names)
 		{
 			if (names.Length != references.Length)
 				throw new ArgumentException("Member name count must match reference count.");
@@ -180,12 +180,14 @@ namespace OpenRA.Mods.Common.Traits
 				}
 			}
 
-			AddRange(newPreviews);
+			var span = newPreviews.AsSpan();
+			AddRange(span);
+			return span;
 		}
 
-		public void AddRange(ReadOnlySpan<ActorReference> references)
+		public ReadOnlySpan<EditorActorPreview> AddRange(ReadOnlySpan<ActorReference> references)
 		{
-			AddRange(references, NextActorNames(references.Length));
+			return AddRange(references, NextActorNames(references.Length));
 		}
 
 		public void Add(EditorActorPreview preview)

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -199,6 +199,40 @@ namespace OpenRA.Mods.Common
 			return ExpandFootprint(cells, true);
 		}
 
+		public static IEnumerable<CPos> GetCurvedLine(CPos start, CPos end, int2 size)
+		{
+			var delta = end - start;
+			var xDelta = Math.Abs(delta.X);
+			var yDelta = Math.Abs(delta.Y);
+			var xDir = Math.Sign(delta.X);
+			var yDir = Math.Sign(delta.Y);
+
+			if (xDelta > yDelta)
+			{
+				for (var i = 0; i <= xDelta; i += size.X)
+				{
+					var newX = start.X + xDir * i;
+					var newY = start.Y + yDelta * i / xDelta * yDir;
+					yield return new CPos(newX, newY);
+				}
+			}
+			else if (yDelta > xDelta)
+			{
+				for (var i = 0; i <= yDelta; i += size.Y)
+				{
+					var newX = start.X + xDelta * i / yDelta * xDir;
+					var newY = start.Y + yDir * i;
+					yield return new CPos(newX, newY);
+				}
+			}
+			else
+			{
+				var step = Math.Min(size.X, size.Y);
+				for (var i = 0; i <= xDelta; i += step)
+					yield return new CPos(start.X + xDir * i, start.Y + yDir * i);
+			}
+		}
+
 		public static int ApplyPercentageModifiers(int number, IEnumerable<int> percentages)
 		{
 			// See the comments of PR#6079 for a faster algorithm if this becomes a performance bottleneck

--- a/OpenRA.Mods.Common/Widgets/EditorViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/EditorViewportControllerWidget.cs
@@ -118,6 +118,14 @@ namespace OpenRA.Mods.Common.Widgets
 			return base.HandleMouseInput(mi);
 		}
 
+		public override bool HandleKeyPress(KeyInput e)
+		{
+			if (CurrentBrush.HandleKeyboardInput(e))
+				return true;
+
+			return base.HandleKeyPress(e);
+		}
+
 		WPos cachedViewportPosition;
 		public override void Tick()
 		{

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -20,7 +20,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	[IncludeStaticFluentReferences(typeof(AddActorAction), typeof(CommonSelectorLogic))]
+	[IncludeStaticFluentReferences(typeof(AddActorsAction), typeof(CommonSelectorLogic))]
 	public class ActorSelectorLogic : CommonSelectorLogic
 	{
 		[FluentReference("actorType")]
@@ -156,12 +156,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			InitializePreviews();
 
 			if (editor.CurrentBrush is EditorActorBrush brush)
-			{
-				var actor = brush.Preview;
-				actor.Owner = option;
-				actor.ReplaceInit(new OwnerInit(option.Name));
-				actor.ReplaceInit(new FactionInit(option.Faction));
-			}
+				brush.UpdatePreviewsOwner(option);
 		}
 
 		protected override void InitializePreviews()
@@ -192,7 +187,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				try
 				{
 					var item = ScrollItemWidget.Setup(ItemTemplate,
-						() => Editor.CurrentBrush is EditorActorBrush eab && eab.Preview.Info == actor,
+						() => Editor.CurrentBrush is EditorActorBrush eab && eab.Previews[0].Info == actor,
 						() => Editor.SetBrush(new EditorActorBrush(Editor, actor, selectedOwner, WorldRenderer)));
 
 					var preview = item.Get<ActorPreviewWidget>("ACTOR_PREVIEW");

--- a/mods/common/fluent/common.ftl
+++ b/mods/common/fluent/common.ftl
@@ -810,7 +810,12 @@ notification-added-resource =
     }
 
 ## EditorTileBrush
-notification-added-tile = Added tile { $id }
+notification-added-tile =
+    { $count ->
+       [one] Added tile { $id }
+      *[other] Added { $count } tiles of type { $id }
+    }
+
 notification-filled-tile = Filled with tile { $id }
 
 ## EditorMarkerLayerBrush

--- a/mods/common/fluent/common.ftl
+++ b/mods/common/fluent/common.ftl
@@ -782,7 +782,11 @@ options-time-limit =
 notification-time-limit-expired = Time limit has expired.
 
 ## EditorActorBrush
-notification-added-actor = Added { $name } ({ $id })
+notification-added-actors =
+    { $count ->
+       [one] Added { $name } ({ $id })
+      *[other] Added { $count } { $name } actors
+    }
 
 ## EditorCopyPasteBrush
 notification-copied-tiles = Copied { $tiles } tiles


### PR DESCRIPTION
Hold shift to drag actors / tiles / resources / marker tiles in a line

Note: actors still don't support regular dragging, which is probably desired as there's no overlap detection

- Tile flood fill was moved from shift modifier to alt
- Fixed tile undo not working well with regular dragging (requiring to a click of undo for each tile change)
- Added a preview to marker tiles