### PR TITLE
Fix TS copy paste preview height

### DIFF
--- a/OpenRA.Mods.Common/EditorBrushes/EditorBlit.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorBlit.cs
@@ -19,7 +19,11 @@ namespace OpenRA.Mods.Common.EditorBrushes
 {
 	public readonly record struct BlitTile(TerrainTile TerrainTile, ResourceTile ResourceTile, ResourceLayerContents? ResourceLayerContents, byte Height);
 
-	public readonly record struct EditorBlitSource(CellRegion CellRegion, Dictionary<string, EditorActorPreview> Actors, Dictionary<CPos, BlitTile> Tiles);
+	public readonly record struct EditorBlitSource(
+		WPos TopLeft,
+		CellRegion CellRegion,
+		Dictionary<string, EditorActorPreview> Actors,
+		Dictionary<CPos, BlitTile> Tiles);
 
 	[Flags]
 	public enum MapBlitFilters
@@ -97,6 +101,7 @@ namespace OpenRA.Mods.Common.EditorBrushes
 
 			var previews = new Dictionary<string, EditorActorPreview>();
 			var tiles = new Dictionary<CPos, BlitTile>();
+			var topLeft = map.CenterOfCell(region.TopLeft);
 
 			foreach (var cell in region.CellCoords)
 			{
@@ -116,7 +121,7 @@ namespace OpenRA.Mods.Common.EditorBrushes
 					if (mask == null || preview.Footprint.Keys.Any(mask.Contains))
 						previews.TryAdd(preview.ID, preview);
 
-			return new EditorBlitSource(region, previews, tiles);
+			return new EditorBlitSource(topLeft, region, previews, tiles);
 		}
 
 		void Blit(bool isRevert)
@@ -216,20 +221,15 @@ namespace OpenRA.Mods.Common.EditorBrushes
 			var world = wr.World;
 			var map = world.Map;
 
-			var terrainRenderer = world.WorldActor.Trait<ITiledTerrainRenderer>();
-			var resourceRenderers = world.WorldActor.TraitsImplementing<IResourceRenderer>().ToArray();
-
-			var wOffset = map.CenterOfCell(CPos.Zero + offset) - map.CenterOfCell(CPos.Zero);
-
 			if (filters.HasFlag(MapBlitFilters.Terrain))
 			{
+				var terrainRenderer = world.WorldActor.Trait<ITiledTerrainRenderer>();
 				foreach (var (cpos, tile) in blitSource.Tiles)
 				{
-					var preview =
-						terrainRenderer.RenderPreview(
-							wr,
-							tile.TerrainTile,
-							map.CenterOfCell(cpos + offset));
+					var wOffset = map.Offset(offset + (cpos - blitSource.CellRegion.TopLeft), tile.Height);
+					var pos = new WPos(blitSource.TopLeft.X + wOffset.X, blitSource.TopLeft.Y + wOffset.Y, wOffset.Z);
+					var preview = terrainRenderer.RenderPreview(wr, tile.TerrainTile, pos);
+
 					foreach (var renderable in preview)
 						yield return renderable;
 				}
@@ -237,16 +237,17 @@ namespace OpenRA.Mods.Common.EditorBrushes
 
 			if (filters.HasFlag(MapBlitFilters.Resources))
 			{
+				var resourceRenderers = world.WorldActor.TraitsImplementing<IResourceRenderer>().ToArray();
 				foreach (var (cpos, tile) in blitSource.Tiles)
 				{
 					if (tile.ResourceLayerContents == null || tile.ResourceLayerContents.Value.Type == null)
 						continue;
 
+					var wOffset = map.Offset(offset + (cpos - blitSource.CellRegion.TopLeft), tile.Height);
+					var pos = new WPos(blitSource.TopLeft.X + wOffset.X, blitSource.TopLeft.Y + wOffset.Y, wOffset.Z);
 					var preview = resourceRenderers
-						.SelectMany(r => r.RenderPreview(
-							wr,
-							tile.ResourceLayerContents.Value.Type,
-							map.CenterOfCell(cpos + offset)));
+						.SelectMany(r => r.RenderPreview(wr, tile.ResourceLayerContents.Value.Type, pos));
+
 					foreach (var renderable in preview)
 						yield return renderable;
 				}
@@ -254,10 +255,12 @@ namespace OpenRA.Mods.Common.EditorBrushes
 
 			if (filters.HasFlag(MapBlitFilters.Actors))
 			{
+				var wOffset = map.Offset(offset, 0);
 				foreach (var (_, editorActorPreview) in blitSource.Actors)
 				{
 					var preview = editorActorPreview.RenderWithOffset(wOffset)
 						.OrderBy(WorldRenderer.RenderableZPositionComparisonKey);
+
 					foreach (var renderable in preview)
 						yield return renderable;
 				}

--- a/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
@@ -809,6 +809,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 						t => new BlitTile(t.Tile, default, null, map.Height[CPos.Zero + t.XY]));
 
 			return new EditorBlitSource(
+				map.CenterOfCell(topLeft),
 				cellRegion,
 				actorPreviews,
 				blitTiles);

--- a/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
@@ -210,13 +210,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<IRenderable> ITiledTerrainRenderer.RenderPreview(WorldRenderer wr, TerrainTile tile, WPos origin)
 		{
-			if (!terrainInfo.TryGetTileInfo(tile, out var tileInfo))
-				yield break;
 			var sprite = tileCache.TileSprite(tile, 0);
-			var offset = map.Offset(new CVec(0, 0), tileInfo.Height);
 			var palette = wr.Palette(terrainInfo.Palette);
 
-			yield return new SpriteRenderable(sprite, origin, offset, 0, palette, 1f, 1f, float3.Ones, TintModifiers.None, false);
+			yield return new SpriteRenderable(sprite, origin, WVec.Zero, 0, palette, 1f, 1f, float3.Ones, TintModifiers.None, false);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
@@ -302,7 +302,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var offset = map.CellContaining(map.ProjectedTopLeft) - generatedMap.CellContaining(generatedMap.ProjectedTopLeft);
-			var blitSource = new EditorBlitSource(generatedMap.AllCells, previews, tiles);
+			var topLeft = generatedMap.CenterOfCell(generatedMap.AllCells.TopLeft);
+			var blitSource = new EditorBlitSource(topLeft, generatedMap.AllCells, previews, tiles);
 			var editorBlit = new EditorBlit(
 				MapBlitFilters.All,
 				resourceLayer,


### PR DESCRIPTION
Now height of the tiles being displayed matches the positions where they will be places

We save WPos in EditorBlitSource, as after copy we do not want to be going back the world to resample height (removed map.CenterOfCell from rendering the cursor)