### PR TITLE
Preview clipboard when copy-pasting in the map editor

### DIFF
--- a/OpenRA.Mods.Common/EditorBrushes/EditorBlit.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorBlit.cs
@@ -256,7 +256,8 @@ namespace OpenRA.Mods.Common.EditorBrushes
 			{
 				foreach (var (_, editorActorPreview) in blitSource.Actors)
 				{
-					var preview = editorActorPreview.RenderWithOffset(wOffset);
+					var preview = editorActorPreview.RenderWithOffset(wOffset)
+						.OrderBy(WorldRenderer.RenderableZPositionComparisonKey);
 					foreach (var renderable in preview)
 						yield return renderable;
 				}

--- a/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
@@ -87,7 +87,20 @@ namespace OpenRA.Mods.Common.Widgets
 		}
 
 		void IEditorBrush.TickRender(WorldRenderer wr, Actor self) { }
-		IEnumerable<IRenderable> IEditorBrush.RenderAboveShroud(Actor self, WorldRenderer wr) { yield break; }
+		IEnumerable<IRenderable> IEditorBrush.RenderAboveShroud(Actor self, WorldRenderer wr)
+		{
+			if (PastePreviewPosition != null)
+			{
+				var preview = EditorBlit.PreviewBlitSource(
+					clipboard,
+					getCopyFilters(),
+					PastePreviewPosition.Value - Region.TopLeft,
+					wr);
+				foreach (var renderable in preview)
+					yield return renderable;
+			}
+		}
+
 		IEnumerable<IRenderable> IEditorBrush.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			if (PastePreviewPosition != null)


### PR DESCRIPTION
Renders a preview of the clipboard contents at the mouse-targeted location when using the EditorCopyPasteBrush.

Depends on #21904