### PR TITLE
Rewrite CheckFluentReferences lint check

### DIFF
--- a/OpenRA.Game/FluentBundle.cs
+++ b/OpenRA.Game/FluentBundle.cs
@@ -48,6 +48,41 @@ namespace OpenRA
 		}
 	}
 
+	[AttributeUsage(AttributeTargets.Class)]
+	public sealed class IncludeStaticFluentReferencesAttribute : Attribute
+	{
+		public readonly Type[] Types;
+
+		public IncludeStaticFluentReferencesAttribute(params Type[] types)
+		{
+			Types = types;
+		}
+	}
+
+	[AttributeUsage(AttributeTargets.Class)]
+	public sealed class IncludeChromeLogicArgsFluentReferencesAttribute : Attribute
+	{
+		public readonly string[] MethodNames;
+
+		public IncludeChromeLogicArgsFluentReferencesAttribute(params string[] methodNames)
+		{
+			MethodNames = methodNames;
+		}
+	}
+
+	[AttributeUsage(AttributeTargets.Field)]
+	public sealed class IncludeFluentReferencesAttribute : Attribute
+	{
+		public readonly LintDictionaryReference DictionaryReference;
+
+		public IncludeFluentReferencesAttribute() { }
+
+		public IncludeFluentReferencesAttribute(LintDictionaryReference dictionaryReference = LintDictionaryReference.None)
+		{
+			DictionaryReference = dictionaryReference;
+		}
+	}
+
 	public class FluentBundle
 	{
 		readonly Linguini.Bundle.FluentBundle bundle;

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -27,6 +27,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA
 {
+	[IncludeStaticFluentReferences(typeof(Server.Server), typeof(Player), typeof(UnitOrders), typeof(OrderManager))]
 	public static class Game
 	{
 		[FluentReference("filename")]

--- a/OpenRA.Game/GameSpeed.cs
+++ b/OpenRA.Game/GameSpeed.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using OpenRA.Traits;
 
 namespace OpenRA
 {
@@ -31,6 +32,7 @@ namespace OpenRA
 		[FieldLoader.Require]
 		public readonly string DefaultSpeed;
 
+		[IncludeFluentReferences(LintDictionaryReference.Values)]
 		[FieldLoader.LoadUsing(nameof(LoadSpeeds))]
 		public readonly Dictionary<string, GameSpeed> Speeds;
 

--- a/OpenRA.Game/Input/IInputHandler.cs
+++ b/OpenRA.Game/Input/IInputHandler.cs
@@ -47,7 +47,7 @@ namespace OpenRA
 	public static class ModifiersExts
 	{
 		[FluentReference]
-		public const string Cmd = "keycode-modifier.cmd";
+		const string Cmd = "keycode-modifier.cmd";
 
 		[FluentReference(Traits.LintDictionaryReference.Values)]
 		public static readonly IReadOnlyDictionary<Modifiers, string> ModifierFluentKeys = new Dictionary<Modifiers, string>()

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -48,12 +48,12 @@ namespace OpenRA
 		// FieldLoader used here, must matching naming in YAML.
 #pragma warning disable IDE1006 // Naming Styles
 		[FluentReference]
-		readonly string Title;
+		public readonly string Title;
 		public readonly string Version;
 		public readonly string Website;
 		public readonly string WebIcon32;
 		[FluentReference]
-		readonly string WindowTitle;
+		public readonly string WindowTitle;
 		public readonly bool Hidden;
 #pragma warning restore IDE1006 // Naming Styles
 

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -45,6 +45,7 @@ namespace OpenRA.Server
 		Dedicated = 3
 	}
 
+	[IncludeStaticFluentReferences(typeof(PlayerMessageTracker), typeof(VoteKickTracker))]
 	public sealed class Server
 	{
 		[FluentReference]

--- a/OpenRA.Mods.Common/Commands/ChatCommands.cs
+++ b/OpenRA.Mods.Common/Commands/ChatCommands.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Commands
 {
 	[TraitLocation(SystemActors.World)]
+	[IncludeStaticFluentReferences(typeof(ChatCommands))]
 	[Desc("Enables commands triggered by typing them into the chatbox. Attach this to the world actor.")]
 	public class ChatCommandsInfo : TraitInfo<ChatCommands> { }
 

--- a/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
@@ -18,6 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Commands
 {
 	[TraitLocation(SystemActors.World)]
+	[IncludeStaticFluentReferences(typeof(DebugVisualizationCommands))]
 	[Desc("Enables visualization commands via the chatbox. Attach this to the world actor.")]
 	public class DebugVisualizationCommandsInfo : TraitInfo<DebugVisualizationCommands> { }
 

--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -19,6 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Commands
 {
 	[TraitLocation(SystemActors.World)]
+	[IncludeStaticFluentReferences(typeof(DevCommands))]
 	[Desc("Enables developer cheats via the chatbox. Attach this to the world actor.")]
 	public class DevCommandsInfo : TraitInfo<DevCommands> { }
 

--- a/OpenRA.Mods.Common/Commands/HelpCommand.cs
+++ b/OpenRA.Mods.Common/Commands/HelpCommand.cs
@@ -17,6 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Commands
 {
 	[TraitLocation(SystemActors.World)]
+	[IncludeStaticFluentReferences(typeof(HelpCommand))]
 	[Desc("Shows a list of available commands in the chatbox. Attach this to the world actor.")]
 	public class HelpCommandInfo : TraitInfo<HelpCommand> { }
 

--- a/OpenRA.Mods.Common/Commands/PlayerCommands.cs
+++ b/OpenRA.Mods.Common/Commands/PlayerCommands.cs
@@ -15,6 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Commands
 {
 	[TraitLocation(SystemActors.World)]
+	[IncludeStaticFluentReferences(typeof(PlayerCommands))]
 	[Desc("Allows the player to pause or surrender the game via the chatbox. Attach this to the world actor.")]
 	public class PlayerCommandsInfo : TraitInfo<PlayerCommands> { }
 

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.Player)]
+	[IncludeStaticFluentReferences(typeof(ConquestVictoryConditions))]
 	public class ConquestVictoryConditionsInfo : TraitInfo, Requires<MissionObjectivesInfo>
 	{
 		[Desc("Delay for the end game notification in milliseconds.")]

--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
@@ -17,6 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.Player)]
+	[IncludeStaticFluentReferences(typeof(DeveloperMode))]
 	[Desc("Attach this to the player actor.")]
 	public class DeveloperModeInfo : TraitInfo, ILobbyOptions
 	{

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -21,6 +21,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class StrategicPoint { }
 
 	[Desc("Allows King of the Hill (KotH) style gameplay.")]
+	[IncludeStaticFluentReferences(typeof(StrategicVictoryConditions))]
 	public class StrategicVictoryConditionsInfo : TraitInfo, Requires<MissionObjectivesInfo>
 	{
 		[Desc("Amount of time (in game ticks) that the player has to hold all the strategic points.", "Defaults to 7500 ticks (5 minutes at default speed).")]

--- a/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
@@ -18,6 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World)]
+	[IncludeStaticFluentReferences(typeof(CustomTerrainDebugOverlay))]
 	[Desc("Displays custom terrain types.")]
 	sealed class CustomTerrainDebugOverlayInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/World/CellTriggerOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/CellTriggerOverlay.cs
@@ -20,6 +20,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World)]
+	[IncludeStaticFluentReferences(typeof(CellTriggerOverlay))]
 	[Desc("Renders a debug overlay showing the script triggers. Attach this to the world actor.")]
 	public class CellTriggerOverlayInfo : TraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/World/EditorActionManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActionManager.cs
@@ -17,6 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.EditorWorld)]
+	[IncludeStaticFluentReferences(typeof(OpenMapAction))]
 	public class EditorActionManagerInfo : TraitInfo<EditorActionManager> { }
 
 	public class EditorActionManager : IWorldLoaded

--- a/OpenRA.Mods.Common/Traits/World/ExitsDebugOverlayManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/ExitsDebugOverlayManager.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World)]
+	[IncludeStaticFluentReferences(typeof(ExitsDebugOverlayManager))]
 	public class ExitsDebugOverlayManagerInfo : TraitInfo
 	{
 		[Desc("The font used to draw cell vectors. Should match the value as-is in the Fonts section of the mod manifest (do not convert to lowercase).")]

--- a/OpenRA.Mods.Common/Traits/World/HierarchicalPathFinderOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/HierarchicalPathFinderOverlay.cs
@@ -21,6 +21,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World)]
+	[IncludeStaticFluentReferences(typeof(HierarchicalPathFinderOverlay))]
 	[Desc("Renders a debug overlay showing the abstract graph of the hierarchical pathfinder. Attach this to the world actor.")]
 	public class HierarchicalPathFinderOverlayInfo : TraitInfo, Requires<PathFinderInfo>
 	{

--- a/OpenRA.Mods.Common/Traits/World/PathFinderOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinderOverlay.cs
@@ -23,6 +23,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World)]
+	[IncludeStaticFluentReferences(typeof(PathFinderOverlay))]
 	[Desc("Renders a visualization overlay showing how the pathfinder searches for paths. Attach this to the world actor.")]
 	public class PathFinderOverlayInfo : TraitInfo, Requires<PathFinderInfo>
 	{

--- a/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
@@ -48,6 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
+		[IncludeFluentReferences(LintDictionaryReference.Values)]
 		[FieldLoader.LoadUsing(nameof(LoadResourceTypes))]
 		public readonly Dictionary<string, ResourceTypeInfo> ResourceTypes = null;
 

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -19,6 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
+	[IncludeStaticFluentReferences(typeof(TerrainGeometryOverlay))]
 	[Desc("Renders a debug overlay showing the terrain cells. Attach this to the world actor.")]
 	public class TerrainGeometryOverlayInfo : TraitInfo<TerrainGeometryOverlay> { }
 

--- a/OpenRA.Mods.Common/Traits/World/TimeLimitManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/TimeLimitManager.cs
@@ -19,6 +19,7 @@ using OpenRA.Widgets;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World)]
+	[IncludeStaticFluentReferences(typeof(TimeLimitManager))]
 	[Desc("This trait allows setting a time limit on matches. Attach this to the World actor.")]
 	public class TimeLimitManagerInfo : TraitInfo, ILobbyOptions, IRulesetLoaded
 	{

--- a/OpenRA.Mods.Common/Widgets/BackgroundWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/BackgroundWidget.cs
@@ -13,6 +13,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets
 {
+	[IncludeStaticFluentReferences(typeof(WidgetUtils))]
 	public class BackgroundWidget : Widget
 	{
 		public readonly bool ClickThrough = false;

--- a/OpenRA.Mods.Common/Widgets/EditorViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/EditorViewportControllerWidget.cs
@@ -17,6 +17,12 @@ using Color = OpenRA.Primitives.Color;
 
 namespace OpenRA.Mods.Common.Widgets
 {
+	[IncludeStaticFluentReferences(
+		typeof(ChangeSelectionAction),
+		typeof(DeleteAreaAction),
+		typeof(RemoveActorAction),
+		typeof(RemoveResourceAction),
+		typeof(MoveActorAction))]
 	public class EditorViewportControllerWidget : Widget
 	{
 		[Desc("Main color of the selection grid.")]

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -19,6 +19,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
+	[IncludeStaticFluentReferences(typeof(EditActorEditorAction))]
 	public class ActorEditLogic : ChromeLogic
 	{
 		[FluentReference]

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -19,6 +19,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
+	[IncludeStaticFluentReferences(typeof(AddActorAction), typeof(CommonSelectorLogic))]
 	public class ActorSelectorLogic : CommonSelectorLogic
 	{
 		[FluentReference("actorType")]

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
@@ -15,6 +15,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
+	[IncludeStaticFluentReferences(typeof(AddResourcesEditorAction))]
 	public class LayerSelectorLogic : ChromeLogic
 	{
 		readonly EditorViewportControllerWidget editor;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorSelectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorSelectionLogic.cs
@@ -17,6 +17,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
+	[IncludeStaticFluentReferences(typeof(CopyPasteEditorAction))]
 	public class MapEditorSelectionLogic : ChromeLogic
 	{
 		[FluentReference]

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapMarkerTilesLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapMarkerTilesLogic.cs
@@ -20,6 +20,10 @@ using static OpenRA.Mods.Common.Traits.MarkerLayerOverlay;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
+	[IncludeStaticFluentReferences(
+		typeof(PaintMarkerTileEditorAction),
+		typeof(ClearSelectedMarkerTilesEditorAction),
+		typeof(ClearAllMarkerTilesEditorAction))]
 	public class MapMarkerTilesLogic : ChromeLogic
 	{
 		[FluentReference]

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
@@ -19,6 +19,10 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
+	[IncludeStaticFluentReferences(
+		typeof(PaintTileEditorAction),
+		typeof(FloodFillEditorAction),
+		typeof(CommonSelectorLogic))]
 	public class TileSelectorLogic : CommonSelectorLogic
 	{
 		sealed class TileSelectorTemplate

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -21,6 +21,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
+	[IncludeStaticFluentReferences(typeof(LobbyUtils))]
 	public class LobbyLogic : ChromeLogic, INotificationHandler<TextNotification>
 	{
 		[FluentReference]

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -24,6 +24,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
+	[IncludeStaticFluentReferences(typeof(ReplayUtils))]
 	public class ReplayBrowserLogic : ChromeLogic
 	{
 		[FluentReference("time")]

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
@@ -17,6 +17,8 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
+	[IncludeChromeLogicArgsFluentReferences(nameof(DynamicFluentReferences))]
+	[IncludeStaticFluentReferences(typeof(KeycodeExts), typeof(ModifiersExts))]
 	public class HotkeysSettingsLogic : ChromeLogic
 	{
 		[FluentReference("key")]
@@ -27,6 +29,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		[FluentReference]
 		const string AnyContext = HotkeyDefinition.ContextFluentPrefix + "-any";
+
+		public static IEnumerable<(string Key, FluentReferenceAttribute Reference)> DynamicFluentReferences(Dictionary<string, MiniYaml> logicArgs)
+		{
+			if (logicArgs.TryGetValue("HotkeyGroups", out var hotkeyGroupsYaml))
+				foreach (var node in hotkeyGroupsYaml.Nodes)
+					yield return (node.Key, new FluentReferenceAttribute());
+		}
 
 		readonly ModData modData;
 		readonly Dictionary<string, MiniYaml> logicArgs;

--- a/mods/common-content/fluent/chrome.ftl
+++ b/mods/common-content/fluent/chrome.ftl
@@ -10,3 +10,37 @@ button-package-download-panel-retry = Retry
 label-content-prompt-panel-title = Install Content
 button-content-prompt-panel-advanced = Advanced Install
 button-content-prompt-panel-quick = Quick Install
+
+## DownloadPackageLogic
+label-downloading = Downloading { $title }
+label-fetching-mirror-list = Fetching list of mirrors...
+label-downloading-from = Downloading from { $host } { $received } { $suffix }
+label-downloading-from-progress = Downloading from { $host } { $received } / { $total } { $suffix } ({ $progress }%)
+label-unknown-host = unknown host
+label-download-failed = Download failed
+label-verifying-archive = Verifying archive...
+label-archive-validation-failed = Archive validation failed
+label-extracting-archive = Extracting...
+label-extracting-archive-entry = Extracting { $entry }
+label-archive-extraction-failed = Archive extraction failed
+label-mirror-selection-failed = Online mirror is not available. Please install from an original disc.
+
+## InstallFromSourceLogic
+label-detecting-sources = Detecting drives
+label-checking-sources = Checking Sources
+label-searching-source-for = Searching for { $title }
+label-content-package-installation = Select which content packages you want to install:
+label-game-sources = Game Sources
+label-digital-installs = Digital Installs
+label-game-content-not-found = Game Content Not Found
+label-alternative-content-sources = Please insert or install one of the following content sources:
+label-installing-content = Installing Content
+label-copying-filename = Copying { $filename }
+label-copying-filename-progress = Copying { $filename } ({ $progress }%)
+label-installation-failed = Installation Failed
+label-check-install-log = Refer to install.log in the logs directory for details.
+label-extracting-filename = Extracting { $filename }
+label-extracting-filename-progress = Extracting { $filename } ({ $progress }%)
+
+## ModContentLogic
+button-manual-install = Manual Install

--- a/mods/common/fluent/common.ftl
+++ b/mods/common/fluent/common.ftl
@@ -295,40 +295,6 @@ options-observer-stats =
 ## WorldTooltipLogic
 label-unrevealed-terrain = Unrevealed Terrain
 
-## DownloadPackageLogic
-label-downloading = Downloading { $title }
-label-fetching-mirror-list = Fetching list of mirrors...
-label-downloading-from = Downloading from { $host } { $received } { $suffix }
-label-downloading-from-progress = Downloading from { $host } { $received } / { $total } { $suffix } ({ $progress }%)
-label-unknown-host = unknown host
-label-download-failed = Download failed
-label-verifying-archive = Verifying archive...
-label-archive-validation-failed = Archive validation failed
-label-extracting-archive = Extracting...
-label-extracting-archive-entry = Extracting { $entry }
-label-archive-extraction-failed = Archive extraction failed
-label-mirror-selection-failed = Online mirror is not available. Please install from an original disc.
-
-## InstallFromSourceLogic
-label-detecting-sources = Detecting drives
-label-checking-sources = Checking Sources
-label-searching-source-for = Searching for { $title }
-label-content-package-installation = Select which content packages you want to install:
-label-game-sources = Game Sources
-label-digital-installs = Digital Installs
-label-game-content-not-found = Game Content Not Found
-label-alternative-content-sources = Please insert or install one of the following content sources:
-label-installing-content = Installing Content
-label-copying-filename = Copying { $filename }
-label-copying-filename-progress = Copying { $filename } ({ $progress }%)
-label-installation-failed = Installation Failed
-label-check-install-log = Refer to install.log in the logs directory for details.
-label-extracting-filename = Extracting { $filename }
-label-extracting-filename-progress = Extracting { $filename } ({ $progress }%)
-
-## ModContentLogic
-button-manual-install = Manual Install
-
 ## KickClientLogic
 dialog-kick-client =
     .prompt = Kick { $player }?
@@ -782,9 +748,6 @@ description-custom-terrain-debug-overlay = toggles the custom terrain debug over
 ## CellTriggerOverlay
 description-cell-triggers-overlay = toggles the script triggers overlay.
 
-## ExitsDebugOverlay
-description-exits-overlay = Displays exits for factories.
-
 ## HierarchicalPathFinderOverlay
 description-hpf-debug-overlay = toggles the hierarchical pathfinder overlay.
 
@@ -878,9 +841,6 @@ notification-player-is-defeated = { $player } is defeated.
 ## OrderManager
 notification-desync-compare-logs = Out of sync in frame { $frame }.
     Compare syncreport.log with other players.
-
-## SupportPowerTimerWidget
-support-power-timer = { $player }'s { $support-power }: { $time }
 
 ## WidgetUtils
 label-win-state-won = Won

--- a/mods/ra/fluent/ra.ftl
+++ b/mods/ra/fluent/ra.ftl
@@ -10,3 +10,6 @@ tileset-desert = Desert
 tileset-snow = Snow
 tileset-temperat = Temperate
 tileset-interior = Interior
+
+## SupportPowerTimerWidget
+support-power-timer = { $player }'s { $support-power }: { $time }

--- a/mods/ts/fluent/ts.ftl
+++ b/mods/ts/fluent/ts.ftl
@@ -8,3 +8,6 @@ loadscreen-loading = Updating EVA installation..., Changing perspective...
 ## Tilesets
 tileset-snow = Snow
 tileset-temperate = Temperate
+
+## ExitsDebugOverlay
+description-exits-overlay = Displays exits for factories.


### PR DESCRIPTION
The current logic has many issues that are mostly a consequence of it assuming that all mods will use all of the classes in all of the referenced dlls.

This PR changes the logic to check only keys that are explicitly referenced from either `Game` or from the different things (traits, weapons, modules, etc) defined in mod.yaml.