### PR TITLE
Fix error IDE0028: Collection initialization can be simplified.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -131,7 +131,7 @@ namespace OpenRA.Mods.Common.Widgets
 						if (s != null)
 						{
 							// Select actors on the screen that have the same selection class as the actor under the mouse cursor
-							var newSelection = SelectionUtils.SelectActorsOnScreen(World, worldRenderer, new HashSet<string> { s.Class }, eligiblePlayers);
+							var newSelection = SelectionUtils.SelectActorsOnScreen(World, worldRenderer, [s.Class], eligiblePlayers);
 
 							World.Selection.Combine(World, newSelection, true, false);
 						}


### PR DESCRIPTION

`make check` resulted in below error. 

OpenRA/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs(134,85): error IDE0028: Collection initialization can 
be simplified (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0028) [OpenRA/OpenRA.Mods.Common
/OpenRA.Mods.Common.csproj] 