### PR TITLE
Check for and fix non-unit MultiBrush segment steps

### DIFF
--- a/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
@@ -189,9 +189,19 @@ namespace OpenRA.Mods.Common.MapGenerator
 					.Split(',', StringSplitOptions.RemoveEmptyEntries);
 				if (parts.Length % 2 != 0)
 					FieldLoader.InvalidValueAction(value, typeof(int2[]), "Points");
+
 				var points = new CVec[parts.Length / 2];
 				for (var i = 0; i < points.Length; i++)
+				{
 					points[i] = new CVec(Exts.ParseInt32Invariant(parts[2 * i]), Exts.ParseInt32Invariant(parts[2 * i + 1]));
+					if (i > 0)
+					{
+						var step = points[i] - points[i - 1];
+						if (Math.Abs(step.X) + Math.Abs(step.Y) != 1)
+							throw new YamlException($"Points sequence {value} has non-unit steps");
+					}
+				}
+
 				Points = [.. points];
 			}
 		}

--- a/mods/cnc/tilesets/desert.yaml
+++ b/mods/cnc/tilesets/desert.yaml
@@ -2232,7 +2232,7 @@ MultiBrushCollections:
 				Start: Cliff.L
 				Inner: Cliff
 				End: Cliff.L
-				Points: 2,1, 1,1, 0,2
+				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@19:
 			Template: 19
 			Segment:

--- a/mods/cnc/tilesets/snow.yaml
+++ b/mods/cnc/tilesets/snow.yaml
@@ -1879,7 +1879,7 @@ MultiBrushCollections:
 				Start: Cliff.L
 				Inner: Cliff
 				End: Cliff.L
-				Points: 2,1, 1,1, 0,2
+				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@19:
 			Template: 19
 			Segment:

--- a/mods/cnc/tilesets/temperat.yaml
+++ b/mods/cnc/tilesets/temperat.yaml
@@ -1880,7 +1880,7 @@ MultiBrushCollections:
 				Start: Cliff.L
 				Inner: Cliff
 				End: Cliff.L
-				Points: 2,1, 1,1, 0,2
+				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@19:
 			Template: 19
 			Segment:

--- a/mods/cnc/tilesets/winter.yaml
+++ b/mods/cnc/tilesets/winter.yaml
@@ -1915,7 +1915,7 @@ MultiBrushCollections:
 				Start: Cliff.L
 				Inner: Cliff
 				End: Cliff.L
-				Points: 2,1, 1,1, 0,2
+				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@19:
 			Template: 19
 			Segment:

--- a/mods/ra/tilesets/desert.yaml
+++ b/mods/ra/tilesets/desert.yaml
@@ -3475,7 +3475,7 @@ MultiBrushCollections:
 				Start: Cliff.L
 				Inner: Cliff
 				End: Cliff.L
-				Points: 2,1, 1,1, 0,2
+				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@186:
 			Template: 186
 			Segment:

--- a/mods/ra/tilesets/snow.yaml
+++ b/mods/ra/tilesets/snow.yaml
@@ -4015,7 +4015,7 @@ MultiBrushCollections:
 				Start: Cliff.L
 				Inner: Cliff
 				End: Cliff.L
-				Points: 2,1, 1,1, 0,2
+				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@141:
 			Template: 141
 			Segment:

--- a/mods/ra/tilesets/temperat.yaml
+++ b/mods/ra/tilesets/temperat.yaml
@@ -4475,7 +4475,7 @@ MultiBrushCollections:
 				Start: Cliff.L
 				Inner: Cliff
 				End: Cliff.L
-				Points: 2,1, 1,1, 0,2
+				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@141:
 			Template: 141
 			Segment:


### PR DESCRIPTION
TilingPath's algorithms are designed on the assumption that MultiBrush segments use unit steps in their point sequences. Non-unit sequences can result in incorrect or suboptimal tilings.

This change ensures point sequences are validated for unit steps, and fixes a non-compliant cliff tile across all tilesets.
