### PR TITLE
Update LangVersion to C# 12.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -63,7 +63,7 @@ dotnet_diagnostic.IDE0161.severity = warning
 
 # IDE0200 Remove unnecessary lambda expression
 #csharp_style_prefer_method_group_conversion = true
-dotnet_diagnostic.IDE0200.severity = silent # Requires C# 11
+dotnet_diagnostic.IDE0200.severity = suggestion # TODO: Consider enabling
 
 # IDE0210 Convert to top-level statements/IDE0211 Convert to 'Program.Main' style program
 csharp_style_prefer_top_level_statements = false
@@ -72,7 +72,7 @@ dotnet_diagnostic.IDE0211.severity = warning
 
 # IDE0290 Use primary constructor
 #csharp_style_prefer_primary_constructors = true
-dotnet_diagnostic.IDE0200.severity = silent # Requires C# 12
+dotnet_diagnostic.IDE0290.severity = suggestion # TODO: Consider enabling
 
 # IDE0330 Prefer 'System.Threading.Lock'
 #csharp_prefer_system_threading_lock = true
@@ -138,7 +138,7 @@ dotnet_diagnostic.IDE0017.severity = warning
 
 # IDE0028 Use collection initializers
 #dotnet_style_collection_initializer = true
-dotnet_diagnostic.IDE0028.severity = warning
+dotnet_diagnostic.IDE0028.severity = suggestion # TODO: Consider enabling
 
 # IDE0029/IDE0030/IDE0270 Use coalesce expression (non-nullable types)/Use coalesce expression (nullable types)/Use coalesce expression (if null)
 #dotnet_style_coalesce_expression = true
@@ -292,7 +292,7 @@ dotnet_diagnostic.IDE0220.severity = warning
 
 # IDE0230 Use UTF-8 string literal
 #csharp_style_prefer_utf8_string_literals = true
-dotnet_diagnostic.IDE0230.severity = silent # Requires C# 11
+dotnet_diagnostic.IDE0230.severity = warning
 
 # IDE0240 Nullable directive is redundant
 # No options
@@ -308,27 +308,27 @@ dotnet_diagnostic.IDE0241.severity = warning
 
 # IDE0300 Use collection expression for array
 # From above, uses dotnet_style_prefer_collection_expression
-dotnet_diagnostic.IDE0300.severity = silent # Requires C# 12
+dotnet_diagnostic.IDE0300.severity = suggestion # TODO: Consider enabling
 
 # IDE0301 Use collection expression for empty
 # From above, uses dotnet_style_prefer_collection_expression
-dotnet_diagnostic.IDE0301.severity = silent # Requires C# 12
+dotnet_diagnostic.IDE0301.severity = suggestion # TODO: Consider enabling
 
 # IDE0302 Use collection expression for stackalloc
 # From above, uses dotnet_style_prefer_collection_expression
-dotnet_diagnostic.IDE0302.severity = silent # Requires C# 12
+dotnet_diagnostic.IDE0302.severity = suggestion # TODO: Consider enabling
 
 # IDE0303 Use collection expression for 'Create()'
 # From above, uses dotnet_style_prefer_collection_expression
-dotnet_diagnostic.IDE0303.severity = silent # Requires C# 12
+dotnet_diagnostic.IDE0303.severity = suggestion # TODO: Consider enabling
 
 # IDE0304 Use collection expression for builder
 # From above, uses dotnet_style_prefer_collection_expression
-dotnet_diagnostic.IDE0304.severity = silent # Requires C# 12
+dotnet_diagnostic.IDE0304.severity = suggestion # TODO: Consider enabling
 
 # IDE0305 Use collection expression for fluent
 # From above, uses dotnet_style_prefer_collection_expression
-dotnet_diagnostic.IDE0305.severity = silent # Requires C# 12
+dotnet_diagnostic.IDE0305.severity = suggestion # TODO: Consider enabling
 
 ## Field preferences
 
@@ -387,7 +387,7 @@ dotnet_diagnostic.IDE0060.severity = warning
 
 # IDE0280 Use 'nameof'
 # No options
-dotnet_diagnostic.IDE0280.severity = silent # Requires C# 11
+dotnet_diagnostic.IDE0280.severity = warning
 
 ## Parentheses preferences
 
@@ -426,7 +426,7 @@ dotnet_diagnostic.IDE0083.severity = warning
 
 # IDE0170 Simplify property pattern
 #csharp_style_prefer_extended_property_pattern = true
-dotnet_diagnostic.IDE0170.severity = silent # Requires C# 10
+dotnet_diagnostic.IDE0170.severity = warning
 
 ## Suppression preferences
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
-    <LangVersion>9</LangVersion>
+    <LangVersion>12</LangVersion>
     <DebugSymbols>true</DebugSymbols>
     <EngineRootPath Condition="'$(EngineRootPath)' == ''">..</EngineRootPath>
     <OutputPath>$(EngineRootPath)/bin</OutputPath>
@@ -52,7 +52,7 @@
 
   <!-- StyleCop/Roslynator -->
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.2.0" PrivateAssets="All" />
     <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.2.0" PrivateAssets="All" />
   </ItemGroup>

--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -482,7 +482,7 @@ namespace OpenRA
 				var badKeysFormatted = new StringBuilder(
 					$"{debugName}, duplicate values found for the following keys: ");
 				foreach (var p in dupKeys)
-					badKeysFormatted.Append($"{logKey(p.Key)}: [{string.Join(",", p.Value)}]");
+					badKeysFormatted.Append(CultureInfo.InvariantCulture, $"{logKey(p.Key)}: [{string.Join(",", p.Value)}]");
 				throw new ArgumentException(badKeysFormatted.ToString());
 			}
 		}

--- a/OpenRA.Game/FieldSaver.cs
+++ b/OpenRA.Game/FieldSaver.cs
@@ -95,7 +95,7 @@ namespace OpenRA
 					var formattedKey = FormatValue(key);
 					var formattedValue = FormatValue(value);
 
-					result.Append($"{formattedKey}: {formattedValue}{Environment.NewLine}");
+					result.Append(CultureInfo.InvariantCulture, $"{formattedKey}: {formattedValue}{Environment.NewLine}");
 				}
 
 				return result.ToString();

--- a/OpenRA.Game/Scripting/ScriptContext.cs
+++ b/OpenRA.Game/Scripting/ScriptContext.cs
@@ -204,7 +204,7 @@ namespace OpenRA.Scripting
 
 			runtime.Globals["MaxUserScriptInstructions"] = MaxUserScriptInstructions;
 
-			using (var fn = runtime.CreateFunctionFromDelegate((Action<string>)LogDebugMessage))
+			using (var fn = runtime.CreateFunctionFromDelegate(LogDebugMessage))
 				runtime.Globals["print"] = fn;
 
 			// Register global tables

--- a/OpenRA.Game/Scripting/ScriptMemberWrapper.cs
+++ b/OpenRA.Game/Scripting/ScriptMemberWrapper.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Scripting
 		public LuaValue Get(LuaRuntime runtime)
 		{
 			if (IsMethod)
-				return runtime.CreateFunctionFromDelegate((Func<LuaVararg, LuaValue>)Invoke);
+				return runtime.CreateFunctionFromDelegate(Invoke);
 
 			if (IsGetProperty)
 				return ((PropertyInfo)Member).GetValue(Target, null).ToLuaValue(context);

--- a/OpenRA.Game/Support/HttpQueryBuilder.cs
+++ b/OpenRA.Game/Support/HttpQueryBuilder.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 namespace OpenRA.Support
@@ -40,7 +41,7 @@ namespace OpenRA.Support
 			builder.Append('?');
 
 			foreach (var parameter in parameters)
-				builder.Append($"{parameter.Key}={parameter.Value}&");
+				builder.Append(CultureInfo.InvariantCulture, $"{parameter.Key}={parameter.Value}&");
 
 			return builder.ToString();
 		}

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianSunMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianSunMapCommand.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -208,6 +209,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			{ 0x65, DamageState.Undamaged },
 		};
 
+		[SuppressMessage("Style", "IDE0230:Use UTF-8 string literal", Justification = "False positive")]
 		protected override Dictionary<byte, byte[]> ResourceFromOverlay { get; } = new()
 		{
 			// "tib" - Regular Tiberium

--- a/OpenRA.Mods.Cnc/UtilityCommands/LegacyTilesetImporter.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/LegacyTilesetImporter.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -63,8 +64,8 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			metadata.AppendLine("General:");
 
 			var name = args.Length > 3 ? args[3] : Path.GetFileNameWithoutExtension(args[2]);
-			metadata.AppendLine($"\tName: {name}");
-			metadata.AppendLine($"\tId: {name.ToUpperInvariant()}");
+			metadata.AppendLine(CultureInfo.InvariantCulture, $"\tName: {name}");
+			metadata.AppendLine(CultureInfo.InvariantCulture, $"\tId: {name.ToUpperInvariant()}");
 			metadata.AppendLine("\tHeightDebugColors: 00000080, 00004480, 00008880, 0000CC80, 0000FF80, 4400CC80," +
 				" 88008880, CC004480, FF110080, FF550080, FF990080, FFDD0080, DDFF0080, 99FF0080, 55FF0080, 11FF0080");
 
@@ -94,11 +95,11 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 
 						using (var s = modData.DefaultFileSystem.Open(templateFilename))
 						{
-							data.AppendLine($"\tTemplate@{templateIndex}:");
-							data.AppendLine($"\t\tCategories: {sectionCategory}");
+							data.AppendLine(CultureInfo.InvariantCulture, $"\tTemplate@{templateIndex}:");
+							data.AppendLine(CultureInfo.InvariantCulture, $"\t\tCategories: {sectionCategory}");
 							usedCategories.Add(sectionCategory);
 
-							data.AppendLine($"\t\tId: {templateIndex}");
+							data.AppendLine(CultureInfo.InvariantCulture, $"\t\tId: {templateIndex}");
 
 							var images = new List<string>
 							{
@@ -111,7 +112,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 									images.Add(variant);
 							}
 
-							data.AppendLine($"\t\tImages: {images.JoinWith(", ")}");
+							data.AppendLine(CultureInfo.InvariantCulture, $"\t\tImages: {images.JoinWith(", ")}");
 
 							var templateWidth = s.ReadUInt32();
 							var templateHeight = s.ReadUInt32();
@@ -121,7 +122,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 							for (var j = 0; j < offsets.Length; j++)
 								offsets[j] = s.ReadUInt32();
 
-							data.AppendLine($"\t\tSize: {templateWidth}, {templateHeight}");
+							data.AppendLine(CultureInfo.InvariantCulture, $"\t\tSize: {templateWidth}, {templateHeight}");
 							data.AppendLine("\t\tTiles:");
 
 							for (var j = 0; j < offsets.Length; j++)
@@ -137,17 +138,17 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 								if (terrainType >= terrainTypes.Length)
 									throw new InvalidDataException($"Unknown terrain type {terrainType} in {templateFilename}");
 
-								data.AppendLine($"\t\t\t{j}: {terrainTypes[terrainType]}");
+								data.AppendLine(CultureInfo.InvariantCulture, $"\t\t\t{j}: {terrainTypes[terrainType]}");
 								if (height != 0)
-									data.AppendLine($"\t\t\t\tHeight: {height}");
+									data.AppendLine(CultureInfo.InvariantCulture, $"\t\t\t\tHeight: {height}");
 
 								if (rampType != 0)
-									data.AppendLine($"\t\t\t\tRampType: {rampType}");
+									data.AppendLine(CultureInfo.InvariantCulture, $"\t\t\t\tRampType: {rampType}");
 
-								data.AppendLine($"\t\t\t\tMinColor: {s.ReadUInt8():X2}{s.ReadUInt8():X2}{s.ReadUInt8():X2}");
-								data.AppendLine($"\t\t\t\tMaxColor: {s.ReadUInt8():X2}{s.ReadUInt8():X2}{s.ReadUInt8():X2}");
+								data.AppendLine(CultureInfo.InvariantCulture, $"\t\t\t\tMinColor: {s.ReadUInt8():X2}{s.ReadUInt8():X2}{s.ReadUInt8():X2}");
+								data.AppendLine(CultureInfo.InvariantCulture, $"\t\t\t\tMaxColor: {s.ReadUInt8():X2}{s.ReadUInt8():X2}{s.ReadUInt8():X2}");
 								var zOffset = -tileSize.Height / 2.0f;
-								data.AppendLine($"\t\t\t\tZOffset: {zOffset}");
+								data.AppendLine(CultureInfo.InvariantCulture, $"\t\t\t\tZOffset: {zOffset}");
 								data.AppendLine("\t\t\t\tZRamp: 0");
 							}
 						}
@@ -170,8 +171,8 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			metadata.AppendLine("Terrain:");
 			foreach (var terrainType in terrainTypes.Distinct())
 			{
-				metadata.AppendLine($"\tTerrainType@{terrainType}:");
-				metadata.AppendLine($"\t\tType: {terrainType}");
+				metadata.AppendLine(CultureInfo.InvariantCulture, $"\tTerrainType@{terrainType}:");
+				metadata.AppendLine(CultureInfo.InvariantCulture, $"\t\tType: {terrainType}");
 
 				if (terrainType == "Water")
 					metadata.AppendLine("\t\tTargetTypes: Water");

--- a/OpenRA.Mods.Common/UtilityCommands/FuzzMapGeneratorCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/FuzzMapGeneratorCommand.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using OpenRA.Mods.Common.Traits;
@@ -237,7 +238,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 					var descriptionBuilder = new StringBuilder();
 					foreach (var variable in config.Variables)
-						descriptionBuilder.Append($"  {variable}={iterationChoices[variable]}\n");
+						descriptionBuilder.Append(CultureInfo.InvariantCulture, $"  {variable}={iterationChoices[variable]}\n");
 
 					if (!config.NoDefaults)
 						descriptionBuilder.Append("  (+Defaults)\n");

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -157,8 +157,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			Game.LoadWidget(world, "LOBBY_OPTIONS_PANEL", optionsPanelContainer, new WidgetArgs()
 			{
-				{ "getMap", (Func<MapPreview>)(() => modData.MapCache[world.Map.Uid]) },
-				{ "configurationDisabled", (Func<bool>)(() => true) }
+				{ "getMap", () => modData.MapCache[world.Map.Uid] },
+				{ "configurationDisabled", () => true }
 			});
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -189,8 +189,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					"onMouseDown", (Action<MapPreviewWidget, MapPreview, MouseInput>)((preview, mapPreview, mi) =>
 						LobbyUtils.SelectSpawnPoint(orderManager, preview, mapPreview, mi))
 				},
-				{ "getSpawnOccupants", (Func<Dictionary<int, SpawnOccupant>>)(() => spawnOccupants) },
-				{ "getDisabledSpawnPoints", (Func<HashSet<int>>)(() => orderManager.LobbyInfo.DisabledSpawnPoints) },
+				{ "getSpawnOccupants", () => spawnOccupants },
+				{ "getDisabledSpawnPoints", () => orderManager.LobbyInfo.DisabledSpawnPoints },
 				{ "showUnoccupiedSpawnpoints", true },
 				{ "mapUpdatesEnabled", true },
 				{
@@ -370,7 +370,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var optionsBin = Ui.LoadWidget("LOBBY_OPTIONS_BIN", lobby.Get("TOP_PANELS_ROOT"), new WidgetArgs()
 			{
 				{ "orderManager", orderManager },
-				{ "getMap", (Func<MapPreview>)(() => map) },
+				{ "getMap", () => map },
 				{ "configurationDisabled", configurationDisabled }
 			});
 


### PR DESCRIPTION
Now that we have moved to net 8 from net 6 (#21683), and with us no longer supporting the mono runtime (#21682), we can raise the C# version to match that supported by the net 8 runtime.

This unlocks C# 10, C# 11 and C# 12 features previously unavailable to us.
- https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history#c-version-10
- https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history#c-version-11
- https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history#c-version-12

A newer version of StyleCop is required to avoid rules tripping up on the new syntax.

Enable a handful of style rules that don't have many violations.

See #20765 for our previous migration to C# 9.