### PR TITLE
Add additional decorative repainting in generated maps

### DIFF
--- a/mods/cnc/rules/map-generators.yaml
+++ b/mods/cnc/rules/map-generators.yaml
@@ -75,19 +75,12 @@
 						Rotations: 1
 			MultiChoiceOption@hidden_tileset_overrides:
 				Choice@common:
-					Tileset: DESERT,SNOW,TEMPERAT
+					Tileset: DESERT,SNOW,TEMPERAT,WINTER
 					Settings:
 						LandTile: 255
 						WaterTile: 1
 						RepaintTiles:
-							1: Water
-				Choice@winter:
-					Tileset: WINTER
-					Settings:
-						LandTile: 255
-						WaterTile: 1
-						RepaintTiles:
-							255: Snow
+							255: Clear
 							1: Water
 			IntegerOption@Seed:
 				Label: label-cnc-map-generator-option-seed

--- a/mods/cnc/tilesets/desert.yaml
+++ b/mods/cnc/tilesets/desert.yaml
@@ -3319,6 +3319,27 @@ MultiBrushCollections:
 			Actor: rock6
 		MultiBrush@rock7:
 			Actor: rock7
+	Clear:
+		MultiBrush@Nothing:
+			Weight: 200000
+		MultiBrush@71:
+			Template: 71
+		MultiBrush@72:
+			Template: 72
+		MultiBrush@73:
+			Template: 73
+		MultiBrush@221:
+			Template: 221
+		MultiBrush@Pebbles2:
+			Tile: 99,0
+		MultiBrush@Pebbles3:
+			Tile: 99,2
+		MultiBrush@Pebbles5:
+			Tile: 106,3
+		MultiBrush@Pebbles6:
+			Tile: 108,0
+		MultiBrush@Pebbles7:
+			Tile: 114,6
 	Water:
 		MultiBrush@1:
 			Template: 1

--- a/mods/cnc/tilesets/snow.yaml
+++ b/mods/cnc/tilesets/snow.yaml
@@ -2851,6 +2851,19 @@ MultiBrushCollections:
 			Actor: t17
 			BackingTile: 255,0
 			Weight: 200
+	Clear:
+		MultiBrush@Nothing:
+			Weight: 200000
+		MultiBrush@73:
+			Template: 73
+			Weight: 2000
+		MultiBrush@74:
+			Template: 74
+			Weight: 2000
+		MultiBrush@Pebbles3:
+			Tile: 136,17
+		MultiBrush@Pebbles4:
+			Tile: 140,3
 	Water:
 		MultiBrush@1:
 			Template: 1
@@ -2866,6 +2879,9 @@ MultiBrushCollections:
 			Template: 76
 		MultiBrush@77:
 			Template: 77
+		MultiBrush@Pebbles1:
+			Tile: 11,0
+			Weight: 50
 	CivilianBuildings:
 		MultiBrush@v01:
 			Actor: v01

--- a/mods/cnc/tilesets/temperat.yaml
+++ b/mods/cnc/tilesets/temperat.yaml
@@ -2854,6 +2854,15 @@ MultiBrushCollections:
 			Actor: t17
 			BackingTile: 255,0
 			Weight: 200
+	Clear:
+		MultiBrush@Nothing:
+			Weight: 200000
+		MultiBrush@73:
+			Template: 73
+		MultiBrush@74:
+			Template: 74
+		MultiBrush@Pebbles4:
+			Tile: 140,3
 	Water:
 		MultiBrush@1:
 			Template: 1
@@ -2869,6 +2878,9 @@ MultiBrushCollections:
 			Template: 76
 		MultiBrush@77:
 			Template: 77
+		MultiBrush@Pebbles1:
+			Tile: 11,0
+			Weight: 50
 	CivilianBuildings:
 		MultiBrush@v01:
 			Actor: v01

--- a/mods/cnc/tilesets/winter.yaml
+++ b/mods/cnc/tilesets/winter.yaml
@@ -2877,9 +2877,13 @@ MultiBrushCollections:
 			Actor: t17
 			BackingTile: 255,0
 			Weight: 200
-	Snow:
+	Clear:
 		MultiBrush@Nothing:
 			Weight: 100000
+		MultiBrush@73:
+			Template: 73
+		MultiBrush@74:
+			Template: 74
 		MultiBrush@81:
 			Template: 81
 		MultiBrush@181:
@@ -2907,6 +2911,9 @@ MultiBrushCollections:
 			Template: 76
 		MultiBrush@77:
 			Template: 77
+		MultiBrush@Pebbles1:
+			Tile: 11,0
+			Weight: 50
 	CivilianBuildings:
 		MultiBrush@v01:
 			Actor: v01

--- a/mods/ra/rules/map-generators.yaml
+++ b/mods/ra/rules/map-generators.yaml
@@ -78,16 +78,25 @@
 					Settings:
 						LandTile: 255
 						WaterTile: 256
+						RepaintTiles:
+							255: Clear
+							256: Water
 				Choice@temperat:
 					Tileset: TEMPERAT
 					Settings:
 						LandTile: 255
 						WaterTile: 1
+						RepaintTiles:
+							255: Clear
+							1: Water
 				Choice@snow:
 					Tileset: SNOW
 					Settings:
 						LandTile: 255
 						WaterTile: 1
+						RepaintTiles:
+							255: Clear
+							1: Water
 			IntegerOption@Seed:
 				Label: label-ra-map-generator-option-seed
 				Parameter: Seed

--- a/mods/ra/tilesets/desert.yaml
+++ b/mods/ra/tilesets/desert.yaml
@@ -4266,6 +4266,37 @@ MultiBrushCollections:
 		MultiBrush@tc01.husk:
 			Actor: tc01.husk
 			Weight: 100
+	Clear:
+		MultiBrush@Nothing:
+			Weight: 200000
+		MultiBrush@39:
+			Template: 39
+		MultiBrush@40:
+			Template: 40
+		MultiBrush@44:
+			Template: 44
+		MultiBrush@Pebbles1:
+			Tile: 126,0
+		MultiBrush@Pebbles2:
+			Tile: 126,2
+		MultiBrush@Pebbles3:
+			Tile: 138,0
+		MultiBrush@Pebbles4:
+			Tile: 137,2
+		MultiBrush@Pebbles5:
+			Tile: 135,8
+		MultiBrush@Pebbles7:
+			Tile: 140,0
+		MultiBrush@Pebbles8:
+			Tile: 141,6
+	Water:
+		MultiBrush@256:
+			Template: 256
+			Weight: 100
+		MultiBrush@257:
+			Template: 257
+		MultiBrush@258:
+			Template: 258
 	Obstructions:
 		MultiBrush@2:
 			Template: 2

--- a/mods/ra/tilesets/snow.yaml
+++ b/mods/ra/tilesets/snow.yaml
@@ -4446,6 +4446,19 @@ MultiBrushCollections:
 		MultiBrush@tc05.husk:
 			Actor: tc05.husk
 			Weight: 100
+	Clear:
+		MultiBrush@Nothing:
+			Weight: 100000
+		MultiBrush@108:
+			Template: 108
+		MultiBrush@Pebbles1:
+			Tile: 194,1
+	Water:
+		MultiBrush@1:
+			Template: 1
+			Weight: 100
+		MultiBrush@2:
+			Template: 2
 	Obstructions:
 		MultiBrush@97:
 			Template: 97

--- a/mods/ra/tilesets/temperat.yaml
+++ b/mods/ra/tilesets/temperat.yaml
@@ -5034,6 +5034,23 @@ MultiBrushCollections:
 		MultiBrush@588:
 			Template: 588
 			Weight: 100
+	Clear:
+		MultiBrush@Nothing:
+			Weight: 200000
+		MultiBrush@108:
+			Template: 108
+		MultiBrush@Pebbles1:
+			Tile: 116,0
+		MultiBrush@Pebbles2:
+			Tile: 130,6
+		MultiBrush@Pebbles3:
+			Tile: 182,0
+	Water:
+		MultiBrush@1:
+			Template: 1
+			Weight: 100
+		MultiBrush@2:
+			Template: 2
 	CivilianBuildings:
 		MultiBrush@v01:
 			Actor: v01


### PR DESCRIPTION
Adds additional decorative clear/water retiling in generated maps. This is purely decorative, intended to add a bit of texture to maps, and does not impact the playability of maps.

Some repainting choices use single tiles taken from various templates. For CnC/TD, these tiles have been checked for visual consistency in original and remastered graphics.
