### PR TITLE
Add script tags to map editor actor properties

### DIFF
--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -710,6 +710,21 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
+	public class EditorActorTextField : EditorActorOption
+	{
+		public readonly Func<EditorActorPreview, string> GetValue;
+		public readonly Action<EditorActorPreview, string> OnChange;
+
+		public EditorActorTextField(string name, int displayOrder,
+			Func<EditorActorPreview, string> getValue,
+			Action<EditorActorPreview, string> onChange)
+			: base(name, displayOrder)
+		{
+			GetValue = getValue;
+			OnChange = onChange;
+		}
+	}
+
 	[RequireExplicitImplementation]
 	public interface INotifyEditorPlacementInfo : ITraitInfoInterface
 	{

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -51,6 +51,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly Widget checkboxOptionTemplate;
 		readonly Widget sliderOptionTemplate;
 		readonly Widget dropdownOptionTemplate;
+		readonly Widget textFieldOptionTemplate;
 
 		ActorIDStatus actorIDStatus = ActorIDStatus.Normal;
 		ActorIDStatus nextActorIDStatus = ActorIDStatus.Normal;
@@ -85,6 +86,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			checkboxOptionTemplate = initContainer.Get("CHECKBOX_OPTION_TEMPLATE");
 			sliderOptionTemplate = initContainer.Get("SLIDER_OPTION_TEMPLATE");
 			dropdownOptionTemplate = initContainer.Get("DROPDOWN_OPTION_TEMPLATE");
+			textFieldOptionTemplate = initContainer.Get("TEXTFIELD_OPTION_TEMPLATE");
 			initContainer.RemoveChildren();
 
 			var deleteButton = actorEditPanel.Get<ButtonWidget>("DELETE_BUTTON");
@@ -319,6 +321,31 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						dropdown.OnClick = () => dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 270, labels, DropdownSetup);
 
 						initContainer.AddChild(dropdownContainer);
+					}
+					else if (o is EditorActorTextField tfo)
+					{
+						var textFieldContainer = textFieldOptionTemplate.Clone();
+						textFieldContainer.Bounds.Y = initContainer.Bounds.Height;
+						initContainer.Bounds.Height += textFieldContainer.Bounds.Height;
+						textFieldContainer.Get<LabelWidget>("LABEL").GetText = () => tfo.Name;
+
+						var editorActionHandle = new EditorActorOptionActionHandle<string>(tfo.OnChange, tfo.GetValue(SelectedActor));
+						editActorPreview.Add(editorActionHandle);
+
+						var textField = textFieldContainer.Get<TextFieldWidget>("OPTION");
+						textField.Text = tfo.GetValue(SelectedActor);
+
+						textField.OnTextEdited = () =>
+						{
+							tfo.OnChange(SelectedActor, textField.Text);
+							editorActionHandle.OnChange(textField.Text);
+						};
+
+						textField.OnEscKey = _ => { textField.YieldKeyboardFocus(); return true; };
+						textField.OnEnterKey = _ => { textField.YieldKeyboardFocus(); return true; };
+						typableFields.Add(textField);
+
+						initContainer.AddChild(textFieldContainer);
 					}
 				}
 

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -651,6 +651,20 @@ Container@EDITOR_WORLD_ROOT:
 											Width: 213
 											Height: 25
 											Font: Bold
+								Container@TEXTFIELD_OPTION_TEMPLATE:
+									Width: PARENT_WIDTH
+									Height: 27
+									Children:
+										Label@LABEL:
+											Y: 1
+											Width: 55
+											Height: 25
+											Align: Right
+										TextField@OPTION:
+											X: 69
+											Y: 1
+											Width: 213
+											Height: 25
 						Container@BUTTON_CONTAINER:
 							Y: 70
 							Children:

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -618,6 +618,20 @@ Container@EDITOR_WORLD_ROOT:
 											Width: 213
 											Height: 25
 											Font: Bold
+								Container@TEXTFIELD_OPTION_TEMPLATE:
+									Width: PARENT_WIDTH
+									Height: 27
+									Children:
+										Label@LABEL:
+											Y: 1
+											Width: 55
+											Height: 25
+											Align: Right
+										TextField@OPTION:
+											X: 69
+											Y: 1
+											Width: 213
+											Height: 25
 						Container@BUTTON_CONTAINER:
 							Y: 75
 							Children:


### PR DESCRIPTION
Currently there's no way to edit script tags inside the map editor, you have to edit the map.yaml directly.

When creating campaign missions I tend to just use the actor names instead since it's more convenient (e.g. HardOnlyTank, which I can then refer to in the lua script).

This just allows script tags to be modified similar to how facing etc. can be. Required adding a new EditorActorTextField since currently only dropdowns, sliders and checkboxes are available, not sure if a text input is suitable for any other actor properties though.

Will only appear for actors with the ScriptTags trait, just as the facing slider doesn't appear unless the actor has a facing etc.

<img width="320" height="308" alt="tags" src="https://github.com/user-attachments/assets/f3bcc95b-94a2-4d19-9253-7ff7c80d91fa" />

<img width="306" height="214" alt="tagscnc" src="https://github.com/user-attachments/assets/2cd45701-4df6-4411-99aa-e64b9bacccf1" />