### PR TITLE
Fix atreides-05 frigate reinforcement

### DIFF
--- a/mods/d2k/maps/atreides-05/rules.yaml
+++ b/mods/d2k/maps/atreides-05/rules.yaml
@@ -24,6 +24,9 @@ carryall.reinforce:
 	Cargo:
 		MaxWeight: 10
 
+frigate:
+	Aircraft:
+		LandableTerrainTypes: Sand, Rock, Transition, Spice, SpiceSand, Dune, Concrete
 
 barracks.harkonnen:
 	Inherits: barracks


### PR DESCRIPTION
https://github.com/user-attachments/assets/f5c709f3-7de4-4a80-bff4-e3b0be860d53

Rolls back a change from https://github.com/OpenRA/OpenRA/pull/21424 which may have been left over from testing.

Frigates work as expected with Starport production, but [some campaign maps](https://github.com/search?q=repo%3AOpenRA%2FOpenRA+frigate+AND+LandableTerrainTypes+NOT+aircraft.yaml&type=code) use them as normal transports. If landable terrain is not defined, the unload is skipped.