### PR TITLE
Skip dropdowns that have no valid options.

### DIFF
--- a/OpenRA.Mods.Common/MapGenerator/MapGeneratorSettings.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MapGeneratorSettings.cs
@@ -133,7 +133,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			get => value;
 			set
 			{
-				if (!Choices.ContainsKey(value))
+				if (value != null && !Choices.ContainsKey(value))
 					throw new ArgumentException($"{value} is not in the list of valid choices");
 
 				this.value = value;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
@@ -187,7 +187,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						if (!validChoices.Contains(mo.Value))
 							mo.Value = mo.Default?.FirstOrDefault(validChoices.Contains) ?? validChoices.FirstOrDefault();
 
-						if (mo.Label != null && validChoices.Count > 0)
+						if (mo.Value != null && mo.Label != null && validChoices.Count > 0)
 						{
 							settingWidget = dropDownSettingTemplate.Clone();
 							var labelWidget = settingWidget.Get<LabelWidget>("LABEL");


### PR DESCRIPTION
This PR partially addresses #21862. The editor no longer crashes, but generation will still fail (with a very ugly dialog!) until the underlying yaml definitions are fixed.