### PR TITLE
Fix tileset MiniYaml keys to be consistent with Ids

### DIFF
--- a/mods/cnc/tilesets/snow.yaml
+++ b/mods/cnc/tilesets/snow.yaml
@@ -1754,7 +1754,7 @@ Templates:
 			6: Water
 			7: Clear
 			8: Clear
-	Template@188:
+	Template@189:
 		Id: 189
 		Images: cliffsl1.sno
 		Size: 1,2
@@ -1762,7 +1762,7 @@ Templates:
 		Tiles:
 			0: Rock
 			1: Rock
-	Template@189:
+	Template@190:
 		Id: 190
 		Images: cliffsl2.sno
 		Size: 1,2
@@ -1770,7 +1770,7 @@ Templates:
 		Tiles:
 			0: Rock
 			1: Rock
-	Template@190:
+	Template@191:
 		Id: 191
 		Images: cliffsl3.sno
 		Size: 2,1
@@ -1778,7 +1778,7 @@ Templates:
 		Tiles:
 			0: Rock
 			1: Rock
-	Template@191:
+	Template@192:
 		Id: 192
 		Images: cliffsl4.sno
 		Size: 2,1

--- a/mods/cnc/tilesets/winter.yaml
+++ b/mods/cnc/tilesets/winter.yaml
@@ -1790,7 +1790,7 @@ Templates:
 			6: Water
 			7: Clear
 			8: Clear
-	Template@188:
+	Template@189:
 		Id: 189
 		Images: cliffsl1.win
 		Size: 1,2
@@ -1798,7 +1798,7 @@ Templates:
 		Tiles:
 			0: Rock
 			1: Rock
-	Template@189:
+	Template@190:
 		Id: 190
 		Images: cliffsl2.win
 		Size: 1,2
@@ -1806,7 +1806,7 @@ Templates:
 		Tiles:
 			0: Rock
 			1: Rock
-	Template@190:
+	Template@191:
 		Id: 191
 		Images: cliffsl3.win
 		Size: 2,1
@@ -1814,7 +1814,7 @@ Templates:
 		Tiles:
 			0: Rock
 			1: Rock
-	Template@191:
+	Template@192:
 		Id: 192
 		Images: cliffsl4.win
 		Size: 2,1


### PR DESCRIPTION
Makes the `Template@...` number consistent with the `Id: ...` (if any).

The keys are ignored by the engine, so this has no behavioral change.