### PR TITLE
Some improvements for SpatiallyPartitioned.

### DIFF
--- a/OpenRA.Game/Traits/World/ScreenMap.cs
+++ b/OpenRA.Game/Traits/World/ScreenMap.cs
@@ -217,11 +217,7 @@ namespace OpenRA.Traits
 				var mouseBounds = a.MouseBounds(worldRenderer);
 				if (!mouseBounds.IsEmpty)
 				{
-					if (partitionedMouseActors.Contains(a))
-						partitionedMouseActors.Update(a, mouseBounds.BoundingRect);
-					else
-						partitionedMouseActors.Add(a, mouseBounds.BoundingRect);
-
+					partitionedMouseActors[a] = mouseBounds.BoundingRect;
 					partitionedMouseActorBounds[a] = new ActorBoundsPair(a, mouseBounds);
 				}
 				else
@@ -229,12 +225,7 @@ namespace OpenRA.Traits
 
 				var screenBounds = a.ScreenBounds(worldRenderer).Union();
 				if (!screenBounds.Size.IsEmpty)
-				{
-					if (partitionedRenderableActors.Contains(a))
-						partitionedRenderableActors.Update(a, screenBounds);
-					else
-						partitionedRenderableActors.Add(a, screenBounds);
-				}
+					partitionedRenderableActors[a] = screenBounds;
 				else
 					partitionedRenderableActors.Remove(a);
 			}
@@ -255,23 +246,13 @@ namespace OpenRA.Traits
 				{
 					var mouseBounds = fa.MouseBounds;
 					if (!mouseBounds.IsEmpty)
-					{
-						if (partitionedMouseFrozenActors[kv.Key].Contains(fa))
-							partitionedMouseFrozenActors[kv.Key].Update(fa, mouseBounds.BoundingRect);
-						else
-							partitionedMouseFrozenActors[kv.Key].Add(fa, mouseBounds.BoundingRect);
-					}
+						partitionedMouseFrozenActors[kv.Key][fa] = mouseBounds.BoundingRect;
 					else
 						partitionedMouseFrozenActors[kv.Key].Remove(fa);
 
 					var screenBounds = fa.ScreenBounds.Union();
 					if (!screenBounds.Size.IsEmpty)
-					{
-						if (partitionedRenderableFrozenActors[kv.Key].Contains(fa))
-							partitionedRenderableFrozenActors[kv.Key].Update(fa, screenBounds);
-						else
-							partitionedRenderableFrozenActors[kv.Key].Add(fa, screenBounds);
-					}
+						partitionedRenderableFrozenActors[kv.Key][fa] = screenBounds;
 					else
 						partitionedRenderableFrozenActors[kv.Key].Remove(fa);
 				}
@@ -293,16 +274,16 @@ namespace OpenRA.Traits
 
 		public IEnumerable<Rectangle> RenderBounds(Player viewer)
 		{
-			var bounds = partitionedRenderableActors.ItemBounds
-				.Concat(partitionedRenderableEffects.ItemBounds);
+			var bounds = partitionedRenderableActors.Values
+				.Concat(partitionedRenderableEffects.Values);
 
-			return viewer != null ? bounds.Concat(partitionedRenderableFrozenActors[viewer].ItemBounds) : bounds;
+			return viewer != null ? bounds.Concat(partitionedRenderableFrozenActors[viewer].Values) : bounds;
 		}
 
 		public IEnumerable<Polygon> MouseBounds(Player viewer)
 		{
 			var bounds = partitionedMouseActorBounds.Values.Select(a => a.Bounds);
-			return viewer != null ? bounds.Concat(partitionedMouseFrozenActors[viewer].Items.Select(fa => fa.MouseBounds)) : bounds;
+			return viewer != null ? bounds.Concat(partitionedMouseFrozenActors[viewer].Keys.Select(fa => fa.MouseBounds)) : bounds;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -340,7 +340,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void PopulateRadarSignatureCells(Actor self, List<(CPos Cell, Color Color)> destinationBuffer)
 		{
-			foreach (var preview in cellMap.Items)
+			foreach (var preview in cellMap.Keys)
 				foreach (var cell in Footprint(preview))
 					destinationBuffer.Add((cell, preview.RadarColor));
 		}

--- a/OpenRA.Test/OpenRA.Game/SpatiallyPartitionedTest.cs
+++ b/OpenRA.Test/OpenRA.Game/SpatiallyPartitionedTest.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Test
 			Assert.That(partition.At(new int2(3, 2)), Does.Not.Contain(b), "b is present in the wrong location");
 			Assert.That(partition.At(new int2(3, 3)), Does.Not.Contain(b), "b is present in the wrong location");
 
-			partition.Update(b, new Rectangle(4, 4, 1, 1));
+			partition[b] = new Rectangle(4, 4, 1, 1);
 			Assert.That(partition.At(new int2(0, 0)), Does.Contain(a), "a wrongly changed location when b was updated");
 			Assert.That(partition.At(new int2(4, 4)), Does.Contain(b), "b is not present at the new location in the extreme corner of the partition");
 			Assert.That(partition.At(new int2(1, 1)), Does.Not.Contain(b), "b is still present at the old location after update");
@@ -79,7 +79,7 @@ namespace OpenRA.Test
 			Assert.That(new[] { a, b }, Is.EquivalentTo(partition.InBox(new Rectangle(-10, -10, 25, 25))),
 				"Searching an area larger than the partition did not return all items");
 
-			partition.Update(b, new Rectangle(4, 4, 1, 1));
+			partition[b] = new Rectangle(4, 4, 1, 1);
 			Assert.That(partition.InBox(new Rectangle(0, 0, 1, 1)), Does.Contain(a), "a wrongly changed location when b was updated");
 			Assert.That(partition.InBox(new Rectangle(4, 4, 1, 1)), Does.Contain(b), "b is not present at the new location in the extreme corner of the partition");
 			Assert.That(partition.InBox(new Rectangle(1, 1, 1, 1)), Does.Not.Contain(b), "b is still present at the old location after update");


### PR DESCRIPTION
- Tweak the Update and Remove methods to reduce the number of dictionary lookups required.
- Change the Update method to an indexer, this allows simplifying callers who wanted to AddOrUpdate a value.
- Implement IDictionary<T, Rectangle>, since the class already implements these semantics by providing a backing store of the bounds for each item.
- Clean up some naming to use the generic `item` instead of `actor`.
- Make the MutateBins action methods static.