### PR TITLE
Remove AllowPlacementOnResources in Building and use TerrainTypes only

### DIFF
--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -88,7 +88,6 @@ namespace OpenRA.Mods.Common.Orders
 		readonly World world;
 		protected readonly ProductionQueue Queue;
 		readonly PlaceBuildingInfo placeBuildingInfo;
-		readonly IResourceLayer resourceLayer;
 		readonly Viewport viewport;
 		readonly VariantWrapper[] variants;
 		int variant;
@@ -98,7 +97,6 @@ namespace OpenRA.Mods.Common.Orders
 			Queue = queue;
 			world = queue.Actor.World;
 			placeBuildingInfo = queue.Actor.Owner.PlayerActor.Info.TraitInfo<PlaceBuildingInfo>();
-			resourceLayer = world.WorldActor.TraitOrDefault<IResourceLayer>();
 			viewport = worldRenderer.Viewport;
 
 			// Clear selection if using Left-Click Orders
@@ -294,12 +292,7 @@ namespace OpenRA.Mods.Common.Orders
 			{
 				var isCloseEnough = buildingInfo.IsCloseEnoughToBase(world, world.LocalPlayer, actorInfo, topLeft);
 				foreach (var t in buildingInfo.Tiles(topLeft))
-					footprint.Add(
-						t,
-						MakeCellType(
-							isCloseEnough &&
-							world.IsCellBuildable(t, actorInfo, buildingInfo) &&
-							(resourceLayer == null || resourceLayer.GetResource(t).Type == null)));
+					footprint.Add(t, MakeCellType(isCloseEnough && world.IsCellBuildable(t, actorInfo, buildingInfo)));
 			}
 
 			return preview?.Render(wr, topLeft, footprint) ?? [];

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -45,8 +45,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly bool AllowInvalidPlacement = false;
 
-		public readonly bool AllowPlacementOnResources = false;
-
 		[Desc("Clear smudges from underneath the building footprint.")]
 		public readonly bool RemoveSmudgesOnBuild = true;
 

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
@@ -84,10 +84,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (bi.AllowInvalidPlacement)
 				return true;
 
-			var resourceLayer = world.WorldActor.TraitOrDefault<IResourceLayer>();
-			return bi.Tiles(cell).All(t => world.Map.Contains(t) &&
-				(bi.AllowPlacementOnResources || resourceLayer == null || resourceLayer.GetResource(t).Type == null) &&
-					world.IsCellBuildable(t, ai, bi, toIgnore));
+			return bi.Tiles(cell).All(t => world.Map.Contains(t) && world.IsCellBuildable(t, ai, bi, toIgnore));
 		}
 
 		public static IEnumerable<(CPos Cell, Actor Actor)> GetLineBuildCells(World world, CPos cell, ActorInfo ai, BuildingInfo bi, Player owner)

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -172,10 +172,11 @@ namespace OpenRA.Mods.Common.Traits
 			if (resourceType == null || !info.ResourceTypes.TryGetValue(resourceType, out var resourceInfo))
 				return false;
 
-			if (!resourceInfo.AllowedTerrainTypes.Contains(Map.GetTerrainInfo(cell).Type))
+			var cellTerrainType = Map.GetTerrainInfo(cell).Type;
+			if (!resourceInfo.AllowedTerrainTypes.Contains(cellTerrainType))
 				return false;
 
-			return !BuildingInfluence.AnyBuildingAt(cell);
+			return BuildingInfluence.GetBuildingsAt(cell).All(a => a.Info.TraitInfo<BuildingInfo>().TerrainTypes.Contains(cellTerrainType));
 		}
 
 		ResourceLayerContents CreateResourceCell(string resourceType, CPos cell, int density)

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20250330/RemoveBuildingInfoAllowPlacementOnResources.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20250330/RemoveBuildingInfoAllowPlacementOnResources.cs
@@ -1,0 +1,68 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Mods.Common.Traits;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	/// <summary>
+	/// Replaces the BaseAttackNotifier with a new AttackNotifier that uses the
+	/// new attack system.
+	/// </summary>
+	public class RemoveBuildingInfoAllowPlacementOnResources : UpdateRule, IBeforeUpdateActors
+	{
+		public override string Name => "Remove AllowPlacementOnResources from BuildingInfo";
+		public override string Description => "Removes AllowPlacementOnResources from BuildingInfo and adds terrains with resources" +
+			"to TerrainTypes (if a Building trait uses AllowPlacementOnResources: true).";
+
+		readonly HashSet<string> terrainTypesWithResources = [];
+
+		IEnumerable<string> IBeforeUpdateActors.BeforeUpdateActors(ModData modData, List<MiniYamlNodeBuilder> resolvedActors)
+		{
+			var resourceLayerInfo = modData.DefaultRules.Actors[SystemActors.World].TraitInfoOrDefault<ResourceLayerInfo>();
+			if (resourceLayerInfo == null)
+				yield break;
+
+			foreach (var resourceType in resourceLayerInfo.ResourceTypes.Values)
+			{
+				terrainTypesWithResources.Add(resourceType.TerrainType);
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
+		{
+			foreach (var buildingInfo in actorNode.ChildrenMatching("Building"))
+			{
+				if (buildingInfo.RemoveNodes("AllowPlacementOnResources") == 0)
+					continue;
+
+				var terrainTypesNode = buildingInfo.Value.NodeWithKeyOrDefault("TerrainTypes");
+				if (terrainTypesNode == null)
+				{
+					terrainTypesNode = new MiniYamlNodeBuilder("TerrainTypes", "");
+					buildingInfo.AddNode(terrainTypesNode);
+				}
+
+				var allowedTerrainTypes = terrainTypesNode?.NodeValue<List<string>>() ?? [];
+				foreach (var terrainType in terrainTypesWithResources)
+				{
+					if (!allowedTerrainTypes.Contains(terrainType))
+						allowedTerrainTypes.Add(terrainType);
+				}
+
+				terrainTypesNode.ReplaceValue(string.Join(", ", allowedTerrainTypes));
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -70,6 +70,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 
 				// bleed only changes here.
 				new ReplaceBaseAttackNotifier(),
+				new RemoveBuildingInfoAllowPlacementOnResources(),
 			]),
 		];
 


### PR DESCRIPTION
This PR removes `AllowPlacementOnResources` from `BuildingInfo` and uses `BuildingInfo.TerrainTypes` only for resource-related checks. Contains an update rule, which adds all resource types defined on `ResourceLayer` to `TerrainTypes` on `BuildingInfo`, if `AllowPlacementOnResources` is true.

The last commit is just for testing the update rule, do not merge/rebase it to bleed.