### PR TITLE
Simplify map generator Player and Symmetry options

### DIFF
--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -980,6 +980,8 @@ namespace OpenRA.Mods.Common.Traits
 		/// <summary>Returns the options that allow users to customise the result.</summary>
 		List<MapGeneratorOption> Options { get; }
 
+		int PlayerCount { get; }
+
 		void Randomize(MersenneTwister random);
 
 		/// <summary>Merge all choices into a complete settings MiniYaml.</summary>

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
@@ -110,6 +110,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (generator == null)
 				return;
 
+			var playerCount = settings.PlayerCount;
 			foreach (var o in settings.Options)
 			{
 				Widget settingWidget = null;
@@ -161,9 +162,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							ScrollItemWidget SetupItem(int choice, ScrollItemWidget template)
 							{
 								bool IsSelected() => choice == mio.Value;
-								void OnClick() => mio.Value = choice;
-								var item = ScrollItemWidget.Setup(template, IsSelected, OnClick);
+								void OnClick()
+								{
+									mio.Value = choice;
+									if (o.Id == "Players")
+										UpdateSettingsUi();
+								}
 
+								var item = ScrollItemWidget.Setup(template, IsSelected, OnClick);
 								var itemLabel = FieldSaver.FormatValue(choice);
 								item.Get<LabelWidget>("LABEL").GetText = () => itemLabel;
 								item.GetTooltipText = null;
@@ -177,7 +183,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					case MapGeneratorMultiChoiceOption mo:
 					{
-						var validChoices = mo.ValidChoices(world.Map.Rules.TerrainInfo);
+						var validChoices = mo.ValidChoices(world.Map.Rules.TerrainInfo, playerCount);
 						if (!validChoices.Contains(mo.Value))
 							mo.Value = mo.Default?.FirstOrDefault(validChoices.Contains) ?? validChoices.FirstOrDefault();
 

--- a/mods/cnc/fluent/rules.ftl
+++ b/mods/cnc/fluent/rules.ftl
@@ -821,19 +821,31 @@ label-cnc-map-generator-choice-terrain-type-mountain-lakes =
    .label = Mountain Lakes
    .description = Lakes and many long cliffs
 
-label-cnc-map-generator-option-rotations = Rotations
-
-label-cnc-map-generator-option-mirror = Mirror
+label-cnc-map-generator-option-symmetry = Symmetry
 label-cnc-map-generator-choice-mirror-none =
    .label = None
-label-cnc-map-generator-choice-mirror-left-matches-right =
-   .label = Left vs right
-label-cnc-map-generator-choice-mirror-top-left-matches-bottom-right =
-   .label = Top left vs bottom right
-label-cnc-map-generator-choice-mirror-top-matches-bottom =
-   .label = Top vs bottom
-label-cnc-map-generator-choice-mirror-top-right-matches-bottom-left =
-   .label = Top right vs bottom left
+label-cnc-map-generator-choice-symmetry-mirror-horizontal =
+   .label = Mirror Horizontal
+label-cnc-map-generator-choice-symmetry-mirror-vertical =
+   .label = Mirror Vertical
+label-cnc-map-generator-choice-symmetry-mirror-diagonal-tl =
+   .label = Mirror Diagonal (Top-Left)
+label-cnc-map-generator-choice-symmetry-mirror-diagonal-tr =
+   .label = Mirror Diagonal (Top-Right)
+label-cnc-map-generator-choice-symmetry-mirror-2-rotations =
+   .label = 2 Rotations
+label-cnc-map-generator-choice-symmetry-mirror-3-rotations =
+   .label = 3 Rotations
+label-cnc-map-generator-choice-symmetry-mirror-4-rotations =
+   .label = 4 Rotations
+label-cnc-map-generator-choice-symmetry-mirror-5-rotations =
+   .label = 5 Rotations
+label-cnc-map-generator-choice-symmetry-mirror-6-rotations =
+   .label = 6 Rotations
+label-cnc-map-generator-choice-symmetry-mirror-7-rotations =
+   .label = 7 Rotations
+label-cnc-map-generator-choice-symmetry-mirror-8-rotations =
+   .label = 8 Rotations
 
 label-cnc-map-generator-option-shape = Bounds Shape
 label-cnc-map-generator-choice-shape-square =
@@ -846,7 +858,7 @@ label-cnc-map-generator-choice-shape-circle-water =
    .label = Circle in water
    .description = Terrain generation is constrained to a circle enclosed by water
 
-label-cnc-map-generator-option-players = Players per side
+label-cnc-map-generator-option-players = Players
 
 label-cnc-map-generator-option-resources = Resources
 label-cnc-map-generator-choice-resources-none =

--- a/mods/cnc/rules/map-generators.yaml
+++ b/mods/cnc/rules/map-generators.yaml
@@ -71,6 +71,8 @@
 						ForestObstacles: Trees
 						UnplayableObstacles: Obstructions
 						CivilianBuildingsObstacles: CivilianBuildings
+						Mirror: None
+						Rotations: 1
 			MultiChoiceOption@hidden_tileset_overrides:
 				Choice@common:
 					Tileset: DESERT,SNOW,TEMPERAT
@@ -169,14 +171,14 @@
 						Mountains: 1000
 						Roughness: 850
 						MinimumTerrainContourSpacing: 5
-			MultiIntegerChoiceOption@Rotations:
-				Label: label-cnc-map-generator-option-rotations
-				Parameter: Rotations
+			MultiIntegerChoiceOption@Players:
+				Label: label-cnc-map-generator-option-players
+				Parameter: Players
 				Choices: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 				Default: 2
 				Priority: 1
-			MultiChoiceOption@Mirror:
-				Label: label-cnc-map-generator-option-mirror
+			MultiChoiceOption@Symmetry:
+				Label: label-cnc-map-generator-option-symmetry
 				Default: None
 				Priority: 1
 				Choice@None:
@@ -184,21 +186,60 @@
 					Settings:
 						Mirror: None
 				Choice@LeftMatchesRight:
-					Label: label-cnc-map-generator-choice-mirror-left-matches-right
+					Label: label-cnc-map-generator-choice-symmetry-mirror-horizontal
+					Players: 2, 4, 6, 8, 10, 12, 14, 16
 					Settings:
 						Mirror: LeftMatchesRight
 				Choice@TopLeftMatchesBottomRight:
-					Label: label-cnc-map-generator-choice-mirror-top-left-matches-bottom-right
+					Label: label-cnc-map-generator-choice-symmetry-mirror-diagonal-tl
+					Players: 2, 4, 6, 8, 10, 12, 14, 16
 					Settings:
 						Mirror: TopLeftMatchesBottomRight
 				Choice@TopMatchesBottom:
-					Label: label-cnc-map-generator-choice-mirror-top-matches-bottom
+					Label: label-cnc-map-generator-choice-symmetry-mirror-vertical
+					Players: 2, 4, 6, 8, 10, 12, 14, 16
 					Settings:
 						Mirror: TopMatchesBottom
 				Choice@TopRightMatchesBottomLeft:
-					Label: label-cnc-map-generator-choice-mirror-top-right-matches-bottom-left
+					Label: label-cnc-map-generator-choice-symmetry-mirror-diagonal-tr
+					Players: 2, 4, 6, 8, 10, 12, 14, 16
 					Settings:
 						Mirror: TopRightMatchesBottomLeft
+				Choice@2Rotations:
+					Label: label-cnc-map-generator-choice-symmetry-mirror-2-rotations
+					Players: 2, 4, 6, 8, 10, 12, 14, 16
+					Settings:
+						Rotations: 2
+				Choice@3Rotations:
+					Label: label-cnc-map-generator-choice-symmetry-mirror-3-rotations
+					Players: 3, 6, 9, 12, 15
+					Settings:
+						Rotations: 3
+				Choice@4Rotations:
+					Label: label-cnc-map-generator-choice-symmetry-mirror-4-rotations
+					Players: 4, 8, 12, 16
+					Settings:
+						Rotations: 4
+				Choice@5Rotations:
+					Label: label-cnc-map-generator-choice-symmetry-mirror-5-rotations
+					Players: 5, 10, 15
+					Settings:
+						Rotations: 5
+				Choice@6Rotations:
+					Label: label-cnc-map-generator-choice-symmetry-mirror-6-rotations
+					Players: 6, 12
+					Settings:
+						Rotations: 6
+				Choice@7Rotations:
+					Label: label-cnc-map-generator-choice-symmetry-mirror-7-rotations
+					Players: 7, 14
+					Settings:
+						Rotations: 7
+				Choice@8Rotations:
+					Label: label-cnc-map-generator-choice-symmetry-mirror-8-rotations
+					Players: 8, 16
+					Settings:
+						Rotations: 8
 			MultiChoiceOption@Shape:
 				Label: label-cnc-map-generator-option-shape
 				Default: Square
@@ -216,12 +257,6 @@
 					Tileset: DESERT
 					Settings:
 						ExternalCircularBias: -1
-			MultiIntegerChoiceOption@Players:
-				Label: label-cnc-map-generator-option-players
-				Parameter: Players
-				Choices: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
-				Default: 1
-				Priority: 1
 			MultiChoiceOption@Resources:
 				Label: label-cnc-map-generator-option-resources
 				Default: Medium

--- a/mods/ra/fluent/rules.ftl
+++ b/mods/ra/fluent/rules.ftl
@@ -1003,19 +1003,31 @@ label-ra-map-generator-choice-terrain-type-narrow-wetlands =
    .label = Narrow Wetlands
    .description = Tight mixtures of land and water
 
-label-ra-map-generator-option-rotations = Rotations
-
-label-ra-map-generator-option-mirror = Mirror
+label-ra-map-generator-option-symmetry = Symmetry
 label-ra-map-generator-choice-mirror-none =
    .label = None
-label-ra-map-generator-choice-mirror-left-matches-right =
-   .label = Left vs right
-label-ra-map-generator-choice-mirror-top-left-matches-bottom-right =
-   .label = Top left vs bottom right
-label-ra-map-generator-choice-mirror-top-matches-bottom =
-   .label = Top vs bottom
-label-ra-map-generator-choice-mirror-top-right-matches-bottom-left =
-   .label = Top right vs bottom left
+label-ra-map-generator-choice-symmetry-mirror-horizontal =
+   .label = Mirror Horizontal
+label-ra-map-generator-choice-symmetry-mirror-vertical =
+   .label = Mirror Vertical
+label-ra-map-generator-choice-symmetry-mirror-diagonal-tl =
+   .label = Mirror Diagonal (Top-Left)
+label-ra-map-generator-choice-symmetry-mirror-diagonal-tr =
+   .label = Mirror Diagonal (Top-Right)
+label-ra-map-generator-choice-symmetry-mirror-2-rotations =
+   .label = 2 Rotations
+label-ra-map-generator-choice-symmetry-mirror-3-rotations =
+   .label = 3 Rotations
+label-ra-map-generator-choice-symmetry-mirror-4-rotations =
+   .label = 4 Rotations
+label-ra-map-generator-choice-symmetry-mirror-5-rotations =
+   .label = 5 Rotations
+label-ra-map-generator-choice-symmetry-mirror-6-rotations =
+   .label = 6 Rotations
+label-ra-map-generator-choice-symmetry-mirror-7-rotations =
+   .label = 7 Rotations
+label-ra-map-generator-choice-symmetry-mirror-8-rotations =
+   .label = 8 Rotations
 
 label-ra-map-generator-option-shape = Bounds Shape
 label-ra-map-generator-choice-shape-square =
@@ -1028,7 +1040,7 @@ label-ra-map-generator-choice-shape-circle-water =
    .label = Circle in water
    .description = Terrain generation is constrained to a circle enclosed by water
 
-label-ra-map-generator-option-players = Players per side
+label-ra-map-generator-option-players = Players
 
 label-ra-map-generator-option-resources = Resources
 label-ra-map-generator-choice-resources-none =

--- a/mods/ra/rules/map-generators.yaml
+++ b/mods/ra/rules/map-generators.yaml
@@ -70,6 +70,8 @@
 						ForestObstacles: Trees
 						UnplayableObstacles: Obstructions
 						CivilianBuildingsObstacles: CivilianBuildings
+						Mirror: None
+						Rotations: 1
 			MultiChoiceOption@hidden_tileset_overrides:
 				Choice@desert:
 					Tileset: DESERT
@@ -192,14 +194,14 @@
 						Forests: 0
 						SpawnBuildSize: 6
 						MinimumSpawnRadius: 4
-			MultiIntegerChoiceOption@Rotations:
-				Label: label-ra-map-generator-option-rotations
-				Parameter: Rotations
+			MultiIntegerChoiceOption@Players:
+				Label: label-ra-map-generator-option-players
+				Parameter: Players
 				Choices: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 				Default: 2
 				Priority: 1
-			MultiChoiceOption@Mirror:
-				Label: label-ra-map-generator-option-mirror
+			MultiChoiceOption@Symmetry:
+				Label: label-ra-map-generator-option-symmetry
 				Default: None
 				Priority: 1
 				Choice@None:
@@ -207,21 +209,60 @@
 					Settings:
 						Mirror: None
 				Choice@LeftMatchesRight:
-					Label: label-ra-map-generator-choice-mirror-left-matches-right
+					Label: label-ra-map-generator-choice-symmetry-mirror-horizontal
+					Players: 2, 4, 6, 8, 10, 12, 14, 16
 					Settings:
 						Mirror: LeftMatchesRight
 				Choice@TopLeftMatchesBottomRight:
-					Label: label-ra-map-generator-choice-mirror-top-left-matches-bottom-right
+					Label: label-ra-map-generator-choice-symmetry-mirror-diagonal-tl
+					Players: 2, 4, 6, 8, 10, 12, 14, 16
 					Settings:
 						Mirror: TopLeftMatchesBottomRight
 				Choice@TopMatchesBottom:
-					Label: label-ra-map-generator-choice-mirror-top-matches-bottom
+					Label: label-ra-map-generator-choice-symmetry-mirror-vertical
+					Players: 2, 4, 6, 8, 10, 12, 14, 16
 					Settings:
 						Mirror: TopMatchesBottom
 				Choice@TopRightMatchesBottomLeft:
-					Label: label-ra-map-generator-choice-mirror-top-right-matches-bottom-left
+					Label: label-ra-map-generator-choice-symmetry-mirror-diagonal-tr
+					Players: 2, 4, 6, 8, 10, 12, 14, 16
 					Settings:
 						Mirror: TopRightMatchesBottomLeft
+				Choice@2Rotations:
+					Label: label-ra-map-generator-choice-symmetry-mirror-2-rotations
+					Players: 2, 4, 6, 8, 10, 12, 14, 16
+					Settings:
+						Rotations: 2
+				Choice@3Rotations:
+					Label: label-ra-map-generator-choice-symmetry-mirror-3-rotations
+					Players: 3, 6, 9, 12, 15
+					Settings:
+						Rotations: 3
+				Choice@4Rotations:
+					Label: label-ra-map-generator-choice-symmetry-mirror-4-rotations
+					Players: 4, 8, 12, 16
+					Settings:
+						Rotations: 4
+				Choice@5Rotations:
+					Label: label-ra-map-generator-choice-symmetry-mirror-5-rotations
+					Players: 5, 10, 15
+					Settings:
+						Rotations: 5
+				Choice@6Rotations:
+					Label: label-ra-map-generator-choice-symmetry-mirror-6-rotations
+					Players: 6, 12
+					Settings:
+						Rotations: 6
+				Choice@7Rotations:
+					Label: label-ra-map-generator-choice-symmetry-mirror-7-rotations
+					Players: 7, 14
+					Settings:
+						Rotations: 7
+				Choice@8Rotations:
+					Label: label-ra-map-generator-choice-symmetry-mirror-8-rotations
+					Players: 8, 16
+					Settings:
+						Rotations: 8
 			MultiChoiceOption@Shape:
 				Label: label-ra-map-generator-option-shape
 				Default: Square
@@ -238,12 +279,6 @@
 					Label: label-ra-map-generator-choice-shape-circle-water
 					Settings:
 						ExternalCircularBias: -1
-			MultiIntegerChoiceOption@Players:
-				Label: label-ra-map-generator-option-players
-				Parameter: Players
-				Choices: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
-				Default: 1
-				Priority: 1
 			MultiChoiceOption@Resources:
 				Label: label-ra-map-generator-option-resources
 				Default: Medium


### PR DESCRIPTION
Player now specifies the total player count, and the Symmetry options (which combine the previous Mirror and Rotations) adjust to show only valid options. This makes it easier to generate valid maps with the expected number of players.

~~Depends on #21849.~~