### PR TITLE
Fix FireProjectilesOnDeath not working for aircraft husks

### DIFF
--- a/OpenRA.Mods.Common/Traits/FireProjectilesOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/FireProjectilesOnDeath.cs
@@ -81,6 +81,8 @@ namespace OpenRA.Mods.Common.Traits
 				for (var i = 0; pieces > i; i++)
 				{
 					var rotation = WRot.FromYaw(new WAngle(self.World.SharedRandom.Next(1024)));
+					var dat = self.World.Map.DistanceAboveTerrain(self.CenterPosition);
+					var source = dat.Length < 0 ? self.CenterPosition - new WVec(0, 0, dat.Length) : self.CenterPosition;
 					var args = new ProjectileArgs
 					{
 						Weapon = wep,
@@ -96,10 +98,10 @@ namespace OpenRA.Mods.Common.Traits
 						RangeModifiers = self.TraitsImplementing<IRangeModifier>()
 							.Select(a => a.GetRangeModifier()).ToArray(),
 
-						Source = self.CenterPosition,
-						CurrentSource = () => self.CenterPosition,
+						Source = source,
+						CurrentSource = () => source,
 						SourceActor = self,
-						PassiveTarget = self.CenterPosition + new WVec(range, 0, 0).Rotate(rotation)
+						PassiveTarget = source + new WVec(range, 0, 0).Rotate(rotation)
 					};
 
 					self.World.AddFrameEndTask(x =>


### PR DESCRIPTION
Noticed in #21930

Projectiles were being spawned from the underground