### PR TITLE
Change Map.MapSize from int2 to Size.

### DIFF
--- a/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
+++ b/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
@@ -49,23 +49,23 @@ namespace OpenRA.Graphics
 			BlendMode = blendMode;
 			map = world.Map;
 
-			vertexRowStride = 4 * map.MapSize.X;
-			vertices = new Vertex[vertexRowStride * map.MapSize.Y];
+			vertexRowStride = 4 * map.MapSize.Width;
+			vertices = new Vertex[vertexRowStride * map.MapSize.Height];
 			vertexBuffer = Game.Renderer.Context.CreateEmptyVertexBuffer<Vertex>(vertices.Length);
 
-			indexRowStride = 6 * map.MapSize.X;
+			indexRowStride = 6 * map.MapSize.Width;
 			lock (IndexBuffers)
 			{
 				indexBufferWrapper = IndexBuffers.GetValue(world, world => new IndexBufferRc(world));
 				indexBufferWrapper.AddRef();
 			}
 
-			palettes = new PaletteReference[map.MapSize.X * map.MapSize.Y];
+			palettes = new PaletteReference[map.MapSize.Width * map.MapSize.Height];
 			wr.PaletteInvalidated += UpdatePaletteIndices;
 
 			if (wr.TerrainLighting != null)
 			{
-				ignoreTint = new bool[vertexRowStride * map.MapSize.Y];
+				ignoreTint = new bool[vertexRowStride * map.MapSize.Height];
 				wr.TerrainLighting.CellChanged += UpdateTint;
 			}
 		}
@@ -80,7 +80,7 @@ namespace OpenRA.Graphics
 				vertices[i] = new Vertex(v.X, v.Y, v.Z, v.S, v.T, v.U, v.V, c, v.R, v.G, v.B, v.A);
 			}
 
-			for (var row = 0; row < map.MapSize.Y; row++)
+			for (var row = 0; row < map.MapSize.Height; row++)
 				dirtyRows.Add(row);
 		}
 
@@ -193,7 +193,7 @@ namespace OpenRA.Graphics
 
 			var offset = vertexRowStride * uv.V + 4 * uv.U;
 			Util.FastCreateQuad(vertices, pos, sprite, samplers, palette?.TextureIndex ?? 0, offset, scale * sprite.Size, alpha * float3.Ones, alpha);
-			palettes[uv.V * map.MapSize.X + uv.U] = palette;
+			palettes[uv.V * map.MapSize.Width + uv.U] = palette;
 
 			if (worldRenderer.TerrainLighting != null)
 			{
@@ -209,8 +209,8 @@ namespace OpenRA.Graphics
 			var cells = restrictToBounds ? viewport.VisibleCellsInsideBounds : viewport.AllVisibleCells;
 
 			// Only draw the rows that are visible.
-			var firstRow = cells.CandidateMapCoords.TopLeft.V.Clamp(0, map.MapSize.Y);
-			var lastRow = (cells.CandidateMapCoords.BottomRight.V + 1).Clamp(firstRow, map.MapSize.Y);
+			var firstRow = cells.CandidateMapCoords.TopLeft.V.Clamp(0, map.MapSize.Height);
+			var lastRow = (cells.CandidateMapCoords.BottomRight.V + 1).Clamp(firstRow, map.MapSize.Height);
 
 			Game.Renderer.Flush();
 
@@ -250,7 +250,8 @@ namespace OpenRA.Graphics
 
 			public IndexBufferRc(World world)
 			{
-				Buffer = Game.Renderer.Context.CreateIndexBuffer(Util.CreateQuadIndices(world.Map.MapSize.X * world.Map.MapSize.Y));
+				Buffer = Game.Renderer.Context.CreateIndexBuffer(
+					Util.CreateQuadIndices(world.Map.MapSize.Width * world.Map.MapSize.Height));
 			}
 
 			public void AddRef() { count++; }

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -155,8 +155,8 @@ namespace OpenRA.Graphics
 			if (wr.World.Type == WorldType.Editor)
 			{
 				// The full map is visible in the editor
-				var width = map.MapSize.X * tileSize.Width;
-				var height = map.MapSize.Y * tileSize.Height;
+				var width = map.MapSize.Width * tileSize.Width;
+				var height = map.MapSize.Height * tileSize.Height;
 				if (wr.World.Map.Grid.Type == MapGridType.RectangularIsometric)
 					height /= 2;
 

--- a/OpenRA.Game/Map/CellLayerBase.cs
+++ b/OpenRA.Game/Map/CellLayerBase.cs
@@ -25,7 +25,7 @@ namespace OpenRA
 		protected readonly Rectangle Bounds;
 
 		protected CellLayerBase(Map map)
-			: this(map.Grid.Type, new Size(map.MapSize.X, map.MapSize.Y)) { }
+			: this(map.Grid.Type, map.MapSize) { }
 
 		protected CellLayerBase(MapGridType gridType, Size size)
 		{

--- a/OpenRA.Game/Primitives/Size.cs
+++ b/OpenRA.Game/Primitives/Size.cs
@@ -74,9 +74,6 @@ namespace OpenRA.Primitives
 			return Width ^ Height;
 		}
 
-		public override string ToString()
-		{
-			return $"{{Width={Width}, Height={Height}}}";
-		}
+		public override string ToString() { return Width + "," + Height; }
 	}
 }

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -264,7 +264,7 @@ namespace OpenRA.Traits
 			frozenActorsById = [];
 
 			partitionedFrozenActors = new SpatiallyPartitioned<FrozenActor>(
-				world.Map.MapSize.X, world.Map.MapSize.Y, binSize);
+				world.Map.MapSize.Width, world.Map.MapSize.Height, binSize);
 
 			self.Trait<Shroud>().OnShroudChanged += uv =>
 			{

--- a/OpenRA.Game/Traits/World/ScreenMap.cs
+++ b/OpenRA.Game/Traits/World/ScreenMap.cs
@@ -62,8 +62,8 @@ namespace OpenRA.Traits
 		public ScreenMap(World world, ScreenMapInfo info)
 		{
 			var size = world.Map.Rules.TerrainInfo.TileSize;
-			var width = world.Map.MapSize.X * size.Width;
-			var height = world.Map.MapSize.Y * size.Height;
+			var width = world.Map.MapSize.Width * size.Width;
+			var height = world.Map.MapSize.Height * size.Height;
 
 			partitionedMouseFrozenActors = new Cache<Player, SpatiallyPartitioned<FrozenActor>>(
 				_ => new SpatiallyPartitioned<FrozenActor>(width, height, info.BinSize));

--- a/OpenRA.Mods.Cnc/Traits/World/TSVeinsRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSVeinsRenderer.cs
@@ -74,9 +74,9 @@ namespace OpenRA.Mods.Cnc.Traits
 			var terrainInfo = map.Rules.TerrainInfo;
 			var info = terrainInfo.TerrainTypes[terrainInfo.GetTerrainIndex(terrainType)];
 
-			for (var i = 0; i < map.MapSize.X; i++)
+			for (var i = 0; i < map.MapSize.Width; i++)
 			{
-				for (var j = 0; j < map.MapSize.Y; j++)
+				for (var j = 0; j < map.MapSize.Height; j++)
 				{
 					var uv = new MPos(i, j);
 

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportGen1MapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportGen1MapCommand.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 				if (!ModData.DefaultTerrainInfo.TryGetValue(tileset, out var terrainInfo))
 					throw new InvalidDataException($"Unknown tileset {tileset}");
 
-				Map = new Map(ModData, terrainInfo, MapSize, MapSize)
+				Map = new Map(ModData, terrainInfo, new Size(MapSize, MapSize))
 				{
 					Title = basic.GetValue("Name", Path.GetFileNameWithoutExtension(filename)),
 					Author = author,

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportGen2MapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportGen2MapCommand.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			var usedAreaSize = new Size(iniSize[2], 2 * iniSize[3]);
 			var mapCanvasSize = new Size(usedAreaSize.Width + Cordon.Left + Cordon.Right, usedAreaSize.Height + Cordon.Top + Cordon.Bottom);
 
-			var map = new Map(Game.ModData, terrainInfo, mapCanvasSize.Width, mapCanvasSize.Height)
+			var map = new Map(Game.ModData, terrainInfo, mapCanvasSize)
 			{
 				Title = basic.GetValue("Name", Path.GetFileNameWithoutExtension(filename)),
 				Author = author,

--- a/OpenRA.Mods.Common/Lint/CheckMapCordon.cs
+++ b/OpenRA.Mods.Common/Lint/CheckMapCordon.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Lint
 		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
 		{
 			if (map.Bounds.Left == 0 || map.Bounds.Top == 0
-				|| map.Bounds.Right == map.MapSize.X || map.Bounds.Bottom == map.MapSize.Y)
+				|| map.Bounds.Right == map.MapSize.Width || map.Bounds.Bottom == map.MapSize.Height)
 				emitError("This map does not define a valid cordon.\n"
 					+ "A one cell (or greater) border is required on all four sides "
 					+ "between the playable bounds and the map edges.");

--- a/OpenRA.Mods.Common/Lint/CheckMultiBrushes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckMultiBrushes.cs
@@ -12,6 +12,7 @@
 using System;
 using OpenRA.Mods.Common.MapGenerator;
 using OpenRA.Mods.Common.Terrain;
+using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.Lint
 {
@@ -23,8 +24,9 @@ namespace OpenRA.Mods.Common.Lint
 			{
 				if (terrainInfo is ITemplatedTerrainInfo templatedTerrainInfo && templatedTerrainInfo.MultiBrushCollections.Count > 0)
 				{
-					var map = new Map(modData, terrainInfo, 1, 1);
+					var map = new Map(modData, terrainInfo, new Size(1, 1));
 					foreach (var (collectionName, collection) in templatedTerrainInfo.MultiBrushCollections)
+					{
 						foreach (var info in collection)
 						{
 							try
@@ -41,6 +43,7 @@ namespace OpenRA.Mods.Common.Lint
 								emitError($"Tileset {terrainInfoName} has invalid MultiBrush collection `{collectionName}`: {e.Message}");
 							}
 						}
+					}
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/MapGenerator/CellLayerUtils.cs
+++ b/OpenRA.Mods.Common/MapGenerator/CellLayerUtils.cs
@@ -322,7 +322,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 		/// </summary>
 		public static Rectangle CellBounds(Map map)
 		{
-			return CellBounds(new Size(map.MapSize.X, map.MapSize.Y), map.Grid.Type);
+			return CellBounds(map.MapSize, map.Grid.Type);
 		}
 
 		/// <summary>

--- a/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
@@ -533,8 +533,9 @@ namespace OpenRA.Mods.Common.MapGenerator
 			var size = map.MapSize;
 			var replaceMposes = new List<MPos>();
 			var remaining = new CellLayer<bool>(map);
-			for (var v = 0; v < size.Y; v++)
-				for (var u = 0; u < size.X; u++)
+			for (var v = 0; v < size.Height; v++)
+			{
+				for (var u = 0; u < size.Width; u++)
 				{
 					var mpos = new MPos(u, v);
 					if (replace[mpos] != Replaceability.None)
@@ -547,8 +548,9 @@ namespace OpenRA.Mods.Common.MapGenerator
 						remaining[mpos] = false;
 					}
 				}
+			}
 
-			var mposes = new MPos[size.X * size.Y];
+			var mposes = new MPos[size.Width * size.Height];
 			int mposCount;
 
 			void RefreshIndices()

--- a/OpenRA.Mods.Common/MapGenerator/PlayableSpace.cs
+++ b/OpenRA.Mods.Common/MapGenerator/PlayableSpace.cs
@@ -70,7 +70,6 @@ namespace OpenRA.Mods.Common.MapGenerator
 			List<ActorPlan> actorPlans,
 			Dictionary<TerrainTile, Playability> playabilityMap)
 		{
-			var size = map.MapSize;
 			var regions = new List<Region>();
 			var regionMap = new CellLayer<int>(map);
 			regionMap.Clear(NullRegion);

--- a/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
+++ b/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
@@ -319,7 +319,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 						false);
 				}
 
-				return new Grid(CPos.Zero, (CPos)map.MapSize, false);
+				return new Grid(CPos.Zero, new CPos(map.MapSize.Width, map.MapSize.Height), false);
 			}
 
 			mapBounds = GetCPosBounds(world.Map);

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
@@ -61,8 +61,8 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			var dangerRadius = owner.SquadManager.Info.DangerScanRadius;
 			detectedEnemyTarget = null;
 
-			var columnCount = (map.MapSize.X + dangerRadius - 1) / dangerRadius;
-			var rowCount = (map.MapSize.Y + dangerRadius - 1) / dangerRadius;
+			var columnCount = (map.MapSize.Width + dangerRadius - 1) / dangerRadius;
+			var rowCount = (map.MapSize.Height + dangerRadius - 1) / dangerRadius;
 
 			var checkIndices = Exts.MakeArray(columnCount * rowCount, i => i).Shuffle(owner.World.LocalRandom);
 			foreach (var i in checkIndices)

--- a/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
@@ -140,9 +140,9 @@ namespace OpenRA.Mods.Common.Traits
 			var suitableLocations = new List<(MPos UV, int Attractiveness)>();
 			var totalAttractiveness = 0;
 
-			for (var i = 0; i < map.MapSize.X; i += checkRadius)
+			for (var i = 0; i < map.MapSize.Width; i += checkRadius)
 			{
-				for (var j = 0; j < map.MapSize.Y; j += checkRadius)
+				for (var j = 0; j < map.MapSize.Height; j += checkRadius)
 				{
 					var tl = new MPos(i, j);
 					var br = new MPos(i + checkRadius, j + checkRadius);

--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -194,8 +194,8 @@ namespace OpenRA.Mods.Common.Traits
 			map = world.Map;
 			influence = [new CellLayer<InfluenceNode>(world.Map)];
 
-			cols = CellCoordToBinIndex(world.Map.MapSize.X) + 1;
-			rows = CellCoordToBinIndex(world.Map.MapSize.Y) + 1;
+			cols = CellCoordToBinIndex(world.Map.MapSize.Width) + 1;
+			rows = CellCoordToBinIndex(world.Map.MapSize.Height) + 1;
 			bins = new Bin[rows * cols];
 			for (var row = 0; row < rows; row++)
 				for (var col = 0; col < cols; col++)

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -85,8 +85,8 @@ namespace OpenRA.Mods.Common.Traits
 			cellMap = new SpatiallyPartitioned<EditorActorPreview>(
 				mapCellSize.X, mapCellSize.Y, Exts.IntegerDivisionRoundingAwayFromZero(Info.BinSize, ts.Width));
 
-			var width = world.Map.MapSize.X * ts.Width;
-			var height = world.Map.MapSize.Y * ts.Height;
+			var width = world.Map.MapSize.Width * ts.Width;
+			var height = world.Map.MapSize.Height * ts.Height;
 			screenMap = new SpatiallyPartitioned<EditorActorPreview>(width, height, Info.BinSize);
 
 			foreach (var kv in world.Map.ActorDefinitions)

--- a/OpenRA.Mods.Common/Traits/World/ExperimentalMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/ExperimentalMapGenerator.cs
@@ -489,9 +489,8 @@ namespace OpenRA.Mods.Common.Traits
 			const int ExternalBias = 4096;
 
 			var size = map.MapSize;
-			var minSpan = Math.Min(size.X, size.Y);
-			var maxSpan = Math.Max(size.X, size.Y);
-			var mapCenter1024ths = size * 512;
+			var minSpan = Math.Min(size.Width, size.Height);
+			var mapCenter1024ths = size.ToInt2() * 512;
 			var wMapCenter = CellLayerUtils.Center(map.Tiles);
 			var matrixMapCenter1024ths = CellLayerUtils.CellBounds(map).Size.ToInt2() * 512;
 			var cellBounds = CellLayerUtils.CellBounds(map);
@@ -756,7 +755,7 @@ namespace OpenRA.Mods.Common.Traits
 					// Limit mountain area to the existing mountain space (starting with all available land)
 					var roominess = MatrixUtils.ChebyshevRoom(cliffPlan, true);
 					var available = 0;
-					var total = size.X * size.Y;
+					var total = size.Width * size.Height;
 					for (var n = 0; n < mountainElevation.Data.Length; n++)
 					{
 						if (roominess.Data[n] < param.MinimumTerrainContourSpacing)
@@ -1719,7 +1718,7 @@ namespace OpenRA.Mods.Common.Traits
 							decorationNoise[mpos] = -1024 * 1024;
 					}
 
-					var mapArea = map.MapSize.X * map.MapSize.Y;
+					var mapArea = map.MapSize.Width * map.MapSize.Height;
 					CellLayerUtils.CalibrateQuantileInPlace(
 						decorationNoise,
 						0,

--- a/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
@@ -80,9 +80,9 @@ namespace OpenRA.Mods.Common.Traits
 				colors.Add(resourceIndex, info.Color);
 			}
 
-			for (var i = 0; i < map.MapSize.X; i++)
+			for (var i = 0; i < map.MapSize.Width; i++)
 			{
-				for (var j = 0; j < map.MapSize.Y; j++)
+				for (var j = 0; j < map.MapSize.Height; j++)
 				{
 					var cell = new MPos(i, j);
 					if (colors.TryGetValue(map.Resources[cell].Type, out var color))

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -314,7 +314,7 @@ namespace OpenRA.Mods.Common.Traits
 			cellsDirty.Clear(true);
 			anyCellDirty = true;
 			var tl = new PPos(0, 0);
-			var br = new PPos(map.MapSize.X - 1, map.MapSize.Y - 1);
+			var br = new PPos(map.MapSize.Width - 1, map.MapSize.Height - 1);
 			UpdateShroud(new ProjectedCellRegion(map, tl, br));
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/TerrainLighting.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainLighting.cs
@@ -61,8 +61,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			var tileScale = map.Grid.TileScale;
 			partitionedLightSources = new SpatiallyPartitioned<LightSource>(
-				(map.MapSize.X + 1) * tileScale,
-				(map.MapSize.Y + 1) * tileScale,
+				(map.MapSize.Width + 1) * tileScale,
+				(map.MapSize.Height + 1) * tileScale,
 				info.BinSize * tileScale);
 		}
 

--- a/OpenRA.Mods.Common/UtilityCommands/FuzzMapGeneratorCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/FuzzMapGeneratorCommand.cs
@@ -17,6 +17,7 @@ using System.Linq;
 using System.Text;
 using OpenRA.Mods.Common.MapGenerator;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
@@ -264,7 +265,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					if (size.Length != 2)
 						throw new ArgumentException($"bad map size `{iterationChoices[Configuration.SizeVariable]}`");
 
-					var map = new Map(modData, terrainInfo, size[0], size[1]);
+					var map = new Map(modData, terrainInfo, new Size(size[0], size[1]));
 					var maxTerrainHeight = map.Grid.MaximumTerrainHeight;
 					var tl = new PPos(1, 1 + maxTerrainHeight);
 					var br = new PPos(size[0], size[1] + maxTerrainHeight);

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
@@ -262,7 +262,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var map = world.Map;
 			var terrainInfo = map.Rules.TerrainInfo;
-			var generatedMap = new Map(modData, terrainInfo, map.MapSize.X, map.MapSize.Y);
+			var generatedMap = new Map(modData, terrainInfo, map.MapSize);
 			var bounds = map.Bounds;
 			generatedMap.SetBounds(new PPos(bounds.Left, bounds.Top), new PPos(bounds.Right - 1, bounds.Bottom - 1));
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -13,6 +13,7 @@ using System;
 using System.Linq;
 using OpenRA.FileSystem;
 using OpenRA.Mods.Common.Terrain;
+using OpenRA.Primitives;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
@@ -59,7 +60,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				var maxTerrainHeight = world.Map.Grid.MaximumTerrainHeight;
 				var tileset = modData.DefaultTerrainInfo[tilesetDropDown.GetText()];
-				var map = new Map(Game.ModData, tileset, width + 2, height + maxTerrainHeight + 2);
+				var map = new Map(Game.ModData, tileset, new Size(width + 2, height + maxTerrainHeight + 2));
 
 				var tl = new PPos(1, 1 + maxTerrainHeight);
 				var br = new PPos(width, height + maxTerrainHeight);

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -75,8 +75,8 @@ namespace OpenRA.Mods.Common.Widgets
 			radarTerrainLayers = world.WorldActor.TraitsImplementing<IRadarTerrainLayer>().ToArray();
 			isRectangularIsometric = world.Map.Grid.Type == MapGridType.RectangularIsometric;
 			cellWidth = isRectangularIsometric ? 2 : 1;
-			previewWidth = world.Map.MapSize.X;
-			previewHeight = world.Map.MapSize.Y;
+			previewWidth = world.Map.MapSize.Width;
+			previewHeight = world.Map.MapSize.Height;
 			if (isRectangularIsometric)
 				previewWidth = 2 * previewWidth - 1;
 		}

--- a/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
@@ -326,7 +326,7 @@ namespace OpenRA.Mods.D2k.UtilityCommands
 			if (terrainInfo == null)
 				throw new InvalidDataException("The D2k map importer requires the DefaultTerrain parser.");
 
-			map = new Map(Game.ModData, terrainInfo, mapSize.Width + 2 * MapCordonWidth, mapSize.Height + 2 * MapCordonWidth)
+			map = new Map(Game.ModData, terrainInfo, new Size(mapSize.Width + 2 * MapCordonWidth, mapSize.Height + 2 * MapCordonWidth))
 			{
 				Title = Path.GetFileNameWithoutExtension(mapFile),
 				Author = "Westwood Studios"


### PR DESCRIPTION
In the very distant past OpenRA used `int2` for all 2D integral types, and it caused much sadness and confusion. `Size` was initially imported from `System.Drawing` and had an incompatible `ToString` that prevented it from being used with `FieldSaver`, and when we switched to our own implementation that was also copied over.

Nowadays, many of the places that interact with `MapSize` need to manually convert between `Size` and `int2`. Fixing `Size` to be able to round-trip through the `FieldSaver`/`FieldLoader` allows these legacy workarounds to be cleaned up.