### PR TITLE
Make AttackMoveInfo public

### DIFF
--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Provides access to the attack-move command, which will make the actor automatically engage viable targets while moving to the destination.")]
-	sealed class AttackMoveInfo : TraitInfo, Requires<IMoveInfo>
+	public class AttackMoveInfo : TraitInfo, Requires<IMoveInfo>
 	{
 		[VoiceReference]
 		public readonly string Voice = "Action";


### PR DESCRIPTION
Please make `AttackMoveInfo` public, we need it for OpenHV for https://github.com/OpenHV/OpenHV/pull/1345