### PR TITLE
Control volume of speech and voice notification sounds independently from other sounds

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -232,6 +232,7 @@ namespace OpenRA
 	public class SoundSettings
 	{
 		public float SoundVolume = 0.5f;
+		public float SpeechVolume = 0.5f;
 		public float MusicVolume = 0.5f;
 		public float VideoVolume = 0.5f;
 

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using OpenRA.FileSystem;
 using OpenRA.GameRules;
 using OpenRA.Primitives;
@@ -45,6 +46,7 @@ namespace OpenRA
 		ISound video;
 		readonly Dictionary<uint, ISound> currentSounds = [];
 		readonly Dictionary<string, ISound> currentNotifications = [];
+		readonly Dictionary<string, ISound> currentSpeechSounds = [];
 		public bool DummyEngine { get; }
 
 		public Sound(IPlatform platform, SoundSettings soundSettings)
@@ -316,6 +318,20 @@ namespace OpenRA
 
 		float InternalSoundVolume => SoundVolume * soundVolumeModifier;
 
+		public float SpeechVolume
+		{
+			get => Game.Settings.Sound.SpeechVolume;
+
+			set
+			{
+				Game.Settings.Sound.SpeechVolume = value;
+				foreach (var item in currentSpeechSounds.Values.Where(s => !s.Complete))
+				{
+					item.Volume = value;
+				}
+			}
+		}
+
 		public float SoundVolume
 		{
 			get => Game.Settings.Sound.SoundVolume;
@@ -406,12 +422,14 @@ namespace OpenRA
 
 			var name = prefix + clip + suffix;
 			var actorId = voicedActor != null && voicedActor.World.Selection.Contains(voicedActor) ? 0 : id;
+			var isSpeechSound = voicedActor != null || type.Equals("Speech", StringComparison.InvariantCultureIgnoreCase);
 
 			if (!string.IsNullOrEmpty(name) && (player == null || player == player.World.LocalPlayer))
 			{
 				ISound PlaySound()
 				{
-					var volume = InternalSoundVolume * volumeModifier * pool.VolumeModifier;
+					var baseVolume = isSpeechSound ? SpeechVolume : InternalSoundVolume;
+					var volume = baseVolume * volumeModifier * pool.VolumeModifier;
 					return soundEngine.Play2D(sounds[name], false, relative, pos, volume, attenuateVolume);
 				}
 
@@ -435,6 +453,8 @@ namespace OpenRA
 						return false;
 					else
 						currentNotifications[name] = sound;
+					if (isSpeechSound)
+						currentSpeechSounds[name] = sound;
 				}
 				else
 				{
@@ -451,6 +471,8 @@ namespace OpenRA
 						return false;
 					else
 						currentSounds[actorId] = sound;
+					if (isSpeechSound)
+						currentSpeechSounds[name] = sound;
 				}
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/AudioSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/AudioSettingsLogic.cs
@@ -55,6 +55,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SettingsUtils.BindCheckboxPref(panel, "MUTE_BACKGROUND_MUSIC", ss, "MuteBackgroundMusic");
 
 			SettingsUtils.BindSliderPref(panel, "SOUND_VOLUME", ss, "SoundVolume");
+			SettingsUtils.BindSliderPref(panel, "SPEECH_VOLUME", ss, "SpeechVolume");
 			SettingsUtils.BindSliderPref(panel, "MUSIC_VOLUME", ss, "MusicVolume");
 			SettingsUtils.BindSliderPref(panel, "VIDEO_VOLUME", ss, "VideoVolume");
 
@@ -95,11 +96,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			panel.Get("MUTE_SOUND_CONTAINER").Visible = !Game.Sound.DummyEngine;
 			panel.Get("MUTE_BACKGROUND_MUSIC_CONTAINER").Visible = !Game.Sound.DummyEngine;
 			panel.Get("SOUND_VOLUME_CONTAINER").Visible = !Game.Sound.DummyEngine;
+			panel.Get("SPEECH_VOLUME_CONTAINER").Visible = !Game.Sound.DummyEngine;
 			panel.Get("MUSIC_VOLUME_CONTAINER").Visible = !Game.Sound.DummyEngine;
 			panel.Get("VIDEO_VOLUME_CONTAINER").Visible = !Game.Sound.DummyEngine;
 
 			var soundVolumeSlider = panel.Get<SliderWidget>("SOUND_VOLUME");
 			soundVolumeSlider.OnChange += x => Game.Sound.SoundVolume = x;
+
+			var speechVolumeSlider = panel.Get<SliderWidget>("SPEECH_VOLUME");
+			speechVolumeSlider.OnChange += x => Game.Sound.SpeechVolume = x;
 
 			var musicVolumeSlider = panel.Get<SliderWidget>("MUSIC_VOLUME");
 			musicVolumeSlider.OnChange += x => Game.Sound.MusicVolume = x;
@@ -138,6 +143,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			return () =>
 			{
 				ss.SoundVolume = dss.SoundVolume;
+				ss.SpeechVolume = dss.SpeechVolume;
 				ss.MusicVolume = dss.MusicVolume;
 				ss.VideoVolume = dss.VideoVolume;
 				ss.CashTicks = dss.CashTicks;
@@ -147,6 +153,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				panel.Get<SliderWidget>("SOUND_VOLUME").Value = ss.SoundVolume;
 				Game.Sound.SoundVolume = ss.SoundVolume;
+				panel.Get<SliderWidget>("SPEECH_VOLUME").Value = ss.SpeechVolume;
+				Game.Sound.SpeechVolume = ss.SpeechVolume;
 				panel.Get<SliderWidget>("MUSIC_VOLUME").Value = ss.MusicVolume;
 				Game.Sound.MusicVolume = ss.MusicVolume;
 				panel.Get<SliderWidget>("VIDEO_VOLUME").Value = ss.VideoVolume;

--- a/mods/common/chrome/settings-audio.yaml
+++ b/mods/common/chrome/settings-audio.yaml
@@ -87,16 +87,16 @@ Container@AUDIO_PANEL:
 									Text: checkbox-mute-background-music-container.label
 									TooltipText: checkbox-mute-background-music-container.tooltip
 									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
-						Container@MUSIC_VOLUME_CONTAINER:
+						Container@SPEECH_VOLUME_CONTAINER:
 							X: PARENT_WIDTH / 2 + 10
 							Width: PARENT_WIDTH / 2 - 20
 							Children:
-								Label@MUSIC_LABEL:
+								Label@SPEECH_LABEL:
 									Width: PARENT_WIDTH
 									Height: 20
-									Text: label-music-title-volume-container
-								ExponentialSlider@MUSIC_VOLUME:
-									Y: 25
+									Text: label-speech-volume-container
+								ExponentialSlider@SPEECH_VOLUME:
+									Y: 30
 									Width: PARENT_WIDTH
 									Height: 20
 									Ticks: 7
@@ -116,6 +116,23 @@ Container@AUDIO_PANEL:
 									Y: 25
 									Width: PARENT_WIDTH
 									Height: 25
+						Container@MUSIC_VOLUME_CONTAINER:
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
+							Children:
+								Label@MUSIC_LABEL:
+									Width: PARENT_WIDTH
+									Height: 20
+									Text: label-music-title-volume-container
+								ExponentialSlider@MUSIC_VOLUME:
+									Y: 25
+									Width: PARENT_WIDTH
+									Height: 20
+									Ticks: 7
+				Container@ROW:
+					Width: PARENT_WIDTH - 24
+					Height: 20
+					Children:
 						Container@VIDEO_VOLUME_CONTAINER:
 							X: PARENT_WIDTH / 2 + 10
 							Width: PARENT_WIDTH / 2 - 20

--- a/mods/common/fluent/chrome.ftl
+++ b/mods/common/fluent/chrome.ftl
@@ -483,6 +483,7 @@ label-no-audio-device-container = Audio controls require an active sound device
 checkbox-cash-ticks-container = Cash Ticks
 checkbox-mute-sound-container = Mute Sound
 label-sound-volume-container = Sound Volume:
+label-speech-volume-container = Speech Volume:
 
 checkbox-mute-background-music-container =
     .label = Mute Menu Music


### PR DESCRIPTION
Another feature for the "cinematic mode". As per discussion on Discord, this PR adds another volume slider to audio panel in Settings, which controls volume of actor voices and notifications.

<img width="1600" height="1000" alt="openra_speech_volume" src="https://github.com/user-attachments/assets/acac021b-d574-42f6-9afc-e129a13d40cd" />
