### PR TITLE
Adjust map generator API

### DIFF
--- a/OpenRA.Mods.Common/MapGenerator/MapGeneratorSettings.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MapGeneratorSettings.cs
@@ -89,9 +89,9 @@ namespace OpenRA.Mods.Common.MapGenerator
 			}
 
 			/// <summary>Check whether this choice is permitted for this map.</summary>
-			public bool Allowed(Map map)
+			public bool Allowed(ITerrainInfo terrainInfo)
 			{
-				if (Tileset != null && !Tileset.Contains(map.Tileset))
+				if (Tileset != null && !Tileset.Contains(terrainInfo.Id))
 					return false;
 
 				return true;
@@ -144,7 +144,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			/// <summary>Settings layering priority. Higher overrides lower.</summary>
 			public readonly int Priority = 0;
 
-			public Option(string id, MiniYaml my, Map map)
+			public Option(string id, MiniYaml my, ITerrainInfo terrainInfo)
 			{
 				Id = id;
 				FieldLoader.Load(this, my);
@@ -214,7 +214,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 								if (split.Length >= 2)
 									choiceId = split[1];
 								var choice = new Choice(choiceId, node.Value);
-								if (choice.Allowed(map))
+								if (choice.Allowed(terrainInfo))
 									choices.Add(choice);
 							}
 						}
@@ -334,7 +334,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 		/// <summary>
 		/// Parse settings from a MiniYaml definition. Returns null if the map isn't compatible.
 		/// </summary>
-		public static MapGeneratorSettings LoadSettings(MiniYaml my, Map map)
+		public static MapGeneratorSettings LoadSettings(MiniYaml my, ITerrainInfo terrainInfo)
 		{
 			var options = new List<Option>();
 
@@ -346,7 +346,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 					string id = null;
 					if (split.Length >= 2)
 						id = split[1];
-					var option = new Option(id, node.Value, map);
+					var option = new Option(id, node.Value, terrainInfo);
 					if (option.Choices.Count == 0)
 						return null;
 					options.Add(option);

--- a/OpenRA.Mods.Common/Traits/World/ClearMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/ClearMapGenerator.cs
@@ -19,9 +19,9 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
+	[TraitLocation(SystemActors.EditorWorld)]
 	[Desc("A map generator that clears a map.")]
-	public sealed class ClearMapGeneratorInfo : TraitInfo, IMapGeneratorInfo
+	public sealed class ClearMapGeneratorInfo : TraitInfo<ClearMapGenerator>, IMapGeneratorInfo
 	{
 		[FieldLoader.Require]
 		[Desc("Human-readable name this generator uses.")]
@@ -44,8 +44,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		string IMapGeneratorInfo.Name => Name;
 
-		public override object Create(ActorInitializer init) { return new ClearMapGenerator(this); }
-
 		static MiniYaml SettingsLoader(MiniYaml my)
 		{
 			return my.NodeWithKey("Settings").Value;
@@ -55,22 +53,10 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			return MapGeneratorSettings.DumpFluent(my.NodeWithKey("Settings").Value);
 		}
-	}
-
-	public sealed class ClearMapGenerator : IMapGenerator
-	{
-		readonly ClearMapGeneratorInfo info;
-
-		IMapGeneratorInfo IMapGenerator.Info => info;
-
-		public ClearMapGenerator(ClearMapGeneratorInfo info)
-		{
-			this.info = info;
-		}
 
 		public MapGeneratorSettings GetSettings(Map map)
 		{
-			return MapGeneratorSettings.LoadSettings(info.Settings, map);
+			return MapGeneratorSettings.LoadSettings(Settings, map);
 		}
 
 		public void Generate(Map map, MiniYaml settings)
@@ -112,4 +98,6 @@ namespace OpenRA.Mods.Common.Traits
 			map.ActorDefinitions = ImmutableArray<MiniYamlNode>.Empty;
 		}
 	}
+
+	public class ClearMapGenerator { /* we're only interested in the Info */ }
 }

--- a/OpenRA.Mods.Common/Traits/World/ClearMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/ClearMapGenerator.cs
@@ -54,9 +54,9 @@ namespace OpenRA.Mods.Common.Traits
 			return MapGeneratorSettings.DumpFluent(my.NodeWithKey("Settings").Value);
 		}
 
-		public MapGeneratorSettings GetSettings(Map map)
+		public MapGeneratorSettings GetSettings(ITerrainInfo terrainInfo)
 		{
-			return MapGeneratorSettings.LoadSettings(Settings, map);
+			return MapGeneratorSettings.LoadSettings(Settings, terrainInfo);
 		}
 
 		public void Generate(Map map, MiniYaml settings)

--- a/OpenRA.Mods.Common/Traits/World/ExperimentalMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/ExperimentalMapGenerator.cs
@@ -23,7 +23,7 @@ using static OpenRA.Mods.Common.Traits.ResourceLayerInfo;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.EditorWorld)]
-	public sealed class RaMapGeneratorInfo : TraitInfo<RaMapGenerator>, IMapGeneratorInfo
+	public sealed class ExperimentalMapGeneratorInfo : TraitInfo<ExperimentalMapGenerator>, IMapGeneratorInfo
 	{
 		[FieldLoader.Require]
 		public readonly string Type = null;
@@ -1802,5 +1802,5 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class RaMapGenerator { /* we're only interested in the Info */ }
+	public class ExperimentalMapGenerator { /* we're only interested in the Info */ }
 }

--- a/OpenRA.Mods.Common/Traits/World/RaMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/RaMapGenerator.cs
@@ -481,9 +481,9 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public MapGeneratorSettings GetSettings(Map map)
+		public MapGeneratorSettings GetSettings(ITerrainInfo terrainInfo)
 		{
-			return MapGeneratorSettings.LoadSettings(Settings, map);
+			return MapGeneratorSettings.LoadSettings(Settings, terrainInfo);
 		}
 
 		public void Generate(Map map, MiniYaml settings)

--- a/OpenRA.Mods.Common/Traits/World/RaMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/RaMapGenerator.cs
@@ -22,8 +22,8 @@ using static OpenRA.Mods.Common.Traits.ResourceLayerInfo;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
-	public sealed class RaMapGeneratorInfo : TraitInfo, IMapGeneratorInfo
+	[TraitLocation(SystemActors.EditorWorld)]
+	public sealed class RaMapGeneratorInfo : TraitInfo<RaMapGenerator>, IMapGeneratorInfo
 	{
 		[FieldLoader.Require]
 		public readonly string Type = null;
@@ -43,8 +43,6 @@ namespace OpenRA.Mods.Common.Traits
 		string IMapGeneratorInfo.Type => Type;
 		string IMapGeneratorInfo.Name => Name;
 
-		public override object Create(ActorInitializer init) { return new RaMapGenerator(this); }
-
 		static MiniYaml SettingsLoader(MiniYaml my)
 		{
 			return my.NodeWithKey("Settings").Value;
@@ -54,10 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			return MapGeneratorSettings.DumpFluent(my.NodeWithKey("Settings").Value);
 		}
-	}
 
-	public sealed class RaMapGenerator : IMapGenerator
-	{
 		const int FractionMax = 1000;
 		const int EntityBonusMax = 1000000;
 
@@ -486,18 +481,9 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		readonly RaMapGeneratorInfo info;
-
-		IMapGeneratorInfo IMapGenerator.Info => info;
-
-		public RaMapGenerator(RaMapGeneratorInfo info)
-		{
-			this.info = info;
-		}
-
 		public MapGeneratorSettings GetSettings(Map map)
 		{
-			return MapGeneratorSettings.LoadSettings(info.Settings, map);
+			return MapGeneratorSettings.LoadSettings(Settings, map);
 		}
 
 		public void Generate(Map map, MiniYaml settings)
@@ -1815,4 +1801,6 @@ namespace OpenRA.Mods.Common.Traits
 			return amplitude;
 		}
 	}
+
+	public class RaMapGenerator { /* we're only interested in the Info */ }
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -973,10 +973,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		string Type { get; }
 		string Name { get; }
-	}
 
-	public interface IMapGenerator
-	{
 		/// <summary>
 		/// Get the generator settings available for this map.
 		/// Returns null if not compatible with the given map.
@@ -993,7 +990,5 @@ namespace OpenRA.Mods.Common.Traits
 		/// Thrown if the map could not be generated with the requested configuration. Map should be discarded.
 		/// </exception>
 		void Generate(Map map, MiniYaml settings);
-
-		IMapGeneratorInfo Info { get; }
 	}
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -975,10 +975,10 @@ namespace OpenRA.Mods.Common.Traits
 		string Name { get; }
 
 		/// <summary>
-		/// Get the generator settings available for this map.
-		/// Returns null if not compatible with the given map.
+		/// Get the generator settings available for this tileset.
+		/// Returns null if not compatible with the given tileset.
 		/// </summary>
-		MapGeneratorSettings GetSettings(Map map);
+		MapGeneratorSettings GetSettings(ITerrainInfo terrainInfo);
 
 		/// <summary>
 		/// Generate or manipulate a supplied map in-place.

--- a/OpenRA.Mods.Common/UtilityCommands/FuzzMapGeneratorCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/FuzzMapGeneratorCommand.cs
@@ -269,7 +269,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					var br = new PPos(size[0], size[1] + maxTerrainHeight);
 					map.SetBounds(tl, br);
 
-					var settings = generator.GetSettings(map);
+					var settings = generator.GetSettings(tileset);
 					var choices = settings.DefaultChoices();
 					foreach (var option in choices.Keys)
 						if (iterationChoices.TryGetValue(option.Id, out var choice))

--- a/OpenRA.Mods.Common/UtilityCommands/FuzzMapGeneratorCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/FuzzMapGeneratorCommand.cs
@@ -16,7 +16,6 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
@@ -205,13 +204,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				.Select(variable => config.Choices[variable].Length)
 				.ToImmutableArray();
 
-			var generatorInfo =
+			var generator =
 				modData.DefaultRules.Actors[SystemActors.EditorWorld].TraitInfos<IMapGeneratorInfo>()
 					.FirstOrDefault(info => info.Type == config.MapGeneratorType);
-			if (generatorInfo == null)
+			if (generator == null)
 				throw new ArgumentException($"No map generator with type `{config.MapGeneratorType}`");
-
-			var generator = (generatorInfo as TraitInfo).Create(null) as IMapGenerator;
 
 			long maxSerial = 1;
 			long tests = 0;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
@@ -17,6 +17,7 @@ using OpenRA.Graphics;
 using OpenRA.Mods.Common.EditorBrushes;
 using OpenRA.Mods.Common.MapGenerator;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
@@ -96,7 +97,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			ChangeGenerator(mapGenerators.FirstOrDefault());
 			if (selectedGenerator != null)
 			{
-				generatorDropDown.GetText = () => FluentProvider.GetMessage(selectedGenerator.Name);
+				var label = new CachedTransform<IMapGeneratorInfo, string>(g => FluentProvider.GetMessage(g.Name));
+				generatorDropDown.GetText = () => label.Update(selectedGenerator);
 				generatorDropDown.OnMouseDown = _ =>
 				{
 					ScrollItemWidget SetupItem(IMapGeneratorInfo g, ScrollItemWidget template)
@@ -104,7 +106,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						bool IsSelected() => g.Type == selectedGenerator.Type;
 						void OnClick() => ChangeGenerator(mapGenerators.First(generator => generator.Type == g.Type));
 						var item = ScrollItemWidget.Setup(template, IsSelected, OnClick);
-						item.Get<LabelWidget>("LABEL").GetText = () => FluentProvider.GetMessage(g.Name);
+						var label = FluentProvider.GetMessage(g.Name);
+						item.Get<LabelWidget>("LABEL").GetText = () => label;
 						return item;
 					}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
@@ -64,11 +64,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			generatorsToSettingsChoices = new Dictionary<IMapGeneratorInfo, Dictionary<MapGeneratorSettings.Option, MapGeneratorSettings.Choice>>();
 
 			var mapGenerators = new List<IMapGeneratorInfo>();
+			var terrainInfo = modData.DefaultTerrainInfo[world.Map.Tileset];
 			foreach (var generator in world.Map.Rules.Actors[SystemActors.EditorWorld].TraitInfos<IMapGeneratorInfo>())
 			{
-				var settings = generator.GetSettings(world.Map);
+				var settings = generator.GetSettings(terrainInfo);
 				if (settings == null)
 					continue;
+
 				var choices = settings.DefaultChoices();
 				mapGenerators.Add(generator);
 				generatorsToSettingsChoices.Add(generator, choices);

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapToolsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapToolsLogic.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Widgets;
@@ -48,7 +47,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var markerToolPanel = widget.Get("MARKER_TOOL_PANEL");
 			toolPanels.Add(MapTool.MarkerTiles, markerToolPanel);
-			if (world.WorldActor.TraitsImplementing<IMapGenerator>().Any())
+			if (world.Map.Rules.Actors[SystemActors.EditorWorld].HasTraitInfo<IMapGeneratorInfo>())
 			{
 				var mapGeneratorToolPanel = widget.GetOrNull("MAP_GENERATOR_TOOL_PANEL");
 				if (mapGeneratorToolPanel != null)

--- a/mods/cnc/fluent/rules.ftl
+++ b/mods/cnc/fluent/rules.ftl
@@ -51,7 +51,7 @@ faction-nod =
      and the alien substance Tiberium. They use stealth technology
      and guerilla tactics to defeat those who oppose them.
 
-map-generator-ra = RA Experimental (CnC)
+map-generator-experimental = Experimental
 map-generator-clear = Clear
 
 ## defaults.yaml

--- a/mods/cnc/rules/map-generators.yaml
+++ b/mods/cnc/rules/map-generators.yaml
@@ -1,7 +1,7 @@
 ^MapGenerators:
-	RaMapGenerator@ra:
-		Type: ra
-		Name: map-generator-ra
+	ExperimentalMapGenerator@experimental:
+		Type: experimental
+		Name: map-generator-experimental
 		Settings:
 			Option@hidden_defaults:
 				Choice@hidden_defaults:

--- a/mods/ra/fluent/rules.ftl
+++ b/mods/ra/fluent/rules.ftl
@@ -34,7 +34,7 @@ options-starting-units =
 
 resource-minerals = Valuable Minerals
 
-map-generator-ra = RA Experimental
+map-generator-experimental = Experimental
 map-generator-clear = Clear
 
 ## Faction

--- a/mods/ra/rules/map-generators.yaml
+++ b/mods/ra/rules/map-generators.yaml
@@ -1,7 +1,7 @@
 ^MapGenerators:
-	RaMapGenerator@ra:
-		Type: ra
-		Name: map-generator-ra
+	ExperimentalMapGenerator@experimental:
+		Type: experimental
+		Name: map-generator-experimental
 		Settings:
 			Option@hidden_defaults:
 				Choice@hidden_defaults:


### PR DESCRIPTION
This PR extracts some initial prepatory work from my WIP skirmish UI.

* Splitting the logic between `IMapGeneratorInfo` and `IMapGenerator` doesn't really work here, and means that the things using the generator need to manually create the trait with a null actor(!). Having all the logic in the Info is fine.
* Requiring a Map instance just to build the generator UI is unnecessarily restrictive, all it actually cares about is the tileset name.
* "RA Experimental (CnC)" 🤨 &rarr; "Experimental" 😎 