### PR TITLE
Refine lobby map generation logic

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
@@ -392,33 +392,27 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			preview.Clear();
 			Task.Run(() =>
 			{
-				for (var i = 0; i < 5; i++)
+				try
 				{
-					try
-					{
-						var args = settings.Compile(selectedTerrain, size);
-						var map = generator.Generate(modData, args);
+					var args = settings.Compile(selectedTerrain, size);
+					var map = generator.Generate(modData, args);
 
-						// Map UID and preview image are generated on save
-						map.Save(package);
-						args.Uid = map.Uid;
+					// Map UID and preview image are generated on save
+					map.Save(package);
+					args.Uid = map.Uid;
 
-						Game.RunAfterTick(() =>
-						{
-							preview.Update(map);
-							onGenerate(args, package);
-							generating = false;
-						});
-						return;
-					}
-					catch (Exception)
+					Game.RunAfterTick(() =>
 					{
-						// Ignore the exception
-					}
+						preview.Update(map);
+						onGenerate(args, package);
+						generating = false;
+					});
 				}
-
-				failed = true;
-				generating = false;
+				catch (MapGenerationException)
+				{
+					failed = true;
+					generating = false;
+				}
 			});
 		}
 

--- a/mods/cnc/fluent/chrome.ftl
+++ b/mods/cnc/fluent/chrome.ftl
@@ -540,7 +540,7 @@ label-mapchooser-random-map-error = Map Generation Failed
 button-mapchooser-random-map-generate = Generate
 label-mapchooser-random-map-tileset = Environment:
 label-mapchooser-random-map-size = Map Size:
-label-mapchooser-random-map-error-desc = Adjust the settings to try again.
+label-mapchooser-random-map-error-desc = Adjust the settings or try again.
 
 ## missionbrowser.yaml
 button-missionbrowser-panel-mission-info = Mission Info

--- a/mods/common/fluent/chrome.ftl
+++ b/mods/common/fluent/chrome.ftl
@@ -359,7 +359,7 @@ label-mapchooser-random-map-error = Map Generation Failed
 button-mapchooser-random-map-generate = Generate
 label-mapchooser-random-map-tileset = Environment:
 label-mapchooser-random-map-size = Map Size:
-label-mapchooser-random-map-error-desc = Adjust the settings to try again.
+label-mapchooser-random-map-error-desc = Adjust the settings or try again.
 
 ## missionbrowser.yaml
 button-missionbrowser-panel-start-briefing-video = Watch Briefing


### PR DESCRIPTION
In early iterations of the lobby map generation logic, a for loop was used to retry map generation with alternative seeds in case it failed. This seed randomization logic didn't exist in the final merged version, but the for loop wasn't cleanup up, and ends up repeating any map generation failures 5 times deterministically.

Additionally, the logic caught Exception instead of the more specific MapGenerationException, which is the only exception that is expected to arise in healthy builds/configurations (due to bad luck rather than bugs).

This change:

- removes the for loop;

- only catches MapGenerationException;

- adjusts the user-visible failure message to reflect that trying again (without adjusting settings) is a valid course of action (now that it's not done internally);