### PR TITLE
Fix Path Tiling tool rally confusion and crash

### DIFF
--- a/OpenRA.Mods.Common/EditorBrushes/EditorTilingPathBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorTilingPathBrush.cs
@@ -106,10 +106,12 @@ namespace OpenRA.Mods.Common.Widgets
 				var isInside = points.Select(p => p.CPos).Contains(cpos);
 				var isRally = plan.Rallies.Contains(cpos);
 				var rallyIndex =
-					points
-						.Where(p => p.CPos == cpos)
-						.Select(p => p.RallyIndex)
-						.FirstOrDefault(0);
+					isRally
+						? plan.Rallies.TakeWhile(r => r != cpos).Count()
+						: points
+							.Where(p => p.CPos == cpos)
+							.Select(p => p.RallyIndex)
+							.FirstOrDefault(0);
 				var isStartDirector =
 					plan.AutoStart != Direction.None
 						&& cpos == plan.FirstPoint - Direction.ToCVec(plan.AutoStart);


### PR DESCRIPTION
If the path being planned by the Path Tiling tool overlaps itself such that a later rally intersects an earlier line, attempting to interact with this later rally caused the UI to instead select the rally associated with the earlier line. This at best leads to user confusion and at worst leads to a crash if they then drag the rally over another rally.

This commit fixes the UI logic to correctly identify the rally being clicked on.
