### PR TITLE
Update chat links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,12 @@ name: Continuous Integration
 
 on:
   push:
+    paths-ignore:
+      - '*.md'
   pull_request:
     branches: [ bleed, 'prep-*' ]
+    paths-ignore:
+      - '*.md'
 
 permissions:
   contents: read  #  to fetch code (actions/checkout)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,6 @@ Don't forget to add yourself to [AUTHORS](https://github.com/OpenRA/OpenRA/blob/
 
 Please propose a [CHANGELOG](https://github.com/OpenRA/OpenRA/wiki/CHANGELOG) entry in the pull-request comments.
 
-While your pull-request is in review it will be helpful if you join [IRC](irc://chat.freenode.net/openra) to discuss the changes.
+While your pull-request is in review it will be helpful if you join [Discord](https://discord.openra.net) or [IRC](ircs://irc.libera.chat:6697/openra) to discuss the changes.
 
 See also the in-depth guide on [contributing](https://github.com/OpenRA/OpenRA/wiki/Contributing) to the OpenRA project.


### PR DESCRIPTION
FreeNode is gone, and Discord is the primary chat now.