### PR TITLE
Yield focus for map generator text settings

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
@@ -230,6 +230,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							input.IsValid = () => valid;
 						};
 
+						input.OnEscKey = _ => { input.YieldKeyboardFocus(); return true; };
+						input.OnEnterKey = _ => { input.YieldKeyboardFocus(); return true; };
 						break;
 					}
 


### PR DESCRIPTION
Makes any selected text-based map generator settings (currently just the seed input) yield keyboard focus when the user presses escape or enter.
