### PR TITLE
Significantly improve actor placement speeds

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -572,6 +572,11 @@ namespace OpenRA
 			return i.ToString(NumberFormatInfo.InvariantInfo);
 		}
 
+		public static string ToStringInvariant(this uint i)
+		{
+			return i.ToString(NumberFormatInfo.InvariantInfo);
+		}
+
 		public static string ToStringInvariant(this float f)
 		{
 			return f.ToString(NumberFormatInfo.InvariantInfo);

--- a/OpenRA.Game/Map/CellCoordsRegion.cs
+++ b/OpenRA.Game/Map/CellCoordsRegion.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -87,6 +88,31 @@ namespace OpenRA
 		IEnumerator IEnumerable.GetEnumerator()
 		{
 			return GetEnumerator();
+		}
+
+		/// <summary>Returns the minimal region that covers at least the specified cells.</summary>
+		public static CellCoordsRegion BoundingRegion(IReadOnlyCollection<CPos> cells)
+		{
+			if (cells == null || cells.Count == 0)
+				throw new ArgumentException("cells must not be null or empty.", nameof(cells));
+
+			var minX = int.MaxValue;
+			var minY = int.MaxValue;
+			var maxX = int.MinValue;
+			var maxY = int.MinValue;
+			foreach (var cell in cells)
+			{
+				if (minX > cell.X)
+					minX = cell.X;
+				if (maxX < cell.X)
+					maxX = cell.X;
+				if (minY > cell.Y)
+					minY = cell.Y;
+				if (maxY < cell.Y)
+					maxY = cell.Y;
+			}
+
+			return new CellCoordsRegion(new CPos(minX, minY), new CPos(maxX, maxY));
 		}
 
 		public CPos TopLeft { get; }

--- a/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
@@ -11,11 +11,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Runtime.InteropServices;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.EditorBrushes;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Support;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets
@@ -384,8 +385,8 @@ namespace OpenRA.Mods.Common.Widgets
 			if (blitFilters.HasFlag(MapBlitFilters.Actors))
 			{
 				// Clear any existing actors in the paste cells.
-				foreach (var regionActor in editorActorLayer.PreviewsInCellRegion(area.CellCoords).ToList())
-					editorActorLayer.Remove(regionActor);
+				using (new PerfTimer("RemoveActors", 1))
+					editorActorLayer.RemoveRegion(area.CellCoords);
 			}
 
 			foreach (var tileKeyValuePair in editorBlitSource.Tiles)
@@ -432,6 +433,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (blitFilters.HasFlag(MapBlitFilters.Actors))
 			{
 				// Create copies of the original actors, update their locations, and place.
+				var copies = new List<ActorReference>(editorBlitSource.Actors.Count);
 				foreach (var actorKeyValuePair in editorBlitSource.Actors)
 				{
 					var copy = actorKeyValuePair.Value.Export();
@@ -445,8 +447,10 @@ namespace OpenRA.Mods.Common.Widgets
 						copy.Add(new LocationInit(locationInit.Value));
 					}
 
-					editorActorLayer.Add(copy);
+					copies.Add(copy);
 				}
+
+				editorActorLayer.AddRange(CollectionsMarshal.AsSpan(copies));
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -41,6 +41,9 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class EditorActorLayer : IWorldLoaded, ITickRender, IRender, IRadarSignature, ICreatePlayers, IRenderAnnotations
 	{
+		const string ActorPrefix = "Actor";
+		const string PlayerSpawnName = "mpspawn";
+
 		public readonly EditorActorLayerInfo Info;
 		readonly List<EditorActorPreview> previews = [];
 
@@ -152,7 +155,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				UpdateNeighbours(preview.Footprint);
 
-				if (preview.Type == "mpspawn")
+				if (preview.Type == PlayerSpawnName)
 					SyncMultiplayerCount();
 			}
 		}
@@ -175,7 +178,7 @@ namespace OpenRA.Mods.Common.Traits
 			preview.RemovedFromEditor();
 			UpdateNeighbours(preview.Footprint);
 
-			if (preview.Info.Name == "mpspawn")
+			if (preview.Info.Name == PlayerSpawnName)
 				SyncMultiplayerCount();
 		}
 
@@ -199,7 +202,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void SyncMultiplayerCount()
 		{
-			var newCount = previews.Count(p => p.Info.Name == "mpspawn");
+			var newCount = previews.Count(p => p.Info.Name == PlayerSpawnName);
 			var mp = Players.Players.Where(p => p.Key.StartsWith("Multi", StringComparison.Ordinal)).ToList();
 			foreach (var kv in mp)
 			{
@@ -303,12 +306,12 @@ namespace OpenRA.Mods.Common.Traits
 		string NextActorName()
 		{
 			var id = previews.Count;
-			var possibleName = "Actor" + id.ToStringInvariant();
+			var possibleName = ActorPrefix + id.ToStringInvariant();
 
 			while (previews.Any(p => p.ID == possibleName))
 			{
 				id++;
-				possibleName = "Actor" + id.ToStringInvariant();
+				possibleName = ActorPrefix + id.ToStringInvariant();
 			}
 
 			return possibleName;


### PR DESCRIPTION
Adding a 1000 actors to the editor instead of stuttering the game for a second, now takes just a few miliseconds.

There were 2 offenders, valid ID search and neighbour checks. The ID search was cut to nothing, while the neighbour checks can take a few miliseconds if you really push it.

Issues were most visible with map generator on maps with a lot of actors, and in  #22002