### PR TITLE
Small Editor improvement

### DIFF
--- a/OpenRA.Game/Map/ActorReference.cs
+++ b/OpenRA.Game/Map/ActorReference.cs
@@ -125,6 +125,15 @@ namespace OpenRA
 			InitDict.Add(init);
 		}
 
+		public void Replace<T>(T init) where T : ActorInit, ISingleInstanceInit
+		{
+			var original = GetOrDefault<T>();
+			if (original != null)
+				Remove(original);
+
+			Add(init);
+		}
+
 		public void Remove(ActorInit o) { initDict.Value.Remove(o); }
 
 		public int RemoveAll<T>() where T : ActorInit

--- a/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public bool HandleMouseInput(MouseInput mi)
 		{
-			// Exclusively uses left and right mouse buttons, but nothing else
+			// Exclusively uses left and right mouse buttons, but nothing else.
 			if (mi.Button != MouseButton.Left && mi.Button != MouseButton.Right)
 				return false;
 
@@ -155,7 +155,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			this.editorLayer = editorLayer;
 
-			// Take an immutable copy of the reference
+			// Take an immutable copy of the reference.
 			this.actor = actor.Clone();
 		}
 

--- a/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 	sealed class CopyPasteEditorAction : IEditorAction
 	{
-		[FluentReference("amount")]
+		[FluentReference("count")]
 		const string CopiedTiles = "notification-copied-tiles";
 
 		public string Text { get; }
@@ -131,7 +131,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			this.editorBlit = editorBlit;
 
-			Text = FluentProvider.GetMessage(CopiedTiles, "amount", editorBlit.TileCount());
+			Text = FluentProvider.GetMessage(CopiedTiles, "count", editorBlit.TileCount());
 		}
 
 		public void Execute()

--- a/OpenRA.Mods.Common/EditorBrushes/EditorMarkerLayerBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorMarkerLayerBrush.cs
@@ -98,10 +98,10 @@ namespace OpenRA.Mods.Common.Widgets
 
 	sealed class PaintMarkerTileEditorAction : IEditorAction
 	{
-		[FluentReference("amount", "type")]
+		[FluentReference("count", "type")]
 		const string AddedMarkerTiles = "notification-added-marker-tiles";
 
-		[FluentReference("amount")]
+		[FluentReference("count")]
 		const string RemovedMarkerTiles = "notification-removed-marker-tiles";
 
 		public string Text { get; private set; }
@@ -150,16 +150,15 @@ namespace OpenRA.Mods.Common.Widgets
 				markerLayerOverlay.SetTile(cell, type);
 			}
 
-			if (type != null)
-				Text = FluentProvider.GetMessage(AddedMarkerTiles, "amount", paintTiles.Count, "type", type);
-			else
-				Text = FluentProvider.GetMessage(RemovedMarkerTiles, "amount", paintTiles.Count);
+			Text = type != null
+				? FluentProvider.GetMessage(AddedMarkerTiles, "count", paintTiles.Count, "type", type)
+				: FluentProvider.GetMessage(RemovedMarkerTiles, "count", paintTiles.Count);
 		}
 	}
 
 	sealed class ClearSelectedMarkerTilesEditorAction : IEditorAction
 	{
-		[FluentReference("amount", "type")]
+		[FluentReference("count", "type")]
 		const string ClearedSelectedMarkerTiles = "notification-cleared-selected-marker-tiles";
 
 		public string Text { get; }
@@ -177,7 +176,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			tiles = markerLayerOverlay.Tiles[tile].ToHashSet();
 
-			Text = FluentProvider.GetMessage(ClearedSelectedMarkerTiles, "amount", tiles.Count, "type", tile);
+			Text = FluentProvider.GetMessage(ClearedSelectedMarkerTiles, "count", tiles.Count, "type", tile);
 		}
 
 		public void Execute()
@@ -198,7 +197,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 	sealed class ClearAllMarkerTilesEditorAction : IEditorAction
 	{
-		[FluentReference("amount")]
+		[FluentReference("count")]
 		const string ClearedAllMarkerTiles = "notification-cleared-all-marker-tiles";
 
 		public string Text { get; }
@@ -214,7 +213,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var allTilesCount = tiles.Values.Sum(x => x.Count);
 
-			Text = FluentProvider.GetMessage(ClearedAllMarkerTiles, "amount", allTilesCount);
+			Text = FluentProvider.GetMessage(ClearedAllMarkerTiles, "count", allTilesCount);
 		}
 
 		public void Execute()

--- a/OpenRA.Mods.Common/EditorBrushes/EditorMarkerLayerBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorMarkerLayerBrush.cs
@@ -123,6 +123,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public void Execute()
 		{
+			paintTiles.TrimExcess();
 		}
 
 		public void Do()

--- a/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 	sealed class AddResourcesEditorAction : IEditorAction
 	{
-		[FluentReference("amount", "type")]
+		[FluentReference("count", "type")]
 		const string AddedResource = "notification-added-resource";
 
 		public string Text { get; private set; }
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.Common.Widgets
 			resourceLayer.ClearResources(resourceCell.Cell);
 			resourceLayer.AddResource(resourceCell.NewResourceType, resourceCell.Cell, resourceLayer.GetMaxDensity(resourceCell.NewResourceType));
 			cellResources.Add(resourceCell);
-			Text = FluentProvider.GetMessage(AddedResource, "amount", cellResources.Count, "type", resourceType);
+			Text = FluentProvider.GetMessage(AddedResource, "count", cellResources.Count, "type", resourceType);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
@@ -130,6 +130,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public void Execute()
 		{
+			cellResources.TrimExcess();
 		}
 
 		public void Do()

--- a/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
@@ -11,7 +11,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Terrain;
 using OpenRA.Mods.Common.Traits;
@@ -49,7 +48,7 @@ namespace OpenRA.Mods.Common.Widgets
 			terrainRenderer = world.WorldActor.Trait<ITiledTerrainRenderer>();
 
 			Template = id;
-			TerrainTemplate = terrainInfo.Templates.First(t => t.Value.Id == id).Value;
+			TerrainTemplate = terrainInfo.Templates[Template];
 			cell = wr.Viewport.ViewToWorld(wr.Viewport.WorldToViewPx(Viewport.LastMousePos));
 			UpdatePreview();
 		}

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -144,8 +144,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!Players.Players.TryGetValue(ownerInit.InternalName, out var owner))
 			{
 				owner = worldOwner;
-				reference.Remove(ownerInit);
-				reference.Add(new OwnerInit(worldOwner.Name));
+				reference.Replace(new OwnerInit(worldOwner.Name));
 			}
 
 			return owner;

--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -245,11 +245,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void ReplaceInit<T>(T init) where T : ActorInit, ISingleInstanceInit
 		{
-			var original = reference.GetOrDefault<T>();
-			if (original != null)
-				reference.Remove(original);
-
-			reference.Add(init);
+			reference.Replace(init);
 			GeneratePreviews();
 			UpdateRadarColor();
 		}

--- a/OpenRA.Mods.Common/Traits/World/MarkerLayerOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/MarkerLayerOverlay.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
@@ -172,7 +173,7 @@ namespace OpenRA.Mods.Common.Traits
 				NumSides = file.NumSides;
 				AxisAngle = file.AxisAngle;
 
-				SetAll(file.Tiles.ToDictionary(d => d.Key, d => new HashSet<CPos>(d.Value)));
+				SetAll(file.Tiles.ToImmutableDictionary(d => d.Key, d => d.Value.ToImmutableArray()));
 			}
 			catch (Exception e)
 			{
@@ -202,7 +203,7 @@ namespace OpenRA.Mods.Common.Traits
 			Tiles.Clear();
 		}
 
-		public void SetAll(Dictionary<int, HashSet<CPos>> newTiles)
+		public void SetAll(IImmutableDictionary<int, ImmutableArray<CPos>> newTiles)
 		{
 			ClearAll();
 
@@ -222,7 +223,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public void SetSelected(int tile, HashSet<CPos> newTiles)
+		public void SetSelected(int tile, ReadOnlySpan<CPos> newTiles)
 		{
 			var type = Tiles[tile];
 			foreach (var pos in type)

--- a/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
@@ -38,10 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 				// If an actor's doesn't have a valid owner transfer ownership to neutral
 				var ownerInit = actorReference.Get<OwnerInit>();
 				if (!world.Players.Any(p => p.InternalName == ownerInit.InternalName))
-				{
-					actorReference.Remove(ownerInit);
-					actorReference.Add(new OwnerInit(world.WorldActor.Owner));
-				}
+					actorReference.Replace(new OwnerInit(world.WorldActor.Owner));
 
 				actorReference.Add(new SkipMakeAnimsInit());
 				actorReference.Add(new SpawnedByMapInit());

--- a/mods/common/fluent/common.ftl
+++ b/mods/common/fluent/common.ftl
@@ -783,9 +783,9 @@ notification-added-actor = Added { $name } ({ $id })
 
 ## EditorCopyPasteBrush
 notification-copied-tiles =
-    { $amount ->
+    { $count ->
        [one] Copied one tile
-      *[other] Copied { $amount } tiles
+      *[other] Copied { $count } tiles
     }
 
 ## EditorDefaultBrush
@@ -799,9 +799,9 @@ notification-moved-actor = Moved { $id } from { $x1 },{ $y1 } to { $x2 },{ $y2 }
 
 ## EditorResourceBrush
 notification-added-resource =
-    { $amount ->
+    { $count ->
        [one] Added one cell of { $type }
-      *[other] Added { $amount } cells of { $type }
+      *[other] Added { $count } cells of { $type }
     }
 
 ## EditorTileBrush
@@ -810,17 +810,17 @@ notification-filled-tile = Filled with tile { $id }
 
 ## EditorMarkerLayerBrush
 notification-added-marker-tiles =
-    { $amount ->
+    { $count ->
        [one] Added one marker tile of type { $type }
-      *[other] Added { $amount } marker tiles of type { $type }
+      *[other] Added { $count } marker tiles of type { $type }
     }
 notification-removed-marker-tiles =
-    { $amount ->
+    { $count ->
        [one] Removed one marker tile
-      *[other] Removed { $amount } marker tiles
+      *[other] Removed { $count } marker tiles
     }
-notification-cleared-selected-marker-tiles = Cleared { $amount } marker tiles of type { $type }
-notification-cleared-all-marker-tiles = Cleared { $amount } marker tiles
+notification-cleared-selected-marker-tiles = Cleared { $count } marker tiles of type { $type }
+notification-cleared-all-marker-tiles = Cleared { $count } marker tiles
 
 ## EditorActionManager
 notification-opened = Opened


### PR DESCRIPTION
Split from #21695

- Added a preview to marker brush
- Swiched to "amount" to "count" naming in fluent keys
- Adds a Replace function to actor reference, and makes use of it in lots of places
- Improves memory footprint of brushes by trimming their undo collections