### PR TITLE
Improve dump sheet command

### DIFF
--- a/OpenRA.Game/Graphics/CursorManager.cs
+++ b/OpenRA.Game/Graphics/CursorManager.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Graphics
 		}
 
 		readonly Dictionary<string, Cursor> cursors = [];
-		readonly SheetBuilder sheetBuilder;
+		public readonly SheetBuilder SheetBuilder;
 		readonly GraphicSettings graphicSettings;
 
 		Cursor cursor;
@@ -44,7 +44,7 @@ namespace OpenRA.Graphics
 			hardwareCursorsDisabled = Game.Settings.Graphics.DisableHardwareCursors;
 
 			graphicSettings = Game.Settings.Graphics;
-			sheetBuilder = new SheetBuilder(SheetType.BGRA, cursorSheetSize);
+			SheetBuilder = new SheetBuilder(SheetType.BGRA, cursorSheetSize);
 
 			// Sort the cursors for better packing onto the sheet.
 			foreach (var kv in cursorProvider.Cursors
@@ -82,7 +82,7 @@ namespace OpenRA.Graphics
 						type = SpriteFrameType.Bgra32;
 					}
 
-					c.Sprites[c.Length++] = sheetBuilder.Add(data, type, f.Size, 0, hotspot);
+					c.Sprites[c.Length++] = SheetBuilder.Add(data, type, f.Size, 0, hotspot);
 
 					// Bounds relative to the hotspot
 					c.Bounds = Rectangle.Union(c.Bounds, new Rectangle(hotspot, f.Size));
@@ -94,8 +94,12 @@ namespace OpenRA.Graphics
 				cursors.Add(kv.Key, c);
 			}
 
-			CreateOrUpdateHardwareCursors();
-			Update();
+			// Allow the utility to create a cursor manager.
+			if (Game.Renderer != null)
+			{
+				CreateOrUpdateHardwareCursors();
+				Update();
+			}
 		}
 
 		void CreateOrUpdateHardwareCursors()
@@ -128,7 +132,7 @@ namespace OpenRA.Graphics
 				}
 			}
 
-			sheetBuilder.Current?.ReleaseBuffer();
+			SheetBuilder.Current?.ReleaseBuffer();
 
 			hardwareCursorsDoubled = graphicSettings.CursorDouble;
 		}
@@ -293,7 +297,7 @@ namespace OpenRA.Graphics
 			ClearHardwareCursors();
 
 			cursors.Clear();
-			sheetBuilder.Dispose();
+			SheetBuilder.Dispose();
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/SequenceSet.cs
+++ b/OpenRA.Game/Graphics/SequenceSet.cs
@@ -44,15 +44,15 @@ namespace OpenRA.Graphics
 
 	public sealed class SequenceSet : IDisposable
 	{
+		public readonly string TileSet;
 		readonly ModData modData;
-		readonly string tileSet;
 		readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, ISpriteSequence>> images;
 		public SpriteCache SpriteCache { get; }
 
 		public SequenceSet(IReadOnlyFileSystem fileSystem, ModData modData, string tileSet, MiniYaml additionalSequences)
 		{
 			this.modData = modData;
-			this.tileSet = tileSet;
+			TileSet = tileSet;
 			SpriteCache = new SpriteCache(fileSystem, modData.SpriteLoaders, modData.SpriteSequenceLoader.BgraSheetSize, modData.SpriteSequenceLoader.IndexedSheetSize);
 			using (new Support.PerfTimer("LoadSequences"))
 				images = Load(fileSystem, additionalSequences);
@@ -97,7 +97,7 @@ namespace OpenRA.Graphics
 				if (node.Key.StartsWith(ActorInfo.AbstractActorPrefix))
 					continue;
 
-				images[node.Key] = modData.SpriteSequenceLoader.ParseSequences(modData, tileSet, SpriteCache, node);
+				images[node.Key] = modData.SpriteSequenceLoader.ParseSequences(modData, TileSet, SpriteCache, node);
 			}
 
 			return images;

--- a/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	public class TerrainRendererInfo : TraitInfo, ITiledTerrainRendererInfo
 	{
-		bool ITiledTerrainRendererInfo.ValidateTileSprites(ITemplatedTerrainInfo terrainInfo, Action<string> onError)
+		bool ITiledTerrainRendererInfo.ValidateTileSprites(ITemplatedTerrainInfo terrainInfo, Action<string> onError, out DefaultTileCache tileCache)
 		{
 			var missingImages = new HashSet<string>();
 			var failed = false;
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 				failed = true;
 			}
 
-			var tileCache = new DefaultTileCache((DefaultTerrain)terrainInfo, OnMissingImage);
+			tileCache = new DefaultTileCache((DefaultTerrain)terrainInfo, OnMissingImage);
 			foreach (var t in terrainInfo.Templates)
 			{
 				var templateInfo = (DefaultTerrainTemplateInfo)t.Value;

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -768,7 +768,7 @@ namespace OpenRA.Mods.Common.Traits
 	[RequireExplicitImplementation]
 	public interface ITiledTerrainRendererInfo : ITraitInfoInterface
 	{
-		bool ValidateTileSprites(ITemplatedTerrainInfo terrainInfo, Action<string> onError);
+		bool ValidateTileSprites(ITemplatedTerrainInfo terrainInfo, Action<string> onError, out DefaultTileCache tileCache);
 	}
 
 	[RequireExplicitImplementation]

--- a/OpenRA.Mods.Common/UtilityCommands/CheckMissingSprites.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckMissingSprites.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						Console.WriteLine("Tileset: " + tileset);
 						if (terrainInfo is ITemplatedTerrainInfo templatedTerrainInfo)
 							foreach (var ttr in modData.DefaultRules.Actors[SystemActors.World].TraitInfos<ITiledTerrainRendererInfo>())
-								failed |= ttr.ValidateTileSprites(templatedTerrainInfo, Console.WriteLine);
+								failed |= ttr.ValidateTileSprites(templatedTerrainInfo, Console.WriteLine, out _);
 
 						var sequences = new SequenceSet(modData.DefaultFileSystem, modData, tileset, null);
 						sequences.SpriteCache.LoadReservations(modData);

--- a/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using OpenRA.FileFormats;
 using OpenRA.FileSystem;
 using OpenRA.Graphics;
@@ -24,47 +25,80 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 		bool IUtilityCommand.ValidateArguments(string[] args)
 		{
-			return args.Length >= 3;
+			return args.Length >= 1;
 		}
 
-		[Desc("PALETTE", "TILESET-OR-MAP", "Exports sequence texture atlas as a set of png images.")]
+		[Desc("[PALETTE]", "[TILESET-OR-MAP]", "Exports texture atlas' as a set of png images. "
+			+ "If palette is not specified, only BGRA sheets are exported. "
+			+ "If tileset-or-map is not specified, all tilesets are exported.")]
 		void IUtilityCommand.Run(Utility utility, string[] args)
 		{
 			// HACK: The engine code assumes that Game.modData is set.
 			var modData = Game.ModData = utility.ModData;
 
-			var palette = new ImmutablePalette(args[1], [0], []);
+			var palette = args.Length > 1 ? new ImmutablePalette(args[1], [0], []) : null;
+			var sequences = new List<SequenceSet>();
 
-			SequenceSet sequences;
-			var tilesetUpper = args[2].ToUpperInvariant();
-			if (modData.DefaultTerrainInfo.ContainsKey(tilesetUpper))
-				sequences = new SequenceSet(modData.ModFiles, modData, tilesetUpper, null);
+			if (args.Length == 3)
+			{
+				var tilesetUpper = args[2].ToUpperInvariant();
+				if (modData.DefaultTerrainInfo.ContainsKey(tilesetUpper))
+					sequences.Add(new SequenceSet(modData.ModFiles, modData, tilesetUpper, null));
+				else
+				{
+					var mapPackage = new Folder(Platform.EngineDir).OpenPackage(args[2], modData.ModFiles);
+					if (mapPackage == null)
+						throw new InvalidOperationException($"{args[2]} is not a valid tileset or map path");
+
+					sequences.Add(new Map(modData, mapPackage).Sequences);
+				}
+			}
 			else
 			{
-				var mapPackage = new Folder(Platform.EngineDir).OpenPackage(args[2], modData.ModFiles);
-				if (mapPackage == null)
-					throw new InvalidOperationException($"{args[2]} is not a valid tileset or map path");
-
-				sequences = new Map(modData, mapPackage).Sequences;
+				foreach (var t in modData.DefaultTerrainInfo.Keys)
+					sequences.Add(new SequenceSet(modData.ModFiles, modData, t, null));
 			}
 
-			sequences.LoadSprites();
-
-			var count = 0;
-
-			var sb = sequences.SpriteCache.SheetBuilders[SheetType.Indexed];
-			foreach (var s in sb.AllSheets)
+			var sheetCount = 1;
+			foreach (var sequence in sequences)
 			{
-				var max = s == sb.Current ? (int)sb.CurrentChannel + 1 : 4;
-				for (var i = 0; i < max; i++)
-					s.AsPng((TextureChannel)ChannelMasks[i], palette).Save($"{count}.{i}.png", Png.Compression.BEST_SPEED);
+				sequence.LoadSprites();
 
-				count++;
+				var sequencesName = "sequences";
+				var terrainName = "tileset";
+				if (sequences.Count > 1)
+				{
+					var name = sequence.TileSet.ToLowerInvariant();
+					sequencesName += "." + name;
+					terrainName += "." + name;
+				}
+
+				var sb = sequence.SpriteCache.SheetBuilders[SheetType.Indexed];
+				foreach (var s in sb.AllSheets)
+					CommitSheet(sb, s, sequencesName, palette, ref sheetCount);
+
+				foreach (var s in sequence.SpriteCache.SheetBuilders[SheetType.BGRA].AllSheets)
+					CommitSheet(null, s, sequencesName, palette, ref sheetCount);
+
+				sequence.Dispose();
 			}
+		}
 
-			sb = sequences.SpriteCache.SheetBuilders[SheetType.BGRA];
-			foreach (var s in sb.AllSheets)
-				s.AsPng().Save($"{count++}.png", Png.Compression.BEST_SPEED);
+		static void CommitSheet(SheetBuilder builder, Sheet sheet, string name, ImmutablePalette palette, ref int count)
+		{
+			if (builder == null)
+				sheet.AsPng().Save($"{count++}.{name}.png", Png.Compression.BEST_SPEED);
+			else
+			{
+				if (palette != null)
+				{
+					var channels = sheet == builder.Current ? (int)builder.CurrentChannel + 1 : 4;
+					for (var i = 0; i < channels; i++)
+						sheet.AsPng((TextureChannel)ChannelMasks[i], palette).Save($"{count}.{i}.{name}.png", Png.Compression.BEST_SPEED);
+
+					count++;
+				}
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
@@ -62,6 +62,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			}
 
 			var sheetCount = 1;
+			var cursorProvider = new CursorProvider(modData);
+			using (var cursor = new CursorManager(cursorProvider, modData.Manifest.CursorSheetSize))
+				foreach (var sheet in cursor.SheetBuilder.AllSheets)
+					CommitSheet(null, sheet, "cursors", palette, ref sheetCount);
+
 			foreach (var sequence in sequences)
 			{
 				sequence.LoadSprites();


### PR DESCRIPTION
- Dump cursor sheets
- Dump tilesets
- Allow the dumping of assets from multiple tilesets

This makes it much easier to check wether sheets are allocated innefectively.