### PR TITLE
Fix an out-of-bounds CellLayer access in RaMapGenerator

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/RaMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/RaMapGenerator.cs
@@ -996,7 +996,7 @@ namespace OpenRA.Mods.Common.Traits
 								var projections = Symmetry.RotateAndMirrorCPos(
 									cpos, map.Tiles, param.Rotations, param.Mirror);
 								foreach (var projection in projections)
-									if (map.Tiles[projection].Type == param.WaterTile)
+									if (map.Tiles.Contains(projection) && map.Tiles[projection].Type == param.WaterTile)
 										unplayableWater.Add(projection);
 							}
 


### PR DESCRIPTION
Adds a bounds check for the water obstruction code, where a rotation projection can be outside of the map area (on rotations other than 1, 2, or 4.)