### PR TITLE
New trait that notifies when an activity finishes FirstRun

### DIFF
--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -102,6 +102,12 @@ namespace OpenRA.Activities
 				OnFirstRun(self);
 				firstRunCompleted = true;
 				State = ActivityState.Active;
+				foreach (var frc in self.TraitsImplementing<INotifyActivityFirstRunCompleted>())
+				{
+					if (!frc.IsTraitEnabled())
+						continue;
+					frc.OnCompleted(self, this);
+				}
 			}
 
 			if (!firstRunCompleted)

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -625,6 +625,9 @@ namespace OpenRA.Traits
 	public interface ICreationActivity { Activity GetCreationActivity(); }
 
 	[RequireExplicitImplementation]
+	public interface INotifyActivityFirstRunCompleted { void OnCompleted(Actor self, Activity activity); }
+
+	[RequireExplicitImplementation]
 	public interface IObservesVariablesInfo : ITraitInfoInterface { }
 
 	public delegate void VariableObserverNotifier(Actor self, IReadOnlyDictionary<string, int> variables);


### PR DESCRIPTION
Requirement for OpenHV/OpenHV#1352

Part of alternative to #21986 due to conceptual concerns.

This creates a trait interface that notifies classes containing such interface when an Activity has finished its FirstRun. Very helpful to obtain activity queue on unit classes using mobile.