### PR TITLE
Make rules lint utility cleaner

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		{
 			var originalColor = Console.ForegroundColor;
 			Console.ForegroundColor = ConsoleColor.Red;
-			Console.Write("OpenRA.Utility(1,1): Error:");
+			Console.Write("Error: ");
 			Console.ForegroundColor = originalColor;
 			Console.WriteLine(e);
 			++errors;
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			{
 				var originalColor = Console.ForegroundColor;
 				Console.ForegroundColor = ConsoleColor.Yellow;
-				Console.Write("OpenRA.Utility(1,1): Warning:");
+				Console.Write("Warning: ");
 				Console.ForegroundColor = originalColor;
 				Console.WriteLine(e);
 				++warnings;


### PR DESCRIPTION
- Forgot to add whitespace between error and log message. 
- Remove redundant "OpenRA.Utility(1,1):". I'm not sure why it's there, it's not used in other lints. For history see #7190 and #3837

# Preview

<img width="859" alt="Screenshot 2025-06-14 at 13 58 19" src="https://github.com/user-attachments/assets/4ccb07d3-c730-4a47-b113-067f95af093f" />