### PR TITLE
Fix FlashPostProcessEffect channel order.

### DIFF
--- a/OpenRA.Mods.Common/Traits/PaletteEffects/FlashPostProcessEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/FlashPostProcessEffect.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 		protected override void PrepareRender(WorldRenderer wr, IShader shader)
 		{
 			shader.SetVec("Blend", blend);
-			shader.SetVec("Color", (float)Info.Color.B / 255, (float)Info.Color.G / 255, (float)Info.Color.R / 255);
+			shader.SetVec("Color", (float)Info.Color.R / 255, (float)Info.Color.G / 255, (float)Info.Color.B / 255);
 		}
 	}
 }


### PR DESCRIPTION
Testcase: add `Color: FF0000` to `FlashPostProcessEffect` used by the a-bomb.