### PR TITLE
Fix incorrect tile definition

### DIFF
--- a/mods/cnc/tilesets/winter.yaml
+++ b/mods/cnc/tilesets/winter.yaml
@@ -2354,7 +2354,7 @@ Templates:
 	Template@184:
 		Id: 184
 		Images: p19.win
-		Size: 6,2
+		Size: 4,3
 		Categories: Debris
 		Tiles:
 			2: Clear


### PR DESCRIPTION
Fixes #21058 

Due to the way tiles are encoded, this change doesn't effect already existing maps