### PR TITLE
Add server setting 'AdvertiseOnLocalNetwork'

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -969,7 +969,8 @@ namespace OpenRA
 			{
 				Name = "Skirmish Game",
 				Map = map,
-				AdvertiseOnline = false
+				AdvertiseOnline = false,
+				AdvertiseOnLocalNetwork = !isSkirmish
 			};
 
 			// Always connect to local games using the same loopback connection

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -53,6 +53,9 @@ namespace OpenRA
 		[Desc("Reports the game to the master server list.")]
 		public bool AdvertiseOnline = true;
 
+		[Desc("Reports the game on the local area network.")]
+		public bool AdvertiseOnLocalNetwork = true;
+
 		[Desc("Locks the game with a password.")]
 		public string Password = "";
 

--- a/launch-dedicated.cmd
+++ b/launch-dedicated.cmd
@@ -7,6 +7,7 @@ set Mod=ra
 set Map=""
 set ListenPort=1234
 set AdvertiseOnline=True
+set AdvertiseOnLocalNetwork=True
 set Password=""
 set RecordReplays=False
 
@@ -26,6 +27,6 @@ set SupportDir=""
 
 :loop
 
-bin\OpenRA.Server.exe Engine.EngineDir=".." Game.Mod=%Mod% Server.Name=%Name% Server.Map=%Map% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.RecordReplays=%RecordReplays% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports% Server.EnableGeoIP=%EnableGeoIP% Server.EnableLintChecks=%EnableLintChecks% Server.ShareAnonymizedIPs=%ShareAnonymizedIPs% Server.FloodLimitJoinCooldown=%FloodLimitJoinCooldown% Engine.SupportDir=%SupportDir%
+bin\OpenRA.Server.exe Engine.EngineDir=".." Game.Mod=%Mod% Server.Name=%Name% Server.Map=%Map% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.AdvertiseOnLocalNetwork=%AdvertiseOnLocalNetwork% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.RecordReplays=%RecordReplays% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports% Server.EnableGeoIP=%EnableGeoIP% Server.EnableLintChecks=%EnableLintChecks% Server.ShareAnonymizedIPs=%ShareAnonymizedIPs% Server.FloodLimitJoinCooldown=%FloodLimitJoinCooldown% Engine.SupportDir=%SupportDir%
 
 goto loop

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -15,6 +15,7 @@ Mod="${Mod:-"ra"}"
 Map="${Map:-""}"
 ListenPort="${ListenPort:-"1234"}"
 AdvertiseOnline="${AdvertiseOnline:-"True"}"
+AdvertiseOnLocalNetwork="${AdvertiseOnLocalNetwork:-"True"}"
 Password="${Password:-""}"
 RecordReplays="${RecordReplays:-"False"}"
 
@@ -38,6 +39,7 @@ while true; do
      Server.Map="$Map" \
      Server.ListenPort="$ListenPort" \
      Server.AdvertiseOnline="$AdvertiseOnline" \
+     Server.AdvertiseOnLocalNetwork="$AdvertiseOnLocalNetwork" \
      Server.EnableSingleplayer="$EnableSingleplayer" \
      Server.Password="$Password" \
      Server.RecordReplays="$RecordReplays" \


### PR DESCRIPTION

Follow up to #21614

- No GUI changes. Optionally a checkbox could be added to the Create game server panel in future.
- Add Game.Settings.Server.AdvertiseOnLocalNetwork bool.
- Do not create a BeaconLib Beacon if set to false. Creating the Beacon already causes a UDP socket bind.

Tested, but not thourougly.

See the issue for the underlying goal.




