### PR TITLE
Fix illegal ore rings popping up around spawns in generated maps

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/RaMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/RaMapGenerator.cs
@@ -1481,10 +1481,7 @@ namespace OpenRA.Mods.Common.Traits
 					// Closer to +inf means "more preferable" for plan.
 					var plan1024ths = new CellLayer<int>(map);
 					foreach (var mpos in map.AllCells.MapCoords)
-						if (playableArea[mpos] && param.AllowedTerrainResourceCombos.Contains((bestResource[mpos], map.GetTerrainIndex(mpos))))
-							plan1024ths[mpos] = pattern1024ths[mpos] * maxStrength1024ths[mpos] / 1024;
-						else
-							plan1024ths[mpos] = -int.MaxValue;
+						plan1024ths[mpos] = pattern1024ths[mpos] * maxStrength1024ths[mpos] / 1024;
 
 					var wSpawnBuildSizeSq = (long)param.SpawnBuildSize * param.SpawnBuildSize * 1024 * 1024;
 					foreach (var actorPlan in actorPlans)
@@ -1496,6 +1493,10 @@ namespace OpenRA.Mods.Common.Traits
 								outside: false,
 								action: (mpos, _, _, rSq) =>
 									plan1024ths[mpos] += (int)(plan1024ths[mpos] * param.SpawnResourceBias * wSpawnBuildSizeSq / Math.Max(rSq, 1024 * 1024) / FractionMax));
+
+					foreach (var mpos in map.AllCells.MapCoords)
+						if (!playableArea[mpos] || !param.AllowedTerrainResourceCombos.Contains((bestResource[mpos], map.GetTerrainIndex(mpos))))
+							plan1024ths[mpos] = -int.MaxValue;
 
 					foreach (var actorPlan in actorPlans)
 						if (actorPlan.Reference.Type == "mpspawn")


### PR DESCRIPTION
Reorders and groups selective clearing of the resource placement plan to -int.MaxValue to avoid subsequent code from inappropriately trying to use it in arithmetic, which may just underflow to some completely wrong value and lead to resources in illegal places.

Fixes regression discussed in https://github.com/OpenRA/OpenRA/pull/21718/#issuecomment-2619935341 and https://github.com/OpenRA/OpenRA/pull/21721#pullrequestreview-2577642120
