### PR TITLE
Fix the check in AllowResourceAt() method of the ResourceLayer class

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -176,7 +176,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!resourceInfo.AllowedTerrainTypes.Contains(cellTerrainType))
 				return false;
 
-			return BuildingInfluence.GetBuildingsAt(cell).All(a => a.Info.TraitInfo<BuildingInfo>().TerrainTypes.Contains(cellTerrainType));
+			return BuildingInfluence.GetBuildingsAt(cell).All(a => a.Info.TraitInfo<BuildingInfo>().TerrainTypes.Contains(resourceInfo.TerrainType));
 		}
 
 		ResourceLayerContents CreateResourceCell(string resourceType, CPos cell, int density)


### PR DESCRIPTION
An incorrect check was added in #21907 into method `ResourceLayer.AllowResourceAt()`. The check is supposed to verify, if there's any building at particular cell, which cannot be placed on a resource. However currently the check looks at **current** terrain type, not the **future** terrain type once the resource is created.

### Example in OpenE2140

This is how a Resource Mine placed in map editor looks like. Resource Mine's footprint is 3x3, resource is visualized with yellow dots.

<img width="545" height="335" alt="image" src="https://github.com/user-attachments/assets/0e1210ad-c353-4309-9257-49c5d7dfba7a" />

(notice that the resource is also placed underneath the Mine)

In OpenE2140 player deploys MCV-like vehicle on top of a resource field like this into the Resource Mine building. Hence Mine building can be placed on top of resources. **For test purposes** for this PR, I've disallowed placing Mine on resources:

```
shared_buildings_mine:
	Inherits: ^CoreBuilding
	Tooltip:
		Name: Mine
	Health:
		HP: 500
	# .. more trait definitions ...
	Building:
		Dimensions: 3,3
		Footprint: xxx xx= ===
		LocalCenterOffset: -370,-520,0
		TerrainTypes: Clear, Road
```

Now this is how it's **supposed** to look like in-game after the resources are created inside the cells by the `ResourceLayer.WorldLoaded()` method:

<img width="465" height="385" alt="image" src="https://github.com/user-attachments/assets/46a54ed3-a174-4c80-8040-ab849be2b429" />

<br/><br/>

However with the current code it does not work like this. `ResourceLayer.WorldLoaded()` calls `AllowResourceAt()` **before** adding resources into the cell. And since the check looks at the **current** terrain type, not the **future** on (as if the resource was already added to the cell), the cell passes the check even though it's not supposed to (see the `Building` trait config above). The fix is have the check look at the terrain type, which will be assigned to the cell later.

For completeness of the example, here's the `ResourceLayer` definition:

```
ResourceLayer:
	RecalculateResourceDensity: true
	ResourceTypes:
		Resources:
			ResourceIndex: 1
			TerrainType: Resources
			AllowedTerrainTypes: Clear
			MaxDensity: 10000
```

