### PR TITLE
Sanitize saved skirmish factions.

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/SkirmishLogic.cs
+++ b/OpenRA.Mods.Common/ServerTraits/SkirmishLogic.cs
@@ -92,12 +92,18 @@ namespace OpenRA.Mods.Common.Server
 				}
 			}
 
+			var selectableFactions = server.Map.WorldActorInfo.TraitInfos<FactionInfo>()
+				.Where(f => f.Selectable)
+				.Select(f => f.InternalName)
+				.ToList();
+
 			var playerNode = nodes.NodeWithKeyOrDefault("Player");
 			if (playerNode != null)
 			{
 				var client = server.GetClient(conn);
 				SkirmishSlot.DeserializeToClient(playerNode.Value, client);
 				client.Color = LobbyCommands.SanitizePlayerColor(server, client.Color, client.Index);
+				client.Faction = LobbyCommands.SanitizePlayerFaction(server, client.Faction, selectableFactions);
 			}
 
 			var botsNode = nodes.NodeWithKeyOrDefault("Bots");
@@ -127,6 +133,8 @@ namespace OpenRA.Mods.Common.Server
 					// Validate whether color is allowed and get an alternative if it isn't
 					if (client.Slot != null && !server.LobbyInfo.Slots[client.Slot].LockColor)
 						client.Color = LobbyCommands.SanitizePlayerColor(server, client.Color, client.Index);
+
+					client.Faction = LobbyCommands.SanitizePlayerFaction(server, client.Faction, selectableFactions);
 
 					server.LobbyInfo.Clients.Add(client);
 					S.SyncClientToPlayerReference(client, server.Map.Players.Players[client.Slot]);

--- a/mods/common/fluent/common.ftl
+++ b/mods/common/fluent/common.ftl
@@ -17,7 +17,6 @@ notification-insufficient-enabled-spawn-points = Unable to start the game until 
 notification-malformed-command = Malformed { $command } command.
 notification-state-unchanged-ready = Cannot change state when marked as ready.
 notification-invalid-faction-selected = Invalid faction selected: { $faction }.
-notification-supported-factions = Supported values: { $factions }.
 notification-state-unchanged-game-started = State cannot be changed once the game has started ({ $command }).
 notification-requires-host = Only the host can do that.
 notification-invalid-bot-slot = Cannot add bots to a slot with another client.


### PR DESCRIPTION
Fixes a crash reported on Discord.

Testcase: edit the `skirmish.{mod}.yaml` file and set bogus values. The existing logic already handled bogus options, but no checking was done for faction names.