### PR TITLE
D2k shellmap: Hide pickup indicators

### DIFF
--- a/mods/d2k/maps/shellmap/rules.yaml
+++ b/mods/d2k/maps/shellmap/rules.yaml
@@ -27,6 +27,10 @@ World:
 	DamageMultiplier@UNKILLABLE:
 		Modifier: 0
 
+^Vehicle:
+	WithDecoration@CARRYALL:
+		RequiresSelection: true
+
 wall:
 	DamageMultiplier@UNKILLABLE:
 		Modifier: 0


### PR DESCRIPTION
Fixes #17078

Requiring an impossible mouse selection seemed like the most straightforward solution, so that's what I went with.