### PR TITLE
DensePathGraph, only traverse layers if enabl…

### DIFF
--- a/OpenRA.Mods.Common/Pathfinder/DensePathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/DensePathGraph.cs
@@ -136,20 +136,23 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 			if (layer == 0)
 			{
-				foreach (var cml in CustomMovementLayers)
+				if (customMovementLayersEnabledForLocomotor > 0)
 				{
-					if (cml == null || !cml.EnabledForLocomotor(locomotor.Info))
-						continue;
+					foreach (var cml in CustomMovementLayers)
+					{
+						if (cml == null || !cml.EnabledForLocomotor(locomotor.Info))
+							continue;
 
-					var layerPosition = new CPos(position.X, position.Y, cml.Index);
-					if (!IsValidNeighbor(layerPosition))
-						continue;
+						var layerPosition = new CPos(position.X, position.Y, cml.Index);
+						if (!IsValidNeighbor(layerPosition))
+							continue;
 
-					var entryCost = cml.EntryMovementCost(locomotor.Info, layerPosition);
-					if (entryCost != PathGraph.MovementCostForUnreachableCell &&
-						CanEnterNode(position, layerPosition, targetPredicate) &&
-						this[layerPosition].Status != CellStatus.Closed)
-						validNeighbors.Add(new GraphConnection(layerPosition, entryCost));
+						var entryCost = cml.EntryMovementCost(locomotor.Info, layerPosition);
+						if (entryCost != PathGraph.MovementCostForUnreachableCell &&
+							CanEnterNode(position, layerPosition, targetPredicate) &&
+							this[layerPosition].Status != CellStatus.Closed)
+							validNeighbors.Add(new GraphConnection(layerPosition, entryCost));
+					}
 				}
 			}
 			else


### PR DESCRIPTION
Closes #21263. 

Only traverse custom movement layers if locomotor is enabled for at least one of them.

Not able to add it to other source files as the locomotor is passed as argument there. An future improvement could be for each Locomotor or ResolvedLocomotor to have a boolean attribute to indicate if at least one custom movement layer support it. Or it might as well maintain a list of those movement layers that support the locomotor.

Untested.


