### PR TITLE
Match the squad check inside .CenterPosition

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/Squad.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/Squad.cs
@@ -142,7 +142,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				new("Units", FieldSaver.FormatValue(Units.Select(a => a.ActorID).ToArray()))
 			};
 
-			if (Target != Target.Invalid)
+			if (Target.Type != TargetType.Invalid)
 			{
 				nodes.Add(new MiniYamlNode("ActorToTarget", FieldSaver.FormatValue(TargetActor.ActorID)));
 				nodes.Add(new MiniYamlNode("TargetOffset", FieldSaver.FormatValue(Target.CenterPosition - TargetActor.CenterPosition)));


### PR DESCRIPTION
```csharp
Exception of type `System.InvalidOperationException`: Attempting to query the position of an invalid Target
   at OpenRA.Traits.Target.get_CenterPosition() in /OpenRA/OpenRA.Game/Traits/Target.cs:line 169
   at OpenRA.Mods.Common.Traits.BotModules.Squads.Squad.Serialize() in /OpenRA/OpenRA.Mods.Common/Traits/BotModules/Squads/Squad.cs:line 148
   at OpenRA.Mods.Common.Traits.SquadManagerBotModule.<>c.<OpenRA.Traits.IGameSaveTraitData.IssueTraitData>b__41_0(Squad s) in /OpenRA/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs:line 525
   at System.Collections.Generic.List`1.ConvertAll[TOutput](Converter`2 converter)
   at OpenRA.Mods.Common.Traits.SquadManagerBotModule.OpenRA.Traits.IGameSaveTraitData.IssueTraitData(Actor self) in /OpenRA/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs:line 523
```