### PR TITLE
Allow installing dune 2000 movies from gruntmods

### DIFF
--- a/mods/d2k-content/installer/gruntmods.yaml
+++ b/mods/d2k-content/installer/gruntmods.yaml
@@ -298,3 +298,50 @@ gruntmods: Dune 2000: GruntMods Edition
 					^SupportDir|Content/d2k/v3/GAMESFX/AI_ORDER.AUD: AI_ORDER.AUD
 					^SupportDir|Content/d2k/v3/GAMESFX/AI_UNRDY.AUD: AI_UNRDY.AUD
 					^SupportDir|Content/d2k/v3/SOUND.RS: SOUND.RS
+		# Campaign briefings (optional):
+		ContentPackage@movies:
+			Name: movies
+			Actions:
+				Copy: Dune 2000/movies
+					^SupportDir|Content/d2k/v3/Movies/A_BR01_E.VQA: A_BR01_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/A_BR02_E.VQA: A_BR02_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/A_BR03_E.VQA: A_BR03_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/A_BR04_E.VQA: A_BR04_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/A_BR05_E.VQA: A_BR05_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/A_BR06_E.VQA: A_BR06_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/A_BR07_E.VQA: A_BR07_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/A_BR08_E.VQA: A_BR08_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/A_BR09_E.VQA: A_BR09_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/A_FINL_E.VQA: A_FINL_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/A_LOSE_E.VQA: A_LOSE_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/A_MNTG_E.VQA: A_MNTG_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/H_BR01_E.VQA: H_BR01_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/H_BR02_E.VQA: H_BR02_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/H_BR03_E.VQA: H_BR03_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/H_BR04_E.VQA: H_BR04_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/H_BR05_E.VQA: H_BR05_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/H_BR06_E.VQA: H_BR06_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/H_BR07_E.VQA: H_BR07_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/H_BR08_E.VQA: H_BR08_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/H_BR09_E.VQA: H_BR09_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/H_FINL_E.VQA: H_FINL_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/H_LOSE_E.VQA: H_LOSE_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/H_MNTG_E.VQA: H_MNTG_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/O_BR01_E.VQA: O_BR01_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/O_BR02_E.VQA: O_BR02_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/O_BR03_E.VQA: O_BR03_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/O_BR04_E.VQA: O_BR04_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/O_BR05_E.VQA: O_BR05_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/O_BR06_E.VQA: O_BR06_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/O_BR07_E.VQA: O_BR07_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/O_BR08_E.VQA: O_BR08_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/O_BR09_E.VQA: O_BR09_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/O_FINL_E.VQA: O_FINL_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/O_LOSE_E.VQA: O_LOSE_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/O_MNTG_E.VQA: O_MNTG_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/G_INT1_E.VQA: G_INT1_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/G_INT2_E.VQA: G_INT2_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/G_MAPS_E.VQA: G_MAPS_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/G_PLN2_E.VQA: G_PLN2_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/G_PLNT_E.VQA: G_PLNT_E.VQA
+					^SupportDir|Content/d2k/v3/Movies/T_TITL_E.VQA: T_TITL_E.VQA

--- a/mods/d2k-content/mod.yaml
+++ b/mods/d2k-content/mod.yaml
@@ -95,7 +95,7 @@ ModContent:
 			Title: modcontent-package-briefings
 			Identifier: movies
 			TestFiles: ^SupportDir|Content/d2k/v3/Movies/A_BR01_E.VQA
-			Sources: d2k
+			Sources: d2k, gruntmods
 	Downloads:
 		d2kcontent|installer/downloads.yaml
 	Sources:


### PR DESCRIPTION
Fixes #16289 

Allows for installing dune 2000 movies from gruntmods. Requires that the user has installed the movies using the MissionLauncher (Part of the install wizard).
![image](https://github.com/user-attachments/assets/0518cf37-6c16-4ed7-af46-9e658f2a26f6)
