### PR TITLE
Fix map generator failures due to broken TilingPath edge extension

### DIFF
--- a/OpenRA.Mods.Common/MapGenerator/TilingPath.cs
+++ b/OpenRA.Mods.Common/MapGenerator/TilingPath.cs
@@ -900,7 +900,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			if (points == null)
 				return null;
 
-			if (points[0] != points[^1])
+			if (points[0] == points[^1])
 			{
 				// Is a loop.
 				return points;


### PR DESCRIPTION
Coastlines and cliffs at the edge of a map should have been getting extended beyond the map edge help them tile reliably. This was not happening due to a conditional that accidentally got inverted during a refactor.

Fixing the conditional makes beach and cliff tiling significantly more reliable. (Note that there is no effect on road tiling.)