### PR TITLE
Move map installed check to LobbyLogic.

### DIFF
--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -535,7 +535,7 @@ namespace OpenRA
 			innerData = newData;
 		}
 
-		public void Install(string mapRepositoryUrl, Action onSuccess)
+		public void Install(string mapRepositoryUrl)
 		{
 			if ((Status != MapStatus.DownloadError && Status != MapStatus.DownloadAvailable) || !Game.Settings.Game.AllowDownloading)
 				return;
@@ -592,10 +592,7 @@ namespace OpenRA
 					if (p == null)
 						innerData.Status = MapStatus.DownloadError;
 					else
-					{
 						UpdateFromMapWithoutOwningPackage(p, mapInstallPackage, MapClassification.User, GridType);
-						Game.RunAfterTick(onSuccess);
-					}
 				}
 				catch (Exception e)
 				{

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -104,6 +104,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		bool teamChat;
 		bool updateDiscordStatus = true;
 		bool resetOptionsButtonEnabled;
+		bool mapAvailable;
 		Dictionary<int, SpawnOccupant> spawnOccupants = [];
 
 		readonly string chatLineSound;
@@ -589,6 +590,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		public override void Tick()
 		{
+			// Map may have been installed or generated in the background
+			if (!mapAvailable && map.Status == MapStatus.Available)
+			{
+				mapAvailable = true;
+				orderManager.IssueOrder(Order.Command($"state {Session.ClientState.NotReady}"));
+			}
+
 			if (panel == PanelType.Options && OptionsTabDisabled())
 				panel = PanelType.Players;
 
@@ -650,7 +658,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			map = modData.MapCache[uid];
 
 			// Tell the server that we have the map
-			if (map.Status == MapStatus.Available)
+			mapAvailable = map.Status == MapStatus.Available;
+			if (mapAvailable)
 				orderManager.IssueOrder(Order.Command($"state {Session.ClientState.NotReady}"));
 
 			// We don't have the map

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		bool mapUpdateAvailable = false;
 
 		[ObjectCreator.UseCtor]
-		internal MapPreviewLogic(Widget widget, ModData modData, OrderManager orderManager, Func<(MapPreview Map, Session.MapStatus Status)> getMap,
+		internal MapPreviewLogic(Widget widget, ModData modData, Func<(MapPreview Map, Session.MapStatus Status)> getMap,
 			Action<MapPreviewWidget, MapPreview, MouseInput> onMouseDown, Func<Dictionary<int, SpawnOccupant>> getSpawnOccupants,
 			bool mapUpdatesEnabled, Action<string> onMapUpdate, Func<HashSet<int>> getDisabledSpawnPoints, bool showUnoccupiedSpawnpoints)
 		{
@@ -132,15 +132,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				var button = parent.Get<ButtonWidget>("MAP_INSTALL");
 				button.IsHighlighted = () => blink;
-				button.OnClick = () =>
-				{
-					getMap().Map.Install(mapRepository, () =>
-					{
-						if (orderManager != null)
-							Game.RunAfterTick(() => orderManager.IssueOrder(Order.Command($"state {Session.ClientState.NotReady}")));
-					});
-				};
-
+				button.OnClick = () => getMap().Map.Install(mapRepository);
 				return parent;
 			}
 
@@ -187,13 +179,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				mapUpdateAvailable = mapUpdatesEnabled && uid != null && map.Uid != uid;
 
 				if (map.Status == MapStatus.DownloadError)
-				{
-					map.Install(mapRepository, () =>
-					{
-						if (orderManager != null)
-							Game.RunAfterTick(() => orderManager.IssueOrder(Order.Command($"state {Session.ClientState.NotReady}")));
-					});
-				}
+					map.Install(mapRepository);
 				else if (map.Status == MapStatus.Unavailable)
 					modData.MapCache.QueryRemoteMapDetails(mapRepository, [map.Uid]);
 			};


### PR DESCRIPTION
Sending the `state NotReady` order from the installed callback was slightly more efficient (avoids having to check a bool each tick), but breaks separation of concerns by leaking `LobbyLogic` specific implementation logic into `MapPreviewLogic`.

Moving the check back into `LobbyLogic` also improves compatibility with generated maps, which would otherwise need its own special case to send the order after generation.