### PR TITLE
Fix resource calculation in map generator

### DIFF
--- a/mods/cnc/rules/map-generators.yaml
+++ b/mods/cnc/rules/map-generators.yaml
@@ -268,7 +268,7 @@
 					Label: label-cnc-map-generator-choice-resources-low
 					Settings:
 						SpawnResourceSpawns: 1
-						ResourcesPerPlayer: 25000
+						ResourcesPerPlayer: 18750
 						ResourceSpawnWeights:
 							split2: 1
 							split3: 1
@@ -278,7 +278,7 @@
 					Label: label-cnc-map-generator-choice-resources-medium
 					Settings:
 						SpawnResourceSpawns: 2
-						ResourcesPerPlayer: 50000
+						ResourcesPerPlayer: 37500
 						ResourceSpawnWeights:
 							split2: 95
 							split3: 95
@@ -289,7 +289,7 @@
 					Label: label-cnc-map-generator-choice-resources-high
 					Settings:
 						SpawnResourceSpawns: 3
-						ResourcesPerPlayer: 75000
+						ResourcesPerPlayer: 56250
 						ResourceSpawnWeights:
 							split2: 9
 							split3: 9
@@ -300,7 +300,7 @@
 					Label: label-cnc-map-generator-choice-resources-very-high
 					Settings:
 						SpawnResourceSpawns: 4
-						ResourcesPerPlayer: 100000
+						ResourcesPerPlayer: 75000
 						ResourceSpawnWeights:
 							split2: 8
 							split3: 8

--- a/mods/ra/rules/map-generators.yaml
+++ b/mods/ra/rules/map-generators.yaml
@@ -295,7 +295,7 @@
 					Label: label-ra-map-generator-choice-resources-low
 					Settings:
 						SpawnResourceSpawns: 2
-						ResourcesPerPlayer: 25000
+						ResourcesPerPlayer: 18750
 						ResourceSpawnWeights:
 							mine: 1
 						MaximumExpansionResourceSpawns: 3
@@ -304,7 +304,7 @@
 					Label: label-ra-map-generator-choice-resources-medium
 					Settings:
 						SpawnResourceSpawns: 3
-						ResourcesPerPlayer: 50000
+						ResourcesPerPlayer: 37500
 						ResourceSpawnWeights:
 							mine: 95
 							gmine: 5
@@ -314,7 +314,7 @@
 					Label: label-ra-map-generator-choice-resources-high
 					Settings:
 						SpawnResourceSpawns: 3
-						ResourcesPerPlayer: 75000
+						ResourcesPerPlayer: 56250
 						ResourceSpawnWeights:
 							mine: 9
 							gmine: 1
@@ -324,7 +324,7 @@
 					Label: label-ra-map-generator-choice-resources-very-high
 					Settings:
 						SpawnResourceSpawns: 4
-						ResourcesPerPlayer: 100000
+						ResourcesPerPlayer: 75000
 						ResourceSpawnWeights:
 							mine: 8
 							gmine: 2


### PR DESCRIPTION
The editor's resource value calculation logic was fixed in #21820 to match actual gameplay. The map generator logic originally copied the editor logic from EditorResourceLayer rather than ResourceLayer and associated game logic. As such, it inherited incorrect calculations.

This change updates the map generator logic to match the now consistent logic in both ResourceLayer classes. Map generator resource settings are also adjusted -25% to continue roughly matching the previous resource output.
