### PR TITLE
Removed msbuild reference from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ gameinstalldir ?= $(libdir)/openra
 
 # Toolchain
 CWD = $(shell pwd)
-MSBUILD = msbuild -verbosity:m -nologo
 DOTNET = dotnet
 RM = rm
 RM_R = $(RM) -r


### PR DESCRIPTION
This is a tiny fix that removes unused reference to MSBuild from a Makefile.  

This PR solves https://github.com/OpenRA/OpenRA/issues/21962