### PR TITLE
Reduce memory allocations

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -99,8 +99,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)
 		{
-			return PreviewsInScreenBox(wr.Viewport.TopLeft, wr.Viewport.BottomRight)
-				.SelectMany(p => p.Render());
+			foreach (var p in PreviewsInScreenBox(wr.Viewport.TopLeft, wr.Viewport.BottomRight))
+				foreach (var r in p.Render())
+					yield return r;
 		}
 
 		IEnumerable<Rectangle> IRender.ScreenBounds(Actor self, WorldRenderer wr)

--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -147,20 +147,23 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<IRenderable> RenderAt(WPos centerPosition)
 		{
-			var items = previews.SelectMany(p => p.Render(worldRenderer, centerPosition));
 			if (Selected)
 			{
-				var overlay = items.Where(r => !r.IsDecoration && r is IModifyableRenderable)
-					.Select(r =>
+				foreach (var p in previews)
+				{
+					foreach (var r in p.Render(worldRenderer, centerPosition))
 					{
-						var mr = (IModifyableRenderable)r;
-						return mr.WithTint(float3.Ones, mr.TintModifiers | TintModifiers.ReplaceColor).WithAlpha(0.5f);
-					});
-
-				return items.Concat(overlay);
+						yield return r;
+						if (!r.IsDecoration && r is IModifyableRenderable mr)
+							yield return mr.WithTint(float3.Ones, mr.TintModifiers | TintModifiers.ReplaceColor)
+								.WithAlpha(0.5f);
+					}
+				}
 			}
-
-			return items;
+			else
+				foreach (var p in previews)
+					foreach (var r in p.Render(worldRenderer, centerPosition))
+						yield return r;
 		}
 
 		public IEnumerable<IRenderable> RenderAnnotations()


### PR DESCRIPTION
Closes #21866

Stopped 3 major abuses of linq, signifficantly cutting down on alocations. Granted two of them are in the map editor.