### PR TITLE
Split IMapGeneratorInfo into core backend and editor frontend.

### DIFF
--- a/OpenRA.Game/Map/MapGenerationArgs.cs
+++ b/OpenRA.Game/Map/MapGenerationArgs.cs
@@ -1,0 +1,43 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Primitives;
+
+namespace OpenRA
+{
+	public class MapGenerationArgs
+	{
+		[FieldLoader.Require]
+		public string Uid = null;
+
+		[FieldLoader.Require]
+		public string Generator = null;
+
+		[FieldLoader.Require]
+		public string Tileset = null;
+
+		[FieldLoader.Require]
+		public Size Size = default;
+
+		[FieldLoader.Require]
+		public string Title = null;
+
+		[FieldLoader.Require]
+		public string Author = null;
+
+		[FieldLoader.LoadUsing(nameof(LoadSettings))]
+		public MiniYaml Settings = null;
+		static MiniYaml LoadSettings(MiniYaml yaml)
+		{
+			return yaml.NodeWithKey("Settings").Value;
+		}
+	}
+}

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -650,4 +650,13 @@ namespace OpenRA.Traits
 		bool CrushableBy(Actor self, Actor crusher, BitSet<CrushClass> crushClasses);
 		LongBitSet<PlayerBitMask> CrushableBy(Actor self, BitSet<CrushClass> crushClasses);
 	}
+
+	public interface IMapGeneratorInfo : ITraitInfoInterface
+	{
+		string Type { get; }
+		string Name { get; }
+		string MapTitle { get; }
+
+		Map Generate(ModData modData, MapGenerationArgs args);
+	}
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -977,33 +977,17 @@ namespace OpenRA.Mods.Common.Traits
 
 	public interface IMapGeneratorSettings
 	{
-		/// <summary>Returns the options that allow users to customise the result.</summary>
 		List<MapGeneratorOption> Options { get; }
 
 		int PlayerCount { get; }
 
 		void Randomize(MersenneTwister random);
 
-		/// <summary>Merge all choices into a complete settings MiniYaml.</summary>
-		MiniYaml Compile(ITerrainInfo terrainInfo);
+		MapGenerationArgs Compile(ITerrainInfo terrainInfo, Size size);
 	}
 
-	public interface IMapGeneratorInfo : ITraitInfoInterface
+	public interface IEditorMapGeneratorInfo : IMapGeneratorInfo
 	{
-		string Type { get; }
-		string Name { get; }
-
 		IMapGeneratorSettings GetSettings();
-
-		/// <summary>
-		/// Generate or manipulate a supplied map in-place.
-		/// </summary>
-		/// <exception cref="YamlException">
-		/// May be thrown if the map settings are invalid. Map should be discarded.
-		/// </exception>
-		/// <exception cref="MapGenerationException">
-		/// Thrown if the map could not be generated with the requested configuration. Map should be discarded.
-		/// </exception>
-		void Generate(Map map, MiniYaml settings);
 	}
 }

--- a/OpenRA.Mods.Common/UtilityCommands/FuzzMapGeneratorCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/FuzzMapGeneratorCommand.cs
@@ -207,7 +207,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				.ToImmutableArray();
 
 			var generator = modData.DefaultRules.Actors[SystemActors.EditorWorld]
-				.TraitInfos<IMapGeneratorInfo>()
+				.TraitInfos<IEditorMapGeneratorInfo>()
 				.FirstOrDefault(info => info.Type == config.MapGeneratorType);
 			if (generator == null)
 				throw new ArgumentException($"No map generator with type `{config.MapGeneratorType}`");
@@ -265,12 +265,6 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					if (size.Length != 2)
 						throw new ArgumentException($"bad map size `{iterationChoices[Configuration.SizeVariable]}`");
 
-					var map = new Map(modData, terrainInfo, new Size(size[0], size[1]));
-					var maxTerrainHeight = map.Grid.MaximumTerrainHeight;
-					var tl = new PPos(1, 1 + maxTerrainHeight);
-					var br = new PPos(size[0], size[1] + maxTerrainHeight);
-					map.SetBounds(tl, br);
-
 					var settings = generator.GetSettings();
 					foreach (var o in settings.Options)
 					{
@@ -299,7 +293,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						tests++;
 						try
 						{
-							generator.Generate(map, settings.Compile(terrainInfo));
+							generator.Generate(modData, settings.Compile(terrainInfo, new Size(size[0], size[1])));
 						}
 						catch (Exception e) when (e is MapGenerationException || e is YamlException)
 						{

--- a/mods/cnc/fluent/rules.ftl
+++ b/mods/cnc/fluent/rules.ftl
@@ -781,6 +781,7 @@ bot-hal9001 =
     .name = HAL 9001
 
 ## map-generators.yaml
+label-random-map = Random Map
 label-clear-map-generator-option-tile = Tile
 label-clear-map-generator-choice-tile-clear =
    .label = Clear

--- a/mods/ra/fluent/rules.ftl
+++ b/mods/ra/fluent/rules.ftl
@@ -946,6 +946,7 @@ bot-naval-ai =
     .name = Naval AI
 
 ## map-generators.yaml
+label-random-map = Random Map
 label-clear-map-generator-option-tile = Tile
 label-clear-map-generator-choice-tile-clear =
    .label = Clear


### PR DESCRIPTION
The core engine will soon need to know about `IMapGenerator` in order to support map sharing. The engine doesn't need to know about any of the editor related UI, so splitting the interface makes more sense than moving a bunch of unrelated UI code also into Game.

Split from #21855 as requested.