### PR TITLE
Add AutoTarget & Selectable to CnC civilians

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -467,6 +467,8 @@
 ^CivInfantry:
 	Inherits: ^Infantry
 	Inherits@selection: ^SelectableSupportUnit
+	Selectable:
+		Class: CivInfantry
 	Valued:
 		Cost: 10
 	Tooltip:
@@ -494,6 +496,7 @@
 		Categories: Civilian infantry
 
 ^ArmedCivilian:
+	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Inherits@selection: ^SelectableCombatUnit
 	Armament:
 		Weapon: Pistol


### PR DESCRIPTION
This PR adds a shared selectable to CnC's civilians to act a bit more like their RA counterparts, while armed civilians gain auto-targeting. The latter means GDI-aligned villagers in `nod04b` ("Mao Civil War") can properly Hunt instead of just trailing their targets.

https://github.com/user-attachments/assets/83ff3eac-b8ff-40b6-9da1-25c300f5e2cc

The original game had a similar issue. Despite some civilian groups being given area guard/hunt orders in missions (e.g. `nod01`, `nod04b`), only certain types had a usable weapon defined (`C1`, `C7`, and `DELPHI` [per IDATA](https://github.com/electronicarts/CnC_Remastered_Collection/blob/master/TIBERIANDAWN/IDATA.CPP)).