### PR TITLE
Add IsDead checks to Fall of Greece 1

### DIFF
--- a/mods/ra/maps/fall-of-greece-1-personal-war/personal-war.lua
+++ b/mods/ra/maps/fall-of-greece-1-personal-war/personal-war.lua
@@ -313,8 +313,12 @@ FootprintTriggers = function()
 				trig9camera.Destroy()
 			end)
 
-			Utils.Do(BridgeMammoths, function(actor)
-				actor.AttackMove(MammysGo.Location)
+			Utils.Do(BridgeMammoths, function(mammoth)
+				if mammoth.IsDead then
+					return
+				end
+
+				mammoth.AttackMove(MammysGo.Location)
 			end)
 		end
 	end)
@@ -333,6 +337,10 @@ FootprintTriggers = function()
 			Media.PlaySpeechNotification(Allies, "SignalFlareNorth")
 			Actor.Create("camera", true, { Owner = Allies, Location = ExtractionPoint.Location })
 			SendExtractionHelicopter()
+
+			if HealCrateTruck.IsDead then
+				return
+			end
 
 			HealCrateTruck.Move(TruckGo.Location)
 		end


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/issues/21921, where dead tanks are given orders that prompt a crash.

Most starting units with scripted orders have an IsDead check. This adds a missing check to two tanks, along with a check for the supply truck near the western edge.