### PR TITLE
Improve --check-yaml robustness against bogus maps.

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -100,8 +100,15 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					if (package == null)
 						continue;
 
-					using (var testMap = new Map(modData, package))
-						TestMap(testMap, modData);
+					try
+					{
+						using (var testMap = new Map(modData, package))
+							TestMap(testMap, modData);
+					}
+					catch (Exception e)
+					{
+						EmitError($"Failed to load map {map.Map} with exception: {e}");
+					}
 				}
 
 				if (errors > 0)


### PR DESCRIPTION
Testcase: run `--check-yaml` on TD while having a stray jungle map in the system maps directory.

bleed behaviour: Utility crashes without reporting which map has the error
PR behaviour: Utility reports that the map is invalid and continues