### PR TITLE
allies-08ab: Remove tech center as bomber target

### DIFF
--- a/mods/ra/maps/allies-08a/allies08a-AI.lua
+++ b/mods/ra/maps/allies-08a/allies08a-AI.lua
@@ -167,6 +167,22 @@ Paradrop = function()
 	Trigger.AfterDelay(DateTime.Minutes(ParadropDelays), Paradrop)
 end
 
+GetBomberTargets = function()
+	if Difficulty ~= "hard" then
+		return Greece.GetActorsByTypes({ "apwr", "powr" })
+	end
+
+	local targets = Utils.Where(Greece.GetActors(), function(actor)
+		return
+			actor.HasProperty("Sell") and
+			actor.Type ~= "brik" and
+			actor.Type ~= "sbag" or
+			actor.Type == "pdox"
+	end)
+
+	return targets
+end
+
 SendParabombs = function()
 	local airfield = Airfield1
 	if Airfield1.IsDead or Airfield1.Owner ~= USSR then
@@ -177,14 +193,7 @@ SendParabombs = function()
 		airfield = Airfield2
 	end
 
-	local targets = Utils.Where(Greece.GetActors(), function(actor)
-		return
-			actor.HasProperty("Sell") and
-			actor.Type ~= "brik" and
-			actor.Type ~= "sbag" or
-			actor.Type == "pdox" or
-			actor.Type == "atek"
-	end)
+	local targets = GetBomberTargets()
 
 	if #targets > 0 then
 		airfield.TargetAirstrike(Utils.Random(targets).CenterPosition)

--- a/mods/ra/maps/allies-08b/allies08b-AI.lua
+++ b/mods/ra/maps/allies-08b/allies08b-AI.lua
@@ -167,6 +167,22 @@ Paradrop = function()
 	Trigger.AfterDelay(DateTime.Minutes(ParadropDelays), Paradrop)
 end
 
+GetBomberTargets = function()
+	if Difficulty ~= "hard" then
+		return Greece.GetActorsByTypes({ "apwr", "powr" })
+	end
+
+	local targets = Utils.Where(Greece.GetActors(), function(actor)
+		return
+			actor.HasProperty("Sell") and
+			actor.Type ~= "brik" and
+			actor.Type ~= "sbag" or
+			actor.Type == "pdox"
+	end)
+
+	return targets
+end
+
 SendParabombs = function()
 	local airfield = Airfield1
 	if Airfield1.IsDead or Airfield1.Owner ~= USSR then
@@ -177,14 +193,7 @@ SendParabombs = function()
 		airfield = Airfield2
 	end
 
-	local targets = Utils.Where(Greece.GetActors(), function(actor)
-		return
-			actor.HasProperty("Sell") and
-			actor.Type ~= "brik" and
-			actor.Type ~= "sbag" or
-			actor.Type == "pdox" or
-			actor.Type == "atek"
-	end)
+	local targets = GetBomberTargets()
 
 	if #targets > 0 then
 		airfield.TargetAirstrike(Utils.Random(targets).CenterPosition)


### PR DESCRIPTION
On release/bleed, it is possible for the player's tech center to die in a single bombing run, if it's selected as the target and the bomber starts with a diaganol facing. The center's survival is a primary objective, so the one-shot potential is not great.

This PR changes Easy/Normal difficulty so bombers only target power plants, as they did in RA1. Hard bombers work as they do now, but with the tech center ignored as a target option.