### PR TITLE
Fix bleed documentation

### DIFF
--- a/packaging/format-docs.py
+++ b/packaging/format-docs.py
@@ -70,7 +70,7 @@ def format_docs(version, collectionName, types, relatedEnums):
 
             sourceUrl = ""
             if currentType["Filename"]:
-                sourceUrl = f"https://github.com/OpenRA/OpenRA/blob/{version}/{currentType["Filename"]}"
+                sourceUrl = f"https://github.com/OpenRA/OpenRA/blob/{version}/{currentType['Filename']}"
                 description = f"{description} [GitHub]({sourceUrl})"
 
             if description:


### PR DESCRIPTION
#21694 is incompatible with the GitHub runner as it runs an older version of Python