### PR TITLE
Add additional MultiBrush segments for RA and CnC

### DIFF
--- a/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
@@ -147,8 +147,19 @@ namespace OpenRA.Mods.Common.MapGenerator
 	/// </summary>
 	public sealed class MultiBrushSegment
 	{
+		/// <summary>Start type, including a direction. E.g. "Cliff.R".</summary>
+		[FieldLoader.Require]
 		public readonly string Start;
-		public readonly string Inner;
+
+		/// <summary>
+		/// Inner type. Does not include a direction. E.g. "Cliff".
+		/// A null (absent) inner type implies that both the start and end types can be considered
+		/// valid inner types.
+		/// </summary>
+		public readonly string Inner = null;
+
+		/// <summary>End type, including a direction. E.g. "Cliff.R".</summary>
+		[FieldLoader.Require]
 		public readonly string End;
 
 		/// <summary>
@@ -196,7 +207,9 @@ namespace OpenRA.Mods.Common.MapGenerator
 		public bool HasStartType(string matcher)
 			=> MatchesType(Start, matcher);
 		public bool HasInnerType(string matcher)
-			=> MatchesType(Inner, matcher);
+			=> Inner != null
+				? MatchesType(Inner, matcher)
+				: (MatchesType(Start, matcher) || MatchesType(End, matcher));
 		public bool HasEndType(string matcher)
 			=> MatchesType(End, matcher);
 	}

--- a/OpenRA.Mods.Common/Traits/World/TilingPathTool.cs
+++ b/OpenRA.Mods.Common/Traits/World/TilingPathTool.cs
@@ -358,7 +358,10 @@ namespace OpenRA.Mods.Common.Traits
 
 			InnerTypes = SegmentedBrushes
 				.Where(b => b.Segment != null)
-				.Select(b => b.Segment.Inner.Split('.')[0])
+				.SelectMany<MultiBrush, string>(b =>
+					b.Segment.Inner != null
+						? [b.Segment.Inner.Split('.')[0]]
+						: [b.Segment.Start.Split('.')[0], b.Segment.End.Split('.')[0]])
 				.Distinct()
 				.Order()
 				.ToImmutableArray();

--- a/mods/cnc/tilesets/desert.yaml
+++ b/mods/cnc/tilesets/desert.yaml
@@ -2940,6 +2940,174 @@ MultiBrushCollections:
 				Inner: Road
 				Points: 1,0, 0,0, 0,1, 0,2
 				Start: Road.Out.LD
+		MultiBrush@149:
+			Template: 149
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,2, 1,2, 2,2, 3,2, 4,2
+		MultiBrush@149reverse:
+			Template: 149
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 4,1, 3,1, 2,1, 1,1, 0,1
+		MultiBrush@150:
+			Template: 150
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,2, 1,2, 2,2, 3,2, 4,2
+		MultiBrush@150reverse:
+			Template: 150
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 4,1, 3,1, 2,1, 1,1, 0,1
+		MultiBrush@151:
+			Template: 151
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,4, 1,4, 2,4, 3,4, 3,3, 4,3, 4,2, 5,2, 6,2
+		MultiBrush@151reverse:
+			Template: 151
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 6,1, 5,1, 4,1, 3,1, 2,1, 2,2, 1,2, 1,3, 0,3
+		MultiBrush@152:
+			Template: 152
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,2, 1,2, 1,3, 2,3, 3,3, 3,4, 4,4, 5,4, 5,5, 6,5
+		MultiBrush@152reverse:
+			Template: 152
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 6,4, 6,3, 5,3, 5,2, 4,2, 4,1, 3,1, 2,1, 1,1, 0,1
+		MultiBrush@153:
+			Template: 153
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 1,0, 1,1, 1,2, 1,3, 1,4
+		MultiBrush@153reverse:
+			Template: 153
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,4, 2,3, 2,2, 2,1, 2,0
+		MultiBrush@154:
+			Template: 154
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 2,0, 2,1, 2,2, 2,3, 2,4
+		MultiBrush@154reverse:
+			Template: 154
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 3,4, 3,3, 3,2, 3,1, 3,0
+		MultiBrush@155:
+			Template: 155
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 4,0, 4,1, 3,1, 3,2, 2,2, 2,3, 2,4, 2,5, 2,6, 1,6, 1,7, 1,8
+		MultiBrush@155reverse:
+			Template: 155
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,8, 2,7, 2,6, 3,6, 3,5, 3,4, 3,3, 4,3, 4,2, 5,2, 5,1, 5,0
+		MultiBrush@156:
+			Template: 156
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 1,0, 1,1, 2,1, 2,2, 2,3, 2,4, 2,5, 3,5, 3,6, 3,7, 4,7, 4,8
+		MultiBrush@156reverse:
+			Template: 156
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 5,8, 5,7, 5,6, 4,6, 4,5, 4,4, 3,4, 3,3, 3,2, 3,1, 2,1, 2,0
+		MultiBrush@157:
+			Template: 157
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.R
+				Points: 2,3, 2,2, 3,2
+		MultiBrush@157reverse:
+			Template: 157
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.D
+				Points: 3,1, 2,1, 1,1, 1,2, 1,3
+		MultiBrush@158:
+			Template: 158
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.D
+				Points: 0,2, 1,2, 1,3
+		MultiBrush@158reverse:
+			Template: 158
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.L
+				Points: 2,3, 2,2, 2,1, 1,1, 0,1
+		MultiBrush@159:
+			Template: 159
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.U
+				Points: 3,1, 2,1, 2,0
+		MultiBrush@159reverse:
+			Template: 159
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.R
+				Points: 1,0, 1,1, 1,2, 2,2, 3,2
+		MultiBrush@160:
+			Template: 160
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.L
+				Points: 1,0, 1,1, 0,1
+		MultiBrush@160reverse:
+			Template: 160
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.U
+				Points: 0,2, 1,2, 2,2, 2,1, 2,0
 		MultiBrush@174:
 			Template: 174
 			Segment:

--- a/mods/cnc/tilesets/snow.yaml
+++ b/mods/cnc/tilesets/snow.yaml
@@ -2601,6 +2601,160 @@ MultiBrushCollections:
 				Inner: Road
 				Points: 1,0, 0,0, 0,1, 0,2
 				Start: Road.Out.LD
+		MultiBrush@136:
+			Template: 136
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,2, 1,2, 2,2, 3,2, 4,2, 5,2
+		MultiBrush@136reverse:
+			Template: 136
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 5,2, 4,2, 3,2, 2,2, 1,2, 0,2
+		MultiBrush@137:
+			Template: 137
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,2, 1,2, 2,2, 2,1, 3,1, 4,1, 5,1
+		MultiBrush@137reverse:
+			Template: 137
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 5,1, 4,1, 3,1, 2,1, 2,2, 1,2, 0,2
+		MultiBrush@138:
+			Template: 138
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,1, 1,1, 1,2, 2,2, 3,2, 3,3, 4,3
+		MultiBrush@138reverse:
+			Template: 138
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 4,3, 3,3, 3,2, 2,2, 1,2, 1,1, 0,1
+		MultiBrush@139:
+			Template: 139
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,3, 1,3, 1,2, 2,2, 3,2, 3,1, 4,1
+		MultiBrush@139reverse:
+			Template: 139
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 4,1, 3,1, 3,2, 2,2, 1,2, 1,3, 0,3
+		MultiBrush@140:
+			Template: 140
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 2,0, 2,1, 2,2, 2,3
+		MultiBrush@140reverse:
+			Template: 140
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,3, 2,2, 2,1, 2,0
+		MultiBrush@141:
+			Template: 141
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 2,0, 2,1, 2,2
+		MultiBrush@141reverse:
+			Template: 141
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,2, 2,1, 2,0
+		MultiBrush@142:
+			Template: 142
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 2,0, 2,1, 2,2
+		MultiBrush@142reverse:
+			Template: 142
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,2, 2,1, 2,0
+		MultiBrush@143:
+			Template: 143
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.R
+				Points: 1,2, 1,1, 2,1
+		MultiBrush@143reverse:
+			Template: 143
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.D
+				Points: 2,1, 1,1, 1,2
+		MultiBrush@144:
+			Template: 144
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.D
+				Points: 0,1, 1,1, 1,2
+		MultiBrush@144reverse:
+			Template: 144
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.L
+				Points: 1,2, 1,1, 0,1
+		MultiBrush@145:
+			Template: 145
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.U
+				Points: 2,1, 1,1, 1,0
+		MultiBrush@145reverse:
+			Template: 145
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.R
+				Points: 1,0, 1,1, 2,1
+		MultiBrush@146:
+			Template: 146
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.L
+				Points: 1,0, 1,1, 0,1
+		MultiBrush@146reverse:
+			Template: 146
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.U
+				Points: 0,1, 1,1, 1,0
 		MultiBrush@186:
 			Template: 186
 			Segment:

--- a/mods/cnc/tilesets/temperat.yaml
+++ b/mods/cnc/tilesets/temperat.yaml
@@ -2602,6 +2602,160 @@ MultiBrushCollections:
 				Inner: Road
 				Points: 1,0, 0,0, 0,1, 0,2
 				Start: Road.Out.LD
+		MultiBrush@136:
+			Template: 136
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,2, 1,2, 2,2, 3,2, 4,2, 5,2
+		MultiBrush@136reverse:
+			Template: 136
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 5,2, 4,2, 3,2, 2,2, 1,2, 0,2
+		MultiBrush@137:
+			Template: 137
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,2, 1,2, 2,2, 2,1, 3,1, 4,1, 5,1
+		MultiBrush@137reverse:
+			Template: 137
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 5,1, 4,1, 3,1, 2,1, 2,2, 1,2, 0,2
+		MultiBrush@138:
+			Template: 138
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,1, 1,1, 1,2, 2,2, 3,2, 3,3, 4,3
+		MultiBrush@138reverse:
+			Template: 138
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 4,3, 3,3, 3,2, 2,2, 1,2, 1,1, 0,1
+		MultiBrush@139:
+			Template: 139
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,3, 1,3, 1,2, 2,2, 3,2, 3,1, 4,1
+		MultiBrush@139reverse:
+			Template: 139
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 4,1, 3,1, 3,2, 2,2, 1,2, 1,3, 0,3
+		MultiBrush@140:
+			Template: 140
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 2,0, 2,1, 2,2, 2,3
+		MultiBrush@140reverse:
+			Template: 140
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,3, 2,2, 2,1, 2,0
+		MultiBrush@141:
+			Template: 141
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 2,0, 2,1, 2,2
+		MultiBrush@141reverse:
+			Template: 141
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,2, 2,1, 2,0
+		MultiBrush@142:
+			Template: 142
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 2,0, 2,1, 2,2
+		MultiBrush@142reverse:
+			Template: 142
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,2, 2,1, 2,0
+		MultiBrush@143:
+			Template: 143
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.R
+				Points: 1,2, 1,1, 2,1
+		MultiBrush@143reverse:
+			Template: 143
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.D
+				Points: 2,1, 1,1, 1,2
+		MultiBrush@144:
+			Template: 144
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.D
+				Points: 0,1, 1,1, 1,2
+		MultiBrush@144reverse:
+			Template: 144
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.L
+				Points: 1,2, 1,1, 0,1
+		MultiBrush@145:
+			Template: 145
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.U
+				Points: 2,1, 1,1, 1,0
+		MultiBrush@145reverse:
+			Template: 145
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.R
+				Points: 1,0, 1,1, 2,1
+		MultiBrush@146:
+			Template: 146
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.L
+				Points: 1,0, 1,1, 0,1
+		MultiBrush@146reverse:
+			Template: 146
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.U
+				Points: 0,1, 1,1, 1,0
 		MultiBrush@186:
 			Template: 186
 			Segment:

--- a/mods/cnc/tilesets/winter.yaml
+++ b/mods/cnc/tilesets/winter.yaml
@@ -2637,6 +2637,160 @@ MultiBrushCollections:
 				Inner: Road
 				Points: 1,0, 0,0, 0,1, 0,2
 				Start: Road.Out.LD
+		MultiBrush@136:
+			Template: 136
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,2, 1,2, 2,2, 3,2, 4,2, 5,2
+		MultiBrush@136reverse:
+			Template: 136
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 5,2, 4,2, 3,2, 2,2, 1,2, 0,2
+		MultiBrush@137:
+			Template: 137
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,2, 1,2, 2,2, 2,1, 3,1, 4,1, 5,1
+		MultiBrush@137reverse:
+			Template: 137
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 5,1, 4,1, 3,1, 2,1, 2,2, 1,2, 0,2
+		MultiBrush@138:
+			Template: 138
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,1, 1,1, 1,2, 2,2, 3,2, 3,3, 4,3
+		MultiBrush@138reverse:
+			Template: 138
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 4,3, 3,3, 3,2, 2,2, 1,2, 1,1, 0,1
+		MultiBrush@139:
+			Template: 139
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,3, 1,3, 1,2, 2,2, 3,2, 3,1, 4,1
+		MultiBrush@139reverse:
+			Template: 139
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 4,1, 3,1, 3,2, 2,2, 1,2, 1,3, 0,3
+		MultiBrush@140:
+			Template: 140
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 2,0, 2,1, 2,2, 2,3
+		MultiBrush@140reverse:
+			Template: 140
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,3, 2,2, 2,1, 2,0
+		MultiBrush@141:
+			Template: 141
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 2,0, 2,1, 2,2
+		MultiBrush@141reverse:
+			Template: 141
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,2, 2,1, 2,0
+		MultiBrush@142:
+			Template: 142
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 2,0, 2,1, 2,2
+		MultiBrush@142reverse:
+			Template: 142
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,2, 2,1, 2,0
+		MultiBrush@143:
+			Template: 143
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.R
+				Points: 1,2, 1,1, 2,1
+		MultiBrush@143reverse:
+			Template: 143
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.D
+				Points: 2,1, 1,1, 1,2
+		MultiBrush@144:
+			Template: 144
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.D
+				Points: 0,1, 1,1, 1,2
+		MultiBrush@144reverse:
+			Template: 144
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.L
+				Points: 1,2, 1,1, 0,1
+		MultiBrush@145:
+			Template: 145
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.U
+				Points: 2,1, 1,1, 1,0
+		MultiBrush@145reverse:
+			Template: 145
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.R
+				Points: 1,0, 1,1, 2,1
+		MultiBrush@146:
+			Template: 146
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.L
+				Points: 1,0, 1,1, 0,1
+		MultiBrush@146reverse:
+			Template: 146
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.U
+				Points: 0,1, 1,1, 1,0
 		MultiBrush@186:
 			Template: 186
 			Segment:

--- a/mods/ra/tilesets/desert.yaml
+++ b/mods/ra/tilesets/desert.yaml
@@ -3182,6 +3182,258 @@ Templates:
 
 MultiBrushCollections:
 	Segmented:
+		MultiBrush@73:
+			Template: 73
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,1, 1,1
+		MultiBrush@73reverse:
+			Template: 73
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 1,0, 0,0
+		MultiBrush@74:
+			Template: 74
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 0,0, 0,1
+		MultiBrush@74reverse:
+			Template: 74
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 1,1, 1,0
+		MultiBrush@296:
+			Template: 296
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,2, 1,2, 2,2
+		MultiBrush@296reverse:
+			Template: 296
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 2,1, 1,1, 0,1
+		MultiBrush@297:
+			Template: 297
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,2, 1,2
+		MultiBrush@297reverse:
+			Template: 297
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 1,1, 0,1
+		MultiBrush@298:
+			Template: 298
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 1,0, 1,1, 1,2
+		MultiBrush@298reverse:
+			Template: 298
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,2, 2,1, 2,0
+		MultiBrush@299:
+			Template: 299
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 1,0, 1,1
+		MultiBrush@299reverse:
+			Template: 299
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,1, 2,0
+		MultiBrush@60:
+			Template: 60
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,2, 1,2, 2,2, 3,2, 4,2
+		MultiBrush@60reverse:
+			Template: 60
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 4,1, 3,1, 2,1, 1,1, 0,1
+		MultiBrush@61:
+			Template: 61
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,2, 1,2, 2,2, 3,2, 4,2
+		MultiBrush@61reverse:
+			Template: 61
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 4,1, 3,1, 2,1, 1,1, 0,1
+		MultiBrush@62:
+			Template: 62
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,4, 1,4, 2,4, 3,4, 3,3, 4,3, 4,2, 5,2, 6,2
+		MultiBrush@62reverse:
+			Template: 62
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 6,1, 5,1, 4,1, 3,1, 2,1, 2,2, 1,2, 1,3, 0,3
+		MultiBrush@63:
+			Template: 63
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,2, 1,2, 1,3, 2,3, 3,3, 3,4, 4,4, 5,4, 5,5, 6,5
+		MultiBrush@63reverse:
+			Template: 63
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 6,4, 6,3, 5,3, 5,2, 4,2, 4,1, 3,1, 2,1, 1,1, 0,1
+		MultiBrush@64:
+			Template: 64
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 1,0, 1,1, 1,2, 1,3, 1,4
+		MultiBrush@64reverse:
+			Template: 64
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,4, 2,3, 2,2, 2,1, 2,0
+		MultiBrush@65:
+			Template: 65
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 2,0, 2,1, 2,2, 2,3, 2,4
+		MultiBrush@65reverse:
+			Template: 65
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 3,4, 3,3, 3,2, 3,1, 3,0
+		MultiBrush@66:
+			Template: 66
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 4,0, 4,1, 3,1, 3,2, 2,2, 2,3, 2,4, 2,5, 2,6, 1,6, 1,7, 1,8
+		MultiBrush@66reverse:
+			Template: 66
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,8, 2,7, 2,6, 3,6, 3,5, 3,4, 3,3, 4,3, 4,2, 5,2, 5,1, 5,0
+		MultiBrush@67:
+			Template: 67
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 1,0, 1,1, 2,1, 2,2, 2,3, 2,4, 2,5, 3,5, 3,6, 3,7, 4,7, 4,8
+		MultiBrush@67reverse:
+			Template: 67
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 5,8, 5,7, 5,6, 4,6, 4,5, 4,4, 3,4, 3,3, 3,2, 3,1, 2,1, 2,0
+		MultiBrush@69:
+			Template: 69
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.R
+				Points: 2,3, 2,2, 3,2
+		MultiBrush@69reverse:
+			Template: 69
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.D
+				Points: 3,1, 2,1, 1,1, 1,2, 1,3
+		MultiBrush@70:
+			Template: 70
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.D
+				Points: 0,2, 1,2, 1,3
+		MultiBrush@70reverse:
+			Template: 70
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.L
+				Points: 2,3, 2,2, 2,1, 1,1, 0,1
+		MultiBrush@71:
+			Template: 71
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.U
+				Points: 3,1, 2,1, 2,0
+		MultiBrush@71reverse:
+			Template: 71
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.R
+				Points: 1,0, 1,1, 1,2, 2,2, 3,2
+		MultiBrush@72:
+			Template: 72
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.L
+				Points: 1,0, 1,1, 0,1
+		MultiBrush@72reverse:
+			Template: 72
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.U
+				Points: 0,2, 1,2, 2,2, 2,1, 2,0
 		MultiBrush@180:
 			Template: 180
 			Segment:
@@ -3924,6 +4176,279 @@ MultiBrushCollections:
 				Inner: Road
 				Points: 1,0, 0,0, 0,1, 0,2
 				Start: Road.Out.LD
+		MultiBrush@300:
+			Template: 300
+			Segment:
+				Start: WaterCliff.L
+				End: Beach.L
+				Points: 2,1, 1,1, 0,1
+		MultiBrush@301:
+			Template: 301
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 2,2, 1,2, 1,1, 0,1
+		MultiBrush@302:
+			Template: 302
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 2,1, 1,1, 0,1
+		MultiBrush@303:
+			Template: 303
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 2,1, 1,1, 0,1
+		MultiBrush@304:
+			Template: 304
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 2,1, 1,1, 0,1
+		MultiBrush@305:
+			Template: 305
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 2,1, 1,1, 1,2, 0,2
+		MultiBrush@306:
+			Template: 306
+			Segment:
+				Start: Beach.L
+				End: WaterCliff.L
+				Points: 2,1, 1,1, 0,1
+		MultiBrush@307:
+			Template: 307
+			Segment:
+				Start: WaterCliff.U
+				End: Beach.U
+				Points: 1,2, 1,1, 1,0
+		MultiBrush@308:
+			Template: 308
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 2,2, 2,1, 1,1, 1,0
+		MultiBrush@309:
+			Template: 309
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 1,2, 1,1, 1,0
+		MultiBrush@310:
+			Template: 310
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 1,2, 1,1, 1,0
+		MultiBrush@311:
+			Template: 311
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 1,2, 1,1, 1,0
+		MultiBrush@312:
+			Template: 312
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 1,2, 1,1, 2,1, 2,0
+		MultiBrush@313:
+			Template: 313
+			Segment:
+				Start: Beach.U
+				End: WaterCliff.U
+				Points: 1,2, 1,1, 1,0
+		MultiBrush@314:
+			Template: 314
+			Segment:
+				Start: Beach.R
+				End: WaterCliff.R
+				Points: 0,2, 1,2, 1,1, 2,1
+		MultiBrush@315:
+			Template: 315
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 0,1, 1,1, 1,2, 2,2
+		MultiBrush@316:
+			Template: 316
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 0,1, 1,1, 2,1
+		MultiBrush@317:
+			Template: 317
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 0,1, 1,1, 2,1
+		MultiBrush@318:
+			Template: 318
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 0,1, 1,1, 2,1
+		MultiBrush@319:
+			Template: 319
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 0,2, 1,2, 1,1, 2,1
+		MultiBrush@320:
+			Template: 320
+			Segment:
+				Start: WaterCliff.R
+				End: Beach.R
+				Points: 0,1, 0,2, 1,2
+		MultiBrush@321:
+			Template: 321
+			Segment:
+				Start: Beach.D
+				End: WaterCliff.D
+				Points: 1,0, 1,1
+		MultiBrush@322:
+			Template: 322
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 2,0, 2,1, 1,1, 1,2
+		MultiBrush@323:
+			Template: 323
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 1,0, 1,1, 1,2
+		MultiBrush@324:
+			Template: 324
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 1,0, 1,1, 1,2
+		MultiBrush@325:
+			Template: 325
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 1,0, 1,1, 1,2
+		MultiBrush@326:
+			Template: 326
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 1,0, 1,1, 2,1, 2,2
+		MultiBrush@327:
+			Template: 327
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: Beach.D
+				Points: 1,0, 1,1, 1,2
+		MultiBrush@328:
+			Template: 328
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 2,1, 1,1, 1,0
+		MultiBrush@329:
+			Template: 329
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 1,2, 1,1, 2,1
+		MultiBrush@330:
+			Template: 330
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 0,1, 1,1, 1,2
+		MultiBrush@331:
+			Template: 331
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 1,0, 1,1, 0,1
+		MultiBrush@332:
+			Template: 332
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 1,0, 1,1, 2,1
+		MultiBrush@333:
+			Template: 333
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 2,1, 1,1, 1,2
+		MultiBrush@334:
+			Template: 334
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 1,2, 1,1, 0,1
+		MultiBrush@335:
+			Template: 335
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 0,1, 1,1, 1,0
+		MultiBrush@386:
+			Template: 386
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 1,1, 0,1
+		MultiBrush@387:
+			Template: 387
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 0,1, 1,1
+		MultiBrush@388:
+			Template: 388
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 1,1, 1,0
+		MultiBrush@389:
+			Template: 389
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 1,0, 1,1
 		MultiBrush@400:
 			Template: 400
 			Segment:

--- a/mods/ra/tilesets/snow.yaml
+++ b/mods/ra/tilesets/snow.yaml
@@ -3575,6 +3575,405 @@ MultiBrushCollections:
 				Inner: Beach
 				End: Beach.U
 				Points: 0,2, 0,1, 1,1, 1,0
+		MultiBrush@59:
+			Template: 59
+			Segment:
+				Start: WaterCliff.L
+				End: Beach.L
+				Points: 2,1, 1,1, 0,1
+		MultiBrush@60:
+			Template: 60
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 2,2, 1,2, 1,1, 0,1
+		MultiBrush@61:
+			Template: 61
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 2,1, 1,1, 0,1
+		MultiBrush@62:
+			Template: 62
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 2,1, 1,1, 0,1
+		MultiBrush@63:
+			Template: 63
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 2,1, 1,1, 0,1
+		MultiBrush@64:
+			Template: 64
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 2,1, 1,1, 1,2, 0,2
+		MultiBrush@65:
+			Template: 65
+			Segment:
+				Start: Beach.L
+				End: WaterCliff.L
+				Points: 2,1, 1,1, 0,1
+		MultiBrush@66:
+			Template: 66
+			Segment:
+				Start: WaterCliff.U
+				End: Beach.U
+				Points: 1,2, 1,1, 1,0
+		MultiBrush@67:
+			Template: 67
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 2,2, 2,1, 1,1, 1,0
+		MultiBrush@68:
+			Template: 68
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 1,2, 1,1, 1,0
+		MultiBrush@69:
+			Template: 69
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 1,2, 1,1, 1,0
+		MultiBrush@70:
+			Template: 70
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 1,2, 1,1, 1,0
+		MultiBrush@71:
+			Template: 71
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 1,2, 1,1, 2,1, 2,0
+		MultiBrush@72:
+			Template: 72
+			Segment:
+				Start: Beach.U
+				End: WaterCliff.U
+				Points: 1,2, 1,1, 1,0
+		MultiBrush@73:
+			Template: 73
+			Segment:
+				Start: Beach.R
+				End: WaterCliff.R
+				Points: 0,1, 1,1, 2,1
+		MultiBrush@74:
+			Template: 74
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 0,1, 1,1, 1,2, 2,2
+		MultiBrush@75:
+			Template: 75
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 0,1, 1,1, 2,1
+		MultiBrush@76:
+			Template: 76
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 0,1, 1,1, 2,1
+		MultiBrush@77:
+			Template: 77
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 0,1, 1,1, 2,1
+		MultiBrush@78:
+			Template: 78
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 0,2, 1,2, 1,1, 2,1
+		MultiBrush@79:
+			Template: 79
+			Segment:
+				Start: WaterCliff.R
+				End: Beach.R
+				Points: 0,1, 1,1
+		MultiBrush@80:
+			Template: 80
+			Segment:
+				Start: Beach.D
+				End: WaterCliff.D
+				Points: 1,0, 1,1, 1,2
+		MultiBrush@81:
+			Template: 81
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 2,0, 2,1, 1,1, 1,2
+		MultiBrush@82:
+			Template: 82
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 1,0, 1,1, 1,2
+		MultiBrush@83:
+			Template: 83
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 1,0, 1,1, 1,2
+		MultiBrush@84:
+			Template: 84
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 1,0, 1,1, 1,2
+		MultiBrush@85:
+			Template: 85
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 1,0, 1,1, 2,1, 2,2
+		MultiBrush@86:
+			Template: 86
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: Beach.D
+				Points: 1,0, 1,1, 1,2
+		MultiBrush@87:
+			Template: 87
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 2,1, 1,1, 1,0
+		MultiBrush@88:
+			Template: 88
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 1,2, 1,1, 2,1
+		MultiBrush@89:
+			Template: 89
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 0,1, 1,1, 1,2
+		MultiBrush@90:
+			Template: 90
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 1,0, 1,1, 0,1
+		MultiBrush@91:
+			Template: 91
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 1,0, 1,1, 2,1
+		MultiBrush@92:
+			Template: 92
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 2,1, 1,1, 1,2
+		MultiBrush@93:
+			Template: 93
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 1,2, 1,1, 0,1
+		MultiBrush@94:
+			Template: 94
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 0,1, 1,1, 1,0
+		MultiBrush@112:
+			Template: 112
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,2, 1,2, 2,2, 3,2, 4,2, 5,2
+		MultiBrush@112reverse:
+			Template: 112
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 5,2, 4,2, 3,2, 2,2, 1,2, 0,2
+		MultiBrush@113:
+			Template: 113
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,2, 1,2, 2,2, 2,1, 3,1, 4,1, 5,1
+		MultiBrush@113reverse:
+			Template: 113
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 5,1, 4,1, 3,1, 2,1, 2,2, 1,2, 0,2
+		MultiBrush@114:
+			Template: 114
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,1, 1,1, 1,2, 2,2, 3,2, 3,3, 4,3
+		MultiBrush@114reverse:
+			Template: 114
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 4,3, 3,3, 3,2, 2,2, 1,2, 1,1, 0,1
+		MultiBrush@115:
+			Template: 115
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,3, 1,3, 1,2, 2,2, 3,2, 3,1, 4,1
+		MultiBrush@115reverse:
+			Template: 115
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 4,1, 3,1, 3,2, 2,2, 1,2, 1,3, 0,3
+		MultiBrush@116:
+			Template: 116
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 2,0, 2,1, 2,2, 2,3
+		MultiBrush@116reverse:
+			Template: 116
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,3, 2,2, 2,1, 2,0
+		MultiBrush@117:
+			Template: 117
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 2,0, 2,1, 2,2
+		MultiBrush@117reverse:
+			Template: 117
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,2, 2,1, 2,0
+		MultiBrush@118:
+			Template: 118
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 2,0, 2,1, 2,2
+		MultiBrush@118reverse:
+			Template: 118
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,2, 2,1, 2,0
+		MultiBrush@119:
+			Template: 119
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.R
+				Points: 1,2, 1,1, 2,1
+		MultiBrush@119reverse:
+			Template: 119
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.D
+				Points: 2,1, 1,1, 1,2
+		MultiBrush@120:
+			Template: 120
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.D
+				Points: 0,1, 1,1, 1,2
+		MultiBrush@120reverse:
+			Template: 120
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.L
+				Points: 1,2, 1,1, 0,1
+		MultiBrush@121:
+			Template: 121
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.U
+				Points: 2,1, 1,1, 1,0
+		MultiBrush@121reverse:
+			Template: 121
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.R
+				Points: 1,0, 1,1, 2,1
+		MultiBrush@122:
+			Template: 122
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.L
+				Points: 1,0, 1,1, 0,1
+		MultiBrush@122reverse:
+			Template: 122
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.U
+				Points: 0,1, 1,1, 1,0
 		MultiBrush@135:
 			Template: 135
 			Segment:
@@ -4317,6 +4716,34 @@ MultiBrushCollections:
 				Inner: Road
 				Points: 1,0, 0,0
 				Start: Road.Main.L
+		MultiBrush@229:
+			Template: 229
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,1, 1,1
+		MultiBrush@229reverse:
+			Template: 229
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 1,1, 0,1
+		MultiBrush@230:
+			Template: 230
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 1,0, 1,1
+		MultiBrush@230reverse:
+			Template: 230
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 1,1, 1,0
 		MultiBrush@401:
 			Template: 401
 			Segment:
@@ -4345,6 +4772,34 @@ MultiBrushCollections:
 				Inner: Cliff
 				Points: 1,1, 1,0
 				Start: Cliff.U
+		MultiBrush@405:
+			Template: 405
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 1,1, 0,1
+		MultiBrush@406:
+			Template: 406
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 0,1, 1,1
+		MultiBrush@407:
+			Template: 407
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 1,0, 1,1
+		MultiBrush@408:
+			Template: 408
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 1,1, 1,0
 	Trees:
 		MultiBrush@t01:
 			Actor: t01

--- a/mods/ra/tilesets/temperat.yaml
+++ b/mods/ra/tilesets/temperat.yaml
@@ -4035,6 +4035,405 @@ MultiBrushCollections:
 				Inner: Beach
 				End: Beach.U
 				Points: 0,2, 0,1, 1,1, 1,0
+		MultiBrush@59:
+			Template: 59
+			Segment:
+				Start: WaterCliff.L
+				End: Beach.L
+				Points: 2,1, 1,1, 0,1
+		MultiBrush@60:
+			Template: 60
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 2,2, 1,2, 1,1, 0,1
+		MultiBrush@61:
+			Template: 61
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 2,1, 1,1, 0,1
+		MultiBrush@62:
+			Template: 62
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 2,1, 1,1, 0,1
+		MultiBrush@63:
+			Template: 63
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 2,1, 1,1, 0,1
+		MultiBrush@64:
+			Template: 64
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 2,1, 1,1, 1,2, 0,2
+		MultiBrush@65:
+			Template: 65
+			Segment:
+				Start: Beach.L
+				End: WaterCliff.L
+				Points: 2,1, 1,1, 0,1
+		MultiBrush@66:
+			Template: 66
+			Segment:
+				Start: WaterCliff.U
+				End: Beach.U
+				Points: 1,2, 1,1, 1,0
+		MultiBrush@67:
+			Template: 67
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 2,2, 2,1, 1,1, 1,0
+		MultiBrush@68:
+			Template: 68
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 1,2, 1,1, 1,0
+		MultiBrush@69:
+			Template: 69
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 1,2, 1,1, 1,0
+		MultiBrush@70:
+			Template: 70
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 1,2, 1,1, 1,0
+		MultiBrush@71:
+			Template: 71
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 1,2, 1,1, 2,1, 2,0
+		MultiBrush@72:
+			Template: 72
+			Segment:
+				Start: Beach.U
+				End: WaterCliff.U
+				Points: 1,2, 1,1, 1,0
+		MultiBrush@73:
+			Template: 73
+			Segment:
+				Start: Beach.R
+				End: WaterCliff.R
+				Points: 0,1, 1,1, 2,1
+		MultiBrush@74:
+			Template: 74
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 0,1, 1,1, 1,2, 2,2
+		MultiBrush@75:
+			Template: 75
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 0,1, 1,1, 2,1
+		MultiBrush@76:
+			Template: 76
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 0,1, 1,1, 2,1
+		MultiBrush@77:
+			Template: 77
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 0,1, 1,1, 2,1
+		MultiBrush@78:
+			Template: 78
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 0,2, 1,2, 1,1, 2,1
+		MultiBrush@79:
+			Template: 79
+			Segment:
+				Start: WaterCliff.R
+				End: Beach.R
+				Points: 0,1, 1,1
+		MultiBrush@80:
+			Template: 80
+			Segment:
+				Start: Beach.D
+				End: WaterCliff.D
+				Points: 1,0, 1,1, 1,2
+		MultiBrush@81:
+			Template: 81
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 2,0, 2,1, 1,1, 1,2
+		MultiBrush@82:
+			Template: 82
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 1,0, 1,1, 1,2
+		MultiBrush@83:
+			Template: 83
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 1,0, 1,1, 1,2
+		MultiBrush@84:
+			Template: 84
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 1,0, 1,1, 1,2
+		MultiBrush@85:
+			Template: 85
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 1,0, 1,1, 2,1, 2,2
+		MultiBrush@86:
+			Template: 86
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: Beach.D
+				Points: 1,0, 1,1, 1,2
+		MultiBrush@87:
+			Template: 87
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 2,1, 1,1, 1,0
+		MultiBrush@88:
+			Template: 88
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 1,2, 1,1, 2,1
+		MultiBrush@89:
+			Template: 89
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 0,1, 1,1, 1,2
+		MultiBrush@90:
+			Template: 90
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 1,0, 1,1, 0,1
+		MultiBrush@91:
+			Template: 91
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 1,0, 1,1, 2,1
+		MultiBrush@92:
+			Template: 92
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 2,1, 1,1, 1,2
+		MultiBrush@93:
+			Template: 93
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 1,2, 1,1, 0,1
+		MultiBrush@94:
+			Template: 94
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 0,1, 1,1, 1,0
+		MultiBrush@112:
+			Template: 112
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,2, 1,2, 2,2, 3,2, 4,2, 5,2
+		MultiBrush@112reverse:
+			Template: 112
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 5,2, 4,2, 3,2, 2,2, 1,2, 0,2
+		MultiBrush@113:
+			Template: 113
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,2, 1,2, 2,2, 2,1, 3,1, 4,1, 5,1
+		MultiBrush@113reverse:
+			Template: 113
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 5,1, 4,1, 3,1, 2,1, 2,2, 1,2, 0,2
+		MultiBrush@114:
+			Template: 114
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,1, 1,1, 1,2, 2,2, 3,2, 3,3, 4,3
+		MultiBrush@114reverse:
+			Template: 114
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 4,3, 3,3, 3,2, 2,2, 1,2, 1,1, 0,1
+		MultiBrush@115:
+			Template: 115
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,3, 1,3, 1,2, 2,2, 3,2, 3,1, 4,1
+		MultiBrush@115reverse:
+			Template: 115
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 4,1, 3,1, 3,2, 2,2, 1,2, 1,3, 0,3
+		MultiBrush@116:
+			Template: 116
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 2,0, 2,1, 2,2, 2,3
+		MultiBrush@116reverse:
+			Template: 116
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,3, 2,2, 2,1, 2,0
+		MultiBrush@117:
+			Template: 117
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 2,0, 2,1, 2,2
+		MultiBrush@117reverse:
+			Template: 117
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,2, 2,1, 2,0
+		MultiBrush@118:
+			Template: 118
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 2,0, 2,1, 2,2
+		MultiBrush@118reverse:
+			Template: 118
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 2,2, 2,1, 2,0
+		MultiBrush@119:
+			Template: 119
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.R
+				Points: 1,2, 1,1, 2,1
+		MultiBrush@119reverse:
+			Template: 119
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.D
+				Points: 2,1, 1,1, 1,2
+		MultiBrush@120:
+			Template: 120
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.D
+				Points: 0,1, 1,1, 1,2
+		MultiBrush@120reverse:
+			Template: 120
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.L
+				Points: 1,2, 1,1, 0,1
+		MultiBrush@121:
+			Template: 121
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.U
+				Points: 2,1, 1,1, 1,0
+		MultiBrush@121reverse:
+			Template: 121
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.R
+				Points: 1,0, 1,1, 2,1
+		MultiBrush@122:
+			Template: 122
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.L
+				Points: 1,0, 1,1, 0,1
+		MultiBrush@122reverse:
+			Template: 122
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.U
+				Points: 0,1, 1,1, 1,0
 		MultiBrush@135:
 			Template: 135
 			Segment:
@@ -4777,6 +5176,34 @@ MultiBrushCollections:
 				Inner: Road
 				Points: 1,0, 0,0
 				Start: Road.Main.L
+		MultiBrush@229:
+			Template: 229
+			Segment:
+				Start: River.R
+				Inner: River
+				End: River.R
+				Points: 0,1, 1,1
+		MultiBrush@229reverse:
+			Template: 229
+			Segment:
+				Start: River.L
+				Inner: River
+				End: River.L
+				Points: 1,1, 0,1
+		MultiBrush@230:
+			Template: 230
+			Segment:
+				Start: River.D
+				Inner: River
+				End: River.D
+				Points: 1,0, 1,1
+		MultiBrush@230reverse:
+			Template: 230
+			Segment:
+				Start: River.U
+				Inner: River
+				End: River.U
+				Points: 1,1, 1,0
 		MultiBrush@401:
 			Template: 401
 			Segment:
@@ -4805,6 +5232,34 @@ MultiBrushCollections:
 				Inner: Cliff
 				Points: 1,1, 1,0
 				Start: Cliff.U
+		MultiBrush@405:
+			Template: 405
+			Segment:
+				Start: WaterCliff.L
+				Inner: WaterCliff
+				End: WaterCliff.L
+				Points: 1,1, 0,1
+		MultiBrush@406:
+			Template: 406
+			Segment:
+				Start: WaterCliff.R
+				Inner: WaterCliff
+				End: WaterCliff.R
+				Points: 0,1, 1,1
+		MultiBrush@407:
+			Template: 407
+			Segment:
+				Start: WaterCliff.D
+				Inner: WaterCliff
+				End: WaterCliff.D
+				Points: 1,0, 1,1
+		MultiBrush@408:
+			Template: 408
+			Segment:
+				Start: WaterCliff.U
+				Inner: WaterCliff
+				End: WaterCliff.U
+				Points: 1,1, 1,0
 	Trees:
 		MultiBrush@t01:
 			Actor: t01


### PR DESCRIPTION
Adds MultiBrush definitions for River (RA and CnC) and WaterCliff (RA only), allowing them to be tiled with the Path Tiling tool.

A small enhancement to the MultiBrush and TilingPathTool code is added to allow the inner type to be derived from start and end types. This allows segments that interface between types (such as WaterCliff to Beach) to be usable when tiling either WaterCliffs or Beach. Whilst this makes the inner types of many of the existing MultiBrushes redundant, no simplification is performed as part of this change.
