### PR TITLE
Add Generate Map tab to the lobby map chooser.

### DIFF
--- a/OpenRA.Game/FileSystem/ZipFile.cs
+++ b/OpenRA.Game/FileSystem/ZipFile.cs
@@ -120,6 +120,23 @@ namespace OpenRA.FileSystem
 					entry.ExtraData = null;
 			}
 
+			public ReadWriteZipFile(byte[] data)
+			{
+				using (var copy = new MemoryStream(data))
+				{
+					pkgStream.Capacity = (int)copy.Length;
+					copy.CopyTo(pkgStream);
+				}
+
+				pkgStream.Position = 0;
+				pkg = new ZipFile(pkgStream);
+				Name = null;
+
+				// Remove subfields that can break ZIP updating.
+				foreach (ZipEntry entry in pkg)
+					entry.ExtraData = null;
+			}
+
 			void Commit()
 			{
 				if (!string.IsNullOrEmpty(Name))
@@ -140,6 +157,16 @@ namespace OpenRA.FileSystem
 				pkg.Delete(filename);
 				pkg.CommitUpdate();
 				Commit();
+			}
+
+			public static ReadWriteZipFile FromBase64String(string data)
+			{
+				return new ReadWriteZipFile(Convert.FromBase64String(data));
+			}
+
+			public string ToBase64String()
+			{
+				return Convert.ToBase64String(pkgStream.ToArray());
 			}
 		}
 

--- a/OpenRA.Game/GameInformation.cs
+++ b/OpenRA.Game/GameInformation.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.FileSystem;
 using OpenRA.Network;
 using OpenRA.Primitives;
 
@@ -27,6 +28,7 @@ namespace OpenRA
 
 		public string MapUid;
 		public string MapTitle;
+		public string MapData;
 		public int FinalGameTick;
 
 		/// <summary>Game start timestamp (when the recoding started).</summary>
@@ -40,7 +42,22 @@ namespace OpenRA
 
 		public IList<Player> Players { get; }
 		public HashSet<int> DisabledSpawnPoints = [];
-		public MapPreview MapPreview => Game.ModData.MapCache[MapUid];
+
+		public MapPreview MapPreview
+		{
+			get
+			{
+				var preview = Game.ModData.MapCache[MapUid];
+				if (preview.Status != MapStatus.Available && MapData != null)
+				{
+					var package = ZipFileLoader.ReadWriteZipFile.FromBase64String(MapData);
+					preview.UpdateFromMap(package, MapClassification.Generated);
+				}
+
+				return preview;
+			}
+		}
+
 		public IEnumerable<Player> HumanPlayers { get { return Players.Where(p => p.IsHuman); } }
 		public bool IsSinglePlayer => HumanPlayers.Count() == 1;
 

--- a/OpenRA.Game/Map/MapGenerationArgs.cs
+++ b/OpenRA.Game/Map/MapGenerationArgs.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Primitives;
 
 namespace OpenRA
@@ -38,6 +39,20 @@ namespace OpenRA
 		static MiniYaml LoadSettings(MiniYaml yaml)
 		{
 			return yaml.NodeWithKey("Settings").Value;
+		}
+
+		public string Serialize()
+		{
+			return new List<MiniYamlNode>()
+			{
+				new("Uid", Uid),
+				new("Generator", Generator),
+				new("Tileset", Tileset),
+				new("Size", FieldSaver.FormatValue(Size)),
+				new("Settings", Settings),
+				new("Title", Title),
+				new("Author", Author)
+			}.WriteToString();
 		}
 	}
 }

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -389,6 +389,13 @@ namespace OpenRA.Network
 					break;
 				}
 
+				case "GenerateMap":
+				{
+					var yaml = new MiniYaml(order.OrderString, MiniYaml.FromString(order.TargetString, order.OrderString));
+					Game.ModData.MapCache.GenerateMap(FieldLoader.Load<MapGenerationArgs>(yaml));
+					break;
+				}
+
 				default:
 				{
 					if (world == null)

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -239,6 +239,10 @@ namespace OpenRA
 				MapTitle = Map.Title
 			};
 
+			var preview = modData.MapCache[Map.Uid];
+			if (preview.Class == MapClassification.Generated)
+				gameInfo.MapData = preview.ToBase64String();
+
 			RulesContainTemporaryBlocker = Map.Rules.Actors.Any(a => a.Value.HasTraitInfo<ITemporaryBlockerInfo>());
 			gameSettings = Game.Settings.Game;
 		}

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -667,6 +667,21 @@ namespace OpenRA.Mods.Common.Server
 				var m = server.ModData.MapCache[s];
 				if (m.Status == MapStatus.Available || m.Status == MapStatus.DownloadAvailable)
 					SelectMap(m);
+				else if (m.Class == MapClassification.Generated)
+				{
+					if (m.Status == MapStatus.Generating)
+					{
+						// Wait up to 5 seconds for the map to be generated
+						var stopwatch = Stopwatch.StartNew();
+						while (m.Status == MapStatus.Generating && stopwatch.ElapsedMilliseconds < 5000)
+							Thread.Sleep(100);
+					}
+
+					if (m.Status == MapStatus.Available)
+						SelectMap(m);
+					else
+						QueryFailed();
+				}
 				else if (server.Settings.QueryMapRepository)
 				{
 					server.SendFluentMessageTo(conn, SearchingMap);

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -983,6 +983,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		void Randomize(MersenneTwister random);
 
+		void Initialize(MapGenerationArgs args);
+
 		MapGenerationArgs Compile(ITerrainInfo terrainInfo, Size size);
 	}
 

--- a/OpenRA.Mods.Common/Widgets/GeneratedMapPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/GeneratedMapPreviewWidget.cs
@@ -1,0 +1,156 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.FileFormats;
+using OpenRA.Graphics;
+using OpenRA.Primitives;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets
+{
+	public class GeneratedMapPreviewWidget : Widget
+	{
+		public readonly bool ShowSpawnPoints = true;
+
+		readonly Sprite spawnUnclaimed;
+		readonly SpriteFont spawnFont;
+		readonly Color spawnColor, spawnContrastColor;
+		readonly int2 spawnLabelOffset;
+
+		Sheet mapSheet;
+		Sprite mapSprite;
+		Rectangle mapRect;
+
+		public GeneratedMapPreviewWidget()
+		{
+			spawnUnclaimed = ChromeProvider.GetImage("lobby-bits", "spawn-unclaimed");
+			spawnFont = Game.Renderer.Fonts[ChromeMetrics.Get<string>("SpawnFont")];
+			spawnColor = ChromeMetrics.Get<Color>("SpawnColor");
+			spawnContrastColor = ChromeMetrics.Get<Color>("SpawnContrastColor");
+			spawnLabelOffset = ChromeMetrics.Get<int2>("SpawnLabelOffset");
+		}
+
+		protected GeneratedMapPreviewWidget(GeneratedMapPreviewWidget other)
+			: base(other)
+		{
+			ShowSpawnPoints = other.ShowSpawnPoints;
+			spawnUnclaimed = ChromeProvider.GetImage("lobby-bits", "spawn-unclaimed");
+			spawnFont = Game.Renderer.Fonts[ChromeMetrics.Get<string>("SpawnFont")];
+			spawnColor = ChromeMetrics.Get<Color>("SpawnColor");
+			spawnContrastColor = ChromeMetrics.Get<Color>("SpawnContrastColor");
+			spawnLabelOffset = ChromeMetrics.Get<int2>("SpawnLabelOffset");
+		}
+
+		public override GeneratedMapPreviewWidget Clone() { return new GeneratedMapPreviewWidget(this); }
+
+		(int2 Pos, string Label, int2 LabelOffset)[] spawns = [];
+
+		public void Update(MapPreview map)
+		{
+			Update(map.SpawnPoints, map.Bounds, map.GridType, map.Preview);
+		}
+
+		public void Update(Map map)
+		{
+			var spawnPoints = map.ActorDefinitions
+				.Where(d => d.Value.Value == "mpspawn")
+				.Select(kv => new ActorReference(kv.Value.Value, kv.Value.ToDictionary()).Get<LocationInit>().Value);
+
+			Update(spawnPoints, map.Bounds, map.Grid.Type, new Png(map.Package.GetStream("map.png")));
+		}
+
+		void Update(IEnumerable<CPos> spawnPoints, Rectangle bounds, MapGridType gridType, Png preview)
+		{
+			if (mapSheet == null || mapSheet.Size.Width < preview.Width || mapSheet.Size.Height < preview.Height)
+			{
+				mapSheet?.Dispose();
+				mapSheet = new Sheet(SheetType.BGRA, new Size(preview.Width, preview.Height).NextPowerOf2());
+			}
+
+			var spriteRect = new Rectangle(0, 0, preview.Width, preview.Height);
+			mapSprite = new Sprite(mapSheet, spriteRect, TextureChannel.RGBA);
+			OpenRA.Graphics.Util.FastCopyIntoSprite(mapSprite, preview);
+			mapSheet.CommitBufferedData();
+
+			// Update map rect
+			var previewScale = Math.Min(RenderBounds.Width * 1f / spriteRect.Width, RenderBounds.Height * 1f / spriteRect.Height);
+			var w = (int)(previewScale * spriteRect.Width);
+			var h = (int)(previewScale * spriteRect.Height);
+			var x = RenderBounds.X + (RenderBounds.Width - w) / 2;
+			var y = RenderBounds.Y + (RenderBounds.Height - h) / 2;
+			mapRect = new Rectangle(x, y, w, h);
+
+			if (ShowSpawnPoints)
+			{
+				var s = new List<(int2, string, int2)>();
+				foreach (var p in spawnPoints)
+				{
+					var pos = ConvertToPreview(p, bounds, gridType, previewScale);
+
+					var sprite = spawnUnclaimed;
+					var offset = sprite.Size.XY.ToInt2() / 2;
+					WidgetUtils.DrawSprite(sprite, pos - offset);
+
+					var number = Convert.ToChar('A' + s.Count).ToString();
+					var textOffset = spawnFont.Measure(number) / 2 + spawnLabelOffset;
+					s.Add((pos, number, textOffset));
+				}
+
+				spawns = s.ToArray();
+			}
+		}
+
+		public void Clear()
+		{
+			mapSprite = null;
+		}
+
+		public int2 ConvertToPreview(CPos cell, Rectangle bounds, MapGridType gridType, float previewScale)
+		{
+			var point = cell.ToMPos(gridType);
+			var cellWidth = gridType == MapGridType.RectangularIsometric ? 2 : 1;
+			var dx = (int)(previewScale * cellWidth * (point.U - bounds.Left));
+			var dy = (int)(previewScale * (point.V - bounds.Top));
+
+			// Odd rows are shifted right by 1px
+			if ((point.V & 1) == 1)
+				dx++;
+
+			return new int2(mapRect.X + dx, mapRect.Y + dy);
+		}
+
+		public override void Draw()
+		{
+			if (mapSprite == null)
+				return;
+
+			WidgetUtils.DrawSprite(mapSprite, mapRect.Location, mapRect.Size);
+			var offset = spawnUnclaimed.Size.XY.ToInt2() / 2;
+			foreach (var (pos, label, labelOffset) in spawns)
+			{
+				WidgetUtils.DrawSprite(spawnUnclaimed, pos - offset);
+				spawnFont.DrawTextWithContrast(label, pos - labelOffset, spawnColor, spawnContrastColor, 1);
+			}
+		}
+
+		public override void Removed()
+		{
+			base.Removed();
+			mapSheet?.Dispose();
+			mapSheet = null;
+		}
+
+		public bool Loaded => mapSprite != null;
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using OpenRA.FileSystem;
 using OpenRA.Network;
 using OpenRA.Widgets;
 
@@ -336,7 +337,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			// Parse the save to find the map UID
 			var save = new GameSave(selectedSave);
-			var map = modData.MapCache[save.GlobalSettings.Map];
+
+			var map = Game.ModData.MapCache[save.GlobalSettings.Map];
+			if (map.Status != MapStatus.Available && save.MapData != null)
+			{
+				// Add to the MapCache so the server will accept the map
+				var package = ZipFileLoader.ReadWriteZipFile.FromBase64String(save.MapData);
+				map.UpdateFromMap(package, MapClassification.Generated);
+			}
+
 			if (map.Status != MapStatus.Available)
 				return;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
@@ -48,6 +48,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Playable,
 			Incompatible,
 			Validating,
+			Generating,
 			DownloadAvailable,
 			Searching,
 			Downloading,
@@ -199,6 +200,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				[previewLarge, widget.Get("MAP_INCOMPATIBLE")];
 			previewWidgets[PreviewStatus.Validating] =
 				[previewSmall, widget.Get("MAP_VALIDATING")];
+			previewWidgets[PreviewStatus.Generating] =
+				[previewSmall, widget.Get("MAP_GENERATING")];
 			previewWidgets[PreviewStatus.UpdateAvailable] =
 				[previewSmall, widget.Get("MAP_UPDATE_AVAILABLE"), updateButton];
 			previewWidgets[PreviewStatus.DownloadAvailable] =
@@ -270,6 +273,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						break;
 					case MapStatus.Searching:
 						status = PreviewStatus.Searching;
+						break;
+					case MapStatus.Generating:
+						status = PreviewStatus.Generating;
 						break;
 					case MapStatus.Unavailable:
 						if (mapUpdateAvailable)

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -211,10 +211,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Game.OpenWindow("MAPCHOOSER_PANEL", new WidgetArgs()
 				{
 					{ "initialMap", null },
+					{ "initialGeneratedMap", (MapGenerationArgs)null },
 					{ "remoteMapPool", null },
 					{ "initialTab", MapClassification.User },
 					{ "onExit", () => SwitchMenu(MenuType.MapEditor) },
 					{ "onSelect", onSelect },
+					{ "onSelectGenerated", null },
 					{ "filter", MapVisibility.Lobby | MapVisibility.Shellmap | MapVisibility.MissionSelector },
 				});
 			};

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -91,6 +91,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[FluentReference]
 		const string RemoteMapsTab = "button-mapchooser-remote-maps-tab";
 
+		public static string MapSizeLabel(Size size)
+		{
+			var area = size.Width * size.Height;
+			var label = area >= 120 * 120 ? MapSizeHuge :
+				area >= 90 * 90 ? MapSizeLarge :
+				area >= 60 * 60 ? MapSizeMedium :
+				MapSizeSmall;
+
+			return $"{size.Width}x{size.Height} ({FluentProvider.GetMessage(label)})";
+		}
+
 		readonly string allMaps;
 
 		readonly Widget widget;
@@ -498,12 +509,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var sizeWidget = item.GetOrNull<LabelWidget>("SIZE");
 				if (sizeWidget != null)
 				{
-					var size = preview.Bounds.Width + "x" + preview.Bounds.Height;
-					var numberPlayableCells = preview.Bounds.Width * preview.Bounds.Height;
-					if (numberPlayableCells >= 120 * 120) size += " " + FluentProvider.GetMessage(MapSizeHuge);
-					else if (numberPlayableCells >= 90 * 90) size += " " + FluentProvider.GetMessage(MapSizeLarge);
-					else if (numberPlayableCells >= 60 * 60) size += " " + FluentProvider.GetMessage(MapSizeMedium);
-					else size += " " + FluentProvider.GetMessage(MapSizeSmall);
+					var size = MapSizeLabel(preview.Bounds.Size);
 					sizeWidget.GetText = () => size;
 				}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
@@ -1,0 +1,424 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using OpenRA.FileSystem;
+using OpenRA.Mods.Common.MapGenerator;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+	public class MapGeneratorLogic : ChromeLogic
+	{
+		[FluentReference]
+		const string Tileset = "label-mapchooser-random-map-tileset";
+
+		[FluentReference]
+		const string MapSize = "label-mapchooser-random-map-size";
+
+		[FluentReference]
+		const string RandomMap = "label-mapchooser-random-map-title";
+
+		[FluentReference]
+		const string Generating = "label-mapchooser-random-map-generating";
+
+		[FluentReference]
+		const string GenerationFailed = "label-mapchooser-random-map-error";
+
+		[FluentReference("players")]
+		const string Players = "label-player-count";
+
+		[FluentReference("author")]
+		const string CreatedBy = "label-created-by";
+
+		[FluentReference]
+		const string MapSizeSmall = "label-map-size-small";
+
+		[FluentReference]
+		const string MapSizeMedium = "label-map-size-medium";
+
+		[FluentReference]
+		const string MapSizeLarge = "label-map-size-large";
+
+		[FluentReference]
+		const string MapSizeHuge = "label-map-size-huge";
+
+		public static readonly IReadOnlyDictionary<string, int2> MapSizes = new Dictionary<string, int2>()
+		{
+			{ MapSizeSmall, new int2(48, 60) },
+			{ MapSizeMedium, new int2(60, 90) },
+			{ MapSizeLarge, new int2(90, 120) },
+			{ MapSizeHuge, new int2(120, 160) },
+		};
+
+		readonly ModData modData;
+		readonly IEditorMapGeneratorInfo generator;
+		readonly IMapGeneratorSettings settings;
+		readonly Action<MapGenerationArgs> onGenerate;
+
+		readonly GeneratedMapPreviewWidget preview;
+		readonly ScrollPanelWidget settingsPanel;
+		readonly Widget checkboxSettingTemplate;
+		readonly Widget textSettingTemplate;
+		readonly Widget dropdownSettingTemplate;
+		readonly Widget tilesetSetting;
+		readonly Widget sizeSetting;
+
+		ITerrainInfo selectedTerrain;
+		string selectedSize;
+		Size size;
+
+		volatile bool generating;
+		volatile bool failed;
+
+		[ObjectCreator.UseCtor]
+		internal MapGeneratorLogic(Widget widget, ModData modData, MapGenerationArgs initialSettings, Action<MapGenerationArgs> onGenerate)
+		{
+			this.modData = modData;
+			this.onGenerate = onGenerate;
+
+			generator = modData.DefaultRules.Actors[SystemActors.EditorWorld].TraitInfos<IEditorMapGeneratorInfo>().First();
+			settings = generator.GetSettings();
+			preview = widget.Get<GeneratedMapPreviewWidget>("PREVIEW");
+
+			widget.Get("ERROR").IsVisible = () => failed;
+
+			var title = new CachedTransform<string, string>(id => FluentProvider.GetMessage(id));
+			var previewTitleLabel = widget.Get<LabelWidget>("TITLE");
+			previewTitleLabel.GetText = () => title.Update(generating ? Generating : failed ? GenerationFailed : RandomMap);
+
+			var previewDetailsLabel = widget.GetOrNull<LabelWidget>("DETAILS");
+			if (previewDetailsLabel != null)
+			{
+				// The default "Conquest" label is hardcoded in Map.cs
+				var desc = new CachedTransform<int, string>(p => "Conquest " + FluentProvider.GetMessage(Players, "players", p));
+				var playersOption = settings.Options.FirstOrDefault(o => o.Id == "Players") as MapGeneratorMultiIntegerChoiceOption;
+				previewDetailsLabel.GetText = () => desc.Update(playersOption?.Value ?? 0);
+				previewDetailsLabel.IsVisible = () => !failed;
+			}
+
+			var previewAuthorLabel = widget.GetOrNull<LabelWithTooltipWidget>("AUTHOR");
+			if (previewAuthorLabel != null)
+			{
+				var desc = FluentProvider.GetMessage(CreatedBy, "author", FluentProvider.GetMessage(generator.Name));
+				previewAuthorLabel.GetText = () => desc;
+				previewAuthorLabel.IsVisible = () => !failed;
+			}
+
+			var previewSizeLabel = widget.GetOrNull<LabelWidget>("SIZE");
+			if (previewSizeLabel != null)
+			{
+				var desc = new CachedTransform<Size, string>(MapChooserLogic.MapSizeLabel);
+				previewSizeLabel.IsVisible = () => !failed;
+				previewSizeLabel.GetText = () => desc.Update(size);
+			}
+
+			settingsPanel = widget.Get<ScrollPanelWidget>("SETTINGS_PANEL");
+			checkboxSettingTemplate = settingsPanel.Get<Widget>("CHECKBOX_TEMPLATE");
+			textSettingTemplate = settingsPanel.Get<Widget>("TEXT_TEMPLATE");
+			dropdownSettingTemplate = settingsPanel.Get<Widget>("DROPDOWN_TEMPLATE");
+			settingsPanel.Layout = new GridLayout(settingsPanel);
+
+			// Tileset and map size are handled outside the generator logic so must be created manually
+			var validTerrainInfos = generator.Tilesets.Select(t => modData.DefaultTerrainInfo[t]).ToList();
+			var tilesetLabel = FluentProvider.GetMessage(Tileset);
+			tilesetSetting = dropdownSettingTemplate.Clone();
+			tilesetSetting.Get<LabelWidget>("LABEL").GetText = () => tilesetLabel;
+
+			var label = new CachedTransform<ITerrainInfo, string>(ti => FluentProvider.GetMessage(ti.Name));
+			var tilesetDropdown = tilesetSetting.Get<DropDownButtonWidget>("DROPDOWN");
+			tilesetDropdown.GetText = () => label.Update(selectedTerrain);
+			tilesetDropdown.OnMouseDown = _ =>
+			{
+				ScrollItemWidget SetupItem(ITerrainInfo terrainInfo, ScrollItemWidget template)
+				{
+					bool IsSelected() => terrainInfo == selectedTerrain;
+					void OnClick()
+					{
+						selectedTerrain = terrainInfo;
+						RefreshSettings();
+						GenerateMap();
+					}
+
+					var item = ScrollItemWidget.Setup(template, IsSelected, OnClick);
+					var itemLabel = FluentProvider.GetMessage(terrainInfo.Name);
+					item.Get<LabelWidget>("LABEL").GetText = () => itemLabel;
+					return item;
+				}
+
+				tilesetDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", validTerrainInfos.Count * 30, validTerrainInfos, SetupItem);
+			};
+
+			var sizeLabel = FluentProvider.GetMessage(MapSize);
+			sizeSetting = dropdownSettingTemplate.Clone();
+			sizeSetting.Get<LabelWidget>("LABEL").GetText = () => sizeLabel;
+
+			var sizeDropdown = sizeSetting.Get<DropDownButtonWidget>("DROPDOWN");
+			var sizeDropdownLabel = new CachedTransform<string, string>(s => FluentProvider.GetMessage(s));
+			sizeDropdown.GetText = () => sizeDropdownLabel.Update(selectedSize);
+			sizeDropdown.OnMouseDown = _ =>
+			{
+				ScrollItemWidget SetupItem(string size, ScrollItemWidget template)
+				{
+					bool IsSelected() => size == selectedSize;
+					void OnClick()
+					{
+						selectedSize = size;
+						RandomizeSize();
+						GenerateMap();
+					}
+
+					var item = ScrollItemWidget.Setup(template, IsSelected, OnClick);
+					var label = FluentProvider.GetMessage(size);
+					item.Get<LabelWidget>("LABEL").GetText = () => label;
+					return item;
+				}
+
+				sizeDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", MapSizes.Count * 30, MapSizes.Keys, SetupItem);
+			};
+
+			var generateButton = widget.Get<ButtonWidget>("BUTTON_GENERATE");
+			generateButton.IsDisabled = () => generating;
+			generateButton.OnClick = () =>
+			{
+				settings.Randomize(Game.CosmeticRandom);
+				RandomizeSize();
+				GenerateMap();
+			};
+
+			selectedSize = MapSizes.Keys.Skip(1).First();
+			if (initialSettings != null)
+			{
+				selectedTerrain = modData.DefaultTerrainInfo[initialSettings.Tileset];
+				size = initialSettings.Size;
+				foreach (var kv in MapSizes)
+					if (kv.Value.X > size.Width && kv.Value.Y <= size.Width)
+						selectedSize = kv.Key;
+
+				settings.Initialize(initialSettings);
+				RefreshSettings();
+
+				var map = modData.MapCache[initialSettings.Uid];
+				if (map.Status == MapStatus.Available)
+				{
+					preview.Update(map);
+					onGenerate(initialSettings);
+				}
+				else
+					GenerateMap();
+			}
+			else
+			{
+				selectedTerrain = validTerrainInfos[0];
+				settings.Randomize(Game.CosmeticRandom);
+				RandomizeSize();
+				RefreshSettings();
+				GenerateMap();
+			}
+		}
+
+		void RandomizeSize()
+		{
+			var sizeRange = MapSizes[selectedSize];
+			var width = Game.CosmeticRandom.Next(sizeRange.X, sizeRange.Y);
+			size = new Size(width + 2, width + 2);
+		}
+
+		void RefreshSettings()
+		{
+			settingsPanel.RemoveChildren();
+			tilesetSetting.Bounds = sizeSetting.Bounds = dropdownSettingTemplate.Bounds;
+			settingsPanel.AddChild(tilesetSetting);
+			settingsPanel.AddChild(sizeSetting);
+
+			var playerCount = settings.PlayerCount;
+			foreach (var o in settings.Options)
+			{
+				if (o.Id == "Seed")
+					continue;
+
+				Widget settingWidget = null;
+				switch (o)
+				{
+					case MapGeneratorBooleanOption bo:
+					{
+						settingWidget = checkboxSettingTemplate.Clone();
+						var checkboxWidget = settingWidget.Get<CheckboxWidget>("CHECKBOX");
+						var label = FluentProvider.GetMessage(bo.Label);
+						checkboxWidget.GetText = () => label;
+						checkboxWidget.IsChecked = () => bo.Value;
+						checkboxWidget.OnClick = () =>
+						{
+							bo.Value ^= true;
+							GenerateMap();
+						};
+						break;
+					}
+
+					case MapGeneratorIntegerOption io:
+					{
+						settingWidget = textSettingTemplate.Clone();
+						var labelWidget = settingWidget.Get<LabelWidget>("LABEL");
+						var label = FluentProvider.GetMessage(io.Label);
+						labelWidget.GetText = () => label;
+						var textFieldWidget = settingWidget.Get<TextFieldWidget>("INPUT");
+						textFieldWidget.Type = TextFieldType.Integer;
+						textFieldWidget.Text = FieldSaver.FormatValue(io.Value);
+						textFieldWidget.OnTextEdited = () =>
+						{
+							var valid = int.TryParse(textFieldWidget.Text, out io.Value);
+							textFieldWidget.IsValid = () => valid;
+						};
+
+						textFieldWidget.OnEscKey = _ => { textFieldWidget.YieldKeyboardFocus(); return true; };
+						textFieldWidget.OnEnterKey = _ => { textFieldWidget.YieldKeyboardFocus(); return true; };
+						textFieldWidget.OnLoseFocus = GenerateMap;
+						break;
+					}
+
+					case MapGeneratorMultiIntegerChoiceOption mio:
+					{
+						settingWidget = dropdownSettingTemplate.Clone();
+						var labelWidget = settingWidget.Get<LabelWidget>("LABEL");
+						var label = FluentProvider.GetMessage(mio.Label);
+						labelWidget.GetText = () => label;
+
+						var labelCache = new CachedTransform<int, string>(v => FieldSaver.FormatValue(v));
+						var dropDownWidget = settingWidget.Get<DropDownButtonWidget>("DROPDOWN");
+						dropDownWidget.GetText = () => labelCache.Update(mio.Value);
+						dropDownWidget.OnMouseDown = _ =>
+						{
+							ScrollItemWidget SetupItem(int choice, ScrollItemWidget template)
+							{
+								bool IsSelected() => choice == mio.Value;
+								void OnClick()
+								{
+									mio.Value = choice;
+									if (o.Id == "Players")
+										RefreshSettings();
+									GenerateMap();
+								}
+
+								var item = ScrollItemWidget.Setup(template, IsSelected, OnClick);
+								var itemLabel = FieldSaver.FormatValue(choice);
+								item.Get<LabelWidget>("LABEL").GetText = () => itemLabel;
+								item.GetTooltipText = null;
+								return item;
+							}
+
+							dropDownWidget.ShowDropDown("LABEL_DROPDOWN_WITH_TOOLTIP_TEMPLATE", mio.Choices.Length * 30, mio.Choices, SetupItem);
+						};
+						break;
+					}
+
+					case MapGeneratorMultiChoiceOption mo:
+					{
+						var validChoices = mo.ValidChoices(selectedTerrain, playerCount);
+						if (!validChoices.Contains(mo.Value))
+							mo.Value = mo.Default?.FirstOrDefault(validChoices.Contains) ?? validChoices.FirstOrDefault();
+
+						if (mo.Label != null && validChoices.Count > 0)
+						{
+							settingWidget = dropdownSettingTemplate.Clone();
+							var labelWidget = settingWidget.Get<LabelWidget>("LABEL");
+							var label = FluentProvider.GetMessage(mo.Label);
+							labelWidget.GetText = () => label;
+
+							var labelCache = new CachedTransform<string, string>(v => FluentProvider.GetMessage(mo.Choices[v].Label + ".label"));
+							var dropDownWidget = settingWidget.Get<DropDownButtonWidget>("DROPDOWN");
+							dropDownWidget.GetText = () => labelCache.Update(mo.Value);
+							dropDownWidget.OnMouseDown = _ =>
+							{
+								ScrollItemWidget SetupItem(string choice, ScrollItemWidget template)
+								{
+									bool IsSelected() => choice == mo.Value;
+									void OnClick()
+									{
+										mo.Value = choice;
+										GenerateMap();
+									}
+
+									var item = ScrollItemWidget.Setup(template, IsSelected, OnClick);
+
+									var itemLabel = FluentProvider.GetMessage(mo.Choices[choice].Label + ".label");
+									item.Get<LabelWidget>("LABEL").GetText = () => itemLabel;
+									if (FluentProvider.TryGetMessage(mo.Choices[choice].Label + ".description", out var desc))
+										item.GetTooltipText = () => desc;
+									else
+										item.GetTooltipText = null;
+
+									return item;
+								}
+
+								dropDownWidget.ShowDropDown("LABEL_DROPDOWN_WITH_TOOLTIP_TEMPLATE", validChoices.Count * 30, validChoices, SetupItem);
+							};
+						}
+
+						break;
+					}
+
+					default:
+						throw new NotImplementedException($"Unhandled MapGeneratorOption type {o.GetType().Name}");
+				}
+
+				if (settingWidget == null)
+					continue;
+
+				settingWidget.IsVisible = () => true;
+				settingsPanel.AddChild(settingWidget);
+			}
+		}
+
+		void GenerateMap()
+		{
+			generating = true;
+			onGenerate(null);
+			failed = false;
+			preview.Clear();
+			Task.Run(() =>
+			{
+				for (var i = 0; i < 5; i++)
+				{
+					try
+					{
+						var args = settings.Compile(selectedTerrain, size);
+						var map = generator.Generate(modData, args);
+
+						// Map UID and preview image are generated on save
+						var package = new ZipFileLoader.ReadWriteZipFile();
+						map.Save(package);
+						args.Uid = map.Uid;
+
+						Game.RunAfterTick(() =>
+						{
+							preview.Update(map);
+							onGenerate(args);
+							generating = false;
+						});
+						return;
+					}
+					catch (Exception)
+					{
+						// Ignore the exception
+					}
+				}
+
+				failed = true;
+				generating = false;
+			});
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -98,10 +98,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					Ui.OpenWindow("MAPCHOOSER_PANEL", new WidgetArgs()
 					{
 						{ "initialMap", map.Uid },
+						{ "initialGeneratedMap", (MapGenerationArgs)null },
 						{ "remoteMapPool", null },
 						{ "initialTab", MapClassification.System },
 						{ "onExit", () => modData.MapCache.UpdateMaps() },
 						{ "onSelect", (Action<string>)(uid => map = modData.MapCache[uid]) },
+						{ "onSelectGenerated", null },
 						{ "filter", MapVisibility.Lobby },
 						{ "onStart", () => { } }
 					});

--- a/mods/cnc/chrome/lobby-mappreview.yaml
+++ b/mods/cnc/chrome/lobby-mappreview.yaml
@@ -102,6 +102,23 @@ Container@MAP_PREVIEW:
 					Width: PARENT_WIDTH
 					Height: 25
 					Indeterminate: True
+		Container@MAP_GENERATING:
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
+			Children:
+				Label@MAP_STATUS_GENERATING:
+					Y: 174
+					Width: PARENT_WIDTH
+					Height: 25
+					Font: Tiny
+					Align: Center
+					Text: label-map-generating-status
+					IgnoreMouseOver: true
+				ProgressBar@MAP_GENERATING_BAR:
+					Y: 194
+					Width: PARENT_WIDTH
+					Height: 25
+					Indeterminate: True
 		Container@MAP_DOWNLOAD_AVAILABLE:
 			Width: PARENT_WIDTH
 			Height: PARENT_HEIGHT

--- a/mods/cnc/chrome/mapchooser.yaml
+++ b/mods/cnc/chrome/mapchooser.yaml
@@ -63,6 +63,9 @@ Container@MAPCHOOSER_PANEL:
 									Width: PARENT_WIDTH
 									Height: PARENT_HEIGHT
 									ItemSpacing: 1
+						Container@GENERATE_MAP_TAB:
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT + 30
 				ScrollItem@MAP_TEMPLATE:
 					Width: 210
 					Height: 262
@@ -186,3 +189,103 @@ Container@MAPCHOOSER_PANEL:
 					Height: 35
 					Text: button-bg-ok
 				TooltipContainer@TOOLTIP_CONTAINER:
+
+Container@MAPCHOOSER_GENERATE_PANEL:
+	Logic: MapGeneratorLogic
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
+	Children:
+		Background@MAP_BG:
+			X: PARENT_WIDTH - WIDTH
+			Width: 370
+			Height: 370
+			Background: panel-gray
+			Children:
+				GeneratedMapPreview@PREVIEW:
+					X: 1
+					Y: 1
+					Width: PARENT_WIDTH - 2
+					Height: PARENT_HEIGHT - 2
+		Label@TITLE:
+			X: PARENT_WIDTH - WIDTH
+			Y: 375
+			Width: 370
+			Height: 24
+			Align: Center
+			Text: label-mapchooser-random-map-title
+			Font: Bold
+		Label@ERROR:
+			X: PARENT_WIDTH - WIDTH
+			Y: 405
+			Width: 370
+			Height: 24
+			Align: Center
+			Text: label-mapchooser-random-map-error-desc
+		Label@DETAILS:
+			X: PARENT_WIDTH - WIDTH
+			Y: 405
+			Width: 370
+			Height: 24
+			Align: Center
+		LabelWithTooltip@AUTHOR:
+			X: PARENT_WIDTH - WIDTH
+			Y: 425
+			Width: 370
+			Height: 24
+			Align: Center
+		Label@SIZE:
+			X: PARENT_WIDTH - WIDTH
+			Y: 445
+			Width: 370
+			Height: 24
+			Align: Center
+		Button@BUTTON_GENERATE:
+			X: PARENT_WIDTH - 135 - WIDTH
+			Y: PARENT_HEIGHT + 14
+			Width: 140
+			Height: 35
+			Text: button-mapchooser-random-map-generate
+		ScrollPanel@SETTINGS_PANEL:
+			TopBottomSpacing: 5
+			Width: 485
+			Height: PARENT_HEIGHT
+			Children:
+				Container@CHECKBOX_TEMPLATE:
+					Width: 230
+					Height: 30
+					Children:
+						Checkbox@CHECKBOX:
+							X: 10
+							Y: 5
+							Width: PARENT_WIDTH - 20
+							Height: 20
+				Container@TEXT_TEMPLATE:
+					Width: 230
+					Height: 50
+					Children:
+						LabelForInput@LABEL:
+							X: 10
+							Width: PARENT_WIDTH - 20
+							Height: 20
+							For: INPUT
+						TextField@INPUT:
+							X: 10
+							Y: 20
+							Width: PARENT_WIDTH - 20
+							Height: 25
+				Container@DROPDOWN_TEMPLATE:
+					Width: 230
+					Height: 50
+					Children:
+						LabelForInput@LABEL:
+							X: 10
+							Width: PARENT_WIDTH - 20
+							Height: 20
+							For: DROPDOWN
+						DropDownButton@DROPDOWN:
+							X: 10
+							Y: 20
+							Width: PARENT_WIDTH - 20
+							Height: 25
+							PanelRoot: GENERATOR_DROPDOWN_PANEL_ROOT # ensure that tooltips for the options are on top of the dropdown panel
+		Container@GENERATOR_DROPDOWN_PANEL_ROOT:

--- a/mods/cnc/fluent/chrome.ftl
+++ b/mods/cnc/fluent/chrome.ftl
@@ -523,6 +523,14 @@ button-bg-delete-map = Delete Map
 button-bg-delete-all-maps = Delete All Maps
 button-bg-ok = Ok
 
+label-mapchooser-random-map-title = Random Map
+label-mapchooser-random-map-generating = Generating...
+label-mapchooser-random-map-error = Map Generation Failed
+button-mapchooser-random-map-generate = Generate
+label-mapchooser-random-map-tileset = Environment:
+label-mapchooser-random-map-size = Map Size:
+label-mapchooser-random-map-error-desc = Adjust the settings to try again.
+
 ## missionbrowser.yaml
 button-missionbrowser-panel-mission-info = Mission Info
 button-missionbrowser-panel-mission-options = Options

--- a/mods/cnc/fluent/chrome.ftl
+++ b/mods/cnc/fluent/chrome.ftl
@@ -378,6 +378,7 @@ button-force-start-dialog-start = Start
 label-map-incompatible-status-a = This map is not compatible
 label-map-incompatible-status-b = with this version of OpenRA
 label-map-validating-status = Validating...
+label-map-generating-status = Generating...
 button-map-download-available-install = Install Map
 button-map-preview-update = Update Map
 button-map-update-download-available-install = Install Map

--- a/mods/cnc/rules/map-generators.yaml
+++ b/mods/cnc/rules/map-generators.yaml
@@ -168,6 +168,22 @@
 						Mountains: 1000
 						Roughness: 850
 						MinimumTerrainContourSpacing: 5
+			MultiChoiceOption@Shape:
+				Label: label-cnc-map-generator-option-shape
+				Default: Square
+				Priority: 1
+				Choice@Square:
+					Label: label-cnc-map-generator-choice-shape-square
+					Settings:
+						ExternalCircularBias: 0
+				Choice@CircleMountain:
+					Label: label-cnc-map-generator-choice-shape-circle-mountain
+					Settings:
+						ExternalCircularBias: 1
+				Choice@CircleWater:
+					Label: label-cnc-map-generator-choice-shape-circle-water
+					Settings:
+						ExternalCircularBias: -1
 			MultiIntegerChoiceOption@Players:
 				Label: label-cnc-map-generator-option-players
 				Parameter: Players
@@ -237,22 +253,6 @@
 					Players: 8, 16
 					Settings:
 						Rotations: 8
-			MultiChoiceOption@Shape:
-				Label: label-cnc-map-generator-option-shape
-				Default: Square
-				Priority: 1
-				Choice@Square:
-					Label: label-cnc-map-generator-choice-shape-square
-					Settings:
-						ExternalCircularBias: 0
-				Choice@CircleMountain:
-					Label: label-cnc-map-generator-choice-shape-circle-mountain
-					Settings:
-						ExternalCircularBias: 1
-				Choice@CircleWater:
-					Label: label-cnc-map-generator-choice-shape-circle-water
-					Settings:
-						ExternalCircularBias: -1
 			MultiChoiceOption@Resources:
 				Label: label-cnc-map-generator-option-resources
 				Default: Medium

--- a/mods/common/chrome/lobby-mappreview.yaml
+++ b/mods/common/chrome/lobby-mappreview.yaml
@@ -102,6 +102,23 @@ Container@MAP_PREVIEW:
 					Width: PARENT_WIDTH
 					Height: 25
 					Indeterminate: True
+		Container@MAP_GENERATING:
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
+			Children:
+				Label@MAP_STATUS_GENERATING:
+					Y: 174
+					Width: PARENT_WIDTH
+					Height: 25
+					Font: Tiny
+					Align: Center
+					Text: label-map-generating-status
+					IgnoreMouseOver: true
+				ProgressBar@MAP_GENERATING_BAR:
+					Y: 194
+					Width: PARENT_WIDTH
+					Height: 25
+					Indeterminate: True
 		Container@MAP_DOWNLOAD_AVAILABLE:
 			Width: PARENT_WIDTH
 			Height: PARENT_HEIGHT

--- a/mods/common/chrome/map-chooser.yaml
+++ b/mods/common/chrome/map-chooser.yaml
@@ -57,6 +57,9 @@ Background@MAPCHOOSER_PANEL:
 						ScrollPanel@MAP_LIST:
 							Width: PARENT_WIDTH
 							Height: PARENT_HEIGHT
+				Container@GENERATE_MAP_TAB:
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
 		ScrollItem@MAP_TEMPLATE:
 			Width: 208
 			Height: 266
@@ -185,3 +188,105 @@ Background@MAPCHOOSER_PANEL:
 			Font: Bold
 			Key: escape
 		TooltipContainer@TOOLTIP_CONTAINER:
+
+
+Container@MAPCHOOSER_GENERATE_PANEL:
+	Logic: MapGeneratorLogic
+	Width: PARENT_WIDTH
+	Height: PARENT_HEIGHT
+	Children:
+		Background@MAP_BG:
+			X: PARENT_WIDTH - WIDTH
+			Width: 370
+			Height: 370
+			Background: dialog3
+			Children:
+				GeneratedMapPreview@PREVIEW:
+					X: 1
+					Y: 1
+					Width: PARENT_WIDTH - 2
+					Height: PARENT_HEIGHT - 2
+		Label@TITLE:
+			X: PARENT_WIDTH - WIDTH
+			Y: 375
+			Width: 370
+			Height: 24
+			Align: Center
+			Text: label-mapchooser-random-map-title
+			Font: Bold
+		Label@ERROR:
+			X: PARENT_WIDTH - WIDTH
+			Y: 405
+			Width: 370
+			Height: 24
+			Align: Center
+			Text: label-mapchooser-random-map-error-desc
+		Label@DETAILS:
+			X: PARENT_WIDTH - WIDTH
+			Y: 405
+			Width: 370
+			Height: 24
+			Align: Center
+		LabelWithTooltip@AUTHOR:
+			X: PARENT_WIDTH - WIDTH
+			Y: 425
+			Width: 370
+			Height: 24
+			Align: Center
+		Label@SIZE:
+			X: PARENT_WIDTH - WIDTH
+			Y: 445
+			Width: 370
+			Height: 24
+			Align: Center
+		Button@BUTTON_GENERATE:
+			X: PARENT_WIDTH - 380
+			Y: PARENT_HEIGHT + 40
+			Width: 120
+			Height: 25
+			Text: button-mapchooser-random-map-generate
+			Font: Bold
+		ScrollPanel@SETTINGS_PANEL:
+			TopBottomSpacing: 5
+			Width: 485
+			Height: PARENT_HEIGHT + 30
+			Children:
+				Container@CHECKBOX_TEMPLATE:
+					Width: 230
+					Height: 30
+					Children:
+						Checkbox@CHECKBOX:
+							X: 10
+							Y: 5
+							Width: PARENT_WIDTH - 20
+							Height: 20
+				Container@TEXT_TEMPLATE:
+					Width: 230
+					Height: 50
+					Children:
+						LabelForInput@LABEL:
+							X: 10
+							Width: PARENT_WIDTH - 20
+							Height: 20
+							For: INPUT
+						TextField@INPUT:
+							X: 10
+							Y: 20
+							Width: PARENT_WIDTH - 20
+							Height: 25
+				Container@DROPDOWN_TEMPLATE:
+					Width: 230
+					Height: 50
+					Children:
+						LabelForInput@LABEL:
+							X: 10
+							Width: PARENT_WIDTH - 20
+							Height: 20
+							For: DROPDOWN
+						DropDownButton@DROPDOWN:
+							X: 10
+							Y: 20
+							Width: PARENT_WIDTH - 20
+							Height: 25
+							PanelRoot: GENERATOR_DROPDOWN_PANEL_ROOT # ensure that tooltips for the options are on top of the dropdown panel
+		Container@GENERATOR_DROPDOWN_PANEL_ROOT:

--- a/mods/common/fluent/chrome.ftl
+++ b/mods/common/fluent/chrome.ftl
@@ -193,6 +193,7 @@ button-force-start-dialog-start = Start
 label-map-incompatible-status-a = This map is not compatible
 label-map-incompatible-status-b = with this version of OpenRA
 label-map-validating-status = Validating...
+label-map-generating-status = Generating...
 button-map-download-available-install = Install Map
 button-map-preview-update = Update Map
 button-map-update-download-available-install = Install Map

--- a/mods/common/fluent/chrome.ftl
+++ b/mods/common/fluent/chrome.ftl
@@ -342,6 +342,14 @@ button-mapchooser-panel-delete-map = Delete Map
 button-mapchooser-panel-delete-all-maps = Delete All Maps
 button-mapchooser-panel-ok = Ok
 
+label-mapchooser-random-map-title = Random Map
+label-mapchooser-random-map-generating = Generating...
+label-mapchooser-random-map-error = Map Generation Failed
+button-mapchooser-random-map-generate = Generate
+label-mapchooser-random-map-tileset = Environment:
+label-mapchooser-random-map-size = Map Size:
+label-mapchooser-random-map-error-desc = Adjust the settings to try again.
+
 ## missionbrowser.yaml
 button-missionbrowser-panel-start-briefing-video = Watch Briefing
 button-missionbrowser-panel-stop-briefing-video = Stop Briefing

--- a/mods/common/fluent/common.ftl
+++ b/mods/common/fluent/common.ftl
@@ -478,10 +478,10 @@ label-player-count =
         [one] { $players } Player
        *[other] { $players } Players
     }
-label-map-size-huge = (Huge)
-label-map-size-large = (Large)
-label-map-size-medium = (Medium)
-label-map-size-small = (Small)
+label-map-size-huge = Huge
+label-map-size-large = Large
+label-map-size-medium = Medium
+label-map-size-small = Small
 label-map-searching-count =
     { $count ->
         [one] Searching the OpenRA Resource Center for { $count } map...

--- a/mods/common/fluent/common.ftl
+++ b/mods/common/fluent/common.ftl
@@ -514,6 +514,7 @@ options-order-maps =
 button-mapchooser-system-maps-tab = Official Maps
 button-mapchooser-remote-maps-tab = Server Maps
 button-mapchooser-user-maps-tab = Custom Maps
+button-mapchooser-generated-maps-tab = Generate Map
 
 ## MissionBrowserLogic
 dialog-no-video =

--- a/mods/ra/rules/map-generators.yaml
+++ b/mods/ra/rules/map-generators.yaml
@@ -195,6 +195,22 @@
 						Forests: 0
 						SpawnBuildSize: 6
 						MinimumSpawnRadius: 4
+			MultiChoiceOption@Shape:
+				Label: label-ra-map-generator-option-shape
+				Default: Square
+				Priority: 1
+				Choice@Square:
+					Label: label-ra-map-generator-choice-shape-square
+					Settings:
+						ExternalCircularBias: 0
+				Choice@CircleMountain:
+					Label: label-ra-map-generator-choice-shape-circle-mountain
+					Settings:
+						ExternalCircularBias: 1
+				Choice@CircleWater:
+					Label: label-ra-map-generator-choice-shape-circle-water
+					Settings:
+						ExternalCircularBias: -1
 			MultiIntegerChoiceOption@Players:
 				Label: label-ra-map-generator-option-players
 				Parameter: Players
@@ -264,22 +280,6 @@
 					Players: 8, 16
 					Settings:
 						Rotations: 8
-			MultiChoiceOption@Shape:
-				Label: label-ra-map-generator-option-shape
-				Default: Square
-				Priority: 1
-				Choice@Square:
-					Label: label-ra-map-generator-choice-shape-square
-					Settings:
-						ExternalCircularBias: 0
-				Choice@CircleMountain:
-					Label: label-ra-map-generator-choice-shape-circle-mountain
-					Settings:
-						ExternalCircularBias: 1
-				Choice@CircleWater:
-					Label: label-ra-map-generator-choice-shape-circle-water
-					Settings:
-						ExternalCircularBias: -1
 			MultiChoiceOption@Resources:
 				Label: label-ra-map-generator-option-resources
 				Default: Medium


### PR DESCRIPTION
This PR introduces a third classification of map (together with local and remote): `MapClassification.Generated`, which is constructed at runtime by passing an opaque yaml blob to a mod-defined map generation trait.

~~The lobby random map generator UI is split into its own followup PR, so this includes a simple testcase that overrides the "Change Map" button to select a random map with default settings. Note that the default settings in RA fail for at least one of the tilesets (probably Interior?), so it may take a couple of button presses for it to work (and/or just test in TD).~~

Depends on ~~#21849~~, ~~#21850~~, ~~#21859~~, ~~#21860~~, ~~#21861~~, ~~#21868~~, ~~#21869~~, ~~#21870~~, ~~#21871~~, ~~#21876~~, ~~#21877~~.

Strongly recommend reviewing by commit.