### PR TITLE
Fix ordos-04 to use internal bot names

### DIFF
--- a/mods/d2k/maps/ordos-04/ordos04-AI.lua
+++ b/mods/d2k/maps/ordos-04/ordos04-AI.lua
@@ -31,9 +31,9 @@ SmugglerTankType = { "combat_tank_o" }
 
 InitAIUnits = function(house)
 	LastHarvesterEaten[house] = true
-	IdlingUnits[house] = Reinforcements.Reinforce(house, InitialReinforcements[house.Name], InitialReinforcementsPaths[house.Name])
+	IdlingUnits[house] = Reinforcements.Reinforce(house, InitialReinforcements[house.InternalName], InitialReinforcementsPaths[house.InternalName])
 
-	DefendAndRepairBase(house, Base[house.Name], 0.75, AttackGroupSize[Difficulty])
+	DefendAndRepairBase(house, Base[house.InternalName], 0.75, AttackGroupSize[Difficulty])
 end
 
 ActivateAI = function()

--- a/mods/d2k/maps/ordos-04/ordos04.lua
+++ b/mods/d2k/maps/ordos-04/ordos04.lua
@@ -65,7 +65,7 @@ SendHarkonnen = function(path)
 end
 
 Hunt = function(house)
-	Trigger.OnAllKilledOrCaptured(Base[house.Name], function()
+	Trigger.OnAllKilledOrCaptured(Base[house.InternalName], function()
 		Utils.Do(house.GetGroundAttackers(), IdleHunt)
 	end)
 end


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/issues/21706

The script on bleed/playtest expects certain names from bot players but those are different ("Smugglers" -> "Campaign Player AI 2") since bot names were exposed to localization. This PR changes the script to use the internal names.

There is something similar happening with the tooltip for the modified Outpost here and in `harkonnen-05`. I'm less certain how that should be handled.

![d2k-2025-01-15T232224028Z](https://github.com/user-attachments/assets/ac60647d-32cf-4101-9ac3-565383efaa9c)
![d2k-2025-01-15T231805945Z](https://github.com/user-attachments/assets/a424a7df-4bdd-4141-9517-eb84b2d039db)

The shellmap script makes use of localized bot names, but not in a way that seems to cause problems.
