### PR TITLE
Fix missing tabs in production sidebar

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -278,12 +278,16 @@ namespace OpenRA.Mods.Common.Widgets
 			// It is possible that production queues get enabled/disabled during their lifetime.
 			// This makes sure every enabled production queue always has its tab associated with it.
 			var shouldUpdateQueues = false;
-			foreach (var (queue, enabled) in cachedProductionQueueEnabledStates)
+			for (var i = 0; i < cachedProductionQueueEnabledStates.Count; i++)
 			{
+				var (queue, enabled) = cachedProductionQueueEnabledStates[i];
+
 				if (queue.Enabled != enabled)
 				{
 					shouldUpdateQueues = true;
-					break;
+
+					// Refresh queue.Enabled value in cache
+					cachedProductionQueueEnabledStates[i] = (queue, queue.Enabled);
 				}
 			}
 


### PR DESCRIPTION
This PR fixes tabs in `ProductionTabsWidget` occasionally disappearing (and reappearing). The issues it fixes unfortunately slipped through the #21162.

### Background
The issue with `ProductionTabsWidget` is that it cannot properly handle situation, when a `ProductionQueue` starts disabled (via `RequiresCondition`) and is later enabled. This causes the widget to "miss" the update of the actor involved and does not create a tab for this `ProductionQueue`. The bug appears only if new production actor is created *while* the previous still has the `ProductionQueue` disabled via `RequiresCondition`.

This is how the bug looks like in OpenE2140:

![productiontabwidget_missing_tabs_bug](https://github.com/user-attachments/assets/7789045b-a17b-45b7-9c6c-8c64cc3fe149)

For more information see the previous PR: #21162.

### Updating cache for production queues' enabled states
The original PR did not update cache for enabled state of production queues in `cachedProductionQueueEnabledStates` field. The reason, why the PR did fix the issue is that what the code currently does, is that it refreshes the production tabs in every tick. This happens only if a production queue, that was enabled on creation, gets disabled. The cache contains stale information, hence it thinks that queue's `Enabled` state keeps changing and tabs should be updated.

The new code in PR updates the cache for the production queue, which `Enabled` state has changed, but only once (because in the next tick, the cache contains up-to-date data).

### Reacting to actors of non-local player
The `ActorChanged()` currently reacts to all actors no matter the owner. It means that whenever a non-local player builds a production building, the production tabs (for the local player naturally) are updated. But if the local player has any queue disabled at this moment, it means tab for that queue *gets removed*

it will clear the cache for *all players*. And since `Tick()` method depends on the cache containing all currently existing production queues, the mechanism for updating tabs gets broken.

The new code in PR changes the logic in the `ActorChanged()` method so that it reacts only to actors, which are owned by the local player.