### PR TITLE
Remove floating points from map generation

### DIFF
--- a/OpenRA.Mods.Common/MapGenerator/CellLayerUtils.cs
+++ b/OpenRA.Mods.Common/MapGenerator/CellLayerUtils.cs
@@ -255,14 +255,14 @@ namespace OpenRA.Mods.Common.MapGenerator
 		}
 
 		/// <summary>
-		/// Uniformally add to or subtract from all matrix cells such that the given quantile,
-		/// fraction, has the given target value.
+		/// Uniformally add to or subtract from all cells such that count out of every outOf cells,
+		/// are no greater than the given target value.
 		/// </summary>
-		public static void CalibrateQuantileInPlace(CellLayer<float> cellLayer, float target, float fraction)
+		public static void CalibrateQuantileInPlace(CellLayer<int> cellLayer, int target, int count, int outOf)
 		{
 			var sorted = Entries(cellLayer);
 			Array.Sort(sorted);
-			var adjustment = target - MatrixUtils.ArrayQuantile(sorted, fraction);
+			var adjustment = target - sorted[(sorted.Length - 1) * count / outOf];
 			foreach (var mpos in cellLayer.CellRegion.MapCoords)
 				cellLayer[mpos] += adjustment;
 		}
@@ -381,12 +381,15 @@ namespace OpenRA.Mods.Common.MapGenerator
 			FromMatrix(output, roominess);
 		}
 
-		/// <summary>Wrapper around MatrixUtils.WalkingDistance in CPos space.</summary>
+		/// <summary>
+		/// Wrapper around MatrixUtils.WalkingDistance in CPos space.
+		/// Returns world distances (1024ths).
+		/// </summary>
 		public static void WalkingDistances(
-			CellLayer<float> distances,
+			CellLayer<int> distances,
 			CellLayer<bool> passable,
 			IEnumerable<CPos> seeds,
-			float maxDistance)
+			int maxDistance)
 		{
 			var passableMatrix = ToMatrix(passable, false);
 			var cellBounds = CellBounds(passable);
@@ -428,7 +431,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 		/// Pick a random MPos position in a CellLayer where each cell is a
 		/// selection weight.
 		/// </summary>
-		public static MPos PickWeighted(CellLayer<float> weights, MersenneTwister random)
+		public static MPos PickWeighted(CellLayer<int> weights, MersenneTwister random)
 		{
 			var entries = Entries(weights);
 			var choice = random.PickWeighted(entries);

--- a/mods/cnc/rules/map-generators.yaml
+++ b/mods/cnc/rules/map-generators.yaml
@@ -6,40 +6,40 @@
 			Option@hidden_defaults:
 				Choice@hidden_defaults:
 					Settings:
-						TerrainFeatureSize: 20.0
-						ForestFeatureSize: 20.0
-						ResourceFeatureSize: 20.0
-						Water: 0.0
-						Mountains: 0.1
-						Forests: 0.025
+						TerrainFeatureSize: 20480
+						ForestFeatureSize: 20480
+						ResourceFeatureSize: 20480
+						Water: 0
+						Mountains: 100
+						Forests: 25
 						ForestCutout: 2
 						MaximumCutoutSpacing: 12
 						TerrainSmoothing: 4
-						SmoothingThreshold: 0.833333
+						SmoothingThreshold: 833
 						MinimumLandSeaThickness: 5
 						MinimumMountainThickness: 5
 						MaximumAltitude: 8
 						RoughnessRadius: 5
-						Roughness: 0.5
+						Roughness: 500
 						MinimumTerrainContourSpacing: 6
 						MinimumCliffLength: 10
-						ForestClumpiness: 0.5
+						ForestClumpiness: 1
 						DenyWalledAreas: True
 						EnforceSymmetry: 0
 						Roads: True
 						RoadSpacing: 5
 						RoadShrink: 0
 						CreateEntities: True
-						CentralSpawnReservationFraction: 0.25
+						CentralSpawnReservationFraction: 250
 						ResourceSpawnReservation: 8
 						SpawnRegionSize: 12
 						SpawnBuildSize: 8
 						SpawnResourceSpawns: 3
 						SpawnReservation: 20
-						SpawnResourceBias: 1.05
+						SpawnResourceBias: 1050
 						ResourcesPerPlayer: 50000
-						OreUniformity: 0.5
-						OreClumpiness: 0.5
+						OreUniformity: 500
+						OreClumpiness: 1
 						MaximumExpansionResourceSpawns: 5
 						MaximumResourceSpawnsPerExpansion: 2
 						MinimumExpansionSize: 2
@@ -92,18 +92,18 @@
 					Label: label-cnc-map-generator-choice-terrain-type-lakes
 					Tileset: DESERT
 					Settings:
-						Water: 0.2
+						Water: 200
 				Choice@Puddles:
 					Label: label-cnc-map-generator-choice-terrain-type-puddles
 					Tileset: DESERT
 					Settings:
-						Water: 0.1
+						Water: 100
 				Choice@Gardens:
 					Label: label-cnc-map-generator-choice-terrain-type-gardens
 					Tileset: DESERT
 					Settings:
-						Water: 0.05
-						Forests: 0.3
+						Water: 50
+						Forests: 300
 						ForestCutout: 3
 						EnforceSymmetry: 2
 						RoadSpacing: 3
@@ -111,17 +111,17 @@
 				Choice@Plains:
 					Label: label-cnc-map-generator-choice-terrain-type-plains
 					Settings:
-						Water: 0.0
+						Water: 0
 				Choice@Parks:
 					Label: label-cnc-map-generator-choice-terrain-type-parks
 					Settings:
-						Water: 0.0
-						Forests: 0.1
+						Water: 0
+						Forests: 100
 				Choice@Woodlands:
 					Label: label-cnc-map-generator-choice-terrain-type-woodlands
 					Settings:
-						Water: 0.0
-						Forests: 0.4
+						Water: 0
+						Forests: 400
 						ForestCutout: 3
 						EnforceSymmetry: 2
 						RoadSpacing: 3
@@ -129,36 +129,36 @@
 				Choice@Overgrown:
 					Label: label-cnc-map-generator-choice-terrain-type-overgrown
 					Settings:
-						Water: 0.0
-						Forests: 0.5
+						Water: 0
+						Forests: 500
 						EnforceSymmetry: 2
-						Mountains: 0.5
-						Roughness: 0.25
+						Mountains: 500
+						Roughness: 250
 				Choice@Rocky:
 					Label: label-cnc-map-generator-choice-terrain-type-rocky
 					Settings:
-						Water: 0.0
-						Forests: 0.3
+						Water: 0
+						Forests: 300
 						ForestCutout: 3
 						EnforceSymmetry: 2
-						Mountains: 0.5
-						Roughness: 0.25
+						Mountains: 500
+						Roughness: 250
 						RoadSpacing: 3
 						RoadShrink: 4
 				Choice@Mountains:
 					Label: label-cnc-map-generator-choice-terrain-type-mountains
 					Settings:
-						Water: 0.0
-						Mountains: 1.0
-						Roughness: 0.60
+						Water: 0
+						Mountains: 1000
+						Roughness: 600
 						MinimumTerrainContourSpacing: 5
 				Choice@MountainLakes:
 					Label: label-cnc-map-generator-choice-terrain-type-mountain-lakes
 					Tileset: DESERT
 					Settings:
-						Water: 0.2
-						Mountains: 1.0
-						Roughness: 0.85
+						Water: 200
+						Mountains: 1000
+						Roughness: 850
 						MinimumTerrainContourSpacing: 5
 			Option@Rotations:
 				Label: label-cnc-map-generator-option-rotations
@@ -230,8 +230,8 @@
 						SpawnResourceSpawns: 1
 						ResourcesPerPlayer: 25000
 						ResourceSpawnWeights:
-							split2: 1.0
-							split3: 1.0
+							split2: 1
+							split3: 1
 						MaximumExpansionResourceSpawns: 2
 						MaximumResourceSpawnsPerExpansion: 1
 				Choice@Medium:
@@ -240,9 +240,9 @@
 						SpawnResourceSpawns: 2
 						ResourcesPerPlayer: 50000
 						ResourceSpawnWeights:
-							split2: 0.95
-							split3: 0.95
-							splitblue: 0.10
+							split2: 95
+							split3: 95
+							splitblue: 10
 						MaximumExpansionResourceSpawns: 3
 						MaximumResourceSpawnsPerExpansion: 1
 				Choice@High:
@@ -251,9 +251,9 @@
 						SpawnResourceSpawns: 3
 						ResourcesPerPlayer: 75000
 						ResourceSpawnWeights:
-							split2: 0.9
-							split3: 0.9
-							splitblue: 0.2
+							split2: 9
+							split3: 9
+							splitblue: 2
 						MaximumExpansionResourceSpawns: 5
 						MaximumResourceSpawnsPerExpansion: 2
 				Choice@VeryHigh:
@@ -262,9 +262,9 @@
 						SpawnResourceSpawns: 4
 						ResourcesPerPlayer: 100000
 						ResourceSpawnWeights:
-							split2: 0.8
-							split3: 0.8
-							splitblue: 0.4
+							split2: 8
+							split3: 8
+							splitblue: 4
 						MaximumExpansionResourceSpawns: 8
 						MaximumResourceSpawnsPerExpansion: 2
 				Choice@Full:
@@ -324,38 +324,38 @@
 				Choice@Players:
 					Label: label-cnc-map-generator-choice-density-players
 					Settings:
-						AreaEntityBonus: 0.0
-						PlayerCountEntityBonus: 1.0
+						AreaEntityBonus: 0
+						PlayerCountEntityBonus: 1000000
 				Choice@AreaAndPlayers:
 					Label: label-cnc-map-generator-choice-density-area-and-players
 					Settings:
-						AreaEntityBonus: 0.0002
-						PlayerCountEntityBonus: 0.5
+						AreaEntityBonus: 200
+						PlayerCountEntityBonus: 500000
 				Choice@AreaVeryLow:
 					Label: label-cnc-map-generator-choice-density-area-very-low
 					Settings:
-						AreaEntityBonus: 0.0001
-						PlayerCountEntityBonus: 0.0
+						AreaEntityBonus: 100
+						PlayerCountEntityBonus: 0
 				Choice@AreaLow:
 					Label: label-cnc-map-generator-choice-density-area-low
 					Settings:
-						AreaEntityBonus: 0.0002
-						PlayerCountEntityBonus: 0.0
+						AreaEntityBonus: 200
+						PlayerCountEntityBonus: 0
 				Choice@AreaMedium:
 					Label: label-cnc-map-generator-choice-density-area-medium
 					Settings:
-						AreaEntityBonus: 0.0004
-						PlayerCountEntityBonus: 0.0
+						AreaEntityBonus: 400
+						PlayerCountEntityBonus: 0
 				Choice@AreaHigh:
 					Label: label-cnc-map-generator-choice-density-area-high
 					Settings:
-						AreaEntityBonus: 0.0006
-						PlayerCountEntityBonus: 0.0
+						AreaEntityBonus: 600
+						PlayerCountEntityBonus: 0
 				Choice@AreaVeryHigh:
 					Label: label-cnc-map-generator-choice-density-area-very-high
 					Settings:
-						AreaEntityBonus: 0.0008
-						PlayerCountEntityBonus: 0.0
+						AreaEntityBonus: 800
+						PlayerCountEntityBonus: 0
 			Option@DenyWalledArea:
 				Label: label-cnc-map-generator-option-deny-walled-areas
 				Checkbox: DenyWalledAreas

--- a/mods/cnc/tilesets/desert.yaml
+++ b/mods/cnc/tilesets/desert.yaml
@@ -3074,16 +3074,16 @@ MultiBrushCollections:
 			Actor: t18
 		MultiBrush@t04.husk:
 			Actor: t04.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t08.husk:
 			Actor: t08.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t09.husk:
 			Actor: t09.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t18.husk:
 			Actor: t18.husk
-			Weight: 0.1
+			Weight: 100
 	Obstructions:
 		MultiBrush@82:
 			Template: 82
@@ -3099,34 +3099,34 @@ MultiBrushCollections:
 			Template: 217
 		MultiBrush@57:
 			Template: 57
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@58:
 			Template: 58
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@59:
 			Template: 59
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@60:
 			Template: 60
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@61:
 			Template: 61
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@62:
 			Template: 62
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@63:
 			Template: 63
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@64:
 			Template: 64
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@65:
 			Template: 65
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@66:
 			Template: 66
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@67:
 			Template: 67
 		MultiBrush@68:
@@ -3140,42 +3140,42 @@ MultiBrushCollections:
 		MultiBrush@t04:
 			Actor: t04
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t08:
 			Actor: t08
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t09:
 			Actor: t09
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t18:
 			Actor: t18
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t04.husk:
 			Actor: t04.husk
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t08.husk:
 			Actor: t08.husk
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t09.husk:
 			Actor: t09.husk
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t18.husk:
 			Actor: t18.husk
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@rock1:
 			Actor: rock1
 		MultiBrush@rock2:
 			Actor: rock2
 		MultiBrush@rock3:
 			Actor: rock3
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@rock4:
 			Actor: rock4
 		MultiBrush@rock5:
@@ -3187,7 +3187,7 @@ MultiBrushCollections:
 	Water:
 		MultiBrush@1:
 			Template: 1
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@76:
 			Template: 76
 		MultiBrush@77:

--- a/mods/cnc/tilesets/jungle.yaml
+++ b/mods/cnc/tilesets/jungle.yaml
@@ -2475,58 +2475,58 @@ MultiBrushCollections:
 			Actor: tc05
 		MultiBrush@t01.husk:
 			Actor: t01.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t02.husk:
 			Actor: t02.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t03.husk:
 			Actor: t03.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t05.husk:
 			Actor: t05.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t06.husk:
 			Actor: t06.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t07.husk:
 			Actor: t07.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t08.husk:
 			Actor: t08.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t10.husk:
 			Actor: t10.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t11.husk:
 			Actor: t11.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t12.husk:
 			Actor: t12.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t13.husk:
 			Actor: t13.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t14.husk:
 			Actor: t14.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t15.husk:
 			Actor: t15.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t16.husk:
 			Actor: t16.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t17.husk:
 			Actor: t17.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc01.husk:
 			Actor: tc01.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc02.husk:
 			Actor: tc02.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc03.husk:
 			Actor: tc03.husk
-			Weight: 0.1
+			Weight: 100
 	Obstructions:
 		MultiBrush@67:
 			Template: 67
@@ -2534,10 +2534,10 @@ MultiBrushCollections:
 			Template: 68
 		MultiBrush@69:
 			Template: 69
-			Weight: 0.02
+			Weight: 20
 		MultiBrush@70:
 			Template: 70
-			Weight: 0.01
+			Weight: 10
 		MultiBrush@79:
 			Template: 79
 		MultiBrush@80:
@@ -2550,79 +2550,79 @@ MultiBrushCollections:
 			Template: 84
 		MultiBrush@188:
 			Template: 188
-			Weight: 0.01
+			Weight: 10
 		MultiBrush@t01:
 			Actor: t01
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t02:
 			Actor: t02
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t03:
 			Actor: t03
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t05:
 			Actor: t05
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t06:
 			Actor: t06
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t07:
 			Actor: t07
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t08:
 			Actor: t08
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t10:
 			Actor: t10
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t11:
 			Actor: t11
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t12:
 			Actor: t12
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t13:
 			Actor: t13
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t14:
 			Actor: t14
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t15:
 			Actor: t15
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t16:
 			Actor: t16
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t17:
 			Actor: t17
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 	Water:
 		MultiBrush@1:
 			Template: 1
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@2:
 			Template: 2
 		MultiBrush@5:
 			Template: 5
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@6:
 			Template: 6
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@76:
 			Template: 76
 		MultiBrush@77:

--- a/mods/cnc/tilesets/snow.yaml
+++ b/mods/cnc/tilesets/snow.yaml
@@ -2474,64 +2474,64 @@ MultiBrushCollections:
 			Actor: tc05
 		MultiBrush@t01.husk:
 			Actor: t01.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t02.husk:
 			Actor: t02.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t03.husk:
 			Actor: t03.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t05.husk:
 			Actor: t05.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t06.husk:
 			Actor: t06.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t07.husk:
 			Actor: t07.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t08.husk:
 			Actor: t08.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t10.husk:
 			Actor: t10.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t11.husk:
 			Actor: t11.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t12.husk:
 			Actor: t12.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t13.husk:
 			Actor: t13.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t14.husk:
 			Actor: t14.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t15.husk:
 			Actor: t15.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t16.husk:
 			Actor: t16.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t17.husk:
 			Actor: t17.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc01.husk:
 			Actor: tc01.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc02.husk:
 			Actor: tc02.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc03.husk:
 			Actor: tc03.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc04.husk:
 			Actor: tc04.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc05.husk:
 			Actor: tc05.husk
-			Weight: 0.1
+			Weight: 100
 	Obstructions:
 		MultiBrush@67:
 			Template: 67
@@ -2539,10 +2539,10 @@ MultiBrushCollections:
 			Template: 68
 		MultiBrush@69:
 			Template: 69
-			Weight: 0.02
+			Weight: 20
 		MultiBrush@70:
 			Template: 70
-			Weight: 0.01
+			Weight: 10
 		MultiBrush@79:
 			Template: 79
 		MultiBrush@80:
@@ -2556,75 +2556,75 @@ MultiBrushCollections:
 		MultiBrush@t01:
 			Actor: t01
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t02:
 			Actor: t02
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t03:
 			Actor: t03
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t05:
 			Actor: t05
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t06:
 			Actor: t06
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t07:
 			Actor: t07
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t08:
 			Actor: t08
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t10:
 			Actor: t10
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t11:
 			Actor: t11
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t12:
 			Actor: t12
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t13:
 			Actor: t13
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t14:
 			Actor: t14
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t15:
 			Actor: t15
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t16:
 			Actor: t16
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t17:
 			Actor: t17
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 	Water:
 		MultiBrush@1:
 			Template: 1
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@2:
 			Template: 2
 		MultiBrush@5:
 			Template: 5
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@6:
 			Template: 6
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@76:
 			Template: 76
 		MultiBrush@77:

--- a/mods/cnc/tilesets/temperat.yaml
+++ b/mods/cnc/tilesets/temperat.yaml
@@ -2475,64 +2475,64 @@ MultiBrushCollections:
 			Actor: tc05
 		MultiBrush@t01.husk:
 			Actor: t01.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t02.husk:
 			Actor: t02.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t03.husk:
 			Actor: t03.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t05.husk:
 			Actor: t05.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t06.husk:
 			Actor: t06.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t07.husk:
 			Actor: t07.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t08.husk:
 			Actor: t08.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t10.husk:
 			Actor: t10.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t11.husk:
 			Actor: t11.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t12.husk:
 			Actor: t12.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t13.husk:
 			Actor: t13.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t14.husk:
 			Actor: t14.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t15.husk:
 			Actor: t15.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t16.husk:
 			Actor: t16.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t17.husk:
 			Actor: t17.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc01.husk:
 			Actor: tc01.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc02.husk:
 			Actor: tc02.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc03.husk:
 			Actor: tc03.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc04.husk:
 			Actor: tc04.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc05.husk:
 			Actor: tc05.husk
-			Weight: 0.1
+			Weight: 100
 	Obstructions:
 		MultiBrush@67:
 			Template: 67
@@ -2542,7 +2542,7 @@ MultiBrushCollections:
 			Template: 69
 		MultiBrush@70:
 			Template: 70
-			Weight: 0.01
+			Weight: 10
 		MultiBrush@79:
 			Template: 79
 		MultiBrush@80:
@@ -2555,79 +2555,79 @@ MultiBrushCollections:
 			Template: 84
 		MultiBrush@188:
 			Template: 188
-			Weight: 0.01
+			Weight: 10
 		MultiBrush@t01:
 			Actor: t01
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t02:
 			Actor: t02
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t03:
 			Actor: t03
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t05:
 			Actor: t05
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t06:
 			Actor: t06
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t07:
 			Actor: t07
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t08:
 			Actor: t08
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t10:
 			Actor: t10
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t11:
 			Actor: t11
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t12:
 			Actor: t12
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t13:
 			Actor: t13
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t14:
 			Actor: t14
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t15:
 			Actor: t15
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t16:
 			Actor: t16
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t17:
 			Actor: t17
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 	Water:
 		MultiBrush@1:
 			Template: 1
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@2:
 			Template: 2
 		MultiBrush@5:
 			Template: 5
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@6:
 			Template: 6
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@76:
 			Template: 76
 		MultiBrush@77:

--- a/mods/cnc/tilesets/winter.yaml
+++ b/mods/cnc/tilesets/winter.yaml
@@ -2510,64 +2510,64 @@ MultiBrushCollections:
 			Actor: tc05
 		MultiBrush@t01.husk:
 			Actor: t01.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t02.husk:
 			Actor: t02.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t03.husk:
 			Actor: t03.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t05.husk:
 			Actor: t05.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t06.husk:
 			Actor: t06.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t07.husk:
 			Actor: t07.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t08.husk:
 			Actor: t08.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t10.husk:
 			Actor: t10.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t11.husk:
 			Actor: t11.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t12.husk:
 			Actor: t12.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t13.husk:
 			Actor: t13.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t14.husk:
 			Actor: t14.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t15.husk:
 			Actor: t15.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t16.husk:
 			Actor: t16.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t17.husk:
 			Actor: t17.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc01.husk:
 			Actor: tc01.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc02.husk:
 			Actor: tc02.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc03.husk:
 			Actor: tc03.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc04.husk:
 			Actor: tc04.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc05.husk:
 			Actor: tc05.husk
-			Weight: 0.1
+			Weight: 100
 	Obstructions:
 		MultiBrush@79:
 			Template: 79
@@ -2582,66 +2582,66 @@ MultiBrushCollections:
 		MultiBrush@t01:
 			Actor: t01
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t02:
 			Actor: t02
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t03:
 			Actor: t03
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t05:
 			Actor: t05
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t06:
 			Actor: t06
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t07:
 			Actor: t07
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t08:
 			Actor: t08
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t10:
 			Actor: t10
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t11:
 			Actor: t11
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t12:
 			Actor: t12
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t13:
 			Actor: t13
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t14:
 			Actor: t14
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t15:
 			Actor: t15
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t16:
 			Actor: t16
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 		MultiBrush@t17:
 			Actor: t17
 			BackingTile: 255,0
-			Weight: 0.2
+			Weight: 200
 	Snow:
 		MultiBrush@Nothing:
-			Weight: 100
+			Weight: 100000
 		MultiBrush@81:
 			Template: 81
 		MultiBrush@181:
@@ -2657,15 +2657,15 @@ MultiBrushCollections:
 	Water:
 		MultiBrush@1:
 			Template: 1
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@2:
 			Template: 2
 		MultiBrush@5:
 			Template: 5
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@6:
 			Template: 6
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@76:
 			Template: 76
 		MultiBrush@77:

--- a/mods/ra/rules/map-generators.yaml
+++ b/mods/ra/rules/map-generators.yaml
@@ -6,40 +6,40 @@
 			Option@hidden_defaults:
 				Choice@hidden_defaults:
 					Settings:
-						TerrainFeatureSize: 20.0
-						ForestFeatureSize: 20.0
-						ResourceFeatureSize: 20.0
-						Water: 0.2
-						Mountains: 0.1
-						Forests: 0.025
+						TerrainFeatureSize: 20480
+						ForestFeatureSize: 20480
+						ResourceFeatureSize: 20480
+						Water: 200
+						Mountains: 100
+						Forests: 25
 						ForestCutout: 2
 						MaximumCutoutSpacing: 12
 						TerrainSmoothing: 4
-						SmoothingThreshold: 0.833333
+						SmoothingThreshold: 833
 						MinimumLandSeaThickness: 5
 						MinimumMountainThickness: 5
 						MaximumAltitude: 8
 						RoughnessRadius: 5
-						Roughness: 0.5
+						Roughness: 500
 						MinimumTerrainContourSpacing: 6
 						MinimumCliffLength: 10
-						ForestClumpiness: 0.5
+						ForestClumpiness: 1
 						DenyWalledAreas: True
 						EnforceSymmetry: 0
 						Roads: True
 						RoadSpacing: 5
 						RoadShrink: 0
 						CreateEntities: True
-						CentralSpawnReservationFraction: 0.25
+						CentralSpawnReservationFraction: 250
 						ResourceSpawnReservation: 8
 						SpawnRegionSize: 12
 						SpawnBuildSize: 8
 						SpawnResourceSpawns: 3
 						SpawnReservation: 20
-						SpawnResourceBias: 1.15
+						SpawnResourceBias: 1150
 						ResourcesPerPlayer: 50000
-						OreUniformity: 0.25
-						OreClumpiness: 0.25
+						OreUniformity: 250
+						OreClumpiness: 2
 						MaximumExpansionResourceSpawns: 5
 						MaximumResourceSpawnsPerExpansion: 2
 						MinimumExpansionSize: 2
@@ -93,12 +93,12 @@
 				Choice@Puddles:
 					Label: label-ra-map-generator-choice-terrain-type-puddles
 					Settings:
-						Water: 0.1
+						Water: 100
 				Choice@Gardens:
 					Label: label-ra-map-generator-choice-terrain-type-gardens
 					Settings:
-						Water: 0.05
-						Forests: 0.3
+						Water: 50
+						Forests: 300
 						ForestCutout: 3
 						EnforceSymmetry: 2
 						RoadSpacing: 3
@@ -106,17 +106,17 @@
 				Choice@Plains:
 					Label: label-ra-map-generator-choice-terrain-type-plains
 					Settings:
-						Water: 0.0
+						Water: 0
 				Choice@Parks:
 					Label: label-ra-map-generator-choice-terrain-type-parks
 					Settings:
-						Water: 0.0
-						Forests: 0.1
+						Water: 0
+						Forests: 100
 				Choice@Woodlands:
 					Label: label-ra-map-generator-choice-terrain-type-woodlands
 					Settings:
-						Water: 0.0
-						Forests: 0.4
+						Water: 0
+						Forests: 400
 						ForestCutout: 3
 						EnforceSymmetry: 2
 						RoadSpacing: 3
@@ -124,62 +124,62 @@
 				Choice@Overgrown:
 					Label: label-ra-map-generator-choice-terrain-type-overgrown
 					Settings:
-						Water: 0.0
-						Forests: 0.5
+						Water: 0
+						Forests: 500
 						EnforceSymmetry: 2
-						Mountains: 0.5
-						Roughness: 0.25
+						Mountains: 500
+						Roughness: 250
 				Choice@Rocky:
 					Label: label-ra-map-generator-choice-terrain-type-rocky
 					Settings:
-						Water: 0.0
-						Forests: 0.3
+						Water: 0
+						Forests: 300
 						ForestCutout: 3
 						EnforceSymmetry: 2
-						Mountains: 0.5
-						Roughness: 0.25
+						Mountains: 500
+						Roughness: 250
 						RoadSpacing: 3
 						RoadShrink: 4
 				Choice@Mountains:
 					Label: label-ra-map-generator-choice-terrain-type-mountains
 					Settings:
-						Water: 0.0
-						Mountains: 1.0
-						Roughness: 0.60
+						Water: 0
+						Mountains: 1000
+						Roughness: 600
 						MinimumTerrainContourSpacing: 5
 				Choice@MountainLakes:
 					Label: label-ra-map-generator-choice-terrain-type-mountain-lakes
 					Settings:
-						Water: 0.2
-						Mountains: 1.0
-						Roughness: 0.85
+						Water: 200
+						Mountains: 1000
+						Roughness: 850
 						MinimumTerrainContourSpacing: 5
 				Choice@Oceanic:
 					Label: label-ra-map-generator-choice-terrain-type-oceanic
 					Settings:
-						Water: 0.8
-						Forests: 0.0
+						Water: 800
+						Forests: 0
 				Choice@LargeIslands:
 					Label: label-ra-map-generator-choice-terrain-type-large-islands
 					Settings:
-						Water: 0.75
-						TerrainFeatureSize: 50.0
-						Forests: 0.0
+						Water: 750
+						TerrainFeatureSize: 51200
+						Forests: 0
 				Choice@Continents:
 					Label: label-ra-map-generator-choice-terrain-type-continents
 					Settings:
-						Water: 0.5
-						TerrainFeatureSize: 100.0
+						Water: 500
+						TerrainFeatureSize: 102400
 				Choice@Wetlands:
 					Label: label-ra-map-generator-choice-terrain-type-wetlands
 					Settings:
-						Water: 0.5
+						Water: 500
 				Choice@NarrowWetlands:
 					Label: label-ra-map-generator-choice-terrain-type-narrow-wetlands
 					Settings:
-						Water: 0.5
-						TerrainFeatureSize: 5.0
-						Forests: 0.0
+						Water: 500
+						TerrainFeatureSize: 5120
+						Forests: 0
 						SpawnBuildSize: 6
 			Option@Rotations:
 				Label: label-ra-map-generator-option-rotations
@@ -250,7 +250,7 @@
 						SpawnResourceSpawns: 2
 						ResourcesPerPlayer: 25000
 						ResourceSpawnWeights:
-							mine: 1.0
+							mine: 1
 						MaximumExpansionResourceSpawns: 3
 						MaximumResourceSpawnsPerExpansion: 1
 				Choice@Medium:
@@ -259,8 +259,8 @@
 						SpawnResourceSpawns: 3
 						ResourcesPerPlayer: 50000
 						ResourceSpawnWeights:
-							mine: 0.95
-							gmine: 0.05
+							mine: 95
+							gmine: 5
 						MaximumExpansionResourceSpawns: 5
 						MaximumResourceSpawnsPerExpansion: 2
 				Choice@High:
@@ -269,8 +269,8 @@
 						SpawnResourceSpawns: 3
 						ResourcesPerPlayer: 75000
 						ResourceSpawnWeights:
-							mine: 0.9
-							gmine: 0.1
+							mine: 9
+							gmine: 1
 						MaximumExpansionResourceSpawns: 8
 						MaximumResourceSpawnsPerExpansion: 3
 				Choice@VeryHigh:
@@ -279,8 +279,8 @@
 						SpawnResourceSpawns: 4
 						ResourcesPerPlayer: 100000
 						ResourceSpawnWeights:
-							mine: 0.8
-							gmine: 0.2
+							mine: 8
+							gmine: 2
 						MaximumExpansionResourceSpawns: 10
 						MaximumResourceSpawnsPerExpansion: 3
 				Choice@Full:
@@ -341,38 +341,38 @@
 				Choice@Players:
 					Label: label-ra-map-generator-choice-density-players
 					Settings:
-						AreaEntityBonus: 0.0
-						PlayerCountEntityBonus: 1.0
+						AreaEntityBonus: 0
+						PlayerCountEntityBonus: 1000000
 				Choice@AreaAndPlayers:
 					Label: label-ra-map-generator-choice-density-area-and-players
 					Settings:
-						AreaEntityBonus: 0.0002
-						PlayerCountEntityBonus: 0.5
+						AreaEntityBonus: 200
+						PlayerCountEntityBonus: 500000
 				Choice@AreaVeryLow:
 					Label: label-ra-map-generator-choice-density-area-very-low
 					Settings:
-						AreaEntityBonus: 0.0001
-						PlayerCountEntityBonus: 0.0
+						AreaEntityBonus: 100
+						PlayerCountEntityBonus: 0
 				Choice@AreaLow:
 					Label: label-ra-map-generator-choice-density-area-low
 					Settings:
-						AreaEntityBonus: 0.0002
-						PlayerCountEntityBonus: 0.0
+						AreaEntityBonus: 200
+						PlayerCountEntityBonus: 0
 				Choice@AreaMedium:
 					Label: label-ra-map-generator-choice-density-area-medium
 					Settings:
-						AreaEntityBonus: 0.0004
-						PlayerCountEntityBonus: 0.0
+						AreaEntityBonus: 400
+						PlayerCountEntityBonus: 0
 				Choice@AreaHigh:
 					Label: label-ra-map-generator-choice-density-area-high
 					Settings:
-						AreaEntityBonus: 0.0006
-						PlayerCountEntityBonus: 0.0
+						AreaEntityBonus: 600
+						PlayerCountEntityBonus: 0
 				Choice@AreaVeryHigh:
 					Label: label-ra-map-generator-choice-density-area-very-high
 					Settings:
-						AreaEntityBonus: 0.0008
-						PlayerCountEntityBonus: 0.0
+						AreaEntityBonus: 800
+						PlayerCountEntityBonus: 0
 			Option@DenyWalledArea:
 				Label: label-ra-map-generator-option-deny-walled-areas
 				Checkbox: DenyWalledAreas

--- a/mods/ra/tilesets/desert.yaml
+++ b/mods/ra/tilesets/desert.yaml
@@ -4071,16 +4071,16 @@ MultiBrushCollections:
 			Actor: tc01
 		MultiBrush@t04.husk:
 			Actor: t04.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t08.husk:
 			Actor: t08.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t09.husk:
 			Actor: t09.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc01.husk:
 			Actor: tc01.husk
-			Weight: 0.1
+			Weight: 100
 	Obstructions:
 		MultiBrush@2:
 			Template: 2
@@ -4096,34 +4096,34 @@ MultiBrushCollections:
 			Template: 7
 		MultiBrush@14:
 			Template: 14
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@15:
 			Template: 15
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@16:
 			Template: 16
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@17:
 			Template: 17
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@18:
 			Template: 18
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@19:
 			Template: 19
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@20:
 			Template: 20
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@21:
 			Template: 21
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@22:
 			Template: 22
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@23:
 			Template: 23
-			Weight: 0.5
+			Weight: 500
 		MultiBrush@35:
 			Template: 35
 		MultiBrush@36:
@@ -4137,32 +4137,32 @@ MultiBrushCollections:
 		MultiBrush@t04:
 			Actor: t04
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t08:
 			Actor: t08
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t09:
 			Actor: t09
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc01:
 			Actor: tc01
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t04.husk:
 			Actor: t04.husk
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t08.husk:
 			Actor: t08.husk
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t09.husk:
 			Actor: t09.husk
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc01.husk:
 			Actor: tc01.husk
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100

--- a/mods/ra/tilesets/snow.yaml
+++ b/mods/ra/tilesets/snow.yaml
@@ -4192,64 +4192,64 @@ MultiBrushCollections:
 			Actor: tc05
 		MultiBrush@t01.husk:
 			Actor: t01.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t02.husk:
 			Actor: t02.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t03.husk:
 			Actor: t03.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t05.husk:
 			Actor: t05.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t06.husk:
 			Actor: t06.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t07.husk:
 			Actor: t07.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t08.husk:
 			Actor: t08.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t10.husk:
 			Actor: t10.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t11.husk:
 			Actor: t11.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t12.husk:
 			Actor: t12.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t13.husk:
 			Actor: t13.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t14.husk:
 			Actor: t14.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t15.husk:
 			Actor: t15.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t16.husk:
 			Actor: t16.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t17.husk:
 			Actor: t17.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc01.husk:
 			Actor: tc01.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc02.husk:
 			Actor: tc02.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc03.husk:
 			Actor: tc03.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc04.husk:
 			Actor: tc04.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc05.husk:
 			Actor: tc05.husk
-			Weight: 0.1
+			Weight: 100
 	Obstructions:
 		MultiBrush@97:
 			Template: 97
@@ -4283,10 +4283,10 @@ MultiBrushCollections:
 			Template: 104
 		MultiBrush@105:
 			Template: 105
-			Weight: 0.05
+			Weight: 50
 		MultiBrush@106:
 			Template: 106
-			Weight: 0.05
+			Weight: 50
 		MultiBrush@109:
 			Template: 109
 		MultiBrush@110:
@@ -4294,60 +4294,60 @@ MultiBrushCollections:
 		MultiBrush@t01:
 			Actor: t01
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t02:
 			Actor: t02
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t03:
 			Actor: t03
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t05:
 			Actor: t05
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t06:
 			Actor: t06
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t07:
 			Actor: t07
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t08:
 			Actor: t08
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t10:
 			Actor: t10
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t11:
 			Actor: t11
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t12:
 			Actor: t12
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t13:
 			Actor: t13
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t14:
 			Actor: t14
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t15:
 			Actor: t15
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t16:
 			Actor: t16
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t17:
 			Actor: t17
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100

--- a/mods/ra/tilesets/temperat.yaml
+++ b/mods/ra/tilesets/temperat.yaml
@@ -4652,64 +4652,64 @@ MultiBrushCollections:
 			Actor: tc05
 		MultiBrush@t01.husk:
 			Actor: t01.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t02.husk:
 			Actor: t02.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t03.husk:
 			Actor: t03.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t05.husk:
 			Actor: t05.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t06.husk:
 			Actor: t06.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t07.husk:
 			Actor: t07.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t08.husk:
 			Actor: t08.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t10.husk:
 			Actor: t10.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t11.husk:
 			Actor: t11.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t12.husk:
 			Actor: t12.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t13.husk:
 			Actor: t13.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t14.husk:
 			Actor: t14.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t15.husk:
 			Actor: t15.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t16.husk:
 			Actor: t16.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t17.husk:
 			Actor: t17.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc01.husk:
 			Actor: tc01.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc02.husk:
 			Actor: tc02.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc03.husk:
 			Actor: tc03.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc04.husk:
 			Actor: tc04.husk
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@tc05.husk:
 			Actor: tc05.husk
-			Weight: 0.1
+			Weight: 100
 	Obstructions:
 		MultiBrush@97:
 			Template: 97
@@ -4743,10 +4743,10 @@ MultiBrushCollections:
 			Template: 104
 		MultiBrush@105:
 			Template: 105
-			Weight: 0.05
+			Weight: 50
 		MultiBrush@106:
 			Template: 106
-			Weight: 0.05
+			Weight: 50
 		MultiBrush@109:
 			Template: 109
 		MultiBrush@110:
@@ -4754,87 +4754,87 @@ MultiBrushCollections:
 		MultiBrush@t01:
 			Actor: t01
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t02:
 			Actor: t02
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t03:
 			Actor: t03
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t05:
 			Actor: t05
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t06:
 			Actor: t06
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t07:
 			Actor: t07
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t08:
 			Actor: t08
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t10:
 			Actor: t10
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t11:
 			Actor: t11
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t12:
 			Actor: t12
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t13:
 			Actor: t13
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t14:
 			Actor: t14
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t15:
 			Actor: t15
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t16:
 			Actor: t16
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@t17:
 			Actor: t17
 			BackingTile: 255,0
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@580:
 			Template: 580
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@581:
 			Template: 581
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@582:
 			Template: 582
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@583:
 			Template: 583
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@584:
 			Template: 584
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@585:
 			Template: 585
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@586:
 			Template: 586
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@587:
 			Template: 587
-			Weight: 0.1
+			Weight: 100
 		MultiBrush@588:
 			Template: 588
-			Weight: 0.1
+			Weight: 100


### PR DESCRIPTION
Removes all use of floating point from the RaMapGenerator map generator and its dependencies.

Floating point behavior is potentially non-portable across client hardware. Removing them should make the map generation logic consistent even across clients with different floating point hardware or compiler behavior. This may be useful for sync-safe multiplayer or replay map generation where clients independently generate the map from settings.

Most previously fractional public-facing settings are now represented as numbers out of 1000, with some exceptions using 1000000. Most internal logic which relies on fixed-point concepts now uses 1024ths, though some floating point mechanisms have been replaced with alternative discrete approximations (e.g. gaussian to binomial).
