### PR TITLE
Fix units being picked up when they no longer want it

### DIFF
--- a/OpenRA.Mods.Common/Activities/MoveToDock.cs
+++ b/OpenRA.Mods.Common/Activities/MoveToDock.cs
@@ -115,6 +115,9 @@ namespace OpenRA.Mods.Common.Activities
 			}
 			else
 			{
+				foreach (var ndcm in notifyDockClientMoving)
+					ndcm.MovementCancelled(self);
+
 				// The dock explicitly chosen by the user is currently occupied. Wait and check again.
 				QueueChild(new Wait(dockClient.Info.SearchForDockDelay));
 				return false;

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -158,6 +158,9 @@ namespace OpenRA.Mods.Common.Activities
 			if (!actualResupplyStarted && activeResupplyTypes > 0)
 			{
 				actualResupplyStarted = true;
+				foreach (var t in transportCallers)
+					t.MovementCancelled(self);
+
 				foreach (var notifyResupply in notifyResupplies)
 					notifyResupply.BeforeResupply(host.Actor, self, activeResupplyTypes);
 

--- a/OpenRA.Mods.Common/Traits/CarryableHarvester.cs
+++ b/OpenRA.Mods.Common/Traits/CarryableHarvester.cs
@@ -52,6 +52,10 @@ namespace OpenRA.Mods.Common.Traits
 				t.MovementCancelled(self);
 		}
 
-		void INotifyHarvestAction.Harvested(Actor self, string resourceType) { }
+		void INotifyHarvestAction.Harvested(Actor self, string resourceType)
+		{
+			foreach (var t in transports)
+				t.MovementCancelled(self);
+		}
 	}
 }


### PR DESCRIPTION
Reported on discord

Reproduction:
- Have 1 carryall and 2 damaged units
- Call the units to repair
- After repairing have the units drive away from the service depot
- The service depot will deliver the formerly undelivered unit (the one that walked or drove) back for repairs

`AutoCarryable` requests pickup via having `Destination` set, and will continue requesting until picked up. We need to unset it.