### PR TITLE
Improve editor path tool

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/ClearMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/ClearMapGenerator.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.EditorWorld)]
 	[Desc("A map generator that clears a map.")]
-	public sealed class ClearMapGeneratorInfo : TraitInfo<ClearMapGenerator>, IEditorMapGeneratorInfo, IEditorToolInfo
+	public sealed class ClearMapGeneratorInfo : TraitInfo, IEditorMapGeneratorInfo
 	{
 		[FieldLoader.Require]
 		[Desc("Human-readable name this generator uses.")]
@@ -93,10 +93,26 @@ namespace OpenRA.Mods.Common.Traits
 			return map;
 		}
 
-		string IEditorToolInfo.Label => Name;
-		string IEditorToolInfo.PanelWidget => PanelWidget;
+		public override object Create(ActorInitializer init)
+		{
+			return new ClearMapGenerator(this);
+		}
+
 		string[] IEditorMapGeneratorInfo.Tilesets => Tilesets;
 	}
 
-	public class ClearMapGenerator { /* we're only interested in the Info */ }
+	public class ClearMapGenerator : IEditorTool
+	{
+		public string Label { get; }
+		public string PanelWidget { get; }
+		public TraitInfo TraitInfo { get; }
+		public bool IsEnabled => true;
+
+		public ClearMapGenerator(ClearMapGeneratorInfo info)
+		{
+			Label = info.Name;
+			PanelWidget = info.PanelWidget;
+			TraitInfo = info;
+		}
+	}
 }

--- a/OpenRA.Mods.Common/Traits/World/ExperimentalMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/ExperimentalMapGenerator.cs
@@ -22,7 +22,7 @@ using static OpenRA.Mods.Common.Traits.ResourceLayerInfo;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.EditorWorld)]
-	public sealed class ExperimentalMapGeneratorInfo : TraitInfo<ExperimentalMapGenerator>, IEditorMapGeneratorInfo, IEditorToolInfo
+	public sealed class ExperimentalMapGeneratorInfo : TraitInfo, IEditorMapGeneratorInfo
 	{
 		[FieldLoader.Require]
 		public readonly string Type = null;
@@ -899,9 +899,25 @@ namespace OpenRA.Mods.Common.Traits
 			return map;
 		}
 
-		string IEditorToolInfo.Label => Name;
-		string IEditorToolInfo.PanelWidget => PanelWidget;
+		public override object Create(ActorInitializer init)
+		{
+			return new ExperimentalMapGenerator(init, this);
+		}
 	}
 
-	public class ExperimentalMapGenerator { /* we're only interested in the Info */ }
+	public class ExperimentalMapGenerator : IEditorTool
+	{
+		public string Label { get; }
+		public string PanelWidget { get; }
+		public TraitInfo TraitInfo { get; }
+		public bool IsEnabled { get; }
+
+		public ExperimentalMapGenerator(ActorInitializer init, ExperimentalMapGeneratorInfo info)
+		{
+			Label = info.Name;
+			PanelWidget = info.PanelWidget;
+			TraitInfo = info;
+			IsEnabled = info.Tilesets.Contains(init.Self.World.Map.Tileset);
+		}
+	}
 }

--- a/OpenRA.Mods.Common/Traits/World/MarkerLayerOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/MarkerLayerOverlay.cs
@@ -21,7 +21,7 @@ using Color = OpenRA.Primitives.Color;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.EditorWorld)]
-	public class MarkerLayerOverlayInfo : TraitInfo, IEditorToolInfo
+	public class MarkerLayerOverlayInfo : TraitInfo
 	{
 		[FluentReference]
 		[Desc("The label to show in the tools menu.")]
@@ -53,13 +53,15 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			return new MarkerLayerOverlay(init.Self, this);
 		}
-
-		string IEditorToolInfo.Label => Label;
-		string IEditorToolInfo.PanelWidget => PanelWidget;
 	}
 
-	public class MarkerLayerOverlay : IRenderAnnotations, INotifyActorDisposing, IWorldLoaded
+	public class MarkerLayerOverlay : IEditorTool, IRenderAnnotations, INotifyActorDisposing, IWorldLoaded
 	{
+		public string Label { get; }
+		public string PanelWidget { get; }
+		public TraitInfo TraitInfo { get; }
+		public bool IsEnabled => true;
+
 		public class MarkerLayer
 		{
 			public readonly Dictionary<int, CPos[]> Tiles;
@@ -132,6 +134,8 @@ namespace OpenRA.Mods.Common.Traits
 			Info = info;
 			world = self.World;
 			var map = self.World.Map;
+			Label = info.Label;
+			PanelWidget = info.PanelWidget;
 
 			tileAlpha = info.Alpha;
 			alphaBlendColors = new Color[info.Colors.Length];

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -977,10 +977,12 @@ namespace OpenRA.Mods.Common.Traits
 		bool PathMightExistForLocomotorBlockedByImmovable(Locomotor locomotor, CPos source, CPos target);
 	}
 
-	public interface IEditorToolInfo : ITraitInfoInterface
+	public interface IEditorTool
 	{
 		string Label { get; }
 		string PanelWidget { get; }
+		bool IsEnabled { get; }
+		TraitInfo TraitInfo { get; }
 	}
 
 	public class MapGenerationException : Exception

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorTabsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorTabsLogic.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Widgets;
@@ -26,6 +27,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		MenuType menuType = MenuType.Tiles;
 		MenuType lastSelectedTab = MenuType.Tiles;
+
+		public static event Action OnTabChanged;
 
 		[ObjectCreator.UseCtor]
 		public MapEditorTabsLogic(Widget widget, World world)
@@ -62,6 +65,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					lastSelectedTab = tabType;
 
 				menuType = tabType;
+				OnTabChanged?.Invoke();
 
 				// Clear keyboard focus when switching tabs.
 				Ui.KeyboardFocusWidget = null;
@@ -89,6 +93,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				menuType = MenuType.Select;
 			else if (menuType == MenuType.Select && !hasSelection)
 				menuType = lastSelectedTab;
+
+			OnTabChanged?.Invoke();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorTabsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorTabsLogic.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Widgets;
 
@@ -72,7 +73,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			if (tabType == MenuType.Tools)
 			{
-				var toolsAvailable = world.Map.Rules.Actors[SystemActors.EditorWorld].HasTraitInfo<IEditorToolInfo>();
+				var toolsAvailable = world.WorldActor.TraitsImplementing<IEditorTool>().Any();
 				tab.IsDisabled = () => !toolsAvailable;
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
@@ -44,15 +44,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly Widget dropDownSettingTemplate;
 
 		[ObjectCreator.UseCtor]
-		public MapGeneratorToolLogic(Widget widget, World world, WorldRenderer worldRenderer, ModData modData,
-			IEditorMapGeneratorInfo tool)
+		public MapGeneratorToolLogic(Widget widget, World world, WorldRenderer worldRenderer, ModData modData, IEditorTool tool)
 		{
 			editorActionManager = world.WorldActor.Trait<EditorActionManager>();
 
 			this.world = world;
 			this.worldRenderer = worldRenderer;
 			this.modData = modData;
-			generator = tool;
+			generator = tool.TraitInfo as IEditorMapGeneratorInfo;
 			settings = generator.GetSettings();
 
 			settingsPanel = widget.Get<ScrollPanelWidget>("SETTINGS_PANEL");

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapToolsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapToolsLogic.cs
@@ -26,10 +26,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		public MapToolsLogic(Widget widget, World world)
 		{
 			var toolDropdownWidget = widget.Get<DropDownButtonWidget>("TOOLS_DROPDOWN");
-			var tools = world.Map.Rules.Actors[SystemActors.EditorWorld].TraitInfos<IEditorToolInfo>();
+			var tools = world.WorldActor.TraitsImplementing<IEditorTool>();
 			foreach (var tool in tools)
 			{
-				if (tool is IEditorMapGeneratorInfo gi && !gi.Tilesets.Contains(world.Map.Tileset))
+				if (!tool.IsEnabled)
 					continue;
 
 				var panel = Game.LoadWidget(world, tool.PanelWidget, widget, new WidgetArgs() { { "tool", tool } });

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/TilingPathToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/TilingPathToolLogic.cs
@@ -40,10 +40,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			((ScrollPanelWidget)widget).Layout.AdjustChildren();
 
 			var editCheckbox = widget.Get<CheckboxWidget>("EDIT");
-			editCheckbox.Disabled = !tool.Available;
-			if (!tool.Available)
-				return;
-
 			editCheckbox.IsChecked = () => editorWidget.CurrentBrush is EditorTilingPathBrush;
 			editCheckbox.OnClick = () =>
 				editorWidget.SetBrush(

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/TilingPathToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/TilingPathToolLogic.cs
@@ -52,15 +52,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						: new EditorTilingPathBrush(tool));
 
 			void SetupDropDown(
-				string name,
+				DropDownButtonWidget dropDown,
 				ImmutableArray<string> choices,
 				Func<string> read,
 				Action<string> write)
 			{
-				var dropDown = widget
-					.Get<ContainerWidget>(name)
-					.Get<DropDownButtonWidget>("DROPDOWN");
-				dropDown.GetText = read;
 				dropDown.OnMouseDown = _ =>
 				{
 					ScrollItemWidget SetupItem(string choice, ScrollItemWidget template)
@@ -76,9 +72,32 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				};
 			}
 
-			SetupDropDown("START_TYPE", tool.StartTypes, () => tool.StartType, tool.SetStartType);
-			SetupDropDown("INNER_TYPE", tool.InnerTypes, () => tool.InnerType, tool.SetInnerType);
-			SetupDropDown("END_TYPE", tool.EndTypes, () => tool.EndType, tool.SetEndType);
+			var startDropdown = widget
+				.Get<ContainerWidget>("START_TYPE")
+				.Get<DropDownButtonWidget>("DROPDOWN");
+			startDropdown.GetText = () => tool.StartType;
+
+			var endDropdown = widget
+				.Get<ContainerWidget>("END_TYPE")
+				.Get<DropDownButtonWidget>("DROPDOWN");
+			endDropdown.GetText = () => tool.EndType;
+
+			var innerDropDown = widget
+				.Get<ContainerWidget>("INNER_TYPE")
+				.Get<DropDownButtonWidget>("DROPDOWN");
+			innerDropDown.GetText = () => tool.InnerType;
+
+			SetupDropDown(startDropdown, tool.StartTypesByInner[tool.InnerType], () => tool.StartType, tool.SetStartType);
+			SetupDropDown(endDropdown, tool.EndTypesByInner[tool.InnerType], () => tool.EndType, tool.SetEndType);
+
+			void PickInnerType(string choice)
+			{
+				tool.SetInnerType(choice);
+				SetupDropDown(startDropdown, tool.StartTypesByInner[choice], () => tool.StartType, tool.SetStartType);
+				SetupDropDown(endDropdown, tool.EndTypesByInner[choice], () => tool.EndType, tool.SetEndType);
+			}
+
+			SetupDropDown(innerDropDown, tool.InnerTypes, () => tool.InnerType, PickInnerType);
 
 			var deviationSlider = widget.Get<ContainerWidget>("DEVIATION").Get<SliderWidget>("SLIDER");
 			deviationSlider.GetValue = () => tool.MaxDeviation;

--- a/OpenRA.Mods.D2k/Traits/World/D2kMapGenerator.cs
+++ b/OpenRA.Mods.D2k/Traits/World/D2kMapGenerator.cs
@@ -23,7 +23,7 @@ using static OpenRA.Mods.Common.Traits.ResourceLayerInfo;
 namespace OpenRA.Mods.D2k.Traits
 {
 	[TraitLocation(SystemActors.EditorWorld)]
-	public sealed class D2kMapGeneratorInfo : TraitInfo<D2kMapGenerator>, IEditorMapGeneratorInfo, IEditorToolInfo
+	public sealed class D2kMapGeneratorInfo : TraitInfo, IEditorMapGeneratorInfo
 	{
 		[FieldLoader.Require]
 		public readonly string Type = null;
@@ -614,9 +614,24 @@ namespace OpenRA.Mods.D2k.Traits
 			return map;
 		}
 
-		string IEditorToolInfo.Label => Name;
-		string IEditorToolInfo.PanelWidget => PanelWidget;
+		public override object Create(ActorInitializer init)
+		{
+			return new D2kMapGenerator(this);
+		}
 	}
 
-	public class D2kMapGenerator { /* we're only interested in the Info */ }
+	public class D2kMapGenerator : IEditorTool
+	{
+		public string Label { get; }
+		public string PanelWidget { get; }
+		public TraitInfo TraitInfo { get; }
+		public bool IsEnabled => true;
+
+		public D2kMapGenerator(D2kMapGeneratorInfo info)
+		{
+			Label = info.Name;
+			PanelWidget = info.PanelWidget;
+			TraitInfo = info;
+		}
+	}
 }

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -1103,11 +1103,6 @@ ScrollPanel@TILING_PATH_TOOL_PANEL:
 	Visible: false
 	Logic: TilingPathToolLogic
 	Children:
-		Checkbox@EDIT:
-			X: 5
-			Width: PARENT_WIDTH - 35
-			Height: 25
-			Text: checkbox-tiling-path-edit
 		Container@START_TYPE:
 			X: 5
 			Width: PARENT_WIDTH - 35

--- a/mods/cnc/fluent/chrome.ftl
+++ b/mods/cnc/fluent/chrome.ftl
@@ -78,7 +78,6 @@ label-marker-mirror-mode = Mirror Mode
 label-marker-axis-angle = Axis Angle
 button-map-generator-generate = Generate
 button-map-generator-generate-random = Generate Random
-checkbox-tiling-path-edit = Enable editing
 label-tiling-path-type-start = Start type
 label-tiling-path-type-inner = Inner type
 label-tiling-path-type-end = End type

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -1077,11 +1077,6 @@ ScrollPanel@TILING_PATH_TOOL_PANEL:
 	Visible: false
 	Logic: TilingPathToolLogic
 	Children:
-		Checkbox@EDIT:
-			X: 5
-			Width: PARENT_WIDTH - 35
-			Height: 25
-			Text: checkbox-tiling-path-edit
 		Container@START_TYPE:
 			X: 5
 			Width: PARENT_WIDTH - 35

--- a/mods/common/fluent/chrome.ftl
+++ b/mods/common/fluent/chrome.ftl
@@ -74,7 +74,6 @@ label-marker-mirror-mode = Mirror Mode
 label-marker-axis-angle = Axis Angle
 button-map-generator-generate = Generate
 button-map-generator-generate-random = Generate Random
-checkbox-tiling-path-edit = Enable editing
 label-tiling-path-type-start = Start type
 label-tiling-path-type-inner = Inner type
 label-tiling-path-type-end = End type


### PR DESCRIPTION
- Only allow selecting valid endpoints
- Disable path tool when it is unavailable in a tileset (and unhardcode map generator)
- When editing path tool settings, enable the path tool if it's disabled

This is important for the usability of the tool