### PR TITLE
Respect MultiBrush weights when path tiling

### DIFF
--- a/OpenRA.Mods.Common/MapGenerator/TilingPath.cs
+++ b/OpenRA.Mods.Common/MapGenerator/TilingPath.cs
@@ -803,7 +803,10 @@ namespace OpenRA.Mods.Common.MapGenerator
 				}
 
 				Debug.Assert(candidates.Count >= 1, "TraceBack didn't find an original route");
-				var chosenSegment = candidates[random.Next(candidates.Count)];
+				var weights = candidates
+					.Select(c => c.MultiBrush.Weight)
+					.ToArray();
+				var chosenSegment = candidates[random.PickWeighted(weights)];
 				var chosenFrom = to - chosenSegment.Moves;
 				compositeBrush.MergeFrom(
 					chosenSegment.MultiBrush,


### PR DESCRIPTION
Allows biasing path tiling towards or away from using certain MultiBrushes using their existing weight property. Note that the probability of brush selection depends on multiple factors, not just their direct weight.
