### PR TITLE
When pathing, prefer optimal paths over short distances.

### DIFF
--- a/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
+++ b/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
@@ -849,9 +849,13 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 				pathFinderOverlay?.NewRecording(self, [source], target);
 
+				// For paths over a short distance, use a heuristic weight of 100% to force the shortest path to be returned.
+				// We do this as players are likely to be sensitive to suboptimal paths over short distances.
+				// So we prefer optimal paths over suboptimal ones.
+				// Since we have a limited search area, we don't mind the additional performance impact.
 				List<CPos> localPath;
 				using (var search = GetLocalPathSearch(
-					self, [source], target, customCost, ignoreActor, check, laneBias, gridToSearch, heuristicWeightPercentage,
+					self, [source], target, customCost, ignoreActor, check, laneBias, gridToSearch, 100,
 					null,
 					inReverse,
 					pathFinderOverlay?.RecordLocalEdges(self)))


### PR DESCRIPTION
The default path weight of 125% allows paths up to 25% longer than the optimal path to be returned, which improves the performance of path searches.

Over short distances, players are likely to be sensitive to suboptimal paths this can produce, so instead use a weight of 100% over short distances to ensure these paths are optimal. As the search area is limited, the additional performance impact is also capped. The hierarchical path finder already has a speculative check for short paths within a 20 cell area (twice the grid size of 10 cells), which allows it to skip a hierarchical search if a path within that area can be found. We can piggy back on this short path logic and use a weight of 100%.

Over longer distances, players are less likely to notice the suboptimal paths, and the performance benefit is more noticeable, so continue to use the 125% weight in these scenarios.

Additionally, expose HeuristicWeightPercentage on PathFinder trait.

Maintain the default weight of 125%, but allow this to be modified via config.

----

Requested on Discord.