### PR TITLE
Initialise VertexBuffers immediately

### DIFF
--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -83,7 +83,8 @@ namespace OpenRA
 
 	public interface IGraphicsContext : IDisposable
 	{
-		IVertexBuffer<T> CreateVertexBuffer<T>(int size) where T : struct;
+		IVertexBuffer<T> CreateEmptyVertexBuffer<T>(int size) where T : struct;
+		IVertexBuffer<T> CreateVertexBuffer<T>(T[] data, bool dynamic = true) where T : struct;
 		T[] CreateVertices<T>(int size) where T : struct;
 		IIndexBuffer CreateIndexBuffer(uint[] indices);
 		ITexture CreateTexture();

--- a/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
+++ b/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Graphics
 
 			vertexRowStride = 4 * map.MapSize.X;
 			vertices = new Vertex[vertexRowStride * map.MapSize.Y];
-			vertexBuffer = Game.Renderer.Context.CreateVertexBuffer<Vertex>(vertices.Length);
+			vertexBuffer = Game.Renderer.Context.CreateEmptyVertexBuffer<Vertex>(vertices.Length);
 
 			indexRowStride = 6 * map.MapSize.X;
 			lock (IndexBuffers)

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -107,7 +107,7 @@ namespace OpenRA
 			RgbaSpriteRenderer = new RgbaSpriteRenderer(SpriteRenderer);
 			RgbaColorRenderer = new RgbaColorRenderer(SpriteRenderer);
 
-			tempVertexBuffer = Context.CreateVertexBuffer<Vertex>(TempVertexBufferSize);
+			tempVertexBuffer = Context.CreateEmptyVertexBuffer<Vertex>(TempVertexBufferSize);
 			quadIndexBuffer = Context.CreateIndexBuffer(Util.CreateQuadIndices(TempIndexBufferSize / 6));
 			worldBufferSnapshot = Context.CreateTexture();
 		}
@@ -413,9 +413,9 @@ namespace OpenRA
 			return Context.CreateShader(bindings);
 		}
 
-		public IVertexBuffer<T> CreateVertexBuffer<T>(int length) where T : struct
+		public IVertexBuffer<T> CreateVertexBuffer<T>(T[] data, bool dynamic) where T : struct
 		{
-			return Context.CreateVertexBuffer<T>(length);
+			return Context.CreateVertexBuffer(data, dynamic);
 		}
 
 		public void EnableScissor(Rectangle rect)

--- a/OpenRA.Mods.Cnc/Graphics/VoxelLoader.cs
+++ b/OpenRA.Mods.Cnc/Graphics/VoxelLoader.cs
@@ -195,8 +195,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 		public void RefreshBuffer()
 		{
 			vertexBuffer?.Dispose();
-			vertexBuffer = Game.Renderer.CreateVertexBuffer<ModelVertex>(totalVertexCount);
-			vertexBuffer.SetData(vertices.SelectMany(v => v).ToArray(), totalVertexCount);
+			vertexBuffer = Game.Renderer.CreateVertexBuffer(vertices.SelectMany(v => v).ToArray(), false);
 			cachedVertexCount = totalVertexCount;
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/World/ChronoVortexRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/ChronoVortexRenderer.cs
@@ -37,7 +37,6 @@ namespace OpenRA.Mods.Cnc.Traits
 			shader = renderer.CreateShader(new RenderPostProcessPassTexturedShaderBindings("vortex"));
 
 			vortexSheet = new Sheet(SheetType.BGRA, new Size(512, 512));
-			vortexBuffer = renderer.CreateVertexBuffer<RenderPostProcessPassTexturedVertex>(288);
 			var vertices = new RenderPostProcessPassTexturedVertex[288];
 
 			var data = vortexSheet.GetData();
@@ -72,7 +71,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				vertices[j++] = new RenderPostProcessPassTexturedVertex(-32, -32, tl.X, tl.Y);
 			}
 
-			vortexBuffer.SetData(ref vertices, 288);
+			vortexBuffer = renderer.CreateVertexBuffer(vertices, false);
 			vortexSheet.CommitBufferedData();
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/RenderPostProcessPassBase.cs
+++ b/OpenRA.Mods.Common/Traits/World/RenderPostProcessPassBase.cs
@@ -36,8 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 				new(-1, -1)
 			};
 
-			buffer = renderer.CreateVertexBuffer<RenderPostProcessPassVertex>(6);
-			buffer.SetData(ref vertices, 6);
+			buffer = renderer.CreateVertexBuffer(vertices, false);
 		}
 
 		PostProcessPassType IRenderPostProcessPass.Type => type;

--- a/OpenRA.Mods.D2k/Traits/World/SonicBlastRenderer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/SonicBlastRenderer.cs
@@ -42,7 +42,6 @@ namespace OpenRA.Mods.D2k.Traits
 			Info = info;
 			renderer = Game.Renderer;
 			shader = renderer.CreateShader(new RenderPostProcessPassTexturedShaderBindings("sonic"));
-			buffer = renderer.CreateVertexBuffer<RenderPostProcessPassTexturedVertex>(6);
 
 			var r = 0.5f * info.Size;
 			shader.SetVec("Scale", r * (1f / info.Zoom - 1));
@@ -56,7 +55,7 @@ namespace OpenRA.Mods.D2k.Traits
 				new(-r, -r, -1, -1)
 			};
 
-			buffer.SetData(ref vertices, 6);
+			buffer = renderer.CreateVertexBuffer(vertices, false);
 		}
 
 		public void Draw(float3 pos)

--- a/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
@@ -49,10 +49,16 @@ namespace OpenRA.Platforms.Default
 			OpenGL.CheckGLError();
 		}
 
-		public IVertexBuffer<T> CreateVertexBuffer<T>(int size) where T : struct
+		public IVertexBuffer<T> CreateEmptyVertexBuffer<T>(int size) where T : struct
 		{
 			VerifyThreadAffinity();
 			return new VertexBuffer<T>(size);
+		}
+
+		public IVertexBuffer<T> CreateVertexBuffer<T>(T[] data, bool dynamic = true) where T : struct
+		{
+			VerifyThreadAffinity();
+			return new VertexBuffer<T>(data, dynamic);
 		}
 
 		public IIndexBuffer CreateIndexBuffer(uint[] indices)

--- a/OpenRA.Platforms.Default/VertexBuffer.cs
+++ b/OpenRA.Platforms.Default/VertexBuffer.cs
@@ -55,6 +55,28 @@ namespace OpenRA.Platforms.Default
 			}
 		}
 
+		public VertexBuffer(T[] data, bool dynamic = true)
+		{
+			OpenGL.glGenBuffers(1, out buffer);
+			OpenGL.CheckGLError();
+			Bind();
+
+			var ptr = GCHandle.Alloc(data, GCHandleType.Pinned);
+			try
+			{
+				OpenGL.glBufferData(OpenGL.GL_ARRAY_BUFFER,
+					new IntPtr(VertexSize * data.Length),
+					ptr.AddrOfPinnedObject(),
+					dynamic ? OpenGL.GL_DYNAMIC_DRAW : OpenGL.GL_STATIC_DRAW);
+			}
+			finally
+			{
+				ptr.Free();
+			}
+
+			OpenGL.CheckGLError();
+		}
+
 		public void SetData(T[] data, int length)
 		{
 			SetData(data, 0, 0, length);


### PR DESCRIPTION
We were first creating buffers, then initialising them by setting all values to zeroes, and only then setting data.

I've added a new vertex buffer contructor which allows us to immediatelly initialise the buffer with data

I also changed buffers which aren't dynamic to actually be static