### PR TITLE
Refine map generator spawn placement rules

### DIFF
--- a/OpenRA.Mods.Common/MapGenerator/Symmetry.cs
+++ b/OpenRA.Mods.Common/MapGenerator/Symmetry.cs
@@ -278,26 +278,5 @@ namespace OpenRA.Mods.Common.MapGenerator
 					action(projections, original);
 				}
 		}
-
-		/// <summary>
-		/// Returns true iff xy is within reservationRadius of the center of a given CellLayer. If
-		/// a mirroring is specified, the radius is measured from the mirror line instead of the
-		/// center point.
-		/// </summary>
-		public static bool IsCPosNearCenter<T>(
-			CPos cpos,
-			CellLayer<T> cellLayer,
-			int reservationRadius,
-			Mirror mirror)
-		{
-			CPos[] testPoints;
-			if (mirror == Mirror.None)
-				testPoints = RotateAndMirrorCPos(cpos, cellLayer, 2, Mirror.None);
-			else
-				testPoints = RotateAndMirrorCPos(cpos, cellLayer, 1, mirror);
-
-			var separation = (testPoints[1] - testPoints[0]).LengthSquared;
-			return separation <= reservationRadius * reservationRadius * 4;
-		}
 	}
 }

--- a/mods/cnc/rules/map-generators.yaml
+++ b/mods/cnc/rules/map-generators.yaml
@@ -34,8 +34,9 @@
 						ResourceSpawnReservation: 8
 						SpawnRegionSize: 12
 						SpawnBuildSize: 8
+						MinimumSpawnRadius: 5
 						SpawnResourceSpawns: 3
-						SpawnReservation: 20
+						SpawnReservation: 16
 						SpawnResourceBias: 1050
 						ResourcesPerPlayer: 50000
 						OreUniformity: 500
@@ -56,6 +57,7 @@
 						PartiallyPlayableTerrain: River,Tree,Water
 						UnplayableTerrain: Rock
 						DominantTerrain: River,Rock,Tree,Water
+						ZoneableTerrain: Clear,Road
 						PartiallyPlayableCategories: Beach,Road
 						ClearSegmentTypes: Clear
 						BeachSegmentTypes: Beach

--- a/mods/ra/rules/map-generators.yaml
+++ b/mods/ra/rules/map-generators.yaml
@@ -34,8 +34,9 @@
 						ResourceSpawnReservation: 8
 						SpawnRegionSize: 12
 						SpawnBuildSize: 8
+						MinimumSpawnRadius: 5
 						SpawnResourceSpawns: 3
-						SpawnReservation: 20
+						SpawnReservation: 16
 						SpawnResourceBias: 1150
 						ResourcesPerPlayer: 50000
 						OreUniformity: 250
@@ -55,6 +56,7 @@
 						PartiallyPlayableTerrain: Tree
 						UnplayableTerrain: River,Rock
 						DominantTerrain: River,Rock,Tree,Water
+						ZoneableTerrain: Clear,Road
 						PartiallyPlayableCategories: Beach,Road
 						ClearSegmentTypes: Clear
 						BeachSegmentTypes: Beach
@@ -159,6 +161,7 @@
 					Settings:
 						Water: 800
 						Forests: 0
+						MinimumSpawnRadius: 4
 				Choice@LargeIslands:
 					Label: label-ra-map-generator-choice-terrain-type-large-islands
 					Settings:
@@ -181,6 +184,7 @@
 						TerrainFeatureSize: 5120
 						Forests: 0
 						SpawnBuildSize: 6
+						MinimumSpawnRadius: 4
 			Option@Rotations:
 				Label: label-ra-map-generator-option-rotations
 				SimpleChoice: Rotations


### PR DESCRIPTION
Spawn generation generally tries to place spawns:

- In spacious areas
- Away from the center (true center or mirror lines)
- Away from a symmetry-projected spawn
- Away from previously placed spawns

This commit introduces the following adjustments:

- The spacing between sequentially placed spawns is relaxed.
- Fix spawn mines contributing too much to the space reservation.
- Factor rotations into anti-center biasing calculation.
- Preserve spacing information in center space fallback decisions.
- Use a linear (instead of binary) falloff for anti-center biasing.
- Enforce that spawns have a minimum buildable area around them.
- Enforce that symmetry-projected spawns have as much separation as
  sequentially placed spawns would.
- Allow spawns on or near roads.

(Addresses comments in https://github.com/OpenRA/OpenRA/pull/21717#pullrequestreview-2575279749 that aren't particularly related to that patch.)