### PR TITLE
Add smooth scrolling

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -724,7 +724,7 @@ namespace OpenRA
 				// Use worldRenderer.World instead of OrderManager.World to avoid a rendering mismatch while processing orders
 				if (worldRenderer != null && !worldRenderer.World.IsLoadingGameSave)
 				{
-					Renderer.BeginWorld(worldRenderer.Viewport.Rectangle);
+					Renderer.BeginWorld(worldRenderer.Viewport.CenterLocation, worldRenderer.Viewport.ViewportSize);
 					Sound.SetListenerPosition(worldRenderer.Viewport.CenterPosition);
 					using (new PerfSample("render_world"))
 						worldRenderer.Draw();

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -49,14 +49,13 @@ namespace OpenRA.Graphics
 		readonly Size tileSize;
 
 		// Viewport geometry (world-px)
-		public int2 CenterLocation { get; private set; }
+		public float2 CenterLocation { get; private set; }
 
-		public WPos CenterPosition => worldRenderer.ProjectedPosition(CenterLocation);
+		public WPos CenterPosition => worldRenderer.ProjectedPosition(CenterLocation.ToInt2());
 
-		public Rectangle Rectangle => new(TopLeft, new Size(viewportSize.X, viewportSize.Y));
-		public int2 TopLeft => CenterLocation - viewportSize / 2;
-		public int2 BottomRight => CenterLocation + viewportSize / 2;
-		int2 viewportSize;
+		public int2 TopLeft => CenterLocation.ToInt2() - ViewportSize.ToInt2() / 2;
+		public int2 BottomRight => CenterLocation.ToInt2() + ViewportSize.ToInt2() / 2;
+		public Size ViewportSize { get; private set; }
 		ProjectedCellRegion cells;
 		bool cellsDirty = true;
 
@@ -79,7 +78,7 @@ namespace OpenRA.Graphics
 			private set
 			{
 				zoom = value;
-				viewportSize = (1f / zoom * new float2(Game.Renderer.NativeResolution)).ToInt2();
+				ViewportSize = Size.FromInt2((1f / zoom * new float2(Game.Renderer.NativeResolution)).ToInt2());
 				cellsDirty = true;
 				allCellsDirty = true;
 			}
@@ -341,7 +340,7 @@ namespace OpenRA.Graphics
 		public void Scroll(float2 delta, bool ignoreBorders)
 		{
 			// Convert scroll delta from world-px to viewport-px
-			CenterLocation += (1f / Zoom * delta).ToInt2();
+			CenterLocation += 1f / Zoom * delta;
 			cellsDirty = true;
 			allCellsDirty = true;
 

--- a/OpenRA.Game/Primitives/float2.cs
+++ b/OpenRA.Game/Primitives/float2.cs
@@ -93,6 +93,21 @@ namespace OpenRA
 		public static float2 Max(float2 a, float2 b) { return new float2(Math.Max(a.X, b.X), Math.Max(a.Y, b.Y)); }
 		public static float2 Min(float2 a, float2 b) { return new float2(Math.Min(a.X, b.X), Math.Min(a.Y, b.Y)); }
 
+		public float2 Clamp(Rectangle r)
+		{
+			var x = X;
+			var y = Y;
+			if (r.Left > X)
+				x = r.Left;
+			if (r.Top > Y)
+				y = r.Top;
+			if (r.Right < X)
+				x = r.Right;
+			if (r.Bottom < Y)
+				y = r.Bottom;
+			return new float2(x, y);
+		}
+
 		public float LengthSquared => X * X + Y * Y;
 		public float Length => (float)Math.Sqrt(LengthSquared);
 	}

--- a/OpenRA.Mods.Common/Traits/World/WeatherOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/WeatherOverlay.cs
@@ -240,7 +240,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void IRenderAboveWorld.RenderAboveWorld(Actor self, WorldRenderer wr)
 		{
-			var center = wr.Viewport.CenterLocation;
+			var center = wr.Viewport.CenterLocation.ToInt2();
 			var viewport = new Rectangle(center - new int2(viewportSize) / 2, viewportSize);
 			var wcr = Game.Renderer.WorldRgbaColorRenderer;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/PerfDebugLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PerfDebugLogic.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var fps = (newestFrame - oldestFrame) / (newestTime - oldestTime).TotalSeconds;
 
 				var wfbSize = Game.Renderer.WorldFrameBufferSize;
-				var viewportSize = worldRenderer.Viewport.Rectangle.Size;
+				var viewportSize = worldRenderer.Viewport.ViewportSize;
 				return $"FPS: {fps:0}\nTick {Game.LocalTick} @ {PerfHistory.Items["tick_time"].Average(Game.Settings.Debug.Samples):F1} ms\n" +
 					$"Render {Game.RenderFrame} @ {PerfHistory.Items["render"].Average(Game.Settings.Debug.Samples):F1} ms\n" +
 					$"Batches: {PerfHistory.Items["batches"].LastValue}\n" +


### PR DESCRIPTION
Closes #21879

Reduces the impact of FPS on scrolling
Fixes bugs where if you were too zoomed in you could not scroll due to integer rounding


This is implemented by tracking scroll in float instead of integer format, and by rendering the world sheet at a slight offset. The world sprite is increased by 1 pixel