### PR TITLE
Make ChildActivity public

### DIFF
--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Activities
 		public ActivityState State { get; private set; }
 
 		Activity childActivity;
-		protected Activity ChildActivity
+		public Activity ChildActivity
 		{
 			get => SkipDoneActivities(childActivity);
 			private set => childActivity = value;


### PR DESCRIPTION
Requirement for OpenHV/OpenHV#1352

Part of alternative to #21986 due to conceptual concerns.

Helpful to obtain the rallypoint AttackMoves created during the ```LeaveProductionActivity```.