### PR TITLE
Use support sequences for scripted powers

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/AirstrikeProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/AirstrikeProperties.cs
@@ -30,6 +30,9 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Activate the actor's Airstrike Power. Returns the aircraft that will attack.")]
 		public Actor[] TargetAirstrike(WPos target, WAngle? facing = null)
 		{
+			foreach (var notify in Self.TraitsImplementing<INotifySupportPower>())
+				notify.Activated(Self);
+
 			return ap.SendAirstrike(Self, target, facing);
 		}
 	}

--- a/OpenRA.Mods.Common/Scripting/Properties/NukeProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/NukeProperties.cs
@@ -31,6 +31,9 @@ namespace OpenRA.Mods.Common.Scripting
 		public void ActivateNukePower(CPos target)
 		{
 			np.Activate(Self, Self.World.Map.CenterOfCell(target));
+
+			foreach (var notify in Self.TraitsImplementing<INotifySupportPower>())
+				notify.Activated(Self);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/Properties/ParadropProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ParadropProperties.cs
@@ -31,6 +31,9 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Command transport to paradrop passengers near the target cell.")]
 		public void Paradrop(CPos cell)
 		{
+			foreach (var notify in Self.TraitsImplementing<INotifySupportPower>())
+				notify.Activated(Self);
+
 			paradrop.SetLZ(cell, true);
 			Self.QueueActivity(new Fly(Self, Target.FromCell(Self.World, cell)));
 			Self.QueueActivity(new FlyOffMap(Self));

--- a/OpenRA.Mods.Common/Scripting/Properties/ParatroopersProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ParatroopersProperties.cs
@@ -30,6 +30,9 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Activate the actor's Paratroopers Power. Returns the aircraft that will drop the reinforcements.")]
 		public Actor[] TargetParatroopers(WPos target, WAngle? facing = null)
 		{
+			foreach (var notify in Self.TraitsImplementing<INotifySupportPower>())
+				notify.Activated(Self);
+
 			var actors = pp.SendParatroopers(Self, target, facing);
 			return actors.Aircraft;
 		}


### PR DESCRIPTION
https://github.com/user-attachments/assets/76b627cd-1630-432c-93c8-7f42ef45489b

This PR activates support power sequences/overlays an actor may have when a map script activates their power. At the moment, this namely affects:
- Temples of Nod (CnC)
- Missile Silos (RA, shown in `allies-10a`)
- Palaces (D2k; Death Hand launches)
- Nod Missile Silos (TS)

These make use of `WithSupportPowerActivationAnimation` or `WithSupportPowerActivationOverlay`. Chronospheres already activate their sequence [from somewhere else entirely](https://github.com/OpenRA/OpenRA/blob/2e3a30c9ca0e12df4255dbaefdf0b01462604ed0/OpenRA.Mods.Cnc/Activities/Teleport.cs#L108-113).