### PR TITLE
Improve the first frames of a match starting

### DIFF
--- a/OpenRA.Game/Traits/Player/Shroud.cs
+++ b/OpenRA.Game/Traits/Player/Shroud.cs
@@ -149,7 +149,7 @@ namespace OpenRA.Traits
 
 			ExploreMapEnabled = gs.OptionOrDefault("explored", info.ExploredMapCheckboxEnabled);
 			if (ExploreMapEnabled)
-				self.World.AddFrameEndTask(w => ExploreAll());
+				ExploreAll();
 
 			if (!fogEnabled && ExploreMapEnabled)
 				RevealedCells = map.ProjectedCells.Length;

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/MenuPostProcessEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/MenuPostProcessEffect.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new MenuPostProcessEffect(this); }
 	}
 
-	public class MenuPostProcessEffect : RenderPostProcessPassBase, IWorldLoaded, INotifyGameLoaded
+	public class MenuPostProcessEffect : RenderPostProcessPassBase, INotifyGameLoaded, IPostWorldLoaded
 	{
 		public enum EffectType { None, Black, Desaturated }
 		public readonly MenuPostProcessEffectInfo Info;
@@ -57,7 +57,8 @@ namespace OpenRA.Mods.Common.Traits
 			to = type;
 		}
 
-		protected override bool Enabled => to != EffectType.None || endTime != 0;
+		protected override bool Enabled => to != EffectType.None || (from != EffectType.None && Game.RunTime < endTime);
+
 		protected override void PrepareRender(WorldRenderer wr, IShader shader)
 		{
 			var blend = (endTime - Game.RunTime) * 1f / (endTime - startTime);
@@ -69,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 			shader.SetVec("Blend", blend);
 		}
 
-		void IWorldLoaded.WorldLoaded(World w, WorldRenderer wr)
+		void IPostWorldLoaded.PostWorldLoaded(World w, WorldRenderer wr)
 		{
 			// HACK: Defer fade-in until the GameLoaded notification for game saves
 			if (!w.IsLoadingGameSave)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -263,7 +263,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Game.RunAfterDelay(exitDelay, () =>
 				{
 					if (Game.IsCurrentWorld(world))
-						mpe.Fade(MenuPostProcessEffect.EffectType.Black);
+						mpe.Fade(mpe.Info.GameExitEffect);
 				});
 				exitDelay += 40 * mpe.Info.FadeLength;
 			}
@@ -288,7 +288,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void CloseMenu()
 		{
 			Ui.CloseWindow();
-			mpe?.Fade(MenuPostProcessEffect.EffectType.None);
+			mpe?.Fade(mpe.Info.Effect);
 			onExit();
 			Ui.ResetTooltips();
 		}
@@ -350,7 +350,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (mpe != null)
 				{
 					if (Game.IsCurrentWorld(world))
-						mpe.Fade(MenuPostProcessEffect.EffectType.Black);
+						mpe.Fade(mpe.Info.GameExitEffect);
 					exitDelay += 40 * mpe.Info.FadeLength;
 				}
 
@@ -545,7 +545,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						Ui.ResetTooltips();
 						void CloseMenu()
 						{
-							mpe?.Fade(MenuPostProcessEffect.EffectType.None);
+							mpe?.Fade(mpe.Info.Effect);
 							onExit();
 						}
 

--- a/mods/cnc/maps/blank-shellmap/map.yaml
+++ b/mods/cnc/maps/blank-shellmap/map.yaml
@@ -53,6 +53,7 @@ Rules:
 			DisableWorldSounds: true
 	# Used for rendering the EVA Database previews
 	^Palettes:
+		-MenuPostProcessEffect:
 		-PlayerColorPalette:
 		-PlayerColorShift:
 		IndexedPlayerPalette:

--- a/mods/cnc/rules/palettes.yaml
+++ b/mods/cnc/rules/palettes.yaml
@@ -106,6 +106,7 @@
 		ReferenceHue: 0.1
 		ReferenceSaturation: 0.75
 	MenuPostProcessEffect:
+		FadeInLength: 4
 		MenuEffect: Desaturated
 	CloakPaletteEffect:
 	FlashPostProcessEffect:

--- a/mods/d2k/maps/shellmap/rules.yaml
+++ b/mods/d2k/maps/shellmap/rules.yaml
@@ -20,6 +20,9 @@ World:
 	LuaScript:
 		Scripts: utils.lua, d2k-shellmap.lua
 
+^Palettes:
+	-MenuPostProcessEffect:
+
 ^ExistsInWorld:
 	-GivesExperience:
 

--- a/mods/d2k/rules/palettes.yaml
+++ b/mods/d2k/rules/palettes.yaml
@@ -26,6 +26,7 @@
 		BasePalette: d2k
 		RemapIndex: 255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240
 	MenuPostProcessEffect:
+		FadeInLength: 4
 	FlashPostProcessEffect:
 	ColorPickerColorShift:
 		BasePalette: colorpicker

--- a/mods/ra/maps/desert-shellmap/rules.yaml
+++ b/mods/ra/maps/desert-shellmap/rules.yaml
@@ -21,6 +21,9 @@ World:
 		Scripts: desert-shellmap.lua
 	-StartGameNotification:
 
+^Palettes:
+	-MenuPostProcessEffect:
+
 ^ExistsInWorld:
 	GivesExperience:
 		ActorExperienceModifier: 0

--- a/mods/ra/rules/palettes.yaml
+++ b/mods/ra/rules/palettes.yaml
@@ -75,6 +75,7 @@
 		BasePalette: player-noshadow
 		RemapIndex: 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95
 	MenuPostProcessEffect:
+		FadeInLength: 4
 	RotationPaletteEffect@defaultwater:
 		Palettes: terrain
 		ExcludeTilesets: DESERT

--- a/mods/ts/maps/fields-of-green/rules.yaml
+++ b/mods/ts/maps/fields-of-green/rules.yaml
@@ -18,6 +18,9 @@ World:
 		DisableWorldSounds: true
 		AllowMuteBackgroundMusic: true
 
+^Palettes:
+	-MenuPostProcessEffect:
+
 ^BaseWorld:
 	TerrainLighting:
 		BlueTint: 0.7

--- a/mods/ts/rules/palettes.yaml
+++ b/mods/ts/rules/palettes.yaml
@@ -157,3 +157,4 @@
 		Name: terrainalpha
 		Alpha: 0.55
 	MenuPostProcessEffect:
+		FadeInLength: 3


### PR DESCRIPTION
As the fade was called in `IWorldLoaded` and was dependent on actual time, it was partly or fully done before the first game render.

- Fixed by moving it to the new `IPostWorldLoaded` call
- I added customization and sped up load in speeds (because when they started actually following the requested timings, it looked bad)
- Fixed explored map not being revealed on the first tick