### PR TITLE
Rewrite map generator settings UI logic.

### DIFF
--- a/OpenRA.Mods.Common/MapGenerator/MapGeneratorSettings.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MapGeneratorSettings.cs
@@ -13,389 +13,231 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Support;
 
 namespace OpenRA.Mods.Common.MapGenerator
 {
-	public sealed class MapGeneratorSettings
+	public abstract class MapGeneratorOption
 	{
-		/// <summary>How an option should be treated for UI purposes.</summary>
-		public enum UiType
+		[FieldLoader.Ignore]
+		public readonly string Id;
+		public readonly string Label = null;
+		public readonly int Priority = 0;
+
+		protected MapGeneratorOption(string id, MiniYaml yaml)
 		{
-			Hidden,
-			DropDown,
-			Checkbox,
-			Integer,
-			Float,
-			String,
+			Id = id;
+			FieldLoader.Load(this, yaml);
 		}
 
-		/// <summary>Represents a bunch of settings, along with UI information.</summary>
-		public sealed class Choice
-		{
-			/// <summary>Uniquely identifies a Choice within an Option.</summary>
-			public readonly string Id;
+		public abstract IReadOnlyCollection<MiniYamlNode> GetSettings(ITerrainInfo terrainInfo);
 
-			/// <summary>The label to use for UI selection. Post-fluent.</summary>
+		public virtual IEnumerable<string> GetFluentReferences()
+		{
+			if (Label != null)
+				yield return Label;
+		}
+	}
+
+	public class MapGeneratorBooleanOption : MapGeneratorOption
+	{
+		[FieldLoader.Require]
+		public readonly string Parameter = null;
+		public readonly bool Default = false;
+		public bool Value;
+
+		public MapGeneratorBooleanOption(string id, MiniYaml yaml)
+			: base(id, yaml)
+		{
+			Value = Default;
+		}
+
+		public override IReadOnlyCollection<MiniYamlNode> GetSettings(ITerrainInfo terrainInfo)
+		{
+			return [new MiniYamlNode(Parameter, FieldSaver.FormatValue(Value))];
+		}
+	}
+
+	public class MapGeneratorIntegerOption : MapGeneratorOption
+	{
+		[FieldLoader.Require]
+		public readonly string Parameter = null;
+		public readonly int Default = 0;
+		public int Value;
+
+		public MapGeneratorIntegerOption(string id, MiniYaml yaml)
+			: base(id, yaml)
+		{
+			Value = Default;
+		}
+
+		public override IReadOnlyCollection<MiniYamlNode> GetSettings(ITerrainInfo terrainInfo)
+		{
+			return [new MiniYamlNode(Parameter, FieldSaver.FormatValue(Value))];
+		}
+	}
+
+	public class MapGeneratorMultiChoiceOption : MapGeneratorOption
+	{
+		public class MapGeneratorDropdownChoice
+		{
 			public readonly string Label = null;
+			public readonly string[] Tileset = null;
 
-			/// <summary>The tooltip to use for UI selection. Post-fluent.</summary>
-			public readonly string Description = null;
+			[FieldLoader.LoadUsing(nameof(LoadSettings))]
+			[FieldLoader.Require]
+			public readonly ImmutableList<MiniYamlNode> Settings = null;
 
-			/// <summary>
-			/// Only offer the Choice for these tilesets. (If null, show for all.)
-			/// </summary>
-			public readonly IReadOnlySet<string> Tileset = null;
-
-			/// <summary>(Partial) settings to combine into the final overall settings.</summary>
-			public readonly MiniYaml Settings;
-
-			public Choice(string id, MiniYaml my)
+			static ImmutableList<MiniYamlNode> LoadSettings(MiniYaml yaml)
 			{
-				Id = id;
-				var label = my.NodeWithKeyOrDefault("Label")?.Value.Value;
-				if (label != null)
-				{
-					Label = FluentProvider.GetMessage($"{label}.label");
-					FluentProvider.TryGetMessage($"{label}.description", out Description);
-				}
-
-				Tileset = my.NodeWithKeyOrDefault("Tileset")?.Value.Value
-					?.Split(',')
-					.ToImmutableHashSet();
-				Settings = my.NodeWithKey("Settings").Value;
-			}
-
-			/// <summary>Create a choice that represents a top-level setting with a given value.</summary>
-			public Choice(string setting, string value)
-			{
-				Id = value;
-				Label = value;
-				Description = null;
-				Tileset = null;
-				Settings = new MiniYaml(null, [new MiniYamlNode(setting, value)]);
-			}
-
-			public static void DumpFluent(MiniYaml my, List<string> references)
-			{
-				var label = my.NodeWithKeyOrDefault("Label")?.Value.Value;
-				if (label != null)
-				{
-					references.Add($"{label}.label");
-
-					// Descriptions are optional.
-					if (FluentProvider.TryGetMessage($"{label}.description", out _))
-						references.Add($"{label}.description");
-				}
-			}
-
-			/// <summary>Check whether this choice is permitted for this map.</summary>
-			public bool Allowed(ITerrainInfo terrainInfo)
-			{
-				if (Tileset != null && !Tileset.Contains(terrainInfo.Id))
-					return false;
-
-				return true;
-			}
-
-			/// <summary>For single-setting choices, creates a new choice for that setting with a given value.</summary>
-			public Choice NewValue(string value)
-			{
-				if (Settings.Nodes.Length != 1)
-					throw new InvalidOperationException("NewValue can only be used on single-setting Choices");
-				return new(Settings.Nodes[0].Key, value);
+				return yaml.NodeWithKey("Settings").Value.Nodes.ToImmutableList();
 			}
 		}
 
-		public sealed class Option
+		[FieldLoader.LoadUsing(nameof(LoadChoices))]
+		public readonly Dictionary<string, MapGeneratorDropdownChoice> Choices = null;
+
+		static Dictionary<string, MapGeneratorDropdownChoice> LoadChoices(MiniYaml yaml)
 		{
-			/// <summary>Unique identifier for this Option.</summary>
-			[FieldLoader.Ignore]
-			public readonly string Id;
-
-			/// <summary>The label to use for UI selection. Post-fluent.</summary>
-			[FieldLoader.Ignore]
-			public readonly string Label = null;
-
-			/// <summary>
-			/// <para>For multiple-choice options (dropdowns/checkboxes) holds the allowed Choices.</para>
-			/// <para>For text entry Options, contains the default value.</para>
-			/// <para>If this is empty, the map is not compatible with the generator.</para>
-			/// </summary>
-			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<Choice> Choices;
-
-			/// <summary>
-			/// <para>The default Choice for this option.</para>
-			/// <para>Default will be ignored if it is not valid for the map.</para>
-			/// </summary>
-			[FieldLoader.Ignore]
-			public readonly Choice Default;
-
-			public readonly double Min = double.NegativeInfinity;
-			public readonly double Max = double.PositiveInfinity;
-
-			/// <summary>Whether the Option can be randomized.</summary>
-			public readonly bool Random = false;
-
-			/// <summary>How an option should be treated for UI purposes.</summary>
-			[FieldLoader.Ignore]
-			public readonly UiType Ui;
-
-			/// <summary>Settings layering priority. Higher overrides lower.</summary>
-			public readonly int Priority = 0;
-
-			public Option(string id, MiniYaml my, ITerrainInfo terrainInfo)
-			{
-				Id = id;
-				FieldLoader.Load(this, my);
-				var label = my.NodeWithKeyOrDefault("Label")?.Value.Value;
-				if (label != null)
-					Label = FluentProvider.GetMessage(label);
-
-				var choices = new List<Choice>();
-				Choices = choices;
-
-				var integerSetting = my.NodeWithKeyOrDefault("Integer");
-				var floatSetting = my.NodeWithKeyOrDefault("Float");
-				var stringSetting = my.NodeWithKeyOrDefault("String");
-				var checkboxSetting = my.NodeWithKeyOrDefault("Checkbox");
-				var simpleChoiceSetting = my.NodeWithKeyOrDefault("SimpleChoice");
-				var textSetting = integerSetting ?? floatSetting ?? stringSetting;
-				if (textSetting != null)
-				{
-					var setting = textSetting.Value.Value;
-					var value = my.NodeWithKeyOrDefault("Default")?.Value.Value ?? "";
-					var choice = new Choice(setting, value);
-					choices.Add(choice);
-					Default = choice;
-					Ui =
-						integerSetting != null ? UiType.Integer :
-						floatSetting != null ? UiType.Float :
-						UiType.String;
-
-					if (Ui == UiType.Integer)
-					{
-						if (Min == double.NegativeInfinity)
-							Min = int.MinValue;
-						if (Max == double.PositiveInfinity)
-							Max = int.MaxValue;
-					}
-				}
-				else if (checkboxSetting != null)
-				{
-					var setting = checkboxSetting.Value.Value;
-					var falseChoice = new Choice(setting, "False");
-					var trueChoice = new Choice(setting, "True");
-					choices.Add(falseChoice);
-					choices.Add(trueChoice);
-					var enabled = (my.NodeWithKeyOrDefault("Default")?.Value.Value ?? "False") == "True";
-					Default = enabled ? trueChoice : falseChoice;
-					Ui = UiType.Checkbox;
-				}
-				else
-				{
-					if (simpleChoiceSetting != null)
-					{
-						var setting = simpleChoiceSetting.Value.Value;
-						var values = simpleChoiceSetting.Value
-							.NodeWithKey("Values").Value.Value
-							.Split(',');
-						foreach (var value in values)
-							choices.Add(new Choice(setting, value));
-					}
-					else
-					{
-						foreach (var node in my.Nodes)
-						{
-							var split = node.Key.Split('@');
-							if (split[0] == "Choice")
-							{
-								string choiceId = null;
-								if (split.Length >= 2)
-									choiceId = split[1];
-								var choice = new Choice(choiceId, node.Value);
-								if (choice.Allowed(terrainInfo))
-									choices.Add(choice);
-							}
-						}
-					}
-
-					if (Choices.Count > 0)
-					{
-						var defaultOrder = my.NodeWithKeyOrDefault("Default")?.Value.Value;
-						if (defaultOrder != null)
-						{
-							foreach (var defaultChoice in defaultOrder.Split(','))
-							{
-								Default = Choices.FirstOrDefault(choice => choice.Id == defaultChoice);
-								if (Default != null)
-									break;
-							}
-
-							if (Default == null)
-								throw new YamlException($"None of option `{id}`'s default choices `{defaultOrder}` are not valid");
-						}
-						else
-						{
-							Default = Choices[0];
-						}
-					}
-
-					Ui = Label == null ? UiType.Hidden : UiType.DropDown;
-				}
-			}
-
-			public static void DumpFluent(MiniYaml my, List<string> references)
-			{
-				var label = my.NodeWithKeyOrDefault("Label")?.Value.Value;
-				if (label != null)
-					references.Add(label);
-				foreach (var node in my.Nodes)
-					if (node.Key.Split('@')[0] == "Choice")
-						Choice.DumpFluent(node.Value, references);
-			}
-
-			public bool ValidateChoice(Choice choice)
-			{
-				switch (Ui)
-				{
-					case UiType.Integer:
-					{
-						var valid = long.TryParse(choice.Id, out var value);
-						if (value < Min || value > Max)
-							valid = false;
-						return valid;
-					}
-
-					case UiType.Float:
-					{
-						var valid = double.TryParse(choice.Id, out var value);
-						if (value < Min || value > Max)
-							valid = false;
-						return valid;
-					}
-
-					case UiType.String:
-						return true;
-
-					default:
-						return Choices.Contains(choice);
-				}
-			}
-
-			public Choice RandomChoice()
-			{
-				if (Random)
-				{
-					var random = (long)Guid.NewGuid().GetHashCode() - int.MinValue;
-					switch (Ui)
-					{
-						case UiType.Integer:
-							var intRandom = (int)(random % (long)(Max - Min + 1) + (long)Min);
-							return Default.NewValue(intRandom.ToStringInvariant());
-						case UiType.Float:
-							var floatRandom = (float)((double)0xffffffff * random / (Max - Min) + Min);
-							return Default.NewValue(floatRandom.ToStringInvariant());
-						case UiType.Checkbox:
-						case UiType.DropDown:
-							if (Choices.Count == 0)
-								throw new InvalidOperationException($"Map is not compatible with Option `{Id}`");
-							return Choices[(int)(random % Choices.Count)];
-						default:
-							throw new InvalidOperationException($"Option `{Id}` does not have a randomizable type");
-					}
-				}
-				else
-				{
-					return Default;
-				}
-			}
-
-			public bool IsFreeform()
-			{
-				switch (Ui)
-				{
-					case UiType.Hidden:
-					case UiType.DropDown:
-					case UiType.Checkbox:
-						return false;
-					case UiType.Integer:
-					case UiType.Float:
-					case UiType.String:
-						return true;
-					default:
-						throw new InvalidOperationException("Bad UiType");
-				}
-			}
-		}
-
-		public readonly IReadOnlyList<Option> Options;
-
-		/// <summary>
-		/// Parse settings from a MiniYaml definition. Returns null if the map isn't compatible.
-		/// </summary>
-		public static MapGeneratorSettings LoadSettings(MiniYaml my, ITerrainInfo terrainInfo)
-		{
-			var options = new List<Option>();
-
-			foreach (var node in my.Nodes)
+			var ret = new Dictionary<string, MapGeneratorDropdownChoice>();
+			foreach (var node in yaml.Nodes)
 			{
 				var split = node.Key.Split('@');
-				if (split[0] == "Option")
-				{
-					string id = null;
-					if (split.Length >= 2)
-						id = split[1];
-					var option = new Option(id, node.Value, terrainInfo);
-					if (option.Choices.Count == 0)
-						return null;
-					options.Add(option);
-				}
+				if (split.Length == 2 && split[0] == "Choice")
+					ret.Add(split[1], FieldLoader.Load<MapGeneratorDropdownChoice>(node.Value));
 			}
 
-			return new MapGeneratorSettings(options);
+			return ret;
 		}
 
-		public static List<string> DumpFluent(MiniYaml my)
+		public readonly string[] Default = null;
+		string value = null;
+
+		public MapGeneratorMultiChoiceOption(string id, MiniYaml yaml)
+			: base(id, yaml) { }
+
+		public override IReadOnlyCollection<MiniYamlNode> GetSettings(ITerrainInfo terrainInfo)
 		{
-			var references = new List<string>();
-			DumpFluent(my, references);
-			return references;
+			var validChoices = ValidChoices(terrainInfo);
+			if (validChoices.Contains(value))
+				return Choices[value].Settings;
+
+			var fallback = Default?.FirstOrDefault(validChoices.Contains) ?? validChoices.FirstOrDefault();
+			return fallback != null ? Choices[fallback].Settings : [];
 		}
 
-		public static void DumpFluent(MiniYaml my, List<string> references)
+		public string Value
 		{
-			foreach (var node in my.Nodes)
-				if (node.Key.Split('@')[0] == "Option")
-					Option.DumpFluent(node.Value, references);
-		}
-
-		MapGeneratorSettings(IReadOnlyList<Option> options)
-		{
-			Options = options;
-		}
-
-		public Dictionary<Option, Choice> DefaultChoices()
-		{
-			return Options.ToDictionary(option => option, option => option.Default);
-		}
-
-		/// <summary>Merge all choices into a complete settings MiniYaml.</summary>
-		public MiniYaml Compile(IReadOnlyDictionary<Option, Choice> choices)
-		{
-			var layers = new List<IReadOnlyCollection<MiniYamlNode>>();
-
-			// Apply the choices in their canonical order.
-			foreach (var option in Options.OrderBy(option => option.Priority))
+			get => value;
+			set
 			{
-				var choice = choices[option];
-				if (!option.ValidateChoice(choice))
-					throw new ArgumentException($"Option `{option.Id}` has illegal choice");
-				layers.Add(choice.Settings.Nodes);
-			}
+				if (!Choices.ContainsKey(value))
+					throw new ArgumentException($"{value} is not in the list of valid choices");
 
-			var settingsNodes = MiniYaml.Merge(layers);
-			return new MiniYaml(null, settingsNodes);
+				this.value = value;
+			}
+		}
+
+		public List<string> ValidChoices(ITerrainInfo terrainInfo)
+		{
+			return Choices
+				.Where(kv => kv.Value.Tileset == null || kv.Value.Tileset.Contains(terrainInfo.Id))
+				.Select(kv => kv.Key)
+				.ToList();
+		}
+
+		public override IEnumerable<string> GetFluentReferences()
+		{
+			if (Label != null)
+				yield return Label;
+
+			foreach (var c in Choices.Values)
+			{
+				if (c.Label == null)
+					continue;
+
+				yield return c.Label + ".label";
+
+				// Descriptions are optional
+				if (FluentProvider.TryGetMessage(c.Label + ".description", out _))
+					yield return c.Label + ".description";
+			}
+		}
+	}
+
+	public class MapGeneratorMultiIntegerChoiceOption : MapGeneratorOption
+	{
+		[FieldLoader.Require]
+		public readonly string Parameter = null;
+
+		[FieldLoader.Require]
+		public readonly int[] Choices = null;
+
+		public readonly int? Default = null;
+		int value;
+
+		public MapGeneratorMultiIntegerChoiceOption(string id, MiniYaml yaml)
+			: base(id, yaml)
+		{
+			Value = Default ?? Choices?.First() ?? 0;
+		}
+
+		public int Value
+		{
+			get => value;
+			set
+			{
+				if (!Choices.Contains(value))
+					throw new ArgumentException($"{value} is not in the list of valid choices");
+
+				this.value = value;
+			}
+		}
+
+		public override IReadOnlyCollection<MiniYamlNode> GetSettings(ITerrainInfo terrainInfo)
+		{
+			return [new MiniYamlNode(Parameter, FieldSaver.FormatValue(Value))];
+		}
+	}
+
+	public sealed class MapGeneratorSettings : IMapGeneratorSettings
+	{
+		public MapGeneratorSettings(MiniYaml yaml)
+		{
+			foreach (var node in yaml.Nodes)
+			{
+				var split = node.Key.Split('@');
+				if (split.Length != 2)
+					continue;
+
+				if (split[0] == "BooleanOption")
+					Options.Add(new MapGeneratorBooleanOption(split[1], node.Value));
+				else if (split[0] == "IntegerOption")
+					Options.Add(new MapGeneratorIntegerOption(split[1], node.Value));
+				else if (split[0] == "MultiIntegerChoiceOption")
+					Options.Add(new MapGeneratorMultiIntegerChoiceOption(split[1], node.Value));
+				else if (split[0] == "MultiChoiceOption")
+					Options.Add(new MapGeneratorMultiChoiceOption(split[1], node.Value));
+			}
+		}
+
+		public List<MapGeneratorOption> Options { get; } = [];
+
+		public void Randomize(MersenneTwister random)
+		{
+			if (Options.FirstOrDefault(o => o.Id == "Seed") is MapGeneratorIntegerOption seed)
+				seed.Value = random.Next();
+		}
+
+		public MiniYaml Compile(ITerrainInfo terrainInfo)
+		{
+			// Apply the choices in their canonical order.
+			var layers = Options
+				.OrderBy(option => option.Priority)
+				.Select(o => o.GetSettings(terrainInfo));
+
+			return new MiniYaml(null, MiniYaml.Merge(layers));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/ClearMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/ClearMapGenerator.cs
@@ -21,21 +21,24 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.EditorWorld)]
 	[Desc("A map generator that clears a map.")]
-	public sealed class ClearMapGeneratorInfo : TraitInfo<ClearMapGenerator>, IMapGeneratorInfo
+	public sealed class ClearMapGeneratorInfo : TraitInfo<ClearMapGenerator>, IMapGeneratorInfo, IEditorToolInfo
 	{
 		[FieldLoader.Require]
 		[Desc("Human-readable name this generator uses.")]
 		[FluentReference]
 		public readonly string Name = null;
 
+		[FieldLoader.Require]
+		[Desc("Internal id for this map generator.")]
+		public readonly string Type = null;
+
+		[Desc("The widget tree to open when the tool is selected.")]
+		public readonly string PanelWidget = "MAP_GENERATOR_TOOL_PANEL";
+
 		// This is purely of interest to the linter.
 		[FieldLoader.LoadUsing(nameof(FluentReferencesLoader))]
 		[FluentReference]
 		public readonly List<string> FluentReferences = null;
-
-		[FieldLoader.Require]
-		[Desc("Internal id for this map generator.")]
-		public readonly string Type = null;
 
 		[FieldLoader.LoadUsing(nameof(SettingsLoader))]
 		public readonly MiniYaml Settings;
@@ -98,6 +101,9 @@ namespace OpenRA.Mods.Common.Traits
 			map.PlayerDefinitions = new MapPlayers(map.Rules, 0).ToMiniYaml();
 			map.ActorDefinitions = [];
 		}
+
+		string IEditorToolInfo.Label => Name;
+		string IEditorToolInfo.PanelWidget => PanelWidget;
 	}
 
 	public class ClearMapGenerator { /* we're only interested in the Info */ }

--- a/OpenRA.Mods.Common/Traits/World/ClearMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/ClearMapGenerator.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Mods.Common.MapGenerator;
 using OpenRA.Mods.Common.Terrain;
 using OpenRA.Support;
@@ -50,12 +51,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		static List<string> FluentReferencesLoader(MiniYaml my)
 		{
-			return MapGeneratorSettings.DumpFluent(my.NodeWithKey("Settings").Value);
+			return new MapGeneratorSettings(my.NodeWithKey("Settings").Value)
+				.Options.SelectMany(o => o.GetFluentReferences()).ToList();
 		}
 
-		public MapGeneratorSettings GetSettings(ITerrainInfo terrainInfo)
+		public IMapGeneratorSettings GetSettings()
 		{
-			return MapGeneratorSettings.LoadSettings(Settings, terrainInfo);
+			return new MapGeneratorSettings(Settings);
 		}
 
 		public void Generate(Map map, MiniYaml settings)

--- a/OpenRA.Mods.Common/Traits/World/ExperimentalMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/ExperimentalMapGenerator.cs
@@ -23,7 +23,7 @@ using static OpenRA.Mods.Common.Traits.ResourceLayerInfo;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.EditorWorld)]
-	public sealed class ExperimentalMapGeneratorInfo : TraitInfo<ExperimentalMapGenerator>, IMapGeneratorInfo
+	public sealed class ExperimentalMapGeneratorInfo : TraitInfo<ExperimentalMapGenerator>, IMapGeneratorInfo, IEditorToolInfo
 	{
 		[FieldLoader.Require]
 		public readonly string Type = null;
@@ -31,6 +31,9 @@ namespace OpenRA.Mods.Common.Traits
 		[FieldLoader.Require]
 		[FluentReference]
 		public readonly string Name = null;
+
+		[Desc("The widget tree to open when the tool is selected.")]
+		public readonly string PanelWidget = "MAP_GENERATOR_TOOL_PANEL";
 
 		// This is purely of interest to the linter.
 		[FieldLoader.LoadUsing(nameof(FluentReferencesLoader))]
@@ -1821,6 +1824,9 @@ namespace OpenRA.Mods.Common.Traits
 				amplitude = Exts.ISqrt(amplitude);
 			return amplitude;
 		}
+
+		string IEditorToolInfo.Label => Name;
+		string IEditorToolInfo.PanelWidget => PanelWidget;
 	}
 
 	public class ExperimentalMapGenerator { /* we're only interested in the Info */ }

--- a/OpenRA.Mods.Common/Traits/World/ExperimentalMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/ExperimentalMapGenerator.cs
@@ -50,7 +50,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		static List<string> FluentReferencesLoader(MiniYaml my)
 		{
-			return MapGeneratorSettings.DumpFluent(my.NodeWithKey("Settings").Value);
+			return new MapGeneratorSettings(my.NodeWithKey("Settings").Value)
+				.Options.SelectMany(o => o.GetFluentReferences()).ToList();
 		}
 
 		const int FractionMax = 1000;
@@ -481,9 +482,9 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public MapGeneratorSettings GetSettings(ITerrainInfo terrainInfo)
+		public IMapGeneratorSettings GetSettings()
 		{
-			return MapGeneratorSettings.LoadSettings(Settings, terrainInfo);
+			return new MapGeneratorSettings(Settings);
 		}
 
 		public void Generate(Map map, MiniYaml settings)

--- a/OpenRA.Mods.Common/Traits/World/MarkerLayerOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/MarkerLayerOverlay.cs
@@ -22,8 +22,15 @@ using Color = OpenRA.Primitives.Color;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.EditorWorld)]
-	public class MarkerLayerOverlayInfo : TraitInfo
+	public class MarkerLayerOverlayInfo : TraitInfo, IEditorToolInfo
 	{
+		[FluentReference]
+		[Desc("The label to show in the tools menu.")]
+		public readonly string Label = "label-tool-marker-tiles";
+
+		[Desc("The widget tree to open when the tool is selected.")]
+		public readonly string PanelWidget = "MARKER_TOOL_PANEL";
+
 		[Desc("A list of colors to be used for drawing.")]
 		public readonly Color[] Colors =
 		[
@@ -47,6 +54,9 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			return new MarkerLayerOverlay(init.Self, this);
 		}
+
+		string IEditorToolInfo.Label => Label;
+		string IEditorToolInfo.PanelWidget => PanelWidget;
 	}
 
 	public class MarkerLayerOverlay : IRenderAnnotations, INotifyActorDisposing, IWorldLoaded

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -969,16 +969,23 @@ namespace OpenRA.Mods.Common.Traits
 			: base(message, inner) { }
 	}
 
+	public interface IMapGeneratorSettings
+	{
+		/// <summary>Returns the options that allow users to customise the result.</summary>
+		List<MapGeneratorOption> Options { get; }
+
+		void Randomize(MersenneTwister random);
+
+		/// <summary>Merge all choices into a complete settings MiniYaml.</summary>
+		MiniYaml Compile(ITerrainInfo terrainInfo);
+	}
+
 	public interface IMapGeneratorInfo : ITraitInfoInterface
 	{
 		string Type { get; }
 		string Name { get; }
 
-		/// <summary>
-		/// Get the generator settings available for this tileset.
-		/// Returns null if not compatible with the given tileset.
-		/// </summary>
-		MapGeneratorSettings GetSettings(ITerrainInfo terrainInfo);
+		IMapGeneratorSettings GetSettings();
 
 		/// <summary>
 		/// Generate or manipulate a supplied map in-place.

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -961,6 +961,12 @@ namespace OpenRA.Mods.Common.Traits
 		bool PathMightExistForLocomotorBlockedByImmovable(Locomotor locomotor, CPos source, CPos target);
 	}
 
+	public interface IEditorToolInfo : ITraitInfoInterface
+	{
+		string Label { get; }
+		string PanelWidget { get; }
+	}
+
 	public class MapGenerationException : Exception
 	{
 		public MapGenerationException(string message)

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorTabsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorTabsLogic.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
@@ -17,6 +18,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	{
 		enum MenuType { Select, Tiles, Layers, Actors, Tools, History }
 
+		readonly World world;
 		readonly Widget panelContainer;
 		readonly Widget tabContainer;
 		readonly EditorViewportControllerWidget editor;
@@ -25,8 +27,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		MenuType lastSelectedTab = MenuType.Tiles;
 
 		[ObjectCreator.UseCtor]
-		public MapEditorTabsLogic(Widget widget)
+		public MapEditorTabsLogic(Widget widget, World world)
 		{
+			this.world = world;
 			panelContainer = widget.Parent;
 			tabContainer = widget.Get("MAP_EDITOR_TAB_CONTAINER");
 
@@ -66,6 +69,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			// Selection tab is special, it can only be selected if a selection exists.
 			if (tabType == MenuType.Select)
 				tab.IsDisabled = () => !editor.DefaultBrush.Selection.HasSelection;
+
+			if (tabType == MenuType.Tools)
+			{
+				var toolsAvailable = world.Map.Rules.Actors[SystemActors.EditorWorld].HasTraitInfo<IEditorToolInfo>();
+				tab.IsDisabled = () => !toolsAvailable;
+			}
 
 			var container = panelContainer.Get<ContainerWidget>(tabId);
 			container.IsVisible = () => menuType == tabType;

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -447,218 +447,6 @@ Container@EDITOR_WORLD_ROOT:
 							Width: PARENT_WIDTH - 60
 							Height: 25
 							Font: Bold
-				Background@MARKER_TOOL_PANEL:
-					Y: 25
-					Width: PARENT_WIDTH
-					Height: PARENT_HEIGHT - 25
-					Background: scrollpanel-bg
-					Logic: MapMarkerTilesLogic
-					Children:
-						ScrollPanel@TILE_COLOR_PANEL:
-							X: 6
-							Y: 6
-							Width: PARENT_WIDTH - 19
-							Height: 31
-							TopBottomSpacing: 1
-							ItemSpacing: 1
-							ScrollBar: Hidden
-							ScrollbarWidth: 0
-							ContentHeight: 31
-							Children:
-								ScrollItem@TILE_COLOR_TEMPLATE:
-									Visible: false
-									Height: 29
-									Width: 29
-									IgnoreChildMouseOver: true
-									Children:
-										ColorBlock@TILE_PREVIEW:
-											X: 2
-											Y: 2
-											Width: 26
-											Height: 26
-								ScrollItem@TILE_ICON_TEMPLATE:
-									Visible: false
-									Height: 29
-									Width: 29
-									IgnoreChildMouseOver: true
-									Children:
-										Image@TILE_ERASE:
-											X: 6
-											Y: 6
-											Width: 26
-											Height: 26
-											ImageCollection: editor
-											ImageName: erase
-						Button@CLEAR_CURRENT_BUTTON:
-							X: 6
-							Y: 42
-							Width: 100
-							Height: 25
-							Text: button-marker-tiles-clear-current
-							Font: Bold
-						Button@CLEAR_ALL_BUTTON:
-							X: 111
-							Y: 42
-							Width: 75
-							Height: 25
-							Text: button-marker-tiles-clear-all
-							Font: Bold
-						Label@ALPHA_LABEL:
-							X: 6
-							Y: 72
-							Width: 265
-							Height: 25
-							Align: Left
-							Text: label-marker-alpha
-						Slider@ALPHA_SLIDER:
-							X: 130
-							Y: 72
-							Width: 128
-							Height: 25
-						Label@ALPHA_VALUE:
-							X: 260
-							Y: 72
-							Width: 30
-							Height: 25
-							Align: Left
-						Label@MODE_LABEL:
-							X: 6
-							Y: 102
-							Width: 260
-							Height: 25
-							Align: Left
-							Text: label-marker-mirror-mode
-						DropDownButton@MODE_DROPDOWN:
-							X: 129
-							Y: 102
-							Width: 157
-							Height: 25
-						Label@NUM_SIDES_LABEL:
-							X: 6
-							Y: 132
-							Width: 256
-							Height: 25
-							Align: Left
-							Text: label-marker-layer-num-sides
-						Slider@ROTATE_NUM_SIDES_SLIDER:
-							X: 130
-							Y: 132
-							Width: 128
-							Height: 25
-							Visible: false
-						Label@ROTATE_NUM_SIDES_VALUE:
-							X: 260
-							Y: 132
-							Width: 30
-							Height: 25
-							Align: Left
-							Visible: false
-						DropDownButton@FLIP_NUM_SIDES_DROPDOWN:
-							X: 129
-							Y: 132
-							Width: 157
-							Height: 25
-						Label@AXIS_ANGLE_LABEL:
-							X: 6
-							Y: 162
-							Width: 256
-							Height: 25
-							Align: Left
-							Text: label-marker-axis-angle
-							Visible: false
-						Slider@AXIS_ANGLE_SLIDER:
-							X: 130
-							Y: 162
-							Width: 128
-							Height: 25
-							Visible: false
-						Label@AXIS_ANGLE_VALUE:
-							X: 260
-							Y: 162
-							Width: 30
-							Height: 25
-							Align: Left
-							Visible: false
-				ScrollPanel@MAP_GENERATOR_TOOL_PANEL:
-					Y: 25
-					Width: PARENT_WIDTH
-					Height: PARENT_HEIGHT - 25
-					Visible: false
-					ScrollBar: Hidden
-					ScrollbarWidth: 0
-					Logic: MapGeneratorToolLogic
-					Children:
-						LabelForInput@GENERATOR_LABEL:
-							Y: 5
-							Width: 65
-							Height: 25
-							Align: Right
-							Font: TinyBold
-							Text: label-map-generator-generator
-							For: GENERATOR
-						DropDownButton@GENERATOR:
-							X: 70
-							Y: 5
-							Width: PARENT_WIDTH - 75
-							Height: 25
-							Font: Bold
-						Button@GENERATE_BUTTON:
-							X: 5
-							Y: 45
-							Width: 95
-							Height: 25
-							Text: button-map-generator-generate
-							Font: Bold
-						Button@GENERATE_RANDOM_BUTTON:
-							X: 105
-							Y: 45
-							Width: 180
-							Height: 25
-							Text: button-map-generator-generate-random
-							Font: Bold
-						ScrollPanel@SETTINGS_PANEL:
-							X: 0
-							Y: 85
-							Width: PARENT_WIDTH
-							Height: PARENT_HEIGHT - 85
-							Children:
-								Container@CHECKBOX_TEMPLATE:
-									X: 5
-									Width: PARENT_WIDTH - 35
-									Height: 30
-									Children:
-										Checkbox@CHECKBOX:
-											Width: PARENT_WIDTH
-											Height: 25
-								Container@TEXT_TEMPLATE:
-									X: 5
-									Width: PARENT_WIDTH - 35
-									Height: 50
-									Children:
-										LabelForInput@LABEL:
-											Y: 0
-											Width: PARENT_WIDTH
-											Height: 20
-											For: INPUT
-										TextField@INPUT:
-											Y: 20
-											Width: PARENT_WIDTH
-											Height: 25
-								Container@DROPDOWN_TEMPLATE:
-									X: 5
-									Width: PARENT_WIDTH - 35
-									Height: 50
-									Children:
-										LabelForInput@LABEL:
-											Y: 0
-											Width: PARENT_WIDTH
-											Height: 20
-											For: DROPDOWN
-										DropDownButton@DROPDOWN:
-											Y: 20
-											Width: PARENT_WIDTH
-											Height: 25
-											PanelRoot: EDITOR_WORLD_ROOT
 		Container@HISTORY_WIDGETS:
 			X: WINDOW_WIDTH - 295
 			Y: 318
@@ -1085,3 +873,207 @@ ScrollPanel@OVERLAY_PANEL:
 			Width: PARENT_WIDTH - 29
 			Height: 20
 			Visible: false
+
+Background@MARKER_TOOL_PANEL:
+	Logic: MapMarkerTilesLogic
+	Y: 24
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT - 25
+	Background: scrollpanel-bg
+	Visible: false
+	Children:
+		ScrollPanel@TILE_COLOR_PANEL:
+			X: 6
+			Y: 6
+			Width: PARENT_WIDTH - 19
+			Height: 31
+			TopBottomSpacing: 1
+			ItemSpacing: 1
+			ScrollBar: Hidden
+			ScrollbarWidth: 0
+			ContentHeight: 31
+			Children:
+				ScrollItem@TILE_COLOR_TEMPLATE:
+					Visible: false
+					Height: 29
+					Width: 29
+					IgnoreChildMouseOver: true
+					Children:
+						ColorBlock@TILE_PREVIEW:
+							X: 2
+							Y: 2
+							Width: 26
+							Height: 26
+				ScrollItem@TILE_ICON_TEMPLATE:
+					Visible: false
+					Height: 29
+					Width: 29
+					IgnoreChildMouseOver: true
+					Children:
+						Image@TILE_ERASE:
+							X: 6
+							Y: 6
+							Width: 26
+							Height: 26
+							ImageCollection: editor
+							ImageName: erase
+		Button@CLEAR_CURRENT_BUTTON:
+			X: 6
+			Y: 42
+			Width: 100
+			Height: 25
+			Text: button-marker-tiles-clear-current
+			Font: Bold
+		Button@CLEAR_ALL_BUTTON:
+			X: 111
+			Y: 42
+			Width: 75
+			Height: 25
+			Text: button-marker-tiles-clear-all
+			Font: Bold
+		Label@ALPHA_LABEL:
+			X: 6
+			Y: 72
+			Width: 265
+			Height: 25
+			Align: Left
+			Text: label-marker-alpha
+		Slider@ALPHA_SLIDER:
+			X: 130
+			Y: 72
+			Width: 128
+			Height: 25
+		Label@ALPHA_VALUE:
+			X: 260
+			Y: 72
+			Width: 30
+			Height: 25
+			Align: Left
+		Label@MODE_LABEL:
+			X: 6
+			Y: 102
+			Width: 260
+			Height: 25
+			Align: Left
+			Text: label-marker-mirror-mode
+		DropDownButton@MODE_DROPDOWN:
+			X: 129
+			Y: 102
+			Width: 157
+			Height: 25
+		Label@NUM_SIDES_LABEL:
+			X: 6
+			Y: 132
+			Width: 256
+			Height: 25
+			Align: Left
+			Text: label-marker-layer-num-sides
+		Slider@ROTATE_NUM_SIDES_SLIDER:
+			X: 130
+			Y: 132
+			Width: 128
+			Height: 25
+			Visible: false
+		Label@ROTATE_NUM_SIDES_VALUE:
+			X: 260
+			Y: 132
+			Width: 30
+			Height: 25
+			Align: Left
+			Visible: false
+		DropDownButton@FLIP_NUM_SIDES_DROPDOWN:
+			X: 129
+			Y: 132
+			Width: 157
+			Height: 25
+		Label@AXIS_ANGLE_LABEL:
+			X: 6
+			Y: 162
+			Width: 256
+			Height: 25
+			Align: Left
+			Text: label-marker-axis-angle
+			Visible: false
+		Slider@AXIS_ANGLE_SLIDER:
+			X: 130
+			Y: 162
+			Width: 128
+			Height: 25
+			Visible: false
+		Label@AXIS_ANGLE_VALUE:
+			X: 260
+			Y: 162
+			Width: 30
+			Height: 25
+			Align: Left
+			Visible: false
+
+Container@MAP_GENERATOR_TOOL_PANEL:
+	Logic: MapGeneratorToolLogic
+	Y: 24
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT - 25
+	Visible: false
+	Children:
+		Background@BUTTON_BG:
+			Background: panel-black
+			Width: PARENT_WIDTH
+			Height: 35
+			Children:
+				Button@GENERATE_BUTTON:
+					X: 5
+					Y: 5
+					Width: 95
+					Height: 25
+					Text: button-map-generator-generate
+					Font: Bold
+				Button@GENERATE_RANDOM_BUTTON:
+					X: 105
+					Y: 5
+					Width: 180
+					Height: 25
+					Text: button-map-generator-generate-random
+					Font: Bold
+		ScrollPanel@SETTINGS_PANEL:
+			X: 0
+			Y: 34
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT - 35
+			Children:
+				Container@CHECKBOX_TEMPLATE:
+					X: 5
+					Width: PARENT_WIDTH - 35
+					Height: 30
+					Children:
+						Checkbox@CHECKBOX:
+							Width: PARENT_WIDTH
+							Height: 25
+				Container@TEXT_TEMPLATE:
+					X: 5
+					Width: PARENT_WIDTH - 35
+					Height: 50
+					Children:
+						LabelForInput@LABEL:
+							Y: 0
+							Width: PARENT_WIDTH
+							Height: 20
+							For: INPUT
+						TextField@INPUT:
+							Y: 20
+							Width: PARENT_WIDTH
+							Height: 25
+				Container@DROPDOWN_TEMPLATE:
+					X: 5
+					Width: PARENT_WIDTH - 35
+					Height: 50
+					Children:
+						LabelForInput@LABEL:
+							Y: 0
+							Width: PARENT_WIDTH
+							Height: 20
+							For: DROPDOWN
+						DropDownButton@DROPDOWN:
+							Y: 20
+							Width: PARENT_WIDTH
+							Height: 25
+							PanelRoot: EDITOR_WORLD_ROOT

--- a/mods/cnc/fluent/chrome.ftl
+++ b/mods/cnc/fluent/chrome.ftl
@@ -76,7 +76,6 @@ label-marker-layer-num-sides = Number of Sides
 label-marker-alpha = Tile Alpha
 label-marker-mirror-mode = Mirror Mode
 label-marker-axis-angle = Axis Angle
-label-map-generator-generator = Generator
 button-map-generator-generate = Generate
 button-map-generator-generate-random = Generate Random
 
@@ -116,7 +115,6 @@ button-select-categories-buttons-all = All
 button-select-categories-buttons-none = None
 
 label-tool-marker-tiles = Marker Tiles
-label-tool-map-generator = Map Generator
 
 ## encyclopedia.yaml, mainmenu.yaml
 label-encyclopedia-title = EVA Database

--- a/mods/cnc/fluent/rules.ftl
+++ b/mods/cnc/fluent/rules.ftl
@@ -51,8 +51,8 @@ faction-nod =
      and the alien substance Tiberium. They use stealth technology
      and guerilla tactics to defeat those who oppose them.
 
-map-generator-experimental = Experimental
-map-generator-clear = Clear
+map-generator-experimental = Experimental RMG
+map-generator-clear = Clear Terrain
 
 ## defaults.yaml
 notification-unit-lost = Unit lost.

--- a/mods/cnc/rules/map-generators.yaml
+++ b/mods/cnc/rules/map-generators.yaml
@@ -3,7 +3,7 @@
 		Type: experimental
 		Name: map-generator-experimental
 		Settings:
-			Option@hidden_defaults:
+			MultiChoiceOption@hidden_defaults:
 				Choice@hidden_defaults:
 					Settings:
 						TerrainFeatureSize: 20480
@@ -71,7 +71,7 @@
 						ForestObstacles: Trees
 						UnplayableObstacles: Obstructions
 						CivilianBuildingsObstacles: CivilianBuildings
-			Option@hidden_tileset_overrides:
+			MultiChoiceOption@hidden_tileset_overrides:
 				Choice@common:
 					Tileset: DESERT,SNOW,TEMPERAT
 					Settings:
@@ -87,12 +87,11 @@
 						RepaintTiles:
 							255: Snow
 							1: Water
-			Option@Seed:
+			IntegerOption@Seed:
 				Label: label-cnc-map-generator-option-seed
-				Random: True
+				Parameter: Seed
 				Default: 0
-				Integer: Seed
-			Option@TerrainType:
+			MultiChoiceOption@TerrainType:
 				Label: label-cnc-map-generator-option-terrain-type
 				Priority: 2
 				Default: Gardens,Rocky
@@ -170,13 +169,13 @@
 						Mountains: 1000
 						Roughness: 850
 						MinimumTerrainContourSpacing: 5
-			Option@Rotations:
+			MultiIntegerChoiceOption@Rotations:
 				Label: label-cnc-map-generator-option-rotations
-				SimpleChoice: Rotations
-					Values: 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16
+				Parameter: Rotations
+				Choices: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 				Default: 2
 				Priority: 1
-			Option@Mirror:
+			MultiChoiceOption@Mirror:
 				Label: label-cnc-map-generator-option-mirror
 				Default: None
 				Priority: 1
@@ -200,7 +199,7 @@
 					Label: label-cnc-map-generator-choice-mirror-top-right-matches-bottom-left
 					Settings:
 						Mirror: TopRightMatchesBottomLeft
-			Option@Shape:
+			MultiChoiceOption@Shape:
 				Label: label-cnc-map-generator-option-shape
 				Default: Square
 				Priority: 1
@@ -217,13 +216,13 @@
 					Tileset: DESERT
 					Settings:
 						ExternalCircularBias: -1
-			Option@Players:
+			MultiIntegerChoiceOption@Players:
 				Label: label-cnc-map-generator-option-players
-				SimpleChoice: Players
-					Values: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16
+				Parameter: Players
+				Choices: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 				Default: 1
 				Priority: 1
-			Option@Resources:
+			MultiChoiceOption@Resources:
 				Label: label-cnc-map-generator-option-resources
 				Default: Medium
 				Choice@None:
@@ -285,7 +284,7 @@
 						ResourceSpawnWeights:
 						MaximumExpansionResourceSpawns: 0
 						MaximumResourceSpawnsPerExpansion: 1
-			Option@Buildings:
+			MultiChoiceOption@Buildings:
 				Label: label-cnc-map-generator-option-buildings
 				Default: Standard
 				Choice@None:
@@ -327,7 +326,7 @@
 						MaximumBuildings: 10
 						BuildingWeights:
 							v19: 1
-			Option@Density:
+			MultiChoiceOption@Density:
 				Label: label-cnc-map-generator-option-density
 				Default: Players
 				Priority: 1
@@ -366,17 +365,17 @@
 					Settings:
 						AreaEntityBonus: 800
 						PlayerCountEntityBonus: 0
-			Option@DenyWalledArea:
+			BooleanOption@DenyWalledArea:
 				Label: label-cnc-map-generator-option-deny-walled-areas
-				Checkbox: DenyWalledAreas
+				Parameter: DenyWalledAreas
 				Default: True
 				Priority: 1
-			Option@Roads:
+			BooleanOption@Roads:
 				Label: label-cnc-map-generator-option-roads
-				Checkbox: Roads
+				Parameter: Roads
 				Default: True
 				Priority: 1
-			Option@CivilianDensity:
+			MultiChoiceOption@CivilianDensity:
 				Label: label-cnc-map-generator-option-civilian-density
 				Default: Default
 				Priority: 3
@@ -411,7 +410,7 @@
 		Type: clear
 		Name: map-generator-clear
 		Settings:
-			Option@Tile:
+			MultiChoiceOption@Tile:
 				Label: label-clear-map-generator-option-tile
 				Choice@CommonClear:
 					Label: label-clear-map-generator-choice-tile-clear

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -281,7 +281,6 @@ World:
 
 EditorWorld:
 	Inherits: ^BaseWorld
-	Inherits@MapGenerators: ^MapGenerators
 	EditorActorLayer:
 	EditorCursorLayer:
 	EditorResourceLayer:
@@ -302,3 +301,4 @@ EditorWorld:
 	BuildableTerrainOverlay:
 		AllowedTerrainTypes: Clear, Road
 	MarkerLayerOverlay:
+	Inherits@MapGenerators: ^MapGenerators

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -408,220 +408,6 @@ Container@EDITOR_WORLD_ROOT:
 					Width: PARENT_WIDTH - 70
 					Height: 25
 					Font: Bold
-				Background@MARKER_TOOL_PANEL:
-					X: 10
-					Y: 35
-					Width: PARENT_WIDTH - 20
-					Height: WINDOW_HEIGHT - 490
-					Background: scrollpanel-bg
-					Logic: MapMarkerTilesLogic
-					Children:
-						ScrollPanel@TILE_COLOR_PANEL:
-							X: 6
-							Y: 6
-							Width: PARENT_WIDTH - 19
-							Height: 31
-							TopBottomSpacing: 1
-							ItemSpacing: 1
-							ScrollBar: Hidden
-							ScrollbarWidth: 0
-							ContentHeight: 31
-							Children:
-								ScrollItem@TILE_COLOR_TEMPLATE:
-									Visible: false
-									Height: 29
-									Width: 29
-									IgnoreChildMouseOver: true
-									Children:
-										ColorBlock@TILE_PREVIEW:
-											X: 2
-											Y: 2
-											Width: 26
-											Height: 26
-								ScrollItem@TILE_ICON_TEMPLATE:
-									Visible: false
-									Height: 29
-									Width: 29
-									IgnoreChildMouseOver: true
-									Children:
-										Image@TILE_ERASE:
-											X: 6
-											Y: 6
-											Width: 26
-											Height: 26
-											ImageCollection: editor
-											ImageName: erase
-						Button@CLEAR_CURRENT_BUTTON:
-							X: 6
-							Y: 42
-							Width: 100
-							Height: 25
-							Text: button-marker-tiles-clear-current
-							Font: Bold
-						Button@CLEAR_ALL_BUTTON:
-							X: 111
-							Y: 42
-							Width: 75
-							Height: 25
-							Text: button-marker-tiles-clear-all
-							Font: Bold
-						Label@ALPHA_LABEL:
-							X: 6
-							Y: 72
-							Width: 265
-							Height: 25
-							Align: Left
-							Text: label-marker-alpha
-						Slider@ALPHA_SLIDER:
-							X: 130
-							Y: 72
-							Width: 128
-							Height: 25
-						Label@ALPHA_VALUE:
-							X: 260
-							Y: 72
-							Width: 30
-							Height: 25
-							Align: Left
-						Label@MODE_LABEL:
-							X: 6
-							Y: 102
-							Width: 260
-							Height: 25
-							Align: Left
-							Text: label-marker-mirror-mode
-						DropDownButton@MODE_DROPDOWN:
-							X: 129
-							Y: 102
-							Width: 157
-							Height: 25
-						Label@NUM_SIDES_LABEL:
-							X: 6
-							Y: 132
-							Width: 256
-							Height: 25
-							Align: Left
-							Text: label-marker-layer-num-sides
-						Slider@ROTATE_NUM_SIDES_SLIDER:
-							X: 130
-							Y: 132
-							Width: 128
-							Height: 25
-							Visible: false
-						Label@ROTATE_NUM_SIDES_VALUE:
-							X: 260
-							Y: 132
-							Width: 30
-							Height: 25
-							Align: Left
-							Visible: false
-						DropDownButton@FLIP_NUM_SIDES_DROPDOWN:
-							X: 129
-							Y: 132
-							Width: 157
-							Height: 25
-						Label@AXIS_ANGLE_LABEL:
-							X: 6
-							Y: 162
-							Width: 256
-							Height: 25
-							Align: Left
-							Text: label-marker-axis-angle
-							Visible: false
-						Slider@AXIS_ANGLE_SLIDER:
-							X: 130
-							Y: 162
-							Width: 128
-							Height: 25
-							Visible: false
-						Label@AXIS_ANGLE_VALUE:
-							X: 260
-							Y: 162
-							Width: 30
-							Height: 25
-							Align: Left
-							Visible: false
-				ScrollPanel@MAP_GENERATOR_TOOL_PANEL:
-					X: 9
-					Y: 35
-					Width: 290
-					Height: WINDOW_HEIGHT - 490
-					Visible: false
-					ScrollBar: Hidden
-					ScrollbarWidth: 0
-					Logic: MapGeneratorToolLogic
-					Children:
-						LabelForInput@GENERATOR_LABEL:
-							Y: 5
-							Width: 65
-							Height: 25
-							Align: Right
-							Font: TinyBold
-							Text: label-map-generator-generator
-							For: GENERATOR
-						DropDownButton@GENERATOR:
-							X: 70
-							Y: 5
-							Width: PARENT_WIDTH - 75
-							Height: 25
-							Font: Bold
-						Button@GENERATE_BUTTON:
-							X: 5
-							Y: 45
-							Width: 95
-							Height: 25
-							Text: button-map-generator-generate
-							Font: Bold
-						Button@GENERATE_RANDOM_BUTTON:
-							X: 105
-							Y: 45
-							Width: 180
-							Height: 25
-							Text: button-map-generator-generate-random
-							Font: Bold
-						ScrollPanel@SETTINGS_PANEL:
-							X: 0
-							Y: 85
-							Width: PARENT_WIDTH
-							Height: PARENT_HEIGHT - 85
-							Children:
-								Container@CHECKBOX_TEMPLATE:
-									X: 5
-									Width: PARENT_WIDTH - 35
-									Height: 30
-									Children:
-										Checkbox@CHECKBOX:
-											Width: PARENT_WIDTH
-											Height: 25
-								Container@TEXT_TEMPLATE:
-									X: 5
-									Width: PARENT_WIDTH - 35
-									Height: 50
-									Children:
-										LabelForInput@LABEL:
-											Y: 0
-											Width: PARENT_WIDTH
-											Height: 20
-											For: INPUT
-										TextField@INPUT:
-											Y: 20
-											Width: PARENT_WIDTH
-											Height: 25
-								Container@DROPDOWN_TEMPLATE:
-									X: 5
-									Width: PARENT_WIDTH - 35
-									Height: 50
-									Children:
-										LabelForInput@LABEL:
-											Y: 0
-											Width: PARENT_WIDTH
-											Height: 20
-											For: DROPDOWN
-										DropDownButton@DROPDOWN:
-											Y: 20
-											Width: PARENT_WIDTH
-											Height: 25
-											PanelRoot: EDITOR_WORLD_ROOT
 		Container@HISTORY_WIDGETS:
 			X: WINDOW_WIDTH - 320
 			Y: 354
@@ -1062,3 +848,205 @@ ScrollPanel@OVERLAY_PANEL:
 			Width: PARENT_WIDTH - 29
 			Height: 20
 			Visible: false
+
+Background@MARKER_TOOL_PANEL:
+	X: 10
+	Y: 35
+	Width: PARENT_WIDTH - 20
+	Height: WINDOW_HEIGHT - 490
+	Background: scrollpanel-bg
+	Logic: MapMarkerTilesLogic
+	Children:
+		ScrollPanel@TILE_COLOR_PANEL:
+			X: 6
+			Y: 6
+			Width: PARENT_WIDTH - 19
+			Height: 31
+			TopBottomSpacing: 1
+			ItemSpacing: 1
+			ScrollBar: Hidden
+			ScrollbarWidth: 0
+			ContentHeight: 31
+			Children:
+				ScrollItem@TILE_COLOR_TEMPLATE:
+					Visible: false
+					Height: 29
+					Width: 29
+					IgnoreChildMouseOver: true
+					Children:
+						ColorBlock@TILE_PREVIEW:
+							X: 2
+							Y: 2
+							Width: 26
+							Height: 26
+				ScrollItem@TILE_ICON_TEMPLATE:
+					Visible: false
+					Height: 29
+					Width: 29
+					IgnoreChildMouseOver: true
+					Children:
+						Image@TILE_ERASE:
+							X: 6
+							Y: 6
+							Width: 26
+							Height: 26
+							ImageCollection: editor
+							ImageName: erase
+		Button@CLEAR_CURRENT_BUTTON:
+			X: 6
+			Y: 42
+			Width: 100
+			Height: 25
+			Text: button-marker-tiles-clear-current
+			Font: Bold
+		Button@CLEAR_ALL_BUTTON:
+			X: 111
+			Y: 42
+			Width: 75
+			Height: 25
+			Text: button-marker-tiles-clear-all
+			Font: Bold
+		Label@ALPHA_LABEL:
+			X: 6
+			Y: 72
+			Width: 265
+			Height: 25
+			Align: Left
+			Text: label-marker-alpha
+		Slider@ALPHA_SLIDER:
+			X: 130
+			Y: 72
+			Width: 128
+			Height: 25
+		Label@ALPHA_VALUE:
+			X: 260
+			Y: 72
+			Width: 30
+			Height: 25
+			Align: Left
+		Label@MODE_LABEL:
+			X: 6
+			Y: 102
+			Width: 260
+			Height: 25
+			Align: Left
+			Text: label-marker-mirror-mode
+		DropDownButton@MODE_DROPDOWN:
+			X: 129
+			Y: 102
+			Width: 157
+			Height: 25
+		Label@NUM_SIDES_LABEL:
+			X: 6
+			Y: 132
+			Width: 256
+			Height: 25
+			Align: Left
+			Text: label-marker-layer-num-sides
+		Slider@ROTATE_NUM_SIDES_SLIDER:
+			X: 130
+			Y: 132
+			Width: 128
+			Height: 25
+			Visible: false
+		Label@ROTATE_NUM_SIDES_VALUE:
+			X: 260
+			Y: 132
+			Width: 30
+			Height: 25
+			Align: Left
+			Visible: false
+		DropDownButton@FLIP_NUM_SIDES_DROPDOWN:
+			X: 129
+			Y: 132
+			Width: 157
+			Height: 25
+		Label@AXIS_ANGLE_LABEL:
+			X: 6
+			Y: 162
+			Width: 256
+			Height: 25
+			Align: Left
+			Text: label-marker-axis-angle
+			Visible: false
+		Slider@AXIS_ANGLE_SLIDER:
+			X: 130
+			Y: 162
+			Width: 128
+			Height: 25
+			Visible: false
+		Label@AXIS_ANGLE_VALUE:
+			X: 260
+			Y: 162
+			Width: 30
+			Height: 25
+			Align: Left
+			Visible: false
+
+ScrollPanel@MAP_GENERATOR_TOOL_PANEL:
+	X: 9
+	Y: 35
+	Width: 290
+	Height: WINDOW_HEIGHT - 490
+	Visible: false
+	ScrollBar: Hidden
+	ScrollbarWidth: 0
+	Logic: MapGeneratorToolLogic
+	Children:
+		Button@GENERATE_BUTTON:
+			X: 5
+			Y: 5
+			Width: 95
+			Height: 25
+			Text: button-map-generator-generate
+			Font: Bold
+		Button@GENERATE_RANDOM_BUTTON:
+			X: 105
+			Y: 5
+			Width: 180
+			Height: 25
+			Text: button-map-generator-generate-random
+			Font: Bold
+		ScrollPanel@SETTINGS_PANEL:
+			X: 0
+			Y: 35
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT - 35
+			Children:
+				Container@CHECKBOX_TEMPLATE:
+					X: 5
+					Width: PARENT_WIDTH - 35
+					Height: 30
+					Children:
+						Checkbox@CHECKBOX:
+							Width: PARENT_WIDTH
+							Height: 25
+				Container@TEXT_TEMPLATE:
+					X: 5
+					Width: PARENT_WIDTH - 35
+					Height: 50
+					Children:
+						LabelForInput@LABEL:
+							Y: 0
+							Width: PARENT_WIDTH
+							Height: 20
+							For: INPUT
+						TextField@INPUT:
+							Y: 20
+							Width: PARENT_WIDTH
+							Height: 25
+				Container@DROPDOWN_TEMPLATE:
+					X: 5
+					Width: PARENT_WIDTH - 35
+					Height: 50
+					Children:
+						LabelForInput@LABEL:
+							Y: 0
+							Width: PARENT_WIDTH
+							Height: 20
+							For: DROPDOWN
+						DropDownButton@DROPDOWN:
+							Y: 20
+							Width: PARENT_WIDTH
+							Height: 25
+							PanelRoot: EDITOR_WORLD_ROOT

--- a/mods/common/fluent/chrome.ftl
+++ b/mods/common/fluent/chrome.ftl
@@ -72,7 +72,6 @@ label-marker-layer-num-sides = Number of Sides
 label-marker-alpha = Tile Alpha
 label-marker-mirror-mode = Mirror Mode
 label-marker-axis-angle = Axis Angle
-label-map-generator-generator = Generator
 button-map-generator-generate = Generate
 button-map-generator-generate-random = Generate Random
 
@@ -116,7 +115,6 @@ button-select-categories-buttons-all = All
 button-select-categories-buttons-none = None
 
 label-tool-marker-tiles = Marker Tiles
-label-tool-map-generator = Map Generator
 
 ## gamesave-browser.yaml
 label-gamesave-browser-panel-load-title = Load game

--- a/mods/common/fluent/common.ftl
+++ b/mods/common/fluent/common.ftl
@@ -1142,5 +1142,4 @@ keycode =
 ## MapGeneratorToolLogic
 label-map-generator-failed-cancel = Dismiss
 notification-map-generator-generated = Generated using { $name }
-notification-map-generator-bad-option = Option "{ $option }" is invalid
 notification-map-generator-failed = Map generation failed

--- a/mods/ra/fluent/rules.ftl
+++ b/mods/ra/fluent/rules.ftl
@@ -34,8 +34,8 @@ options-starting-units =
 
 resource-minerals = Valuable Minerals
 
-map-generator-experimental = Experimental
-map-generator-clear = Clear
+map-generator-experimental = Experimental RMG
+map-generator-clear = Clear Terrain
 
 ## Faction
 faction-allies =

--- a/mods/ra/rules/map-generators.yaml
+++ b/mods/ra/rules/map-generators.yaml
@@ -3,7 +3,7 @@
 		Type: experimental
 		Name: map-generator-experimental
 		Settings:
-			Option@hidden_defaults:
+			MultiChoiceOption@hidden_defaults:
 				Choice@hidden_defaults:
 					Settings:
 						TerrainFeatureSize: 20480
@@ -70,7 +70,7 @@
 						ForestObstacles: Trees
 						UnplayableObstacles: Obstructions
 						CivilianBuildingsObstacles: CivilianBuildings
-			Option@hidden_tileset_overrides:
+			MultiChoiceOption@hidden_tileset_overrides:
 				Choice@desert:
 					Tileset: DESERT
 					Settings:
@@ -86,12 +86,11 @@
 					Settings:
 						LandTile: 255
 						WaterTile: 1
-			Option@Seed:
+			IntegerOption@Seed:
 				Label: label-ra-map-generator-option-seed
-				Random: True
+				Parameter: Seed
 				Default: 0
-				Integer: Seed
-			Option@TerrainType:
+			MultiChoiceOption@TerrainType:
 				Label: label-ra-map-generator-option-terrain-type
 				Priority: 2
 				Default: Gardens
@@ -193,13 +192,13 @@
 						Forests: 0
 						SpawnBuildSize: 6
 						MinimumSpawnRadius: 4
-			Option@Rotations:
+			MultiIntegerChoiceOption@Rotations:
 				Label: label-ra-map-generator-option-rotations
-				SimpleChoice: Rotations
-					Values: 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16
+				Parameter: Rotations
+				Choices: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 				Default: 2
 				Priority: 1
-			Option@Mirror:
+			MultiChoiceOption@Mirror:
 				Label: label-ra-map-generator-option-mirror
 				Default: None
 				Priority: 1
@@ -223,7 +222,7 @@
 					Label: label-ra-map-generator-choice-mirror-top-right-matches-bottom-left
 					Settings:
 						Mirror: TopRightMatchesBottomLeft
-			Option@Shape:
+			MultiChoiceOption@Shape:
 				Label: label-ra-map-generator-option-shape
 				Default: Square
 				Priority: 1
@@ -239,13 +238,13 @@
 					Label: label-ra-map-generator-choice-shape-circle-water
 					Settings:
 						ExternalCircularBias: -1
-			Option@Players:
+			MultiIntegerChoiceOption@Players:
 				Label: label-ra-map-generator-option-players
-				SimpleChoice: Players
-					Values: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16
+				Parameter: Players
+				Choices: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 				Default: 1
 				Priority: 1
-			Option@Resources:
+			MultiChoiceOption@Resources:
 				Label: label-ra-map-generator-option-resources
 				Default: Medium
 				Choice@None:
@@ -303,7 +302,7 @@
 						ResourceSpawnWeights:
 						MaximumExpansionResourceSpawns: 0
 						MaximumResourceSpawnsPerExpansion: 1
-			Option@Buildings:
+			MultiChoiceOption@Buildings:
 				Label: label-ra-map-generator-option-buildings
 				Default: Standard
 				Choice@None:
@@ -346,7 +345,7 @@
 						MaximumBuildings: 10
 						BuildingWeights:
 							oilb: 1
-			Option@Density:
+			MultiChoiceOption@Density:
 				Label: label-ra-map-generator-option-density
 				Default: Players
 				Priority: 1
@@ -385,17 +384,17 @@
 					Settings:
 						AreaEntityBonus: 800
 						PlayerCountEntityBonus: 0
-			Option@DenyWalledArea:
+			BooleanOption@DenyWalledArea:
 				Label: label-ra-map-generator-option-deny-walled-areas
-				Checkbox: DenyWalledAreas
+				Parameter: DenyWalledAreas
 				Default: True
 				Priority: 1
-			Option@Roads:
+			BooleanOption@Roads:
 				Label: label-ra-map-generator-option-roads
-				Checkbox: Roads
+				Parameter: Roads
 				Default: True
 				Priority: 1
-			Option@CivilianDensity:
+			MultiChoiceOption@CivilianDensity:
 				Label: label-ra-map-generator-option-civilian-density
 				Default: Default
 				Priority: 3
@@ -430,7 +429,7 @@
 		Type: clear
 		Name: map-generator-clear
 		Settings:
-			Option@Tile:
+			MultiChoiceOption@Tile:
 				Label: label-clear-map-generator-option-tile
 				Choice@DesertClear:
 					Label: label-clear-map-generator-choice-tile-clear

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -299,7 +299,6 @@ World:
 
 EditorWorld:
 	Inherits: ^BaseWorld
-	Inherits@MapGenerators: ^MapGenerators
 	EditorActorLayer:
 	EditorCursorLayer:
 	EditorResourceLayer:
@@ -320,3 +319,4 @@ EditorWorld:
 	BuildableTerrainOverlay:
 		AllowedTerrainTypes: Clear, Road
 	MarkerLayerOverlay:
+	Inherits@MapGenerators: ^MapGenerators


### PR DESCRIPTION
This PR rewrites the map generator settings UI logic to be more consistent with OpenRA design conventions, and to improve flexibility for the planned future changes. Most of the validation logic that previously needed to be explicit is now enforced by the type system.

There shouldn't be any notable changes in ingame behaviour. See my `rmg-player-count` and `skirmish-rmg` branches for examples of what the improved flexibility enables.