### PR TITLE
Removing unnecessary punctuation from descriptions

### DIFF
--- a/mods/cnc/fluent/rules.ftl
+++ b/mods/cnc/fluent/rules.ftl
@@ -35,7 +35,7 @@ resource-tiberium = Tiberium
 faction-random =
     .name = Any
     .description = Random Faction
-     A random faction is chosen at the start of the game.
+     A random faction is chosen at the start of the game
 
 faction-gdi =
     .name = GDI
@@ -66,7 +66,7 @@ actor-tran =
     .name = Chinook Transport
     .description =
     Fast Infantry Transport Helicopter.
-      Unarmed.
+      Unarmed
     .encyclopedia =
     The chinook is a flying transport capable of carrying a detachement of infantry. It is mostly used to transport commandos or engineers for backline-destruction.
 
@@ -76,8 +76,8 @@ actor-heli =
     .name = Apache Longbow
     .description =
     Helicopter Gunship with chainguns.
-      Strong vs Infantry, Light Vehicles and Aircraft.
-      Weak vs Tanks.
+      Strong vs Infantry, Light Vehicles and Aircraft
+      Weak vs Tanks
     .encyclopedia =
     Has more health than the Orca and acts as a support unit. It works well with artillery, as it can kill approaching light vehicles.
 
@@ -87,8 +87,8 @@ actor-orca =
     .name = Orca
     .description =
     Helicopter gunship with AG missiles.
-      Strong vs Buildings and Tanks.
-      Weak vs Infantry.
+      Strong vs Buildings and Tanks
+      Weak vs Infantry
     .encyclopedia =
     Fast but fragile, the Orca harasses enemy vehicles and aircraft with AT missiles. It is best used opportunistically, and can be kept alive longer with careful micro. Its AA missiles are effective but have a hard time hitting fast-moving air targets.
 
@@ -233,9 +233,9 @@ actor-truck-husk-name = Supply Truck (Destroyed)
 actor-e1 =
     .name = Minigunner
     .description =
-    General-purpose infantry.
-      Strong vs Infantry.
-      Weak vs Vehicles.
+    General-purpose infantry
+      Strong vs Infantry
+      Weak vs Vehicles
     .encyclopedia =
     The humble Minigunner is a highly specialized infantry unit designed to soak damage and kill other infantry.
 
@@ -244,8 +244,8 @@ actor-e1 =
 actor-e2 =
     .name = Grenadier
     .description =
-    Fast infantry with grenades.
-      Strong vs Buildings, slow-moving targets.
+    Fast infantry with grenades
+      Strong vs Buildings, slow-moving targets
     .encyclopedia =
     Fast and able to keep up with medium tanks, letting it work well with flanking armies.
 
@@ -255,8 +255,8 @@ actor-e3 =
     .name = Rocket Soldier
     .description =
     Anti-tank/Anti-aircraft infantry.
-      Strong vs Tanks and Aircraft.
-      Weak vs Infantry.
+      Strong vs Tanks and Aircraft
+      Weak vs Infantry
     .encyclopedia =
     Highly vulnerable but excelling at eliminating enemy armor and aircraft. It is the slowest unit in the game, lagging behind other infantry and even mammoth tanks.
 
@@ -266,8 +266,8 @@ actor-e4 =
     .name = Flamethrower
     .description =
     Advanced anti-infantry unit.
-      Strong vs Infantry and Buildings.
-      Weak vs Tanks.
+      Strong vs Infantry and Buildings
+      Weak vs Tanks
     .encyclopedia =
     Good for flanking and burning down structures. It has more health than a standard Minigunner, but its short weapons range makes it difficult to use in large armies.
 
@@ -275,7 +275,7 @@ actor-e5 =
     .name = Chemical Warrior
     .description =
     Advanced general-purpose infantry.
-      Strong vs all Ground units.
+      Strong vs all Ground units
     .encyclopedia =
     Similar stats to the Flamethrower but deals good damage vs heavy armor. Great for stopping enemy armor from crushing your forces.
 
@@ -285,8 +285,8 @@ actor-e6 =
     .name = Engineer
     .description =
     Damages and captures enemy structures.
-      Repairs destroyed vehicles.
-      Unarmed.
+    Repairs destroyed vehicles.
+      Unarmed
     .encyclopedia =
     Like the rocket soldier, the Engineer is slow and requires escorts to be used effectively. It can instantly capture structures but is consumed in the process.
 
@@ -298,8 +298,8 @@ actor-rmbo =
     .name = Commando
     .description =
     Elite sniper infantry unit.
-      Strong vs Infantry and Buildings.
-      Weak vs Vehicles.
+      Strong vs Infantry and Buildings
+      Weak vs Vehicles
     .encyclopedia =
     Equipped with a long-range sniper rifle, the Commando fires slowly but can eliminate enemy infantry from a distance when well-supported.
 
@@ -308,8 +308,8 @@ actor-rmbo =
 actor-pvice =
     .description =
     Mutated abomination that spits liquid Tiberium.
-      Strong vs Infantry and Buildings.
-      Weak vs Aircraft.
+      Strong vs Infantry and Buildings
+      Weak vs Aircraft
     .encyclopedia =
     A mutated lifeform created from the strange properties of Tiberium, when infantry units are expose to it.
 
@@ -448,7 +448,7 @@ actor-hpad =
 actor-hq =
     .name = Communications Center
     .description =
-    Provides radar and Air Strike support power
+    Provides radar and Air Strike support power.
     Unlocks higher-tech units and buildings.
     Requires power to operate.
     .airstrikepower-name = Air Strike
@@ -491,8 +491,8 @@ actor-gun =
     .name = Turret
     .description =
     Basic Anti-Tank base defense.
-      Strong vs Tanks and Vehicles.
-      Weak vs Infantry.
+      Strong vs Tanks and Vehicles
+      Weak vs Infantry
     .encyclopedia =
     Base defense armed with an armor-piercing cannon, it deals significant damage to vehicles in range.
 
@@ -500,8 +500,8 @@ actor-sam =
     .name = SAM Site
     .description =
     Anti-Aircraft base defense.
-      Strong vs Aircraft.
-      Cannot target Ground units.
+      Strong vs Aircraft
+      Cannot target Ground units
     .encyclopedia =
     Nod anti-air base defense. It remains protected when closed and opens to engage aircraft.
 
@@ -510,8 +510,8 @@ actor-obli =
     .description =
     Advanced base defense.
     Requires power to operate.
-      Strong vs all Ground units.
-      Cannot target Aircraft.
+      Strong vs all Ground units
+      Cannot target Aircraft
     .encyclopedia =
     Advanced defense for Nod that quickly destroys ground targets with a powerful laser.
 
@@ -519,8 +519,8 @@ actor-gtwr =
     .name = Guard Tower
     .description =
     Basic defensive structure.
-      Strong vs Infantry.
-      Weak vs Tanks.
+      Strong vs Infantry
+      Weak vs Tanks
     .encyclopedia =
     Base defense armed with a high-velocity machine gun, it shreds infantry and light vehicles within range with its large area of effect.
 
@@ -528,8 +528,8 @@ actor-atwr =
     .name = Advanced Guard Tower
     .description =
     All-purpose defensive structure.
-      Strong vs Aircraft and Infantry.
-      Weak vs Tanks.
+      Strong vs Aircraft and Infantry
+      Weak vs Tanks
     .encyclopedia =
     Advanced defense for GDI that fires volleys of high explosive missiles at both ground and air targets. Effective versus everything.
 
@@ -537,7 +537,7 @@ actor-sbag =
     .name = Sandbag Barrier
     .description =
     Stops infantry and light vehicles.
-       Can be crushed by tanks.
+      Can be crushed by tanks.
     .encyclopedia =
     Blocks movement of infantry and light vehicles, but can be crushed by tanks. Immune to small arms fire.
 
@@ -547,7 +547,7 @@ actor-cycl =
     .name = Chain Link Barrier
     .description =
     Stops infantry and light vehicles.
-       Can be crushed by tanks.
+      Can be crushed by tanks.
     .encyclopedia =
     Blocks movement of infantry and light vehicles, but can be crushed by tanks. Immune to small arms fire.
 
@@ -611,7 +611,7 @@ actor-mcv =
     .name = Mobile Construction Vehicle
     .description =
     Deploys into a Construction Yard.
-      Unarmed.
+      Unarmed
     .encyclopedia =
     Deploying an MCV changes it into a Construction Yard. The MCV has more health in its deployed form, but undeploying can be helpful to escape infantry.
 
@@ -622,7 +622,7 @@ actor-harv =
     .generic-name = Harvester
     .description =
     Collects Tiberium for processing.
-      Unarmed.
+      Unarmed
     .encyclopedia =
     Harvesters slowly mine Tiberium and deposit it in your refinery, where it is converted into credits. They can also be sent to allied refineries to provide funds.
 
@@ -633,8 +633,8 @@ actor-apc =
     .description =
     Armed infantry transport.
     Can attack Aircraft.
-      Strong vs Vehicles.
-      Weak vs Infantry.
+      Strong vs Vehicles
+      Weak vs Infantry
     .encyclopedia =
     The APC (Armored Personnel Carrier) transports infantry, making it handy for capturing civilian structures. While its flak gun does not do much damage to enemy vehicles, the APC can resist enemy shots while your Hum-vees deal the damage.
 
@@ -644,7 +644,7 @@ actor-arty =
     .name = Artillery
     .description =
     Long-range artillery.
-      Strong vs Infantry, Vehicles and Buildings.
+      Strong vs Infantry, Vehicles and Buildings
     .encyclopedia =
     Nod's artillery is a glass cannon, fragile but dealing large amounts of damage at long range. Particularly strong vs structures and infantry, it can destroy stationary tanks.
 
@@ -654,8 +654,8 @@ actor-ftnk =
     .name = Flame Tank
     .description =
     Heavily armored flame-throwing vehicle.
-      Strong vs Infantry, Buildings and Vehicles.
-      Weak vs Tanks.
+      Strong vs Infantry, Buildings and Vehicles
+      Weak vs Tanks
     .encyclopedia =
     Roast infantry and structures alike, making them great for surprise attacks. Be wary of their splash damage on death, but be aware it can also be used to your advantage.
 
@@ -663,8 +663,8 @@ actor-bggy =
     .name = Nod Buggy
     .description =
     Fast scout and anti-infantry vehicle.
-      Strong vs Infantry.
-      Weak vs Tanks.
+      Strong vs Infantry
+      Weak vs Tanks
     .encyclopedia =
     Strong versus light vehicles and infantry, Buggies are great at scouting and killing isolated infantry. Though it is a little cheaper and faster than the GDI Hum-vee, they are more fragile.
 
@@ -673,8 +673,8 @@ actor-bike =
     .description =
     Fast scout vehicle with rockets.
     Can attack Aircraft.
-      Strong vs Vehicles and Tanks.
-      Weak vs Infantry.
+      Strong vs Vehicles and Tanks
+      Weak vs Infantry
     .encyclopedia =
     The Nod bike is a very fast vehicle armed with armor-piercing rockets, which makes it great for hit and run and harvester harassment.
 
@@ -684,8 +684,8 @@ actor-jeep =
     .name = Hum-vee
     .description =
     Fast scout and anti-infantry vehicle.
-      Strong vs Infantry.
-      Weak vs Tanks.
+      Strong vs Infantry
+      Weak vs Tanks
     .encyclopedia =
     Strong versus light vehicles and infantry, Hum-vees are great at scouting and eliminating isolated infantry.
 
@@ -695,8 +695,8 @@ actor-ltnk =
     .name = Light Tank
     .description =
     Fast, light tank.
-      Strong vs Vehicles and Tanks.
-      Weak vs Infantry.
+      Strong vs Vehicles and Tanks
+      Weak vs Infantry
     .encyclopedia =
     With its great speed and high health pool, the light tank works great as a frontline unit in various compositions despite its damage output.
 
@@ -705,9 +705,9 @@ actor-ltnk =
 actor-mtnk =
     .name = Medium Tank
     .description =
-    General-Purpose GDI Tank.
-      Strong vs Tanks and Vehicles.
-      Weak vs Infantry.
+    General-purpose GDI Tank.
+      Strong vs Tanks and Vehicles
+      Weak vs Infantry
     .encyclopedia =
     The workhorse of GDI, offering a good balance of speed, durability and firepower. It will easily destroy Nod light tanks and can tear through structures if it sneaks into a base.
 
@@ -718,7 +718,7 @@ actor-htnk =
     .description =
     Heavily armored GDI Tank.
     Can attack Aircraft.
-      Strong vs Everything.
+      Strong vs Everything
     .encyclopedia =
     A crawling battle station, capable of self-repair and engaging any threat. It is particularly effective against enemy armor, but can also destroy small amounts of infantry or aircraft.
 
@@ -728,7 +728,7 @@ actor-msam =
     .name = Rocket Launcher
     .description =
     Long-range rocket artillery.
-      Strong vs all ground units.
+      Strong vs all ground units
     .encyclopedia =
     Referred to as  “MLRS” by players (Multiple Launch Rocket System), this artillery platform fires volleys of rockets at distant targets. It is particularly effective against light vehicles and does moderate damage vs infantry, buildings, and heavy armor.
 
@@ -738,7 +738,7 @@ actor-mlrs =
     .name = Mobile SAM
     .description =
     Powerful anti-air unit.
-    Cannot attack ground units.
+      Cannot attack ground units.
     .encyclopedia =
     Generally referred to as “MSAM” by players, this Nod vehicle is a dedicated anti-air vehicle when their bikes do not cut it. It fires slow-moving missiles with powerful splash damage.
 
@@ -749,8 +749,8 @@ actor-stnk =
     Can attack Aircraft.
     Has weak armor. Can be spotted by infantry and
     defense structures.
-      Strong vs Vehicles and Tanks.
-      Weak vs Infantry.
+      Strong vs Vehicles and Tanks
+      Weak vs Infantry
     .encyclopedia =
     Cloaked units that become visible when damaged or firing their weapons. They can also be detected by defenses within a small radius or infantry at a one-cell range.
 
@@ -765,8 +765,8 @@ actor-truck =
     .name = Supply Truck
     .description =
     Transports cash to other players.
-    Builds quickly.
-      Unarmed.
+    Builds quickly
+      Unarmed
     .encyclopedia =
     Supply trucks are a convenient way to share cash when your ally is out of money, or you can't spend yours fast enough. They build far quicker than their cost suggests.
 

--- a/mods/d2k/fluent/rules.ftl
+++ b/mods/d2k/fluent/rules.ftl
@@ -36,7 +36,7 @@ resource-spice = Spice
 faction-random =
     .name = Any
     .description = Random House.
-    A random house is chosen at the start of the game.
+    A random house is chosen at the start of the game
 
 faction-atreides =
     .name = Atreides
@@ -65,7 +65,7 @@ faction-harkonnen =
     wealth, and the destruction of House Atreides.
 
     Faction Variations:
-        - Combat Tanks are more durable but move at a slower speed.
+        - Combat Tanks are more durable but move at a slower speed
 
     Special Units:
         - Sardaukar
@@ -82,8 +82,8 @@ faction-ordos =
     and forbidden Ixian technologies to gain the upper hand.
 
     Faction Variations:
-        - Trikes are replaced by Raider Trikes.
-        - Combat Tanks are faster but less durable.
+        - Trikes are replaced by Raider Trikes
+        - Combat Tanks are faster but less durable
 
     Special Units:
         - Raider Trike
@@ -165,8 +165,8 @@ actor-light-inf =
     .name = Light Infantry
     .description =
     General-purpose infantry.
-      Strong vs Infantry.
-      Weak vs Vehicles and Artillery.
+      Strong vs Infantry
+      Weak vs Vehicles and Artillery
     .encyclopedia =
     Lightly armored foot soldiers, equipped with 9mm RP assault rifles. They are effective against infantry and lightly armored vehicles.
 
@@ -177,9 +177,9 @@ actor-engineer =
     .description =
     Infiltrates and captures enemy
     structures.
-      Strong vs Buildings.
-      Weak vs Everything.
-      Repairs damaged cliffs.
+      Strong vs Buildings
+      Weak vs Everything
+      Repairs damaged cliffs
     .encyclopedia =
     Can be used to capture enemy buildings.
 
@@ -189,8 +189,8 @@ actor-trooper =
     .name = Trooper
     .description =
     Anti-tank infantry.
-      Strong vs Tanks.
-      Weak vs Infantry and Artillery.
+      Strong vs Tanks
+      Weak vs Infantry and Artillery
     .encyclopedia =
     Armed with wire-guided, armor-piercing missile warheads, Troopers are very effective against vehicles and buildings but struggle against infantry.
 
@@ -200,7 +200,7 @@ actor-thumper =
     .name = Thumper Infantry
     .description =
     Attracts nearby worms when deployed.
-      Unarmed.
+      Unarmed
     .encyclopedia =
     Deploys a loud hammering device that draws Sandworms to the area.
 
@@ -208,9 +208,9 @@ actor-fremen =
     .name = Fremen
     .description =
     Elite infantry unit with assault rifles and rockets.
-      Strong vs Infantry and Vehicles.
-      Weak vs Artillery.
-      Special Ability: Invisibility.
+      Strong vs Infantry and Vehicles
+      Weak vs Artillery
+      Special Ability: Invisibility
     .encyclopedia =
     The native desert warriors of Dune, armed with 10mm Assault Rifles and Rockets. Their firepower is equally effective against infantry and vehicles.
 
@@ -220,8 +220,8 @@ actor-grenadier =
     .name = Grenadier
     .description =
     Infantry with grenades.
-      Strong vs Buildings and Infantry.
-      Weak vs Vehicles.
+      Strong vs Buildings and Infantry
+      Weak vs Vehicles
     .encyclopedia =
     An infantry artillery unit strong against buildings. They have a chance of exploding when killed, so should not be grouped together.
 
@@ -229,24 +229,24 @@ actor-sardaukar =
     .name = Sardaukar
     .description =
     Elite Corrino assault infantry.
-      Strong vs Infantry and Vehicles.
-      Weak vs Artillery.
+      Strong vs Infantry and Vehicles
+      Weak vs Artillery
     .encyclopedia =
     Powerful heavy troopers equipped with a machine gun that is effective against infantry and a rocket launcher for targeting vehicles.
 
 actor-mpsardaukar-description =
     Elite Harkonnen assault infantry.
-      Strong vs Infantry and Vehicles.
-      Weak vs Artillery.
+      Strong vs Infantry and Vehicles
+      Weak vs Artillery
 
 actor-saboteur =
     .name = Saboteur
     .description =
     Sneaky infantry with explosives.
     Turns invisible for a limited time.
-      Strong vs Buildings.
-      Weak vs Everything.
-      Special Ability: Destroys buildings.
+      Strong vs Buildings
+      Weak vs Everything
+      Special Ability: Destroys buildings
     .encyclopedia =
     A specialized military unit of House Ordos, capable of demolishing enemy buildings upon entry, but dying in the resulting explosion. It can activate stealth mode to become invisible.
 
@@ -254,8 +254,8 @@ actor-saboteur =
 
 actor-nsfremen-description =
     Elite infantry unit with assault rifles and rockets.
-      Strong vs Infantry and Vehicles.
-      Weak vs Artillery.
+      Strong vs Infantry and Vehicles
+      Weak vs Artillery
 
 ## misc.yaml
 actor-crate-name = Crate
@@ -435,8 +435,8 @@ actor-medium-gun-turret =
     .name = Gun Turret
     .description =
     Defensive structure.
-      Strong vs Tanks.
-      Weak vs Infantry and Aircraft.
+      Strong vs Tanks
+      Weak vs Infantry and Aircraft
     .encyclopedia =
     A medium-range weapon that is effective against all types of vehicle, particularly heavily armored ones. It automatically fires upon any enemy unit within its range and requires power to operate.
 
@@ -447,8 +447,8 @@ actor-large-gun-turret =
     .description =
     Defensive structure.
     Requires power to operate.
-      Strong vs Infantry and Aircraft.
-      Weak vs Tanks.
+      Strong vs Infantry and Aircraft
+      Weak vs Tanks
     .encyclopedia =
     An enhanced defensive structure with a longer range and faster rate of fire than the Gun Turret. Its advanced targeting system requires power to operate.
 
@@ -493,22 +493,22 @@ actor-palace =
     .nukepower-description = Launches an atomic missile at a target location.
     .produceactorpower-fremen-name = Recruit Fremen
     .produceactorpower-fremen-description = Elite infantry unit with assault rifles and rockets.
-      Strong vs Infantry and Vehicles.
-      Weak vs Artillery.
-      Special Ability: Invisibility.
+      Strong vs Infantry and Vehicles
+      Weak vs Artillery
+      Special Ability: Invisibility
     .produceactorpower-saboteur-name = Recruit Saboteur
     .produceactorpower-saboteur-description = Sneaky infantry with explosives.
     Can be deployed to become invisible for a limited time.
-      Strong vs Buildings.
-      Weak vs Everything.
-      Special Ability: Destroys buildings.
+      Strong vs Buildings
+      Weak vs Everything
+      Special Ability: Destroys buildings
 
 ## vehicles.yaml
 actor-mcv =
     .name = Mobile Construction Vehicle
     .description =
     Deploys into a Construction Yard.
-      Unarmed.
+      Unarmed
     .encyclopedia =
     Must be driven to an area where it can be deployed. After finding a suitable rock surface, the MCV can be transformed into a Construction Yard.
 
@@ -518,7 +518,7 @@ actor-harvester =
     .name = Spice Harvester
     .description =
     Collects Spice for processing.
-      Unarmed.
+      Unarmed
     .encyclopedia =
     Resistant to bullets, and to some degree, high explosives. They are vulnerable to missiles and high-caliber guns.
 
@@ -528,8 +528,8 @@ actor-trike =
     .name = Trike
     .description =
     Fast scout.
-      Strong vs Infantry.
-      Weak vs Tanks.
+      Strong vs Infantry
+      Weak vs Tanks
     .encyclopedia =
     Lightly armored, three-wheeled vehicles armed with heavy machine guns, effective against infantry and lightly armored vehicles.
 
@@ -539,8 +539,8 @@ actor-quad =
     .name = Missile Quad
     .description =
     Missile Scout.
-      Strong vs Vehicles.
-      Weak vs Infantry.
+      Strong vs Vehicles
+      Weak vs Infantry
     .encyclopedia =
     Superior to the Trike in both armor and firepower, the Quad is a four-wheeled vehicle firing armor-piercing rockets. It is effective against most vehicles.
 
@@ -550,8 +550,8 @@ actor-siege-tank =
     .name = Siege Tank
     .description =
     Siege Artillery.
-      Strong vs Infantry and Buildings.
-      Weak vs Tanks.
+      Strong vs Infantry and Buildings
+      Weak vs Tanks
     .encyclopedia =
     Incredibly effective against infantry and lightly armored vehicles, but struggles against heavily armored targets. It has a long firing range.
 
@@ -561,8 +561,8 @@ actor-missile-tank =
     .name = Missile Tank
     .description =
     Rocket Artillery.
-      Strong vs Vehicles, Buildings and Aircraft.
-      Weak vs Infantry.
+      Strong vs Vehicles, Buildings and Aircraft
+      Weak vs Infantry
     .encyclopedia =
     Shoots down aircraft and is effective against most targets, except infantry.
 
@@ -572,8 +572,8 @@ actor-sonic-tank =
     .name = Sonic Tank
     .description =
     Fires sonic shocks.
-      Strong vs Infantry and Vehicles.
-      Weak vs Artillery.
+      Strong vs Infantry and Vehicles
+      Weak vs Artillery
     .encyclopedia =
     Most effective against infantry and lightly armored vehicles, but weaker against armored targets.
 
@@ -585,8 +585,8 @@ actor-devastator =
     .name = Devastator
     .description =
     Super Heavy Tank.
-      Strong vs Tanks.
-      Weak vs Artillery.
+      Strong vs Tanks
+      Weak vs Artillery
     .encyclopedia =
     As the most powerful tank on Dune, the Devastator is slow but highly effective against most units. It fires dual plasma charges and can self-destruct on command, damaging nearby units and structures.
 
@@ -596,8 +596,8 @@ actor-raider =
     .name = Raider Trike
     .description =
     Improved Scout.
-      Strong vs Infantry and Light Vehicles.
-      Weak vs Tanks.
+      Strong vs Infantry and Light Vehicles
+      Weak vs Tanks
     .encyclopedia =
     Raider Trikes, upgraded by House Ordos, have enhanced firepower, speed, and armor. Equipped with dual 20mm cannons, they are strong against infantry and lightly armored vehicles.
 
@@ -607,8 +607,8 @@ actor-stealth-raider =
     .name = Stealth Raider Trike
     .description =
     Invisible Raider Trike.
-      Strong vs Infantry and Light Vehicles.
-      Weak vs Tanks.
+      Strong vs Infantry and Light Vehicles
+      Weak vs Tanks
     .encyclopedia =
     A cloaked version of the Raider, good for stealth attacks. It uncloaks when it fires its machine guns.
 
@@ -624,8 +624,8 @@ actor-deviator =
 
 meta-combat-tank-description =
     Main Battle Tank.
-      Strong vs Tanks.
-      Weak vs Infantry.
+      Strong vs Tanks
+      Weak vs Infantry
 
 actor-combat-tank-a =
     .name = Atreides Combat Tank

--- a/mods/ra/fluent/rules.ftl
+++ b/mods/ra/fluent/rules.ftl
@@ -43,19 +43,19 @@ faction-allies =
 
 faction-england =
     .name = England
-    .description = England: Counterintelligence.
+    .description = England: Counterintelligence
      Special Unit: British Spy
      Special Unit: Mobile Gap Generator
 
 faction-france =
     .name = France
-    .description = France: Deception.
+    .description = France: Deception
      Special Ability: Can build fake structures
      Special Unit: Phase Transport
 
 faction-germany =
     .name = Germany
-    .description = Germany: Chronoshift Technology.
+    .description = Germany: Chronoshift Technology
      Special Ability: Advanced Chronoshift
      Special Unit: Chrono Tank
 
@@ -64,30 +64,30 @@ faction-soviet =
 
 faction-russia =
     .name = Russia
-    .description = Russia: Tesla Weapons.
+    .description = Russia: Tesla Weapons
      Special Unit: Tesla Tank
      Special Unit: Shock Trooper
 
 faction-ukraine =
     .name = Ukraine
-    .description = Ukraine: Demolitions.
+    .description = Ukraine: Demolitions
      Special Ability: Parabombs
      Special Unit: Demolition Truck
 
 faction-random =
     .name = Any
-    .description = Random Country.
-     A random country is chosen when the game starts.
+    .description = Random Country
+     A random country is chosen when the game starts
 
 faction-randomallies =
     .name = Allies
-    .description = Random Allied Country.
-     A random Allied country is chosen when the game starts.
+    .description = Random Allied Country
+     A random Allied country is chosen when the game starts
 
 faction-randomsoviet =
     .name = Soviet
-    .description = Random Soviet Country.
-     A random Soviet country is chosen when the game starts.
+    .description = Random Soviet Country
+     A random Soviet country is chosen when the game starts
 
 ## aircraft.yaml
 actor-badr-name = Badger
@@ -96,15 +96,15 @@ actor-mig =
     .name = MiG Attack Plane
     .description =
     Fast Ground-Attack Plane.
-      Strong vs Buildings and Vehicles.
-      Weak vs Infantry and Aircraft.
+      Strong vs Buildings and Vehicles
+      Weak vs Infantry and Aircraft
 
 actor-yak =
     .name = Yak Attack Plane
     .description =
     Attack Plane with dual machine guns.
-      Strong vs Infantry and Light armor.
-      Weak vs Tanks and Aircraft.
+      Strong vs Infantry and Light armor
+      Weak vs Tanks and Aircraft
 
 actor-tran =
     .name = Chinook
@@ -116,15 +116,15 @@ actor-heli =
     .name = Longbow
     .description =
     Helicopter gunship with multi-purpose missiles.
-      Strong vs Buildings, Vehicles and Aircraft.
-      Weak vs Infantry.
+      Strong vs Buildings, Vehicles and Aircraft
+      Weak vs Infantry
 
 actor-hind =
     .name = Hind
     .description =
     Helicopter gunship with dual chain guns.
-      Strong vs Infantry and Light armor.
-      Weak vs Tanks and Aircraft.
+      Strong vs Infantry and Light armor
+      Weak vs Tanks and Aircraft
 
 actor-u2-name = Spy Plane
 
@@ -132,8 +132,8 @@ actor-mh60 =
     .name = Black Hawk
     .description =
     Helicopter gunship with dual chain guns.
-      Strong vs Infantry and Light armor.
-      Weak vs Tanks and Aircraft.
+      Strong vs Infantry and Light armor
+      Weak vs Tanks and Aircraft
 
 ## civilian.yaml
 actor-c10-name = Scientist
@@ -291,43 +291,43 @@ actor-dog =
     .description =
     Anti-infantry unit.
     Can detect spies.
-      Strong vs Infantry.
-      Weak vs Vehicles and Aircraft.
+      Strong vs Infantry
+      Weak vs Vehicles and Aircraft
 
 actor-e1 =
     .name = Rifle Infantry
     .description =
     General-purpose infantry.
-      Strong vs Infantry.
-      Weak vs Vehicles and Aircraft.
+      Strong vs Infantry
+      Weak vs Vehicles and Aircraft
 
 actor-e2 =
     .name = Grenadier
     .description =
     Infantry with grenades.
-      Strong vs Buildings and Infantry.
-      Weak vs Vehicles and Aircraft.
+      Strong vs Buildings and Infantry
+      Weak vs Vehicles and Aircraft
 
 actor-e3 =
     .name = Rocket Soldier
     .description =
     Anti-tank/Anti-aircraft infantry.
-      Strong vs Vehicles and Aircraft.
-      Weak vs Infantry.
+      Strong vs Vehicles and Aircraft
+      Weak vs Infantry
 
 actor-e4 =
     .name = Flame Infantry
     .description =
     Advanced anti-structure unit.
-      Strong vs Infantry and Buildings.
-      Weak vs Vehicles and Aircraft.
+      Strong vs Infantry and Buildings
+      Weak vs Vehicles and Aircraft
 
 actor-e6 =
     .name = Engineer
     .description =
     Infiltrates and captures
     enemy structures.
-      Unarmed.
+      Unarmed
 
 actor-spy =
     .disguisetooltip-name = Spy
@@ -338,9 +338,9 @@ actor-spy =
     building infiltrated.
     Loses disguise when attacking.
     Can detect spies.
-      Strong vs Infantry.
-      Weak vs Vehicles and Aircraft.
-      Special Ability: Disguised.
+      Strong vs Infantry
+      Weak vs Vehicles and Aircraft
+      Special Ability: Disguised
 
 actor-spy-england-disguisetooltip-name = British Spy
 
@@ -350,22 +350,22 @@ actor-e7 =
     Elite commando infantry, with dual pistols
     and C4.
     Maximum of one can be built.
-      Strong vs Infantry and Buildings.
-      Weak vs Vehicles and Aircraft.
-      Special Ability: Destroys buildings with C4.
+      Strong vs Infantry and Buildings
+      Weak vs Vehicles and Aircraft
+      Special Ability: Destroys buildings with C4
 
 actor-medi =
     .name = Medic
     .description =
     Heals nearby infantry.
-      Unarmed.
+      Unarmed
 
 actor-mech =
     .name = Mechanic
     .description =
     Repairs nearby vehicles and restores husks to
     working condition by capturing them.
-      Unarmed.
+      Unarmed
 
 actor-einstein-name = Prof. Einstein
 actor-delphi-name = Agent Delphi
@@ -377,14 +377,14 @@ actor-thf =
     .description =
     Steals enemy credits.
     Hijacks enemy vehicles.
-      Unarmed.
+      Unarmed
 
 actor-shok =
     .name = Shock Trooper
     .description =
     Elite infantry with portable Tesla coils.
-      Strong vs Infantry and Vehicles.
-      Weak vs Aircraft.
+      Strong vs Infantry and Vehicles
+      Weak vs Aircraft
 
 actor-zombie =
     .name = Zombie
@@ -429,9 +429,9 @@ actor-ss =
     .description =
     Submerged anti-ship unit with torpedoes.
     Can detect other submarines.
-      Strong vs Naval units.
-      Weak vs Ground units and Aircraft.
-      Special Ability: Submerge.
+      Strong vs Naval units
+      Weak vs Ground units and Aircraft
+      Special Ability: Submerge
 
 actor-msub =
     .name = Missile Submarine
@@ -439,39 +439,39 @@ actor-msub =
     Submerged anti-ground siege unit with anti-air
     capabilities.
     Can detect other submarines.
-      Strong vs Buildings, Ground units and Aircraft.
-      Weak vs Naval units.
-      Special Ability: Submerge.
+      Strong vs Buildings, Ground units and Aircraft
+      Weak vs Naval units
+      Special Ability: Submerge
 
 actor-dd =
     .name = Destroyer
     .description =
     Fast multi-role ship.
     Can detect submarines.
-      Strong vs Naval units, Vehicles and Aircraft.
-      Weak vs Infantry.
+      Strong vs Naval units, Vehicles and Aircraft
+      Weak vs Infantry
 
 actor-ca =
     .name = Cruiser
     .description =
     Very slow long-range ship.
-      Strong vs Buildings and Ground units.
-      Weak vs Naval units and Aircraft.
+      Strong vs Buildings and Ground units
+      Weak vs Naval units and Aircraft
 
 actor-lst =
     .name = Transport
     .description =
     General-purpose naval transport.
-    Carries infantry and tanks.
-      Unarmed.
+    Carries infantry and tanks
+      Unarmed
 
 actor-pt =
     .name = Gunboat
     .description =
     Light scout and support ship.
     Can detect submarines.
-      Strong vs Naval units.
-      Weak vs Ground units and Aircraft.
+      Strong vs Naval units
+      Weak vs Ground units and Aircraft
 
 ## structures.yaml
 notification-construction-complete = Construction complete.
@@ -500,7 +500,7 @@ actor-mslo =
     Provides an atomic bomb.
     Requires power to operate.
     Maximum of one can be built.
-      Special Ability: Atom Bomb.
+      Special Ability: Atom Bomb
     .nukepower-name = Atom Bomb
     .nukepower-description = Launches a devastating atomic bomb
     at the target location.
@@ -530,7 +530,7 @@ actor-iron =
     invulnerability.
     Requires power to operate.
     Maximum of one can be built.
-      Special Ability: Invulnerability.
+      Special Ability: Invulnerability
     .grantexternalconditionpower-ironcurtain-name = Invulnerability
     .grantexternalconditionpower-ironcurtain-description = Grants invulnerability to a group of units
     for 20 seconds.
@@ -556,16 +556,16 @@ actor-tsla =
     Advanced base defense.
     Requires power to operate.
     Can detect cloaked units.
-      Strong vs Vehicles and Infantry.
-      Weak vs Aircraft.
+      Strong vs Vehicles and Infantry
+      Weak vs Aircraft
 
 actor-agun =
     .name = AA Gun
     .description =
     Anti-Air base defense.
     Requires power to operate.
-      Strong vs Aircraft.
-      Weak vs Ground units.
+      Strong vs Aircraft
+      Weak vs Ground units
 
 actor-dome =
     .name = Radar Dome
@@ -580,8 +580,8 @@ actor-pbox =
     Static defense with a fireport for
     a garrisoned soldier.
     Can detect cloaked units.
-      Strong vs Infantry and Light armor.
-      Weak vs Tanks and Aircraft.
+      Strong vs Infantry and Light armor
+      Weak vs Tanks and Aircraft
 
 actor-hbox =
     .name = Camo Pillbox
@@ -589,38 +589,38 @@ actor-hbox =
     Camouflaged static defense with a fireport
     for a garrisoned soldier.
     Can detect cloaked units.
-      Strong vs Infantry and Light armor.
-      Weak vs Tanks and Aircraft.
+      Strong vs Infantry and Light armor
+      Weak vs Tanks and Aircraft
 
 actor-gun =
     .name = Turret
     .description =
     Anti-Armor base defense.
     Can detect cloaked units.
-      Strong vs Vehicles.
-      Weak vs Infantry and Aircraft.
+      Strong vs Vehicles
+      Weak vs Infantry and Aircraft
 
 actor-ftur =
     .name = Flame Tower
     .description =
     Anti-Infantry base defense.
     Can detect cloaked units.
-      Strong vs Infantry and Light armor.
-      Weak vs Tanks and Aircraft.
+      Strong vs Infantry and Light armor
+      Weak vs Tanks and Aircraft
 
 actor-sam =
     .name = SAM Site
     .description =
     Anti-Air base defense.
     Requires power to operate.
-      Strong vs Aircraft.
-      Weak vs Ground units.
+      Strong vs Aircraft
+      Weak vs Ground units
 
 actor-atek =
     .name = Allied Tech Center
     .description =
     Provides advanced Allied technology.
-      Special Ability: GPS Satellite.
+      Special Ability: GPS Satellite
     .gpspower-name = GPS Satellite
     .gpspower-description =
     Reveals map terrain and provides tactical information.
@@ -657,8 +657,8 @@ actor-afld =
     .name = Airfield
     .description =
     Produces and reloads aircraft.
-      Special Ability: Spy Plane.
-      Special Ability: Paratroopers.
+      Special Ability: Spy Plane
+      Special Ability: Paratroopers
     .airstrikepower-spyplane-name = Spy Plane
     .airstrikepower-spyplane-description = Reveals an area of the map.
     .paratrooperspower-paratroopers-name = Paratroopers
@@ -740,32 +740,32 @@ actor-v2rl =
     .name = V2 Rocket Launcher
     .description =
     Long-range rocket artillery.
-      Strong vs Infantry and Buildings.
-      Weak vs Vehicles and Aircraft.
+      Strong vs Infantry and Buildings
+      Weak vs Vehicles and Aircraft
 
 actor-1tnk =
     .name = Light Tank
     .generic-name = Tank
     .description =
     Fast tank; good for scouting.
-      Strong vs Light armor.
-      Weak vs Infantry, Tanks and Aircraft.
+      Strong vs Light armor
+      Weak vs Infantry, Tanks and Aircraft
 
 actor-2tnk =
     .name = Medium Tank
     .generic-name = Tank
     .description =
     Allied Main Battle Tank.
-      Strong vs Vehicles.
-      Weak vs Infantry and Aircraft.
+      Strong vs Vehicles
+      Weak vs Infantry and Aircraft
 
 actor-3tnk =
     .name = Heavy Tank
     .generic-name = Tank
     .description =
     Soviet Main Battle Tank with dual cannons.
-      Strong vs Vehicles.
-      Weak vs Infantry and Aircraft.
+      Strong vs Vehicles
+      Weak vs Infantry and Aircraft
 
 actor-4tnk =
     .name = Mammoth Tank
@@ -773,15 +773,15 @@ actor-4tnk =
     .description =
     Large, slow tank with anti-air capabilities.
     Can crush concrete walls.
-      Strong vs Vehicles, Infantry and Aircraft.
-      Weak vs Nothing.
+      Strong vs Vehicles, Infantry and Aircraft
+      Weak vs Nothing
 
 actor-arty =
     .name = Artillery
     .description =
     Long-range artillery.
-      Strong vs Infantry and Buildings.
-      Weak vs Vehicles and Aircraft.
+      Strong vs Infantry and Buildings
+      Weak vs Vehicles and Aircraft
 
 actor-harv =
     .name = Ore Truck
@@ -789,28 +789,28 @@ actor-harv =
     .description =
     Collects Ore and Gems for
     processing.
-      Unarmed.
+      Unarmed
 
 actor-mcv =
     .name = Mobile Construction Vehicle
     .description =
     Deploys into a Construction Yard.
-      Unarmed.
+      Unarmed
 
 actor-jeep =
     .name = Ranger
     .description =
     Fast scout and anti-infantry vehicle.
     Can carry just one infantry unit.
-      Strong vs Infantry.
-      Weak vs Vehicles and Aircraft.
+      Strong vs Infantry
+      Weak vs Vehicles and Aircraft
 
 actor-apc =
     .name = Armored Personnel Carrier
     .description =
     Tough infantry transport.
-      Strong vs Infantry and Light armor.
-      Weak vs Tanks and Aircraft.
+      Strong vs Infantry and Light armor
+      Weak vs Tanks and Aircraft
 
 actor-mnly =
     .name = Minelayer
@@ -818,41 +818,41 @@ actor-mnly =
     Lays mines to destroy
     unwary enemy units.
     Can detect mines.
-      Unarmed.
+      Unarmed
 
 actor-truk =
     .name = Supply Truck
     .description =
     Transports cash to other players.
-      Unarmed.
+      Unarmed
 
 actor-mgg =
     .name = Mobile Gap Generator
     .description =
     Regenerates shroud to obscure nearby areas.
-      Unarmed.
+      Unarmed
 
 actor-mrj =
     .name = Mobile Radar Jammer
     .description =
     Jams nearby enemy Radar Domes
     and deflects incoming missiles.
-      Unarmed.
+      Unarmed
 
 actor-ttnk =
     .name = Tesla Tank
     .generic-name = Tank
     .description =
     Tank with mounted Tesla coil.
-      Strong vs Infantry, Vehicles and Buildings.
-      Weak vs Aircraft.
+      Strong vs Infantry, Vehicles and Buildings
+      Weak vs Aircraft
 
 actor-ftrk =
     .name = Mobile Flak
     .description =
     Mobile unit with a Flak cannon.
-      Strong vs Infantry, Light armor and Aircraft.
-      Weak vs Tanks.
+      Strong vs Infantry, Light armor and Aircraft
+      Weak vs Tanks
 
 actor-dtrk =
     .name = Demolition Truck
@@ -866,9 +866,9 @@ actor-ctnk =
     .description =
     Armed with anti-ground missiles.
     Teleports to any area within range.
-      Strong vs Vehicles and Buildings.
-      Weak vs Infantry and Aircraft.
-      Special ability: Can teleport.
+      Strong vs Vehicles and Buildings
+      Weak vs Infantry and Aircraft
+      Special ability: Can teleport
 
 actor-qtnk =
     .name = MAD Tank
@@ -876,16 +876,16 @@ actor-qtnk =
     .description =
     Deals seismic damage to nearby vehicles
     and structures.
-      Strong vs Vehicles and Buildings.
-      Weak vs Infantry and Aircraft.
+      Strong vs Vehicles and Buildings
+      Weak vs Infantry and Aircraft
 
 actor-stnk =
     .name = Phase Transport
     .description =
     Light armored infantry transport which can
     cloak. Armed with anti-ground missiles.
-      Strong vs Light armor.
-      Weak vs Infantry, Tanks and Aircraft.
+      Strong vs Light armor
+      Weak vs Infantry, Tanks and Aircraft
 
 ## Civilian Tech
 actor-hosp =

--- a/mods/ts/fluent/rules.ftl
+++ b/mods/ts/fluent/rules.ftl
@@ -84,15 +84,15 @@ actor-orca =
     .description =
     Fast assault gunship with
     dual missile launchers.
-       Strong vs Buildings and Vehicles.
-       Weak vs Infantry and Aircraft.
+       Strong vs Buildings and Vehicles
+       Weak vs Infantry and Aircraft
 
 actor-orcab =
     .name = Orca Bomber
     .description =
     Heavy bomber.
-       Strong vs Buildings and Vehicles.
-       Weak vs Infantry and Aircraft.
+       Strong vs Buildings and Vehicles
+       Weak vs Infantry and Aircraft
 
 actor-orcatran-name = Orca Transport
 
@@ -101,23 +101,23 @@ actor-trnsport =
     .description =
     VTOL aircraft capable of lifting
     and transporting vehicles.
-      Unarmed.
+      Unarmed
 
 actor-scrin =
     .name = Banshee Fighter
     .description =
     Advanced fighter-bomber craft
     with twin plasma cannons.
-       Strong vs Buildings and Vehicles.
-       Weak vs Infantry and Aircraft.
+       Strong vs Buildings and Vehicles
+       Weak vs Infantry and Aircraft
 
 actor-apache =
     .name = Harpy
     .description =
     Anti-personnel support gunship
     with dual chain guns.
-       Strong vs Infantry, Light armor and Aircraft.
-       Weak vs Vehicles.
+       Strong vs Infantry, Light armor and Aircraft
+       Weak vs Vehicles
 
 actor-hunter-name = Hunter-Seeker Droid
 
@@ -297,21 +297,21 @@ actor-e2 =
     .name = Disc Thrower
     .description =
     Infantry with special explosive discs.
-       Strong vs Buildings and Infantry.
-       Weak vs Vehicles and Aircraft.
+       Strong vs Buildings and Infantry
+       Weak vs Vehicles and Aircraft
 
 actor-medic =
     .name = Medic
     .description =
     Heals nearby infantry.
-       Unarmed.
+       Unarmed
 
 actor-jumpjet =
     .name = Jump Jet Infantry
     .description =
     Airborne soldiers.
-       Strong vs Infantry and Aircraft.
-       Weak vs Vehicles.
+       Strong vs Infantry and Aircraft
+       Weak vs Vehicles
 
 actor-jumpjet-husk-name = Jump Jet Infantry
 
@@ -321,9 +321,9 @@ actor-ghost =
     Elite commando infantry with a railgun
     and C4.
     Only one can be trained at a time.
-       Strong vs Infantry and Buildings.
-       Weak vs Vehicles and Aircraft.
-       Special Ability: Destroy Building with C4.
+       Strong vs Infantry and Buildings
+       Weak vs Vehicles and Aircraft
+       Special Ability: Destroy Building with C4
 
 
 ## gdi-structures.yaml
@@ -431,24 +431,24 @@ actor-gavulc =
     .description =
     Basic base defense.
     Does not require power to operate.
-       Strong vs Infantry and Light armor.
-       Weak vs Aircraft.
+       Strong vs Infantry and Light armor
+       Weak vs Aircraft
 
 actor-garock =
     .name = RPG Upgrade
     .description =
     GDI Advanced base defense.
     Does not require power to operate.
-       Strong vs Armored ground units.
-       Weak vs Aircraft.
+       Strong vs Armored ground units
+       Weak vs Aircraft
 
 actor-gacsam =
     .name = SAM Upgrade
     .description =
     GDI Anti-Air base defense.
     Does not require power to operate.
-       Strong vs Aircraft.
-       Weak vs Ground units.
+       Strong vs Aircraft
+       Weak vs Ground units
 
 ## gdi-vehicles.yaml
 actor-apc =
@@ -456,29 +456,29 @@ actor-apc =
     .description =
     Armored infantry transport.
     Can move on water.
-       Unarmed.
+       Unarmed
 
 actor-hvr =
     .name = Hover MLRS
     .description =
     Hovering vehicle with
     long-range missiles.
-       Strong vs Vehicles and Aircraft.
-       Weak vs Infantry.
+       Strong vs Vehicles and Aircraft
+       Weak vs Infantry
 
 actor-smech =
     .name = Wolverine
     .description =
     Anti-personnel walker.
-       Strong vs Infantry and Light armor.
-       Weak vs Vehicles and Aircraft.
+       Strong vs Infantry and Light armor
+       Weak vs Vehicles and Aircraft
 
 actor-mmch =
     .name = Titan
     .description =
     General purpose mechanized walker.
-       Strong vs Vehicles.
-       Weak vs Infantry and Aircraft.
+       Strong vs Vehicles
+       Weak vs Infantry and Aircraft
 
 actor-hmec =
     .name = Mammoth Mk. II
@@ -486,16 +486,16 @@ actor-hmec =
     Slow, heavily armored walker.
     Maximum of one can be built.
     Armed with dual railguns and rocket launchers.
-       Strong vs Infantry, Vehicles, Aircraft and Buildings.
-       Weak vs Nothing.
+       Strong vs Infantry, Vehicles, Aircraft and Buildings
+       Weak vs Nothing
 
 actor-sonic =
     .name = Disruptor
     .description =
     Armored high-tech vehicle with
     long-range and sonic armament.
-       Strong vs Infantry, Vehicles and Buildings.
-       Weak vs Aircraft.
+       Strong vs Infantry, Vehicles and Buildings
+       Weak vs Aircraft
 
 actor-jugg =
     .name = Juggernaut
@@ -503,8 +503,8 @@ actor-jugg =
     .description =
     Mobile Artillery Mech.
     Must be deployed in order to shoot.
-       Strong vs Ground units.
-       Weak vs Aircraft.
+       Strong vs Ground units
+       Weak vs Aircraft
 
 actor-mobilemp =
     .name = Mobile EMP Cannon
@@ -531,29 +531,29 @@ actor-e3 =
     .name = Rocket Infantry
     .description =
     Anti-tank infantry.
-       Strong vs Vehicles, Aircraft and Buildings.
-       Weak vs Infantry.
+       Strong vs Vehicles, Aircraft and Buildings
+       Weak vs Infantry
 
 actor-cyborg =
     .name = Cyborg Infantry
     .description =
     Cybernetic infantry unit.
-       Strong vs Infantry and Light armor.
-       Weak vs Vehicles and Aircraft.
+       Strong vs Infantry and Light armor
+       Weak vs Vehicles and Aircraft
 
 actor-cyc2 =
     .name = Cyborg Commando
     .description =
     Elite cybernetic infantry unit.
     Maximum of one can be built.
-       Strong vs Infantry, Vehicles and Buildings.
-       Weak vs Aircraft.
+       Strong vs Infantry, Vehicles and Buildings
+       Weak vs Aircraft
 
 actor-mhijack =
     .name = Mutant Hijacker
     .description =
     Hijacks enemy vehicles.
-       Unarmed.
+       Unarmed
 
 ## nod-structures.yaml
 actor-napowr =
@@ -648,39 +648,39 @@ actor-nalasr =
     .description =
     Basic base defense.
     Requires power to operate.
-       Strong vs Ground units.
-       Weak vs Aircraft.
+       Strong vs Ground units
+       Weak vs Aircraft
 
 actor-naobel =
     .name = Obelisk of Light
     .description =
     Advanced base defense.
     Requires power to operate.
-       Strong vs Ground units.
-       Weak vs Aircraft.
+       Strong vs Ground units
+       Weak vs Aircraft
 
 actor-nasam =
     .name = S.A.M. Site
     .description =
     Nod Anti-Air base defense.
     Requires power to operate.
-       Strong vs Aircraft.
-       Weak vs Ground units.
+       Strong vs Aircraft
+       Weak vs Ground units
 
 ## nod-vehicles.yaml
 actor-bggy =
     .name = Attack Buggy
     .description =
     Fast scout and anti-infantry vehicle.
-       Strong vs Infantry and Light armor.
-       Weak vs Vehicles and Aircraft.
+       Strong vs Infantry and Light armor
+       Weak vs Vehicles and Aircraft
 
 actor-bike =
     .name = Attack Cycle
     .description =
     Fast scout vehicle with rockets.
-       Strong vs Vehicles.
-       Weak vs Infantry and Aircraft.
+       Strong vs Vehicles
+       Weak vs Infantry and Aircraft
 
 actor-ttnk =
     .name = Tick Tank
@@ -688,8 +688,8 @@ actor-ttnk =
     .description =
     Nod's main battle tank.
     Can deploy to gain extra protection.
-       Strong vs Vehicles.
-       Weak vs Infantry and Aircraft.
+       Strong vs Vehicles
+       Weak vs Infantry and Aircraft
 
 actor-art2 =
     .name = Artillery
@@ -697,35 +697,35 @@ actor-art2 =
     .description =
     Mobile Artillery.
     Needs to be deployed in order to shoot.
-       Strong vs Ground units.
-       Weak vs Aircraft.
+       Strong vs Ground units
+       Weak vs Aircraft
 
 actor-repair =
     .name = Mobile Repair Vehicle
     .description =
     Repairs nearby vehicles.
-       Unarmed.
+       Unarmed
 
 actor-weed =
     .name = Weed Eater
     .description =
     Collects Tiberium veins for processing.
-       Unarmed.
+       Unarmed
 
 actor-sapc =
     .name = Subterranean APC
     .description =
     Troop transport capable of moving
     underground to avoid detection.
-       Unarmed.
+       Unarmed
 
 actor-subtank =
     .name = Devil's Tongue
     .description =
     Subterranean Flame Tank
     with the ability to move underground.
-       Strong vs Infantry and Buildings.
-       Weak vs Tanks and Aircraft.
+       Strong vs Infantry and Buildings
+       Weak vs Tanks and Aircraft
 
 actor-stnk =
     .name = Stealth Tank
@@ -733,29 +733,29 @@ actor-stnk =
     Lightly armored tank equipped with a personal
     stealth generator. Armed with missiles.
     Visible to infantry at close range.
-       Strong vs Vehicles and Aircraft.
-       Weak vs Infantry.
+       Strong vs Vehicles and Aircraft
+       Weak vs Infantry
 
 actor-sgen =
     .name = Mobile Stealth Generator
     .deployed-name = Mobile Stealth Generator (deployed)
     .description =
     Able to cloak units once deployed.
-       Unarmed.
+       Unarmed
 
 ## shared-infantry.yaml
 actor-e1 =
     .name = Light Infantry
     .description =
     General-purpose infantry.
-       Strong vs Infantry.
-       Weak vs Vehicles and Aircraft.
+       Strong vs Infantry
+       Weak vs Vehicles and Aircraft
 
 actor-engineer =
     .name = Engineer
     .description =
     Infiltrates and captures enemy structures.
-       Unarmed.
+       Unarmed
 
 ## shared-structures.yaml
 actor-gacnst =
@@ -795,13 +795,13 @@ actor-mcv =
     .name = Mobile Construction Vehicle
     .description =
     Deploys into a Construction Yard.
-      Unarmed.
+      Unarmed
 
 actor-harv =
     .name = Harvester
     .description =
     Collects Tiberium for processing.
-       Unarmed.
+       Unarmed
 
 actor-lpst =
     .name = Mobile Sensor Array
@@ -809,7 +809,7 @@ actor-lpst =
     .description =
     Detects cloaked and subterranean
     units when deployed.
-       Unarmed.
+       Unarmed
 
 ## trees.yaml
 actor-bigblue-name = Large Blue Tiberium Crystal


### PR DESCRIPTION
Given no clear consensus on full stops. I’ve mostly reverted strong vs, weak vs and any one word/two word statements. Anything else, I used the version of the previous release.
