### PR TITLE
Allow null sequence arrays

### DIFF
--- a/OpenRA.Mods.Common/Lint/LintExts.cs
+++ b/OpenRA.Mods.Common/Lint/LintExts.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Lint
 				return [(string)fieldInfo.GetValue(ruleInfo)];
 
 			if (typeof(IEnumerable<string>).IsAssignableFrom(type))
-				return fieldInfo.GetValue(ruleInfo) as IEnumerable<string>;
+				return fieldInfo.GetValue(ruleInfo) as IEnumerable<string> ?? [];
 
 			if (type == typeof(BooleanExpression) || type == typeof(IntegerExpression))
 			{


### PR DESCRIPTION
Currently we allow

```csharp
[SequenceReference(nameof(Image), allowNullImage: true)]
public readonly string GroundCorpseSequence = null;
```

but dissalow
```csharp
[SequenceReference(nameof(Image), allowNullImage: true)]
public readonly string[] GroundCorpseSequence = null;
```

as the lint crashes