### PR TITLE
Fix CA2024

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -972,6 +972,9 @@ dotnet_diagnostic.CA2021.severity = warning
 # Avoid inexact read with Stream.Read.
 dotnet_diagnostic.CA2022.severity = warning
 
+# Do not use StreamReader.EndOfStream in async methods.
+dotnet_diagnostic.CA2024.severity = warning
+
 ### Security Rules
 ### https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/security-warnings
 


### PR DESCRIPTION
Enable code quality rule [CA2024](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2024)

No existing violations but seems worth having for the future.