### PR TITLE
Add missing campaign bots

### DIFF
--- a/mods/d2k/maps/ordos-06a/map.yaml
+++ b/mods/d2k/maps/ordos-06a/map.yaml
@@ -39,6 +39,7 @@ Players:
 		Enemies: Atreides, Harkonnen, Creeps
 	PlayerReference@Atreides:
 		Name: Atreides
+		Bot: campaign
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
@@ -47,6 +48,7 @@ Players:
 		Enemies: Ordos, Creeps
 	PlayerReference@Harkonnen:
 		Name: Harkonnen
+		Bot: campaign
 		LockFaction: True
 		Faction: harkonnen
 		LockColor: True

--- a/mods/ra/maps/allies-05b/map.yaml
+++ b/mods/ra/maps/allies-05b/map.yaml
@@ -26,6 +26,7 @@ Players:
 		Faction: allies
 	PlayerReference@USSR:
 		Name: USSR
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Allies: BadGuy

--- a/mods/ra/maps/allies-05c/map.yaml
+++ b/mods/ra/maps/allies-05c/map.yaml
@@ -26,12 +26,14 @@ Players:
 		Faction: allies
 	PlayerReference@USSR:
 		Name: USSR
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Allies: BadGuy
 		Enemies: Greece
 	PlayerReference@BadGuy:
 		Name: BadGuy
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Allies: USSR

--- a/mods/ra/maps/allies-10a/map.yaml
+++ b/mods/ra/maps/allies-10a/map.yaml
@@ -26,12 +26,14 @@ Players:
 		Faction: allies
 	PlayerReference@USSR:
 		Name: USSR
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Allies: BadGuy
 		Enemies: Greece
 	PlayerReference@BadGuy:
 		Name: BadGuy
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Allies: USSR

--- a/mods/ra/maps/allies-10b/map.yaml
+++ b/mods/ra/maps/allies-10b/map.yaml
@@ -26,6 +26,7 @@ Players:
 		Faction: england
 	PlayerReference@USSR:
 		Name: USSR
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Allies: BadGuy
@@ -44,6 +45,7 @@ Players:
 		Enemies: USSR, BadGuy
 	PlayerReference@BadGuy:
 		Name: BadGuy
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Allies: USSR

--- a/mods/ra/maps/allies-13/map.yaml
+++ b/mods/ra/maps/allies-13/map.yaml
@@ -26,6 +26,7 @@ Players:
 		Faction: england
 	PlayerReference@USSR:
 		Name: USSR
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Allies: BadGuy
@@ -50,6 +51,7 @@ Players:
 		Enemies: USSR, BadGuy
 	PlayerReference@BadGuy:
 		Name: BadGuy
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Allies: USSR

--- a/mods/ra/maps/ant-03/map.yaml
+++ b/mods/ra/maps/ant-03/map.yaml
@@ -26,6 +26,7 @@ Players:
 		Faction: allies
 	PlayerReference@BadGuy:
 		Name: BadGuy
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Allies: USSR

--- a/mods/ra/maps/fall-of-greece-1-personal-war/map.yaml
+++ b/mods/ra/maps/fall-of-greece-1-personal-war/map.yaml
@@ -26,6 +26,7 @@ Players:
 		Faction: allies
 	PlayerReference@England:
 		Name: England
+		Bot: campaign
 		Faction: allies
 		Color: A0F08C
 		Allies: GreekCivilians, Allies
@@ -50,12 +51,14 @@ Players:
 		Allies: England
 	PlayerReference@USSR:
 		Name: USSR
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Allies: BadGuy
 		Enemies: England, GreekCivilians, Allies
 	PlayerReference@BadGuy:
 		Name: BadGuy
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Allies: USSR

--- a/mods/ra/maps/fall-of-greece-2-evacuation/map.yaml
+++ b/mods/ra/maps/fall-of-greece-2-evacuation/map.yaml
@@ -50,6 +50,7 @@ Players:
 		Enemies: USSR
 	PlayerReference@USSR:
 		Name: USSR
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Enemies: Allies, England

--- a/mods/ra/maps/in-the-nick-of-time/map.yaml
+++ b/mods/ra/maps/in-the-nick-of-time/map.yaml
@@ -26,11 +26,13 @@ Players:
 		Faction: england
 	PlayerReference@USSR:
 		Name: USSR
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Enemies: Greece
 	PlayerReference@GoodGuy:
 		Name: GoodGuy
+		Bot: campaign
 		Faction: allies
 		Color: E2E6F6
 		Allies: Greece

--- a/mods/ra/maps/sarin-gas-3-controlled-burn/map.yaml
+++ b/mods/ra/maps/sarin-gas-3-controlled-burn/map.yaml
@@ -30,12 +30,14 @@ Players:
 		Faction: england
 	PlayerReference@BadGuy:
 		Name: BadGuy
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Allies: USSR
 		Enemies: Greece
 	PlayerReference@USSR:
 		Name: USSR
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Allies: BadGuy

--- a/mods/ra/maps/shock-therapy/map.yaml
+++ b/mods/ra/maps/shock-therapy/map.yaml
@@ -26,18 +26,21 @@ Players:
 		Faction: england
 	PlayerReference@Spain:
 		Name: Spain
+		Bot: campaign
 		Faction: allies
 		Color: F6D679
 		Allies: Greece, GoodGuy
 		Enemies: USSR
 	PlayerReference@Greece:
 		Name: Greece
+		Bot: campaign
 		Faction: allies
 		Color: E2E6F6
 		Allies: Spain, GoodGuy
 		Enemies: USSR
 	PlayerReference@GoodGuy:
 		Name: GoodGuy
+		Bot: campaign
 		Faction: allies
 		Color: E2E6F6
 		Allies: Spain, Greece

--- a/mods/ra/maps/siberian-conflict-1-fresh-tracks/map.yaml
+++ b/mods/ra/maps/siberian-conflict-1-fresh-tracks/map.yaml
@@ -49,6 +49,7 @@ Players:
 		Enemies: USSR
 	PlayerReference@USSR:
 		Name: USSR
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Enemies: Allies, England

--- a/mods/ra/maps/siberian-conflict-3-wasteland/map.yaml
+++ b/mods/ra/maps/siberian-conflict-3-wasteland/map.yaml
@@ -26,12 +26,14 @@ Players:
 		Faction: allies
 	PlayerReference@USSR:
 		Name: USSR
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Allies: BadGuy
 		Enemies: USSR, Allies
 	PlayerReference@BadGuy:
 		Name: BadGuy
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Allies: USSR

--- a/mods/ra/maps/soviet-13a/map.yaml
+++ b/mods/ra/maps/soviet-13a/map.yaml
@@ -33,6 +33,7 @@ Players:
 		Enemies: USSR
 	PlayerReference@GoodGuy:
 		Name: GoodGuy
+		Bot: campaign
 		Faction: allies
 		Color: E2E6F6
 		Allies: Greece

--- a/mods/ra/maps/soviet-13b/map.yaml
+++ b/mods/ra/maps/soviet-13b/map.yaml
@@ -33,6 +33,7 @@ Players:
 		Enemies: USSR
 	PlayerReference@GoodGuy:
 		Name: GoodGuy
+		Bot: campaign
 		Faction: allies
 		Color: E2E6F6
 		Allies: Greece


### PR DESCRIPTION
Some players in missions were missing their campaign bots. I have added those, with some exceptions:
- Allies 13: Focused Blast
  - England is only used to color flares, while Turkey owns a lone Flame Tower.
- Fall of Greece 2: Evacuation
  - Greece only owns the civilian houses, while England only owns the evacuation center.
- Mousetrap:
  - England is only used to color flares.
- Siberian Conflict 1: Fresh Tracks
  - England seems to be unused but would not be a combatant. The original map used green flares to mark convoy paths.
- Ants 3: Hunt!
  - USSR owns the abandoned base and does nothing.

----

I recently replayed Tanya's Tale (C), and it became clear that the USSR player lacked a campaign bot. Units would stand still while being pummeled by artillery, whereas they'd retaliate in other maps. I launched the rest of the missions after I added  this function to the end of common\scripts\utils.lua:

```lua
local function FindHeadlessBots()
	local headlessBots = Player.GetPlayers(function(player)
		local nonLocal = not player.IsLocalPlayer
		local combatant = not player.IsNonCombatant
		local botSkipped = not player.IsBot

		return nonLocal and combatant and botSkipped
	end)

	Utils.Do(headlessBots, function(hb)
		Media.Debug("Headless bot found: " .. tostring(hb))
	end)
end

Trigger.AfterDelay(3, FindHeadlessBots)
```

That seemed to work well enough and came back with multiple hits which are corrected here.
