### PR TITLE
Add civilian idle sequences

### DIFF
--- a/mods/cnc/rules/civilian.yaml
+++ b/mods/cnc/rules/civilian.yaml
@@ -519,12 +519,16 @@ DELPHI:
 
 CHAN:
 	Inherits: ^CivInfantry
+	WithInfantryBody:
+		IdleSequences: idle1, idle2
 	Tooltip:
 		Name: actor-chan-name
 
 MOEBIUS:
 	Inherits: ^CivInfantry
 	-Wanders:
+	WithInfantryBody:
+		IdleSequences: idle1, idle2
 	Voiced:
 		VoiceSet: MoebiusVoice
 	Tooltip:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -492,6 +492,10 @@
 		MinMoveDelay: 150
 		MaxMoveDelay: 750
 		AvoidTerrainTypes: Tiberium, BlueTiberium
+	WithInfantryBody:
+		IdleSequences: idle1
+		MinIdleDelay: 60
+		MaxIdleDelay: 220
 	MapEditorData:
 		Categories: Civilian infantry
 
@@ -503,6 +507,7 @@
 	AttackFrontal:
 		FacingTolerance: 0
 	WithInfantryBody:
+		IdleSequences: idle1,idle2
 		DefaultAttackSequence: shoot
 
 ^DINO:

--- a/mods/cnc/sequences/civilian.yaml
+++ b/mods/cnc/sequences/civilian.yaml
@@ -13,6 +13,15 @@ c1:
 		Start: 56
 		Length: 6
 		Facings: 8
+		Tick: 80
+	idle1:
+		Start: 189
+		Length: 9
+		Tick: 80
+	idle2:
+		Start: 199
+		Length: 6
+		Tick: 80
 	shoot:
 		Start: 205
 		Length: 4
@@ -121,6 +130,9 @@ moebius:
 	idle1:
 		Start: 104
 		Length: 15
+	idle2:
+		Start: 120
+		Length: 20
 	die1:
 		Start: 212
 		Length: 8

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -479,6 +479,10 @@
 	Wanders:
 		MinMoveDelay: 150
 		MaxMoveDelay: 750
+	WithInfantryBody:
+		IdleSequences: idle1
+		MinIdleDelay: 60
+		MaxIdleDelay: 220
 	MapEditorData:
 		Categories: Civilian infantry
 
@@ -492,6 +496,7 @@
 	AttackFrontal:
 		FacingTolerance: 0
 	WithInfantryBody:
+		IdleSequences: idle1,idle2
 		DefaultAttackSequence: shoot
 
 ^Ship:

--- a/mods/ra/sequences/infantry.yaml
+++ b/mods/ra/sequences/infantry.yaml
@@ -1088,6 +1088,14 @@ c1:
 		Start: 120
 		Length: 4
 		Facings: 8
+	idle1:
+		Start: 104
+		Length: 9
+		Tick: 80
+	idle2:
+		Start: 114
+		Length: 6
+		Tick: 80
 	die1:
 		Start: 152
 		Length: 8
@@ -1143,6 +1151,14 @@ c2:
 		Start: 120
 		Length: 4
 		Facings: 8
+	idle1:
+		Start: 104
+		Length: 9
+		Tick: 80
+	idle2:
+		Start: 114
+		Length: 6
+		Tick: 80
 	die1:
 		Start: 152
 		Length: 8
@@ -1198,6 +1214,14 @@ c11:
 		Start: 120
 		Length: 4
 		Facings: 8
+	idle1:
+		Start: 104
+		Length: 9
+		Tick: 80
+	idle2:
+		Start: 114
+		Length: 6
+		Tick: 80
 	die1:
 		Start: 152
 		Length: 8
@@ -1254,6 +1278,10 @@ einstein:
 		Length: 6
 		Facings: 8
 		Tick: 80
+	idle1:
+		Start: 104
+		Length: 15
+		Tick: 80
 	die1:
 		Start: 120
 		Length: 8
@@ -1305,6 +1333,14 @@ delphi:
 		Length: 6
 		Facings: 8
 		Tick: 80
+	idle1:
+		Start: 189
+		Length: 9
+		Tick: 80
+	idle2:
+		Start: 199
+		Length: 6
+		Tick: 80
 	die1:
 		Start: 329
 		Length: 8
@@ -1355,6 +1391,10 @@ chan:
 		Start: 56
 		Length: 6
 		Facings: 8
+		Tick: 80
+	idle1:
+		Start: 104
+		Length: 15
 		Tick: 80
 	die1:
 		Start: 120


### PR DESCRIPTION
This PR adds some original idle sequences to make CnC/RA civilians a bit more lively (per the [CnC IDATA](https://github.com/electronicarts/CnC_Remastered_Collection/blob/master/TIBERIANDAWN/IDATA.CPP) and [RA1 IDATA](https://github.com/electronicarts/CnC_Remastered_Collection/blob/master/REDALERT/IDATA.CPP)). These include the "glancing around" `idle1` sequence for all civilians, the "pistol flash" `idle2` for armed civilian types, and the "kneeled prayer" `idle2` [unique to Dr. Chan and Dr. Moebius](https://github.com/electronicarts/CnC_Remastered_Collection/blob/master/TIBERIANDAWN/IDATA.CPP#L1364).

https://github.com/user-attachments/assets/681082bc-37cd-4381-9707-66acef5a2635

----

CnC civilian movement is adjusted because the current run cycle is double speed compared to RA, and it looks less natural (to _my_ eyes at least).

https://github.com/user-attachments/assets/5337217b-e51b-4616-9182-0f4db5ad5863
