### PR TITLE
Wavreader robustness

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -143,6 +143,7 @@ Also thanks to:
     * Riderr3
     * riiga
     * Rikhardur Bjarni Einarsson (WolfGaming)
+    * Robert Nordan (robpvn)
     * Sascha Biedermann (bidifx)
     * Sean Hunt (coppro)
     * Shawn Collins (UberWaffe)


### PR DESCRIPTION
This change makes WavReader correctly read the chunk size of a chunk as an unsigned int (https://en.wikipedia.org/wiki/Resource_Interchange_File_Format#Explanation), and cleans up the inconsistent logic around checking chunk sizes. It also attempts to handle buggy/chopped off Wav files where the reported data chunk size is larger than the actual file.

I ran into this while trying to load a Wav file where all the bits in its chunk size field were 1, meaning it first was reported as -1 and after fixing the reading was reported as uint.MAX_VALUE, much longer than the file actually was. These changes should have no impact on correct Wav files. 