### PR TITLE
Use long in CellLayerUtils.CalibrateQuantileInPlace index calculation

### DIFF
--- a/OpenRA.Mods.Common/MapGenerator/CellLayerUtils.cs
+++ b/OpenRA.Mods.Common/MapGenerator/CellLayerUtils.cs
@@ -275,7 +275,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 		{
 			var sorted = Entries(cellLayer);
 			Array.Sort(sorted);
-			var adjustment = target - sorted[(sorted.Length - 1) * count / outOf];
+			var adjustment = target - sorted[(long)(sorted.Length - 1) * count / outOf];
 			foreach (var mpos in cellLayer.CellRegion.MapCoords)
 				cellLayer[mpos] += adjustment;
 		}


### PR DESCRIPTION
This is similar to #21727, but in CellLayerUtils instead of MatrixUtils. Note that the lack of long does not result in any overflows/crashes in existing code, but can cause crashes for new features requiring larger calculations.
