### PR TITLE
Implement WavStreams Length property

### DIFF
--- a/OpenRA.Mods.Common/FileFormats/WavReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/WavReader.cs
@@ -122,6 +122,8 @@ namespace OpenRA.Mods.Common.FileFormats
 			int outOffset;
 			int currentBlock;
 
+			public override long Length => outputSize;
+
 			public WavStreamImaAdpcm(Stream stream, int dataSize, short blockAlign, short channels, int uncompressedSize)
 				: base(stream)
 			{
@@ -206,15 +208,19 @@ namespace OpenRA.Mods.Common.FileFormats
 
 			static readonly int[] AdaptCoeff2 = [0, -256, 0, 64, 0, -208, -232];
 
+			readonly int dataSize;
 			readonly short channels;
 			readonly int blockDataSize;
 			readonly int numBlocks;
 
 			int currentBlock;
 
+			public override long Length => dataSize;
+
 			public WavStreamMsAdpcm(Stream stream, int dataSize, short blockAlign, short channels)
 				: base(stream)
 			{
+				this.dataSize = dataSize;
 				this.channels = channels;
 				blockDataSize = blockAlign - channels * 7;
 				numBlocks = dataSize / blockAlign;


### PR DESCRIPTION
These would be queried when music WAV files are loaded as an optimization attempt to initialize a buffer stream, but that would backfire poorly when they throw `NotSupportedExceptions`.

The default mods all seem to be using AUD for music and for some bizarre reason this code path is quite specific, so we never felt the issue there. A `try/catch` in the offending spot - `OpenAlAsyncLoadSound` has apparently been masking this for RA2 for a while as well.

I am unsure what the `uncompressedSize` in `WavStreamImaAdpcm` is, but to me it feels like quite the opposite - compressed size. 
![image](https://github.com/user-attachments/assets/5333def3-cce8-40a1-8fc1-303f4d462bdd)

As for `WavStreamMsAdpcm` the proposed `Length => dataSize` is pure speculation on my part.

P.S.: I am actually very inclined to remove the first `try/catch` from `OpenAlAsyncLoadSound` now. Thoughts?

P.P.S.: Noticed as part of https://github.com/OpenRA/ra2/pull/811.