### PR TITLE
Correct nod-06c capture objective

### DIFF
--- a/mods/cnc/fluent/lua.ftl
+++ b/mods/cnc/fluent/lua.ftl
@@ -105,7 +105,7 @@ destroy-gdi-supporter-houses = Destroy the houses of the GDI supporters
     in the village.
 
 ## nod06c
-infiltrate-barracks-factory-conyard = Infiltrate the barracks, weapons factory and
+capture-barracks-factory-conyard = Capture the barracks, weapons factory and
     construction yard.
 
 ## nod07a

--- a/mods/cnc/maps/nod06c/nod06c.lua
+++ b/mods/cnc/maps/nod06c/nod06c.lua
@@ -62,7 +62,7 @@ WorldLoaded = function()
 	InitObjectives(Nod)
 
 	NodObjective1 = AddPrimaryObjective(Nod, "steal-nuclear-detonator")
-	InfiltrateObjective = AddSecondaryObjective(Nod, "infiltrate-barracks-factory-conyard")
+	CaptureObjective = AddSecondaryObjective(Nod, "capture-barracks-factory-conyard")
 
 	InsertNodUnits()
 
@@ -111,18 +111,18 @@ WorldLoaded = function()
 	Trigger.AfterDelay(ProductionDelay, ProdTriggerFunction)
 
 	Trigger.OnAnyKilled(BuildingsToCapture, function()
-		if not Nod.IsObjectiveCompleted(InfiltrateObjective) then
-			Nod.MarkFailedObjective(InfiltrateObjective)
+		if not Nod.IsObjectiveCompleted(CaptureObjective) then
+			Nod.MarkFailedObjective(CaptureObjective)
 		end
 	end)
 
+	local captured = 0
 	Utils.Do(BuildingsToCapture, function(building)
-		local captured = 0
 		Trigger.OnCapture(building, function()
 			captured = captured + 1
 
 			if captured == 3 then
-				Nod.MarkCompletedObjective(InfiltrateObjective)
+				Nod.MarkCompletedObjective(CaptureObjective)
 			end
 		end)
 	end)


### PR DESCRIPTION
The group of structures to be captured now has a shared capture tally as intended, rather than individual tallies that make the objective impossible.

Fixes an issue reported by **Henskelion** on the discord.