### PR TITLE
Docking: fix aircraft clients trying to dock with different host than expected

### DIFF
--- a/OpenRA.Mods.Common/Traits/DockClientManager.cs
+++ b/OpenRA.Mods.Common/Traits/DockClientManager.cs
@@ -381,6 +381,7 @@ namespace OpenRA.Mods.Common.Traits
 					.OrderBy(dock =>
 						(clientActor.Location - clientActor.World.Map.CellContaining(dock.Trait.DockPosition)).LengthSquared +
 						dock.Trait.ReservationCount * client.OccupancyCostModifier)
+					.Cast<TraitPair<IDockHost>?>()
 					.FirstOrDefault();
 			}
 


### PR DESCRIPTION
### Background

`MoveToDock` activity looks for the nearest dock on specified actor (if no dock has been specified). However, if the specified actor has no docks available, [the docking should be canceled](https://github.com/OpenRA/OpenRA/blob/release-20250330/OpenRA.Mods.Common/Activities/MoveToDock.cs#L61-L67).

### The bug

This does not work for `Aircraft` docking clients, which will instead go looking for closest dock on a different actor (despite player having specified the target actor).

### Details

The logic for picking closest dock is in the `ClosestDock()` extension method, which should return `null`, when there's no closest dock on specified actor. However, this works only for `Mobile` clients. When the client is an `Aircraft`, it returns `TraitPair<IDockHost>` with null actor and trait:

![Screenshot_20250415_223749](https://github.com/user-attachments/assets/3e9ca680-1eea-4a6b-9716-d36da336dc4b)

As such, `MoveToDock` [proceeds to look](https://github.com/OpenRA/OpenRA/blob/release-20250330/OpenRA.Mods.Common/Activities/MoveToDock.cs#L83-L90) for another actor with available docks. This is clearly wrong as the player has specified target actor for docking. Here's how the bug looks like in OpenE2140 (the GIF also shows `Mobile` client, showing the expected behavior):

![opene2140_heavy_lifter_docking_issue](https://github.com/user-attachments/assets/eb774cbc-8761-4eb6-ad6e-6e8c980408d5)

### The fix

The fix is to make sure `ClosestDock()` extension method returns `null` for `Aircraft`, if there's no available dock on specified dock hosts.

After applying the fix, the bug is gone:

![opene2140_heavy_lifter_docking_issue_fixed](https://github.com/user-attachments/assets/c831e9a1-934d-40a0-bfc9-b3c058223e65)