### PR TITLE
Fixes infinite building production notification bug

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -488,7 +488,10 @@ namespace OpenRA.Mods.Common.Traits
 						{
 							// Make sure the item hasn't been invalidated between the ProductionItem ticking and this FrameEndTask running
 							if (!Queue.Any(i => i.Done && i.Item == unit.Name))
+							{
+								hasPlayedSound = false;
 								return;
+							}
 
 							var isBuilding = unit.HasTraitInfo<BuildingInfo>();
 							if (isBuilding && !hasPlayedSound)


### PR DESCRIPTION
Addresses OpenHV/OpenHV#1317

Fixes bug where infinite building production queue does not notify on ready after the first building has been completed.
The underlying issue happens as ```hasPlayedSound``` does not get reset to false for each infinite production item. New infinite production items utilize the first item's ```onComplete``` Action which has already played the sound.

Here, I reset the ```hasPlayedSound``` variable to false when it becomes invalidated when the item is removed from the production queue and a new infinite item is added to the queue.