### PR TITLE
Improve HD sheet creation

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using OpenRA.FileFormats;
 using OpenRA.FileSystem;
 using OpenRA.Graphics;
 
@@ -56,14 +57,14 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			{
 				var max = s == sb.Current ? (int)sb.CurrentChannel + 1 : 4;
 				for (var i = 0; i < max; i++)
-					s.AsPng((TextureChannel)ChannelMasks[i], palette).Save($"{count}.{i}.png");
+					s.AsPng((TextureChannel)ChannelMasks[i], palette).Save($"{count}.{i}.png", Png.Compression.BEST_SPEED);
 
 				count++;
 			}
 
 			sb = sequences.SpriteCache.SheetBuilders[SheetType.BGRA];
 			foreach (var s in sb.AllSheets)
-				s.AsPng().Save($"{count++}.png");
+				s.AsPng().Save($"{count++}.png", Png.Compression.BEST_SPEED);
 		}
 	}
 }


### PR DESCRIPTION
Performance regression from #21225

For DORF the creation of one png sheet took about 9 seconds. This is a bit absurd for a debug command, this reduces it to less than half a second