### PR TITLE
Make aircraft return to base when out of ammo

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -74,6 +74,18 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override bool Tick(Actor self)
 		{
+			// Check if aircraft needs to rearm before continuing attack
+			if (rearmable != null && !returnToBase)
+			{
+				var ammoPool = self.TraitsImplementing<AmmoPool>().FirstOrDefault();
+				if (ammoPool == null || !ammoPool.HasAmmo)
+				{
+					// Return to base when out of ammo
+					QueueChild(new ReturnToBase(self));
+					return true;
+				}
+			}
+
 			if (!IsCanceling && !HasArmamentsFor(target))
 				Cancel(self, true);
 
@@ -128,13 +140,21 @@ namespace OpenRA.Mods.Common.Activities
 
 			// If all valid weapons have depleted their ammo and Rearmable trait exists, return to RearmActor to reload
 			// and resume the activity after reloading if AbortOnResupply is set to 'false'
-			if (rearmable != null && !useLastVisibleTarget && attackAircraft.Armaments.All(x => x.IsTraitPaused || !x.Weapon.IsValidAgainst(target, self.World, self)))
+			// Fix the weapon validity check
+			if (rearmable != null && !useLastVisibleTarget &&
+				attackAircraft.Armaments.All(x =>
+					x.IsTraitPaused ||
+					(rearmable != null &&
+						(self.TraitsImplementing<AmmoPool>().FirstOrDefault() == null ||
+						 !self.TraitsImplementing<AmmoPool>().FirstOrDefault().HasAmmo)) ||
+					!x.Weapon.IsValidAgainst(target, self.World, self)))
 			{
 				// Attack moves never resupply
 				if (source == AttackSource.AttackMove)
 					return true;
 
-				// AbortOnResupply cancels the current activity (after resupplying) plus any queued activities
+				// AbortOnResupply cancels the current activity (after resupplying)
+				// plus any queued activities
 				if (attackAircraft.Info.AbortOnResupply)
 					NextActivity?.Cancel(self);
 

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -746,6 +746,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected virtual void OnBecomingIdle(Actor self)
 		{
+			// Add ammo check before other idle behaviors
+			if (rearmable != null && rearmable.Info.RearmActors.Count > 0 &&
+				self.TraitsImplementing<AmmoPool>().Any(p => !p.HasAmmo))
+			{
+				self.QueueActivity(new ReturnToBase(self));
+				return;
+			}
+
 			if (Info.IdleBehavior == IdleBehaviorType.LeaveMap)
 			{
 				self.QueueActivity(new FlyOffMap(self));


### PR DESCRIPTION
Fixes aircraft getting stuck in the air or flying aimlessly when out of ammo. Key changes:
- Add early ammo check in FlyAttack to detect empty ammo pools
- Update weapon validity check to properly handle empty ammo pools
- Add ammo check in Aircraft.OnBecomingIdle for proper idle behavior
- Maintain existing attack-move and abort behavior logic

Fixes #21893 where rearmable aircraft would not automatically return to base when out of ammo during attacks.
