### PR TITLE
Fix PBOG offset not accounting for zoom.

### DIFF
--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -154,7 +154,7 @@ namespace OpenRA.Mods.Common.Orders
 			{
 				var offsetPos = Viewport.LastMousePos;
 				if (variants[variant].Preview != null)
-					offsetPos += variants[variant].Preview.TopLeftScreenOffset;
+					offsetPos = viewport.WorldToViewPx(viewport.ViewToWorldPx(offsetPos) + variants[variant].Preview.TopLeftScreenOffset);
 
 				return viewport.ViewToWorld(offsetPos);
 			}


### PR DESCRIPTION
`TopLeftScreenOffset` is defined in world pixels, while `offsetPos` is in viewport pixels. The two differ by a factor of the viewport zoom, which in the default mods is close enough to 1 for the mismatch to go unnoticed. This is not true for TDHD, which ends up with visibly incorrect place building preview positions.

This PR fixes the offset to work correctly for any zoom level.