### PR TITLE
Fix wrong Spread on some Warheads

### DIFF
--- a/mods/d2k/weapons/debris.yaml
+++ b/mods/d2k/weapons/debris.yaml
@@ -12,7 +12,7 @@ Debris:
 		BounceRangeModifier: 20
 	Warhead@1Dam: SpreadDamage
 		Damage: 1500
-		Spread: 512
+		Spread: 1c0
 		Falloff: 100, 0
 		Versus:
 			none: 20
@@ -44,7 +44,7 @@ Debris2:
 		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
 		Damage: 2500
-		Spread: 1c0
+		Spread: 2c0
 		Versus:
 			none: 90
 			wall: 5

--- a/mods/d2k/weapons/largeguns.yaml
+++ b/mods/d2k/weapons/largeguns.yaml
@@ -9,7 +9,7 @@
 		Image: 120mm
 	Warhead@1Dam: SpreadDamage
 		Damage: 2700
-		Spread: 756
+		Spread: 1c0
 		Falloff: 100, 0
 		Versus:
 			none: 30

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -12,7 +12,7 @@
 		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
 		Damage: 3000
-		Spread: 700
+		Spread: 1c0
 		Falloff: 100, 0
 		Versus:
 			none: 15

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -145,7 +145,7 @@ DeathHandCluster:
 CrateExplosion:
 	Warhead@1Dam: SpreadDamage
 		Damage: 5000
-		Spread: 1c0
+		Spread: 2c0
 		Falloff: 100, 0
 		Versus:
 			none: 90
@@ -218,7 +218,7 @@ grenade:
 		Shadow: true
 	Warhead@1Dam: SpreadDamage
 		Damage: 1500
-		Spread: 1c512
+		Spread: 2c0
 		Falloff: 100, 0
 		Versus:
 			none: 135
@@ -247,7 +247,7 @@ grenade:
 GrenDeath:
 	Warhead@1Dam: SpreadDamage
 		Damage: 1500
-		Spread: 1c0
+		Spread: 2c0
 		Falloff: 100, 0
 		Versus:
 			none: 125


### PR DESCRIPTION
According to D2k editor we have wrong spread values on some Warheads. Before we start balancing D2k we should have default values.
Radius  32 is same as  1c0 ORA.
 64  is same as 2c0. etc.
![d2k-Warhead Spread](https://github.com/user-attachments/assets/47d6dc2d-a77e-4462-8eaf-0b37d240019a)
