### PR TITLE
Re-add a mini lobby options menu to missionbrowser

### DIFF
--- a/mods/cnc/chrome/missionbrowser.yaml
+++ b/mods/cnc/chrome/missionbrowser.yaml
@@ -68,6 +68,44 @@ Container@MISSIONBROWSER_PANEL:
 									IgnoreMouseOver: True
 									IgnoreMouseInput: True
 									ShowSpawnPoints: False
+						Container@MISSION_MINIFIED_OPTIONS:
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
+							Visible: False
+							Children:
+								LabelForInput@DIFFICULTY_DESC:
+									Y: PARENT_HEIGHT - HEIGHT + 2
+									Width: 56
+									Height: 25
+									Align: Right
+									Text: dropdown-missionbrowser-difficulty.label
+									For: DIFFICULTY
+								DropDownButton@DIFFICULTY:
+									X: 61
+									Y: PARENT_HEIGHT - HEIGHT + 2
+									Width: 120
+									Height: 25
+									Font: Regular
+									Text: label-missionbrowser-normal-difficulty
+									TooltipText: dropdown-missionbrowser-difficulty.description
+									PanelRoot: MISSION_DROPDOWN_PANEL_ROOT
+									TooltipContainer: TOOLTIP_CONTAINER
+								LabelForInput@GAMESPEED_DESC:
+									X: PARENT_WIDTH - WIDTH - 125
+									Y: PARENT_HEIGHT - HEIGHT + 2
+									Width: 120
+									Height: 25
+									Align: Right
+									Text: dropdown-missionbrowser-gamespeed
+									For: GAMESPEED
+								DropDownButton@GAMESPEED:
+									X: PARENT_WIDTH - WIDTH
+									Y: PARENT_HEIGHT - HEIGHT + 2
+									Width: 120
+									Height: 25
+									Font: Regular
+									PanelRoot: MISSION_DROPDOWN_PANEL_ROOT
+									TooltipContainer: TOOLTIP_CONTAINER
 						Container@MISSION_TABS:
 							Width: PARENT_WIDTH
 							Y: PARENT_HEIGHT - 31

--- a/mods/cnc/fluent/campaign.ftl
+++ b/mods/cnc/fluent/campaign.ftl
@@ -1,7 +1,7 @@
 ## world
 dropdown-difficulty =
     .label = Difficulty
-    .description = The difficulty of the mission.
+    .description = The difficulty of the mission
 
 options-difficulty =
     .easy = Easy

--- a/mods/cnc/fluent/chrome.ftl
+++ b/mods/cnc/fluent/chrome.ftl
@@ -523,6 +523,12 @@ button-missionbrowser-panel-stop-briefing-video = Stop Briefing
 button-missionbrowser-panel-start-info-video = Watch Info Video
 button-missionbrowser-panel-stop-info-video = Stop Info Video
 button-missionbrowser-panel-play = Play
+dropdown-missionbrowser-difficulty =
+    .label = Difficulty
+    .description = The difficulty of the mission
+
+dropdown-missionbrowser-gamespeed = Speed:
+label-missionbrowser-normal-difficulty = Normal
 
 ## multiplayer-browser.yaml
 image-bg-password-protected-tooltip = Requires Password

--- a/mods/common/chrome/missionbrowser.yaml
+++ b/mods/common/chrome/missionbrowser.yaml
@@ -76,6 +76,44 @@ Background@MISSIONBROWSER_PANEL:
 							Height: 31
 							Font: Bold
 							Text: button-missionbrowser-panel-mission-options
+				Container@MISSION_MINIFIED_OPTIONS:
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
+					Visible: False
+					Children:
+						LabelForInput@DIFFICULTY_DESC:
+							Y: PARENT_HEIGHT - HEIGHT
+							Width: 56
+							Height: 25
+							Align: Right
+							Text: dropdown-missionbrowser-difficulty.label
+							For: DIFFICULTY
+						DropDownButton@DIFFICULTY:
+							X: 61
+							Y: PARENT_HEIGHT - HEIGHT
+							Width: 135
+							Height: 25
+							Font: Regular
+							Text: label-missionbrowser-normal-difficulty
+							TooltipText: dropdown-missionbrowser-difficulty.description
+							PanelRoot: MISSION_DROPDOWN_PANEL_ROOT
+							TooltipContainer: TOOLTIP_CONTAINER
+						LabelForInput@GAMESPEED_DESC:
+							X: PARENT_WIDTH - WIDTH - 115
+							Y: PARENT_HEIGHT - HEIGHT
+							Width: 120
+							Height: 25
+							Align: Right
+							Text: dropdown-missionbrowser-gamespeed
+							For: GAMESPEED
+						DropDownButton@GAMESPEED:
+							X: PARENT_WIDTH - WIDTH
+							Y: PARENT_HEIGHT - HEIGHT
+							Width: 110
+							Height: 25
+							Font: Regular
+							PanelRoot: MISSION_DROPDOWN_PANEL_ROOT
+							TooltipContainer: TOOLTIP_CONTAINER
 				Container@MISSION_DETAIL:
 					Y: 212
 					Width: PARENT_WIDTH

--- a/mods/common/fluent/chrome.ftl
+++ b/mods/common/fluent/chrome.ftl
@@ -354,6 +354,12 @@ button-missionbrowser-panel-stop-info-video = Stop Info Video
 button-missionbrowser-panel-play = Play
 button-missionbrowser-panel-mission-info = Mission Info
 button-missionbrowser-panel-mission-options = Options
+dropdown-missionbrowser-difficulty =
+    .label = Difficulty
+    .description = The difficulty of the mission
+
+dropdown-missionbrowser-gamespeed = Speed:
+label-missionbrowser-normal-difficulty = Normal
 
 ## multiplayer-browser.yaml
 image-multiplayer-panel-password-protected-tooltip = Requires Password

--- a/mods/d2k/chrome/missionbrowser.yaml
+++ b/mods/d2k/chrome/missionbrowser.yaml
@@ -144,6 +144,45 @@ Background@MISSIONBROWSER_PANEL:
 											Visible: False
 											PanelRoot: MISSION_DROPDOWN_PANEL_ROOT
 											TooltipContainer: TOOLTIP_CONTAINER
+		Container@MISSION_MINIFIED_OPTIONS:
+			X: 220
+			Width: PARENT_WIDTH - 220
+			Height: PARENT_HEIGHT
+			Visible: False
+			Children:
+				LabelForInput@DIFFICULTY_DESC:
+					Y: PARENT_HEIGHT - 80
+					Width: 56
+					Height: 25
+					Align: Right
+					Text: dropdown-missionbrowser-difficulty.label
+					For: DIFFICULTY
+				DropDownButton@DIFFICULTY:
+					X: 71
+					Y: PARENT_HEIGHT - 80
+					Width: 140
+					Height: 25
+					Font: Regular
+					Text: label-missionbrowser-normal-difficulty
+					TooltipText: dropdown-missionbrowser-difficulty.description
+					PanelRoot: MISSION_DROPDOWN_PANEL_ROOT
+					TooltipContainer: TOOLTIP_CONTAINER
+				LabelForInput@GAMESPEED_DESC:
+					X: PARENT_WIDTH - 140 - WIDTH - 35
+					Y: PARENT_HEIGHT - 80
+					Width: 56
+					Height: 25
+					Align: Right
+					Text: dropdown-missionbrowser-gamespeed
+					For: GAMESPEED
+				DropDownButton@GAMESPEED:
+					X: PARENT_WIDTH - 160
+					Y: PARENT_HEIGHT - 80
+					Width: 140
+					Height: 25
+					Font: Regular
+					PanelRoot: MISSION_DROPDOWN_PANEL_ROOT
+					TooltipContainer: TOOLTIP_CONTAINER
 		Button@START_BRIEFING_VIDEO_BUTTON:
 			X: 20
 			Y: PARENT_HEIGHT - 45

--- a/mods/d2k/fluent/campaign.ftl
+++ b/mods/d2k/fluent/campaign.ftl
@@ -1,7 +1,7 @@
 ## world
 dropdown-difficulty =
     .label = Difficulty
-    .description = The difficulty of the mission.
+    .description = The difficulty of the mission
 
 options-difficulty =
     .easy = Easy

--- a/mods/ra/fluent/campaign.ftl
+++ b/mods/ra/fluent/campaign.ftl
@@ -1,7 +1,7 @@
 ## world
 dropdown-difficulty =
     .label = Difficulty
-    .description = The difficulty of the mission.
+    .description = The difficulty of the mission
 
 options-difficulty =
     .easy = Easy


### PR DESCRIPTION
Partially reverts #20934

I've been angry at that PR ever since it got merged. Hiding crucial information behind a click is not acceptable. I've still kept the lobby-style UI for missions that have more options available (f.e. openra specials)

Partially addresses #21698, when navigating the mission selector we remember speed and difficulty. Info is still destroyed on closing the menu

<img width="771" alt="Screenshot 2025-01-17 at 13 27 02" src="https://github.com/user-attachments/assets/e18aebd5-7a5d-4fcd-9b9b-b851063907b4" />
