### PR TITLE
Fix unrepairable desert bridge

### DIFF
--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -572,6 +572,14 @@ BR1:
 	FreeActor:
 		Actor: bridgehut
 		SpawnOffset: 2,0
+		RequiresCondition: !desert-bridge
+	FreeActor@DESERT:
+		Actor: bridgehut
+		SpawnOffset: 2,-1
+		RequiresCondition: desert-bridge
+	GrantConditionOnTileSet@DESERT:
+		Condition: desert-bridge
+		TileSets: DESERT
 
 BR2:
 	Inherits: ^Bridge
@@ -583,6 +591,14 @@ BR2:
 	FreeActor:
 		Actor: bridgehut
 		SpawnOffset: 1,1
+		RequiresCondition: !desert-bridge
+	FreeActor@DESERT:
+		Actor: bridgehut
+		SpawnOffset: 0,1
+		RequiresCondition: desert-bridge
+	GrantConditionOnTileSet@DESERT:
+		Condition: desert-bridge
+		TileSets: DESERT
 
 BR3:
 	Inherits: ^Bridge


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/issues/20623

On bleed, the long bridge for the desert tileset can not be repaired from its north end piece, `BR1`. Because the dimensions for that piece are unusual, the default offset for the hut blocks Engineers.
![NorthEnd_Composite](https://github.com/user-attachments/assets/1ea4d8e6-c374-42b8-888f-c7cd2cebbede)

https://github.com/user-attachments/assets/d6a93257-a0c5-4a35-8200-dcead46a0070

Tanya is still able to Demolish, though the bridge death will kill her unless she is directed to safety.

https://github.com/user-attachments/assets/5e95298e-90b0-45d2-adda-fa0d2fe4e87d

The south end piece, `BR2`, has a similar irregularity. It remains accessible but it's not by much and the same Demolish problem occurs.

![SouthEnd_Composite](https://github.com/user-attachments/assets/9caff54f-da92-4177-aac7-79f3cb4860f5)

https://github.com/user-attachments/assets/2b613d14-2186-4097-b509-a5a54b3ce396

----

This PR adjusts both huts so they are close to the middle of the road connection, like other bridges. This adjustment is conditional and should only take effect if the desert tileset is being used.

https://github.com/user-attachments/assets/b0f1e002-ee6d-4443-b3bd-e8ea063e67c6