### PR TITLE
feature: Implement height editing in map editor

### DIFF
--- a/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
@@ -30,6 +30,11 @@ namespace OpenRA.Mods.Common.Widgets
 		IEnumerable<IRenderable> RenderAnnotations(Actor self, WorldRenderer wr);
 	}
 
+	public interface IKeyHandlingEditorBrush : IEditorBrush
+	{
+		bool HandleKeyPress(KeyInput ki);
+	}
+
 	public class EditorSelection
 	{
 		public CellRegion Area;

--- a/OpenRA.Mods.Common/EditorBrushes/EditorHeightBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorHeightBrush.cs
@@ -1,0 +1,192 @@
+#region Copyright & License Information
+
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
+
+namespace OpenRA.Mods.Common.Widgets
+{
+	public sealed class EditorHeightBrush(
+		HeightTool heightTool,
+		World world,
+		WorldRenderer worldRenderer,
+		EditorActionManager editorActionManager)
+		: IKeyHandlingEditorBrush
+	{
+		ChangeHeightEditorAction action;
+
+		CPos? cell;
+		int size = heightTool.Info.MinSize;
+		HeightTool.Settings settings;
+
+		public CPos? Cell
+		{
+			get => cell;
+			set
+			{
+				cell = value;
+				Update();
+			}
+		}
+
+		public int Size
+		{
+			get => size;
+			set
+			{
+				size = value;
+				Update();
+			}
+		}
+
+		public HeightTool.Settings Settings
+		{
+			get => settings;
+			private set
+			{
+				settings = value;
+				Update();
+			}
+		}
+
+		void Update()
+		{
+			heightTool.Update(cell, size, settings);
+		}
+
+		public bool HandleMouseInput(MouseInput mouseInput)
+		{
+			var oldCell = cell;
+			Cell = worldRenderer.Viewport.ViewToWorld(mouseInput.Location);
+
+			if (mouseInput.Button == MouseButton.Left)
+			{
+				if (mouseInput.Event == MouseInputEvent.Down)
+				{
+					editorActionManager.Add(action = new ChangeHeightEditorAction(world));
+					action.Add(heightTool.Changes);
+					return true;
+				}
+
+				if (mouseInput.Event == MouseInputEvent.Up)
+				{
+					action = null;
+					return true;
+				}
+			}
+
+			if (mouseInput.Event == MouseInputEvent.Move && action != null && oldCell != cell)
+				action.Add(heightTool.Changes);
+
+			if (mouseInput.Event == MouseInputEvent.Scroll && mouseInput.Modifiers.HasFlag(Modifiers.Alt))
+			{
+				// TODO: it seems scrolling cannot be captured by the editor brush, so it doesn't work here.
+				Size = Math.Clamp(Size + (mouseInput.Delta.Y > 0 ? 1 : -1), heightTool.Info.MinSize, heightTool.Info.MaxSize);
+				return true;
+			}
+
+			return false;
+		}
+
+		void IEditorBrush.TickRender(WorldRenderer wr, Actor self) { }
+		IEnumerable<IRenderable> IEditorBrush.RenderAboveShroud(Actor self, WorldRenderer wr) { yield break; }
+		IEnumerable<IRenderable> IEditorBrush.RenderAnnotations(Actor self, WorldRenderer wr) { yield break; }
+
+		public bool HandleKeyPress(KeyInput keyInput)
+		{
+			// TODO we might want to set these in the controls?
+			switch (keyInput.Key)
+			{
+				case Keycode.LCTRL or Keycode.RCTRL:
+					ToggleSetting(HeightTool.Settings.Lower, keyInput.Event == KeyInputEvent.Down);
+					break;
+
+				case Keycode.TAB:
+					if (keyInput.Event == KeyInputEvent.Down)
+						ToggleSetting(HeightTool.Settings.Circle);
+					break;
+			}
+
+			return false;
+		}
+
+		public void ToggleSetting(HeightTool.Settings setting, bool? active = null)
+		{
+			switch (active)
+			{
+				case true:
+				case null when !Settings.HasFlag(setting):
+					Settings |= setting;
+					break;
+
+				case false:
+				case null when Settings.HasFlag(setting):
+					Settings &= ~setting;
+					break;
+			}
+		}
+
+		public void Tick() { }
+
+		public void Dispose() { }
+	}
+
+	sealed class ChangeHeightEditorAction(World world) : IEditorAction
+	{
+		readonly Dictionary<CPos, HeightTool.Change> changes = [];
+
+		public void Execute()
+		{
+		}
+
+		public void Do()
+		{
+			Do(changes);
+		}
+
+		void Do(IReadOnlyDictionary<CPos, HeightTool.Change> newChanges)
+		{
+			foreach (var (cell, change) in newChanges)
+			{
+				if (change.Old != change.New)
+					world.Map.Height[cell] = change.New;
+			}
+		}
+
+		public void Undo()
+		{
+			foreach (var (cell, change) in changes)
+			{
+				if (change.Old != change.New)
+					world.Map.Height[cell] = change.Old;
+			}
+		}
+
+		public string Text { get; }
+
+		public void Add(IReadOnlyDictionary<CPos, HeightTool.Change> newChanges)
+		{
+			foreach (var (cell, newChange) in newChanges)
+			{
+				if (changes.TryGetValue(cell, out var oldChange))
+					oldChange.New = newChange.New;
+				else
+					changes.Add(cell, newChange);
+			}
+
+			Do(newChanges);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/World/HeightTool.cs
+++ b/OpenRA.Mods.Common/Traits/World/HeightTool.cs
@@ -1,0 +1,157 @@
+#region Copyright & License Information
+
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Traits;
+using Color = OpenRA.Primitives.Color;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[TraitLocation(SystemActors.EditorWorld)]
+	public sealed class HeightToolInfo : TraitInfo, IEditorToolInfo
+	{
+		[FluentReference]
+		const string Label = "label-tool-height";
+
+		[Desc("The widget tree to open when the tool is selected.")]
+		const string PanelWidget = "HEIGHT_TOOL_PANEL";
+
+		public readonly int MinSize = 1;
+		public readonly int MaxSize = 10;
+
+		public override object Create(ActorInitializer init)
+		{
+			return new HeightTool(init.World, this);
+		}
+
+		string IEditorToolInfo.Label => Label;
+		string IEditorToolInfo.PanelWidget => PanelWidget;
+	}
+
+	public sealed class HeightTool(World world, HeightToolInfo info) : IRenderAnnotations
+	{
+		[Flags]
+		public enum Settings
+		{
+			Lower = 0x01,
+			Circle = 0x02
+		}
+
+		public class Change
+		{
+			public byte Old;
+			public byte New;
+			public bool Extended;
+		}
+
+		public readonly HeightToolInfo Info = info;
+
+		readonly Dictionary<CPos, Change> changes = [];
+		CPos? currentCell;
+		int currentSize;
+		Settings currentSettings;
+
+		public bool SpatiallyPartitionable => false;
+		public IReadOnlyDictionary<CPos, Change> Changes => new ReadOnlyDictionary<CPos, Change>(changes);
+
+		public void Update(CPos? cell, int size, Settings settings)
+		{
+			if (currentCell == cell && currentSize == size && currentSettings == settings)
+				return;
+
+			currentCell = cell;
+			currentSize = size;
+			currentSettings = settings;
+
+			RebuildCache();
+		}
+
+		public IEnumerable<IRenderable> RenderAnnotations(Actor self, WorldRenderer wr)
+		{
+			foreach (var (cell, change) in changes)
+			{
+				var color = change.New > change.Old ? Color.FromArgb(0x00, 0xff, 0x00) :
+					change.New < change.Old ? Color.FromArgb(0xff, 0x00, 0x00) :
+					change.Extended ? Color.FromArgb(0x00, 0x00, 0xff) :
+					Color.FromArgb(0x22, 0x22, 0x22);
+
+				yield return new MarkerTileRenderable(cell, Color.FromArgb(0x22, color));
+			}
+		}
+
+		void RebuildCache()
+		{
+			changes.Clear();
+
+			if (currentCell == null || !world.Map.Contains(currentCell.Value))
+				return;
+
+			var brushCells = GetBrushCells(currentCell.Value);
+			ApplyDesiredHeightChanges(brushCells);
+		}
+
+		HashSet<CPos> GetBrushCells(CPos centerCell)
+		{
+			var cells = new HashSet<CPos>();
+			var center = world.Map.CenterOfCell(centerCell);
+			var radius = currentSize / 2;
+
+			for (var x = -radius; x <= radius; x++)
+			{
+				for (var y = -radius; y <= radius; y++)
+				{
+					var cell = centerCell - new CVec(x, y);
+
+					if (!world.Map.Contains(cell))
+						continue;
+
+					if (currentSettings.HasFlag(Settings.Circle) && (world.Map.CenterOfCell(cell) - center).Length > radius * 1024)
+						continue;
+
+					cells.Add(cell);
+				}
+			}
+
+			return cells;
+		}
+
+		void ApplyDesiredHeightChanges(HashSet<CPos> brushCells)
+		{
+			byte source;
+			byte target;
+
+			if (currentSettings.HasFlag(Settings.Lower))
+			{
+				source = brushCells.Max(cell => world.Map.Height[cell]);
+				target = (byte)Math.Clamp(source - 1, byte.MinValue, world.Map.Grid.MaximumTerrainHeight);
+			}
+			else
+			{
+				source = brushCells.Min(cell => world.Map.Height[cell]);
+				target = (byte)Math.Clamp(source + 1, byte.MinValue, world.Map.Grid.MaximumTerrainHeight);
+			}
+
+			if (source == target)
+				return;
+
+			foreach (var cell in brushCells.Where(cell => world.Map.Height[cell] == source))
+			{
+				changes.Add(cell, new Change { Old = source, New = target });
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/EditorViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/EditorViewportControllerWidget.cs
@@ -118,6 +118,14 @@ namespace OpenRA.Mods.Common.Widgets
 			return base.HandleMouseInput(mi);
 		}
 
+		public override bool HandleKeyPress(KeyInput e)
+		{
+			if (CurrentBrush is IKeyHandlingEditorBrush keyHandlingBrush && keyHandlingBrush.HandleKeyPress(e))
+				return true;
+
+			return base.HandleKeyPress(e);
+		}
+
 		WPos cachedViewportPosition;
 		public override void Tick()
 		{

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/HeightToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/HeightToolLogic.cs
@@ -1,0 +1,79 @@
+#region Copyright & License Information
+
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+
+#endregion
+
+using System.Globalization;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+	[IncludeStaticFluentReferences(typeof(ChangeHeightEditorAction))]
+	public sealed class HeightToolLogic : ChromeLogic
+	{
+		readonly EditorViewportControllerWidget editor;
+		readonly EditorHeightBrush heightBrush;
+
+		[ObjectCreator.UseCtor]
+		public HeightToolLogic(Widget widget, World world, WorldRenderer worldRenderer)
+		{
+			var heightTool = world.WorldActor.Trait<HeightTool>();
+			var editorActionManager = world.WorldActor.Trait<EditorActionManager>();
+
+			heightBrush = new EditorHeightBrush(heightTool, world, worldRenderer, editorActionManager);
+
+			editor = widget.Parent.Parent.Parent.Parent.Get<EditorViewportControllerWidget>("MAP_EDITOR");
+			editor.BrushChanged += HandleBrushChanged;
+
+			var sizeDropdown = widget.Get<DropDownButtonWidget>("DROPDOWN");
+			sizeDropdown.GetText = () => heightBrush.Size.ToString(CultureInfo.InvariantCulture);
+			sizeDropdown.OnClick = () => sizeDropdown.ShowDropDown(
+				"LABEL_DROPDOWN_TEMPLATE",
+				270,
+				Enumerable.Range(heightTool.Info.MinSize, heightTool.Info.MaxSize - heightTool.Info.MinSize + 1),
+				SetupItem);
+
+			var direction = widget.Get<ButtonWidget>("DIRECTION");
+			direction.OnClick = () => heightBrush.ToggleSetting(HeightTool.Settings.Lower);
+			direction.GetText = () => FluentProvider.GetMessage(heightBrush.Settings.HasFlag(HeightTool.Settings.Lower) ? "label-height-down" : "label-height-up");
+
+			var circle = widget.Get<ButtonWidget>("CIRCLE");
+			circle.OnClick = () => heightBrush.ToggleSetting(HeightTool.Settings.Circle);
+			circle.IsHighlighted = () => heightBrush.Settings.HasFlag(HeightTool.Settings.Circle);
+
+			var paint = widget.Get<ButtonWidget>("PAINT");
+			paint.OnClick = () => editor.SetBrush(paint.IsHighlighted() ? null : heightBrush);
+			paint.IsHighlighted = () => editor.CurrentBrush is EditorHeightBrush;
+		}
+
+		ScrollItemWidget SetupItem(int size, ScrollItemWidget itemTemplate)
+		{
+			var item = ScrollItemWidget.Setup(itemTemplate, () => heightBrush.Size == size, () => heightBrush.Size = size);
+			item.Get<LabelWidget>("LABEL").GetText = () => size.ToString(CultureInfo.InvariantCulture);
+			return item;
+		}
+
+		void HandleBrushChanged()
+		{
+			if (editor.CurrentBrush is not EditorHeightBrush)
+				heightBrush.Cell = null;
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			editor.BrushChanged -= HandleBrushChanged;
+			base.Dispose(disposing);
+		}
+	}
+}

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -1052,6 +1052,45 @@ ScrollPanel@MAP_GENERATOR_TOOL_PANEL:
 							Height: 25
 							PanelRoot: EDITOR_WORLD_ROOT
 
+Background@HEIGHT_TOOL_PANEL:
+	X: 10
+	Y: 35
+	Width: PARENT_WIDTH - 20
+	Height: WINDOW_HEIGHT - 490
+	Background: scrollpanel-bg
+	Visible: false
+	Logic: HeightToolLogic
+	Children:
+		LabelForInput@LABEL:
+			X: 5
+			Y: 0
+			Width: PARENT_WIDTH - 10
+			Height: 20
+			Text: label-height-brush-size
+			For: DROPDOWN
+		DropDownButton@DROPDOWN:
+			X: 5
+			Y: 20
+			Width: PARENT_WIDTH - 10
+			Height: 25
+		Button@DIRECTION:
+			X: 5
+			Y: 50
+			Width: (PARENT_WIDTH - 20) / 2
+			Height: 25
+		Button@CIRCLE:
+			X: 5 + ((PARENT_WIDTH - 20) / 2 + 5)
+			Y: 50
+			Width: (PARENT_WIDTH - 20) / 2
+			Height: 25
+			Text: label-height-circle
+		Button@PAINT:
+			X: 5
+			Y: 80
+			Width: PARENT_WIDTH - 10
+			Height: 25
+			Text: label-height-paint
+
 ScrollPanel@TILING_PATH_TOOL_PANEL:
 	X: 10
 	Y: 35

--- a/mods/common/fluent/chrome.ftl
+++ b/mods/common/fluent/chrome.ftl
@@ -126,6 +126,13 @@ button-select-categories-buttons-none = None
 
 label-tool-marker-tiles = Marker Tiles
 label-tool-tiling-path = Path Tiler
+label-tool-height = Height
+
+label-height-brush-size = Brush size
+label-height-up = Up
+label-height-down = Down
+label-height-circle = Circle
+label-height-paint = Paint
 
 ## gamesave-browser.yaml
 label-gamesave-browser-panel-load-title = Load game

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -430,3 +430,4 @@ EditorWorld:
 		Palette: ra
 		Alpha: 0.35
 	MarkerLayerOverlay:
+	HeightTool:


### PR DESCRIPTION
Concider this a draft!

Basic implementation of height editing in the map editor.

Open topics:
- Re-calculation of tiles and ramps is currently missing.
- Due to above restriction, the Extend option does currently not extend the changed tiles outside of the brush.
- It seems the mousewheel cannot be processed in the brush for easier brush size manipulation.
- We might want to be able to change the editor keys via the settings?
