### PR TITLE
Fix copy-paste editor crash for RectangularIsometric

### DIFF
--- a/OpenRA.Mods.Common/EditorBrushes/EditorBlit.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorBlit.cs
@@ -275,9 +275,11 @@ namespace OpenRA.Mods.Common.EditorBrushes
 		{
 			var mask = new HashSet<CPos>();
 
+			var sourceCellCoords = blitSource.CellRegion.CellCoords;
+
 			foreach (var (cpos, _) in blitSource.Tiles)
 			{
-				if (!blitSource.CellRegion.Contains(cpos))
+				if (!sourceCellCoords.Contains(cpos))
 					throw new ArgumentException("EditorBlitSource contains a BlitTile outside of its CellRegion");
 				mask.Add(cpos + offset);
 			}
@@ -286,11 +288,13 @@ namespace OpenRA.Mods.Common.EditorBrushes
 			{
 				var anyContained = false;
 				foreach (var cpos in editorActorPreview.Footprint.Keys)
-					if (blitSource.CellRegion.Contains(cpos))
+				{
+					if (sourceCellCoords.Contains(cpos))
 					{
 						mask.Add(cpos + offset);
 						anyContained = true;
 					}
+				}
 
 				if (!anyContained)
 					throw new ArgumentException("EditorBlitSource contains an actor entirely outside of its CellRegion");


### PR DESCRIPTION
EditorBlit was incorrectly using CellRegion.Contains instead of CellRegion.CellCoords.Contains (i.e. CellCoordsRegion.Contains). This resulted in a crash upon attempting to paste within the editor for RectangularIsometric maps (such as in TS).

This change updates the code to use the correct region type and fixes the crash.
