### PR TITLE
Move WorldViewportSizes.DefaultScale to TerrainInfo.

### DIFF
--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Graphics
 
 		public void OverrideDefaultHeight(float height)
 		{
-			defaultScale = viewportSizes.DefaultScale * Game.Renderer.NativeResolution.Height / height;
+			defaultScale = worldRenderer.World.Map.Rules.TerrainInfo.DefaultScale * Game.Renderer.NativeResolution.Height / height;
 			overrideUserScale = true;
 			UpdateViewportZooms(false);
 		}
@@ -149,7 +149,7 @@ namespace OpenRA.Graphics
 			tileSize = map.Rules.TerrainInfo.TileSize;
 			viewportSizes = Game.ModData.Manifest.Get<WorldViewportSizes>();
 			graphicSettings = Game.Settings.Graphics;
-			defaultScale = viewportSizes.DefaultScale;
+			defaultScale = map.Rules.TerrainInfo.DefaultScale;
 
 			// Calculate map bounds in world-px
 			if (wr.World.Type == WorldType.Editor)

--- a/OpenRA.Game/Map/TerrainInfo.cs
+++ b/OpenRA.Game/Map/TerrainInfo.cs
@@ -26,6 +26,7 @@ namespace OpenRA
 	{
 		string Id { get; }
 		Size TileSize { get; }
+		float DefaultScale { get; }
 		TerrainTypeInfo[] TerrainTypes { get; }
 		TerrainTileInfo GetTerrainInfo(TerrainTile r);
 		bool TryGetTerrainInfo(TerrainTile r, out TerrainTileInfo info);

--- a/OpenRA.Game/WorldViewportSizes.cs
+++ b/OpenRA.Game/WorldViewportSizes.cs
@@ -19,7 +19,6 @@ namespace OpenRA
 		public readonly int2 MediumWindowHeights = new(600, 900);
 		public readonly int2 FarWindowHeights = new(900, 1300);
 
-		public readonly float DefaultScale = 1.0f;
 		public readonly float MaxZoomScale = 2.0f;
 		public readonly int MaxZoomWindowHeight = 240;
 		public readonly bool AllowNativeZoom = true;

--- a/OpenRA.Mods.Common/Terrain/DefaultTerrain.cs
+++ b/OpenRA.Mods.Common/Terrain/DefaultTerrain.cs
@@ -71,6 +71,7 @@ namespace OpenRA.Mods.Common.Terrain
 		public readonly string Name;
 		public readonly string Id;
 		public readonly Size TileSize = new(24, 24);
+		public readonly float DefaultScale = 1.0f;
 		public readonly int SheetSize = 512;
 		public readonly Color[] HeightDebugColors = [Color.Red];
 		public readonly string[] EditorTemplateOrder;
@@ -171,6 +172,7 @@ namespace OpenRA.Mods.Common.Terrain
 
 		string ITerrainInfo.Id => Id;
 		Size ITerrainInfo.TileSize => TileSize;
+		float ITerrainInfo.DefaultScale => DefaultScale;
 		TerrainTypeInfo[] ITerrainInfo.TerrainTypes => TerrainInfo;
 		TerrainTileInfo ITerrainInfo.GetTerrainInfo(TerrainTile r) { return GetTileInfo(r); }
 		bool ITerrainInfo.TryGetTerrainInfo(TerrainTile r, out TerrainTileInfo info) { return TryGetTileInfo(r, out info); }

--- a/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public Func<float> GetScale = () => 1f;
 
 		readonly WorldRenderer worldRenderer;
-		readonly WorldViewportSizes viewportSizes;
+		readonly float defaultScale;
 
 		IActorPreview[] preview = [];
 		public int2 PreviewOffset { get; private set; }
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Widgets
 		[ObjectCreator.UseCtor]
 		public ActorPreviewWidget(ModData modData, WorldRenderer worldRenderer)
 		{
-			viewportSizes = modData.Manifest.Get<WorldViewportSizes>();
+			defaultScale = worldRenderer.World.Map.Rules.TerrainInfo.DefaultScale;
 			this.worldRenderer = worldRenderer;
 		}
 
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			preview = other.preview;
 			worldRenderer = other.worldRenderer;
-			viewportSizes = other.viewportSizes;
+			defaultScale = other.defaultScale;
 		}
 
 		public override ActorPreviewWidget Clone() { return new ActorPreviewWidget(this); }
@@ -58,14 +58,14 @@ namespace OpenRA.Mods.Common.Widgets
 			// Calculate the preview bounds
 			var r = preview.SelectMany(p => p.ScreenBounds(worldRenderer, WPos.Zero));
 			var b = r.Union();
-			IdealPreviewSize = new int2((int)(b.Width * viewportSizes.DefaultScale), (int)(b.Height * viewportSizes.DefaultScale));
-			PreviewOffset = -new int2((int)(b.Left * viewportSizes.DefaultScale), (int)(b.Top * viewportSizes.DefaultScale)) - IdealPreviewSize / 2;
+			IdealPreviewSize = new int2((int)(b.Width * defaultScale), (int)(b.Height * defaultScale));
+			PreviewOffset = -new int2((int)(b.Left * defaultScale), (int)(b.Top * defaultScale)) - IdealPreviewSize / 2;
 		}
 
 		IFinalizedRenderable[] renderables;
 		public override void PrepareRenderables()
 		{
-			var scale = GetScale() * viewportSizes.DefaultScale;
+			var scale = GetScale() * defaultScale;
 			var origin = RenderOrigin + PreviewOffset + new int2(RenderBounds.Size.Width / 2, RenderBounds.Size.Height / 2);
 
 			renderables = preview

--- a/OpenRA.Mods.Common/Widgets/ResourcePreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ResourcePreviewWidget.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public Func<float> GetScale = () => 1f;
 
 		readonly WorldRenderer worldRenderer;
-		readonly WorldViewportSizes viewportSizes;
+		readonly float defaultScale;
 		readonly IResourceRenderer[] resourceRenderers;
 		readonly Size tileSize;
 
@@ -47,15 +47,15 @@ namespace OpenRA.Mods.Common.Widgets
 		public Size IdealPreviewSize { get; }
 
 		[ObjectCreator.UseCtor]
-		public ResourcePreviewWidget(ModData modData, WorldRenderer worldRenderer, World world)
+		public ResourcePreviewWidget(WorldRenderer worldRenderer, World world)
 		{
 			this.worldRenderer = worldRenderer;
-			viewportSizes = modData.Manifest.Get<WorldViewportSizes>();
+			defaultScale = world.Map.Rules.TerrainInfo.DefaultScale;
 			resourceRenderers = world.WorldActor.TraitsImplementing<IResourceRenderer>().ToArray();
 			tileSize = world.Map.Rules.TerrainInfo.TileSize;
 			IdealPreviewSize = new Size(
-				(int)(viewportSizes.DefaultScale * tileSize.Width),
-				(int)(viewportSizes.DefaultScale * tileSize.Height));
+				(int)(defaultScale * tileSize.Width),
+				(int)(defaultScale * tileSize.Height));
 		}
 
 		protected ResourcePreviewWidget(ResourcePreviewWidget other)
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			GetScale = other.GetScale;
 			worldRenderer = other.worldRenderer;
-			viewportSizes = other.viewportSizes;
+			defaultScale = other.defaultScale;
 			resourceRenderers = other.resourceRenderers;
 			tileSize = other.tileSize;
 			resourceType = other.resourceType;
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (resourceRenderer == null)
 				return;
 
-			var scale = GetScale() * viewportSizes.DefaultScale;
+			var scale = GetScale() * defaultScale;
 			var origin = RenderOrigin + new int2(
 				(int)(0.5f * (RenderBounds.Size.Width - scale * tileSize.Width)),
 				(int)(0.5f * (RenderBounds.Size.Height - scale * tileSize.Height)));

--- a/OpenRA.Mods.Common/Widgets/TerrainTemplatePreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TerrainTemplatePreviewWidget.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		readonly ITiledTerrainRenderer terrainRenderer;
 		readonly WorldRenderer worldRenderer;
-		readonly WorldViewportSizes viewportSizes;
+		readonly float defaultScale;
 
 		TerrainTemplateInfo template;
 
@@ -31,12 +31,11 @@ namespace OpenRA.Mods.Common.Widgets
 		public int2 IdealPreviewSize { get; private set; }
 
 		[ObjectCreator.UseCtor]
-		public TerrainTemplatePreviewWidget(ModData modData, WorldRenderer worldRenderer, World world)
+		public TerrainTemplatePreviewWidget(WorldRenderer worldRenderer, World world)
 		{
 			this.worldRenderer = worldRenderer;
-			viewportSizes = modData.Manifest.Get<WorldViewportSizes>();
-
 			terrainRenderer = world.WorldActor.TraitOrDefault<ITiledTerrainRenderer>();
+			defaultScale = world.Map.Rules.TerrainInfo.DefaultScale;
 			if (terrainRenderer == null)
 				throw new YamlException("TerrainTemplatePreviewWidget requires a tile-based terrain renderer.");
 		}
@@ -45,9 +44,9 @@ namespace OpenRA.Mods.Common.Widgets
 			: base(other)
 		{
 			worldRenderer = other.worldRenderer;
-			viewportSizes = other.viewportSizes;
 			terrainRenderer = other.terrainRenderer;
 			template = other.template;
+			defaultScale = other.defaultScale;
 			GetScale = other.GetScale;
 		}
 
@@ -57,10 +56,10 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			this.template = template;
 			var b = terrainRenderer.TemplateBounds(template);
-			IdealPreviewSize = new int2((int)(b.Width * viewportSizes.DefaultScale), (int)(b.Height * viewportSizes.DefaultScale));
+			IdealPreviewSize = new int2((int)(b.Width * defaultScale), (int)(b.Height * defaultScale));
 
 			// Measured from the middle of the widget to the middle of the top-left cell of the template
-			PreviewOffset = -new int2((int)(b.Left * viewportSizes.DefaultScale), (int)(b.Top * viewportSizes.DefaultScale)) - IdealPreviewSize / 2;
+			PreviewOffset = -new int2((int)(b.Left * defaultScale), (int)(b.Top * defaultScale)) - IdealPreviewSize / 2;
 		}
 
 		public override void Draw()
@@ -68,7 +67,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (template == null)
 				return;
 
-			var scale = GetScale() * viewportSizes.DefaultScale;
+			var scale = GetScale() * defaultScale;
 			var origin = RenderOrigin + PreviewOffset + new int2(RenderBounds.Size.Width / 2, RenderBounds.Size.Height / 2);
 
 			foreach (var r in terrainRenderer.RenderUIPreview(worldRenderer, template, origin, scale))


### PR DESCRIPTION
This is the second PR (after #21822) to enable the "Classic / Remastered artwork" toggle in TDHD. The default viewport scale is tied closely to the tile size, so the simplest solution (compared to e.g. specifying WorldViewportSizes in cells) is to define it next to the tile size.

Partially reverts #20573.