### PR TITLE
Add colors to utility commands

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/CheckConditionalTraitInterfaceOverrides.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckConditionalTraitInterfaceOverrides.cs
@@ -57,7 +57,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly) != null;
 				if (overridesCreated)
 				{
+					var originalColor = Console.ForegroundColor;
+					Console.ForegroundColor = ConsoleColor.Red;
 					Console.WriteLine("{0} must override ConditionalTrait's {1} method instead of implementing {2} directly", t.Name, methodName, interfaceType.Name);
+					Console.ForegroundColor = originalColor;
 					violationCount++;
 				}
 			}

--- a/OpenRA.Mods.Common/UtilityCommands/CheckExplicitInterfacesCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckExplicitInterfacesCommand.cs
@@ -119,7 +119,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 		void OnViolation(Type implementor, Type interfaceType, MemberInfo violator)
 		{
+			var originalColor = Console.ForegroundColor;
+			Console.ForegroundColor = ConsoleColor.Red;
 			Console.WriteLine($"{implementor.Name} must explicitly implement the interface member {interfaceType.Name}.{violator.Name}");
+			Console.ForegroundColor = originalColor;
 			violationCount++;
 		}
 	}

--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		string IUtilityCommand.Name => "--check-yaml";
 
 		static int errors = 0;
+		static int warnings = 0;
 
 		// mimic Windows compiler error format
 		static void EmitError(string e)
@@ -31,9 +32,15 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			++errors;
 		}
 
-		static void EmitWarning(string e)
+		void EmitWarning(string e)
 		{
-			Console.WriteLine($"OpenRA.Utility(1,1): Warning: {e}");
+			if (warningAsError)
+				EmitError(e);
+			else
+			{
+				Console.WriteLine($"OpenRA.Utility(1,1): Warning: {e}");
+				++warnings;
+			}
 		}
 
 		bool IUtilityCommand.ValidateArguments(string[] args)
@@ -80,7 +87,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						try
 						{
 							var customPass = (ILintPass)modData.ObjectCreator.CreateBasic(customPassType);
-							customPass.Run(EmitError, warningAsError ? EmitError : EmitWarning, modData);
+							customPass.Run(EmitError, EmitWarning, modData);
 						}
 						catch (Exception e)
 						{
@@ -110,6 +117,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						EmitError($"Failed to load map {map.Map} with exception: {e}");
 					}
 				}
+
+				if (warnings > 0)
+					Console.WriteLine($"Warnings: {warnings}");
 
 				if (errors > 0)
 				{
@@ -150,7 +160,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				try
 				{
 					var customMapPass = (ILintMapPass)modData.ObjectCreator.CreateBasic(customMapPassType);
-					customMapPass.Run(EmitError, warningAsError ? EmitError : EmitWarning, modData, map);
+					customMapPass.Run(EmitError, EmitWarning, modData, map);
 				}
 				catch (Exception e)
 				{
@@ -166,7 +176,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				try
 				{
 					var customRulesPass = (ILintRulesPass)modData.ObjectCreator.CreateBasic(customRulesPassType);
-					customRulesPass.Run(EmitError, warningAsError ? EmitError : EmitWarning, modData, rules);
+					customRulesPass.Run(EmitError, EmitWarning, modData, rules);
 				}
 				catch (Exception e)
 				{
@@ -182,7 +192,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				try
 				{
 					var customRulesPass = (ILintSequencesPass)modData.ObjectCreator.CreateBasic(customSequencesPassType);
-					customRulesPass.Run(EmitError, warningAsError ? EmitError : EmitWarning, modData, rules, sequences);
+					customRulesPass.Run(EmitError, EmitWarning, modData, rules, sequences);
 				}
 				catch (Exception e)
 				{

--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -28,7 +28,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		// mimic Windows compiler error format
 		static void EmitError(string e)
 		{
-			Console.WriteLine($"OpenRA.Utility(1,1): Error: {e}");
+			var originalColor = Console.ForegroundColor;
+			Console.ForegroundColor = ConsoleColor.Red;
+			Console.Write("OpenRA.Utility(1,1): Error:");
+			Console.ForegroundColor = originalColor;
+			Console.WriteLine(e);
 			++errors;
 		}
 
@@ -38,7 +42,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				EmitError(e);
 			else
 			{
-				Console.WriteLine($"OpenRA.Utility(1,1): Warning: {e}");
+				var originalColor = Console.ForegroundColor;
+				Console.ForegroundColor = ConsoleColor.Yellow;
+				Console.Write("OpenRA.Utility(1,1): Warning:");
+				Console.ForegroundColor = originalColor;
+				Console.WriteLine(e);
 				++warnings;
 			}
 		}

--- a/OpenRA.Mods.Common/UtilityCommands/UpdateMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpdateMapCommand.cs
@@ -110,18 +110,27 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 					// Files are saved after each successful automated rule update
 					mapFiles.Save();
+
+					var originalColor = Console.ForegroundColor;
+					Console.ForegroundColor = ConsoleColor.Green;
 					Console.WriteLine("COMPLETE");
+					Console.ForegroundColor = originalColor;
 
 					if (manualSteps.Count > 0)
 					{
+						Console.ForegroundColor = ConsoleColor.Yellow;
 						Console.WriteLine("   Manual changes are required to complete this update:");
+						Console.ForegroundColor = originalColor;
 						foreach (var manualStep in manualSteps)
 							Console.WriteLine("    * " + manualStep.Replace("\n", "\n      "));
 					}
 				}
 				catch (Exception ex)
 				{
+					var originalColor = Console.ForegroundColor;
+					Console.ForegroundColor = ConsoleColor.Red;
 					Console.WriteLine("FAILED");
+					Console.ForegroundColor = originalColor;
 
 					Console.WriteLine();
 					Console.WriteLine("   The automated changes for this rule were not applied because of an error.");
@@ -138,8 +147,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			if (externalFilenames.Count > 0)
 			{
+				Console.WriteLine();
 				Console.WriteLine("The following shared yaml files referenced by the map have been ignored:");
 				Console.WriteLine(UpdateUtils.FormatMessageList(externalFilenames));
+				Console.WriteLine();
 				Console.WriteLine("These files are assumed to have already been updated by the --update-mod command");
 				Console.WriteLine();
 			}

--- a/OpenRA.Mods.Common/UtilityCommands/UpdateModCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpdateModCommand.cs
@@ -151,6 +151,36 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			Console.WriteLine(format, args);
 		}
 
+		static void LogSuccess(StreamWriter logWriter, string format, params object[] args)
+		{
+			logWriter.WriteLine(format, args);
+
+			var originalColor = Console.ForegroundColor;
+			Console.ForegroundColor = ConsoleColor.Green;
+			Console.WriteLine(format, args);
+			Console.ForegroundColor = originalColor;
+		}
+
+		static void LogError(StreamWriter logWriter, string format, params object[] args)
+		{
+			logWriter.WriteLine(format, args);
+
+			var originalColor = Console.ForegroundColor;
+			Console.ForegroundColor = ConsoleColor.Red;
+			Console.WriteLine(format, args);
+			Console.ForegroundColor = originalColor;
+		}
+
+		static void LogWarning(StreamWriter logWriter, string format, params object[] args)
+		{
+			logWriter.WriteLine(format, args);
+
+			var originalColor = Console.ForegroundColor;
+			Console.ForegroundColor = ConsoleColor.Yellow;
+			Console.WriteLine(format, args);
+			Console.ForegroundColor = originalColor;
+		}
+
 		static void LogLine(StreamWriter logWriter)
 		{
 			logWriter.WriteLine();
@@ -176,12 +206,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				{
 					Log(logWriter, "   Updating mod... ");
 					manualSteps.AddRange(UpdateUtils.UpdateMod(modData, rule, out allFiles, externalFilenames));
-					LogLine(logWriter, "COMPLETE");
+					LogSuccess(logWriter, "COMPLETE");
 				}
 				catch (Exception ex)
 				{
-					Console.WriteLine("FAILED");
-
+					LogError(logWriter, "FAILED");
 					LogLine(logWriter);
 					LogLine(logWriter, "   The automated changes for this rule were not applied because of an error.");
 					LogLine(logWriter, "   After the issue reported below is resolved you should run the updater");
@@ -211,7 +240,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						}
 						catch (Exception ex)
 						{
-							LogLine(logWriter, "FAILED");
+							LogError(logWriter, "FAILED");
 							LogLine(logWriter);
 							LogLine(logWriter, "   The automated changes for this rule were not applied because of an error.");
 							LogLine(logWriter, "   After the issue reported below is resolved you should run the updater");
@@ -230,7 +259,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					if (mapsFailed)
 						continue;
 
-					LogLine(logWriter, "COMPLETE");
+					LogSuccess(logWriter, "COMPLETE");
 				}
 				else
 					LogLine(logWriter, "SKIPPED");
@@ -240,7 +269,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 				if (manualSteps.Count > 0)
 				{
-					LogLine(logWriter, "   Manual changes are required to complete this update:");
+					LogWarning(logWriter, "   Manual changes are required to complete this update:");
 					LogLine(logWriter, UpdateUtils.FormatMessageList(manualSteps, 1));
 				}
 
@@ -249,8 +278,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			if (externalFilenames.Count > 0)
 			{
+				LogLine(logWriter);
 				LogLine(logWriter, "The following external mod files have been ignored:");
 				LogLine(logWriter, UpdateUtils.FormatMessageList(externalFilenames));
+				LogLine(logWriter);
 				LogLine(logWriter, "These files should be updated by running --update-mod on the referenced mod(s)");
 				LogLine(logWriter);
 			}


### PR DESCRIPTION
Closes #21888

- Added color to all commands that are run with `make test`
- Added color to --update-mod and --update-map
- Counting warnings in --check-yaml

Recommended to review commit by commit
