### PR TITLE
Fix overflow when calculating array quantile index

### DIFF
--- a/OpenRA.Mods.Common/MapGenerator/MatrixUtils.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MatrixUtils.cs
@@ -718,7 +718,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 		{
 			var sorted = (int[])matrix.Data.Clone();
 			Array.Sort(sorted);
-			var adjustment = target - sorted[(sorted.Length - 1) * count / outOf];
+			var adjustment = target - sorted[(long)(sorted.Length - 1) * count / outOf];
 			for (var i = 0; i < matrix.Data.Length; i++)
 				matrix[i] += adjustment;
 		}


### PR DESCRIPTION
Fixes a crash which happens when trying to generate very large maps, such as 256x256.

```
Exception of type `System.IndexOutOfRangeException`: Index was outside the bounds of the array.
   at OpenRA.Mods.Common.MapGenerator.MatrixUtils.CalibrateQuantileInPlace(Matrix`1 matrix, Int32 target, Int32 count, Int32 outOf) in /home/ashley/devel/OpenRA/OpenRA.Mods.Common/MapGenerator/MatrixUtils.cs:line 719
   at OpenRA.Mods.Common.Traits.RaMapGenerator.Generate(Map map, MiniYaml settings) in /home/ashley/devel/OpenRA/OpenRA.Mods.Common/Traits/World/RaMapGenerator.cs:line 755
...
```
