### PR TITLE
Add decorative civilian buildings to random maps

### DIFF
--- a/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
@@ -338,7 +338,8 @@ namespace OpenRA.Mods.Common.MapGenerator
 			List<ActorPlan> actorPlans,
 			CellLayer<Replaceability> replace,
 			IReadOnlyList<MultiBrush> availableBrushes,
-			MersenneTwister random)
+			MersenneTwister random,
+			bool alwaysPreferLargerBrushes = false)
 		{
 			var brushesByAreaDict = new Dictionary<int, List<MultiBrush>>();
 			foreach (var brush in availableBrushes)
@@ -438,7 +439,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 				var brushWeights = brushes.Select(o => o.Weight).ToArray();
 				var brushWeightForArea = brushWeights.Sum();
 				var remainingQuota =
-					brushArea == 1
+					(brushArea == 1 || alwaysPreferLargerBrushes)
 						? int.MaxValue
 						: (int)(((long)replaceMposes.Count * brushWeightForArea + brushTotalWeight - 1) / brushTotalWeight);
 				RefreshIndices();

--- a/mods/cnc/fluent/rules.ftl
+++ b/mods/cnc/fluent/rules.ftl
@@ -841,3 +841,12 @@ label-cnc-map-generator-choice-density-area-very-high = Scale with area (very hi
 
 label-cnc-map-generator-option-roads = Roads
 label-cnc-map-generator-option-deny-walled-areas = Obstruct walled areas
+
+label-cnc-map-generator-option-civilian-density = Civilian Density
+label-cnc-map-generator-choice-civilian-density-default = Default
+label-cnc-map-generator-choice-civilian-density-none = None
+label-cnc-map-generator-choice-civilian-density-low = Low
+label-cnc-map-generator-choice-civilian-density-medium = Medium
+label-cnc-map-generator-choice-civilian-density-high = High
+label-cnc-map-generator-choice-civilian-density-very-high = Very High
+label-cnc-map-generator-choice-civilian-density-max = Maximum

--- a/mods/cnc/rules/map-generators.yaml
+++ b/mods/cnc/rules/map-generators.yaml
@@ -49,8 +49,9 @@
 						ExpansionInner: 2
 						ExpansionBorder: 1
 						CivilianBuildings: 125
-						MinimumCivilianBuildingDensity: 50
-						CivilianBuildingDensityRadius: 6
+						CivilianBuildingDensity: 500
+						MinimumCivilianBuildingDensity: 90
+						CivilianBuildingDensityRadius: 3
 						DefaultResource: Tiberium
 						ResourceSpawnSeeds:
 							split2: Tiberium

--- a/mods/cnc/rules/map-generators.yaml
+++ b/mods/cnc/rules/map-generators.yaml
@@ -9,6 +9,7 @@
 						TerrainFeatureSize: 20480
 						ForestFeatureSize: 20480
 						ResourceFeatureSize: 20480
+						CivilianBuildingsFeatureSize: 10240
 						Water: 0
 						Mountains: 100
 						Forests: 25
@@ -47,6 +48,9 @@
 						MaximumExpansionSize: 12
 						ExpansionInner: 2
 						ExpansionBorder: 1
+						CivilianBuildings: 125
+						MinimumCivilianBuildingDensity: 50
+						CivilianBuildingDensityRadius: 6
 						DefaultResource: Tiberium
 						ResourceSpawnSeeds:
 							split2: Tiberium
@@ -65,6 +69,7 @@
 						RoadSegmentTypes: Road,RoadIn,RoadOut
 						ForestObstacles: Trees
 						UnplayableObstacles: Obstructions
+						CivilianBuildingsObstacles: CivilianBuildings
 			Option@hidden_tileset_overrides:
 				Choice@common:
 					Tileset: DESERT,JUNGLE,SNOW,TEMPERAT
@@ -114,11 +119,13 @@
 					Label: label-cnc-map-generator-choice-terrain-type-plains
 					Settings:
 						Water: 0
+						CivilianBuildings: 100
 				Choice@Parks:
 					Label: label-cnc-map-generator-choice-terrain-type-parks
 					Settings:
 						Water: 0
 						Forests: 100
+						CivilianBuildings: 100
 				Choice@Woodlands:
 					Label: label-cnc-map-generator-choice-terrain-type-woodlands
 					Settings:
@@ -368,6 +375,37 @@
 				Checkbox: Roads
 				Default: True
 				Priority: 1
+			Option@CivilianDensity:
+				Label: label-cnc-map-generator-option-civilian-density
+				Default: Default
+				Priority: 3
+				Choice@Default:
+					Label: label-cnc-map-generator-choice-civilian-density-default
+					Settings:
+				Choice@None:
+					Label: label-cnc-map-generator-choice-civilian-density-none
+					Settings:
+						CivilianBuildings: 0
+				Choice@Low:
+					Label: label-cnc-map-generator-choice-civilian-density-low
+					Settings:
+						CivilianBuildings: 75
+				Choice@Medium:
+					Label: label-cnc-map-generator-choice-civilian-density-medium
+					Settings:
+						CivilianBuildings: 125
+				Choice@High:
+					Label: label-cnc-map-generator-choice-civilian-density-high
+					Settings:
+						CivilianBuildings: 250
+				Choice@VeryHigh:
+					Label: label-cnc-map-generator-choice-civilian-density-very-high
+					Settings:
+						CivilianBuildings: 500
+				Choice@Max:
+					Label: label-cnc-map-generator-choice-civilian-density-max
+					Settings:
+						CivilianBuildings: 1000
 	ClearMapGenerator@clear:
 		Type: clear
 		Name: map-generator-clear

--- a/mods/cnc/tilesets/desert.yaml
+++ b/mods/cnc/tilesets/desert.yaml
@@ -3192,3 +3192,48 @@ MultiBrushCollections:
 			Template: 76
 		MultiBrush@77:
 			Template: 77
+	CivilianBuildings:
+		MultiBrush@v20:
+			Actor: v20
+			Weight: 25000
+		MultiBrush@v21:
+			Actor: v21
+			Weight: 25000
+		MultiBrush@v22:
+			Actor: v22
+			Weight: 10000
+		MultiBrush@v23:
+			Actor: v23
+		MultiBrush@v24:
+			Actor: v24
+			Weight: 25000
+		MultiBrush@v25:
+			Actor: v25
+			Weight: 25000
+		MultiBrush@v26:
+			Actor: v26
+			Weight: 10000
+		MultiBrush@v27:
+			Actor: v27
+		MultiBrush@v28:
+			Actor: v28
+		MultiBrush@v29:
+			Actor: v29
+		MultiBrush@v30:
+			Actor: v30
+			Weight: 10000
+		MultiBrush@v31:
+			Actor: v31
+			Weight: 10000
+		MultiBrush@v32:
+			Actor: v32
+			Weight: 10000
+		MultiBrush@v33:
+			Actor: v33
+			Weight: 10000
+		MultiBrush@v34:
+			Actor: v34
+		MultiBrush@v35:
+			Actor: v35
+		MultiBrush@v36:
+			Actor: v36

--- a/mods/cnc/tilesets/desert.yaml
+++ b/mods/cnc/tilesets/desert.yaml
@@ -3195,24 +3195,18 @@ MultiBrushCollections:
 	CivilianBuildings:
 		MultiBrush@v20:
 			Actor: v20
-			Weight: 25000
 		MultiBrush@v21:
 			Actor: v21
-			Weight: 25000
 		MultiBrush@v22:
 			Actor: v22
-			Weight: 10000
 		MultiBrush@v23:
 			Actor: v23
 		MultiBrush@v24:
 			Actor: v24
-			Weight: 25000
 		MultiBrush@v25:
 			Actor: v25
-			Weight: 25000
 		MultiBrush@v26:
 			Actor: v26
-			Weight: 10000
 		MultiBrush@v27:
 			Actor: v27
 		MultiBrush@v28:
@@ -3221,16 +3215,12 @@ MultiBrushCollections:
 			Actor: v29
 		MultiBrush@v30:
 			Actor: v30
-			Weight: 10000
 		MultiBrush@v31:
 			Actor: v31
-			Weight: 10000
 		MultiBrush@v32:
 			Actor: v32
-			Weight: 10000
 		MultiBrush@v33:
 			Actor: v33
-			Weight: 10000
 		MultiBrush@v34:
 			Actor: v34
 		MultiBrush@v35:

--- a/mods/cnc/tilesets/jungle.yaml
+++ b/mods/cnc/tilesets/jungle.yaml
@@ -2630,25 +2630,16 @@ MultiBrushCollections:
 	CivilianBuildings:
 		MultiBrush@v01:
 			Actor: v01
-			Weight: 25000
 		MultiBrush@v02:
 			Actor: v02
-			Weight: 25000
 		MultiBrush@v03:
 			Actor: v03
-			Weight: 25000
 		MultiBrush@v04:
 			Actor: v04
-			Weight: 25000
 		MultiBrush@v05:
 			Actor: v05
-			Weight: 10000
-		MultiBrush@v06:
-			Actor: v06
-			Weight: 10000
 		MultiBrush@v07:
 			Actor: v07
-			Weight: 10000
 		MultiBrush@v08:
 			Actor: v08
 		MultiBrush@v09:
@@ -2657,17 +2648,3 @@ MultiBrushCollections:
 			Actor: v10
 		MultiBrush@v11:
 			Actor: v11
-		MultiBrush@v12:
-			Actor: v12
-		MultiBrush@v13:
-			Actor: v13
-		MultiBrush@v14:
-			Actor: v14
-		MultiBrush@v15:
-			Actor: v15
-		MultiBrush@v16:
-			Actor: v16
-		MultiBrush@v17:
-			Actor: v17
-		MultiBrush@v18:
-			Actor: v18

--- a/mods/cnc/tilesets/jungle.yaml
+++ b/mods/cnc/tilesets/jungle.yaml
@@ -2627,3 +2627,47 @@ MultiBrushCollections:
 			Template: 76
 		MultiBrush@77:
 			Template: 77
+	CivilianBuildings:
+		MultiBrush@v01:
+			Actor: v01
+			Weight: 25000
+		MultiBrush@v02:
+			Actor: v02
+			Weight: 25000
+		MultiBrush@v03:
+			Actor: v03
+			Weight: 25000
+		MultiBrush@v04:
+			Actor: v04
+			Weight: 25000
+		MultiBrush@v05:
+			Actor: v05
+			Weight: 10000
+		MultiBrush@v06:
+			Actor: v06
+			Weight: 10000
+		MultiBrush@v07:
+			Actor: v07
+			Weight: 10000
+		MultiBrush@v08:
+			Actor: v08
+		MultiBrush@v09:
+			Actor: v09
+		MultiBrush@v10:
+			Actor: v10
+		MultiBrush@v11:
+			Actor: v11
+		MultiBrush@v12:
+			Actor: v12
+		MultiBrush@v13:
+			Actor: v13
+		MultiBrush@v14:
+			Actor: v14
+		MultiBrush@v15:
+			Actor: v15
+		MultiBrush@v16:
+			Actor: v16
+		MultiBrush@v17:
+			Actor: v17
+		MultiBrush@v18:
+			Actor: v18

--- a/mods/cnc/tilesets/snow.yaml
+++ b/mods/cnc/tilesets/snow.yaml
@@ -2629,3 +2629,47 @@ MultiBrushCollections:
 			Template: 76
 		MultiBrush@77:
 			Template: 77
+	CivilianBuildings:
+		MultiBrush@v01:
+			Actor: v01
+			Weight: 25000
+		MultiBrush@v02:
+			Actor: v02
+			Weight: 25000
+		MultiBrush@v03:
+			Actor: v03
+			Weight: 25000
+		MultiBrush@v04:
+			Actor: v04
+			Weight: 25000
+		MultiBrush@v05:
+			Actor: v05
+			Weight: 10000
+		MultiBrush@v06:
+			Actor: v06
+			Weight: 10000
+		MultiBrush@v07:
+			Actor: v07
+			Weight: 10000
+		MultiBrush@v08:
+			Actor: v08
+		MultiBrush@v09:
+			Actor: v09
+		MultiBrush@v10:
+			Actor: v10
+		MultiBrush@v11:
+			Actor: v11
+		MultiBrush@v12:
+			Actor: v12
+		MultiBrush@v13:
+			Actor: v13
+		MultiBrush@v14:
+			Actor: v14
+		MultiBrush@v15:
+			Actor: v15
+		MultiBrush@v16:
+			Actor: v16
+		MultiBrush@v17:
+			Actor: v17
+		MultiBrush@v18:
+			Actor: v18

--- a/mods/cnc/tilesets/snow.yaml
+++ b/mods/cnc/tilesets/snow.yaml
@@ -2632,25 +2632,18 @@ MultiBrushCollections:
 	CivilianBuildings:
 		MultiBrush@v01:
 			Actor: v01
-			Weight: 25000
 		MultiBrush@v02:
 			Actor: v02
-			Weight: 25000
 		MultiBrush@v03:
 			Actor: v03
-			Weight: 25000
 		MultiBrush@v04:
 			Actor: v04
-			Weight: 25000
 		MultiBrush@v05:
 			Actor: v05
-			Weight: 10000
 		MultiBrush@v06:
 			Actor: v06
-			Weight: 10000
 		MultiBrush@v07:
 			Actor: v07
-			Weight: 10000
 		MultiBrush@v08:
 			Actor: v08
 		MultiBrush@v09:
@@ -2661,15 +2654,7 @@ MultiBrushCollections:
 			Actor: v11
 		MultiBrush@v12:
 			Actor: v12
+			Weight: 500
 		MultiBrush@v13:
 			Actor: v13
-		MultiBrush@v14:
-			Actor: v14
-		MultiBrush@v15:
-			Actor: v15
-		MultiBrush@v16:
-			Actor: v16
-		MultiBrush@v17:
-			Actor: v17
-		MultiBrush@v18:
-			Actor: v18
+			Weight: 500

--- a/mods/cnc/tilesets/temperat.yaml
+++ b/mods/cnc/tilesets/temperat.yaml
@@ -2632,3 +2632,47 @@ MultiBrushCollections:
 			Template: 76
 		MultiBrush@77:
 			Template: 77
+	CivilianBuildings:
+		MultiBrush@v01:
+			Actor: v01
+			Weight: 25000
+		MultiBrush@v02:
+			Actor: v02
+			Weight: 25000
+		MultiBrush@v03:
+			Actor: v03
+			Weight: 25000
+		MultiBrush@v04:
+			Actor: v04
+			Weight: 25000
+		MultiBrush@v05:
+			Actor: v05
+			Weight: 10000
+		MultiBrush@v06:
+			Actor: v06
+			Weight: 10000
+		MultiBrush@v07:
+			Actor: v07
+			Weight: 10000
+		MultiBrush@v08:
+			Actor: v08
+		MultiBrush@v09:
+			Actor: v09
+		MultiBrush@v10:
+			Actor: v10
+		MultiBrush@v11:
+			Actor: v11
+		MultiBrush@v12:
+			Actor: v12
+		MultiBrush@v13:
+			Actor: v13
+		MultiBrush@v14:
+			Actor: v14
+		MultiBrush@v15:
+			Actor: v15
+		MultiBrush@v16:
+			Actor: v16
+		MultiBrush@v17:
+			Actor: v17
+		MultiBrush@v18:
+			Actor: v18

--- a/mods/cnc/tilesets/temperat.yaml
+++ b/mods/cnc/tilesets/temperat.yaml
@@ -2635,25 +2635,18 @@ MultiBrushCollections:
 	CivilianBuildings:
 		MultiBrush@v01:
 			Actor: v01
-			Weight: 25000
 		MultiBrush@v02:
 			Actor: v02
-			Weight: 25000
 		MultiBrush@v03:
 			Actor: v03
-			Weight: 25000
 		MultiBrush@v04:
 			Actor: v04
-			Weight: 25000
 		MultiBrush@v05:
 			Actor: v05
-			Weight: 10000
 		MultiBrush@v06:
 			Actor: v06
-			Weight: 10000
 		MultiBrush@v07:
 			Actor: v07
-			Weight: 10000
 		MultiBrush@v08:
 			Actor: v08
 		MultiBrush@v09:
@@ -2662,14 +2655,6 @@ MultiBrushCollections:
 			Actor: v10
 		MultiBrush@v11:
 			Actor: v11
-		MultiBrush@v12:
-			Actor: v12
-		MultiBrush@v13:
-			Actor: v13
-		MultiBrush@v14:
-			Actor: v14
-		MultiBrush@v15:
-			Actor: v15
 		MultiBrush@v16:
 			Actor: v16
 		MultiBrush@v17:

--- a/mods/cnc/tilesets/winter.yaml
+++ b/mods/cnc/tilesets/winter.yaml
@@ -2670,3 +2670,47 @@ MultiBrushCollections:
 			Template: 76
 		MultiBrush@77:
 			Template: 77
+	CivilianBuildings:
+		MultiBrush@v01:
+			Actor: v01
+			Weight: 25000
+		MultiBrush@v02:
+			Actor: v02
+			Weight: 25000
+		MultiBrush@v03:
+			Actor: v03
+			Weight: 25000
+		MultiBrush@v04:
+			Actor: v04
+			Weight: 25000
+		MultiBrush@v05:
+			Actor: v05
+			Weight: 10000
+		MultiBrush@v06:
+			Actor: v06
+			Weight: 10000
+		MultiBrush@v07:
+			Actor: v07
+			Weight: 10000
+		MultiBrush@v08:
+			Actor: v08
+		MultiBrush@v09:
+			Actor: v09
+		MultiBrush@v10:
+			Actor: v10
+		MultiBrush@v11:
+			Actor: v11
+		MultiBrush@v12:
+			Actor: v12
+		MultiBrush@v13:
+			Actor: v13
+		MultiBrush@v14:
+			Actor: v14
+		MultiBrush@v15:
+			Actor: v15
+		MultiBrush@v16:
+			Actor: v16
+		MultiBrush@v17:
+			Actor: v17
+		MultiBrush@v18:
+			Actor: v18

--- a/mods/cnc/tilesets/winter.yaml
+++ b/mods/cnc/tilesets/winter.yaml
@@ -2673,25 +2673,18 @@ MultiBrushCollections:
 	CivilianBuildings:
 		MultiBrush@v01:
 			Actor: v01
-			Weight: 25000
 		MultiBrush@v02:
 			Actor: v02
-			Weight: 25000
 		MultiBrush@v03:
 			Actor: v03
-			Weight: 25000
 		MultiBrush@v04:
 			Actor: v04
-			Weight: 25000
 		MultiBrush@v05:
 			Actor: v05
-			Weight: 10000
 		MultiBrush@v06:
 			Actor: v06
-			Weight: 10000
 		MultiBrush@v07:
 			Actor: v07
-			Weight: 10000
 		MultiBrush@v08:
 			Actor: v08
 		MultiBrush@v09:
@@ -2702,15 +2695,13 @@ MultiBrushCollections:
 			Actor: v11
 		MultiBrush@v12:
 			Actor: v12
+			Weight: 250
 		MultiBrush@v13:
 			Actor: v13
-		MultiBrush@v14:
-			Actor: v14
-		MultiBrush@v15:
-			Actor: v15
-		MultiBrush@v16:
-			Actor: v16
-		MultiBrush@v17:
-			Actor: v17
-		MultiBrush@v18:
-			Actor: v18
+			Weight: 250
+		MultiBrush@v12.husk:
+			Actor: v12.husk
+			Weight: 250
+		MultiBrush@v13.husk:
+			Actor: v13.husk
+			Weight: 250

--- a/mods/ra/fluent/rules.ftl
+++ b/mods/ra/fluent/rules.ftl
@@ -1012,3 +1012,12 @@ label-ra-map-generator-choice-density-area-very-high = Scale with area (very hig
 
 label-ra-map-generator-option-roads = Roads
 label-ra-map-generator-option-deny-walled-areas = Obstruct walled areas
+
+label-ra-map-generator-option-civilian-density = Civilian Density
+label-ra-map-generator-choice-civilian-density-default = Default
+label-ra-map-generator-choice-civilian-density-none = None
+label-ra-map-generator-choice-civilian-density-low = Low
+label-ra-map-generator-choice-civilian-density-medium = Medium
+label-ra-map-generator-choice-civilian-density-high = High
+label-ra-map-generator-choice-civilian-density-very-high = Very High
+label-ra-map-generator-choice-civilian-density-max = Maximum

--- a/mods/ra/rules/map-generators.yaml
+++ b/mods/ra/rules/map-generators.yaml
@@ -49,8 +49,9 @@
 						ExpansionInner: 2
 						ExpansionBorder: 1
 						CivilianBuildings: 125
-						MinimumCivilianBuildingDensity: 50
-						CivilianBuildingDensityRadius: 6
+						CivilianBuildingDensity: 500
+						MinimumCivilianBuildingDensity: 90
+						CivilianBuildingDensityRadius: 3
 						DefaultResource: Ore
 						ResourceSpawnSeeds:
 							mine: Ore
@@ -180,7 +181,6 @@
 					Settings:
 						Water: 500
 						TerrainFeatureSize: 102400
-						CivilianBuildings: 256
 				Choice@Wetlands:
 					Label: label-ra-map-generator-choice-terrain-type-wetlands
 					Settings:

--- a/mods/ra/rules/map-generators.yaml
+++ b/mods/ra/rules/map-generators.yaml
@@ -9,6 +9,7 @@
 						TerrainFeatureSize: 20480
 						ForestFeatureSize: 20480
 						ResourceFeatureSize: 20480
+						CivilianBuildingsFeatureSize: 10240
 						Water: 200
 						Mountains: 100
 						Forests: 25
@@ -47,6 +48,9 @@
 						MaximumExpansionSize: 12
 						ExpansionInner: 2
 						ExpansionBorder: 1
+						CivilianBuildings: 125
+						MinimumCivilianBuildingDensity: 50
+						CivilianBuildingDensityRadius: 6
 						DefaultResource: Ore
 						ResourceSpawnSeeds:
 							mine: Ore
@@ -64,6 +68,7 @@
 						RoadSegmentTypes: Road,RoadIn,RoadOut
 						ForestObstacles: Trees
 						UnplayableObstacles: Obstructions
+						CivilianBuildingsObstacles: CivilianBuildings
 			Option@hidden_tileset_overrides:
 				Choice@desert:
 					Tileset: DESERT
@@ -109,11 +114,13 @@
 					Label: label-ra-map-generator-choice-terrain-type-plains
 					Settings:
 						Water: 0
+						CivilianBuildings: 100
 				Choice@Parks:
 					Label: label-ra-map-generator-choice-terrain-type-parks
 					Settings:
 						Water: 0
 						Forests: 100
+						CivilianBuildings: 100
 				Choice@Woodlands:
 					Label: label-ra-map-generator-choice-terrain-type-woodlands
 					Settings:
@@ -173,6 +180,7 @@
 					Settings:
 						Water: 500
 						TerrainFeatureSize: 102400
+						CivilianBuildings: 256
 				Choice@Wetlands:
 					Label: label-ra-map-generator-choice-terrain-type-wetlands
 					Settings:
@@ -387,6 +395,37 @@
 				Checkbox: Roads
 				Default: True
 				Priority: 1
+			Option@CivilianDensity:
+				Label: label-ra-map-generator-option-civilian-density
+				Default: Default
+				Priority: 3
+				Choice@Default:
+					Label: label-ra-map-generator-choice-civilian-density-default
+					Settings:
+				Choice@None:
+					Label: label-ra-map-generator-choice-civilian-density-none
+					Settings:
+						CivilianBuildings: 0
+				Choice@Low:
+					Label: label-ra-map-generator-choice-civilian-density-low
+					Settings:
+						CivilianBuildings: 75
+				Choice@Medium:
+					Label: label-ra-map-generator-choice-civilian-density-medium
+					Settings:
+						CivilianBuildings: 125
+				Choice@High:
+					Label: label-ra-map-generator-choice-civilian-density-high
+					Settings:
+						CivilianBuildings: 250
+				Choice@VeryHigh:
+					Label: label-ra-map-generator-choice-civilian-density-very-high
+					Settings:
+						CivilianBuildings: 500
+				Choice@Max:
+					Label: label-ra-map-generator-choice-civilian-density-max
+					Settings:
+						CivilianBuildings: 1000
 	ClearMapGenerator@clear:
 		Type: clear
 		Name: map-generator-clear

--- a/mods/ra/tilesets/desert.yaml
+++ b/mods/ra/tilesets/desert.yaml
@@ -4166,3 +4166,48 @@ MultiBrushCollections:
 			Actor: tc01.husk
 			BackingTile: 255,0
 			Weight: 100
+	CivilianBuildings:
+		MultiBrush@v20:
+			Actor: v20
+			Weight: 25000
+		MultiBrush@v21:
+			Actor: v21
+			Weight: 25000
+		MultiBrush@v22:
+			Actor: v22
+			Weight: 10000
+		MultiBrush@v23:
+			Actor: v23
+		MultiBrush@v24:
+			Actor: v24
+			Weight: 25000
+		MultiBrush@v25:
+			Actor: v25
+			Weight: 25000
+		MultiBrush@v26:
+			Actor: v26
+			Weight: 10000
+		MultiBrush@v27:
+			Actor: v27
+		MultiBrush@v28:
+			Actor: v28
+		MultiBrush@v29:
+			Actor: v29
+		MultiBrush@v30:
+			Actor: v30
+			Weight: 10000
+		MultiBrush@v31:
+			Actor: v31
+			Weight: 10000
+		MultiBrush@v32:
+			Actor: v32
+			Weight: 10000
+		MultiBrush@v33:
+			Actor: v33
+			Weight: 10000
+		MultiBrush@v34:
+			Actor: v34
+		MultiBrush@v35:
+			Actor: v35
+		MultiBrush@v36:
+			Actor: v36

--- a/mods/ra/tilesets/desert.yaml
+++ b/mods/ra/tilesets/desert.yaml
@@ -4169,24 +4169,18 @@ MultiBrushCollections:
 	CivilianBuildings:
 		MultiBrush@v20:
 			Actor: v20
-			Weight: 25000
 		MultiBrush@v21:
 			Actor: v21
-			Weight: 25000
 		MultiBrush@v22:
 			Actor: v22
-			Weight: 10000
 		MultiBrush@v23:
 			Actor: v23
 		MultiBrush@v24:
 			Actor: v24
-			Weight: 25000
 		MultiBrush@v25:
 			Actor: v25
-			Weight: 25000
 		MultiBrush@v26:
 			Actor: v26
-			Weight: 10000
 		MultiBrush@v27:
 			Actor: v27
 		MultiBrush@v28:
@@ -4195,16 +4189,12 @@ MultiBrushCollections:
 			Actor: v29
 		MultiBrush@v30:
 			Actor: v30
-			Weight: 10000
 		MultiBrush@v31:
 			Actor: v31
-			Weight: 10000
 		MultiBrush@v32:
 			Actor: v32
-			Weight: 10000
 		MultiBrush@v33:
 			Actor: v33
-			Weight: 10000
 		MultiBrush@v34:
 			Actor: v34
 		MultiBrush@v35:

--- a/mods/ra/tilesets/snow.yaml
+++ b/mods/ra/tilesets/snow.yaml
@@ -4354,25 +4354,18 @@ MultiBrushCollections:
 	CivilianBuildings:
 		MultiBrush@v01:
 			Actor: v01
-			Weight: 25000
 		MultiBrush@v02:
 			Actor: v02
-			Weight: 25000
 		MultiBrush@v03:
 			Actor: v03
-			Weight: 25000
 		MultiBrush@v04:
 			Actor: v04
-			Weight: 25000
 		MultiBrush@v05:
 			Actor: v05
-			Weight: 10000
 		MultiBrush@v06:
 			Actor: v06
-			Weight: 10000
 		MultiBrush@v07:
 			Actor: v07
-			Weight: 10000
 		MultiBrush@v08:
 			Actor: v08
 		MultiBrush@v09:
@@ -4383,18 +4376,10 @@ MultiBrushCollections:
 			Actor: v11
 		MultiBrush@v12:
 			Actor: v12
+			Weight: 500
 		MultiBrush@v13:
 			Actor: v13
-		MultiBrush@v14:
-			Actor: v14
-		MultiBrush@v15:
-			Actor: v15
-		MultiBrush@v16:
-			Actor: v16
-		MultiBrush@v17:
-			Actor: v17
-		MultiBrush@v18:
-			Actor: v18
+			Weight: 500
 		MultiBrush@railmine:
 			Actor: railmine
 		MultiBrush@snowhut:

--- a/mods/ra/tilesets/snow.yaml
+++ b/mods/ra/tilesets/snow.yaml
@@ -4351,3 +4351,51 @@ MultiBrushCollections:
 			Actor: t17
 			BackingTile: 255,0
 			Weight: 100
+	CivilianBuildings:
+		MultiBrush@v01:
+			Actor: v01
+			Weight: 25000
+		MultiBrush@v02:
+			Actor: v02
+			Weight: 25000
+		MultiBrush@v03:
+			Actor: v03
+			Weight: 25000
+		MultiBrush@v04:
+			Actor: v04
+			Weight: 25000
+		MultiBrush@v05:
+			Actor: v05
+			Weight: 10000
+		MultiBrush@v06:
+			Actor: v06
+			Weight: 10000
+		MultiBrush@v07:
+			Actor: v07
+			Weight: 10000
+		MultiBrush@v08:
+			Actor: v08
+		MultiBrush@v09:
+			Actor: v09
+		MultiBrush@v10:
+			Actor: v10
+		MultiBrush@v11:
+			Actor: v11
+		MultiBrush@v12:
+			Actor: v12
+		MultiBrush@v13:
+			Actor: v13
+		MultiBrush@v14:
+			Actor: v14
+		MultiBrush@v15:
+			Actor: v15
+		MultiBrush@v16:
+			Actor: v16
+		MultiBrush@v17:
+			Actor: v17
+		MultiBrush@v18:
+			Actor: v18
+		MultiBrush@railmine:
+			Actor: railmine
+		MultiBrush@snowhut:
+			Actor: snowhut

--- a/mods/ra/tilesets/snow.yaml
+++ b/mods/ra/tilesets/snow.yaml
@@ -4374,13 +4374,3 @@ MultiBrushCollections:
 			Actor: v10
 		MultiBrush@v11:
 			Actor: v11
-		MultiBrush@v12:
-			Actor: v12
-			Weight: 500
-		MultiBrush@v13:
-			Actor: v13
-			Weight: 500
-		MultiBrush@railmine:
-			Actor: railmine
-		MultiBrush@snowhut:
-			Actor: snowhut

--- a/mods/ra/tilesets/temperat.yaml
+++ b/mods/ra/tilesets/temperat.yaml
@@ -4838,3 +4838,53 @@ MultiBrushCollections:
 		MultiBrush@588:
 			Template: 588
 			Weight: 100
+	CivilianBuildings:
+		MultiBrush@v01:
+			Actor: v01
+			Weight: 25000
+		MultiBrush@v02:
+			Actor: v02
+			Weight: 25000
+		MultiBrush@v03:
+			Actor: v03
+			Weight: 25000
+		MultiBrush@v04:
+			Actor: v04
+			Weight: 25000
+		MultiBrush@v05:
+			Actor: v05
+			Weight: 10000
+		MultiBrush@v06:
+			Actor: v06
+			Weight: 10000
+		MultiBrush@v07:
+			Actor: v07
+			Weight: 10000
+		MultiBrush@v08:
+			Actor: v08
+		MultiBrush@v09:
+			Actor: v09
+		MultiBrush@v10:
+			Actor: v10
+		MultiBrush@v11:
+			Actor: v11
+		MultiBrush@v12:
+			Actor: v12
+		MultiBrush@v13:
+			Actor: v13
+		MultiBrush@v14:
+			Actor: v14
+		MultiBrush@v15:
+			Actor: v15
+		MultiBrush@v16:
+			Actor: v16
+		MultiBrush@v17:
+			Actor: v17
+		MultiBrush@v18:
+			Actor: v18
+		MultiBrush@railmine:
+			Actor: railmine
+		MultiBrush@rice:
+			Actor: rice
+		MultiBrush@asianhut:
+			Actor: asianhut

--- a/mods/ra/tilesets/temperat.yaml
+++ b/mods/ra/tilesets/temperat.yaml
@@ -4861,16 +4861,5 @@ MultiBrushCollections:
 			Actor: v10
 		MultiBrush@v11:
 			Actor: v11
-		MultiBrush@v16:
-			Actor: v16
-		MultiBrush@v17:
-			Actor: v17
-		MultiBrush@v18:
-			Actor: v18
-		MultiBrush@railmine:
-			Actor: railmine
-			Weight: 250
-		MultiBrush@rice:
-			Actor: rice
 		MultiBrush@asianhut:
 			Actor: asianhut

--- a/mods/ra/tilesets/temperat.yaml
+++ b/mods/ra/tilesets/temperat.yaml
@@ -4841,25 +4841,18 @@ MultiBrushCollections:
 	CivilianBuildings:
 		MultiBrush@v01:
 			Actor: v01
-			Weight: 25000
 		MultiBrush@v02:
 			Actor: v02
-			Weight: 25000
 		MultiBrush@v03:
 			Actor: v03
-			Weight: 25000
 		MultiBrush@v04:
 			Actor: v04
-			Weight: 25000
 		MultiBrush@v05:
 			Actor: v05
-			Weight: 10000
 		MultiBrush@v06:
 			Actor: v06
-			Weight: 10000
 		MultiBrush@v07:
 			Actor: v07
-			Weight: 10000
 		MultiBrush@v08:
 			Actor: v08
 		MultiBrush@v09:
@@ -4868,14 +4861,6 @@ MultiBrushCollections:
 			Actor: v10
 		MultiBrush@v11:
 			Actor: v11
-		MultiBrush@v12:
-			Actor: v12
-		MultiBrush@v13:
-			Actor: v13
-		MultiBrush@v14:
-			Actor: v14
-		MultiBrush@v15:
-			Actor: v15
 		MultiBrush@v16:
 			Actor: v16
 		MultiBrush@v17:
@@ -4884,6 +4869,7 @@ MultiBrushCollections:
 			Actor: v18
 		MultiBrush@railmine:
 			Actor: railmine
+			Weight: 250
 		MultiBrush@rice:
 			Actor: rice
 		MultiBrush@asianhut:


### PR DESCRIPTION
Allows the random map generator to optionally place civilian buildings around the map for extra decoration. Buildings are placed last with lowest priority to avoid competing for play area and resources.

Depends on #21738
