### PR TITLE
Harvesters prefer ore near to the refinery.

### DIFF
--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -173,7 +173,8 @@ namespace OpenRA.Mods.Common.Activities
 			// Prioritise search by these locations in this order: lastHarvestedCell -> lastLinkedDock -> self.
 			CPos searchFromLoc;
 			int searchRadius;
-			WPos? dockPos = null;
+			var dockPos = harv.DockClientManager?.LastReservedHost?.DockPosition;
+
 			if (lastHarvestedCell.HasValue)
 			{
 				searchRadius = harvInfo.SearchFromHarvesterRadius;
@@ -182,12 +183,8 @@ namespace OpenRA.Mods.Common.Activities
 			else
 			{
 				searchRadius = harvInfo.SearchFromProcRadius;
-				var dock = harv.DockClientManager?.LastReservedHost;
-				if (dock != null)
-				{
-					dockPos = dock.DockPosition;
+				if (dockPos != null)
 					searchFromLoc = self.World.Map.CellContaining(dockPos.Value);
-				}
 				else
 					searchFromLoc = self.Location;
 			}


### PR DESCRIPTION
When searching for ore, harvesters will prefer ore close to their refinery, the dockPos. However this only works when this is set, and is was not being set when expected. Fixing this prevents harvesters moving in straight lines, particularly when the ore is to the left of the refinery, which is the default path search direction.

Fixes a regression from #20636.

Fixes #21780, recommend porting onto the prep branch.