### PR TITLE
Mobile changes for custom rallypoint activity

### DIFF
--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -178,7 +178,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly bool returnToCellOnCreation;
 		readonly bool returnToCellOnCreationRecalculateSubCell = true;
 		readonly int creationActivityDelay;
-		readonly CPos[] creationRallypoint;
+		public readonly CPos[] CreationRallypoints;
 
 		#region IMove CurrentMovementTypes
 		MovementType movementTypes;
@@ -301,7 +301,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			creationActivityDelay = init.GetValue<CreationActivityDelayInit, int>(0);
-			creationRallypoint = init.GetOrDefault<RallyPointInit>()?.Value;
+			CreationRallypoints = init.GetOrDefault<RallyPointInit>()?.Value;
 		}
 
 		protected override void Created(Actor self)
@@ -316,8 +316,8 @@ namespace OpenRA.Mods.Common.Traits
 				.Single(l => l.Info.Name == Info.Locomotor);
 
 			base.Created(self);
-			if (creationRallypoint != null)
-				foreach (var cell in creationRallypoint)
+			if (CreationRallypoints != null)
+				foreach (var cell in CreationRallypoints)
 					self.QueueActivity(new AttackMoveActivity(self, () => MoveTo(cell, 1, evaluateNearestMovableCell: true, targetLineColor: Color.OrangeRed)));
 		}
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -316,6 +316,9 @@ namespace OpenRA.Mods.Common.Traits
 				.Single(l => l.Info.Name == Info.Locomotor);
 
 			base.Created(self);
+			if (creationRallypoint != null)
+				foreach (var cell in creationRallypoint)
+					self.QueueActivity(new AttackMoveActivity(self, () => MoveTo(cell, 1, evaluateNearestMovableCell: true, targetLineColor: Color.OrangeRed)));
 		}
 
 		void ITick.Tick(Actor self)
@@ -975,16 +978,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		public class LeaveProductionActivity : Activity
 		{
-			readonly Mobile mobile;
 			readonly int delay;
-			readonly CPos[] rallyPoint;
 			readonly ReturnToCellActivity returnToCell;
 
-			public LeaveProductionActivity(Actor self, int delay, CPos[] rallyPoint, ReturnToCellActivity returnToCell)
+			public LeaveProductionActivity(Actor self, int delay, ReturnToCellActivity returnToCell)
 			{
-				mobile = self.Trait<Mobile>();
 				this.delay = delay;
-				this.rallyPoint = rallyPoint;
 				this.returnToCell = returnToCell;
 			}
 
@@ -995,10 +994,6 @@ namespace OpenRA.Mods.Common.Traits
 					QueueChild(returnToCell);
 				else if (delay > 0)
 					QueueChild(new Wait(delay));
-
-				if (rallyPoint != null)
-					foreach (var cell in rallyPoint)
-						QueueChild(new AttackMoveActivity(self, () => mobile.MoveTo(cell, 1, evaluateNearestMovableCell: true, targetLineColor: Color.OrangeRed)));
 			}
 
 			public override IEnumerable<Target> GetTargets(Actor self)
@@ -1021,8 +1016,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		Activity ICreationActivity.GetCreationActivity()
 		{
-			if (returnToCellOnCreation || creationRallypoint != null || creationActivityDelay > 0)
-				return new LeaveProductionActivity(self, creationActivityDelay, creationRallypoint,
+			if (returnToCellOnCreation || creationActivityDelay > 0)
+				return new LeaveProductionActivity(self, creationActivityDelay,
 					returnToCellOnCreation ? new ReturnToCellActivity(self, creationActivityDelay, returnToCellOnCreationRecalculateSubCell) : null);
 
 			return null;


### PR DESCRIPTION
Related as an alternative to #21982 and necessary for OpenHV/OpenHV#1352.

Changes to Mobile.cs include:

- Moving where AttackMove is set for each rallypoint of mobile units to within the Mobile class ```Created``` method instead of within the ```FirstRun``` method of the LeaveProductionActivity class. This removes the need of the rallypoint and mobile fields in the LeaveProductionActivity class. The change also prevents the forced use of AttackMoves for the rallypoints as they do not appear in the actor's activity queue when an INotifyCreated.Created method is called, and as such cannot be modified at that time.

- Making ```creationRallypoint``` public and renaming to ```CreationRallypoints``` as it is an array field with multiple rallypoints. This field is set to public to allow units to make use of it on their own INotifyCreated.Created methods to set custom activities for each rallypoint.

These changes were made to provide custom rallypoint activities for units through the INotifyCreated.Created method. This method is favored from ICreationActivity.GetCreationActivity because Actors prevent having more than one trait with GetCreationActivity, and mobile always implements the GetCreationActivity for units without a way to override it. Therefore, making units with a mobile trait unable to set a ICreationActivity.GetCreationActivity method without triggering the exception.

https://github.com/OpenRA/OpenRA/blob/44c6747decd4d98c2267b64bc7b629d888b9b66d/OpenRA.Game/Actor.cs#L252

Actors also favor using the INotifyCreated interface for activities since the initial CreationActivity is run before all others.

https://github.com/OpenRA/OpenRA/blob/44c6747decd4d98c2267b64bc7b629d888b9b66d/OpenRA.Game/Actor.cs#L243-L244

These changes should not affect current functionality, while providing the ability to extend rallypoint functionality to mobile units. It is also possible for these changes to be implemented for Aircraft.cs to avoid rallypoint activities from being set in the Tick method of their AssociateWithAirfieldActivity and allow for custom rallypoint activities.