### PR TITLE
Remove empty Path Tiling Tool dropdown tooltips

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/TilingPathToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/TilingPathToolLogic.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						return item;
 					}
 
-					dropDown.ShowDropDown("LABEL_DROPDOWN_WITH_TOOLTIP_TEMPLATE", choices.Length * 30, choices, SetupItem);
+					dropDown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", choices.Length * 30, choices, SetupItem);
 				};
 			}
 


### PR DESCRIPTION
I'd accidentally copy-pasted the wrong item template in the original TilingPathToolLogic implementation. This change uses the normal tooltipless LABEL_DROPDOWN_TEMPLATE.
