### PR TITLE
Fix resource calculation

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -160,7 +160,9 @@ namespace OpenRA.Mods.Common.Traits
 						++adjacent;
 				}
 
-				// Adjacent includes the current cell, so is always >= 1
+				// We need to have at least one resource in the cell.
+				// HACK: we should not be lerping to 9, as maximum adjacent resources is 8.
+				// HACK: it's too disruptive to fix.
 				var density = Math.Max(int2.Lerp(0, resourceInfo.MaxDensity, adjacent, 9), 1);
 				Content[cell] = new ResourceLayerContents(resource.Type, density);
 			}


### PR DESCRIPTION
Closes #21147
#13318 was an incorrect fix to #13299

The issue was in the neighbor calculation, in ResourceLayer we don't count ourselves as an adjacent tile, while in EditorResourceLayer we did. Now as the calculations match the resource counters match as well