### PR TITLE
Allow `IDumpSheetsTerrainInfo` to be implemented by thirdparty mods

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		void DumpSheets(string terrainName, ImmutablePalette palette, ref int sheetCount);
 	}
 
-	sealed class DumpSequenceSheetsCommand : IUtilityCommand
+	public class DumpSequenceSheetsCommand : IUtilityCommand
 	{
 		static readonly int[] ChannelMasks = [2, 1, 0, 3];
 


### PR DESCRIPTION
This is a followup to https://github.com/OpenRA/OpenRA/pull/21981.