### PR TITLE
MiniYaml.From* methods support deferred execution.

### DIFF
--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -110,7 +110,7 @@ namespace OpenRA
 			Package = package;
 
 			var stringPool = new HashSet<string>(); // Reuse common strings in YAML
-			var nodes = MiniYaml.FromStream(package.GetStream("mod.yaml"), $"{package.Name}:mod.yaml", stringPool: stringPool);
+			var nodes = MiniYaml.FromStream(package.GetStream("mod.yaml"), $"{package.Name}:mod.yaml", stringPool: stringPool).ToList();
 			for (var i = nodes.Count - 1; i >= 0; i--)
 			{
 				if (nodes[i].Key != "Include")

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -113,7 +113,7 @@ namespace OpenRA
 				return key == "world" || key == "player";
 			}
 
-			public void SetCustomRules(ModData modData, IReadOnlyFileSystem fileSystem, Dictionary<string, MiniYaml> yaml, IEnumerable<List<MiniYamlNode>> modDataRules)
+			public void SetCustomRules(ModData modData, IReadOnlyFileSystem fileSystem, Dictionary<string, MiniYaml> yaml, MiniYamlNode[][] modDataRules)
 			{
 				RuleDefinitions = LoadRuleSection(yaml, "Rules");
 				WeaponDefinitions = LoadRuleSection(yaml, "Weapons");
@@ -341,7 +341,7 @@ namespace OpenRA
 		/// A new copy of the map package will be opened lazily when needed.
 		/// </summary>
 		public void UpdateFromMapWithoutOwningPackage(IReadOnlyPackage p, IReadOnlyPackage parent, MapClassification classification,
-			MapGridType? gridType = null, IEnumerable<List<MiniYamlNode>> modDataRules = null)
+			MapGridType? gridType = null, MiniYamlNode[][] modDataRules = null)
 		{
 			UpdateFromMap(p, classification, gridType, modDataRules);
 			parentPackage = parent;
@@ -353,7 +353,7 @@ namespace OpenRA
 		/// The package remains in memory and must not be disposed.
 		/// </summary>
 		public void UpdateFromMap(IReadOnlyPackage p, MapClassification classification,
-			MapGridType? gridType = null, IEnumerable<List<MiniYamlNode>> modDataRules = null)
+			MapGridType? gridType = null, MiniYamlNode[][] modDataRules = null)
 		{
 			Path = p.Name;
 			package = p;

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -154,10 +154,10 @@ namespace OpenRA
 					entry.Value.Load(map);
 		}
 
-		public List<MiniYamlNode>[] GetRulesYaml()
+		public MiniYamlNode[][] GetRulesYaml()
 		{
 			var stringPool = new HashSet<string>(); // Reuse common strings in YAML
-			return Manifest.Rules.Select(s => MiniYaml.FromStream(DefaultFileSystem.Open(s), s, stringPool: stringPool)).ToArray();
+			return Manifest.Rules.Select(s => MiniYaml.FromStream(DefaultFileSystem.Open(s), s, stringPool: stringPool).ToArray()).ToArray();
 		}
 
 		public void Dispose()

--- a/OpenRA.Game/Network/GameSave.cs
+++ b/OpenRA.Game/Network/GameSave.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Network
 				lastSyncPacket = rs.ReadBytes(Order.SyncHashOrderLength);
 
 				var globalSettings = MiniYaml.FromString(rs.ReadLengthPrefixedString(Encoding.UTF8, Connection.MaxOrderLength), $"{filepath}:globalSettings");
-				GlobalSettings = Session.Global.Deserialize(globalSettings[0].Value);
+				GlobalSettings = Session.Global.Deserialize(globalSettings.First().Value);
 
 				var slots = MiniYaml.FromString(rs.ReadLengthPrefixedString(Encoding.UTF8, Connection.MaxOrderLength), $"{filepath}:slots");
 				Slots = [];

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -183,7 +183,7 @@ namespace OpenRA.Network
 
 					if (!string.IsNullOrEmpty(order.TargetString))
 					{
-						var data = MiniYaml.FromString(order.TargetString, order.OrderString);
+						var data = MiniYaml.FromString(order.TargetString, order.OrderString).ToList();
 						var saveLastOrdersFrame = data.FirstOrDefault(n => n.Key == "SaveLastOrdersFrame");
 						if (saveLastOrdersFrame != null)
 							orderManager.GameSaveLastFrame =
@@ -203,7 +203,7 @@ namespace OpenRA.Network
 
 				case "SaveTraitData":
 				{
-					var data = MiniYaml.FromString(order.TargetString, order.OrderString)[0];
+					var data = MiniYaml.FromString(order.TargetString, order.OrderString).First();
 					var traitIndex = Exts.ParseInt32Invariant(data.Key);
 
 					world?.AddGameSaveTraitData(traitIndex, data.Value);

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -1016,7 +1016,7 @@ namespace OpenRA.Server
 					{
 						if (GameSave != null)
 						{
-							var data = MiniYaml.FromString(o.TargetString, o.OrderString)[0];
+							var data = MiniYaml.FromString(o.TargetString, o.OrderString).First();
 							GameSave.AddTraitData(OpenRA.Exts.ParseInt32Invariant(data.Key), data.Value);
 						}
 

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -348,7 +348,7 @@ namespace OpenRA
 
 				if (File.Exists(settingsFile))
 				{
-					yamlCache = MiniYaml.FromFile(settingsFile, false);
+					yamlCache = MiniYaml.FromFile(settingsFile, false).ToList();
 					foreach (var yamlSection in yamlCache)
 					{
 						if (yamlSection.Key != null && Sections.TryGetValue(yamlSection.Key, out var settingsSection))

--- a/OpenRA.Game/StreamExts.cs
+++ b/OpenRA.Game/StreamExts.cs
@@ -211,7 +211,7 @@ namespace OpenRA
 				{
 					var offset = 0;
 					int read;
-					while ((read = sr.ReadBlock(buffer, offset, buffer.Length - offset)) != 0)
+					while ((read = sr.Read(buffer, offset, buffer.Length - offset)) != 0)
 					{
 						offset += read;
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20230225/ExplicitSequenceFilenames.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20230225/ExplicitSequenceFilenames.cs
@@ -38,7 +38,8 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			// Keep a resolved copy of the sequences so we can account for values imported through inheritance or Defaults.
 			// This will be modified during processing, so take a deep copy to avoid side-effects on other update rules.
 			this.resolvedImagesNodes = MiniYaml.FromString(resolvedImagesNodes.WriteToString(), nameof(BeforeUpdateSequences))
-				.ConvertAll(n => new MiniYamlNodeBuilder(n));
+				.Select(n => new MiniYamlNodeBuilder(n))
+				.ToList();
 
 			var requiredMetadata = new HashSet<string>();
 			foreach (var imageNode in resolvedImagesNodes)
@@ -286,7 +287,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 						imageNode.Value.Nodes.Insert(inheritsNodeIndex, defaultsNode);
 					}
 
-					var nodes = MiniYaml.FromString(duplicateTilesetCount.First(kv => kv.Value == maxDuplicateTilesetCount).Key, nameof(UpdateSequenceNode));
+					var nodes = MiniYaml.FromString(duplicateTilesetCount.First(kv => kv.Value == maxDuplicateTilesetCount).Key, nameof(UpdateSequenceNode)).ToList();
 					defaultTilesetFilenamesNode = new MiniYamlNodeBuilder("TilesetFilenames", "", nodes);
 					defaultsNode.Value.Nodes.Insert(0, defaultTilesetFilenamesNode);
 				}

--- a/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
@@ -40,7 +40,8 @@ namespace OpenRA.Mods.Common.UpdateRules
 					name,
 					MiniYaml
 						.FromStream(package.GetStream(name), $"{package.Name}:{name}", false)
-						.ConvertAll(n => new MiniYamlNodeBuilder(n))));
+						.Select(n => new MiniYamlNodeBuilder(n))
+						.ToList()));
 			}
 
 			return yaml;
@@ -78,7 +79,8 @@ namespace OpenRA.Mods.Common.UpdateRules
 						filename,
 						MiniYaml
 							.FromStream(mapPackage.GetStream(filename), $"{mapPackage.Name}:{filename}", false)
-							.ConvertAll(n => new MiniYamlNodeBuilder(n))));
+							.Select(n => new MiniYamlNodeBuilder(n))
+							.ToList()));
 				else if (modData.ModFiles.Exists(filename))
 					externalFilenames.Add(filename);
 			}
@@ -104,7 +106,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 					return manualSteps;
 				}
 
-				var yaml = new MiniYamlBuilder(null, MiniYaml.FromStream(mapStream, $"{mapPackage.Name}:map.yaml", false));
+				var yaml = new MiniYamlBuilder(null, MiniYaml.FromStream(mapStream, $"{mapPackage.Name}:map.yaml", false).ToList());
 				files = [(mapPackage, "map.yaml", yaml.Nodes)];
 
 				manualSteps.AddRange(rule.BeforeUpdate(modData));

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractChromeStrings.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractChromeStrings.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					modData.ModFiles.TryGetPackageContaining(chrome, out var chromePackage, out var chromeName);
 					var chromePath = Path.Combine(chromePackage.Name, chromeName);
 
-					var yaml = MiniYaml.FromFile(chromePath, false).ConvertAll(n => new MiniYamlNodeBuilder(n));
+					var yaml = MiniYaml.FromFile(chromePath, false).Select(n => new MiniYamlNodeBuilder(n)).ToList();
 					yamlSet.Add(((IReadWritePackage)chromePackage, chromeName, yaml));
 
 					var extractionCandidates = new List<ExtractionCandidate>();

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractYamlStrings.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractYamlStrings.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					if (mapStream == null)
 						continue;
 
-					var yaml = new MiniYamlBuilder(null, MiniYaml.FromStream(mapStream, $"{package.Name}:map.yaml", false));
+					var yaml = new MiniYamlBuilder(null, MiniYaml.FromStream(mapStream, $"{package.Name}:map.yaml", false).ToList());
 					var mapRulesNode = yaml.NodeWithKeyOrDefault("Rules");
 					if (mapRulesNode != null)
 						modRules.AddRange(UpdateUtils.LoadExternalMapYaml(modData, mapRulesNode.Value, []));
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					if (mapStream == null)
 						continue;
 
-					var yaml = new MiniYamlBuilder(null, MiniYaml.FromStream(mapStream, $"{package.Name}:map.yaml", false));
+					var yaml = new MiniYamlBuilder(null, MiniYaml.FromStream(mapStream, $"{package.Name}:map.yaml", false).ToList());
 					var mapRules = new YamlFileSet() { (package, "map.yaml", yaml.Nodes) };
 
 					var mapRulesNode = yaml.NodeWithKeyOrDefault("Rules");

--- a/OpenRA.Mods.Common/UtilityCommands/PngSheetImportMetadataCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/PngSheetImportMetadataCommand.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			using (var pngStream = File.OpenRead(args[1]))
 				png = new Png(pngStream);
 
-			var yaml = MiniYaml.FromFile(Path.ChangeExtension(args[1], "yaml"));
+			var yaml = MiniYaml.FromFile(Path.ChangeExtension(args[1], "yaml")).ToList();
 
 			var frameSizeField = yaml.Where(y => y.Key == "FrameSize").Select(y => y.Value.Value).FirstOrDefault();
 			if (frameSizeField != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -492,7 +492,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							continue;
 
 						var game = new MiniYamlBuilder(MiniYaml.FromString(
-							bl.Data, $"BeaconLocation_{bl.Address}_{bl.LastAdvertised:s}", stringPool: stringPool)[0].Value);
+							bl.Data, $"BeaconLocation_{bl.Address}_{bl.LastAdvertised:s}", stringPool: stringPool).First().Value);
 						var idNode = game.NodeWithKeyOrDefault("Id");
 
 						// Skip beacons created by this instance and replace Id by expected int value


### PR DESCRIPTION
Previously, the MiniYaml.From* helpers such as FromStream would consume the entire input and then return a list of top-level nodes. Now, the input is processed using deferred execution and top-level nodes are yielded as they are resolved from the input.

The motivating use-case is MapCache, which currently manually buffers nodes before passing to MiniYaml.FromString in order to improve responsiveness when large payloads are processed. Now that MiniYaml.FromStream yields results back as they come in, we can switch to that without disadvantage.

The maintains the performance where map cache can update search results as each node comes in over the network rather than having to wait for the entire batch to be transferred. Now we can also remove the string buffer that captures each node, reducing memory pressure and simplifying the code.

----

Follow-up to #21831