### PR TITLE
Restore StartGameNotification in missions

### DIFF
--- a/mods/ra/maps/monster-tank-madness/rules.yaml
+++ b/mods/ra/maps/monster-tank-madness/rules.yaml
@@ -5,7 +5,8 @@ Player:
 World:
 	LuaScript:
 		Scripts: campaign.lua, utils.lua, monster-tank-madness.lua
-	-StartGameNotification:
+	StartGameNotification:
+		Notification:
 	MissionData:
 		Briefing: Dr. Demitri, creator of a Soviet Super Tank, wants to defect.\n\nWe planned to extract him while the Soviets were testing their new weapon, but something has gone wrong.\n\nThe Super Tanks are out of control, and Demitri is missing -- likely hiding in the village to the far south.\n\nFind our outpost and start repairs on it, then find and evacuate Demitri.\n\nAs for the tanks, we can reprogram them. Send a spy into the Soviet radar dome in the NE, turning the tanks on their creators.\n
 		WinVideo: sovbatl.vqa

--- a/mods/ra/maps/mousetrap/rules.yaml
+++ b/mods/ra/maps/mousetrap/rules.yaml
@@ -14,8 +14,9 @@ World:
 			normal: options-difficulty.normal
 			hard: options-difficulty.hard
 		Default: normal
-	# Stavros' opening line makes this feel redundant.
-	-StartGameNotification:
+	# Skip the normal start notification in favor of Stavros' opening line.
+	StartGameNotification:
+		Notification:
 	# Give our Chrono dummy the ability to move (and be shifted) within the void.
 	Locomotor@TRACKED:
 		TerrainSpeeds:


### PR DESCRIPTION
A tiny step toward #21711

StartGameNotification is incorrectly removed in two missions so a sound takes the normal start notification's place in the mission script. This PR still skips the sound while preserving other notifications like save/load ones.