### PR TITLE
Avoid `DefaultTileCache` in interfaces

### DIFF
--- a/OpenRA.Mods.Common/Terrain/TileCache.cs
+++ b/OpenRA.Mods.Common/Terrain/TileCache.cs
@@ -1,0 +1,22 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Graphics;
+
+namespace OpenRA
+{
+	public interface ITileCache
+	{
+		bool HasTileSprite(TerrainTile r, int? variant = null);
+		Sprite TileSprite(TerrainTile r, int? variant = null);
+		SheetBuilder GetSheetBuilder(SheetType sheetType);
+	}
+}

--- a/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	public class TerrainRendererInfo : TraitInfo, ITiledTerrainRendererInfo
 	{
-		bool ITiledTerrainRendererInfo.ValidateTileSprites(ITemplatedTerrainInfo terrainInfo, Action<string> onError, out DefaultTileCache tileCache)
+		bool ITiledTerrainRendererInfo.ValidateTileSprites(ITemplatedTerrainInfo terrainInfo, Action<string> onError, out ITileCache tileCache)
 		{
 			var missingImages = new HashSet<string>();
 			var failed = false;

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -768,7 +768,7 @@ namespace OpenRA.Mods.Common.Traits
 	[RequireExplicitImplementation]
 	public interface ITiledTerrainRendererInfo : ITraitInfoInterface
 	{
-		bool ValidateTileSprites(ITemplatedTerrainInfo terrainInfo, Action<string> onError, out DefaultTileCache tileCache);
+		bool ValidateTileSprites(ITemplatedTerrainInfo terrainInfo, Action<string> onError, out ITileCache tileCache);
 	}
 
 	[RequireExplicitImplementation]

--- a/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
@@ -80,12 +80,12 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					terrainName += "." + name;
 				}
 
-				var sb = sequence.SpriteCache.SheetBuilders[SheetType.Indexed];
-				foreach (var s in sb.AllSheets)
-					CommitSheet(sb, s, sequencesName, palette, ref sheetCount);
+				var sheetBuilder = sequence.SpriteCache.SheetBuilders[SheetType.Indexed];
+				foreach (var sheet in sheetBuilder.AllSheets)
+					CommitSheet(sheetBuilder, sheet, sequencesName, palette, ref sheetCount);
 
-				foreach (var s in sequence.SpriteCache.SheetBuilders[SheetType.BGRA].AllSheets)
-					CommitSheet(null, s, sequencesName, palette, ref sheetCount);
+				foreach (var sheet in sequence.SpriteCache.SheetBuilders[SheetType.BGRA].AllSheets)
+					CommitSheet(null, sheet, sequencesName, palette, ref sheetCount);
 
 				modData.DefaultTerrainInfo.TryGetValue(sequence.TileSet, out var terrainInfo);
 				if (terrainInfo is ITemplatedTerrainInfo templatedTerrainInfo)
@@ -94,12 +94,12 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					{
 						if (!ttr.ValidateTileSprites(templatedTerrainInfo, Console.WriteLine, out var tileCache))
 						{
-							sb = tileCache.GetSheetBuilder(SheetType.Indexed);
-							foreach (var s in sb.AllSheets)
-								CommitSheet(sb, s, terrainName, palette, ref sheetCount);
+							sheetBuilder = tileCache.GetSheetBuilder(SheetType.Indexed);
+							foreach (var sheet in sheetBuilder.AllSheets)
+								CommitSheet(sheetBuilder, sheet, terrainName, palette, ref sheetCount);
 
-							foreach (var s in tileCache.GetSheetBuilder(SheetType.BGRA).AllSheets)
-								CommitSheet(null, s, terrainName, palette, ref sheetCount);
+							foreach (var sheet in tileCache.GetSheetBuilder(SheetType.BGRA).AllSheets)
+								CommitSheet(null, sheet, terrainName, palette, ref sheetCount);
 						}
 					}
 				}

--- a/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
@@ -94,11 +94,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					{
 						if (!ttr.ValidateTileSprites(templatedTerrainInfo, Console.WriteLine, out var tileCache))
 						{
-							sb = tileCache.SheetBuilders[SheetType.Indexed];
+							sb = tileCache.GetSheetBuilder(SheetType.Indexed);
 							foreach (var s in sb.AllSheets)
 								CommitSheet(sb, s, terrainName, palette, ref sheetCount);
 
-							foreach (var s in tileCache.SheetBuilders[SheetType.BGRA].AllSheets)
+							foreach (var s in tileCache.GetSheetBuilder(SheetType.BGRA).AllSheets)
 								CommitSheet(null, s, terrainName, palette, ref sheetCount);
 						}
 					}


### PR DESCRIPTION
I can't replace it with [CustomTileCache](https://github.com/OpenHV/OpenHV/blob/main/OpenRA.Mods.HV/Terrain/CustomTileCache.cs) otherwise. This regressed since release.