### PR TITLE
Support relaxed end points in TilingPath

### DIFF
--- a/OpenRA.Mods.Common/MapGenerator/MatrixUtils.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MatrixUtils.cs
@@ -15,6 +15,7 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using OpenRA.Primitives;
+using OpenRA.Support;
 
 namespace OpenRA.Mods.Common.MapGenerator
 {
@@ -1501,6 +1502,35 @@ namespace OpenRA.Mods.Common.MapGenerator
 				matrix[i] = (int)((long)matrix[i] * targetAmplitude / inputAmplitude);
 
 			return matrix;
+		}
+
+		/// <summary>
+		/// Rank all cell values and select the best (greatest compared) value.
+		/// If there are equally good best candidates, choose one at random.
+		/// </summary>
+		public static (int2 MPos, T Value) FindRandomBest<T>(
+			Matrix<T> matrix,
+			MersenneTwister random,
+			Comparison<T> comparison)
+		{
+			var candidates = new List<int2>();
+			var best = matrix[new int2(0, 0)];
+			for (var y = 0; y < matrix.Size.Y; y++)
+				for (var x = 0; x < matrix.Size.X; x++)
+				{
+					var rank = comparison(matrix[x, y], best);
+					if (rank > 0)
+					{
+						best = matrix[x, y];
+						candidates.Clear();
+					}
+
+					if (rank >= 0)
+						candidates.Add(new int2(x, y));
+				}
+
+			var choice = candidates[random.Next(candidates.Count)];
+			return (choice, best);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/ExperimentalMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/ExperimentalMapGenerator.cs
@@ -662,6 +662,7 @@ namespace OpenRA.Mods.Common.Traits
 						beachPermittedTemplates);
 					beachPath
 						.ExtendEdge(4)
+						.SetAutoEndDeviation()
 						.OptimizeLoop();
 					tiledBeaches[i] =
 						beachPath.Tile(beachTilingRandom)
@@ -728,6 +729,7 @@ namespace OpenRA.Mods.Common.Traits
 							nonLoopedCliffPermittedTemplates);
 					cliffPath
 						.ExtendEdge(4)
+						.SetAutoEndDeviation()
 						.OptimizeLoop();
 					if (cliffPath.Tile(cliffTilingRandom) == null)
 						throw new MapGenerationException("Could not fit tiles for exterior circle cliffs");
@@ -808,6 +810,7 @@ namespace OpenRA.Mods.Common.Traits
 								nonLoopedCliffPermittedTemplates);
 						cliffPath
 							.ExtendEdge(4)
+							.SetAutoEndDeviation()
 							.OptimizeLoop();
 						if (cliffPath.Tile(cliffTilingRandom) == null)
 							throw new MapGenerationException("Could not fit tiles for cliffs");
@@ -1172,6 +1175,7 @@ namespace OpenRA.Mods.Common.Traits
 						.ExtendEdge(2 * roadTotalShrink + RoadMinimumShrinkLength)
 						.Shrink(roadTotalShrink, RoadMinimumShrinkLength)
 						.InertiallyExtend(RoadStraightenGrow, RoadInertialRange)
+						.SetAutoEndDeviation()
 						.OptimizeLoop()
 						.RetainIfValid();
 

--- a/mods/cnc/tilesets/desert.yaml
+++ b/mods/cnc/tilesets/desert.yaml
@@ -1069,16 +1069,6 @@ Templates:
 				Inner: Road
 				Points: 2,1, 2,0
 				Start: Clear.U
-			Segment@1extended:
-				End: Clear.D
-				Inner: Road
-				Points: 1,0, 1,1, 1,2
-				Start: Road.D
-			Segment@2extended:
-				End: Road.U
-				Inner: Road
-				Points: 2,2, 2,1, 2,0
-				Start: Clear.U
 	Template@94:
 		Id: 94
 		Images: d02.des
@@ -1100,16 +1090,6 @@ Templates:
 				Inner: Road
 				Points: 1,1, 2,1
 				Start: Clear.R
-			Segment@1extended:
-				End: Clear.L
-				Inner: Road
-				Points: 2,0, 1,0, 0,0
-				Start: Road.L
-			Segment@2extended:
-				End: Road.R
-				Inner: Road
-				Points: 0,1, 1,1, 2,1
-				Start: Clear.R
 	Template@95:
 		Id: 95
 		Images: d03.des
@@ -1128,16 +1108,6 @@ Templates:
 				End: Road.D
 				Inner: Road
 				Points: 0,1, 0,2
-				Start: Clear.D
-			Segment@1extended:
-				End: Clear.U
-				Inner: Road
-				Points: 1,2, 1,1, 1,0
-				Start: Road.U
-			Segment@2extended:
-				End: Road.D
-				Inner: Road
-				Points: 0,0, 0,1, 0,2
 				Start: Clear.D
 	Template@96:
 		Id: 96
@@ -1158,16 +1128,6 @@ Templates:
 				End: Road.L
 				Inner: Road
 				Points: 1,1, 0,1
-				Start: Clear.L
-			Segment@1extended:
-				End: Clear.R
-				Inner: Road
-				Points: 0,2, 1,2, 2,2
-				Start: Road.R
-			Segment@2extended:
-				End: Road.L
-				Inner: Road
-				Points: 2,1, 1,1, 0,1
 				Start: Clear.L
 	Template@97:
 		Id: 97

--- a/mods/cnc/tilesets/snow.yaml
+++ b/mods/cnc/tilesets/snow.yaml
@@ -1143,16 +1143,6 @@ Templates:
 				Inner: Road
 				Points: 2,1, 2,0
 				Start: Clear.U
-			Segment@1extended:
-				End: Clear.D
-				Inner: Road
-				Points: 1,0, 1,1, 1,2
-				Start: Road.D
-			Segment@2extended:
-				End: Road.U
-				Inner: Road
-				Points: 2,2, 2,1, 2,0
-				Start: Clear.U
 	Template@94:
 		Id: 94
 		Images: d02.sno
@@ -1174,16 +1164,6 @@ Templates:
 				Inner: Road
 				Points: 1,1, 2,1
 				Start: Clear.R
-			Segment@1extended:
-				End: Clear.L
-				Inner: Road
-				Points: 2,0, 1,0, 0,0
-				Start: Road.L
-			Segment@2extended:
-				End: Road.R
-				Inner: Road
-				Points: 0,1, 1,1, 2,1
-				Start: Clear.R
 	Template@95:
 		Id: 95
 		Images: d03.sno
@@ -1202,16 +1182,6 @@ Templates:
 				End: Road.D
 				Inner: Road
 				Points: 0,1, 0,2
-				Start: Clear.D
-			Segment@1extended:
-				End: Clear.U
-				Inner: Road
-				Points: 1,2, 1,1, 1,0
-				Start: Road.U
-			Segment@2extended:
-				End: Road.D
-				Inner: Road
-				Points: 0,0, 0,1, 0,2
 				Start: Clear.D
 	Template@96:
 		Id: 96
@@ -1232,16 +1202,6 @@ Templates:
 				End: Road.L
 				Inner: Road
 				Points: 1,1, 0,1
-				Start: Clear.L
-			Segment@1extended:
-				End: Clear.R
-				Inner: Road
-				Points: 0,2, 1,2, 2,2
-				Start: Road.R
-			Segment@2extended:
-				End: Road.L
-				Inner: Road
-				Points: 2,1, 1,1, 0,1
 				Start: Clear.L
 	Template@97:
 		Id: 97

--- a/mods/cnc/tilesets/temperat.yaml
+++ b/mods/cnc/tilesets/temperat.yaml
@@ -1131,16 +1131,6 @@ Templates:
 				Inner: Road
 				Points: 2,1, 2,0
 				Start: Clear.U
-			Segment@1extended:
-				End: Clear.D
-				Inner: Road
-				Points: 1,0, 1,1, 1,2
-				Start: Road.D
-			Segment@2extended:
-				End: Road.U
-				Inner: Road
-				Points: 2,2, 2,1, 2,0
-				Start: Clear.U
 	Template@94:
 		Id: 94
 		Images: d02.tem
@@ -1162,16 +1152,6 @@ Templates:
 				Inner: Road
 				Points: 1,1, 2,1
 				Start: Clear.R
-			Segment@1extended:
-				End: Clear.L
-				Inner: Road
-				Points: 2,0, 1,0, 0,0
-				Start: Road.L
-			Segment@2extended:
-				End: Road.R
-				Inner: Road
-				Points: 0,1, 1,1, 2,1
-				Start: Clear.R
 	Template@95:
 		Id: 95
 		Images: d03.tem
@@ -1190,16 +1170,6 @@ Templates:
 				End: Road.D
 				Inner: Road
 				Points: 0,1, 0,2
-				Start: Clear.D
-			Segment@1extended:
-				End: Clear.U
-				Inner: Road
-				Points: 1,2, 1,1, 1,0
-				Start: Road.U
-			Segment@2extended:
-				End: Road.D
-				Inner: Road
-				Points: 0,0, 0,1, 0,2
 				Start: Clear.D
 	Template@96:
 		Id: 96
@@ -1220,16 +1190,6 @@ Templates:
 				End: Road.L
 				Inner: Road
 				Points: 1,1, 0,1
-				Start: Clear.L
-			Segment@1extended:
-				End: Clear.R
-				Inner: Road
-				Points: 0,2, 1,2, 2,2
-				Start: Road.R
-			Segment@2extended:
-				End: Road.L
-				Inner: Road
-				Points: 2,1, 1,1, 0,1
 				Start: Clear.L
 	Template@97:
 		Id: 97

--- a/mods/cnc/tilesets/winter.yaml
+++ b/mods/cnc/tilesets/winter.yaml
@@ -1115,16 +1115,6 @@ Templates:
 				Inner: Road
 				Points: 2,1, 2,0
 				Start: Clear.U
-			Segment@1extended:
-				End: Clear.D
-				Inner: Road
-				Points: 1,0, 1,1, 1,2
-				Start: Road.D
-			Segment@2extended:
-				End: Road.U
-				Inner: Road
-				Points: 2,2, 2,1, 2,0
-				Start: Clear.U
 	Template@94:
 		Id: 94
 		Images: d02.win
@@ -1146,16 +1136,6 @@ Templates:
 				Inner: Road
 				Points: 1,1, 2,1
 				Start: Clear.R
-			Segment@1extended:
-				End: Clear.L
-				Inner: Road
-				Points: 2,0, 1,0, 0,0
-				Start: Road.L
-			Segment@2extended:
-				End: Road.R
-				Inner: Road
-				Points: 0,1, 1,1, 2,1
-				Start: Clear.R
 	Template@95:
 		Id: 95
 		Images: d03.win
@@ -1174,16 +1154,6 @@ Templates:
 				End: Road.D
 				Inner: Road
 				Points: 0,1, 0,2
-				Start: Clear.D
-			Segment@1extended:
-				End: Clear.U
-				Inner: Road
-				Points: 1,2, 1,1, 1,0
-				Start: Road.U
-			Segment@2extended:
-				End: Road.D
-				Inner: Road
-				Points: 0,0, 0,1, 0,2
 				Start: Clear.D
 	Template@96:
 		Id: 96
@@ -1204,16 +1174,6 @@ Templates:
 				End: Road.L
 				Inner: Road
 				Points: 1,1, 0,1
-				Start: Clear.L
-			Segment@1extended:
-				End: Clear.R
-				Inner: Road
-				Points: 0,2, 1,2, 2,2
-				Start: Road.R
-			Segment@2extended:
-				End: Road.L
-				Inner: Road
-				Points: 2,1, 1,1, 0,1
 				Start: Clear.L
 	Template@97:
 		Id: 97


### PR DESCRIPTION
Whilst TilingPath has always allowed deviating from the path points between the start and end point, it didn't allow deviation from the start or end points themselves. This change allows the end point to deviate if the tiling would otherwise fail. The start point remains strictly positioned, as before. Loop end points (which must necessarily match the start) also remain strict.

The ExperimentalMapGenerator is modified to benefit from the relaxed tiling constraints. As a result, failed map generation due to tiling failures is much rarer, and will make some otherwise very inflexible template categories viable for tiling.

Includes some impure refactoring around the treatment of start, intermediate, and end segments. As such, this changes map generation output, even for maps which already tiled perfectly.

A previous workaround used for CnC road templates, whereby additional segments were defined for road ending templates, is now redundant and cleaned up.