### PR TITLE
Fix camera being in an incorrect position of first frame

### DIFF
--- a/mods/d2k/maps/shellmap/d2k-shellmap.lua
+++ b/mods/d2k/maps/shellmap/d2k-shellmap.lua
@@ -201,4 +201,6 @@ WorldLoaded = function()
 		Produce(Corrino, CorrinoTankTypes)
 		Produce(Corrino, CorrinoStarportTypes)
 	end)
+
+	Tick()
 end


### PR DESCRIPTION
Split from #21799 for prep

The D2K shellmap has camera in the wrong position on the first tick, which lead to a weird flash