### PR TITLE
Add map-generated beaches to more CnC tilesets

### DIFF
--- a/mods/cnc/rules/map-generators.yaml
+++ b/mods/cnc/rules/map-generators.yaml
@@ -99,17 +99,14 @@
 				Default: Gardens,Rocky
 				Choice@Lakes:
 					Label: label-cnc-map-generator-choice-terrain-type-lakes
-					Tileset: DESERT
 					Settings:
 						Water: 200
 				Choice@Puddles:
 					Label: label-cnc-map-generator-choice-terrain-type-puddles
-					Tileset: DESERT
 					Settings:
 						Water: 100
 				Choice@Gardens:
 					Label: label-cnc-map-generator-choice-terrain-type-gardens
-					Tileset: DESERT
 					Settings:
 						Water: 50
 						Forests: 300
@@ -165,7 +162,6 @@
 						MinimumTerrainContourSpacing: 5
 				Choice@MountainLakes:
 					Label: label-cnc-map-generator-choice-terrain-type-mountain-lakes
-					Tileset: DESERT
 					Settings:
 						Water: 200
 						Mountains: 1000
@@ -254,7 +250,6 @@
 						ExternalCircularBias: 1
 				Choice@CircleWater:
 					Label: label-cnc-map-generator-choice-shape-circle-water
-					Tileset: DESERT
 					Settings:
 						ExternalCircularBias: -1
 			MultiChoiceOption@Resources:

--- a/mods/cnc/tilesets/snow.yaml
+++ b/mods/cnc/tilesets/snow.yaml
@@ -1789,6 +1789,55 @@ Templates:
 
 MultiBrushCollections:
 	Segmented:
+		MultiBrush@3:
+			Template: 3
+			Segment:
+				Start: Beach.L
+				Inner: Beach
+				End: Beach.L
+				Points: 3,1, 2,1, 1,1, 0,1
+		MultiBrush@4:
+			Template: 4
+			Segment:
+				Start: Beach.L
+				Inner: Beach
+				End: Beach.L
+				Points: 3,1, 2,1, 1,1, 0,1
+		MultiBrush@7:
+			Template: 7
+			Segment:
+				Start: Beach.L
+				Inner: Beach
+				End: Beach.L
+				Points: 3,1, 2,1, 1,1, 0,1
+		MultiBrush@9:
+			Template: 9
+			Segment:
+				Start: Beach.R
+				Inner: Beach
+				End: Beach.R
+				Points: 0,2, 1,2, 2,2, 3,2
+		MultiBrush@10:
+			Template: 10
+			Segment:
+				Start: Beach.R
+				Inner: Beach
+				End: Beach.R
+				Points: 0,2, 1,2, 2,2, 3,2
+		MultiBrush@11:
+			Template: 11
+			Segment:
+				Start: Beach.R
+				Inner: Beach
+				End: Beach.R
+				Points: 0,2, 1,2, 2,2, 3,2
+		MultiBrush@12:
+			Template: 12
+			Segment:
+				Start: Beach.R
+				Inner: Beach
+				End: Beach.R
+				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@13:
 			Template: 13
 			Segment:
@@ -2041,6 +2090,55 @@ MultiBrushCollections:
 				Inner: Cliff
 				End: Cliff.U
 				Points: 0,1, 1,1, 1,0
+		MultiBrush@51:
+			Template: 51
+			Segment:
+				Start: Beach.R
+				Inner: Beach
+				End: Beach.U
+				Points: 0,2, 1,2, 2,2, 2,1, 2,0
+		MultiBrush@52:
+			Template: 52
+			Segment:
+				Start: Beach.D
+				Inner: Beach
+				End: Beach.R
+				Points: 1,0, 1,1, 1,2, 2,2, 3,2
+		MultiBrush@88:
+			Template: 88
+			Segment:
+				Start: Beach.L
+				Inner: Beach
+				End: Beach.L
+				Points: 3,1, 2,1, 1,1, 0,1
+		MultiBrush@89:
+			Template: 89
+			Segment:
+				Start: Beach.D
+				Inner: Beach
+				End: Beach.L
+				Points: 1,0, 1,1, 0,1
+		MultiBrush@90:
+			Template: 90
+			Segment:
+				Start: Beach.L
+				Inner: Beach
+				End: Beach.D
+				Points: 3,1, 2,1, 1,1, 1,2, 1,3
+		MultiBrush@91:
+			Template: 91
+			Segment:
+				Start: Beach.U
+				Inner: Beach
+				End: Beach.L
+				Points: 2,3, 2,2, 2,1, 1,1, 0,1
+		MultiBrush@92:
+			Template: 92
+			Segment:
+				Start: Beach.L
+				Inner: Beach
+				End: Beach.U
+				Points: 2,1, 1,1, 1,0
 		MultiBrush@93:
 			Template: 93
 			Segment:
@@ -2503,6 +2601,20 @@ MultiBrushCollections:
 				Inner: Road
 				Points: 1,0, 0,0, 0,1, 0,2
 				Start: RoadOut.LD
+		MultiBrush@186:
+			Template: 186
+			Segment:
+				Start: Beach.D
+				Inner: Beach
+				End: Beach.D
+				Points: 1,0, 1,1, 1,2, 1,3
+		MultiBrush@187:
+			Template: 187
+			Segment:
+				Start: Beach.U
+				Inner: Beach
+				End: Beach.U
+				Points: 2,3, 2,2, 2,1, 2,0
 		MultiBrush@189:
 			Template: 189
 			Segment:
@@ -2531,6 +2643,32 @@ MultiBrushCollections:
 				Inner: Cliff
 				Points: 1,1, 1,0
 				Start: Cliff.U
+		MultiBrush@TopRightBeachCorner:
+			Tile@0: 52,2
+				Offset: 0,0
+			Tile@2: 52,5
+				Offset: 0,1
+			Tile@3: 52,2
+				Offset: 1,1
+			Segment:
+				Start: Beach.R
+				Inner: Beach
+				End: Beach.D
+				Points: 0,1, 1,1, 1,2
+		MultiBrush@TopLeftBeachCorner:
+			Tile@1: 75,2
+				Offset: 1,0
+			Tile@2: 75,2
+				Offset: 0,1
+			Tile@3: 51,1
+				Offset: 1,1
+			Actor: tc05.husk
+				Offset: 0,0,0
+			Segment:
+				Start: Beach.U
+				Inner: Beach
+				End: Beach.R
+				Points: 1,2, 1,1, 2,1
 	Trees:
 		MultiBrush@t01:
 			Actor: t01
@@ -2716,12 +2854,11 @@ MultiBrushCollections:
 	Water:
 		MultiBrush@1:
 			Template: 1
-			Weight: 100
 		MultiBrush@2:
 			Template: 2
 		MultiBrush@5:
 			Template: 5
-			Weight: 500
+			Weight: 50
 		MultiBrush@6:
 			Template: 6
 			Weight: 500

--- a/mods/cnc/tilesets/temperat.yaml
+++ b/mods/cnc/tilesets/temperat.yaml
@@ -1790,6 +1790,55 @@ Templates:
 
 MultiBrushCollections:
 	Segmented:
+		MultiBrush@3:
+			Template: 3
+			Segment:
+				Start: Beach.L
+				Inner: Beach
+				End: Beach.L
+				Points: 3,1, 2,1, 1,1, 0,1
+		MultiBrush@4:
+			Template: 4
+			Segment:
+				Start: Beach.L
+				Inner: Beach
+				End: Beach.L
+				Points: 3,1, 2,1, 1,1, 0,1
+		MultiBrush@7:
+			Template: 7
+			Segment:
+				Start: Beach.L
+				Inner: Beach
+				End: Beach.L
+				Points: 3,1, 2,1, 1,1, 0,1
+		MultiBrush@9:
+			Template: 9
+			Segment:
+				Start: Beach.R
+				Inner: Beach
+				End: Beach.R
+				Points: 0,2, 1,2, 2,2, 3,2
+		MultiBrush@10:
+			Template: 10
+			Segment:
+				Start: Beach.R
+				Inner: Beach
+				End: Beach.R
+				Points: 0,2, 1,2, 2,2, 3,2
+		MultiBrush@11:
+			Template: 11
+			Segment:
+				Start: Beach.R
+				Inner: Beach
+				End: Beach.R
+				Points: 0,2, 1,2, 2,2, 3,2
+		MultiBrush@12:
+			Template: 12
+			Segment:
+				Start: Beach.R
+				Inner: Beach
+				End: Beach.R
+				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@13:
 			Template: 13
 			Segment:
@@ -2042,6 +2091,55 @@ MultiBrushCollections:
 				Inner: Cliff
 				End: Cliff.U
 				Points: 0,1, 1,1, 1,0
+		MultiBrush@51:
+			Template: 51
+			Segment:
+				Start: Beach.R
+				Inner: Beach
+				End: Beach.U
+				Points: 0,2, 1,2, 2,2, 2,1, 2,0
+		MultiBrush@52:
+			Template: 52
+			Segment:
+				Start: Beach.D
+				Inner: Beach
+				End: Beach.R
+				Points: 1,0, 1,1, 1,2, 2,2, 3,2
+		MultiBrush@88:
+			Template: 88
+			Segment:
+				Start: Beach.L
+				Inner: Beach
+				End: Beach.L
+				Points: 3,1, 2,1, 1,1, 0,1
+		MultiBrush@89:
+			Template: 89
+			Segment:
+				Start: Beach.D
+				Inner: Beach
+				End: Beach.L
+				Points: 1,0, 1,1, 0,1
+		MultiBrush@90:
+			Template: 90
+			Segment:
+				Start: Beach.L
+				Inner: Beach
+				End: Beach.D
+				Points: 3,1, 2,1, 1,1, 1,2, 1,3
+		MultiBrush@91:
+			Template: 91
+			Segment:
+				Start: Beach.U
+				Inner: Beach
+				End: Beach.L
+				Points: 2,3, 2,2, 2,1, 1,1, 0,1
+		MultiBrush@92:
+			Template: 92
+			Segment:
+				Start: Beach.L
+				Inner: Beach
+				End: Beach.U
+				Points: 2,1, 1,1, 1,0
 		MultiBrush@93:
 			Template: 93
 			Segment:
@@ -2504,6 +2602,20 @@ MultiBrushCollections:
 				Inner: Road
 				Points: 1,0, 0,0, 0,1, 0,2
 				Start: RoadOut.LD
+		MultiBrush@186:
+			Template: 186
+			Segment:
+				Start: Beach.D
+				Inner: Beach
+				End: Beach.D
+				Points: 1,0, 1,1, 1,2, 1,3
+		MultiBrush@187:
+			Template: 187
+			Segment:
+				Start: Beach.U
+				Inner: Beach
+				End: Beach.U
+				Points: 2,3, 2,2, 2,1, 2,0
 		MultiBrush@189:
 			Template: 189
 			Segment:
@@ -2532,6 +2644,32 @@ MultiBrushCollections:
 				Inner: Cliff
 				Points: 1,1, 1,0
 				Start: Cliff.U
+		MultiBrush@TopRightBeachCorner:
+			Tile@0: 52,2
+				Offset: 0,0
+			Tile@2: 52,5
+				Offset: 0,1
+			Tile@3: 52,2
+				Offset: 1,1
+			Segment:
+				Start: Beach.R
+				Inner: Beach
+				End: Beach.D
+				Points: 0,1, 1,1, 1,2
+		MultiBrush@TopLeftBeachCorner:
+			Tile@1: 75,2
+				Offset: 1,0
+			Tile@2: 75,2
+				Offset: 0,1
+			Tile@3: 51,1
+				Offset: 1,1
+			Actor: tc05.husk
+				Offset: 0,0,0
+			Segment:
+				Start: Beach.U
+				Inner: Beach
+				End: Beach.R
+				Points: 1,2, 1,1, 2,1
 	Trees:
 		MultiBrush@t01:
 			Actor: t01
@@ -2719,12 +2857,11 @@ MultiBrushCollections:
 	Water:
 		MultiBrush@1:
 			Template: 1
-			Weight: 100
 		MultiBrush@2:
 			Template: 2
 		MultiBrush@5:
 			Template: 5
-			Weight: 500
+			Weight: 50
 		MultiBrush@6:
 			Template: 6
 			Weight: 500

--- a/mods/cnc/tilesets/winter.yaml
+++ b/mods/cnc/tilesets/winter.yaml
@@ -1825,6 +1825,55 @@ Templates:
 
 MultiBrushCollections:
 	Segmented:
+		MultiBrush@3:
+			Template: 3
+			Segment:
+				Start: Beach.L
+				Inner: Beach
+				End: Beach.L
+				Points: 3,1, 2,1, 1,1, 0,1
+		MultiBrush@4:
+			Template: 4
+			Segment:
+				Start: Beach.L
+				Inner: Beach
+				End: Beach.L
+				Points: 3,1, 2,1, 1,1, 0,1
+		MultiBrush@7:
+			Template: 7
+			Segment:
+				Start: Beach.L
+				Inner: Beach
+				End: Beach.L
+				Points: 3,1, 2,1, 1,1, 0,1
+		MultiBrush@9:
+			Template: 9
+			Segment:
+				Start: Beach.R
+				Inner: Beach
+				End: Beach.R
+				Points: 0,2, 1,2, 2,2, 3,2
+		MultiBrush@10:
+			Template: 10
+			Segment:
+				Start: Beach.R
+				Inner: Beach
+				End: Beach.R
+				Points: 0,2, 1,2, 2,2, 3,2
+		MultiBrush@11:
+			Template: 11
+			Segment:
+				Start: Beach.R
+				Inner: Beach
+				End: Beach.R
+				Points: 0,2, 1,2, 2,2, 3,2
+		MultiBrush@12:
+			Template: 12
+			Segment:
+				Start: Beach.R
+				Inner: Beach
+				End: Beach.R
+				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@13:
 			Template: 13
 			Segment:
@@ -2077,6 +2126,55 @@ MultiBrushCollections:
 				Inner: Cliff
 				End: Cliff.U
 				Points: 0,1, 1,1, 1,0
+		MultiBrush@51:
+			Template: 51
+			Segment:
+				Start: Beach.R
+				Inner: Beach
+				End: Beach.U
+				Points: 0,2, 1,2, 2,2, 2,1, 2,0
+		MultiBrush@52:
+			Template: 52
+			Segment:
+				Start: Beach.D
+				Inner: Beach
+				End: Beach.R
+				Points: 1,0, 1,1, 1,2, 2,2, 3,2
+		MultiBrush@88:
+			Template: 88
+			Segment:
+				Start: Beach.L
+				Inner: Beach
+				End: Beach.L
+				Points: 3,1, 2,1, 1,1, 0,1
+		MultiBrush@89:
+			Template: 89
+			Segment:
+				Start: Beach.D
+				Inner: Beach
+				End: Beach.L
+				Points: 1,0, 1,1, 0,1
+		MultiBrush@90:
+			Template: 90
+			Segment:
+				Start: Beach.L
+				Inner: Beach
+				End: Beach.D
+				Points: 3,1, 2,1, 1,1, 1,2, 1,3
+		MultiBrush@91:
+			Template: 91
+			Segment:
+				Start: Beach.U
+				Inner: Beach
+				End: Beach.L
+				Points: 2,3, 2,2, 2,1, 1,1, 0,1
+		MultiBrush@92:
+			Template: 92
+			Segment:
+				Start: Beach.L
+				Inner: Beach
+				End: Beach.U
+				Points: 2,1, 1,1, 1,0
 		MultiBrush@93:
 			Template: 93
 			Segment:
@@ -2539,6 +2637,20 @@ MultiBrushCollections:
 				Inner: Road
 				Points: 1,0, 0,0, 0,1, 0,2
 				Start: RoadOut.LD
+		MultiBrush@186:
+			Template: 186
+			Segment:
+				Start: Beach.D
+				Inner: Beach
+				End: Beach.D
+				Points: 1,0, 1,1, 1,2, 1,3
+		MultiBrush@187:
+			Template: 187
+			Segment:
+				Start: Beach.U
+				Inner: Beach
+				End: Beach.U
+				Points: 2,3, 2,2, 2,1, 2,0
 		MultiBrush@189:
 			Template: 189
 			Segment:
@@ -2567,6 +2679,32 @@ MultiBrushCollections:
 				Inner: Cliff
 				Points: 1,0, 1,1
 				Start: Cliff.D
+		MultiBrush@TopRightBeachCorner:
+			Tile@0: 52,2
+				Offset: 0,0
+			Tile@2: 52,5
+				Offset: 0,1
+			Tile@3: 52,2
+				Offset: 1,1
+			Segment:
+				Start: Beach.R
+				Inner: Beach
+				End: Beach.D
+				Points: 0,1, 1,1, 1,2
+		MultiBrush@TopLeftBeachCorner:
+			Tile@1: 75,2
+				Offset: 1,0
+			Tile@2: 75,2
+				Offset: 0,1
+			Tile@3: 51,1
+				Offset: 1,1
+			Actor: tc05.husk
+				Offset: 0,0,0
+			Segment:
+				Start: Beach.U
+				Inner: Beach
+				End: Beach.R
+				Points: 1,2, 1,1, 2,1
 	Trees:
 		MultiBrush@t01:
 			Actor: t01
@@ -2757,12 +2895,11 @@ MultiBrushCollections:
 	Water:
 		MultiBrush@1:
 			Template: 1
-			Weight: 100
 		MultiBrush@2:
 			Template: 2
 		MultiBrush@5:
 			Template: 5
-			Weight: 500
+			Weight: 50
 		MultiBrush@6:
 			Template: 6
 			Weight: 500


### PR DESCRIPTION
CnC map generation previously only supported maps with water/beaches or the DESERT tileset, as it is the only tileset with a complete set of beach tiles. This change adds support for the other tilesets (TEMPERAT, SNOW, WINTER) by adding fake beach templates constructed from actors and other templates' tiles that look reasonable in both original and remastered graphics.

This means all CnC tilesets have feature parity in the map generator.

Depends on #21845 and #21846