### PR TITLE
Fix invalid CachedTransform uses of MapPreview.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
@@ -111,17 +111,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Widget SetupAuthorAndMapType(Widget parent)
 			{
 				var typeLabel = parent.Get<LabelWidget>("MAP_TYPE");
-				var typeCache = new CachedTransform<MapPreview, string>(
-					m => m.Categories.FirstOrDefault() ?? "");
+				var typeCache = new CachedTransform<string[], string>(c => c.FirstOrDefault() ?? "");
 
-				typeLabel.GetText = () => typeCache.Update(getMap().Map);
+				typeLabel.GetText = () => typeCache.Update(getMap().Map.Categories);
 
 				var authorLabel = parent.Get<LabelWidget>("MAP_AUTHOR");
 				var font = Game.Renderer.Fonts[authorLabel.Font];
-				var truncateCache = new CachedTransform<MapPreview, string>(
-					m => WidgetUtils.TruncateText(authorCache.Update(m.Author), authorLabel.Bounds.Width, font));
+				var truncateCache = new CachedTransform<string, string>(author =>
+					WidgetUtils.TruncateText(authorCache.Update(author), authorLabel.Bounds.Width, font));
 
-				authorLabel.GetText = () => truncateCache.Update(getMap().Map);
+				authorLabel.GetText = () => truncateCache.Update(getMap().Map.Author);
 
 				return parent;
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -335,12 +335,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (mapTitle != null)
 			{
 				var font = Game.Renderer.Fonts[mapTitle.Font];
-				var title = new CachedTransform<MapPreview, string>(m =>
+				var title = new CachedTransform<string, string>(t =>
 				{
-					var truncated = WidgetUtils.TruncateText(m.Title, mapTitle.Bounds.Width, font);
+					var truncated = WidgetUtils.TruncateText(t, mapTitle.Bounds.Width, font);
 
-					if (m.Title != truncated)
-						mapTitle.GetTooltipText = () => m.Title;
+					if (t != truncated)
+						mapTitle.GetTooltipText = () => t;
 					else
 						mapTitle.GetTooltipText = null;
 
@@ -358,7 +358,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					if (currentMap.Class == MapClassification.Unknown)
 						return mapClassificationUnknown;
 
-					return title.Update(currentMap);
+					return title.Update(currentMap.Title);
 				};
 			}
 


### PR DESCRIPTION
The `MapPreview` reference does not change when its innerdata is updated, so these values were never updated.

Split from #21855.