### PR TITLE
Fix .NET 6 CI false positives.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+      - name: Remove System .NET
+        run: sudo apt-get remove -y dotnet*
+
       - name: Clone Repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Filed directly against prep as bleed has already moved onto NET 8.