### PR TITLE
Remove redundant world checks

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/BuildableTerrainOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/BuildableTerrainOverlay.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void IWorldLoaded.WorldLoaded(World w, WorldRenderer wr)
 		{
-			render = new TerrainSpriteLayer(w, wr, disabledSprite, BlendMode.Alpha, wr.World.Type != WorldType.Editor);
+			render = new TerrainSpriteLayer(w, wr, disabledSprite, BlendMode.Alpha, false);
 
 			world.Map.Tiles.CellEntryChanged += UpdateTerrainCell;
 			world.Map.CustomTerrain.CellEntryChanged += UpdateTerrainCell;

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -59,9 +59,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ICreatePlayers.CreatePlayers(World w, MersenneTwister playerRandom)
 		{
-			if (w.Type != WorldType.Editor)
-				return;
-
 			Players = new MapPlayers(w.Map.PlayerDefinitions);
 
 			worldOwner = Players.Players.Select(kvp => kvp.Value).First(p => !p.Playable && p.OwnsWorld);
@@ -70,9 +67,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void WorldLoaded(World world, WorldRenderer wr)
 		{
-			if (world.Type != WorldType.Editor)
-				return;
-
 			worldRenderer = wr;
 
 			foreach (var pr in Players.Players.Values)
@@ -99,19 +93,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ITickRender.TickRender(WorldRenderer wr, Actor self)
 		{
-			if (wr.World.Type != WorldType.Editor)
-				return;
-
 			foreach (var p in previews)
 				p.Tick();
 		}
 
-		static readonly IEnumerable<IRenderable> NoRenderables = [];
 		public virtual IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)
 		{
-			if (wr.World.Type != WorldType.Editor)
-				return NoRenderables;
-
 			return PreviewsInScreenBox(wr.Viewport.TopLeft, wr.Viewport.BottomRight)
 				.SelectMany(p => p.Render());
 		}
@@ -124,9 +111,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<IRenderable> RenderAnnotations(Actor self, WorldRenderer wr)
 		{
-			if (wr.World.Type != WorldType.Editor)
-				return NoRenderables;
-
 			return PreviewsInScreenBox(wr.Viewport.TopLeft, wr.Viewport.BottomRight)
 				.SelectMany(p => p.RenderAnnotations());
 		}

--- a/OpenRA.Mods.Common/Traits/World/EditorCursorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorCursorLayer.cs
@@ -33,17 +33,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ITickRender.TickRender(WorldRenderer wr, Actor self)
 		{
-			if (wr.World.Type != WorldType.Editor)
-				return;
-
 			brush?.TickRender(wr, self);
 		}
 
 		IEnumerable<IRenderable> IRenderAboveShroud.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
-			if (wr.World.Type != WorldType.Editor)
-				return NoRenderables;
-
 			return brush?.RenderAboveShroud(self, wr) ?? NoRenderables;
 		}
 
@@ -51,9 +45,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<IRenderable> RenderAnnotations(Actor self, WorldRenderer wr)
 		{
-			if (wr.World.Type != WorldType.Editor)
-				return NoRenderables;
-
 			return brush?.RenderAnnotations(self, wr) ?? NoRenderables;
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
@@ -96,9 +96,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		public EditorResourceLayer(Actor self, EditorResourceLayerInfo info)
 		{
-			if (self.World.Type != WorldType.Editor)
-				return;
-
 			this.info = info;
 			Map = self.World.Map;
 			Tiles = new CellLayer<ResourceLayerContents>(Map);
@@ -111,9 +108,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void WorldLoaded(World w, WorldRenderer wr)
 		{
-			if (w.Type != WorldType.Editor)
-				return;
-
 			var playerResourcesInfo = w.Map.Rules.Actors[SystemActors.Player].TraitInfoOrDefault<PlayerResourcesInfo>();
 			resourceValues = playerResourcesInfo?.ResourceValues ?? [];
 

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Common.Traits
 					+ "Try using different smudge types for smudges that use different blend modes.");
 
 			paletteReference = wr.Palette(Info.Palette);
-			render = new TerrainSpriteLayer(w, wr, emptySprite, blendMode, w.Type != WorldType.Editor);
+			render = new TerrainSpriteLayer(w, wr, emptySprite, blendMode, true);
 
 			// Add map smudges
 			foreach (var kv in Info.InitialSmudges)

--- a/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 		void IWorldLoaded.WorldLoaded(World w, WorldRenderer wr)
 		{
-			render = new TerrainSpriteLayer(w, wr, terrainRenderer.MissingTile, BlendMode.Alpha, wr.World.Type != WorldType.Editor);
+			render = new TerrainSpriteLayer(w, wr, terrainRenderer.MissingTile, BlendMode.Alpha, true);
 			paletteReference = wr.Palette(info.Palette);
 		}
 


### PR DESCRIPTION
We have lint test to check for valid trait location `CheckTraitLocation` added in #19239. The PR has forgot to remove some of the checks

Inspired by https://github.com/OpenRA/OpenRA/pull/21867#discussion_r2067226052