### PR TITLE
Improve editor resource brush

### DIFF
--- a/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
@@ -45,8 +45,6 @@ namespace OpenRA.Mods.Common.Widgets
 			resourceRenderers = world.WorldActor.TraitsImplementing<IResourceRenderer>().ToArray();
 			cell = wr.Viewport.ViewToWorld(wr.Viewport.WorldToViewPx(Viewport.LastMousePos));
 			UpdatePreview();
-
-			action = new AddResourcesEditorAction(resourceType, resourceLayer);
 		}
 
 		public bool HandleMouseInput(MouseInput mi)
@@ -70,13 +68,14 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (mi.Button == MouseButton.Left && mi.Event != MouseInputEvent.Up && resourceLayer.CanAddResource(ResourceType, cell))
 			{
+				action ??= new AddResourcesEditorAction(ResourceType, resourceLayer);
 				action.Add(new CellResource(cell, resourceLayer.GetResource(cell)));
 				resourceAdded = true;
 			}
 			else if (resourceAdded && mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Up)
 			{
 				editorActionManager.Add(action);
-				action = new AddResourcesEditorAction(ResourceType, resourceLayer);
+				action = null;
 				resourceAdded = false;
 			}
 
@@ -101,7 +100,7 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 		}
 
-		IEnumerable<IRenderable> IEditorBrush.RenderAboveShroud(Actor self, WorldRenderer wr) { return preview; }
+		IEnumerable<IRenderable> IEditorBrush.RenderAboveShroud(Actor self, WorldRenderer wr) { return action == null ? preview : null; }
 		IEnumerable<IRenderable> IEditorBrush.RenderAnnotations(Actor self, WorldRenderer wr) { yield break; }
 
 		public void Tick() { }

--- a/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
@@ -135,25 +135,24 @@ namespace OpenRA.Mods.Common.Widgets
 		public void Do()
 		{
 			foreach (var resourceCell in cellResources)
-			{
-				resourceLayer.ClearResources(resourceCell.Cell);
 				resourceLayer.AddResource(resourceType, resourceCell.Cell, resourceLayer.GetMaxDensity(resourceType));
-			}
 		}
 
 		public void Undo()
 		{
 			foreach (var resourceCell in cellResources)
 			{
-				resourceLayer.ClearResources(resourceCell.Cell);
-				if (resourceCell.OldResourceTile.Type != null)
+				// If resources match, simulate a replace command.
+				if (resourceCell.OldResourceTile.Type == resourceType || resourceCell.OldResourceTile.Type == null)
+					resourceLayer.ClearResources(resourceCell.Cell);
+
+				if (resourceCell.OldResourceTile.Type == resourceType || resourceCell.OldResourceTile.Type != null)
 					resourceLayer.AddResource(resourceCell.OldResourceTile.Type, resourceCell.Cell, resourceCell.OldResourceTile.Density);
 			}
 		}
 
 		public void Add(CellResource resourceCell)
 		{
-			resourceLayer.ClearResources(resourceCell.Cell);
 			resourceLayer.AddResource(resourceType, resourceCell.Cell, resourceLayer.GetMaxDensity(resourceType));
 			cellResources.Add(resourceCell);
 			Text = FluentProvider.GetMessage(AddedResource, "amount", cellResources.Count, "type", resourceType);

--- a/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (mi.Button == MouseButton.Left && mi.Event != MouseInputEvent.Up && resourceLayer.CanAddResource(ResourceType, cell))
 			{
-				action.Add(new CellResource(cell, resourceLayer.GetResource(cell), ResourceType));
+				action.Add(new CellResource(cell, resourceLayer.GetResource(cell)));
 				resourceAdded = true;
 			}
 			else if (resourceAdded && mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Up)
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public void Dispose() { }
 	}
 
-	readonly record struct CellResource(CPos Cell, ResourceLayerContents OldResourceTile, string NewResourceType);
+	readonly record struct CellResource(CPos Cell, ResourceLayerContents OldResourceTile);
 
 	sealed class AddResourcesEditorAction : IEditorAction
 	{
@@ -137,7 +137,7 @@ namespace OpenRA.Mods.Common.Widgets
 			foreach (var resourceCell in cellResources)
 			{
 				resourceLayer.ClearResources(resourceCell.Cell);
-				resourceLayer.AddResource(resourceCell.NewResourceType, resourceCell.Cell, resourceLayer.GetMaxDensity(resourceCell.NewResourceType));
+				resourceLayer.AddResource(resourceType, resourceCell.Cell, resourceLayer.GetMaxDensity(resourceType));
 			}
 		}
 
@@ -154,7 +154,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public void Add(CellResource resourceCell)
 		{
 			resourceLayer.ClearResources(resourceCell.Cell);
-			resourceLayer.AddResource(resourceCell.NewResourceType, resourceCell.Cell, resourceLayer.GetMaxDensity(resourceCell.NewResourceType));
+			resourceLayer.AddResource(resourceType, resourceCell.Cell, resourceLayer.GetMaxDensity(resourceType));
 			cellResources.Add(resourceCell);
 			Text = FluentProvider.GetMessage(AddedResource, "amount", cellResources.Count, "type", resourceType);
 		}


### PR DESCRIPTION
Split from #21695

- Disables resource cursor when painting for a smoother experience
- Reduces redundant updates to editor resource layer
- Reduces resource brush undo cache size