### PR TITLE
Add explosion effects to RA bridges

### DIFF
--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -564,6 +564,7 @@ OILB:
 
 BR1:
 	Inherits: ^Bridge
+	Inherits@EXPLOSIVE: ^ExplosiveBridge
 	Bridge:
 		Template: 235
 		DamagedTemplate: 236
@@ -583,6 +584,7 @@ BR1:
 
 BR2:
 	Inherits: ^Bridge
+	Inherits@EXPLOSIVE: ^ExplosiveBridge
 	Bridge:
 		Template: 238
 		DamagedTemplate: 239
@@ -602,6 +604,7 @@ BR2:
 
 BR3:
 	Inherits: ^Bridge
+	Inherits@EXPLOSIVE: ^ExplosiveBridge
 	Bridge:
 		Long: true
 		ShorePieces: br1,br2
@@ -616,6 +619,7 @@ BR3:
 
 BRIDGE1:
 	Inherits: ^Bridge
+	Inherits@EXPLOSIVE: ^ExplosiveBridge
 	Bridge:
 		Template: 131
 		DamagedTemplate: 378
@@ -634,6 +638,7 @@ BRIDGE1:
 
 BRIDGE2:
 	Inherits: ^Bridge
+	Inherits@EXPLOSIVE: ^ExplosiveBridge
 	Bridge:
 		Template: 133
 		DamagedTemplate: 379
@@ -652,6 +657,7 @@ BRIDGE2:
 
 BRIDGE3:
 	Inherits: ^Bridge
+	Inherits@EXPLOSIVE: ^ExplosiveBridge
 	Bridge:
 		Template: 620
 		DamagedTemplate: 621
@@ -670,6 +676,7 @@ BRIDGE3:
 
 BRIDGE4:
 	Inherits: ^Bridge
+	Inherits@EXPLOSIVE: ^ExplosiveBridge
 	Bridge:
 		Template: 624
 		DamagedTemplate: 625
@@ -688,6 +695,7 @@ BRIDGE4:
 
 SBRIDGE1:
 	Inherits: ^Bridge
+	Inherits@EXPLOSIVE: ^ExplosiveBridge
 	Bridge:
 		Template: 520
 		DamagedTemplate: 521
@@ -706,6 +714,7 @@ SBRIDGE1:
 
 SBRIDGE2:
 	Inherits: ^Bridge
+	Inherits@EXPLOSIVE: ^ExplosiveBridge
 	Bridge:
 		Template: 531
 		DamagedTemplate: 532
@@ -724,6 +733,7 @@ SBRIDGE2:
 
 SBRIDGE3:
 	Inherits: ^Bridge
+	Inherits@EXPLOSIVE: ^ExplosiveBridge
 	Bridge:
 		Template: 523
 		DamagedTemplate: 524
@@ -737,6 +747,7 @@ SBRIDGE3:
 
 SBRIDGE4:
 	Inherits: ^Bridge
+	Inherits@EXPLOSIVE: ^ExplosiveBridge
 	Bridge:
 		Template: 527
 		DamagedTemplate: 528

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -1146,6 +1146,16 @@
 		Duration: 15
 		Intensity: 6
 
+^ExplosiveBridge:
+	ExplosionOnDamageTransition@DAMAGED:
+		DamageState: Heavy
+		Weapon: BridgeExplode
+	ExplosionOnDamageTransition@COLLAPSED:
+		DamageState: Dead
+		Weapon: BridgeExplode
+	SoundOnDamageTransition:
+		DestroyedSounds: crmble2.aud
+
 ^Rock:
 	Inherits@1: ^SpriteActor
 	Interactable:

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -184,6 +184,12 @@ BarrelCluster:
 	Warhead@Smu: LeaveSmudge
 		SmudgeType: Scorch
 
+BridgeExplode:
+	Inherits: VisualExplode
+	Warhead@2Eff: CreateEffect
+		Explosions: large_napalm
+		ValidTargets: Bridge, Ground, Water
+
 ATMine:
 	ValidTargets: Ground, Water, GroundActor, WaterActor
 	Warhead@1Dam: SpreadDamage


### PR DESCRIPTION
Current -> added effects:

https://github.com/user-attachments/assets/df51c3b4-9711-4b50-a1e2-ec58ee8cf8df

For more oomph, bridge damage or destruction in RA '96 spawns a fireball and its associated sound. This PR adds the same effect for ORA bridges, with an added crumbling sound if it's a full collapse.

I'm not confident about the names used, so suggestions for them are extra welcome. Originally, the shore-connecting pieces of the long bridge (`BR1` and `BR2`) do not share this behavior, but I didn't see the harm in adding it.

RA1 code references:
- `Destroy_Bridge_At`, where `ANIM_NAPALM3` can be spawned: https://github.com/electronicarts/CnC_Red_Alert/blob/0dc09bb1d6188d1ec79ab4765b22a48b75ffee32/CODE/MAP.CPP#L1790
- `ANIM_NAPALM3` data: https://github.com/electronicarts/CnC_Red_Alert/blob/0dc09bb1d6188d1ec79ab4765b22a48b75ffee32/CODE/ADATA.CPP#L769