### PR TITLE
D2k balance patch 2025

### DIFF
--- a/mods/d2k/fluent/rules.ftl
+++ b/mods/d2k/fluent/rules.ftl
@@ -30,6 +30,7 @@ options-starting-units =
     .mcv-only = MCV Only
     .light-support = Light Support
     .heavy-support = Heavy Support
+    .carryall = MCV + Carryall
 
 resource-spice = Spice
 

--- a/mods/d2k/fluent/rules.ftl
+++ b/mods/d2k/fluent/rules.ftl
@@ -176,6 +176,13 @@ actor-light-inf =
 
     Light Infantry are resistant to missiles and large-caliber guns, but are very vulnerable to high-explosives, fire, and small arms.
 
+    Summary:
+
+        - Explosion Radius: Small
+        - Vision: Very small
+        - Strong vs  Light Infantry, Trooper, Missile tank, Deviator
+        - Weak vs Combat tank, Siege tank, Grenadier, Trike, Sonic Tank
+
 actor-engineer =
     .name = Engineer
     .description =
@@ -189,6 +196,8 @@ actor-engineer =
 
     Engineers are resistant to anti-tank weaponry but are very vulnerable to high-explosives, fire, and small arms.
 
+    Engineer can reactivate destoryed husk to barely functional state. This allow send husk to nearest repair pad for full repair.
+
 actor-trooper =
     .name = Trooper
     .description =
@@ -199,6 +208,13 @@ actor-trooper =
     Armed with wire-guided, armor-piercing missile warheads, Troopers are very effective against vehicles and buildings but struggle against infantry.
 
     Troopers are resistant to anti-tank weaponry but very vulnerable to high-explosives, fire and bullet weapons.
+
+    Summary:
+
+        - Explosion Radius: Medium
+        - Vision: Small
+        - Strong vs  Combat tank, Missile tank, Quad, Trike, Deviator, Buildings, Defenses
+        - Weak vs Siege tank, Light Infantry, Grenadier, Sonic Tank
 
 actor-thumper =
     .name = Thumper Infantry
@@ -220,6 +236,13 @@ actor-fremen =
 
     Fremen units are very vulnerable to high-explosive and bullet weapons.
 
+    Summary:
+
+        - Explosion Radius: Medium
+        - Vision: Small
+        - Strong vs  Quad, Trike, Missile tank, Combat tank, Devastator Buildings, Defenses
+        - Weak vs Siege tank, Light Infantry, Grenadier, Sonic Tank
+
 actor-grenadier =
     .name = Grenadier
     .description =
@@ -229,6 +252,13 @@ actor-grenadier =
     .encyclopedia =
     An infantry artillery unit strong against buildings. They have a chance of exploding when killed, so should not be grouped together.
 
+    Summary:
+
+        - Explosion Radius: Large
+        - Vision: Small
+        - Strong vs  Light Infantry, Trike, Missile tank, Combat tank, Buildings, Defenses
+        - Weak vs Siege tank, Combat tank, Sonic Tank, Devastator
+
 actor-sardaukar =
     .name = Sardaukar
     .description =
@@ -236,7 +266,14 @@ actor-sardaukar =
       Strong vs Infantry and Vehicles
       Weak vs Artillery
     .encyclopedia =
-    Powerful heavy troopers equipped with a machine gun that is effective against infantry and a rocket launcher for targeting vehicles.
+    Powerful heavy troopers equipped with a machine gun that is effective against infantry and a rocket launcher for targeting vehicles. When crushed Unit Explode and damage vehicle above him.
+
+    Summary:
+
+        - Explosion Radius: Large
+        - Vision: Small
+        - Strong vs  Trike, Quad, Missile tank, Combat tank, Buildings, Defenses
+        - Weak vs Siege tank, Sonic Tank, Grenadier, Tank Crush
 
 actor-mpsardaukar-description =
     Elite Harkonnen assault infantry.
@@ -252,7 +289,7 @@ actor-saboteur =
       Weak vs Everything
       Special Ability: Destroys buildings
     .encyclopedia =
-    A specialized military unit of House Ordos, capable of demolishing enemy buildings upon entry, but dying in the resulting explosion. It can activate stealth mode to become invisible.
+    A specialized military unit of House Ordos, capable of demolishing enemy buildings and vehicles upon entry, but dying in the resulting explosion. It can activate self destruction and damage near by enemy units.
 
     The Saboteur is resistant to anti-tank weaponry, but very vulnerable to high-explosives, fire, and bullet weapons.
 
@@ -413,6 +450,7 @@ actor-outpost =
     .description =
     Provides a radar map of the battlefield.
     Requires power to operate.
+    Detects stealth units.
     .encyclopedia =
     Once enough power is available, the Radar Outpost activates, providing a radar map.
 
@@ -438,21 +476,22 @@ actor-wall =
 actor-medium-gun-turret =
     .name = Gun Turret
     .description =
-    Defensive structure.
-      Strong vs Tanks
-      Weak vs Infantry and Aircraft
+    Defensive structure. Detects stealth units.
+      Strong vs Light vehicles
+      Medium vs Infantry
+      Weak vs Tanks and Aircraft
     .encyclopedia =
     A medium-range weapon that is effective against all types of vehicle, particularly heavily armored ones. It automatically fires upon any enemy unit within its range and requires power to operate.
 
-    The Gun Turret is resistant to small arms and explosive weapons, but vulnerable to missiles and high-caliber guns.
+    The Gun Turret is resistant to small arms and explosive weapons, but vulnerable to missiles and heavy explosives.
 
 actor-large-gun-turret =
     .name = Rocket Turret
     .description =
-    Defensive structure.
+    Defensive structure. Detects stealth units.
     Requires power to operate.
-      Strong vs Infantry and Aircraft
-      Weak vs Tanks
+      Strong vs Tanks, Aircraft, Moving targets
+      Weak vs Infantry
     .encyclopedia =
     An enhanced defensive structure with a longer range and faster rate of fire than the Gun Turret. Its advanced targeting system requires power to operate.
 
@@ -539,6 +578,15 @@ actor-trike =
 
     Trikes are vulnerable to most weapons, high-caliber guns are slightly less effective against them.
 
+    Summary:
+
+        - Explosion Radius: Small
+        - Vision: Medium
+        - Strong vs  Light Infantry, Trooper, Missile tank, Deviator
+        - Weak vs Combat tank, Siege tank, Grenadier, Sardaukars
+
+    Tip: Trike have 0.5 range advantage against light infantry. Move them back as soon as light infantry come too close.
+
 actor-quad =
     .name = Missile Quad
     .description =
@@ -549,6 +597,15 @@ actor-quad =
     Superior to the Trike in both armor and firepower, the Quad is a four-wheeled vehicle firing armor-piercing rockets. It is effective against most vehicles.
 
     Quads are resistant to bullets and, to a lesser degree, explosives. They are vulnerable to missiles and high-caliber guns.
+
+    Summary:
+
+        - Explosion Radius: Medium
+        - Vision: Medium
+        - Strong vs  Siege tanks, Sonic Tanks, Buildings.
+        - Weak vs Combat tanks, Troopers, Missile tanks
+
+    Tip: Quad Has big inaccuracy against moving targets. Get as close to the target as possible to get maximum damage.
 
 actor-siege-tank =
     .name = Siege Tank
@@ -561,6 +618,17 @@ actor-siege-tank =
 
     Siege Tanks are resistant to bullets, and to some degree, explosives. They are vulnerable to missiles and high-caliber guns.
 
+    Big loads of high explosive shells are reason of big explosion after vehicle is destroyed
+
+    Summary:
+
+        - Explosion Radius: Large
+        - Vision: Large
+        - Strong vs any Infantry, Trike, Deviator
+        - Weak vs Combat tank, Quad, Missile tank
+
+    Tip: Siege tank can shoot beyound they vision range.
+
 actor-missile-tank =
     .name = Missile Tank
     .description =
@@ -571,6 +639,16 @@ actor-missile-tank =
     Shoots down aircraft and is effective against most targets, except infantry.
 
     Missile Tanks are vulnerable to most weapons, high-caliber guns are slightly less effective.
+
+    Summary:
+
+        - Explosion Radius: Medium
+        - Vision: Large
+        - Strong vs Combat tank, Devastator, Quad
+        - Weak vs any Infantry type, Trike, Stealth Raider
+
+    Tip: Missile tank can shoot beyond they vision range.
+
 
 actor-sonic-tank =
     .name = Sonic Tank
@@ -585,6 +663,15 @@ actor-sonic-tank =
 
     Resistant to bullets and small-explosives, but vulnerable to missiles and high-caliber guns.
 
+    Summary:
+
+        - Explosion Radius: Very large
+        - Vision: Medium
+        - Strong: any Infantry, Siege tank, Missile tank, Deviator
+        - Weak vs Combat tank, Quad, Devastator
+
+    Tip: Sonic wave strength increase with range. Try shoot at maximum range to get maximum damage.
+
 actor-devastator =
     .name = Devastator
     .description =
@@ -596,6 +683,15 @@ actor-devastator =
 
     Resistant to bullets and high explosives, but vulnerable to missiles and high-caliber guns.
 
+    Summary:
+
+        - Explosion Radius: Large
+        - Vision: Medium
+        - Strong: Combat tank, Siege tank, Light infantry, Sonic Tank
+        - Weak vs Troopers, Missile tank, Deviator
+
+    Tip: Devastator is vulnerable against lots of Troopers. Use selfdestruct instead.
+
 actor-raider =
     .name = Raider Trike
     .description =
@@ -605,7 +701,14 @@ actor-raider =
     .encyclopedia =
     Raider Trikes, upgraded by House Ordos, have enhanced firepower, speed, and armor. Equipped with dual 20mm cannons, they are strong against infantry and lightly armored vehicles.
 
-    Raiders are vulnerable to most weapons, though high-caliber guns are slightly less effective against them.
+    Raiders are vulnerable to most weapons, though high-caliber guns (combat tanks) are slightly less effective against them.
+
+    Summary:
+
+        - Explosion Radius: small
+        - Vision: small
+        - Strong vs  Light Infantry, Trooper, Missile tank, Deviator, Trike
+        - Weak vs Combat tank, Siege tank, Grenadier, Sardaukars, Quad
 
 actor-stealth-raider =
     .name = Stealth Raider Trike
@@ -615,6 +718,15 @@ actor-stealth-raider =
       Weak vs Tanks
     .encyclopedia =
     A cloaked version of the Raider, good for stealth attacks. It uncloaks when it fires its machine guns.
+
+    Summary:
+
+        - Explosion Radius: Small
+        - Vision: Small
+        - Strong vs  Light Infantry, Trooper, Missile tank, Deviator, Trike
+        - Weak vs Combat tank, Siege tank, Grenadier, Sardaukars
+
+    Tip: Siege and Missile tanks can shoot beyound they vision. Use Stealth raider to extend they vision so they can shoot at maximum range.
 
 actor-deviator =
     .name = Deviator
@@ -626,6 +738,16 @@ actor-deviator =
 
     The Deviator is vulnerable to most weapons, high-caliber guns are slightly less effective.
 
+    Summary:
+
+        - Explosion Radius: Small
+        - Vision: Large
+        - Strong vs Combat tank,  Quad, Devastator, Missile tank
+        - Weak vs any infantry, Missile tank, Sonic Tank, Trike
+
+    Tip: Deviator reload time is very long. You Hold fire for some Deviators in your mix to always have missile ready when opportunity rise.
+
+
 meta-combat-tank-description =
     Main Battle Tank.
       Strong vs Tanks
@@ -636,21 +758,48 @@ actor-combat-tank-a =
     .encyclopedia =
     Effective against most vehicles but less suited against lightly armored targets.
 
-    Resistant to bullets and heavy explosives, but vulnerable to missiles and high-caliber guns.
+    Resistant to bullets and heavy explosives, but vulnerable to missiles and high-caliber guns. Atreides Combat Tank is good compromise between mobility and Armor with slight range advantage.
+
+    Summary:
+
+        - Explosion Radius: medium
+        - Vision: Medium
+        - Strong vs Combat tank, Siege tank, Quad, Sonic Tank
+        - Weak vs Trooper, Missile tank, Devastator, Deviator
+
+    Atreides tank bonus: better range
 
 actor-combat-tank-h =
     .name = Harkonnen Combat Tank
     .encyclopedia =
     Effective against most vehicles but less suited against lightly armored targets.
 
-    Stronger than its counterparts, but also slower.
+    Stronger than its counterparts, but also slower and with lower rate of fire.
+
+    Summary:
+
+        - Explosion Radius: medium
+        - Vision: Medium
+        - Strong vs Combat tank, Siege tank, Quad, Sonic Tank
+        - Weak vs Trooper, Missile tank, Devastator, Deviator
+
+    Harkonnen tank bonus: Stronger Armor
 
 actor-combat-tank-o =
     .name = Ordos Combat Tank
     .encyclopedia =
     Effective against most vehicles but less suited against lightly armored targets.
 
-    The fastest variant of Combat Tank, but also the weakest.
+    The fastest variant of Combat Tank, but also the weakest. Best rate of fire than its counterparts.
+
+    Summary:
+
+        - Explosion Radius: medium
+        - Vision: Medium
+        - Strong vs Combat tank, Siege tank, Quad, Sonic Tank
+        - Weak vs Trooper, Missile tank, Devastator, Deviator
+
+    Ordos tank bonus: rate of fire
 
 meta-destroyabletile =
     .generic-name = Passage (destroyable)

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -25,7 +25,7 @@ Player:
 		Decisions:
 			Airstrike:
 				OrderName: AirstrikePowerInfoOrder
-				MinimumAttractiveness: 2000
+				MinimumAttractiveness: 2500
 				Consideration@1:
 					Against: Enemy
 					Types: Vehicle, Tank, Infantry
@@ -34,25 +34,37 @@ Player:
 					CheckRadius: 3c0
 				Consideration@2:
 					Against: Enemy
-					Types: Structure
+					Types: Structure, Defense
 					Attractiveness: 1
 					TargetMetric: Value
-					CheckRadius: 2c0
+					CheckRadius: 5c0
 				Consideration@3:
 					Against: Ally
 					Types: Ground
 					Attractiveness: -10
 					TargetMetric: Value
 					CheckRadius: 4c0
+				Consideration@4:
+					Against: Enemy
+					Types: Defense
+					Attractiveness: 6
+					TargetMetric: Value
+					CheckRadius: 4c0
 			NukePower:
 				OrderName: NukePowerInfoOrder
-				MinimumAttractiveness: 3000
+				MinimumAttractiveness: 3500
 				Consideration@1:
 					Against: Enemy
-					Types: Structure
-					Attractiveness: 1
+					Types: Structure, Defense
+					Attractiveness: 10
 					TargetMetric: Value
 					CheckRadius: 5c0
+				Consideration@3:
+					Against: Enemy
+					Types: Infantry, Vehicle, Tank, Defense
+					Attractiveness: 5
+					TargetMetric: Value
+					CheckRadius: 4c0
 				Consideration@2:
 					Against: Ally
 					Types: Air, Ground
@@ -70,8 +82,8 @@ Player:
 	BaseBuilderBotModule@omnius:
 		RequiresCondition: enable-omnius-ai
 		BuildingQueues: Building, Upgrade
-		MinimumExcessPower: 50
-		MaximumExcessPower: 200
+		MinimumExcessPower: 60
+		MaximumExcessPower: 250
 		ExcessPowerIncrement: 50
 		ExcessPowerIncreaseThreshold: 4
 		MaxBaseRadius: 40
@@ -129,8 +141,8 @@ Player:
 	BaseBuilderBotModule@vidious:
 		RequiresCondition: enable-vidious-ai
 		BuildingQueues: Building, Upgrade
-		MinimumExcessPower: 50
-		MaximumExcessPower: 200
+		MinimumExcessPower: 60
+		MaximumExcessPower: 250
 		ExcessPowerIncrement: 50
 		ExcessPowerIncreaseThreshold: 4
 		MaxBaseRadius: 40
@@ -186,8 +198,8 @@ Player:
 	BaseBuilderBotModule@gladius:
 		RequiresCondition: enable-gladius-ai
 		BuildingQueues: Building, Upgrade
-		MinimumExcessPower: 50
-		MaximumExcessPower: 200
+		MinimumExcessPower: 60
+		MaximumExcessPower: 250
 		ExcessPowerIncrement: 50
 		ExcessPowerIncreaseThreshold: 4
 		MaxBaseRadius: 40

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -1,19 +1,19 @@
 carryall.reinforce:
 	Inherits: ^Plane
 	Valued:
-		Cost: 1100
+		Cost: 1000
 	UpdatesPlayerStatistics:
 		AddToAssetsValue: false
 	Tooltip:
 		Name: actor-carryall-reinforce.name
 	Health:
-		HP: 48000
+		HP: 20000
 	Armor:
 		Type: light
 	Aircraft:
 		CruiseAltitude: 2160
 		CruisingCondition: cruising
-		Speed: 144
+		Speed: 170
 		TurnSpeed: 16
 		LandableTerrainTypes: Sand, Rock, Transition, Spice, SpiceSand, Dune, Concrete
 		Repulsable: False
@@ -21,7 +21,8 @@ carryall.reinforce:
 		CanForceLand: false
 		CanSlide: True
 		VTOL: true
-		IdleTurnSpeed: 4
+		IdleTurnSpeed: 5
+		IdleSpeed: 115
 	Targetable@GROUND:
 		TargetTypes: Ground, Vehicle
 		RequiresCondition: !airborne
@@ -108,7 +109,7 @@ ornithopter:
 	Armament:
 		Weapon: OrniBomb
 	Health:
-		HP: 9000
+		HP: 8000
 	Armor:
 		Type: light
 	Encyclopedia:
@@ -129,7 +130,6 @@ ornithopter:
 	SpawnActorOnDeath:
 		Actor: ornithopter.husk
 	RejectsOrders:
-	RevealOnFire:
 	-MapEditorData:
 
 ornithopter.husk:
@@ -141,6 +141,16 @@ ornithopter.husk:
 		Speed: 224
 	RenderSprites:
 		Image: ornithopter
+	FallsToEarth:
+		MaximumSpinSpeed: 1
+	FireProjectilesOnDeath@derbisshort:
+		Weapons: Debris, Debris2
+		Pieces: 1, 3
+		Range: 1c0, 2c512
+	FireProjectilesOnDeath@derbislong:
+		Weapons: Debris, Debris2, Debris3, Debris4
+		Pieces: 2, 4
+		Range: 3c0, 6c0
 
 carryall.husk:
 	Inherits: ^AircraftHusk
@@ -153,6 +163,14 @@ carryall.husk:
 		VTOL: true
 	RenderSprites:
 		Image: carryall
+	FireProjectilesOnDeath@derbisshort:
+		Weapons: Debris, Debris2
+		Pieces: 1, 3
+		Range: 1c0, 2c512
+	FireProjectilesOnDeath@derbislong:
+		Weapons: Debris, Debris2, Debris3, Debris4
+		Pieces: 2, 4
+		Range: 3c0, 6c0
 
 carryall.huskVTOL:
 	Inherits: ^AircraftHusk
@@ -167,3 +185,11 @@ carryall.huskVTOL:
 		VTOL: true
 	RenderSprites:
 		Image: carryall
+	FireProjectilesOnDeath@derbisshort:
+		Weapons: Debris, Debris2
+		Pieces: 1, 3
+		Range: 1c0, 2c512
+	FireProjectilesOnDeath@derbislong:
+		Weapons: Debris, Debris2, Debris3, Debris4
+		Pieces: 2, 4
+		Range: 3c0, 6c0

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -156,6 +156,7 @@ sietch:
 	-WithMakeAnimation:
 	-WithCrumbleOverlay:
 	-WithBuildingRepairDecoration:
+	-FireWarheadsOnDeath@sabotuerDemolition:
 
 pass01_destroyable_bottom:
 	Inherits: ^DestroyableTile

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -222,8 +222,14 @@
 		PauseOnCondition: notmobile
 	Selectable:
 		Bounds: 1024, 1024
+	ExternalCondition@deviatorInfluence:
+		Condition: unit-captured
 	Targetable:
 		TargetTypes: Ground, Vehicle, C4
+		RequiresCondition: !unit-captured
+	Targetable@CAPTURED:
+		TargetTypes: Ground, CapturedUnit
+		RequiresCondition: unit-captured
 	Passenger:
 		CargoType: Vehicle
 	AttackMove:
@@ -241,6 +247,16 @@
 	AmbientSound@onBeingDemolished:
 		SoundFiles: O_SCONF2.AUD
 		RequiresCondition: being-demolished
+	FireWarheadsOnDeath@sabotuerDemolition:
+		RequiresCondition: being-demolished
+		Type: CenterPosition
+		Weapon: PlasmaSaboteur
+		EmptyWeapon: PlasmaSaboteur
+	FireProjectilesOnDeath@OnsabotuerDemolition:
+		Weapons: Debris2, Debris3, Debris4, ExplosiveDebris
+		Pieces: 3, 7
+		Range: 3c512, 6c0
+		RequiresCondition: being-demolished
 	TemporaryOwnerManager:
 	MustBeDestroyed:
 	Voiced:
@@ -254,7 +270,6 @@
 		Margin: 7, 9
 		Sequence: pickup-indicator
 		RequiresCondition: carryall-reserved
-	RevealOnFire:
 	RevealOnDeath:
 		Duration: 100
 		Radius: 2c512
@@ -285,12 +300,16 @@
 	Inherits: ^Vehicle
 	Mobile:
 		Locomotor: tank
+	GrantConditionOnDamageState@HEAVY:
+		ValidDamageStates: Critical
+	SpawnActorOnDeath:
+		RequiresCondition: !being-demolished
 
 ^Husk:
 	Inherits@1: ^SpriteActor
 	Interactable:
 	Health:
-		HP: 10000
+		HP: 8000
 	Armor:
 		Type: light
 	HiddenUnderFog:
@@ -340,16 +359,16 @@
 		Duration: 1500
 		RequiresCondition: decoration2 || decoration3
 	ChangesHealth:
-		Step: -30
+		Step: -27
 		StartIfBelow: 101
 		Delay: 4
 	GrantRandomCondition:
 		Conditions: decoration1, decoration2, decoration3
 	TransformOnCapture:
-		ForceHealthPercentage: 20
+		ForceHealthPercentage: 5
 	InfiltrateForTransform:
 		Types: Husk
-		ForceHealthPercentage: 20
+		ForceHealthPercentage: 5
 
 ^AircraftHusk:
 	Inherits: ^Husk
@@ -359,7 +378,7 @@
 	FallsToEarth:
 		MaximumSpinSpeed: 0
 		Moves: True
-		Explosion: UnitExplodeLarge
+		Explosion: ExplosionAircraft
 	-MapEditorData:
 
 ^Infantry:
@@ -396,7 +415,7 @@
 		IdleSequences: idle1, idle2
 	TakeCover:
 		DamageModifiers:
-			Prone50Percent: 50
+			Prone80Percent: 80
 		DamageTriggers: TriggerProne
 		ProneOffset: 300,0,0
 	WithDeathAnimation:
@@ -427,7 +446,6 @@
 			Rough: 80
 	Voiced:
 		VoiceSet: InfantryVoice
-	RevealOnFire:
 	RevealOnDeath:
 		Duration: 100
 	HitShape:
@@ -527,6 +545,11 @@
 	AmbientSound@onBeingDemolished:
 		SoundFiles: O_SCONF2.AUD
 		RequiresCondition: being-demolished
+	FireWarheadsOnDeath@sabotuerDemolition:
+		RequiresCondition: being-demolished
+		Type: CenterPosition
+		Weapon: PlasmaSaboteur
+		EmptyWeapon: PlasmaSaboteur
 	Sellable:
 		RequiresCondition: !build-incomplete && !being-demolished
 		SellSounds: BUILD1.WAV
@@ -564,7 +587,7 @@
 		PauseOnCondition: build-incomplete
 	RenderRangeCircle:
 	DetectCloaked:
-		Range: 1c768
+		Range: 4c768
 	-GivesBuildableArea:
 	WithMakeAnimation:
 		BodyNames: make
@@ -582,7 +605,6 @@
 		Range: 2c0, 4c0
 	MustBeDestroyed:
 		RequiredForShortGame: false
-	RevealOnFire:
 	Targetable:
 		TargetTypes: Ground, C4, Structure, Defense
 	MapEditorData:
@@ -623,6 +645,7 @@
 		Modifier: 0
 	RepairableBuilding:
 		RepairCondition: repairing
+		RepairStep: 500
 	WithBuildingRepairDecoration:
 		Offsets:
 			powerdown: -10, 0

--- a/mods/d2k/rules/husks.yaml
+++ b/mods/d2k/rules/husks.yaml
@@ -1,7 +1,7 @@
 mcv.husk:
 	Inherits: ^VehicleHusk
 	Health:
-		HP: 13000
+		HP: 11000
 	Tooltip:
 		Name: actor-mcv-husk-name
 	TransformOnCapture:
@@ -53,7 +53,7 @@ sonic_tank.husk:
 	Husk:
 		Locomotor: vehicle
 	Health:
-		HP: 11000
+		HP: 9000
 	Tooltip:
 		Name: actor-sonic-tank-husk-name
 	ThrowsParticle@turret:
@@ -76,7 +76,7 @@ devastator.husk:
 	Husk:
 		Locomotor: devastator
 	Health:
-		HP: 12500
+		HP: 10000
 	Tooltip:
 		Name: actor-devastator-husk-name
 	TransformOnCapture:
@@ -87,7 +87,7 @@ devastator.husk:
 deviator.husk:
 	Inherits: ^VehicleHusk
 	Health:
-		HP: 11000
+		HP: 10000
 	Tooltip:
 		Name: actor-deviator-husk-name
 	ThrowsParticle@turret:
@@ -105,6 +105,10 @@ deviator.husk:
 		IntoActor: deviator
 	InfiltrateForTransform:
 		IntoActor: deviator
+	FireWarheads:
+		Weapons: DeviatorGas
+		Interval: 50
+		StartCooldown: 100
 
 ^combat_tank.husk:
 	Inherits: ^VehicleHusk

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -31,9 +31,9 @@ engineer:
 	Inherits@selection: ^SelectableSupportUnit
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 30
+		BuildPaletteOrder: 80
 		Prerequisites: upgrade.barracks, ~techlevel.medium
-		BuildDuration: 125
+		BuildDuration: 150
 		BuildDurationModifier: 100
 		Description: actor-engineer.description
 	Valued:
@@ -67,7 +67,6 @@ engineer:
 		Description: actor-engineer.encyclopedia
 		Order: 30
 		Category: Units
-	-RevealOnFire:
 	Voiced:
 		VoiceSet: EngineerVoice
 	-AttackFrontal:
@@ -79,11 +78,11 @@ trooper:
 		Queue: Infantry
 		BuildPaletteOrder: 20
 		Prerequisites: upgrade.barracks, ~techlevel.medium
-		BuildDuration: 85
+		BuildDuration: 124
 		BuildDurationModifier: 100
 		Description: actor-trooper.description
 	Valued:
-		Cost: 90
+		Cost: 100
 	Tooltip:
 		Name: actor-trooper.name
 	UpdatesPlayerStatistics:
@@ -108,10 +107,9 @@ trooper:
 
 thumper:
 	Inherits: ^Infantry
-	-RevealOnFire:
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 40
+		BuildPaletteOrder: 100
 		Prerequisites: upgrade.barracks, ~techlevel.high
 		BuildDuration: 125
 		BuildDurationModifier: 100
@@ -303,6 +301,9 @@ mpsardaukar:
 
 saboteur:
 	Inherits: ^Infantry
+	Selectable:
+		Priority: 8
+		PriorityModifiers: Ctrl, Alt
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 100
@@ -315,36 +316,57 @@ saboteur:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 4000
+		HP: 5000
 	Encyclopedia:
 		Description: actor-saboteur.encyclopedia
 		Order: 80
 		Category: Units
 	Mobile:
 		Speed: 43
+		PauseOnCondition: triggered
 	Demolition:
-		DetonationDelay: 25
+		DetonationDelay: 50
 		Flashes: 3
 		EnterBehaviour: Suicide
-	-RevealOnFire:
-	GrantChargedConditionOnToggle:
-		ActivatedCondition: cloaked
-		CanCancelCondition: true
-		ChargeDuration: 1250
-		ChargeThreshhold: 100
-		ConditionDuration: 375
 	Cloak:
-		RequiresCondition: cloaked
-		InitialDelay: 0
-		CloakDelay: 25
+		InitialDelay: 100
+		CloakDelay: 100
 		CloakSound: STEALTH1.WAV
 		UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage, Heal
 		PauseOnCondition: cloak-force-disabled
+		RequiresCondition: !triggered
+	FireWarheadsOnDeath@Selfkill:
+		Weapon: PlasmaSaboteur
+		EmptyWeapon: PlasmaSaboteur
+		RequiresCondition: kamikadze
+	GrantConditionOnDeploy:
+		DeployCursor: c4
+		DeployedCondition: triggered
+		PauseOnCondition: triggered
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical
+	KillsSelf@SuicideKillCount:
+		Delay: 45
+		RequiresCondition: triggered
+		GrantsCondition: kamikadze
+	TakeCover:
+		RequiresCondition: triggered
 	Voiced:
 		VoiceSet: SaboteurVoice
+	RevealsShroud:
+		Range: 4c768
+	Crushable:
+		WarnProbability: 95
+	WithInfantryBody:
+		RequiresCondition: !triggered
+	WithIdleOverlay:
+		Sequence: active
+		RequiresCondition: triggered
+	WithIdleOverlay@prone:
+		StartSequence: standup
+		Sequence: prone-stand
+		RequiresCondition: triggered
 	-AttackFrontal:
 
 nsfremen:

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -242,7 +242,7 @@ upgrade.barracks:
 		Prerequisites: barracks
 		Queue: Upgrade
 		BuildLimit: 1
-		BuildDuration: 208
+		BuildDuration: 260
 		BuildDurationModifier: 100
 		Description: actor-upgrade-barracks.description
 	Valued:
@@ -266,7 +266,7 @@ upgrade.light:
 		Prerequisites: light_factory
 		Queue: Upgrade
 		BuildLimit: 1
-		BuildDuration: 268
+		BuildDuration: 330
 		BuildDurationModifier: 100
 		Description: actor-upgrade-light.description
 	Valued:
@@ -290,7 +290,7 @@ upgrade.heavy:
 		Prerequisites: heavy_factory
 		Queue: Upgrade
 		BuildLimit: 1
-		BuildDuration: 468
+		BuildDuration: 600
 		BuildDurationModifier: 100
 		Description: actor-upgrade-heavy.description
 	Valued:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -97,7 +97,7 @@ construction_yard:
 	ProductionBar:
 		ProductionType: Building
 	Power:
-		Amount: 20
+		Amount: 50
 	RenderSprites:
 		Image: conyard.ordos
 		FactionImages:
@@ -139,7 +139,7 @@ wind_trap:
 		Category: Buildings
 		Order: 20
 	Health:
-		HP: 30000
+		HP: 28000
 	HitShape:
 		Type: Rectangle
 			TopLeft: -1024, -1024
@@ -174,13 +174,13 @@ barracks:
 		Prerequisites: wind_trap
 		Queue: Building
 		BuildPaletteOrder: 220
-		BuildDuration: 268
+		BuildDuration: 290
 		BuildDurationModifier: 100
 		Description: actor-barracks.description
 	Selectable:
 		Bounds: 2048, 2048
 	Valued:
-		Cost: 225
+		Cost: 300
 	Tooltip:
 		Name: actor-barracks.name
 	D2kBuilding:
@@ -227,7 +227,7 @@ barracks:
 		Prerequisite: barracks.harkonnen
 		Factions: harkonnen
 	Power:
-		Amount: -30
+		Amount: -50
 	RenderSprites:
 		Image: barracks.ordos
 		FactionImages:
@@ -276,7 +276,7 @@ refinery:
 			TopLeft: -1536, 0
 			BottomRight: 512, 1024
 	Armor:
-		Type: heavy
+		Type: building
 	RevealsShroud:
 		Range: 3c768
 	Refinery:
@@ -382,13 +382,13 @@ light_factory:
 		Prerequisites: refinery
 		Queue: Building
 		BuildPaletteOrder: 230
-		BuildDuration: 321
+		BuildDuration: 390
 		BuildDurationModifier: 100
 		Description: actor-light-factory.description
 	Selectable:
 		Bounds: 3072, 2048
 	Valued:
-		Cost: 500
+		Cost: 600
 	Tooltip:
 		Name: actor-light-factory.name
 	D2kBuilding:
@@ -455,7 +455,7 @@ light_factory:
 		Factions: ordos, smuggler, mercenary
 	ProvidesPrerequisite@buildingname:
 	Power:
-		Amount: -125
+		Amount: -100
 	GrantConditionOnPrerequisite@UPGRADEABLE:
 		Prerequisites: upgrade.light
 
@@ -473,7 +473,7 @@ heavy_factory:
 	Selectable:
 		Bounds: 3072, 3072
 	Valued:
-		Cost: 1000
+		Cost: 1200
 	Tooltip:
 		Name: actor-heavy-factory.name
 	D2kBuilding:
@@ -588,7 +588,14 @@ outpost:
 	Armor:
 		Type: building
 	RevealsShroud:
-		Range: 5c768
+		Range: 11c0
+		RequiresCondition: !disabled
+	RevealsShroud@lowpower:
+		Range: 4c0
+		RequiresCondition: disabled
+	DetectCloaked:
+		Range: 6c0
+		RequiresCondition: !disabled
 	ProvidesRadar:
 		RequiresCondition: !disabled
 	RenderSprites:
@@ -606,7 +613,7 @@ outpost:
 	GrantConditionOnDamageState@STOPDISH:
 		Condition: severe-damaged
 	Power:
-		Amount: -125
+		Amount: -75
 	ProvidesPrerequisite@buildingname:
 
 starport:
@@ -713,7 +720,7 @@ wall:
 		BuildDurationModifier: 100
 		Description: actor-wall.description
 	Valued:
-		Cost: 20
+		Cost: 100
 	CustomSellValue:
 		Value: 0
 	Tooltip:
@@ -777,7 +784,7 @@ medium_gun_turret:
 		Queue: Building
 		Prerequisites: barracks
 		BuildPaletteOrder: 510
-		BuildDuration: 268
+		BuildDuration: 310
 		BuildDurationModifier: 100
 		Description: actor-medium-gun-turret.description
 	Valued:
@@ -790,15 +797,15 @@ medium_gun_turret:
 		Bounds: 1024, 1024
 		DecorationBounds: 1024, 1280, 0, -256
 	Health:
-		HP: 27000
+		HP: 24000
 	Encyclopedia:
 		Description: actor-medium-gun-turret.encyclopedia
 		Category: Buildings
 		Order: 100
 	Armor:
-		Type: heavy
+		Type: wall
 	RevealsShroud:
-		Range: 4c768
+		Range: 5c0
 	BodyOrientation:
 		QuantizedFacings: 32
 	WithMuzzleOverlay:
@@ -825,7 +832,7 @@ large_gun_turret:
 		Queue: Building
 		Prerequisites: outpost, upgrade.conyard, ~techlevel.medium
 		BuildPaletteOrder: 610
-		BuildDuration: 312
+		BuildDuration: 380
 		BuildDurationModifier: 100
 		Description: actor-large-gun-turret.description
 	Valued:
@@ -842,11 +849,11 @@ large_gun_turret:
 		Bounds: 1024, 1024
 		DecorationBounds: 1024, 1280, 0, -256
 	Health:
-		HP: 30000
+		HP: 27000
 	Armor:
-		Type: heavy
+		Type: wall
 	RevealsShroud:
-		Range: 5c768
+		Range: 6c0
 	BodyOrientation:
 		QuantizedFacings: 32
 	Armament:
@@ -858,8 +865,6 @@ large_gun_turret:
 		RealignDelay: -1
 	Power:
 		Amount: -60
-	RevealOnDeath:
-		Radius: 5c768
 	Replacement:
 		ReplaceableTypes: Tower
 
@@ -867,7 +872,7 @@ repair_pad:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		Prerequisites: heavy_factory, upgrade.heavy, ~techlevel.medium
+		Prerequisites: heavy_factory, ~techlevel.medium
 		BuildPaletteOrder: 430
 		BuildDuration: 375
 		BuildDurationModifier: 100
@@ -1165,12 +1170,12 @@ palace:
 		MissileImage: deathhand
 		MissileDelay: 18
 		SpawnOffset: 32,816,0
-		DetonationAltitude: 3c0
-		RemoveMissileOnDetonation: False
+		DetonationAltitude: 6c0
+		RemoveMissileOnDetonation: True
 		DisplayBeacon: True
 		DisplayRadarPing: True
 		CameraRange: 10c0
-		CameraRemoveDelay: 60
+		CameraRemoveDelay: 90
 		ArrowSequence: arrow
 		CircleSequence: circles
 		FlightVelocity: 384
@@ -1185,7 +1190,7 @@ palace:
 		PauseOnCondition: disabled
 		RequiresCondition: atreides
 		Prerequisites: ~techlevel.superweapons, ~palace.fremen
-		Actors: fremen, fremen
+		Actors: fremen, fremen, fremen, fremen, fremen
 		Type: Fremen
 		ChargeInterval: 2250
 		EndChargeTextNotification: notification-fremen-ready

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -2,7 +2,7 @@ mcv:
 	Inherits: ^Tank
 	Inherits@selection: ^SelectableSupportUnit
 	Buildable:
-		Prerequisites: repair_pad, upgrade.heavy, ~techlevel.medium
+		Prerequisites: repair_pad, ~techlevel.medium
 		Queue: Armor
 		BuildPaletteOrder: 110
 		BuildDuration: 750
@@ -50,7 +50,6 @@ mcv:
 		Step: 50
 		Delay: 3
 		StartIfBelow: 50
-	-RevealOnFire:
 
 harvester:
 	Inherits: ^Tank
@@ -109,7 +108,6 @@ harvester:
 		Step: 50
 		Delay: 3
 		StartIfBelow: 50
-	-RevealOnFire:
 	WithStoresResourcesPipsDecoration:
 		Position: BottomLeft
 		Margin: 1, 4
@@ -158,7 +156,7 @@ trike:
 		TurnSpeed: 40
 		Speed: 128
 	RevealsShroud:
-		Range: 4c768
+		Range: 5c512
 	WithMuzzleOverlay:
 	Armament:
 		Weapon: HMG
@@ -223,17 +221,17 @@ siege_tank:
 		Queue: Armor
 		Prerequisites: upgrade.heavy, ~techlevel.medium
 		BuildPaletteOrder: 50
-		BuildDuration: 375
+		BuildDuration: 475
 		BuildDurationModifier: 100
 		Description: actor-siege-tank.description
 	Valued:
-		Cost: 700
+		Cost: 800
 	Tooltip:
 		Name: actor-siege-tank.name
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 12000
+		HP: 11500
 	Armor:
 		Type: light
 	Encyclopedia:
@@ -241,7 +239,7 @@ siege_tank:
 		Order: 170
 		Category: Units
 	Mobile:
-		Speed: 43
+		Speed: 40
 		TurnSpeed: 12
 	RevealsShroud:
 		Range: 6c768
@@ -256,11 +254,13 @@ siege_tank:
 		MuzzleSequence: muzzle
 	AttackFrontal:
 		FacingTolerance: 0
+		ForceFireIgnoresActors: True
+		TargetFrozenActors: True
 	WithMuzzleOverlay:
 	WithSpriteTurret:
 	FireWarheadsOnDeath:
-		Weapon: UnitExplodeMed
-		EmptyWeapon: UnitExplodeMed
+		Weapon: SiegeExplode
+		EmptyWeapon: SiegeExplode
 	AutoTarget:
 		InitialStanceAI: Defend
 	Selectable:
@@ -271,6 +271,10 @@ siege_tank:
 		EffectiveOwnerFromOwner: true
 	AttractsWorms:
 		Intensity: 600
+	FireProjectilesOnDeath:
+		Weapons: Debris3, Debris
+		Pieces: 0,2
+		Range: 2c0, 3c0
 
 missile_tank:
 	Inherits: ^Tank
@@ -290,7 +294,7 @@ missile_tank:
 	Valued:
 		Cost: 900
 	Mobile:
-		Speed: 64
+		Speed: 60
 		TurnSpeed: 20
 	Health:
 		HP: 13000
@@ -307,6 +311,8 @@ missile_tank:
 		LocalOffset: -128,128,171, -128,-128,171
 	AttackFrontal:
 		FacingTolerance: 0
+		ForceFireIgnoresActors: True
+		TargetFrozenActors: True
 	AutoTarget:
 		InitialStanceAI: Defend
 	FireWarheadsOnDeath:
@@ -337,11 +343,11 @@ sonic_tank:
 		Queue: Armor
 		BuildPaletteOrder: 100
 		Prerequisites: ~heavy.atreides, research_centre, ~techlevel.high
-		BuildDuration: 562
+		BuildDuration: 600
 		BuildDurationModifier: 100
 		Description: actor-sonic-tank.description
 	Valued:
-		Cost: 1000
+		Cost: 1100
 	Tooltip:
 		Name: actor-sonic-tank.name
 	UpdatesPlayerStatistics:
@@ -386,7 +392,7 @@ devastator:
 		BuildDurationModifier: 100
 		Description: actor-devastator.description
 	Valued:
-		Cost: 1050
+		Cost: 1200
 	Tooltip:
 		Name: actor-devastator.name
 	UpdatesPlayerStatistics:
@@ -400,11 +406,11 @@ devastator:
 		Speed: 31
 		Locomotor: devastator
 		RequiresCondition: !overload
-		PauseOnCondition: notmobile
+		PauseOnCondition: notmobile || being-demolished
 	AutoCarryable:
 		RequiresCondition: !overload
 	RevealsShroud:
-		Range: 4c768
+		Range: 5c512
 	Armament:
 		Weapon: DevBullet
 		LocalOffset: 640,0,32
@@ -425,6 +431,7 @@ devastator:
 		Actor: devastator.husk
 		OwnerType: InternalName
 		EffectiveOwnerFromOwner: true
+		RequiresCondition: !meltdown
 	FireWarheadsOnDeath@OVERLOAD:
 		Weapon: PlasmaExplosion
 		EmptyWeapon: PlasmaExplosion
@@ -432,6 +439,7 @@ devastator:
 	GrantConditionOnDeploy@REACTOR:
 		DeployedCondition: overload
 		PauseOnCondition: overload
+		RequiresCondition: !unit-captured
 	WithIdleOverlay@OVERLOAD:
 		Sequence: active
 		RequiresCondition: overload
@@ -439,7 +447,7 @@ devastator:
 		Sequence: active-2
 		RequiresCondition: overload
 	KillsSelf@MELTDOWN:
-		Delay: 240
+		Delay: 150
 		RequiresCondition: overload
 		GrantsCondition: meltdown
 	AmbientSound@onMeltDown:
@@ -449,11 +457,20 @@ devastator:
 	AttractsWorms:
 		Intensity: 700
 	ChangesHealth:
-		Step: 50
+		Step: 40
 		Delay: 3
 		StartIfBelow: 50
 	Selectable:
 		DecorationBounds: 1408, 1216, 0, 0
+	FireProjectilesOnDeath@OnMeldown:
+		Weapons: Debris2, Debris3, Debris4
+		Pieces: 7, 15
+		Range: 3c512, 6c0
+		RequiresCondition: meltdown
+	FireProjectilesOnDeath@standart:
+		Weapons: Debris, ExplosiveDebris
+		Pieces: 1, 2
+		RequiresCondition: !meltdown
 
 raider:
 	Inherits: ^Vehicle
@@ -463,11 +480,11 @@ raider:
 		Queue: Vehicle
 		BuildPaletteOrder: 10
 		Prerequisites: ~light.raider
-		BuildDuration: 225
+		BuildDuration: 255
 		BuildDurationModifier: 100
 		Description: actor-raider.description
 	Valued:
-		Cost: 350
+		Cost: 330
 	Tooltip:
 		Name: actor-raider.name
 	Encyclopedia:
@@ -477,16 +494,16 @@ raider:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 10000
+		HP: 9200
 	Armor:
 		Type: wood
 	Mobile:
 		TurnSpeed: 40
-		Speed: 149
+		Speed: 140
 	RevealsShroud:
 		Range: 4c768
 	WithMuzzleOverlay:
-	Armament@damage:
+	Armament:
 		Weapon: HMGo
 		MuzzleSequence: muzzle
 		LocalOffset: 100,0,0
@@ -503,7 +520,7 @@ stealth_raider:
 	Buildable:
 		Prerequisites: ~light.ordos, upgrade.light, high_tech_factory, ~techlevel.medium
 		BuildPaletteOrder: 30
-		BuildDuration: 225
+		BuildDuration: 275
 		BuildDurationModifier: 100
 		Description: actor-stealth-raider.description
 	Valued:
@@ -520,6 +537,8 @@ stealth_raider:
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical
+	Health:
+		HP: 10000
 	Encyclopedia:
 		Description: actor-stealth-raider.encyclopedia
 		Order: 120
@@ -550,7 +569,7 @@ deviator:
 		TurnSpeed: 12
 		Speed: 53
 	Health:
-		HP: 11000
+		HP: 12500
 	Armor:
 		Type: wood
 	Encyclopedia:
@@ -558,7 +577,7 @@ deviator:
 		Order: 210
 		Category: Units
 	RevealsShroud:
-		Range: 4c768
+		Range: 6c0
 	Armament:
 		Weapon: DeviatorMissile
 		LocalOffset: -299,0,85
@@ -571,7 +590,7 @@ deviator:
 		EmptyWeapon: UnitExplodeLarge
 	SpawnActorOnDeath:
 		Actor: deviator.husk
-		OwnerType: InternalName
+		OwnerType: Victim
 		EffectiveOwnerFromOwner: true
 	AttractsWorms:
 		Intensity: 600
@@ -591,7 +610,7 @@ deviator:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 21000
+		HP: 22000
 	Armor:
 		Type: heavy
 	Mobile:
@@ -656,7 +675,7 @@ combat_tank_h:
 	Mobile:
 		Speed: 64
 	Health:
-		HP: 27000
+		HP: 28500
 	SpawnActorOnDeath:
 		Actor: combat_tank_h.husk
 
@@ -677,6 +696,6 @@ combat_tank_o:
 	Mobile:
 		Speed: 85
 	Health:
-		HP: 18000
+		HP: 19000
 	SpawnActorOnDeath:
 		Actor: combat_tank_o.husk

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -179,12 +179,18 @@ World:
 		ClassName: options-starting-units.mcv-only
 		BaseActor: mcv
 		Factions: atreides, ordos, harkonnen
+	StartingUnits@Carryall:
+		Class: carryall
+		ClassName: options-starting-units.carryall
+		BaseActor: mcv
+		SupportActors: carryall
+		Factions: atreides, ordos, harkonnen
 	StartingUnits@lightatreides:
 		Class: light
 		ClassName: options-starting-units.light-support
 		Factions: atreides
 		BaseActor: mcv
-		SupportActors: light_inf, light_inf, light_inf, trooper, grenadier, trike, quad
+		SupportActors: light_inf, light_inf, light_inf, trooper, grenadier, trike, quad, carryall
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
 	StartingUnits@lightharkonnen:
@@ -192,7 +198,7 @@ World:
 		ClassName: options-starting-units.light-support
 		Factions: harkonnen
 		BaseActor: mcv
-		SupportActors: light_inf, light_inf, light_inf, trooper, trooper, trike, quad
+		SupportActors: light_inf, light_inf, light_inf, trooper, trooper, trike, quad, carryall
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
 	StartingUnits@lightordos:
@@ -200,7 +206,7 @@ World:
 		ClassName: options-starting-units.light-support
 		Factions: ordos
 		BaseActor: mcv
-		SupportActors: light_inf, light_inf, light_inf, trooper, engineer, raider, quad
+		SupportActors: light_inf, light_inf, light_inf, trooper, engineer, raider, quad, carryall
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
 	StartingUnits@heavyatreides:
@@ -208,7 +214,7 @@ World:
 		ClassName: options-starting-units.heavy-support
 		Factions: atreides
 		BaseActor: mcv
-		SupportActors: light_inf, light_inf, light_inf, trooper, grenadier, trike, combat_tank_a, missile_tank
+		SupportActors: light_inf, light_inf, light_inf, trooper, grenadier, trike, combat_tank_a, missile_tank, carryall
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
 	StartingUnits@heavyharkonnen:
@@ -216,7 +222,7 @@ World:
 		ClassName: options-starting-units.heavy-support
 		Factions: harkonnen
 		BaseActor: mcv
-		SupportActors: light_inf, light_inf, light_inf, trooper, engineer, quad, combat_tank_h, siege_tank
+		SupportActors: light_inf, light_inf, light_inf, trooper, engineer, quad, combat_tank_h, siege_tank, carryall
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
 	StartingUnits@heavyordos:
@@ -224,7 +230,7 @@ World:
 		ClassName: options-starting-units.heavy-support
 		Factions: ordos
 		BaseActor: mcv
-		SupportActors: light_inf, light_inf, light_inf, trooper, engineer, raider, combat_tank_o, missile_tank
+		SupportActors: light_inf, light_inf, light_inf, trooper, engineer, raider, combat_tank_o, missile_tank, carryall
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
 	SpawnStartingUnits:
@@ -239,6 +245,9 @@ World:
 	ScriptTriggers:
 	CellTriggerOverlay:
 	StartGameNotification:
+	FlashPostProcessEffect:
+		Type: flash
+		Color: E2DD8F4D
 	TimeLimitManager:
 		TimeLimitDisplayOrder: 2
 	ColorPickerManager:

--- a/mods/d2k/sequences/infantry.yaml
+++ b/mods/d2k/sequences/infantry.yaml
@@ -472,6 +472,12 @@ saboteur:
 		Facings: -8
 		Transpose: true
 		Tick: 120
+	active:
+		Filename: DATA.R16
+		Start: 3839
+		Length: 14
+		Tick: 80
+		BlendMode: Additive
 	die1:
 		Filename: DATA.R16
 		Frames: 2325, 2332, 2339, 2346, 2353, 2360, 2367, 2374, 2381, 2383, 2385, 2387

--- a/mods/d2k/weapons/debris.yaml
+++ b/mods/d2k/weapons/debris.yaml
@@ -12,7 +12,7 @@ Debris:
 		BounceRangeModifier: 20
 	Warhead@1Dam: SpreadDamage
 		Damage: 1500
-		Spread: 1c0
+		Spread: 0c756
 		Falloff: 100, 0
 		Versus:
 			none: 20
@@ -25,7 +25,7 @@ Debris:
 			invulnerable: 0
 			cy: 20
 			harvester: 50
-		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
+		DamageTypes: TriggerProne, SmallExplosionDeath
 		DamageCalculationType: ClosestTargetablePosition
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater
@@ -44,7 +44,7 @@ Debris2:
 		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
 		Damage: 2500
-		Spread: 2c0
+		Spread: 1c0
 		Versus:
 			none: 90
 			wall: 5
@@ -56,7 +56,7 @@ Debris2:
 			invulnerable: 0
 			cy: 20
 			harvester: 25
-		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+		DamageTypes: TriggerProne, ExplosionDeath
 	Warhead@3Eff: CreateEffect
 		Explosions: small_napalm
 	Warhead@4Concrete: DamagesConcrete
@@ -69,6 +69,7 @@ Debris3:
 		TrailImage: small_trail2
 	Warhead@1Dam: SpreadDamage
 		Damage: 1500
+		Spread: 1c512
 	Warhead@4Concrete: DamagesConcrete
 		Damage: 1350
 
@@ -77,6 +78,8 @@ Debris4:
 	Projectile: Bullet
 		Image: shrapnel4
 		TrailImage: large_trail
+	Warhead@1Dam: SpreadDamage
+		Spread: 2c0
 
 DebrisMissile:
 	Inherits: ^Missile

--- a/mods/d2k/weapons/largeguns.yaml
+++ b/mods/d2k/weapons/largeguns.yaml
@@ -1,6 +1,6 @@
 ^Cannon:
 	ReloadDelay: 50
-	Range: 4c0
+	Range: 4c624
 	Report: MEDTANK1.WAV
 	Projectile: Bullet
 		Speed: 562
@@ -8,7 +8,7 @@
 		InaccuracyType: PerCellIncrement
 		Image: 120mm
 	Warhead@1Dam: SpreadDamage
-		Damage: 2700
+		Damage: 2800
 		Spread: 1c0
 		Falloff: 100, 0
 		Versus:
@@ -20,7 +20,7 @@
 			invulnerable: 0
 			cy: 20
 			harvester: 50
-		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
+		DamageTypes: Prone80Percent, TriggerProne, SmallExplosionDeath
 		DamageCalculationType: ClosestTargetablePosition
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
@@ -34,18 +34,24 @@
 110mm_Gun:
 	Inherits: ^Cannon
 	ReloadDelay: 35
-	Range: 5c0
+	Range: 6c0
 	Report: TURRET1.WAV
 	Projectile: Bullet
-		Speed: 875
+		Speed: 800
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Damage: 2900
+		Versus:
+			none: 65
+			wood: 80
+			heavy: 30
+			harvester: 50
 	Warhead@4Concrete: DamagesConcrete
 		Damage: 2900
 
 80mm_A:
 	Inherits: ^Cannon
+	Range: 5c112
 
 80mm_H:
 	Inherits: ^Cannon
@@ -53,7 +59,7 @@
 
 80mm_O:
 	Inherits: ^Cannon
-	ReloadDelay: 45
+	ReloadDelay: 44
 
 DevBullet:
 	Inherits: ^Cannon
@@ -64,7 +70,7 @@ DevBullet:
 		Image: doubleblastbullet
 	Warhead@1Dam: SpreadDamage
 		Damage: 6500
-		Spread: 1c0
+		Spread: 1c225
 		Versus:
 			none: 65
 			wall: 100
@@ -82,8 +88,8 @@ DevBullet:
 
 155mm:
 	Inherits: ^Cannon
-	ReloadDelay: 80
-	Range: 5c512
+	ReloadDelay: 105
+	Range: 6c900
 	Report: MORTAR1.WAV
 	Projectile: Bullet
 		Speed: 192
@@ -94,10 +100,10 @@ DevBullet:
 		Image: 155mm
 	Warhead@1Dam: SpreadDamage
 		Damage: 4500
-		Spread: 2c0
+		Spread: 1c800
 		Versus:
-			none: 125
-			wall: 100
+			none: 100
+			wall: 70
 			building: 100
 			wood: 70
 			light: 30
@@ -105,11 +111,7 @@ DevBullet:
 			invulnerable: 0
 			cy: 20
 			harvester: 25
-		DamageTypes: Prone50Percent, ExplosionDeath
-	Warhead@proneeffect: TargetDamage
-		DamageTypes: TriggerProne
-		Damage: 1
-		Spread: 1c512
+		DamageTypes: Prone80Percent, TriggerProne, ExplosionDeath
 	Warhead@4Concrete: DamagesConcrete
 		Damage: 5625
 	Warhead@3Eff: CreateEffect

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -1,30 +1,30 @@
 ^Rocket:
 	ReloadDelay: 40
-	Range: 3c0
+	Range: 3c870
 	Report: ROCKET1.WAV
 	Projectile: Bullet
 		Blockable: false
 		Speed: 281
-		Inaccuracy: 140
+		Inaccuracy: 130
 		InaccuracyType: PerCellIncrement
 		Image: RPG
 		TrailImage: bazooka_trail2
 		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
 		Damage: 3000
-		Spread: 1c0
+		Spread: 870
 		Falloff: 100, 0
 		Versus:
-			none: 15
+			none: 10
 			wall: 75
 			building: 40
-			wood: 45
+			wood: 55
 			light: 70
 			heavy: 100
 			invulnerable: 0
 			cy: 20
-			harvester: 50
-		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
+			harvester: 60
+		DamageTypes: Prone80Percent, TriggerProne, SmallExplosionDeath
 		DamageCalculationType: ClosestTargetablePosition
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
@@ -39,14 +39,14 @@
 ^Missile:
 	Inherits: ^Rocket
 	ReloadDelay: 60
-	Range: 5c512
+	Range: 7c0
 	MinRange: 0c512
 	Projectile: Missile
 		Shadow: true
 		InaccuracyType: Maximum
 		Inaccuracy: 250
 		HorizontalRateOfTurn: 22
-		RangeLimit: 7c614
+		RangeLimit: 10c0
 		CruiseAltitude: 1c0
 		MinimumLaunchAngle: 64
 		VerticalRateOfTurn: 40
@@ -57,16 +57,16 @@
 		Damage: 4800
 		Spread: 1c0
 		Versus:
-			none: 15
+			none: 10
 			wall: 75
 			building: 60
-			wood: 65
-			light: 90
+			wood: 60
+			light: 80
 			heavy: 100
 			invulnerable: 0
 			cy: 30
 			harvester: 50
-		DamageTypes: Prone50Percent, SmallExplosionDeath
+		DamageTypes: Prone80Percent, SmallExplosionDeath
 	Warhead@proneeffect: TargetDamage
 		Damage: 1
 		Spread: 600
@@ -82,22 +82,25 @@ Bazooka:
 
 Rocket:
 	Inherits: ^Rocket
-	ReloadDelay: 30
-	Range: 3c512
+	ReloadDelay: 50
+	Burst: 2
+	BurstDelays: 10
+	Range: 4c112
 	Projectile: Bullet
 		Speed: 352
+		Inaccuracy: 140
 	Warhead@1Dam: SpreadDamage
 		Damage: 2500
 		Versus:
 			none: 25
-			wall: 100
+			wall: 70
 			building: 50
 			wood: 65
 			light: 100
 			heavy: 50
 			invulnerable: 0
 			cy: 20
-			harvester: 50
+			harvester: 55
 	Warhead@4Concrete: DamagesConcrete
 		Damage: 625
 	Warhead@3Eff: CreateEffect
@@ -111,17 +114,18 @@ TowerMissile:
 	ValidTargets: Ground, Air
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: Ground, Air
-		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+		DamageTypes: Prone80Percent, TriggerProne, ExplosionDeath
 
 mtank_pri:
 	Inherits: ^Missile
 	ReloadDelay: 115
 	Burst: 2
 	BurstDelays: 115
-	Range: 6c0
+	Range: 7c900
+	MinRange: 1c0
 	ValidTargets: Ground, Air
 	Projectile: Missile
-		RangeLimit: 7c204
+		RangeLimit: 11c0
 	Warhead@1Dam: SpreadDamage
 		Damage: 6000
 		ValidTargets: Ground, Air
@@ -131,7 +135,7 @@ mtank_pri:
 DeviatorMissile:
 	Inherits: ^Missile
 	ReloadDelay: 160
-	Range: 5c0
+	Range: 6c0
 	Report: MISSLE1.WAV
 	Projectile: Missile
 		RangeLimit: 6c0
@@ -141,7 +145,7 @@ DeviatorMissile:
 		TrailPalette: player
 		TrailUsePlayerPalette: true
 	Warhead@1Dam: SpreadDamage
-		Damage: 1000
+		Damage: 2000
 		Spread: 480
 		Versus:
 			none: 100
@@ -161,8 +165,11 @@ DeviatorMissile:
 		-ImpactSounds:
 	Warhead@5OwnerChange: ChangeOwner
 		Range: 512
-		Duration: 375
+		Duration: 405
 		InvalidTargets: Infantry, Structure
 		ValidRelationships: Enemy, Neutral
+	Warhead@Trigger: GrantExternalCondition
+		Condition: unit-captured
+		Duration: 405
 	Warhead@4Concrete: DamagesConcrete
 		Damage: 1000

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -1,6 +1,6 @@
 Sound:
 	ReloadDelay: 90
-	Range: 5c0
+	Range: 6c0
 	Report: SONIC1.WAV
 	Projectile: SonicBlast
 		Speed: 0c128
@@ -8,8 +8,8 @@ Sound:
 		InaccuracyType: PerCellIncrement
 		DamageInterval: 1
 		Falloff: 0, 0, 100, 0
-		Range: 0, 0c512, 4c0, 6c0
-		MinDistance: 5c0
+		Range: 0, 0c756, 6c0, 6c100
+		MinDistance: 6c0
 	Warhead@1Dam: SpreadDamage
 		Falloff: 100, 0
 		Spread: 1c756
@@ -39,9 +39,9 @@ WormJaw:
 
 OrniBomb:
 	ReloadDelay: 25
-	Burst: 5
+	Burst: 7
 	BurstDelays: 6
-	Range: 3c0
+	Range: 3c512 #3c0 in original, reduce when bombers can do multiple passes
 	Report: ORNIBOMB.WAV
 	Projectile: GravityBomb
 		Image: BOMBS
@@ -49,20 +49,20 @@ OrniBomb:
 		Acceleration: 0, 0, 0
 		Shadow: true
 	Warhead@1Dam: SpreadDamage
-		Damage: 7500 #400 in original, reduce when bombers can do multiple passes
+		Damage: 10000
 		Spread: 2c0
 		Falloff: 100, 0
 		Versus:
 			none: 90
-			wall: 50
+			wall: 120
 			building: 75
 			wood: 60
 			light: 60
-			heavy: 60
+			heavy: 100
 			invulnerable: 0
 			cy: 25
 			harvester: 60
-		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
+		DamageTypes: Prone80Percent, TriggerProne, SmallExplosionDeath
 		DamageCalculationType: ClosestTargetablePosition
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
@@ -88,13 +88,16 @@ Demolish:
 		Explosions: building
 		ImpactSounds: EXPLLG2.WAV
 		ImpactActors: false
+	Warhead@flash: FlashEffect
+		FlashType: flash
+		Duration: 20
 
 DeathHand:
 	Warhead@Cluster: FireCluster
 		Weapon: DeathHandCluster
-		RandomClusterCount: 14
-		Dimensions: 3,3
-		Footprint: xxx xXx xxx
+		RandomClusterCount: 36
+		Dimensions: 6,6
+		Footprint: xXxXxX xxXXxx xXXXXx xxXXxx xXxxXx XxXxXx
 	Warhead@2Eff: CreateEffect
 		Explosions: nuke
 		ImpactSounds: EXPLLG2.WAV
@@ -103,8 +106,12 @@ DeathHand:
 		Duration: 20
 		Intensity: 5
 		Multiplier: 1,1
+	Warhead@flash: FlashEffect
+		FlashType: flash
+		Duration: 20
 
 DeathHandCluster:
+	Report: NAPALM1.WAV
 	Inherits: Debris2
 	Range: 7c0
 	Projectile: Bullet
@@ -115,19 +122,19 @@ DeathHandCluster:
 		Inaccuracy: 1c512
 		BounceCount: 0
 	Warhead@1Dam: SpreadDamage
-		Damage: 4500
+		Damage: 6000
 		Spread: 2c0
 		Versus:
 			none: 90
-			wall: 50
+			wall: 110
 			building: 100
 			wood: 60
-			light: 60
-			heavy: 60
+			light: 80
+			heavy: 100
 			invulnerable: 0
 			cy: 25
 			harvester: 60
-		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+		DamageTypes: Prone80Percent, TriggerProne, ExplosionDeath
 		DamageCalculationType: ClosestTargetablePosition
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
@@ -154,7 +161,7 @@ CrateExplosion:
 			cy: 20
 			harvester: 25
 		AffectsParent: true
-		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
+		DamageTypes: Prone80Percent, TriggerProne, SmallExplosionDeath
 		DamageCalculationType: ClosestTargetablePosition
 	Warhead@2Eff: CreateEffect
 		Explosions: large_explosion
@@ -192,6 +199,15 @@ WallExplode:
 		ImpactSounds: EXPLHG1.WAV
 		ImpactActors: false
 
+SiegeExplode:
+	Inherits: 155mm
+	Warhead@1Dam: SpreadDamage
+		Damage: 4500
+		Spread: 2c0
+	Warhead@3Eff: CreateEffect
+		Explosions: med_explosion
+		ImpactSounds: EXPLSML2.WAV
+
 CliffExplode:
 	Warhead@1Eff: CreateEffect
 		Explosions: building
@@ -203,7 +219,7 @@ CliffExplode:
 
 grenade:
 	ReloadDelay: 50
-	Range: 4c0
+	Range: 4c225
 	Projectile: Bullet
 		Speed: 160
 		Blockable: false
@@ -214,7 +230,7 @@ grenade:
 		Shadow: true
 	Warhead@1Dam: SpreadDamage
 		Damage: 1500
-		Spread: 2c0
+		Spread: 1c512
 		Falloff: 100, 0
 		Versus:
 			none: 135
@@ -224,12 +240,8 @@ grenade:
 			invulnerable: 0
 			cy: 20
 			harvester: 25
-		DamageTypes: Prone50Percent, ExplosionDeath
+		DamageTypes: Prone80Percent, ExplosionDeath, TriggerProne
 		DamageCalculationType: ClosestTargetablePosition
-	Warhead@proneeffect: TargetDamage
-		Damage: 1
-		Spread: 1c0
-		DamageTypes: TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater
 		InvalidTargets: Vehicle, Structure
@@ -243,7 +255,7 @@ grenade:
 GrenDeath:
 	Warhead@1Dam: SpreadDamage
 		Damage: 1500
-		Spread: 2c0
+		Spread: 1c512
 		Falloff: 100, 0
 		Versus:
 			none: 125
@@ -253,7 +265,7 @@ GrenDeath:
 			invulnerable: 0
 			cy: 20
 			harvester: 25
-		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+		DamageTypes: Prone80Percent, TriggerProne, ExplosionDeath
 		DamageCalculationType: ClosestTargetablePosition
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
@@ -267,18 +279,19 @@ GrenDeath:
 SardDeath:
 	Warhead@1Dam: SpreadDamage
 		Damage: 3000
-		Spread: 512
+		Spread: 1c0
 		Falloff: 100, 0
 		Versus:
-			none: 15
+			none: 10
 			wall: 75
 			building: 60
 			wood: 65
 			light: 90
+			heavy: 140
 			invulnerable: 0
 			cy: 30
 			harvester: 50
-		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+		DamageTypes: Prone80Percent, TriggerProne, ExplosionDeath
 		DamageCalculationType: ClosestTargetablePosition
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
@@ -311,7 +324,7 @@ SpiceExplosion:
 			invulnerable: 0
 			cy: 20
 			harvester: 25
-		DamageTypes: Prone50Percent, TriggerProne, SpiceExplosion
+		DamageTypes: Prone80Percent, TriggerProne, SpiceExplosion
 		DamageCalculationType: ClosestTargetablePosition
 		AffectsParent: true
 	Warhead@2Res: CreateResource
@@ -339,7 +352,7 @@ BloomExplosion:
 			invulnerable: 0
 			cy: 20
 			harvester: 25
-		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath, SpiceExplosion
+		DamageTypes: Prone80Percent, TriggerProne, ExplosionDeath, SpiceExplosion
 		DamageCalculationType: ClosestTargetablePosition
 		AffectsParent: true
 	Warhead@2Res: CreateResource
@@ -349,7 +362,7 @@ BloomExplosion:
 PlasmaExplosion:
 	Warhead@1Dam: SpreadDamage
 		Damage: 20000
-		Spread: 3c0
+		Spread: 6c0
 		Falloff: 100, 0
 		Versus:
 			None: 100
@@ -357,11 +370,101 @@ PlasmaExplosion:
 			Light: 100
 			Heavy: 100
 			Concrete: 60
-		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+		DamageTypes: Prone80Percent, TriggerProne, ExplosionDeath
 		DamageCalculationType: ClosestTargetablePosition
-	Warhead@2Smu: LeaveSmudge
-		SmudgeType: SandCrater
+	Warhead@Resources: DestroyResource
+		Size: 5
+	Warhead@Smudge1: LeaveSmudge
+		SmudgeType: SandCrater, RockCrater
+		Delay: 1
+	Warhead@Smudge2: LeaveSmudge
+		SmudgeType: SandCrater, RockCrater
+		Delay: 2
+	Warhead@Smudge3: LeaveSmudge
+		SmudgeType: SandCrater, RockCrater
+		Delay: 3
+	Warhead@Smudge4: LeaveSmudge
+		SmudgeType: SandCrater, RockCrater
+		Delay: 4
+	Warhead@Smudge5: LeaveSmudge
+		SmudgeType: SandCrater, RockCrater
+		Size: 1
+		Delay: 5
 	Warhead@3Eff: CreateEffect
 		Explosions: devastator
+		ImpactSounds: EXPLLG5.WAV
 	Warhead@4Concrete: DamagesConcrete
 		Damage: 20000
+	Warhead@5Shake: ShakeScreen
+		Duration: 15
+		Intensity: 10
+		Multiplier: 2,2
+
+PlasmaSaboteur:
+	Inherits: PlasmaExplosion
+	Warhead@flash: FlashEffect
+		FlashType: flash
+		Duration: 20
+
+ExplosionAircraft:
+	Warhead@sound: CreateEffect
+		Explosions: building
+		ImpactSounds: EXPLLG3.WAV
+		Inaccuracy: 1c0
+	Warhead@1: SpreadDamage
+		Spread: 2c0
+		Damage: 13000
+		Falloff: 100, 0
+		DamageTypes: Prone80Percent, TriggerProne, SmallExplosionDeath
+		Versus:
+			none: 110
+			light: 80
+			heavy: 50
+			harvester: 70
+			wall: 80
+			invulnerable: 0
+			cy: 30
+	Warhead@4Concrete: DamagesConcrete
+		Damage: 4500
+	Warhead@2Smu: LeaveSmudge
+		SmudgeType: SandCrater, RockCrater
+		InvalidTargets: Vehicle, Structure
+
+ExplosiveDebris:
+	Inherits: Debris2
+	Range: 7c0
+	Projectile: Bullet
+		Image: 120mm
+		TrailImage: small_trail2
+		Speed: 50, 70
+		LaunchAngle: 150, 220
+		Inaccuracy: 2c512
+		BounceCount: 1
+	Warhead@1Dam: SpreadDamage
+		Damage: 3000
+		Spread: 1c562
+		Versus:
+			none: 100
+			wood: 100
+			light: 100
+			heavy: 50
+			harvester: 100
+	Warhead@2Smu: LeaveSmudge
+		SmudgeType: SandCrater, RockCrater
+		InvalidTargets: Vehicle, Structure
+	Warhead@3Eff: CreateEffect
+		Explosions: large_explosion
+		ImpactSounds: EXPLSML4.WAV
+	Warhead@4Concrete: DamagesConcrete
+		Damage: 4500
+
+DeviatorGas:
+	Warhead@5OwnerChange: ChangeOwner
+		Range: 1c850
+		Duration: 160
+		ValidRelationships: Enemy, Neutral
+		InvalidTargets: Infantry, Structure
+	Warhead@3Eff: CreateEffect
+		Explosions: deviator
+		ExplosionPalette: player
+		UsePlayerPalette: true

--- a/mods/d2k/weapons/smallguns.yaml
+++ b/mods/d2k/weapons/smallguns.yaml
@@ -1,25 +1,25 @@
 ^MG:
 	ReloadDelay: 30
-	Range: 2c512
+	Range: 3c112
 	Report: MGUN2.WAV
 	Projectile: InstantHit
 		Inaccuracy: 135
 		InaccuracyType: PerCellIncrement
 	Warhead@1Dam: SpreadDamage
 		Damage: 1250
-		Spread: 480
+		Spread: 512
 		Falloff: 100, 0
 		Versus:
-			none: 110
+			none: 115
 			wall: 10
-			building: 25
-			wood: 75
-			light: 40
-			heavy: 18
+			building: 30
+			wood: 65
+			light: 35
+			heavy: 13
 			invulnerable: 0
 			cy: 20
-			harvester: 25
-		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
+			harvester: 23
+		DamageTypes: Prone80Percent, TriggerProne, BulletDeath
 		DamageCalculationType: ClosestTargetablePosition
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
@@ -41,6 +41,7 @@ M_LMG:
 	Inherits: ^MG
 	ReloadDelay: 40
 	ValidTargets: Infantry
+	Range: 4c0
 
 M_LMG_H:
 	Inherits: M_LMG
@@ -49,7 +50,7 @@ M_LMG_H:
 M_HMG:
 	Inherits: ^MG
 	ReloadDelay: 40
-	Range: 3c512
+	Range: 4c0
 	Report: 20MMGUN1.WAV
 	InvalidTargets: Infantry
 	Warhead@1Dam: SpreadDamage
@@ -76,14 +77,14 @@ Fremen_L:
 	Inherits: M_HMG
 	Report: BAZOOK2.WAV
 	Warhead@1Dam: SpreadDamage
-		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
+		DamageTypes: Prone80Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: small_explosion
 
 HMG:
 	Inherits: ^MG
 	ReloadDelay: 20
-	Range: 3c0
+	Range: 3c875
 	Report: 20MMGUN1.WAV
 	Warhead@1Dam: SpreadDamage
 		Damage: 1800


### PR DESCRIPTION
Lets bring D2k to 21 century :).  part of: #21154

Patch is big, but take in mind this is 4 years effort that was tested in custom maps and tournament maps.  Balance patch was made from scratch by me and Blacksir, but we ended with very similar balance to what was used in D2k tournaments and custom maps. Just with less radical changes. So this line from openra website is still valid:
_The Dune 2000 mod currently focuses on providing an experience that is authentic to the original game._
Casual and nostalgia players should be not confused by this patch. Biggest differences are in Support powers and Turrets.

Major changes:
-	No RevealOnFire.
-	speed penalty for tanks  activates when units has less that 25% HP instead of 50%.
-	New starting unit option: MCV + Carryall. Also add Carryall to heavy support and light support
-	Range increase for all units. Dependent on class and role. (this is needed as ORA big resolution and fog of war made OG weapon range obsolete)
-	Rebalanced Support powers: now the support power have real impact, and you want to use them. They are able to destroy big  blobs of army or buildings or wall of turrets.
     o	Deathhand: can kill any building/defenses (expect cy) in 6x6 cells.
     o	Airstrike: can kill any building/defenses (expect cy) in 7x3 cells
     o	Saboteur: permanent cloak. Add selfdestruction option that detonate plasmaExplosion weapon with 6c0 radius effect. When detonate building/vehicle plasmaExplosion is also applied. Doesn’t use prone.
         o	Spawn 5 fremens instead of 2.
-	Rebalanced turrets: in OG both turrets act as Strong vs tanks, vehicles and Weak vs infantry. Now they act as:
       o	Medium turret: Strong vs Light vehicles, Modest vs infantry, Weak vs Tanks. Fire 4x before reload
       o	Missile turret: Strong vs Tanks, Vehicles, Air. Weak vs infantry. 

Buildings:
-	Building repairs: RepairStep from 500 to 300 per step
-	construction_yard: power from 30 to 50. (Allow more early game openings.)
-	Wind trap: Hp from 30000 to 28000
-	Barracks: BuildDuration from 268 to 290. Cost from 225$ to 300$, Power from -30 to -50
-	Refinery: Armor type from heavy to building
-	Light factory: BuildDuration from 321 to 390. Cost from 500$ to 600$. Power from -125 to -100
-	Heavy factory: cost from 1000$ to 1200$
-	Outpost: RevealsShroud from 5c768 to 11c0. DetectCloaked to 6c0. Power from -125 to -75
-	Repair pad doesn’t require heavy.upgrade as prerequisite
-	Upgrade BuildDuration: Barrack.Upgrade from 208 to 260, light.upgrade from 268 to 330, heavy.upgrade from 468 to 600

Defenses:
-	Detected clock from 1c768 to 4c768
-	Armor type from heavy to wall. (Turrets are now vulnerable to Airstrike and DeathHand)
-	Wall cost from 20$ to 100$
-	Medium Turret: Hp from 27000 to 24000. BuildDuration from 268 to 310.  Fire 4x before reload. Reload time increase 4x
-	Rocket turret: HP from 30000 to 27000. BuildDuration from 312 to 380

Units:
-	Carryall: Cost from 1100$ to 1000$. Speed from 144 to 170. Idle speed 115. IdleTurn: 5. HP from 48000 to 20000
-	Trooper: Cost from 90$ to 100$. BuildDuration from 85 to 124 (double of light infantry)
-	Engineer: BuildDuration from 125 to 150
-	Grenadier: Explode only when firing.
-	MCV: Prerequisite doesn’t require heavy.upgrade
-	Trike: RevealsShroud from 4c768 to 5c512 (bonus compare to raider)
-	Raider: HP from 10000 to 9200. BuildDuration from 225 to 255. Cost from 350$ to 330$
-	Stealth Raider: BuildDuration 225 to 275. HP 10000
-	Combat tanks: all types + 1000 HP
     o	Atreides combat tank bonus: Range
     o	Harkonnen combat tank bonus: HP
     o	Ordos combat tank bonus: rate of fire
-	Siege: Cost from 700 to 800$. BuildDuration from 375 to 475. HP from 12000 to 11500. Speed from 43 to 40. Explode when killed.
-	Missile tank: speed from 64 to 60
-	Sonic Tank: Cost from 1000 to 1100$
-	Devastator: cost from 1050$ to 1200$.. Selfdestruct cannot be triggered when devastator is captured by Deviator. RevealsShroud same as combat tank. Selfdestruct time from 240 to 150. Dont spawn husk when killed by selfdestruction. 
-	Deviator: HP from 11000 to 12500. RevealsShroud from 5c512 to 6c0. Captured units are no longer automatically targeted by the former allies. They are targeted only when captured unit attack first. Add gas leaks from deviator husk, that can capture units within 1 cell radius. Gas leaks disappears after 350 ticks. Husk can be targeted by enemy without force fire.

Weapons
-	MG weapons: range from 2c512 to 3c112, Spread from 480 to 512. Trigger Prone80Percent instead of Prone50Percent. Versus armors:
     o	None: from 110 to 115
     o	Wood from 75 to 65
     o	Light: from 40 to 35
     o	Heavy: from 18 to 13
     o	Harvester: from 25 to 23
-	M_LMG: range from 3c512 to 4c0
-	HMG: range from 3c0 to 3870 
-	M_HMG: Range from 3c512 to 4c0
-	^Rocket: Range from 3c0 to 3c870. Inaccuracy from 140 to 130. Spread from 1c0 to 870. Trigger Prone80 instead of Prone50. Versus armor:
     o	None: from 15 to 10
     o	Wood: from 45 to 55
     o	Harvester: from 50 to 60
-	Rocket: range from 3c512 to 4c225. Double shot. Reload delay from 30 to 50. Burst from 1 to 2. Versus armor:
     o	Wall: from 100 to 70
     o	Harvester: from 50 to 55
-	^Missile: Range from 5c512 to 7c0. Range limit from 7c614 to 10c0. Versus armor:
     o	Wood: from 65 to 55
     o	Light: from 90 to 80
-	Mtank: range from 6c0 to 7c900
-	DeviatorMissile: range from 5c0 to 6c0. Damage from 1000 to 2000. ChangeOwner duration form 375 to 405
-	^Cannon: range from 4c0 to 4c624. Damage from 2700 to 2800. Trigger prone80 instead of prone50. 80mm_A has range bonus 0.5 cell. 80mm_O reload from 45 to 44.
-	110m_gun: burst from 1 to 4, Reload delay from 35 to 140. Range from 5c0 to 6c0. Versus armor:
     o	None: from 30 to 65
      o         Wood: from 60 to 80
      o	Heavy: from 80 to 30
-	155m:  range from 5c512 to 6c900. Reload from 80 to 105. Versus wall armor from 100 to 70. Spread from 2c0 to 1c800
-	devBullet:  Spread 1c0 to 1c225
-	Sound: Range from 5c0 to 6c0
-	Grenade: range from 4c0 to 4c225. Spread from 2c0 to 1c512. Use prone80 instead of prone50
-	PlasmaExplosion: Spread from 3c0 to 6c0. Destroy resource in 5 cell radius.

Other balance changes:
-	Husk HP -2000, reclaimed husk HP from 20% to 5%.
-	Aircrafts husks explode after impact dealing area damage.
-	Reduce Debris Spread damage. Debris1 from 1c0 to 0c756, Debris2 from 2c0 to 1c0, Debris3 from 1c0 to 1c512. 

Quality of live improvements:
-	 Selection priority for Saboteur from combat unit to support units.
-	Add skull icon for saboteur
-	Fix trike/raider going to close to target via MinimumScanTimeInterval: 0 and  MaximumScanTimeInterval: 0
-	Add contails to Aircraft husk, so there is more visible that they are falling down.
-	Add ambient sound to ornithopter (made by me) so player is aware airstrike is coming.
-	Add new targetable class: Tank (can be used for AI autotarget priority)
-	Add flash effect for deathHand and Sabouter detonations.
-	Move Engineer and Thumper to the bottom of the BuildPaletteOrder. So you can use F1 – F4 to most used units
-	Update encyclopedia: Encyclopedia use abstract terms as High exposive, High caliber, which no one understand. Add summary section that specifically against which units unit is good or bad. (My english is bad so there is high probability of typos.)


Know Issues:
-	Ordos faction has no easy way to deal with lots of turrets. Atreides have Airstrike, Harkonnen DeathHand, but ordos nothing. This cannot be solved within scope of OG units or support powers.  As alternative ordos Saboteur get, permanent cloack and selfdestruct ability, until future solution
-	Atreides Airstrike is OP right now. This is because it strikes only 1  with 2.5x bigger damage but should strike 3x with regular damage. Cannot be solved until d2k airstrike is implemented
-	Sonic tank will have proper testing after playtest will be released, as its not present in current stable.
-	Late campaign mission will become from super hard to imposible to finish. Will be adjusted after playtest release. Dependent on: #21878

