### PR TITLE
Remove save dialog when creating a new map.

### DIFF
--- a/OpenRA.Game/FileSystem/ZipFile.cs
+++ b/OpenRA.Game/FileSystem/ZipFile.cs
@@ -98,11 +98,11 @@ namespace OpenRA.FileSystem
 		{
 			readonly MemoryStream pkgStream = new();
 
-			public ReadWriteZipFile(string filename, bool create = false)
+			public ReadWriteZipFile(string filename = null, bool create = false)
 			{
 				// SharpZipLib breaks when asked to update archives loaded from outside streams or files
 				// We can work around this by creating a clean in-memory-only file, cutting all outside references
-				if (!create)
+				if (!string.IsNullOrEmpty(filename) && !create)
 				{
 					using (var copy = new MemoryStream(File.ReadAllBytes(filename)))
 					{
@@ -122,7 +122,8 @@ namespace OpenRA.FileSystem
 
 			void Commit()
 			{
-				File.WriteAllBytes(Name, pkgStream.ToArray());
+				if (!string.IsNullOrEmpty(Name))
+					File.WriteAllBytes(Name, pkgStream.ToArray());
 			}
 
 			public void Update(string filename, byte[] contents)

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -978,7 +978,7 @@ namespace OpenRA
 				Order.Command($"state {Session.ClientState.Ready}")
 			};
 
-			var map = ModData.MapCache.SingleOrDefault(m => m.Uid == launchMap || Path.GetFileName(m.PackageName) == launchMap);
+			var map = ModData.MapCache.SingleOrDefault(m => m.Uid == launchMap || Path.GetFileName(m.Path) == launchMap);
 			if (map == null)
 				throw new ArgumentException($"Could not find map '{launchMap}'.");
 

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -317,54 +317,6 @@ namespace OpenRA
 			};
 		}
 
-		// For linting purposes only!
-		public MapPreview(Map map, ModData modData)
-		{
-			this.modData = modData;
-			cache = modData.MapCache;
-
-			Uid = map.Uid;
-			PackageName = map.Package.Name;
-
-			var mapPlayers = new MapPlayers(map.PlayerDefinitions);
-			var spawns = new List<CPos>();
-			foreach (var kv in map.ActorDefinitions.Where(d => d.Value.Value == "mpspawn"))
-			{
-				var s = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
-				spawns.Add(s.Get<LocationInit>().Value);
-			}
-
-			innerData = new InnerData
-			{
-				MapFormat = map.MapFormat,
-				Title = map.Title,
-				Categories = map.Categories,
-				Author = map.Author,
-				TileSet = map.Tileset,
-				Players = mapPlayers,
-				PlayerCount = mapPlayers.Players.Count(x => x.Value.Playable),
-				SpawnPoints = spawns.ToArray(),
-				GridType = map.Grid.Type,
-				Bounds = map.Bounds,
-				Preview = null,
-				Status = MapStatus.Available,
-				Class = MapClassification.Unknown,
-				Visibility = map.Visibility,
-			};
-
-			innerData.SetCustomRules(modData, this, new Dictionary<string, MiniYaml>()
-			{
-				{ "Rules", map.RuleDefinitions },
-				{ "FluentMessages", map.FluentMessageDefinitions },
-				{ "Weapons", map.WeaponDefinitions },
-				{ "Voices", map.VoiceDefinitions },
-				{ "Music", map.MusicDefinitions },
-				{ "Notifications", map.NotificationDefinitions },
-				{ "Sequences", map.SequenceDefinitions },
-				{ "ModelSequences", map.ModelSequenceDefinitions }
-			}, null);
-		}
-
 		public void UpdateFromMap(IReadOnlyPackage p, IReadOnlyPackage parent, MapClassification classification,
 			string[] mapCompatibility, MapGridType gridType, IEnumerable<List<MiniYamlNode>> modDataRules)
 		{

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -12,7 +12,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.IO;
 using System.Linq;
 using OpenRA.FileSystem;
 using OpenRA.Graphics;
@@ -141,15 +140,11 @@ namespace OpenRA
 
 		public IEnumerable<string> Languages { get; }
 
-		public Map PrepareMap(string uid)
+		public void PrepareMap(Map map)
 		{
 			LoadScreen?.Display();
 
-			if (MapCache[uid].Status != MapStatus.Available)
-				throw new InvalidDataException($"Invalid map uid: {uid}");
-
 			// Reinitialize all our assets
-			var map = MapCache[uid].ToMap();
 			InitializeLoaders(map);
 			map.Sequences.LoadSprites();
 
@@ -157,8 +152,6 @@ namespace OpenRA
 			using (new Support.PerfTimer("Map.Music"))
 				foreach (var entry in map.Rules.Music)
 					entry.Value.Load(map);
-
-			return map;
 		}
 
 		public List<MiniYamlNode>[] GetRulesYaml()

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -148,11 +148,8 @@ namespace OpenRA
 			if (MapCache[uid].Status != MapStatus.Available)
 				throw new InvalidDataException($"Invalid map uid: {uid}");
 
-			Map map;
-			using (new Support.PerfTimer("Map"))
-				map = new Map(this, MapCache[uid].Package);
-
 			// Reinitialize all our assets
+			var map = MapCache[uid].ToMap();
 			InitializeLoaders(map);
 			map.Sequences.LoadSprites();
 

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -188,13 +188,12 @@ namespace OpenRA
 
 		bool wasLoadingGameSave;
 
-		internal World(string mapUID, ModData modData, OrderManager orderManager, WorldType type)
+		internal World(Map map, ModData modData, OrderManager orderManager, WorldType type)
 		{
 			this.modData = modData;
 			Type = type;
 			OrderManager = orderManager;
-			using (new PerfTimer("PrepareMap"))
-				Map = modData.PrepareMap(mapUID);
+			Map = map;
 
 			if (string.IsNullOrEmpty(modData.Manifest.DefaultOrderGenerator))
 				throw new InvalidDataException("mod.yaml must define a DefaultOrderGenerator");

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Linq;
+using OpenRA.FileSystem;
 using OpenRA.Mods.Common.Terrain;
 using OpenRA.Widgets;
 
@@ -69,24 +70,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (map.Rules.TerrainInfo is ITerrainInfoNotifyMapCreated notifyMapCreated)
 					notifyMapCreated.MapCreated(map);
 
-				Action<string> afterSave = uid =>
-				{
-					map.Dispose();
-					Game.LoadEditor(uid);
-
-					Ui.CloseWindow();
-					onSelect(uid);
-				};
-
-				Ui.OpenWindow("SAVE_MAP_PANEL", new WidgetArgs()
-				{
-					{ "onSave", afterSave },
-					{ "onExit", () => { Ui.CloseWindow(); onExit(); } },
-					{ "map", map },
-					{ "world", world },
-					{ "playerDefinitions", map.PlayerDefinitions },
-					{ "actorDefinitions", map.ActorDefinitions }
-				});
+				var package = new ZipFileLoader.ReadWriteZipFile();
+				map.Save(package);
+				map = new Map(modData, package);
+				Game.LoadEditor(map);
+				Ui.CloseWindow();
+				onSelect(map.Uid);
 			};
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -145,7 +145,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					}
 				}
 
-				if (map.Package != null)
+				if (!string.IsNullOrEmpty(map.Package?.Name))
 				{
 					selectedDirectory = writableDirectories.FirstOrDefault(k => k.Folder.Contains(map.Package.Name));
 					selectedDirectory ??= writableDirectories.FirstOrDefault(k => Directory.GetDirectories(k.Folder.Name).Any(f => f.Contains(map.Package.Name)));

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -247,7 +247,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (map.Package?.Name != combinedPath)
 			{
 				// When creating a new map or when file paths don't match
-				if (modData.MapCache.Any(m => m.Status == MapStatus.Available && m.PackageName == combinedPath))
+				if (modData.MapCache.Any(m => m.Status == MapStatus.Available && m.Path == combinedPath))
 				{
 					ConfirmationDialogs.ButtonPrompt(modData,
 						title: OverwriteMapFailedTitle,

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -519,8 +519,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return;
 
 			var actionManager = world.WorldActor.Trait<EditorActionManager>();
-			AddButton("PLAY_MAP", "Play Map")
-				.OnClick = () =>
+			var button = AddButton("PLAY_MAP", "Play Map");
+			button.IsDisabled = () => leaving || string.IsNullOrEmpty(world.Map.Package.Name);
+			button.OnClick = () =>
 				{
 					hideMenu = true;
 					var uid = modData.MapCache.GetUpdatedMap(world.Map.Uid);
@@ -618,8 +619,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void ExitEditor(EditorActionManager actionManager, Action onSuccess)
 		{
-			var map = modData.MapCache.GetUpdatedMap(world.Map.Uid);
-			var deletedOrUnavailable = map == null || modData.MapCache[map].Status != MapStatus.Available;
+			var deletedOrUnavailable = false;
+			if (!string.IsNullOrEmpty(world.Map.Package.Name))
+			{
+				var map = modData.MapCache.GetUpdatedMap(world.Map.Uid);
+				deletedOrUnavailable = map == null || modData.MapCache[map].Status != MapStatus.Available;
+			}
+
 			if (actionManager.HasUnsavedItems() || deletedOrUnavailable)
 			{
 				hideMenu = true;

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -166,7 +166,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						.Select(p => new
 						{
 							Preview = p,
-							Index = missionMapPaths.IndexOf(Path.GetFileName(p.PackageName))
+							Index = missionMapPaths.IndexOf(Path.GetFileName(p.Path))
 						})
 						.Where(x => x.Index != -1)
 						.OrderBy(x => x.Index)


### PR DESCRIPTION
This PR (together with #21773) complete the prerequisites for the in-lobby skirmish map generator. The changes here enable maps to be created and loaded in memory, without having to save the backing package to the filesystem.

See https://github.com/pchote/OpenRA/tree/skirmish-rmg for additional context on the API changes.

Closes #21650.