### PR TITLE
Hide owner row for D2k special mission Outposts

### DIFF
--- a/mods/d2k/maps/harkonnen-05/rules.yaml
+++ b/mods/d2k/maps/harkonnen-05/rules.yaml
@@ -79,3 +79,4 @@ outpost:
 	Tooltip@Modified:
 		Name: actor-outpost-modified-name
 		RequiresCondition: modified
+		ShowOwnerRow: false

--- a/mods/d2k/maps/ordos-04/ordos04.lua
+++ b/mods/d2k/maps/ordos-04/ordos04.lua
@@ -112,8 +112,6 @@ WorldLoaded = function()
 	CaptureOutpost = AddPrimaryObjective(Ordos, "capture-smuggler-outpost")
 	KillHarkonnen = AddSecondaryObjective(Ordos, "destroy-harkonnen")
 
-	SOutpost.GrantCondition("modified")
-
 	Camera.Position = OConyard.CenterPosition
 	HarkonnenAttackLocation = OConyard.Location
 
@@ -138,6 +136,7 @@ WorldLoaded = function()
 			Ordos.MarkCompletedObjective(CaptureOutpost)
 			Smuggler.MarkFailedObjective(DefendOutpost)
 		end)
+		SOutpost.GrantCondition("modified")
 	end)
 	Trigger.OnDamaged(SOutpost, function(_, attacker)
 		if SOutpost.Owner ~= Smuggler or attacker.IsDead or attacker.Owner ~= Ordos then

--- a/mods/d2k/maps/ordos-04/rules.yaml
+++ b/mods/d2k/maps/ordos-04/rules.yaml
@@ -42,6 +42,7 @@ outpost:
 	Tooltip@Modified:
 		Name: actor-outpost-modified-name
 		RequiresCondition: modified
+		ShowOwnerRow: false
 
 quad:
 	Buildable:


### PR DESCRIPTION
Fixes #21709

In the `ordos-04` case, the "modified" condition is also delayed until the Outpost is under the player's control.