### PR TITLE
Fix a potential crash when cancelling capture

### DIFF
--- a/OpenRA.Mods.Common/Activities/CaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/CaptureActor.cs
@@ -152,7 +152,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		void CancelCapture()
 		{
-			manager.CancelCapture(enterCaptureManager);
+			manager.CancelCapture(enterActor, enterCaptureManager);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/CaptureManager.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureManager.cs
@@ -189,7 +189,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (target != currentTarget)
 			{
 				if (currentTargetManager != null)
-					CancelCapture(currentTargetManager);
+					CancelCapture(currentTarget, currentTargetManager);
 
 				targetManager.currentCaptors.Add(self);
 				currentTarget = target;
@@ -239,12 +239,11 @@ namespace OpenRA.Mods.Common.Traits
 		/// This method revokes the capturing conditions on the captor and target
 		/// and resets any capturing progress.
 		/// </summary>
-		public void CancelCapture(CaptureManager targetManager)
+		public void CancelCapture(Actor target, CaptureManager targetManager)
 		{
 			if (currentTarget == null)
 				return;
 
-			var target = targetManager.self;
 			foreach (var w in progressWatchers)
 				w.Update(self, self, target, 0, 0);
 


### PR DESCRIPTION
Closes #21800
Regression from #20261
Revert to #19617

In CaptureActor activity the target can optionally have a `CaptureManager`. The interesting thing is that a capture can't start if the target actor doesn't have a `CaptureManager`, something must happen to change the `Target` of `Enter` activity. 