### PR TITLE
Fix tree husks on jungle tileset

### DIFF
--- a/mods/cnc/sequences/decorations.yaml
+++ b/mods/cnc/sequences/decorations.yaml
@@ -69,8 +69,6 @@ tc04:
 			SNOW: tc04.sno
 			JUNGLE: tc04.jun
 	idle:
-	damaged-idle:
-		Start: 1
 
 tc04.husk:
 	Defaults:
@@ -80,7 +78,7 @@ tc04.husk:
 			SNOW: tc04.sno
 			JUNGLE: tc04.jun
 	idle:
-		Start: 2
+		Start: 1
 
 tc05:
 	Defaults:
@@ -90,8 +88,6 @@ tc05:
 			SNOW: tc05.sno
 			JUNGLE: tc05.jun
 	idle:
-	damaged-idle:
-		Start: 1
 
 tc05.husk:
 	Defaults:
@@ -101,7 +97,7 @@ tc05.husk:
 			SNOW: tc05.sno
 			JUNGLE: tc05.jun
 	idle:
-		Start: 2
+		Start: 1
 
 tc03:
 	Defaults:


### PR DESCRIPTION
Fixes #21788

Jungle tileset TC trees are missing decay textures, so they get zeroed by #21368, leading to the crash.

This PR makes sure TC04 and TC05 are not using any non-existent textures.

Now the jungle tileset tree husks are actually visible.
<img width="879" alt="Screenshot 2025-03-10 at 11 44 29" src="https://github.com/user-attachments/assets/c83f3729-4029-4991-8326-7aa64b9699bf" />

For reference base tempatate version
<img width="524" alt="Screenshot 2025-03-10 at 11 45 44" src="https://github.com/user-attachments/assets/9be2bbfa-2c54-4656-9637-bdae195ce251" />
