### PR TITLE
DockClientManager: enter cursor per DockHost's DockType

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoDockClientManager.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoDockClientManager.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Primitives;
 using OpenRA.Traits;
+using static OpenRA.Mods.Common.Traits.DockActorTargeter;
 
 namespace OpenRA.Mods.Common.Traits
 {
@@ -66,12 +67,18 @@ namespace OpenRA.Mods.Common.Traits
 			get
 			{
 				yield return new DockActorTargeter(
-					6,
-					Info.EnterCursor,
-					Info.EnterBlockedCursor,
-					() => Info.RequiresForceMove,
-					CanQueueDockAt,
-					CanDockAt);
+					priority: 6,
+					context =>
+					{
+						if (Info.RequiresForceMove && !context.ForceEnter)
+							return CanTargetResult.Blocked(Info.EnterCursor);
+
+						if (!CanQueueDockAt(context.Target.Actor, context.ForceEnter, context.IsQueued))
+							return CanTargetResult.Blocked(Info.EnterCursor);
+
+						var cursor = context.IsQueued || CanDockAt(context.Target.Actor, context.ForceEnter) ? Info.EnterCursor : Info.EnterBlockedCursor;
+						return CanTargetResult.Allowed(cursor);
+					});
 			}
 		}
 


### PR DESCRIPTION
Currently, `DockClientManager` supports only single enter cursor. This PR adds support for multiple cursors - one cursor per `DockType`. Keeps backward compatibility with existing mods by defining extra property `EnterCursorOverrides` and having `EnterCursor` as fallback if `EnterCursorOverrides` are not configured.

(Contrived) test case:
- standard Harvester uses default enter cursor on both custom and standard Refinery
- custom Harvester uses custom cursor for custom Refinery

![openra_EnterCursorOverrides](https://github.com/user-attachments/assets/8289c23f-7473-4873-889a-e3d1b27df729)

Real life use case in OpenE2140 mod:
- both mobile and flying crate transporters use different cursor for Mine (on the left) and Refinery (on the right)

![opene2140_dockclientmanager_entercursor_per_docktype](https://github.com/user-attachments/assets/99374791-caf6-4f93-950e-388b6467d3b3)
